### PR TITLE
fix nil ptr on polygon

### DIFF
--- a/cmd/rpcdaemon/commands/tracing.go
+++ b/cmd/rpcdaemon/commands/tracing.go
@@ -78,6 +78,10 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 		stream.WriteNil()
 		return err
 	}
+	
+	if config == nil {
+		config = &tracers.TraceConfig{}
+	}
 
 	if config.BorTraceEnabled == nil {
 		config.BorTraceEnabled = newBoolPtr(false)


### PR DESCRIPTION
when assigning default bor parameters, need to make sure config exists first.