### PR TITLE
ChainSegment efficiency

### DIFF
--- a/cmd/sentry/download/downloader.go
+++ b/cmd/sentry/download/downloader.go
@@ -522,7 +522,7 @@ func (cs *ControlServerImpl) blockHeaders(ctx context.Context, pkt eth.BlockHead
 		csHeaders = append(csHeaders, headerdownload.ChainSegmentHeader{
 			Header:    header,
 			HeaderRaw: headerRaw,
-			Hash:      header.Hash(),
+			Hash:      types.RawRlpHash(headerRaw),
 			Number:    number,
 		})
 	}

--- a/cmd/sentry/download/downloader.go
+++ b/cmd/sentry/download/downloader.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ledgerwatch/erigon-lib/direct"
 	"github.com/ledgerwatch/erigon-lib/gointerfaces"
 	proto_sentry "github.com/ledgerwatch/erigon-lib/gointerfaces/sentry"
+	proto_types "github.com/ledgerwatch/erigon-lib/gointerfaces/types"
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/consensus"
@@ -468,7 +469,13 @@ func (cs *ControlServerImpl) newBlockHashes65(ctx context.Context, req *proto_se
 }
 
 func (cs *ControlServerImpl) blockHeaders66(ctx context.Context, in *proto_sentry.InboundMessage, sentry direct.SentryClient) error {
-	// Extract header from the block
+	// Parse the entire packet from scratch
+	var pkt eth.BlockHeadersPacket66
+	if err := rlp.DecodeBytes(in.Data, &pkt); err != nil {
+		return fmt.Errorf("decode 1 BlockHeadersPacket66: %w", err)
+	}
+
+	// Prepare to extract raw headers from the block
 	rlpStream := rlp.NewStream(bytes.NewReader(in.Data), uint64(len(in.Data)))
 	if _, err := rlpStream.List(); err != nil { // Now stream is at the beginning of 66 object
 		return fmt.Errorf("decode 1 BlockHeadersPacket66: %w", err)
@@ -476,102 +483,43 @@ func (cs *ControlServerImpl) blockHeaders66(ctx context.Context, in *proto_sentr
 	if _, err := rlpStream.Uint(); err != nil { // Now stream is at the requestID field
 		return fmt.Errorf("decode 2 BlockHeadersPacket66: %w", err)
 	}
-	if _, err := rlpStream.List(); err != nil { // Now stream is at the BlockHeadersPacket, which is list of headers
-		return fmt.Errorf("decode 3 BlockHeadersPacket66: %w", err)
-	}
-	var headersRaw [][]byte
-	for headerRaw, err := rlpStream.Raw(); ; headerRaw, err = rlpStream.Raw() {
-		if err != nil {
-			if !errors.Is(err, rlp.EOL) {
-				return fmt.Errorf("decode 4 BlockHeadersPacket66: %w", err)
-			}
-			break
-		}
+	// Now stream is at the BlockHeadersPacket, which is list of headers
 
-		headersRaw = append(headersRaw, headerRaw)
-	}
-
-	// Parse the entire request from scratch
-	var request eth.BlockHeadersPacket66
-	if err := rlp.DecodeBytes(in.Data, &request); err != nil {
-		return fmt.Errorf("decode 5 BlockHeadersPacket66: %w", err)
-	}
-	headers := request.BlockHeadersPacket
-	var heighestBlock uint64
-	for _, h := range headers {
-		if h.Number.Uint64() > heighestBlock {
-			heighestBlock = h.Number.Uint64()
-		}
-	}
-
-	if segments, penalty, err := cs.Hd.SplitIntoSegments(headersRaw, headers); err == nil {
-		if penalty == headerdownload.NoPenalty {
-			var canRequestMore bool
-			for _, segment := range segments {
-				requestMore, penalties := cs.Hd.ProcessSegment(segment, false /* newBlock */, ConvertH256ToPeerID(in.PeerId))
-				canRequestMore = canRequestMore || requestMore
-				if len(penalties) > 0 {
-					cs.Penalize(ctx, penalties)
-				}
-			}
-
-			if canRequestMore {
-				currentTime := uint64(time.Now().Unix())
-				req, penalties := cs.Hd.RequestMoreHeaders(currentTime)
-				if req != nil {
-					if _, ok := cs.SendHeaderRequest(ctx, req); ok {
-						cs.Hd.SentRequest(req, currentTime, 5 /* timeout */)
-						log.Trace("Sent request", "height", req.Number)
-					}
-				}
-				cs.Penalize(ctx, penalties)
-			}
-		} else {
-			outreq := proto_sentry.PenalizePeerRequest{
-				PeerId:  in.PeerId,
-				Penalty: proto_sentry.PenaltyKind_Kick, // TODO: Extend penalty kinds
-			}
-			if _, err1 := sentry.PenalizePeer(ctx, &outreq, &grpc.EmptyCallOption{}); err1 != nil {
-				log.Error("Could not send penalty", "err", err1)
-			}
-		}
-	} else {
-		return fmt.Errorf("singleHeaderAsSegment failed: %w", err)
-	}
-	outreq := proto_sentry.PeerMinBlockRequest{
-		PeerId:   in.PeerId,
-		MinBlock: heighestBlock,
-	}
-	if _, err1 := sentry.PeerMinBlock(ctx, &outreq, &grpc.EmptyCallOption{}); err1 != nil {
-		log.Error("Could not send min block for peer", "err", err1)
-	}
-	return nil
+	return cs.blockHeaders(ctx, pkt.BlockHeadersPacket, rlpStream, in.PeerId, sentry)
 }
 
 func (cs *ControlServerImpl) blockHeaders65(ctx context.Context, in *proto_sentry.InboundMessage, sentry direct.SentryClient) error {
-	// Extract header from the block
-	rlpStream := rlp.NewStream(bytes.NewReader(in.Data), uint64(len(in.Data)))
-	if _, err := rlpStream.List(); err != nil { // Now stream is at the BlockHeadersPacket, which is list of headers
-		return fmt.Errorf("decode 3 BlockHeadersPacket66: %w", err)
+	// Parse the entire packet from scratch
+	var pkt eth.BlockHeadersPacket
+	if err := rlp.DecodeBytes(in.Data, &pkt); err != nil {
+		return fmt.Errorf("decode 1 BlockHeadersPacket65: %w", err)
 	}
+
+	// Prepare to extract raw headers from the block
+	rlpStream := rlp.NewStream(bytes.NewReader(in.Data), uint64(len(in.Data)))
+	// Now stream is at the BlockHeadersPacket, which is list of headers
+
+	return cs.blockHeaders(ctx, pkt, rlpStream, in.PeerId, sentry)
+}
+
+func (cs *ControlServerImpl) blockHeaders(ctx context.Context, pkt eth.BlockHeadersPacket, rlpStream *rlp.Stream, peerID *proto_types.H256, sentry direct.SentryClient) error {
+	// Stream is at the BlockHeadersPacket, which is list of headers
+	if _, err := rlpStream.List(); err != nil {
+		return fmt.Errorf("decode 2 BlockHeadersPacket65: %w", err)
+	}
+	// Extract headers from the block
 	var headersRaw [][]byte
 	for headerRaw, err := rlpStream.Raw(); ; headerRaw, err = rlpStream.Raw() {
 		if err != nil {
 			if !errors.Is(err, rlp.EOL) {
-				return fmt.Errorf("decode 4 BlockHeadersPacket66: %w", err)
+				return fmt.Errorf("decode 3 BlockHeadersPacket65: %w", err)
 			}
 			break
 		}
-
 		headersRaw = append(headersRaw, headerRaw)
 	}
 
-	// Parse the entire request from scratch
-	var request eth.BlockHeadersPacket
-	if err := rlp.DecodeBytes(in.Data, &request); err != nil {
-		return fmt.Errorf("decode 5 BlockHeadersPacket66: %w", err)
-	}
-	headers := request
+	headers := pkt
 	var heighestBlock uint64
 	for _, h := range headers {
 		if h.Number.Uint64() > heighestBlock {
@@ -583,7 +531,7 @@ func (cs *ControlServerImpl) blockHeaders65(ctx context.Context, in *proto_sentr
 		if penalty == headerdownload.NoPenalty {
 			var canRequestMore bool
 			for _, segment := range segments {
-				requestMore, penalties := cs.Hd.ProcessSegment(segment, false /* newBlock */, ConvertH256ToPeerID(in.PeerId))
+				requestMore, penalties := cs.Hd.ProcessSegment(segment, false /* newBlock */, ConvertH256ToPeerID(peerID))
 				canRequestMore = canRequestMore || requestMore
 				if len(penalties) > 0 {
 					cs.Penalize(ctx, penalties)
@@ -603,7 +551,7 @@ func (cs *ControlServerImpl) blockHeaders65(ctx context.Context, in *proto_sentr
 			}
 		} else {
 			outreq := proto_sentry.PenalizePeerRequest{
-				PeerId:  in.PeerId,
+				PeerId:  peerID,
 				Penalty: proto_sentry.PenaltyKind_Kick, // TODO: Extend penalty kinds
 			}
 			if _, err1 := sentry.PenalizePeer(ctx, &outreq, &grpc.EmptyCallOption{}); err1 != nil {
@@ -614,7 +562,7 @@ func (cs *ControlServerImpl) blockHeaders65(ctx context.Context, in *proto_sentr
 		return fmt.Errorf("singleHeaderAsSegment failed: %w", err)
 	}
 	outreq := proto_sentry.PeerMinBlockRequest{
-		PeerId:   in.PeerId,
+		PeerId:   peerID,
 		MinBlock: heighestBlock,
 	}
 	if _, err1 := sentry.PeerMinBlock(ctx, &outreq, &grpc.EmptyCallOption{}); err1 != nil {

--- a/core/types/hashing.go
+++ b/core/types/hashing.go
@@ -167,6 +167,15 @@ var hasherPool = sync.Pool{
 	},
 }
 
+func RawRlpHash(rawRlpData []byte) (h common.Hash) {
+	sha := hasherPool.Get().(crypto.KeccakState)
+	defer hasherPool.Put(sha)
+	sha.Reset()
+	sha.Write(rawRlpData) //nolint:errcheck
+	sha.Read(h[:])        //nolint:errcheck
+	return h
+}
+
 func rlpHash(x interface{}) (h common.Hash) {
 	sha := hasherPool.Get().(crypto.KeccakState)
 	defer hasherPool.Put(sha)

--- a/core/types/hashing.go
+++ b/core/types/hashing.go
@@ -167,7 +167,7 @@ var hasherPool = sync.Pool{
 	},
 }
 
-func RawRlpHash(rawRlpData []byte) (h common.Hash) {
+func RawRlpHash(rawRlpData rlp.RawValue) (h common.Hash) {
 	sha := hasherPool.Get().(crypto.KeccakState)
 	defer hasherPool.Put(sha)
 	sha.Reset()

--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -896,11 +896,10 @@ func (hd *HeaderDownload) ProcessSegment(segment ChainSegment, newBlock bool, pe
 		}
 		return
 	}
-	height := segment[len(segment)-1].Number
-	hash := segment[len(segment)-1].Hash
-	if newBlock || hd.seenAnnounces.Seen(hash) {
-		if height > hd.topSeenHeight {
-			hd.topSeenHeight = height
+	highest := segment[len(segment)-1]
+	if highest.Number > hd.topSeenHeight {
+		if newBlock || hd.seenAnnounces.Seen(highest.Hash) {
+			hd.topSeenHeight = highest.Number
 		}
 	}
 	startNum := segment[start].Number

--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -924,14 +924,12 @@ func (hd *HeaderDownload) ProcessSegment(segment ChainSegment, newBlock bool, pe
 			log.Trace("Extended Down", "start", startNum, "end", endNum)
 		}
 	} else if foundTip {
-		if end > 0 {
-			// ExtendUp
-			if err := hd.extendUp(segment, start, end); err != nil {
-				log.Debug("ExtendUp failed", "error", err)
-				return
-			}
-			log.Trace("Extended Up", "start", startNum, "end", endNum)
+		// ExtendUp
+		if err := hd.extendUp(segment, start, end); err != nil {
+			log.Debug("ExtendUp failed", "error", err)
+			return
 		}
+		log.Trace("Extended Up", "start", startNum, "end", endNum)
 	} else {
 		// NewAnchor
 		var err error

--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -158,7 +158,7 @@ func (hd *HeaderDownload) removeUpwards(toRemove []*Link) {
 	for len(toRemove) > 0 {
 		removal := toRemove[len(toRemove)-1]
 		toRemove = toRemove[:len(toRemove)-1]
-		delete(hd.links, removal.header.Hash())
+		delete(hd.links, removal.hash)
 		heap.Remove(hd.linkQueue, removal.idx)
 		toRemove = append(toRemove, removal.next...)
 	}
@@ -627,11 +627,11 @@ func (hd *HeaderDownload) InsertHeaders(hf func(header *types.Header, hash commo
 			if _, bad := hd.badHeaders[link.hash]; bad {
 				skip = true
 			} else if err := hd.engine.VerifyHeader(hd.headerReader, link.header, true /* seal */); err != nil {
-				log.Warn("Verification failed for header", "hash", link.header.Hash(), "height", link.blockHeight, "error", err)
+				log.Warn("Verification failed for header", "hash", link.hash, "height", link.blockHeight, "error", err)
 				if errors.Is(err, consensus.ErrFutureBlock) {
 					// This may become valid later
 					linksInFuture = append(linksInFuture, link)
-					log.Warn("Added future link", "hash", link.header.Hash(), "height", link.blockHeight, "timestamp", link.header.Time)
+					log.Warn("Added future link", "hash", link.hash, "height", link.blockHeight, "timestamp", link.header.Time)
 					continue // prevent removal of the link from the hd.linkQueue
 				} else {
 					skip = true

--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -100,7 +100,7 @@ func (hd *HeaderDownload) SingleHeaderAsSegment(headerRaw []byte, header *types.
 	hd.lock.RLock()
 	defer hd.lock.RUnlock()
 
-	headerHash := header.Hash()
+	headerHash := types.RawRlpHash(headerRaw)
 	if _, bad := hd.badHeaders[headerHash]; bad {
 		return nil, BadBlockPenalty, nil
 	}
@@ -497,7 +497,7 @@ func (hd *HeaderDownload) RecoverFromDb(db kv.RoDB) error {
 			h := ChainSegmentHeader{
 				HeaderRaw: v,
 				Header:    &header,
-				Hash:      header.Hash(),
+				Hash:      types.RawRlpHash(v),
 				Number:    header.Number.Uint64(),
 			}
 			hd.addHeaderAsLink(h, true /* persisted */)
@@ -1063,7 +1063,8 @@ func DecodeTips(encodings []string) (map[common.Hash]HeaderRecord, error) {
 			return nil, fmt.Errorf("parsing hard coded header on %d: %w", i, err)
 		}
 
-		hardTips[h.Hash()] = HeaderRecord{Raw: b, Header: &h}
+		headerHash := types.RawRlpHash(res)
+		hardTips[headerHash] = HeaderRecord{Raw: b, Header: &h}
 
 		buf.Reset()
 	}

--- a/turbo/stages/headerdownload/header_data_struct.go
+++ b/turbo/stages/headerdownload/header_data_struct.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ledgerwatch/erigon/consensus"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/p2p/enode"
+	"github.com/ledgerwatch/erigon/rlp"
 )
 
 // Link is a chain link that can be connect to other chain links
@@ -119,7 +120,7 @@ func (aq *AnchorQueue) Pop() interface{} {
 }
 
 type ChainSegmentHeader struct {
-	HeaderRaw []byte
+	HeaderRaw rlp.RawValue
 	Header    *types.Header
 	Hash      common.Hash
 	Number    uint64

--- a/turbo/stages/headerdownload/header_data_struct.go
+++ b/turbo/stages/headerdownload/header_data_struct.go
@@ -118,12 +118,16 @@ func (aq *AnchorQueue) Pop() interface{} {
 	return x
 }
 
+type ChainSegmentHeader struct {
+	HeaderRaw []byte
+	Header    *types.Header
+	Hash      common.Hash
+	Number    uint64
+}
+
 // First item in ChainSegment is the anchor
 // ChainSegment must be contigous and must not include bad headers
-type ChainSegment struct {
-	HeadersRaw [][]byte
-	Headers    []*types.Header
-}
+type ChainSegment []ChainSegmentHeader
 
 type PeerHandle int // This is int just for the PoC phase - will be replaced by more appropriate type to find a peer
 


### PR DESCRIPTION
Lots of optimizations here, mainly around avoiding redundant hashing, re-encoding RLP, map look-ups, and even just `big.Int` to `uint64` conversions. Aside from that, they also make the code a lot simpler.

As a result of the simplification, it also removes a latent bug in `SplitIntoSegments()` where `headersRaw` was being indexed with the sorted order of `headers`, despite not being sorted itself. `headersRaw` wasn't being used anywhere yet, so this bug had not yet manifested.