### PR TITLE
[Gnosis] Don't call ExecuteSystemWithdrawals before Shanghai

### DIFF
--- a/consensus/serenity/serenity.go
+++ b/consensus/serenity/serenity.go
@@ -134,8 +134,10 @@ func (s *Serenity) Finalize(config *chain.Config, header *types.Header, state *s
 		if err := auraEngine.ApplyRewards(header, state, syscall); err != nil {
 			return nil, nil, err
 		}
-		if err := auraEngine.ExecuteSystemWithdrawals(withdrawals, syscall); err != nil {
-			return nil, nil, err
+		if withdrawals != nil {
+			if err := auraEngine.ExecuteSystemWithdrawals(withdrawals, syscall); err != nil {
+				return nil, nil, err
+			}
 		}
 	} else {
 		for _, w := range withdrawals {


### PR DESCRIPTION
This is a patch to PR #6940. Withdrawal contract should not be called for pre-Shanghai block. The issue was found on gnosis_withdrawals_devnet_2. 