### PR TITLE
Avoid a redundant rlpHash() in FeedHeader()

### DIFF
--- a/turbo/stages/headerdownload/header_algo_test.go
+++ b/turbo/stages/headerdownload/header_algo_test.go
@@ -36,17 +36,22 @@ func TestInserter1(t *testing.T) {
 	}
 	defer tx.Rollback()
 	hi := NewHeaderInserter("headers", big.NewInt(0), 0)
-	var h1, h2 types.Header
-	h1.Number = big.NewInt(1)
-	h1.Difficulty = big.NewInt(10)
-	h1.ParentHash = genesis.Hash()
-	h2.Number = big.NewInt(2)
-	h2.Difficulty = big.NewInt(1010)
-	h2.ParentHash = h1.Hash()
-	if err = hi.FeedHeader(tx, &h1, 1); err != nil {
+	h1 := types.Header{
+		Number:     big.NewInt(1),
+		Difficulty: big.NewInt(10),
+		ParentHash: genesis.Hash(),
+	}
+	h1Hash := h1.Hash()
+	h2 := types.Header{
+		Number:     big.NewInt(2),
+		Difficulty: big.NewInt(1010),
+		ParentHash: h1Hash,
+	}
+	h2Hash := h2.Hash()
+	if err = hi.FeedHeader(tx, &h1, h1Hash, 1); err != nil {
 		t.Errorf("feed empty header 1: %v", err)
 	}
-	if err = hi.FeedHeader(tx, &h2, 2); err != nil {
+	if err = hi.FeedHeader(tx, &h2, h2Hash, 2); err != nil {
 		t.Errorf("feed empty header 2: %v", err)
 	}
 }


### PR DESCRIPTION
Plenty more of these, but this was a trivial one.