### PR TITLE
feat(hive): update exclusions after timeouts fix

### DIFF
--- a/hive/exclusions.json
+++ b/hive/exclusions.json
@@ -3,7 +3,34 @@
     {
       "name": "engine-api",
       "testCases": [
-        "Sidechain Reorg"
+        "Sidechain Reorg",
+        "Inconsistent Head in ForkchoiceState",
+        "Invalid Ancestor Chain Re-Org, Invalid StateRoot, Invalid P9'",
+        "Invalid Ancestor Chain Sync, Invalid StateRoot, Invalid P9'",
+        "Invalid Ancestor Chain Re-Org, Invalid StateRoot, Empty Txs, Invalid P9', Reveal using sync",
+        "Invalid Ancestor Chain Sync, Invalid StateRoot, Empty Txs, Invalid P9'",
+        "Invalid Ancestor Chain Re-Org, Invalid ReceiptsRoot, Invalid P8', Reveal using sync",
+        "Invalid Ancestor Chain Sync, Invalid ReceiptsRoot, Invalid P8'",
+        "Invalid Ancestor Chain Re-Org, Invalid GasLimit, Invalid P9', Reveal using sync",
+        "Invalid Ancestor Chain Sync, Invalid GasLimit, Invalid P9'",
+        "Invalid Ancestor Chain Re-Org, Invalid GasUsed, Invalid P9', Reveal using sync",
+        "Invalid Ancestor Chain Sync, Invalid GasUsed, Invalid P9'",
+        "Invalid Ancestor Chain Re-Org, Invalid Timestamp, Invalid P9', Reveal using sync",
+        "Invalid Ancestor Chain Sync, Invalid Timestamp, Invalid P9'",
+        "Invalid Ancestor Chain Re-Org, Incomplete Transactions, Invalid P9', Reveal using sync",
+        "Invalid Ancestor Chain Sync, Incomplete Transactions, Invalid P9'",
+        "Invalid Ancestor Chain Re-Org, Invalid Transaction Signature, Invalid P9', Reveal using sync",
+        "Invalid Ancestor Chain Sync, Invalid Transaction Signature, Invalid P9'",
+        "Invalid Ancestor Chain Re-Org, Invalid Transaction Nonce, Invalid P9', Reveal using sync",
+        "Invalid Ancestor Chain Sync, Invalid Transaction Nonce, Invalid P9'",
+        "Invalid Ancestor Chain Re-Org, Invalid Transaction Gas, Invalid P9', Reveal using sync",
+        "Invalid Ancestor Chain Sync, Invalid Transaction Gas, Invalid P9'",
+        "Invalid Ancestor Chain Re-Org, Invalid Transaction GasPrice, Invalid P9', Reveal using sync",
+        "Invalid Ancestor Chain Sync, Invalid Transaction GasPrice, Invalid P9'",
+        "Invalid Ancestor Chain Re-Org, Invalid Transaction Value, Invalid P9', Reveal using sync",
+        "Invalid Ancestor Chain Sync, Invalid Transaction Value, Invalid P9'",
+        "Invalid Ancestor Chain Re-Org, Invalid Ommers, Invalid P9', Reveal using sync",
+        "Invalid Ancestor Chain Sync, Invalid Ommers, Invalid P9'"
       ]
     },
     {
@@ -15,7 +42,8 @@
         "Syncing on an Invalid Terminal Execution - Sealed Nonce",
         "Syncing on an Invalid Terminal Execution - Balance Mismatch",
         "Stop processing gossiped Post-TTD PoW blocks",
-        "Terminal blocks are gossiped (Common Ancestor Depth 5"
+        "Terminal blocks are gossiped (Common Ancestor Depth 5",
+        "Long PoW Chain Sync"
       ]
     }
   ]


### PR DESCRIPTION
The exclusions are the tests failing due to reasons other than timeout (which is now fixed in the hive branch in my fork which is used to build thorax/hive)