### PR TITLE
added a way to get latest executed block post POS

### DIFF
--- a/cmd/rpcdaemon/README.md
+++ b/cmd/rpcdaemon/README.md
@@ -313,7 +313,7 @@ The following table shows the current implementation status of Erigon's RPC daem
 | erigon_forks                               | Yes     | Erigon only                          |
 | erigon_issuance                            | Yes     | Erigon only                          |
 | erigon_GetBlockByTimestamp                 | Yes     | Erigon only                          |
-| erigon_ExecutedBlockNumber                 | Yes     | Erigon only                          |
+| erigon_BlockNumber                         | Yes     | Erigon only                          |
 |                                            |         |                                      |
 | bor_getSnapshot                            | Yes     | Bor only                             |
 | bor_getAuthor                              | Yes     | Bor only                             |

--- a/cmd/rpcdaemon/README.md
+++ b/cmd/rpcdaemon/README.md
@@ -313,6 +313,7 @@ The following table shows the current implementation status of Erigon's RPC daem
 | erigon_forks                               | Yes     | Erigon only                          |
 | erigon_issuance                            | Yes     | Erigon only                          |
 | erigon_GetBlockByTimestamp                 | Yes     | Erigon only                          |
+| erigon_ExecutedBlockNumber                 | Yes     | Erigon only                          |
 |                                            |         |                                      |
 | bor_getSnapshot                            | Yes     | Bor only                             |
 | bor_getAuthor                              | Yes     | Bor only                             |

--- a/cmd/rpcdaemon/commands/erigon_system.go
+++ b/cmd/rpcdaemon/commands/erigon_system.go
@@ -4,7 +4,9 @@ import (
 	"context"
 
 	"github.com/ledgerwatch/erigon/common"
+	"github.com/ledgerwatch/erigon/common/hexutil"
 	"github.com/ledgerwatch/erigon/core/forkid"
+	"github.com/ledgerwatch/erigon/turbo/rpchelper"
 )
 
 // Forks is a data type to record a list of forks passed by this node
@@ -28,4 +30,21 @@ func (api *ErigonImpl) Forks(ctx context.Context) (Forks, error) {
 	forksBlocks := forkid.GatherForks(chainConfig)
 
 	return Forks{genesis.Hash(), forksBlocks}, nil
+}
+
+// Post the merge eth_blockNumber will return latest forkChoiceHead block number
+// erigon_executedBlockNumber will return latest executed block number
+func (api *ErigonImpl) ExecutedBlockNumber(ctx context.Context) (hexutil.Uint64, error) {
+	tx, err := api.db.BeginRo(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+
+	blockNum, err := rpchelper.GetLatestExecutedBlockNumber(tx)
+	if err != nil {
+		return 0, err
+	}
+
+	return hexutil.Uint64(blockNum), nil
 }

--- a/cmd/rpcdaemon/commands/erigon_system.go
+++ b/cmd/rpcdaemon/commands/erigon_system.go
@@ -34,7 +34,7 @@ func (api *ErigonImpl) Forks(ctx context.Context) (Forks, error) {
 }
 
 // Post the merge eth_blockNumber will return latest forkChoiceHead block number
-// erigon_blockNumber will return latest executed block number
+// erigon_blockNumber will return latest executed block number or any block number requested
 func (api *ErigonImpl) BlockNumber(ctx context.Context, rpcBlockNumPtr *rpc.BlockNumber) (hexutil.Uint64, error) {
 	tx, err := api.db.BeginRo(ctx)
 	if err != nil {

--- a/turbo/rpchelper/rpc_block.go
+++ b/turbo/rpchelper/rpc_block.go
@@ -54,3 +54,11 @@ func GetSafeBlockNumber(tx kv.Tx) (uint64, error) {
 	}
 	return 0, UnknownBlockError
 }
+
+func GetLatestExecutedBlockNumber(tx kv.Tx) (uint64, error) {
+	blockNum, err := stages.GetStageProgress(tx, stages.Execution)
+	if err != nil {
+		return 0, err
+	}
+	return blockNum, err
+}


### PR DESCRIPTION
After "the merge" latest will turn into the latest ForkchoiceHead block number, while some people might still want to get the latest executed block number from Erigon. That won't be possible since `eth_blockNumber` will not return the latest executed so I have added `erigon_executedBlockNumber` which returns the latest executed block number.