### PR TITLE
Fix go-releaser version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ git-submodules:
 	@git submodule update --quiet --init --recursive --force || true
 
 PACKAGE_NAME          := github.com/ledgerwatch/erigon
-GOLANG_CROSS_VERSION  ?= v1.18.5
+GOLANG_CROSS_VERSION  ?= v1.18.1
 
 .PHONY: release-dry-run
 release-dry-run: git-submodules


### PR DESCRIPTION
Issue : https://github.com/ledgerwatch/erigon/actions/runs/3202785385/jobs/5232131489

Reason : There is no go-releaser version with v1.18.5
https://hub.docker.com/r/goreleaser/goreleaser-cross/tags

Updated it to v1.18.1 which we use in matic-fork/erigon.