### PR TITLE
Revert "fix: relax deposit contract prune to first deposit (#5295)"

### DIFF
--- a/ethdb/prune/storage_mode.go
+++ b/ethdb/prune/storage_mode.go
@@ -24,9 +24,9 @@ var DefaultMode = Mode{
 }
 
 var (
-	mainnetDepositContractBlock uint64 = 11185311
+	mainnetDepositContractBlock uint64 = 11052984
 	sepoliaDepositContractBlock uint64 = 1273020
-	goerliDepositContractBlock  uint64 = 4422009
+	goerliDepositContractBlock  uint64 = 4367322
 )
 
 type Experiments struct {


### PR DESCRIPTION
This reverts commit d8c9b1151d574491baf14e208edabe72c1c65d89.

Reverting PR #5295 since it'd break backward compatibility. For instance, Erigon [v2022.09.01](https://github.com/ledgerwatch/erigon/releases/tag/v2022.09.01), started with `--prune=hrtc`, would've failed to start after upgrade.