### PR TITLE
rpcdaemon: add txpool_status()

### DIFF
--- a/cmd/rpcdaemon/commands/txpool_api.go
+++ b/cmd/rpcdaemon/commands/txpool_api.go
@@ -8,8 +8,8 @@ import (
 	proto_txpool "github.com/ledgerwatch/erigon-lib/gointerfaces/txpool"
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon/common"
-	"github.com/ledgerwatch/erigon/core/rawdb"
 	"github.com/ledgerwatch/erigon/common/hexutil"
+	"github.com/ledgerwatch/erigon/core/rawdb"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/rlp"
 )
@@ -101,22 +101,13 @@ func (api *TxPoolAPIImpl) Content(ctx context.Context) (map[string]map[string]ma
 
 // Status returns the number of pending and queued transaction in the pool.
 func (api *TxPoolAPIImpl) Status(ctx context.Context) (map[string]hexutil.Uint, error) {
-	reply, err := api.pool.All(ctx, &proto_txpool.AllRequest{})
+	reply, err := api.pool.Status(ctx, &proto_txpool.StatusRequest{})
 	if err != nil {
 		return nil, err
 	}
-	var pending, queued uint
-	for _, tx := range reply.GetTxs() {
-		switch tx.GetType() {
-		case proto_txpool.AllReply_PENDING:
-			pending++
-		case proto_txpool.AllReply_QUEUED:
-			queued++
-		}
-	}
 	return map[string]hexutil.Uint{
-		"pending": hexutil.Uint(pending),
-		"queued":  hexutil.Uint(queued),
+		"pending": hexutil.Uint(reply.PendingCount),
+		"queued":  hexutil.Uint(reply.QueuedCount),
 	}, nil
 }
 

--- a/cmd/rpcdaemon/commands/txpool_api_test.go
+++ b/cmd/rpcdaemon/commands/txpool_api_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/filters"
 	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/rpcdaemontest"
 	"github.com/ledgerwatch/erigon/common"
+	"github.com/ledgerwatch/erigon/common/hexutil"
 	"github.com/ledgerwatch/erigon/common/u256"
 	"github.com/ledgerwatch/erigon/core"
 	"github.com/ledgerwatch/erigon/core/types"
@@ -79,4 +80,10 @@ func TestTxPoolContent(t *testing.T) {
 	sender := m.Address.String()
 	require.Equal(1, len(content["pending"][sender]))
 	require.Equal(expectValue, content["pending"][sender]["0"].Value.ToInt().Uint64())
+
+	status, err := api.Status(ctx)
+	require.NoError(err)
+	require.Len(status, 2)
+	require.Equal(status["pending"], hexutil.Uint(1))
+	require.Equal(status["queued"], hexutil.Uint(0))
 }

--- a/cmd/sentry/download/broadcast.go
+++ b/cmd/sentry/download/broadcast.go
@@ -176,7 +176,7 @@ func (cs *ControlServerImpl) BroadcastLocalPooledTxs(ctx context.Context, txs []
 					}
 					log.Error("BroadcastLocalPooledTxs", "error", err)
 				}
-				avgPeersPerSent65 += len(peers.Peers)
+				avgPeersPerSent65 += len(peers.GetPeers())
 
 			case eth.ETH66:
 				if req66 == nil {
@@ -192,7 +192,7 @@ func (cs *ControlServerImpl) BroadcastLocalPooledTxs(ctx context.Context, txs []
 					}
 					log.Error("BroadcastLocalPooledTxs", "error", err)
 				}
-				avgPeersPerSent66 += len(peers.Peers)
+				avgPeersPerSent66 += len(peers.GetPeers())
 			}
 		}
 	}

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -510,6 +510,16 @@ func (pool *TxPool) Content() (map[common.Address]types.Transactions, map[common
 	return pending, queued
 }
 
+// CountContent returns the number of pending and queued transactions
+// in the transaction pool.
+func (pool *TxPool) CountContent() (pending uint, queued uint) {
+	pool.mu.Lock()
+	defer pool.mu.Unlock()
+	pending = uint(len(pool.pending))
+	queued = uint(len(pool.queue))
+	return
+}
+
 // Pending retrieves all currently processable transactions, grouped by origin
 // account and sorted by nonce. The returned transaction set is a copy and can be
 // freely modified by calling code.

--- a/ethdb/privateapi/txpool.go
+++ b/ethdb/privateapi/txpool.go
@@ -24,6 +24,7 @@ type txPool interface {
 	Get(hash common.Hash) types.Transaction
 	AddLocals(txs []types.Transaction) []error
 	Content() (map[common.Address]types.Transactions, map[common.Address]types.Transactions)
+	CountContent() (uint, uint)
 	SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) event.Subscription
 }
 
@@ -171,4 +172,12 @@ func (s *TxPoolServer) Transactions(ctx context.Context, in *proto_txpool.Transa
 	}
 
 	return reply, nil
+}
+
+func (s *TxPoolServer) Status(_ context.Context, _ *proto_txpool.StatusRequest) (*proto_txpool.StatusReply, error) {
+	pending, queued := s.txPool.CountContent()
+	return &proto_txpool.StatusReply{
+		PendingCount: uint32(pending),
+		QueuedCount:  uint32(queued),
+	}, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -70,5 +70,6 @@ require (
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
 	gopkg.in/olebedev/go-duktape.v3 v3.0.0-20200619000410-60c24ae608a6
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	pgregory.net/rapid v0.4.6
 )

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/json-iterator/go v1.1.11
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/kevinburke/go-bindata v3.21.0+incompatible
-	github.com/ledgerwatch/erigon-lib v0.0.0-20210730030258-1f46e8166b35
+	github.com/ledgerwatch/erigon-lib v0.0.0-20210805134345-01813294dd83
 	github.com/ledgerwatch/log/v3 v3.2.0
 	github.com/ledgerwatch/secp256k1 v0.0.0-20210626115225-cd5cd00ed72d
 	github.com/logrusorgru/aurora v2.0.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -635,6 +635,8 @@ github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 github.com/ledgerwatch/erigon-lib v0.0.0-20210730030258-1f46e8166b35 h1:rdgmC6OA/iFrSfdu4ZJEpgCAwsWCCtagwVGQKNu6qSY=
 github.com/ledgerwatch/erigon-lib v0.0.0-20210730030258-1f46e8166b35/go.mod h1:WcCPcXxQzQJxEuN8l1+pqGYR59l7FWvmctEV2UOOc28=
+github.com/ledgerwatch/erigon-lib v0.0.0-20210805134345-01813294dd83 h1:33N+HgFhirmJN0vbkH+Vv+tQtp7b0f9Igu+RtJRmrvo=
+github.com/ledgerwatch/erigon-lib v0.0.0-20210805134345-01813294dd83/go.mod h1:AgDRPtcxUnVICv3XtfcHTzgSOYM/swXp5gI+W/xjD68=
 github.com/ledgerwatch/log/v3 v3.1.2/go.mod h1:J58eOHHrIYHxl7LKkRsb/0YibKwtLfauUryl5SLRGm0=
 github.com/ledgerwatch/log/v3 v3.2.0 h1:g0lVx5/hDQs+t+l7xzLTXDDlx+7W2JeTcoWQJQXhXJk=
 github.com/ledgerwatch/log/v3 v3.2.0/go.mod h1:J58eOHHrIYHxl7LKkRsb/0YibKwtLfauUryl5SLRGm0=

--- a/turbo/mock/txpool.go
+++ b/turbo/mock/txpool.go
@@ -98,6 +98,15 @@ func (p *TestTxPool) Content() (map[common.Address]types.Transactions, map[commo
 	return batches, nil
 }
 
+// CountContent returns the number of pending and queued transactions
+// in the transaction pool.
+func (p *TestTxPool) CountContent() (pending uint, queued uint) {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	pending = uint(len(p.pool))
+	return
+}
+
 // SubscribeNewTxsEvent should return an event subscription of NewTxsEvent and
 // send events to the given channel.
 func (p *TestTxPool) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) event.Subscription {


### PR DESCRIPTION
Changes:
- Implements new gRPC `Txpool.Status()` method
- Adds `txpool_status` JSON-RPC method: https://geth.ethereum.org/docs/rpc/ns-txpool#txpool_status
- Fixes panic in `cmd/sentry/download/broadcast.go` seen while testing
- Minor go.mod update