### PR TITLE
Disable ipv6 flag

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -655,6 +655,17 @@ var (
 		Name:  "downloader.verify",
 		Usage: "verify snapshots on startup. it will not report founded problems but just re-download broken pieces",
 	}
+	DisableIPV6 = cli.BoolFlag{
+		Name:  "downloader.disable.ipv6",
+		Usage: "Turns off ipv6 for the downlaoder",
+		Value: false,
+	}
+
+	DisableIPV4 = cli.BoolFlag{
+		Name:  "downloader.disable.ipv4",
+		Usage: "Turn off ipv4 for the downloader",
+		Value: false,
+	}
 	TorrentPortFlag = cli.IntFlag{
 		Name:  "torrent.port",
 		Value: 42069,
@@ -722,12 +733,6 @@ var (
 		Name:  "sentinel.port",
 		Usage: "Port for sentinel",
 		Value: 7777,
-	}
-
-	DisableIPV6 = cli.BoolFlag{
-		Name:  "disable.ipv6",
-		Usage: "Turns off ipv6",
-		Value: false,
 	}
 )
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -723,6 +723,12 @@ var (
 		Usage: "Port for sentinel",
 		Value: 7777,
 	}
+
+	DisableIPV6 = cli.BoolFlag{
+		Name:  "disable.ipv6",
+		Usage: "Turns off ipv6",
+		Value: false,
+	}
 )
 
 var MetricFlags = []cli.Flag{&MetricsEnabledFlag, &MetricsHTTPFlag, &MetricsPortFlag}

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -132,6 +132,8 @@ var DefaultFlags = []cli.Flag{
 	&utils.SentryAddrFlag,
 	&utils.SentryLogPeerInfoFlag,
 	&utils.DownloaderAddrFlag,
+	&utils.DisableIPV4,
+	&utils.DisableIPV6,
 	&utils.NoDownloaderFlag,
 	&utils.DownloaderVerifyFlag,
 	&HealthCheckFlag,
@@ -154,5 +156,4 @@ var DefaultFlags = []cli.Flag{
 	&utils.LightClientDiscoveryTCPPortFlag,
 	&utils.SentinelAddrFlag,
 	&utils.SentinelPortFlag,
-	&utils.DisableIPV6,
 }

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -154,4 +154,5 @@ var DefaultFlags = []cli.Flag{
 	&utils.LightClientDiscoveryTCPPortFlag,
 	&utils.SentinelAddrFlag,
 	&utils.SentinelPortFlag,
+	&utils.DisableIPV6,
 }

--- a/turbo/cli/flags.go
+++ b/turbo/cli/flags.go
@@ -250,6 +250,9 @@ func ApplyFlagsForEthConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		}
 	}
 
+	if ctx.Bool(utils.DisableIPV6.Name) {
+		cfg.Downloader.ClientConfig.DisableIPv6 = true
+	}
 }
 
 func ApplyFlagsForEthConfigCobra(f *pflag.FlagSet, cfg *ethconfig.Config) {

--- a/turbo/cli/flags.go
+++ b/turbo/cli/flags.go
@@ -250,13 +250,17 @@ func ApplyFlagsForEthConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		}
 	}
 
+	disableIPV6 := ctx.Bool(utils.DisableIPV6.Name)
+	disableIPV4 := ctx.Bool(utils.DisableIPV4.Name)
+	downloadRate := ctx.String(utils.TorrentDownloadRateFlag.Name)
+	uploadRate := ctx.String(utils.TorrentUploadRateFlag.Name)
+
+	log.Info("[Downloader] Runnning with", "ipv6-enabled", !disableIPV6, "ipv4-enabled", !disableIPV4, "download.rate", downloadRate, "upload.rate", uploadRate)
 	if ctx.Bool(utils.DisableIPV6.Name) {
-		log.Info("Downloader Disabled IPV6")
 		cfg.Downloader.ClientConfig.DisableIPv6 = true
 	}
 
 	if ctx.Bool(utils.DisableIPV4.Name) {
-		log.Info("Downloader Disabled IPV4")
 		cfg.Downloader.ClientConfig.DisableIPv4 = true
 	}
 }

--- a/turbo/cli/flags.go
+++ b/turbo/cli/flags.go
@@ -257,7 +257,7 @@ func ApplyFlagsForEthConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 
 	if ctx.Bool(utils.DisableIPV4.Name) {
 		log.Info("Downloader Disabled IPV4")
-		cfg.Downloader.ClientConfig.DisableIPv4 = false
+		cfg.Downloader.ClientConfig.DisableIPv4 = true
 	}
 }
 

--- a/turbo/cli/flags.go
+++ b/turbo/cli/flags.go
@@ -251,6 +251,7 @@ func ApplyFlagsForEthConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 	}
 
 	if ctx.Bool(utils.DisableIPV6.Name) {
+		log.Info("Disabled IPV6")
 		cfg.Downloader.ClientConfig.DisableIPv6 = true
 	}
 }

--- a/turbo/cli/flags.go
+++ b/turbo/cli/flags.go
@@ -251,8 +251,13 @@ func ApplyFlagsForEthConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 	}
 
 	if ctx.Bool(utils.DisableIPV6.Name) {
-		log.Info("Disabled IPV6")
+		log.Info("Downloader Disabled IPV6")
 		cfg.Downloader.ClientConfig.DisableIPv6 = true
+	}
+
+	if ctx.Bool(utils.DisableIPV4.Name) {
+		log.Info("Downloader Disabled IPV4")
+		cfg.Downloader.ClientConfig.DisableIPv4 = false
 	}
 }
 


### PR DESCRIPTION
This was a great idea #6261 
Added two new flags to turn off downloader ipv6 and/or ipv4 usage