### PR TITLE
run traceCall on top of state resulting from fully executed baseblock…

### DIFF
--- a/cmd/rpcdaemon/commands/tracing.go
+++ b/cmd/rpcdaemon/commands/tracing.go
@@ -216,7 +216,7 @@ func (api *PrivateDebugAPIImpl) TraceCall(ctx context.Context, args ethapi.CallA
 		}
 		stateReader = state.NewCachedReader2(cacheView, dbtx)
 	} else {
-		stateReader = state.NewPlainState(dbtx, blockNumber)
+		stateReader = state.NewPlainState(dbtx, blockNumber+1)
 	}
 	header := rawdb.ReadHeader(dbtx, hash, blockNumber)
 	if header == nil {


### PR DESCRIPTION
… a.k.a. starting state of blockNumber+1

This PR is needed to make behavior of debug_traceCall match eth_call, trace_call and geth's debug_traceCall.

Discussion in discord: https://discord.com/channels/687972960811745322/687972960811745326/1024415001966018561