### PR TITLE
eth_getTransactionReceipt not to return unrelated different tx receipts

### DIFF
--- a/cmd/rpcdaemon/commands/eth_receipts.go
+++ b/cmd/rpcdaemon/commands/eth_receipts.go
@@ -265,11 +265,16 @@ func (api *APIImpl) GetTransactionReceipt(ctx context.Context, hash common.Hash)
 		return nil, fmt.Errorf("could not find block  %d", *blockNumber)
 	}
 	var txIndex uint64
+	var found bool
 	for idx, txn := range block.Transactions() {
 		if txn.Hash() == hash {
 			txIndex = uint64(idx)
+			found = true
 			break
 		}
+	}
+	if !found {
+		return nil, nil
 	}
 
 	cc, err := api.chainConfig(tx)

--- a/eth/stagedsync/stage_txlookup.go
+++ b/eth/stagedsync/stage_txlookup.go
@@ -152,7 +152,9 @@ func unwindTxLookup(u *UnwindState, s *StageState, tx kv.RwTx, cfg TxLookupCfg, 
 	}, etl.IdentityLoadFunc, etl.TransformArgs{
 		Quit:            quitCh,
 		ExtractStartKey: dbutils.EncodeBlockNumber(u.UnwindPoint + 1),
-		ExtractEndKey:   dbutils.EncodeBlockNumber(s.BlockNumber),
+		// end key needs to be s.BlockNumber + 1 and not s.BlockNumber, because
+		// the keys in BlockBody table always have hash after the block number
+		ExtractEndKey: dbutils.EncodeBlockNumber(s.BlockNumber + 1),
 		LogDetailsExtract: func(k, v []byte) (additionalLogArguments []interface{}) {
 			return []interface{}{"block", binary.BigEndian.Uint64(k)}
 		},


### PR DESCRIPTION
* Cleanup

* Restore

* Fix for existing tx

* Cleanup

Co-authored-by: Alex Sharp <alexsharp@Alexs-MacBook-Pro.local>