### PR TITLE
changed 1 to 0 to avoid null

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -290,7 +290,7 @@ func RPCMarshalBlockEx(block *types.Block, inclTx bool, fullTx bool, borTx types
 	fields := RPCMarshalHeader(block.Header())
 	fields["size"] = hexutil.Uint64(block.Size())
 	if _, ok := fields["transactions"]; !ok {
-		fields["transactions"] = make([]interface{}, 1)
+		fields["transactions"] = make([]interface{}, 0)
 	}
 
 	if inclTx {


### PR DESCRIPTION
currently appears like this
`"transactions": [
        null
      ],`
should be:

`"transactions":[]`