### PR TITLE
Revert "return [] instead of null for withdrawals (#7279)"

### DIFF
--- a/turbo/adapter/ethapi/api.go
+++ b/turbo/adapter/ethapi/api.go
@@ -341,11 +341,6 @@ func RPCMarshalBlockExDeprecated(block *types.Block, inclTx bool, fullTx bool, b
 		fields["withdrawals"] = block.Withdrawals()
 	}
 
-	// Ensure that withdrawals is not null at all times.
-	if fields["withdrawals"] == nil {
-		fields["withdrawals"] = []*types.Withdrawal{}
-	}
-
 	return fields, nil
 }
 


### PR DESCRIPTION
Pre-Shanghai blocks should have `nil` withdrawals, while post-Shanghai blocks should have non-nil withdrawals (empty or non-empty slice, but not `nil`). Judging from Issue #6976, that's not always a case. PR #7279 attempted to fix the issue, but unfortunately it only masks the root cause.

This reverts commit c60a6a2962c95e4bafd5e295bf1b3332baf2bfd9.