### PR TITLE
fix sentry forks slice race

### DIFF
--- a/cmd/sentry/download/sentry.go
+++ b/cmd/sentry/download/sentry.go
@@ -171,7 +171,9 @@ func handShake(
 		errc <- p2p.Send(rw, eth.StatusMsg, s)
 	}()
 	var readStatus = func() error {
-		forkFilter := forkid.NewFilterFromForks(status.ForkData.Forks, genesisHash, status.MaxBlock)
+		forks := make([]uint64, len(status.ForkData.Forks)) // copy because forkid.NewFilterFromForks will write into this slice
+		copy(forks, status.ForkData.Forks)
+		forkFilter := forkid.NewFilterFromForks(forks, genesisHash, status.MaxBlock)
 		networkID := status.NetworkId
 		// Read handshake message
 		msg, err1 := rw.ReadMsg()


### PR DESCRIPTION
for 
```

WARNING: DATA RACE
Write at 0x00c0005bc050 by goroutine 119:
  github.com/ledgerwatch/erigon/core/forkid.newFilter()
      github.com/ledgerwatch/erigon/core/forkid/forkid.go:118 +0x2fb
  github.com/ledgerwatch/erigon/core/forkid.NewFilterFromForks()
      github.com/ledgerwatch/erigon/core/forkid/forkid.go:92 +0xb3
  github.com/ledgerwatch/erigon/cmd/sentry/download.handShake.func2()
      github.com/ledgerwatch/erigon/cmd/sentry/download/sentry.go:174 +0x15c
  github.com/ledgerwatch/erigon/cmd/sentry/download.handShake.func3()
      github.com/ledgerwatch/erigon/cmd/sentry/download/sentry.go:228 +0x39

Previous write at 0x00c0005bc050 by goroutine 126:
  github.com/ledgerwatch/erigon/core/forkid.newFilter()
      github.com/ledgerwatch/erigon/core/forkid/forkid.go:118 +0x2fb
  github.com/ledgerwatch/erigon/core/forkid.NewFilterFromForks()
      github.com/ledgerwatch/erigon/core/forkid/forkid.go:92 +0xb3
  github.com/ledgerwatch/erigon/cmd/sentry/download.handShake.func2()
      github.com/ledgerwatch/erigon/cmd/sentry/download/sentry.go:174 +0x15c
  github.com/ledgerwatch/erigon/cmd/sentry/download.handShake.func3()
      github.com/ledgerwatch/erigon/cmd/sentry/download/sentry.go:228 +0x39
```