### PR TITLE
Discovery: refactor public key to node ID conversions.

### DIFF
--- a/p2p/discover/node.go
+++ b/p2p/discover/node.go
@@ -17,15 +17,9 @@
 package discover
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"errors"
-	"math/big"
 	"net"
 	"time"
 
-	"github.com/ledgerwatch/erigon/common/math"
-	"github.com/ledgerwatch/erigon/crypto"
 	"github.com/ledgerwatch/erigon/p2p/enode"
 )
 
@@ -35,33 +29,6 @@ type node struct {
 	enode.Node
 	addedAt        time.Time // time when the node was added to the table
 	livenessChecks uint      // how often liveness was checked
-}
-
-type encPubkey [64]byte
-
-func encodePubkey(key *ecdsa.PublicKey) encPubkey {
-	var e encPubkey
-	math.ReadBits(key.X, e[:len(e)/2])
-	math.ReadBits(key.Y, e[len(e)/2:])
-	return e
-}
-
-func decodePubkey(curve elliptic.Curve, e []byte) (*ecdsa.PublicKey, error) {
-	if len(e) != len(encPubkey{}) {
-		return nil, errors.New("wrong size public key data")
-	}
-	p := &ecdsa.PublicKey{Curve: curve, X: new(big.Int), Y: new(big.Int)}
-	half := len(e) / 2
-	p.X.SetBytes(e[:half])
-	p.Y.SetBytes(e[half:])
-	if !p.Curve.IsOnCurve(p.X, p.Y) {
-		return nil, errors.New("invalid curve point")
-	}
-	return p, nil
-}
-
-func (e encPubkey) id() enode.ID {
-	return enode.ID(crypto.Keccak256Hash(e[:]))
 }
 
 func wrapNode(n *enode.Node) *node {

--- a/p2p/discover/table_util_test.go
+++ b/p2p/discover/table_util_test.go
@@ -244,7 +244,7 @@ func hexEncPrivkey(h string) *ecdsa.PrivateKey {
 }
 
 // hexEncPubkey decodes h as a public key.
-func hexEncPubkey(h string) (ret encPubkey) {
+func hexEncPubkey(h string) (ret enode.PubkeyEncoded) {
 	b, err := hex.DecodeString(h)
 	if err != nil {
 		panic(err)

--- a/p2p/discover/v4wire/v4wire.go
+++ b/p2p/discover/v4wire/v4wire.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/ledgerwatch/erigon/common/math"
 	"github.com/ledgerwatch/erigon/crypto"
-	"github.com/ledgerwatch/erigon/p2p/enode"
 	"github.com/ledgerwatch/erigon/p2p/enr"
 	"github.com/ledgerwatch/erigon/rlp"
 )
@@ -125,11 +124,6 @@ const MaxNeighbors = 12
 // Pubkey represents an encoded 64-byte secp256k1 public key.
 type Pubkey [64]byte
 
-// ID returns the node ID corresponding to the public key.
-func (e Pubkey) ID() enode.ID {
-	return enode.ID(crypto.Keccak256Hash(e[:]))
-}
-
 // Node represents information about a node.
 type Node struct {
 	IP  net.IP // len 4 for IPv4 or 16 for IPv6
@@ -192,6 +186,7 @@ func seqFromTail(tail []rlp.RawValue) uint64 {
 		return 0
 	}
 	var seq uint64
+	//goland:noinspection GoUnhandledErrorResult
 	rlp.DecodeBytes(tail[0], &seq) //nolint:errcheck
 	return seq
 }
@@ -279,7 +274,8 @@ func recoverNodeKey(hash, sig []byte) (key Pubkey, err error) {
 	return key, nil
 }
 
-// EncodePubkey encodes a secp256k1 public key.
+// EncodePubkey converts a public key into a binary format.
+// The logic matches DecodePubkey.
 func EncodePubkey(key *ecdsa.PublicKey) Pubkey {
 	var e Pubkey
 	math.ReadBits(key.X, e[:len(e)/2])

--- a/p2p/discover/v5_udp_test.go
+++ b/p2p/discover/v5_udp_test.go
@@ -565,7 +565,7 @@ func TestUDPv5_lookup(t *testing.T) {
 	test := newUDPV5Test(t)
 
 	// Lookup on empty table returns no nodes.
-	if results := test.udp.Lookup(lookupTestnet.target.id()); len(results) > 0 {
+	if results := test.udp.Lookup(lookupTestnet.target.ID()); len(results) > 0 {
 		t.Fatalf("lookup on empty table returned %d results: %#v", len(results), results)
 	}
 
@@ -584,7 +584,7 @@ func TestUDPv5_lookup(t *testing.T) {
 	// Start the lookup.
 	resultC := make(chan []*enode.Node, 1)
 	go func() {
-		resultC <- test.udp.Lookup(lookupTestnet.target.id())
+		resultC <- test.udp.Lookup(lookupTestnet.target.ID())
 		test.close()
 	}()
 
@@ -768,7 +768,7 @@ func (test *udpV5Test) packetInFrom(key *ecdsa.PrivateKey, addr *net.UDPAddr, pa
 
 // getNode ensures the test knows about a node at the given endpoint.
 func (test *udpV5Test) getNode(key *ecdsa.PrivateKey, addr *net.UDPAddr) *enode.LocalNode {
-	id := encodePubkey(&key.PublicKey).id()
+	id := enode.PubkeyToIDV4(&key.PublicKey)
 	ln := test.nodesByID[id]
 	if ln == nil {
 		db, err := enode.OpenDB(test.t.TempDir())

--- a/p2p/enode/urlv4.go
+++ b/p2p/enode/urlv4.go
@@ -26,7 +26,6 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.com/ledgerwatch/erigon/common/math"
 	"github.com/ledgerwatch/erigon/crypto"
 	"github.com/ledgerwatch/erigon/p2p/enr"
 )
@@ -192,12 +191,4 @@ func (n *Node) URLv4() string {
 		}
 	}
 	return u.String()
-}
-
-// PubkeyToIDV4 derives the v4 node address from the given public key.
-func PubkeyToIDV4(key *ecdsa.PublicKey) ID {
-	e := make([]byte, 64)
-	math.ReadBits(key.X, e[:len(e)/2])
-	math.ReadBits(key.Y, e[len(e)/2:])
-	return ID(crypto.Keccak256Hash(e))
 }


### PR DESCRIPTION
Encode and hash logic was duplicated in multiple places.
* Move encoding to p2p/discover/v4wire
* Move hashing to p2p/enode/idscheme

* Change newRandomLookup to create a proper random key on a curve.