### PR TITLE
Snapshots: tx lookup in RPC from snapshots

### DIFF
--- a/cmd/downloader/readme.md
+++ b/cmd/downloader/readme.md
@@ -72,6 +72,7 @@ rsync server1:<your_datadir>/snapshots/*.torrent server2:<your_datadir>/snapshot
 ### Re-create all .idx files
 
 ```
+// Disk-read-intense
 erigon snapshots index --datadir=<your_datadir>
 ```
 

--- a/cmd/downloader/readme.md
+++ b/cmd/downloader/readme.md
@@ -69,6 +69,12 @@ rsync server1:<your_datadir>/snapshots/*.torrent server2:<your_datadir>/snapshot
 // re-start downloader 
 ```
 
+### Re-create all .idx files
+
+```
+erigon snapshots index --datadir=<your_datadir>
+```
+
 ## Known Issues
 
 - RPCDaemon with --datadir option need restart to make new segments available

--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -868,7 +868,7 @@ func validateTxLookups2(db kv.RwDB, startBlock uint64, interruptCh chan bool) {
 	for !interrupt {
 		blockHash, err := rawdb.ReadCanonicalHash(tx, blockNum)
 		tool.Check(err)
-		body := rawdb.ReadBodyWithTransactions(tx, blockHash, blockNum)
+		body := rawdb.ReadCanonicalBodyWithTransactions(tx, blockHash, blockNum)
 
 		if body == nil {
 			break
@@ -1676,7 +1676,7 @@ func mint(chaindata string, block uint64) error {
 			fmt.Printf("Gap [%d-%d]\n", prevBlock, blockNumber-1)
 		}
 		prevBlock = blockNumber
-		body := rawdb.ReadBodyWithTransactions(tx, blockHash, blockNumber)
+		body := rawdb.ReadCanonicalBodyWithTransactions(tx, blockHash, blockNumber)
 		header := rawdb.ReadHeader(tx, blockHash, blockNumber)
 		senders, errSenders := rawdb.ReadSenders(tx, blockHash, blockNumber)
 		if errSenders != nil {

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -231,7 +231,7 @@ func checkDbCompatibility(ctx context.Context, db kv.RoDB) error {
 	return nil
 }
 
-func RemoteServices(ctx context.Context, cfg Flags, logger log.Logger, rootCancel context.CancelFunc) (db kv.RoDB, eth services.ApiBackend, txPool *services.TxPoolService, mining *services.MiningService, stateCache kvcache.Cache, blockReader interfaces.BlockReader, err error) {
+func RemoteServices(ctx context.Context, cfg Flags, logger log.Logger, rootCancel context.CancelFunc) (db kv.RoDB, eth services.ApiBackend, txPool *services.TxPoolService, mining *services.MiningService, stateCache kvcache.Cache, blockReader interfaces.BlockAndTxnReader, err error) {
 	if !cfg.SingleNodeMode && cfg.PrivateApiAddr == "" {
 		return nil, nil, nil, nil, nil, nil, fmt.Errorf("either remote db or local db must be specified")
 	}

--- a/cmd/rpcdaemon/commands/daemon.go
+++ b/cmd/rpcdaemon/commands/daemon.go
@@ -17,7 +17,7 @@ import (
 func APIList(ctx context.Context, db kv.RoDB,
 	eth services.ApiBackend, txPool txpool.TxpoolClient, mining txpool.MiningClient, filters *filters.Filters,
 	stateCache kvcache.Cache,
-	blockReader interfaces.FullBlockReader,
+	blockReader interfaces.BlockAndTxnReader,
 	cfg cli.Flags, customAPIList []rpc.API) []rpc.API {
 	var defaultAPIList []rpc.API
 

--- a/cmd/rpcdaemon/commands/daemon.go
+++ b/cmd/rpcdaemon/commands/daemon.go
@@ -17,7 +17,7 @@ import (
 func APIList(ctx context.Context, db kv.RoDB,
 	eth services.ApiBackend, txPool txpool.TxpoolClient, mining txpool.MiningClient, filters *filters.Filters,
 	stateCache kvcache.Cache,
-	blockReader interfaces.BlockReader,
+	blockReader interfaces.FullBlockReader,
 	cfg cli.Flags, customAPIList []rpc.API) []rpc.API {
 	var defaultAPIList []rpc.API
 

--- a/cmd/rpcdaemon/commands/erigon_issuance.go
+++ b/cmd/rpcdaemon/commands/erigon_issuance.go
@@ -59,7 +59,7 @@ func (api *ErigonImpl) WatchTheBurn(ctx context.Context, blockNr rpc.BlockNumber
 		return Issuance{}, fmt.Errorf("could not find block header")
 	}
 
-	body := rawdb.ReadBodyWithTransactions(tx, hash, uint64(blockNr))
+	body := rawdb.ReadCanonicalBodyWithTransactions(tx, hash, uint64(blockNr))
 
 	if body == nil {
 		return Issuance{}, fmt.Errorf("could not find block body")

--- a/cmd/rpcdaemon/commands/eth_api.go
+++ b/cmd/rpcdaemon/commands/eth_api.go
@@ -107,11 +107,11 @@ type BaseAPI struct {
 	_genesis     *types.Block
 	_genesisLock sync.RWMutex
 
-	_blockReader interfaces.BlockReader
+	_blockReader interfaces.FullBlockReader
 	TevmEnabled  bool // experiment
 }
 
-func NewBaseApi(f *filters.Filters, stateCache kvcache.Cache, blockReader interfaces.BlockReader, singleNodeMode bool) *BaseAPI {
+func NewBaseApi(f *filters.Filters, stateCache kvcache.Cache, blockReader interfaces.FullBlockReader, singleNodeMode bool) *BaseAPI {
 	blocksLRUSize := 128 // ~32Mb
 	if !singleNodeMode {
 		blocksLRUSize = 512

--- a/cmd/rpcdaemon/commands/eth_api.go
+++ b/cmd/rpcdaemon/commands/eth_api.go
@@ -107,7 +107,8 @@ type BaseAPI struct {
 	_genesis     *types.Block
 	_genesisLock sync.RWMutex
 
-	_blockReader interfaces.BlockAndTxnReader
+	_blockReader interfaces.BlockReader
+	_txnReader   interfaces.TxnReader
 	TevmEnabled  bool // experiment
 }
 
@@ -121,7 +122,7 @@ func NewBaseApi(f *filters.Filters, stateCache kvcache.Cache, blockReader interf
 		panic(err)
 	}
 
-	return &BaseAPI{filters: f, stateCache: stateCache, blocksLRU: blocksLRU, _blockReader: blockReader}
+	return &BaseAPI{filters: f, stateCache: stateCache, blocksLRU: blocksLRU, _blockReader: blockReader, _txnReader: blockReader}
 }
 
 func (api *BaseAPI) chainConfig(tx kv.Tx) (*params.ChainConfig, error) {
@@ -135,6 +136,10 @@ func (api *BaseAPI) EnableTevmExperiment() { api.TevmEnabled = true }
 func (api *BaseAPI) genesis(tx kv.Tx) (*types.Block, error) {
 	_, genesis, err := api.chainConfigWithGenesis(tx)
 	return genesis, err
+}
+
+func (api *BaseAPI) txnLookup(ctx context.Context, tx kv.Tx, txnHash common.Hash) (uint64, bool, error) {
+	return api._txnReader.TxnLookup(ctx, tx, txnHash)
 }
 
 func (api *BaseAPI) blockByNumberWithSenders(tx kv.Tx, number uint64) (*types.Block, error) {

--- a/cmd/rpcdaemon/commands/eth_api.go
+++ b/cmd/rpcdaemon/commands/eth_api.go
@@ -180,6 +180,11 @@ func (api *BaseAPI) blockWithSenders(tx kv.Tx, hash common.Hash, number uint64) 
 		return block, nil
 	}
 	if api.blocksLRU != nil {
+		// calc fields before put to cache
+		for _, txn := range block.Transactions() {
+			txn.Hash()
+		}
+		block.Hash()
 		api.blocksLRU.Add(hash, block)
 	}
 	return block, nil

--- a/cmd/rpcdaemon/commands/eth_api.go
+++ b/cmd/rpcdaemon/commands/eth_api.go
@@ -107,11 +107,11 @@ type BaseAPI struct {
 	_genesis     *types.Block
 	_genesisLock sync.RWMutex
 
-	_blockReader interfaces.FullBlockReader
+	_blockReader interfaces.BlockAndTxnReader
 	TevmEnabled  bool // experiment
 }
 
-func NewBaseApi(f *filters.Filters, stateCache kvcache.Cache, blockReader interfaces.FullBlockReader, singleNodeMode bool) *BaseAPI {
+func NewBaseApi(f *filters.Filters, stateCache kvcache.Cache, blockReader interfaces.BlockAndTxnReader, singleNodeMode bool) *BaseAPI {
 	blocksLRUSize := 128 // ~32Mb
 	if !singleNodeMode {
 		blocksLRUSize = 512

--- a/cmd/rpcdaemon/commands/eth_block.go
+++ b/cmd/rpcdaemon/commands/eth_block.go
@@ -42,7 +42,7 @@ func (api *APIImpl) CallBundle(ctx context.Context, txHashes []common.Hash, stat
 	var txs types.Transactions
 
 	for _, txHash := range txHashes {
-		blockNum, ok, err := api._blockReader.TxnLookup(ctx, tx, txHash)
+		blockNum, ok, err := api.txnLookup(ctx, tx, txHash)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/rpcdaemon/commands/eth_receipts.go
+++ b/cmd/rpcdaemon/commands/eth_receipts.go
@@ -248,7 +248,7 @@ func (api *APIImpl) GetTransactionReceipt(ctx context.Context, hash common.Hash)
 	}
 	defer tx.Rollback()
 
-	blockNum, ok, err := api._blockReader.TxnLookup(ctx, tx, hash)
+	blockNum, ok, err := api.txnLookup(ctx, tx, hash)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/rpcdaemon/commands/eth_receipts.go
+++ b/cmd/rpcdaemon/commands/eth_receipts.go
@@ -253,14 +253,14 @@ func (api *APIImpl) GetTransactionReceipt(ctx context.Context, hash common.Hash)
 		return nil, err
 	}
 	if !ok {
-		return nil, nil
+		return nil, nil // not error, see https://github.com/ledgerwatch/erigon/issues/1645
 	}
 	block, err := api.blockByNumberWithSenders(tx, blockNum)
 	if err != nil {
 		return nil, err
 	}
 	if block == nil {
-		return nil, nil
+		return nil, nil // not error, see https://github.com/ledgerwatch/erigon/issues/1645
 	}
 	var txnIndex uint64
 	var txn types.Transaction

--- a/cmd/rpcdaemon/commands/eth_receipts.go
+++ b/cmd/rpcdaemon/commands/eth_receipts.go
@@ -248,32 +248,30 @@ func (api *APIImpl) GetTransactionReceipt(ctx context.Context, hash common.Hash)
 	}
 	defer tx.Rollback()
 
-	blockNumber, err := rawdb.ReadTxLookupEntry(tx, hash)
+	blockNum, ok, err := api._blockReader.TxnLookup(ctx, tx, hash)
 	if err != nil {
 		return nil, err
 	}
-	if blockNumber == nil {
-		return nil, nil // not error, see https://github.com/ledgerwatch/erigon/issues/1645
+	if !ok {
+		return nil, nil
 	}
-
-	// Extract transactions from block
-	block, bErr := api.blockByNumberWithSenders(tx, *blockNumber)
-	if bErr != nil {
-		return nil, bErr
+	block, err := api.blockByNumberWithSenders(tx, blockNum)
+	if err != nil {
+		return nil, err
 	}
 	if block == nil {
-		return nil, fmt.Errorf("could not find block  %d", *blockNumber)
+		return nil, nil
 	}
-	var txIndex uint64
-	var found bool
-	for idx, txn := range block.Transactions() {
-		if txn.Hash() == hash {
-			txIndex = uint64(idx)
-			found = true
+	var txnIndex uint64
+	var txn types.Transaction
+	for i, transaction := range block.Transactions() {
+		if transaction.Hash() == hash {
+			txn = transaction
+			txnIndex = uint64(i)
 			break
 		}
 	}
-	if !found {
+	if txn == nil {
 		return nil, nil
 	}
 
@@ -285,10 +283,10 @@ func (api *APIImpl) GetTransactionReceipt(ctx context.Context, hash common.Hash)
 	if err != nil {
 		return nil, fmt.Errorf("getReceipts error: %w", err)
 	}
-	if len(receipts) <= int(txIndex) {
-		return nil, fmt.Errorf("block has less receipts than expected: %d <= %d, block: %d", len(receipts), int(txIndex), blockNumber)
+	if len(receipts) <= int(txnIndex) {
+		return nil, fmt.Errorf("block has less receipts than expected: %d <= %d, block: %d", len(receipts), int(txnIndex), blockNum)
 	}
-	return marshalReceipt(receipts[txIndex], block.Transactions()[txIndex], cc, block), nil
+	return marshalReceipt(receipts[txnIndex], block.Transactions()[txnIndex], cc, block), nil
 }
 
 // GetBlockReceipts - receipts for individual block

--- a/cmd/rpcdaemon/commands/eth_txs.go
+++ b/cmd/rpcdaemon/commands/eth_txs.go
@@ -26,7 +26,7 @@ func (api *APIImpl) GetTransactionByHash(ctx context.Context, hash common.Hash) 
 	defer tx.Rollback()
 
 	// https://infura.io/docs/ethereum/json-rpc/eth-getTransactionByHash
-	blockNum, ok, err := api._blockReader.TxnLookup(ctx, tx, hash)
+	blockNum, ok, err := api.txnLookup(ctx, tx, hash)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func (api *APIImpl) GetRawTransactionByHash(ctx context.Context, hash common.Has
 	defer tx.Rollback()
 
 	// https://infura.io/docs/ethereum/json-rpc/eth-getTransactionByHash
-	blockNum, ok, err := api._blockReader.TxnLookup(ctx, tx, hash)
+	blockNum, ok, err := api.txnLookup(ctx, tx, hash)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/rpcdaemon/commands/eth_txs.go
+++ b/cmd/rpcdaemon/commands/eth_txs.go
@@ -26,16 +26,29 @@ func (api *APIImpl) GetTransactionByHash(ctx context.Context, hash common.Hash) 
 	defer tx.Rollback()
 
 	// https://infura.io/docs/ethereum/json-rpc/eth-getTransactionByHash
-	blockNum, err := rawdb.ReadTxLookupEntry(tx, hash)
+	blockNum, ok, err := api._blockReader.TxnLookup(ctx, tx, hash)
 	if err != nil {
 		return nil, err
 	}
-	if blockNum == nil {
+	if !ok {
 		return nil, nil
 	}
-	txn, blockHash, blockNumber, txIndex, err := rawdb.ReadTransaction(tx, hash, *blockNum)
+	block, err := api.blockByNumberWithSenders(tx, blockNum)
 	if err != nil {
 		return nil, err
+	}
+	if block == nil {
+		return nil, nil
+	}
+	blockHash := block.Hash()
+	var txnIndex uint64
+	var txn types2.Transaction
+	for i, transaction := range block.Transactions() {
+		if transaction.Hash() == hash {
+			txn = transaction
+			txnIndex = uint64(i)
+			break
+		}
 	}
 
 	// Add GasPrice for the DynamicFeeTransaction
@@ -44,16 +57,12 @@ func (api *APIImpl) GetTransactionByHash(ctx context.Context, hash common.Hash) 
 	if err != nil {
 		return nil, err
 	}
-	if chainConfig.IsLondon(blockNumber) && blockHash != (common.Hash{}) {
-		block, err := api.blockByHashWithSenders(tx, blockHash)
-		if err != nil {
-			return nil, err
-		}
+	if chainConfig.IsLondon(blockNum) && blockHash != (common.Hash{}) {
 		baseFee = block.BaseFee()
 	}
 
 	if txn != nil {
-		return newRPCTransaction(txn, blockHash, blockNumber, txIndex, baseFee), nil
+		return newRPCTransaction(txn, blockHash, blockNum, txnIndex, baseFee), nil
 	}
 
 	curHeader := rawdb.ReadCurrentHeader(tx)
@@ -88,17 +97,28 @@ func (api *APIImpl) GetRawTransactionByHash(ctx context.Context, hash common.Has
 	defer tx.Rollback()
 
 	// https://infura.io/docs/ethereum/json-rpc/eth-getTransactionByHash
-	blockNum, err := rawdb.ReadTxLookupEntry(tx, hash)
+	blockNum, ok, err := api._blockReader.TxnLookup(ctx, tx, hash)
 	if err != nil {
 		return nil, err
 	}
-	if blockNum == nil {
+	if !ok {
 		return nil, nil
 	}
-	txn, _, _, _, err := rawdb.ReadTransaction(tx, hash, *blockNum)
+	block, err := api.blockByNumberWithSenders(tx, blockNum)
 	if err != nil {
 		return nil, err
 	}
+	if block == nil {
+		return nil, nil
+	}
+	var txn types2.Transaction
+	for _, transaction := range block.Transactions() {
+		if transaction.Hash() == hash {
+			txn = transaction
+			break
+		}
+	}
+
 	if txn != nil {
 		var buf bytes.Buffer
 		err = txn.MarshalBinary(&buf)

--- a/cmd/rpcdaemon/commands/trace_adhoc.go
+++ b/cmd/rpcdaemon/commands/trace_adhoc.go
@@ -696,30 +696,29 @@ func (api *TraceAPIImpl) ReplayTransaction(ctx context.Context, txHash common.Ha
 		return nil, err
 	}
 
-	blockNumber, err := rawdb.ReadTxLookupEntry(tx, txHash)
+	blockNum, ok, err := api._blockReader.TxnLookup(ctx, tx, txHash)
 	if err != nil {
 		return nil, err
 	}
-	if blockNumber == nil {
-		return nil, nil // not error, see https://github.com/ledgerwatch/erigon/issues/1645
+	if !ok {
+		return nil, nil
 	}
-
-	// Extract transactions from block
-	block, bErr := api.blockByNumberWithSenders(tx, *blockNumber)
-	if bErr != nil {
-		return nil, bErr
+	block, err := api.blockByNumberWithSenders(tx, blockNum)
+	if err != nil {
+		return nil, err
 	}
 	if block == nil {
-		return nil, fmt.Errorf("could not find block  %d", *blockNumber)
+		return nil, nil
 	}
-	var txIndex int
-	for idx, txn := range block.Transactions() {
-		if txn.Hash() == txHash {
-			txIndex = idx
+	var txnIndex uint64
+	for i, transaction := range block.Transactions() {
+		if transaction.Hash() == txHash {
+			txnIndex = uint64(i)
 			break
 		}
 	}
-	bn := hexutil.Uint64(*blockNumber)
+
+	bn := hexutil.Uint64(blockNum)
 
 	parentNr := bn
 	if parentNr > 0 {
@@ -727,7 +726,7 @@ func (api *TraceAPIImpl) ReplayTransaction(ctx context.Context, txHash common.Ha
 	}
 
 	// Returns an array of trace arrays, one trace array for each transaction
-	traces, err := api.callManyTransactions(ctx, tx, block.Transactions(), traceTypes, block.ParentHash(), rpc.BlockNumber(parentNr), block.Header(), txIndex, types.MakeSigner(chainConfig, *blockNumber))
+	traces, err := api.callManyTransactions(ctx, tx, block.Transactions(), traceTypes, block.ParentHash(), rpc.BlockNumber(parentNr), block.Header(), int(txnIndex), types.MakeSigner(chainConfig, blockNum))
 	if err != nil {
 		return nil, err
 	}
@@ -749,7 +748,7 @@ func (api *TraceAPIImpl) ReplayTransaction(ctx context.Context, txHash common.Ha
 
 	for txno, trace := range traces {
 		// We're only looking for a specific transaction
-		if txno == txIndex {
+		if txno == int(txnIndex) {
 			result.Output = trace.Output
 			if traceTypeTrace {
 				result.Trace = trace.Trace

--- a/cmd/rpcdaemon/commands/trace_adhoc.go
+++ b/cmd/rpcdaemon/commands/trace_adhoc.go
@@ -696,7 +696,7 @@ func (api *TraceAPIImpl) ReplayTransaction(ctx context.Context, txHash common.Ha
 		return nil, err
 	}
 
-	blockNum, ok, err := api._blockReader.TxnLookup(ctx, tx, txHash)
+	blockNum, ok, err := api.txnLookup(ctx, tx, txHash)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/rpcdaemon/commands/trace_filtering.go
+++ b/cmd/rpcdaemon/commands/trace_filtering.go
@@ -31,7 +31,7 @@ func (api *TraceAPIImpl) Transaction(ctx context.Context, txHash common.Hash) (P
 		return nil, err
 	}
 
-	blockNumber, ok, err := api._blockReader.TxnLookup(ctx, tx, txHash)
+	blockNumber, ok, err := api.txnLookup(ctx, tx, txHash)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/rpcdaemon/commands/tracing.go
+++ b/cmd/rpcdaemon/commands/tracing.go
@@ -29,7 +29,7 @@ func (api *PrivateDebugAPIImpl) TraceTransaction(ctx context.Context, hash commo
 	defer tx.Rollback()
 
 	// Retrieve the transaction and assemble its EVM context
-	blockNum, ok, err := api._blockReader.TxnLookup(ctx, tx, hash)
+	blockNum, ok, err := api.txnLookup(ctx, tx, hash)
 	if err != nil {
 		return err
 	}

--- a/cmd/rpcdaemon/commands/tracing.go
+++ b/cmd/rpcdaemon/commands/tracing.go
@@ -29,16 +29,29 @@ func (api *PrivateDebugAPIImpl) TraceTransaction(ctx context.Context, hash commo
 	defer tx.Rollback()
 
 	// Retrieve the transaction and assemble its EVM context
-	blockNum, err := rawdb.ReadTxLookupEntry(tx, hash)
+	blockNum, ok, err := api._blockReader.TxnLookup(ctx, tx, hash)
 	if err != nil {
 		return err
 	}
-	if blockNum == nil {
+	if !ok {
 		return nil
 	}
-	txn, blockHash, _, txIndex, err := rawdb.ReadTransaction(tx, hash, *blockNum)
+	block, err := api.blockByNumberWithSenders(tx, blockNum)
 	if err != nil {
 		return err
+	}
+	if block == nil {
+		return nil
+	}
+	blockHash := block.Hash()
+	var txnIndex uint64
+	var txn types.Transaction
+	for i, transaction := range block.Transactions() {
+		if transaction.Hash() == hash {
+			txnIndex = uint64(i)
+			txn = transaction
+			break
+		}
 	}
 	if txn == nil {
 		stream.WriteNil()
@@ -51,13 +64,6 @@ func (api *PrivateDebugAPIImpl) TraceTransaction(ctx context.Context, hash commo
 		return err
 	}
 
-	block, err := api.blockByHashWithSenders(tx, blockHash)
-	if err != nil {
-		return err
-	}
-	if block == nil {
-		return nil
-	}
 	getHeader := func(hash common.Hash, number uint64) *types.Header {
 		return rawdb.ReadHeader(tx, hash, number)
 	}
@@ -65,7 +71,7 @@ func (api *PrivateDebugAPIImpl) TraceTransaction(ctx context.Context, hash commo
 	if api.TevmEnabled {
 		contractHasTEVM = ethdb.GetHasTEVM(tx)
 	}
-	msg, blockCtx, txCtx, ibs, _, err := transactions.ComputeTxEnv(ctx, block, chainConfig, getHeader, contractHasTEVM, ethash.NewFaker(), tx, blockHash, txIndex)
+	msg, blockCtx, txCtx, ibs, _, err := transactions.ComputeTxEnv(ctx, block, chainConfig, getHeader, contractHasTEVM, ethash.NewFaker(), tx, blockHash, txnIndex)
 	if err != nil {
 		stream.WriteNil()
 		return err

--- a/cmd/rpcdaemon/interfaces/interfaces.go
+++ b/cmd/rpcdaemon/interfaces/interfaces.go
@@ -21,14 +21,14 @@ type HeaderReader interface {
 }
 
 type BodyReader interface {
-	BodyWithTransaction(ctx context.Context, tx kv.Tx, hash common.Hash, blockHeight uint64) (body *types.Body, err error)
+	BodyWithTransactions(ctx context.Context, tx kv.Tx, hash common.Hash, blockHeight uint64) (body *types.Body, err error)
 	BodyRlp(ctx context.Context, tx kv.Tx, hash common.Hash, blockHeight uint64) (bodyRlp rlp.RawValue, err error)
 	Body(ctx context.Context, tx kv.Tx, hash common.Hash, blockHeight uint64) (body *types.Body, err error)
 }
 
 type TxnReader interface {
 	TxnLookup(ctx context.Context, tx kv.Getter, txnHash common.Hash) (uint64, bool, error)
-	TxnByHashDeprecated(ctx context.Context, tx kv.Tx, txnHash common.Hash) (txn types.Transaction, blockHash common.Hash, blockNum, txnIndex uint64, err error)
+	//TxnByHashDeprecated(ctx context.Context, tx kv.Tx, txnHash common.Hash) (txn types.Transaction, blockHash common.Hash, blockNum, txnIndex uint64, err error)
 }
 
 type FullBlockReader interface {

--- a/cmd/rpcdaemon/interfaces/interfaces.go
+++ b/cmd/rpcdaemon/interfaces/interfaces.go
@@ -21,7 +21,7 @@ type HeaderReader interface {
 }
 
 type BodyReader interface {
-	BodyWithTransactions(ctx context.Context, tx kv.Tx, hash common.Hash, blockHeight uint64) (body *types.Body, err error)
+	//BodyWithTransactions(ctx context.Context, tx kv.Tx, hash common.Hash, blockHeight uint64) (body *types.Body, err error)
 	BodyRlp(ctx context.Context, tx kv.Tx, hash common.Hash, blockHeight uint64) (bodyRlp rlp.RawValue, err error)
 	Body(ctx context.Context, tx kv.Tx, hash common.Hash, blockHeight uint64) (body *types.Body, err error)
 }

--- a/cmd/rpcdaemon/interfaces/interfaces.go
+++ b/cmd/rpcdaemon/interfaces/interfaces.go
@@ -41,7 +41,7 @@ type HeaderAndCanonicalReader interface {
 
 type BlockAndTxnReader interface {
 	BlockReader
-	HeaderReader
+	//HeaderReader
 	TxnReader
 }
 

--- a/cmd/rpcdaemon/interfaces/interfaces.go
+++ b/cmd/rpcdaemon/interfaces/interfaces.go
@@ -17,18 +17,32 @@ type HeaderReader interface {
 	Header(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (*types.Header, error)
 	HeaderByNumber(ctx context.Context, tx kv.Getter, blockHeight uint64) (*types.Header, error)
 	HeaderByHash(ctx context.Context, tx kv.Getter, hash common.Hash) (*types.Header, error)
+}
+
+type CanonicalReader interface {
 	CanonicalHash(ctx context.Context, tx kv.Getter, blockHeight uint64) (common.Hash, error)
 }
 
 type BodyReader interface {
-	//BodyWithTransactions(ctx context.Context, tx kv.Tx, hash common.Hash, blockHeight uint64) (body *types.Body, err error)
+	BodyWithTransactions(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (body *types.Body, err error)
 	BodyRlp(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (bodyRlp rlp.RawValue, err error)
 	Body(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (body *types.Body, err error)
 }
 
 type TxnReader interface {
 	TxnLookup(ctx context.Context, tx kv.Getter, txnHash common.Hash) (uint64, bool, error)
-	//TxnByHashDeprecated(ctx context.Context, tx kv.Tx, txnHash common.Hash) (txn types.Transaction, blockHash common.Hash, blockNum, txnIndex uint64, err error)
+	//TxnByHashDeprecated(ctx context.Context, tx kv.Getter, txnHash common.Hash) (txn types.Transaction, blockHash common.Hash, blockNum, txnIndex uint64, err error)
+}
+
+type HeaderAndCanonicalReader interface {
+	HeaderReader
+	CanonicalReader
+}
+
+type BlockAndTxnReader interface {
+	BlockReader
+	HeaderReader
+	TxnReader
 }
 
 type FullBlockReader interface {
@@ -36,4 +50,5 @@ type FullBlockReader interface {
 	BodyReader
 	HeaderReader
 	TxnReader
+	CanonicalReader
 }

--- a/cmd/rpcdaemon/interfaces/interfaces.go
+++ b/cmd/rpcdaemon/interfaces/interfaces.go
@@ -10,7 +10,7 @@ import (
 )
 
 type BlockReader interface {
-	BlockWithSenders(ctx context.Context, tx kv.Tx, hash common.Hash, blockHeight uint64) (block *types.Block, senders []common.Address, err error)
+	BlockWithSenders(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (block *types.Block, senders []common.Address, err error)
 }
 
 type HeaderReader interface {
@@ -22,8 +22,8 @@ type HeaderReader interface {
 
 type BodyReader interface {
 	//BodyWithTransactions(ctx context.Context, tx kv.Tx, hash common.Hash, blockHeight uint64) (body *types.Body, err error)
-	BodyRlp(ctx context.Context, tx kv.Tx, hash common.Hash, blockHeight uint64) (bodyRlp rlp.RawValue, err error)
-	Body(ctx context.Context, tx kv.Tx, hash common.Hash, blockHeight uint64) (body *types.Body, err error)
+	BodyRlp(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (bodyRlp rlp.RawValue, err error)
+	Body(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (body *types.Body, err error)
 }
 
 type TxnReader interface {

--- a/cmd/rpcdaemon/interfaces/interfaces.go
+++ b/cmd/rpcdaemon/interfaces/interfaces.go
@@ -21,12 +21,19 @@ type HeaderReader interface {
 }
 
 type BodyReader interface {
-	Body(ctx context.Context, tx kv.Tx, hash common.Hash, blockHeight uint64) (body *types.Body, err error)
+	BodyWithTransaction(ctx context.Context, tx kv.Tx, hash common.Hash, blockHeight uint64) (body *types.Body, err error)
 	BodyRlp(ctx context.Context, tx kv.Tx, hash common.Hash, blockHeight uint64) (bodyRlp rlp.RawValue, err error)
+	Body(ctx context.Context, tx kv.Tx, hash common.Hash, blockHeight uint64) (body *types.Body, err error)
+}
+
+type TxnReader interface {
+	TxnLookup(ctx context.Context, tx kv.Getter, txnHash common.Hash) (uint64, bool, error)
+	TxnByHashDeprecated(ctx context.Context, tx kv.Tx, txnHash common.Hash) (txn types.Transaction, blockHash common.Hash, blockNum, txnIndex uint64, err error)
 }
 
 type FullBlockReader interface {
 	BlockReader
 	BodyReader
 	HeaderReader
+	TxnReader
 }

--- a/cmd/rpcdaemon/services/eth_backend.go
+++ b/cmd/rpcdaemon/services/eth_backend.go
@@ -32,7 +32,7 @@ type ApiBackend interface {
 	ProtocolVersion(ctx context.Context) (uint64, error)
 	ClientVersion(ctx context.Context) (string, error)
 	Subscribe(ctx context.Context, cb func(*remote.SubscribeReply)) error
-	BlockWithSenders(ctx context.Context, tx kv.Tx, hash common.Hash, blockHeight uint64) (block *types.Block, senders []common.Address, err error)
+	BlockWithSenders(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (block *types.Block, senders []common.Address, err error)
 	EngineExecutePayloadV1(ctx context.Context, payload *types2.ExecutionPayload) (*remote.EngineExecutePayloadReply, error)
 	EngineForkchoiceUpdateV1(ctx context.Context, request *remote.EngineForkChoiceUpdatedRequest) (*remote.EngineForkChoiceUpdatedReply, error)
 	EngineGetPayloadV1(ctx context.Context, payloadId uint64) (*types2.ExecutionPayload, error)
@@ -157,7 +157,7 @@ func (back *RemoteBackend) Subscribe(ctx context.Context, onNewEvent func(*remot
 	return nil
 }
 
-func (back *RemoteBackend) BlockWithSenders(ctx context.Context, tx kv.Tx, hash common.Hash, blockHeight uint64) (block *types.Block, senders []common.Address, err error) {
+func (back *RemoteBackend) BlockWithSenders(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (block *types.Block, senders []common.Address, err error) {
 	return back.blockReader.BlockWithSenders(ctx, tx, hash, blockHeight)
 }
 

--- a/cmd/rpcdaemon/services/eth_backend.go
+++ b/cmd/rpcdaemon/services/eth_backend.go
@@ -44,10 +44,10 @@ type RemoteBackend struct {
 	log              log.Logger
 	version          gointerfaces.Version
 	db               kv.RoDB
-	blockReader      interfaces.BlockReader
+	blockReader      interfaces.BlockAndTxnReader
 }
 
-func NewRemoteBackend(cc grpc.ClientConnInterface, db kv.RoDB, blockReader interfaces.BlockReader) *RemoteBackend {
+func NewRemoteBackend(cc grpc.ClientConnInterface, db kv.RoDB, blockReader interfaces.BlockAndTxnReader) *RemoteBackend {
 	return &RemoteBackend{
 		remoteEthBackend: remote.NewETHBACKENDClient(cc),
 		version:          gointerfaces.VersionFromProto(privateapi.EthBackendAPIVersion),
@@ -158,7 +158,7 @@ func (back *RemoteBackend) Subscribe(ctx context.Context, onNewEvent func(*remot
 }
 
 func (back *RemoteBackend) TxnLookup(ctx context.Context, tx kv.Getter, txnHash common.Hash) (uint64, bool, error) {
-	panic("not implemented yet")
+	return back.blockReader.TxnLookup(ctx, tx, txnHash)
 }
 func (back *RemoteBackend) BlockWithSenders(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (block *types.Block, senders []common.Address, err error) {
 	return back.blockReader.BlockWithSenders(ctx, tx, hash, blockHeight)

--- a/cmd/rpcdaemon/services/eth_backend.go
+++ b/cmd/rpcdaemon/services/eth_backend.go
@@ -157,6 +157,9 @@ func (back *RemoteBackend) Subscribe(ctx context.Context, onNewEvent func(*remot
 	return nil
 }
 
+func (back *RemoteBackend) TxnLookup(ctx context.Context, tx kv.Getter, txnHash common.Hash) (uint64, bool, error) {
+	panic("not implemented yet")
+}
 func (back *RemoteBackend) BlockWithSenders(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (block *types.Block, senders []common.Address, err error) {
 	return back.blockReader.BlockWithSenders(ctx, tx, hash, blockHeight)
 }

--- a/cmd/sentry/sentry/downloader.go
+++ b/cmd/sentry/sentry/downloader.go
@@ -339,10 +339,10 @@ type ControlServerImpl struct {
 	networkId   uint64
 	db          kv.RwDB
 	Engine      consensus.Engine
-	blockReader interfaces.FullBlockReader
+	blockReader interfaces.HeaderAndCanonicalReader
 }
 
-func NewControlServer(db kv.RwDB, nodeName string, chainConfig *params.ChainConfig, genesisHash common.Hash, engine consensus.Engine, networkID uint64, sentries []direct.SentryClient, window int, blockReader interfaces.FullBlockReader) (*ControlServerImpl, error) {
+func NewControlServer(db kv.RwDB, nodeName string, chainConfig *params.ChainConfig, genesisHash common.Hash, engine consensus.Engine, networkID uint64, sentries []direct.SentryClient, window int, blockReader interfaces.HeaderAndCanonicalReader) (*ControlServerImpl, error) {
 	hd := headerdownload.NewHeaderDownload(
 		512,       /* anchorLimit */
 		1024*1024, /* linkLimit */

--- a/cmd/state/verify/verify_txlookup.go
+++ b/cmd/state/verify/verify_txlookup.go
@@ -48,7 +48,7 @@ func ValidateTxLookups(chaindata string) error {
 		if err != nil {
 			return err
 		}
-		body := rawdb.ReadBodyWithTransactions(tx, blockHash, blockNum)
+		body := rawdb.ReadCanonicalBodyWithTransactions(tx, blockHash, blockNum)
 
 		if body == nil {
 			log.Error("Empty body", "blocknum", blockNum)

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -997,7 +997,7 @@ func HasBlock(db kv.Getter, hash common.Hash, number uint64) bool {
 	return len(body) > 0
 }
 
-func ReadBlockWithSenders(db kv.Tx, hash common.Hash, number uint64) (*types.Block, []common.Address, error) {
+func ReadBlockWithSenders(db kv.Getter, hash common.Hash, number uint64) (*types.Block, []common.Address, error) {
 	block := ReadBlock(db, hash, number)
 	if block == nil {
 		return nil, nil, nil

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -1114,7 +1114,7 @@ func ReadHeaderByHash(db kv.Getter, hash common.Hash) (*types.Header, error) {
 	return ReadHeader(db, hash, *number), nil
 }
 
-func ReadAncestor(db kv.Getter, hash common.Hash, number, ancestor uint64, maxNonCanonical *uint64, blockReader interfaces.FullBlockReader) (common.Hash, uint64) {
+func ReadAncestor(db kv.Getter, hash common.Hash, number, ancestor uint64, maxNonCanonical *uint64, blockReader interfaces.HeaderAndCanonicalReader) (common.Hash, uint64) {
 	if ancestor > number {
 		return common.Hash{}, 0
 	}

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -96,11 +96,11 @@ func TestBodyStorage(t *testing.T) {
 	_ = rlp.Encode(hasher, body)
 	hash := common.BytesToHash(hasher.Sum(nil))
 
-	if entry := ReadBodyWithTransactions(tx, hash, 0); entry != nil {
+	if entry := ReadCanonicalBodyWithTransactions(tx, hash, 0); entry != nil {
 		t.Fatalf("Non existent body returned: %v", entry)
 	}
 	require.NoError(WriteBody(tx, hash, 0, body))
-	if entry := ReadBodyWithTransactions(tx, hash, 0); entry == nil {
+	if entry := ReadCanonicalBodyWithTransactions(tx, hash, 0); entry == nil {
 		t.Fatalf("Stored body not found")
 	} else if types.DeriveSha(types.Transactions(entry.Transactions)) != types.DeriveSha(types.Transactions(body.Transactions)) || types.CalcUncleHash(entry.Uncles) != types.CalcUncleHash(body.Uncles) {
 		t.Fatalf("Retrieved body mismatch: have %v, want %v", entry, body)
@@ -117,7 +117,7 @@ func TestBodyStorage(t *testing.T) {
 	}
 	// Delete the body and verify the execution
 	DeleteBody(tx, hash, 0)
-	if entry := ReadBodyWithTransactions(tx, hash, 0); entry != nil {
+	if entry := ReadCanonicalBodyWithTransactions(tx, hash, 0); entry != nil {
 		t.Fatalf("Deleted body returned: %v", entry)
 	}
 }
@@ -139,7 +139,7 @@ func TestBlockStorage(t *testing.T) {
 	if entry := ReadHeader(tx, block.Hash(), block.NumberU64()); entry != nil {
 		t.Fatalf("Non existent header returned: %v", entry)
 	}
-	if entry := ReadBodyWithTransactions(tx, block.Hash(), block.NumberU64()); entry != nil {
+	if entry := ReadCanonicalBodyWithTransactions(tx, block.Hash(), block.NumberU64()); entry != nil {
 		t.Fatalf("Non existent body returned: %v", entry)
 	}
 	// Write and verify the block in the database
@@ -157,7 +157,7 @@ func TestBlockStorage(t *testing.T) {
 	} else if entry.Hash() != block.Hash() {
 		t.Fatalf("Retrieved header mismatch: have %v, want %v", entry, block.Header())
 	}
-	if entry := ReadBodyWithTransactions(tx, block.Hash(), block.NumberU64()); entry == nil {
+	if entry := ReadCanonicalBodyWithTransactions(tx, block.Hash(), block.NumberU64()); entry == nil {
 		t.Fatalf("Stored body not found")
 	} else if types.DeriveSha(types.Transactions(entry.Transactions)) != types.DeriveSha(block.Transactions()) || types.CalcUncleHash(entry.Uncles) != types.CalcUncleHash(block.Uncles()) {
 		t.Fatalf("Retrieved body mismatch: have %v, want %v", entry, block.Body())
@@ -172,7 +172,7 @@ func TestBlockStorage(t *testing.T) {
 	if entry := ReadHeader(tx, block.Hash(), block.NumberU64()); entry != nil {
 		t.Fatalf("Deleted header returned: %v", entry)
 	}
-	if entry := ReadBodyWithTransactions(tx, block.Hash(), block.NumberU64()); entry != nil {
+	if entry := ReadCanonicalBodyWithTransactions(tx, block.Hash(), block.NumberU64()); entry != nil {
 		t.Fatalf("Deleted body returned: %v", entry)
 	}
 }

--- a/core/rawdb/accessors_indexes.go
+++ b/core/rawdb/accessors_indexes.go
@@ -80,7 +80,7 @@ func ReadTransactionByHash(db kv.Tx, hash common.Hash) (types.Transaction, commo
 	if blockHash == (common.Hash{}) {
 		return nil, common.Hash{}, 0, 0, nil
 	}
-	body := ReadBodyWithTransactions(db, blockHash, *blockNumber)
+	body := ReadCanonicalBodyWithTransactions(db, blockHash, *blockNumber)
 	if body == nil {
 		log.Error("Transaction referenced missing", "number", blockNumber, "hash", blockHash)
 		return nil, common.Hash{}, 0, 0, nil
@@ -109,7 +109,7 @@ func ReadTransaction(db kv.Tx, hash common.Hash, blockNumber uint64) (types.Tran
 	if blockHash == (common.Hash{}) {
 		return nil, common.Hash{}, 0, 0, nil
 	}
-	body := ReadBodyWithTransactions(db, blockHash, blockNumber)
+	body := ReadCanonicalBodyWithTransactions(db, blockHash, blockNumber)
 	if body == nil {
 		log.Error("Transaction referenced missing", "number", blockNumber, "hash", blockHash)
 		return nil, common.Hash{}, 0, 0, nil

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -29,7 +29,7 @@ import (
 	"github.com/ledgerwatch/log/v3"
 )
 
-func AnswerGetBlockHeadersQuery(db kv.Tx, query *GetBlockHeadersPacket, blockReader interfaces.FullBlockReader) ([]*types.Header, error) {
+func AnswerGetBlockHeadersQuery(db kv.Tx, query *GetBlockHeadersPacket, blockReader interfaces.HeaderAndCanonicalReader) ([]*types.Header, error) {
 	hashMode := query.Origin.Hash != (common.Hash{})
 	first := true
 	maxNonCanonical := uint64(100)

--- a/eth/stagedsync/stage_senders.go
+++ b/eth/stagedsync/stage_senders.go
@@ -222,7 +222,7 @@ Loop:
 			// non-canonical case
 			continue
 		}
-		body := rawdb.ReadBodyWithTransactions(tx, blockHash, blockNumber)
+		body := rawdb.ReadCanonicalBodyWithTransactions(tx, blockHash, blockNumber)
 
 		select {
 		case recoveryErr := <-errCh:

--- a/eth/stagedsync/stage_senders_test.go
+++ b/eth/stagedsync/stage_senders_test.go
@@ -113,13 +113,13 @@ func TestSenders(t *testing.T) {
 	assert.NoError(t, err)
 
 	{
-		found := rawdb.ReadBodyWithTransactions(tx, common.HexToHash("01"), 1)
+		found := rawdb.ReadCanonicalBodyWithTransactions(tx, common.HexToHash("01"), 1)
 		assert.NotNil(t, found)
 		assert.Equal(t, 2, len(found.Transactions))
-		found = rawdb.ReadBodyWithTransactions(tx, common.HexToHash("02"), 2)
+		found = rawdb.ReadCanonicalBodyWithTransactions(tx, common.HexToHash("02"), 2)
 		assert.NotNil(t, found)
 		assert.NotNil(t, 3, len(found.Transactions))
-		found = rawdb.ReadBodyWithTransactions(tx, common.HexToHash("03"), 3)
+		found = rawdb.ReadCanonicalBodyWithTransactions(tx, common.HexToHash("03"), 3)
 		assert.NotNil(t, found)
 		assert.NotNil(t, 0, len(found.Transactions))
 		assert.NotNil(t, 2, len(found.Uncles))

--- a/eth/stagedsync/stage_txlookup.go
+++ b/eth/stagedsync/stage_txlookup.go
@@ -89,7 +89,7 @@ func TxLookupTransform(logPrefix string, tx kv.RwTx, startKey, endKey []byte, qu
 	return etl.Transform(logPrefix, tx, kv.HeaderCanonical, kv.TxLookup, cfg.tmpdir, func(k []byte, v []byte, next etl.ExtractNextFunc) error {
 		blocknum := binary.BigEndian.Uint64(k)
 		blockHash := common.BytesToHash(v)
-		body := rawdb.ReadBodyWithTransactions(tx, blockHash, blocknum)
+		body := rawdb.ReadCanonicalBodyWithTransactions(tx, blockHash, blocknum)
 		if body == nil {
 			return fmt.Errorf("empty block body %d, hash %x", blocknum, v)
 		}

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/kevinburke/go-bindata v3.21.0+incompatible
-	github.com/ledgerwatch/erigon-lib v0.0.0-20220107072726-68b0fe6030a6
+	github.com/ledgerwatch/erigon-lib v0.0.0-20220107073727-6aa0a5f08e25
 	github.com/ledgerwatch/log/v3 v3.4.0
 	github.com/ledgerwatch/secp256k1 v1.0.0
 	github.com/logrusorgru/aurora/v3 v3.0.0

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/kevinburke/go-bindata v3.21.0+incompatible
-	github.com/ledgerwatch/erigon-lib v0.0.0-20220107073727-6aa0a5f08e25
+	github.com/ledgerwatch/erigon-lib v0.0.0-20220107073838-8a0d41693f23
 	github.com/ledgerwatch/log/v3 v3.4.0
 	github.com/ledgerwatch/secp256k1 v1.0.0
 	github.com/logrusorgru/aurora/v3 v3.0.0

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/kevinburke/go-bindata v3.21.0+incompatible
-	github.com/ledgerwatch/erigon-lib v0.0.0-20220107073838-8a0d41693f23
+	github.com/ledgerwatch/erigon-lib v0.0.0-20220107100549-70454f534eae
 	github.com/ledgerwatch/log/v3 v3.4.0
 	github.com/ledgerwatch/secp256k1 v1.0.0
 	github.com/logrusorgru/aurora/v3 v3.0.0

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/kevinburke/go-bindata v3.21.0+incompatible
-	github.com/ledgerwatch/erigon-lib v0.0.0-20220106044902-17462c2ee02f
+	github.com/ledgerwatch/erigon-lib v0.0.0-20220107072726-68b0fe6030a6
 	github.com/ledgerwatch/log/v3 v3.4.0
 	github.com/ledgerwatch/secp256k1 v1.0.0
 	github.com/logrusorgru/aurora/v3 v3.0.0

--- a/go.sum
+++ b/go.sum
@@ -616,8 +616,8 @@ github.com/kylelemons/godebug v0.0.0-20170224010052-a616ab194758 h1:0D5M2HQSGD3P
 github.com/kylelemons/godebug v0.0.0-20170224010052-a616ab194758/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
-github.com/ledgerwatch/erigon-lib v0.0.0-20220107072726-68b0fe6030a6 h1:syenyxlmynvPKMsBXX5196E61/qyYjSMRKXC+Y3mRhk=
-github.com/ledgerwatch/erigon-lib v0.0.0-20220107072726-68b0fe6030a6/go.mod h1:KLOqW8SHseF7EI4h/yohCUyBynKYjMVgkHfe/VcG8Z8=
+github.com/ledgerwatch/erigon-lib v0.0.0-20220107073727-6aa0a5f08e25 h1:dBGRsNcpwmPixx0+q0lo6PgvitqHj9GwulzUWbpWV34=
+github.com/ledgerwatch/erigon-lib v0.0.0-20220107073727-6aa0a5f08e25/go.mod h1:KLOqW8SHseF7EI4h/yohCUyBynKYjMVgkHfe/VcG8Z8=
 github.com/ledgerwatch/log/v3 v3.4.0 h1:SEIOcv5a2zkG3PmoT5jeTU9m/0nEUv0BJS5bzsjwKCI=
 github.com/ledgerwatch/log/v3 v3.4.0/go.mod h1:VXcz6Ssn6XEeU92dCMc39/g1F0OYAjw1Mt+dGP5DjXY=
 github.com/ledgerwatch/secp256k1 v1.0.0 h1:Usvz87YoTG0uePIV8woOof5cQnLXGYa162rFf3YnwaQ=

--- a/go.sum
+++ b/go.sum
@@ -616,8 +616,8 @@ github.com/kylelemons/godebug v0.0.0-20170224010052-a616ab194758 h1:0D5M2HQSGD3P
 github.com/kylelemons/godebug v0.0.0-20170224010052-a616ab194758/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
-github.com/ledgerwatch/erigon-lib v0.0.0-20220106044902-17462c2ee02f h1:2ESsKcl36oucSxd4uDfTQTQxvswzP7O5SalnbVFC5J4=
-github.com/ledgerwatch/erigon-lib v0.0.0-20220106044902-17462c2ee02f/go.mod h1:KLOqW8SHseF7EI4h/yohCUyBynKYjMVgkHfe/VcG8Z8=
+github.com/ledgerwatch/erigon-lib v0.0.0-20220107072726-68b0fe6030a6 h1:syenyxlmynvPKMsBXX5196E61/qyYjSMRKXC+Y3mRhk=
+github.com/ledgerwatch/erigon-lib v0.0.0-20220107072726-68b0fe6030a6/go.mod h1:KLOqW8SHseF7EI4h/yohCUyBynKYjMVgkHfe/VcG8Z8=
 github.com/ledgerwatch/log/v3 v3.4.0 h1:SEIOcv5a2zkG3PmoT5jeTU9m/0nEUv0BJS5bzsjwKCI=
 github.com/ledgerwatch/log/v3 v3.4.0/go.mod h1:VXcz6Ssn6XEeU92dCMc39/g1F0OYAjw1Mt+dGP5DjXY=
 github.com/ledgerwatch/secp256k1 v1.0.0 h1:Usvz87YoTG0uePIV8woOof5cQnLXGYa162rFf3YnwaQ=

--- a/go.sum
+++ b/go.sum
@@ -616,8 +616,8 @@ github.com/kylelemons/godebug v0.0.0-20170224010052-a616ab194758 h1:0D5M2HQSGD3P
 github.com/kylelemons/godebug v0.0.0-20170224010052-a616ab194758/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
-github.com/ledgerwatch/erigon-lib v0.0.0-20220107073727-6aa0a5f08e25 h1:dBGRsNcpwmPixx0+q0lo6PgvitqHj9GwulzUWbpWV34=
-github.com/ledgerwatch/erigon-lib v0.0.0-20220107073727-6aa0a5f08e25/go.mod h1:KLOqW8SHseF7EI4h/yohCUyBynKYjMVgkHfe/VcG8Z8=
+github.com/ledgerwatch/erigon-lib v0.0.0-20220107073838-8a0d41693f23 h1:5m0kLLogJM1I87wpA63ljHxXlgZgql/EATpGowIQNB8=
+github.com/ledgerwatch/erigon-lib v0.0.0-20220107073838-8a0d41693f23/go.mod h1:KLOqW8SHseF7EI4h/yohCUyBynKYjMVgkHfe/VcG8Z8=
 github.com/ledgerwatch/log/v3 v3.4.0 h1:SEIOcv5a2zkG3PmoT5jeTU9m/0nEUv0BJS5bzsjwKCI=
 github.com/ledgerwatch/log/v3 v3.4.0/go.mod h1:VXcz6Ssn6XEeU92dCMc39/g1F0OYAjw1Mt+dGP5DjXY=
 github.com/ledgerwatch/secp256k1 v1.0.0 h1:Usvz87YoTG0uePIV8woOof5cQnLXGYa162rFf3YnwaQ=

--- a/go.sum
+++ b/go.sum
@@ -616,8 +616,8 @@ github.com/kylelemons/godebug v0.0.0-20170224010052-a616ab194758 h1:0D5M2HQSGD3P
 github.com/kylelemons/godebug v0.0.0-20170224010052-a616ab194758/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
-github.com/ledgerwatch/erigon-lib v0.0.0-20220107073838-8a0d41693f23 h1:5m0kLLogJM1I87wpA63ljHxXlgZgql/EATpGowIQNB8=
-github.com/ledgerwatch/erigon-lib v0.0.0-20220107073838-8a0d41693f23/go.mod h1:KLOqW8SHseF7EI4h/yohCUyBynKYjMVgkHfe/VcG8Z8=
+github.com/ledgerwatch/erigon-lib v0.0.0-20220107100549-70454f534eae h1:RHoDxund6X4c5JA+l2U8UsKKugfYjwbyzPvmi0kRQ5Q=
+github.com/ledgerwatch/erigon-lib v0.0.0-20220107100549-70454f534eae/go.mod h1:KLOqW8SHseF7EI4h/yohCUyBynKYjMVgkHfe/VcG8Z8=
 github.com/ledgerwatch/log/v3 v3.4.0 h1:SEIOcv5a2zkG3PmoT5jeTU9m/0nEUv0BJS5bzsjwKCI=
 github.com/ledgerwatch/log/v3 v3.4.0/go.mod h1:VXcz6Ssn6XEeU92dCMc39/g1F0OYAjw1Mt+dGP5DjXY=
 github.com/ledgerwatch/secp256k1 v1.0.0 h1:Usvz87YoTG0uePIV8woOof5cQnLXGYa162rFf3YnwaQ=

--- a/turbo/cli/snapshots.go
+++ b/turbo/cli/snapshots.go
@@ -111,11 +111,6 @@ func rebuildIndices(ctx context.Context, chainDB kv.RoDB, snapshotDir, tmpDir st
 	_ = chainID
 	_ = os.MkdirAll(snapshotDir, fs.ModePerm)
 
-	workers := runtime.NumCPU() - 1
-	if workers < 1 {
-		workers = 1
-	}
-
 	allSnapshots := snapshotsync.NewAllSnapshots(snapshotDir, snapshothashes.KnownConfig(chainConfig.ChainName))
 	if err := allSnapshots.ReopenSegments(); err != nil {
 		return err

--- a/turbo/snapshotsync/block_reader.go
+++ b/turbo/snapshotsync/block_reader.go
@@ -37,6 +37,10 @@ func (back *BlockReader) Body(ctx context.Context, tx kv.Getter, hash common.Has
 	return body, nil
 }
 
+func (back *BlockReader) BodyWithTransactions(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (body *types.Body, err error) {
+	return rawdb.ReadBodyWithTransactions(tx, hash, blockHeight)
+}
+
 func (back *BlockReader) BodyRlp(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (bodyRlp rlp.RawValue, err error) {
 	body, err := back.Body(ctx, tx, hash, blockHeight)
 	if err != nil {
@@ -85,10 +89,10 @@ func (back *BlockReader) TxnLookup(ctx context.Context, tx kv.Getter, txnHash co
 	return *n, true, nil
 }
 
-//func (back *BlockReader) TxnByHashDeprecated(ctx context.Context, tx kv.Tx, txnHash common.Hash) (txn types.Transaction, blockHash common.Hash, blockNum, txnIndex uint64, err error) {
+//func (back *BlockReader) TxnByHashDeprecated(ctx context.Context, tx kv.Getter, txnHash common.Hash) (txn types.Transaction, blockHash common.Hash, blockNum, txnIndex uint64, err error) {
 //	return rawdb.ReadTransactionByHash(tx, txnHash)
 //}
-//func (back *BlockReader) BodyWithTransactions(ctx context.Context, tx kv.Tx, hash common.Hash, blockHeight uint64) (body *types.Body, err error) {
+//func (back *BlockReader) BodyWithTransactions(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (body *types.Body, err error) {
 //	return rawdb.ReadBodyWithTransactions(tx, hash, blockHeight)
 //}
 
@@ -98,6 +102,10 @@ type RemoteBlockReader struct {
 
 func NewRemoteBlockReader(client remote.ETHBACKENDClient) *RemoteBlockReader {
 	return &RemoteBlockReader{client}
+}
+
+func (back *RemoteBlockReader) TxnLookup(ctx context.Context, tx kv.Getter, txnHash common.Hash) (uint64, bool, error) {
+	panic("not implemented yet")
 }
 
 func (back *RemoteBlockReader) BlockWithSenders(ctx context.Context, _ kv.Getter, hash common.Hash, blockHeight uint64) (block *types.Block, senders []common.Address, err error) {

--- a/turbo/snapshotsync/block_reader.go
+++ b/turbo/snapshotsync/block_reader.go
@@ -105,7 +105,14 @@ func NewRemoteBlockReader(client remote.ETHBACKENDClient) *RemoteBlockReader {
 }
 
 func (back *RemoteBlockReader) TxnLookup(ctx context.Context, tx kv.Getter, txnHash common.Hash) (uint64, bool, error) {
-	panic("not implemented yet")
+	reply, err := back.client.TxnLookup(ctx, &remote.TxnLookupRequest{TxnHash: gointerfaces.ConvertHashToH256(txnHash)})
+	if err != nil {
+		return 0, false, err
+	}
+	if reply == nil {
+		return 0, false, nil
+	}
+	return reply.BlockNumber, true, nil
 }
 
 func (back *RemoteBlockReader) BlockWithSenders(ctx context.Context, _ kv.Getter, hash common.Hash, blockHeight uint64) (block *types.Block, senders []common.Address, err error) {

--- a/turbo/snapshotsync/block_reader.go
+++ b/turbo/snapshotsync/block_reader.go
@@ -84,6 +84,12 @@ func (back *BlockReader) TxnLookup(ctx context.Context, tx kv.Getter, txnHash co
 	}
 	return *n, true, nil
 }
+func (back *BlockReader) TxnByHashDeprecated(ctx context.Context, tx kv.Tx, txnHash common.Hash) (txn types.Transaction, blockHash common.Hash, blockNum, txnIndex uint64, err error) {
+	return rawdb.ReadTransactionByHash(tx, txnHash)
+}
+func (back *BlockReader) BodyWithTransactions(ctx context.Context, tx kv.Tx, hash common.Hash, blockHeight uint64) (body *types.Body, err error) {
+	return rawdb.ReadBodyWithTransactions(tx, hash, blockHeight)
+}
 
 type RemoteBlockReader struct {
 	client remote.ETHBACKENDClient

--- a/turbo/snapshotsync/block_reader.go
+++ b/turbo/snapshotsync/block_reader.go
@@ -367,7 +367,6 @@ func (back *BlockReaderWithSnapshots) BlockWithSenders(ctx context.Context, tx k
 
 	block = types.NewBlockFromStorage(hash, h, txs, b.Uncles)
 	if len(senders) != block.Transactions().Len() {
-		panic(fmt.Sprintf("alex: %d, %d\n", len(block.Transactions()), len(senders)))
 		return block, senders, nil // no senders is fine - will recover them on the fly
 	}
 	block.SendersToTxs(senders)

--- a/turbo/snapshotsync/block_reader.go
+++ b/turbo/snapshotsync/block_reader.go
@@ -367,6 +367,7 @@ func (back *BlockReaderWithSnapshots) BlockWithSenders(ctx context.Context, tx k
 
 	block = types.NewBlockFromStorage(hash, h, txs, b.Uncles)
 	if len(senders) != block.Transactions().Len() {
+		panic(fmt.Sprintf("alex: %d, %d\n", len(block.Transactions()), len(senders)))
 		return block, senders, nil // no senders is fine - will recover them on the fly
 	}
 	block.SendersToTxs(senders)

--- a/turbo/snapshotsync/block_snapshots.go
+++ b/turbo/snapshotsync/block_snapshots.go
@@ -755,8 +755,6 @@ func TransactionsHashIdx(chainID uint256.Int, sn *BlocksSnapshot, firstTxID, fir
 
 	buf := make([]byte, 1024)
 
-	tmpPath1 := path.Join(tmpDir, IdxFileName(sn.From, sn.To, Transactions))
-	finalPath1 := path.Join(dir, IdxFileName(sn.From, sn.To, Transactions))
 	txnHashIdx, err := recsplit.NewRecSplit(recsplit.RecSplitArgs{
 		KeyCount:   d.Count(),
 		Enums:      true,
@@ -764,14 +762,12 @@ func TransactionsHashIdx(chainID uint256.Int, sn *BlocksSnapshot, firstTxID, fir
 		Salt:       0,
 		LeafSize:   8,
 		TmpDir:     tmpDir,
-		IndexFile:  tmpPath1,
+		IndexFile:  path.Join(dir, IdxFileName(sn.From, sn.To, Transactions)),
 		BaseDataID: firstTxID,
 	})
 	if err != nil {
 		return err
 	}
-	tmpPath2 := path.Join(tmpDir, IdxFileName(sn.From, sn.To, Transactions2Block))
-	finalPath2 := path.Join(dir, IdxFileName(sn.From, sn.To, Transactions2Block))
 	txnHash2BlockNumIdx, err := recsplit.NewRecSplit(recsplit.RecSplitArgs{
 		KeyCount:   d.Count(),
 		Enums:      true,
@@ -779,7 +775,7 @@ func TransactionsHashIdx(chainID uint256.Int, sn *BlocksSnapshot, firstTxID, fir
 		Salt:       0,
 		LeafSize:   8,
 		TmpDir:     tmpDir,
-		IndexFile:  tmpPath2,
+		IndexFile:  path.Join(dir, IdxFileName(sn.From, sn.To, Transactions2Block)),
 		BaseDataID: firstBlockNum,
 	})
 	if err != nil {
@@ -850,13 +846,6 @@ RETRY:
 		panic(fmt.Errorf("expect: %d, got %d\n", expectedCount, j))
 	}
 
-	//move from tmp dir - when no errors
-	if err = os.Rename(tmpPath1, finalPath1); err != nil {
-		return err
-	}
-	if err = os.Rename(tmpPath2, finalPath2); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -947,9 +936,6 @@ func Idx(d *compress.Decompressor, firstDataID uint64, tmpDir string, walker fun
 	segmentFileName := d.FilePath()
 	var extension = filepath.Ext(segmentFileName)
 	var idxFilePath = segmentFileName[0:len(segmentFileName)-len(extension)] + ".idx"
-	_, fileName := filepath.Split(idxFilePath)
-
-	idxTmpPath := path.Join(tmpDir, fileName)
 
 	rs, err := recsplit.NewRecSplit(recsplit.RecSplitArgs{
 		KeyCount:   d.Count(),
@@ -958,7 +944,7 @@ func Idx(d *compress.Decompressor, firstDataID uint64, tmpDir string, walker fun
 		Salt:       0,
 		LeafSize:   8,
 		TmpDir:     tmpDir,
-		IndexFile:  idxTmpPath,
+		IndexFile:  idxFilePath,
 		BaseDataID: firstDataID,
 	})
 	if err != nil {
@@ -988,9 +974,6 @@ RETRY:
 		return err
 	}
 
-	if err := os.Rename(idxTmpPath, idxFilePath); err != nil {
-		return err
-	}
 	return nil
 }
 


### PR DESCRIPTION
- added new .idx file like `v1-005000-005500-transactions-to-block.idx` 
- .idx files now created in etl-tmp folder and moved to snapshots folder on success .Build
(will do same for .seg in anoter RP)
