### PR TITLE
Revert --prune=r to mean --prune.r.older=90000

### DIFF
--- a/ethdb/prune/storage_mode.go
+++ b/ethdb/prune/storage_mode.go
@@ -73,16 +73,13 @@ func FromCli(chainId uint64, flags string, exactHistory, exactReceipts, exactTxI
 	}
 	if beforeR > 0 {
 		if pruneBlockBefore != 0 {
-			log.Warn("specifying prune.before.r might break CL compatibility")
 			if beforeR > pruneBlockBefore {
-				log.Warn("the specified prune.before.r block number is higher than the deposit contract contract block number", "highest block number", pruneBlockBefore)
+				log.Warn("The specified prune.before.r block number is higher than the deposit contract contract block number", "highest block number", pruneBlockBefore)
 			}
 		}
 		mode.Receipts = Before(beforeR)
-	} else {
-		if exactReceipts == 0 && mode.Receipts.Enabled() {
-			mode.Receipts = Before(pruneBlockBefore)
-		}
+	} else if mode.Receipts.Enabled() {
+		log.Warn("Specifying chain-tip-relative receipt pruning by --prune=r or --prune.r.older might break CL compatibility. If you must prune receipts, use --prune.r.before")
 	}
 	if beforeT > 0 {
 		mode.TxIndex = Before(beforeT)

--- a/turbo/cli/flags.go
+++ b/turbo/cli/flags.go
@@ -66,7 +66,7 @@ var (
 	c - prune call traces (used by trace_filter method)
 	Does delete data older than 90K blocks, --prune=h is shortcut for: --prune.h.older=90_000 
 	If item is NOT in the list - means NO pruning for this data.
-	Example: --prune=hrtc`,
+	Example: --prune=htc`,
 		Value: "disabled",
 	}
 	PruneHistoryFlag = cli.Uint64Flag{


### PR DESCRIPTION
Prior to PR #5065 `--prune=r` meant `--prune.r.older=90000` and that was stored to the DB. With PR  #5065 `--prune=r` was changed to mean `--prune.r.before=11052984`, leading to Erigon failing to start due to the pruning mode incompatibility (Issue #5115). 