### PR TITLE
feat: add deposit contract blocks for Gnosis

### DIFF
--- a/ethdb/prune/storage_mode.go
+++ b/ethdb/prune/storage_mode.go
@@ -27,6 +27,8 @@ var (
 	mainnetDepositContractBlock uint64 = 11052984
 	sepoliaDepositContractBlock uint64 = 1273020
 	goerliDepositContractBlock  uint64 = 4367322
+	gnosisDepositContractBlock  uint64 = 19475089
+	chiadoDepositContractBlock  uint64 = 155530
 )
 
 type Experiments struct {
@@ -109,6 +111,10 @@ func pruneBlockDefault(chainId uint64) uint64 {
 		return sepoliaDepositContractBlock
 	case 5 /* goerli */ :
 		return goerliDepositContractBlock
+	case 10200 /* chiado */ :
+		return chiadoDepositContractBlock
+	case 100 /* gnosis */ :
+		return gnosisDepositContractBlock
 	}
 
 	return 0


### PR DESCRIPTION
From what I understand, this should be sufficient to add `--prune=r` support for Gnosis and Chiado.