### PR TITLE
Workaround for BSC nodes not propagating new block hashes and blocks

### DIFF
--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ledgerwatch/erigon-lib/kv/temporal/historyv2"
 	"github.com/ledgerwatch/erigon-lib/recsplit"
 	"github.com/ledgerwatch/erigon-lib/recsplit/eliasfano32"
+	librlp "github.com/ledgerwatch/erigon-lib/rlp"
 	"golang.org/x/exp/slices"
 
 	"github.com/ledgerwatch/erigon/turbo/debug"
@@ -1345,6 +1346,33 @@ func dumpState(chaindata string) error {
 	return nil
 }
 
+type NewPooledTransactionHashesPacket68 struct {
+	Types  []byte
+	Sizes  []uint32
+	Hashes []libcommon.Hash
+}
+
+func rlptest() error {
+	var p = NewPooledTransactionHashesPacket68{
+		Types:  []byte{44, 200},
+		Sizes:  []uint32{56, 57680},
+		Hashes: []libcommon.Hash{{}, {}},
+	}
+	b, err := rlp.EncodeToBytes(&p)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%x\n", b)
+	var hashes []byte
+	for _, h := range p.Hashes {
+		hashes = append(hashes, h[:]...)
+	}
+	b = make([]byte, librlp.AnnouncementsLen(p.Types, p.Sizes, hashes))
+	l := librlp.EncodeAnnouncements(p.Types, p.Sizes, hashes, b)
+	fmt.Printf("%x\n%d %d\n", b, len(b), l)
+	return nil
+}
+
 func main() {
 	debug.RaiseFdLimit()
 	flag.Parse()
@@ -1476,6 +1504,8 @@ func main() {
 		err = readSeg(*chaindata)
 	case "dumpState":
 		err = dumpState(*chaindata)
+	case "rlptest":
+		err = rlptest()
 	}
 
 	if err != nil {

--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -1323,5 +1323,5 @@ func initConsensusEngine(cc *chain2.Config, datadir string, db kv.RwDB) (engine 
 	} else {
 		consensusConfig = &config.Ethash
 	}
-	return ethconsensusconfig.CreateConsensusEngine(cc, l, consensusConfig, config.Miner.Notify, config.Miner.Noverify, config.HeimdallgRPCAddress, config.HeimdallURL, config.WithoutHeimdall, datadir, snapshots, db.ReadOnly(), db)
+	return ethconsensusconfig.CreateConsensusEngine(cc, l, consensusConfig, config.Miner.Notify, config.Miner.Noverify, HeimdallgRPCAddress, HeimdallURL, config.WithoutHeimdall, datadir, snapshots, db.ReadOnly(), db)
 }

--- a/cmd/sentry/sentry/sentry_api.go
+++ b/cmd/sentry/sentry/sentry_api.go
@@ -104,19 +104,13 @@ func (cs *MultiClient) SendHeaderRequest(ctx context.Context, req *headerdownloa
 		}
 		minBlock := req.Number
 
-		var maxPeers uint64
-		if cs.sendHeaderRequestsToMultiplePeers {
-			maxPeers = 5
-		} else {
-			maxPeers = 1
-		}
 		outreq := proto_sentry.SendMessageByMinBlockRequest{
 			MinBlock: minBlock,
 			Data: &proto_sentry.OutboundMessageData{
 				Id:   proto_sentry.MessageId_GET_BLOCK_HEADERS_66,
 				Data: bytes,
 			},
-			MaxPeers: maxPeers,
+			MaxPeers: 5,
 		}
 		sentPeers, err1 := cs.sentries[i].SendMessageByMinBlock(ctx, &outreq, &grpc.EmptyCallOption{})
 		if err1 != nil {

--- a/cmd/sentry/sentry/sentry_grpc_server.go
+++ b/cmd/sentry/sentry/sentry_grpc_server.go
@@ -454,7 +454,7 @@ func runPeer(
 			if _, err := io.ReadFull(msg.Payload, b); err != nil {
 				log.Error(fmt.Sprintf("%s: reading msg into bytes: %v", peerID, err))
 			}
-			log.Debug("NewBlockHashesMsg from", "peerId", fmt.Sprintf("%x", peerID)[:20], "name", peerInfo.peer.Name())
+			//log.Debug("NewBlockHashesMsg from", "peerId", fmt.Sprintf("%x", peerID)[:20], "name", peerInfo.peer.Name())
 			send(eth.ToProto[protocol][msg.Code], peerID, b)
 		case eth.NewBlockMsg:
 			if !hasSubscribers(eth.ToProto[protocol][msg.Code]) {
@@ -464,7 +464,7 @@ func runPeer(
 			if _, err := io.ReadFull(msg.Payload, b); err != nil {
 				log.Error(fmt.Sprintf("%s: reading msg into bytes: %v", peerID, err))
 			}
-			log.Debug("NewBlockMsg from", "peerId", fmt.Sprintf("%x", peerID)[:20], "name", peerInfo.peer.Name())
+			//log.Debug("NewBlockMsg from", "peerId", fmt.Sprintf("%x", peerID)[:20], "name", peerInfo.peer.Name())
 			send(eth.ToProto[protocol][msg.Code], peerID, b)
 		case eth.NewPooledTransactionHashesMsg:
 			if !hasSubscribers(eth.ToProto[protocol][msg.Code]) {

--- a/cmd/sentry/sentry/sentry_grpc_server.go
+++ b/cmd/sentry/sentry/sentry_grpc_server.go
@@ -454,6 +454,7 @@ func runPeer(
 			if _, err := io.ReadFull(msg.Payload, b); err != nil {
 				log.Error(fmt.Sprintf("%s: reading msg into bytes: %v", peerID, err))
 			}
+			log.Debug("NewBlockHashesMsg from", "peerId", fmt.Sprintf("%x", peerID)[:20], "name", peerInfo.peer.Name())
 			send(eth.ToProto[protocol][msg.Code], peerID, b)
 		case eth.NewBlockMsg:
 			if !hasSubscribers(eth.ToProto[protocol][msg.Code]) {
@@ -463,6 +464,7 @@ func runPeer(
 			if _, err := io.ReadFull(msg.Payload, b); err != nil {
 				log.Error(fmt.Sprintf("%s: reading msg into bytes: %v", peerID, err))
 			}
+			log.Debug("NewBlockMsg from", "peerId", fmt.Sprintf("%x", peerID)[:20], "name", peerInfo.peer.Name())
 			send(eth.ToProto[protocol][msg.Code], peerID, b)
 		case eth.NewPooledTransactionHashesMsg:
 			if !hasSubscribers(eth.ToProto[protocol][msg.Code]) {

--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -1173,7 +1173,7 @@ func (c *Bor) CommitStates(
 	to := time.Unix(int64(chain.Chain.GetHeaderByNumber(number-c.config.CalculateSprint(number)).Time), 0)
 	lastStateID := _lastStateID.Uint64()
 
-	log.Info(
+	log.Debug(
 		"Fetching state updates from Heimdall",
 		"fromID", lastStateID+1,
 		"to", to.Format(time.RFC3339))

--- a/consensus/bor/heimdall/client.go
+++ b/consensus/bor/heimdall/client.go
@@ -80,7 +80,7 @@ func (h *HeimdallClient) StateSyncEvents(ctx context.Context, fromID uint64, to 
 			return nil, err
 		}
 
-		log.Info("Fetching state sync events", "queryParams", url.RawQuery)
+		log.Debug("Fetching state sync events", "queryParams", url.RawQuery)
 
 		ctx = withRequestType(ctx, stateSyncRequest)
 

--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -481,14 +481,17 @@ func (hd *HeaderDownload) RequestSkeleton() *HeaderRequest {
 	hd.lock.RLock()
 	defer hd.lock.RUnlock()
 	log.Debug("[Downloader] Request skeleton", "anchors", len(hd.anchors), "highestInDb", hd.highestInDb)
-	stride := uint64(192)
+	var stride uint64
+	if hd.initialCycle {
+		stride = 192
+	}
 	var length uint64 = 192
 	// Include one header that we have already, to make sure the responses are not empty and do not get penalised when we are at the tip of the chain
 	from := hd.highestInDb
 	if from == 0 {
 		from = 1
 	}
-	return &HeaderRequest{Number: from, Length: length, Skip: stride - 1, Reverse: false}
+	return &HeaderRequest{Number: from, Length: length, Skip: stride, Reverse: false}
 }
 
 func (hd *HeaderDownload) VerifyHeader(header *types.Header) error {

--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -488,8 +488,10 @@ func (hd *HeaderDownload) RequestSkeleton() *HeaderRequest {
 	var length uint64 = 192
 	// Include one header that we have already, to make sure the responses are not empty and do not get penalised when we are at the tip of the chain
 	from := hd.highestInDb
-	if from == 0 {
+	if from <= 1 {
 		from = 1
+	} else {
+		from--
 	}
 	return &HeaderRequest{Number: from, Length: length, Skip: stride, Reverse: false}
 }


### PR DESCRIPTION
It turns out that "standard" BSC nodes based on Geth, do not propagate new block hashes and blocks, at least towards Erigon nodes. This is a workaround