### PR TITLE
Pruning Receipts Default

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,12 +184,16 @@ relies on availability of receipts – don't prune them: don't add character `r`
  ## ETH2 Deposit Contract Block Number
 
  - Mainnnet: 11052984
- - Sepolia: 
+ - Sepolia: 1273020
+ - Goerli: 4367322
+
 
  ## ETH2 Deposit Contract Address
 
  - Mainnet: 0x00000000219ab540356cBB839Cbe05303d7705Fa
- - Sepolia: 
+ - Sepolia: 0x7f02C3E3c98b133055B8B348B2Ac625669Ed295D
+ - Goerli: 0xff50ed3d0ec03aC01D4C79aAd74928BFF48a7b2b
+
 
 If your CL client is on a different device, add `--authrpc.addr 0.0.0.0` ([Engine API] listens on localhost by default)
 as well as `--authrpc.vhosts <CL host>`.

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin
 
 Erigon can be used as an Execution Layer (EL) for Consensus Layer clients (CL). Default configuration is OK. CL
 relies on availability of receipts – don't prune them: don't add character `r` to `--prune` flag. However, old receipts
- are not needed for CL and you can safely prune them with `--prune.r.before=<old block number>` in combination with `--prune htc`.
+ are not needed for CL and you can safely prune them with `--prune htc`.
 
  ## ETH2 Deposit Contract Block Number
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,16 @@ Erigon can be used as an Execution Layer (EL) for Consensus Layer clients (CL). 
 relies on availability of receipts – don't prune them: don't add character `r` to `--prune` flag. However, old receipts
  are not needed for CL and you can safely prune them with `--prune.r.before=<old block number>` in combination with `--prune htc`.
 
+ ## ETH2 Deposit Contract Block Number
+
+ - Mainnnet: 11052984
+ - Sepolia: 
+
+ ## ETH2 Deposit Contract Address
+
+ - Mainnet: 0x00000000219ab540356cBB839Cbe05303d7705Fa
+ - Sepolia: 
+
 If your CL client is on a different device, add `--authrpc.addr 0.0.0.0` ([Engine API] listens on localhost by default)
 as well as `--authrpc.vhosts <CL host>`.
 

--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -1226,7 +1226,8 @@ func stage(st *stagedsync.Sync, tx kv.Tx, db kv.RoDB, stage stages.SyncStage) *s
 }
 
 func overrideStorageMode(db kv.RwDB) error {
-	pm, err := prune.FromCli(pruneFlag, pruneH, pruneR, pruneT, pruneC,
+	chainConfig := tool.ChainConfigFromDB(db)
+	pm, err := prune.FromCli(chainConfig.ChainID.Uint64(), pruneFlag, pruneH, pruneR, pruneT, pruneC,
 		pruneHBefore, pruneRBefore, pruneTBefore, pruneCBefore, experiments)
 	if err != nil {
 		return err

--- a/ethdb/prune/storage_mode.go
+++ b/ethdb/prune/storage_mode.go
@@ -80,7 +80,7 @@ func FromCli(chainId uint64, flags string, exactHistory, exactReceipts, exactTxI
 		if pruneBlockBefore != 0 {
 			log.Warn("specifying prune.before.r might break CL compatibility")
 			if beforeR > pruneBlockBefore {
-				log.Warn("the specified prune.before.r block number is higher than the deployed contract block number")
+				log.Warn("the specified prune.before.r block number is higher than the deposit contract contract block number", "highest block number", pruneBlockBefore)
 			}
 		}
 		mode.Initialised = true

--- a/ethdb/prune/storage_mode.go
+++ b/ethdb/prune/storage_mode.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon/params"
+	"github.com/ledgerwatch/log/v3"
 )
 
 var DefaultMode = Mode{
@@ -76,6 +77,12 @@ func FromCli(chainId uint64, flags string, exactHistory, exactReceipts, exactTxI
 		mode.History = Before(beforeH)
 	}
 	if beforeR > 0 {
+		if pruneBlockBefore != 0 {
+			log.Warn("specifying prune.before.r might break CL compatibility")
+			if beforeR > pruneBlockBefore {
+				log.Warn("the specified prune.before.r block number is higher than the deployed contract block number")
+			}
+		}
 		mode.Initialised = true
 		mode.Receipts = Before(beforeR)
 	} else {

--- a/turbo/cli/flags.go
+++ b/turbo/cli/flags.go
@@ -188,6 +188,7 @@ var (
 
 func ApplyFlagsForEthConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 	mode, err := prune.FromCli(
+		cfg.Genesis.Config.ChainID.Uint64(),
 		ctx.GlobalString(PruneFlag.Name),
 		ctx.GlobalUint64(PruneHistoryFlag.Name),
 		ctx.GlobalUint64(PruneReceiptFlag.Name),
@@ -276,7 +277,7 @@ func ApplyFlagsForEthConfigCobra(f *pflag.FlagSet, cfg *ethconfig.Config) {
 			beforeC = *v
 		}
 
-		mode, err := prune.FromCli(*v, exactH, exactR, exactT, exactC, beforeH, beforeR, beforeT, beforeC, experiments)
+		mode, err := prune.FromCli(cfg.Genesis.Config.ChainID.Uint64(), *v, exactH, exactR, exactT, exactC, beforeH, beforeR, beforeT, beforeC, experiments)
 		if err != nil {
 			utils.Fatalf(fmt.Sprintf("error while parsing mode: %v", err))
 		}


### PR DESCRIPTION
Pruning unnecessary receipts for POS by setting default prune receipts before deposit contract block