### PR TITLE
UX improvement for pre-merge sync with Teku

### DIFF
--- a/turbo/engineapi/fork_validator.go
+++ b/turbo/engineapi/fork_validator.go
@@ -186,7 +186,7 @@ func (fv *ForkValidator) ValidatePayload(tx kv.RwTx, header *types.Header, body 
 			return
 		}
 		// MakesBodyCanonical do not support PoS.
-		if has && len(sb.body.Transactions) > 0 {
+		if has {
 			status = remote.EngineStatus_ACCEPTED
 			return
 		}


### PR DESCRIPTION
This PR contains a small UX improvement: not spamming the stageloop when fcu is already set to the fields provided. and i also removed a condition from the safety check for non-canonical block bodies in Fcu. lastly, i also removed code duplications. hive tests were not affected.