### PR TITLE
Fix compatibility of eth_getBlockTransactionCountByHash

### DIFF
--- a/cmd/rpcdaemon/commands/eth_block.go
+++ b/cmd/rpcdaemon/commands/eth_block.go
@@ -336,7 +336,8 @@ func (api *APIImpl) GetBlockTransactionCountByHash(ctx context.Context, blockHas
 	defer tx.Rollback()
 	blockNum, _, _, err := rpchelper.GetBlockNumber(rpc.BlockNumberOrHash{BlockHash: &blockHash}, tx, nil)
 	if err != nil {
-		return nil, err
+		// (Compatibility) Every other node just return `null` for when the block does not exist.
+		return nil, nil
 	}
 	_, txAmount, err := api._blockReader.Body(ctx, tx, blockHash, blockNum)
 	if err != nil {

--- a/cmd/rpcdaemon/commands/eth_block.go
+++ b/cmd/rpcdaemon/commands/eth_block.go
@@ -337,6 +337,7 @@ func (api *APIImpl) GetBlockTransactionCountByHash(ctx context.Context, blockHas
 	blockNum, _, _, err := rpchelper.GetBlockNumber(rpc.BlockNumberOrHash{BlockHash: &blockHash}, tx, nil)
 	if err != nil {
 		// (Compatibility) Every other node just return `null` for when the block does not exist.
+		log.Debug("eth_getBlockTransactionCountByHash GetBlockNumber failed", "err", err)
 		return nil, nil
 	}
 	_, txAmount, err := api._blockReader.Body(ctx, tx, blockHash, blockNum)


### PR DESCRIPTION
## Request
```
{
	"id": 420,
	"jsonrpc": "2.0",
	"method": "eth_getBlockTransactionCountByHash",
	"params": ["0x00017db1000010f480725ae9e96e8b613017af0de144037899a46118731e57b7"]
}
```

## Response, Erigon (before fix)

```
{
	"jsonrpc": "2.0",
	"id": 420,
	"error": {
		"code": -32000,
		"message": "block 00017db1000010f480725ae9e96e8b613017af0de144037899a46118731e57b7 not found"
	}
}
```

## Response, Public RPC 

```
{
	"jsonrpc": "2.0",
	"id": 420,
	"result": null
}
```

## Response, Erigon (after fix)

```
{
	"jsonrpc": "2.0",
	"id": 420,
	"result": null
}
```