### PR TITLE
tevm open cursor after commit

### DIFF
--- a/eth/stagedsync/stage_tevm.go
+++ b/eth/stagedsync/stage_tevm.go
@@ -129,7 +129,11 @@ func transpileBatch(logPrefix string, s *StageState, fromBlock uint64, toBlock u
 					return fmt.Errorf("cannot begin the batch transaction on %q: %w",
 						common.BytesToHash(hash), err)
 				}
-
+				k, hash = common.CopyBytes(k), common.CopyBytes(hash)
+				_, err = c.SeekBothRange(k, hash)
+				if err != nil {
+					return err
+				}
 				// TODO: This creates stacked up deferrals
 				defer tx.Rollback()
 			}


### PR DESCRIPTION
I think need change logic to next one: 
- call func transpileBatch in loop
- transpileBatch will start new tx if need,new batch, open cursor, commit if need AND return (k,v) where it stopped (when commit happened)
- external func will pass this (k,v) to next call of transpileBatch
This will solve `TODO: This creates stacked up deferrals` and allow remove code when need reopen tx/batch/cursor/etc... 
- external func to call transpileBatch until it returns k==nil
something like:
```
func SpawnStage() {
   for lastKey != nil  {
        lastKey, lastValue = processBatch(lastKey, lastValue) // start tx, open batch, open cursor, commit tx if need - but doesn't reopen anything
   }   
}

func processBatch(k, v []byte) {
	useExternalTx := tx != nil
	if !useExternalTx {
		tx := db.Begin()
		defer tx.Rollback()
	}
	b := NewBatch()
	defer b.Rollback()

	c = tx.Cursor()
	defer c.Close()

	for c.SeekBothExact(k, v); ; c.Next() {
		// do the work
	}
	k, v = c.Current()
	lastKey, lastValue := common.CopyBytes(k), common.CopyBytes(v) // data valid only until end of tx - copy it

	stage.Done(tx)
	if !useExternalTx {
		tx.Commit()
	}
	return lastKey, lastValue
}
```

original panic: 
```
 invalid memory address or nil pointer dereference, trace: goroutine 77 [running]: runtime/debug.Stack(0x15336c0, 0xc066c72040, 0x6) runtime/debug/stack.go:24 +0x9f github.com/ledgerwatch/erigon/turbo/stages.StageLoopStep.func1(0xc0000a4000) github.com/ledgerwatch/erigon/turbo/stages/stageloop.go:119 +0x1d5 panic(0x1483020, 0x2833460) runtime/panic.go:971 +0x499 github.com/ledgerwatch/erigon/ethdb/mdbx.(*Cursor).getVal0.func1(0xc01a9ce370, 0x8, 0x300000002) github.com/ledgerwatch/erigon/ethdb/mdbx/cursor.go:182 +0x29 github.com/ledgerwatch/erigon/ethdb/mdbx.(*Cursor).getVal0(0xc01a9ce370, 0x8, 0x18897, 0xc007d1ba88) github.com/ledgerwatch/erigon/ethdb/mdbx/cursor.go:182 +0x39 github.com/ledgerwatch/erigon/ethdb/mdbx.(*Cursor).Get(0xc01a9ce370, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x8, 0x203007, 0x7f39d50202b0, ...) github.com/ledgerwatch/erigon/ethdb/mdbx/cursor.go:140 +0x405 github.com/ledgerwatch/erigon/ethdb.(*MdbxCursor).next(...) github.com/ledgerwatch/erigon/ethdb/kv_mdbx.go:1037 github.com/ledgerwatch/erigon/ethdb.(*MdbxCursor).Next(0xc041722a80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0) github.com/ledgerwatch/erigon/ethdb/kv_mdbx.go:1186 +0x65 github.com/ledgerwatch/erigon/eth/stagedsync.transpileBatch(0xc0ab8c5920, 0x10, 0xc028e79720, 0x0, 0xc05d3e, 0x206a3e0, 0xc0770c7500, 0x206a680, 0xc01c9a8a00, 0x205cfc8, ...) github.com/ledgerwatch/erigon/eth/stagedsync/stage_tevm.go:61 +0x2df github.com/ledgerwatch/erigon/eth/stagedsync.SpawnTranspileStage(0xc028e79720, 0x0, 0xc02acf5410, 0x0, 0xc0000c8cc0, 0x205cfc8, 0xc000432000, 0x20000000, 0x0, 0x0, ...) github.com/ledgerwatch/erigon/eth/stagedsync/stage_tevm.go:203 +0x5cf github.com/ledgerwatch/erigon/eth/stagedsync.ReplacementStages.func8.1(0xc028e79720, 0x2032260, 0xc0000ba5c0, 0x0, 0x0, 0xc028e79720, 0x0) github.com/ledgerwatch/erigon/eth/stagedsync/replacement_stages.go:186 +0xce github.com/ledgerwatch/erigon/eth/stagedsync.(*State).runStage(0xc0000ba5c0, 0xc00037e230, 0x205cfc8, 0xc000432000, 0x0, 0x0, 0x0, 0x0) github.com/ledgerwatch/erigon/eth/stagedsync/state.go:223 +0x203 github.com/ledgerwatch/erigon/eth/stagedsync.(*State).Run(0xc0000ba5c0, 0x205cfc8, 0xc000432000, 0x0, 0x0, 0x0, 0xc0000ba180) github.com/ledgerwatch/erigon/eth/stagedsync/state.go:183 +0x285 github.com/ledgerwatch/erigon/turbo/stages.StageLoopStep(0x20517b0, 0xc00169b5c0, 0x205cfc8, 0xc000432000, 0xc0003b4380, 0x0, 0x2845d00, 0x2051cb8, 0xc00169b540, 0x1, ...) github.com/ledgerwatch/erigon/turbo/stages/stageloop.go:177 +0x529 github.com/ledgerwatch/erigon/turbo/stages.StageLoop(0x20517b0, 0xc00169b5c0, 0x205cfc8, 0xc000432000, 0xc0003b4380, 0xc00025c3c0, 0x2845d00, 0x2051cb8, 0xc00169b540, 0x0, ...) github.com/ledgerwatch/erigon/turbo/stages/stageloop.go:86 +0x18f github.com/ledgerwatch/erigon/eth.Loop(0x20517b0, 0xc00169b5c0, 0x205cfc8, 0xc000432000, 0xc0003b4380, 0xc00025c0f0, 0x2051cb8, 0xc00169b540, 0xc001658000, 0xc0000c82a0) github.com/ledgerwatch/erigon/eth/backend.go:672 +0xd9 created by github.com/ledgerwatch/erigon/eth.(*Ethereum).Start github.com/ledgerwatch/erigon/eth/backend.go:630
```
