### PR TITLE
fix some nil on shutdown

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -756,7 +756,7 @@ func (s *Ethereum) Stop() error {
 		sentryServer.Close()
 	}
 	s.chainDB.Close()
-	if s.config.TxPool.V2 {
+	if s.config.TxPool.V2 && s.txPool2DB != nil {
 		s.txPool2DB.Close()
 	}
 	return nil


### PR DESCRIPTION
```
goroutine 43675 [running]:
github.com/ledgerwatch/erigon/eth.(*Ethereum).Stop(0xc000246340)
        github.com/ledgerwatch/erigon/eth/backend.go:760 +0x270
github.com/ledgerwatch/erigon/node.(*Node).stopServices(0x939b88, {0xc000790660, 0x1, 0xc015836b40})
        github.com/ledgerwatch/erigon/node/node.go:263 +0xb3
```