### PR TITLE
Don't panic on some AuRa transactions in the past

### DIFF
--- a/consensus/aura/aura.go
+++ b/consensus/aura/aura.go
@@ -1251,10 +1251,15 @@ func (c *AuRa) IsServiceTransaction(sender libcommon.Address, syscall consensus.
 	}
 	res, err := certifierAbi().Unpack("certified", out)
 	if err != nil {
-		panic(err)
+		return false
 	}
-	certified := res[0].(bool)
-	return certified
+	if len(res) == 0 {
+		return false
+	}
+	if certified, ok := res[0].(bool); ok {
+		return certified
+	}
+	return false
 }
 
 // Close implements consensus.Engine. It's a noop for clique as there are no background threads.

--- a/consensus/aura/aura.go
+++ b/consensus/aura/aura.go
@@ -1251,6 +1251,7 @@ func (c *AuRa) IsServiceTransaction(sender libcommon.Address, syscall consensus.
 	}
 	res, err := certifierAbi().Unpack("certified", out)
 	if err != nil {
+		log.Warn("error while detecting service tx on AuRa", "err", err)
 		return false
 	}
 	if len(res) == 0 {


### PR DESCRIPTION
Example request that crashed the RPC method handler on Gnosis Chain mainnet.
```
{
    "id": "1",
    "jsonrpc": "2.0",
    "method": "debug_traceBlockByNumber",
    "params": [
        "0x8a1f76",
        {
            "tracer": "callTracer"
        }
    ]
}
```