### PR TITLE
Add transaction rlp encoder. Use it in DynamicFeeTransaction

### DIFF
--- a/core/types/dynamic_fee_tx.go
+++ b/core/types/dynamic_fee_tx.go
@@ -417,10 +417,11 @@ func (tx *DynamicFeeTransaction) DecodeRLP(s *rlp.Stream) error {
 	}
 	tx.Value = value
 
-	err = decoder.Data(&tx.Data)
+	data, err := decoder.Data()
 	if err != nil {
 		return err
 	}
+	tx.Data = data
 
 	tx.AccessList = AccessList{}
 	if err = decoder.AccessList(&tx.AccessList); err != nil {

--- a/core/types/starknet_tx.go
+++ b/core/types/starknet_tx.go
@@ -39,10 +39,12 @@ func (tx *StarknetTransaction) DecodeRLP(s *rlp.Stream) error {
 	if len(b) > 32 {
 		return fmt.Errorf("wrong size for ChainID: %d", len(b))
 	}
-	//tx.ChainID = new(uint256.Int).SetBytes(b)
+	tx.ChainID = new(uint256.Int).SetBytes(b)
+
 	if tx.Nonce, err = s.Uint(); err != nil {
 		return err
 	}
+
 	if b, err = s.Bytes(); err != nil {
 		return err
 	}
@@ -50,6 +52,7 @@ func (tx *StarknetTransaction) DecodeRLP(s *rlp.Stream) error {
 		return fmt.Errorf("wrong size for MaxPriorityFeePerGas: %d", len(b))
 	}
 	tx.Tip = new(uint256.Int).SetBytes(b)
+
 	if b, err = s.Bytes(); err != nil {
 		return err
 	}
@@ -57,6 +60,7 @@ func (tx *StarknetTransaction) DecodeRLP(s *rlp.Stream) error {
 		return fmt.Errorf("wrong size for MaxFeePerGas: %d", len(b))
 	}
 	tx.FeeCap = new(uint256.Int).SetBytes(b)
+
 	if tx.Gas, err = s.Uint(); err != nil {
 		return err
 	}
@@ -70,6 +74,7 @@ func (tx *StarknetTransaction) DecodeRLP(s *rlp.Stream) error {
 		tx.To = &common.Address{}
 		copy((*tx.To)[:], b)
 	}
+
 	if b, err = s.Bytes(); err != nil {
 		return err
 	}

--- a/core/types/transaction_rlp_decoder.go
+++ b/core/types/transaction_rlp_decoder.go
@@ -54,6 +54,10 @@ func (d TransactionRLPDecoder) To() (*common.Address, error) {
 		return nil, fmt.Errorf("wrong size for To: %d", len(b))
 	}
 
+	if len(b) == 0 {
+		return nil, nil
+	}
+
 	to := &common.Address{}
 	copy((*to)[:], b)
 
@@ -64,12 +68,18 @@ func (d TransactionRLPDecoder) Value() (*uint256.Int, error) {
 	return d.uint256Bytes()
 }
 
-func (d TransactionRLPDecoder) Data(data *[]byte) error {
-	var err error
-	if *data, err = d.bytes(); err != nil {
-		return err
+func (d TransactionRLPDecoder) Data() ([]byte, error) {
+	data, err := d.bytes()
+
+	if err != nil {
+		return nil, err
 	}
-	return nil
+
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	return data, nil
 }
 
 func (d TransactionRLPDecoder) AccessList(al *AccessList) error {

--- a/core/types/transaction_rlp_decoder.go
+++ b/core/types/transaction_rlp_decoder.go
@@ -1,0 +1,119 @@
+package types
+
+import (
+	"fmt"
+	"github.com/holiman/uint256"
+	"github.com/ledgerwatch/erigon/common"
+	"github.com/ledgerwatch/erigon/rlp"
+)
+
+type TransactionRLPDecoder struct {
+	s *rlp.Stream
+}
+
+func (d *TransactionRLPDecoder) Start() error {
+	if _, err := d.s.List(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *TransactionRLPDecoder) End() error {
+	return d.s.ListEnd()
+}
+
+func (d TransactionRLPDecoder) ChainID() (*uint256.Int, error) {
+	return d.uint256Bytes()
+}
+
+func (d TransactionRLPDecoder) Nonce() (uint64, error) {
+	return d.uint64()
+}
+
+func (d TransactionRLPDecoder) Tip() (*uint256.Int, error) {
+	return d.uint256Bytes()
+}
+
+func (d TransactionRLPDecoder) FeeCap() (*uint256.Int, error) {
+	return d.uint256Bytes()
+}
+
+func (d TransactionRLPDecoder) Gas() (uint64, error) {
+	return d.uint64()
+}
+
+func (d TransactionRLPDecoder) To() (*common.Address, error) {
+	b, err := d.s.Bytes()
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(b) > 0 && len(b) != 20 {
+		return nil, fmt.Errorf("wrong size for To: %d", len(b))
+	}
+
+	to := &common.Address{}
+	copy((*to)[:], b)
+
+	return to, nil
+}
+
+func (d TransactionRLPDecoder) Value() (*uint256.Int, error) {
+	return d.uint256Bytes()
+}
+
+func (d TransactionRLPDecoder) Data(data *[]byte) error {
+	var err error
+	if *data, err = d.bytes(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d TransactionRLPDecoder) AccessList(al *AccessList) error {
+	return decodeAccessList(al, d.s)
+}
+
+func (d TransactionRLPDecoder) V() (*uint256.Int, error) {
+	return d.uint256Bytes()
+}
+
+func (d TransactionRLPDecoder) R() (*uint256.Int, error) {
+	return d.uint256Bytes()
+}
+
+func (d TransactionRLPDecoder) S() (*uint256.Int, error) {
+	return d.uint256Bytes()
+}
+
+func (d TransactionRLPDecoder) uint64() (uint64, error) {
+	value, err := d.s.Uint()
+
+	if err != nil {
+		return value, err
+	}
+
+	return value, nil
+}
+
+func (d TransactionRLPDecoder) uint256Bytes() (*uint256.Int, error) {
+	b, err := d.s.Uint256Bytes()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return new(uint256.Int).SetBytes(b), nil
+}
+
+func (d TransactionRLPDecoder) bytes() ([]byte, error) {
+	b, err := d.s.Bytes()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}

--- a/core/types/transaction_rlp_decoder_test.go
+++ b/core/types/transaction_rlp_decoder_test.go
@@ -1,0 +1,113 @@
+package types
+
+import (
+	"bytes"
+	"github.com/holiman/uint256"
+	"github.com/ledgerwatch/erigon/common"
+	"github.com/ledgerwatch/erigon/crypto"
+	"github.com/ledgerwatch/erigon/params"
+	"github.com/ledgerwatch/erigon/rlp"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/sha3"
+	"testing"
+)
+
+const (
+	privateKey = "b9a8b19ff082a7f4b943fcbe0da6cce6ce2c860090f05d031f463412ab534e95"
+	address    = "0x67b1d87101671b127f5f8714789c7192f7ad340e"
+)
+
+func TestDecodeList(t *testing.T) {
+	require := require.New(t)
+
+	privateKey, _ := crypto.HexToECDSA(privateKey)
+	address := common.HexToAddress(address)
+	chainConfig := params.AllEthashProtocolChanges
+
+	signature, _ := crypto.Sign(sha3.New256().Sum(nil), privateKey)
+	signer := MakeSigner(chainConfig, 1)
+
+	t.Run("DynamicFeeTransaction", func(t *testing.T) {
+		tx := DynamicFeeTransaction{
+			CommonTx: CommonTx{
+				ChainID: uint256.NewInt(chainConfig.ChainID.Uint64()),
+				Nonce:   1,
+				Value:   uint256.NewInt(20),
+				Gas:     1,
+				To:      &address,
+				Data:    []byte("{\"abi\": []}"),
+			},
+			Tip:    uint256.NewInt(1),
+			FeeCap: uint256.NewInt(1),
+		}
+
+		signedTx, err := tx.WithSignature(*signer, signature)
+		require.NoError(err)
+
+		buf := bytes.NewBuffer(nil)
+
+		err = signedTx.MarshalBinary(buf)
+		require.NoError(err)
+		buf.Next(1)
+
+		encodedTx := buf.Bytes()
+
+		decoder := TransactionRLPDecoder{
+			rlp.NewStream(bytes.NewReader(encodedTx), uint64(len(encodedTx))),
+		}
+
+		err = decoder.Start()
+		require.NoError(err)
+
+		chainID, err := decoder.ChainID()
+		require.NoError(err)
+		require.Equal(signedTx.GetChainID(), chainID)
+
+		nonce, err := decoder.Nonce()
+		require.NoError(err)
+		require.Equal(signedTx.GetNonce(), nonce)
+
+		tip, err := decoder.Tip()
+		require.NoError(err)
+		require.Equal(signedTx.GetTip(), tip)
+
+		feeCap, err := decoder.FeeCap()
+		require.NoError(err)
+		require.Equal(signedTx.GetFeeCap(), feeCap)
+
+		gas, err := decoder.Gas()
+		require.NoError(err)
+		require.Equal(signedTx.GetGas(), gas)
+
+		to, err := decoder.To()
+		require.NoError(err)
+		require.Equal(signedTx.GetTo(), to)
+
+		value, err := decoder.Value()
+		require.NoError(err)
+		require.Equal(signedTx.GetValue(), value)
+
+		data := &[]byte{}
+		err = decoder.Data(data)
+		require.NoError(err)
+		require.Equal(signedTx.GetData(), *data)
+
+		accessList := &AccessList{}
+		err = decoder.AccessList(accessList)
+		require.NoError(err)
+
+		V, R, S := signedTx.RawSignatureValues()
+
+		v, err := decoder.V()
+		require.NoError(err)
+		require.Equal(V, v)
+
+		r, err := decoder.R()
+		require.NoError(err)
+		require.Equal(R, r)
+
+		s, err := decoder.S()
+		require.NoError(err)
+		require.Equal(S, s)
+	})
+}

--- a/core/types/transaction_rlp_decoder_test.go
+++ b/core/types/transaction_rlp_decoder_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ledgerwatch/erigon/rlp"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/sha3"
+	"math/big"
 	"testing"
 )
 
@@ -27,87 +28,129 @@ func TestDecodeList(t *testing.T) {
 	signature, _ := crypto.Sign(sha3.New256().Sum(nil), privateKey)
 	signer := MakeSigner(chainConfig, 1)
 
-	t.Run("DynamicFeeTransaction", func(t *testing.T) {
-		tx := DynamicFeeTransaction{
-			CommonTx: CommonTx{
-				ChainID: uint256.NewInt(chainConfig.ChainID.Uint64()),
-				Nonce:   1,
-				Value:   uint256.NewInt(20),
-				Gas:     1,
-				To:      &address,
-				Data:    []byte("{\"abi\": []}"),
-			},
-			Tip:    uint256.NewInt(1),
-			FeeCap: uint256.NewInt(1),
-		}
+	cases := []struct {
+		name string
+		tx   *DynamicFeeTransaction
+	}{
+		{name: "without data", tx: dynamicFeeTransactionWithoutData(chainConfig.ChainID, address)},
+		{name: "with data", tx: dynamicFeeTransactionWithData(chainConfig.ChainID, address)},
+		{name: "contract deploy", tx: dynamicFeeTransactionContractDeploy(chainConfig.ChainID, address)},
+	}
 
-		signedTx, err := tx.WithSignature(*signer, signature)
-		require.NoError(err)
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			tx := tt.tx
+			signedTx, err := tx.WithSignature(*signer, signature)
+			require.NoError(err)
 
-		buf := bytes.NewBuffer(nil)
+			buf := bytes.NewBuffer(nil)
 
-		err = signedTx.MarshalBinary(buf)
-		require.NoError(err)
-		buf.Next(1)
+			err = signedTx.MarshalBinary(buf)
+			require.NoError(err)
+			buf.Next(1)
 
-		encodedTx := buf.Bytes()
+			encodedTx := buf.Bytes()
 
-		decoder := TransactionRLPDecoder{
-			rlp.NewStream(bytes.NewReader(encodedTx), uint64(len(encodedTx))),
-		}
+			decoder := TransactionRLPDecoder{
+				rlp.NewStream(bytes.NewReader(encodedTx), uint64(len(encodedTx))),
+			}
 
-		err = decoder.Start()
-		require.NoError(err)
+			err = decoder.Start()
+			require.NoError(err)
 
-		chainID, err := decoder.ChainID()
-		require.NoError(err)
-		require.Equal(signedTx.GetChainID(), chainID)
+			chainID, err := decoder.ChainID()
+			require.NoError(err)
+			require.Equal(signedTx.GetChainID(), chainID)
 
-		nonce, err := decoder.Nonce()
-		require.NoError(err)
-		require.Equal(signedTx.GetNonce(), nonce)
+			nonce, err := decoder.Nonce()
+			require.NoError(err)
+			require.Equal(signedTx.GetNonce(), nonce)
 
-		tip, err := decoder.Tip()
-		require.NoError(err)
-		require.Equal(signedTx.GetTip(), tip)
+			tip, err := decoder.Tip()
+			require.NoError(err)
+			require.Equal(signedTx.GetTip(), tip)
 
-		feeCap, err := decoder.FeeCap()
-		require.NoError(err)
-		require.Equal(signedTx.GetFeeCap(), feeCap)
+			feeCap, err := decoder.FeeCap()
+			require.NoError(err)
+			require.Equal(signedTx.GetFeeCap(), feeCap)
 
-		gas, err := decoder.Gas()
-		require.NoError(err)
-		require.Equal(signedTx.GetGas(), gas)
+			gas, err := decoder.Gas()
+			require.NoError(err)
+			require.Equal(signedTx.GetGas(), gas)
 
-		to, err := decoder.To()
-		require.NoError(err)
-		require.Equal(signedTx.GetTo(), to)
+			to, err := decoder.To()
+			require.NoError(err)
+			require.Equal(signedTx.GetTo(), to)
 
-		value, err := decoder.Value()
-		require.NoError(err)
-		require.Equal(signedTx.GetValue(), value)
+			value, err := decoder.Value()
+			require.NoError(err)
+			require.Equal(signedTx.GetValue(), value)
 
-		data := &[]byte{}
-		err = decoder.Data(data)
-		require.NoError(err)
-		require.Equal(signedTx.GetData(), *data)
+			//data := &[]byte{}
+			data, err := decoder.Data()
+			require.NoError(err)
+			require.Equal(signedTx.GetData(), data)
 
-		accessList := &AccessList{}
-		err = decoder.AccessList(accessList)
-		require.NoError(err)
+			accessList := &AccessList{}
+			err = decoder.AccessList(accessList)
+			require.NoError(err)
 
-		V, R, S := signedTx.RawSignatureValues()
+			V, R, S := signedTx.RawSignatureValues()
 
-		v, err := decoder.V()
-		require.NoError(err)
-		require.Equal(V, v)
+			v, err := decoder.V()
+			require.NoError(err)
+			require.Equal(V, v)
 
-		r, err := decoder.R()
-		require.NoError(err)
-		require.Equal(R, r)
+			r, err := decoder.R()
+			require.NoError(err)
+			require.Equal(R, r)
 
-		s, err := decoder.S()
-		require.NoError(err)
-		require.Equal(S, s)
-	})
+			s, err := decoder.S()
+			require.NoError(err)
+			require.Equal(S, s)
+		})
+	}
+}
+
+func dynamicFeeTransactionWithoutData(chainId *big.Int, address common.Address) *DynamicFeeTransaction {
+	return &DynamicFeeTransaction{
+		CommonTx: CommonTx{
+			ChainID: uint256.NewInt(chainId.Uint64()),
+			Nonce:   1,
+			Value:   uint256.NewInt(20),
+			Gas:     1,
+			To:      &address,
+		},
+		Tip:    uint256.NewInt(1),
+		FeeCap: uint256.NewInt(1),
+	}
+}
+
+func dynamicFeeTransactionWithData(chainId *big.Int, address common.Address) *DynamicFeeTransaction {
+	return &DynamicFeeTransaction{
+		CommonTx: CommonTx{
+			ChainID: uint256.NewInt(chainId.Uint64()),
+			Nonce:   1,
+			Value:   uint256.NewInt(20),
+			Gas:     1,
+			To:      &address,
+			Data:    []byte("{\"abi\": []}"),
+		},
+		Tip:    uint256.NewInt(1),
+		FeeCap: uint256.NewInt(1),
+	}
+}
+
+func dynamicFeeTransactionContractDeploy(chainId *big.Int, address common.Address) *DynamicFeeTransaction {
+	return &DynamicFeeTransaction{
+		CommonTx: CommonTx{
+			ChainID: uint256.NewInt(chainId.Uint64()),
+			Nonce:   1,
+			Value:   uint256.NewInt(20),
+			Gas:     1,
+			Data:    []byte("{\"abi\": []}"),
+		},
+		Tip:    uint256.NewInt(1),
+		FeeCap: uint256.NewInt(1),
+	}
 }


### PR DESCRIPTION
RLP decoder was added to reduce copy/paste in the `DecodeRLP` method of transactions.
For now, it is only used in *DynamicFeeTransaction*. I would like to know your opinion about this approach. If it is ok I will update other types of transactions.

Also, there are two approaches:
1. Send parameter to the function
```
err = decoder.Data(&tx.Data)
```
2. Return it from it
```
value, err := decoder.Value()
tx.Value = value
```

Both of these have one drawback: check error
```
if err != nil {
    return err
}
```