### PR TITLE
Adding config-file flag

### DIFF
--- a/cmd/erigon/main.go
+++ b/cmd/erigon/main.go
@@ -73,9 +73,11 @@ func setFlagsFromYamlFile(ctx *cli.Context, filePath string) error {
 
 	// sets global flags to value in yaml file
 	for key, value := range yamlFileConfig {
-		err := ctx.GlobalSet(key, value)
-		if err != nil {
-			return err
+		if !ctx.GlobalIsSet(key) {
+			err := ctx.GlobalSet(key, value)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/cmd/erigon/main.go
+++ b/cmd/erigon/main.go
@@ -42,7 +42,7 @@ func runErigon(cliCtx *cli.Context) {
 	// initializing the node and providing the current git commit there
 	logger.Info("Build info", "git_branch", params.GitBranch, "git_tag", params.GitTag, "git_commit", params.GitCommit)
 
-	yamlFilePath := cliCtx.GlobalString(utils.YamlConfigFlag.Name)
+	yamlFilePath := cliCtx.GlobalString(utils.ConfigFlag.Name)
 	if yamlFilePath != "" {
 		if err := setFlagsFromConfigFile(cliCtx, yamlFilePath); err != nil {
 			log.Warn("failed setting config flags from yaml file", "err", err)

--- a/cmd/erigon/main.go
+++ b/cmd/erigon/main.go
@@ -39,7 +39,7 @@ func runErigon(cliCtx *cli.Context) {
 	// initializing the node and providing the current git commit there
 	logger.Info("Build info", "git_branch", params.GitBranch, "git_tag", params.GitTag, "git_commit", params.GitCommit)
 
-	yamlFilePath := cliCtx.GlobalString(utils.ConfigYamlFileFlag.Name)
+	yamlFilePath := cliCtx.GlobalString(utils.YamlConfigFlag.Name)
 	if yamlFilePath != "" {
 		if err := setFlagsFromYamlFile(cliCtx, yamlFilePath); err != nil {
 			log.Warn("failed setting config flags from yaml file", "err", err)

--- a/cmd/erigon/main.go
+++ b/cmd/erigon/main.go
@@ -71,6 +71,7 @@ func setFlagsFromYamlFile(ctx *cli.Context, filePath string) error {
 		return err
 	}
 
+	// sets global flags to value in yaml file
 	for key, value := range yamlFileConfig {
 		err := ctx.GlobalSet(key, value)
 		if err != nil {

--- a/cmd/erigon/main.go
+++ b/cmd/erigon/main.go
@@ -2,15 +2,18 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 
 	"github.com/ledgerwatch/erigon-lib/common/dbg"
+	"github.com/ledgerwatch/erigon/cmd/utils"
 	"github.com/ledgerwatch/erigon/params"
 	erigonapp "github.com/ledgerwatch/erigon/turbo/app"
 	erigoncli "github.com/ledgerwatch/erigon/turbo/cli"
 	"github.com/ledgerwatch/erigon/turbo/node"
 	"github.com/ledgerwatch/log/v3"
 	"github.com/urfave/cli"
+	"gopkg.in/yaml.v2"
 )
 
 func main() {
@@ -35,6 +38,14 @@ func runErigon(cliCtx *cli.Context) {
 	logger := log.New()
 	// initializing the node and providing the current git commit there
 	logger.Info("Build info", "git_branch", params.GitBranch, "git_tag", params.GitTag, "git_commit", params.GitCommit)
+
+	yamlFilePath := cliCtx.GlobalString(utils.ConfigFileFlag.Name)
+	if yamlFilePath != "" {
+		if err := setFlagsFromYamlFile(cliCtx, yamlFilePath); err != nil {
+			log.Warn("failed setting config flags from yaml file", "err", err)
+		}
+	}
+
 	nodeCfg := node.NewNodConfigUrfave(cliCtx)
 	ethCfg := node.NewEthConfigUrfave(cliCtx, nodeCfg)
 
@@ -47,4 +58,25 @@ func runErigon(cliCtx *cli.Context) {
 	if err != nil {
 		log.Error("error while serving an Erigon node", "err", err)
 	}
+}
+
+func setFlagsFromYamlFile(ctx *cli.Context, filePath string) error {
+	yamlFile, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+	yamlFileConfig := make(map[string]string)
+	err = yaml.Unmarshal(yamlFile, yamlFileConfig)
+	if err != nil {
+		return err
+	}
+
+	for key, value := range yamlFileConfig {
+		err := ctx.GlobalSet(key, value)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/cmd/erigon/main.go
+++ b/cmd/erigon/main.go
@@ -39,7 +39,7 @@ func runErigon(cliCtx *cli.Context) {
 	// initializing the node and providing the current git commit there
 	logger.Info("Build info", "git_branch", params.GitBranch, "git_tag", params.GitTag, "git_commit", params.GitCommit)
 
-	yamlFilePath := cliCtx.GlobalString(utils.ConfigFileFlag.Name)
+	yamlFilePath := cliCtx.GlobalString(utils.ConfigYamlFileFlag.Name)
 	if yamlFilePath != "" {
 		if err := setFlagsFromYamlFile(cliCtx, yamlFilePath); err != nil {
 			log.Warn("failed setting config flags from yaml file", "err", err)

--- a/cmd/erigon/main.go
+++ b/cmd/erigon/main.go
@@ -42,10 +42,10 @@ func runErigon(cliCtx *cli.Context) {
 	// initializing the node and providing the current git commit there
 	logger.Info("Build info", "git_branch", params.GitBranch, "git_tag", params.GitTag, "git_commit", params.GitCommit)
 
-	yamlFilePath := cliCtx.GlobalString(utils.ConfigFlag.Name)
-	if yamlFilePath != "" {
-		if err := setFlagsFromConfigFile(cliCtx, yamlFilePath); err != nil {
-			log.Warn("failed setting config flags from yaml file", "err", err)
+	configFilePath := cliCtx.GlobalString(utils.ConfigFlag.Name)
+	if configFilePath != "" {
+		if err := setFlagsFromConfigFile(cliCtx, configFilePath); err != nil {
+			log.Warn("failed setting config flags from yaml/toml file", "err", err)
 		}
 	}
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -722,7 +722,7 @@ var (
 		Usage: "Run without Heimdall service (for testing purpose)",
 	}
 
-	ConfigFileFlag = cli.StringFlag{
+	ConfigYamlFileFlag = cli.StringFlag{
 		Name:  "config.yaml.file",
 		Usage: "Sets erigon flags from YAML file",
 		Value: "",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -721,6 +721,12 @@ var (
 		Name:  "bor.withoutheimdall",
 		Usage: "Run without Heimdall service (for testing purpose)",
 	}
+
+	ConfigFileFlag = cli.StringFlag{
+		Name:  "config.file",
+		Usage: "Sets erigon flags from YAML file",
+		Value: "",
+	}
 )
 
 var MetricFlags = []cli.Flag{MetricsEnabledFlag, MetricsEnabledExpensiveFlag, MetricsHTTPFlag, MetricsPortFlag}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -722,8 +722,8 @@ var (
 		Usage: "Run without Heimdall service (for testing purpose)",
 	}
 
-	ConfigYamlFileFlag = cli.StringFlag{
-		Name:  "config.yaml.file",
+	YamlConfigFlag = cli.StringFlag{
+		Name:  "yaml.config",
 		Usage: "Sets erigon flags from YAML file",
 		Value: "",
 	}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -723,7 +723,7 @@ var (
 	}
 
 	ConfigFileFlag = cli.StringFlag{
-		Name:  "config.file",
+		Name:  "config.yaml.file",
 		Usage: "Sets erigon flags from YAML file",
 		Value: "",
 	}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -722,9 +722,9 @@ var (
 		Usage: "Run without Heimdall service (for testing purpose)",
 	}
 
-	YamlConfigFlag = cli.StringFlag{
-		Name:  "yaml.config",
-		Usage: "Sets erigon flags from YAML file",
+	ConfigFlag = cli.StringFlag{
+		Name:  "config",
+		Usage: "Sets erigon flags from YAML/TOML file",
 		Value: "",
 	}
 )

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/ledgerwatch/log/v3 v3.4.1
 	github.com/ledgerwatch/secp256k1 v1.0.0
 	github.com/ledgerwatch/trackerslist v1.0.0
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (

--- a/testing.yaml
+++ b/testing.yaml
@@ -1,5 +1,0 @@
-chain: "goerli"
-port: 30302
-datadir: "~/Desktop/projects/erigon/testing-flag"
-http.port: 8542
-engine.port: 9999

--- a/testing.yaml
+++ b/testing.yaml
@@ -1,0 +1,5 @@
+chain: "goerli"
+port: 30302
+datadir: "~/Desktop/projects/erigon/testing-flag"
+http.port: 8542
+engine.port: 9999

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -139,5 +139,5 @@ var DefaultFlags = []cli.Flag{
 	utils.OverrideTerminalTotalDifficulty,
 	utils.OverrideMergeNetsplitBlock,
 
-	utils.ConfigYamlFileFlag,
+	utils.YamlConfigFlag,
 }

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -139,5 +139,5 @@ var DefaultFlags = []cli.Flag{
 	utils.OverrideTerminalTotalDifficulty,
 	utils.OverrideMergeNetsplitBlock,
 
-	utils.ConfigFileFlag,
+	utils.ConfigYamlFileFlag,
 }

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -139,5 +139,5 @@ var DefaultFlags = []cli.Flag{
 	utils.OverrideTerminalTotalDifficulty,
 	utils.OverrideMergeNetsplitBlock,
 
-	utils.YamlConfigFlag,
+	utils.ConfigFlag,
 }

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -138,4 +138,6 @@ var DefaultFlags = []cli.Flag{
 	utils.EthStatsURLFlag,
 	utils.OverrideTerminalTotalDifficulty,
 	utils.OverrideMergeNetsplitBlock,
+
+	utils.ConfigFileFlag,
 }

--- a/turbo/cli/flags.go
+++ b/turbo/cli/flags.go
@@ -2,12 +2,10 @@ package cli
 
 import (
 	"fmt"
-	"io/ioutil"
 	"strings"
 	"time"
 
 	"github.com/ledgerwatch/erigon/rpc/rpccfg"
-	"gopkg.in/yaml.v3"
 
 	"github.com/c2h5oh/datasize"
 	"github.com/ledgerwatch/erigon-lib/etl"
@@ -321,10 +319,6 @@ func setEmbeddedRpcDaemon(ctx *cli.Context, cfg *nodecfg.Config) {
 	apis := ctx.GlobalString(utils.HTTPApiFlag.Name)
 	log.Info("starting HTTP APIs", "APIs", apis)
 
-	if err := setFlagsFromYamlFile(ctx, ctx.GlobalString(utils.ConfigFileFlag.Name)); err != nil {
-		log.Warn("failed setting config flags from yaml file", "err", err)
-	}
-
 	c := &httpcfg.HttpCfg{
 		Enabled: ctx.GlobalBool(utils.HTTPEnabledFlag.Name),
 		Dirs:    cfg.Dirs,
@@ -416,25 +410,4 @@ func setPrivateApi(ctx *cli.Context, cfg *nodecfg.Config) {
 		cfg.TLSCACert = ctx.GlobalString(TLSCACertFlag.Name)
 	}
 	cfg.HealthCheck = ctx.GlobalBool(HealthCheckFlag.Name)
-}
-
-func setFlagsFromYamlFile(ctx *cli.Context, filePath string) error {
-	yamlFile, err := ioutil.ReadFile(filePath)
-	if err != nil {
-		return err
-	}
-	yamlFileConfig := make(map[string]string)
-	err = yaml.Unmarshal(yamlFile, yamlFileConfig)
-	if err != nil {
-		return err
-	}
-
-	for key, value := range yamlFileConfig {
-		err := ctx.GlobalSet(key, value)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }


### PR DESCRIPTION
`--config-file` will allow for Erigon to accept a YAML file with flags, as specified in #4863 
Also added a log for all the http.api APIs being used