### PR TITLE
Feat: Experimental workaround for dockerized rpcdaemon in Local-Mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ docker:
 	docker build -t turbo-geth:latest --build-arg git_commit='${GIT_COMMIT}' --build-arg git_branch='${GIT_BRANCH}' --build-arg git_tag='${GIT_TAG}' .
 
 docker-compose:
-	docker-compose up
+	UID_GID=$(shell id -u):$(shell id -g) docker-compose up
 
 # debug build allows see C stack traces, run it with GOTRACEBACK=crash. You don't need debug build for C pit for profiling. To profile C code use SETCGOTRCKEBACK=1
 dbg:

--- a/README.md
+++ b/README.md
@@ -306,10 +306,10 @@ If genesis sync passed, then it's fine to run multiple Erigon on same Disk.
 Please read https://github.com/ledgerwatch/erigon/issues/1516#issuecomment-811958891
 In short: network-disks are bad for blocks execution - because blocks execution reading data from db non-parallel non-batched way.
 
-### rpcdaemon "Local-Mode" does not work with Docker Container
+### rpcdaemon "Local-Mode" experimentally working with docker-compose
 
 Running rpcdaemon in "Local-Mode" (including the `--datadir` flag) generally results in better performance for 
-RPC calls, however, this does not work when running erigon and rpcdaemon in separate containers and datadir as volume.
-But it works fine if run erigon and rpcdaemon in same container. 
+RPC calls. By sharing the PID namespace for both containers, it's possible now to run erigon and rpcdaemon in separate containers and datadir as volume.
+You can start up the whole stack with the following command: `make docker-compose`
 For the absolute best performance bare metal is recommended at this time.
 Please, help us configure Docker volume driver to support MMAP files with POSIX file-locks (MDBX).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,10 @@ services:
 
   erigon:
     image: thorax/erigon:latest
+    user: ${UID_GID:-1000:1000}
     build: .
     command: erigon --datadir=/var/lib/erigon --metrics --metrics.addr=0.0.0.0 --metrics.port=6060 --private.api.addr=0.0.0.0:9090 --pprof --pprof.addr=0.0.0.0 --pprof.port=6061
+    pid: host
     volumes:
       - ${XDG_DATA_HOME:-~/.local/share}/erigon:/var/lib/erigon
     ports:
@@ -17,6 +19,7 @@ services:
 
   prometheus:
     image: prom/prometheus:v2.28.1
+    user: ${UID_GID:-1000:1000}
     command: --log.level=warn --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --web.console.libraries=/usr/share/prometheus/console_libraries --web.console.templates=/usr/share/prometheus/consoles
     ports:
       - "9090:9090"
@@ -27,6 +30,7 @@ services:
 
   grafana:
     image: grafana/grafana:8.0.6
+    user: ${UID_GID:-1000:1000}
     ports:
       - "3000:3000"
     volumes:
@@ -38,7 +42,11 @@ services:
 
   rpcdaemon:
     image: thorax/erigon:latest
-    command: rpcdaemon --private.api.addr=erigon:9090 --http.addr=0.0.0.0 --http.vhosts=* --http.corsdomain=* --http.api=eth,debug,net
+    user: ${UID_GID:-1000:1000}
+    command: rpcdaemon --datadir /var/lib/erigon --private.api.addr=erigon:9090 --http.addr=0.0.0.0 --http.vhosts=* --http.corsdomain=* --http.api=eth,debug,net
+    pid: host
+    volumes:
+      - ${XDG_DATA_HOME:-~/.local/share}/erigon:/var/lib/erigon
     ports:
       - "8545:8545"
     restart: unless-stopped


### PR DESCRIPTION
I found out it's possible to set the PID namespace so that both `erigon` and `rpcdaemon` docker containers share the same namespace. This has the nice side-effect that it's possible to use `--datadir` on both containers with a mounted volume because the mdbx lock is not exclusive anymore. This PR is an experimental workaround for running `rpcdaemon` in dockerized Local-Mode.

I've tested it on Ubuntu 18.04.5 LTS with a USB stick mounted as a volume and passed via `XDG_DATA_HOME` 

I've also changed the default user of the containers to either `$UID_GUID` env or `1000:1000` as default if it's not set so that permissions are properly handled for the volume. 

So far it works pretty stable for me :construction_worker: 