### PR TITLE
ETL: Enforce "oldest appeared" property at load time

### DIFF
--- a/common/etl/buffers.go
+++ b/common/etl/buffers.go
@@ -274,3 +274,16 @@ func getBufferByType(tp int, size datasize.ByteSize) Buffer {
 		panic("unknown buffer type " + strconv.Itoa(tp))
 	}
 }
+
+func getTypeByBuffer(b Buffer) int {
+	switch b.(type) {
+	case *sortableBuffer:
+		return SortableSliceBuffer
+	case *appendSortableBuffer:
+		return SortableAppendBuffer
+	case *oldestEntrySortableBuffer:
+		return SortableOldestAppearedBuffer
+	default:
+		panic(fmt.Sprintf("unknown buffer type: %T ", b))
+	}
+}

--- a/common/etl/buffers.go
+++ b/common/etl/buffers.go
@@ -2,6 +2,7 @@ package etl
 
 import (
 	"bytes"
+	"fmt"
 	"sort"
 	"strconv"
 

--- a/common/etl/collector.go
+++ b/common/etl/collector.go
@@ -66,7 +66,7 @@ func NewCriticalCollector(tmpdir string, sortableBuffer Buffer) *Collector {
 }
 
 func NewCollector(tmpdir string, sortableBuffer Buffer) *Collector {
-	c := &Collector{autoClean: true, bufType: getTypByBuffer(sortableBuffer)}
+	c := &Collector{autoClean: true, bufType: getTypeByBuffer(sortableBuffer)}
 	encoder := codec.NewEncoder(nil, &cbor)
 
 	c.flushBuffer = func(currentKey []byte, canStoreInRam bool) error {

--- a/common/etl/collector.go
+++ b/common/etl/collector.go
@@ -31,6 +31,7 @@ type Collector struct {
 	dataProviders   []dataProvider
 	allFlushed      bool
 	autoClean       bool
+	bufType         int
 }
 
 // NewCollectorFromFiles creates collector from existing files (left over from previous unsuccessful loading)
@@ -65,7 +66,7 @@ func NewCriticalCollector(tmpdir string, sortableBuffer Buffer) *Collector {
 }
 
 func NewCollector(tmpdir string, sortableBuffer Buffer) *Collector {
-	c := &Collector{autoClean: true}
+	c := &Collector{autoClean: true, bufType: getTypByBuffer(sortableBuffer)}
 	encoder := codec.NewEncoder(nil, &cbor)
 
 	c.flushBuffer = func(currentKey []byte, canStoreInRam bool) error {
@@ -117,7 +118,7 @@ func (c *Collector) Load(logPrefix string, db ethdb.RwTx, toBucket string, loadF
 			return e
 		}
 	}
-	if err := loadFilesIntoBucket(logPrefix, db, toBucket, c.dataProviders, loadFunc, args); err != nil {
+	if err := loadFilesIntoBucket(logPrefix, db, toBucket, c.bufType, c.dataProviders, loadFunc, args); err != nil {
 		return err
 	}
 	return nil
@@ -127,7 +128,7 @@ func (c *Collector) Close(logPrefix string) {
 	disposeProviders(logPrefix, c.dataProviders)
 }
 
-func loadFilesIntoBucket(logPrefix string, db ethdb.RwTx, bucket string, providers []dataProvider, loadFunc LoadFunc, args TransformArgs) error {
+func loadFilesIntoBucket(logPrefix string, db ethdb.RwTx, bucket string, bufType int, providers []dataProvider, loadFunc LoadFunc, args TransformArgs) error {
 	decoder := codec.NewDecoder(nil, &cbor)
 	var m runtime.MemStats
 
@@ -167,12 +168,21 @@ func loadFilesIntoBucket(logPrefix string, db ethdb.RwTx, bucket string, provide
 	defer logEvery.Stop()
 
 	i := 0
+	var prevK, prevV []byte
 	loadNextFunc := func(originalK, k, v []byte) error {
 		if i == 0 {
 			isEndOfBucket := lastKey == nil || bytes.Compare(lastKey, k) == -1
 			canUseAppend = haveSortingGuaranties && isEndOfBucket
 		}
 		i++
+
+		// SortableOldestAppearedBuffer must guarantee that only 1 oldest value of key will appear
+		// but because size of buffer is limited - each flushed file does guarantee "oldest appeared"
+		// property, but files may overlap. skip repeated keys here
+		if bufType == SortableOldestAppearedBuffer && bytes.Equal(prevK, k) {
+			return nil
+		}
+		prevK, prevV = k, v
 
 		select {
 		default:

--- a/common/etl/collector.go
+++ b/common/etl/collector.go
@@ -178,7 +178,7 @@ func loadFilesIntoBucket(logPrefix string, db ethdb.RwTx, bucket string, bufType
 
 		// SortableOldestAppearedBuffer must guarantee that only 1 oldest value of key will appear
 		// but because size of buffer is limited - each flushed file does guarantee "oldest appeared"
-		// property, but files may overlap. skip repeated keys here
+		// property, but files may overlap. files are sorted, just skip repeated keys here
 		if bufType == SortableOldestAppearedBuffer && bytes.Equal(prevK, k) {
 			return nil
 		}

--- a/common/etl/collector.go
+++ b/common/etl/collector.go
@@ -168,7 +168,7 @@ func loadFilesIntoBucket(logPrefix string, db ethdb.RwTx, bucket string, bufType
 	defer logEvery.Stop()
 
 	i := 0
-	var prevK, prevV []byte
+	var prevK []byte
 	loadNextFunc := func(originalK, k, v []byte) error {
 		if i == 0 {
 			isEndOfBucket := lastKey == nil || bytes.Compare(lastKey, k) == -1
@@ -182,7 +182,7 @@ func loadFilesIntoBucket(logPrefix string, db ethdb.RwTx, bucket string, bufType
 		if bufType == SortableOldestAppearedBuffer && bytes.Equal(prevK, k) {
 			return nil
 		}
-		prevK, prevV = k, v
+		prevK = k
 
 		select {
 		default:


### PR DESCRIPTION
I discovered it by reducing Buffer size to 1Mb (and event to 128Kb) just for test