### PR TITLE
Demote "stage loop is busy" to debug

### DIFF
--- a/ethdb/privateapi/ethbackend.go
+++ b/ethdb/privateapi/ethbackend.go
@@ -485,7 +485,7 @@ func (s *EthBackendServer) getQuickPayloadStatusIfPossible(blockHash common.Hash
 
 	// If another payload is already commissioned then we just reply with syncing
 	if s.stageLoopIsBusy() {
-		log.Info(fmt.Sprintf("[%s] stage loop is busy", prefix))
+		log.Debug(fmt.Sprintf("[%s] stage loop is busy", prefix))
 		return &engineapi.PayloadStatus{Status: remote.EngineStatus_SYNCING}, nil
 	}
 


### PR DESCRIPTION
Otherwise the logs are spammed by "stage loop is busy" when Erigon is catching up with the chain tip.