### PR TITLE
prepare state in replay blocks in callMany

### DIFF
--- a/cmd/rpcdaemon/commands/eth_callMany.go
+++ b/cmd/rpcdaemon/commands/eth_callMany.go
@@ -206,7 +206,8 @@ func (api *APIImpl) CallMany(ctx context.Context, bundles []Bundle, simulateCont
 	// Setup the gas pool (also for unmetered requests)
 	// and apply the message.
 	gp := new(core.GasPool).AddGas(math.MaxUint64)
-	for _, txn := range replayTransactions {
+	for idx, txn := range replayTransactions {
+		st.Prepare(txn.Hash(), block.Hash(), idx)
 		msg, err := txn.AsMessage(*signer, block.BaseFee(), rules)
 		if err != nil {
 			return nil, err

--- a/cmd/rpcdaemon/commands/tracing.go
+++ b/cmd/rpcdaemon/commands/tracing.go
@@ -391,7 +391,8 @@ func (api *PrivateDebugAPIImpl) TraceCallMany(ctx context.Context, bundles []Bun
 	// Setup the gas pool (also for unmetered requests)
 	// and apply the message.
 	gp := new(core.GasPool).AddGas(math.MaxUint64)
-	for _, txn := range replayTransactions {
+	for idx, txn := range replayTransactions {
+		st.Prepare(txn.Hash(), block.Hash(), idx)
 		msg, err := txn.AsMessage(*signer, block.BaseFee(), rules)
 		if err != nil {
 			stream.WriteNil()


### PR DESCRIPTION
Some transactions in replayed blocks do not get reverted, although they were originally reverted due to out of gas. This causes false balance calculations for some addresses