### PR TITLE
[BSC Euler fork] Undo unnecessary change

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -107,12 +107,7 @@ func applyTransaction(config *params.ChainConfig, gp *GasPool, statedb *state.In
 	if err = statedb.FinalizeTx(rules, stateWriter); err != nil {
 		return nil, nil, err
 	}
-	// checks if current header is an Euler block or not (returns false for all the chains except BSC)
-	if config.IsEuler(header.Number) {
-		*usedGas += result.UsedGas * 3
-	} else {
-		*usedGas += result.UsedGas
-	}
+	*usedGas += result.UsedGas
 
 	// Set the receipt logs and create the bloom filter.
 	// based on the eip phase, we're passing whether the root touch-delete accounts.


### PR DESCRIPTION
In BSC repo, the corresponding change was only for the miner, and it only affects the gas pool for the block, not the receipts