### PR TITLE
State sync transactions added to debug_traceBlockByNumber call

### DIFF
--- a/cmd/rpcdaemon/commands/tracing.go
+++ b/cmd/rpcdaemon/commands/tracing.go
@@ -92,9 +92,7 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 	rules := chainConfig.Rules(block.NumberU64(), block.Time())
 	stream.WriteArrayStart()
 
-	var borTx types.Transaction
-	borTx, _, _, _ = rawdb.ReadBorTransactionForBlock(tx, block)
-
+	borTx, _, _, _ := rawdb.ReadBorTransactionForBlock(tx, block)
 	txns := block.Transactions()
 	if borTx != nil && *config.BorTraceEnabled {
 		txns = append(txns, borTx)

--- a/cmd/rpcdaemon/commands/tracing.go
+++ b/cmd/rpcdaemon/commands/tracing.go
@@ -133,7 +133,6 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 		}
 
 		err = transactions.TraceTx(ctx, msg, blockCtx, txCtx, ibs, config, chainConfig, stream, api.evmCallTimeout)
-
 		if err == nil {
 			err = ibs.FinalizeTx(rules, state.NewNoopWriter())
 		}

--- a/cmd/rpcdaemon/commands/tracing.go
+++ b/cmd/rpcdaemon/commands/tracing.go
@@ -123,7 +123,6 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 			GasPrice: msg.GasPrice(),
 		}
 
-		config.BorTx = newBoolPtr(false)
 		if borTx != nil && idx == len(txns)-1 {
 			if *config.BorTraceEnabled {
 				config.BorTx = newBoolPtr(true)

--- a/consensus/bor/statefull/processor.go
+++ b/consensus/bor/statefull/processor.go
@@ -1,9 +1,13 @@
 package statefull
 
 import (
+	"github.com/holiman/uint256"
+	ethereum "github.com/ledgerwatch/erigon"
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon/consensus"
+	"github.com/ledgerwatch/erigon/core"
 	"github.com/ledgerwatch/erigon/core/types"
+	"github.com/ledgerwatch/erigon/core/vm"
 )
 
 type ChainContext struct {
@@ -17,4 +21,40 @@ func (c ChainContext) Engine() consensus.Engine {
 
 func (c ChainContext) GetHeader(hash libcommon.Hash, number uint64) *types.Header {
 	return c.Chain.GetHeader(hash, number)
+}
+
+// callmsg implements core.Message to allow passing it as a transaction simulator.
+type Callmsg struct {
+	ethereum.CallMsg
+}
+
+func (m Callmsg) From() libcommon.Address { return m.CallMsg.From }
+func (m Callmsg) Nonce() uint64           { return 0 }
+func (m Callmsg) CheckNonce() bool        { return false }
+func (m Callmsg) To() *libcommon.Address  { return m.CallMsg.To }
+func (m Callmsg) GasPrice() *uint256.Int  { return m.CallMsg.GasPrice }
+func (m Callmsg) Gas() uint64             { return m.CallMsg.Gas }
+func (m Callmsg) Value() *uint256.Int     { return m.CallMsg.Value }
+func (m Callmsg) Data() []byte            { return m.CallMsg.Data }
+
+func ApplyBorMessage(vmenv vm.EVM, msg Callmsg) (*core.ExecutionResult, error) {
+	initialGas := msg.Gas()
+
+	// Apply the transaction to the current state (included in the env)
+	ret, gasLeft, err := vmenv.Call(
+		vm.AccountRef(msg.From()),
+		*msg.To(),
+		msg.Data(),
+		msg.Gas(),
+		msg.Value(),
+		false,
+	)
+
+	gasUsed := initialGas - gasLeft
+
+	return &core.ExecutionResult{
+		UsedGas:    gasUsed,
+		Err:        err,
+		ReturnData: ret,
+	}, nil
 }

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -16,4 +16,7 @@ type TraceConfig struct {
 	Reexec         *uint64
 	NoRefunds      *bool // Turns off gas refunds when tracing
 	StateOverrides *ethapi.StateOverrides
+
+	BorTraceEnabled *bool
+	BorTx           *bool
 }

--- a/turbo/transactions/tracing.go
+++ b/turbo/transactions/tracing.go
@@ -186,8 +186,8 @@ func TraceTx(
 		stream.WriteObjectField("structLogs")
 		stream.WriteArrayStart()
 	}
-	var result *core.ExecutionResult
 
+	var result *core.ExecutionResult
 	if *config.BorTx {
 		callmsg := prepareCallMessage(message)
 		result, err = statefull.ApplyBorMessage(*vmenv, callmsg)

--- a/turbo/transactions/tracing.go
+++ b/turbo/transactions/tracing.go
@@ -190,9 +190,7 @@ func TraceTx(
 
 	if *config.BorTx {
 		callmsg := prepareCallMessage(message)
-		fmt.Println(callmsg)
 		result, err = statefull.ApplyBorMessage(*vmenv, callmsg)
-		fmt.Println(result)
 	} else {
 		result, err = core.ApplyMessage(vmenv, message, new(core.GasPool).AddGas(message.Gas()), refunds, false /* gasBailout */)
 	}

--- a/turbo/transactions/tracing.go
+++ b/turbo/transactions/tracing.go
@@ -9,10 +9,12 @@ import (
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
+	ethereum "github.com/ledgerwatch/erigon"
 	"github.com/ledgerwatch/erigon-lib/chain"
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon/consensus"
+	"github.com/ledgerwatch/erigon/consensus/bor/statefull"
 	"github.com/ledgerwatch/erigon/core"
 	"github.com/ledgerwatch/erigon/core/state"
 	"github.com/ledgerwatch/erigon/core/types"
@@ -184,7 +186,16 @@ func TraceTx(
 		stream.WriteObjectField("structLogs")
 		stream.WriteArrayStart()
 	}
-	result, err := core.ApplyMessage(vmenv, message, new(core.GasPool).AddGas(message.Gas()), refunds, false /* gasBailout */)
+	var result *core.ExecutionResult
+
+	if *config.BorTx {
+		callmsg := prepareCallMessage(message)
+		result, err = statefull.ApplyBorMessage(*vmenv, callmsg)
+	} else {
+		result, err = core.ApplyMessage(vmenv, message, new(core.GasPool).AddGas(message.Gas()), refunds, false /* gasBailout */)
+	}
+
+	result, err = core.ApplyMessage(vmenv, message, new(core.GasPool).AddGas(message.Gas()), refunds, false /* gasBailout */)
 	if err != nil {
 		if streaming {
 			stream.WriteArrayEnd()
@@ -220,4 +231,17 @@ func TraceTx(
 		}
 	}
 	return nil
+}
+
+func prepareCallMessage(msg core.Message) statefull.Callmsg {
+	return statefull.Callmsg{
+		CallMsg: ethereum.CallMsg{
+			From:       msg.From(),
+			To:         msg.To(),
+			Gas:        msg.Gas(),
+			GasPrice:   msg.GasPrice(),
+			Value:      msg.Value(),
+			Data:       msg.Data(),
+			AccessList: msg.AccessList(),
+		}}
 }

--- a/turbo/transactions/tracing.go
+++ b/turbo/transactions/tracing.go
@@ -188,7 +188,7 @@ func TraceTx(
 	}
 
 	var result *core.ExecutionResult
-	if *config.BorTx {
+	if config.BorTx != nil && *config.BorTx {
 		callmsg := prepareCallMessage(message)
 		result, err = statefull.ApplyBorMessage(*vmenv, callmsg)
 	} else {

--- a/turbo/transactions/tracing.go
+++ b/turbo/transactions/tracing.go
@@ -190,12 +190,13 @@ func TraceTx(
 
 	if *config.BorTx {
 		callmsg := prepareCallMessage(message)
+		fmt.Println(callmsg)
 		result, err = statefull.ApplyBorMessage(*vmenv, callmsg)
+		fmt.Println(result)
 	} else {
 		result, err = core.ApplyMessage(vmenv, message, new(core.GasPool).AddGas(message.Gas()), refunds, false /* gasBailout */)
 	}
 
-	result, err = core.ApplyMessage(vmenv, message, new(core.GasPool).AddGas(message.Gas()), refunds, false /* gasBailout */)
 	if err != nil {
 		if streaming {
 			stream.WriteArrayEnd()


### PR DESCRIPTION
State sync transactions can be enabled using `"borTraceEnabled": true` parameter, this is to ensure that the current behaviour is unchanged.