### PR TITLE
Add STOP_AFTER_STAGE environ

### DIFF
--- a/cmd/downloader/readme.md
+++ b/cmd/downloader/readme.md
@@ -57,7 +57,7 @@ Additional info:
 
 ```shell
 # Snapshots creation does not require fully-synced Erigon - few first stages enough. For example:  
-STOP_BEFORE_STAGE=Execution ./build/bin/erigon --snapshots=false --datadir=<your_datadir> 
+STOP_AFTER_STAGE=Senders ./build/bin/erigon --snapshots=false --datadir=<your_datadir> 
 # But for security - better have fully-synced Erigon
 
 

--- a/common/debug/experiments.go
+++ b/common/debug/experiments.go
@@ -70,6 +70,8 @@ func SlowCommit() time.Duration {
 var (
 	stopBeforeStage     string
 	stopBeforeStageFlag sync.Once
+	stopAfterStage      string
+	stopAfterStageFlag  sync.Once
 )
 
 func StopBeforeStage() string {
@@ -81,4 +83,18 @@ func StopBeforeStage() string {
 	}
 	stopBeforeStageFlag.Do(f)
 	return stopBeforeStage
+}
+
+// TODO(allada) We should possibly consider removing `STOP_BEFORE_STAGE`, as `STOP_AFTER_STAGE` can
+// perform all same the functionality, but due to reverse compatibility reasons we are going to
+// leave it.
+func StopAfterStage() string {
+	f := func() {
+		v, _ := os.LookupEnv("STOP_AFTER_STAGE") // see names in eth/stagedsync/stages/stages.go
+		if v != "" {
+			stopAfterStage = v
+		}
+	}
+	stopAfterStageFlag.Do(f)
+	return stopAfterStage
 }

--- a/eth/stagedsync/sync.go
+++ b/eth/stagedsync/sync.go
@@ -256,6 +256,11 @@ func (s *Sync) Run(db kv.RwDB, tx kv.RwTx, firstCycle bool) error {
 			return err
 		}
 
+		if string(stage.ID) == debug.StopAfterStage() { // stop process for debugging reasons
+			log.Warn("STOP_AFTER_STAGE env flag forced to stop app")
+			return libcommon.ErrStopped
+		}
+
 		s.NextStage()
 	}
 


### PR DESCRIPTION
Adds ability to stop after a stage instead of just before a stage.
This will allow users to use something like:
`STOP_AFTER_STAGE=Finish erigon`
And erigon will stop after a full cycle of syncing.

closes #5201