### PR TITLE
Pick up erigon-lib fix for h2048 (#367)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/kevinburke/go-bindata v3.21.0+incompatible
-	github.com/ledgerwatch/erigon-lib v0.0.0-20220316042255-c79ae94e37b2
+	github.com/ledgerwatch/erigon-lib v0.0.0-20220316043033-05b59ea52483
 	github.com/ledgerwatch/log/v3 v3.4.1
 	github.com/ledgerwatch/secp256k1 v1.0.0
 	github.com/magiconair/properties v1.8.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -615,8 +615,8 @@ github.com/kylelemons/godebug v0.0.0-20170224010052-a616ab194758 h1:0D5M2HQSGD3P
 github.com/kylelemons/godebug v0.0.0-20170224010052-a616ab194758/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
-github.com/ledgerwatch/erigon-lib v0.0.0-20220316042255-c79ae94e37b2 h1:Ga73O/2JnXUB9eDxNOuA/Rgz/3VfhUfvXEDA/5TEAsg=
-github.com/ledgerwatch/erigon-lib v0.0.0-20220316042255-c79ae94e37b2/go.mod h1:DOOU7AueOIleumnEzs21bwDaOMu5lJAzZtuxBoTrgm4=
+github.com/ledgerwatch/erigon-lib v0.0.0-20220316043033-05b59ea52483 h1:OHZBBaYEvY4HF0B+6Ccn+EuRRTB8yejTgyIkNYGS2yA=
+github.com/ledgerwatch/erigon-lib v0.0.0-20220316043033-05b59ea52483/go.mod h1:DOOU7AueOIleumnEzs21bwDaOMu5lJAzZtuxBoTrgm4=
 github.com/ledgerwatch/log/v3 v3.4.1 h1:/xGwlVulXnsO9Uq+tzaExc8OWmXXHU0dnLalpbnY5Bc=
 github.com/ledgerwatch/log/v3 v3.4.1/go.mod h1:VXcz6Ssn6XEeU92dCMc39/g1F0OYAjw1Mt+dGP5DjXY=
 github.com/ledgerwatch/secp256k1 v1.0.0 h1:Usvz87YoTG0uePIV8woOof5cQnLXGYa162rFf3YnwaQ=


### PR DESCRIPTION
Update erigon-lib to https://github.com/ledgerwatch/erigon-lib/commit/05b59ea52483e9607258b1ebdca8923a4a2960c3 and thus pick up https://github.com/ledgerwatch/erigon-lib/pull/367.