### PR TITLE
Fix separated auth RPC server 

### DIFF
--- a/cmd/devnettest/rpcdaemon/daemon.go
+++ b/cmd/devnettest/rpcdaemon/daemon.go
@@ -1,12 +1,12 @@
 package rpcdaemon
 
 import (
-	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/cli/httpcfg"
 	"os"
 	"time"
 
 	"github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/cli"
+	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/cli/httpcfg"
 	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/commands"
 	"github.com/ledgerwatch/log/v3"
 	"github.com/spf13/cobra"
@@ -31,8 +31,7 @@ func RunDaemon() {
 		}
 
 		apiList := commands.APIList(db, borDb, backend, txPool, mining, starknet, ff, stateCache, blockReader, *cfg)
-		authApiList := commands.AuthAPIList(db, backend, txPool, mining, ff, stateCache, blockReader, *cfg)
-		if err := cli.StartRpcServer(ctx, *cfg, apiList, authApiList); err != nil {
+		if err := cli.StartRpcServer(ctx, *cfg, apiList, nil); err != nil {
 			log.Error(err.Error())
 			return nil
 		}

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -439,10 +439,12 @@ func RemoteServices(ctx context.Context, cfg httpcfg.HttpCfg, logger log.Logger,
 
 func StartRpcServer(ctx context.Context, cfg httpcfg.HttpCfg, rpcAPI []rpc.API, authAPI []rpc.API) error {
 	if len(authAPI) > 0 {
-		err := startAuthenticatedRpcServer(ctx, cfg, authAPI)
-		if err != nil {
-			return err
-		}
+		go func() {
+			if err := startAuthenticatedRpcServer(ctx, cfg, authAPI); err != nil {
+				log.Error(err.Error())
+				return
+			}
+		}()
 	}
 
 	if cfg.Enabled {

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -438,9 +438,11 @@ func RemoteServices(ctx context.Context, cfg httpcfg.HttpCfg, logger log.Logger,
 }
 
 func StartRpcServer(ctx context.Context, cfg httpcfg.HttpCfg, rpcAPI []rpc.API, authAPI []rpc.API) error {
-	err := startAuthenticatedRpcServer(ctx, cfg, authAPI)
-	if err != nil {
-		return err
+	if len(authAPI) > 0 {
+		err := startAuthenticatedRpcServer(ctx, cfg, authAPI)
+		if err != nil {
+			return err
+		}
 	}
 
 	if cfg.Enabled {

--- a/cmd/rpcdaemon/main.go
+++ b/cmd/rpcdaemon/main.go
@@ -27,8 +27,7 @@ func main() {
 		}
 
 		apiList := commands.APIList(db, borDb, backend, txPool, mining, starknet, ff, stateCache, blockReader, *cfg)
-		authApiList := commands.AuthAPIList(db, backend, txPool, mining, ff, stateCache, blockReader, *cfg)
-		if err := cli.StartRpcServer(ctx, *cfg, apiList, authApiList); err != nil {
+		if err := cli.StartRpcServer(ctx, *cfg, apiList, nil); err != nil {
 			log.Error(err.Error())
 			return nil
 		}


### PR DESCRIPTION
This is a fix for PR #4822. Two issues were [reported](https://discord.com/channels/687972960811745322/687972960811745326/1003409967493156874) on Discord:

1. `startAuthenticatedRpcServer` was not returning and this preventing `startRegularRpcServer` from starting
2. Engine API server was also started by `rpcdaemon`, conflicting with the one started by `erigon`.

With this change `rpcdaemon` does not start an Engine API server, only `erigon` itself does.