### PR TITLE
Add a `TransactionIndex` for StateSync receipt in Bor

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -444,8 +444,9 @@ func ExecuteBlockEphemerallyBor(
 			types.DeriveFieldsForBorLogs(stateSyncLogs, block.Hash(), block.NumberU64(), uint(len(receipts)), uint(len(logs)))
 
 			stateSyncReceipt = &types.ReceiptForStorage{
-				Status: types.ReceiptStatusSuccessful, // make receipt status successful
-				Logs:   stateSyncLogs,
+				Status:           types.ReceiptStatusSuccessful, // make receipt status successful
+				Logs:             stateSyncLogs,
+				TransactionIndex: uint(len(includedTxs)),
 			}
 		}
 	}


### PR DESCRIPTION
Still trying to sync Erigon with Polygon mainnet ; this time I found an issue when trying to save state-sync "receipts". The issue was that the TransactionIndex of the receipt wasn't set, although it was used in `WriteBorReceipt` https://github.com/ledgerwatch/erigon/blob/390108f352dffa3e0ff10c8997bd23631c3a80dd/core/rawdb/bor_receipts.go#L88 ; which might be overwriting other receipts, or cause any other issues.

BTW, in `WriteBorReceipt` linked above, it seems that receipts are `cbor` encoded, although they are decoded with an RLP decoder. Is there any issue there?