### PR TITLE
fix eth_gasPrice RPC issue.

### DIFF
--- a/cmd/rpcdaemon/commands/eth_system.go
+++ b/cmd/rpcdaemon/commands/eth_system.go
@@ -115,13 +115,14 @@ func (api *APIImpl) GasPrice(ctx context.Context) (*hexutil.Big, error) {
 	}
 	oracle := gasprice.NewOracle(NewGasPriceOracleBackend(tx, cc, api.BaseAPI), ethconfig.Defaults.GPO)
 	tipcap, err := oracle.SuggestTipCap(ctx)
+	gasResult := big.NewInt(0)
 	if err != nil {
 		return nil, err
 	}
 	if head := rawdb.ReadCurrentHeader(tx); head != nil && head.BaseFee != nil {
-		tipcap.Add(tipcap, head.BaseFee)
+		gasResult.Add(tipcap, head.BaseFee)
 	}
-	return (*hexutil.Big)(tipcap), err
+	return (*hexutil.Big)(gasResult), err
 }
 
 // MaxPriorityFeePerGas returns a suggestion for a gas tip cap for dynamic fee transactions.

--- a/cmd/rpcdaemon/commands/eth_system.go
+++ b/cmd/rpcdaemon/commands/eth_system.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"math/big"
 
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon/common"

--- a/cmd/rpcdaemon/commands/eth_system.go
+++ b/cmd/rpcdaemon/commands/eth_system.go
@@ -117,6 +117,8 @@ func (api *APIImpl) GasPrice(ctx context.Context) (*hexutil.Big, error) {
 	oracle := gasprice.NewOracle(NewGasPriceOracleBackend(tx, cc, api.BaseAPI), ethconfig.Defaults.GPO)
 	tipcap, err := oracle.SuggestTipCap(ctx)
 	gasResult := big.NewInt(0)
+
+	gasResult.Set(tipcap)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
See [4918](https://github.com/ledgerwatch/erigon/issues/4918)
big.Int's Add method will save the result to self, since oracle.SuggestTipCap() might come from [gpo.lastPrice](https://github.com/ledgerwatch/erigon/blob/7e2d46cbe42c958ec541bb1837cc1e351eaf08ef/eth/gasprice/gasprice.go#L153), this will change all following rpc result.