### PR TITLE
cmd: make sure chain config is initialized before accessing it

### DIFF
--- a/cmd/rpcdaemon/commands/send_transaction.go
+++ b/cmd/rpcdaemon/commands/send_transaction.go
@@ -26,13 +26,6 @@ func (api *APIImpl) SendRawTransaction(ctx context.Context, encodedTx hexutil.By
 		return common.Hash{}, err
 	}
 
-	txnChainId := txn.GetChainID()
-	chainId := api._chainConfig.ChainID
-
-	if chainId.Cmp(txnChainId.ToBig()) != 0 {
-		return common.Hash{}, fmt.Errorf("invalid chain id, expected: %d got: %d", chainId, *txnChainId)
-	}
-
 	// If the transaction fee cap is already specified, ensure the
 	// fee of the given transaction is _reasonable_.
 	if err := checkTxFee(txn.GetPrice().ToBig(), txn.GetGas(), ethconfig.Defaults.RPCTxFeeCap); err != nil {
@@ -66,6 +59,14 @@ func (api *APIImpl) SendRawTransaction(ctx context.Context, encodedTx hexutil.By
 	if err != nil {
 		return common.Hash{}, err
 	}
+
+	txnChainId := txn.GetChainID()
+	chainId := api._chainConfig.ChainID
+
+	if chainId.Cmp(txnChainId.ToBig()) != 0 {
+		return common.Hash{}, fmt.Errorf("invalid chain id, expected: %d got: %d", chainId, *txnChainId)
+	}
+
 	signer := types.MakeSigner(cc, *blockNum)
 	from, err := txn.Sender(*signer)
 	if err != nil {

--- a/cmd/rpcdaemon/commands/send_transaction.go
+++ b/cmd/rpcdaemon/commands/send_transaction.go
@@ -61,7 +61,7 @@ func (api *APIImpl) SendRawTransaction(ctx context.Context, encodedTx hexutil.By
 	}
 
 	txnChainId := txn.GetChainID()
-	chainId := api._chainConfig.ChainID
+	chainId := cc.ChainID
 
 	if chainId.Cmp(txnChainId.ToBig()) != 0 {
 		return common.Hash{}, fmt.Errorf("invalid chain id, expected: %d got: %d", chainId, *txnChainId)


### PR DESCRIPTION
Issue: https://github.com/ledgerwatch/erigon/issues/4974

The nil pointer is because the `chainConfig` is not initialized at the time of accessing it and validating `chainID`. 
I have moved `chainID` validation logic after the `chainConfig` initialization. 