### PR TITLE
Args usage msg bug fix

### DIFF
--- a/turbo/app/support_cmd.go
+++ b/turbo/app/support_cmd.go
@@ -38,7 +38,7 @@ var supportCommand = cli.Command{
 	Action:    MigrateFlags(connectDiagnostics),
 	Name:      "support",
 	Usage:     "Connect Erigon instance to a diagnostics system for support",
-	ArgsUsage: "--diagnostics.url <URL for the diagnostics system> --metrics.url <http://erigon_host:metrics_port>",
+	ArgsUsage: "--diagnostics.url <URL for the diagnostics system> --metrics.urls <http://erigon_host:metrics_port>",
 	Flags: []cli.Flag{
 		&metricsURLsFlag,
 		&diagnosticsURLFlag,


### PR DESCRIPTION
## What's this PR is about?
Minor fix in args usage message of support flag. The current message says that the flag should be 'metrics.url' but it reality it should be 'metrics.urls'