### PR TITLE
reusable evm caller for purpose of eth_estimateGas

### DIFF
--- a/cmd/rpcdaemon/commands/eth_call.go
+++ b/cmd/rpcdaemon/commands/eth_call.go
@@ -66,7 +66,8 @@ func (api *APIImpl) Call(ctx context.Context, args ethapi2.CallArgs, blockNrOrHa
 	if err != nil {
 		return nil, err
 	}
-	result, err := transactions.DoCall(ctx, args, tx, blockNrOrHash, block, overrides, api.GasCap, chainConfig, stateReader, api._blockReader, api.evmCallTimeout)
+	header := block.HeaderNoCopy()
+	result, err := transactions.DoCall(ctx, args, tx, blockNrOrHash, header, overrides, api.GasCap, chainConfig, stateReader, api._blockReader, api.evmCallTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -236,12 +237,16 @@ func (api *APIImpl) EstimateGas(ctx context.Context, argsOrNil *ethapi2.CallArgs
 	if err != nil {
 		return 0, err
 	}
+	header := block.HeaderNoCopy()
+
+	caller, err := transactions.NewReusableCaller(stateReader, nil, header, args, api.GasCap, latestNumOrHash, dbtx, api._blockReader, chainConfig, api.evmCallTimeout)
+	if err != nil {
+		return 0, err
+	}
 
 	// Create a helper to check if a gas allowance results in an executable transaction
 	executable := func(gas uint64) (bool, *core.ExecutionResult, error) {
-		args.Gas = (*hexutil.Uint64)(&gas)
-
-		result, err := transactions.DoCall(ctx, args, dbtx, latestNumOrHash, block, nil, api.GasCap, chainConfig, stateReader, api._blockReader, api.evmCallTimeout)
+		result, err := caller.DoCallWithNewGas(ctx, gas)
 		if err != nil {
 			if errors.Is(err, core.ErrIntrinsicGas) {
 				// Special case, raise gas limit

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -27,7 +27,10 @@ import (
 	"time"
 
 	"github.com/holiman/uint256"
+	"github.com/ledgerwatch/log/v3"
+
 	"github.com/ledgerwatch/erigon/common"
+	"github.com/ledgerwatch/erigon/common/math"
 	"github.com/ledgerwatch/erigon/crypto"
 	"github.com/ledgerwatch/erigon/params"
 	"github.com/ledgerwatch/erigon/rlp"
@@ -504,4 +507,20 @@ func (m *Message) SetCheckNonce(checkNonce bool) {
 func (m Message) IsFree() bool { return m.isFree }
 func (m *Message) SetIsFree(isFree bool) {
 	m.isFree = isFree
+}
+
+func (m *Message) ChangeGas(globalGasCap, desiredGas uint64) {
+	gas := globalGasCap
+	if gas == 0 {
+		gas = uint64(math.MaxUint64 / 2)
+	}
+	if desiredGas > 0 {
+		gas = desiredGas
+	}
+	if globalGasCap != 0 && globalGasCap < gas {
+		log.Warn("Caller gas above allowance, capping", "requested", gas, "cap", globalGasCap)
+		gas = globalGasCap
+	}
+
+	m.gasLimit = gas
 }

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/holiman/uint256"
+
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/common/u256"
 	"github.com/ledgerwatch/erigon/crypto"
@@ -161,6 +162,9 @@ func NewEVM(blockCtx BlockContext, txCtx TxContext, state IntraBlockState, chain
 func (evm *EVM) Reset(txCtx TxContext, ibs IntraBlockState) {
 	evm.txContext = txCtx
 	evm.intraBlockState = ibs
+
+	// ensure the evm is reset to be used again
+	atomic.StoreInt32(&evm.abort, 0)
 }
 
 // Cancel cancels any running EVM operation. This may be called concurrently and

--- a/turbo/transactions/call.go
+++ b/turbo/transactions/call.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/holiman/uint256"
 	"github.com/ledgerwatch/erigon-lib/kv"
+	"github.com/ledgerwatch/log/v3"
+
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/consensus/ethash"
 	"github.com/ledgerwatch/erigon/core"
@@ -17,18 +19,20 @@ import (
 	"github.com/ledgerwatch/erigon/rpc"
 	ethapi2 "github.com/ledgerwatch/erigon/turbo/adapter/ethapi"
 	"github.com/ledgerwatch/erigon/turbo/services"
-	"github.com/ledgerwatch/log/v3"
 )
 
 func DoCall(
 	ctx context.Context,
 	args ethapi2.CallArgs,
-	tx kv.Tx, blockNrOrHash rpc.BlockNumberOrHash,
-	block *types.Block, overrides *ethapi2.StateOverrides,
+	tx kv.Tx,
+	blockNrOrHash rpc.BlockNumberOrHash,
+	header *types.Header,
+	overrides *ethapi2.StateOverrides,
 	gasCap uint64,
 	chainConfig *params.ChainConfig,
 	stateReader state.StateReader,
-	headerReader services.HeaderReader, callTimeout time.Duration,
+	headerReader services.HeaderReader,
+	callTimeout time.Duration,
 ) (*core.ExecutionResult, error) {
 	// todo: Pending state is only known by the miner
 	/*
@@ -37,16 +41,14 @@ func DoCall(
 			return state, block.Header(), nil
 		}
 	*/
-	state := state.New(stateReader)
 
-	header := block.Header()
+	state := state.New(stateReader)
 
 	// Override the fields of specified contracts before execution.
 	if overrides != nil {
 		if err := overrides.Override(state); err != nil {
 			return nil, err
 		}
-
 	}
 
 	// Setup context so it may be cancelled the call has completed
@@ -123,4 +125,105 @@ func getHashGetter(requireCanonical bool, tx kv.Tx, headerReader services.Header
 		}
 		return h.Hash()
 	}
+}
+
+type ReusableCaller struct {
+	evm             *vm.EVM
+	intraBlockState *state.IntraBlockState
+	gasCap          uint64
+	baseFee         *uint256.Int
+	stateReader     state.StateReader
+	callTimeout     time.Duration
+	message         *types.Message
+}
+
+func (r *ReusableCaller) DoCallWithNewGas(
+	ctx context.Context,
+	newGas uint64,
+) (*core.ExecutionResult, error) {
+	var cancel context.CancelFunc
+	if r.callTimeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, r.callTimeout)
+	} else {
+		ctx, cancel = context.WithCancel(ctx)
+	}
+
+	// Make sure the context is cancelled when the call has completed
+	// this makes sure resources are cleaned up.
+	defer cancel()
+
+	r.message.ChangeGas(r.gasCap, newGas)
+
+	// reset the EVM so that we can continue to use it with the new context
+	txCtx := core.NewEVMTxContext(r.message)
+	r.intraBlockState.Reset()
+	r.evm.Reset(txCtx, r.intraBlockState)
+
+	timedOut := false
+	go func() {
+		<-ctx.Done()
+		timedOut = true
+	}()
+
+	gp := new(core.GasPool).AddGas(r.message.Gas())
+
+	result, err := core.ApplyMessage(r.evm, r.message, gp, true /* refunds */, false /* gasBailout */)
+	if err != nil {
+		return nil, err
+	}
+
+	// If the timer caused an abort, return an appropriate error message
+	if timedOut {
+		return nil, fmt.Errorf("execution aborted (timeout = %v)", r.callTimeout)
+	}
+
+	return result, nil
+}
+
+func NewReusableCaller(
+	stateReader state.StateReader,
+	overrides *ethapi2.StateOverrides,
+	header *types.Header,
+	initialArgs ethapi2.CallArgs,
+	gasCap uint64,
+	blockNrOrHash rpc.BlockNumberOrHash,
+	tx kv.Tx,
+	headerReader services.HeaderReader,
+	chainConfig *params.ChainConfig,
+	callTimeout time.Duration,
+) (*ReusableCaller, error) {
+	intraBlockState := state.New(stateReader)
+
+	if overrides != nil {
+		if err := overrides.Override(intraBlockState); err != nil {
+			return nil, err
+		}
+	}
+
+	var baseFee *uint256.Int
+	if header != nil && header.BaseFee != nil {
+		var overflow bool
+		baseFee, overflow = uint256.FromBig(header.BaseFee)
+		if overflow {
+			return nil, fmt.Errorf("header.BaseFee uint256 overflow")
+		}
+	}
+
+	msg, err := initialArgs.ToMessage(gasCap, baseFee)
+	if err != nil {
+		return nil, err
+	}
+	blockCtx, txCtx := GetEvmContext(msg, header, blockNrOrHash.RequireCanonical, tx, headerReader)
+
+	evm := vm.NewEVM(blockCtx, txCtx, intraBlockState, chainConfig, vm.Config{NoBaseFee: true})
+
+	return &ReusableCaller{
+		evm:             evm,
+		intraBlockState: intraBlockState,
+		baseFee:         baseFee,
+		gasCap:          gasCap,
+		callTimeout:     callTimeout,
+		stateReader:     stateReader,
+		message:         &msg,
+	}, nil
 }


### PR DESCRIPTION
One simple change to send the header in rather than the body allowing re-use in a loop which saves the copy call when looping.

The other one for a reusable evm seems potentially dangerous so feedback more than welcome on that one, local testing shows it gains me around 6k±rps so if it's safe is a good win, but I feel it will need more work.  I could only validate against goerli chain which seems to always return the same value for eth_estimateGas so if anybody could validate it against another chain that would be awesome.