### PR TITLE
make: fix db-tools target error when it's first command after cloning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,7 @@ db-tools:
 
 	go mod vendor
 	cd vendor/github.com/torquem-ch/mdbx-go && MDBX_BUILD_TIMESTAMP=unknown make tools
+	mkdir -p $(GOBIN)
 	cd vendor/github.com/torquem-ch/mdbx-go/mdbxdist && cp mdbx_chk $(GOBIN) && cp mdbx_copy $(GOBIN) && cp mdbx_dump $(GOBIN) && cp mdbx_drop $(GOBIN) && cp mdbx_load $(GOBIN) && cp mdbx_stat $(GOBIN)
 	rm -rf vendor
 	@echo "Run \"$(GOBIN)/mdbx_stat -h\" to get info about mdbx db file."


### PR DESCRIPTION
**Reproducer:**
```sh
$ git clone --depth 1 https://github.com/ledgerwatch/erigon
$ cd erigon
$ make db-tools
...
  CC+LD mdbx_load
  CC+LD mdbx_chk
  CC+LD mdbx_drop
make[2]: Leaving directory '/home/user/devel/er/erigon/vendor/github.com/torquem-ch/mdbx-go/mdbxdist'
make[1]: Leaving directory '/home/user/devel/er/erigon/vendor/github.com/torquem-ch/mdbx-go'
cd vendor/github.com/torquem-ch/mdbx-go/mdbxdist && cp mdbx_chk /home/user/devel/er/erigon/build/bin && cp mdbx_copy /home/user/devel/er/erigon/build/bin && cp mdbx_dump /home/user/devel/er/erigon/build/bin && cp mdbx_drop /home/user/devel/er/erigon/build/bin && cp mdbx_load /home/user/devel/er/erigon/build/bin && cp mdbx_stat /home/user/devel/er/erigon/build/bin
cp: cannot create regular file '/home/user/devel/er/erigon/build/bin': No such file or directory
make: *** [Makefile:138: db-tools] Error 1
```

**Fix:**
create `$(GOBIN)` directory if it's not exists