### PR TITLE
pending block will only return if it is not nil

### DIFF
--- a/cmd/rpcdaemon/commands/eth_api.go
+++ b/cmd/rpcdaemon/commands/eth_api.go
@@ -213,12 +213,6 @@ func (api *BaseAPI) pendingBlock() *types.Block {
 }
 
 func (api *BaseAPI) blockByRPCNumber(number rpc.BlockNumber, tx kv.Tx) (*types.Block, error) {
-	if number == rpc.PendingBlockNumber {
-		if pendingBlock := api.pendingBlock(); pendingBlock != nil {
-			return pendingBlock, nil
-		}
-	}
-
 	n, _, _, err := rpchelper.GetBlockNumber(rpc.BlockNumberOrHashWithNumber(number), tx, api.filters)
 	if err != nil {
 		return nil, err

--- a/cmd/rpcdaemon/commands/eth_api.go
+++ b/cmd/rpcdaemon/commands/eth_api.go
@@ -214,7 +214,9 @@ func (api *BaseAPI) pendingBlock() *types.Block {
 
 func (api *BaseAPI) blockByRPCNumber(number rpc.BlockNumber, tx kv.Tx) (*types.Block, error) {
 	if number == rpc.PendingBlockNumber {
-		return api.pendingBlock(), nil
+		if pendingBlock := api.pendingBlock(); pendingBlock != nil {
+			return pendingBlock, nil
+		}
 	}
 
 	n, _, _, err := rpchelper.GetBlockNumber(rpc.BlockNumberOrHashWithNumber(number), tx, api.filters)


### PR DESCRIPTION
In some scenarios we are always returning nil as pending block number, while in `rpchelper.GetBlockByNumber` will return the latest block inside of our cache which we never get to do because of the initial if statement.