### PR TITLE
block BaseFee in callMany

### DIFF
--- a/cmd/rpcdaemon/commands/eth_callMany.go
+++ b/cmd/rpcdaemon/commands/eth_callMany.go
@@ -206,7 +206,7 @@ func (api *APIImpl) CallMany(ctx context.Context, bundles []Bundle, simulateCont
 	// and apply the message.
 	gp := new(core.GasPool).AddGas(math.MaxUint64)
 	for _, txn := range replayTransactions {
-		msg, err := txn.AsMessage(*signer, nil, rules)
+		msg, err := txn.AsMessage(*signer, block.BaseFee(), rules)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/rpcdaemon/commands/tracing.go
+++ b/cmd/rpcdaemon/commands/tracing.go
@@ -391,7 +391,7 @@ func (api *PrivateDebugAPIImpl) TraceCallMany(ctx context.Context, bundles []Bun
 	// and apply the message.
 	gp := new(core.GasPool).AddGas(math.MaxUint64)
 	for _, txn := range replayTransactions {
-		msg, err := txn.AsMessage(*signer, nil, rules)
+		msg, err := txn.AsMessage(*signer, block.BaseFee(), rules)
 		if err != nil {
 			stream.WriteNil()
 			return err


### PR DESCRIPTION
Continuing the work of https://github.com/ledgerwatch/erigon/pull/6381 . We encountered a problem in blocks with type 2 transactions, specifically blocks with two transactions with the same `tx.from`. When the first tx is replayed, a high `gasPrice` is being calculate in `txn.AsMessage` causing the second replayed tx to fail with the following error:
```
insufficient funds for gas * price + value: address ...
```
This happens in both `eth_callMany` and `debug_traceCallMany`.
This pull request follows the `debug_traceTransaction` usage of `tx.AsMessage` in `ComputeTxEnv`