### PR TITLE
Remove config.name (const "erigon") from paths

### DIFF
--- a/cmd/integration/commands/root.go
+++ b/cmd/integration/commands/root.go
@@ -20,10 +20,10 @@ var rootCmd = &cobra.Command{
 			panic(err)
 		}
 		if chaindata == "" {
-			chaindata = path.Join(datadir, "erigon", "chaindata")
+			chaindata = path.Join(datadir, "chaindata")
 		}
 		if snapshotDir == "" {
-			snapshotDir = path.Join(datadir, "erigon", "snapshot")
+			snapshotDir = path.Join(datadir, "snapshot")
 		}
 	},
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {

--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -880,7 +880,7 @@ func byChain() (*core.Genesis, *params.ChainConfig) {
 
 func newSync(ctx context.Context, db kv.RwDB, miningConfig *params.MiningConfig) (prune.Mode, consensus.Engine, *params.ChainConfig, *vm.Config, *core.TxPool, *stagedsync.Sync, *stagedsync.Sync, stagedsync.MiningState) {
 	tmpdir := path.Join(datadir, etl.TmpDirName)
-	snapshotDir = path.Join(datadir, "erigon", "snapshot")
+	snapshotDir = path.Join(datadir, "snapshot")
 	logger := log.New()
 
 	var pm prune.Mode

--- a/cmd/integration/commands/state_stages.go
+++ b/cmd/integration/commands/state_stages.go
@@ -57,7 +57,7 @@ Examples:
 		miningConfig := params.MiningConfig{}
 		utils.SetupMinerCobra(cmd, &miningConfig)
 		logger := log.New()
-		db := openDB(path.Join(cfg.DataDir, "erigon", "chaindata"), logger, true)
+		db := openDB(path.Join(cfg.DataDir, "chaindata"), logger, true)
 		defer db.Close()
 
 		if err := syncBySmallSteps(db, miningConfig, ctx); err != nil {

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -116,11 +116,8 @@ func RootCommand() (*cobra.Command, *Flags) {
 				cfg.Datadir = paths.DefaultDataDir()
 			}
 			if cfg.Chaindata == "" {
-				cfg.Chaindata = path.Join(cfg.Datadir, "erigon", "chaindata")
+				cfg.Chaindata = path.Join(cfg.Datadir, "chaindata")
 			}
-			//if cfg.SnapshotDir == "" {
-			//	cfg.SnapshotDir = path.Join(cfg.Datadir, "erigon", "snapshot")
-			//}
 		}
 		return nil
 	}

--- a/cmd/sentry/commands/sentry.go
+++ b/cmd/sentry/commands/sentry.go
@@ -62,11 +62,8 @@ var rootCmd = &cobra.Command{
 			panic(err)
 		}
 		if chaindata == "" {
-			chaindata = path.Join(datadir, "erigon", "chaindata")
+			chaindata = path.Join(datadir, "chaindata")
 		}
-		//if snapshotDir == "" {
-		//	snapshotDir = path.Join(datadir, "erigon", "snapshot")
-		//}
 	},
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
 		debug.Exit()

--- a/cmd/state/commands/root.go
+++ b/cmd/state/commands/root.go
@@ -57,7 +57,7 @@ var rootCmd = &cobra.Command{
 			genesis = genesisFromFile(genesisPath)
 		}
 		if chaindata == "" {
-			chaindata = path.Join(datadir, "erigon", "chaindata")
+			chaindata = path.Join(datadir, "chaindata")
 		}
 	},
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -551,7 +551,7 @@ func setNodeKey(ctx *cli.Context, cfg *p2p.Config, nodeName, dataDir string) {
 		}
 		cfg.PrivateKey = key
 	default:
-		cfg.PrivateKey = nodeKey(path.Join(dataDir, "erigon", "nodekey"))
+		cfg.PrivateKey = nodeKey(path.Join(dataDir, "nodekey"))
 	}
 }
 
@@ -687,7 +687,7 @@ func NewP2PConfig(nodiscover bool, datadir, netRestrict, natSetting, nodeName st
 	default:
 		return nil, fmt.Errorf("unknown protocol: %v", protocol)
 	}
-	serverKey := nodeKey(path.Join(datadir, "erigon", "nodekey"))
+	serverKey := nodeKey(path.Join(datadir, "nodekey"))
 
 	cfg := &p2p.Config{
 		ListenAddr:   fmt.Sprintf(":%d", port),
@@ -969,7 +969,7 @@ func setEthash(ctx *cli.Context, datadir string, cfg *ethconfig.Config) {
 	if ctx.GlobalIsSet(EthashDatasetDirFlag.Name) {
 		cfg.Ethash.DatasetDir = ctx.GlobalString(EthashDatasetDirFlag.Name)
 	} else {
-		cfg.Ethash.DatasetDir = path.Join(datadir, "erigon", "ethash-dags")
+		cfg.Ethash.DatasetDir = path.Join(datadir, "ethash-dags")
 	}
 	if ctx.GlobalIsSet(EthashCachesInMemoryFlag.Name) {
 		cfg.Ethash.CachesInMem = ctx.GlobalInt(EthashCachesInMemoryFlag.Name)

--- a/node/config.go
+++ b/node/config.go
@@ -271,18 +271,7 @@ func (c *Config) ResolvePath(path string) string {
 	if c.DataDir == "" {
 		return ""
 	}
-	return filepath.Join(c.instanceDir(), path)
-}
-
-func (c *Config) instanceDir() string {
-	if c.DataDir == "" {
-		return ""
-	}
-	if c.name() == "turbo-geth" {
-		// backwards compatibility
-		return filepath.Join(c.DataDir, "tg")
-	}
-	return filepath.Join(c.DataDir, c.name())
+	return filepath.Join(c.DataDir, path)
 }
 
 // NodeKey retrieves the currently configured private key of the node, checking
@@ -311,7 +300,7 @@ func (c *Config) NodeKey() (*ecdsa.PrivateKey, error) {
 	if err != nil {
 		log.Crit(fmt.Sprintf("Failed to generate node key: %v", err))
 	}
-	instanceDir := c.instanceDir()
+	instanceDir := c.DataDir
 	if err := os.MkdirAll(instanceDir, 0700); err != nil {
 		log.Error(fmt.Sprintf("Failed to persist node key: %v", err))
 		return key, nil

--- a/node/config_test.go
+++ b/node/config_test.go
@@ -110,7 +110,7 @@ func TestNodeKeyPersistency(t *testing.T) {
 	// Create a temporary folder and make sure no key is present
 	dir := t.TempDir()
 
-	keyfile := filepath.Join(dir, "unit-test", datadirPrivateKey)
+	keyfile := filepath.Join(dir, datadirPrivateKey)
 
 	// Configure a node with a preset key and ensure it's not persisted
 	key, err := crypto.GenerateKey()
@@ -151,7 +151,7 @@ func TestNodeKeyPersistency(t *testing.T) {
 	// Configure ephemeral node and ensure no key is dumped locally
 	config = &Config{Name: "unit-test", DataDir: ""}
 	config.NodeKey()
-	if _, err := os.Stat(filepath.Join(".", "unit-test", datadirPrivateKey)); err == nil {
+	if _, err := os.Stat(filepath.Join(".", datadirPrivateKey)); err == nil {
 		t.Fatalf("ephemeral node key persisted to disk")
 	}
 }

--- a/node/node.go
+++ b/node/node.go
@@ -508,7 +508,12 @@ func OpenDatabase(config *Config, logger log.Logger, label kv.Label) (kv.RwDB, e
 		return db, nil
 	}
 
+	oldDbPath := filepath.Join(config.DataDir, "erigon", name)
 	dbPath := filepath.Join(config.DataDir, name)
+	if _, err := os.Stat(oldDbPath); err == nil {
+		log.Error("Old data directory found", "path", oldDbPath, "please move to new path", dbPath)
+		return nil, fmt.Errorf("safety error, see log message")
+	}
 
 	var openFunc func(exclusive bool) (kv.RwDB, error)
 	log.Info("Opening Database", "label", name, "path", dbPath)

--- a/node/node.go
+++ b/node/node.go
@@ -273,7 +273,7 @@ func (n *Node) openDataDir() error {
 		return nil // ephemeral
 	}
 
-	instdir := n.config.instanceDir()
+	instdir := n.config.DataDir
 	if err := os.MkdirAll(instdir, 0700); err != nil {
 		return err
 	}
@@ -475,7 +475,7 @@ func (n *Node) DataDir() string {
 
 // InstanceDir retrieves the instance directory used by the protocol stack.
 func (n *Node) InstanceDir() string {
-	return n.config.instanceDir()
+	return n.config.DataDir
 }
 
 // HTTPEndpoint returns the URL of the HTTP server. Note that this URL does not
@@ -507,7 +507,8 @@ func OpenDatabase(config *Config, logger log.Logger, label kv.Label) (kv.RwDB, e
 		db = memdb.New()
 		return db, nil
 	}
-	dbPath := config.ResolvePath(name)
+
+	dbPath := filepath.Join(config.DataDir, name)
 
 	var openFunc func(exclusive bool) (kv.RwDB, error)
 	log.Info("Opening Database", "label", name, "path", dbPath)


### PR DESCRIPTION
**** THIS IS A BREAKING PR **** evaluate carefully !

## Rationale
Data paths are "polluted" by erigon's [internal config.name](https://github.com/ledgerwatch/erigon/blob/devel/turbo/node/node.go#L110-L121) which is set to constant "erigon" string
Hence resulting tree is 
```
C:\USERS\ANDREA\APPDATA\LOCAL\ERIGON
├───erigon
│   └───chaindata
└───nodes
    ├───eth65
    └───eth66
```
which depicts a "redundacy" of "erigon" name in the paths (particularly chaindata)
All ancillary binaries (rpcdaemon, integration etc) hardcode "erigon" when building path to chaindata and is quite unlikely node instance name will ever change.

Also ecosystem apps (Silkworm and Akula) are forced to keep that hardcode path.

This pr removes "the pollution" and will make the tree simpler like this
```
├───chaindata
└───nodes
    ├───eth65
    └───eth66
```

By consequence the application of this PR requires to move already populated DB.
The only point where "Erigon" (constant) will be part of path is when no data dir is specified in command line arguments and persistence container path will be built on behalf of host's env vars

**MARKED AS DRAFT SO DON'T ACCIDENTALLY MERGED**