### PR TITLE
Revert "Log data if cannot decode BlockBodiesPacket66 (#4850)"

### DIFF
--- a/cmd/sentry/sentry/sentry_multi_client.go
+++ b/cmd/sentry/sentry/sentry_multi_client.go
@@ -499,7 +499,7 @@ func (cs *MultiClient) newBlock66(ctx context.Context, inreq *proto_sentry.Inbou
 func (cs *MultiClient) blockBodies66(inreq *proto_sentry.InboundMessage, _ direct.SentryClient) error {
 	var request eth.BlockRawBodiesPacket66
 	if err := rlp.DecodeBytes(inreq.Data, &request); err != nil {
-		return fmt.Errorf("decode BlockBodiesPacket66: %w, data: %x", err, inreq.Data)
+		return fmt.Errorf("decode BlockBodiesPacket66: %w", err)
 	}
 	txs, uncles := request.BlockRawBodiesPacket.Unpack()
 	cs.Bd.DeliverBodies(&txs, &uncles, uint64(len(inreq.Data)), ConvertH512ToPeerID(inreq.PeerId))


### PR DESCRIPTION
This reverts PR #4850 since it clogs the logs. But here's a example of the problematic block bodies packet:
[PR_4850_message.txt](https://github.com/ledgerwatch/erigon/files/9258576/PR_4850_message.txt)
