### PR TITLE
revert execution batch size logic to size on disk

### DIFF
--- a/ethdb/olddb/mapmutation.go
+++ b/ethdb/olddb/mapmutation.go
@@ -10,8 +10,9 @@ import (
 
 	"github.com/ledgerwatch/erigon-lib/etl"
 	"github.com/ledgerwatch/erigon-lib/kv"
-	"github.com/ledgerwatch/erigon/ethdb"
 	"github.com/ledgerwatch/log/v3"
+
+	"github.com/ledgerwatch/erigon/ethdb"
 )
 
 type mapmutation struct {
@@ -165,7 +166,7 @@ func (m *mapmutation) Put(table string, k, v []byte) error {
 		m.puts[table] = make(map[string][]byte)
 	}
 
-	stringKey := *(*string)(unsafe.Pointer(&k))
+	stringKey := string(k)
 
 	var ok bool
 	if _, ok = m.puts[table][stringKey]; !ok {
@@ -176,6 +177,7 @@ func (m *mapmutation) Put(table string, k, v []byte) error {
 	m.puts[table][stringKey] = v
 	m.size += len(k) + len(v)
 	m.count++
+
 	return nil
 }
 


### PR DESCRIPTION
Revert to older batch size logic to keep memory usage down during execution phase and closer to the --batchSize flag size.

Spotted a "leak" in key generation as well.  The unsafe pointer keeps the byte slice around for as long as the batch is not committed, takes up a fair chunk of memory surprisingly doing that so removed the unsafe pointer usage giving the GC some chance to clean up along the way.

Moved the batch rollback into a defer func call rather than allowing them to stack in the for loop.  If this isn't going to work just let me know and can change it back.