### PR TITLE
Merge range

### DIFF
--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -1371,6 +1371,7 @@ func WaitForDownloader(ctx context.Context, cfg HeadersCfg, tx kv.RwTx) error {
 		}
 		if err := snapshotsync.RequestSnapshotDownload(ctx, downloadRequest, cfg.snapshotDownloader); err != nil {
 			log.Error("[Snapshots] call downloader", "err", err)
+			time.Sleep(10 * time.Second)
 			continue
 		}
 		break

--- a/turbo/snapshotsync/block_reader.go
+++ b/turbo/snapshotsync/block_reader.go
@@ -516,7 +516,7 @@ func (back *BlockReaderWithSnapshots) headerFromSnapshot(blockHeight uint64, sn 
 func (back *BlockReaderWithSnapshots) headerFromSnapshotByHash(hash common.Hash, sn *HeaderSegment, buf []byte) (*types.Header, error) {
 	defer func() {
 		if rec := recover(); rec != nil {
-			panic(fmt.Errorf("%+v, snapshot: %d-%d, trace: %s", rec, sn.From, sn.To, dbg.Stack()))
+			panic(fmt.Errorf("%+v, snapshot: %d-%d, trace: %s", rec, sn.ranges.from, sn.ranges.to, dbg.Stack()))
 		}
 	}() // avoid crash because Erigon's core does many things
 
@@ -564,7 +564,7 @@ func (back *BlockReaderWithSnapshots) bodyFromSnapshot(blockHeight uint64, sn *B
 func (back *BlockReaderWithSnapshots) bodyForStorageFromSnapshot(blockHeight uint64, sn *BodySegment, buf []byte) (*types.BodyForStorage, []byte, error) {
 	defer func() {
 		if rec := recover(); rec != nil {
-			panic(fmt.Errorf("%+v, snapshot: %d-%d, trace: %s", rec, sn.From, sn.To, dbg.Stack()))
+			panic(fmt.Errorf("%+v, snapshot: %d-%d, trace: %s", rec, sn.ranges.from, sn.ranges.to, dbg.Stack()))
 		}
 	}() // avoid crash because Erigon's core does many things
 
@@ -597,7 +597,7 @@ func (back *BlockReaderWithSnapshots) bodyForStorageFromSnapshot(blockHeight uin
 func (back *BlockReaderWithSnapshots) txsFromSnapshot(baseTxnID uint64, txsAmount uint32, txsSeg *TxnSegment, buf []byte) (txs []types.Transaction, senders []common.Address, err error) {
 	defer func() {
 		if rec := recover(); rec != nil {
-			panic(fmt.Errorf("%+v, snapshot: %d-%d, trace: %s", rec, txsSeg.From, txsSeg.To, dbg.Stack()))
+			panic(fmt.Errorf("%+v, snapshot: %d-%d, trace: %s", rec, txsSeg.ranges.from, txsSeg.ranges.to, dbg.Stack()))
 		}
 	}() // avoid crash because Erigon's core does many things
 

--- a/turbo/snapshotsync/block_snapshots.go
+++ b/turbo/snapshotsync/block_snapshots.go
@@ -50,20 +50,20 @@ type DownloadRequest struct {
 type HeaderSegment struct {
 	seg           *compress.Decompressor // value: first_byte_of_header_hash + header_rlp
 	idxHeaderHash *recsplit.Index        // header_hash       -> headers_segment_offset
-	From, To      uint64
+	ranges        MergeRange
 }
 
 type BodySegment struct {
 	seg           *compress.Decompressor // value: rlp(types.BodyForStorage)
 	idxBodyNumber *recsplit.Index        // block_num_u64     -> bodies_segment_offset
-	From, To      uint64
+	ranges        MergeRange
 }
 
 type TxnSegment struct {
 	Seg                 *compress.Decompressor // value: first_byte_of_transaction_hash + sender_address + transaction_rlp
 	IdxTxnHash          *recsplit.Index        // transaction_hash  -> transactions_segment_offset
 	IdxTxnHash2BlockNum *recsplit.Index        // transaction_hash  -> block_number
-	From, To            uint64
+	ranges              MergeRange
 }
 
 func (sn *HeaderSegment) close() {
@@ -79,12 +79,12 @@ func (sn *HeaderSegment) close() {
 
 func (sn *HeaderSegment) reopen(dir string) (err error) {
 	sn.close()
-	fileName := snap.SegmentFileName(sn.From, sn.To, snap.Headers)
+	fileName := snap.SegmentFileName(sn.ranges.from, sn.ranges.to, snap.Headers)
 	sn.seg, err = compress.NewDecompressor(path.Join(dir, fileName))
 	if err != nil {
 		return err
 	}
-	sn.idxHeaderHash, err = recsplit.OpenIndex(path.Join(dir, snap.IdxFileName(sn.From, sn.To, snap.Headers.String())))
+	sn.idxHeaderHash, err = recsplit.OpenIndex(path.Join(dir, snap.IdxFileName(sn.ranges.from, sn.ranges.to, snap.Headers.String())))
 	if err != nil {
 		return err
 	}
@@ -104,12 +104,12 @@ func (sn *BodySegment) close() {
 
 func (sn *BodySegment) reopen(dir string) (err error) {
 	sn.close()
-	fileName := snap.SegmentFileName(sn.From, sn.To, snap.Bodies)
+	fileName := snap.SegmentFileName(sn.ranges.from, sn.ranges.to, snap.Bodies)
 	sn.seg, err = compress.NewDecompressor(path.Join(dir, fileName))
 	if err != nil {
 		return err
 	}
-	sn.idxBodyNumber, err = recsplit.OpenIndex(path.Join(dir, snap.IdxFileName(sn.From, sn.To, snap.Bodies.String())))
+	sn.idxBodyNumber, err = recsplit.OpenIndex(path.Join(dir, snap.IdxFileName(sn.ranges.from, sn.ranges.to, snap.Bodies.String())))
 	if err != nil {
 		return err
 	}
@@ -148,16 +148,16 @@ func (sn *TxnSegment) close() {
 }
 func (sn *TxnSegment) reopen(dir string) (err error) {
 	sn.close()
-	fileName := snap.SegmentFileName(sn.From, sn.To, snap.Transactions)
+	fileName := snap.SegmentFileName(sn.ranges.from, sn.ranges.to, snap.Transactions)
 	sn.Seg, err = compress.NewDecompressor(path.Join(dir, fileName))
 	if err != nil {
 		return err
 	}
-	sn.IdxTxnHash, err = recsplit.OpenIndex(path.Join(dir, snap.IdxFileName(sn.From, sn.To, snap.Transactions.String())))
+	sn.IdxTxnHash, err = recsplit.OpenIndex(path.Join(dir, snap.IdxFileName(sn.ranges.from, sn.ranges.to, snap.Transactions.String())))
 	if err != nil {
 		return err
 	}
-	sn.IdxTxnHash2BlockNum, err = recsplit.OpenIndex(path.Join(dir, snap.IdxFileName(sn.From, sn.To, snap.Transactions2Block.String())))
+	sn.IdxTxnHash2BlockNum, err = recsplit.OpenIndex(path.Join(dir, snap.IdxFileName(sn.ranges.from, sn.ranges.to, snap.Transactions2Block.String())))
 	if err != nil {
 		return err
 	}
@@ -194,7 +194,7 @@ func (s *headerSegments) ViewSegment(blockNum uint64, f func(sn *HeaderSegment) 
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	for _, seg := range s.segments {
-		if !(blockNum >= seg.From && blockNum < seg.To) {
+		if !(blockNum >= seg.ranges.from && blockNum < seg.ranges.to) {
 			continue
 		}
 		return true, f(seg)
@@ -232,7 +232,7 @@ func (s *bodySegments) ViewSegment(blockNum uint64, f func(*BodySegment) error) 
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	for _, seg := range s.segments {
-		if !(blockNum >= seg.From && blockNum < seg.To) {
+		if !(blockNum >= seg.ranges.from && blockNum < seg.ranges.to) {
 			continue
 		}
 		return true, f(seg)
@@ -270,7 +270,7 @@ func (s *txnSegments) ViewSegment(blockNum uint64, f func(*TxnSegment) error) (f
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	for _, seg := range s.segments {
-		if !(blockNum >= seg.From && blockNum < seg.To) {
+		if !(blockNum >= seg.ranges.from && blockNum < seg.ranges.to) {
 			continue
 		}
 		return true, f(seg)
@@ -323,7 +323,7 @@ func (s *RoSnapshots) idxAvailability() uint64 {
 		if seg.idxHeaderHash == nil {
 			continue
 		}
-		headers = seg.To - 1
+		headers = seg.ranges.to - 1
 		break
 	}
 	for i := len(s.Bodies.segments) - 1; i >= 0; i-- {
@@ -331,7 +331,7 @@ func (s *RoSnapshots) idxAvailability() uint64 {
 		if seg.idxBodyNumber == nil {
 			continue
 		}
-		bodies = seg.To - 1
+		bodies = seg.ranges.to - 1
 		break
 	}
 
@@ -340,7 +340,7 @@ func (s *RoSnapshots) idxAvailability() uint64 {
 		if seg.IdxTxnHash == nil || seg.IdxTxnHash2BlockNum == nil {
 			continue
 		}
-		txs = seg.To - 1
+		txs = seg.ranges.to - 1
 		break
 	}
 	return cmp.Min(headers, cmp.Min(bodies, txs))
@@ -422,7 +422,7 @@ func (s *RoSnapshots) Reopen() error {
 	s.Txs.segments = s.Txs.segments[:0]
 	for _, f := range files {
 		{
-			seg := &BodySegment{From: f.From, To: f.To}
+			seg := &BodySegment{ranges: MergeRange{f.From, f.To}}
 			fileName := snap.SegmentFileName(f.From, f.To, snap.Bodies)
 			seg.seg, err = compress.NewDecompressor(path.Join(s.dir, fileName))
 			if err != nil {
@@ -434,7 +434,7 @@ func (s *RoSnapshots) Reopen() error {
 			s.Bodies.segments = append(s.Bodies.segments, seg)
 		}
 		{
-			seg := &HeaderSegment{From: f.From, To: f.To}
+			seg := &HeaderSegment{ranges: MergeRange{f.From, f.To}}
 			fileName := snap.SegmentFileName(f.From, f.To, snap.Headers)
 			seg.seg, err = compress.NewDecompressor(path.Join(s.dir, fileName))
 			if err != nil {
@@ -446,7 +446,7 @@ func (s *RoSnapshots) Reopen() error {
 			s.Headers.segments = append(s.Headers.segments, seg)
 		}
 		{
-			seg := &TxnSegment{From: f.From, To: f.To}
+			seg := &TxnSegment{ranges: MergeRange{f.From, f.To}}
 			fileName := snap.SegmentFileName(f.From, f.To, snap.Transactions)
 			seg.Seg, err = compress.NewDecompressor(path.Join(s.dir, fileName))
 			if err != nil {
@@ -471,23 +471,23 @@ func (s *RoSnapshots) Reopen() error {
 	s.segmentsReady.Store(true)
 
 	for _, sn := range s.Headers.segments {
-		sn.idxHeaderHash, err = recsplit.OpenIndex(path.Join(s.dir, snap.IdxFileName(sn.From, sn.To, snap.Headers.String())))
+		sn.idxHeaderHash, err = recsplit.OpenIndex(path.Join(s.dir, snap.IdxFileName(sn.ranges.from, sn.ranges.to, snap.Headers.String())))
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
 	}
 	for _, sn := range s.Bodies.segments {
-		sn.idxBodyNumber, err = recsplit.OpenIndex(path.Join(s.dir, snap.IdxFileName(sn.From, sn.To, snap.Bodies.String())))
+		sn.idxBodyNumber, err = recsplit.OpenIndex(path.Join(s.dir, snap.IdxFileName(sn.ranges.from, sn.ranges.to, snap.Bodies.String())))
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
 	}
 	for _, sn := range s.Txs.segments {
-		sn.IdxTxnHash, err = recsplit.OpenIndex(path.Join(s.dir, snap.IdxFileName(sn.From, sn.To, snap.Transactions.String())))
+		sn.IdxTxnHash, err = recsplit.OpenIndex(path.Join(s.dir, snap.IdxFileName(sn.ranges.from, sn.ranges.to, snap.Transactions.String())))
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
-		sn.IdxTxnHash2BlockNum, err = recsplit.OpenIndex(path.Join(s.dir, snap.IdxFileName(sn.From, sn.To, snap.Transactions2Block.String())))
+		sn.IdxTxnHash2BlockNum, err = recsplit.OpenIndex(path.Join(s.dir, snap.IdxFileName(sn.ranges.from, sn.ranges.to, snap.Transactions2Block.String())))
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
@@ -517,7 +517,7 @@ func (s *RoSnapshots) ReopenSegments() error {
 	var segmentsMaxSet bool
 	for _, f := range files {
 		{
-			seg := &BodySegment{From: f.From, To: f.To}
+			seg := &BodySegment{ranges: MergeRange{f.From, f.To}}
 			fileName := snap.SegmentFileName(f.From, f.To, snap.Bodies)
 			seg.seg, err = compress.NewDecompressor(path.Join(s.dir, fileName))
 			if err != nil {
@@ -529,7 +529,7 @@ func (s *RoSnapshots) ReopenSegments() error {
 			s.Bodies.segments = append(s.Bodies.segments, seg)
 		}
 		{
-			seg := &HeaderSegment{From: f.From, To: f.To}
+			seg := &HeaderSegment{ranges: MergeRange{f.From, f.To}}
 			fileName := snap.SegmentFileName(f.From, f.To, snap.Headers)
 			seg.seg, err = compress.NewDecompressor(path.Join(s.dir, fileName))
 			if err != nil {
@@ -541,7 +541,7 @@ func (s *RoSnapshots) ReopenSegments() error {
 			s.Headers.segments = append(s.Headers.segments, seg)
 		}
 		{
-			seg := &TxnSegment{From: f.From, To: f.To}
+			seg := &TxnSegment{ranges: MergeRange{f.From, f.To}}
 			fileName := snap.SegmentFileName(f.From, f.To, snap.Transactions)
 			seg.Seg, err = compress.NewDecompressor(path.Join(s.dir, fileName))
 			if err != nil {
@@ -600,15 +600,15 @@ func (s *RoSnapshots) PrintDebug() {
 	fmt.Printf("sn: %d, %d\n", s.segmentsMax.Load(), s.idxMax.Load())
 	fmt.Println("    == Snapshots, Header")
 	for _, sn := range s.Headers.segments {
-		fmt.Printf("%d,  %t\n", sn.From, sn.idxHeaderHash == nil)
+		fmt.Printf("%d,  %t\n", sn.ranges.from, sn.idxHeaderHash == nil)
 	}
 	fmt.Println("    == Snapshots, Body")
 	for _, sn := range s.Bodies.segments {
-		fmt.Printf("%d,  %t\n", sn.From, sn.idxBodyNumber == nil)
+		fmt.Printf("%d,  %t\n", sn.ranges.from, sn.idxBodyNumber == nil)
 	}
 	fmt.Println("    == Snapshots, Txs")
 	for _, sn := range s.Txs.segments {
-		fmt.Printf("%d,  %t, %t\n", sn.From, sn.IdxTxnHash == nil, sn.IdxTxnHash2BlockNum == nil)
+		fmt.Printf("%d,  %t, %t\n", sn.ranges.from, sn.IdxTxnHash == nil, sn.IdxTxnHash2BlockNum == nil)
 	}
 }
 func (s *RoSnapshots) ViewHeaders(blockNum uint64, f func(sn *HeaderSegment) error) (found bool, err error) {
@@ -639,7 +639,7 @@ func BuildIndices(ctx context.Context, s *RoSnapshots, chainID uint256.Int, tmpD
 		errs := make(chan error, len(segments)*2)
 		workersCh := make(chan struct{}, workers)
 		for _, sn := range segments {
-			if sn.From < from {
+			if sn.ranges.from < from {
 				continue
 			}
 
@@ -667,7 +667,7 @@ func BuildIndices(ctx context.Context, s *RoSnapshots, chainID uint256.Int, tmpD
 				default:
 				}
 
-			}(sn.From, sn.To)
+			}(sn.ranges.from, sn.ranges.to)
 		}
 		go func() {
 			wg.Wait()
@@ -688,7 +688,7 @@ func BuildIndices(ctx context.Context, s *RoSnapshots, chainID uint256.Int, tmpD
 		errs := make(chan error, len(segments)*2)
 		workersCh := make(chan struct{}, workers)
 		for _, sn := range segments {
-			if sn.From < from {
+			if sn.ranges.from < from {
 				continue
 			}
 
@@ -716,7 +716,7 @@ func BuildIndices(ctx context.Context, s *RoSnapshots, chainID uint256.Int, tmpD
 				default:
 				}
 
-			}(sn.From, sn.To)
+			}(sn.ranges.from, sn.ranges.to)
 		}
 		go func() {
 			wg.Wait()
@@ -741,7 +741,7 @@ func BuildIndices(ctx context.Context, s *RoSnapshots, chainID uint256.Int, tmpD
 			errs := make(chan error, len(segments)*2)
 			workersCh := make(chan struct{}, workers)
 			for i, sn := range segments {
-				if sn.From < from {
+				if sn.ranges.from < from {
 					continue
 				}
 
@@ -772,7 +772,7 @@ func BuildIndices(ctx context.Context, s *RoSnapshots, chainID uint256.Int, tmpD
 					default:
 					}
 
-				}(sn.From, sn.To)
+				}(sn.ranges.from, sn.ranges.to)
 			}
 			go func() {
 				wg.Wait()
@@ -1727,20 +1727,20 @@ func (r MergeRange) String() string { return fmt.Sprintf("%dk-%dk", r.from/1000,
 func (*Merger) FindMergeRanges(snapshots *RoSnapshots) (res []MergeRange) {
 	for i := len(snapshots.Headers.segments) - 1; i > 0; i-- {
 		sn := snapshots.Headers.segments[i]
-		if sn.To-sn.From >= snap.DEFAULT_SEGMENT_SIZE { // is complete .seg
+		if sn.ranges.to-sn.ranges.from >= snap.DEFAULT_SEGMENT_SIZE { // is complete .seg
 			continue
 		}
 
 		for _, span := range []uint64{500_000, 100_000, 10_000} {
-			if sn.To%span != 0 {
+			if sn.ranges.to%span != 0 {
 				continue
 			}
-			if sn.To-sn.From == span {
+			if sn.ranges.to-sn.ranges.from == span {
 				break
 			}
-			aggFrom := sn.To - span
-			res = append(res, MergeRange{from: aggFrom, to: sn.To})
-			for snapshots.Headers.segments[i].From > aggFrom {
+			aggFrom := sn.ranges.to - span
+			res = append(res, MergeRange{from: aggFrom, to: sn.ranges.to})
+			for snapshots.Headers.segments[i].ranges.from > aggFrom {
 				i--
 			}
 			break
@@ -1754,10 +1754,10 @@ func (m *Merger) filesByRange(snapshots *RoSnapshots, from, to uint64) (toMergeH
 		return snapshots.Bodies.View(func(bSegments []*BodySegment) error {
 			return snapshots.Txs.View(func(tSegments []*TxnSegment) error {
 				for i, sn := range hSegments {
-					if sn.From < from {
+					if sn.ranges.from < from {
 						continue
 					}
-					if sn.To > to {
+					if sn.ranges.to > to {
 						break
 					}
 

--- a/turbo/snapshotsync/block_snapshots.go
+++ b/turbo/snapshotsync/block_snapshots.go
@@ -1956,7 +1956,6 @@ func RequestSnapshotDownload(ctx context.Context, downloadRequest []DownloadRequ
 	// start seed large .seg of large size
 	req := BuildProtoRequest(downloadRequest)
 	if _, err := downloader.Download(ctx, req); err != nil {
-		time.Sleep(10 * time.Second)
 		return err
 	}
 	return nil

--- a/turbo/snapshotsync/block_snapshots.go
+++ b/turbo/snapshotsync/block_snapshots.go
@@ -1017,9 +1017,8 @@ func retireBlocks(ctx context.Context, blockFrom, blockTo uint64, chainID uint25
 	for _, r := range ranges {
 		downloadRequest = append(downloadRequest, NewDownloadRequest(&r, "", ""))
 	}
-	RequestSnapshotDownload(ctx, downloadRequest, downloader)
 
-	return nil
+	return RequestSnapshotDownload(ctx, downloadRequest, downloader)
 }
 
 func DumpBlocks(ctx context.Context, blockFrom, blockTo, blocksPerFile uint64, tmpDir, snapDir string, chainDB kv.RoDB, workers int, lvl log.Lvl) error {
@@ -1953,13 +1952,14 @@ func NewDownloadRequest(ranges *MergeRange, path string, torrentHash string) Dow
 }
 
 // builds the snapshots download request and downloads them
-func RequestSnapshotDownload(ctx context.Context, downloadRequest []DownloadRequest, downloader proto_downloader.DownloaderClient) {
+func RequestSnapshotDownload(ctx context.Context, downloadRequest []DownloadRequest, downloader proto_downloader.DownloaderClient) error {
 	// start seed large .seg of large size
 	req := BuildProtoRequest(downloadRequest)
 	if _, err := downloader.Download(ctx, req); err != nil {
-		log.Error("[Snapshots] call downloader", "err", err)
 		time.Sleep(10 * time.Second)
+		return err
 	}
+	return nil
 }
 
 func BuildProtoRequest(downloadRequest []DownloadRequest) *proto_downloader.DownloadRequest {

--- a/turbo/snapshotsync/block_snapshots_test.go
+++ b/turbo/snapshotsync/block_snapshots_test.go
@@ -163,14 +163,14 @@ func TestOpenAllSnapshot(t *testing.T) {
 	require.Equal(2, len(s.Headers.segments))
 
 	ok, err := s.ViewTxs(10, func(sn *TxnSegment) error {
-		require.Equal(int(sn.To), 500_000)
+		require.Equal(int(sn.ranges.to), 500_000)
 		return nil
 	})
 	require.NoError(err)
 	require.True(ok)
 
 	ok, err = s.ViewTxs(500_000, func(sn *TxnSegment) error {
-		require.Equal(int(sn.To), 1_000_000) // [from:to)
+		require.Equal(int(sn.ranges.to), 1_000_000) // [from:to)
 		return nil
 	})
 	require.NoError(err)

--- a/turbo/snapshotsync/snap/files.go
+++ b/turbo/snapshotsync/snap/files.go
@@ -167,8 +167,6 @@ func TmpFiles(dir string) (res []string, err error) {
 	return res, nil
 }
 
-var ErrSnapshotMissed = fmt.Errorf("snapshot missed")
-
 // ParseDir - reading dir (
 func ParseDir(dir string) (res []FileInfo, err error) {
 	files, err := os.ReadDir(dir)


### PR DESCRIPTION
Using `MergeRange` struct instead of `from, to uint64` which is the same as the `MergeRange` struct.
Got rid of missing snapshot errors and added warning if we couldn't get missing snapshots
Made `RequestSnapshotDownload` more reusable