### PR TITLE
chore: add multi-arch goreleaser workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  push:
+    branches-ignore:
+      - '**'
+    tags:
+      - 'v*.*.*'
+      # to be used by fork patch-releases ^^
+      - 'v*.*.*-*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@master
+        with:
+          go-version: 1.18.x
+
+      - name: Prepare
+        id: prepare
+        run: |
+            TAG=${GITHUB_REF#refs/tags/}
+            echo ::set-output name=tag_name::${TAG}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Run GoReleaser
+        run: |
+            make release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
+          VERSION: ${{ steps.prepare.outputs.tag_name }}
+          DOCKER_USERNAME: ${{ secrets.DOCKERHUB }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ docker-compose.*.yml
 .env
 coverage.out
 
+dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,110 @@
+project_name: erigon
+
+release:
+  disable: false
+  draft: true
+  prerelease: auto
+
+builds:
+  - id: darwin-amd64
+    main: ./cmd/erigon
+    binary: erigon
+    goos:
+      - darwin
+    goarch:
+      - amd64
+    env:
+      - CC=o64-clang
+      - CXX=o64-clang++
+    tags:
+      - netgo
+    ldflags:
+      -s -w
+
+  - id: darwin-arm64
+    main: ./cmd/erigon
+    binary: erigon
+    goos:
+      - darwin
+    goarch:
+      - arm64
+    env:
+      - CC=oa64-clang
+      - CXX=oa64-clang++
+    tags:
+      - netgo
+    ldflags:
+      -s -w
+
+  - id: linux-amd64
+    main: ./cmd/erigon
+    binary: erigon
+    goos:
+      - linux
+    goarch:
+      - amd64
+    env:
+      - CC=gcc
+      - CXX=g++
+    tags:
+      - netgo
+    ldflags:
+      # We need to build a static binary because we are building in a glibc based system and running in a musl container
+      -s -w -extldflags "-static"
+
+  - id: linux-arm64
+    main: ./cmd/erigon
+    binary: erigon
+    goos:
+      - linux
+    goarch:
+      - arm64
+    env:
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
+    tags:
+      - netgo
+    ldflags:
+      # We need to build a static binary because we are building in a glibc based system and running in a musl container
+      -s -w -extldflags "-static"
+
+snapshot:
+  name_template: "{{ .Tag }}.next"
+
+dockers:
+  - image_templates:
+      - thorax/{{ .ProjectName }}:{{ .Version }}-amd64
+    dockerfile: Dockerfile.release
+    use: buildx
+    goarch: amd64
+    ids:
+      - linux-amd64
+    build_flag_templates:
+      - --platform=linux/amd64
+
+  - image_templates:
+      - thorax/{{ .ProjectName }}:{{ .Version }}-arm64
+    dockerfile: Dockerfile.release
+    use: buildx
+    goarch: arm64
+    ids:
+      - linux-arm64
+    build_flag_templates:
+      - --platform=linux/arm64/v8
+
+docker_manifests:
+  - name_template: thorax/{{ .ProjectName }}:{{ .Version }}
+    image_templates:
+      - thorax/{{ .ProjectName }}:{{ .Version }}-amd64
+      - thorax/{{ .ProjectName }}:{{ .Version }}-arm64
+
+  - name_template: thorax/{{ .ProjectName }}:latest
+    image_templates:
+    - thorax/{{ .ProjectName }}:{{ .Version }}-amd64
+    - thorax/{{ .ProjectName }}:{{ .Version }}-arm64
+
+announce:
+  slack:
+    enabled: false
+    # The name of the channel that the user selected as a destination for webhook messages.
+    channel: '#code-releases'

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,8 @@
+FROM alpine:3.14
+
+RUN apk add --no-cache ca-certificates && \
+    mkdir -p /etc/erigon
+COPY erigon /usr/local/bin/
+
+EXPOSE 8545 8551 8546 30303 30303/udp 42069 42069/udp 8080 9090 6060
+ENTRYPOINT ["erigon"]

--- a/Makefile
+++ b/Makefile
@@ -203,6 +203,39 @@ git-submodules:
 	@git submodule sync --quiet --recursive || true
 	@git submodule update --quiet --init --recursive --force || true
 
+PACKAGE_NAME          := github.com/ledgerwatch/erigon
+GOLANG_CROSS_VERSION  ?= v1.18.1
+
+.PHONY: release-dry-run
+release-dry-run: git-submodules
+	@docker run \
+		--rm \
+		--privileged \
+		-e CGO_ENABLED=1 \
+		-e GITHUB_TOKEN \
+		-e DOCKER_USERNAME \
+		-e DOCKER_PASSWORD \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v `pwd`:/go/src/$(PACKAGE_NAME) \
+		-w /go/src/$(PACKAGE_NAME) \
+		goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
+		--rm-dist --skip-validate --skip-publish
+
+.PHONY: release
+release: git-submodules
+	@docker run \
+		--rm \
+		--privileged \
+		-e CGO_ENABLED=1 \
+		-e GITHUB_TOKEN \
+		-e DOCKER_USERNAME \
+		-e DOCKER_PASSWORD \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v `pwd`:/go/src/$(PACKAGE_NAME) \
+		-w /go/src/$(PACKAGE_NAME) \
+		goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
+		--rm-dist --skip-validate
+
 # since DOCKER_UID, DOCKER_GID are default initialized to the current user uid/gid,
 # we need separate envvars to facilitate creation of the erigon user on the host OS.
 ERIGON_USER_UID ?= 3473


### PR DESCRIPTION
Upstreams the improvement from the maticnetwork/erigon fork
to add a goreleaser workflow that will build and release
a docker image for both arm and amd64.

**Note**: This will only work if the GHA secrets `DOCKERHUB` and `DOCKERHUB_KEY` are added in
order to push to https://hub.docker.com/r/thorax/erigon.