### PR TITLE
Enable negative Merkle proofs for eth_getProof

### DIFF
--- a/cmd/rpcdaemon/commands/eth_call.go
+++ b/cmd/rpcdaemon/commands/eth_call.go
@@ -385,6 +385,9 @@ func (api *APIImpl) GetProof(ctx context.Context, address libcommon.Address, sto
 	if err != nil {
 		return nil, err
 	}
+	if a == nil {
+		a = &accounts.Account{}
+	}
 	pr, err := trie.NewProofRetainer(address, a, storageKeys, rl)
 	if err != nil {
 		return nil, err

--- a/cmd/rpcdaemon/commands/eth_call_test.go
+++ b/cmd/rpcdaemon/commands/eth_call_test.go
@@ -137,11 +137,37 @@ func TestGetProof(t *testing.T) {
 			blockNum: 3,
 		},
 		{
+			name:     "currentBlockNoAccount",
+			addr:     libcommon.HexToAddress("0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddead0"),
+			blockNum: 3,
+		},
+		{
 			name:        "currentBlockWithState",
 			addr:        contractAddr,
 			blockNum:    3,
 			storageKeys: []libcommon.Hash{key(0), key(4), key(8), key(10)},
 			stateVal:    2,
+		},
+		{
+			name:        "currentBlockWithMissingState",
+			addr:        contractAddr,
+			storageKeys: []libcommon.Hash{libcommon.HexToHash("0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddead")},
+			blockNum:    3,
+			stateVal:    0,
+		},
+		{
+			name:        "currentBlockEOAMissingState",
+			addr:        bankAddr,
+			storageKeys: []libcommon.Hash{libcommon.HexToHash("0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddead")},
+			blockNum:    3,
+			stateVal:    0,
+		},
+		{
+			name:        "currentBlockNoAccountMissingState",
+			addr:        libcommon.HexToAddress("0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddead0"),
+			storageKeys: []libcommon.Hash{libcommon.HexToHash("0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddead")},
+			blockNum:    3,
+			stateVal:    0,
 		},
 		{
 			name:        "olderBlockWithState",
@@ -192,7 +218,7 @@ func TestGetProof(t *testing.T) {
 						continue
 					}
 					found = true
-					require.Equal(t, uint256.NewInt(tt.stateVal).ToBig(), (*big.Int)(storageProof.Value))
+					require.Equal(t, tt.stateVal, (*big.Int)(storageProof.Value).Uint64())
 					err = trie.VerifyStorageProof(proof.StorageHash, storageProof)
 					require.NoError(t, err)
 				}

--- a/turbo/trie/gen_struct_step.go
+++ b/turbo/trie/gen_struct_step.go
@@ -184,7 +184,7 @@ func GenStructStepEx(
 				}
 				buildExtensions = true
 			case *GenStructStepAccountData:
-				proving := retainIfProving(curr[:len(curr)-1])
+				proving := retainIfProving(curr[:remainderStart])
 				if proving || retain(curr[:maxLen]) {
 					if err := e.accountLeaf(remainderLen, curr, &v.Balance, v.Nonce, v.Incarnation, v.FieldSet, codeSizeUncached); err != nil {
 						return nil, nil, nil, err
@@ -199,7 +199,7 @@ func GenStructStepEx(
 				}
 			case *GenStructStepLeafData:
 				/* building leafs */
-				proving := retainIfProving(curr[:len(curr)-1])
+				proving := retainIfProving(curr[:remainderStart])
 				if proving || retain(curr[:maxLen]) {
 					if err := e.leaf(remainderLen, curr, v.Value); err != nil {
 						return nil, nil, nil, err

--- a/turbo/trie/retain_list.go
+++ b/turbo/trie/retain_list.go
@@ -20,10 +20,12 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"math/big"
 	"sort"
 
 	"github.com/holiman/uint256"
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/common/length"
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/common/hexutil"
 	"github.com/ledgerwatch/erigon/core/types/accounts"
@@ -139,12 +141,12 @@ func (pr *ProofRetainer) ProofResult() (*accounts.AccProofResult, error) {
 			continue
 		}
 		result.AccountProof = append(result.AccountProof, pe.proof.Bytes())
-		if pe.storageRoot != (libcommon.Hash{}) {
+		if bytes.Equal(pr.accHexKey, pe.storageRootKey) {
 			result.StorageHash = pe.storageRoot
 		}
 	}
 
-	if result.StorageHash == (libcommon.Hash{}) {
+	if pr.acc.Initialised && result.StorageHash == (libcommon.Hash{}) {
 		return nil, fmt.Errorf("did not find storage root in proof elements")
 	}
 
@@ -152,6 +154,19 @@ func (pr *ProofRetainer) ProofResult() (*accounts.AccProofResult, error) {
 	for i, sk := range pr.storageKeys {
 		result.StorageProof[i].Key = sk
 		hexKey := pr.storageHexKeys[i]
+		if !pr.acc.Initialised || result.StorageHash == EmptyRoot {
+			// The yellow paper makes it clear that the EmptyRoot is a special case
+			// when the trie has no nodes, but EIP-1186 states that the proof is
+			// "starting with the storageHash-Node".  Since the trie has no nodes,
+			// it's unclear whether the correct proof should contain the EmptyRoot
+			// pre-image of RLP([]byte(nil)), or be empty.  This implementation
+			// chooses 'empty' as it seems more consistent and it is expected that
+			// provers will treat the EmptyRoot as a special case and ignore the proof
+			// bytes.
+			result.StorageProof[i].Value = (*hexutil.Big)(new(big.Int))
+			continue
+		}
+
 		for _, pe := range pr.proofs {
 			if len(pe.hexKey) <= 2*32 {
 				// Ignore the proof elements above the storage tree (64 bytes, as nibble
@@ -161,7 +176,8 @@ func (pr *ProofRetainer) ProofResult() (*accounts.AccProofResult, error) {
 			if !bytes.HasPrefix(hexKey, pe.hexKey) {
 				continue
 			}
-			if pe.storageValue != nil {
+
+			if pe.storageValue != nil && bytes.Equal(pe.storageKey, hexKey[2*(length.Hash+length.Incarnation):]) {
 				result.StorageProof[i].Value = (*hexutil.Big)(pe.storageValue.ToBig())
 			}
 
@@ -169,7 +185,7 @@ func (pr *ProofRetainer) ProofResult() (*accounts.AccProofResult, error) {
 		}
 
 		if result.StorageProof[i].Value == nil {
-			return nil, fmt.Errorf("no storage value for storage key 0x%x set", sk)
+			result.StorageProof[i].Value = (*hexutil.Big)(new(big.Int))
 		}
 	}
 
@@ -192,9 +208,19 @@ type proofElement struct {
 	// an account leaf
 	storageRoot libcommon.Hash
 
-	// storageValue stores the value of the particular storage
-	// key if this writer is for a storage key
+	// storageRootKey stores the actual hexKey from which the storageRoot came.
+	// This is needed because other proof nodes can be included in the negative
+	// proof case.
+	storageRootKey []byte
+
+	// storageValue stores the value of the particular storage key if this writer
+	// is for a storage key
 	storageValue *uint256.Int
+
+	// storageKey stores the actual hexKey from which the storageValue came. This
+	// is needed because the same proofElement may be used to both prove and
+	// disprove two different storage elements.
+	storageKey []byte
 }
 
 // RetainList encapsulates the list of keys that are required to be fully available, or loaded


### PR DESCRIPTION
This addresses the last known deficiency of the eth_getProof implementation.  The previous code would return an error in the event that the element was not found in the trie.  EIP-1186 allows for 'negative' proofs where a proof demonstrates that an element cannot be in the trie, so this commit updates the logic to support that case.