### PR TITLE
Fix dev chain listen port not set

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -965,10 +965,12 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config, nodeName, datadir string) {
 	if ctx.GlobalString(ChainFlag.Name) == networkname.DevChainName {
 		// --dev mode can't use p2p networking.
 		//cfg.MaxPeers = 0 // It can have peers otherwise local sync is not possible
-		//cfg.ListenAddr = ":0" // It is useful to set the port for local sync
+		if !ctx.GlobalIsSet(ListenPortFlag.Name) {
+			cfg.ListenAddr = ":0"
+		}
 		cfg.NoDiscovery = true
 		cfg.DiscoveryV5 = false
-		log.Info("Development Chain Flags Set", "--nodiscover", cfg.NoDiscovery, "--v5disc", cfg.DiscoveryV5)
+		log.Info("Development chain flags set", "--nodiscover", cfg.NoDiscovery, "--v5disc", cfg.DiscoveryV5, "--port", cfg.ListenAddr)
 	}
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -965,9 +965,10 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config, nodeName, datadir string) {
 	if ctx.GlobalString(ChainFlag.Name) == networkname.DevChainName {
 		// --dev mode can't use p2p networking.
 		//cfg.MaxPeers = 0 // It can have peers otherwise local sync is not possible
-		cfg.ListenAddr = ":0"
+		//cfg.ListenAddr = ":0" // It is useful to set the port for local sync
 		cfg.NoDiscovery = true
 		cfg.DiscoveryV5 = false
+		log.Info("Development Chain Flags Set", "--nodiscover", cfg.NoDiscovery, "--v5disc", cfg.DiscoveryV5)
 	}
 }
 

--- a/turbo/node/node.go
+++ b/turbo/node/node.go
@@ -72,7 +72,7 @@ func NewNodConfigUrfave(ctx *cli.Context) *node.Config {
 	case networkname.RialtoChainName:
 		log.Info("Starting Erigon on Chapel testnet...")
 	case networkname.DevChainName:
-		log.Info("Starting Erigon in ephemerasl dev mode...")
+		log.Info("Starting Erigon in ephemeral dev mode...")
 	case networkname.BorMainnetChainName:
 		log.Info("Starting Erigon on Bor Mainnet")
 	case "", networkname.MainnetChainName:


### PR DESCRIPTION
It's useful for those using the dev chain to be able to set the ports for discovery, previously, setting the `--port` flag wouldn't have any effect. 

With this PR merged `--chain=dev --port=30302`:

```
[INFO] [03-10|03:43:50.699] Development chain flags set              --nodiscover=true --v5disc=false --port=:0
...
[INFO] [03-10|03:42:22.305] Started P2P networking                   version=66 self="enode://trimmed@127.0.0.1:30302?discport=0" name=erigon/v2022.99.99-dev-540b41ed/linux-amd64/go1.17.6
```

and with `--chain=dev` and port unset:

```
[INFO] [03-10|03:43:50.699] Development chain flags set              --nodiscover=true --v5disc=false --port=:0
...
[INFO] [03-10|03:43:50.905] Started P2P networking                   version=66 self="enode://trimmed@127.0.0.1:39689?discport=0" name=erigon/v2022.99.99-dev-540b41ed/linux-amd64/go1.17.6
```

Also, a small typo fix.