### PR TITLE
p2p: Disable port mapping task with --nat extip

### DIFF
--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -111,7 +111,7 @@ func main() {
 
 	realaddr := conn.LocalAddr().(*net.UDPAddr)
 	if natm != nil {
-		if !realaddr.IP.IsLoopback() {
+		if !realaddr.IP.IsLoopback() && natm.SupportsMapping() {
 			go nat.Map(natm, nil, "udp", realaddr.Port, realaddr.Port, "ethereum discovery")
 		}
 		if ext, err := natm.ExternalIP(); err == nil {

--- a/p2p/nat/natpmp.go
+++ b/p2p/nat/natpmp.go
@@ -63,6 +63,10 @@ func (n *pmp) DeleteMapping(protocol string, extport, intport int) (err error) {
 	return err
 }
 
+func (n *pmp) SupportsMapping() bool {
+	return true
+}
+
 func discoverPMP() Interface {
 	// run external address lookups on all potential gateways
 	gws := potentialGateways()

--- a/p2p/nat/natupnp.go
+++ b/p2p/nat/natupnp.go
@@ -123,6 +123,10 @@ func (n *upnp) DeleteMapping(protocol string, extport, intport int) error {
 	})
 }
 
+func (n *upnp) SupportsMapping() bool {
+	return true
+}
+
 func (n *upnp) String() string {
 	return "UPNP " + n.service
 }

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -581,7 +581,7 @@ func (srv *Server) setupDiscovery(ctx context.Context) error {
 	realaddr := conn.LocalAddr().(*net.UDPAddr)
 	srv.log.Trace("UDP listener up", "addr", realaddr)
 	if srv.NAT != nil {
-		if !realaddr.IP.IsLoopback() {
+		if !realaddr.IP.IsLoopback() && srv.NAT.SupportsMapping() {
 			srv.loopWG.Add(1)
 			go func() {
 				defer debug.LogPanic()
@@ -693,7 +693,7 @@ func (srv *Server) setupListening() error {
 	// Update the local node record and map the TCP listening port if NAT is configured.
 	if tcp, ok := listener.Addr().(*net.TCPAddr); ok {
 		srv.localnode.Set(enr.TCP(tcp.Port))
-		if !tcp.IP.IsLoopback() && srv.NAT != nil {
+		if !tcp.IP.IsLoopback() && (srv.NAT != nil) && srv.NAT.SupportsMapping() {
 			srv.loopWG.Add(1)
 			go func() {
 				defer debug.LogPanic()


### PR DESCRIPTION
If --nat extip:1.2.3.4 option is specified, the port mapping logic
(AddMapping/DeleteMapping) does nothing.
This optimization avoids running a goroutine for doing nothing.