### PR TITLE
Only zero-gas transactions may be service ones

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -38,7 +38,8 @@ func applyTransaction(config *params.ChainConfig, engine consensus.Engine, gp *G
 	}
 	msg.SetCheckNonce(!cfg.StatelessExec)
 
-	if engine != nil {
+	if msg.FeeCap().IsZero() && engine != nil {
+		// Only zero-gas transactions may be service ones
 		syscall := func(contract common.Address, data []byte) ([]byte, error) {
 			return SysCallContract(contract, data, *config, ibs, header, engine, true /* constCall */)
 		}


### PR DESCRIPTION
Correction to PR #5873.

See [Nethermind's code](https://github.com/NethermindEth/nethermind/blob/1.14.5/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/TxCertifierFilter.cs#L57).