### PR TITLE
rpcdaemon: added debug_TraceBlockByNumber and debug_TraceBlockByHash

### DIFF
--- a/cmd/rpcdaemon/README.md
+++ b/cmd/rpcdaemon/README.md
@@ -236,6 +236,8 @@ The following table shows the current implementation status of Erigon's RPC daem
 | debug_getModifiedAccountsByNumber          | Yes     |                                            |
 | debug_getModifiedAccountsByHash            | Yes     |                                            |
 | debug_storageRangeAt                       | Yes     |                                            |
+| debug_traceBlockByHash                     | Yes     | Streaming (can handle huge results)        |
+| debug_traceBlockByNumber                   | Yes     | Streaming (can handle huge results)        |
 | debug_traceTransaction                     | Yes     | Streaming (can handle huge results)        |
 | debug_traceCall                            | Yes     | Streaming (can handle huge results)        |
 |                                            |         |                                            |

--- a/cmd/rpcdaemon/commands/debug_api.go
+++ b/cmd/rpcdaemon/commands/debug_api.go
@@ -28,6 +28,8 @@ const AccountRangeMaxResults = 256
 type PrivateDebugAPI interface {
 	StorageRangeAt(ctx context.Context, blockHash common.Hash, txIndex uint64, contractAddress common.Address, keyStart hexutil.Bytes, maxResult int) (StorageRangeResult, error)
 	TraceTransaction(ctx context.Context, hash common.Hash, config *tracers.TraceConfig, stream *jsoniter.Stream) error
+	TraceBlockByHash(ctx context.Context, hash common.Hash, config *tracers.TraceConfig, stream *jsoniter.Stream) error
+	TraceBlockByNumber(ctx context.Context, number rpc.BlockNumber, config *tracers.TraceConfig, stream *jsoniter.Stream) error
 	AccountRange(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash, start []byte, maxResults int, nocode, nostorage bool) (state.IteratorDump, error)
 	GetModifiedAccountsByNumber(ctx context.Context, startNum rpc.BlockNumber, endNum *rpc.BlockNumber) ([]common.Address, error)
 	GetModifiedAccountsByHash(_ context.Context, startHash common.Hash, endHash *common.Hash) ([]common.Address, error)

--- a/cmd/rpcdaemon/commands/debug_api_test.go
+++ b/cmd/rpcdaemon/commands/debug_api_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/eth/tracers"
 	"github.com/ledgerwatch/erigon/internal/ethapi"
+	"github.com/ledgerwatch/erigon/rpc"
 	"github.com/ledgerwatch/erigon/turbo/snapshotsync"
 )
 
@@ -35,6 +36,87 @@ var debugTraceTransactionNoRefundTests = []struct {
 	{"3f3cb8a0e13ed2481f97f53f7095b9cbc78b6ffb779f2d3e565146371a8830ea", 21000, false, ""},
 	{"f588c6426861d9ad25d5ccc12324a8d213f35ef1ed4153193f0c13eb81ca7f4a", 49189, false, "0000000000000000000000000000000000000000000000000000000000000001"},
 	{"b6449d8e167a8826d050afe4c9f07095236ff769a985f02649b1023c2ded2059", 62899, false, ""},
+}
+
+func TestTraceBlockByNumber(t *testing.T) {
+	db := rpcdaemontest.CreateTestKV(t)
+	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
+	baseApi := NewBaseApi(nil, stateCache, snapshotsync.NewBlockReader(), false)
+	ethApi := NewEthAPI(baseApi, db, nil, nil, nil, 5000000)
+	api := NewPrivateDebugAPI(baseApi, db, 0)
+	for _, tt := range debugTraceTransactionTests {
+		var buf bytes.Buffer
+		stream := jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096)
+		tx, err := ethApi.GetTransactionByHash(context.Background(), common.HexToHash(tt.txHash))
+		if err != nil {
+			t.Errorf("traceBlock %s: %v", tt.txHash, err)
+		}
+		txcount, err := ethApi.GetBlockTransactionCountByHash(context.Background(), *tx.BlockHash)
+		if err != nil {
+			t.Errorf("traceBlock %s: %v", tt.txHash, err)
+		}
+		err = api.TraceBlockByNumber(context.Background(), rpc.BlockNumber(tx.BlockNumber.ToInt().Uint64()), &tracers.TraceConfig{}, stream)
+		if err != nil {
+			t.Errorf("traceBlock %s: %v", tt.txHash, err)
+		}
+		if err = stream.Flush(); err != nil {
+			t.Fatalf("error flusing: %v", err)
+		}
+		var er []ethapi.ExecutionResult
+		if err = json.Unmarshal(buf.Bytes(), &er); err != nil {
+			t.Fatalf("parsing result: %v", err)
+		}
+		if len(er) != int(*txcount) {
+			t.Fatalf("incorrect length: %v", err)
+		}
+	}
+	var buf bytes.Buffer
+	stream := jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096)
+	err := api.TraceBlockByNumber(context.Background(), rpc.BlockNumber(rpc.LatestBlockNumber), &tracers.TraceConfig{}, stream)
+	if err != nil {
+		t.Errorf("traceBlock %v: %v", rpc.LatestBlockNumber, err)
+	}
+	if err = stream.Flush(); err != nil {
+		t.Fatalf("error flusing: %v", err)
+	}
+	var er []ethapi.ExecutionResult
+	if err = json.Unmarshal(buf.Bytes(), &er); err != nil {
+		t.Fatalf("parsing result: %v", err)
+	}
+}
+
+func TestTraceBlockByHash(t *testing.T) {
+	db := rpcdaemontest.CreateTestKV(t)
+	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
+	baseApi := NewBaseApi(nil, stateCache, snapshotsync.NewBlockReader(), false)
+	ethApi := NewEthAPI(baseApi, db, nil, nil, nil, 5000000)
+	api := NewPrivateDebugAPI(baseApi, db, 0)
+	for _, tt := range debugTraceTransactionTests {
+		var buf bytes.Buffer
+		stream := jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096)
+		tx, err := ethApi.GetTransactionByHash(context.Background(), common.HexToHash(tt.txHash))
+		if err != nil {
+			t.Errorf("traceBlock %s: %v", tt.txHash, err)
+		}
+		txcount, err := ethApi.GetBlockTransactionCountByHash(context.Background(), *tx.BlockHash)
+		if err != nil {
+			t.Errorf("traceBlock %s: %v", tt.txHash, err)
+		}
+		err = api.TraceBlockByHash(context.Background(), *tx.BlockHash, &tracers.TraceConfig{}, stream)
+		if err != nil {
+			t.Errorf("traceBlock %s: %v", tt.txHash, err)
+		}
+		if err = stream.Flush(); err != nil {
+			t.Fatalf("error flusing: %v", err)
+		}
+		var er []ethapi.ExecutionResult
+		if err = json.Unmarshal(buf.Bytes(), &er); err != nil {
+			t.Fatalf("parsing result: %v", err)
+		}
+		if len(er) != int(*txcount) {
+			t.Fatalf("incorrect length: %v", err)
+		}
+	}
 }
 
 func TestTraceTransaction(t *testing.T) {

--- a/cmd/rpctest/main.go
+++ b/cmd/rpctest/main.go
@@ -152,6 +152,16 @@ func main() {
 	}
 	with(bench9Cmd, withErigonUrl, withGethUrl, withNeedCompare)
 
+	var benchTraceBlockByHashCmd = &cobra.Command{
+		Use:   "benchTraceBlockByHash",
+		Short: "",
+		Long:  ``,
+		Run: func(cmd *cobra.Command, args []string) {
+			rpctest.BenchTraceBlockByHash(erigonURL, gethURL, needCompare, blockFrom, blockTo, recordFile, errorFile)
+		},
+	}
+	with(benchTraceBlockByHashCmd, withGethUrl, withErigonUrl, withNeedCompare, withBlockNum, withRecord, withErrorFile)
+
 	var benchTraceTransactionCmd = &cobra.Command{
 		Use:   "benchTraceTransaction",
 		Short: "",

--- a/cmd/rpctest/rpctest/bench_tracetransaction.go
+++ b/cmd/rpctest/rpctest/bench_tracetransaction.go
@@ -8,6 +8,63 @@ import (
 	"time"
 )
 
+func BenchTraceBlockByHash(erigonUrl, gethUrl string, needCompare bool, blockFrom uint64, blockTo uint64, recordFile string, errorFile string) {
+	setRoutes(erigonUrl, gethUrl)
+	var client = &http.Client{
+		Timeout: time.Second * 600,
+	}
+
+	var rec *bufio.Writer
+	if recordFile != "" {
+		f, err := os.Create(recordFile)
+		if err != nil {
+			fmt.Printf("Cannot create file %s for recording: %v\n", recordFile, err)
+			return
+		}
+		defer f.Close()
+		rec = bufio.NewWriter(f)
+		defer rec.Flush()
+	}
+	var errs *bufio.Writer
+	if errorFile != "" {
+		ferr, err := os.Create(errorFile)
+		if err != nil {
+			fmt.Printf("Cannot create file %s for error output: %v\n", errorFile, err)
+			return
+		}
+		defer ferr.Close()
+		errs = bufio.NewWriter(ferr)
+		defer errs.Flush()
+	}
+
+	var res CallResult
+	reqGen := &RequestGenerator{
+		client: client,
+	}
+
+	reqGen.reqID++
+
+	for bn := blockFrom; bn < blockTo; bn++ {
+		var b EthBlockByNumber
+		res = reqGen.Erigon("eth_getBlockByNumber", reqGen.getBlockByNumber(bn), &b)
+		if res.Err != nil {
+			fmt.Printf("retrieve block (Erigon) %d: %v", blockFrom, res.Err)
+			return
+		}
+		if b.Error != nil {
+			fmt.Printf("retrieving block (Erigon): %d %s", b.Error.Code, b.Error.Message)
+			return
+		}
+		reqGen.reqID++
+		request := reqGen.traceBlockByHash(b.Result.Hash.Hex())
+		errCtx := fmt.Sprintf("block %d, tx %s", bn, b.Result.Hash.Hex())
+		if err := requestAndCompare(request, "debug_traceBlockByHash", errCtx, reqGen, needCompare, rec, errs, nil); err != nil {
+			fmt.Println(err)
+			return
+		}
+	}
+}
+
 func BenchTraceTransaction(erigonUrl, gethUrl string, needCompare bool, blockFrom uint64, blockTo uint64, recordFile string, errorFile string) {
 	setRoutes(erigonUrl, gethUrl)
 	var client = &http.Client{

--- a/cmd/rpctest/rpctest/request_generator.go
+++ b/cmd/rpctest/rpctest/request_generator.go
@@ -41,6 +41,11 @@ func (g *RequestGenerator) storageRangeAt(hash common.Hash, i int, to *common.Ad
 	return fmt.Sprintf(template, hash, i, to, nextKey, 1024, g.reqID)
 }
 
+func (g *RequestGenerator) traceBlockByHash(hash string) string {
+	const template = `{"jsonrpc":"2.0","method":"debug_traceBlockByHash","params":["%s"],"id":%d}`
+	return fmt.Sprintf(template, hash, g.reqID)
+}
+
 func (g *RequestGenerator) traceTransaction(hash string) string {
 	const template = `{"jsonrpc":"2.0","method":"debug_traceTransaction","params":["%s"],"id":%d}`
 	return fmt.Sprintf(template, hash, g.reqID)


### PR DESCRIPTION
First PR. Reuses a lot of the plumbing from `debug_traceTransaction`. 

Implements: 
* https://geth.ethereum.org/docs/rpc/ns-debug#debug_traceblockbyhash
* https://geth.ethereum.org/docs/rpc/ns-debug#debug_traceblockbynumber

Iteratively calling `debug_traceTransaction` to obtain full traces of a block is extremely resource intensive `O(n^2)`. Since for each transaction all proceeding transactions in the block need to be replayed. The ability to trace an entire block at once greatly reduces the overhead and executing time.



## Testing done so far:
* Compared with results of `debug_traceTransaction`. Call `debug_traceTransactionByHash` and use the transaction index in the block as the index in results returned. `jq '.results[193]' trace.json`
* Use of `callTracer`. e.g. `debug.traceBlockByNumber(14212372,{tracer: "callTracer"})`
* Use of custom filters: 
```
debug.traceBlockByNumber(14212372,  {tracer: '{data: [], fault: function(log) {}, step: function(log) { if(log.op.toString() === "SLOAD") {this.data.push({"address": toHex(log.contract.getAddress()), "storage": "0x" + log.stack.peek(0).toString(16)});}}, result: function() { return this.data; }}'});
```

## Caveats:

* `debug.traceTransactionByNumber("latest")` without any filters consumes a lot of memory! Often more than 32GB. Using filters this become a lot more manageable. `{"disableStack":true, "disableMemory": true, "disableStorage": true}`
* I have opted to not implement https://geth.ethereum.org/docs/rpc/ns-debug#debug_traceblock for now. 

## TODO

* Run benchmark against `geth`. Busy syncing a node to test with. 