### PR TITLE
remove simd lib, because it doesn't work with ghcr.io/goreleaser/goreleaser-cross (which producing release binaries)

### DIFF
--- a/cl/utils/crypto.go
+++ b/cl/utils/crypto.go
@@ -14,10 +14,9 @@
 package utils
 
 import (
+	"crypto/sha256"
 	"hash"
 	"sync"
-
-	"github.com/minio/sha256-simd"
 )
 
 type HashFunc func(data []byte, extras ...[]byte) [32]byte

--- a/cmd/devnet/requests/tx.go
+++ b/cmd/devnet/requests/tx.go
@@ -35,7 +35,7 @@ func TxpoolContent(reqId int) (int, int, int, error) {
 
 	if resp["queue"] != nil {
 		queued = resp["queue"].(map[string]interface{})
-		for _, txs := range pending {
+		for _, txs := range queued {
 			queuedLen += len(txs.(map[string]interface{}))
 		}
 	}

--- a/cmd/erigon-cl/core/state/state.go
+++ b/cmd/erigon-cl/core/state/state.go
@@ -1,9 +1,8 @@
 package state
 
 import (
+	"crypto/sha256"
 	"encoding/binary"
-
-	"github.com/minio/sha256-simd"
 
 	lru2 "github.com/hashicorp/golang-lru/v2"
 	libcommon "github.com/ledgerwatch/erigon-lib/common"

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -17,11 +17,10 @@
 package vm
 
 import (
+	"crypto/sha256"
 	"encoding/binary"
 	"errors"
 	"math/big"
-
-	"github.com/minio/sha256-simd"
 
 	"github.com/holiman/uint256"
 	"github.com/ledgerwatch/erigon-lib/chain"

--- a/crypto/ecies/ecies_test.go
+++ b/crypto/ecies/ecies_test.go
@@ -33,14 +33,13 @@ import (
 	"bytes"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"flag"
 	"fmt"
 	"math/big"
 	"os"
 	"testing"
-
-	"github.com/minio/sha256-simd"
 
 	"github.com/ledgerwatch/erigon/crypto"
 )

--- a/crypto/ecies/params.go
+++ b/crypto/ecies/params.go
@@ -37,11 +37,10 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/elliptic"
+	"crypto/sha256"
 	"crypto/sha512"
 	"fmt"
 	"hash"
-
-	"github.com/minio/sha256-simd"
 
 	ethcrypto "github.com/ledgerwatch/erigon/crypto"
 )

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,6 @@ require (
 	github.com/libp2p/go-libp2p-pubsub v0.9.3
 	github.com/maticnetwork/crand v1.0.2
 	github.com/maticnetwork/polyproto v0.0.2
-	github.com/minio/sha256-simd v1.0.0
 	github.com/multiformats/go-multiaddr v0.8.0
 	github.com/nxadm/tail v1.4.9-0.20211216163028-4472660a31a6
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
@@ -180,6 +179,7 @@ require (
 	github.com/miekg/dns v1.1.50 // indirect
 	github.com/mikioh/tcpinfo v0.0.0-20190314235526-30a79bb1804b // indirect
 	github.com/mikioh/tcpopt v0.0.0-20190314235656-172688c1accc // indirect
+	github.com/minio/sha256-simd v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/p2p/discover/v5wire/crypto_test.go
+++ b/p2p/discover/v5wire/crypto_test.go
@@ -20,11 +20,10 @@ import (
 	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/sha256"
 	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/minio/sha256-simd"
 
 	"github.com/ledgerwatch/erigon/common/hexutil"
 	"github.com/ledgerwatch/erigon/crypto"

--- a/p2p/discover/v5wire/encoding.go
+++ b/p2p/discover/v5wire/encoding.go
@@ -22,12 +22,11 @@ import (
 	"crypto/cipher"
 	"crypto/ecdsa"
 	crand "crypto/rand"
+	"crypto/sha256"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"hash"
-
-	"github.com/minio/sha256-simd"
 
 	"github.com/ledgerwatch/erigon/common/mclock"
 	"github.com/ledgerwatch/erigon/p2p/enode"

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -19,6 +19,7 @@ package p2p
 import (
 	"context"
 	"crypto/ecdsa"
+	"crypto/sha256"
 	"errors"
 	"io"
 	"math/rand"
@@ -27,8 +28,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/minio/sha256-simd"
 
 	"github.com/ledgerwatch/erigon/crypto"
 	"github.com/ledgerwatch/erigon/p2p/enode"

--- a/turbo/trie/vtree/verkle_utils_test.go
+++ b/turbo/trie/vtree/verkle_utils_test.go
@@ -1,11 +1,10 @@
 package vtree
 
 import (
+	"crypto/sha256"
 	"math/big"
 	"math/rand"
 	"testing"
-
-	"github.com/minio/sha256-simd"
 )
 
 func BenchmarkPedersenHash(b *testing.B) {


### PR DESCRIPTION
@shyba hi, seems this lib doesn't work with ghcr.io/goreleaser/goreleaser-cross (which producing release binaries) 
removing it for now, feel free to add it in future - if can make it work with goreleaser-cross
see: https://github.com/ledgerwatch/erigon/issues/7210