### PR TITLE
Fix binary vs raw confusion for PoS transaction

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -98,13 +98,14 @@ type TransactionMisc struct {
 	from atomic.Value
 }
 
-type RawTransactions [][]byte
+// RLP-marshalled legacy transactions and binary-marshalled (not wrapped into an RLP string) typed (EIP-2718) transactions
+type BinaryTransactions [][]byte
 
-func (t RawTransactions) Len() int {
+func (t BinaryTransactions) Len() int {
 	return len(t)
 }
 
-func (t RawTransactions) EncodeIndex(i int, w *bytes.Buffer) {
+func (t BinaryTransactions) EncodeIndex(i int, w *bytes.Buffer) {
 	w.Write(t[i])
 }
 

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -184,7 +184,7 @@ func HeadersPOS(
 	if forkChoiceInsteadOfNewPayload {
 		payloadStatus, err = startHandlingForkChoice(forkChoiceMessage, requestStatus, requestId, s, u, ctx, tx, cfg, headerInserter)
 	} else {
-		payloadMessage := request.(*engineapi.PayloadMessage)
+		payloadMessage := request.(*types.Block)
 		payloadStatus, err = handleNewPayload(payloadMessage, requestStatus, requestId, s, ctx, tx, cfg, headerInserter)
 	}
 
@@ -431,7 +431,7 @@ func finishHandlingForkChoice(
 }
 
 func handleNewPayload(
-	payloadMessage *engineapi.PayloadMessage,
+	block *types.Block,
 	requestStatus engineapi.RequestStatus,
 	requestId int,
 	s *StageState,
@@ -440,9 +440,9 @@ func handleNewPayload(
 	cfg HeadersCfg,
 	headerInserter *headerdownload.HeaderInserter,
 ) (*privateapi.PayloadStatus, error) {
-	header := payloadMessage.Header
+	header := block.Header()
 	headerNumber := header.Number.Uint64()
-	headerHash := header.Hash()
+	headerHash := block.Hash()
 
 	log.Debug(fmt.Sprintf("[%s] Handling new payload", s.LogPrefix()), "height", headerNumber, "hash", headerHash)
 	cfg.hd.UpdateTopSeenHeightPoS(headerNumber)
@@ -507,38 +507,14 @@ func handleNewPayload(
 
 	cfg.hd.BeaconRequestList.Remove(requestId)
 
-	for _, tx := range payloadMessage.Body.Transactions {
-		if types.TypedTransactionMarshalledAsRlpString(tx) {
-			log.Warn(fmt.Sprintf("[%s] typed txn marshalled as RLP string", s.LogPrefix()), "tx", common.Bytes2Hex(tx))
-			cfg.hd.ReportBadHeaderPoS(headerHash, header.ParentHash)
-			return &privateapi.PayloadStatus{
-				Status:          remote.EngineStatus_INVALID,
-				LatestValidHash: header.ParentHash,
-				ValidationError: errors.New("typed txn marshalled as RLP string"),
-			}, nil
-		}
-	}
-
-	transactions, err := types.DecodeTransactions(payloadMessage.Body.Transactions)
-	if err != nil {
-		log.Warn(fmt.Sprintf("[%s] Error during Beacon transaction decoding", s.LogPrefix()), "err", err.Error())
-		cfg.hd.ReportBadHeaderPoS(headerHash, header.ParentHash)
-		return &privateapi.PayloadStatus{
-			Status:          remote.EngineStatus_INVALID,
-			LatestValidHash: header.ParentHash,
-			ValidationError: err,
-		}, nil
-	}
-
 	log.Debug(fmt.Sprintf("[%s] New payload begin verification", s.LogPrefix()))
-	response, success, err := verifyAndSaveNewPoSHeader(requestStatus, s, ctx, tx, cfg, header, payloadMessage.Body, headerInserter)
+	response, success, err := verifyAndSaveNewPoSHeader(requestStatus, s, ctx, tx, cfg, block, headerInserter)
 	log.Debug(fmt.Sprintf("[%s] New payload verification ended", s.LogPrefix()), "success", success, "err", err)
 	if err != nil || !success {
 		return response, err
 	}
 
 	if cfg.bodyDownload != nil {
-		block := types.NewBlockFromStorage(headerHash, header, transactions, nil)
 		cfg.bodyDownload.AddToPrefetch(block)
 	}
 
@@ -551,12 +527,12 @@ func verifyAndSaveNewPoSHeader(
 	ctx context.Context,
 	tx kv.RwTx,
 	cfg HeadersCfg,
-	header *types.Header,
-	body *types.RawBody,
+	block *types.Block,
 	headerInserter *headerdownload.HeaderInserter,
 ) (response *privateapi.PayloadStatus, success bool, err error) {
+	header := block.Header()
 	headerNumber := header.Number.Uint64()
-	headerHash := header.Hash()
+	headerHash := block.Hash()
 
 	if verificationErr := cfg.hd.VerifyHeader(header); verificationErr != nil {
 		log.Warn("Verification failed for header", "hash", headerHash, "height", headerNumber, "err", verificationErr)
@@ -581,7 +557,7 @@ func verifyAndSaveNewPoSHeader(
 	if cfg.memoryOverlay {
 		extendingHash := cfg.forkValidator.ExtendingForkHeadHash()
 		extendCanonical := (extendingHash == common.Hash{} && header.ParentHash == currentHeadHash) || extendingHash == header.ParentHash
-		status, latestValidHash, validationError, criticalError := cfg.forkValidator.ValidatePayload(tx, header, body, extendCanonical)
+		status, latestValidHash, validationError, criticalError := cfg.forkValidator.ValidatePayload(tx, header, block.RawBody(), extendCanonical)
 		if criticalError != nil {
 			return nil, false, criticalError
 		}

--- a/ethdb/privateapi/ethbackend.go
+++ b/ethdb/privateapi/ethbackend.go
@@ -303,7 +303,7 @@ func (s *EthBackendServer) EngineNewPayloadV1(ctx context.Context, req *types2.E
 		Difficulty:  serenity.SerenityDifficulty,
 		Nonce:       serenity.SerenityNonce,
 		ReceiptHash: gointerfaces.ConvertH256ToHash(req.ReceiptRoot),
-		TxHash:      types.DeriveSha(types.RawTransactions(req.Transactions)),
+		TxHash:      types.DeriveSha(types.BinaryTransactions(req.Transactions)),
 	}
 
 	blockHash := gointerfaces.ConvertH256ToHash(req.BlockHash)

--- a/ethdb/privateapi/ethbackend.go
+++ b/ethdb/privateapi/ethbackend.go
@@ -307,6 +307,32 @@ func (s *EthBackendServer) EngineNewPayloadV1(ctx context.Context, req *types2.E
 	}
 
 	blockHash := gointerfaces.ConvertH256ToHash(req.BlockHash)
+	if header.Hash() != blockHash {
+		log.Error("[NewPayload] invalid block hash", "stated", common.Hash(blockHash), "actual", header.Hash())
+		return &remote.EnginePayloadStatus{Status: remote.EngineStatus_INVALID_BLOCK_HASH}, nil
+	}
+
+	for _, txn := range req.Transactions {
+		if types.TypedTransactionMarshalledAsRlpString(txn) {
+			log.Warn("[NewPayload]typed txn marshalled as RLP string", "txn", common.Bytes2Hex(txn))
+			return &remote.EnginePayloadStatus{
+				Status:          remote.EngineStatus_INVALID,
+				LatestValidHash: nil,
+				ValidationError: "typed txn marshalled as RLP string",
+			}, nil
+		}
+	}
+
+	transactions, err := types.DecodeTransactions(req.Transactions)
+	if err != nil {
+		return &remote.EnginePayloadStatus{
+			Status:          remote.EngineStatus_INVALID,
+			LatestValidHash: nil,
+			ValidationError: err.Error(),
+		}, nil
+	}
+	block := types.NewBlockFromStorage(blockHash, &header, transactions, nil)
+
 	tx, err := s.db.BeginRo(ctx)
 	if err != nil {
 		return nil, err
@@ -322,6 +348,7 @@ func (s *EthBackendServer) EngineNewPayloadV1(ctx context.Context, req *types2.E
 		return &remote.EnginePayloadStatus{Status: remote.EngineStatus_INVALID, LatestValidHash: gointerfaces.ConvertHashToH256(common.Hash{})}, nil
 	}
 	tx.Rollback()
+
 	// If another payload is already commissioned then we just reply with syncing
 	if s.stageLoopIsBusy() {
 		// We are still syncing a commissioned payload
@@ -333,11 +360,6 @@ func (s *EthBackendServer) EngineNewPayloadV1(ctx context.Context, req *types2.E
 		return &remote.EnginePayloadStatus{Status: remote.EngineStatus_SYNCING}, nil
 	}
 
-	if header.Hash() != blockHash {
-		log.Error("[NewPayload] invalid block hash", "stated", common.Hash(blockHash), "actual", header.Hash())
-		return &remote.EnginePayloadStatus{Status: remote.EngineStatus_INVALID_BLOCK_HASH}, nil
-	}
-
 	// Lock the thread (We modify shared resources).
 	log.Debug("[NewPayload] acquiring lock")
 	s.lock.Lock()
@@ -345,13 +367,7 @@ func (s *EthBackendServer) EngineNewPayloadV1(ctx context.Context, req *types2.E
 	log.Debug("[NewPayload] lock acquired")
 
 	log.Debug("[NewPayload] sending block", "height", header.Number, "hash", common.Hash(blockHash))
-	s.requestList.AddPayloadRequest(&engineapi.PayloadMessage{
-		Header: &header,
-		Body: &types.RawBody{
-			Transactions: req.Transactions,
-			Uncles:       nil,
-		},
-	})
+	s.requestList.AddPayloadRequest(block)
 
 	payloadStatus := <-s.statusCh
 	log.Debug("[NewPayload] got reply", "payloadStatus", payloadStatus)

--- a/turbo/engineapi/request_list.go
+++ b/turbo/engineapi/request_list.go
@@ -10,12 +10,6 @@ import (
 	"github.com/ledgerwatch/erigon/core/types"
 )
 
-// The message we are going to send to the stage sync in NewPayload
-type PayloadMessage struct {
-	Header *types.Header
-	Body   *types.RawBody
-}
-
 // The message we are going to send to the stage sync in ForkchoiceUpdated
 type ForkChoiceMessage struct {
 	HeadBlockHash      common.Hash
@@ -31,7 +25,7 @@ const ( // RequestStatus values
 )
 
 type RequestWithStatus struct {
-	Message interface{} // *PayloadMessage or *ForkChoiceMessage
+	Message interface{} // *Block or *ForkChoiceMessage
 	Status  RequestStatus
 }
 
@@ -59,7 +53,7 @@ func NewRequestList() *RequestList {
 	return rl
 }
 
-func (rl *RequestList) AddPayloadRequest(message *PayloadMessage) {
+func (rl *RequestList) AddPayloadRequest(message *types.Block) {
 	rl.syncCond.L.Lock()
 	defer rl.syncCond.L.Unlock()
 

--- a/turbo/stages/mock_sentry.go
+++ b/turbo/stages/mock_sentry.go
@@ -522,7 +522,7 @@ func (ms *MockSentry) InsertChain(chain *core.ChainPack) error {
 	return nil
 }
 
-func (ms *MockSentry) SendPayloadRequest(message *engineapi.PayloadMessage) {
+func (ms *MockSentry) SendPayloadRequest(message *types.Block) {
 	ms.sentriesClient.Hd.BeaconRequestList.AddPayloadRequest(message)
 }
 

--- a/turbo/stages/sentry_mock_test.go
+++ b/turbo/stages/sentry_mock_test.go
@@ -571,12 +571,8 @@ func TestPoSDownloader(t *testing.T) {
 	}, false /* intermediateHashes */)
 	require.NoError(t, err)
 
-	// Send a payload with missing parent
-	payloadMessage := engineapi.PayloadMessage{
-		Header: chain.TopBlock.Header(),
-		Body:   chain.TopBlock.RawBody(),
-	}
-	m.SendPayloadRequest(&payloadMessage)
+	// Send a payload whose parent isn't downloaded yet
+	m.SendPayloadRequest(chain.TopBlock)
 	headBlockHash, err := stages.StageLoopStep(m.Ctx, m.DB, m.Sync, 0, m.Notifications, true, m.UpdateHead, nil)
 	require.NoError(t, err)
 	stages.SendPayloadStatus(m.HeaderDownload(), headBlockHash, err)
@@ -640,12 +636,9 @@ func TestPoSSyncWithInvalidHeader(t *testing.T) {
 	invalidTip := chain.TopBlock.Header()
 	invalidTip.ParentHash = invalidParent.Hash()
 
-	// Send a payload with missing parent
-	payloadMessage := engineapi.PayloadMessage{
-		Header: invalidTip,
-		Body:   chain.TopBlock.RawBody(),
-	}
-	m.SendPayloadRequest(&payloadMessage)
+	// Send a payload with the parent missing
+	payloadMessage := types.NewBlockFromStorage(invalidTip.Hash(), invalidTip, chain.TopBlock.Transactions(), nil)
+	m.SendPayloadRequest(payloadMessage)
 	headBlockHash, err := stages.StageLoopStep(m.Ctx, m.DB, m.Sync, 0, m.Notifications, true, m.UpdateHead, nil)
 	require.NoError(t, err)
 	stages.SendPayloadStatus(m.HeaderDownload(), headBlockHash, err)


### PR DESCRIPTION
[Typed](https://eips.ethereum.org/EIPS/eip-2718) transactions can be serialized either by EIP-2718 rules (type byte + serialization) or additionally wrapped into an RLP string. In Erigon we call the former "binary" (e.g. `(Transaction)MarshalBinary()`) and the latter "raw" (e.g. `(*Block) RawBody()`). For an illustration see `TestEIP2718TransactionEncode`.

This PR should fix cases when we mistakenly treated binary PoS transactions as raw.