### PR TITLE
Observer: fix panic on clean start (#4002)

### DIFF
--- a/cmd/observer/observer/crawler.go
+++ b/cmd/observer/observer/crawler.go
@@ -243,6 +243,9 @@ func (crawler *Crawler) Run(ctx context.Context) error {
 			}
 			return fmt.Errorf("failed to count ping errors: %w", err)
 		}
+		if prevPingTries == nil {
+			prevPingTries = new(uint)
+		}
 
 		handshakeNextRetryTime, err := crawler.db.FindHandshakeRetryTime(ctx, id)
 		if err != nil {


### PR DESCRIPTION
Problem: (nil, nil) from CountPingErrors was not handled.
This happens if the node is not in the db (a bootstrap node),
and was never crawled before.