### PR TITLE
Fix SendHeaderRequest peer minBlock

### DIFF
--- a/cmd/sentry/download/sentry_api.go
+++ b/cmd/sentry/download/sentry_api.go
@@ -106,7 +106,7 @@ func (cs *ControlServerImpl) SendHeaderRequest(ctx context.Context, req *headerd
 			}
 			minBlock := req.Number
 			if !req.Reverse {
-				minBlock = req.Number + req.Length*req.Skip
+				minBlock = req.Number + (req.Length-1)*(req.Skip+1)
 			}
 
 			outreq := proto_sentry.SendMessageByMinBlockRequest{


### PR DESCRIPTION
The `Skip` parameter of the Eth API is unintuitive, and easy to assume as an offset or multiple.  `Length` already includes the base block, so it needs to be `Length - 1` here.

This would have been causing valid peer choices to be ignored as header sources, especially when close to the current head, resulting in a synched node repeatedly falling out of synch (before catching up again).