### PR TITLE
Add REVERT result to trace

### DIFF
--- a/cmd/rpcdaemon/commands/trace_adhoc.go
+++ b/cmd/rpcdaemon/commands/trace_adhoc.go
@@ -366,6 +366,7 @@ func (ot *OeTracer) CaptureEnd(depth int, output []byte, startGas, endGas uint64
 	}
 	if err != nil && !ignoreError {
 		if err == vm.ErrExecutionReverted {
+			topTrace.Error = "Reverted"
 			topTrace.Result.(*TraceResult).GasUsed = new(hexutil.Big)
 			topTrace.Result.(*TraceResult).GasUsed.ToInt().SetUint64(startGas - endGas)
 			topTrace.Result.(*TraceResult).Output = common.CopyBytes(output)


### PR DESCRIPTION
OP code `REVERT` has return data like `RETURN` which can be very useful, we should not hide/drop them.
Example result:
```
{
	"action": {
		"from": "0x799c5727581cf092fe3f15a6a289146fd908fc7c",
		"callType": "call",
		"gas": "0x49f8",
		"input": "0x9e5faafc",
		"to": "0x2cab154122bddaee2c555a58f88913f9e07622fc",
		"value": "0x0"
	},
	"blockHash": "0xc0fc77a433c21cc43823459f92186c2c551548a6e6763cc40ca825a7198d2d48",
	"blockNumber": 12336209,
	"error": "Reverted",
	"result": {
		"gasUsed": "0x3809",
		"output": "0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000176368616c6c656e6765206e6f7420636f6d706c65746564000000000000000000"
	},
	"subtraces": 2,
	"traceAddress": [],
	"transactionHash": "0x07f17c1359aa656b91510b7dd992e6f988c0481c92f7250e87e6872c5f18a05b",
	"transactionPosition": 21,
	"type": "call"
},
...
```