### PR TITLE
CI: run integration tests on trunk after PR is merged

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -5,19 +5,10 @@ on:
       - devel
       - alpha
       - stable
-  pull_request:
-    branches:
-      - devel
-      - alpha
-      - stable
-    types:
-      - closed
   schedule:
     - cron: '20 16 * * *' # daily at 16:20 UTC
 jobs:
   tests:
-    if: github.event.schedule || github.event.pull_request.merged
-
     strategy:
       matrix:
         os: [ ubuntu-20.04, macos-11 ] # list of os: https://github.com/actions/virtual-environments


### PR DESCRIPTION
Running on PR close event tests the PR commit, not the final merged commit.
The final commit is tested by "push" event, but it appears as "skipped" in the list of devel ccmmits,
because "push" event was skipped by "if".