### PR TITLE
Fix erigon_blockNumber

### DIFF
--- a/cmd/rpcdaemon/commands/erigon_system.go
+++ b/cmd/rpcdaemon/commands/erigon_system.go
@@ -47,6 +47,8 @@ func (api *ErigonImpl) BlockNumber(ctx context.Context, rpcBlockNumPtr *rpc.Bloc
 	var rpcBlockNum rpc.BlockNumber
 	if rpcBlockNumPtr == nil {
 		rpcBlockNum = rpc.LatestExecutedBlockNumber
+	} else {
+		rpcBlockNum = *rpcBlockNumPtr
 	}
 
 	var blockNum uint64


### PR DESCRIPTION
erigon_blockNumber  returns "latest executed block number" or any block number requested. 
In this last case the rpcBlockNum variable was not initialized