### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Windows users may run erigon in 3 possible ways:
     * [Git](https://git-scm.com/downloads) for Windows must be installed. If you're cloning this repository is very
       likely you already have it
     * [GO Programming Language](https://golang.org/dl/) must be installed. Minimum required version is 1.16
+    * GNU CC Compiler at least version 10 (is highly suggested that you install `chocolatey` package manager - see
+      following point)
     * If you need to build MDBX tools (i.e. `.\wmake.ps1 db-tools`)
       then [Chocolatey package manager](https://chocolatey.org/) for Windows must be installed. By Chocolatey you need
       to install the following components : `cmake`, `make`, `mingw` by `choco install cmake make mingw`.


### PR DESCRIPTION
Rationale : CGO needs a GCC compiler