### PR TITLE
Check TerminalTotalDifficulty for NewPayload & ForkChoice

### DIFF
--- a/ethdb/privateapi/ethbackend.go
+++ b/ethdb/privateapi/ethbackend.go
@@ -326,7 +326,7 @@ func (s *EthBackendServer) EngineNewPayloadV1(ctx context.Context, req *types2.E
 		return nil, err
 	}
 	if parentTd != nil && parentTd.Cmp(s.config.TerminalTotalDifficulty) < 0 {
-		log.Warn("[NewPayload] TTD not reached yet", "forkChoice", "height", header.Number, "hash", common.Hash(blockHash))
+		log.Warn("[NewPayload] TTD not reached yet", "height", header.Number, "hash", common.Hash(blockHash))
 		return &remote.EnginePayloadStatus{Status: remote.EngineStatus_INVALID_TERMINAL_BLOCK}, nil
 	}
 	tx.Rollback()

--- a/ethdb/privateapi/ethbackend.go
+++ b/ethdb/privateapi/ethbackend.go
@@ -317,6 +317,20 @@ func (s *EthBackendServer) EngineNewPayloadV1(ctx context.Context, req *types2.E
 		return &remote.EnginePayloadStatus{Status: remote.EngineStatus_INVALID_BLOCK_HASH}, nil
 	}
 
+	tx, err := s.db.BeginRo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	parentTd, err := rawdb.ReadTd(tx, header.ParentHash, req.BlockNumber-1)
+	if err != nil {
+		return nil, err
+	}
+	if parentTd != nil && parentTd.Cmp(s.config.TerminalTotalDifficulty) < 0 {
+		log.Warn("[NewPayload] TTD not reached yet", "forkChoice", "height", header.Number, "hash", common.Hash(blockHash))
+		return &remote.EnginePayloadStatus{Status: remote.EngineStatus_INVALID_TERMINAL_BLOCK}, nil
+	}
+	tx.Rollback()
+
 	// If another payload is already commissioned then we just reply with syncing
 	if s.stageLoopIsBusy() {
 		// We are still syncing a commissioned payload
@@ -416,6 +430,28 @@ func (s *EthBackendServer) EngineForkChoiceUpdatedV1(ctx context.Context, req *r
 		return nil, fmt.Errorf("not a proof-of-stake chain")
 	}
 
+	forkChoiceMessage := engineapi.ForkChoiceMessage{
+		HeadBlockHash:      gointerfaces.ConvertH256ToHash(req.ForkchoiceState.HeadBlockHash),
+		SafeBlockHash:      gointerfaces.ConvertH256ToHash(req.ForkchoiceState.SafeBlockHash),
+		FinalizedBlockHash: gointerfaces.ConvertH256ToHash(req.ForkchoiceState.FinalizedBlockHash),
+	}
+
+	tx1, err := s.db.BeginRo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	td, err := rawdb.ReadTdByHash(tx1, forkChoiceMessage.HeadBlockHash)
+	if err != nil {
+		return nil, err
+	}
+	if td != nil && td.Cmp(s.config.TerminalTotalDifficulty) < 0 {
+		log.Warn("[ForkChoiceUpdated] TTD not reached yet", "forkChoice", forkChoiceMessage)
+		return &remote.EngineForkChoiceUpdatedReply{
+			PayloadStatus: &remote.EnginePayloadStatus{Status: remote.EngineStatus_INVALID_TERMINAL_BLOCK},
+		}, nil
+	}
+	tx1.Rollback()
+
 	// TODO(yperbasis): Client software MAY skip an update of the forkchoice state and
 	// MUST NOT begin a payload build process if forkchoiceState.headBlockHash doesn't reference a leaf of the block tree
 	// (i.e. it references an old block).
@@ -426,12 +462,6 @@ func (s *EthBackendServer) EngineForkChoiceUpdatedV1(ctx context.Context, req *r
 		return &remote.EngineForkChoiceUpdatedReply{
 			PayloadStatus: &remote.EnginePayloadStatus{Status: remote.EngineStatus_SYNCING},
 		}, nil
-	}
-
-	forkChoiceMessage := engineapi.ForkChoiceMessage{
-		HeadBlockHash:      gointerfaces.ConvertH256ToHash(req.ForkchoiceState.HeadBlockHash),
-		SafeBlockHash:      gointerfaces.ConvertH256ToHash(req.ForkchoiceState.SafeBlockHash),
-		FinalizedBlockHash: gointerfaces.ConvertH256ToHash(req.ForkchoiceState.FinalizedBlockHash),
 	}
 
 	log.Trace("[ForkChoiceUpdated] sending forkChoiceMessage", "head", forkChoiceMessage.HeadBlockHash)
@@ -458,14 +488,14 @@ func (s *EthBackendServer) EngineForkChoiceUpdatedV1(ctx context.Context, req *r
 	// payload IDs start from 1 (0 signifies null)
 	s.payloadId++
 
-	tx, err := s.db.BeginRo(ctx)
+	tx2, err := s.db.BeginRo(ctx)
 	if err != nil {
 		return nil, err
 	}
-	headHash := rawdb.ReadHeadBlockHash(tx)
-	headNumber := rawdb.ReadHeaderNumber(tx, headHash)
-	headHeader := rawdb.ReadHeader(tx, headHash, *headNumber)
-	tx.Rollback()
+	headHash := rawdb.ReadHeadBlockHash(tx2)
+	headNumber := rawdb.ReadHeaderNumber(tx2, headHash)
+	headHeader := rawdb.ReadHeader(tx2, headHash, *headNumber)
+	tx2.Rollback()
 
 	if headHeader.Hash() != forkChoiceMessage.HeadBlockHash {
 		return nil, fmt.Errorf("unexpected head hash: %x vs %x", headHeader.Hash(), forkChoiceMessage.HeadBlockHash)


### PR DESCRIPTION
This should fix the following Hive test failures:
- Invalid Terminal Block in ForkchoiceUpdated: Test sends an fcU with a block that has not reached the TTD (the genesis in this case), expected response is INVALID_TERMINAL_BLOCK, but Erigon responds SYNCING
- Invalid Terminal Block in NewPayload: Test creates a payload that references a PoW block with an invalid total difficulty (the genesis in this case), expected response is INVALID_TERMINAL_BLOCK, but Erigon responds SYNCING