### PR TITLE
fix(vmtrace): return value pushed by smod

### DIFF
--- a/cmd/rpcdaemon/commands/trace_adhoc.go
+++ b/cmd/rpcdaemon/commands/trace_adhoc.go
@@ -448,7 +448,7 @@ func (ot *OeTracer) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost
 				vm.ADD, vm.EXP, vm.CALLER, vm.SHA3, vm.SUB, vm.ADDRESS, vm.GAS, vm.MUL, vm.RETURNDATASIZE, vm.NOT, vm.SHR, vm.SHL,
 				vm.EXTCODESIZE, vm.SLT, vm.OR, vm.NUMBER, vm.PC, vm.TIMESTAMP, vm.BALANCE, vm.SELFBALANCE, vm.MULMOD, vm.ADDMOD, vm.BASEFEE,
 				vm.BLOCKHASH, vm.BYTE, vm.XOR, vm.ORIGIN, vm.CODESIZE, vm.MOD, vm.SIGNEXTEND, vm.GASLIMIT, vm.DIFFICULTY, vm.SGT, vm.GASPRICE,
-				vm.MSIZE, vm.EXTCODEHASH:
+				vm.MSIZE, vm.EXTCODEHASH, vm.SMOD:
 				showStack = 1
 			}
 			for i := showStack - 1; i >= 0; i-- {


### PR DESCRIPTION
i was doing a pairwise comparison with geth trace and found a discrepancy in vmtrace. consider this request
```
trace_replayTransaction
['0x53546f6ac3d342842acfeeedeca5d66d7fda92acaa5bbc91ef94fd52b6f45a94', ['vmTrace']]
```
the stack divergest after this operation:
```json
{
    "cost": 5,
    "ex": {
      "mem": null,
      "push": [],
      "store": null,
      "used": 298747
    },
    "pc": 17605,
    "sub": null,
    "op": "SMOD",
    "idx": "161-525-1253-663"
}
```

`SMOD` consumes two items from the stack and puts back one, but here it doesn't return what to push.

here is the same operation after the patch applied:
```json
{
    "cost": 5,
    "ex": {
      "mem": null,
      "push": [
        "0x48"
      ],
      "store": null,
      "used": 298747
    },
    "pc": 17605,
    "sub": null,
    "op": "SMOD",
    "idx": "161-525-1253-663"
}
```