### PR TITLE
Propagate new txs to P2P

### DIFF
--- a/cmd/rpcdaemon/commands/corner_cases_support_test.go
+++ b/cmd/rpcdaemon/commands/corner_cases_support_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/rpcdaemontest"
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/rpc"
 	"github.com/stretchr/testify/require"
@@ -13,7 +14,7 @@ import (
 // see https://github.com/ledgerwatch/erigon/issues/1645
 func TestNotFoundMustReturnNil(t *testing.T) {
 	require := require.New(t)
-	db := createTestKV(t)
+	db := rpcdaemontest.CreateTestKV(t)
 	defer db.Close()
 	api := NewEthAPI(NewBaseApi(nil), db, nil, nil, nil, 5000000)
 	ctx := context.Background()

--- a/cmd/rpcdaemon/commands/debug_api_test.go
+++ b/cmd/rpcdaemon/commands/debug_api_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	jsoniter "github.com/json-iterator/go"
+	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/rpcdaemontest"
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/eth/tracers"
 	"github.com/ledgerwatch/erigon/internal/ethapi"
@@ -35,7 +36,7 @@ var debugTraceTransactionNoRefundTests = []struct {
 }
 
 func TestTraceTransaction(t *testing.T) {
-	db := createTestKV(t)
+	db := rpcdaemontest.CreateTestKV(t)
 	api := NewPrivateDebugAPI(NewBaseApi(nil), db, 0)
 	for _, tt := range debugTraceTransactionTests {
 		var buf bytes.Buffer
@@ -64,7 +65,7 @@ func TestTraceTransaction(t *testing.T) {
 }
 
 func TestTraceTransactionNoRefund(t *testing.T) {
-	db := createTestKV(t)
+	db := rpcdaemontest.CreateTestKV(t)
 	api := NewPrivateDebugAPI(NewBaseApi(nil), db, 0)
 	for _, tt := range debugTraceTransactionNoRefundTests {
 		var buf bytes.Buffer

--- a/cmd/rpcdaemon/commands/eth_api_test.go
+++ b/cmd/rpcdaemon/commands/eth_api_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/rpcdaemontest"
 	"github.com/ledgerwatch/erigon/common"
 )
 
 func TestGetTransactionReceipt(t *testing.T) {
-	db := createTestKV(t)
+	db := rpcdaemontest.CreateTestKV(t)
 	api := NewEthAPI(NewBaseApi(nil), db, nil, nil, nil, 5000000)
 	// Call GetTransactionReceipt for transaction which is not in the database
 	if _, err := api.GetTransactionReceipt(context.Background(), common.Hash{}); err != nil {
@@ -17,7 +18,7 @@ func TestGetTransactionReceipt(t *testing.T) {
 }
 
 func TestGetTransactionReceiptUnprotected(t *testing.T) {
-	db := createTestKV(t)
+	db := rpcdaemontest.CreateTestKV(t)
 	api := NewEthAPI(NewBaseApi(nil), db, nil, nil, nil, 5000000)
 	// Call GetTransactionReceipt for un-protected transaction
 	if _, err := api.GetTransactionReceipt(context.Background(), common.HexToHash("0x3f3cb8a0e13ed2481f97f53f7095b9cbc78b6ffb779f2d3e565146371a8830ea")); err != nil {

--- a/cmd/rpcdaemon/commands/eth_call_test.go
+++ b/cmd/rpcdaemon/commands/eth_call_test.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/rpcdaemontest"
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/internal/ethapi"
 	"github.com/ledgerwatch/erigon/rpc"
 )
 
 func TestEstimateGas(t *testing.T) {
-	db := createTestKV(t)
+	db := rpcdaemontest.CreateTestKV(t)
 	api := NewEthAPI(NewBaseApi(nil), db, nil, nil, nil, 5000000)
 	var from = common.HexToAddress("0x71562b71999873db5b286df957af199ec94617f7")
 	var to = common.HexToAddress("0x0d3ab14bbad3d99f4203bd7a11acb94882050e7e")
@@ -24,7 +25,7 @@ func TestEstimateGas(t *testing.T) {
 }
 
 func TestEthCallNonCanonical(t *testing.T) {
-	db := createTestKV(t)
+	db := rpcdaemontest.CreateTestKV(t)
 	api := NewEthAPI(NewBaseApi(nil), db, nil, nil, nil, 5000000)
 	var from = common.HexToAddress("0x71562b71999873db5b286df957af199ec94617f7")
 	var to = common.HexToAddress("0x0d3ab14bbad3d99f4203bd7a11acb94882050e7e")

--- a/cmd/rpcdaemon/commands/eth_ming_test.go
+++ b/cmd/rpcdaemon/commands/eth_ming_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/filters"
+	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/rpcdaemontest"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/gointerfaces/txpool"
 	"github.com/ledgerwatch/erigon/rlp"
@@ -14,7 +15,7 @@ import (
 )
 
 func TestPendingBlock(t *testing.T) {
-	ctx, conn := createTestGrpcConn(t, stages.Mock(t))
+	ctx, conn := rpcdaemontest.CreateTestGrpcConn(t, stages.Mock(t))
 	mining := txpool.NewMiningClient(conn)
 	ff := filters.New(ctx, nil, nil, mining)
 	api := NewEthAPI(NewBaseApi(ff), nil, nil, nil, mining, 5000000)
@@ -23,10 +24,10 @@ func TestPendingBlock(t *testing.T) {
 	require.NoError(t, err)
 	ch := make(chan *types.Block, 1)
 	defer close(ch)
-	id := api.filters.SubscribePendingBlock(ch)
-	defer api.filters.UnsubscribePendingBlock(id)
+	id := ff.SubscribePendingBlock(ch)
+	defer ff.UnsubscribePendingBlock(id)
 
-	api.filters.HandlePendingBlock(&txpool.OnPendingBlockReply{RplBlock: b})
+	ff.HandlePendingBlock(&txpool.OnPendingBlockReply{RplBlock: b})
 	block := api.pendingBlock()
 
 	require.Equal(t, block.Number().Uint64(), expect)
@@ -39,20 +40,19 @@ func TestPendingBlock(t *testing.T) {
 }
 
 func TestPendingLogs(t *testing.T) {
-	ctx, conn := createTestGrpcConn(t, stages.Mock(t))
+	ctx, conn := rpcdaemontest.CreateTestGrpcConn(t, stages.Mock(t))
 	mining := txpool.NewMiningClient(conn)
 	ff := filters.New(ctx, nil, nil, mining)
-	api := NewEthAPI(NewBaseApi(ff), nil, nil, nil, mining, 5000000)
 	expect := []byte{211}
 
 	ch := make(chan types.Logs, 1)
 	defer close(ch)
-	id := api.filters.SubscribePendingLogs(ch)
-	defer api.filters.UnsubscribePendingLogs(id)
+	id := ff.SubscribePendingLogs(ch)
+	defer ff.UnsubscribePendingLogs(id)
 
 	b, err := rlp.EncodeToBytes([]*types.Log{{Data: expect}})
 	require.NoError(t, err)
-	api.filters.HandlePendingLogs(&txpool.OnPendingLogsReply{RplLogs: b})
+	ff.HandlePendingLogs(&txpool.OnPendingLogsReply{RplLogs: b})
 	select {
 	case logs := <-ch:
 		require.Equal(t, expect, logs[0].Data)

--- a/cmd/rpcdaemon/commands/send_transaction_test.go
+++ b/cmd/rpcdaemon/commands/send_transaction_test.go
@@ -1,4 +1,4 @@
-package commands
+package commands_test
 
 import (
 	"bytes"
@@ -7,7 +7,9 @@ import (
 	"testing"
 
 	"github.com/holiman/uint256"
+	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/commands"
 	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/filters"
+	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/rpcdaemontest"
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/common/u256"
 	"github.com/ledgerwatch/erigon/core"
@@ -66,10 +68,10 @@ func TestSendRawTransaction(t *testing.T) {
 	txn, err := types.SignTx(types.NewTransaction(0, common.Address{1}, uint256.NewInt(expectValue), params.TxGas, u256.Num1, nil), *types.LatestSignerForChainID(m.ChainConfig.ChainID), m.Key)
 	require.NoError(err)
 
-	ctx, conn := createTestGrpcConn(t, m)
+	ctx, conn := rpcdaemontest.CreateTestGrpcConn(t, m)
 	txPool := txpool.NewTxpoolClient(conn)
 	ff := filters.New(ctx, nil, txPool, txpool.NewMiningClient(conn))
-	api := NewEthAPI(NewBaseApi(ff), m.DB, nil, txPool, nil, 5000000)
+	api := commands.NewEthAPI(commands.NewBaseApi(ff), m.DB, nil, txPool, nil, 5000000)
 
 	buf := bytes.NewBuffer(nil)
 	err = txn.MarshalBinary(buf)
@@ -77,8 +79,8 @@ func TestSendRawTransaction(t *testing.T) {
 
 	txsCh := make(chan []types.Transaction, 1)
 	defer close(txsCh)
-	id := api.filters.SubscribePendingTxs(txsCh)
-	defer api.filters.UnsubscribePendingTxs(id)
+	id := ff.SubscribePendingTxs(txsCh)
+	defer ff.UnsubscribePendingTxs(id)
 
 	_, err = api.SendRawTransaction(ctx, buf.Bytes())
 	require.NoError(err)
@@ -90,6 +92,12 @@ func TestSendRawTransaction(t *testing.T) {
 	_, err = api.SendRawTransaction(ctx, buf.Bytes())
 	require.NotNil(err)
 	require.Equal("ALREADY_EXISTS: already known", err.Error())
+	m.ReceiveWg.Wait()
+
+	//TODO: make propagation easy to test - now race
+	//time.Sleep(time.Second)
+	//sent := m.SentMessage(0)
+	//require.Equal(eth.ToProto[m.SentryClient.Protocol()][eth.NewPooledTransactionHashesMsg], sent.Id)
 }
 
 func transaction(nonce uint64, gaslimit uint64, key *ecdsa.PrivateKey) types.Transaction {

--- a/cmd/rpcdaemon/commands/trace_adhoc_test.go
+++ b/cmd/rpcdaemon/commands/trace_adhoc_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/cli"
+	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/rpcdaemontest"
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/common/hexutil"
 	"github.com/ledgerwatch/erigon/core/rawdb"
@@ -15,7 +16,7 @@ import (
 )
 
 func TestEmptyQuery(t *testing.T) {
-	db := createTestKV(t)
+	db := rpcdaemontest.CreateTestKV(t)
 	api := NewTraceAPI(NewBaseApi(nil), db, &cli.Flags{})
 	// Call GetTransactionReceipt for transaction which is not in the database
 	var latest = rpc.LatestBlockNumber
@@ -31,7 +32,7 @@ func TestEmptyQuery(t *testing.T) {
 	}
 }
 func TestCoinbaseBalance(t *testing.T) {
-	db := createTestKV(t)
+	db := rpcdaemontest.CreateTestKV(t)
 	api := NewTraceAPI(NewBaseApi(nil), db, &cli.Flags{})
 	// Call GetTransactionReceipt for transaction which is not in the database
 	var latest = rpc.LatestBlockNumber
@@ -57,7 +58,7 @@ func TestCoinbaseBalance(t *testing.T) {
 }
 
 func TestReplayTransaction(t *testing.T) {
-	db := createTestKV(t)
+	db := rpcdaemontest.CreateTestKV(t)
 	api := NewTraceAPI(NewBaseApi(nil), db, &cli.Flags{})
 	var txnHash common.Hash
 	if err := db.View(context.Background(), func(tx ethdb.Tx) error {
@@ -84,7 +85,7 @@ func TestReplayTransaction(t *testing.T) {
 }
 
 func TestReplayBlockTransactions(t *testing.T) {
-	db := createTestKV(t)
+	db := rpcdaemontest.CreateTestKV(t)
 	api := NewTraceAPI(NewBaseApi(nil), db, &cli.Flags{})
 
 	// Call GetTransactionReceipt for transaction which is not in the database

--- a/cmd/rpcdaemon/commands/txpool_api_test.go
+++ b/cmd/rpcdaemon/commands/txpool_api_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/holiman/uint256"
 	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/filters"
+	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/rpcdaemontest"
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/common/u256"
 	"github.com/ledgerwatch/erigon/core"
@@ -59,7 +60,7 @@ func TestTxPoolContent(t *testing.T) {
 		}
 	}
 
-	ctx, conn := createTestGrpcConn(t, m)
+	ctx, conn := rpcdaemontest.CreateTestGrpcConn(t, m)
 	txPool := txpool.NewTxpoolClient(conn)
 	ff := filters.New(ctx, nil, txPool, txpool.NewMiningClient(conn))
 	api := NewTxPoolAPI(NewBaseApi(ff), m.DB, txPool)

--- a/cmd/rpcdaemon/rpcdaemontest/test_util.go
+++ b/cmd/rpcdaemon/rpcdaemontest/test_util.go
@@ -1,4 +1,4 @@
-package commands
+package rpcdaemontest
 
 import (
 	"context"
@@ -25,7 +25,7 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 )
 
-func createTestKV(t *testing.T) ethdb.RwKV {
+func CreateTestKV(t *testing.T) ethdb.RwKV {
 	// Configure and generate a sample block chain
 	var (
 		key, _   = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
@@ -203,7 +203,7 @@ type IsMiningMock struct{}
 
 func (*IsMiningMock) IsMining() bool { return false }
 
-func createTestGrpcConn(t *testing.T, m *stages.MockSentry) (context.Context, *grpc.ClientConn) { //nolint
+func CreateTestGrpcConn(t *testing.T, m *stages.MockSentry) (context.Context, *grpc.ClientConn) { //nolint
 	ctx, cancel := context.WithCancel(context.Background())
 
 	apis := m.Engine.APIs(nil)

--- a/cmd/sentry/download/broadcast.go
+++ b/cmd/sentry/download/broadcast.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/big"
 
+	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/eth/protocols/eth"
 	proto_sentry "github.com/ledgerwatch/erigon/gointerfaces/sentry"
@@ -14,6 +15,12 @@ import (
 )
 
 // Methods of sentry called by Core
+
+const (
+	// This is the target size for the packs of transactions or announcements. A
+	// pack can get larger than this if a single transactions exceeds this size.
+	maxTxPacketSize = 100 * 1024
+)
 
 func (cs *ControlServerImpl) PropagateNewBlockHashes(ctx context.Context, announces []headerdownload.Announce) {
 	cs.lock.RLock()
@@ -111,6 +118,64 @@ func (cs *ControlServerImpl) BroadcastNewBlock(ctx context.Context, block *types
 				log.Error("broadcastNewBlock", "error", err)
 			}
 			continue
+		}
+	}
+}
+
+func (cs *ControlServerImpl) BroadcastNewTxs(ctx context.Context, txs []types.Transaction) {
+	cs.lock.RLock()
+	defer cs.lock.RUnlock()
+
+	for len(txs) > 0 {
+		pendingLen := maxTxPacketSize / common.HashLength
+		pending := make([]common.Hash, 0, pendingLen)
+
+		for i := 0; i < pendingLen && i < len(txs); i++ {
+			pending = append(pending, txs[i].Hash())
+		}
+		txs = txs[len(pending):]
+
+		data, err := rlp.EncodeToBytes(eth.NewPooledTransactionHashesPacket(pending))
+		if err != nil {
+			log.Error("broadcastNewBlock", "error", err)
+		}
+		var req66, req65 *proto_sentry.SendMessageToRandomPeersRequest
+		for _, sentry := range cs.sentries {
+			if !sentry.Ready() {
+				continue
+			}
+
+			switch sentry.Protocol() {
+			case eth.ETH65:
+				if req65 == nil {
+					req65 = &proto_sentry.SendMessageToRandomPeersRequest{
+						MaxPeers: 1024,
+						Data: &proto_sentry.OutboundMessageData{
+							Id:   proto_sentry.MessageId_NEW_POOLED_TRANSACTION_HASHES_65,
+							Data: data,
+						},
+					}
+				}
+
+				if _, err = sentry.SendMessageToRandomPeers(ctx, req65, &grpc.EmptyCallOption{}); err != nil {
+					log.Error("broadcastNewBlock", "error", err)
+				}
+
+			case eth.ETH66:
+				if req66 == nil {
+					req66 = &proto_sentry.SendMessageToRandomPeersRequest{
+						MaxPeers: 1024,
+						Data: &proto_sentry.OutboundMessageData{
+							Id:   proto_sentry.MessageId_NEW_POOLED_TRANSACTION_HASHES_66,
+							Data: data,
+						},
+					}
+				}
+				if _, err = sentry.SendMessageToRandomPeers(ctx, req66, &grpc.EmptyCallOption{}); err != nil {
+					log.Error("broadcastNewBlock", "error", err)
+				}
+				continue
+			}
 		}
 	}
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -411,7 +411,6 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		log.Info("Set torrent params", "snapshotsDir", snapshotsDir)
 	}
 
-	go txpropagate.SendPendingTxsToRpcDaemon(backend.downloadV2Ctx, backend.txPool, backend.events)
 	go txpropagate.BroadcastNewTxsToNetworks(backend.downloadV2Ctx, backend.txPool, backend.downloadServer)
 
 	go func() {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -62,6 +62,7 @@ import (
 	"github.com/ledgerwatch/erigon/turbo/remote"
 	"github.com/ledgerwatch/erigon/turbo/snapshotsync"
 	stages2 "github.com/ledgerwatch/erigon/turbo/stages"
+	"github.com/ledgerwatch/erigon/turbo/stages/txpropagate"
 	"github.com/ledgerwatch/erigon/turbo/txpool"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -410,17 +411,21 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		log.Info("Set torrent params", "snapshotsDir", snapshotsDir)
 	}
 
-	go SendPendingTxsToRpcDaemon(backend.txPool, backend.events)
+	go txpropagate.SendPendingTxsToRpcDaemon(backend.downloadV2Ctx, backend.txPool, backend.events)
+	go txpropagate.BroadcastNewTxsToNetworks(backend.downloadV2Ctx, backend.txPool, backend.downloadServer)
 
 	go func() {
 		defer debug.LogPanic()
 		for {
 			select {
 			case b := <-backend.minedBlocks:
-				// todo: broadcast p2p
+				//p2p
+				//backend.downloadServer.BroadcastNewBlock(context.Background(), b, b.Difficulty())
+				//rpcdaemon
 				if err := miningRPC.BroadcastMinedBlock(b); err != nil {
 					log.Error("txpool rpc mined block broadcast", "err", err)
 				}
+
 			case b := <-backend.pendingBlocks:
 				if err := miningRPC.BroadcastPendingBlock(b); err != nil {
 					log.Error("txpool rpc pending block broadcast", "err", err)
@@ -448,27 +453,6 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	return backend, nil
 }
 
-const txChanSize int = 4096
-
-func SendPendingTxsToRpcDaemon(txPool *core.TxPool, notifier *remotedbserver.Events) {
-	defer debug.LogPanic()
-	if notifier == nil {
-		return
-	}
-
-	txsCh := make(chan core.NewTxsEvent, txChanSize)
-	txsSub := txPool.SubscribeNewTxsEvent(txsCh)
-	defer txsSub.Unsubscribe()
-
-	for {
-		select {
-		case e := <-txsCh:
-			notifier.OnNewPendingTxs(e.Txs)
-		case <-txsSub.Err():
-			return
-		}
-	}
-}
 func (s *Ethereum) APIs() []rpc.API {
 	return []rpc.API{}
 }
@@ -568,7 +552,7 @@ func (s *Ethereum) StartMining(ctx context.Context, kv ethdb.RwKV, mining *stage
 	go func() {
 		defer debug.LogPanic()
 		defer close(s.waitForMiningStop)
-		newTransactions := make(chan core.NewTxsEvent, txChanSize)
+		newTransactions := make(chan core.NewTxsEvent, 128)
 		sub := s.txPool.SubscribeNewTxsEvent(newTransactions)
 		defer sub.Unsubscribe()
 		defer close(newTransactions)

--- a/eth/protocols/eth/handler_test.go
+++ b/eth/protocols/eth/handler_test.go
@@ -136,8 +136,8 @@ func (b *testBackend) GetBlockHashesFromHash(tx ethdb.Tx, hash common.Hash, max 
 }
 
 // Tests that block headers can be retrieved from a remote chain based on user queries.
+func TestGetBlockHeaders64(t *testing.T) { testGetBlockHeaders(t, 64) }
 func TestGetBlockHeaders65(t *testing.T) { testGetBlockHeaders(t, 65) }
-func TestGetBlockHeaders66(t *testing.T) { testGetBlockHeaders(t, 66) }
 
 func testGetBlockHeaders(t *testing.T, protocol uint) {
 	backend := newTestBackend(t, eth.MaxHeadersServe+15)
@@ -310,8 +310,8 @@ func testGetBlockHeaders(t *testing.T, protocol uint) {
 }
 
 // Tests that block contents can be retrieved from a remote chain based on their hashes.
+func TestGetBlockBodies64(t *testing.T) { testGetBlockBodies(t, 64) }
 func TestGetBlockBodies65(t *testing.T) { testGetBlockBodies(t, 65) }
-func TestGetBlockBodies66(t *testing.T) { testGetBlockBodies(t, 66) }
 
 func testGetBlockBodies(t *testing.T, protocol uint) {
 	backend := newTestBackend(t, eth.MaxBodiesServe+15)
@@ -394,6 +394,7 @@ func testGetBlockBodies(t *testing.T, protocol uint) {
 }
 
 // Tests that the transaction receipts can be retrieved based on hashes.
+func TestGetBlockReceipts64(t *testing.T) { testGetBlockReceipts(t, 64) }
 func TestGetBlockReceipts65(t *testing.T) { testGetBlockReceipts(t, 65) }
 func TestGetBlockReceipts66(t *testing.T) { testGetBlockReceipts(t, 66) }
 

--- a/eth/protocols/eth/handler_test.go
+++ b/eth/protocols/eth/handler_test.go
@@ -136,8 +136,8 @@ func (b *testBackend) GetBlockHashesFromHash(tx ethdb.Tx, hash common.Hash, max 
 }
 
 // Tests that block headers can be retrieved from a remote chain based on user queries.
-func TestGetBlockHeaders64(t *testing.T) { testGetBlockHeaders(t, 64) }
 func TestGetBlockHeaders65(t *testing.T) { testGetBlockHeaders(t, 65) }
+func TestGetBlockHeaders66(t *testing.T) { testGetBlockHeaders(t, 66) }
 
 func testGetBlockHeaders(t *testing.T, protocol uint) {
 	backend := newTestBackend(t, eth.MaxHeadersServe+15)
@@ -310,8 +310,8 @@ func testGetBlockHeaders(t *testing.T, protocol uint) {
 }
 
 // Tests that block contents can be retrieved from a remote chain based on their hashes.
-func TestGetBlockBodies64(t *testing.T) { testGetBlockBodies(t, 64) }
 func TestGetBlockBodies65(t *testing.T) { testGetBlockBodies(t, 65) }
+func TestGetBlockBodies66(t *testing.T) { testGetBlockBodies(t, 66) }
 
 func testGetBlockBodies(t *testing.T, protocol uint) {
 	backend := newTestBackend(t, eth.MaxBodiesServe+15)
@@ -394,7 +394,6 @@ func testGetBlockBodies(t *testing.T, protocol uint) {
 }
 
 // Tests that the transaction receipts can be retrieved based on hashes.
-func TestGetBlockReceipts64(t *testing.T) { testGetBlockReceipts(t, 64) }
 func TestGetBlockReceipts65(t *testing.T) { testGetBlockReceipts(t, 65) }
 func TestGetBlockReceipts66(t *testing.T) { testGetBlockReceipts(t, 66) }
 

--- a/eth/stagedsync/stagebuilder.go
+++ b/eth/stagedsync/stagebuilder.go
@@ -14,8 +14,6 @@ import (
 type ChainEventNotifier interface {
 	OnNewHeader(*types.Header)
 	OnNewPendingLogs(types.Logs)
-	OnNewPendingBlock(*types.Block)
-	OnNewPendingTxs([]types.Transaction)
 }
 
 // StageParameters contains the stage that stages receives at runtime when initializes.

--- a/ethdb/remote/remotedbserver/events.go
+++ b/ethdb/remote/remotedbserver/events.go
@@ -49,12 +49,6 @@ func (e *Events) AddPendingBlockSubscription(s PendingBlockSubscription) {
 	e.pendingBlockSubscriptions[len(e.pendingBlockSubscriptions)] = s
 }
 
-func (e *Events) AddPendingTxsSubscription(s PendingTxsSubscription) {
-	e.lock.Lock()
-	defer e.lock.Unlock()
-	e.pendingTxsSubscriptions[len(e.pendingTxsSubscriptions)] = s
-}
-
 func (e *Events) OnNewHeader(newHeader *types.Header) {
 	e.lock.Lock()
 	defer e.lock.Unlock()
@@ -71,26 +65,6 @@ func (e *Events) OnNewPendingLogs(logs types.Logs) {
 	for i, sub := range e.pendingLogsSubscriptions {
 		if err := sub(logs); err != nil {
 			delete(e.pendingLogsSubscriptions, i)
-		}
-	}
-}
-
-func (e *Events) OnNewPendingBlock(block *types.Block) {
-	e.lock.Lock()
-	defer e.lock.Unlock()
-	for i, sub := range e.pendingBlockSubscriptions {
-		if err := sub(block); err != nil {
-			delete(e.pendingBlockSubscriptions, i)
-		}
-	}
-}
-
-func (e *Events) OnNewPendingTxs(txs []types.Transaction) {
-	e.lock.Lock()
-	defer e.lock.Unlock()
-	for i, sub := range e.pendingTxsSubscriptions {
-		if err := sub(txs); err != nil {
-			delete(e.pendingTxsSubscriptions, i)
 		}
 	}
 }

--- a/turbo/stages/mock_sentry.go
+++ b/turbo/stages/mock_sentry.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ledgerwatch/erigon/turbo/remote"
 	"github.com/ledgerwatch/erigon/turbo/stages/bodydownload"
 	"github.com/ledgerwatch/erigon/turbo/stages/headerdownload"
+	"github.com/ledgerwatch/erigon/turbo/stages/txpropagate"
 	"github.com/ledgerwatch/erigon/turbo/txpool"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
@@ -262,6 +263,7 @@ func MockWithEverything(t *testing.T, gspec *core.Genesis, key *ecdsa.PrivateKey
 		stagedsync.StageTxPoolCfg(mock.DB, txPool, func() {
 			mock.StreamWg.Add(1)
 			go txpool.RecvTxMessageLoop(mock.Ctx, mock.SentryClient, mock.downloader, mock.TxPoolP2PServer.HandleInboundMessage, &mock.ReceiveWg)
+			go txpropagate.BroadcastNewTxsToNetworks(mock.Ctx, txPool, mock.downloader)
 			mock.StreamWg.Wait()
 			mock.TxPoolP2PServer.TxFetcher.Start()
 		}),

--- a/turbo/stages/txpropagate/deprecated.go
+++ b/turbo/stages/txpropagate/deprecated.go
@@ -1,0 +1,53 @@
+package txpropagate
+
+import (
+	"context"
+
+	"github.com/ledgerwatch/erigon/cmd/sentry/download"
+	"github.com/ledgerwatch/erigon/common/debug"
+	"github.com/ledgerwatch/erigon/core"
+	"github.com/ledgerwatch/erigon/ethdb/remote/remotedbserver"
+)
+
+const txChanSize int = 4096
+
+func SendPendingTxsToRpcDaemon(ctx context.Context, txPool *core.TxPool, notifier *remotedbserver.Events) {
+	defer debug.LogPanic()
+	if notifier == nil {
+		return
+	}
+
+	txsCh := make(chan core.NewTxsEvent, txChanSize)
+	txsSub := txPool.SubscribeNewTxsEvent(txsCh)
+	defer txsSub.Unsubscribe()
+
+	for {
+		select {
+		case e := <-txsCh:
+			notifier.OnNewPendingTxs(e.Txs)
+		case <-txsSub.Err():
+			return
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func BroadcastNewTxsToNetworks(ctx context.Context, txPool *core.TxPool, s *download.ControlServerImpl) {
+	defer debug.LogPanic()
+
+	txsCh := make(chan core.NewTxsEvent, txChanSize)
+	txsSub := txPool.SubscribeNewTxsEvent(txsCh)
+	defer txsSub.Unsubscribe()
+
+	for {
+		select {
+		case e := <-txsCh:
+			s.BroadcastNewTxs(context.Background(), e.Txs)
+		case <-txsSub.Err():
+			return
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/turbo/stages/txpropagate/deprecated.go
+++ b/turbo/stages/txpropagate/deprecated.go
@@ -6,32 +6,9 @@ import (
 	"github.com/ledgerwatch/erigon/cmd/sentry/download"
 	"github.com/ledgerwatch/erigon/common/debug"
 	"github.com/ledgerwatch/erigon/core"
-	"github.com/ledgerwatch/erigon/ethdb/remote/remotedbserver"
 )
 
 const txChanSize int = 4096
-
-func SendPendingTxsToRpcDaemon(ctx context.Context, txPool *core.TxPool, notifier *remotedbserver.Events) {
-	defer debug.LogPanic()
-	if notifier == nil {
-		return
-	}
-
-	txsCh := make(chan core.NewTxsEvent, txChanSize)
-	txsSub := txPool.SubscribeNewTxsEvent(txsCh)
-	defer txsSub.Unsubscribe()
-
-	for {
-		select {
-		case e := <-txsCh:
-			notifier.OnNewPendingTxs(e.Txs)
-		case <-txsSub.Err():
-			return
-		case <-ctx.Done():
-			return
-		}
-	}
-}
 
 func BroadcastNewTxsToNetworks(ctx context.Context, txPool *core.TxPool, s *download.ControlServerImpl) {
 	defer debug.LogPanic()


### PR DESCRIPTION
- without any optimisation (go-ethereum maintain list of sent hashes, trying to accumulate bigger batches, etc...)
- now it's done as separated goroutine because it's easy, but it's hard to test - will need change it in future 
- Also removed `SendPendingTxsToRpcDaemon` - it's old subscription mechanism of pending txs in rpcdaemon
