### PR TITLE
bor/consensus: Only write Snapshots to DB for checkpoints

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -554,11 +554,14 @@ func (c *Bor) snapshot(chain consensus.ChainHeaderReader, number uint64, hash co
 				return nil, err
 			}
 			c.recents.Add(snap.Hash, snap)
-			// We've generated a new checkpoint snapshot, save to disk
-			if err = snap.store(c.DB); err != nil {
-				return nil, err
+
+			if snap.Number%checkpointInterval == 0 {
+				// We've generated a new checkpoint snapshot, save to disk
+				if err = snap.store(c.DB); err != nil {
+					return nil, err
+				}
+				log.Trace("Stored snapshot to disk", "number", snap.Number, "hash", snap.Hash)
 			}
-			log.Trace("Stored snapshot to disk", "number", snap.Number, "hash", snap.Hash)
 		}
 		if cont {
 			snap = nil


### PR DESCRIPTION
I tried to debug an Erigon node syncing on Polygon/Bor, with a very slow `Inserting headers` stage. After digging a bit, it seems that it took an increasingly high duration to get a `snapshot` at a each new block for Bor's consensus. Most of the time came from writing it in DB, although it seems to be only ever read for block numbers corresponding to checkpoints.

The solution is thus to limit the writes only on those blocks.

It drastically improved by sync perfs:
![image](https://user-images.githubusercontent.com/2864519/190320306-19f0d660-8834-4f69-b4c0-9d97645a4cb9.png)

The left "flat" line is when syncing on latest release, and the right one is with my fix 