### PR TITLE
Native tracers - step 4

### DIFF
--- a/cmd/rpcdaemon/commands/otterscan_default_tracer.go
+++ b/cmd/rpcdaemon/commands/otterscan_default_tracer.go
@@ -21,13 +21,13 @@ func (t *DefaultTracer) CaptureTxEnd(restGas uint64) {}
 func (t *DefaultTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, calltype vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
 }
 
-func (t *DefaultTracer) CaptureEnter(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, calltype vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (t *DefaultTracer) CaptureEnter(from common.Address, to common.Address, precompile bool, create bool, calltype vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
 }
 
-func (t *DefaultTracer) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
+func (t *DefaultTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
 }
 
-func (t *DefaultTracer) CaptureFault(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
+func (t *DefaultTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
 }
 
 func (t *DefaultTracer) CaptureEnd(output []byte, startGas, endGas uint64, d time.Duration, err error) {

--- a/cmd/rpcdaemon/commands/otterscan_default_tracer.go
+++ b/cmd/rpcdaemon/commands/otterscan_default_tracer.go
@@ -18,10 +18,10 @@ func (t *DefaultTracer) CaptureTxStart(gasLimit uint64) {}
 
 func (t *DefaultTracer) CaptureTxEnd(restGas uint64) {}
 
-func (t *DefaultTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, calltype vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (t *DefaultTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
 }
 
-func (t *DefaultTracer) CaptureEnter(from common.Address, to common.Address, precompile bool, create bool, calltype vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (t *DefaultTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
 }
 
 func (t *DefaultTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {

--- a/cmd/rpcdaemon/commands/otterscan_trace_contract_creator.go
+++ b/cmd/rpcdaemon/commands/otterscan_trace_contract_creator.go
@@ -53,6 +53,6 @@ func (t *CreateTracer) CaptureStart(env *vm.EVM, from common.Address, to common.
 	t.captureStartOrEnter(from, to, create)
 }
 
-func (t *CreateTracer) CaptureEnter(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, calltype vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (t *CreateTracer) CaptureEnter(from common.Address, to common.Address, precompile bool, create bool, calltype vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	t.captureStartOrEnter(from, to, create)
 }

--- a/cmd/rpcdaemon/commands/otterscan_trace_contract_creator.go
+++ b/cmd/rpcdaemon/commands/otterscan_trace_contract_creator.go
@@ -49,10 +49,10 @@ func (t *CreateTracer) captureStartOrEnter(from, to common.Address, create bool)
 	t.Creator = from
 }
 
-func (t *CreateTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, calltype vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (t *CreateTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	t.captureStartOrEnter(from, to, create)
 }
 
-func (t *CreateTracer) CaptureEnter(from common.Address, to common.Address, precompile bool, create bool, calltype vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (t *CreateTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	t.captureStartOrEnter(from, to, create)
 }

--- a/cmd/rpcdaemon/commands/otterscan_trace_operations.go
+++ b/cmd/rpcdaemon/commands/otterscan_trace_operations.go
@@ -38,15 +38,15 @@ func NewOperationsTracer(ctx context.Context) *OperationsTracer {
 	}
 }
 
-func (t *OperationsTracer) CaptureEnter(from common.Address, to common.Address, precompile bool, create bool, calltype vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
-	if calltype == vm.CALLT && value.Uint64() != 0 {
+func (t *OperationsTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
+	if typ == vm.CALL && value.Uint64() != 0 {
 		t.Results = append(t.Results, &InternalOperation{OP_TRANSFER, from, to, (*hexutil.Big)(value.ToBig())})
 		return
 	}
-	if calltype == vm.CREATET {
+	if typ == vm.CREATE {
 		t.Results = append(t.Results, &InternalOperation{OP_CREATE, from, to, (*hexutil.Big)(value.ToBig())})
 	}
-	if calltype == vm.CREATE2T {
+	if typ == vm.CREATE2 {
 		t.Results = append(t.Results, &InternalOperation{OP_CREATE2, from, to, (*hexutil.Big)(value.ToBig())})
 	}
 }

--- a/cmd/rpcdaemon/commands/otterscan_trace_operations.go
+++ b/cmd/rpcdaemon/commands/otterscan_trace_operations.go
@@ -38,7 +38,7 @@ func NewOperationsTracer(ctx context.Context) *OperationsTracer {
 	}
 }
 
-func (t *OperationsTracer) CaptureEnter(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, calltype vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (t *OperationsTracer) CaptureEnter(from common.Address, to common.Address, precompile bool, create bool, calltype vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	if calltype == vm.CALLT && value.Uint64() != 0 {
 		t.Results = append(t.Results, &InternalOperation{OP_TRANSFER, from, to, (*hexutil.Big)(value.ToBig())})
 		return

--- a/cmd/rpcdaemon/commands/otterscan_trace_touch.go
+++ b/cmd/rpcdaemon/commands/otterscan_trace_touch.go
@@ -26,10 +26,10 @@ func (t *TouchTracer) captureStartOrEnter(from, to common.Address) {
 	}
 }
 
-func (t *TouchTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, calltype vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (t *TouchTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	t.captureStartOrEnter(from, to)
 }
 
-func (t *TouchTracer) CaptureEnter(from common.Address, to common.Address, precompile bool, create bool, calltype vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (t *TouchTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	t.captureStartOrEnter(from, to)
 }

--- a/cmd/rpcdaemon/commands/otterscan_trace_touch.go
+++ b/cmd/rpcdaemon/commands/otterscan_trace_touch.go
@@ -30,6 +30,6 @@ func (t *TouchTracer) CaptureStart(env *vm.EVM, from common.Address, to common.A
 	t.captureStartOrEnter(from, to)
 }
 
-func (t *TouchTracer) CaptureEnter(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, calltype vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (t *TouchTracer) CaptureEnter(from common.Address, to common.Address, precompile bool, create bool, calltype vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	t.captureStartOrEnter(from, to)
 }

--- a/cmd/rpcdaemon/commands/otterscan_trace_transaction.go
+++ b/cmd/rpcdaemon/commands/otterscan_trace_transaction.go
@@ -89,7 +89,7 @@ func (t *TransactionTracer) CaptureStart(env *vm.EVM, from common.Address, to co
 	t.captureStartOrEnter(from, to, precompile, callType, input, value)
 }
 
-func (t *TransactionTracer) CaptureEnter(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (t *TransactionTracer) CaptureEnter(from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	t.depth++
 	t.captureStartOrEnter(from, to, precompile, callType, input, value)
 }

--- a/cmd/rpcdaemon/commands/otterscan_trace_transaction.go
+++ b/cmd/rpcdaemon/commands/otterscan_trace_transaction.go
@@ -49,7 +49,7 @@ func NewTransactionTracer(ctx context.Context) *TransactionTracer {
 	}
 }
 
-func (t *TransactionTracer) captureStartOrEnter(from, to common.Address, precompile bool, callType vm.CallType, input []byte, value *uint256.Int) {
+func (t *TransactionTracer) captureStartOrEnter(typ vm.OpCode, from, to common.Address, precompile bool, input []byte, value *uint256.Int) {
 	if precompile {
 		return
 	}
@@ -58,40 +58,40 @@ func (t *TransactionTracer) captureStartOrEnter(from, to common.Address, precomp
 	copy(inputCopy, input)
 	_value := new(big.Int)
 	_value.Set(value.ToBig())
-	if callType == vm.CALLT {
+	if typ == vm.CALL {
 		t.Results = append(t.Results, &TraceEntry{"CALL", t.depth, from, to, (*hexutil.Big)(_value), inputCopy})
 		return
 	}
-	if callType == vm.STATICCALLT {
+	if typ == vm.STATICCALL {
 		t.Results = append(t.Results, &TraceEntry{"STATICCALL", t.depth, from, to, nil, inputCopy})
 		return
 	}
-	if callType == vm.DELEGATECALLT {
+	if typ == vm.DELEGATECALL {
 		t.Results = append(t.Results, &TraceEntry{"DELEGATECALL", t.depth, from, to, nil, inputCopy})
 		return
 	}
-	if callType == vm.CALLCODET {
+	if typ == vm.CALLCODE {
 		t.Results = append(t.Results, &TraceEntry{"CALLCODE", t.depth, from, to, (*hexutil.Big)(_value), inputCopy})
 		return
 	}
-	if callType == vm.CREATET {
+	if typ == vm.CREATE {
 		t.Results = append(t.Results, &TraceEntry{"CREATE", t.depth, from, to, (*hexutil.Big)(value.ToBig()), inputCopy})
 		return
 	}
-	if callType == vm.CREATE2T {
+	if typ == vm.CREATE2 {
 		t.Results = append(t.Results, &TraceEntry{"CREATE2", t.depth, from, to, (*hexutil.Big)(value.ToBig()), inputCopy})
 		return
 	}
 }
 
-func (t *TransactionTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (t *TransactionTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	t.depth = 0
-	t.captureStartOrEnter(from, to, precompile, callType, input, value)
+	t.captureStartOrEnter(vm.CALL, from, to, precompile, input, value)
 }
 
-func (t *TransactionTracer) CaptureEnter(from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (t *TransactionTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	t.depth++
-	t.captureStartOrEnter(from, to, precompile, callType, input, value)
+	t.captureStartOrEnter(typ, from, to, precompile, input, value)
 }
 
 func (t *TransactionTracer) CaptureExit(output []byte, startGas, endGas uint64, d time.Duration, err error) {

--- a/cmd/rpcdaemon/commands/trace_adhoc.go
+++ b/cmd/rpcdaemon/commands/trace_adhoc.go
@@ -341,7 +341,7 @@ func (ot *OeTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Add
 	ot.captureStartOrEnter(false /* deep */, from, to, precompile, create, callType, input, gas, value, code)
 }
 
-func (ot *OeTracer) CaptureEnter(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (ot *OeTracer) CaptureEnter(from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	ot.captureStartOrEnter(true /* deep */, from, to, precompile, create, callType, input, gas, value, code)
 }
 
@@ -438,7 +438,7 @@ func (ot *OeTracer) CaptureExit(output []byte, startGas, endGas uint64, t time.D
 	ot.captureEndOrExit(true /* deep */, output, startGas, endGas, t, err)
 }
 
-func (ot *OeTracer) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, opDepth int, err error) {
+func (ot *OeTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, opDepth int, err error) {
 	memory := scope.Memory
 	st := scope.Stack
 
@@ -566,7 +566,7 @@ func (ot *OeTracer) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost
 	}
 }
 
-func (ot *OeTracer) CaptureFault(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, opDepth int, err error) {
+func (ot *OeTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, opDepth int, err error) {
 }
 
 func (ot *OeTracer) CaptureSelfDestruct(from common.Address, to common.Address, value *uint256.Int) {

--- a/cmd/state/commands/opcode_tracer.go
+++ b/cmd/state/commands/opcode_tracer.go
@@ -190,13 +190,13 @@ func (ot *opcodeTracer) captureStartOrEnter(from, to common.Address, create bool
 	ot.stack = append(ot.stack, &newTx)
 }
 
-func (ot *opcodeTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (ot *opcodeTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	ot.env = env
 	ot.depth = 0
 	ot.captureStartOrEnter(from, to, create, input)
 }
 
-func (ot *opcodeTracer) CaptureEnter(from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (ot *opcodeTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	ot.depth++
 	ot.captureStartOrEnter(from, to, create, input)
 }

--- a/cmd/state/exec3/calltracer22.go
+++ b/cmd/state/exec3/calltracer22.go
@@ -28,10 +28,10 @@ func (ct *CallTracer) captureStartOrEnter(from, to common.Address) {
 	ct.froms[from] = struct{}{}
 	ct.tos[to] = struct{}{}
 }
-func (ct *CallTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (ct *CallTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	ct.captureStartOrEnter(from, to)
 }
-func (ct *CallTracer) CaptureEnter(from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (ct *CallTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	ct.captureStartOrEnter(from, to)
 }
 func (ct *CallTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {

--- a/cmd/state/exec3/calltracer22.go
+++ b/cmd/state/exec3/calltracer22.go
@@ -31,12 +31,12 @@ func (ct *CallTracer) captureStartOrEnter(from, to common.Address) {
 func (ct *CallTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	ct.captureStartOrEnter(from, to)
 }
-func (ct *CallTracer) CaptureEnter(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (ct *CallTracer) CaptureEnter(from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	ct.captureStartOrEnter(from, to)
 }
-func (ct *CallTracer) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
+func (ct *CallTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
 }
-func (ct *CallTracer) CaptureFault(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
+func (ct *CallTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
 }
 func (ct *CallTracer) CaptureEnd(output []byte, startGas, endGas uint64, t time.Duration, err error) {
 }

--- a/core/vm/access_list_tracer.go
+++ b/core/vm/access_list_tracer.go
@@ -174,11 +174,11 @@ func (*AccessListTracer) CaptureFault(pc uint64, op OpCode, gas, cost uint64, sc
 func (*AccessListTracer) CaptureEnd(output []byte, startGas, endGas uint64, t time.Duration, err error) {
 }
 
-func (a *AccessListTracer) CaptureStart(env *EVM, from common.Address, to common.Address, precompile bool, create bool, callType CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (a *AccessListTracer) CaptureStart(env *EVM, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	panic("implement me")
 }
 
-func (a *AccessListTracer) CaptureEnter(from common.Address, to common.Address, precompile bool, create bool, callType CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (a *AccessListTracer) CaptureEnter(typ OpCode, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	panic("implement me")
 }
 

--- a/core/vm/access_list_tracer.go
+++ b/core/vm/access_list_tracer.go
@@ -148,7 +148,7 @@ func NewAccessListTracer(acl types.AccessList, from, to common.Address, precompi
 }
 
 // CaptureState captures all opcodes that touch storage or addresses and adds them to the accesslist.
-func (a *AccessListTracer) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost uint64, scope *ScopeContext, rData []byte, depth int, err error) {
+func (a *AccessListTracer) CaptureState(pc uint64, op OpCode, gas, cost uint64, scope *ScopeContext, rData []byte, depth int, err error) {
 	stack := scope.Stack
 	if (op == SLOAD || op == SSTORE) && stack.Len() >= 1 {
 		slot := common.Hash(stack.Data[stack.Len()-1].Bytes32())
@@ -168,7 +168,7 @@ func (a *AccessListTracer) CaptureState(env *EVM, pc uint64, op OpCode, gas, cos
 	}
 }
 
-func (*AccessListTracer) CaptureFault(env *EVM, pc uint64, op OpCode, gas, cost uint64, scope *ScopeContext, depth int, err error) {
+func (*AccessListTracer) CaptureFault(pc uint64, op OpCode, gas, cost uint64, scope *ScopeContext, depth int, err error) {
 }
 
 func (*AccessListTracer) CaptureEnd(output []byte, startGas, endGas uint64, t time.Duration, err error) {
@@ -178,7 +178,7 @@ func (a *AccessListTracer) CaptureStart(env *EVM, from common.Address, to common
 	panic("implement me")
 }
 
-func (a *AccessListTracer) CaptureEnter(env *EVM, from common.Address, to common.Address, precompile bool, create bool, callType CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (a *AccessListTracer) CaptureEnter(from common.Address, to common.Address, precompile bool, create bool, callType CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	panic("implement me")
 }
 

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -183,7 +183,7 @@ func (evm *EVM) call(callType CallType, caller ContractRef, addr common.Address,
 				evm.config.Tracer.CaptureEnd(ret, startGas, gas, time.Since(startTime), err)
 			}(gas, time.Now())
 		} else {
-			evm.config.Tracer.CaptureEnter(evm, caller.Address(), addr, isPrecompile, false /* create */, callType, input, gas, value, code)
+			evm.config.Tracer.CaptureEnter(caller.Address(), addr, isPrecompile, false /* create */, callType, input, gas, value, code)
 			defer func(startGas uint64, startTime time.Time) { // Lazy evaluation of the parameters
 				evm.config.Tracer.CaptureExit(ret, startGas, gas, time.Since(startTime), err)
 			}(gas, time.Now())
@@ -325,7 +325,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 				evm.config.Tracer.CaptureEnd(ret, startGas, gas, time.Since(startTime), err)
 			}(gas, time.Now())
 		} else {
-			evm.config.Tracer.CaptureEnter(evm, caller.Address(), address, false /* precompile */, true /* create */, calltype, codeAndHash.code, gas, value, nil)
+			evm.config.Tracer.CaptureEnter(caller.Address(), address, false /* precompile */, true /* create */, calltype, codeAndHash.code, gas, value, nil)
 			defer func(startGas uint64, startTime time.Time) { // Lazy evaluation of the parameters
 				evm.config.Tracer.CaptureExit(ret, startGas, gas, time.Since(startTime), err)
 			}(gas, time.Now())

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -154,7 +154,7 @@ func (evm *EVM) Interpreter() Interpreter {
 	return evm.interpreter
 }
 
-func (evm *EVM) call(callType CallType, caller ContractRef, addr common.Address, input []byte, gas uint64, value *uint256.Int, bailout bool) (ret []byte, leftOverGas uint64, err error) {
+func (evm *EVM) call(typ OpCode, caller ContractRef, addr common.Address, input []byte, gas uint64, value *uint256.Int, bailout bool) (ret []byte, leftOverGas uint64, err error) {
 	if evm.config.NoRecursion && evm.depth > 0 {
 		return nil, gas, nil
 	}
@@ -162,7 +162,7 @@ func (evm *EVM) call(callType CallType, caller ContractRef, addr common.Address,
 	if evm.depth > int(params.CallCreateDepth) {
 		return nil, gas, ErrDepth
 	}
-	if callType == CALLT || callType == CALLCODET {
+	if typ == CALL || typ == CALLCODE {
 		// Fail if we're trying to transfer more than the available balance
 		if !value.IsZero() && !evm.context.CanTransfer(evm.intraBlockState, caller.Address(), value) {
 			if !bailout {
@@ -178,12 +178,12 @@ func (evm *EVM) call(callType CallType, caller ContractRef, addr common.Address,
 	// Capture the tracer start/end events in debug mode
 	if evm.config.Debug {
 		if evm.depth == 0 {
-			evm.config.Tracer.CaptureStart(evm, caller.Address(), addr, isPrecompile, false /* create */, callType, input, gas, value, code)
+			evm.config.Tracer.CaptureStart(evm, caller.Address(), addr, isPrecompile, false /* create */, input, gas, value, code)
 			defer func(startGas uint64, startTime time.Time) { // Lazy evaluation of the parameters
 				evm.config.Tracer.CaptureEnd(ret, startGas, gas, time.Since(startTime), err)
 			}(gas, time.Now())
 		} else {
-			evm.config.Tracer.CaptureEnter(caller.Address(), addr, isPrecompile, false /* create */, callType, input, gas, value, code)
+			evm.config.Tracer.CaptureEnter(typ, caller.Address(), addr, isPrecompile, false /* create */, input, gas, value, code)
 			defer func(startGas uint64, startTime time.Time) { // Lazy evaluation of the parameters
 				evm.config.Tracer.CaptureExit(ret, startGas, gas, time.Since(startTime), err)
 			}(gas, time.Now())
@@ -192,7 +192,7 @@ func (evm *EVM) call(callType CallType, caller ContractRef, addr common.Address,
 
 	snapshot := evm.intraBlockState.Snapshot()
 
-	if callType == CALLT {
+	if typ == CALL {
 		if !evm.intraBlockState.Exist(addr) {
 			if !isPrecompile && evm.chainRules.IsSpuriousDragon && value.IsZero() {
 				return nil, gas, nil
@@ -200,7 +200,7 @@ func (evm *EVM) call(callType CallType, caller ContractRef, addr common.Address,
 			evm.intraBlockState.CreateAccount(addr, false)
 		}
 		evm.context.Transfer(evm.intraBlockState, caller.Address(), addr, value, bailout)
-	} else if callType == STATICCALLT {
+	} else if typ == STATICCALL {
 		// We do an AddBalance of zero here, just in order to trigger a touch.
 		// This doesn't matter on Mainnet, where all empties are gone at the time of Byzantium,
 		// but is the correct thing to do and matters on other networks, in tests, and potential
@@ -224,16 +224,16 @@ func (evm *EVM) call(callType CallType, caller ContractRef, addr common.Address,
 		// The contract is a scoped environment for this execution context only.
 		codeHash := evm.intraBlockState.GetCodeHash(addrCopy)
 		var contract *Contract
-		if callType == CALLCODET {
+		if typ == CALLCODE {
 			contract = NewContract(caller, AccountRef(caller.Address()), value, gas, evm.config.SkipAnalysis)
-		} else if callType == DELEGATECALLT {
+		} else if typ == DELEGATECALL {
 			contract = NewContract(caller, AccountRef(caller.Address()), value, gas, evm.config.SkipAnalysis).AsDelegate()
 		} else {
 			contract = NewContract(caller, AccountRef(addrCopy), value, gas, evm.config.SkipAnalysis)
 		}
 		contract.SetCallCode(&addrCopy, codeHash, code)
 		readOnly := false
-		if callType == STATICCALLT {
+		if typ == STATICCALL {
 			readOnly = true
 		}
 		ret, err = run(evm, contract, input, readOnly)
@@ -259,7 +259,7 @@ func (evm *EVM) call(callType CallType, caller ContractRef, addr common.Address,
 // the necessary steps to create accounts and reverses the state in case of an
 // execution error or failed value transfer.
 func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas uint64, value *uint256.Int, bailout bool) (ret []byte, leftOverGas uint64, err error) {
-	return evm.call(CALLT, caller, addr, input, gas, value, bailout)
+	return evm.call(CALL, caller, addr, input, gas, value, bailout)
 }
 
 // CallCode executes the contract associated with the addr with the given input
@@ -270,7 +270,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 // CallCode differs from Call in the sense that it executes the given address'
 // code with the caller as context.
 func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, gas uint64, value *uint256.Int) (ret []byte, leftOverGas uint64, err error) {
-	return evm.call(CALLCODET, caller, addr, input, gas, value, false)
+	return evm.call(CALLCODE, caller, addr, input, gas, value, false)
 }
 
 // DelegateCall executes the contract associated with the addr with the given input
@@ -279,7 +279,7 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 // DelegateCall differs from CallCode in the sense that it executes the given address'
 // code with the caller as context and the caller is set to the caller of the caller.
 func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []byte, gas uint64) (ret []byte, leftOverGas uint64, err error) {
-	return evm.call(DELEGATECALLT, caller, addr, input, gas, nil, false)
+	return evm.call(DELEGATECALL, caller, addr, input, gas, nil, false)
 }
 
 // StaticCall executes the contract associated with the addr with the given input
@@ -287,7 +287,7 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 // Opcodes that attempt to perform such modifications will result in exceptions
 // instead of performing the modifications.
 func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte, gas uint64) (ret []byte, leftOverGas uint64, err error) {
-	return evm.call(STATICCALLT, caller, addr, input, gas, new(uint256.Int), false)
+	return evm.call(STATICCALL, caller, addr, input, gas, new(uint256.Int), false)
 }
 
 type codeAndHash struct {
@@ -303,7 +303,7 @@ func (c *codeAndHash) Hash() common.Hash {
 }
 
 // create creates a new contract using code as deployment code.
-func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64, value *uint256.Int, address common.Address, calltype CallType, incrementNonce bool) ([]byte, common.Address, uint64, error) {
+func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64, value *uint256.Int, address common.Address, typ OpCode, incrementNonce bool) ([]byte, common.Address, uint64, error) {
 	var ret []byte
 	var err error
 	// Depth check execution. Fail if we're trying to execute above the
@@ -320,12 +320,12 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 	}
 	if evm.config.Debug {
 		if evm.depth == 0 {
-			evm.config.Tracer.CaptureStart(evm, caller.Address(), address, false /* precompile */, true /* create */, calltype, codeAndHash.code, gas, value, nil)
+			evm.config.Tracer.CaptureStart(evm, caller.Address(), address, false /* precompile */, true /* create */, codeAndHash.code, gas, value, nil)
 			defer func(startGas uint64, startTime time.Time) { // Lazy evaluation of the parameters
 				evm.config.Tracer.CaptureEnd(ret, startGas, gas, time.Since(startTime), err)
 			}(gas, time.Now())
 		} else {
-			evm.config.Tracer.CaptureEnter(caller.Address(), address, false /* precompile */, true /* create */, calltype, codeAndHash.code, gas, value, nil)
+			evm.config.Tracer.CaptureEnter(typ, caller.Address(), address, false /* precompile */, true /* create */, codeAndHash.code, gas, value, nil)
 			defer func(startGas uint64, startTime time.Time) { // Lazy evaluation of the parameters
 				evm.config.Tracer.CaptureExit(ret, startGas, gas, time.Since(startTime), err)
 			}(gas, time.Now())
@@ -413,7 +413,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 // DESCRIBED: docs/programmers_guide/guide.md#nonce
 func (evm *EVM) Create(caller ContractRef, code []byte, gas uint64, endowment *uint256.Int) (ret []byte, contractAddr common.Address, leftOverGas uint64, err error) {
 	contractAddr = crypto.CreateAddress(caller.Address(), evm.intraBlockState.GetNonce(caller.Address()))
-	return evm.create(caller, &codeAndHash{code: code}, gas, endowment, contractAddr, CREATET, true /* incrementNonce */)
+	return evm.create(caller, &codeAndHash{code: code}, gas, endowment, contractAddr, CREATE, true /* incrementNonce */)
 }
 
 // Create2 creates a new contract using code as deployment code.
@@ -424,13 +424,13 @@ func (evm *EVM) Create(caller ContractRef, code []byte, gas uint64, endowment *u
 func (evm *EVM) Create2(caller ContractRef, code []byte, gas uint64, endowment *uint256.Int, salt *uint256.Int) (ret []byte, contractAddr common.Address, leftOverGas uint64, err error) {
 	codeAndHash := &codeAndHash{code: code}
 	contractAddr = crypto.CreateAddress2(caller.Address(), salt.Bytes32(), codeAndHash.Hash().Bytes())
-	return evm.create(caller, codeAndHash, gas, endowment, contractAddr, CREATE2T, true /* incrementNonce */)
+	return evm.create(caller, codeAndHash, gas, endowment, contractAddr, CREATE2, true /* incrementNonce */)
 }
 
 // SysCreate is a special (system) contract creation methods for genesis constructors.
 // Unlike the normal Create & Create2, it doesn't increment caller's nonce.
 func (evm *EVM) SysCreate(caller ContractRef, code []byte, gas uint64, endowment *uint256.Int, contractAddr common.Address) (ret []byte, leftOverGas uint64, err error) {
-	ret, _, leftOverGas, err = evm.create(caller, &codeAndHash{code: code}, gas, endowment, contractAddr, CREATET, false /* incrementNonce */)
+	ret, _, leftOverGas, err = evm.create(caller, &codeAndHash{code: code}, gas, endowment, contractAddr, CREATE, false /* incrementNonce */)
 	return
 }
 

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -255,9 +255,9 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		defer func() {
 			if err != nil {
 				if !logged {
-					in.cfg.Tracer.CaptureState(in.evm, pcCopy, op, gasCopy, cost, callContext, in.returnData, in.evm.depth, err) //nolint:errcheck
+					in.cfg.Tracer.CaptureState(pcCopy, op, gasCopy, cost, callContext, in.returnData, in.evm.depth, err) //nolint:errcheck
 				} else {
-					in.cfg.Tracer.CaptureFault(in.evm, pcCopy, op, gasCopy, cost, callContext, in.evm.depth, err)
+					in.cfg.Tracer.CaptureFault(pcCopy, op, gasCopy, cost, callContext, in.evm.depth, err)
 				}
 			}
 		}()
@@ -340,7 +340,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		}
 
 		if in.cfg.Debug {
-			in.cfg.Tracer.CaptureState(in.evm, _pc, op, gasCopy, cost, callContext, in.returnData, in.evm.depth, err) //nolint:errcheck
+			in.cfg.Tracer.CaptureState(_pc, op, gasCopy, cost, callContext, in.returnData, in.evm.depth, err) //nolint:errcheck
 			logged = true
 		}
 

--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -104,17 +104,6 @@ func (s *StructLog) ErrorString() string {
 	return ""
 }
 
-type CallType int
-
-const (
-	CALLT CallType = iota
-	CALLCODET
-	DELEGATECALLT
-	STATICCALLT
-	CREATET
-	CREATE2T
-)
-
 // Tracer is used to collect execution traces from an EVM transaction
 // execution. CaptureState is called for each step of the VM with the
 // current VM state.
@@ -125,10 +114,10 @@ type Tracer interface {
 	CaptureTxStart(gasLimit uint64)
 	CaptureTxEnd(restGas uint64)
 	// Top call frame
-	CaptureStart(env *EVM, from common.Address, to common.Address, precompile bool, create bool, callType CallType, input []byte, gas uint64, value *uint256.Int, code []byte)
+	CaptureStart(env *EVM, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte)
 	CaptureEnd(output []byte, startGas, endGas uint64, t time.Duration, err error)
 	// Rest of the frames
-	CaptureEnter(efrom common.Address, to common.Address, precompile bool, create bool, callType CallType, input []byte, gas uint64, value *uint256.Int, code []byte)
+	CaptureEnter(typ OpCode, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte)
 	CaptureExit(output []byte, startGas, endGas uint64, t time.Duration, err error)
 	// Opcode level
 	CaptureState(pc uint64, op OpCode, gas, cost uint64, scope *ScopeContext, rData []byte, depth int, err error)
@@ -191,12 +180,12 @@ func (l *StructLogger) CaptureTxStart(gasLimit uint64) {}
 func (l *StructLogger) CaptureTxEnd(restGas uint64) {}
 
 // CaptureStart implements the Tracer interface to initialize the tracing operation.
-func (l *StructLogger) CaptureStart(env *EVM, from common.Address, to common.Address, precompile bool, create bool, callType CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (l *StructLogger) CaptureStart(env *EVM, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	l.env = env
 }
 
 // CaptureEnter implements the Tracer interface to initialize the tracing operation for an internal call.
-func (l *StructLogger) CaptureEnter(from common.Address, to common.Address, precompile bool, create bool, callType CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (l *StructLogger) CaptureEnter(typ OpCode, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
 }
 
 // CaptureState logs a new structured log message and pushes it out to the environment
@@ -440,12 +429,12 @@ func (t *mdLogger) captureStartOrEnter(from, to common.Address, create bool, inp
 `)
 }
 
-func (t *mdLogger) CaptureStart(env *EVM, from common.Address, to common.Address, precompile bool, create bool, callType CallType, input []byte, gas uint64, value *uint256.Int, code []byte) { //nolint:interfacer
+func (t *mdLogger) CaptureStart(env *EVM, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) { //nolint:interfacer
 	t.env = env
 	t.captureStartOrEnter(from, to, create, input, gas, value)
 }
 
-func (t *mdLogger) CaptureEnter(from common.Address, to common.Address, precompile bool, create bool, callType CallType, input []byte, gas uint64, value *uint256.Int, code []byte) { //nolint:interfacer
+func (t *mdLogger) CaptureEnter(typ OpCode, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) { //nolint:interfacer
 	t.captureStartOrEnter(from, to, create, input, gas, value)
 }
 

--- a/core/vm/logger_json.go
+++ b/core/vm/logger_json.go
@@ -30,12 +30,13 @@ import (
 type JSONLogger struct {
 	encoder *json.Encoder
 	cfg     *LogConfig
+	env     *EVM
 }
 
 // NewJSONLogger creates a new EVM tracer that prints execution steps as JSON objects
 // into the provided stream.
 func NewJSONLogger(cfg *LogConfig, writer io.Writer) *JSONLogger {
-	l := &JSONLogger{json.NewEncoder(writer), cfg}
+	l := &JSONLogger{json.NewEncoder(writer), cfg, nil}
 	if l.cfg == nil {
 		l.cfg = &LogConfig{}
 	}
@@ -47,13 +48,14 @@ func (l *JSONLogger) CaptureTxStart(gasLimit uint64) {}
 func (l *JSONLogger) CaptureTxEnd(restGas uint64) {}
 
 func (l *JSONLogger) CaptureStart(env *EVM, from common.Address, to common.Address, precompile bool, create bool, callType CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+	l.env = env
 }
 
-func (l *JSONLogger) CaptureEnter(env *EVM, from common.Address, to common.Address, precompile bool, create bool, callType CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (l *JSONLogger) CaptureEnter(from common.Address, to common.Address, precompile bool, create bool, callType CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
 }
 
 // CaptureState outputs state information on the logger.
-func (l *JSONLogger) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost uint64, scope *ScopeContext, rData []byte, depth int, err error) {
+func (l *JSONLogger) CaptureState(pc uint64, op OpCode, gas, cost uint64, scope *ScopeContext, rData []byte, depth int, err error) {
 	memory := scope.Memory
 	stack := scope.Stack
 
@@ -65,7 +67,7 @@ func (l *JSONLogger) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost uint
 		MemorySize:    memory.Len(),
 		Storage:       nil,
 		Depth:         depth,
-		RefundCounter: env.IntraBlockState().GetRefund(),
+		RefundCounter: l.env.IntraBlockState().GetRefund(),
 		Err:           err,
 	}
 	if !l.cfg.DisableMemory {
@@ -83,7 +85,7 @@ func (l *JSONLogger) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost uint
 }
 
 // CaptureFault outputs state information on the logger.
-func (l *JSONLogger) CaptureFault(env *EVM, pc uint64, op OpCode, gas, cost uint64, scope *ScopeContext, depth int, err error) {
+func (l *JSONLogger) CaptureFault(pc uint64, op OpCode, gas, cost uint64, scope *ScopeContext, depth int, err error) {
 }
 
 // CaptureEnd is triggered at end of execution.

--- a/core/vm/logger_json.go
+++ b/core/vm/logger_json.go
@@ -47,11 +47,11 @@ func (l *JSONLogger) CaptureTxStart(gasLimit uint64) {}
 
 func (l *JSONLogger) CaptureTxEnd(restGas uint64) {}
 
-func (l *JSONLogger) CaptureStart(env *EVM, from common.Address, to common.Address, precompile bool, create bool, callType CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (l *JSONLogger) CaptureStart(env *EVM, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	l.env = env
 }
 
-func (l *JSONLogger) CaptureEnter(from common.Address, to common.Address, precompile bool, create bool, callType CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (l *JSONLogger) CaptureEnter(typ OpCode, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
 }
 
 // CaptureState outputs state information on the logger.

--- a/core/vm/logger_test.go
+++ b/core/vm/logger_test.go
@@ -39,7 +39,8 @@ func TestStoreCapture(t *testing.T) {
 	stack.Push(uint256.NewInt(1))
 	stack.Push(uint256.NewInt(0))
 	var index common.Hash
-	logger.CaptureState(env, 0, SSTORE, 0, 0, &ScopeContext{
+	logger.CaptureStart(env, common.Address{}, common.Address{}, false, false, CALLT, nil, 0, nil, nil)
+	logger.CaptureState(0, SSTORE, 0, 0, &ScopeContext{
 		Memory:   mem,
 		Stack:    stack,
 		Contract: contract,

--- a/core/vm/logger_test.go
+++ b/core/vm/logger_test.go
@@ -39,7 +39,7 @@ func TestStoreCapture(t *testing.T) {
 	stack.Push(uint256.NewInt(1))
 	stack.Push(uint256.NewInt(0))
 	var index common.Hash
-	logger.CaptureStart(env, common.Address{}, common.Address{}, false, false, CALLT, nil, 0, nil, nil)
+	logger.CaptureStart(env, common.Address{}, common.Address{}, false, false, nil, 0, nil, nil)
 	logger.CaptureState(0, SSTORE, 0, 0, &ScopeContext{
 		Memory:   mem,
 		Stack:    stack,

--- a/eth/calltracer/calltracer.go
+++ b/eth/calltracer/calltracer.go
@@ -46,12 +46,12 @@ func (ct *CallTracer) captureStartOrEnter(from, to common.Address, create bool, 
 func (ct *CallTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	ct.captureStartOrEnter(from, to, create, code)
 }
-func (ct *CallTracer) CaptureEnter(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (ct *CallTracer) CaptureEnter(from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	ct.captureStartOrEnter(from, to, create, code)
 }
-func (ct *CallTracer) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
+func (ct *CallTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
 }
-func (ct *CallTracer) CaptureFault(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
+func (ct *CallTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
 }
 func (ct *CallTracer) CaptureEnd(output []byte, startGas, endGas uint64, t time.Duration, err error) {
 }

--- a/eth/calltracer/calltracer.go
+++ b/eth/calltracer/calltracer.go
@@ -43,10 +43,10 @@ func (ct *CallTracer) captureStartOrEnter(from, to common.Address, create bool, 
 	}
 }
 
-func (ct *CallTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (ct *CallTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	ct.captureStartOrEnter(from, to, create, code)
 }
-func (ct *CallTracer) CaptureEnter(from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (ct *CallTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	ct.captureStartOrEnter(from, to, create, code)
 }
 func (ct *CallTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {

--- a/eth/tracers/logger/access_list_tracer.go
+++ b/eth/tracers/logger/access_list_tracer.go
@@ -142,10 +142,10 @@ func (a *AccessListTracer) CaptureTxStart(gasLimit uint64) {}
 
 func (a *AccessListTracer) CaptureTxEnd(restGas uint64) {}
 
-func (a *AccessListTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (a *AccessListTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
 }
 
-func (a *AccessListTracer) CaptureEnter(from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (a *AccessListTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
 }
 
 // CaptureState captures all opcodes that touch storage or addresses and adds them to the accesslist.

--- a/eth/tracers/logger/access_list_tracer.go
+++ b/eth/tracers/logger/access_list_tracer.go
@@ -145,11 +145,11 @@ func (a *AccessListTracer) CaptureTxEnd(restGas uint64) {}
 func (a *AccessListTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
 }
 
-func (a *AccessListTracer) CaptureEnter(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (a *AccessListTracer) CaptureEnter(from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
 }
 
 // CaptureState captures all opcodes that touch storage or addresses and adds them to the accesslist.
-func (a *AccessListTracer) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
+func (a *AccessListTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
 	stack := scope.Stack
 	contract := scope.Contract
 
@@ -173,7 +173,7 @@ func (a *AccessListTracer) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, ga
 	}
 }
 
-func (*AccessListTracer) CaptureFault(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
+func (*AccessListTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
 }
 func (*AccessListTracer) CaptureEnd(output []byte, startGas, endGas uint64, t time.Duration, err error) {
 }

--- a/eth/tracers/tracer.go
+++ b/eth/tracers/tracer.go
@@ -585,7 +585,7 @@ func (jst *Tracer) CaptureTxStart(gasLimit uint64) {}
 func (jst *Tracer) CaptureTxEnd(restGas uint64) {}
 
 // CaptureStart implements the Tracer interface to initialize the tracing operation.
-func (jst *Tracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (jst *Tracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	jst.env = env
 	jst.ctx["type"] = "CALL"
 	if create {
@@ -613,7 +613,7 @@ func (jst *Tracer) CaptureStart(env *vm.EVM, from common.Address, to common.Addr
 	jst.ctx["intrinsicGas"] = intrinsicGas
 }
 
-func (jst *Tracer) CaptureEnter(from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (jst *Tracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
 }
 
 // CaptureState implements the Tracer interface to trace a single step of VM execution.

--- a/eth/tracers/tracer_test.go
+++ b/eth/tracers/tracer_test.go
@@ -72,7 +72,7 @@ func runTrace(tracer *Tracer, vmctx *vmContext) (json.RawMessage, error) {
 	contract := vm.NewContract(account{}, account{}, value, startGas, false)
 	contract.Code = []byte{byte(vm.PUSH1), 0x1, byte(vm.PUSH1), 0x1, 0x0}
 
-	tracer.CaptureStart(env, contract.Caller(), contract.Address(), false, false, vm.CallType(0), []byte{}, startGas, uint256.NewInt(value.Uint64()), contract.Code)
+	tracer.CaptureStart(env, contract.Caller(), contract.Address(), false, false, []byte{}, startGas, uint256.NewInt(value.Uint64()), contract.Code)
 	ret, err := env.Interpreter().Run(contract, []byte{}, false)
 	tracer.CaptureEnd(ret, startGas, contract.Gas, 1, err)
 	if err != nil {
@@ -161,7 +161,7 @@ func TestHaltBetweenSteps(t *testing.T) {
 	}, evmtypes.TxContext{GasPrice: &uint256.Int{}}, &dummyStatedb{}, params.TestChainConfig, vm.Config{Debug: true, Tracer: tracer})
 	contract := vm.NewContract(&account{}, &account{}, uint256.NewInt(0), 0, false)
 
-	tracer.CaptureStart(env, common.Address{}, common.Address{}, false, false, vm.CALLT, nil, 0, &uint256.Int{}, nil)
+	tracer.CaptureStart(env, common.Address{}, common.Address{}, false, false, nil, 0, &uint256.Int{}, nil)
 	tracer.CaptureState(0, 0, 0, 0, &vm.ScopeContext{Contract: contract}, nil, 0, nil) //nolint:errcheck
 	timeout := errors.New("stahp")
 	tracer.Stop(timeout)
@@ -179,7 +179,7 @@ func TestNoStepExec(t *testing.T) {
 		env := vm.NewEVM(vmctx.blockCtx, vmctx.txCtx, &dummyStatedb{}, params.TestChainConfig, vm.Config{Debug: true, Tracer: tracer})
 		startGas := uint64(10000)
 		contract := vm.NewContract(account{}, account{}, uint256.NewInt(1), startGas, true)
-		tracer.CaptureStart(env, contract.Caller(), contract.Address(), false, false, vm.CALLT, nil, 0, uint256.NewInt(0), nil)
+		tracer.CaptureStart(env, contract.Caller(), contract.Address(), false, false, nil, 0, uint256.NewInt(0), nil)
 		tracer.CaptureEnd(nil, startGas-contract.Gas, 1, 0, nil)
 		return tracer.GetResult()
 	}

--- a/eth/tracers/tracer_test.go
+++ b/eth/tracers/tracer_test.go
@@ -158,13 +158,14 @@ func TestHaltBetweenSteps(t *testing.T) {
 	}
 	env := vm.NewEVM(evmtypes.BlockContext{
 		BlockNumber: 1,
-	}, evmtypes.TxContext{}, &dummyStatedb{}, params.TestChainConfig, vm.Config{Debug: true, Tracer: tracer})
+	}, evmtypes.TxContext{GasPrice: &uint256.Int{}}, &dummyStatedb{}, params.TestChainConfig, vm.Config{Debug: true, Tracer: tracer})
 	contract := vm.NewContract(&account{}, &account{}, uint256.NewInt(0), 0, false)
 
-	tracer.CaptureState(env, 0, 0, 0, 0, &vm.ScopeContext{Contract: contract}, nil, 0, nil) //nolint:errcheck
+	tracer.CaptureStart(env, common.Address{}, common.Address{}, false, false, vm.CALLT, nil, 0, &uint256.Int{}, nil)
+	tracer.CaptureState(0, 0, 0, 0, &vm.ScopeContext{Contract: contract}, nil, 0, nil) //nolint:errcheck
 	timeout := errors.New("stahp")
 	tracer.Stop(timeout)
-	tracer.CaptureState(env, 0, 0, 0, 0, &vm.ScopeContext{Contract: contract}, nil, 0, nil) //nolint:errcheck
+	tracer.CaptureState(0, 0, 0, 0, &vm.ScopeContext{Contract: contract}, nil, 0, nil) //nolint:errcheck
 
 	if _, err := tracer.GetResult(); err.Error() != timeout.Error() {
 		t.Errorf("Expected timeout error, got %v", err)

--- a/turbo/transactions/tracing.go
+++ b/turbo/transactions/tracing.go
@@ -258,11 +258,11 @@ func (l *JsonStreamLogger) CaptureTxStart(gasLimit uint64) {}
 func (l *JsonStreamLogger) CaptureTxEnd(restGas uint64) {}
 
 // CaptureStart implements the Tracer interface to initialize the tracing operation.
-func (l *JsonStreamLogger) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (l *JsonStreamLogger) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
 	l.env = env
 }
 
-func (l *JsonStreamLogger) CaptureEnter(from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (l *JsonStreamLogger) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
 }
 
 // CaptureState logs a new structured log message and pushes it out to the environment

--- a/turbo/transactions/tracing.go
+++ b/turbo/transactions/tracing.go
@@ -236,6 +236,7 @@ type JsonStreamLogger struct {
 	logs      []vm.StructLog
 	output    []byte //nolint
 	err       error  //nolint
+	env       *vm.EVM
 }
 
 // NewStructLogger returns a new logger
@@ -258,15 +259,16 @@ func (l *JsonStreamLogger) CaptureTxEnd(restGas uint64) {}
 
 // CaptureStart implements the Tracer interface to initialize the tracing operation.
 func (l *JsonStreamLogger) CaptureStart(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+	l.env = env
 }
 
-func (l *JsonStreamLogger) CaptureEnter(env *vm.EVM, from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
+func (l *JsonStreamLogger) CaptureEnter(from common.Address, to common.Address, precompile bool, create bool, callType vm.CallType, input []byte, gas uint64, value *uint256.Int, code []byte) {
 }
 
 // CaptureState logs a new structured log message and pushes it out to the environment
 //
 // CaptureState also tracks SLOAD/SSTORE ops to track storage change.
-func (l *JsonStreamLogger) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
+func (l *JsonStreamLogger) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
 	contract := scope.Contract
 	memory := scope.Memory
 	stack := scope.Stack
@@ -298,7 +300,7 @@ func (l *JsonStreamLogger) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, ga
 				address = common.Hash(stack.Data[stack.Len()-1].Bytes32())
 				value   uint256.Int
 			)
-			env.IntraBlockState().GetState(contract.Address(), &address, &value)
+			l.env.IntraBlockState().GetState(contract.Address(), &address, &value)
 			l.storage[contract.Address()][address] = value.Bytes32()
 			outputStorage = true
 		}
@@ -392,7 +394,7 @@ func (l *JsonStreamLogger) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, ga
 
 // CaptureFault implements the Tracer interface to trace an execution fault
 // while running an opcode.
-func (l *JsonStreamLogger) CaptureFault(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
+func (l *JsonStreamLogger) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
 }
 
 // CaptureEnd is called after the call finishes to finalize the tracing.


### PR DESCRIPTION
Remove `callType` argument from `CaptureStart`, and change `callType vm.CallType` to `typ vm.OpCode` in `CaptureEnter` and move to the first position (as it is in geth)