### PR TITLE
Native tracers - step 2

### DIFF
--- a/cmd/rpcdaemon/commands/otterscan_default_tracer.go
+++ b/cmd/rpcdaemon/commands/otterscan_default_tracer.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"math/big"
 	"time"
 
 	"github.com/holiman/uint256"
@@ -19,7 +18,10 @@ func (t *DefaultTracer) CaptureTxStart(gasLimit uint64) {}
 
 func (t *DefaultTracer) CaptureTxEnd(restGas uint64) {}
 
-func (t *DefaultTracer) CaptureStart(env *vm.EVM, depth int, from common.Address, to common.Address, precompile bool, create bool, calltype vm.CallType, input []byte, gas uint64, value *big.Int, code []byte) {
+func (t *DefaultTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, calltype vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+}
+
+func (t *DefaultTracer) CaptureEnter(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, calltype vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
 }
 
 func (t *DefaultTracer) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
@@ -28,7 +30,10 @@ func (t *DefaultTracer) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, gas, 
 func (t *DefaultTracer) CaptureFault(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
 }
 
-func (t *DefaultTracer) CaptureEnd(depth int, output []byte, startGas, endGas uint64, d time.Duration, err error) {
+func (t *DefaultTracer) CaptureEnd(output []byte, startGas, endGas uint64, d time.Duration, err error) {
+}
+
+func (t *DefaultTracer) CaptureExit(output []byte, startGas, endGas uint64, d time.Duration, err error) {
 }
 
 func (t *DefaultTracer) CaptureSelfDestruct(from common.Address, to common.Address, value *uint256.Int) {

--- a/cmd/rpcdaemon/commands/otterscan_trace_contract_creator.go
+++ b/cmd/rpcdaemon/commands/otterscan_trace_contract_creator.go
@@ -34,7 +34,7 @@ func (t *CreateTracer) Found() bool {
 	return t.found
 }
 
-func (t *CreateTracer) CaptureStart(env *vm.EVM, depth int, from common.Address, to common.Address, precompile bool, create bool, calltype vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (t *CreateTracer) captureStartOrEnter(from, to common.Address, create bool) {
 	if t.found {
 		return
 	}
@@ -47,4 +47,12 @@ func (t *CreateTracer) CaptureStart(env *vm.EVM, depth int, from common.Address,
 
 	t.found = true
 	t.Creator = from
+}
+
+func (t *CreateTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, calltype vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+	t.captureStartOrEnter(from, to, create)
+}
+
+func (t *CreateTracer) CaptureEnter(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, calltype vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+	t.captureStartOrEnter(from, to, create)
 }

--- a/cmd/rpcdaemon/commands/otterscan_trace_operations.go
+++ b/cmd/rpcdaemon/commands/otterscan_trace_operations.go
@@ -38,11 +38,7 @@ func NewOperationsTracer(ctx context.Context) *OperationsTracer {
 	}
 }
 
-func (t *OperationsTracer) CaptureStart(env *vm.EVM, depth int, from common.Address, to common.Address, precompile bool, create bool, calltype vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
-	if depth == 0 {
-		return
-	}
-
+func (t *OperationsTracer) CaptureEnter(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, calltype vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	if calltype == vm.CALLT && value.Uint64() != 0 {
 		t.Results = append(t.Results, &InternalOperation{OP_TRANSFER, from, to, (*hexutil.Big)(value.ToBig())})
 		return

--- a/cmd/rpcdaemon/commands/otterscan_trace_touch.go
+++ b/cmd/rpcdaemon/commands/otterscan_trace_touch.go
@@ -20,8 +20,16 @@ func NewTouchTracer(searchAddr common.Address) *TouchTracer {
 	}
 }
 
-func (t *TouchTracer) CaptureStart(env *vm.EVM, depth int, from common.Address, to common.Address, precompile bool, create bool, calltype vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (t *TouchTracer) captureStartOrEnter(from, to common.Address) {
 	if !t.Found && (bytes.Equal(t.searchAddr.Bytes(), from.Bytes()) || bytes.Equal(t.searchAddr.Bytes(), to.Bytes())) {
 		t.Found = true
 	}
+}
+
+func (t *TouchTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, calltype vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+	t.captureStartOrEnter(from, to)
+}
+
+func (t *TouchTracer) CaptureEnter(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, calltype vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+	t.captureStartOrEnter(from, to)
 }

--- a/cmd/rpcdaemon/commands/otterscan_trace_transaction.go
+++ b/cmd/rpcdaemon/commands/otterscan_trace_transaction.go
@@ -39,7 +39,7 @@ type TransactionTracer struct {
 	DefaultTracer
 	ctx     context.Context
 	Results []*TraceEntry
-	depth   int // computer from CaptureStart, CaptureEnter, and CaptureExit calls
+	depth   int // computed from CaptureStart, CaptureEnter, and CaptureExit calls
 }
 
 func NewTransactionTracer(ctx context.Context) *TransactionTracer {

--- a/cmd/rpcdaemon/commands/otterscan_trace_transaction.go
+++ b/cmd/rpcdaemon/commands/otterscan_trace_transaction.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"math/big"
+	"time"
 
 	"github.com/holiman/uint256"
 	"github.com/ledgerwatch/erigon/common"
@@ -38,6 +39,7 @@ type TransactionTracer struct {
 	DefaultTracer
 	ctx     context.Context
 	Results []*TraceEntry
+	depth   int // computer from CaptureStart, CaptureEnter, and CaptureExit calls
 }
 
 func NewTransactionTracer(ctx context.Context) *TransactionTracer {
@@ -47,7 +49,7 @@ func NewTransactionTracer(ctx context.Context) *TransactionTracer {
 	}
 }
 
-func (t *TransactionTracer) CaptureStart(env *vm.EVM, depth int, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (t *TransactionTracer) captureStartOrEnter(from, to common.Address, precompile bool, callType vm.CallType, input []byte, value *uint256.Int) {
 	if precompile {
 		return
 	}
@@ -57,29 +59,43 @@ func (t *TransactionTracer) CaptureStart(env *vm.EVM, depth int, from common.Add
 	_value := new(big.Int)
 	_value.Set(value.ToBig())
 	if callType == vm.CALLT {
-		t.Results = append(t.Results, &TraceEntry{"CALL", depth, from, to, (*hexutil.Big)(_value), inputCopy})
+		t.Results = append(t.Results, &TraceEntry{"CALL", t.depth, from, to, (*hexutil.Big)(_value), inputCopy})
 		return
 	}
 	if callType == vm.STATICCALLT {
-		t.Results = append(t.Results, &TraceEntry{"STATICCALL", depth, from, to, nil, inputCopy})
+		t.Results = append(t.Results, &TraceEntry{"STATICCALL", t.depth, from, to, nil, inputCopy})
 		return
 	}
 	if callType == vm.DELEGATECALLT {
-		t.Results = append(t.Results, &TraceEntry{"DELEGATECALL", depth, from, to, nil, inputCopy})
+		t.Results = append(t.Results, &TraceEntry{"DELEGATECALL", t.depth, from, to, nil, inputCopy})
 		return
 	}
 	if callType == vm.CALLCODET {
-		t.Results = append(t.Results, &TraceEntry{"CALLCODE", depth, from, to, (*hexutil.Big)(_value), inputCopy})
+		t.Results = append(t.Results, &TraceEntry{"CALLCODE", t.depth, from, to, (*hexutil.Big)(_value), inputCopy})
 		return
 	}
 	if callType == vm.CREATET {
-		t.Results = append(t.Results, &TraceEntry{"CREATE", depth, from, to, (*hexutil.Big)(value.ToBig()), inputCopy})
+		t.Results = append(t.Results, &TraceEntry{"CREATE", t.depth, from, to, (*hexutil.Big)(value.ToBig()), inputCopy})
 		return
 	}
 	if callType == vm.CREATE2T {
-		t.Results = append(t.Results, &TraceEntry{"CREATE2", depth, from, to, (*hexutil.Big)(value.ToBig()), inputCopy})
+		t.Results = append(t.Results, &TraceEntry{"CREATE2", t.depth, from, to, (*hexutil.Big)(value.ToBig()), inputCopy})
 		return
 	}
+}
+
+func (t *TransactionTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+	t.depth = 0
+	t.captureStartOrEnter(from, to, precompile, callType, input, value)
+}
+
+func (t *TransactionTracer) CaptureEnter(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+	t.depth++
+	t.captureStartOrEnter(from, to, precompile, callType, input, value)
+}
+
+func (t *TransactionTracer) CaptureExit(output []byte, startGas, endGas uint64, d time.Duration, err error) {
+	t.depth--
 }
 
 func (l *TransactionTracer) CaptureSelfDestruct(from common.Address, to common.Address, value *uint256.Int) {

--- a/cmd/rpcdaemon/commands/trace_adhoc.go
+++ b/cmd/rpcdaemon/commands/trace_adhoc.go
@@ -239,11 +239,11 @@ func (ot *OeTracer) CaptureTxStart(gasLimit uint64) {}
 
 func (ot *OeTracer) CaptureTxEnd(restGas uint64) {}
 
-func (ot *OeTracer) CaptureStart(env *vm.EVM, depth int, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (ot *OeTracer) captureStartOrEnter(deep bool, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	//fmt.Printf("CaptureStart depth %d, from %x, to %x, create %t, input %x, gas %d, value %d, precompile %t\n", depth, from, to, create, input, gas, value, precompile)
 	if ot.r.VmTrace != nil {
 		var vmTrace *VmTrace
-		if depth > 0 {
+		if deep {
 			var vmT *VmTrace
 			if len(ot.vmOpStack) > 0 {
 				vmT = ot.vmOpStack[len(ot.vmOpStack)-1].Sub
@@ -270,7 +270,7 @@ func (ot *OeTracer) CaptureStart(env *vm.EVM, depth int, from common.Address, to
 			vmTrace.Code = code
 		}
 	}
-	if precompile && depth > 0 && (value == nil || value.IsZero()) {
+	if precompile && deep && (value == nil || value.IsZero()) {
 		ot.precompile = true
 		return
 	}
@@ -288,7 +288,7 @@ func (ot *OeTracer) CaptureStart(env *vm.EVM, depth int, from common.Address, to
 		trace.Result = &TraceResult{}
 		trace.Type = CALL
 	}
-	if depth > 0 {
+	if deep {
 		topTrace := ot.traceStack[len(ot.traceStack)-1]
 		traceIdx := topTrace.Subtraces
 		ot.traceAddr = append(ot.traceAddr, traceIdx)
@@ -337,16 +337,24 @@ func (ot *OeTracer) CaptureStart(env *vm.EVM, depth int, from common.Address, to
 	ot.traceStack = append(ot.traceStack, trace)
 }
 
-func (ot *OeTracer) CaptureEnd(depth int, output []byte, startGas, endGas uint64, t time.Duration, err error) {
+func (ot *OeTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+	ot.captureStartOrEnter(false /* deep */, from, to, precompile, create, callType, input, gas, value, code)
+}
+
+func (ot *OeTracer) CaptureEnter(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+	ot.captureStartOrEnter(true /* deep */, from, to, precompile, create, callType, input, gas, value, code)
+}
+
+func (ot *OeTracer) captureEndOrExit(deep bool, output []byte, startGas, endGas uint64, t time.Duration, err error) {
 	if ot.r.VmTrace != nil {
 		if len(ot.vmOpStack) > 0 {
 			ot.lastOffStack = ot.vmOpStack[len(ot.vmOpStack)-1]
 			ot.vmOpStack = ot.vmOpStack[:len(ot.vmOpStack)-1]
 		}
-		if !ot.compat && depth > 0 {
+		if !ot.compat && deep {
 			ot.idx = ot.idx[:len(ot.idx)-1]
 		}
-		if depth > 0 {
+		if deep {
 			ot.lastMemOff = ot.memOffStack[len(ot.memOffStack)-1]
 			ot.memOffStack = ot.memOffStack[:len(ot.memOffStack)-1]
 			ot.lastMemLen = ot.memLenStack[len(ot.memLenStack)-1]
@@ -357,13 +365,13 @@ func (ot *OeTracer) CaptureEnd(depth int, output []byte, startGas, endGas uint64
 		ot.precompile = false
 		return
 	}
-	if depth == 0 {
+	if !deep {
 		ot.r.Output = common.CopyBytes(output)
 	}
 	ignoreError := false
 	topTrace := ot.traceStack[len(ot.traceStack)-1]
 	if ot.compat {
-		ignoreError = depth == 0 && topTrace.Type == CREATE
+		ignoreError = !deep && topTrace.Type == CREATE
 	}
 	if err != nil && !ignoreError {
 		if err == vm.ErrExecutionReverted {
@@ -417,9 +425,17 @@ func (ot *OeTracer) CaptureEnd(depth int, output []byte, startGas, endGas uint64
 		}
 	}
 	ot.traceStack = ot.traceStack[:len(ot.traceStack)-1]
-	if depth > 0 {
+	if deep {
 		ot.traceAddr = ot.traceAddr[:len(ot.traceAddr)-1]
 	}
+}
+
+func (ot *OeTracer) CaptureEnd(output []byte, startGas, endGas uint64, t time.Duration, err error) {
+	ot.captureEndOrExit(false /* deep */, output, startGas, endGas, t, err)
+}
+
+func (ot *OeTracer) CaptureExit(output []byte, startGas, endGas uint64, t time.Duration, err error) {
+	ot.captureEndOrExit(true /* deep */, output, startGas, endGas, t, err)
 }
 
 func (ot *OeTracer) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, opDepth int, err error) {

--- a/cmd/state/commands/opcode_tracer.go
+++ b/cmd/state/commands/opcode_tracer.go
@@ -108,6 +108,7 @@ type opcodeTracer struct {
 	saveOpcodes bool
 	saveBblocks bool
 	blockNumber uint64
+	depth       int
 }
 
 func NewOpcodeTracer(blockNum uint64, saveOpcodes bool, saveBblocks bool) *opcodeTracer {
@@ -160,44 +161,54 @@ func (ot *opcodeTracer) CaptureTxStart(gasLimit uint64) {}
 
 func (ot *opcodeTracer) CaptureTxEnd(restGas uint64) {}
 
-func (ot *opcodeTracer) CaptureStart(env *vm.EVM, depth int, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (ot *opcodeTracer) captureStartOrEnter(from, to common.Address, create bool, input []byte) {
 	//fmt.Fprint(ot.summary, ot.lastLine)
 
 	// When a CaptureStart is called, a Tx is starting. Create its entry in our list and initialize it with the partial data available
 	//calculate the "address" of the Tx in its tree
 	ltid := len(ot.txsInDepth)
-	if ltid-1 != depth {
-		panic(fmt.Sprintf("Wrong addr slice depth: d=%d, slice len=%d", depth, ltid))
+	if ltid-1 != ot.depth {
+		panic(fmt.Sprintf("Wrong addr slice depth: d=%d, slice len=%d", ot.depth, ltid))
 	}
 
-	ot.txsInDepth[depth]++
+	ot.txsInDepth[ot.depth]++
 	ot.txsInDepth = append(ot.txsInDepth, 0)
 
 	ls := len(ot.stack)
 	txAddr := ""
 	if ls > 0 {
-		txAddr = ot.stack[ls-1].TxAddr + "-" + strconv.Itoa(int(ot.txsInDepth[depth])) // fmt.Sprintf("%s-%d", ot.stack[ls-1].TxAddr, ot.txsInDepth[depth])
+		txAddr = ot.stack[ls-1].TxAddr + "-" + strconv.Itoa(int(ot.txsInDepth[ot.depth])) // fmt.Sprintf("%s-%d", ot.stack[ls-1].TxAddr, ot.txsInDepth[depth])
 	} else {
-		txAddr = strconv.Itoa(int(ot.txsInDepth[depth]))
+		txAddr = strconv.Itoa(int(ot.txsInDepth[ot.depth]))
 	}
 
-	newTx := tx{From: from, To: to, Create: create, Input: input, Depth: depth, TxAddr: txAddr, lastOp: 0xfe, lastPc16: MaxUint16}
+	newTx := tx{From: from, To: to, Create: create, Input: input, Depth: ot.depth, TxAddr: txAddr, lastOp: 0xfe, lastPc16: MaxUint16}
 	ot.Txs = append(ot.Txs, &newTx)
 
 	// take note in our own stack that the tx stack has grown
 	ot.stack = append(ot.stack, &newTx)
 }
 
-func (ot *opcodeTracer) CaptureEnd(depth int, output []byte, startGas, endGas uint64, t time.Duration, err error) {
+func (ot *opcodeTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+	ot.depth = 0
+	ot.captureStartOrEnter(from, to, create, input)
+}
+
+func (ot *opcodeTracer) CaptureEnter(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+	ot.depth++
+	ot.captureStartOrEnter(from, to, create, input)
+}
+
+func (ot *opcodeTracer) captureEndOrExit(err error) {
 	// When a CaptureEnd is called, a Tx has finished. Pop our stack
 	ls := len(ot.stack)
 	currentEntry := ot.stack[ls-1]
 	ot.stack = ot.stack[:ls-1]
-	ot.txsInDepth = ot.txsInDepth[:depth+1]
+	ot.txsInDepth = ot.txsInDepth[:ot.depth+1]
 
 	// sanity check: depth of stack == depth reported by system
-	if ls-1 != depth || depth != currentEntry.Depth {
-		panic(fmt.Sprintf("End of Tx at d=%d but stack has d=%d and entry has d=%d", depth, ls, currentEntry.Depth))
+	if ls-1 != ot.depth || ot.depth != currentEntry.Depth {
+		panic(fmt.Sprintf("End of Tx at d=%d but stack has d=%d and entry has d=%d", ot.depth, ls, currentEntry.Depth))
 	}
 
 	// Close the last bblock
@@ -218,7 +229,15 @@ func (ot *opcodeTracer) CaptureEnd(depth int, output []byte, startGas, endGas ui
 		errstr = err.Error()
 		currentEntry.Fault = errstr
 	}
+}
 
+func (ot *opcodeTracer) CaptureEnd(output []byte, startGas, endGas uint64, t time.Duration, err error) {
+	ot.captureEndOrExit(err)
+}
+
+func (ot *opcodeTracer) CaptureExit(output []byte, startGas, endGas uint64, t time.Duration, err error) {
+	ot.captureEndOrExit(err)
+	ot.depth--
 }
 
 func (ot *opcodeTracer) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, opDepth int, err error) {

--- a/cmd/state/exec3/calltracer22.go
+++ b/cmd/state/exec3/calltracer22.go
@@ -24,7 +24,11 @@ func (ct *CallTracer) Tos() map[common.Address]struct{}   { return ct.tos }
 
 func (ct *CallTracer) CaptureTxStart(gasLimit uint64) {}
 func (ct *CallTracer) CaptureTxEnd(restGas uint64)    {}
-func (ct *CallTracer) CaptureStart(env *vm.EVM, depth int, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (ct *CallTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+	ct.froms[from] = struct{}{}
+	ct.tos[to] = struct{}{}
+}
+func (ct *CallTracer) CaptureEnter(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	ct.froms[from] = struct{}{}
 	ct.tos[to] = struct{}{}
 }
@@ -32,7 +36,9 @@ func (ct *CallTracer) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, gas, co
 }
 func (ct *CallTracer) CaptureFault(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
 }
-func (ct *CallTracer) CaptureEnd(depth int, output []byte, startGas, endGas uint64, t time.Duration, err error) {
+func (ct *CallTracer) CaptureEnd(output []byte, startGas, endGas uint64, t time.Duration, err error) {
+}
+func (ct *CallTracer) CaptureExit(output []byte, startGas, endGas uint64, t time.Duration, err error) {
 }
 func (ct *CallTracer) CaptureSelfDestruct(from common.Address, to common.Address, value *uint256.Int) {
 	ct.froms[from] = struct{}{}

--- a/cmd/state/exec3/calltracer22.go
+++ b/cmd/state/exec3/calltracer22.go
@@ -24,13 +24,15 @@ func (ct *CallTracer) Tos() map[common.Address]struct{}   { return ct.tos }
 
 func (ct *CallTracer) CaptureTxStart(gasLimit uint64) {}
 func (ct *CallTracer) CaptureTxEnd(restGas uint64)    {}
-func (ct *CallTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (ct *CallTracer) captureStartOrEnter(from, to common.Address) {
 	ct.froms[from] = struct{}{}
 	ct.tos[to] = struct{}{}
 }
+func (ct *CallTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+	ct.captureStartOrEnter(from, to)
+}
 func (ct *CallTracer) CaptureEnter(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
-	ct.froms[from] = struct{}{}
-	ct.tos[to] = struct{}{}
+	ct.captureStartOrEnter(from, to)
 }
 func (ct *CallTracer) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
 }

--- a/core/vm/access_list_tracer.go
+++ b/core/vm/access_list_tracer.go
@@ -171,11 +171,18 @@ func (a *AccessListTracer) CaptureState(env *EVM, pc uint64, op OpCode, gas, cos
 func (*AccessListTracer) CaptureFault(env *EVM, pc uint64, op OpCode, gas, cost uint64, scope *ScopeContext, depth int, err error) {
 }
 
-func (*AccessListTracer) CaptureEnd(depth int, output []byte, startGas, endGas uint64, t time.Duration, err error) {
+func (*AccessListTracer) CaptureEnd(output []byte, startGas, endGas uint64, t time.Duration, err error) {
 }
 
-func (a *AccessListTracer) CaptureStart(env *EVM, depth int, from common.Address, to common.Address, precompile bool, create bool, callType CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (a *AccessListTracer) CaptureStart(env *EVM, from common.Address, to common.Address, precompile bool, create bool, callType CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	panic("implement me")
+}
+
+func (a *AccessListTracer) CaptureEnter(env *EVM, from common.Address, to common.Address, precompile bool, create bool, callType CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+	panic("implement me")
+}
+
+func (*AccessListTracer) CaptureExit(output []byte, startGas, endGas uint64, t time.Duration, err error) {
 }
 
 func (a *AccessListTracer) CaptureSelfDestruct(from common.Address, to common.Address, value *uint256.Int) {

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -177,10 +177,17 @@ func (evm *EVM) call(callType CallType, caller ContractRef, addr common.Address,
 	}
 	// Capture the tracer start/end events in debug mode
 	if evm.config.Debug {
-		evm.config.Tracer.CaptureStart(evm, evm.depth, caller.Address(), addr, isPrecompile, false /* create */, callType, input, gas, value, code)
-		defer func(startGas uint64, startTime time.Time) { // Lazy evaluation of the parameters
-			evm.config.Tracer.CaptureEnd(evm.depth, ret, startGas, gas, time.Since(startTime), err)
-		}(gas, time.Now())
+		if evm.depth == 0 {
+			evm.config.Tracer.CaptureStart(evm, caller.Address(), addr, isPrecompile, false /* create */, callType, input, gas, value, code)
+			defer func(startGas uint64, startTime time.Time) { // Lazy evaluation of the parameters
+				evm.config.Tracer.CaptureEnd(ret, startGas, gas, time.Since(startTime), err)
+			}(gas, time.Now())
+		} else {
+			evm.config.Tracer.CaptureEnter(evm, caller.Address(), addr, isPrecompile, false /* create */, callType, input, gas, value, code)
+			defer func(startGas uint64, startTime time.Time) { // Lazy evaluation of the parameters
+				evm.config.Tracer.CaptureExit(ret, startGas, gas, time.Since(startTime), err)
+			}(gas, time.Now())
+		}
 	}
 
 	snapshot := evm.intraBlockState.Snapshot()
@@ -312,10 +319,17 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 		return nil, address, gas, ErrMaxInitCodeSizeExceeded
 	}
 	if evm.config.Debug {
-		evm.config.Tracer.CaptureStart(evm, evm.depth, caller.Address(), address, false /* precompile */, true /* create */, calltype, codeAndHash.code, gas, value, nil)
-		defer func(startGas uint64, startTime time.Time) { // Lazy evaluation of the parameters
-			evm.config.Tracer.CaptureEnd(evm.depth, ret, startGas, gas, time.Since(startTime), err)
-		}(gas, time.Now())
+		if evm.depth == 0 {
+			evm.config.Tracer.CaptureStart(evm, caller.Address(), address, false /* precompile */, true /* create */, calltype, codeAndHash.code, gas, value, nil)
+			defer func(startGas uint64, startTime time.Time) { // Lazy evaluation of the parameters
+				evm.config.Tracer.CaptureEnd(ret, startGas, gas, time.Since(startTime), err)
+			}(gas, time.Now())
+		} else {
+			evm.config.Tracer.CaptureEnter(evm, caller.Address(), address, false /* precompile */, true /* create */, calltype, codeAndHash.code, gas, value, nil)
+			defer func(startGas uint64, startTime time.Time) { // Lazy evaluation of the parameters
+				evm.config.Tracer.CaptureExit(ret, startGas, gas, time.Since(startTime), err)
+			}(gas, time.Now())
+		}
 	}
 	if incrementNonce {
 		nonce := evm.intraBlockState.GetNonce(caller.Address())

--- a/core/vm/logger_json.go
+++ b/core/vm/logger_json.go
@@ -46,7 +46,10 @@ func (l *JSONLogger) CaptureTxStart(gasLimit uint64) {}
 
 func (l *JSONLogger) CaptureTxEnd(restGas uint64) {}
 
-func (l *JSONLogger) CaptureStart(env *EVM, depth int, from common.Address, to common.Address, precompile bool, create bool, callType CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (l *JSONLogger) CaptureStart(env *EVM, from common.Address, to common.Address, precompile bool, create bool, callType CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+}
+
+func (l *JSONLogger) CaptureEnter(env *EVM, from common.Address, to common.Address, precompile bool, create bool, callType CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
 }
 
 // CaptureState outputs state information on the logger.
@@ -84,21 +87,21 @@ func (l *JSONLogger) CaptureFault(env *EVM, pc uint64, op OpCode, gas, cost uint
 }
 
 // CaptureEnd is triggered at end of execution.
-func (l *JSONLogger) CaptureEnd(depth int, output []byte, startGas, endGas uint64, t time.Duration, err error) {
+func (l *JSONLogger) CaptureEnd(output []byte, startGas, endGas uint64, t time.Duration, err error) {
 	type endLog struct {
 		Output  string              `json:"output"`
 		GasUsed math.HexOrDecimal64 `json:"gasUsed"`
 		Time    time.Duration       `json:"time"`
 		Err     string              `json:"error,omitempty"`
 	}
-	if depth != 0 {
-		return
-	}
 	var errMsg string
 	if err != nil {
 		errMsg = err.Error()
 	}
 	_ = l.encoder.Encode(endLog{common.Bytes2Hex(output), math.HexOrDecimal64(startGas - endGas), t, errMsg})
+}
+
+func (l *JSONLogger) CaptureExit(output []byte, startGas, endGas uint64, t time.Duration, err error) {
 }
 
 func (l *JSONLogger) CaptureSelfDestruct(from common.Address, to common.Address, value *uint256.Int) {

--- a/eth/calltracer/calltracer.go
+++ b/eth/calltracer/calltracer.go
@@ -28,7 +28,7 @@ func NewCallTracer() *CallTracer {
 func (ct *CallTracer) CaptureTxStart(gasLimit uint64) {}
 func (ct *CallTracer) CaptureTxEnd(restGas uint64)    {}
 
-func (ct *CallTracer) CaptureStart(env *vm.EVM, depth int, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (ct *CallTracer) captureStartOrEnter(from, to common.Address, create bool, code []byte) {
 	ct.froms[from] = struct{}{}
 
 	created, ok := ct.tos[to]
@@ -42,11 +42,20 @@ func (ct *CallTracer) CaptureStart(env *vm.EVM, depth int, from common.Address, 
 		}
 	}
 }
+
+func (ct *CallTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+	ct.captureStartOrEnter(from, to, create, code)
+}
+func (ct *CallTracer) CaptureEnter(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+	ct.captureStartOrEnter(from, to, create, code)
+}
 func (ct *CallTracer) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
 }
 func (ct *CallTracer) CaptureFault(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
 }
-func (ct *CallTracer) CaptureEnd(depth int, output []byte, startGas, endGas uint64, t time.Duration, err error) {
+func (ct *CallTracer) CaptureEnd(output []byte, startGas, endGas uint64, t time.Duration, err error) {
+}
+func (ct *CallTracer) CaptureExit(output []byte, startGas, endGas uint64, t time.Duration, err error) {
 }
 func (ct *CallTracer) CaptureSelfDestruct(from common.Address, to common.Address, value *uint256.Int) {
 	ct.froms[from] = struct{}{}

--- a/eth/tracers/logger/access_list_tracer.go
+++ b/eth/tracers/logger/access_list_tracer.go
@@ -142,7 +142,10 @@ func (a *AccessListTracer) CaptureTxStart(gasLimit uint64) {}
 
 func (a *AccessListTracer) CaptureTxEnd(restGas uint64) {}
 
-func (a *AccessListTracer) CaptureStart(env *vm.EVM, depth int, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (a *AccessListTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+}
+
+func (a *AccessListTracer) CaptureEnter(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
 }
 
 // CaptureState captures all opcodes that touch storage or addresses and adds them to the accesslist.
@@ -172,7 +175,9 @@ func (a *AccessListTracer) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, ga
 
 func (*AccessListTracer) CaptureFault(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
 }
-func (*AccessListTracer) CaptureEnd(depth int, output []byte, startGas, endGas uint64, t time.Duration, err error) {
+func (*AccessListTracer) CaptureEnd(output []byte, startGas, endGas uint64, t time.Duration, err error) {
+}
+func (*AccessListTracer) CaptureExit(output []byte, startGas, endGas uint64, t time.Duration, err error) {
 }
 func (*AccessListTracer) CaptureSelfDestruct(from common.Address, to common.Address, value *uint256.Int) {
 }

--- a/eth/tracers/tracer.go
+++ b/eth/tracers/tracer.go
@@ -584,10 +584,7 @@ func (jst *Tracer) CaptureTxStart(gasLimit uint64) {}
 func (jst *Tracer) CaptureTxEnd(restGas uint64) {}
 
 // CaptureStart implements the Tracer interface to initialize the tracing operation.
-func (jst *Tracer) CaptureStart(env *vm.EVM, depth int, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
-	if depth != 0 {
-		return
-	}
+func (jst *Tracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	jst.ctx["type"] = "CALL"
 	if create {
 		jst.ctx["type"] = "CREATE"
@@ -612,6 +609,9 @@ func (jst *Tracer) CaptureStart(env *vm.EVM, depth int, from common.Address, to 
 		return
 	}
 	jst.ctx["intrinsicGas"] = intrinsicGas
+}
+
+func (jst *Tracer) CaptureEnter(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
 }
 
 // CaptureState implements the Tracer interface to trace a single step of VM execution.
@@ -661,10 +661,7 @@ func (jst *Tracer) CaptureFault(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost 
 }
 
 // CaptureEnd is called after the call finishes to finalize the tracing.
-func (jst *Tracer) CaptureEnd(depth int, output []byte, startGas, endGas uint64, t time.Duration, err error) {
-	if depth != 0 {
-		return
-	}
+func (jst *Tracer) CaptureEnd(output []byte, startGas, endGas uint64, t time.Duration, err error) {
 	jst.ctx["output"] = output
 	jst.ctx["time"] = t.String()
 	jst.ctx["gasUsed"] = startGas - endGas
@@ -672,6 +669,9 @@ func (jst *Tracer) CaptureEnd(depth int, output []byte, startGas, endGas uint64,
 	if err != nil {
 		jst.ctx["error"] = err.Error()
 	}
+}
+
+func (jst *Tracer) CaptureExit(output []byte, startGas, endGas uint64, t time.Duration, err error) {
 }
 
 func (jst *Tracer) CaptureSelfDestruct(from common.Address, to common.Address, value *uint256.Int) {

--- a/eth/tracers/tracer_test.go
+++ b/eth/tracers/tracer_test.go
@@ -72,9 +72,9 @@ func runTrace(tracer *Tracer, vmctx *vmContext) (json.RawMessage, error) {
 	contract := vm.NewContract(account{}, account{}, value, startGas, false)
 	contract.Code = []byte{byte(vm.PUSH1), 0x1, byte(vm.PUSH1), 0x1, 0x0}
 
-	tracer.CaptureStart(env, 0, contract.Caller(), contract.Address(), false, false, vm.CallType(0), []byte{}, startGas, uint256.NewInt(value.Uint64()), contract.Code)
+	tracer.CaptureStart(env, contract.Caller(), contract.Address(), false, false, vm.CallType(0), []byte{}, startGas, uint256.NewInt(value.Uint64()), contract.Code)
 	ret, err := env.Interpreter().Run(contract, []byte{}, false)
-	tracer.CaptureEnd(0, ret, startGas, contract.Gas, 1, err)
+	tracer.CaptureEnd(ret, startGas, contract.Gas, 1, err)
 	if err != nil {
 		return nil, err
 	}
@@ -178,8 +178,8 @@ func TestNoStepExec(t *testing.T) {
 		env := vm.NewEVM(vmctx.blockCtx, vmctx.txCtx, &dummyStatedb{}, params.TestChainConfig, vm.Config{Debug: true, Tracer: tracer})
 		startGas := uint64(10000)
 		contract := vm.NewContract(account{}, account{}, uint256.NewInt(1), startGas, true)
-		tracer.CaptureStart(env, 0, contract.Caller(), contract.Address(), false, false, vm.CALLT, nil, 0, uint256.NewInt(0), nil)
-		tracer.CaptureEnd(0, nil, startGas-contract.Gas, 1, 0, nil)
+		tracer.CaptureStart(env, contract.Caller(), contract.Address(), false, false, vm.CALLT, nil, 0, uint256.NewInt(0), nil)
+		tracer.CaptureEnd(nil, startGas-contract.Gas, 1, 0, nil)
 		return tracer.GetResult()
 	}
 	execTracer := func(code string) []byte {

--- a/turbo/transactions/tracing.go
+++ b/turbo/transactions/tracing.go
@@ -257,7 +257,10 @@ func (l *JsonStreamLogger) CaptureTxStart(gasLimit uint64) {}
 func (l *JsonStreamLogger) CaptureTxEnd(restGas uint64) {}
 
 // CaptureStart implements the Tracer interface to initialize the tracing operation.
-func (l *JsonStreamLogger) CaptureStart(env *vm.EVM, depth int, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (l *JsonStreamLogger) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+}
+
+func (l *JsonStreamLogger) CaptureEnter(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
 }
 
 // CaptureState logs a new structured log message and pushes it out to the environment
@@ -393,7 +396,10 @@ func (l *JsonStreamLogger) CaptureFault(env *vm.EVM, pc uint64, op vm.OpCode, ga
 }
 
 // CaptureEnd is called after the call finishes to finalize the tracing.
-func (l *JsonStreamLogger) CaptureEnd(depth int, output []byte, startGas, endGas uint64, t time.Duration, err error) {
+func (l *JsonStreamLogger) CaptureEnd(output []byte, startGas, endGas uint64, t time.Duration, err error) {
+}
+
+func (l *JsonStreamLogger) CaptureExit(output []byte, startGas, endGas uint64, t time.Duration, err error) {
 }
 
 func (l *JsonStreamLogger) CaptureSelfDestruct(from common.Address, to common.Address, value *uint256.Int) {


### PR DESCRIPTION
Splitting function `CaptureStart` into `CaptureStart` (when depth == 0) and `CaptureEnter` (when depth > 0), while removing argument `depth`. Same with splitting `CaptureEnd` into `CaptureEnd` and `CaptureExit`