### PR TITLE
snapshotsync: HeaderByHash segment loop should break on result (tiny)

### DIFF
--- a/turbo/snapshotsync/block_reader.go
+++ b/turbo/snapshotsync/block_reader.go
@@ -276,6 +276,9 @@ func (back *BlockReaderWithSnapshots) HeaderByHash(ctx context.Context, tx kv.Ge
 			if err != nil {
 				return err
 			}
+			if h != nil {
+				break
+			}
 		}
 		return nil
 	}); err != nil {


### PR DESCRIPTION
### What

This tiny PR fixes a correctness bug in `BlockReaderWithSnapshots::HeaderByHash`. `HeaderByHash` should stop at the first in-segment match. Otherwise, the result is always whatever the last loop iteration found.

### Testing

I tested manually with a throw-away test case against an archive node database. Without the fix, `HeaderByHash` always returns `nil` unless the header hash happens to be in the oldest snapshot segment.

Should I write a test for this? If yes, how? I couldn't find a unit-testing / test fixture setup for `BlockReaderWithSnapshots`.