### PR TITLE
Workaround for the code history of BSC system contracts

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -171,9 +171,9 @@ func (b *SimulatedBackend) emptyPendingBlock() {
 // stateByBlockNumber retrieves a state by a given blocknumber.
 func (b *SimulatedBackend) stateByBlockNumber(db kv.Tx, blockNumber *big.Int) *state.IntraBlockState {
 	if blockNumber == nil || blockNumber.Cmp(b.pendingBlock.Number()) == 0 {
-		return state.New(state.NewPlainState(db, b.pendingBlock.NumberU64()+1))
+		return state.New(state.NewPlainState(db, b.pendingBlock.NumberU64()+1, nil))
 	}
-	return state.New(state.NewPlainState(db, blockNumber.Uint64()+1))
+	return state.New(state.NewPlainState(db, blockNumber.Uint64()+1, nil))
 }
 
 // CodeAt returns the code associated with a certain account in the blockchain.

--- a/accounts/abi/bind/backends/simulated_test.go
+++ b/accounts/abi/bind/backends/simulated_test.go
@@ -146,7 +146,7 @@ func TestNewSimulatedBackend(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	statedb := state.New(state.NewPlainState(tx, num+1))
+	statedb := state.New(state.NewPlainState(tx, num+1, nil))
 	bal := statedb.GetBalance(testAddr)
 	if !bal.Eq(expectedBal) {
 		t.Errorf("expected balance for test address not received. expected: %v actual: %v", expectedBal, bal)

--- a/cmd/rpcdaemon/commands/erigon_block.go
+++ b/cmd/rpcdaemon/commands/erigon_block.go
@@ -208,7 +208,7 @@ func (api *ErigonImpl) GetBalanceChangesInBlock(ctx context.Context, blockNrOrHa
 
 	balancesMapping := make(map[common.Address]*hexutil.Big)
 
-	newReader, err := rpchelper.CreateStateReader(ctx, tx, blockNrOrHash, 0, api.filters, api.stateCache, api.historyV3(tx), api._agg)
+	newReader, err := rpchelper.CreateStateReader(ctx, tx, blockNrOrHash, 0, api.filters, api.stateCache, api.historyV3(tx), api._agg, "")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/rpcdaemon/commands/eth_accounts.go
+++ b/cmd/rpcdaemon/commands/eth_accounts.go
@@ -22,7 +22,7 @@ func (api *APIImpl) GetBalance(ctx context.Context, address common.Address, bloc
 		return nil, fmt.Errorf("getBalance cannot open tx: %w", err1)
 	}
 	defer tx.Rollback()
-	reader, err := rpchelper.CreateStateReader(ctx, tx, blockNrOrHash, 0, api.filters, api.stateCache, api.historyV3(tx), api._agg)
+	reader, err := rpchelper.CreateStateReader(ctx, tx, blockNrOrHash, 0, api.filters, api.stateCache, api.historyV3(tx), api._agg, "")
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (api *APIImpl) GetTransactionCount(ctx context.Context, address common.Addr
 		return nil, fmt.Errorf("getTransactionCount cannot open tx: %w", err1)
 	}
 	defer tx.Rollback()
-	reader, err := rpchelper.CreateStateReader(ctx, tx, blockNrOrHash, 0, api.filters, api.stateCache, api.historyV3(tx), api._agg)
+	reader, err := rpchelper.CreateStateReader(ctx, tx, blockNrOrHash, 0, api.filters, api.stateCache, api.historyV3(tx), api._agg, "")
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,11 @@ func (api *APIImpl) GetCode(ctx context.Context, address common.Address, blockNr
 		return nil, fmt.Errorf("getCode cannot open tx: %w", err1)
 	}
 	defer tx.Rollback()
-	reader, err := rpchelper.CreateStateReader(ctx, tx, blockNrOrHash, 0, api.filters, api.stateCache, api.historyV3(tx), api._agg)
+	chainConfig, err := api.chainConfig(tx)
+	if err != nil {
+		return nil, fmt.Errorf("read chain config: %v", err)
+	}
+	reader, err := rpchelper.CreateStateReader(ctx, tx, blockNrOrHash, 0, api.filters, api.stateCache, api.historyV3(tx), api._agg, chainConfig.ChainName)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +107,7 @@ func (api *APIImpl) GetStorageAt(ctx context.Context, address common.Address, in
 	}
 	defer tx.Rollback()
 
-	reader, err := rpchelper.CreateStateReader(ctx, tx, blockNrOrHash, 0, api.filters, api.stateCache, api.historyV3(tx), api._agg)
+	reader, err := rpchelper.CreateStateReader(ctx, tx, blockNrOrHash, 0, api.filters, api.stateCache, api.historyV3(tx), api._agg, "")
 	if err != nil {
 		return hexutil.Encode(common.LeftPadBytes(empty, 32)), err
 	}
@@ -128,7 +132,7 @@ func (api *APIImpl) Exist(ctx context.Context, address common.Address, blockNrOr
 	}
 	defer tx.Rollback()
 
-	reader, err := rpchelper.CreateStateReader(ctx, tx, blockNrOrHash, 0, api.filters, api.stateCache, api.historyV3(tx), api._agg)
+	reader, err := rpchelper.CreateStateReader(ctx, tx, blockNrOrHash, 0, api.filters, api.stateCache, api.historyV3(tx), api._agg, "")
 	if err != nil {
 		return false, err
 	}

--- a/cmd/rpcdaemon/commands/eth_block.go
+++ b/cmd/rpcdaemon/commands/eth_block.go
@@ -85,7 +85,7 @@ func (api *APIImpl) CallBundle(ctx context.Context, txHashes []common.Hash, stat
 		}
 		stateReader = state.NewCachedReader2(cacheView, tx)
 	} else {
-		stateReader, err = rpchelper.CreateHistoryStateReader(tx, stateBlockNumber, 0, api._agg, api.historyV3(tx))
+		stateReader, err = rpchelper.CreateHistoryStateReader(tx, stateBlockNumber, 0, api._agg, api.historyV3(tx), chainConfig.ChainName)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/rpcdaemon/commands/eth_call.go
+++ b/cmd/rpcdaemon/commands/eth_call.go
@@ -61,7 +61,7 @@ func (api *APIImpl) Call(ctx context.Context, args ethapi2.CallArgs, blockNrOrHa
 		return nil, nil
 	}
 
-	stateReader, err := rpchelper.CreateStateReader(ctx, tx, blockNrOrHash, 0, api.filters, api.stateCache, api.historyV3(tx), api._agg)
+	stateReader, err := rpchelper.CreateStateReader(ctx, tx, blockNrOrHash, 0, api.filters, api.stateCache, api.historyV3(tx), api._agg, chainConfig.ChainName)
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +233,7 @@ func (api *APIImpl) EstimateGas(ctx context.Context, argsOrNil *ethapi2.CallArgs
 		return 0, fmt.Errorf("could not find latest block in cache or db")
 	}
 
-	stateReader, err := rpchelper.CreateStateReaderFromBlockNumber(ctx, dbtx, latestCanBlockNumber, isLatest, 0, api.stateCache, api.historyV3(dbtx), api._agg)
+	stateReader, err := rpchelper.CreateStateReaderFromBlockNumber(ctx, dbtx, latestCanBlockNumber, isLatest, 0, api.stateCache, api.historyV3(dbtx), api._agg, chainConfig.ChainName)
 	if err != nil {
 		return 0, err
 	}
@@ -361,7 +361,7 @@ func (api *APIImpl) CreateAccessList(ctx context.Context, args ethapi2.CallArgs,
 		}
 		stateReader = state.NewCachedReader2(cacheView, tx)
 	} else {
-		stateReader, err = rpchelper.CreateHistoryStateReader(tx, blockNumber+1, 0, api._agg, api.historyV3(tx))
+		stateReader, err = rpchelper.CreateHistoryStateReader(tx, blockNumber+1, 0, api._agg, api.historyV3(tx), chainConfig.ChainName)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/rpcdaemon/commands/eth_callMany.go
+++ b/cmd/rpcdaemon/commands/eth_callMany.go
@@ -130,7 +130,7 @@ func (api *APIImpl) CallMany(ctx context.Context, bundles []Bundle, simulateCont
 
 	replayTransactions = block.Transactions()[:transactionIndex]
 
-	stateReader, err := rpchelper.CreateStateReader(ctx, tx, rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(blockNum-1)), 0, api.filters, api.stateCache, api.historyV3(tx), api._agg)
+	stateReader, err := rpchelper.CreateStateReader(ctx, tx, rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(blockNum-1)), 0, api.filters, api.stateCache, api.historyV3(tx), api._agg, chainConfig.ChainName)
 
 	if err != nil {
 		return nil, err

--- a/cmd/rpcdaemon/commands/eth_call_test.go
+++ b/cmd/rpcdaemon/commands/eth_call_test.go
@@ -358,13 +358,13 @@ func chainWithDeployedContract(t *testing.T) (*stages.MockSentry, common.Address
 
 	agg := m.HistoryV3Components()
 
-	stateReader, err := rpchelper.CreateHistoryStateReader(tx, 1, 0, agg, m.HistoryV3)
+	stateReader, err := rpchelper.CreateHistoryStateReader(tx, 1, 0, agg, m.HistoryV3, "")
 	assert.NoError(t, err)
 	st := state.New(stateReader)
 	assert.NoError(t, err)
 	assert.False(t, st.Exist(contractAddr), "Contract should not exist at block #1")
 
-	stateReader, err = rpchelper.CreateHistoryStateReader(tx, 2, 0, agg, m.HistoryV3)
+	stateReader, err = rpchelper.CreateHistoryStateReader(tx, 2, 0, agg, m.HistoryV3, "")
 	assert.NoError(t, err)
 	st = state.New(stateReader)
 	assert.NoError(t, err)

--- a/cmd/rpcdaemon/commands/otterscan_generic_tracer.go
+++ b/cmd/rpcdaemon/commands/otterscan_generic_tracer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/core"
 	"github.com/ledgerwatch/erigon/core/state"
+	"github.com/ledgerwatch/erigon/core/systemcontracts"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/core/vm"
 	"github.com/ledgerwatch/erigon/params"
@@ -29,7 +30,7 @@ func (api *OtterscanAPIImpl) genericTracer(dbtx kv.Tx, ctx context.Context, bloc
 		return nil
 	}
 
-	reader := state.NewPlainState(dbtx, blockNum)
+	reader := state.NewPlainState(dbtx, blockNum, systemcontracts.SystemContractCodeLookup[chainConfig.ChainName])
 	stateCache := shards.NewStateCache(32, 0 /* no limit */)
 	cachedReader := state.NewCachedReader(reader, stateCache)
 	noop := state.NewNoopWriter()

--- a/cmd/rpcdaemon/commands/otterscan_search_trace.go
+++ b/cmd/rpcdaemon/commands/otterscan_search_trace.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ledgerwatch/erigon/core"
 	"github.com/ledgerwatch/erigon/core/rawdb"
 	"github.com/ledgerwatch/erigon/core/state"
+	"github.com/ledgerwatch/erigon/core/systemcontracts"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/core/vm"
 	"github.com/ledgerwatch/erigon/params"
@@ -52,7 +53,7 @@ func (api *OtterscanAPIImpl) traceBlock(dbtx kv.Tx, ctx context.Context, blockNu
 		return false, nil, err
 	}
 
-	reader := state.NewPlainState(dbtx, blockNum)
+	reader := state.NewPlainState(dbtx, blockNum, systemcontracts.SystemContractCodeLookup[chainConfig.ChainName])
 	stateCache := shards.NewStateCache(32, 0 /* no limit */)
 	cachedReader := state.NewCachedReader(reader, stateCache)
 	noop := state.NewNoopWriter()

--- a/cmd/rpcdaemon/commands/trace_adhoc.go
+++ b/cmd/rpcdaemon/commands/trace_adhoc.go
@@ -869,7 +869,7 @@ func (api *TraceAPIImpl) Call(ctx context.Context, args TraceCallParam, traceTyp
 		return nil, err
 	}
 
-	stateReader, err := rpchelper.CreateStateReader(ctx, tx, *blockNrOrHash, 0, api.filters, api.stateCache, api.historyV3(tx), api._agg)
+	stateReader, err := rpchelper.CreateStateReader(ctx, tx, *blockNrOrHash, 0, api.filters, api.stateCache, api.historyV3(tx), api._agg, chainConfig.ChainName)
 	if err != nil {
 		return nil, err
 	}
@@ -1079,7 +1079,7 @@ func (api *TraceAPIImpl) doCallMany(ctx context.Context, dbtx kv.Tx, msgs []type
 	if err != nil {
 		return nil, err
 	}
-	stateReader, err := rpchelper.CreateStateReader(ctx, dbtx, *parentNrOrHash, 0, api.filters, api.stateCache, api.historyV3(dbtx), api._agg)
+	stateReader, err := rpchelper.CreateStateReader(ctx, dbtx, *parentNrOrHash, 0, api.filters, api.stateCache, api.historyV3(dbtx), api._agg, chainConfig.ChainName)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/rpcdaemon/commands/tracing.go
+++ b/cmd/rpcdaemon/commands/tracing.go
@@ -214,7 +214,7 @@ func (api *PrivateDebugAPIImpl) TraceCall(ctx context.Context, args ethapi.CallA
 		return fmt.Errorf("get block number: %v", err)
 	}
 
-	stateReader, err := rpchelper.CreateStateReader(ctx, dbtx, blockNrOrHash, 0, api.filters, api.stateCache, api.historyV3(dbtx), api._agg)
+	stateReader, err := rpchelper.CreateStateReader(ctx, dbtx, blockNrOrHash, 0, api.filters, api.stateCache, api.historyV3(dbtx), api._agg, chainConfig.ChainName)
 	if err != nil {
 		return fmt.Errorf("create state reader: %v", err)
 	}
@@ -319,7 +319,7 @@ func (api *PrivateDebugAPIImpl) TraceCallMany(ctx context.Context, bundles []Bun
 
 	replayTransactions = block.Transactions()[:transactionIndex]
 
-	stateReader, err := rpchelper.CreateStateReader(ctx, tx, rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(blockNum-1)), 0, api.filters, api.stateCache, api.historyV3(tx), api._agg)
+	stateReader, err := rpchelper.CreateStateReader(ctx, tx, rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(blockNum-1)), 0, api.filters, api.stateCache, api.historyV3(tx), api._agg, chainConfig.ChainName)
 	if err != nil {
 		stream.WriteNil()
 		return err

--- a/cmd/state/commands/check_change_sets.go
+++ b/cmd/state/commands/check_change_sets.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ledgerwatch/erigon/common/dbutils"
 	"github.com/ledgerwatch/erigon/core"
 	"github.com/ledgerwatch/erigon/core/state"
+	"github.com/ledgerwatch/erigon/core/systemcontracts"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/core/vm"
 	"github.com/ledgerwatch/erigon/eth/ethconfig"
@@ -146,7 +147,7 @@ func CheckChangeSets(genesis *core.Genesis, logger log.Logger, blockNum uint64, 
 		if b == nil {
 			break
 		}
-		reader := state.NewPlainState(historyTx, blockNum)
+		reader := state.NewPlainState(historyTx, blockNum, systemcontracts.SystemContractCodeLookup[chainConfig.ChainName])
 		//reader.SetTrace(blockNum == uint64(block))
 		intraBlockState := state.New(reader)
 		csw := state.NewChangeSetWriterPlain(nil /* db */, blockNum)

--- a/cmd/state/commands/opcode_tracer.go
+++ b/cmd/state/commands/opcode_tracer.go
@@ -553,7 +553,7 @@ func OpcodeTracer(genesis *core.Genesis, blockNum uint64, chaindata string, numB
 			ot.fsumWriter = bufio.NewWriter(fsum)
 		}
 
-		dbstate := state.NewPlainState(historyTx, block.NumberU64())
+		dbstate := state.NewPlainState(historyTx, block.NumberU64(), systemcontracts.SystemContractCodeLookup[chainConfig.ChainName])
 		intraBlockState := state.New(dbstate)
 		intraBlockState.SetTracer(ot)
 

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -180,7 +180,7 @@ func TestAllocConstructor(t *testing.T) {
 	require.NoError(err)
 	defer tx.Rollback()
 
-	state := state.New(state.NewPlainState(tx, 1))
+	state := state.New(state.NewPlainState(tx, 1, nil))
 	balance := state.GetBalance(address)
 	assert.Equal(funds, balance.ToBig())
 	code := state.GetCode(address)

--- a/core/state/access_list_test.go
+++ b/core/state/access_list_test.go
@@ -68,7 +68,7 @@ func TestAccessList(t *testing.T) {
 	slot := common.HexToHash
 
 	_, tx := memdb.NewTestTx(t)
-	state := New(NewPlainState(tx, 1))
+	state := New(NewPlainState(tx, 1, nil))
 	state.accessList = newAccessList()
 
 	state.AddAddressToAccessList(addr("aa"))          // 1

--- a/core/state/database_test.go
+++ b/core/state/database_test.go
@@ -841,7 +841,7 @@ func TestReproduceCrash(t *testing.T) {
 
 	_, tx := memdb.NewTestTx(t)
 	tsw := state.NewPlainStateWriter(tx, nil, 1)
-	intraBlockState := state.New(state.NewPlainState(tx, 1))
+	intraBlockState := state.New(state.NewPlainState(tx, 1, nil))
 	// Start the 1st transaction
 	intraBlockState.CreateAccount(contract, true)
 	if err := intraBlockState.FinalizeTx(&params.Rules{}, tsw); err != nil {
@@ -1267,7 +1267,7 @@ func TestCacheCodeSizeSeparately(t *testing.T) {
 	//root := common.HexToHash("0xb939e5bcf5809adfb87ab07f0795b05b95a1d64a90f0eddd0c3123ac5b433854")
 
 	_, tx := memdb.NewTestTx(t)
-	r, w := state.NewPlainState(tx, 0), state.NewPlainStateWriter(tx, nil, 0)
+	r, w := state.NewPlainState(tx, 0, nil), state.NewPlainStateWriter(tx, nil, 0)
 	intraBlockState := state.New(r)
 	// Start the 1st transaction
 	intraBlockState.CreateAccount(contract, true)
@@ -1300,7 +1300,7 @@ func TestCacheCodeSizeInTrie(t *testing.T) {
 	root := common.HexToHash("0xb939e5bcf5809adfb87ab07f0795b05b95a1d64a90f0eddd0c3123ac5b433854")
 
 	_, tx := memdb.NewTestTx(t)
-	r, w := state.NewPlainState(tx, 0), state.NewPlainStateWriter(tx, nil, 0)
+	r, w := state.NewPlainState(tx, 0, nil), state.NewPlainStateWriter(tx, nil, 0)
 	intraBlockState := state.New(r)
 	// Start the 1st transaction
 	intraBlockState.CreateAccount(contract, true)

--- a/core/state/history.go
+++ b/core/state/history.go
@@ -29,6 +29,7 @@ func GetAsOf(tx kv.Tx, indexC kv.Cursor, changesC kv.CursorDupSort, storage bool
 }
 
 func FindByHistory(tx kv.Tx, indexC kv.Cursor, changesC kv.CursorDupSort, storage bool, key []byte, timestamp uint64) ([]byte, error) {
+	fmt.Printf("FindByHistory %x, timestamp %d\n", key, timestamp)
 	var csBucket string
 	if storage {
 		csBucket = kv.StorageChangeSet
@@ -88,6 +89,7 @@ func FindByHistory(tx kv.Tx, indexC kv.Cursor, changesC kv.CursorDupSort, storag
 			if err != nil {
 				return nil, err
 			}
+			fmt.Printf("Restoring codehash for incarnation %d, got %x\n", acc.Incarnation, codeHash)
 			if len(codeHash) > 0 {
 				acc.CodeHash.SetBytes(codeHash)
 			}

--- a/core/state/history.go
+++ b/core/state/history.go
@@ -29,7 +29,6 @@ func GetAsOf(tx kv.Tx, indexC kv.Cursor, changesC kv.CursorDupSort, storage bool
 }
 
 func FindByHistory(tx kv.Tx, indexC kv.Cursor, changesC kv.CursorDupSort, storage bool, key []byte, timestamp uint64) ([]byte, error) {
-	fmt.Printf("FindByHistory %x, timestamp %d\n", key, timestamp)
 	var csBucket string
 	if storage {
 		csBucket = kv.StorageChangeSet
@@ -89,7 +88,6 @@ func FindByHistory(tx kv.Tx, indexC kv.Cursor, changesC kv.CursorDupSort, storag
 			if err != nil {
 				return nil, err
 			}
-			fmt.Printf("Restoring codehash for incarnation %d, got %x\n", acc.Incarnation, codeHash)
 			if len(codeHash) > 0 {
 				acc.CodeHash.SetBytes(codeHash)
 			}

--- a/core/state/plain_readonly.go
+++ b/core/state/plain_readonly.go
@@ -216,9 +216,9 @@ func (s *PlainState) ReadAccountCode(address common.Address, incarnation uint64,
 		return nil, nil
 	}
 	code, err := s.tx.GetOne(kv.Code, codeHash[:])
-	//if s.trace {
-	fmt.Printf("ReadAccountCode [%x %x] => [%x]\n", address, codeHash, code)
-	//}
+	if s.trace {
+		fmt.Printf("ReadAccountCode [%x %x] => [%x]\n", address, codeHash, code)
+	}
 	if len(code) == 0 {
 		return nil, nil
 	}

--- a/core/state/plain_readonly.go
+++ b/core/state/plain_readonly.go
@@ -177,10 +177,16 @@ func (s *PlainState) ReadAccountData(address common.Address) (*accounts.Account,
 	}
 	//restore codehash
 	if a.Incarnation > 0 && a.IsEmptyCodeHash() {
+		fmt.Printf("restore codehash\n")
 		if records, ok := s.systemContractLookup[address]; ok {
+			fmt.Printf("Using system contract lookup for %x %d\n", address, s.blockNr)
+			for i, rec := range records {
+				fmt.Printf("i=%d, blockN = %d, codeHash = %x\n", i, rec.BlockNumber, rec.CodeHash)
+			}
 			p := sort.Search(len(records), func(i int) bool {
 				return records[i].BlockNumber > s.blockNr
 			})
+			fmt.Printf("p = %d\n", p)
 			a.CodeHash = records[p-1].CodeHash
 		} else if codeHash, err1 := s.tx.GetOne(kv.PlainContractCode, dbutils.PlainGenerateStoragePrefix(address[:], a.Incarnation)); err1 == nil {
 			if len(codeHash) > 0 {

--- a/core/state/plain_readonly.go
+++ b/core/state/plain_readonly.go
@@ -176,19 +176,19 @@ func (s *PlainState) ReadAccountData(address common.Address) (*accounts.Account,
 		return nil, err
 	}
 	//restore codehash
-	if a.Incarnation > 0 && a.IsEmptyCodeHash() {
-		fmt.Printf("restore codehash\n")
-		if records, ok := s.systemContractLookup[address]; ok {
-			fmt.Printf("Using system contract lookup for %x %d\n", address, s.blockNr)
-			for i, rec := range records {
-				fmt.Printf("i=%d, blockN = %d, codeHash = %x\n", i, rec.BlockNumber, rec.CodeHash)
-			}
-			p := sort.Search(len(records), func(i int) bool {
-				return records[i].BlockNumber > s.blockNr
-			})
-			fmt.Printf("p = %d\n", p)
-			a.CodeHash = records[p-1].CodeHash
-		} else if codeHash, err1 := s.tx.GetOne(kv.PlainContractCode, dbutils.PlainGenerateStoragePrefix(address[:], a.Incarnation)); err1 == nil {
+	if records, ok := s.systemContractLookup[address]; ok {
+		fmt.Printf("Using system contract lookup for %x %d\n", address, s.blockNr)
+		for i, rec := range records {
+			fmt.Printf("i=%d, blockN = %d, codeHash = %x\n", i, rec.BlockNumber, rec.CodeHash)
+		}
+		p := sort.Search(len(records), func(i int) bool {
+			return records[i].BlockNumber > s.blockNr
+		})
+		fmt.Printf("p = %d\n", p)
+		a.CodeHash = records[p-1].CodeHash
+	} else if a.Incarnation > 0 && a.IsEmptyCodeHash() {
+		fmt.Printf("restore codehash for incarnation %d\n", a.Incarnation)
+		if codeHash, err1 := s.tx.GetOne(kv.PlainContractCode, dbutils.PlainGenerateStoragePrefix(address[:], a.Incarnation)); err1 == nil {
 			if len(codeHash) > 0 {
 				a.CodeHash = common.BytesToHash(codeHash)
 			}

--- a/core/state/plain_readonly.go
+++ b/core/state/plain_readonly.go
@@ -177,9 +177,9 @@ func (s *PlainState) ReadAccountData(address common.Address) (*accounts.Account,
 			return nil, err1
 		}
 	}
-	if s.trace {
-		fmt.Printf("ReadAccountData [%x] => [nonce: %d, balance: %d, codeHash: %x]\n", address, a.Nonce, &a.Balance, a.CodeHash)
-	}
+	//if s.trace {
+	fmt.Printf("ReadAccountData [%x] => [nonce: %d, balance: %d, codeHash: %x]\n", address, a.Nonce, &a.Balance, a.CodeHash)
+	//}
 	return &a, nil
 }
 
@@ -203,9 +203,9 @@ func (s *PlainState) ReadAccountCode(address common.Address, incarnation uint64,
 		return nil, nil
 	}
 	code, err := s.tx.GetOne(kv.Code, codeHash[:])
-	if s.trace {
-		fmt.Printf("ReadAccountCode [%x %x] => [%x]\n", address, codeHash, code)
-	}
+	//if s.trace {
+	fmt.Printf("ReadAccountCode [%x %x] => [%x]\n", address, codeHash, code)
+	//}
 	if len(code) == 0 {
 		return nil, nil
 	}

--- a/core/state/plain_readonly.go
+++ b/core/state/plain_readonly.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"sort"
 
 	"github.com/google/btree"
 	"github.com/holiman/uint256"
@@ -30,6 +31,11 @@ import (
 	"github.com/ledgerwatch/erigon/core/types/accounts"
 	"github.com/ledgerwatch/log/v3"
 )
+
+type CodeRecord struct {
+	BlockNumber uint64
+	CodeHash    common.Hash
+}
 
 type storageItem struct {
 	key, seckey common.Hash
@@ -49,9 +55,10 @@ type PlainState struct {
 	blockNr                      uint64
 	storage                      map[common.Address]*btree.BTree
 	trace                        bool
+	systemContractLookup         map[common.Address][]CodeRecord
 }
 
-func NewPlainState(tx kv.Tx, blockNr uint64) *PlainState {
+func NewPlainState(tx kv.Tx, blockNr uint64, systemContractLookup map[common.Address][]CodeRecord) *PlainState {
 	c1, _ := tx.Cursor(kv.AccountsHistory)
 	c2, _ := tx.Cursor(kv.StorageHistory)
 	c3, _ := tx.CursorDupSort(kv.AccountChangeSet)
@@ -62,6 +69,7 @@ func NewPlainState(tx kv.Tx, blockNr uint64) *PlainState {
 		blockNr:     blockNr,
 		storage:     make(map[common.Address]*btree.BTree),
 		accHistoryC: c1, storageHistoryC: c2, accChangesC: c3, storageChangesC: c4,
+		systemContractLookup: systemContractLookup,
 	}
 }
 
@@ -169,7 +177,12 @@ func (s *PlainState) ReadAccountData(address common.Address) (*accounts.Account,
 	}
 	//restore codehash
 	if a.Incarnation > 0 && a.IsEmptyCodeHash() {
-		if codeHash, err1 := s.tx.GetOne(kv.PlainContractCode, dbutils.PlainGenerateStoragePrefix(address[:], a.Incarnation)); err1 == nil {
+		if records, ok := s.systemContractLookup[address]; ok {
+			p := sort.Search(len(records), func(i int) bool {
+				return records[i].BlockNumber > s.blockNr
+			})
+			a.CodeHash = records[p-1].CodeHash
+		} else if codeHash, err1 := s.tx.GetOne(kv.PlainContractCode, dbutils.PlainGenerateStoragePrefix(address[:], a.Incarnation)); err1 == nil {
 			if len(codeHash) > 0 {
 				a.CodeHash = common.BytesToHash(codeHash)
 			}

--- a/core/state/plain_readonly.go
+++ b/core/state/plain_readonly.go
@@ -177,17 +177,11 @@ func (s *PlainState) ReadAccountData(address common.Address) (*accounts.Account,
 	}
 	//restore codehash
 	if records, ok := s.systemContractLookup[address]; ok {
-		fmt.Printf("Using system contract lookup for %x %d\n", address, s.blockNr)
-		for i, rec := range records {
-			fmt.Printf("i=%d, blockN = %d, codeHash = %x\n", i, rec.BlockNumber, rec.CodeHash)
-		}
 		p := sort.Search(len(records), func(i int) bool {
 			return records[i].BlockNumber > s.blockNr
 		})
-		fmt.Printf("p = %d\n", p)
 		a.CodeHash = records[p-1].CodeHash
 	} else if a.Incarnation > 0 && a.IsEmptyCodeHash() {
-		fmt.Printf("restore codehash for incarnation %d\n", a.Incarnation)
 		if codeHash, err1 := s.tx.GetOne(kv.PlainContractCode, dbutils.PlainGenerateStoragePrefix(address[:], a.Incarnation)); err1 == nil {
 			if len(codeHash) > 0 {
 				a.CodeHash = common.BytesToHash(codeHash)
@@ -196,9 +190,9 @@ func (s *PlainState) ReadAccountData(address common.Address) (*accounts.Account,
 			return nil, err1
 		}
 	}
-	//if s.trace {
-	fmt.Printf("ReadAccountData [%x] => [nonce: %d, balance: %d, codeHash: %x]\n", address, a.Nonce, &a.Balance, a.CodeHash)
-	//}
+	if s.trace {
+		fmt.Printf("ReadAccountData [%x] => [nonce: %d, balance: %d, codeHash: %x]\n", address, a.Nonce, &a.Balance, a.CodeHash)
+	}
 	return &a, nil
 }
 

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -108,8 +108,8 @@ func (s *StateSuite) SetUpTest(c *checker.C) {
 		panic(err)
 	}
 	s.tx = tx
-	s.r = NewPlainState(tx, 1)
-	s.w = NewPlainState(tx, 1)
+	s.r = NewPlainState(tx, 1, nil)
+	s.w = NewPlainState(tx, 1, nil)
 	s.state = New(s.r)
 }
 
@@ -204,8 +204,8 @@ func (s *StateSuite) TestSnapshotEmpty(c *checker.C) {
 // printing/logging in tests (-check.vv does not work)
 func TestSnapshot2(t *testing.T) {
 	_, tx := memdb.NewTestTx(t)
-	w := NewPlainState(tx, 1)
-	state := New(NewPlainState(tx, 1))
+	w := NewPlainState(tx, 1, nil)
+	state := New(NewPlainState(tx, 1, nil))
 
 	stateobjaddr0 := toAddr([]byte("so0"))
 	stateobjaddr1 := toAddr([]byte("so1"))
@@ -230,7 +230,7 @@ func TestSnapshot2(t *testing.T) {
 	if err != nil {
 		t.Fatal("error while finalizing transaction", err)
 	}
-	w = NewPlainState(tx, 2)
+	w = NewPlainState(tx, 2, nil)
 
 	err = state.CommitBlock(&params.Rules{}, w)
 	if err != nil {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -395,9 +395,11 @@ func (st *StateTransition) TransitionDb(refunds bool, gasBailout bool) (*Executi
 	if rules.IsNano {
 		for _, blackListAddr := range types.NanoBlackList {
 			if blackListAddr == sender.Address() {
+				fmt.Printf("block blacklist accountn\n")
 				return nil, fmt.Errorf("block blacklist account")
 			}
 			if msg.To() != nil && *msg.To() == blackListAddr {
+				fmt.Printf("block blacklist account from\n")
 				return nil, fmt.Errorf("block blacklist account")
 			}
 		}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -395,11 +395,9 @@ func (st *StateTransition) TransitionDb(refunds bool, gasBailout bool) (*Executi
 	if rules.IsNano {
 		for _, blackListAddr := range types.NanoBlackList {
 			if blackListAddr == sender.Address() {
-				fmt.Printf("block blacklist accountn\n")
 				return nil, fmt.Errorf("block blacklist account")
 			}
 			if msg.To() != nil && *msg.To() == blackListAddr {
-				fmt.Printf("block blacklist account from\n")
 				return nil, fmt.Errorf("block blacklist account")
 			}
 		}

--- a/core/system_contract_lookup.go
+++ b/core/system_contract_lookup.go
@@ -1,0 +1,99 @@
+package core
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/ledgerwatch/erigon/common"
+	"github.com/ledgerwatch/erigon/core/state"
+	"github.com/ledgerwatch/erigon/core/systemcontracts"
+	"github.com/ledgerwatch/erigon/params"
+	"github.com/ledgerwatch/erigon/params/networkname"
+)
+
+func init() {
+	// Initialise systemContractCodeLookup
+	for _, chainName := range []string{networkname.BSCChainName, networkname.ChapelChainName, networkname.RialtoChainName} {
+		byChain := map[common.Address][]state.CodeRecord{}
+		systemcontracts.SystemContractCodeLookup[chainName] = byChain
+		// Apply genesis with the block number 0
+		genesisBlock := DefaultGenesisBlockByChainName(chainName)
+		for addr, alloc := range genesisBlock.Alloc {
+			if len(alloc.Code) > 0 {
+				list, ok := byChain[addr]
+				if !ok {
+					list = []state.CodeRecord{}
+					byChain[addr] = list
+				}
+				codeHash, err := common.HashData(alloc.Code)
+				if err != nil {
+					panic(fmt.Errorf("failed to hash system contract code: %s", err.Error()))
+				}
+				list = append(list, state.CodeRecord{BlockNumber: 0, CodeHash: codeHash})
+			}
+		}
+		// Process upgrades
+		chainConfig := params.ChainConfigByChainName(chainName)
+		if chainConfig.RamanujanBlock != nil {
+			blockNum := chainConfig.RamanujanBlock.Uint64()
+			if blockNum != 0 {
+				addCodeRecords(systemcontracts.RamanujanUpgrade[chainName], blockNum, byChain)
+			}
+		}
+		if chainConfig.NielsBlock != nil {
+			blockNum := chainConfig.NielsBlock.Uint64()
+			if blockNum != 0 {
+				addCodeRecords(systemcontracts.NielsUpgrade[chainName], blockNum, byChain)
+			}
+		}
+		if chainConfig.MirrorSyncBlock != nil {
+			blockNum := chainConfig.MirrorSyncBlock.Uint64()
+			if blockNum != 0 {
+				addCodeRecords(systemcontracts.MirrorUpgrade[chainName], blockNum, byChain)
+			}
+		}
+		if chainConfig.BrunoBlock != nil {
+			blockNum := chainConfig.BrunoBlock.Uint64()
+			if blockNum != 0 {
+				addCodeRecords(systemcontracts.BrunoUpgrade[chainName], blockNum, byChain)
+			}
+		}
+		if chainConfig.EulerBlock != nil {
+			blockNum := chainConfig.EulerBlock.Uint64()
+			if blockNum != 0 {
+				addCodeRecords(systemcontracts.EulerUpgrade[chainName], blockNum, byChain)
+			}
+		}
+		if chainConfig.MoranBlock != nil {
+			blockNum := chainConfig.MoranBlock.Uint64()
+			if blockNum != 0 {
+				addCodeRecords(systemcontracts.MoranUpgrade[chainName], blockNum, byChain)
+			}
+		}
+		if chainConfig.GibbsBlock != nil {
+			blockNum := chainConfig.GibbsBlock.Uint64()
+			if blockNum != 0 {
+				addCodeRecords(systemcontracts.GibbsUpgrade[chainName], blockNum, byChain)
+			}
+		}
+	}
+}
+
+func addCodeRecords(upgrade *systemcontracts.Upgrade, blockNum uint64, byChain map[common.Address][]state.CodeRecord) {
+	for _, config := range upgrade.Configs {
+		list, ok := byChain[config.ContractAddr]
+		if !ok {
+			list = []state.CodeRecord{}
+			byChain[config.ContractAddr] = list
+		}
+		code, err := hex.DecodeString(config.Code)
+		if err != nil {
+			panic(fmt.Errorf("failed to decode system contract code: %s", err.Error()))
+		}
+		codeHash, err := common.HashData(code)
+		if err != nil {
+			panic(fmt.Errorf("failed to hash system contract code: %s", err.Error()))
+		}
+		list = append(list, state.CodeRecord{BlockNumber: blockNum, CodeHash: codeHash})
+	}
+}

--- a/core/system_contract_lookup.go
+++ b/core/system_contract_lookup.go
@@ -20,16 +20,13 @@ func init() {
 		genesisBlock := DefaultGenesisBlockByChainName(chainName)
 		for addr, alloc := range genesisBlock.Alloc {
 			if len(alloc.Code) > 0 {
-				list, ok := byChain[addr]
-				if !ok {
-					list = []state.CodeRecord{}
-					byChain[addr] = list
-				}
+				list := byChain[addr]
 				codeHash, err := common.HashData(alloc.Code)
 				if err != nil {
 					panic(fmt.Errorf("failed to hash system contract code: %s", err.Error()))
 				}
 				list = append(list, state.CodeRecord{BlockNumber: 0, CodeHash: codeHash})
+				byChain[addr] = list
 			}
 		}
 		// Process upgrades
@@ -81,11 +78,7 @@ func init() {
 
 func addCodeRecords(upgrade *systemcontracts.Upgrade, blockNum uint64, byChain map[common.Address][]state.CodeRecord) {
 	for _, config := range upgrade.Configs {
-		list, ok := byChain[config.ContractAddr]
-		if !ok {
-			list = []state.CodeRecord{}
-			byChain[config.ContractAddr] = list
-		}
+		list := byChain[config.ContractAddr]
 		code, err := hex.DecodeString(config.Code)
 		if err != nil {
 			panic(fmt.Errorf("failed to decode system contract code: %s", err.Error()))
@@ -95,5 +88,6 @@ func addCodeRecords(upgrade *systemcontracts.Upgrade, blockNum uint64, byChain m
 			panic(fmt.Errorf("failed to hash system contract code: %s", err.Error()))
 		}
 		list = append(list, state.CodeRecord{BlockNumber: blockNum, CodeHash: codeHash})
+		byChain[config.ContractAddr] = list
 	}
 }

--- a/core/systemcontracts/upgrade.go
+++ b/core/systemcontracts/upgrade.go
@@ -27,32 +27,32 @@ type Upgrade struct {
 
 type upgradeHook func(blockNumber *big.Int, contractAddr common.Address, statedb *state.IntraBlockState) error
 
-const (
-	mainNet    = "Mainnet"
-	chapelNet  = "Chapel"
-	rialtoNet  = "Rialto"
-	defaultNet = "Default"
-)
-
 var (
 	//upgrade config
-	ramanujanUpgrade = make(map[string]*Upgrade)
+	RamanujanUpgrade = make(map[string]*Upgrade)
 
-	nielsUpgrade = make(map[string]*Upgrade)
+	NielsUpgrade = make(map[string]*Upgrade)
 
-	mirrorUpgrade = make(map[string]*Upgrade)
+	MirrorUpgrade = make(map[string]*Upgrade)
 
-	brunoUpgrade = make(map[string]*Upgrade)
+	BrunoUpgrade = make(map[string]*Upgrade)
 
-	eulerUpgrade = make(map[string]*Upgrade)
+	EulerUpgrade = make(map[string]*Upgrade)
 
-	gibbsUpgrade = make(map[string]*Upgrade)
+	GibbsUpgrade = make(map[string]*Upgrade)
 
-	moranUpgrade = make(map[string]*Upgrade)
+	MoranUpgrade = make(map[string]*Upgrade)
+
+	// SystemContractCodeLookup is used to address a flaw in the upgrade logic of the system contracts. Since they are updated directly, without first being self-destructed
+	// and then re-created, the usual incarnation logic does not get activated, and all historical records of the code of these contracts are retrieved as the most
+	// recent version. This problem will not exist in erigon3, but until then, a workaround will be used to access code of such contracts through this structure
+	// Lookup is performed first by chain name, then by contract address. The value in the map is the list of CodeRecords, with increasing block numbers,
+	// to be used in binary search to determine correct historical code
+	SystemContractCodeLookup = map[string]map[common.Address][]state.CodeRecord{}
 )
 
 func init() {
-	ramanujanUpgrade[rialtoNet] = &Upgrade{
+	RamanujanUpgrade[networkname.RialtoChainName] = &Upgrade{
 		UpgradeName: "ramanujan",
 		Configs: []*UpgradeConfig{
 			{
@@ -108,7 +108,7 @@ func init() {
 		},
 	}
 
-	ramanujanUpgrade[chapelNet] = &Upgrade{
+	RamanujanUpgrade[networkname.ChapelChainName] = &Upgrade{
 		UpgradeName: "ramanujan",
 		Configs: []*UpgradeConfig{
 			{
@@ -164,7 +164,7 @@ func init() {
 		},
 	}
 
-	nielsUpgrade[chapelNet] = &Upgrade{
+	NielsUpgrade[networkname.ChapelChainName] = &Upgrade{
 		UpgradeName: "niels",
 		Configs: []*UpgradeConfig{
 			{
@@ -220,7 +220,7 @@ func init() {
 		},
 	}
 
-	mirrorUpgrade[mainNet] = &Upgrade{
+	MirrorUpgrade[networkname.BSCChainName] = &Upgrade{
 		UpgradeName: "mirror",
 		Configs: []*UpgradeConfig{
 			{
@@ -241,7 +241,7 @@ func init() {
 		},
 	}
 
-	mirrorUpgrade[chapelNet] = &Upgrade{
+	MirrorUpgrade[networkname.ChapelChainName] = &Upgrade{
 		UpgradeName: "mirror",
 		Configs: []*UpgradeConfig{
 			{
@@ -262,7 +262,7 @@ func init() {
 		},
 	}
 
-	mirrorUpgrade[rialtoNet] = &Upgrade{
+	MirrorUpgrade[networkname.RialtoChainName] = &Upgrade{
 		UpgradeName: "mirror",
 		Configs: []*UpgradeConfig{
 			{
@@ -283,7 +283,7 @@ func init() {
 		},
 	}
 
-	brunoUpgrade[mainNet] = &Upgrade{
+	BrunoUpgrade[networkname.BSCChainName] = &Upgrade{
 		UpgradeName: "bruno",
 		Configs: []*UpgradeConfig{
 			{
@@ -294,7 +294,7 @@ func init() {
 		},
 	}
 
-	brunoUpgrade[chapelNet] = &Upgrade{
+	BrunoUpgrade[networkname.ChapelChainName] = &Upgrade{
 		UpgradeName: "bruno",
 		Configs: []*UpgradeConfig{
 			{
@@ -305,7 +305,7 @@ func init() {
 		},
 	}
 
-	brunoUpgrade[rialtoNet] = &Upgrade{
+	BrunoUpgrade[networkname.RialtoChainName] = &Upgrade{
 		UpgradeName: "bruno",
 		Configs: []*UpgradeConfig{
 			{
@@ -316,7 +316,7 @@ func init() {
 		},
 	}
 
-	eulerUpgrade[mainNet] = &Upgrade{
+	EulerUpgrade[networkname.BSCChainName] = &Upgrade{
 		UpgradeName: "euler",
 		Configs: []*UpgradeConfig{
 			{
@@ -332,7 +332,7 @@ func init() {
 		},
 	}
 
-	eulerUpgrade[chapelNet] = &Upgrade{
+	EulerUpgrade[networkname.ChapelChainName] = &Upgrade{
 		UpgradeName: "euler",
 		Configs: []*UpgradeConfig{
 			{
@@ -348,7 +348,7 @@ func init() {
 		},
 	}
 
-	eulerUpgrade[rialtoNet] = &Upgrade{
+	EulerUpgrade[networkname.RialtoChainName] = &Upgrade{
 		UpgradeName: "euler",
 		Configs: []*UpgradeConfig{
 			{
@@ -364,7 +364,7 @@ func init() {
 		},
 	}
 
-	gibbsUpgrade[chapelNet] = &Upgrade{
+	GibbsUpgrade[networkname.ChapelChainName] = &Upgrade{
 		UpgradeName: "gibbs",
 		Configs: []*UpgradeConfig{
 			{
@@ -380,7 +380,7 @@ func init() {
 		},
 	}
 
-	gibbsUpgrade[rialtoNet] = &Upgrade{
+	GibbsUpgrade[networkname.RialtoChainName] = &Upgrade{
 		UpgradeName: "gibbs",
 		Configs: []*UpgradeConfig{
 			{
@@ -396,7 +396,7 @@ func init() {
 		},
 	}
 
-	gibbsUpgrade[mainNet] = &Upgrade{
+	GibbsUpgrade[networkname.BSCChainName] = &Upgrade{
 		UpgradeName: "gibbs",
 		Configs: []*UpgradeConfig{
 			{
@@ -412,7 +412,7 @@ func init() {
 		},
 	}
 
-	moranUpgrade[mainNet] = &Upgrade{
+	MoranUpgrade[networkname.BSCChainName] = &Upgrade{
 		UpgradeName: "moran",
 		Configs: []*UpgradeConfig{
 			{
@@ -433,7 +433,7 @@ func init() {
 		},
 	}
 
-	moranUpgrade[chapelNet] = &Upgrade{
+	MoranUpgrade[networkname.ChapelChainName] = &Upgrade{
 		UpgradeName: "moran",
 		Configs: []*UpgradeConfig{
 			{
@@ -454,7 +454,7 @@ func init() {
 		},
 	}
 
-	moranUpgrade[rialtoNet] = &Upgrade{
+	MoranUpgrade[networkname.RialtoChainName] = &Upgrade{
 		UpgradeName: "moran",
 		Configs: []*UpgradeConfig{
 			{
@@ -480,45 +480,34 @@ func UpgradeBuildInSystemContract(config *params.ChainConfig, blockNumber *big.I
 	if config == nil || blockNumber == nil || statedb == nil {
 		return
 	}
-	var network string
-	switch config.ChainName {
-	case networkname.BSCChainName:
-		network = mainNet
-	case networkname.ChapelChainName:
-		network = chapelNet
-	case networkname.RialtoChainName:
-		network = rialtoNet
-	default:
-		network = defaultNet
-	}
 
-	logger := log.New("system-contract-upgrade", network)
+	logger := log.New("system-contract-upgrade", config.ChainName)
 	if config.IsOnRamanujan(blockNumber) {
-		applySystemContractUpgrade(ramanujanUpgrade[network], blockNumber, statedb, logger)
+		applySystemContractUpgrade(RamanujanUpgrade[config.ChainName], blockNumber, statedb, logger)
 	}
 
 	if config.IsOnNiels(blockNumber) {
-		applySystemContractUpgrade(nielsUpgrade[network], blockNumber, statedb, logger)
+		applySystemContractUpgrade(NielsUpgrade[config.ChainName], blockNumber, statedb, logger)
 	}
 
 	if config.IsOnMirrorSync(blockNumber) {
-		applySystemContractUpgrade(mirrorUpgrade[network], blockNumber, statedb, logger)
+		applySystemContractUpgrade(MirrorUpgrade[config.ChainName], blockNumber, statedb, logger)
 	}
 
 	if config.IsOnBruno(blockNumber) {
-		applySystemContractUpgrade(brunoUpgrade[network], blockNumber, statedb, logger)
+		applySystemContractUpgrade(BrunoUpgrade[config.ChainName], blockNumber, statedb, logger)
 	}
 
 	if config.IsOnEuler(blockNumber) {
-		applySystemContractUpgrade(eulerUpgrade[network], blockNumber, statedb, logger)
-	}
-
-	if config.IsOnGibbs(blockNumber) {
-		applySystemContractUpgrade(gibbsUpgrade[network], blockNumber, statedb, logger)
+		applySystemContractUpgrade(EulerUpgrade[config.ChainName], blockNumber, statedb, logger)
 	}
 
 	if config.IsOnMoran(blockNumber) {
-		applySystemContractUpgrade(moranUpgrade[network], blockNumber, statedb, logger)
+		applySystemContractUpgrade(MoranUpgrade[config.ChainName], blockNumber, statedb, logger)
+	}
+
+	if config.IsOnGibbs(blockNumber) {
+		applySystemContractUpgrade(GibbsUpgrade[config.ChainName], blockNumber, statedb, logger)
 	}
 
 	/*

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -161,7 +161,7 @@ func BenchmarkCall(b *testing.B) {
 func benchmarkEVM_Create(bench *testing.B, code string) {
 	_, tx := memdb.NewTestTx(bench)
 	var (
-		statedb  = state.New(state.NewPlainState(tx, 1))
+		statedb  = state.New(state.NewPlainState(tx, 1, nil))
 		sender   = common.BytesToAddress([]byte("sender"))
 		receiver = common.BytesToAddress([]byte("receiver"))
 	)
@@ -329,7 +329,7 @@ func benchmarkNonModifyingCode(gas uint64, code []byte, name string, b *testing.
 	cfg := new(Config)
 	setDefaults(cfg)
 	_, tx := memdb.NewTestTx(b)
-	cfg.State = state.New(state.NewPlainState(tx, 1))
+	cfg.State = state.New(state.NewPlainState(tx, 1, nil))
 	cfg.GasLimit = gas
 	var (
 		destination = common.BytesToAddress([]byte("contract"))

--- a/turbo/stages/blockchain_test.go
+++ b/turbo/stages/blockchain_test.go
@@ -1387,7 +1387,7 @@ func TestDeleteRecreateSlots(t *testing.T) {
 		t.Fatalf("failed to insert into chain: %v", err)
 	}
 	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
-		statedb := state.New(state.NewPlainState(tx, 2))
+		statedb := state.New(state.NewPlainState(tx, 2, nil))
 
 		// If all is correct, then slot 1 and 2 are zero
 		key1 := common.HexToHash("01")
@@ -1495,7 +1495,7 @@ func TestCVE2020_26265(t *testing.T) {
 		t.Fatalf("failed to insert into chain: %v", err)
 	}
 	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
-		statedb := state.New(state.NewPlainState(tx, 2))
+		statedb := state.New(state.NewPlainState(tx, 2, nil))
 
 		got := statedb.GetBalance(aa)
 		if !got.Eq(new(uint256.Int).SetUint64(5)) {
@@ -1561,7 +1561,7 @@ func TestDeleteRecreateAccount(t *testing.T) {
 		t.Fatalf("failed to insert into chain: %v", err)
 	}
 	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
-		statedb := state.New(state.NewPlainState(tx, 2))
+		statedb := state.New(state.NewPlainState(tx, 2, nil))
 
 		// If all is correct, then both slots are zero
 		key1 := common.HexToHash("01")
@@ -1875,7 +1875,7 @@ func TestInitThenFailCreateContract(t *testing.T) {
 	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
 
 		// Import the canonical chain
-		statedb := state.New(state.NewPlainState(tx, 2))
+		statedb := state.New(state.NewPlainState(tx, 2, nil))
 		if got, exp := statedb.GetBalance(aa), uint64(100000); got.Uint64() != exp {
 			t.Fatalf("Genesis err, got %v exp %v", got, exp)
 		}
@@ -1885,7 +1885,7 @@ func TestInitThenFailCreateContract(t *testing.T) {
 			if err := m.InsertChain(chain.Slice(0, 1)); err != nil {
 				t.Fatalf("block %d: failed to insert into chain: %v", block.NumberU64(), err)
 			}
-			statedb = state.New(state.NewPlainState(tx, 1))
+			statedb = state.New(state.NewPlainState(tx, 1, nil))
 			if got, exp := statedb.GetBalance(aa), uint64(100000); got.Uint64() != exp {
 				t.Fatalf("block %d: got %v exp %v", block.NumberU64(), got, exp)
 			}
@@ -2081,7 +2081,7 @@ func TestEIP1559Transition(t *testing.T) {
 	}
 
 	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
-		statedb := state.New(state.NewPlainState(tx, 1))
+		statedb := state.New(state.NewPlainState(tx, 1, nil))
 
 		// 3: Ensure that miner received only the tx's tip.
 		actual := statedb.GetBalance(block.Coinbase())
@@ -2122,7 +2122,7 @@ func TestEIP1559Transition(t *testing.T) {
 
 	block = chain.Blocks[0]
 	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
-		statedb := state.New(state.NewPlainState(tx, 1))
+		statedb := state.New(state.NewPlainState(tx, 1, nil))
 		effectiveTip := block.Transactions()[0].GetPrice().Uint64() - block.BaseFee().Uint64()
 
 		// 6+5: Ensure that miner received only the tx's effective tip.

--- a/turbo/stages/mock_sentry.go
+++ b/turbo/stages/mock_sentry.go
@@ -657,7 +657,7 @@ func (ms *MockSentry) NewHistoricalStateReader(blockNum uint64, tx kv.Tx) state.
 		return r
 	}
 
-	return state.NewPlainState(tx, blockNum)
+	return state.NewPlainState(tx, blockNum, nil)
 }
 
 func (ms *MockSentry) NewStateReader(tx kv.Tx) state.StateReader {

--- a/turbo/transactions/tracing.go
+++ b/turbo/transactions/tracing.go
@@ -36,7 +36,7 @@ type BlockGetter interface {
 // ComputeTxEnv returns the execution environment of a certain transaction.
 func ComputeTxEnv(ctx context.Context, engine consensus.EngineReader, block *types.Block, cfg *params.ChainConfig, headerReader services.HeaderReader, dbtx kv.Tx, txIndex uint64, agg *state2.Aggregator22, historyV3 bool) (core.Message, evmtypes.BlockContext, evmtypes.TxContext, *state.IntraBlockState, state.StateReader, error) {
 	header := block.HeaderNoCopy()
-	reader, err := rpchelper.CreateHistoryStateReader(dbtx, block.NumberU64(), txIndex, agg, historyV3)
+	reader, err := rpchelper.CreateHistoryStateReader(dbtx, block.NumberU64(), txIndex, agg, historyV3, cfg.ChainName)
 	if err != nil {
 		return nil, evmtypes.BlockContext{}, evmtypes.TxContext{}, nil, nil, err
 	}


### PR DESCRIPTION
Works around a flaw in the upgrade logic of the system contracts. Since they are updated directly, without first being self-destructed and then re-created, the usual incarnation logic does not get activated, and all historical records of the code of these contracts are retrieved as the most recent version. This problem will not exist in erigon3, but until then, a workaround will be used to access code of such contracts through a special structure, `SystemContractCodeLookup`

Fixes https://github.com/ledgerwatch/erigon/issues/5865