### PR TITLE
fixed disconnecting and now nimbus happy with us

### DIFF
--- a/cmd/lightclient/sentinel/handlers/heartbeats.go
+++ b/cmd/lightclient/sentinel/handlers/heartbeats.go
@@ -39,6 +39,7 @@ func (c *ConsensusHandlers) metadataHandlerV1(ctx *communication.StreamContext, 
 	return nil
 }
 
+// TODO: Actually respond with proper status
 func statusHandler(ctx *communication.StreamContext, dat *p2p.Status) error {
 	log.Debug("[ReqResp] Status",
 		"epoch", dat.FinalizedEpoch,

--- a/cmd/lightclient/sentinel/handlers/heartbeats.go
+++ b/cmd/lightclient/sentinel/handlers/heartbeats.go
@@ -31,12 +31,8 @@ func pingHandler(ctx *communication.StreamContext, dat *p2p.Ping) error {
 }
 
 func (c *ConsensusHandlers) metadataHandlerV1(ctx *communication.StreamContext, dat *communication.EmptyPacket) error {
-	_, err := ctx.Codec.WritePacket(c.metadataV1)
+	_, err := ctx.Codec.WritePacket(c.metadataV1, SuccessfullResponsePrefix)
 	if err != nil {
-		return err
-	}
-
-	if err := ctx.Codec.CloseWriter(); err != nil {
 		return err
 	}
 
@@ -51,5 +47,9 @@ func statusHandler(ctx *communication.StreamContext, dat *p2p.Status) error {
 		"head slot", dat.HeadSlot,
 		"fork digest", utils.BytesToHex(dat.ForkDigest),
 	)
+	_, err := ctx.Codec.WritePacket(dat, SuccessfullResponsePrefix)
+	if err != nil {
+		return err
+	}
 	return nil
 }

--- a/cmd/lightclient/sentinel/sentinel.go
+++ b/cmd/lightclient/sentinel/sentinel.go
@@ -120,6 +120,7 @@ func (s *Sentinel) createListener() (*discover.UDPv5, error) {
 		return nil, err
 	}
 
+	// TODO: Set up proper attestation number
 	s.metadataV1 = &lightrpc.MetadataV1{
 		SeqNumber: localNode.Seq(),
 		Attnets:   0,


### PR DESCRIPTION
Added no disconnecting with metadata requests, and we answer now with a bogus status call and proper prefix for both status and metadata request. This changes allows for nimbus nodes to connect to us and actually stay connected.