### PR TITLE
Fix operation order during tracing suicide op code

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -837,10 +837,10 @@ func opSuicide(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]
 	callerAddr := scope.Contract.Address()
 	beneficiaryAddr := common.Address(beneficiary.Bytes20())
 	balance := interpreter.evm.IntraBlockState().GetBalance(callerAddr)
-	interpreter.evm.IntraBlockState().AddBalance(beneficiaryAddr, balance)
 	if interpreter.evm.Config().Debug {
 		interpreter.evm.Config().Tracer.CaptureSelfDestruct(callerAddr, beneficiaryAddr, balance.ToBig())
 	}
+	interpreter.evm.IntraBlockState().AddBalance(beneficiaryAddr, balance)
 	interpreter.evm.IntraBlockState().Suicide(callerAddr)
 	return nil, nil
 }


### PR DESCRIPTION
When a contract calls suicide where the refund address is same as his address - refunding to himself -, then the tracer should be called after balance change.
I believe the L839 variable `balance` is just a pointer to an uint256 object, which is the same what is used during `AddBalance`.
This fixes #3953 issue.