### PR TITLE
rpc: fix for map concurrency issue in logs subscription

### DIFF
--- a/turbo/rpchelper/filters.go
+++ b/turbo/rpchelper/filters.go
@@ -17,12 +17,13 @@ import (
 	"github.com/ledgerwatch/erigon-lib/gointerfaces/remote"
 	"github.com/ledgerwatch/erigon-lib/gointerfaces/txpool"
 	txpool2 "github.com/ledgerwatch/erigon-lib/txpool"
+	"github.com/ledgerwatch/log/v3"
+	"google.golang.org/grpc"
+
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/eth/filters"
 	"github.com/ledgerwatch/erigon/rlp"
-	"github.com/ledgerwatch/log/v3"
-	"google.golang.org/grpc"
 )
 
 type (
@@ -400,14 +401,14 @@ func (ff *Filters) SubscribeLogs(out chan *types.Log, crit filters.FilterCriteri
 		AllAddresses: ff.logsSubs.aggLogsFilter.allAddrs == 1,
 		AllTopics:    ff.logsSubs.aggLogsFilter.allTopics == 1,
 	}
+	ff.mu.Lock()
+	defer ff.mu.Unlock()
 	for addr := range ff.logsSubs.aggLogsFilter.addrs {
 		lfr.Addresses = append(lfr.Addresses, gointerfaces.ConvertAddressToH160(addr))
 	}
 	for topic := range ff.logsSubs.aggLogsFilter.topics {
 		lfr.Topics = append(lfr.Topics, gointerfaces.ConvertHashToH256(topic))
 	}
-	ff.mu.Lock()
-	defer ff.mu.Unlock()
 	loaded := ff.logsRequestor.Load()
 	if loaded != nil {
 		if err := loaded.(func(*remote.LogsFilterRequest) error)(lfr); err != nil {
@@ -424,14 +425,14 @@ func (ff *Filters) UnsubscribeLogs(id LogsSubID) bool {
 		AllAddresses: ff.logsSubs.aggLogsFilter.allAddrs == 1,
 		AllTopics:    ff.logsSubs.aggLogsFilter.allTopics == 1,
 	}
+	ff.mu.Lock()
+	defer ff.mu.Unlock()
 	for addr := range ff.logsSubs.aggLogsFilter.addrs {
 		lfr.Addresses = append(lfr.Addresses, gointerfaces.ConvertAddressToH160(addr))
 	}
 	for topic := range ff.logsSubs.aggLogsFilter.topics {
 		lfr.Topics = append(lfr.Topics, gointerfaces.ConvertHashToH256(topic))
 	}
-	ff.mu.Lock()
-	defer ff.mu.Unlock()
 	loaded := ff.logsRequestor.Load()
 	if loaded != nil {
 		if err := loaded.(func(*remote.LogsFilterRequest) error)(lfr); err != nil {

--- a/turbo/rpchelper/logsfilter.go
+++ b/turbo/rpchelper/logsfilter.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ledgerwatch/erigon-lib/gointerfaces"
 	"github.com/ledgerwatch/erigon-lib/gointerfaces/remote"
+
 	"github.com/ledgerwatch/erigon/common"
 	types2 "github.com/ledgerwatch/erigon/core/types"
 )
@@ -81,6 +82,8 @@ func (a *LogsFilterAggregator) subtractLogFilters(f *LogsFilter) {
 }
 
 func (a *LogsFilterAggregator) addLogsFilters(f *LogsFilter) {
+	a.logsFilterLock.Lock()
+	defer a.logsFilterLock.Unlock()
 	a.aggLogsFilter.allAddrs += f.allAddrs
 	for addr, count := range f.addrs {
 		a.aggLogsFilter.addrs[addr] += count


### PR DESCRIPTION
moving a couple of mutex locks and introducing another to prevent a deferred call to unsubscribe clashing with a new call to subscribe.

Hard to replicate locally due to the nature of the problem, but can successfully subscribe, unsubscribe and close socket connections without anything going wrong.