### PR TITLE
fix(release): use prefixed compiler for amd64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,8 +34,8 @@ builds:
     goos: [ linux ]
     goarch: [ amd64 ]
     env:
-      - CC=gcc
-      - CXX=g++
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
     tags: [ nosqlite, noboltdb ]
     ldflags: -s -w -extldflags "-static" # We need to build a static binary because we are building in a glibc based system and running in a musl container
 


### PR DESCRIPTION
if ever planned to release from arm64 this
fix allows to build it as gcc defaults
to host arch

Signed-off-by: Artur Troian <troian.ap@gmail.com>