### PR TITLE
Revert recent change to MiningStep

### DIFF
--- a/turbo/stages/stageloop.go
+++ b/turbo/stages/stageloop.go
@@ -246,7 +246,7 @@ func MiningStep(ctx context.Context, kv kv.RwDB, mining *stagedsync.Sync) (err e
 	if err = mining.Run(nil, miningBatch, false); err != nil {
 		return err
 	}
-
+	tx.Rollback()
 	return nil
 }
 


### PR DESCRIPTION
This reverts a clean-up of `MiningStep` introduced by PR #5162.
Though `tx.Rollback()` seem to be unnecessary there due to `defer tx.Rollback()` a few lines before, without it I get the following error in tests on macOS:
```
--- FAIL: TestIHCursor (0.00s)
panic: sync: WaitGroup is reused before previous Wait has returned [recovered]
	panic: sync: WaitGroup is reused before previous Wait has returned
```