### PR TITLE
Authorize Clique & Parlia even when wrapped into Serenity

### DIFF
--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -421,7 +421,6 @@ func (c *Clique) Seal(chain consensus.ChainHeaderReader, block *types.Block, res
 		return err
 	}
 	if _, authorized := snap.Signers[signer]; !authorized {
-		 log.Warn("ErrUnauthorizedSigner","signer", signer, "snap.Signers", snap.Signers )
 		return ErrUnauthorizedSigner
 	}
 	// If we're amongst the recent signers, wait for the next block

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -421,6 +421,7 @@ func (c *Clique) Seal(chain consensus.ChainHeaderReader, block *types.Block, res
 		return err
 	}
 	if _, authorized := snap.Signers[signer]; !authorized {
+		 log.Warn("ErrUnauthorizedSigner","signer", signer, "snap.Signers", snap.Signers )
 		return ErrUnauthorizedSigner
 	}
 	// If we're amongst the recent signers, wait for the next block

--- a/consensus/serenity/serenity.go
+++ b/consensus/serenity/serenity.go
@@ -59,7 +59,7 @@ func (s *Serenity) InnerEngine() consensus.Engine {
 	return s.eth1Engine
 }
 
-// Type returns underlying consensus engine
+// Type returns the type of the underlying consensus engine.
 func (s *Serenity) Type() params.ConsensusType {
 	return s.eth1Engine.Type()
 }

--- a/consensus/serenity/serenity.go
+++ b/consensus/serenity/serenity.go
@@ -54,6 +54,11 @@ func New(eth1Engine consensus.Engine) *Serenity {
 	return &Serenity{eth1Engine: eth1Engine}
 }
 
+// InnerEngine returns the embedded eth1 consensus engine.
+func (s *Serenity) InnerEngine() consensus.Engine {
+	return s.eth1Engine
+}
+
 // Type returns underlying consensus engine
 func (s *Serenity) Type() params.ConsensusType {
 	return s.eth1Engine.Type()

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -621,31 +621,41 @@ func (s *Ethereum) StartMining(ctx context.Context, db kv.RwDB, mining *stagedsy
 		log.Error("Cannot start mining without etherbase", "err", err)
 		return fmt.Errorf("etherbase missing: %w", err)
 	}
-	var cli *clique.Clique
+
+	var clq *clique.Clique
 	if c, ok := s.engine.(*clique.Clique); ok {
-		cli = c
+		clq = c
 	} else if cl, ok := s.engine.(*serenity.Serenity); ok {
 		if c, ok := cl.InnerEngine().(*clique.Clique); ok {
-			cli = c
+			clq = c
 		}
 	}
-	if cli != nil {
+	if clq != nil {
 		if cfg.SigKey == nil {
 			log.Error("Etherbase account unavailable locally", "err", err)
 			return fmt.Errorf("signer missing: %w", err)
 		}
 
-		cli.Authorize(eb, func(_ common.Address, mimeType string, message []byte) ([]byte, error) {
+		clq.Authorize(eb, func(_ common.Address, mimeType string, message []byte) ([]byte, error) {
 			return crypto.Sign(crypto.Keccak256(message), cfg.SigKey)
 		})
 	}
+
+	var prl *parlia.Parlia
 	if p, ok := s.engine.(*parlia.Parlia); ok {
+		prl = p
+	} else if cl, ok := s.engine.(*serenity.Serenity); ok {
+		if p, ok := cl.InnerEngine().(*parlia.Parlia); ok {
+			prl = p
+		}
+	}
+	if prl != nil {
 		if cfg.SigKey == nil {
 			log.Error("Etherbase account unavailable locally", "err", err)
 			return fmt.Errorf("signer missing: %w", err)
 		}
 
-		p.Authorize(eb, func(validator common.Address, payload []byte, chainId *big.Int) ([]byte, error) {
+		prl.Authorize(eb, func(validator common.Address, payload []byte, chainId *big.Int) ([]byte, error) {
 			return crypto.Sign(payload, cfg.SigKey)
 		})
 	}


### PR DESCRIPTION
This should fix, for instance, fix "Invalid Terminal Block in ForkchoiceUpdated" Hive test.