### PR TITLE
sentry: log peer events in erigon

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/kevinburke/go-bindata v3.21.0+incompatible
-	github.com/ledgerwatch/erigon-lib v0.0.0-20220525112105-b544bfe85dee
+	github.com/ledgerwatch/erigon-lib v0.0.0-20220526112101-6b62bf17b5ba
 	github.com/ledgerwatch/log/v3 v3.4.1
 	github.com/ledgerwatch/secp256k1 v1.0.0
 	github.com/pelletier/go-toml v1.9.5

--- a/go.sum
+++ b/go.sum
@@ -382,8 +382,8 @@ github.com/kylelemons/godebug v0.0.0-20170224010052-a616ab194758 h1:0D5M2HQSGD3P
 github.com/kylelemons/godebug v0.0.0-20170224010052-a616ab194758/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
-github.com/ledgerwatch/erigon-lib v0.0.0-20220525112105-b544bfe85dee h1:wWX/fzHkmeGRQQYkkFE/sHki6e3yGxi9p+fOiaAFuog=
-github.com/ledgerwatch/erigon-lib v0.0.0-20220525112105-b544bfe85dee/go.mod h1:xwTBiT7FMP6tpPThN4WGEo11Mx0dxlR/BZnRq150sFo=
+github.com/ledgerwatch/erigon-lib v0.0.0-20220526112101-6b62bf17b5ba h1:TqoJQJcipTQTBQDvlJUdhc+BKCKQCMBIv4W2P87Mbyg=
+github.com/ledgerwatch/erigon-lib v0.0.0-20220526112101-6b62bf17b5ba/go.mod h1:xwTBiT7FMP6tpPThN4WGEo11Mx0dxlR/BZnRq150sFo=
 github.com/ledgerwatch/log/v3 v3.4.1 h1:/xGwlVulXnsO9Uq+tzaExc8OWmXXHU0dnLalpbnY5Bc=
 github.com/ledgerwatch/log/v3 v3.4.1/go.mod h1:VXcz6Ssn6XEeU92dCMc39/g1F0OYAjw1Mt+dGP5DjXY=
 github.com/ledgerwatch/secp256k1 v1.0.0 h1:Usvz87YoTG0uePIV8woOof5cQnLXGYa162rFf3YnwaQ=


### PR DESCRIPTION
* refactor pumpStreamLoop to support streams with arbitrary message types
* subscribe to PeerEvents

Example output:
```
[DBUG] [05-26|11:43:31.575] Sentry peer did Connect                  peer=2098142ba904cb76194eec84c76b23fcd840d9ba8834633efcd5da5780fee573ea464fbd64e97fd198758df7826497adbd6fcba2ccaaf952a1f840fe2bb63c00
[DBUG] [05-26|11:43:53.823] Sentry peer did Connect                  peer=252ab6a1d0f971d9722cb839a42cb81db019ba44c08754628ab4a823487071b5695317c8ccd085219c3a03af063495b2f1da8d18218da2d6a82981b45e6ffc00
[DBUG] [05-26|11:43:53.823] Sentry peer did Disconnect               peer=252ab6a1d0f971d9722cb839a42cb81db019ba44c08754628ab4a823487071b5695317c8ccd085219c3a03af063495b2f1da8d18218da2d6a82981b45e6ffc00
[DBUG] [05-26|11:43:54.196] Sentry peer did Connect                  peer=85e1419dcc1b84f415372f8d415f92d205ded455a7a71834c9033472002b5372fe2d311d437112001c0d3ce9cf1b91ee80dfcfad53f24f312353b790c8bcaf00
[DBUG] [05-26|11:44:02.478] Sentry peer did Connect                  peer=b446c86fbeb42ad7ff1a4993db3d1d131dc82cd6a9705ea97e5aa69dad640b95c8808623767f72d112c1aea970dc87a901090ff454acd16635d961191101f900
[DBUG] [05-26|11:44:09.133] Sentry peer did Connect                  peer=1210585f17f886ac02266e88b1aaead5667b99dabcaea9f0e59aa7ed192f38d5dd7e17ab90c5498029bf2ccfc3cd5f7f7ff7fad1df8ba0751f5beeb54bd4d300
```