### PR TITLE
mark support for eip-1559 tx types for most permissive signer

### DIFF
--- a/core/types/dynamic_fee_tx.go
+++ b/core/types/dynamic_fee_tx.go
@@ -555,3 +555,19 @@ func (tx DynamicFeeTransaction) GetSender() (common.Address, bool) {
 func (tx *DynamicFeeTransaction) SetSender(addr common.Address) {
 	tx.from.Store(addr)
 }
+
+// NewTransaction creates an unsigned eip1559 transaction.
+func NewEIP1559Transaction(chainID uint256.Int, nonce uint64, to common.Address, amount *uint256.Int, gasLimit uint64, gasPrice *uint256.Int, gasTip *uint256.Int, gasFeeCap *uint256.Int, data []byte) *DynamicFeeTransaction {
+	return &DynamicFeeTransaction{
+		CommonTx: CommonTx{
+			Nonce: nonce,
+			To:    &to,
+			Value: amount,
+			Gas:   gasLimit,
+			Data:  data,
+		},
+		ChainID: &chainID,
+		Tip:     gasTip,
+		FeeCap:  gasFeeCap,
+	}
+}

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -106,7 +106,7 @@ func LatestSigner(config *params.ChainConfig) *Signer {
 }
 
 // LatestSignerForChainID returns the 'most permissive' Signer available. Specifically,
-// this enables support for EIP-155 replay protection and all implemented EIP-2718
+// this marks support for EIP-155 replay protection, EIP-2718 typed transactions and EIP-1559 dynamic fee
 // transaction types if chainID is non-nil.
 //
 // Use this in transaction-handling code where the current block number and fork
@@ -126,6 +126,7 @@ func LatestSignerForChainID(chainID *big.Int) *Signer {
 	signer.chainIDMul.Mul(chainId, u256.Num2)
 	signer.protected = true
 	signer.accesslist = true
+	signer.dynamicfee = true
 	return &signer
 }
 

--- a/core/types/transaction_signing_test.go
+++ b/core/types/transaction_signing_test.go
@@ -28,6 +28,26 @@ import (
 	"github.com/ledgerwatch/erigon/rlp"
 )
 
+func TestEIP1559Signing(t *testing.T) {
+	key, _ := crypto.GenerateKey()
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+
+	chainId := uint256.NewInt(18)
+	signer := LatestSignerForChainID(chainId.ToBig())
+	tx, err := SignTx(NewEIP1559Transaction(*chainId, 0, addr, new(uint256.Int), 0, new(uint256.Int), new(uint256.Int), new(uint256.Int), nil), *signer, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	from, err := tx.Sender(*signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if from != addr {
+		t.Errorf("exected from and address to be equal. Got %x want %x", from, addr)
+	}
+}
+
 func TestEIP155Signing(t *testing.T) {
 	key, _ := crypto.GenerateKey()
 	addr := crypto.PubkeyToAddress(key.PublicKey)


### PR DESCRIPTION
I am getting a
```dynamicfee tx is not supported by signer Signer[chainId=1,malleable=false,unprotected=true,protected=true,accesslist=true,dynamicfee=false``` 
error when using erigon as a library in a custom tool when using
```types.LatestSignerForChainID()``` on top of EIP-1559 transaction. Specifically when calling the `signedTx.Sender(*signer)`

This simple fix seems to fix it. Not sure however how it might affect the other users using erigon as a library.