### PR TITLE
Limit amount of deletes during one sync cycle

### DIFF
--- a/eth/stagedsync/stage.go
+++ b/eth/stagedsync/stage.go
@@ -109,7 +109,7 @@ func (s *PruneState) DoneAt(db kv.Putter, blockNum uint64) error {
 	return stages.SaveStagePruneProgress(db, s.ID, blockNum)
 }
 
-func PruneTable(tx kv.RwTx, table string, logPrefix string, pruneTo uint64, logEvery *time.Ticker, ctx context.Context) error {
+func PruneTable(tx kv.RwTx, table string, logPrefix string, pruneTo uint64, logEvery *time.Ticker, ctx context.Context, limit int) error {
 	c, err := tx.RwCursor(table)
 
 	if err != nil {
@@ -117,9 +117,14 @@ func PruneTable(tx kv.RwTx, table string, logPrefix string, pruneTo uint64, logE
 	}
 	defer c.Close()
 
+	i := 0
 	for k, _, err := c.First(); k != nil; k, _, err = c.Next() {
 		if err != nil {
 			return err
+		}
+		i++
+		if i > limit {
+			break
 		}
 
 		blockNum := binary.BigEndian.Uint64(k)

--- a/eth/stagedsync/stage.go
+++ b/eth/stagedsync/stage.go
@@ -109,6 +109,7 @@ func (s *PruneState) DoneAt(db kv.Putter, blockNum uint64) error {
 	return stages.SaveStagePruneProgress(db, s.ID, blockNum)
 }
 
+// PruneTable has `limit` parameter to avoid too large data deletes per one sync cycle - better delete by small portions to reduce db.FreeList size
 func PruneTable(tx kv.RwTx, table string, logPrefix string, pruneTo uint64, logEvery *time.Ticker, ctx context.Context, limit int) error {
 	c, err := tx.RwCursor(table)
 

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -571,10 +571,10 @@ func PruneExecutionStage(s *PruneState, tx kv.RwTx, cfg ExecuteBlockCfg, ctx con
 	}
 
 	if cfg.prune.Receipts.Enabled() {
-		if err = PruneTable(tx, kv.Receipts, logPrefix, cfg.prune.Receipts.PruneTo(s.ForwardProgress), logEvery, ctx, 10_000); err != nil {
+		if err = PruneTable(tx, kv.Receipts, logPrefix, cfg.prune.Receipts.PruneTo(s.ForwardProgress), logEvery, ctx, 1_000); err != nil {
 			return err
 		}
-		if err = PruneTable(tx, kv.Log, logPrefix, cfg.prune.Receipts.PruneTo(s.ForwardProgress), logEvery, ctx, 10_000); err != nil {
+		if err = PruneTable(tx, kv.Log, logPrefix, cfg.prune.Receipts.PruneTo(s.ForwardProgress), logEvery, ctx, 1_000); err != nil {
 			return err
 		}
 	}

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -571,10 +571,10 @@ func PruneExecutionStage(s *PruneState, tx kv.RwTx, cfg ExecuteBlockCfg, ctx con
 	}
 
 	if cfg.prune.Receipts.Enabled() {
-		if err = PruneTable(tx, kv.Receipts, logPrefix, cfg.prune.Receipts.PruneTo(s.ForwardProgress), logEvery, ctx); err != nil {
+		if err = PruneTable(tx, kv.Receipts, logPrefix, cfg.prune.Receipts.PruneTo(s.ForwardProgress), logEvery, ctx, 10_000); err != nil {
 			return err
 		}
-		if err = PruneTable(tx, kv.Log, logPrefix, cfg.prune.Receipts.PruneTo(s.ForwardProgress), logEvery, ctx); err != nil {
+		if err = PruneTable(tx, kv.Log, logPrefix, cfg.prune.Receipts.PruneTo(s.ForwardProgress), logEvery, ctx, 10_000); err != nil {
 			return err
 		}
 	}

--- a/eth/stagedsync/stage_senders.go
+++ b/eth/stagedsync/stage_senders.go
@@ -378,7 +378,7 @@ func PruneSendersStage(s *PruneState, tx kv.RwTx, cfg SendersCfg, ctx context.Co
 			return fmt.Errorf("retireBlocks: %w", err)
 		}
 	} else if cfg.prune.TxIndex.Enabled() {
-		if err = PruneTable(tx, kv.Senders, s.LogPrefix(), to, logEvery, ctx, 10_000); err != nil {
+		if err = PruneTable(tx, kv.Senders, s.LogPrefix(), to, logEvery, ctx, 1_000); err != nil {
 			return err
 		}
 	}

--- a/eth/stagedsync/stage_senders.go
+++ b/eth/stagedsync/stage_senders.go
@@ -378,7 +378,7 @@ func PruneSendersStage(s *PruneState, tx kv.RwTx, cfg SendersCfg, ctx context.Co
 			return fmt.Errorf("retireBlocks: %w", err)
 		}
 	} else if cfg.prune.TxIndex.Enabled() {
-		if err = PruneTable(tx, kv.Senders, s.LogPrefix(), to, logEvery, ctx); err != nil {
+		if err = PruneTable(tx, kv.Senders, s.LogPrefix(), to, logEvery, ctx, 10_000); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
problem: bsc with --prune flag producing much GC in DB. (it's mostly related to stage_senders.prune func)
solution: just prune data by smaller portions on each sync cycle - then new blocks will re-use existing free space in DB and effect will be smaller. 
 