### PR TITLE
[bor] Desambiguate the term checkpoint

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -41,9 +41,9 @@ import (
 )
 
 const (
-	checkpointInterval = 1024 // Number of blocks after which to save the vote snapshot to the database
-	inmemorySnapshots  = 128  // Number of recent vote snapshots to keep in memory
-	inmemorySignatures = 4096 // Number of recent block signatures to keep in memory
+	snapshotPersistInterval = 1024 // Number of blocks after which to persist the vote snapshot to the database
+	inmemorySnapshots       = 128  // Number of recent vote snapshots to keep in memory
+	inmemorySignatures      = 4096 // Number of recent block signatures to keep in memory
 )
 
 // Bor protocol constants.
@@ -544,8 +544,8 @@ func (c *Bor) snapshot(chain consensus.ChainHeaderReader, number uint64, hash li
 			break
 		}
 
-		// If an on-disk checkpoint snapshot can be found, use that
-		if number%checkpointInterval == 0 {
+		// If an on-disk snapshot can be found, use that
+		if number%snapshotPersistInterval == 0 {
 			if s, err := loadSnapshot(c.config, c.signatures, c.DB, hash); err == nil {
 				c.logger.Trace("Loaded snapshot from disk", "number", number, "hash", hash)
 
@@ -625,8 +625,8 @@ func (c *Bor) snapshot(chain consensus.ChainHeaderReader, number uint64, hash li
 
 	c.recents.Add(snap.Hash, snap)
 
-	// If we've generated a new checkpoint snapshot, save to disk
-	if snap.Number%checkpointInterval == 0 && len(headers) > 0 {
+	// If we've generated a new persistent snapshot, save to disk
+	if snap.Number%snapshotPersistInterval == 0 && len(headers) > 0 {
 		if err = snap.store(c.DB); err != nil {
 			return nil, err
 		}

--- a/consensus/bor/snapshot.go
+++ b/consensus/bor/snapshot.go
@@ -139,10 +139,11 @@ func (s *Snapshot) apply(headers []*types.Header, logger log.Logger) (*Snapshot,
 	for _, header := range headers {
 		// Remove any votes on checkpoint blocks
 		number := header.Number.Uint64()
+		sprintLen := s.config.CalculateSprint(number)
 
 		// Delete the oldest signer from the recent list to allow it signing again
-		if number >= s.config.CalculateSprint(number) {
-			delete(snap.Recents, number-s.config.CalculateSprint(number))
+		if number >= sprintLen {
+			delete(snap.Recents, number-sprintLen)
 		}
 
 		// Resolve the authorization key and check against signers
@@ -164,7 +165,7 @@ func (s *Snapshot) apply(headers []*types.Header, logger log.Logger) (*Snapshot,
 		snap.Recents[number] = signer
 
 		// change validator set and change proposer
-		if number > 0 && (number+1)%s.config.CalculateSprint(number) == 0 {
+		if number > 0 && (number+1)%sprintLen == 0 {
 			if err := validateHeaderExtraField(header.Extra); err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
I realised that the term `checkpoint` is used in 2 different meanings in the code, which are distinct. Renaming one of the to persistentSnapshots to reduce confusion