### PR TITLE
Move transition logic out of FeedHeaderFunc

### DIFF
--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -410,7 +410,7 @@ Loop:
 		}
 		// Load headers into the database
 		var inSync bool
-		if inSync, err = cfg.hd.InsertHeaders(headerInserter.FeedHeaderFunc(tx, cfg.blockReader), cfg.chainConfig.TerminalTotalDifficulty, logPrefix, logEvery.C); err != nil {
+		if inSync, err = cfg.hd.InsertHeaders(headerInserter.NewFeedHeaderFunc(tx, cfg.blockReader), cfg.chainConfig.TerminalTotalDifficulty, logPrefix, logEvery.C); err != nil {
 			return err
 		}
 

--- a/turbo/stages/headerdownload/header_algo_test.go
+++ b/turbo/stages/headerdownload/header_algo_test.go
@@ -51,11 +51,11 @@ func TestInserter1(t *testing.T) {
 	}
 	h2Hash := h2.Hash()
 	data1, _ := rlp.EncodeToBytes(&h1)
-	if _, err = hi.FeedHeader(tx, snapshotsync.NewBlockReader(), &h1, data1, h1Hash, 1, nil); err != nil {
+	if _, err = hi.FeedHeader(tx, snapshotsync.NewBlockReader(), &h1, data1, h1Hash, 1); err != nil {
 		t.Errorf("feed empty header 1: %v", err)
 	}
 	data2, _ := rlp.EncodeToBytes(&h2)
-	if _, err = hi.FeedHeader(tx, snapshotsync.NewBlockReader(), &h2, data2, h2Hash, 2, nil); err != nil {
+	if _, err = hi.FeedHeader(tx, snapshotsync.NewBlockReader(), &h2, data2, h2Hash, 2); err != nil {
 		t.Errorf("feed empty header 2: %v", err)
 	}
 }


### PR DESCRIPTION
Moves the transition logic out of `FeedHeader()` rather than passing in `terminalTotalDifficulty` and returning `isTrans`.

These changes are split from another larger, dependent PR so that they can be approved without the larger changes blocking the Serenity PR, due to the overlap with `FeedHeaderFunc`.