### PR TITLE
warning of missing block and returning nil if no err

### DIFF
--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -227,10 +227,16 @@ func (gpo *Oracle) getBlockPrices(ctx context.Context, blockNum uint64, limit in
 		return err
 	}
 	block, err := gpo.backend.BlockByNumber(ctx, rpc.BlockNumber(blockNum))
-	if block == nil {
+	if err != nil {
 		log.Error("gasprice.go: getBlockPrices", "err", err)
 		return err
 	}
+
+	if block == nil {
+		log.Warn("gasprice.go: getBlockPrices found no block", "blockNum", blockNum)
+		return nil
+	}
+
 	blockTxs := block.Transactions()
 	plainTxs := make([]types.Transaction, len(blockTxs))
 	copy(plainTxs, blockTxs)

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -233,7 +233,6 @@ func (gpo *Oracle) getBlockPrices(ctx context.Context, blockNum uint64, limit in
 	}
 
 	if block == nil {
-		log.Warn("gasprice.go: getBlockPrices found no block", "blockNum", blockNum)
 		return nil
 	}
 


### PR DESCRIPTION
If we don't find the block we are returning an error message and the err (which is nil) instead of returning nil
#5543