### PR TITLE
Check that safe & finalized blocks are ancestors of head block

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -64,6 +64,19 @@ func DeleteCanonicalHash(db kv.Deleter, number uint64) error {
 	return nil
 }
 
+// IsCanonicalHash determines whether a header with the given hash is on the canonical chain.
+func IsCanonicalHash(db kv.Getter, hash common.Hash) (bool, error) {
+	number := ReadHeaderNumber(db, hash)
+	if number == nil {
+		return false, nil
+	}
+	canonicalHash, err := ReadCanonicalHash(db, *number)
+	if err != nil {
+		return false, err
+	}
+	return canonicalHash != (common.Hash{}) && canonicalHash == hash, nil
+}
+
 // ReadHeaderNumber returns the header number assigned to a hash.
 func ReadHeaderNumber(db kv.Getter, hash common.Hash) *uint64 {
 	data, err := db.GetOne(kv.HeaderNumber, hash.Bytes())


### PR DESCRIPTION
This should fix the following Hive test failures:
- Unknown SafeBlockHash: Test sends an fcU with an unknown (random) hash in the SafeBlockHash, and expects an error back, Erigon responds with VALID
- Unknown FinalizedBlockHash: Test sends an fcU with an unknown (random) hash in the FinalizedBlockHash, and expects an error back, Erigon responds with VALID

See also https://discord.com/channels/595666850260713488/892088344438255616/961231105921536010