### PR TITLE
Remove authrpc.* flags from rpcdaemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ Detailed explanation: [./docs/programmers_guide/db_faq.md](./docs/programmers_gu
 
 Typically, 30303 is exposed to the internet to allow incoming peering connections. 9090 is exposed only
 internally for rpcdaemon or other connections, (e.g. rpcdaemon -> erigon).
-Port 8551 (JWT authenticated) should exposed only internally for [Engine API] JSON-RPC queries from the Consensus Layer node.
+Port 8551 (JWT authenticated) is exposed only internally for [Engine API] JSON-RPC queries from the Consensus Layer node.
 
 #### `RPC` ports
 

--- a/README.md
+++ b/README.md
@@ -410,19 +410,19 @@ Detailed explanation: [./docs/programmers_guide/db_faq.md](./docs/programmers_gu
 |  9090 |    TCP    | gRPC Connections       | Private |
 | 42069 | TCP & UDP | Snap sync (Bittorrent) |  Public |
 |  6060 |    TCP    | Metrics or Pprof       | Private |
+|  8551 |    TCP    | Engine API (JWT auth)  | Private |
 
 Typically, 30303 is exposed to the internet to allow incoming peering connections. 9090 is exposed only
 internally for rpcdaemon or other connections, (e.g. rpcdaemon -> erigon).
+Port 8551 (JWT authenticated) should exposed only internally for [Engine API] JSON-RPC queries from the Consensus Layer node.
 
 #### `RPC` ports
 
 |  Port |  Protocol |      Purpose       |  Expose |
 |:-----:|:---------:|:------------------:|:-------:|
 |  8545 |    TCP    | HTTP & WebSockets  | Private |
-|  8551 |    TCP    | HTTP with JWT auth | Private |
 
 Typically, 8545 is exposed only internally for JSON-RPC queries. Both HTTP and WebSocket connections are on the same port.
-Typically, 8551 (JWT authenticated) is exposed only internally for the [Engine API] JSON-RPC queries.
 
 #### `sentry` ports
 

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -57,8 +57,6 @@ var rootCmd = &cobra.Command{
 	Short: "rpcdaemon is JSON RPC server that connects to Erigon node for remote DB access",
 }
 
-const JwtDefaultFile = "jwt.hex"
-
 func RootCommand() (*cobra.Command, *httpcfg.HttpCfg) {
 	utils.CobraFlags(rootCmd, append(debug.Flags, utils.MetricFlags...))
 
@@ -66,15 +64,12 @@ func RootCommand() (*cobra.Command, *httpcfg.HttpCfg) {
 	rootCmd.PersistentFlags().StringVar(&cfg.PrivateApiAddr, "private.api.addr", "127.0.0.1:9090", "private api network address, for example: 127.0.0.1:9090")
 	rootCmd.PersistentFlags().StringVar(&cfg.DataDir, "datadir", "", "path to Erigon working directory")
 	rootCmd.PersistentFlags().StringVar(&cfg.HttpListenAddress, "http.addr", nodecfg.DefaultHTTPHost, "HTTP-RPC server listening interface")
-	rootCmd.PersistentFlags().StringVar(&cfg.AuthRpcHTTPListenAddress, "authrpc.addr", nodecfg.DefaultHTTPHost, "HTTP-RPC server listening interface for the Engine API")
 	rootCmd.PersistentFlags().StringVar(&cfg.TLSCertfile, "tls.cert", "", "certificate for client side TLS handshake")
 	rootCmd.PersistentFlags().StringVar(&cfg.TLSKeyFile, "tls.key", "", "key file for client side TLS handshake")
 	rootCmd.PersistentFlags().StringVar(&cfg.TLSCACert, "tls.cacert", "", "CA certificate for client side TLS handshake")
 	rootCmd.PersistentFlags().IntVar(&cfg.HttpPort, "http.port", nodecfg.DefaultHTTPPort, "HTTP-RPC server listening port")
-	rootCmd.PersistentFlags().IntVar(&cfg.AuthRpcPort, "authrpc.port", nodecfg.DefaultAuthRpcPort, "HTTP-RPC server listening port for the Engine API")
 	rootCmd.PersistentFlags().StringSliceVar(&cfg.HttpCORSDomain, "http.corsdomain", []string{}, "Comma separated list of domains from which to accept cross origin requests (browser enforced)")
 	rootCmd.PersistentFlags().StringSliceVar(&cfg.HttpVirtualHost, "http.vhosts", nodecfg.DefaultConfig.HTTPVirtualHosts, "Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard.")
-	rootCmd.PersistentFlags().StringSliceVar(&cfg.AuthRpcVirtualHost, "authrpc.vhosts", nodecfg.DefaultConfig.HTTPVirtualHosts, "Comma separated list of virtual hostnames from which to accept Engine API requests (server enforced). Accepts '*' wildcard.")
 	rootCmd.PersistentFlags().BoolVar(&cfg.HttpCompression, "http.compression", true, "Disable http compression")
 	rootCmd.PersistentFlags().StringSliceVar(&cfg.API, "http.api", []string{"eth", "erigon"}, "API's offered over the HTTP-RPC interface: eth,erigon,web3,net,debug,trace,txpool,db,starknet. Supported methods: https://github.com/ledgerwatch/erigon/tree/devel/cmd/rpcdaemon")
 	rootCmd.PersistentFlags().Uint64Var(&cfg.Gascap, "rpc.gascap", 50000000, "Sets a cap on gas that can be used in eth_call/estimateGas")
@@ -95,14 +90,10 @@ func RootCommand() (*cobra.Command, *httpcfg.HttpCfg) {
 	rootCmd.PersistentFlags().IntVar(&cfg.GRPCPort, "grpc.port", nodecfg.DefaultGRPCPort, "GRPC server listening port")
 	rootCmd.PersistentFlags().BoolVar(&cfg.GRPCHealthCheckEnabled, "grpc.healthcheck", false, "Enable GRPC health check")
 	rootCmd.PersistentFlags().StringVar(&cfg.StarknetGRPCAddress, "starknet.grpc.address", "127.0.0.1:6066", "Starknet GRPC address")
-	rootCmd.PersistentFlags().StringVar(&cfg.JWTSecretPath, utils.JWTSecretPath.Name, utils.JWTSecretPath.Value, "Token to ensure safe connection between CL and EL")
 	rootCmd.PersistentFlags().BoolVar(&cfg.TraceRequests, utils.HTTPTraceFlag.Name, false, "Trace HTTP requests with INFO level")
 	rootCmd.PersistentFlags().DurationVar(&cfg.HTTPTimeouts.ReadTimeout, "http.timeouts.read", rpccfg.DefaultHTTPTimeouts.ReadTimeout, "Maximum duration for reading the entire request, including the body.")
 	rootCmd.PersistentFlags().DurationVar(&cfg.HTTPTimeouts.WriteTimeout, "http.timeouts.write", rpccfg.DefaultHTTPTimeouts.WriteTimeout, "Maximum duration before timing out writes of the response. It is reset whenever a new request's header is read")
 	rootCmd.PersistentFlags().DurationVar(&cfg.HTTPTimeouts.IdleTimeout, "http.timeouts.idle", rpccfg.DefaultHTTPTimeouts.IdleTimeout, "Maximum amount of time to wait for the next request when keep-alives are enabled. If http.timeouts.idle is zero, the value of http.timeouts.read is used")
-	rootCmd.PersistentFlags().DurationVar(&cfg.AuthRpcTimeouts.ReadTimeout, "authrpc.timeouts.read", rpccfg.DefaultHTTPTimeouts.ReadTimeout, "Maximum duration for reading the entire request, including the body.")
-	rootCmd.PersistentFlags().DurationVar(&cfg.AuthRpcTimeouts.WriteTimeout, "authrpc.timeouts.write", rpccfg.DefaultHTTPTimeouts.WriteTimeout, "Maximum duration before timing out writes of the response. It is reset whenever a new request's header is read.")
-	rootCmd.PersistentFlags().DurationVar(&cfg.AuthRpcTimeouts.IdleTimeout, "authrpc.timeouts.idle", rpccfg.DefaultHTTPTimeouts.IdleTimeout, "Maximum amount of time to wait for the next request when keep-alives are enabled. If authrpc.timeouts.idle is zero, the value of authrpc.timeouts.read is used.")
 
 	if err := rootCmd.MarkPersistentFlagFilename("rpc.accessList", "json"); err != nil {
 		panic(err)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,8 @@ services:
       erigon ${ERIGON_FLAGS-} --private.api.addr=0.0.0.0:9090
       --sentry.api.addr=sentry:9091 --downloader.api.addr=downloader:9093 --txpool.disable
       --metrics --metrics.addr=0.0.0.0 --metrics.port=6060 --pprof --pprof.addr=0.0.0.0 --pprof.port=6061
+      --authrpc.jwtsecret=/home/erigon/.local/share/erigon/jwt.hex
+    ports: [ "8551:8551" ]
     volumes:
       # It's ok to mount sub-dirs of "datadir" to different drives
       - ${XDG_DATA_HOME:-~/.local/share}/erigon:/home/erigon/.local/share/erigon
@@ -59,8 +61,7 @@ services:
     command: |
       rpcdaemon ${RPCDAEMON_FLAGS-} --http.addr=0.0.0.0 --http.vhosts=* --http.corsdomain=* --ws
       --private.api.addr=erigon:9090 --txpool.api.addr=txpool:9094
-      --authrpc.jwtsecret=/home/erigon/.local/share/erigon/jwt.hex
-    ports: [ "8545:8545" ] # "8551:8551"
+    ports: [ "8545:8545" ]
 
 
 

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -75,9 +75,9 @@ var DefaultFlags = []cli.Flag{
 	HTTPReadTimeoutFlag,
 	HTTPWriteTimeoutFlag,
 	HTTPIdleTimeoutFlag,
-	EngineReadTimeoutFlag,
-	EngineWriteTimeoutFlag,
-	EngineIdleTimeoutFlag,
+	AuthRpcReadTimeoutFlag,
+	AuthRpcWriteTimeoutFlag,
+	AuthRpcIdleTimeoutFlag,
 
 	utils.SnapKeepBlocksFlag,
 	utils.SnapStopFlag,

--- a/turbo/cli/flags.go
+++ b/turbo/cli/flags.go
@@ -169,17 +169,17 @@ var (
 		Value: rpccfg.DefaultHTTPTimeouts.IdleTimeout,
 	}
 
-	EngineReadTimeoutFlag = cli.DurationFlag{
+	AuthRpcReadTimeoutFlag = cli.DurationFlag{
 		Name:  "authrpc.timeouts.read",
 		Usage: "Maximum duration for reading the entire request, including the body.",
 		Value: rpccfg.DefaultHTTPTimeouts.ReadTimeout,
 	}
-	EngineWriteTimeoutFlag = cli.DurationFlag{
+	AuthRpcWriteTimeoutFlag = cli.DurationFlag{
 		Name:  "authrpc.timeouts.write",
 		Usage: "Maximum duration before timing out writes of the response. It is reset whenever a new request's header is read.",
 		Value: rpccfg.DefaultHTTPTimeouts.WriteTimeout,
 	}
-	EngineIdleTimeoutFlag = cli.DurationFlag{
+	AuthRpcIdleTimeoutFlag = cli.DurationFlag{
 		Name:  "authrpc.timeouts.idle",
 		Usage: "Maximum amount of time to wait for the next request when keep-alives are enabled. If authrpc.timeouts.idle is zero, the value of authrpc.timeouts.read is used.",
 		Value: rpccfg.DefaultHTTPTimeouts.IdleTimeout,
@@ -343,8 +343,8 @@ func setEmbeddedRpcDaemon(ctx *cli.Context, cfg *nodecfg.Config) {
 			IdleTimeout:  ctx.GlobalDuration(HTTPIdleTimeoutFlag.Name),
 		},
 		AuthRpcTimeouts: rpccfg.HTTPTimeouts{
-			ReadTimeout:  ctx.GlobalDuration(EngineReadTimeoutFlag.Name),
-			WriteTimeout: ctx.GlobalDuration(EngineWriteTimeoutFlag.Name),
+			ReadTimeout:  ctx.GlobalDuration(AuthRpcReadTimeoutFlag.Name),
+			WriteTimeout: ctx.GlobalDuration(AuthRpcWriteTimeoutFlag.Name),
 			IdleTimeout:  ctx.GlobalDuration(HTTPIdleTimeoutFlag.Name),
 		},
 


### PR DESCRIPTION
After PR #4887 `rpcdaemon` does not listen on the Engine API port – only `erigon` does.