### PR TITLE
--mdbx.augment.limit

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -96,6 +96,11 @@ var (
 		Usage: "Data directory for the databases",
 		Value: DirectoryString(paths.DefaultDataDir()),
 	}
+	MdbxAugmentLimitFlag = DirectoryFlag{
+		Name:  "mdbx.augment.limit",
+		Usage: "Data directory for the databases",
+		Value: DirectoryString(paths.DefaultDataDir()),
+	}
 	AncientFlag = DirectoryFlag{
 		Name:  "datadir.ancient",
 		Usage: "Data directory for ancient chain segments (default = inside chaindata)",
@@ -876,6 +881,10 @@ func setDataDir(ctx *cli.Context, cfg *node.Config) {
 		cfg.DataDir = ctx.GlobalString(DataDirFlag.Name)
 	} else {
 		cfg.DataDir = DataDirForNetwork(cfg.DataDir, ctx.GlobalString(ChainFlag.Name))
+	}
+
+	if ctx.GlobalIsSet(MdbxAugmentLimitFlag.Name) {
+		cfg.MdbxAugumentLimit = ctx.GlobalUint64(MdbxAugmentLimitFlag.Name)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/json-iterator/go v1.1.11
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/kevinburke/go-bindata v3.21.0+incompatible
-	github.com/ledgerwatch/erigon-lib v0.0.0-20210926124830-9b3efaa33e2a
+	github.com/ledgerwatch/erigon-lib v0.0.0-20210927024337-0468c7c3a0fe
 	github.com/ledgerwatch/log/v3 v3.3.1
 	github.com/ledgerwatch/secp256k1 v0.0.0-20210626115225-cd5cd00ed72d
 	github.com/logrusorgru/aurora/v3 v3.0.0

--- a/go.sum
+++ b/go.sum
@@ -494,8 +494,8 @@ github.com/kylelemons/godebug v0.0.0-20170224010052-a616ab194758 h1:0D5M2HQSGD3P
 github.com/kylelemons/godebug v0.0.0-20170224010052-a616ab194758/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
-github.com/ledgerwatch/erigon-lib v0.0.0-20210926124830-9b3efaa33e2a h1:zK1CbuTV8MClnVuxH35a4CqAXcJoEcAaqBLb9DqBjTc=
-github.com/ledgerwatch/erigon-lib v0.0.0-20210926124830-9b3efaa33e2a/go.mod h1:WgyjBACSDhgfepaaDJIbzd2TV868EjOrp2ILnEMKspY=
+github.com/ledgerwatch/erigon-lib v0.0.0-20210927024337-0468c7c3a0fe h1:Sh5g1jIm43Jp8XAJ/EIT3cza2925u7mE8AY0EOW7vE4=
+github.com/ledgerwatch/erigon-lib v0.0.0-20210927024337-0468c7c3a0fe/go.mod h1:WgyjBACSDhgfepaaDJIbzd2TV868EjOrp2ILnEMKspY=
 github.com/ledgerwatch/log/v3 v3.3.1 h1:HmvLeTEvtCtqSvtu4t/a5MAdcLfeBcbIeowXbLYuzLc=
 github.com/ledgerwatch/log/v3 v3.3.1/go.mod h1:S3VJqhhVX32rbp1JyyvhJou12twtFwNEPESBgpbNkRk=
 github.com/ledgerwatch/secp256k1 v0.0.0-20210626115225-cd5cd00ed72d h1:/IKMrJdfRsoYNc36PXqP4xMH3vhW/8IQyBKGQbKZUno=

--- a/node/config.go
+++ b/node/config.go
@@ -158,6 +158,8 @@ type Config struct {
 	AllowUnprotectedTxs bool `toml:",omitempty"`
 	TLSKeyFile          string
 	TLSCACert           string
+
+	MdbxAugumentLimit uint64
 }
 
 // IPCEndpoint resolves an IPC endpoint based on a configured value, taking into

--- a/node/node.go
+++ b/node/node.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ledgerwatch/erigon/params"
 	"net"
 	"net/http"
 	"os"
@@ -28,6 +27,8 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+
+	"github.com/ledgerwatch/erigon/params"
 
 	"github.com/gofrs/flock"
 	"github.com/ledgerwatch/erigon-lib/kv"
@@ -523,6 +524,9 @@ func OpenDatabase(config *Config, logger log.Logger, label kv.Label) (kv.RwDB, e
 		opts := mdbx.NewMDBX(logger).Path(dbPath).Label(label).DBVerbosity(config.DatabaseVerbosity)
 		if exclusive {
 			opts = opts.Exclusive()
+		}
+		if label == kv.ChainDB {
+			opts.AugumentLimit(config.MdbxAugumentLimit)
 		}
 		return opts.Open()
 	}

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -9,6 +9,7 @@ import (
 // DefaultFlags contains all flags that are used and supported by Erigon binary.
 var DefaultFlags = []cli.Flag{
 	utils.DataDirFlag,
+	utils.MdbxAugmentLimitFlag,
 	utils.EthashDatasetDirFlag,
 	utils.TxPoolV2Flag,
 	utils.TxPoolDisableFlag,


### PR DESCRIPTION
meaning: 
```

  /** \brief Controls the in-process limit to grow a list of reclaimed/recycled
   * page's numbers for finding a sequence of contiguous pages for large data
   * items.
   *
   * \details A long values requires allocation of contiguous database pages.
   * To find such sequences, it may be necessary to accumulate very large lists,
   * especially when placing very long values (more than a megabyte) in a large
   * databases (several tens of gigabytes), which is much expensive in extreme
   * cases. This threshold allows you to avoid such costs by allocating new
   * pages at the end of the database (with its possible growth on disk),
   * instead of further accumulating/reclaiming Garbage Collection records.
   *
   * On the other hand, too small threshold will lead to unreasonable database
   * growth, or/and to the inability of put long values.
   *
   * The `MDBX_opt_rp_augment_limit` controls described limit for the current
   * process. Default is 262144, it is usually enough for most cases. */
  MDBX_opt_rp_augment_limit,
```

mdbx's default: 256*1024
our current value: 32*1024*1024

Bigger value - means faster inserts of big values (eth transactions, receipt logs), but may lead to bigger db (but unlikely). But we don't have much large values in our db. 

TODO: find smaller good value