### PR TITLE
eth/filters: Fix filterLogs()

### DIFF
--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -297,7 +297,7 @@ Logs:
 		}
 		// If the to filtered topics is greater than the amount of topics in logs, skip.
 		if len(topics) > len(log.Topics) {
-			continue Logs
+			continue
 		}
 		for i, sub := range topics {
 			match := len(sub) == 0 // empty rule set == wildcard


### PR DESCRIPTION
In filter.go:
https://github.com/ledgerwatch/erigon/blob/93ab7f5d826cf9ddb3d2b570036725bcb34e5448/eth/filters/filter.go#L298-L301
If `len(topics)` greater than len(log.Topics), `continue Logs` will make `filterLogs()` got an infinite loop.
So, It should be `continue`, not `continue Logs`.
