### PR TITLE
(*PrefetchedBlocks) Pop -> Get

### DIFF
--- a/turbo/stages/bodydownload/body_algos.go
+++ b/turbo/stages/bodydownload/body_algos.go
@@ -210,7 +210,7 @@ func (bd *BodyDownload) RequestMoreBodies(tx kv.RwTx, blockReader services.FullB
 
 // checks if we have the block prefetched, returns true if found and stored or false if not present
 func (bd *BodyDownload) checkPrefetchedBlock(hash common.Hash, tx kv.RwTx, blockNum uint64, blockPropagator adapter.BlockPropagator) bool {
-	header, body := bd.prefetchedBlocks.Pop(hash)
+	header, body := bd.prefetchedBlocks.Get(hash)
 
 	if body == nil {
 		return false

--- a/turbo/stages/bodydownload/prefetched_blocks.go
+++ b/turbo/stages/bodydownload/prefetched_blocks.go
@@ -21,9 +21,8 @@ func NewPrefetchedBlocks() *PrefetchedBlocks {
 	return &PrefetchedBlocks{blocks: cache}
 }
 
-func (pb *PrefetchedBlocks) Pop(hash common.Hash) (*types.Header, *types.RawBody) {
+func (pb *PrefetchedBlocks) Get(hash common.Hash) (*types.Header, *types.RawBody) {
 	if val, ok := pb.blocks.Get(hash); ok && val != nil {
-		//pb.blocks.Remove(hash)
 		if headerAndBody, ok := val.(types.HeaderAndBody); ok {
 			return headerAndBody.Header, headerAndBody.Body
 		}


### PR DESCRIPTION
After PR #6515 `(*PrefetchedBlocks) Pop` doesn't remove the block from the LRU cache anymore, so `Get` is a better name.