### PR TITLE
removed obsolete trie variant

### DIFF
--- a/cmd/state/commands/erigon2.go
+++ b/cmd/state/commands/erigon2.go
@@ -150,10 +150,6 @@ func Erigon2(genesis *core.Genesis, chainConfig *params.ChainConfig, logger log.
 	switch commitmentTrie {
 	case "bin":
 		logger.Info("using Binary Patricia Hashed Trie for commitments")
-		trieVariant = commitment.VariantReducedHexPatriciaTrie
-		blockRootMismatchExpected = true
-	case "bin-slow":
-		logger.Info("using slow Binary Patricia Hashed Trie for commitments")
 		trieVariant = commitment.VariantBinPatriciaTrie
 		blockRootMismatchExpected = true
 	case "hex":


### PR DESCRIPTION
requires merge at https://github.com/ledgerwatch/erigon-lib/pull/451
and update of go.mod.