### PR TITLE
fix sentry discover race

### DIFF
--- a/cmd/sentry/download/sentry.go
+++ b/cmd/sentry/download/sentry.go
@@ -523,12 +523,12 @@ func Sentry(datadir string, sentryAddr string, discoveryDNS []string, cfg *p2p.C
 	}
 	ctx := rootContext()
 	sentryServer := NewSentryServer(ctx, nil, func() *eth.NodeInfo { return nil }, cfg, protocolVersion)
+	sentryServer.discoveryDNS = discoveryDNS
 
 	grpcServer, err := grpcSentryServer(ctx, sentryAddr, sentryServer)
 	if err != nil {
 		return err
 	}
-	sentryServer.discoveryDNS = discoveryDNS
 
 	<-ctx.Done()
 	grpcServer.GracefulStop()


### PR DESCRIPTION
for 
```
WARNING: DATA RACE
Read at 0x00c0002044f0 by goroutine 50:
  github.com/ledgerwatch/erigon/cmd/sentry/download.(*SentryServerImpl).SetStatus()
      github.com/ledgerwatch/erigon/cmd/sentry/download/sentry.go:815 +0x249
  github.com/ledgerwatch/erigon-lib/gointerfaces/sentry._Sentry_SetStatus_Handler.func1()
      github.com/ledgerwatch/erigon-lib@v0.0.0-20210913043526-b3f03203e43e/gointerfaces/sentry/sentry_grpc.pb.go:283 +0x88
  github.com/grpc-ecosystem/go-grpc-middleware/recovery.UnaryServerInterceptor.func1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/recovery/interceptors.go:33 +0x144
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:25 +0x8e
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:34 +0x126
  github.com/ledgerwatch/erigon-lib/gointerfaces/sentry._Sentry_SetStatus_Handler()
      github.com/ledgerwatch/erigon-lib@v0.0.0-20210913043526-b3f03203e43e/gointerfaces/sentry/sentry_grpc.pb.go:285 +0x1da
  google.golang.org/grpc.(*Server).processUnaryRPC()
      google.golang.org/grpc@v1.39.1/server.go:1293 +0x1437
  google.golang.org/grpc.(*Server).handleStream()
      google.golang.org/grpc@v1.39.1/server.go:1618 +0xfd3
  google.golang.org/grpc.(*Server).serveStreams.func1.2()
      google.golang.org/grpc@v1.39.1/server.go:941 +0xfd

Previous write at 0x00c0002044f0 by main goroutine:
  github.com/ledgerwatch/erigon/cmd/sentry/download.Sentry()
      github.com/ledgerwatch/erigon/cmd/sentry/download/sentry.go:531 +0x265
  github.com/ledgerwatch/erigon/cmd/sentry/commands.glob..func3()
      github.com/ledgerwatch/erigon/cmd/sentry/commands/sentry.go:83 +0x444
  github.com/spf13/cobra.(*Command).execute()
      github.com/spf13/cobra@v1.2.1/command.go:856 +0xa7d
  github.com/spf13/cobra.(*Command).ExecuteC()
      github.com/spf13/cobra@v1.2.1/command.go:974 +0x5da
  github.com/spf13/cobra.(*Command).Execute()
      github.com/spf13/cobra@v1.2.1/command.go:902 +0xdb
  github.com/spf13/cobra.(*Command).ExecuteContext()
      github.com/spf13/cobra@v1.2.1/command.go:895 +0xd6
  github.com/ledgerwatch/erigon/cmd/sentry/commands.Execute()
      github.com/ledgerwatch/erigon/cmd/sentry/commands/sentry.go:90 +0x68
  main.main()
      github.com/ledgerwatch/erigon/cmd/sentry/main.go:10 +0x24
```