### PR TITLE
RPCDaemon: reduce --rpc.batch.concurrency default from 50 to 2

### DIFF
--- a/cmd/prometheus/dashboards/erigon.json
+++ b/cmd/prometheus/dashboards/erigon.json
@@ -22,7 +22,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 1,
-  "iteration": 1632801657282,
+  "iteration": 1633497111542,
   "links": [],
   "panels": [
     {
@@ -3070,7 +3070,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "reqps"
         },
         "overrides": []
       },
@@ -3097,14 +3097,311 @@
       "targets": [
         {
           "exemplar": true,
+          "expr": "rate(rpc_duration_seconds_count{instance=~\"$instance\",success=\"success\"}[1m])",
+          "interval": "",
+          "legendFormat": "success {{ method }} {{ instance }} ",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "rate(rpc_duration_seconds_count{instance=~\"$instance\",success=\"failure\"}[1m])",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "failure {{ method }} {{ instance }} ",
+          "refId": "B"
+        }
+      ],
+      "title": "RPS",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 80
+      },
+      "id": 186,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "last"
+          ],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "db_begin_seconds{quantile=\"$quantile\",instance=~\"$instance\"}",
+          "interval": "",
+          "legendFormat": "db_begin_seconds: {{ method }} {{ instance }}",
+          "refId": "A"
+        }
+      ],
+      "title": "DB begin",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  " eth_call turbogeth16c.weblogix.it:6060 success"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 88
+      },
+      "id": 187,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "last"
+          ],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
           "expr": "rpc_duration_seconds{quantile=\"$quantile\",instance=~\"$instance\"}",
           "interval": "",
-          "legendFormat": "rpc_duration_seconds: {{ method }} {{ instance }}",
+          "legendFormat": " {{ method }} {{ instance }} {{ success }}",
           "refId": "A"
         }
       ],
       "title": "Timings",
       "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 88
+      },
+      "id": 188,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "expr": "go_goroutines{instance=~\"$instance\"}",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "go/goroutines: {{instance}}",
+          "refId": "A"
+        },
+        {
+          "expr": "go_threads{instance=~\"$instance\"}",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "go/threads: {{instance}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "GO Goroutines and Threads",
       "type": "timeseries"
     },
     {
@@ -3160,10 +3457,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 80
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 96
       },
       "id": 184,
       "options": {
@@ -3199,7 +3496,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 88
+        "y": 102
       },
       "id": 146,
       "panels": [
@@ -3898,7 +4195,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 89
+        "y": 103
       },
       "id": 75,
       "panels": [],
@@ -3962,7 +4259,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 90
+        "y": 104
       },
       "id": 96,
       "links": [],
@@ -4065,7 +4362,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 90
+        "y": 104
       },
       "id": 77,
       "links": [],
@@ -4123,7 +4420,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 96
+        "y": 110
       },
       "id": 4,
       "panels": [],
@@ -4167,7 +4464,7 @@
         "h": 3,
         "w": 4,
         "x": 0,
-        "y": 97
+        "y": 111
       },
       "id": 108,
       "interval": null,
@@ -4246,7 +4543,7 @@
         "h": 3,
         "w": 4,
         "x": 4,
-        "y": 97
+        "y": 111
       },
       "id": 111,
       "interval": null,
@@ -4326,7 +4623,7 @@
         "h": 3,
         "w": 4,
         "x": 8,
-        "y": 97
+        "y": 111
       },
       "id": 109,
       "interval": null,
@@ -4406,7 +4703,7 @@
         "h": 3,
         "w": 4,
         "x": 12,
-        "y": 97
+        "y": 111
       },
       "id": 113,
       "interval": null,
@@ -4485,7 +4782,7 @@
         "h": 3,
         "w": 4,
         "x": 16,
-        "y": 97
+        "y": 111
       },
       "id": 114,
       "interval": null,
@@ -4564,7 +4861,7 @@
         "h": 3,
         "w": 4,
         "x": 20,
-        "y": 97
+        "y": 111
       },
       "id": 115,
       "interval": null,
@@ -4664,7 +4961,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 100
+        "y": 114
       },
       "id": 110,
       "links": [],
@@ -4768,7 +5065,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 100
+        "y": 114
       },
       "id": 116,
       "links": [],
@@ -4872,7 +5169,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 106
+        "y": 120
       },
       "id": 117,
       "links": [],
@@ -5000,7 +5297,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 113
+        "y": 127
       },
       "id": 138,
       "panels": [
@@ -5110,7 +5407,7 @@
       "type": "row"
     }
   ],
-  "refresh": "30s",
+  "refresh": false,
   "schemaVersion": 30,
   "style": "dark",
   "tags": [],
@@ -5165,14 +5462,12 @@
       {
         "allValue": null,
         "current": {
-          "selected": true,
+          "selected": false,
           "text": [
-            "turbogeth16c.weblogix.it:6060",
-            "turbogeth16c.weblogix.it:6061"
+            "turbogeth16c.weblogix.it:6060"
           ],
           "value": [
-            "turbogeth16c.weblogix.it:6060",
-            "turbogeth16c.weblogix.it:6061"
+            "turbogeth16c.weblogix.it:6060"
           ]
         },
         "datasource": "Prometheus",
@@ -5203,7 +5498,7 @@
         "auto_count": 30,
         "auto_min": "10s",
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "1m",
           "value": "1m"
         },
@@ -5278,8 +5573,8 @@
     ]
   },
   "time": {
-    "from": "now-2m",
-    "to": "now"
+    "from": "2021-10-06T03:54:19.826Z",
+    "to": "2021-10-06T04:08:12.196Z"
   },
   "timepicker": {
     "refresh_intervals": [
@@ -5308,5 +5603,5 @@
   "timezone": "",
   "title": "Erigon Prometheus",
   "uid": "FPpjH6Hik",
-  "version": 45
+  "version": 50
 }

--- a/cmd/rpcdaemon/README.md
+++ b/cmd/rpcdaemon/README.md
@@ -66,8 +66,7 @@ INFO [date-time] HTTP endpoint opened url=localhost:8545...
 
 ### Healthcheck
 
-Running the daemon also opens an endpoint `/health` that provides a basic
-health check.
+Running the daemon also opens an endpoint `/health` that provides a basic health check.
 
 If the health check is successful it returns 200 OK.
 
@@ -90,9 +89,10 @@ Not adding a check disables that.
 **`known_block`** -- sets up the block that node has to know about. Requires
 `eth` namespace to be listed in `http.api`.
 
-Example request 
+Example request
 ```http POST http://localhost:8545/health --raw '{"min_peer_count": 3, "known_block": "0x1F"}'```
 Example response
+
 ```
 {
     "check_block": "HEALTHY",
@@ -100,7 +100,6 @@ Example response
     "min_peer_count": "HEALTHY"
 }
 ```
-
 
 ### Testing
 
@@ -452,7 +451,7 @@ Reduce `--private.api.ratelimit`
 ### Batch requests
 
 Currently batch requests are spawn multiple goroutines and process all sub-requests in parallel. To limit impact of 1
-huge batch to other users - added flag `--rpc.batch.concurrency` (default: 50). Increase it to process large batches
+huge batch to other users - added flag `--rpc.batch.concurrency` (default: 2). Increase it to process large batches
 faster.
 
 Known Issue: if at least 1 request is "stremable" (has parameter of type *jsoniter.Stream) - then whole batch will

--- a/cmd/rpcdaemon/README.md
+++ b/cmd/rpcdaemon/README.md
@@ -13,7 +13,7 @@
     * [Trace transactions progress](#trace-transactions-progress)
     * [Clients getting timeout, but server load is low](#clients-getting-timeout--but-server-load-is-low)
     * [Server load too high](#server-load-too-high)
-    * [Batch requests](#batch-requests)
+    * [Faster Batch requests](#faster-batch-requests)
 - [For Developers](#for-developers)
     * [Code generation](#code-generation)
 
@@ -448,7 +448,7 @@ Reduce `--private.api.ratelimit`
 
 [./docs/programmers_guide/db_faq.md](./docs/programmers_guide/db_faq.md)
 
-### Batch requests
+### Faster Batch requests
 
 Currently batch requests are spawn multiple goroutines and process all sub-requests in parallel. To limit impact of 1
 huge batch to other users - added flag `--rpc.batch.concurrency` (default: 2). Increase it to process large batches

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -93,7 +93,7 @@ func RootCommand() (*cobra.Command, *Flags) {
 	rootCmd.PersistentFlags().BoolVar(&cfg.WebsocketEnabled, "ws", false, "Enable Websockets")
 	rootCmd.PersistentFlags().BoolVar(&cfg.WebsocketCompression, "ws.compression", false, "Enable Websocket compression (RFC 7692)")
 	rootCmd.PersistentFlags().StringVar(&cfg.RpcAllowListFilePath, "rpc.accessList", "", "Specify granular (method-by-method) API allowlist")
-	rootCmd.PersistentFlags().UintVar(&cfg.RpcBatchConcurrency, "rpc.batch.concurrency", 50, "Does limit amount of goroutines to process 1 batch request. Means 1 bach request can't overload server. 1 batch still can have unlimited amount of request")
+	rootCmd.PersistentFlags().UintVar(&cfg.RpcBatchConcurrency, "rpc.batch.concurrency", 2, "Does limit amount of goroutines to process 1 batch request. Means 1 bach request can't overload server. 1 batch still can have unlimited amount of request")
 	rootCmd.PersistentFlags().BoolVar(&cfg.TraceCompatibility, "trace.compat", false, "Bug for bug compatibility with OE for trace_ routines")
 	rootCmd.PersistentFlags().BoolVar(&cfg.TxPoolV2, "txpool.v2", false, "experimental external txpool")
 	rootCmd.PersistentFlags().StringVar(&cfg.TxPoolApiAddr, "txpool.api.addr", "127.0.0.1:9090", "txpool api network address, for example: 127.0.0.1:9090")


### PR DESCRIPTION
Reason: 
- benchmark of large batches with fast sub-requests showed that high concurrency harming it.
- benchmark of much parallel batches also suffer from too high parallelism.
- value 2 still increasing throughput of batches with fast sub-requests 2 times. (value 4 increasing throughput 3 times, which is not great anymore, then further increasing must be done manually depending on traffic and server capacity).
- value 2 useful when batch has much sub-requests, but small sub-set of them is slow.
- users who have much slow sub-requests will need manually increase it - depend on their Server capacity.
