### PR TITLE
BSC: Fix of gas bailout flag for trace and call calculations

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -98,11 +98,7 @@ func applyTransaction(config *params.ChainConfig, gp *GasPool, statedb *state.In
 	// Update the evm with the new transaction context.
 	evm.Reset(txContext, statedb)
 
-	gasBailout := false
-	if config.Parlia != nil {
-		gasBailout = true
-	}
-	result, err := ApplyMessage(evm, msg, gp, true /* refunds */, gasBailout /* gasBailout */)
+	result, err := ApplyMessage(evm, msg, gp, true /* refunds */, false /* gasBailout */)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -341,6 +341,12 @@ func (st *StateTransition) TransitionDb(refunds bool, gasBailout bool) (*Executi
 	// 5. there is no overflow when calculating intrinsic gas
 	// 6. caller has enough balance to cover asset transfer for **topmost** call
 
+	// BSC always gave gas bailout due to system transactions that set 2^256/2 gas limit and
+	// for Parlia consensus this flag should be always be set
+	if st.evm.ChainConfig().Parlia != nil {
+		gasBailout = true
+	}
+
 	// Check clauses 1-3 and 6, buy gas if everything is correct
 	if err := st.preCheck(gasBailout); err != nil {
 		return nil, err


### PR DESCRIPTION
BSC always have in block system transaction that consume 2^256/2 gas price that cause block's gas price overflow. That is why applying readonly calls or trace to such transactions and even trace of block fail with insufficient gas.

https://github.com/ledgerwatch/erigon/issues/3329