### PR TITLE
Ensure system contracts created by upgrades get persisted correctly

### DIFF
--- a/core/systemcontracts/upgrade.go
+++ b/core/systemcontracts/upgrade.go
@@ -464,6 +464,13 @@ func applySystemContractUpgrade(upgrade *Upgrade, blockNumber *big.Int, statedb 
 		if err != nil {
 			panic(fmt.Errorf("failed to decode new contract code: %s", err.Error()))
 		}
+
+		prevContractCode := statedb.GetCode(cfg.ContractAddr)
+		if len(prevContractCode) == 0 && len(newContractCode) > 0 {
+			// system contracts defined after genesis need to be explicitly created
+			statedb.CreateAccount(cfg.ContractAddr, true)
+		}
+
 		statedb.SetCode(cfg.ContractAddr, newContractCode)
 
 		if cfg.AfterUpgrade != nil {


### PR DESCRIPTION
Fixes #5418.

The system-contract upgrade logic ported from upstream BSC worked for BSC, but was subtly flawed when used under Erigon. This caused sync to stall at block `22885040` on Chapel, the first time the upgraded contract was called. This PR corrects the problem.

Details:

The upgrade logic ported from BSC does not presume that the contract already exists; instead, it assumes that setting the contract's code will work for both existent and non-existent accounts. This assumption works in upstream geth, but in Erigon, contracts don't exist until `CreateAccount` is called on them (which wasn't happening here.)

Gibbs was the first upgrade that tried to "upgrade a contract into existence" by setting its code; previous upgrades were only updating system contracts that had existed since genesis (which worked, because the genesis code _does_ call `CreateAccount`, or the lower-level `SetIncarnation`.)