### PR TITLE
add more sync stages to metrics

### DIFF
--- a/eth/stagedsync/all_stages.go
+++ b/eth/stagedsync/all_stages.go
@@ -9,30 +9,10 @@ import (
 	"github.com/ledgerwatch/erigon/eth/stagedsync/stages"
 )
 
-var syncMetrics = map[stages.SyncStage]*metrics.Counter{
-	stages.Headers:   metrics.GetOrCreateCounter(`sync{stage="headers"}`),
-	stages.Execution: metrics.GetOrCreateCounter(`sync{stage="execution"}`),
-	stages.Finish:    metrics.GetOrCreateCounter(`sync{stage="finish"}`),
-}
+var syncMetrics = map[stages.SyncStage]*metrics.Counter{}
 
 func init() {
-	for _, v := range []stages.SyncStage{
-		stages.Snapshots,
-		stages.CumulativeIndex,
-		stages.BlockHashes,
-		stages.Bodies,
-		stages.Senders,
-		stages.Translation,
-		stages.VerkleTrie,
-		stages.IntermediateHashes,
-		stages.HashState,
-		stages.AccountHistoryIndex,
-		stages.StorageHistoryIndex,
-		stages.LogIndex,
-		stages.CallTraces,
-		stages.TxLookup,
-		stages.Issuance,
-	} {
+	for _, v := range stages.AllStages {
 		syncMetrics[v] = metrics.GetOrCreateCounter(
 			fmt.Sprintf(
 				`sync{stage="%s"}`,

--- a/eth/stagedsync/all_stages.go
+++ b/eth/stagedsync/all_stages.go
@@ -1,7 +1,10 @@
 package stagedsync
 
 import (
+	"fmt"
+
 	"github.com/VictoriaMetrics/metrics"
+	"github.com/huandu/xstrings"
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon/eth/stagedsync/stages"
 )
@@ -10,6 +13,26 @@ var syncMetrics = map[stages.SyncStage]*metrics.Counter{
 	stages.Headers:   metrics.GetOrCreateCounter(`sync{stage="headers"}`),
 	stages.Execution: metrics.GetOrCreateCounter(`sync{stage="execution"}`),
 	stages.Finish:    metrics.GetOrCreateCounter(`sync{stage="finish"}`),
+	// additional
+	stages.Snapshots:           makeSyncMetric(stages.Snapshots),
+	stages.CumulativeIndex:     makeSyncMetric(stages.CumulativeIndex),
+	stages.BlockHashes:         makeSyncMetric(stages.BlockHashes),
+	stages.Bodies:              makeSyncMetric(stages.Bodies),
+	stages.Senders:             makeSyncMetric(stages.Senders),
+	stages.Translation:         makeSyncMetric(stages.Translation),
+	stages.VerkleTrie:          makeSyncMetric(stages.VerkleTrie),
+	stages.IntermediateHashes:  makeSyncMetric(stages.IntermediateHashes),
+	stages.HashState:           makeSyncMetric(stages.HashState),
+	stages.AccountHistoryIndex: makeSyncMetric(stages.AccountHistoryIndex),
+	stages.StorageHistoryIndex: makeSyncMetric(stages.StorageHistoryIndex),
+	stages.LogIndex:            makeSyncMetric(stages.LogIndex),
+	stages.CallTraces:          makeSyncMetric(stages.CallTraces),
+	stages.TxLookup:            makeSyncMetric(stages.TxLookup),
+	stages.Issuance:            makeSyncMetric(stages.Issuance),
+}
+
+func makeSyncMetric(stage stages.SyncStage) *metrics.Counter {
+	return metrics.GetOrCreateCounter(fmt.Sprintf(`sync{stage="%s"}`, xstrings.ToSnakeCase(string(stage))))
 }
 
 // UpdateMetrics - need update metrics manually because current "metrics" package doesn't support labels

--- a/eth/stagedsync/all_stages.go
+++ b/eth/stagedsync/all_stages.go
@@ -13,26 +13,33 @@ var syncMetrics = map[stages.SyncStage]*metrics.Counter{
 	stages.Headers:   metrics.GetOrCreateCounter(`sync{stage="headers"}`),
 	stages.Execution: metrics.GetOrCreateCounter(`sync{stage="execution"}`),
 	stages.Finish:    metrics.GetOrCreateCounter(`sync{stage="finish"}`),
-	// additional
-	stages.Snapshots:           makeSyncMetric(stages.Snapshots),
-	stages.CumulativeIndex:     makeSyncMetric(stages.CumulativeIndex),
-	stages.BlockHashes:         makeSyncMetric(stages.BlockHashes),
-	stages.Bodies:              makeSyncMetric(stages.Bodies),
-	stages.Senders:             makeSyncMetric(stages.Senders),
-	stages.Translation:         makeSyncMetric(stages.Translation),
-	stages.VerkleTrie:          makeSyncMetric(stages.VerkleTrie),
-	stages.IntermediateHashes:  makeSyncMetric(stages.IntermediateHashes),
-	stages.HashState:           makeSyncMetric(stages.HashState),
-	stages.AccountHistoryIndex: makeSyncMetric(stages.AccountHistoryIndex),
-	stages.StorageHistoryIndex: makeSyncMetric(stages.StorageHistoryIndex),
-	stages.LogIndex:            makeSyncMetric(stages.LogIndex),
-	stages.CallTraces:          makeSyncMetric(stages.CallTraces),
-	stages.TxLookup:            makeSyncMetric(stages.TxLookup),
-	stages.Issuance:            makeSyncMetric(stages.Issuance),
 }
 
-func makeSyncMetric(stage stages.SyncStage) *metrics.Counter {
-	return metrics.GetOrCreateCounter(fmt.Sprintf(`sync{stage="%s"}`, xstrings.ToSnakeCase(string(stage))))
+func init() {
+	for _, v := range []stages.SyncStage{
+		stages.Snapshots,
+		stages.CumulativeIndex,
+		stages.BlockHashes,
+		stages.Bodies,
+		stages.Senders,
+		stages.Translation,
+		stages.VerkleTrie,
+		stages.IntermediateHashes,
+		stages.HashState,
+		stages.AccountHistoryIndex,
+		stages.StorageHistoryIndex,
+		stages.LogIndex,
+		stages.CallTraces,
+		stages.TxLookup,
+		stages.Issuance,
+	} {
+		syncMetrics[v] = metrics.GetOrCreateCounter(
+			fmt.Sprintf(
+				`sync{stage="%s"}`,
+				xstrings.ToSnakeCase(string(v)),
+			),
+		)
+	}
 }
 
 // UpdateMetrics - need update metrics manually because current "metrics" package doesn't support labels


### PR DESCRIPTION
hi! 

this pr adds more sync stages to the prometheus metrics. node now shows 

```
sync{stage="account_history_index"} 15742138
sync{stage="block_hashes"} 15742138
sync{stage="bodies"} 15742138
sync{stage="call_traces"} 15742138
sync{stage="cumulative_index"} 15742138
sync{stage="execution"} 15742138
sync{stage="finish"} 15742138
sync{stage="hash_state"} 15742138
sync{stage="headers"} 15742138
sync{stage="intermediate_hashes"} 15742138
sync{stage="log_index"} 15742138
sync{stage="senders"} 15742138
sync{stage="snapshots"} 15742138
sync{stage="storage_history_index"} 15742138
sync{stage="translation"} 0
sync{stage="tx_lookup"} 15742138
sync{stage="verkle_trie"} 0
sync{stage="watch_the_burn"} 0
``` 