### PR TITLE
Fix rpc json #4838

### DIFF
--- a/cmd/rpcdaemon/commands/trace_filtering.go
+++ b/cmd/rpcdaemon/commands/trace_filtering.go
@@ -9,16 +9,16 @@ import (
 	jsoniter "github.com/json-iterator/go"
 	"github.com/ledgerwatch/erigon-lib/kv"
 
-	"github.com/ledgerwatch/erigon/common"
-	"github.com/ledgerwatch/erigon/common/hexutil"
-	"github.com/ledgerwatch/erigon/consensus/ethash"
-	"github.com/ledgerwatch/erigon/core/rawdb"
-	"github.com/ledgerwatch/erigon/core/types"
-	"github.com/ledgerwatch/erigon/ethdb"
-	"github.com/ledgerwatch/erigon/ethdb/bitmapdb"
-	"github.com/ledgerwatch/erigon/params"
-	"github.com/ledgerwatch/erigon/rpc"
-	"github.com/ledgerwatch/erigon/turbo/rpchelper"
+	"github.com/dafky2000/erigon/common"
+	"github.com/dafky2000/erigon/common/hexutil"
+	"github.com/dafky2000/erigon/consensus/ethash"
+	"github.com/dafky2000/erigon/core/rawdb"
+	"github.com/dafky2000/erigon/core/types"
+	"github.com/dafky2000/erigon/ethdb"
+	"github.com/dafky2000/erigon/ethdb/bitmapdb"
+	"github.com/dafky2000/erigon/params"
+	"github.com/dafky2000/erigon/rpc"
+	"github.com/dafky2000/erigon/turbo/rpchelper"
 )
 
 // Transaction implements trace_transaction
@@ -326,7 +326,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 			} else {
 				stream.WriteMore()
 			}
-			rpc.handleError(hashErr, stream)
+			handleError(hashErr, stream)
 			continue
 		}
 
@@ -337,7 +337,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 			} else {
 				stream.WriteMore()
 			}
-			rpc.handleError(bErr, stream)
+			handleError(bErr, stream)
 			continue
 		}
 		if block == nil {
@@ -346,7 +346,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 			} else {
 				stream.WriteMore()
 			}
-			rpc.handleError(fmt.Errorf("could not find block %x %d", hash, b), stream)
+			handleError(fmt.Errorf("could not find block %x %d", hash, b), stream)
 			continue
 		}
 
@@ -360,7 +360,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 			} else {
 				stream.WriteMore()
 			}
-			rpc.handleError(tErr, stream)
+			handleError(tErr, stream)
 			continue
 		}
 		includeAll := len(fromAddresses) == 0 && len(toAddresses) == 0
@@ -382,7 +382,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 						} else {
 							stream.WriteMore()
 						}
-						rpc.handleError(err, stream)
+						handleError(err, stream)
 						continue
 					}
 					if nSeen > after && nExported < count {
@@ -419,7 +419,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 				} else {
 					stream.WriteMore()
 				}
-				rpc.handleError(err, stream)
+				handleError(err, stream)
 				continue
 			}
 			if nSeen > after && nExported < count {
@@ -455,7 +455,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 						} else {
 							stream.WriteMore()
 						}
-						rpc.handleError(err, stream)
+						handleError(err, stream)
 						continue
 					}
 					if nSeen > after && nExported < count {

--- a/cmd/rpcdaemon/commands/trace_filtering.go
+++ b/cmd/rpcdaemon/commands/trace_filtering.go
@@ -9,16 +9,16 @@ import (
 	jsoniter "github.com/json-iterator/go"
 	"github.com/ledgerwatch/erigon-lib/kv"
 
-	"github.com/dafky2000/erigon/common"
-	"github.com/dafky2000/erigon/common/hexutil"
-	"github.com/dafky2000/erigon/consensus/ethash"
-	"github.com/dafky2000/erigon/core/rawdb"
-	"github.com/dafky2000/erigon/core/types"
-	"github.com/dafky2000/erigon/ethdb"
-	"github.com/dafky2000/erigon/ethdb/bitmapdb"
-	"github.com/dafky2000/erigon/params"
-	"github.com/dafky2000/erigon/rpc"
-	"github.com/dafky2000/erigon/turbo/rpchelper"
+	"github.com/ledgerwatch/erigon/common"
+	"github.com/ledgerwatch/erigon/common/hexutil"
+	"github.com/ledgerwatch/erigon/consensus/ethash"
+	"github.com/ledgerwatch/erigon/core/rawdb"
+	"github.com/ledgerwatch/erigon/core/types"
+	"github.com/ledgerwatch/erigon/ethdb"
+	"github.com/ledgerwatch/erigon/ethdb/bitmapdb"
+	"github.com/ledgerwatch/erigon/params"
+	"github.com/ledgerwatch/erigon/rpc"
+	"github.com/ledgerwatch/erigon/turbo/rpchelper"
 )
 
 // Transaction implements trace_transaction
@@ -326,7 +326,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 			} else {
 				stream.WriteMore()
 			}
-			handleError(hashErr, stream)
+			rpc.handleError(hashErr, stream)
 			continue
 		}
 
@@ -337,7 +337,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 			} else {
 				stream.WriteMore()
 			}
-			handleError(bErr, stream)
+			rpc.handleError(bErr, stream)
 			continue
 		}
 		if block == nil {
@@ -346,7 +346,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 			} else {
 				stream.WriteMore()
 			}
-			handleError(fmt.Errorf("could not find block %x %d", hash, b), stream)
+			rpc.handleError(fmt.Errorf("could not find block %x %d", hash, b), stream)
 			continue
 		}
 
@@ -360,7 +360,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 			} else {
 				stream.WriteMore()
 			}
-			handleError(tErr, stream)
+			rpc.handleError(tErr, stream)
 			continue
 		}
 		includeAll := len(fromAddresses) == 0 && len(toAddresses) == 0
@@ -382,7 +382,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 						} else {
 							stream.WriteMore()
 						}
-						handleError(err, stream)
+						rpc.handleError(err, stream)
 						continue
 					}
 					if nSeen > after && nExported < count {
@@ -419,7 +419,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 				} else {
 					stream.WriteMore()
 				}
-				handleError(err, stream)
+				rpc.handleError(err, stream)
 				continue
 			}
 			if nSeen > after && nExported < count {
@@ -455,7 +455,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 						} else {
 							stream.WriteMore()
 						}
-						handleError(err, stream)
+						rpc.handleError(err, stream)
 						continue
 					}
 					if nSeen > after && nExported < count {

--- a/cmd/rpcdaemon/commands/trace_filtering.go
+++ b/cmd/rpcdaemon/commands/trace_filtering.go
@@ -321,7 +321,9 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 			} else {
 				stream.WriteMore()
 			}
+			stream.WriteObjectStart()
 			rpc.HandleError(hashErr, stream)
+			stream.WriteObjectEnd()
 			continue
 		}
 
@@ -332,7 +334,9 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 			} else {
 				stream.WriteMore()
 			}
+			stream.WriteObjectStart()
 			rpc.HandleError(bErr, stream)
+			stream.WriteObjectEnd()
 			continue
 		}
 		if block == nil {
@@ -341,7 +345,9 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 			} else {
 				stream.WriteMore()
 			}
+			stream.WriteObjectStart()
 			rpc.HandleError(fmt.Errorf("could not find block %x %d", hash, b), stream)
+			stream.WriteObjectEnd()
 			continue
 		}
 
@@ -355,7 +361,9 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 			} else {
 				stream.WriteMore()
 			}
+			stream.WriteObjectStart()
 			rpc.HandleError(tErr, stream)
+			stream.WriteObjectEnd()
 			continue
 		}
 		includeAll := len(fromAddresses) == 0 && len(toAddresses) == 0
@@ -377,7 +385,9 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 						} else {
 							stream.WriteMore()
 						}
+						stream.WriteObjectStart()
 						rpc.HandleError(err, stream)
+						stream.WriteObjectEnd()
 						continue
 					}
 					if nSeen > after && nExported < count {
@@ -414,7 +424,9 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 				} else {
 					stream.WriteMore()
 				}
+				stream.WriteObjectStart()
 				rpc.HandleError(err, stream)
+				stream.WriteObjectEnd()
 				continue
 			}
 			if nSeen > after && nExported < count {
@@ -450,7 +462,9 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 						} else {
 							stream.WriteMore()
 						}
+						stream.WriteObjectStart()
 						rpc.HandleError(err, stream)
+						stream.WriteObjectEnd()
 						continue
 					}
 					if nSeen > after && nExported < count {

--- a/cmd/rpcdaemon/commands/trace_filtering.go
+++ b/cmd/rpcdaemon/commands/trace_filtering.go
@@ -212,7 +212,6 @@ func (api *TraceAPIImpl) Block(ctx context.Context, blockNr rpc.BlockNumber) (Pa
 func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, stream *jsoniter.Stream) error {
 	dbtx, err1 := api.kv.BeginRo(ctx)
 	if err1 != nil {
-		stream.WriteNil()
 		return fmt.Errorf("traceFilter cannot open tx: %w", err1)
 	}
 	defer dbtx.Rollback()
@@ -233,7 +232,6 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 	}
 
 	if fromBlock > toBlock {
-		stream.WriteNil()
 		return fmt.Errorf("invalid parameters: fromBlock cannot be greater than toBlock")
 	}
 
@@ -252,7 +250,6 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 				if errors.Is(err, ethdb.ErrKeyNotFound) {
 					continue
 				}
-				stream.WriteNil()
 				return err
 			}
 			allBlocks.Or(b)
@@ -268,7 +265,6 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 					continue
 				}
 
-				stream.WriteNil()
 				return err
 			}
 			blocksTo.Or(b)
@@ -295,7 +291,6 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 
 	chainConfig, err := api.chainConfig(dbtx)
 	if err != nil {
-		stream.WriteNil()
 		return err
 	}
 

--- a/cmd/rpcdaemon/commands/trace_filtering.go
+++ b/cmd/rpcdaemon/commands/trace_filtering.go
@@ -326,7 +326,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 			} else {
 				stream.WriteMore()
 			}
-			rpc.handleError(hashErr, stream)
+			rpc.HandleError(hashErr, stream)
 			continue
 		}
 
@@ -337,7 +337,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 			} else {
 				stream.WriteMore()
 			}
-			rpc.handleError(bErr, stream)
+			rpc.HandleError(bErr, stream)
 			continue
 		}
 		if block == nil {
@@ -346,7 +346,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 			} else {
 				stream.WriteMore()
 			}
-			rpc.handleError(fmt.Errorf("could not find block %x %d", hash, b), stream)
+			rpc.HandleError(fmt.Errorf("could not find block %x %d", hash, b), stream)
 			continue
 		}
 
@@ -360,7 +360,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 			} else {
 				stream.WriteMore()
 			}
-			rpc.handleError(tErr, stream)
+			rpc.HandleError(tErr, stream)
 			continue
 		}
 		includeAll := len(fromAddresses) == 0 && len(toAddresses) == 0
@@ -382,7 +382,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 						} else {
 							stream.WriteMore()
 						}
-						rpc.handleError(err, stream)
+						rpc.HandleError(err, stream)
 						continue
 					}
 					if nSeen > after && nExported < count {
@@ -419,7 +419,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 				} else {
 					stream.WriteMore()
 				}
-				rpc.handleError(err, stream)
+				rpc.HandleError(err, stream)
 				continue
 			}
 			if nSeen > after && nExported < count {
@@ -455,7 +455,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 						} else {
 							stream.WriteMore()
 						}
-						rpc.handleError(err, stream)
+						rpc.HandleError(err, stream)
 						continue
 					}
 					if nSeen > after && nExported < count {

--- a/cmd/rpcdaemon22/commands/trace_filtering.go
+++ b/cmd/rpcdaemon22/commands/trace_filtering.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sort"
 

--- a/cmd/rpcdaemon22/commands/trace_filtering.go
+++ b/cmd/rpcdaemon22/commands/trace_filtering.go
@@ -335,7 +335,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 				} else {
 					stream.WriteMore()
 				}
-				rpc.handleError(err, stream)
+				rpc.HandleError(err, stream)
 				continue
 			}
 			lastBlockNum = blockNum
@@ -351,7 +351,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 				} else {
 					stream.WriteMore()
 				}
-				rpc.handleError(err, stream)
+				rpc.HandleError(err, stream)
 				continue
 			}
 			// Block reward section, handle specially
@@ -377,7 +377,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 					} else {
 						stream.WriteMore()
 					}
-					rpc.handleError(err, stream)
+					rpc.HandleError(err, stream)
 					continue
 				}
 				if nSeen > after && nExported < count {
@@ -413,7 +413,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 							} else {
 								stream.WriteMore()
 							}
-							rpc.handleError(err, stream)
+							rpc.HandleError(err, stream)
 							continue
 						}
 						if nSeen > after && nExported < count {
@@ -449,7 +449,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 			} else {
 				stream.WriteMore()
 			}
-			rpc.handleError(err, stream)
+			rpc.HandleError(err, stream)
 			continue
 		}
 		contractHasTEVM := func(contractHash common.Hash) (bool, error) { return false, nil }
@@ -481,7 +481,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 			} else {
 				stream.WriteMore()
 			}
-			rpc.handleError(err, stream)
+			rpc.HandleError(err, stream)
 			continue
 		}
 		traceResult.Output = common.CopyBytes(execResult.ReturnData)
@@ -491,7 +491,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 			} else {
 				stream.WriteMore()
 			}
-			rpc.handleError(err, stream)
+			rpc.HandleError(err, stream)
 			continue
 		}
 		if err = ibs.CommitBlock(evm.ChainRules(), cachedWriter); err != nil {
@@ -500,7 +500,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 			} else {
 				stream.WriteMore()
 			}
-			rpc.handleError(err, stream)
+			rpc.HandleError(err, stream)
 			continue
 		}
 		for _, pt := range traceResult.Trace {
@@ -517,7 +517,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 					} else {
 						stream.WriteMore()
 					}
-					rpc.handleError(err, stream)
+					rpc.HandleError(err, stream)
 					continue
 				}
 				if nSeen > after && nExported < count {

--- a/cmd/rpcdaemon22/commands/trace_filtering.go
+++ b/cmd/rpcdaemon22/commands/trace_filtering.go
@@ -332,7 +332,9 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 				} else {
 					stream.WriteMore()
 				}
+				stream.WriteObjectStart()
 				rpc.HandleError(err, stream)
+				stream.WriteObjectEnd()
 				continue
 			}
 			lastBlockNum = blockNum
@@ -348,7 +350,9 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 				} else {
 					stream.WriteMore()
 				}
+				stream.WriteObjectStart()
 				rpc.HandleError(err, stream)
+				stream.WriteObjectEnd()
 				continue
 			}
 			// Block reward section, handle specially
@@ -374,7 +378,9 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 					} else {
 						stream.WriteMore()
 					}
+					stream.WriteObjectStart()
 					rpc.HandleError(err, stream)
+					stream.WriteObjectEnd()
 					continue
 				}
 				if nSeen > after && nExported < count {
@@ -410,7 +416,9 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 							} else {
 								stream.WriteMore()
 							}
+							stream.WriteObjectStart()
 							rpc.HandleError(err, stream)
+							stream.WriteObjectEnd()
 							continue
 						}
 						if nSeen > after && nExported < count {
@@ -440,7 +448,9 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 			} else {
 				stream.WriteMore()
 			}
+			stream.WriteObjectStart()
 			rpc.HandleError(err, stream)
+			stream.WriteObjectEnd()
 			continue
 		}
 		txHash := txn.Hash()
@@ -451,7 +461,9 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 			} else {
 				stream.WriteMore()
 			}
+			stream.WriteObjectStart()
 			rpc.HandleError(err, stream)
+			stream.WriteObjectEnd()
 			continue
 		}
 		contractHasTEVM := func(contractHash common.Hash) (bool, error) { return false, nil }
@@ -483,7 +495,9 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 			} else {
 				stream.WriteMore()
 			}
+			stream.WriteObjectStart()
 			rpc.HandleError(err, stream)
+			stream.WriteObjectEnd()
 			continue
 		}
 		traceResult.Output = common.CopyBytes(execResult.ReturnData)
@@ -493,7 +507,9 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 			} else {
 				stream.WriteMore()
 			}
+			stream.WriteObjectStart()
 			rpc.HandleError(err, stream)
+			stream.WriteObjectEnd()
 			continue
 		}
 		if err = ibs.CommitBlock(evm.ChainRules(), cachedWriter); err != nil {
@@ -502,7 +518,9 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 			} else {
 				stream.WriteMore()
 			}
+			stream.WriteObjectStart()
 			rpc.HandleError(err, stream)
+			stream.WriteObjectEnd()
 			continue
 		}
 		for _, pt := range traceResult.Trace {
@@ -519,7 +537,9 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, str
 					} else {
 						stream.WriteMore()
 					}
+					stream.WriteObjectStart()
 					rpc.HandleError(err, stream)
+					stream.WriteObjectEnd()
 					continue
 				}
 				if nSeen > after && nExported < count {

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -79,7 +79,7 @@ type callProc struct {
 	notifiers []*Notifier
 }
 
-func handleError(err error, stream *jsoniter.Stream) error {
+func HandleError(err error, stream *jsoniter.Stream) error {
 	if err != nil {
 		//return msg.errorResponse(err)
 		stream.WriteObjectStart()

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -511,7 +511,10 @@ func (h *handler) runMethod(ctx context.Context, msg *jsonrpcMessage, callb *cal
 		stream.WriteMore()
 	}
 	stream.WriteObjectField("result")
-	callb.call(ctx, msg.Method, args, stream)
+	_, err := callb.call(ctx, msg.Method, args, stream)
+	if err != nil {
+		HandleError(err, stream)
+	}
 	stream.WriteObjectEnd()
 	stream.Flush()
 	return nil

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -82,7 +82,6 @@ type callProc struct {
 func HandleError(err error, stream *jsoniter.Stream) error {
 	if err != nil {
 		//return msg.errorResponse(err)
-		stream.WriteObjectStart()
 		stream.WriteObjectField("error")
 		stream.WriteObjectStart()
 		stream.WriteObjectField("code")
@@ -106,7 +105,6 @@ func HandleError(err error, stream *jsoniter.Stream) error {
 				stream.WriteString(fmt.Sprintf("%v", derr))
 			}
 		}
-		stream.WriteObjectEnd()
 		stream.WriteObjectEnd()
 	}
 
@@ -513,6 +511,8 @@ func (h *handler) runMethod(ctx context.Context, msg *jsonrpcMessage, callb *cal
 	stream.WriteObjectField("result")
 	_, err := callb.call(ctx, msg.Method, args, stream)
 	if err != nil {
+		stream.WriteNil();
+		stream.WriteMore();
 		HandleError(err, stream)
 	}
 	stream.WriteObjectEnd()

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -511,8 +511,8 @@ func (h *handler) runMethod(ctx context.Context, msg *jsonrpcMessage, callb *cal
 	stream.WriteObjectField("result")
 	_, err := callb.call(ctx, msg.Method, args, stream)
 	if err != nil {
-		stream.WriteNil();
-		stream.WriteMore();
+		stream.WriteNil()
+		stream.WriteMore()
 		HandleError(err, stream)
 	}
 	stream.WriteObjectEnd()


### PR DESCRIPTION
A little bit of guesswork and my first foray into Golang... It has fixed the error case I was exhibiting with some trace_filter requests on polygon (same as #4784) and seems to be running well beyond. Should return a trace (or error) for each transaction and not fail mid-way through the batch of transactions.

maybe
fixes #4838 
fixes #4784 