### PR TITLE
Explicit dev version

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -31,10 +31,10 @@ var (
 
 // see https://calver.org
 const (
-	VersionMajor       = 2021    // Major version component of the current release
-	VersionMinor       = 11      // Minor version component of the current release
-	VersionMicro       = 3       // Patch version component of the current release
-	VersionModifier    = "alpha" // Patch version component of the current release
+	VersionMajor       = 2022  // Major version component of the current release
+	VersionMinor       = 99    // Minor version component of the current release
+	VersionMicro       = 99    // Patch version component of the current release
+	VersionModifier    = "dev" // Patch version component of the current release
 	VersionKeyCreated  = "ErigonVersionCreated"
 	VersionKeyFinished = "ErigonVersionFinished"
 )

--- a/params/version.go
+++ b/params/version.go
@@ -34,7 +34,7 @@ const (
 	VersionMajor       = 2022  // Major version component of the current release
 	VersionMinor       = 99    // Minor version component of the current release
 	VersionMicro       = 99    // Patch version component of the current release
-	VersionModifier    = "dev" // Patch version component of the current release
+	VersionModifier    = "dev" // Modifier component of the current release
 	VersionKeyCreated  = "ErigonVersionCreated"
 	VersionKeyFinished = "ErigonVersionFinished"
 )


### PR DESCRIPTION
to highlight that Erigon built from the devel branch has some indeterminate future version "2022.99.99-dev" instead of 2021.11.3-alpha.

Also see how many "2021.11.3-alpha" instances https://www.ethernodes.org/client/erigon shows currently.