### PR TITLE
Don't wait for CL in initialCycle

### DIFF
--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -139,7 +139,7 @@ func SpawnStageHeaders(
 
 	if transitionedToPoS {
 		libcommon.SafeClose(cfg.hd.QuitPoWMining)
-		return HeadersPOS(s, u, ctx, tx, cfg, test, useExternalTx)
+		return HeadersPOS(s, u, ctx, tx, cfg, initialCycle, test, useExternalTx)
 	} else {
 		return HeadersPOW(s, u, ctx, tx, cfg, initialCycle, test, useExternalTx)
 	}
@@ -153,9 +153,15 @@ func HeadersPOS(
 	ctx context.Context,
 	tx kv.RwTx,
 	cfg HeadersCfg,
+	initialCycle bool,
 	test bool,
 	useExternalTx bool,
 ) error {
+	if initialCycle {
+		// Let execution and other stages to finish before waiting for CL
+		return nil
+	}
+
 	log.Info(fmt.Sprintf("[%s] Waiting for Beacon Chain...", s.LogPrefix()))
 
 	onlyNewRequests := cfg.hd.PosStatus() == headerdownload.Syncing


### PR DESCRIPTION
If Erigon is restarted before it's fully synced, we want to continue with the block execution, etc rather than waiting for CL. Also the previous behaviour was a tad wasteful because `forkPoint` was too early since some previous blocks didn't have a chance to progress to canonical.