### PR TITLE
Revert "Fix ignored SkipAnalysis in core/state_processor.go"

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -143,10 +143,6 @@ func applyTransaction(config *params.ChainConfig, gp *GasPool, statedb *state.In
 func ApplyTransaction(config *params.ChainConfig, getHeader func(hash common.Hash, number uint64) *types.Header, engine consensus.Engine, author *common.Address, gp *GasPool, ibs *state.IntraBlockState, stateWriter state.StateWriter, header *types.Header, tx types.Transaction, usedGas *uint64, cfg vm.Config, contractHasTEVM func(contractHash common.Hash) (bool, error)) (*types.Receipt, []byte, error) {
 	// Create a new context to be used in the EVM environment
 
-	// Add addresses to access list if applicable
-	// about the transaction and calling mechanisms.
-	cfg.SkipAnalysis = SkipAnalysis(config, header.Number.Uint64())
-
 	var vmenv vm.VMInterface
 
 	if tx.IsStarkNet() {
@@ -155,6 +151,10 @@ func ApplyTransaction(config *params.ChainConfig, getHeader func(hash common.Has
 		blockContext := NewEVMBlockContext(header, getHeader, engine, author, contractHasTEVM)
 		vmenv = vm.NewEVM(blockContext, vm.TxContext{}, ibs, config, cfg)
 	}
+
+	// Add addresses to access list if applicable
+	// about the transaction and calling mechanisms.
+	cfg.SkipAnalysis = SkipAnalysis(config, header.Number.Uint64())
 
 	return applyTransaction(config, gp, ibs, stateWriter, header, tx, usedGas, vmenv, cfg)
 }


### PR DESCRIPTION
Befor this fix there was Warning on mainnet:
```
WARN[05-06|10:20:16.316] Code Bitmap used for detecting invalid jump tx=0x21ab7bf7245a87eae265124aaf180d91133377e47db2b1a4866493ec4b371150 block_num=13119520
```
After this fix error:
```
EROR[05-06|10:20:42.606] [6/16 Execution] Execution failed        block=13119520 hash=0x9d683102479c742b46e9647a8290615e86ecb92a83cdf2b8f2d6ed90c31c189b err="mismatched receipt headers for block 13119520"
```
Reverting this PR