### PR TITLE
Native tracers step 6: Rename Tracer to EVMLogger, reduce args CaptureExit

### DIFF
--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -95,7 +95,7 @@ func Main(ctx *cli.Context) error {
 		err     error
 		baseDir = ""
 	)
-	var getTracer func(txIndex int, txHash common.Hash) (vm.Tracer, error)
+	var getTracer func(txIndex int, txHash common.Hash) (vm.EVMLogger, error)
 
 	// If user specified a basedir, make sure it exists
 	if ctx.IsSet(OutputBasedir.Name) {
@@ -122,7 +122,7 @@ func Main(ctx *cli.Context) error {
 				prevFile.Close()
 			}
 		}()
-		getTracer = func(txIndex int, txHash common.Hash) (vm.Tracer, error) {
+		getTracer = func(txIndex int, txHash common.Hash) (vm.EVMLogger, error) {
 			if prevFile != nil {
 				prevFile.Close()
 			}
@@ -134,7 +134,7 @@ func Main(ctx *cli.Context) error {
 			return vm.NewJSONLogger(logConfig, traceFile), nil
 		}
 	} else {
-		getTracer = func(txIndex int, txHash common.Hash) (tracer vm.Tracer, err error) {
+		getTracer = func(txIndex int, txHash common.Hash) (tracer vm.EVMLogger, err error) {
 			return nil, nil
 		}
 	}

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -126,7 +126,7 @@ func runCmd(ctx *cli.Context) error {
 	}
 
 	var (
-		tracer        vm.Tracer
+		tracer        vm.EVMLogger
 		debugLogger   *vm.StructLogger
 		statedb       *state.IntraBlockState
 		chainConfig   *params.ChainConfig

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -67,7 +67,7 @@ func stateTestCmd(ctx *cli.Context) error {
 		DisableReturnData: ctx.Bool(DisableReturnDataFlag.Name),
 	}
 	var (
-		tracer   vm.Tracer
+		tracer   vm.EVMLogger
 		debugger *vm.StructLogger
 	)
 	switch {
@@ -105,7 +105,7 @@ func stateTestCmd(ctx *cli.Context) error {
 func aggregateResultsFromStateTests(
 	ctx *cli.Context,
 	stateTests map[string]tests.StateTest,
-	tracer vm.Tracer,
+	tracer vm.EVMLogger,
 	debugger *vm.StructLogger,
 ) ([]StatetestResult, error) {
 	// Iterate over all the stateTests, run them and aggregate the results

--- a/cmd/rpcdaemon/commands/gen_traces_test.go
+++ b/cmd/rpcdaemon/commands/gen_traces_test.go
@@ -42,8 +42,6 @@ func TestGeneratedDebugApi(t *testing.T) {
 	if err = json.Unmarshal(buf.Bytes(), &result); err != nil {
 		t.Fatalf("parsing result: %v", err)
 	}
-	// Remove time because it is non-deterministic
-	delete(result.([]interface{})[0].(map[string]interface{})["result"].(map[string]interface{}), "time")
 	expectedJSON := `
 	[
 		{

--- a/cmd/rpcdaemon/commands/otterscan_api.go
+++ b/cmd/rpcdaemon/commands/otterscan_api.go
@@ -106,7 +106,7 @@ func (api *OtterscanAPIImpl) getTransactionByHash(ctx context.Context, tx kv.Tx,
 	return txn, block, blockHash, blockNum, txnIndex, nil
 }
 
-func (api *OtterscanAPIImpl) runTracer(ctx context.Context, tx kv.Tx, hash common.Hash, tracer vm.Tracer) (*core.ExecutionResult, error) {
+func (api *OtterscanAPIImpl) runTracer(ctx context.Context, tx kv.Tx, hash common.Hash, tracer vm.EVMLogger) (*core.ExecutionResult, error) {
 	txn, block, _, _, txIndex, err := api.getTransactionByHash(ctx, tx, hash)
 	if err != nil {
 		return nil, err

--- a/cmd/rpcdaemon/commands/otterscan_default_tracer.go
+++ b/cmd/rpcdaemon/commands/otterscan_default_tracer.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"time"
-
 	"github.com/holiman/uint256"
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/core/vm"
@@ -30,10 +28,10 @@ func (t *DefaultTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, 
 func (t *DefaultTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
 }
 
-func (t *DefaultTracer) CaptureEnd(output []byte, startGas, endGas uint64, d time.Duration, err error) {
+func (t *DefaultTracer) CaptureEnd(output []byte, usedGas uint64, err error) {
 }
 
-func (t *DefaultTracer) CaptureExit(output []byte, startGas, endGas uint64, d time.Duration, err error) {
+func (t *DefaultTracer) CaptureExit(output []byte, usedGas uint64, err error) {
 }
 
 func (t *DefaultTracer) CaptureSelfDestruct(from common.Address, to common.Address, value *uint256.Int) {

--- a/cmd/rpcdaemon/commands/otterscan_generic_tracer.go
+++ b/cmd/rpcdaemon/commands/otterscan_generic_tracer.go
@@ -16,7 +16,7 @@ import (
 )
 
 type GenericTracer interface {
-	vm.Tracer
+	vm.EVMLogger
 	SetTransaction(tx types.Transaction)
 	Found() bool
 }

--- a/cmd/rpcdaemon/commands/otterscan_trace_transaction.go
+++ b/cmd/rpcdaemon/commands/otterscan_trace_transaction.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"context"
 	"math/big"
-	"time"
 
 	"github.com/holiman/uint256"
 	"github.com/ledgerwatch/erigon/common"
@@ -96,7 +95,7 @@ func (t *TransactionTracer) CaptureEnter(typ vm.OpCode, from common.Address, to 
 	t.captureStartOrEnter(typ, from, to, precompile, input, value)
 }
 
-func (t *TransactionTracer) CaptureExit(output []byte, startGas, endGas uint64, d time.Duration, err error) {
+func (t *TransactionTracer) CaptureExit(output []byte, usedGas uint64, err error) {
 	t.depth--
 }
 

--- a/cmd/state/commands/opcode_tracer.go
+++ b/cmd/state/commands/opcode_tracer.go
@@ -233,11 +233,11 @@ func (ot *opcodeTracer) captureEndOrExit(err error) {
 	}
 }
 
-func (ot *opcodeTracer) CaptureEnd(output []byte, startGas, endGas uint64, t time.Duration, err error) {
+func (ot *opcodeTracer) CaptureEnd(output []byte, usedGas uint64, err error) {
 	ot.captureEndOrExit(err)
 }
 
-func (ot *opcodeTracer) CaptureExit(output []byte, startGas, endGas uint64, t time.Duration, err error) {
+func (ot *opcodeTracer) CaptureExit(output []byte, usedGas uint64, err error) {
 	ot.captureEndOrExit(err)
 	ot.depth--
 }

--- a/cmd/state/exec3/calltracer22.go
+++ b/cmd/state/exec3/calltracer22.go
@@ -1,8 +1,6 @@
 package exec3
 
 import (
-	"time"
-
 	"github.com/holiman/uint256"
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/core/vm"
@@ -38,9 +36,9 @@ func (ct *CallTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, sc
 }
 func (ct *CallTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
 }
-func (ct *CallTracer) CaptureEnd(output []byte, startGas, endGas uint64, t time.Duration, err error) {
+func (ct *CallTracer) CaptureEnd(output []byte, usedGas uint64, err error) {
 }
-func (ct *CallTracer) CaptureExit(output []byte, startGas, endGas uint64, t time.Duration, err error) {
+func (ct *CallTracer) CaptureExit(output []byte, usedGas uint64, err error) {
 }
 func (ct *CallTracer) CaptureSelfDestruct(from common.Address, to common.Address, value *uint256.Int) {
 	ct.froms[from] = struct{}{}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -79,7 +79,7 @@ func ExecuteBlockEphemerallyForBSC(
 	stateWriter state.WriterWithChangeSets,
 	epochReader consensus.EpochReader,
 	chainReader consensus.ChainHeaderReader,
-	getTracer func(txIndex int, txHash common.Hash) (vm.Tracer, error),
+	getTracer func(txIndex int, txHash common.Hash) (vm.EVMLogger, error),
 ) (*EphemeralExecResult, error) {
 	defer BlockExecutionTimer.UpdateDuration(time.Now())
 	block.Uncles()
@@ -228,7 +228,7 @@ func ExecuteBlockEphemerally(
 	stateWriter state.WriterWithChangeSets,
 	epochReader consensus.EpochReader,
 	chainReader consensus.ChainHeaderReader,
-	getTracer func(txIndex int, txHash common.Hash) (vm.Tracer, error),
+	getTracer func(txIndex int, txHash common.Hash) (vm.EVMLogger, error),
 ) (*EphemeralExecResult, error) {
 
 	defer BlockExecutionTimer.UpdateDuration(time.Now())
@@ -339,7 +339,7 @@ func ExecuteBlockEphemerallyBor(
 	stateWriter state.WriterWithChangeSets,
 	epochReader consensus.EpochReader,
 	chainReader consensus.ChainHeaderReader,
-	getTracer func(txIndex int, txHash common.Hash) (vm.Tracer, error),
+	getTracer func(txIndex int, txHash common.Hash) (vm.EVMLogger, error),
 ) (*EphemeralExecResult, error) {
 
 	defer BlockExecutionTimer.UpdateDuration(time.Now())

--- a/core/vm/access_list_tracer.go
+++ b/core/vm/access_list_tracer.go
@@ -17,8 +17,6 @@
 package vm
 
 import (
-	"time"
-
 	"github.com/holiman/uint256"
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/core/types"
@@ -105,7 +103,7 @@ func (al accessList) accessList() types.AccessList {
 	return acl
 }
 
-var _ Tracer = (*AccessListTracer)(nil)
+var _ EVMLogger = (*AccessListTracer)(nil)
 
 // AccessListTracer is a tracer that accumulates touched accounts and storage
 // slots into an internal set.
@@ -171,7 +169,7 @@ func (a *AccessListTracer) CaptureState(pc uint64, op OpCode, gas, cost uint64, 
 func (*AccessListTracer) CaptureFault(pc uint64, op OpCode, gas, cost uint64, scope *ScopeContext, depth int, err error) {
 }
 
-func (*AccessListTracer) CaptureEnd(output []byte, startGas, endGas uint64, t time.Duration, err error) {
+func (*AccessListTracer) CaptureEnd(output []byte, usedGas uint64, err error) {
 }
 
 func (a *AccessListTracer) CaptureStart(env *EVM, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte) {
@@ -182,7 +180,7 @@ func (a *AccessListTracer) CaptureEnter(typ OpCode, from common.Address, to comm
 	panic("implement me")
 }
 
-func (*AccessListTracer) CaptureExit(output []byte, startGas, endGas uint64, t time.Duration, err error) {
+func (*AccessListTracer) CaptureExit(output []byte, usedGas uint64, err error) {
 }
 
 func (a *AccessListTracer) CaptureSelfDestruct(from common.Address, to common.Address, value *uint256.Int) {

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -180,12 +180,12 @@ func (evm *EVM) call(typ OpCode, caller ContractRef, addr common.Address, input 
 		if evm.depth == 0 {
 			evm.config.Tracer.CaptureStart(evm, caller.Address(), addr, isPrecompile, false /* create */, input, gas, value, code)
 			defer func(startGas uint64, startTime time.Time) { // Lazy evaluation of the parameters
-				evm.config.Tracer.CaptureEnd(ret, startGas, gas, time.Since(startTime), err)
+				evm.config.Tracer.CaptureEnd(ret, startGas-gas, err)
 			}(gas, time.Now())
 		} else {
 			evm.config.Tracer.CaptureEnter(typ, caller.Address(), addr, isPrecompile, false /* create */, input, gas, value, code)
 			defer func(startGas uint64, startTime time.Time) { // Lazy evaluation of the parameters
-				evm.config.Tracer.CaptureExit(ret, startGas, gas, time.Since(startTime), err)
+				evm.config.Tracer.CaptureExit(ret, startGas-gas, err)
 			}(gas, time.Now())
 		}
 	}
@@ -322,12 +322,12 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 		if evm.depth == 0 {
 			evm.config.Tracer.CaptureStart(evm, caller.Address(), address, false /* precompile */, true /* create */, codeAndHash.code, gas, value, nil)
 			defer func(startGas uint64, startTime time.Time) { // Lazy evaluation of the parameters
-				evm.config.Tracer.CaptureEnd(ret, startGas, gas, time.Since(startTime), err)
+				evm.config.Tracer.CaptureEnd(ret, startGas-gas, err)
 			}(gas, time.Now())
 		} else {
 			evm.config.Tracer.CaptureEnter(typ, caller.Address(), address, false /* precompile */, true /* create */, codeAndHash.code, gas, value, nil)
 			defer func(startGas uint64, startTime time.Time) { // Lazy evaluation of the parameters
-				evm.config.Tracer.CaptureExit(ret, startGas, gas, time.Since(startTime), err)
+				evm.config.Tracer.CaptureExit(ret, startGas-gas, err)
 			}(gas, time.Now())
 		}
 	}

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -30,16 +30,16 @@ import (
 
 // Config are the configuration options for the Interpreter
 type Config struct {
-	Debug         bool   // Enables debugging
-	Tracer        Tracer // Opcode logger
-	NoRecursion   bool   // Disables call, callcode, delegate call and create
-	NoBaseFee     bool   // Forces the EIP-1559 baseFee to 0 (needed for 0 price calls)
-	SkipAnalysis  bool   // Whether we can skip jumpdest analysis based on the checked history
-	TraceJumpDest bool   // Print transaction hashes where jumpdest analysis was useful
-	NoReceipts    bool   // Do not calculate receipts
-	ReadOnly      bool   // Do no perform any block finalisation
-	StatelessExec bool   // true is certain conditions (like state trie root hash matching) need to be relaxed for stateless EVM execution
-	RestoreState  bool   // Revert all changes made to the state (useful for constant system calls)
+	Debug         bool      // Enables debugging
+	Tracer        EVMLogger // Opcode logger
+	NoRecursion   bool      // Disables call, callcode, delegate call and create
+	NoBaseFee     bool      // Forces the EIP-1559 baseFee to 0 (needed for 0 price calls)
+	SkipAnalysis  bool      // Whether we can skip jumpdest analysis based on the checked history
+	TraceJumpDest bool      // Print transaction hashes where jumpdest analysis was useful
+	NoReceipts    bool      // Do not calculate receipts
+	ReadOnly      bool      // Do no perform any block finalisation
+	StatelessExec bool      // true is certain conditions (like state trie root hash matching) need to be relaxed for stateless EVM execution
+	RestoreState  bool      // Revert all changes made to the state (useful for constant system calls)
 
 	ExtraEips []int // Additional EIPS that are to be enabled
 }

--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -25,7 +25,6 @@ import (
 	"math/big"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/holiman/uint256"
 	"github.com/ledgerwatch/erigon/common"
@@ -104,21 +103,21 @@ func (s *StructLog) ErrorString() string {
 	return ""
 }
 
-// Tracer is used to collect execution traces from an EVM transaction
+// EVMLogger is used to collect execution traces from an EVM transaction
 // execution. CaptureState is called for each step of the VM with the
 // current VM state.
 // Note that reference types are actual VM data structures; make copies
 // if you need to retain them beyond the current call.
-type Tracer interface {
+type EVMLogger interface {
 	// Transaction level
 	CaptureTxStart(gasLimit uint64)
 	CaptureTxEnd(restGas uint64)
 	// Top call frame
 	CaptureStart(env *EVM, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte)
-	CaptureEnd(output []byte, startGas, endGas uint64, t time.Duration, err error)
+	CaptureEnd(output []byte, usedGas uint64, err error)
 	// Rest of the frames
 	CaptureEnter(typ OpCode, from common.Address, to common.Address, precompile bool, create bool, input []byte, gas uint64, value *uint256.Int, code []byte)
-	CaptureExit(output []byte, startGas, endGas uint64, t time.Duration, err error)
+	CaptureExit(output []byte, usedGas uint64, err error)
 	// Opcode level
 	CaptureState(pc uint64, op OpCode, gas, cost uint64, scope *ScopeContext, rData []byte, depth int, err error)
 	CaptureFault(pc uint64, op OpCode, gas, cost uint64, scope *ScopeContext, depth int, err error)
@@ -131,7 +130,7 @@ type Tracer interface {
 // FlushableTracer is a Tracer extension whose accumulated traces has to be
 // flushed once the tracing is completed.
 type FlushableTracer interface {
-	Tracer
+	EVMLogger
 	Flush(tx types.Transaction)
 }
 
@@ -258,7 +257,7 @@ func (l *StructLogger) CaptureFault(pc uint64, op OpCode, gas, cost uint64, scop
 }
 
 // CaptureEnd is called after the call finishes to finalize the tracing.
-func (l *StructLogger) CaptureEnd(output []byte, startGas, endGas uint64, t time.Duration, err error) {
+func (l *StructLogger) CaptureEnd(output []byte, usedGas uint64, err error) {
 	l.output = output
 	l.err = err
 	if l.cfg.Debug {
@@ -270,7 +269,7 @@ func (l *StructLogger) CaptureEnd(output []byte, startGas, endGas uint64, t time
 }
 
 // CaptureExit is called after the internal call finishes to finalize the tracing.
-func (l *StructLogger) CaptureExit(output []byte, startGas, endGas uint64, t time.Duration, err error) {
+func (l *StructLogger) CaptureExit(output []byte, usedGas uint64, err error) {
 }
 
 func (l *StructLogger) CaptureSelfDestruct(from common.Address, to common.Address, value *uint256.Int) {
@@ -463,17 +462,17 @@ func (t *mdLogger) CaptureFault(pc uint64, op OpCode, gas, cost uint64, scope *S
 	fmt.Fprintf(t.out, "\nError: at pc=%d, op=%v: %v\n", pc, op, err)
 }
 
-func (t *mdLogger) captureEndOrExit(output []byte, startGas, endGas uint64, err error) {
+func (t *mdLogger) captureEndOrExit(output []byte, usedGas uint64, err error) {
 	fmt.Fprintf(t.out, "\nOutput: `0x%x`\nConsumed gas: `%d`\nError: `%v`\n",
-		output, startGas-endGas, err)
+		output, usedGas, err)
 }
 
-func (t *mdLogger) CaptureEnd(output []byte, startGas, endGas uint64, tm time.Duration, err error) {
-	t.captureEndOrExit(output, startGas, endGas, err)
+func (t *mdLogger) CaptureEnd(output []byte, usedGas uint64, err error) {
+	t.captureEndOrExit(output, usedGas, err)
 }
 
-func (t *mdLogger) CaptureExit(output []byte, startGas, endGas uint64, tm time.Duration, err error) {
-	t.captureEndOrExit(output, startGas, endGas, err)
+func (t *mdLogger) CaptureExit(output []byte, usedGas uint64, err error) {
+	t.captureEndOrExit(output, usedGas, err)
 }
 
 func (t *mdLogger) CaptureSelfDestruct(from common.Address, to common.Address, value *uint256.Int) {

--- a/core/vm/logger_json.go
+++ b/core/vm/logger_json.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"io"
 	"math/big"
-	"time"
 
 	"github.com/holiman/uint256"
 	"github.com/ledgerwatch/erigon/common"
@@ -89,21 +88,20 @@ func (l *JSONLogger) CaptureFault(pc uint64, op OpCode, gas, cost uint64, scope 
 }
 
 // CaptureEnd is triggered at end of execution.
-func (l *JSONLogger) CaptureEnd(output []byte, startGas, endGas uint64, t time.Duration, err error) {
+func (l *JSONLogger) CaptureEnd(output []byte, usedGas uint64, err error) {
 	type endLog struct {
 		Output  string              `json:"output"`
 		GasUsed math.HexOrDecimal64 `json:"gasUsed"`
-		Time    time.Duration       `json:"time"`
 		Err     string              `json:"error,omitempty"`
 	}
 	var errMsg string
 	if err != nil {
 		errMsg = err.Error()
 	}
-	_ = l.encoder.Encode(endLog{common.Bytes2Hex(output), math.HexOrDecimal64(startGas - endGas), t, errMsg})
+	_ = l.encoder.Encode(endLog{common.Bytes2Hex(output), math.HexOrDecimal64(usedGas), errMsg})
 }
 
-func (l *JSONLogger) CaptureExit(output []byte, startGas, endGas uint64, t time.Duration, err error) {
+func (l *JSONLogger) CaptureExit(output []byte, usedGas uint64, err error) {
 }
 
 func (l *JSONLogger) CaptureSelfDestruct(from common.Address, to common.Address, value *uint256.Int) {

--- a/eth/calltracer/calltracer.go
+++ b/eth/calltracer/calltracer.go
@@ -3,7 +3,6 @@ package calltracer
 import (
 	"encoding/binary"
 	"sort"
-	"time"
 
 	"github.com/holiman/uint256"
 	"github.com/ledgerwatch/erigon-lib/common/length"
@@ -53,9 +52,9 @@ func (ct *CallTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, sc
 }
 func (ct *CallTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
 }
-func (ct *CallTracer) CaptureEnd(output []byte, startGas, endGas uint64, t time.Duration, err error) {
+func (ct *CallTracer) CaptureEnd(output []byte, usedGas uint64, err error) {
 }
-func (ct *CallTracer) CaptureExit(output []byte, startGas, endGas uint64, t time.Duration, err error) {
+func (ct *CallTracer) CaptureExit(output []byte, usedGas uint64, err error) {
 }
 func (ct *CallTracer) CaptureSelfDestruct(from common.Address, to common.Address, value *uint256.Int) {
 	ct.froms[from] = struct{}{}

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -151,7 +151,7 @@ func executeBlock(
 		return h
 	}
 
-	getTracer := func(txIndex int, txHash ecom.Hash) (vm.Tracer, error) {
+	getTracer := func(txIndex int, txHash ecom.Hash) (vm.EVMLogger, error) {
 		return vm.NewStructLogger(&vm.LogConfig{}), nil
 	}
 

--- a/eth/tracers/logger/access_list_tracer.go
+++ b/eth/tracers/logger/access_list_tracer.go
@@ -17,8 +17,6 @@
 package logger
 
 import (
-	"time"
-
 	"github.com/holiman/uint256"
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/core/types"
@@ -175,9 +173,9 @@ func (a *AccessListTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint6
 
 func (*AccessListTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
 }
-func (*AccessListTracer) CaptureEnd(output []byte, startGas, endGas uint64, t time.Duration, err error) {
+func (*AccessListTracer) CaptureEnd(output []byte, usedGas uint64, err error) {
 }
-func (*AccessListTracer) CaptureExit(output []byte, startGas, endGas uint64, t time.Duration, err error) {
+func (*AccessListTracer) CaptureExit(output []byte, usedGas uint64, err error) {
 }
 func (*AccessListTracer) CaptureSelfDestruct(from common.Address, to common.Address, value *uint256.Int) {
 }

--- a/eth/tracers/tracer.go
+++ b/eth/tracers/tracer.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"math/big"
 	"sync/atomic"
-	"time"
 	"unsafe"
 
 	"github.com/ledgerwatch/erigon/core"
@@ -663,17 +662,16 @@ func (jst *Tracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, scope
 }
 
 // CaptureEnd is called after the call finishes to finalize the tracing.
-func (jst *Tracer) CaptureEnd(output []byte, startGas, endGas uint64, t time.Duration, err error) {
+func (jst *Tracer) CaptureEnd(output []byte, usedGas uint64, err error) {
 	jst.ctx["output"] = output
-	jst.ctx["time"] = t.String()
-	jst.ctx["gasUsed"] = startGas - endGas
+	jst.ctx["gasUsed"] = usedGas
 
 	if err != nil {
 		jst.ctx["error"] = err.Error()
 	}
 }
 
-func (jst *Tracer) CaptureExit(output []byte, startGas, endGas uint64, t time.Duration, err error) {
+func (jst *Tracer) CaptureExit(output []byte, usedGas uint64, err error) {
 }
 
 func (jst *Tracer) CaptureSelfDestruct(from common.Address, to common.Address, value *uint256.Int) {

--- a/eth/tracers/tracer_test.go
+++ b/eth/tracers/tracer_test.go
@@ -74,7 +74,7 @@ func runTrace(tracer *Tracer, vmctx *vmContext) (json.RawMessage, error) {
 
 	tracer.CaptureStart(env, contract.Caller(), contract.Address(), false, false, []byte{}, startGas, uint256.NewInt(value.Uint64()), contract.Code)
 	ret, err := env.Interpreter().Run(contract, []byte{}, false)
-	tracer.CaptureEnd(ret, startGas, contract.Gas, 1, err)
+	tracer.CaptureEnd(ret, startGas-contract.Gas, err)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +180,7 @@ func TestNoStepExec(t *testing.T) {
 		startGas := uint64(10000)
 		contract := vm.NewContract(account{}, account{}, uint256.NewInt(1), startGas, true)
 		tracer.CaptureStart(env, contract.Caller(), contract.Address(), false, false, nil, 0, uint256.NewInt(0), nil)
-		tracer.CaptureEnd(nil, startGas-contract.Gas, 1, 0, nil)
+		tracer.CaptureEnd(nil, startGas-contract.Gas, nil)
 		return tracer.GetResult()
 	}
 	execTracer := func(code string) []byte {

--- a/turbo/transactions/tracing.go
+++ b/turbo/transactions/tracing.go
@@ -134,7 +134,7 @@ func TraceTx(
 ) error {
 	// Assemble the structured logger or the JavaScript tracer
 	var (
-		tracer vm.Tracer
+		tracer vm.EVMLogger
 		err    error
 	)
 	var streaming bool
@@ -398,10 +398,10 @@ func (l *JsonStreamLogger) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint6
 }
 
 // CaptureEnd is called after the call finishes to finalize the tracing.
-func (l *JsonStreamLogger) CaptureEnd(output []byte, startGas, endGas uint64, t time.Duration, err error) {
+func (l *JsonStreamLogger) CaptureEnd(output []byte, usedGas uint64, err error) {
 }
 
-func (l *JsonStreamLogger) CaptureExit(output []byte, startGas, endGas uint64, t time.Duration, err error) {
+func (l *JsonStreamLogger) CaptureExit(output []byte, usedGas uint64, err error) {
 }
 
 func (l *JsonStreamLogger) CaptureSelfDestruct(from common.Address, to common.Address, value *uint256.Int) {


### PR DESCRIPTION
Getting closer to Geth's tracer interfaces