### PR TITLE
Update golangci-lint to behave properly on `clean` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,8 +130,11 @@ lintci-deps:
 
 clean:
 	go clean -cache
-	rm -fr build/*
+	find ./build ! -regex "\(./build/bin/golangci-lint\|./build/bin\|./build\)" -type f,d -delete
 	cd libmdbx/ && make clean
+ifneq (,$(wildcard ./build/bin/golangci-lint))
+	./build/bin/golangci-lint cache clean
+endif
 
 # The devtools target installs tools required for 'go generate'.
 # You need to put $GOBIN (or $GOPATH/bin) in your PATH to use 'go generate'.

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ lintci-deps:
 
 clean:
 	go clean -cache
-	find ./build ! -regex "\(./build/bin/golangci-lint\|./build/bin\|./build\)" -type f,d -delete
+	find ./build ! -path "./build/bin/golangci-lint" -type f,d -empty -delete
 	cd libmdbx/ && make clean
 ifneq (,$(wildcard ./build/bin/golangci-lint))
 	./build/bin/golangci-lint cache clean

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,6 @@ clean:
 	go clean -cache
 	rm -fr build/*
 	cd libmdbx/ && make clean
-	./build/bin/golangci-lint cache clean
 
 # The devtools target installs tools required for 'go generate'.
 # You need to put $GOBIN (or $GOPATH/bin) in your PATH to use 'go generate'.


### PR DESCRIPTION
Two lines above the removed line removes `golangci-lint`, even if it was previously downloaded with `make lintci-deps` which would always cause an error when attempting to call `golangci-lint`. I do not believe there is much use in running the linter in the `clean` target anyway.