### PR TITLE
feat(trace): use specific error string

### DIFF
--- a/cmd/rpcdaemon/commands/gen_traces_test.go
+++ b/cmd/rpcdaemon/commands/gen_traces_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 
 	jsoniter "github.com/json-iterator/go"
+	"github.com/stretchr/testify/assert"
+
+	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/kv/kvcache"
 	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/cli/httpcfg"
 	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/rpcdaemontest"
@@ -14,7 +17,6 @@ import (
 	"github.com/ledgerwatch/erigon/rpc"
 	"github.com/ledgerwatch/erigon/rpc/rpccfg"
 	"github.com/ledgerwatch/erigon/turbo/snapshotsync"
-	"github.com/stretchr/testify/assert"
 
 	// Force-load native and js packages, to trigger registration
 	_ "github.com/ledgerwatch/erigon/eth/tracers/js"
@@ -263,6 +265,78 @@ func TestGeneratedTraceApi(t *testing.T) {
 		  "type": "reward"
 		}
 	  ]`
+	var expected interface{}
+	if err = json.Unmarshal([]byte(expectedJSON), &expected); err != nil {
+		t.Fatalf("parsing expected: %v", err)
+	}
+	if !assert.Equal(t, expected, result) {
+		t.Fatalf("not equal")
+	}
+}
+
+func TestGeneratedTraceApiCollision(t *testing.T) {
+	m := rpcdaemontest.CreateTestSentryForTracesCollision(t)
+	agg := m.HistoryV3Components()
+	br := snapshotsync.NewBlockReaderWithSnapshots(m.BlockSnapshots)
+	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
+	baseApi := NewBaseApi(nil, stateCache, br, agg, false, rpccfg.DefaultEvmCallTimeout, m.Engine)
+	api := NewTraceAPI(baseApi, m.DB, &httpcfg.HttpCfg{})
+	traces, err := api.Transaction(context.Background(), libcommon.HexToHash("0xb2b9fa4c999c1c8370ce1fbd1c4315a9ce7f8421fe2ebed8a9051ff2e4e7e3da"))
+	if err != nil {
+		t.Errorf("trace_block %d: %v", 0, err)
+	}
+	buf, err := json.Marshal(traces)
+	if err != nil {
+		t.Errorf("marshall result into JSON: %v", err)
+	}
+	var result interface{}
+	if err = json.Unmarshal(buf, &result); err != nil {
+		t.Fatalf("parsing result: %v", err)
+	}
+	expectedJSON := `
+[
+    {
+        "action": {
+            "from": "0x71562b71999873db5b286df957af199ec94617f7",
+            "callType": "call",
+            "gas": "0x13498",
+            "input": "0x",
+            "to": "0x000000000000000000000000000000000000bbbb",
+            "value": "0x0"
+        },
+        "blockHash": "0xc78e9674685b04e1300d62cafdae0708d030a9bc0ff7aa9eb9315da23de650dc",
+        "blockNumber": 1,
+        "result": {
+            "gasUsed": "0x131bb",
+            "output": "0x"
+        },
+        "subtraces": 1,
+        "traceAddress": [],
+        "transactionHash": "0xb2b9fa4c999c1c8370ce1fbd1c4315a9ce7f8421fe2ebed8a9051ff2e4e7e3da",
+        "transactionPosition": 2,
+        "type": "call"
+    },
+    {
+        "action": {
+            "from": "0x000000000000000000000000000000000000bbbb",
+            "gas": "0xb49d",
+            "init": "0x600360035560046004556158ff6000526002601ef3",
+            "value": "0x0"
+        },
+        "blockHash": "0xc78e9674685b04e1300d62cafdae0708d030a9bc0ff7aa9eb9315da23de650dc",
+        "blockNumber": 1,
+        "error": "contract address collision",
+        "result": null,
+        "subtraces": 0,
+        "traceAddress": [
+            0
+        ],
+        "transactionHash": "0xb2b9fa4c999c1c8370ce1fbd1c4315a9ce7f8421fe2ebed8a9051ff2e4e7e3da",
+        "transactionPosition": 2,
+        "type": "create"
+    }
+]	
+`
 	var expected interface{}
 	if err = json.Unmarshal([]byte(expectedJSON), &expected); err != nil {
 		t.Fatalf("parsing expected: %v", err)

--- a/cmd/rpcdaemon/commands/trace_adhoc.go
+++ b/cmd/rpcdaemon/commands/trace_adhoc.go
@@ -396,23 +396,7 @@ func (ot *OeTracer) captureEndOrExit(deep bool, output []byte, usedGas uint64, e
 			}
 		} else {
 			topTrace.Result = nil
-			switch err {
-			case vm.ErrInvalidJump:
-				topTrace.Error = "Bad jump destination"
-			case vm.ErrContractAddressCollision, vm.ErrCodeStoreOutOfGas, vm.ErrOutOfGas, vm.ErrGasUintOverflow:
-				topTrace.Error = "Out of gas"
-			case vm.ErrWriteProtection:
-				topTrace.Error = "Mutable Call In Static Context"
-			default:
-				switch err.(type) {
-				case *vm.ErrStackUnderflow:
-					topTrace.Error = "Stack underflow"
-				case *vm.ErrInvalidOpCode:
-					topTrace.Error = "Bad instruction"
-				default:
-					topTrace.Error = err.Error()
-				}
-			}
+			topTrace.Error = err.Error()
 		}
 	} else {
 		if len(output) > 0 {

--- a/cmd/rpcdaemon/rpcdaemontest/test_util.go
+++ b/cmd/rpcdaemon/rpcdaemontest/test_util.go
@@ -10,15 +10,15 @@ import (
 	"testing"
 
 	"github.com/holiman/uint256"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+
 	"github.com/ledgerwatch/erigon-lib/chain"
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/gointerfaces/remote"
 	"github.com/ledgerwatch/erigon-lib/gointerfaces/txpool"
 	"github.com/ledgerwatch/erigon-lib/kv"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/test/bufconn"
-
 	"github.com/ledgerwatch/erigon/accounts/abi/bind"
 	"github.com/ledgerwatch/erigon/accounts/abi/bind/backends"
 	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/commands/contracts"
@@ -431,5 +431,114 @@ func CreateTestSentryForTraces(t *testing.T) *stages.MockSentry {
 	if err := m.InsertChain(chain); err != nil {
 		t.Fatalf("failed to insert into chain: %v", err)
 	}
+	return m
+}
+
+func CreateTestSentryForTracesCollision(t *testing.T) *stages.MockSentry {
+	var (
+		// Generate a canonical chain to act as the main dataset
+		// A sender who makes transactions, has some funds
+		key, _    = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		address   = crypto.PubkeyToAddress(key.PublicKey)
+		funds     = big.NewInt(1000000000)
+		bb        = libcommon.HexToAddress("0x000000000000000000000000000000000000bbbb")
+		aaStorage = make(map[libcommon.Hash]libcommon.Hash)    // Initial storage in AA
+		aaCode    = []byte{byte(vm.PC), byte(vm.SELFDESTRUCT)} // Code for AA (simple selfdestruct)
+	)
+	// Populate two slots
+	aaStorage[libcommon.HexToHash("01")] = libcommon.HexToHash("01")
+	aaStorage[libcommon.HexToHash("02")] = libcommon.HexToHash("02")
+
+	// The bb-code needs to CREATE2 the aa contract. It consists of
+	// both initcode and deployment code
+	// initcode:
+	// 1. Set slots 3=3, 4=4,
+	// 2. Return aaCode
+
+	initCode := []byte{
+		byte(vm.PUSH1), 0x3, // value
+		byte(vm.PUSH1), 0x3, // location
+		byte(vm.SSTORE),     // Set slot[3] = 3
+		byte(vm.PUSH1), 0x4, // value
+		byte(vm.PUSH1), 0x4, // location
+		byte(vm.SSTORE), // Set slot[4] = 4
+		// Slots are set, now return the code
+		byte(vm.PUSH2), byte(vm.PC), byte(vm.SELFDESTRUCT), // Push code on stack
+		byte(vm.PUSH1), 0x0, // memory start on stack
+		byte(vm.MSTORE),
+		// Code is now in memory.
+		byte(vm.PUSH1), 0x2, // size
+		byte(vm.PUSH1), byte(32 - 2), // offset
+		byte(vm.RETURN),
+	}
+	if l := len(initCode); l > 32 {
+		t.Fatalf("init code is too long for a pushx, need a more elaborate deployer")
+	}
+	bbCode := []byte{
+		// Push initcode onto stack
+		byte(vm.PUSH1) + byte(len(initCode)-1)}
+	bbCode = append(bbCode, initCode...)
+	bbCode = append(bbCode, []byte{
+		byte(vm.PUSH1), 0x0, // memory start on stack
+		byte(vm.MSTORE),
+		byte(vm.PUSH1), 0x00, // salt
+		byte(vm.PUSH1), byte(len(initCode)), // size
+		byte(vm.PUSH1), byte(32 - len(initCode)), // offset
+		byte(vm.PUSH1), 0x00, // endowment
+		byte(vm.CREATE2),
+	}...)
+
+	initHash := crypto.Keccak256Hash(initCode)
+	aa := crypto.CreateAddress2(bb, [32]byte{}, initHash[:])
+	t.Logf("Destination address: %x\n", aa)
+
+	gspec := &core.Genesis{
+		Config: params.TestChainConfig,
+		Alloc: core.GenesisAlloc{
+			address: {Balance: funds},
+			// The address 0xAAAAA selfdestructs if called
+			aa: {
+				// Code needs to just selfdestruct
+				Code:    aaCode,
+				Nonce:   1,
+				Balance: big.NewInt(0),
+				Storage: aaStorage,
+			},
+			// The contract BB recreates AA
+			bb: {
+				Code:    bbCode,
+				Balance: big.NewInt(1),
+			},
+			bb: {
+				Code:    bbCode,
+				Balance: big.NewInt(1),
+			},
+		},
+	}
+	m := stages.MockWithGenesis(t, gspec, key, false)
+	chain, err := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 1, func(i int, b *core.BlockGen) {
+		b.SetCoinbase(libcommon.Address{1})
+		// One transaction to AA, to kill it
+		tx, _ := types.SignTx(types.NewTransaction(0, aa,
+			u256.Num0, 50000, u256.Num1, nil), *types.LatestSignerForChainID(nil), key)
+		b.AddTx(tx)
+		// One transaction to BB, to recreate AA
+		tx, _ = types.SignTx(types.NewTransaction(1, bb,
+			u256.Num0, 100000, u256.Num1, nil), *types.LatestSignerForChainID(nil), key)
+		b.AddTx(tx)
+		tx, _ = types.SignTx(types.NewTransaction(2, bb,
+			u256.Num0, 100000, u256.Num1, nil), *types.LatestSignerForChainID(nil), key)
+		b.AddTx(tx)
+	}, false /* intermediateHashes */)
+	if err != nil {
+		t.Fatalf("generate blocks: %v", err)
+	}
+	// Import the canonical chain
+	if err := m.InsertChain(chain); err != nil {
+		t.Fatalf("failed to insert into chain: %v", err)
+	}
+
+	fmt.Println(chain.Blocks[0].Transactions()[2].Hash().Hex())
+
 	return m
 }

--- a/eth/tracers/internal/tracetest/prestate_test.go
+++ b/eth/tracers/internal/tracetest/prestate_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/holiman/uint256"
+
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/kv/memdb"
 

--- a/eth/tracers/internal/tracetest/testdata/prestate_tracer/create_existing_contract.json
+++ b/eth/tracers/internal/tracetest/testdata/prestate_tracer/create_existing_contract.json
@@ -65,7 +65,7 @@
   "result": {
     "0x082d4cdf07f386ffa9258f52a5c49db4ac321ec6": {
       "balance": "0xc820f93200f4000",
-      "nonce": 94
+      "nonce": 93
     },
     "0x332b656504f4eabb44c8617a42af37461a34e9dc": {
       "balance": "0x11faea4f35e5af80000",

--- a/eth/tracers/internal/tracetest/testdata/prestate_tracer_with_diff_mode/create.json
+++ b/eth/tracers/internal/tracetest/testdata/prestate_tracer_with_diff_mode/create.json
@@ -63,7 +63,7 @@
       },
       "0xf0c5cef39b17c213cfe090a46b8c7760ffb7928a": {
         "balance": "0x15b6828e22bb12188",
-        "nonce": 747
+        "nonce": 746
       }
     },
     "post": {

--- a/eth/tracers/internal/tracetest/testdata/prestate_tracer_with_diff_mode/create_suicide.json
+++ b/eth/tracers/internal/tracetest/testdata/prestate_tracer_with_diff_mode/create_suicide.json
@@ -71,7 +71,7 @@
     "pre": {
       "0x082d4cdf07f386ffa9258f52a5c49db4ac321ec6": {
         "balance": "0xc820f93200f4000",
-        "nonce": 94
+        "nonce": 93
       },
       "0x332b656504f4eabb44c8617a42af37461a34e9dc": {
         "balance": "0x11faea4f35e5af80000",


### PR DESCRIPTION
In v2.36.0 we correctly trace this transaction, however due to a code ordering issue in previous releases, there was an 'out of gas' response, because we fell through to the code here where ErrContractAddressCollision will be returned as such. This change isn't the fix, but ensures the actual error is returned.