### PR TITLE
Enable --http by default

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -306,9 +306,9 @@ var (
 		Name:  "ipcpath",
 		Usage: "Filename for IPC socket/pipe within the datadir (explicit paths escape it)",
 	}
-	HTTPEnabledFlag = cli.BoolFlag{
+	HTTPEnabledFlag = cli.BoolTFlag{
 		Name:  "http",
-		Usage: "Disabled by default. Use --http to enable the HTTP-RPC server",
+		Usage: "HTTP-RPC server (enabled by default). Use --http false to disable it",
 	}
 	HTTPListenAddrFlag = cli.StringFlag{
 		Name:  "http.addr",


### PR DESCRIPTION
After the Merge Erigon won't work w/o exposed Engine API, so it makes sense to enable HTTP RPC by default.