### PR TITLE
Rename Datadir/dataDir to follow conventions.

### DIFF
--- a/cmd/cons/commands/clique.go
+++ b/cmd/cons/commands/clique.go
@@ -40,7 +40,7 @@ var configs embed.FS
 
 func init() {
 	withApiAddr(cliqueCmd)
-	withDatadir(cliqueCmd)
+	withDataDir(cliqueCmd)
 	withConfig(cliqueCmd)
 	rootCmd.AddCommand(cliqueCmd)
 }

--- a/cmd/cons/commands/root.go
+++ b/cmd/cons/commands/root.go
@@ -51,7 +51,7 @@ func must(err error) {
 	}
 }
 
-func withDatadir(cmd *cobra.Command) {
+func withDataDir(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&datadir, "datadir", paths.DefaultDataDir(), "directory where databases and temporary files are kept")
 	must(cmd.MarkFlagDirname("datadir"))
 }

--- a/cmd/downloader/debug/debug_test.go
+++ b/cmd/downloader/debug/debug_test.go
@@ -40,10 +40,10 @@ func WithBlock(block uint64, key []byte) []byte {
 }
 func TestMatreshkaStream(t *testing.T) {
 	t.Skip()
-	chaindataDir := "/media/b00ris/nvme/fresh_sync/tg/chaindata"
+	chaindatadir := "/media/b00ris/nvme/fresh_sync/tg/chaindata"
 	tmpDbDir := "/home/b00ris/event_stream"
 
-	chaindata, err := mdbx.Open(chaindataDir, log.New(), true)
+	chaindata, err := mdbx.Open(chaindatadir, log.New(), true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -48,7 +48,7 @@ func init() {
 	flags := append(debug.Flags, utils.MetricFlags...)
 	utils.CobraFlags(rootCmd, flags)
 
-	withDatadir(rootCmd)
+	withDataDir(rootCmd)
 
 	rootCmd.Flags().StringVar(&downloaderApiAddr, "downloader.api.addr", "127.0.0.1:9093", "external downloader api network address, for example: 127.0.0.1:9093 serves remote downloader interface")
 	rootCmd.Flags().StringVar(&torrentVerbosity, "torrent.verbosity", lg.Warning.LogString(), "DEBUG | INFO | WARN | ERROR")
@@ -56,7 +56,7 @@ func init() {
 	rootCmd.Flags().StringVar(&uploadRateStr, "torrent.upload.rate", "8mb", "bytes per second, example: 32mb")
 	rootCmd.Flags().IntVar(&torrentPort, "torrent.port", 42069, "port to listen and serve BitTorrent protocol")
 
-	withDatadir(printTorrentHashes)
+	withDataDir(printTorrentHashes)
 	printTorrentHashes.PersistentFlags().BoolVar(&asJson, "json", false, "Print in json format (default: toml)")
 	printTorrentHashes.PersistentFlags().BoolVar(&forceRebuild, "rebuild", false, "Force re-create .torrent files")
 	printTorrentHashes.PersistentFlags().BoolVar(&forceVerify, "verify", false, "Force verify data files if have .torrent files")
@@ -64,7 +64,7 @@ func init() {
 	rootCmd.AddCommand(printTorrentHashes)
 }
 
-func withDatadir(cmd *cobra.Command) {
+func withDataDir(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&datadir, utils.DataDirFlag.Name, paths.DefaultDataDir(), utils.DataDirFlag.Usage)
 	if err := cmd.MarkFlagDirname(utils.DataDirFlag.Name); err != nil {
 		panic(err)

--- a/cmd/integration/commands/flags.go
+++ b/cmd/integration/commands/flags.go
@@ -89,7 +89,7 @@ func withBucket(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&bucket, "bucket", "", "reset given stage")
 }
 
-func withDatadir2(cmd *cobra.Command) {
+func withDataDir2(cmd *cobra.Command) {
 	cmd.Flags().String(utils.DataDirFlag.Name, paths.DefaultDataDir(), utils.DataDirFlag.Usage)
 	must(cmd.MarkFlagDirname(utils.DataDirFlag.Name))
 	must(cmd.MarkFlagRequired(utils.DataDirFlag.Name))
@@ -97,7 +97,7 @@ func withDatadir2(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&enableSnapshot, ethconfig.FlagSnapshot, false, "")
 }
 
-func withDatadir(cmd *cobra.Command) {
+func withDataDir(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&datadir, "datadir", paths.DefaultDataDir(), "data directory for temporary ELT files")
 	must(cmd.MarkFlagDirname("datadir"))
 

--- a/cmd/integration/commands/refetence_db.go
+++ b/cmd/integration/commands/refetence_db.go
@@ -101,19 +101,19 @@ var cmdFToMdbx = &cobra.Command{
 }
 
 func init() {
-	withDatadir(cmdCompareBucket)
+	withDataDir(cmdCompareBucket)
 	withReferenceChaindata(cmdCompareBucket)
 	withBucket(cmdCompareBucket)
 
 	rootCmd.AddCommand(cmdCompareBucket)
 
-	withDatadir(cmdCompareStates)
+	withDataDir(cmdCompareStates)
 	withReferenceChaindata(cmdCompareStates)
 	withBucket(cmdCompareStates)
 
 	rootCmd.AddCommand(cmdCompareStates)
 
-	withDatadir(cmdMdbxToMdbx)
+	withDataDir(cmdMdbxToMdbx)
 	withToChaindata(cmdMdbxToMdbx)
 	withBucket(cmdMdbxToMdbx)
 

--- a/cmd/integration/commands/reset_state.go
+++ b/cmd/integration/commands/reset_state.go
@@ -36,7 +36,7 @@ var cmdResetState = &cobra.Command{
 }
 
 func init() {
-	withDatadir(cmdResetState)
+	withDataDir(cmdResetState)
 	withChain(cmdResetState)
 
 	rootCmd.AddCommand(cmdResetState)

--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -282,7 +282,7 @@ var cmdSetPrune = &cobra.Command{
 }
 
 func init() {
-	withDatadir(cmdPrintStages)
+	withDataDir(cmdPrintStages)
 	withChain(cmdPrintStages)
 	withHeimdall(cmdPrintStages)
 	rootCmd.AddCommand(cmdPrintStages)
@@ -291,27 +291,27 @@ func init() {
 	withReset(cmdStageSenders)
 	withBlock(cmdStageSenders)
 	withUnwind(cmdStageSenders)
-	withDatadir(cmdStageSenders)
+	withDataDir(cmdStageSenders)
 	withChain(cmdStageSenders)
 	withHeimdall(cmdStageSenders)
 
 	rootCmd.AddCommand(cmdStageSenders)
 
-	withDatadir(cmdStageHeaders)
+	withDataDir(cmdStageHeaders)
 	withUnwind(cmdStageHeaders)
 	withChain(cmdStageHeaders)
 	withHeimdall(cmdStageHeaders)
 
 	rootCmd.AddCommand(cmdStageHeaders)
 
-	withDatadir(cmdStageBodies)
+	withDataDir(cmdStageBodies)
 	withUnwind(cmdStageBodies)
 	withChain(cmdStageBodies)
 	withHeimdall(cmdStageBodies)
 
 	rootCmd.AddCommand(cmdStageBodies)
 
-	withDatadir(cmdStageExec)
+	withDataDir(cmdStageExec)
 	withReset(cmdStageExec)
 	withBlock(cmdStageExec)
 	withUnwind(cmdStageExec)
@@ -323,7 +323,7 @@ func init() {
 
 	rootCmd.AddCommand(cmdStageExec)
 
-	withDatadir(cmdStageHashState)
+	withDataDir(cmdStageHashState)
 	withReset(cmdStageHashState)
 	withBlock(cmdStageHashState)
 	withUnwind(cmdStageHashState)
@@ -334,7 +334,7 @@ func init() {
 
 	rootCmd.AddCommand(cmdStageHashState)
 
-	withDatadir(cmdStageTrie)
+	withDataDir(cmdStageTrie)
 	withReset(cmdStageTrie)
 	withBlock(cmdStageTrie)
 	withUnwind(cmdStageTrie)
@@ -345,7 +345,7 @@ func init() {
 
 	rootCmd.AddCommand(cmdStageTrie)
 
-	withDatadir(cmdStageHistory)
+	withDataDir(cmdStageHistory)
 	withReset(cmdStageHistory)
 	withBlock(cmdStageHistory)
 	withUnwind(cmdStageHistory)
@@ -355,7 +355,7 @@ func init() {
 
 	rootCmd.AddCommand(cmdStageHistory)
 
-	withDatadir(cmdLogIndex)
+	withDataDir(cmdLogIndex)
 	withReset(cmdLogIndex)
 	withBlock(cmdLogIndex)
 	withUnwind(cmdLogIndex)
@@ -365,7 +365,7 @@ func init() {
 
 	rootCmd.AddCommand(cmdLogIndex)
 
-	withDatadir(cmdCallTraces)
+	withDataDir(cmdCallTraces)
 	withReset(cmdCallTraces)
 	withBlock(cmdCallTraces)
 	withUnwind(cmdCallTraces)
@@ -378,28 +378,28 @@ func init() {
 	withReset(cmdStageTxLookup)
 	withBlock(cmdStageTxLookup)
 	withUnwind(cmdStageTxLookup)
-	withDatadir(cmdStageTxLookup)
+	withDataDir(cmdStageTxLookup)
 	withPruneTo(cmdStageTxLookup)
 	withChain(cmdStageTxLookup)
 	withHeimdall(cmdStageTxLookup)
 
 	rootCmd.AddCommand(cmdStageTxLookup)
 
-	withDatadir(cmdPrintMigrations)
+	withDataDir(cmdPrintMigrations)
 	rootCmd.AddCommand(cmdPrintMigrations)
 
-	withDatadir(cmdRemoveMigration)
+	withDataDir(cmdRemoveMigration)
 	withMigration(cmdRemoveMigration)
 	withChain(cmdRemoveMigration)
 	withHeimdall(cmdRemoveMigration)
 	rootCmd.AddCommand(cmdRemoveMigration)
 
-	withDatadir(cmdRunMigrations)
+	withDataDir(cmdRunMigrations)
 	withChain(cmdRunMigrations)
 	withHeimdall(cmdRunMigrations)
 	rootCmd.AddCommand(cmdRunMigrations)
 
-	withDatadir(cmdSetPrune)
+	withDataDir(cmdSetPrune)
 	withChain(cmdSetPrune)
 	cmdSetPrune.Flags().StringVar(&pruneFlag, "prune", "hrtc", "")
 	cmdSetPrune.Flags().Uint64Var(&pruneH, "prune.h.older", 0, "")

--- a/cmd/integration/commands/state_stages.go
+++ b/cmd/integration/commands/state_stages.go
@@ -117,7 +117,7 @@ var loopExecCmd = &cobra.Command{
 }
 
 func init() {
-	withDatadir2(stateStags)
+	withDataDir2(stateStags)
 	withReferenceChaindata(stateStags)
 	withUnwind(stateStags)
 	withUnwindEvery(stateStags)
@@ -129,7 +129,7 @@ func init() {
 
 	rootCmd.AddCommand(stateStags)
 
-	withDatadir(loopIhCmd)
+	withDataDir(loopIhCmd)
 	withBatchSize(loopIhCmd)
 	withUnwind(loopIhCmd)
 	withChain(loopIhCmd)
@@ -137,7 +137,7 @@ func init() {
 
 	rootCmd.AddCommand(loopIhCmd)
 
-	withDatadir(loopExecCmd)
+	withDataDir(loopExecCmd)
 	withBatchSize(loopExecCmd)
 	withUnwind(loopExecCmd)
 	withChain(loopExecCmd)

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -51,7 +51,7 @@ func RootCommand() (*cobra.Command, *httpcfg.HttpCfg) {
 
 	cfg := &httpcfg.HttpCfg{StateCache: kvcache.DefaultCoherentConfig}
 	rootCmd.PersistentFlags().StringVar(&cfg.PrivateApiAddr, "private.api.addr", "127.0.0.1:9090", "private api network address, for example: 127.0.0.1:9090")
-	rootCmd.PersistentFlags().StringVar(&cfg.Datadir, "datadir", "", "path to Erigon working directory")
+	rootCmd.PersistentFlags().StringVar(&cfg.DataDir, "datadir", "", "path to Erigon working directory")
 	rootCmd.PersistentFlags().StringVar(&cfg.Chaindata, "chaindata", "", "path to the database")
 	rootCmd.PersistentFlags().StringVar(&cfg.HttpListenAddress, "http.addr", node.DefaultHTTPHost, "HTTP-RPC server listening interface")
 	rootCmd.PersistentFlags().StringVar(&cfg.EngineHTTPListenAddress, "engine.addr", node.DefaultHTTPHost, "HTTP-RPC server listening interface for engineAPI")
@@ -95,13 +95,13 @@ func RootCommand() (*cobra.Command, *httpcfg.HttpCfg) {
 		if err := utils.SetupCobra(cmd); err != nil {
 			return err
 		}
-		cfg.SingleNodeMode = cfg.Datadir != "" || cfg.Chaindata != ""
+		cfg.SingleNodeMode = cfg.DataDir != "" || cfg.Chaindata != ""
 		if cfg.SingleNodeMode {
-			if cfg.Datadir == "" {
-				cfg.Datadir = paths.DefaultDataDir()
+			if cfg.DataDir == "" {
+				cfg.DataDir = paths.DefaultDataDir()
 			}
 			if cfg.Chaindata == "" {
-				cfg.Chaindata = filepath.Join(cfg.Datadir, "chaindata")
+				cfg.Chaindata = filepath.Join(cfg.DataDir, "chaindata")
 			}
 			cfg.Snapshot = ethconfig.NewSnapshotCfg(cfg.Snapshot.Enabled, cfg.Snapshot.RetireEnabled)
 		}
@@ -250,7 +250,7 @@ func RemoteServices(ctx context.Context, cfg httpcfg.HttpCfg, logger log.Logger,
 
 		// bor (consensus) specific db
 		var borKv kv.RoDB
-		borDbPath := filepath.Join(cfg.Datadir, "bor")
+		borDbPath := filepath.Join(cfg.DataDir, "bor")
 		{
 			// ensure db exist
 			tmpDb, err := kv2.NewMDBX(logger).Path(borDbPath).Label(kv.ConsensusDB).Open()
@@ -295,7 +295,7 @@ func RemoteServices(ctx context.Context, cfg httpcfg.HttpCfg, logger log.Logger,
 				return nil, nil, nil, nil, nil, nil, nil, nil, ff, fmt.Errorf("chain config not found in db. Need start erigon at least once on this db")
 			}
 
-			allSnapshots := snapshotsync.NewRoSnapshots(cfg.Snapshot, filepath.Join(cfg.Datadir, "snapshots"))
+			allSnapshots := snapshotsync.NewRoSnapshots(cfg.Snapshot, filepath.Join(cfg.DataDir, "snapshots"))
 			allSnapshots.AsyncOpenAll(ctx)
 			blockReader = snapshotsync.NewBlockReaderWithSnapshots(allSnapshots)
 		} else {

--- a/cmd/rpcdaemon/cli/httpcfg/http_cfg.go
+++ b/cmd/rpcdaemon/cli/httpcfg/http_cfg.go
@@ -9,7 +9,7 @@ type HttpCfg struct {
 	Enabled                 bool
 	PrivateApiAddr          string
 	SingleNodeMode          bool // Erigon's database can be read by separated processes on same machine - in read-only mode - with full support of transactions. It will share same "OS PageCache" with Erigon process.
-	Datadir                 string
+	DataDir                 string
 	Chaindata               string
 	HttpListenAddress       string
 	EngineHTTPListenAddress string

--- a/cmd/starknet/cmd/generate_raw_tx.go
+++ b/cmd/starknet/cmd/generate_raw_tx.go
@@ -26,7 +26,7 @@ type Flags struct {
 	Gas        uint64
 	Nonce      uint64
 	PrivateKey string
-	Datadir    string
+	DataDir    string
 	Chaindata  string
 	Output     string
 }
@@ -99,16 +99,16 @@ func config() (*cobra.Command, *Flags) {
 	generateRawTxCmd.PersistentFlags().StringVar(&flags.PrivateKey, "private_key", "", "Private key")
 	generateRawTxCmd.MarkPersistentFlagRequired("private_key")
 
-	generateRawTxCmd.PersistentFlags().StringVar(&flags.Datadir, "datadir", "", "path to Erigon working directory")
+	generateRawTxCmd.PersistentFlags().StringVar(&flags.DataDir, "datadir", "", "path to Erigon working directory")
 
 	generateRawTxCmd.PersistentFlags().StringVarP(&flags.Output, "output", "o", "", "Path to file where sign transaction will be saved. Print to stdout if empty.")
 
 	generateRawTxCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-		if flags.Datadir == "" {
-			flags.Datadir = paths.DefaultDataDir()
+		if flags.DataDir == "" {
+			flags.DataDir = paths.DefaultDataDir()
 		}
 		if flags.Chaindata == "" {
-			flags.Chaindata = filepath.Join(flags.Datadir, "chaindata")
+			flags.Chaindata = filepath.Join(flags.DataDir, "chaindata")
 		}
 		return nil
 	}

--- a/cmd/state/commands/check_change_sets.go
+++ b/cmd/state/commands/check_change_sets.go
@@ -34,7 +34,7 @@ var (
 
 func init() {
 	withBlock(checkChangeSetsCmd)
-	withDatadir(checkChangeSetsCmd)
+	withDataDir(checkChangeSetsCmd)
 	checkChangeSetsCmd.Flags().StringVar(&historyfile, "historyfile", "", "path to the file where the changesets and history are expected to be. If omitted, the same as <datadir>/erion/chaindata")
 	checkChangeSetsCmd.Flags().BoolVar(&nocheck, "nocheck", false, "set to turn off the changeset checking and only execute transaction (for performance testing)")
 	checkChangeSetsCmd.Flags().BoolVar(&writeReceipts, "writeReceipts", false, "set to turn on writing receipts as the execution ongoing")

--- a/cmd/state/commands/check_enc.go
+++ b/cmd/state/commands/check_enc.go
@@ -6,7 +6,7 @@ import (
 )
 
 func init() {
-	withDatadir(checkEncCmd)
+	withDataDir(checkEncCmd)
 	withStatsfile(checkEncCmd)
 	rootCmd.AddCommand(checkEncCmd)
 }

--- a/cmd/state/commands/check_index.go
+++ b/cmd/state/commands/check_index.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	withDatadir(checkIndexCMD)
+	withDataDir(checkIndexCMD)
 	withIndexBucket(checkIndexCMD)
 	withCSBucket(checkIndexCMD)
 	rootCmd.AddCommand(checkIndexCMD)

--- a/cmd/state/commands/erigon2.go
+++ b/cmd/state/commands/erigon2.go
@@ -53,7 +53,7 @@ var blockExecutionTimer = metrics2.GetOrCreateSummary("chain_execution_seconds")
 
 func init() {
 	withBlock(erigon2Cmd)
-	withDatadir(erigon2Cmd)
+	withDataDir(erigon2Cmd)
 	withSnapshotBlocks(erigon2Cmd)
 	erigon2Cmd.Flags().BoolVar(&changesets, "changesets", false, "set to true to generate changesets")
 	erigon2Cmd.Flags().IntVar(&commitmentFrequency, "commfreq", 625, "how many blocks to skip between calculating commitment")

--- a/cmd/state/commands/global_flags_vars.go
+++ b/cmd/state/commands/global_flags_vars.go
@@ -26,7 +26,7 @@ func withBlock(cmd *cobra.Command) {
 	cmd.Flags().Uint64Var(&block, "block", 0, "specifies a block number for operation")
 }
 
-func withDatadir(cmd *cobra.Command) {
+func withDataDir(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&datadir, "datadir", paths.DefaultDataDir(), "data directory for temporary ELT files")
 	must(cmd.MarkFlagDirname("datadir"))
 

--- a/cmd/state/commands/history2.go
+++ b/cmd/state/commands/history2.go
@@ -33,7 +33,7 @@ var (
 
 func init() {
 	withBlock(history2Cmd)
-	withDatadir(history2Cmd)
+	withDataDir(history2Cmd)
 	history2Cmd.Flags().IntVar(&traceBlock, "traceblock", 0, "block number at which to turn on tracing")
 	history2Cmd.Flags().IntVar(&blockTo, "blockto", 0, "block number to stop replay of history at")
 	rootCmd.AddCommand(history2Cmd)

--- a/cmd/state/commands/index_stats.go
+++ b/cmd/state/commands/index_stats.go
@@ -6,7 +6,7 @@ import (
 )
 
 func init() {
-	withDatadir(indexStatsCmd)
+	withDataDir(indexStatsCmd)
 	withStatsfile(indexStatsCmd)
 	withIndexBucket(indexStatsCmd)
 	rootCmd.AddCommand(indexStatsCmd)

--- a/cmd/state/commands/opcode_tracer.go
+++ b/cmd/state/commands/opcode_tracer.go
@@ -40,7 +40,7 @@ var (
 
 func init() {
 	withBlock(opcodeTracerCmd)
-	withDatadir(opcodeTracerCmd)
+	withDataDir(opcodeTracerCmd)
 	opcodeTracerCmd.Flags().Uint64Var(&numBlocks, "numBlocks", 1, "number of blocks to run the operation on")
 	opcodeTracerCmd.Flags().BoolVar(&saveOpcodes, "saveOpcodes", false, "set to save the opcodes")
 	opcodeTracerCmd.Flags().BoolVar(&saveBBlocks, "saveBBlocks", false, "set to save the basic blocks")

--- a/cmd/state/commands/state_root.go
+++ b/cmd/state/commands/state_root.go
@@ -27,7 +27,7 @@ import (
 
 func init() {
 	withBlock(stateRootCmd)
-	withDatadir(stateRootCmd)
+	withDataDir(stateRootCmd)
 	rootCmd.AddCommand(stateRootCmd)
 }
 

--- a/cmd/state/commands/verify_txlookup.go
+++ b/cmd/state/commands/verify_txlookup.go
@@ -6,7 +6,7 @@ import (
 )
 
 func init() {
-	withDatadir(verifyTxLookupCmd)
+	withDataDir(verifyTxLookupCmd)
 	rootCmd.AddCommand(verifyTxLookupCmd)
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -669,7 +669,7 @@ var MetricFlags = []cli.Flag{MetricsEnabledFlag, MetricsEnabledExpensiveFlag, Me
 // setNodeKey creates a node key from set command line flags, either loading it
 // from a file or as a specified hex value. If neither flags were provided, this
 // method returns nil and an emphemeral key is to be generated.
-func setNodeKey(ctx *cli.Context, cfg *p2p.Config, nodeName, dataDir string) {
+func setNodeKey(ctx *cli.Context, cfg *p2p.Config, nodeName, datadir string) {
 	cfg.Name = nodeName
 	var (
 		hex  = ctx.GlobalString(NodeKeyHexFlag.Name)
@@ -692,7 +692,7 @@ func setNodeKey(ctx *cli.Context, cfg *p2p.Config, nodeName, dataDir string) {
 		}
 		cfg.PrivateKey = key
 	default:
-		cfg.PrivateKey = nodeKey(path.Join(dataDir, "nodekey"))
+		cfg.PrivateKey = nodeKey(path.Join(datadir, "nodekey"))
 	}
 }
 
@@ -999,8 +999,8 @@ func setEtherbase(ctx *cli.Context, cfg *ethconfig.Config) {
 	}
 }
 
-func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config, nodeName, dataDir string) {
-	setNodeKey(ctx, cfg, nodeName, dataDir)
+func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config, nodeName, datadir string) {
+	setNodeKey(ctx, cfg, nodeName, datadir)
 	setNAT(ctx, cfg)
 	setListenAddress(ctx, cfg)
 	setBootstrapNodes(ctx, cfg)

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -224,7 +224,7 @@ type Config struct {
 	WithoutHeimdall bool
 }
 
-func CreateConsensusEngine(chainConfig *params.ChainConfig, logger log.Logger, config interface{}, notify []string, noverify bool, HeimdallURL string, WithoutHeimdall bool, dataDir string) consensus.Engine {
+func CreateConsensusEngine(chainConfig *params.ChainConfig, logger log.Logger, config interface{}, notify []string, noverify bool, HeimdallURL string, WithoutHeimdall bool, datadir string) consensus.Engine {
 	var eng consensus.Engine
 
 	switch consensusCfg := config.(type) {
@@ -267,7 +267,7 @@ func CreateConsensusEngine(chainConfig *params.ChainConfig, logger log.Logger, c
 		}
 	case *params.BorConfig:
 		if chainConfig.Bor != nil {
-			borDbPath := filepath.Join(dataDir, "bor") // bor consensus path: datadir/bor
+			borDbPath := filepath.Join(datadir, "bor") // bor consensus path: datadir/bor
 			eng = bor.New(chainConfig, db.OpenDatabase(borDbPath, logger, false), HeimdallURL, WithoutHeimdall)
 		}
 	}

--- a/node/config_test.go
+++ b/node/config_test.go
@@ -30,7 +30,7 @@ import (
 
 // Tests that datadirs can be successfully created, be them manually configured
 // ones or automatically generated temporary ones.
-func TestDatadirCreation(t *testing.T) {
+func TestDataDirCreation(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("fix me on win please")
 	}

--- a/node/errors.go
+++ b/node/errors.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	ErrDatadirUsed    = errors.New("datadir already used by another process")
+	ErrDataDirUsed    = errors.New("datadir already used by another process")
 	ErrNodeStopped    = errors.New("node not started")
 	ErrNodeRunning    = errors.New("node already running")
 	ErrServiceUnknown = errors.New("unknown service")
@@ -34,7 +34,7 @@ var (
 
 func convertFileLockError(err error) error {
 	if errno, ok := err.(syscall.Errno); ok && datadirInUseErrnos[uint(errno)] {
-		return ErrDatadirUsed
+		return ErrDataDirUsed
 	}
 	return err
 }

--- a/node/node.go
+++ b/node/node.go
@@ -289,7 +289,7 @@ func (n *Node) openDataDir() error {
 		return convertFileLockError(err)
 	}
 	if !locked {
-		return fmt.Errorf("%w: %s\n", ErrDatadirUsed, instdir)
+		return fmt.Errorf("%w: %s\n", ErrDataDirUsed, instdir)
 	}
 	n.dirLock = l
 	return nil

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -115,8 +115,8 @@ func TestNodeUsedDataDir(t *testing.T) {
 	}
 
 	// Create a second node based on the same data directory and ensure failure
-	if _, err := New(&Config{DataDir: dir}); !errors.Is(err, ErrDatadirUsed) {
-		t.Fatalf("duplicate datadir failure mismatch: have %v, want %v", err, ErrDatadirUsed)
+	if _, err := New(&Config{DataDir: dir}); !errors.Is(err, ErrDataDirUsed) {
+		t.Fatalf("duplicate datadir failure mismatch: have %v, want %v", err, ErrDataDirUsed)
 	}
 }
 

--- a/turbo/app/snapshots.go
+++ b/turbo/app/snapshots.go
@@ -92,13 +92,13 @@ func doIndicesCommand(cliCtx *cli.Context) error {
 	ctx, cancel := common.RootContext()
 	defer cancel()
 
-	dataDir := cliCtx.String(utils.DataDirFlag.Name)
-	snapshotDir := filepath.Join(dataDir, "snapshots")
-	tmpDir := filepath.Join(dataDir, etl.TmpDirName)
+	datadir := cliCtx.String(utils.DataDirFlag.Name)
+	snapshotDir := filepath.Join(datadir, "snapshots")
+	tmpDir := filepath.Join(datadir, etl.TmpDirName)
 	rebuild := cliCtx.Bool(SnapshotRebuildFlag.Name)
 	from := cliCtx.Uint64(SnapshotFromFlag.Name)
 
-	chainDB := mdbx.NewMDBX(log.New()).Path(path.Join(dataDir, "chaindata")).Readonly().MustOpen()
+	chainDB := mdbx.NewMDBX(log.New()).Path(path.Join(datadir, "chaindata")).Readonly().MustOpen()
 	defer chainDB.Close()
 
 	if rebuild {
@@ -125,12 +125,12 @@ func doSnapshotCommand(cliCtx *cli.Context) error {
 	if segmentSize < 1000 {
 		return fmt.Errorf("too small --segment.size %d", segmentSize)
 	}
-	dataDir := cliCtx.String(utils.DataDirFlag.Name)
-	snapshotDir := filepath.Join(dataDir, "snapshots")
-	tmpDir := filepath.Join(dataDir, etl.TmpDirName)
+	datadir := cliCtx.String(utils.DataDirFlag.Name)
+	snapshotDir := filepath.Join(datadir, "snapshots")
+	tmpDir := filepath.Join(datadir, etl.TmpDirName)
 	dir.MustExist(tmpDir)
 
-	chainDB := mdbx.NewMDBX(log.New()).Path(filepath.Join(dataDir, "chaindata")).Readonly().MustOpen()
+	chainDB := mdbx.NewMDBX(log.New()).Path(filepath.Join(datadir, "chaindata")).Readonly().MustOpen()
 	defer chainDB.Close()
 
 	if err := snapshotBlocks(ctx, chainDB, fromBlock, toBlock, segmentSize, snapshotDir, tmpDir); err != nil {
@@ -142,12 +142,12 @@ func doRecompressCommand(cliCtx *cli.Context) error {
 	ctx, cancel := common.RootContext()
 	defer cancel()
 
-	dataDir := cliCtx.String(utils.DataDirFlag.Name)
-	snapshotDir, err := dir.OpenRw(filepath.Join(dataDir, "snapshots"))
+	datadir := cliCtx.String(utils.DataDirFlag.Name)
+	snapshotDir, err := dir.OpenRw(filepath.Join(datadir, "snapshots"))
 	if err != nil {
 		return err
 	}
-	tmpDir := filepath.Join(dataDir, etl.TmpDirName)
+	tmpDir := filepath.Join(datadir, etl.TmpDirName)
 	dir.MustExist(tmpDir)
 
 	if err := snapshotsync.RecompressSegments(ctx, snapshotDir, tmpDir); err != nil {
@@ -219,13 +219,13 @@ func snapshotBlocks(ctx context.Context, chainDB kv.RoDB, fromBlock, toBlock, bl
 func checkBlockSnapshot(chaindata string) error {
 	database := mdbx.MustOpen(chaindata)
 	defer database.Close()
-	dataDir := path.Dir(chaindata)
+	datadir := path.Dir(chaindata)
 	chainConfig := tool.ChainConfigFromDB(database)
 	chainID, _ := uint256.FromBig(chainConfig.ChainID)
 	_ = chainID
 
 	cfg := ethconfig.NewSnapshotCfg(true, true)
-	snapshots := snapshotsync.NewRoSnapshots(cfg, filepath.Join(dataDir, "snapshots"))
+	snapshots := snapshotsync.NewRoSnapshots(cfg, filepath.Join(datadir, "snapshots"))
 	snapshots.ReopenSegments()
 	snapshots.ReopenIndices()
 	//if err := snapshots.BuildIndices(context.Background(), *chainID); err != nil {

--- a/turbo/cli/flags.go
+++ b/turbo/cli/flags.go
@@ -287,7 +287,7 @@ func ApplyFlagsForNodeConfig(ctx *cli.Context, cfg *node.Config) {
 func setEmbeddedRpcDaemon(ctx *cli.Context, cfg *node.Config) {
 	c := &httpcfg.HttpCfg{
 		Enabled:   ctx.GlobalBool(utils.HTTPEnabledFlag.Name),
-		Datadir:   cfg.DataDir,
+		DataDir:   cfg.DataDir,
 		Chaindata: filepath.Join(cfg.DataDir, "chaindata"),
 
 		TLSKeyFile:  cfg.TLSKeyFile,


### PR DESCRIPTION
In most places (100+) the convention is to use "DataDir" in function names and public names,
and use "datadir" for local variables.

This fixes the discrepancies from this rule.

* rename from Datadir to DataDir (functions and public vars)
* rename dataDir to datadir (local variables)
