### PR TITLE
eip-4844: extensions to compute fees for data blobs

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -807,6 +807,10 @@ func (m callMsg) Data() []byte                  { return m.CallMsg.Data }
 func (m callMsg) AccessList() types2.AccessList { return m.CallMsg.AccessList }
 func (m callMsg) IsFree() bool                  { return false }
 
+func (m callMsg) DataGas() uint64                { return params.DataGasPerBlob * uint64(len(m.CallMsg.DataHashes)) }
+func (m callMsg) MaxFeePerDataGas() *uint256.Int { return m.CallMsg.MaxFeePerDataGas }
+func (m callMsg) DataHashes() []libcommon.Hash   { return m.CallMsg.DataHashes }
+
 /*
 // filterBackend implements filters.Backend to support filtering for logs without
 // taking bloom-bits acceleration structures into account.

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -84,12 +84,15 @@ type Message interface {
 	FeeCap() *uint256.Int
 	Tip() *uint256.Int
 	Gas() uint64
+	DataGas() uint64
+	MaxFeePerDataGas() *uint256.Int
 	Value() *uint256.Int
 
 	Nonce() uint64
 	CheckNonce() bool
 	Data() []byte
 	AccessList() types2.AccessList
+	DataHashes() []libcommon.Hash
 
 	IsFree() bool
 }
@@ -448,4 +451,8 @@ func (st *StateTransition) refundGas(refundQuotient uint64) {
 // gasUsed returns the amount of gas used up by the state transition.
 func (st *StateTransition) gasUsed() uint64 {
 	return st.initialGas - st.gas
+}
+
+func (st *StateTransition) dataGasUsed() uint64 {
+	return uint64(len(st.msg.DataHashes())) * params.DataGasPerBlob
 }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -36,6 +36,7 @@ import (
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/common/math"
 	"github.com/ledgerwatch/erigon/crypto"
+	"github.com/ledgerwatch/erigon/params"
 	"github.com/ledgerwatch/erigon/rlp"
 )
 
@@ -529,6 +530,11 @@ func (m *Message) ChangeGas(globalGasCap, desiredGas uint64) {
 	}
 
 	m.gasLimit = gas
+}
+
+func (m Message) DataGas() uint64 { return params.DataGasPerBlob * uint64(len(m.dataHashes)) }
+func (m Message) MaxFeePerDataGas() *uint256.Int {
+	return &m.maxFeePerDataGas
 }
 
 func (m Message) DataHashes() []libcommon.Hash { return m.dataHashes }

--- a/interfaces.go
+++ b/interfaces.go
@@ -116,16 +116,18 @@ type ChainSyncReader interface {
 
 // CallMsg contains parameters for contract calls.
 type CallMsg struct {
-	From     libcommon.Address  // the sender of the 'transaction'
-	To       *libcommon.Address // the destination contract (nil for contract creation)
-	Gas      uint64             // if 0, the call executes with near-infinite gas
-	GasPrice *uint256.Int       // wei <-> gas exchange ratio
-	Value    *uint256.Int       // amount of wei sent along with the call
-	Data     []byte             // input data, usually an ABI-encoded contract method invocation
+	From             libcommon.Address  // the sender of the 'transaction'
+	To               *libcommon.Address // the destination contract (nil for contract creation)
+	Gas              uint64             // if 0, the call executes with near-infinite gas
+	MaxFeePerDataGas *uint256.Int       // EIP-4844 max_fee_per_data_gas
+	GasPrice         *uint256.Int       // wei <-> gas exchange ratio
+	Value            *uint256.Int       // amount of wei sent along with the call
+	Data             []byte             // input data, usually an ABI-encoded contract method invocation
 
 	FeeCap     *uint256.Int      // EIP-1559 fee cap per gas.
 	Tip        *uint256.Int      // EIP-1559 tip per gas.
 	AccessList types2.AccessList // EIP-2930 access list.
+	DataHashes []libcommon.Hash  // EIP-4844 versioned data hashes.
 }
 
 // A ContractCaller provides contract calls, essentially transactions that are executed by


### PR DESCRIPTION
Small additions that will be used to compute data blob fees and to verify transactions for "willingness" to pay for these fees.