### PR TITLE
Fix otterscan tx tracing for delegatecall

### DIFF
--- a/cmd/rpcdaemon/commands/otterscan_trace_transaction.go
+++ b/cmd/rpcdaemon/commands/otterscan_trace_transaction.go
@@ -57,7 +57,9 @@ func (t *TransactionTracer) captureStartOrEnter(typ vm.OpCode, from, to common.A
 	inputCopy := make([]byte, len(input))
 	copy(inputCopy, input)
 	_value := new(big.Int)
-	_value.Set(value.ToBig())
+	if value != nil {
+		_value.Set(value.ToBig())
+	}
 	if typ == vm.CALL {
 		t.Results = append(t.Results, &TraceEntry{"CALL", t.depth, from, to, (*hexutil.Big)(_value), inputCopy})
 		return


### PR DESCRIPTION
This fixes Otterscan tx tracer, which broke on the following refactoring: https://github.com/ledgerwatch/erigon/commit/60cb4e2bbb94d5749c17fad335dced1e14fd8647

It used to receive value == -1 for delegatecall, now it is receiving nil, so we safeguard against it now.