### PR TITLE
Enable Sentry to send "peer disconnected" event

### DIFF
--- a/cmd/sentry/sentry/sentry.go
+++ b/cmd/sentry/sentry/sentry.go
@@ -538,6 +538,7 @@ func NewSentryServer(ctx context.Context, dialCandidates enode.Iterator, readNod
 			); err != nil {
 				log.Trace(fmt.Sprintf("[%s] Error while running peer: %v", peerID, err))
 			}
+			ss.sendGonePeerToClients(gointerfaces.ConvertHashToH256(peerID))
 			return nil
 		},
 		NodeInfo: func() interface{} {
@@ -978,6 +979,12 @@ func (ss *SentryServerImpl) Close() {
 func (ss *SentryServerImpl) sendNewPeerToClients(peerID *proto_types.H256) {
 	if err := ss.peersStreams.Broadcast(&proto_sentry.PeersReply{PeerId: peerID, Event: proto_sentry.PeersReply_Connect}); err != nil {
 		log.Warn("Sending new peer notice to core P2P failed", "error", err)
+	}
+}
+
+func (ss *SentryServerImpl) sendGonePeerToClients(peerID *proto_types.H256) {
+	if err := ss.peersStreams.Broadcast(&proto_sentry.PeersReply{PeerId: peerID, Event: proto_sentry.PeersReply_Disconnect}); err != nil {
+		log.Warn("Sending gone peer notice to core P2P failed", "error", err)
 	}
 }
 


### PR DESCRIPTION
This solves #3318

_The Sentry already sends the PeersReply_Connect event to remote clients when a new Peer connects. 
Also it should send the PeersReply_Disconnect event to signal that a Peer disconnected so the clients can react and take actions, for example simple tracing the event or asking for the new peer count._

This PR aims to adds this behavior.  