### PR TITLE
fix deadlock in filters.go

### DIFF
--- a/turbo/rpchelper/filters.go
+++ b/turbo/rpchelper/filters.go
@@ -328,6 +328,7 @@ func (ff *Filters) UnsubscribeHeads(id HeadsSubID) bool {
 				ff.storeMu.Lock()
 				delete(ff.pendingHeadsStores, id)
 				ff.storeMu.Unlock()
+				ff.mu.Unlock()
 				return true
 			}
 		}

--- a/turbo/rpchelper/filters.go
+++ b/turbo/rpchelper/filters.go
@@ -318,7 +318,7 @@ func (ff *Filters) UnsubscribeHeads(id HeadsSubID) bool {
 	if !ok {
 		return false
 	}
-	// Drain the channel to avoid the deadlock in the OnNewTxs function
+	// Drain the channel to avoid the deadlock in the OnNewEvent function
 	// Draining of the channel is safe without a lock because it does not panic
 	// when the channel is closed
 	for {


### PR DESCRIPTION
When the filter is in the onNewTxs function, the subscription function exits and no longer receives information from the msg channel. In this case, the unsubscribe_xxx function is triggered, which will cause filter.mu read and write locks to enter a deadlock state