### PR TITLE
Don't use embedded CL by default for Gnosis

### DIFF
--- a/cl/clparams/config.go
+++ b/cl/clparams/config.go
@@ -904,3 +904,9 @@ func GetCheckpointSyncEndpoint(net NetworkType) string {
 func EmbeddedSupported(id uint64) bool {
 	return id == 1 || id == 5 || id == 11155111 || id == 100 || id == 10200
 }
+
+// Subset of supported networks where embedded CL is stable enough
+// (sufficient number of light-client peers) as to be enabled by default
+func EmbeddedEnabledByDefault(id uint64) bool {
+	return id == 1 || id == 5 || id == 11155111
+}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1614,7 +1614,7 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 	if ctx.IsSet(ExternalConsensusFlag.Name) {
 		cfg.ExternalCL = ctx.Bool(ExternalConsensusFlag.Name)
 	} else {
-		cfg.ExternalCL = !clparams.EmbeddedSupported(cfg.NetworkID)
+		cfg.ExternalCL = !clparams.EmbeddedEnabledByDefault(cfg.NetworkID)
 	}
 	nodeConfig.Http.InternalCL = !cfg.ExternalCL
 }


### PR DESCRIPTION
Only Nimbus peers support light clients, and there's not enough Nimbus peers on Gnosis.