### PR TITLE
Switch validateAndStorePayload to Body.RawBody()

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -1638,8 +1638,7 @@ func (b *Block) RawBody() *RawBody {
 	return br
 }
 
-// RawBody creates a RawBody based on the body. It is not very efficient, so
-// will probably be removed in favour of RawBlock. Also it panics
+// RawBody creates a RawBody based on the body.
 func (b *Body) RawBody() *RawBody {
 	br := &RawBody{Transactions: make([][]byte, len(b.Transactions)), Uncles: b.Uncles, Withdrawals: b.Withdrawals}
 	for i, tx := range b.Transactions {

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -1624,11 +1624,23 @@ func (b *Block) SendersToTxs(senders []common.Address) {
 	}
 }
 
-// RawBody creates a RawBody based on the block. It is not very efficient, so
-// will probably be removed in favour of RawBlock. Also it panics
+// RawBody creates a RawBody based on the block.
 func (b *Block) RawBody() *RawBody {
 	br := &RawBody{Transactions: make([][]byte, len(b.transactions)), Uncles: b.uncles, Withdrawals: b.withdrawals}
 	for i, tx := range b.transactions {
+		var err error
+		br.Transactions[i], err = rlp.EncodeToBytes(tx)
+		if err != nil {
+			panic(err)
+		}
+	}
+	return br
+}
+
+// RawBody creates a RawBody based on the body.
+func (b *Body) RawBody() *RawBody {
+	br := &RawBody{Transactions: make([][]byte, len(b.Transactions)), Uncles: b.Uncles, Withdrawals: b.Withdrawals}
+	for i, tx := range b.Transactions {
 		var err error
 		br.Transactions[i], err = rlp.EncodeToBytes(tx)
 		if err != nil {

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -724,7 +724,7 @@ type BodyForStorage struct {
 }
 
 // Alternative representation of the Block.
-type HeaderAndBody struct {
+type RawBlock struct {
 	Header *Header
 	Body   *RawBody
 }
@@ -1624,7 +1624,8 @@ func (b *Block) SendersToTxs(senders []common.Address) {
 	}
 }
 
-// RawBody creates a RawBody based on the block.
+// RawBody creates a RawBody based on the block. It is not very efficient, so
+// will probably be removed in favour of RawBlock. Also it panics
 func (b *Block) RawBody() *RawBody {
 	br := &RawBody{Transactions: make([][]byte, len(b.transactions)), Uncles: b.uncles, Withdrawals: b.withdrawals}
 	for i, tx := range b.transactions {
@@ -1637,7 +1638,8 @@ func (b *Block) RawBody() *RawBody {
 	return br
 }
 
-// RawBody creates a RawBody based on the body.
+// RawBody creates a RawBody based on the body. It is not very efficient, so
+// will probably be removed in favour of RawBlock. Also it panics
 func (b *Body) RawBody() *RawBody {
 	br := &RawBody{Transactions: make([][]byte, len(b.Transactions)), Uncles: b.Uncles, Withdrawals: b.Withdrawals}
 	for i, tx := range b.Transactions {

--- a/turbo/stages/bodydownload/prefetched_blocks.go
+++ b/turbo/stages/bodydownload/prefetched_blocks.go
@@ -23,8 +23,8 @@ func NewPrefetchedBlocks() *PrefetchedBlocks {
 
 func (pb *PrefetchedBlocks) Get(hash common.Hash) (*types.Header, *types.RawBody) {
 	if val, ok := pb.blocks.Get(hash); ok && val != nil {
-		if headerAndBody, ok := val.(types.HeaderAndBody); ok {
-			return headerAndBody.Header, headerAndBody.Body
+		if block, ok := val.(types.RawBlock); ok {
+			return block.Header, block.Body
 		}
 	}
 	return nil, nil
@@ -35,5 +35,5 @@ func (pb *PrefetchedBlocks) Add(h *types.Header, b *types.RawBody) {
 		return
 	}
 	hash := h.Hash()
-	pb.blocks.ContainsOrAdd(hash, types.HeaderAndBody{Header: h, Body: b})
+	pb.blocks.ContainsOrAdd(hash, types.RawBlock{Header: h, Body: b})
 }


### PR DESCRIPTION
Ensure that withdrawals are not lost in `validateAndStorePayload`.