### PR TITLE
added --p2p.allowed-port flag

### DIFF
--- a/cmd/sentry/main.go
+++ b/cmd/sentry/main.go
@@ -28,6 +28,7 @@ var (
 	discoveryDNS []string
 	nodiscover   bool // disable sentry's discovery mechanism
 	protocol     uint
+	allowedPorts []uint
 	netRestrict  string // CIDR to restrict peering to
 	maxPeers     int
 	maxPendPeers int
@@ -46,6 +47,7 @@ func init() {
 	rootCmd.Flags().StringSliceVar(&discoveryDNS, utils.DNSDiscoveryFlag.Name, []string{}, utils.DNSDiscoveryFlag.Usage)
 	rootCmd.Flags().BoolVar(&nodiscover, utils.NoDiscoverFlag.Name, false, utils.NoDiscoverFlag.Usage)
 	rootCmd.Flags().UintVar(&protocol, utils.P2pProtocolVersionFlag.Name, utils.P2pProtocolVersionFlag.Value.Value()[0], utils.P2pProtocolVersionFlag.Usage)
+	rootCmd.Flags().UintSliceVar(&allowedPorts, utils.P2pProtocolAllowedPorts.Name, utils.P2pProtocolAllowedPorts.Value.Value(), utils.P2pProtocolAllowedPorts.Usage)
 	rootCmd.Flags().StringVar(&netRestrict, utils.NetrestrictFlag.Name, utils.NetrestrictFlag.Value, utils.NetrestrictFlag.Usage)
 	rootCmd.Flags().IntVar(&maxPeers, utils.MaxPeersFlag.Name, utils.MaxPeersFlag.Value, utils.MaxPeersFlag.Usage)
 	rootCmd.Flags().IntVar(&maxPendPeers, utils.MaxPendingPeersFlag.Name, utils.MaxPendingPeersFlag.Value, utils.MaxPendingPeersFlag.Usage)
@@ -82,6 +84,7 @@ var rootCmd = &cobra.Command{
 			trustedPeers,
 			uint(port),
 			protocol,
+			allowedPorts,
 		)
 		if err != nil {
 			return err

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -481,7 +481,7 @@ var (
 	P2pProtocolAllowedPorts = cli.UintSliceFlag{
 		Name:  "p2p.allowed-ports",
 		Usage: "Allowed ports to pick for different eth p2p protocol versions as follows <porta>,<portb>,..,<porti>",
-		Value: cli.NewUintSlice(uint(ListenPortFlag.Value), 30304),
+		Value: cli.NewUintSlice(uint(ListenPortFlag.Value), 30304, 30305, 30306, 30307),
 	}
 	SentryAddrFlag = cli.StringFlag{
 		Name:  "sentry.api.addr",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -935,6 +935,21 @@ func setListenAddress(ctx *cli.Context, cfg *p2p.Config) {
 	if ctx.IsSet(P2pProtocolAllowedPorts.Name) {
 		cfg.AllowedPorts = ctx.UintSlice(P2pProtocolAllowedPorts.Name)
 	}
+
+	if ctx.IsSet(ListenPortFlag.Name) {
+		// add non-default port to allowed port list
+		lp := ctx.Int(ListenPortFlag.Name)
+		found := false
+		for _, p := range cfg.AllowedPorts {
+			if int(p) == lp {
+				found = true
+				break
+			}
+		}
+		if !found {
+			cfg.AllowedPorts = append([]uint{uint(lp)}, cfg.AllowedPorts...)
+		}
+	}
 }
 
 // setNAT creates a port mapper from command line flags.

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -480,7 +480,7 @@ var (
 	}
 	P2pProtocolAllowedPorts = cli.UintSliceFlag{
 		Name:  "p2p.allowed-ports",
-		Usage: "Allowed ports to pick for different eth p2p protocol versions as follows <porta>,<portb>,..,<porti>  If you using --port, make sure that provided port also presented as allowed port",
+		Usage: "Allowed ports to pick for different eth p2p protocol versions as follows <porta>,<portb>,..,<porti>",
 		Value: cli.NewUintSlice(uint(ListenPortFlag.Value), 30304),
 	}
 	SentryAddrFlag = cli.StringFlag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -844,18 +844,18 @@ func ParseNodesFromURLs(urls []string) ([]*enode.Node, error) {
 // NewP2PConfig
 //   - doesn't setup bootnodes - they will set when genesisHash will know
 func NewP2PConfig(
-	 nodiscover bool,
-	 dirs datadir.Dirs,
-	 netRestrict string,
-	 natSetting string,
-	 maxPeers int,
-	 maxPendPeers int,
-	 nodeName string,
-	 staticPeers []string,
-	 trustedPeers []string,
-	 port,
-	 protocol uint,
-	 allowedPorts []uint,
+	nodiscover bool,
+	dirs datadir.Dirs,
+	netRestrict string,
+	natSetting string,
+	maxPeers int,
+	maxPendPeers int,
+	nodeName string,
+	staticPeers []string,
+	trustedPeers []string,
+	port,
+	protocol uint,
+	allowedPorts []uint,
 ) (*p2p.Config, error) {
 	var enodeDBPath string
 	switch protocol {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -326,13 +326,14 @@ func New(stack *node.Node, config *ethconfig.Config, logger log.Logger) (*Ethere
 			// pick port from allowed list
 			var picked bool
 			for ; pi < len(refCfg.AllowedPorts); pi++ {
-				listenPort = int(refCfg.AllowedPorts[pi])
-				if !checkPortIsFree(fmt.Sprintf("%s:%d", listenHost, listenPort)) {
-					log.Warn("bind protocol to port has failed: port is busy", "protocol", fmt.Sprintf("eth/%d", protocol), "port", listenPort)
+				pc := int(refCfg.AllowedPorts[pi])
+				if !checkPortIsFree(fmt.Sprintf("%s:%d", listenHost, pc)) {
+					log.Warn("bind protocol to port has failed: port is busy", "protocol", fmt.Sprintf("eth/%d", protocol), "port", pc)
 					continue
 				}
 				picked = true
 				pi++
+				listenPort = pc
 
 				cfg.ListenAddr = fmt.Sprintf("%s:%d", listenHost, listenPort)
 				break

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -344,8 +344,6 @@ func New(stack *node.Node, config *ethconfig.Config, logger log.Logger) (*Ethere
 			server := sentry.NewGrpcServer(backend.sentryCtx, discovery, readNodeInfo, &cfg, protocol)
 			backend.sentryServers = append(backend.sentryServers, server)
 			sentries = append(sentries, direct.NewSentryClientDirect(protocol, server))
-
-			log.Info("sentry gRPC server has been started", "protocol", fmt.Sprintf("eth/%d", protocol), "addr", cfg.ListenAddr)
 		}
 
 		go func() {

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -139,6 +139,10 @@ type Config struct {
 	// the server is started.
 	ListenAddr string
 
+	// AllowedPorts is list of ports allowed to pick to create Listener on it (see ListenAddr)
+	// for different protocol versions
+	AllowedPorts []uint
+
 	// eth/66, eth/67, etc
 	ProtocolVersion []uint
 

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -91,6 +91,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.TorrentVerbosityFlag,
 	&utils.ListenPortFlag,
 	&utils.P2pProtocolVersionFlag,
+	&utils.P2pProtocolAllowedPorts,
 	&utils.NATFlag,
 	&utils.NoDiscoverFlag,
 	&utils.DiscoveryV5Flag,


### PR DESCRIPTION
Regarding https://github.com/ledgerwatch/erigon/issues/6260

added flag `--p2p.allowed-ports=<porta>,<portb>` to restrict which ports to use for sentries for different protocol versions.

Default for this flag is `30303, 30304` (first port is inherited from `--port` flag defaults.
If `--port` is changed and it's new value is not presented in allowed port list, provided port will be allowed as well as list provided via `--p2p.allowed-ports` 

Port picking is straightforward, we create sentry gRPC server for protocol over first allowed port that is not already taken.
If there are no allowed ports left, erigon exits with hint.
