### PR TITLE
RPC: small optimizations

### DIFF
--- a/cmd/rpcdaemon/commands/call_traces_test.go
+++ b/cmd/rpcdaemon/commands/call_traces_test.go
@@ -51,8 +51,8 @@ func TestCallTraceOneByOne(t *testing.T) {
 			t.Fatalf("inserting chain: %v", err)
 		}
 	}
-	var buf bytes.Buffer
-	stream := jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096)
+	stream := jsoniter.ConfigDefault.BorrowStream(nil)
+	defer jsoniter.ConfigDefault.ReturnStream(stream)
 	var fromBlock, toBlock uint64
 	fromBlock = 1
 	toBlock = 10
@@ -65,7 +65,7 @@ func TestCallTraceOneByOne(t *testing.T) {
 	if err = api.Filter(context.Background(), traceReq1, stream); err != nil {
 		t.Fatalf("trace_filter failed: %v", err)
 	}
-	assert.Equal(t, []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, blockNumbersFromTraces(t, buf.Bytes()))
+	assert.Equal(t, []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, blockNumbersFromTraces(t, stream.Buffer()))
 }
 
 func TestCallTraceUnwind(t *testing.T) {

--- a/common/hexutil/json.go
+++ b/common/hexutil/json.go
@@ -36,10 +36,12 @@ var (
 // The empty slice marshals as "0x".
 type Bytes []byte
 
+const hexPrefix = `0x`
+
 // MarshalText implements encoding.TextMarshaler
 func (b Bytes) MarshalText() ([]byte, error) {
 	result := make([]byte, len(b)*2+2)
-	copy(result, `0x`)
+	copy(result, hexPrefix)
 	hex.Encode(result[2:], b)
 	return result, nil
 }

--- a/core/state/history.go
+++ b/core/state/history.go
@@ -16,8 +16,8 @@ import (
 	"github.com/ledgerwatch/erigon/ethdb/bitmapdb"
 )
 
-func GetAsOf(tx kv.Tx, storage bool, key []byte, timestamp uint64) ([]byte, error) {
-	v, err := FindByHistory(tx, storage, key, timestamp)
+func GetAsOf(tx kv.Tx, indexC kv.Cursor, changesC kv.CursorDupSort, storage bool, key []byte, timestamp uint64) ([]byte, error) {
+	v, err := FindByHistory(tx, indexC, changesC, storage, key, timestamp)
 	if err == nil {
 		return v, nil
 	}
@@ -27,7 +27,7 @@ func GetAsOf(tx kv.Tx, storage bool, key []byte, timestamp uint64) ([]byte, erro
 	return tx.GetOne(kv.PlainState, key)
 }
 
-func FindByHistory(tx kv.Tx, storage bool, key []byte, timestamp uint64) ([]byte, error) {
+func FindByHistory(tx kv.Tx, indexC kv.Cursor, changesC kv.CursorDupSort, storage bool, key []byte, timestamp uint64) ([]byte, error) {
 	var csBucket string
 	if storage {
 		csBucket = kv.StorageChangeSet
@@ -35,12 +35,7 @@ func FindByHistory(tx kv.Tx, storage bool, key []byte, timestamp uint64) ([]byte
 		csBucket = kv.AccountChangeSet
 	}
 
-	ch, err := tx.Cursor(changeset.Mapper[csBucket].IndexBucket)
-	if err != nil {
-		return nil, err
-	}
-	defer ch.Close()
-	k, v, seekErr := ch.Seek(changeset.Mapper[csBucket].IndexChunkKey(key, timestamp))
+	k, v, seekErr := indexC.Seek(changeset.Mapper[csBucket].IndexChunkKey(key, timestamp))
 	if seekErr != nil {
 		return nil, seekErr
 	}
@@ -66,16 +61,12 @@ func FindByHistory(tx kv.Tx, storage bool, key []byte, timestamp uint64) ([]byte
 	changeSetBlock := found
 
 	var data []byte
+	var err error
 	if ok {
-		c, err := tx.CursorDupSort(csBucket)
-		if err != nil {
-			return nil, err
-		}
-		defer c.Close()
 		if storage {
-			data, err = changeset.Mapper[csBucket].Find(c, changeSetBlock, key)
+			data, err = changeset.Mapper[csBucket].Find(changesC, changeSetBlock, key)
 		} else {
-			data, err = changeset.Mapper[csBucket].Find(c, changeSetBlock, key)
+			data, err = changeset.Mapper[csBucket].Find(changesC, changeSetBlock, key)
 		}
 		if err != nil {
 			if !errors.Is(err, changeset.ErrNotFound) {
@@ -101,7 +92,7 @@ func FindByHistory(tx kv.Tx, storage bool, key []byte, timestamp uint64) ([]byte
 				return nil, err
 			}
 			if len(codeHash) > 0 {
-				acc.CodeHash = common.BytesToHash(codeHash)
+				acc.CodeHash.SetBytes(codeHash)
 			}
 			data = make([]byte, acc.EncodingLengthForStorage())
 			acc.EncodeForStorage(data)

--- a/core/state/history_test.go
+++ b/core/state/history_test.go
@@ -132,7 +132,9 @@ func TestMutationCommit(t *testing.T) {
 		}
 
 		for k, v := range accHistoryStateStorage[i] {
-			res, err := GetAsOf(tx, true /* storage */, dbutils.PlainGenerateCompositeStorageKey(addr.Bytes(), acc.Incarnation, k.Bytes()), 1)
+			c1, _ := tx.Cursor(kv.StorageHistory)
+			c2, _ := tx.CursorDupSort(kv.StorageChangeSet)
+			res, err := GetAsOf(tx, c1, c2, true /* storage */, dbutils.PlainGenerateCompositeStorageKey(addr.Bytes(), acc.Incarnation, k.Bytes()), 1)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -701,6 +701,7 @@ func opCall(pc *uint64, interpreter *EVMInterpreter, callContext *callCtx) ([]by
 	}
 	stack.Push(&temp)
 	if err == nil || err == ErrExecutionReverted {
+		ret = common.CopyBytes(ret)
 		callContext.memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
 	}
 
@@ -734,6 +735,7 @@ func opCallCode(pc *uint64, interpreter *EVMInterpreter, callContext *callCtx) (
 	}
 	stack.Push(&temp)
 	if err == nil || err == ErrExecutionReverted {
+		ret = common.CopyBytes(ret)
 		callContext.memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
 	}
 
@@ -762,6 +764,7 @@ func opDelegateCall(pc *uint64, interpreter *EVMInterpreter, callContext *callCt
 	}
 	stack.Push(&temp)
 	if err == nil || err == ErrExecutionReverted {
+		ret = common.CopyBytes(ret)
 		callContext.memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
 	}
 
@@ -790,6 +793,7 @@ func opStaticCall(pc *uint64, interpreter *EVMInterpreter, callContext *callCtx)
 	}
 	stack.Push(&temp)
 	if err == nil || err == ErrExecutionReverted {
+		ret = common.CopyBytes(ret)
 		callContext.memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
 	}
 

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -319,7 +319,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		// if the operation clears the return data (e.g. it has returning data)
 		// set the last return to the result of the operation.
 		if operation.returns {
-			in.returnData = common.CopyBytes(res)
+			in.returnData = res
 		}
 
 		switch {

--- a/ethdb/bitmapdb/dbutils.go
+++ b/ethdb/bitmapdb/dbutils.go
@@ -306,11 +306,9 @@ func Get64(db kv.Tx, bucket string, key []byte, from, to uint64) (*roaring64.Bit
 
 // SeekInBitmap - returns value in bitmap which is >= n
 func SeekInBitmap64(m *roaring64.Bitmap, n uint64) (found uint64, ok bool) {
-	i := m.Iterator()
-	i.AdvanceIfNeeded(n)
-	ok = i.HasNext()
-	if ok {
-		found = i.Next()
+	m.RemoveRange(0, n)
+	if m.IsEmpty() {
+		return 0, false
 	}
-	return found, ok
+	return m.Minimum(), true
 }

--- a/turbo/adapter/reader.go
+++ b/turbo/adapter/reader.go
@@ -12,19 +12,26 @@ import (
 )
 
 type StateReader struct {
-	blockNr uint64
-	tx      kv.Tx
+	accHistoryC, storageHistoryC kv.Cursor
+	accChangesC, storageChangesC kv.CursorDupSort
+	blockNr                      uint64
+	tx                           kv.Tx
 }
 
 func NewStateReader(tx kv.Tx, blockNr uint64) *StateReader {
+	c1, _ := tx.Cursor(kv.AccountsHistory)
+	c2, _ := tx.Cursor(kv.StorageHistory)
+	c3, _ := tx.CursorDupSort(kv.AccountChangeSet)
+	c4, _ := tx.CursorDupSort(kv.StorageChangeSet)
 	return &StateReader{
-		tx:      tx,
-		blockNr: blockNr,
+		tx:          tx,
+		blockNr:     blockNr,
+		accHistoryC: c1, storageHistoryC: c2, accChangesC: c3, storageChangesC: c4,
 	}
 }
 
 func (r *StateReader) ReadAccountData(address common.Address) (*accounts.Account, error) {
-	enc, err := state.GetAsOf(r.tx, false /* storage */, address[:], r.blockNr+1)
+	enc, err := state.GetAsOf(r.tx, r.accHistoryC, r.accChangesC, false /* storage */, address[:], r.blockNr+1)
 	if err != nil || enc == nil || len(enc) == 0 {
 		return nil, nil
 	}
@@ -37,7 +44,7 @@ func (r *StateReader) ReadAccountData(address common.Address) (*accounts.Account
 
 func (r *StateReader) ReadAccountStorage(address common.Address, incarnation uint64, key *common.Hash) ([]byte, error) {
 	compositeKey := dbutils.PlainGenerateCompositeStorageKey(address.Bytes(), incarnation, key.Bytes())
-	return state.GetAsOf(r.tx, true /* storage */, compositeKey, r.blockNr+1)
+	return state.GetAsOf(r.tx, r.storageHistoryC, r.storageChangesC, true /* storage */, compositeKey, r.blockNr+1)
 }
 
 func (r *StateReader) ReadAccountCode(address common.Address, incarnation uint64, codeHash common.Hash) ([]byte, error) {


### PR DESCRIPTION
- trace_filter - don't create intermediate copy of json
- seek in bitmap - don't create iterator
- getAsOf - don't create cursors