### PR TITLE
Add support to init private chain with custom genesis file

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"os"
 	"sync"
 
 	"github.com/holiman/uint256"
@@ -665,6 +666,27 @@ func DeveloperGenesisBlock(period uint64, faucet common.Address) *Genesis {
 			faucet:                           {Balance: new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(9))},
 		},
 	}
+}
+
+// ReadGenesis will read the given JSON format genesis file and return
+// the initialized Genesis structure
+func ReadGenesis(genesisPath string) (*Genesis, error) {
+	// Make sure we have a valid genesis JSON
+	if len(genesisPath) == 0 {
+		return nil, errors.New("must supply path to genesis JSON file")
+	}
+	file, err := os.Open(genesisPath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	genesis := new(Genesis)
+	if err := json.NewDecoder(file).Decode(genesis); err != nil {
+		return nil, err
+	}
+
+	return genesis, nil
 }
 
 func readPrealloc(filename string) GenesisAlloc {

--- a/params/config.go
+++ b/params/config.go
@@ -31,6 +31,7 @@ const (
 	RinkebyChainName = "rinkeby"
 	GoerliChainName  = "goerli"
 	DevChainName     = "dev"
+	PrivateChainName = "private"
 	ErigonMineName   = "erigonmine"
 	SokolChainName   = "sokol"
 	KovanChainName   = "kovan"

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -9,6 +9,7 @@ import (
 // DefaultFlags contains all flags that are used and supported by Erigon binary.
 var DefaultFlags = []cli.Flag{
 	utils.DataDirFlag,
+	utils.GenesisFlag,
 	utils.MdbxAugmentLimitFlag,
 	utils.EthashDatasetDirFlag,
 	utils.TxPoolDisableFlag,


### PR DESCRIPTION
Solves part of #2030 

This PR allows starting a private chain with a custom chain id and custom genesis file. Adding genesis to `dev` chain would be done in another PR.

Currently I am trying to debug the following erroneous situations
- [ ] Transaction made to one of the miners via metamask is not being picked up by the RPC Daemon, though it's clearly visible in the txpool

That said @AskAlexSharov can you please give this PR a preliminary review? Thanks.