### PR TITLE
if no latest valid hash default to empty hash

### DIFF
--- a/cmd/rpcdaemon/commands/engine_api.go
+++ b/cmd/rpcdaemon/commands/engine_api.go
@@ -78,6 +78,8 @@ func convertPayloadStatus(x *remote.EnginePayloadStatus) map[string]interface{} 
 	}
 	if x.LatestValidHash != nil {
 		json["latestValidHash"] = common.Hash(gointerfaces.ConvertH256ToHash(x.LatestValidHash))
+	} else {
+		json["latestValidHash"] = common.Hash{}
 	}
 	if x.ValidationError != "" {
 		json["validationError"] = x.ValidationError


### PR DESCRIPTION
Right now if we don't have the latest valid hash we answer with nil, so I changed it so we answer with an empty hash according to the specs