### PR TITLE
handle nil update return values without panic

### DIFF
--- a/cmd/sentinel/sentinel/handlers/lightclient.go
+++ b/cmd/sentinel/sentinel/handlers/lightclient.go
@@ -44,7 +44,7 @@ func (c *ConsensusHandlers) lightClientFinalityUpdateHandler(stream network.Stre
 	}
 	defer tx.Rollback()
 	update, err := rawdb.ReadLightClientFinalityUpdate(tx)
-	if err != nil {
+	if err != nil || update == nil {
 		stream.Close()
 		return
 	}
@@ -74,7 +74,7 @@ func (c *ConsensusHandlers) lightClientOptimisticUpdateHandler(stream network.St
 	}
 	defer tx.Rollback()
 	update, err := rawdb.ReadLightClientOptimisticUpdate(tx)
-	if err != nil {
+	if err != nil || update == nil {
 		stream.Close()
 		return
 	}


### PR DESCRIPTION
Saw this when trying to sync goerli today:


```
INFO[02-23|11:10:20.611] [2/15 Headers] Waiting for Consensus Layer...
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x14a58dd]

goroutine 11484998 [running]:
github.com/ledgerwatch/erigon/cl/cltypes.(*LightClientOptimisticUpdate).EncodingSizeSSZ(0x0)
        github.com/ledgerwatch/erigon/cl/cltypes/lightclient.go:620 +0x1d
github.com/ledgerwatch/erigon/cmd/sentinel/sentinel/communication/ssz_snappy.EncodeAndWrite({0x77f6a74bc058?, 0xc03912b100?}, {0x2c2f628, 0x0}, {0xc022ad9f
5c, 0x1, 0x1})
        github.com/ledgerwatch/erigon/cmd/sentinel/sentinel/communication/ssz_snappy/encoding.go:34 +0xae
github.com/ledgerwatch/erigon/cmd/sentinel/sentinel/handlers.(*ConsensusHandlers).lightClientOptimisticUpdateHandler(0xc021f0d500, {0x2c57c28, 0xc03912b100
})
        github.com/ledgerwatch/erigon/cmd/sentinel/sentinel/handlers/lightclient.go:82 +0x19d
github.com/libp2p/go-libp2p/p2p/host/basic.(*BasicHost).SetStreamHandler.func1({0xc085e0fa90, 0x42}, {0x77f6a74bbfe8?, 0xc03912b100})
        github.com/libp2p/go-libp2p@v0.25.1/p2p/host/basic/basic_host.go:580 +0x76
created by github.com/libp2p/go-libp2p/p2p/host/basic.(*BasicHost).newStreamHandler
        github.com/libp2p/go-libp2p@v0.25.1/p2p/host/basic/basic_host.go:421 +0x74f

```