### PR TITLE
Add storage proof support to eth_getProof

### DIFF
--- a/cmd/rpcdaemon/README.md
+++ b/cmd/rpcdaemon/README.md
@@ -255,7 +255,7 @@ The following table shows the current implementation status of Erigon's RPC daem
 | eth_signTransaction                        | -       | not yet implemented                  |
 | eth_signTypedData                          | -       | ????                                 |
 |                                            |         |                                      |
-| eth_getProof                               | -       | not yet implemented                  |
+| eth_getProof                               | Yes     | Limited to last 1000 blocks          |
 |                                            |         |                                      |
 | eth_mining                                 | Yes     | returns true if --mine flag provided |
 | eth_coinbase                               | Yes     |                                      |

--- a/cmd/rpcdaemon/commands/eth_call_test.go
+++ b/cmd/rpcdaemon/commands/eth_call_test.go
@@ -184,15 +184,18 @@ func decodeNode(t *testing.T, encoded []byte) any {
 }
 
 // proofMap creates a map from hash to proof node
-func proofMap(t *testing.T, proof []hexutil.Bytes) map[libcommon.Hash]any {
+func proofMap(t *testing.T, proof []hexutil.Bytes) (map[libcommon.Hash]any, map[libcommon.Hash][]byte) {
 	res := map[libcommon.Hash]any{}
+	raw := map[libcommon.Hash][]byte{}
 	for _, proofB := range proof {
-		res[crypto.Keccak256Hash(proofB)] = decodeNode(t, proofB)
+		hash := crypto.Keccak256Hash(proofB)
+		res[hash] = decodeNode(t, proofB)
+		raw[hash] = proofB
 	}
-	return res
+	return res, raw
 }
 
-func verifyProof(t *testing.T, root libcommon.Hash, key []byte, proofs map[libcommon.Hash]any) []byte {
+func verifyProof(t *testing.T, root libcommon.Hash, key []byte, proofs map[libcommon.Hash]any, used map[libcommon.Hash][]byte) []byte {
 	t.Helper()
 	key = (&trie.Keybytes{Data: key}).ToHex()
 	var node any = hashNode(root)
@@ -210,8 +213,12 @@ func verifyProof(t *testing.T, root libcommon.Hash, key []byte, proofs map[libco
 			var ok bool
 			node, ok = proofs[libcommon.Hash(nt)]
 			require.True(t, ok, "missing hash %x", nt)
+			delete(used, libcommon.Hash(nt))
 		case valueNode:
 			require.Len(t, key, 0)
+			for hash, raw := range used {
+				require.Failf(t, "not all proof elements were used", "hash=%x value=%x decoded=%#v", hash, raw, proofs[hash])
+			}
 			return nt
 		default:
 			t.Fatalf("unexpected type: %T", node)
@@ -222,8 +229,8 @@ func verifyProof(t *testing.T, root libcommon.Hash, key []byte, proofs map[libco
 func verifyAccountProof(t *testing.T, stateRoot libcommon.Hash, proof *accounts.AccProofResult) {
 	t.Helper()
 	accountKey := crypto.Keccak256(proof.Address[:])
-	pm := proofMap(t, proof.AccountProof)
-	value := verifyProof(t, stateRoot, accountKey, pm)
+	pm, used := proofMap(t, proof.AccountProof)
+	value := verifyProof(t, stateRoot, accountKey, pm, used)
 
 	expected, err := rlp.EncodeToBytes([]any{
 		uint64(proof.Nonce),
@@ -240,8 +247,8 @@ func verifyStorageProof(t *testing.T, storageRoot libcommon.Hash, proof accounts
 	t.Helper()
 
 	storageKey := crypto.Keccak256(proof.Key[:])
-	pm := proofMap(t, proof.Proof)
-	value := verifyProof(t, storageRoot, storageKey, pm)
+	pm, used := proofMap(t, proof.Proof)
+	value := verifyProof(t, storageRoot, storageKey, pm, used)
 
 	expected, err := rlp.EncodeToBytes(proof.Value.ToInt().Bytes())
 	require.NoError(t, err)
@@ -252,7 +259,7 @@ func verifyStorageProof(t *testing.T, storageRoot libcommon.Hash, proof accounts
 func TestGetProof(t *testing.T) {
 	maxGetProofRewindBlockCount = 1 // Note, this is unsafe for parallel tests, but, this test is the only consumer for now
 
-	m, bankAddress, _ := chainWithDeployedContract(t)
+	m, bankAddr, contractAddr := chainWithDeployedContract(t)
 	br := snapshotsync.NewBlockReaderWithSnapshots(m.BlockSnapshots, m.TransactionsV3)
 
 	if m.HistoryV3 {
@@ -263,28 +270,47 @@ func TestGetProof(t *testing.T) {
 	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
 	api := NewEthAPI(NewBaseApi(nil, stateCache, br, agg, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs), m.DB, nil, nil, nil, 5000000, 100_000)
 
+	key := func(b byte) libcommon.Hash {
+		result := libcommon.Hash{}
+		result[31] = b
+		return result
+	}
+
 	tests := []struct {
 		name        string
 		blockNum    uint64
+		addr        libcommon.Address
 		storageKeys []libcommon.Hash
+		stateVal    uint64
 		expectedErr string
 	}{
 		{
-			name:     "currentBlock",
+			name:     "currentBlockNoState",
+			addr:     contractAddr,
 			blockNum: 3,
 		},
 		{
-			name:        "withState",
-			blockNum:    3,
-			storageKeys: []libcommon.Hash{{1}},
-			expectedErr: "the method is currently not implemented: eth_getProof with storageKeys",
+			name:     "currentBlockEOA",
+			addr:     bankAddr,
+			blockNum: 3,
 		},
 		{
-			name:     "olderBlock",
-			blockNum: 2,
+			name:        "currentBlockWithState",
+			addr:        contractAddr,
+			blockNum:    3,
+			storageKeys: []libcommon.Hash{key(0), key(4), key(8), key(10)},
+			stateVal:    2,
+		},
+		{
+			name:        "olderBlockWithState",
+			addr:        contractAddr,
+			blockNum:    2,
+			storageKeys: []libcommon.Hash{key(1), key(5), key(9), key(13)},
+			stateVal:    1,
 		},
 		{
 			name:        "tooOldBlock",
+			addr:        contractAddr,
 			blockNum:    1,
 			expectedErr: "requested block is too old, block must be within 1 blocks of the head block number (currently 3)",
 		},
@@ -294,7 +320,7 @@ func TestGetProof(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			proof, err := api.GetProof(
 				context.Background(),
-				bankAddress,
+				tt.addr,
 				tt.storageKeys,
 				rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(tt.blockNum)),
 			)
@@ -312,17 +338,21 @@ func TestGetProof(t *testing.T) {
 			header, err := api.headerByRPCNumber(rpc.BlockNumber(tt.blockNum), tx)
 			require.NoError(t, err)
 
-			require.Equal(t, bankAddress, proof.Address)
+			require.Equal(t, tt.addr, proof.Address)
 			verifyAccountProof(t, header.Root, proof)
 
 			require.Equal(t, len(tt.storageKeys), len(proof.StorageProof))
 			for _, storageKey := range tt.storageKeys {
+				found := false
 				for _, storageProof := range proof.StorageProof {
 					if storageProof.Key != storageKey {
 						continue
 					}
+					found = true
+					require.Equal(t, uint256.NewInt(tt.stateVal).ToBig(), (*big.Int)(storageProof.Value))
 					verifyStorageProof(t, proof.StorageHash, storageProof)
 				}
+				require.True(t, found, "did not find storage proof for key=%x", storageKey)
 			}
 		})
 	}
@@ -544,13 +574,85 @@ func TestGetBlockByTimestamp(t *testing.T) {
 	}
 }
 
+// contractHexString is the output of compiling the following solidity contract:
+//
+// pragma solidity ^0.8.0;
+//
+//	contract Box {
+//	    uint256 private _value0x0;
+//	    uint256 private _value0x1;
+//	    uint256 private _value0x2;
+//	    uint256 private _value0x3;
+//	    uint256 private _value0x4;
+//	    uint256 private _value0x5;
+//	    uint256 private _value0x6;
+//	    uint256 private _value0x7;
+//	    uint256 private _value0x8;
+//	    uint256 private _value0x9;
+//	    uint256 private _value0xa;
+//	    uint256 private _value0xb;
+//	    uint256 private _value0xc;
+//	    uint256 private _value0xd;
+//	    uint256 private _value0xe;
+//	    uint256 private _value0xf;
+//	    uint256 private _value0x10;
+//
+//	    // Emitted when the stored value changes
+//	    event ValueChanged(uint256 value);
+//
+//	    // Stores a new value in the contract
+//	    function store(uint256 value) public {
+//	        _value0x0 = value;
+//	        _value0x1 = value;
+//	        _value0x2 = value;
+//	        _value0x3 = value;
+//	        _value0x4 = value;
+//	        _value0x5 = value;
+//	        _value0x6 = value;
+//	        _value0x7 = value;
+//	        _value0x8 = value;
+//	        _value0x9 = value;
+//	        _value0xa = value;
+//	        _value0xb = value;
+//	        _value0xc = value;
+//	        _value0xd = value;
+//	        _value0xe = value;
+//	        _value0xf = value;
+//	        _value0x10 = value;
+//	        emit ValueChanged(value);
+//	    }
+//
+//	    // Reads the last stored value
+//	    function retrieve() public view returns (uint256) {
+//	        return _value0x0;
+//	    }
+//	}
+//
+// You may produce this hex string by saving the contract into a file
+// Box.sol and invoking
+//
+//	solc Box.sol --bin --abi --optimize
+//
+// This contract is a slight modification of Box.sol to use more storage nodes
+// and ensure the contract storage will contain at least 1 non-leaf node (by
+// storing 17 values).
+const contractHexString = "0x608060405234801561001057600080fd5b5061013f806100206000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c80632e64cec11461003b5780636057361d14610050575b600080fd5b60005460405190815260200160405180910390f35b61006361005e3660046100f0565b610065565b005b6000819055600181905560028190556003819055600481905560058190556006819055600781905560088190556009819055600a819055600b819055600c819055600d819055600e819055600f81905560108190556040518181527f93fe6d397c74fdf1402a8b72e47b68512f0510d7b98a4bc4cbdf6ac7108b3c599060200160405180910390a150565b60006020828403121561010257600080fd5b503591905056fea2646970667358221220031e17f1bd1d1dcbee088287a905b152410b180064c149763590a0bbc516d95e64736f6c63430008130033"
+
+var contractFuncSelector = crypto.Keccak256([]byte("store(uint256)"))[:4]
+
+// contractInvocationData returns data suitable for invoking the 'store'
+// function of the contract in contractHexString, note
+func contractInvocationData(val byte) []byte {
+	return hexutil.MustDecode(fmt.Sprintf("0x%x00000000000000000000000000000000000000000000000000000000000000%02x", contractFuncSelector, val))
+}
+
 func chainWithDeployedContract(t *testing.T) (*stages.MockSentry, libcommon.Address, libcommon.Address) {
 	var (
 		signer      = types.LatestSignerForChainID(nil)
 		bankKey, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 		bankAddress = crypto.PubkeyToAddress(bankKey.PublicKey)
 		bankFunds   = big.NewInt(1e9)
-		contract    = hexutil.MustDecode("0x608060405234801561001057600080fd5b50610150806100206000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c80632e64cec11461003b5780636057361d14610059575b600080fd5b610043610075565b60405161005091906100d9565b60405180910390f35b610073600480360381019061006e919061009d565b61007e565b005b60008054905090565b8060008190555050565b60008135905061009781610103565b92915050565b6000602082840312156100b3576100b26100fe565b5b60006100c184828501610088565b91505092915050565b6100d3816100f4565b82525050565b60006020820190506100ee60008301846100ca565b92915050565b6000819050919050565b600080fd5b61010c816100f4565b811461011757600080fd5b5056fea26469706673582212209a159a4f3847890f10bfb87871a61eba91c5dbf5ee3cf6398207e292eee22a1664736f6c63430008070033")
+		contract    = hexutil.MustDecode(contractHexString)
 		gspec       = &types.Genesis{
 			Config: params.TestChainConfig,
 			Alloc:  types.GenesisAlloc{bankAddress: {Balance: bankFunds}},
@@ -569,8 +671,12 @@ func chainWithDeployedContract(t *testing.T) (*stages.MockSentry, libcommon.Addr
 			assert.NoError(t, err)
 			block.AddTx(tx)
 			contractAddr = crypto.CreateAddress(bankAddress, nonce)
-		case 1, 2:
-			txn, err := types.SignTx(types.NewTransaction(nonce, contractAddr, new(uint256.Int), 90000, new(uint256.Int), nil), *signer, bankKey)
+		case 1:
+			txn, err := types.SignTx(types.NewTransaction(nonce, contractAddr, new(uint256.Int), 900000, new(uint256.Int), contractInvocationData(1)), *signer, bankKey)
+			assert.NoError(t, err)
+			block.AddTx(txn)
+		case 2:
+			txn, err := types.SignTx(types.NewTransaction(nonce, contractAddr, new(uint256.Int), 900000, new(uint256.Int), contractInvocationData(2)), *signer, bankKey)
 			assert.NoError(t, err)
 			block.AddTx(txn)
 		}

--- a/turbo/trie/hashbuilder.go
+++ b/turbo/trie/hashbuilder.go
@@ -12,7 +12,6 @@ import (
 	"golang.org/x/crypto/sha3"
 
 	"github.com/ledgerwatch/erigon/common"
-	"github.com/ledgerwatch/erigon/common/hexutil"
 	"github.com/ledgerwatch/erigon/core/types/accounts"
 	"github.com/ledgerwatch/erigon/crypto"
 	"github.com/ledgerwatch/erigon/rlp"
@@ -43,12 +42,10 @@ type HashBuilder struct {
 
 	topHashesCopy []byte
 
-	// If an Account proof was requested in trie_root.go, nodes will be written here.
-	accProofResult *accounts.AccProofResult
-	// Flag to indicate that the next node should be copied to the stack specified above.
-	// This was previously done with a "doProof" flag added to the relevant function calls.
-	// By moving it here the original function signatures do not need to be modified.
-	collectNode bool
+	// proofElement is set when the next element computation should have its RLP
+	// encoding retained.  Additionally, the account root storage hash and storage
+	// values are stored into this field when set and in the relavent codepath.
+	proofElement *proofElement
 }
 
 // NewHashBuilder creates a new HashBuilder
@@ -69,24 +66,13 @@ func (hb *HashBuilder) Reset() {
 		hb.nodeStack = hb.nodeStack[:0]
 	}
 	hb.topHashesCopy = hb.topHashesCopy[:0]
-	hb.accProofResult = nil
-	hb.collectNode = false
+	hb.proofElement = nil
 }
 
-func (hb *HashBuilder) SetProofReturn(accProofResult *accounts.AccProofResult) {
-	accProofResult.AccountProof = make([]hexutil.Bytes, 0)
-	accProofResult.StorageProof = make([]accounts.StorProofResult, 0)
-	hb.accProofResult = accProofResult
-}
-
-// Set the collectNode flag. It will be cleared after an item is added to the proof stack.
-func (hb *HashBuilder) collectNextNode() error {
-	if hb.accProofResult != nil && hb.accProofResult.AccountProof != nil {
-		hb.collectNode = true
-		return nil
-	} else {
-		return fmt.Errorf("collectNextNode() called with missing accProofResult.AccountProof")
-	}
+// setProofElement sets the proofElement field in which the relevant methods
+// will check and additionally write the proof bytes to during trie computation.
+func (hb *HashBuilder) setProofElement(pe *proofElement) {
+	hb.proofElement = pe
 }
 
 func (hb *HashBuilder) leaf(length int, keyHex []byte, val rlphacks.RlpSerializable) error {
@@ -98,6 +84,9 @@ func (hb *HashBuilder) leaf(length int, keyHex []byte, val rlphacks.RlpSerializa
 	}
 	key := keyHex[len(keyHex)-length:]
 	s := &shortNode{Key: common.CopyBytes(key), Val: valueNode(common.CopyBytes(val.RawBytes()))}
+	if hb.proofElement != nil {
+		hb.proofElement.storageValue = new(uint256.Int).SetBytes(val.RawBytes())
+	}
 	hb.nodeStack = append(hb.nodeStack, s)
 	if err := hb.leafHashWithKeyVal(key, val); err != nil {
 		return err
@@ -175,35 +164,30 @@ func (hb *HashBuilder) completeLeafHash(kp, kl, compactLen int, key []byte, comp
 		reader = hb.sha
 	}
 	// Collect a copy of the hash input if needed for an eth_getProof
-	var proofBuf bytes.Buffer
-	mWriter := io.MultiWriter(writer, &proofBuf)
+	if hb.proofElement != nil {
+		writer = io.MultiWriter(writer, &hb.proofElement.proof)
+	}
 
-	if _, err := mWriter.Write(hb.lenPrefix[:pt]); err != nil {
+	if _, err := writer.Write(hb.lenPrefix[:pt]); err != nil {
 		return err
 	}
-	if _, err := mWriter.Write(hb.keyPrefix[:kp]); err != nil {
+	if _, err := writer.Write(hb.keyPrefix[:kp]); err != nil {
 		return err
 	}
 	hb.b[0] = compact0
-	if _, err := mWriter.Write(hb.b[:]); err != nil {
+	if _, err := writer.Write(hb.b[:]); err != nil {
 		return err
 	}
 	for i := 1; i < compactLen; i++ {
 		hb.b[0] = key[ni]*16 + key[ni+1]
-		if _, err := mWriter.Write(hb.b[:]); err != nil {
+		if _, err := writer.Write(hb.b[:]); err != nil {
 			return err
 		}
 		ni += 2
 	}
 
-	if err := val.ToDoubleRLP(mWriter, hb.prefixBuf[:]); err != nil {
+	if err := val.ToDoubleRLP(writer, hb.prefixBuf[:]); err != nil {
 		return err
-	}
-
-	if hb.collectNode {
-		nodeBytes := hexutil.Bytes(proofBuf.Bytes())
-		hb.accProofResult.AccountProof = append(hb.accProofResult.AccountProof, nodeBytes)
-		hb.collectNode = false
 	}
 
 	if reader != nil {
@@ -267,6 +251,12 @@ func (hb *HashBuilder) accountLeaf(length int, keyHex []byte, balance *uint256.I
 			}
 		}
 		popped++
+	}
+
+	if hb.proofElement != nil {
+		// The storageRoot is not stored with the account info, therefore
+		// we capture it with the account proof element
+		hb.proofElement.storageRoot = hb.acc.Root
 	}
 	var accCopy accounts.Account
 	accCopy.Copy(&hb.acc)
@@ -398,8 +388,10 @@ func (hb *HashBuilder) extension(key []byte) error {
 }
 
 func (hb *HashBuilder) extensionHash(key []byte) error {
-	var proofBuf bytes.Buffer
-	mWriter := io.MultiWriter(hb.sha, &proofBuf)
+	writer := io.Writer(hb.sha)
+	if hb.proofElement != nil {
+		writer = io.MultiWriter(hb.sha, &hb.proofElement.proof)
+	}
 
 	if hb.trace {
 		fmt.Printf("EXTENSIONHASH %x\n", key)
@@ -437,35 +429,30 @@ func (hb *HashBuilder) extensionHash(key []byte) error {
 	totalLen := kp + kl + 33
 	pt := rlphacks.GenerateStructLen(hb.lenPrefix[:], totalLen)
 	hb.sha.Reset()
-	if _, err := mWriter.Write(hb.lenPrefix[:pt]); err != nil {
+	if _, err := writer.Write(hb.lenPrefix[:pt]); err != nil {
 		return err
 	}
-	if _, err := mWriter.Write(hb.keyPrefix[:kp]); err != nil {
+	if _, err := writer.Write(hb.keyPrefix[:kp]); err != nil {
 		return err
 	}
 	hb.b[0] = compact0
-	if _, err := mWriter.Write(hb.b[:]); err != nil {
+	if _, err := writer.Write(hb.b[:]); err != nil {
 		return err
 	}
 	for i := 1; i < compactLen; i++ {
 		hb.b[0] = key[ni]*16 + key[ni+1]
-		if _, err := mWriter.Write(hb.b[:]); err != nil {
+		if _, err := writer.Write(hb.b[:]); err != nil {
 			return err
 		}
 		ni += 2
 	}
 	//capture := common.CopyBytes(branchHash[:length2.Hash+1])
-	if _, err := mWriter.Write(branchHash[:length2.Hash+1]); err != nil {
+	if _, err := writer.Write(branchHash[:length2.Hash+1]); err != nil {
 		return err
 	}
 	// Replace previous hash with the new one
 	if _, err := hb.sha.Read(hb.hashStack[len(hb.hashStack)-length2.Hash:]); err != nil {
 		return err
-	}
-
-	if hb.accProofResult != nil {
-		nodeBytes := hexutil.Bytes(proofBuf.Bytes())
-		hb.accProofResult.AccountProof = append(hb.accProofResult.AccountProof, nodeBytes)
 	}
 
 	hb.hashStack[len(hb.hashStack)-hashStackStride] = 0x80 + length2.Hash
@@ -516,8 +503,10 @@ func (hb *HashBuilder) branch(set uint16) error {
 }
 
 func (hb *HashBuilder) branchHash(set uint16) error {
-	var proofBuf bytes.Buffer
-	mWriter := io.MultiWriter(hb.sha, &proofBuf)
+	writer := io.Writer(hb.sha)
+	if hb.proofElement != nil {
+		writer = io.MultiWriter(hb.sha, &hb.proofElement.proof)
+	}
 
 	if hb.trace {
 		fmt.Printf("BRANCHHASH (%b)\n", set)
@@ -543,7 +532,7 @@ func (hb *HashBuilder) branchHash(set uint16) error {
 	}
 	hb.sha.Reset()
 	pt := rlphacks.GenerateStructLen(hb.lenPrefix[:], totalSize)
-	if _, err := mWriter.Write(hb.lenPrefix[:pt]); err != nil {
+	if _, err := writer.Write(hb.lenPrefix[:pt]); err != nil {
 		return err
 	}
 	// Output hasState hashes or embedded RLPs
@@ -553,21 +542,21 @@ func (hb *HashBuilder) branchHash(set uint16) error {
 	for digit := uint(0); digit < 17; digit++ {
 		if ((1 << digit) & set) != 0 {
 			if hashes[hashStackStride*i] == byte(0x80+length2.Hash) {
-				if _, err := mWriter.Write(hashes[hashStackStride*i : hashStackStride*i+hashStackStride]); err != nil {
+				if _, err := writer.Write(hashes[hashStackStride*i : hashStackStride*i+hashStackStride]); err != nil {
 					return err
 				}
 				//fmt.Printf("%x: [%x]\n", digit, hashes[hashStackStride*i:hashStackStride*i+hashStackStride])
 			} else {
 				// Embedded node
 				size := int(hashes[hashStackStride*i]) - rlp.EmptyListCode
-				if _, err := mWriter.Write(hashes[hashStackStride*i : hashStackStride*i+size+1]); err != nil {
+				if _, err := writer.Write(hashes[hashStackStride*i : hashStackStride*i+size+1]); err != nil {
 					return err
 				}
 				//fmt.Printf("%x: embedded [%x]\n", digit, hashes[hashStackStride*i:hashStackStride*i+size+1])
 			}
 			i++
 		} else {
-			if _, err := mWriter.Write(hb.b[:]); err != nil {
+			if _, err := writer.Write(hb.b[:]); err != nil {
 				return err
 			}
 			//fmt.Printf("%x: empty\n", digit)
@@ -577,12 +566,6 @@ func (hb *HashBuilder) branchHash(set uint16) error {
 	hb.hashStack[len(hb.hashStack)-hashStackStride] = 0x80 + length2.Hash
 	if _, err := hb.sha.Read(hb.hashStack[len(hb.hashStack)-length2.Hash:]); err != nil {
 		return err
-	}
-
-	if hb.collectNode {
-		nodeBytes := hexutil.Bytes(proofBuf.Bytes())
-		hb.accProofResult.AccountProof = append(hb.accProofResult.AccountProof, nodeBytes)
-		hb.collectNode = false
 	}
 
 	//fmt.Printf("} [%x]\n", hb.hashStack[len(hb.hashStack)-hashStackStride:])

--- a/turbo/trie/retain_list_test.go
+++ b/turbo/trie/retain_list_test.go
@@ -1,0 +1,106 @@
+package trie
+
+import (
+	"testing"
+
+	"github.com/holiman/uint256"
+	libcommon "github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon/core/types/accounts"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProofRetainerConstruction(t *testing.T) {
+	rl := NewRetainList(0)
+	pr, err := NewProofRetainer(
+		libcommon.Address{0x1},
+		&accounts.Account{
+			Initialised: true,
+			Nonce:       2,
+			Balance:     *uint256.NewInt(6e9),
+			CodeHash:    libcommon.Hash{3},
+			Incarnation: 3,
+		},
+		[]libcommon.Hash{{1}, {2}, {3}},
+		rl,
+	)
+	require.NoError(t, err)
+	require.Len(t, rl.hexes, 4)
+
+	validKeys := [][]byte{
+		{},
+		pr.accHexKey[:15],
+		pr.accHexKey[:],
+		pr.storageHexKeys[0][:85],
+		pr.storageHexKeys[0][:],
+		pr.storageHexKeys[1][:90],
+		pr.storageHexKeys[1][:],
+		pr.storageHexKeys[2][:98],
+		pr.storageHexKeys[2][:95],
+		pr.storageHexKeys[2][:],
+	}
+
+	invalidKeys := [][]byte{
+		pr.accHexKey[1:16],
+		pr.storageHexKeys[0][12:80],
+		pr.storageHexKeys[2][19:90],
+	}
+
+	for _, key := range validKeys {
+		pe := pr.ProofElement(key)
+		require.NotNil(t, pe)
+		require.Equal(t, pe.hexKey, key)
+		switch len(key) {
+		case 64: // Account leaf key
+			pe.storageRoot = libcommon.Hash{3}
+		case 144: // Storage leaf key
+			pe.storageValue = uint256.NewInt(5)
+		}
+		pe.proof.Write(key)
+	}
+	for _, key := range invalidKeys {
+		pe := pr.ProofElement(key)
+		require.Nil(t, pe)
+	}
+	require.Equal(t, len(validKeys), len(pr.proofs))
+
+	accProof, err := pr.ProofResult()
+	require.NoError(t, err)
+
+	require.Len(t, accProof.AccountProof, 3)
+	require.Equal(t, []byte(nil), []byte(accProof.AccountProof[0]))
+	require.Equal(t, validKeys[1], []byte(accProof.AccountProof[1]))
+	require.Equal(t, validKeys[2], []byte(accProof.AccountProof[2]))
+
+	require.Len(t, accProof.StorageProof, 3)
+	require.Equal(t, accProof.StorageProof[0].Key, libcommon.Hash{1})
+	require.Len(t, accProof.StorageProof[0].Proof, 2)
+	require.Equal(t, validKeys[3], []byte(accProof.StorageProof[0].Proof[0]))
+	require.Equal(t, validKeys[4], []byte(accProof.StorageProof[0].Proof[1]))
+
+	require.Equal(t, accProof.StorageProof[1].Key, libcommon.Hash{2})
+	require.Len(t, accProof.StorageProof[1].Proof, 2)
+	require.Equal(t, validKeys[5], []byte(accProof.StorageProof[1].Proof[0]))
+	require.Equal(t, validKeys[6], []byte(accProof.StorageProof[1].Proof[1]))
+
+	require.Equal(t, accProof.StorageProof[2].Key, libcommon.Hash{3})
+	require.Len(t, accProof.StorageProof[2].Proof, 3)
+	require.Equal(t, validKeys[7], []byte(accProof.StorageProof[2].Proof[0]))
+	require.Equal(t, validKeys[8], []byte(accProof.StorageProof[2].Proof[1]))
+	require.Equal(t, validKeys[9], []byte(accProof.StorageProof[2].Proof[2]))
+
+	t.Run("missingStorageRoot", func(t *testing.T) {
+		oldStorageHash := pr.proofs[2].storageRoot
+		pr.proofs[2].storageRoot = libcommon.Hash{}
+		defer func() { pr.proofs[2].storageRoot = oldStorageHash }()
+		_, err := pr.ProofResult()
+		require.Error(t, err, "did not find storage root in proof elements")
+	})
+
+	t.Run("missingStorageValue", func(t *testing.T) {
+		oldKey := pr.proofs[4].storageValue
+		pr.proofs[4].storageValue = nil
+		defer func() { pr.proofs[4].storageValue = oldKey }()
+		_, err := pr.ProofResult()
+		require.Error(t, err, "no storage value for storage key 0x%x", validKeys[4])
+	})
+}

--- a/turbo/trie/trie_root.go
+++ b/turbo/trie/trie_root.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/common/length"
 	length2 "github.com/ledgerwatch/erigon-lib/common/length"
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/log/v3"
@@ -126,8 +127,8 @@ type RootHashAggregator struct {
 	accData        GenStructStepAccountData
 
 	// Used to construct an Account proof while calculating the tree root.
-	proofMatch RetainDecider
-	cutoff     bool
+	proofRetainer *ProofRetainer
+	cutoff        bool
 }
 
 func NewRootHashAggregator() *RootHashAggregator {
@@ -160,9 +161,8 @@ func NewFlatDBTrieLoader(logPrefix string, rd RetainDeciderWithMarker, hc HashCo
 	}
 }
 
-func (l *FlatDBTrieLoader) SetProofReturn(accProofResult *accounts.AccProofResult) {
-	l.receiver.proofMatch = l.rd
-	l.receiver.hb.SetProofReturn(accProofResult)
+func (l *FlatDBTrieLoader) SetProofRetainer(pr *ProofRetainer) {
+	l.receiver.proofRetainer = pr
 }
 
 // CalcTrieRoot algo:
@@ -339,6 +339,7 @@ func (r *RootHashAggregator) Receive(itemType StreamItem,
 	//	fmt.Printf("1: %d, %x, %x, %x\n", itemType, accountKey, storageKey, hash)
 	//	//}
 	//}
+	//
 
 	switch itemType {
 	case StorageStreamItem:
@@ -534,13 +535,32 @@ func (r *RootHashAggregator) genStructStorage() error {
 		r.leafData.Value = rlphacks.RlpSerializableBytes(r.valueStorage)
 		data = &r.leafData
 	}
-	r.groupsStorage, r.hasTreeStorage, r.hasHashStorage, err = GenStructStep(r.RetainNothing, r.currStorage.Bytes(), r.succStorage.Bytes(), r.hb, func(keyHex []byte, hasState, hasTree, hasHash uint16, hashes, rootHash []byte) error {
+	var wantProof func(_ []byte) *proofElement
+	if r.proofRetainer != nil {
+		var fullKey [2 * (length.Hash + length.Incarnation + length.Hash)]byte
+		for i, b := range r.currAccK {
+			fullKey[i*2] = b / 16
+			fullKey[i*2+1] = b % 16
+		}
+		for i, b := range binary.BigEndian.AppendUint64(nil, r.a.Incarnation) {
+			fullKey[2*length.Hash+i*2] = b / 16
+			fullKey[2*length.Hash+i*2+1] = b % 16
+		}
+		baseKeyLen := 2 * (length.Hash + length.Incarnation)
+		wantProof = func(prefix []byte) *proofElement {
+			copy(fullKey[baseKeyLen:], prefix)
+			return r.proofRetainer.ProofElement(fullKey[:baseKeyLen+len(prefix)])
+		}
+	}
+	r.groupsStorage, r.hasTreeStorage, r.hasHashStorage, err = GenStructStepEx(r.RetainNothing, r.currStorage.Bytes(), r.succStorage.Bytes(), r.hb, func(keyHex []byte, hasState, hasTree, hasHash uint16, hashes, rootHash []byte) error {
 		if r.shc == nil {
 			return nil
 		}
 		return r.shc(r.currAccK, keyHex, hasState, hasTree, hasHash, hashes, rootHash)
 	}, data, r.groupsStorage, r.hasTreeStorage, r.hasHashStorage,
 		r.trace,
+		wantProof,
+		r.cutoff,
 	)
 	if err != nil {
 		return err
@@ -603,9 +623,9 @@ func (r *RootHashAggregator) genStructAccount() error {
 	r.succStorage.Reset()
 	var err error
 
-	var wantProof func(_ []byte) bool
-	if r.proofMatch != nil {
-		wantProof = r.proofMatch.Retain
+	var wantProof func(_ []byte) *proofElement
+	if r.proofRetainer != nil {
+		wantProof = r.proofRetainer.ProofElement
 	}
 	if r.groups, r.hasTree, r.hasHash, err = GenStructStepEx(r.RetainNothing, r.curr.Bytes(), r.succ.Bytes(), r.hb, func(keyHex []byte, hasState, hasTree, hasHash uint16, hashes, rootHash []byte) error {
 		if r.hc == nil {


### PR DESCRIPTION
This PR completes the implementation of `eth_getProof` by adding support for storage proofs.

Because storage proofs are potentially overlapping, the existing strategy of simply aggregating all proofs together into a single result was challenging.  Instead, this commit rewires things to introduce a ProofRetainer, which aggregates proofs and their corresponding nibble encoded paths in the trie.  Once all of the proofs have been aggregated, the caller requests the proof result, which then iterates over the aggregated proofs, placing each into the relevant proof array into the result.

Although there are tests for `eth_getProof` as an RPC and for the new `ProofRetainer` code, the code coverage for the proof generation over complex tries is lacking.  But, since this is not a new problem I'll plan to follow up this PR with an additional one adding more coverage into `turbo/trie`.