### PR TITLE
Fix for custom tracer method crashing

### DIFF
--- a/cmd/rpcdaemon/commands/tracing.go
+++ b/cmd/rpcdaemon/commands/tracing.go
@@ -57,6 +57,10 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 		return err
 	}
 
+	if block == nil {
+		return fmt.Errorf("invalid arguments; cannot retrieve block")
+	}
+
 	chainConfig, err := api.chainConfig(tx)
 	if err != nil {
 		stream.WriteNil()

--- a/cmd/rpcdaemon/commands/tracing.go
+++ b/cmd/rpcdaemon/commands/tracing.go
@@ -44,15 +44,15 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 	}
 	defer tx.Rollback()
 	var (
-		block     *types.Block
-		number    rpc.BlockNumber
-		hasNumber bool
-		hash      common.Hash
-		hasHash   bool
+		block    *types.Block
+		number   rpc.BlockNumber
+		numberOk bool
+		hash     common.Hash
+		hashOk   bool
 	)
-	if number, hasNumber = blockNrOrHash.Number(); hasNumber {
+	if number, numberOk = blockNrOrHash.Number(); numberOk {
 		block, err = api.blockByRPCNumber(number, tx)
-	} else if hash, hasHash = blockNrOrHash.Hash(); hasHash {
+	} else if hash, hashOk = blockNrOrHash.Hash(); hashOk {
 		block, err = api.blockByHashWithSenders(tx, hash)
 	} else {
 		return fmt.Errorf("invalid arguments; neither block nor hash specified")
@@ -64,12 +64,10 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 	}
 
 	if block == nil {
-		if hasNumber {
+		if numberOk {
 			return fmt.Errorf("invalid arguments; block with number %d not found", number)
 		}
-		if hasHash {
-			return fmt.Errorf("invalid arguments; block with hash %v not found", hash)
-		}
+		return fmt.Errorf("invalid arguments; block with hash %v not found", hash)
 	}
 
 	chainConfig, err := api.chainConfig(tx)

--- a/cmd/rpcdaemon/commands/tracing.go
+++ b/cmd/rpcdaemon/commands/tracing.go
@@ -58,7 +58,11 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 	}
 
 	if block == nil {
-		return fmt.Errorf("invalid arguments; cannot retrieve block")
+		if number, ok := blockNrOrHash.Number(); ok {
+			return fmt.Errorf("invalid arguments; block with number %d not found", number)
+		} else if hash, ok := blockNrOrHash.Hash(); ok {
+			return fmt.Errorf("invalid arguments; block with hash %v not found", hash)
+		}
 	}
 
 	chainConfig, err := api.chainConfig(tx)

--- a/cmd/rpcdaemon/commands/tracing.go
+++ b/cmd/rpcdaemon/commands/tracing.go
@@ -67,7 +67,7 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 		if numberOk {
 			return fmt.Errorf("invalid arguments; block with number %d not found", number)
 		}
-		return fmt.Errorf("invalid arguments; block with hash %v not found", hash)
+		return fmt.Errorf("invalid arguments; block with hash %x not found", hash)
 	}
 
 	chainConfig, err := api.chainConfig(tx)

--- a/cmd/rpcdaemon/commands/tracing.go
+++ b/cmd/rpcdaemon/commands/tracing.go
@@ -43,10 +43,16 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 		return err
 	}
 	defer tx.Rollback()
-	var block *types.Block
-	if number, ok := blockNrOrHash.Number(); ok {
+	var (
+		block     *types.Block
+		number    rpc.BlockNumber
+		hasNumber bool
+		hash      common.Hash
+		hasHash   bool
+	)
+	if number, hasNumber = blockNrOrHash.Number(); hasNumber {
 		block, err = api.blockByRPCNumber(number, tx)
-	} else if hash, ok := blockNrOrHash.Hash(); ok {
+	} else if hash, hasHash = blockNrOrHash.Hash(); hasHash {
 		block, err = api.blockByHashWithSenders(tx, hash)
 	} else {
 		return fmt.Errorf("invalid arguments; neither block nor hash specified")
@@ -58,9 +64,10 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 	}
 
 	if block == nil {
-		if number, ok := blockNrOrHash.Number(); ok {
+		if hasNumber {
 			return fmt.Errorf("invalid arguments; block with number %d not found", number)
-		} else if hash, ok := blockNrOrHash.Hash(); ok {
+		}
+		if hasHash {
 			return fmt.Errorf("invalid arguments; block with hash %v not found", hash)
 		}
 	}


### PR DESCRIPTION
This PR aims to fix this issue: https://github.com/ledgerwatch/erigon/issues/4340
The `blockWithSenders` method returns a `nil` block on a condition (I'm still investigating to know why that happens. Maybe some blocks are missing).
This PR prevents the crash by making sure the error returns for an invalid/missing block until I find out why it happens