### PR TITLE
check prune history on trace calls

### DIFF
--- a/cmd/rpcdaemon/commands/eth_call_test.go
+++ b/cmd/rpcdaemon/commands/eth_call_test.go
@@ -78,7 +78,7 @@ func TestEthCallToPrunedBlock(t *testing.T) {
 	m, bankAddress, contractAddress := chainWithDeployedContract(t)
 	br := snapshotsync.NewBlockReaderWithSnapshots(m.BlockSnapshots, m.TransactionsV3)
 
-	prune(t, m.DB, pruneTo)
+	doPrune(t, m.DB, pruneTo)
 
 	agg := m.HistoryV3Components()
 
@@ -373,7 +373,7 @@ func chainWithDeployedContract(t *testing.T) (*stages.MockSentry, libcommon.Addr
 	return m, bankAddress, contractAddr
 }
 
-func prune(t *testing.T, db kv.RwDB, pruneTo uint64) {
+func doPrune(t *testing.T, db kv.RwDB, pruneTo uint64) {
 	ctx := context.Background()
 	tx, err := db.BeginRw(ctx)
 	assert.NoError(t, err)


### PR DESCRIPTION
Not sure if this is too aggressive or not, but return early once we have a block number if state history has been pruned for that block number.