### PR TITLE
fix: erigon_getLatestLogs

### DIFF
--- a/cmd/rpcdaemon/commands/erigon_receipts.go
+++ b/cmd/rpcdaemon/commands/erigon_receipts.go
@@ -251,7 +251,7 @@ func (api *ErigonImpl) GetLatestLogs(ctx context.Context, crit filters.FilterCri
 	}
 	topicsMap := make(map[common.Hash]struct{})
 	for i := range crit.Topics {
-		for j := range crit.Topics {
+		for j := range crit.Topics[i] {
 			topicsMap[crit.Topics[i][j]] = struct{}{}
 		}
 	}


### PR DESCRIPTION
When calling erigon_getLatestLogs, I was getting a crash in [erigon_receipts.go](https://github.com/ledgerwatch/erigon/blob/beb97784d43ece5acde365a74efe8763692ebdba/cmd/rpcdaemon/commands/erigon_receipts.go#L254). I think it is a simple indexing bug

```
[service.go:217 panic.go:884 panic.go:113 erigon_receipts.go:254 value.go:586 value.go:370 service.go:222 
handler.go:494 handler.go:444 handler.go:392 handler.go:223 handler.go:316 asm_amd64.s:1598]
[WARN] [05-05|21:13:59.749] Served                                   
conn=100.70.204.111:50141 method=erigon_getLatestLogs reqid=1 t=621.5936ms err="method handler crashed"
```


