### PR TITLE
Return bor receipts correctly in getTransactionReceipt and getBlockReceipts

### DIFF
--- a/cmd/rpcdaemon/commands/eth_receipts.go
+++ b/cmd/rpcdaemon/commands/eth_receipts.go
@@ -501,22 +501,15 @@ func (api *APIImpl) GetTransactionReceipt(ctx context.Context, txnHash common.Ha
 		}
 	}
 
+	var borTx types.Transaction
 	if txn == nil {
-		borTx, _, _, _, err := rawdb.ReadBorTransactionForBlockNumber(tx, blockNum)
+		borTx, _, _, _, err = rawdb.ReadBorTransactionForBlockNumber(tx, blockNum)
 		if err != nil {
 			return nil, err
 		}
 		if borTx == nil {
 			return nil, nil
 		}
-		borReceipt, err := rawdb.ReadBorReceipt(tx, blockNum)
-		if err != nil {
-			return nil, err
-		}
-		if borReceipt == nil {
-			return nil, nil
-		}
-		return marshalReceipt(borReceipt, borTx, cc, block, txnHash, false), nil
 	}
 
 	receipts, err := api.getReceipts(ctx, tx, cc, block, block.Body().SendersFromTxs())
@@ -526,6 +519,18 @@ func (api *APIImpl) GetTransactionReceipt(ctx context.Context, txnHash common.Ha
 	if len(receipts) <= int(txnIndex) {
 		return nil, fmt.Errorf("block has less receipts than expected: %d <= %d, block: %d", len(receipts), int(txnIndex), blockNum)
 	}
+
+	if txn == nil {
+		borReceipt, err := rawdb.ReadBorReceipt(tx, block.Hash(), blockNum, receipts)
+		if err != nil {
+			return nil, err
+		}
+		if borReceipt == nil {
+			return nil, nil
+		}
+		return marshalReceipt(borReceipt, borTx, cc, block, txnHash, false), nil
+	}
+
 	return marshalReceipt(receipts[txnIndex], block.Transactions()[txnIndex], cc, block, txnHash, true), nil
 }
 
@@ -566,7 +571,7 @@ func (api *APIImpl) GetBlockReceipts(ctx context.Context, number rpc.BlockNumber
 	if chainConfig.Bor != nil {
 		borTx, _, _, _ := rawdb.ReadBorTransactionForBlock(tx, block)
 		if borTx != nil {
-			borReceipt, err := rawdb.ReadBorReceipt(tx, blockNum)
+			borReceipt, err := rawdb.ReadBorReceipt(tx, block.Hash(), block.NumberU64(), receipts)
 			if err != nil {
 				return nil, err
 			}

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -947,7 +947,13 @@ func ReadRawReceipts(db kv.Tx, blockNum uint64) types.Receipts {
 			return fmt.Errorf("receipt unmarshal failed:  %w", err)
 		}
 
-		receipts[binary.BigEndian.Uint32(k[8:])].Logs = logs
+		txIndex := int(binary.BigEndian.Uint32(k[8:]))
+
+		// only return logs from real txs (not from block's stateSyncReceipt)
+		if txIndex < len(receipts) {
+			receipts[txIndex].Logs = logs
+		}
+
 		return nil
 	}); err != nil {
 		log.Error("logs fetching failed", "err", err)

--- a/core/types/bor_receipt.go
+++ b/core/types/bor_receipt.go
@@ -57,6 +57,7 @@ func DeriveFieldsForBorReceipt(receipt *Receipt, blockHash common.Hash, blockNum
 		receipt.Logs[j].Index = uint(logIndex)
 		logIndex++
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
Fixes a nil-pointer dereference in Decode when attempting to call `getTransactionReceipt` / `getBlockReceipts` on blocks containing stateSync events.