### PR TITLE
Commit transaction before responding on Engine API

### DIFF
--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -309,7 +309,7 @@ func startHandlingForkChoice(
 		log.Info(fmt.Sprintf("[%s] Fork choice missing header with hash %x", s.LogPrefix(), headerHash))
 		hashToDownload := headerHash
 		cfg.hd.SetPoSDownloaderTip(headerHash)
-		schedulePoSDownload(requestStatus, requestId, hashToDownload, 0 /* header height is unknown, setting to 0 */, s, cfg)
+		schedulePoSDownload(requestId, hashToDownload, 0 /* header height is unknown, setting to 0 */, s, cfg)
 		return &privateapi.PayloadStatus{Status: remote.EngineStatus_SYNCING}, nil
 	}
 
@@ -491,7 +491,7 @@ func handleNewPayload(
 		hashToDownload := header.ParentHash
 		heightToDownload := headerNumber - 1
 		cfg.hd.SetPoSDownloaderTip(headerHash)
-		schedulePoSDownload(requestStatus, requestId, hashToDownload, heightToDownload, s, cfg)
+		schedulePoSDownload(requestId, hashToDownload, heightToDownload, s, cfg)
 		return &privateapi.PayloadStatus{Status: remote.EngineStatus_SYNCING}, nil
 	}
 
@@ -609,7 +609,6 @@ func verifyAndSaveNewPoSHeader(
 }
 
 func schedulePoSDownload(
-	requestStatus engineapi.RequestStatus,
 	requestId int,
 	hashToDownload common.Hash,
 	heightToDownload uint64,

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -336,7 +336,7 @@ func startHandlingForkChoice(
 		if canonical {
 			return &privateapi.PayloadStatus{
 				Status:          remote.EngineStatus_VALID,
-				LatestValidHash: currentHeadHash,
+				LatestValidHash: headerHash,
 			}, nil
 		} else {
 			return &privateapi.PayloadStatus{

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -200,13 +200,16 @@ func HeadersPOS(
 		return err
 	}
 
+	if !useExternalTx {
+		if err = tx.Commit(); err != nil {
+			return err
+		}
+	}
+
 	if response != nil && status == engineapi.New {
 		cfg.hd.PayloadStatusCh <- *response
 	}
 
-	if !useExternalTx {
-		return tx.Commit()
-	}
 	return nil
 }
 

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -369,13 +369,12 @@ func startHandlingForkChoice(
 
 	log.Info(fmt.Sprintf("[%s] Fork choice re-org", s.LogPrefix()), "headerNumber", headerNumber, "forkingPoint", forkingPoint)
 
-	var response *privateapi.PayloadStatus
 	if requestStatus == engineapi.New {
 		if headerNumber-forkingPoint <= ShortPoSReorgThresholdBlocks {
 			// TODO(yperbasis): what if some bodies are missing and we have to download them?
 			cfg.hd.SetPendingPayloadStatus(headerHash)
 		} else {
-			response = &privateapi.PayloadStatus{Status: remote.EngineStatus_SYNCING}
+			cfg.hd.PayloadStatusCh <- privateapi.PayloadStatus{Status: remote.EngineStatus_SYNCING}
 		}
 	}
 
@@ -383,7 +382,7 @@ func startHandlingForkChoice(
 
 	cfg.hd.SetUnsettledForkChoice(forkChoice, headerNumber)
 
-	return response, nil
+	return nil, nil
 }
 
 func finishHandlingForkChoice(

--- a/turbo/engineapi/request_list.go
+++ b/turbo/engineapi/request_list.go
@@ -38,8 +38,7 @@ type RequestWithStatus struct {
 type Interrupt int
 
 const ( // Interrupt values
-	None  = iota
-	Yield // e.g. yield RW transaction to block building
+	None = iota
 	Synced
 	Stopping
 )


### PR DESCRIPTION
Consider the following scenario:
1. CL sends `engine_newPayload`
2. CL sends `engine_forkchoiceUpdated` with `headBlockHash` pointing to the newly added block
3. CL asks for `eth_getBlockByNumber("latest")`

If we don't commit the DB transaction before replying to CL in 2, there's a race condition between 2 & 3 because in 3 we might be looking at the old `LastForkchoice.headBlockHash`. That's why Hive test "Inconsistent Head in ForkchoiceState" was failing.