### PR TITLE
taking bad transaction out the slice

### DIFF
--- a/eth/stagedsync/stage_mining_create_block.go
+++ b/eth/stagedsync/stage_mining_create_block.go
@@ -362,7 +362,7 @@ func filterBadTransactions(tx kv.Tx, transactions []types.Transaction, config pa
 		transaction := transactions[0]
 		sender, ok := transaction.GetSender()
 		if !ok {
-			transactions = transactions[:1]
+			transactions = transactions[1:]
 			continue
 		}
 		var account accounts.Account
@@ -371,7 +371,7 @@ func filterBadTransactions(tx kv.Tx, transactions []types.Transaction, config pa
 			return nil, err
 		}
 		if !ok {
-			transactions = transactions[:1]
+			transactions = transactions[1:]
 			continue
 		}
 		// Check transaction nonce


### PR DESCRIPTION
Currently if a transaction doesn't pass a check we do this `transactions = transactions[:1]` instead of this
`transactions = transactions[1:]` which would actually get rid of the transactions. This is causing us to keep looping since we fail the same check multiple times #5239