### PR TITLE
Support for `latest` block in `erigon_getHeaderByNumber`

### DIFF
--- a/cmd/rpcdaemon/commands/erigon_block.go
+++ b/cmd/rpcdaemon/commands/erigon_block.go
@@ -27,9 +27,14 @@ func (api *ErigonImpl) GetHeaderByNumber(ctx context.Context, blockNumber rpc.Bl
 	}
 	defer tx.Rollback()
 
-	header := rawdb.ReadHeaderByNumber(tx, uint64(blockNumber.Int64()))
+	blockNum, err := getBlockNumber(blockNumber, tx)
+	if err != nil {
+		return nil, err
+	}
+
+	header := rawdb.ReadHeaderByNumber(tx, blockNum)
 	if header == nil {
-		return nil, fmt.Errorf("block header not found: %d", blockNumber.Int64())
+		return nil, fmt.Errorf("block header not found: %d", blockNum)
 	}
 
 	return header, nil


### PR DESCRIPTION
`{"jsonrpc":"2.0","method":"erigon_getHeaderByNumber","params": ["latest"],"id":0}`

was failing and returning 

`{"jsonrpc":"2.0","id":0,"error":{"code":-32000,"message":"block header not found: -1"}`

and now fetches latest and returns the proper header.


