### PR TITLE
Avoid redundant BitLen()

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -557,7 +557,7 @@ func (b *SimulatedBackend) EstimateGas(ctx context.Context, call ethereum.CallMs
 		hi = b.pendingBlock.GasLimit()
 	}
 	// Recap the highest gas allowance with account's balance.
-	if call.GasPrice != nil && call.GasPrice.BitLen() != 0 {
+	if call.GasPrice != nil && !call.GasPrice.IsZero() {
 		balance := b.pendingState.GetBalance(call.From) // from can't be nil
 		available := balance.ToBig()
 		if call.Value != nil {

--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -285,7 +285,7 @@ func signUnsignedTransactions(txs []*txWithKey, signer types.Signer) (types.Tran
 		tx := txWithKey.tx
 		key := txWithKey.key
 		v, r, s := tx.RawSignatureValues()
-		if key != nil && v.BitLen()+r.BitLen()+s.BitLen() == 0 {
+		if key != nil && v.IsZero() && r.IsZero() && s.IsZero() {
 			// This transaction needs to be signed
 			signed, err := types.SignTx(tx, signer, key)
 			if err != nil {

--- a/cmd/rpcdaemon/commands/eth_call.go
+++ b/cmd/rpcdaemon/commands/eth_call.go
@@ -159,7 +159,7 @@ func (api *APIImpl) EstimateGas(ctx context.Context, args ethapi.CallArgs, block
 		feeCap = common.Big0
 	}
 	// Recap the highest gas limit with account's available balance.
-	if feeCap.BitLen() != 0 {
+	if feeCap.Sign() != 0 {
 		cacheView, err := api.stateCache.View(ctx, dbtx)
 		if err != nil {
 			return 0, err

--- a/cmd/rpcdaemon/commands/trace_adhoc.go
+++ b/cmd/rpcdaemon/commands/trace_adhoc.go
@@ -194,7 +194,7 @@ func (args *TraceCallParam) ToMessage(globalGasCap uint64, baseFee *uint256.Int)
 			}
 			// Backfill the legacy gasPrice for EVM execution, unless we're all zeroes
 			gasPrice = new(uint256.Int)
-			if gasFeeCap.BitLen() > 0 || gasTipCap.BitLen() > 0 {
+			if !gasFeeCap.IsZero() || !gasTipCap.IsZero() {
 				gasPrice = math2.U256Min(new(uint256.Int).Add(gasTipCap, baseFee), gasFeeCap)
 			} else {
 				// This means gasFeeCap == 0, gasTipCap == 0

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -254,7 +254,7 @@ func (st *StateTransition) preCheck(gasBailout bool) error {
 	// Make sure the transaction gasFeeCap is greater than the block's baseFee.
 	if st.evm.ChainRules.IsLondon {
 		// Skip the checks if gas fields are zero and baseFee was explicitly disabled (eth_call)
-		if !st.evm.Config.NoBaseFee || st.gasFeeCap.BitLen() > 0 || st.tip.BitLen() > 0 {
+		if !st.evm.Config.NoBaseFee || !st.gasFeeCap.IsZero() || !st.tip.IsZero() {
 			if l := st.gasFeeCap.BitLen(); l > 256 {
 				return fmt.Errorf("%w: address %v, gasFeeCap bit length: %d", ErrFeeCapVeryHigh,
 					st.msg.From().Hex(), l)

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -384,7 +384,7 @@ func (c *bigModExp) Run(input []byte) ([]byte, error) {
 		exp  = new(big.Int).SetBytes(getData(input, baseLen, expLen))
 		mod  = new(big.Int).SetBytes(getData(input, baseLen+expLen, modLen))
 	)
-	if mod.BitLen() == 0 {
+	if mod.Sign() == 0 {
 		// Modulo 0 is undefined, return zero
 		return common.LeftPadBytes([]byte{}, int(modLen)), nil
 	}

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -310,7 +310,7 @@ func TestBlockhash(t *testing.T) {
 	zero := new(big.Int).SetBytes(ret[0:32])
 	first := new(big.Int).SetBytes(ret[32:64])
 	last := new(big.Int).SetBytes(ret[64:96])
-	if zero.BitLen() != 0 {
+	if zero.Sign() != 0 {
 		t.Fatalf("expected zeroes, got %x", ret[0:32])
 	}
 	if first.Uint64() != 999 {

--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -324,9 +324,12 @@ func (nbp NewBlockPacket) EncodeRLP(w io.Writer) error {
 	encodingSize += blockLen
 	// size of TD
 	encodingSize++
-	var tdLen int
-	if nbp.TD.BitLen() >= 8 {
-		tdLen = (nbp.TD.BitLen() + 7) / 8
+	var tdBitLen, tdLen int
+	if nbp.TD != nil {
+		tdBitLen = nbp.TD.BitLen()
+		if tdBitLen >= 8 {
+			tdLen = (tdBitLen + 7) / 8
+		}
 	}
 	encodingSize += tdLen
 	var b [33]byte
@@ -339,16 +342,18 @@ func (nbp NewBlockPacket) EncodeRLP(w io.Writer) error {
 		return err
 	}
 	// encode TD
-	if nbp.TD != nil && nbp.TD.BitLen() > 0 && nbp.TD.BitLen() < 8 {
-		b[0] = byte(nbp.TD.Uint64())
+	if tdBitLen < 8 {
+		if tdBitLen > 0 {
+			b[0] = byte(nbp.TD.Uint64())
+		} else {
+			b[0] = 128
+		}
 		if _, err := w.Write(b[:1]); err != nil {
 			return err
 		}
 	} else {
 		b[0] = 128 + byte(tdLen)
-		if nbp.TD != nil {
-			nbp.TD.FillBytes(b[1 : 1+tdLen])
-		}
+		nbp.TD.FillBytes(b[1 : 1+tdLen])
 		if _, err := w.Write(b[:1+tdLen]); err != nil {
 			return err
 		}
@@ -388,8 +393,8 @@ func (request *NewBlockPacket) sanityCheck() error {
 	}
 	//TD at mainnet block #7753254 is 76 bits. If it becomes 100 million times
 	// larger, it will still fit within 100 bits
-	if tdlen := request.TD.BitLen(); tdlen > 100 {
-		return fmt.Errorf("too large block TD: bitlen %d", tdlen)
+	if tdLen := request.TD.BitLen(); tdLen > 100 {
+		return fmt.Errorf("too large block TD: bitlen %d", tdLen)
 	}
 	return nil
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -120,7 +120,7 @@ func (args *CallArgs) ToMessage(globalGasCap uint64, baseFee *uint256.Int) (type
 			}
 			// Backfill the legacy gasPrice for EVM execution, unless we're all zeroes
 			gasPrice = new(uint256.Int)
-			if gasFeeCap.BitLen() > 0 || gasTipCap.BitLen() > 0 {
+			if !gasFeeCap.IsZero() || !gasTipCap.IsZero() {
 				gasPrice = math.U256Min(new(uint256.Int).Add(gasTipCap, baseFee), gasFeeCap)
 			}
 		}


### PR DESCRIPTION
A few places using `big.Int.BitLen()` or `uint256.Int.BitLen()` only for testing zero or non-zero. This replaces those with `big.Int.Sign()` and `uint256.Int.IsZero()`.

Also during RLP-encoding of blocks and headers, where `big.Int.BitLen()` was called 2 or 4 times each for a single unchanged value.