### PR TITLE
Fix for eth_getBalance (and other RPC methods accessing history)

### DIFF
--- a/turbo/rpchelper/helper.go
+++ b/turbo/rpchelper/helper.go
@@ -99,7 +99,7 @@ func CreateStateReader(ctx context.Context, tx kv.Tx, blockNrOrHash rpc.BlockNum
 		}
 		stateReader = state.NewCachedReader2(cacheView, tx)
 	} else {
-		stateReader = state.NewPlainState(tx, blockNumber)
+		stateReader = state.NewPlainState(tx, blockNumber+1)
 	}
 	return stateReader, nil
 }


### PR DESCRIPTION
Fixes https://github.com/ledgerwatch/erigon/issues/3630