### PR TITLE
HashBuilder: fix top node shorter than 32 bytes

### DIFF
--- a/core/types/withdrawal_test.go
+++ b/core/types/withdrawal_test.go
@@ -1,0 +1,22 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ledgerwatch/erigon/common"
+	"github.com/ledgerwatch/erigon/common/u256"
+)
+
+func TestWithdrawalsHash(t *testing.T) {
+	w := &Withdrawal{
+		Index:     0,
+		Validator: 0,
+		Address:   common.HexToAddress("0x6295ee1b4f6dd65047762f924ecd367c17eabf8f"),
+		Amount:    *u256.Num1,
+	}
+	withdrawals := Withdrawals([]*Withdrawal{w})
+	hash := DeriveSha(withdrawals)
+	assert.Equal(t, common.HexToHash("82cc6fbe74c41496b382fcdf25216c5af7bdbb5a3929e8f2e61bd6445ab66436"), hash)
+}

--- a/core/types/withdrawal_test.go
+++ b/core/types/withdrawal_test.go
@@ -18,5 +18,7 @@ func TestWithdrawalsHash(t *testing.T) {
 	}
 	withdrawals := Withdrawals([]*Withdrawal{w})
 	hash := DeriveSha(withdrawals)
+	// The only trie node is short (its RLP < 32 bytes).
+	// Its Keccak should be returned, not the node itself.
 	assert.Equal(t, common.HexToHash("82cc6fbe74c41496b382fcdf25216c5af7bdbb5a3929e8f2e61bd6445ab66436"), hash)
 }

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/ledgerwatch/erigon-lib/kv/memdb"
 	"github.com/ledgerwatch/erigon/core/vm"
+	"github.com/ledgerwatch/erigon/eth/tracers/logger"
 	"github.com/ledgerwatch/log/v3"
 )
 
@@ -86,7 +87,7 @@ func withTrace(t *testing.T, test func(vm.Config) error) {
 	t.Error(err)
 	buf := new(bytes.Buffer)
 	w := bufio.NewWriter(buf)
-	tracer := vm.NewJSONLogger(&vm.LogConfig{DisableMemory: true}, w)
+	tracer := logger.NewJSONLogger(&logger.LogConfig{DisableMemory: true}, w)
 	config.Debug, config.Tracer = true, tracer
 	err2 := test(config)
 	if !reflect.DeepEqual(err, err2) {

--- a/turbo/trie/gen_struct_step.go
+++ b/turbo/trie/gen_struct_step.go
@@ -284,7 +284,7 @@ func GenStructStep(
 			send := maxLen == 0 && (hasTree[maxLen] != 0 || hasHash[maxLen] != 0) // account.root - store only if have useful info
 			send = send || (maxLen == 1 && groups[maxLen] != 0)                   // first level of trie_account - store in any case
 			if send {
-				if err := h(curr[:maxLen], groups[maxLen], hasTree[maxLen], hasHash[maxLen], usefulHashes, e.topHash()); err != nil {
+				if err := h(curr[:maxLen], groups[maxLen], hasTree[maxLen], hasHash[maxLen], usefulHashes, e.topHash()[1:]); err != nil {
 					return nil, nil, nil, err
 				}
 			}
@@ -412,7 +412,7 @@ func GenStructStepOld(
 				}
 			}
 			if h != nil {
-				if err := h(curr[:maxLen], e.topHash()); err != nil {
+				if err := h(curr[:maxLen], e.topHash()[1:]); err != nil {
 					return nil, err
 				}
 			}


### PR DESCRIPTION
Prior to withdrawals, it was extremely unlikely to have short (RLP < 32) top trie nodes outside test scenarios.