### PR TITLE
Prevent slice bounds out of range on invalid payload.LogsBloom

### DIFF
--- a/cmd/rpcdaemon22/commands/engine_api.go
+++ b/cmd/rpcdaemon22/commands/engine_api.go
@@ -155,6 +155,12 @@ func (e *EngineImpl) NewPayloadV1(ctx context.Context, payload *ExecutionPayload
 		}
 	}
 
+	if len(payload.LogsBloom) != 256 {
+		// Lengths of the other fields are ensured by their types (common.Hash or Address)
+		log.Warn("NewPayload unexpected LogsBloom length", "LogsBloom", payload.LogsBloom)
+		return nil, fmt.Errorf("invalid LogsBloom length")
+	}
+
 	// Convert slice of hexutil.Bytes to a slice of slice of bytes
 	transactions := make([][]byte, len(payload.Transactions))
 	for i, transaction := range payload.Transactions {


### PR DESCRIPTION
Discovered by @MariusVanDerWijden:
Hey all been fuzzing the clients a bit, I can crash the erigon handler very easily
```
EROR[08-25|20:08:54.674] RPC method engine_newPayloadV1 crashed: runtime error: slice bounds out of range [64:0]
[service.go:217 panic.go:884 panic.go:153 type_utils.go:36 engine_api.go:168 value.go:584 value.go:368 service.go:222 handler.go:494 handler.go:444 handler.go:392 handler.go:223 handler.go:316 asm_amd64.s:1594] 
```