### PR TITLE
Avoid constantly triggering stageloop when using Engine API

### DIFF
--- a/cmd/rpcdaemon/commands/eth_subscribe_test.go
+++ b/cmd/rpcdaemon/commands/eth_subscribe_test.go
@@ -40,7 +40,7 @@ func TestEthSubscribe(t *testing.T) {
 	m.ReceiveWg.Wait() // Wait for all messages to be processed before we proceeed
 
 	ctx := context.Background()
-	backendServer := privateapi.NewEthBackendServer(ctx, nil, m.DB, m.Notifications.Events, snapshotsync.NewBlockReader(), nil, nil, nil, nil, false)
+	backendServer := privateapi.NewEthBackendServer(ctx, nil, m.DB, m.Notifications.Events, snapshotsync.NewBlockReader(), nil, nil, nil, nil, nil, false)
 	backendClient := direct.NewEthBackendClientDirect(backendServer)
 	backend := rpcservices.NewRemoteBackend(backendClient, m.DB, snapshotsync.NewBlockReader())
 	ff := rpchelper.New(ctx, backend, nil, nil, func() {})

--- a/cmd/rpcdaemon/commands/eth_subscribe_test.go
+++ b/cmd/rpcdaemon/commands/eth_subscribe_test.go
@@ -40,7 +40,7 @@ func TestEthSubscribe(t *testing.T) {
 	m.ReceiveWg.Wait() // Wait for all messages to be processed before we proceeed
 
 	ctx := context.Background()
-	backendServer := privateapi.NewEthBackendServer(ctx, nil, m.DB, m.Notifications.Events, snapshotsync.NewBlockReader(), nil, nil, nil, nil, nil, false)
+	backendServer := privateapi.NewEthBackendServer(ctx, nil, m.DB, m.Notifications.Events, snapshotsync.NewBlockReader(), nil, nil, nil, false)
 	backendClient := direct.NewEthBackendClientDirect(backendServer)
 	backend := rpcservices.NewRemoteBackend(backendClient, m.DB, snapshotsync.NewBlockReader())
 	ff := rpchelper.New(ctx, backend, nil, nil, func() {})

--- a/cmd/rpcdaemon/rpcdaemontest/test_util.go
+++ b/cmd/rpcdaemon/rpcdaemontest/test_util.go
@@ -292,7 +292,7 @@ func CreateTestGrpcConn(t *testing.T, m *stages.MockSentry) (context.Context, *g
 	ethashApi := apis[1].Service.(*ethash.API)
 	server := grpc.NewServer()
 
-	remote.RegisterETHBACKENDServer(server, privateapi.NewEthBackendServer(ctx, nil, m.DB, m.Notifications.Events, snapshotsync.NewBlockReader(), nil, nil, nil, nil, false))
+	remote.RegisterETHBACKENDServer(server, privateapi.NewEthBackendServer(ctx, nil, m.DB, m.Notifications.Events, snapshotsync.NewBlockReader(), nil, nil, nil, nil, nil, false))
 	txpool.RegisterTxpoolServer(server, m.TxPoolGrpcServer)
 	txpool.RegisterMiningServer(server, privateapi.NewMiningServer(ctx, &IsMiningMock{}, ethashApi))
 	starknet.RegisterCAIROVMServer(server, &starknet.UnimplementedCAIROVMServer{})

--- a/cmd/rpcdaemon/rpcdaemontest/test_util.go
+++ b/cmd/rpcdaemon/rpcdaemontest/test_util.go
@@ -292,7 +292,7 @@ func CreateTestGrpcConn(t *testing.T, m *stages.MockSentry) (context.Context, *g
 	ethashApi := apis[1].Service.(*ethash.API)
 	server := grpc.NewServer()
 
-	remote.RegisterETHBACKENDServer(server, privateapi.NewEthBackendServer(ctx, nil, m.DB, m.Notifications.Events, snapshotsync.NewBlockReader(), nil, nil, nil, nil, nil, false))
+	remote.RegisterETHBACKENDServer(server, privateapi.NewEthBackendServer(ctx, nil, m.DB, m.Notifications.Events, snapshotsync.NewBlockReader(), nil, nil, nil, false))
 	txpool.RegisterTxpoolServer(server, m.TxPoolGrpcServer)
 	txpool.RegisterMiningServer(server, privateapi.NewMiningServer(ctx, &IsMiningMock{}, ethashApi))
 	starknet.RegisterCAIROVMServer(server, &starknet.UnimplementedCAIROVMServer{})

--- a/cmd/rpcdaemon22/rpcdaemontest/test_util.go
+++ b/cmd/rpcdaemon22/rpcdaemontest/test_util.go
@@ -293,7 +293,7 @@ func CreateTestGrpcConn(t *testing.T, m *stages.MockSentry) (context.Context, *g
 	ethashApi := apis[1].Service.(*ethash.API)
 	server := grpc.NewServer()
 
-	remote.RegisterETHBACKENDServer(server, privateapi.NewEthBackendServer(ctx, nil, m.DB, m.Notifications.Events, snapshotsync.NewBlockReader(), nil, nil, nil, nil, false))
+	remote.RegisterETHBACKENDServer(server, privateapi.NewEthBackendServer(ctx, nil, m.DB, m.Notifications.Events, snapshotsync.NewBlockReader(), nil, nil, nil, nil, nil, false))
 	txpool.RegisterTxpoolServer(server, m.TxPoolGrpcServer)
 	txpool.RegisterMiningServer(server, privateapi.NewMiningServer(ctx, &IsMiningMock{}, ethashApi))
 	starknet.RegisterCAIROVMServer(server, &starknet.UnimplementedCAIROVMServer{})

--- a/cmd/rpcdaemon22/rpcdaemontest/test_util.go
+++ b/cmd/rpcdaemon22/rpcdaemontest/test_util.go
@@ -293,7 +293,7 @@ func CreateTestGrpcConn(t *testing.T, m *stages.MockSentry) (context.Context, *g
 	ethashApi := apis[1].Service.(*ethash.API)
 	server := grpc.NewServer()
 
-	remote.RegisterETHBACKENDServer(server, privateapi.NewEthBackendServer(ctx, nil, m.DB, m.Notifications.Events, snapshotsync.NewBlockReader(), nil, nil, nil, nil, nil, false))
+	remote.RegisterETHBACKENDServer(server, privateapi.NewEthBackendServer(ctx, nil, m.DB, m.Notifications.Events, snapshotsync.NewBlockReader(), nil, nil, nil, false))
 	txpool.RegisterTxpoolServer(server, m.TxPoolGrpcServer)
 	txpool.RegisterMiningServer(server, privateapi.NewMiningServer(ctx, &IsMiningMock{}, ethashApi))
 	starknet.RegisterCAIROVMServer(server, &starknet.UnimplementedCAIROVMServer{})

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -412,7 +412,7 @@ func New(stack *node.Node, config *ethconfig.Config, logger log.Logger) (*Ethere
 	// Initialize ethbackend
 	ethBackendRPC := privateapi.NewEthBackendServer(ctx, backend, backend.chainDB, backend.notifications.Events,
 		blockReader, chainConfig, backend.sentriesClient.Hd.BeaconRequestList, backend.sentriesClient.Hd.PayloadStatusCh,
-		assembleBlockPOS, config.Miner.EnabledPOS)
+		assembleBlockPOS, backend.sentriesClient.Hd, config.Miner.EnabledPOS)
 	miningRPC = privateapi.NewMiningServer(ctx, backend, ethashApi)
 
 	if stack.Config().PrivateApiAddr != "" {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -411,8 +411,7 @@ func New(stack *node.Node, config *ethconfig.Config, logger log.Logger) (*Ethere
 
 	// Initialize ethbackend
 	ethBackendRPC := privateapi.NewEthBackendServer(ctx, backend, backend.chainDB, backend.notifications.Events,
-		blockReader, chainConfig, backend.sentriesClient.Hd.BeaconRequestList, backend.sentriesClient.Hd.PayloadStatusCh,
-		assembleBlockPOS, backend.sentriesClient.Hd, config.Miner.EnabledPOS)
+		blockReader, chainConfig, assembleBlockPOS, backend.sentriesClient.Hd, config.Miner.EnabledPOS)
 	miningRPC = privateapi.NewMiningServer(ctx, backend, ethashApi)
 
 	if stack.Config().PrivateApiAddr != "" {

--- a/ethdb/privateapi/engine_test.go
+++ b/ethdb/privateapi/engine_test.go
@@ -90,10 +90,10 @@ func TestMockDownloadRequest(t *testing.T) {
 
 	makeTestDb(ctx, db)
 	beaconRequestList := engineapi.NewRequestList()
-	statusCh := make(chan PayloadStatus)
+	statusCh := make(chan engineapi.PayloadStatus)
 
 	events := NewEvents()
-	backend := NewEthBackendServer(ctx, nil, db, events, nil, &params.ChainConfig{TerminalTotalDifficulty: common.Big1}, beaconRequestList, statusCh, nil, false)
+	backend := NewEthBackendServer(ctx, nil, db, events, nil, &params.ChainConfig{TerminalTotalDifficulty: common.Big1}, beaconRequestList, statusCh, nil, nil, false)
 
 	var err error
 	var reply *remote.EnginePayloadStatus
@@ -105,7 +105,7 @@ func TestMockDownloadRequest(t *testing.T) {
 	}()
 
 	beaconRequestList.WaitForRequest(true)
-	statusCh <- PayloadStatus{Status: remote.EngineStatus_SYNCING}
+	statusCh <- engineapi.PayloadStatus{Status: remote.EngineStatus_SYNCING}
 	<-done
 	require.NoError(err)
 	require.Equal(reply.Status, remote.EngineStatus_SYNCING)
@@ -149,10 +149,10 @@ func TestMockValidExecution(t *testing.T) {
 	makeTestDb(ctx, db)
 
 	beaconRequestList := engineapi.NewRequestList()
-	statusCh := make(chan PayloadStatus)
+	statusCh := make(chan engineapi.PayloadStatus)
 
 	events := NewEvents()
-	backend := NewEthBackendServer(ctx, nil, db, events, nil, &params.ChainConfig{TerminalTotalDifficulty: common.Big1}, beaconRequestList, statusCh, nil, false)
+	backend := NewEthBackendServer(ctx, nil, db, events, nil, &params.ChainConfig{TerminalTotalDifficulty: common.Big1}, beaconRequestList, statusCh, nil, nil, false)
 
 	var err error
 	var reply *remote.EnginePayloadStatus
@@ -165,7 +165,7 @@ func TestMockValidExecution(t *testing.T) {
 
 	beaconRequestList.WaitForRequest(true)
 
-	statusCh <- PayloadStatus{
+	statusCh <- engineapi.PayloadStatus{
 		Status:          remote.EngineStatus_VALID,
 		LatestValidHash: payload3Hash,
 	}
@@ -185,10 +185,10 @@ func TestMockInvalidExecution(t *testing.T) {
 	makeTestDb(ctx, db)
 
 	beaconRequestList := engineapi.NewRequestList()
-	statusCh := make(chan PayloadStatus)
+	statusCh := make(chan engineapi.PayloadStatus)
 
 	events := NewEvents()
-	backend := NewEthBackendServer(ctx, nil, db, events, nil, &params.ChainConfig{TerminalTotalDifficulty: common.Big1}, beaconRequestList, statusCh, nil, false)
+	backend := NewEthBackendServer(ctx, nil, db, events, nil, &params.ChainConfig{TerminalTotalDifficulty: common.Big1}, beaconRequestList, statusCh, nil, nil, false)
 
 	var err error
 	var reply *remote.EnginePayloadStatus
@@ -201,7 +201,7 @@ func TestMockInvalidExecution(t *testing.T) {
 
 	beaconRequestList.WaitForRequest(true)
 	// Simulate invalid status
-	statusCh <- PayloadStatus{
+	statusCh <- engineapi.PayloadStatus{
 		Status:          remote.EngineStatus_INVALID,
 		LatestValidHash: startingHeadHash,
 	}
@@ -221,10 +221,10 @@ func TestNoTTD(t *testing.T) {
 	makeTestDb(ctx, db)
 
 	beaconRequestList := engineapi.NewRequestList()
-	statusCh := make(chan PayloadStatus)
+	statusCh := make(chan engineapi.PayloadStatus)
 
 	events := NewEvents()
-	backend := NewEthBackendServer(ctx, nil, db, events, nil, &params.ChainConfig{}, beaconRequestList, statusCh, nil, false)
+	backend := NewEthBackendServer(ctx, nil, db, events, nil, &params.ChainConfig{}, beaconRequestList, statusCh, nil, nil, false)
 
 	var err error
 

--- a/ethdb/privateapi/engine_test.go
+++ b/ethdb/privateapi/engine_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ledgerwatch/erigon/core/rawdb"
 	"github.com/ledgerwatch/erigon/params"
 	"github.com/ledgerwatch/erigon/turbo/engineapi"
+	"github.com/ledgerwatch/erigon/turbo/stages/headerdownload"
 	"github.com/stretchr/testify/require"
 )
 
@@ -89,11 +90,10 @@ func TestMockDownloadRequest(t *testing.T) {
 	require := require.New(t)
 
 	makeTestDb(ctx, db)
-	beaconRequestList := engineapi.NewRequestList()
-	statusCh := make(chan engineapi.PayloadStatus)
+	hd := headerdownload.NewHeaderDownload(0, 0, nil, nil)
 
 	events := NewEvents()
-	backend := NewEthBackendServer(ctx, nil, db, events, nil, &params.ChainConfig{TerminalTotalDifficulty: common.Big1}, beaconRequestList, statusCh, nil, nil, false)
+	backend := NewEthBackendServer(ctx, nil, db, events, nil, &params.ChainConfig{TerminalTotalDifficulty: common.Big1}, nil, hd, false)
 
 	var err error
 	var reply *remote.EnginePayloadStatus
@@ -104,8 +104,8 @@ func TestMockDownloadRequest(t *testing.T) {
 		done <- true
 	}()
 
-	beaconRequestList.WaitForRequest(true)
-	statusCh <- engineapi.PayloadStatus{Status: remote.EngineStatus_SYNCING}
+	hd.BeaconRequestList.WaitForRequest(true)
+	hd.PayloadStatusCh <- engineapi.PayloadStatus{Status: remote.EngineStatus_SYNCING}
 	<-done
 	require.NoError(err)
 	require.Equal(reply.Status, remote.EngineStatus_SYNCING)
@@ -148,11 +148,10 @@ func TestMockValidExecution(t *testing.T) {
 
 	makeTestDb(ctx, db)
 
-	beaconRequestList := engineapi.NewRequestList()
-	statusCh := make(chan engineapi.PayloadStatus)
+	hd := headerdownload.NewHeaderDownload(0, 0, nil, nil)
 
 	events := NewEvents()
-	backend := NewEthBackendServer(ctx, nil, db, events, nil, &params.ChainConfig{TerminalTotalDifficulty: common.Big1}, beaconRequestList, statusCh, nil, nil, false)
+	backend := NewEthBackendServer(ctx, nil, db, events, nil, &params.ChainConfig{TerminalTotalDifficulty: common.Big1}, nil, hd, false)
 
 	var err error
 	var reply *remote.EnginePayloadStatus
@@ -163,9 +162,9 @@ func TestMockValidExecution(t *testing.T) {
 		done <- true
 	}()
 
-	beaconRequestList.WaitForRequest(true)
+	hd.BeaconRequestList.WaitForRequest(true)
 
-	statusCh <- engineapi.PayloadStatus{
+	hd.PayloadStatusCh <- engineapi.PayloadStatus{
 		Status:          remote.EngineStatus_VALID,
 		LatestValidHash: payload3Hash,
 	}
@@ -184,11 +183,10 @@ func TestMockInvalidExecution(t *testing.T) {
 
 	makeTestDb(ctx, db)
 
-	beaconRequestList := engineapi.NewRequestList()
-	statusCh := make(chan engineapi.PayloadStatus)
+	hd := headerdownload.NewHeaderDownload(0, 0, nil, nil)
 
 	events := NewEvents()
-	backend := NewEthBackendServer(ctx, nil, db, events, nil, &params.ChainConfig{TerminalTotalDifficulty: common.Big1}, beaconRequestList, statusCh, nil, nil, false)
+	backend := NewEthBackendServer(ctx, nil, db, events, nil, &params.ChainConfig{TerminalTotalDifficulty: common.Big1}, nil, hd, false)
 
 	var err error
 	var reply *remote.EnginePayloadStatus
@@ -199,9 +197,9 @@ func TestMockInvalidExecution(t *testing.T) {
 		done <- true
 	}()
 
-	beaconRequestList.WaitForRequest(true)
+	hd.BeaconRequestList.WaitForRequest(true)
 	// Simulate invalid status
-	statusCh <- engineapi.PayloadStatus{
+	hd.PayloadStatusCh <- engineapi.PayloadStatus{
 		Status:          remote.EngineStatus_INVALID,
 		LatestValidHash: startingHeadHash,
 	}
@@ -220,11 +218,10 @@ func TestNoTTD(t *testing.T) {
 
 	makeTestDb(ctx, db)
 
-	beaconRequestList := engineapi.NewRequestList()
-	statusCh := make(chan engineapi.PayloadStatus)
+	hd := headerdownload.NewHeaderDownload(0, 0, nil, nil)
 
 	events := NewEvents()
-	backend := NewEthBackendServer(ctx, nil, db, events, nil, &params.ChainConfig{}, beaconRequestList, statusCh, nil, nil, false)
+	backend := NewEthBackendServer(ctx, nil, db, events, nil, &params.ChainConfig{}, nil, hd, false)
 
 	var err error
 

--- a/ethdb/privateapi/ethbackend.go
+++ b/ethdb/privateapi/ethbackend.go
@@ -381,6 +381,9 @@ func (s *EthBackendServer) EngineNewPayloadV1(ctx context.Context, req *types2.E
 func (s *EthBackendServer) getPayloadStatusFromHashIfPossible(blockHash common.Hash, blockNumber uint64, parentHash common.Hash, newPayload bool) (*engineapi.PayloadStatus, error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
+	if s.hd == nil {
+		return nil, nil
+	}
 	var prefix string
 	if newPayload {
 		prefix = "NewPayload"
@@ -461,6 +464,7 @@ func (s *EthBackendServer) getPayloadStatusFromHashIfPossible(blockHash common.H
 	if blockHash != headHash && canonicalHash == blockHash {
 		return &engineapi.PayloadStatus{Status: remote.EngineStatus_VALID, LatestValidHash: blockHash}, nil
 	}
+
 	return nil, nil
 }
 

--- a/turbo/engineapi/request_list.go
+++ b/turbo/engineapi/request_list.go
@@ -6,9 +6,20 @@ import (
 
 	"github.com/emirpasic/gods/maps/treemap"
 
+	"github.com/ledgerwatch/erigon-lib/gointerfaces/remote"
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/core/types"
 )
+
+// This is the status of a newly execute block.
+// Hash: Block hash
+// Status: block's status
+type PayloadStatus struct {
+	Status          remote.EngineStatus
+	LatestValidHash common.Hash
+	ValidationError error
+	CriticalError   error
+}
 
 // The message we are going to send to the stage sync in ForkchoiceUpdated
 type ForkChoiceMessage struct {

--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ledgerwatch/erigon/core/rawdb"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/eth/stagedsync/stages"
-	"github.com/ledgerwatch/erigon/ethdb/privateapi"
 	"github.com/ledgerwatch/erigon/params"
 	"github.com/ledgerwatch/erigon/rlp"
 	"github.com/ledgerwatch/erigon/turbo/engineapi"
@@ -1134,13 +1133,13 @@ func (hd *HeaderDownload) ClearPendingPayloadHash() {
 	hd.pendingPayloadHash = common.Hash{}
 }
 
-func (hd *HeaderDownload) GetPendingPayloadStatus() *privateapi.PayloadStatus {
+func (hd *HeaderDownload) GetPendingPayloadStatus() *engineapi.PayloadStatus {
 	hd.lock.RLock()
 	defer hd.lock.RUnlock()
 	return hd.pendingPayloadStatus
 }
 
-func (hd *HeaderDownload) SetPendingPayloadStatus(response *privateapi.PayloadStatus) {
+func (hd *HeaderDownload) SetPendingPayloadStatus(response *engineapi.PayloadStatus) {
 	hd.lock.Lock()
 	defer hd.lock.Unlock()
 	hd.pendingPayloadStatus = response

--- a/turbo/stages/headerdownload/header_data_struct.go
+++ b/turbo/stages/headerdownload/header_data_struct.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/consensus"
 	"github.com/ledgerwatch/erigon/core/types"
-	"github.com/ledgerwatch/erigon/ethdb/privateapi"
 	"github.com/ledgerwatch/erigon/rlp"
 	"github.com/ledgerwatch/erigon/turbo/engineapi"
 	"github.com/ledgerwatch/erigon/turbo/services"
@@ -305,16 +304,16 @@ type HeaderDownload struct {
 	requestId            int
 	posAnchor            *Anchor
 	posStatus            SyncStatus
-	posSync              bool                          // Whether the chain is syncing in the PoS mode
-	headersCollector     *etl.Collector                // ETL collector for headers
-	BeaconRequestList    *engineapi.RequestList        // Requests from ethbackend to staged sync
-	PayloadStatusCh      chan privateapi.PayloadStatus // Responses (validation/execution status)
-	pendingPayloadHash   common.Hash                   // Header whose status we still should send to PayloadStatusCh
-	pendingPayloadStatus *privateapi.PayloadStatus     // Alternatively, there can be an already prepared response to send to PayloadStatusCh
-	unsettledForkChoice  *engineapi.ForkChoiceMessage  // Forkchoice to process after unwind
-	unsettledHeadHeight  uint64                        // Height of unsettledForkChoice.headBlockHash
-	posDownloaderTip     common.Hash                   // See https://hackmd.io/GDc0maGsQeKfP8o2C7L52w
-	badPoSHeaders        map[common.Hash]common.Hash   // Invalid Tip -> Last Valid Ancestor
+	posSync              bool                         // Whether the chain is syncing in the PoS mode
+	headersCollector     *etl.Collector               // ETL collector for headers
+	BeaconRequestList    *engineapi.RequestList       // Requests from ethbackend to staged sync
+	PayloadStatusCh      chan engineapi.PayloadStatus // Responses (validation/execution status)
+	pendingPayloadHash   common.Hash                  // Header whose status we still should send to PayloadStatusCh
+	pendingPayloadStatus *engineapi.PayloadStatus     // Alternatively, there can be an already prepared response to send to PayloadStatusCh
+	unsettledForkChoice  *engineapi.ForkChoiceMessage // Forkchoice to process after unwind
+	unsettledHeadHeight  uint64                       // Height of unsettledForkChoice.headBlockHash
+	posDownloaderTip     common.Hash                  // See https://hackmd.io/GDc0maGsQeKfP8o2C7L52w
+	badPoSHeaders        map[common.Hash]common.Hash  // Invalid Tip -> Last Valid Ancestor
 }
 
 // HeaderRecord encapsulates two forms of the same header - raw RLP encoding (to avoid duplicated decodings and encodings), and parsed value types.Header
@@ -343,7 +342,7 @@ func NewHeaderDownload(
 		DeliveryNotify:     make(chan struct{}, 1),
 		QuitPoWMining:      make(chan struct{}),
 		BeaconRequestList:  engineapi.NewRequestList(),
-		PayloadStatusCh:    make(chan privateapi.PayloadStatus, 1),
+		PayloadStatusCh:    make(chan engineapi.PayloadStatus, 1),
 		headerReader:       headerReader,
 		badPoSHeaders:      make(map[common.Hash]common.Hash),
 	}

--- a/turbo/stages/mock_sentry.go
+++ b/turbo/stages/mock_sentry.go
@@ -530,7 +530,7 @@ func (ms *MockSentry) SendForkChoiceRequest(message *engineapi.ForkChoiceMessage
 	ms.sentriesClient.Hd.BeaconRequestList.AddForkChoiceRequest(message)
 }
 
-func (ms *MockSentry) ReceivePayloadStatus() privateapi.PayloadStatus {
+func (ms *MockSentry) ReceivePayloadStatus() engineapi.PayloadStatus {
 	return <-ms.sentriesClient.Hd.PayloadStatusCh
 }
 

--- a/turbo/stages/sentry_mock_test.go
+++ b/turbo/stages/sentry_mock_test.go
@@ -669,11 +669,10 @@ func TestPoSSyncWithInvalidHeader(t *testing.T) {
 		FinalizedBlockHash: invalidTip.Hash(),
 	}
 	m.SendForkChoiceRequest(&forkChoiceMessage)
-	headBlockHash, err = stages.StageLoopStep(m.Ctx, m.DB, m.Sync, 0, m.Notifications, false, m.UpdateHead, nil)
+	_, err = stages.StageLoopStep(m.Ctx, m.DB, m.Sync, 0, m.Notifications, false, m.UpdateHead, nil)
 	require.NoError(t, err)
-	stages.SendPayloadStatus(m.HeaderDownload(), headBlockHash, err)
 
-	payloadStatus2 := m.ReceivePayloadStatus()
-	require.Equal(t, remote.EngineStatus_INVALID, payloadStatus2.Status)
-	assert.Equal(t, lastValidHeader.Hash(), payloadStatus2.LatestValidHash)
+	bad, lastValidHash := m.HeaderDownload().IsBadHeaderPoS(invalidTip.Hash())
+	assert.True(t, bad)
+	assert.Equal(t, lastValidHash, lastValidHeader.Hash())
 }

--- a/turbo/stages/stageloop.go
+++ b/turbo/stages/stageloop.go
@@ -23,7 +23,6 @@ import (
 	"github.com/ledgerwatch/erigon/eth/ethconfig"
 	"github.com/ledgerwatch/erigon/eth/stagedsync"
 	"github.com/ledgerwatch/erigon/eth/stagedsync/stages"
-	"github.com/ledgerwatch/erigon/ethdb/privateapi"
 	"github.com/ledgerwatch/erigon/p2p"
 	"github.com/ledgerwatch/erigon/turbo/engineapi"
 	"github.com/ledgerwatch/erigon/turbo/services"
@@ -35,13 +34,13 @@ import (
 func SendPayloadStatus(hd *headerdownload.HeaderDownload, headBlockHash common.Hash, err error) {
 	if pendingPayloadStatus := hd.GetPendingPayloadStatus(); pendingPayloadStatus != nil {
 		if err != nil {
-			hd.PayloadStatusCh <- privateapi.PayloadStatus{CriticalError: err}
+			hd.PayloadStatusCh <- engineapi.PayloadStatus{CriticalError: err}
 		} else {
 			hd.PayloadStatusCh <- *pendingPayloadStatus
 		}
 	} else if pendingPayloadHash := hd.GetPendingPayloadHash(); pendingPayloadHash != (common.Hash{}) {
 		if err != nil {
-			hd.PayloadStatusCh <- privateapi.PayloadStatus{CriticalError: err}
+			hd.PayloadStatusCh <- engineapi.PayloadStatus{CriticalError: err}
 		} else {
 			var status remote.EngineStatus
 			if headBlockHash == pendingPayloadHash {
@@ -50,7 +49,7 @@ func SendPayloadStatus(hd *headerdownload.HeaderDownload, headBlockHash common.H
 				log.Warn("Failed to execute pending payload", "pendingPayload", pendingPayloadHash, "headBlock", headBlockHash)
 				status = remote.EngineStatus_INVALID
 			}
-			hd.PayloadStatusCh <- privateapi.PayloadStatus{
+			hd.PayloadStatusCh <- engineapi.PayloadStatus{
 				Status:          status,
 				LatestValidHash: headBlockHash,
 			}


### PR DESCRIPTION
# Rationale

Moving all non-stagedsync dependent rpc answers outside stage_headers.go as pre-checks in eth_backend.go.
# Motivations
* Not get spammed with stageloop logs
* Avoid filling the request lists to oblivion while syncing up
* Remove code duplication
* Set up a more readable set of pre-requisites
* better UX
* Being less prone to bugs and more simple code in stage_headers overall.
* Ability to give proper answers to Consensus Layer even if stageloop is busy.