### PR TITLE
Rename log/logger to follow conventions.

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -871,7 +871,7 @@ func NewP2PConfig(nodiscover bool, datadir, netRestrict, natSetting, nodeName st
 		NoDiscovery:  nodiscover,
 		PrivateKey:   serverKey,
 		Name:         nodeName,
-		Logger:       log.New(),
+		Log:          log.New(),
 		NodeDatabase: enodeDBPath,
 	}
 	if netRestrict != "" {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -92,7 +92,7 @@ type Config = ethconfig.Config
 // Ethereum implements the Ethereum full node service.
 type Ethereum struct {
 	config *ethconfig.Config
-	logger log.Logger
+	log    log.Logger
 
 	// DB interfaces
 	chainDB    kv.RwDB
@@ -197,7 +197,7 @@ func New(stack *node.Node, config *ethconfig.Config, txpoolCfg txpool2.Config, l
 		sentryCtx:            ctx,
 		sentryCancel:         ctxCancel,
 		config:               config,
-		logger:               logger,
+		log:                  logger,
 		chainDB:              chainKv,
 		networkID:            config.NetworkID,
 		etherbase:            config.Miner.Etherbase,
@@ -498,7 +498,7 @@ func New(stack *node.Node, config *ethconfig.Config, txpoolCfg txpool2.Config, l
 		return nil, err
 	}
 
-	backend.stagedSync, err = stages2.NewStagedSync(backend.sentryCtx, backend.logger, backend.chainDB,
+	backend.stagedSync, err = stages2.NewStagedSync(backend.sentryCtx, backend.log, backend.chainDB,
 		stack.Config().P2P, *config, chainConfig.TerminalTotalDifficulty,
 		backend.sentryControlServer, tmpdir, backend.notifications.Accumulator,
 		backend.newPayloadCh, backend.forkChoiceCh, &backend.waitingForBeaconChain,

--- a/internal/testlog/testlog.go
+++ b/internal/testlog/testlog.go
@@ -44,10 +44,10 @@ func (h *handler) Log(r *log.Record) error {
 // helpers, so the file and line number in unit test output correspond to the call site
 // which emitted the log message.
 type logger struct {
-	t  *testing.T
-	l  log.Logger
-	mu *sync.Mutex
-	h  *bufHandler
+	t   *testing.T
+	log log.Logger
+	mu  *sync.Mutex
+	h   *bufHandler
 }
 
 type bufHandler struct {
@@ -63,12 +63,12 @@ func (h *bufHandler) Log(r *log.Record) error {
 // Logger returns a logger which logs to the unit test log of t.
 func Logger(t *testing.T, level log.Lvl) log.Logger {
 	l := &logger{
-		t:  t,
-		l:  log.New(),
-		mu: new(sync.Mutex),
-		h:  &bufHandler{fmt: log.TerminalFormat()},
+		t:   t,
+		log: log.New(),
+		mu:  new(sync.Mutex),
+		h:   &bufHandler{fmt: log.TerminalFormat()},
 	}
-	l.l.SetHandler(log.LvlFilterHandler(level, l.h))
+	l.log.SetHandler(log.LvlFilterHandler(level, l.h))
 	return l
 }
 
@@ -76,7 +76,7 @@ func (l *logger) Trace(msg string, ctx ...interface{}) {
 	l.t.Helper()
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	l.l.Trace(msg, ctx...)
+	l.log.Trace(msg, ctx...)
 	l.flush()
 }
 
@@ -84,7 +84,7 @@ func (l *logger) Debug(msg string, ctx ...interface{}) {
 	l.t.Helper()
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	l.l.Debug(msg, ctx...)
+	l.log.Debug(msg, ctx...)
 	l.flush()
 }
 
@@ -92,7 +92,7 @@ func (l *logger) Info(msg string, ctx ...interface{}) {
 	l.t.Helper()
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	l.l.Info(msg, ctx...)
+	l.log.Info(msg, ctx...)
 	l.flush()
 }
 
@@ -100,7 +100,7 @@ func (l *logger) Warn(msg string, ctx ...interface{}) {
 	l.t.Helper()
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	l.l.Warn(msg, ctx...)
+	l.log.Warn(msg, ctx...)
 	l.flush()
 }
 
@@ -108,7 +108,7 @@ func (l *logger) Error(msg string, ctx ...interface{}) {
 	l.t.Helper()
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	l.l.Error(msg, ctx...)
+	l.log.Error(msg, ctx...)
 	l.flush()
 }
 
@@ -116,20 +116,20 @@ func (l *logger) Crit(msg string, ctx ...interface{}) {
 	l.t.Helper()
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	l.l.Crit(msg, ctx...)
+	l.log.Crit(msg, ctx...)
 	l.flush()
 }
 
 func (l *logger) New(ctx ...interface{}) log.Logger {
-	return &logger{l.t, l.l.New(ctx...), l.mu, l.h}
+	return &logger{l.t, l.log.New(ctx...), l.mu, l.h}
 }
 
 func (l *logger) GetHandler() log.Handler {
-	return l.l.GetHandler()
+	return l.log.GetHandler()
 }
 
 func (l *logger) SetHandler(h log.Handler) {
-	l.l.SetHandler(h)
+	l.log.SetHandler(h)
 }
 
 // flush writes all buffered messages and clears the buffer.

--- a/node/api_test.go
+++ b/node/api_test.go
@@ -254,7 +254,7 @@ func TestStartRPC(t *testing.T) {
 
 			// Apply some sane defaults.
 			config := test.cfg //nolint:scopelint
-			// config.Logger = testlog.Logger(t, log.LvlDebug)
+			// config.Log = testlog.Log(t, log.LvlDebug)
 			config.P2P.NoDiscovery = true
 
 			// Create Node.

--- a/node/config.go
+++ b/node/config.go
@@ -143,8 +143,8 @@ type Config struct {
 	// private APIs to untrusted users is a major security risk.
 	WSExposeAll bool `toml:",omitempty"`
 
-	// Logger is a custom logger to use with the p2p.Server.
-	Logger log.Logger `toml:",omitempty"`
+	// Log is a custom logger to use with the p2p.Server.
+	Log log.Logger `toml:",omitempty"`
 
 	DatabaseVerbosity kv.DBVerbosityLvl
 
@@ -378,7 +378,7 @@ func (c *Config) warnOnce(w *bool, format string, args ...interface{}) {
 	if *w {
 		return
 	}
-	l := c.Logger
+	l := c.Log
 	if l == nil {
 		l = log.Root()
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -82,8 +82,8 @@ func New(conf *Config) (*Node, error) {
 		}
 		conf.DataDir = absdatadir
 	}
-	if conf.Logger == nil {
-		conf.Logger = log.New()
+	if conf.Log == nil {
+		conf.Log = log.New()
 	}
 
 	// Ensure that the instance name doesn't cause weird conflicts with
@@ -98,7 +98,7 @@ func New(conf *Config) (*Node, error) {
 	node := &Node{
 		config:        conf,
 		inprocHandler: rpc.NewServer(50),
-		log:           conf.Logger,
+		log:           conf.Log,
 		stop:          make(chan struct{}),
 		databases:     make([]kv.Closer, 0),
 	}

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -81,8 +81,8 @@ type httpServer struct {
 	handlerNames map[string]string
 }
 
-func newHTTPServer(log log.Logger, timeouts rpc.HTTPTimeouts) *httpServer {
-	h := &httpServer{log: log, timeouts: timeouts, handlerNames: make(map[string]string)}
+func newHTTPServer(logger log.Logger, timeouts rpc.HTTPTimeouts) *httpServer {
+	h := &httpServer{log: logger, timeouts: timeouts, handlerNames: make(map[string]string)}
 
 	h.httpHandler.Store((*rpcHandler)(nil))
 	h.wsHandler.Store((*rpcHandler)(nil))

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -100,7 +100,7 @@ type bucket struct {
 	ips          netutil.DistinctNetSet
 }
 
-func newTable(t transport, db *enode.DB, bootnodes []*enode.Node, log log.Logger) (*Table, error) {
+func newTable(t transport, db *enode.DB, bootnodes []*enode.Node, logger log.Logger) (*Table, error) {
 	tab := &Table{
 		net:        t,
 		db:         db,
@@ -110,7 +110,7 @@ func newTable(t transport, db *enode.DB, bootnodes []*enode.Node, log log.Logger
 		closed:     make(chan struct{}),
 		rand:       mrand.New(mrand.NewSource(0)),
 		ips:        netutil.DistinctNetSet{Subnet: tableSubnet, Limit: tableIPLimit},
-		log:        log,
+		log:        logger,
 	}
 	if err := tab.setFallbackNodes(bootnodes); err != nil {
 		return nil, err

--- a/p2p/dnsdisc/client.go
+++ b/p2p/dnsdisc/client.go
@@ -50,7 +50,7 @@ type Config struct {
 	RateLimit       float64            // maximum DNS requests / second (default 3)
 	ValidSchemes    enr.IdentityScheme // acceptable ENR identity schemes (default enode.ValidSchemes)
 	Resolver        Resolver           // the DNS resolver to use (defaults to system DNS)
-	Logger          log.Logger         // destination of client log messages (defaults to root logger)
+	Log             log.Logger         // destination of client log messages (defaults to root logger)
 }
 
 // Resolver is a DNS resolver that can query TXT records.
@@ -83,8 +83,8 @@ func (cfg Config) withDefaults() Config {
 	if cfg.Resolver == nil {
 		cfg.Resolver = new(net.Resolver)
 	}
-	if cfg.Logger == nil {
-		cfg.Logger = log.Root()
+	if cfg.Log == nil {
+		cfg.Log = log.Root()
 	}
 	return cfg
 }
@@ -131,7 +131,7 @@ func (c *Client) NewIterator(urls ...string) (enode.Iterator, error) {
 // resolveRoot retrieves a root entry via DNS.
 func (c *Client) resolveRoot(ctx context.Context, loc *linkEntry) (rootEntry, error) {
 	txts, err := c.cfg.Resolver.LookupTXT(ctx, loc.domain)
-	c.cfg.Logger.Trace("Updating DNS discovery root", "tree", loc.domain, "err", err)
+	c.cfg.Log.Trace("Updating DNS discovery root", "tree", loc.domain, "err", err)
 	if err != nil {
 		return rootEntry{}, err
 	}
@@ -177,7 +177,7 @@ func (c *Client) doResolveEntry(ctx context.Context, domain, hash string) (entry
 	}
 	name := hash + "." + domain
 	txts, err := c.cfg.Resolver.LookupTXT(ctx, hash+"."+domain)
-	c.cfg.Logger.Trace("DNS discovery lookup", "name", name, "err", err)
+	c.cfg.Log.Trace("DNS discovery lookup", "name", name, "err", err)
 	if err != nil {
 		return nil, err
 	}
@@ -276,7 +276,7 @@ func (it *randomIterator) nextNode() *enode.Node {
 			if err == it.ctx.Err() {
 				return nil // context canceled.
 			}
-			it.c.cfg.Logger.Trace("Error in DNS random node sync", "tree", ct.loc.domain, "err", err)
+			it.c.cfg.Log.Trace("Error in DNS random node sync", "tree", ct.loc.domain, "err", err)
 			continue
 		}
 		if n != nil {
@@ -349,7 +349,7 @@ func (it *randomIterator) waitForRootUpdates(trees []*clientTree) bool {
 	}
 
 	sleep := nextCheck.Sub(it.c.clock.Now())
-	it.c.cfg.Logger.Trace("DNS iterator waiting for root updates", "sleep", sleep, "tree", minTree.loc.domain)
+	it.c.cfg.Log.Trace("DNS iterator waiting for root updates", "sleep", sleep, "tree", minTree.loc.domain)
 	timeout := it.c.clock.NewTimer(sleep)
 	defer timeout.Stop()
 	select {

--- a/p2p/dnsdisc/client_test.go
+++ b/p2p/dnsdisc/client_test.go
@@ -55,7 +55,7 @@ func TestClientSyncTree(t *testing.T) {
 		wantSeq   = uint(1)
 	)
 
-	c := NewClient(Config{Resolver: r, Logger: testlog.Logger(t, log.LvlError)})
+	c := NewClient(Config{Resolver: r, Log: testlog.Logger(t, log.LvlError)})
 	stree, err := c.SyncTree("enrtree://AKPYQIUQIL7PSIACI32J7FGZW56E5FKHEFCCOFHILBIMW3M6LWXS2@n")
 	if err != nil {
 		t.Fatal("sync error:", err)
@@ -89,7 +89,7 @@ func TestClientSyncTreeBadNode(t *testing.T) {
 		"C7HRFPF3BLGF3YR4DY5KX3SMBE.n": "enrtree://AM5FCQLWIZX2QFPNJAP7VUERCCRNGRHWZG3YYHIUV7BVDQ5FDPRT2@morenodes.example.org",
 		"INDMVBZEEQ4ESVYAKGIYU74EAA.n": "enr:-----",
 	}
-	c := NewClient(Config{Resolver: r, Logger: testlog.Logger(t, log.LvlError)})
+	c := NewClient(Config{Resolver: r, Log: testlog.Logger(t, log.LvlError)})
 	_, err := c.SyncTree("enrtree://AKPYQIUQIL7PSIACI32J7FGZW56E5FKHEFCCOFHILBIMW3M6LWXS2@n")
 	wantErr := nameError{name: "INDMVBZEEQ4ESVYAKGIYU74EAA.n", err: entryError{typ: "enr", err: errInvalidENR}}
 	if err != wantErr {
@@ -104,7 +104,7 @@ func TestIterator(t *testing.T) {
 	r := mapResolver(tree.ToTXT("n"))
 	c := NewClient(Config{
 		Resolver:  r,
-		Logger:    testlog.Logger(t, log.LvlError),
+		Log:       testlog.Logger(t, log.LvlError),
 		RateLimit: 500,
 	})
 	it, err := c.NewIterator(url)
@@ -145,7 +145,7 @@ func TestIteratorLinks(t *testing.T) {
 	tree2, url2 := makeTestTree("t2", nodes[10:], []string{url1})
 	c := NewClient(Config{
 		Resolver:  newMapResolver(tree1.ToTXT("t1"), tree2.ToTXT("t2")),
-		Logger:    testlog.Logger(t, log.LvlError),
+		Log:       testlog.Logger(t, log.LvlError),
 		RateLimit: 500,
 	})
 	it, err := c.NewIterator(url2)
@@ -165,7 +165,7 @@ func TestIteratorNodeUpdates(t *testing.T) {
 		resolver = newMapResolver()
 		c        = NewClient(Config{
 			Resolver:        resolver,
-			Logger:          testlog.Logger(t, log.LvlError),
+			Log:             testlog.Logger(t, log.LvlError),
 			RecheckInterval: 20 * time.Minute,
 			RateLimit:       500,
 		})
@@ -202,7 +202,7 @@ func TestIteratorRootRecheckOnFail(t *testing.T) {
 		resolver = newMapResolver()
 		c        = NewClient(Config{
 			Resolver:        resolver,
-			Logger:          testlog.Logger(t, log.LvlError),
+			Log:             testlog.Logger(t, log.LvlError),
 			RecheckInterval: 20 * time.Minute,
 			RateLimit:       500,
 			// Disabling the cache is required for this test because the client doesn't
@@ -239,7 +239,7 @@ func TestIteratorEmptyTree(t *testing.T) {
 		resolver = newMapResolver()
 		c        = NewClient(Config{
 			Resolver:        resolver,
-			Logger:          testlog.Logger(t, log.LvlError),
+			Log:             testlog.Logger(t, log.LvlError),
 			RecheckInterval: 20 * time.Minute,
 			RateLimit:       500,
 		})
@@ -300,7 +300,7 @@ func TestIteratorLinkUpdates(t *testing.T) {
 		resolver = newMapResolver()
 		c        = NewClient(Config{
 			Resolver:        resolver,
-			Logger:          testlog.Logger(t, log.LvlError),
+			Log:             testlog.Logger(t, log.LvlError),
 			RecheckInterval: 20 * time.Minute,
 			RateLimit:       500,
 		})

--- a/p2p/nat/nat.go
+++ b/p2p/nat/nat.go
@@ -98,17 +98,17 @@ const (
 // Map adds a port mapping on m and keeps it alive until c is closed.
 // This function is typically invoked in its own goroutine.
 func Map(m Interface, c <-chan struct{}, protocol string, extport, intport int, name string) {
-	log := log.New("proto", protocol, "extport", extport, "intport", intport, "interface", m)
+	logger := log.New("proto", protocol, "extport", extport, "intport", intport, "interface", m)
 	refresh := time.NewTimer(mapTimeout)
 	defer func() {
 		refresh.Stop()
-		log.Trace("Deleting port mapping")
+		logger.Trace("Deleting port mapping")
 		m.DeleteMapping(protocol, extport, intport)
 	}()
 	if err := m.AddMapping(protocol, extport, intport, name, mapTimeout); err != nil {
-		log.Debug("Couldn't add port mapping", "err", err)
+		logger.Debug("Couldn't add port mapping", "err", err)
 	} else {
-		log.Info("Mapped network port")
+		logger.Info("Mapped network port")
 	}
 	for {
 		select {
@@ -117,9 +117,9 @@ func Map(m Interface, c <-chan struct{}, protocol string, extport, intport int, 
 				return
 			}
 		case <-refresh.C:
-			log.Trace("Refreshing port mapping")
+			logger.Trace("Refreshing port mapping")
 			if err := m.AddMapping(protocol, extport, intport, name, mapTimeout); err != nil {
-				log.Debug("Couldn't add port mapping", "err", err)
+				logger.Debug("Couldn't add port mapping", "err", err)
 			}
 			refresh.Reset(mapTimeout)
 		}

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -204,7 +204,7 @@ func (p *Peer) Inbound() bool {
 	return p.rw.is(inboundConn)
 }
 
-func newPeer(log log.Logger, conn *conn, protocols []Protocol) *Peer {
+func newPeer(logger log.Logger, conn *conn, protocols []Protocol) *Peer {
 	protomap := matchProtocols(protocols, conn.caps, conn)
 	p := &Peer{
 		rw:       conn,
@@ -213,7 +213,7 @@ func newPeer(log log.Logger, conn *conn, protocols []Protocol) *Peer {
 		disc:     make(chan DiscReason),
 		protoErr: make(chan error, len(protomap)+1), // protocols + pingLoop
 		closed:   make(chan struct{}),
-		log:      log.New("id", conn.node.ID(), "conn", conn.flags),
+		log:      logger.New("id", conn.node.ID(), "conn", conn.flags),
 	}
 	return p
 }

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -155,8 +155,8 @@ type Config struct {
 	// whenever a message is sent to or received from a peer
 	EnableMsgEvents bool
 
-	// Logger is a custom logger to use with the p2p.Server.
-	Logger log.Logger `toml:",omitempty"`
+	// Log is a custom logger to use with the p2p.Server.
+	Log log.Logger `toml:",omitempty"`
 
 	// it is actually used but a linter got confused
 	clock mclock.Clock //nolint:structcheck
@@ -459,7 +459,7 @@ func (srv *Server) Start() error {
 		return errors.New("server already running")
 	}
 
-	srv.log = srv.Config.Logger
+	srv.log = srv.Config.Log
 	if srv.log == nil {
 		srv.log = log.Root()
 	}
@@ -640,7 +640,7 @@ func (srv *Server) setupDialScheduler() {
 		self:           srv.localnode.ID(),
 		maxDialPeers:   srv.maxDialedConns(),
 		maxActiveDials: srv.MaxPendingPeers,
-		log:            srv.Logger,
+		log:            srv.Log,
 		netRestrict:    srv.NetRestrict,
 		dialer:         srv.Dialer,
 		clock:          srv.clock,

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -73,7 +73,7 @@ func startTestServer(t *testing.T, remoteKey *ecdsa.PublicKey, pf func(*Peer)) *
 		ListenAddr:  "127.0.0.1:0",
 		NoDiscovery: true,
 		PrivateKey:  newkey(),
-		Logger:      testlog.Logger(t, log.LvlError),
+		Log:         testlog.Logger(t, log.LvlError),
 	}
 	server := &Server{
 		Config:      config,
@@ -209,7 +209,7 @@ func TestServerRemovePeerDisconnect(t *testing.T) {
 		PrivateKey:  newkey(),
 		MaxPeers:    1,
 		NoDiscovery: true,
-		Logger:      testlog.Logger(t, log.LvlTrace).New("server", "1"),
+		Log:         testlog.Logger(t, log.LvlTrace).New("server", "1"),
 	}}
 	srv2 := &Server{Config: Config{
 		PrivateKey:  newkey(),
@@ -217,7 +217,7 @@ func TestServerRemovePeerDisconnect(t *testing.T) {
 		NoDiscovery: true,
 		NoDial:      true,
 		ListenAddr:  "127.0.0.1:0",
-		Logger:      testlog.Logger(t, log.LvlTrace).New("server", "2"),
+		Log:         testlog.Logger(t, log.LvlTrace).New("server", "2"),
 	}}
 	if err := srv1.Start(); err != nil {
 		t.Fatal("cant start srv1")
@@ -249,7 +249,7 @@ func TestServerAtCap(t *testing.T) {
 			NoDial:       true,
 			NoDiscovery:  true,
 			TrustedNodes: []*enode.Node{newNode(trustedID, "")},
-			Logger:       testlog.Logger(t, log.LvlTrace),
+			Log:          testlog.Logger(t, log.LvlTrace),
 		},
 	}
 	if err := srv.Start(); err != nil {
@@ -325,7 +325,7 @@ func TestServerPeerLimits(t *testing.T) {
 			NoDial:      true,
 			NoDiscovery: true,
 			Protocols:   []Protocol{discard},
-			Logger:      testlog.Logger(t, log.LvlTrace),
+			Log:         testlog.Logger(t, log.LvlTrace),
 		},
 		newTransport: func(fd net.Conn, dialDest *ecdsa.PublicKey) transport { return tp },
 	}
@@ -432,12 +432,12 @@ func TestServerSetupConn(t *testing.T) {
 				NoDial:      true,
 				NoDiscovery: true,
 				Protocols:   []Protocol{discard},
-				Logger:      testlog.Logger(t, log.LvlTrace),
+				Log:         testlog.Logger(t, log.LvlTrace),
 			}
 			srv := &Server{
 				Config:       cfg,
 				newTransport: func(fd net.Conn, dialDest *ecdsa.PublicKey) transport { return test.tt }, //nolint:scopelint
-				log:          cfg.Logger,
+				log:          cfg.Log,
 			}
 			if !test.dontstart {
 				if err := srv.Start(); err != nil {
@@ -519,7 +519,7 @@ func TestServerInboundThrottle(t *testing.T) {
 			NoDial:      true,
 			NoDiscovery: true,
 			Protocols:   []Protocol{discard},
-			Logger:      testlog.Logger(t, log.LvlTrace),
+			Log:         testlog.Logger(t, log.LvlTrace),
 		},
 		newTransport: func(fd net.Conn, dialDest *ecdsa.PublicKey) transport {
 			newTransportCalled <- struct{}{}

--- a/p2p/simulations/adapters/inproc.go
+++ b/p2p/simulations/adapters/inproc.go
@@ -101,7 +101,7 @@ func (s *SimAdapter) NewNode(config *NodeConfig) (Node, error) {
 			EnableMsgEvents: config.EnableMsgEvents,
 		},
 		// Convert node ID to string once, rather than for every log line
-		Logger: log.New("node.id", id.String()),
+		Log: log.New("node.id", id.String()),
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
* use "log" for struct fields
* use "logger" for function parameters and local vars

This is a compromise between:
1) using `logger := log.New()` to avoid aliasing (as in `log := log.New()`)
2) and keeping it short when logging e.g.: `srv.log.Info(...)`