### PR TITLE
Expore --miner.sigkey cli parameter

### DIFF
--- a/docs/mining.md
+++ b/docs/mining.md
@@ -2,7 +2,7 @@
 
 Support only remote-miners.
 
-* To enable, add `--mine --miner.etherbase=...` or `--mine --miner.miner.sigkey=...` flags.
+* To enable, add `--mine --miner.etherbase=...` or `--mine --miner.sigkey=...` flags.
 * Other supported options: `--miner.extradata`, `--miner.notify`, `--miner.gaslimit`, `--miner.gasprice`
   , `--miner.gastarget`
 * RPCDaemon supports methods: eth_coinbase , eth_hashrate, eth_mining, eth_getWork, eth_submitWork, eth_submitHashrate

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -77,5 +77,6 @@ var DefaultFlags = []cli.Flag{
 	utils.MinerEtherbaseFlag,
 	utils.MinerExtraDataFlag,
 	utils.MinerNoVerfiyFlag,
+	utils.MinerSigningKeyFlag,
 	utils.SentryAddrFlag,
 }


### PR DESCRIPTION
Seems like `--miner.sigkey` has been lost in command-line parsing routines; also the cli argument has been incorrectly referred in `mining.md`. 