### PR TITLE
Fix eth_subscribe_test timeout on CI

### DIFF
--- a/cmd/rpcdaemon/commands/eth_subscribe_test.go
+++ b/cmd/rpcdaemon/commands/eth_subscribe_test.go
@@ -1,17 +1,18 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
-	"github.com/ledgerwatch/erigon-lib/gointerfaces/remote"
+	"github.com/ledgerwatch/erigon-lib/direct"
 	"github.com/ledgerwatch/erigon-lib/gointerfaces/sentry"
-	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/rpcdaemontest"
 	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/rpcservices"
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/core"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/eth/protocols/eth"
+	"github.com/ledgerwatch/erigon/ethdb/privateapi"
 	"github.com/ledgerwatch/erigon/rlp"
 	"github.com/ledgerwatch/erigon/turbo/rpchelper"
 	"github.com/ledgerwatch/erigon/turbo/snapshotsync"
@@ -38,8 +39,10 @@ func TestEthSubscribe(t *testing.T) {
 	}
 	m.ReceiveWg.Wait() // Wait for all messages to be processed before we proceeed
 
-	ctx, conn := rpcdaemontest.CreateTestGrpcConn(t, m)
-	backend := rpcservices.NewRemoteBackend(remote.NewETHBACKENDClient(conn), m.DB, snapshotsync.NewBlockReader())
+	ctx := context.Background()
+	backendServer := privateapi.NewEthBackendServer(ctx, nil, m.DB, m.Notifications.Events, snapshotsync.NewBlockReader(), nil, nil, nil, nil, false)
+	backendClient := direct.NewEthBackendClientDirect(backendServer)
+	backend := rpcservices.NewRemoteBackend(backendClient, m.DB, snapshotsync.NewBlockReader())
 	ff := rpchelper.New(ctx, backend, nil, nil, func() {})
 
 	newHeads := make(chan *types.Header)


### PR DESCRIPTION
Reduce the likelihood of a deadlock caused by goroutine starvation on CI.
The CI macOS runners have 3 cores.
When running other tests in parallel having too few available cores could cause a deadlock.

Test with:

GOMAXPROCS=2 go test ./cmd/rpcdaemon/commands/eth_subscribe_test.go -test.count 100 --timeout 10s

Expected: the command finishes within 3 sec
Before the fix: it timeouts (without a timeout - hangs forever)

CI log:
https://github.com/ledgerwatch/erigon/runs/7104670914?check_suite_focus=true#step:10:53