### PR TITLE
Update Engine API to v1.0.0-alpha.5

### DIFF
--- a/cmd/rpcdaemon/commands/engine_api.go
+++ b/cmd/rpcdaemon/commands/engine_api.go
@@ -34,12 +34,6 @@ type ExecutionPayload struct {
 	Transactions  []hexutil.Bytes `json:"transactions"  gencodec:"required"`
 }
 
-type ForkchoiceState struct {
-	HeadBlockHash      common.Hash `json:"headBlockHash"      gencodec:"required"`
-	SafeBlockHash      common.Hash `json:"safeBlockHash"      gencodec:"required"`
-	FinalizedBlockHash common.Hash `json:"finalizedBlockHash" gencodec:"required"`
-}
-
 // PayloadAttributes represent the attributes required to start assembling a payload
 type PayloadAttributes struct {
 	Timestamp             hexutil.Uint64 `json:"timestamp"             gencodec:"required"`
@@ -49,7 +43,7 @@ type PayloadAttributes struct {
 
 // EngineAPI Beacon chain communication endpoint
 type EngineAPI interface {
-	ForkchoiceUpdatedV1(context.Context, *ForkchoiceState, *PayloadAttributes) (map[string]interface{}, error)
+	ForkchoiceUpdatedV1(context.Context, struct{}, *PayloadAttributes) (map[string]interface{}, error)
 	ExecutePayloadV1(context.Context, *ExecutionPayload) (map[string]interface{}, error)
 	GetPayloadV1(ctx context.Context, payloadID hexutil.Uint64) (*ExecutionPayload, error)
 }
@@ -64,7 +58,7 @@ type EngineImpl struct {
 // ForkchoiceUpdatedV1 is executed only if we are running a beacon validator,
 // in erigon we do not use this for reorgs like go-ethereum does since we can do that in engine_executePayloadV1
 // if the payloadAttributes is different than null, we return
-func (e *EngineImpl) ForkchoiceUpdatedV1(_ context.Context, forkchoiceState *ForkchoiceState, payloadAttributes *PayloadAttributes) (map[string]interface{}, error) {
+func (e *EngineImpl) ForkchoiceUpdatedV1(_ context.Context, _ struct{}, payloadAttributes *PayloadAttributes) (map[string]interface{}, error) {
 	// Unwinds can be made within engine_excutePayloadV1 so we can return success regardless
 	if payloadAttributes == nil {
 		return map[string]interface{}{

--- a/cmd/rpcdaemon/commands/engine_api.go
+++ b/cmd/rpcdaemon/commands/engine_api.go
@@ -19,32 +19,38 @@ import (
 // ExecutionPayload represents an execution payload (aka slot/block)
 type ExecutionPayload struct {
 	ParentHash    common.Hash     `json:"parentHash"    gencodec:"required"`
+	FeeRecipient  common.Address  `json:"feeRecipient"  gencodec:"required"`
 	StateRoot     common.Hash     `json:"stateRoot"     gencodec:"required"`
-	ReceiptRoot   common.Hash     `json:"receiptRoot"   gencodec:"required"`
+	ReceiptsRoot  common.Hash     `json:"receiptsRoot"  gencodec:"required"`
 	LogsBloom     hexutil.Bytes   `json:"logsBloom"     gencodec:"required"`
 	Random        common.Hash     `json:"random"        gencodec:"required"`
 	BlockNumber   hexutil.Uint64  `json:"blockNumber"   gencodec:"required"`
 	GasLimit      hexutil.Uint64  `json:"gasLimit"      gencodec:"required"`
 	GasUsed       hexutil.Uint64  `json:"gasUsed"       gencodec:"required"`
-	Extra         hexutil.Bytes   `json:"extraData"     gencodec:"required"`
+	Timestamp     hexutil.Uint64  `json:"timestamp"     gencodec:"required"`
+	ExtraData     hexutil.Bytes   `json:"extraData"     gencodec:"required"`
 	BaseFeePerGas *hexutil.Big    `json:"baseFeePerGas" gencodec:"required"`
 	BlockHash     common.Hash     `json:"blockHash"     gencodec:"required"`
-	Timestamp     hexutil.Uint64  `json:"timestamp"     gencodec:"required"`
-	Coinbase      common.Address  `json:"coinbase"      gencodec:"required"`
 	Transactions  []hexutil.Bytes `json:"transactions"  gencodec:"required"`
 }
 
-// PreparePayloadArgs represents a request to assemble a payload from the beacon chain
-type PreparePayloadArgs struct {
-	Random       *common.Hash    `json:"random"`
-	Timestamp    *hexutil.Uint64 `json:"timestamp"`
-	FeeRecipient *common.Address `json:"feeRecipient"`
+type ForkchoiceState struct {
+	HeadBlockHash      common.Hash `json:"headBlockHash"      gencodec:"required"`
+	SafeBlockHash      common.Hash `json:"safeBlockHash"      gencodec:"required"`
+	FinalizedBlockHash common.Hash `json:"finalizedBlockHash" gencodec:"required"`
+}
+
+// PayloadAttributes represent the attributes required to start assembling a payload
+type PayloadAttributes struct {
+	Timestamp             hexutil.Uint64 `json:"timestamp"             gencodec:"required"`
+	Random                common.Hash    `json:"random"                gencodec:"required"`
+	SuggestedFeeRecipient common.Address `json:"suggestedFeeRecipient" gencodec:"required"`
 }
 
 // EngineAPI Beacon chain communication endpoint
 type EngineAPI interface {
-	ForkchoiceUpdatedV1(context.Context, struct{}, *PreparePayloadArgs) (map[string]interface{}, error)
-	ExecutePayloadV1(context.Context, ExecutionPayload) (map[string]interface{}, error)
+	ForkchoiceUpdatedV1(context.Context, *ForkchoiceState, *PayloadAttributes) (map[string]interface{}, error)
+	ExecutePayloadV1(context.Context, *ExecutionPayload) (map[string]interface{}, error)
 	GetPayloadV1(ctx context.Context, payloadID hexutil.Uint64) (*ExecutionPayload, error)
 }
 
@@ -57,10 +63,10 @@ type EngineImpl struct {
 
 // ForkchoiceUpdatedV1 is executed only if we are running a beacon validator,
 // in erigon we do not use this for reorgs like go-ethereum does since we can do that in engine_executePayloadV1
-// if the buildPayloadArgs is different than null, we return
-func (e *EngineImpl) ForkchoiceUpdatedV1(_ context.Context, _ struct{}, buildPayloadArgs *PreparePayloadArgs) (map[string]interface{}, error) {
+// if the payloadAttributes is different than null, we return
+func (e *EngineImpl) ForkchoiceUpdatedV1(_ context.Context, forkchoiceState *ForkchoiceState, payloadAttributes *PayloadAttributes) (map[string]interface{}, error) {
 	// Unwinds can be made within engine_excutePayloadV1 so we can return success regardless
-	if buildPayloadArgs == nil {
+	if payloadAttributes == nil {
 		return map[string]interface{}{
 			"status":    "SUCCESS",
 			"payloadId": nil,
@@ -73,7 +79,7 @@ func (e *EngineImpl) ForkchoiceUpdatedV1(_ context.Context, _ struct{}, buildPay
 // ExecutePayloadV1 takes a block from the beacon chain and do either two of the following things
 // - Stageloop the block just received if we have the payload's parent hash already
 // - Start the reverse sync process otherwise, and return "Syncing"
-func (e *EngineImpl) ExecutePayloadV1(ctx context.Context, payload ExecutionPayload) (map[string]interface{}, error) {
+func (e *EngineImpl) ExecutePayloadV1(ctx context.Context, payload *ExecutionPayload) (map[string]interface{}, error) {
 	var baseFee *uint256.Int
 	if payload.BaseFeePerGas != nil {
 		var overflow bool
@@ -83,7 +89,7 @@ func (e *EngineImpl) ExecutePayloadV1(ctx context.Context, payload ExecutionPayl
 		}
 	}
 	// Maximum length of extra is 32 bytes so we can use the hash datatype
-	extra := common.BytesToHash(payload.Extra)
+	extra := common.BytesToHash(payload.ExtraData)
 
 	log.Info("Received Payload from beacon-chain")
 
@@ -94,10 +100,9 @@ func (e *EngineImpl) ExecutePayloadV1(ctx context.Context, payload ExecutionPayl
 	}
 	res, err := e.api.EngineExecutePayloadV1(ctx, &types2.ExecutionPayload{
 		ParentHash:    gointerfaces.ConvertHashToH256(payload.ParentHash),
-		BlockHash:     gointerfaces.ConvertHashToH256(payload.BlockHash),
+		Coinbase:      gointerfaces.ConvertAddressToH160(payload.FeeRecipient),
 		StateRoot:     gointerfaces.ConvertHashToH256(payload.StateRoot),
-		Coinbase:      gointerfaces.ConvertAddressToH160(payload.Coinbase),
-		ReceiptRoot:   gointerfaces.ConvertHashToH256(payload.ReceiptRoot),
+		ReceiptRoot:   gointerfaces.ConvertHashToH256(payload.ReceiptsRoot),
 		LogsBloom:     gointerfaces.ConvertBytesToH2048(([]byte)(payload.LogsBloom)),
 		Random:        gointerfaces.ConvertHashToH256(payload.Random),
 		BlockNumber:   (uint64)(payload.BlockNumber),
@@ -106,6 +111,7 @@ func (e *EngineImpl) ExecutePayloadV1(ctx context.Context, payload ExecutionPayl
 		Timestamp:     (uint64)(payload.Timestamp),
 		ExtraData:     gointerfaces.ConvertHashToH256(extra),
 		BaseFeePerGas: gointerfaces.ConvertUint256IntToH256(baseFee),
+		BlockHash:     gointerfaces.ConvertHashToH256(payload.BlockHash),
 		Transactions:  transactions,
 	})
 	if err != nil {
@@ -139,18 +145,18 @@ func (e *EngineImpl) GetPayloadV1(ctx context.Context, payloadID hexutil.Uint64)
 	}
 	return &ExecutionPayload{
 		ParentHash:    gointerfaces.ConvertH256ToHash(payload.ParentHash),
-		BlockHash:     gointerfaces.ConvertH256ToHash(payload.BlockHash),
-		ReceiptRoot:   gointerfaces.ConvertH256ToHash(payload.ReceiptRoot),
+		FeeRecipient:  gointerfaces.ConvertH160toAddress(payload.Coinbase),
 		StateRoot:     gointerfaces.ConvertH256ToHash(payload.StateRoot),
-		Random:        gointerfaces.ConvertH256ToHash(payload.Random),
+		ReceiptsRoot:  gointerfaces.ConvertH256ToHash(payload.ReceiptRoot),
 		LogsBloom:     bloom[:],
-		Extra:         extra[:],
-		BaseFeePerGas: (*hexutil.Big)(baseFee),
+		Random:        gointerfaces.ConvertH256ToHash(payload.Random),
 		BlockNumber:   hexutil.Uint64(payload.BlockNumber),
 		GasLimit:      hexutil.Uint64(payload.GasLimit),
 		GasUsed:       hexutil.Uint64(payload.GasUsed),
 		Timestamp:     hexutil.Uint64(payload.Timestamp),
-		Coinbase:      gointerfaces.ConvertH160toAddress(payload.Coinbase),
+		ExtraData:     extra[:],
+		BaseFeePerGas: (*hexutil.Big)(baseFee),
+		BlockHash:     gointerfaces.ConvertH256ToHash(payload.BlockHash),
 		Transactions:  transactions,
 	}, nil
 }


### PR DESCRIPTION
[Kintsugi v3](https://hackmd.io/@n0ble/kintsugi-spec#Kintsugi-Spec-v3) is going to use Engine API [v1.0.0-alpha.5](https://github.com/ethereum/execution-apis/releases/tag/v1.0.0-alpha.5).