### PR TITLE
Fix block hash announces

### DIFF
--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -801,6 +801,9 @@ func (hd *HeaderDownload) InsertHeaders(hf FeedHeaderFunc, terminalTotalDifficul
 					return false, err
 				}
 				if td != nil {
+					if hd.seenAnnounces.Pop(link.hash) {
+						hd.toAnnounce = append(hd.toAnnounce, Announce{Hash: link.hash, Number: link.blockHeight})
+					}
 					// Check if transition to proof-of-stake happened and stop forward syncing
 					if terminalTotalDifficulty != nil && td.Cmp(terminalTotalDifficulty) >= 0 {
 						hd.highestInDb = link.blockHeight


### PR DESCRIPTION
The refactor of `InsertHeaders()` in #3489 left out the migration from `seenAnnounces` to `toAnnounce`, so new block hashes were no longer being re-broadcast / re-propagated.