### PR TITLE
Trace calls to precompiles if value is not zero

### DIFF
--- a/cmd/rpcdaemon/commands/trace_adhoc.go
+++ b/cmd/rpcdaemon/commands/trace_adhoc.go
@@ -270,7 +270,7 @@ func (ot *OeTracer) CaptureStart(depth int, from common.Address, to common.Addre
 			vmTrace.Code = code
 		}
 	}
-	if precompile && depth > 0 {
+	if precompile && depth > 0 && value.Sign() == 0 {
 		ot.precompile = true
 		return nil
 	}


### PR DESCRIPTION
Make it behave the same as in OE: https://github.com/openethereum/openethereum/blob/ac30783c8248ea6adc57f0e38c89a778659c26e9/crates/ethcore/src/trace/executive_tracer.rs#L47

```
        if depth != 0 && is_builtin && params.value.value() == U256::zero() {
            self.skip_one = true;
            return;
        }
```