### PR TITLE
Add parameter for minimum time between sync loop iterations

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -655,7 +655,7 @@ func (s *Ethereum) Start() error {
 		}(i)
 	}
 
-	go Loop(s.downloadCtx, s.chainKV, s.stagedSync, s.downloadServer, s.events, s.config.StateStream, s.waitForStageLoopStop, s.config.ThrottleLoopMinTimeFlag)
+	go Loop(s.downloadCtx, s.chainKV, s.stagedSync, s.downloadServer, s.events, s.config.StateStream, s.waitForStageLoopStop, s.config.SyncLoopThrottle)
 	return nil
 }
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -655,7 +655,7 @@ func (s *Ethereum) Start() error {
 		}(i)
 	}
 
-	go Loop(s.downloadCtx, s.chainKV, s.stagedSync, s.downloadServer, s.events, s.config.StateStream, s.waitForStageLoopStop)
+	go Loop(s.downloadCtx, s.chainKV, s.stagedSync, s.downloadServer, s.events, s.config.StateStream, s.waitForStageLoopStop, s.config.ThrottleLoopMinTimeFlag)
 	return nil
 }
 
@@ -696,7 +696,15 @@ func (s *Ethereum) Stop() error {
 }
 
 //Deprecated - use stages.StageLoop
-func Loop(ctx context.Context, db ethdb.RwKV, sync *stagedsync.StagedSync, controlServer *download.ControlServerImpl, notifier stagedsync.ChainEventNotifier, stateStream bool, waitForDone chan struct{}) {
+func Loop(
+	ctx context.Context,
+	db ethdb.RwKV, sync *stagedsync.StagedSync,
+	controlServer *download.ControlServerImpl,
+	notifier stagedsync.ChainEventNotifier,
+	stateStream bool,
+	waitForDone chan struct{},
+	loopMinTime time.Duration,
+) {
 	defer debug.LogPanic()
 	stages2.StageLoop(
 		ctx,
@@ -708,5 +716,6 @@ func Loop(ctx context.Context, db ethdb.RwKV, sync *stagedsync.StagedSync, contr
 		stateStream,
 		controlServer.UpdateHead,
 		waitForDone,
+		loopMinTime,
 	)
 }

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -186,8 +186,8 @@ type Config struct {
 
 	StateStream bool
 
-	// ThrottleLoopMinTimeFlag sets a minimum time between staged loop iterations
-	ThrottleLoopMinTimeFlag time.Duration
+	// SyncLoopThrottle sets a minimum time between staged loop iterations
+	SyncLoopThrottle time.Duration
 }
 
 func CreateConsensusEngine(chainConfig *params.ChainConfig, config interface{}, notify []string, noverify bool) consensus.Engine {

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -185,6 +185,9 @@ type Config struct {
 	CheckpointOracle *params.CheckpointOracleConfig `toml:",omitempty"`
 
 	StateStream bool
+
+	// ThrottleLoopMinTimeFlag sets a minimum time between staged loop iterations
+	ThrottleLoopMinTimeFlag time.Duration
 }
 
 func CreateConsensusEngine(chainConfig *params.ChainConfig, config interface{}, notify []string, noverify bool) consensus.Engine {

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -35,6 +35,7 @@ var DefaultFlags = []cli.Flag{
 	TLSCertFlag,
 	TLSKeyFlag,
 	TLSCACertFlag,
+	ThrottleLoopMinTimeFlag,
 	utils.ListenPortFlag,
 	utils.ListenPort65Flag,
 	utils.NATFlag,

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -35,7 +35,7 @@ var DefaultFlags = []cli.Flag{
 	TLSCertFlag,
 	TLSKeyFlag,
 	TLSCACertFlag,
-	ThrottleLoopMinTimeFlag,
+	SyncLoopThrottleFlag,
 	utils.ListenPortFlag,
 	utils.ListenPort65Flag,
 	utils.NATFlag,

--- a/turbo/cli/flags.go
+++ b/turbo/cli/flags.go
@@ -117,9 +117,9 @@ var (
 	}
 
 	// Throttling Flags
-	ThrottleLoopMinTimeFlag = cli.StringFlag{
-		Name:  "throttle.loopMinTime",
-		Usage: "Sets the minimum time between stage loop iterations (e.g. 1h30m, default is none)",
+	SyncLoopThrottleFlag = cli.StringFlag{
+		Name:  "sync.loop.throttle",
+		Usage: "Sets the minimum time between sync loop starts (e.g. 1h30m, default is none)",
 		Value: "",
 	}
 )
@@ -159,12 +159,12 @@ func ApplyFlagsForEthConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 	cfg.StateStream = ctx.GlobalBool(StateStreamFlag.Name)
 	cfg.BlockDownloaderWindow = ctx.GlobalInt(BlockDownloaderWindowFlag.Name)
 
-	if ctx.GlobalString(ThrottleLoopMinTimeFlag.Name) != "" {
-		throttleLoopMinTime, err := time.ParseDuration(ctx.GlobalString(ThrottleLoopMinTimeFlag.Name))
+	if ctx.GlobalString(SyncLoopThrottleFlag.Name) != "" {
+		syncLoopThrottle, err := time.ParseDuration(ctx.GlobalString(SyncLoopThrottleFlag.Name))
 		if err != nil {
-			utils.Fatalf("Invalid time duration provided in %s: %v", ThrottleLoopMinTimeFlag.Name, err)
+			utils.Fatalf("Invalid time duration provided in %s: %v", SyncLoopThrottleFlag.Name, err)
 		}
-		cfg.ThrottleLoopMinTimeFlag = throttleLoopMinTime
+		cfg.SyncLoopThrottle = syncLoopThrottle
 	}
 }
 

--- a/turbo/cli/flags.go
+++ b/turbo/cli/flags.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/c2h5oh/datasize"
 	"github.com/ledgerwatch/erigon/cmd/utils"
@@ -114,6 +115,13 @@ var (
 		Name:  "state.stream",
 		Usage: "Enable streaming of state changes from core to RPC daemon",
 	}
+
+	// Throttling Flags
+	ThrottleLoopMinTimeFlag = cli.StringFlag{
+		Name:  "throttle.loopMinTime",
+		Usage: "Sets the minimum time between stage loop iterations (e.g. 1h30m, default is none)",
+		Value: "",
+	}
 )
 
 func ApplyFlagsForEthConfig(ctx *cli.Context, cfg *ethconfig.Config) {
@@ -150,7 +158,16 @@ func ApplyFlagsForEthConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 	cfg.ExternalSnapshotDownloaderAddr = ctx.GlobalString(ExternalSnapshotDownloaderAddrFlag.Name)
 	cfg.StateStream = ctx.GlobalBool(StateStreamFlag.Name)
 	cfg.BlockDownloaderWindow = ctx.GlobalInt(BlockDownloaderWindowFlag.Name)
+
+	if ctx.GlobalString(ThrottleLoopMinTimeFlag.Name) != "" {
+		throttleLoopMinTime, err := time.ParseDuration(ctx.GlobalString(ThrottleLoopMinTimeFlag.Name))
+		if err != nil {
+			utils.Fatalf("Invalid time duration provided in %s: %v", ThrottleLoopMinTimeFlag.Name, err)
+		}
+		cfg.ThrottleLoopMinTimeFlag = throttleLoopMinTime
+	}
 }
+
 func ApplyFlagsForEthConfigCobra(f *pflag.FlagSet, cfg *ethconfig.Config) {
 	if v := f.String(StorageModeFlag.Name, StorageModeFlag.Value, StorageModeFlag.Usage); v != nil {
 		mode, err := ethdb.StorageModeFromString(*v)


### PR DESCRIPTION
This pull requests adds a cli parameter `--sync.loop.throttle`, which allows us to set minimum time between loop iterations. I.e. If you want to have at least 30 minutes between sync loops, you add `--sync.loop.throttle 30m`. This way, Erigon will not start the next cycle if it happens before an interval of 30 minutes from the start of previous one. The parameter is parsed as a duration.

*Rationale*
I order to decrease the SSD wear and server utilisation I have introduced a throttling mechanism to the syncing process. To ensure more consistent update times the delay between loops is the rest of the minimum time between loop cycles. For instance if we set a 30 minutes minimum loop time, and the previous cycle took 12 minutes, Erigon will wait for another 18 minutes before the start of the next cycle. However, if the previous cycle took 40 minutes, the next one will start immediately. Half-an-hour updates are perfectly fine for my use case. Moreover, this feature was also requested by wmitsuda in Discord server.