### PR TITLE
StageSenders: wrong canonical array size at initial sync with snapshots

### DIFF
--- a/cmd/integration/commands/refetence_db.go
+++ b/cmd/integration/commands/refetence_db.go
@@ -13,9 +13,11 @@ import (
 	"github.com/ledgerwatch/erigon-lib/kv"
 	mdbx2 "github.com/ledgerwatch/erigon-lib/kv/mdbx"
 	"github.com/ledgerwatch/erigon/common"
+	"github.com/ledgerwatch/erigon/common/math"
 	"github.com/ledgerwatch/log/v3"
 	"github.com/spf13/cobra"
 	"github.com/torquem-ch/mdbx-go/mdbx"
+	"go.uber.org/atomic"
 )
 
 var stateBuckets = []string{
@@ -371,6 +373,7 @@ func kv2kv(ctx context.Context, src, dst kv.RwDB) error {
 			continue
 		}
 
+		kv.ReadAhead(ctx, src, atomic.NewBool(false), name, nil, math.MaxUint32)
 		c, err := dstTx.RwCursor(name)
 		if err != nil {
 			return err

--- a/eth/stagedsync/stage_bodies.go
+++ b/eth/stagedsync/stage_bodies.go
@@ -58,6 +58,9 @@ func BodiesForward(
 	test bool, // Set to true in tests, allows the stage to fail rather than wait indefinitely
 	firstCycle bool,
 ) error {
+	if cfg.snapshots != nil && s.BlockNumber < cfg.snapshots.BlocksAvailable() {
+		s.BlockNumber = cfg.snapshots.BlocksAvailable()
+	}
 
 	var d1, d2, d3, d4, d5, d6 time.Duration
 	var err error
@@ -71,14 +74,6 @@ func BodiesForward(
 	}
 	timeout := cfg.timeout
 
-	if cfg.snapshots != nil {
-		if s.BlockNumber < cfg.snapshots.BlocksAvailable() {
-			if err := s.Update(tx, cfg.snapshots.BlocksAvailable()); err != nil {
-				return err
-			}
-			s.BlockNumber = cfg.snapshots.BlocksAvailable()
-		}
-	}
 	// This will update bd.maxProgress
 	if _, _, _, err = cfg.bd.UpdateFromDb(tx); err != nil {
 		return err

--- a/eth/stagedsync/stage_senders.go
+++ b/eth/stagedsync/stage_senders.go
@@ -256,13 +256,11 @@ Loop:
 		}
 	}
 	if minBlockErr != nil {
-		fmt.Printf("alex99\n")
 		log.Error(fmt.Sprintf("[%s] Error recovering senders for block %d %x): %v", logPrefix, minBlockNum, minBlockHash, minBlockErr))
 		if to > s.BlockNumber {
 			u.UnwindTo(minBlockNum-1, minBlockHash)
 		}
 	} else {
-		fmt.Printf("alex98\n")
 		if err := collectorSenders.Load(tx, kv.Senders, etl.IdentityLoadFunc, etl.TransformArgs{
 			Quit: quitCh,
 			LogDetailsLoad: func(k, v []byte) (additionalLogArguments []interface{}) {

--- a/eth/stagedsync/stage_senders.go
+++ b/eth/stagedsync/stage_senders.go
@@ -225,12 +225,6 @@ Loop:
 		}
 
 		if canonical[blockNumber-s.BlockNumber-1] != blockHash {
-			fmt.Printf("non-can: %d, %d, %x, %x, %x\n", blockNumber, blockNumber-s.BlockNumber-1, canonical[blockNumber-s.BlockNumber-1], blockHash, canonical[blockNumber-s.BlockNumber-1+1])
-			tx.ForAmount(kv.HeaderCanonical, dbutils.EncodeBlockNumber(blockNumber-2), 4, func(k, v []byte) error {
-				fmt.Printf("in db: %x, %x, \n", k, v)
-				return nil
-			})
-			//panic(1)
 			// non-canonical case
 			continue
 		}
@@ -277,10 +271,6 @@ Loop:
 		}); err != nil {
 			return err
 		}
-		c, _ := tx.Cursor(kv.Senders)
-		cnt, _ := c.Count()
-		fmt.Printf("cojnt: %d\n", cnt)
-
 		if err = s.Update(tx, to); err != nil {
 			return err
 		}

--- a/eth/stagedsync/sync.go
+++ b/eth/stagedsync/sync.go
@@ -3,7 +3,6 @@ package stagedsync
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
@@ -223,7 +222,7 @@ func (s *Sync) Run(db kv.RwDB, tx kv.RwTx, firstCycle bool) error {
 
 		if string(stage.ID) == debug.StopBeforeStage() { // stop process for debugging reasons
 			log.Warn("STOP_BEFORE_STAGE env flag forced to stop app")
-			os.Exit(1)
+			return libcommon.ErrStopped
 		}
 
 		if stage.Disabled || stage.Forward == nil {


### PR DESCRIPTION
Cause non-producing senders in DB during initial sync 