### PR TITLE
Refactor node private key setup.

### DIFF
--- a/node/config.go
+++ b/node/config.go
@@ -17,7 +17,6 @@
 package node
 
 import (
-	"crypto/ecdsa"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -31,7 +30,6 @@ import (
 
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/common/paths"
-	"github.com/ledgerwatch/erigon/crypto"
 	"github.com/ledgerwatch/erigon/p2p"
 	"github.com/ledgerwatch/erigon/p2p/enode"
 	"github.com/ledgerwatch/erigon/rpc"
@@ -39,7 +37,6 @@ import (
 )
 
 const (
-	datadirPrivateKey   = "nodekey"            // Path within the datadir to the node's private key
 	datadirStaticNodes  = "static-nodes.json"  // Path within the datadir to the static node list
 	datadirTrustedNodes = "trusted-nodes.json" // Path within the datadir to the trusted node list
 	datadirNodeDatabase = "nodes"              // Path within the datadir to store the node infos
@@ -283,44 +280,6 @@ func (c *Config) ResolvePath(path string) string {
 		return ""
 	}
 	return filepath.Join(c.DataDir, path)
-}
-
-// NodeKey retrieves the currently configured private key of the node, checking
-// first any manually set key, falling back to the one found in the configured
-// data folder. If no key can be found, a new one is generated.
-func (c *Config) NodeKey() (*ecdsa.PrivateKey, error) {
-	// Use any specifically configured key.
-	if c.P2P.PrivateKey != nil {
-		return c.P2P.PrivateKey, nil
-	}
-	// Generate ephemeral key if no datadir is being used.
-	if c.DataDir == "" {
-		key, err := crypto.GenerateKey()
-		if err != nil {
-			return key, fmt.Errorf("failed to generate ephemeral node key: %w", err)
-		}
-		return key, nil
-	}
-
-	keyfile := c.ResolvePath(datadirPrivateKey)
-	if key, err := crypto.LoadECDSA(keyfile); err == nil {
-		return key, nil
-	}
-	// No persistent key found, generate and store a new one.
-	key, err := crypto.GenerateKey()
-	if err != nil {
-		log.Crit(fmt.Sprintf("Failed to generate node key: %v", err))
-	}
-	instanceDir := c.DataDir
-	if err := os.MkdirAll(instanceDir, 0700); err != nil {
-		log.Error(fmt.Sprintf("Failed to persist node key: %v", err))
-		return key, nil
-	}
-	keyfile = filepath.Join(instanceDir, datadirPrivateKey)
-	if err := crypto.SaveECDSA(keyfile, key); err != nil {
-		log.Error(fmt.Sprintf("Failed to persist node key: %v", err))
-	}
-	return key, nil
 }
 
 // StaticNodes returns a list of node enode URLs configured as static nodes.

--- a/p2p/node_key_config.go
+++ b/p2p/node_key_config.go
@@ -1,0 +1,81 @@
+package p2p
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"github.com/ledgerwatch/erigon/crypto"
+	"os"
+	"path"
+)
+
+type NodeKeyConfig struct {
+}
+
+func (config NodeKeyConfig) DefaultPath(datadir string) string {
+	return path.Join(datadir, "nodekey")
+}
+
+func (config NodeKeyConfig) generateKey() (*ecdsa.PrivateKey, error) {
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		err = fmt.Errorf("failed to generate node key: %w", err)
+	}
+	return key, err
+}
+
+func (config NodeKeyConfig) parseHex(hex string) (*ecdsa.PrivateKey, error) {
+	key, err := crypto.HexToECDSA(hex)
+	if err != nil {
+		err = fmt.Errorf("failed to parse node key from %s: %w", hex, err)
+	}
+	return key, err
+}
+
+func (config NodeKeyConfig) load(keyfile string) (*ecdsa.PrivateKey, error) {
+	key, err := crypto.LoadECDSA(keyfile)
+	if err != nil {
+		err = fmt.Errorf("failed to load node key from %s: %w", keyfile, err)
+	}
+	return key, err
+}
+
+func (config NodeKeyConfig) save(keyfile string, key *ecdsa.PrivateKey) error {
+	err := os.MkdirAll(path.Dir(keyfile), 0755)
+	if err != nil {
+		err = crypto.SaveECDSA(keyfile, key)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to save node key to %s: %w", keyfile, err)
+	}
+	return nil
+}
+
+func (config NodeKeyConfig) LoadOrGenerateAndSave(keyfile string) (*ecdsa.PrivateKey, error) {
+	// If file exists, try to load it.
+	if _, err := os.Stat(keyfile); err == nil {
+		return config.load(keyfile)
+	}
+
+	// No persistent key found, generate and store a new one.
+	key, err := config.generateKey()
+	if err != nil {
+		return nil, err
+	}
+	if err := config.save(keyfile, key); err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+func (config NodeKeyConfig) LoadOrParseOrGenerateAndSave(file, hex, datadir string) (*ecdsa.PrivateKey, error) {
+	switch {
+	case file != "" && hex != "":
+		return nil, fmt.Errorf("P2P node key is set as both file and hex string - these options are mutually exclusive")
+	case file != "":
+		return config.load(file)
+	case hex != "":
+		return config.parseHex(hex)
+	default:
+		return config.LoadOrGenerateAndSave(config.DefaultPath(datadir))
+	}
+}


### PR DESCRIPTION
Extract private key setup from the global config setup to make it reusable.
Return errors instead of panicing.

* NodeKey() method is removed - it is unused.