### PR TITLE
Fix retrieving Bor transactions from the pool

### DIFF
--- a/cmd/rpcdaemon/commands/eth_txs.go
+++ b/cmd/rpcdaemon/commands/eth_txs.go
@@ -41,12 +41,13 @@ func (api *APIImpl) GetTransactionByHash(ctx context.Context, txnHash libcommon.
 		if err != nil {
 			return nil, err
 		}
-		if blockNumPtr == nil {
-			return nil, nil
+
+		ok = blockNumPtr != nil
+		if ok {
+			blockNum = *blockNumPtr
 		}
-		blockNum = *blockNumPtr
 	}
-	if ok || (chainConfig.Bor != nil && blockNum != 0) {
+	if ok {
 		block, err := api.blockByNumberWithSenders(tx, blockNum)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
At the moment erigon does not try to look for bor transactions inside the pool