### PR TITLE
torrent verbosity now uses int

### DIFF
--- a/cmd/downloader/downloader/downloadercfg/logger.go
+++ b/cmd/downloader/downloader/downloadercfg/logger.go
@@ -21,15 +21,15 @@ func Int2LogLevel(level int) (lg.Level, error) {
 	case 0:
 		lvl = lg.NotSet
 	case 1:
-		lvl = lg.Error
-	case 2:
-		lvl = lg.Warning
-	case 3:
-		lvl = lg.Info
-	case 4:
-		lvl = lg.Debug
-	case 5:
 		lvl = lg.Critical
+	case 2:
+		lvl = lg.Error
+	case 3:
+		lvl = lg.Warning
+	case 4:
+		lvl = lg.Info
+	case 5:
+		lvl = lg.Debug
 	default:
 		return lvl, fmt.Errorf("invalid level set, expected a number between 0-5 but got: %d", level)
 	}

--- a/cmd/downloader/downloader/downloadercfg/logger.go
+++ b/cmd/downloader/downloader/downloadercfg/logger.go
@@ -1,6 +1,7 @@
 package downloadercfg
 
 import (
+	"fmt"
 	"strings"
 
 	utp "github.com/anacrolix/go-libutp"
@@ -13,10 +14,24 @@ func init() {
 	utp.Logger.Handlers = []lg.Handler{noopHandler{}}
 }
 
-func Str2LogLevel(in string) (lg.Level, error) {
+func Int2LogLevel(level int) (lg.Level, error) {
 	lvl := lg.Level{}
-	if err := lvl.UnmarshalText([]byte(in)); err != nil {
-		return lvl, err
+
+	switch level {
+	case 0:
+		lvl = lg.NotSet
+	case 1:
+		lvl = lg.Error
+	case 2:
+		lvl = lg.Warning
+	case 3:
+		lvl = lg.Info
+	case 4:
+		lvl = lg.Debug
+	case 5:
+		lvl = lg.Critical
+	default:
+		return lvl, fmt.Errorf("invalid level set, expected a number between 0-5 but got: %d", level)
 	}
 	return lvl, nil
 }

--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -38,7 +38,7 @@ var (
 	forceVerify                    bool
 	downloaderApiAddr              string
 	natSetting                     string
-	torrentVerbosity               string
+	torrentVerbosity               int
 	downloadRateStr, uploadRateStr string
 	torrentDownloadSlots           int
 	torrentPort                    int
@@ -55,9 +55,9 @@ func init() {
 
 	rootCmd.Flags().StringVar(&natSetting, "nat", utils.NATFlag.Value, utils.NATFlag.Usage)
 	rootCmd.Flags().StringVar(&downloaderApiAddr, "downloader.api.addr", "127.0.0.1:9093", "external downloader api network address, for example: 127.0.0.1:9093 serves remote downloader interface")
-	rootCmd.Flags().StringVar(&torrentVerbosity, "torrent.verbosity", utils.TorrentVerbosityFlag.Value, utils.TorrentVerbosityFlag.Usage)
 	rootCmd.Flags().StringVar(&downloadRateStr, "torrent.download.rate", utils.TorrentDownloadRateFlag.Value, utils.TorrentDownloadRateFlag.Usage)
 	rootCmd.Flags().StringVar(&uploadRateStr, "torrent.upload.rate", utils.TorrentUploadRateFlag.Value, utils.TorrentUploadRateFlag.Usage)
+	rootCmd.Flags().IntVar(&torrentVerbosity, "torrent.verbosity", utils.TorrentVerbosityFlag.Value, utils.TorrentVerbosityFlag.Usage)
 	rootCmd.Flags().IntVar(&torrentPort, "torrent.port", utils.TorrentPortFlag.Value, utils.TorrentPortFlag.Usage)
 	rootCmd.Flags().IntVar(&torrentMaxPeers, "torrent.maxpeers", utils.TorrentMaxPeersFlag.Value, utils.TorrentMaxPeersFlag.Usage)
 	rootCmd.Flags().IntVar(&torrentConnsPerFile, "torrent.conns.perfile", utils.TorrentConnsPerFileFlag.Value, utils.TorrentConnsPerFileFlag.Usage)
@@ -114,10 +114,11 @@ var rootCmd = &cobra.Command{
 
 func Downloader(ctx context.Context) error {
 	dirs := datadir.New(datadirCli)
-	torrentLogLevel, err := downloadercfg.Str2LogLevel(torrentVerbosity)
+	torrentLogLevel, err := downloadercfg.Int2LogLevel(torrentVerbosity)
 	if err != nil {
 		return err
 	}
+	log.Info("torrentLogLevel", torrentLogLevel)
 
 	var downloadRate, uploadRate datasize.ByteSize
 	if err := downloadRate.UnmarshalText([]byte(downloadRateStr)); err != nil {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1400,7 +1400,7 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 		if err := uploadRate.UnmarshalText([]byte(uploadRateStr)); err != nil {
 			panic(err)
 		}
-
+		log.Info("torrent verbosity", "level", ctx.GlobalInt(TorrentVerbosityFlag.Name))
 		lvl, err := downloadercfg.Int2LogLevel(ctx.GlobalInt(TorrentVerbosityFlag.Name))
 		if err != nil {
 			panic(err)
@@ -1442,7 +1442,6 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 	if ctx.GlobalIsSet(RPCGlobalGasCapFlag.Name) {
 		cfg.RPCGasCap = ctx.GlobalUint64(RPCGlobalGasCapFlag.Name)
 	}
-	log.Info("torrentVerbosityFlag1", "level", ctx.GlobalInt(TorrentVerbosityFlag.Name))
 	if cfg.RPCGasCap != 0 {
 		log.Info("Set global gas cap", "cap", cfg.RPCGasCap)
 	} else {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -29,7 +29,6 @@ import (
 	"text/tabwriter"
 	"text/template"
 
-	lg "github.com/anacrolix/log"
 	"github.com/c2h5oh/datasize"
 	"github.com/ledgerwatch/erigon-lib/kv/kvcache"
 	"github.com/ledgerwatch/erigon-lib/txpool"
@@ -645,10 +644,10 @@ var (
 		Name:  ethconfig.FlagSnapStop,
 		Usage: "Stop producing new snapshots",
 	}
-	TorrentVerbosityFlag = cli.StringFlag{
+	TorrentVerbosityFlag = cli.IntFlag{
 		Name:  "torrent.verbosity",
-		Value: lg.Warning.LogString(),
-		Usage: "DBG | INF | WRN | ERR (must set --verbosity to equal or higher level)",
+		Value: 3,
+		Usage: "0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=detail (must set --verbosity to equal or higher level and has defeault: 3)",
 	}
 	TorrentDownloadRateFlag = cli.StringFlag{
 		Name:  "torrent.download.rate",
@@ -1402,7 +1401,7 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 			panic(err)
 		}
 
-		lvl, err := downloadercfg.Str2LogLevel(ctx.GlobalString(TorrentVerbosityFlag.Name))
+		lvl, err := downloadercfg.Int2LogLevel(ctx.GlobalInt(TorrentVerbosityFlag.Name))
 		if err != nil {
 			panic(err)
 		}
@@ -1443,6 +1442,7 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 	if ctx.GlobalIsSet(RPCGlobalGasCapFlag.Name) {
 		cfg.RPCGasCap = ctx.GlobalUint64(RPCGlobalGasCapFlag.Name)
 	}
+	log.Info("torrentVerbosityFlag1", "level", ctx.GlobalInt(TorrentVerbosityFlag.Name))
 	if cfg.RPCGasCap != 0 {
 		log.Info("Set global gas cap", "cap", cfg.RPCGasCap)
 	} else {


### PR DESCRIPTION
changed the flag `--torrent.verbosity` to use an int value like the `--verbosity` flag.

`--torrent.verbosity` now uses values between zero to five, zero being no verbosity and five being detailed/critical