### PR TITLE
Update consensus tests to v11.2

### DIFF
--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -30,7 +30,6 @@ import (
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/core/state"
 	"github.com/ledgerwatch/erigon/core/vm"
-	"github.com/ledgerwatch/erigon/params"
 	"github.com/ledgerwatch/erigon/tests"
 	"github.com/ledgerwatch/erigon/turbo/trie"
 )
@@ -131,7 +130,7 @@ func aggregateResultsFromStateTests(
 			var root common.Hash
 			var calcRootErr error
 
-			statedb, err := test.Run(&params.Rules{}, tx, st, cfg)
+			statedb, err := test.Run(tx, st, cfg)
 			// print state root for evmlab tracing
 			root, calcRootErr = trie.CalcRoot("", tx)
 			if err == nil && calcRootErr != nil {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -388,6 +388,7 @@ func (st *StateTransition) TransitionDb(refunds bool, gasBailout bool) (*Executi
 	sender := vm.AccountRef(msg.From())
 	contractCreation := msg.To() == nil
 	rules := st.evm.ChainRules()
+	vmConfig := st.evm.Config()
 
 	if rules.IsNano {
 		for _, blackListAddr := range types.NanoBlackList {
@@ -419,7 +420,7 @@ func (st *StateTransition) TransitionDb(refunds bool, gasBailout bool) (*Executi
 	}
 
 	// Check whether the init code size has been exceeded.
-	if rules.IsShanghai && contractCreation && len(st.data) > params.MaxInitCodeSize {
+	if vmConfig.HasEip3860(rules) && contractCreation && len(st.data) > params.MaxInitCodeSize {
 		return nil, fmt.Errorf("%w: code size %v limit %v", ErrMaxInitCodeSizeExceeded, len(st.data), params.MaxInitCodeSize)
 	}
 

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -361,7 +361,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 		return nil, common.Address{}, 0, err
 	}
 	// Check whether the init code size has been exceeded.
-	if evm.chainRules.IsShanghai && len(codeAndHash.code) > params.MaxInitCodeSize {
+	if evm.config.HasEip3860(evm.chainRules) && len(codeAndHash.code) > params.MaxInitCodeSize {
 		return nil, address, gas, ErrMaxInitCodeSizeExceeded
 	}
 	// Create a new account on the state

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -20,10 +20,12 @@ import (
 	"hash"
 	"sync/atomic"
 
+	"github.com/ledgerwatch/log/v3"
+
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/common/math"
 	"github.com/ledgerwatch/erigon/core/vm/stack"
-	"github.com/ledgerwatch/log/v3"
+	"github.com/ledgerwatch/erigon/params"
 )
 
 // Config are the configuration options for the Interpreter
@@ -40,6 +42,15 @@ type Config struct {
 	RestoreState  bool   // Revert all changes made to the state (useful for constant system calls)
 
 	ExtraEips []int // Additional EIPS that are to be enabled
+}
+
+func (vmConfig *Config) HasEip3860(rules *params.Rules) bool {
+	for _, eip := range vmConfig.ExtraEips {
+		if eip == 3860 {
+			return true
+		}
+	}
+	return rules.IsShanghai
 }
 
 // Interpreter is used to run Ethereum based contracts and will utilise the

--- a/eth/tracers/tracer.go
+++ b/eth/tracers/tracer.go
@@ -599,9 +599,10 @@ func (jst *Tracer) CaptureStart(env *vm.EVM, depth int, from common.Address, to 
 	jst.dbWrapper.db = env.IntraBlockState()
 	// Compute intrinsic gas
 	isHomestead := env.ChainConfig().IsHomestead(env.Context().BlockNumber)
-	isIstanbul := env.ChainConfig().IsIstanbul(env.Context().BlockNumber)
-	isShanghai := env.ChainConfig().IsShanghai(env.Context().BlockNumber)
-	intrinsicGas, err := core.IntrinsicGas(input, nil, jst.ctx["type"] == "CREATE", isHomestead, isIstanbul, isShanghai)
+	isEIP2028 := env.ChainConfig().IsIstanbul(env.Context().BlockNumber)
+	vmConfig := env.Config()
+	isEIP3860 := vmConfig.HasEip3860(env.ChainRules())
+	intrinsicGas, err := core.IntrinsicGas(input, nil, jst.ctx["type"] == "CREATE", isHomestead, isEIP2028, isEIP3860)
 	if err != nil {
 		return
 	}

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -42,6 +42,9 @@ func TestState(t *testing.T) {
 
 	st := new(testMatcher)
 
+	// EOF is not implemented yet
+	st.skipLoad(`^stEIP3540/`)
+
 	// Very time consuming
 	st.skipLoad(`^stTimeConsuming/`)
 	st.skipLoad(`.*vmPerformance/loop.*`)

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -56,17 +56,12 @@ func TestState(t *testing.T) {
 			key := fmt.Sprintf("%s/%d", subtest.Fork, subtest.Index)
 			t.Run(key, func(t *testing.T) {
 				withTrace(t, func(vmconfig vm.Config) error {
-					config, ok := Forks[subtest.Fork]
-					if !ok {
-						return UnsupportedForkError{subtest.Fork}
-					}
-					rules := config.Rules(1)
 					tx, err := db.BeginRw(context.Background())
 					if err != nil {
 						t.Fatal(err)
 					}
 					defer tx.Rollback()
-					_, err = test.Run(rules, tx, subtest, vmconfig)
+					_, err = test.Run(tx, subtest, vmconfig)
 					tx.Rollback()
 					if err != nil && len(test.json.Post[subtest.Fork][subtest.Index].ExpectException) > 0 {
 						// Ignore expected errors

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -165,8 +165,8 @@ func (t *StateTest) Subtests() []StateSubtest {
 }
 
 // Run executes a specific subtest and verifies the post-state and logs
-func (t *StateTest) Run(rules *params.Rules, tx kv.RwTx, subtest StateSubtest, vmconfig vm.Config) (*state.IntraBlockState, error) {
-	state, root, err := t.RunNoVerify(rules, tx, subtest, vmconfig)
+func (t *StateTest) Run(tx kv.RwTx, subtest StateSubtest, vmconfig vm.Config) (*state.IntraBlockState, error) {
+	state, root, err := t.RunNoVerify(tx, subtest, vmconfig)
 	if err != nil {
 		return state, err
 	}
@@ -183,7 +183,7 @@ func (t *StateTest) Run(rules *params.Rules, tx kv.RwTx, subtest StateSubtest, v
 }
 
 // RunNoVerify runs a specific subtest and returns the statedb and post-state root
-func (t *StateTest) RunNoVerify(rules *params.Rules, tx kv.RwTx, subtest StateSubtest, vmconfig vm.Config) (*state.IntraBlockState, common.Hash, error) {
+func (t *StateTest) RunNoVerify(tx kv.RwTx, subtest StateSubtest, vmconfig vm.Config) (*state.IntraBlockState, common.Hash, error) {
 	config, eips, err := GetChainConfig(subtest.Fork)
 	if err != nil {
 		return nil, common.Hash{}, UnsupportedForkError{subtest.Fork}


### PR DESCRIPTION
[v11.2](https://github.com/ethereum/tests/releases/tag/v11.2) includes, among other things, tests for [EIP-3860](https://eips.ethereum.org/EIPS/eip-3860): Limit and meter initcode.