### PR TITLE
add_abigen_error_handle

### DIFF
--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -35,6 +35,7 @@ type ABI struct {
 	Constructor Method
 	Methods     map[string]Method
 	Events      map[string]Event
+	Errors      map[string]Error
 
 	// Additional "special" functions introduced in solidity v0.6.0.
 	// It's separated from the original default fallback. Each contract
@@ -158,6 +159,7 @@ func (abi *ABI) UnmarshalJSON(data []byte) error {
 	}
 	abi.Methods = make(map[string]Method)
 	abi.Events = make(map[string]Event)
+	abi.Errors = make(map[string]Error)
 	for _, field := range fields {
 		switch field.Type {
 		case "constructor":
@@ -185,6 +187,8 @@ func (abi *ABI) UnmarshalJSON(data []byte) error {
 		case "event":
 			name := abi.overloadedEventName(field.Name)
 			abi.Events[name] = NewEvent(name, field.Name, field.Anonymous, field.Inputs)
+		case "error":
+			abi.Errors[field.Name] = NewError(field.Name, field.Inputs)
 		default:
 			return fmt.Errorf("abi: could not recognize type %v of field %v", field.Type, field.Name)
 		}

--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -1144,3 +1144,17 @@ func TestUnpackRevert(t *testing.T) {
 		})
 	}
 }
+
+func TestCustomErrors(t *testing.T) {
+	json := `[{ "inputs": [	{ "internalType": "uint256", "name": "", "type": "uint256" } ],"name": "MyError", "type": "error"} ]`
+	abi, err := JSON(strings.NewReader(json))
+	if err != nil {
+		t.Fatal(err)
+	}
+	check := func(name string, expect string) {
+		if abi.Errors[name].Sig != expect {
+			t.Fatalf("The signature of overloaded method mismatch, want %s, have %s", expect, abi.Methods[name].Sig)
+		}
+	}
+	check("MyError", "MyError(uint256)")
+}

--- a/accounts/abi/error.go
+++ b/accounts/abi/error.go
@@ -17,10 +17,77 @@
 package abi
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
+
+	"github.com/ledgerwatch/erigon/common"
+	"github.com/ledgerwatch/erigon/crypto"
 )
+
+type Error struct {
+	Name   string
+	Inputs Arguments
+	str    string
+	// Sig contains the string signature according to the ABI spec.
+	// e.g.	 event foo(uint32 a, int b) = "foo(uint32,int256)"
+	// Please note that "int" is substitute for its canonical representation "int256"
+	Sig string
+	// ID returns the canonical representation of the event's signature used by the
+	// abi definition to identify event names and types.
+	ID common.Hash
+}
+
+func NewError(name string, inputs Arguments) Error {
+	names := make([]string, len(inputs))
+	types := make([]string, len(inputs))
+	for i, input := range inputs {
+		if input.Name == "" {
+			inputs[i] = Argument{
+				Name:    fmt.Sprintf("arg%d", i),
+				Indexed: input.Indexed,
+				Type:    input.Type,
+			}
+		} else {
+			inputs[i] = input
+		}
+		// string representation
+		names[i] = fmt.Sprintf("%v %v", input.Type, inputs[i].Name)
+		if input.Indexed {
+			names[i] = fmt.Sprintf("%v indexed %v", input.Type, inputs[i].Name)
+		}
+		// sig representation
+		types[i] = input.Type.String()
+	}
+
+	str := fmt.Sprintf("error %v(%v)", name, strings.Join(names, ", "))
+	sig := fmt.Sprintf("%v(%v)", name, strings.Join(types, ","))
+	id := common.BytesToHash(crypto.Keccak256([]byte(sig)))
+
+	return Error{
+		Name:   name,
+		Inputs: inputs,
+		str:    str,
+		Sig:    sig,
+		ID:     id,
+	}
+}
+
+func (e *Error) String() string {
+	return e.str
+}
+
+func (e *Error) Unpack(data []byte) (interface{}, error) {
+	if len(data) < 4 {
+		return "", errors.New("invalid data for unpacking")
+	}
+	if !bytes.Equal(data[:4], e.ID[:4]) {
+		return "", errors.New("invalid data for unpacking")
+	}
+	return e.Inputs.Unpack(data[4:])
+}
 
 var (
 	errBadBool = errors.New("abi: improperly encoded boolean value")


### PR DESCRIPTION
add 'Error' Handle when using `abigen` to generate erigon code 
Linked error: "Fatal: Failed to generate ABI binding: abi: could not recognize type error of field xxx"