### PR TITLE
p2p: TestUDPv4_Lookup - unsolicited reply error

### DIFF
--- a/p2p/discover/common.go
+++ b/p2p/discover/common.go
@@ -52,6 +52,8 @@ type Config struct {
 	Clock        mclock.Clock
 	ReplyTimeout time.Duration
 
+	PingBackDelay time.Duration
+
 	PrivateKeyGenerator func() (*ecdsa.PrivateKey, error)
 }
 
@@ -67,6 +69,9 @@ func (cfg Config) withDefaults() Config {
 	}
 	if cfg.ReplyTimeout == 0 {
 		cfg.ReplyTimeout = respTimeout
+	}
+	if cfg.PingBackDelay == 0 {
+		cfg.PingBackDelay = respTimeout
 	}
 	if cfg.PrivateKeyGenerator == nil {
 		cfg.PrivateKeyGenerator = crypto.GenerateKey

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -78,6 +78,7 @@ type UDPv4 struct {
 	addReplyMatcher chan *replyMatcher
 	gotreply        chan reply
 	replyTimeout    time.Duration
+	pingBackDelay   time.Duration
 	closeCtx        context.Context
 	cancelCloseCtx  context.CancelFunc
 
@@ -141,6 +142,7 @@ func ListenV4(ctx context.Context, c UDPConn, ln *enode.LocalNode, cfg Config) (
 		gotreply:        make(chan reply),
 		addReplyMatcher: make(chan *replyMatcher),
 		replyTimeout:    cfg.ReplyTimeout,
+		pingBackDelay:   cfg.PingBackDelay,
 		closeCtx:        closeCtx,
 		cancelCloseCtx:  cancel,
 		log:             cfg.Log,
@@ -601,7 +603,7 @@ func (t *UDPv4) ensureBond(toid enode.ID, toaddr *net.UDPAddr) {
 		rm := t.sendPing(toid, toaddr, nil)
 		<-rm.errc
 		// Wait for them to ping back and process our pong.
-		time.Sleep(t.replyTimeout)
+		time.Sleep(t.pingBackDelay)
 	}
 }
 

--- a/p2p/discover/v4_udp_test.go
+++ b/p2p/discover/v4_udp_test.go
@@ -92,6 +92,8 @@ func newUDPTestContext(ctx context.Context, t *testing.T) *udpTest {
 
 		ReplyTimeout: replyTimeout,
 
+		PingBackDelay: time.Nanosecond,
+
 		PrivateKeyGenerator: contextGetPrivateKeyGenerator(ctx),
 	})
 	if err != nil {
@@ -124,7 +126,11 @@ func (test *udpTest) packetInFrom(wantError error, key *ecdsa.PrivateKey, addr *
 		test.t.Errorf("%s encode error: %v", data.Name(), err)
 	}
 	test.sent = append(test.sent, enc)
-	if err = test.udp.handlePacket(addr, enc); err != wantError {
+
+	err = test.udp.handlePacket(addr, enc)
+	if (wantError == nil) && (err != nil) {
+		test.t.Errorf("handlePacket error: %q", err)
+	} else if (wantError != nil) && (err != wantError) {
 		test.t.Errorf("error mismatch: got %q, want %q", err, wantError)
 	}
 }

--- a/p2p/discover/v5_udp_test.go
+++ b/p2p/discover/v5_udp_test.go
@@ -127,6 +127,7 @@ func TestUDPv5_pingHandling(t *testing.T) {
 	}
 	t.Parallel()
 	test := newUDPV5Test(t)
+	t.Cleanup(test.close)
 
 	test.packetIn(&v5wire.Ping{ReqID: []byte("foo")})
 	test.waitPacketOut(func(p *v5wire.Pong, addr *net.UDPAddr, _ v5wire.Nonce) {
@@ -146,6 +147,7 @@ func TestUDPv5_unknownPacket(t *testing.T) {
 	}
 	t.Parallel()
 	test := newUDPV5Test(t)
+	t.Cleanup(test.close)
 
 	nonce := v5wire.Nonce{1, 2, 3}
 	check := func(p *v5wire.Whoareyou, wantSeq uint64) {
@@ -184,6 +186,7 @@ func TestUDPv5_findnodeHandling(t *testing.T) {
 	}
 	t.Parallel()
 	test := newUDPV5Test(t)
+	t.Cleanup(test.close)
 
 	// Create test nodes and insert them into the table.
 	nodes253 := nodesAtDistance(test.table.self().ID(), 253, 10)
@@ -270,6 +273,7 @@ func TestUDPv5_pingCall(t *testing.T) {
 	}
 	t.Parallel()
 	test := newUDPV5Test(t)
+	t.Cleanup(test.close)
 
 	remote := test.getNode(test.remotekey, test.remoteaddr).Node()
 	done := make(chan error, 1)
@@ -318,6 +322,7 @@ func TestUDPv5_findnodeCall(t *testing.T) {
 	}
 	t.Parallel()
 	test := newUDPV5Test(t)
+	t.Cleanup(test.close)
 
 	// Launch the request:
 	var (
@@ -369,6 +374,7 @@ func TestUDPv5_callResend(t *testing.T) {
 	}
 	t.Parallel()
 	test := newUDPV5Test(t)
+	t.Cleanup(test.close)
 
 	remote := test.getNode(test.remotekey, test.remoteaddr).Node()
 	done := make(chan error, 2)
@@ -408,6 +414,7 @@ func TestUDPv5_multipleHandshakeRounds(t *testing.T) {
 	}
 	t.Parallel()
 	test := newUDPV5Test(t)
+	t.Cleanup(test.close)
 
 	remote := test.getNode(test.remotekey, test.remoteaddr).Node()
 	done := make(chan error, 1)
@@ -436,6 +443,7 @@ func TestUDPv5_callTimeoutReset(t *testing.T) {
 	}
 	t.Parallel()
 	test := newUDPV5Test(t)
+	t.Cleanup(test.close)
 
 	// Launch the request:
 	var (
@@ -477,6 +485,7 @@ func TestUDPv5_talkHandling(t *testing.T) {
 	}
 	t.Parallel()
 	test := newUDPV5Test(t)
+	t.Cleanup(test.close)
 
 	var recvMessage []byte
 	test.udp.RegisterTalkHandler("test", func(id enode.ID, addr *net.UDPAddr, message []byte) []byte {
@@ -529,6 +538,7 @@ func TestUDPv5_talkRequest(t *testing.T) {
 	}
 	t.Parallel()
 	test := newUDPV5Test(t)
+	t.Cleanup(test.close)
 
 	remote := test.getNode(test.remotekey, test.remoteaddr).Node()
 	done := make(chan error, 1)
@@ -572,6 +582,7 @@ func TestUDPv5_lookup(t *testing.T) {
 	}
 	t.Parallel()
 	test := newUDPV5Test(t)
+	t.Cleanup(test.close)
 
 	// Lookup on empty table returns no nodes.
 	if results := test.udp.Lookup(lookupTestnet.target.ID()); len(results) > 0 {


### PR DESCRIPTION
The UDP test must be closed after the serveTestnet processing.
If it happens during the processing, the serveTestnet encounters this error.
(it tries to emulate a packet receival handling when the handler is already cleaned up)

FindNode triggers a Ping in ensureBond.
This causes an extra Sleep for "ping back".
Don't wait for this in tests.

Close v5 tests.

The requests may also timeout if a lot of them queue up in the udpTest.pipe,
and serveTestnet is slow to process them.
Increase replyTimeout a bit to prevent that.