### PR TITLE
Ensure no in-memory execution when --experimental.overlay=false

### DIFF
--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -587,14 +587,14 @@ func verifyAndSaveNewPoSHeader(
 
 	currentHeadHash := rawdb.ReadHeadHeaderHash(tx)
 	canExtendCanonical := header.ParentHash == currentHeadHash
-	canExtendInMemory := cfg.forkValidator.ExtendingForkHeadHash() == (common.Hash{}) || header.ParentHash == cfg.forkValidator.ExtendingForkHeadHash()
+	canExtendFork := cfg.forkValidator.ExtendingForkHeadHash() == (common.Hash{}) || header.ParentHash == cfg.forkValidator.ExtendingForkHeadHash()
 
 	if !cfg.memoryOverlay && !canExtendCanonical {
 		log.Info("Side chain or something weird", "parentHash", header.ParentHash, "currentHead", currentHeadHash)
 		return &privateapi.PayloadStatus{Status: remote.EngineStatus_ACCEPTED}, true, nil
 	}
 
-	if cfg.memoryOverlay && (canExtendInMemory || !canExtendCanonical) {
+	if cfg.memoryOverlay && (canExtendFork || !canExtendCanonical) {
 		status, latestValidHash, validationError, criticalError := cfg.forkValidator.ValidatePayload(tx, header, body, canExtendCanonical)
 		if criticalError != nil {
 			return &privateapi.PayloadStatus{CriticalError: criticalError}, false, criticalError

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -612,7 +612,7 @@ func verifyAndSaveNewPoSHeader(
 		return nil, false, err
 	}
 
-	if !cfg.memoryOverlay && !canExtendCanonical {
+	if !canExtendCanonical {
 		log.Info("Side chain or something weird", "parentHash", header.ParentHash, "currentHead", currentHeadHash)
 		return &privateapi.PayloadStatus{Status: remote.EngineStatus_ACCEPTED}, true, nil
 	}

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -590,7 +590,7 @@ func verifyAndSaveNewPoSHeader(
 	canExtendInMemory := cfg.forkValidator.ExtendingForkHeadHash() == (common.Hash{}) || header.ParentHash == cfg.forkValidator.ExtendingForkHeadHash()
 
 	if !cfg.memoryOverlay && !canExtendCanonical {
-		log.Debug("Side chain or something weird", "parentHash", header.ParentHash, "currentHead", currentHeadHash)
+		log.Info("Side chain or something weird", "parentHash", header.ParentHash, "currentHead", currentHeadHash)
 		return &privateapi.PayloadStatus{Status: remote.EngineStatus_ACCEPTED}, true, nil
 	}
 


### PR DESCRIPTION
This partially reverts PR #4611