### PR TITLE
Do log tables size, db metrics - avoid concurrency, check stale readers hourly 

### DIFF
--- a/cmd/integration/commands/root.go
+++ b/cmd/integration/commands/root.go
@@ -8,7 +8,6 @@ import (
 	kv2 "github.com/ledgerwatch/erigon/ethdb/kv"
 	"github.com/ledgerwatch/erigon/internal/debug"
 	"github.com/ledgerwatch/erigon/log"
-	"github.com/ledgerwatch/erigon/metrics"
 	"github.com/ledgerwatch/erigon/migrations"
 	"github.com/spf13/cobra"
 )
@@ -56,7 +55,6 @@ func openDB(path string, applyMigrations bool) ethdb.RwKV {
 			db = kv2.NewObjectDatabase(openKV(label, path, false))
 		}
 	}
-	metrics.AddCallback(db.RwKV().CollectMetrics)
 	return db.RwKV()
 }
 
@@ -69,6 +67,5 @@ func openKV(label ethdb.Label, path string, exclusive bool) ethdb.RwKV {
 		opts = opts.DBVerbosity(ethdb.DBVerbosityLvl(databaseVerbosity))
 	}
 	kv := opts.MustOpen()
-	metrics.AddCallback(kv.CollectMetrics)
 	return kv
 }

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -324,11 +324,9 @@ Loop:
 		case <-logEvery.C:
 			logBlock, logTx, logTime = logProgress(logPrefix, logBlock, logTime, blockNum, logTx, lastLogTx, gas, batch)
 			gas = 0
-			if hasTx, ok := tx.(ethdb.HasTx); ok {
-				hasTx.Tx().CollectMetrics()
-			}
+			tx.CollectMetrics()
+			stageExecutionGauge.Update(int64(blockNum))
 		}
-		stageExecutionGauge.Update(int64(blockNum))
 	}
 
 	if err := s.Update(batch, stageProgress); err != nil {

--- a/eth/stagedsync/stage_tevm.go
+++ b/eth/stagedsync/stage_tevm.go
@@ -97,9 +97,7 @@ func transpileBatch(logPrefix string, s *StageState, fromBlock uint64, toBlock u
 		select {
 		case <-logEvery.C:
 			logBlock, logTime = logTEVMProgress(logPrefix, logBlock, logTime, stageProgress)
-			if hasTx, ok := tx.(ethdb.HasTx); ok {
-				hasTx.Tx().CollectMetrics()
-			}
+			tx.CollectMetrics()
 		default:
 		}
 

--- a/eth/stagedsync/state.go
+++ b/eth/stagedsync/state.go
@@ -202,13 +202,14 @@ func (s *State) Run(db ethdb.RwKV, tx ethdb.RwTx) error {
 	} else {
 		log.Info("Timings", timings...)
 	}
-	if err := printBucketsSize(tx); err != nil {
+	if err := printBucketsSize(db, tx); err != nil {
 		return err
 	}
+	tx.CollectMetrics()
 	return nil
 }
 
-func printBucketsSize(tx ethdb.RwTx) error {
+func printBucketsSize(db ethdb.RoKV, tx ethdb.Tx) error {
 	if tx == nil {
 		return nil
 	}
@@ -227,9 +228,6 @@ func printBucketsSize(tx ethdb.RwTx) error {
 			return err1
 		}
 		bucketSizes = append(bucketSizes, bucket, common.StorageSize(sz))
-	}
-	if len(bucketSizes) == 0 {
-		return nil
 	}
 	log.Info("Tables", bucketSizes...)
 	return nil

--- a/eth/stagedsync/state.go
+++ b/eth/stagedsync/state.go
@@ -194,6 +194,13 @@ func (s *State) Run(db ethdb.RwKV, tx ethdb.RwTx) error {
 		timings = append(timings, string(stage.ID), time.Since(t))
 	}
 
+	if err := printLogs(tx, timings); err != nil {
+		return err
+	}
+	return nil
+}
+
+func printLogs(tx ethdb.RwTx, timings []interface{}) error {
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)
 	log.Info("Memory", "alloc", common.StorageSize(m.Alloc), "sys", common.StorageSize(m.Sys))
@@ -202,13 +209,7 @@ func (s *State) Run(db ethdb.RwKV, tx ethdb.RwTx) error {
 	} else {
 		log.Info("Timings", timings...)
 	}
-	if err := printBucketsSize(tx); err != nil {
-		return err
-	}
-	return nil
-}
 
-func printBucketsSize(tx ethdb.RwTx) error {
 	if tx == nil {
 		return nil
 	}

--- a/eth/stagedsync/state.go
+++ b/eth/stagedsync/state.go
@@ -202,14 +202,13 @@ func (s *State) Run(db ethdb.RwKV, tx ethdb.RwTx) error {
 	} else {
 		log.Info("Timings", timings...)
 	}
-	if err := printBucketsSize(db, tx); err != nil {
+	if err := printBucketsSize(tx); err != nil {
 		return err
 	}
-	tx.CollectMetrics()
 	return nil
 }
 
-func printBucketsSize(db ethdb.RoKV, tx ethdb.Tx) error {
+func printBucketsSize(tx ethdb.RwTx) error {
 	if tx == nil {
 		return nil
 	}
@@ -230,6 +229,7 @@ func printBucketsSize(db ethdb.RoKV, tx ethdb.Tx) error {
 		bucketSizes = append(bucketSizes, bucket, common.StorageSize(sz))
 	}
 	log.Info("Tables", bucketSizes...)
+	tx.CollectMetrics()
 	return nil
 }
 

--- a/ethdb/kv/kv_mdbx.go
+++ b/ethdb/kv/kv_mdbx.go
@@ -289,7 +289,7 @@ func (opts MdbxOpts) Open() (ethdb.RwKV, error) {
 		if staleReaders, err := db.env.ReaderCheck(); err != nil {
 			db.log.Error("failed ReaderCheck", "err", err)
 		} else if staleReaders > 0 {
-			db.log.Debug("cleared reader slots from dead processes", "amount", staleReaders)
+			db.log.Info("cleared reader slots from dead processes", "amount", staleReaders)
 		}
 	}
 	return db, nil

--- a/ethdb/kv/kv_remote.go
+++ b/ethdb/kv/kv_remote.go
@@ -243,9 +243,8 @@ func (db *RemoteKV) Update(ctx context.Context, f func(tx ethdb.RwTx) error) (er
 	return fmt.Errorf("remote db provider doesn't support .Update method")
 }
 
-func (tx *remoteTx) Comparator(bucket string) dbutils.CmpFunc { panic("not implemented yet") }
-func (tx *remoteTx) CollectMetrics()                          {}
-func (tx *remoteTx) CHandle() unsafe.Pointer                  { panic("not implemented yet") }
+func (tx *remoteTx) CollectMetrics()         {}
+func (tx *remoteTx) CHandle() unsafe.Pointer { panic("not implemented yet") }
 
 func (tx *remoteTx) IncrementSequence(bucket string, amount uint64) (uint64, error) {
 	panic("not implemented yet")
@@ -282,6 +281,8 @@ func (tx *remoteTx) statelessCursor(bucket string) (ethdb.Cursor, error) {
 	}
 	return c, nil
 }
+
+func (tx *remoteTx) BucketSize(name string) (uint64, error) { panic("not implemented") }
 
 // TODO: this must be optimized - and implemented as single command on server, with server-side buffered streaming
 func (tx *remoteTx) ForEach(bucket string, fromPrefix []byte, walker func(k, v []byte) error) error {

--- a/ethdb/kv/kv_remote.go
+++ b/ethdb/kv/kv_remote.go
@@ -213,8 +213,6 @@ func (db *RemoteKV) Close() {
 	}
 }
 
-func (db *RemoteKV) CollectMetrics() {}
-
 func (db *RemoteKV) BeginRo(ctx context.Context) (ethdb.Tx, error) {
 	streamCtx, streamCancelFn := context.WithCancel(ctx) // We create child context for the stream so we can cancel it to prevent leak
 	stream, err := db.remoteKV.Tx(streamCtx)

--- a/ethdb/kv/kv_snapshot.go
+++ b/ethdb/kv/kv_snapshot.go
@@ -150,10 +150,6 @@ func (s *SnapshotKV) SnapshotKV(bucket string) ethdb.RoKV {
 	return s.snapshots[bucket].snapshot
 }
 
-func (s *SnapshotKV) CollectMetrics() {
-	s.db.CollectMetrics()
-}
-
 func (s *SnapshotKV) BeginRo(ctx context.Context) (ethdb.Tx, error) {
 	dbTx, err := s.db.BeginRo(ctx)
 	if err != nil {
@@ -345,7 +341,9 @@ func (s *snTX) Delete(bucket string, k, v []byte) error {
 }
 
 func (s *snTX) CollectMetrics() {
-	s.dbTX.CollectMetrics()
+	if rw, ok := s.dbTX.(ethdb.RwTx); ok {
+		rw.CollectMetrics()
+	}
 }
 
 func (s *snTX) getSnapshotTX(bucket string) (ethdb.Tx, error) {

--- a/ethdb/kv/kv_snapshot.go
+++ b/ethdb/kv/kv_snapshot.go
@@ -465,12 +465,8 @@ func (s *snTX) Rollback() {
 
 }
 
-func (s *snTX) BucketSize(name string) (uint64, error) {
-	panic("implement me")
-}
-
-func (s *snTX) Comparator(bucket string) dbutils.CmpFunc {
-	return s.dbTX.Comparator(bucket)
+func (s *snTX) BucketSize(bucket string) (uint64, error) {
+	return s.dbTX.BucketSize(bucket)
 }
 
 func (s *snTX) IncrementSequence(bucket string, amount uint64) (uint64, error) {

--- a/ethdb/kv_interface.go
+++ b/ethdb/kv_interface.go
@@ -129,8 +129,6 @@ type RoKV interface {
 	//	Commit and Rollback while it has active child transactions.
 	BeginRo(ctx context.Context) (Tx, error)
 	AllBuckets() dbutils.BucketsCfg
-
-	CollectMetrics()
 }
 
 // RwKV low-level database interface - main target is - to provide common abstraction over top of MDBX and RemoteKV.
@@ -211,7 +209,6 @@ type Tx interface {
 	ForAmount(bucket string, prefix []byte, amount uint32, walker func(k, v []byte) error) error
 
 	CHandle() unsafe.Pointer // Pointer to the underlying C transaction handle (e.g. *C.MDB_txn)
-	CollectMetrics()
 }
 
 type RwTx interface {
@@ -221,6 +218,10 @@ type RwTx interface {
 
 	RwCursor(bucket string) (RwCursor, error)
 	RwCursorDupSort(bucket string) (RwCursorDupSort, error)
+
+	// CollectMetrics - does collect all DB-related and Tx-related metrics
+	// this method exists only in RwTx to avoid concurrency
+	CollectMetrics()
 }
 
 // BucketMigrator used for buckets migration, don't use it in usual app code

--- a/ethdb/kv_interface.go
+++ b/ethdb/kv_interface.go
@@ -37,14 +37,30 @@ var (
 	DbPgopsUnspill = metrics.GetOrRegisterGauge("db/pgops/unspill", metrics.DefaultRegistry) //nolint
 	DbPgopsWops    = metrics.GetOrRegisterGauge("db/pgops/wops", metrics.DefaultRegistry)    //nolint
 
+	DbCommitBigBatchTimer = metrics.NewRegisteredTimer("db/commit/big_batch", nil)
+
 	GcLeafMetric     = metrics.GetOrRegisterGauge("db/gc/leaf", metrics.DefaultRegistry)     //nolint
 	GcOverflowMetric = metrics.GetOrRegisterGauge("db/gc/overflow", metrics.DefaultRegistry) //nolint
 	GcPagesMetric    = metrics.GetOrRegisterGauge("db/gc/pages", metrics.DefaultRegistry)    //nolint
 
-	StateLeafMetric     = metrics.GetOrRegisterGauge("db/state/leaf", metrics.DefaultRegistry)   //nolint
-	StateBranchesMetric = metrics.GetOrRegisterGauge("db/state/branch", metrics.DefaultRegistry) //nolint
-
-	DbCommitBigBatchTimer = metrics.NewRegisteredTimer("db/commit/big_batch", nil)
+	TableScsLeaf      = metrics.GetOrRegisterGauge("table/scs/leaf", metrics.DefaultRegistry)      //nolint
+	TableScsBranch    = metrics.GetOrRegisterGauge("table/scs/branch", metrics.DefaultRegistry)    //nolint
+	TableScsEntries   = metrics.GetOrRegisterGauge("table/scs/entries", metrics.DefaultRegistry)   //nolint
+	TableScsSize      = metrics.GetOrRegisterGauge("table/scs/size", metrics.DefaultRegistry)      //nolint
+	TableStateLeaf    = metrics.GetOrRegisterGauge("table/state/leaf", metrics.DefaultRegistry)    //nolint
+	TableStateBranch  = metrics.GetOrRegisterGauge("table/state/branch", metrics.DefaultRegistry)  //nolint
+	TableStateEntries = metrics.GetOrRegisterGauge("table/state/entries", metrics.DefaultRegistry) //nolint
+	TableStateSize    = metrics.GetOrRegisterGauge("table/state/size", metrics.DefaultRegistry)    //nolint
+	TableLogLeaf      = metrics.GetOrRegisterGauge("table/log/leaf", metrics.DefaultRegistry)      //nolint
+	TableLogBranch    = metrics.GetOrRegisterGauge("table/log/branch", metrics.DefaultRegistry)    //nolint
+	TableLogOverflow  = metrics.GetOrRegisterGauge("table/log/overflow", metrics.DefaultRegistry)  //nolint
+	TableLogEntries   = metrics.GetOrRegisterGauge("table/log/entries", metrics.DefaultRegistry)   //nolint
+	TableLogSize      = metrics.GetOrRegisterGauge("table/log/size", metrics.DefaultRegistry)      //nolint
+	TableTxLeaf       = metrics.GetOrRegisterGauge("table/tx/leaf", metrics.DefaultRegistry)       //nolint
+	TableTxBranch     = metrics.GetOrRegisterGauge("table/tx/branch", metrics.DefaultRegistry)     //nolint
+	TableTxOverflow   = metrics.GetOrRegisterGauge("table/tx/overflow", metrics.DefaultRegistry)   //nolint
+	TableTxEntries    = metrics.GetOrRegisterGauge("table/tx/entries", metrics.DefaultRegistry)    //nolint
+	TableTxSize       = metrics.GetOrRegisterGauge("table/tx/size", metrics.DefaultRegistry)       //nolint
 )
 
 type DBVerbosityLvl int8
@@ -92,7 +108,7 @@ type Closer interface {
 	Close()
 }
 
-// Read-only version of KV.
+// RoKV - Read-only version of KV.
 type RoKV interface {
 	Closer
 
@@ -117,7 +133,7 @@ type RoKV interface {
 	CollectMetrics()
 }
 
-// KV low-level database interface - main target is - to provide common abstraction over top of MDBX and RemoteKV.
+// RwKV low-level database interface - main target is - to provide common abstraction over top of MDBX and RemoteKV.
 //
 // Common pattern for short-living transactions:
 //
@@ -160,6 +176,8 @@ type StatelessReadTx interface {
 	// Sequence changes become visible outside the current write transaction after it is committed, and discarded on abort.
 	// Starts from 0.
 	ReadSequence(bucket string) (uint64, error)
+
+	BucketSize(bucket string) (uint64, error)
 }
 
 type StatelessWriteTx interface {
@@ -191,8 +209,6 @@ type Tx interface {
 	ForEach(bucket string, fromPrefix []byte, walker func(k, v []byte) error) error
 	ForPrefix(bucket string, prefix []byte, walker func(k, v []byte) error) error
 	ForAmount(bucket string, prefix []byte, amount uint32, walker func(k, v []byte) error) error
-
-	Comparator(bucket string) dbutils.CmpFunc
 
 	CHandle() unsafe.Pointer // Pointer to the underlying C transaction handle (e.g. *C.MDB_txn)
 	CollectMetrics()

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
-	github.com/torquem-ch/mdbx-go v0.12.0 // indirect
+	github.com/torquem-ch/mdbx-go v0.13.0
 	github.com/ugorji/go/codec v1.1.13
 	github.com/ugorji/go/codec/codecgen v1.1.13
 	github.com/urfave/cli v1.22.4

--- a/go.sum
+++ b/go.sum
@@ -984,8 +984,8 @@ github.com/tklauser/numcpus v0.2.1 h1:ct88eFm+Q7m2ZfXJdan1xYoXKlmwsfP+k88q05KvlZ
 github.com/tklauser/numcpus v0.2.1/go.mod h1:9aU+wOc6WjUIZEwWMP62PL/41d65P+iks1gBkr4QyP8=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/torquem-ch/mdbx-go v0.12.0 h1:hhD9lJtKJPPKCyDoguxpgEoKgQC+derFUSeDGX0PyHk=
-github.com/torquem-ch/mdbx-go v0.12.0/go.mod h1:T2fsoJDVppxfAPTLd1svUgH1kpPmeXdPESmroSHcL1E=
+github.com/torquem-ch/mdbx-go v0.13.0 h1:+QSPxgDKXgv/5SlSXFgmM5OVL1KOB25y7j2U09wLsXg=
+github.com/torquem-ch/mdbx-go v0.13.0/go.mod h1:T2fsoJDVppxfAPTLd1svUgH1kpPmeXdPESmroSHcL1E=
 github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31/go.mod h1:onvgF043R+lC5RZ8IT9rBXDaEDnpnw/Cl+HFiw+v/7Q=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9Kjc7aWznkXaL4U4TWaDSs8zcsY4Ka08nM=
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=

--- a/turbo/node/node.go
+++ b/turbo/node/node.go
@@ -76,8 +76,6 @@ func New(
 
 	ethereum := RegisterEthService(node, ethConfig)
 
-	metrics.AddCallback(ethereum.ChainKV().CollectMetrics)
-
 	return &ErigonNode{stack: node, backend: ethereum}
 }
 


### PR DESCRIPTION
- Do log tables size
- db metrics - avoid concurrency - by bound it to RwTx
- check stale reads once an hour (inside CollectMetrics method)
- 