### PR TITLE
FinalizeTx after engine.Initialize

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -572,5 +572,7 @@ func InitializeBlockExecution(engine consensus.Engine, chain consensus.ChainHead
 	engine.Initialize(cc, chain, epochReader, header, txs, uncles, func(contract common.Address, data []byte) ([]byte, error) {
 		return SysCallContract(contract, data, *cc, ibs, header, engine)
 	})
+	noop := state.NewNoopWriter()
+	ibs.FinalizeTx(cc.Rules(header.Number.Uint64()), noop)
 	return nil
 }


### PR DESCRIPTION
AuRa storage changes made by `onEpochBegin` should be finalized. Otherwise, `SSTORE` cost might be incorrect in block transactions when [EIP-2200](https://eips.ethereum.org/EIPS/eip-2200) is active. https://gnosisscan.io/tx/0xa6d45d903c977ad237165737ebc4e34fb7756675719d112a199af858bb1275e0 is an example of a transaction on Gnosis Chain whose gas used was previously calculated incorrectly.