### PR TITLE
Fix index out of range in (*Accumulator) ChangeStorage

### DIFF
--- a/turbo/shards/state_change_accumulator.go
+++ b/turbo/shards/state_change_accumulator.go
@@ -105,6 +105,7 @@ func (a *Accumulator) DeleteAccount(address common.Address) {
 	accountChange.Code = nil
 	accountChange.StorageChanges = nil
 	accountChange.Action = remote.Action_REMOVE
+	delete(a.storageChangeIndex, address)
 }
 
 // ChangeCode adds code to the latest change


### PR DESCRIPTION
Hopefully this helps with the following error:
```
[INFO] [07-18|15:21:34.158] [10/16 CallTraces] Unwind                from=12616632 to=12616589
[INFO] [07-18|15:21:34.252] [8/16 HashState] Unwinding started       from=12616632 to=12616589 storage=false codes=true
[INFO] [07-18|15:21:34.258] [8/16 HashState] Unwinding started       from=12616632 to=12616589 storage=false codes=false
[INFO] [07-18|15:21:34.330] [8/16 HashState] Unwinding started       from=12616632 to=12616589 storage=true codes=false
[INFO] [07-18|15:21:34.414] [9/16 IntermediateHashes] Unwinding of trie hashes from=12616632 to=12616589 csbucket=AccountChangeSet
[INFO] [07-18|15:21:34.440] [9/16 IntermediateHashes] Unwinding of trie hashes from=12616632 to=12616589 csbucket=StorageChangeSet
[INFO] [07-18|15:21:34.903] [9/16 IntermediateHashes] Trie root      hash=0x8369ebd423858226a69a9154e4f67d67383f57542d799c4bbb555b85038e6e4d
[INFO] [07-18|15:21:35.024] [6/16 Execution] Unwind Execution        from=12616632 to=12616589
[EROR] [07-18|15:21:35.160] Staged Sync                              err="runtime error: index out of range [0] with length 0, trace: [stageloop.go:127 panic.go:844 panic.go:89 state_change_accumulator.go:156 stage_execute.go:526 collector.go:265 collector.go:140 stage_execute.go:471 stage_execute.go:429 default_stages.go:88 sync.go:379 sync.go:223 stageloop.go:161 stageloop.go:82 asm_amd64.s:1571]"
```