### PR TITLE
Snapshots: retire blocks by default 

### DIFF
--- a/cmd/downloader/readme.md
+++ b/cmd/downloader/readme.md
@@ -24,6 +24,8 @@ downloader --downloader.api.addr=127.0.0.1:9093 --torrent.port=42068 --datadir=<
 erigon --experimental.snapshot --downloader.api.addr=127.0.0.1:9093 --datadir=<your_datadir> 
 ```
 
+Use `--experimental.snapshot.keepblocks=true` to don't delete retired blocks from DB
+
 ## How to create new network or bootnode
 
 ```shell

--- a/cmd/integration/commands/flags.go
+++ b/cmd/integration/commands/flags.go
@@ -90,7 +90,7 @@ func withBucket(cmd *cobra.Command) {
 }
 
 func withDataDir2(cmd *cobra.Command) {
-	cmd.Flags().String(utils.DataDirFlag.Name, paths.DefaultDataDir(), utils.DataDirFlag.Usage)
+	cmd.Flags().StringVar(&datadir, utils.DataDirFlag.Name, paths.DefaultDataDir(), utils.DataDirFlag.Usage)
 	must(cmd.MarkFlagDirname(utils.DataDirFlag.Name))
 	must(cmd.MarkFlagRequired(utils.DataDirFlag.Name))
 	cmd.Flags().IntVar(&databaseVerbosity, "database.verbosity", 2, "Enabling internal db logs. Very high verbosity levels may require recompile db. Default: 2, means warning.")

--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -1030,7 +1030,7 @@ var _allSnapshotsSingleton *snapshotsync.RoSnapshots
 func allSnapshots(cc *params.ChainConfig) *snapshotsync.RoSnapshots {
 	openSnapshotOnce.Do(func() {
 		if enableSnapshot {
-			snapshotCfg := ethconfig.NewSnapshotCfg(true, false)
+			snapshotCfg := ethconfig.NewSnapshotCfg(true, true)
 			_allSnapshotsSingleton = snapshotsync.NewRoSnapshots(snapshotCfg, filepath.Join(datadir, "snapshots"))
 			if err := _allSnapshotsSingleton.ReopenSegments(); err != nil {
 				panic(err)

--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -1030,7 +1030,7 @@ var _allSnapshotsSingleton *snapshotsync.RoSnapshots
 func allSnapshots(cc *params.ChainConfig) *snapshotsync.RoSnapshots {
 	openSnapshotOnce.Do(func() {
 		if enableSnapshot {
-			snapshotCfg := ethconfig.NewSnapshotCfg(true, true)
+			snapshotCfg := ethconfig.NewSnapshotCfg(enableSnapshot, true)
 			_allSnapshotsSingleton = snapshotsync.NewRoSnapshots(snapshotCfg, filepath.Join(datadir, "snapshots"))
 			if err := _allSnapshotsSingleton.ReopenSegments(); err != nil {
 				panic(err)

--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -552,7 +552,7 @@ func stageSenders(db kv.RwDB, ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	cfg := stagedsync.StageSendersCfg(db, chainConfig, tmpdir, pm, snapshotsync.NewBlockRetire(runtime.NumCPU(), tmpdir, allSnapshots(chainConfig)))
+	cfg := stagedsync.StageSendersCfg(db, chainConfig, tmpdir, pm, snapshotsync.NewBlockRetire(runtime.NumCPU(), tmpdir, allSnapshots(chainConfig), db))
 	if unwind > 0 {
 		u := sync.NewUnwindState(stages.Senders, s.BlockNumber-unwind, s.BlockNumber)
 		if err = stagedsync.UnwindSendersStage(u, tx, cfg, ctx); err != nil {

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -115,7 +115,7 @@ func RootCommand() (*cobra.Command, *httpcfg.HttpCfg) {
 			if cfg.Chaindata == "" {
 				cfg.Chaindata = filepath.Join(cfg.DataDir, "chaindata")
 			}
-			cfg.Snapshot = ethconfig.NewSnapshotCfg(cfg.Snapshot.Enabled, cfg.Snapshot.RetireEnabled)
+			cfg.Snapshot = ethconfig.NewSnapshotCfg(cfg.Snapshot.Enabled, cfg.Snapshot.KeepBlocks)
 		}
 		if cfg.TxPoolApiAddr == "" {
 			cfg.TxPoolApiAddr = cfg.PrivateApiAddr

--- a/cmd/state/commands/erigon2.go
+++ b/cmd/state/commands/erigon2.go
@@ -130,7 +130,7 @@ func Erigon2(genesis *core.Genesis, chainConfig *params.ChainConfig, logger log.
 		if err != nil {
 			return err
 		}
-		allSnapshots := snapshotsync.NewRoSnapshots(ethconfig.NewSnapshotCfg(true, false), path.Join(datadir, "snapshots"))
+		allSnapshots := snapshotsync.NewRoSnapshots(ethconfig.NewSnapshotCfg(true, true), path.Join(datadir, "snapshots"))
 		defer allSnapshots.Close()
 		blockReader = snapshotsync.NewBlockReaderWithSnapshots(allSnapshots)
 	} else {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -623,6 +623,10 @@ var (
 		Name:  ethconfig.FlagSnapshotRetire,
 		Usage: "Delete(!) old blocks from DB, by moving them to snapshots",
 	}
+	SnapshotKeepBlocksFlag = cli.BoolFlag{
+		Name:  ethconfig.FlagSnapshotKeepBlocks,
+		Usage: "Keep ancient blocks in db (useful for debug)",
+	}
 	TorrentVerbosityFlag = cli.StringFlag{
 		Name:  "torrent.verbosity",
 		Value: lg.Warning.LogString(),
@@ -1333,9 +1337,7 @@ func CheckExclusive(ctx *cli.Context, args ...interface{}) {
 
 // SetEthConfig applies eth-related command line flags to the config.
 func SetEthConfig(ctx *cli.Context, nodeConfig *node.Config, cfg *ethconfig.Config) {
-	if ctx.GlobalBool(SnapshotSyncFlag.Name) {
-		cfg.Snapshot.Enabled = true
-	}
+	cfg.Snapshot.Enabled = ctx.GlobalBool(SnapshotSyncFlag.Name)
 	if cfg.Snapshot.Enabled {
 		snDir, err := dir.OpenRw(filepath.Join(nodeConfig.DataDir, "snapshots"))
 		if err != nil {
@@ -1343,9 +1345,8 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *node.Config, cfg *ethconfig.Conf
 		}
 		cfg.SnapshotDir = snDir
 	}
-	if ctx.GlobalBool(SnapshotRetireFlag.Name) {
-		cfg.Snapshot.RetireEnabled = true
-	}
+	cfg.Snapshot.RetireEnabled = ctx.GlobalBool(SnapshotRetireFlag.Name)
+	cfg.Snapshot.KeepBlocks = ctx.GlobalBool(SnapshotKeepBlocksFlag.Name)
 	torrentVerbosity := lg.Warning
 	if ctx.GlobalIsSet(TorrentVerbosityFlag.Name) {
 		torrentVerbosity = torrentcfg.String2LogLevel[ctx.GlobalString(TorrentVerbosityFlag.Name)]

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -619,10 +619,6 @@ var (
 		Name:  "experimental.snapshot",
 		Usage: "Enabling experimental snapshot sync",
 	}
-	SnapshotRetireFlag = cli.BoolFlag{
-		Name:  ethconfig.FlagSnapshotRetire,
-		Usage: "Delete(!) old blocks from DB, by moving them to snapshots",
-	}
 	SnapshotKeepBlocksFlag = cli.BoolFlag{
 		Name:  ethconfig.FlagSnapshotKeepBlocks,
 		Usage: "Keep ancient blocks in db (useful for debug)",
@@ -1345,7 +1341,6 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *node.Config, cfg *ethconfig.Conf
 		}
 		cfg.SnapshotDir = snDir
 	}
-	cfg.Snapshot.RetireEnabled = ctx.GlobalBool(SnapshotRetireFlag.Name)
 	cfg.Snapshot.KeepBlocks = ctx.GlobalBool(SnapshotKeepBlocksFlag.Name)
 	torrentVerbosity := lg.Warning
 	if ctx.GlobalIsSet(TorrentVerbosityFlag.Name) {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -311,6 +311,7 @@ func New(stack *node.Node, config *ethconfig.Config, txpoolCfg txpool2.Config, l
 	}
 
 	var blockReader interfaces.FullBlockReader
+	var allSnapshots *snapshotsync.RoSnapshots
 	if config.Snapshot.Enabled {
 		snConfig := snapshothashes.KnownConfig(chainConfig.ChainName)
 		snConfig.ExpectBlocks, err = RestoreExpectedExternalSnapshot(chainKv, snConfig)
@@ -318,7 +319,7 @@ func New(stack *node.Node, config *ethconfig.Config, txpoolCfg txpool2.Config, l
 			return nil, err
 		}
 
-		allSnapshots := snapshotsync.NewRoSnapshots(config.Snapshot, config.SnapshotDir.Path)
+		allSnapshots = snapshotsync.NewRoSnapshots(config.Snapshot, config.SnapshotDir.Path)
 		allSnapshots.AsyncOpenAll(ctx)
 		blockReader = snapshotsync.NewBlockReaderWithSnapshots(allSnapshots)
 
@@ -502,7 +503,7 @@ func New(stack *node.Node, config *ethconfig.Config, txpoolCfg txpool2.Config, l
 		stack.Config().P2P, *config, chainConfig.TerminalTotalDifficulty,
 		backend.sentryControlServer, tmpdir, backend.notifications.Accumulator,
 		backend.newPayloadCh, backend.forkChoiceCh, &backend.waitingForBeaconChain,
-		backend.downloaderClient)
+		backend.downloaderClient, allSnapshots)
 	if err != nil {
 		return nil, err
 	}

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -123,9 +123,7 @@ func init() {
 //go:generate gencodec -type Config -formats toml -out gen_config.go
 
 type Snapshot struct {
-	Enabled       bool
-	RetireEnabled bool
-
+	Enabled    bool
 	KeepBlocks bool
 }
 
@@ -133,9 +131,6 @@ func (s Snapshot) String() string {
 	var out []string
 	if s.Enabled {
 		out = append(out, "--"+FlagSnapshot+"=true")
-	}
-	if s.RetireEnabled {
-		out = append(out, "--"+FlagSnapshotRetire+"=true")
 	}
 	if s.KeepBlocks {
 		out = append(out, "--"+FlagSnapshotKeepBlocks+"=true")
@@ -145,12 +140,11 @@ func (s Snapshot) String() string {
 
 var (
 	FlagSnapshot           = "experimental.snapshot"
-	FlagSnapshotRetire     = "experimental.snapshot.retire"
 	FlagSnapshotKeepBlocks = "experimental.snapshot.keepblocks"
 )
 
 func NewSnapshotCfg(enabled, keepBlocks bool) Snapshot {
-	return Snapshot{Enabled: enabled, RetireEnabled: true, KeepBlocks: keepBlocks}
+	return Snapshot{Enabled: enabled, KeepBlocks: keepBlocks}
 }
 
 // Config contains configuration options for ETH protocol.

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -125,6 +125,8 @@ func init() {
 type Snapshot struct {
 	Enabled       bool
 	RetireEnabled bool
+
+	KeepBlocks bool
 }
 
 func (s Snapshot) String() string {
@@ -135,16 +137,20 @@ func (s Snapshot) String() string {
 	if s.RetireEnabled {
 		out = append(out, "--"+FlagSnapshotRetire+"=true")
 	}
+	if s.KeepBlocks {
+		out = append(out, "--"+FlagSnapshotKeepBlocks+"=true")
+	}
 	return strings.Join(out, " ")
 }
 
 var (
-	FlagSnapshot       = "experimental.snapshot"
-	FlagSnapshotRetire = "experimental.snapshot.retire"
+	FlagSnapshot           = "experimental.snapshot"
+	FlagSnapshotRetire     = "experimental.snapshot.retire"
+	FlagSnapshotKeepBlocks = "experimental.snapshot.keepblocks"
 )
 
-func NewSnapshotCfg(enabled, retireEnabled bool) Snapshot {
-	return Snapshot{Enabled: enabled, RetireEnabled: retireEnabled}
+func NewSnapshotCfg(enabled, keepBlocks bool) Snapshot {
+	return Snapshot{Enabled: enabled, RetireEnabled: true, KeepBlocks: keepBlocks}
 }
 
 // Config contains configuration options for ETH protocol.

--- a/eth/stagedsync/stage_senders.go
+++ b/eth/stagedsync/stage_senders.go
@@ -419,8 +419,10 @@ func retireBlocks(s *PruneState, cfg SendersCfg, ctx context.Context) (err error
 
 	chainID, _ := uint256.FromBig(cfg.chainConfig.ChainID)
 	cfg.br.RetireBlocks(ctx, blockFrom, blockTo, *chainID, log.LvlDebug)
-	if err := cfg.br.Wait(); err != nil {
-		panic(err)
+	cfg.br.Wait()
+	res := cfg.br.Result()
+	if res.Err != nil {
+		panic(res.Err)
 	}
 
 	return nil

--- a/eth/stagedsync/stage_senders.go
+++ b/eth/stagedsync/stage_senders.go
@@ -377,13 +377,12 @@ func PruneSendersStage(s *PruneState, tx kv.RwTx, cfg SendersCfg, ctx context.Co
 		if err := retireBlocks(s, tx, cfg, ctx); err != nil {
 			return fmt.Errorf("retireBlocks: %w", err)
 		}
-	}
-
-	if cfg.prune.TxIndex.Enabled() {
+	} else {
 		if err = PruneTable(tx, kv.Senders, s.LogPrefix(), to, logEvery, ctx); err != nil {
 			return err
 		}
 	}
+
 	if !useExternalTx {
 		if err = tx.Commit(); err != nil {
 			return err
@@ -400,12 +399,6 @@ func retireBlocks(s *PruneState, tx kv.RwTx, cfg SendersCfg, ctx context.Context
 		if res.Err != nil {
 			return fmt.Errorf("[%s] retire blocks last error: %w", s.LogPrefix(), res.Err)
 		}
-
-		//TODO: avoid too large deletes
-		//if err := rawdb.DeleteAncientBlocks(tx, res.BlockFrom, res.BlockTo); err != nil {
-		//	return nil
-		//}
-		// TODO: seed new 500K files (calc sha1 hash in background)
 	}
 
 	canDeleteTo := cfg.blockRetire.CanDeleteTo(s.ForwardProgress)

--- a/eth/stagedsync/stage_senders.go
+++ b/eth/stagedsync/stage_senders.go
@@ -377,7 +377,7 @@ func PruneSendersStage(s *PruneState, tx kv.RwTx, cfg SendersCfg, ctx context.Co
 		if err := retireBlocks(s, tx, cfg, ctx); err != nil {
 			return fmt.Errorf("retireBlocks: %w", err)
 		}
-	} else {
+	} else if cfg.prune.TxIndex.Enabled() {
 		if err = PruneTable(tx, kv.Senders, s.LogPrefix(), to, logEvery, ctx); err != nil {
 			return err
 		}

--- a/eth/stagedsync/stage_senders.go
+++ b/eth/stagedsync/stage_senders.go
@@ -417,7 +417,7 @@ func retireBlocks(s *PruneState, tx kv.RwTx, cfg SendersCfg, ctx context.Context
 	}
 
 	chainID, _ := uint256.FromBig(cfg.chainConfig.ChainID)
-	cfg.blockRetire.RetireBlocksInBackground(ctx, blockFrom, blockTo, *chainID, log.LvlDebug)
+	cfg.blockRetire.RetireBlocksInBackground(ctx, blockFrom, blockTo, *chainID, log.LvlInfo)
 
 	return nil
 }

--- a/eth/stagedsync/stage_senders_test.go
+++ b/eth/stagedsync/stage_senders_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ledgerwatch/erigon/eth/stagedsync/stages"
 	"github.com/ledgerwatch/erigon/ethdb/prune"
 	"github.com/ledgerwatch/erigon/params"
+	"github.com/ledgerwatch/erigon/turbo/snapshotsync"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -108,7 +109,7 @@ func TestSenders(t *testing.T) {
 
 	require.NoError(stages.SaveStageProgress(tx, stages.Bodies, 3))
 
-	cfg := StageSendersCfg(db, params.TestChainConfig, "", prune.Mode{}, nil)
+	cfg := StageSendersCfg(db, params.TestChainConfig, "", prune.Mode{}, snapshotsync.NewBlockRetire(1, "", nil, db))
 	err := SpawnRecoverSendersStage(cfg, &StageState{ID: stages.Senders}, nil, tx, 3, ctx)
 	assert.NoError(t, err)
 

--- a/turbo/app/snapshots.go
+++ b/turbo/app/snapshots.go
@@ -157,10 +157,12 @@ func doRetireCommand(cliCtx *cli.Context) error {
 	snapshots := snapshotsync.NewRoSnapshots(cfg, snapshotDir)
 	snapshots.ReopenSegments()
 
+	br := snapshotsync.NewBlockRetire(runtime.NumCPU()/2, tmpDir, snapshots, chainDB)
+
 	for i := from; i < to; i += every {
-		if err := snapshotsync.RetireBlocks(ctx, i, i+every, *chainID, tmpDir, snapshots, chainDB, runtime.NumCPU()/2, log.LvlInfo); err != nil {
+		br.RetireBlocks(ctx, i, i+every, *chainID, log.LvlInfo)
+		if err := br.Wait(); err != nil {
 			panic(err)
-			//return err
 		}
 	}
 	return nil

--- a/turbo/app/snapshots.go
+++ b/turbo/app/snapshots.go
@@ -161,8 +161,10 @@ func doRetireCommand(cliCtx *cli.Context) error {
 
 	for i := from; i < to; i += every {
 		br.RetireBlocks(ctx, i, i+every, *chainID, log.LvlInfo)
-		if err := br.Wait(); err != nil {
-			panic(err)
+		br.Wait()
+		res := br.Result()
+		if res.Err != nil {
+			panic(res.Err)
 		}
 	}
 	return nil

--- a/turbo/app/snapshots.go
+++ b/turbo/app/snapshots.go
@@ -160,7 +160,7 @@ func doRetireCommand(cliCtx *cli.Context) error {
 	br := snapshotsync.NewBlockRetire(runtime.NumCPU()/2, tmpDir, snapshots, chainDB)
 
 	for i := from; i < to; i += every {
-		br.RetireBlocks(ctx, i, i+every, *chainID, log.LvlInfo)
+		br.RetireBlocksInBackground(ctx, i, i+every, *chainID, log.LvlInfo)
 		br.Wait()
 		res := br.Result()
 		if res.Err != nil {

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -70,7 +70,6 @@ var DefaultFlags = []cli.Flag{
 	utils.TraceMaxtracesFlag,
 
 	utils.SnapshotSyncFlag,
-	utils.SnapshotRetireFlag,
 	utils.SnapshotKeepBlocksFlag,
 	utils.DbPageSizeFlag,
 	utils.TorrentPortFlag,

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -71,6 +71,7 @@ var DefaultFlags = []cli.Flag{
 
 	utils.SnapshotSyncFlag,
 	utils.SnapshotRetireFlag,
+	utils.SnapshotKeepBlocksFlag,
 	utils.DbPageSizeFlag,
 	utils.TorrentPortFlag,
 	utils.TorrentUploadRateFlag,

--- a/turbo/snapshotsync/block_reader.go
+++ b/turbo/snapshotsync/block_reader.go
@@ -190,13 +190,22 @@ type BlockReaderWithSnapshots struct {
 func NewBlockReaderWithSnapshots(snapshots *RoSnapshots) *BlockReaderWithSnapshots {
 	return &BlockReaderWithSnapshots{sn: snapshots}
 }
-func (back *BlockReaderWithSnapshots) HeaderByNumber(ctx context.Context, tx kv.Getter, blockHeight uint64) (*types.Header, error) {
-	sn, ok := back.sn.Blocks(blockHeight)
-	if !ok {
-		h := rawdb.ReadHeaderByNumber(tx, blockHeight)
+func (back *BlockReaderWithSnapshots) HeaderByNumber(ctx context.Context, tx kv.Getter, blockHeight uint64) (h *types.Header, err error) {
+	ok, err := back.sn.ViewHeaders(blockHeight, func(segment *HeaderSegment) error {
+		h, err = back.headerFromSnapshot(blockHeight, segment, nil)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if ok {
 		return h, nil
 	}
-	return back.headerFromSnapshot(blockHeight, sn, nil)
+
+	return rawdb.ReadHeaderByNumber(tx, blockHeight), nil
 }
 
 // HeaderByHash - will search header in all snapshots starting from recent
@@ -224,53 +233,95 @@ func (back *BlockReaderWithSnapshots) HeaderByHash(ctx context.Context, tx kv.Ge
 	return h, nil
 }
 
-func (back *BlockReaderWithSnapshots) CanonicalHash(ctx context.Context, tx kv.Getter, blockHeight uint64) (common.Hash, error) {
-	sn, ok := back.sn.Blocks(blockHeight)
-	if !ok {
-		return rawdb.ReadCanonicalHash(tx, blockHeight)
-	}
-
-	h, err := back.headerFromSnapshot(blockHeight, sn, nil)
+func (back *BlockReaderWithSnapshots) CanonicalHash(ctx context.Context, tx kv.Getter, blockHeight uint64) (h common.Hash, err error) {
+	ok, err := back.sn.ViewHeaders(blockHeight, func(segment *HeaderSegment) error {
+		header, err := back.headerFromSnapshot(blockHeight, segment, nil)
+		if err != nil {
+			return err
+		}
+		if header == nil {
+			return nil
+		}
+		h = header.Hash()
+		return nil
+	})
 	if err != nil {
-		return common.Hash{}, err
+		return h, err
 	}
-	if h == nil {
-		return common.Hash{}, err
-	}
-	return h.Hash(), nil
-}
-
-func (back *BlockReaderWithSnapshots) Header(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (*types.Header, error) {
-	sn, ok := back.sn.Blocks(blockHeight)
-	if !ok {
-		h := rawdb.ReadHeader(tx, hash, blockHeight)
+	if ok {
 		return h, nil
 	}
 
-	return back.headerFromSnapshot(blockHeight, sn, nil)
+	return rawdb.ReadCanonicalHash(tx, blockHeight)
 }
 
-func (back *BlockReaderWithSnapshots) ReadHeaderByNumber(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (*types.Header, error) {
-	sn, ok := back.sn.Blocks(blockHeight)
-	if !ok {
-		h := rawdb.ReadHeader(tx, hash, blockHeight)
+func (back *BlockReaderWithSnapshots) Header(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (h *types.Header, err error) {
+	ok, err := back.sn.ViewHeaders(blockHeight, func(segment *HeaderSegment) error {
+		h, err = back.headerFromSnapshot(blockHeight, segment, nil)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if ok {
 		return h, nil
 	}
 
-	return back.headerFromSnapshot(blockHeight, sn, nil)
+	h = rawdb.ReadHeader(tx, hash, blockHeight)
+	return h, nil
+}
+
+func (back *BlockReaderWithSnapshots) ReadHeaderByNumber(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (h *types.Header, err error) {
+	ok, err := back.sn.ViewHeaders(blockHeight, func(segment *HeaderSegment) error {
+		h, err = back.headerFromSnapshot(blockHeight, segment, nil)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return h, nil
+	}
+
+	h = rawdb.ReadHeader(tx, hash, blockHeight)
+	return h, nil
 }
 
 func (back *BlockReaderWithSnapshots) BodyWithTransactions(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (body *types.Body, err error) {
-	sn, ok := back.sn.Blocks(blockHeight)
-	if !ok {
-		body, err := rawdb.ReadBodyWithTransactions(tx, hash, blockHeight)
+	var baseTxnID uint64
+	var txsAmount uint32
+	ok, err := back.sn.ViewBodies(blockHeight, func(seg *BodySegment) error {
+		body, baseTxnID, txsAmount, err = back.bodyFromSnapshot(blockHeight, seg, nil)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		ok, err = back.sn.ViewTxs(blockHeight, func(seg *TxnSegment) error {
+			txs, senders, err := back.txsFromSnapshot(baseTxnID, txsAmount, seg, nil)
+			if err != nil {
+				return err
+			}
+			body.Transactions = txs
+			body.SendersToTxs(senders)
+			return nil
+		})
 		if err != nil {
 			return nil, err
 		}
-		return body, nil
+		if ok {
+			return body, nil
+		}
 	}
 
-	body, _, _, _, err = back.bodyWithTransactionsFromSnapshot(blockHeight, sn, nil)
+	body, err = rawdb.ReadBodyWithTransactions(tx, hash, blockHeight)
 	if err != nil {
 		return nil, err
 	}
@@ -290,99 +341,119 @@ func (back *BlockReaderWithSnapshots) BodyRlp(ctx context.Context, tx kv.Getter,
 }
 
 func (back *BlockReaderWithSnapshots) Body(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (body *types.Body, err error) {
-	sn, ok := back.sn.Blocks(blockHeight)
-	if !ok {
-		body, _, _ := rawdb.ReadBody(tx, hash, blockHeight)
-		return body, nil
-	}
-
-	body, _, _, err = back.bodyFromSnapshot(blockHeight, sn, nil)
+	ok, err := back.sn.ViewBodies(blockHeight, func(seg *BodySegment) error {
+		body, _, _, err = back.bodyFromSnapshot(blockHeight, seg, nil)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
+	if ok {
+		return body, nil
+	}
+	body, _, _ = rawdb.ReadBody(tx, hash, blockHeight)
 	return body, nil
 }
 
 func (back *BlockReaderWithSnapshots) BlockWithSenders(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (block *types.Block, senders []common.Address, err error) {
-	sn, ok := back.sn.Blocks(blockHeight)
-	if !ok {
-		canonicalHash, err := rawdb.ReadCanonicalHash(tx, blockHeight)
-		if err != nil {
-			return nil, nil, fmt.Errorf("requested non-canonical hash %x. canonical=%x", hash, canonicalHash)
+	var buf []byte
+	var h *types.Header
+	ok, err := back.sn.ViewHeaders(blockHeight, func(seg *HeaderSegment) error {
+		headerOffset := seg.idxHeaderHash.Lookup2(blockHeight - seg.idxHeaderHash.BaseDataID())
+		gg := seg.seg.MakeGetter()
+		gg.Reset(headerOffset)
+		buf, _ = gg.Next(buf[:0])
+		h = &types.Header{}
+		if err = rlp.DecodeBytes(buf[1:], h); err != nil {
+			return err
 		}
-		if canonicalHash == hash {
-			block, senders, err = rawdb.ReadBlockWithSenders(tx, hash, blockHeight)
-			if err != nil {
-				return nil, nil, err
-			}
-			return block, senders, nil
-		}
-		return rawdb.NonCanonicalBlockWithSenders(tx, hash, blockHeight)
+		return nil
+	})
+	if err != nil {
+		return
 	}
-
-	buf := make([]byte, 16)
-
-	back.lock.Lock()
-	defer back.lock.Unlock()
-
-	headerOffset := sn.HeaderHashIdx.Lookup2(blockHeight - sn.HeaderHashIdx.BaseDataID())
-	bodyOffset := sn.BodyNumberIdx.Lookup2(blockHeight - sn.BodyNumberIdx.BaseDataID())
-
-	gg := sn.Headers.MakeGetter()
-	gg.Reset(headerOffset)
-	buf, _ = gg.Next(buf[:0])
-	h := &types.Header{}
-	if err = rlp.DecodeBytes(buf[1:], h); err != nil {
-		return nil, nil, err
-	}
-
-	gg = sn.Bodies.MakeGetter()
-	gg.Reset(bodyOffset)
-	buf, _ = gg.Next(buf[:0])
-	b := &types.BodyForStorage{}
-	reader := bytes.NewReader(buf)
-	if err = rlp.Decode(reader, b); err != nil {
-		return nil, nil, err
-	}
-
-	if b.BaseTxId < sn.TxnHashIdx.BaseDataID() {
-		return nil, nil, fmt.Errorf(".idx file has wrong baseDataID? %d<%d, %s", b.BaseTxId, sn.TxnHashIdx.BaseDataID(), sn.Transactions.FilePath())
-	}
-
-	txs := make([]types.Transaction, b.TxAmount-2)
-	senders = make([]common.Address, b.TxAmount-2)
-	if b.TxAmount > 2 {
-		r := recsplit.NewIndexReader(sn.TxnIdsIdx)
-		binary.BigEndian.PutUint64(buf[:8], b.BaseTxId-sn.TxnIdsIdx.BaseDataID())
-		txnOffset := r.Lookup(buf[:8])
-		gg = sn.Transactions.MakeGetter()
-		gg.Reset(txnOffset)
-		stream := rlp.NewStream(reader, 0)
-		buf, _ = gg.Next(buf[:0]) //first system-tx
-		for i := uint32(0); i < b.TxAmount-2; i++ {
+	if ok {
+		var b *types.BodyForStorage
+		ok, err = back.sn.ViewBodies(blockHeight, func(seg *BodySegment) error {
+			bodyOffset := seg.idxBodyNumber.Lookup2(blockHeight - seg.idxBodyNumber.BaseDataID())
+			gg := seg.seg.MakeGetter()
+			gg.Reset(bodyOffset)
 			buf, _ = gg.Next(buf[:0])
-			senders[i].SetBytes(buf[1 : 1+20])
-			txRlp := buf[1+20:]
-			reader.Reset(txRlp)
-			stream.Reset(reader, 0)
-			txs[i], err = types.DecodeTransaction(stream)
-			if err != nil {
-				return nil, nil, err
+			b = &types.BodyForStorage{}
+			reader := bytes.NewReader(buf)
+			if err = rlp.Decode(reader, b); err != nil {
+				return err
+			}
+			return nil
+		})
+		if err != nil {
+			return
+		}
+		if ok {
+			txs := make([]types.Transaction, b.TxAmount-2)
+			senders = make([]common.Address, b.TxAmount-2)
+			reader := bytes.NewReader(nil)
+			if b.TxAmount > 2 {
+				ok, err = back.sn.ViewTxs(blockHeight, func(seg *TxnSegment) error {
+					if b.BaseTxId < seg.idxTxnHash.BaseDataID() {
+						return fmt.Errorf(".idx file has wrong baseDataID? %d<%d, %s", b.BaseTxId, seg.idxTxnHash.BaseDataID(), seg.seg.FilePath())
+					}
+					r := recsplit.NewIndexReader(seg.idxTxnId)
+					binary.BigEndian.PutUint64(buf[:8], b.BaseTxId-seg.idxTxnId.BaseDataID())
+					txnOffset := r.Lookup(buf[:8])
+					gg := seg.seg.MakeGetter()
+					gg.Reset(txnOffset)
+					stream := rlp.NewStream(reader, 0)
+					buf, _ = gg.Next(buf[:0]) //first system-tx
+					for i := uint32(0); i < b.TxAmount-2; i++ {
+						buf, _ = gg.Next(buf[:0])
+						senders[i].SetBytes(buf[1 : 1+20])
+						txRlp := buf[1+20:]
+						reader.Reset(txRlp)
+						stream.Reset(reader, 0)
+						txs[i], err = types.DecodeTransaction(stream)
+						if err != nil {
+							return err
+						}
+						txs[i].SetSender(senders[i])
+					}
+					return nil
+				})
+				if err != nil {
+					return nil, nil, err
+				}
+				if ok {
+					block = types.NewBlockFromStorage(hash, h, txs, b.Uncles)
+					if len(senders) != block.Transactions().Len() {
+						return block, senders, nil // no senders is fine - will recover them on the fly
+					}
+					block.SendersToTxs(senders)
+					return block, senders, nil
+				}
 			}
 		}
 	}
 
-	block = types.NewBlockFromStorage(hash, h, txs, b.Uncles)
-	if len(senders) != block.Transactions().Len() {
-		return block, senders, nil // no senders is fine - will recover them on the fly
+	canonicalHash, err := rawdb.ReadCanonicalHash(tx, blockHeight)
+	if err != nil {
+		return nil, nil, fmt.Errorf("requested non-canonical hash %x. canonical=%x", hash, canonicalHash)
 	}
-	block.SendersToTxs(senders)
-	return block, senders, nil
+	if canonicalHash == hash {
+		block, senders, err = rawdb.ReadBlockWithSenders(tx, hash, blockHeight)
+		if err != nil {
+			return nil, nil, err
+		}
+		return block, senders, nil
+	}
+	return rawdb.NonCanonicalBlockWithSenders(tx, hash, blockHeight)
 }
 
-func (back *BlockReaderWithSnapshots) headerFromSnapshot(blockHeight uint64, sn *BlocksSnapshot, buf []byte) (*types.Header, error) {
-	headerOffset := sn.HeaderHashIdx.Lookup2(blockHeight - sn.HeaderHashIdx.BaseDataID())
-	gg := sn.Headers.MakeGetter()
+func (back *BlockReaderWithSnapshots) headerFromSnapshot(blockHeight uint64, sn *HeaderSegment, buf []byte) (*types.Header, error) {
+	headerOffset := sn.idxHeaderHash.Lookup2(blockHeight - sn.idxHeaderHash.BaseDataID())
+	gg := sn.seg.MakeGetter()
 	gg.Reset(headerOffset)
 	buf, _ = gg.Next(buf[:0])
 	h := &types.Header{}
@@ -417,10 +488,10 @@ func (back *BlockReaderWithSnapshots) headerFromSnapshotByHash(hash common.Hash,
 	return h, nil
 }
 
-func (back *BlockReaderWithSnapshots) bodyFromSnapshot(blockHeight uint64, sn *BlocksSnapshot, buf []byte) (*types.Body, uint64, uint32, error) {
-	bodyOffset := sn.BodyNumberIdx.Lookup2(blockHeight - sn.BodyNumberIdx.BaseDataID())
+func (back *BlockReaderWithSnapshots) bodyFromSnapshot(blockHeight uint64, sn *BodySegment, buf []byte) (*types.Body, uint64, uint32, error) {
+	bodyOffset := sn.idxBodyNumber.Lookup2(blockHeight - sn.idxBodyNumber.BaseDataID())
 
-	gg := sn.Bodies.MakeGetter()
+	gg := sn.seg.MakeGetter()
 	gg.Reset(bodyOffset)
 	buf, _ = gg.Next(buf[:0])
 	b := &types.BodyForStorage{}
@@ -429,8 +500,8 @@ func (back *BlockReaderWithSnapshots) bodyFromSnapshot(blockHeight uint64, sn *B
 		return nil, 0, 0, err
 	}
 
-	if b.BaseTxId < sn.TxnHashIdx.BaseDataID() {
-		return nil, 0, 0, fmt.Errorf(".idx file has wrong baseDataID? %d<%d, %s", b.BaseTxId, sn.TxnHashIdx.BaseDataID(), sn.Transactions.FilePath())
+	if b.BaseTxId < sn.idxBodyNumber.BaseDataID() {
+		return nil, 0, 0, fmt.Errorf(".idx file has wrong baseDataID? %d<%d, %s", b.BaseTxId, sn.idxBodyNumber.BaseDataID(), sn.seg.FilePath())
 	}
 
 	body := new(types.Body)
@@ -438,7 +509,7 @@ func (back *BlockReaderWithSnapshots) bodyFromSnapshot(blockHeight uint64, sn *B
 	return body, b.BaseTxId + 1, b.TxAmount - 2, nil // empty txs in the beginning and end of block
 }
 
-func (back *BlockReaderWithSnapshots) bodyWithTransactionsFromSnapshot(blockHeight uint64, sn *BlocksSnapshot, buf []byte) (*types.Body, []common.Address, uint64, uint32, error) {
+func (back *BlockReaderWithSnapshots) bodyWithTransactionsFromSnapshot(blockHeight uint64, sn *BodySegment, txsSeg *TxnSegment, buf []byte) (*types.Body, []common.Address, uint64, uint32, error) {
 	body, baseTxnID, txsAmount, err := back.bodyFromSnapshot(blockHeight, sn, buf)
 	if err != nil {
 		return nil, nil, 0, 0, err
@@ -447,10 +518,10 @@ func (back *BlockReaderWithSnapshots) bodyWithTransactionsFromSnapshot(blockHeig
 	senders := make([]common.Address, txsAmount)
 	reader := bytes.NewReader(buf)
 	if txsAmount > 0 {
-		r := recsplit.NewIndexReader(sn.TxnIdsIdx)
-		binary.BigEndian.PutUint64(buf[:8], baseTxnID-sn.TxnIdsIdx.BaseDataID())
+		r := recsplit.NewIndexReader(txsSeg.idxTxnId)
+		binary.BigEndian.PutUint64(buf[:8], baseTxnID-txsSeg.idxTxnId.BaseDataID())
 		txnOffset := r.Lookup(buf[:8])
-		gg := sn.Transactions.MakeGetter()
+		gg := txsSeg.seg.MakeGetter()
 		gg.Reset(txnOffset)
 		stream := rlp.NewStream(reader, 0)
 		for i := uint32(0); i < txsAmount; i++ {
@@ -468,6 +539,34 @@ func (back *BlockReaderWithSnapshots) bodyWithTransactionsFromSnapshot(blockHeig
 	}
 
 	return body, senders, baseTxnID, txsAmount, nil
+}
+
+func (back *BlockReaderWithSnapshots) txsFromSnapshot(baseTxnID uint64, txsAmount uint32, txsSeg *TxnSegment, buf []byte) ([]types.Transaction, []common.Address, error) {
+	txs := make([]types.Transaction, txsAmount)
+	senders := make([]common.Address, txsAmount)
+	reader := bytes.NewReader(buf)
+	if txsAmount > 0 {
+		r := recsplit.NewIndexReader(txsSeg.idxTxnId)
+		binary.BigEndian.PutUint64(buf[:8], baseTxnID-txsSeg.idxTxnId.BaseDataID())
+		txnOffset := r.Lookup(buf[:8])
+		gg := txsSeg.seg.MakeGetter()
+		gg.Reset(txnOffset)
+		stream := rlp.NewStream(reader, 0)
+		for i := uint32(0); i < txsAmount; i++ {
+			buf, _ = gg.Next(buf[:0])
+			senders[i].SetBytes(buf[1 : 1+20])
+			txRlp := buf[1+20:]
+			reader.Reset(txRlp)
+			stream.Reset(reader, 0)
+			var err error
+			txs[i], err = types.DecodeTransaction(stream)
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+	}
+
+	return txs, senders, nil
 }
 
 func (back *BlockReaderWithSnapshots) txnByHash(txnHash common.Hash, buf []byte) (txn types.Transaction, blockNum, txnID uint64, err error) {

--- a/turbo/snapshotsync/block_reader.go
+++ b/turbo/snapshotsync/block_reader.go
@@ -441,7 +441,6 @@ func (back *BlockReaderWithSnapshots) BlockWithSenders(ctx context.Context, tx k
 				block.SendersToTxs(senders)
 				return block, senders, nil
 			}
-
 		}
 	}
 	canonicalHash, err := rawdb.ReadCanonicalHash(tx, blockHeight)

--- a/turbo/snapshotsync/block_snapshots.go
+++ b/turbo/snapshotsync/block_snapshots.go
@@ -414,7 +414,6 @@ func (s *RoSnapshots) ReopenSomeIndices(types ...Type) (err error) {
 			panic(fmt.Sprintf("unknown snapshot type: %s", t))
 		}
 	}
-	fmt.Printf("b: %d\n", s.segmentsAvailable.Load())
 
 	//TODO: make calculatable?
 	segments := s.Headers.segments
@@ -503,7 +502,6 @@ func (s *RoSnapshots) ReopenSegments() error {
 			s.segmentsAvailable.Store(0)
 		}
 	}
-	fmt.Printf("a: %d\n", s.segmentsAvailable.Load())
 	s.segmentsReady.Store(true)
 	return nil
 }

--- a/turbo/snapshotsync/block_snapshots.go
+++ b/turbo/snapshotsync/block_snapshots.go
@@ -910,7 +910,7 @@ func canRetire(from, to uint64) (blockFrom, blockTo uint64, can bool) {
 	blockFrom = (from / 1_000) * 1_000
 	roundedTo1K := (to / 1_000) * 1_000
 	jump := roundedTo1K - blockFrom
-	switch true { // only next segment sizes are allowed
+	switch { // only next segment sizes are allowed
 	case jump >= 500_000:
 		blockTo = blockFrom + 500_000
 	case jump >= 100_000:

--- a/turbo/snapshotsync/block_snapshots.go
+++ b/turbo/snapshotsync/block_snapshots.go
@@ -417,7 +417,7 @@ func (s *RoSnapshots) ReopenSomeIndices(types ...Type) (err error) {
 
 	//TODO: make calculatable?
 	segments := s.Headers.segments
-	if segments[len(segments)-1].To > 0 {
+	if len(segments) > 0 && segments[len(segments)-1].To > 0 {
 		s.idxAvailable.Store(segments[len(segments)-1].To - 1)
 	} else {
 		s.idxAvailable.Store(0)

--- a/turbo/snapshotsync/block_snapshots.go
+++ b/turbo/snapshotsync/block_snapshots.go
@@ -1669,35 +1669,6 @@ func NewMerger(tmpDir string, workers int, lvl log.Lvl) *Merger {
 	return &Merger{tmpDir: tmpDir, workers: workers, lvl: lvl}
 }
 
-/*
-	a.fileLocks[fType].RLock()
-	defer a.fileLocks[fType].RUnlock()
-	var maxEndBlock uint64
-	a.files[fType].Ascend(func(i btree.Item) bool {
-		item := i.(*byEndBlockItem)
-		if item.decompressor == nil {
-			return true // Skip B-tree based items
-		}
-		pre = append(pre, item)
-		if aggTo == 0 {
-			var doubleEnd uint64
-			nextDouble := item.endBlock
-			for nextDouble <= maxEndBlock && nextDouble-item.startBlock < maxSpan {
-				doubleEnd = nextDouble
-				nextDouble = doubleEnd + (doubleEnd - item.startBlock) + 1
-			}
-			if doubleEnd != item.endBlock {
-				aggFrom = item.startBlock
-				aggTo = doubleEnd
-			} else {
-				post = append(post, item)
-				return true
-			}
-		}
-		toAggregate = append(toAggregate, item)
-		return item.endBlock < aggTo
-	})
-*/
 type mergeRange struct {
 	from, to uint64
 }

--- a/turbo/snapshotsync/block_snapshots.go
+++ b/turbo/snapshotsync/block_snapshots.go
@@ -198,7 +198,7 @@ func (sn *TxnSegment) close() {
 }
 func (sn *TxnSegment) reopen(dir string) (err error) {
 	sn.close()
-	fileName := SegmentFileName(sn.From, sn.To, Bodies)
+	fileName := SegmentFileName(sn.From, sn.To, Transactions)
 	sn.Seg, err = compress.NewDecompressor(path.Join(dir, fileName))
 	if err != nil {
 		return err

--- a/turbo/snapshotsync/block_snapshots.go
+++ b/turbo/snapshotsync/block_snapshots.go
@@ -126,7 +126,7 @@ func (sn *HeaderSegment) close() {
 		sn.idxHeaderHash = nil
 	}
 }
-func (sn *HeaderSegment) Reopen(dir string) (err error) {
+func (sn *HeaderSegment) reopen(dir string) (err error) {
 	sn.close()
 	fileName := SegmentFileName(sn.From, sn.To, Headers)
 	sn.seg, err = compress.NewDecompressor(path.Join(dir, fileName))
@@ -156,7 +156,7 @@ func (sn *BodySegment) close() {
 		sn.idxBodyNumber = nil
 	}
 }
-func (sn *BodySegment) Reopen(dir string) (err error) {
+func (sn *BodySegment) reopen(dir string) (err error) {
 	sn.close()
 	fileName := SegmentFileName(sn.From, sn.To, Bodies)
 	sn.seg, err = compress.NewDecompressor(path.Join(dir, fileName))
@@ -196,7 +196,7 @@ func (sn *TxnSegment) close() {
 		sn.IdxTxnHash2BlockNum = nil
 	}
 }
-func (sn *TxnSegment) Reopen(dir string) (err error) {
+func (sn *TxnSegment) reopen(dir string) (err error) {
 	sn.close()
 	fileName := SegmentFileName(sn.From, sn.To, Bodies)
 	sn.Seg, err = compress.NewDecompressor(path.Join(dir, fileName))
@@ -211,7 +211,7 @@ func (sn *TxnSegment) Reopen(dir string) (err error) {
 	if err != nil {
 		return err
 	}
-	sn.IdxTxnId, err = recsplit.OpenIndex(path.Join(dir, IdxFileName(sn.From, sn.To, Transactions2Block.String())))
+	sn.IdxTxnHash2BlockNum, err = recsplit.OpenIndex(path.Join(dir, IdxFileName(sn.From, sn.To, Transactions2Block.String())))
 	if err != nil {
 		return err
 	}
@@ -230,7 +230,7 @@ func (s *headerSegments) closeLocked() {
 }
 func (s *headerSegments) reopen(dir string) error {
 	for i := range s.segments {
-		if err := s.segments[i].Reopen(dir); err != nil {
+		if err := s.segments[i].reopen(dir); err != nil {
 			return err
 		}
 	}
@@ -265,7 +265,7 @@ func (s *bodySegments) closeLocked() {
 }
 func (s *bodySegments) reopen(dir string) error {
 	for i := range s.segments {
-		if err := s.segments[i].Reopen(dir); err != nil {
+		if err := s.segments[i].reopen(dir); err != nil {
 			return err
 		}
 	}
@@ -300,7 +300,7 @@ func (s *txnSegments) closeLocked() {
 }
 func (s *txnSegments) reopen(dir string) error {
 	for i := range s.segments {
-		if err := s.segments[i].Reopen(dir); err != nil {
+		if err := s.segments[i].reopen(dir); err != nil {
 			return err
 		}
 	}

--- a/turbo/snapshotsync/block_snapshots.go
+++ b/turbo/snapshotsync/block_snapshots.go
@@ -693,7 +693,7 @@ func (br *BlockRetire) Wait() *BlockRetireResult {
 }
 func (br *BlockRetire) RetireBlocks(ctx context.Context, blockFrom, blockTo uint64, chainID uint256.Int, lvl log.Lvl) {
 	br.result = nil
-	if br.working.Load() == true {
+	if br.working.Load() {
 		return
 	}
 
@@ -709,7 +709,6 @@ func (br *BlockRetire) RetireBlocks(ctx context.Context, blockFrom, blockTo uint
 			BlockTo:   blockTo,
 			Err:       err,
 		}
-		return
 	}()
 }
 

--- a/turbo/snapshotsync/block_snapshots.go
+++ b/turbo/snapshotsync/block_snapshots.go
@@ -907,7 +907,7 @@ func (br *BlockRetire) CanRetire(curBlockNum uint64) (blockFrom, blockTo uint64,
 	return canRetire(blockFrom, curBlockNum-params.FullImmutabilityThreshold)
 }
 func canRetire(from, to uint64) (blockFrom, blockTo uint64, can bool) {
-	blockFrom = from
+	blockFrom = (from / 1_000) * 1_000
 	roundedTo1K := (to / 1_000) * 1_000
 	jump := roundedTo1K - blockFrom
 	switch true { // only next segment sizes are allowed
@@ -919,6 +919,8 @@ func canRetire(from, to uint64) (blockFrom, blockTo uint64, can bool) {
 		blockTo = blockFrom + 10_000
 	case jump >= 1_000:
 		blockTo = blockFrom + 1_000
+	default:
+		blockTo = blockFrom
 	}
 	return blockFrom, blockTo, blockTo-blockFrom >= 1_000
 }

--- a/turbo/snapshotsync/block_snapshots.go
+++ b/turbo/snapshotsync/block_snapshots.go
@@ -513,25 +513,22 @@ func (s *RoSnapshots) Close() {
 	s.Txs.Close()
 }
 func (s *RoSnapshots) ViewHeaders(blockNum uint64, f func(*HeaderSegment) error) (found bool, err error) {
-	if !s.indicesReady.Load() {
+	if !s.indicesReady.Load() || blockNum > s.segmentsAvailable.Load() {
 		return false, nil
 	}
 	return s.Headers.ViewSegment(blockNum, f)
 }
-func (s *RoSnapshots) Blocks(blockNumber uint64) (snapshot *BlocksSnapshot, found bool) {
-	if !s.indicesReady.Load() {
-		return nil, false
+func (s *RoSnapshots) ViewBodies(blockNum uint64, f func(*BodySegment) error) (found bool, err error) {
+	if !s.indicesReady.Load() || blockNum > s.segmentsAvailable.Load() {
+		return false, nil
 	}
-
-	if blockNumber > s.segmentsAvailable.Load() {
-		return nil, false
+	return s.Bodies.ViewSegment(blockNum, f)
+}
+func (s *RoSnapshots) ViewTxs(blockNum uint64, f func(segment *TxnSegment) error) (found bool, err error) {
+	if !s.indicesReady.Load() || blockNum > s.segmentsAvailable.Load() {
+		return false, nil
 	}
-	for _, blocksSnapshot := range s.blocks {
-		if blocksSnapshot.Has(blockNumber) {
-			return blocksSnapshot, true
-		}
-	}
-	return snapshot, false
+	return s.Txs.ViewSegment(blockNum, f)
 }
 func (s *RoSnapshots) Blocks(blockNumber uint64) (snapshot *BlocksSnapshot, found bool) {
 	if !s.indicesReady.Load() {

--- a/turbo/snapshotsync/block_snapshots.go
+++ b/turbo/snapshotsync/block_snapshots.go
@@ -531,8 +531,6 @@ func (s *RoSnapshots) closeSegmentsLocked() {
 }
 func (s *RoSnapshots) ViewHeaders(blockNum uint64, f func(sn *HeaderSegment) error) (found bool, err error) {
 	if !s.indicesReady.Load() || blockNum > s.segmentsAvailable.Load() {
-		fmt.Printf("c: %t, %d\n", s.indicesReady.Load(), s.segmentsAvailable.Load())
-		panic(1)
 		return false, nil
 	}
 	return s.Headers.ViewSegment(blockNum, f)

--- a/turbo/snapshotsync/block_snapshots.go
+++ b/turbo/snapshotsync/block_snapshots.go
@@ -414,6 +414,7 @@ func (s *RoSnapshots) ReopenSomeIndices(types ...Type) (err error) {
 			panic(fmt.Sprintf("unknown snapshot type: %s", t))
 		}
 	}
+	fmt.Printf("b: %d\n", s.segmentsAvailable.Load())
 
 	//TODO: make calculatable?
 	segments := s.Headers.segments
@@ -453,7 +454,6 @@ func (s *RoSnapshots) ReopenSegments() error {
 	defer s.Bodies.lock.Unlock()
 	s.Txs.lock.Lock()
 	defer s.Txs.lock.Unlock()
-
 	s.closeSegmentsLocked()
 	files, err := segmentsOfType(s.dir, Headers)
 	if err != nil {
@@ -503,6 +503,7 @@ func (s *RoSnapshots) ReopenSegments() error {
 			s.segmentsAvailable.Store(0)
 		}
 	}
+	fmt.Printf("a: %d\n", s.segmentsAvailable.Load())
 	s.segmentsReady.Store(true)
 	return nil
 }
@@ -532,6 +533,8 @@ func (s *RoSnapshots) closeSegmentsLocked() {
 }
 func (s *RoSnapshots) ViewHeaders(blockNum uint64, f func(sn *HeaderSegment) error) (found bool, err error) {
 	if !s.indicesReady.Load() || blockNum > s.segmentsAvailable.Load() {
+		fmt.Printf("c: %t, %d\n", s.indicesReady.Load(), s.segmentsAvailable.Load())
+		panic(1)
 		return false, nil
 	}
 	return s.Headers.ViewSegment(blockNum, f)

--- a/turbo/snapshotsync/block_snapshots.go
+++ b/turbo/snapshotsync/block_snapshots.go
@@ -687,10 +687,7 @@ func NewBlockRetire(workers int, tmpDir string, snapshots *RoSnapshots, db kv.Ro
 func (br *BlockRetire) Snapshots() *RoSnapshots    { return br.snapshots }
 func (br *BlockRetire) Working() bool              { return br.working.Load() }
 func (br *BlockRetire) Result() *BlockRetireResult { return br.result }
-func (br *BlockRetire) Wait() *BlockRetireResult {
-	br.wg.Wait()
-	return br.result
-}
+func (br *BlockRetire) Wait()                      { br.wg.Wait() }
 func (br *BlockRetire) RetireBlocks(ctx context.Context, blockFrom, blockTo uint64, chainID uint256.Int, lvl log.Lvl) {
 	br.result = nil
 	if br.working.Load() {

--- a/turbo/snapshotsync/block_snapshots_test.go
+++ b/turbo/snapshotsync/block_snapshots_test.go
@@ -107,6 +107,24 @@ func TestMergeSnapshots(t *testing.T) {
 	require.Equal(1, a)
 }
 
+func TestCanRetire(t *testing.T) {
+	require := require.New(t)
+	cases := []struct {
+		inFrom, inTo, outFrom, outTo uint64
+		can                          bool
+	}{
+		{0, 1234, 0, 1000, true},
+		{1_000_000, 1_120_000, 1_000_000, 1_100_000, true},
+		{2_500_000, 4_100_000, 2_500_000, 3_000_000, true},
+		{2_500_000, 2_500_100, 2_500_000, 2_500_000, false},
+	}
+	for _, tc := range cases {
+		from, to, can := canRetire(tc.inFrom, tc.inTo)
+		require.Equal(int(tc.outFrom), int(from))
+		require.Equal(int(tc.outTo), int(to))
+		require.Equal(tc.can, can, tc.inFrom, tc.inTo)
+	}
+}
 func TestRecompress(t *testing.T) {
 	dir, require := t.TempDir(), require.New(t)
 	createFile := func(from, to uint64) { createTestSegmentFile(t, from, to, Headers, dir) }

--- a/turbo/snapshotsync/snapshotsynccli/flags.go
+++ b/turbo/snapshotsync/snapshotsynccli/flags.go
@@ -8,8 +8,7 @@ import (
 )
 
 var (
-	blockSnapshotEnabledKey       = []byte("blocksSnapshotEnabled")
-	blockSnapshotRetireEnabledKey = []byte("blocksSnapshotRetireEnabled")
+	blockSnapshotEnabledKey = []byte("blocksSnapshotEnabled")
 )
 
 func EnsureNotChanged(tx kv.GetPut, cfg ethconfig.Snapshot) error {
@@ -19,13 +18,6 @@ func EnsureNotChanged(tx kv.GetPut, cfg ethconfig.Snapshot) error {
 	}
 	if !ok {
 		return fmt.Errorf("node was started with --%s=%v, can't change it", ethconfig.FlagSnapshot, v)
-	}
-	ok, v, err = kv.EnsureNotChangedBool(tx, kv.DatabaseInfo, blockSnapshotRetireEnabledKey, cfg.RetireEnabled)
-	if err != nil {
-		return err
-	}
-	if !ok {
-		return fmt.Errorf("node was started with --%s=%v, can't change it", ethconfig.FlagSnapshotRetire, v)
 	}
 	return nil
 }

--- a/turbo/stages/mock_sentry.go
+++ b/turbo/stages/mock_sentry.go
@@ -326,7 +326,7 @@ func MockWithEverything(t *testing.T, gspec *core.Genesis, key *ecdsa.PrivateKey
 				blockReader,
 			),
 			stagedsync.StageIssuanceCfg(mock.DB, mock.ChainConfig, blockReader, true),
-			stagedsync.StageSendersCfg(mock.DB, mock.ChainConfig, mock.tmpdir, prune, allSnapshots),
+			stagedsync.StageSendersCfg(mock.DB, mock.ChainConfig, mock.tmpdir, prune, snapshotsync.NewBlockRetire(1, mock.tmpdir, allSnapshots, mock.DB)),
 			stagedsync.StageExecuteBlocksCfg(
 				mock.DB,
 				prune,

--- a/turbo/stages/stageloop.go
+++ b/turbo/stages/stageloop.go
@@ -303,7 +303,7 @@ func NewStagedSync(
 				blockReader,
 			),
 			stagedsync.StageIssuanceCfg(db, controlServer.ChainConfig, blockReader, cfg.EnabledIssuance),
-			stagedsync.StageSendersCfg(db, controlServer.ChainConfig, tmpdir, cfg.Prune, allSnapshots),
+			stagedsync.StageSendersCfg(db, controlServer.ChainConfig, tmpdir, cfg.Prune, snapshotsync.NewBlockRetire(1, tmpdir, allSnapshots, db)),
 			stagedsync.StageExecuteBlocksCfg(
 				db,
 				cfg.Prune,

--- a/turbo/stages/stageloop.go
+++ b/turbo/stages/stageloop.go
@@ -253,11 +253,10 @@ func NewStagedSync(
 	forkChoiceCh chan privateapi.ForkChoiceMessage,
 	waitingForBeaconChain *uint32,
 	snapshotDownloader proto_downloader.DownloaderClient,
+	allSnapshots *snapshotsync.RoSnapshots,
 ) (*stagedsync.Sync, error) {
 	var blockReader interfaces.FullBlockReader
-	var allSnapshots *snapshotsync.RoSnapshots
 	if cfg.Snapshot.Enabled {
-		allSnapshots = snapshotsync.NewRoSnapshots(cfg.Snapshot, cfg.SnapshotDir.Path)
 		blockReader = snapshotsync.NewBlockReaderWithSnapshots(allSnapshots)
 	} else {
 		blockReader = snapshotsync.NewBlockReader()


### PR DESCRIPTION
- auto-merge segments on 1K, 10K, 100K, 500K thresholds
- retire old blocks and delete from db
- now background retire initiated by stage_senders.Prune func, even if pruning disabled (maybe in future will move to own stage or smash around multiple sages - will see).
- deletes are not limited yet