### PR TITLE
Fix lint: remove unused findAndMergeBlockSegments log level parameter.

### DIFF
--- a/turbo/snapshotsync/block_snapshots.go
+++ b/turbo/snapshotsync/block_snapshots.go
@@ -608,7 +608,7 @@ func RetireBlocks(ctx context.Context, blockFrom, blockTo uint64, chainID uint25
 	if err := snapshots.ReopenSegments(); err != nil {
 		return fmt.Errorf("ReopenSegments: %w", err)
 	}
-	mergedFrom, err := findAndMergeBlockSegments(ctx, snapshots, tmpDir, workers, lvl)
+	mergedFrom, err := findAndMergeBlockSegments(ctx, snapshots, tmpDir, workers)
 	if err != nil {
 		return fmt.Errorf("findAndMergeBlockSegments: %w", err)
 	}
@@ -622,7 +622,7 @@ func RetireBlocks(ctx context.Context, blockFrom, blockTo uint64, chainID uint25
 	return nil
 }
 
-func findAndMergeBlockSegments(ctx context.Context, snapshots *RoSnapshots, tmpDir string, workers int, lvl log.Lvl) (uint64, error) {
+func findAndMergeBlockSegments(ctx context.Context, snapshots *RoSnapshots, tmpDir string, workers int) (uint64, error) {
 	var toMergeBodies, toMergeHeaders, toMergeTxs []string
 	var from, to, stopAt uint64
 	// merge segments


### PR DESCRIPTION
Fixes lint errors:
turbo/snapshotsync/block_snapshots_test.go:77:69: not enough arguments in call to findAndMergeBlockSegments (typecheck)
	_, err := findAndMergeBlockSegments(context.Background(), s, dir, 1)
turbo/snapshotsync/block_snapshots_test.go:88:68: not enough arguments in call to findAndMergeBlockSegments (typecheck)
	_, err = findAndMergeBlockSegments(context.Background(), s, dir, 1)