### PR TITLE
eth_blockNumber should be equal to latest in eth_getBlockByNumber

### DIFF
--- a/cmd/rpcdaemon/commands/eth_system.go
+++ b/cmd/rpcdaemon/commands/eth_system.go
@@ -22,14 +22,14 @@ func (api *APIImpl) BlockNumber(ctx context.Context) (hexutil.Uint64, error) {
 		return 0, err
 	}
 	defer tx.Rollback()
-	execution, err := stages.GetStageProgress(tx, stages.Finish)
+	blockNum, err := getLatestBlockNumber(tx)
 	if err != nil {
 		return 0, err
 	}
-	return hexutil.Uint64(execution), nil
+	return hexutil.Uint64(blockNum), nil
 }
 
-// Syncing implements eth_syncing. Returns a data object detaling the status of the sync process or false if not syncing.
+// Syncing implements eth_syncing. Returns a data object detailing the status of the sync process or false if not syncing.
 func (api *APIImpl) Syncing(ctx context.Context) (interface{}, error) {
 	tx, err := api.db.BeginRo(ctx)
 	if err != nil {


### PR DESCRIPTION
In the PoS world we should wait for `headBlockHash` in [engine_forkchoiceUpdatedV1.forkchoiceState](https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#engine_forkchoiceupdatedv1) before making the block available as "latest" in the RPC requests.

See also PR #4382.