### PR TITLE
No MaxCodeSize limit for AuRa

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -502,7 +502,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 	ret, err = run(evm, contract, nil, false)
 
 	// check whether the max code size has been exceeded
-	maxCodeSizeExceeded := evm.chainRules.IsSpuriousDragon && len(ret) > params.MaxCodeSize
+	maxCodeSizeExceeded := evm.chainRules.IsSpuriousDragon && len(ret) > params.MaxCodeSize && !evm.chainRules.IsAura
 
 	// Reject code starting with 0xEF if EIP-3541 is enabled.
 	if err == nil && !maxCodeSizeExceeded {


### PR DESCRIPTION
[Nethermind/Chains/xdai.json](https://github.com/NethermindEth/nethermind/blob/master/src/Nethermind/Chains/xdai.json) does not contain `maxCodeSize`, so it defaults to 2^63-1 (virtually unlimited).

https://gnosisscan.io/tx/0x3bfa6631d0a3a845c16674f56771de30bc840e828ea8ead21dbea04541a30173 is a transaction example on Gnosis Chain where the code size exceed the mainnet `maxCodeSize` of 24576.