### PR TITLE
Added non root logger to bor.ValidatorSet

### DIFF
--- a/cmd/state/commands/check_change_sets.go
+++ b/cmd/state/commands/check_change_sets.go
@@ -164,7 +164,7 @@ func CheckChangeSets(genesis *types.Genesis, logger log.Logger, blockNum uint64,
 			}
 			return h
 		}
-		receipts, err1 := runBlock(engine, intraBlockState, noOpWriter, blockWriter, chainConfig, getHeader, b, vmConfig, blockNum == block)
+		receipts, err1 := runBlock(engine, intraBlockState, noOpWriter, blockWriter, chainConfig, getHeader, b, vmConfig, blockNum == block, logger)
 		if err1 != nil {
 			return err1
 		}

--- a/cmd/state/commands/check_change_sets.go
+++ b/cmd/state/commands/check_change_sets.go
@@ -53,13 +53,13 @@ var checkChangeSetsCmd = &cobra.Command{
 			logger.Error("Setting up", "error", err)
 			return err
 		}
-		return CheckChangeSets(genesis, logger, block, chaindata, historyfile, nocheck)
+		return CheckChangeSets(genesis, block, chaindata, historyfile, nocheck, logger)
 	},
 }
 
 // CheckChangeSets re-executes historical transactions in read-only mode
 // and checks that their outputs match the database ChangeSets.
-func CheckChangeSets(genesis *types.Genesis, logger log.Logger, blockNum uint64, chaindata string, historyfile string, nocheck bool) error {
+func CheckChangeSets(genesis *types.Genesis, blockNum uint64, chaindata string, historyfile string, nocheck bool, logger log.Logger) error {
 	if len(historyfile) == 0 {
 		historyfile = chaindata
 	}

--- a/cmd/state/commands/opcode_tracer.go
+++ b/cmd/state/commands/opcode_tracer.go
@@ -57,7 +57,8 @@ var opcodeTracerCmd = &cobra.Command{
 	Use:   "opcodeTracer",
 	Short: "Re-executes historical transactions in read-only mode and traces them at the opcode level",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return OpcodeTracer(genesis, block, chaindata, numBlocks, saveOpcodes, saveBBlocks)
+		logger := log.New("opcode-tracer", genesis.Config.ChainID)
+		return OpcodeTracer(genesis, logger, block, chaindata, numBlocks, saveOpcodes, saveBBlocks)
 	},
 }
 
@@ -396,7 +397,7 @@ type segPrefix struct {
 
 // OpcodeTracer re-executes historical transactions in read-only mode
 // and traces them at the opcode level
-func OpcodeTracer(genesis *types.Genesis, blockNum uint64, chaindata string, numBlocks uint64,
+func OpcodeTracer(genesis *types.Genesis, logger log.Logger, blockNum uint64, chaindata string, numBlocks uint64,
 	saveOpcodes bool, saveBblocks bool) error {
 	blockNumOrig := blockNum
 
@@ -595,7 +596,7 @@ func OpcodeTracer(genesis *types.Genesis, blockNum uint64, chaindata string, num
 		getHeader := func(hash libcommon.Hash, number uint64) *types.Header {
 			return rawdb.ReadHeader(historyTx, hash, number)
 		}
-		receipts, err1 := runBlock(ethash.NewFullFaker(), intraBlockState, noOpWriter, noOpWriter, chainConfig, getHeader, block, vmConfig, false)
+		receipts, err1 := runBlock(ethash.NewFullFaker(), intraBlockState, noOpWriter, noOpWriter, chainConfig, getHeader, block, vmConfig, false, logger)
 		if err1 != nil {
 			return err1
 		}
@@ -706,7 +707,7 @@ func OpcodeTracer(genesis *types.Genesis, blockNum uint64, chaindata string, num
 }
 
 func runBlock(engine consensus.Engine, ibs *state.IntraBlockState, txnWriter state.StateWriter, blockWriter state.StateWriter,
-	chainConfig *chain2.Config, getHeader func(hash libcommon.Hash, number uint64) *types.Header, block *types.Block, vmConfig vm.Config, trace bool) (types.Receipts, error) {
+	chainConfig *chain2.Config, getHeader func(hash libcommon.Hash, number uint64) *types.Header, block *types.Block, vmConfig vm.Config, trace bool, logger log.Logger) (types.Receipts, error) {
 	header := block.Header()
 	vmConfig.TraceJumpDest = true
 	gp := new(core.GasPool).AddGas(block.GasLimit()).AddDataGas(params.MaxDataGasPerBlock)
@@ -715,7 +716,7 @@ func runBlock(engine consensus.Engine, ibs *state.IntraBlockState, txnWriter sta
 	if chainConfig.DAOForkBlock != nil && chainConfig.DAOForkBlock.Cmp(block.Number()) == 0 {
 		misc.ApplyDAOHardFork(ibs)
 	}
-	systemcontracts.UpgradeBuildInSystemContract(chainConfig, header.Number, ibs)
+	systemcontracts.UpgradeBuildInSystemContract(chainConfig, header.Number, ibs, logger)
 	rules := chainConfig.Rules(block.NumberU64(), block.Time())
 	for i, tx := range block.Transactions() {
 		ibs.SetTxContext(tx.Hash(), block.Hash(), i)

--- a/cmd/state/commands/opcode_tracer.go
+++ b/cmd/state/commands/opcode_tracer.go
@@ -58,7 +58,7 @@ var opcodeTracerCmd = &cobra.Command{
 	Short: "Re-executes historical transactions in read-only mode and traces them at the opcode level",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		logger := log.New("opcode-tracer", genesis.Config.ChainID)
-		return OpcodeTracer(genesis, logger, block, chaindata, numBlocks, saveOpcodes, saveBBlocks)
+		return OpcodeTracer(genesis, block, chaindata, numBlocks, saveOpcodes, saveBBlocks, logger)
 	},
 }
 
@@ -397,8 +397,8 @@ type segPrefix struct {
 
 // OpcodeTracer re-executes historical transactions in read-only mode
 // and traces them at the opcode level
-func OpcodeTracer(genesis *types.Genesis, logger log.Logger, blockNum uint64, chaindata string, numBlocks uint64,
-	saveOpcodes bool, saveBblocks bool) error {
+func OpcodeTracer(genesis *types.Genesis, blockNum uint64, chaindata string, numBlocks uint64,
+	saveOpcodes bool, saveBblocks bool, logger log.Logger) error {
 	blockNumOrig := blockNum
 
 	startTime := time.Now()

--- a/cmd/state/commands/state_root.go
+++ b/cmd/state/commands/state_root.go
@@ -48,7 +48,7 @@ var stateRootCmd = &cobra.Command{
 			logger.Error("Setting up", "error", err)
 			return err
 		}
-		return StateRoot(genesis, logger, block, datadirCli)
+		return StateRoot(genesis, block, datadirCli, logger)
 	},
 }
 
@@ -65,7 +65,7 @@ func blocksIO(db kv.RoDB) (services.FullBlockReader, *blockio.BlockWriter) {
 	return br, bw
 }
 
-func StateRoot(genesis *types.Genesis, logger log.Logger, blockNum uint64, datadir string) error {
+func StateRoot(genesis *types.Genesis, blockNum uint64, datadir string, logger log.Logger) error {
 	sigs := make(chan os.Signal, 1)
 	interruptCh := make(chan bool, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)

--- a/cmd/state/commands/state_root.go
+++ b/cmd/state/commands/state_root.go
@@ -157,7 +157,7 @@ func StateRoot(genesis *types.Genesis, logger log.Logger, blockNum uint64, datad
 			h, _ := blockReader.Header(ctx, historyTx, hash, number)
 			return h
 		}
-		if _, err = runBlock(ethash.NewFullFaker(), intraBlockState, noOpWriter, w, chainConfig, getHeader, b, vmConfig, false); err != nil {
+		if _, err = runBlock(ethash.NewFullFaker(), intraBlockState, noOpWriter, w, chainConfig, getHeader, b, vmConfig, false, logger); err != nil {
 			return fmt.Errorf("block %d: %w", block, err)
 		}
 		if block+1 == blockNum {

--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -575,7 +575,7 @@ func (c *Bor) snapshot(chain consensus.ChainHeaderReader, number uint64, hash li
 				}
 
 				// new snap shot
-				snap = newSnapshot(c.config, c.signatures, number, hash, validators)
+				snap = newSnapshot(c.config, c.signatures, number, hash, validators, c.logger)
 				if err := snap.store(c.DB); err != nil {
 					return nil, err
 				}
@@ -1352,7 +1352,7 @@ func getUpdatedValidatorSet(oldValidatorSet *valset.ValidatorSet, newVals []*val
 		}
 	}
 
-	if err := v.UpdateWithChangeSet(changes); err != nil {
+	if err := v.UpdateWithChangeSet(changes, logger); err != nil {
 		logger.Error("Error while updating change set", "error", err)
 	}
 

--- a/consensus/bor/snapshot.go
+++ b/consensus/bor/snapshot.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/hashicorp/golang-lru/v2"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/ledgerwatch/erigon-lib/chain"
 	"github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/kv"
@@ -43,13 +43,14 @@ func newSnapshot(
 	number uint64,
 	hash common.Hash,
 	validators []*valset.Validator,
+	logger log.Logger,
 ) *Snapshot {
 	snap := &Snapshot{
 		config:       config,
 		sigcache:     sigcache,
 		Number:       number,
 		Hash:         hash,
-		ValidatorSet: valset.NewValidatorSet(validators),
+		ValidatorSet: valset.NewValidatorSet(validators, logger),
 		Recents:      make(map[uint64]common.Address),
 	}
 	return snap
@@ -172,7 +173,7 @@ func (s *Snapshot) apply(headers []*types.Header, logger log.Logger) (*Snapshot,
 			// get validators from headers and use that for new validator set
 			newVals, _ := valset.ParseValidators(validatorBytes)
 			v := getUpdatedValidatorSet(snap.ValidatorSet.Copy(), newVals, logger)
-			v.IncrementProposerPriority(1)
+			v.IncrementProposerPriority(1, logger)
 			snap.ValidatorSet = v
 		}
 	}

--- a/consensus/bor/snapshot_test.go
+++ b/consensus/bor/snapshot_test.go
@@ -7,6 +7,7 @@ import (
 
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon/consensus/bor/valset"
+	"github.com/ledgerwatch/log/v3"
 	crand "github.com/maticnetwork/crand"
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +20,7 @@ func TestGetSignerSuccessionNumber_ProposerIsSigner(t *testing.T) {
 	t.Parallel()
 
 	validators := buildRandomValidatorSet(numVals)
-	validatorSet := valset.NewValidatorSet(validators)
+	validatorSet := valset.NewValidatorSet(validators, log.New())
 	snap := Snapshot{
 		ValidatorSet: validatorSet,
 	}
@@ -47,7 +48,7 @@ func TestGetSignerSuccessionNumber_SignerIndexIsLarger(t *testing.T) {
 	// give highest ProposerPriority to a particular val, so that they become the proposer
 	validators[proposerIndex].VotingPower = 200
 	snap := Snapshot{
-		ValidatorSet: valset.NewValidatorSet(validators),
+		ValidatorSet: valset.NewValidatorSet(validators, log.New()),
 	}
 
 	// choose a signer at an index greater than proposer index
@@ -69,7 +70,7 @@ func TestGetSignerSuccessionNumber_SignerIndexIsSmaller(t *testing.T) {
 	// give highest ProposerPriority to a particular val, so that they become the proposer
 	validators[proposerIndex].VotingPower = 200
 	snap := Snapshot{
-		ValidatorSet: valset.NewValidatorSet(validators),
+		ValidatorSet: valset.NewValidatorSet(validators, log.New()),
 	}
 
 	// choose a signer at an index greater than proposer index
@@ -87,7 +88,7 @@ func TestGetSignerSuccessionNumber_ProposerNotFound(t *testing.T) {
 
 	validators := buildRandomValidatorSet(numVals)
 	snap := Snapshot{
-		ValidatorSet: valset.NewValidatorSet(validators),
+		ValidatorSet: valset.NewValidatorSet(validators, log.New()),
 	}
 
 	dummyProposerAddress := randomAddress()
@@ -110,7 +111,7 @@ func TestGetSignerSuccessionNumber_SignerNotFound(t *testing.T) {
 
 	validators := buildRandomValidatorSet(numVals)
 	snap := Snapshot{
-		ValidatorSet: valset.NewValidatorSet(validators),
+		ValidatorSet: valset.NewValidatorSet(validators, log.New()),
 	}
 
 	dummySignerAddress := randomAddress()

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon/core/systemcontracts"
 	"github.com/ledgerwatch/erigon/eth/ethconfig"
+	"github.com/ledgerwatch/log/v3"
 
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/consensus"
@@ -309,6 +310,8 @@ func GenerateChain(config *chain.Config, parent *types.Block, engine consensus.E
 	}
 	defer tx.Rollback()
 
+	logger := log.New("generate-chain", config.ChainName)
+
 	genblock := func(i int, parent *types.Block, ibs *state.IntraBlockState, stateReader state.StateReader,
 		stateWriter state.StateWriter) (*types.Block, types.Receipts, error) {
 		b := &BlockGen{i: i, chain: blocks, parent: parent, ibs: ibs, stateReader: stateReader, config: config, engine: engine, txs: make([]types.Transaction, 0, 1), receipts: make([]*types.Receipt, 0, 1), uncles: make([]*types.Header, 0, 1)}
@@ -323,7 +326,7 @@ func GenerateChain(config *chain.Config, parent *types.Block, engine consensus.E
 				misc.ApplyDAOHardFork(ibs)
 			}
 		}
-		systemcontracts.UpgradeBuildInSystemContract(config, b.header.Number, ibs)
+		systemcontracts.UpgradeBuildInSystemContract(config, b.header.Number, ibs, logger)
 		// Execute any user modifications to the block
 		if gen != nil {
 			gen(i, b)

--- a/core/systemcontracts/upgrade.go
+++ b/core/systemcontracts/upgrade.go
@@ -73,12 +73,10 @@ func init() {
 	}
 }
 
-func UpgradeBuildInSystemContract(config *chain.Config, blockNumber *big.Int, statedb evmtypes.IntraBlockState) {
+func UpgradeBuildInSystemContract(config *chain.Config, blockNumber *big.Int, statedb evmtypes.IntraBlockState, logger log.Logger) {
 	if config == nil || blockNumber == nil || statedb == nil {
 		return
 	}
-
-	logger := log.New("system-contract-upgrade", config.ChainName)
 
 	if config.Bor != nil && config.Bor.IsOnCalcutta(blockNumber) {
 		applySystemContractUpgrade(CalcuttaUpgrade[config.ChainName], blockNumber, statedb, logger)

--- a/eth/stagedsync/stage_mining_exec.go
+++ b/eth/stagedsync/stage_mining_exec.go
@@ -90,7 +90,7 @@ func SpawnMiningExecStage(s *StageState, tx kv.RwTx, cfg MiningExecCfg, quit <-c
 	if cfg.chainConfig.DAOForkBlock != nil && cfg.chainConfig.DAOForkBlock.Cmp(current.Header.Number) == 0 {
 		misc.ApplyDAOHardFork(ibs)
 	}
-	systemcontracts.UpgradeBuildInSystemContract(&cfg.chainConfig, current.Header.Number, ibs)
+	systemcontracts.UpgradeBuildInSystemContract(&cfg.chainConfig, current.Header.Number, ibs, logger)
 
 	// Create an empty block based on temporary copied state for
 	// sealing in advance without waiting block execution finished.


### PR DESCRIPTION
I've added a non root logger to bor.ValidatorSet validator set. This creates a signature change on a number of calling functions to propagate the logger. This is mostly constrained to the bor package but impacts a number of tests and utilities which call the validators set.