### PR TITLE
eip-4844: receipts to include dataGasPrice and dataGasUsed

### DIFF
--- a/cmd/rpcdaemon/commands/erigon_receipts.go
+++ b/cmd/rpcdaemon/commands/erigon_receipts.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"math/big"
 
 	"github.com/RoaringBitmap/roaring"
 	"github.com/ledgerwatch/erigon-lib/common"
@@ -391,10 +392,18 @@ func (api *ErigonImpl) GetBlockReceiptsByBlockHash(ctx context.Context, cannonic
 	if err != nil {
 		return nil, fmt.Errorf("getReceipts error: %w", err)
 	}
+	var edg *big.Int
+	if blockNum > 0 {
+		if parentHeader, err := api._blockReader.HeaderByNumber(ctx, tx, blockNum-1); err != nil {
+			return nil, err
+		} else {
+			edg = parentHeader.ExcessDataGas
+		}
+	}
 	result := make([]map[string]interface{}, 0, len(receipts))
 	for _, receipt := range receipts {
 		txn := block.Transactions()[receipt.TransactionIndex]
-		result = append(result, marshalReceipt(receipt, txn, chainConfig, block.HeaderNoCopy(), txn.Hash(), true))
+		result = append(result, marshalReceipt(receipt, txn, chainConfig, block.HeaderNoCopy(), txn.Hash(), true, edg))
 	}
 
 	if chainConfig.Bor != nil {
@@ -405,7 +414,7 @@ func (api *ErigonImpl) GetBlockReceiptsByBlockHash(ctx context.Context, cannonic
 				return nil, err
 			}
 			if borReceipt != nil {
-				result = append(result, marshalReceipt(borReceipt, borTx, chainConfig, block.HeaderNoCopy(), borReceipt.TxHash, false))
+				result = append(result, marshalReceipt(borReceipt, borTx, chainConfig, block.HeaderNoCopy(), borReceipt.TxHash, false, edg))
 			}
 		}
 	}

--- a/cmd/rpcdaemon/commands/erigon_receipts.go
+++ b/cmd/rpcdaemon/commands/erigon_receipts.go
@@ -393,8 +393,8 @@ func (api *ErigonImpl) GetBlockReceiptsByBlockHash(ctx context.Context, cannonic
 		return nil, fmt.Errorf("getReceipts error: %w", err)
 	}
 	var edg *big.Int
-	if blockNum > 0 {
-		if parentHeader, err := api._blockReader.HeaderByNumber(ctx, tx, blockNum-1); err != nil {
+	if n := block.Number().Uint64(); n > 0 {
+		if parentHeader, err := api._blockReader.Header(ctx, tx, block.ParentHash(), n-1); err != nil {
 			return nil, err
 		} else {
 			edg = parentHeader.ExcessDataGas

--- a/cmd/rpcdaemon/commands/eth_receipts.go
+++ b/cmd/rpcdaemon/commands/eth_receipts.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ledgerwatch/erigon/common/hexutil"
 	"github.com/ledgerwatch/erigon/consensus"
+	"github.com/ledgerwatch/erigon/consensus/misc"
 	"github.com/ledgerwatch/erigon/core"
 	"github.com/ledgerwatch/erigon/core/rawdb"
 	"github.com/ledgerwatch/erigon/core/state"
@@ -646,6 +647,15 @@ func (api *APIImpl) GetTransactionReceipt(ctx context.Context, txnHash common.Ha
 		return nil, fmt.Errorf("getReceipts error: %w", err)
 	}
 
+	var edg *big.Int
+	if n := block.Number().Uint64(); n > 0 {
+		if parentHeader, err := api._blockReader.HeaderByNumber(ctx, tx, n-1); err != nil {
+			return nil, err
+		} else {
+			edg = parentHeader.ExcessDataGas
+		}
+	}
+
 	if txn == nil {
 		borReceipt, err := rawdb.ReadBorReceipt(tx, block.Hash(), blockNum, receipts)
 		if err != nil {
@@ -654,14 +664,14 @@ func (api *APIImpl) GetTransactionReceipt(ctx context.Context, txnHash common.Ha
 		if borReceipt == nil {
 			return nil, nil
 		}
-		return marshalReceipt(borReceipt, borTx, cc, block.HeaderNoCopy(), txnHash, false), nil
+		return marshalReceipt(borReceipt, borTx, cc, block.HeaderNoCopy(), txnHash, false, edg), nil
 	}
 
 	if len(receipts) <= int(txnIndex) {
 		return nil, fmt.Errorf("block has less receipts than expected: %d <= %d, block: %d", len(receipts), int(txnIndex), blockNum)
 	}
 
-	return marshalReceipt(receipts[txnIndex], block.Transactions()[txnIndex], cc, block.HeaderNoCopy(), txnHash, true), nil
+	return marshalReceipt(receipts[txnIndex], block.Transactions()[txnIndex], cc, block.HeaderNoCopy(), txnHash, true, edg), nil
 }
 
 // GetBlockReceipts - receipts for individual block
@@ -693,9 +703,17 @@ func (api *APIImpl) GetBlockReceipts(ctx context.Context, number rpc.BlockNumber
 		return nil, fmt.Errorf("getReceipts error: %w", err)
 	}
 	result := make([]map[string]interface{}, 0, len(receipts))
+	var edg *big.Int
+	if n := block.Number().Uint64(); n > 0 {
+		if parentHeader, err := api._blockReader.HeaderByNumber(ctx, tx, n-1); err != nil {
+			return nil, err
+		} else {
+			edg = parentHeader.ExcessDataGas
+		}
+	}
 	for _, receipt := range receipts {
 		txn := block.Transactions()[receipt.TransactionIndex]
-		result = append(result, marshalReceipt(receipt, txn, chainConfig, block.HeaderNoCopy(), txn.Hash(), true))
+		result = append(result, marshalReceipt(receipt, txn, chainConfig, block.HeaderNoCopy(), txn.Hash(), true, edg))
 	}
 
 	if chainConfig.Bor != nil {
@@ -706,7 +724,7 @@ func (api *APIImpl) GetBlockReceipts(ctx context.Context, number rpc.BlockNumber
 				return nil, err
 			}
 			if borReceipt != nil {
-				result = append(result, marshalReceipt(borReceipt, borTx, chainConfig, block.HeaderNoCopy(), borReceipt.TxHash, false))
+				result = append(result, marshalReceipt(borReceipt, borTx, chainConfig, block.HeaderNoCopy(), borReceipt.TxHash, false, edg))
 			}
 		}
 	}
@@ -714,7 +732,7 @@ func (api *APIImpl) GetBlockReceipts(ctx context.Context, number rpc.BlockNumber
 	return result, nil
 }
 
-func marshalReceipt(receipt *types.Receipt, txn types.Transaction, chainConfig *chain.Config, header *types.Header, txnHash common.Hash, signed bool) map[string]interface{} {
+func marshalReceipt(receipt *types.Receipt, txn types.Transaction, chainConfig *chain.Config, header *types.Header, txnHash common.Hash, signed bool, excessDataGas *big.Int) map[string]interface{} {
 	var chainId *big.Int
 	switch t := txn.(type) {
 	case *types.LegacyTx:
@@ -763,6 +781,16 @@ func marshalReceipt(receipt *types.Receipt, txn types.Transaction, chainConfig *
 	// If the ContractAddress is 20 0x0 bytes, assume it is not a contract creation
 	if receipt.ContractAddress != (common.Address{}) {
 		fields["contractAddress"] = receipt.ContractAddress
+	}
+	// Set derived blob related fields
+	numBlobs := len(txn.GetDataHashes())
+	if numBlobs > 0 {
+		if excessDataGas == nil {
+			log.Warn("excess data gas not set when trying to marshal blob tx")
+		} else {
+			fields["dataGasPrice"] = misc.GetDataGasPrice(excessDataGas)
+			fields["dataGasUsed"] = misc.GetDataGasUsed(numBlobs)
+		}
 	}
 	return fields
 }

--- a/cmd/rpcdaemon/commands/eth_receipts.go
+++ b/cmd/rpcdaemon/commands/eth_receipts.go
@@ -649,7 +649,7 @@ func (api *APIImpl) GetTransactionReceipt(ctx context.Context, txnHash common.Ha
 
 	var edg *big.Int
 	if n := block.Number().Uint64(); n > 0 {
-		if parentHeader, err := api._blockReader.HeaderByNumber(ctx, tx, n-1); err != nil {
+		if parentHeader, err := api._blockReader.Header(ctx, tx, block.ParentHash(), n-1); err != nil {
 			return nil, err
 		} else {
 			edg = parentHeader.ExcessDataGas
@@ -705,7 +705,7 @@ func (api *APIImpl) GetBlockReceipts(ctx context.Context, number rpc.BlockNumber
 	result := make([]map[string]interface{}, 0, len(receipts))
 	var edg *big.Int
 	if n := block.Number().Uint64(); n > 0 {
-		if parentHeader, err := api._blockReader.HeaderByNumber(ctx, tx, n-1); err != nil {
+		if parentHeader, err := api._blockReader.Header(ctx, tx, block.ParentHash(), n-1); err != nil {
 			return nil, err
 		} else {
 			edg = parentHeader.ExcessDataGas

--- a/cmd/rpcdaemon/commands/graphql_api.go
+++ b/cmd/rpcdaemon/commands/graphql_api.go
@@ -78,7 +78,7 @@ func (api *GraphQLAPIImpl) GetBlockDetails(ctx context.Context, blockNumber rpc.
 	}
 	var edg *big.Int
 	if n := block.Number().Uint64(); n > 0 {
-		if parentHeader, err := api._blockReader.HeaderByNumber(ctx, tx, n-1); err != nil {
+		if parentHeader, err := api._blockReader.Header(ctx, tx, block.ParentHash(), n-1); err != nil {
 			return nil, err
 		} else {
 			edg = parentHeader.ExcessDataGas

--- a/cmd/rpcdaemon/commands/graphql_api.go
+++ b/cmd/rpcdaemon/commands/graphql_api.go
@@ -76,11 +76,19 @@ func (api *GraphQLAPIImpl) GetBlockDetails(ctx context.Context, blockNumber rpc.
 	if err != nil {
 		return nil, fmt.Errorf("getReceipts error: %w", err)
 	}
+	var edg *big.Int
+	if n := block.Number().Uint64(); n > 0 {
+		if parentHeader, err := api._blockReader.HeaderByNumber(ctx, tx, n-1); err != nil {
+			return nil, err
+		} else {
+			edg = parentHeader.ExcessDataGas
+		}
+	}
 	result := make([]map[string]interface{}, 0, len(receipts))
 	for _, receipt := range receipts {
 		txn := block.Transactions()[receipt.TransactionIndex]
 
-		transaction := marshalReceipt(receipt, txn, chainConfig, block.HeaderNoCopy(), txn.Hash(), true)
+		transaction := marshalReceipt(receipt, txn, chainConfig, block.HeaderNoCopy(), txn.Hash(), true, edg)
 		transaction["nonce"] = txn.GetNonce()
 		transaction["value"] = txn.GetValue()
 		transaction["data"] = txn.GetData()

--- a/cmd/rpcdaemon/commands/otterscan_api.go
+++ b/cmd/rpcdaemon/commands/otterscan_api.go
@@ -588,7 +588,7 @@ func (api *OtterscanAPIImpl) GetBlockTransactions(ctx context.Context, number rp
 
 	var edg *big.Int
 	if n := b.Number().Uint64(); n > 0 {
-		if parentHeader, err := api._blockReader.HeaderByNumber(ctx, tx, n-1); err != nil {
+		if parentHeader, err := api._blockReader.Header(ctx, tx, b.ParentHash(), n-1); err != nil {
 			return nil, err
 		} else {
 			edg = parentHeader.ExcessDataGas

--- a/cmd/rpcdaemon/commands/otterscan_api.go
+++ b/cmd/rpcdaemon/commands/otterscan_api.go
@@ -287,6 +287,7 @@ func (api *OtterscanAPIImpl) searchTransactionsBeforeV3(tx kv.TemporalTx, ctx co
 	receipts := make([]map[string]interface{}, 0, pageSize)
 	resultCount := uint16(0)
 
+	var excessDataGas *big.Int
 	for txNumsIter.HasNext() {
 		txNum, blockNum, txIndex, isFinalTxn, blockNumChanged, err := txNumsIter.Next()
 		if err != nil {
@@ -306,6 +307,13 @@ func (api *OtterscanAPIImpl) searchTransactionsBeforeV3(tx kv.TemporalTx, ctx co
 			}
 			blockHash = header.Hash()
 			exec.changeBlock(header)
+			if blockNum > 0 {
+				if parentHeader, err := api._blockReader.Header(ctx, tx, header.ParentHash, blockNum-1); err != nil {
+					return nil, err
+				} else {
+					excessDataGas = parentHeader.ExcessDataGas
+				}
+			}
 		}
 
 		//fmt.Printf("txNum=%d, blockNum=%d, txIndex=%d, maxTxNumInBlock=%d,mixTxNumInBlock=%d\n", txNum, blockNum, txIndex, maxTxNumInBlock, minTxNumInBlock)
@@ -327,7 +335,7 @@ func (api *OtterscanAPIImpl) searchTransactionsBeforeV3(tx kv.TemporalTx, ctx co
 			TransactionIndex: uint(txIndex),
 			BlockNumber:      header.Number, BlockHash: blockHash, Logs: rawLogs,
 		}
-		mReceipt := marshalReceipt(receipt, txn, chainConfig, header, txn.Hash(), true)
+		mReceipt := marshalReceipt(receipt, txn, chainConfig, header, txn.Hash(), true, excessDataGas)
 		mReceipt["timestamp"] = header.Time
 		receipts = append(receipts, mReceipt)
 
@@ -577,10 +585,19 @@ func (api *OtterscanAPIImpl) GetBlockTransactions(ctx context.Context, number rp
 	if err != nil {
 		return nil, fmt.Errorf("getReceipts error: %v", err)
 	}
+
+	var edg *big.Int
+	if n := b.Number().Uint64(); n > 0 {
+		if parentHeader, err := api._blockReader.HeaderByNumber(ctx, tx, n-1); err != nil {
+			return nil, err
+		} else {
+			edg = parentHeader.ExcessDataGas
+		}
+	}
 	result := make([]map[string]interface{}, 0, len(receipts))
 	for _, receipt := range receipts {
 		txn := b.Transactions()[receipt.TransactionIndex]
-		marshalledRcpt := marshalReceipt(receipt, txn, chainConfig, b.HeaderNoCopy(), txn.Hash(), true)
+		marshalledRcpt := marshalReceipt(receipt, txn, chainConfig, b.HeaderNoCopy(), txn.Hash(), true, edg)
 		marshalledRcpt["logs"] = nil
 		marshalledRcpt["logsBloom"] = nil
 		result = append(result, marshalledRcpt)

--- a/cmd/rpcdaemon/commands/otterscan_search_trace.go
+++ b/cmd/rpcdaemon/commands/otterscan_search_trace.go
@@ -97,7 +97,7 @@ func (api *OtterscanAPIImpl) traceBlock(dbtx kv.Tx, ctx context.Context, blockNu
 
 		if tracer.Found {
 			rpcTx := newRPCTransaction(tx, block.Hash(), blockNum, uint64(idx), block.BaseFee())
-			mReceipt := marshalReceipt(blockReceipts[idx], tx, chainConfig, block.HeaderNoCopy(), tx.Hash(), true)
+			mReceipt := marshalReceipt(blockReceipts[idx], tx, chainConfig, block.HeaderNoCopy(), tx.Hash(), true, excessDataGas)
 			mReceipt["timestamp"] = block.Time()
 			rpcTxs = append(rpcTxs, rpcTx)
 			receipts = append(receipts, mReceipt)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -34,7 +34,7 @@ import (
 // and uses the input parameters for its environment. It returns the receipt
 // for the transaction, gas used and an error if the transaction failed,
 // indicating the block was invalid.
-func applyTransaction(config *chain.Config, engine consensus.EngineReader, gp *GasPool, ibs *state.IntraBlockState, stateWriter state.StateWriter, header *types.Header, tx types.Transaction, usedGas *uint64, evm vm.VMInterface, cfg vm.Config) (*types.Receipt, []byte, error) {
+func applyTransaction(config *chain.Config, engine consensus.EngineReader, gp *GasPool, ibs *state.IntraBlockState, stateWriter state.StateWriter, header *types.Header, tx types.Transaction, usedGas *uint64, evm vm.VMInterface, cfg vm.Config, excessDataGas *big.Int) (*types.Receipt, []byte, error) {
 	rules := evm.ChainRules()
 	msg, err := tx.AsMessage(*types.MakeSigner(config, header.Number.Uint64()), header.BaseFee, rules)
 	if err != nil {
@@ -45,7 +45,7 @@ func applyTransaction(config *chain.Config, engine consensus.EngineReader, gp *G
 	if msg.FeeCap().IsZero() && engine != nil {
 		// Only zero-gas transactions may be service ones
 		syscall := func(contract libcommon.Address, data []byte) ([]byte, error) {
-			return SysCallContract(contract, data, *config, ibs, header, engine, true /* constCall */, nil /*excessDataGas*/)
+			return SysCallContract(contract, data, *config, ibs, header, engine, true /* constCall */, excessDataGas)
 		}
 		msg.SetIsFree(engine.IsServiceTransaction(msg.From(), syscall))
 	}
@@ -109,5 +109,5 @@ func ApplyTransaction(config *chain.Config, blockHashFunc func(n uint64) libcomm
 	blockContext := NewEVMBlockContext(header, blockHashFunc, engine, author, excessDataGas)
 	vmenv := vm.NewEVM(blockContext, evmtypes.TxContext{}, ibs, config, cfg)
 
-	return applyTransaction(config, engine, gp, ibs, stateWriter, header, tx, usedGas, vmenv, cfg)
+	return applyTransaction(config, engine, gp, ibs, stateWriter, header, tx, usedGas, vmenv, cfg, excessDataGas)
 }


### PR DESCRIPTION
Small additions to block receipts. Now it includes `dataGasPrice` and `dataGasUsed`. `dataGas` is a new type of a gas and blobs are priced in it. 