### PR TITLE
open `erigon_blockNumber` API

### DIFF
--- a/cmd/rpcdaemon/commands/erigon_api.go
+++ b/cmd/rpcdaemon/commands/erigon_api.go
@@ -18,6 +18,7 @@ import (
 type ErigonAPI interface {
 	// System related (see ./erigon_system.go)
 	Forks(ctx context.Context) (Forks, error)
+	BlockNumber(ctx context.Context, rpcBlockNumPtr *rpc.BlockNumber) (hexutil.Uint64, error)
 
 	// Blocks related (see ./erigon_blocks.go)
 	GetHeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error)


### PR DESCRIPTION
open `erigon_blockNumber`  feature API that has been implemented. Support request with params options like`safe`/`latest`/`finalized`/`earliest`/`pending`.