### PR TITLE
Support "latests block number" in Oracle Backend

### DIFF
--- a/cmd/rpcdaemon/commands/eth_api.go
+++ b/cmd/rpcdaemon/commands/eth_api.go
@@ -222,6 +222,14 @@ func (api *BaseAPI) blockByRPCNumber(number rpc.BlockNumber, tx kv.Tx) (*types.B
 	return block, err
 }
 
+func (api *BaseAPI) headerByRPCNumber(number rpc.BlockNumber, tx kv.Tx) (*types.Header, error) {
+	n, h, _, err := rpchelper.GetBlockNumber(rpc.BlockNumberOrHashWithNumber(number), tx, api.filters)
+	if err != nil {
+		return nil, err
+	}
+	return api._blockReader.Header(context.Background(), tx, h, n)
+}
+
 // APIImpl is implementation of the EthAPI interface based on remote Db access
 type APIImpl struct {
 	*BaseAPI

--- a/cmd/rpcdaemon/commands/eth_system.go
+++ b/cmd/rpcdaemon/commands/eth_system.go
@@ -201,7 +201,11 @@ func NewGasPriceOracleBackend(tx kv.Tx, cc *params.ChainConfig, baseApi *BaseAPI
 }
 
 func (b *GasPriceOracleBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error) {
-	header, err := b.baseApi._blockReader.HeaderByNumber(ctx, b.tx, uint64(number.Int64()))
+	blockNumber, hash, _, err := rpchelper.GetCanonicalBlockNumber(rpc.BlockNumberOrHash{BlockNumber: &number}, b.tx, nil) // DoCall cannot be executed on non-canonical blocks
+	if err != nil {
+		return nil, err
+	}
+	header, err := b.baseApi._blockReader.Header(ctx, b.tx, hash, blockNumber)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/rpcdaemon/commands/eth_system.go
+++ b/cmd/rpcdaemon/commands/eth_system.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon/common"
@@ -15,7 +14,6 @@ import (
 	"github.com/ledgerwatch/erigon/params"
 	"github.com/ledgerwatch/erigon/rpc"
 	"github.com/ledgerwatch/erigon/turbo/rpchelper"
-	"github.com/ledgerwatch/log/v3"
 )
 
 // BlockNumber implements eth_blockNumber. Returns the block number of most recent block.
@@ -201,19 +199,13 @@ func NewGasPriceOracleBackend(tx kv.Tx, cc *params.ChainConfig, baseApi *BaseAPI
 }
 
 func (b *GasPriceOracleBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error) {
-	blockNumber, hash, _, err := rpchelper.GetCanonicalBlockNumber(rpc.BlockNumberOrHash{BlockNumber: &number}, b.tx, nil) // DoCall cannot be executed on non-canonical blocks
-	if err != nil {
-		return nil, err
-	}
-	header, err := b.baseApi._blockReader.Header(ctx, b.tx, hash, blockNumber)
+	header, err := b.baseApi.headerByRPCNumber(number, b.tx)
 	if err != nil {
 		return nil, err
 	}
 	if header == nil {
-		log.Info("HeaderByNumber2", "is_nil", header == nil, "type", fmt.Sprintf("%T", b.baseApi._blockReader))
 		return nil, nil
 	}
-	log.Info("HeaderByNumber", "is_nil", header == nil)
 	return header, nil
 }
 func (b *GasPriceOracleBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Block, error) {

--- a/cmd/rpcdaemon/commands/eth_system.go
+++ b/cmd/rpcdaemon/commands/eth_system.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon/common"
@@ -205,7 +206,7 @@ func (b *GasPriceOracleBackend) HeaderByNumber(ctx context.Context, number rpc.B
 		return nil, err
 	}
 	if header == nil {
-		log.Info("HeaderByNumber2", "is_nil", header == nil)
+		log.Info("HeaderByNumber2", "is_nil", header == nil, "type", fmt.Sprintf("%T", b.baseApi._blockReader))
 		return nil, nil
 	}
 	log.Info("HeaderByNumber", "is_nil", header == nil)

--- a/cmd/rpcdaemon/commands/eth_system.go
+++ b/cmd/rpcdaemon/commands/eth_system.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ledgerwatch/erigon/params"
 	"github.com/ledgerwatch/erigon/rpc"
 	"github.com/ledgerwatch/erigon/turbo/rpchelper"
+	"github.com/ledgerwatch/log/v3"
 )
 
 // BlockNumber implements eth_blockNumber. Returns the block number of most recent block.
@@ -204,8 +205,10 @@ func (b *GasPriceOracleBackend) HeaderByNumber(ctx context.Context, number rpc.B
 		return nil, err
 	}
 	if header == nil {
+		log.Info("HeaderByNumber2", "is_nil", header == nil)
 		return nil, nil
 	}
+	log.Info("HeaderByNumber", "is_nil", header == nil)
 	return header, nil
 }
 func (b *GasPriceOracleBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Block, error) {

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -119,6 +119,7 @@ func NewOracle(backend OracleBackend, params Config) *Oracle {
 func (gpo *Oracle) SuggestTipCap(ctx context.Context) (*big.Int, error) {
 	head, _ := gpo.backend.HeaderByNumber(ctx, rpc.LatestBlockNumber)
 	if head == nil {
+		log.Info("SuggestTipCap1", "gpo.lastPrice", gpo.lastPrice)
 		return gpo.lastPrice, nil
 	}
 	headHash := head.Hash()
@@ -128,6 +129,7 @@ func (gpo *Oracle) SuggestTipCap(ctx context.Context) (*big.Int, error) {
 	lastHead, lastPrice := gpo.lastHead, gpo.lastPrice
 	gpo.cacheLock.RUnlock()
 	if headHash == lastHead {
+		log.Info("SuggestTipCap2", "lastPrice", lastPrice)
 		return lastPrice, nil
 	}
 
@@ -136,6 +138,7 @@ func (gpo *Oracle) SuggestTipCap(ctx context.Context) (*big.Int, error) {
 	lastHead, lastPrice = gpo.lastHead, gpo.lastPrice
 	gpo.cacheLock.RUnlock()
 	if headHash == lastHead {
+		log.Info("SuggestTipCap3", "lastPrice", lastPrice)
 		return lastPrice, nil
 	}
 	number := head.Number.Uint64()
@@ -167,6 +170,7 @@ func (gpo *Oracle) SuggestTipCap(ctx context.Context) (*big.Int, error) {
 	gpo.lastHead = headHash
 	gpo.lastPrice = price
 	gpo.cacheLock.Unlock()
+	log.Info("SuggestTipCap4", "price", price)
 	return price, nil
 }
 

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -117,7 +117,10 @@ func NewOracle(backend OracleBackend, params Config) *Oracle {
 // NODE: if caller wants legacy tx SuggestedPrice, we need to add
 // baseFee to the returned bigInt
 func (gpo *Oracle) SuggestTipCap(ctx context.Context) (*big.Int, error) {
-	head, _ := gpo.backend.HeaderByNumber(ctx, rpc.LatestBlockNumber)
+	head, err := gpo.backend.HeaderByNumber(ctx, rpc.LatestBlockNumber)
+	if err != nil {
+		return gpo.lastPrice, err
+	}
 	if head == nil {
 		log.Info("SuggestTipCap1", "gpo.lastPrice", gpo.lastPrice)
 		return gpo.lastPrice, nil

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -170,7 +170,6 @@ func (gpo *Oracle) SuggestTipCap(ctx context.Context) (*big.Int, error) {
 	gpo.lastHead = headHash
 	gpo.lastPrice = price
 	gpo.cacheLock.Unlock()
-	log.Info("SuggestTipCap4", "price", price)
 	return price, nil
 }
 

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -122,7 +122,6 @@ func (gpo *Oracle) SuggestTipCap(ctx context.Context) (*big.Int, error) {
 		return gpo.lastPrice, err
 	}
 	if head == nil {
-		log.Info("SuggestTipCap1", "gpo.lastPrice", gpo.lastPrice)
 		return gpo.lastPrice, nil
 	}
 	headHash := head.Hash()
@@ -132,7 +131,6 @@ func (gpo *Oracle) SuggestTipCap(ctx context.Context) (*big.Int, error) {
 	lastHead, lastPrice := gpo.lastHead, gpo.lastPrice
 	gpo.cacheLock.RUnlock()
 	if headHash == lastHead {
-		log.Info("SuggestTipCap2", "lastPrice", lastPrice)
 		return lastPrice, nil
 	}
 
@@ -141,7 +139,6 @@ func (gpo *Oracle) SuggestTipCap(ctx context.Context) (*big.Int, error) {
 	lastHead, lastPrice = gpo.lastHead, gpo.lastPrice
 	gpo.cacheLock.RUnlock()
 	if headHash == lastHead {
-		log.Info("SuggestTipCap3", "lastPrice", lastPrice)
 		return lastPrice, nil
 	}
 	number := head.Number.Uint64()

--- a/turbo/snapshotsync/block_reader.go
+++ b/turbo/snapshotsync/block_reader.go
@@ -250,7 +250,7 @@ func (back *BlockReaderWithSnapshots) HeaderByNumber(ctx context.Context, tx kv.
 		return nil, err
 	}
 	if ok {
-		log.Info("HeaderByNumber", "blockHeight", blockHeight, "is_nil", h == nil)
+		log.Info("HeaderByNumber2", "blockHeight", blockHeight, "is_nil", h == nil)
 		return h, nil
 	}
 	h = rawdb.ReadHeaderByNumber(tx, blockHeight)

--- a/turbo/snapshotsync/block_reader.go
+++ b/turbo/snapshotsync/block_reader.go
@@ -250,6 +250,7 @@ func (back *BlockReaderWithSnapshots) HeaderByNumber(ctx context.Context, tx kv.
 		return nil, err
 	}
 	if ok {
+		log.Info("HeaderByNumber", "blockHeight", blockHeight, "is_nil", h == nil)
 		return h, nil
 	}
 	h = rawdb.ReadHeaderByNumber(tx, blockHeight)

--- a/turbo/snapshotsync/block_reader.go
+++ b/turbo/snapshotsync/block_reader.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ledgerwatch/erigon/core/rawdb"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/rlp"
-	"github.com/ledgerwatch/log/v3"
 )
 
 // BlockReader can read blocks from db and snapshots
@@ -250,11 +249,9 @@ func (back *BlockReaderWithSnapshots) HeaderByNumber(ctx context.Context, tx kv.
 		return nil, err
 	}
 	if ok {
-		log.Info("HeaderByNumber2", "blockHeight", blockHeight, "is_nil", h == nil)
 		return h, nil
 	}
 	h = rawdb.ReadHeaderByNumber(tx, blockHeight)
-	log.Info("HeaderByNumber", "blockHeight", blockHeight, "is_nil", h == nil)
 	return h, nil
 }
 

--- a/turbo/snapshotsync/block_reader.go
+++ b/turbo/snapshotsync/block_reader.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ledgerwatch/erigon/core/rawdb"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/rlp"
+	"github.com/ledgerwatch/log/v3"
 )
 
 // BlockReader can read blocks from db and snapshots
@@ -251,7 +252,9 @@ func (back *BlockReaderWithSnapshots) HeaderByNumber(ctx context.Context, tx kv.
 	if ok {
 		return h, nil
 	}
-	return rawdb.ReadHeaderByNumber(tx, blockHeight), nil
+	h = rawdb.ReadHeaderByNumber(tx, blockHeight)
+	log.Info("HeaderByNumber", "blockHeight", blockHeight, "is_nil", h == nil)
+	return h, nil
 }
 
 // HeaderByHash - will search header in all snapshots starting from recent


### PR DESCRIPTION
It was regression from https://github.com/ledgerwatch/erigon/pull/4528 which caused uin64 underflow (PendingBlock=-1 was converted to uint64)
