### PR TITLE
RPC: admin.peers()

### DIFF
--- a/cmd/downloader/downloader/downloader.go
+++ b/cmd/downloader/downloader/downloader.go
@@ -163,19 +163,6 @@ type AggStats struct {
 	bytesWritten int64
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 func CalcStats(prevStats AggStats, interval time.Duration, client *torrent.Client) (result AggStats) {
 	var aggBytesCompleted, aggLen int64
 	//var aggCompletedPieces, aggNumPieces, aggPartialPieces int

--- a/cmd/rpcdaemon/commands/admin_api.go
+++ b/cmd/rpcdaemon/commands/admin_api.go
@@ -13,6 +13,10 @@ import (
 type AdminAPI interface {
 	// NodeInfo returns a collection of metadata known about the host.
 	NodeInfo(ctx context.Context) (*p2p.NodeInfo, error)
+
+	// Peers returns information about the connected remote nodes.
+	// https://geth.ethereum.org/docs/rpc/ns-admin#admin_peers
+	Peers(ctx context.Context) ([]*p2p.PeerInfo, error)
 }
 
 // AdminAPIImpl data structure to store things needed for admin_* commands.
@@ -38,4 +42,8 @@ func (api *AdminAPIImpl) NodeInfo(ctx context.Context) (*p2p.NodeInfo, error) {
 	}
 
 	return &nodes[0], nil
+}
+
+func (api *AdminAPIImpl) Peers(ctx context.Context) ([]*p2p.PeerInfo, error) {
+	return api.ethBackend.Peers(ctx)
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"google.golang.org/protobuf/types/known/emptypb"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -768,6 +769,18 @@ func (s *Ethereum) NodesInfo(limit int) (*remote.NodesInfoReply, error) {
 	sort.Sort(nodesInfo)
 
 	return nodesInfo, nil
+}
+
+func (s *Ethereum) Peers(ctx context.Context) (*remote.PeersReply, error) {
+	var reply remote.PeersReply
+	for _, sentryClient := range s.sentries {
+		peers, err := sentryClient.Peers(ctx, &emptypb.Empty{})
+		if err != nil {
+			return nil, fmt.Errorf("Ethereum backend SentryClient.Peers error: %w", err)
+		}
+		reply.Peers = append(reply.Peers, peers.Peers...)
+	}
+	return &reply, nil
 }
 
 // Protocols returns all the currently configured

--- a/ethdb/privateapi/ethbackend.go
+++ b/ethdb/privateapi/ethbackend.go
@@ -70,6 +70,7 @@ type EthBackend interface {
 	NetVersion() (uint64, error)
 	NetPeerCount() (uint64, error)
 	NodesInfo(limit int) (*remote.NodesInfoReply, error)
+	Peers(ctx context.Context) (*remote.PeersReply, error)
 }
 
 // This is the status of a newly execute block.
@@ -614,6 +615,10 @@ func (s *EthBackendServer) NodeInfo(_ context.Context, r *remote.NodesInfoReques
 		return nil, err
 	}
 	return nodesInfo, nil
+}
+
+func (s *EthBackendServer) Peers(ctx context.Context, _ *emptypb.Empty) (*remote.PeersReply, error) {
+	return s.eth.Peers(ctx)
 }
 
 func (s *EthBackendServer) SubscribeLogs(server remote.ETHBACKEND_SubscribeLogsServer) (err error) {

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/kevinburke/go-bindata v3.21.0+incompatible
-	github.com/ledgerwatch/erigon-lib v0.0.0-20220423144324-c3b480409230
+	github.com/ledgerwatch/erigon-lib v0.0.0-20220425121849-c73165f269e0
 	github.com/ledgerwatch/log/v3 v3.4.1
 	github.com/ledgerwatch/secp256k1 v1.0.0
 	github.com/pelletier/go-toml v1.9.5

--- a/go.sum
+++ b/go.sum
@@ -454,8 +454,8 @@ github.com/kylelemons/godebug v0.0.0-20170224010052-a616ab194758 h1:0D5M2HQSGD3P
 github.com/kylelemons/godebug v0.0.0-20170224010052-a616ab194758/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
-github.com/ledgerwatch/erigon-lib v0.0.0-20220423144324-c3b480409230 h1:zcnLesdHt2/hLmCPo21zSzMcmhupkZfYp4GyesmodiY=
-github.com/ledgerwatch/erigon-lib v0.0.0-20220423144324-c3b480409230/go.mod h1:0VKhW10UjEr7I6DaV+N0KNbXvMygC99qmRl2CfaN9gw=
+github.com/ledgerwatch/erigon-lib v0.0.0-20220425121849-c73165f269e0 h1:nDbzAEItEqkoxjJrnegSGUrxJjuJatATww5QZT40hmo=
+github.com/ledgerwatch/erigon-lib v0.0.0-20220425121849-c73165f269e0/go.mod h1:0VKhW10UjEr7I6DaV+N0KNbXvMygC99qmRl2CfaN9gw=
 github.com/ledgerwatch/log/v3 v3.4.1 h1:/xGwlVulXnsO9Uq+tzaExc8OWmXXHU0dnLalpbnY5Bc=
 github.com/ledgerwatch/log/v3 v3.4.1/go.mod h1:VXcz6Ssn6XEeU92dCMc39/g1F0OYAjw1Mt+dGP5DjXY=
 github.com/ledgerwatch/secp256k1 v1.0.0 h1:Usvz87YoTG0uePIV8woOof5cQnLXGYa162rFf3YnwaQ=


### PR DESCRIPTION
This RPC method returns information about the connected remote nodes.
https://geth.ethereum.org/docs/rpc/ns-admin#admin_peers

The peers are collected from all configured sentries.
See: https://github.com/ledgerwatch/interfaces/pull/102

Test with:
curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "admin_peers", "params": [], "id":1}' localhost:8545