### PR TITLE
fixed passing of raw byte slices to tx processing

### DIFF
--- a/cmd/sentry/sentry/sentry_multi_client.go
+++ b/cmd/sentry/sentry/sentry_multi_client.go
@@ -500,7 +500,7 @@ func (cs *MultiClient) blockBodies66(inreq *proto_sentry.InboundMessage, _ direc
 		return fmt.Errorf("decode BlockBodiesPacket66: %w", err)
 	}
 	txs, uncles := request.BlockRawBodiesPacket.Unpack()
-	cs.Bd.DeliverBodies(txs, uncles, uint64(len(inreq.Data)), ConvertH512ToPeerID(inreq.PeerId))
+	cs.Bd.DeliverBodies(&txs, &uncles, uint64(len(inreq.Data)), ConvertH512ToPeerID(inreq.PeerId))
 	return nil
 }
 

--- a/turbo/stages/bodydownload/body_data_struct.go
+++ b/turbo/stages/bodydownload/body_data_struct.go
@@ -14,8 +14,8 @@ const MaxBodiesInRequest = 1024
 
 type Delivery struct {
 	peerID          [64]byte
-	txs             [][][]byte
-	uncles          [][]*types.Header
+	txs             *[][][]byte
+	uncles          *[][]*types.Header
 	lenOfP2PMessage uint64
 }
 


### PR DESCRIPTION
fix for https://github.com/ledgerwatch/erigon/issues/4688 

Inuse space at goerli during stage 6/16 
![profile001](https://user-images.githubusercontent.com/9694143/180276842-9b2c04cf-71a4-4f77-9125-4171f2342b69.png)

pprof data before patch were similar to https://github.com/ledgerwatch/erigon/issues/4688#issuecomment-1180099181

Another interesting thing: recently were updated `core.ExecuteBlockEphemerally`. Is that correct that it's called during syncing? 