### PR TITLE
pass config to tracer from RPC request

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -1,6 +1,8 @@
 package tracers
 
 import (
+	"encoding/json"
+
 	"github.com/ledgerwatch/erigon/eth/tracers/logger"
 	"github.com/ledgerwatch/erigon/turbo/adapter/ethapi"
 )
@@ -9,6 +11,7 @@ import (
 type TraceConfig struct {
 	*logger.LogConfig
 	Tracer         *string
+	TracerConfig   *json.RawMessage
 	Timeout        *string
 	Reexec         *uint64
 	NoRefunds      *bool // Turns off gas refunds when tracing

--- a/turbo/transactions/tracing.go
+++ b/turbo/transactions/tracing.go
@@ -146,9 +146,13 @@ func TraceTx(
 			}
 		}
 		// Construct the JavaScript tracer to execute with
+		cfg := json.RawMessage("{}")
+		if config != nil && config.TracerConfig != nil {
+			cfg = *config.TracerConfig
+		}
 		if tracer, err = tracers.New(*config.Tracer, &tracers.Context{
 			TxHash: txCtx.TxHash,
-		}, json.RawMessage("{}")); err != nil {
+		}, cfg); err != nil {
 			stream.WriteNil()
 			return err
 		}


### PR DESCRIPTION
Created to handle #6758.

Just takes the parameters and passes them down the pipe.  A local test against mainnet showed the trace size varied accordingly when passing true/false values for `onlyTopCall`.