### PR TITLE
config: add block downloader window flag

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -372,8 +372,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		backend.sentryServers = append(backend.sentryServers, server65)
 		backend.sentries = append(backend.sentries, remote.NewSentryClientDirect(eth.ETH65, server65))
 	}
-	blockDownloaderWindow := 65536
-	backend.downloadServer, err = download.NewControlServer(chainDb.RwKV(), stack.Config().NodeName(), chainConfig, genesis.Hash(), backend.engine, backend.config.NetworkID, backend.sentries, blockDownloaderWindow)
+	backend.downloadServer, err = download.NewControlServer(chainDb.RwKV(), stack.Config().NodeName(), chainConfig, genesis.Hash(), backend.engine, backend.config.NetworkID, backend.sentries, config.BlockDownloaderWindow)
 	if err != nil {
 		return nil, err
 	}

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -131,6 +131,8 @@ type Config struct {
 	SnapshotSeeding bool
 	SnapshotLayout  bool
 
+	BlockDownloaderWindow int
+
 	// Address to connect to external snapshot downloader
 	// empty if you want to use internal bittorrent snapshot downloader
 	ExternalSnapshotDownloaderAddr string

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -27,6 +27,7 @@ var DefaultFlags = []cli.Flag{
 	SnapshotDatabaseLayoutFlag,
 	ExternalSnapshotDownloaderAddrFlag,
 	BatchSizeFlag,
+	BlockDownloaderWindowFlag,
 	DatabaseVerbosityFlag,
 	PrivateApiAddr,
 	EtlBufferSizeFlag,

--- a/turbo/cli/flags.go
+++ b/turbo/cli/flags.go
@@ -31,6 +31,11 @@ var (
 		Usage: "Buffer size for ETL operations.",
 		Value: etl.BufferOptimalSize.String(),
 	}
+	BlockDownloaderWindowFlag = cli.IntFlag{
+		Name:  "blockDownloaderWindow",
+		Usage: "Outstanding limit of block bodies being downloaded",
+		Value: 65536,
+	}
 
 	PrivateApiAddr = cli.StringFlag{
 		Name:  "private.api.addr",
@@ -144,6 +149,7 @@ func ApplyFlagsForEthConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 
 	cfg.ExternalSnapshotDownloaderAddr = ctx.GlobalString(ExternalSnapshotDownloaderAddrFlag.Name)
 	cfg.StateStream = ctx.GlobalBool(StateStreamFlag.Name)
+	cfg.BlockDownloaderWindow = ctx.GlobalInt(BlockDownloaderWindowFlag.Name)
 }
 func ApplyFlagsForEthConfigCobra(f *pflag.FlagSet, cfg *ethconfig.Config) {
 	if v := f.String(StorageModeFlag.Name, StorageModeFlag.Value, StorageModeFlag.Usage); v != nil {


### PR DESCRIPTION
This PR adds a config option for the `blockDownloaderWindow` that is used to set the number of outstanding block body requests in flight, see the comment here:

https://github.com/ledgerwatch/erigon/blob/3d6d45a82f5fbd8b48faf323dbf1099369f539b0/turbo/stages/bodydownload/body_data_struct.go#L38

Any suggestions for renaming the CLI flag name from `blockDownloaderWindow` to something more canonical? All of the other flags are lowercase with dot separations between namespaces besides `batchSize` which is camel case and doesn't have a namespace.

The previous default value is maintained but now it can be lowered without the need to make a diff to the codebase.

Discord conversation here about a user manually setting the value lower which allowed them to sync:
https://discord.com/channels/687972960811745322/687972960811745326/853756684907970570

Closes https://github.com/ledgerwatch/erigon/issues/2160