### PR TITLE
cmd/evm: support batched statetest-mode

### DIFF
--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -17,9 +17,9 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -57,9 +57,6 @@ type StatetestResult struct {
 }
 
 func stateTestCmd(ctx *cli.Context) error {
-	if len(ctx.Args().First()) == 0 {
-		return errors.New("path-to-test argument required")
-	}
 	// Configure the go-ethereum logger
 	log.Root().SetHandler(log.LvlFilterHandler(log.LvlDebug, log.StderrHandler))
 
@@ -70,23 +67,35 @@ func stateTestCmd(ctx *cli.Context) error {
 		DisableStorage:    ctx.Bool(DisableStorageFlag.Name),
 		DisableReturnData: ctx.Bool(DisableReturnDataFlag.Name),
 	}
-	var (
-		tracer   vm.EVMLogger
-		debugger *logger.StructLogger
-	)
-	switch {
-	case ctx.Bool(MachineFlag.Name):
-		tracer = logger.NewJSONLogger(config, os.Stderr)
-
-	case ctx.Bool(DebugFlag.Name):
-		debugger = logger.NewStructLogger(config)
-		tracer = debugger
-
-	default:
-		debugger = logger.NewStructLogger(config)
+	cfg := vm.Config{
+		Debug: ctx.Bool(DebugFlag.Name) || ctx.Bool(MachineFlag.Name),
 	}
+	if ctx.Bool(MachineFlag.Name) {
+		cfg.Tracer = logger.NewJSONLogger(config, os.Stderr)
+	} else if ctx.Bool(DebugFlag.Name) {
+		cfg.Tracer = logger.NewStructLogger(config)
+	}
+
+	if len(ctx.Args().First()) != 0 {
+		return runStateTest(ctx.Args().First(), cfg, ctx.Bool(MachineFlag.Name))
+	}
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		fname := scanner.Text()
+		if len(fname) == 0 {
+			return nil
+		}
+		if err := runStateTest(fname, cfg, ctx.Bool(MachineFlag.Name)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// runStateTest loads the state-test given by fname, and executes the test.
+func runStateTest(fname string, cfg vm.Config, jsonOut bool) error {
 	// Load the test content from the input file
-	src, err := os.ReadFile(ctx.Args().First())
+	src, err := os.ReadFile(fname)
 	if err != nil {
 		return err
 	}
@@ -96,7 +105,7 @@ func stateTestCmd(ctx *cli.Context) error {
 	}
 
 	// Iterate over all the stateTests, run them and aggregate the results
-	results, err := aggregateResultsFromStateTests(ctx, stateTests, tracer, debugger)
+	results, err := aggregateResultsFromStateTests(stateTests, cfg, jsonOut)
 	if err != nil {
 		return err
 	}
@@ -107,17 +116,8 @@ func stateTestCmd(ctx *cli.Context) error {
 }
 
 func aggregateResultsFromStateTests(
-	ctx *cli.Context,
-	stateTests map[string]tests.StateTest,
-	tracer vm.EVMLogger,
-	debugger *logger.StructLogger,
-) ([]StatetestResult, error) {
-	// Iterate over all the stateTests, run them and aggregate the results
-	cfg := vm.Config{
-		Tracer: tracer,
-		Debug:  ctx.Bool(DebugFlag.Name) || ctx.Bool(MachineFlag.Name),
-	}
-
+	stateTests map[string]tests.StateTest, cfg vm.Config,
+	jsonOut bool) ([]StatetestResult, error) {
 	//this DB is shared. means:
 	// - faster sequential tests: don't need create/delete db
 	// - less parallelism: multiple processes can open same DB but only 1 can create rw-transaction (other will wait when 1-st finish)
@@ -156,24 +156,10 @@ func aggregateResultsFromStateTests(
 				result.Pass, result.Error = false, err.Error()
 			}
 
-			/*
-				if result.Error != "" {
-					if ctx.GlobalBool(DumpFlag.Name) && statedb != nil {
-						tx, err1 := tds.Database().Begin(context.Background(), ethdb.RO)
-						if err1 != nil {
-							return fmt.Errorf("transition cannot open tx: %v", err1)
-						}
-						dump := state.NewDumper(tx, tds.GetBlockNr()).DefaultRawDump()
-						tx.Rollback()
-						result.State = &dump
-					}
-				}
-			*/
-
 			// print state root for evmlab tracing
 			if statedb != nil {
 				result.Root = &root
-				if ctx.Bool(MachineFlag.Name) {
+				if jsonOut {
 					_, printErr := fmt.Fprintf(os.Stderr, "{\"stateRoot\": \"%#x\"}\n", root.Bytes())
 					if printErr != nil {
 						log.Warn("Failed to write to stderr", "err", printErr)
@@ -181,17 +167,6 @@ func aggregateResultsFromStateTests(
 				}
 			}
 			results = append(results, *result)
-
-			// Print any structured logs collected
-			if ctx.Bool(DebugFlag.Name) {
-				if debugger != nil {
-					_, printErr := fmt.Fprintln(os.Stderr, "#### TRACE ####")
-					if printErr != nil {
-						log.Warn("Failed to write to stderr", "err", printErr)
-					}
-					logger.WriteTrace(os.Stderr, debugger.StructLogs())
-				}
-			}
 		}
 	}
 	return results, nil


### PR DESCRIPTION
This implements batched state-test exectution, similar to https://github.com/ethereum/go-ethereum/pull/27318 . 
Some speedtests, executing a state-test twice on current master takes ~4-5 seconds, and scales linerarly.
```
Doing 2 execs old style

real    0m8.185s
user    0m8.081s
sys     0m0.110s
```
Doing `100` executions on this PR -- a few seconds of ramp-up time, but very quick execution after that : 
```
Doing 100 execs v2

real    0m5.009s
user    0m4.560s
sys     0m0.508s
```
I also tested a version where I moved the db instantiation into the top callsite, with the `MustOpen` and `.Close` only performed once, instead of `100` times -- however, I noticed no additional speed gains from doing so (my branch `batched_evm_v2`). 

Therefore, I suspect that the slowdowns comes not from the db, but the kzg library initialization.