### PR TITLE
Fix Trace RPCs for Bor Transactions

### DIFF
--- a/cmd/rpcdaemon/commands/trace_adhoc.go
+++ b/cmd/rpcdaemon/commands/trace_adhoc.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ledgerwatch/erigon/common/hexutil"
 	math2 "github.com/ledgerwatch/erigon/common/math"
 	"github.com/ledgerwatch/erigon/core"
+	"github.com/ledgerwatch/erigon/core/rawdb"
 	"github.com/ledgerwatch/erigon/core/state"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/core/types/accounts"
@@ -728,6 +729,17 @@ func (api *TraceAPIImpl) ReplayTransaction(ctx context.Context, txHash common.Ha
 	}
 	if !ok {
 		return nil, nil
+	}
+	// Private API returns 0 if transaction is not found.
+	if blockNum == 0 && chainConfig.Bor != nil {
+		blockNumPtr, err := rawdb.ReadBorTxLookupEntry(tx, txHash)
+		if err != nil {
+			return nil, err
+		}
+		if blockNumPtr == nil {
+			return nil, nil
+		}
+		blockNum = *blockNumPtr
 	}
 	block, err := api.blockByNumberWithSenders(tx, blockNum)
 	if err != nil {

--- a/cmd/rpcdaemon/commands/trace_filtering.go
+++ b/cmd/rpcdaemon/commands/trace_filtering.go
@@ -45,6 +45,17 @@ func (api *TraceAPIImpl) Transaction(ctx context.Context, txHash common.Hash) (P
 	if !ok {
 		return nil, nil
 	}
+	// Private API returns 0 if transaction is not found.
+	if blockNumber == 0 && chainConfig.Bor != nil {
+		blockNumPtr, err := rawdb.ReadBorTxLookupEntry(tx, txHash)
+		if err != nil {
+			return nil, err
+		}
+		if blockNumPtr == nil {
+			return nil, nil
+		}
+		blockNumber = *blockNumPtr
+	}
 	block, err := api.blockByNumberWithSenders(tx, blockNumber)
 	if err != nil {
 		return nil, err

--- a/cmd/rpcdaemon/commands/tracing.go
+++ b/cmd/rpcdaemon/commands/tracing.go
@@ -137,6 +137,11 @@ func (api *PrivateDebugAPIImpl) TraceTransaction(ctx context.Context, hash commo
 		return err
 	}
 	defer tx.Rollback()
+	chainConfig, err := api.chainConfig(tx)
+	if err != nil {
+		stream.WriteNil()
+		return err
+	}
 	// Retrieve the transaction and assemble its EVM context
 	blockNum, ok, err := api.txnLookup(ctx, tx, hash)
 	if err != nil {
@@ -146,6 +151,19 @@ func (api *PrivateDebugAPIImpl) TraceTransaction(ctx context.Context, hash commo
 	if !ok {
 		stream.WriteNil()
 		return nil
+	}
+	// Private API returns 0 if transaction is not found.
+	if blockNum == 0 && chainConfig.Bor != nil {
+		blockNumPtr, err := rawdb.ReadBorTxLookupEntry(tx, hash)
+		if err != nil {
+			stream.WriteNil()
+			return err
+		}
+		if blockNumPtr == nil {
+			stream.WriteNil()
+			return nil
+		}
+		blockNum = *blockNumPtr
 	}
 	block, err := api.blockByNumberWithSenders(tx, blockNum)
 	if err != nil {
@@ -179,11 +197,6 @@ func (api *PrivateDebugAPIImpl) TraceTransaction(ctx context.Context, hash commo
 		}
 		stream.WriteNil()
 		return fmt.Errorf("transaction %#x not found", hash)
-	}
-	chainConfig, err := api.chainConfig(tx)
-	if err != nil {
-		stream.WriteNil()
-		return err
 	}
 	engine := api.engine()
 


### PR DESCRIPTION
FIrst of all, thanks in advance for your advice.

I've found that `trace_replayTransaction` is having trouble tracing some Polygon State Sync transactions such as [`0xd5f4f8c3cd85cf65e8df23a2c1ae02aefda1e6293db0c3a9ddcc08cee8ca1131`](https://polygonscan.com/tx/0xd5f4f8c3cd85cf65e8df23a2c1ae02aefda1e6293db0c3a9ddcc08cee8ca1131), just like [the case of the previous PR][p].

[p]: https://github.com/ledgerwatch/erigon/pull/6286

```shell
$ curl -XPOST 'http://localhost:8545' \
      -H 'Content-Type: application/json' \
     --data '{"method":"trace_replayTransaction","params":["0xd5f4f8c3cd85cf65e8df23a2c1ae02aefda1e6293db0c3a9ddcc08cee8ca1131",["trace","stateDiff"]],"id":1,"jsonrpc":"2.0"}'
{"jsonrpc":"2.0","id":1,"result":null}
```

This is because RPCDaemon doesn't query for blocks by Bor Hash, even though `api.txnLookup` has failed. Same as #6286.