### PR TITLE
feat: add base kubernetes manifests

### DIFF
--- a/k8s/base/eth66-peering-tcp.yaml
+++ b/k8s/base/eth66-peering-tcp.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: erigon
+  name: eth66-peering-tcp
+spec:
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: eth66-pr-tcp
+    port: 30303
+    protocol: TCP
+    targetPort: 30303
+  selector:
+    app: erigon
+  type: LoadBalancer

--- a/k8s/base/eth66-peering-udp.yaml
+++ b/k8s/base/eth66-peering-udp.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: erigon
+  name: eth66-peering-udp
+spec:
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: eth66-pr-udp
+    port: 30303
+    protocol: UDP
+    targetPort: 30303
+  selector:
+    app: erigon
+  type: LoadBalancer

--- a/k8s/base/http.yaml
+++ b/k8s/base/http.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: erigon
+  name: http
+spec:
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    port: 8545
+    protocol: TCP
+    targetPort: 8545
+  selector:
+    app: erigon
+  type: LoadBalancer

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,0 +1,8 @@
+resources:
+- eth66-peering-tcp.yaml
+- eth66-peering-udp.yaml
+- http.yaml
+- metrics.yaml
+- snap-sync-tcp.yaml
+- snap-sync-udp.yaml
+- statefulset.yaml

--- a/k8s/base/metrics.yaml
+++ b/k8s/base/metrics.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: erigon
+  name: metrics
+spec:
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: metrics
+    port: 6060
+    protocol: TCP
+    targetPort: 6060
+  selector:
+    app: erigon

--- a/k8s/base/snap-sync-tcp.yaml
+++ b/k8s/base/snap-sync-tcp.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: erigon
+  name: snap-sync-tcp
+spec:
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: snap-sync-tcp
+    port: 42069
+    protocol: TCP
+    targetPort: 42069
+  selector:
+    app: erigon
+  type: LoadBalancer

--- a/k8s/base/snap-sync-udp.yaml
+++ b/k8s/base/snap-sync-udp.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: erigon
+  name: snap-sync-udp
+spec:
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: snap-sync-udp
+    port: 42069
+    protocol: UDP
+    targetPort: 42069
+  selector:
+    app: erigon
+  type: LoadBalancer

--- a/k8s/base/statefulset.yaml
+++ b/k8s/base/statefulset.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app: erigon
+  name: erigon
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: erigon
+  serviceName: erigon
+  template:
+    metadata:
+      labels:
+        app: erigon
+    spec:
+      containers:
+      - args:
+        - '--authrpc.vhosts=*'
+        - '--datadir=/home/erigon/.local/share/erigon'
+        - '--healthcheck'
+        - '--log.json'
+        - '--metrics'
+        - '--metrics.addr=0.0.0.0'
+        - '--metrics.port=6060'
+        - '--nat=none'
+        - '--private.api.ratelimit=50000'
+        - '--private.api.addr=0.0.0.0:9090'
+        - '--torrent.download.rate=3000mb'
+        - '--torrent.download.slots=200'
+        - '--verbosity=3'
+        - —-batchSize=8000M
+        command:
+        - erigon
+        image: erigon-image
+        livenessProbe:
+          initialDelaySeconds: 1800
+          periodSeconds: 20
+          tcpSocket:
+            port: 9090
+        name: erigon
+        ports:
+        - containerPort: 9090
+          name: private-api
+        - containerPort: 8551
+          name: engine
+        - containerPort: 30303
+          name: eth66-pr-tcp
+          protocol: TCP
+        - containerPort: 30303
+          name: eth66-pr-udp
+          protocol: UDP
+        - containerPort: 6060
+          name: metrics
+        - containerPort: 6070
+          name: pprof
+        - containerPort: 42069
+          name: snap-sync-tcp
+          protocol: TCP
+        - containerPort: 42069
+          name: snap-sync-udp
+          protocol: UDP
+        readinessProbe:
+          initialDelaySeconds: 1800
+          periodSeconds: 20
+          tcpSocket:
+            port: 9090
+        resources:
+          requests:
+            cpu: 2462m
+            memory: 16Gi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsGroup: 1000
+          runAsUser: 1000
+        volumeMounts: []
+      initContainers: []
+      volumes: []
+  volumeClaimTemplates: []


### PR DESCRIPTION
Adds bare minimum, base kubernetes manifests for running erigon in kubernetes.

Does not include crucial beacon chain, persistent volumes, etc.

I currently use this as a base for 5 erigon Pods, each with an erigon execution node and prysm beacon node, along with 10 rpcdaemon pods, a TLS-terminated Ingress with a cert-manager issued TLS certificate. I would like to give back to the community then use this as an upstream kustomized base.  See: https://kustomize.io