### PR TITLE
RPC: return latest available block rather than forkchoice head

### DIFF
--- a/cmd/rpcdaemon/commands/rpc_block.go
+++ b/cmd/rpcdaemon/commands/rpc_block.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 
 	"github.com/ledgerwatch/erigon-lib/kv"
-	"github.com/ledgerwatch/erigon/common"
-	"github.com/ledgerwatch/erigon/core/rawdb"
 	"github.com/ledgerwatch/erigon/eth/stagedsync/stages"
 	"github.com/ledgerwatch/erigon/rpc"
 )
@@ -28,14 +26,6 @@ func getBlockNumber(number rpc.BlockNumber, tx kv.Tx) (uint64, error) {
 }
 
 func getLatestBlockNumber(tx kv.Tx) (uint64, error) {
-	forkchoiceHeadHash := rawdb.ReadForkchoiceHead(tx)
-	if forkchoiceHeadHash != (common.Hash{}) {
-		forkchoiceHeadNum := rawdb.ReadHeaderNumber(tx, forkchoiceHeadHash)
-		if forkchoiceHeadNum != nil {
-			return *forkchoiceHeadNum, nil
-		}
-	}
-
 	blockNum, err := stages.GetStageProgress(tx, stages.Execution)
 	if err != nil {
 		return 0, fmt.Errorf("getting latest block number: %w", err)


### PR DESCRIPTION
To be consistent with geth. This partially reverts PR #3806.