### PR TITLE
[header downloader] introduce queues instead of insertList (#3489)

### DIFF
--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -681,7 +681,7 @@ func (hd *HeaderDownload) InsertHeaders(hf func(header *types.Header, hash commo
 				if !skip {
 					_, skip = hd.badHeaders[link.hash]
 				}
-				if !skip {
+				if !skip && !link.persisted {
 					_, skip = hd.badHeaders[link.header.ParentHash]
 				}
 				if !skip {
@@ -711,7 +711,7 @@ func (hd *HeaderDownload) InsertHeaders(hf func(header *types.Header, hash commo
 			for hd.insertQueue.Len() > 0 && hd.insertQueue[0].blockHeight <= hd.highestInDb+1 {
 				link := hd.insertQueue[0]
 				_, bad := hd.badHeaders[link.hash]
-				if !bad {
+				if !bad && !link.persisted {
 					_, bad = hd.badHeaders[link.header.ParentHash]
 				}
 				if bad {

--- a/turbo/stages/mock_sentry.go
+++ b/turbo/stages/mock_sentry.go
@@ -431,7 +431,7 @@ func (ms *MockSentry) InsertChain(chain *core.ChainPack) error {
 	if ms.TxPoolV2 != nil {
 		ms.ReceiveWg.Add(1)
 	}
-	if err := StageLoopStep(ms.Ctx, ms.DB, ms.Sync, highestSeenHeader, ms.Notifications, initialCycle, ms.UpdateHead, nil); err != nil {
+	if err = StageLoopStep(ms.Ctx, ms.DB, ms.Sync, highestSeenHeader, ms.Notifications, initialCycle, ms.UpdateHead, nil); err != nil {
 		return err
 	}
 	if ms.TxPoolV2 != nil {


### PR DESCRIPTION
* First change for header queues

* Fix

* Fix import

* trigger verification when highestInDb changes

* Print hash, fix MarkAllPreverified

* Fix test

* Cleanup

* More cleanup

Co-authored-by: Alexey Sharp <alexeysharp@Alexeys-iMac.local>
Co-authored-by: Alex Sharp <alexsharp@Alexs-MacBook-Pro.local>