### PR TITLE
OOM fix for bodies stage

### DIFF
--- a/eth/stagedsync/stage_bodies.go
+++ b/eth/stagedsync/stage_bodies.go
@@ -1,6 +1,7 @@
 package stagedsync
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"runtime"
@@ -9,17 +10,23 @@ import (
 	"github.com/c2h5oh/datasize"
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/kv"
+	"github.com/ledgerwatch/log/v3"
+
 	"github.com/ledgerwatch/erigon/common"
+	"github.com/ledgerwatch/erigon/common/dbutils"
 	"github.com/ledgerwatch/erigon/core/rawdb"
+	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/eth/stagedsync/stages"
 	"github.com/ledgerwatch/erigon/params"
+	"github.com/ledgerwatch/erigon/rlp"
 	"github.com/ledgerwatch/erigon/turbo/adapter"
 	"github.com/ledgerwatch/erigon/turbo/services"
 	"github.com/ledgerwatch/erigon/turbo/snapshotsync"
 	"github.com/ledgerwatch/erigon/turbo/stages/bodydownload"
 	"github.com/ledgerwatch/erigon/turbo/stages/headerdownload"
-	"github.com/ledgerwatch/log/v3"
 )
+
+const requestLoopCutOff int = 50
 
 type BodiesCfg struct {
 	db              kv.RwDB
@@ -32,8 +39,7 @@ type BodiesCfg struct {
 	batchSize       datasize.ByteSize
 	snapshots       *snapshotsync.RoSnapshots
 	blockReader     services.FullBlockReader
-
-	historyV2 bool
+	historyV2       bool
 }
 
 func StageBodiesCfg(db kv.RwDB, bd *bodydownload.BodyDownload, bodyReqSend func(context.Context, *bodydownload.BodyRequest) ([64]byte, bool), penalise func(context.Context, []headerdownload.PenaltyItem), blockPropagator adapter.BlockPropagator, timeout int, chanConfig params.ChainConfig, batchSize datasize.ByteSize, snapshots *snapshotsync.RoSnapshots, blockReader services.FullBlockReader, historyV2 bool) BodiesCfg {
@@ -118,27 +124,60 @@ func BodiesForward(
 	var prevDeliveredCount float64 = 0
 	var prevWastedCount float64 = 0
 	timer := time.NewTimer(1 * time.Second) // Check periodically even in the abseence of incoming messages
-	var blockNum uint64
 	var req *bodydownload.BodyRequest
 	var peer [64]byte
 	var sentToPeer bool
 	stopped := false
 	prevProgress := bodyProgress
 	noProgressCount := 0 // How many time the progress was printed without actual progress
-Loop:
-	for !stopped {
-		// TODO: this is incorrect use
-		if req == nil {
-			start := time.Now()
-			currentTime := uint64(time.Now().Unix())
-			req, blockNum, err = cfg.bd.RequestMoreBodies(tx, cfg.blockReader, blockNum, currentTime, cfg.blockPropagator)
-			if err != nil {
-				return fmt.Errorf("request more bodies: %w", err)
-			}
-			d1 += time.Since(start)
+	var totalDelivered uint64 = 0
+
+	// create a temporary bucket to fire the bodies into as we start to collect them
+	// this will allow us to restart the bodies stage and not request bodies we already have
+	// once the bodies stage is complete this bucket is dropped
+	err = tx.CreateBucket("BodiesStage")
+	if err != nil {
+		return err
+	}
+	err = tx.ClearBucket("BodiesStage")
+	if err != nil {
+		return err
+	}
+
+	if !useExternalTx {
+		err = tx.Commit()
+		if err != nil {
+			return err
 		}
+	}
+
+	loopBody := func() (bool, error) {
+		// innerTx is used for the temporary stage bucket to hold on to bodies as they're downloaded
+		// offering restart capability for the stage bodies process
+		var innerTx kv.RwTx
+		if !useExternalTx {
+			innerTx, err = cfg.db.BeginRw(context.Background())
+			if err != nil {
+				return false, err
+			}
+			defer innerTx.Rollback()
+		} else {
+			innerTx = tx
+		}
+
+		// always check if a new request is needed at the start of the loop
+		// this will check for timed out old requests and attempt to send them again
+		start := time.Now()
+		currentTime := uint64(time.Now().Unix())
+		req, err = cfg.bd.RequestMoreBodies(innerTx, cfg.blockReader, currentTime, cfg.blockPropagator)
+		if err != nil {
+			return false, fmt.Errorf("request more bodies: %w", err)
+		}
+		d1 += time.Since(start)
+
 		peer = [64]byte{}
 		sentToPeer = false
+
 		if req != nil {
 			start := time.Now()
 			peer, sentToPeer = cfg.bodyReqSend(ctx, req)
@@ -150,12 +189,18 @@ Loop:
 			cfg.bd.RequestSent(req, currentTime+uint64(timeout), peer)
 			d3 += time.Since(start)
 		}
+
+		// loopCount is used here to ensure we don't get caught in a constant loop of making requests
+		// having some time out so requesting again and cycling like that forever.  We'll cap it
+		// and break the loop so we can see if there are any records to actually process further down
+		// then come back here again in the next cycle
+		loopCount := 0
 		for req != nil && sentToPeer {
 			start := time.Now()
 			currentTime := uint64(time.Now().Unix())
-			req, blockNum, err = cfg.bd.RequestMoreBodies(tx, cfg.blockReader, blockNum, currentTime, cfg.blockPropagator)
+			req, err = cfg.bd.RequestMoreBodies(innerTx, cfg.blockReader, currentTime, cfg.blockPropagator)
 			if err != nil {
-				return fmt.Errorf("request more bodies: %w", err)
+				return false, fmt.Errorf("request more bodies: %w", err)
 			}
 			d1 += time.Since(start)
 			peer = [64]byte{}
@@ -170,56 +215,111 @@ Loop:
 				cfg.bd.RequestSent(req, currentTime+uint64(timeout), peer)
 				d3 += time.Since(start)
 			}
+
+			loopCount++
+			if loopCount >= requestLoopCutOff {
+				break
+			}
 		}
-		start := time.Now()
-		headers, rawBodies, err := cfg.bd.GetDeliveries()
+
+		start = time.Now()
+		requestedLow, delivered, err := cfg.bd.GetDeliveries(innerTx)
 		if err != nil {
-			return err
+			return false, err
 		}
+		totalDelivered += delivered
 		d4 += time.Since(start)
 		start = time.Now()
-		cr := ChainReader{Cfg: cfg.chanConfig, Db: tx}
-		for i, header := range headers {
-			rawBody := rawBodies[i]
-			blockHeight := header.Number.Uint64()
-			// Txn & uncle roots are verified via bd.requestedMap
-			err := cfg.bd.Engine.VerifyUncles(cr, header, rawBody.Uncles)
-			if err != nil {
-				log.Error(fmt.Sprintf("[%s] Uncle verification failed", logPrefix), "number", blockHeight, "hash", header.Hash().String(), "err", err)
-				u.UnwindTo(blockHeight-1, header.Hash())
-				break Loop
-			}
+		cr := ChainReader{Cfg: cfg.chanConfig, Db: innerTx}
 
-			// Check existence before write - because WriteRawBody isn't idempotent (it allocates new sequence range for transactions on every call)
-			ok, lastTxnNum, err := rawdb.WriteRawBodyIfNotExists(tx, header.Hash(), blockHeight, rawBody)
-			if err != nil {
-				return fmt.Errorf("WriteRawBodyIfNotExists: %w", err)
-			}
-			if cfg.historyV2 && ok {
-				if err := rawdb.TxNums.Append(tx, blockHeight, lastTxnNum); err != nil {
-					return err
+		toProcess := cfg.bd.NextProcessingCount()
+
+		if toProcess > 0 {
+			var i uint64
+			for i = 0; i < toProcess; i++ {
+				nextBlock := requestedLow + i
+				key := dbutils.EncodeBlockNumber(nextBlock)
+				body, err := innerTx.GetOne("BodiesStage", key)
+				if err != nil {
+					return false, err
 				}
-				//cfg.txNums.Append(blockHeight, lastTxnNum)
-			}
+				if body == nil {
+					return false, fmt.Errorf("[%s] Body was nil when reading from bucket, block: %v", logPrefix, nextBlock)
+				}
 
-			if blockHeight > bodyProgress {
-				bodyProgress = blockHeight
-				if err = s.Update(tx, blockHeight); err != nil {
-					return fmt.Errorf("saving Bodies progress: %w", err)
+				header, _, err := cfg.bd.GetHeader(nextBlock, cfg.blockReader, innerTx)
+				if err != nil {
+					return false, err
+				}
+
+				var rawBody types.RawBody
+				fromHex := common.CopyBytes(common.FromHex(string(body)))
+				bodyReader := bytes.NewReader(fromHex)
+				stream := rlp.NewStream(bodyReader, 0)
+				err = rawBody.DecodeRLP(stream)
+				if err != nil {
+					log.Error("Unexpected body from bucket", "err", err, "block", nextBlock)
+					return false, fmt.Errorf("%w, nextBlock=%d", err, nextBlock)
+				}
+
+				blockHeight := header.Number.Uint64()
+
+				if blockHeight != nextBlock {
+					return false, fmt.Errorf("[%s] Header block unexpected when matching body, got %v, expected %v", logPrefix, blockHeight, nextBlock)
+				}
+
+				// Txn & uncle roots are verified via bd.requestedMap
+				err = cfg.bd.Engine.VerifyUncles(cr, header, rawBody.Uncles)
+				if err != nil {
+					log.Error(fmt.Sprintf("[%s] Uncle verification failed", logPrefix), "number", blockHeight, "hash", header.Hash().String(), "err", err)
+					u.UnwindTo(blockHeight-1, header.Hash())
+					return true, nil
+				}
+
+				// Check existence before write - because WriteRawBody isn't idempotent (it allocates new sequence range for transactions on every call)
+				ok, lastTxnNum, err := rawdb.WriteRawBodyIfNotExists(innerTx, header.Hash(), blockHeight, &rawBody)
+				if err != nil {
+					return false, fmt.Errorf("WriteRawBodyIfNotExists: %w", err)
+				}
+				if cfg.historyV2 && ok {
+					if err := rawdb.TxNums.Append(tx, blockHeight, lastTxnNum); err != nil {
+						return false, err
+					}
+				}
+
+				if blockHeight > bodyProgress {
+					bodyProgress = blockHeight
+					if err = s.Update(innerTx, blockHeight); err != nil {
+						return false, fmt.Errorf("saving Bodies progress: %w", err)
+					}
 				}
 			}
 		}
+
+		// if some form of work has happened then commit the transaction
+		if !useExternalTx && (cfg.bd.HasAddedBodies() || toProcess > 0) {
+			err = innerTx.Commit()
+			if err != nil {
+				return false, err
+			}
+			cfg.bd.ResetAddedBodies()
+		}
+
+		if toProcess > 0 {
+			logWritingBodies(logPrefix, bodyProgress, headerProgress)
+		}
+
 		d5 += time.Since(start)
 		start = time.Now()
 		if bodyProgress == headerProgress {
-			break
+			return true, nil
 		}
 		if test {
 			stopped = true
-			break
+			return true, nil
 		}
 		if !firstCycle && s.BlockNumber > 0 && noProgressCount >= 5 {
-			break
+			return true, nil
 		}
 		timer.Stop()
 		timer = time.NewTimer(1 * time.Second)
@@ -233,7 +333,7 @@ Loop:
 			} else {
 				noProgressCount = 0 // Reset, there was progress
 			}
-			logProgressBodies(logPrefix, bodyProgress, prevDeliveredCount, deliveredCount, prevWastedCount, wastedCount)
+			logDownloadingBodies(logPrefix, bodyProgress, headerProgress-requestedLow, totalDelivered, prevDeliveredCount, deliveredCount, prevWastedCount, wastedCount)
 			prevProgress = bodyProgress
 			prevDeliveredCount = deliveredCount
 			prevWastedCount = wastedCount
@@ -244,15 +344,38 @@ Loop:
 			log.Trace("bodyLoop woken up by the incoming request")
 		}
 		d6 += time.Since(start)
+
+		return false, nil
 	}
-	if err := s.Update(tx, bodyProgress); err != nil {
-		return err
-	}
-	if !useExternalTx {
-		if err := tx.Commit(); err != nil {
+
+	// kick off the loop and check for any reason to stop and break early
+	for !stopped {
+		shouldBreak, err := loopBody()
+		if err != nil {
 			return err
 		}
+		if shouldBreak {
+			break
+		}
 	}
+
+	// remove the temporary bucket for bodies stage
+	if !useExternalTx {
+		bucketTx, err := cfg.db.BeginRw(context.Background())
+		if err != nil {
+			return err
+		}
+		defer bucketTx.Rollback()
+
+		bucketTx.ClearBucket("BodiesStage")
+		err = bucketTx.Commit()
+		if err != nil {
+			return err
+		}
+	} else {
+		tx.ClearBucket("BodiesStage")
+	}
+
 	if stopped {
 		return libcommon.ErrStopped
 	}
@@ -262,7 +385,7 @@ Loop:
 	return nil
 }
 
-func logProgressBodies(logPrefix string, committed uint64, prevDeliveredCount, deliveredCount, prevWastedCount, wastedCount float64) {
+func logDownloadingBodies(logPrefix string, committed, requested uint64, totalDelivered uint64, prevDeliveredCount, deliveredCount, prevWastedCount, wastedCount float64) {
 	speed := (deliveredCount - prevDeliveredCount) / float64(logInterval/time.Second)
 	wastedSpeed := (wastedCount - prevWastedCount) / float64(logInterval/time.Second)
 	if speed == 0 && wastedSpeed == 0 {
@@ -272,10 +395,24 @@ func logProgressBodies(logPrefix string, committed uint64, prevDeliveredCount, d
 
 	var m runtime.MemStats
 	libcommon.ReadMemStats(&m)
-	log.Info(fmt.Sprintf("[%s] Wrote block bodies", logPrefix),
+	log.Info(fmt.Sprintf("[%s] Downloading block bodies", logPrefix),
 		"block_num", committed,
 		"delivery/sec", libcommon.ByteCount(uint64(speed)),
 		"wasted/sec", libcommon.ByteCount(uint64(wastedSpeed)),
+		"open_requests", requested,
+		"delivered", totalDelivered,
+		"alloc", libcommon.ByteCount(m.Alloc),
+		"sys", libcommon.ByteCount(m.Sys),
+	)
+}
+
+func logWritingBodies(logPrefix string, committed, headerProgress uint64) {
+	var m runtime.MemStats
+	libcommon.ReadMemStats(&m)
+	remaining := headerProgress - committed
+	log.Info(fmt.Sprintf("[%s] Writing block bodies", logPrefix),
+		"block_num", committed,
+		"remaining", remaining,
 		"alloc", libcommon.ByteCount(m.Alloc),
 		"sys", libcommon.ByteCount(m.Sys),
 	)

--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -999,18 +999,18 @@ func (s *Stream) readKind() (kind Kind, size uint64, err error) {
 	}
 	s.byteval = 0
 	switch {
-	case b < 0x80:
+	case b < 0x80: //128
 		// For a single byte whose value is in the [0x00, 0x7F] range, that byte
 		// is its own RLP encoding.
 		s.byteval = b
 		return Byte, 0, nil
-	case b < 0xB8:
+	case b < 0xB8: //184
 		// Otherwise, if a string is 0-55 bytes long,
 		// the RLP encoding consists of a single byte with value 0x80 plus the
 		// length of the string followed by the string. The range of the first
 		// byte is thus [0x80, 0xB7].
 		return String, uint64(b - 0x80), nil
-	case b < 0xC0:
+	case b < 0xC0: //192
 		// If a string is more than 55 bytes long, the
 		// RLP encoding consists of a single byte with value 0xB7 plus the length
 		// of the length of the string in binary form, followed by the length of
@@ -1022,7 +1022,7 @@ func (s *Stream) readKind() (kind Kind, size uint64, err error) {
 			err = ErrCanonSize
 		}
 		return String, size, err
-	case b < 0xF8:
+	case b < 0xF8: //248
 		// If the total payload of a list
 		// (i.e. the combined length of all its items) is 0-55 bytes long, the
 		// RLP encoding consists of a single byte with value 0xC0 plus the length
@@ -1036,7 +1036,7 @@ func (s *Stream) readKind() (kind Kind, size uint64, err error) {
 		// form, followed by the length of the payload, followed by
 		// the concatenation of the RLP encodings of the items. The
 		// range of the first byte is thus [0xF8, 0xFF].
-		size, err = s.readUint(b - 0xF7)
+		size, err = s.readUint(b - 0xF7) //247
 		if err == nil && size < 56 {
 			err = ErrCanonSize
 		}

--- a/turbo/stages/bodydownload/body_algos.go
+++ b/turbo/stages/bodydownload/body_algos.go
@@ -12,6 +12,8 @@ import (
 	"github.com/ledgerwatch/log/v3"
 
 	"github.com/ledgerwatch/erigon/common"
+	"github.com/ledgerwatch/erigon/common/dbutils"
+	"github.com/ledgerwatch/erigon/common/hexutil"
 	"github.com/ledgerwatch/erigon/core/rawdb"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/eth/stagedsync/stages"
@@ -41,11 +43,8 @@ func (bd *BodyDownload) UpdateFromDb(db kv.Tx) (headHeight uint64, headHash comm
 	bd.delivered.Clear()
 	bd.deliveredCount = 0
 	bd.wastedCount = 0
-	for i := 0; i < len(bd.deliveriesH); i++ {
-		bd.deliveriesH[i] = nil
-		bd.deliveriesB[i] = nil
-		bd.requests[i] = nil
-	}
+	bd.deliveriesH = make(map[uint64]*types.Header)
+	bd.requests = make(map[uint64]*BodyRequest)
 	bd.peerMap = make(map[[64]byte]int)
 	headHeight = bodyProgress
 	headHash, err = rawdb.ReadCanonicalHash(db, headHeight)
@@ -69,101 +68,124 @@ func (bd *BodyDownload) UpdateFromDb(db kv.Tx) (headHeight uint64, headHash comm
 }
 
 // RequestMoreBodies - returns nil if nothing to request
-func (bd *BodyDownload) RequestMoreBodies(tx kv.RwTx, blockReader services.FullBlockReader, blockNum uint64, currentTime uint64, blockPropagator adapter.BlockPropagator) (*BodyRequest, uint64, error) {
-	if blockNum < bd.requestedLow {
-		blockNum = bd.requestedLow
-	}
+func (bd *BodyDownload) RequestMoreBodies(tx kv.RwTx, blockReader services.FullBlockReader, currentTime uint64, blockPropagator adapter.BlockPropagator) (*BodyRequest, error) {
 	var bodyReq *BodyRequest
 	blockNums := make([]uint64, 0, BlockBufferSize)
 	hashes := make([]common.Hash, 0, BlockBufferSize)
-	for ; len(blockNums) < BlockBufferSize && bd.requestedLow <= bd.maxProgress; blockNum++ {
+
+	// go right back to the start of the earliest request that it still outstanding here so that we can
+	// check for timeouts, as requests are delivered from peers bd.requestedLow will be incremented so this loop will move forwards over time.
+	// If a request has timed out we nil out the request and add it back in to the next request going to a peer.
+	// not all requests will have contiguous block numbers because of this
+	for bNum := bd.requestedLow; len(blockNums) < BlockBufferSize && bNum <= bd.maxProgress; bNum++ {
 		// Check if we reached highest allowed request block number, and turn back
-		if blockNum >= bd.requestedLow+bd.outstandingLimit || blockNum >= bd.maxProgress {
-			blockNum = 0
+		if bNum >= bd.requestedLow+bd.outstandingLimit || bNum >= bd.maxProgress {
 			break // Avoid tight loop
 		}
-		if bd.delivered.Contains(blockNum) {
+		if bd.delivered.Contains(bNum) {
 			// Already delivered, no need to request
 			continue
 		}
-		req := bd.requests[blockNum-bd.requestedLow]
+
+		// check if we already have a request and check if it has timed out
+		req := bd.requests[bNum]
 		if req != nil {
 			if currentTime < req.waitUntil {
 				continue
 			}
 			bd.peerMap[req.peerID]++
-			bd.requests[blockNum-bd.requestedLow] = nil
+			bd.requests[bNum] = nil
 		}
+
+		// check in the bucket if that has been received either in this run or a previous one.
+		// if we already have the body we can continue on to populate header info and then skip
+		// the body request altogether
+		var err error
+		key := dbutils.EncodeBlockNumber(bNum)
+		bodyInBucket, err := tx.Has("BodiesStage", key)
+		if err != nil {
+			return nil, err
+		}
+		if bodyInBucket {
+			bd.delivered.Add(bNum)
+			continue
+		}
+
 		var hash common.Hash
 		var header *types.Header
-		var err error
 		request := true
-
-		if bd.deliveriesH[blockNum-bd.requestedLow] != nil {
+		if bd.deliveriesH[bNum] != nil {
 			// If this block was requested before, we don't need to fetch the headers from the database the second time
-			header = bd.deliveriesH[blockNum-bd.requestedLow]
+			header = bd.deliveriesH[bNum]
 			if header == nil {
-				return nil, 0, fmt.Errorf("header not found: %w, blockNum=%d, trace=%s", err, blockNum, dbg.Stack())
+				return nil, fmt.Errorf("header not found: %w, blockNum=%d, trace=%s", err, bNum, dbg.Stack())
 			}
 			hash = header.Hash()
 
 			// check here if we have the block prefetched as this could have come in as part of a data race
 			// we want to avoid an infinite loop if the header was populated in deliveriesH before the block
 			// was added to the prefetched cache
-			if hasPrefetched := bd.checkPrefetchedBlock(hash, tx, blockNum, blockPropagator); hasPrefetched {
+			if hasPrefetched := bd.checkPrefetchedBlock(hash, tx, bNum, blockPropagator); hasPrefetched {
 				request = false
 			}
 		} else {
-			hash, err = rawdb.ReadCanonicalHash(tx, blockNum)
+			hash, err = rawdb.ReadCanonicalHash(tx, bNum)
 			if err != nil {
-				return nil, 0, fmt.Errorf("could not find canonical header: %w, blockNum=%d, trace=%s", err, blockNum, dbg.Stack())
+				return nil, fmt.Errorf("could not find canonical header: %w, blockNum=%d, trace=%s", err, bNum, dbg.Stack())
 			}
 
-			header, err = blockReader.Header(context.Background(), tx, hash, blockNum)
+			header, err = blockReader.Header(context.Background(), tx, hash, bNum)
 			if err != nil {
-				return nil, 0, fmt.Errorf("header not found: %w, blockNum=%d, trace=%s", err, blockNum, dbg.Stack())
+				return nil, fmt.Errorf("header not found: %w, blockNum=%d, trace=%s", err, bNum, dbg.Stack())
 			}
 			if header == nil {
-				return nil, 0, fmt.Errorf("header not found: blockNum=%d, hash=%x, trace=%s", blockNum, hash, dbg.Stack())
+				return nil, fmt.Errorf("header not found: blockNum=%d, hash=%x, trace=%s", bNum, hash, dbg.Stack())
 			}
 
-			if hasPrefetched := bd.checkPrefetchedBlock(hash, tx, blockNum, blockPropagator); hasPrefetched {
+			if hasPrefetched := bd.checkPrefetchedBlock(hash, tx, bNum, blockPropagator); hasPrefetched {
 				request = false
 			} else {
-				bd.deliveriesH[blockNum-bd.requestedLow] = header
+				bd.deliveriesH[bNum] = header
 				if header.UncleHash != types.EmptyUncleHash || header.TxHash != types.EmptyRootHash {
 					// Perhaps we already have this block
-					block := rawdb.ReadBlock(tx, hash, blockNum)
+					block := rawdb.ReadBlock(tx, hash, bNum)
 					if block == nil {
 						var doubleHash DoubleHash
 						copy(doubleHash[:], header.UncleHash.Bytes())
 						copy(doubleHash[common.HashLength:], header.TxHash.Bytes())
-						bd.requestedMap[doubleHash] = blockNum
+						bd.requestedMap[doubleHash] = bNum
 					} else {
-						bd.deliveriesB[blockNum-bd.requestedLow] = block.RawBody()
+						err = bd.addBodyToBucket(tx, bNum, block.RawBody())
+						if err != nil {
+							log.Error("Failed to add block body to bucket", "err", err, "number", block.NumberU64()-1, "hash", block.ParentHash())
+						}
 						request = false
 					}
 				} else {
-					bd.deliveriesB[blockNum-bd.requestedLow] = &types.RawBody{}
+					err = bd.addBodyToBucket(tx, bNum, &types.RawBody{})
+					if err != nil {
+						log.Error("Failed to add block body to bucket", "err", err, "number", bNum, "hash", hash)
+					}
 					request = false
 				}
 			}
 		}
+
 		if request {
-			blockNums = append(blockNums, blockNum)
+			blockNums = append(blockNums, bNum)
 			hashes = append(hashes, hash)
 		} else {
 			// Both uncleHash and txHash are empty (or block is prefetched), no need to request
-			bd.delivered.Add(blockNum)
+			bd.delivered.Add(bNum)
 		}
 	}
 	if len(blockNums) > 0 {
 		bodyReq = &BodyRequest{BlockNums: blockNums, Hashes: hashes}
-		for _, blockNum := range blockNums {
-			bd.requests[blockNum-bd.requestedLow] = bodyReq
+		for _, num := range blockNums {
+			bd.requests[num] = bodyReq
 		}
 	}
-	return bodyReq, blockNum, nil
+	return bodyReq, nil
 }
 
 // checks if we have the block prefetched, returns true if found and stored or false if not present
@@ -176,7 +198,6 @@ func (bd *BodyDownload) checkPrefetchedBlock(hash common.Hash, tx kv.RwTx, block
 
 	// Block is prefetched, no need to request
 	bd.deliveriesH[blockNum-bd.requestedLow] = block.Header()
-	bd.deliveriesB[blockNum-bd.requestedLow] = block.RawBody()
 
 	// Calculate the TD of the block (it's not imported yet, so block.Td is not valid)
 	if parent, err := rawdb.ReadTd(tx, block.ParentHash(), block.NumberU64()-1); err != nil {
@@ -198,10 +219,10 @@ func (bd *BodyDownload) RequestSent(bodyReq *BodyRequest, timeWithTimeout uint64
 		if blockNum < bd.requestedLow {
 			continue
 		}
-		req := bd.requests[blockNum-bd.requestedLow]
+		req := bd.requests[blockNum]
 		if req != nil {
-			bd.requests[blockNum-bd.requestedLow].waitUntil = timeWithTimeout
-			bd.requests[blockNum-bd.requestedLow].peerID = peer
+			bd.requests[blockNum].waitUntil = timeWithTimeout
+			bd.requests[blockNum].peerID = peer
 		}
 	}
 }
@@ -241,7 +262,13 @@ func (rt RawTransactions) EncodeIndex(i int, w *bytes.Buffer) {
 	w.Write(rt[i]) //nolint:errcheck
 }
 
-func (bd *BodyDownload) doDeliverBodies() (err error) {
+func (bd *BodyDownload) DeliverySize(delivered float64, wasted float64) {
+	bd.deliveredCount += delivered
+	bd.wastedCount += wasted
+}
+
+func (bd *BodyDownload) GetDeliveries(tx kv.RwTx) (uint64, uint64, error) {
+	var delivered, undelivered int
 Loop:
 	for {
 		var delivery Delivery
@@ -265,7 +292,6 @@ Loop:
 
 		reqMap := make(map[uint64]*BodyRequest)
 		txs, uncles, lenOfP2PMessage, _ := *delivery.txs, *delivery.uncles, delivery.lenOfP2PMessage, delivery.peerID
-		var delivered, undelivered int
 
 		for i := range txs {
 			uncleHash := types.CalcUncleHash(uncles[i])
@@ -281,7 +307,7 @@ Loop:
 				undelivered++
 				continue
 			}
-			req := bd.requests[blockNum-bd.requestedLow]
+			req := bd.requests[blockNum]
 			if req != nil {
 				if _, ok := reqMap[req.BlockNums[0]]; !ok {
 					reqMap[req.BlockNums[0]] = req
@@ -289,14 +315,17 @@ Loop:
 			}
 			delete(bd.requestedMap, doubleHash) // Delivered, cleaning up
 
-			bd.deliveriesB[blockNum-bd.requestedLow] = &types.RawBody{Transactions: txs[i], Uncles: uncles[i]}
+			err := bd.addBodyToBucket(tx, blockNum, &types.RawBody{Transactions: txs[i], Uncles: uncles[i]})
+			if err != nil {
+				return 0, 0, err
+			}
 			bd.delivered.Add(blockNum)
 			delivered++
 		}
 		// Clean up the requests
 		for _, req := range reqMap {
 			for _, blockNum := range req.BlockNums {
-				bd.requests[blockNum-bd.requestedLow] = nil
+				bd.requests[blockNum] = nil
 			}
 		}
 		total := delivered + undelivered
@@ -305,44 +334,20 @@ Loop:
 			bd.DeliverySize(float64(lenOfP2PMessage)*float64(delivered)/float64(delivered+undelivered), float64(lenOfP2PMessage)*float64(undelivered)/float64(delivered+undelivered))
 		}
 	}
-	return nil
+
+	return bd.requestedLow, uint64(delivered), nil
 }
 
-func (bd *BodyDownload) DeliverySize(delivered float64, wasted float64) {
-	bd.deliveredCount += delivered
-	bd.wastedCount += wasted
-}
-
-func (bd *BodyDownload) GetDeliveries() ([]*types.Header, []*types.RawBody, error) {
-	err := bd.doDeliverBodies() // TODO: join this 2 funcs and simplify
-	if err != nil {
-		return nil, nil, err
-	}
-
+// NextProcessingCount returns the count of contiguous block numbers ready to process from the
+// requestedLow minimum value.
+// the requestedLow count is increased by the number returned
+func (bd *BodyDownload) NextProcessingCount() uint64 {
 	var i uint64
 	for i = 0; !bd.delivered.IsEmpty() && bd.requestedLow+i == bd.delivered.Minimum(); i++ {
 		bd.delivered.Remove(bd.requestedLow + i)
 	}
-	// Move the deliveries back
-	// bd.requestedLow can only be moved forward if there are consecutive block numbers present in the bd.delivered map
-	var headers []*types.Header
-	var rawBodies []*types.RawBody
-	if i > 0 {
-		headers = make([]*types.Header, i)
-		rawBodies = make([]*types.RawBody, i)
-		copy(headers, bd.deliveriesH[:i])
-		copy(rawBodies, bd.deliveriesB[:i])
-		copy(bd.deliveriesH, bd.deliveriesH[i:])
-		copy(bd.deliveriesB, bd.deliveriesB[i:])
-		copy(bd.requests, bd.requests[i:])
-		for j := len(bd.deliveriesH) - int(i); j < len(bd.deliveriesH); j++ {
-			bd.deliveriesH[j] = nil
-			bd.deliveriesB[j] = nil
-			bd.requests[j] = nil
-		}
-		bd.requestedLow += i
-	}
-	return headers, rawBodies, nil
+	bd.requestedLow += i
+	return i
 }
 
 func (bd *BodyDownload) DeliveryCounts() (float64, float64) {
@@ -383,4 +388,56 @@ func (bd *BodyDownload) AddToPrefetch(block *types.Block) {
 func (bd *BodyDownload) AddMinedBlock(block *types.Block) error {
 	bd.AddToPrefetch(block)
 	return nil
+}
+
+// GetHeader returns a header by either loading from the deliveriesH slice populated when running RequestMoreBodies
+// or if the code is continuing from a previous run and this isn't present, by reading from the DB as the RequestMoreBodies would have.
+// as the requestedLow count is incremented before a call to this function we need the process count so that we can anticipate this,
+// effectively reversing time a little to get the actual position we need in the slice prior to requestedLow being incremented
+func (bd *BodyDownload) GetHeader(blockNum uint64, blockReader services.FullBlockReader, tx kv.Tx) (*types.Header, common.Hash, error) {
+	var header *types.Header
+	if bd.deliveriesH[blockNum] != nil {
+		header = bd.deliveriesH[blockNum]
+	} else {
+		hash, err := rawdb.ReadCanonicalHash(tx, blockNum)
+		if err != nil {
+			return nil, common.Hash{}, err
+		}
+		header, err = blockReader.Header(context.Background(), tx, hash, blockNum)
+		if err != nil {
+			return nil, common.Hash{}, err
+		}
+		if header == nil {
+			return nil, common.Hash{}, fmt.Errorf("header not found: blockNum=%d, hash=%x, trace=%s", blockNum, hash, dbg.Stack())
+		}
+	}
+	return header, header.Hash(), nil
+}
+
+func (bd *BodyDownload) addBodyToBucket(tx kv.RwTx, key uint64, body *types.RawBody) error {
+	writer := bytes.NewBuffer(nil)
+	err := body.EncodeRLP(writer)
+	if err != nil {
+		return err
+	}
+	rlpBytes := common.CopyBytes(writer.Bytes())
+	writer.Reset()
+	writer.WriteString(hexutil.Encode(rlpBytes))
+
+	k := dbutils.EncodeBlockNumber(key)
+	err = tx.Put("BodiesStage", k, writer.Bytes())
+	if err != nil {
+		return err
+	}
+
+	bd.bodiesAdded = true
+	return nil
+}
+
+func (bd *BodyDownload) HasAddedBodies() bool {
+	return bd.bodiesAdded
+}
+
+func (bd *BodyDownload) ResetAddedBodies() {
+	bd.bodiesAdded = false
 }

--- a/turbo/stages/bodydownload/body_algos.go
+++ b/turbo/stages/bodydownload/body_algos.go
@@ -197,7 +197,10 @@ func (bd *BodyDownload) checkPrefetchedBlock(hash common.Hash, tx kv.RwTx, block
 	}
 
 	// Block is prefetched, no need to request
-	bd.deliveriesH[blockNum-bd.requestedLow] = block.Header()
+	bd.deliveriesH[blockNum] = block.Header()
+
+	// make sure we have the body in the bucket for later use
+	bd.addBodyToBucket(tx, blockNum, block.RawBody())
 
 	// Calculate the TD of the block (it's not imported yet, so block.Td is not valid)
 	if parent, err := rawdb.ReadTd(tx, block.ParentHash(), block.NumberU64()-1); err != nil {

--- a/turbo/stages/bodydownload/body_data_struct.go
+++ b/turbo/stages/bodydownload/body_data_struct.go
@@ -2,6 +2,7 @@ package bodydownload
 
 import (
 	"github.com/RoaringBitmap/roaring/roaring64"
+
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/consensus"
 	"github.com/ledgerwatch/erigon/core/types"
@@ -28,9 +29,8 @@ type BodyDownload struct {
 	Engine           consensus.Engine
 	delivered        *roaring64.Bitmap
 	prefetchedBlocks *PrefetchedBlocks
-	deliveriesH      []*types.Header
-	deliveriesB      []*types.RawBody
-	requests         []*BodyRequest
+	deliveriesH      map[uint64]*types.Header
+	requests         map[uint64]*BodyRequest
 	maxProgress      uint64
 	requestedLow     uint64 // Lower bound of block number for outstanding requests
 	requestHigh      uint64
@@ -38,6 +38,7 @@ type BodyDownload struct {
 	outstandingLimit uint64 // Limit of number of outstanding blocks for body requests
 	deliveredCount   float64
 	wastedCount      float64
+	bodiesAdded      bool
 }
 
 // BodyRequest is a sketch of the request for block bodies, meaning that access to the database is required to convert it to the actual BlockBodies request (look up hashes of canonical blocks)
@@ -54,9 +55,8 @@ func NewBodyDownload(outstandingLimit int, engine consensus.Engine) *BodyDownloa
 		requestedMap:     make(map[DoubleHash]uint64),
 		outstandingLimit: uint64(outstandingLimit),
 		delivered:        roaring64.New(),
-		deliveriesH:      make([]*types.Header, outstandingLimit+MaxBodiesInRequest),
-		deliveriesB:      make([]*types.RawBody, outstandingLimit+MaxBodiesInRequest),
-		requests:         make([]*BodyRequest, outstandingLimit+MaxBodiesInRequest),
+		deliveriesH:      make(map[uint64]*types.Header),
+		requests:         make(map[uint64]*BodyRequest),
 		peerMap:          make(map[[64]byte]int),
 		prefetchedBlocks: NewPrefetchedBlocks(),
 		// DeliveryNotify has capacity 1, and it is also used so that senders never block

--- a/turbo/stages/bodydownload/body_test.go
+++ b/turbo/stages/bodydownload/body_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/ledgerwatch/erigon-lib/kv/memdb"
+
 	"github.com/ledgerwatch/erigon/consensus/ethash"
 )
 


### PR DESCRIPTION
Addresses the OOM issue during the block bodies stage by using a bucket which is flushed at the end of each run of the bodies stage.  The bucket is used to effectively replace the slice that held on to bodies as they were downloaded.

The original idea of using an ETL for this fell a little short as it didn't allow for easy checking of whether we already had a block on resuming the process, so switching to the bucket won out here.

A couple of other bits are added in there too:
- easing the understanding of the code by not relying so much on block numbers - requested low to get positions in slices.  These are replaced with maps which makes the code much easier to reason about.
- the existing code had a path for re-requesting bodies but would never be hit.  The changes here always go back to the requested low number when checking for new body requests so as requests time out they will be retried potentially with a new peer if they are available.
- progress is committed to the DB as it's made allowing you to halt the process and continue again later and bodies previously received will still be in the bucket so won't be requested again.  Progress on the chain is also persisted as it's made rather than going back to the start every time.
- Better logging, isolating the downloading of bodies steps vs. writing of bodies.

Some of the code may be a little naive around the use of the bucket, I'd imagine having the bucket name in erigon-lib would be better and making it an official long lived bucket might also be a good idea as it will be used once the node has caught up as well.  Any advice on this would be great and I can make the changes.

