### PR TITLE
Add NodeInfo implementation

### DIFF
--- a/cmd/rpcdaemon/commands/admin_api.go
+++ b/cmd/rpcdaemon/commands/admin_api.go
@@ -1,0 +1,41 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/services"
+	"github.com/ledgerwatch/erigon/p2p"
+)
+
+// AdminAPI the interface for the admin_* RPC commands.
+type AdminAPI interface {
+	// NodeInfo returns a collection of metadata known about the host.
+	NodeInfo(ctx context.Context) (*p2p.NodeInfo, error)
+}
+
+// AdminAPIImpl data structure to store things needed for admin_* commands.
+type AdminAPIImpl struct {
+	ethBackend services.ApiBackend
+}
+
+// NewAdminAPI returns AdminAPIImpl instance.
+func NewAdminAPI(eth services.ApiBackend) *AdminAPIImpl {
+	return &AdminAPIImpl{
+		ethBackend: eth,
+	}
+}
+
+func (api *AdminAPIImpl) NodeInfo(ctx context.Context) (*p2p.NodeInfo, error) {
+	nodes, err := api.ethBackend.NodeInfo(ctx, 1)
+	if err != nil {
+		return nil, fmt.Errorf("node info request error: %w", err)
+	}
+
+	if len(nodes) == 0 {
+		return nil, errors.New("empty nodesInfo response")
+	}
+
+	return &nodes[0], nil
+}

--- a/cmd/rpcdaemon/commands/daemon.go
+++ b/cmd/rpcdaemon/commands/daemon.go
@@ -26,7 +26,7 @@ func APIList(ctx context.Context, db kv.RoDB,
 		base.EnableTevmExperiment()
 	}
 	ethImpl := NewEthAPI(base, db, eth, txPool, mining, cfg.Gascap)
-	erigonImpl := NewErigonAPI(base, db)
+	erigonImpl := NewErigonAPI(base, db, eth)
 	txpoolImpl := NewTxPoolAPI(base, db, txPool)
 	netImpl := NewNetAPIImpl(eth)
 	debugImpl := NewPrivateDebugAPI(base, db, cfg.Gascap)
@@ -34,6 +34,7 @@ func APIList(ctx context.Context, db kv.RoDB,
 	web3Impl := NewWeb3APIImpl(eth)
 	dbImpl := NewDBAPIImpl() /* deprecated */
 	engineImpl := NewEngineAPI(base, db, eth)
+	adminImpl := NewAdminAPI(eth)
 
 	for _, enabledAPI := range cfg.API {
 		switch enabledAPI {
@@ -98,6 +99,13 @@ func APIList(ctx context.Context, db kv.RoDB,
 				Namespace: "engine",
 				Public:    true,
 				Service:   EngineAPI(engineImpl),
+				Version:   "1.0",
+			})
+		case "admin":
+			defaultAPIList = append(defaultAPIList, rpc.API{
+				Namespace: "admin",
+				Public:    false,
+				Service:   AdminAPI(adminImpl),
 				Version:   "1.0",
 			})
 		}

--- a/cmd/rpcdaemon/commands/erigon_api.go
+++ b/cmd/rpcdaemon/commands/erigon_api.go
@@ -4,8 +4,10 @@ import (
 	"context"
 
 	"github.com/ledgerwatch/erigon-lib/kv"
+	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/services"
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/core/types"
+	"github.com/ledgerwatch/erigon/p2p"
 	"github.com/ledgerwatch/erigon/rpc"
 )
 
@@ -26,18 +28,23 @@ type ErigonAPI interface {
 	// BlockReward(ctx context.Context, blockNr rpc.BlockNumber) (Issuance, error)
 	// UncleReward(ctx context.Context, blockNr rpc.BlockNumber) (Issuance, error)
 	Issuance(ctx context.Context, blockNr rpc.BlockNumber) (Issuance, error)
+
+	// NodeInfo returns a collection of metadata known about the host.
+	NodeInfo(ctx context.Context) ([]p2p.NodeInfo, error)
 }
 
 // ErigonImpl is implementation of the ErigonAPI interface
 type ErigonImpl struct {
 	*BaseAPI
-	db kv.RoDB
+	db         kv.RoDB
+	ethBackend services.ApiBackend
 }
 
 // NewErigonAPI returns ErigonImpl instance
-func NewErigonAPI(base *BaseAPI, db kv.RoDB) *ErigonImpl {
+func NewErigonAPI(base *BaseAPI, db kv.RoDB, eth services.ApiBackend) *ErigonImpl {
 	return &ErigonImpl{
-		BaseAPI: base,
-		db:      db,
+		BaseAPI:    base,
+		db:         db,
+		ethBackend: eth,
 	}
 }

--- a/cmd/rpcdaemon/commands/erigon_nodeInfo.go
+++ b/cmd/rpcdaemon/commands/erigon_nodeInfo.go
@@ -1,0 +1,11 @@
+package commands
+
+import (
+	"context"
+
+	"github.com/ledgerwatch/erigon/p2p"
+)
+
+func (api *ErigonImpl) NodeInfo(ctx context.Context) ([]p2p.NodeInfo, error) {
+	return api.ethBackend.NodeInfo(ctx, 0)
+}

--- a/cmd/rpcdaemon/commands/erigon_nodeInfo.go
+++ b/cmd/rpcdaemon/commands/erigon_nodeInfo.go
@@ -6,6 +6,11 @@ import (
 	"github.com/ledgerwatch/erigon/p2p"
 )
 
+const (
+	// allNodesInfo used in NodeInfo request to receive meta data from all running sentries.
+	allNodesInfo = 0
+)
+
 func (api *ErigonImpl) NodeInfo(ctx context.Context) ([]p2p.NodeInfo, error) {
-	return api.ethBackend.NodeInfo(ctx, 0)
+	return api.ethBackend.NodeInfo(ctx, allNodesInfo)
 }

--- a/cmd/sentry/download/sentry.go
+++ b/cmd/sentry/download/sentry.go
@@ -3,6 +3,8 @@ package download
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -978,6 +980,33 @@ func (ss *SentryServerImpl) Peers(req *proto_sentry.PeersRequest, server proto_s
 	case <-server.Context().Done():
 		return nil
 	}
+}
+
+func (ss *SentryServerImpl) NodeInfo(_ context.Context, _ *emptypb.Empty) (*proto_types.NodeInfoReply, error) {
+	if ss.P2pServer == nil {
+		return nil, errors.New("p2p server was not started")
+	}
+
+	info := ss.P2pServer.NodeInfo()
+	ret := &proto_types.NodeInfoReply{
+		Id:    info.ID,
+		Name:  info.Name,
+		Enode: info.Enode,
+		Enr:   info.ENR,
+		Ports: &proto_types.NodeInfoPorts{
+			Discovery: uint32(info.Ports.Discovery),
+			Listener:  uint32(info.Ports.Listener),
+		},
+		ListenerAddr: info.ListenAddr,
+	}
+
+	protos, err := json.Marshal(info.Protocols)
+	if err != nil {
+		return nil, fmt.Errorf("cannot encode protocols map: %w", err)
+	}
+
+	ret.Protocols = protos
+	return ret, nil
 }
 
 // PeersStreams - it's safe to use this class as non-pointer

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path"
 	"reflect"
+	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -34,8 +35,10 @@ import (
 	"github.com/ledgerwatch/erigon-lib/direct"
 	"github.com/ledgerwatch/erigon-lib/etl"
 	"github.com/ledgerwatch/erigon-lib/gointerfaces/grpcutil"
+	"github.com/ledgerwatch/erigon-lib/gointerfaces/remote"
 	"github.com/ledgerwatch/erigon-lib/gointerfaces/sentry"
 	txpool_proto "github.com/ledgerwatch/erigon-lib/gointerfaces/txpool"
+	prototypes "github.com/ledgerwatch/erigon-lib/gointerfaces/types"
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon-lib/kv/kvcache"
 	"github.com/ledgerwatch/erigon-lib/kv/remotedbserver"
@@ -627,6 +630,29 @@ func (s *Ethereum) NetPeerCount() (uint64, error) {
 	}
 
 	return sentryPc, nil
+}
+
+func (s *Ethereum) NodesInfo(limit int) (*remote.NodesInfoReply, error) {
+	if limit == 0 || limit > len(s.sentries) {
+		limit = len(s.sentries)
+	}
+
+	nodes := make([]*prototypes.NodeInfoReply, 0, limit)
+	for i := 0; i < limit; i++ {
+		sc := s.sentries[i]
+
+		node, err := sc.NodeInfo(context.Background(), nil)
+		if err != nil {
+			log.Error("sentry nodeInfo", "err", err)
+		}
+
+		nodes = append(nodes, node)
+	}
+
+	nodesInfo := &remote.NodesInfoReply{NodesInfo: nodes}
+	sort.Sort(nodesInfo)
+
+	return nodesInfo, nil
 }
 
 // Protocols returns all the currently configured

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"path"
 	"reflect"
-	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -72,6 +71,7 @@ import (
 	"github.com/ledgerwatch/log/v3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"modernc.org/sortutil"
 )
 
 // Config contains the configuration options of the ETH protocol.
@@ -641,16 +641,16 @@ func (s *Ethereum) NodesInfo(limit int) (*remote.NodesInfoReply, error) {
 	for i := 0; i < limit; i++ {
 		sc := s.sentries[i]
 
-		node, err := sc.NodeInfo(context.Background(), nil)
+		nodeInfo, err := sc.NodeInfo(context.Background(), nil)
 		if err != nil {
 			log.Error("sentry nodeInfo", "err", err)
 		}
 
-		nodes = append(nodes, node)
+		nodes = append(nodes, nodeInfo)
 	}
 
 	nodesInfo := &remote.NodesInfoReply{NodesInfo: nodes}
-	sort.Sort(nodesInfo)
+	nodesInfo.NodesInfo = nodesInfo.NodesInfo[:sortutil.Dedupe(nodesInfo)]
 
 	return nodesInfo, nil
 }

--- a/eth/backend_test.go
+++ b/eth/backend_test.go
@@ -1,0 +1,108 @@
+package eth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ledgerwatch/erigon-lib/direct"
+	"github.com/ledgerwatch/erigon-lib/gointerfaces/sentry"
+	"github.com/ledgerwatch/erigon-lib/gointerfaces/types"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+func TestNodesInfo_Deduplication(t *testing.T) {
+	tests := []struct {
+		name  string
+		limit int
+		nodes []*types.NodeInfoReply
+		want  []*types.NodeInfoReply
+	}{
+		{
+			name:  "one node",
+			nodes: []*types.NodeInfoReply{{Name: "name", Enode: "enode"}},
+			want:  []*types.NodeInfoReply{{Name: "name", Enode: "enode"}},
+		},
+		{
+			name: "two different nodes",
+			nodes: []*types.NodeInfoReply{
+				{Name: "name", Enode: "enode"},
+				{Name: "name1", Enode: "enode1"},
+			},
+			want: []*types.NodeInfoReply{
+				{Name: "name", Enode: "enode"},
+				{Name: "name1", Enode: "enode1"},
+			},
+		},
+		{
+			name: "two same nodes",
+			nodes: []*types.NodeInfoReply{
+				{Name: "name", Enode: "enode"},
+				{Name: "name", Enode: "enode"},
+			},
+			want: []*types.NodeInfoReply{
+				{Name: "name", Enode: "enode"},
+			},
+		},
+		{
+			name: "three nodes",
+			nodes: []*types.NodeInfoReply{
+				{Name: "name", Enode: "enode"},
+				{Name: "name1", Enode: "enode1"},
+				{Name: "name2", Enode: "enode2"},
+			},
+			want: []*types.NodeInfoReply{
+				{Name: "name", Enode: "enode"},
+				{Name: "name1", Enode: "enode1"},
+				{Name: "name2", Enode: "enode2"},
+			},
+		},
+		{
+			name: "three nodes with repeats",
+			nodes: []*types.NodeInfoReply{
+				{Name: "name", Enode: "enode"},
+				{Name: "name", Enode: "enode"},
+				{Name: "name1", Enode: "enode1"},
+			},
+			want: []*types.NodeInfoReply{
+				{Name: "name", Enode: "enode"},
+				{Name: "name1", Enode: "enode1"},
+			},
+		},
+		{
+			name: "three same nodes",
+			nodes: []*types.NodeInfoReply{
+				{Name: "name", Enode: "enode"},
+				{Name: "name", Enode: "enode"},
+				{Name: "name", Enode: "enode"},
+			},
+			want: []*types.NodeInfoReply{
+				{Name: "name", Enode: "enode"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eth := Ethereum{}
+
+			for _, n := range tt.nodes {
+				n := n
+				eth.sentries = append(eth.sentries,
+					direct.NewSentryClientRemote(&sentry.SentryClientMock{
+						NodeInfoFunc: func(context.Context, *emptypb.Empty, ...grpc.CallOption) (*types.NodeInfoReply, error) {
+							return n, nil
+						},
+					}),
+				)
+			}
+
+			got, err := eth.NodesInfo(tt.limit)
+			if err != nil {
+				t.Error(err)
+			}
+
+			assert.Equal(t, tt.want, got.NodesInfo)
+		})
+	}
+}

--- a/eth/backend_test.go
+++ b/eth/backend_test.go
@@ -27,8 +27,8 @@ func TestNodesInfo_Deduplication(t *testing.T) {
 		{
 			name: "two different nodes",
 			nodes: []*types.NodeInfoReply{
-				{Name: "name", Enode: "enode"},
 				{Name: "name1", Enode: "enode1"},
+				{Name: "name", Enode: "enode"},
 			},
 			want: []*types.NodeInfoReply{
 				{Name: "name", Enode: "enode"},
@@ -48,9 +48,9 @@ func TestNodesInfo_Deduplication(t *testing.T) {
 		{
 			name: "three nodes",
 			nodes: []*types.NodeInfoReply{
+				{Name: "name2", Enode: "enode2"},
 				{Name: "name", Enode: "enode"},
 				{Name: "name1", Enode: "enode1"},
-				{Name: "name2", Enode: "enode2"},
 			},
 			want: []*types.NodeInfoReply{
 				{Name: "name", Enode: "enode"},
@@ -62,8 +62,8 @@ func TestNodesInfo_Deduplication(t *testing.T) {
 			name: "three nodes with repeats",
 			nodes: []*types.NodeInfoReply{
 				{Name: "name", Enode: "enode"},
-				{Name: "name", Enode: "enode"},
 				{Name: "name1", Enode: "enode1"},
+				{Name: "name", Enode: "enode"},
 			},
 			want: []*types.NodeInfoReply{
 				{Name: "name", Enode: "enode"},

--- a/ethdb/privateapi/ethbackend.go
+++ b/ethdb/privateapi/ethbackend.go
@@ -32,6 +32,7 @@ const (
 // EthBackendAPIVersion
 // 2.0.0 - move all mining-related methods to 'txpool/mining' server
 // 2.1.0 - add NetPeerCount function
+// 2.2.0 - add NodesInfo function
 var EthBackendAPIVersion = &types2.VersionReply{Major: 2, Minor: 1, Patch: 0}
 
 type EthBackendServer struct {

--- a/ethdb/privateapi/ethbackend.go
+++ b/ethdb/privateapi/ethbackend.go
@@ -60,6 +60,7 @@ type EthBackend interface {
 	Etherbase() (common.Address, error)
 	NetVersion() (uint64, error)
 	NetPeerCount() (uint64, error)
+	NodesInfo(limit int) (*remote.NodesInfoReply, error)
 }
 
 // This is the status of a newly execute block.
@@ -287,4 +288,12 @@ func (s *EthBackendServer) EngineGetPayloadV1(ctx context.Context, req *remote.E
 		return &payload, nil
 	}
 	return nil, fmt.Errorf("unknown payload")
+}
+
+func (s *EthBackendServer) NodeInfo(_ context.Context, r *remote.NodesInfoRequest) (*remote.NodesInfoReply, error) {
+	nodesInfo, err := s.eth.NodesInfo(int(r.Limit))
+	if err != nil {
+		return nil, err
+	}
+	return nodesInfo, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/kevinburke/go-bindata v3.21.0+incompatible
-	github.com/ledgerwatch/erigon-lib v0.0.0-20211130023247-dfd4f5ebf76b
+	github.com/ledgerwatch/erigon-lib v0.0.0-20211130144131-da3c239ed6a1
 	github.com/ledgerwatch/log/v3 v3.4.0
 	github.com/ledgerwatch/secp256k1 v1.0.0
 	github.com/logrusorgru/aurora/v3 v3.0.0
@@ -65,5 +65,3 @@ require (
 	gopkg.in/olebedev/go-duktape.v3 v3.0.0-20200619000410-60c24ae608a6
 	pgregory.net/rapid v0.4.7
 )
-
-replace github.com/ledgerwatch/erigon-lib => github.com/dsavelev/erigon-lib v0.0.1-alpha

--- a/go.mod
+++ b/go.mod
@@ -63,5 +63,6 @@ require (
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
 	gopkg.in/olebedev/go-duktape.v3 v3.0.0-20200619000410-60c24ae608a6
+	modernc.org/sortutil v1.1.0 // indirect
 	pgregory.net/rapid v0.4.7
 )

--- a/go.mod
+++ b/go.mod
@@ -65,3 +65,5 @@ require (
 	gopkg.in/olebedev/go-duktape.v3 v3.0.0-20200619000410-60c24ae608a6
 	pgregory.net/rapid v0.4.7
 )
+
+replace github.com/ledgerwatch/erigon-lib => github.com/dsavelev/erigon-lib v0.0.1-alpha

--- a/go.sum
+++ b/go.sum
@@ -596,8 +596,8 @@ github.com/kylelemons/godebug v0.0.0-20170224010052-a616ab194758 h1:0D5M2HQSGD3P
 github.com/kylelemons/godebug v0.0.0-20170224010052-a616ab194758/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
-github.com/ledgerwatch/erigon-lib v0.0.0-20211130023247-dfd4f5ebf76b h1:Yquun3KVIuDGbnX9OTXVH2vhkWytP8FsXqhW+AUNzj0=
-github.com/ledgerwatch/erigon-lib v0.0.0-20211130023247-dfd4f5ebf76b/go.mod h1:lyGP3i0x4CeabdKZ4beycD5xZfHWZwJsAX+70OfGj4Y=
+github.com/ledgerwatch/erigon-lib v0.0.0-20211130144131-da3c239ed6a1 h1:Wv1FfPX8KylbRXEJ4jNVcwb/Oidhtp2KFDL0JK0zC1M=
+github.com/ledgerwatch/erigon-lib v0.0.0-20211130144131-da3c239ed6a1/go.mod h1:lyGP3i0x4CeabdKZ4beycD5xZfHWZwJsAX+70OfGj4Y=
 github.com/ledgerwatch/log/v3 v3.4.0 h1:SEIOcv5a2zkG3PmoT5jeTU9m/0nEUv0BJS5bzsjwKCI=
 github.com/ledgerwatch/log/v3 v3.4.0/go.mod h1:VXcz6Ssn6XEeU92dCMc39/g1F0OYAjw1Mt+dGP5DjXY=
 github.com/ledgerwatch/secp256k1 v1.0.0 h1:Usvz87YoTG0uePIV8woOof5cQnLXGYa162rFf3YnwaQ=

--- a/go.sum
+++ b/go.sum
@@ -832,6 +832,7 @@ github.com/prometheus/procfs v0.3.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/quasilyte/go-ruleguard/dsl v0.3.6 h1:W2wnISJifyda0x/RXq15Qjrsu9iOhX2gy4+Ku+owylw=
 github.com/quasilyte/go-ruleguard/dsl v0.3.6/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -1506,6 +1507,9 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=
+modernc.org/sortutil v1.1.0 h1:oP3U4uM+NT/qBQcbg/K2iqAX0Nx7B1b6YZtq3Gk/PjM=
+modernc.org/sortutil v1.1.0/go.mod h1:ZyL98OQHJgH9IEfN71VsamvJgrtRX9Dj2gX+vH86L1k=
 pgregory.net/rapid v0.4.7 h1:MTNRktPuv5FNqOO151TM9mDTa+XHcX6ypYeISDVD14g=
 pgregory.net/rapid v0.4.7/go.mod h1:UYpPVyjFHzYBGHIxLFoupi8vwk6rXNzRY9OMvVxFIOU=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=


### PR DESCRIPTION
Add NodeInfo implementation (https://github.com/ledgerwatch/erigon/issues/2679)

(blocked by https://github.com/ledgerwatch/erigon-lib/pull/196 need to revert `go.mod` after the merge)

Not sure if we can assert that `p2p.NodeInfo.Protocols` is either `map[string]eth.NodeInfo` or `map[string]string`. Even though I didn't find any other usages, `p2p.NodeInfo` declares this field as `map[string]interface{}`, so i decided just to marshal it into json, as the first approach.