### PR TITLE
Refactor payload building

### DIFF
--- a/cmd/rpcdaemon/commands/engine_api.go
+++ b/cmd/rpcdaemon/commands/engine_api.go
@@ -202,7 +202,9 @@ func (e *EngineImpl) GetPayloadV1(ctx context.Context, payloadID hexutil.Bytes) 
 	}, nil
 }
 
-// Gets a transistionConfiguration and pings the execution layer and checks if the execution layer has the correct configurations
+// Receives consensus layer's transition configuration and checks if the execution layer has the correct configuration.
+// Can also be used to ping the execution layer (heartbeats).
+// See https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.7/src/engine/specification.md#engine_exchangetransitionconfigurationv1
 func (e *EngineImpl) ExchangeTransitionConfigurationV1(ctx context.Context, beaconConfig TransitionConfiguration) (TransitionConfiguration, error) {
 	tx, err := e.db.BeginRo(ctx)
 

--- a/core/block_proposer.go
+++ b/core/block_proposer.go
@@ -1,0 +1,11 @@
+package core
+
+import "github.com/ledgerwatch/erigon/common"
+
+// See https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#payloadattributesv1
+type BlockProposerParametersPOS struct {
+	ParentHash            common.Hash
+	Timestamp             uint64
+	PrevRandao            common.Hash
+	SuggestedFeeRecipient common.Address
+}

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -958,6 +958,7 @@ func NewBlock(header *Header, txs []Transaction, uncles []*Header, receipts []*R
 
 	if len(receipts) == 0 {
 		b.header.ReceiptHash = EmptyRootHash
+		b.header.Bloom = Bloom{}
 	} else {
 		b.header.ReceiptHash = DeriveSha(Receipts(receipts))
 		b.header.Bloom = CreateBloom(receipts)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -395,16 +395,12 @@ func New(stack *node.Node, config *ethconfig.Config, txpoolCfg txpool2.Config, l
 		ethashApi = casted.APIs(nil)[1].Service.(*ethash.API)
 	}
 	// proof-of-stake mining
-	assembleBlockPOS := func(random common.Hash, suggestedFeeRecipient common.Address, timestamp uint64) (*types.Block, error) {
+	assembleBlockPOS := func(param *core.BlockProposerParametersPOS) (*types.Block, error) {
 		miningStatePos := stagedsync.NewMiningState(&config.Miner)
-		miningStatePos.MiningConfig.Etherbase = suggestedFeeRecipient
+		miningStatePos.MiningConfig.Etherbase = param.SuggestedFeeRecipient
 		proposingSync := stagedsync.New(
 			stagedsync.MiningStages(backend.sentryCtx,
-				stagedsync.StageMiningCreateBlockCfg(backend.chainDB, miningStatePos, *backend.chainConfig, backend.engine, backend.txPool2, backend.txPool2DB, &stagedsync.BlockProposerParametersPOS{
-					Random:                random,
-					SuggestedFeeRecipient: suggestedFeeRecipient,
-					Timestamp:             timestamp,
-				}, tmpdir),
+				stagedsync.StageMiningCreateBlockCfg(backend.chainDB, miningStatePos, *backend.chainConfig, backend.engine, backend.txPool2, backend.txPool2DB, param, tmpdir),
 				stagedsync.StageMiningExecCfg(backend.chainDB, miningStatePos, backend.notifications.Events, *backend.chainConfig, backend.engine, &vm.Config{}, tmpdir),
 				stagedsync.StageHashStateCfg(backend.chainDB, tmpdir),
 				stagedsync.StageTrieCfg(backend.chainDB, false, true, tmpdir, blockReader),

--- a/eth/stagedsync/stage_mining_create_block.go
+++ b/eth/stagedsync/stage_mining_create_block.go
@@ -97,11 +97,11 @@ func SpawnMiningCreateBlockStage(s *StageState, tx kv.RwTx, cfg MiningCreateBloc
 	}
 	parent := rawdb.ReadHeaderByNumber(tx, executionAt)
 	if parent == nil { // todo: how to return error and don't stop Erigon?
-		return fmt.Errorf(fmt.Sprintf("[%s] Empty block", logPrefix), "blocknum", executionAt)
+		return fmt.Errorf("empty block %d", executionAt)
 	}
 
 	if cfg.blockProposerParameters != nil && cfg.blockProposerParameters.ParentHash != parent.Hash() {
-		return fmt.Errorf(fmt.Sprintf("[%s] Wrong head block", logPrefix), "headBlock", parent.Hash(), "requested", cfg.blockProposerParameters.ParentHash)
+		return fmt.Errorf("wrong head block: %x (current) vs %x (requested)", parent.Hash(), cfg.blockProposerParameters.ParentHash)
 	}
 
 	isTrans, err := rawdb.Transitioned(tx, executionAt, cfg.chainConfig.TerminalTotalDifficulty)

--- a/ethdb/privateapi/ethbackend.go
+++ b/ethdb/privateapi/ethbackend.go
@@ -35,7 +35,7 @@ type assemblePayloadPOSFunc func(random common.Hash, suggestedFeeRecipient commo
 // 3.0.0 - adding PoS interfaces
 var EthBackendAPIVersion = &types2.VersionReply{Major: 3, Minor: 0, Patch: 0}
 
-const MaxPendingPayloads = 128
+const MaxPendingPayloads = 1024
 
 type EthBackendServer struct {
 	remote.UnimplementedETHBACKENDServer // must be embedded to have forward compatible implementations.

--- a/ethdb/privateapi/ethbackend.go
+++ b/ethdb/privateapi/ethbackend.go
@@ -249,7 +249,7 @@ func (s *EthBackendServer) stageLoopIsBusy() bool {
 			// and thus waitingForBeaconChain is not set yet.
 
 			// TODO(yperbasis): find a more elegant solution
-			time.Sleep(time.Millisecond)
+			time.Sleep(2 * time.Millisecond)
 		}
 	}
 	return atomic.LoadUint32(s.waitingForBeaconChain) == 0

--- a/ethdb/privateapi/ethbackend.go
+++ b/ethdb/privateapi/ethbackend.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/params"
 	"github.com/ledgerwatch/erigon/rlp"
+	"github.com/ledgerwatch/erigon/rpc"
 	"github.com/ledgerwatch/log/v3"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
@@ -36,6 +37,8 @@ type assemblePayloadPOSFunc func(random common.Hash, suggestedFeeRecipient commo
 var EthBackendAPIVersion = &types2.VersionReply{Major: 3, Minor: 0, Patch: 0}
 
 const MaxPendingPayloads = 1024
+
+var UnknownPayload = rpc.CustomError{Code: -32001, Message: "Unknown payload"}
 
 type EthBackendServer struct {
 	remote.UnimplementedETHBACKENDServer // must be embedded to have forward compatible implementations.
@@ -333,7 +336,7 @@ func (s *EthBackendServer) EngineGetPayloadV1(ctx context.Context, req *remote.E
 	for {
 		payload, ok := s.pendingPayloads[req.PayloadId]
 		if !ok {
-			return nil, fmt.Errorf("unknown payload")
+			return nil, &UnknownPayload
 		}
 
 		if payload.BlockNumber != 0 {

--- a/ethdb/privateapi/ethbackend.go
+++ b/ethdb/privateapi/ethbackend.go
@@ -522,7 +522,11 @@ func (s *EthBackendServer) StartProposer() {
 			if err != nil {
 				log.Warn("Error during block assembling", "err", err.Error())
 			} else {
-				s.pendingPayloads[payloadId] = &pendingPayload{block: block, built: true}
+				payload, ok := s.pendingPayloads[payloadId]
+				if ok && !payload.built { // don't update after engine_getPayload was called
+					payload.block = block
+					payload.built = true
+				}
 			}
 		}
 	}()

--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -25,6 +25,7 @@ var (
 	_ Error = new(invalidRequestError)
 	_ Error = new(invalidMessageError)
 	_ Error = new(invalidParamsError)
+	_ Error = new(CustomError)
 )
 
 const defaultErrorCode = -32000
@@ -72,3 +73,12 @@ type invalidParamsError struct{ message string }
 func (e *invalidParamsError) ErrorCode() int { return -32602 }
 
 func (e *invalidParamsError) Error() string { return e.message }
+
+type CustomError struct {
+	Code    int
+	Message string
+}
+
+func (e *CustomError) ErrorCode() int { return e.Code }
+
+func (e *CustomError) Error() string { return e.Message }


### PR DESCRIPTION
1. Ensure that, when we're building a payload, our current state matches `headBlockHash` of the corresponding `forkchoiceUpdated`.
2. Use empty (no txns) but valid blocks to initialize pending payloads. They serve as fallback in case we fail to actually build a block with transactions.
