### PR TITLE
Change eth.Peer.ID() type from string to enode.ID

### DIFF
--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/p2p"
+	"github.com/ledgerwatch/erigon/p2p/enode"
 	"github.com/ledgerwatch/erigon/rlp"
 )
 
@@ -66,7 +67,7 @@ func max(a, b int) int { //nolint:unparam
 
 // Peer is a collection of relevant information we have about a `eth` peer.
 type Peer struct {
-	id string // Unique ID for the peer, cached
+	id enode.ID // Unique ID for the peer, cached
 
 	*p2p.Peer                   // The embedded P2P package peer
 	rw        p2p.MsgReadWriter // Input/output streams for snap
@@ -92,7 +93,7 @@ type Peer struct {
 // version.
 func NewPeer(version uint, p *p2p.Peer, rw p2p.MsgReadWriter, txpool TxPool) *Peer {
 	peer := &Peer{
-		id:              p.ID().String(),
+		id:              p.ID(),
 		Peer:            p,
 		rw:              rw,
 		version:         version,
@@ -121,7 +122,7 @@ func (p *Peer) Close() {
 }
 
 // ID retrieves the peer's unique identifier.
-func (p *Peer) ID() string {
+func (p *Peer) ID() enode.ID {
 	return p.id
 }
 

--- a/p2p/simulations/adapters/inproc.go
+++ b/p2p/simulations/adapters/inproc.go
@@ -100,6 +100,7 @@ func (s *SimAdapter) NewNode(config *NodeConfig) (Node, error) {
 			Dialer:          s,
 			EnableMsgEvents: config.EnableMsgEvents,
 		},
+		// Convert node ID to string once, rather than for every log line
 		Logger: log.New("node.id", id.String()),
 	})
 	if err != nil {

--- a/p2p/simulations/adapters/types.go
+++ b/p2p/simulations/adapters/types.go
@@ -217,11 +217,11 @@ func RandomNodeConfig() *NodeConfig {
 		panic("unable to assign tcp port")
 	}
 
-	enodId := enode.PubkeyToIDV4(&prvkey.PublicKey)
+	enodeId := enode.PubkeyToIDV4(&prvkey.PublicKey)
 	return &NodeConfig{
 		PrivateKey:      prvkey,
-		ID:              enodId,
-		Name:            fmt.Sprintf("node_%s", enodId.String()),
+		ID:              enodeId,
+		Name:            "node_" + enodeId.String(),
 		Port:            port,
 		EnableMsgEvents: true,
 		LogVerbosity:    log.LvlInfo,

--- a/p2p/simulations/network_test.go
+++ b/p2p/simulations/network_test.go
@@ -473,7 +473,7 @@ func TestGetNodeIDs(t *testing.T) {
 		}
 
 		if !match {
-			t.Fatalf("A created node was not returned by GetNodes(), ID: %s", node1.ID().String())
+			t.Fatalf("A created node was not returned by GetNodes(), ID: %s", node1.ID())
 		}
 	}
 
@@ -484,7 +484,7 @@ func TestGetNodeIDs(t *testing.T) {
 	}
 	for _, nodeID := range gotNodeIDsExcl {
 		if bytes.Equal(excludeNodeID.Bytes(), nodeID.Bytes()) {
-			t.Fatalf("GetNodeIDs returned the node ID we excluded, ID: %s", nodeID.String())
+			t.Fatalf("GetNodeIDs returned the node ID we excluded, ID: %s", nodeID)
 		}
 	}
 }
@@ -523,7 +523,7 @@ func TestGetNodes(t *testing.T) {
 		}
 
 		if !match {
-			t.Fatalf("A created node was not returned by GetNodes(), ID: %s", node1.ID().String())
+			t.Fatalf("A created node was not returned by GetNodes(), ID: %s", node1.ID())
 		}
 	}
 
@@ -534,7 +534,7 @@ func TestGetNodes(t *testing.T) {
 	}
 	for _, node := range gotNodesExcl {
 		if bytes.Equal(excludeNodeID.Bytes(), node.ID().Bytes()) {
-			t.Fatalf("GetNodes returned the node we excluded, ID: %s", node.ID().String())
+			t.Fatalf("GetNodes returned the node we excluded, ID: %s", node.ID())
 		}
 	}
 }
@@ -579,7 +579,7 @@ func TestGetNodesByID(t *testing.T) {
 		}
 
 		if !match {
-			t.Fatalf("A created node was not returned by GetNodesByID(), ID: %s", node1.ID().String())
+			t.Fatalf("A created node was not returned by GetNodesByID(), ID: %s", node1.ID())
 		}
 	}
 }
@@ -625,7 +625,7 @@ func TestGetNodesByProperty(t *testing.T) {
 		}
 
 		if !match {
-			t.Fatalf("A created node with property was not returned by GetNodesByProperty(), ID: %s", node1.ID().String())
+			t.Fatalf("A created node with property was not returned by GetNodesByProperty(), ID: %s", node1.ID())
 		}
 	}
 }
@@ -672,7 +672,7 @@ func TestGetNodeIDsByProperty(t *testing.T) {
 		}
 
 		if !match {
-			t.Fatalf("Not all nodes IDs were returned by GetNodeIDsByProperty(), ID: %s", id1.String())
+			t.Fatalf("Not all nodes IDs were returned by GetNodeIDsByProperty(), ID: %s", id1)
 		}
 	}
 }


### PR DESCRIPTION
`eth.Peer` (distinct from `p2p.Peer`) was still using a `string` for its `id` field (and `ID()` accessor), although this was not actually being used by anything. This update changes it to use `enode.ID` in keeping with the rest of the code base.

`p2p.NodeInfo` and `p2p.PeerInfo` (distinct from Sentry's `download.PeerInfo`) continue to use a `string` for the id as they are informational / presentation types.

Related to #3013.