### PR TITLE
etl-temp location changed so cleaning up docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ System Requirements
 ===================
 
 * For an Archive node of Ethereum Mainnet we recommend >=3TB storage space: 1.8TB state (as of March 2022),
-  200GB temp files (can symlink or mount folder `<datadir>/etl-tmp` to another disk). Ethereum Mainnet Full node (
+  200GB temp files (can symlink or mount folder `<datadir>/temp` to another disk). Ethereum Mainnet Full node (
   see `--prune*` flags): 400Gb (April 2022).
 
 * Goerli Full node (see `--prune*` flags): 189GB on Beta, 114GB on Alpha (April 2022).


### PR DESCRIPTION
It seems this got changed around so that `temp` is used but the docs were not changed.