### PR TITLE
Fix disabled value for `--prune.*` flags

### DIFF
--- a/ethdb/prune/storage_mode.go
+++ b/ethdb/prune/storage_mode.go
@@ -199,7 +199,7 @@ func (m Mode) String() string {
 	if !m.Initialised {
 		return "default"
 	}
-	const defaultVal uint64 = 90000
+	const defaultVal uint64 = params.FullImmutabilityThreshold
 	long := ""
 	short := ""
 	if m.History.Enabled() {

--- a/ethdb/prune/storage_mode.go
+++ b/ethdb/prune/storage_mode.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"strings"
 
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon/params"
@@ -198,32 +199,33 @@ func (m Mode) String() string {
 	if !m.Initialised {
 		return "default"
 	}
+	const defaultVal uint64 = 90000
 	long := ""
-	short := "--prune="
+	short := ""
 	if m.History.Enabled() {
 		if m.History.useDefaultValue() {
-			short += "h"
+			short += fmt.Sprintf(" --prune.h.older=%d", defaultVal)
 		} else {
 			long += fmt.Sprintf(" --prune.h.%s=%d", m.History.dbType(), m.History.toValue())
 		}
 	}
 	if m.Receipts.Enabled() {
 		if m.Receipts.useDefaultValue() {
-			short += "r"
+			short += fmt.Sprintf(" --prune.r.older=%d", defaultVal)
 		} else {
 			long += fmt.Sprintf(" --prune.r.%s=%d", m.Receipts.dbType(), m.Receipts.toValue())
 		}
 	}
 	if m.TxIndex.Enabled() {
 		if m.TxIndex.useDefaultValue() {
-			short += "t"
+			short += fmt.Sprintf(" --prune.t.older=%d", defaultVal)
 		} else {
 			long += fmt.Sprintf(" --prune.t.%s=%d", m.TxIndex.dbType(), m.TxIndex.toValue())
 		}
 	}
 	if m.CallTraces.Enabled() {
 		if m.CallTraces.useDefaultValue() {
-			short += "c"
+			short += fmt.Sprintf(" --prune.c.older=%d", defaultVal)
 		} else {
 			long += fmt.Sprintf(" --prune.c.%s=%d", m.CallTraces.dbType(), m.CallTraces.toValue())
 		}
@@ -231,7 +233,8 @@ func (m Mode) String() string {
 	if m.Experiments.TEVM {
 		long += " --experiments.tevm=enabled"
 	}
-	return short + long
+
+	return strings.TrimLeft(short+long, " ")
 }
 
 func Override(db kv.RwTx, sm Mode) error {

--- a/ethdb/prune/storage_mode.go
+++ b/ethdb/prune/storage_mode.go
@@ -45,36 +45,44 @@ func FromCli(flags string, exactHistory, exactReceipts, exactTxIndex, exactCallT
 		}
 	}
 
-	mode.Initialised = true
 	if exactHistory > 0 {
+		mode.Initialised = true
 		mode.History = Distance(exactHistory)
 	}
 	if exactReceipts > 0 {
+		mode.Initialised = true
 		mode.Receipts = Distance(exactReceipts)
 	}
 	if exactTxIndex > 0 {
+		mode.Initialised = true
 		mode.TxIndex = Distance(exactTxIndex)
 	}
 	if exactCallTraces > 0 {
+		mode.Initialised = true
 		mode.CallTraces = Distance(exactCallTraces)
 	}
 
 	if beforeH > 0 {
+		mode.Initialised = true
 		mode.History = Before(beforeH)
 	}
 	if beforeR > 0 {
+		mode.Initialised = true
 		mode.Receipts = Before(beforeR)
 	}
 	if beforeT > 0 {
+		mode.Initialised = true
 		mode.TxIndex = Before(beforeT)
 	}
 	if beforeC > 0 {
+		mode.Initialised = true
 		mode.CallTraces = Before(beforeC)
 	}
 
 	for _, ex := range experiments {
 		switch ex {
 		case "tevm":
+			mode.Initialised = true
 			mode.Experiments.TEVM = true
 		case "":
 			// skip

--- a/ethdb/prune/storage_mode.go
+++ b/ethdb/prune/storage_mode.go
@@ -27,25 +27,25 @@ type Experiments struct {
 func FromCli(flags string, exactHistory, exactReceipts, exactTxIndex, exactCallTraces,
 	beforeH, beforeR, beforeT, beforeC uint64, experiments []string) (Mode, error) {
 	mode := DefaultMode
-	if flags == "default" || flags == "disabled" {
-		return DefaultMode, nil
-	}
-	mode.Initialised = true
-	for _, flag := range flags {
-		switch flag {
-		case 'h':
-			mode.History = Distance(params.FullImmutabilityThreshold)
-		case 'r':
-			mode.Receipts = Distance(params.FullImmutabilityThreshold)
-		case 't':
-			mode.TxIndex = Distance(params.FullImmutabilityThreshold)
-		case 'c':
-			mode.CallTraces = Distance(params.FullImmutabilityThreshold)
-		default:
-			return DefaultMode, fmt.Errorf("unexpected flag found: %c", flag)
+	if flags != "default" && flags != "disabled" {
+		mode.Initialised = true
+		for _, flag := range flags {
+			switch flag {
+			case 'h':
+				mode.History = Distance(params.FullImmutabilityThreshold)
+			case 'r':
+				mode.Receipts = Distance(params.FullImmutabilityThreshold)
+			case 't':
+				mode.TxIndex = Distance(params.FullImmutabilityThreshold)
+			case 'c':
+				mode.CallTraces = Distance(params.FullImmutabilityThreshold)
+			default:
+				return DefaultMode, fmt.Errorf("unexpected flag found: %c", flag)
+			}
 		}
 	}
 
+	mode.Initialised = true
 	if exactHistory > 0 {
 		mode.History = Distance(exactHistory)
 	}

--- a/turbo/cli/flags.go
+++ b/turbo/cli/flags.go
@@ -63,8 +63,8 @@ var (
 	r - prune receipts (Receipts, Logs, LogTopicIndex, LogAddressIndex - used by eth_getLogs and similar RPC methods)
 	t - prune transaction by it's hash index
 	c - prune call traces (used by trace_filter method)
-	Does delete data older than 90K block (can set another value by '--prune.*.older' flags). 
-	If item is NOT in the list - means NO pruning for this data.s
+	Does delete data older than 90K blocks, --prune=h is shortcut for: --prune.h.older=90_000 
+	If item is NOT in the list - means NO pruning for this data.
 	Example: --prune=hrtc`,
 		Value: "disabled",
 	}


### PR DESCRIPTION
Changes:
* Proceeded to check if other h, r, t or c flags for 'before' and 'older' are set before returning from the default state of --prune
Concern:
* Does the 'disabled' value for '--prune=' need to be updated if the '--prune.*' flags are set but the '--prune=' flag is not?