### PR TITLE
Transaction count fix

### DIFF
--- a/cmd/rpcdaemon/commands/eth_block.go
+++ b/cmd/rpcdaemon/commands/eth_block.go
@@ -318,15 +318,18 @@ func (api *APIImpl) GetBlockTransactionCountByNumber(ctx context.Context, blockN
 	if err != nil {
 		return nil, err
 	}
-	body, err := api._blockReader.BodyWithTransactions(ctx, tx, blockHash, blockNum)
+	_, txAmount, err := api._blockReader.Body(ctx, tx, blockHash, blockNum)
 	if err != nil {
 		return nil, err
 	}
-	if body == nil {
+
+	if txAmount == 0 {
 		return nil, nil
 	}
-	txAmount := hexutil.Uint(len(body.Transactions))
-	return &txAmount, nil
+
+	numOfTx := hexutil.Uint(txAmount)
+
+	return &numOfTx, nil
 }
 
 // GetBlockTransactionCountByHash implements eth_getBlockTransactionCountByHash. Returns the number of transactions in a block given the block's block hash.
@@ -340,11 +343,16 @@ func (api *APIImpl) GetBlockTransactionCountByHash(ctx context.Context, blockHas
 	if err != nil {
 		return nil, err
 	}
-	blockBody, err := api._blockReader.BodyWithTransactions(ctx, tx, blockHash, blockNum)
+	_, txAmount, err := api._blockReader.Body(ctx, tx, blockHash, blockNum)
 	if err != nil {
 		return nil, err
 	}
 
-	numOfTx := hexutil.Uint(len(blockBody.Transactions))
+	if txAmount == 0 {
+		return nil, nil
+	}
+
+	numOfTx := hexutil.Uint(txAmount)
+
 	return &numOfTx, nil
 }

--- a/cmd/rpcdaemon/commands/eth_block.go
+++ b/cmd/rpcdaemon/commands/eth_block.go
@@ -314,19 +314,19 @@ func (api *APIImpl) GetBlockTransactionCountByNumber(ctx context.Context, blockN
 		n := hexutil.Uint(len(b.Transactions()))
 		return &n, nil
 	}
-	blockNum, _, _, err := rpchelper.GetBlockNumber(rpc.BlockNumberOrHashWithNumber(blockNr), tx, api.filters)
+	blockNum, blockHash, _, err := rpchelper.GetBlockNumber(rpc.BlockNumberOrHashWithNumber(blockNr), tx, api.filters)
 	if err != nil {
 		return nil, err
 	}
-	body, _, txAmount, err := rawdb.ReadBodyByNumber(tx, blockNum)
+	body, err := api._blockReader.Body(ctx, tx, blockHash, blockNum)
 	if err != nil {
 		return nil, err
 	}
 	if body == nil {
 		return nil, nil
 	}
-	n := hexutil.Uint(txAmount)
-	return &n, nil
+	txAmount := hexutil.Uint(len(body.Transactions) - 2) // 1 system txn in the begining of block, and 1 at the end
+	return &txAmount, nil
 }
 
 // GetBlockTransactionCountByHash implements eth_getBlockTransactionCountByHash. Returns the number of transactions in a block given the block's block hash.
@@ -346,6 +346,6 @@ func (api *APIImpl) GetBlockTransactionCountByHash(ctx context.Context, blockHas
 		return nil, err
 	}
 
-	numOfTx := (uint)(len(blockBody.Transactions) - 2) // 1 system txn in the begining of block, and 1 at the end
-	return (*hexutil.Uint)(&numOfTx), nil
+	numOfTx := hexutil.Uint((len(blockBody.Transactions) - 2)) // 1 system txn in the begining of block, and 1 at the end
+	return &numOfTx, nil
 }

--- a/cmd/rpcdaemon/commands/eth_block.go
+++ b/cmd/rpcdaemon/commands/eth_block.go
@@ -318,14 +318,14 @@ func (api *APIImpl) GetBlockTransactionCountByNumber(ctx context.Context, blockN
 	if err != nil {
 		return nil, err
 	}
-	body, err := api._blockReader.Body(ctx, tx, blockHash, blockNum)
+	body, err := api._blockReader.BodyWithTransactions(ctx, tx, blockHash, blockNum)
 	if err != nil {
 		return nil, err
 	}
 	if body == nil {
 		return nil, nil
 	}
-	txAmount := hexutil.Uint(len(body.Transactions) - 2) // 1 system txn in the begining of block, and 1 at the end
+	txAmount := hexutil.Uint(len(body.Transactions))
 	return &txAmount, nil
 }
 
@@ -340,12 +340,11 @@ func (api *APIImpl) GetBlockTransactionCountByHash(ctx context.Context, blockHas
 	if err != nil {
 		return nil, err
 	}
-
-	blockBody, err := api._blockReader.Body(ctx, tx, blockHash, blockNum)
+	blockBody, err := api._blockReader.BodyWithTransactions(ctx, tx, blockHash, blockNum)
 	if err != nil {
 		return nil, err
 	}
 
-	numOfTx := hexutil.Uint((len(blockBody.Transactions) - 2)) // 1 system txn in the begining of block, and 1 at the end
+	numOfTx := hexutil.Uint(len(blockBody.Transactions))
 	return &numOfTx, nil
 }

--- a/cmd/rpcdaemon/rpcservices/eth_backend.go
+++ b/cmd/rpcdaemon/rpcservices/eth_backend.go
@@ -177,7 +177,7 @@ func (back *RemoteBackend) BodyWithTransactions(ctx context.Context, tx kv.Gette
 func (back *RemoteBackend) BodyRlp(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (bodyRlp rlp.RawValue, err error) {
 	return back.blockReader.BodyRlp(ctx, tx, hash, blockHeight)
 }
-func (back *RemoteBackend) Body(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (body *types.Body, err error) {
+func (back *RemoteBackend) Body(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (body *types.Body, txAmount uint32, err error) {
 	return back.blockReader.Body(ctx, tx, hash, blockHeight)
 }
 func (back *RemoteBackend) Header(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (*types.Header, error) {

--- a/cmd/rpcdaemon22/commands/trace_filtering.go
+++ b/cmd/rpcdaemon22/commands/trace_filtering.go
@@ -339,7 +339,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 			lastRules = chainConfig.Rules(blockNum)
 		}
 		if txNum+1 == api._txNums[blockNum] {
-			body, err := api._blockReader.Body(ctx, nil, lastBlockHash, blockNum)
+			body, _, err := api._blockReader.Body(ctx, nil, lastBlockHash, blockNum)
 			if err != nil {
 				stream.WriteNil()
 				return err

--- a/cmd/rpcdaemon22/rpcservices/eth_backend.go
+++ b/cmd/rpcdaemon22/rpcservices/eth_backend.go
@@ -177,7 +177,7 @@ func (back *RemoteBackend) BodyWithTransactions(ctx context.Context, tx kv.Gette
 func (back *RemoteBackend) BodyRlp(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (bodyRlp rlp.RawValue, err error) {
 	return back.blockReader.BodyRlp(ctx, tx, hash, blockHeight)
 }
-func (back *RemoteBackend) Body(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (body *types.Body, err error) {
+func (back *RemoteBackend) Body(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (body *types.Body, txAmount uint32, err error) {
 	return back.blockReader.Body(ctx, tx, hash, blockHeight)
 }
 func (back *RemoteBackend) Header(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (*types.Header, error) {

--- a/eth/stagedsync/stage_issuance.go
+++ b/eth/stagedsync/stage_issuance.go
@@ -133,7 +133,7 @@ func SpawnStageIssuance(cfg IssuanceCfg, s *StageState, tx kv.RwTx, ctx context.
 			if header.UncleHash == types.EmptyUncleHash {
 				blockReward, uncleRewards = ethash.AccumulateRewards(cfg.chainConfig, &header, nil)
 			} else {
-				body, err := cfg.blockReader.Body(ctx, tx, hash, currentBlockNumber)
+				body, _, err := cfg.blockReader.Body(ctx, tx, hash, currentBlockNumber)
 				if err != nil {
 					return err
 				}

--- a/turbo/services/interfaces.go
+++ b/turbo/services/interfaces.go
@@ -30,7 +30,7 @@ type CanonicalReader interface {
 type BodyReader interface {
 	BodyWithTransactions(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (body *types.Body, err error)
 	BodyRlp(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (bodyRlp rlp.RawValue, err error)
-	Body(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (body *types.Body, err error)
+	Body(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (body *types.Body, txAmount uint32, err error)
 }
 
 type TxnReader interface {


### PR DESCRIPTION
Addressing the issue in #4755. We are now reading the block bodies from the `blockreader`