### PR TITLE
Disable PoW sync for mainnet

### DIFF
--- a/params/chainspecs/mainnet.json
+++ b/params/chainspecs/mainnet.json
@@ -18,5 +18,6 @@
   "arrowGlacierBlock": 13773000,
   "grayGlacierBlock": 15050000,
   "terminalTotalDifficulty": 58750000000000000000000,
+  "terminalTotalDifficultyPassed": true,
   "ethash": {}
 }


### PR DESCRIPTION
Similar to geth release [1.10.25](https://github.com/ethereum/go-ethereum/releases/tag/v1.10.25).