### PR TITLE
Update wmake.ps1

### DIFF
--- a/wmake.ps1
+++ b/wmake.ps1
@@ -207,7 +207,7 @@ function Test-GO-Installed {
 # -----------------------------------------------------------------------------
 function Test-Git-Installed {
 
-    $Private:item   = Get-Uninstall-Item "^Git\ "
+    $Private:item   = Get-Uninstall-Item "(Git)"
     $Private:result = $false
 
     if ($Private:item) {


### PR DESCRIPTION
Attempted to run the wmake build operation.

Although git was installed, Test-Git-Installed returned an error.

Manually verified that a key for Git installation existed in the registry.

Replicated search function. Found that imatch used regex. Found that the current version git installation pspath 


On my machine:

Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Uninstall\Git_is1 


did not have a string structure which would return a good result utilizing provided search string parameter.

Modified default search string to return true in the event of regex finding any example of "Git" (Case insensitive as a result of using imatch rather than match)

Tested, which resulted in wmake.ps1 validating Git installation and attempting build.

I will propose some additional changes soon, wmake.ps1 should be importable without executing code. Doing this would not prevent direct command line execution as stated in the usage description but would prevent "right click - run" functionality which, in this case, isn't practical anyway. I think BuildTargets should be a Cmdlet.