### PR TITLE
EIP-3855: PUSH0 instruction

### DIFF
--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -26,6 +26,7 @@ import (
 )
 
 var activators = map[int]func(*JumpTable){
+	3855: enable3855,
 	3529: enable3529,
 	3198: enable3198,
 	2929: enable2929,
@@ -169,5 +170,22 @@ func enable3198(jt *JumpTable) {
 func opBaseFee(pc *uint64, interpreter *EVMInterpreter, callContext *ScopeContext) ([]byte, error) {
 	baseFee := interpreter.evm.Context().BaseFee
 	callContext.Stack.Push(baseFee)
+	return nil, nil
+}
+
+// enable3855 applies EIP-3855 (PUSH0 opcode)
+func enable3855(jt *JumpTable) {
+	// New opcode
+	jt[PUSH0] = &operation{
+		execute:     opPush0,
+		constantGas: GasQuickStep,
+		minStack:    minStack(0, 1),
+		maxStack:    maxStack(0, 1),
+	}
+}
+
+// opPush0 implements the PUSH0 opcode
+func opPush0(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	scope.Stack.push(new(uint256.Int))
 	return nil, nil
 }

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -186,6 +186,6 @@ func enable3855(jt *JumpTable) {
 
 // opPush0 implements the PUSH0 opcode
 func opPush0(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	scope.Stack.push(new(uint256.Int))
+	scope.Stack.Push(new(uint256.Int))
 	return nil, nil
 }

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -84,6 +84,7 @@ func newCancunInstructionSet() JumpTable {
 // constantinople, istanbul, petersburg, berlin, london, paris, and shanghai instructions.
 func newShanghaiInstructionSet() JumpTable {
 	instructionSet := newLondonInstructionSet()
+	enable3855(&instructionSet) // PUSH0 instruction https://eips.ethereum.org/EIPS/eip-3855
 	return instructionSet
 }
 
@@ -91,7 +92,7 @@ func newShanghaiInstructionSet() JumpTable {
 // constantinople, istanbul, petersburg, berlin, and london instructions.
 func newLondonInstructionSet() JumpTable {
 	instructionSet := newBerlinInstructionSet()
-	enable3529(&instructionSet) // EIP-3529: Reduction in refunds https://eips.ethereum.org/EIPS/eip-3529
+	enable3529(&instructionSet) // Reduction in refunds https://eips.ethereum.org/EIPS/eip-3529
 	enable3198(&instructionSet) // Base fee opcode https://eips.ethereum.org/EIPS/eip-3198
 	return instructionSet
 }

--- a/core/vm/opcodes.go
+++ b/core/vm/opcodes.go
@@ -120,6 +120,7 @@ const (
 	MSIZE    OpCode = 0x59
 	GAS      OpCode = 0x5a
 	JUMPDEST OpCode = 0x5b
+	PUSH0    OpCode = 0x5f
 )
 
 // 0x60 range.
@@ -298,6 +299,7 @@ var opCodeToString = map[OpCode]string{
 	MSIZE:    "MSIZE",
 	GAS:      "GAS",
 	JUMPDEST: "JUMPDEST",
+	PUSH0:    "PUSH0",
 
 	// 0x60 range - push.
 	PUSH1:  "PUSH1",
@@ -464,6 +466,7 @@ var stringToOp = map[string]OpCode{
 	"MSIZE":          MSIZE,
 	"GAS":            GAS,
 	"JUMPDEST":       JUMPDEST,
+	"PUSH0":          PUSH0,
 	"PUSH1":          PUSH1,
 	"PUSH2":          PUSH2,
 	"PUSH3":          PUSH3,


### PR DESCRIPTION
[EIP-3855](https://eips.ethereum.org/EIPS/eip-3855) is part of [Shanghai](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/shanghai.md).