### PR TITLE
fix(release): download page https redirect

### DIFF
--- a/cmd/release/docker-compose.yml
+++ b/cmd/release/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - "--certificatesresolvers.letsencrypt.acme.email=max.revitt@gateway.fm"
       - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
       - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web"
+      - "--middlewares.redirectscheme.scheme=https"
     ports:
       - "80:80"
       - "443:443"
@@ -27,12 +28,15 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=traefik"
-      - "traefik.frontend.rule=Host:download.erigon.ch"
-      - "traefik.frontend.redirect.entryPoint=https"
-      - "traefik.http.routers.app.rule=Host(`download.erigon.ch`)"
-      - "traefik.http.routers.app.entrypoints=web,websecure"
-      - "traefik.http.routers.app.tls=true"
-      - "traefik.http.routers.app.tls.certresolver=letsencrypt"
+      - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
+      - "traefik.http.middlewares.redirect-to-https.redirectscheme.permanent=true"
+      - "traefik.http.routers.app-insecure.rule=Host(`download.erigon.ch`)"
+      - "traefik.http.routers.app-insecure.entrypoints=web"
+      - "traefik.http.routers.app-insecure.middlewares=redirect-to-https"
+      - "traefik.http.routers.app-secure.rule=Host(`download.erigon.ch`)"
+      - "traefik.http.routers.app-secure.entrypoints=websecure"
+      - "traefik.http.routers.app-secure.tls=true"
+      - "traefik.http.routers.app-secure.tls.certresolver=letsencrypt"
       - "traefik.http.services.app.loadbalancer.server.port=80"
     networks:
       - traefik

--- a/cmd/release/main.go
+++ b/cmd/release/main.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/go-version"
 )
 
 type Binary struct {


### PR DESCRIPTION
Updated initial traefik config so the http -> https redirect on download.erigon.sh will work.