### PR TITLE
Fix `rpc.BlockNumberOrHash` unmarshaling

### DIFF
--- a/rpc/types.go
+++ b/rpc/types.go
@@ -136,6 +136,9 @@ func (bnh *BlockNumberOrHash) UnmarshalJSON(data []byte) error {
 		if e.BlockNumber != nil && e.BlockHash != nil {
 			return fmt.Errorf("cannot specify both BlockHash and BlockNumber, choose one or the other")
 		}
+		if e.BlockNumber == nil && e.BlockHash == nil {
+			return fmt.Errorf("at least one of BlockNumber or BlockHash is needed if a dictionary is provided")
+		}
 		bnh.BlockNumber = e.BlockNumber
 		bnh.BlockHash = e.BlockHash
 		bnh.RequireCanonical = e.RequireCanonical

--- a/rpc/types_test.go
+++ b/rpc/types_test.go
@@ -98,6 +98,8 @@ func TestBlockNumberOrHash_UnmarshalJSON(t *testing.T) {
 		23: {`{"blockNumber":"latest"}`, false, BlockNumberOrHashWithNumber(LatestBlockNumber)},
 		24: {`{"blockNumber":"earliest"}`, false, BlockNumberOrHashWithNumber(EarliestBlockNumber)},
 		25: {`{"blockNumber":"0x1", "blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000"}`, true, BlockNumberOrHash{}},
+		26: {`{}`, true, BlockNumberOrHash{}},
+		27: {`{"jsonrpc":"2.0","result":{"code":418,"message":"blabla"},"id":""}]`, true, BlockNumberOrHash{}},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
`rpc.BlockNumberOrHash` can be unmarshalled from a JSON dictionary.

I found that if you provide an empty or an invalid dictionary, it still unmarshalls successfully but with `nil` values. That crashes method handlers.

Added tests and error handling for this case.

```
		26: {`{}`, true, BlockNumberOrHash{}},
		27: {`{"jsonrpc":"2.0","result":{"code":418,"message":"blabla"},"id":""}]`, true, BlockNumberOrHash{}},
```

