### PR TITLE
check if block is nil

### DIFF
--- a/cmd/rpcdaemon/commands/eth_system.go
+++ b/cmd/rpcdaemon/commands/eth_system.go
@@ -203,6 +203,9 @@ func (b *GasPriceOracleBackend) HeaderByNumber(ctx context.Context, number rpc.B
 	if err != nil {
 		return nil, err
 	}
+	if block == nil {
+		return nil, nil
+	}
 	return block.Header(), nil
 }
 func (b *GasPriceOracleBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Block, error) {

--- a/cmd/rpcdaemon22/commands/eth_system.go
+++ b/cmd/rpcdaemon22/commands/eth_system.go
@@ -202,6 +202,9 @@ func (b *GasPriceOracleBackend) HeaderByNumber(ctx context.Context, number rpc.B
 	if err != nil {
 		return nil, err
 	}
+	if block == nil {
+		return nil, nil
+	}
 	return block.Header(), nil
 }
 func (b *GasPriceOracleBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Block, error) {

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -118,6 +118,9 @@ func NewOracle(backend OracleBackend, params Config) *Oracle {
 // baseFee to the returned bigInt
 func (gpo *Oracle) SuggestTipCap(ctx context.Context) (*big.Int, error) {
 	head, _ := gpo.backend.HeaderByNumber(ctx, rpc.LatestBlockNumber)
+	if head == nil {
+		return gpo.lastPrice, nil
+	}
 	headHash := head.Hash()
 
 	// If the latest gasprice is still available, return it.


### PR DESCRIPTION
Currently func (b *GasPriceOracleBackend) HeaderByNumber is not checking wether the block response is not nil causing the following error inside `SuggestedGasPrice`:
`[EROR] [06-24|10:45:22.076] RPC method eth_gasPrice crashed: runtime error: invalid memory address or nil pointer dereference
[service.go:217 panic.go:838 panic.go:220 signal_unix.go:818 block.go:1184 eth_system.go:206 gasprice.go:120 eth_system.go:117 value.go:556 value.go:339 service.go:222 handler.go:503 handler.go:408 handler.go:353 handler.go:187 handler.go:277 asm_amd64.s:1571]`

I have added a check, and if the response of the block is nil now `SuggestedGasPrice` will log a warning and return the last suggested tip gas