### PR TITLE
simplify receipts reading

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -260,7 +260,7 @@ func (b *SimulatedBackend) TransactionReceipt(ctx context.Context, txHash common
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	receipt, _, _, _ := rawdb.ReadReceipt(b.database, txHash)
+	receipt, _, _, _ := rawdb.ReadReceiptDeprecated(b.database, txHash)
 	return receipt, nil
 }
 

--- a/cmd/rpcdaemon/commands/erigon_receipts.go
+++ b/cmd/rpcdaemon/commands/erigon_receipts.go
@@ -17,17 +17,16 @@ func (api *ErigonImpl) GetLogsByHash(ctx context.Context, hash common.Hash) ([][
 	}
 	defer tx.Rollback()
 
-	number := rawdb.ReadHeaderNumber(tx, hash)
-	if number == nil {
-		return nil, fmt.Errorf("block not found: %x", hash)
-	}
-
 	chainConfig, err := api.chainConfig(tx)
 	if err != nil {
 		return nil, err
 	}
 
-	receipts, err := getReceipts(ctx, tx, chainConfig, *number, hash)
+	block, senders, err := rawdb.ReadBlockByHashWithSenders(tx, hash)
+	if err != nil {
+		return nil, err
+	}
+	receipts, err := getReceipts(ctx, tx, chainConfig, block, senders)
 	if err != nil {
 		return nil, fmt.Errorf("getReceipts error: %v", err)
 	}

--- a/common/dbutils/bucket.go
+++ b/common/dbutils/bucket.go
@@ -214,8 +214,8 @@ const (
 
 	BlockBodyPrefix     = "b"      // block_num_u64 + hash -> block body
 	EthTx               = "eth_tx" // tbl_sequence_u64 -> rlp(tx)
-	BlockReceiptsPrefix = "r"      // block_num_u64 + hash -> block receipts
-	Log                 = "log"    // block_num_u64 + hash -> block receipts
+	BlockReceiptsPrefix = "r"      // block_num_u64 -> canonical block receipts (non-canonical are not stored)
+	Log                 = "log"    // block_num_u64 + txId -> logs of transaction
 
 	// Stores bitmap indices - in which block numbers saw logs of given 'address' or 'topic'
 	// [addr or topic] + [2 bytes inverted shard number] -> bitmap(blockN)
@@ -237,8 +237,8 @@ const (
 	CallFromIndex = "call_from_index"
 	CallToIndex   = "call_to_index"
 
-	TxLookupPrefix  = "l" // txLookupPrefix + hash -> transaction/receipt lookup metadata
-	BloomBitsPrefix = "B" // bloomBitsPrefix + bit (uint16 big endian) + section (uint64 big endian) + hash -> bloom bits
+	TxLookupPrefix  = "l" // hash -> transaction/receipt lookup metadata
+	BloomBitsPrefix = "B" // bit (uint16 big endian) + section (uint64 big endian) + hash -> bloom bits
 
 	PreimagePrefix = "secure-key-"      // preimagePrefix + hash -> preimage
 	ConfigPrefix   = "ethereum-config-" // config prefix for the db
@@ -262,7 +262,7 @@ const (
 	InodesBucket = "inodes"
 
 	// Transaction senders - stored separately from the block bodies
-	Senders = "txSenders"
+	Senders = "txSenders" // block_num_u64 + blockHash -> sendersList (no serialization format, every 20 bytes is new sender)
 
 	// headBlockKey tracks the latest know full block's hash.
 	HeadBlockKey = "LastBlock"

--- a/common/dbutils/composite_keys.go
+++ b/common/dbutils/composite_keys.go
@@ -26,12 +26,12 @@ func DecodeBlockNumber(number []byte) (uint64, error) {
 	return binary.BigEndian.Uint64(number), nil
 }
 
-// headerKey = headerPrefix + num (uint64 big endian) + hash
+// HeaderKey = num (uint64 big endian) + hash
 func HeaderKey(number uint64, hash common.Hash) []byte {
 	return append(EncodeBlockNumber(number), hash.Bytes()...)
 }
 
-// blockBodyKey = blockBodyPrefix + num (uint64 big endian) + hash
+// BlockBodyKey = num (uint64 big endian) + hash
 func BlockBodyKey(number uint64, hash common.Hash) []byte {
 	return append(EncodeBlockNumber(number), hash.Bytes()...)
 }

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -307,26 +307,18 @@ func ReadTransactions(db ethdb.Tx, baseTxId uint64, amount uint32) ([]types.Tran
 	txs := make([]types.Transaction, amount)
 	binary.BigEndian.PutUint64(txIdKey, baseTxId)
 	i := uint32(0)
-	c, err := db.Cursor(dbutils.EthTx)
-	if err != nil {
-		return nil, err
-	}
-	defer c.Close()
 
-	var decodeErr error
-	for k, v, err := c.Seek(txIdKey); k != nil; k, v, err = c.Next() {
-		if err != nil {
-			return nil, err
-		}
+	if err := db.ForAmount(dbutils.EthTx, txIdKey, amount, func(k, v []byte) error {
+		var decodeErr error
 		reader.Reset(v)
 		stream.Reset(reader, 0)
 		if txs[i], decodeErr = types.DecodeTransaction(stream); decodeErr != nil {
-			return nil, decodeErr
+			return decodeErr
 		}
 		i++
-		if i >= amount {
-			break
-		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 	txs = txs[:i] // user may request big "amount", but db can return small "amount". Return as much as we found.
 	return txs, nil
@@ -627,9 +619,9 @@ func HasReceipts(db ethdb.Has, hash common.Hash, number uint64) bool {
 // ReadRawReceipts retrieves all the transaction receipts belonging to a block.
 // The receipt metadata fields are not guaranteed to be populated, so they
 // should not be used. Use ReadReceipts instead if the metadata is needed.
-func ReadRawReceipts(db ethdb.Tx, hash common.Hash, number uint64) types.Receipts {
+func ReadRawReceipts(db ethdb.Tx, blockNum uint64) types.Receipts {
 	// Retrieve the flattened receipt slice
-	data, err := db.GetOne(dbutils.BlockReceiptsPrefix, dbutils.ReceiptsKey(number))
+	data, err := db.GetOne(dbutils.BlockReceiptsPrefix, dbutils.ReceiptsKey(blockNum))
 	if err != nil {
 		log.Error("ReadRawReceipts failed", "err", err)
 	}
@@ -638,26 +630,22 @@ func ReadRawReceipts(db ethdb.Tx, hash common.Hash, number uint64) types.Receipt
 	}
 	var receipts types.Receipts
 	if err := cbor.Unmarshal(&receipts, bytes.NewReader(data)); err != nil {
-		log.Error("receipt unmarshal failed", "hash", hash, "err", err)
+		log.Error("receipt unmarshal failed", "err", err)
 		return nil
 	}
 
-	c, err := db.Cursor(dbutils.Log)
-	if err != nil {
-		log.Error("receipt unmarshal failed", "hash", hash, "err", err)
-		return nil
-	}
-	defer c.Close()
-	if err := ethdb.Walk(c, dbutils.LogKey(number, 0), 8*8, func(k, v []byte) (bool, error) {
+	prefix := make([]byte, 8)
+	binary.BigEndian.PutUint64(prefix, blockNum)
+	if err := db.ForPrefix(dbutils.Log, prefix, func(k, v []byte) error {
 		var logs types.Logs
 		if err := cbor.Unmarshal(&logs, bytes.NewReader(v)); err != nil {
-			return false, fmt.Errorf("receipt unmarshal failed: %x, %w", hash, err)
+			return fmt.Errorf("receipt unmarshal failed:  %w", err)
 		}
 
 		receipts[binary.BigEndian.Uint32(k[8:])].Logs = logs
-		return true, nil
+		return nil
 	}); err != nil {
-		log.Error("logs fetching failed", "hash", hash, "err", err)
+		log.Error("logs fetching failed", "err", err)
 		return nil
 	}
 
@@ -701,27 +689,15 @@ func ReadRawReceiptsDeprecated(db ethdb.Getter, hash common.Hash, number uint64)
 // The current implementation populates these metadata fields by reading the receipts'
 // corresponding block body, so if the block body is not found it will return nil even
 // if the receipt itself is stored.
-func ReadReceipts(db ethdb.Tx, hash common.Hash, number uint64) types.Receipts {
+func ReadReceipts(db ethdb.Tx, block *types.Block, senders []common.Address) types.Receipts {
 	// We're deriving many fields from the block body, retrieve beside the receipt
-	receipts := ReadRawReceipts(db, hash, number)
+	receipts := ReadRawReceipts(db, block.NumberU64())
 	if receipts == nil {
 		return nil
 	}
-	body := ReadBody(db, hash, number)
-	if body == nil {
-		log.Error("Missing body but have receipt", "hash", hash, "number", number)
-		return nil
-	}
-	senders, err := ReadSenders(db, hash, number)
-	if err != nil {
-		log.Error("Failed to read Senders", "hash", hash, "number", number, "err", err)
-		return nil
-	}
-	if senders == nil {
-		return nil
-	}
-	if err = receipts.DeriveFields(hash, number, body.Transactions, senders); err != nil {
-		log.Error("Failed to derive block receipts fields", "hash", hash, "number", number, "err", err)
+	block.Body().SendersToTxs(senders)
+	if err := receipts.DeriveFields(block.Hash(), block.NumberU64(), block.Transactions(), senders); err != nil {
+		log.Error("Failed to derive block receipts fields", "hash", block.Hash(), "number", block.NumberU64(), "err", err)
 		return nil
 	}
 	return receipts
@@ -848,61 +824,30 @@ func DeleteReceipts(db ethdb.RwTx, number uint64) error {
 		return fmt.Errorf("receipts delete failed: %d, %w", number, err)
 	}
 
-	c, err := db.Cursor(dbutils.Log)
-	if err != nil {
-		return err
-	}
-	defer c.Close()
-
-	if err := ethdb.Walk(c, dbutils.LogKey(number, 0), 8*8, func(k, v []byte) (bool, error) {
-		if err := db.Delete(dbutils.Log, k, nil); err != nil {
-			return false, err
-		}
-		return true, nil
+	prefix := make([]byte, 8)
+	binary.BigEndian.PutUint64(prefix, number)
+	if err := db.ForPrefix(dbutils.Log, prefix, func(k, v []byte) error {
+		return db.Delete(dbutils.Log, k, nil)
 	}); err != nil {
-		return fmt.Errorf("logs delete failed: %d, %w", number, err)
+		return err
 	}
 	return nil
 }
 
 // DeleteNewerReceipts removes all receipt for given block number or newer
 func DeleteNewerReceipts(db ethdb.RwTx, number uint64) error {
-	receipts, err := db.Cursor(dbutils.BlockReceiptsPrefix)
-	if err != nil {
-		return err
-	}
-	defer receipts.Close()
-	receiptsDel, err := db.RwCursor(dbutils.BlockReceiptsPrefix)
-	if err != nil {
-		return err
-	}
-	defer receiptsDel.Close()
-	if err := ethdb.Walk(receipts, dbutils.ReceiptsKey(number), 0, func(k, v []byte) (bool, error) {
-		if err := receiptsDel.Delete(k, nil); err != nil {
-			return false, err
-		}
-		return true, nil
+	if err := db.ForEach(dbutils.BlockReceiptsPrefix, dbutils.ReceiptsKey(number), func(k, v []byte) error {
+		return db.Delete(dbutils.BlockReceiptsPrefix, k, nil)
 	}); err != nil {
-		return fmt.Errorf("delete newer receipts failed: %d, %w", number, err)
+		return err
 	}
 
-	logs, err := db.Cursor(dbutils.Log)
-	if err != nil {
-		return err
-	}
-	defer logs.Close()
-	logsDel, err := db.RwCursor(dbutils.Log)
-	if err != nil {
-		return err
-	}
-	defer logsDel.Close()
-	if err := ethdb.Walk(logs, dbutils.LogKey(number, 0), 0, func(k, v []byte) (bool, error) {
-		if err := logsDel.Delete(k, nil); err != nil {
-			return false, err
-		}
-		return true, nil
+	from := make([]byte, 8)
+	binary.BigEndian.PutUint64(from, number)
+	if err := db.ForEach(dbutils.Log, from, func(k, v []byte) error {
+		return db.Delete(dbutils.Log, k, nil)
 	}); err != nil {
-		return fmt.Errorf("delete newer logs failed: %d, %w", number, err)
+		return err
 	}
 	return nil
 }

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -690,6 +690,9 @@ func ReadRawReceiptsDeprecated(db ethdb.Getter, hash common.Hash, number uint64)
 // corresponding block body, so if the block body is not found it will return nil even
 // if the receipt itself is stored.
 func ReadReceipts(db ethdb.Tx, block *types.Block, senders []common.Address) types.Receipts {
+	if block == nil {
+		return nil
+	}
 	// We're deriving many fields from the block body, retrieve beside the receipt
 	receipts := ReadRawReceipts(db, block.NumberU64())
 	if receipts == nil {

--- a/core/rawdb/accessors_indexes.go
+++ b/core/rawdb/accessors_indexes.go
@@ -36,8 +36,8 @@ type TxLookupEntry struct {
 
 // ReadTxLookupEntry retrieves the positional metadata associated with a transaction
 // hash to allow retrieving the transaction or receipt by hash.
-func ReadTxLookupEntry(db ethdb.Tx, hash common.Hash) *uint64 {
-	data, _ := db.GetOne(dbutils.TxLookupPrefix, hash.Bytes())
+func ReadTxLookupEntry(db ethdb.Tx, txnHash common.Hash) *uint64 {
+	data, _ := db.GetOne(dbutils.TxLookupPrefix, txnHash.Bytes())
 	if len(data) == 0 {
 		return nil
 	}
@@ -131,11 +131,11 @@ func ReadTransactionDeprecated(db ethdb.Getter, hash common.Hash) (types.Transac
 	return nil, common.Hash{}, 0, 0
 }
 
-// ReadReceipt retrieves a specific transaction receipt from the database, along with
+// ReadReceiptDeprecated retrieves a specific transaction receipt from the database, along with
 // its added positional metadata.
-func ReadReceipt(db ethdb.Getter, hash common.Hash) (*types.Receipt, common.Hash, uint64, uint64) {
+func ReadReceiptDeprecated(db ethdb.Getter, txHash common.Hash) (*types.Receipt, common.Hash, uint64, uint64) {
 	// Retrieve the context of the receipt based on the transaction hash
-	blockNumber := ReadTxLookupEntryDeprecated(db, hash)
+	blockNumber := ReadTxLookupEntryDeprecated(db, txHash)
 	if blockNumber == nil {
 		return nil, common.Hash{}, 0, 0
 	}
@@ -150,11 +150,11 @@ func ReadReceipt(db ethdb.Getter, hash common.Hash) (*types.Receipt, common.Hash
 	// Read all the receipts from the block and return the one with the matching hash
 	receipts := ReadReceiptsDeprecated(db, blockHash, *blockNumber)
 	for receiptIndex, receipt := range receipts {
-		if receipt.TxHash == hash {
+		if receipt.TxHash == txHash {
 			return receipt, blockHash, *blockNumber, uint64(receiptIndex)
 		}
 	}
-	log.Error("Receipt not found", "number", blockNumber, "hash", blockHash, "txhash", hash)
+	log.Error("Receipt not found", "number", blockNumber, "hash", blockHash, "txhash", txHash)
 	return nil, common.Hash{}, 0, 0
 }
 

--- a/core/state/plain_readonly.go
+++ b/core/state/plain_readonly.go
@@ -328,7 +328,10 @@ func (s *PlainKVState) ForEachStorage(addr common.Address, startLocation common.
 	st := llrb.New()
 	var k [common.AddressLength + common.IncarnationLength + common.HashLength]byte
 	copy(k[:], addr[:])
-	accData, _ := GetAsOf(s.tx, false /* storage */, addr[:], s.blockNr+1)
+	accData, err := GetAsOf(s.tx, false /* storage */, addr[:], s.blockNr+1)
+	if err != nil {
+		return err
+	}
 	var acc accounts.Account
 	if err := acc.DecodeForStorage(accData); err != nil {
 		log.Error("Error decoding account", "error", err)

--- a/ethdb/kv_abstract.go
+++ b/ethdb/kv_abstract.go
@@ -170,6 +170,7 @@ type Tx interface {
 
 	ForEach(bucket string, fromPrefix []byte, walker func(k, v []byte) error) error
 	ForPrefix(bucket string, prefix []byte, walker func(k, v []byte) error) error
+	ForAmount(bucket string, prefix []byte, amount uint32, walker func(k, v []byte) error) error
 
 	Comparator(bucket string) dbutils.CmpFunc
 

--- a/ethdb/kv_lmdb.go
+++ b/ethdb/kv_lmdb.go
@@ -450,6 +450,25 @@ func (tx *lmdbTx) ForPrefix(bucket string, prefix []byte, walker func(k, v []byt
 	return nil
 }
 
+func (tx *lmdbTx) ForAmount(bucket string, fromPrefix []byte, amount uint32, walker func(k, v []byte) error) error {
+	c, err := tx.Cursor(bucket)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	for k, v, err := c.Seek(fromPrefix); k != nil && amount > 0; k, v, err = c.Next() {
+		if err != nil {
+			return err
+		}
+		if err := walker(k, v); err != nil {
+			return err
+		}
+		amount--
+	}
+	return nil
+}
+
 // All buckets stored as keys of un-named bucketw
 func (tx *lmdbTx) ExistingBuckets() ([]string, error) {
 	var res []string

--- a/ethdb/kv_mdbx.go
+++ b/ethdb/kv_mdbx.go
@@ -449,6 +449,24 @@ func (tx *MdbxTx) ForPrefix(bucket string, prefix []byte, walker func(k, v []byt
 	}
 	return nil
 }
+func (tx *MdbxTx) ForAmount(bucket string, fromPrefix []byte, amount uint32, walker func(k, v []byte) error) error {
+	c, err := tx.Cursor(bucket)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	for k, v, err := c.Seek(fromPrefix); k != nil && amount > 0; k, v, err = c.Next() {
+		if err != nil {
+			return err
+		}
+		if err := walker(k, v); err != nil {
+			return err
+		}
+		amount--
+	}
+	return nil
+}
 
 func (tx *MdbxTx) CollectMetrics() {
 	if !metrics.Enabled {

--- a/ethdb/kv_remote.go
+++ b/ethdb/kv_remote.go
@@ -321,6 +321,25 @@ func (tx *remoteTx) ForPrefix(bucket string, prefix []byte, walker func(k, v []b
 	return nil
 }
 
+func (tx *remoteTx) ForAmount(bucket string, fromPrefix []byte, amount uint32, walker func(k, v []byte) error) error {
+	c, err := tx.Cursor(bucket)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	for k, v, err := c.Seek(fromPrefix); k != nil && amount > 0; k, v, err = c.Next() {
+		if err != nil {
+			return err
+		}
+		if err := walker(k, v); err != nil {
+			return err
+		}
+		amount--
+	}
+	return nil
+}
+
 func (tx *remoteTx) GetOne(bucket string, key []byte) (val []byte, err error) {
 	c, err := tx.statelessCursor(bucket)
 	if err != nil {

--- a/ethdb/kv_snapshot.go
+++ b/ethdb/kv_snapshot.go
@@ -429,6 +429,23 @@ func (s *snTX) ForPrefix(bucket string, prefix []byte, walker func(k, v []byte) 
 	}
 	return nil
 }
+func (s *snTX) ForAmount(bucket string, fromPrefix []byte, amount uint32, walker func(k, v []byte) error) error {
+	c, err := s.Cursor(bucket)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	for k, v, err := c.Seek(fromPrefix); k != nil && amount > 0; k, v, err = c.Next() {
+		if err != nil {
+			return err
+		}
+		if err := walker(k, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
 func (s *snTX) Commit() error {
 	for i := range s.snTX {

--- a/turbo/stages/blockchain_test.go
+++ b/turbo/stages/blockchain_test.go
@@ -456,7 +456,7 @@ func TestChainTxReorgs(t *testing.T) {
 		if txn, _, _, _ := rawdb.ReadTransactionDeprecated(db, tx.Hash()); txn != nil {
 			t.Errorf("drop %d: tx %v found while shouldn't have been", i, txn)
 		}
-		if rcpt, _, _, _ := rawdb.ReadReceipt(db, tx.Hash()); rcpt != nil {
+		if rcpt, _, _, _ := rawdb.ReadReceiptDeprecated(db, tx.Hash()); rcpt != nil {
 			t.Errorf("drop %d: receipt %v found while shouldn't have been", i, rcpt)
 		}
 	}
@@ -466,7 +466,7 @@ func TestChainTxReorgs(t *testing.T) {
 		if txn, _, _, _ := rawdb.ReadTransactionDeprecated(db, tx.Hash()); txn == nil {
 			t.Errorf("add %d: expected tx to be found", i)
 		}
-		if rcpt, _, _, _ := rawdb.ReadReceipt(db, tx.Hash()); rcpt == nil {
+		if rcpt, _, _, _ := rawdb.ReadReceiptDeprecated(db, tx.Hash()); rcpt == nil {
 			t.Errorf("add %d: expected receipt to be found", i)
 		}
 	}
@@ -476,7 +476,7 @@ func TestChainTxReorgs(t *testing.T) {
 		if txn, _, _, _ := rawdb.ReadTransactionDeprecated(db, tx.Hash()); txn == nil {
 			t.Errorf("share %d: expected tx to be found", i)
 		}
-		if rcpt, _, _, _ := rawdb.ReadReceipt(db, tx.Hash()); rcpt == nil {
+		if rcpt, _, _, _ := rawdb.ReadReceiptDeprecated(db, tx.Hash()); rcpt == nil {
 			t.Errorf("share %d: expected receipt to be found", i)
 		}
 	}


### PR DESCRIPTION
- do not read blocks twice (in eth_getTransactionReceipt and couple other methods)
- fix some bad docs in bucket.go
