### PR TITLE
Restore MigrateFlags

### DIFF
--- a/turbo/app/import.go
+++ b/turbo/app/import.go
@@ -30,7 +30,7 @@ const (
 )
 
 var importCommand = cli.Command{
-	Action:    importChain,
+	Action:    MigrateFlags(importChain),
 	Name:      "import",
 	Usage:     "Import a blockchain file",
 	ArgsUsage: "<filename> (<filename 2> ... <filename N>) ",

--- a/turbo/app/init.go
+++ b/turbo/app/init.go
@@ -14,7 +14,7 @@ import (
 )
 
 var initCommand = cli.Command{
-	Action:    initGenesis,
+	Action:    MigrateFlags(initGenesis),
 	Name:      "init",
 	Usage:     "Bootstrap and initialize a new genesis block",
 	ArgsUsage: "<genesisPath>",

--- a/turbo/app/make_app.go
+++ b/turbo/app/make_app.go
@@ -2,6 +2,8 @@
 package app
 
 import (
+	"strings"
+
 	"github.com/urfave/cli/v2"
 
 	"github.com/ledgerwatch/erigon/cmd/utils"
@@ -31,6 +33,63 @@ func MakeApp(action cli.ActionFunc, cliFlags []cli.Flag) *cli.App {
 	}
 	app.Commands = []*cli.Command{&initCommand, &importCommand, &snapshotCommand}
 	return app
+}
+
+// MigrateFlags makes all global flag values available in the
+// context. This should be called as early as possible in app.Before.
+//
+// Example:
+//
+//	geth account new --keystore /tmp/mykeystore --lightkdf
+//
+// is equivalent after calling this method with:
+//
+//	geth --keystore /tmp/mykeystore --lightkdf account new
+//
+// i.e. in the subcommand Action function of 'account new', ctx.Bool("lightkdf)
+// will return true even if --lightkdf is set as a global option.
+//
+// This function may become unnecessary when https://github.com/urfave/cli/pull/1245 is merged.
+func MigrateFlags(action cli.ActionFunc) cli.ActionFunc {
+	return func(ctx *cli.Context) error {
+		doMigrateFlags(ctx)
+		return action(ctx)
+	}
+}
+
+func doMigrateFlags(ctx *cli.Context) {
+	// Figure out if there are any aliases of commands. If there are, we want
+	// to ignore them when iterating over the flags.
+	var aliases = make(map[string]bool)
+	for _, fl := range ctx.Command.Flags {
+		for _, alias := range fl.Names()[1:] {
+			aliases[alias] = true
+		}
+	}
+	for _, name := range ctx.FlagNames() {
+		for _, parent := range ctx.Lineage()[1:] {
+			if parent.IsSet(name) {
+				// When iterating across the lineage, we will be served both
+				// the 'canon' and alias formats of all commands. In most cases,
+				// it's fine to set it in the ctx multiple times (one for each
+				// name), however, the Slice-flags are not fine.
+				// The slice-flags accumulate, so if we set it once as
+				// "foo" and once as alias "F", then both will be present in the slice.
+				if _, isAlias := aliases[name]; isAlias {
+					continue
+				}
+				// If it is a string-slice, we need to set it as
+				// "alfa, beta, gamma" instead of "[alfa beta gamma]", in order
+				// for the backing StringSlice to parse it properly.
+				if result := parent.StringSlice(name); len(result) > 0 {
+					ctx.Set(name, strings.Join(result, ","))
+				} else {
+					ctx.Set(name, parent.String(name))
+				}
+				break
+			}
+		}
+	}
 }
 
 func NewNodeConfig(ctx *cli.Context) *nodecfg.Config {


### PR DESCRIPTION
Another postfix to PR #6047. This fixes `--datadir` flag passed to `erigon init`. See also https://github.com/ethereum/go-ethereum/pull/24751.