### PR TITLE
to fix txpool startup race

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -610,8 +610,6 @@ func New(stack *node.Node, config *ethconfig.Config, logger log.Logger) (*Ethere
 	// 1) Hive tests requires us to do so and starting it from eth_sendRawTransaction is not viable as we have not enough data
 	// to initialize it properly.
 	// 2) we cannot propose for block 1 regardless.
-	//go func() {
-	//	time.Sleep(10 * time.Millisecond)
 	{
 		baseFee := uint64(0)
 		if currentBlock.BaseFee() != nil {
@@ -620,7 +618,6 @@ func New(stack *node.Node, config *ethconfig.Config, logger log.Logger) (*Ethere
 		backend.notifications.Accumulator.StartChange(currentBlock.NumberU64(), currentBlock.Hash(), nil, false)
 		backend.notifications.Accumulator.SendAndReset(ctx, backend.notifications.StateChangesConsumer, baseFee, currentBlock.GasLimit())
 	}
-	//}()
 
 	if !config.DeprecatedTxPool.Disable {
 		backend.txPool2Fetch.ConnectCore()

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -610,16 +610,17 @@ func New(stack *node.Node, config *ethconfig.Config, logger log.Logger) (*Ethere
 	// 1) Hive tests requires us to do so and starting it from eth_sendRawTransaction is not viable as we have not enough data
 	// to initialize it properly.
 	// 2) we cannot propose for block 1 regardless.
-	go func() {
-		time.Sleep(10 * time.Millisecond)
+	//go func() {
+	//	time.Sleep(10 * time.Millisecond)
+	{
 		baseFee := uint64(0)
 		if currentBlock.BaseFee() != nil {
 			baseFee = currentBlock.BaseFee().Uint64()
 		}
 		backend.notifications.Accumulator.StartChange(currentBlock.NumberU64(), currentBlock.Hash(), nil, false)
 		backend.notifications.Accumulator.SendAndReset(ctx, backend.notifications.StateChangesConsumer, baseFee, currentBlock.GasLimit())
-
-	}()
+	}
+	//}()
 
 	if !config.DeprecatedTxPool.Disable {
 		backend.txPool2Fetch.ConnectCore()


### PR DESCRIPTION
```

==================
WARNING: DATA RACE
Write at 0x00c0005dc570 by goroutine 273633:
  github.com/ledgerwatch/erigon/turbo/shards.(*Accumulator).Reset()
      github.com/ledgerwatch/erigon/turbo/shards/state_change_accumulator.go:32 +0x5ec
  github.com/ledgerwatch/erigon/turbo/stages.StageLoopStep()
      github.com/ledgerwatch/erigon/turbo/stages/stageloop.go:163 +0x3bd
  github.com/ledgerwatch/erigon/turbo/stages.StageLoop()
      github.com/ledgerwatch/erigon/turbo/stages/stageloop.go:94 +0x197
  github.com/ledgerwatch/erigon/eth.(*Ethereum).Start.func1()
      github.com/ledgerwatch/erigon/eth/backend.go:1058 +0x10b

Previous write at 0x00c0005dc570 by goroutine 273468:
  github.com/ledgerwatch/erigon/turbo/shards.(*Accumulator).Reset()
      github.com/ledgerwatch/erigon/turbo/shards/state_change_accumulator.go:32 +0x2ef
  github.com/ledgerwatch/erigon/turbo/shards.(*Accumulator).SendAndReset()
      github.com/ledgerwatch/erigon/turbo/shards/state_change_accumulator.go:41 +0x228
  github.com/ledgerwatch/erigon/eth.New.func8()
      github.com/ledgerwatch/erigon/eth/backend.go:620 +0x80e

```