### PR TITLE
fix potential deadlock in eth_filters logs event

### DIFF
--- a/cmd/rpcdaemon/commands/eth_filters.go
+++ b/cmd/rpcdaemon/commands/eth_filters.go
@@ -262,6 +262,7 @@ func (api *APIImpl) Logs(ctx context.Context, crit filters.FilterCriteria) (*rpc
 		logs := make(chan *types.Log, 1)
 		id := api.filters.SubscribeLogs(logs, crit)
 		defer api.filters.UnsubscribeLogs(id)
+
 		for {
 			select {
 			case h, ok := <-logs:

--- a/turbo/rpchelper/logsfilter.go
+++ b/turbo/rpchelper/logsfilter.go
@@ -112,8 +112,8 @@ func (a *LogsFilterAggregator) getAggMaps() (map[common.Address]int, map[common.
 }
 
 func (a *LogsFilterAggregator) distributeLog(eventLog *remote.SubscribeLogsReply) error {
-	a.logsFilterLock.Lock()
-	defer a.logsFilterLock.Unlock()
+	a.logsFilterLock.RLock()
+	defer a.logsFilterLock.RUnlock()
 	for _, filter := range a.logsFilters {
 		if filter.allAddrs == 0 {
 			_, addrOk := filter.addrs[gointerfaces.ConvertH160toAddress(eventLog.Address)]


### PR DESCRIPTION
Like the newPendingTransaction event, the logs event also has the potential for deadlock when unsubscribed