### PR TITLE
Handle a corner case in forkchoiceUpdated

### DIFF
--- a/cmd/rpcdaemon/commands/call_traces_test.go
+++ b/cmd/rpcdaemon/commands/call_traces_test.go
@@ -47,7 +47,7 @@ func TestCallTraceOneByOne(t *testing.T) {
 	defer m.DB.Close()
 	chain, err := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 10, func(i int, gen *core.BlockGen) {
 		gen.SetCoinbase(common.Address{1})
-	}, false /* intemediateHashes */)
+	}, false /* intermediateHashes */)
 	if err != nil {
 		t.Fatalf("generate chain: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestCallTraceUnwind(t *testing.T) {
 	var err error
 	chainA, err = core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 10, func(i int, gen *core.BlockGen) {
 		gen.SetCoinbase(common.Address{1})
-	}, false /* intemediateHashes */)
+	}, false /* intermediateHashes */)
 	if err != nil {
 		t.Fatalf("generate chainA: %v", err)
 	}
@@ -94,7 +94,7 @@ func TestCallTraceUnwind(t *testing.T) {
 		} else {
 			gen.SetCoinbase(common.Address{2})
 		}
-	}, false /* intemediateHashes */)
+	}, false /* intermediateHashes */)
 	if err != nil {
 		t.Fatalf("generate chainB: %v", err)
 	}
@@ -154,7 +154,7 @@ func TestFilterNoAddresses(t *testing.T) {
 	defer m.DB.Close()
 	chain, err := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 10, func(i int, gen *core.BlockGen) {
 		gen.SetCoinbase(common.Address{1})
-	}, false /* intemediateHashes */)
+	}, false /* intermediateHashes */)
 	if err != nil {
 		t.Fatalf("generate chain: %v", err)
 	}
@@ -207,7 +207,7 @@ func TestFilterAddressIntersection(t *testing.T) {
 			t.Fatal(err)
 		}
 		block.AddTx(txn)
-	}, false /* intemediateHashes */)
+	}, false /* intermediateHashes */)
 	require.NoError(t, err, "generate chain")
 
 	err = m.InsertChain(chain)

--- a/cmd/rpcdaemon/commands/eth_subscribe_test.go
+++ b/cmd/rpcdaemon/commands/eth_subscribe_test.go
@@ -22,7 +22,7 @@ func TestEthSubscribe(t *testing.T) {
 	m, require := stages.Mock(t), require.New(t)
 	chain, err := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 42, func(i int, b *core.BlockGen) {
 		b.SetCoinbase(common.Address{1})
-	}, false /* intemediateHashes */)
+	}, false /* intermediateHashes */)
 	require.NoError(err)
 
 	b, err := rlp.EncodeToBytes(&eth.BlockHeadersPacket66{

--- a/cmd/rpcdaemon/commands/send_transaction_test.go
+++ b/cmd/rpcdaemon/commands/send_transaction_test.go
@@ -31,7 +31,7 @@ func TestSendRawTransaction(t *testing.T) {
 
 	chain, err := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 1, func(i int, b *core.BlockGen) {
 		b.SetCoinbase(common.Address{1})
-	}, false /* intemediateHashes */)
+	}, false /* intermediateHashes */)
 	require.NoError(err)
 	{ // Do 1 step to start txPool
 

--- a/cmd/rpcdaemon/commands/txpool_api_test.go
+++ b/cmd/rpcdaemon/commands/txpool_api_test.go
@@ -25,7 +25,7 @@ func TestTxPoolContent(t *testing.T) {
 	m, require := stages.MockWithTxPool(t), require.New(t)
 	chain, err := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 1, func(i int, b *core.BlockGen) {
 		b.SetCoinbase(common.Address{1})
-	}, false /* intemediateHashes */)
+	}, false /* intermediateHashes */)
 	require.NoError(err)
 	err = m.InsertChain(chain)
 	require.NoError(err)

--- a/consensus/clique/snapshot_test.go
+++ b/consensus/clique/snapshot_test.go
@@ -433,7 +433,7 @@ func TestClique(t *testing.T) {
 					copy(nonce[:], clique.NonceAuthVote)
 					gen.SetNonce(nonce)
 				}
-			}, false /* intemediateHashes */)
+			}, false /* intermediateHashes */)
 			if err != nil {
 				t.Fatalf("generate blocks: %v", err)
 			}

--- a/core/block_validator_test.go
+++ b/core/block_validator_test.go
@@ -36,7 +36,7 @@ func TestHeaderVerification(t *testing.T) {
 	)
 	m := stages.MockWithGenesisEngine(t, gspec, engine)
 
-	chain, err := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 8, nil, false /* intemediateHashes */)
+	chain, err := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 8, nil, false /* intermediateHashes */)
 	if err != nil {
 		t.Fatalf("genetate chain: %v", err)
 	}
@@ -73,7 +73,7 @@ func TestHeaderWithSealVerification(t *testing.T) {
 	)
 	m := stages.MockWithGenesisEngine(t, gspec, engine)
 
-	chain, err := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 8, nil, false /* intemediateHashes */)
+	chain, err := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 8, nil, false /* intermediateHashes */)
 	if err != nil {
 		t.Fatalf("genetate chain: %v", err)
 	}

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -223,7 +223,7 @@ type ChainPack struct {
 	Headers  []*types.Header
 	Blocks   []*types.Block
 	Receipts []types.Receipts
-	TopBlock *types.Block // Convinience field to access the last block
+	TopBlock *types.Block // Convenience field to access the last block
 }
 
 // OneBlock returns a ChainPack which contains just one

--- a/docs/evm_semantics.md
+++ b/docs/evm_semantics.md
@@ -111,9 +111,8 @@ WHERE prevaccount = select(state, tx.sender)
 WHEN prevaccount.nonce = tx.nonce AND prevbalance >= cost
 ```
 
-We have introduced `WHERE` section to define some variable for convinience, and placed the guard into the `WHEN` section.
-Pattern and substitution are on the first line, separated by the arrow `==>`. One needs to notice that the substution
+We have introduced `WHERE` section to define some variable for convenience, and placed the guard into the `WHEN` section.
+Pattern and substitution are on the first line, separated by the arrow `==>`. One needs to notice that the substitution
 contains three-element sequence whereas the pattern contains only two elements. If the gas purchase is successful,
 the "gas" object gets introduced. It will be useful for the subsequent rules, because now we can make all of them
 simply require the presence of that "gas" object, instead of repeating the guards of the gas purchasing rule.
-

--- a/docs/merry-go-round-sync.md
+++ b/docs/merry-go-round-sync.md
@@ -13,7 +13,7 @@ node might like to do in the beginning).
 
 The process of syncing happens in cycles. During each cycle, all participants attempt to distribute the entire content of the
 Ethereum state to each other. Therefore the duration of one cycle for the Ethereum mainnet is likely to be some hours.
-Cycle is divided into ticks. For convinience, we can say that each ticks starts after the mining of certain block, and lasts
+Cycle is divided into ticks. For convenience, we can say that each ticks starts after the mining of certain block, and lasts
 for some predetermined amount of time, let's say, 30 seconds. This definition means that the ticks will often overlap, but not
 always, as shown on the picture below.
 

--- a/eth/stagedsync/stage_hashstate.go
+++ b/eth/stagedsync/stage_hashstate.go
@@ -109,7 +109,7 @@ func UnwindHashStateStage(u *UnwindState, s *StageState, tx kv.RwTx, cfg HashSta
 }
 
 func unwindHashStateStageImpl(logPrefix string, u *UnwindState, s *StageState, tx kv.RwTx, cfg HashStateCfg, quit <-chan struct{}) error {
-	// Currently it does not require unwinding because it does not create any Intemediate Hash records
+	// Currently it does not require unwinding because it does not create any Intermediate Hash records
 	// and recomputes the state root from scratch
 	prom := NewPromoter(tx, quit)
 	prom.TempDir = cfg.tmpDir

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -244,6 +244,15 @@ func handleForkChoice(
 	headerHash := forkChoiceMessage.HeadBlockHash
 	log.Info(fmt.Sprintf("[%s] Handling fork choice", s.LogPrefix()), "headerHash", headerHash)
 
+	currentHeadHash := rawdb.ReadHeadHeaderHash(tx)
+	if currentHeadHash == headerHash { // no-op
+		cfg.hd.PayloadStatusCh <- privateapi.PayloadStatus{
+			Status:          remote.EngineStatus_VALID,
+			LatestValidHash: currentHeadHash,
+		}
+		return nil
+	}
+
 	header, err := rawdb.ReadHeaderByHash(tx, headerHash)
 	if err != nil {
 		cfg.hd.PayloadStatusCh <- privateapi.PayloadStatus{CriticalError: err}

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -130,7 +130,7 @@ func SpawnStageHeaders(
 	}
 
 	pendingHeaderHash, pendingHeaderHeight := cfg.hd.GetPendingHeader()
-	if pendingHeaderHeight != 0 { // some work left to do after unwind
+	if pendingHeaderHash != (common.Hash{}) { // some work left to do after unwind
 		log.Info(fmt.Sprintf("[%s] Pending header after unwind", s.LogPrefix()), "height", pendingHeaderHeight, "hash", pendingHeaderHash)
 
 		logEvery := time.NewTicker(logInterval)
@@ -271,14 +271,16 @@ func handleForkChoice(
 	headerNumber := header.Number.Uint64()
 	cfg.hd.UpdateTopSeenHeightPoS(headerNumber)
 
-	parent := rawdb.ReadHeader(tx, header.ParentHash, headerNumber-1)
-
-	forkingPoint, err := headerInserter.ForkingPoint(tx, header, parent)
-	if err != nil {
-		if !repliedWithSyncStatus {
-			cfg.hd.PayloadStatusCh <- privateapi.PayloadStatus{CriticalError: err}
+	forkingPoint := uint64(0)
+	if headerNumber > 0 {
+		parent := rawdb.ReadHeader(tx, header.ParentHash, headerNumber-1)
+		forkingPoint, err = headerInserter.ForkingPoint(tx, header, parent)
+		if err != nil {
+			if !repliedWithSyncStatus {
+				cfg.hd.PayloadStatusCh <- privateapi.PayloadStatus{CriticalError: err}
+			}
+			return err
 		}
-		return err
 	}
 
 	if !repliedWithSyncStatus {

--- a/turbo/stages/blockchain_test.go
+++ b/turbo/stages/blockchain_test.go
@@ -311,13 +311,13 @@ func testReorg(t *testing.T, first, second []int64, td int64) {
 	// Insert an easy and a difficult chain afterwards
 	easyChain, err := core.GenerateChain(m.ChainConfig, current(m.DB), m.Engine, m.DB, len(first), func(i int, b *core.BlockGen) {
 		b.OffsetTime(first[i])
-	}, false /* intemediateHashes */)
+	}, false /* intermediateHashes */)
 	if err != nil {
 		t.Fatalf("generate chain: %v", err)
 	}
 	diffChain, err := core.GenerateChain(m.ChainConfig, current(m.DB), m.Engine, m.DB, len(second), func(i int, b *core.BlockGen) {
 		b.OffsetTime(second[i])
-	}, false /* intemediateHashes */)
+	}, false /* intermediateHashes */)
 	if err != nil {
 		t.Fatalf("generate chain: %v", err)
 	}
@@ -437,7 +437,7 @@ func TestChainTxReorgs(t *testing.T) {
 
 			gen.OffsetTime(9) // Lower the block difficulty to simulate a weaker chain
 		}
-	}, false /* intemediateHashes */)
+	}, false /* intermediateHashes */)
 	if err != nil {
 		t.Fatalf("generate chain: %v", err)
 	}
@@ -464,7 +464,7 @@ func TestChainTxReorgs(t *testing.T) {
 			futureAdd, _ = types.SignTx(types.NewTransaction(gen.TxNonce(addr3), addr3, uint256.NewInt(1000), params.TxGas, nil, nil), *signer, key3)
 			gen.AddTx(futureAdd) // This transaction will be added after a full reorg
 		}
-	}, false /* intemediateHashes */)
+	}, false /* intermediateHashes */)
 	if err != nil {
 		t.Fatalf("generate chain: %v", err)
 	}
@@ -647,7 +647,7 @@ func TestEIP155Transition(t *testing.T) {
 			}
 			block.AddTx(tx)
 		}
-	}, false /* intemediateHashes */)
+	}, false /* intermediateHashes */)
 	if chainErr != nil {
 		t.Fatalf("generate blocks: %v", chainErr)
 	}
@@ -730,7 +730,7 @@ func doModesTest(t *testing.T, pm prune.Mode) error {
 			}
 			block.AddTx(tx)
 		}
-	}, false /* intemediateHashes */)
+	}, false /* intermediateHashes */)
 	if err != nil {
 		return fmt.Errorf("generate blocks: %w", err)
 	}
@@ -903,7 +903,7 @@ func TestEIP161AccountRemoval(t *testing.T) {
 			t.Fatal(err)
 		}
 		block.AddTx(txn)
-	}, false /* intemediateHashes */)
+	}, false /* intermediateHashes */)
 	if err != nil {
 		t.Fatalf("generate blocks: %v", err)
 	}
@@ -1046,7 +1046,7 @@ func TestBlockchainHeaderchainReorgConsistency(t *testing.T) {
 			} else {
 				b.SetCoinbase(common.Address{1})
 			}
-		}, false /* intemediateHashes */)
+		}, false /* intermediateHashes */)
 		if err != nil {
 			t.Fatalf("generate fork %d: %v", i, err)
 		}
@@ -1087,7 +1087,7 @@ func TestLargeReorgTrieGC(t *testing.T) {
 
 	shared, err := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 64, func(i int, b *core.BlockGen) {
 		b.SetCoinbase(common.Address{1})
-	}, false /* intemediateHashes */)
+	}, false /* intermediateHashes */)
 	if err != nil {
 		t.Fatalf("generate shared chain: %v", err)
 	}
@@ -1097,7 +1097,7 @@ func TestLargeReorgTrieGC(t *testing.T) {
 		} else {
 			b.SetCoinbase(common.Address{2})
 		}
-	}, false /* intemediateHashes */)
+	}, false /* intermediateHashes */)
 	if err != nil {
 		t.Fatalf("generate original chain: %v", err)
 	}
@@ -1108,7 +1108,7 @@ func TestLargeReorgTrieGC(t *testing.T) {
 			b.SetCoinbase(common.Address{3})
 			b.OffsetTime(-2)
 		}
-	}, false /* intemediateHashes */)
+	}, false /* intermediateHashes */)
 	if err != nil {
 		t.Fatalf("generate competitor chain: %v", err)
 	}
@@ -1447,7 +1447,7 @@ func TestDeleteRecreateAccount(t *testing.T) {
 		tx, _ = types.SignTx(types.NewTransaction(1, aa,
 			u256.Num1, 100000, u256.Num1, nil), *types.LatestSignerForChainID(nil), key)
 		b.AddTx(tx)
-	}, false /* intemediateHashes */)
+	}, false /* intermediateHashes */)
 	if err != nil {
 		t.Fatalf("generate blocks: %v", err)
 	}
@@ -1624,7 +1624,7 @@ func TestDeleteRecreateSlotsAcrossManyBlocks(t *testing.T) {
 		}
 		expectations = append(expectations, exp)
 		current = exp
-	}, false /* intemediateHashes */)
+	}, false /* intermediateHashes */)
 	if err != nil {
 		t.Fatalf("generate blocks: %v", err)
 	}
@@ -1763,7 +1763,7 @@ func TestInitThenFailCreateContract(t *testing.T) {
 			u256.Num0, 100000, u256.Num1, nil), *types.LatestSignerForChainID(nil), key)
 		b.AddTx(tx)
 		nonce++
-	}, false /* intemediateHashes */)
+	}, false /* intermediateHashes */)
 	if err != nil {
 		t.Fatalf("generate blocks: %v", err)
 	}


### PR DESCRIPTION
This handles the following corner case failing during Hive testing: the chain consists of a single genesis block and a trivial `forkchoiceUpdated` is sent with all hashes pointing to the genesis block.

Also, some typos are fixed.