### PR TITLE
Revert to simple polling wait

### DIFF
--- a/ethdb/privateapi/ethbackend.go
+++ b/ethdb/privateapi/ethbackend.go
@@ -270,15 +270,17 @@ func convertPayloadStatus(payloadStatus *engineapi.PayloadStatus) *remote.Engine
 
 func (s *EthBackendServer) stageLoopIsBusy() bool {
 	for i := 0; i < 100; i++ {
-		if !s.hd.BeaconRequestList.IsWaiting() {
-			// This might happen, for example, in the following scenario:
-			// 1) CL sends NewPayload and immediately after that ForkChoiceUpdated.
-			// 2) We happily process NewPayload and stage loop is at the end.
-			// 3) We start processing ForkChoiceUpdated,
-			// but the stage loop hasn't moved yet from the end to the beginning of HeadersPOS
-			// and thus requestList.WaitForRequest() is not called yet.
-			time.Sleep(10 * time.Millisecond)
+		if s.hd.BeaconRequestList.IsWaiting() {
+			return false
 		}
+
+		// This might happen, for example, in the following scenario:
+		// 1) CL sends NewPayload and immediately after that ForkChoiceUpdated.
+		// 2) We happily process NewPayload and stage loop is at the end.
+		// 3) We start processing ForkChoiceUpdated,
+		// but the stage loop hasn't moved yet from the end to the beginning of HeadersPOS
+		// and thus requestList.WaitForRequest() is not called yet.
+		time.Sleep(10 * time.Millisecond)
 	}
 
 	return !s.hd.BeaconRequestList.IsWaiting()


### PR DESCRIPTION
Unfortunately PR #6763 breaks a few Hive tests, for example "Invalid Ancestor Chain Sync, Invalid StateRoot, Invalid P9". Thus reverting to the simpler old logic, but with the maximum wait kept as 1 sec.