### PR TITLE
Header download simplifications

### DIFF
--- a/cmd/sentry/download/downloader.go
+++ b/cmd/sentry/download/downloader.go
@@ -484,7 +484,7 @@ func (cs *ControlServerImpl) blockHeaders(ctx context.Context, pkt eth.BlockHead
 
 			if canRequestMore {
 				currentTime := uint64(time.Now().Unix())
-				req, penalty := cs.Hd.RequestMoreHeaders(currentTime)
+				req, penalties := cs.Hd.RequestMoreHeaders(currentTime)
 				if req != nil {
 					if _, sentToPeer := cs.SendHeaderRequest(ctx, req); sentToPeer {
 						// If request was actually sent to a peer, we update retry time to be 5 seconds in the future
@@ -492,8 +492,8 @@ func (cs *ControlServerImpl) blockHeaders(ctx context.Context, pkt eth.BlockHead
 						log.Trace("Sent request", "height", req.Number)
 					}
 				}
-				if penalty != nil {
-					cs.Penalize(ctx, []headerdownload.PenaltyItem{*penalty})
+				if len(penalties) > 0 {
+					cs.Penalize(ctx, penalties)
 				}
 			}
 		} else {

--- a/cmd/sentry/download/downloader.go
+++ b/cmd/sentry/download/downloader.go
@@ -486,8 +486,9 @@ func (cs *ControlServerImpl) blockHeaders(ctx context.Context, pkt eth.BlockHead
 				currentTime := uint64(time.Now().Unix())
 				req, penalties := cs.Hd.RequestMoreHeaders(currentTime)
 				if req != nil {
-					if _, ok := cs.SendHeaderRequest(ctx, req); ok {
-						cs.Hd.SentRequest(req, currentTime, 5 /* timeout */)
+					if _, sentToPeer := cs.SendHeaderRequest(ctx, req); sentToPeer {
+						// If request was actually sent to a peer, we update retry time to be 5 seconds in the future
+						cs.Hd.UpdateRetryTime(req, currentTime, 5 /* timeout */)
 						log.Trace("Sent request", "height", req.Number)
 					}
 				}

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -365,7 +365,8 @@ Loop:
 		if req != nil {
 			_, sentToPeer = cfg.headerReqSend(ctx, req)
 			if sentToPeer {
-				cfg.hd.SentRequest(req, currentTime, 5 /* timeout */)
+				// If request was actually sent to a peer, we update retry time to be 5 seconds in the future
+				cfg.hd.UpdateRetryTime(req, currentTime, 5 /* timeout */)
 				log.Trace("Sent request", "height", req.Number)
 			}
 		}
@@ -376,7 +377,8 @@ Loop:
 			if req != nil {
 				_, sentToPeer = cfg.headerReqSend(ctx, req)
 				if sentToPeer {
-					cfg.hd.SentRequest(req, currentTime, 5 /*timeout */)
+					// If request was actually sent to a peer, we update retry time to be 5 seconds in the future
+					cfg.hd.UpdateRetryTime(req, currentTime, 5 /*timeout */)
 					log.Trace("Sent request", "height", req.Number)
 				}
 			}

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -361,7 +361,7 @@ Loop:
 			break
 		}
 		currentTime := uint64(time.Now().Unix())
-		req, penalty := cfg.hd.RequestMoreHeaders(currentTime)
+		req, penalties := cfg.hd.RequestMoreHeaders(currentTime)
 		if req != nil {
 			_, sentToPeer = cfg.headerReqSend(ctx, req)
 			if sentToPeer {
@@ -370,12 +370,12 @@ Loop:
 				log.Trace("Sent request", "height", req.Number)
 			}
 		}
-		if penalty != nil {
-			cfg.penalize(ctx, []headerdownload.PenaltyItem{*penalty})
+		if len(penalties) > 0 {
+			cfg.penalize(ctx, penalties)
 		}
 		maxRequests := 64 // Limit number of requests sent per round to let some headers to be inserted into the database
 		for req != nil && sentToPeer && maxRequests > 0 {
-			req, penalty = cfg.hd.RequestMoreHeaders(currentTime)
+			req, penalties = cfg.hd.RequestMoreHeaders(currentTime)
 			if req != nil {
 				_, sentToPeer = cfg.headerReqSend(ctx, req)
 				if sentToPeer {
@@ -384,8 +384,8 @@ Loop:
 					log.Trace("Sent request", "height", req.Number)
 				}
 			}
-			if penalty != nil {
-				cfg.penalize(ctx, []headerdownload.PenaltyItem{*penalty})
+			if len(penalties) > 0 {
+				cfg.penalize(ctx, penalties)
 			}
 			maxRequests--
 		}

--- a/turbo/stages/headerdownload/header_algo_test.go
+++ b/turbo/stages/headerdownload/header_algo_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/crypto"
 	"github.com/ledgerwatch/erigon/params"
+	"github.com/ledgerwatch/erigon/rlp"
 	"github.com/ledgerwatch/erigon/turbo/snapshotsync"
 )
 
@@ -49,10 +50,12 @@ func TestInserter1(t *testing.T) {
 		ParentHash: h1Hash,
 	}
 	h2Hash := h2.Hash()
-	if _, err = hi.FeedHeader(tx, snapshotsync.NewBlockReader(), &h1, h1Hash, 1, nil); err != nil {
+	data1, _ := rlp.EncodeToBytes(&h1)
+	if _, err = hi.FeedHeader(tx, snapshotsync.NewBlockReader(), &h1, data1, h1Hash, 1, nil); err != nil {
 		t.Errorf("feed empty header 1: %v", err)
 	}
-	if _, err = hi.FeedHeader(tx, snapshotsync.NewBlockReader(), &h2, h2Hash, 2, nil); err != nil {
+	data2, _ := rlp.EncodeToBytes(&h2)
+	if _, err = hi.FeedHeader(tx, snapshotsync.NewBlockReader(), &h2, data2, h2Hash, 2, nil); err != nil {
 		t.Errorf("feed empty header 2: %v", err)
 	}
 }

--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -188,7 +188,7 @@ func (hd *HeaderDownload) extendUp(segment ChainSegment, attachmentLink *Link) {
 	prevLink := attachmentLink
 	for i := len(segment) - 1; i >= 0; i-- {
 		link := hd.addHeaderAsLink(segment[i], false /* persisted */)
-		if attachmentLink.persisted {
+		if prevLink.persisted {
 			// If we are attching to already persisted link, schedule for insertion (persistence)
 			hd.insertList = append(hd.insertList, link)
 		}

--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -137,31 +137,31 @@ func (hd *HeaderDownload) IsBadHeader(headerHash common.Hash) bool {
 	return ok
 }
 
-// FindAnchors attempts to find anchors to which given chain segment can be attached to
-func (hd *HeaderDownload) findAnchors(segment ChainSegment) (found bool, start int) {
+// findAnchor attempts to find anchor to which given chain segment can be attached to
+func (hd *HeaderDownload) findAnchor(segment ChainSegment) (found bool, anchor *Anchor, start int) {
 	// Walk the segment from children towards parents
 	for i, h := range segment {
 		// Check if the header can be attached to an anchor of a working tree
-		if _, attaching := hd.anchors[h.Hash]; attaching {
-			return true, i
+		if anchor, attaching := hd.anchors[h.Hash]; attaching {
+			return true, anchor, i
 		}
 	}
-	return false, 0
+	return false, nil, 0
 }
 
 // FindLink attempts to find a non-persisted link that given chain segment can be attached to.
-func (hd *HeaderDownload) findLink(segment ChainSegment, start int) (found bool, end int) {
+func (hd *HeaderDownload) findLink(segment ChainSegment, start int) (found bool, link *Link, end int) {
 	if _, duplicate := hd.getLink(segment[start].Hash); duplicate {
-		return false, 0
+		return false, nil, 0
 	}
 	// Walk the segment from children towards parents
 	for i, h := range segment[start:] {
 		// Check if the header can be attached to any links
-		if _, attaching := hd.getLink(h.Header.ParentHash); attaching {
-			return true, start + i + 1
+		if link, attaching := hd.getLink(h.Header.ParentHash); attaching {
+			return true, link, start + i + 1
 		}
 	}
-	return false, len(segment)
+	return false, nil, len(segment)
 }
 
 func (hd *HeaderDownload) removeUpwards(toRemove []*Link) {
@@ -183,108 +183,28 @@ func (hd *HeaderDownload) markPreverified(link *Link) {
 }
 
 // ExtendUp extends a working tree up from the link, using given chain segment
-func (hd *HeaderDownload) extendUp(segment ChainSegment) error {
-	// Find attachment link again
-	linkH := segment[len(segment)-1]
-	attachmentLink, attaching := hd.getLink(linkH.Header.ParentHash)
-	if !attaching {
-		return fmt.Errorf("extendUp attachment link not found for %x", linkH.Header.ParentHash)
-	}
-	if attachmentLink.preverified && len(attachmentLink.next) > 0 {
-		return fmt.Errorf("cannot extendUp from preverified link %d with children", attachmentLink.blockHeight)
-	}
+func (hd *HeaderDownload) extendUp(segment ChainSegment, attachmentLink *Link) {
 	// Iterate over headers backwards (from parents towards children)
 	prevLink := attachmentLink
 	for i := len(segment) - 1; i >= 0; i-- {
 		link := hd.addHeaderAsLink(segment[i], false /* persisted */)
+		if attachmentLink.persisted {
+			// If we are attching to already persisted link, schedule for insertion (persistence)
+			hd.insertList = append(hd.insertList, link)
+		}
 		prevLink.next = append(prevLink.next, link)
 		prevLink = link
 		if _, ok := hd.preverifiedHashes[link.hash]; ok {
 			hd.markPreverified(link)
 		}
 	}
-
-	if _, bad := hd.badHeaders[attachmentLink.hash]; !bad && attachmentLink.persisted {
-		link := hd.links[linkH.Hash]
-		hd.insertList = append(hd.insertList, link)
-	}
-	return nil
 }
 
 // ExtendDown extends some working trees down from the anchor, using given chain segment
 // it creates a new anchor and collects all the links from the attached anchors to it
-func (hd *HeaderDownload) extendDown(segment ChainSegment) (bool, error) {
+func (hd *HeaderDownload) extendDown(segment ChainSegment, anchor *Anchor) bool {
 	// Find attachment anchor again
-	anchorHash := segment[0].Hash
-	if anchor, attaching := hd.anchors[anchorHash]; attaching {
-		anchorPreverified := false
-		for _, link := range anchor.links {
-			if link.preverified {
-				anchorPreverified = true
-				break
-			}
-		}
-		newAnchorH := segment[len(segment)-1]
-		newAnchorHeader := newAnchorH.Header
-		var newAnchor *Anchor
-		newAnchor, preExisting := hd.anchors[newAnchorHeader.ParentHash]
-		if !preExisting {
-			newAnchor = &Anchor{
-				parentHash:    newAnchorHeader.ParentHash,
-				nextRetryTime: 0, // Will ensure this anchor will be top priority
-				peerID:        anchor.peerID,
-				blockHeight:   newAnchorH.Number,
-			}
-			if newAnchor.blockHeight > 0 {
-				hd.anchors[newAnchorHeader.ParentHash] = newAnchor
-				heap.Push(hd.anchorQueue, newAnchor)
-			}
-		}
-		// Anchor is removed from the map, and from the priority queue
-		delete(hd.anchors, anchor.parentHash)
-		heap.Remove(hd.anchorQueue, anchor.idx)
-		// Add all headers in the segments as links to this anchor
-		var prevLink *Link
-		for i := len(segment) - 1; i >= 0; i-- {
-			link := hd.addHeaderAsLink(segment[i], false /* pesisted */)
-			if prevLink == nil {
-				newAnchor.links = append(newAnchor.links, link)
-			} else {
-				prevLink.next = append(prevLink.next, link)
-			}
-			prevLink = link
-			if _, ok := hd.preverifiedHashes[link.hash]; ok {
-				hd.markPreverified(link)
-			}
-		}
-		prevLink.next = anchor.links
-		anchor.links = nil
-		if anchorPreverified {
-			// Mark the entire segment as preverified
-			hd.markPreverified(prevLink)
-		}
-		return !preExisting, nil
-	}
-	return false, fmt.Errorf("extendDown attachment anchors not found for %x", anchorHash)
-}
 
-// Connect connects some working trees using anchors of some, and a link of another
-func (hd *HeaderDownload) connect(segment ChainSegment) ([]PenaltyItem, error) {
-	// Find attachment link again
-	linkH := segment[len(segment)-1]
-	// Find attachement anchors again
-	anchorHash := segment[0].Hash
-	attachmentLink, ok1 := hd.getLink(linkH.Header.ParentHash)
-	if !ok1 {
-		return nil, fmt.Errorf("connect attachment link not found for %x", linkH.Header.ParentHash)
-	}
-	if attachmentLink.preverified && len(attachmentLink.next) > 0 {
-		return nil, fmt.Errorf("cannot connect to preverified link %d with children", attachmentLink.blockHeight)
-	}
-	anchor, ok2 := hd.anchors[anchorHash]
-	if !ok2 {
-		return nil, fmt.Errorf("connect attachment anchors not found for %x", anchorHash)
-	}
 	anchorPreverified := false
 	for _, link := range anchor.links {
 		if link.preverified {
@@ -292,13 +212,64 @@ func (hd *HeaderDownload) connect(segment ChainSegment) ([]PenaltyItem, error) {
 			break
 		}
 	}
-	// Anchor is removed from the map, and from the priority queue
-	delete(hd.anchors, anchor.parentHash)
-	heap.Remove(hd.anchorQueue, anchor.idx)
+	newAnchorH := segment[len(segment)-1]
+	newAnchorHeader := newAnchorH.Header
+	var newAnchor *Anchor
+	newAnchor, preExisting := hd.anchors[newAnchorHeader.ParentHash]
+	if !preExisting {
+		newAnchor = &Anchor{
+			parentHash:    newAnchorHeader.ParentHash,
+			nextRetryTime: 0, // Will ensure this anchor will be top priority
+			peerID:        anchor.peerID,
+			blockHeight:   newAnchorH.Number,
+		}
+		if newAnchor.blockHeight > 0 {
+			hd.anchors[newAnchorHeader.ParentHash] = newAnchor
+			heap.Push(hd.anchorQueue, newAnchor)
+		}
+	}
+	hd.removeAnchor(anchor)
+	// Add all headers in the segments as links to this anchor
+	var prevLink *Link
+	for i := len(segment) - 1; i >= 0; i-- {
+		link := hd.addHeaderAsLink(segment[i], false /* pesisted */)
+		if prevLink == nil {
+			newAnchor.links = append(newAnchor.links, link)
+		} else {
+			prevLink.next = append(prevLink.next, link)
+		}
+		prevLink = link
+		if _, ok := hd.preverifiedHashes[link.hash]; ok {
+			hd.markPreverified(link)
+		}
+	}
+	prevLink.next = anchor.links
+	anchor.links = nil
+	if anchorPreverified {
+		// Mark the entire segment as preverified
+		hd.markPreverified(prevLink)
+	}
+	return !preExisting
+}
+
+// Connect connects some working trees using anchors of some, and a link of another
+func (hd *HeaderDownload) connect(segment ChainSegment, attachmentLink *Link, anchor *Anchor) []PenaltyItem {
+	anchorPreverified := false
+	for _, link := range anchor.links {
+		if link.preverified {
+			anchorPreverified = true
+			break
+		}
+	}
+	hd.removeAnchor(anchor)
 	// Iterate over headers backwards (from parents towards children)
 	prevLink := attachmentLink
 	for i := len(segment) - 1; i >= 0; i-- {
 		link := hd.addHeaderAsLink(segment[i], false /* persisted */)
+		// If we attach to already persisted link, mark this one for insertion
+		if prevLink.persisted {
+			hd.insertList = append(hd.insertList, link)
+		}
 		prevLink.next = append(prevLink.next, link)
 		prevLink = link
 		if _, ok := hd.preverifiedHashes[link.hash]; ok {
@@ -313,25 +284,16 @@ func (hd *HeaderDownload) connect(segment ChainSegment) ([]PenaltyItem, error) {
 	}
 	var penalties []PenaltyItem
 	if _, bad := hd.badHeaders[attachmentLink.hash]; bad {
-		hd.invalidateAnchor(anchor)
+		hd.invalidateAnchor(anchor, "descendant of a known bad block")
 		penalties = append(penalties, PenaltyItem{Penalty: AbandonedAnchorPenalty, PeerID: anchor.peerID})
-	} else if attachmentLink.persisted {
-		link := hd.links[linkH.Hash]
-		hd.insertList = append(hd.insertList, link)
 	}
-	return penalties, nil
+	return penalties
 }
 
-func (hd *HeaderDownload) removeAnchor(anchorHash common.Hash) error {
-	// Find attachement anchors again
-	anchor, ok := hd.anchors[anchorHash]
-	if !ok {
-		return fmt.Errorf("connect attachment anchors not found for %x", anchorHash)
-	}
+func (hd *HeaderDownload) removeAnchor(anchor *Anchor) {
 	// Anchor is removed from the map, and from the priority queue
 	delete(hd.anchors, anchor.parentHash)
 	heap.Remove(hd.anchorQueue, anchor.idx)
-	return nil
 }
 
 // if anchor will be abandoned - given peerID will get Penalty
@@ -569,40 +531,38 @@ func (hd *HeaderDownload) ReadProgressFromDb(tx kv.RwTx) (err error) {
 	return nil
 }
 
-func (hd *HeaderDownload) invalidateAnchor(anchor *Anchor) {
-	log.Warn("Invalidating anchor for suspected unavailability", "height", anchor.blockHeight)
-	// Anchor is removed only from the map here, because we assume it has been popped from the priority queue
-	delete(hd.anchors, anchor.parentHash)
+func (hd *HeaderDownload) invalidateAnchor(anchor *Anchor, reason string) {
+	log.Warn("Invalidating anchor", "height", anchor.blockHeight, "hash", anchor.parentHash, "reason", reason)
+	hd.removeAnchor(anchor)
 	hd.removeUpwards(anchor.links)
 }
 
-func (hd *HeaderDownload) RequestMoreHeaders(currentTime uint64) (*HeaderRequest, []PenaltyItem) {
+func (hd *HeaderDownload) RequestMoreHeaders(currentTime uint64) (*HeaderRequest, *PenaltyItem) {
 	hd.lock.Lock()
 	defer hd.lock.Unlock()
-	var penalties []PenaltyItem
 	if hd.anchorQueue.Len() == 0 {
 		log.Trace("Empty anchor queue")
-		return nil, penalties
+		return nil, nil
 	}
 	// Only process the anchors for which the nextRetryTime has already come
-	for hd.anchorQueue.Len() > 0 && (*hd.anchorQueue)[0].nextRetryTime <= currentTime {
-		anchor := heap.Pop(hd.anchorQueue).(*Anchor)
-		if anchor.timeouts < 10 {
-			// Produce a header request that would extend this anchor (add parent, parent of parent, etc.)
-			return &HeaderRequest{
-				Anchor:  anchor,
-				Hash:    anchor.parentHash,
-				Number:  anchor.blockHeight - 1,
-				Length:  192,
-				Skip:    0,
-				Reverse: true,
-			}, penalties
-		}
-		// Ancestors of this anchor seem to be unavailable, invalidate and move on
-		hd.invalidateAnchor(anchor)
-		penalties = append(penalties, PenaltyItem{Penalty: AbandonedAnchorPenalty, PeerID: anchor.peerID})
+	if (*hd.anchorQueue)[0].nextRetryTime > currentTime {
+		return nil, nil
 	}
-	return nil, penalties
+	anchor := (*hd.anchorQueue)[0]
+	if anchor.timeouts < 10 {
+		// Produce a header request that would extend this anchor (add parent, parent of parent, etc.)
+		return &HeaderRequest{
+			Anchor:  anchor,
+			Hash:    anchor.parentHash,
+			Number:  anchor.blockHeight - 1,
+			Length:  192,
+			Skip:    0,
+			Reverse: true,
+		}, nil
+	}
+	// Ancestors of this anchor seem to be unavailable, invalidate and move on
+	hd.invalidateAnchor(anchor, "suspected unavailability")
+	return nil, &PenaltyItem{Penalty: AbandonedAnchorPenalty, PeerID: anchor.peerID}
 }
 
 func (hd *HeaderDownload) UpdateRetryTime(req *HeaderRequest, currentTime, timeout uint64) {
@@ -923,16 +883,14 @@ func (hd *HeaderDownload) ProcessSegment(segment ChainSegment, newBlock bool, pe
 	log.Trace("processSegment", "from", lowestNum, "to", highestNum)
 	hd.lock.Lock()
 	defer hd.lock.Unlock()
-	foundAnchor, start := hd.findAnchors(segment)
-	foundTip, end := hd.findLink(segment, start) // We ignore penalty because we will check it as part of PoW check
+	foundAnchor, anchor, start := hd.findAnchor(segment)
+	foundTip, link, end := hd.findLink(segment, start)
 	if end == 0 {
 		log.Trace("Duplicate segment")
 		if foundAnchor {
 			// If duplicate segment is extending from the anchor, the anchor needs to be deleted,
 			// otherwise it will keep producing requests that will be found duplicate
-			if err := hd.removeAnchor(segment[start].Hash); err != nil {
-				log.Warn("removal of anchor failed", "error", err)
-			}
+			hd.removeAnchor(anchor)
 		}
 		return
 	}
@@ -949,27 +907,16 @@ func (hd *HeaderDownload) ProcessSegment(segment ChainSegment, newBlock bool, pe
 	if foundAnchor {
 		if foundTip {
 			// Connect
-			var err error
-			if penalties, err = hd.connect(subSegment); err != nil {
-				log.Debug("Connect failed", "error", err)
-				return
-			}
+			penalties = hd.connect(subSegment, link, anchor)
 			log.Trace("Connected", "start", startNum, "end", endNum)
 		} else {
 			// ExtendDown
-			var err error
-			if requestMore, err = hd.extendDown(subSegment); err != nil {
-				log.Debug("ExtendDown failed", "error", err)
-				return
-			}
+			requestMore = hd.extendDown(subSegment, anchor)
 			log.Trace("Extended Down", "start", startNum, "end", endNum)
 		}
 	} else if foundTip {
 		// ExtendUp
-		if err := hd.extendUp(subSegment); err != nil {
-			log.Debug("ExtendUp failed", "error", err)
-			return
-		}
+		hd.extendUp(subSegment, link)
 		log.Trace("Extended Up", "start", startNum, "end", endNum)
 	} else {
 		// NewAnchor

--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -305,11 +305,11 @@ func (hd *HeaderDownload) newAnchor(segment ChainSegment, peerID enode.ID) bool 
 	anchor, preExisting := hd.anchors[anchorHeader.ParentHash]
 	if !preExisting {
 		if anchorH.Number < hd.highestInDb {
-			log.Warn(fmt.Sprintf("new anchor too far in the past: %d, latest header in db: %d", anchorH.Number, hd.highestInDb))
+			log.Debug(fmt.Sprintf("new anchor too far in the past: %d, latest header in db: %d", anchorH.Number, hd.highestInDb))
 			return false
 		}
 		if len(hd.anchors) >= hd.anchorLimit {
-			log.Warn(fmt.Sprintf("too many anchors: %d, limit %d", len(hd.anchors), hd.anchorLimit))
+			log.Debug(fmt.Sprintf("too many anchors: %d, limit %d", len(hd.anchors), hd.anchorLimit))
 			return false
 		}
 		anchor = &Anchor{

--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -240,11 +240,9 @@ func (hd *HeaderDownload) extendDown(segment ChainSegment) (bool, error) {
 				heap.Push(hd.anchorQueue, newAnchor)
 			}
 		}
-
-		// Anchor is removed from the map, but not from the anchorQueue
-		// This is because it is hard to find the index under which the anchor is stored in the anchorQueue
-		// But removal will happen anyway, in th function RequestMoreHeaders, if it disapppears from the map
+		// Anchor is removed from the map, and from the priority queue
 		delete(hd.anchors, anchor.parentHash)
+		heap.Remove(hd.anchorQueue, anchor.idx)
 		// Add all headers in the segments as links to this anchor
 		var prevLink *Link
 		for i := len(segment) - 1; i >= 0; i-- {
@@ -294,10 +292,9 @@ func (hd *HeaderDownload) connect(segment ChainSegment) ([]PenaltyItem, error) {
 			break
 		}
 	}
-	// Anchor is removed from the map, but not from the anchorQueue
-	// This is because it is hard to find the index under which the anchor is stored in the anchorQueue
-	// But removal will happen anyway, in th function RequestMoreHeaders, if it disapppears from the map
+	// Anchor is removed from the map, and from the priority queue
 	delete(hd.anchors, anchor.parentHash)
+	heap.Remove(hd.anchorQueue, anchor.idx)
 	// Iterate over headers backwards (from parents towards children)
 	prevLink := attachmentLink
 	for i := len(segment) - 1; i >= 0; i-- {
@@ -331,10 +328,9 @@ func (hd *HeaderDownload) removeAnchor(anchorHash common.Hash) error {
 	if !ok {
 		return fmt.Errorf("connect attachment anchors not found for %x", anchorHash)
 	}
-	// Anchor is removed from the map, but not from the anchorQueue
-	// This is because it is hard to find the index under which the anchor is stored in the anchorQueue
-	// But removal will happen anyway, in th function RequestMoreHeaders, if it disapppears from the map
+	// Anchor is removed from the map, and from the priority queue
 	delete(hd.anchors, anchor.parentHash)
+	heap.Remove(hd.anchorQueue, anchor.idx)
 	return nil
 }
 
@@ -575,6 +571,7 @@ func (hd *HeaderDownload) ReadProgressFromDb(tx kv.RwTx) (err error) {
 
 func (hd *HeaderDownload) invalidateAnchor(anchor *Anchor) {
 	log.Warn("Invalidating anchor for suspected unavailability", "height", anchor.blockHeight)
+	// Anchor is removed only from the map here, because we assume it has been popped from the priority queue
 	delete(hd.anchors, anchor.parentHash)
 	hd.removeUpwards(anchor.links)
 }
@@ -587,37 +584,33 @@ func (hd *HeaderDownload) RequestMoreHeaders(currentTime uint64) (*HeaderRequest
 		log.Trace("Empty anchor queue")
 		return nil, penalties
 	}
-	for hd.anchorQueue.Len() > 0 {
-		anchor := (*hd.anchorQueue)[0]
-		if _, ok := hd.anchors[anchor.parentHash]; ok {
-			if anchor.nextRetryTime > currentTime {
-				// Anchor not ready for re-request yet
-				return nil, penalties
-			}
-			if anchor.timeouts < 10 {
-				return &HeaderRequest{Hash: anchor.parentHash, Number: anchor.blockHeight - 1, Length: 192, Skip: 0, Reverse: true}, penalties
-			} else {
-				// Ancestors of this anchor seem to be unavailable, invalidate and move on
-				hd.invalidateAnchor(anchor)
-				penalties = append(penalties, PenaltyItem{Penalty: AbandonedAnchorPenalty, PeerID: anchor.peerID})
-			}
+	// Only process the anchors for which the nextRetryTime has already come
+	for hd.anchorQueue.Len() > 0 && (*hd.anchorQueue)[0].nextRetryTime <= currentTime {
+		anchor := heap.Pop(hd.anchorQueue).(*Anchor)
+		if anchor.timeouts < 10 {
+			// Produce a header request that would extend this anchor (add parent, parent of parent, etc.)
+			return &HeaderRequest{
+				Anchor:  anchor,
+				Hash:    anchor.parentHash,
+				Number:  anchor.blockHeight - 1,
+				Length:  192,
+				Skip:    0,
+				Reverse: true,
+			}, penalties
 		}
-		// Anchor disappeared or unavailable, pop from the queue and move on
-		heap.Remove(hd.anchorQueue, 0)
+		// Ancestors of this anchor seem to be unavailable, invalidate and move on
+		hd.invalidateAnchor(anchor)
+		penalties = append(penalties, PenaltyItem{Penalty: AbandonedAnchorPenalty, PeerID: anchor.peerID})
 	}
 	return nil, penalties
 }
 
-func (hd *HeaderDownload) SentRequest(req *HeaderRequest, currentTime, timeout uint64) {
+func (hd *HeaderDownload) UpdateRetryTime(req *HeaderRequest, currentTime, timeout uint64) {
 	hd.lock.Lock()
 	defer hd.lock.Unlock()
-	anchor, ok := hd.anchors[req.Hash]
-	if !ok {
-		return
-	}
-	anchor.timeouts++
-	anchor.nextRetryTime = currentTime + timeout
-	heap.Fix(hd.anchorQueue, anchor.idx)
+	req.Anchor.timeouts++
+	req.Anchor.nextRetryTime = currentTime + timeout
+	heap.Fix(hd.anchorQueue, req.Anchor.idx)
 }
 
 func (hd *HeaderDownload) RequestSkeleton() *HeaderRequest {

--- a/turbo/stages/headerdownload/header_data_struct.go
+++ b/turbo/stages/headerdownload/header_data_struct.go
@@ -179,6 +179,7 @@ type HeaderRequest struct {
 	Length  uint64
 	Skip    uint64
 	Reverse bool
+	Anchor  *Anchor
 }
 
 type PenaltyItem struct {

--- a/turbo/stages/headerdownload/header_data_struct.go
+++ b/turbo/stages/headerdownload/header_data_struct.go
@@ -21,6 +21,7 @@ import (
 // present to allow potential reorgs
 type Link struct {
 	header      *types.Header
+	headerRaw   []byte
 	next        []*Link     // Allows iteration over links in ascending block height order
 	hash        common.Hash // Hash of the header
 	blockHeight uint64


### PR DESCRIPTION
1. Anchors are now deleted from both `anchors` map and the `anchorQueue` to keep them in sync
2. Following (1), function `RequestMoreHeader` can now stop checking if anchor is still in `anchors` map
3. `HeaderRequest` now includes pointer to the anchor, from which that request was originated, it means we don't need to look for the anchor again by hash
4. Function `SentHeaderRequest` renamed to `UpdateRetryTime` to better describe what it does