### PR TITLE
Setup web socket endpoints to listen for new transactions after sending

### DIFF
--- a/cmd/devnet/commands/all.go
+++ b/cmd/devnet/commands/all.go
@@ -8,8 +8,10 @@ import (
 // ExecuteAllMethods runs all the simulation tests for erigon devnet
 func ExecuteAllMethods() {
 	// test connection to JSON RPC
-	fmt.Println("Mocking get requests to JSON RPC...")
-	pingErigonRpc()
+	fmt.Printf("\nPINGING JSON RPC...\n")
+	if err := pingErigonRpc(); err != nil {
+		return
+	}
 	fmt.Println()
 
 	// get balance of the receiver's account
@@ -17,14 +19,29 @@ func ExecuteAllMethods() {
 	fmt.Println()
 
 	// confirm that the txpool is empty
-	fmt.Println("Confirming the tx pool is empty...")
-	callTxPoolContent()
-
-	// send a token from the dev address to the recipient address
-	callSendTx(sendValue, recipientAddress, models.DevAddress)
+	fmt.Println("CONFIRMING TXPOOL IS EMPTY BEFORE SENDING TRANSACTION...")
+	checkTxPoolContent(0, 0)
 	fmt.Println()
 
-	// confirm that the txpool has this transaction in the queue
-	fmt.Println("Confirming the tx pool has the latest transaction...")
-	callTxPoolContent()
+	// send a token from the dev address to the recipient address
+	hash, err := callSendTx(sendValue, recipientAddress, models.DevAddress)
+	if err != nil {
+		fmt.Printf("callSendTx error: %v\n", err)
+		return
+	}
+	fmt.Println()
+
+	// confirm that the txpool has this transaction in the pending queue
+	fmt.Println("CONFIRMING TXPOOL HAS THE LATEST TRANSACTION...")
+	checkTxPoolContent(1, 0)
+	fmt.Println()
+
+	// look for the transaction hash in the newly mined block
+	fmt.Println("LOOKING FOR TRANSACTION IN THE LATEST BLOCK...")
+	callSubscribeToNewHeads(*hash)
+	fmt.Println()
+
+	// confirm that the transaction has been moved from the pending queue and the txpool is empty once again
+	fmt.Println("CONFIRMING TXPOOL IS EMPTY ONCE AGAIN...")
+	checkTxPoolContent(0, 0)
 }

--- a/cmd/devnet/commands/block.go
+++ b/cmd/devnet/commands/block.go
@@ -14,28 +14,31 @@ const (
 	sendValue        uint64 = 10000
 )
 
-func callSendTx(value uint64, toAddr, fromAddr string) {
+func callSendTx(value uint64, toAddr, fromAddr string) (*common.Hash, error) {
 	fmt.Printf("Sending %d ETH to %q from %q...\n", value, toAddr, fromAddr)
 
 	// get the latest nonce for the next transaction
 	nonce, err := services.GetNonce(models.ReqId, common.HexToAddress(fromAddr))
 	if err != nil {
 		fmt.Printf("failed to get latest nonce: %s\n", err)
-		return
+		return nil, err
 	}
 
 	// create a non-contract transaction and sign it
 	signedTx, _, err := services.CreateTransaction(models.NonContractTx, toAddr, value, nonce)
 	if err != nil {
 		fmt.Printf("failed to create a transaction: %s\n", err)
+		return nil, err
 	}
 
 	// send the signed transaction
 	hash, err := requests.SendTransaction(models.ReqId, signedTx)
 	if err != nil {
 		fmt.Printf("failed to send transaction: %s\n", err)
-		return
+		return nil, err
 	}
 
 	fmt.Printf("SUCCESS => Tx submitted, adding tx with hash %q to txpool\n", hash)
+
+	return hash, nil
 }

--- a/cmd/devnet/commands/event.go
+++ b/cmd/devnet/commands/event.go
@@ -1,0 +1,16 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/ledgerwatch/erigon/cmd/devnet/services"
+	"github.com/ledgerwatch/erigon/common"
+)
+
+func callSubscribeToNewHeads(hash common.Hash) {
+	_, err := services.SearchBlockForTransactionHash(hash)
+	if err != nil {
+		fmt.Printf("FAILURE => %v\n", err)
+		return
+	}
+}

--- a/cmd/devnet/commands/request.go
+++ b/cmd/devnet/commands/request.go
@@ -7,8 +7,10 @@ import (
 	"github.com/ledgerwatch/erigon/cmd/devnet/requests"
 )
 
-func pingErigonRpc() {
-	if err := requests.PingErigonRpc(models.ReqId); err != nil {
-		fmt.Printf("error mocking get request: %v\n", err)
+func pingErigonRpc() error {
+	err := requests.PingErigonRpc(models.ReqId)
+	if err != nil {
+		fmt.Printf("FAILURE => %v\n", err)
 	}
+	return err
 }

--- a/cmd/devnet/commands/tx.go
+++ b/cmd/devnet/commands/tx.go
@@ -6,8 +6,19 @@ import (
 	"github.com/ledgerwatch/erigon/cmd/devnet/requests"
 )
 
-func callTxPoolContent() {
-	if err := requests.TxpoolContent(models.ReqId); err != nil {
-		fmt.Printf("error getting txpool content: %v\n", err)
+func checkTxPoolContent(expectedPendingSize, expectedQueuedSize int) {
+	pendingSize, queuedSize, err := requests.TxpoolContent(models.ReqId)
+	if err != nil {
+		fmt.Printf("FAILURE => error getting txpool content: %v\n", err)
 	}
+
+	if pendingSize != expectedPendingSize {
+		fmt.Printf("FAILURE => %v\n", fmt.Errorf("expected %d transaction(s) in pending pool, got %d", expectedPendingSize, pendingSize))
+	}
+
+	if queuedSize != expectedQueuedSize {
+		fmt.Printf("FAILURE => %v\n", fmt.Errorf("expected %d transaction(s) in queued pool, got %d", expectedQueuedSize, queuedSize))
+	}
+
+	fmt.Printf("SUCCESS => %d transaction(s) in the pending pool and %d transaction(s) in the queued pool\n", pendingSize, queuedSize)
 }

--- a/cmd/devnet/devnetutils/utils.go
+++ b/cmd/devnet/devnetutils/utils.go
@@ -3,8 +3,11 @@ package devnetutils
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/ledgerwatch/erigon/cmd/devnet/models"
 	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/ledgerwatch/erigon/cmd/devnet/models"
 )
 
 // ClearDevDB cleans up the dev folder used for the operations
@@ -75,4 +78,20 @@ func ParseResponse(resp interface{}) (string, error) {
 	}
 
 	return string(result), nil
+}
+
+// HexToInt converts a hexadecimal string to uint64
+func HexToInt(hexStr string) uint64 {
+	cleaned := strings.ReplaceAll(hexStr, "0x", "") // remove the 0x prefix
+	result, _ := strconv.ParseUint(cleaned, 16, 64)
+	return result
+}
+
+// NamespaceAndSubMethodFromMethod splits a parent method into namespace and the actual method
+func NamespaceAndSubMethodFromMethod(method string) (string, string, error) {
+	parts := strings.SplitN(method, "_", 2)
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid string to split")
+	}
+	return parts[0], parts[1], nil
 }

--- a/cmd/devnet/devnetutils/utils_test.go
+++ b/cmd/devnet/devnetutils/utils_test.go
@@ -1,6 +1,11 @@
 package devnetutils
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestUniqueIDFromEnode(t *testing.T) {
 	testCases := []struct {
@@ -33,9 +38,7 @@ func TestUniqueIDFromEnode(t *testing.T) {
 		if !testCase.shouldError && err != nil {
 			t.Errorf("expected no error, got %s", err)
 		}
-		if got != testCase.expectedRes {
-			t.Errorf("expected %s, got %s", testCase.expectedRes, got)
-		}
+		require.EqualValues(t, got, testCase.expectedRes)
 	}
 }
 
@@ -76,8 +79,67 @@ func TestParseResponse(t *testing.T) {
 
 	for _, testCase := range testCases {
 		got, _ := ParseResponse(testCase.input)
-		if got != testCase.expected {
-			t.Errorf("expected: %v, got %v", testCase.expected, got)
+		require.EqualValues(t, testCase.expected, got)
+	}
+}
+
+func TestNamespaceAndSubMethodFromMethod(t *testing.T) {
+	expectedError := fmt.Errorf("invalid string to split")
+
+	testCases := []struct {
+		method            string
+		expectedNamespace string
+		expectedSubMethod string
+		shouldError       bool
+		expectedError     error
+	}{
+		{
+			"eth_logs",
+			"eth",
+			"logs",
+			false,
+			nil,
+		},
+		{
+			"ethNewHeads",
+			"",
+			"",
+			true,
+			expectedError,
+		},
+		{
+			"",
+			"",
+			"",
+			true,
+			expectedError,
+		},
+	}
+
+	for _, testCase := range testCases {
+		namespace, subMethod, err := NamespaceAndSubMethodFromMethod(testCase.method)
+		require.EqualValues(t, testCase.expectedNamespace, namespace)
+		require.EqualValues(t, testCase.expectedSubMethod, subMethod)
+		require.EqualValues(t, testCase.expectedError, err)
+		if testCase.shouldError {
+			require.Errorf(t, testCase.expectedError, expectedError.Error())
 		}
+	}
+}
+
+func TestHexToInt(t *testing.T) {
+	testCases := []struct {
+		hexStr   string
+		expected uint64
+	}{
+		{"0x0", 0},
+		{"0x32424", 205860},
+		{"0x200", 512},
+		{"0x39", 57},
+	}
+
+	for _, testCase := range testCases {
+		got := HexToInt(testCase.hexStr)
+		require.EqualValues(t, testCase.expected, got)
 	}
 }

--- a/cmd/devnet/models/model.go
+++ b/cmd/devnet/models/model.go
@@ -117,23 +117,14 @@ var (
 
 // Responses for the rpc calls
 type (
-	// TxpoolContextResponse is the response for calls made to txpool_content
-	TxpoolContextResponse map[string]interface{}
-
 	// AdminNodeInfoResponse is the response for calls made to admin_nodeInfo
 	AdminNodeInfoResponse struct {
 		rpctest.CommonResponse
 		Result p2p.NodeInfo `json:"result"`
 	}
-
-	//content := map[string]map[string]map[string]*RPCTransaction{
-	//	"pending": make(map[string]map[string]*RPCTransaction),
-	//	"baseFee": make(map[string]map[string]*RPCTransaction),
-	//	"queued":  make(map[string]map[string]*RPCTransaction),
-	//}
 )
 
-// Block represents a block
+// Block represents a simple block for queries
 type Block struct {
 	Number       *hexutil.Big
 	Transactions []common.Hash

--- a/cmd/devnet/models/model.go
+++ b/cmd/devnet/models/model.go
@@ -3,6 +3,8 @@ package models
 import (
 	"fmt"
 	"github.com/ledgerwatch/erigon/cmd/rpctest/rpctest"
+	"github.com/ledgerwatch/erigon/common"
+	"github.com/ledgerwatch/erigon/common/hexutil"
 	"github.com/ledgerwatch/erigon/crypto"
 	"github.com/ledgerwatch/erigon/p2p"
 )
@@ -15,6 +17,8 @@ type (
 
 	// RPCMethod is the type for rpc methods used
 	RPCMethod string
+	// SubMethod is the type for sub methods used in subscriptions
+	SubMethod string
 )
 
 const (
@@ -26,8 +30,6 @@ const (
 	ChainArg = "--chain"
 	// DevPeriodArg is the dev.period flag
 	DevPeriodArg = "--dev.period"
-	// VerbosityArg is the verbosity flag
-	VerbosityArg = "--verbosity"
 	// ConsoleVerbosityArg is the log.console.verbosity flag
 	ConsoleVerbosityArg = "--log.console.verbosity"
 	// LogDirArg is the log.dir.path flag
@@ -42,6 +44,8 @@ const (
 	StaticPeersArg = "--staticpeers"
 	// HttpApiArg is the http.api flag
 	HttpApiArg = "--http.api"
+	// WSArg is the --ws flag for rpcdaemon
+	WSArg = "--ws"
 
 	// DataDirParam is the datadir parameter
 	DataDirParam = "./dev"
@@ -49,8 +53,6 @@ const (
 	ChainParam = "dev"
 	// DevPeriodParam is the dev.period parameter
 	DevPeriodParam = "0"
-	// VerbosityParam is the verbosity parameter
-	VerbosityParam = "0"
 	// ConsoleVerbosityParam is the verbosity parameter for the console logs
 	ConsoleVerbosityParam = "0"
 	// LogDirParam is the log directory parameter for logging to disk
@@ -59,14 +61,20 @@ const (
 	PrivateApiParamMine = "localhost:9090"
 	// PrivateApiParamNoMine is the private.api.addr parameter for the non-mining node
 	PrivateApiParamNoMine = "localhost:9091"
+	// HttpApiParam is the http.api default parameter for rpcdaemon
+	HttpApiParam = "admin,eth,erigon,web3,net,debug,trace,txpool,parity"
+	//// WSParam is the ws default parameter for rpcdaemon
+	//WSParam = ""
 
 	// ErigonUrl is the default url for rpc connections
 	ErigonUrl = "http://localhost:8545"
-	// ErigonLogFilePrefix is the default file prefix for logging erigon node info and errors
-	ErigonLogFilePrefix = "erigon_node_"
+	// Localhost is the default localhost endpoint for web socket attachments
+	Localhost = "127.0.0.1:8545"
 
 	// ReqId is the request id for each request
 	ReqId = 0
+	// MaxNumberOfBlockChecks is the max number of blocks to look for a transaction in
+	MaxNumberOfBlockChecks = 1
 
 	// Latest is the parameter for the latest block
 	Latest BlockNumber = "latest"
@@ -91,10 +99,15 @@ const (
 	ETHGetBalance RPCMethod = "eth_getBalance"
 	// ETHSendRawTransaction represents the eth_sendRawTransaction method
 	ETHSendRawTransaction RPCMethod = "eth_sendRawTransaction"
+	// ETHGetBlockByNumber represents the eth_getBlockByNumber method
+	ETHGetBlockByNumber RPCMethod = "eth_getBlockByNumber"
 	// AdminNodeInfo represents the admin_nodeInfo method
 	AdminNodeInfo RPCMethod = "admin_nodeInfo"
 	// TxpoolContent represents the txpool_content method
 	TxpoolContent RPCMethod = "txpool_content"
+
+	// ETHNewHeads represents the eth_newHeads sub method
+	ETHNewHeads SubMethod = "eth_newHeads"
 )
 
 var (
@@ -102,9 +115,28 @@ var (
 	DevSignedPrivateKey, _ = crypto.HexToECDSA(hexPrivateKey)
 )
 
-type AdminNodeInfoResponse struct {
-	rpctest.CommonResponse
-	Result p2p.NodeInfo `json:"result"`
+// Responses for the rpc calls
+type (
+	// TxpoolContextResponse is the response for calls made to txpool_content
+	TxpoolContextResponse map[string]interface{}
+
+	// AdminNodeInfoResponse is the response for calls made to admin_nodeInfo
+	AdminNodeInfoResponse struct {
+		rpctest.CommonResponse
+		Result p2p.NodeInfo `json:"result"`
+	}
+
+	//content := map[string]map[string]map[string]*RPCTransaction{
+	//	"pending": make(map[string]map[string]*RPCTransaction),
+	//	"baseFee": make(map[string]map[string]*RPCTransaction),
+	//	"queued":  make(map[string]map[string]*RPCTransaction),
+	//}
+)
+
+// Block represents a block
+type Block struct {
+	Number       *hexutil.Big
+	Transactions []common.Hash
 }
 
 // ParameterFromArgument merges the argument and parameter and returns a flag input string

--- a/cmd/devnet/node/node.go
+++ b/cmd/devnet/node/node.go
@@ -49,7 +49,7 @@ func Start(wg *sync.WaitGroup) {
 
 // StartNode starts an erigon node on the dev chain
 func StartNode(wg *sync.WaitGroup, args []string) {
-	fmt.Printf("Running node %d with flags ==> %v\n", nodeNumber, args)
+	fmt.Printf("\nRunning node %d with flags ==> %v\n", nodeNumber, args)
 
 	// catch any errors and avoid panics if an error occurs
 	defer func() {
@@ -80,15 +80,6 @@ func StartNode(wg *sync.WaitGroup, args []string) {
 func runNode(ctx *cli.Context) {
 	logger := log.New()
 
-	//handler, err := log.FileHandler(models.ErigonLogFilePrefix+fmt.Sprintf("%d", nodeNumber), log.LogfmtFormat(), 1<<27) // 128Mb
-	//if err != nil {
-	//	log.Error("Issue setting up log file handler", "err", err)
-	//	return
-	//}
-	//
-	//logger.SetHandler(handler)
-	//log.SetRootHandler(handler)
-
 	// Initializing the node and providing the current git commit there
 	logger.Info("Build info", "git_branch", params.GitBranch, "git_tag", params.GitTag, "git_commit", params.GitCommit)
 
@@ -113,12 +104,12 @@ func miningNodeArgs() []string {
 	chainType, _ := models.ParameterFromArgument(models.ChainArg, models.ChainParam)
 	devPeriod, _ := models.ParameterFromArgument(models.DevPeriodArg, models.DevPeriodParam)
 	privateApiAddr, _ := models.ParameterFromArgument(models.PrivateApiAddrArg, models.PrivateApiParamMine)
-	httpApi, _ := models.ParameterFromArgument(models.HttpApiArg, "admin,eth,erigon,web3,net,debug,trace,txpool,parity")
-	//verbosity, _ := models.ParameterFromArgument(models.VerbosityArg, models.VerbosityParam)
+	httpApi, _ := models.ParameterFromArgument(models.HttpApiArg, models.HttpApiParam)
+	ws := models.WSArg
 	consoleVerbosity, _ := models.ParameterFromArgument(models.ConsoleVerbosityArg, models.ConsoleVerbosityParam)
 	logDir, _ := models.ParameterFromArgument(models.LogDirArg, models.LogDirParam+"/node_1")
 
-	return []string{models.BuildDirArg, dataDir, chainType, privateApiAddr, models.Mine, httpApi, devPeriod, consoleVerbosity, logDir}
+	return []string{models.BuildDirArg, dataDir, chainType, privateApiAddr, models.Mine, httpApi, ws, devPeriod, consoleVerbosity, logDir}
 }
 
 // nonMiningNodeArgs returns custom args for starting a non-mining node
@@ -127,7 +118,6 @@ func nonMiningNodeArgs(nodeNumber int, enode string) []string {
 	chainType, _ := models.ParameterFromArgument(models.ChainArg, models.ChainParam)
 	privateApiAddr, _ := models.ParameterFromArgument(models.PrivateApiAddrArg, models.PrivateApiParamNoMine)
 	staticPeers, _ := models.ParameterFromArgument(models.StaticPeersArg, enode)
-	//verbosity, _ := models.ParameterFromArgument(models.VerbosityArg, models.VerbosityParam)
 	consoleVerbosity, _ := models.ParameterFromArgument(models.ConsoleVerbosityArg, models.ConsoleVerbosityParam)
 	logDir, _ := models.ParameterFromArgument(models.LogDirArg, models.LogDirParam+"/node_2")
 

--- a/cmd/devnet/requests/tx.go
+++ b/cmd/devnet/requests/tx.go
@@ -2,25 +2,37 @@ package requests
 
 import (
 	"fmt"
-
 	"github.com/ledgerwatch/erigon/cmd/devnet/devnetutils"
-
 	"github.com/ledgerwatch/erigon/cmd/rpctest/rpctest"
 )
 
-func TxpoolContent(reqId int) error {
+func TxpoolContent(reqId int) (int, int, error) {
+	var (
+		b       rpctest.EthTxPool
+		pending map[string]interface{}
+		queued  map[string]interface{}
+	)
+
 	reqGen := initialiseRequestGenerator(reqId)
-	var b rpctest.EthTxPool
 
 	if res := reqGen.Erigon("txpool_content", reqGen.TxpoolContent(), &b); res.Err != nil {
-		return fmt.Errorf("failed to fetch txpool content: %v", res.Err)
+		return len(pending), len(queued), fmt.Errorf("failed to fetch txpool content: %v", res.Err)
 	}
+
+	resp := b.Result.(map[string]interface{})
 
 	s, err := devnetutils.ParseResponse(b)
 	if err != nil {
-		return fmt.Errorf("error parsing resonse: %v", err)
+		return len(pending), len(queued), fmt.Errorf("error parsing resonse: %v", err)
+	}
+
+	if resp["pending"] != nil {
+		pending = resp["pending"].(map[string]interface{})
+	}
+	if resp["queue"] != nil {
+		queued = resp["queue"].(map[string]interface{})
 	}
 
 	fmt.Printf("Txpool content: %v\n", s)
-	return nil
+	return len(pending), len(queued), nil
 }

--- a/cmd/devnet/requests/tx.go
+++ b/cmd/devnet/requests/tx.go
@@ -2,6 +2,7 @@ package requests
 
 import (
 	"fmt"
+
 	"github.com/ledgerwatch/erigon/cmd/devnet/devnetutils"
 	"github.com/ledgerwatch/erigon/cmd/rpctest/rpctest"
 )

--- a/cmd/devnet/services/block.go
+++ b/cmd/devnet/services/block.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/holiman/uint256"
 	"github.com/ledgerwatch/erigon/cmd/devnet/devnetutils"
 	"github.com/ledgerwatch/erigon/cmd/devnet/models"
@@ -10,7 +12,6 @@ import (
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/params"
 	"github.com/ledgerwatch/erigon/rpc"
-	"time"
 )
 
 const gasPrice = 912345678

--- a/cmd/devnet/services/block.go
+++ b/cmd/devnet/services/block.go
@@ -1,12 +1,16 @@
 package services
 
 import (
+	"context"
 	"fmt"
 	"github.com/holiman/uint256"
+	"github.com/ledgerwatch/erigon/cmd/devnet/devnetutils"
 	"github.com/ledgerwatch/erigon/cmd/devnet/models"
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/params"
+	"github.com/ledgerwatch/erigon/rpc"
+	"time"
 )
 
 const gasPrice = 912345678
@@ -41,4 +45,25 @@ func createNonContractTx(addr string, value, nonce uint64) (*types.Transaction, 
 	}
 
 	return &signedTx, toAddress, nil
+}
+
+// txHashInBlock checks if the block with block number has the transaction hash in its list of transactions
+func txHashInBlock(client *rpc.Client, hash common.Hash, blockNumber string) (uint64, bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel() // releases the resources held by the context
+
+	var currBlock models.Block
+	err := client.CallContext(ctx, &currBlock, string(models.ETHGetBlockByNumber), blockNumber, false)
+	if err != nil {
+		return uint64(0), false, fmt.Errorf("failed to get block by number: %v", err)
+	}
+
+	for _, txnHash := range currBlock.Transactions {
+		if txnHash == hash {
+			fmt.Printf("SUCCESS => Tx with hash %q is in mined block with number %q\n", hash, blockNumber)
+			return devnetutils.HexToInt(blockNumber), true, nil
+		}
+	}
+
+	return uint64(0), false, nil
 }

--- a/cmd/devnet/services/event.go
+++ b/cmd/devnet/services/event.go
@@ -12,6 +12,7 @@ import (
 
 var subscriptionChan = make(chan interface{})
 
+// SearchBlockForTransactionHash looks for the given hash in the latest black using the eth_newHeads method
 func SearchBlockForTransactionHash(hash common.Hash) (uint64, error) {
 	client, err := rpc.DialWebsocket(context.Background(), fmt.Sprintf("ws://%s", models.Localhost), "")
 	if err != nil {
@@ -45,11 +46,11 @@ func subscribe(client *rpc.Client, method string, args ...interface{}) (*rpc.Cli
 }
 
 func subscribeToNewHeads(client *rpc.Client, hash common.Hash) (uint64, error) {
-	sub, err := subscribe(client, string(models.ETHNewHeads)) // TODO: put eth_newHeads in models
+	sub, err := subscribe(client, string(models.ETHNewHeads))
 	if err != nil {
 		return uint64(0), fmt.Errorf("error subscribing to newHeads: %v", err)
 	}
-	defer unSubscribe(sub)
+	defer unsubscribe(sub)
 
 	var (
 		blockCount int
@@ -79,7 +80,8 @@ mark:
 	return blockN, nil
 }
 
-func unSubscribe(sub *rpc.ClientSubscription) {
+// unsubscribe closes the client subscription and empties the global subscription channel
+func unsubscribe(sub *rpc.ClientSubscription) {
 	sub.Unsubscribe()
 	for len(subscriptionChan) > 0 {
 		<-subscriptionChan

--- a/cmd/devnet/services/event.go
+++ b/cmd/devnet/services/event.go
@@ -1,0 +1,87 @@
+package services
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ledgerwatch/erigon/cmd/devnet/devnetutils"
+	"github.com/ledgerwatch/erigon/cmd/devnet/models"
+	"github.com/ledgerwatch/erigon/common"
+	"github.com/ledgerwatch/erigon/rpc"
+)
+
+var subscriptionChan = make(chan interface{})
+
+func SearchBlockForTransactionHash(hash common.Hash) (uint64, error) {
+	client, err := rpc.DialWebsocket(context.Background(), fmt.Sprintf("ws://%s", models.Localhost), "")
+	if err != nil {
+		return 0, fmt.Errorf("failed to dial websocket: %v", err)
+	}
+
+	fmt.Printf("Searching for tx %q in new block...\n", hash)
+	blockN, err := subscribeToNewHeads(client, hash)
+	if err != nil {
+		return 0, fmt.Errorf("failed to subscribe to ws: %v", err)
+	}
+
+	return blockN, nil
+}
+
+// subscribe connects to a websocket client and returns the subscription handler and a channel buffer
+func subscribe(client *rpc.Client, method string, args ...interface{}) (*rpc.ClientSubscription, error) {
+	namespace, subMethod, err := devnetutils.NamespaceAndSubMethodFromMethod(method)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get namespace and submethod from method: %v", err)
+	}
+
+	arr := append([]interface{}{subMethod}, args...)
+
+	sub, err := client.Subscribe(context.Background(), namespace, subscriptionChan, arr...)
+	if err != nil {
+		return nil, fmt.Errorf("client failed to subscribe: %v", err)
+	}
+
+	return sub, nil
+}
+
+func subscribeToNewHeads(client *rpc.Client, hash common.Hash) (uint64, error) {
+	sub, err := subscribe(client, string(models.ETHNewHeads)) // TODO: put eth_newHeads in models
+	if err != nil {
+		return uint64(0), fmt.Errorf("error subscribing to newHeads: %v", err)
+	}
+	defer unSubscribe(sub)
+
+	var (
+		blockCount int
+		blockN     uint64
+	)
+
+mark:
+	for {
+		select {
+		case v := <-subscriptionChan:
+			blockCount++ // increment the number of blocks seen to check against the max number of blocks to iterate over
+			blockNumber := v.(map[string]interface{})["number"]
+			num, foundTx, err := txHashInBlock(client, hash, blockNumber.(string)) // check if the block has the transaction to look for inside of it
+			if err != nil {
+				return uint64(0), fmt.Errorf("could not verify if current block contains the tx hash: %v", err)
+			}
+			// if the tx is found or the max number of blocks to check is reached, break the tag
+			if foundTx || blockCount == models.MaxNumberOfBlockChecks {
+				blockN = num
+				break mark
+			}
+		case err := <-sub.Err():
+			return uint64(0), fmt.Errorf("subscription error from client: %v", err)
+		}
+	}
+
+	return blockN, nil
+}
+
+func unSubscribe(sub *rpc.ClientSubscription) {
+	sub.Unsubscribe()
+	for len(subscriptionChan) > 0 {
+		<-subscriptionChan
+	}
+}


### PR DESCRIPTION
- Added listening methods for WebSocket subscriptions 
- Listened for new blocks using the newHeads method to determine when to look for a transaction
- Added new util methods and tests for them
- Simplified communication to the user upon initiating the devnet tool