### PR TITLE
Additional bor RPC fixes

### DIFF
--- a/cmd/rpcdaemon/commands/eth_api.go
+++ b/cmd/rpcdaemon/commands/eth_api.go
@@ -339,6 +339,30 @@ func newRPCTransaction(tx types.Transaction, blockHash common.Hash, blockNumber 
 	return result
 }
 
+// newRPCBorTransaction returns a Bor transaction that will serialize to the RPC
+// representation, with the given location metadata set (if available).
+func newRPCBorTransaction(opaqueTx types.Transaction, txHash common.Hash, blockHash common.Hash, blockNumber uint64, index uint64, baseFee *big.Int) *RPCTransaction {
+	tx := opaqueTx.(*types.LegacyTx)
+	result := &RPCTransaction{
+		Type:     hexutil.Uint64(tx.Type()),
+		ChainID:  (*hexutil.Big)(new(big.Int)),
+		GasPrice: (*hexutil.Big)(tx.GasPrice.ToBig()),
+		Gas:      hexutil.Uint64(tx.GetGas()),
+		Hash:     txHash,
+		Input:    hexutil.Bytes(tx.GetData()),
+		Nonce:    hexutil.Uint64(tx.GetNonce()),
+		From:     common.Address{},
+		To:       tx.GetTo(),
+		Value:    (*hexutil.Big)(tx.GetValue().ToBig()),
+	}
+	if blockHash != (common.Hash{}) {
+		result.BlockHash = &blockHash
+		result.BlockNumber = (*hexutil.Big)(new(big.Int).SetUint64(blockNumber))
+		result.TransactionIndex = (*hexutil.Uint64)(&index)
+	}
+	return result
+}
+
 // newRPCPendingTransaction returns a pending transaction that will serialize to the RPC representation
 func newRPCPendingTransaction(tx types.Transaction, current *types.Header, config *params.ChainConfig) *RPCTransaction {
 	var baseFee *big.Int

--- a/cmd/rpcdaemon/commands/eth_block.go
+++ b/cmd/rpcdaemon/commands/eth_block.go
@@ -219,10 +219,7 @@ func (api *APIImpl) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber
 	var borTx types.Transaction
 	var borTxHash common.Hash
 	if chainConfig.Bor != nil {
-		borTx, _, _, _, err = rawdb.ReadBorTransactionWithBlockNumberAndHash(tx, b.NumberU64(), b.Hash())
-		if err != nil {
-			return nil, err
-		}
+		borTx, _, _, _ = rawdb.ReadBorTransactionForBlock(tx, b)
 		if borTx != nil {
 			borTxHash = types.ComputeBorTxHash(b.NumberU64(), b.Hash())
 		}
@@ -282,10 +279,7 @@ func (api *APIImpl) GetBlockByHash(ctx context.Context, numberOrHash rpc.BlockNu
 	var borTx types.Transaction
 	var borTxHash common.Hash
 	if chainConfig.Bor != nil {
-		borTx, _, _, _, err = rawdb.ReadBorTransactionWithBlockNumberAndHash(tx, block.NumberU64(), block.Hash())
-		if err != nil {
-			return nil, err
-		}
+		borTx, _, _, _ = rawdb.ReadBorTransactionForBlock(tx, block)
 		if borTx != nil {
 			borTxHash = types.ComputeBorTxHash(block.NumberU64(), block.Hash())
 		}

--- a/cmd/rpcdaemon/commands/eth_receipts.go
+++ b/cmd/rpcdaemon/commands/eth_receipts.go
@@ -301,7 +301,7 @@ func (api *APIImpl) GetTransactionReceipt(ctx context.Context, txnHash common.Ha
 			return nil, nil
 		}
 
-		borTx, blockHash, _, _, err := rawdb.ReadBorTransactionWithBlockNumber(tx, blockNum)
+		borTx, blockHash, _, _, err := rawdb.ReadBorTransactionForBlockNumber(tx, blockNum)
 		if err != nil {
 			return nil, err
 		}
@@ -360,10 +360,7 @@ func (api *APIImpl) GetBlockReceipts(ctx context.Context, number rpc.BlockNumber
 	}
 
 	if chainConfig.Bor != nil {
-		borTx, _, _, _, err := rawdb.ReadBorTransactionWithBlockNumberAndHash(tx, blockNum, block.Hash())
-		if err != nil {
-			return nil, err
-		}
+		borTx, _, _, _ := rawdb.ReadBorTransactionForBlock(tx, block)
 		if borTx != nil {
 			borReceipt := rawdb.ReadBorReceipt(tx, block.Hash(), blockNum)
 			if borReceipt != nil {

--- a/cmd/rpcdaemon/commands/eth_txs.go
+++ b/cmd/rpcdaemon/commands/eth_txs.go
@@ -64,10 +64,7 @@ func (api *APIImpl) GetTransactionByHash(ctx context.Context, txnHash common.Has
 			if chainConfig.Bor == nil {
 				return nil, nil
 			}
-			borTx, _, _, _, err := rawdb.ReadBorTransactionWithBlockNumberAndHash(tx, blockNum, block.Hash())
-			if err != nil {
-				return nil, err
-			}
+			borTx, _, _, _ := rawdb.ReadBorTransactionForBlock(tx, block)
 			if borTx == nil {
 				return nil, nil
 			}
@@ -182,10 +179,7 @@ func (api *APIImpl) GetTransactionByBlockHashAndIndex(ctx context.Context, block
 		if chainConfig.Bor == nil {
 			return nil, nil // not error
 		}
-		borTx, _, _, _, err := rawdb.ReadBorTransactionWithBlockNumberAndHash(tx, block.NumberU64(), block.Hash())
-		if err != nil {
-			return nil, err
-		}
+		borTx, _, _, _ := rawdb.ReadBorTransactionForBlock(tx, block)
 		if borTx == nil {
 			return nil, nil // not error
 		}
@@ -249,10 +243,7 @@ func (api *APIImpl) GetTransactionByBlockNumberAndIndex(ctx context.Context, blo
 		if chainConfig.Bor == nil {
 			return nil, nil // not error
 		}
-		borTx, _, _, _, err := rawdb.ReadBorTransactionWithBlockNumberAndHash(tx, blockNum, block.Hash())
-		if err != nil {
-			return nil, err
-		}
+		borTx, _, _, _ := rawdb.ReadBorTransactionForBlock(tx, block)
 		if borTx == nil {
 			return nil, nil
 		}

--- a/cmd/rpcdaemon/commands/eth_txs.go
+++ b/cmd/rpcdaemon/commands/eth_txs.go
@@ -18,7 +18,7 @@ import (
 )
 
 // GetTransactionByHash implements eth_getTransactionByHash. Returns information about a transaction given the transaction's hash.
-func (api *APIImpl) GetTransactionByHash(ctx context.Context, hash common.Hash) (*RPCTransaction, error) {
+func (api *APIImpl) GetTransactionByHash(ctx context.Context, txnHash common.Hash) (*RPCTransaction, error) {
 	tx, err := api.db.BeginRo(ctx)
 	if err != nil {
 		return nil, err
@@ -30,7 +30,7 @@ func (api *APIImpl) GetTransactionByHash(ctx context.Context, hash common.Hash) 
 	}
 
 	// https://infura.io/docs/ethereum/json-rpc/eth-getTransactionByHash
-	blockNum, ok, err := api.txnLookup(ctx, tx, hash)
+	blockNum, ok, err := api.txnLookup(ctx, tx, txnHash)
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +46,7 @@ func (api *APIImpl) GetTransactionByHash(ctx context.Context, hash common.Hash) 
 		var txnIndex uint64
 		var txn types2.Transaction
 		for i, transaction := range block.Transactions() {
-			if transaction.Hash() == hash {
+			if transaction.Hash() == txnHash {
 				txn = transaction
 				txnIndex = uint64(i)
 				break
@@ -61,17 +61,17 @@ func (api *APIImpl) GetTransactionByHash(ctx context.Context, hash common.Hash) 
 
 		// if no transaction was found then we return nil
 		if txn == nil {
-			if chainConfig.Bor != nil {
-				borTx, _, _, _, err := rawdb.ReadBorTransactionWithBlockNumberAndHash(tx, blockNum, block.Hash())
-				if err != nil {
-					return nil, err
-				}
-				if borTx != nil {
-					return newRPCTransaction(borTx, blockHash, blockNum, uint64(len(block.Transactions())), baseFee), nil
-				}
+			if chainConfig.Bor == nil {
+				return nil, nil
 			}
-
-			return nil, nil
+			borTx, _, _, _, err := rawdb.ReadBorTransactionWithBlockNumberAndHash(tx, blockNum, block.Hash())
+			if err != nil {
+				return nil, err
+			}
+			if borTx == nil {
+				return nil, nil
+			}
+			return newRPCBorTransaction(borTx, txnHash, blockHash, blockNum, uint64(len(block.Transactions())), baseFee), nil
 		}
 
 		return newRPCTransaction(txn, blockHash, blockNum, txnIndex, baseFee), nil
@@ -83,7 +83,7 @@ func (api *APIImpl) GetTransactionByHash(ctx context.Context, hash common.Hash) 
 	}
 
 	// No finalized transaction, try to retrieve it from the pool
-	reply, err := api.txPool.Transactions(ctx, &txpool.TransactionsRequest{Hashes: []*types.H256{gointerfaces.ConvertHashToH256(hash)}})
+	reply, err := api.txPool.Transactions(ctx, &txpool.TransactionsRequest{Hashes: []*types.H256{gointerfaces.ConvertHashToH256(txnHash)}})
 	if err != nil {
 		return nil, err
 	}
@@ -179,17 +179,18 @@ func (api *APIImpl) GetTransactionByBlockHashAndIndex(ctx context.Context, block
 	if uint64(txIndex) > uint64(len(txs)) {
 		return nil, nil // not error
 	} else if uint64(txIndex) == uint64(len(txs)) {
-		if chainConfig.Bor != nil {
-			borTx, _, _, _, err := rawdb.ReadBorTransactionWithBlockNumberAndHash(tx, block.NumberU64(), block.Hash())
-			if err != nil {
-				return nil, err
-			}
-			if borTx != nil {
-				return newRPCTransaction(borTx, block.Hash(), block.NumberU64(), uint64(txIndex), block.BaseFee()), nil
-			}
-		} else {
+		if chainConfig.Bor == nil {
 			return nil, nil // not error
 		}
+		borTx, _, _, _, err := rawdb.ReadBorTransactionWithBlockNumberAndHash(tx, block.NumberU64(), block.Hash())
+		if err != nil {
+			return nil, err
+		}
+		if borTx == nil {
+			return nil, nil // not error
+		}
+		derivedBorTxHash := types2.ComputeBorTxHash(block.NumberU64(), block.Hash())
+		return newRPCBorTransaction(borTx, derivedBorTxHash, block.Hash(), block.NumberU64(), uint64(txIndex), block.BaseFee()), nil
 	}
 
 	return newRPCTransaction(txs[txIndex], block.Hash(), block.NumberU64(), uint64(txIndex), block.BaseFee()), nil
@@ -245,17 +246,18 @@ func (api *APIImpl) GetTransactionByBlockNumberAndIndex(ctx context.Context, blo
 	if uint64(txIndex) > uint64(len(txs)) {
 		return nil, nil // not error
 	} else if uint64(txIndex) == uint64(len(txs)) {
-		if chainConfig.Bor != nil {
-			borTx, _, _, _, err := rawdb.ReadBorTransactionWithBlockNumberAndHash(tx, blockNum, block.Hash())
-			if err != nil {
-				return nil, err
-			}
-			if borTx != nil {
-				return newRPCTransaction(borTx, block.Hash(), block.NumberU64(), uint64(txIndex), block.BaseFee()), nil
-			}
-		} else {
+		if chainConfig.Bor == nil {
 			return nil, nil // not error
 		}
+		borTx, _, _, _, err := rawdb.ReadBorTransactionWithBlockNumberAndHash(tx, blockNum, block.Hash())
+		if err != nil {
+			return nil, err
+		}
+		if borTx == nil {
+			return nil, nil
+		}
+		derivedBorTxHash := types2.ComputeBorTxHash(block.NumberU64(), block.Hash())
+		return newRPCBorTransaction(borTx, derivedBorTxHash, block.Hash(), block.NumberU64(), uint64(txIndex), block.BaseFee()), nil
 	}
 
 	return newRPCTransaction(txs[txIndex], block.Hash(), block.NumberU64(), uint64(txIndex), block.BaseFee()), nil

--- a/cmd/rpcdaemon22/commands/eth_receipts.go
+++ b/cmd/rpcdaemon22/commands/eth_receipts.go
@@ -305,7 +305,7 @@ func (api *APIImpl) GetTransactionReceipt(ctx context.Context, hash common.Hash)
 			return nil, nil
 		}
 
-		borTx, blockHash, _, _, err := rawdb.ReadBorTransactionWithBlockNumber(tx, blockNum)
+		borTx, blockHash, _, _, err := rawdb.ReadBorTransactionForBlockNumber(tx, blockNum)
 		if err != nil {
 			return nil, err
 		}

--- a/core/rawdb/bor_receipts.go
+++ b/core/rawdb/bor_receipts.go
@@ -18,7 +18,7 @@ var (
 
 // HasBorReceipt verifies the existence of all block receipt belonging
 // to a block.
-func HasBorReceipts(db kv.Has, hash common.Hash, number uint64) bool {
+func HasBorReceipts(db kv.Has, number uint64) bool {
 	if has, err := db.Has(kv.BorReceipts, borReceiptKey(number)); !has || err != nil {
 		return false
 	}
@@ -140,7 +140,7 @@ func ReadBorTransactionWithBlockHash(db kv.Tx, borTxHash common.Hash, blockHash 
 }
 */
 
-// ReadBorTransaction retrieves a specific bor (fake) transaction by hash, along with
+// ReadBorTransaction returns a specific bor (fake) transaction by txn hash, along with
 // its added positional metadata.
 func ReadBorTransaction(db kv.Tx, borTxHash common.Hash) (types.Transaction, common.Hash, uint64, uint64, error) {
 	blockNumber, err := ReadTxLookupEntry(db, borTxHash)
@@ -151,12 +151,19 @@ func ReadBorTransaction(db kv.Tx, borTxHash common.Hash) (types.Transaction, com
 		return nil, common.Hash{}, 0, 0, errors.New("missing block number")
 	}
 
-	return ReadBorTransactionWithBlockNumber(db, *blockNumber)
+	return computeBorTransactionForBlockNumber(db, *blockNumber)
 }
 
-// ReadBorTransaction retrieves a specific bor (fake) transaction by block number, along with
+// ReadBorTransactionForBlockNumber returns a bor (fake) transaction by block number, along with
 // its added positional metadata.
-func ReadBorTransactionWithBlockNumber(db kv.Tx, blockNumber uint64) (types.Transaction, common.Hash, uint64, uint64, error) {
+func ReadBorTransactionForBlockNumber(db kv.Tx, blockNumber uint64) (types.Transaction, common.Hash, uint64, uint64, error) {
+	if !HasBorReceipts(db, blockNumber) {
+		return nil, common.Hash{}, 0, 0, nil
+	}
+	return computeBorTransactionForBlockNumber(db, blockNumber)
+}
+
+func computeBorTransactionForBlockNumber(db kv.Tx, blockNumber uint64) (types.Transaction, common.Hash, uint64, uint64, error) {
 	blockHash, err := ReadCanonicalHash(db, blockNumber)
 	if err != nil {
 		return nil, common.Hash{}, 0, 0, err
@@ -165,12 +172,19 @@ func ReadBorTransactionWithBlockNumber(db kv.Tx, blockNumber uint64) (types.Tran
 		return nil, common.Hash{}, 0, 0, errors.New("missing block hash")
 	}
 
-	return ReadBorTransactionWithBlockNumberAndHash(db, blockNumber, blockHash)
+	return computeBorTransactionForBlockNumberAndHash(db, blockNumber, blockHash)
 }
 
-// ReadBorTransactionWithBlockNumberAndHash retrieves a specific bor (fake) transaction by block number and block hash, along with
+// ReadBorTransactionForBlockNumberAndHash returns a bor (fake) transaction by block number and block hash, along with
 // its added positional metadata.
-func ReadBorTransactionWithBlockNumberAndHash(db kv.Tx, blockNumber uint64, blockHash common.Hash) (types.Transaction, common.Hash, uint64, uint64, error) {
+func ReadBorTransactionForBlockNumberAndHash(db kv.Tx, blockNumber uint64, blockHash common.Hash) (types.Transaction, common.Hash, uint64, uint64, error) {
+	if !HasBorReceipts(db, blockNumber) {
+		return nil, common.Hash{}, 0, 0, nil
+	}
+	return computeBorTransactionForBlockNumberAndHash(db, blockNumber, blockHash)
+}
+
+func computeBorTransactionForBlockNumberAndHash(db kv.Tx, blockNumber uint64, blockHash common.Hash) (types.Transaction, common.Hash, uint64, uint64, error) {
 	bodyForStorage, err := ReadStorageBody(db, blockHash, blockNumber)
 	if err != nil {
 		return nil, common.Hash{}, 0, 0, err
@@ -178,6 +192,20 @@ func ReadBorTransactionWithBlockNumberAndHash(db kv.Tx, blockNumber uint64, bloc
 
 	var tx types.Transaction = types.NewBorTransaction()
 	return tx, blockHash, blockNumber, uint64(bodyForStorage.TxAmount), nil
+}
+
+// ReadBorTransactionForBlock retrieves a specific bor (fake) transaction associated with a block, along with
+// its added positional metadata.
+func ReadBorTransactionForBlock(db kv.Tx, block *types.Block) (types.Transaction, common.Hash, uint64, uint64) {
+	if !HasBorReceipts(db, block.NumberU64()) {
+		return nil, common.Hash{}, 0, 0
+	}
+	return computeBorTransactionForBlock(db, block)
+}
+
+func computeBorTransactionForBlock(db kv.Tx, block *types.Block) (types.Transaction, common.Hash, uint64, uint64) {
+	var tx types.Transaction = types.NewBorTransaction()
+	return tx, block.Hash(), block.NumberU64(), uint64(len(block.Transactions()))
 }
 
 // TruncateBorReceipts removes all bor receipt for given block number or newer

--- a/core/types/access_list_tx.go
+++ b/core/types/access_list_tx.go
@@ -566,10 +566,6 @@ func (tx *AccessListTx) FakeSign(address common.Address) (Transaction, error) {
 	return cpy, nil
 }
 
-func (tx *AccessListTx) WithHash(newHash common.Hash) (Transaction, error) {
-	return nil, errors.New("hash is immutable for AccessListTx")
-}
-
 // Hash computes the hash (but not for signatures!)
 func (tx *AccessListTx) Hash() common.Hash {
 	if hash := tx.hash.Load(); hash != nil {

--- a/core/types/dynamic_fee_tx.go
+++ b/core/types/dynamic_fee_tx.go
@@ -463,10 +463,6 @@ func (tx DynamicFeeTransaction) AsMessage(s Signer, baseFee *big.Int, rules *par
 	return msg, err
 }
 
-func (tx *DynamicFeeTransaction) WithHash(newHash common.Hash) (Transaction, error) {
-	return nil, errors.New("hash is immutable for DynamicFeeTransaction")
-}
-
 // Hash computes the hash (but not for signatures!)
 func (tx *DynamicFeeTransaction) Hash() common.Hash {
 	if hash := tx.hash.Load(); hash != nil {

--- a/core/types/legacy_tx.go
+++ b/core/types/legacy_tx.go
@@ -482,12 +482,6 @@ func (tx *LegacyTx) FakeSign(address common.Address) (Transaction, error) {
 	return cpy, nil
 }
 
-func (tx *LegacyTx) WithHash(hash common.Hash) (Transaction, error) {
-	cpy := tx.copy()
-	cpy.hash.Store(&hash)
-	return cpy, nil
-}
-
 // Hash computes the hash (but not for signatures!)
 func (tx *LegacyTx) Hash() common.Hash {
 	if hash := tx.hash.Load(); hash != nil {

--- a/core/types/starknet_tx.go
+++ b/core/types/starknet_tx.go
@@ -170,10 +170,6 @@ func (tx StarknetTransaction) FakeSign(address common.Address) (Transaction, err
 	panic("implement me")
 }
 
-func (tx *StarknetTransaction) WithHash(newHash common.Hash) (Transaction, error) {
-	return nil, errors.New("hash is immutable for StarknetTransaction")
-}
-
 func (tx StarknetTransaction) Hash() common.Hash {
 	if hash := tx.hash.Load(); hash != nil {
 		return *hash.(*common.Hash)

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -65,7 +65,6 @@ type Transaction interface {
 	AsMessage(s Signer, baseFee *big.Int, rules *params.Rules) (Message, error)
 	WithSignature(signer Signer, sig []byte) (Transaction, error)
 	FakeSign(address common.Address) (Transaction, error)
-	WithHash(newHash common.Hash) (Transaction, error)
 	Hash() common.Hash
 	SigningHash(chainID *big.Int) common.Hash
 	Size() common.StorageSize

--- a/turbo/adapter/ethapi/internal.go
+++ b/turbo/adapter/ethapi/internal.go
@@ -2,6 +2,7 @@ package ethapi
 
 // This file stores proxy-objects for `internal` package
 import (
+	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/core"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/internal/ethapi"
@@ -45,8 +46,8 @@ func RPCMarshalBlock(b *types.Block, inclTx bool, fullTx bool, additional map[st
 }
 
 //nolint
-func RPCMarshalBlockEx(b *types.Block, inclTx bool, fullTx bool, borTx types.Transaction, borReceipt *types.Receipt, additional map[string]interface{}) (map[string]interface{}, error) {
-	fields, err := ethapi.RPCMarshalBlockEx(b, inclTx, fullTx, borTx, borReceipt)
+func RPCMarshalBlockEx(b *types.Block, inclTx bool, fullTx bool, borTx types.Transaction, borTxHash common.Hash, additional map[string]interface{}) (map[string]interface{}, error) {
+	fields, err := ethapi.RPCMarshalBlockEx(b, inclTx, fullTx, borTx, borTxHash)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
* Add borTx to `eth_getBlockByHash` response
* Ensure borTxs have correct hashes (computing it if we have to)
* Don't try to derive `RPCTransaction.From` from signature for unsigned (e.g. bor) transactions; default to the zero address
* Derive txHash correctly in `DeriveFieldsForBorLogs`
* Surface borReceipt.Logs in `eth_getLogs`