### PR TITLE
update disk storage requirements in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ changes but we don't guarantee anything. Things can and will break.**
 System Requirements
 ===================
 
-Recommend 2Tb storage space on a single partition: 1.8Tb state, 200GB temp files (can symlink or mount
+Recommend 3.84Tb storage space on a single partition: 3.4Tb state, 400GB temp files (can symlink or mount
 folder `<datadir>/etl-tmp` to another disk).
 
 RAM: 16GB, 64-bit architecture, [Golang version >= 1.16](https://golang.org/doc/install), GCC 10+


### PR DESCRIPTION
Updated the storage requirements for the Erigon server. I had a 2TB drive which has fallen over as the chaindata has increaesed over time.