### PR TITLE
Block difficulty can be really big on Gnosis Chain

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -460,7 +460,7 @@ func (h *Header) SanityCheck() error {
 		return fmt.Errorf("too large block number: bitlen %d", h.Number.BitLen())
 	}
 	if h.Difficulty != nil {
-		if diffLen := h.Difficulty.BitLen(); diffLen > 80 {
+		if diffLen := h.Difficulty.BitLen(); diffLen > 192 {
 			return fmt.Errorf("too large block difficulty: bitlen %d", diffLen)
 		}
 	}


### PR DESCRIPTION
For example, see https://gnosisscan.io/block/24938312.

This fixes the following errors:
```
t=2022-11-11T12:39:01+0000 lvl=dbug msg="Handling incoming message" stream=RecvMessage err="newBlock66: too large block difficulty: bitlen 128"
t=2022-11-11T12:39:01+0000 lvl=dbug msg="Handling incoming message" stream=RecvMessage err="newBlock66: too large block difficulty: bitlen 128"
t=2022-11-11T12:39:01+0000 lvl=dbug msg="Handling incoming message" stream=RecvMessage err="newBlock66: too large block difficulty: bitlen 128"
```
