### PR TITLE
Enable gosec linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,7 @@ linters:
     - varcheck
 #    - gocritic
 #    - bodyclose # 1.18
-#    - gosec
+    - gosec
 #    - forcetypeassert
 
 linters-settings:

--- a/cmd/observer/database/db_retrier.go
+++ b/cmd/observer/database/db_retrier.go
@@ -22,7 +22,7 @@ func retryBackoffTime(attempt int) time.Duration {
 	if attempt <= 0 {
 		return 0
 	}
-	jitter := rand.Int63n(30 * time.Millisecond.Nanoseconds() * int64(attempt))
+	jitter := rand.Int63n(30 * time.Millisecond.Nanoseconds() * int64(attempt)) // nolint: gosec
 	var ns int64
 	if attempt <= 6 {
 		ns = ((50 * time.Millisecond.Nanoseconds()) << (attempt - 1)) + jitter

--- a/cmd/sentry/sentry/sentry_api.go
+++ b/cmd/sentry/sentry/sentry_api.go
@@ -49,7 +49,7 @@ func (cs *MultiClient) SendBodyRequest(ctx context.Context, req *bodydownload.Bo
 			var bytes []byte
 			var err error
 			bytes, err = rlp.EncodeToBytes(&eth.GetBlockBodiesPacket66{
-				RequestId:            rand.Uint64(),
+				RequestId:            rand.Uint64(), // nolint: gosec
 				GetBlockBodiesPacket: req.Hashes,
 			})
 			if err != nil {
@@ -88,7 +88,7 @@ func (cs *MultiClient) SendHeaderRequest(ctx context.Context, req *headerdownloa
 		case eth.ETH66, eth.ETH67:
 			//log.Info(fmt.Sprintf("Sending header request {hash: %x, height: %d, length: %d}", req.Hash, req.Number, req.Length))
 			reqData := &eth.GetBlockHeadersPacket66{
-				RequestId: rand.Uint64(),
+				RequestId: rand.Uint64(), // nolint: gosec
 				GetBlockHeadersPacket: &eth.GetBlockHeadersPacket{
 					Amount:  req.Length,
 					Reverse: req.Reverse,
@@ -130,7 +130,7 @@ func (cs *MultiClient) SendHeaderRequest(ctx context.Context, req *headerdownloa
 func (cs *MultiClient) randSentryIndex() (int, bool, func() (int, bool)) {
 	var i int
 	if len(cs.sentries) > 1 {
-		i = rand.Intn(len(cs.sentries) - 1)
+		i = rand.Intn(len(cs.sentries) - 1) // nolint: gosec
 	}
 	to := i
 	return i, true, func() (int, bool) {

--- a/cmd/sentry/sentry/sentry_grpc_server.go
+++ b/cmd/sentry/sentry/sentry_grpc_server.go
@@ -642,7 +642,7 @@ func (ss *GrpcServer) startSync(ctx context.Context, bestHash common.Hash, peerI
 	switch ss.Protocol.Version {
 	case eth.ETH66, eth.ETH67:
 		b, err := rlp.EncodeToBytes(&eth.GetBlockHeadersPacket66{
-			RequestId: rand.Uint64(),
+			RequestId: rand.Uint64(), // nolint: gosec
 			GetBlockHeadersPacket: &eth.GetBlockHeadersPacket{
 				Amount:  1,
 				Reverse: false,

--- a/cmd/sentry/sentry/sentry_multi_client.go
+++ b/cmd/sentry/sentry/sentry_multi_client.go
@@ -328,7 +328,7 @@ func (cs *MultiClient) newBlockHashes66(ctx context.Context, req *proto_sentry.I
 		}
 		//log.Info(fmt.Sprintf("Sending header request {hash: %x, height: %d, length: %d}", announce.Hash, announce.Number, 1))
 		b, err := rlp.EncodeToBytes(&eth.GetBlockHeadersPacket66{
-			RequestId: rand.Uint64(),
+			RequestId: rand.Uint64(), // nolint: gosec
 			GetBlockHeadersPacket: &eth.GetBlockHeadersPacket{
 				Amount:  1,
 				Reverse: false,

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -310,7 +310,7 @@ func (c *Clique) Prepare(chain consensus.ChainHeaderReader, header *types.Header
 		}
 		// If there's pending proposals, cast a vote on them
 		if len(addresses) > 0 {
-			header.Coinbase = addresses[rand.Intn(len(addresses))]
+			header.Coinbase = addresses[rand.Intn(len(addresses))] // nolint: gosec
 			if c.proposals[header.Coinbase] {
 				copy(header.Nonce[:], NonceAuthVote)
 			} else {
@@ -438,7 +438,7 @@ func (c *Clique) Seal(chain consensus.ChainHeaderReader, block *types.Block, res
 	if header.Difficulty.Cmp(diffNoTurn) == 0 {
 		// It's not our turn explicitly to sign, delay it a bit
 		wiggle := time.Duration(len(snap.Signers)/2+1) * wiggleTime
-		delay += time.Duration(rand.Int63n(int64(wiggle)))
+		delay += time.Duration(rand.Int63n(int64(wiggle))) // nolint: gosec
 
 		log.Trace("Out-of-turn signing requested", "wiggle", common.PrettyDuration(wiggle))
 	}

--- a/consensus/parlia/utils.go
+++ b/consensus/parlia/utils.go
@@ -16,7 +16,7 @@ func backOffTime(snap *Snapshot, val common.Address) uint64 {
 			return 0
 		}
 		s := rand.NewSource(int64(snap.Number))
-		r := rand.New(s)
+		r := rand.New(s) // nolint: gosec
 		n := len(snap.Validators)
 		backOffSteps := make([]uint64, 0, n)
 		for idx := uint64(0); idx < uint64(n); idx++ {

--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -157,7 +157,7 @@ func (cfg dialConfig) withDefaults() dialConfig {
 			panic(err)
 		}
 		seed := int64(binary.BigEndian.Uint64(seedb))
-		cfg.rand = mrand.New(mrand.NewSource(seed))
+		cfg.rand = mrand.New(mrand.NewSource(seed)) // nolint: gosec
 	}
 	return cfg
 }

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -116,7 +116,7 @@ func newTable(
 		initDone:   make(chan struct{}),
 		closeReq:   make(chan struct{}),
 		closed:     make(chan struct{}),
-		rand:       mrand.New(mrand.NewSource(0)),
+		rand:       mrand.New(mrand.NewSource(0)), // nolint: gosec
 		ips:        netutil.DistinctNetSet{Subnet: tableSubnet, Limit: tableIPLimit},
 
 		revalidateInterval: revalidateInterval,

--- a/rpc/subscription.go
+++ b/rpc/subscription.go
@@ -60,7 +60,7 @@ func randomIDGenerator() func() ID {
 
 	var (
 		mu  sync.Mutex
-		rng = rand.New(rand.NewSource(seed))
+		rng = rand.New(rand.NewSource(seed)) // nolint: gosec
 	)
 	return func() ID {
 		mu.Lock()


### PR DESCRIPTION
Assume these are fine to ignore. Anyway, I think there's value of having the linter turned on so no violating code is checked in without explicit ignores.