### PR TITLE
Support block parameter for integration stage_log_index

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -850,7 +850,7 @@ func stageLogIndex(db kv.RwDB, ctx context.Context) error {
 			return err
 		}
 	} else {
-		if err := stagedsync.SpawnLogIndex(s, tx, cfg, ctx); err != nil {
+		if err := stagedsync.SpawnLogIndex(s, tx, cfg, ctx, block); err != nil {
 			return err
 		}
 	}

--- a/eth/stagedsync/default_stages.go
+++ b/eth/stagedsync/default_stages.go
@@ -177,7 +177,7 @@ func DefaultStages(ctx context.Context, sm prune.Mode, headers HeadersCfg, cumul
 			ID:          stages.LogIndex,
 			Description: "Generate receipt logs index",
 			Forward: func(firstCycle bool, badBlockUnwind bool, s *StageState, u Unwinder, tx kv.RwTx) error {
-				return SpawnLogIndex(s, tx, logIndex, ctx)
+				return SpawnLogIndex(s, tx, logIndex, ctx, 0)
 			},
 			Unwind: func(firstCycle bool, u *UnwindState, s *StageState, tx kv.RwTx) error {
 				return UnwindLogIndex(u, s, tx, logIndex, ctx)

--- a/eth/stagedsync/stage_log_index.go
+++ b/eth/stagedsync/stage_log_index.go
@@ -66,7 +66,10 @@ func SpawnLogIndex(s *StageState, tx kv.RwTx, cfg LogIndexCfg, ctx context.Conte
 	if prematureEndBlock != 0 && prematureEndBlock < endBlock {
 		endBlock = prematureEndBlock
 	}
-	if endBlock == s.BlockNumber {
+	// It is possible that prematureEndBlock < s.BlockNumber,
+	// in which case it is important that we skip this stage,
+	// or else we could overwrite stage_at with prematureEndBlock
+	if endBlock <= s.BlockNumber {
 		return nil
 	}
 

--- a/eth/stagedsync/stage_log_index.go
+++ b/eth/stagedsync/stage_log_index.go
@@ -45,7 +45,7 @@ func StageLogIndexCfg(db kv.RwDB, prune prune.Mode, tmpDir string) LogIndexCfg {
 	}
 }
 
-func SpawnLogIndex(s *StageState, tx kv.RwTx, cfg LogIndexCfg, ctx context.Context) error {
+func SpawnLogIndex(s *StageState, tx kv.RwTx, cfg LogIndexCfg, ctx context.Context, prematureEndBlock uint64) error {
 	useExternalTx := tx != nil
 	if !useExternalTx {
 		var err error
@@ -61,6 +61,11 @@ func SpawnLogIndex(s *StageState, tx kv.RwTx, cfg LogIndexCfg, ctx context.Conte
 	if err != nil {
 		return fmt.Errorf("getting last executed block: %w", err)
 	}
+	// if prematureEndBlock is nonzero and less than the latest executed block,
+	// then we only run the log index stage until prematureEndBlock
+	if prematureEndBlock != 0 && prematureEndBlock < endBlock {
+		endBlock = prematureEndBlock
+	}
 	if endBlock == s.BlockNumber {
 		return nil
 	}
@@ -73,8 +78,7 @@ func SpawnLogIndex(s *StageState, tx kv.RwTx, cfg LogIndexCfg, ctx context.Conte
 	if startBlock > 0 {
 		startBlock++
 	}
-
-	if err = promoteLogIndex(logPrefix, tx, startBlock, cfg, ctx); err != nil {
+	if err = promoteLogIndex(logPrefix, tx, startBlock, endBlock, cfg, ctx); err != nil {
 		return err
 	}
 	if err = s.Update(tx, endBlock); err != nil {
@@ -90,7 +94,7 @@ func SpawnLogIndex(s *StageState, tx kv.RwTx, cfg LogIndexCfg, ctx context.Conte
 	return nil
 }
 
-func promoteLogIndex(logPrefix string, tx kv.RwTx, start uint64, cfg LogIndexCfg, ctx context.Context) error {
+func promoteLogIndex(logPrefix string, tx kv.RwTx, start uint64, endBlock uint64, cfg LogIndexCfg, ctx context.Context) error {
 	quit := ctx.Done()
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
@@ -112,6 +116,10 @@ func promoteLogIndex(logPrefix string, tx kv.RwTx, start uint64, cfg LogIndexCfg
 
 	reader := bytes.NewReader(nil)
 
+	if endBlock != 0 {
+		log.Info(fmt.Sprintf("Running LogIndex from blocks %d to %d", start, endBlock), "block", endBlock)
+	}
+
 	for k, v, err := logs.Seek(dbutils.LogKey(start, 0)); k != nil; k, v, err = logs.Next() {
 		if err != nil {
 			return err
@@ -121,6 +129,13 @@ func promoteLogIndex(logPrefix string, tx kv.RwTx, start uint64, cfg LogIndexCfg
 			return err
 		}
 		blockNum := binary.BigEndian.Uint64(k[:8])
+
+		// if endBlock is positive, we only run the stage up until endBlock
+		// if endBlock is zero, we run the stage for all available blocks
+		if endBlock != 0 && blockNum > endBlock {
+			log.Info("Reached user-specified end block", "endBlock", endBlock)
+			break
+		}
 
 		select {
 		default:

--- a/eth/stagedsync/stage_log_index.go
+++ b/eth/stagedsync/stage_log_index.go
@@ -117,7 +117,7 @@ func promoteLogIndex(logPrefix string, tx kv.RwTx, start uint64, endBlock uint64
 	reader := bytes.NewReader(nil)
 
 	if endBlock != 0 {
-		log.Info(fmt.Sprintf("Running LogIndex from blocks %d to %d", start, endBlock), "block", endBlock)
+		log.Info(fmt.Sprintf("[%s] Running from blocks %d to %d", logPrefix, start, endBlock), "endBlock", endBlock)
 	}
 
 	for k, v, err := logs.Seek(dbutils.LogKey(start, 0)); k != nil; k, v, err = logs.Next() {
@@ -133,7 +133,7 @@ func promoteLogIndex(logPrefix string, tx kv.RwTx, start uint64, endBlock uint64
 		// if endBlock is positive, we only run the stage up until endBlock
 		// if endBlock is zero, we run the stage for all available blocks
 		if endBlock != 0 && blockNum > endBlock {
-			log.Info("Reached user-specified end block", "endBlock", endBlock)
+			log.Info(fmt.Sprintf("[%s] Reached user-specified end block", logPrefix), "endBlock", endBlock)
 			break
 		}
 

--- a/eth/stagedsync/stage_log_index_test.go
+++ b/eth/stagedsync/stage_log_index_test.go
@@ -101,7 +101,7 @@ func TestPromoteLogIndex(t *testing.T) {
 	cfgCopy.bufLimit = 10
 	cfgCopy.flushEvery = time.Nanosecond
 
-	err := promoteLogIndex("logPrefix", tx, 0, cfgCopy, ctx)
+	err := promoteLogIndex("logPrefix", tx, 0, 0, cfgCopy, ctx)
 	require.NoError(err)
 
 	// Check indices GetCardinality (in how many blocks they meet)
@@ -127,7 +127,7 @@ func TestPruneLogIndex(t *testing.T) {
 	cfgCopy := cfg
 	cfgCopy.bufLimit = 10
 	cfgCopy.flushEvery = time.Nanosecond
-	err := promoteLogIndex("logPrefix", tx, 0, cfgCopy, ctx)
+	err := promoteLogIndex("logPrefix", tx, 0, 0, cfgCopy, ctx)
 	require.NoError(err)
 
 	// Mode test
@@ -166,7 +166,7 @@ func TestUnwindLogIndex(t *testing.T) {
 	cfgCopy := cfg
 	cfgCopy.bufLimit = 10
 	cfgCopy.flushEvery = time.Nanosecond
-	err := promoteLogIndex("logPrefix", tx, 0, cfgCopy, ctx)
+	err := promoteLogIndex("logPrefix", tx, 0, 0, cfgCopy, ctx)
 	require.NoError(err)
 
 	// Mode test


### PR DESCRIPTION
Integration stage_log_index --block=N is currently ignored. This change ensures that stage_log_index stops at the specified block.