### PR TITLE
observer: sentry candidates intake

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -1203,7 +1203,18 @@ func newSync(ctx context.Context, db kv.RwDB, miningConfig *params.MiningConfig)
 	}
 
 	br := getBlockReader(chainConfig, db)
-	sentryControlServer, err := sentry.NewMultiClient(db, "", chainConfig, genesisBlock.Hash(), engine, 1, nil, ethconfig.Defaults.Sync, br)
+	sentryControlServer, err := sentry.NewMultiClient(
+		db,
+		"",
+		chainConfig,
+		genesisBlock.Hash(),
+		engine,
+		1,
+		nil,
+		ethconfig.Defaults.Sync,
+		br,
+		false,
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/observer/database/db.go
+++ b/cmd/observer/database/db.go
@@ -56,6 +56,9 @@ type DB interface {
 	UpdateNeighborBucketKeys(ctx context.Context, id NodeID, keys []string) error
 	FindNeighborBucketKeys(ctx context.Context, id NodeID) ([]string, error)
 
+	UpdateSentryCandidatesLastEventTime(ctx context.Context, value time.Time) error
+	FindSentryCandidatesLastEventTime(ctx context.Context) (*time.Time, error)
+
 	UpdateCrawlRetryTime(ctx context.Context, id NodeID, retryTime time.Time) error
 	CountCandidates(ctx context.Context) (uint, error)
 	FindCandidates(ctx context.Context, limit uint) ([]NodeID, error)

--- a/cmd/observer/database/db.go
+++ b/cmd/observer/database/db.go
@@ -36,6 +36,7 @@ type DB interface {
 	CountPingErrors(ctx context.Context, id NodeID) (*uint, error)
 
 	UpdateClientID(ctx context.Context, id NodeID, clientID string) error
+	FindClientID(ctx context.Context, id NodeID) (*string, error)
 	UpdateNetworkID(ctx context.Context, id NodeID, networkID uint) error
 	UpdateEthVersion(ctx context.Context, id NodeID, ethVersion uint) error
 	UpdateHandshakeTransientError(ctx context.Context, id NodeID, hasTransientErr bool) error

--- a/cmd/observer/database/db_retrier.go
+++ b/cmd/observer/database/db_retrier.go
@@ -88,6 +88,18 @@ func (db DBRetrier) UpdateClientID(ctx context.Context, id NodeID, clientID stri
 	return err
 }
 
+func (db DBRetrier) FindClientID(ctx context.Context, id NodeID) (*string, error) {
+	resultAny, err := db.retry(ctx, "FindClientID", func(ctx context.Context) (interface{}, error) {
+		return db.db.FindClientID(ctx, id)
+	})
+
+	if resultAny == nil {
+		return nil, err
+	}
+	result := resultAny.(*string)
+	return result, err
+}
+
 func (db DBRetrier) UpdateNetworkID(ctx context.Context, id NodeID, networkID uint) error {
 	_, err := db.retry(ctx, "UpdateNetworkID", func(ctx context.Context) (interface{}, error) {
 		return nil, db.db.UpdateNetworkID(ctx, id, networkID)

--- a/cmd/observer/database/db_retrier.go
+++ b/cmd/observer/database/db_retrier.go
@@ -216,6 +216,25 @@ func (db DBRetrier) FindNeighborBucketKeys(ctx context.Context, id NodeID) ([]st
 	return result, err
 }
 
+func (db DBRetrier) UpdateSentryCandidatesLastEventTime(ctx context.Context, value time.Time) error {
+	_, err := db.retry(ctx, "UpdateSentryCandidatesLastEventTime", func(ctx context.Context) (interface{}, error) {
+		return nil, db.db.UpdateSentryCandidatesLastEventTime(ctx, value)
+	})
+	return err
+}
+
+func (db DBRetrier) FindSentryCandidatesLastEventTime(ctx context.Context) (*time.Time, error) {
+	resultAny, err := db.retry(ctx, "FindSentryCandidatesLastEventTime", func(ctx context.Context) (interface{}, error) {
+		return db.db.FindSentryCandidatesLastEventTime(ctx)
+	})
+
+	if resultAny == nil {
+		return nil, err
+	}
+	result := resultAny.(*time.Time)
+	return result, err
+}
+
 func (db DBRetrier) UpdateCrawlRetryTime(ctx context.Context, id NodeID, retryTime time.Time) error {
 	_, err := db.retry(ctx, "UpdateCrawlRetryTime", func(ctx context.Context) (interface{}, error) {
 		return nil, db.db.UpdateCrawlRetryTime(ctx, id, retryTime)

--- a/cmd/observer/database/db_sqlite.go
+++ b/cmd/observer/database/db_sqlite.go
@@ -116,6 +116,10 @@ UPDATE nodes SET
 WHERE id = ?
 `
 
+	sqlFindClientID = `
+SELECT client_id FROM nodes WHERE id = ?
+`
+
 	sqlUpdateNetworkID = `
 UPDATE nodes SET 
 	network_id = ?, 
@@ -428,6 +432,22 @@ func (db *DBSQLite) UpdateClientID(ctx context.Context, id NodeID, clientID stri
 		return fmt.Errorf("UpdateClientID failed to update a node: %w", err)
 	}
 	return nil
+}
+
+func (db *DBSQLite) FindClientID(ctx context.Context, id NodeID) (*string, error) {
+	row := db.db.QueryRowContext(ctx, sqlFindClientID, id)
+	var clientID sql.NullString
+	err := row.Scan(&clientID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("FindClientID failed: %w", err)
+	}
+	if clientID.Valid {
+		return &clientID.String, nil
+	}
+	return nil, nil
 }
 
 func (db *DBSQLite) UpdateNetworkID(ctx context.Context, id NodeID, networkID uint) error {

--- a/cmd/observer/database/db_sqlite.go
+++ b/cmd/observer/database/db_sqlite.go
@@ -54,6 +54,11 @@ CREATE TABLE IF NOT EXISTS handshake_errors (
     updated INTEGER NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS sentry_candidates_intake (
+    id INTEGER PRIMARY KEY,
+    last_event_time INTEGER NOT NULL
+);
+
 CREATE INDEX IF NOT EXISTS idx_nodes_crawl_retry_time ON nodes (crawl_retry_time);
 CREATE INDEX IF NOT EXISTS idx_nodes_ip ON nodes (ip);
 CREATE INDEX IF NOT EXISTS idx_nodes_ip_v6 ON nodes (ip_v6);
@@ -196,6 +201,19 @@ UPDATE nodes SET neighbor_keys = ? WHERE id = ?
 
 	sqlFindNeighborBucketKeys = `
 SELECT neighbor_keys FROM nodes WHERE id = ?
+`
+
+	sqlUpdateSentryCandidatesLastEventTime = `
+INSERT INTO sentry_candidates_intake(
+	id,
+	last_event_time
+) VALUES (0, ?)
+ON CONFLICT(id) DO UPDATE SET
+	last_event_time = excluded.last_event_time
+`
+
+	sqlFindSentryCandidatesLastEventTime = `
+SELECT last_event_time FROM sentry_candidates_intake WHERE id = 0
 `
 
 	sqlUpdateCrawlRetryTime = `
@@ -690,6 +708,29 @@ func (db *DBSQLite) FindNeighborBucketKeys(ctx context.Context, id NodeID) ([]st
 		return nil, nil
 	}
 	return strings.Split(keysStr.String, ","), nil
+}
+
+func (db *DBSQLite) UpdateSentryCandidatesLastEventTime(ctx context.Context, value time.Time) error {
+	_, err := db.db.ExecContext(ctx, sqlUpdateSentryCandidatesLastEventTime, value.Unix())
+	if err != nil {
+		return fmt.Errorf("UpdateSentryCandidatesLastEventTime failed: %w", err)
+	}
+	return nil
+}
+
+func (db *DBSQLite) FindSentryCandidatesLastEventTime(ctx context.Context) (*time.Time, error) {
+	row := db.db.QueryRowContext(ctx, sqlFindSentryCandidatesLastEventTime)
+
+	var timestamp sql.NullInt64
+	if err := row.Scan(&timestamp); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("FindSentryCandidatesLastEventTime failed: %w", err)
+	}
+
+	value := time.Unix(timestamp.Int64, 0)
+	return &value, nil
 }
 
 func (db *DBSQLite) UpdateCrawlRetryTime(ctx context.Context, id NodeID, retryTime time.Time) error {

--- a/cmd/observer/main.go
+++ b/cmd/observer/main.go
@@ -49,6 +49,8 @@ func mainWithFlags(ctx context.Context, flags observer.CommandFlags) error {
 
 		KeygenTimeout:     flags.KeygenTimeout,
 		KeygenConcurrency: flags.KeygenConcurrency,
+
+		ErigonLogPath: flags.ErigonLogPath,
 	}
 
 	crawler, err := observer.NewCrawler(discV4, db, crawlerConfig, log.Root())

--- a/cmd/observer/main.go
+++ b/cmd/observer/main.go
@@ -77,6 +77,15 @@ func reportWithFlags(ctx context.Context, flags reports.CommandFlags) error {
 		return nil
 	}
 
+	if flags.SentryCandidates {
+		report, err := reports.CreateSentryCandidatesReport(ctx, db, flags.ErigonLogPath)
+		if err != nil {
+			return err
+		}
+		fmt.Println(report)
+		return nil
+	}
+
 	statusReport, err := reports.CreateStatusReport(ctx, db, flags.MaxPingTries, networkID)
 	if err != nil {
 		return err

--- a/cmd/observer/observer/command.go
+++ b/cmd/observer/observer/command.go
@@ -35,6 +35,8 @@ type CommandFlags struct {
 	HandshakeRefreshTimeout time.Duration
 	HandshakeRetryDelay     time.Duration
 	HandshakeMaxTries       uint
+
+	ErigonLogPath string
 }
 
 type Command struct {
@@ -77,6 +79,8 @@ func NewCommand() *Command {
 	instance.withHandshakeRefreshTimeout()
 	instance.withHandshakeRetryDelay()
 	instance.withHandshakeMaxTries()
+
+	instance.withErigonLogPath()
 
 	return &instance
 }
@@ -201,6 +205,14 @@ func (command *Command) withHandshakeMaxTries() {
 		Value: 3,
 	}
 	command.command.Flags().UintVar(&command.flags.HandshakeMaxTries, flag.Name, flag.Value, flag.Usage)
+}
+
+func (command *Command) withErigonLogPath() {
+	flag := cli.StringFlag{
+		Name:  "erigon-log",
+		Usage: "Erigon log file path. Enables sentry candidates intake.",
+	}
+	command.command.Flags().StringVar(&command.flags.ErigonLogPath, flag.Name, flag.Value, flag.Usage)
 }
 
 func (command *Command) ExecuteContext(ctx context.Context, runFunc func(ctx context.Context, flags CommandFlags) error) error {

--- a/cmd/observer/observer/diplomacy.go
+++ b/cmd/observer/observer/diplomacy.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/ledgerwatch/erigon/cmd/observer/database"
+	"github.com/ledgerwatch/erigon/cmd/observer/observer/node_utils"
 	"github.com/ledgerwatch/erigon/cmd/observer/utils"
 	"github.com/ledgerwatch/log/v3"
 	"golang.org/x/sync/semaphore"
@@ -143,7 +144,7 @@ func (diplomacy *Diplomacy) Run(ctx context.Context) error {
 			return fmt.Errorf("failed to get the node address: %w", err)
 		}
 
-		node, err := makeNodeFromAddr(id, *nodeAddr)
+		node, err := node_utils.MakeNodeFromAddr(id, *nodeAddr)
 		if err != nil {
 			return fmt.Errorf("failed to make node from node address: %w", err)
 		}

--- a/cmd/observer/observer/node_utils/node_id.go
+++ b/cmd/observer/observer/node_utils/node_id.go
@@ -1,0 +1,21 @@
+package node_utils
+
+import (
+	"errors"
+	"fmt"
+	"github.com/ledgerwatch/erigon/cmd/observer/database"
+	"github.com/ledgerwatch/erigon/p2p/enode"
+	"net/url"
+)
+
+func NodeID(node *enode.Node) (database.NodeID, error) {
+	if node.Incomplete() {
+		return "", errors.New("NodeID not implemented for incomplete nodes")
+	}
+	nodeURL, err := url.Parse(node.URLv4())
+	if err != nil {
+		return "", fmt.Errorf("failed to parse node URL: %w", err)
+	}
+	id := nodeURL.User.Username()
+	return database.NodeID(id), nil
+}

--- a/cmd/observer/observer/sentry_candidates/intake.go
+++ b/cmd/observer/observer/sentry_candidates/intake.go
@@ -1,0 +1,207 @@
+package sentry_candidates
+
+import (
+	"context"
+	"fmt"
+	"github.com/ledgerwatch/erigon/cmd/observer/database"
+	"github.com/ledgerwatch/erigon/cmd/observer/observer/node_utils"
+	"github.com/ledgerwatch/erigon/cmd/observer/utils"
+	"github.com/ledgerwatch/erigon/p2p/enode"
+	"github.com/ledgerwatch/erigon/params"
+	"github.com/ledgerwatch/log/v3"
+	"github.com/nxadm/tail"
+	"time"
+)
+
+type Intake struct {
+	logPath   string
+	db        database.DBRetrier
+	saveQueue *utils.TaskQueue
+	chain     string
+
+	handshakeRefreshTimeout time.Duration
+
+	statusLogPeriod time.Duration
+	log             log.Logger
+}
+
+func NewIntake(
+	logPath string,
+	db database.DBRetrier,
+	saveQueue *utils.TaskQueue,
+	chain string,
+	handshakeRefreshTimeout time.Duration,
+	statusLogPeriod time.Duration,
+	logger log.Logger,
+) *Intake {
+	instance := Intake{
+		logPath,
+		db,
+		saveQueue,
+		chain,
+		handshakeRefreshTimeout,
+		statusLogPeriod,
+		logger,
+	}
+	return &instance
+}
+
+func (intake *Intake) Run(ctx context.Context) error {
+	tailConfig := tail.Config{
+		MustExist:     true,
+		Follow:        true,
+		CompleteLines: true,
+	}
+	logFile, err := tail.TailFile(intake.logPath, tailConfig)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = logFile.Stop()
+		logFile.Cleanup()
+	}()
+	eventLog := NewLog(NewTailLineReader(ctx, logFile))
+
+	var lastEventTime *time.Time
+	lastEventTime, err = intake.db.FindSentryCandidatesLastEventTime(ctx)
+	if err != nil {
+		return err
+	}
+
+	doneCount := 0
+	statusLogDate := time.Now()
+
+	for {
+		event, err := eventLog.Read()
+		if err != nil {
+			return err
+		}
+		if event == nil {
+			break
+		}
+
+		if (event.NodeURL == "") || (event.ClientID == "") {
+			continue
+		}
+
+		// Skip all events processed previously.
+		// The time is stored with a second precision, hence adding a slack.
+		if (lastEventTime != nil) && !event.Timestamp.After(lastEventTime.Add(time.Second)) {
+			continue
+		}
+
+		doneCount++
+		if time.Since(statusLogDate) > intake.statusLogPeriod {
+			intake.log.Info(
+				"Sentry candidates intake",
+				"done", doneCount,
+			)
+			statusLogDate = time.Now()
+		}
+
+		peerNode, err := enode.ParseV4(event.NodeURL)
+		if err != nil {
+			return err
+		}
+
+		networkID := params.NetworkIDByChainName(intake.chain)
+		isCompatFork := true
+
+		handshakeRetryTime := time.Now().Add(intake.handshakeRefreshTimeout)
+		crawlRetryTime := time.Now()
+
+		intake.log.Trace("sentry_candidates.Intake saving peer",
+			"timestamp", event.Timestamp,
+			"peerNode", peerNode,
+			"clientID", event.ClientID,
+		)
+
+		intake.saveQueue.EnqueueTask(ctx, func(ctx context.Context) error {
+			return intake.savePeer(
+				ctx,
+				event.Timestamp,
+				peerNode,
+				event.ClientID,
+				networkID,
+				isCompatFork,
+				event.EthVersion(),
+				handshakeRetryTime,
+				crawlRetryTime)
+		})
+	}
+	return nil
+}
+
+func (intake *Intake) savePeer(
+	ctx context.Context,
+	eventTime time.Time,
+	peer *enode.Node,
+	clientID string,
+	networkID uint64,
+	isCompatFork bool,
+	ethVersion uint,
+	handshakeRetryTime time.Time,
+	crawlRetryTime time.Time,
+) error {
+	id, err := node_utils.NodeID(peer)
+	if err != nil {
+		return fmt.Errorf("failed to get peer node ID: %w", err)
+	}
+
+	var dbErr error
+
+	// Update the eventTime early. If the save fails, the candidate will be skipped on the next run.
+	dbErr = intake.db.UpdateSentryCandidatesLastEventTime(ctx, eventTime)
+	if dbErr != nil {
+		return dbErr
+	}
+
+	dbErr = intake.db.UpsertNodeAddr(ctx, id, node_utils.MakeNodeAddr(peer))
+	if dbErr != nil {
+		return dbErr
+	}
+
+	dbErr = intake.db.ResetPingError(ctx, id)
+	if dbErr != nil {
+		return dbErr
+	}
+
+	dbErr = intake.db.UpdateClientID(ctx, id, clientID)
+	if dbErr != nil {
+		return dbErr
+	}
+
+	dbErr = intake.db.UpdateNetworkID(ctx, id, uint(networkID))
+	if dbErr != nil {
+		return dbErr
+	}
+
+	dbErr = intake.db.UpdateForkCompatibility(ctx, id, isCompatFork)
+	if dbErr != nil {
+		return dbErr
+	}
+
+	if ethVersion != 0 {
+		dbErr = intake.db.UpdateEthVersion(ctx, id, ethVersion)
+		if dbErr != nil {
+			return dbErr
+		}
+	}
+
+	dbErr = intake.db.DeleteHandshakeErrors(ctx, id)
+	if dbErr != nil {
+		return dbErr
+	}
+
+	dbErr = intake.db.UpdateHandshakeTransientError(ctx, id, false)
+	if dbErr != nil {
+		return dbErr
+	}
+
+	dbErr = intake.db.UpdateHandshakeRetryTime(ctx, id, handshakeRetryTime)
+	if dbErr != nil {
+		return dbErr
+	}
+
+	return intake.db.UpdateCrawlRetryTime(ctx, id, crawlRetryTime)
+}

--- a/cmd/observer/observer/sentry_candidates/log.go
+++ b/cmd/observer/observer/sentry_candidates/log.go
@@ -1,0 +1,80 @@
+package sentry_candidates
+
+import (
+	"bufio"
+	"encoding/json"
+	"github.com/ledgerwatch/erigon/eth/protocols/eth"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Log struct {
+	reader LineReader
+}
+
+type LogEvent struct {
+	Timestamp    time.Time `json:"t"`
+	Message      string    `json:"msg"`
+	PeerIDHex    string    `json:"peer,omitempty"`
+	NodeURL      string    `json:"nodeURL,omitempty"`
+	ClientID     string    `json:"clientID,omitempty"`
+	Capabilities []string  `json:"capabilities,omitempty"`
+}
+
+func NewLog(reader LineReader) *Log {
+	return &Log{reader}
+}
+
+func (log *Log) Read() (*LogEvent, error) {
+	var event LogEvent
+	for event.Message != "Sentry peer did Connect" {
+		line, err := log.reader.ReadLine()
+		if (err != nil) || (line == nil) {
+			return nil, err
+		}
+
+		lineData := []byte(*line)
+		if err := json.Unmarshal(lineData, &event); err != nil {
+			return nil, err
+		}
+	}
+	return &event, nil
+}
+
+func (event *LogEvent) EthVersion() uint {
+	var maxVersion uint64
+	for _, capability := range event.Capabilities {
+		if !strings.HasPrefix(capability, eth.ProtocolName) {
+			continue
+		}
+		versionStr := capability[len(eth.ProtocolName)+1:]
+		version, _ := strconv.ParseUint(versionStr, 10, 32)
+		if version > maxVersion {
+			maxVersion = version
+		}
+	}
+	return uint(maxVersion)
+}
+
+type LineReader interface {
+	ReadLine() (*string, error)
+}
+
+type ScannerLineReader struct {
+	scanner *bufio.Scanner
+}
+
+func NewScannerLineReader(reader io.Reader) *ScannerLineReader {
+	return &ScannerLineReader{bufio.NewScanner(reader)}
+}
+
+func (reader *ScannerLineReader) ReadLine() (*string, error) {
+	if reader.scanner.Scan() {
+		line := reader.scanner.Text()
+		return &line, nil
+	} else {
+		return nil, reader.scanner.Err()
+	}
+}

--- a/cmd/observer/observer/sentry_candidates/log_test.go
+++ b/cmd/observer/observer/sentry_candidates/log_test.go
@@ -1,0 +1,37 @@
+package sentry_candidates
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+)
+
+func TestLogRead(t *testing.T) {
+	line := `
+{"capabilities":["eth/66","wit/0"],"clientID":"Nethermind/v1.13.0-0-2e8910b5b-20220520/X64-Linux/6.0.4","lvl":"dbug","msg":"Sentry peer did Connect","nodeURL":"enode://4293b17b897abed4a88d6e760e86a4bb700d62c12a9411fbf9ec0c9df3740c8670b184bd9f24d163cbd9bf05264b3047a69f079209d53d2e0dc05dd678d07cf0@1.2.3.4:45492","peer":"93b17b897abed4a88d6e760e86a4bb700d62c12a9411fbf9ec0c9df3740c8670b184bd9f24d163cbd9bf05264b3047a69f079209d53d2e0dc05dd678d07cf000","t":"2022-05-31T11:10:19.032092272Z"}
+`
+	line = strings.TrimLeft(line, "\r\n ")
+	eventLog := NewLog(NewScannerLineReader(strings.NewReader(line)))
+	event, err := eventLog.Read()
+	assert.Nil(t, err)
+	require.NotNil(t, event)
+
+	assert.NotEmpty(t, event.Message)
+	assert.NotEmpty(t, event.PeerIDHex)
+	assert.NotEmpty(t, event.NodeURL)
+	assert.NotEmpty(t, event.ClientID)
+
+	assert.Equal(t, int64(1653995419), event.Timestamp.Unix())
+	assert.Equal(t, "Sentry peer did Connect", event.Message)
+	assert.True(t, strings.HasPrefix(event.NodeURL, "enode:"))
+	assert.True(t, strings.HasPrefix(event.ClientID, "Nethermind"))
+	assert.Equal(t, 2, len(event.Capabilities))
+}
+
+func TestLogEventEthVersion(t *testing.T) {
+	event := LogEvent{}
+	event.Capabilities = []string{"wit/0", "eth/64", "eth/65", "eth/66"}
+	version := event.EthVersion()
+	assert.Equal(t, uint(66), version)
+}

--- a/cmd/observer/observer/sentry_candidates/log_test.go
+++ b/cmd/observer/observer/sentry_candidates/log_test.go
@@ -1,6 +1,8 @@
 package sentry_candidates
 
 import (
+	"context"
+	"github.com/nxadm/tail"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"strings"
@@ -27,6 +29,27 @@ func TestLogRead(t *testing.T) {
 	assert.True(t, strings.HasPrefix(event.NodeURL, "enode:"))
 	assert.True(t, strings.HasPrefix(event.ClientID, "Nethermind"))
 	assert.Equal(t, 2, len(event.Capabilities))
+}
+
+func TestLogReadTailSkimFile(t *testing.T) {
+	t.Skip()
+
+	logFile, err := tail.TailFile(
+		"erigon.log",
+		tail.Config{Follow: false, MustExist: true})
+	require.Nil(t, err)
+	defer func() {
+		_ = logFile.Stop()
+	}()
+
+	eventLog := NewLog(NewTailLineReader(context.Background(), logFile))
+	for {
+		event, err := eventLog.Read()
+		require.Nil(t, err)
+		if event == nil {
+			break
+		}
+	}
 }
 
 func TestLogEventEthVersion(t *testing.T) {

--- a/cmd/observer/reports/command.go
+++ b/cmd/observer/reports/command.go
@@ -13,6 +13,9 @@ type CommandFlags struct {
 	ClientsLimit uint
 	MaxPingTries uint
 	Estimate     bool
+
+	SentryCandidates bool
+	ErigonLogPath    string
 }
 
 type Command struct {
@@ -34,6 +37,8 @@ func NewCommand() *Command {
 	instance.withClientsLimit()
 	instance.withMaxPingTries()
 	instance.withEstimate()
+	instance.withSentryCandidates()
+	instance.withErigonLogPath()
 
 	return &instance
 }
@@ -73,6 +78,22 @@ func (command *Command) withEstimate() {
 		Usage: "Estimate totals including nodes that replied with 'too many peers'",
 	}
 	command.command.Flags().BoolVar(&command.flags.Estimate, flag.Name, false, flag.Usage)
+}
+
+func (command *Command) withSentryCandidates() {
+	flag := cli.BoolFlag{
+		Name:  "sentry-candidates",
+		Usage: "Count unseen peers. Requires 'erigon-log'.",
+	}
+	command.command.Flags().BoolVar(&command.flags.SentryCandidates, flag.Name, false, flag.Usage)
+}
+
+func (command *Command) withErigonLogPath() {
+	flag := cli.StringFlag{
+		Name:  "erigon-log",
+		Usage: "Erigon log file path",
+	}
+	command.command.Flags().StringVar(&command.flags.ErigonLogPath, flag.Name, flag.Value, flag.Usage)
 }
 
 func (command *Command) RawCommand() *cobra.Command {

--- a/cmd/observer/reports/sentry_candidates_report.go
+++ b/cmd/observer/reports/sentry_candidates_report.go
@@ -1,0 +1,111 @@
+package reports
+
+import (
+	"context"
+	"fmt"
+	"github.com/ledgerwatch/erigon/cmd/observer/database"
+	"github.com/ledgerwatch/erigon/cmd/observer/observer/sentry_candidates"
+	"net/url"
+	"os"
+	"strings"
+)
+
+type SentryCandidatesReport struct {
+	TotalCount       uint
+	SeenCount        uint
+	HandshakeCount   uint
+	UnknownClientIDs []string
+	UnseenClientIDs  []string
+}
+
+func CreateSentryCandidatesReport(
+	ctx context.Context,
+	db database.DB,
+	logPath string,
+) (*SentryCandidatesReport, error) {
+	logFile, err := os.Open(logPath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = logFile.Close()
+	}()
+	log := sentry_candidates.NewLog(sentry_candidates.NewScannerLineReader(logFile))
+
+	report := SentryCandidatesReport{}
+
+	for {
+		event, err := log.Read()
+		if err != nil {
+			return nil, err
+		}
+		if event == nil {
+			break
+		}
+
+		if event.NodeURL == "" {
+			continue
+		}
+		nodeURL, err := url.Parse(event.NodeURL)
+		if err != nil {
+			return nil, err
+		}
+		id := database.NodeID(nodeURL.User.Username())
+
+		knownAddr, err := db.FindNodeAddr(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+
+		knownClientID, err := db.FindClientID(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+
+		isSeen := knownAddr != nil
+		isKnownClientID := knownClientID != nil
+
+		report.TotalCount++
+		if isSeen {
+			report.SeenCount++
+		} else {
+			report.UnseenClientIDs = append(report.UnseenClientIDs, event.ClientID)
+		}
+		if isKnownClientID {
+			report.HandshakeCount++
+		} else {
+			report.UnknownClientIDs = append(report.UnknownClientIDs, event.ClientID)
+		}
+	}
+
+	return &report, nil
+}
+
+func (report *SentryCandidatesReport) String() string {
+	var builder strings.Builder
+
+	builder.WriteString(fmt.Sprintf("total: %d", report.TotalCount))
+	builder.WriteRune('\n')
+	builder.WriteString(fmt.Sprintf("seen: %d", report.SeenCount))
+	builder.WriteRune('\n')
+	builder.WriteString(fmt.Sprintf("handshakes: %d", report.HandshakeCount))
+	builder.WriteRune('\n')
+
+	builder.WriteRune('\n')
+	builder.WriteString("unseen:")
+	builder.WriteRune('\n')
+	for _, clientID := range report.UnseenClientIDs {
+		builder.WriteString(clientID)
+		builder.WriteRune('\n')
+	}
+
+	builder.WriteRune('\n')
+	builder.WriteString("unknown:")
+	builder.WriteRune('\n')
+	for _, clientID := range report.UnknownClientIDs {
+		builder.WriteString(clientID)
+		builder.WriteRune('\n')
+	}
+
+	return builder.String()
+}

--- a/cmd/observer/utils/pubkey_hex.go
+++ b/cmd/observer/utils/pubkey_hex.go
@@ -1,0 +1,48 @@
+package utils
+
+import (
+	"crypto/ecdsa"
+	"encoding/hex"
+	"fmt"
+	"github.com/ledgerwatch/erigon/crypto"
+	"github.com/ledgerwatch/erigon/p2p/enode"
+)
+
+func ParseHexPublicKey(keyStr string) (*ecdsa.PublicKey, error) {
+	nodeWithPubkey, err := enode.ParseV4("enode://" + keyStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode a public key: %w", err)
+	}
+	return nodeWithPubkey.Pubkey(), nil
+}
+
+func ParseHexPublicKeys(hexKeys []string) ([]*ecdsa.PublicKey, error) {
+	if hexKeys == nil {
+		return nil, nil
+	}
+	keys := make([]*ecdsa.PublicKey, 0, len(hexKeys))
+	for _, keyStr := range hexKeys {
+		key, err := ParseHexPublicKey(keyStr)
+		if err != nil {
+			return nil, err
+		}
+		keys = append(keys, key)
+	}
+	return keys, nil
+}
+
+func HexEncodePublicKey(key *ecdsa.PublicKey) string {
+	return hex.EncodeToString(crypto.MarshalPubkey(key))
+}
+
+func HexEncodePublicKeys(keys []*ecdsa.PublicKey) []string {
+	if keys == nil {
+		return nil
+	}
+	hexKeys := make([]string, 0, len(keys))
+	for _, key := range keys {
+		keyStr := HexEncodePublicKey(key)
+		hexKeys = append(hexKeys, keyStr)
+	}
+	return hexKeys
+}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -496,6 +496,10 @@ var (
 		Name:  "sentry.api.addr",
 		Usage: "comma separated sentry addresses '<host>:<port>,<host>:<port>'",
 	}
+	SentryLogPeerInfoFlag = cli.BoolFlag{
+		Name:  "sentry.log-peer-info",
+		Usage: "Log detailed peer info when a peer connects or disconnects. Enable to integrate with observer.",
+	}
 	DownloaderAddrFlag = cli.StringFlag{
 		Name:  "downloader.api.addr",
 		Usage: "downloader address '<host>:<port>'",
@@ -1017,6 +1021,7 @@ func SetNodeConfig(ctx *cli.Context, cfg *nodecfg.Config) {
 	SetP2PConfig(ctx, &cfg.P2P, cfg.NodeName(), cfg.DataDir)
 
 	cfg.DownloaderAddr = strings.TrimSpace(ctx.GlobalString(DownloaderAddrFlag.Name))
+	cfg.SentryLogPeerInfo = ctx.GlobalIsSet(SentryLogPeerInfoFlag.Name)
 }
 
 func SetNodeConfigCobra(cmd *cobra.Command, cfg *nodecfg.Config) {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -342,7 +342,18 @@ func New(stack *node.Node, config *ethconfig.Config, logger log.Logger) (*Ethere
 		return nil, err
 	}
 
-	backend.sentriesClient, err = sentry.NewMultiClient(chainKv, stack.Config().NodeName(), chainConfig, genesis.Hash(), backend.engine, backend.config.NetworkID, sentries, config.Sync, blockReader)
+	backend.sentriesClient, err = sentry.NewMultiClient(
+		chainKv,
+		stack.Config().NodeName(),
+		chainConfig,
+		genesis.Hash(),
+		backend.engine,
+		backend.config.NetworkID,
+		sentries,
+		config.Sync,
+		blockReader,
+		stack.Config().SentryLogPeerInfo,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -93,6 +93,7 @@ require (
 	github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/flanglet/kanzi-go v1.9.1-0.20211212184056-72dda96261ee // indirect
+	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61 // indirect
 	github.com/go-kit/kit v0.10.0 // indirect
 	github.com/go-logfmt/logfmt v0.5.0 // indirect
@@ -114,6 +115,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mschoch/smat v0.2.0 // indirect
+	github.com/nxadm/tail v1.4.9-0.20211216163028-4472660a31a6 // indirect
 	github.com/pion/datachannel v1.5.2 // indirect
 	github.com/pion/dtls/v2 v2.1.2 // indirect
 	github.com/pion/ice/v2 v2.1.20 // indirect
@@ -148,6 +150,7 @@ require (
 	golang.org/x/tools v0.1.10 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/genproto v0.0.0-20200825200019-8632dd797987 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 	lukechampine.com/uint128 v1.1.1 // indirect
 	modernc.org/cc/v3 v3.36.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -199,6 +199,7 @@ github.com/frankban/quicktest v1.14.0 h1:+cqqvzZV87b4adx/5ayVOaYZ2CrvM4ejQvUdBzP
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
+github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61 h1:IZqZOB2fydHte3kUgxrzK5E1fW7RQGeDwE8F/ZZnUYc=
 github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61/go.mod h1:Q0X6pkwTILDlzrGEckF6HKjXe48EgsY/l7K7vhY4MW8=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -436,6 +437,8 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
+github.com/nxadm/tail v1.4.9-0.20211216163028-4472660a31a6 h1:iZ5rEHU561k2tdi/atkIsrP5/3AX3BjyhYtC96nJ260=
+github.com/nxadm/tail v1.4.9-0.20211216163028-4472660a31a6/go.mod h1:A+9rV4WFp4DKg1Ym1v6YtCrJ2vvlt1ZA/iml0CNuu2A=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=

--- a/node/nodecfg/config.go
+++ b/node/nodecfg/config.go
@@ -152,6 +152,8 @@ type Config struct {
 	staticNodesWarning  bool
 	trustedNodesWarning bool
 
+	SentryLogPeerInfo bool
+
 	TLSConnection bool
 	TLSCertFile   string
 	// AllowUnprotectedTxs allows non EIP-155 protected transactions to be send over RPC.

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -118,6 +118,7 @@ var DefaultFlags = []cli.Flag{
 	utils.MinerNoVerfiyFlag,
 	utils.MinerSigningKeyFileFlag,
 	utils.SentryAddrFlag,
+	utils.SentryLogPeerInfoFlag,
 	utils.DownloaderAddrFlag,
 	HealthCheckFlag,
 	utils.HeimdallURLFlag,

--- a/turbo/stages/mock_sentry.go
+++ b/turbo/stages/mock_sentry.go
@@ -282,7 +282,18 @@ func MockWithEverything(t *testing.T, gspec *core.Genesis, key *ecdsa.PrivateKey
 	blockReader := snapshotsync.NewBlockReader()
 
 	networkID := uint64(1)
-	mock.sentriesClient, err = sentry.NewMultiClient(mock.DB, "mock", mock.ChainConfig, mock.Genesis.Hash(), mock.Engine, networkID, sentries, cfg.Sync, blockReader)
+	mock.sentriesClient, err = sentry.NewMultiClient(
+		mock.DB,
+		"mock",
+		mock.ChainConfig,
+		mock.Genesis.Hash(),
+		mock.Engine,
+		networkID,
+		sentries,
+		cfg.Sync,
+		blockReader,
+		false,
+	)
 	if err != nil {
 		if t != nil {
 			t.Fatal(err)


### PR DESCRIPTION
The connected peers info is logged by erigon.
Observer is able to grep these events from the erigon log,
and use for crawling with the provided handshake info.
These peers are known to be from the compatible fork/network, and have a known clientID.
This increases the observer quality significantly if the sentries network is large.
