### PR TITLE
"fix" windows localhost resolution

### DIFF
--- a/wmake.ps1
+++ b/wmake.ps1
@@ -413,7 +413,9 @@ $Erigon.Commit     = [string]@(git.exe rev-list -1 HEAD)
 $Erigon.Branch     = [string]@(git.exe rev-parse --abbrev-ref HEAD)
 $Erigon.Tag        = [string]@(git.exe describe --tags)
 
-$Erigon.BuildTags = "nosqlite,noboltdb,netgo"
+## https://github.com/golang/go/issues/57757 
+## windows cannot build with netgo tag until this issue is resolved
+$Erigon.BuildTags = "nosqlite,noboltdb"
 $Erigon.Package = "github.com/ledgerwatch/erigon"
 
 $Erigon.BuildFlags = "-trimpath -tags $($Erigon.BuildTags) -buildvcs=false -v"


### PR DESCRIPTION
https://github.com/golang/go/issues/57757

i think we added netgo tag for the internalcl, since there was an issue with resolution there on linux at some point, but i guess in windows, netgo localhost resolution is broken.  

i just tested on my windows machine and removing netgo seems to work with both --internalcl=true  and false

