### PR TITLE
Makefile: pass docker build arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,5 +102,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - run: git submodule update --init --recursive --force
-      - run: docker build .
+        with:
+          fetch-depth: 0 # fetch git tags for "git describe"
+      - run: make docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ EXPOSE 8545 8551 8546 30303 30303/udp 42069 42069/udp 8080 9090 6060
 # https://github.com/opencontainers/image-spec/blob/main/annotations.md
 ARG BUILD_DATE
 ARG VCS_REF
+ARG VERSION
 LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.name="Erigon" \
       org.label-schema.description="Erigon Ethereum Client" \

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GOBIN = $(CURDIR)/build/bin
 
 GIT_COMMIT ?= $(shell git rev-list -1 HEAD)
 GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
-GIT_TAG    ?= $(shell git describe --tags `git rev-list --tags="v*" --max-count=1`)
+GIT_TAG    ?= $(shell git describe --tags --dirty)
 
 CGO_CFLAGS := $(shell $(GO) env CGO_CFLAGS) # don't loose default
 CGO_CFLAGS += -DMDBX_FORCE_ASSERTIONS=1 # Enable MDBX's asserts by default in 'devel' branch and disable in 'stable'
@@ -30,7 +30,12 @@ go-version:
 	fi
 
 docker: git-submodules
-	DOCKER_BUILDKIT=1 docker build -t erigon:latest --build-arg git_commit='${GIT_COMMIT}' --build-arg git_branch='${GIT_BRANCH}' --build-arg git_tag='${GIT_TAG}' .
+	DOCKER_BUILDKIT=1 docker build \
+		--build-arg "BUILD_DATE=$(shell date -Iseconds)" \
+		--build-arg VCS_REF=${GIT_COMMIT} \
+		--build-arg VERSION=${GIT_TAG} \
+		${DOCKER_FLAGS} \
+		.
 
 xdg_data_home :=  ~/.local/share
 ifdef XDG_DATA_HOME


### PR DESCRIPTION
Dockerfile requires some --build-arg options.
Fix "docker" target to pass them.
Fix GIT_TAG to reflect the most recent tag related to HEAD, instead of an unrelated most recent tag.
Use it as the image VERSION.

Image tags need to be passed explicitly if needed:

    DOCKER_FLAGS='-t erigon:latest' make docker