### PR TITLE
Fixes issue #2527 and #2526 and adds testing to rpctest

### DIFF
--- a/cmd/rpctest/rpctest/bench_tracefilter.go
+++ b/cmd/rpctest/rpctest/bench_tracefilter.go
@@ -108,6 +108,38 @@ func BenchTraceFilter(erigonURL, oeURL string, needCompare bool, blockFrom uint6
 					return
 				}
 			}
+			if len(accounts) > 1 {
+				from := accounts[0]
+				to := accounts[1]
+				reqGen.reqID++
+				request := reqGen.traceFilterUnion(prevBn, bn, from, to)
+				errCtx := fmt.Sprintf("traceFilterUnion fromBlock %d, toBlock %d, fromAddress %x, toAddress %x", prevBn, bn, from, to)
+				if err := requestAndCompare(request, "trace_filter", errCtx, reqGen, needCompare, rec, errs); err != nil {
+					fmt.Println(err)
+					return
+				}
+				reqGen.reqID++
+				request = reqGen.traceFilterAfter(prevBn, bn, 1)
+				errCtx = fmt.Sprintf("traceFilterAfter fromBlock %d, toBlock %d, after %x", prevBn, bn, 1)
+				if err := requestAndCompare(request, "trace_filter", errCtx, reqGen, needCompare, rec, errs); err != nil {
+					fmt.Println(err)
+					return
+				}
+				reqGen.reqID++
+				request = reqGen.traceFilterCount(prevBn, bn, 1)
+				errCtx = fmt.Sprintf("traceFilterCount fromBlock %d, toBlock %d, count %x", prevBn, bn, 1)
+				if err := requestAndCompare(request, "trace_filter", errCtx, reqGen, needCompare, rec, errs); err != nil {
+					fmt.Println(err)
+					return
+				}
+				reqGen.reqID++
+				request = reqGen.traceFilterCountAfter(prevBn, bn, 1, 1)
+				errCtx = fmt.Sprintf("traceFilterCountAfter fromBlock %d, toBlock %d, count %x, after %x", prevBn, bn, 1, 1)
+				if err := requestAndCompare(request, "trace_filter", errCtx, reqGen, needCompare, rec, errs); err != nil {
+					fmt.Println(err)
+					return
+				}
+			}
 		}
 		fmt.Printf("Done blocks %d-%d, modified accounts: %d\n", prevBn, bn, len(mag.Result))
 		prevBn = bn

--- a/cmd/rpctest/rpctest/request_generator.go
+++ b/cmd/rpctest/rpctest/request_generator.go
@@ -172,6 +172,34 @@ func (g *RequestGenerator) traceBlock(bn uint64) string {
 	return sb.String()
 }
 
+func (g *RequestGenerator) traceFilterCount(prevBn uint64, bn uint64, count uint64) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, `{ "jsonrpc": "2.0", "method": "trace_filter", "params": [{"fromBlock":"0x%x", "toBlock": "0x%x", "count": %d}]`, prevBn, bn, count)
+	fmt.Fprintf(&sb, `, "id":%d}`, g.reqID)
+	return sb.String()
+}
+
+func (g *RequestGenerator) traceFilterAfter(prevBn uint64, bn uint64, after uint64) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, `{ "jsonrpc": "2.0", "method": "trace_filter", "params": [{"fromBlock":"0x%x", "toBlock": "0x%x", "after": %d}]`, prevBn, bn, after)
+	fmt.Fprintf(&sb, `, "id":%d}`, g.reqID)
+	return sb.String()
+}
+
+func (g *RequestGenerator) traceFilterCountAfter(prevBn uint64, bn uint64, after, count uint64) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, `{ "jsonrpc": "2.0", "method": "trace_filter", "params": [{"fromBlock":"0x%x", "toBlock": "0x%x", "count": %d, "after": %d}]`, prevBn, bn, count, after)
+	fmt.Fprintf(&sb, `, "id":%d}`, g.reqID)
+	return sb.String()
+}
+
+func (g *RequestGenerator) traceFilterUnion(prevBn uint64, bn uint64, from, to common.Address) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, `{ "jsonrpc": "2.0", "method": "trace_filter", "params": [{"fromBlock":"0x%x", "toBlock": "0x%x", "fromAddress": ["0x%x"], "toAddress": ["0x%x"]}]`, prevBn, bn, from, to)
+	fmt.Fprintf(&sb, `, "id":%d}`, g.reqID)
+	return sb.String()
+}
+
 func (g *RequestGenerator) traceFilterFrom(prevBn uint64, bn uint64, account common.Address) string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, `{ "jsonrpc": "2.0", "method": "trace_filter", "params": [{"fromBlock":"0x%x", "toBlock": "0x%x", "fromAddress": ["0x%x"]}]`, prevBn, bn, account)


### PR DESCRIPTION
This fixes the only remaining nine tests cases from TrueBlocks that were failing against Erigon (compared with OpenEthereum). All related to Erigon not support `trace_filter`'s `after` or `count` options.

I also added test cases to the `rpctest` code.