### PR TITLE
Revert "apply --db.read.concurrency flag value when open embedded db "

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -384,7 +384,7 @@ var (
 	DBReadConcurrencyFlag = cli.IntFlag{
 		Name:  "db.read.concurrency",
 		Usage: "Does limit amount of parallel db reads. Default: equal to GOMAXPROCS (or number of CPU)",
-		Value: cmp.Max(10, runtime.GOMAXPROCS(-1)*4),
+		Value: cmp.Max(10, runtime.GOMAXPROCS(-1)*2),
 	}
 	RpcAccessListFlag = cli.StringFlag{
 		Name:  "rpc.accessList",

--- a/node/node.go
+++ b/node/node.go
@@ -30,7 +30,6 @@ import (
 	"github.com/c2h5oh/datasize"
 	"github.com/ledgerwatch/erigon/node/nodecfg"
 	"github.com/ledgerwatch/erigon/params"
-	"golang.org/x/sync/semaphore"
 
 	"github.com/gofrs/flock"
 	"github.com/ledgerwatch/erigon-lib/kv"
@@ -320,8 +319,7 @@ func OpenDatabase(config *nodecfg.Config, logger log.Logger, label kv.Label) (kv
 	var openFunc func(exclusive bool) (kv.RwDB, error)
 	log.Info("Opening Database", "label", name, "path", dbPath)
 	openFunc = func(exclusive bool) (kv.RwDB, error) {
-		roTxsLimiter := semaphore.NewWeighted(int64(config.Http.DBReadConcurrency)) // 1 less than max to allow unlocking to happen
-		opts := mdbx.NewMDBX(logger).Path(dbPath).Label(label).DBVerbosity(config.DatabaseVerbosity).RoTxsLimiter(roTxsLimiter)
+		opts := mdbx.NewMDBX(logger).Path(dbPath).Label(label).DBVerbosity(config.DatabaseVerbosity)
 		if exclusive {
 			opts = opts.Exclusive()
 		}


### PR DESCRIPTION
Reverts ledgerwatch/erigon#5540