### PR TITLE
fix: relax deposit contract prune to first deposit

### DIFF
--- a/ethdb/prune/storage_mode.go
+++ b/ethdb/prune/storage_mode.go
@@ -24,9 +24,9 @@ var DefaultMode = Mode{
 }
 
 var (
-	mainnetDepositContractBlock uint64 = 11052984
+	mainnetDepositContractBlock uint64 = 11185311
 	sepoliaDepositContractBlock uint64 = 1273020
-	goerliDepositContractBlock  uint64 = 4367322
+	goerliDepositContractBlock  uint64 = 4422009
 )
 
 type Experiments struct {


### PR DESCRIPTION
change the minimum required blocks to the blocks where the first deposit has occured.

<img width="421" alt="Screen Shot 2022-09-06 at 19 47 15" src="https://user-images.githubusercontent.com/4562643/188683321-0d60250c-9621-40bb-9963-963aef497e10.png">

<img width="546" alt="Screen Shot 2022-09-06 at 20 05 34" src="https://user-images.githubusercontent.com/4562643/188683413-081c4396-c15a-4dd3-a439-e24863565fe8.png">

see also #5026