### PR TITLE
p2p: crawler-friendly handshake

### DIFF
--- a/node/defaults.go
+++ b/node/defaults.go
@@ -46,7 +46,7 @@ var DefaultConfig = Config{
 		ListenAddr:      ":30303",
 		ListenAddr65:    ":30304",
 		MaxPeers:        100,
-		MaxPendingPeers: 50,
+		MaxPendingPeers: 1000,
 		NAT:             nat.Any(),
 	},
 }


### PR DESCRIPTION
* exchange RLPx Hello even when maxpeers limit is reached
* bump MaxPendingPeers to increase the default handshake queue
(and the likelyhood of Hello exchange)