### PR TITLE
Snapshot: link.header is nil sometime

### DIFF
--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -129,11 +129,11 @@ func Downloader(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	defer protocols.Close()
 	log.Info("[torrent] Start", "my peerID", fmt.Sprintf("%x", protocols.TorrentClient.PeerID()))
 	if err = downloader.CreateTorrentFilesAndAdd(ctx, snapshotDir, protocols.TorrentClient); err != nil {
 		return fmt.Errorf("CreateTorrentFilesAndAdd: %w", err)
 	}
-	defer protocols.Close()
 
 	go downloader.LoggingLoop(ctx, protocols.TorrentClient)
 

--- a/cmd/sentry/sentry/downloader.go
+++ b/cmd/sentry/sentry/downloader.go
@@ -472,9 +472,6 @@ func (cs *ControlServerImpl) blockHeaders(ctx context.Context, pkt eth.BlockHead
 		if number > highestBlock {
 			highestBlock = number
 		}
-		if header == nil {
-			panic("alex")
-		}
 		csHeaders = append(csHeaders, headerdownload.ChainSegmentHeader{
 			Header:    header,
 			HeaderRaw: headerRaw,

--- a/cmd/sentry/sentry/downloader.go
+++ b/cmd/sentry/sentry/downloader.go
@@ -472,6 +472,9 @@ func (cs *ControlServerImpl) blockHeaders(ctx context.Context, pkt eth.BlockHead
 		if number > highestBlock {
 			highestBlock = number
 		}
+		if header == nil {
+			panic("alex")
+		}
 		csHeaders = append(csHeaders, headerdownload.ChainSegmentHeader{
 			Header:    header,
 			HeaderRaw: headerRaw,

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -324,6 +324,9 @@ func New(stack *node.Node, config *ethconfig.Config, txpoolCfg txpool2.Config, l
 			if err != nil {
 				return nil, err
 			}
+			if err = downloader.CreateTorrentFilesAndAdd(ctx, config.SnapshotDir, backend.downloadProtocols.TorrentClient); err != nil {
+				return nil, fmt.Errorf("CreateTorrentFilesAndAdd: %w", err)
+			}
 			bittorrentServer, err := downloader.NewGrpcServer(backend.downloadProtocols.DB, backend.downloadProtocols, config.SnapshotDir, false)
 			if err != nil {
 				return nil, fmt.Errorf("new server: %w", err)

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -1095,6 +1095,11 @@ func WaitForDownloader(ctx context.Context, tx kv.RwTx, cfg HeadersCfg) error {
 	}
 	log.Info("[Snapshots] Fetching torrent files metadata")
 	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
 		if _, err := cfg.snapshotDownloader.Download(ctx, req); err != nil {
 			log.Error("[Snapshots] Can't call downloader", "err", err)
 			time.Sleep(10 * time.Second)

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -1057,7 +1057,7 @@ func DownloadAndIndexSnapshotsIfNeed(s *StageState, ctx context.Context, tx kv.R
 
 	// Add last headers from snapshots to HeaderDownloader (as persistent links)
 	if s.BlockNumber < cfg.snapshots.BlocksAvailable() {
-		if err := cfg.hd.AddHeaderFromSnapshot(cfg.snapshots.BlocksAvailable(), cfg.blockReader); err != nil {
+		if err := cfg.hd.AddHeaderFromSnapshot(tx, cfg.snapshots.BlocksAvailable(), cfg.blockReader); err != nil {
 			return err
 		}
 		if err := s.Update(tx, cfg.snapshots.BlocksAvailable()); err != nil {

--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -734,6 +734,10 @@ func (hd *HeaderDownload) InsertHeaders(hf FeedHeaderFunc, terminalTotalDifficul
 				link := hd.insertQueue[0]
 				_, bad := hd.badHeaders[link.hash]
 				if !bad {
+					fmt.Printf("a: %t\n", hd == nil)
+					fmt.Printf("a: %t\n", hd.badHeaders == nil)
+					fmt.Printf("a: %t\n", link == nil)
+					fmt.Printf("a: %t\n", link.header == nil)
 					_, bad = hd.badHeaders[link.header.ParentHash]
 				}
 				if bad {

--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -890,6 +890,10 @@ func (hd *HeaderDownload) addHeaderAsLink(h ChainSegmentHeader, persisted bool) 
 		headerRaw:   h.HeaderRaw,
 		persisted:   persisted,
 	}
+	if persisted {
+		link.header = nil // Drop header reference to free memory, as we won't need it anymore
+		link.headerRaw = nil
+	}
 	hd.links[h.Hash] = link
 	if persisted {
 		hd.moveLinkToQueue(link, PersistedQueueID)

--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -703,7 +703,7 @@ func (hd *HeaderDownload) InsertHeaders(hf FeedHeaderFunc, terminalTotalDifficul
 				if !skip {
 					_, skip = hd.badHeaders[link.hash]
 				}
-				if !skip {
+				if !skip && !link.persisted {
 					_, skip = hd.badHeaders[link.header.ParentHash]
 				}
 				if !skip {

--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -1250,7 +1250,7 @@ func (hd *HeaderDownload) AddMinedHeader(header *types.Header) error {
 	return nil
 }
 
-func (hd *HeaderDownload) AddHeaderFromSnapshot(n uint64, r interfaces.FullBlockReader) error {
+func (hd *HeaderDownload) AddHeaderFromSnapshot(tx kv.Tx, n uint64, r interfaces.FullBlockReader) error {
 	hd.lock.Lock()
 	defer hd.lock.Unlock()
 	addPreVerifiedHashes := len(hd.preverifiedHashes) == 0
@@ -1259,7 +1259,7 @@ func (hd *HeaderDownload) AddHeaderFromSnapshot(n uint64, r interfaces.FullBlock
 	}
 
 	for i := n; i > 0 && hd.persistedLinkQueue.Len() < hd.persistedLinkLimit; i-- {
-		header, err := r.HeaderByNumber(context.Background(), nil, i)
+		header, err := r.HeaderByNumber(context.Background(), tx, i)
 		if err != nil {
 			return err
 		}

--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -108,6 +108,9 @@ func (hd *HeaderDownload) childParentValid(child, parent *types.Header) (bool, P
 
 // SingleHeaderAsSegment converts message containing 1 header into one singleton chain segment
 func (hd *HeaderDownload) SingleHeaderAsSegment(headerRaw []byte, header *types.Header) ([]ChainSegment, Penalty, error) {
+	if header == nil {
+		panic("alex")
+	}
 	hd.lock.RLock()
 	defer hd.lock.RUnlock()
 
@@ -734,10 +737,10 @@ func (hd *HeaderDownload) InsertHeaders(hf FeedHeaderFunc, terminalTotalDifficul
 				link := hd.insertQueue[0]
 				_, bad := hd.badHeaders[link.hash]
 				if !bad {
-					fmt.Printf("a: %t\n", hd == nil)
-					fmt.Printf("a: %t\n", hd.badHeaders == nil)
-					fmt.Printf("a: %t\n", link == nil)
-					fmt.Printf("a: %t\n", link.header == nil)
+					fmt.Printf("a1: %t\n", hd == nil)
+					fmt.Printf("a2: %t\n", hd.badHeaders == nil)
+					fmt.Printf("a3: %t\n", link == nil)
+					fmt.Printf("a4: %t\n", link.header == nil)
 					_, bad = hd.badHeaders[link.header.ParentHash]
 				}
 				if bad {
@@ -881,6 +884,9 @@ func (hd *HeaderDownload) getLink(linkHash common.Hash) (*Link, bool) {
 
 // addHeaderAsLink wraps header into a link and adds it to either queue of persisted links or queue of non-persisted links
 func (hd *HeaderDownload) addHeaderAsLink(h ChainSegmentHeader, persisted bool) *Link {
+	if h.Header == nil {
+		panic("alex")
+	}
 	link := &Link{
 		blockHeight: h.Number,
 		hash:        h.Hash,

--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -108,9 +108,6 @@ func (hd *HeaderDownload) childParentValid(child, parent *types.Header) (bool, P
 
 // SingleHeaderAsSegment converts message containing 1 header into one singleton chain segment
 func (hd *HeaderDownload) SingleHeaderAsSegment(headerRaw []byte, header *types.Header) ([]ChainSegment, Penalty, error) {
-	if header == nil {
-		panic("alex")
-	}
 	hd.lock.RLock()
 	defer hd.lock.RUnlock()
 
@@ -880,9 +877,6 @@ func (hd *HeaderDownload) getLink(linkHash common.Hash) (*Link, bool) {
 
 // addHeaderAsLink wraps header into a link and adds it to either queue of persisted links or queue of non-persisted links
 func (hd *HeaderDownload) addHeaderAsLink(h ChainSegmentHeader, persisted bool) *Link {
-	if h.Header == nil {
-		panic("alex")
-	}
 	link := &Link{
 		blockHeight: h.Number,
 		hash:        h.Hash,

--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -736,11 +736,7 @@ func (hd *HeaderDownload) InsertHeaders(hf FeedHeaderFunc, terminalTotalDifficul
 			for hd.insertQueue.Len() > 0 && hd.insertQueue[0].blockHeight <= hd.highestInDb+1 {
 				link := hd.insertQueue[0]
 				_, bad := hd.badHeaders[link.hash]
-				if !bad {
-					fmt.Printf("a1: %t\n", hd == nil)
-					fmt.Printf("a2: %t\n", hd.badHeaders == nil)
-					fmt.Printf("a3: %t\n", link == nil)
-					fmt.Printf("a4: %t\n", link.header == nil)
+				if !bad && !link.persisted {
 					_, bad = hd.badHeaders[link.header.ParentHash]
 				}
 				if bad {


### PR DESCRIPTION
@AlexeyAkhunov hi. 
I see that when link get persisted, it set `link.header=nil` at `stages/headerdownload/header_algos.go:769`
and in same time there is code like which reading `link.header.ParentHash` without nil or persisted flag check:
```
_, bad := hd.badHeaders[link.hash]
if !bad {
	_, bad = hd.badHeaders[link.header.ParentHash]
}
```
Is this correct fix?
https://github.com/ledgerwatch/erigon/compare/sn_nil?expand=1#diff-afffa34063d33db53677de5b49f3f3fcced5b5c65889f1d27d4d92eedddd1e99L736