### PR TITLE
New Ropsten TTD

### DIFF
--- a/params/chainspecs/ropsten.json
+++ b/params/chainspecs/ropsten.json
@@ -14,7 +14,7 @@
   "muirGlacierBlock": 7117117,
   "berlinBlock": 9812189,
   "londonBlock": 10499401,
-  "terminalTotalDifficulty": 100000000000000000000000,
+  "terminalTotalDifficulty": 50000000000000000,
   "terminalBlockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
   "ethash": {}
 }


### PR DESCRIPTION
Per https://blog.ethereum.org/2022/06/03/ropsten-merge-ttd/