### PR TITLE
Add eth_call bench test

### DIFF
--- a/cmd/rpctest/main.go
+++ b/cmd/rpctest/main.go
@@ -50,6 +50,16 @@ func main() {
 		}
 	}
 
+	var benchEthCallCmd = &cobra.Command{
+		Use:   "benchEthCall",
+		Short: "",
+		Long:  ``,
+		Run: func(cmd *cobra.Command, args []string) {
+			rpctest.BenchEthCall(erigonURL, gethURL, needCompare, blockFrom, blockTo, recordFile, errorFile)
+		},
+	}
+	with(benchEthCallCmd, withErigonUrl, withGethUrl, withNeedCompare, withBlockNum, withRecord, withErrorFile)
+
 	var bench1Cmd = &cobra.Command{
 		Use:   "bench1",
 		Short: "",
@@ -250,6 +260,7 @@ func main() {
 	rootCmd.Flags().Uint64Var(&blockTo, "blockTo", 2101000, "Block number to end test generation at")
 
 	rootCmd.AddCommand(
+		benchEthCallCmd,
 		bench1Cmd,
 		bench2Cmd,
 		bench3Cmd,

--- a/cmd/rpctest/rpctest/bench_debugtracecall.go
+++ b/cmd/rpctest/rpctest/bench_debugtracecall.go
@@ -12,7 +12,6 @@ import (
 // but also can be used for comparing RPCDaemon with Geth
 // parameters:
 // needCompare - if false - doesn't call Erigon and doesn't compare responses
-// 		use false value - to generate vegeta files, it's faster but we can generate vegeta files for Geth and Erigon
 func BenchDebugTraceCall(erigonURL, gethURL string, needCompare bool, blockFrom uint64, blockTo uint64, recordFile string, errorFile string) {
 	setRoutes(erigonURL, gethURL)
 	var client = &http.Client{
@@ -94,7 +93,7 @@ func BenchDebugTraceCall(erigonURL, gethURL string, needCompare bool, blockFrom 
 
 			request := reqGen.debugTraceCall(tx.From, tx.To, &tx.Gas, &tx.GasPrice, &tx.Value, tx.Input, bn-1)
 			errCtx := fmt.Sprintf("block %d tx %s", bn, tx.Hash)
-			if err := requestAndCompare(request, "debug_traceCall", errCtx, reqGen, needCompare, rec, errs); err != nil {
+			if err := requestAndCompare(request, "debug_traceCall", errCtx, reqGen, needCompare, rec, errs, nil); err != nil {
 				fmt.Println(err)
 				return
 			}

--- a/cmd/rpctest/rpctest/bench_ethcall.go
+++ b/cmd/rpctest/rpctest/bench_ethcall.go
@@ -1,0 +1,117 @@
+package rpctest
+
+import (
+	"bufio"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+// BenchEthCall compares response of Erigon with Geth
+// but also can be used for comparing RPCDaemon with Geth or infura
+// parameters:
+// needCompare - if false - doesn't call Erigon and doesn't compare responses
+// 		    false value - to generate vegeta files, it's faster but we can generate vegeta files for Geth and Erigon
+//                  recordFile stores all eth_call returned with success
+//                  errorFile stores information when erigon and geth doesn't return same data
+func BenchEthCall(erigonURL, gethURL string, needCompare bool, blockFrom uint64, blockTo uint64, recordFile string, errorFile string) {
+	setRoutes(erigonURL, gethURL)
+	var client = &http.Client{
+		Timeout: time.Second * 600,
+	}
+
+	var rec *bufio.Writer
+	var errs *bufio.Writer
+	var resultsCh chan CallResult = nil
+	var nTransactions = 0
+
+	if errorFile != "" {
+		f, err := os.Create(errorFile)
+		if err != nil {
+			fmt.Printf("Cannot create file %s for errorFile: %v\n", errorFile, err)
+			return
+		}
+		defer f.Close()
+		errs = bufio.NewWriter(f)
+		defer errs.Flush()
+	}
+
+	if recordFile != "" {
+		frec, errRec := os.Create(recordFile)
+		if errRec != nil {
+			fmt.Printf("Cannot create file %s for errorFile: %v\n", recordFile, errRec)
+			return
+		}
+		defer frec.Close()
+		rec = bufio.NewWriter(frec)
+		defer rec.Flush()
+	}
+
+	if !needCompare {
+		resultsCh = make(chan CallResult, 1000)
+		defer close(resultsCh)
+		go vegetaWrite(true, []string{"eth_call"}, resultsCh)
+	}
+	var res CallResult
+
+	reqGen := &RequestGenerator{
+		client: client,
+	}
+
+	reqGen.reqID++
+
+	for bn := blockFrom; bn <= blockTo; bn++ {
+		reqGen.reqID++
+		var b EthBlockByNumber
+		res = reqGen.Erigon("eth_getBlockByNumber", reqGen.getBlockByNumber(bn), &b)
+		if res.Err != nil {
+			fmt.Printf("Could not retrieve block (Erigon) %d: %v\n", bn, res.Err)
+			return
+		}
+
+		if b.Error != nil {
+			fmt.Printf("Error retrieving block (Erigon): %d %s\n", b.Error.Code, b.Error.Message)
+			return
+		}
+
+		if needCompare {
+			var bg EthBlockByNumber
+			res = reqGen.Geth("eth_getBlockByNumber", reqGen.getBlockByNumber(bn), &bg)
+			if res.Err != nil {
+				fmt.Printf("Could not retrieve block (geth) %d: %v\n", bn, res.Err)
+				return
+			}
+			if bg.Error != nil {
+				fmt.Printf("Error retrieving block (geth): %d %s\n", bg.Error.Code, bg.Error.Message)
+				return
+			}
+			if !compareBlocks(&b, &bg) {
+				fmt.Printf("Block difference for %d\n", bn)
+				if rec != nil {
+					fmt.Fprintf(rec, "Block difference for block=%d\n", bn)
+					rec.Flush()
+					continue
+				} else {
+					return
+				}
+			}
+		}
+
+		for _, tx := range b.Result.Transactions {
+
+			reqGen.reqID++
+			nTransactions = nTransactions + 1
+
+			request := reqGen.ethCall(tx.From, tx.To, &tx.Gas, &tx.GasPrice, &tx.Value, tx.Input, bn-1)
+			errCtx := fmt.Sprintf(" bn=%d hash=%s", bn, tx.Hash)
+
+			if err := requestAndCompare(request, "eth_call", errCtx, reqGen, needCompare, rec, errs, resultsCh); err != nil {
+				fmt.Println(err)
+				return
+			}
+		}
+
+		fmt.Println("\nProcessed Transactions: ", nTransactions)
+	}
+}

--- a/cmd/rpctest/rpctest/bench_traceblock.go
+++ b/cmd/rpctest/rpctest/bench_traceblock.go
@@ -12,7 +12,6 @@ import (
 // but also can be used for comparing RPCDaemon with OpenEthereum
 // parameters:
 // needCompare - if false - doesn't call Erigon and doesn't compare responses
-// 		use false value - to generate vegeta files, it's faster but we can generate vegeta files for Geth and Erigon
 func BenchTraceBlock(erigonURL, oeURL string, needCompare bool, blockFrom uint64, blockTo uint64, recordFile string, errorFile string) {
 	setRoutes(erigonURL, oeURL)
 	var client = &http.Client{
@@ -74,7 +73,7 @@ func BenchTraceBlock(erigonURL, oeURL string, needCompare bool, blockFrom uint64
 		reqGen.reqID++
 		request := reqGen.traceBlock(bn)
 		errCtx := fmt.Sprintf("block %d", bn)
-		if err := requestAndCompare(request, "trace_block", errCtx, reqGen, needCompare, rec, errs); err != nil {
+		if err := requestAndCompare(request, "trace_block", errCtx, reqGen, needCompare, rec, errs, nil); err != nil {
 			fmt.Println(err)
 			return
 		}

--- a/cmd/rpctest/rpctest/bench_tracecall.go
+++ b/cmd/rpctest/rpctest/bench_tracecall.go
@@ -12,7 +12,6 @@ import (
 // but also can be used for comparing RPCDaemon with Geth
 // parameters:
 // needCompare - if false - doesn't call Erigon and doesn't compare responses
-// 		use false value - to generate vegeta files, it's faster but we can generate vegeta files for Geth and Erigon
 func BenchTraceCall(erigonURL, oeURL string, needCompare bool, blockFrom uint64, blockTo uint64, recordFile string, errorFile string) {
 	setRoutes(erigonURL, oeURL)
 	var client = &http.Client{
@@ -76,7 +75,7 @@ func BenchTraceCall(erigonURL, oeURL string, needCompare bool, blockFrom uint64,
 			reqGen.reqID++
 			request := reqGen.traceCall(tx.From, tx.To, &tx.Gas, &tx.GasPrice, &tx.Value, tx.Input, bn-1)
 			errCtx := fmt.Sprintf("block %d, tx %s", bn, tx.Hash)
-			if err := requestAndCompare(request, "trace_call", errCtx, reqGen, needCompare, rec, errs); err != nil {
+			if err := requestAndCompare(request, "trace_call", errCtx, reqGen, needCompare, rec, errs, nil); err != nil {
 				return
 			}
 		}

--- a/cmd/rpctest/rpctest/bench_tracecallmany.go
+++ b/cmd/rpctest/rpctest/bench_tracecallmany.go
@@ -15,7 +15,6 @@ import (
 // but also can be used for comparing RPCDaemon with Geth
 // parameters:
 // needCompare - if false - doesn't call Erigon and doesn't compare responses
-// 		use false value - to generate vegeta files, it's faster but we can generate vegeta files for Geth and Erigon
 func BenchTraceCallMany(erigonURL, oeURL string, needCompare bool, blockFrom uint64, blockTo uint64, recordFile string, errorFile string) {
 	setRoutes(erigonURL, oeURL)
 	var client = &http.Client{
@@ -95,7 +94,7 @@ func BenchTraceCallMany(erigonURL, oeURL string, needCompare bool, blockFrom uin
 
 		request := reqGen.traceCallMany(from, to, gas, gasPrice, value, data, bn-1)
 		errCtx := fmt.Sprintf("block %d", bn)
-		if err := requestAndCompare(request, "trace_callMany", errCtx, reqGen, needCompare, rec, errs); err != nil {
+		if err := requestAndCompare(request, "trace_callMany", errCtx, reqGen, needCompare, rec, errs, nil); err != nil {
 			fmt.Println(err)
 			return
 		}

--- a/cmd/rpctest/rpctest/bench_tracefilter.go
+++ b/cmd/rpctest/rpctest/bench_tracefilter.go
@@ -15,7 +15,6 @@ import (
 // but also can be used for comparing RPCDaemon with Geth
 // parameters:
 // needCompare - if false - doesn't call Erigon and doesn't compare responses
-// 		use false value - to generate vegeta files, it's faster but we can generate vegeta files for Geth and Erigon
 func BenchTraceFilter(erigonURL, oeURL string, needCompare bool, blockFrom uint64, blockTo uint64, recordFile string, errorFile string) {
 	setRoutes(erigonURL, oeURL)
 	var client = &http.Client{
@@ -96,14 +95,14 @@ func BenchTraceFilter(erigonURL, oeURL string, needCompare bool, blockFrom uint6
 				reqGen.reqID++
 				request := reqGen.traceFilterFrom(prevBn, bn, account)
 				errCtx := fmt.Sprintf("traceFilterFrom fromBlock %d, toBlock %d, fromAddress %x", prevBn, bn, account)
-				if err := requestAndCompare(request, "trace_filter", errCtx, reqGen, needCompare, rec, errs); err != nil {
+				if err := requestAndCompare(request, "trace_filter", errCtx, reqGen, needCompare, rec, errs, nil); err != nil {
 					fmt.Println(err)
 					return
 				}
 				reqGen.reqID++
 				request = reqGen.traceFilterTo(prevBn, bn, account)
 				errCtx = fmt.Sprintf("traceFilterTo fromBlock %d, toBlock %d, fromAddress %x", prevBn, bn, account)
-				if err := requestAndCompare(request, "trace_filter", errCtx, reqGen, needCompare, rec, errs); err != nil {
+				if err := requestAndCompare(request, "trace_filter", errCtx, reqGen, needCompare, rec, errs, nil); err != nil {
 					fmt.Println(err)
 					return
 				}
@@ -114,28 +113,28 @@ func BenchTraceFilter(erigonURL, oeURL string, needCompare bool, blockFrom uint6
 				reqGen.reqID++
 				request := reqGen.traceFilterUnion(prevBn, bn, from, to)
 				errCtx := fmt.Sprintf("traceFilterUnion fromBlock %d, toBlock %d, fromAddress %x, toAddress %x", prevBn, bn, from, to)
-				if err := requestAndCompare(request, "trace_filter", errCtx, reqGen, needCompare, rec, errs); err != nil {
+				if err := requestAndCompare(request, "trace_filter", errCtx, reqGen, needCompare, rec, errs, nil); err != nil {
 					fmt.Println(err)
 					return
 				}
 				reqGen.reqID++
 				request = reqGen.traceFilterAfter(prevBn, bn, 1)
 				errCtx = fmt.Sprintf("traceFilterAfter fromBlock %d, toBlock %d, after %x", prevBn, bn, 1)
-				if err := requestAndCompare(request, "trace_filter", errCtx, reqGen, needCompare, rec, errs); err != nil {
+				if err := requestAndCompare(request, "trace_filter", errCtx, reqGen, needCompare, rec, errs, nil); err != nil {
 					fmt.Println(err)
 					return
 				}
 				reqGen.reqID++
 				request = reqGen.traceFilterCount(prevBn, bn, 1)
 				errCtx = fmt.Sprintf("traceFilterCount fromBlock %d, toBlock %d, count %x", prevBn, bn, 1)
-				if err := requestAndCompare(request, "trace_filter", errCtx, reqGen, needCompare, rec, errs); err != nil {
+				if err := requestAndCompare(request, "trace_filter", errCtx, reqGen, needCompare, rec, errs, nil); err != nil {
 					fmt.Println(err)
 					return
 				}
 				reqGen.reqID++
 				request = reqGen.traceFilterCountAfter(prevBn, bn, 1, 1)
 				errCtx = fmt.Sprintf("traceFilterCountAfter fromBlock %d, toBlock %d, count %x, after %x", prevBn, bn, 1, 1)
-				if err := requestAndCompare(request, "trace_filter", errCtx, reqGen, needCompare, rec, errs); err != nil {
+				if err := requestAndCompare(request, "trace_filter", errCtx, reqGen, needCompare, rec, errs, nil); err != nil {
 					fmt.Println(err)
 					return
 				}

--- a/cmd/rpctest/rpctest/bench_tracereplaytransaction.go
+++ b/cmd/rpctest/rpctest/bench_tracereplaytransaction.go
@@ -59,7 +59,7 @@ func BenchTraceReplayTransaction(erigonUrl, gethUrl string, needCompare bool, bl
 			reqGen.reqID++
 			request := reqGen.traceReplayTransaction(tx.Hash)
 			errCtx := fmt.Sprintf("block %d, tx %s", bn, tx.Hash)
-			if err := requestAndCompare(request, "trace_replayTransaction", errCtx, reqGen, needCompare, rec, errs); err != nil {
+			if err := requestAndCompare(request, "trace_replayTransaction", errCtx, reqGen, needCompare, rec, errs, nil); err != nil {
 				fmt.Println(err)
 				return
 			}

--- a/cmd/rpctest/rpctest/bench_tracetransaction.go
+++ b/cmd/rpctest/rpctest/bench_tracetransaction.go
@@ -59,7 +59,7 @@ func BenchTraceTransaction(erigonUrl, gethUrl string, needCompare bool, blockFro
 			reqGen.reqID++
 			request := reqGen.traceTransaction(tx.Hash)
 			errCtx := fmt.Sprintf("block %d, tx %s", bn, tx.Hash)
-			if err := requestAndCompare(request, "debug_traceTransaction", errCtx, reqGen, needCompare, rec, errs); err != nil {
+			if err := requestAndCompare(request, "debug_traceTransaction", errCtx, reqGen, needCompare, rec, errs, nil); err != nil {
 				fmt.Println(err)
 				return
 			}

--- a/cmd/rpctest/rpctest/bench_txreceipts.go
+++ b/cmd/rpctest/rpctest/bench_txreceipts.go
@@ -12,7 +12,6 @@ import (
 // but also can be used for comparing RPCDaemon with Geth
 // parameters:
 // needCompare - if false - doesn't call Erigon and doesn't compare responses
-// 		use false value - to generate vegeta files, it's faster but we can generate vegeta files for Geth and Erigon
 func BenchTxReceipt(erigonURL, gethURL string, needCompare bool, blockFrom uint64, blockTo uint64, recordFile string, errorFile string) {
 	setRoutes(erigonURL, gethURL)
 	var client = &http.Client{
@@ -76,7 +75,7 @@ func BenchTxReceipt(erigonURL, gethURL string, needCompare bool, blockFrom uint6
 			reqGen.reqID++
 			request := reqGen.getTransactionReceipt(tx.Hash)
 			errCtx := fmt.Sprintf("block %d, tx %s", bn, tx.Hash)
-			if err := requestAndCompare(request, "eth_getTransactionReceipt", errCtx, reqGen, needCompare, rec, errs); err != nil {
+			if err := requestAndCompare(request, "eth_getTransactionReceipt", errCtx, reqGen, needCompare, rec, errs, nil); err != nil {
 				fmt.Println(err)
 				return
 			}

--- a/cmd/rpctest/rpctest/replay.go
+++ b/cmd/rpctest/rpctest/replay.go
@@ -33,21 +33,21 @@ func Replay(erigonURL string, recordFile string) error {
 		request := s.Text()
 		res = reqGen.Erigon2("", request)
 		if res.Err != nil {
-			return fmt.Errorf("Could not get replay for %s: %w", request, res.Err)
+			return fmt.Errorf("could not get replay for %s: %w", request, res.Err)
 		}
 		if errVal := res.Result.Get("error"); errVal != nil {
-			return fmt.Errorf("Error getting replay for %s: %d %s", request, errVal.GetInt("code"), errVal.GetStringBytes("message"))
+			return fmt.Errorf("error getting replay for %s: %d %s", request, errVal.GetInt("code"), errVal.GetStringBytes("message"))
 		}
 		s.Scan() // Advance to the expected response
 		expectedResult, err1 := fastjson.ParseBytes(s.Bytes())
 		if err1 != nil {
-			return fmt.Errorf("Could not parse expected result %s: %w", request, err1)
+			return fmt.Errorf("could not parse expected result %s: %w", request, err1)
 		}
 		if err := compareResults(res.Result, expectedResult); err != nil {
 			fmt.Printf("Different results for %s:\n %v\n", request, err)
 			fmt.Printf("\n\nTG response=================================\n%s\n", res.Response)
 			fmt.Printf("\n\nG response=================================\n%s\n", s.Bytes())
-			return fmt.Errorf("Different results for %s:\n %w", request, err)
+			return fmt.Errorf("different results for %s:\n %w", request, err)
 		}
 		s.Scan()
 		s.Scan() // Skip the extra new line between response and the next request

--- a/cmd/rpctest/rpctest/request_generator.go
+++ b/cmd/rpctest/rpctest/request_generator.go
@@ -219,6 +219,28 @@ func (g *RequestGenerator) traceReplayTransaction(hash string) string {
 	return fmt.Sprintf(template, hash, g.reqID)
 }
 
+func (g *RequestGenerator) ethCall(from common.Address, to *common.Address, gas *hexutil.Big, gasPrice *hexutil.Big, value *hexutil.Big, data hexutil.Bytes, bn uint64) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, `{ "jsonrpc": "2.0", "method": "eth_call", "params": [{"from":"0x%x"`, from)
+	if to != nil {
+		fmt.Fprintf(&sb, `,"to":"0x%x"`, *to)
+	}
+	if gas != nil {
+		fmt.Fprintf(&sb, `,"gas":"%s"`, gas)
+	}
+	if gasPrice != nil {
+		fmt.Fprintf(&sb, `,"gasPrice":"%s"`, gasPrice)
+	}
+	if len(data) > 0 {
+		fmt.Fprintf(&sb, `,"data":"%s"`, data)
+	}
+	if value != nil {
+		fmt.Fprintf(&sb, `,"value":"%s"`, value)
+	}
+	fmt.Fprintf(&sb, `},"0x%x"], "id":%d}`, bn, g.reqID)
+	return sb.String()
+}
+
 func (g *RequestGenerator) call(target string, method, body string, response interface{}) CallResult {
 	start := time.Now()
 	err := post(g.client, routes[target], body, response)

--- a/cmd/rpctest/rpctest/utils.go
+++ b/cmd/rpctest/rpctest/utils.go
@@ -185,24 +185,73 @@ func compareResults(trace, traceg *fastjson.Value) error {
 	return compareJsonValues("result", r, rg)
 }
 
-func requestAndCompare(request string, methodName string, errCtx string, reqGen *RequestGenerator, needCompare bool, rec *bufio.Writer, errs *bufio.Writer) error {
+func compareErrors(errVal *fastjson.Value, errValg *fastjson.Value, methodName string, errCtx string, errs *bufio.Writer) error {
+	if errVal != nil && errValg == nil {
+		if errs != nil {
+			fmt.Printf("different results for method %s, errCtx: %s\n", methodName, errCtx)
+			fmt.Fprintf(errs, "Different results for method %s, errCtx: %s\n", methodName, errCtx)
+			fmt.Fprintf(errs, "Result (Erigon) returns error code=%d message=%s, while G/OE returns OK\n", errVal.GetInt("code"), errVal.GetStringBytes("message"))
+			errs.Flush() // nolint:errcheck
+		} else {
+			return fmt.Errorf("different result (Erigon) returns error code=%d message=%s, while G/OE returns OK", errVal.GetInt("code"), errVal.GetStringBytes("message"))
+		}
+	} else if errVal == nil && errValg != nil {
+		if errs != nil {
+			fmt.Printf("different results for method %s, errCtx: %s\n", methodName, errCtx)
+			fmt.Fprintf(errs, "Different results for method %s, errCtx: %s\n", methodName, errCtx)
+			fmt.Fprintf(errs, "Result (Erigon) returns OK, while G/OE returns error code=%d message=%s\n", errValg.GetInt("code"), errValg.GetStringBytes("message"))
+			errs.Flush() // nolint:errcheck
+		} else {
+			return fmt.Errorf("different result (Erigon) returns OK, while G/OE returns error code=%d message=%s", errValg.GetInt("code"), errValg.GetStringBytes("message"))
+		}
+	} else {
+		s1 := strings.ToUpper(string((errVal.GetStringBytes("message"))))
+		s2 := strings.ToUpper(string((errValg.GetStringBytes("message"))))
+		if strings.Compare(s1, s2) != 0 {
+			if errs != nil {
+				fmt.Printf("different error-message for method %s, errCtx: %s\n", methodName, errCtx)
+				fmt.Fprintf(errs, "Different results for method %s, errCtx: %s\n", methodName, errCtx)
+				fmt.Fprintf(errs, "error-message (Erigon) returns message=%s, while G/OE returns message=%s\n", errVal.GetStringBytes("message"), errValg.GetStringBytes("message"))
+				errs.Flush() // nolint:errcheck
+			} else {
+				return fmt.Errorf("different error-message (Erigon) returns message=%s, while G/OE returns message=%s", errVal.GetStringBytes("message"), errValg.GetStringBytes("message"))
+			}
+		} else if errVal.GetInt("code") != errValg.GetInt("code") {
+			if errs != nil {
+				fmt.Printf("Different error-code for method %s, errCtx: %s\n", methodName, errCtx)
+				fmt.Fprintf(errs, "Different results for method %s, errCtx: %s\n", methodName, errCtx)
+				fmt.Fprintf(errs, "error-code (Erigon) returns code=%d, while G/OE returns code=%d\n", errVal.GetInt("code"), errValg.GetInt("code"))
+				errs.Flush() // nolint:errcheck
+			} else {
+				return fmt.Errorf("different error-code (Erigon) returns code=%d, while G/OE returns code=%d", errVal.GetInt("code"), errValg.GetInt("code"))
+			}
+		}
+	}
+	return nil
+}
+
+func requestAndCompare(request string, methodName string, errCtx string, reqGen *RequestGenerator, needCompare bool, rec *bufio.Writer, errs *bufio.Writer, channel chan CallResult) error {
 	recording := rec != nil
 	res := reqGen.Erigon2(methodName, request)
 	if res.Err != nil {
-		return fmt.Errorf("could not invoke %s (Erigon): %w\n", methodName, res.Err)
+		return fmt.Errorf("could not invoke %s (Erigon): %w", methodName, res.Err)
 	}
-	if errVal := res.Result.Get("error"); errVal != nil {
-		return fmt.Errorf("error invoking %s (Erigon): %d %s\n", methodName, errVal.GetInt("code"), errVal.GetStringBytes("message"))
+	errVal := res.Result.Get("error")
+	if errVal != nil {
+		if !needCompare && channel == nil {
+			return fmt.Errorf("error invoking %s (Erigon): %d %s", methodName, errVal.GetInt("code"), errVal.GetStringBytes("message"))
+		}
+	}
+	if channel != nil {
+		channel <- res
 	}
 	if needCompare {
 		resg := reqGen.Geth2(methodName, request)
 		if resg.Err != nil {
-			return fmt.Errorf("could not invoke %s (Geth/OE): %w\n", methodName, res.Err)
+			return fmt.Errorf("could not invoke %s (Geth/OE): %w", methodName, res.Err)
 		}
-		if errVal := resg.Result.Get("error"); errVal != nil {
-			return fmt.Errorf("error invoking %s (Geth/OE): %d %s\n", methodName, errVal.GetInt("code"), errVal.GetStringBytes("message"))
-		}
-		if resg.Err == nil && resg.Result.Get("error") == nil {
+		errValg := resg.Result.Get("error")
+		if errVal == nil && errValg == nil {
 			if err := compareResults(res.Result, resg.Result); err != nil {
 				recording = false
 				if errs != nil {
@@ -223,9 +272,11 @@ func requestAndCompare(request string, methodName string, errCtx string, reqGen 
 					oeRespFile, _ := os.Create("oe-response.json")         //nolint:errcheck
 					oeRespFile.Write(resg.Response)                        //nolint:errcheck
 					oeRespFile.Close()                                     //nolint:errcheck
-					return fmt.Errorf("different results for method %s, errCtx %s: %w\nRequest in file request.json, Erigon response in file erigon-response.json, Geth/OE response in file oe-response.json", methodName, errCtx, err)
+					return fmt.Errorf("different results for method %s, errCtx %s: %v\nRequest in file request.json, Erigon response in file erigon-response.json, Geth/OE response in file oe-response.json", methodName, errCtx, err)
 				}
 			}
+		} else {
+			return compareErrors(errVal, errValg, methodName, errCtx, errs)
 		}
 	}
 	if recording {


### PR DESCRIPTION
Add `eth_call` bench test
Refactor `requestAndCompare` to check errors and optionally write to Vegeta channel
Restore Vegeta file in `bench_EthGetLogs`

The `bench_EthCall` can be launched in four ways:
1) The test exits when first compare fails:
```
./rpctest benchEthCall --erigonUrl http://localhost:8545 --gethUrl http://localhost:51515 --needCompare --blockFrom 0 --blockTo 3000000
```
2) The test runs until all blocks are verified and reports on the error file all the differences:
```
./rpctest benchEthCall --erigonUrl http://localhost:8545 --gethUrl http://localhost:51515 --needCompare --blockFrom 0 --blockTo 3000000 --errorFile /tmp/report2409.txt
```
3) The test generates vegeta files (no comparison):
```
./rpctest benchEthCall --erigonUrl http://localhost:8545 --blockFrom 0 --blockTo 3000000 
```
4) The test generates record file containing request/response of each successful eth_call. The test exits at first error
```
./rpctest benchEthCall --erigonUrl http://localhost:8545 --blockFrom 0 --blockTo 3000000 --recordFile /tmp/record0
```