### PR TITLE
add ENTRYPOINT to Dockerfile and Dockerfile.debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,3 +103,5 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.vcs-url="https://github.com/ledgerwatch/erigon.git" \
       org.label-schema.vendor="Torquem" \
       org.label-schema.version=$VERSION
+
+ENTRYPOINT ["erigon"]

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -100,3 +100,5 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.vcs-url="https://github.com/ledgerwatch/erigon.git" \
       org.label-schema.vendor="Torquem" \
       org.label-schema.version=$VERSION
+
+ENTRYPOINT ["erigon"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@
 # This file is an example: how to start Erigon's services as separated processes.
 
 # Default: --datadir=/home/erigon/.local/share/erigon
-# Default UID: 3473
-# Default GID: 3473
+# Default UID: 1000
+# Default GID: 1000
 # Ports: `9090` execution engine (private api), `9091` sentry, `9092` consensus engine, `9093` snapshot downloader, `9094` TxPool
 # Ports: `8545` json rpc, `8551` consensus json rpc, `30303` eth p2p protocol, `42069` bittorrent protocol,
 
@@ -31,7 +31,7 @@ services:
         GID: ${DOCKER_GID:-1000}
       context: .
     command: |
-      erigon ${ERIGON_FLAGS-} --private.api.addr=0.0.0.0:9090
+      ${ERIGON_FLAGS-} --private.api.addr=0.0.0.0:9090
       --sentry.api.addr=sentry:9091 --downloader.api.addr=downloader:9093 --txpool.disable
       --metrics --metrics.addr=0.0.0.0 --metrics.port=6060 --pprof --pprof.addr=0.0.0.0 --pprof.port=6061
       --authrpc.jwtsecret=/home/erigon/.local/share/erigon/jwt.hex --datadir=/home/erigon/.local/share/erigon
@@ -44,22 +44,26 @@ services:
 
   sentry:
     <<: *default-erigon-service
-    command: sentry ${SENTRY_FLAGS-} --sentry.api.addr=0.0.0.0:9091 --datadir=/home/erigon/.local/share/erigon
+    entrypoint: sentry
+    command: ${SENTRY_FLAGS-} --sentry.api.addr=0.0.0.0:9091 --datadir=/home/erigon/.local/share/erigon
     ports: [ "30303:30303/tcp", "30303:30303/udp" ]
 
   downloader:
     <<: *default-erigon-service
-    command: downloader ${DOWNLOADER_FLAGS-} --downloader.api.addr=0.0.0.0:9093 --datadir=/home/erigon/.local/share/erigon
+    entrypoint: downloader 
+    command: ${DOWNLOADER_FLAGS-} --downloader.api.addr=0.0.0.0:9093 --datadir=/home/erigon/.local/share/erigon
     ports: [ "42069:42069/tcp", "42069:42069/udp" ]
 
   txpool:
     <<: *default-erigon-service
-    command: txpool ${TXPOOL_FLAGS-} --private.api.addr=erigon:9090 --txpool.api.addr=0.0.0.0:9094 --sentry.api.addr=sentry:9091 --datadir=/home/erigon/.local/share/erigon
+    entrypoint: txpool
+    command: ${TXPOOL_FLAGS-} --private.api.addr=erigon:9090 --txpool.api.addr=0.0.0.0:9094 --sentry.api.addr=sentry:9091 --datadir=/home/erigon/.local/share/erigon
 
   rpcdaemon:
     <<: *default-erigon-service
+    entrypoint: rpcdaemon
     command: |
-      rpcdaemon ${RPCDAEMON_FLAGS-} --http.addr=0.0.0.0 --http.vhosts=* --http.corsdomain=* --ws
+      ${RPCDAEMON_FLAGS-} --http.addr=0.0.0.0 --http.vhosts=* --http.corsdomain=* --ws
       --private.api.addr=erigon:9090 --txpool.api.addr=txpool:9094 --datadir=/home/erigon/.local/share/erigon
     ports: [ "8545:8545" ]
 

--- a/tests/automated-testing/docker-compose.yml
+++ b/tests/automated-testing/docker-compose.yml
@@ -33,8 +33,9 @@ services:
     profiles:
       - first
     image: thorax/erigon:$ERIGON_TAG
-    entrypoint: |
-      rpcdaemon --private.api.addr=erigon:9090 --http.api=admin,eth,erigon,web3,net,debug,trace,txpool,parity --http.addr=0.0.0.0 --http.vhosts=* --http.corsdomain=* --http.port=8545 --graphql --log.dir.path=/logs/node1
+    entrypoint: rpcdaemon
+    command: |
+      --private.api.addr=erigon:9090 --http.api=admin,eth,erigon,web3,net,debug,trace,txpool,parity --http.addr=0.0.0.0 --http.vhosts=* --http.corsdomain=* --http.port=8545 --graphql --log.dir.path=/logs/node1
     volumes:
       - ./logdir:/logs
     user: ${DOCKER_UID}:${DOCKER_GID}
@@ -44,8 +45,9 @@ services:
     profiles:
       - second
     image: thorax/erigon:$ERIGON_TAG
-    entrypoint: |
-      rpcdaemon --private.api.addr=erigon-node2:9090 --http.api=admin,eth,erigon,web3,net,debug,trace,txpool,parity --http.addr=0.0.0.0 --http.vhosts=* --http.corsdomain=* --http.port=8545 --log.dir.path=/logs/node2
+    entrypoint: rpcdaemon
+    command: |
+      --private.api.addr=erigon-node2:9090 --http.api=admin,eth,erigon,web3,net,debug,trace,txpool,parity --http.addr=0.0.0.0 --http.vhosts=* --http.corsdomain=* --http.port=8545 --log.dir.path=/logs/node2
     volumes:
       - ./logdir:/logs
     user: ${DOCKER_UID}:${DOCKER_GID}
@@ -56,8 +58,9 @@ services:
     image: thorax/automated-testing
     volumes:
       - ./results:/erigon-automated-testing/results
-    entrypoint: |
-      pytest -m smoke_test --quiet --junitxml="./results/result.xml" --url="http://rpcdaemon:8545" --tb=line
+    entrypoint: pytest
+    command: |
+      -m smoke_test --quiet --junitxml="./results/result.xml" --url="http://rpcdaemon:8545" --tb=line
 
 volumes:
   datadir:

--- a/tests/automated-testing/docker-compose.yml
+++ b/tests/automated-testing/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - first
     image: thorax/erigon:$ERIGON_TAG   
     command: |
-      erigon --datadir=/home/erigon/.local/share/erigon --chain=dev --private.api.addr=0.0.0.0:9090 --mine --log.dir.path=/logs/node1
+      --datadir=/home/erigon/.local/share/erigon --chain=dev --private.api.addr=0.0.0.0:9090 --mine --log.dir.path=/logs/node1
     ports:
       - "8551:8551"
     volumes:      
@@ -21,7 +21,7 @@ services:
         - second
       image: thorax/erigon:$ERIGON_TAG
       command: |
-        erigon --datadir=/home/erigon/.local/share/erigon --chain=dev --private.api.addr=0.0.0.0:9090 --staticpeers=$ENODE --log.dir.path=/logs/node2
+        --datadir=/home/erigon/.local/share/erigon --chain=dev --private.api.addr=0.0.0.0:9090 --staticpeers=$ENODE --log.dir.path=/logs/node2
       volumes:
         - datadir2:/home/erigon/.local/share/erigon
         - ./logdir:/logs
@@ -33,8 +33,8 @@ services:
     profiles:
       - first
     image: thorax/erigon:$ERIGON_TAG
-    command: |
-       rpcdaemon --private.api.addr=erigon:9090 --http.api=admin,eth,erigon,web3,net,debug,trace,txpool,parity --http.addr=0.0.0.0 --http.vhosts=* --http.corsdomain=* --http.port=8545 --graphql --log.dir.path=/logs/node1
+    entrypoint: |
+      rpcdaemon --private.api.addr=erigon:9090 --http.api=admin,eth,erigon,web3,net,debug,trace,txpool,parity --http.addr=0.0.0.0 --http.vhosts=* --http.corsdomain=* --http.port=8545 --graphql --log.dir.path=/logs/node1
     volumes:
       - ./logdir:/logs
     user: ${DOCKER_UID}:${DOCKER_GID}
@@ -44,8 +44,8 @@ services:
     profiles:
       - second
     image: thorax/erigon:$ERIGON_TAG
-    command: |
-        rpcdaemon --private.api.addr=erigon-node2:9090 --http.api=admin,eth,erigon,web3,net,debug,trace,txpool,parity --http.addr=0.0.0.0 --http.vhosts=* --http.corsdomain=* --http.port=8545 --log.dir.path=/logs/node2
+    entrypoint: |
+      rpcdaemon --private.api.addr=erigon-node2:9090 --http.api=admin,eth,erigon,web3,net,debug,trace,txpool,parity --http.addr=0.0.0.0 --http.vhosts=* --http.corsdomain=* --http.port=8545 --log.dir.path=/logs/node2
     volumes:
       - ./logdir:/logs
     user: ${DOCKER_UID}:${DOCKER_GID}


### PR DESCRIPTION
Providing an ENTRYPOINT in Dockerfiles is best practice, so I've added an ENTRYPOINT to Dockerfile and Dockerfile.debian, setting it to erigon, because it's the binary most people want to run. The setting can be overridden in the ` docker run`  command to execute different binaries. Currently everybody has to override it anyway, because there's neither a CMD nor an ENTRYPOINT given.

The Dockerfile.release already contains the ENTRYPOINT erigon.

P.S.: This PR originated in #6862.