### PR TITLE
Make lint happy

### DIFF
--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -882,7 +882,6 @@ func ReconstituteState(ctx context.Context, s *StageState, dirs datadir.Dirs, wo
 			}
 			inputTxNum++
 		}
-		b, txs = nil, nil
 
 		core.BlockExecutionTimer.UpdateDuration(t)
 		syncMetrics[stages.Execution].Set(blockNum)


### PR DESCRIPTION
Fixes
```
eth/stagedsync/exec3.go:885:6: ineffectual assignment to txs (ineffassign)
        b, txs = nil, nil
           ^
```