### PR TITLE
lint: silence non-working go 1.18 linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,15 +7,15 @@ linters:
     - gofmt
     - deadcode
     - errcheck
-    - gosimple
+#    - gosimple # 1.18
     - govet
     - ineffassign
-    - staticcheck
-    - structcheck
-    - unused
+#    - staticcheck # 1.18
+#    - structcheck # 1.18
+#    - unused # 1.18
     - varcheck
 #    - gocritic
-    - bodyclose
+#    - bodyclose # 1.18
 #    - gosec
 #    - forcetypeassert
 


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/issues/2649

```
WARN [linters context] bodyclose is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] gosimple is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] staticcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] structcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] unused is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
```