### PR TITLE
Allow ephemeral ports for p2p

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -360,6 +360,12 @@ func New(stack *node.Node, config *ethconfig.Config, logger log.Logger) (*Ethere
 			var picked bool
 			for ; pi < len(refCfg.AllowedPorts) && !picked; pi++ {
 				pc := int(refCfg.AllowedPorts[pi])
+				if pc == 0 {
+					// For ephemeral ports probing to see if the port is taken does not
+					// make sense.
+					picked = true
+					break
+				}
 				if !checkPortIsFree(fmt.Sprintf("%s:%d", listenHost, pc)) {
 					logger.Warn("bind protocol to port has failed: port is busy", "protocols", fmt.Sprintf("eth/%d", refCfg.ProtocolVersion), "port", pc)
 					continue


### PR DESCRIPTION
Currently, the p2p ports require an explicit enumeration of ports to pick.  Sometimes, for instance when writing integration tests utilizing an Erigon binary the particular p2p port does not matter and trying to pick non-allocated port ranges is fragile.

This small PR simply checks to see if the enumerated port is '0', in which case it disables the probing check which would otherwise cause Erigon not to try binding to an ephemeral port.