### PR TITLE
add /.git to the dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,8 @@
 **/*.o
 **/*.dSYM
 
+/.git
+
 build
 tests/testdata
 cmd/prometheus


### PR DESCRIPTION
When I `git pull`, `docker build` builds a new image even if nothing changed. Ignoring the `.git` directory will make it only build a new image if something in the erigon code has changed.