### PR TITLE
state.PlainState is now at the beginning of blockNbr, not the end

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -173,9 +173,9 @@ func (b *SimulatedBackend) emptyPendingBlock() {
 // stateByBlockNumber retrieves a state by a given blocknumber.
 func (b *SimulatedBackend) stateByBlockNumber(db kv.Tx, blockNumber *big.Int) *state.IntraBlockState {
 	if blockNumber == nil || blockNumber.Cmp(b.pendingBlock.Number()) == 0 {
-		return state.New(state.NewPlainState(db, b.pendingBlock.NumberU64()))
+		return state.New(state.NewPlainState(db, b.pendingBlock.NumberU64()+1))
 	}
-	return state.New(state.NewPlainState(db, uint64(blockNumber.Int64())))
+	return state.New(state.NewPlainState(db, blockNumber.Uint64()+1))
 }
 
 // CodeAt returns the code associated with a certain account in the blockchain.

--- a/accounts/abi/bind/backends/simulated_test.go
+++ b/accounts/abi/bind/backends/simulated_test.go
@@ -146,7 +146,7 @@ func TestNewSimulatedBackend(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	statedb := state.New(state.NewPlainState(tx, num))
+	statedb := state.New(state.NewPlainState(tx, num+1))
 	bal := statedb.GetBalance(testAddr)
 	if !bal.Eq(expectedBal) {
 		t.Errorf("expected balance for test address not received. expected: %v actual: %v", expectedBal, bal)

--- a/cmd/rpcdaemon/commands/trace_adhoc.go
+++ b/cmd/rpcdaemon/commands/trace_adhoc.go
@@ -1077,7 +1077,7 @@ func (api *TraceAPIImpl) doCallMany(ctx context.Context, dbtx kv.Tx, msgs []type
 		}
 		stateReader = state.NewCachedReader2(cacheView, dbtx) // this cache stays between RPC calls
 	} else {
-		stateReader = state.NewPlainState(dbtx, blockNumber)
+		stateReader = state.NewPlainState(dbtx, blockNumber+1)
 	}
 	stateCache := shards.NewStateCache(32, 0 /* no limit */) // this cache living only during current RPC call, but required to store state writes
 	cachedReader := state.NewCachedReader(stateReader, stateCache)

--- a/cmd/state/commands/check_change_sets.go
+++ b/cmd/state/commands/check_change_sets.go
@@ -129,10 +129,10 @@ func CheckChangeSets(genesis *core.Genesis, logger log.Logger, blockNum uint64, 
 			break
 		}
 
-		reader := state.NewPlainState(historyTx, blockNum-1)
+		reader := state.NewPlainState(historyTx, blockNum)
 		reader.SetTrace(blockNum == uint64(block))
 		intraBlockState := state.New(reader)
-		csw := state.NewChangeSetWriterPlain(nil /* db */, blockNum-1)
+		csw := state.NewChangeSetWriterPlain(nil /* db */, blockNum)
 		var blockWriter state.StateWriter
 		if nocheck {
 			blockWriter = noOpWriter

--- a/cmd/state/commands/opcode_tracer.go
+++ b/cmd/state/commands/opcode_tracer.go
@@ -553,7 +553,7 @@ func OpcodeTracer(genesis *core.Genesis, blockNum uint64, chaindata string, numB
 			ot.fsumWriter = bufio.NewWriter(fsum)
 		}
 
-		dbstate := state.NewPlainState(historyTx, block.NumberU64()-1)
+		dbstate := state.NewPlainState(historyTx, block.NumberU64())
 		intraBlockState := state.New(dbstate)
 		intraBlockState.SetTracer(ot)
 

--- a/core/state/database_test.go
+++ b/core/state/database_test.go
@@ -895,8 +895,8 @@ func TestReproduceCrash(t *testing.T) {
 	value2 := uint256.NewInt(0x58c00a51)
 
 	_, tx := memdb.NewTestTx(t)
-	tsw := state.NewPlainStateWriter(tx, nil, 0)
-	intraBlockState := state.New(state.NewPlainState(tx, 0))
+	tsw := state.NewPlainStateWriter(tx, nil, 1)
+	intraBlockState := state.New(state.NewPlainState(tx, 1))
 	// Start the 1st transaction
 	intraBlockState.CreateAccount(contract, true)
 	if err := intraBlockState.FinalizeTx(params.Rules{}, tsw); err != nil {

--- a/core/state/intra_block_state_test.go
+++ b/core/state/intra_block_state_test.go
@@ -226,7 +226,7 @@ func (test *snapshotTest) run() bool {
 	}
 	defer tx.Rollback()
 	var (
-		ds           = NewPlainState(tx, 0)
+		ds           = NewPlainState(tx, 1)
 		state        = New(ds)
 		snapshotRevs = make([]int, len(test.snapshots))
 		sindex       = 0
@@ -241,7 +241,7 @@ func (test *snapshotTest) run() bool {
 	// Revert all snapshots in reverse order. Each revert must yield a state
 	// that is equivalent to fresh state with all actions up the snapshot applied.
 	for sindex--; sindex >= 0; sindex-- {
-		checkds := NewPlainState(tx, 0)
+		checkds := NewPlainState(tx, 1)
 		checkstate := New(checkds)
 		for _, action := range test.actions[:test.snapshots[sindex]] {
 			action.fn(action, checkstate)
@@ -404,7 +404,7 @@ func TestAccessList(t *testing.T) {
 	slot := common.HexToHash
 
 	_, tx := memdb.NewTestTx(t)
-	state := New(NewPlainState(tx, 0))
+	state := New(NewPlainState(tx, 1))
 	state.accessList = newAccessList()
 
 	state.AddAddressToAccessList(addr("aa"))          // 1

--- a/core/state/plain_readonly.go
+++ b/core/state/plain_readonly.go
@@ -40,6 +40,7 @@ func (a *storageItem) Less(b btree.Item) bool {
 	return bytes.Compare(a.key[:], bi.key[:]) < 0
 }
 
+// State at the beginning of blockNr
 type PlainState struct {
 	accHistoryC, storageHistoryC kv.Cursor
 	accChangesC, storageChangesC kv.CursorDupSort
@@ -79,7 +80,7 @@ func (s *PlainState) ForEachStorage(addr common.Address, startLocation common.Ha
 	st := btree.New(16)
 	var k [common.AddressLength + common.IncarnationLength + common.HashLength]byte
 	copy(k[:], addr[:])
-	accData, err := GetAsOf(s.tx, s.accHistoryC, s.accChangesC, false /* storage */, addr[:], s.blockNr+1)
+	accData, err := GetAsOf(s.tx, s.accHistoryC, s.accChangesC, false /* storage */, addr[:], s.blockNr)
 	if err != nil {
 		return err
 	}
@@ -106,7 +107,7 @@ func (s *PlainState) ForEachStorage(addr common.Address, startLocation common.Ha
 		})
 	}
 	numDeletes := st.Len() - overrideCounter
-	if err := WalkAsOfStorage(s.tx, addr, acc.Incarnation, startLocation, s.blockNr+1, func(kAddr, kLoc, vs []byte) (bool, error) {
+	if err := WalkAsOfStorage(s.tx, addr, acc.Incarnation, startLocation, s.blockNr, func(kAddr, kLoc, vs []byte) (bool, error) {
 		if !bytes.Equal(kAddr, addr[:]) {
 			return false, nil
 		}
@@ -151,7 +152,7 @@ func (s *PlainState) ForEachStorage(addr common.Address, startLocation common.Ha
 }
 
 func (s *PlainState) ReadAccountData(address common.Address) (*accounts.Account, error) {
-	enc, err := GetAsOf(s.tx, s.accHistoryC, s.accChangesC, false /* storage */, address[:], s.blockNr+1)
+	enc, err := GetAsOf(s.tx, s.accHistoryC, s.accChangesC, false /* storage */, address[:], s.blockNr)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +178,7 @@ func (s *PlainState) ReadAccountData(address common.Address) (*accounts.Account,
 
 func (s *PlainState) ReadAccountStorage(address common.Address, incarnation uint64, key *common.Hash) ([]byte, error) {
 	compositeKey := dbutils.PlainGenerateCompositeStorageKey(address.Bytes(), incarnation, key.Bytes())
-	enc, err := GetAsOf(s.tx, s.storageHistoryC, s.storageChangesC, true /* storage */, compositeKey, s.blockNr+1)
+	enc, err := GetAsOf(s.tx, s.storageHistoryC, s.storageChangesC, true /* storage */, compositeKey, s.blockNr)
 	if err != nil {
 		return nil, err
 	}
@@ -207,7 +208,7 @@ func (s *PlainState) ReadAccountCodeSize(address common.Address, incarnation uin
 }
 
 func (s *PlainState) ReadAccountIncarnation(address common.Address) (uint64, error) {
-	enc, err := GetAsOf(s.tx, s.accHistoryC, s.accChangesC, false /* storage */, address[:], s.blockNr+2)
+	enc, err := GetAsOf(s.tx, s.accHistoryC, s.accChangesC, false /* storage */, address[:], s.blockNr+1)
 	if err != nil {
 		return 0, err
 	}

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -108,8 +108,8 @@ func (s *StateSuite) SetUpTest(c *checker.C) {
 		panic(err)
 	}
 	s.tx = tx
-	s.r = NewPlainState(tx, 0)
-	s.w = NewPlainState(tx, 0)
+	s.r = NewPlainState(tx, 1)
+	s.w = NewPlainState(tx, 1)
 	s.state = New(s.r)
 }
 
@@ -177,8 +177,8 @@ func (s *StateSuite) TestSnapshotEmpty(c *checker.C) {
 // printing/logging in tests (-check.vv does not work)
 func TestSnapshot2(t *testing.T) {
 	_, tx := memdb.NewTestTx(t)
-	w := NewPlainState(tx, 0)
-	state := New(NewPlainState(tx, 0))
+	w := NewPlainState(tx, 1)
+	state := New(NewPlainState(tx, 1))
 
 	stateobjaddr0 := toAddr([]byte("so0"))
 	stateobjaddr1 := toAddr([]byte("so1"))
@@ -203,7 +203,7 @@ func TestSnapshot2(t *testing.T) {
 	if err != nil {
 		t.Fatal("error while finalizing transaction", err)
 	}
-	w = NewPlainState(tx, 1)
+	w = NewPlainState(tx, 2)
 
 	err = state.CommitBlock(params.Rules{}, w)
 	if err != nil {

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -161,7 +161,7 @@ func BenchmarkCall(b *testing.B) {
 func benchmarkEVM_Create(bench *testing.B, code string) {
 	_, tx := memdb.NewTestTx(bench)
 	var (
-		statedb  = state.New(state.NewPlainState(tx, 0))
+		statedb  = state.New(state.NewPlainState(tx, 1))
 		sender   = common.BytesToAddress([]byte("sender"))
 		receiver = common.BytesToAddress([]byte("receiver"))
 	)
@@ -330,7 +330,7 @@ func benchmarkNonModifyingCode(gas uint64, code []byte, name string, b *testing.
 	cfg := new(Config)
 	setDefaults(cfg)
 	_, tx := memdb.NewTestTx(b)
-	cfg.State = state.New(state.NewPlainState(tx, 0))
+	cfg.State = state.New(state.NewPlainState(tx, 1))
 	cfg.GasLimit = gas
 	var (
 		destination = common.BytesToAddress([]byte("contract"))

--- a/turbo/stages/blockchain_test.go
+++ b/turbo/stages/blockchain_test.go
@@ -1008,15 +1008,15 @@ func TestDoubleAccountRemoval(t *testing.T) {
 		t.Fatalf("read only db tx to read state: %v", err)
 	}
 	defer tx.Rollback()
-	st := state.New(state.NewPlainState(tx, 0))
+	st := state.New(state.NewPlainState(tx, 1))
 	assert.NoError(t, err)
 	assert.False(t, st.Exist(theAddr), "Contract should not exist at block #0")
 
-	st = state.New(state.NewPlainState(tx, 1))
+	st = state.New(state.NewPlainState(tx, 2))
 	assert.NoError(t, err)
 	assert.True(t, st.Exist(theAddr), "Contract should exist at block #1")
 
-	st = state.New(state.NewPlainState(tx, 2))
+	st = state.New(state.NewPlainState(tx, 3))
 	assert.NoError(t, err)
 	assert.True(t, st.Exist(theAddr), "Contract should exist at block #2")
 }
@@ -1371,7 +1371,7 @@ func TestDeleteRecreateSlots(t *testing.T) {
 		t.Fatalf("failed to insert into chain: %v", err)
 	}
 	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
-		statedb := state.New(state.NewPlainState(tx, 1))
+		statedb := state.New(state.NewPlainState(tx, 2))
 
 		// If all is correct, then slot 1 and 2 are zero
 		key1 := common.HexToHash("01")
@@ -1456,7 +1456,7 @@ func TestDeleteRecreateAccount(t *testing.T) {
 		t.Fatalf("failed to insert into chain: %v", err)
 	}
 	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
-		statedb := state.New(state.NewPlainState(tx, 1))
+		statedb := state.New(state.NewPlainState(tx, 2))
 
 		// If all is correct, then both slots are zero
 		key1 := common.HexToHash("01")
@@ -1771,7 +1771,7 @@ func TestInitThenFailCreateContract(t *testing.T) {
 	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
 
 		// Import the canonical chain
-		statedb := state.New(state.NewPlainState(tx, 1))
+		statedb := state.New(state.NewPlainState(tx, 2))
 		if got, exp := statedb.GetBalance(aa), uint64(100000); got.Uint64() != exp {
 			t.Fatalf("Genesis err, got %v exp %v", got, exp)
 		}
@@ -1781,7 +1781,7 @@ func TestInitThenFailCreateContract(t *testing.T) {
 			if err := m.InsertChain(chain.Slice(0, 1)); err != nil {
 				t.Fatalf("block %d: failed to insert into chain: %v", block.NumberU64(), err)
 			}
-			statedb = state.New(state.NewPlainState(tx, 0))
+			statedb = state.New(state.NewPlainState(tx, 1))
 			if got, exp := statedb.GetBalance(aa), uint64(100000); got.Uint64() != exp {
 				t.Fatalf("block %d: got %v exp %v", block.NumberU64(), got, exp)
 			}
@@ -1977,7 +1977,7 @@ func TestEIP1559Transition(t *testing.T) {
 	}
 
 	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
-		statedb := state.New(state.NewPlainState(tx, 0))
+		statedb := state.New(state.NewPlainState(tx, 1))
 
 		// 3: Ensure that miner received only the tx's tip.
 		actual := statedb.GetBalance(block.Coinbase())
@@ -2018,7 +2018,7 @@ func TestEIP1559Transition(t *testing.T) {
 
 	block = chain.Blocks[0]
 	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
-		statedb := state.New(state.NewPlainState(tx, 0))
+		statedb := state.New(state.NewPlainState(tx, 1))
 		effectiveTip := block.Transactions()[0].GetPrice().Uint64() - block.BaseFee().Uint64()
 
 		// 6+5: Ensure that miner received only the tx's effective tip.

--- a/turbo/transactions/tracing.go
+++ b/turbo/transactions/tracing.go
@@ -33,7 +33,7 @@ type BlockGetter interface {
 // ComputeTxEnv returns the execution environment of a certain transaction.
 func ComputeTxEnv(ctx context.Context, block *types.Block, cfg *params.ChainConfig, getHeader func(hash common.Hash, number uint64) *types.Header, contractHasTEVM func(common.Hash) (bool, error), engine consensus.Engine, dbtx kv.Tx, blockHash common.Hash, txIndex uint64) (core.Message, vm.BlockContext, vm.TxContext, *state.IntraBlockState, *state.PlainState, error) {
 	// Create the parent state database
-	reader := state.NewPlainState(dbtx, block.NumberU64()-1)
+	reader := state.NewPlainState(dbtx, block.NumberU64())
 	statedb := state.New(reader)
 
 	if txIndex == 0 && len(block.Transactions()) == 0 {


### PR DESCRIPTION
This change fixes discrepancy between `state.PlainState` and `GetAsOf`. It also fixes the second part of Issue #3413 (`eth_createAccessList` not returning all accessed addresses/storage keys).