### PR TITLE
Finalize state after each call in callMany

### DIFF
--- a/cmd/rpcdaemon/commands/eth_callMany.go
+++ b/cmd/rpcdaemon/commands/eth_callMany.go
@@ -217,6 +217,9 @@ func (api *APIImpl) CallMany(ctx context.Context, bundles []Bundle, simulateCont
 		if err != nil {
 			return nil, err
 		}
+
+		_ = st.FinalizeTx(rules, state.NewNoopWriter())
+
 		// If the timer caused an abort, return an appropriate error message
 		if evm.Cancelled() {
 			return nil, fmt.Errorf("execution aborted (timeout = %v)", timeout)
@@ -274,6 +277,9 @@ func (api *APIImpl) CallMany(ctx context.Context, bundles []Bundle, simulateCont
 			if err != nil {
 				return nil, err
 			}
+
+			_ = st.FinalizeTx(rules, state.NewNoopWriter())
+
 			// If the timer caused an abort, return an appropriate error message
 			if evm.Cancelled() {
 				return nil, fmt.Errorf("execution aborted (timeout = %v)", timeout)

--- a/cmd/rpcdaemon/commands/tracing.go
+++ b/cmd/rpcdaemon/commands/tracing.go
@@ -404,6 +404,7 @@ func (api *PrivateDebugAPIImpl) TraceCallMany(ctx context.Context, bundles []Bun
 			stream.WriteNil()
 			return err
 		}
+		_ = st.FinalizeTx(rules, state.NewNoopWriter())
 
 	}
 
@@ -439,6 +440,8 @@ func (api *PrivateDebugAPIImpl) TraceCallMany(ctx context.Context, bundles []Bun
 				stream.WriteNil()
 				return err
 			}
+
+			_ = ibs.FinalizeTx(rules, state.NewNoopWriter())
 
 			if txn_index < len(bundle.Transactions)-1 {
 				stream.WriteMore()


### PR DESCRIPTION
In `debug_traceCallMany` and `eth_callMany` the `IntraBlockState` is not being finalized after each replayed transaction and after each call. This can cause several problems:

- False gas consumption calculation. Specifically in `SSTORE` dynamic gas calculation being affected by "warm" and "cold" storage slots, and by "original" value comparison.
- Ability to call contracts that were `SELFDESTRUCT`ed in the replayed transactions or during previous calls, as the self-destruction has not been finalized.

see https://github.com/ledgerwatch/erigon/issues/6373 as an example.

This pull request adds a call to `FinalizeTx` after each `ApplyMessage` and `TraceTx`