### PR TITLE
Prohibit EIP-2718 txn wrapped as RLP strings

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -205,6 +205,11 @@ func DecodeTransactions(txs [][]byte) ([]Transaction, error) {
 	return result, nil
 }
 
+func TypedTransactionMarshalledAsRlpString(data []byte) bool {
+	// Unless it's a single byte, serialized RLP strings have their first byte in the [0x80, 0xc0) range
+	return len(data) > 0 && 0x80 <= data[0] && data[0] < 0xc0
+}
+
 func sanityCheckSignature(v *uint256.Int, r *uint256.Int, s *uint256.Int, maybeProtected bool) error {
 	if isProtectedV(v) && !maybeProtected {
 		return ErrUnexpectedProtection

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math/big"
 	"reflect"
 	"testing"
@@ -32,6 +33,7 @@ import (
 	"github.com/ledgerwatch/erigon/common/u256"
 	"github.com/ledgerwatch/erigon/crypto"
 	"github.com/ledgerwatch/erigon/rlp"
+	"github.com/stretchr/testify/assert"
 )
 
 // The values in those tests are from the Transaction Tests
@@ -96,6 +98,14 @@ var (
 	)
 )
 
+func TestDecodeEmptyInput(t *testing.T) {
+	input := []byte{}
+	_, err := DecodeTransaction(rlp.NewStream(bytes.NewReader(input), 0))
+	if !errors.Is(err, io.EOF) {
+		t.Fatal("wrong error:", err)
+	}
+}
+
 func TestDecodeEmptyTypedTx(t *testing.T) {
 	input := []byte{0x80}
 	_, err := DecodeTransaction(rlp.NewStream(bytes.NewReader(input), 0))
@@ -122,6 +132,7 @@ func TestTransactionEncode(t *testing.T) {
 	if !bytes.Equal(txb, should) {
 		t.Errorf("encoded RLP mismatch, got %x", txb)
 	}
+	assert.False(t, TypedTransactionMarshalledAsRlpString(txb))
 }
 
 func TestEIP2718TransactionSigHash(t *testing.T) {
@@ -226,6 +237,7 @@ func TestEIP2718TransactionEncode(t *testing.T) {
 		if !bytes.Equal(have, want) {
 			t.Errorf("encoded RLP mismatch, got %x", have)
 		}
+		assert.True(t, TypedTransactionMarshalledAsRlpString(have))
 	}
 	// Binary representation
 	{
@@ -238,6 +250,7 @@ func TestEIP2718TransactionEncode(t *testing.T) {
 		if !bytes.Equal(have, want) {
 			t.Errorf("encoded RLP mismatch, got %x", have)
 		}
+		assert.False(t, TypedTransactionMarshalledAsRlpString(have))
 	}
 }
 func TestEIP1559TransactionEncode(t *testing.T) {
@@ -255,6 +268,7 @@ func TestEIP1559TransactionEncode(t *testing.T) {
 		if err != nil {
 			t.Fatalf("decode error: %v", err)
 		}
+		assert.False(t, TypedTransactionMarshalledAsRlpString(have))
 	}
 }
 

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -365,6 +365,19 @@ func handleNewPayload(
 
 	cfg.hd.BeaconRequestList.Remove(requestId)
 
+	for _, tx := range payloadMessage.Body.Transactions {
+		if types.TypedTransactionMarshalledAsRlpString(tx) {
+			if requestStatus == engineapi.New {
+				cfg.hd.PayloadStatusCh <- privateapi.PayloadStatus{
+					Status:          remote.EngineStatus_INVALID,
+					LatestValidHash: header.ParentHash,
+					ValidationError: errors.New("typed txn marshalled as RLP string"),
+				}
+			}
+			return nil
+		}
+	}
+
 	transactions, err := types.DecodeTransactions(payloadMessage.Body.Transactions)
 	if err != nil {
 		log.Warn("Error during Beacon transaction decoding", "err", err.Error())

--- a/ethdb/privateapi/ethbackend.go
+++ b/ethdb/privateapi/ethbackend.go
@@ -308,7 +308,7 @@ func (s *EthBackendServer) EngineNewPayloadV1(ctx context.Context, req *types2.E
 		Difficulty:  serenity.SerenityDifficulty,
 		Nonce:       serenity.SerenityNonce,
 		ReceiptHash: gointerfaces.ConvertH256ToHash(req.ReceiptRoot),
-		TxHash:      types.DeriveSha(types.RawTransactions(req.Transactions)), // TODO(yperbasis): prohibit EIP-2718 txn wrapped as RLP strings
+		TxHash:      types.DeriveSha(types.RawTransactions(req.Transactions)),
 	}
 
 	blockHash := gointerfaces.ConvertH256ToHash(req.BlockHash)


### PR DESCRIPTION
According to [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718), for the purpose of calculating transaction root in headers typed transactions should be serialized with their type prepended as the first byte, without extra wrapping as RLP strings. On the other hand, `DecodeTransaction` (and, by extension,`DecodeTransactions`) parses such string wraps fine.