### PR TITLE
File system logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ docker-compose.*.yml
 coverage.out
 
 dist
+__debug_bin

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Erigon is an implementation of Ethereum (execution client), on the efficiency fr
 - [System Requirements](#system-requirements)
 - [Usage](#usage)
     + [Getting Started](#getting-started)
+    + [Logging](#logging)
     + [Testnets](#testnets)
     + [Mining](#mining)
     + [Windows](#windows)
@@ -100,6 +101,34 @@ Use `--datadir` to choose where to store data.
 Use `--chain=bor-mainnet` for Polygon Mainnet and `--chain=mumbai` for Polygon Mumbai.
 
 Running `make help` will list and describe the convenience commands available in the [Makefile](./Makefile)
+
+### Logging
+
+_Flags:_ 
+
+  - `verbosity`
+  - `log.console.verbosity` (overriding alias for `verbosity`)
+  - `log.json`
+  - `log.console.json` (alias for `log.json`)
+  - `log.dir.path`
+  - `log.dir.verbosity`
+  - `log.dir.json`
+
+
+In order to log only to the stdout/stderr the `--verbosity` (or `log.console.verbosity`) flag can be used to supply an int value specifying the highest output log level:
+
+```
+  LvlCrit = 0
+  LvlError = 1
+  LvlWarn = 2
+  LvlInfo = 3
+  LvlDebug = 4
+  LvlTrace = 5
+```
+
+To set an output dir for logs to be collected on disk, please set `--log.dir.path`. The flag `--log.dir.verbosity` is also available to control the verbosity of this logging, with the same int value as above, or the string value e.g. 'debug' or 'info'. Default verbosity is 'debug' (4), for disk logging.
+
+Log format can be set to json by the use of the boolean flags `log.json` or `log.console.json`, or for the disk output `--log.dir.json`.
 
 ### Modularity
 

--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -28,11 +28,11 @@ import (
 
 	"github.com/ledgerwatch/erigon/cmd/utils"
 	"github.com/ledgerwatch/erigon/crypto"
+	"github.com/ledgerwatch/erigon/internal/logging"
 	"github.com/ledgerwatch/erigon/p2p/discover"
 	"github.com/ledgerwatch/erigon/p2p/enode"
 	"github.com/ledgerwatch/erigon/p2p/nat"
 	"github.com/ledgerwatch/erigon/p2p/netutil"
-	"github.com/ledgerwatch/log/v3"
 )
 
 func main() {
@@ -45,18 +45,13 @@ func main() {
 		natdesc     = flag.String(utils.NATFlag.Name, "", utils.NATFlag.Usage)
 		netrestrict = flag.String("netrestrict", "", "restrict network communication to the given IP networks (CIDR masks)")
 		runv5       = flag.Bool("v5", false, "run a v5 topic discovery bootnode")
-		verbosity   = flag.Int("verbosity", int(log.LvlInfo), "log verbosity (0-5)")
-		//vmodule     = flag.String("vmodule", "", "log verbosity pattern")
 
 		nodeKey *ecdsa.PrivateKey
 		err     error
 	)
 	flag.Parse()
 
-	//glogger := log.NewGlogHandler(log.StreamHandler(os.Stderr, log.TerminalFormat(false)))
-	//glogger.Verbosity(log.Lvl(*verbosity))
-	//glogger.Vmodule(*vmodule)
-	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(*verbosity), log.StderrHandler))
+	_ = logging.GetLogger("bootnode")
 
 	natm, err := nat.Parse(*natdesc)
 	if err != nil {

--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ledgerwatch/erigon/cmd/utils"
 	"github.com/ledgerwatch/erigon/common/paths"
 	"github.com/ledgerwatch/erigon/internal/debug"
+	"github.com/ledgerwatch/erigon/internal/logging"
 	"github.com/ledgerwatch/erigon/node/nodecfg/datadir"
 	"github.com/ledgerwatch/erigon/p2p/nat"
 	"github.com/ledgerwatch/log/v3"
@@ -49,6 +50,7 @@ var (
 
 func init() {
 	flags := append(debug.Flags, utils.MetricFlags...)
+	flags = append(flags, logging.Flags...)
 	utils.CobraFlags(rootCmd, flags)
 
 	withDataDir(rootCmd)
@@ -104,6 +106,7 @@ var rootCmd = &cobra.Command{
 		debug.Exit()
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		_ = logging.GetLoggerCmd("downloader", cmd)
 		if err := Downloader(cmd.Context()); err != nil {
 			log.Error("Downloader", "err", err)
 			return nil

--- a/cmd/erigon/main.go
+++ b/cmd/erigon/main.go
@@ -8,17 +8,18 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/ledgerwatch/log/v3"
 	"github.com/pelletier/go-toml"
 	"github.com/urfave/cli"
 	"gopkg.in/yaml.v2"
 
 	"github.com/ledgerwatch/erigon-lib/common/dbg"
 	"github.com/ledgerwatch/erigon/cmd/utils"
+	"github.com/ledgerwatch/erigon/internal/logging"
 	"github.com/ledgerwatch/erigon/params"
 	erigonapp "github.com/ledgerwatch/erigon/turbo/app"
 	erigoncli "github.com/ledgerwatch/erigon/turbo/cli"
 	"github.com/ledgerwatch/erigon/turbo/node"
+	"github.com/ledgerwatch/log/v3"
 )
 
 func main() {
@@ -43,7 +44,8 @@ func main() {
 }
 
 func runErigon(cliCtx *cli.Context) {
-	logger := log.New()
+	logger := logging.GetLoggerCtx("erigon", cliCtx)
+
 	// initializing the node and providing the current git commit there
 	logger.Info("Build info", "git_branch", params.GitBranch, "git_tag", params.GitTag, "git_commit", params.GitCommit)
 

--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -44,6 +44,7 @@ import (
 	"github.com/ledgerwatch/erigon/ethdb"
 	"github.com/ledgerwatch/erigon/ethdb/cbor"
 	"github.com/ledgerwatch/erigon/internal/debug"
+	"github.com/ledgerwatch/erigon/internal/logging"
 	"github.com/ledgerwatch/erigon/params"
 	"github.com/ledgerwatch/erigon/rlp"
 	"github.com/ledgerwatch/erigon/turbo/snapshotsync"
@@ -53,7 +54,6 @@ import (
 const ASSERT = false
 
 var (
-	verbosity  = flag.Uint("verbosity", 3, "Logging verbosity: 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=detail (default 3)")
 	action     = flag.String("action", "", "action to execute")
 	cpuprofile = flag.String("cpuprofile", "", "write cpu profile `file`")
 	block      = flag.Int("block", 1, "specifies a block number for operation")
@@ -1305,7 +1305,8 @@ func iterate(filename string, prefix string) error {
 func main() {
 	debug.RaiseFdLimit()
 	flag.Parse()
-	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(*verbosity), log.StderrHandler))
+
+	_ = logging.GetLogger("hack")
 
 	if *cpuprofile != "" {
 		f, err := os.Create(*cpuprofile)

--- a/cmd/integration/commands/state_stages.go
+++ b/cmd/integration/commands/state_stages.go
@@ -36,7 +36,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var stateStags = &cobra.Command{
+var stateStages = &cobra.Command{
 	Use: "state_stages",
 	Short: `Run all StateStages (which happen after senders) in loop.
 Examples: 
@@ -113,18 +113,18 @@ var loopExecCmd = &cobra.Command{
 }
 
 func init() {
-	withDataDir2(stateStags)
-	withReferenceChaindata(stateStags)
-	withUnwind(stateStags)
-	withUnwindEvery(stateStags)
-	withBlock(stateStags)
-	withIntegrityChecks(stateStags)
-	withMining(stateStags)
-	withChain(stateStags)
-	withHeimdall(stateStags)
-	withWorkers(stateStags)
+	withDataDir2(stateStages)
+	withReferenceChaindata(stateStages)
+	withUnwind(stateStages)
+	withUnwindEvery(stateStages)
+	withBlock(stateStages)
+	withIntegrityChecks(stateStages)
+	withMining(stateStages)
+	withChain(stateStages)
+	withHeimdall(stateStages)
+	withWorkers(stateStages)
 
-	rootCmd.AddCommand(stateStags)
+	rootCmd.AddCommand(stateStages)
 
 	withDataDir(loopIhCmd)
 	withBatchSize(loopIhCmd)

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -37,6 +37,7 @@ import (
 	"github.com/ledgerwatch/erigon/common/paths"
 	"github.com/ledgerwatch/erigon/core/rawdb"
 	"github.com/ledgerwatch/erigon/internal/debug"
+	"github.com/ledgerwatch/erigon/internal/logging"
 	"github.com/ledgerwatch/erigon/node"
 	"github.com/ledgerwatch/erigon/node/nodecfg"
 	"github.com/ledgerwatch/erigon/node/nodecfg/datadir"
@@ -60,7 +61,9 @@ var rootCmd = &cobra.Command{
 }
 
 func RootCommand() (*cobra.Command, *httpcfg.HttpCfg) {
-	utils.CobraFlags(rootCmd, append(debug.Flags, utils.MetricFlags...))
+	predefinedFlags := append(debug.Flags, utils.MetricFlags...)
+	predefinedFlags = append(predefinedFlags, logging.Flags...)
+	utils.CobraFlags(rootCmd, predefinedFlags)
 
 	cfg := &httpcfg.HttpCfg{Enabled: true, StateCache: kvcache.DefaultCoherentConfig}
 	rootCmd.PersistentFlags().StringVar(&cfg.PrivateApiAddr, "private.api.addr", "127.0.0.1:9090", "private api network address, for example: 127.0.0.1:9090")

--- a/cmd/rpcdaemon/cli/httpcfg/http_cfg.go
+++ b/cmd/rpcdaemon/cli/httpcfg/http_cfg.go
@@ -1,11 +1,12 @@
 package httpcfg
 
 import (
+	"time"
+
 	"github.com/ledgerwatch/erigon-lib/kv/kvcache"
 	"github.com/ledgerwatch/erigon/eth/ethconfig"
 	"github.com/ledgerwatch/erigon/node/nodecfg/datadir"
 	"github.com/ledgerwatch/erigon/rpc/rpccfg"
-	"time"
 )
 
 type HttpCfg struct {
@@ -49,4 +50,6 @@ type HttpCfg struct {
 	HTTPTimeouts             rpccfg.HTTPTimeouts
 	AuthRpcTimeouts          rpccfg.HTTPTimeouts
 	EvmCallTimeout           time.Duration
+	LogDirVerbosity          string
+	LogDirPath               string
 }

--- a/cmd/rpcdaemon/main.go
+++ b/cmd/rpcdaemon/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/cli"
 	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/commands"
+	"github.com/ledgerwatch/erigon/internal/logging"
 	"github.com/ledgerwatch/log/v3"
 	"github.com/spf13/cobra"
 )
@@ -15,7 +16,7 @@ func main() {
 	rootCtx, rootCancel := common.RootContext()
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
-		logger := log.New()
+		logger := logging.GetLoggerCmd("rpcdaemon", cmd)
 		db, borDb, backend, txPool, mining, stateCache, blockReader, ff, agg, err := cli.RemoteServices(ctx, *cfg, logger, rootCancel)
 		if err != nil {
 			log.Error("Could not connect to DB", "err", err)

--- a/cmd/sentry/main.go
+++ b/cmd/sentry/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ledgerwatch/erigon/cmd/utils"
 	"github.com/ledgerwatch/erigon/common/paths"
 	"github.com/ledgerwatch/erigon/internal/debug"
+	"github.com/ledgerwatch/erigon/internal/logging"
 	"github.com/ledgerwatch/erigon/node/nodecfg/datadir"
 	node2 "github.com/ledgerwatch/erigon/turbo/node"
 	"github.com/spf13/cobra"
@@ -86,6 +87,7 @@ var rootCmd = &cobra.Command{
 			return err
 		}
 
+		_ = logging.GetLoggerCmd("sentry", cmd)
 		return sentry.Sentry(cmd.Context(), dirs, sentryAddr, discoveryDNS, p2pConfig, uint(protocol), healthCheck)
 	},
 }

--- a/cmd/state/commands/erigon2.go
+++ b/cmd/state/commands/erigon2.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ledgerwatch/erigon-lib/kv/mdbx"
 	kv2 "github.com/ledgerwatch/erigon-lib/kv/mdbx"
 	"github.com/ledgerwatch/erigon/eth/ethconsensusconfig"
+	"github.com/ledgerwatch/erigon/internal/logging"
 	"github.com/ledgerwatch/erigon/turbo/services"
 	"github.com/ledgerwatch/log/v3"
 	"github.com/spf13/cobra"
@@ -79,7 +80,7 @@ var erigon2Cmd = &cobra.Command{
 		if commitmentFrequency < 1 || commitmentFrequency > aggregationStep {
 			return fmt.Errorf("commitmentFrequency cannot be less than 1 or more than %d: %d", commitmentFrequency, aggregationStep)
 		}
-		logger := log.New()
+		logger := logging.GetLoggerCmd("erigon2", cmd)
 		return Erigon2(genesis, chainConfig, logger)
 	},
 }

--- a/cmd/state/commands/global_flags_vars.go
+++ b/cmd/state/commands/global_flags_vars.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"path"
-
 	"github.com/spf13/cobra"
 
 	"github.com/ledgerwatch/erigon-lib/kv"
@@ -60,8 +58,4 @@ func withSnapshotBlocks(cmd *cobra.Command) {
 
 func withChain(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&chain, "chain", "", "pick a chain to assume (mainnet, ropsten, etc.)")
-}
-
-func withLogPath(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&logdir, "log-dir", path.Join(paths.DefaultDataDir(), "logs"), "path to write user and error logs to")
 }

--- a/cmd/txpool/main.go
+++ b/cmd/txpool/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ledgerwatch/erigon/common/paths"
 	"github.com/ledgerwatch/erigon/ethdb/privateapi"
 	"github.com/ledgerwatch/erigon/internal/debug"
+	"github.com/ledgerwatch/erigon/internal/logging"
 	"github.com/ledgerwatch/erigon/node/nodecfg/datadir"
 	"github.com/ledgerwatch/log/v3"
 	"github.com/spf13/cobra"
@@ -50,7 +51,10 @@ var (
 )
 
 func init() {
-	utils.CobraFlags(rootCmd, append(debug.Flags, utils.MetricFlags...))
+	predefinedFlags := append(debug.Flags, utils.MetricFlags...)
+	predefinedFlags = append(predefinedFlags, logging.Flags...)
+
+	utils.CobraFlags(rootCmd, predefinedFlags)
 	rootCmd.Flags().StringSliceVar(&sentryAddr, "sentry.api.addr", []string{"localhost:9091"}, "comma separated sentry addresses '<host>:<port>,<host>:<port>'")
 	rootCmd.Flags().StringVar(&privateApiAddr, "private.api.addr", "localhost:9090", "execution service <host>:<port>")
 	rootCmd.Flags().StringVar(&txpoolApiAddr, "txpool.api.addr", "localhost:9094", "txpool service <host>:<port>")
@@ -81,6 +85,7 @@ var rootCmd = &cobra.Command{
 		debug.Exit()
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		_ = logging.GetLoggerCmd("txpool", cmd)
 		ctx := cmd.Context()
 		creds, err := grpcutil.TLS(TLSCACert, TLSCertfile, TLSKeyFile)
 		if err != nil {

--- a/internal/debug/flags.go
+++ b/internal/debug/flags.go
@@ -20,10 +20,10 @@ import (
 	"fmt"
 	"net/http"
 	_ "net/http/pprof" //nolint:gosec
-	"os"
 
 	metrics2 "github.com/VictoriaMetrics/metrics"
 	"github.com/ledgerwatch/erigon/common/fdlimit"
+	"github.com/ledgerwatch/erigon/internal/logging"
 	"github.com/ledgerwatch/erigon/metrics"
 	"github.com/ledgerwatch/erigon/metrics/exp"
 	"github.com/ledgerwatch/log/v3"
@@ -32,15 +32,6 @@ import (
 )
 
 var (
-	verbosityFlag = cli.IntFlag{
-		Name:  "verbosity",
-		Usage: "Logging verbosity: 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=detail",
-		Value: 3,
-	}
-	logjsonFlag = cli.BoolFlag{
-		Name:  "log.json",
-		Usage: "Format logs with JSON",
-	}
 	//nolint
 	vmoduleFlag = cli.StringFlag{
 		Name:  "vmodule",
@@ -80,46 +71,15 @@ var (
 
 // Flags holds all command-line flags required for debugging.
 var Flags = []cli.Flag{
-	verbosityFlag, logjsonFlag, //backtraceAtFlag, vmoduleFlag, debugFlag,
 	pprofFlag, pprofAddrFlag, pprofPortFlag,
 	cpuprofileFlag, traceFlag,
-}
-
-//var glogger *log.GlogHandler
-
-func init() {
-	//log.Root().SetHandler(log.LvlFilterHandler(log.LvlInfo, log.StderrHandler))
-	//glogger = log.NewGlogHandler(log.StreamHandler(os.Stderr, log.TerminalFormat(false)))
-	//glogger.Verbosity(log.LvlInfo)
-	//log.Root().SetHandler(glogger)
 }
 
 func SetupCobra(cmd *cobra.Command) error {
 	RaiseFdLimit()
 	flags := cmd.Flags()
-	lvl, err := flags.GetInt(verbosityFlag.Name)
-	if err != nil {
-		return err
-	}
 
-	/*
-		dbg, err := flags.GetBool(debugFlag.Name)
-		if err != nil {
-			return err
-		}
-		vmodule, err := flags.GetString(vmoduleFlag.Name)
-		if err != nil {
-			return err
-		}
-		backtrace, err := flags.GetString(backtraceAtFlag.Name)
-		if err != nil {
-			return err
-		}
-
-		_, glogger = log.SetupDefaultTerminalLogger(log.Lvl(lvl), vmodule, backtrace)
-		log.PrintOrigins(dbg)
-	*/
-	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(lvl), log.StderrHandler))
+	_ = logging.GetLogger("debug")
 
 	traceFile, err := flags.GetString(traceFlag.Name)
 	if err != nil {
@@ -182,26 +142,6 @@ func SetupCobra(cmd *cobra.Command) error {
 // It should be called as early as possible in the program.
 func Setup(ctx *cli.Context) error {
 	RaiseFdLimit()
-	//var ostream log.Handler
-	//output := io.Writer(os.Stderr)
-	if ctx.Bool(logjsonFlag.Name) {
-		log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(ctx.Int(verbosityFlag.Name)), log.StreamHandler(os.Stderr, log.JsonFormat())))
-		//ostream = log.StreamHandler(output, log.JsonFormat())
-	} else {
-		log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(ctx.Int(verbosityFlag.Name)), log.StderrHandler))
-	}
-	//log.Root().SetHandler(ostream)
-
-	/*
-		glogger.SetHandler(ostream)
-		// logging
-		log.PrintOrigins(ctx.GlobalBool(debugFlag.Name))
-		_, glogger = log.SetupDefaultTerminalLogger(
-			log.Lvl(ctx.GlobalInt(verbosityFlag.Name)),
-			ctx.GlobalString(vmoduleFlag.Name),
-			ctx.GlobalString(backtraceAtFlag.Name),
-		)
-	*/
 
 	if traceFile := ctx.String(traceFlag.Name); traceFile != "" {
 		if err := Handler.StartGoTrace(traceFile); err != nil {

--- a/internal/logging/flags.go
+++ b/internal/logging/flags.go
@@ -1,0 +1,56 @@
+package logging
+
+import (
+	"github.com/ledgerwatch/log/v3"
+	"github.com/urfave/cli"
+)
+
+var (
+	LogJsonFlag = cli.BoolFlag{
+		Name:  "log.json",
+		Usage: "Format console logs with JSON",
+	}
+
+	LogConsoleJsonFlag = cli.BoolFlag{
+		Name:  "log.console.json",
+		Usage: "Format console logs with JSON",
+	}
+
+	LogDirJsonFlag = cli.BoolFlag{
+		Name:  "log.dir.json",
+		Usage: "Format file logs with JSON",
+	}
+
+	LogVerbosityFlag = cli.StringFlag{
+		Name:  "verbosity",
+		Usage: "Set the log level for console logs",
+		Value: log.LvlInfo.String(),
+	}
+
+	LogConsoleVerbosityFlag = cli.StringFlag{
+		Name:  "log.console.verbosity",
+		Usage: "Set the log level for console logs",
+		Value: log.LvlInfo.String(),
+	}
+
+	LogDirPathFlag = cli.StringFlag{
+		Name:  "log.dir.path",
+		Usage: "Path to store user and error logs to disk",
+	}
+
+	LogDirVerbosityFlag = cli.StringFlag{
+		Name:  "log.dir.verbosity",
+		Usage: "Set the log verbosity for logs stored to disk",
+		Value: log.LvlDebug.String(),
+	}
+)
+
+var Flags = []cli.Flag{
+	LogJsonFlag,
+	LogConsoleJsonFlag,
+	LogDirJsonFlag,
+	LogVerbosityFlag,
+	LogConsoleVerbosityFlag,
+	LogDirPathFlag,
+	LogDirVerbosityFlag,
+}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,162 @@
+package logging
+
+import (
+	"flag"
+	"os"
+	"path"
+	"strconv"
+
+	"github.com/ledgerwatch/log/v3"
+	"github.com/spf13/cobra"
+	"github.com/urfave/cli"
+)
+
+func GetLoggerCtx(filePrefix string, ctx *cli.Context) log.Logger {
+	var consoleJson = ctx.Bool(LogJsonFlag.Name) || ctx.Bool(LogConsoleJsonFlag.Name)
+	var dirJson = ctx.Bool(LogDirJsonFlag.Name)
+
+	consoleLevel, lErr := tryGetLogLevel(ctx.String(LogConsoleVerbosityFlag.Name))
+	if lErr != nil {
+		// try verbosity flag
+		consoleLevel, lErr = tryGetLogLevel(ctx.String(LogVerbosityFlag.Name))
+		if lErr != nil {
+			consoleLevel = log.LvlInfo
+		}
+	}
+
+	dirLevel, dErr := tryGetLogLevel(ctx.String(LogDirVerbosityFlag.Name))
+	if dErr != nil {
+		dirLevel = log.LvlDebug
+	}
+
+	dirPath := ctx.String(LogDirPathFlag.Name)
+	return initSeparatedLogging(filePrefix, dirPath, consoleLevel, dirLevel, consoleJson, dirJson)
+}
+
+func GetLoggerCmd(filePrefix string, cmd *cobra.Command) log.Logger {
+
+	logJsonVal, ljerr := cmd.Flags().GetBool(LogJsonFlag.Name)
+	if ljerr != nil {
+		logJsonVal = false
+	}
+
+	logConsoleJsonVal, lcjerr := cmd.Flags().GetBool(LogConsoleJsonFlag.Name)
+	if lcjerr != nil {
+		logConsoleJsonVal = false
+	}
+
+	var consoleJson = logJsonVal || logConsoleJsonVal
+	dirJson, djerr := cmd.Flags().GetBool(LogDirJsonFlag.Name)
+	if djerr != nil {
+		dirJson = false
+	}
+
+	consoleLevel, lErr := tryGetLogLevel(cmd.Flags().Lookup(LogConsoleVerbosityFlag.Name).Value.String())
+	if lErr != nil {
+		// try verbosity flag
+		consoleLevel, lErr = tryGetLogLevel(cmd.Flags().Lookup(LogVerbosityFlag.Name).Value.String())
+		if lErr != nil {
+			consoleLevel = log.LvlInfo
+		}
+	}
+
+	dirLevel, dErr := tryGetLogLevel(cmd.Flags().Lookup(LogDirVerbosityFlag.Name).Value.String())
+	if dErr != nil {
+		dirLevel = log.LvlDebug
+	}
+
+	dirPath := cmd.Flags().Lookup(LogDirPathFlag.Name).Value.String()
+	return initSeparatedLogging(filePrefix, dirPath, consoleLevel, dirLevel, consoleJson, dirJson)
+}
+
+func GetLogger(filePrefix string) log.Logger {
+	var logConsoleVerbosity = flag.String(LogConsoleVerbosityFlag.Name, "", LogConsoleVerbosityFlag.Usage)
+	var logDirVerbosity = flag.String(LogDirVerbosityFlag.Name, "", LogDirVerbosityFlag.Usage)
+	var logDirPath = flag.String(LogDirPathFlag.Name, "", LogDirPathFlag.Usage)
+	var logVerbosity = flag.String(LogVerbosityFlag.Name, "", LogVerbosityFlag.Usage)
+	var logConsoleJson = flag.Bool(LogConsoleJsonFlag.Name, false, LogConsoleJsonFlag.Usage)
+	var logJson = flag.Bool(LogJsonFlag.Name, false, LogJsonFlag.Usage)
+	var logDirJson = flag.Bool(LogDirJsonFlag.Name, false, LogDirJsonFlag.Usage)
+	flag.Parse()
+
+	var consoleJson = *logJson || *logConsoleJson
+	var dirJson = logDirJson
+
+	consoleLevel, lErr := tryGetLogLevel(*logConsoleVerbosity)
+	if lErr != nil {
+		// try verbosity flag
+		consoleLevel, lErr = tryGetLogLevel(*logVerbosity)
+		if lErr != nil {
+			consoleLevel = log.LvlInfo
+		}
+	}
+
+	dirLevel, dErr := tryGetLogLevel(*logDirVerbosity)
+	if dErr != nil {
+		dirLevel = log.LvlDebug
+	}
+
+	return initSeparatedLogging(filePrefix, *logDirPath, consoleLevel, dirLevel, consoleJson, *dirJson)
+}
+
+func initSeparatedLogging(
+	filePrefix string,
+	dirPath string,
+	consoleLevel log.Lvl,
+	dirLevel log.Lvl,
+	consoleJson bool,
+	dirJson bool) log.Logger {
+
+	logger := log.Root()
+
+	if consoleJson {
+		log.Root().SetHandler(log.LvlFilterHandler(consoleLevel, log.StreamHandler(os.Stderr, log.JsonFormat())))
+	} else {
+		log.Root().SetHandler(log.LvlFilterHandler(consoleLevel, log.StderrHandler))
+	}
+
+	if len(dirPath) == 0 {
+		logger.Warn("no log dir set, console logging only")
+		return logger
+	}
+
+	err := os.MkdirAll(dirPath, 0764)
+	if err != nil {
+		logger.Warn("failed to create log dir, console logging only")
+		return logger
+	}
+
+	dirFormat := log.LogfmtFormat()
+	if dirJson {
+		dirFormat = log.JsonFormat()
+	}
+
+	userLog, err := log.FileHandler(path.Join(dirPath, filePrefix+"-user.log"), dirFormat, 1<<27) // 128Mb
+	if err != nil {
+		logger.Warn("failed to open user log, console logging only")
+		return logger
+	}
+	errLog, err := log.FileHandler(path.Join(dirPath, filePrefix+"-error.log"), dirFormat, 1<<27) // 128Mb
+	if err != nil {
+		logger.Warn("failed to open error log, console logging only")
+		return logger
+	}
+
+	mux := log.MultiHandler(logger.GetHandler(), log.LvlFilterHandler(dirLevel, userLog), log.LvlFilterHandler(log.LvlError, errLog))
+	log.Root().SetHandler(mux)
+	logger.SetHandler(mux)
+	logger.Info("logging to file system", "log dir", dirPath, "file prefix", filePrefix, "log level", dirLevel, "json", dirJson)
+	return logger
+}
+
+func tryGetLogLevel(s string) (log.Lvl, error) {
+	lvl, err := log.LvlFromString(s)
+	if err != nil {
+		l, err := strconv.Atoi(s)
+		if err != nil {
+			return 0, err
+		}
+		return log.Lvl(l), nil
+	}
+	return lvl, nil
+}

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"github.com/ledgerwatch/erigon/cmd/utils"
+	"github.com/ledgerwatch/erigon/internal/logging"
 
 	"github.com/urfave/cli"
 )
@@ -141,4 +142,10 @@ var DefaultFlags = []cli.Flag{
 	utils.OverrideMergeNetsplitBlock,
 
 	utils.ConfigFlag,
+	logging.LogConsoleVerbosityFlag,
+	logging.LogDirVerbosityFlag,
+	logging.LogDirPathFlag,
+	logging.LogConsoleJsonFlag,
+	logging.LogJsonFlag,
+	logging.LogDirJsonFlag,
 }


### PR DESCRIPTION
- lives in internal/logging
- all log flags moved to internal/logging/flags
- allows continued use of root logger via log.Info etc.
- update logger to take change allowing string to lvl for 'trace'

Verbosity flag is overridden by log.console.verbosity. Logs will be colocated if all run as one process, only split where progs are run as separate processes, in a future update this will be addressed so for example rpcdeamon will always log to it's own file