### PR TITLE
prune speedup. stage_senders: don't re-calc existing senders

### DIFF
--- a/cmd/erigon-el/stages/stages.go
+++ b/cmd/erigon-el/stages/stages.go
@@ -47,7 +47,7 @@ func NewStagedSync(
 	blockWriter *blockio.BlockWriter,
 ) (*stagedsync.Sync, error) {
 	dirs := cfg.Dirs
-	blockRetire := snapshotsync.NewBlockRetire(1, dirs.Tmp, blockReader, db, snapDownloader, notifications.Events, logger)
+	blockRetire := snapshotsync.NewBlockRetire(1, dirs.Tmp, blockReader, blockWriter, db, snapDownloader, notifications.Events, logger)
 
 	// During Import we don't want other services like header requests, body requests etc. to be running.
 	// Hence we run it in the test mode.

--- a/cmd/hack/tool/fromdb/tool.go
+++ b/cmd/hack/tool/fromdb/tool.go
@@ -38,6 +38,19 @@ func PruneMode(db kv.RoDB) (pm prune.Mode) {
 func TxsV3(db kv.RoDB) (enabled bool) {
 	if err := db.View(context.Background(), func(tx kv.Tx) error {
 		var err error
+		enabled, err = kvcfg.TransactionsV3.Enabled(tx)
+		if err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		panic(err)
+	}
+	return
+}
+func HistV3(db kv.RoDB) (enabled bool) {
+	if err := db.View(context.Background(), func(tx kv.Tx) error {
+		var err error
 		enabled, err = kvcfg.HistoryV3.Enabled(tx)
 		if err != nil {
 			return err

--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -868,7 +868,7 @@ func stageSenders(db kv.RwDB, ctx context.Context, logger log.Logger) error {
 
 	var blockRetire *snapshotsync.BlockRetire
 	if sn.Cfg().Enabled {
-		blockRetire = snapshotsync.NewBlockRetire(estimate.CompressSnapshot.Workers(), tmpdir, br, db, nil, nil, logger)
+		blockRetire = snapshotsync.NewBlockRetire(estimate.CompressSnapshot.Workers(), tmpdir, br, bw, db, nil, nil, logger)
 	}
 
 	pm, err := prune.Get(tx)

--- a/cmd/state/commands/check_change_sets.go
+++ b/cmd/state/commands/check_change_sets.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ledgerwatch/erigon-lib/kv"
 	kv2 "github.com/ledgerwatch/erigon-lib/kv/mdbx"
 	"github.com/ledgerwatch/erigon-lib/kv/temporal/historyv2"
+	"github.com/ledgerwatch/erigon/cmd/utils"
 	"github.com/ledgerwatch/log/v3"
 	"github.com/spf13/cobra"
 
@@ -41,7 +42,7 @@ func init() {
 	withSnapshotBlocks(checkChangeSetsCmd)
 	checkChangeSetsCmd.Flags().StringVar(&historyfile, "historyfile", "", "path to the file where the changesets and history are expected to be. If omitted, the same as <datadir>/erion/chaindata")
 	checkChangeSetsCmd.Flags().BoolVar(&nocheck, "nocheck", false, "set to turn off the changeset checking and only execute transaction (for performance testing)")
-	checkChangeSetsCmd.Flags().BoolVar(&transactionsV3, "experimental.transactions.v3", false, "(this flag is in testing stage) Not recommended yet: Can't change this flag after node creation. New DB table for transactions allows keeping multiple branches of block bodies in the DB simultaneously")
+	checkChangeSetsCmd.Flags().BoolVar(&transactionsV3, utils.TransactionV3Flag.Name, utils.TransactionV3Flag.Value, utils.TransactionV3Flag.Usage)
 	rootCmd.AddCommand(checkChangeSetsCmd)
 }
 

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -1291,10 +1291,13 @@ func DeleteAncientBlocks(tx kv.RwTx, blockTo uint64, blocksDeleteLimit int) erro
 		// Copying k because otherwise the same memory will be reused
 		// for the next key and Delete below will end up deleting 1 more record than required
 		kCopy := common.CopyBytes(k)
-		if err = tx.Delete(kv.Headers, kCopy); err != nil {
+		if err = tx.Delete(kv.Senders, kCopy); err != nil {
 			return err
 		}
 		if err = tx.Delete(kv.BlockBody, kCopy); err != nil {
+			return err
+		}
+		if err = tx.Delete(kv.Headers, kCopy); err != nil {
 			return err
 		}
 	}

--- a/core/rawdb/blockio/block_writer.go
+++ b/core/rawdb/blockio/block_writer.go
@@ -19,6 +19,10 @@ import (
 	"github.com/ledgerwatch/log/v3"
 )
 
+//Naming:
+//  Prune: delete old data
+//  Unwind: delete recent data
+
 // BlockReader can read blocks from db and snapshots
 type BlockWriter struct {
 	historyV3 bool
@@ -114,6 +118,11 @@ func (w *BlockWriter) MakeBodiesNonCanonical(tx kv.RwTx, from uint64, deleteBodi
 		return nil
 	}
 
+	//if deleteBodies {
+	//if err := rawdb.MakeBodiesNonCanonical(tx, from, deleteBodies, ctx, logPrefix, logEvery); err != nil {
+	//	return err
+	//}
+	//}
 	if w.historyV3 {
 		if err := rawdbv3.TxNums.Truncate(tx, from); err != nil {
 			return err
@@ -122,7 +131,7 @@ func (w *BlockWriter) MakeBodiesNonCanonical(tx kv.RwTx, from uint64, deleteBodi
 	return nil
 }
 
-func extractHeaders(k []byte, v []byte, next etl.ExtractNextFunc) error {
+func extractHeaders(k []byte, _ []byte, next etl.ExtractNextFunc) error {
 	// We only want to extract entries composed by Block Number + Header Hash
 	if len(k) != 40 {
 		return nil
@@ -169,10 +178,10 @@ func (w *BlockWriter) ResetSenders(ctx context.Context, db kv.RoDB, tx kv.RwTx) 
 	return backup.ClearTables(ctx, db, tx, kv.Senders)
 }
 
-// Prune - [1, to) old blocks after moving it to snapshots.
+// PruneBlocks - [1, to) old blocks after moving it to snapshots.
 // keeps genesis in db
 // doesn't change sequences of kv.EthTx and kv.NonCanonicalTxs
 // doesn't delete Receipts, Senders, Canonical markers, TotalDifficulty
-func (w *BlockWriter) Prune(ctx context.Context, tx kv.RwTx, blockTo uint64, blocksDeleteLimit int) error {
+func (w *BlockWriter) PruneBlocks(ctx context.Context, tx kv.RwTx, blockTo uint64, blocksDeleteLimit int) error {
 	return rawdb.DeleteAncientBlocks(tx, blockTo, blocksDeleteLimit)
 }

--- a/eth/stagedsync/default_stages.go
+++ b/eth/stagedsync/default_stages.go
@@ -24,7 +24,7 @@ func DefaultStages(ctx context.Context, snapshots SnapshotsCfg, headers HeadersC
 				return nil
 			},
 			Prune: func(firstCycle bool, p *PruneState, tx kv.RwTx, logger log.Logger) error {
-				return SnapshotsPrune(p, snapshots, ctx, tx)
+				return SnapshotsPrune(p, firstCycle, snapshots, ctx, tx)
 			},
 		},
 		{
@@ -368,7 +368,6 @@ var StateUnwindOrder = UnwindOrder{
 
 var DefaultPruneOrder = PruneOrder{
 	stages.Finish,
-	stages.Snapshots,
 	stages.TxLookup,
 	stages.LogIndex,
 	stages.StorageHistoryIndex,
@@ -386,6 +385,7 @@ var DefaultPruneOrder = PruneOrder{
 	stages.Bodies,
 	stages.BlockHashes,
 	stages.Headers,
+	stages.Snapshots,
 }
 
 var MiningUnwindOrder = UnwindOrder{} // nothing to unwind in mining - because mining does not commit db changes

--- a/eth/stagedsync/default_stages.go
+++ b/eth/stagedsync/default_stages.go
@@ -24,7 +24,7 @@ func DefaultStages(ctx context.Context, snapshots SnapshotsCfg, headers HeadersC
 				return nil
 			},
 			Prune: func(firstCycle bool, p *PruneState, tx kv.RwTx, logger log.Logger) error {
-				return SnapshotsPrune(p, firstCycle, snapshots, ctx, tx)
+				return SnapshotsPrune(p, snapshots, ctx, tx)
 			},
 		},
 		{

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -711,7 +711,9 @@ func saveDownloadedPoSHeaders(tx kv.RwTx, cfg HeadersCfg, headerInserter *header
 		logger.Info("PoS headers verified and saved", "requestId", cfg.hd.RequestId(), "fork head", lastValidHash)
 	}
 
-	cfg.hd.HeadersCollector().Close()
+	if cfg.hd.HeadersCollector() != nil {
+		cfg.hd.HeadersCollector().Close()
+	}
 	cfg.hd.SetHeadersCollector(nil)
 	cfg.hd.SetPosStatus(headerdownload.Idle)
 }

--- a/eth/stagedsync/stage_senders_test.go
+++ b/eth/stagedsync/stage_senders_test.go
@@ -130,7 +130,7 @@ func TestSenders(t *testing.T) {
 
 	require.NoError(stages.SaveStageProgress(tx, stages.Bodies, 3))
 
-	blockRetire := snapshotsync.NewBlockRetire(1, "", br, db, nil, nil, logger)
+	blockRetire := snapshotsync.NewBlockRetire(1, "", br, bw, db, nil, nil, logger)
 	cfg := stagedsync.StageSendersCfg(db, params.TestChainConfig, false, "", prune.Mode{}, blockRetire, bw, br, nil)
 	err = stagedsync.SpawnRecoverSendersStage(cfg, &stagedsync.StageState{ID: stages.Senders}, nil, tx, 3, m.Ctx, log.New())
 	require.NoError(err)

--- a/eth/stagedsync/stage_snapshots.go
+++ b/eth/stagedsync/stage_snapshots.go
@@ -289,8 +289,14 @@ func FillDBFromSnapshots(logPrefix string, ctx context.Context, tx kv.RwTx,
 				}); err != nil {
 					return fmt.Errorf("build txNum => blockNum mapping: %w", err)
 				}
-				if err := rawdb.AppendCanonicalTxNums(tx, blockReader.Snapshots().BlocksAvailable()+1); err != nil {
-					return err
+				if blockReader.Snapshots().BlocksAvailable() > 0 {
+					if err := rawdb.AppendCanonicalTxNums(tx, blockReader.Snapshots().BlocksAvailable()+1); err != nil {
+						return err
+					}
+				} else {
+					if err := rawdb.AppendCanonicalTxNums(tx, 0); err != nil {
+						return err
+					}
 				}
 			}
 			if err := rawdb.WriteSnapshots(tx, sn.Files(), agg.Files()); err != nil {

--- a/eth/stagedsync/stage_snapshots.go
+++ b/eth/stagedsync/stage_snapshots.go
@@ -478,7 +478,7 @@ func calculateTime(amountLeft, rate uint64) string {
 /* ====== PRUNING ====== */
 // snapshots pruning sections works more as a retiring of blocks
 // retiring blocks means moving block data from db into snapshots
-func SnapshotsPrune(s *PruneState, initialCycle bool, cfg SnapshotsCfg, ctx context.Context, tx kv.RwTx) (err error) {
+func SnapshotsPrune(s *PruneState, cfg SnapshotsCfg, ctx context.Context, tx kv.RwTx) (err error) {
 	useExternalTx := tx != nil
 	if !useExternalTx {
 		tx, err = cfg.db.BeginRw(ctx)

--- a/eth/stagedsync/stage_snapshots.go
+++ b/eth/stagedsync/stage_snapshots.go
@@ -269,16 +269,10 @@ func FillDBFromSnapshots(logPrefix string, ctx context.Context, tx kv.RwTx,
 			}
 			if historyV3 {
 				_ = tx.ClearBucket(kv.MaxTxNum)
-				//if err := rawdbv3.TxNums.WriteForGenesis(tx, 1); err != nil {
-				//	return err
-				//}
 				type IterBody interface {
 					IterateFrozenBodies(f func(blockNum, baseTxNum, txAmount uint64) error) error
 				}
 				if err := blockReader.(IterBody).IterateFrozenBodies(func(blockNum, baseTxNum, txAmount uint64) error {
-					if blockNum == 0 {
-						fmt.Printf("[dbg] iterate: %d, %d, %d\n", blockNum, baseTxNum, txAmount)
-					}
 					select {
 					case <-ctx.Done():
 						return ctx.Err()

--- a/metrics/exp/exp.go
+++ b/metrics/exp/exp.go
@@ -17,7 +17,7 @@ import (
 func Setup(address string) {
 	http.HandleFunc("/debug/metrics/prometheus", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
-		metrics2.WritePrometheus(w, false)
+		metrics2.WritePrometheus(w, true)
 		contentType := expfmt.Negotiate(r.Header)
 		enc := expfmt.NewEncoder(w, contentType)
 		mf, err := prometheus.DefaultGatherer.Gather()

--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ledgerwatch/erigon/cmd/hack/tool/fromdb"
 	"github.com/ledgerwatch/erigon/cmd/utils"
 	"github.com/ledgerwatch/erigon/core/rawdb"
+	"github.com/ledgerwatch/erigon/core/rawdb/blockio"
 	"github.com/ledgerwatch/erigon/eth/ethconfig"
 	"github.com/ledgerwatch/erigon/eth/ethconfig/estimate"
 	"github.com/ledgerwatch/erigon/eth/stagedsync/stages"
@@ -415,8 +416,9 @@ func doRetireCommand(cliCtx *cli.Context) error {
 		return err
 	}
 	blockReader := snapshotsync.NewBlockReader(snapshots, fromdb.TxsV3(db))
+	blockWriter := blockio.NewBlockWriter(fromdb.HistV3(db), fromdb.TxsV3(db))
 
-	br := snapshotsync.NewBlockRetire(estimate.CompressSnapshot.Workers(), dirs.Tmp, blockReader, db, nil, nil, logger)
+	br := snapshotsync.NewBlockRetire(estimate.CompressSnapshot.Workers(), dirs.Tmp, blockReader, blockWriter, db, nil, nil, logger)
 	agg, err := libstate.NewAggregatorV3(ctx, dirs.SnapHistory, dirs.Tmp, ethconfig.HistoryV3AggregationStep, db, logger)
 	if err != nil {
 		return err

--- a/turbo/snapshotsync/block_reader.go
+++ b/turbo/snapshotsync/block_reader.go
@@ -788,7 +788,7 @@ func (r *BlockReader) FirstTxNumNotInSnapshots() uint64 {
 	return lastTxnID
 }
 
-func (r *BlockReader) IterateBodies(f func(blockNum, baseTxNum, txAmount uint64) error) error {
+func (r *BlockReader) IterateFrozenBodies(f func(blockNum, baseTxNum, txAmount uint64) error) error {
 	view := r.sn.View()
 	defer view.Close()
 

--- a/turbo/stages/mock_sentry.go
+++ b/turbo/stages/mock_sentry.go
@@ -370,7 +370,7 @@ func MockWithEverything(tb testing.TB, gspec *types.Genesis, key *ecdsa.PrivateK
 
 	var snapshotsDownloader proto_downloader.DownloaderClient
 
-	blockRetire := snapshotsync.NewBlockRetire(1, dirs.Tmp, blockReader, mock.DB, snapshotsDownloader, mock.Notifications.Events, logger)
+	blockRetire := snapshotsync.NewBlockRetire(1, dirs.Tmp, blockReader, blockWriter, mock.DB, snapshotsDownloader, mock.Notifications.Events, logger)
 	mock.Sync = stagedsync.New(
 		stagedsync.DefaultStages(mock.Ctx,
 			stagedsync.StageSnapshotsCfg(mock.DB, *mock.ChainConfig, dirs, blockRetire, snapshotsDownloader, blockReader, mock.Notifications.Events, mock.HistoryV3, mock.agg),

--- a/turbo/stages/stageloop.go
+++ b/turbo/stages/stageloop.go
@@ -406,7 +406,7 @@ func NewDefaultStages(ctx context.Context,
 ) []*stagedsync.Stage {
 	dirs := cfg.Dirs
 	blockWriter := blockio.NewBlockWriter(cfg.HistoryV3, cfg.TransactionsV3)
-	blockRetire := snapshotsync.NewBlockRetire(1, dirs.Tmp, blockReader, db, snapDownloader, notifications.Events, logger)
+	blockRetire := snapshotsync.NewBlockRetire(1, dirs.Tmp, blockReader, blockWriter, db, snapDownloader, notifications.Events, logger)
 
 	// During Import we don't want other services like header requests, body requests etc. to be running.
 	// Hence we run it in the test mode.


### PR DESCRIPTION
- stage_senders: don't re-calc existing senders
- stage_tx_lookup: prune less blocks per iteration - because random-deletes are expensive. pruning must not slow-down sync. 
- prune data even if --snap.stop is set
- "prune as-much-as-possible at startup" is not very good idea: at initialCycle machine can be cold and prune will cause big downtime, no reason to produce much freelist in 1 tx. People may also restart erigon - because of some bug - and it will cause unexpected downtime (usually Erigon startup very fast). So, I just remove all `initialSync`-related logic in pruning.   
- fix lost metrics about disk write byte/sec