### PR TITLE
Improve error handling for the non-delayed PoS downloader

### DIFF
--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -503,9 +503,8 @@ func verifyAndSaveNewPoSHeader(
 	headerNumber := header.Number.Uint64()
 	headerHash := block.Hash()
 
-	bad, lastValidHash := cfg.hd.IsBadHeaderPoS(header.ParentHash)
+	bad, lastValidHash := cfg.hd.IsBadHeaderPoS(headerHash)
 	if bad {
-		cfg.hd.ReportBadHeaderPoS(headerHash, lastValidHash)
 		return &engineapi.PayloadStatus{Status: remote.EngineStatus_INVALID, LatestValidHash: lastValidHash}, false, nil
 	}
 


### PR DESCRIPTION
A couple of corrections to PR #4812:
1. Don't wait for the downloader when `schedulePoSDownload` doesn't actually schedule it.
2. Use `headerHash` rather than parent hash as the check for downloader success in `verifyAndSaveNewPoSHeader` since `verifyAndSaveDownloadedPoSHeaders` uses `downloaderTip`, set to `headerHash`, to report bad blocks.