### PR TITLE
renamed LC to CL for clarity

### DIFF
--- a/cmd/lightclient/main.go
+++ b/cmd/lightclient/main.go
@@ -30,7 +30,7 @@ import (
 )
 
 func main() {
-	app := lightclientapp.MakeApp(runLightClientNode, flags.LightClientDefaultFlags)
+	app := lightclientapp.MakeApp(runLightClientNode, flags.ConsensusLayerDefaultFlags)
 	if err := app.Run(os.Args); err != nil {
 		_, printErr := fmt.Fprintln(os.Stderr, err)
 		if printErr != nil {
@@ -42,13 +42,13 @@ func main() {
 
 func runLightClientNode(cliCtx *cli.Context) {
 	ctx := context.Background()
-	lcCfg, err := lcCli.SetUpLightClientCfg(cliCtx)
+	lcCfg, err := lcCli.SetUpConsensusLayerCfg(cliCtx)
 	if err != nil {
 		log.Error("[Lightclient] Could not initialize lightclient", "err", err)
 	}
 	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(lcCfg.LogLvl), log.StderrHandler))
-	log.Info("[LightClient]", "chain", cliCtx.GlobalString(flags.LightClientChain.Name))
-	log.Info("[LightClient] Running lightclient", "cfg", lcCfg)
+	log.Info("[ConsensusLayer]", "chain", cliCtx.GlobalString(flags.ConsensusLayerChain.Name))
+	log.Info("[ConsensusLayer] Running lightclient", "cfg", lcCfg)
 	sentinel, err := service.StartSentinelService(&sentinel.SentinelConfig{
 		IpAddr:        lcCfg.Addr,
 		Port:          int(lcCfg.Port),

--- a/cmd/sentinel/cli/cliSettings.go
+++ b/cmd/sentinel/cli/cliSettings.go
@@ -8,7 +8,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-type LightClientCliCfg struct {
+type ConsensusLayerCliCfg struct {
 	GenesisCfg     *clparams.GenesisConfig     `json:"genesisCfg"`
 	BeaconCfg      *clparams.BeaconChainConfig `json:"beaconCfg"`
 	NetworkCfg     *clparams.NetworkConfig     `json:"networkCfg"`
@@ -22,23 +22,23 @@ type LightClientCliCfg struct {
 	CheckpointUri  string                      `json:"checkpointUri"`
 }
 
-func SetUpLightClientCfg(ctx *cli.Context) (*LightClientCliCfg, error) {
-	cfg := &LightClientCliCfg{}
-	chainName := ctx.GlobalString(flags.LightClientChain.Name)
+func SetUpConsensusLayerCfg(ctx *cli.Context) (*ConsensusLayerCliCfg, error) {
+	cfg := &ConsensusLayerCliCfg{}
+	chainName := ctx.GlobalString(flags.ConsensusLayerChain.Name)
 	var err error
 	var network clparams.NetworkType
 	cfg.GenesisCfg, cfg.NetworkCfg, cfg.BeaconCfg, network, err = clparams.GetConfigsByNetworkName(chainName)
 	if err != nil {
 		return nil, err
 	}
-	cfg.ServerAddr = fmt.Sprintf("%s:%d", ctx.GlobalString(flags.LightClientServerAddr.Name), ctx.GlobalInt(flags.LightClientServerPort.Name))
-	cfg.ServerProtocol = ServerProtocolFromInt(ctx.GlobalUint(flags.LightClientServerProtocol.Name))
+	cfg.ServerAddr = fmt.Sprintf("%s:%d", ctx.GlobalString(flags.ConsensusLayerServerAddr.Name), ctx.GlobalInt(flags.ConsensusLayerServerPort.Name))
+	cfg.ServerProtocol = ServerProtocolFromInt(ctx.GlobalUint(flags.ConsensusLayerServerProtocol.Name))
 
-	cfg.Port = uint(ctx.GlobalInt(flags.LightClientPort.Name))
-	cfg.Addr = ctx.GlobalString(flags.LightClientAddr.Name)
+	cfg.Port = uint(ctx.GlobalInt(flags.ConsensusLayerPort.Name))
+	cfg.Addr = ctx.GlobalString(flags.ConsensusLayerAddr.Name)
 
-	cfg.LogLvl = ctx.GlobalUint(flags.LightClientVerbosity.Name)
-	cfg.NoDiscovery = !ctx.GlobalBoolT(flags.LightClientDiscovery.Name)
+	cfg.LogLvl = ctx.GlobalUint(flags.ConsensusLayerVerbosity.Name)
+	cfg.NoDiscovery = !ctx.GlobalBoolT(flags.ConsensusLayerDiscovery.Name)
 	cfg.CheckpointUri = clparams.GetCheckpointSyncEndpoint(network)
 	return cfg, nil
 }

--- a/cmd/sentinel/cli/flags/defaultFlags.go
+++ b/cmd/sentinel/cli/flags/defaultFlags.go
@@ -2,14 +2,14 @@ package flags
 
 import "github.com/urfave/cli"
 
-var LightClientDefaultFlags = []cli.Flag{
-	LightClientPort,
-	LightClientAddr,
-	LightClientTcpPort,
-	LightClientVerbosity,
-	LightClientChain,
-	LightClientServerAddr,
-	LightClientServerPort,
-	LightClientServerProtocol,
-	LightClientDiscovery,
+var ConsensusLayerDefaultFlags = []cli.Flag{
+	ConsensusLayerPort,
+	ConsensusLayerAddr,
+	ConsensusLayerTcpPort,
+	ConsensusLayerVerbosity,
+	ConsensusLayerChain,
+	ConsensusLayerServerAddr,
+	ConsensusLayerServerPort,
+	ConsensusLayerServerProtocol,
+	ConsensusLayerDiscovery,
 }

--- a/cmd/sentinel/cli/flags/flags.go
+++ b/cmd/sentinel/cli/flags/flags.go
@@ -3,48 +3,48 @@ package flags
 import "github.com/urfave/cli"
 
 var (
-	LightClientPort = cli.IntFlag{
-		Name:  "lc.port",
-		Usage: "sets the lightclient port",
+	ConsensusLayerPort = cli.IntFlag{
+		Name:  "cl.port",
+		Usage: "sets the consensus layer port",
 		Value: 8080,
 	}
-	LightClientAddr = cli.StringFlag{
-		Name:  "lc.addr",
-		Usage: "sets the lightclient host addr",
+	ConsensusLayerAddr = cli.StringFlag{
+		Name:  "cl.addr",
+		Usage: "sets the consensus layer host addr",
 		Value: "127.0.0.1",
 	}
-	LightClientTcpPort = cli.UintFlag{
+	ConsensusLayerTcpPort = cli.UintFlag{
 		Name:  "lc.tcp.port",
-		Usage: "sets lightclient tcp port",
+		Usage: "sets consensus layer tcp port",
 		Value: 9000,
 	}
-	LightClientVerbosity = cli.UintFlag{
+	ConsensusLayerVerbosity = cli.UintFlag{
 		Name:  "lc.verbosity",
-		Usage: "specify lightclient verbosity level 0=silent, 1=err, 2=warn, 3=info, 4=debug, 5=details",
+		Usage: "specify consensus layer verbosity level 0=silent, 1=err, 2=warn, 3=info, 4=debug, 5=details",
 		Value: 3,
 	}
-	LightClientServerPort = cli.IntFlag{
+	ConsensusLayerServerPort = cli.IntFlag{
 		Name:  "lc.server.port",
-		Usage: "sets the lightclient server port",
+		Usage: "sets the consensus layer server port",
 		Value: 7777,
 	}
-	LightClientServerAddr = cli.StringFlag{
+	ConsensusLayerServerAddr = cli.StringFlag{
 		Name:  "lc.server.addr",
-		Usage: "sets the lightclient server host addr",
+		Usage: "sets the consensus layer server host addr",
 		Value: "localhost",
 	}
-	LightClientServerProtocol = cli.UintFlag{
+	ConsensusLayerServerProtocol = cli.UintFlag{
 		Name:  "lc.server.protocol",
-		Usage: "sets the lightclient server protocol 1=tcp 2=udp",
+		Usage: "sets the consensus layer server protocol 1=tcp 2=udp",
 		Value: 1,
 	}
-	LightClientChain = cli.StringFlag{
+	ConsensusLayerChain = cli.StringFlag{
 		Name:  "lc.chain",
-		Usage: "sets the chain specs for the lightclient",
+		Usage: "sets the chain specs for the consensus layer",
 		Value: "mainnet",
 	}
-	LightClientDiscovery = cli.BoolTFlag{
+	ConsensusLayerDiscovery = cli.BoolTFlag{
 		Name:  "lc.discover",
-		Usage: "turn off or on the lightclient finding peers",
+		Usage: "turn off or on the consensus layer finding peers",
 	}
 )

--- a/cmd/sentinel/cli/flags/flags.go
+++ b/cmd/sentinel/cli/flags/flags.go
@@ -14,37 +14,37 @@ var (
 		Value: "127.0.0.1",
 	}
 	ConsensusLayerTcpPort = cli.UintFlag{
-		Name:  "lc.tcp.port",
+		Name:  "cl.tcp.port",
 		Usage: "sets consensus layer tcp port",
 		Value: 9000,
 	}
 	ConsensusLayerVerbosity = cli.UintFlag{
-		Name:  "lc.verbosity",
+		Name:  "cl.verbosity",
 		Usage: "specify consensus layer verbosity level 0=silent, 1=err, 2=warn, 3=info, 4=debug, 5=details",
 		Value: 3,
 	}
 	ConsensusLayerServerPort = cli.IntFlag{
-		Name:  "lc.server.port",
+		Name:  "cl.server.port",
 		Usage: "sets the consensus layer server port",
 		Value: 7777,
 	}
 	ConsensusLayerServerAddr = cli.StringFlag{
-		Name:  "lc.server.addr",
+		Name:  "cl.server.addr",
 		Usage: "sets the consensus layer server host addr",
 		Value: "localhost",
 	}
 	ConsensusLayerServerProtocol = cli.UintFlag{
-		Name:  "lc.server.protocol",
+		Name:  "cl.server.protocol",
 		Usage: "sets the consensus layer server protocol 1=tcp 2=udp",
 		Value: 1,
 	}
 	ConsensusLayerChain = cli.StringFlag{
-		Name:  "lc.chain",
+		Name:  "cl.chain",
 		Usage: "sets the chain specs for the consensus layer",
 		Value: "mainnet",
 	}
 	ConsensusLayerDiscovery = cli.BoolTFlag{
-		Name:  "lc.discover",
+		Name:  "cl.discover",
 		Usage: "turn off or on the consensus layer finding peers",
 	}
 )

--- a/cmd/sentinel/main.go
+++ b/cmd/sentinel/main.go
@@ -38,7 +38,7 @@ import (
 )
 
 func main() {
-	app := sentinelapp.MakeApp(runSentinelNode, flags.LightClientDefaultFlags)
+	app := sentinelapp.MakeApp(runSentinelNode, flags.ConsensusLayerDefaultFlags)
 	if err := app.Run(os.Args); err != nil {
 		_, printErr := fmt.Fprintln(os.Stderr, err)
 		if printErr != nil {
@@ -74,7 +74,7 @@ func constructRequest(t string, reqBody cltypes.ObjectSSZ) (*consensusrpc.Reques
 }
 
 func runSentinelNode(cliCtx *cli.Context) {
-	lcCfg, _ := lcCli.SetUpLightClientCfg(cliCtx)
+	lcCfg, _ := lcCli.SetUpConsensusLayerCfg(cliCtx)
 	ctx := context.Background()
 
 	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(lcCfg.LogLvl), log.StderrHandler))
@@ -103,12 +103,12 @@ func runSentinelNode(cliCtx *cli.Context) {
 
 	log.Info("Sending test request")
 	/*
-		sendRequest(ctx, s, constructBodyFreeRequest(handlers.LightClientFinalityUpdateV1))
+		sendRequest(ctx, s, constructBodyFreeRequest(handlers.ConsensusLayerFinalityUpdateV1))
 		sendRequest(ctx, s, constructBodyFreeRequest(handlers.MetadataProtocolV1))
 		sendRequest(ctx, s, constructBodyFreeRequest(handlers.MetadataProtocolV2))
-		sendRequest(ctx, s, constructBodyFreeRequest(handlers.LightClientOptimisticUpdateV1))
+		sendRequest(ctx, s, constructBodyFreeRequest(handlers.ConsensusLayerOptimisticUpdateV1))
 
-		lcUpdateReq := &cltypes.LightClientUpdatesByRangeRequest{
+		lcUpdateReq := &cltypes.ConsensusLayerUpdatesByRangeRequest{
 			Period: 604,
 			Count:  1,
 		}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -726,19 +726,19 @@ var (
 		Usage: "Sets erigon flags from YAML/TOML file",
 		Value: "",
 	}
-	LightClientDiscoveryAddrFlag = cli.StringFlag{
-		Name:  "lightclient.discovery.addr",
-		Usage: "Address for lightclient DISCV5 protocol",
+	ConsensusLayerDiscoveryAddrFlag = cli.StringFlag{
+		Name:  "cl.discovery.addr",
+		Usage: "Address for consensus layer DISCV5 protocol",
 		Value: "127.0.0.1",
 	}
-	LightClientDiscoveryPortFlag = cli.Uint64Flag{
-		Name:  "lightclient.discovery.port",
-		Usage: "Port for lightclient DISCV5 protocol",
+	ConsensusLayerDiscoveryPortFlag = cli.Uint64Flag{
+		Name:  "cl.discovery.port",
+		Usage: "Port for consensus layer DISCV5 protocol",
 		Value: 4000,
 	}
-	LightClientDiscoveryTCPPortFlag = cli.Uint64Flag{
-		Name:  "lightclient.discovery.tcpport",
-		Usage: "TCP Port for lightclient DISCV5 protocol",
+	ConsensusLayerDiscoveryTCPPortFlag = cli.Uint64Flag{
+		Name:  "cl.discovery.tcpport",
+		Usage: "TCP Port for consensus layer DISCV5 protocol",
 		Value: 4001,
 	}
 	SentinelAddrFlag = cli.StringFlag{
@@ -1453,9 +1453,9 @@ func CheckExclusive(ctx *cli.Context, args ...interface{}) {
 // SetEthConfig applies eth-related command line flags to the config.
 func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.Config) {
 	cfg.CL = ctx.GlobalBool(ExternalConsensusFlag.Name)
-	cfg.LightClientDiscoveryAddr = ctx.GlobalString(LightClientDiscoveryAddrFlag.Name)
-	cfg.LightClientDiscoveryPort = ctx.GlobalUint64(LightClientDiscoveryPortFlag.Name)
-	cfg.LightClientDiscoveryTCPPort = ctx.GlobalUint64(LightClientDiscoveryTCPPortFlag.Name)
+	cfg.ConsensusLayerDiscoveryAddr = ctx.GlobalString(ConsensusLayerDiscoveryAddrFlag.Name)
+	cfg.ConsensusLayerDiscoveryPort = ctx.GlobalUint64(ConsensusLayerDiscoveryPortFlag.Name)
+	cfg.ConsensusLayerDiscoveryTCPPort = ctx.GlobalUint64(ConsensusLayerDiscoveryTCPPortFlag.Name)
 	cfg.SentinelAddr = ctx.GlobalString(SentinelAddrFlag.Name)
 	cfg.SentinelPort = ctx.GlobalUint64(SentinelPortFlag.Name)
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -482,9 +482,9 @@ func New(stack *node.Node, config *ethconfig.Config, logger log.Logger) (*Ethere
 			return nil, err
 		}
 		client, err := service.StartSentinelService(&sentinel.SentinelConfig{
-			IpAddr:        config.LightClientDiscoveryAddr,
-			Port:          int(config.LightClientDiscoveryPort),
-			TCPPort:       uint(config.LightClientDiscoveryTCPPort),
+			IpAddr:        config.ConsensusLayerDiscoveryAddr,
+			Port:          int(config.ConsensusLayerDiscoveryPort),
+			TCPPort:       uint(config.ConsensusLayerDiscoveryTCPPort),
 			GenesisConfig: genesisCfg,
 			NetworkConfig: networkCfg,
 			BeaconConfig:  beaconCfg,

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -236,12 +236,12 @@ type Config struct {
 	// Ethstats service
 	Ethstats string
 	// ConsenSUS layer
-	CL                          bool
-	LightClientDiscoveryAddr    string
-	LightClientDiscoveryPort    uint64
-	LightClientDiscoveryTCPPort uint64
-	SentinelAddr                string
-	SentinelPort                uint64
+	CL                             bool
+	ConsensusLayerDiscoveryAddr    string
+	ConsensusLayerDiscoveryPort    uint64
+	ConsensusLayerDiscoveryTCPPort uint64
+	SentinelAddr                   string
+	SentinelPort                   uint64
 
 	// FORK_NEXT_VALUE (see EIP-3675) block override
 	OverrideMergeNetsplitBlock *big.Int `toml:",omitempty"`

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -149,9 +149,9 @@ var DefaultFlags = []cli.Flag{
 	logging.LogJsonFlag,
 	logging.LogDirJsonFlag,
 
-	utils.LightClientDiscoveryAddrFlag,
-	utils.LightClientDiscoveryPortFlag,
-	utils.LightClientDiscoveryTCPPortFlag,
+	utils.ConsensusLayerDiscoveryAddrFlag,
+	utils.ConsensusLayerDiscoveryPortFlag,
+	utils.ConsensusLayerDiscoveryTCPPortFlag,
 	utils.SentinelAddrFlag,
 	utils.SentinelPortFlag,
 }


### PR DESCRIPTION
Some people get confused with "lc" in the flags not knowing it is LightClient and part of the CL so I have renamed it to "cl"