### PR TITLE
Add Status fetching and made sentinel request logic generic

### DIFF
--- a/cmd/erigon-cl/cl-core/syncfromcheckpoint.go
+++ b/cmd/erigon-cl/cl-core/syncfromcheckpoint.go
@@ -12,39 +12,101 @@ import (
 	"github.com/ledgerwatch/log/v3"
 )
 
-func GetCheckpointBlock(ctx context.Context, sc consensusrpc.SentinelClient, cp *cltypes.BeaconState, fd [4]byte) (*cltypes.SignedBeaconBlockBellatrix, error) {
-	// Request for blocks by root given the finalized checkpoint root.
-	finalizedRootSlice := [][32]byte{cp.FinalizedCheckpoint.Root}
+type sentinelRequestOpts struct {
+	respChan chan cltypes.ObjectSSZ
+	errChan  chan error
+	req      interface{}
+	sc       consensusrpc.SentinelClient
+}
 
+type singleReq func(context.Context, sentinelRequestOpts)
+
+func sendSentinelRequest(ctx context.Context, srFn singleReq, opts sentinelRequestOpts) (cltypes.ObjectSSZ, error) {
 	newReqTicker := time.NewTicker(1000 * time.Millisecond)
-
-	respChan := make(chan *cltypes.SignedBeaconBlockBellatrix)
+	respChan := make(chan cltypes.ObjectSSZ)
 	errChan := make(chan error)
+	opts.respChan = respChan
+	opts.errChan = errChan
 	for {
 		select {
 		case <-newReqTicker.C:
-			go func() {
-				log.Info("Getting checkpoint block by root", "root", hex.EncodeToString(cp.FinalizedCheckpoint.Root[:]))
-				resp, err := rpc.SendBeaconBlocksByRootReq(ctx, finalizedRootSlice, sc)
-				if err != nil {
-					errChan <- err
-					return
-				}
-				if len(resp) != 1 {
-					errChan <- fmt.Errorf("unexpected response length, got %d want %d", len(resp), 1)
-					return
-				}
-				result, ok := resp[0].(*cltypes.SignedBeaconBlockBellatrix)
-				if !ok {
-					errChan <- fmt.Errorf("unable to cast object: %+v into block", resp[0])
-				}
-				respChan <- result
-			}()
+			go srFn(ctx, opts)
 		case err := <-errChan:
 			log.Error("Error received from peer", "error", err)
-		case block := <-respChan:
-			log.Info("Block received by root")
-			return block, nil
+		case resp := <-respChan:
+			log.Info("Response received.")
+			return resp, nil
 		}
 	}
+}
+
+func GetCheckpointBlock(ctx context.Context, sc consensusrpc.SentinelClient, cp *cltypes.BeaconState) (*cltypes.SignedBeaconBlockBellatrix, error) {
+	root := cp.FinalizedCheckpoint.Root
+	log.Info("Getting checkpoint block by root", "root", hex.EncodeToString(root[:]))
+
+	// Send request
+	resp, err := sendSentinelRequest(ctx, getCPBlockSRFn, sentinelRequestOpts{
+		req: root,
+		sc:  sc,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unexpected error sending sentinel request: %v", err)
+	}
+	ret, ok := resp.(*cltypes.SignedBeaconBlockBellatrix)
+	if !ok {
+		return nil, fmt.Errorf("unable to cast response to type: %+v", resp)
+	}
+	return ret, nil
+}
+
+func getCPBlockSRFn(ctx context.Context, opts sentinelRequestOpts) {
+	// Assert that the request is a single root.
+	root := opts.req.([32]byte)
+
+	log.Info("Getting checkpoint block by root", "root", hex.EncodeToString(root[:]))
+	finalizedRootSlice := [][32]byte{root}
+	// Request for blocks by root given the finalized checkpoint root.
+	resp, err := rpc.SendBeaconBlocksByRootReq(ctx, finalizedRootSlice, opts.sc)
+	if err != nil {
+		opts.errChan <- err
+		return
+	}
+	if len(resp) != 1 {
+		opts.errChan <- fmt.Errorf("unexpected response length, got %d want %d", len(resp), 1)
+		return
+	}
+	result, ok := resp[0].(*cltypes.SignedBeaconBlockBellatrix)
+	if !ok {
+		opts.errChan <- fmt.Errorf("unable to cast object: %+v into block", resp[0])
+	}
+	opts.respChan <- result
+}
+
+func GetStatus(ctx context.Context, sc consensusrpc.SentinelClient, req *cltypes.Status) (*cltypes.Status, error) {
+	// Send request
+	resp, err := sendSentinelRequest(ctx, getStatusSRFn, sentinelRequestOpts{
+		req: req,
+		sc:  sc,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unexpected error sending sentinel request: %v", err)
+	}
+	ret, ok := resp.(*cltypes.Status)
+	if !ok {
+		return nil, fmt.Errorf("unable to cast response to type: %+v", resp)
+	}
+	return ret, nil
+}
+
+func getStatusSRFn(ctx context.Context, opts sentinelRequestOpts) {
+	// Assert that the request is a single root.
+	req := opts.req.(*cltypes.Status)
+
+	log.Info("Getting status for epoch", "epoch", req.FinalizedEpoch)
+	resp, err := rpc.SendStatusReq(ctx, req, opts.sc)
+	if err != nil {
+		opts.errChan <- err
+		return
+	}
+	opts.respChan <- resp
 }


### PR DESCRIPTION
Part of https://github.com/ledgerwatch/erigon/issues/5965.

An example logging output shows that we are getting accurate data:

the current finalized checkpoint block: https://beaconcha.in/slot/5180288
the current head block: https://beaconcha.in/slot/5180361

```
INFO[11-20|16:52:36.631] Retrieved status.                        status="&{ForkDigest:[74 38 197 139] FinalizedRoot:[133 83 36 34 8 25 208 12 77 180 192 189 151 179 237 244 192 20 216 226 40 178 142 28 242 91 4 66 250 58 200 92] FinalizedEpoch:161884 HeadRoot:[164 219 216 224 200 71 201 76 70 253 61 144 64 238 11 14 224 173 49 5 107 109 238 32 215 126 85 23 10 170 107 223] HeadSlot:5180361}"
INFO[11-20|16:52:36.631] Current finalized root.                  root=855324220819d00c4db4c0bd97b3edf4c014d8e228b28e1cf25b0442fa3ac85c
INFO[11-20|16:52:36.631] Current finalized epoch.                 epoch=161884
INFO[11-20|16:52:36.631] Current head root.                       root=a4dbd8e0c847c94c46fd3d9040ee0b0ee0ad31056b6dee20d77e55170aaa6bdf
INFO[11-20|16:52:36.631] Current head slot.                       slot=5180361
```