### PR TITLE
p2p: STUN external IP detection

### DIFF
--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -41,7 +41,7 @@ func main() {
 		writeAddr   = flag.Bool("writeaddress", false, "write out the node's public key and quit")
 		nodeKeyFile = flag.String("nodekey", "", "private key filename")
 		nodeKeyHex  = flag.String("nodekeyhex", "", "private key as hex (for testing)")
-		natdesc     = flag.String("nat", "none", "port mapping mechanism (any|none|upnp|pmp|extip:<IP>)")
+		natdesc     = flag.String(utils.NATFlag.Name, "", utils.NATFlag.Usage)
 		netrestrict = flag.String("netrestrict", "", "restrict network communication to the given IP networks (CIDR masks)")
 		runv5       = flag.Bool("v5", false, "run a v5 topic discovery bootnode")
 		verbosity   = flag.Int("verbosity", int(log.LvlInfo), "log verbosity (0-5)")

--- a/cmd/observer/observer/server.go
+++ b/cmd/observer/observer/server.go
@@ -142,7 +142,7 @@ func (server *Server) detectNATExternalIP() (net.IP, error) {
 		return nil, errors.New("no NAT flag configured")
 	}
 	if _, hasExtIP := server.natInterface.(nat.ExtIP); !hasExtIP {
-		server.log.Info("Detecting external IP...")
+		server.log.Debug("Detecting external IP...")
 	}
 	ip, err := server.natInterface.ExternalIP()
 	if err != nil {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -536,13 +536,15 @@ var (
 	}
 	NATFlag = cli.StringFlag{
 		Name: "nat",
-		Usage: `NAT port mapping mechanism (any|none|upnp|pmp|extip:<IP>)
+		Usage: `NAT port mapping mechanism (any|none|upnp|pmp|stun|extip:<IP>)
 	     "" or "none"         default - do not nat
 	     "extip:77.12.33.4"   will assume the local machine is reachable on the given IP
 	     "any"                uses the first auto-detected mechanism
 	     "upnp"               uses the Universal Plug and Play protocol
 	     "pmp"                uses NAT-PMP with an auto-detected gateway address
 	     "pmp:192.168.0.1"    uses NAT-PMP with the given gateway address
+	     "stun"               uses STUN to detect an external IP using a default server
+	     "stun:<server>"      uses STUN to detect an external IP using the given server (host:port)
 `,
 		Value: "",
 	}

--- a/p2p/nat/nat_stun.go
+++ b/p2p/nat/nat_stun.go
@@ -1,0 +1,66 @@
+package nat
+
+import (
+	"fmt"
+	"github.com/pion/stun"
+	"net"
+	"time"
+)
+
+const STUNDefaultServerAddr = "stun.l.google.com:19302"
+
+type STUN struct {
+	serverAddr string
+}
+
+func NewSTUN(serverAddr string) STUN {
+	if serverAddr == "" {
+		serverAddr = STUNDefaultServerAddr
+	}
+	return STUN{serverAddr: serverAddr}
+}
+
+func (s STUN) String() string {
+	return fmt.Sprintf("STUN(%s)", s.serverAddr)
+}
+
+func (STUN) SupportsMapping() bool {
+	return false
+}
+
+func (STUN) AddMapping(string, int, int, string, time.Duration) error {
+	return nil
+}
+
+func (STUN) DeleteMapping(string, int, int) error {
+	return nil
+}
+
+func (s STUN) ExternalIP() (net.IP, error) {
+	conn, err := stun.Dial("udp4", s.serverAddr)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	message := stun.MustBuild(stun.TransactionID, stun.BindingRequest)
+	var response *stun.Event
+	err = conn.Do(message, func(event stun.Event) {
+		response = &event
+	})
+	if err != nil {
+		return nil, err
+	}
+	if response.Error != nil {
+		return nil, response.Error
+	}
+
+	var mappedAddr stun.XORMappedAddress
+	if err := mappedAddr.GetFrom(response.Message); err != nil {
+		return nil, err
+	}
+
+	return mappedAddr.IP, nil
+}


### PR DESCRIPTION
--nat stun is an automatic external IP detection alternative to manual --nat extip option.
It can be used both at home or on production servers without any extra setup.
It is fast (up to 5 ms) and more reliable than alternatives (as the request goes to the public internet).

This auto-detection is useful to run multiple instances of a service in cloud environments
where the node IPs are not known in advance.