### PR TITLE
added separated user/error log files to erigon 22/23

### DIFF
--- a/cmd/erigon/main.go
+++ b/cmd/erigon/main.go
@@ -8,16 +8,17 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/ledgerwatch/log/v3"
+	"github.com/pelletier/go-toml"
+	"github.com/urfave/cli"
+	"gopkg.in/yaml.v2"
+
 	"github.com/ledgerwatch/erigon-lib/common/dbg"
 	"github.com/ledgerwatch/erigon/cmd/utils"
 	"github.com/ledgerwatch/erigon/params"
 	erigonapp "github.com/ledgerwatch/erigon/turbo/app"
 	erigoncli "github.com/ledgerwatch/erigon/turbo/cli"
 	"github.com/ledgerwatch/erigon/turbo/node"
-	"github.com/ledgerwatch/log/v3"
-	"github.com/pelletier/go-toml"
-	"github.com/urfave/cli"
-	"gopkg.in/yaml.v2"
 )
 
 func main() {

--- a/cmd/state/commands/erigon22.go
+++ b/cmd/state/commands/erigon22.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ledgerwatch/erigon-lib/kv"
 	kv2 "github.com/ledgerwatch/erigon-lib/kv/mdbx"
 	libstate "github.com/ledgerwatch/erigon-lib/state"
+
 	"github.com/ledgerwatch/erigon/cmd/hack/tool/fromdb"
 	"github.com/ledgerwatch/erigon/cmd/sentry/sentry"
 	"github.com/ledgerwatch/erigon/common"
@@ -48,7 +49,7 @@ var erigon22Cmd = &cobra.Command{
 	Use:   "erigon22",
 	Short: "Exerimental command to re-execute blocks from beginning using erigon2 histoty (ugrade 2)",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		logger, err := initSeparatedLogging(logdir)
+		logger, err := initSeparatedLogging(logdir, "erigon22")
 		if err != nil {
 			return err
 		}

--- a/cmd/state/commands/erigon22.go
+++ b/cmd/state/commands/erigon22.go
@@ -6,6 +6,10 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/ledgerwatch/log/v3"
+	"github.com/spf13/cobra"
+	"golang.org/x/sync/semaphore"
+
 	"github.com/ledgerwatch/erigon-lib/common/dir"
 	"github.com/ledgerwatch/erigon-lib/kv"
 	kv2 "github.com/ledgerwatch/erigon-lib/kv/mdbx"
@@ -24,9 +28,6 @@ import (
 	"github.com/ledgerwatch/erigon/turbo/services"
 	"github.com/ledgerwatch/erigon/turbo/snapshotsync"
 	stages2 "github.com/ledgerwatch/erigon/turbo/stages"
-	"github.com/ledgerwatch/log/v3"
-	"github.com/spf13/cobra"
-	"golang.org/x/sync/semaphore"
 )
 
 var (
@@ -40,13 +41,17 @@ func init() {
 	withDataDir(erigon22Cmd)
 	rootCmd.AddCommand(erigon22Cmd)
 	withChain(erigon22Cmd)
+	withLogPath(erigon22Cmd)
 }
 
 var erigon22Cmd = &cobra.Command{
 	Use:   "erigon22",
 	Short: "Exerimental command to re-execute blocks from beginning using erigon2 histoty (ugrade 2)",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		logger := log.New()
+		logger, err := initSeparatedLogging(logdir)
+		if err != nil {
+			return err
+		}
 		return Erigon22(cmd.Context(), genesis, logger)
 	},
 }

--- a/cmd/state/commands/erigon23.go
+++ b/cmd/state/commands/erigon23.go
@@ -52,7 +52,7 @@ var erigon23Cmd = &cobra.Command{
 	Use:   "erigon23",
 	Short: "Exerimental command to re-execute blocks from beginning using erigon2 state representation and histoty (ugrade 3)",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		logger, err := initSeparatedLogging(logdir)
+		logger, err := initSeparatedLogging(logdir, "erigon23")
 		if err != nil {
 			return err
 		}
@@ -60,18 +60,18 @@ var erigon23Cmd = &cobra.Command{
 	},
 }
 
-func initSeparatedLogging(logPath string) (log.Logger, error) {
+func initSeparatedLogging(logPath string, filePrefix string) (log.Logger, error) {
 	err := os.MkdirAll(logPath, 0764)
 	if err != nil {
 		return nil, err
 	}
 
 	logger := log.New()
-	userLog, err := log.FileHandler(path.Join(logPath, "erigon23-user.log"), log.LogfmtFormat(), 1<<27) // 128Mb
+	userLog, err := log.FileHandler(path.Join(logPath, filePrefix+"-user.log"), log.LogfmtFormat(), 1<<27) // 128Mb
 	if err != nil {
 		return nil, err
 	}
-	errLog, err := log.FileHandler(path.Join(logPath, "erigon23-error.log"), log.LogfmtFormat(), 1<<27) // 128Mb
+	errLog, err := log.FileHandler(path.Join(logPath, filePrefix+"-error.log"), log.LogfmtFormat(), 1<<27) // 128Mb
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/state/commands/global_flags_vars.go
+++ b/cmd/state/commands/global_flags_vars.go
@@ -1,10 +1,11 @@
 package commands
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon/cmd/utils"
 	"github.com/ledgerwatch/erigon/common/paths"
-	"github.com/spf13/cobra"
 )
 
 var (
@@ -16,6 +17,7 @@ var (
 	indexBucket     string
 	snapshotsCli    bool
 	chain           string
+	logdir          string
 )
 
 func must(err error) {
@@ -55,4 +57,8 @@ func withSnapshotBlocks(cmd *cobra.Command) {
 
 func withChain(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&chain, "chain", "", "pick a chain to assume (mainnet, ropsten, etc.)")
+}
+
+func withLogPath(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&logdir, "log-dir", "/var/lib/erigon", "path to write user and error logs to")
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/ledgerwatch/erigon-lib v0.0.0-20220920040819-2928d1d9903a
 	github.com/ledgerwatch/erigon-snapshot v1.0.1-0.20220913092204-de54ee30c7b9
-	github.com/ledgerwatch/log/v3 v3.4.1
+	github.com/ledgerwatch/log/v3 v3.4.2
 	github.com/ledgerwatch/secp256k1 v1.0.0
 	github.com/ledgerwatch/trackerslist v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -398,8 +398,8 @@ github.com/ledgerwatch/erigon-lib v0.0.0-20220920040819-2928d1d9903a h1:tQGONWCt
 github.com/ledgerwatch/erigon-lib v0.0.0-20220920040819-2928d1d9903a/go.mod h1:r+WpLFk+Xv7OXoY6ML5KO9OzMKzu02ArBf9Kg62B/EI=
 github.com/ledgerwatch/erigon-snapshot v1.0.1-0.20220913092204-de54ee30c7b9 h1:iWjzYLtOsp/Wpo9ZWV/eMIlnFzk8bm7POSzrXAILw24=
 github.com/ledgerwatch/erigon-snapshot v1.0.1-0.20220913092204-de54ee30c7b9/go.mod h1:3AuPxZc85jkehh/HA9h8gabv5MSi3kb/ddtzBsTVJFo=
-github.com/ledgerwatch/log/v3 v3.4.1 h1:/xGwlVulXnsO9Uq+tzaExc8OWmXXHU0dnLalpbnY5Bc=
-github.com/ledgerwatch/log/v3 v3.4.1/go.mod h1:VXcz6Ssn6XEeU92dCMc39/g1F0OYAjw1Mt+dGP5DjXY=
+github.com/ledgerwatch/log/v3 v3.4.2 h1:chvjB7c100rlIFgPv+Col2eerxIrHL88OiZRuPZDkxw=
+github.com/ledgerwatch/log/v3 v3.4.2/go.mod h1:VXcz6Ssn6XEeU92dCMc39/g1F0OYAjw1Mt+dGP5DjXY=
 github.com/ledgerwatch/secp256k1 v1.0.0 h1:Usvz87YoTG0uePIV8woOof5cQnLXGYa162rFf3YnwaQ=
 github.com/ledgerwatch/secp256k1 v1.0.0/go.mod h1:SPmqJFciiF/Q0mPt2jVs2dTr/1TZBTIA+kPMmKgBAak=
 github.com/ledgerwatch/trackerslist v1.0.0 h1:6gnQu93WCTL4jPcdmc8UEmw56Cb8IFQHLGnevfIeLwo=


### PR DESCRIPTION
Implemented logging to different files of error and user logs along with stdout. 
Default log directory is /var/log/erigon

Data printed to stderr doesnt go to this logs.
Requires merge of https://github.com/ledgerwatch/log/pull/5