### PR TITLE
fix block rlp logging bug

### DIFF
--- a/cmd/rpcdaemon/rpcservices/eth_backend.go
+++ b/cmd/rpcdaemon/rpcservices/eth_backend.go
@@ -318,7 +318,7 @@ func (back *RemoteBackend) PendingBlock(ctx context.Context) (*types.Block, erro
 	var block types.Block
 	err = rlp.Decode(bytes.NewReader(blockRlp.BlockRlp), &block)
 	if err != nil {
-		return nil, fmt.Errorf("decoding block from %x: %w", blockRlp, err)
+		return nil, fmt.Errorf("decoding block from %x: %w", blockRlp.BlockRlp, err)
 	}
 
 	return &block, nil


### PR DESCRIPTION
fixes a logging statement was logging the outer rpc proto instead of the inner rlp of the block as intended
