### PR TITLE
Fix grafana startup in docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ xdg_data_home :=  ~/.local/share
 ifdef XDG_DATA_HOME
 	xdg_data_home = $(XDG_DATA_HOME)
 endif
-xdg_data_home_subdirs = $(xdg_data_home)/erigon $(xdg_data_home)/erigon-grafana $(xdg_data_home)/erigon-prometheus
+xdg_data_home_subdirs = $(xdg_data_home)/erigon $(xdg_data_home)/erigon-prometheus
 
 docker-compose: validate_docker_build_args
 	mkdir -p $(xdg_data_home_subdirs)

--- a/Makefile
+++ b/Makefile
@@ -65,10 +65,15 @@ xdg_data_home :=  ~/.local/share
 ifdef XDG_DATA_HOME
 	xdg_data_home = $(XDG_DATA_HOME)
 endif
-xdg_data_home_subdirs = $(xdg_data_home)/erigon $(xdg_data_home)/erigon-prometheus
+xdg_data_home_subdirs = $(xdg_data_home)/erigon $(xdg_data_home)/erigon-grafana $(xdg_data_home)/erigon-prometheus
 
-docker-compose: validate_docker_build_args
+setup_xdg_data_home:
 	mkdir -p $(xdg_data_home_subdirs)
+	ls -aln $(xdg_data_home) | grep -E "472*0*erigon-grafana" || sudo chown 472:0 $(xdg_data_home)/erigon-grafana
+	@echo "✔️ xdg_data_home setup"
+	@ls -al $(xdg_data_home)
+
+docker-compose: validate_docker_build_args setup_xdg_data_home
 	docker-compose up
 
 # debug build allows see C stack traces, run it with GOTRACEBACK=crash. You don't need debug build for C pit for profiling. To profile C code use SETCGOTRCKEBACK=1

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ xdg_data_home_subdirs = $(xdg_data_home)/erigon $(xdg_data_home)/erigon-grafana 
 
 setup_xdg_data_home:
 	mkdir -p $(xdg_data_home_subdirs)
-	ls -aln $(xdg_data_home) | grep -E "472*0*erigon-grafana" || sudo chown 472:0 $(xdg_data_home)/erigon-grafana
+	ls -aln $(xdg_data_home) | grep -E "472*0*erigon-grafana" || sudo chown -R 472:0 $(xdg_data_home)/erigon-grafana
 	@echo "✔️ xdg_data_home setup"
 	@ls -al $(xdg_data_home)
 

--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ endif
 ifdef DOCKER
 	sudo usermod -aG docker $(ERIGON_USER)
 endif
-	sudo -u $(ERIGON_USER) mkdir -p ~$(ERIGON_USER_XDG_DATA_HOME)
+	sudo -u $(ERIGON_USER) mkdir -p $(ERIGON_USER_XDG_DATA_HOME)
 
 # create "erigon" user
 user_macos:
@@ -206,4 +206,4 @@ user_macos:
 	sudo dscl . -create /Users/$(ERIGON_USER) PrimaryGroupID $(ERIGON_USER_GID)
 	sudo dscl . -create /Users/$(ERIGON_USER) NFSHomeDirectory /Users/$(ERIGON_USER)
 	sudo dscl . -append /Groups/admin GroupMembership $(ERIGON_USER)
-	sudo -u $(ERIGON_USER) mkdir -p ~$(ERIGON_USER_XDG_DATA_HOME)
+	sudo -u $(ERIGON_USER) mkdir -p $(ERIGON_USER_XDG_DATA_HOME)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
 
   grafana:
     image: grafana/grafana:9.0.2
-    user: ${DOCKER_UID}:${DOCKER_GID} # Uses erigon user from Dockerfile
+    user: "472:0" # required for grafana version >= 7.3
     ports: [ "3000:3000" ]
     volumes:
       - ${ERIGON_GRAFANA_CONFIG:-./cmd/prometheus/grafana.ini}:/etc/grafana/grafana.ini


### PR DESCRIPTION
# Issue
Grafana expects to run as user id 472 and group id 0.

https://grafana.com/docs/grafana/latest/setup-grafana/installation/docker/#user-id-changes

# Fix
Specify `user: "472:0"` in `docker-compose.yaml` for `grafana` and modify `Makefile` to update permissions lazily as needed.

# Author
Patch authored by cory.eth (Cory Gabrielsen) (@cory_eth)