### PR TITLE
Eth2 does not work with --prune.r.older=2_000_000

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,7 @@ Windows users may run erigon in 3 possible ways:
 ### Beacon Chain
 
 Erigon can be used as an execution-layer for beacon chain consensus clients (Eth2). Default configuration is ok. Eth2
-rely on availability of receipts - don't prune them: don't add character `r` to `--prune` flag or set
-large `--prune.r.older=2_000_000`.
+relies on availability of receipts - don't prune them: don't add character `r` to `--prune` flag. However, old receipes are not needed for Eth2 and you can safely prune them with `--prune.r.before=11184524` in combination with `--prune htc`.
 
 You must run the [JSON-RPC daemon](#json-rpc-daemon) in addition to the Erigon.
 


### PR DESCRIPTION
The recommended pruning parameter `--prune.r.older=2_000_000` prunes too many blocks to successfully sync an Eth2 client.

Some days ago, we were at block 13411141. That means with the above prune parameter, recipes of blocks older than 11411141 are pruned. This misses some required blocks, as the deposit contract was deployed at block 11184524 (for example see option `--contract-deployment-block` from https://docs.prylabs.network/docs/prysm-usage/parameters/)

Instead, use `--prune.r.before 11184524` option together with `--prune htc`