### PR TITLE
erigon3: move tx.AsMessage() out of critical path

### DIFF
--- a/cmd/state/exec3/state.go
+++ b/cmd/state/exec3/state.go
@@ -136,20 +136,20 @@ func (rw *Worker22) RunTxTask(txTask *state.TxTask) {
 		// Block initialisation
 		//fmt.Printf("txNum=%d, blockNum=%d, initialisation of the block\n", txTask.TxNum, txTask.BlockNum)
 		if rw.isPoSA {
-			systemcontracts.UpgradeBuildInSystemContract(rw.chainConfig, txTask.Header.Number, ibs)
+			systemcontracts.UpgradeBuildInSystemContract(rw.chainConfig, txTask.Block.Number(), ibs)
 		}
 		syscall := func(contract common.Address, data []byte) ([]byte, error) {
-			return core.SysCallContract(contract, data, *rw.chainConfig, ibs, txTask.Header, rw.engine)
+			return core.SysCallContract(contract, data, *rw.chainConfig, ibs, txTask.Block.Header(), rw.engine)
 		}
-		rw.engine.Initialize(rw.chainConfig, rw.chain, rw.epoch, txTask.Header, txTask.Block.Transactions(), txTask.Block.Uncles(), syscall)
+		rw.engine.Initialize(rw.chainConfig, rw.chain, rw.epoch, txTask.Block.Header(), txTask.Block.Transactions(), txTask.Block.Uncles(), syscall)
 	} else if txTask.Final {
 		if txTask.BlockNum > 0 {
 			//fmt.Printf("txNum=%d, blockNum=%d, finalisation of the block\n", txTask.TxNum, txTask.BlockNum)
 			// End of block transaction in a block
 			syscall := func(contract common.Address, data []byte) ([]byte, error) {
-				return core.SysCallContract(contract, data, *rw.chainConfig, ibs, txTask.Header, rw.engine)
+				return core.SysCallContract(contract, data, *rw.chainConfig, ibs, txTask.Block.Header(), rw.engine)
 			}
-			if _, _, err := rw.engine.Finalize(rw.chainConfig, txTask.Header, ibs, txTask.Block.Transactions(), txTask.Block.Uncles(), nil /* receipts */, rw.epoch, rw.chain, syscall); err != nil {
+			if _, _, err := rw.engine.Finalize(rw.chainConfig, txTask.Block.Header(), ibs, txTask.Block.Transactions(), txTask.Block.Uncles(), nil /* receipts */, rw.epoch, rw.chain, syscall); err != nil {
 				//fmt.Printf("error=%v\n", err)
 				txTask.Error = err
 			} else {
@@ -163,7 +163,7 @@ func (rw *Worker22) RunTxTask(txTask *state.TxTask) {
 	} else {
 		//fmt.Printf("txNum=%d, blockNum=%d, txIndex=%d\n", txTask.TxNum, txTask.BlockNum, txTask.TxIndex)
 		if rw.isPoSA {
-			if isSystemTx, err := rw.posa.IsSystemTransaction(txTask.Tx, txTask.Header); err != nil {
+			if isSystemTx, err := rw.posa.IsSystemTransaction(txTask.Tx, txTask.Block.Header()); err != nil {
 				panic(err)
 			} else if isSystemTx {
 				//fmt.Printf("System tx\n")
@@ -175,12 +175,9 @@ func (rw *Worker22) RunTxTask(txTask *state.TxTask) {
 		ct := NewCallTracer()
 		vmConfig := vm.Config{Debug: true, Tracer: ct, SkipAnalysis: core.SkipAnalysis(rw.chainConfig, txTask.BlockNum)}
 		ibs.Prepare(txHash, txTask.BlockHash, txTask.TxIndex)
-		getHashFn := core.GetHashFn(txTask.Header, rw.getHeader)
-		blockContext := core.NewEVMBlockContext(txTask.Header, getHashFn, rw.engine, nil /* author */)
-		msg, err := txTask.Tx.AsMessage(*types.MakeSigner(rw.chainConfig, txTask.BlockNum), txTask.Header.BaseFee, txTask.Rules)
-		if err != nil {
-			panic(err)
-		}
+		getHashFn := core.GetHashFn(txTask.Block.Header(), rw.getHeader)
+		blockContext := core.NewEVMBlockContext(txTask.Block.Header(), getHashFn, rw.engine, nil /* author */)
+		msg := txTask.TxAsMessage
 		txContext := core.NewEVMTxContext(msg)
 		vmenv := vm.NewEVM(blockContext, txContext, ibs, rw.chainConfig, vmConfig)
 		if _, err = core.ApplyMessage(vmenv, msg, gp, true /* refunds */, false /* gasBailout */); err != nil {

--- a/core/state/rw22.go
+++ b/core/state/rw22.go
@@ -31,13 +31,13 @@ type TxTask struct {
 	TxNum              uint64
 	BlockNum           uint64
 	Rules              *params.Rules
-	Header             *types.Header
 	Block              *types.Block
 	BlockHash          common.Hash
 	Sender             *common.Address
 	TxIndex            int // -1 for block initialisation
 	Final              bool
 	Tx                 types.Transaction
+	TxAsMessage        types.Message
 	BalanceIncreaseSet map[common.Address]uint256.Int
 	ReadLists          map[string]*KvList
 	WriteLists         map[string]*KvList

--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -22,7 +22,6 @@ import (
 	kv2 "github.com/ledgerwatch/erigon-lib/kv/mdbx"
 	state2 "github.com/ledgerwatch/erigon-lib/state"
 	"github.com/ledgerwatch/erigon/cmd/state/exec3"
-	common2 "github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/consensus"
 	"github.com/ledgerwatch/erigon/core"
 	"github.com/ledgerwatch/erigon/core/rawdb"
@@ -266,27 +265,16 @@ func Exec3(ctx context.Context,
 		}()
 	}
 
-	var blockHash common2.Hash
 	var b *types.Block
 	var blockNum uint64
 loop:
 	for blockNum = block; blockNum <= maxBlockNum; blockNum++ {
 		atomic.StoreUint64(&inputBlockNum, blockNum)
 		rules := chainConfig.Rules(blockNum)
-		if err = chainDb.View(ctx, func(tx kv.Tx) error {
-			blockHash, err = rawdb.ReadCanonicalHash(tx, blockNum)
-			if err != nil {
-				return err
-			}
-			b, _, err = blockReader.BlockWithSenders(ctx, tx, blockHash, blockNum)
-			if err != nil {
-				return err
-			}
-			return nil
-		}); err != nil {
+		b, err = blockWithSenders(chainDb, applyTx, blockReader, blockNum)
+		if err != nil {
 			return err
 		}
-
 		txs := b.Transactions()
 		for txIndex := -1; txIndex <= len(txs); txIndex++ {
 			// Do not oversend, wait for the result heap to go under certain size
@@ -305,7 +293,7 @@ loop:
 				Block:     b,
 				TxNum:     inputTxNum,
 				TxIndex:   txIndex,
-				BlockHash: blockHash,
+				BlockHash: b.Hash(),
 				Final:     txIndex == len(txs),
 			}
 			if txIndex >= 0 && txIndex < len(txs) {
@@ -413,6 +401,24 @@ loop:
 		}
 	}
 	return nil
+}
+func blockWithSenders(db kv.RoDB, tx kv.Tx, blockReader services.BlockReader, blockNum uint64) (b *types.Block, err error) {
+	if tx == nil {
+		tx, err = db.BeginRo(context.Background())
+		if err != nil {
+			return nil, err
+		}
+		defer tx.Rollback()
+	}
+	blockHash, err := rawdb.ReadCanonicalHash(tx, blockNum)
+	if err != nil {
+		return nil, err
+	}
+	b, _, err = blockReader.BlockWithSenders(context.Background(), tx, blockHash, blockNum)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 func processResultQueue(rws *state.TxTaskQueue, outputTxNum *uint64, rs *state.State22, agg *state2.Aggregator22, applyTx kv.Tx,
@@ -743,26 +749,14 @@ func ReconstituteState(ctx context.Context, s *StageState, dirs datadir.Dirs, wo
 		}
 	}()
 	var inputTxNum uint64
-	var blockHash common2.Hash
 	var b *types.Block
 	var txKey [8]byte
 	for bn := uint64(0); bn <= blockNum; bn++ {
 		rules := chainConfig.Rules(bn)
-		if err := chainDb.View(ctx, func(tx kv.Tx) error {
-			blockHash, err = rawdb.ReadCanonicalHash(tx, bn)
-			if err != nil {
-				return err
-			}
-			b, _, err = blockReader.BlockWithSenders(ctx, tx, blockHash, bn)
-			if err != nil {
-				return err
-			}
-
-			return nil
-		}); err != nil {
+		b, err = blockWithSenders(chainDb, nil, blockReader, blockNum)
+		if err != nil {
 			return err
 		}
-
 		txs := b.Transactions()
 		for txIndex := -1; txIndex <= len(txs); txIndex++ {
 			if bitmap.Contains(inputTxNum) {
@@ -773,7 +767,7 @@ func ReconstituteState(ctx context.Context, s *StageState, dirs datadir.Dirs, wo
 					Rules:     rules,
 					TxNum:     inputTxNum,
 					TxIndex:   txIndex,
-					BlockHash: blockHash,
+					BlockHash: b.Hash(),
 					Final:     txIndex == len(txs),
 				}
 				if txIndex >= 0 && txIndex < len(txs) {

--- a/eth/stagedsync/stage_execute_test.go
+++ b/eth/stagedsync/stage_execute_test.go
@@ -132,7 +132,6 @@ func apply(tx kv.RwTx, agg *libstate.Aggregator22) (beforeBlock, afterBlock test
 			stateWriter.ResetWriteSet()
 		}, func(n, from, numberOfBlocks uint64) {
 			txTask := &state.TxTask{
-				Header:     nil,
 				BlockNum:   n,
 				Rules:      params.TestRules,
 				Block:      nil,


### PR DESCRIPTION
i see that producer of `workCh` does produce faster than consumers consume. it means we can move some work from consumers to producer

and also remove txTask.Header field because have txTask.Block