### PR TITLE
MergeForkBlock -> MergeNetsplitBlock

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -134,8 +134,8 @@ var (
 		Name:  "override.terminaltotaldifficulty",
 		Usage: "Manually specify TerminalTotalDifficulty, overriding the bundled setting",
 	}
-	OverrideMergeForkBlock = BigFlag{
-		Name:  "override.mergeForkBlock",
+	OverrideMergeNetsplitBlock = BigFlag{
+		Name:  "override.mergeNetsplitBlock",
 		Usage: "Manually specify FORK_NEXT_VALUE (see EIP-3675), overriding the bundled setting",
 	}
 	// Ethash settings
@@ -1495,8 +1495,8 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 	if ctx.GlobalIsSet(OverrideTerminalTotalDifficulty.Name) {
 		cfg.OverrideTerminalTotalDifficulty = GlobalBig(ctx, OverrideTerminalTotalDifficulty.Name)
 	}
-	if ctx.GlobalIsSet(OverrideMergeForkBlock.Name) {
-		cfg.OverrideMergeForkBlock = GlobalBig(ctx, OverrideMergeForkBlock.Name)
+	if ctx.GlobalIsSet(OverrideMergeNetsplitBlock.Name) {
+		cfg.OverrideMergeNetsplitBlock = GlobalBig(ctx, OverrideMergeNetsplitBlock.Name)
 	}
 }
 

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -176,13 +176,13 @@ func CommitGenesisBlock(db kv.RwDB, genesis *Genesis) (*params.ChainConfig, *typ
 	return CommitGenesisBlockWithOverride(db, genesis, nil, nil)
 }
 
-func CommitGenesisBlockWithOverride(db kv.RwDB, genesis *Genesis, overrideMergeForkBlock, overrideTerminalTotalDifficulty *big.Int) (*params.ChainConfig, *types.Block, error) {
+func CommitGenesisBlockWithOverride(db kv.RwDB, genesis *Genesis, overrideMergeNetsplitBlock, overrideTerminalTotalDifficulty *big.Int) (*params.ChainConfig, *types.Block, error) {
 	tx, err := db.BeginRw(context.Background())
 	if err != nil {
 		return nil, nil, err
 	}
 	defer tx.Rollback()
-	c, b, err := WriteGenesisBlock(tx, genesis, overrideMergeForkBlock, overrideTerminalTotalDifficulty)
+	c, b, err := WriteGenesisBlock(tx, genesis, overrideMergeNetsplitBlock, overrideTerminalTotalDifficulty)
 	if err != nil {
 		return c, b, err
 	}
@@ -201,7 +201,7 @@ func MustCommitGenesisBlock(db kv.RwDB, genesis *Genesis) (*params.ChainConfig, 
 	return c, b
 }
 
-func WriteGenesisBlock(db kv.RwTx, genesis *Genesis, overrideMergeForkBlock, overrideTerminalTotalDifficulty *big.Int) (*params.ChainConfig, *types.Block, error) {
+func WriteGenesisBlock(db kv.RwTx, genesis *Genesis, overrideMergeNetsplitBlock, overrideTerminalTotalDifficulty *big.Int) (*params.ChainConfig, *types.Block, error) {
 	if genesis != nil && genesis.Config == nil {
 		return params.AllEthashProtocolChanges, nil, ErrGenesisNoConfig
 	}
@@ -217,8 +217,8 @@ func WriteGenesisBlock(db kv.RwTx, genesis *Genesis, overrideMergeForkBlock, ove
 			genesis = DefaultGenesisBlock()
 			custom = false
 		}
-		if overrideMergeForkBlock != nil {
-			genesis.Config.MergeForkBlock = overrideMergeForkBlock
+		if overrideMergeNetsplitBlock != nil {
+			genesis.Config.MergeNetsplitBlock = overrideMergeNetsplitBlock
 		}
 		if overrideTerminalTotalDifficulty != nil {
 			genesis.Config.TerminalTotalDifficulty = overrideTerminalTotalDifficulty
@@ -250,8 +250,8 @@ func WriteGenesisBlock(db kv.RwTx, genesis *Genesis, overrideMergeForkBlock, ove
 	}
 	// Get the existing chain configuration.
 	newCfg := genesis.configOrDefault(storedHash)
-	if overrideMergeForkBlock != nil {
-		newCfg.MergeForkBlock = overrideMergeForkBlock
+	if overrideMergeNetsplitBlock != nil {
+		newCfg.MergeNetsplitBlock = overrideMergeNetsplitBlock
 	}
 	if overrideTerminalTotalDifficulty != nil {
 		newCfg.TerminalTotalDifficulty = overrideTerminalTotalDifficulty
@@ -274,7 +274,7 @@ func WriteGenesisBlock(db kv.RwTx, genesis *Genesis, overrideMergeForkBlock, ove
 	// Special case: don't change the existing config of a non-mainnet chain if no new
 	// config is supplied. These chains would get AllProtocolChanges (and a compatibility error)
 	// if we just continued here.
-	if genesis == nil && storedHash != params.MainnetGenesisHash && overrideMergeForkBlock == nil && overrideTerminalTotalDifficulty == nil {
+	if genesis == nil && storedHash != params.MainnetGenesisHash && overrideMergeNetsplitBlock == nil && overrideTerminalTotalDifficulty == nil {
 		return storedCfg, storedBlock, nil
 	}
 	// Check config compatibility and write the config. Compatibility errors

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -175,7 +175,7 @@ func New(stack *node.Node, config *ethconfig.Config, logger log.Logger) (*Ethere
 		panic(err)
 	}
 
-	chainConfig, genesis, genesisErr := core.CommitGenesisBlockWithOverride(chainKv, config.Genesis, config.OverrideMergeForkBlock, config.OverrideTerminalTotalDifficulty)
+	chainConfig, genesis, genesisErr := core.CommitGenesisBlockWithOverride(chainKv, config.Genesis, config.OverrideMergeNetsplitBlock, config.OverrideTerminalTotalDifficulty)
 	if _, ok := genesisErr.(*params.ConfigCompatError); genesisErr != nil && !ok {
 		return nil, genesisErr
 	}

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -224,7 +224,7 @@ type Config struct {
 	Ethstats string
 
 	// FORK_NEXT_VALUE (see EIP-3675) block override
-	OverrideMergeForkBlock *big.Int `toml:",omitempty"`
+	OverrideMergeNetsplitBlock *big.Int `toml:",omitempty"`
 
 	OverrideTerminalTotalDifficulty *big.Int `toml:",omitempty"`
 }

--- a/params/chainspecs/kiln-devnet.json
+++ b/params/chainspecs/kiln-devnet.json
@@ -14,6 +14,6 @@
   "londonBlock": 0,
   "terminalTotalDifficulty": 20000000000000,
   "terminalBlockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-  "mergeForkBlock": 1000,
+  "mergeNetsplitBlock": 1000,
   "ethash": {}
 }

--- a/params/config.go
+++ b/params/config.go
@@ -248,7 +248,7 @@ type ChainConfig struct {
 	TerminalTotalDifficulty *big.Int    `json:"terminalTotalDifficulty,omitempty"` // The merge happens when terminal total difficulty is reached
 	TerminalBlockNumber     *big.Int    `json:"terminalBlockNumber,omitempty"`     // Enforce particular terminal block; see TerminalBlockNumber in EIP-3675
 	TerminalBlockHash       common.Hash `json:"terminalBlockHash,omitempty"`       // Enforce particular terminal block; see TERMINAL_BLOCK_HASH in EIP-3675
-	MergeForkBlock          *big.Int    `json:"mergeForkBlock,omitempty"`
+	MergeNetsplitBlock      *big.Int    `json:"mergeNetsplitBlock,omitempty"`      // Virtual fork after The Merge to use as a network splitter; see FORK_NEXT_VALUE in EIP-3675
 
 	// Various consensus engines
 	Ethash *EthashConfig `json:"ethash,omitempty"`

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -125,5 +125,5 @@ var DefaultFlags = []cli.Flag{
 	utils.WithoutHeimdallFlag,
 	utils.EthStatsURLFlag,
 	utils.OverrideTerminalTotalDifficulty,
-	utils.OverrideMergeForkBlock,
+	utils.OverrideMergeNetsplitBlock,
 }


### PR DESCRIPTION
Rename `MergeForkBlock` to `MergeNetsplitBlock` for consistency with geth (see https://github.com/ethereum/go-ethereum/pull/24904).