### PR TITLE
simplify DecodeRLP for some types

### DIFF
--- a/core/types/dynamic_fee_tx.go
+++ b/core/types/dynamic_fee_tx.go
@@ -317,60 +317,15 @@ func (tx *DynamicFeeTransaction) DecodeRLP(s *rlp.Stream) error {
 	if err != nil {
 		return err
 	}
-	var b []byte
-	if b, err = s.Uint256Bytes(); err != nil {
+	if err = s.DecodeMany(&tx.ChainID, &tx.Nonce, &tx.Tip, &tx.FeeCap, &tx.Gas); err != nil {
 		return err
 	}
-	tx.ChainID = new(uint256.Int).SetBytes(b)
-	if tx.Nonce, err = s.Uint(); err != nil {
+	if err = s.DecodeOptional(&tx.To); err != nil {
 		return err
 	}
-	if b, err = s.Uint256Bytes(); err != nil {
+	if err = s.DecodeMany(&tx.Value, &tx.Data, &tx.AccessList, &tx.V, &tx.R, &tx.S); err != nil {
 		return err
 	}
-	tx.Tip = new(uint256.Int).SetBytes(b)
-	if b, err = s.Uint256Bytes(); err != nil {
-		return err
-	}
-	tx.FeeCap = new(uint256.Int).SetBytes(b)
-	if tx.Gas, err = s.Uint(); err != nil {
-		return err
-	}
-	if b, err = s.Bytes(); err != nil {
-		return err
-	}
-	if len(b) > 0 && len(b) != 20 {
-		return fmt.Errorf("wrong size for To: %d", len(b))
-	}
-	if len(b) > 0 {
-		tx.To = &libcommon.Address{}
-		copy((*tx.To)[:], b)
-	}
-	if b, err = s.Uint256Bytes(); err != nil {
-		return err
-	}
-	tx.Value = new(uint256.Int).SetBytes(b)
-	if tx.Data, err = s.Bytes(); err != nil {
-		return err
-	}
-	// decode AccessList
-	tx.AccessList = types2.AccessList{}
-	if err = decodeAccessList(&tx.AccessList, s); err != nil {
-		return err
-	}
-	// decode V
-	if b, err = s.Uint256Bytes(); err != nil {
-		return err
-	}
-	tx.V.SetBytes(b)
-	if b, err = s.Uint256Bytes(); err != nil {
-		return err
-	}
-	tx.R.SetBytes(b)
-	if b, err = s.Uint256Bytes(); err != nil {
-		return err
-	}
-	tx.S.SetBytes(b)
 	return s.ListEnd()
 }
 

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -152,7 +152,7 @@ func DecodeTransaction(s *rlp.Stream) (Transaction, error) {
 		tx = t
 	case DynamicFeeTxType:
 		t := &DynamicFeeTransaction{}
-		if err = t.DecodeRLP(s); err != nil {
+		if err = s.Decode(t); err != nil {
 			return nil, err
 		}
 		tx = t

--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -871,6 +871,30 @@ func (s *Stream) ListEnd() error {
 	return nil
 }
 
+// Like Decode, but ignores empty values
+func (s *Stream) DecodeOptional(val interface{}) error {
+	_, size, err := s.Kind()
+	if err != nil {
+		return err
+	}
+	if size > 0 {
+		return s.Decode(val)
+	} else {
+		s.Bytes() // ignore it
+		return nil
+	}
+}
+
+func (s *Stream) DecodeMany(vals ...interface{}) error {
+	for _, val := range vals {
+		err := s.Decode(val)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Decode decodes a value and stores the result in the value pointed
 // to by val. Please see the documentation for the Decode function
 // to learn about the decoding rules.


### PR DESCRIPTION
Hi,

I was going through types to learn how they work and saw that `DecodeRLP` is pretty complex for some types but can be simplified in some cases. This is a partial PR to demonstrate an idea. If you like I can open another PR to do the same to the other implementations.
This is just a refactor suggestion, feel free to close.