### PR TITLE
Total difficulty can be huge on Gnosis

### DIFF
--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -394,15 +394,7 @@ func (nbp *NewBlockPacket) DecodeRLP(s *rlp.Stream) error {
 
 // SanityCheck verifies that the values are reasonable, as a DoS protection
 func (request *NewBlockPacket) SanityCheck() error {
-	if err := request.Block.SanityCheck(); err != nil {
-		return err
-	}
-	//TD at mainnet block #7753254 is 76 bits. If it becomes 100 million times
-	// larger, it will still fit within 100 bits
-	if tdLen := request.TD.BitLen(); tdLen > 100 {
-		return fmt.Errorf("too large block TD: bitlen %d", tdLen)
-	}
-	return nil
+	return request.Block.SanityCheck()
 }
 
 // GetBlockBodiesPacket represents a block body query.


### PR DESCRIPTION
This fixes the following issue observed on gnosis_withdrawals_devnet_2:
```
[DBUG] [03-21|09:24:15.060] Handling incoming message                stream=RecvMessage err="newBlock66: too large block TD: bitlen 144"
```