### PR TITLE
use nested datadir/network path for db supporting legacy

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -32,13 +33,14 @@ import (
 	"github.com/c2h5oh/datasize"
 	"github.com/ledgerwatch/erigon-lib/kv/kvcache"
 	"github.com/ledgerwatch/erigon-lib/txpool"
-	"github.com/ledgerwatch/erigon/cmd/downloader/downloader/downloadercfg"
-	"github.com/ledgerwatch/erigon/node/nodecfg"
-	"github.com/ledgerwatch/erigon/node/nodecfg/datadir"
 	"github.com/ledgerwatch/log/v3"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/urfave/cli"
+
+	"github.com/ledgerwatch/erigon/cmd/downloader/downloader/downloadercfg"
+	"github.com/ledgerwatch/erigon/node/nodecfg"
+	"github.com/ledgerwatch/erigon/node/nodecfg/datadir"
 
 	"github.com/ledgerwatch/erigon/eth/protocols/eth"
 	"github.com/ledgerwatch/erigon/params/networkname"
@@ -1069,28 +1071,45 @@ func DataDirForNetwork(datadir string, network string) string {
 	case networkname.DevChainName:
 		return "" // unless explicitly requested, use memory databases
 	case networkname.RinkebyChainName:
-		return filepath.Join(datadir, "rinkeby")
+		return networkDataDirCheckingLegacy(datadir, "rinkeby")
 	case networkname.GoerliChainName:
-		filepath.Join(datadir, "goerli")
+		return networkDataDirCheckingLegacy(datadir, "goerli")
 	case networkname.KilnDevnetChainName:
-		filepath.Join(datadir, "kiln-devnet")
+		return networkDataDirCheckingLegacy(datadir, "kiln-devnet")
 	case networkname.SokolChainName:
-		return filepath.Join(datadir, "sokol")
+		return networkDataDirCheckingLegacy(datadir, "sokol")
 	case networkname.FermionChainName:
-		return filepath.Join(datadir, "fermion")
+		return networkDataDirCheckingLegacy(datadir, "fermion")
 	case networkname.MumbaiChainName:
-		return filepath.Join(datadir, "mumbai")
+		return networkDataDirCheckingLegacy(datadir, "mumbai")
 	case networkname.BorMainnetChainName:
-		return filepath.Join(datadir, "bor-mainnet")
+		return networkDataDirCheckingLegacy(datadir, "bor-mainnet")
 	case networkname.BorDevnetChainName:
-		return filepath.Join(datadir, "bor-devnet")
+		return networkDataDirCheckingLegacy(datadir, "bor-devnet")
 	case networkname.SepoliaChainName:
-		return filepath.Join(datadir, "sepolia")
+		return networkDataDirCheckingLegacy(datadir, "sepolia")
 	default:
 		return datadir
 	}
+}
 
-	return datadir
+// networkDataDirCheckingLegacy checks if the datadir for the network already exists and uses that if found.
+// if not checks for a LOCK file at the root of the datadir and uses this if found
+// or by default assume a fresh node and to use the nested directory for the network
+func networkDataDirCheckingLegacy(datadir, network string) string {
+	anticipated := filepath.Join(datadir, network)
+
+	if _, err := os.Stat(anticipated); !os.IsNotExist(err) {
+		return anticipated
+	}
+
+	legacyLockFile := filepath.Join(datadir, "LOCK")
+	if _, err := os.Stat(legacyLockFile); !os.IsNotExist(err) {
+		log.Info("Using legacy datadir")
+		return datadir
+	}
+
+	return anticipated
 }
 
 func setDataDir(ctx *cli.Context, cfg *nodecfg.Config) {


### PR DESCRIPTION
Created to solve #884.

It looks like some of this was implemented already, just a couple of missing `return`s for goerli and kiln-devnet.

This is based on the assumption that this change would only be needed by Erigon itself, and that components like rpcdaemon ran separately would point to the correct datadir using a command line flag.  Also an assumption that if a LOCK file exists at the root datadir that it would take precedence over the nested folder to be more backwards compatible?