### PR TITLE
sentry: HTTP health check

### DIFF
--- a/cmd/sentry/main.go
+++ b/cmd/sentry/main.go
@@ -33,6 +33,8 @@ var (
 	maxPeers     int
 	maxPendPeers int
 	healthCheck  bool
+
+	healthCheckHTTPAddr string
 )
 
 func init() {
@@ -51,6 +53,7 @@ func init() {
 	rootCmd.Flags().IntVar(&maxPeers, utils.MaxPeersFlag.Name, utils.MaxPeersFlag.Value, utils.MaxPeersFlag.Usage)
 	rootCmd.Flags().IntVar(&maxPendPeers, utils.MaxPendingPeersFlag.Name, utils.MaxPendingPeersFlag.Value, utils.MaxPendingPeersFlag.Usage)
 	rootCmd.Flags().BoolVar(&healthCheck, utils.HealthCheckFlag.Name, false, utils.HealthCheckFlag.Usage)
+	rootCmd.Flags().StringVar(&healthCheckHTTPAddr, utils.HealthCheckHTTPAddrFlag.Name, "", utils.HealthCheckHTTPAddrFlag.Usage)
 
 	if err := rootCmd.MarkFlagDirname(utils.DataDirFlag.Name); err != nil {
 		panic(err)
@@ -92,7 +95,16 @@ var rootCmd = &cobra.Command{
 			return err
 		}
 
-		return sentry.Sentry(cmd.Context(), datadir, sentryAddr, discoveryDNS, p2pConfig, uint(p), healthCheck)
+		return sentry.Sentry(
+			cmd.Context(),
+			datadir,
+			sentryAddr,
+			discoveryDNS,
+			p2pConfig,
+			uint(p),
+			healthCheck,
+			healthCheckHTTPAddr,
+		)
 	},
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -685,6 +685,11 @@ var (
 		Usage: "Enabling grpc health check",
 	}
 
+	HealthCheckHTTPAddrFlag = cli.BoolFlag{
+		Name:  "healthcheck.http.addr",
+		Usage: "<host>:<port> of an HTTP health check endpoint",
+	}
+
 	HeimdallURLFlag = cli.StringFlag{
 		Name:  "bor.heimdall",
 		Usage: "URL of Heimdall service",

--- a/common/health_check_handler.go
+++ b/common/health_check_handler.go
@@ -1,0 +1,22 @@
+package common
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type HealthCheckHandler func() bool
+
+func (handler HealthCheckHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	if request.URL.Path != "/health" {
+		http.NotFound(writer, request)
+		return
+	}
+
+	if handler() {
+		writer.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintln(writer, "100%")
+	} else {
+		http.Error(writer, "Service Unavailable", http.StatusServiceUnavailable)
+	}
+}


### PR DESCRIPTION
This is useful for some cloud deployments.
For example, Google AppEngine requires an HTTP server that replies to health checks.