### PR TITLE
Snap: call AddHeadersFromSnapshot only at initialCycle

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -745,7 +745,7 @@ func stageTrie(db kv.RwDB, ctx context.Context) error {
 			return err
 		}
 	}
-	integrity.Trie(tx, integritySlow, ctx)
+	integrity.Trie(db, tx, integritySlow, ctx)
 	return tx.Commit()
 }
 

--- a/cmd/integration/commands/state_stages.go
+++ b/cmd/integration/commands/state_stages.go
@@ -283,7 +283,7 @@ func syncBySmallSteps(db kv.RwDB, miningConfig params.MiningConfig, ctx context.
 			if err := checkChanges(expectedAccountChanges, tx, expectedStorageChanges, execAtBlock, pm.History.PruneTo(execToBlock)); err != nil {
 				return err
 			}
-			integrity.Trie(tx, integritySlow, ctx)
+			integrity.Trie(db, tx, integritySlow, ctx)
 		}
 		//receiptsInDB := rawdb.ReadReceiptsByNumber(tx, progress(tx, stages.Execution)+1)
 

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -1136,6 +1136,7 @@ func DeleteAncientBlocks(db kv.RwTx, blockTo uint64, blocksDeleteLimit int) erro
 	return nil
 }
 
+// LastKey - candidate on move to kv.Tx interface
 func LastKey(tx kv.Tx, table string) ([]byte, error) {
 	c, err := tx.Cursor(table)
 	if err != nil {
@@ -1149,6 +1150,7 @@ func LastKey(tx kv.Tx, table string) ([]byte, error) {
 	return k, nil
 }
 
+// FirstKey - candidate on move to kv.Tx interface
 func FirstKey(tx kv.Tx, table string) ([]byte, error) {
 	c, err := tx.Cursor(table)
 	if err != nil {
@@ -1156,6 +1158,24 @@ func FirstKey(tx kv.Tx, table string) ([]byte, error) {
 	}
 	defer c.Close()
 	k, _, err := c.First()
+	if err != nil {
+		return nil, err
+	}
+	return k, nil
+}
+
+// SecondKey - useful if table always has zero-key (for example genesis block)
+func SecondKey(tx kv.Tx, table string) ([]byte, error) {
+	c, err := tx.Cursor(table)
+	if err != nil {
+		return nil, err
+	}
+	defer c.Close()
+	_, _, err = c.First()
+	if err != nil {
+		return nil, err
+	}
+	k, _, err := c.Next()
 	if err != nil {
 		return nil, err
 	}

--- a/eth/integrity/trie.go
+++ b/eth/integrity/trie.go
@@ -11,9 +11,11 @@ import (
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/common/hexutil"
+	"github.com/ledgerwatch/erigon/common/math"
 	"github.com/ledgerwatch/erigon/ethdb"
 	"github.com/ledgerwatch/erigon/turbo/trie"
 	"github.com/ledgerwatch/log/v3"
+	"go.uber.org/atomic"
 )
 
 // AssertSubset a & b == a - checks whether a is subset of b
@@ -23,7 +25,7 @@ func AssertSubset(prefix []byte, a, b uint16) {
 	}
 }
 
-func Trie(tx kv.Tx, slowChecks bool, ctx context.Context) {
+func Trie(db kv.RoDB, tx kv.Tx, slowChecks bool, ctx context.Context) {
 	quit := ctx.Done()
 	logEvery := time.NewTicker(10 * time.Second)
 	defer logEvery.Stop()
@@ -32,6 +34,8 @@ func Trie(tx kv.Tx, slowChecks bool, ctx context.Context) {
 	buf2 := make([]byte, 256)
 
 	{
+		kv.ReadAhead(ctx, db, atomic.NewBool(false), kv.TrieOfAccounts, nil, math.MaxInt32)
+		kv.ReadAhead(ctx, db, atomic.NewBool(false), kv.HashedAccounts, nil, math.MaxInt32)
 		c, err := tx.Cursor(kv.TrieOfAccounts)
 		if err != nil {
 			panic(err)
@@ -141,6 +145,8 @@ func Trie(tx kv.Tx, slowChecks bool, ctx context.Context) {
 		}
 	}
 	{
+		kv.ReadAhead(ctx, db, atomic.NewBool(false), kv.TrieOfStorage, nil, math.MaxInt32)
+		kv.ReadAhead(ctx, db, atomic.NewBool(false), kv.HashedStorage, nil, math.MaxInt32)
 		c, err := tx.Cursor(kv.TrieOfStorage)
 		if err != nil {
 			panic(err)

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -439,11 +439,12 @@ func unwindExecutionStage(u *UnwindState, s *StageState, tx kv.RwTx, quit <-chan
 
 	changes := etl.NewCollector(logPrefix, cfg.tmpdir, etl.NewOldestEntryBuffer(etl.BufferOptimalSize))
 	defer changes.Close()
+	t := time.Now()
 	errRewind := changeset.RewindData(tx, s.BlockNumber, u.UnwindPoint, changes, quit)
 	if errRewind != nil {
 		return fmt.Errorf("getting rewind data: %w", errRewind)
 	}
-
+	fmt.Printf("rewind: %s\n", time.Since(t))
 	if err := changes.Load(tx, stateBucket, func(k, v []byte, table etl.CurrentTableReader, next etl.LoadNextFunc) error {
 		if len(k) == 20 {
 			if len(v) > 0 {

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -445,6 +445,7 @@ func unwindExecutionStage(u *UnwindState, s *StageState, tx kv.RwTx, quit <-chan
 		return fmt.Errorf("getting rewind data: %w", errRewind)
 	}
 	fmt.Printf("rewind: %s\n", time.Since(t))
+
 	if err := changes.Load(tx, stateBucket, func(k, v []byte, table etl.CurrentTableReader, next etl.LoadNextFunc) error {
 		if len(k) == 20 {
 			if len(v) > 0 {

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -1120,7 +1120,10 @@ func DownloadAndIndexSnapshotsIfNeed(s *StageState, ctx context.Context, tx kv.R
 		if err != nil {
 			return err
 		}
-		hasInDB := binary.BigEndian.Uint64(k)
+		var hasInDB uint64 = 1
+		if k != nil {
+			hasInDB = binary.BigEndian.Uint64(k)
+		}
 		if cfg.snapshots.SegmentsMax() < hasInDB {
 			return fmt.Errorf("not enough snapshots available: snapshots=%d, blockInDB=%d, expect=%d", cfg.snapshots.SegmentsMax(), hasInDB, expect)
 		} else {

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -1103,64 +1103,63 @@ func HeadersPrune(p *PruneState, tx kv.RwTx, cfg HeadersCfg, ctx context.Context
 }
 
 func DownloadAndIndexSnapshotsIfNeed(s *StageState, ctx context.Context, tx kv.RwTx, cfg HeadersCfg, initialCycle bool) error {
-	if cfg.snapshots == nil {
+	if cfg.snapshots == nil || !initialCycle {
 		return nil
 	}
 
-	if initialCycle {
-		if err := WaitForDownloader(ctx, tx, cfg); err != nil {
+	if err := WaitForDownloader(ctx, tx, cfg); err != nil {
+		return err
+	}
+	if err := cfg.snapshots.Reopen(); err != nil {
+		return fmt.Errorf("ReopenSegments: %w", err)
+	}
+
+	expect := snapshothashes.KnownConfig(cfg.chainConfig.ChainName).ExpectBlocks
+	if cfg.snapshots.SegmentsMax() < expect {
+		c, err := tx.Cursor(kv.Headers)
+		if err != nil {
 			return err
 		}
-		if err := cfg.snapshots.Reopen(); err != nil {
-			return fmt.Errorf("ReopenSegments: %w", err)
+		defer c.Close()
+		firstK, _, err := c.First()
+		if err != nil {
+			return err
+		}
+		c.Close()
+		hasInDB := binary.BigEndian.Uint64(firstK)
+		if cfg.snapshots.SegmentsMax() < hasInDB {
+			return fmt.Errorf("not enough snapshots available: snapshots=%d, blockInDB=%d, expect=%d", cfg.snapshots.SegmentsMax(), hasInDB, expect)
+		} else {
+			log.Warn(fmt.Sprintf("not enough snapshots available: %d < %d, but we can re-generate them because DB has historical blocks up to: %d", cfg.snapshots.SegmentsMax(), expect, hasInDB))
+		}
+	}
+	if err := cfg.snapshots.Reopen(); err != nil {
+		return fmt.Errorf("ReopenIndices: %w", err)
+	}
+
+	// Create .idx files
+	if cfg.snapshots.IndicesMax() < cfg.snapshots.SegmentsMax() {
+		if !cfg.snapshots.SegmentsReady() {
+			return fmt.Errorf("not all snapshot segments are available")
 		}
 
-		expect := snapshothashes.KnownConfig(cfg.chainConfig.ChainName).ExpectBlocks
-		if cfg.snapshots.SegmentsMax() < expect {
-			c, err := tx.Cursor(kv.Headers)
-			if err != nil {
+		// wait for Downloader service to download all expected snapshots
+		if cfg.snapshots.IndicesMax() < cfg.snapshots.SegmentsMax() {
+			chainID, _ := uint256.FromBig(cfg.chainConfig.ChainID)
+			workers := cmp.InRange(1, 2, runtime.GOMAXPROCS(-1)-1)
+			if err := snapshotsync.BuildIndices(ctx, cfg.snapshots, *chainID, cfg.tmpdir, cfg.snapshots.IndicesMax(), workers, log.LvlInfo); err != nil {
 				return err
-			}
-			defer c.Close()
-			firstK, _, err := c.First()
-			if err != nil {
-				return err
-			}
-			c.Close()
-			hasInDB := binary.BigEndian.Uint64(firstK)
-			if cfg.snapshots.SegmentsMax() < hasInDB {
-				return fmt.Errorf("not enough snapshots available: snapshots=%d, blockInDB=%d, expect=%d", cfg.snapshots.SegmentsMax(), hasInDB, expect)
-			} else {
-				log.Warn(fmt.Sprintf("not enough snapshots available: %d < %d, but we can re-generate them because DB has historical blocks up to: %d", cfg.snapshots.SegmentsMax(), expect, hasInDB))
 			}
 		}
+
 		if err := cfg.snapshots.Reopen(); err != nil {
 			return fmt.Errorf("ReopenIndices: %w", err)
 		}
-
-		// Create .idx files
-		if cfg.snapshots.IndicesMax() < cfg.snapshots.SegmentsMax() {
-			if !cfg.snapshots.SegmentsReady() {
-				return fmt.Errorf("not all snapshot segments are available")
-			}
-
-			// wait for Downloader service to download all expected snapshots
-			if cfg.snapshots.IndicesMax() < cfg.snapshots.SegmentsMax() {
-				chainID, _ := uint256.FromBig(cfg.chainConfig.ChainID)
-				workers := cmp.InRange(1, 2, runtime.GOMAXPROCS(-1)-1)
-				if err := snapshotsync.BuildIndices(ctx, cfg.snapshots, *chainID, cfg.tmpdir, cfg.snapshots.IndicesMax(), workers, log.LvlInfo); err != nil {
-					return err
-				}
-			}
-
-			if err := cfg.snapshots.Reopen(); err != nil {
-				return fmt.Errorf("ReopenIndices: %w", err)
-			}
-		}
-		if cfg.dbEventNotifier != nil {
-			cfg.dbEventNotifier.OnNewSnapshot()
-		}
 	}
+	if cfg.dbEventNotifier != nil {
+		cfg.dbEventNotifier.OnNewSnapshot()
+	}
+	log.Info("[snapshots] see", "blocks", cfg.snapshots.BlocksAvailable())
 
 	if s.BlockNumber < cfg.snapshots.BlocksAvailable() { // allow genesis
 		logEvery := time.NewTicker(logInterval)

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -1103,7 +1103,7 @@ func HeadersPrune(p *PruneState, tx kv.RwTx, cfg HeadersCfg, ctx context.Context
 }
 
 func DownloadAndIndexSnapshotsIfNeed(s *StageState, ctx context.Context, tx kv.RwTx, cfg HeadersCfg, initialCycle bool) error {
-	if cfg.snapshots == nil || !initialCycle {
+	if cfg.snapshots == nil || !cfg.snapshots.Cfg().Enabled || !initialCycle {
 		return nil
 	}
 
@@ -1221,7 +1221,7 @@ func DownloadAndIndexSnapshotsIfNeed(s *StageState, ctx context.Context, tx kv.R
 		}
 		s.BlockNumber = cfg.snapshots.BlocksAvailable()
 	}
-	if err := cfg.hd.AddHeaderFromSnapshot(tx, cfg.snapshots.BlocksAvailable(), cfg.blockReader); err != nil {
+	if err := cfg.hd.AddHeadersFromSnapshot(tx, cfg.snapshots.BlocksAvailable(), cfg.blockReader); err != nil {
 		return err
 	}
 

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -1121,7 +1121,6 @@ func DownloadAndIndexSnapshotsIfNeed(s *StageState, ctx context.Context, tx kv.R
 			return err
 		}
 		hasInDB := binary.BigEndian.Uint64(k)
-		fmt.Printf("aaa: %d\n", cfg.snapshots.SegmentsMax(), hasInDB)
 		if cfg.snapshots.SegmentsMax() < hasInDB {
 			return fmt.Errorf("not enough snapshots available: snapshots=%d, blockInDB=%d, expect=%d", cfg.snapshots.SegmentsMax(), hasInDB, expect)
 		} else {

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -1110,6 +1110,10 @@ func DownloadAndIndexSnapshotsIfNeed(s *StageState, ctx context.Context, tx kv.R
 	if err := WaitForDownloader(ctx, cfg); err != nil {
 		return err
 	}
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	log.Info("[Snapshots] after", "blocks", cfg.snapshots.BlocksAvailable(), "alloc", libcommon.ByteCount(m.Alloc), "sys", libcommon.ByteCount(m.Sys))
+
 	if err := cfg.snapshots.Reopen(); err != nil {
 		return fmt.Errorf("ReopenSegments: %w", err)
 	}
@@ -1153,7 +1157,6 @@ func DownloadAndIndexSnapshotsIfNeed(s *StageState, ctx context.Context, tx kv.R
 	if cfg.dbEventNotifier != nil {
 		cfg.dbEventNotifier.OnNewSnapshot()
 	}
-	var m runtime.MemStats
 	runtime.ReadMemStats(&m)
 	log.Info("[Snapshots] Stat", "blocks", cfg.snapshots.BlocksAvailable(), "alloc", libcommon.ByteCount(m.Alloc), "sys", libcommon.ByteCount(m.Sys))
 
@@ -1218,17 +1221,9 @@ func DownloadAndIndexSnapshotsIfNeed(s *StageState, ctx context.Context, tx kv.R
 		s.BlockNumber = cfg.snapshots.BlocksAvailable()
 	}
 
-	if s.BlockNumber > cfg.snapshots.BlocksAvailable() {
-
-	}
-	runtime.ReadMemStats(&m)
-	log.Info("[Snapshots] before", "blocks", cfg.snapshots.BlocksAvailable(), "alloc", libcommon.ByteCount(m.Alloc), "sys", libcommon.ByteCount(m.Sys))
-
 	if err := cfg.hd.AddHeadersFromSnapshot(tx, cfg.snapshots.BlocksAvailable(), cfg.blockReader); err != nil {
 		return err
 	}
-	runtime.ReadMemStats(&m)
-	log.Info("[Snapshots] after", "blocks", cfg.snapshots.BlocksAvailable(), "alloc", libcommon.ByteCount(m.Alloc), "sys", libcommon.ByteCount(m.Sys))
 
 	return nil
 }

--- a/eth/stagedsync/stage_txlookup.go
+++ b/eth/stagedsync/stage_txlookup.go
@@ -102,7 +102,6 @@ func SpawnTxLookup(s *StageState, tx kv.RwTx, toBlock uint64, cfg TxLookupCfg, c
 
 func txnLookupTransform(logPrefix string, tx kv.RwTx, startKey, endKey []byte, quitCh <-chan struct{}, cfg TxLookupCfg) error {
 	bigNum := new(big.Int)
-	fmt.Printf("start: %x\n", startKey)
 	return etl.Transform(logPrefix, tx, kv.HeaderCanonical, kv.TxLookup, cfg.tmpdir, func(k, v []byte, next etl.ExtractNextFunc) error {
 		blocknum := binary.BigEndian.Uint64(k)
 		blockHash := common.BytesToHash(v)

--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -1100,7 +1100,7 @@ func (hd *HeaderDownload) AddMinedHeader(header *types.Header) error {
 	return nil
 }
 
-func (hd *HeaderDownload) AddHeaderFromSnapshot(tx kv.Tx, n uint64, r interfaces.FullBlockReader) error {
+func (hd *HeaderDownload) AddHeadersFromSnapshot(tx kv.Tx, n uint64, r interfaces.FullBlockReader) error {
 	hd.lock.Lock()
 	defer hd.lock.Unlock()
 

--- a/turbo/trie/structural_branch_test.go
+++ b/turbo/trie/structural_branch_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestIHCursor(t *testing.T) {
-	_, tx := memdb.NewTestTx(t)
+	db, tx := memdb.NewTestTx(t)
 	require := require.New(t)
 	hash := common.HexToHash(fmt.Sprintf("%064d", 0))
 
@@ -57,7 +57,7 @@ func TestIHCursor(t *testing.T) {
 	put("05000f", 0b0000000000000001, 0b0000000000000000, 0b0000000000000001, []common.Hash{hash})
 	put("06", 0b0000000000000001, 0b0000000000000000, 0b0000000000000001, []common.Hash{hash})
 
-	integrity.Trie(tx, false, context.Background())
+	integrity.Trie(db, tx, false, context.Background())
 
 	cursor, err := tx.Cursor(kv.TrieOfAccounts)
 	require.NoError(err)


### PR DESCRIPTION
- print amount of blocks in snapshots at node startup (and alloc)
- fix unwind of TxLookup stage behind snapshot threshold
- call AddHeadersFromSnapshot only at initialCycle