### PR TITLE
consensus/bor: use current producers for extra data validation

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -482,13 +482,13 @@ func (c *Bor) verifyCascadingFields(chain consensus.ChainHeaderReader, header *t
 
 	// Verify the validator list match the local contract
 	if isSprintStart(number+1, c.config.CalculateSprint(number)) {
-		newValidators, err := c.spanner.GetCurrentValidators(number+1, c.authorizedSigner.Load().signer, c.getSpanForBlock)
+		producerSet, err := c.spanner.GetCurrentProducers(number+1, c.authorizedSigner.Load().signer, c.getSpanForBlock)
 
 		if err != nil {
 			return err
 		}
 
-		sort.Sort(valset.ValidatorsByAddress(newValidators))
+		sort.Sort(valset.ValidatorsByAddress(producerSet))
 
 		headerVals, err := valset.ParseValidators(header.Extra[extraVanity : len(header.Extra)-extraSeal])
 
@@ -496,11 +496,11 @@ func (c *Bor) verifyCascadingFields(chain consensus.ChainHeaderReader, header *t
 			return err
 		}
 
-		if len(newValidators) != len(headerVals) {
+		if len(producerSet) != len(headerVals) {
 			return errInvalidSpanValidators
 		}
 
-		for i, val := range newValidators {
+		for i, val := range producerSet {
 			if !bytes.Equal(val.HeaderBytes(), headerVals[i].HeaderBytes()) {
 				return errInvalidSpanValidators
 			}

--- a/consensus/bor/heimdall/span/spanner.go
+++ b/consensus/bor/heimdall/span/spanner.go
@@ -109,9 +109,9 @@ func (c *ChainSpanner) GetCurrentProducers(blockNumber uint64, signer libcommon.
 		return nil, err
 	}
 
-	producers := make([]*valset.Validator, 0, len(span.SelectedProducers))
-	for _, producer := range span.SelectedProducers {
-		producers = append(producers, &producer)
+	producers := make([]*valset.Validator, len(span.SelectedProducers))
+	for i := range span.SelectedProducers {
+		producers[i] = &span.SelectedProducers[i]
 	}
 
 	return producers, nil

--- a/consensus/bor/heimdall/span/spanner.go
+++ b/consensus/bor/heimdall/span/spanner.go
@@ -89,6 +89,34 @@ func (c *ChainSpanner) GetCurrentValidators(blockNumber uint64, signer libcommon
 	return span.ValidatorSet.Validators, nil
 }
 
+func (c *ChainSpanner) GetCurrentProducers(blockNumber uint64, signer libcommon.Address, getSpanForBlock func(blockNum uint64) (*HeimdallSpan, error)) ([]*valset.Validator, error) {
+	// Use signer as validator in case of bor devent
+	if c.chainConfig.ChainName == networkname.BorDevnetChainName {
+		validators := []*valset.Validator{
+			{
+				ID:               1,
+				Address:          signer,
+				VotingPower:      1000,
+				ProposerPriority: 1,
+			},
+		}
+
+		return validators, nil
+	}
+
+	span, err := getSpanForBlock(blockNumber)
+	if err != nil {
+		return nil, err
+	}
+
+	producers := make([]*valset.Validator, 0, len(span.SelectedProducers))
+	for _, producer := range span.SelectedProducers {
+		producers = append(producers, &producer)
+	}
+
+	return producers, nil
+}
+
 func (c *ChainSpanner) CommitSpan(heimdallSpan HeimdallSpan, syscall consensus.SystemCall) error {
 
 	// method

--- a/consensus/bor/span.go
+++ b/consensus/bor/span.go
@@ -11,5 +11,6 @@ import (
 type Spanner interface {
 	GetCurrentSpan(syscall consensus.SystemCall) (*span.Span, error)
 	GetCurrentValidators(blockNumber uint64, signer libcommon.Address, getSpanForBlock func(blockNum uint64) (*span.HeimdallSpan, error)) ([]*valset.Validator, error)
+	GetCurrentProducers(blockNumber uint64, signer libcommon.Address, getSpanForBlock func(blockNum uint64) (*span.HeimdallSpan, error)) ([]*valset.Validator, error)
 	CommitSpan(heimdallSpan span.HeimdallSpan, syscall consensus.SystemCall) error
 }

--- a/consensus/bor/span_mock.go
+++ b/consensus/bor/span_mock.go
@@ -51,6 +51,21 @@ func (mr *MockSpannerMockRecorder) CommitSpan(arg0, arg1 interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommitSpan", reflect.TypeOf((*MockSpanner)(nil).CommitSpan), arg0, arg1)
 }
 
+// GetCurrentProducers mocks base method.
+func (m *MockSpanner) GetCurrentProducers(arg0 uint64, arg1 common.Address, arg2 func(uint64) (*span.HeimdallSpan, error)) ([]*valset.Validator, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCurrentProducers", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]*valset.Validator)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCurrentProducers indicates an expected call of GetCurrentProducers.
+func (mr *MockSpannerMockRecorder) GetCurrentProducers(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentProducers", reflect.TypeOf((*MockSpanner)(nil).GetCurrentProducers), arg0, arg1, arg2)
+}
+
 // GetCurrentSpan mocks base method.
 func (m *MockSpanner) GetCurrentSpan(arg0 consensus.SystemCall) (*span.Span, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Fixes issues with consensus validation. Compare against current producer set instead of whole validator set. 