### PR TITLE
consensus/bor: return txs and receipts in FinalizeAndAssemble

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -817,7 +817,7 @@ func (c *Bor) FinalizeAndAssemble(chainConfig *params.ChainConfig, header *types
 	// bc.SetStateSync(stateSyncData)
 
 	// return the final block for sealing
-	return block, nil, types.Receipts{}, nil
+	return block, txs, receipts, nil
 }
 
 func (c *Bor) GenerateSeal(chain consensus.ChainHeaderReader, currnt, parent *types.Header, call consensus.Call) []byte {


### PR DESCRIPTION
Due to a change in a previous [commit](https://github.com/ledgerwatch/erigon/pull/5212/files#diff-335eb65f5a52a99fd4cb182ce6385022828dfc04118b85336754d5a142f45be7R134), the txs and receipts are overridden. This breaks compatibility with bor consensus as the `bor.FinalizeAndAssemble` method returns nil txs and receipts. This PR fixes that. 