### PR TITLE
docker-compose with minimal PID namespace and non-root permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,8 @@ COPY --from=builder /app/build/bin/* /usr/local/bin/
 
 WORKDIR /var/lib/erigon
 
+RUN adduser -H -u 1000 -g 1000 -D erigon
+RUN chown -R erigon:erigon /var/lib/erigon
+USER erigon
+
 EXPOSE 8545 8546 30303 30303/udp 30304 30304/udp 8080 9090 6060

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ GO_DBG_BUILD = go build -trimpath -tags=debug -ldflags "-X github.com/ledgerwatc
 
 GO_MAJOR_VERSION = $(shell go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1)
 GO_MINOR_VERSION = $(shell go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f2)
+ERIGON_HOME = ~/.local/share
 
 all: erigon hack rpctest state pics rpcdaemon integration db-tools sentry
 
@@ -22,8 +23,12 @@ docker:
 	docker build -t turbo-geth:latest --build-arg git_commit='${GIT_COMMIT}' --build-arg git_branch='${GIT_BRANCH}' --build-arg git_tag='${GIT_TAG}' .
 
 docker-compose:
-	# Uses host's PID,UID,GID. It required to open Erigon's DB from another process (RPCDaemon local-mode)
-	UID_GID=$(shell id -u):$(shell id -g) docker-compose up
+	@if test -n "$(XDG_DATA_HOME)"; then \
+		mkdir -p $(XDG_DATA_HOME)/erigon $(XDG_DATA_HOME)/erigon-grafana $(XDG_DATA_HOME)/erigon-prometheus; \
+	else \
+	  mkdir -p $(ERIGON_HOME)/erigon $(ERIGON_HOME)/erigon-grafana $(ERIGON_HOME)/erigon-prometheus; \
+	fi
+	docker-compose up
 
 # debug build allows see C stack traces, run it with GOTRACEBACK=crash. You don't need debug build for C pit for profiling. To profile C code use SETCGOTRCKEBACK=1
 dbg:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ GO_DBG_BUILD = go build -trimpath -tags=debug -ldflags "-X github.com/ledgerwatc
 
 GO_MAJOR_VERSION = $(shell go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1)
 GO_MINOR_VERSION = $(shell go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f2)
-ERIGON_HOME = ~/.local/share
 
 all: erigon hack rpctest state pics rpcdaemon integration db-tools sentry
 
@@ -22,12 +21,12 @@ go-version:
 docker:
 	docker build -t turbo-geth:latest --build-arg git_commit='${GIT_COMMIT}' --build-arg git_branch='${GIT_BRANCH}' --build-arg git_tag='${GIT_TAG}' .
 
+xdg_data_home :=  ~/.local/share
+ifdef XDG_DATA_HOME
+	xdg_data_home = $(XDG_DATA_HOME)
+endif
 docker-compose:
-	@if test -n "$(XDG_DATA_HOME)"; then \
-		mkdir -p $(XDG_DATA_HOME)/erigon $(XDG_DATA_HOME)/erigon-grafana $(XDG_DATA_HOME)/erigon-prometheus; \
-	else \
-		mkdir -p $(ERIGON_HOME)/erigon $(ERIGON_HOME)/erigon-grafana $(ERIGON_HOME)/erigon-prometheus; \
-	fi
+	mkdir -p $(xdg_data_home)/erigon $(xdg_data_home)/erigon-grafana $(xdg_data_home)/erigon-prometheus; \
 	docker-compose up
 
 # debug build allows see C stack traces, run it with GOTRACEBACK=crash. You don't need debug build for C pit for profiling. To profile C code use SETCGOTRCKEBACK=1

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ GO_DBG_BUILD = go build -trimpath -tags=debug -ldflags "-X github.com/ledgerwatc
 GO_MAJOR_VERSION = $(shell go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1)
 GO_MINOR_VERSION = $(shell go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f2)
 ERIGON_HOME = ~/.local/share
+ERIGON_UID_GID = 1000:1000
 
 all: erigon hack rpctest state pics rpcdaemon integration db-tools sentry
 
@@ -25,8 +26,10 @@ docker:
 docker-compose:
 	@if test -n "$(XDG_DATA_HOME)"; then \
 		mkdir -p $(XDG_DATA_HOME)/erigon $(XDG_DATA_HOME)/erigon-grafana $(XDG_DATA_HOME)/erigon-prometheus; \
+		chown -R $(ERIGON_UID_GID) $(XDG_DATA_HOME)/erigon $(XDG_DATA_HOME)/erigon-grafana $(XDG_DATA_HOME)/erigon-prometheus; \
 	else \
-	  mkdir -p $(ERIGON_HOME)/erigon $(ERIGON_HOME)/erigon-grafana $(ERIGON_HOME)/erigon-prometheus; \
+		mkdir -p $(ERIGON_HOME)/erigon $(ERIGON_HOME)/erigon-grafana $(ERIGON_HOME)/erigon-prometheus; \
+		chown -R $(ERIGON_UID_GID) $(ERIGON_HOME)/erigon $(ERIGON_HOME)/erigon-grafana $(ERIGON_HOME)/erigon-prometheus; \
 	fi
 	docker-compose up
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ GO_DBG_BUILD = go build -trimpath -tags=debug -ldflags "-X github.com/ledgerwatc
 GO_MAJOR_VERSION = $(shell go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1)
 GO_MINOR_VERSION = $(shell go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f2)
 ERIGON_HOME = ~/.local/share
-ERIGON_UID_GID = 1000:1000
 
 all: erigon hack rpctest state pics rpcdaemon integration db-tools sentry
 
@@ -26,10 +25,8 @@ docker:
 docker-compose:
 	@if test -n "$(XDG_DATA_HOME)"; then \
 		mkdir -p $(XDG_DATA_HOME)/erigon $(XDG_DATA_HOME)/erigon-grafana $(XDG_DATA_HOME)/erigon-prometheus; \
-		chown -R $(ERIGON_UID_GID) $(XDG_DATA_HOME)/erigon $(XDG_DATA_HOME)/erigon-grafana $(XDG_DATA_HOME)/erigon-prometheus; \
 	else \
 		mkdir -p $(ERIGON_HOME)/erigon $(ERIGON_HOME)/erigon-grafana $(ERIGON_HOME)/erigon-prometheus; \
-		chown -R $(ERIGON_UID_GID) $(ERIGON_HOME)/erigon $(ERIGON_HOME)/erigon-grafana $(ERIGON_HOME)/erigon-prometheus; \
 	fi
 	docker-compose up
 

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ or
 XDG_DATA_HOME=/preferred/data/folder make docker-compose
 ```
 
-Makefile uses host's PID,UID,GID. It required to open Erigon's DB from another process (RPCDaemon local-mode).
+Makefile uses host's UID,GID. The PID namespace is shared between erigon and rpcdaemon which is required to open Erigon's DB from another process (RPCDaemon local-mode).
 See: https://github.com/ledgerwatch/erigon/pull/2392/files
 
 Windows support for docker-compose is not ready yet. Please help us with .ps1 port

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ or
 XDG_DATA_HOME=/preferred/data/folder make docker-compose
 ```
 
-Makefile uses host's UID,GID. The PID namespace is shared between erigon and rpcdaemon which is required to open Erigon's DB from another process (RPCDaemon local-mode).
+Makefile creates the initial directories for erigon, prometheus and grafana. The PID namespace is shared between erigon and rpcdaemon which is required to open Erigon's DB from another process (RPCDaemon local-mode).
 See: https://github.com/ledgerwatch/erigon/pull/2392/files
 
 Windows support for docker-compose is not ready yet. Please help us with .ps1 port

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
     image: thorax/erigon:latest
     build: .
     command: erigon --datadir=/var/lib/erigon --metrics --metrics.addr=0.0.0.0 --metrics.port=6060 --private.api.addr=0.0.0.0:9090 --pprof --pprof.addr=0.0.0.0 --pprof.port=6061
-    user: ${UID_GID:-1000:1000} # Uses host's UID,GID.
     volumes:
       - ${XDG_DATA_HOME:-~/.local/share}/erigon:/var/lib/erigon
     ports:
@@ -18,7 +17,7 @@ services:
 
   prometheus:
     image: prom/prometheus:v2.28.1
-    user: ${UID_GID:-1000:1000} # Uses host's UID,GID.
+    user: 1000:1000 # Uses erigon user from Dockerfile
     command: --log.level=warn --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --web.console.libraries=/usr/share/prometheus/console_libraries --web.console.templates=/usr/share/prometheus/consoles
     ports:
       - "9090:9090"
@@ -29,7 +28,7 @@ services:
 
   grafana:
     image: grafana/grafana:8.0.6
-    user: ${UID_GID:-1000:1000} # Uses host's UID,GID.
+    user: 1000:1000 # Uses erigon user from Dockerfile
     ports:
       - "3000:3000"
     volumes:
@@ -42,7 +41,6 @@ services:
   rpcdaemon:
     image: thorax/erigon:latest
     command: rpcdaemon --datadir /var/lib/erigon --private.api.addr=erigon:9090 --http.addr=0.0.0.0 --http.vhosts=* --http.corsdomain=* --http.api=eth,debug,net
-    user: ${UID_GID:-1000:1000} # Uses host's UID,GID.
     pid: service:erigon # Use erigon's PID namespace. It's required to open Erigon's DB from another process (RPCDaemon local-mode)
     volumes:
       - ${XDG_DATA_HOME:-~/.local/share}/erigon:/var/lib/erigon

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,7 @@ services:
     image: thorax/erigon:latest
     build: .
     command: erigon --datadir=/var/lib/erigon --metrics --metrics.addr=0.0.0.0 --metrics.port=6060 --private.api.addr=0.0.0.0:9090 --pprof --pprof.addr=0.0.0.0 --pprof.port=6061
-    user: ${UID_GID:-1000:1000} # Uses host's PID,UID,GID. It required to open Erigon's DB from another process (RPCDaemon local-mode)
-    pid: host
+    user: ${UID_GID:-1000:1000} # Uses host's UID,GID.
     volumes:
       - ${XDG_DATA_HOME:-~/.local/share}/erigon:/var/lib/erigon
     ports:
@@ -19,7 +18,7 @@ services:
 
   prometheus:
     image: prom/prometheus:v2.28.1
-    user: ${UID_GID:-1000:1000}
+    user: ${UID_GID:-1000:1000} # Uses host's UID,GID.
     command: --log.level=warn --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --web.console.libraries=/usr/share/prometheus/console_libraries --web.console.templates=/usr/share/prometheus/consoles
     ports:
       - "9090:9090"
@@ -30,7 +29,7 @@ services:
 
   grafana:
     image: grafana/grafana:8.0.6
-    user: ${UID_GID:-1000:1000}
+    user: ${UID_GID:-1000:1000} # Uses host's UID,GID.
     ports:
       - "3000:3000"
     volumes:
@@ -43,8 +42,8 @@ services:
   rpcdaemon:
     image: thorax/erigon:latest
     command: rpcdaemon --datadir /var/lib/erigon --private.api.addr=erigon:9090 --http.addr=0.0.0.0 --http.vhosts=* --http.corsdomain=* --http.api=eth,debug,net
-    user: ${UID_GID:-1000:1000} # Uses host's PID,UID,GID. It required to open Erigon's DB from another process (RPCDaemon local-mode)
-    pid: host
+    user: ${UID_GID:-1000:1000} # Uses host's UID,GID.
+    pid: service:erigon # Use erigon's PID namespace. It's required to open Erigon's DB from another process (RPCDaemon local-mode)
     volumes:
       - ${XDG_DATA_HOME:-~/.local/share}/erigon:/var/lib/erigon
     ports:


### PR DESCRIPTION
### What I did

1. I reduced the number of processes visible in both containers to only `erigon` and `rpcdaemon` which is sufficient
2. I created an erigon user in the thorax/erigon image and run all containers with that user for the benefit of consistent data permissions

### How I did it
1. I used the erigon container PID namespace instead of the entire host namespace.
2. After some digging I found out that when the volumes are initially created by docker-compose they will be owned by root which is causing problems in various scenarios. Therefore `make docker-compose` now takes care of creating the initial docker volume sub-directories `erigon`, `erigon-grafana` and `erigon-prometheus`
I've also created a `erigon` user in the Dockerfile and using the same UID:GID combination for the prometheus and grafana containers.

### Results

- volume directories are always  owned by the erigon user defined in Dockerfile
- running dockerized erigon from scratch works with or without `XDG_DATA_HOME` set
- running dockerized erigon with existing data works in most common cases
- tested on linux/mac

I hope this will be useful in 90% of the cases :joy: 


