### PR TITLE
run E4 via integration binary

### DIFF
--- a/cmd/integration/commands/flags.go
+++ b/cmd/integration/commands/flags.go
@@ -1,8 +1,9 @@
 package commands
 
 import (
-	"github.com/ledgerwatch/erigon/turbo/cli"
 	"github.com/spf13/cobra"
+
+	"github.com/ledgerwatch/erigon/turbo/cli"
 
 	"github.com/ledgerwatch/erigon/cmd/utils"
 	"github.com/ledgerwatch/erigon/eth/ethconfig"
@@ -30,6 +31,12 @@ var (
 	pruneTBefore, pruneCBefore     uint64
 	experiments                    []string
 	chain                          string // Which chain to use (mainnet, rinkeby, goerli, etc.)
+
+	commitmentMode string
+	commitmentTrie string
+	commitmentFreq int
+	startTxNum     uint64
+	traceFromTx    uint64
 
 	_forceSetHistoryV3    bool
 	workers, reconWorkers uint64
@@ -141,4 +148,18 @@ func withHeimdall(cmd *cobra.Command) {
 func withWorkers(cmd *cobra.Command) {
 	cmd.Flags().Uint64Var(&workers, "exec.workers", uint64(ethconfig.Defaults.Sync.ExecWorkerCount), "")
 	cmd.Flags().Uint64Var(&reconWorkers, "recon.workers", uint64(ethconfig.Defaults.Sync.ReconWorkerCount), "")
+}
+
+func withStartTx(cmd *cobra.Command) {
+	cmd.Flags().Uint64Var(&startTxNum, "startTx", 0, "start processing from tx")
+}
+
+func withTraceFromTx(cmd *cobra.Command) {
+	cmd.Flags().Uint64Var(&traceFromTx, "txtrace.from", 0, "start tracing from tx number")
+}
+
+func withCommitment(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&commitmentMode, "commitment.mode", "direct", "defines the way to calculate commitments: 'direct' mode reads from state directly, 'update' accumulate updates before commitment, 'off' actually disables commitment calculation")
+	cmd.Flags().StringVar(&commitmentTrie, "commitment.trie", "hex", "hex - use Hex Patricia Hashed Trie for commitments, bin - use of binary patricia trie")
+	cmd.Flags().IntVar(&commitmentFreq, "commitment.freq", 25000, "how many blocks to skip between calculating commitment")
 }

--- a/cmd/integration/commands/root.go
+++ b/cmd/integration/commands/root.go
@@ -6,14 +6,15 @@ import (
 	"github.com/c2h5oh/datasize"
 	"github.com/ledgerwatch/erigon-lib/kv"
 	kv2 "github.com/ledgerwatch/erigon-lib/kv/mdbx"
-	"github.com/ledgerwatch/erigon/cmd/utils"
-	"github.com/ledgerwatch/erigon/migrations"
-	"github.com/ledgerwatch/erigon/turbo/debug"
-	"github.com/ledgerwatch/erigon/turbo/logging"
 	"github.com/ledgerwatch/log/v3"
 	"github.com/spf13/cobra"
 	"github.com/torquem-ch/mdbx-go/mdbx"
 	"golang.org/x/sync/semaphore"
+
+	"github.com/ledgerwatch/erigon/cmd/utils"
+	"github.com/ledgerwatch/erigon/migrations"
+	"github.com/ledgerwatch/erigon/turbo/debug"
+	"github.com/ledgerwatch/erigon/turbo/logging"
 )
 
 var rootCmd = &cobra.Command{

--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -1248,7 +1248,7 @@ func allDomains(ctx context.Context, db kv.RoDB, mode libstate.CommitmentMode, t
 		_allSnapshotsSingleton = snapshotsync.NewRoSnapshots(snapCfg, dirs.Snap)
 
 		var err error
-		_aggDomainSingleton, err = libstate.NewAggregator(filepath.Join(dirs.DataDir, "e4"), dirs.Tmp, ethconfig.HistoryV3AggregationStep, mode, trie)
+		_aggDomainSingleton, err = libstate.NewAggregator(filepath.Join(dirs.DataDir, "state"), dirs.Tmp, ethconfig.HistoryV3AggregationStep, mode, trie)
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -1275,13 +1275,11 @@ func allDomains(ctx context.Context, db kv.RoDB, mode libstate.CommitmentMode, t
 
 func newDomains(ctx context.Context, db kv.RwDB, mode libstate.CommitmentMode, trie commitment.TrieVariant) (consensus.Engine, ethconfig.Config, *snapshotsync.RoSnapshots, *libstate.Aggregator) {
 	historyV3, pm := kvcfg.HistoryV3.FromDB(db), fromdb.PruneMode(db)
-	//vmConfig := &vm.Config{}
-	//
 	//events := shards.NewEvents()
 	genesis := core.DefaultGenesisBlockByChainName(chain)
 
 	chainConfig, genesisBlock, genesisErr := core.CommitGenesisBlock(db, genesis, "")
-	_ = genesisBlock
+	_ = genesisBlock // TODO apply if needed here
 
 	if _, ok := genesisErr.(*chain2.ConfigCompatError); genesisErr != nil && !ok {
 		panic(genesisErr)
@@ -1306,13 +1304,11 @@ func newDomains(ctx context.Context, db kv.RwDB, mode libstate.CommitmentMode, t
 	//	cfg.Miner = *miningConfig
 	//}
 	cfg.Dirs = datadir.New(datadirCli)
+
 	allSn, agg := allDomains(ctx, db, mode, trie)
 	cfg.Snapshot = allSn.Cfg()
 
 	engine := initConsensusEngine(chainConfig, cfg.Dirs.DataDir, db)
-
-	//br := getBlockReader(db)
-
 	return engine, cfg, allSn, agg
 }
 

--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -5,12 +5,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/c2h5oh/datasize"
 	chain2 "github.com/ledgerwatch/erigon-lib/chain"
+	"github.com/ledgerwatch/erigon-lib/commitment"
 	common2 "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/common/cmp"
 	"github.com/ledgerwatch/erigon-lib/common/datadir"
@@ -479,6 +481,8 @@ func init() {
 
 	withDataDir2(cmdForceSetHistoryV3)
 	cmdForceSetHistoryV3.Flags().BoolVar(&_forceSetHistoryV3, "history.v3", false, "")
+	rootCmd.AddCommand(cmdForceSetHistoryV3)
+
 	rootCmd.AddCommand(cmdForceSetHistoryV3)
 
 	withDataDir(cmdSetPrune)
@@ -1225,6 +1229,91 @@ func getBlockReader(db kv.RoDB) (blockReader services.FullBlockReader) {
 		_blockReaderSingleton = snapshotsync.NewBlockReaderWithSnapshots(sn, transactionsV3)
 	})
 	return _blockReaderSingleton
+}
+
+var openDomainsOnce sync.Once
+var _aggDomainSingleton *libstate.Aggregator
+
+func allDomains(ctx context.Context, db kv.RoDB, mode libstate.CommitmentMode, trie commitment.TrieVariant) (*snapshotsync.RoSnapshots, *libstate.Aggregator) {
+	openDomainsOnce.Do(func() {
+		var useSnapshots bool
+		_ = db.View(context.Background(), func(tx kv.Tx) error {
+			useSnapshots, _ = snap.Enabled(tx)
+			return nil
+		})
+		dirs := datadir.New(datadirCli)
+		dir.MustExist(dirs.SnapHistory)
+
+		snapCfg := ethconfig.NewSnapCfg(useSnapshots, true, true)
+		_allSnapshotsSingleton = snapshotsync.NewRoSnapshots(snapCfg, dirs.Snap)
+
+		var err error
+		_aggDomainSingleton, err = libstate.NewAggregator(filepath.Join(dirs.DataDir, "e4"), dirs.Tmp, ethconfig.HistoryV3AggregationStep, mode, trie)
+		if err != nil {
+			panic(err)
+		}
+		if err = _aggDomainSingleton.ReopenFolder(); err != nil {
+			panic(err)
+		}
+
+		if useSnapshots {
+			if err := _allSnapshotsSingleton.ReopenFolder(); err != nil {
+				panic(err)
+			}
+			_allSnapshotsSingleton.LogStat()
+			//db.View(context.Background(), func(tx kv.Tx) error {
+			//	_aggSingleton.LogStats(tx, func(endTxNumMinimax uint64) uint64 {
+			//		_, histBlockNumProgress, _ := rawdbv3.TxNums.FindBlockNum(tx, endTxNumMinimax)
+			//		return histBlockNumProgress
+			//	})
+			//	return nil
+			//})
+		}
+	})
+	return _allSnapshotsSingleton, _aggDomainSingleton
+}
+
+func newDomains(ctx context.Context, db kv.RwDB, mode libstate.CommitmentMode, trie commitment.TrieVariant) (consensus.Engine, ethconfig.Config, *snapshotsync.RoSnapshots, *libstate.Aggregator) {
+	historyV3, pm := kvcfg.HistoryV3.FromDB(db), fromdb.PruneMode(db)
+	//vmConfig := &vm.Config{}
+	//
+	//events := shards.NewEvents()
+	genesis := core.DefaultGenesisBlockByChainName(chain)
+
+	chainConfig, genesisBlock, genesisErr := core.CommitGenesisBlock(db, genesis, "")
+	_ = genesisBlock
+
+	if _, ok := genesisErr.(*chain2.ConfigCompatError); genesisErr != nil && !ok {
+		panic(genesisErr)
+	}
+	//log.Info("Initialised chain configuration", "config", chainConfig)
+
+	// Apply special hacks for BSC params
+	if chainConfig.Parlia != nil {
+		params.ApplyBinanceSmartChainParams()
+	}
+
+	var batchSize datasize.ByteSize
+	must(batchSize.UnmarshalText([]byte(batchSizeStr)))
+
+	cfg := ethconfig.Defaults
+	cfg.HistoryV3 = historyV3
+	cfg.Prune = pm
+	cfg.BatchSize = batchSize
+	cfg.DeprecatedTxPool.Disable = true
+	cfg.Genesis = core.DefaultGenesisBlockByChainName(chain)
+	//if miningConfig != nil {
+	//	cfg.Miner = *miningConfig
+	//}
+	cfg.Dirs = datadir.New(datadirCli)
+	allSn, agg := allDomains(ctx, db, mode, trie)
+	cfg.Snapshot = allSn.Cfg()
+
+	engine := initConsensusEngine(chainConfig, cfg.Dirs.DataDir, db)
+
+	//br := getBlockReader(db)
+
+	return engine, cfg, allSn, agg
 }
 
 func newSync(ctx context.Context, db kv.RwDB, miningConfig *params.MiningConfig) (consensus.Engine, *vm.Config, *stagedsync.Sync, *stagedsync.Sync, stagedsync.MiningState) {

--- a/cmd/integration/commands/state_domains.go
+++ b/cmd/integration/commands/state_domains.go
@@ -208,7 +208,6 @@ func loopProcessDomains(chainDb, stateDb kv.RwDB, ctx context.Context) error {
 		default:
 		}
 	}
-	return nil
 }
 
 type blockProcessor struct {
@@ -341,8 +340,8 @@ func (b *blockProcessor) ProcessNext(ctx context.Context) error {
 }
 
 func (b *blockProcessor) applyBlock(
-	 ctx context.Context,
-	 block *types.Block,
+	ctx context.Context,
+	block *types.Block,
 ) (types.Receipts, error) {
 	//defer blockExecutionTimer.UpdateDuration(time.Now())
 

--- a/cmd/integration/commands/state_domains.go
+++ b/cmd/integration/commands/state_domains.go
@@ -1,0 +1,711 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"math/bits"
+	"runtime"
+	"time"
+
+	"github.com/holiman/uint256"
+	chain2 "github.com/ledgerwatch/erigon-lib/chain"
+	"github.com/ledgerwatch/erigon-lib/commitment"
+	libcommon "github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/common/dbg"
+	"github.com/ledgerwatch/erigon-lib/kv"
+	kv2 "github.com/ledgerwatch/erigon-lib/kv/mdbx"
+	libstate "github.com/ledgerwatch/erigon-lib/state"
+	"github.com/ledgerwatch/log/v3"
+	"github.com/spf13/cobra"
+
+	"github.com/ledgerwatch/erigon/cmd/hack/tool/fromdb"
+	"github.com/ledgerwatch/erigon/cmd/state/exec3"
+	"github.com/ledgerwatch/erigon/cmd/utils"
+	"github.com/ledgerwatch/erigon/consensus"
+	"github.com/ledgerwatch/erigon/consensus/misc"
+	"github.com/ledgerwatch/erigon/core"
+	"github.com/ledgerwatch/erigon/core/state"
+	"github.com/ledgerwatch/erigon/core/types"
+	"github.com/ledgerwatch/erigon/core/types/accounts"
+	"github.com/ledgerwatch/erigon/core/vm"
+	"github.com/ledgerwatch/erigon/eth/ethconfig"
+	"github.com/ledgerwatch/erigon/node/nodecfg"
+	erigoncli "github.com/ledgerwatch/erigon/turbo/cli"
+	"github.com/ledgerwatch/erigon/turbo/services"
+)
+
+func init() {
+	withDataDir(stateDomains)
+	withUnwind(stateDomains)
+	withUnwindEvery(stateDomains)
+	withBlock(stateDomains)
+	withIntegrityChecks(stateDomains)
+	withBatchSize(stateDomains)
+	withChain(stateDomains)
+	withHeimdall(stateDomains)
+	withWorkers(stateDomains)
+	withStartTx(stateDomains)
+	withCommitment(stateDomains)
+	withTraceFromTx(stateDomains)
+
+	rootCmd.AddCommand(stateDomains)
+}
+
+// if trie variant is not hex, we could not have another rootHash with to verify it
+var (
+	dirtySpaceThreshold       = uint64(2 * 1024 * 1024 * 1024) /* threshold of dirty space in MDBX transaction that triggers a commit */
+	blockRootMismatchExpected bool
+)
+
+var stateDomains = &cobra.Command{
+	Use:     "state_domains",
+	Short:   `Run block execution and commitment with Domains.`,
+	Example: "go run ./cmd/integration state_domains --datadir=... --verbosity=3 --unwind=100 --unwind.every=100000 --block=2000000",
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx, _ := libcommon.RootContext()
+		cfg := &nodecfg.DefaultConfig
+		utils.SetNodeConfigCobra(cmd, cfg)
+		ethConfig := &ethconfig.Defaults
+		ethConfig.Genesis = core.DefaultGenesisBlockByChainName(chain)
+		erigoncli.ApplyFlagsForEthConfigCobra(cmd.Flags(), ethConfig)
+
+		db := openDB(dbCfg(kv.ChainDB, chaindata), true)
+		defer db.Close()
+
+		if err := loopProcessDomains(db, ctx); err != nil {
+			if !errors.Is(err, context.Canceled) {
+				log.Error(err.Error())
+			}
+			return
+		}
+	},
+}
+
+func ParseTrieVariant(s string) commitment.TrieVariant {
+	var trieVariant commitment.TrieVariant
+	switch s {
+	case "bin":
+		trieVariant = commitment.VariantBinPatriciaTrie
+	case "hex":
+		fallthrough
+	default:
+		trieVariant = commitment.VariantHexPatriciaTrie
+	}
+	return trieVariant
+}
+
+func ParseCommitmentMode(s string) libstate.CommitmentMode {
+	var mode libstate.CommitmentMode
+	switch s {
+	case "off":
+		mode = libstate.CommitmentModeDisabled
+	case "update":
+		mode = libstate.CommitmentModeUpdate
+	default:
+		mode = libstate.CommitmentModeDirect
+	}
+	return mode
+}
+
+func loopProcessDomains(db kv.RwDB, ctx context.Context) error {
+	//dirs, pm := datadir.New(datadirCli), fromdb.PruneMode(db)
+	//sn, agg := allSnapshots(ctx, db)
+	//defer sn.Close()
+	//defer agg.Close()
+	//var batchSize datasize.ByteSize
+	//must(batchSize.UnmarshalText([]byte(batchSizeStr)))
+
+	trieVariant := ParseTrieVariant(commitmentTrie)
+	if trieVariant != commitment.VariantHexPatriciaTrie {
+		blockRootMismatchExpected = true
+	}
+	mode := ParseCommitmentMode(commitmentMode)
+
+	engine, _, _, agg := newDomains(ctx, db, mode, trieVariant)
+	defer agg.Close()
+
+	tx, err := db.BeginRw(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	must(tx.Commit())
+	tx, err = db.BeginRw(ctx)
+	must(err)
+	defer tx.Rollback()
+
+	agg.SetTx(tx)
+
+	latestTx, err := agg.SeekCommitment()
+	if err != nil && startTxNum != 0 {
+		return fmt.Errorf("failed to seek commitment to tx %d: %w", startTxNum, err)
+	}
+	if latestTx < startTxNum {
+		return fmt.Errorf("latest available tx to start is  %d and its less than start tx %d", latestTx, startTxNum)
+	}
+	fmt.Printf("Max txNum in files: %d\n", latestTx)
+
+	var (
+		interrupt bool
+		blockNum  uint64
+		txNum     uint64
+
+		readWrapper  = &ReaderWrapper4{ac: agg.MakeContext(), roTx: tx}
+		writeWrapper = &WriterWrapper4{w: agg}
+		started      = time.Now()
+	)
+
+	commitFn := func(txn uint64) error {
+		if db == nil || tx == nil {
+			return fmt.Errorf("commit failed due to invalid db/rwTx")
+		}
+		var spaceDirty uint64
+		if spaceDirty, _, err = tx.(*kv2.MdbxTx).SpaceDirty(); err != nil {
+			return fmt.Errorf("retrieving spaceDirty: %w", err)
+		}
+		if spaceDirty >= dirtySpaceThreshold {
+			log.Info("Initiated tx commit", "block", blockNum, "space dirty", libcommon.ByteCount(spaceDirty))
+		}
+		log.Info("database commitment", "block", blockNum, "txNum", txn, "uptime", time.Since(started))
+		if err := agg.Flush(ctx); err != nil {
+			return err
+		}
+		if err = tx.Commit(); err != nil {
+			return err
+		}
+		if interrupt {
+			return nil
+		}
+
+		if tx, err = db.BeginRw(ctx); err != nil {
+			return err
+		}
+
+		readWrapper.ac.Close()
+		agg.SetTx(tx)
+		readWrapper.roTx = tx
+		readWrapper.ac = agg.MakeContext()
+		return nil
+	}
+
+	blockReader := getBlockReader(db)
+	mergedRoots := agg.AggregatedRoots()
+
+	proc := blockProcessor{
+		chainConfig: fromdb.ChainConfig(db),
+		vmConfig:    vm.Config{},
+		engine:      engine,
+		reader:      readWrapper,
+		writer:      writeWrapper,
+		blockReader: blockReader,
+		getHeader: func(hash libcommon.Hash, number uint64) *types.Header {
+			h, err := blockReader.Header(ctx, tx /*, historyTx*/, hash, number)
+			if err != nil {
+				panic(err)
+			}
+			return h
+		},
+	}
+
+	if startTxNum == 0 {
+		genesis := core.DefaultGenesisBlockByChainName(chain)
+		if err := proc.ApplyGenesis(genesis); err != nil {
+			return err
+		}
+	}
+
+	for {
+		err := proc.ProcessNext(ctx, tx)
+		if err != nil {
+			return err
+		}
+
+		// Check for interrupts
+		select {
+		case <-ctx.Done():
+			interrupt = true
+			// Commit transaction only when interrupted or just before computing commitment (so it can be re-done)
+			if err := agg.Flush(ctx); err != nil {
+				log.Error("aggregator flush", "err", err)
+			}
+
+			log.Info(fmt.Sprintf("interrupted, please wait for cleanup, next time start with --tx %d", txNum))
+			if err := commitFn(txNum); err != nil {
+				log.Error("db commit", "err", err)
+			}
+			return nil
+		case <-mergedRoots:
+			if err := commitFn(txNum); err != nil {
+				log.Error("db commit on merge", "err", err)
+			}
+		default:
+		}
+	}
+	return nil
+}
+
+type blockProcessor struct {
+	vmConfig    vm.Config
+	chainConfig *chain2.Config
+	engine      consensus.Engine
+	agg         *libstate.Aggregator
+	trace       bool
+
+	blockReader services.FullBlockReader
+	writer      *WriterWrapper4
+	reader      *ReaderWrapper4
+
+	blockNum uint64
+	txNum    uint64
+
+	getHeader func(hash libcommon.Hash, number uint64) *types.Header
+}
+
+func (b *blockProcessor) ApplyGenesis(genesis *core.Genesis) error {
+	genBlock, genesisIbs, err := genesis.ToBlock("")
+	if err != nil {
+		return err
+	}
+	b.agg.SetTxNum(0)
+	if err = genesisIbs.CommitBlock(&chain2.Rules{}, b.writer); err != nil {
+		return fmt.Errorf("cannot write state: %w", err)
+	}
+
+	blockRootHash, err := b.agg.ComputeCommitment(true, false)
+	if err != nil {
+		return err
+	}
+	if err = b.agg.FinishTx(); err != nil {
+		return err
+	}
+
+	genesisRootHash := genBlock.Root()
+	if blockRootMismatchExpected && !bytes.Equal(blockRootHash, genesisRootHash[:]) {
+		return fmt.Errorf("genesis root hash mismatch: expected %x got %x", genesisRootHash, blockRootHash)
+	}
+	return nil
+}
+
+func (b *blockProcessor) blockHeader(hash libcommon.Hash, number uint64) *types.Header {
+	return b.getHeader(hash, number)
+}
+
+func (b *blockProcessor) ProcessNext(ctx context.Context, tx kv.RwTx) error {
+	b.blockNum++
+	b.trace = traceFromTx > 0 && b.txNum == traceFromTx
+	blockHash, err := b.blockReader.CanonicalHash(ctx, tx, b.blockNum)
+	if err != nil {
+		return err
+	}
+
+	block, _, err := b.blockReader.BlockWithSenders(ctx, tx, blockHash, b.blockNum)
+	if err != nil {
+		return err
+	}
+	if block == nil {
+		log.Info("history: block is nil", "block", b.blockNum)
+		return fmt.Errorf("block %d is nil", b.blockNum)
+	}
+
+	b.agg.SetTx(tx)
+	b.agg.SetTxNum(b.txNum)
+
+	if _, err = b.processBlock4(startTxNum, b.reader, b.writer, block); err != nil {
+		log.Error("processing error", "block", b.blockNum, "err", err)
+		return fmt.Errorf("processing block %d: %w", b.blockNum, err)
+	}
+	return err
+}
+
+func (b *blockProcessor) processBlock4(
+	startTxNum uint64,
+	rw *ReaderWrapper4,
+	ww *WriterWrapper4,
+	block *types.Block,
+) (types.Receipts, error) {
+	//defer blockExecutionTimer.UpdateDuration(time.Now())
+
+	header := block.Header()
+	b.vmConfig.Debug = true
+	gp := new(core.GasPool).AddGas(block.GasLimit())
+	usedGas := new(uint64)
+	var receipts types.Receipts
+	rules := b.chainConfig.Rules(block.NumberU64(), block.Time())
+
+	rw.blockNum = block.NumberU64()
+	ww.SetBlockNum(block.NumberU64())
+	ww.SetTxNum(b.txNum)
+
+	daoFork := b.txNum >= startTxNum && b.chainConfig.DAOForkSupport && b.chainConfig.DAOForkBlock != nil && b.chainConfig.DAOForkBlock.Cmp(block.Number()) == 0
+	if daoFork {
+		ibs := state.New(rw)
+		// TODO Actually add tracing to the DAO related accounts
+		misc.ApplyDAOHardFork(ibs)
+		if err := ibs.FinalizeTx(rules, ww); err != nil {
+			return nil, err
+		}
+		if err := ww.w.FinishTx(); err != nil {
+			return nil, fmt.Errorf("finish daoFork failed: %w", err)
+		}
+	}
+
+	b.txNum++ // Pre-block transaction
+	ww.SetTxNum(b.txNum)
+	if err := ww.w.FinishTx(); err != nil {
+		return nil, fmt.Errorf("finish pre-block tx %d (block %d) has failed: %w", b.txNum, block.NumberU64(), err)
+	}
+
+	getHashFn := core.GetHashFn(header, b.getHeader)
+
+	for i, tx := range block.Transactions() {
+		if b.txNum >= startTxNum {
+			ibs := state.New(rw)
+			ibs.Prepare(tx.Hash(), block.Hash(), i)
+			ct := exec3.NewCallTracer()
+			b.vmConfig.Tracer = ct
+			receipt, _, err := core.ApplyTransaction(b.chainConfig, getHashFn, b.engine, nil, gp, ibs, ww, header, tx, usedGas, b.vmConfig)
+			if err != nil {
+				return nil, fmt.Errorf("could not apply tx %d [%x] failed: %w", i, tx.Hash(), err)
+			}
+			for from := range ct.Froms() {
+				if err := ww.w.AddTraceFrom(from[:]); err != nil {
+					return nil, err
+				}
+			}
+			for to := range ct.Tos() {
+				if err := ww.w.AddTraceTo(to[:]); err != nil {
+					return nil, err
+				}
+			}
+			receipts = append(receipts, receipt)
+			for _, log := range receipt.Logs {
+				if err = ww.w.AddLogAddr(log.Address[:]); err != nil {
+					return nil, fmt.Errorf("adding event log for addr %x: %w", log.Address, err)
+				}
+				for _, topic := range log.Topics {
+					if err = ww.w.AddLogTopic(topic[:]); err != nil {
+						return nil, fmt.Errorf("adding event log for topic %x: %w", topic, err)
+					}
+				}
+			}
+			if err = ww.w.FinishTx(); err != nil {
+				return nil, fmt.Errorf("finish tx %d [%x] failed: %w", i, tx.Hash(), err)
+			}
+			if b.trace {
+				fmt.Printf("FinishTx called for blockNum=%d, txIndex=%d, txNum=%d txHash=[%x]\n", b.blockNum, i, b.txNum, tx.Hash())
+			}
+		}
+		b.txNum++
+		ww.SetTxNum(b.txNum)
+	}
+
+	if b.txNum >= startTxNum {
+		if b.chainConfig.IsByzantium(block.NumberU64()) {
+			receiptSha := types.DeriveSha(receipts)
+			if receiptSha != block.ReceiptHash() {
+				fmt.Printf("mismatched receipt headers for block %d\n", block.NumberU64())
+				for j, receipt := range receipts {
+					fmt.Printf("tx %d, used gas: %d\n", j, receipt.GasUsed)
+				}
+			}
+		}
+		ibs := state.New(rw)
+		if err := ww.w.AddTraceTo(block.Coinbase().Bytes()); err != nil {
+			return nil, fmt.Errorf("adding coinbase trace: %w", err)
+		}
+		for _, uncle := range block.Uncles() {
+			if err := ww.w.AddTraceTo(uncle.Coinbase.Bytes()); err != nil {
+				return nil, fmt.Errorf("adding uncle trace: %w", err)
+			}
+		}
+
+		// Finalize the block, applying any consensus engine specific extras (e.g. block rewards)
+		if _, _, err := b.engine.Finalize(b.chainConfig, header, ibs, block.Transactions(), block.Uncles(), receipts, block.Withdrawals(), nil, nil, nil); err != nil {
+			return nil, fmt.Errorf("finalize of block %d failed: %w", block.NumberU64(), err)
+		}
+
+		if err := ibs.CommitBlock(rules, ww); err != nil {
+			return nil, fmt.Errorf("committing block %d failed: %w", block.NumberU64(), err)
+		}
+
+		if err := ww.w.FinishTx(); err != nil {
+			return nil, fmt.Errorf("failed to finish tx: %w", err)
+		}
+		if b.trace {
+			fmt.Printf("FinishTx called for %d block %d\n", b.txNum, block.NumberU64())
+		}
+	}
+
+	b.txNum++ // Post-block transaction
+	ww.SetTxNum(b.txNum)
+	if b.txNum >= startTxNum {
+		if block.Number().Uint64()%uint64(commitmentFreq) == 0 {
+			rootHash, err := ww.w.ComputeCommitment(true, b.trace)
+			if err != nil {
+				return nil, err
+			}
+			if !blockRootMismatchExpected && !bytes.Equal(rootHash, header.Root[:]) {
+				return nil, fmt.Errorf("invalid root hash for block %d: expected %x got %x", block.NumberU64(), header.Root, rootHash)
+			}
+		}
+
+		if err := ww.w.FinishTx(); err != nil {
+			return nil, fmt.Errorf("finish after-block tx %d (block %d) has failed: %w", b.txNum, block.NumberU64(), err)
+		}
+	}
+
+	return receipts, nil
+}
+
+// Implements StateReader and StateWriter
+type ReaderWrapper4 struct {
+	roTx     kv.Tx
+	ac       *libstate.AggregatorContext
+	blockNum uint64
+}
+
+type WriterWrapper4 struct {
+	w               *libstate.Aggregator
+	blockNum, txNum uint64
+	stat            stat4
+}
+
+type stat4 struct {
+	prevBlock    uint64
+	blockNum     uint64
+	hits         uint64
+	misses       uint64
+	hitMissRatio float64
+	blockSpeed   float64
+	txSpeed      float64
+	prevTxNum    uint64
+	txNum        uint64
+	prevTime     time.Time
+	mem          runtime.MemStats
+}
+
+func (ww *WriterWrapper4) PrintStatsLoop(ctx context.Context, interval time.Duration, logger log.Logger) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			ww.stat.delta(ww.blockNum, ww.txNum).print(ww.w.Stats(), logger)
+		}
+	}
+}
+
+func (s *stat4) print(aStats libstate.FilesStats, logger log.Logger) {
+	totalFiles := aStats.FilesCount
+	totalDatSize := aStats.DataSize
+	totalIdxSize := aStats.IdxSize
+
+	logger.Info("Progress", "block", s.blockNum, "blk/s", s.blockSpeed, "tx", s.txNum, "txn/s", s.txSpeed, "state files", totalFiles,
+		"total dat", libcommon.ByteCount(totalDatSize), "total idx", libcommon.ByteCount(totalIdxSize),
+		"hit ratio", s.hitMissRatio, "hits+misses", s.hits+s.misses,
+		"alloc", libcommon.ByteCount(s.mem.Alloc), "sys", libcommon.ByteCount(s.mem.Sys),
+	)
+}
+
+func (s *stat4) delta(blockNum, txNum uint64) *stat4 {
+	currentTime := time.Now()
+	dbg.ReadMemStats(&s.mem)
+
+	interval := currentTime.Sub(s.prevTime).Seconds()
+	s.blockNum = blockNum
+	s.blockSpeed = float64(s.blockNum-s.prevBlock) / interval
+	s.txNum = txNum
+	s.txSpeed = float64(s.txNum-s.prevTxNum) / interval
+	s.prevBlock = blockNum
+	s.prevTxNum = txNum
+	s.prevTime = currentTime
+
+	total := s.hits + s.misses
+	if total > 0 {
+		s.hitMissRatio = float64(s.hits) / float64(total)
+	}
+	return s
+}
+
+func (rw *ReaderWrapper4) ReadAccountData(address libcommon.Address) (*accounts.Account, error) {
+	enc, err := rw.ac.ReadAccountData(address.Bytes(), rw.roTx)
+	if err != nil {
+		return nil, err
+	}
+	if len(enc) == 0 {
+		return nil, nil
+	}
+	var a accounts.Account
+	a.Reset()
+	pos := 0
+	nonceBytes := int(enc[pos])
+	pos++
+	if nonceBytes > 0 {
+		a.Nonce = bytesToUint64(enc[pos : pos+nonceBytes])
+		pos += nonceBytes
+	}
+	balanceBytes := int(enc[pos])
+	pos++
+	if balanceBytes > 0 {
+		a.Balance.SetBytes(enc[pos : pos+balanceBytes])
+		pos += balanceBytes
+	}
+	codeHashBytes := int(enc[pos])
+	pos++
+	if codeHashBytes > 0 {
+		copy(a.CodeHash[:], enc[pos:pos+codeHashBytes])
+		pos += codeHashBytes
+	}
+	incBytes := int(enc[pos])
+	pos++
+	if incBytes > 0 {
+		a.Incarnation = bytesToUint64(enc[pos : pos+incBytes])
+	}
+	return &a, nil
+}
+
+func (rw *ReaderWrapper4) ReadAccountStorage(address libcommon.Address, incarnation uint64, key *libcommon.Hash) ([]byte, error) {
+	enc, err := rw.ac.ReadAccountStorage(address.Bytes(), key.Bytes(), rw.roTx)
+	if err != nil {
+		return nil, err
+	}
+	if enc == nil {
+		return nil, nil
+	}
+	if len(enc) == 1 && enc[0] == 0 {
+		return nil, nil
+	}
+	return enc, nil
+}
+
+func (rw *ReaderWrapper4) ReadAccountCode(address libcommon.Address, incarnation uint64, codeHash libcommon.Hash) ([]byte, error) {
+	return rw.ac.ReadAccountCode(address.Bytes(), rw.roTx)
+}
+
+func (rw *ReaderWrapper4) ReadAccountCodeSize(address libcommon.Address, incarnation uint64, codeHash libcommon.Hash) (int, error) {
+	return rw.ac.ReadAccountCodeSize(address.Bytes(), rw.roTx)
+}
+
+func (rw *ReaderWrapper4) ReadAccountIncarnation(address libcommon.Address) (uint64, error) {
+	return 0, nil
+}
+
+func (ww *WriterWrapper4) UpdateAccountData(address libcommon.Address, original, account *accounts.Account) error {
+	var l int
+	l++
+	if account.Nonce > 0 {
+		l += (bits.Len64(account.Nonce) + 7) / 8
+	}
+	l++
+	if !account.Balance.IsZero() {
+		l += account.Balance.ByteLen()
+	}
+	l++
+	if !account.IsEmptyCodeHash() {
+		l += 32
+	}
+	l++
+	if account.Incarnation > 0 {
+		l += (bits.Len64(account.Incarnation) + 7) / 8
+	}
+	value := make([]byte, l)
+	pos := 0
+
+	if account.Nonce == 0 {
+		value[pos] = 0
+		pos++
+	} else {
+		nonceBytes := (bits.Len64(account.Nonce) + 7) / 8
+		value[pos] = byte(nonceBytes)
+		var nonce = account.Nonce
+		for i := nonceBytes; i > 0; i-- {
+			value[pos+i] = byte(nonce)
+			nonce >>= 8
+		}
+		pos += nonceBytes + 1
+	}
+	if account.Balance.IsZero() {
+		value[pos] = 0
+		pos++
+	} else {
+		balanceBytes := account.Balance.ByteLen()
+		value[pos] = byte(balanceBytes)
+		pos++
+		account.Balance.WriteToSlice(value[pos : pos+balanceBytes])
+		pos += balanceBytes
+	}
+	if account.IsEmptyCodeHash() {
+		value[pos] = 0
+		pos++
+	} else {
+		value[pos] = 32
+		pos++
+		copy(value[pos:pos+32], account.CodeHash[:])
+		pos += 32
+	}
+	if account.Incarnation == 0 {
+		value[pos] = 0
+	} else {
+		incBytes := (bits.Len64(account.Incarnation) + 7) / 8
+		value[pos] = byte(incBytes)
+		var inc = account.Incarnation
+		for i := incBytes; i > 0; i-- {
+			value[pos+i] = byte(inc)
+			inc >>= 8
+		}
+	}
+	if err := ww.w.UpdateAccountData(address.Bytes(), value); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (ww *WriterWrapper4) UpdateAccountCode(address libcommon.Address, incarnation uint64, codeHash libcommon.Hash, code []byte) error {
+	if err := ww.w.UpdateAccountCode(address.Bytes(), code); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (ww *WriterWrapper4) DeleteAccount(address libcommon.Address, original *accounts.Account) error {
+	if err := ww.w.DeleteAccount(address.Bytes()); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (ww *WriterWrapper4) WriteAccountStorage(address libcommon.Address, incarnation uint64, key *libcommon.Hash, original, value *uint256.Int) error {
+	if err := ww.w.WriteAccountStorage(address.Bytes(), key.Bytes(), value.Bytes()); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (ww *WriterWrapper4) CreateContract(address libcommon.Address) error {
+	return nil
+}
+
+func (ww *WriterWrapper4) SetBlockNum(blockNum uint64) {
+	ww.blockNum = blockNum
+}
+
+func (ww *WriterWrapper4) SetTxNum(txNum uint64) {
+	ww.txNum = txNum
+	ww.w.SetTxNum(txNum)
+}
+
+func bytesToUint64(buf []byte) (x uint64) {
+	for i, b := range buf {
+		x = x<<8 + uint64(b)
+		if i == 7 {
+			return
+		}
+	}
+	return
+}

--- a/cmd/state/commands/erigon4.go
+++ b/cmd/state/commands/erigon4.go
@@ -108,6 +108,7 @@ func Erigon4(genesis *core.Genesis, chainConfig *chain2.Config, logger log.Logge
 		return err1
 	}
 	defer historyTx.Rollback()
+
 	stateDbPath := path.Join(datadirCli, "db4")
 	if _, err = os.Stat(stateDbPath); err != nil {
 		if !errors.Is(err, os.ErrNotExist) {


### PR DESCRIPTION
added subcommand `state_domains` of `bin/integration` to start processing of existing chaindata with use of state domains and commitment.
It creates two directory in `datadir`: `state` and `statedb` for files and mdbx respectively. 

This version runs blocks one after another and produces merged files. 
Want to add some metrics to export later. 