### PR TITLE
Use strings.EqualFold for string comparison

### DIFF
--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -597,7 +597,7 @@ func stopAuthenticatedRpcServer(ctx context.Context, engineInfo *engineInfo) {
 
 // isWebsocket checks the header of a http request for a websocket upgrade request.
 func isWebsocket(r *http.Request) bool {
-	return strings.ToLower(r.Header.Get("Upgrade")) == "websocket" &&
+	return strings.EqualFold(r.Header.Get("Upgrade"), "websocket") &&
 		strings.Contains(strings.ToLower(r.Header.Get("Connection")), "upgrade")
 }
 

--- a/cmd/rpcdaemon22/cli/config.go
+++ b/cmd/rpcdaemon22/cli/config.go
@@ -573,7 +573,7 @@ func stopAuthenticatedRpcServer(ctx context.Context, engineInfo *engineInfo) {
 
 // isWebsocket checks the header of a http request for a websocket upgrade request.
 func isWebsocket(r *http.Request) bool {
-	return strings.ToLower(r.Header.Get("Upgrade")) == "websocket" &&
+	return strings.EqualFold(r.Header.Get("Upgrade"), "websocket") &&
 		strings.Contains(strings.ToLower(r.Header.Get("Connection")), "upgrade")
 }
 

--- a/core/asm/compiler.go
+++ b/core/asm/compiler.go
@@ -243,12 +243,12 @@ func (c *Compiler) pushBin(v interface{}) {
 // isPush returns whether the string op is either any of
 // push(N).
 func isPush(op string) bool {
-	return strings.ToUpper(op) == "PUSH"
+	return strings.EqualFold(op, "PUSH")
 }
 
 // isJump returns whether the string op is jump(i)
 func isJump(op string) bool {
-	return strings.ToUpper(op) == "JUMPI" || strings.ToUpper(op) == "JUMP"
+	return strings.EqualFold(op, "JUMPI") || strings.EqualFold(op, "JUMP")
 }
 
 // toBinary converts text to a vm.OpCode

--- a/node/rpcstack_test.go
+++ b/node/rpcstack_test.go
@@ -324,7 +324,7 @@ func rpcRequest(t *testing.T, url string, extraHeaders ...string) *http.Response
 	}
 	for i := 0; i < len(extraHeaders); i += 2 {
 		key, value := extraHeaders[i], extraHeaders[i+1]
-		if strings.ToLower(key) == "host" {
+		if strings.EqualFold(key, "host") {
 			req.Host = value
 		} else {
 			req.Header.Set(key, value)


### PR DESCRIPTION
It's [more efficient](https://stackoverflow.com/questions/34383705/how-do-i-compare-strings-in-golang) to use `strings.EqualFold()` for [string comparison](https://github.com/dgryski/go-perfbook/blob/master/performance.md#common-gotchas-with-the-standard-library) than the normal operator. Especially when you have to lower or upper case one of the strings first.
