### PR TITLE
Fix erigon version miss git commit

### DIFF
--- a/turbo/app/make_app.go
+++ b/turbo/app/make_app.go
@@ -17,7 +17,7 @@ import (
 // * action: the main function for the application. receives `*cli.Context` with parsed command-line flags. Returns no error, if some error could not be recovered from write to the log or panic.
 // * cliFlags: the list of flags `cli.Flag` that the app should set and parse. By default, use `DefaultFlags()`. If you want to specify your own flag, use `append(DefaultFlags(), myFlag)` for this parameter.
 func MakeApp(action func(*cli.Context), cliFlags []cli.Flag) *cli.App {
-	app := flags.NewApp("", "", "erigon experimental cli")
+	app := flags.NewApp(params.GitCommit, "", "erigon experimental cli")
 	app.Action = action
 	app.Flags = append(cliFlags, debug.Flags...) // debug flags are required
 	app.Before = func(ctx *cli.Context) error {


### PR DESCRIPTION
`app.MakeApp()` should pass erigon's `params.GitCommit` to `cli.NewApp()` 
https://github.com/ledgerwatch/erigon/blob/ec4b5e6c6f7561bf34676f868b0c538e45091114/turbo/app/make_app.go#L19-L21
