### PR TITLE
Update signal_windows.go

### DIFF
--- a/internal/debug/signal_windows.go
+++ b/internal/debug/signal_windows.go
@@ -9,12 +9,11 @@ import (
 
 	_debug "github.com/ledgerwatch/erigon/common/debug"
 	"github.com/ledgerwatch/log/v3"
-	"golang.org/x/sys/windows"
 )
 
 func ListenSignals(stack io.Closer) {
 	sigc := make(chan os.Signal, 1)
-	signal.Notify(sigc, windows.SIGINT, windows.SIGTERM)
+	signal.Notify(sigc, os.Interrupt)
 	_debug.GetSigC(&sigc)
 	defer signal.Stop(sigc)
 


### PR DESCRIPTION
Trap os.interrupt instead of SIGINT and SIGTERM
Fixes #2728 

Now output is 
```
INFO[10-03|10:49:40.574] [1/18 Headers] Processed                 highest inserted=13345212 age=13s
INFO[10-03|10:49:41.831] [4/18 Bodies] Processing bodies...       from=13345069 to=13345212 # CTRl+C here
INFO[10-03|10:49:58.328] Got interrupt, shutting down...
INFO[10-03|10:50:00.030] Successfully update p2p node database    path=E:\\erigon-mainnet/nodes/eth66 updated=0 deleted=127
INFO[10-03|10:50:00.032] database closed                          label=sentry
INFO[10-03|10:50:00.546] Successfully update p2p node database    path=E:\\erigon-mainnet/nodes/eth65 updated=0 deleted=162
INFO[10-03|10:50:00.548] database closed                          label=sentry
INFO[10-03|10:50:00.575] database closed                          label=chaindata
```