### PR TITLE
Introduce `eth_callMany` and `debug_traceCallMany`

### DIFF
--- a/cmd/rpcdaemon/commands/eth_callMany.go
+++ b/cmd/rpcdaemon/commands/eth_callMany.go
@@ -114,7 +114,7 @@ func (api *APIImpl) CallMany(ctx context.Context, bundles []Bundle, simulateCont
 
 	st := state.New(stateReader)
 
-	parent := rawdb.ReadHeader(tx, hash, blockNum)
+	parent := block.Header()
 
 	if parent == nil {
 		return nil, fmt.Errorf("block %d(%x) not found", blockNum, hash)

--- a/cmd/rpcdaemon/commands/eth_callMany.go
+++ b/cmd/rpcdaemon/commands/eth_callMany.go
@@ -1,0 +1,286 @@
+package commands
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/holiman/uint256"
+	"github.com/ledgerwatch/erigon/common"
+	"github.com/ledgerwatch/erigon/common/hexutil"
+	"github.com/ledgerwatch/erigon/common/math"
+	"github.com/ledgerwatch/erigon/core"
+	"github.com/ledgerwatch/erigon/core/rawdb"
+	"github.com/ledgerwatch/erigon/core/state"
+	"github.com/ledgerwatch/erigon/core/types"
+	"github.com/ledgerwatch/erigon/core/vm"
+	"github.com/ledgerwatch/erigon/ethdb"
+	rpcapi "github.com/ledgerwatch/erigon/internal/ethapi"
+	"github.com/ledgerwatch/erigon/rpc"
+	"github.com/ledgerwatch/erigon/turbo/adapter/ethapi"
+	"github.com/ledgerwatch/erigon/turbo/rpchelper"
+	"github.com/ledgerwatch/log/v3"
+)
+
+type BlockContext struct {
+	BlockNumber *hexutil.Uint64
+	Coinbase    *common.Address
+	Timestamp   *hexutil.Uint64
+	GasLimit    *hexutil.Uint
+	Difficulty  *hexutil.Uint
+	BaseFee     *uint256.Int
+	BlockHash   *map[uint64]common.Hash
+}
+
+type Bundle struct {
+	Transactions  []rpcapi.CallArgs
+	BlockOverride BlockContext
+}
+
+type StateContext struct {
+	BlockNumber      rpc.BlockNumberOrHash
+	TransactionIndex *int
+	StateOverride    *rpcapi.StateOverrides
+}
+
+func (api *APIImpl) CallMany(ctx context.Context, bundles []Bundle, simulateContext StateContext, timeoutMilliSecondsPtr *int64) ([][]map[string]interface{}, error) {
+	var (
+		hash               common.Hash
+		replayTransactions types.Transactions
+		evm                *vm.EVM
+		blockCtx           vm.BlockContext
+		txCtx              vm.TxContext
+		overrideBlockHash  map[uint64]common.Hash
+		baseFee            uint256.Int
+	)
+
+	overrideBlockHash = make(map[uint64]common.Hash)
+	tx, err := api.db.BeginRo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+	chainConfig, err := api.chainConfig(tx)
+	if err != nil {
+		return nil, err
+	}
+	if len(bundles) == 0 {
+		return nil, fmt.Errorf("empty bundles")
+	}
+	empty := true
+	for _, bundle := range bundles {
+		if len(bundle.Transactions) != 0 {
+			empty = false
+		}
+	}
+
+	if empty {
+		return nil, fmt.Errorf("empty bundles")
+	}
+
+	defer func(start time.Time) { log.Trace("Executing EVM callMany finished", "runtime", time.Since(start)) }(time.Now())
+
+	blockNum, hash, _, err := rpchelper.GetBlockNumber(simulateContext.BlockNumber, tx, api.filters)
+	if err != nil {
+		return nil, err
+	}
+
+	block, err := api.blockByNumberWithSenders(tx, blockNum)
+	if err != nil {
+		return nil, err
+	}
+
+	// -1 is a default value for transaction index.
+	// If it's -1, we will try to replay every single transaction in that block
+	transactionIndex := -1
+
+	if simulateContext.TransactionIndex != nil {
+		transactionIndex = *simulateContext.TransactionIndex
+	}
+
+	if transactionIndex == -1 {
+		transactionIndex = len(block.Transactions())
+	}
+
+	replayTransactions = block.Transactions()[:transactionIndex]
+
+	stateReader, err := rpchelper.CreateStateReader(ctx, tx, rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(blockNum-1)), api.filters, api.stateCache)
+
+	if err != nil {
+		return nil, err
+	}
+
+	st := state.New(stateReader)
+
+	parent := rawdb.ReadHeader(tx, hash, blockNum)
+
+	if parent == nil {
+		return nil, fmt.Errorf("block %d(%x) not found", blockNum, hash)
+	}
+
+	// Get a new instance of the EVM
+	signer := types.MakeSigner(chainConfig, blockNum)
+	rules := chainConfig.Rules(blockNum)
+
+	contractHasTEVM := func(contractHash common.Hash) (bool, error) { return false, nil }
+
+	if api.TevmEnabled {
+		contractHasTEVM = ethdb.GetHasTEVM(tx)
+	}
+
+	getHash := func(i uint64) common.Hash {
+		if hash, ok := overrideBlockHash[i]; ok {
+			return hash
+		}
+		hash, err := rawdb.ReadCanonicalHash(tx, i)
+		if err != nil {
+			log.Debug("Can't get block hash by number", "number", i, "only-canonical", true)
+		}
+		return hash
+	}
+
+	if parent.BaseFee != nil {
+		baseFee.SetFromBig(parent.BaseFee)
+	}
+
+	blockCtx = vm.BlockContext{
+		CanTransfer:     core.CanTransfer,
+		Transfer:        core.Transfer,
+		GetHash:         getHash,
+		ContractHasTEVM: contractHasTEVM,
+		Coinbase:        parent.Coinbase,
+		BlockNumber:     parent.Number.Uint64(),
+		Time:            parent.Time,
+		Difficulty:      new(big.Int).Set(parent.Difficulty),
+		GasLimit:        parent.GasLimit,
+		BaseFee:         &baseFee,
+	}
+
+	evm = vm.NewEVM(blockCtx, txCtx, st, chainConfig, vm.Config{Debug: false})
+
+	timeoutMilliSeconds := int64(5000)
+
+	if timeoutMilliSecondsPtr != nil {
+		timeoutMilliSeconds = *timeoutMilliSecondsPtr
+	}
+
+	timeout := time.Millisecond * time.Duration(timeoutMilliSeconds)
+	// Setup context so it may be cancelled the call has completed
+	// or, in case of unmetered gas, setup a context with a timeout.
+	var cancel context.CancelFunc
+	if timeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+	} else {
+		ctx, cancel = context.WithCancel(ctx)
+	}
+	// Make sure the context is cancelled when the call has completed
+	// this makes sure resources are cleaned up.
+	defer cancel()
+
+	// Wait for the context to be done and cancel the evm. Even if the
+	// EVM has finished, cancelling may be done (repeatedly)
+	go func() {
+		<-ctx.Done()
+		evm.Cancel()
+	}()
+
+	// Setup the gas pool (also for unmetered requests)
+	// and apply the message.
+	gp := new(core.GasPool).AddGas(math.MaxUint64)
+
+	for _, txn := range replayTransactions {
+		msg, err := txn.AsMessage(*signer, nil, rules)
+		if err != nil {
+			return nil, err
+		}
+		txCtx = core.NewEVMTxContext(msg)
+		evm = vm.NewEVM(blockCtx, txCtx, evm.IntraBlockState(), chainConfig, vm.Config{Debug: false})
+		// Execute the transaction message
+		_, err = core.ApplyMessage(evm, msg, gp, true /* refunds */, false /* gasBailout */)
+		if err != nil {
+			return nil, err
+		}
+		// If the timer caused an abort, return an appropriate error message
+		if evm.Cancelled() {
+			return nil, fmt.Errorf("execution aborted (timeout = %v)", timeout)
+		}
+	}
+
+	// after replaying the txns, we want to overload the state
+	// overload state
+	if simulateContext.StateOverride != nil {
+		err = simulateContext.StateOverride.Override((evm.IntraBlockState()).(*state.IntraBlockState))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	ret := make([][]map[string]interface{}, 0)
+
+	for _, bundle := range bundles {
+		// first change blockContext
+		if bundle.BlockOverride.BlockNumber != nil {
+			blockCtx.BlockNumber = uint64(*bundle.BlockOverride.BlockNumber)
+		}
+		if bundle.BlockOverride.BaseFee != nil {
+			blockCtx.BaseFee = bundle.BlockOverride.BaseFee
+		}
+		if bundle.BlockOverride.Coinbase != nil {
+			blockCtx.Coinbase = *bundle.BlockOverride.Coinbase
+		}
+		if bundle.BlockOverride.Difficulty != nil {
+			blockCtx.Difficulty = big.NewInt(int64(*bundle.BlockOverride.Difficulty))
+		}
+		if bundle.BlockOverride.Timestamp != nil {
+			blockCtx.Time = uint64(*bundle.BlockOverride.Timestamp)
+		}
+		if bundle.BlockOverride.GasLimit != nil {
+			blockCtx.GasLimit = uint64(*bundle.BlockOverride.GasLimit)
+		}
+		if bundle.BlockOverride.BlockHash != nil {
+			for blockNum, hash := range *bundle.BlockOverride.BlockHash {
+				overrideBlockHash[blockNum] = hash
+			}
+		}
+		results := []map[string]interface{}{}
+		for _, txn := range bundle.Transactions {
+			if txn.Gas == nil || *(txn.Gas) == 0 {
+				txn.Gas = (*hexutil.Uint64)(&api.GasCap)
+			}
+			msg, err := txn.ToMessage(api.GasCap, blockCtx.BaseFee)
+			if err != nil {
+				return nil, err
+			}
+			txCtx = core.NewEVMTxContext(msg)
+			evm = vm.NewEVM(blockCtx, txCtx, evm.IntraBlockState(), chainConfig, vm.Config{Debug: false})
+			result, err := core.ApplyMessage(evm, msg, gp, true, false)
+			if err != nil {
+				return nil, err
+			}
+			// If the timer caused an abort, return an appropriate error message
+			if evm.Cancelled() {
+				return nil, fmt.Errorf("execution aborted (timeout = %v)", timeout)
+			}
+			jsonResult := make(map[string]interface{})
+			if result.Err != nil {
+				if len(result.Revert()) > 0 {
+					jsonResult["error"] = ethapi.NewRevertError(result)
+				} else {
+					jsonResult["error"] = result.Err.Error()
+				}
+			} else {
+				jsonResult["value"] = hex.EncodeToString(result.Return())
+			}
+
+			results = append(results, jsonResult)
+		}
+
+		blockCtx.BlockNumber++
+		blockCtx.Time++
+		ret = append(ret, results)
+	}
+
+	return ret, err
+}

--- a/cmd/rpcdaemon/commands/eth_callMany_test.go
+++ b/cmd/rpcdaemon/commands/eth_callMany_test.go
@@ -1,0 +1,165 @@
+package commands
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"strconv"
+	"testing"
+
+	"github.com/ledgerwatch/erigon-lib/kv/kvcache"
+	"github.com/ledgerwatch/erigon/accounts/abi/bind"
+	"github.com/ledgerwatch/erigon/accounts/abi/bind/backends"
+	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/commands/contracts"
+	"github.com/ledgerwatch/erigon/common/hexutil"
+	"github.com/ledgerwatch/erigon/core"
+	"github.com/ledgerwatch/erigon/crypto"
+	"github.com/ledgerwatch/erigon/internal/ethapi"
+	"github.com/ledgerwatch/erigon/params"
+	"github.com/ledgerwatch/erigon/rpc"
+	"github.com/ledgerwatch/erigon/turbo/snapshotsync"
+)
+
+// block 1 contains 3 Transactions
+//	 1. deploy token A
+//	 2. mint address 2 100 token
+//	 3. transfer from address 2 to address 1
+
+// test 2 bundles
+// check balance of addr1 and addr 2 at the end of block and interblock
+
+func TestCallMany(t *testing.T) {
+	var (
+		key, _   = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		key1, _  = crypto.HexToECDSA("49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee")
+		key2, _  = crypto.HexToECDSA("8a1f9a8f95be41cd7ccb6168179afb4504aefe388d1e14474d32c45c72ce7b7a")
+		address  = crypto.PubkeyToAddress(key.PublicKey)
+		address1 = crypto.PubkeyToAddress(key1.PublicKey)
+		address2 = crypto.PubkeyToAddress(key2.PublicKey)
+		gspec    = &core.Genesis{
+			Config: params.AllEthashProtocolChanges,
+			Alloc: core.GenesisAlloc{
+				address:  {Balance: big.NewInt(9000000000000000000)},
+				address1: {Balance: big.NewInt(200000000000000000)},
+				address2: {Balance: big.NewInt(300000000000000000)},
+			},
+			GasLimit: 10000000,
+		}
+		chainID = big.NewInt(1337)
+		ctx     = context.Background()
+
+		addr1BalanceCheck = "70a08231" + "000000000000000000000000" + address1.Hex()[2:]
+		addr2BalanceCheck = "70a08231" + "000000000000000000000000" + address2.Hex()[2:]
+		transferAddr2     = "70a08231" + "000000000000000000000000" + address1.Hex()[2:] + "0000000000000000000000000000000000000000000000000000000000000064"
+	)
+
+	hexBytes, _ := hex.DecodeString(addr2BalanceCheck)
+	balanceCallAddr2 := hexutil.Bytes(hexBytes)
+	hexBytes, _ = hex.DecodeString(addr1BalanceCheck)
+	balanceCallAddr1 := hexutil.Bytes(hexBytes)
+	hexBytes, _ = hex.DecodeString(transferAddr2)
+	transferCallData := hexutil.Bytes(hexBytes)
+
+	//submit 3 Transactions and commit the results
+	transactOpts, _ := bind.NewKeyedTransactorWithChainID(key, chainID)
+	transactOpts1, _ := bind.NewKeyedTransactorWithChainID(key1, chainID)
+	transactOpts2, _ := bind.NewKeyedTransactorWithChainID(key2, chainID)
+	contractBackend := backends.NewSimulatedBackendWithConfig(gspec.Alloc, gspec.Config, gspec.GasLimit)
+	defer contractBackend.Close()
+	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
+	tokenAddr, _, tokenContract, _ := contracts.DeployToken(transactOpts, contractBackend, address1)
+	tokenContract.Mint(transactOpts1, address2, big.NewInt(100))
+	tokenContract.Transfer(transactOpts2, address1, big.NewInt(100))
+	contractBackend.Commit()
+
+	// set up the callargs
+	var nonce hexutil.Uint64 = 1
+	var secondNonce hexutil.Uint64 = 2
+
+	db := contractBackend.DB()
+	api := NewEthAPI(NewBaseApi(nil, stateCache, snapshotsync.NewBlockReader(), false), db, nil, nil, nil, 5000000)
+
+	callArgAddr1 := ethapi.CallArgs{From: &address, To: &tokenAddr, Nonce: &nonce,
+		MaxPriorityFeePerGas: (*hexutil.Big)(big.NewInt(1e9)),
+		MaxFeePerGas:         (*hexutil.Big)(big.NewInt(1e10)),
+		Data:                 &balanceCallAddr1,
+	}
+	callArgAddr2 := ethapi.CallArgs{From: &address, To: &tokenAddr, Nonce: &secondNonce,
+		MaxPriorityFeePerGas: (*hexutil.Big)(big.NewInt(1e9)),
+		MaxFeePerGas:         (*hexutil.Big)(big.NewInt(1e10)),
+		Data:                 &balanceCallAddr2,
+	}
+
+	callArgTransferAddr2 := ethapi.CallArgs{From: &address2, To: &tokenAddr, Nonce: &nonce,
+		MaxPriorityFeePerGas: (*hexutil.Big)(big.NewInt(1e9)),
+		MaxFeePerGas:         (*hexutil.Big)(big.NewInt(1e10)),
+		Data:                 &transferCallData,
+	}
+
+	timeout := int64(50000)
+	txIndex := -1
+	res, err := api.CallMany(ctx, []Bundle{{
+		Transactions: []ethapi.CallArgs{callArgAddr1, callArgAddr2}}}, StateContext{BlockNumber: rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber), TransactionIndex: &txIndex}, &timeout)
+	if err != nil {
+		t.Errorf("eth_callMany: %v", err)
+	}
+
+	// parse the results and do balance checks
+	addr1CalRet := fmt.Sprintf("%v", res[0][0]["value"])[2:]
+	addr2CalRet := fmt.Sprintf("%v", res[0][1]["value"])[2:]
+	addr1Balance, err := strconv.ParseInt(addr1CalRet, 16, 64)
+	if err != nil {
+		t.Errorf("eth_callMany: %v", err)
+	}
+	addr2Balance, err := strconv.ParseInt(addr2CalRet, 16, 64)
+
+	if err != nil {
+		t.Errorf("eth_callMany: %v", err)
+	}
+	if addr1Balance != 100 || addr2Balance != 0 {
+		t.Errorf("eth_callMany: %v", "balanceUnmatch")
+	}
+
+	txIndex = 2
+	res, err = api.CallMany(ctx, []Bundle{{
+		Transactions: []ethapi.CallArgs{callArgAddr1, callArgAddr2}}}, StateContext{BlockNumber: rpc.BlockNumberOrHashWithNumber(1), TransactionIndex: &txIndex}, &timeout)
+	if err != nil {
+		t.Errorf("eth_callMany: %v", err)
+	}
+
+	addr1CalRet = fmt.Sprintf("%v", res[0][0]["value"])[2:]
+	addr2CalRet = fmt.Sprintf("%v", res[0][1]["value"])[2:]
+	addr1Balance, err = strconv.ParseInt(addr1CalRet, 16, 64)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	addr2Balance, err = strconv.ParseInt(addr2CalRet, 16, 64)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	if addr1Balance != 0 || addr2Balance != 100 {
+		t.Errorf("eth_callMany: %s", "balanceUnmatch")
+	}
+	txIndex = -1
+	res, err = api.CallMany(ctx, []Bundle{{Transactions: []ethapi.CallArgs{callArgTransferAddr2, callArgAddr1, callArgAddr2}}}, StateContext{BlockNumber: rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber), TransactionIndex: &txIndex}, &timeout)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	addr1CalRet = fmt.Sprintf("%v", res[0][1]["value"])[2:]
+	addr2CalRet = fmt.Sprintf("%v", res[0][2]["value"])[2:]
+
+	addr1Balance, err = strconv.ParseInt(addr1CalRet, 16, 64)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	addr2Balance, err = strconv.ParseInt(addr2CalRet, 16, 64)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	if addr1Balance != 100 || addr2Balance != 0 {
+		t.Errorf("eth_callMany: %s", "balanceUnmatch")
+	}
+}

--- a/cmd/rpcdaemon/commands/eth_callMany_test.go
+++ b/cmd/rpcdaemon/commands/eth_callMany_test.go
@@ -100,7 +100,7 @@ func TestCallMany(t *testing.T) {
 	timeout := int64(50000)
 	txIndex := -1
 	res, err := api.CallMany(ctx, []Bundle{{
-		Transactions: []ethapi.CallArgs{callArgAddr1, callArgAddr2}}}, StateContext{BlockNumber: rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber), TransactionIndex: &txIndex}, &timeout)
+		Transactions: []ethapi.CallArgs{callArgAddr1, callArgAddr2}}}, StateContext{BlockNumber: rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber), TransactionIndex: &txIndex}, nil, &timeout)
 	if err != nil {
 		t.Errorf("eth_callMany: %v", err)
 	}
@@ -123,7 +123,7 @@ func TestCallMany(t *testing.T) {
 
 	txIndex = 2
 	res, err = api.CallMany(ctx, []Bundle{{
-		Transactions: []ethapi.CallArgs{callArgAddr1, callArgAddr2}}}, StateContext{BlockNumber: rpc.BlockNumberOrHashWithNumber(1), TransactionIndex: &txIndex}, &timeout)
+		Transactions: []ethapi.CallArgs{callArgAddr1, callArgAddr2}}}, StateContext{BlockNumber: rpc.BlockNumberOrHashWithNumber(1), TransactionIndex: &txIndex}, nil, &timeout)
 	if err != nil {
 		t.Errorf("eth_callMany: %v", err)
 	}
@@ -143,7 +143,7 @@ func TestCallMany(t *testing.T) {
 		t.Errorf("eth_callMany: %s", "balanceUnmatch")
 	}
 	txIndex = -1
-	res, err = api.CallMany(ctx, []Bundle{{Transactions: []ethapi.CallArgs{callArgTransferAddr2, callArgAddr1, callArgAddr2}}}, StateContext{BlockNumber: rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber), TransactionIndex: &txIndex}, &timeout)
+	res, err = api.CallMany(ctx, []Bundle{{Transactions: []ethapi.CallArgs{callArgTransferAddr2, callArgAddr1, callArgAddr2}}}, StateContext{BlockNumber: rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber), TransactionIndex: &txIndex}, nil, &timeout)
 	if err != nil {
 		t.Errorf("%v", err)
 	}

--- a/cmd/rpcdaemon/commands/tracing.go
+++ b/cmd/rpcdaemon/commands/tracing.go
@@ -3,11 +3,16 @@ package commands
 import (
 	"context"
 	"fmt"
+	"math/big"
+	"time"
 
 	"github.com/holiman/uint256"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/ledgerwatch/erigon/common"
+	"github.com/ledgerwatch/erigon/common/hexutil"
+	"github.com/ledgerwatch/erigon/common/math"
 	"github.com/ledgerwatch/erigon/consensus/ethash"
+	"github.com/ledgerwatch/erigon/core"
 	"github.com/ledgerwatch/erigon/core/rawdb"
 	"github.com/ledgerwatch/erigon/core/state"
 	"github.com/ledgerwatch/erigon/core/types"
@@ -238,4 +243,196 @@ func (api *PrivateDebugAPIImpl) TraceCall(ctx context.Context, args ethapi.CallA
 	blockCtx, txCtx := transactions.GetEvmContext(msg, header, blockNrOrHash.RequireCanonical, dbtx, contractHasTEVM, api._blockReader)
 	// Trace the transaction and return
 	return transactions.TraceTx(ctx, msg, blockCtx, txCtx, ibs, config, chainConfig, stream)
+}
+
+func (api *PrivateDebugAPIImpl) TraceCallMany(ctx context.Context, bundles []Bundle, simulateContext StateContext, config *tracers.TraceConfig, stream *jsoniter.Stream) error {
+	var (
+		hash               common.Hash
+		replayTransactions types.Transactions
+		evm                *vm.EVM
+		blockCtx           vm.BlockContext
+		txCtx              vm.TxContext
+		overrideBlockHash  map[uint64]common.Hash
+		baseFee            uint256.Int
+	)
+
+	overrideBlockHash = make(map[uint64]common.Hash)
+	tx, err := api.db.BeginRo(ctx)
+	if err != nil {
+		stream.WriteNil()
+		return err
+	}
+	defer tx.Rollback()
+	chainConfig, err := api.chainConfig(tx)
+	if err != nil {
+		stream.WriteNil()
+		return err
+	}
+	if len(bundles) == 0 {
+		stream.WriteNil()
+		return fmt.Errorf("empty bundles")
+	}
+	empty := true
+	for _, bundle := range bundles {
+		if len(bundle.Transactions) != 0 {
+			empty = false
+		}
+	}
+
+	if empty {
+		stream.WriteNil()
+		return fmt.Errorf("empty bundles")
+	}
+
+	defer func(start time.Time) { log.Trace("Tracing CallMany finished", "runtime", time.Since(start)) }(time.Now())
+
+	blockNum, hash, _, err := rpchelper.GetBlockNumber(simulateContext.BlockNumber, tx, api.filters)
+	if err != nil {
+		stream.WriteNil()
+		return err
+	}
+
+	block, err := api.blockByNumberWithSenders(tx, blockNum)
+	if err != nil {
+		stream.WriteNil()
+		return err
+	}
+
+	// -1 is a default value for transaction index.
+	// If it's -1, we will try to replay every single transaction in that block
+	transactionIndex := -1
+
+	if simulateContext.TransactionIndex != nil {
+		transactionIndex = *simulateContext.TransactionIndex
+	}
+
+	if transactionIndex == -1 {
+		transactionIndex = len(block.Transactions())
+	}
+
+	replayTransactions = block.Transactions()[:transactionIndex]
+
+	stateReader, err := rpchelper.CreateStateReader(ctx, tx, rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(blockNum-1)), api.filters, api.stateCache)
+
+	if err != nil {
+		stream.WriteNil()
+		return err
+	}
+
+	st := state.New(stateReader)
+
+	parent := block.Header()
+
+	if parent == nil {
+		stream.WriteNil()
+		return fmt.Errorf("block %d(%x) not found", blockNum, hash)
+	}
+
+	// Get a new instance of the EVM
+	signer := types.MakeSigner(chainConfig, blockNum)
+	rules := chainConfig.Rules(blockNum)
+
+	contractHasTEVM := func(contractHash common.Hash) (bool, error) { return false, nil }
+
+	if api.TevmEnabled {
+		contractHasTEVM = ethdb.GetHasTEVM(tx)
+	}
+
+	getHash := func(i uint64) common.Hash {
+		if hash, ok := overrideBlockHash[i]; ok {
+			return hash
+		}
+		hash, err := rawdb.ReadCanonicalHash(tx, i)
+		if err != nil {
+			log.Debug("Can't get block hash by number", "number", i, "only-canonical", true)
+		}
+		return hash
+	}
+
+	if parent.BaseFee != nil {
+		baseFee.SetFromBig(parent.BaseFee)
+	}
+
+	blockCtx = vm.BlockContext{
+		CanTransfer:     core.CanTransfer,
+		Transfer:        core.Transfer,
+		GetHash:         getHash,
+		ContractHasTEVM: contractHasTEVM,
+		Coinbase:        parent.Coinbase,
+		BlockNumber:     parent.Number.Uint64(),
+		Time:            parent.Time,
+		Difficulty:      new(big.Int).Set(parent.Difficulty),
+		GasLimit:        parent.GasLimit,
+		BaseFee:         &baseFee,
+	}
+
+	evm = vm.NewEVM(blockCtx, txCtx, st, chainConfig, vm.Config{Debug: false})
+
+	// Setup the gas pool (also for unmetered requests)
+	// and apply the message.
+	gp := new(core.GasPool).AddGas(math.MaxUint64)
+	for _, txn := range replayTransactions {
+		msg, err := txn.AsMessage(*signer, nil, rules)
+		if err != nil {
+			stream.WriteNil()
+			return err
+		}
+		txCtx = core.NewEVMTxContext(msg)
+		evm = vm.NewEVM(blockCtx, txCtx, evm.IntraBlockState(), chainConfig, vm.Config{Debug: false})
+		// Execute the transaction message
+		_, err = core.ApplyMessage(evm, msg, gp, true /* refunds */, false /* gasBailout */)
+		if err != nil {
+			stream.WriteNil()
+			return err
+		}
+
+	}
+
+	// after replaying the txns, we want to overload the state
+	if config.StateOverrides != nil {
+		err = config.StateOverrides.Override(evm.IntraBlockState().(*state.IntraBlockState))
+		if err != nil {
+			stream.WriteNil()
+			return err
+		}
+	}
+
+	stream.WriteArrayStart()
+	for bundle_index, bundle := range bundles {
+		stream.WriteArrayStart()
+		// first change blockContext
+		blockHeaderOverride(&blockCtx, bundle.BlockOverride, overrideBlockHash)
+		for txn_index, txn := range bundle.Transactions {
+			if txn.Gas == nil || *(txn.Gas) == 0 {
+				txn.Gas = (*hexutil.Uint64)(&api.GasCap)
+			}
+			msg, err := txn.ToMessage(api.GasCap, blockCtx.BaseFee)
+			if err != nil {
+				stream.WriteNil()
+				return err
+			}
+			txCtx = core.NewEVMTxContext(msg)
+			ibs := evm.IntraBlockState().(*state.IntraBlockState)
+			ibs.Prepare(common.Hash{}, parent.Hash(), txn_index)
+			err = transactions.TraceTx(ctx, msg, blockCtx, txCtx, evm.IntraBlockState(), config, chainConfig, stream)
+
+			if err != nil {
+				stream.WriteNil()
+				return err
+			}
+
+			if txn_index < len(bundle.Transactions)-1 {
+				stream.WriteMore()
+			}
+		}
+		stream.WriteArrayEnd()
+
+		if bundle_index < len(bundles)-1 {
+			stream.WriteMore()
+		}
+		blockCtx.BlockNumber++
+		blockCtx.Time++
+	}
+	stream.WriteArrayEnd()
+	return nil
 }


### PR DESCRIPTION
In this PR, we want to introduce two new rpc methods `eth_callMany` and `debug_traceCallMany`. The rationale and the specification of those two methods could be found at [Issue #4471](https://github.com/ledgerwatch/erigon/issues/4471). 

We'd love to get code reviews from the erigon team. 