### PR TITLE
Fix eth_getProof element order

### DIFF
--- a/turbo/trie/retain_list.go
+++ b/turbo/trie/retain_list.go
@@ -114,7 +114,10 @@ func (pr *ProofRetainer) ProofElement(prefix []byte) *proofElement {
 	pe := &proofElement{
 		hexKey: append([]byte{}, prefix...),
 	}
-	pr.proofs = append(pr.proofs, pe)
+	// Since we do a depth-first traversal, reverse the proof elements so that
+	// they are ordered correctly root -> node -> ... -> leaf as dictated by
+	// EIP-1186
+	pr.proofs = append([]*proofElement{pe}, pr.proofs...)
 	return pe
 }
 

--- a/turbo/trie/retain_list_test.go
+++ b/turbo/trie/retain_list_test.go
@@ -27,16 +27,16 @@ func TestProofRetainerConstruction(t *testing.T) {
 	require.Len(t, rl.hexes, 4)
 
 	validKeys := [][]byte{
-		{},
-		pr.accHexKey[:15],
-		pr.accHexKey[:],
-		pr.storageHexKeys[0][:85],
-		pr.storageHexKeys[0][:],
-		pr.storageHexKeys[1][:90],
-		pr.storageHexKeys[1][:],
+		pr.storageHexKeys[2][:],
 		pr.storageHexKeys[2][:98],
 		pr.storageHexKeys[2][:95],
-		pr.storageHexKeys[2][:],
+		pr.storageHexKeys[1][:],
+		pr.storageHexKeys[1][:90],
+		pr.storageHexKeys[0][:],
+		pr.storageHexKeys[0][:85],
+		pr.accHexKey[:],
+		pr.accHexKey[:15],
+		{},
 	}
 
 	invalidKeys := [][]byte{
@@ -68,25 +68,25 @@ func TestProofRetainerConstruction(t *testing.T) {
 
 	require.Len(t, accProof.AccountProof, 3)
 	require.Equal(t, []byte(nil), []byte(accProof.AccountProof[0]))
-	require.Equal(t, validKeys[1], []byte(accProof.AccountProof[1]))
-	require.Equal(t, validKeys[2], []byte(accProof.AccountProof[2]))
+	require.Equal(t, validKeys[8], []byte(accProof.AccountProof[1]))
+	require.Equal(t, validKeys[7], []byte(accProof.AccountProof[2]))
 
 	require.Len(t, accProof.StorageProof, 3)
 	require.Equal(t, accProof.StorageProof[0].Key, libcommon.Hash{1})
 	require.Len(t, accProof.StorageProof[0].Proof, 2)
-	require.Equal(t, validKeys[3], []byte(accProof.StorageProof[0].Proof[0]))
-	require.Equal(t, validKeys[4], []byte(accProof.StorageProof[0].Proof[1]))
+	require.Equal(t, validKeys[6], []byte(accProof.StorageProof[0].Proof[0]))
+	require.Equal(t, validKeys[5], []byte(accProof.StorageProof[0].Proof[1]))
 
 	require.Equal(t, accProof.StorageProof[1].Key, libcommon.Hash{2})
 	require.Len(t, accProof.StorageProof[1].Proof, 2)
-	require.Equal(t, validKeys[5], []byte(accProof.StorageProof[1].Proof[0]))
-	require.Equal(t, validKeys[6], []byte(accProof.StorageProof[1].Proof[1]))
+	require.Equal(t, validKeys[4], []byte(accProof.StorageProof[1].Proof[0]))
+	require.Equal(t, validKeys[3], []byte(accProof.StorageProof[1].Proof[1]))
 
 	require.Equal(t, accProof.StorageProof[2].Key, libcommon.Hash{3})
 	require.Len(t, accProof.StorageProof[2].Proof, 3)
-	require.Equal(t, validKeys[7], []byte(accProof.StorageProof[2].Proof[0]))
-	require.Equal(t, validKeys[8], []byte(accProof.StorageProof[2].Proof[1]))
-	require.Equal(t, validKeys[9], []byte(accProof.StorageProof[2].Proof[2]))
+	require.Equal(t, validKeys[2], []byte(accProof.StorageProof[2].Proof[0]))
+	require.Equal(t, validKeys[1], []byte(accProof.StorageProof[2].Proof[1]))
+	require.Equal(t, validKeys[0], []byte(accProof.StorageProof[2].Proof[2]))
 
 	t.Run("missingStorageRoot", func(t *testing.T) {
 		oldStorageHash := pr.proofs[2].storageRoot


### PR DESCRIPTION
According to EIP-1186 the `proof` parts of the response to eth_getProof should be returned "starting with the stateRoot-Node, following the path of the SHA3 (address) as key."  Currently, the proof is returned in traversal order, rather than from the root.

Although all of the proof elements are there and correct, this is contrary to the EIP and will cause problems for some clients.  The existing rpc test uses a map to lookup proof elements by hash, rather than by index, so this bug was not initially caught.

This commit fixes the behavior, updates the existing test, and adds additional checks to the rpc test.