### PR TITLE
remove extra byte from access list tx size computation

### DIFF
--- a/core/types/access_list_tx.go
+++ b/core/types/access_list_tx.go
@@ -103,7 +103,6 @@ func (tx *AccessListTx) Size() common.StorageSize {
 		return size.(common.StorageSize)
 	}
 	c := tx.EncodingSize()
-	c++ // TxType
 	tx.size.Store(common.StorageSize(c))
 	return common.StorageSize(c)
 }


### PR DESCRIPTION
For all other tx types, Size() == EncodingSize(), so I assume this is unintentional. Plus, AccessListTx.EncodingSize() already accounts for the encoding of type byte.
