### PR TITLE
Still fixing index out of range in (*Accumulator) ChangeStorage

### DIFF
--- a/turbo/shards/state_change_accumulator.go
+++ b/turbo/shards/state_change_accumulator.go
@@ -74,6 +74,7 @@ func (a *Accumulator) ChangeAccount(address common.Address, incarnation uint64, 
 		i = len(a.latestChange.Changes)
 		a.latestChange.Changes = append(a.latestChange.Changes, &remote.AccountChange{Address: gointerfaces.ConvertAddressToH160(address)})
 		a.accountChangeIndex[address] = i
+		delete(a.storageChangeIndex, address)
 	}
 	accountChange := a.latestChange.Changes[i]
 	switch accountChange.Action {
@@ -116,6 +117,7 @@ func (a *Accumulator) ChangeCode(address common.Address, incarnation uint64, cod
 		i = len(a.latestChange.Changes)
 		a.latestChange.Changes = append(a.latestChange.Changes, &remote.AccountChange{Address: gointerfaces.ConvertAddressToH160(address), Action: remote.Action_CODE})
 		a.accountChangeIndex[address] = i
+		delete(a.storageChangeIndex, address)
 	}
 	accountChange := a.latestChange.Changes[i]
 	switch accountChange.Action {
@@ -137,6 +139,7 @@ func (a *Accumulator) ChangeStorage(address common.Address, incarnation uint64, 
 		i = len(a.latestChange.Changes)
 		a.latestChange.Changes = append(a.latestChange.Changes, &remote.AccountChange{Address: gointerfaces.ConvertAddressToH160(address), Action: remote.Action_STORAGE})
 		a.accountChangeIndex[address] = i
+		delete(a.storageChangeIndex, address)
 	}
 	accountChange := a.latestChange.Changes[i]
 	if accountChange.Action == remote.Action_REMOVE {


### PR DESCRIPTION
Continuation of PR #4738.

Consider `(a *Accumulator) ChangeStorage()` method. `storageChangeIndex` is used to access `accountChange.StorageChanges`. But there is a condition in the beginning of the method when `accountChange` might be replaced with a new instance of `remote.AccountChange`. In that case the previous `storageChangeIndex` for that address is no longer relevant and would point to non-existent `StorageChanges`.