### PR TITLE
p2p: fix peer ID serialization

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -1014,7 +1014,7 @@ func (srv *Server) setupConn(c *conn, flags connFlag, dialDest *enode.Node) erro
 		srv.log.Trace("Failed RLPx handshake", "addr", c.fd.RemoteAddr(), "conn", c.flags, "err", err)
 		return err
 	}
-	copy(c.pubkey[:], crypto.MarshalPubkey(remotePubkey)[1:])
+	copy(c.pubkey[:], crypto.MarshalPubkey(remotePubkey))
 	if dialDest != nil {
 		c.node = dialDest
 	} else {


### PR DESCRIPTION
The peer ID in sentry.proto is a H512 / 64 bytes value, and MarshalPubkey creates it from a public key.

There's no need to cut the first byte, because MarshalPubkey already does it.
Doing so results in a 63 bytes value that is incompatible with silkworm sentry.