### PR TITLE
add missed break clause during protocols port picking

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -336,6 +336,7 @@ func New(stack *node.Node, config *ethconfig.Config, logger log.Logger) (*Ethere
 				}
 				pi++
 				picked = true
+				break
 			}
 			if !picked {
 				return nil, fmt.Errorf("run out of allowed ports for p2p eth protocols %v. Extend allowed port list via --p2p.allowed-ports", cfg.AllowedPorts)


### PR DESCRIPTION
Missing break clause leaded to unnecessary incrementing of `pi` when port is already picked.
