### PR TITLE
added support of Clique consensus for block processing for erigon2

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -26,13 +26,14 @@ import (
 	"time"
 
 	"github.com/ledgerwatch/erigon-lib/kv"
+	"github.com/ledgerwatch/log/v3"
+
 	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/interfaces"
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/common/dbutils"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/ethdb/cbor"
 	"github.com/ledgerwatch/erigon/rlp"
-	"github.com/ledgerwatch/log/v3"
 )
 
 // ReadCanonicalHash retrieves the hash assigned to a canonical block number.
@@ -509,10 +510,69 @@ func ReadBody(db kv.Getter, hash common.Hash, number uint64) (*types.Body, uint6
 	}
 	body := new(types.Body)
 	body.Uncles = bodyForStorage.Uncles
+
 	if bodyForStorage.TxAmount < 2 {
 		panic(fmt.Sprintf("block body hash too few txs amount: %d, %d", number, bodyForStorage.TxAmount))
 	}
 	return body, bodyForStorage.BaseTxId + 1, bodyForStorage.TxAmount - 2 // 1 system txn in the begining of block, and 1 at the end
+}
+
+func ReadBodyWithoutSystemTx(db kv.Getter, hash common.Hash, number uint64) (*types.Body, uint64, uint32) {
+	data := ReadStorageBodyRLP(db, hash, number)
+	if len(data) == 0 {
+		return nil, 0, 0
+	}
+	bodyForStorage := new(types.BodyForStorage)
+	err := rlp.DecodeBytes(data, bodyForStorage)
+	if err != nil {
+		log.Error("Invalid block body RLP", "hash", hash, "err", err)
+		return nil, 0, 0
+	}
+	body := new(types.Body)
+	body.Uncles = bodyForStorage.Uncles
+	return body, bodyForStorage.BaseTxId, bodyForStorage.TxAmount
+}
+
+func ReadCanonicalBodyWithTransactionsExceptSystems(db kv.Getter, hash common.Hash, number uint64) *types.Body {
+	body, baseTxId, txAmount := ReadBodyWithoutSystemTx(db, hash, number)
+	if body == nil {
+		return nil
+	}
+	var err error
+	body.Transactions, err = CanonicalTransactions(db, baseTxId, txAmount)
+	if err != nil {
+		log.Error("failed ReadTransactionByHash", "hash", hash, "block", number, "err", err)
+		return nil
+	}
+	return body
+}
+
+func ReadBlockNoSystemTx(tx kv.Getter, hash common.Hash, number uint64) *types.Block {
+	header := ReadHeader(tx, hash, number)
+	if header == nil {
+		return nil
+	}
+	body := ReadCanonicalBodyWithTransactionsExceptSystems(tx, hash, number)
+	if body == nil {
+		return nil
+	}
+	return types.NewBlockFromStorage(hash, header, body.Transactions, body.Uncles)
+}
+
+func ReadBlockWithSendersNoSystemTx(db kv.Getter, hash common.Hash, number uint64) (*types.Block, []common.Address, error) {
+	block := ReadBlockNoSystemTx(db, hash, number)
+	if block == nil {
+		return nil, nil, nil
+	}
+	senders, err := ReadSenders(db, hash, number)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(senders) != block.Transactions().Len() {
+		return block, senders, nil // no senders is fine - will recover them on the fly
+	}
+	block.SendersToTxs(senders)
+	return block, senders, nil
 }
 
 func ReadSenders(db kv.Getter, hash common.Hash, number uint64) ([]common.Address, error) {

--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -493,6 +493,9 @@ func InitPreverifiedHashes(chain string) (map[common.Hash]struct{}, uint64) {
 	case networkname.SepoliaChainName:
 		encodings = sepoliaPreverifiedHashes
 		height = sepoliaPreverifiedHeight
+	case networkname.GoerliChainName:
+		encodings = goerliPreverifiedHashes
+		height = goerliPreferifiedHeight
 	default:
 		log.Debug("Preverified hashes not found for", "chain", chain)
 		return nil, 0

--- a/turbo/stages/headerdownload/preverified_hashes_goerli.go
+++ b/turbo/stages/headerdownload/preverified_hashes_goerli.go
@@ -1,0 +1,8 @@
+package headerdownload
+
+var goerliPreferifiedHeight uint64 = 2
+
+var goerliPreverifiedHashes = []string{
+	"696d95da6726a67afd5be2a37d3883e9be8008491b30d5bd1069ea5922fa2a41",
+	"89b977ffab1052f5f6f778e4680354a8a1a1e0f623db9b2f20beba9f36f68721",
+}


### PR DESCRIPTION
Touches issue https://github.com/ledgerwatch/erigon-lib/issues/257

Here are necessary updates to support different consensus engines during block processing by erigon2.

 - Implemented wrapper `cliqueConsensusBlockReader` to read blocks without leading and finishing system transaction. Use of hacky BlockReader led to uint64 overflow, so when first transaction appears, reader tried to read tremendous amount of canonical transactions, which hangs app
 - moved stat printing to separate routine. Yes, this is not thread safe to read blockNum, which is easy to solve but more important - statistics will be printed even if block processing took too much time
 - blocks processing now using external consensus engine instead of initialized on each block ethash.

Requires merged https://github.com/ledgerwatch/erigon-lib/pull/366 and `go.mod` update before merge.