### PR TITLE
Add a new stage to accumulate total issued/burnt ETH

### DIFF
--- a/cmd/integration/commands/reset_state.go
+++ b/cmd/integration/commands/reset_state.go
@@ -81,7 +81,6 @@ func resetAllIssuance(db kv.RwDB, logger log.Logger, ctx context.Context) error 
 	return nil
 }
 
-
 func resetState(db kv.RwDB, logger log.Logger, ctx context.Context) error {
 	if err := db.View(ctx, func(tx kv.Tx) error { return printStages(tx) }); err != nil {
 		return err
@@ -200,6 +199,9 @@ func resetIssuance(tx kv.RwTx) error {
 		return err
 	}
 	if err := stages.SaveStageProgress(tx, stages.Issuance, 0); err != nil {
+		return err
+	}
+	if err := stages.SaveStagePruneProgress(tx, stages.Issuance, 0); err != nil {
 		return err
 	}
 

--- a/cmd/rpcdaemon/commands/erigon_issuance.go
+++ b/cmd/rpcdaemon/commands/erigon_issuance.go
@@ -118,5 +118,5 @@ type Issuance struct {
 	UncleReward string `json:"uncleReward,omitempty"`
 	Issuance    string `json:"issuance,omitempty"`
 	TotalIssued string `json:"totalIssued,omitempty"`
-	TotalBurnt  string `json:"totalBurnt,omitEmpty"`
+	TotalBurnt  string `json:"totalBurnt,omitempty"`
 }

--- a/common/dbutils/composite_keys.go
+++ b/common/dbutils/composite_keys.go
@@ -159,3 +159,10 @@ func CompositeKeySuffix(key []byte, timestamp uint64) (composite, encodedTS []by
 	copy(composite[len(key):], encodedTS)
 	return composite, encodedTS
 }
+
+// IssuanceKey = num (uint64 big endian)
+func IssuanceKey(number uint64) []byte {
+	k := make([]byte, NumberLength)
+	binary.BigEndian.PutUint64(k, number)
+	return k
+}

--- a/eth/stagedsync/default_stages.go
+++ b/eth/stagedsync/default_stages.go
@@ -323,8 +323,8 @@ type PruneOrder []stages.SyncStage
 
 var DefaultUnwindOrder = UnwindOrder{
 	stages.Finish,
-	stages.TxLookup,
 	stages.Issuance,
+	stages.TxLookup,
 	stages.LogIndex,
 	stages.StorageHistoryIndex,
 	stages.AccountHistoryIndex,

--- a/eth/stagedsync/stage_issuance.go
+++ b/eth/stagedsync/stage_issuance.go
@@ -1,0 +1,237 @@
+package stagedsync
+
+import (
+	"context"
+	"fmt"
+	"github.com/holiman/uint256"
+	"github.com/ledgerwatch/erigon-lib/kv"
+	"github.com/ledgerwatch/erigon/common"
+	"github.com/ledgerwatch/erigon/common/dbutils"
+	"github.com/ledgerwatch/erigon/consensus/ethash"
+	"github.com/ledgerwatch/erigon/core"
+	"github.com/ledgerwatch/erigon/core/rawdb"
+	"github.com/ledgerwatch/erigon/params"
+	"github.com/ledgerwatch/erigon/rlp"
+	"github.com/ledgerwatch/log/v3"
+	"math/big"
+	"time"
+)
+
+type IssuanceCfg struct {
+	db          kv.RwDB
+	genesis     *core.Genesis
+	chainConfig *params.ChainConfig
+}
+
+func StageIssuanceCfg(db kv.RwDB, genesis *core.Genesis, chainConfig *params.ChainConfig) IssuanceCfg {
+	return IssuanceCfg{
+		db,
+		genesis,
+		chainConfig,
+	}
+}
+
+func SpawnIssuance(s *StageState, tx kv.RwTx, cfg IssuanceCfg, ctx context.Context) error {
+	useExternalTx := tx != nil
+	if !useExternalTx {
+		var err error
+		tx, err = cfg.db.BeginRw(ctx)
+		if err != nil {
+			return err
+		}
+		defer tx.Rollback()
+	}
+
+	endBlock, err := s.ExecutionAt(tx)
+	if err != nil {
+		return err
+	}
+
+	logPrefix := s.LogPrefix()
+	if endBlock > s.BlockNumber+16 {
+		log.Info(fmt.Sprintf("[%s] Computing issuance", logPrefix), "from", s.BlockNumber, "to", endBlock)
+	}
+
+	startBlock := s.BlockNumber
+	if startBlock > 0 {
+		startBlock++
+	}
+	if err := computeIssuance(logPrefix, tx, cfg.genesis, cfg.chainConfig, startBlock, endBlock, ctx.Done()); err != nil {
+		return err
+	}
+
+	if err := s.Update(tx, endBlock); err != nil {
+		return err
+	}
+
+	if !useExternalTx {
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type Issuance struct {
+	TotalIssued *uint256.Int
+	TotalBurnt  *uint256.Int
+}
+
+func computeInitialAlloc(genesis *core.Genesis) *big.Int {
+	total := big.NewInt(0)
+
+	if genesis == nil {
+		genesis = core.DefaultGenesisBlock()
+	}
+	for _, v := range genesis.Alloc {
+		total.Add(total, v.Balance)
+	}
+	return total
+}
+
+func computeIssuance(logPrefix string, tx kv.RwTx, genesis *core.Genesis, chainConfig *params.ChainConfig, startBlock, endBlock uint64, quitCh <-chan struct{}) error {
+	logEvery := time.NewTicker(30 * time.Second)
+	defer logEvery.Stop()
+
+	cursor, err := tx.RwCursor(kv.Issuance)
+	if err != nil {
+		return err
+	}
+	defer cursor.Close()
+
+	// Initialize from previous grandtotal
+	totalIssued := uint256.NewInt(0)
+	totalBurnt := uint256.NewInt(0)
+	if startBlock == 0 {
+		totalIssued.SetFromBig(computeInitialAlloc(genesis))
+	} else {
+		prevBlock := startBlock - 1
+
+		key := dbutils.IssuanceKey(prevBlock)
+		_, v, err := cursor.SeekExact(key)
+		if err != nil {
+			return err
+		}
+
+		if v != nil {
+			lastTotals := new(Issuance)
+			if err := rlp.DecodeBytes(v, lastTotals); err != nil {
+				return err
+			}
+
+			totalIssued.Set(lastTotals.TotalIssued)
+			totalBurnt.Set(lastTotals.TotalBurnt)
+		}
+	}
+
+	for i := startBlock; i <= endBlock; i++ {
+		select {
+		default:
+		case <-quitCh:
+			return common.ErrStopped
+		case <-logEvery.C:
+			log.Info(fmt.Sprintf("[%s] Progress", logPrefix), "block", i)
+		}
+
+		blockHash, err := rawdb.ReadCanonicalHash(tx, i)
+		if err != nil {
+			return err
+		}
+		header := rawdb.ReadHeader(tx, blockHash, i)
+		body, _, _ := rawdb.ReadBody(tx, blockHash, i)
+
+		// Calculate issuance for this block; accumulate it in grand total
+		minerReward, uncleRewards := ethash.AccumulateRewards(chainConfig, header, body.Uncles)
+		issued := minerReward
+		for _, v := range uncleRewards {
+			issued.Add(&issued, &v)
+		}
+		totalIssued.Add(totalIssued, &issued)
+
+		// Calculate burnt for this block; accumulate it in grand total
+		burnt := uint256.NewInt(0)
+		if chainConfig.IsLondon(i) {
+			gasUsed := uint256.NewInt(0)
+			gasUsed.SetUint64(header.GasUsed)
+
+			baseFee, overflow := uint256.FromBig(header.BaseFee)
+			if overflow {
+				log.Error("Overflow while reading basefee")
+			} else {
+				burnt.Mul(baseFee, gasUsed)
+			}
+
+			totalBurnt.Add(totalBurnt, burnt)
+		}
+
+		// Persist
+		key := dbutils.IssuanceKey(i)
+		value, err := rlp.EncodeToBytes(Issuance{totalIssued, totalBurnt})
+		if err != nil {
+			return err
+		}
+		if err := cursor.Append(key, value); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func UnwindIssuance(u *UnwindState, s *StageState, tx kv.RwTx, cfg IssuanceCfg, ctx context.Context) error {
+	useExternalTx := tx != nil
+	if !useExternalTx {
+		tx, err := cfg.db.BeginRw(ctx)
+		if err != nil {
+			return err
+		}
+		defer tx.Rollback()
+	}
+
+	logPrefix := u.LogPrefix()
+	log.Info(fmt.Sprintf("[%s] Unwinding issuance", logPrefix), "from", s.BlockNumber, "to", u.UnwindPoint)
+	cursor, err := tx.RwCursor(kv.Issuance)
+	if err != nil {
+		return err
+	}
+	defer cursor.Close()
+
+	key := dbutils.IssuanceKey(u.UnwindPoint + 1)
+	for k, _, err := cursor.SeekExact(key); k != nil; k, _, err = cursor.Next() {
+		if err != nil {
+			return err
+		}
+
+		if err = cursor.DeleteCurrent(); err != nil {
+			return err
+		}
+	}
+
+	if err := u.Done(tx); err != nil {
+		return err
+	}
+	if !useExternalTx {
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func PruneIssuance(p *PruneState, tx kv.RwTx, cfg IssuanceCfg, ctx context.Context) error {
+	useExternalTx := tx != nil
+	if !useExternalTx {
+		tx, err := cfg.db.BeginRw(ctx)
+		if err != nil {
+			return err
+		}
+		defer tx.Rollback()
+	}
+
+	if !useExternalTx {
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/eth/stagedsync/stages/stages.go
+++ b/eth/stagedsync/stages/stages.go
@@ -42,6 +42,7 @@ var (
 	LogIndex            SyncStage = "LogIndex"            // Generating logs index (from receipts)
 	CallTraces          SyncStage = "CallTraces"          // Generating call traces index
 	TxLookup            SyncStage = "TxLookup"            // Generating transactions lookup index
+	Issuance            SyncStage = "Issuance"            // Compute total issuance/burnt
 	TxPool              SyncStage = "TxPool"              // Starts Backend
 	Finish              SyncStage = "Finish"              // Nominal stage after all other stages
 
@@ -68,6 +69,7 @@ var AllStages = []SyncStage{
 	LogIndex,
 	CallTraces,
 	TxLookup,
+	Issuance,
 	TxPool,
 	Finish,
 }

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/kevinburke/go-bindata v3.21.0+incompatible
 	github.com/kylelemons/godebug v1.1.0 // indirect
-	github.com/ledgerwatch/erigon-lib v0.0.0-20210826022733-7506e3c8dbd7
+	github.com/ledgerwatch/erigon-lib v0.0.0-20210827070031-0d39461db7c5
 	github.com/ledgerwatch/log/v3 v3.3.0
 	github.com/ledgerwatch/secp256k1 v0.0.0-20210626115225-cd5cd00ed72d
 	github.com/logrusorgru/aurora/v3 v3.0.0

--- a/go.sum
+++ b/go.sum
@@ -490,8 +490,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
-github.com/ledgerwatch/erigon-lib v0.0.0-20210826022733-7506e3c8dbd7 h1:i2KNQASh8expgxOnHiNTjuWLvIskfnlj29+qFPPlcig=
-github.com/ledgerwatch/erigon-lib v0.0.0-20210826022733-7506e3c8dbd7/go.mod h1:MeJOD9uuq8iDAbH83qsJ5V52yuUSTJ13I6ORvm/ft6U=
+github.com/ledgerwatch/erigon-lib v0.0.0-20210827070031-0d39461db7c5 h1:nhkMNzSAq/ha7YVEBwv12dyDMK599xdZ+Ls6uZ4BBec=
+github.com/ledgerwatch/erigon-lib v0.0.0-20210827070031-0d39461db7c5/go.mod h1:MeJOD9uuq8iDAbH83qsJ5V52yuUSTJ13I6ORvm/ft6U=
 github.com/ledgerwatch/log/v3 v3.2.0/go.mod h1:J58eOHHrIYHxl7LKkRsb/0YibKwtLfauUryl5SLRGm0=
 github.com/ledgerwatch/log/v3 v3.3.0 h1:k8N/3NQLILr8CKCMyza261vLFKU7VA+nMNNb0wVyQSc=
 github.com/ledgerwatch/log/v3 v3.3.0/go.mod h1:J58eOHHrIYHxl7LKkRsb/0YibKwtLfauUryl5SLRGm0=

--- a/turbo/stages/mock_sentry.go
+++ b/turbo/stages/mock_sentry.go
@@ -296,6 +296,7 @@ func MockWithEverything(t *testing.T, gspec *core.Genesis, key *ecdsa.PrivateKey
 			stagedsync.StageLogIndexCfg(mock.DB, prune, mock.tmpdir),
 			stagedsync.StageCallTracesCfg(mock.DB, prune, 0, mock.tmpdir),
 			stagedsync.StageTxLookupCfg(mock.DB, prune, mock.tmpdir),
+			stagedsync.StageIssuanceCfg(mock.DB, gspec, mock.ChainConfig),
 			stagedsync.StageTxPoolCfg(mock.DB, txPool, func() {
 				mock.StreamWg.Add(1)
 				go txpool.RecvTxMessageLoop(mock.Ctx, mock.SentryClient, mock.TxPoolP2PServer.HandleInboundMessage, &mock.ReceiveWg)

--- a/turbo/stages/stageloop.go
+++ b/turbo/stages/stageloop.go
@@ -261,6 +261,7 @@ func NewStagedSync(
 			stagedsync.StageLogIndexCfg(db, cfg.Prune, tmpdir),
 			stagedsync.StageCallTracesCfg(db, cfg.Prune, 0, tmpdir),
 			stagedsync.StageTxLookupCfg(db, cfg.Prune, tmpdir),
+			stagedsync.StageIssuanceCfg(db, cfg.Genesis, controlServer.ChainConfig),
 			stagedsync.StageTxPoolCfg(db, txPool, func() {
 				for i := range txPoolServer.Sentries {
 					go func(i int) {


### PR DESCRIPTION
This patch adds a new stage to erigon pipeline, it saves the total accumulated issued/burnt ETH by block in a new bucket called "Issuance".

The bucket creation is registered on erigon-lib, I'l submit another PR for erigon-lib which is necessary for this PR to work.

I also modified the erigon_issuance rpc method to return these new info so people can discover this erigon capability.

Please note that otterscan will not use erigon_issuance method, instead I have another custom method that returns this same info along other ones from db in one network call. If you prefer I can restore the original erigon_issuance method.