### PR TITLE
new rpc block number

### DIFF
--- a/rpc/types.go
+++ b/rpc/types.go
@@ -71,11 +71,12 @@ type BlockNumber int64
 type Timestamp uint64
 
 const (
-	FinalizedBlockNumber = BlockNumber(-4)
-	SafeBlockNumber      = BlockNumber(-3)
-	PendingBlockNumber   = BlockNumber(-2)
-	LatestBlockNumber    = BlockNumber(-1)
-	EarliestBlockNumber  = BlockNumber(0)
+	LatestExecutedBlockNumber = BlockNumber(-5)
+	FinalizedBlockNumber      = BlockNumber(-4)
+	SafeBlockNumber           = BlockNumber(-3)
+	PendingBlockNumber        = BlockNumber(-2)
+	LatestBlockNumber         = BlockNumber(-1)
+	EarliestBlockNumber       = BlockNumber(0)
 )
 
 // UnmarshalJSON parses the given JSON fragment into a BlockNumber. It supports:
@@ -106,6 +107,8 @@ func (bn *BlockNumber) UnmarshalJSON(data []byte) error {
 	case "finalized":
 		*bn = FinalizedBlockNumber
 		return nil
+	case "latestExecuted":
+		*bn = LatestExecutedBlockNumber
 	case "null":
 		*bn = LatestBlockNumber
 		return nil

--- a/turbo/rpchelper/helper.go
+++ b/turbo/rpchelper/helper.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ledgerwatch/erigon/eth/stagedsync/stages"
 	"github.com/ledgerwatch/erigon/rpc"
 	"github.com/ledgerwatch/erigon/turbo/adapter"
+	"github.com/ledgerwatch/log/v3"
 )
 
 // unable to decode supplied params, or an invalid number of parameters

--- a/turbo/rpchelper/helper.go
+++ b/turbo/rpchelper/helper.go
@@ -63,6 +63,7 @@ func _GetBlockNumber(requireCanonical bool, blockNrOrHash rpc.BlockNumberOrHash,
 		case rpc.PendingBlockNumber:
 			pendingBlock := filters.LastPendingBlock()
 			if pendingBlock == nil {
+				log.Warn("no pending block found returning latest executed block")
 				blockNumber = plainStateBlockNumber
 			} else {
 				return pendingBlock.NumberU64(), pendingBlock.Hash(), false, nil

--- a/turbo/rpchelper/helper.go
+++ b/turbo/rpchelper/helper.go
@@ -67,6 +67,8 @@ func _GetBlockNumber(requireCanonical bool, blockNrOrHash rpc.BlockNumberOrHash,
 			} else {
 				return pendingBlock.NumberU64(), pendingBlock.Hash(), false, nil
 			}
+		case rpc.LatestExecutedBlockNumber:
+			blockNumber = plainStateBlockNumber
 		default:
 			blockNumber = uint64(number.Int64())
 		}


### PR DESCRIPTION
Added `latestExecutedBlockNumber` which will return the plainstate block number.