### PR TITLE
ci(hive): use run context rather than artifacts for results

### DIFF
--- a/.github/workflows/hive-nightly.yml
+++ b/.github/workflows/hive-nightly.yml
@@ -10,36 +10,29 @@ concurrency:
   
 jobs:
   hive:
-     runs-on: ubuntu-latest
-     steps:
-       - uses: AutoModality/action-clean@v1
-       - uses: actions/checkout@v3
-         with:
-           fetch-depth: 0 # fetch git tags for "git describe"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: AutoModality/action-clean@v1
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # fetch git tags for "git describe"
 
-       - name: build erigon image
-         run: DOCKER_TAG=thorax/erigon:ci-$GITHUB_SHA DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) make docker
+      - name: build erigon image
+        run: DOCKER_TAG=thorax/erigon:ci-$GITHUB_SHA DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) make docker
 
-       # check with root permissions, should be cached from previous build
-       - name: build erigon image (root permissions)
-         run: sudo DOCKER_TAG=thorax/erigon:ci-$GITHUB_SHA DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) make docker
+      # check with root permissions, should be cached from previous build
+      - name: build erigon image (root permissions)
+        run: sudo DOCKER_TAG=thorax/erigon:ci-$GITHUB_SHA DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) make docker
 
-       - name: run hive and parse output
-         run: |
+      - name: run hive and parse output
+        run: |
           sudo mkdir -p /results-${{ github.run_id }}
           docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${{ github.workspace }}:/work thorax/hive:latest --sim ethereum/engine --results-root=/work/results-${{ github.run_id }} --client erigon_ci-$GITHUB_SHA --exit.fail=false
           docker run --rm --pull always -v /var/run/docker.sock:/var/run/docker.sock -v ${{ github.workspace }}:/work --entrypoint /app/hivecioutput thorax/hive:latest --resultsdir=/work/results-${{ github.run_id }} --outdir=/work/results-${{ github.run_id }} --exclusionsfile=/work/hive/exclusions.json
 
-       - name: archive hive results
-         uses: actions/upload-artifact@v3
-         if: always()
-         with:
-           name: test-results
-           path: results-${{ github.run_id }}/*.xml
-
-       - name: clean up containers
-         if: always()
-         run: |
+      - name: clean up containers
+        if: always()
+        run: |
           ids=$(docker ps -a -q)
           for id in $ids
           do
@@ -47,29 +40,17 @@ jobs:
             docker stop $id && docker rm $id
           done
 
-  hive-results:
-    needs: hive
-    name: Hive results
-    runs-on: ubuntu-latest
+      - name: parse hive results
+        uses: phoenix-actions/test-reporting@v10
+        with:
+          name: Tests
+          path: results-${{ github.run_id }}/*.xml
+          reporter: java-junit
 
-    permissions:
-      checks: write
-      pull-requests: write
-      actions: read
-
-    steps:
-    - name: parse hive results
-      uses: phoenix-actions/test-reporting@v8
-      with:
-        artifact: test-results
-        name: Tests
-        path: '*.xml'
-        reporter: java-junit
-
-    - name: set badge color
-      shell: bash
-      run: |
-        case ${{ fromJSON( steps.test-results.outputs.json ).conclusion }} in
+      - name: set badge color
+        shell: bash
+        run: |
+          case ${{ fromJSON( steps.test-results.outputs.json ).conclusion }} in
           success)
             echo "BADGE_COLOR=31c653" >> $GITHUB_ENV
             ;;
@@ -79,22 +60,22 @@ jobs:
           neutral)
             echo "BADGE_COLOR=696969" >> $GITHUB_ENV
             ;;
-        esac
+          esac
 
-    - name: create badge
-      uses: emibcn/badge-action@d6f51ff11b5c3382b3b88689ae2d6db22d9737d1
-      with:
-        label: Hive
-        status: '${{ fromJSON( steps.test-results.outputs.json ).formatted.stats.tests }} tests, ${{ fromJSON( steps.test-results.outputs.json ).formatted.stats.runs }} runs: ${{ fromJSON( steps.test-results.outputs.json ).conclusion }}'
-        color: ${{ env.BADGE_COLOR }}
-        path: badge.svg
+      - name: create badge
+        uses: emibcn/badge-action@d6f51ff11b5c3382b3b88689ae2d6db22d9737d1
+        with:
+          label: Hive
+          status: '${{ fromJSON( steps.test-results.outputs.json ).formatted.stats.tests }} tests, ${{ fromJSON( steps.test-results.outputs.json ).formatted.stats.runs }} runs: ${{ fromJSON( steps.test-results.outputs.json ).conclusion }}'
+          color: ${{ env.BADGE_COLOR }}
+          path: badge.svg
 
-    - name: upload badge to gist
-      if: >
-        github.event_name == 'workflow_run' && github.event.workflow_run.head_branch == 'devel' ||
-        github.event_name != 'workflow_run' && github.ref == 'refs/heads/devel'
-      uses: andymckay/append-gist-action@1fbfbbce708a39bd45846f0955ed5521f2099c6d
-      with:
-        token: ${{ secrets.GIST_TOKEN }}
-        gistURL: https://gist.githubusercontent.com/revitteth/dc492845ba6eb694e6c7279224634b20
-        file: badge.svg
+      - name: upload badge to gist
+        if: >
+          github.event_name == 'workflow_run' && github.event.workflow_run.head_branch == 'devel' ||
+          github.event_name != 'workflow_run' && github.ref == 'refs/heads/devel'
+        uses: andymckay/append-gist-action@1fbfbbce708a39bd45846f0955ed5521f2099c6d
+        with:
+          token: ${{ secrets.GIST_TOKEN }}
+          gistURL: https://gist.githubusercontent.com/revitteth/dc492845ba6eb694e6c7279224634b20
+          file: badge.svg


### PR DESCRIPTION
When running from forks results would need to be uploaded as artifacts and separately parsed. This is no longer true when running as a scheduled job and we can therefore fix and get a speedup by reading the results straight from the workspace.