### PR TITLE
got rid of the automatic usage of net api

### DIFF
--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -325,6 +325,7 @@ func RemoteServices(ctx context.Context, cfg httpcfg.HttpCfg, logger log.Logger,
 				case "engine":
 					hasEngineApiEnabled = true
 			}
+			}
 
 			if !hasEthApiEnabled {
 				cfg.API = append(cfg.API, "eth")

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -288,7 +288,7 @@ func RemoteServices(ctx context.Context, cfg httpcfg.HttpCfg, logger log.Logger,
 		}
 		log.Info("if you run RPCDaemon on same machine with Erigon add --datadir option")
 	}
-	
+
 	if db != nil {
 		var cc *params.ChainConfig
 		if err := db.View(context.Background(), func(tx kv.Tx) error {

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -313,7 +313,7 @@ func RemoteServices(ctx context.Context, cfg httpcfg.HttpCfg, logger log.Logger,
 			cfg.Snapshot = ethconfig.NewSnapshotCfg(cfg.Snapshot.Enabled, cfg.Snapshot.KeepBlocks)
 		}
 
-		// if chain config has terminal total difficulty then rpc has to have these API's to function
+		// if chain config has terminal total difficulty then rpc must have eth and engine APIs enableds
 		if cc.TerminalTotalDifficulty != nil {
 			hasEthApiEnabled := false
 			hasEngineApiEnabled := false

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -288,6 +288,7 @@ func RemoteServices(ctx context.Context, cfg httpcfg.HttpCfg, logger log.Logger,
 		}
 		log.Info("if you run RPCDaemon on same machine with Erigon add --datadir option")
 	}
+	
 	if db != nil {
 		var cc *params.ChainConfig
 		if err := db.View(context.Background(), func(tx kv.Tx) error {

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -317,7 +317,6 @@ func RemoteServices(ctx context.Context, cfg httpcfg.HttpCfg, logger log.Logger,
 		if cc.TerminalTotalDifficulty != nil {
 			hasEthApiEnabled := false
 			hasEngineApiEnabled := false
-			hasNetApiEnabled := false
 
 			for _, api := range cfg.API {
 				switch api {
@@ -325,9 +324,6 @@ func RemoteServices(ctx context.Context, cfg httpcfg.HttpCfg, logger log.Logger,
 					hasEthApiEnabled = true
 				case "engine":
 					hasEngineApiEnabled = true
-				case "net":
-					hasNetApiEnabled = true
-				}
 			}
 
 			if !hasEthApiEnabled {
@@ -337,11 +333,6 @@ func RemoteServices(ctx context.Context, cfg httpcfg.HttpCfg, logger log.Logger,
 			if !hasEngineApiEnabled {
 				cfg.API = append(cfg.API, "engine")
 			}
-
-			if !hasNetApiEnabled {
-				cfg.API = append(cfg.API, "net")
-			}
-
 		}
 	}
 

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -324,7 +324,7 @@ func RemoteServices(ctx context.Context, cfg httpcfg.HttpCfg, logger log.Logger,
 					hasEthApiEnabled = true
 				case "engine":
 					hasEngineApiEnabled = true
-			}
+				}
 			}
 
 			if !hasEthApiEnabled {


### PR DESCRIPTION
Net API is not required for to run the engine rpc