### PR TITLE
Speed up docker image build by use layer cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,4 +76,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: git submodule update --init --recursive --force
+
+      # In this step, this action saves a list of existing images,
+      # the cache is created without them in the post run.
+      # It also restores the cache if it exists.
+      - uses: satackey/action-docker-layer-caching@v0.0.11
+        continue-on-error: false
+
       - run: docker build .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
 # syntax=docker/dockerfile:1
 FROM docker.io/library/golang:1.18-alpine3.15 AS builder
 
+WORKDIR /app
+
+# Get dependancies - will also be cached if we won't change go.mod/go.sum
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
 RUN apk --no-cache add make gcc g++ linux-headers git bash ca-certificates libgcc libstdc++
 
-WORKDIR /app
 ADD . .
 
 RUN make erigon rpcdaemon integration sentry txpool downloader hack observer db-tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
 # syntax=docker/dockerfile:1
 FROM docker.io/library/golang:1.18-alpine3.15 AS builder
 
+RUN apk --no-cache add make gcc g++ linux-headers git bash ca-certificates libgcc libstdc++
+
 WORKDIR /app
 
-# Get dependancies - will also be cached if we won't change go.mod/go.sum
+# Get dependencies - will also be cached if we won't change go.mod/go.sum
 COPY go.mod .
 COPY go.sum .
 RUN go mod download
 
-RUN apk --no-cache add make gcc g++ linux-headers git bash ca-certificates libgcc libstdc++
 
 ADD . .
 


### PR DESCRIPTION
Docker image build will use cached layers, since`go.mod` and `go.sum` won't changed very often, so we can add `RUN go mod download` early in `Dockerfile`.

# Reference:
https://cloud.google.com/architecture/best-practices-for-building-containers#optimize-for-the-docker-build-cache