### PR TITLE
p2p (#4119): treat slow integration tests

### DIFF
--- a/p2p/dial_integration_test.go
+++ b/p2p/dial_integration_test.go
@@ -1,0 +1,10 @@
+//go:build integration
+// +build integration
+
+package p2p
+
+import "time"
+
+func init() {
+	dialTestDialerUnexpectedDialTimeout = 150 * time.Millisecond
+}

--- a/p2p/dial_test.go
+++ b/p2p/dial_test.go
@@ -591,11 +591,13 @@ func (d *dialTestDialer) waitForDials(nodes []*enode.Node) error {
 	return d.checkUnexpectedDial()
 }
 
+var dialTestDialerUnexpectedDialTimeout = time.Millisecond
+
 func (d *dialTestDialer) checkUnexpectedDial() error {
 	select {
 	case req := <-d.init:
 		return fmt.Errorf("attempt to dial unexpected node %v", req.n.ID())
-	case <-time.After(150 * time.Millisecond):
+	case <-time.After(dialTestDialerUnexpectedDialTimeout):
 		return nil
 	}
 }

--- a/p2p/discover/table_integration_test.go
+++ b/p2p/discover/table_integration_test.go
@@ -10,6 +10,23 @@ import (
 	"time"
 )
 
+func TestTable_bumpNoDuplicates_quickCheck(t *testing.T) {
+	t.Parallel()
+
+	config := quick.Config{
+		MaxCount: 200,
+		Rand:     rand.New(rand.NewSource(time.Now().Unix())),
+	}
+
+	test := func(bucketCountGen byte, bumpCountGen byte) bool {
+		return testTableBumpNoDuplicatesRun(t, bucketCountGen, bumpCountGen, config.Rand)
+	}
+
+	if err := quick.Check(test, &config); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestTable_findNodeByID_quickCheck(t *testing.T) {
 	t.Parallel()
 
@@ -20,6 +37,23 @@ func TestTable_findNodeByID_quickCheck(t *testing.T) {
 
 	test := func(nodesCount uint16, resultsCount byte) bool {
 		return testTableFindNodeByIDRun(t, nodesCount, resultsCount, config.Rand)
+	}
+
+	if err := quick.Check(test, &config); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestTable_ReadRandomNodesGetAll_quickCheck(t *testing.T) {
+	t.Parallel()
+
+	config := quick.Config{
+		MaxCount: 200,
+		Rand:     rand.New(rand.NewSource(time.Now().Unix())),
+	}
+
+	test := func(nodesCount uint16) bool {
+		return testTableReadRandomNodesGetAllRun(t, nodesCount, config.Rand)
 	}
 
 	if err := quick.Check(test, &config); err != nil {

--- a/p2p/discover/v4_udp_test.go
+++ b/p2p/discover/v4_udp_test.go
@@ -542,6 +542,9 @@ func TestUDPv4_smallNetConvergence(t *testing.T) {
 	}
 	t.Parallel()
 
+	ctx := context.Background()
+	ctx = disableLookupSlowdown(ctx)
+
 	// Start the network.
 	nodes := make([]*UDPv4, 4)
 	for i := range nodes {
@@ -550,9 +553,18 @@ func TestUDPv4_smallNetConvergence(t *testing.T) {
 			bn := nodes[0].Self()
 			cfg.Bootnodes = []*enode.Node{bn}
 		}
-		nodes[i] = startLocalhostV4(t, cfg)
-		defer nodes[i].Close()
+		cfg.ReplyTimeout = 50 * time.Millisecond
+		cfg.PingBackDelay = time.Nanosecond
+		cfg.TableRevalidateInterval = time.Hour
+
+		nodes[i] = startLocalhostV4(ctx, t, cfg)
 	}
+
+	defer func() {
+		for _, node := range nodes {
+			node.Close()
+		}
+	}()
 
 	// Run through the iterator on all nodes until
 	// they have all found each other.
@@ -574,14 +586,13 @@ func TestUDPv4_smallNetConvergence(t *testing.T) {
 	}
 
 	// Wait for all status reports.
-	timeout := time.NewTimer(30 * time.Second)
+	timeout := time.NewTimer(5 * time.Second)
 	defer timeout.Stop()
 	for received := 0; received < len(nodes); {
 		select {
 		case <-timeout.C:
-			for _, node := range nodes {
-				node.Close()
-			}
+			t.Fatalf("Failed to converge within timeout")
+			return
 		case err := <-status:
 			received++
 			if err != nil {
@@ -592,7 +603,7 @@ func TestUDPv4_smallNetConvergence(t *testing.T) {
 	}
 }
 
-func startLocalhostV4(t *testing.T, cfg Config) *UDPv4 {
+func startLocalhostV4(ctx context.Context, t *testing.T, cfg Config) *UDPv4 {
 	t.Helper()
 
 	cfg.PrivateKey = newkey()
@@ -619,8 +630,6 @@ func startLocalhostV4(t *testing.T, cfg Config) *UDPv4 {
 	realaddr := socket.LocalAddr().(*net.UDPAddr)
 	ln.SetStaticIP(realaddr.IP)
 	ln.SetFallbackUDP(realaddr.Port)
-	ctx := context.Background()
-	ctx = disableLookupSlowdown(ctx)
 	udp, err := ListenV4(ctx, socket, ln, cfg)
 	if err != nil {
 		t.Fatal(err)

--- a/p2p/enode/iter_integration_test.go
+++ b/p2p/enode/iter_integration_test.go
@@ -1,0 +1,14 @@
+//go:build integration
+// +build integration
+
+package enode
+
+import "testing"
+
+// This test checks fairness of FairMix in the happy case where all sources return nodes
+// within the context's deadline.
+func TestFairMix(t *testing.T) {
+	for i := 0; i < 500; i++ {
+		testMixerFairness(t)
+	}
+}

--- a/p2p/enode/iter_test.go
+++ b/p2p/enode/iter_test.go
@@ -91,8 +91,9 @@ func checkNodes(t *testing.T, nodes []*Node, wantLen int) {
 
 // This test checks fairness of FairMix in the happy case where all sources return nodes
 // within the context's deadline.
-func TestFairMix(t *testing.T) {
-	for i := 0; i < 500; i++ {
+// see: iter_integration_test.go
+func TestFairMixOnce(t *testing.T) {
+	for i := 0; i < 10; i++ {
 		testMixerFairness(t)
 	}
 }

--- a/p2p/nat/natupnp_test.go
+++ b/p2p/nat/natupnp_test.go
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
+//go:build integration
+// +build integration
+
 package nat
 
 import (


### PR DESCRIPTION
* TestTable_ReadRandomNodesGetAll: refactor to integration and examples
* TestTable_bumpNoDuplicates: refactor to integration and examples
* TestUDPv4_smallNetConvergence: speed up from 1.7s to 0.3s by applying the test config
* TestUPNP_DDWRT: move to integration tests
* TestFairMix: split in 2, do more iterations in integration tests
* TestDialSched: speed up from 1s to 0.2s by removing the unexpected dial check,
(keep the check during the integration tests)