### PR TITLE
checking if we build torrent file

### DIFF
--- a/cmd/downloader/downloader/downloader_grpc_server.go
+++ b/cmd/downloader/downloader/downloader_grpc_server.go
@@ -125,14 +125,14 @@ func seedNewSnapshot(it *proto_downloader.DownloadItem, torrentClient *torrent.C
 // we dont have .seg or .torrent so we get them through the torrent hash
 func createMagnetLinkWithInfoHash(hash *prototypes.H160, torrentClient *torrent.Client, snapDir string) (bool, error) {
 	mi := &metainfo.MetaInfo{AnnounceList: Trackers}
-	var infoHash *metainfo.Hash
+	var infoHash metainfo.Hash
 	if hash != nil {
-		*infoHash = Proto2InfoHash(hash)
-		if _, ok := torrentClient.Torrent(*infoHash); ok {
+		infoHash = Proto2InfoHash(hash)
+		if _, ok := torrentClient.Torrent(infoHash); ok {
 			return true, nil
 		}
 	}
-	magnet := mi.Magnet(infoHash, nil)
+	magnet := mi.Magnet(&infoHash, nil)
 	go func(magnetUrl string) {
 		t, err := torrentClient.AddMagnet(magnetUrl)
 		if err != nil {

--- a/cmd/downloader/downloader/downloader_grpc_server.go
+++ b/cmd/downloader/downloader/downloader_grpc_server.go
@@ -40,6 +40,11 @@ func (s *GrpcServer) Download(ctx context.Context, request *proto_downloader.Dow
 			}
 		}
 
+		if it.TorrentHash == nil {
+			log.Info("Discarding torrent file with no hash")
+			continue
+		}
+
 		hash := Proto2InfoHash(it.TorrentHash)
 		if _, ok := torrentClient.Torrent(hash); ok {
 			continue

--- a/cmd/downloader/downloader/downloader_grpc_server.go
+++ b/cmd/downloader/downloader/downloader_grpc_server.go
@@ -39,13 +39,11 @@ func (s *GrpcServer) Download(ctx context.Context, request *proto_downloader.Dow
 				return nil, err
 			}
 		}
-
-		if it.TorrentHash == nil {
-			log.Info("Discarding torrent file with no hash")
-			continue
+		var hash metainfo.Hash
+		if it.TorrentHash != nil {
+			hash = Proto2InfoHash(it.TorrentHash)
 		}
 
-		hash := Proto2InfoHash(it.TorrentHash)
 		if _, ok := torrentClient.Torrent(hash); ok {
 			continue
 		}

--- a/cmd/downloader/downloader/downloader_grpc_server.go
+++ b/cmd/downloader/downloader/downloader_grpc_server.go
@@ -127,6 +127,7 @@ func createMagnetLinkWithInfoHash(hash *prototypes.H160, torrentClient *torrent.
 	log.Info("[downloader] downloading torrent and seg file")
 	infoHash := Proto2InfoHash(hash)
 	if _, ok := torrentClient.Torrent(infoHash); ok {
+		log.Warn("[downloader] torrent client related to hash found")
 		return true, nil
 	}
 
@@ -147,6 +148,6 @@ func createMagnetLinkWithInfoHash(hash *prototypes.H160, torrentClient *torrent.
 			return
 		}
 	}(magnet.String())
-
+	log.Warn("[downloader] downloaded both seg and torrent files")
 	return false, nil
 }

--- a/cmd/downloader/downloader/downloader_grpc_server.go
+++ b/cmd/downloader/downloader/downloader_grpc_server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/anacrolix/torrent"
 	"github.com/anacrolix/torrent/metainfo"
 	"github.com/ledgerwatch/erigon-lib/gointerfaces"
 	proto_downloader "github.com/ledgerwatch/erigon-lib/gointerfaces/downloader"
@@ -32,50 +33,35 @@ func (s *GrpcServer) Download(ctx context.Context, request *proto_downloader.Dow
 	defer logEvery.Stop()
 
 	torrentClient := s.d.Torrent()
-	mi := &metainfo.MetaInfo{AnnounceList: Trackers}
+	snapDir := s.d.SnapDir()
 	for i, it := range request.Items {
-		var hash *metainfo.Hash
-		if it.TorrentHash == nil { // seed new snapshot
-			if err := BuildTorrentFileIfNeed(it.Path, s.d.SnapDir()); err != nil {
+		var ok bool
+		var err error
+		if it.TorrentHash == nil {
+			// if we dont have the torrent hash then we seed a new snapshot
+			ok, err = seedNewSnapshot(it, torrentClient, snapDir)
+			if err != nil {
 				return nil, err
-			}
-		} else {
-			*hash = Proto2InfoHash(it.TorrentHash)
-			if _, ok := torrentClient.Torrent(*hash); ok {
-				continue
 			}
 		}
 
-		ok, err := AddSegment(it.Path, s.d.SnapDir(), torrentClient)
-		if err != nil {
-			return nil, fmt.Errorf("AddSegment: %w", err)
-		}
 		select {
 		case <-logEvery.C:
-			log.Info("[snpshots] initializing", "files", fmt.Sprintf("%d/%d", i, len(request.Items)))
+			log.Info("[snapshots] initializing", "files", fmt.Sprintf("%d/%d", i, len(request.Items)))
 		default:
 		}
 		if ok {
 			continue
 		}
 
-		magnet := mi.Magnet(hash, nil)
-		go func(magnetUrl string) {
-			t, err := torrentClient.AddMagnet(magnetUrl)
-			if err != nil {
-				log.Warn("[downloader] add magnet link", "err", err)
-				return
-			}
-			t.DisallowDataDownload()
-			t.AllowDataUpload()
-			<-t.GotInfo()
+		ok, err = createMagnetLinkWithInfoHash(it.TorrentHash, torrentClient, snapDir)
+		if err != nil {
+			return nil, err
+		}
 
-			mi := t.Metainfo()
-			if err := CreateTorrentFileIfNotExists(s.d.SnapDir(), t.Info(), &mi); err != nil {
-				log.Warn("[downloader] create torrent file", "err", err)
-				return
-			}
-		}(magnet.String())
+		if ok {
+			continue
+		}
 	}
 	s.d.ReCalcStats(10 * time.Second) // immediately call ReCalc to set stat.Complete flag
 	return &emptypb.Empty{}, nil
@@ -110,4 +96,53 @@ func (s *GrpcServer) Stats(ctx context.Context, request *proto_downloader.StatsR
 
 func Proto2InfoHash(in *prototypes.H160) metainfo.Hash {
 	return gointerfaces.ConvertH160toAddress(in)
+}
+
+func seedNewSnapshot(it *proto_downloader.DownloadItem, torrentClient *torrent.Client, snapDir string) (bool, error) {
+	// if we dont have the torrent file we build it
+	if err := BuildTorrentFileIfNeed(it.Path, snapDir); err != nil {
+		return false, err
+	}
+
+	ok, err := AddSegment(it.Path, snapDir, torrentClient)
+	if err != nil {
+		return false, fmt.Errorf("AddSegment: %w", err)
+	}
+
+	if !ok {
+		return createMagnetLinkWithInfoHash(nil, torrentClient, snapDir)
+	}
+
+	return true, nil
+}
+
+// we dont have .seg or .torrent so we get them through the torrent hash
+func createMagnetLinkWithInfoHash(hash *prototypes.H160, torrentClient *torrent.Client, snapDir string) (bool, error) {
+	mi := &metainfo.MetaInfo{AnnounceList: Trackers}
+	var infoHash *metainfo.Hash
+	if hash != nil {
+		*infoHash = Proto2InfoHash(hash)
+		if _, ok := torrentClient.Torrent(*infoHash); ok {
+			return true, nil
+		}
+	}
+	magnet := mi.Magnet(infoHash, nil)
+	go func(magnetUrl string) {
+		t, err := torrentClient.AddMagnet(magnetUrl)
+		if err != nil {
+			log.Warn("[downloader] add magnet link", "err", err)
+			return
+		}
+		t.DisallowDataDownload()
+		t.AllowDataUpload()
+		<-t.GotInfo()
+
+		mi := t.Metainfo()
+		if err := CreateTorrentFileIfNotExists(snapDir, t.Info(), &mi); err != nil {
+			log.Warn("[downloader] create torrent file", "err", err)
+			return
+		}
+	}(magnet.String())
+
+	return false, nil
 }

--- a/cmd/downloader/downloader/downloader_grpc_server.go
+++ b/cmd/downloader/downloader/downloader_grpc_server.go
@@ -98,21 +98,27 @@ func Proto2InfoHash(in *prototypes.H160) metainfo.Hash {
 	return gointerfaces.ConvertH160toAddress(in)
 }
 
+// decides what we do depending on wether we have the .seg file or the .torrent file
+// have .torrent no .seg => get .seg file from .torrent
+// have .seg no .torrent => get .torrent from .seg
 func seedNewSnapshot(it *proto_downloader.DownloadItem, torrentClient *torrent.Client, snapDir string) (bool, error) {
-	// if we dont have the torrent file we build it
+	// if we dont have the torrent file we build it if we have the .seg file
 	if err := BuildTorrentFileIfNeed(it.Path, snapDir); err != nil {
 		return false, err
 	}
 
+	// we add the .seg file we have and create the .torrent file if we dont have it
 	ok, err := AddSegment(it.Path, snapDir, torrentClient)
 	if err != nil {
 		return false, fmt.Errorf("AddSegment: %w", err)
 	}
 
+	// torrent file already exists so we only add segment and to magnet
 	if !ok {
-		return createMagnetLinkWithInfoHash(nil, torrentClient, snapDir)
+		return false, nil
 	}
 
+	// we skip the item in for loop we already have everything
 	return true, nil
 }
 

--- a/cmd/downloader/downloader/downloader_grpc_server.go
+++ b/cmd/downloader/downloader/downloader_grpc_server.go
@@ -125,12 +125,14 @@ func seedNewSnapshot(it *proto_downloader.DownloadItem, torrentClient *torrent.C
 // we dont have .seg or .torrent so we get them through the torrent hash
 func createMagnetLinkWithInfoHash(hash *prototypes.H160, torrentClient *torrent.Client, snapDir string) (bool, error) {
 	mi := &metainfo.MetaInfo{AnnounceList: Trackers}
-	var infoHash metainfo.Hash
+	var magnet metainfo.Magnet
 	if hash != nil {
-		infoHash = Proto2InfoHash(hash)
+		infoHash := Proto2InfoHash(hash)
 		if _, ok := torrentClient.Torrent(infoHash); ok {
 			return true, nil
 		}
+	} else {
+		magnet = mi.Magnet(nil, nil)
 	}
 	magnet := mi.Magnet(&infoHash, nil)
 	go func(magnetUrl string) {

--- a/cmd/downloader/downloader/downloader_grpc_server.go
+++ b/cmd/downloader/downloader/downloader_grpc_server.go
@@ -50,8 +50,10 @@ func (s *GrpcServer) Download(ctx context.Context, request *proto_downloader.Dow
 			}
 			if ok {
 				log.Debug("[snapshots] already have both seg and torrent file")
-				continue
+			} else {
+				log.Warn("[snapshots] didn't get the seg or the torrent file")
 			}
+			continue
 		}
 
 		_, err := createMagnetLinkWithInfoHash(it.TorrentHash, torrentClient, snapDir)

--- a/cmd/downloader/downloader/downloader_grpc_server.go
+++ b/cmd/downloader/downloader/downloader_grpc_server.go
@@ -125,6 +125,7 @@ func createMagnetLinkWithInfoHash(hash *prototypes.H160, torrentClient *torrent.
 		if _, ok := torrentClient.Torrent(infoHash); ok {
 			return true, nil
 		}
+		magnet = mi.Magnet(&infoHash, nil)
 	} else {
 		magnet = mi.Magnet(nil, nil)
 	}

--- a/cmd/downloader/downloader/downloader_grpc_server.go
+++ b/cmd/downloader/downloader/downloader_grpc_server.go
@@ -49,7 +49,7 @@ func (s *GrpcServer) Download(ctx context.Context, request *proto_downloader.Dow
 				return nil, err
 			}
 			if ok {
-				log.Warn("[snapshots] already have both seg and torrent file")
+				log.Debug("[snapshots] already have both seg and torrent file")
 				continue
 			}
 		}
@@ -124,10 +124,11 @@ func createMagnetLinkWithInfoHash(hash *prototypes.H160, torrentClient *torrent.
 	if hash == nil {
 		return false, nil
 	}
-	log.Info("[downloader] downloading torrent and seg file")
 	infoHash := Proto2InfoHash(hash)
+	log.Debug("[downloader] downloading torrent and seg file", "hash", infoHash)
+
 	if _, ok := torrentClient.Torrent(infoHash); ok {
-		log.Warn("[downloader] torrent client related to hash found")
+		log.Debug("[downloader] torrent client related to hash found", "hash", infoHash)
 		return true, nil
 	}
 
@@ -148,6 +149,6 @@ func createMagnetLinkWithInfoHash(hash *prototypes.H160, torrentClient *torrent.
 			return
 		}
 	}(magnet.String())
-	log.Warn("[downloader] downloaded both seg and torrent files")
+	log.Debug("[downloader] downloaded both seg and torrent files", "hash", infoHash)
 	return false, nil
 }


### PR DESCRIPTION
Sometimes we don't need to build torrent files , which return nil inside of `BuildTorrentFileIfNeed`. This means that sometimes we try to convert a Proto file to an info hash, but we don't have one throwing a nil pointer.