### PR TITLE
CI: more caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,19 @@ jobs:
       - name: Install dependencies on Linux
         if: runner.os == 'Linux'
         run: sudo apt update && sudo apt install build-essential
+
       - uses: actions/cache@v3
         with:
-          path: ~/go/pkg/mod
-          key: ${{ matrix.os }}-go-${{ hashFiles('**/go.sum') }}
+          path: |
+            ~/.cache/go-build
+            ~/Library/Caches/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-
+
       - name: Build
         run: make all
+
       - name: Reproducible build test
         run: |
           make erigon
@@ -41,6 +48,7 @@ jobs:
           if ! cmp -s erigon1.sha256 erigon2.sha256; then
             echo >&2 "Reproducible build broken"; cat erigon1.sha256; cat erigon2.sha256; exit 1
           fi
+
       - name: Lint
         if: runner.os == 'Linux'
         uses: golangci/golangci-lint-action@v3
@@ -48,6 +56,7 @@ jobs:
           version: v1.45
           skip-pkg-cache: true
           skip-build-cache: true
+
       - name: Test
         run: make test
 
@@ -60,7 +69,26 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
-      - run: choco upgrade mingw cmake -y --no-progress
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            C:\ProgramData\chocolatey\lib\mingw
+            C:\ProgramData\chocolatey\lib\cmake
+          key: chocolatey
+      - name: Install dependencies
+        run: |
+          choco upgrade mingw -y --no-progress --version 11.2.0.07112021
+          choco install cmake -y --no-progress --version 3.23.1
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~\AppData\Local\go-build
+            ~\go\pkg\mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-
+
       - name: Test
         run: .\wmake.ps1 && make test
 

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -26,8 +26,12 @@ jobs:
 
       - uses: actions/cache@v3
         with:
-          path: ~/go/pkg/mod
-          key: ${{ matrix.os }}-go-${{ hashFiles('**/go.sum') }}
+          path: |
+            ~/.cache/go-build
+            ~/Library/Caches/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-
 
       - name: test-integration
         run: make test-integration
@@ -41,13 +45,25 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
-      - name: Install dependencies
-        run: choco upgrade mingw cmake -y --no-progress
 
       - uses: actions/cache@v3
         with:
-          path: ~/go/pkg/mod
-          key: ${{ matrix.os }}-go-${{ hashFiles('**/go.sum') }}
+          path: |
+            C:\ProgramData\chocolatey\lib\mingw
+            C:\ProgramData\chocolatey\lib\cmake
+          key: chocolatey
+      - name: Install dependencies
+        run: |
+          choco upgrade mingw -y --no-progress --version 11.2.0.07112021
+          choco install cmake -y --no-progress --version 3.23.1
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~\AppData\Local\go-build
+            ~\go\pkg\mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-
 
       - name: test-integration
         run: .\wmake.ps1 && make test-integration


### PR DESCRIPTION
Cache "go-build" containing cached build artifacts from the Go build system.
This saves up to:
- 6 min on Linux (from 10 min to 4 min)
- 3 min on macOS (from 13 min to 10 min)
- 7 min on Windows (from 27 min to 20 min)

Cache Windows deps (mingw, cmake).
This saves 6,5 min on Windows builds (from 20 min to 13,5 min)
