### PR TITLE
Fix header skeleton

### DIFF
--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -572,6 +572,9 @@ func (hd *HeaderDownload) RequestSkeleton() *HeaderRequest {
 	log.Trace("Request skeleton", "anchors", len(hd.anchors), "top seen height", hd.topSeenHeight, "highestInDb", hd.highestInDb)
 	stride := uint64(8 * 192)
 	queryRange := hd.topSeenHeight
+	if queryRange <= hd.highestInDb {
+		return nil
+	}
 	// Determine the query range as the height of lowest anchor
 	for _, anchor := range hd.anchors {
 		if anchor.blockHeight > hd.highestInDb && anchor.blockHeight < queryRange {
@@ -581,9 +584,6 @@ func (hd *HeaderDownload) RequestSkeleton() *HeaderRequest {
 	length := (queryRange - hd.highestInDb) / stride
 	if length > 192 {
 		length = 192
-	}
-	if length == 0 {
-		return nil
 	}
 	return &HeaderRequest{Number: hd.highestInDb + stride, Length: length, Skip: stride, Reverse: false}
 }

--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -571,21 +571,22 @@ func (hd *HeaderDownload) RequestSkeleton() *HeaderRequest {
 	defer hd.lock.RUnlock()
 	log.Trace("Request skeleton", "anchors", len(hd.anchors), "top seen height", hd.topSeenHeight, "highestInDb", hd.highestInDb)
 	stride := uint64(8 * 192)
-	maxHeight := hd.topSeenHeight
-	if maxHeight <= hd.highestInDb {
+	nextHeight := hd.highestInDb + stride
+	maxHeight := hd.topSeenHeight + 1 // Inclusive upper bound
+	if maxHeight <= nextHeight {
 		return nil
 	}
 	// Determine the query range as the height of lowest anchor
 	for _, anchor := range hd.anchors {
-		if anchor.blockHeight > hd.highestInDb && anchor.blockHeight < maxHeight {
-			maxHeight = anchor.blockHeight
+		if anchor.blockHeight > nextHeight && anchor.blockHeight < maxHeight {
+			maxHeight = anchor.blockHeight // Exclusive upper bound
 		}
 	}
-	length := (maxHeight - hd.highestInDb) / stride
+	length := (maxHeight - nextHeight) / stride
 	if length > 192 {
 		length = 192
 	}
-	return &HeaderRequest{Number: hd.highestInDb + stride, Length: length, Skip: stride, Reverse: false}
+	return &HeaderRequest{Number: nextHeight, Length: length, Skip: stride - 1, Reverse: false}
 }
 
 // InsertHeaders attempts to insert headers into the database, verifying them first

--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -571,17 +571,17 @@ func (hd *HeaderDownload) RequestSkeleton() *HeaderRequest {
 	defer hd.lock.RUnlock()
 	log.Trace("Request skeleton", "anchors", len(hd.anchors), "top seen height", hd.topSeenHeight, "highestInDb", hd.highestInDb)
 	stride := uint64(8 * 192)
-	queryRange := hd.topSeenHeight
-	if queryRange <= hd.highestInDb {
+	maxHeight := hd.topSeenHeight
+	if maxHeight <= hd.highestInDb {
 		return nil
 	}
 	// Determine the query range as the height of lowest anchor
 	for _, anchor := range hd.anchors {
-		if anchor.blockHeight > hd.highestInDb && anchor.blockHeight < queryRange {
-			queryRange = anchor.blockHeight
+		if anchor.blockHeight > hd.highestInDb && anchor.blockHeight < maxHeight {
+			maxHeight = anchor.blockHeight
 		}
 	}
-	length := (queryRange - hd.highestInDb) / stride
+	length := (maxHeight - hd.highestInDb) / stride
 	if length > 192 {
 		length = 192
 	}


### PR DESCRIPTION
Multiple edge-cases here. Commits are split up to make the changes more readable. The first commit fixes just the underflow problem, while retaining the original logic.

Third commit changes the logic, to how I believe `RequestSkeleton()` was intended to work.