### PR TITLE
Hive - test exclusions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
          run: sudo DOCKER_TAG=thorax/erigon:ci-$GITHUB_SHA DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) make docker
 
        - name: run hive
-         run: sudo mkdir /results && docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${{ github.workspace }}:/work thorax/hive:latest --sim ethereum/engine --results-root=/work/results --client erigon_ci-$GITHUB_SHA --docker.output --loglevel 5
+         run: sudo mkdir /results && docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${{ github.workspace }}:/work thorax/hive:latest --sim ethereum/engine --results-root=/work/results --client erigon_ci-$GITHUB_SHA
 
        - name: parse hive output
          run: docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${{ github.workspace }}:/work --entrypoint /app/hivecioutput thorax/hive:latest --resultsdir=/work/results --outdir=/work/results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
        - name: run hive and parse output
          run: |
           sudo mkdir /results && docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${{ github.workspace }}:/work thorax/hive:latest --sim ethereum/engine --results-root=/work/results --client erigon_ci-$GITHUB_SHA
-          docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${{ github.workspace }}:/work --entrypoint /app/hivecioutput thorax/hive:latest --resultsdir=/work/results --outdir=/work/results
+          docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${{ github.workspace }}:/work --entrypoint /app/hivecioutput thorax/hive:latest --resultsdir=/work/results --outdir=/work/results --exclusionsFile=/work/hive/exclusions.json
 
        - name: archive hive results
          uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,11 +138,10 @@ jobs:
        - name: build erigon image (root permissions)
          run: sudo DOCKER_TAG=thorax/erigon:ci-$GITHUB_SHA DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) make docker
 
-       - name: run hive
-         run: sudo mkdir /results && docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${{ github.workspace }}:/work thorax/hive:latest --sim ethereum/engine --results-root=/work/results --client erigon_ci-$GITHUB_SHA
-
-       - name: parse hive output
-         run: docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${{ github.workspace }}:/work --entrypoint /app/hivecioutput thorax/hive:latest --resultsdir=/work/results --outdir=/work/results
+       - name: run hive and parse output
+         run: |
+          sudo mkdir /results && docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${{ github.workspace }}:/work thorax/hive:latest --sim ethereum/engine --results-root=/work/results --client erigon_ci-$GITHUB_SHA
+          docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${{ github.workspace }}:/work --entrypoint /app/hivecioutput thorax/hive:latest --resultsdir=/work/results --outdir=/work/results
 
        - name: archive hive results
          uses: actions/upload-artifact@v3

--- a/hive/exclusions.json
+++ b/hive/exclusions.json
@@ -1,0 +1,17 @@
+{
+  "testSuites": [
+    {
+      "name": "engine-transition",
+      "testCases": [
+        "Terminal blocks are gossiped",
+        "Build Payload After Multiple Terminal blocks via gossip"
+      ]
+    },
+    {
+      "Name": "sync",
+      "testCases": [
+        "go-ethereum as sync source"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
In the reporting stage, add the ability to ignore failing tests. If an excluded test passes, we include it in the successes, otherwise it goes to the 'skipped' count on failure, which should mean CI remains green for expected failures.

The json file containing excluded tests is currently a WIP, awaiting more detail on expected failures. (If anyone has an extensive list of these please comment and I will update the PR).