### PR TITLE
accounts/abi, cmd, core, tests: remove NewKeyedTransactor function

### DIFF
--- a/accounts/abi/bind/auth.go
+++ b/accounts/abi/bind/auth.go
@@ -24,7 +24,6 @@ import (
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/crypto"
-	"github.com/ledgerwatch/log/v3"
 )
 
 // ErrNoChainID is returned whenever the user failed to specify a chain id.

--- a/accounts/abi/bind/auth.go
+++ b/accounts/abi/bind/auth.go
@@ -33,29 +33,6 @@ var ErrNoChainID = errors.New("no chain id specified")
 // ErrNotAuthorized is returned when an account is not properly unlocked.
 var ErrNotAuthorized = errors.New("not authorized to sign this account")
 
-// NewKeyedTransactor is a utility method to easily create a transaction signer
-// from a single private key.
-//
-// Deprecated: Use NewKeyedTransactorWithChainID instead.
-func NewKeyedTransactor(key *ecdsa.PrivateKey) *TransactOpts {
-	log.Warn("WARNING: NewKeyedTransactor has been deprecated in favour of NewKeyedTransactorWithChainID")
-	keyAddr := crypto.PubkeyToAddress(key.PublicKey)
-	signer := types.LatestSignerForChainID(nil)
-	return &TransactOpts{
-		From: keyAddr,
-		Signer: func(address common.Address, tx types.Transaction) (types.Transaction, error) {
-			if address != keyAddr {
-				return nil, ErrNotAuthorized
-			}
-			signature, err := crypto.Sign(tx.SigningHash(nil).Bytes(), key)
-			if err != nil {
-				return nil, err
-			}
-			return tx.WithSignature(*signer, signature)
-		},
-	}
-}
-
 // NewKeyedTransactorWithChainID is a utility method to easily create a transaction signer
 // from a single private key.
 func NewKeyedTransactorWithChainID(key *ecdsa.PrivateKey, chainID *big.Int) (*TransactOpts, error) {

--- a/cmd/pics/state.go
+++ b/cmd/pics/state.go
@@ -288,9 +288,9 @@ func initialState1() error {
 
 	contractBackend := backends.NewSimulatedBackendWithConfig(gspec.Alloc, gspec.Config, gspec.GasLimit)
 	defer contractBackend.Close()
-	transactOpts := bind.NewKeyedTransactor(key)
-	transactOpts1 := bind.NewKeyedTransactor(key1)
-	transactOpts2 := bind.NewKeyedTransactor(key2)
+	transactOpts := bind.NewKeyedTransactorWithChainID(key)
+	transactOpts1 := bind.NewKeyedTransactorWithChainID(key1)
+	transactOpts2 := bind.NewKeyedTransactorWithChainID(key2)
 
 	var tokenContract *contracts.Token
 	// We generate the blocks without plainstant because it's not supported in core.GenerateChain

--- a/core/state/database_test.go
+++ b/core/state/database_test.go
@@ -73,7 +73,7 @@ func TestCreate2Revive(t *testing.T) {
 
 	contractBackend := backends.NewSimulatedBackendWithConfig(gspec.Alloc, gspec.Config, gspec.GasLimit)
 	defer contractBackend.Close()
-	transactOpts := bind.NewKeyedTransactor(key)
+	transactOpts := bind.NewKeyedTransactorWithChainID(key)
 	transactOpts.GasLimit = 1000000
 
 	var contractAddress common.Address
@@ -265,7 +265,7 @@ func TestCreate2Polymorth(t *testing.T) {
 
 	contractBackend := backends.NewSimulatedBackendWithConfig(gspec.Alloc, gspec.Config, gspec.GasLimit)
 	defer contractBackend.Close()
-	transactOpts := bind.NewKeyedTransactor(key)
+	transactOpts := bind.NewKeyedTransactorWithChainID(key)
 	transactOpts.GasLimit = 1000000
 
 	var contractAddress common.Address
@@ -512,7 +512,7 @@ func TestReorgOverSelfDestruct(t *testing.T) {
 
 	contractBackend := backends.NewSimulatedBackendWithConfig(gspec.Alloc, gspec.Config, gspec.GasLimit)
 	defer contractBackend.Close()
-	transactOpts := bind.NewKeyedTransactor(key)
+	transactOpts := bind.NewKeyedTransactorWithChainID(key)
 	transactOpts.GasLimit = 1000000
 
 	var contractAddress common.Address
@@ -552,7 +552,7 @@ func TestReorgOverSelfDestruct(t *testing.T) {
 	// Create a longer chain, with 4 blocks (with higher total difficulty) that reverts the change of stroage self-destruction of the contract
 	contractBackendLonger := backends.NewSimulatedBackendWithConfig(gspec.Alloc, gspec.Config, gspec.GasLimit)
 	defer contractBackendLonger.Close()
-	transactOptsLonger := bind.NewKeyedTransactor(key)
+	transactOptsLonger := bind.NewKeyedTransactorWithChainID(key)
 	transactOptsLonger.GasLimit = 1000000
 
 	longerChain, err := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 4, func(i int, block *core.BlockGen) {
@@ -662,7 +662,7 @@ func TestReorgOverStateChange(t *testing.T) {
 
 	contractBackend := backends.NewSimulatedBackendWithConfig(gspec.Alloc, gspec.Config, gspec.GasLimit)
 	defer contractBackend.Close()
-	transactOpts := bind.NewKeyedTransactor(key)
+	transactOpts := bind.NewKeyedTransactorWithChainID(key)
 	transactOpts.GasLimit = 1000000
 
 	var contractAddress common.Address
@@ -696,7 +696,7 @@ func TestReorgOverStateChange(t *testing.T) {
 	// Create a longer chain, with 4 blocks (with higher total difficulty) that reverts the change of stroage self-destruction of the contract
 	contractBackendLonger := backends.NewSimulatedBackendWithConfig(gspec.Alloc, gspec.Config, gspec.GasLimit)
 	defer contractBackendLonger.Close()
-	transactOptsLonger := bind.NewKeyedTransactor(key)
+	transactOptsLonger := bind.NewKeyedTransactorWithChainID(key)
 	transactOptsLonger.GasLimit = 1000000
 	longerChain, err := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 3, func(i int, block *core.BlockGen) {
 		var tx types.Transaction
@@ -949,7 +949,7 @@ func TestEip2200Gas(t *testing.T) {
 
 	contractBackend := backends.NewSimulatedBackendWithConfig(gspec.Alloc, gspec.Config, gspec.GasLimit)
 	defer contractBackend.Close()
-	transactOpts := bind.NewKeyedTransactor(key)
+	transactOpts := bind.NewKeyedTransactorWithChainID(key)
 	transactOpts.GasLimit = 1000000
 
 	var contractAddress common.Address
@@ -1042,7 +1042,7 @@ func TestWrongIncarnation(t *testing.T) {
 
 	contractBackend := backends.NewSimulatedBackendWithConfig(gspec.Alloc, gspec.Config, gspec.GasLimit)
 	defer contractBackend.Close()
-	transactOpts := bind.NewKeyedTransactor(key)
+	transactOpts := bind.NewKeyedTransactorWithChainID(key)
 	transactOpts.GasLimit = 1000000
 
 	var contractAddress common.Address
@@ -1159,7 +1159,7 @@ func TestWrongIncarnation2(t *testing.T) {
 
 	contractBackend := backends.NewSimulatedBackendWithConfig(gspec.Alloc, gspec.Config, gspec.GasLimit)
 	defer contractBackend.Close()
-	transactOpts := bind.NewKeyedTransactor(key)
+	transactOpts := bind.NewKeyedTransactorWithChainID(key)
 	transactOpts.GasLimit = 1000000
 	var err error
 
@@ -1198,7 +1198,7 @@ func TestWrongIncarnation2(t *testing.T) {
 
 	// Create a longer chain, with 4 blocks (with higher total difficulty) that reverts the change of stroage self-destruction of the contract
 	contractBackendLonger := backends.NewSimulatedBackendWithConfig(gspec.Alloc, gspec.Config, gspec.GasLimit)
-	transactOptsLonger := bind.NewKeyedTransactor(key)
+	transactOptsLonger := bind.NewKeyedTransactorWithChainID(key)
 	transactOptsLonger.GasLimit = 1000000
 	longerChain, err := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 3, func(i int, block *core.BlockGen) {
 		var tx types.Transaction
@@ -1410,7 +1410,7 @@ func TestRecreateAndRewind(t *testing.T) {
 	m := stages.MockWithGenesis(t, gspec, key)
 	contractBackend := backends.NewSimulatedBackendWithConfig(gspec.Alloc, gspec.Config, gspec.GasLimit)
 	defer contractBackend.Close()
-	transactOpts := bind.NewKeyedTransactor(key)
+	transactOpts := bind.NewKeyedTransactorWithChainID(key)
 	transactOpts.GasLimit = 1000000
 	var revive *contracts.Revive2
 	var phoenix *contracts.Phoenix
@@ -1478,7 +1478,7 @@ func TestRecreateAndRewind(t *testing.T) {
 
 	contractBackendLonger := backends.NewSimulatedBackendWithConfig(gspec.Alloc, gspec.Config, gspec.GasLimit)
 	defer contractBackendLonger.Close()
-	transactOptsLonger := bind.NewKeyedTransactor(key)
+	transactOptsLonger := bind.NewKeyedTransactorWithChainID(key)
 	transactOptsLonger.GasLimit = 1000000
 	longerChain, err1 := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 5, func(i int, block *core.BlockGen) {
 		var tx types.Transaction

--- a/tests/statedb_chain_test.go
+++ b/tests/statedb_chain_test.go
@@ -65,7 +65,7 @@ func TestSelfDestructReceive(t *testing.T) {
 
 	contractBackend := backends.NewSimulatedBackendWithConfig(gspec.Alloc, gspec.Config, gspec.GasLimit)
 	defer contractBackend.Close()
-	transactOpts := bind.NewKeyedTransactor(key)
+	transactOpts := bind.NewKeyedTransactorWithChainID(key)
 
 	var contractAddress common.Address
 	var selfDestructorContract *contracts.SelfDestructor

--- a/tests/statedb_insert_chain_transaction_test.go
+++ b/tests/statedb_insert_chain_transaction_test.go
@@ -705,7 +705,7 @@ func getGenesis(funds ...*big.Int) initialData {
 	for _, key := range keys {
 		addr := crypto.PubkeyToAddress(key.PublicKey)
 		addresses = append(addresses, addr)
-		transactOpts = append(transactOpts, bind.NewKeyedTransactor(key))
+		transactOpts = append(transactOpts, bind.NewKeyedTransactorWithChainID(key))
 
 		allocs[addr] = core.GenesisAccount{Balance: accountFunds}
 	}


### PR DESCRIPTION
This function was long since deprecated.