### PR TITLE
Add trusted peers flag

### DIFF
--- a/cmd/sentry/commands/sentry.go
+++ b/cmd/sentry/commands/sentry.go
@@ -22,6 +22,7 @@ var (
 	natSetting   string   // NAT setting
 	port         int      // Listening port
 	staticPeers  []string // static peers
+	trustedPeers []string // trusted peers
 	discoveryDNS []string
 	nodiscover   bool // disable sentry's discovery mechanism
 	protocol     string
@@ -43,6 +44,7 @@ func init() {
 	rootCmd.Flags().StringVar(&sentryAddr, "sentry.api.addr", "localhost:9091", "grpc addresses")
 	rootCmd.Flags().StringVar(&protocol, "p2p.protocol", "eth66", "eth66")
 	rootCmd.Flags().StringSliceVar(&staticPeers, "staticpeers", []string{}, "static peer list [enode]")
+	rootCmd.Flags().StringSliceVar(&trustedPeers, "trustedpeers", []string{}, "trusted peer list [enode]")
 	rootCmd.Flags().StringSliceVar(&discoveryDNS, utils.DNSDiscoveryFlag.Name, []string{}, utils.DNSDiscoveryFlag.Usage)
 	rootCmd.Flags().BoolVar(&nodiscover, utils.NoDiscoverFlag.Name, false, utils.NoDiscoverFlag.Usage)
 	rootCmd.Flags().StringVar(&netRestrict, "netrestrict", "", "CIDR range to accept peers from <CIDR>")
@@ -71,7 +73,7 @@ var rootCmd = &cobra.Command{
 		p := eth.ETH66
 
 		nodeConfig := node2.NewNodeConfig()
-		p2pConfig, err := utils.NewP2PConfig(nodiscover, datadir, netRestrict, natSetting, nodeConfig.NodeName(), staticPeers, uint(port), uint(p))
+		p2pConfig, err := utils.NewP2PConfig(nodiscover, datadir, netRestrict, natSetting, nodeConfig.NodeName(), staticPeers, trustedPeers, uint(port), uint(p))
 		if err != nil {
 			return err
 		}

--- a/cmd/sentry/download/sentry.go
+++ b/cmd/sentry/download/sentry.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ledgerwatch/erigon-lib/gointerfaces/grpcutil"
 	proto_sentry "github.com/ledgerwatch/erigon-lib/gointerfaces/sentry"
 	proto_types "github.com/ledgerwatch/erigon-lib/gointerfaces/types"
+	"github.com/ledgerwatch/erigon/cmd/utils"
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/common/debug"
 	"github.com/ledgerwatch/erigon/core/forkid"
@@ -123,17 +124,7 @@ func makeP2PServer(
 	case params.FermionGenesisHash:
 		urls = params.FermionBootnodes
 	}
-	p2pConfig.BootstrapNodes = make([]*enode.Node, 0, len(urls))
-	for _, url := range urls {
-		if url != "" {
-			node, err := enode.Parse(enode.ValidSchemes, url)
-			if err != nil {
-				log.Crit("Bootstrap URL invalid", "enode", url, "err", err)
-				continue
-			}
-			p2pConfig.BootstrapNodes = append(p2pConfig.BootstrapNodes, node)
-		}
-	}
+	p2pConfig.BootstrapNodes, _ = utils.GetUrlListNodes(urls, utils.BootnodesFlag.Name, log.Crit)
 	p2pConfig.BootstrapNodesV5 = p2pConfig.BootstrapNodes
 	p2pConfig.Protocols = []p2p.Protocol{protocol}
 	return &p2p.Server{Config: p2pConfig}, nil

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -606,17 +606,7 @@ func setBootstrapNodes(ctx *cli.Context, cfg *p2p.Config) {
 		}
 	}
 
-	cfg.BootstrapNodes = make([]*enode.Node, 0, len(urls))
-	for _, url := range urls {
-		if url != "" {
-			node, err := enode.Parse(enode.ValidSchemes, url)
-			if err != nil {
-				log.Crit("Bootstrap URL invalid", "enode", url, "err", err)
-				continue
-			}
-			cfg.BootstrapNodes = append(cfg.BootstrapNodes, node)
-		}
-	}
+	cfg.BootstrapNodes, _ = GetUrlListNodes(urls, BootnodesFlag.Name, log.Crit)
 }
 
 // setBootstrapNodesV5 creates a list of bootstrap nodes from the command line
@@ -650,42 +640,43 @@ func setBootstrapNodesV5(ctx *cli.Context, cfg *p2p.Config) {
 		}
 	}
 
-	cfg.BootstrapNodesV5 = make([]*enode.Node, 0, len(urls))
+	cfg.BootstrapNodesV5, _ = GetUrlListNodes(urls, BootnodesFlag.Name, log.Error)
+}
+
+func setStaticPeers(ctx *cli.Context, cfg *p2p.Config) {
+	cfg.StaticNodes, _ = appendCfgUrlListNodes(cfg.StaticNodes, ctx, StaticPeersFlag.Name, log.Error)
+}
+
+func appendCfgUrlListNodes(nodes []*enode.Node, ctx *cli.Context, flagName string, logFn func(msg string, ctx ...interface{})) ([]*enode.Node, error) {
+	if ctx.GlobalIsSet(flagName) {
+		urls := SplitAndTrim(ctx.GlobalString(flagName))
+		return appendUrlListNodes(nodes, urls, flagName, logFn)
+	}
+	return nodes, nil
+}
+
+func GetUrlListNodes(urls []string, nodeType string, logFn func(msg string, ctx ...interface{})) (_ []*enode.Node, retErr error) {
+	return appendUrlListNodes(nil, urls, nodeType, logFn)
+}
+
+func appendUrlListNodes(nodes []*enode.Node, urls []string, nodeType string, logFn func(msg string, ctx ...interface{})) (_ []*enode.Node, retErr error) {
+	if nodes == nil {
+		nodes = make([]*enode.Node, 0, len(urls))
+	}
 	for _, url := range urls {
 		if url != "" {
 			node, err := enode.Parse(enode.ValidSchemes, url)
 			if err != nil {
-				log.Error("Bootstrap URL invalid", "enode", url, "err", err)
-				continue
+				retErr = err
+				if logFn != nil {
+					logFn(fmt.Sprintf("%s URL invalid", nodeType), "url", url, "err", err)
+				}
+			} else {
+				nodes = append(nodes, node)
 			}
-			cfg.BootstrapNodesV5 = append(cfg.BootstrapNodesV5, node)
 		}
 	}
-}
-
-func setStaticPeers(ctx *cli.Context, cfg *p2p.Config) {
-	if !ctx.GlobalIsSet(StaticPeersFlag.Name) {
-		return
-	}
-	urls := SplitAndTrim(ctx.GlobalString(StaticPeersFlag.Name))
-	err := SetStaticPeers(cfg, urls)
-	if err != nil {
-		log.Error("setStaticPeers", "err", err)
-	}
-}
-
-func SetStaticPeers(cfg *p2p.Config, urls []string) error {
-	for _, url := range urls {
-		if url == "" {
-			continue
-		}
-		node, err := enode.Parse(enode.ValidSchemes, url)
-		if err != nil {
-			return fmt.Errorf("static peer URL invalid: %s, %w", url, err)
-		}
-		cfg.StaticNodes = append(cfg.StaticNodes, node)
-	}
-	return nil
+	return nodes, retErr
 }
 
 // NewP2PConfig
@@ -715,9 +706,11 @@ func NewP2PConfig(nodiscover bool, datadir, netRestrict, natSetting, nodeName st
 		cfg.NetRestrict.Add(netRestrict)
 	}
 	if staticPeers != nil {
-		if err := SetStaticPeers(cfg, staticPeers); err != nil {
+		staticNodes, err := GetUrlListNodes(staticPeers, StaticPeersFlag.Name, log.Error)
+		if err != nil {
 			return nil, err
 		}
+		cfg.StaticNodes = staticNodes
 	}
 	natif, err := nat.Parse(natSetting)
 	if err != nil {

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -55,6 +55,7 @@ var DefaultFlags = []cli.Flag{
 	utils.NodeKeyHexFlag,
 	utils.DNSDiscoveryFlag,
 	utils.StaticPeersFlag,
+	utils.TrustedPeersFlag,
 	utils.MaxPeersFlag,
 	utils.ChainFlag,
 	utils.DeveloperPeriodFlag,


### PR DESCRIPTION
Refactored the enode url list parsing first, as there was a lot of duplication and almost-duplication (eg. `log.Error` vs `log.Crit`, and returning with an error if a one url was invalid vs ignoring just that url).

Trusted peers were already supported at runtime, but they just needed to have a flag exposed to configure them from the CLI.