### PR TITLE
Allow NewPayloadV2 for pre-Shanghai blocks

### DIFF
--- a/ethdb/privateapi/ethbackend.go
+++ b/ethdb/privateapi/ethbackend.go
@@ -663,17 +663,12 @@ func (s *EthBackendServer) engineForkChoiceUpdated(ctx context.Context, reqForkc
 	// payload IDs start from 1 (0 signifies null)
 	s.payloadId++
 
-	var withdrawals []*types.Withdrawal
-	if reqWithdrawals != nil {
-		withdrawals = ConvertWithdrawalsFromRpc(reqWithdrawals)
-	}
-
 	param := core.BlockBuilderParameters{
 		ParentHash:            forkChoice.HeadBlockHash,
 		Timestamp:             payloadAttributes.Timestamp,
 		PrevRandao:            gointerfaces.ConvertH256ToHash(payloadAttributes.PrevRandao),
 		SuggestedFeeRecipient: gointerfaces.ConvertH160toAddress(payloadAttributes.SuggestedFeeRecipient),
-		Withdrawals:           withdrawals,
+		Withdrawals:           ConvertWithdrawalsFromRpc(reqWithdrawals),
 		PayloadId:             s.payloadId,
 	}
 
@@ -718,6 +713,9 @@ func (s *EthBackendServer) SubscribeLogs(server remote.ETHBACKEND_SubscribeLogsS
 }
 
 func ConvertWithdrawalsFromRpc(in []*types2.Withdrawal) []*types.Withdrawal {
+	if in == nil {
+		return nil
+	}
 	out := make([]*types.Withdrawal, 0, len(in))
 	for _, w := range in {
 		out = append(out, &types.Withdrawal{
@@ -731,6 +729,9 @@ func ConvertWithdrawalsFromRpc(in []*types2.Withdrawal) []*types.Withdrawal {
 }
 
 func ConvertWithdrawalsToRpc(in []*types.Withdrawal) []*types2.Withdrawal {
+	if in == nil {
+		return nil
+	}
 	out := make([]*types2.Withdrawal, 0, len(in))
 	for _, w := range in {
 		out = append(out, &types2.Withdrawal{


### PR DESCRIPTION
This is a fix for [withdrawal-devnet-3](https://forkmon.withdrawal-devnet-3.ethpandaops.io/). The problem was that CL calls `NewPayloadV2` for pre-Shanghai blocks with `nil` withdrawals, which is OK, but that `nil` was erroneously converted into an empty array, causing block hash mismatch.