### PR TITLE
chore: goreleaser workflow fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,10 @@
 name: Release
 
+# Uncomment the following to let goreleaser automatically
+# create a GitHub release when a tag is pushed.
+# permissions:
+#   contents: write
+
 on:
   push:
     branches-ignore:
@@ -35,7 +40,7 @@ jobs:
         run: |
             make release
         env:
-          GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.prepare.outputs.tag_name }}
           DOCKER_USERNAME: ${{ secrets.DOCKERHUB }}
           DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ git-submodules:
 	@git submodule update --quiet --init --recursive --force || true
 
 PACKAGE_NAME          := github.com/ledgerwatch/erigon
-GOLANG_CROSS_VERSION  ?= v1.18.1
+GOLANG_CROSS_VERSION  ?= v1.18.5
 
 .PHONY: release-dry-run
 release-dry-run: git-submodules


### PR DESCRIPTION
Use the automatically provided GITHUB_TOKEN secret.

Currently only has the default permissions which should let
it read the tag as needed.

Commented permissions would allow it to also automatically write
a github release, but will see if it works without that for now
for minimimum change.