### PR TITLE
Fix MarkAllVerified

### DIFF
--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -174,8 +174,7 @@ func (hd *HeaderDownload) removeUpwards(link *Link) {
 func (hd *HeaderDownload) MarkAllVerified() {
 	hd.lock.Lock()
 	defer hd.lock.Unlock()
-	for hd.insertQueue.Len() > 0 {
-		link := hd.insertQueue[0]
+	for _, link := range hd.insertQueue {
 		if !link.verified {
 			link.linked = true
 			link.verified = true


### PR DESCRIPTION
Previously `MarkAllVerified` was stuck in an infinite loop when `insertQueue` wasn't empty.