### PR TITLE
core/vm: fill gaps in jump table with opUndefined

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -837,6 +837,10 @@ func opRevert(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 	return ret, nil
 }
 
+func opUndefined(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	return nil, &ErrInvalidOpCode{opcode: OpCode(scope.Contract.Code[*pc])}
+}
+
 func opStop(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	return nil, nil
 }

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -281,10 +281,6 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		// enough stack items available to perform the operation.
 		op = contract.GetOp(_pc)
 		operation := in.jt[op]
-
-		if operation == nil {
-			return nil, &ErrInvalidOpCode{opcode: op}
-		}
 		// Validate stack
 		if sLen := locStack.Len(); sLen < operation.minStack {
 			return nil, &ErrStackUnderflow{stackLen: sLen, required: operation.minStack}

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -258,7 +258,7 @@ func newHomesteadInstructionSet() JumpTable {
 // newFrontierInstructionSet returns the frontier instructions
 // that can be executed during the frontier phase.
 func newFrontierInstructionSet() JumpTable {
-	return JumpTable{
+	tbl := JumpTable{
 		STOP: {
 			execute:     opStop,
 			constantGas: 0,
@@ -1463,4 +1463,13 @@ func newFrontierInstructionSet() JumpTable {
 			writes:     true,
 		},
 	}
+
+	// Fill all unassigned slots with opUndefined.
+	for i, entry := range tbl {
+		if entry == nil {
+			tbl[i] = &operation{execute: opUndefined, maxStack: maxStack(0, 0)}
+		}
+	}
+
+	return tbl
 }


### PR DESCRIPTION
Cherry-pick https://github.com/ethereum/go-ethereum/pull/24031