### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,21 @@ Usage
 
 ### Getting Started
 
+For building the latest alpha release (this will be suitable for most users just wanting to run a node):
 ```sh
-git clone --recurse-submodules -j8 https://github.com/ledgerwatch/erigon.git
+git clone https://github.com/ledgerwatch/erigon.git
 cd erigon
+git checkout alpha
+make erigon
+./build/bin/erigon
+```
+You can check [the list of releases](https://github.com/ledgerwatch/erigon/releases) for release notes.
+
+For building the bleeding edge development branch:
+```sh
+git clone --recurse-submodules https://github.com/ledgerwatch/erigon.git
+cd erigon
+git checkout devel
 make erigon
 ./build/bin/erigon
 ```


### PR DESCRIPTION
Updated the "getting started" instructions to direct normal users to building the latest alpha release (rather than devel).

A similar change was previously made to the README.md in the alpha branch only. However, since the git repo defaults to the devel branch, most users will still see the README.md in the devel branch first. This may inadvertently guide new users to build the devel branch. Hence the change to the README.md in the devel branch.

An alternative option would be to default the git repo to the alpha branch, rather than the devel branch.