### PR TITLE
Changing rawdb to blockReader

### DIFF
--- a/cmd/rpcdaemon/commands/eth_call_test.go
+++ b/cmd/rpcdaemon/commands/eth_call_test.go
@@ -180,7 +180,10 @@ func TestGetBlockByTimeMiddle(t *testing.T) {
 	api := NewErigonAPI(NewBaseApi(nil, stateCache, snapshotsync.NewBlockReader(), false), db, nil)
 
 	currentHeader := rawdb.ReadCurrentHeader(tx)
-	oldestHeader := rawdb.ReadHeaderByNumber(tx, 0)
+	oldestHeader, err := api._blockReader.HeaderByNumber(ctx, tx, 0)
+	if err != nil {
+		t.Error("couldn't find olderst header")
+	}
 
 	middleNumber := (currentHeader.Number.Uint64() + oldestHeader.Number.Uint64()) / 2
 	middleBlock, err := rawdb.ReadBlockByNumber(tx, middleNumber)

--- a/cmd/rpcdaemon22/commands/bor_helper.go
+++ b/cmd/rpcdaemon22/commands/bor_helper.go
@@ -2,13 +2,13 @@ package commands
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/consensus/bor"
-	"github.com/ledgerwatch/erigon/core/rawdb"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/crypto"
 	"github.com/ledgerwatch/erigon/params"
@@ -44,7 +44,7 @@ var (
 
 // getHeaderByNumber returns a block's header given a block number ignoring the block's transaction and uncle list (may be faster).
 // derived from erigon_getHeaderByNumber implementation (see ./erigon_block.go)
-func getHeaderByNumber(number rpc.BlockNumber, api *BorImpl, tx kv.Tx) (*types.Header, error) {
+func getHeaderByNumber(ctx context.Context, number rpc.BlockNumber, api *BorImpl, tx kv.Tx) (*types.Header, error) {
 	// Pending block is only known by the miner
 	if number == rpc.PendingBlockNumber {
 		block := api.pendingBlock()
@@ -59,7 +59,10 @@ func getHeaderByNumber(number rpc.BlockNumber, api *BorImpl, tx kv.Tx) (*types.H
 		return nil, err
 	}
 
-	header := rawdb.ReadHeaderByNumber(tx, blockNum)
+	header, err := api._blockReader.HeaderByNumber(ctx, tx, blockNum)
+	if err != nil {
+		return nil, err
+	}
 	if header == nil {
 		return nil, fmt.Errorf("block header not found: %d", blockNum)
 	}
@@ -69,8 +72,8 @@ func getHeaderByNumber(number rpc.BlockNumber, api *BorImpl, tx kv.Tx) (*types.H
 
 // getHeaderByHash returns a block's header given a block's hash.
 // derived from erigon_getHeaderByHash implementation (see ./erigon_block.go)
-func getHeaderByHash(tx kv.Tx, hash common.Hash) (*types.Header, error) {
-	header, err := rawdb.ReadHeaderByHash(tx, hash)
+func getHeaderByHash(ctx context.Context, api *BorImpl, tx kv.Tx, hash common.Hash) (*types.Header, error) {
+	header, err := api._blockReader.HeaderByHash(ctx, tx, hash)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/rpcdaemon22/commands/erigon_block.go
+++ b/cmd/rpcdaemon22/commands/erigon_block.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -35,7 +36,10 @@ func (api *ErigonImpl) GetHeaderByNumber(ctx context.Context, blockNumber rpc.Bl
 		return nil, err
 	}
 
-	header := rawdb.ReadHeaderByNumber(tx, blockNum)
+	header, err := api._blockReader.HeaderByNumber(ctx, tx, blockNum)
+	if err != nil {
+		return nil, err
+	}
 	if header == nil {
 		return nil, fmt.Errorf("block header not found: %d", blockNum)
 	}
@@ -51,7 +55,7 @@ func (api *ErigonImpl) GetHeaderByHash(ctx context.Context, hash common.Hash) (*
 	}
 	defer tx.Rollback()
 
-	header, err := rawdb.ReadHeaderByHash(tx, hash)
+	header, err := api._blockReader.HeaderByHash(ctx, tx, hash)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +79,15 @@ func (api *ErigonImpl) GetBlockByTimestamp(ctx context.Context, timeStamp rpc.Ti
 	currenttHeaderTime := currentHeader.Time
 	highestNumber := currentHeader.Number.Uint64()
 
-	firstHeader := rawdb.ReadHeaderByNumber(tx, 0)
+	firstHeader, err := api._blockReader.HeaderByNumber(ctx, tx, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	if firstHeader == nil {
+		return nil, errors.New("genesis header not found")
+	}
+
 	firstHeaderTime := firstHeader.Time
 
 	if currenttHeaderTime <= uintTimestamp {
@@ -97,12 +109,26 @@ func (api *ErigonImpl) GetBlockByTimestamp(ctx context.Context, timeStamp rpc.Ti
 	}
 
 	blockNum := sort.Search(int(currentHeader.Number.Uint64()), func(blockNum int) bool {
-		currentHeader := rawdb.ReadHeaderByNumber(tx, uint64(blockNum))
+		currentHeader, err := api._blockReader.HeaderByNumber(ctx, tx, uint64(blockNum))
+		if err != nil {
+			return false
+		}
+
+		if currentHeader == nil {
+			return false
+		}
 
 		return currentHeader.Time >= uintTimestamp
 	})
 
-	resultingHeader := rawdb.ReadHeaderByNumber(tx, uint64(blockNum))
+	resultingHeader, err := api._blockReader.HeaderByNumber(ctx, tx, uint64(blockNum))
+	if err != nil {
+		return nil, err
+	}
+
+	if resultingHeader == nil {
+		return nil, fmt.Errorf("no header found with block num %d", blockNum)
+	}
 
 	if resultingHeader.Time > uintTimestamp {
 		response, err := buildBlockResponse(tx, uint64(blockNum)-1, fullTx)

--- a/cmd/rpcdaemon22/commands/eth_call_test.go
+++ b/cmd/rpcdaemon22/commands/eth_call_test.go
@@ -174,7 +174,10 @@ func TestGetBlockByTimeMiddle(t *testing.T) {
 	api := NewErigonAPI(NewBaseApi(nil, stateCache, snapshotsync.NewBlockReader(), nil, nil, false), db, nil)
 
 	currentHeader := rawdb.ReadCurrentHeader(tx)
-	oldestHeader := rawdb.ReadHeaderByNumber(tx, 0)
+	oldestHeader, err := api._blockReader.HeaderByNumber(ctx, tx, 0)
+	if err != nil {
+		t.Error("error getting oldest header")
+	}
 
 	middleNumber := (currentHeader.Number.Uint64() + oldestHeader.Number.Uint64()) / 2
 	middleBlock, err := rawdb.ReadBlockByNumber(tx, middleNumber)


### PR DESCRIPTION
Because we switched to using snapshots, sometimes we are missing headers inside of db that are inside of snapshots so I am changing from `rawdb.ReadHeader` to `api._blockReader.ReadHeader` which reads from snapshots fixing the issue #4599 