### PR TITLE
txpool: update cli flags

### DIFF
--- a/cmd/txpool/main.go
+++ b/cmd/txpool/main.go
@@ -70,7 +70,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&TLSCACert, "tls.cacert", "", "CA certificate for client side TLS handshake")
 
 	rootCmd.PersistentFlags().IntVar(&pendingPoolLimit, "txpool.globalslots", txpoolcfg.DefaultConfig.PendingSubPoolLimit, "Maximum number of executable transaction slots for all accounts")
-	rootCmd.PersistentFlags().IntVar(&baseFeePoolLimit, "txpool.globalbasefeeeslots", txpoolcfg.DefaultConfig.BaseFeeSubPoolLimit, "Maximum number of non-executable transactions where only not enough baseFee")
+	rootCmd.PersistentFlags().IntVar(&baseFeePoolLimit, "txpool.globalbasefeeslots", txpoolcfg.DefaultConfig.BaseFeeSubPoolLimit, "Maximum number of non-executable transactions where only not enough baseFee")
 	rootCmd.PersistentFlags().IntVar(&queuedPoolLimit, "txpool.globalqueue", txpoolcfg.DefaultConfig.QueuedSubPoolLimit, "Maximum number of non-executable transaction slots for all accounts")
 	rootCmd.PersistentFlags().Uint64Var(&priceLimit, "txpool.pricelimit", txpoolcfg.DefaultConfig.MinFeeCap, "Minimum gas price (fee cap) limit to enforce for acceptance into the pool")
 	rootCmd.PersistentFlags().Uint64Var(&accountSlots, "txpool.accountslots", txpoolcfg.DefaultConfig.AccountSlots, "Minimum number of executable transaction slots guaranteed per account")

--- a/cmd/txpool/readme.md
+++ b/cmd/txpool/readme.md
@@ -27,7 +27,7 @@ make txpool
 # --private.api.addr - connect to Erigon's grpc api
 # --sentry.api.addr  - connect to Sentry's grpc api
 # --txpool.api.addr  - other services to connect TxPool's grpc api
-# Increase limits flags: --txpool.globalslots, --txpool.globalbasefeeeslots, --txpool.globalqueue
+# Increase limits flags: --txpool.globalslots, --txpool.globalbasefeeslots, --txpool.globalqueue
 # --txpool.trace.senders - print more logs about Txs with senders in this list 
 ./build/bin/txpool --private.api.addr=localhost:9090 --sentry.api.addr=localhost:9091 --txpool.api.addr=localhost:9094 --datadir=<your_datadir>
 


### PR DESCRIPTION
it would appear that an extra `e` was added somewhere along the way to the cli flags for txpool. If this was intentional I was curious as to why, otherwise it seems like fixing the flag would remedy some confusion. Thank you

Upon further investigation it would appear https://github.com/ledgerwatch/erigon/blob/devel/cmd/utils/flags.go#L173 shows corrected spelling.