### PR TITLE
Fix broken link in doc

### DIFF
--- a/docs/programmers_guide/dupsort.md
+++ b/docs/programmers_guide/dupsort.md
@@ -153,7 +153,8 @@ Erigon
 This article target is to show tricky concepts on examples. Future
 reading [here](./db_walkthrough.MD#table-history-of-accounts)
 
-Erigon supports multiple typed cursors, see [AbstractKV.md](./../../ethdb/AbstractKV.md)
+Erigon supports multiple typed cursors, see the [KV
+Readme.md](https://github.com/ledgerwatch/erigon-lib/tree/main/kv)
 
 
 


### PR DESCRIPTION
The doc in [dupsort.md](https://github.com/ledgerwatch/erigon/blob/devel/docs/programmers_guide/dupsort.md#erigon) points to a non-existent `AbstractKV.md`

As best as I can tell, the `AbstractKV.md` was reworked and renamed in commit

0bc61c06edd1d2de3d9376736e0e4f4f4e7b9ed1

then, this was later moved into erigon-lib.  This commit simply repoints the doc at this new location.