### PR TITLE
subtract from account balance only after enough gaspool is ensured

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -257,12 +257,13 @@ func (st *StateTransition) buyGas(gasBailout bool) error {
 			return fmt.Errorf("%w: address %v", ErrInsufficientFunds, st.msg.From().Hex())
 		}
 	}
+	var subBalance bool = false
 	if have, want := st.state.GetBalance(st.msg.From()), balanceCheck; have.Cmp(want) < 0 {
 		if !gasBailout {
 			return fmt.Errorf("%w: address %v have %v want %v", ErrInsufficientFunds, st.msg.From().Hex(), have, want)
 		}
 	} else {
-		st.state.SubBalance(st.msg.From(), mgval)
+		subBalance = true
 	}
 	if err := st.gp.SubGas(st.msg.Gas()); err != nil {
 		if !gasBailout {
@@ -272,6 +273,9 @@ func (st *StateTransition) buyGas(gasBailout bool) error {
 	st.gas += st.msg.Gas()
 
 	st.initialGas = st.msg.Gas()
+	if subBalance {
+		st.state.SubBalance(st.msg.From(), mgval)
+	}
 	return nil
 }
 


### PR DESCRIPTION
- noticed the difference when in post-transaction account states when executing `evm t8n` for testdata#10 in go-ethereum and erigon.
- `SubGas` function can return "gas limit reached" error, and the sender account shouldn't be deducted before this check is ensured.