### PR TITLE
Enable DeveloperPeriodFlag

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1310,6 +1310,7 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *node.Config, cfg *ethconfig.Conf
 
 		// Create a new developer genesis block or reuse existing one
 		cfg.Genesis = core.DeveloperGenesisBlock(uint64(ctx.GlobalInt(DeveloperPeriodFlag.Name)), developer)
+		log.Info("Using custom developer period", "seconds", cfg.Genesis.Config.Clique.Period)
 		if !ctx.GlobalIsSet(MinerGasPriceFlag.Name) {
 			cfg.Miner.GasPrice = big.NewInt(1)
 		}

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -63,6 +63,7 @@ var DefaultFlags = []cli.Flag{
 	utils.StaticPeersFlag,
 	utils.MaxPeersFlag,
 	utils.ChainFlag,
+	utils.DeveloperPeriodFlag,
 	utils.VMEnableDebugFlag,
 	utils.NetworkIdFlag,
 	utils.FakePoWFlag,


### PR DESCRIPTION
Setting a period !=0 allows mining of empty blocks