### PR TITLE
Update version.go to be higher than current release

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -32,7 +32,7 @@ var (
 // see https://calver.org
 const (
 	VersionMajor       = 2     // Major version component of the current release
-	VersionMinor       = 41    // Minor version component of the current release
+	VersionMinor       = 43    // Minor version component of the current release
 	VersionMicro       = 0     // Patch version component of the current release
 	VersionModifier    = "dev" // Modifier component of the current release
 	VersionKeyCreated  = "ErigonVersionCreated"


### PR DESCRIPTION
Current release is v2.42 ... it gets confusing if make shows v2.41