### PR TITLE
fix eth_callBundle by allowing nil baseFee in tx serialize

### DIFF
--- a/core/types/dynamic_fee_tx.go
+++ b/core/types/dynamic_fee_tx.go
@@ -469,9 +469,11 @@ func (tx DynamicFeeTransaction) AsMessage(s Signer, baseFee *big.Int) (Message, 
 		accessList: tx.AccessList,
 		checkNonce: true,
 	}
-	overflow := msg.gasPrice.SetFromBig(baseFee)
-	if overflow {
-		return msg, fmt.Errorf("gasPrice higher than 2^256-1")
+	if baseFee != nil {
+		overflow := msg.gasPrice.SetFromBig(baseFee)
+		if overflow {
+			return msg, fmt.Errorf("gasPrice higher than 2^256-1")
+		}
 	}
 	msg.gasPrice.Add(&msg.gasPrice, tx.Tip)
 	if msg.gasPrice.Gt(tx.FeeCap) {


### PR DESCRIPTION
CallBundle in eth_block.go uses
```
firstMsg, err := txs[0].AsMessage(*signer, nil)
```
which was crashing

Maybe this is the wrong fix, but it works.