### PR TITLE
rpcdaemon: optimize tests

### DIFF
--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -238,6 +238,38 @@ func (cp ChainPack) Slice(i, j int) *ChainPack {
 	}
 }
 
+// Copy creates a deep copy of the ChainPack.
+func (cp *ChainPack) Copy() *ChainPack {
+	headers := make([]*types.Header, 0, len(cp.Headers))
+	for _, header := range cp.Headers {
+		headers = append(headers, types.CopyHeader(header))
+	}
+
+	blocks := make([]*types.Block, 0, len(cp.Blocks))
+	for _, block := range cp.Blocks {
+		blocks = append(blocks, block.Copy())
+	}
+
+	receipts := make([]types.Receipts, 0, len(cp.Receipts))
+	for _, receiptList := range cp.Receipts {
+		receiptListCopy := make(types.Receipts, 0, len(receiptList))
+		for _, receipt := range receiptList {
+			receiptListCopy = append(receiptListCopy, receipt.Copy())
+		}
+		receipts = append(receipts, receiptListCopy)
+	}
+
+	topBlock := cp.TopBlock.Copy()
+
+	return &ChainPack{
+		Length:   cp.Length,
+		Headers:  headers,
+		Blocks:   blocks,
+		Receipts: receipts,
+		TopBlock: topBlock,
+	}
+}
+
 // GenerateChain creates a chain of n blocks. The first block's
 // parent will be the provided parent. db is used to store
 // intermediate states and should contain the parent's state trie.

--- a/core/types/log.go
+++ b/core/types/log.go
@@ -100,6 +100,30 @@ func (l *Log) DecodeRLP(s *rlp.Stream) error {
 	return err
 }
 
+// Copy creates a deep copy of the Log.
+func (l *Log) Copy() *Log {
+	topics := make([]common.Hash, 0, len(l.Topics))
+	for _, topic := range l.Topics {
+		topicCopy := common.BytesToHash(topic.Bytes())
+		topics = append(topics, topicCopy)
+	}
+
+	data := make([]byte, len(l.Data))
+	copy(data, l.Data)
+
+	return &Log{
+		Address:     common.BytesToAddress(l.Address.Bytes()),
+		Topics:      topics,
+		Data:        data,
+		BlockNumber: l.BlockNumber,
+		TxHash:      common.BytesToHash(l.TxHash.Bytes()),
+		TxIndex:     l.TxIndex,
+		BlockHash:   common.BytesToHash(l.BlockHash.Bytes()),
+		Index:       l.Index,
+		Removed:     l.Removed,
+	}
+}
+
 // LogForStorage is a wrapper around a Log that flattens and parses the entire content of
 // a log including non-consensus fields.
 type LogForStorage Log

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -297,6 +297,39 @@ func (r *Receipt) Size() common.StorageSize {
 	return size
 }
 
+// Copy creates a deep copy of the Receipt.
+func (r *Receipt) Copy() *Receipt {
+	postState := make([]byte, len(r.PostState))
+	copy(postState, r.PostState)
+
+	bloom := BytesToBloom(r.Bloom.Bytes())
+
+	logs := make(Logs, 0, len(r.Logs))
+	for _, log := range r.Logs {
+		logs = append(logs, log.Copy())
+	}
+
+	txHash := common.BytesToHash(r.TxHash.Bytes())
+	contractAddress := common.BytesToAddress(r.ContractAddress.Bytes())
+	blockHash := common.BytesToHash(r.BlockHash.Bytes())
+	blockNumber := big.NewInt(0).Set(r.BlockNumber)
+
+	return &Receipt{
+		Type:              r.Type,
+		PostState:         postState,
+		Status:            r.Status,
+		CumulativeGasUsed: r.CumulativeGasUsed,
+		Bloom:             bloom,
+		Logs:              logs,
+		TxHash:            txHash,
+		ContractAddress:   contractAddress,
+		GasUsed:           r.GasUsed,
+		BlockHash:         blockHash,
+		BlockNumber:       blockNumber,
+		TransactionIndex:  r.TransactionIndex,
+	}
+}
+
 type ReceiptsForStorage []*ReceiptForStorage
 
 // ReceiptForStorage is a wrapper around a Receipt that flattens and parses the


### PR DESCRIPTION
* reuse the generated test blockchain across tests
* copy ChainPack to ensure test isolation

This improves the speed from 10s to 4s.

The package tests timeout can be reduced to 5s:

    go test ./cmd/rpcdaemon/commands -count 1 --timeout 5s