### PR TITLE
fix: issue #5723 type conversion bug

### DIFF
--- a/eth/tracers/jsvm.go
+++ b/eth/tracers/jsvm.go
@@ -94,7 +94,10 @@ func (vm *JSVM) GetBuffer(index int) (rawPtr unsafe.Pointer, outSize uint) {
 		return nil, 0
 	}
 
-	buf := expValue.([]byte)
+	buf, ok := expValue.([]byte)
+	if !ok {
+		return nil, 0
+	}
 	if len(buf) == 0 {
 		return unsafe.Pointer(nil), 0
 	}


### PR DESCRIPTION
fix:
fix for issue #5723  type conversion bug by adding check. `expValue` should be `uint64[]`.