### PR TITLE
Fix 'make bindings'

### DIFF
--- a/core/state/contracts/selfdestruct.sol
+++ b/core/state/contracts/selfdestruct.sol
@@ -27,6 +27,6 @@ contract Selfdestruct {
 
     /* Self-destructs */
     function destruct() public {
-        selfdestruct(address(this));
+        selfdestruct(payable(this));
     }
 }

--- a/tests/contracts/selfDestructor.sol
+++ b/tests/contracts/selfDestructor.sol
@@ -7,7 +7,7 @@ contract selfDestructor {
     }
 
     function selfDestruct() public {
-        address payable nil = address(0);
+        address payable nil = payable(0);
         selfdestruct(nil);
     }
 }


### PR DESCRIPTION
Solidity 0.8.0 breaks the current use of `payable` in these test contracts, resulting in errors like
```
Error: Type address is not implicitly convertible to expected type address payable.
  --> selfDestructor.sol:10:9:
   |
10 |         address payable nil = address(0);
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Related to #6680