### PR TITLE
Fix/rpcdaemon ws upgrade (#3490)

### DIFF
--- a/cmd/devnettest/commands/requests.go
+++ b/cmd/devnettest/commands/requests.go
@@ -1,0 +1,18 @@
+package commands
+
+import (
+	"github.com/ledgerwatch/erigon/cmd/devnettest/requests"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(mockRequestCmd)
+}
+
+var mockRequestCmd = &cobra.Command{
+	Use:   "mock",
+	Short: "Mocks a request on the devnet",
+	Run: func(cmd *cobra.Command, args []string) {
+		requests.MockGetRequest(reqId)
+	},
+}

--- a/cmd/devnettest/requests/mock_requests.go
+++ b/cmd/devnettest/requests/mock_requests.go
@@ -1,0 +1,16 @@
+package requests
+
+import "fmt"
+
+func MockGetRequest(reqId int) {
+	reqGen := initialiseRequestGenerator(reqId)
+
+	res := reqGen.Get()
+
+	if res.Err != nil {
+		fmt.Printf("error: %v\n", res.Err)
+		return
+	}
+
+	fmt.Printf("OK\n")
+}

--- a/cmd/devnettest/requests/request_generator.go
+++ b/cmd/devnettest/requests/request_generator.go
@@ -1,7 +1,9 @@
 package requests
 
 import (
+	"errors"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -32,6 +34,39 @@ func initialiseRequestGenerator(reqId int) *RequestGenerator {
 	}
 
 	return &reqGen
+}
+
+func (req *RequestGenerator) Get() rpctest.CallResult {
+	start := time.Now()
+	res := rpctest.CallResult{
+		RequestID: req.reqID,
+	}
+
+	resp, err := http.Get(erigonUrl)
+	if err != nil {
+		res.Took = time.Since(start)
+		res.Err = err
+		return res
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		res.Took = time.Since(start)
+		res.Err = errors.New("bad request")
+		return res
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		res.Took = time.Since(start)
+		res.Err = err
+		return res
+	}
+
+	res.Response = body
+	res.Took = time.Since(start)
+	res.Err = err
+	return res
 }
 
 func (req *RequestGenerator) Erigon(method, body string, response interface{}) rpctest.CallResult {

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -9,23 +9,30 @@ import (
 	"net"
 	"net/http"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/ledgerwatch/erigon-lib/gointerfaces"
 	"github.com/ledgerwatch/erigon-lib/gointerfaces/grpcutil"
 	"github.com/ledgerwatch/erigon-lib/gointerfaces/remote"
+	"github.com/ledgerwatch/erigon-lib/gointerfaces/txpool"
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon-lib/kv/kvcache"
 	kv2 "github.com/ledgerwatch/erigon-lib/kv/mdbx"
 	"github.com/ledgerwatch/erigon-lib/kv/remotedb"
 	"github.com/ledgerwatch/erigon-lib/kv/remotedbserver"
 	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/health"
+	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/interfaces"
 	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/services"
 	"github.com/ledgerwatch/erigon/cmd/utils"
 	"github.com/ledgerwatch/erigon/common/paths"
+	"github.com/ledgerwatch/erigon/core/rawdb"
+	"github.com/ledgerwatch/erigon/eth/ethconfig"
 	"github.com/ledgerwatch/erigon/internal/debug"
 	"github.com/ledgerwatch/erigon/node"
+	"github.com/ledgerwatch/erigon/params"
 	"github.com/ledgerwatch/erigon/rpc"
+	"github.com/ledgerwatch/erigon/turbo/snapshotsync"
 	"github.com/ledgerwatch/log/v3"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
@@ -36,34 +43,37 @@ import (
 )
 
 type Flags struct {
-	PrivateApiAddr         string
-	SingleNodeMode         bool // Erigon's database can be read by separated processes on same machine - in read-only mode - with full support of transactions. It will share same "OS PageCache" with Erigon process.
-	Datadir                string
-	Chaindata              string
-	HttpListenAddress      string
-	TLSCertfile            string
-	TLSCACert              string
-	TLSKeyFile             string
-	HttpPort               int
-	HttpCORSDomain         []string
-	HttpVirtualHost        []string
-	HttpCompression        bool
-	API                    []string
-	Gascap                 uint64
-	MaxTraces              uint64
-	WebsocketEnabled       bool
-	WebsocketCompression   bool
-	RpcAllowListFilePath   string
-	RpcBatchConcurrency    uint
-	TraceCompatibility     bool // Bug for bug compatibility for trace_ routines with OpenEthereum
-	TxPoolV2               bool
-	TxPoolApiAddr          string
-	TevmEnabled            bool
-	StateCache             kvcache.CoherentConfig
-	GRPCServerEnabled      bool
-	GRPCListenAddress      string
-	GRPCPort               int
-	GRPCHealthCheckEnabled bool
+	PrivateApiAddr          string
+	SingleNodeMode          bool // Erigon's database can be read by separated processes on same machine - in read-only mode - with full support of transactions. It will share same "OS PageCache" with Erigon process.
+	Datadir                 string
+	Chaindata               string
+	HttpListenAddress       string
+	EngineHTTPListenAddress string
+	TLSCertfile             string
+	TLSCACert               string
+	TLSKeyFile              string
+	HttpPort                int
+	EnginePort              int
+	HttpCORSDomain          []string
+	HttpVirtualHost         []string
+	HttpCompression         bool
+	API                     []string
+	Gascap                  uint64
+	MaxTraces               uint64
+	WebsocketEnabled        bool
+	WebsocketCompression    bool
+	RpcAllowListFilePath    string
+	RpcBatchConcurrency     uint
+	TraceCompatibility      bool // Bug for bug compatibility for trace_ routines with OpenEthereum
+	TxPoolApiAddr           string
+	TevmEnabled             bool
+	StateCache              kvcache.CoherentConfig
+	Snapshot                ethconfig.Snapshot
+	GRPCServerEnabled       bool
+	GRPCListenAddress       string
+	GRPCPort                int
+	GRPCHealthCheckEnabled  bool
+	StarknetGRPCAddress     string
 }
 
 var rootCmd = &cobra.Command{
@@ -79,14 +89,16 @@ func RootCommand() (*cobra.Command, *Flags) {
 	rootCmd.PersistentFlags().StringVar(&cfg.Datadir, "datadir", "", "path to Erigon working directory")
 	rootCmd.PersistentFlags().StringVar(&cfg.Chaindata, "chaindata", "", "path to the database")
 	rootCmd.PersistentFlags().StringVar(&cfg.HttpListenAddress, "http.addr", node.DefaultHTTPHost, "HTTP-RPC server listening interface")
+	rootCmd.PersistentFlags().StringVar(&cfg.EngineHTTPListenAddress, "engine.addr", node.DefaultHTTPHost, "HTTP-RPC server listening interface for engineAPI")
 	rootCmd.PersistentFlags().StringVar(&cfg.TLSCertfile, "tls.cert", "", "certificate for client side TLS handshake")
 	rootCmd.PersistentFlags().StringVar(&cfg.TLSKeyFile, "tls.key", "", "key file for client side TLS handshake")
 	rootCmd.PersistentFlags().StringVar(&cfg.TLSCACert, "tls.cacert", "", "CA certificate for client side TLS handshake")
 	rootCmd.PersistentFlags().IntVar(&cfg.HttpPort, "http.port", node.DefaultHTTPPort, "HTTP-RPC server listening port")
+	rootCmd.PersistentFlags().IntVar(&cfg.EnginePort, "engine.port", node.DefaultEngineHTTPPort, "HTTP-RPC server listening port for the engineAPI")
 	rootCmd.PersistentFlags().StringSliceVar(&cfg.HttpCORSDomain, "http.corsdomain", []string{}, "Comma separated list of domains from which to accept cross origin requests (browser enforced)")
 	rootCmd.PersistentFlags().StringSliceVar(&cfg.HttpVirtualHost, "http.vhosts", node.DefaultConfig.HTTPVirtualHosts, "Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard.")
 	rootCmd.PersistentFlags().BoolVar(&cfg.HttpCompression, "http.compression", true, "Disable http compression")
-	rootCmd.PersistentFlags().StringSliceVar(&cfg.API, "http.api", []string{"eth", "erigon"}, "API's offered over the HTTP-RPC interface: eth,erigon,web3,net,debug,trace,txpool,db. Supported methods: https://github.com/ledgerwatch/erigon/tree/devel/cmd/rpcdaemon")
+	rootCmd.PersistentFlags().StringSliceVar(&cfg.API, "http.api", []string{"eth", "erigon"}, "API's offered over the HTTP-RPC interface: eth,erigon,web3,net,debug,trace,txpool,db,starknet. Supported methods: https://github.com/ledgerwatch/erigon/tree/devel/cmd/rpcdaemon")
 	rootCmd.PersistentFlags().Uint64Var(&cfg.Gascap, "rpc.gascap", 50000000, "Sets a cap on gas that can be used in eth_call/estimateGas")
 	rootCmd.PersistentFlags().Uint64Var(&cfg.MaxTraces, "trace.maxtraces", 200, "Sets a limit on traces that can be returned in trace_filter")
 	rootCmd.PersistentFlags().BoolVar(&cfg.WebsocketEnabled, "ws", false, "Enable Websockets")
@@ -96,11 +108,13 @@ func RootCommand() (*cobra.Command, *Flags) {
 	rootCmd.PersistentFlags().BoolVar(&cfg.TraceCompatibility, "trace.compat", false, "Bug for bug compatibility with OE for trace_ routines")
 	rootCmd.PersistentFlags().StringVar(&cfg.TxPoolApiAddr, "txpool.api.addr", "127.0.0.1:9090", "txpool api network address, for example: 127.0.0.1:9090")
 	rootCmd.PersistentFlags().BoolVar(&cfg.TevmEnabled, "tevm", false, "Enables Transpiled EVM experiment")
+	rootCmd.PersistentFlags().BoolVar(&cfg.Snapshot.Enabled, ethconfig.FlagSnapshot, false, "Enables Snapshot Sync")
 	rootCmd.PersistentFlags().IntVar(&cfg.StateCache.KeysLimit, "state.cache", kvcache.DefaultCoherentConfig.KeysLimit, "Amount of keys to store in StateCache (enabled if no --datadir set). Set 0 to disable StateCache. 1_000_000 keys ~ equal to 2Gb RAM (maybe we will add RAM accounting in future versions).")
 	rootCmd.PersistentFlags().BoolVar(&cfg.GRPCServerEnabled, "grpc", false, "Enable GRPC server")
 	rootCmd.PersistentFlags().StringVar(&cfg.GRPCListenAddress, "grpc.addr", node.DefaultGRPCHost, "GRPC server listening interface")
 	rootCmd.PersistentFlags().IntVar(&cfg.GRPCPort, "grpc.port", node.DefaultGRPCPort, "GRPC server listening port")
 	rootCmd.PersistentFlags().BoolVar(&cfg.GRPCHealthCheckEnabled, "grpc.healthcheck", false, "Enable GRPC health check")
+	rootCmd.PersistentFlags().StringVar(&cfg.StarknetGRPCAddress, "starknet.grpc.address", "127.0.0.1:6066", "Starknet GRPC address")
 
 	if err := rootCmd.MarkPersistentFlagFilename("rpc.accessList", "json"); err != nil {
 		panic(err)
@@ -124,8 +138,8 @@ func RootCommand() (*cobra.Command, *Flags) {
 			if cfg.Chaindata == "" {
 				cfg.Chaindata = path.Join(cfg.Datadir, "chaindata")
 			}
+			cfg.Snapshot = ethconfig.NewSnapshotCfg(cfg.Snapshot.Enabled, cfg.Snapshot.RetireEnabled)
 		}
-		cfg.TxPoolV2 = true
 		return nil
 	}
 	rootCmd.PersistentPostRunE = func(cmd *cobra.Command, args []string) error {
@@ -224,23 +238,47 @@ func checkDbCompatibility(ctx context.Context, db kv.RoDB) error {
 	return nil
 }
 
-func RemoteServices(ctx context.Context, cfg Flags, logger log.Logger, rootCancel context.CancelFunc) (db kv.RoDB, eth services.ApiBackend, txPool *services.TxPoolService, mining *services.MiningService, stateCache kvcache.Cache, err error) {
+// RemoteServices - use when RPCDaemon run as independent process. Still it can use --datadir flag to enable
+// `cfg.SingleNodeMode` (mode when it on 1 machine with Erigon)
+func RemoteServices(ctx context.Context, cfg Flags, logger log.Logger, rootCancel context.CancelFunc) (db kv.RoDB, borDb kv.RoDB, eth services.ApiBackend, txPool txpool.TxpoolClient, mining txpool.MiningClient, starknet *services.StarknetService, stateCache kvcache.Cache, blockReader interfaces.BlockAndTxnReader, err error) {
 	if !cfg.SingleNodeMode && cfg.PrivateApiAddr == "" {
-		return nil, nil, nil, nil, nil, fmt.Errorf("either remote db or local db must be specified")
+		return nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("either remote db or local db must be specified")
 	}
+
 	// Do not change the order of these checks. Chaindata needs to be checked first, because PrivateApiAddr has default value which is not ""
 	// If PrivateApiAddr is checked first, the Chaindata option will never work
 	if cfg.SingleNodeMode {
 		var rwKv kv.RwDB
+		log.Trace("Creating chain db", "path", cfg.Chaindata)
 		rwKv, err = kv2.NewMDBX(logger).Path(cfg.Chaindata).Readonly().Open()
 		if err != nil {
-			return nil, nil, nil, nil, nil, err
+			return nil, nil, nil, nil, nil, nil, nil, nil, err
 		}
 		if compatErr := checkDbCompatibility(ctx, rwKv); compatErr != nil {
-			return nil, nil, nil, nil, nil, compatErr
+			return nil, nil, nil, nil, nil, nil, nil, nil, compatErr
 		}
 		db = rwKv
 		stateCache = kvcache.NewDummy()
+		blockReader = snapshotsync.NewBlockReader()
+
+		// bor (consensus) specific db
+		var borKv kv.RoDB
+		borDbPath := path.Join(cfg.Datadir, "bor")
+		{
+			// ensure db exist
+			tmpDb, err := kv2.NewMDBX(logger).Path(borDbPath).Label(kv.ConsensusDB).Open()
+			if err != nil {
+				return nil, nil, nil, nil, nil, nil, nil, nil, err
+			}
+			tmpDb.Close()
+		}
+		log.Trace("Creating consensus db", "path", borDbPath)
+		borKv, err = kv2.NewMDBX(logger).Path(borDbPath).Label(kv.ConsensusDB).Readonly().Open()
+		if err != nil {
+			return nil, nil, nil, nil, nil, nil, nil, nil, err
+		}
+		// Skip the compatibility check, until we have a schema in erigon-lib
+		borDb = borKv
 	} else {
 		if cfg.StateCache.KeysLimit > 0 {
 			stateCache = kvcache.New(cfg.StateCache)
@@ -250,37 +288,72 @@ func RemoteServices(ctx context.Context, cfg Flags, logger log.Logger, rootCance
 		log.Info("if you run RPCDaemon on same machine with Erigon add --datadir option")
 	}
 
+	if cfg.SingleNodeMode {
+		if cfg.Snapshot.Enabled {
+			var cc *params.ChainConfig
+			if err := db.View(context.Background(), func(tx kv.Tx) error {
+				genesisBlock, err := rawdb.ReadBlockByNumber(tx, 0)
+				if err != nil {
+					return err
+				}
+				cc, err = rawdb.ReadChainConfig(tx, genesisBlock.Hash())
+				if err != nil {
+					return err
+				}
+				return nil
+			}); err != nil {
+				return nil, nil, nil, nil, nil, nil, nil, nil, err
+			}
+			if cc == nil {
+				return nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("chain config not found in db. Need start erigon at least once on this db")
+			}
+
+			allSnapshots := snapshotsync.NewAllSnapshots(cfg.Snapshot, path.Join(cfg.Datadir, "snapshots"))
+			allSnapshots.AsyncOpenAll(ctx)
+			blockReader = snapshotsync.NewBlockReaderWithSnapshots(allSnapshots)
+		} else {
+			blockReader = snapshotsync.NewBlockReader()
+		}
+	}
 	if cfg.PrivateApiAddr == "" {
-		return db, eth, txPool, mining, stateCache, nil
+		return db, borDb, eth, txPool, mining, starknet, stateCache, blockReader, nil
 	}
 
 	creds, err := grpcutil.TLS(cfg.TLSCACert, cfg.TLSCertfile, cfg.TLSKeyFile)
 	if err != nil {
-		return nil, nil, nil, nil, nil, fmt.Errorf("open tls cert: %w", err)
+		return nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("open tls cert: %w", err)
 	}
 	conn, err := grpcutil.Connect(creds, cfg.PrivateApiAddr)
 	if err != nil {
-		return nil, nil, nil, nil, nil, fmt.Errorf("could not connect to execution service privateApi: %w", err)
+		return nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("could not connect to execution service privateApi: %w", err)
 	}
 
 	kvClient := remote.NewKVClient(conn)
 	remoteKv, err := remotedb.NewRemote(gointerfaces.VersionFromProto(remotedbserver.KvServiceAPIVersion), logger, kvClient).Open()
 	if err != nil {
-		return nil, nil, nil, nil, nil, fmt.Errorf("could not connect to remoteKv: %w", err)
+		return nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("could not connect to remoteKv: %w", err)
 	}
 
 	subscribeToStateChangesLoop(ctx, kvClient, stateCache)
 
-	remoteEth := services.NewRemoteBackend(conn)
+	if !cfg.SingleNodeMode {
+		blockReader = snapshotsync.NewRemoteBlockReader(remote.NewETHBACKENDClient(conn))
+	}
+	remoteEth := services.NewRemoteBackend(remote.NewETHBACKENDClient(conn), db, blockReader)
+	blockReader = remoteEth
+
 	txpoolConn := conn
-	if cfg.TxPoolV2 {
+	if cfg.TxPoolApiAddr != cfg.PrivateApiAddr {
 		txpoolConn, err = grpcutil.Connect(creds, cfg.TxPoolApiAddr)
 		if err != nil {
-			return nil, nil, nil, nil, nil, fmt.Errorf("could not connect to txpool api: %w", err)
+			return nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("could not connect to txpool api: %w", err)
 		}
 	}
-	mining = services.NewMiningService(txpoolConn)
-	txPool = services.NewTxPoolService(txpoolConn)
+
+	mining = txpool.NewMiningClient(txpoolConn)
+	miningService := services.NewMiningService(mining)
+	txPool = txpool.NewTxpoolClient(txpoolConn)
+	txPoolService := services.NewTxPoolService(txPool)
 	if db == nil {
 		db = remoteKv
 	}
@@ -292,17 +365,30 @@ func RemoteServices(ctx context.Context, cfg Flags, logger log.Logger, rootCance
 		if !remoteEth.EnsureVersionCompatibility() {
 			rootCancel()
 		}
-		if mining != nil && !mining.EnsureVersionCompatibility() {
+		if mining != nil && !miningService.EnsureVersionCompatibility() {
 			rootCancel()
 		}
-		if !txPool.EnsureVersionCompatibility() {
+		if !txPoolService.EnsureVersionCompatibility() {
 			rootCancel()
 		}
 	}()
-	return db, eth, txPool, mining, stateCache, err
+
+	if cfg.StarknetGRPCAddress != "" {
+		starknetConn, err := grpcutil.Connect(creds, cfg.StarknetGRPCAddress)
+		if err != nil {
+			return nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("could not connect to starknet api: %w", err)
+		}
+		starknet = services.NewStarknetService(starknetConn)
+	}
+
+	return db, borDb, eth, txPool, mining, starknet, stateCache, blockReader, err
 }
 
 func StartRpcServer(ctx context.Context, cfg Flags, rpcAPI []rpc.API) error {
+	var engineListener *http.Server
+	var enginesrv *rpc.Server
+	var engineHttpEndpoint string
+
 	// register apis and create handler stack
 	httpEndpoint := fmt.Sprintf("%s:%d", cfg.HttpListenAddress, cfg.HttpPort)
 
@@ -314,7 +400,29 @@ func StartRpcServer(ctx context.Context, cfg Flags, rpcAPI []rpc.API) error {
 	}
 	srv.SetAllowList(allowListForRPC)
 
-	if err := node.RegisterApisFromWhitelist(rpcAPI, cfg.API, srv, false); err != nil {
+	var defaultAPIList []rpc.API
+	var engineAPI []rpc.API
+
+	for _, api := range rpcAPI {
+		if api.Namespace != "engine" {
+			defaultAPIList = append(defaultAPIList, api)
+		} else {
+			engineAPI = append(engineAPI, api)
+		}
+	}
+
+	var apiFlags []string
+	var engineFlag []string
+
+	for _, flag := range cfg.API {
+		if flag != "engine" {
+			apiFlags = append(apiFlags, flag)
+		} else {
+			engineFlag = append(engineFlag, flag)
+		}
+	}
+
+	if err := node.RegisterApisFromWhitelist(defaultAPIList, apiFlags, srv, false); err != nil {
 		return fmt.Errorf("could not start register RPC apis: %w", err)
 	}
 
@@ -324,24 +432,22 @@ func StartRpcServer(ctx context.Context, cfg Flags, rpcAPI []rpc.API) error {
 		wsHandler = srv.WebsocketHandler([]string{"*"}, cfg.WebsocketCompression)
 	}
 
-	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// adding a healthcheck here
-		if health.ProcessHealthcheckIfNeeded(w, r, rpcAPI) {
-			return
-		}
-		if cfg.WebsocketEnabled && r.Method == "GET" {
-			wsHandler.ServeHTTP(w, r)
-			return
-		}
-		httpHandler.ServeHTTP(w, r)
-	})
+	apiHandler := createHandler(cfg, defaultAPIList, httpHandler, wsHandler)
 
-	listener, _, err := node.StartHTTPEndpoint(httpEndpoint, rpc.DefaultHTTPTimeouts, handler)
+	listener, _, err := node.StartHTTPEndpoint(httpEndpoint, rpc.DefaultHTTPTimeouts, apiHandler)
 	if err != nil {
 		return fmt.Errorf("could not start RPC api: %w", err)
 	}
 	info := []interface{}{"url", httpEndpoint, "ws", cfg.WebsocketEnabled,
 		"ws.compression", cfg.WebsocketCompression, "grpc", cfg.GRPCServerEnabled}
+
+	if len(engineAPI) > 0 {
+		engineListener, enginesrv, engineHttpEndpoint, err = createEngineListener(cfg, engineAPI, engineFlag)
+		if err != nil {
+			return fmt.Errorf("could not start RPC api for engine: %w", err)
+		}
+	}
+
 	var (
 		healthServer *grpcHealth.Server
 		grpcServer   *grpc.Server
@@ -366,10 +472,18 @@ func StartRpcServer(ctx context.Context, cfg Flags, rpcAPI []rpc.API) error {
 
 	defer func() {
 		srv.Stop()
+		if enginesrv != nil {
+			enginesrv.Stop()
+		}
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		_ = listener.Shutdown(shutdownCtx)
 		log.Info("HTTP endpoint closed", "url", httpEndpoint)
+
+		if engineListener != nil {
+			_ = engineListener.Shutdown(shutdownCtx)
+			log.Info("Engine HTTP endpoint close", "url", engineHttpEndpoint)
+		}
 
 		if cfg.GRPCServerEnabled {
 			if cfg.GRPCHealthCheckEnabled {
@@ -383,4 +497,55 @@ func StartRpcServer(ctx context.Context, cfg Flags, rpcAPI []rpc.API) error {
 	<-ctx.Done()
 	log.Info("Exiting...")
 	return nil
+}
+
+// isWebsocket checks the header of a http request for a websocket upgrade request.
+func isWebsocket(r *http.Request) bool {
+	return strings.ToLower(r.Header.Get("Upgrade")) == "websocket" &&
+		strings.Contains(strings.ToLower(r.Header.Get("Connection")), "upgrade")
+}
+
+func createHandler(cfg Flags, apiList []rpc.API, httpHandler http.Handler, wsHandler http.Handler) http.Handler {
+	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// adding a healthcheck here
+		if health.ProcessHealthcheckIfNeeded(w, r, apiList) {
+			return
+		}
+		if cfg.WebsocketEnabled && wsHandler != nil && isWebsocket(r) {
+			wsHandler.ServeHTTP(w, r)
+			return
+		}
+		httpHandler.ServeHTTP(w, r)
+	})
+
+	return handler
+}
+
+func createEngineListener(cfg Flags, engineApi []rpc.API, engineFlag []string) (*http.Server, *rpc.Server, string, error) {
+	engineHttpEndpoint := fmt.Sprintf("%s:%d", cfg.EngineHTTPListenAddress, cfg.EnginePort)
+
+	enginesrv := rpc.NewServer(cfg.RpcBatchConcurrency)
+
+	allowListForRPC, err := parseAllowListForRPC(cfg.RpcAllowListFilePath)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	enginesrv.SetAllowList(allowListForRPC)
+
+	if err := node.RegisterApisFromWhitelist(engineApi, engineFlag, enginesrv, false); err != nil {
+		return nil, nil, "", fmt.Errorf("could not start register RPC engine api: %w", err)
+	}
+
+	engineHttpHandler := node.NewHTTPHandlerStack(enginesrv, cfg.HttpCORSDomain, cfg.HttpVirtualHost, cfg.HttpCompression)
+	engineApiHandler := createHandler(cfg, engineApi, engineHttpHandler, nil)
+
+	engineListener, _, err := node.StartHTTPEndpoint(engineHttpEndpoint, rpc.DefaultHTTPTimeouts, engineApiHandler)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("could not start RPC api: %w", err)
+	}
+	engineInfo := []interface{}{"url", engineHttpEndpoint}
+	log.Info("HTTP endpoint opened for engine", engineInfo...)
+
+	return engineListener, enginesrv, engineHttpEndpoint, nil
+
 }


### PR DESCRIPTION
* Added a method to `cmd/rpcdaemon/cli/config.go` to check header of incoming http request for a ws upgrade request

* Added the testing of the 'GET /' request for ws to the devnet tool

* Fixed lint errors