### PR TITLE
e2: avoid do RestoreCodeHash twice

### DIFF
--- a/core/state/historyv2read/history.go
+++ b/core/state/historyv2read/history.go
@@ -52,10 +52,6 @@ func GetAsOf(tx kv.Tx, indexC kv.Cursor, changesC kv.CursorDupSort, storage bool
 		//restore codehash
 		if !storage {
 			//restore codehash
-			v, err = RestoreCodeHash(tx, key, v, nil)
-			if err != nil {
-				return nil, err
-			}
 		}
 
 		return v, nil


### PR DESCRIPTION
- do it only once in HistoryStateReader 