### PR TITLE
Partial EIP1186 eth_getProof implementation

### DIFF
--- a/cmd/rpcdaemon/commands/eth_api.go
+++ b/cmd/rpcdaemon/commands/eth_api.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ledgerwatch/erigon/consensus/misc"
 	"github.com/ledgerwatch/erigon/core/rawdb"
 	"github.com/ledgerwatch/erigon/core/types"
+	"github.com/ledgerwatch/erigon/core/types/accounts"
 	ethFilters "github.com/ledgerwatch/erigon/eth/filters"
 	"github.com/ledgerwatch/erigon/params"
 	"github.com/ledgerwatch/erigon/rpc"
@@ -86,7 +87,7 @@ type EthAPI interface {
 	SendTransaction(_ context.Context, txObject interface{}) (common.Hash, error)
 	Sign(ctx context.Context, _ common.Address, _ hexutil.Bytes) (hexutil.Bytes, error)
 	SignTransaction(_ context.Context, txObject interface{}) (common.Hash, error)
-	GetProof(ctx context.Context, address common.Address, storageKeys []string, blockNr rpc.BlockNumber) (*interface{}, error)
+	GetProof(ctx context.Context, address common.Address, storageKeys []string, blockNr rpc.BlockNumberOrHash) (*accounts.AccProofResult, error)
 	CreateAccessList(ctx context.Context, args ethapi2.CallArgs, blockNrOrHash *rpc.BlockNumberOrHash, optimizeGas *bool) (*accessListResult, error)
 
 	// Mining related (see ./eth_mining.go)

--- a/cmd/rpcdaemon/commands/eth_call.go
+++ b/cmd/rpcdaemon/commands/eth_call.go
@@ -339,6 +339,7 @@ func (api *APIImpl) GetProof(ctx context.Context, address common.Address, storag
 		}
 
 		var accProof accounts.AccProofResult
+		loader.SetProofReturn(&accProof)
 
 		_, err = loader.CalcTrieRoot(tx, nil, nil)
 		if err != nil {

--- a/cmd/rpcdaemon/commands/eth_call.go
+++ b/cmd/rpcdaemon/commands/eth_call.go
@@ -339,6 +339,7 @@ func (api *APIImpl) GetProof(ctx context.Context, address common.Address, storag
 		}
 
 		var accProof accounts.AccProofResult
+		accProof.Address = address
 		loader.SetProofReturn(&accProof)
 
 		_, err = loader.CalcTrieRoot(tx, nil, nil)

--- a/core/types/accounts/account_proof.go
+++ b/core/types/accounts/account_proof.go
@@ -1,0 +1,22 @@
+package accounts
+
+import (
+	"github.com/ledgerwatch/erigon/common"
+	"github.com/ledgerwatch/erigon/common/hexutil"
+)
+
+// Result structs for GetProof
+type AccProofResult struct {
+	Address      common.Address    `json:"address"`
+	AccountProof []string          `json:"accountProof"`
+	Balance      *hexutil.Big      `json:"balance"`
+	CodeHash     common.Hash       `json:"codeHash"`
+	Nonce        hexutil.Uint64    `json:"nonce"`
+	StorageHash  common.Hash       `json:"storageHash"`
+	StorageProof []StorProofResult `json:"storageProof"`
+}
+type StorProofResult struct {
+	Key   string       `json:"key"`
+	Value *hexutil.Big `json:"value"`
+	Proof []string     `json:"proof"`
+}

--- a/turbo/trie/gen_struct_step.go
+++ b/turbo/trie/gen_struct_step.go
@@ -99,7 +99,10 @@ func (GenStructStepHashData) GenStructStepData() {}
 // Whenever a `BRANCH` or `BRANCHHASH` opcode is emitted, the set of digits is taken from the corresponding `groups` item, which is
 // then removed from the slice. This signifies the usage of the number of the stack items by the `BRANCH` or `BRANCHHASH` opcode.
 // DESCRIBED: docs/programmers_guide/guide.md#separation-of-keys-and-the-structure
-func GenStructStep(
+
+// GenStructStepEx is extended to support optional generation of an Account Proof during trie_root.go CalcTrieRoot().
+// The wrapper below calls it with nil/false defaults so that other callers do not need to be modified.
+func GenStructStepEx(
 	retain func(prefix []byte) bool,
 	curr, succ []byte,
 	e structInfoReceiver,
@@ -109,6 +112,8 @@ func GenStructStep(
 	hasTree []uint16,
 	hasHash []uint16,
 	trace bool,
+	wantProof func(prefix []byte) bool,
+	cutoff bool,
 ) ([]uint16, []uint16, []uint16, error) {
 	for precLen, buildExtensions := calcPrecLen(groups), false; precLen >= 0; precLen, buildExtensions = calcPrecLen(groups), true {
 		var precExists = len(groups) > 0
@@ -304,6 +309,19 @@ func GenStructStep(
 		}
 	}
 	return nil, nil, nil, nil
+}
+func GenStructStep(
+	retain func(prefix []byte) bool,
+	curr, succ []byte,
+	e structInfoReceiver,
+	h HashCollector2,
+	data GenStructStepData,
+	groups []uint16,
+	hasTree []uint16,
+	hasHash []uint16,
+	trace bool,
+) ([]uint16, []uint16, []uint16, error) {
+	return GenStructStepEx(retain, curr, succ, e, h, data, groups, hasTree, hasHash, trace, nil, false)
 }
 
 func GenStructStepOld(

--- a/turbo/trie/hashbuilder.go
+++ b/turbo/trie/hashbuilder.go
@@ -39,6 +39,9 @@ type HashBuilder struct {
 	trace     bool // Set to true when HashBuilder is required to print trace information for diagnostics
 
 	topHashesCopy []byte
+
+	// If an Account proof was requested in trie_root.go, nodes will be written here.
+	accProofResult *accounts.AccProofResult
 }
 
 // NewHashBuilder creates a new HashBuilder
@@ -59,6 +62,12 @@ func (hb *HashBuilder) Reset() {
 		hb.nodeStack = hb.nodeStack[:0]
 	}
 	hb.topHashesCopy = hb.topHashesCopy[:0]
+	hb.accProofResult = nil
+}
+
+func (hb *HashBuilder) SetProofReturn(accProofResult *accounts.AccProofResult) {
+	accProofResult.AccountProof = make([]string,0)
+	hb.accProofResult = accProofResult
 }
 
 func (hb *HashBuilder) leaf(length int, keyHex []byte, val rlphacks.RlpSerializable) error {

--- a/turbo/trie/trie_root.go
+++ b/turbo/trie/trie_root.go
@@ -362,6 +362,7 @@ func (r *RootHashAggregator) Reset(hc HashCollector2, shc StorageHashCollector2,
 	r.root = common.Hash{}
 	r.trace = trace
 	r.hb.trace = trace
+	r.proofMatch = nil
 }
 
 func (r *RootHashAggregator) Receive(itemType StreamItem,

--- a/turbo/trie/trie_root.go
+++ b/turbo/trie/trie_root.go
@@ -92,6 +92,9 @@ type FlatDBTrieLoader struct {
 	defaultReceiver *RootHashAggregator
 	hc              HashCollector2
 	shc             StorageHashCollector2
+
+	// Optionally construct an Account Proof for an account key specified in 'rd'
+	accProofResult *accounts.AccProofResult
 }
 
 // RootHashAggregator - calculates Merkle trie root hash from incoming data stream
@@ -124,6 +127,10 @@ type RootHashAggregator struct {
 	a              accounts.Account
 	leafData       GenStructStepLeafData
 	accData        GenStructStepAccountData
+
+	// Used to construct an Account proof while calculating the tree root.
+	proofMatch RetainDecider
+	cutoff     bool
 }
 
 type StreamReceiver interface {
@@ -168,7 +175,14 @@ func (l *FlatDBTrieLoader) Reset(rd RetainDeciderWithMarker, hc HashCollector2, 
 		fmt.Printf("----------\n")
 		fmt.Printf("CalcTrieRoot\n")
 	}
+	l.accProofResult = nil
 	return nil
+}
+
+func (l *FlatDBTrieLoader) SetProofReturn(accProofResult *accounts.AccProofResult) {
+	l.accProofResult = accProofResult
+	l.defaultReceiver.proofMatch = l.rd
+	l.defaultReceiver.hb.SetProofReturn(accProofResult)
 }
 
 func (l *FlatDBTrieLoader) SetStreamReceiver(receiver StreamReceiver) {


### PR DESCRIPTION
This is a partial implementation of eth_getProof (see issue #1349), supporting only a request for the latest block and an empty list of storage keys (i.e. Account proof only). I don't know if there's a better way of implementing this, but this was what I could come up with. Posting it here in case it's useful.

Example output:
```
> eth.getProof("0x67b1d87101671b127f5f8714789C7192f7ad340e", [], 'latest')
{
  accountProof: ["0xf90131a0252c9d4ed347b4cf3fdccaea3ccef0a507e6bd4dbe4dcd98609b7195347c4062a0ab8cdb808c8303bb61fb48e276217be9770fa83ecf3f90f2234d558885f5abf18080a01a697e814758281972fcd13bc9707dbcd2f195986b05463d7b78426508445a04a0b5d7a91be5ee273cce27e2ad9a160d2faadd5a6ba518d384019b68728a4f62f4a0c2c799b60a0cd6acd42c1015512872e86c186bcf196e85061e76842f3b7cf86080a0e73919d9f472eec11f6da95518503f5527a98b9428f7a02c4f55bf51854214e480a06301b39b2ea8a44df8b0356120db64b788e71f52e1d7a6309d0d2e5b86fee7cb8080a01b7779e149cadf24d4ffb77ca7e11314b8db7097e4d70b2a173493153ca2e5a0a066a7662811491b3d352e969506b420d269e8b51a224f574b3b38b3463f43f0098080", "0xf8518080808080a0a00135c9ec2655cb6a47ab7ad27d6fc150d9cba8b3d4a702e879179116a68a60808080808080a02fb46956347985b9870156b5747712899d213b1636ad4fe553c63e33521d567a80808080", "0xf873a02056274a27dd7524955417c11ecd917251cc7c4c8310f4c7e4bd3c304d3d9a79b850f84e808a021e19e0c9bab2400000a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"],
  address: "0x67b1d87101671b127f5f8714789c7192f7ad340e",
  balance: "0x21e19e0c9bab2400000",
  codeHash: "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
  nonce: "0x0",
  storageHash: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
  storageProof: []
}
> eth.getBlock('latest').stateRoot
"0x6a0673c691edfa4c4528323986bb43c579316f436ff6f8b4ac70854bbd95340b"
```
