### PR TITLE
rpc: Significantly speedup debug_traceCallMany

### DIFF
--- a/cmd/rpcdaemon/commands/tracing.go
+++ b/cmd/rpcdaemon/commands/tracing.go
@@ -385,13 +385,14 @@ func (api *PrivateDebugAPIImpl) TraceCallMany(ctx context.Context, bundles []Bun
 		transactionIndex = *simulateContext.TransactionIndex
 	}
 
-	if transactionIndex == -1 {
-		transactionIndex = len(block.Transactions())
+	stateBlockNum := blockNum
+	
+	if transactionIndex != -1 {
+		stateBlockNum = blockNum-1
+		replayTransactions = block.Transactions()[:transactionIndex]
 	}
 
-	replayTransactions = block.Transactions()[:transactionIndex]
-
-	stateReader, err := rpchelper.CreateStateReader(ctx, tx, rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(blockNum-1)), 0, api.filters, api.stateCache, api.historyV3(tx), chainConfig.ChainName)
+	stateReader, err := rpchelper.CreateStateReader(ctx, tx, rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(stateBlockNum)), 0, api.filters, api.stateCache, api.historyV3(tx), chainConfig.ChainName)
 	if err != nil {
 		stream.WriteNil()
 		return err


### PR DESCRIPTION
Currently, when using the default value of `transactionIndex` (-1) in the `debug_traceCallMany` function, the state is obtained from the previous block and all the transactions are replayed. 

This pull request retrieves the most recent state, resulting in a significant decrease in tracing time from 50-150 ms to just 1 ms. 

I have tested the modification and it functions as intended. However, I kindly request you to review it, as I lack experience with the Go programming language and the client internals.