### PR TITLE
Makefile: allow command-specific go.mod files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ dbg:
 %.cmd: git-submodules
 	@# Note: $* is replaced by the command name
 	@echo "Building $*"
-	@$(GOBUILD) -o $(GOBIN)/$* ./cmd/$*
+	@cd ./cmd/$* && $(GOBUILD) -o $(GOBIN)/$*
 	@echo "Run \"$(GOBIN)/$*\" to launch $*."
 
 geth: erigon


### PR DESCRIPTION
The command builds were always using the root go.mod.
Adding cmd/mycmd/go.mod produced an "package not found" error.

This changes the build to run in the cmd/mycmd directory:
* If cmd/mycmd/go.mod is present, it is used.
* Otherwise it builds the main package using the root go.mod as before.