### PR TITLE
Fix for issue 4205 (optimize eth_getLogs)

### DIFF
--- a/cmd/rpcdaemon/commands/eth_receipts.go
+++ b/cmd/rpcdaemon/commands/eth_receipts.go
@@ -191,7 +191,7 @@ func (api *APIImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria) ([
 		}
 
 		body, err := api._blockReader.BodyWithTransactions(ctx, tx, blockHash, blockNumber)
-		if body == nil {
+		if err != nil || body == nil {
 			return nil, fmt.Errorf("block not found %d", blockNumber)
 		}
 		for _, log := range blockLogs {

--- a/cmd/rpcdaemon/commands/eth_receipts.go
+++ b/cmd/rpcdaemon/commands/eth_receipts.go
@@ -190,7 +190,7 @@ func (api *APIImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria) ([
 			return nil, err
 		}
 
-		body := rawdb.ReadCanonicalBodyWithTransactions(tx, blockHash, blockNumber)
+		body, err := api._blockReader.BodyWithTransactions(ctx, tx, blockHash, blockNumber)
 		if body == nil {
 			return nil, fmt.Errorf("block not found %d", blockNumber)
 		}


### PR DESCRIPTION
I used `rawdb.ReadCanonicalBodyWithTransactions` to get the list of Transactions associated with the block hash and number. Then used the `txLogIndex` for the particular transaction. Apart from the overhead of using the `api` compared to `rawdb`, I do not see any other optimization. Did I do it wrong?