### PR TITLE
Disable PoW sync for networks that have already passed through the Merge

### DIFF
--- a/cmd/sentry/sentry/sentry_multi_client.go
+++ b/cmd/sentry/sentry/sentry_multi_client.go
@@ -472,13 +472,11 @@ func (cs *MultiClient) newBlock66(ctx context.Context, inreq *proto_sentry.Inbou
 
 	if segments, penalty, err := cs.Hd.SingleHeaderAsSegment(headerRaw, request.Block.Header(), true /* penalizePoSBlocks */); err == nil {
 		if penalty == headerdownload.NoPenalty {
+			propagate := !cs.ChainConfig.TerminalTotalDifficultyPassed
 			// Do not propagate blocks who are post TTD
 			firstPosSeen := cs.Hd.FirstPoSHeight()
-			var propagate bool
-			if firstPosSeen != nil {
+			if firstPosSeen != nil && propagate {
 				propagate = *firstPosSeen >= segments[0].Number
-			} else {
-				propagate = true
 			}
 			if !cs.IsMock && propagate {
 				if cs.forkValidator != nil {

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -146,9 +146,13 @@ func SpawnStageHeaders(
 		return finishHandlingForkChoice(unsettledForkChoice, headHeight, s, tx, cfg, useExternalTx)
 	}
 
-	transitionedToPoS, err := rawdb.Transitioned(tx, blockNumber, cfg.chainConfig.TerminalTotalDifficulty)
-	if err != nil {
-		return err
+	transitionedToPoS := cfg.chainConfig.TerminalTotalDifficultyPassed
+	if !transitionedToPoS {
+		var err error
+		transitionedToPoS, err = rawdb.Transitioned(tx, blockNumber, cfg.chainConfig.TerminalTotalDifficulty)
+		if err != nil {
+			return err
+		}
 	}
 
 	if transitionedToPoS {

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -153,11 +153,13 @@ func SpawnStageHeaders(
 		if err != nil {
 			return err
 		}
+		if transitionedToPoS {
+			cfg.hd.SetFirstPoSHeight(blockNumber)
+		}
 	}
 
 	if transitionedToPoS {
 		libcommon.SafeClose(cfg.hd.QuitPoWMining)
-		cfg.hd.SetFirstPoSHeight(blockNumber)
 		return HeadersPOS(s, u, ctx, tx, cfg, initialCycle, test, useExternalTx)
 	} else {
 		return HeadersPOW(s, u, ctx, tx, cfg, initialCycle, test, useExternalTx)

--- a/params/chainspecs/goerli.json
+++ b/params/chainspecs/goerli.json
@@ -14,7 +14,7 @@
   "berlinBlock": 4460644,
   "londonBlock": 5062605,
   "terminalTotalDifficulty": 10790000,
-  "terminalBlockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "terminalTotalDifficultyPassed": true,
   "clique": {
     "period": 15,
     "epoch": 30000

--- a/params/chainspecs/kiln-devnet.json
+++ b/params/chainspecs/kiln-devnet.json
@@ -13,7 +13,7 @@
   "berlinBlock": 0,
   "londonBlock": 0,
   "terminalTotalDifficulty": 20000000000000,
-  "terminalBlockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "terminalTotalDifficultyPassed": true,
   "mergeNetsplitBlock": 1000,
   "ethash": {}
 }

--- a/params/chainspecs/ropsten.json
+++ b/params/chainspecs/ropsten.json
@@ -15,6 +15,6 @@
   "berlinBlock": 9812189,
   "londonBlock": 10499401,
   "terminalTotalDifficulty": 50000000000000000,
-  "terminalBlockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "terminalTotalDifficultyPassed": true,
   "ethash": {}
 }

--- a/params/chainspecs/sepolia.json
+++ b/params/chainspecs/sepolia.json
@@ -15,6 +15,7 @@
   "berlinBlock": 0,
   "londonBlock": 0,
   "terminalTotalDifficulty": 17000000000000000,
+  "terminalTotalDifficultyPassed": true,
   "mergeNetsplitBlock": 1735371,
   "ethash": {}
 }

--- a/params/config.go
+++ b/params/config.go
@@ -254,10 +254,11 @@ type ChainConfig struct {
 	EulerBlock      *big.Int `json:"eulerBlock,omitempty" toml:",omitempty"`      // eulerBlock switch block (nil = no fork, 0 = already activated)
 
 	// EIP-3675: Upgrade consensus to Proof-of-Stake
-	TerminalTotalDifficulty *big.Int    `json:"terminalTotalDifficulty,omitempty"` // The merge happens when terminal total difficulty is reached
-	TerminalBlockNumber     *big.Int    `json:"terminalBlockNumber,omitempty"`     // Enforce particular terminal block; see TerminalBlockNumber in EIP-3675
-	TerminalBlockHash       common.Hash `json:"terminalBlockHash,omitempty"`       // Enforce particular terminal block; see TERMINAL_BLOCK_HASH in EIP-3675
-	MergeNetsplitBlock      *big.Int    `json:"mergeNetsplitBlock,omitempty"`      // Virtual fork after The Merge to use as a network splitter; see FORK_NEXT_VALUE in EIP-3675
+	TerminalTotalDifficulty       *big.Int    `json:"terminalTotalDifficulty,omitempty"`       // The merge happens when terminal total difficulty is reached
+	TerminalTotalDifficultyPassed bool        `json:"terminalTotalDifficultyPassed,omitempty"` // Disable PoW sync for networks that have already passed through the Merge
+	TerminalBlockNumber           *big.Int    `json:"terminalBlockNumber,omitempty"`           // Enforce particular terminal block; see TerminalBlockNumber in EIP-3675
+	TerminalBlockHash             common.Hash `json:"terminalBlockHash,omitempty"`             // Enforce particular terminal block; see TERMINAL_BLOCK_HASH in EIP-3675
+	MergeNetsplitBlock            *big.Int    `json:"mergeNetsplitBlock,omitempty"`            // Virtual fork after The Merge to use as a network splitter; see FORK_NEXT_VALUE in EIP-3675
 
 	// Various consensus engines
 	Ethash *EthashConfig `json:"ethash,omitempty"`


### PR DESCRIPTION
PoW block gossip is disabled for networks that have passed through the Merge, so we should go straight into PoS sync.

See also https://github.com/ethereum/go-ethereum/pull/24538.