### PR TITLE
get localnode address up front on creation to save potential data race

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -196,12 +196,13 @@ type Server struct {
 	peerFeed     event.Feed
 	log          log.Logger
 
-	nodedb    *enode.DB
-	localnode *enode.LocalNode
-	ntab      *discover.UDPv4
-	DiscV5    *discover.UDPv5
-	discmix   *enode.FairMix
-	dialsched *dialScheduler
+	nodedb           *enode.DB
+	localnode        *enode.LocalNode
+	localnodeAddress string
+	ntab             *discover.UDPv4
+	DiscV5           *discover.UDPv5
+	discmix          *enode.FairMix
+	dialsched        *dialScheduler
 
 	// Channels into the run loop.
 	quitCtx                 context.Context
@@ -545,6 +546,7 @@ func (srv *Server) setupLocalNode() error {
 	srv.nodedb = db
 	srv.localnode = enode.NewLocalNode(db, srv.PrivateKey)
 	srv.localnode.SetFallbackIP(net.IP{127, 0, 0, 1})
+	srv.localnodeAddress = srv.localnode.Node().URLv4()
 	// TODO: check conflicts
 	for _, p := range srv.Protocols {
 		for _, e := range p.Attributes {
@@ -745,7 +747,7 @@ func (srv *Server) doPeerOp(fn peerOpFunc) {
 func (srv *Server) run() {
 	defer debug.LogPanic()
 	if len(srv.Config.Protocols) > 0 {
-		srv.log.Info("Started P2P networking", "version", srv.Config.Protocols[0].Version, "self", srv.localnode.Node().URLv4(), "name", srv.Name)
+		srv.log.Info("Started P2P networking", "version", srv.Config.Protocols[0].Version, "self", srv.localnodeAddress, "name", srv.Name)
 	}
 	defer srv.loopWG.Done()
 	defer srv.nodedb.Close()


### PR DESCRIPTION
the log line here was the culprit for the race.  made sense to just capture this on localnode creation instead and hold onto it for when the server is started.

ran test with `-race` and `-count=5000` to double check and all looks good