### PR TITLE
Use "err" key for logging errors.

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -169,7 +169,7 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 	for i, txn := range txs {
 		msg, err := txn.AsMessage(*signer, pre.Env.BaseFee)
 		if err != nil {
-			log.Warn("rejected txn", "index", i, "hash", txn.Hash(), "error", err)
+			log.Warn("rejected txn", "index", i, "hash", txn.Hash(), "err", err)
 			rejectedTxs = append(rejectedTxs, &rejectedTx{i, err.Error()})
 			continue
 		}
@@ -188,7 +188,7 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 		msgResult, err := core.ApplyMessage(evm, msg, gaspool, true /* refunds */, false /* gasBailout */)
 		if err != nil {
 			ibs.RevertToSnapshot(snapshot)
-			log.Info("rejected txn", "index", i, "hash", txn.Hash(), "from", msg.From(), "error", err)
+			log.Info("rejected txn", "index", i, "hash", txn.Hash(), "from", msg.From(), "err", err)
 			rejectedTxs = append(rejectedTxs, &rejectedTx{i, err.Error()})
 			continue
 		}

--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -2521,11 +2521,11 @@ func main() {
 	if *cpuprofile != "" {
 		f, err := os.Create(*cpuprofile)
 		if err != nil {
-			log.Error("could not create CPU profile", "error", err)
+			log.Error("could not create CPU profile", "err", err)
 			return
 		}
 		if err := pprof.StartCPUProfile(f); err != nil {
-			log.Error("could not start CPU profile", "error", err)
+			log.Error("could not start CPU profile", "err", err)
 			return
 		}
 		defer pprof.StopCPUProfile()

--- a/cmd/rpcdaemon/health/health.go
+++ b/cmd/rpcdaemon/health/health.go
@@ -44,7 +44,7 @@ func ProcessHealthcheckIfNeeded(
 	defer r.Body.Close()
 
 	if errParse != nil {
-		log.Root().Warn("unable to process healthcheck request", "error", errParse)
+		log.Root().Warn("unable to process healthcheck request", "err", errParse)
 	} else {
 		// 1. net_peerCount
 		if body.MinPeerCount != nil {
@@ -59,7 +59,7 @@ func ProcessHealthcheckIfNeeded(
 
 	err := reportHealth(errParse, errMinPeerCount, errCheckBlock, w)
 	if err != nil {
-		log.Root().Warn("unable to process healthcheck request", "error", err)
+		log.Root().Warn("unable to process healthcheck request", "err", err)
 	}
 
 	return true

--- a/cmd/rpcdaemon/main.go
+++ b/cmd/rpcdaemon/main.go
@@ -18,7 +18,7 @@ func main() {
 		logger := log.New()
 		db, borDb, backend, txPool, mining, starknet, stateCache, blockReader, ff, err := cli.RemoteServices(ctx, *cfg, logger, rootCancel)
 		if err != nil {
-			log.Error("Could not connect to DB", "error", err)
+			log.Error("Could not connect to DB", "err", err)
 			return nil
 		}
 		defer db.Close()

--- a/cmd/rpcdaemon/services/eth_backend.go
+++ b/cmd/rpcdaemon/services/eth_backend.go
@@ -61,7 +61,7 @@ func (back *RemoteBackend) EnsureVersionCompatibility() bool {
 	versionReply, err := back.remoteEthBackend.Version(context.Background(), &emptypb.Empty{}, grpc.WaitForReady(true))
 	if err != nil {
 
-		back.log.Error("getting Version", "error", err)
+		back.log.Error("getting Version", "err", err)
 		return false
 	}
 	if !gointerfaces.EnsureVersion(back.version, versionReply) {

--- a/cmd/rpcdaemon/services/eth_mining.go
+++ b/cmd/rpcdaemon/services/eth_mining.go
@@ -29,7 +29,7 @@ func NewMiningService(client txpool.MiningClient) *MiningService {
 func (s *MiningService) EnsureVersionCompatibility() bool {
 	versionReply, err := s.Version(context.Background(), &emptypb.Empty{}, grpc.WaitForReady(true))
 	if err != nil {
-		s.log.Error("getting Version", "error", err)
+		s.log.Error("getting Version", "err", err)
 		return false
 	}
 	if !gointerfaces.EnsureVersion(s.version, versionReply) {

--- a/cmd/rpcdaemon/services/eth_txpool.go
+++ b/cmd/rpcdaemon/services/eth_txpool.go
@@ -37,7 +37,7 @@ Start:
 			time.Sleep(3 * time.Second)
 			goto Start
 		}
-		s.log.Error("ensure version", "error", err)
+		s.log.Error("ensure version", "err", err)
 		return false
 	}
 	if !gointerfaces.EnsureVersion(s.version, versionReply) {

--- a/cmd/sentry/sentry/broadcast.go
+++ b/cmd/sentry/sentry/broadcast.go
@@ -37,7 +37,7 @@ func (cs *ControlServerImpl) PropagateNewBlockHashes(ctx context.Context, announ
 	}
 	data, err := rlp.EncodeToBytes(&typedRequest)
 	if err != nil {
-		log.Error("propagateNewBlockHashes", "error", err)
+		log.Error("propagateNewBlockHashes", "err", err)
 		return
 	}
 	var req66 *proto_sentry.OutboundMessageData
@@ -57,7 +57,7 @@ func (cs *ControlServerImpl) PropagateNewBlockHashes(ctx context.Context, announ
 
 				_, err = sentry.SendMessageToAll(ctx, req66, &grpc.EmptyCallOption{})
 				if err != nil {
-					log.Error("propagateNewBlockHashes", "error", err)
+					log.Error("propagateNewBlockHashes", "err", err)
 				}
 			}
 		default:
@@ -74,7 +74,7 @@ func (cs *ControlServerImpl) BroadcastNewBlock(ctx context.Context, block *types
 		TD:    td,
 	})
 	if err != nil {
-		log.Error("broadcastNewBlock", "error", err)
+		log.Error("broadcastNewBlock", "err", err)
 	}
 	var req66 *proto_sentry.SendMessageToRandomPeersRequest
 	for _, sentry := range cs.sentries {
@@ -96,10 +96,10 @@ func (cs *ControlServerImpl) BroadcastNewBlock(ctx context.Context, block *types
 			}
 			if _, err = sentry.SendMessageToRandomPeers(ctx, req66, &grpc.EmptyCallOption{}); err != nil {
 				if isPeerNotFoundErr(err) || networkTemporaryErr(err) {
-					log.Debug("broadcastNewBlock", "error", err)
+					log.Debug("broadcastNewBlock", "err", err)
 					continue
 				}
-				log.Error("broadcastNewBlock", "error", err)
+				log.Error("broadcastNewBlock", "err", err)
 			}
 		}
 	}
@@ -128,7 +128,7 @@ func (cs *ControlServerImpl) BroadcastLocalPooledTxs(ctx context.Context, txs []
 
 		data, err := rlp.EncodeToBytes(eth.NewPooledTransactionHashesPacket(pending))
 		if err != nil {
-			log.Error("BroadcastLocalPooledTxs", "error", err)
+			log.Error("BroadcastLocalPooledTxs", "err", err)
 		}
 		var req66 *proto_sentry.OutboundMessageData
 		for _, sentry := range cs.sentries {
@@ -147,10 +147,10 @@ func (cs *ControlServerImpl) BroadcastLocalPooledTxs(ctx context.Context, txs []
 				peers, err := sentry.SendMessageToAll(ctx, req66, &grpc.EmptyCallOption{})
 				if err != nil {
 					if isPeerNotFoundErr(err) || networkTemporaryErr(err) {
-						log.Debug("BroadcastLocalPooledTxs", "error", err)
+						log.Debug("BroadcastLocalPooledTxs", "err", err)
 						continue
 					}
-					log.Error("BroadcastLocalPooledTxs", "error", err)
+					log.Error("BroadcastLocalPooledTxs", "err", err)
 				}
 				avgPeersPerSent66 += len(peers.GetPeers())
 			}
@@ -182,7 +182,7 @@ func (cs *ControlServerImpl) BroadcastRemotePooledTxs(ctx context.Context, txs [
 
 		data, err := rlp.EncodeToBytes(eth.NewPooledTransactionHashesPacket(pending))
 		if err != nil {
-			log.Error("BroadcastRemotePooledTxs", "error", err)
+			log.Error("BroadcastRemotePooledTxs", "err", err)
 		}
 		var req66 *proto_sentry.SendMessageToRandomPeersRequest
 		for _, sentry := range cs.sentries {
@@ -204,10 +204,10 @@ func (cs *ControlServerImpl) BroadcastRemotePooledTxs(ctx context.Context, txs [
 				}
 				if _, err = sentry.SendMessageToRandomPeers(ctx, req66, &grpc.EmptyCallOption{}); err != nil {
 					if isPeerNotFoundErr(err) || networkTemporaryErr(err) {
-						log.Debug("BroadcastRemotePooledTxs", "error", err)
+						log.Debug("BroadcastRemotePooledTxs", "err", err)
 						continue
 					}
-					log.Error("BroadcastRemotePooledTxs", "error", err)
+					log.Error("BroadcastRemotePooledTxs", "err", err)
 				}
 			}
 		}
@@ -233,7 +233,7 @@ func (cs *ControlServerImpl) PropagatePooledTxsToPeersList(ctx context.Context, 
 
 		data, err := rlp.EncodeToBytes(eth.NewPooledTransactionHashesPacket(pending))
 		if err != nil {
-			log.Error("PropagatePooledTxsToPeersList", "error", err)
+			log.Error("PropagatePooledTxsToPeersList", "err", err)
 		}
 		for _, sentry := range cs.sentries {
 			if !sentry.Ready() {
@@ -253,10 +253,10 @@ func (cs *ControlServerImpl) PropagatePooledTxsToPeersList(ctx context.Context, 
 					}
 					if _, err = sentry.SendMessageById(ctx, req66, &grpc.EmptyCallOption{}); err != nil {
 						if isPeerNotFoundErr(err) || networkTemporaryErr(err) {
-							log.Debug("PropagatePooledTxsToPeersList", "error", err)
+							log.Debug("PropagatePooledTxsToPeersList", "err", err)
 							continue
 						}
-						log.Error("PropagatePooledTxsToPeersList", "error", err)
+						log.Error("PropagatePooledTxsToPeersList", "err", err)
 					}
 				}
 			}

--- a/cmd/sentry/sentry/downloader.go
+++ b/cmd/sentry/sentry/downloader.go
@@ -117,7 +117,7 @@ func RecvUploadMessage(ctx context.Context,
 			return
 		}
 		if err = handleInboundMessage(ctx, req, sentry); err != nil {
-			log.Debug("[RecvUploadMessage]: Handling incoming message", "error", err)
+			log.Debug("[RecvUploadMessage]: Handling incoming message", "err", err)
 
 		}
 		if wg != nil {
@@ -204,7 +204,7 @@ func RecvUploadHeadersMessage(ctx context.Context,
 			return
 		}
 		if err = handleInboundMessage(ctx, req, sentry); err != nil {
-			log.Debug("[RecvUploadHeadersMessage] Handling incoming message", "error", err)
+			log.Debug("[RecvUploadHeadersMessage] Handling incoming message", "err", err)
 		}
 		if wg != nil {
 			wg.Done()
@@ -301,7 +301,7 @@ func RecvMessage(
 
 		if err = handleInboundMessage(ctx, req, sentry); err != nil {
 			if rlp.IsInvalidRLPError(err) {
-				log.Debug("[RecvMessage] Kick peer for invalid RLP", "error", err)
+				log.Debug("[RecvMessage] Kick peer for invalid RLP", "err", err)
 				outreq := proto_sentry.PenalizePeerRequest{
 					PeerId:  req.PeerId,
 					Penalty: proto_sentry.PenaltyKind_Kick, // TODO: Extend penalty kinds
@@ -310,7 +310,7 @@ func RecvMessage(
 					log.Error("Could not send penalty", "err", err1)
 				}
 			} else {
-				log.Warn("[RecvMessage] Handling incoming message", "error", err)
+				log.Warn("[RecvMessage] Handling incoming message", "err", err)
 			}
 		}
 

--- a/cmd/sentry/sentry/sentry.go
+++ b/cmd/sentry/sentry/sentry.go
@@ -950,7 +950,7 @@ func (ss *SentryServerImpl) hasSubscribers(msgID proto_sentry.MessageId) bool {
 	ss.messageStreamsLock.RLock()
 	defer ss.messageStreamsLock.RUnlock()
 	return ss.messageStreams[msgID] != nil && len(ss.messageStreams[msgID]) > 0
-	//	log.Error("Sending msg to core P2P failed", "msg", proto_sentry.MessageId_name[int32(streamMsg.msgId)], "error", err)
+	//	log.Error("Sending msg to core P2P failed", "msg", proto_sentry.MessageId_name[int32(streamMsg.msgId)], "err", err)
 }
 
 func (ss *SentryServerImpl) addMessagesStream(ids []proto_sentry.MessageId, ch chan *proto_sentry.InboundMessage) func() {
@@ -996,7 +996,7 @@ func (ss *SentryServerImpl) Messages(req *proto_sentry.MessagesRequest, server p
 			return nil
 		case in := <-ch:
 			if err := server.Send(in); err != nil {
-				log.Warn("Sending msg to core P2P failed", "msg", in.Id.String(), "error", err)
+				log.Warn("Sending msg to core P2P failed", "msg", in.Id.String(), "err", err)
 				return err
 			}
 		}
@@ -1012,13 +1012,13 @@ func (ss *SentryServerImpl) Close() {
 
 func (ss *SentryServerImpl) sendNewPeerToClients(peerID *proto_types.H256) {
 	if err := ss.peersStreams.Broadcast(&proto_sentry.PeersReply{PeerId: peerID, Event: proto_sentry.PeersReply_Connect}); err != nil {
-		log.Warn("Sending new peer notice to core P2P failed", "error", err)
+		log.Warn("Sending new peer notice to core P2P failed", "err", err)
 	}
 }
 
 func (ss *SentryServerImpl) sendGonePeerToClients(peerID *proto_types.H256) {
 	if err := ss.peersStreams.Broadcast(&proto_sentry.PeersReply{PeerId: peerID, Event: proto_sentry.PeersReply_Disconnect}); err != nil {
-		log.Warn("Sending gone peer notice to core P2P failed", "error", err)
+		log.Warn("Sending gone peer notice to core P2P failed", "err", err)
 	}
 }
 

--- a/cmd/sentry/sentry/sentry_api.go
+++ b/cmd/sentry/sentry/sentry_api.go
@@ -32,7 +32,7 @@ func (cs *ControlServerImpl) UpdateHead(ctx context.Context, height uint64, hash
 		}
 
 		if _, err := sentry.SetStatus(ctx, statusMsg, &grpc.EmptyCallOption{}); err != nil {
-			log.Error("Update status message for the sentry", "error", err)
+			log.Error("Update status message for the sentry", "err", err)
 		}
 	}
 }

--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -701,7 +701,7 @@ func (c *Bor) Finalize(config *params.ChainConfig, header *types.Header, state *
 		cx := chainContext{Chain: chain, Bor: c}
 		// check and commit span
 		if err := c.checkAndCommitSpan(state, header, cx, syscall); err != nil {
-			log.Error("Error while committing span", "error", err)
+			log.Error("Error while committing span", "err", err)
 			return nil, types.Receipts{}, err
 		}
 
@@ -709,14 +709,14 @@ func (c *Bor) Finalize(config *params.ChainConfig, header *types.Header, state *
 			// commit states
 			_, err = c.CommitStates(state, header, cx, syscall)
 			if err != nil {
-				log.Error("Error while committing states", "error", err)
+				log.Error("Error while committing states", "err", err)
 				return nil, types.Receipts{}, err
 			}
 		}
 	}
 
 	if err = c.changeContractCodeIfNeeded(headerNumber, state); err != nil {
-		log.Error("Error changing contract code", "error", err)
+		log.Error("Error changing contract code", "err", err)
 		return nil, types.Receipts{}, err
 	}
 
@@ -771,7 +771,7 @@ func (c *Bor) FinalizeAndAssemble(chainConfig *params.ChainConfig, header *types
 		// check and commit span
 		err := c.checkAndCommitSpan(state, header, cx, syscall)
 		if err != nil {
-			log.Error("Error while committing span", "error", err)
+			log.Error("Error while committing span", "err", err)
 			return nil, nil, types.Receipts{}, err
 		}
 
@@ -779,14 +779,14 @@ func (c *Bor) FinalizeAndAssemble(chainConfig *params.ChainConfig, header *types
 			// commit states
 			_, err = c.CommitStates(state, header, cx, syscall)
 			if err != nil {
-				log.Error("Error while committing states", "error", err)
+				log.Error("Error while committing states", "err", err)
 				return nil, nil, types.Receipts{}, err
 			}
 		}
 	}
 
 	if err := c.changeContractCodeIfNeeded(headerNumber, state); err != nil {
-		log.Error("Error changing contract code", "error", err)
+		log.Error("Error changing contract code", "err", err)
 		return nil, nil, types.Receipts{}, err
 	}
 
@@ -950,7 +950,7 @@ func (c *Bor) GetCurrentSpan(header *types.Header, state *state.IntraBlockState,
 	method := "getCurrentSpan"
 	data, err := c.validatorSetABI.Pack(method)
 	if err != nil {
-		log.Error("Unable to pack tx for getCurrentSpan", "error", err)
+		log.Error("Unable to pack tx for getCurrentSpan", "err", err)
 		return nil, err
 	}
 
@@ -1146,7 +1146,7 @@ func (c *Bor) fetchAndCommitSpan(
 		producerBytes,
 	)
 	if err != nil {
-		log.Error("Unable to pack tx for commitSpan", "error", err)
+		log.Error("Unable to pack tx for commitSpan", "err", err)
 		return err
 	}
 

--- a/consensus/bor/genesis_contracts_client.go
+++ b/consensus/bor/genesis_contracts_client.go
@@ -58,7 +58,7 @@ func (gc *GenesisContractsClient) CommitState(
 	t := event.Time.Unix()
 	data, err := gc.stateReceiverABI.Pack(method, big.NewInt(0).SetInt64(t), recordBytes)
 	if err != nil {
-		log.Error("Unable to pack tx for commitState", "error", err)
+		log.Error("Unable to pack tx for commitState", "err", err)
 		return err
 	}
 	log.Trace("→ committing new state", "eventRecord", event.String())
@@ -78,7 +78,7 @@ func (gc *GenesisContractsClient) LastStateId(header *types.Header,
 	method := "lastStateId"
 	data, err := gc.stateReceiverABI.Pack(method)
 	if err != nil {
-		log.Error("Unable to pack tx for LastStateId", "error", err)
+		log.Error("Unable to pack tx for LastStateId", "err", err)
 		return nil, err
 	}
 

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -224,12 +224,12 @@ func New(cfg *params.ChainConfig, snapshotConfig *params.ConsensusSnapshotConfig
 	snapNum, err := lastSnapshot(cliqueDB)
 	if err != nil {
 		if !errors.Is(err, ErrNotFound) {
-			log.Error("on Clique init while getting latest snapshot", "error", err)
+			log.Error("on Clique init while getting latest snapshot", "err", err)
 		}
 	} else {
 		snaps, err := c.snapshots(snapNum, warmupCacheSnapshots)
 		if err != nil {
-			log.Error("on Clique init", "error", err)
+			log.Error("on Clique init", "err", err)
 		}
 
 		for _, sn := range snaps {

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -985,7 +985,7 @@ func (p *Parlia) getCurrentValidators(header *types.Header, ibs *state.IntraBloc
 	method := "getValidators"
 	data, err := p.validatorSetABI.Pack(method)
 	if err != nil {
-		log.Error("Unable to pack tx for getValidators", "error", err)
+		log.Error("Unable to pack tx for getValidators", "err", err)
 		return nil, err
 	}
 	// call
@@ -1060,7 +1060,7 @@ func (p *Parlia) slash(spoiledVal common.Address, state *state.IntraBlockState, 
 		spoiledVal,
 	)
 	if err != nil {
-		log.Error("Unable to pack tx for slash", "error", err)
+		log.Error("Unable to pack tx for slash", "err", err)
 		return nil, nil, nil, err
 	}
 	// apply message
@@ -1087,7 +1087,7 @@ func (p *Parlia) initContract(state *state.IntraBlockState, header *types.Header
 	// get packed data
 	data, err := p.validatorSetABI.Pack(method)
 	if err != nil {
-		log.Error("Unable to pack tx for init validator set", "error", err)
+		log.Error("Unable to pack tx for init validator set", "err", err)
 		return nil, nil, nil, err
 	}
 	for _, c := range contracts {
@@ -1124,7 +1124,7 @@ func (p *Parlia) distributeToValidator(amount *uint256.Int, validator common.Add
 		validator,
 	)
 	if err != nil {
-		log.Error("Unable to pack tx for deposit", "error", err)
+		log.Error("Unable to pack tx for deposit", "err", err)
 		return nil, nil, nil, err
 	}
 	// apply message

--- a/core/state/plain_readonly.go
+++ b/core/state/plain_readonly.go
@@ -86,7 +86,7 @@ func (s *PlainState) ForEachStorage(addr common.Address, startLocation common.Ha
 	}
 	var acc accounts.Account
 	if err := acc.DecodeForStorage(accData); err != nil {
-		log.Error("Error decoding account", "error", err)
+		log.Error("Error decoding account", "err", err)
 		return err
 	}
 	binary.BigEndian.PutUint64(k[common.AddressLength:], acc.Incarnation)

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -114,7 +114,7 @@ func NewEVMInterpreter(evm *EVM, cfg Config) *EVMInterpreter {
 			if err := EnableEIP(eip, jt); err != nil {
 				// Disable it, so caller can check if it's activated or not
 				cfg.ExtraEips = append(cfg.ExtraEips[:i], cfg.ExtraEips[i+1:]...)
-				log.Error("EIP activation failed", "eip", eip, "error", err)
+				log.Error("EIP activation failed", "eip", eip, "err", err)
 			}
 		}
 	}
@@ -155,7 +155,7 @@ func NewEVMInterpreterByVM(vm *VM) *EVMInterpreter {
 			if err := EnableEIP(eip, jt); err != nil {
 				// Disable it, so caller can check if it's activated or not
 				vm.cfg.ExtraEips = append(vm.cfg.ExtraEips[:i], vm.cfg.ExtraEips[i+1:]...)
-				log.Error("EIP activation failed", "eip", eip, "error", err)
+				log.Error("EIP activation failed", "eip", eip, "err", err)
 			}
 		}
 	}

--- a/eth/calltracer/calltracer.go
+++ b/eth/calltracer/calltracer.go
@@ -45,7 +45,7 @@ func (ct *CallTracer) CaptureStart(evm *vm.EVM, depth int, from common.Address, 
 			}
 
 			if err != nil {
-				log.Warn("while CaptureStart", "error", err)
+				log.Warn("while CaptureStart", "err", err)
 			}
 		}
 	}

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -214,12 +214,12 @@ func (gpo *Oracle) getBlockPrices(ctx context.Context, blockNum uint64, limit in
 	ignoreUnder, overflow := uint256.FromBig(ingoreUnderBig)
 	if overflow {
 		err := errors.New("overflow in getBlockPrices, gasprice.go: ignoreUnder too large")
-		log.Error("gasprice.go: getBlockPrices", "error", err)
+		log.Error("gasprice.go: getBlockPrices", "err", err)
 		return err
 	}
 	block, err := gpo.backend.BlockByNumber(ctx, rpc.BlockNumber(blockNum))
 	if block == nil {
-		log.Error("gasprice.go: getBlockPrices", "error", err)
+		log.Error("gasprice.go: getBlockPrices", "err", err)
 		return err
 	}
 	blockTxs := block.Transactions()
@@ -232,7 +232,7 @@ func (gpo *Oracle) getBlockPrices(ctx context.Context, blockNum uint64, limit in
 		baseFee, overflow = uint256.FromBig(block.BaseFee())
 		if overflow {
 			err := errors.New("overflow in getBlockPrices, gasprice.go: baseFee > 2^256-1")
-			log.Error("gasprice.go: getBlockPrices", "error", err)
+			log.Error("gasprice.go: getBlockPrices", "err", err)
 			return err
 		}
 	}

--- a/eth/stagedsync/stage_bodies.go
+++ b/eth/stagedsync/stage_bodies.go
@@ -182,7 +182,7 @@ Loop:
 			blockHeight := header.Number.Uint64()
 			_, err := cfg.bd.VerifyUncles(header, rawBody.Uncles, cr)
 			if err != nil {
-				log.Error(fmt.Sprintf("[%s] Uncle verification failed", logPrefix), "number", blockHeight, "hash", header.Hash().String(), "error", err)
+				log.Error(fmt.Sprintf("[%s] Uncle verification failed", logPrefix), "number", blockHeight, "hash", header.Hash().String(), "err", err)
 				u.UnwindTo(blockHeight-1, header.Hash())
 				break Loop
 			}

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -272,7 +272,7 @@ Loop:
 		writeReceipts := nextStagesExpectData || blockNum > cfg.prune.Receipts.PruneTo(to)
 		writeCallTraces := nextStagesExpectData || blockNum > cfg.prune.CallTraces.PruneTo(to)
 		if err = executeBlock(block, tx, batch, cfg, *cfg.vmConfig, writeChangeSets, writeReceipts, writeCallTraces, contractHasTEVM, initialCycle); err != nil {
-			log.Error(fmt.Sprintf("[%s] Execution failed", logPrefix), "block", blockNum, "hash", block.Hash().String(), "error", err)
+			log.Error(fmt.Sprintf("[%s] Execution failed", logPrefix), "block", blockNum, "hash", block.Hash().String(), "err", err)
 			u.UnwindTo(blockNum-1, block.Hash())
 			break Loop
 		}

--- a/eth/stagedsync/stage_finish.go
+++ b/eth/stagedsync/stage_finish.go
@@ -135,7 +135,7 @@ func NotifyNewHeaders(ctx context.Context, finishStageBeforeSync uint64, finishS
 		headersRlp = append(headersRlp, common2.CopyBytes(headerRLP))
 		return libcommon.Stopped(ctx.Done())
 	}); err != nil {
-		log.Error("RPC Daemon notification failed", "error", err)
+		log.Error("RPC Daemon notification failed", "err", err)
 		return err
 	}
 	notifier.OnNewHeader(headersRlp)

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -360,7 +360,7 @@ func handleNewPayload(
 		}
 
 		if verificationErr := cfg.hd.VerifyHeader(header); verificationErr != nil {
-			log.Warn("Verification failed for header", "hash", headerHash, "height", headerNumber, "error", verificationErr)
+			log.Warn("Verification failed for header", "hash", headerHash, "height", headerNumber, "err", verificationErr)
 			return nil
 		}
 
@@ -389,7 +389,7 @@ func verifyAndSaveNewPoSHeader(
 	headerHash := header.Hash()
 
 	if verificationErr := cfg.hd.VerifyHeader(header); verificationErr != nil {
-		log.Warn("Verification failed for header", "hash", headerHash, "height", headerNumber, "error", verificationErr)
+		log.Warn("Verification failed for header", "hash", headerHash, "height", headerNumber, "err", verificationErr)
 		cfg.hd.PayloadStatusCh <- privateapi.PayloadStatus{
 			Status:          remote.EngineStatus_INVALID,
 			LatestValidHash: header.ParentHash,
@@ -519,7 +519,7 @@ func downloadMissingPoSHeaders(
 			return err
 		}
 		if err := cfg.hd.VerifyHeader(&h); err != nil {
-			log.Warn("Verification failed for header", "hash", h.Hash(), "height", h.Number.Uint64(), "error", err)
+			log.Warn("Verification failed for header", "hash", h.Hash(), "height", h.Number.Uint64(), "err", err)
 			return err
 		}
 		return headerInserter.FeedHeaderPoS(tx, &h, h.Hash())

--- a/internal/debug/flags.go
+++ b/internal/debug/flags.go
@@ -265,10 +265,10 @@ func Exit() {
 func RaiseFdLimit() {
 	limit, err := fdlimit.Maximum()
 	if err != nil {
-		log.Error("Failed to retrieve file descriptor allowance", "error", err)
+		log.Error("Failed to retrieve file descriptor allowance", "err", err)
 		return
 	}
 	if _, err = fdlimit.Raise(uint64(limit)); err != nil {
-		log.Error("Failed to raise file descriptor allowance", "error", err)
+		log.Error("Failed to raise file descriptor allowance", "err", err)
 	}
 }

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -140,12 +140,12 @@ func ruleAllowsOrigin(allowedOrigin string, browserOrigin string) bool {
 	)
 	allowedScheme, allowedHostname, allowedPort, err = parseOriginURL(allowedOrigin)
 	if err != nil {
-		log.Warn("Error parsing allowed origin specification", "spec", allowedOrigin, "error", err)
+		log.Warn("Error parsing allowed origin specification", "spec", allowedOrigin, "err", err)
 		return false
 	}
 	browserScheme, browserHostname, browserPort, err = parseOriginURL(browserOrigin)
 	if err != nil {
-		log.Warn("Error parsing browser 'Origin' field", "Origin", browserOrigin, "error", err)
+		log.Warn("Error parsing browser 'Origin' field", "Origin", browserOrigin, "err", err)
 		return false
 	}
 	if allowedScheme != "" && allowedScheme != browserScheme {

--- a/turbo/cli/flags.go
+++ b/turbo/cli/flags.go
@@ -208,7 +208,7 @@ func ApplyFlagsForEthConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 	if ctx.GlobalString(BadBlockFlag.Name) != "" {
 		bytes, err := hexutil.Decode(ctx.GlobalString(BadBlockFlag.Name))
 		if err != nil {
-			log.Warn("Error decoding block hash", "hash", ctx.GlobalString(BadBlockFlag.Name), "error", err)
+			log.Warn("Error decoding block hash", "hash", ctx.GlobalString(BadBlockFlag.Name), "err", err)
 		} else {
 			cfg.BadBlockHash = common.BytesToHash(bytes)
 		}

--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -716,7 +716,7 @@ func (hd *HeaderDownload) InsertHeaders(hf FeedHeaderFunc, terminalTotalDifficul
 							log.Warn("Added future link", "hash", link.hash, "height", link.blockHeight, "timestamp", link.header.Time)
 							break // prevent removal of the link from the hd.linkQueue
 						} else {
-							log.Warn("Verification failed for header", "hash", link.hash, "height", link.blockHeight, "error", err)
+							log.Warn("Verification failed for header", "hash", link.hash, "height", link.blockHeight, "err", err)
 							skip = true
 						}
 					}

--- a/turbo/stages/stageloop.go
+++ b/turbo/stages/stageloop.go
@@ -82,9 +82,9 @@ func StageLoop(
 				return
 			}
 
-			log.Error("Staged Sync", "error", err)
+			log.Error("Staged Sync", "err", err)
 			if recoveryErr := hd.RecoverFromDb(db); recoveryErr != nil {
-				log.Error("Failed to recover header downloader", "error", recoveryErr)
+				log.Error("Failed to recover header downloader", "err", recoveryErr)
 			}
 			continue
 		}


### PR DESCRIPTION
log.Warn/Error uses "err" key to log errors in most places.
This renames "error" to "err" in some places to adhere to this convention.