### PR TITLE
feat: Dockerfile apk add curl jq

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN --mount=type=cache,target=/root/.cache \
 
 FROM docker.io/library/alpine:3.15
 
-RUN apk add --no-cache ca-certificates libstdc++ tzdata
+RUN apk add --no-cache ca-certificates curl libstdc++ jq tzdata
 # copy compiled artifacts from builder
 COPY --from=builder /app/build/bin/* /usr/local/bin/
 


### PR DESCRIPTION
# Problem

Checking the block number in a kubernetes readinessProbe requires the following long command:

```
wget -q -O- --header='Content-Type:application/json' --post-data='{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", false],"id":1}' http://0.0.0.0:8545 |  grep -oE '"number":"0x.[a-f0-9]+"' | awk -F\" '{printf("%d\n", $4)}'
```

# Solution

Add `jq` and `curl` commands to Dockerfile

# Result

Able to reduce above command to the following:

```
curl -s -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", false],"id":1}' http://0.0.0.0:8545 | jq -rC .result.number | xargs /usr/bin/printf "\%d\n"
```