### PR TITLE
Withdrawals part 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ tests/testdata/*
 
 go.work
 go.work.sum
+erigon-lib/
 
 /goerli
 

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -361,6 +361,11 @@ func (g *Genesis) ToBlock() (*types.Block, *state.IntraBlockState, error) {
 		}
 	}
 
+	var withdrawals []*types.Withdrawal
+	if g.Config != nil && (g.Config.IsShanghai(g.Timestamp)) {
+		withdrawals = []*types.Withdrawal{}
+	}
+
 	var root common.Hash
 	var statedb *state.IntraBlockState
 	wg := sync.WaitGroup{}
@@ -431,7 +436,7 @@ func (g *Genesis) ToBlock() (*types.Block, *state.IntraBlockState, error) {
 
 	head.Root = root
 
-	return types.NewBlock(head, nil, nil, nil, nil), statedb, nil
+	return types.NewBlock(head, nil, nil, nil, withdrawals), statedb, nil
 }
 
 func (g *Genesis) WriteGenesisState(tx kv.RwTx) (*types.Block, *state.IntraBlockState, error) {

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -624,6 +624,7 @@ func ReadBody(db kv.Getter, hash common.Hash, number uint64) (*types.Body, uint6
 	}
 	body := new(types.Body)
 	body.Uncles = bodyForStorage.Uncles
+	body.Withdrawals = bodyForStorage.Withdrawals
 
 	if bodyForStorage.TxAmount < 2 {
 		panic(fmt.Sprintf("block body hash too few txs amount: %d, %d", number, bodyForStorage.TxAmount))
@@ -660,9 +661,10 @@ func WriteRawBody(db kv.RwTx, hash common.Hash, number uint64, body *types.RawBo
 		return false, 0, err
 	}
 	data := types.BodyForStorage{
-		BaseTxId: baseTxId,
-		TxAmount: uint32(len(body.Transactions)) + 2,
-		Uncles:   body.Uncles,
+		BaseTxId:    baseTxId,
+		TxAmount:    uint32(len(body.Transactions)) + 2,
+		Uncles:      body.Uncles,
+		Withdrawals: body.Withdrawals,
 	}
 	if err = WriteBodyForStorage(db, hash, number, &data); err != nil {
 		return false, 0, fmt.Errorf("WriteBodyForStorage: %w", err)
@@ -682,9 +684,10 @@ func WriteBody(db kv.RwTx, hash common.Hash, number uint64, body *types.Body) er
 		return err
 	}
 	data := types.BodyForStorage{
-		BaseTxId: baseTxId,
-		TxAmount: uint32(len(body.Transactions)) + 2,
-		Uncles:   body.Uncles,
+		BaseTxId:    baseTxId,
+		TxAmount:    uint32(len(body.Transactions)) + 2,
+		Uncles:      body.Uncles,
+		Withdrawals: body.Withdrawals,
 	}
 	if err := WriteBodyForStorage(db, hash, number, &data); err != nil {
 		return fmt.Errorf("failed to write body: %w", err)

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -24,6 +24,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/holiman/uint256"
 	"github.com/ledgerwatch/erigon-lib/kv/memdb"
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/common/u256"
@@ -432,6 +433,185 @@ func TestBlockReceiptStorage(t *testing.T) {
 	if rs := ReadReceipts(tx, b, senders); len(rs) != 0 {
 		t.Fatalf("deleted receipts returned: %v", rs)
 	}
+}
+
+// Tests block storage and retrieval operations with withdrawals.
+func TestBlockWithdrawalsStorage(t *testing.T) {
+	_, tx := memdb.NewTestTx(t)
+	require := require.New(t)
+
+	// create fake withdrawals
+	w := types.Withdrawal{
+		Index:     uint64(15),
+		Validator: uint64(5500),
+		Address:   common.Address{0: 0xff},
+		Amount:    *uint256.NewInt(1000),
+	}
+
+	w2 := types.Withdrawal{
+		Index:     uint64(16),
+		Validator: uint64(5501),
+		Address:   common.Address{0: 0xff},
+		Amount:    *uint256.NewInt(1001),
+	}
+
+	withdrawals := make([]*types.Withdrawal, 0)
+	withdrawals = append(withdrawals, &w)
+	withdrawals = append(withdrawals, &w2)
+
+	// Create a test block to move around the database and make sure it's really new
+	block := types.NewBlockWithHeader(&types.Header{
+		Number:      big.NewInt(1),
+		Extra:       []byte("test block"),
+		UncleHash:   types.EmptyUncleHash,
+		TxHash:      types.EmptyRootHash,
+		ReceiptHash: types.EmptyRootHash,
+	})
+	if entry := ReadBlock(tx, block.Hash(), block.NumberU64()); entry != nil {
+		t.Fatalf("Non existent block returned: %v", entry)
+	}
+	if entry := ReadHeader(tx, block.Hash(), block.NumberU64()); entry != nil {
+		t.Fatalf("Non existent header returned: %v", entry)
+	}
+	if entry := ReadCanonicalBodyWithTransactions(tx, block.Hash(), block.NumberU64()); entry != nil {
+		t.Fatalf("Non existent body returned: %v", entry)
+	}
+
+	// Write withdrawals to block
+	wBlock := types.NewBlockFromStorage(block.Hash(), block.Header(), block.Transactions(), block.Uncles(), withdrawals)
+
+	if err := WriteBody(tx, wBlock.Hash(), wBlock.NumberU64(), wBlock.Body()); err != nil {
+		t.Fatalf("Could not write body: %v", err)
+	}
+
+	// Write and verify the block in the database
+	err := WriteBlock(tx, wBlock)
+	if err != nil {
+		t.Fatalf("Could not write block: %v", err)
+	}
+	if entry := ReadBlock(tx, block.Hash(), block.NumberU64()); entry == nil {
+		t.Fatalf("Stored block not found")
+	} else if entry.Hash() != block.Hash() {
+		t.Fatalf("Retrieved block mismatch: have %v, want %v", entry, block)
+	}
+	if entry := ReadHeader(tx, block.Hash(), block.NumberU64()); entry == nil {
+		t.Fatalf("Stored header not found")
+	} else if entry.Hash() != block.Hash() {
+		t.Fatalf("Retrieved header mismatch: have %v, want %v", entry, block.Header())
+	}
+	if err := TruncateBlocks(context.Background(), tx, 2); err != nil {
+		t.Fatal(err)
+	}
+	entry := ReadCanonicalBodyWithTransactions(tx, block.Hash(), block.NumberU64())
+	if entry == nil {
+		t.Fatalf("Stored body not found")
+	} else if types.DeriveSha(types.Transactions(entry.Transactions)) != types.DeriveSha(block.Transactions()) || types.CalcUncleHash(entry.Uncles) != types.CalcUncleHash(block.Uncles()) {
+		t.Fatalf("Retrieved body mismatch: have %v, want %v", entry, block.Body())
+	}
+
+	// Verify withdrawals on block
+	readWithdrawals := entry.Withdrawals
+	if len(readWithdrawals) != len(withdrawals) {
+		t.Fatalf("Retrieved withdrawals mismatch: have %v, want %v", readWithdrawals, withdrawals)
+	}
+
+	rw := readWithdrawals[0]
+	rw2 := readWithdrawals[1]
+
+	require.NotNil(rw)
+	require.Equal(uint64(15), rw.Index)
+	require.Equal(uint64(5500), rw.Validator)
+	require.Equal(common.Address{0: 0xff}, rw.Address)
+	require.Equal(*uint256.NewInt(1000), rw.Amount)
+
+	require.NotNil(rw2)
+	require.Equal(uint64(16), rw2.Index)
+	require.Equal(uint64(5501), rw2.Validator)
+	require.Equal(common.Address{0: 0xff}, rw2.Address)
+	require.Equal(*uint256.NewInt(1001), rw2.Amount)
+
+	// Delete the block and verify the execution
+	if err := TruncateBlocks(context.Background(), tx, block.NumberU64()); err != nil {
+		t.Fatal(err)
+	}
+	//if err := DeleteBlock(tx, block.Hash(), block.NumberU64()); err != nil {
+	//	t.Fatalf("Could not delete block: %v", err)
+	//}
+	if entry := ReadBlock(tx, block.Hash(), block.NumberU64()); entry != nil {
+		t.Fatalf("Deleted block returned: %v", entry)
+	}
+	if entry := ReadHeader(tx, block.Hash(), block.NumberU64()); entry != nil {
+		t.Fatalf("Deleted header returned: %v", entry)
+	}
+	if entry := ReadCanonicalBodyWithTransactions(tx, block.Hash(), block.NumberU64()); entry != nil {
+		t.Fatalf("Deleted body returned: %v", entry)
+	}
+
+	// write again and delete it as old one
+	if err := WriteBlock(tx, block); err != nil {
+		t.Fatalf("Could not write block: %v", err)
+	}
+	if _, _, err := DeleteAncientBlocks(tx, 0, 1); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Tests pre-shanghai body to make sure withdrawals doesn't panic
+func TestPreShanghaiBodyNoPanicOnWithdrawals(t *testing.T) {
+	require := require.New(t)
+
+	const bodyRlp = "f902bef8bef85d0101019471562b71999873db5b286df957af199ec94617f701801ca023f4aad9a71341d2990012a732366c3bc8a4ce9ff54c05546a9487445ac67692a0290d3a1411c2a675a4c12c98af60e34ea4d689f0ddfe0250a9e09c0819dfe3bff85d0201029471562b71999873db5b286df957af199ec94617f701801ca0f824d7edc241758aca948ff34d3797e4e31003f76cc9e05fb9c19e967fc48113a070e1389f0fa23fe765a04b23e98f98db6d630e3a035c1c7c968142ababb85a1df901fbf901f8a00000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000940000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000b901000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080808080808b7465737420686561646572a00000000000000000000000000000000000000000000000000000000000000000880000000000000000"
+	bstring, _ := hex.DecodeString(bodyRlp)
+
+	body := new(types.Body)
+	rlp.DecodeBytes([]byte(bstring), body)
+
+	require.Nil(body.Withdrawals)
+	require.Equal(2, len(body.Transactions))
+}
+
+// Tests pre-shanghai bodyForStorage to make sure withdrawals doesn't panic
+func TestPreShanghaiBodyForStorageNoPanicOnWithdrawals(t *testing.T) {
+	require := require.New(t)
+
+	const bodyForStorageRlp = "c38002c0"
+	bstring, _ := hex.DecodeString(bodyForStorageRlp)
+
+	body := new(types.BodyForStorage)
+	rlp.DecodeBytes([]byte(bstring), body)
+
+	require.Nil(body.Withdrawals)
+	require.Equal(uint32(2), body.TxAmount)
+}
+
+// Tests shanghai bodyForStorage to make sure withdrawals are present
+func TestShanghaiBodyForStorageHasWithdrawals(t *testing.T) {
+	require := require.New(t)
+
+	const bodyForStorageRlp = "f83f8002c0f83adc0f82157c94ff000000000000000000000000000000000000008203e8dc1082157d94ff000000000000000000000000000000000000008203e9"
+	bstring, _ := hex.DecodeString(bodyForStorageRlp)
+
+	body := new(types.BodyForStorage)
+	rlp.DecodeBytes([]byte(bstring), body)
+
+	require.NotNil(body.Withdrawals)
+	require.Equal(2, len(body.Withdrawals))
+	require.Equal(uint32(2), body.TxAmount)
+}
+
+// Tests shanghai bodyForStorage to make sure when no withdrawals the slice is empty (not nil)
+func TestShanghaiBodyForStorageNoWithdrawals(t *testing.T) {
+	require := require.New(t)
+
+	const bodyForStorageRlp = "c48002c0c0c0"
+	bstring, _ := hex.DecodeString(bodyForStorageRlp)
+
+	body := new(types.BodyForStorage)
+	rlp.DecodeBytes([]byte(bstring), body)
+
+	require.NotNil(body.Withdrawals)
+	require.Equal(0, len(body.Withdrawals))
+	require.Equal(uint32(2), body.TxAmount)
 }
 
 func checkReceiptsRLP(have, want types.Receipts) error {

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -535,10 +535,10 @@ type RawBody struct {
 }
 
 type BodyForStorage struct {
-	BaseTxId uint64
-	TxAmount uint32
-	Uncles   []*Header
-	// TODO(yperbasis): withdrawals
+	BaseTxId    uint64
+	TxAmount    uint32
+	Uncles      []*Header
+	Withdrawals []*Withdrawal
 }
 
 // Block represents an entire block in the Ethereum blockchain.
@@ -735,6 +735,159 @@ func (rb *RawBody) DecodeRLP(s *rlp.Stream) error {
 			break
 		}
 		rb.Withdrawals = append(rb.Withdrawals, &withdrawal)
+	}
+	if !errors.Is(err, rlp.EOL) {
+		return err
+	}
+	// end of Withdrawals
+	if err = s.ListEnd(); err != nil {
+		return err
+	}
+
+	return s.ListEnd()
+}
+
+func (bfs BodyForStorage) payloadSize() (payloadSize, unclesLen, withdrawalsLen int) {
+
+	payloadSize++
+
+	baseTxIdLen := 1 + rlp.IntLenExcludingHead(bfs.BaseTxId)
+	txAmountLen := 1 + rlp.IntLenExcludingHead(uint64(bfs.TxAmount))
+
+	payloadSize += baseTxIdLen
+	payloadSize += txAmountLen
+
+	// size of Uncles
+	for _, uncle := range bfs.Uncles {
+		unclesLen++
+		uncleLen := uncle.EncodingSize()
+		if uncleLen >= 56 {
+			unclesLen += bitsToBytes(bits.Len(uint(uncleLen)))
+		}
+		unclesLen += uncleLen
+	}
+	if unclesLen >= 56 {
+		payloadSize += bitsToBytes(bits.Len(uint(unclesLen)))
+	}
+	payloadSize += unclesLen
+
+	// size of Withdrawals
+	if bfs.Withdrawals != nil {
+		payloadSize++
+		for _, withdrawal := range bfs.Withdrawals {
+			withdrawalsLen++
+			withdrawalLen := withdrawal.EncodingSize()
+			if withdrawalLen >= 56 {
+				withdrawalLen += bitsToBytes(bits.Len(uint(withdrawalLen)))
+			}
+			withdrawalsLen += withdrawalLen
+		}
+		if withdrawalsLen >= 56 {
+			payloadSize += bitsToBytes(bits.Len(uint(withdrawalsLen)))
+		}
+		payloadSize += withdrawalsLen
+	}
+
+	return payloadSize, unclesLen, withdrawalsLen
+}
+
+func (bfs BodyForStorage) EncodeRLP(w io.Writer) error {
+	payloadSize, unclesLen, withdrawalsLen := bfs.payloadSize()
+	var b [33]byte
+
+	// prefix
+	if err := EncodeStructSizePrefix(payloadSize, w, b[:]); err != nil {
+		return err
+	}
+
+	// encode BaseTxId
+	if err := rlp.Encode(w, bfs.BaseTxId); err != nil {
+		return err
+	}
+
+	// encode TxAmount
+	if err := rlp.Encode(w, bfs.TxAmount); err != nil {
+		return err
+	}
+
+	// encode Uncles
+	if err := EncodeStructSizePrefix(unclesLen, w, b[:]); err != nil {
+		return err
+	}
+	for _, uncle := range bfs.Uncles {
+		if err := uncle.EncodeRLP(w); err != nil {
+			return err
+		}
+	}
+	// encode Withdrawals
+	// nil if pre-shanghai, empty slice if shanghai and no withdrawals in block, otherwise non-empty
+	if bfs.Withdrawals != nil {
+		if err := EncodeStructSizePrefix(withdrawalsLen, w, b[:]); err != nil {
+			return err
+		}
+		for _, withdrawal := range bfs.Withdrawals {
+			if err := withdrawal.EncodeRLP(w); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (bfs *BodyForStorage) DecodeRLP(s *rlp.Stream) error {
+	_, err := s.List()
+	if err != nil {
+		return err
+	}
+
+	// decode BaseTxId
+	if err = s.Decode(&bfs.BaseTxId); err != nil {
+		return err
+	}
+
+	// decode TxAmount
+	if err = s.Decode(&bfs.TxAmount); err != nil {
+		return err
+	}
+
+	// decode Uncles
+	if _, err = s.List(); err != nil {
+		return err
+	}
+	for err == nil {
+		var uncle Header
+		if err = uncle.DecodeRLP(s); err != nil {
+			break
+		}
+		bfs.Uncles = append(bfs.Uncles, &uncle)
+	}
+	if !errors.Is(err, rlp.EOL) {
+		return err
+	}
+	// end of Uncles
+	if err = s.ListEnd(); err != nil {
+		return err
+	}
+
+	// decode Withdrawals
+	if _, err = s.List(); err != nil {
+		if errors.Is(err, rlp.EOL) {
+			// pre-shanghai block
+			bfs.Withdrawals = nil
+			return s.ListEnd()
+		}
+		return fmt.Errorf("read Withdrawals: %w", err)
+	}
+	for err == nil {
+		var withdrawal Withdrawal
+		if err = withdrawal.DecodeRLP(s); err != nil {
+			// shanghai block with no withdrawals
+			if len(bfs.Withdrawals) == 0 {
+				bfs.Withdrawals = []*Withdrawal{}
+			}
+			break
+		}
+		bfs.Withdrawals = append(bfs.Withdrawals, &withdrawal)
 	}
 	if !errors.Is(err, rlp.EOL) {
 		return err

--- a/docs/programmers_guide/dupsort.md
+++ b/docs/programmers_guide/dupsort.md
@@ -68,7 +68,7 @@ for k, _ := cursor.SeekDup(subTableName, keyInSubTable); k != nil; k, _ = cursor
 } 
 ```
 
-Enough strait forward. No performance penalty (only profit from smaller database size).
+Enough straight forward. No performance penalty (only profit from smaller database size).
 
 MDBX in-depth
 -------------

--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -514,6 +514,17 @@ func (bb BlockBody) EncodeRLP(w io.Writer) error {
 			return err
 		}
 	}
+	// encode withdrawals
+	if bb.Withdrawals != nil {
+		if err := types.EncodeStructSizePrefix(len(bb.Withdrawals), w, b[:]); err != nil {
+			return err
+		}
+		for _, withdrawal := range bb.Withdrawals {
+			if err := withdrawal.EncodeRLP(w); err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }
 
@@ -552,6 +563,29 @@ func (bb *BlockBody) DecodeRLP(s *rlp.Stream) error {
 		return err
 	}
 	// end of Uncles
+	if err = s.ListEnd(); err != nil {
+		return err
+	}
+	// decode Withdrawals
+	if _, err = s.List(); err != nil {
+		if errors.Is(err, rlp.EOL) {
+			bb.Withdrawals = nil
+			return s.ListEnd()
+		}
+		return err
+	}
+	bb.Withdrawals = []*types.Withdrawal{}
+	for err == nil {
+		var withdrawal types.Withdrawal
+		if err = withdrawal.DecodeRLP(s); err != nil {
+			break
+		}
+		bb.Withdrawals = append(bb.Withdrawals, &withdrawal)
+	}
+	if !errors.Is(err, rlp.EOL) {
+		return err
+	}
+	// end of Withdrawals
 	if err = s.ListEnd(); err != nil {
 		return err
 	}

--- a/params/config.go
+++ b/params/config.go
@@ -855,6 +855,7 @@ func (c *ChainConfig) Rules(num uint64, time uint64) *Rules {
 	if chainID == nil {
 		chainID = new(big.Int)
 	}
+
 	return &Rules{
 		ChainID:               new(big.Int).Set(chainID),
 		IsHomestead:           c.IsHomestead(num),

--- a/turbo/adapter/ethapi/api.go
+++ b/turbo/adapter/ethapi/api.go
@@ -275,6 +275,9 @@ func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 	if head.BaseFee != nil {
 		result["baseFeePerGas"] = (*hexutil.Big)(head.BaseFee)
 	}
+	if head.WithdrawalsHash != nil {
+		result["withdrawalsRoot"] = head.WithdrawalsHash
+	}
 
 	return result
 }
@@ -327,6 +330,10 @@ func RPCMarshalBlockExDeprecated(block *types.Block, inclTx bool, fullTx bool, b
 		uncleHashes[i] = uncle.Hash()
 	}
 	fields["uncles"] = uncleHashes
+
+	if block.Withdrawals() != nil {
+		fields["withdrawals"] = block.Withdrawals()
+	}
 
 	return fields, nil
 }


### PR DESCRIPTION
Continuation of PR #6009. Storage and retrieval of withdrawals.

- [x] storage of withdrawals on writeblock
- [x] composite key (block number | block hash)
- [x] value ([]withdrawal)
- [x] retrieval of withdrawals with block
- [x] tests around storing/retrieving withdrawals
- [x] tested in hive
- [x] commits tidied


## Hive Failures
- [x] Withdrawals Fork on Block 2
- [x] Withdrawals Fork on Block 3
- [ ] Sync after 2 blocks - Withdrawals on Block 1 - Single Withdrawal Account - No Transactions ( Syncing client rejected valid chain)
- [ ] Sync after 2 blocks - Withdrawals on Block 1 - Single Withdrawal Account (Timeout while waiting for secondary client to sync)
- [ ] Sync after 2 blocks - Withdrawals on Genesis - Single Withdrawal Account (Timeout while waiting for secondary client to sync)
- [ ] Sync after 2 blocks - Withdrawals on Block 2 - Single Withdrawal Account - No Transactions (Syncing client rejected valid chain)
- [ ] Sync after 2 blocks - Withdrawals on Block 2 - Single Withdrawal Account (Timeout while waiting for secondary client to sync)
- [ ] Sync after 128 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts (Unexpected error on BalanceAt: Post "http://172.17.0.4:8545/": context deadline exceeded, expected=<None>)
- [ ] Withdrawals Fork on Block 1 - 8 Block Re-Org, Sync (Expected no error on EngineNewPayloadV2: error=Post "http://172.17.0.4:8551/": context deadline exceeded)
- [ ] Withdrawals Fork on Block 8 - 10 Block Re-Org Sync (Expected no error on EngineNewPayloadV2: error=Post "http://172.17.0.4:8551/": context deadline exceeded)
- [ ] Withdrawals Fork on Canonical Block 8 / Side Block 7 - 10 Block Re-Org Sync (Expected no error on EngineNewPayloadV2: error=Post "http://172.17.0.4:8551/": context deadline exceeded)
- [ ] Withdrawals Fork on Canonical Block 8 / Side Block 9 - 10 Block Re-Org Sync (Expected no error on EngineNewPayloadV2: error=Post "http://172.17.0.4:8551/": context deadline exceeded)