### PR TITLE
Fix eth_getTransactionByHash for Bor Transactions

### DIFF
--- a/cmd/rpcdaemon/commands/eth_txs.go
+++ b/cmd/rpcdaemon/commands/eth_txs.go
@@ -34,6 +34,17 @@ func (api *APIImpl) GetTransactionByHash(ctx context.Context, txnHash common.Has
 	if err != nil {
 		return nil, err
 	}
+	// Private API returns 0 if transaction is not found.
+	if blockNum == 0 && chainConfig.Bor != nil {
+		blockNumPtr, err := rawdb.ReadBorTxLookupEntry(tx, txnHash)
+		if err != nil {
+			return nil, err
+		}
+		if blockNumPtr == nil {
+			return nil, nil
+		}
+		blockNum = *blockNumPtr
+	}
 	if ok {
 		block, err := api.blockByNumberWithSenders(tx, blockNum)
 		if err != nil {


### PR DESCRIPTION
FIrst of all, thanks in advance for your advice.

I've found that `eth_getTransactionByHash` is having trouble retrieving some Polygon State Sync transactions such as [`0xd5f4f8c3cd85cf65e8df23a2c1ae02aefda1e6293db0c3a9ddcc08cee8ca1131`](https://polygonscan.com/tx/0xd5f4f8c3cd85cf65e8df23a2c1ae02aefda1e6293db0c3a9ddcc08cee8ca1131), while `eth_getBlockByNumber` can retrieve them without problem.

```shell
$ curl -XPOST 'http://localhost:8545' \
     -H 'Content-Type: application/json' \
     --data '{"method":"eth_getTransactionByHash","params":["0xd5f4f8c3cd85cf65e8df23a2c1ae02aefda1e6293db0c3a9ddcc08cee8ca1131"],"id":1,"jsonrpc":"2.0"}'
{"jsonrpc":"2.0","id":1,"result":null}
```

This is because RPCDaemon doesn't query for blocks by Bor Hash, even though `api.txnLookup` has failed.