### PR TITLE
Sender stage hangs

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -367,7 +367,7 @@ func stageBodies(db ethdb.RwKV, ctx context.Context) error {
 
 func stageSenders(db ethdb.RwKV, ctx context.Context) error {
 	tmpdir := path.Join(datadir, etl.TmpDirName)
-	_, _, _, _, _, sync, _, _, _ := newSync(ctx, db)
+	_, _, chainConfig, _, _, sync, _, _, _ := newSync(ctx, db)
 
 	tx, err := db.BeginRw(ctx)
 	if err != nil {
@@ -390,7 +390,7 @@ func stageSenders(db ethdb.RwKV, ctx context.Context) error {
 	ch := make(chan struct{})
 	defer close(ch)
 
-	cfg := stagedsync.StageSendersCfg(db, params.MainnetChainConfig, tmpdir)
+	cfg := stagedsync.StageSendersCfg(db, chainConfig, tmpdir)
 	if unwind > 0 {
 		u := &stagedsync.UnwindState{Stage: stages.Senders, UnwindPoint: stage3.BlockNumber - unwind}
 		err = stagedsync.UnwindSendersStage(u, stage3, tx, cfg)

--- a/eth/stagedsync/stage_senders.go
+++ b/eth/stagedsync/stage_senders.go
@@ -118,12 +118,14 @@ func SpawnRecoverSendersStage(cfg SendersCfg, s *StageState, u Unwinder, tx ethd
 	out := make(chan *senderRecoveryJob, cfg.batchSize)
 	wg := new(sync.WaitGroup)
 	wg.Add(cfg.numOfGoroutines)
+	ctx, cancelWorkers := context.WithCancel(context.Background())
+	defer cancelWorkers()
 	for i := 0; i < cfg.numOfGoroutines; i++ {
 		go func(threadNo int) {
 			defer func() { debug.LogPanic(nil, true, recover()) }()
 			defer wg.Done()
 			// each goroutine gets it's own crypto context to make sure they are really parallel
-			recoverSenders(logPrefix, secp256k1.ContextForThread(threadNo), cfg.chainConfig, jobs, out, quitCh)
+			recoverSenders(ctx, logPrefix, secp256k1.ContextForThread(threadNo), cfg.chainConfig, jobs, out, quitCh)
 		}(i)
 	}
 
@@ -133,30 +135,50 @@ func SpawnRecoverSendersStage(cfg SendersCfg, s *StageState, u Unwinder, tx ethd
 	go func() {
 		defer func() { debug.LogPanic(nil, true, recover()) }()
 		defer close(errCh)
-		for j := range out {
-			if j.err != nil {
-				errCh <- senderRecoveryError{err: j.err, blockNumber: j.blockNumber, blockHash: j.blockHash}
-				return
-			}
-			if err := common.Stopped(quitCh); err != nil {
-				errCh <- senderRecoveryError{err: j.err}
-				return
-			}
+		defer cancelWorkers()
+		var ok bool
+		var j *senderRecoveryJob
+		for {
 			select {
-			default:
+			case <-quitCh:
+				return
 			case <-logEvery.C:
 				log.Info(fmt.Sprintf("[%s] Recovery", logPrefix), "block_number", s.BlockNumber+uint64(j.index))
-			}
+			case j, ok = <-out:
+				if !ok {
+					return
+				}
+				if j.err != nil {
+					errCh <- senderRecoveryError{err: j.err, blockNumber: j.blockNumber, blockHash: j.blockHash}
+					return
+				}
 
-			k := make([]byte, 4)
-			binary.BigEndian.PutUint32(k, uint32(j.index))
-			index := int(binary.BigEndian.Uint32(k))
-			if err := collectorSenders.Collect(dbutils.BlockBodyKey(s.BlockNumber+uint64(index)+1, canonical[index]), j.senders); err != nil {
-				errCh <- senderRecoveryError{err: j.err}
-				return
+				k := make([]byte, 4)
+				binary.BigEndian.PutUint32(k, uint32(j.index))
+				index := int(binary.BigEndian.Uint32(k))
+				if err := collectorSenders.Collect(dbutils.BlockBodyKey(s.BlockNumber+uint64(index)+1, canonical[index]), j.senders); err != nil {
+					errCh <- senderRecoveryError{err: j.err}
+					return
+				}
 			}
 		}
 	}()
+
+	var minBlockNum uint64 = math.MaxUint64
+	var minBlockHash common.Hash
+	var minBlockErr error
+	handleRecoverErr := func(recErr senderRecoveryError) error {
+		if recErr.blockHash == (common.Hash{}) {
+			return recErr.err
+		}
+
+		if recErr.blockNumber < minBlockNum {
+			minBlockNum = recErr.blockNumber
+			minBlockHash = recErr.blockHash
+			minBlockErr = recErr.err
+		}
+		return nil
+	}
 
 	bodiesC, err := tx.Cursor(dbutils.BlockBodyPrefix)
 	if err != nil {
@@ -164,6 +186,7 @@ func SpawnRecoverSendersStage(cfg SendersCfg, s *StageState, u Unwinder, tx ethd
 	}
 	defer bodiesC.Close()
 
+Loop:
 	for k, _, err := bodiesC.Seek(dbutils.EncodeBlockNumber(s.BlockNumber + 1)); k != nil; k, _, err = bodiesC.Next() {
 		if err != nil {
 			return err
@@ -187,9 +210,11 @@ func SpawnRecoverSendersStage(cfg SendersCfg, s *StageState, u Unwinder, tx ethd
 		select {
 		case recoveryErr := <-errCh:
 			if recoveryErr.err != nil {
-				if recoveryErr.blockHash == (common.Hash{}) {
-					return recoveryErr.err
+				cancelWorkers()
+				if err := handleRecoverErr(recoveryErr); err != nil {
+					return err
 				}
+				break Loop
 			}
 		case jobs <- &senderRecoveryJob{body: body, key: k, blockNumber: blockNumber, blockHash: blockHash, index: int(blockNumber - s.BlockNumber - 1)}:
 		}
@@ -198,18 +223,11 @@ func SpawnRecoverSendersStage(cfg SendersCfg, s *StageState, u Unwinder, tx ethd
 	close(jobs)
 	wg.Wait()
 	close(out)
-	var minBlockNum uint64 = math.MaxUint64
-	var minBlockHash common.Hash
-	var minBlockErr error
 	for recoveryErr := range errCh {
 		if recoveryErr.err != nil {
-			if recoveryErr.blockHash == (common.Hash{}) {
-				return recoveryErr.err
-			}
-			if recoveryErr.blockNumber < minBlockNum {
-				minBlockNum = recoveryErr.blockNumber
-				minBlockHash = recoveryErr.blockHash
-				minBlockErr = recoveryErr.err
+			cancelWorkers()
+			if err := handleRecoverErr(recoveryErr); err != nil {
+				return err
 			}
 		}
 	}
@@ -263,11 +281,24 @@ type senderRecoveryJob struct {
 	err         error
 }
 
-func recoverSenders(logPrefix string, cryptoContext *secp256k1.Context, config *params.ChainConfig, in, out chan *senderRecoveryJob, quit <-chan struct{}) {
-	for job := range in {
-		if job == nil {
+func recoverSenders(ctx context.Context, logPrefix string, cryptoContext *secp256k1.Context, config *params.ChainConfig, in, out chan *senderRecoveryJob, quit <-chan struct{}) {
+	var job *senderRecoveryJob
+	var ok bool
+	for {
+		select {
+		case job, ok = <-in:
+			if !ok {
+				return
+			}
+			if job == nil {
+				return
+			}
+		case <-ctx.Done():
+			return
+		case <-quit:
 			return
 		}
+
 		body := job.body
 		signer := types.MakeSigner(config, job.blockNumber)
 		job.senders = make([]byte, len(body.Transactions)*common.AddressLength)
@@ -282,6 +313,8 @@ func recoverSenders(logPrefix string, cryptoContext *secp256k1.Context, config *
 
 		// prevent sending to close channel
 		if err := common.Stopped(quit); err != nil {
+			job.err = err
+		} else if err = common.Stopped(ctx.Done()); err != nil {
 			job.err = err
 		}
 		out <- job


### PR DESCRIPTION
- 1 place didn't check error - it lead to hang 
```
case recoveryErr := <-errCh:
			if recoveryErr.err != nil {
				if recoveryErr.blockHash == (common.Hash{}) {
					return recoveryErr.err
				} // here is no "else" - and real error comes here, need stop 
			}
		
```
- add context for goroutines shutdown - cancel this context if any error happen
- use 1 select for all channels to avoid deadlock in `recoverSenders` func - for example if producer failed and no `in` messages until context cancelation 
- integration: senders to use right chainconfig


This PR - is a bit quick fix, but stage_senders needs some love and simplification. 
For example next code looks dangerous: 
```
if minBlockErr != nil {
	unwind(minBlockNum-1)
	s.Done()
}
tx.Commit()
```
^ error happened, but we only log it and commit transaction. 
maybe it's correct behavior but need at least some comments why it's good. 
And why only this error is "good enough"  for commit results - why not do same for any error... 