### PR TITLE
Add diagnostics endpoint for flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ For building the latest stable release (this will be suitable for most users jus
 ```sh
 git clone --branch stable --single-branch https://github.com/ledgerwatch/erigon.git
 cd erigon
-mate erigon
+make erigon
 ./build/bin/erigon
 ```
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ For building the latest stable release (this will be suitable for most users jus
 ```sh
 git clone --branch stable --single-branch https://github.com/ledgerwatch/erigon.git
 cd erigon
-make erigon
+mate erigon
 ./build/bin/erigon
 ```
 

--- a/cmd/utils/flags/flags.go
+++ b/cmd/utils/flags/flags.go
@@ -46,6 +46,10 @@ func (s *DirectoryString) Set(value string) error {
 	return nil
 }
 
+func (s *DirectoryString) Get() any {
+	return s.String()
+}
+
 var (
 	_ cli.Flag              = (*DirectoryFlag)(nil)
 	_ cli.RequiredFlag      = (*DirectoryFlag)(nil)

--- a/diagnostics/CHANGELOG.md
+++ b/diagnostics/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to `diagnostics` will be documented in this file.
+
+## Version 2
+
+### Added
+
+- Introduce `flags` endpoint (#7417)
+
+### Changed
+
+- Increment diagnostic version to 2 in `version.go` (#7417)
+
+## Version 1
+
+### Added
+
+- Introduce diagnostics versioning via `version` endpoint (#7300)
+- Introduce `logs/list` and `logs/read` endpoint (#6930)
+- Introduce `db/list`, `db/tables` and `db/read` endpoint (#6930)
+- Introduce `cmdline` (#7271)
+- Introduce `block_body_download` (#7373)

--- a/diagnostics/flags.go
+++ b/diagnostics/flags.go
@@ -1,0 +1,23 @@
+package diagnostics
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/urfave/cli/v2"
+)
+
+func SetupFlagsAccess(ctx *cli.Context) {
+	http.HandleFunc("/debug/metrics/flags", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		writeFlags(w, ctx)
+	})
+}
+
+func writeFlags(w io.Writer, ctx *cli.Context) {
+	fmt.Fprintf(w, "SUCCESS\n")
+	for _, flagName := range ctx.FlagNames() {
+		fmt.Fprintf(w, "%s=%v\n", flagName, ctx.Value(flagName))
+	}
+}

--- a/diagnostics/version.go
+++ b/diagnostics/version.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ledgerwatch/erigon/params"
 )
 
-const Version = 1
+const Version = 2
 
 func SetupVersionAccess() {
 	http.HandleFunc("/debug/metrics/version", func(w http.ResponseWriter, r *http.Request) {

--- a/turbo/debug/flags.go
+++ b/turbo/debug/flags.go
@@ -192,6 +192,7 @@ func Setup(ctx *cli.Context) error {
 		diagnostics.SetupLogsAccess(ctx)
 		diagnostics.SetupDbAccess(ctx)
 		diagnostics.SetupCmdLineAccess()
+		diagnostics.SetupFlagsAccess(ctx)
 		diagnostics.SetupVersionAccess()
 		diagnostics.SetupBlockBodyDownload()
 	}


### PR DESCRIPTION
To expose context flags through diagnostic endpoint `/debug/metrics/flags`. 

The current `/debug/metrics/cmdline` only provides the command run by user. In the case when user runs Erigon using config file, `cmdline`’s info does not truly reflect the ‘launch setting' and flags set that Erigon is running on.

## Example

### Command
```
erigon --datadir /tmp/data --config test.yaml
```
### Pseudo config file (in yaml)
```
datadir : '/tmp/data'
chain : "sepolia"
http : true
metrics: true
private.api.addr : "localhost:9090"

http.api : ["eth","debug","net"]
```
### Output
```
SUCCESS
chain=sepolia
config=test.yaml
datadir=/tmp/data
http=true
http.api=eth,debug,net
metrics=true
private.api.addr=localhost:9090
```