### PR TITLE
Fix some cli flag descriptions

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -313,7 +313,7 @@ var (
 	}
 	HTTPEnabledFlag = cli.BoolFlag{
 		Name:  "http",
-		Usage: "Enable the HTTP-RPC server",
+		Usage: "Enabled by default. Use --http=false to disable the HTTP-RPC server",
 	}
 	HTTPListenAddrFlag = cli.StringFlag{
 		Name:  "http.addr",
@@ -344,11 +344,11 @@ var (
 
 	HttpCompressionFlag = cli.BoolFlag{
 		Name:  "http.compression",
-		Usage: "Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard.",
+		Usage: "Enable compression over HTTP-RPC",
 	}
 	WsCompressionFlag = cli.BoolFlag{
 		Name:  "ws.compression",
-		Usage: "Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard.",
+		Usage: "Enable compression over WebSocket",
 	}
 	HTTPCORSDomainFlag = cli.StringFlag{
 		Name:  "http.corsdomain",
@@ -645,7 +645,7 @@ var (
 	TorrentUploadRateFlag = cli.StringFlag{
 		Name:  "torrent.upload.rate",
 		Value: "4mb",
-		Usage: "byt,es per second, example: 32mb",
+		Usage: "bytes per second, example: 32mb",
 	}
 	TorrentPortFlag = cli.IntFlag{
 		Name:  "torrent.port",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -635,7 +635,7 @@ var (
 	TorrentVerbosityFlag = cli.StringFlag{
 		Name:  "torrent.verbosity",
 		Value: lg.Warning.LogString(),
-		Usage: "DEBUG | INFO | WARN | ERROR",
+		Usage: "DEBUG | INFO | WARN | ERROR (must set --verbosity to equal or higher level)",
 	}
 	TorrentDownloadRateFlag = cli.StringFlag{
 		Name:  "torrent.download.rate",


### PR DESCRIPTION
A few easy fixes related to my #3932 issue

* Changes the wording on `--http` to clearly indicate that it's default, and how to disable it
* Changes the description of http and ws compression flags
* Fixes typo
* Adds a note about `--verbosity` for `--torrent.verbosity` flag