### PR TITLE
Fix NodeInfo.Protocols decoding

### DIFF
--- a/cmd/rpcdaemon/services/eth_backend.go
+++ b/cmd/rpcdaemon/services/eth_backend.go
@@ -182,9 +182,14 @@ func (back *RemoteBackend) NodeInfo(ctx context.Context, limit uint32) ([]p2p.No
 
 	ret := make([]p2p.NodeInfo, 0, len(nodes.NodesInfo))
 	for _, node := range nodes.NodesInfo {
-		var protocols map[string]interface{}
-		if err = json.Unmarshal(node.Protocols, &protocols); err != nil {
+		var rawProtocols map[string]json.RawMessage
+		if err = json.Unmarshal(node.Protocols, &rawProtocols); err != nil {
 			return nil, fmt.Errorf("cannot decode protocols metadata: %w", err)
+		}
+
+		protocols := make(map[string]interface{}, len(rawProtocols))
+		for k, v := range rawProtocols {
+			protocols[k] = v
 		}
 
 		ret = append(ret, p2p.NodeInfo{


### PR DESCRIPTION
Following https://github.com/ledgerwatch/erigon/pull/3073#issuecomment-984425567

The solution is rather ugly, but unfortunately, I don't have any other ideas on how to deal with `map[string]interface{}` datatype (maybe we can implement a custom serializer for it?).

The problem was in numeric precision loss during json unmarshalling of big integers since they are decoded as a float64.

So after this fix, "NodeInfo.Protocols.Difficulty" field is formatted properly in rpcdaemon response.