### PR TITLE
Expose eth API on the same ports as engine API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN chown -R erigon:erigon /home/erigon
 
 USER erigon
 
-EXPOSE 8545 8550 8546 30303 30303/udp 30304 30304/udp 8080 9090 6060
+EXPOSE 8545 8550 8551 8546 30303 30303/udp 30304 30304/udp 8080 9090 6060
 
 # https://github.com/opencontainers/image-spec/blob/main/annotations.md
 ARG BUILD_DATE

--- a/README.md
+++ b/README.md
@@ -322,14 +322,14 @@ internally for rpcdaemon or other connections, (e.g. rpcdaemon -> erigon)
 
 #### `rpcdaemon` ports
 
-|  Port |  Protocol |      Purpose      |  Expose |
-|:-----:|:---------:|:-----------------:|:-------:|
-|  8545 |    TCP    | HTTP & WebSockets | Private |
-|:-----:|:---------:|:-----------------:|:-------:|
-|  8550 |    TCP    |       HTTP        | Private |
+|  Port |  Protocol |      Purpose       |  Expose |
+|:-----:|:---------:|:------------------:|:-------:|
+|  8545 |    TCP    | HTTP & WebSockets  | Private |
+|  8550 |    TCP    |       HTTP         | Private |
+|  8551 |    TCP    | HTTP with JWS auth | Private |
 
 Typically 8545 is exposed only internally for JSON-RPC queries. Both HTTP and WebSocket connections are on the same port.
-Typically 8550 is exposed only internally for the engineApi JSON-RPC queries
+Typically 8550 (unauthenticated) and 8551 (authenticated) are exposed only internally for the Engine API JSON-RPC queries.
 
 #### `sentry` ports
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,7 @@ services:
     ports:
       - "8545:8545"
       - "8550:8550"
+      - "8551:8551"
     restart: unless-stopped
 
   downloader: # Service to download/seed historical data (need only if you use --experimental.snapshot)


### PR DESCRIPTION
Per the [Engine API spec](https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#underlying-protocol), eth API should be exposed alongside engine API.