### PR TITLE
added miner address extracting for Bor in block api response

### DIFF
--- a/cmd/rpcdaemon/commands/eth_block.go
+++ b/cmd/rpcdaemon/commands/eth_block.go
@@ -223,7 +223,9 @@ func (api *APIImpl) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber
 	}
 
 	response, err := ethapi.RPCMarshalBlockEx(b, true, fullTx, borTx, borTxHash, additionalFields)
-
+	if chainConfig.Bor != nil {
+		response["miner"], _ = ecrecover(b.Header(), chainConfig.Bor)
+	}
 	if err == nil && number == rpc.PendingBlockNumber {
 		// Pending blocks need to nil out a few fields
 		for _, field := range []string{"hash", "nonce", "miner"} {
@@ -283,6 +285,10 @@ func (api *APIImpl) GetBlockByHash(ctx context.Context, numberOrHash rpc.BlockNu
 	}
 
 	response, err := ethapi.RPCMarshalBlockEx(block, true, fullTx, borTx, borTxHash, additionalFields)
+
+	if chainConfig.Bor != nil {
+		response["miner"], _ = ecrecover(block.Header(), chainConfig.Bor)
+	}
 
 	if err == nil && int64(number) == rpc.PendingBlockNumber.Int64() {
 		// Pending blocks need to nil out a few fields


### PR DESCRIPTION
This PR adds correct miner address to the response of `eth_getBlockByNumber`/`eth_getBlockByHash` API methods.

Currently miner address is returned as zero address (`0x000...000`) for Polygon - https://wiki.polygon.technology/docs/edge/faq/validators/#why-do-the-json-rpc-commands-eth_getblockbynumber-and-eth_getblockbyhash-not-return-the-miners-address .
Unfortunately this behaviour confuses a lot, I've succeeded in restoring the miner address in block related API, want this to be the default behaviour.