### PR TITLE
Don't start engine API in standalone rpcdaemon

### DIFF
--- a/cmd/devnettest/rpcdaemon/daemon.go
+++ b/cmd/devnettest/rpcdaemon/daemon.go
@@ -1,12 +1,12 @@
 package rpcdaemon
 
 import (
-	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/cli/httpcfg"
 	"os"
 	"time"
 
 	"github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/cli"
+	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/cli/httpcfg"
 	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/commands"
 	"github.com/ledgerwatch/log/v3"
 	"github.com/spf13/cobra"
@@ -31,8 +31,7 @@ func RunDaemon() {
 		}
 
 		apiList := commands.APIList(db, borDb, backend, txPool, mining, starknet, ff, stateCache, blockReader, *cfg)
-		authApiList := commands.AuthAPIList(db, backend, txPool, mining, ff, stateCache, blockReader, *cfg)
-		if err := cli.StartRpcServer(ctx, *cfg, apiList, authApiList); err != nil {
+		if err := cli.StartRpcServer(ctx, *cfg, apiList, nil); err != nil {
 			log.Error(err.Error())
 			return nil
 		}

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -438,10 +438,12 @@ func RemoteServices(ctx context.Context, cfg httpcfg.HttpCfg, logger log.Logger,
 }
 
 func StartRpcServer(ctx context.Context, cfg httpcfg.HttpCfg, rpcAPI []rpc.API, authAPI []rpc.API) error {
-	engineInfo, err := startAuthenticatedRpcServer(cfg, authAPI)
-	go stopAuthenticatedRpcServer(ctx, engineInfo)
-	if err != nil {
-		return err
+	if len(authAPI) > 0 {
+		engineInfo, err := startAuthenticatedRpcServer(cfg, authAPI)
+		if err != nil {
+			return err
+		}
+		go stopAuthenticatedRpcServer(ctx, engineInfo)
 	}
 
 	if cfg.Enabled {

--- a/cmd/rpcdaemon/main.go
+++ b/cmd/rpcdaemon/main.go
@@ -27,8 +27,7 @@ func main() {
 		}
 
 		apiList := commands.APIList(db, borDb, backend, txPool, mining, starknet, ff, stateCache, blockReader, *cfg)
-		authApiList := commands.AuthAPIList(db, backend, txPool, mining, ff, stateCache, blockReader, *cfg)
-		if err := cli.StartRpcServer(ctx, *cfg, apiList, authApiList); err != nil {
+		if err := cli.StartRpcServer(ctx, *cfg, apiList, nil); err != nil {
 			log.Error(err.Error())
 			return nil
 		}


### PR DESCRIPTION
With this change `rpcdaemon` does not start an Engine API server, only `erigon` itself does. This prevents a conflict [reported](https://discord.com/channels/687972960811745322/687972960811745326/1003409967493156874) on Discord.