### PR TITLE
getting header instead of block

### DIFF
--- a/cmd/rpcdaemon/commands/eth_system.go
+++ b/cmd/rpcdaemon/commands/eth_system.go
@@ -199,14 +199,14 @@ func NewGasPriceOracleBackend(tx kv.Tx, cc *params.ChainConfig, baseApi *BaseAPI
 }
 
 func (b *GasPriceOracleBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error) {
-	block, err := b.baseApi.blockByRPCNumber(number, b.tx)
+	header, err := b.baseApi._blockReader.HeaderByNumber(ctx, b.tx, uint64(number.Int64()))
 	if err != nil {
 		return nil, err
 	}
-	if block == nil {
+	if header == nil {
 		return nil, nil
 	}
-	return block.Header(), nil
+	return header, nil
 }
 func (b *GasPriceOracleBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Block, error) {
 	return b.baseApi.blockByRPCNumber(number, b.tx)

--- a/cmd/rpcdaemon22/commands/eth_system.go
+++ b/cmd/rpcdaemon22/commands/eth_system.go
@@ -198,14 +198,14 @@ func NewGasPriceOracleBackend(tx kv.Tx, cc *params.ChainConfig, baseApi *BaseAPI
 }
 
 func (b *GasPriceOracleBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error) {
-	block, err := b.baseApi.blockByRPCNumber(number, b.tx)
+	header, err := b.baseApi._blockReader.HeaderByNumber(ctx, b.tx, uint64(number.Int64()))
 	if err != nil {
 		return nil, err
 	}
-	if block == nil {
+	if header == nil {
 		return nil, nil
 	}
-	return block.Header(), nil
+	return header, nil
 }
 func (b *GasPriceOracleBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Block, error) {
 	return b.baseApi.blockByRPCNumber(number, b.tx)


### PR DESCRIPTION
Instead of getting the whole block to obtain the header inside of `GetHeaderByNumber` now we are getting the header straight away using `._blockreader`