### PR TITLE
Use NewValidatorSafeContract in ValidatorContract

### DIFF
--- a/consensus/aura/config.go
+++ b/consensus/aura/config.go
@@ -58,7 +58,7 @@ func newValidatorSetFromJson(j *ValidatorSetJson, posdaoTransition *uint64) Vali
 	if j.Contract != nil {
 		return &ValidatorContract{
 			contractAddress:  *j.Contract,
-			validators:       ValidatorSafeContract{contractAddress: *j.Contract, posdaoTransition: posdaoTransition},
+			validators:       NewValidatorSafeContract(*j.Contract, posdaoTransition, nil),
 			posdaoTransition: posdaoTransition,
 		}
 	}

--- a/consensus/aura/validators.go
+++ b/consensus/aura/validators.go
@@ -860,7 +860,7 @@ func (s *ValidatorSafeContract) onCloseBlock(header *types.Header, ourAddress co
 // ValidatorContract a validator contract with reporting.
 type ValidatorContract struct {
 	contractAddress  common.Address
-	validators       ValidatorSafeContract
+	validators       *ValidatorSafeContract
 	posdaoTransition *uint64
 }
 


### PR DESCRIPTION
This fixes the following panic for Gnosis Chain on the validator switch at block 9186425:
```
panic: method 'getValidators' not found

goroutine 90 [running]:
github.com/ledgerwatch/erigon/consensus/aura.(*ValidatorSafeContract).getListSyscall(0x14000ed9358, 0xd40004bf620)
        github.com/ledgerwatch/erigon/consensus/aura/validators.go:634 +0x258
github.com/ledgerwatch/erigon/consensus/aura.(*ValidatorSafeContract).epochSet(0x16?, 0x20?, 0x8c2c79, {0xd4002d77180, 0x25f, 0x25f}, 0x11400fac7ee8?)
        github.com/ledgerwatch/erigon/consensus/aura/validators.go:453 +0xdc
github.com/ledgerwatch/erigon/consensus/aura.(*ValidatorContract).epochSet(0x140006ae980?, 0x38?, 0x6f9d00000000c28e?, {0xd4002d77180?, 0x108acc108?, 0x40?}, 0x14000618000?)
```