### PR TITLE
CI: windows-2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,8 @@ jobs:
             ~/.cache/go-build
             ~/Library/Caches/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
+          key: go-${{ matrix.os }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: go-${{ matrix.os }}-
 
       - name: Build
         run: make all
@@ -61,7 +61,10 @@ jobs:
         run: make test
 
   tests-windows:
-    runs-on: windows-2019
+    strategy:
+      matrix:
+        os: [ windows-2022 ]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v3
@@ -75,7 +78,7 @@ jobs:
           path: |
             C:\ProgramData\chocolatey\lib\mingw
             C:\ProgramData\chocolatey\lib\cmake
-          key: chocolatey
+          key: chocolatey-${{ matrix.os }}
       - name: Install dependencies
         run: |
           choco upgrade mingw -y --no-progress --version 11.2.0.07112021
@@ -86,8 +89,8 @@ jobs:
           path: |
             ~\AppData\Local\go-build
             ~\go\pkg\mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
+          key: go-${{ matrix.os }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: go-${{ matrix.os }}-
 
       - name: Build
         run: .\wmake.ps1 all

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -30,14 +30,17 @@ jobs:
             ~/.cache/go-build
             ~/Library/Caches/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
+          key: go-${{ matrix.os }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: go-${{ matrix.os }}-
 
       - name: test-integration
         run: make test-integration
 
   tests-windows:
-    runs-on: windows-2019
+    strategy:
+      matrix:
+        os: [ windows-2022 ]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v3
@@ -51,7 +54,7 @@ jobs:
           path: |
             C:\ProgramData\chocolatey\lib\mingw
             C:\ProgramData\chocolatey\lib\cmake
-          key: chocolatey
+          key: chocolatey-${{ matrix.os }}
       - name: Install dependencies
         run: |
           choco upgrade mingw -y --no-progress --version 11.2.0.07112021
@@ -62,8 +65,8 @@ jobs:
           path: |
             ~\AppData\Local\go-build
             ~\go\pkg\mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
+          key: go-${{ matrix.os }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: go-${{ matrix.os }}-
 
       - name: test-integration
         run: .\wmake.ps1 test-integration


### PR DESCRIPTION
Use matrix.os in cache keys to not share caches between OS versions:
- runner.os = Windows
- matrix.os = windows-2022