### PR TITLE
nat settings similar to tg behaviour

### DIFF
--- a/cmd/headers/commands/sentry.go
+++ b/cmd/headers/commands/sentry.go
@@ -14,7 +14,14 @@ var (
 )
 
 func init() {
-	sentryCmd.Flags().StringVar(&natSetting, "nat", "any", "NAT port mapping mechanism (any|none|upnp|pmp|extip:<IP>)")
+	sentryCmd.Flags().StringVar(&natSetting, "nat", "", `NAT port mapping mechanism (any|none|upnp|pmp|extip:<IP>)
+	     "" or "none"         default - do not nat
+	     "extip:77.12.33.4"   will assume the local machine is reachable on the given IP
+	     "any"                uses the first auto-detected mechanism
+	     "upnp"               uses the Universal Plug and Play protocol
+	     "pmp"                uses NAT-PMP with an auto-detected gateway address
+	     "pmp:192.168.0.1"    uses NAT-PMP with the given gateway address
+`)
 	sentryCmd.Flags().IntVar(&port, "port", 30303, "p2p port number")
 	sentryCmd.Flags().StringVar(&sentryAddr, "sentry.api.addr", "localhost:9091", "comma separated sentry addresses '<host>:<port>,<host>:<port>'")
 	sentryCmd.Flags().StringArrayVar(&staticPeers, "staticpeers", []string{}, "static peer list [enode]")

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -448,9 +448,16 @@ var (
 		Usage: "P2P node key as hex (for testing)",
 	}
 	NATFlag = cli.StringFlag{
-		Name:  "nat",
-		Usage: "NAT port mapping mechanism (any|none|upnp|pmp|extip:<IP>)",
-		Value: "any",
+		Name: "nat",
+		Usage: `NAT port mapping mechanism (any|none|upnp|pmp|extip:<IP>)
+	     "" or "none"         default - do not nat
+	     "extip:77.12.33.4"   will assume the local machine is reachable on the given IP
+	     "any"                uses the first auto-detected mechanism
+	     "upnp"               uses the Universal Plug and Play protocol
+	     "pmp"                uses NAT-PMP with an auto-detected gateway address
+	     "pmp:192.168.0.1"    uses NAT-PMP with the given gateway address
+`,
+		Value: "",
 	}
 	NoDiscoverFlag = cli.BoolFlag{
 		Name:  "nodiscover",


### PR DESCRIPTION
In TG we have code: 
```
if ctx.GlobalIsSet(NATFlag.Name) {
	p2pcfg.Nat := nat.Parse(ctx.GlobalString(NATFlag.Name))
}
```
This code is controversial because: 
NATFlag default value is "any" (means p2pcfg.Nat is not nil), but this value not used if flag not set (means p2pcfg.Nat is nil) :-)

This RP: changing default value of this flag (and flag in sentry) to match current TG behavior: do not detect nat automatically.