### PR TITLE
p2p: speed-up TestUDPv4_LookupIterator

### DIFF
--- a/p2p/discover/common.go
+++ b/p2p/discover/common.go
@@ -19,7 +19,9 @@ package discover
 import (
 	"context"
 	"crypto/ecdsa"
+	"github.com/ledgerwatch/erigon/crypto"
 	"net"
+	"time"
 
 	"github.com/ledgerwatch/erigon/common/mclock"
 	"github.com/ledgerwatch/erigon/p2p/enode"
@@ -48,6 +50,9 @@ type Config struct {
 	Log          log.Logger         // if set, log messages go here
 	ValidSchemes enr.IdentityScheme // allowed identity schemes
 	Clock        mclock.Clock
+	ReplyTimeout time.Duration
+
+	PrivateKeyGenerator func() (*ecdsa.PrivateKey, error)
 }
 
 func (cfg Config) withDefaults() Config {
@@ -59,6 +64,12 @@ func (cfg Config) withDefaults() Config {
 	}
 	if cfg.Clock == nil {
 		cfg.Clock = mclock.System{}
+	}
+	if cfg.ReplyTimeout == 0 {
+		cfg.ReplyTimeout = respTimeout
+	}
+	if cfg.PrivateKeyGenerator == nil {
+		cfg.PrivateKeyGenerator = crypto.GenerateKey
 	}
 	return cfg
 }


### PR DESCRIPTION
The test was slow, because it was trying to find
predefined nodeIDs (lookupTestnet) by generating random keys
and trying to find their neighbours
until it hits all nodes of the lookupTestnet.
In addition each FindNode response was waiting for 0.5 sec (respTimeout).
This could take up to 30 sec and fail the test suite.

A fake random key generator is now used during the test.
It issues the expected keys, and the lookup converges quickly.
The reply timeout is reduced for the test.
Now it normally takes less than.1 sec.