### PR TITLE
fix: use variable for slots per epoch in CL

### DIFF
--- a/cmd/erigon-cl/main.go
+++ b/cmd/erigon-cl/main.go
@@ -127,7 +127,7 @@ func startSentinel(cliCtx *cli.Context, cfg lcCli.ConsensusClientCliCfg, beaconS
 		ForkDigest:     forkDigest,
 		FinalizedRoot:  beaconState.FinalizedCheckpoint().Root,
 		FinalizedEpoch: beaconState.FinalizedCheckpoint().Epoch,
-		HeadSlot:       beaconState.FinalizedCheckpoint().Epoch * 32,
+		HeadSlot:       beaconState.FinalizedCheckpoint().Epoch * cfg.BeaconCfg.SlotsPerEpoch,
 		HeadRoot:       beaconState.FinalizedCheckpoint().Root,
 	}, handshake.FullClientRule)
 	if err != nil {


### PR DESCRIPTION
Some network might have different `SLOTS_PER_EPOCH` configs instead of the currently hardcoded `32`.