### PR TITLE
Rework PR 4505

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -271,6 +271,12 @@ func WriteGenesisBlock(db kv.RwTx, genesis *Genesis, overrideMergeNetsplitBlock,
 		}
 		return newCfg, storedBlock, nil
 	}
+	// Special case: don't change the existing config of a non-mainnet chain if no new
+	// config is supplied. These chains would get AllProtocolChanges (and a compatibility error)
+	// if we just continued here.
+	if genesis == nil && storedHash != params.MainnetGenesisHash && overrideMergeNetsplitBlock == nil && overrideTerminalTotalDifficulty == nil {
+		return storedCfg, storedBlock, nil
+	}
 	// Check config compatibility and write the config. Compatibility errors
 	// are returned to the caller unless we're already at block zero.
 	height := rawdb.ReadHeaderNumber(db, rawdb.ReadHeadHeaderHash(db))

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -271,10 +271,9 @@ func WriteGenesisBlock(db kv.RwTx, genesis *Genesis, overrideMergeNetsplitBlock,
 		}
 		return newCfg, storedBlock, nil
 	}
-	// Special case: don't change the existing config of a non-mainnet chain if no new
-	// config is supplied. These chains would get AllProtocolChanges (and a compatibility error)
-	// if we just continued here.
-	if genesis == nil && storedHash != params.MainnetGenesisHash && overrideMergeNetsplitBlock == nil && overrideTerminalTotalDifficulty == nil {
+	// Special case: don't change the existing config of an unknown chain if no new
+	// config is supplied. This is useful, for example, to preserve DB config created by erigon init.
+	if genesis == nil && params.ChainConfigByGenesisHash(storedHash) == nil && overrideMergeNetsplitBlock == nil && overrideTerminalTotalDifficulty == nil {
 		return storedCfg, storedBlock, nil
 	}
 	// Check config compatibility and write the config. Compatibility errors

--- a/params/config.go
+++ b/params/config.go
@@ -599,6 +599,7 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		{name: "petersburgBlock", block: c.PetersburgBlock},
 		{name: "istanbulBlock", block: c.IstanbulBlock},
 		{name: "muirGlacierBlock", block: c.MuirGlacierBlock, optional: true},
+		{name: "eulerBlock", block: c.EulerBlock, optional: true},
 		{name: "berlinBlock", block: c.BerlinBlock},
 		{name: "londonBlock", block: c.LondonBlock},
 		{name: "arrowGlacierBlock", block: c.ArrowGlacierBlock, optional: true},
@@ -674,6 +675,9 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head uint64) *ConfigC
 	}
 	if isForkIncompatible(c.GrayGlacierBlock, newcfg.GrayGlacierBlock, head) {
 		return newCompatError("Gray Glacier fork block", c.GrayGlacierBlock, newcfg.GrayGlacierBlock)
+	}
+	if isForkIncompatible(c.EulerBlock, newcfg.EulerBlock, head) {
+		return newCompatError("Euler fork block", c.EulerBlock, newcfg.EulerBlock)
 	}
 	return nil
 }

--- a/turbo/stages/genesis_test.go
+++ b/turbo/stages/genesis_test.go
@@ -167,6 +167,15 @@ func TestSetupGenesis(t *testing.T) {
 			wantConfig: params.MainnetChainConfig,
 		},
 		{
+			name: "custom block in DB, genesis == nil",
+			fn: func(db kv.RwDB) (*params.ChainConfig, *types.Block, error) {
+				customg.MustCommit(db)
+				return core.CommitGenesisBlock(db, nil)
+			},
+			wantHash:   customghash,
+			wantConfig: customg.Config,
+		},
+		{
 			name: "custom block in DB, genesis == ropsten",
 			fn: func(db kv.RwDB) (*params.ChainConfig, *types.Block, error) {
 				customg.MustCommit(db)


### PR DESCRIPTION
Preserve DB config created by `erigon init`. Hive tests, for instance, rely on this funstionality.