### PR TITLE
Delete bad blocks on unwind

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -486,7 +486,7 @@ func stageHeaders(db kv.RwDB, ctx context.Context) error {
 			}
 		}
 		// remove all canonical markers from this point
-		if err = rawdb.TruncateCanonicalHash(tx, progress+1); err != nil {
+		if err = rawdb.TruncateCanonicalHash(tx, progress+1, false); err != nil {
 			return err
 		}
 		if err = rawdb.TruncateTd(tx, progress+1); err != nil {

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -302,7 +302,7 @@ func TestCanonicalMappingStorage(t *testing.T) {
 		t.Fatalf("Retrieved canonical mapping mismatch: have %v, want %v", entry, hash)
 	}
 	// Delete the TD and verify the execution
-	err = TruncateCanonicalHash(tx, number)
+	err = TruncateCanonicalHash(tx, number, false)
 	if err != nil {
 		t.Fatalf("DeleteCanonicalHash failed: %v", err)
 	}

--- a/core/rawdb/rawdbreset/reset_stages.go
+++ b/core/rawdb/rawdbreset/reset_stages.go
@@ -55,7 +55,7 @@ func ResetBlocks(tx kv.RwTx) error {
 	}
 
 	// remove all canonical markers from this point
-	if err := rawdb.TruncateCanonicalHash(tx, 1); err != nil {
+	if err := rawdb.TruncateCanonicalHash(tx, 1, false); err != nil {
 		return err
 	}
 	if err := rawdb.TruncateTd(tx, 1); err != nil {
@@ -69,7 +69,7 @@ func ResetBlocks(tx kv.RwTx) error {
 		return err
 	}
 
-	// ensure no grabage records left (it may happen if db is inconsistent)
+	// ensure no garbage records left (it may happen if db is inconsistent)
 	if err := tx.ForEach(kv.BlockBody, dbutils.EncodeBlockNumber(2), func(k, _ []byte) error { return tx.Delete(kv.BlockBody, k, nil) }); err != nil {
 		return err
 	}

--- a/eth/stagedsync/stage_bodies.go
+++ b/eth/stagedsync/stage_bodies.go
@@ -9,6 +9,7 @@ import (
 	"github.com/c2h5oh/datasize"
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/kv"
+	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/core/rawdb"
 	"github.com/ledgerwatch/erigon/eth/stagedsync/stages"
 	"github.com/ledgerwatch/erigon/params"
@@ -281,8 +282,8 @@ func UnwindBodiesStage(u *UnwindState, tx kv.RwTx, cfg BodiesCfg, ctx context.Co
 	logEvery := time.NewTicker(logInterval)
 	defer logEvery.Stop()
 
-	// TODO(yperbasis): delete bodies and transactions for bad blocks and their descendants
-	if err := rawdb.MakeBodiesNonCanonical(tx, u.UnwindPoint+1, ctx, u.LogPrefix(), logEvery); err != nil {
+	badBlock := u.BadBlock != (common.Hash{})
+	if err := rawdb.MakeBodiesNonCanonical(tx, u.UnwindPoint+1, badBlock /* deleteBodies */, ctx, u.LogPrefix(), logEvery); err != nil {
 		return err
 	}
 

--- a/eth/stagedsync/stage_bodies.go
+++ b/eth/stagedsync/stage_bodies.go
@@ -281,6 +281,7 @@ func UnwindBodiesStage(u *UnwindState, tx kv.RwTx, cfg BodiesCfg, ctx context.Co
 	logEvery := time.NewTicker(logInterval)
 	defer logEvery.Stop()
 
+	// TODO(yperbasis): delete bodies and transactions for bad blocks and their descendants
 	if err := rawdb.MakeBodiesNonCanonical(tx, u.UnwindPoint+1, ctx, u.LogPrefix(), logEvery); err != nil {
 		return err
 	}

--- a/eth/stagedsync/stage_bodies_test.go
+++ b/eth/stagedsync/stage_bodies_test.go
@@ -35,7 +35,7 @@ func TestBodiesUnwind(t *testing.T) {
 		require.NoError(err)
 	}
 	{
-		err = rawdb.MakeBodiesNonCanonical(tx, 5+1, ctx, "test", logEvery) // block 5 already canonical, start from next one
+		err = rawdb.MakeBodiesNonCanonical(tx, 5+1, false, ctx, "test", logEvery) // block 5 already canonical, start from next one
 		require.NoError(err)
 
 		n, err := tx.ReadSequence(kv.EthTx)
@@ -61,7 +61,7 @@ func TestBodiesUnwind(t *testing.T) {
 
 	{
 		// unwind to block 5, means mark blocks >= 6 as non-canonical
-		err = rawdb.MakeBodiesNonCanonical(tx, 5+1, ctx, "test", logEvery)
+		err = rawdb.MakeBodiesNonCanonical(tx, 5+1, false, ctx, "test", logEvery)
 		require.NoError(err)
 
 		n, err := tx.ReadSequence(kv.EthTx)

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -953,7 +953,7 @@ func HeadersUnwind(u *UnwindState, s *StageState, tx kv.RwTx, cfg HeadersCfg, te
 			return fmt.Errorf("iterate over headers to mark bad headers: %w", err)
 		}
 	}
-	if err := rawdb.TruncateCanonicalHash(tx, u.UnwindPoint+1); err != nil {
+	if err := rawdb.TruncateCanonicalHash(tx, u.UnwindPoint+1, badBlock /* deleteHeaders */); err != nil {
 		return err
 	}
 	if badBlock {
@@ -996,6 +996,11 @@ func HeadersUnwind(u *UnwindState, s *StageState, tx kv.RwTx, cfg HeadersCfg, te
 				return err
 			}
 		}
+		/* TODO(yperbasis): Is it safe?
+		if err := rawdb.TruncateTd(tx, u.UnwindPoint+1); err != nil {
+			return err
+		}
+		*/
 		if maxNum == 0 {
 			maxNum = u.UnwindPoint
 			if maxHash, err = rawdb.ReadCanonicalHash(tx, maxNum); err != nil {

--- a/migrations/txs_begin_end_test.go
+++ b/migrations/txs_begin_end_test.go
@@ -41,7 +41,7 @@ func TestTxsBeginEnd(t *testing.T) {
 			return err
 		}
 
-		err = rawdb.TruncateCanonicalHash(tx, 7)
+		err = rawdb.TruncateCanonicalHash(tx, 7, false)
 		for i := uint64(7); i < 10; i++ {
 			require.NoError(err)
 			hash := common.Hash{0xa, byte(i)}


### PR DESCRIPTION
Delete headers & bodies of bad blocks (e.g. with invalid state root) on unwind. Otherwise bad blocks stay accessible by `eth_getBlockByHash`.

This should fix "Invalid StateRoot NewPayload" test in Hive.