### PR TITLE
embed rpcdaemon: enable it only by --http flag

### DIFF
--- a/cmd/rpcdaemon/cli/httpcfg/http_cfg.go
+++ b/cmd/rpcdaemon/cli/httpcfg/http_cfg.go
@@ -6,6 +6,7 @@ import (
 )
 
 type HttpCfg struct {
+	Enabled                 bool
 	PrivateApiAddr          string
 	SingleNodeMode          bool // Erigon's database can be read by separated processes on same machine - in read-only mode - with full support of transactions. It will share same "OS PageCache" with Erigon process.
 	Datadir                 string

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -533,27 +533,29 @@ func New(stack *node.Node, config *ethconfig.Config, txpoolCfg txpool2.Config, l
 
 	// start HTTP API
 	httpRpcCfg := stack.Config().Http
-	ethRpcClient, txPoolRpcClient, miningRpcClient, starkNetRpcClient, stateCache, ff, err := cli.EmbeddedServices(
-		ctx, chainKv, httpRpcCfg.StateCache, blockReader,
-		ethBackendRPC,
-		backend.txPool2GrpcServer,
-		miningRPC,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	var borDb kv.RoDB
-	if casted, ok := backend.engine.(*bor.Bor); ok {
-		borDb = casted.DB
-	}
-	apiList := commands.APIList(chainKv, borDb, ethRpcClient, txPoolRpcClient, miningRpcClient, starkNetRpcClient, ff, stateCache, blockReader, httpRpcCfg)
-	go func() {
-		if err := cli.StartRpcServer(ctx, httpRpcCfg, apiList); err != nil {
-			log.Error(err.Error())
-			return
+	if httpRpcCfg.Enabled {
+		ethRpcClient, txPoolRpcClient, miningRpcClient, starkNetRpcClient, stateCache, ff, err := cli.EmbeddedServices(
+			ctx, chainKv, httpRpcCfg.StateCache, blockReader,
+			ethBackendRPC,
+			backend.txPool2GrpcServer,
+			miningRPC,
+		)
+		if err != nil {
+			return nil, err
 		}
-	}()
+
+		var borDb kv.RoDB
+		if casted, ok := backend.engine.(*bor.Bor); ok {
+			borDb = casted.DB
+		}
+		apiList := commands.APIList(chainKv, borDb, ethRpcClient, txPoolRpcClient, miningRpcClient, starkNetRpcClient, ff, stateCache, blockReader, httpRpcCfg)
+		go func() {
+			if err := cli.StartRpcServer(ctx, httpRpcCfg, apiList); err != nil {
+				log.Error(err.Error())
+				return
+			}
+		}()
+	}
 
 	// Register the backend on the node
 	stack.RegisterAPIs(backend.APIs())

--- a/turbo/cli/flags.go
+++ b/turbo/cli/flags.go
@@ -286,6 +286,7 @@ func ApplyFlagsForNodeConfig(ctx *cli.Context, cfg *node.Config) {
 
 func setEmbeddedRpcDaemon(ctx *cli.Context, cfg *node.Config) {
 	c := &httpcfg.HttpCfg{
+		Enabled:   ctx.GlobalBool(utils.HTTPEnabledFlag.Name),
 		Datadir:   cfg.DataDir,
 		Chaindata: filepath.Join(cfg.DataDir, "chaindata"),
 


### PR DESCRIPTION
compatible with geth (and no conflict with existing rpcdaemons)
