### PR TITLE
p2p: TestUDPv4_LookupIterator failures workaround

### DIFF
--- a/p2p/discover/v4_lookup_test.go
+++ b/p2p/discover/v4_lookup_test.go
@@ -39,7 +39,7 @@ func TestUDPv4_Lookup(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	ctx = contextWithReplyTimeout(ctx, 100*time.Millisecond)
+	ctx = contextWithReplyTimeout(ctx, 200*time.Millisecond)
 
 	test := newUDPTestContext(ctx, t)
 	defer test.close()
@@ -84,7 +84,7 @@ func TestUDPv4_LookupIterator(t *testing.T) {
 		return testNetPrivateKeys[testNetPrivateKeyIndex], nil
 	}
 	ctx := context.Background()
-	ctx = contextWithReplyTimeout(ctx, 100*time.Millisecond)
+	ctx = contextWithReplyTimeout(ctx, 200*time.Millisecond)
 	ctx = contextWithPrivateKeyGenerator(ctx, privateKeyGenerator)
 
 	test := newUDPTestContext(ctx, t)


### PR DESCRIPTION
--- FAIL: TestUDPv4_LookupIterator (1.36s)
155
    v4_lookup_test.go:168: handlePacket error: "unsolicited reply"
156