### PR TITLE
Windows build automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Erigon is an implementation of Ethereum (aka "Ethereum client"), on the efficien
     + [Run all components by docker-compose](#run-all-components-by-docker-compose)
     + [Grafana dashboard](#grafana-dashboard)
 - [Getting in touch](#getting-in-touch)
-    + [Turbo-Geth Discord Server](#turbo-geth-discord-server)
+    + [Erigon Discord Server](#erigon-discord-server)
     + [Reporting security issues/concerns](#reporting-security-issues-concerns)
     + [Team](#team)
 - [Known issues](#known-issues)
@@ -53,8 +53,8 @@ Usage
 ### Getting Started
 
 ```sh
-> git clone --recurse-submodules -j8 https://github.com/ledgerwatch/turbo-geth.git
-> cd turbo-geth
+> git clone --recurse-submodules -j8 https://github.com/ledgerwatch/erigon.git
+> cd erigon
 > make tg
 > ./build/bin/tg
 ```
@@ -63,8 +63,8 @@ Usage
 
 If you would like to give turbo-geth a try, but do not have spare 2Tb on your driver, a good option is to start syncing one of the public testnets, Görli. It syncs much quicker, and does not take so much disk space:
 ```sh
-> git clone --recurse-submodules -j8 https://github.com/ledgerwatch/turbo-geth.git
-> cd turbo-geth
+> git clone --recurse-submodules -j8 https://github.com/ledgerwatch/erigon.git
+> cd erigon
 > make tg
 > ./build/bin/tg --datadir goerli --chain goerli
 ```
@@ -91,9 +91,11 @@ Support only remote-miners.
 
 ### Windows
 
-Windows users may run turbo-geth in 3 possible ways:
+Windows users may run erigon in 3 possible ways:
 
-* Build tg binaries natively for Windows : while this method is possible we still lack a fully automated build process thus, at the moment, is not to be preferred. Besides there's also a caveat which might cause your experience with TG as native on Windows uncomfortable: data file allocation is fixed so you need to know in advance how much space you want to allocate for database file using the option `--lmdb.mapSize`
+* Build executable binaries natively for Windows using provided `win-build.ps1` PowerShell script which has to be run with local Administrator privileges.
+The script creates `libmdbx.dll` (MDBX is current default database for Erigon) and copies it into Windows's `system32` folder (generally `C:\Windows\system32`). 
+Though is still possible to run erigon with LMDB database there's a caveat which might cause your experience with LMDB on Windows uncomfortable: data file allocation is fixed so you need to know in advance how much space you want to allocate for database file using the command line option `--lmdb.mapSize`
 
 * Use Docker :  see [docker-compose.yml](./docker-compose.yml)
 
@@ -138,7 +140,7 @@ accounts and the storage.
 
 ### Faster Initial Sync
 
-Turbo-Geth uses a rearchitected full sync algorithm from
+Erigon uses a rearchitected full sync algorithm from
 [Go-Ethereum](https://github.com/ethereum/go-ethereum) that is split into
 "stages".
 
@@ -158,15 +160,17 @@ Examples of stages are:
 
 * Downloading block bodies;
 
+* Recovering senders' addresses;
+
 * Executing blocks;
 
 * Validating root hashes and building intermediate hashes for the state Merkle trie;
 
-* And more...
+* [...]
 
 ### JSON-RPC daemon
 
-In turbo-geth RPC calls are extracted out of the main binary into a separate daemon.
+In Erigon RPC calls are extracted out of the main binary into a separate daemon.
 This daemon can use both local or remote DBs. That means, that this RPC daemon
 doesn't have to be running on the same machine as the main turbo-geth binary or
 it can run from a snapshot of a database for read-only calls. 
@@ -222,7 +226,7 @@ XDG_DATA_HOME=/preferred/data/folder docker-compose up
 Getting in touch
 ================
 
-### Turbo-Geth Discord Server
+### Erigon Discord Server
 
 The main discussions are happening on our Discord server. 
 To get an invite, send an email to `tg [at] torquem.ch` with your name, occupation, 
@@ -240,11 +244,11 @@ Core contributors (in alpabetical order of first names):
 
 * Alexey Akhunov ([@realLedgerwatch](https://twitter.com/realLedgerwatch))
 
-* Andrea Lanfranchi
+* Andrea Lanfranchi([@AndreaLanfranchi](https://github.com/AndreaLanfranchi))
 
 * Andrew Ashikhmin ([yperbasis](https://github.com/yperbasis))
 
-* Artem Vorotnikov
+* Artem Vorotnikov ([vorot93](https://github.com/vorot93))
 
 * Boris Petrov ([b00ris](https://github.com/b00ris))
 
@@ -252,7 +256,7 @@ Core contributors (in alpabetical order of first names):
 
 * Igor Mandrigin ([@mandrigin](https://twitter.com/mandrigin))
 
-* Giulio Rebuffo
+* Giulio Rebuffo ([Giulio2002](https://github.com/Giulio2002))
 
 * Thomas Jay Rush ([@tjayrush](https://twitter.com/tjayrush))
 
@@ -271,7 +275,7 @@ Known issues
 
 ### `htop` shows incorrect memory usage
 
-TurboGeth's internal DB (LMDB) using `MemoryMap` - when OS does manage all `read, write, cache` operations instead of Application
+Erigon's internal DB (LMDB) using `MemoryMap` - when OS does manage all `read, write, cache` operations instead of Application
 ([linux](https://linux-kernel-labs.github.io/refs/heads/master/labs/memory_mapping.html), [windows](https://docs.microsoft.com/en-us/windows/win32/memory/file-mapping))
 
 `htop` on column `res` shows memory of "App + OS used to hold page cache for given App", 
@@ -286,7 +290,7 @@ Without `grep` you can see details - `section MALLOC ZONE column Resident Size` 
 - `Prometheus` dashboard shows memory of Go app without OS pages cache (`make prometheus`, open in browser `localhost:3000`, credentials `admin/admin`)
 - `cat /proc/<PID>/smaps`
 
-TurboGeth uses ~4Gb of RAM during genesis sync and < 1Gb during normal work. OS pages cache can utilize unlimited amount of memory. 
+Erigon uses ~4Gb of RAM during genesis sync and < 1Gb during normal work. OS pages cache can utilize unlimited amount of memory. 
 
 **Warning:** Multiple instances of TG on same machine will touch Disk concurrently, 
 it impacts performance - one of main TG optimisations: "reduce Disk random access". 

--- a/win-build.ps1
+++ b/win-build.ps1
@@ -1,0 +1,227 @@
+﻿<#
+   Copyright 2021 The Erigon Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+#>
+
+$goErrorText = @"
+
+ Requirement Error.
+ You need to have Go Programming Language (aka golang) installed.
+ Minimum required version is 1.16
+ Please visit https://golang.org/dl/ and download the appropriate
+ installer.
+
+"@
+
+$chocolateyErrorText = @"
+
+ Requirement Error.
+ For this script to run properly you need to install
+ chocolatey [https://chocolatey.org/] with the following
+ mandatory components: 
+
+ - cmake 3.20.2
+ - make 4.3
+ - mingw 10.2.0
+
+"@
+
+$chocolateyPathErrorText = @"
+
+ Environment PATH Error.
+ Chocolatey install has been detected but the environment
+ variable PATH does not include a full path to its binaries
+ Please amend your setup and ensure the following
+ chocolatey directory is properly inserted into your PATH
+ environment variable.
+
+"@
+
+$privilegeErrorText = @"
+
+ Privileges Error !
+ You must run this script with Administrator privileges
+
+"@
+
+$Error.Clear()
+$ErrorActionPreference = "SilentlyContinue"
+
+Set-Variable -Name "MyContext" -Value ([hashtable]::Synchronized(@{})) -Scope Script
+$MyContext.Name       = $MyInvocation.MyCommand.Name
+$MyContext.Definition = $MyInvocation.MyCommand.Definition
+$MyContext.Directory  = (Split-Path (Resolve-Path $MyInvocation.MyCommand.Definition) -Parent)
+$MyContext.StartDir   = (Get-Location -PSProvider FileSystem).ProviderPath
+$MyContext.WinVer     = (Get-WmiObject Win32_OperatingSystem).Version.Split(".")
+$MyContext.PSVer      = [int]$PSVersionTable.PSVersion.Major
+
+# Test we have ADMIN Privileges
+$myWindowsID = [System.Security.Principal.WindowsIdentity]::GetCurrent();
+$myWindowsPrincipal = New-Object System.Security.Principal.WindowsPrincipal($myWindowsID);
+$adminRole = [System.Security.Principal.WindowsBuiltInRole]::Administrator;
+if (!($myWindowsPrincipal.IsInRole($adminRole))) {
+   Write-Host $privilegeErrorText
+   return
+}
+
+
+# Test GO is installed and is at least 1.16
+$goInstalled = (Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Where-Object {$_.DisplayName -imatch "^Go\ Programming\ Language"})
+if(!$goInstalled) {
+    Write-Host $goErrorText
+    return
+}
+Write-Host " Found GO version $($goInstalled.DisplayVersion)"
+$goVersionMajor = [int]$goInstalled.VersionMajor
+$goVersionMinor = [int]$goInstalled.VersionMinor
+if($goVersionMajor -lt 1 -or $goVersionMinor -lt 16) {
+    Write-Host $goErrorText
+    return
+}
+
+# Test Chocolatey Install
+if(!(Test-Path env:chocolateyInstall)) {
+    Write-Host $chocolateyErrorText
+    return
+}
+$chocolateyPath = $env:ChocolateyInstall
+
+# Test Chocolatey bin directory is actually in %PATH%
+$chocolateyBinPath = (Join-Path $chocolateyPath "bin")
+$chocolateyBinPathInPath = $false
+$pathExpanded = $env:Path.Split(";")
+for($i=0; $i -lt $pathExpanded.Count; $i++){
+    $pathItem = $pathExpanded[$i]
+    if($pathItem -ieq $chocolateyBinPath){
+        Write-Host " Found $($chocolateyBinPath) in PATH"
+        $chocolateyBinPathInPath = $true
+    }
+}
+if(!$chocolateyBinPathInPath) {
+    Write-Host $chocolateyPathErrorText
+    Write-Host $chocolateyBinPath
+    return
+}
+
+# Test Chocolatey Components
+$chocolateyHasCmake = $false
+$chocolateyHasMake = $false
+$chocolateyHasMingw = $false
+$chocolateyComponents = @(clist -l)
+for($i=0; $i -lt $chocolateyComponents.Count; $i++){
+    $item = $chocolateyComponents[$i]
+    if($item -imatch "^cmake\ [0-9]") {
+        $chocolateyHasCmake = $true
+        Write-Host " Found Chocolatey component $($item)"
+    }
+    if($item -imatch "^make\ [0-9]") {
+        $chocolateyHasMake = $true
+        Write-Host " Found Chocolatey component $($item)"
+    }
+    if($item -imatch "^mingw\ [0-9]") {
+        $chocolateyHasMingw = $true
+        Write-Host " Found Chocolatey component $($item)"
+    }
+}
+If(!$chocolateyHasCmake -or !$chocolateyHasMake -or !$chocolateyHasMingw) {
+    Write-Host $chocolateyErrorText
+    return
+}
+
+# Enter MDBX directory and build libmdbx.dll
+Write-Host " Building libmdbx.dll ..."
+Set-Location (Join-Path $MyContext.Directory "ethdb\mdbx\dist")
+cmake -G "MinGW Makefiles" . -D CMAKE_MAKE_PROGRAM:PATH=$(Join-Path $chocolateyBinPath "make.exe") -D MDBX_BUILD_SHARED_LIBRARY:BOOL=ON -D MDBX_WITHOUT_MSVC_CRT:BOOOL=OFF
+if($LASTEXITCODE) {
+    Write-Host "An error has occurred while configuring MDBX dll"
+    return
+}
+cmake --build .
+if($LASTEXITCODE -or !(Test-Path "libmdbx.dll" -PathType leaf)) {
+    Write-Host "An error has occurred while building MDBX dll or libmdbx.dll cannot be found"
+    return
+}
+
+# Copy libmdbx.dll into %windir%\System32 directory
+# Note! default behavior is to overwrite
+Copy-Item libmdbx.dll (Join-Path $env:SystemRoot system32)
+if(!$?) {
+   Write-Host " Error ! Could not copy libmdbx.dll to $(Join-Path $env:SystemRoot system32)"
+   Write-Host " What can you do : "
+   Write-Host " - Check your permissions to directory "
+   Write-Host " - Check there's an already existing libmdbx.dll file "
+   Write-Host " - Check no instance of Erigon with mdbx is currently running "
+   return
+}
+
+# Return to source folder
+Set-Location $MyContext.Directory
+
+# Build erigon binaries
+Set-Variable -Name "Erigon" -Value ([hashtable]::Synchronized(@{})) -Scope Script
+$Erigon.Commit  = [string]@(git.exe rev-list -1 HEAD)
+$Erigon.Branch  = [string]@(git.exe rev-parse --abbrev-ref HEAD)
+$Erigon.Build   = "go build -v -trimpath -tags=mdbx -ldflags ""-X main.gitCommit=$($Erigon.Commit) -X main.gitBranch=$($Erigon.Branch)"""
+$Erigon.BinPath = [string](Join-Path $MyContext.StartDir "\build\bin")
+$env:GO111MODULE = "on"
+
+Write-Host " Building tg ..."
+$outExecutable = [string](Join-Path $Erigon.BinPath "tg.exe")
+$BuildCommand = "$($Erigon.Build) -o ""$($outExecutable)"" ./cmd/tg"
+$BuildCommand += ';$?'
+$success = Invoke-Expression -Command $BuildCommand
+if (-not $success) {
+    Write-Host "Could not build tg executable"
+    return
+}
+
+Write-Host " Building rpcdaemon ..."
+$outExecutable = [string](Join-Path $Erigon.BinPath "rpcdaemon.exe")
+$BuildCommand = "$($Erigon.Build) -o ""$($outExecutable)"" ./cmd/rpcdaemon"
+$BuildCommand += ';$?'
+$success = Invoke-Expression -Command $BuildCommand
+if (-not $success) {
+    Write-Host "Could not build rpcdaemon executable"
+    return
+}
+
+Write-Host " Building integration ..."
+$outExecutable = [string](Join-Path $Erigon.BinPath "integration.exe")
+$BuildCommand = "$($Erigon.Build) -o ""$($outExecutable)"" ./cmd/integration"
+$BuildCommand += ';$?'
+$success = Invoke-Expression -Command $BuildCommand
+if (-not $success) {
+    Write-Host "Could not build integration executable"
+    return
+}
+
+Write-Host " Building rpctest ..."
+$outExecutable = [string](Join-Path $Erigon.BinPath "rpctest.exe")
+$BuildCommand = "$($Erigon.Build) -o ""$($outExecutable)"" ./cmd/rpctest"
+$BuildCommand += ';$?'
+$success = Invoke-Expression -Command $BuildCommand
+if (-not $success) {
+    Write-Host "Could not build rpctest executable"
+    return
+}
+
+Write-Host " Building state ..."
+$outExecutable = [string](Join-Path $Erigon.BinPath "state.exe")
+$BuildCommand = "$($Erigon.Build) -o ""$($outExecutable)"" ./cmd/state"
+$BuildCommand += ';$?'
+$success = Invoke-Expression -Command $BuildCommand
+if (-not $success) {
+    Write-Host "Could not build state executable"
+    return
+}


### PR DESCRIPTION
* PowerShell script
* Patch Readme.md

The script checks :
* Running with `Administrator` privileges
* chocolatey is installed
* required chocolatey components (`cmake`, `make`, `mingw`) are installed
* GO is installed and >= 1.16

```
PS D:\GitHub\erigon> .\win-build.ps1
 Found GO version 1.16.4
 Found C:\ProgramData\chocolatey\bin in PATH
 Found Chocolatey component cmake 3.20.2
 Found Chocolatey component make 4.3
 Found Chocolatey component mingw 10.2.0
 Building libmdbx.dll ...
-- The C compiler identification is GNU 10.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/ProgramData/chocolatey/bin/gcc.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Looking for a CXX compiler
-- Looking for a CXX compiler - C:/ProgramData/chocolatey/bin/g++.exe
-- The CXX compiler identification is GNU 10.2.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/ProgramData/chocolatey/bin/g++.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Assume No any CI environment
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Check if compiler accepts -pthread
-- Check if compiler accepts -pthread - yes
-- Found Threads: TRUE
-- Performing Test CC_HAS_WNO_UNKNOWN_PRAGMAS
-- Performing Test CC_HAS_WNO_UNKNOWN_PRAGMAS - Success
-- Performing Test CC_HAS_WEXTRA
-- Performing Test CC_HAS_WEXTRA - Success
-- Performing Test CC_HAS_WERROR
-- Performing Test CC_HAS_WERROR - Success
-- Performing Test CC_HAS_FEXCEPTIONS
-- Performing Test CC_HAS_FEXCEPTIONS - Success
-- Performing Test CC_HAS_FCXX_EXCEPTIONS
-- Performing Test CC_HAS_FCXX_EXCEPTIONS - Failed
-- Performing Test CC_HAS_FUNWIND_TABLES
-- Performing Test CC_HAS_FUNWIND_TABLES - Success
-- Performing Test CC_HAS_FNO_OMIT_FRAME_POINTER
-- Performing Test CC_HAS_FNO_OMIT_FRAME_POINTER - Success
-- Performing Test CC_HAS_FNO_COMMON
-- Performing Test CC_HAS_FNO_COMMON - Success
-- Performing Test CC_HAS_GGDB
-- Performing Test CC_HAS_GGDB - Success
-- Performing Test CC_HAS_VISIBILITY
-- Performing Test CC_HAS_VISIBILITY - Success
-- Performing Test CC_HAS_ARCH_NATIVE
-- Performing Test CC_HAS_ARCH_NATIVE - Success
-- Performing Test CC_HAS_DEBUG_FRIENDLY_OPTIMIZATION
-- Performing Test CC_HAS_DEBUG_FRIENDLY_OPTIMIZATION - Success
-- Performing Test CC_HAS_WALL
-- Performing Test CC_HAS_WALL - Success
-- Performing Test CC_HAS_OMINIMAL
-- Performing Test CC_HAS_OMINIMAL - Failed
-- Performing Test CC_HAS_SECTIONS
-- Performing Test CC_HAS_SECTIONS - Success
-- Performing Test CC_HAS_FASTMATH
-- Performing Test CC_HAS_FASTMATH - Success
-- Performing Test CC_HAS_WNO_ATTRIBUTES
-- Performing Test CC_HAS_WNO_ATTRIBUTES - Success
-- Performing Test HAVE_OPENMP
-- Performing Test HAVE_OPENMP - Failed
-- Link-Time Optimization by GCC is NOT available
-- Looking for __gcov_flush in gcov
-- Looking for __gcov_flush in gcov - found
-- Looking for C++ include valgrind/memcheck.h
-- Looking for C++ include valgrind/memcheck.h - not found
-- Looking for pow
-- Looking for pow - found
-- Found dlltool: C:/ProgramData/chocolatey/bin/dlltool.exe
-- libmdbx version is 0.10.0.27
-- Use C11 and C++20 for libmdbx
-- MDBX Compile Flags:  -fexceptions -fno-common -ggdb -Wno-unknown-pragmas -ffunction-sections -fdata-sections -Wall -Wextra -Wno-format-extra-args -Wno-format -Wno-cast-function-type -Wno-implicit-fallthrough -O3 -DNDEBUG LIBMDBX_EXPORTS MDBX_BUILD_SHARED_LIBRARY=1 -ffast-math -fvisibility=hidden
-- MDBX_VERSION: 0.10.0.27
-- CMAKE_C_COMPILER: C:/ProgramData/chocolatey/bin/gcc.exe
-- CMAKE_CXX_COMPILER: C:/ProgramData/chocolatey/bin/g++.exe
-- MDBX_BUILD_TARGET: MinGW-Windows
-- MDBX_BUILD_TYPE: Release
-- libmdbx package version is 0.10.0.27
-- Configuring done
-- Generating done
-- Build files have been written to: D:/GitHub/erigon/ethdb/mdbx/dist
[  5%] Building C object CMakeFiles/mdbx.dir/mdbx.c.obj
[ 11%] Building CXX object CMakeFiles/mdbx.dir/mdbx.c++.obj
[ 16%] Linking CXX shared library libmdbx.dll
[ 16%] Built target mdbx
[ 22%] Building C object CMakeFiles/mdbx-static.dir/mdbx.c.obj
[ 27%] Building CXX object CMakeFiles/mdbx-static.dir/mdbx.c++.obj
[ 33%] Linking CXX static library libmdbx-static.a
[ 33%] Built target mdbx-static
[ 38%] Building C object CMakeFiles/mdbx_stat.dir/mdbx_stat.c.obj
[ 44%] Linking CXX executable mdbx_stat.exe
[ 44%] Built target mdbx_stat
[ 50%] Building C object CMakeFiles/mdbx_chk.dir/mdbx_chk.c.obj
[ 55%] Linking CXX executable mdbx_chk.exe
[ 55%] Built target mdbx_chk
[ 61%] Building C object CMakeFiles/mdbx_copy.dir/mdbx_copy.c.obj
[ 66%] Linking CXX executable mdbx_copy.exe
[ 66%] Built target mdbx_copy
[ 72%] Building C object CMakeFiles/mdbx_dump.dir/mdbx_dump.c.obj
[ 77%] Linking CXX executable mdbx_dump.exe
[ 77%] Built target mdbx_dump
[ 83%] Building C object CMakeFiles/mdbx_load.dir/mdbx_load.c.obj
[ 88%] Linking CXX executable mdbx_load.exe
[ 88%] Built target mdbx_load
[ 94%] Building C object CMakeFiles/mdbx_drop.dir/mdbx_drop.c.obj
[100%] Linking CXX executable mdbx_drop.exe
[100%] Built target mdbx_drop
 Building tg ...
github.com/ledgerwatch/erigon/gointerfaces
github.com/ledgerwatch/erigon/common/dbutils
github.com/ledgerwatch/erigon/gointerfaces/remote
github.com/ledgerwatch/erigon/turbo/shards
github.com/ledgerwatch/erigon/ethdb
github.com/ledgerwatch/erigon/gointerfaces/txpool
github.com/ledgerwatch/erigon/consensus/db
github.com/ledgerwatch/erigon/eth/stagedsync/stages
github.com/ledgerwatch/erigon/ethdb/bitmapdb
github.com/ledgerwatch/erigon/turbo/silkworm
github.com/ledgerwatch/erigon/common/etl
github.com/ledgerwatch/erigon/p2p/enode
github.com/ledgerwatch/erigon/turbo/trie
github.com/ledgerwatch/erigon/common/changeset
github.com/ledgerwatch/erigon/migrations
github.com/ledgerwatch/erigon/p2p/discover/v4wire
github.com/ledgerwatch/erigon/p2p/discover/v5wire
github.com/ledgerwatch/erigon/p2p/dnsdisc
github.com/ledgerwatch/erigon/p2p/discover
github.com/ledgerwatch/erigon/p2p
github.com/ledgerwatch/erigon/core/types
github.com/ledgerwatch/erigon/node
github.com/ledgerwatch/erigon/core/rawdb
github.com/ledgerwatch/erigon
github.com/ledgerwatch/erigon/eth/gasprice
github.com/ledgerwatch/erigon/core/vm
github.com/ledgerwatch/erigon/core/state
github.com/ledgerwatch/erigon/turbo/snapshotsync
github.com/ledgerwatch/erigon/consensus
github.com/ledgerwatch/erigon/consensus/misc
github.com/ledgerwatch/erigon/eth/ethutils
github.com/ledgerwatch/erigon/consensus/clique
github.com/ledgerwatch/erigon/turbo/adapter
github.com/ledgerwatch/erigon/consensus/ethash
github.com/ledgerwatch/erigon/core
github.com/ledgerwatch/erigon/turbo/stages/headerdownload
github.com/ledgerwatch/erigon/eth/fetcher
github.com/ledgerwatch/erigon/ethdb/remote/remotedbserver
github.com/ledgerwatch/erigon/eth/protocols/eth
github.com/ledgerwatch/erigon/turbo/stages/bodydownload
github.com/ledgerwatch/erigon/eth/stagedsync
github.com/ledgerwatch/erigon/eth/ethconfig
github.com/ledgerwatch/erigon/turbo/stages
github.com/ledgerwatch/erigon/eth/downloader
github.com/ledgerwatch/erigon/cmd/utils
github.com/ledgerwatch/erigon/cmd/headers/download
github.com/ledgerwatch/erigon/turbo/cli
github.com/ledgerwatch/erigon/eth
github.com/ledgerwatch/erigon/turbo/node
github.com/ledgerwatch/erigon/cmd/tg
 Building rpcdaemon ...
github.com/ledgerwatch/erigon/cmd/rpcdaemon/services
github.com/ledgerwatch/erigon/core/bloombits
github.com/ledgerwatch/erigon/turbo/mock
github.com/ledgerwatch/erigon/accounts/abi/bind
# gopkg.in/olebedev/go-duktape.v3
duk_minimal_printf.c: In function 'duk__parse_pointer':
duk_minimal_printf.c:126:9: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
  126 |  *out = (void *) val;
      |         ^
duk_minimal_printf.c: In function 'duk_minimal_vsnprintf':
duk_minimal_printf.c:236:76: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  236 |     off = duk__format_long(str, size, off, sizeof(void *) * 2, '0', 16, 0, (unsigned long) v);
      |                                                                            ^
github.com/ledgerwatch/erigon/eth/tracers
github.com/ledgerwatch/erigon/eth/filters
github.com/ledgerwatch/erigon/internal/ethapi
github.com/ledgerwatch/erigon/cmd/rpcdaemon/cli
github.com/ledgerwatch/erigon/cmd/rpcdaemon/filters
github.com/ledgerwatch/erigon/cmd/rpcdaemon/commands/contracts
github.com/ledgerwatch/erigon/turbo/rpchelper
github.com/ledgerwatch/erigon/accounts/abi/bind/backends
github.com/ledgerwatch/erigon/turbo/adapter/ethapi
github.com/ledgerwatch/erigon/turbo/transactions
github.com/ledgerwatch/erigon/cmd/rpcdaemon/commands
github.com/ledgerwatch/erigon/cmd/rpcdaemon
 Building integration ...
github.com/ledgerwatch/erigon/common/debugprint
github.com/ledgerwatch/erigon/eth/integrity
github.com/ledgerwatch/erigon/cmd/integration/commands
github.com/ledgerwatch/erigon/cmd/integration
 Building rpctest ...
github.com/ledgerwatch/erigon/cmd/rpctest/rpctest
github.com/ledgerwatch/erigon/cmd/rpctest
 Building state ...
github.com/ledgerwatch/erigon/cmd/state/stats
github.com/ledgerwatch/erigon/cmd/state/verify
github.com/ledgerwatch/erigon/cmd/state/generate
github.com/ledgerwatch/erigon/cmd/state/commands
github.com/ledgerwatch/erigon/cmd/state
```