### PR TITLE
Sentry: clients can't slow down each-other, dedicated stream for sending headers  

### DIFF
--- a/cmd/sentry/download/downloader.go
+++ b/cmd/sentry/download/downloader.go
@@ -58,6 +58,11 @@ func GrpcSentryClient(ctx context.Context, sentryAddr string) (*direct.SentryCli
 	return direct.NewSentryClientRemote(proto_sentry.NewSentryClient(conn)), nil
 }
 
+// 3 streams:
+// RecvMessage - processing incoming headers/bodies
+// RecvUploadHeadersMessage - sending headers - dedicated stream because headers propagation speed important for network health
+// RecvUploadMessage - sending bodies/receipts - may be heavy, it's ok to not process this messages enough fast, it's also ok to drop some of this messages if can't process.
+
 func RecvUploadMessageLoop(ctx context.Context,
 	sentry direct.SentryClient,
 	cs *ControlServerImpl,
@@ -113,13 +118,96 @@ func RecvUploadMessage(ctx context.Context,
 	defer cancel()
 
 	stream, err := sentry.Messages(streamCtx, &proto_sentry.MessagesRequest{Ids: []proto_sentry.MessageId{
-		eth.ToProto[eth.ETH65][eth.GetBlockHeadersMsg],
 		eth.ToProto[eth.ETH65][eth.GetBlockBodiesMsg],
 		eth.ToProto[eth.ETH65][eth.GetReceiptsMsg],
 
-		eth.ToProto[eth.ETH66][eth.GetBlockHeadersMsg],
 		eth.ToProto[eth.ETH66][eth.GetBlockBodiesMsg],
 		eth.ToProto[eth.ETH66][eth.GetReceiptsMsg],
+	}}, grpc.WaitForReady(true))
+	if err != nil {
+		return err
+	}
+	var req *proto_sentry.InboundMessage
+	for req, err = stream.Recv(); ; req, err = stream.Recv() {
+		if err != nil {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			return err
+		}
+		if req == nil {
+			return
+		}
+		if err = handleInboundMessage(ctx, req, sentry); err != nil {
+			log.Error("RecvUploadMessage: Handling incoming message", "error", err)
+		}
+		if wg != nil {
+			wg.Done()
+		}
+
+	}
+}
+
+func RecvUploadHeadersMessageLoop(ctx context.Context,
+	sentry direct.SentryClient,
+	cs *ControlServerImpl,
+	wg *sync.WaitGroup,
+) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		if _, err := sentry.HandShake(ctx, &emptypb.Empty{}, grpc.WaitForReady(true)); err != nil {
+			s, ok := status.FromError(err)
+			doLog := !((ok && s.Code() == codes.Canceled) || errors.Is(err, io.EOF) || errors.Is(err, context.Canceled))
+			if doLog {
+				log.Warn("[RecvUploadMessage] sentry not ready yet", "err", err)
+			}
+			time.Sleep(time.Second)
+			continue
+		}
+		if err := SentrySetStatus(ctx, sentry, cs); err != nil {
+			s, ok := status.FromError(err)
+			doLog := !((ok && s.Code() == codes.Canceled) || errors.Is(err, io.EOF) || errors.Is(err, context.Canceled))
+			if doLog {
+				log.Warn("[RecvUploadMessage] sentry not ready yet", "err", err)
+			}
+			time.Sleep(time.Second)
+			continue
+		}
+		if err := RecvUploadHeadersMessage(ctx, sentry, cs.HandleInboundMessage, wg); err != nil {
+			if isPeerNotFoundErr(err) {
+				continue
+			}
+			s, ok := status.FromError(err)
+			if (ok && s.Code() == codes.Canceled) || errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) {
+				time.Sleep(time.Second)
+				continue
+			}
+			log.Warn("[RecvUploadMessage]", "err", err)
+			continue
+		}
+	}
+}
+
+func RecvUploadHeadersMessage(ctx context.Context,
+	sentry direct.SentryClient,
+	handleInboundMessage func(ctx context.Context, inreq *proto_sentry.InboundMessage, sentry direct.SentryClient) error,
+	wg *sync.WaitGroup,
+) (err error) {
+	defer func() { err = debug2.ReportPanicAndRecover(err) }() // avoid crash because Erigon's core does many things
+	streamCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	stream, err := sentry.Messages(streamCtx, &proto_sentry.MessagesRequest{Ids: []proto_sentry.MessageId{
+		eth.ToProto[eth.ETH65][eth.GetBlockHeadersMsg],
+
+		eth.ToProto[eth.ETH66][eth.GetBlockHeadersMsg],
 	}}, grpc.WaitForReady(true))
 	if err != nil {
 		return err

--- a/cmd/sentry/download/sentry.go
+++ b/cmd/sentry/download/sentry.go
@@ -912,6 +912,7 @@ func (ss *SentryServerImpl) send(msgID proto_sentry.MessageId, peerID string, b 
 	}
 	for i := range ss.messageStreams[msgID] {
 		ss.messageStreams[msgID][i] <- req
+		log.Info("le", "len", len(ss.messageStreams[msgID][i]))
 	}
 }
 
@@ -937,11 +938,11 @@ func (ss *SentryServerImpl) addMessagesStream(ids []proto_sentry.MessageId, ch c
 			ss.messageStreams[id] = m
 		}
 		m[ss.messagesSubscriberID] = ch
-		log.Info(fmt.Sprintf("[Messages] len of list: %d", len(m)))
 	}
 
 	sID := ss.messagesSubscriberID
 	return func() {
+		log.Info(fmt.Sprintf("[Messages] delete start"))
 		ss.messageStreamsLock.Lock()
 		defer ss.messageStreamsLock.Unlock()
 		for _, id := range ids {

--- a/cmd/sentry/download/sentry.go
+++ b/cmd/sentry/download/sentry.go
@@ -914,14 +914,15 @@ func (ss *SentryServerImpl) send(msgID proto_sentry.MessageId, peerID string, b 
 		ch := ss.messageStreams[msgID][i]
 		ch <- req
 		if len(ch) > 512 {
-		LRUEvictLoop:
+		EvictOldLoop:
 			for j := 0; j < 256; j++ {
 				select {
 				case <-ch:
 				default:
-					break LRUEvictLoop
+					break EvictOldLoop
 				}
 			}
+			log.Warn("[sentry] consuming is slow", "msgID", msgID.String())
 		}
 	}
 }

--- a/cmd/sentry/download/sentry.go
+++ b/cmd/sentry/download/sentry.go
@@ -912,9 +912,6 @@ func (ss *SentryServerImpl) send(msgID proto_sentry.MessageId, peerID string, b 
 	for i := range ss.messageStreams[msgID] {
 		ch := ss.messageStreams[msgID][i]
 		ch <- req
-		if len(ch) > 10 {
-			fmt.Printf("ch: %d,%s\n", len(ch), msgID)
-		}
 		if len(ch) > MessagesQueueSize/2 {
 			log.Warn("[sentry] consuming is slow", "msgID", msgID.String())
 			// evict old messages from channel

--- a/cmd/sentry/download/sentry.go
+++ b/cmd/sentry/download/sentry.go
@@ -914,6 +914,7 @@ func (ss *SentryServerImpl) send(msgID proto_sentry.MessageId, peerID string, b 
 		ch := ss.messageStreams[msgID][i]
 		ch <- req
 		if len(ch) > 512 {
+			log.Warn("[sentry] consuming is slow", "msgID", msgID.String())
 		EvictOldLoop:
 			for j := 0; j < 256; j++ {
 				select {
@@ -922,7 +923,6 @@ func (ss *SentryServerImpl) send(msgID proto_sentry.MessageId, peerID string, b 
 					break EvictOldLoop
 				}
 			}
-			log.Warn("[sentry] consuming is slow", "msgID", msgID.String())
 		}
 	}
 }

--- a/cmd/sentry/download/sentry.go
+++ b/cmd/sentry/download/sentry.go
@@ -912,6 +912,9 @@ func (ss *SentryServerImpl) send(msgID proto_sentry.MessageId, peerID string, b 
 	for i := range ss.messageStreams[msgID] {
 		ch := ss.messageStreams[msgID][i]
 		ch <- req
+		if len(ch) > 10 {
+			fmt.Printf("ch: %d,%s\n", len(ch), msgID)
+		}
 		if len(ch) > MessagesQueueSize/2 {
 			log.Warn("[sentry] consuming is slow", "msgID", msgID.String())
 			// evict old messages from channel

--- a/cmd/sentry/download/sentry.go
+++ b/cmd/sentry/download/sentry.go
@@ -914,12 +914,11 @@ func (ss *SentryServerImpl) send(msgID proto_sentry.MessageId, peerID string, b 
 		ch <- req
 		if len(ch) > 512 {
 			log.Warn("[sentry] consuming is slow", "msgID", msgID.String())
-		EvictOldLoop:
+			// evict old messages from channel
 			for j := 0; j < 256; j++ {
 				select {
 				case <-ch:
 				default:
-					break EvictOldLoop
 				}
 			}
 		}

--- a/cmd/sentry/download/sentry.go
+++ b/cmd/sentry/download/sentry.go
@@ -937,6 +937,7 @@ func (ss *SentryServerImpl) addMessagesStream(ids []proto_sentry.MessageId, ch c
 			ss.messageStreams[id] = m
 		}
 		m[ss.messagesSubscriberID] = ch
+		log.Info(fmt.Sprintf("[Messages] len of list: %d", len(m)))
 	}
 
 	sID := ss.messagesSubscriberID
@@ -946,6 +947,7 @@ func (ss *SentryServerImpl) addMessagesStream(ids []proto_sentry.MessageId, ch c
 		for _, id := range ids {
 			delete(ss.messageStreams[id], sID)
 		}
+		log.Info(fmt.Sprintf("[Messages] deleted"))
 	}
 }
 
@@ -963,6 +965,7 @@ func (ss *SentryServerImpl) Messages(req *proto_sentry.MessagesRequest, server p
 		case <-server.Context().Done():
 			return nil
 		case in := <-ch:
+
 			log.Info(fmt.Sprintf("[Messages] in: %d,%s", len(ch), req.Ids))
 			if err := server.Send(in); err != nil {
 				log.Warn("Sending msg to core P2P failed", "msg", in.Id.String(), "error", err)

--- a/cmd/sentry/download/sentry.go
+++ b/cmd/sentry/download/sentry.go
@@ -21,7 +21,6 @@ import (
 	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
 	"github.com/ledgerwatch/log/v3"
 	"google.golang.org/protobuf/types/known/emptypb"
-
 	//grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/holiman/uint256"
 	"github.com/ledgerwatch/erigon-lib/gointerfaces"

--- a/cmd/sentry/download/sentry.go
+++ b/cmd/sentry/download/sentry.go
@@ -951,7 +951,7 @@ func (ss *SentryServerImpl) addMessagesStream(ids []proto_sentry.MessageId, ch c
 
 func (ss *SentryServerImpl) Messages(req *proto_sentry.MessagesRequest, server proto_sentry.Sentry_MessagesServer) error {
 	log.Debug(fmt.Sprintf("[Messages] new subscriber to: %s", req.Ids))
-	ch := make(chan *proto_sentry.InboundMessage, 1)
+	ch := make(chan *proto_sentry.InboundMessage, 1024)
 	defer close(ch)
 	clean := ss.addMessagesStream(req.Ids, ch)
 	defer clean()
@@ -963,6 +963,7 @@ func (ss *SentryServerImpl) Messages(req *proto_sentry.MessagesRequest, server p
 		case <-server.Context().Done():
 			return nil
 		case in := <-ch:
+			log.Info(fmt.Sprintf("[Messages] in: %d,%s", len(ch), req.Ids))
 			if err := server.Send(in); err != nil {
 				log.Warn("Sending msg to core P2P failed", "msg", in.Id.String(), "error", err)
 				return err

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -679,6 +679,9 @@ func (s *Ethereum) Start() error {
 		go func(i int) {
 			download.RecvUploadMessageLoop(s.downloadCtx, s.sentries[i], s.downloadServer, nil)
 		}(i)
+		go func(i int) {
+			download.RecvUploadHeadersMessageLoop(s.downloadCtx, s.sentries[i], s.downloadServer, nil)
+		}(i)
 	}
 
 	go stages2.StageLoop(s.downloadCtx, s.chainKV, s.stagedSync, s.downloadServer.Hd, s.notifications, s.downloadServer.UpdateHead, s.waitForStageLoopStop, s.config.SyncLoopThrottle)

--- a/turbo/stages/mock_sentry.go
+++ b/turbo/stages/mock_sentry.go
@@ -337,6 +337,7 @@ func MockWithEverything(t *testing.T, gspec *core.Genesis, key *ecdsa.PrivateKey
 	mock.StreamWg.Wait()
 	mock.StreamWg.Add(1)
 	go download.RecvUploadMessageLoop(mock.Ctx, mock.SentryClient, mock.downloader, &mock.ReceiveWg)
+	go download.RecvUploadHeadersMessageLoop(mock.Ctx, mock.SentryClient, mock.downloader, &mock.ReceiveWg)
 	mock.StreamWg.Wait()
 	if t != nil {
 		t.Cleanup(func() {

--- a/turbo/stages/mock_sentry.go
+++ b/turbo/stages/mock_sentry.go
@@ -334,9 +334,9 @@ func MockWithEverything(t *testing.T, gspec *core.Genesis, key *ecdsa.PrivateKey
 
 	mock.StreamWg.Add(1)
 	go download.RecvMessageLoop(mock.Ctx, mock.SentryClient, mock.downloader, &mock.ReceiveWg)
-	mock.StreamWg.Wait()
 	mock.StreamWg.Add(1)
 	go download.RecvUploadMessageLoop(mock.Ctx, mock.SentryClient, mock.downloader, &mock.ReceiveWg)
+	mock.StreamWg.Add(1)
 	go download.RecvUploadHeadersMessageLoop(mock.Ctx, mock.SentryClient, mock.downloader, &mock.ReceiveWg)
 	mock.StreamWg.Wait()
 	if t != nil {

--- a/turbo/stages/mock_sentry.go
+++ b/turbo/stages/mock_sentry.go
@@ -334,8 +334,10 @@ func MockWithEverything(t *testing.T, gspec *core.Genesis, key *ecdsa.PrivateKey
 
 	mock.StreamWg.Add(1)
 	go download.RecvMessageLoop(mock.Ctx, mock.SentryClient, mock.downloader, &mock.ReceiveWg)
+	mock.StreamWg.Wait()
 	mock.StreamWg.Add(1)
 	go download.RecvUploadMessageLoop(mock.Ctx, mock.SentryClient, mock.downloader, &mock.ReceiveWg)
+	mock.StreamWg.Wait()
 	mock.StreamWg.Add(1)
 	go download.RecvUploadHeadersMessageLoop(mock.Ctx, mock.SentryClient, mock.downloader, &mock.ReceiveWg)
 	mock.StreamWg.Wait()


### PR DESCRIPTION
- clients can't slow down each-other, sentry to work well even if client very slow
- moved sending headers to dedicated stream, because: 1. headers propagation speed important for network health 2. sending bodies and receipts may be slow and it's ok to drop some of this P2P requests if we can't process them, and better don't block headers propagation by this messages