### PR TITLE
engine payload bodies rpc endpoints

### DIFF
--- a/cmd/rpcdaemon/rpcservices/eth_backend.go
+++ b/cmd/rpcdaemon/rpcservices/eth_backend.go
@@ -212,6 +212,14 @@ func (back *RemoteBackend) EngineGetPayload(ctx context.Context, payloadId uint6
 	})
 }
 
+func (back *RemoteBackend) EngineGetPayloadBodiesByHashV1(ctx context.Context, request *remote.EngineGetPayloadBodiesByHashV1Request) (*remote.EngineGetPayloadBodiesV1Response, error) {
+	return back.remoteEthBackend.EngineGetPayloadBodiesByHashV1(ctx, request)
+}
+
+func (back *RemoteBackend) EngineGetPayloadBodiesByRangeV1(ctx context.Context, request *remote.EngineGetPayloadBodiesByRangeV1Request) (*remote.EngineGetPayloadBodiesV1Response, error) {
+	return back.remoteEthBackend.EngineGetPayloadBodiesByRangeV1(ctx, request)
+}
+
 func (back *RemoteBackend) NodeInfo(ctx context.Context, limit uint32) ([]p2p.NodeInfo, error) {
 	nodes, err := back.remoteEthBackend.NodeInfo(ctx, &remote.NodesInfoRequest{Limit: limit})
 	if err != nil {

--- a/turbo/rpchelper/interface.go
+++ b/turbo/rpchelper/interface.go
@@ -31,4 +31,6 @@ type ApiBackend interface {
 	NodeInfo(ctx context.Context, limit uint32) ([]p2p.NodeInfo, error)
 	Peers(ctx context.Context) ([]*p2p.PeerInfo, error)
 	PendingBlock(ctx context.Context) (*types.Block, error)
+	EngineGetPayloadBodiesByHashV1(ctx context.Context, request *remote.EngineGetPayloadBodiesByHashV1Request) (*remote.EngineGetPayloadBodiesV1Response, error)
+	EngineGetPayloadBodiesByRangeV1(ctx context.Context, request *remote.EngineGetPayloadBodiesByRangeV1Request) (*remote.EngineGetPayloadBodiesV1Response, error)
 }


### PR DESCRIPTION
Very basic implementation for get payload bodies rpc calls.  Once we have Hive tests for these calls I can pick this back up and work through any issues.

Implementation of https://github.com/ethereum/execution-apis/pull/352.