### PR TITLE
Add clique API, support "clique" option in --http.api flag

### DIFF
--- a/cmd/rpcdaemon/commands/daemon.go
+++ b/cmd/rpcdaemon/commands/daemon.go
@@ -7,6 +7,7 @@ import (
 	libstate "github.com/ledgerwatch/erigon-lib/state"
 	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/cli/httpcfg"
 	"github.com/ledgerwatch/erigon/consensus"
+	"github.com/ledgerwatch/erigon/consensus/clique"
 	"github.com/ledgerwatch/erigon/rpc"
 	"github.com/ledgerwatch/erigon/turbo/rpchelper"
 	"github.com/ledgerwatch/erigon/turbo/services"
@@ -127,6 +128,8 @@ func APIList(db kv.RoDB, borDb kv.RoDB, eth rpchelper.ApiBackend, txPool txpool.
 				Service:   OtterscanAPI(otsImpl),
 				Version:   "1.0",
 			})
+		case "clique":
+			list = append(list, clique.NewCliqueAPI(db, engine))
 		}
 	}
 

--- a/consensus/chain_reader.go
+++ b/consensus/chain_reader.go
@@ -1,0 +1,72 @@
+package consensus
+
+import (
+	"math/big"
+
+	"github.com/ledgerwatch/erigon-lib/chain"
+	libcommon "github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/kv"
+	"github.com/ledgerwatch/log/v3"
+
+	"github.com/ledgerwatch/erigon/core/rawdb"
+	"github.com/ledgerwatch/erigon/core/types"
+)
+
+// Implements consensus.ChainReader
+type ChainReaderImpl struct {
+	Cfg chain.Config
+	Db  kv.Getter
+}
+
+// Config retrieves the blockchain's chain configuration.
+func (cr ChainReaderImpl) Config() *chain.Config {
+	return &cr.Cfg
+}
+
+// CurrentHeader retrieves the current header from the local chain.
+func (cr ChainReaderImpl) CurrentHeader() *types.Header {
+	hash := rawdb.ReadHeadHeaderHash(cr.Db)
+	number := rawdb.ReadHeaderNumber(cr.Db, hash)
+	return rawdb.ReadHeader(cr.Db, hash, *number)
+}
+
+// GetHeader retrieves a block header from the database by hash and number.
+func (cr ChainReaderImpl) GetHeader(hash libcommon.Hash, number uint64) *types.Header {
+	return rawdb.ReadHeader(cr.Db, hash, number)
+}
+
+// GetHeaderByNumber retrieves a block header from the database by number.
+func (cr ChainReaderImpl) GetHeaderByNumber(number uint64) *types.Header {
+	hash, err := rawdb.ReadCanonicalHash(cr.Db, number)
+	if err != nil {
+		log.Error("ReadCanonicalHash failed", "err", err)
+		return nil
+	}
+	return rawdb.ReadHeader(cr.Db, hash, number)
+}
+
+// GetHeaderByHash retrieves a block header from the database by its hash.
+func (cr ChainReaderImpl) GetHeaderByHash(hash libcommon.Hash) *types.Header {
+	number := rawdb.ReadHeaderNumber(cr.Db, hash)
+	return rawdb.ReadHeader(cr.Db, hash, *number)
+}
+
+// GetBlock retrieves a block from the database by hash and number.
+func (cr ChainReaderImpl) GetBlock(hash libcommon.Hash, number uint64) *types.Block {
+	return rawdb.ReadBlock(cr.Db, hash, number)
+}
+
+// HasBlock retrieves a block from the database by hash and number.
+func (cr ChainReaderImpl) HasBlock(hash libcommon.Hash, number uint64) bool {
+	return rawdb.HasBlock(cr.Db, hash, number)
+}
+
+// GetTd retrieves the total difficulty from the database by hash and number.
+func (cr ChainReaderImpl) GetTd(hash libcommon.Hash, number uint64) *big.Int {
+	td, err := rawdb.ReadTd(cr.Db, hash, number)
+	if err != nil {
+		log.Error("ReadTd failed", "err", err)
+		return nil
+	}
+	return td
+}

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -175,10 +175,10 @@ func ecrecover(header *types.Header, sigcache *lru2.ARCCache[libcommon.Hash, lib
 // Clique is the proof-of-authority consensus engine proposed to support the
 // Ethereum testnet following the Ropsten attacks.
 type Clique struct {
-	chainConfig    *chain.Config
+	ChainConfig    *chain.Config
 	config         *chain.CliqueConfig             // Consensus engine configuration parameters
 	snapshotConfig *params.ConsensusSnapshotConfig // Consensus engine configuration parameters
-	db             kv.RwDB                         // Database to store and retrieve snapshot checkpoints
+	DB             kv.RwDB                         // Database to store and retrieve snapshot checkpoints
 
 	signatures *lru2.ARCCache[libcommon.Hash, libcommon.Address] // Signatures of recent blocks to speed up mining
 	recents    *lru2.ARCCache[libcommon.Hash, *Snapshot]         // Snapshots for recent block to speed up reorgs
@@ -212,10 +212,10 @@ func New(cfg *chain.Config, snapshotConfig *params.ConsensusSnapshotConfig, cliq
 	exitCh := make(chan struct{})
 
 	c := &Clique{
-		chainConfig:    cfg,
+		ChainConfig:    cfg,
 		config:         &conf,
 		snapshotConfig: snapshotConfig,
-		db:             cliqueDB,
+		DB:             cliqueDB,
 		recents:        recents,
 		signatures:     signatures,
 		proposals:      make(map[libcommon.Address]bool),
@@ -528,6 +528,20 @@ func (c *Clique) APIs(chain consensus.ChainHeaderReader) []rpc.API {
 	}
 }
 
+func NewCliqueAPI(db kv.RoDB, engine consensus.EngineReader) rpc.API {
+	var c *Clique
+	if casted, ok := engine.(*Clique); ok {
+		c = casted
+	}
+
+	return rpc.API{
+		Namespace: "clique",
+		Version:   "1.0",
+		Service:   &API{db: db, clique: c},
+		Public:    false,
+	}
+}
+
 // SealHash returns the hash of a block prior to it being sealed.
 func SealHash(header *types.Header) (hash libcommon.Hash) {
 	hasher := cryptopool.NewLegacyKeccak256()
@@ -584,7 +598,7 @@ func (c *Clique) snapshots(latest uint64, total int) ([]*Snapshot, error) {
 
 	blockEncoded := dbutils.EncodeBlockNumber(latest)
 
-	tx, err := c.db.BeginRo(context.Background())
+	tx, err := c.DB.BeginRo(context.Background())
 	if err != nil {
 		return nil, err
 	}

--- a/consensus/clique/verifier.go
+++ b/consensus/clique/verifier.go
@@ -168,7 +168,7 @@ func (c *Clique) Snapshot(chain consensus.ChainHeaderReader, number uint64, hash
 		}
 		// If an on-disk checkpoint snapshot can be found, use that
 		if number%c.snapshotConfig.CheckpointInterval == 0 {
-			if s, err := loadSnapshot(c.config, c.db, number, hash); err == nil {
+			if s, err := loadSnapshot(c.config, c.DB, number, hash); err == nil {
 				log.Trace("Loaded voting snapshot from disk", "number", number, "hash", hash)
 				snap = s
 				break
@@ -188,7 +188,7 @@ func (c *Clique) Snapshot(chain consensus.ChainHeaderReader, number uint64, hash
 					copy(signers[i][:], checkpoint.Extra[ExtraVanity+i*length.Addr:])
 				}
 				snap = newSnapshot(c.config, number, hash, signers)
-				if err := snap.store(c.db); err != nil {
+				if err := snap.store(c.DB); err != nil {
 					return nil, err
 				}
 				log.Info("[Clique] Stored checkpoint snapshot to disk", "number", number, "hash", hash)
@@ -226,7 +226,7 @@ func (c *Clique) Snapshot(chain consensus.ChainHeaderReader, number uint64, hash
 
 	// If we've generated a new checkpoint snapshot, save to disk
 	if snap.Number%c.snapshotConfig.CheckpointInterval == 0 && len(headers) > 0 {
-		if err = snap.store(c.db); err != nil {
+		if err = snap.store(c.DB); err != nil {
 			return nil, err
 		}
 		log.Trace("Stored voting snapshot to disk", "number", snap.Number, "hash", snap.Hash)

--- a/eth/stagedsync/stage_mining_finish.go
+++ b/eth/stagedsync/stage_mining_finish.go
@@ -61,12 +61,14 @@ func SpawnMiningFinishStage(s *StageState, tx kv.RwTx, cfg MiningFinishCfg, quit
 		return nil
 	}
 
-	// Note: To propose a new signer for Clique consensus, the block nonce should be set to 0xFFFFFFFFFFFFFFFF.
 	// Tests may set pre-calculated nonce
-	// if block.NonceU64() != 0 {
-	// 	cfg.miningState.MiningResultCh <- block
-	// 	return nil
-	// }
+	if block.NonceU64() != 0 {
+		// Note: To propose a new signer for Clique consensus, the block nonce should be set to 0xFFFFFFFFFFFFFFFF.
+		if cfg.engine.Type() != chain.CliqueConsensus {
+			cfg.miningState.MiningResultCh <- block
+			return nil
+		}
+	}
 
 	cfg.miningState.PendingResultCh <- block
 

--- a/eth/stagedsync/stage_mining_finish.go
+++ b/eth/stagedsync/stage_mining_finish.go
@@ -60,11 +60,13 @@ func SpawnMiningFinishStage(s *StageState, tx kv.RwTx, cfg MiningFinishCfg, quit
 		cfg.miningState.MiningResultPOSCh <- blockWithReceipts
 		return nil
 	}
+
+	// Note: To propose a new signer for Clique consensus, the block nonce should be set to 0xFFFFFFFFFFFFFFFF.
 	// Tests may set pre-calculated nonce
-	if block.NonceU64() != 0 {
-		cfg.miningState.MiningResultCh <- block
-		return nil
-	}
+	// if block.NonceU64() != 0 {
+	// 	cfg.miningState.MiningResultCh <- block
+	// 	return nil
+	// }
 
 	cfg.miningState.PendingResultCh <- block
 


### PR DESCRIPTION
* Enable the `clique` option in the `--http.api` flag.

* List of Clique commands:
`clique_getSnapshot(block number)`
`clique_getSnapshotAtHash(block hash)`
`clique_getSnapshotAtHash(block hash)`
`clique_getSigners(block number)`
`clique_getSignersAtHash(block hash)`
`clique_proposals()`
`clique_propose(signer address, bool)`
`clique_discard(signer address)`
`clique_status()`
Example:
`curl --data '{"method":"clique_getSigners","params":[],"id":1,"jsonrpc":"2.0"}' -H "Content-Type: application/json" -X POST http://localhost:8545`

* Please be careful while using the Clique API. Do not make the HTTP API public on the Clique's signer node, as anyone can directly call a Clique command. Instead, it should only be allowed in the localhost by using the flag `--http.addr "127.0.0.1"`.