### PR TITLE
Fix getBlockTransactionCount returning null

### DIFF
--- a/cmd/rpcdaemon/commands/debug_api_test.go
+++ b/cmd/rpcdaemon/commands/debug_api_test.go
@@ -393,7 +393,7 @@ func TestGetModifiedAccountsByNumber(t *testing.T) {
 		require.Equal(t, 3, len(result))
 	})
 	t.Run("invalid input", func(t *testing.T) {
-		n, n2 := rpc.BlockNumber(0), rpc.BlockNumber(10)
+		n, n2 := rpc.BlockNumber(0), rpc.BlockNumber(11)
 		_, err := api.GetModifiedAccountsByNumber(m.Ctx, n, &n2)
 		require.Error(t, err)
 
@@ -473,14 +473,14 @@ func TestAccountAt(t *testing.T) {
 	base := NewBaseApi(nil, stateCache, br, agg, false, rpccfg.DefaultEvmCallTimeout, m.Engine)
 	api := NewPrivateDebugAPI(base, m.DB, 0)
 
-	var blockHash0, blockHash1, blockHash3, blockHash10, blockHash11 common.Hash
+	var blockHash0, blockHash1, blockHash3, blockHash10, blockHash12 common.Hash
 	_ = m.DB.View(m.Ctx, func(tx kv.Tx) error {
 		blockHash0, _ = rawdb.ReadCanonicalHash(tx, 0)
 		blockHash1, _ = rawdb.ReadCanonicalHash(tx, 1)
 		blockHash3, _ = rawdb.ReadCanonicalHash(tx, 3)
 		blockHash10, _ = rawdb.ReadCanonicalHash(tx, 10)
-		blockHash11, _ = rawdb.ReadCanonicalHash(tx, 11)
-		_, _, _, _, _ = blockHash0, blockHash1, blockHash3, blockHash10, blockHash11
+		blockHash12, _ = rawdb.ReadCanonicalHash(tx, 12)
+		_, _, _, _, _ = blockHash0, blockHash1, blockHash3, blockHash10, blockHash12
 		return nil
 	})
 
@@ -500,8 +500,8 @@ func TestAccountAt(t *testing.T) {
 		require.NoError(err)
 		require.Equal(1, int(results.Nonce))
 
-		//only 10 blocks in chain
-		results, err = api.AccountAt(m.Ctx, blockHash11, 0, addr)
+		//only 11 blocks in chain
+		results, err = api.AccountAt(m.Ctx, blockHash12, 0, addr)
 		require.NoError(err)
 		require.Nil(results)
 	})

--- a/cmd/rpcdaemon/commands/erigon_receipts_test.go
+++ b/cmd/rpcdaemon/commands/erigon_receipts_test.go
@@ -40,39 +40,24 @@ func TestGetLogs(t *testing.T) {
 		assert.NoError(err)
 		assert.Equal(uint64(10), logs[0].BlockNumber)
 
-		//filer by wrong address
+		// filter by wrong address
 		logs, err = ethApi.GetLogs(context.Background(), filters.FilterCriteria{
+			FromBlock: big.NewInt(10),
+			ToBlock:   big.NewInt(10),
 			Addresses: common.Addresses{libcommon.Address{}},
 		})
 		assert.NoError(err)
 		assert.Equal(0, len(logs))
 
-		//filer by wrong address
+		// filter by wrong address
 		logs, err = ethApi.GetLogs(m.Ctx, filters.FilterCriteria{
-			Topics: [][]libcommon.Hash{{libcommon.HexToHash("0x68f6a0f063c25c6678c443b9a484086f15ba8f91f60218695d32a5251f2050eb")}},
+			FromBlock: big.NewInt(10),
+			ToBlock:   big.NewInt(10),
+			Topics:    [][]libcommon.Hash{{libcommon.HexToHash("0x68f6a0f063c25c6678c443b9a484086f15ba8f91f60218695d32a5251f2050eb")}},
 		})
 		assert.NoError(err)
 		assert.Equal(1, len(logs))
 	}
-	//
-	//api := NewErigonAPI(baseApi, m.DB, nil)
-	//logs, err := api.GetLogs(m.Ctx, filters.FilterCriteria{FromBlock: big.NewInt(0), ToBlock: big.NewInt(10)})
-	//assert.NoError(err)s
-	//assert.Equal(uint64(10), logs[0].BlockNumber)
-	//
-	////filer by wrong address
-	//logs, err = api.GetLogs(m.Ctx, filters.FilterCriteria{
-	//	Addresses: common.Addresses{common.Address{}},
-	//})
-	//assert.NoError(err)
-	//assert.Equal(0, len(logs))
-	//
-	////filer by wrong address
-	//logs, err = api.GetLogs(m.Ctx, filters.FilterCriteria{
-	//	Topics: [][]common.Hash{{common.HexToHash("0x68f6a0f063c25c6678c443b9a484086f15ba8f91f60218695d32a5251f2050eb")}},
-	//})
-	//assert.NoError(err)
-	//assert.Equal(1, len(logs))
 }
 
 func TestErigonGetLatestLogs(t *testing.T) {

--- a/cmd/rpcdaemon/commands/eth_block.go
+++ b/cmd/rpcdaemon/commands/eth_block.go
@@ -314,6 +314,7 @@ func (api *APIImpl) GetBlockTransactionCountByNumber(ctx context.Context, blockN
 		return nil, err
 	}
 	defer tx.Rollback()
+
 	if blockNr == rpc.PendingBlockNumber {
 		b, err := api.blockByRPCNumber(blockNr, tx)
 		if err != nil {
@@ -325,19 +326,24 @@ func (api *APIImpl) GetBlockTransactionCountByNumber(ctx context.Context, blockN
 		n := hexutil.Uint(len(b.Transactions()))
 		return &n, nil
 	}
+
 	blockNum, blockHash, _, err := rpchelper.GetBlockNumber(rpc.BlockNumberOrHashWithNumber(blockNr), tx, api.filters)
 	if err != nil {
 		return nil, err
 	}
+	latestBlockNumber, err := rpchelper.GetLatestBlockNumber(tx)
+	if err != nil {
+		return nil, err
+	}
+	if blockNum > latestBlockNumber {
+		// (Compatibility) Every other node just returns `null` for when the block does not exist.
+		return nil, nil
+	}
+
 	_, txAmount, err := api._blockReader.Body(ctx, tx, blockHash, blockNum)
 	if err != nil {
 		return nil, err
 	}
-
-	if txAmount == 0 {
-		return nil, nil
-	}
-
 	numOfTx := hexutil.Uint(txAmount)
 
 	return &numOfTx, nil
@@ -350,21 +356,18 @@ func (api *APIImpl) GetBlockTransactionCountByHash(ctx context.Context, blockHas
 		return nil, err
 	}
 	defer tx.Rollback()
+
 	blockNum, _, _, err := rpchelper.GetBlockNumber(rpc.BlockNumberOrHash{BlockHash: &blockHash}, tx, nil)
 	if err != nil {
 		// (Compatibility) Every other node just return `null` for when the block does not exist.
 		log.Debug("eth_getBlockTransactionCountByHash GetBlockNumber failed", "err", err)
 		return nil, nil
 	}
+
 	_, txAmount, err := api._blockReader.Body(ctx, tx, blockHash, blockNum)
 	if err != nil {
 		return nil, err
 	}
-
-	if txAmount == 0 {
-		return nil, nil
-	}
-
 	numOfTx := hexutil.Uint(txAmount)
 
 	return &numOfTx, nil

--- a/cmd/rpcdaemon/commands/eth_block_test.go
+++ b/cmd/rpcdaemon/commands/eth_block_test.go
@@ -30,7 +30,7 @@ func TestGetBlockByNumberWithLatestTag(t *testing.T) {
 	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
 	api := NewEthAPI(NewBaseApi(nil, stateCache, br, agg, false, rpccfg.DefaultEvmCallTimeout, m.Engine), m.DB, nil, nil, nil, 5000000, 100_000)
 	b, err := api.GetBlockByNumber(context.Background(), rpc.LatestBlockNumber, false)
-	expected := common.HexToHash("0x6804117de2f3e6ee32953e78ced1db7b20214e0d8c745a03b8fecf7cc8ee76ef")
+	expected := common.HexToHash("0x5883164d4100b95e1d8e931b8b9574586a1dea7507941e6ad3c1e3a2591485fd")
 	if err != nil {
 		t.Errorf("error getting block number with latest tag: %s", err)
 	}
@@ -227,6 +227,42 @@ func TestGetBlockTransactionCountByHash(t *testing.T) {
 	assert.Equal(t, expectedAmount, *txAmount)
 }
 
+func TestGetBlockTransactionCountByHash_ZeroTx(t *testing.T) {
+	m, _, _ := rpcdaemontest.CreateTestSentry(t)
+	agg := m.HistoryV3Components()
+	br := snapshotsync.NewBlockReaderWithSnapshots(m.BlockSnapshots)
+	ctx := context.Background()
+	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
+
+	api := NewEthAPI(NewBaseApi(nil, stateCache, br, agg, false, rpccfg.DefaultEvmCallTimeout, m.Engine), m.DB, nil, nil, nil, 5000000, 100_000)
+	blockHash := common.HexToHash("0x5883164d4100b95e1d8e931b8b9574586a1dea7507941e6ad3c1e3a2591485fd")
+
+	tx, err := m.DB.BeginRw(ctx)
+	if err != nil {
+		t.Errorf("could not begin read write transaction: %s", err)
+	}
+	header, err := rawdb.ReadHeaderByHash(tx, blockHash)
+	if err != nil {
+		tx.Rollback()
+		t.Errorf("failed reading block by hash: %s", err)
+	}
+	bodyWithTx, err := rawdb.ReadBodyWithTransactions(tx, blockHash, header.Number.Uint64())
+	if err != nil {
+		tx.Rollback()
+		t.Errorf("failed getting body with transactions: %s", err)
+	}
+	tx.Rollback()
+
+	expectedAmount := hexutil.Uint(len(bodyWithTx.Transactions))
+
+	txAmount, err := api.GetBlockTransactionCountByHash(ctx, blockHash)
+	if err != nil {
+		t.Errorf("failed getting the transaction count, err=%s", err)
+	}
+
+	assert.Equal(t, expectedAmount, *txAmount)
+}
+
 func TestGetBlockTransactionCountByNumber(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestSentry(t)
 	agg := m.HistoryV3Components()
@@ -235,6 +271,42 @@ func TestGetBlockTransactionCountByNumber(t *testing.T) {
 	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
 	api := NewEthAPI(NewBaseApi(nil, stateCache, br, agg, false, rpccfg.DefaultEvmCallTimeout, m.Engine), m.DB, nil, nil, nil, 5000000, 100_000)
 	blockHash := common.HexToHash("0x6804117de2f3e6ee32953e78ced1db7b20214e0d8c745a03b8fecf7cc8ee76ef")
+
+	tx, err := m.DB.BeginRw(ctx)
+	if err != nil {
+		t.Errorf("could not begin read write transaction: %s", err)
+	}
+	header, err := rawdb.ReadHeaderByHash(tx, blockHash)
+	if err != nil {
+		tx.Rollback()
+		t.Errorf("failed reading block by hash: %s", err)
+	}
+	bodyWithTx, err := rawdb.ReadBodyWithTransactions(tx, blockHash, header.Number.Uint64())
+	if err != nil {
+		tx.Rollback()
+		t.Errorf("failed getting body with transactions: %s", err)
+	}
+	tx.Rollback()
+
+	expectedAmount := hexutil.Uint(len(bodyWithTx.Transactions))
+
+	txAmount, err := api.GetBlockTransactionCountByNumber(ctx, rpc.BlockNumber(header.Number.Uint64()))
+	if err != nil {
+		t.Errorf("failed getting the transaction count, err=%s", err)
+	}
+
+	assert.Equal(t, expectedAmount, *txAmount)
+}
+
+func TestGetBlockTransactionCountByNumber_ZeroTx(t *testing.T) {
+	m, _, _ := rpcdaemontest.CreateTestSentry(t)
+	agg := m.HistoryV3Components()
+	br := snapshotsync.NewBlockReaderWithSnapshots(m.BlockSnapshots)
+	ctx := context.Background()
+	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
+	api := NewEthAPI(NewBaseApi(nil, stateCache, br, agg, false, rpccfg.DefaultEvmCallTimeout, m.Engine), m.DB, nil, nil, nil, 5000000, 100_000)
+
+	blockHash := common.HexToHash("0x5883164d4100b95e1d8e931b8b9574586a1dea7507941e6ad3c1e3a2591485fd")
 
 	tx, err := m.DB.BeginRw(ctx)
 	if err != nil {

--- a/cmd/rpcdaemon/rpcdaemontest/test_util.go
+++ b/cmd/rpcdaemon/rpcdaemontest/test_util.go
@@ -156,7 +156,7 @@ func generateChain(
 	var tokenContract *contracts.Token
 
 	// We generate the blocks without plain state because it's not supported in core.GenerateChain
-	return core.GenerateChain(config, parent, engine, db, 10, func(i int, block *core.BlockGen) {
+	return core.GenerateChain(config, parent, engine, db, 11, func(i int, block *core.BlockGen) {
 		var (
 			txn types.Transaction
 			txs []types.Transaction
@@ -260,6 +260,9 @@ func generateChain(
 				panic(err)
 			}
 			txs = append(txs, txn)
+		case 10:
+			// Empty block
+			break
 		}
 
 		if err != nil {


### PR DESCRIPTION
So... for blocks that don't exist, the eth_getBlockTransactionCount RPCs should return `null`. Erigon does this correctly right now and this is covered by the unit test in [rpcdaemon/commands/corner_cases_support_test.go](https://github.com/ledgerwatch/erigon/blob/devel/cmd/rpcdaemon/commands/corner_cases_support_test.go).

But, for blocks that don't have any transactions, like [703696](https://etherscan.io/block/703696), the RPC also returns `null`.

I've changed this to correctly return `0` and have added 2 new tests to handle it. (I had to add another block to the test chain in rpcdaemon/rpcdaemontest/test_util.go and had to fix a few other tests that broke as a result.)

Resolves #6775