### PR TITLE
eip-4844: Unwrap() additional tx method

### DIFF
--- a/cmd/rpcdaemon/commands/engine_api.go
+++ b/cmd/rpcdaemon/commands/engine_api.go
@@ -378,7 +378,7 @@ func (e *EngineImpl) GetPayloadV2(ctx context.Context, payloadID hexutility.Byte
 }
 
 func (e *EngineImpl) GetPayloadV3(ctx context.Context, payloadID hexutility.Bytes) (*GetPayloadV3Response, error) {
-	if e.internalCL { // TODO: find out what is the way around it
+	if e.internalCL {
 		log.Error("EXTERNAL CONSENSUS LAYER IS NOT ENABLED, PLEASE RESTART WITH FLAG --externalcl")
 		return nil, fmt.Errorf("engine api should not be used, restart with --externalcl")
 	}
@@ -496,8 +496,10 @@ var ourCapabilities = []string{
 	"engine_forkchoiceUpdatedV2",
 	"engine_newPayloadV1",
 	"engine_newPayloadV2",
+	// "engine_newPayloadV3",
 	"engine_getPayloadV1",
 	"engine_getPayloadV2",
+	// "engine_getPayloadV3",
 	"engine_exchangeTransitionConfigurationV1",
 	"engine_getPayloadBodiesByHashV1",
 	"engine_getPayloadBodiesByRangeV1",

--- a/core/types/access_list_tx.go
+++ b/core/types/access_list_tx.go
@@ -85,6 +85,10 @@ func (tx AccessListTx) Protected() bool {
 	return true
 }
 
+func (tx *AccessListTx) Unwrap() Transaction {
+	return tx
+}
+
 // EncodingSize returns the RLP encoding size of the whole transaction envelope
 func (tx AccessListTx) EncodingSize() int {
 	payloadSize, _, _, _ := tx.payloadSize()

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -109,7 +109,7 @@ type Header struct {
 // returns nil if the parent header could not be fetched, or if the parent block's excess data gas
 // is nil.
 func (h *Header) ParentExcessDataGas(getHeader func(hash libcommon.Hash, number uint64) *Header) *big.Int {
-	p := getHeader(h.ParentHash, h.Number.Uint64())
+	p := getHeader(h.ParentHash, h.Number.Uint64()-1)
 	if p != nil {
 		return p.ExcessDataGas
 	}

--- a/core/types/dynamic_fee_tx.go
+++ b/core/types/dynamic_fee_tx.go
@@ -67,6 +67,10 @@ func (tx DynamicFeeTransaction) Cost() *uint256.Int {
 	return total
 }
 
+func (tx *DynamicFeeTransaction) Unwrap() Transaction {
+	return tx
+}
+
 // copy creates a deep copy of the transaction data and initializes all fields.
 func (tx DynamicFeeTransaction) copy() *DynamicFeeTransaction {
 	cpy := &DynamicFeeTransaction{

--- a/core/types/legacy_tx.go
+++ b/core/types/legacy_tx.go
@@ -134,6 +134,10 @@ func (tx LegacyTx) Protected() bool {
 	return isProtectedV(&tx.V)
 }
 
+func (tx *LegacyTx) Unwrap() Transaction {
+	return tx
+}
+
 // NewTransaction creates an unsigned legacy transaction.
 // Deprecated: use NewTx instead.
 func NewTransaction(nonce uint64, to libcommon.Address, amount *uint256.Int, gasLimit uint64, gasPrice *uint256.Int, data []byte) *LegacyTx {

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -443,6 +443,9 @@ func (rs Receipts) EncodeIndex(i int, w *bytes.Buffer) {
 		if err := rlp.Encode(w, data); err != nil {
 			panic(err)
 		}
+	case BlobTxType:
+		w.WriteByte(BlobTxType)
+		rlp.Encode(w, data)
 	default:
 		// For unsupported types, write nothing. Since this is for
 		// DeriveSha, the error will be caught matching the derived hash

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -93,6 +93,7 @@ type Transaction interface {
 	GetSender() (libcommon.Address, bool)
 	SetSender(libcommon.Address)
 	IsContractDeploy() bool
+	Unwrap() Transaction // If this is a network wrapper, returns the unwrapped tx. Otherwiwes returns itself.
 }
 
 // TransactionMisc is collection of miscelaneous fields for transaction that is supposed to be embedded into concrete


### PR DESCRIPTION
Transaction extension to support BlobTxWrapper (or network representation of BlobTx). BlobTxWrapper wraps BlobTx with additional data: blobs, commitments and proofs. Unwrap() returns unwrapped tx if its network tx, otherwise returns itself. 