### PR TITLE
Docker: explicitly declare base image source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.13 as builder
+FROM docker.io/library/golang:1.16-alpine3.13 as builder
 
 ARG git_commit
 ENV GIT_COMMIT=$git_commit
@@ -23,7 +23,7 @@ RUN go mod download
 ADD . .
 RUN make all
 
-FROM alpine:3.13
+FROM docker.io/library/alpine:3.13
 
 RUN apk add --no-cache ca-certificates libgcc libstdc++ tzdata
 COPY --from=builder /app/build/bin/* /usr/local/bin/


### PR DESCRIPTION
Some container engines such as podman have started to prompt the user to explicitly state (thus sometimes causing service scripts on systemd) to fail for lack of mentioning what container image hub is used. This change declares the hub to be docker.io, thus removing the prompt on systems that use podman.