### PR TITLE
Fix Header.EncodingSize() to match EncodeRLP() with EIP-3675

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -170,6 +170,10 @@ func (h Header) EncodingSize() int {
 		encodingSize += baseFeeLen
 	}
 
+	if h.Eip3675 {
+		encodingSize += common.HashLength + 1
+	}
+
 	return encodingSize
 }
 

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -558,10 +558,10 @@ func (h *Header) DecodeRLP(s *rlp.Stream) error {
 				}
 				return nil
 			}
-			return fmt.Errorf("read BaseFee: %w", err)
+			return fmt.Errorf("read Random: %w", err)
 		}
 		if len(b) != common.HashLength {
-			return fmt.Errorf("wrong size for BaseFee: %d", len(b))
+			return fmt.Errorf("wrong size for Random: %d", len(b))
 		}
 		h.Eip3675 = true
 		h.Random = common.BytesToHash(b)


### PR DESCRIPTION
A `Random` field was added to `Header.EncodeRLP()`, but the change was not also reflected in `Header.EncodingSize()`.

This also fixes a copy/paste error in a couple of error messages for decoding `Random` in `Header.DecodeRLP()`.