### PR TITLE
Log data if cannot decode BlockBodiesPacket66

### DIFF
--- a/cmd/sentry/sentry/sentry_multi_client.go
+++ b/cmd/sentry/sentry/sentry_multi_client.go
@@ -497,7 +497,7 @@ func (cs *MultiClient) newBlock66(ctx context.Context, inreq *proto_sentry.Inbou
 func (cs *MultiClient) blockBodies66(inreq *proto_sentry.InboundMessage, _ direct.SentryClient) error {
 	var request eth.BlockRawBodiesPacket66
 	if err := rlp.DecodeBytes(inreq.Data, &request); err != nil {
-		return fmt.Errorf("decode BlockBodiesPacket66: %w", err)
+		return fmt.Errorf("decode BlockBodiesPacket66: %w, data: %x", err, inreq.Data)
 	}
 	txs, uncles := request.BlockRawBodiesPacket.Unpack()
 	cs.Bd.DeliverBodies(&txs, &uncles, uint64(len(inreq.Data)), ConvertH512ToPeerID(inreq.PeerId))


### PR DESCRIPTION
Parithosh's teku-erigon node on MSF10 is stuck at a certain block with the following logs:
```
[WARN] [07-25|10:53:30.761] Handling incoming message                stream=RecvMessage err="decode BlockBodiesPacket66: rlp: input list has too many elements for eth.BlockRawBodiesPacket66"
[EROR] [07-28|09:24:30.643] gasprice.go: getBlockPrices              err=nil
[EROR] [07-28|09:24:30.643] gasprice.go: getBlockPrices              err=nil
```

This extra logging will give us more clues to what's going on.