### PR TITLE
Don't check TerminalBlockHash in exchangeTransitionConfiguration

### DIFF
--- a/cmd/rpcdaemon/commands/engine_api.go
+++ b/cmd/rpcdaemon/commands/engine_api.go
@@ -266,14 +266,6 @@ func (e *EngineImpl) ExchangeTransitionConfigurationV1(ctx context.Context, beac
 		return TransitionConfiguration{}, fmt.Errorf("the execution layer has a wrong terminal total difficulty. expected %v, but instead got: %d", beaconConfig.TerminalTotalDifficulty, terminalTotalDifficulty)
 	}
 
-	if beaconConfig.TerminalBlockHash != (common.Hash{}) {
-		return TransitionConfiguration{}, fmt.Errorf("the consensus layer has a non-stub terminal block hash: %x", beaconConfig.TerminalBlockHash)
-	}
-
-	if common.Big0.Cmp((*big.Int)(beaconConfig.TerminalBlockNumber)) != 0 {
-		return TransitionConfiguration{}, fmt.Errorf("the consensus layer has a non-stub terminal block number: %s", beaconConfig.TerminalBlockNumber)
-	}
-
 	return TransitionConfiguration{
 		TerminalTotalDifficulty: (*hexutil.Big)(terminalTotalDifficulty),
 		TerminalBlockHash:       common.Hash{},

--- a/cmd/rpcdaemon22/commands/engine_api.go
+++ b/cmd/rpcdaemon22/commands/engine_api.go
@@ -272,14 +272,6 @@ func (e *EngineImpl) ExchangeTransitionConfigurationV1(ctx context.Context, beac
 		return TransitionConfiguration{}, fmt.Errorf("the execution layer has a wrong terminal total difficulty. expected %v, but instead got: %d", beaconConfig.TerminalTotalDifficulty, terminalTotalDifficulty)
 	}
 
-	if beaconConfig.TerminalBlockHash != (common.Hash{}) {
-		return TransitionConfiguration{}, fmt.Errorf("the consensus layer has a non-stub terminal block hash: %x", beaconConfig.TerminalBlockHash)
-	}
-
-	if common.Big0.Cmp((*big.Int)(beaconConfig.TerminalBlockNumber)) != 0 {
-		return TransitionConfiguration{}, fmt.Errorf("the consensus layer has a non-stub terminal block number: %s", beaconConfig.TerminalBlockNumber)
-	}
-
 	return TransitionConfiguration{
 		TerminalTotalDifficulty: (*hexutil.Big)(terminalTotalDifficulty),
 		TerminalBlockHash:       common.Hash{},


### PR DESCRIPTION
Nimbus incorrectly sends non-zero TerminalBlockHash after The Merge, leading to
"the execution layer has a wrong terminal block hash. expected 0x55b11b918355b1ef9c5db810302ebad0bf2544255b530cdce90674d5887bb286, but instead got: 0x0000000000000000000000000000000000000000000000000000000000000000\"}"