### PR TITLE
fix memory leak in HandleInboundMessage

### DIFF
--- a/cmd/sentry/sentry/sentry_multi_client.go
+++ b/cmd/sentry/sentry/sentry_multi_client.go
@@ -20,6 +20,12 @@ import (
 	proto_sentry "github.com/ledgerwatch/erigon-lib/gointerfaces/sentry"
 	proto_types "github.com/ledgerwatch/erigon-lib/gointerfaces/types"
 	"github.com/ledgerwatch/erigon-lib/kv"
+	"github.com/ledgerwatch/log/v3"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/keepalive"
+	"google.golang.org/protobuf/types/known/emptypb"
+
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/consensus"
 	"github.com/ledgerwatch/erigon/core/forkid"
@@ -31,11 +37,6 @@ import (
 	"github.com/ledgerwatch/erigon/turbo/services"
 	"github.com/ledgerwatch/erigon/turbo/stages/bodydownload"
 	"github.com/ledgerwatch/erigon/turbo/stages/headerdownload"
-	"github.com/ledgerwatch/log/v3"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/backoff"
-	"google.golang.org/grpc/keepalive"
-	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 type sentryMessageStream grpc.ClientStream
@@ -384,14 +385,15 @@ func (cs *MultiClient) blockHeaders(ctx context.Context, pkt eth.BlockHeadersPac
 		if err != nil {
 			return fmt.Errorf("decode 3 BlockHeadersPacket66: %w", err)
 		}
+		hRaw := append([]byte{}, headerRaw...)
 		number := header.Number.Uint64()
 		if number > highestBlock {
 			highestBlock = number
 		}
 		csHeaders = append(csHeaders, headerdownload.ChainSegmentHeader{
 			Header:    header,
-			HeaderRaw: headerRaw,
-			Hash:      types.RawRlpHash(headerRaw),
+			HeaderRaw: hRaw,
+			Hash:      types.RawRlpHash(hRaw),
 			Number:    number,
 		})
 	}


### PR DESCRIPTION
A lot of the issues surrounding this point the finger to the call to `Stream.Raw`, after some digging and moving some code around I found the issue to be where a `Link` is created, this holds a reference to the raw header when it gets queued to be written to the DB.  On a successful write the raw header is then nil'd but the GC doesn't seem to want to mop it up properly.  The code change copies the result from the call to Raw into a new slice, pprof shows the allocation move up a level as expected, but this allocation does look to be mopped up properly.  Unsure if this is anything to do with the re-slicing happening inside Raw or not.

In trialling this locally it looks to stop the heap growing out of control.  Tried on chapel and goerli chains and ran them for about an hour each without leaking.  The memory pressure is still there but the GC looks to be clearing it properly now.

Originally tried using a pool of bytes.Buffer for the call to Raw to use which did solve the allocation issue as expected but blew a lot of tests up as the underlying`[]byte`s we're being re-used too quickly, so scrapped this idea.  If this fix doesn't solve the issue then perhaps we could use a slice of buffers and use an atomic counter to loop over them, if we had enough buffers then chance of the underlying []byte being re-used too quickly would be slim, but knowing how many buffers we'd need isn't something we could answer?

Created to help solve #4692