### PR TITLE
New transactions should prompt mining instead of postponing it

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -746,7 +746,7 @@ func (s *Ethereum) StartMining(ctx context.Context, db kv.RwDB, mining *stagedsy
 			mineEvery.Reset(3 * time.Second)
 			select {
 			case <-s.notifyMiningAboutNewTxs:
-				hasWork = false
+				hasWork = true
 			case <-mineEvery.C:
 				hasWork = true
 			case err := <-errc:


### PR DESCRIPTION
For some reason recent PR #5212 flipped the logic. It looks to me that the change there was accidental. It stands to reason that new transactions should prompt mining instead of delaying it by resetting the timer.

This change fixes Hive test "PrevRandao Opcode Transactions".