### PR TITLE
FullSync instead of FastSync

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ make erigon
 ./build/bin/erigon
 ```
 
-Default `--syncmode=snap` for `mainnet`, `goerli`, `bsc`. Other networks now have default `--syncmode=fast`. Increase download speed by flag `--torrent.download.rate=20mb`. <code>🔬 See [Downloader docs](./cmd/downloader/readme.md)</code> 
+Default `--syncmode=snap` for `mainnet`, `goerli`, `bsc`. Other networks now have default `--syncmode=full`. Increase download speed by flag `--torrent.download.rate=20mb`. <code>🔬 See [Downloader docs](./cmd/downloader/readme.md)</code> 
 
 Use `--datadir` to choose where to store data.
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -155,7 +155,7 @@ var (
 	}
 	SyncModeFlag = cli.StringFlag{
 		Name:  "syncmode",
-		Usage: `Default: "snap" for BSC, Mainnet and Goerli. "fast" in all other cases`,
+		Usage: `Default: "snap" for BSC, Mainnet and Goerli. "full" in all other cases`,
 	}
 	// Transaction pool settings
 	TxPoolDisableFlag = cli.BoolFlag{

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -71,7 +71,7 @@ var LightClientGPO = gasprice.Config{
 
 // Defaults contains default settings for use on the Ethereum main net.
 var Defaults = Config{
-	SyncMode: FastSync,
+	SyncMode: FullSync,
 	Ethash: ethash.Config{
 		CachesInMem:      2,
 		CachesLockMmap:   false,
@@ -290,13 +290,13 @@ func CreateConsensusEngine(chainConfig *params.ChainConfig, logger log.Logger, c
 type SyncMode string
 
 const (
-	FastSync SyncMode = "fast"
+	FullSync SyncMode = "full"
 	SnapSync SyncMode = "snap"
 )
 
 func SyncModeByChainName(chain, syncCliFlag string) SyncMode {
-	if syncCliFlag == "fast" {
-		return FastSync
+	if syncCliFlag == "full" {
+		return FullSync
 	} else if syncCliFlag == "snap" {
 		return SnapSync
 	}
@@ -304,6 +304,6 @@ func SyncModeByChainName(chain, syncCliFlag string) SyncMode {
 	case networkname.MainnetChainName, networkname.BSCChainName, networkname.GoerliChainName:
 		return SnapSync
 	default:
-		return FastSync
+		return FullSync
 	}
 }

--- a/turbo/snapshotsync/snapshotsynccli/flags.go
+++ b/turbo/snapshotsync/snapshotsynccli/flags.go
@@ -20,7 +20,7 @@ func EnsureNotChanged(tx kv.GetPut, cfg ethconfig.Snapshot) error {
 		if v {
 			return fmt.Errorf("we recently changed default of --syncmode flag, please add flag --syncmode=snap")
 		} else {
-			return fmt.Errorf("we recently changed default of --syncmode flag, please add flag --syncmode=fast")
+			return fmt.Errorf("we recently changed default of --syncmode flag, please add flag --syncmode=full")
 		}
 	}
 	return nil


### PR DESCRIPTION
Our previous sync mode is closer to geth's `FullSync` (execute all blocks from genesis) rather than `FastSync` (obsolete mode replaced by `SnapSync`). Mind that geth's [snap sync](https://github.com/ethereum/devp2p/blob/master/caps/snap.md) is very different from our new torrent sync, but I defer potential renaming to another PR.