### PR TITLE
Implement historical tx simulation rpc api

### DIFF
--- a/cmd/rpcdaemon/commands/eth_block.go
+++ b/cmd/rpcdaemon/commands/eth_block.go
@@ -3,14 +3,163 @@ package commands
 import (
 	"context"
 	"fmt"
+	"math/big"
+	"time"
+
+	"golang.org/x/crypto/sha3"
 
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/common/hexutil"
+	"github.com/ledgerwatch/turbo-geth/common/math"
+	"github.com/ledgerwatch/turbo-geth/core"
 	"github.com/ledgerwatch/turbo-geth/core/rawdb"
+	"github.com/ledgerwatch/turbo-geth/core/state"
+	"github.com/ledgerwatch/turbo-geth/core/types"
+	"github.com/ledgerwatch/turbo-geth/core/vm"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
+	"github.com/ledgerwatch/turbo-geth/log"
 	"github.com/ledgerwatch/turbo-geth/rpc"
 	"github.com/ledgerwatch/turbo-geth/turbo/adapter/ethapi"
+	"github.com/ledgerwatch/turbo-geth/turbo/rpchelper"
+	"github.com/ledgerwatch/turbo-geth/turbo/transactions"
 )
+
+func (api *APIImpl) CallBundle(ctx context.Context, txHashes []common.Hash, stateBlockNumberOrHash rpc.BlockNumberOrHash, timeoutMilliSecondsPtr *int64) (map[string]interface{}, error) {
+	dbtx, err := api.db.BeginRo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer dbtx.Rollback()
+
+	chainConfig, err := api.chainConfig(dbtx)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(txHashes) == 0 {
+		return nil, nil
+	}
+
+	var txs types.Transactions
+
+	for _, txHash := range txHashes {
+		txn, _, _, _ := rawdb.ReadTransaction(ethdb.NewRoTxDb(dbtx), txHash)
+		if txn == nil {
+			return nil, nil // not error, see https://github.com/ledgerwatch/turbo-geth/issues/1645
+		}
+		txs = append(txs, txn)
+	}
+	defer func(start time.Time) { log.Debug("Executing EVM call finished", "runtime", time.Since(start)) }(time.Now())
+
+	stateBlockNumber, hash, err := rpchelper.GetBlockNumber(stateBlockNumberOrHash, dbtx, api.pending)
+	if err != nil {
+		return nil, err
+	}
+
+	var stateReader state.StateReader
+	if num, ok := stateBlockNumberOrHash.Number(); ok && num == rpc.LatestBlockNumber {
+		stateReader = state.NewPlainStateReader(dbtx)
+	} else {
+		stateReader = state.NewPlainKvState(dbtx, stateBlockNumber)
+	}
+	st := state.New(stateReader)
+
+	parent := rawdb.ReadHeader(dbtx, hash, stateBlockNumber)
+	if parent == nil {
+		return nil, fmt.Errorf("block %d(%x) not found", stateBlockNumber, hash)
+	}
+
+	blockNumber := stateBlockNumber + 1
+
+	timestamp := parent.Time // Dont care about the timestamp
+
+	coinbase := parent.Coinbase
+	header := &types.Header{
+		ParentHash: parent.Hash(),
+		Number:     big.NewInt(int64(blockNumber)),
+		GasLimit:   parent.GasLimit,
+		Time:       timestamp,
+		Difficulty: parent.Difficulty,
+		Coinbase:   coinbase,
+	}
+
+	// Get a new instance of the EVM
+	signer := types.MakeSigner(chainConfig, blockNumber)
+	firstMsg, err := txs[0].AsMessage(*signer)
+	if err != nil {
+		return nil, err
+	}
+
+	blockCtx, txCtx := transactions.GetEvmContext(firstMsg, header, stateBlockNumberOrHash.RequireCanonical, dbtx)
+	evm := vm.NewEVM(blockCtx, txCtx, st, chainConfig, vm.Config{Debug: false})
+
+	timeoutMilliSeconds := int64(5000)
+	if timeoutMilliSecondsPtr != nil {
+		timeoutMilliSeconds = *timeoutMilliSecondsPtr
+	}
+	timeout := time.Millisecond * time.Duration(timeoutMilliSeconds)
+
+	// Setup context so it may be cancelled the call has completed
+	// or, in case of unmetered gas, setup a context with a timeout.
+	var cancel context.CancelFunc
+	if timeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+	} else {
+		ctx, cancel = context.WithCancel(ctx)
+	}
+	// Make sure the context is cancelled when the call has completed
+	// this makes sure resources are cleaned up.
+	defer cancel()
+
+	// Wait for the context to be done and cancel the evm. Even if the
+	// EVM has finished, cancelling may be done (repeatedly)
+	go func() {
+		<-ctx.Done()
+		evm.Cancel()
+	}()
+
+	// Setup the gas pool (also for unmetered requests)
+	// and apply the message.
+	gp := new(core.GasPool).AddGas(math.MaxUint64)
+
+	results := []map[string]interface{}{}
+
+	bundleHash := sha3.NewLegacyKeccak256()
+	for _, tx := range txs {
+		msg, err := tx.AsMessage(*signer)
+		if err != nil {
+			return nil, err
+		}
+		// Execute the transaction message
+		result, err := core.ApplyMessage(evm, msg, gp, true /* refunds */, false /* gasBailout */)
+		if err != nil {
+			return nil, err
+		}
+		// If the timer caused an abort, return an appropriate error message
+		if evm.Cancelled() {
+			return nil, fmt.Errorf("execution aborted (timeout = %v)", timeout)
+		}
+
+		txHash := tx.Hash().String()
+		jsonResult := map[string]interface{}{
+			"txHash":  txHash,
+			"gasUsed": result.UsedGas,
+		}
+		bundleHash.Write(tx.Hash().Bytes())
+		if result.Err != nil {
+			jsonResult["error"] = result.Err.Error()
+		} else {
+			jsonResult["value"] = common.BytesToHash(result.Return())
+		}
+
+		results = append(results, jsonResult)
+	}
+
+	ret := map[string]interface{}{}
+	ret["results"] = results
+	ret["bundleHash"] = "0x" + common.Bytes2Hex(bundleHash.Sum(nil))
+	return ret, nil
+}
 
 // GetBlockByNumber implements eth_getBlockByNumber. Returns information about a block given the block's number.
 func (api *APIImpl) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (map[string]interface{}, error) {


### PR DESCRIPTION
Introduces eth_callBundle rpc call to simulate an ordered sequence of transactions on top of a given block state.