### PR TITLE
ci(test): add -race -count=10 flag to ci test runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ GO_FLAGS += -ldflags "-X ${PACKAGE}/params.GitCommit=${GIT_COMMIT} -X ${PACKAGE}
 
 GOBUILD = $(CGO_CFLAGS) $(GO) build $(GO_FLAGS)
 GO_DBG_BUILD = $(GO) build $(GO_FLAGS) -tags $(BUILD_TAGS),debug -gcflags=all="-N -l"  # see delve docs
-GOTEST = $(CGO_CFLAGS) GODEBUG=cgocheck=0 $(GO) test $(GO_FLAGS) ./... -p 2
+GOTEST = $(CGO_CFLAGS) GODEBUG=cgocheck=0 $(GO) test $(GO_FLAGS) ./... -p 2 -race -count=10
 
 default: all
 
@@ -136,10 +136,10 @@ db-tools:
 
 ## test:                              run unit tests with a 50s timeout
 test:
-	$(GOTEST) --timeout 50s
+	$(GOTEST) --timeout 90s
 
 test3:
-	$(GOTEST) --timeout 50s -tags $(BUILD_TAGS),erigon3
+	$(GOTEST) --timeout 90s -tags $(BUILD_TAGS),erigon3
 
 ## test-integration:                  run integration tests with a 30m timeout
 test-integration:


### PR DESCRIPTION
- [x] - race flag added 
- [ ] - existing race conditions fixed
- [ ] - if some individual test failing - try optimize it's speed, if not possible - move it to integration suite by `//go:build integration`
- [ ] - add race flag to `make test3`
- [ ] - add race flag to `make test-integration`
- [ ] - existing race conditions fixed
- [ ] - couple optimizations for integration tests speed
- [ ] - add race flag to `make test3-integration`

NB: DO NOT MERGE until both points above are checked.