### PR TITLE
Fix eth_getTransactionReceipt for Bor Transactions

### DIFF
--- a/cmd/rpcdaemon/commands/eth_receipts.go
+++ b/cmd/rpcdaemon/commands/eth_receipts.go
@@ -501,8 +501,9 @@ func (api *APIImpl) GetTransactionReceipt(ctx context.Context, txnHash common.Ha
 		return nil, nil
 	}
 
-	// if not ok and cc.Bor != nil then we might have a bor transaction
-	if !ok {
+	// if not ok and cc.Bor != nil then we might have a bor transaction.
+	// Note that Private API returns 0 if transaction is not found.
+	if !ok || blockNum == 0 {
 		blockNumPtr, err := rawdb.ReadBorTxLookupEntry(tx, txnHash)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Same as #6286 and #6288

This patch closes #6276 

```shell
$ curl -XPOST 'http://localhost:8545' \
     -H 'Content-Type: application/json' \
     --data '{"method":"eth_getTransactionReceipt","params":["0x31ce15ce9a1ff347f4204a1ed3625861165c53ae08743c1f36a32865c62744c6"],"id":1,"jsonrpc":"2.0"}'
{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"block has less receipts than expected: 0 \u003c= 0, block: 36635776"}}
```

cc. @0xKrishna 