### PR TITLE
No need for ApplyBinanceSmartChainEIPs

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -1109,7 +1109,6 @@ func newSync(ctx context.Context, db kv.RwDB, miningConfig *params.MiningConfig)
 	// Apply special hacks for BSC params
 	if chainConfig.Parlia != nil {
 		params.ApplyBinanceSmartChainParams()
-		vm.ApplyBinanceSmartChainEIPs()
 	}
 
 	var batchSize datasize.ByteSize

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -34,11 +34,6 @@ var activators = map[int]func(*JumpTable){
 	1344: enable1344,
 }
 
-func ApplyBinanceSmartChainEIPs() {
-	delete(activators, 3529)
-	delete(activators, 3198)
-}
-
 // EnableEIP enables the given EIP on the config.
 // This operation writes in-place, and callers need to ensure that the globally
 // defined jump tables are not polluted.

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -183,7 +183,6 @@ func New(stack *node.Node, config *ethconfig.Config, logger log.Logger) (*Ethere
 	// Apply special hacks for BSC params
 	if chainConfig.Parlia != nil {
 		params.ApplyBinanceSmartChainParams()
-		vm.ApplyBinanceSmartChainEIPs()
 	}
 
 	ctx, ctxCancel := context.WithCancel(context.Background())


### PR DESCRIPTION
`BSCChainConfig` doesn't have `LondonBlock`, so no need to remove [London](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/london.md) EIP-3198 & EIP-3529.