### PR TITLE
fix on number of samples for blocks

### DIFF
--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -253,6 +253,7 @@ func (gpo *Oracle) getBlockPrices(ctx context.Context, blockNum uint64, limit in
 	txs := newTransactionsByGasPrice(plainTxs, baseFee)
 	heap.Init(&txs)
 
+        count := 0
 	for txs.Len() > 0 {
 		tx := heap.Pop(&txs).(types.Transaction)
 		tip := tx.GetEffectiveGasTip(baseFee)
@@ -262,7 +263,8 @@ func (gpo *Oracle) getBlockPrices(ctx context.Context, blockNum uint64, limit in
 		sender, _ := tx.GetSender()
 		if err == nil && sender != block.Coinbase() {
 			heap.Push(s, tip)
-			if s.Len() >= limit {
+                        count = count + 1
+			if count  >= limit {
 				break
 			}
 		}

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -253,7 +253,7 @@ func (gpo *Oracle) getBlockPrices(ctx context.Context, blockNum uint64, limit in
 	txs := newTransactionsByGasPrice(plainTxs, baseFee)
 	heap.Init(&txs)
 
-        count := 0
+	count := 0
 	for txs.Len() > 0 {
 		tx := heap.Pop(&txs).(types.Transaction)
 		tip := tx.GetEffectiveGasTip(baseFee)
@@ -263,9 +263,9 @@ func (gpo *Oracle) getBlockPrices(ctx context.Context, blockNum uint64, limit in
 		sender, _ := tx.GetSender()
 		if err == nil && sender != block.Coinbase() {
 			heap.Push(s, tip)
-                        count = count + 1
-                        // verify if reached max samples(limit) for current block
-			if count  >= limit {
+			count = count + 1
+			// verify if reached max samples(limit) for current block
+			if count >= limit {
 				break
 			}
 		}

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -264,6 +264,7 @@ func (gpo *Oracle) getBlockPrices(ctx context.Context, blockNum uint64, limit in
 		if err == nil && sender != block.Coinbase() {
 			heap.Push(s, tip)
                         count = count + 1
+                        // verify if reached max samples(limit) for current block
 			if count  >= limit {
 				break
 			}

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -254,7 +254,7 @@ func (gpo *Oracle) getBlockPrices(ctx context.Context, blockNum uint64, limit in
 	heap.Init(&txs)
 
 	count := 0
-	for txs.Len() > 0 {
+	for count < limit && txs.Len() > 0 {
 		tx := heap.Pop(&txs).(types.Transaction)
 		tip := tx.GetEffectiveGasTip(baseFee)
 		if ignoreUnder != nil && tip.Lt(ignoreUnder) {
@@ -264,10 +264,6 @@ func (gpo *Oracle) getBlockPrices(ctx context.Context, blockNum uint64, limit in
 		if err == nil && sender != block.Coinbase() {
 			heap.Push(s, tip)
 			count = count + 1
-			// verify if reached max samples(limit) for current block
-			if count >= limit {
-				break
-			}
 		}
 	}
 	return nil


### PR DESCRIPTION
eth_gasPrice(): A maximum of 3 samples should be taken per block (see sample const)
The getBlockPrices() function takes 3 samples on the first block and one on the others.
In the check s.Len() >= limit  s.Len() after first block will contain 3 samples and so the loop will be executed only one time for each block NOT three times