### PR TITLE
p2p (#4119): treat slow discover v5 tests

### DIFF
--- a/p2p/discover/common.go
+++ b/p2p/discover/common.go
@@ -56,9 +56,11 @@ type Config struct {
 	PingBackDelay time.Duration
 
 	PrivateKeyGenerator func() (*ecdsa.PrivateKey, error)
+
+	TableRevalidateInterval time.Duration
 }
 
-func (cfg Config) withDefaults() Config {
+func (cfg Config) withDefaults(defaultReplyTimeout time.Duration) Config {
 	if cfg.Log == nil {
 		cfg.Log = log.Root()
 	}
@@ -69,13 +71,16 @@ func (cfg Config) withDefaults() Config {
 		cfg.Clock = mclock.System{}
 	}
 	if cfg.ReplyTimeout == 0 {
-		cfg.ReplyTimeout = respTimeout
+		cfg.ReplyTimeout = defaultReplyTimeout
 	}
 	if cfg.PingBackDelay == 0 {
 		cfg.PingBackDelay = respTimeout
 	}
 	if cfg.PrivateKeyGenerator == nil {
 		cfg.PrivateKeyGenerator = crypto.GenerateKey
+	}
+	if cfg.TableRevalidateInterval == 0 {
+		cfg.TableRevalidateInterval = revalidateInterval
 	}
 	return cfg
 }

--- a/p2p/discover/table_util_test.go
+++ b/p2p/discover/table_util_test.go
@@ -26,6 +26,7 @@ import (
 	"net"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/ledgerwatch/erigon/crypto"
 	"github.com/ledgerwatch/erigon/p2p/enode"
@@ -46,7 +47,7 @@ func newTestTable(t transport) (*Table, *enode.DB) {
 	if err != nil {
 		panic(err)
 	}
-	tab, _ := newTable(t, db, nil, log.Root())
+	tab, _ := newTable(t, db, nil, time.Hour, log.Root())
 	go tab.loop()
 	return tab, db
 }
@@ -60,9 +61,16 @@ func nodeAtDistance(base enode.ID, ld int, ip net.IP) *node {
 
 // nodesAtDistance creates n nodes for which enode.LogDist(base, node.ID()) == ld.
 func nodesAtDistance(base enode.ID, ld int, n int) []*enode.Node {
-	results := make([]*enode.Node, n)
-	for i := range results {
-		results[i] = unwrapNode(nodeAtDistance(base, ld, intIP(i)))
+	results := make([]*enode.Node, 0, n)
+	nodeSet := make(map[enode.ID]bool, n)
+	for len(results) < n {
+		node := unwrapNode(nodeAtDistance(base, ld, intIP(len(results)+1)))
+		// idAtDistance might return an ID that's already generated
+		// make sure that the node has a unique ID, otherwise regenerate
+		if !nodeSet[node.ID()] {
+			nodeSet[node.ID()] = true
+			results = append(results, node)
+		}
 	}
 	return results
 }

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -131,7 +131,7 @@ type reply struct {
 }
 
 func ListenV4(ctx context.Context, c UDPConn, ln *enode.LocalNode, cfg Config) (*UDPv4, error) {
-	cfg = cfg.withDefaults()
+	cfg = cfg.withDefaults(respTimeout)
 	closeCtx, cancel := context.WithCancel(ctx)
 	t := &UDPv4{
 		conn:            c,
@@ -150,7 +150,7 @@ func ListenV4(ctx context.Context, c UDPConn, ln *enode.LocalNode, cfg Config) (
 		privateKeyGenerator: cfg.PrivateKeyGenerator,
 	}
 
-	tab, err := newTable(t, ln.Database(), cfg.Bootnodes, t.log)
+	tab, err := newTable(t, ln.Database(), cfg.Bootnodes, cfg.TableRevalidateInterval, cfg.Log)
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/discover/v4_udp_test.go
+++ b/p2p/discover/v4_udp_test.go
@@ -95,6 +95,8 @@ func newUDPTestContext(ctx context.Context, t *testing.T) *udpTest {
 		PingBackDelay: time.Nanosecond,
 
 		PrivateKeyGenerator: contextGetPrivateKeyGenerator(ctx),
+
+		TableRevalidateInterval: time.Hour,
 	})
 	if err != nil {
 		panic(err)

--- a/p2p/discover/v5_lookup_test.go
+++ b/p2p/discover/v5_lookup_test.go
@@ -1,0 +1,120 @@
+//go:build integration
+// +build integration
+
+package discover
+
+import (
+	"math/rand"
+	"net"
+	"runtime"
+	"sort"
+	"testing"
+
+	"github.com/ledgerwatch/erigon/p2p/discover/v5wire"
+	"github.com/ledgerwatch/erigon/p2p/enode"
+)
+
+// This test checks that lookup works.
+func TestUDPv5_lookup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fix me on win please")
+	}
+	t.Parallel()
+	test := newUDPV5Test(t)
+	t.Cleanup(test.close)
+
+	// Lookup on empty table returns no nodes.
+	if results := test.udp.Lookup(lookupTestnet.target.ID()); len(results) > 0 {
+		t.Fatalf("lookup on empty table returned %d results: %#v", len(results), results)
+	}
+
+	// Ensure the tester knows all nodes in lookupTestnet by IP.
+	for d, nn := range lookupTestnet.dists {
+		for i, key := range nn {
+			n := lookupTestnet.node(d, i)
+			test.getNode(key, &net.UDPAddr{IP: n.IP(), Port: n.UDP()})
+		}
+	}
+
+	// Seed table with initial node.
+	initialNode := lookupTestnet.node(256, 0)
+	fillTable(test.table, []*node{wrapNode(initialNode)})
+
+	// Start the lookup.
+	resultC := make(chan []*enode.Node, 1)
+	go func() {
+		resultC <- test.udp.Lookup(lookupTestnet.target.ID())
+		test.close()
+	}()
+
+	// Answer lookup packets.
+	asked := make(map[enode.ID]bool)
+	for done := false; !done; {
+		done = test.waitPacketOut(func(p v5wire.Packet, to *net.UDPAddr, _ v5wire.Nonce) {
+			recipient, key := lookupTestnet.nodeByAddr(to)
+			switch p := p.(type) {
+			case *v5wire.Ping:
+				test.packetInFrom(key, to, &v5wire.Pong{ReqID: p.ReqID})
+			case *v5wire.Findnode:
+				if asked[recipient.ID()] {
+					t.Error("Asked node", recipient.ID(), "twice")
+				}
+				asked[recipient.ID()] = true
+				nodes := lookupTestnet.neighborsAtDistances(recipient, p.Distances, 16)
+				t.Logf("Got FINDNODE for %v, returning %d nodes", p.Distances, len(nodes))
+				for _, resp := range packNodes(p.ReqID, nodes) {
+					test.packetInFrom(key, to, resp)
+				}
+			}
+		})
+	}
+
+	// Verify result nodes.
+	results := <-resultC
+	checkLookupResults(t, lookupTestnet, results)
+}
+
+// Real sockets, real crypto: this test checks end-to-end connectivity for UDPv5.
+func TestUDPv5_lookupE2E(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fix me on win please")
+	}
+	t.Parallel()
+
+	bootNode := startLocalhostV5(t, Config{})
+	bootNodeRec := bootNode.Self()
+
+	const N = 5
+	nodes := []*UDPv5{bootNode}
+	for len(nodes) < N {
+		cfg := Config{
+			Bootnodes: []*enode.Node{bootNodeRec},
+		}
+		node := startLocalhostV5(t, cfg)
+		nodes = append(nodes, node)
+	}
+
+	defer func() {
+		for _, node := range nodes {
+			node.Close()
+		}
+	}()
+
+	last := nodes[N-1]
+	target := nodes[rand.Intn(N-2)].Self()
+
+	// It is expected that all nodes can be found.
+	expectedResult := make([]*enode.Node, len(nodes))
+	for i := range nodes {
+		expectedResult[i] = nodes[i].Self()
+	}
+	sort.Slice(expectedResult, func(i, j int) bool {
+		return enode.DistCmp(target.ID(), expectedResult[i].ID(), expectedResult[j].ID()) < 0
+	})
+
+	// Do the lookup.
+	results := last.Lookup(target.ID())
+	if err := checkNodesEqual(results, expectedResult); err != nil {
+		t.Fatalf("lookup returned wrong results: %v", err)
+	}
+}


### PR DESCRIPTION
* configure a 50 ms timeout for tests (like v4 tests)
* use in-memory DB (like v4 tests)
* TestUDPv5_callTimeoutReset: improve speed from 1.2s to 0.2s
* TestUDPv5_callTimeoutReset: reduce the likelihood of "RPC timeout"
* move lookup tests to the "integration" suite
* log details of unmatched packets and sends to non-existing nodes
* fix flaky TestUDPv5_findnodeHandling:

    Table.nextRevalidateTime was random (from 0 to 10s).
    Sometimes it triggered doRevalidate immediately, and it produced an unexpected ping.
    Configure a high interval to not revalidate during the tests.

Time improved from 1.7s to 0.2s.

Test with:

    go test ./p2p/discover -run TestUDPv5 -count 1