### PR TITLE
added --log.dir.prefix flag

### DIFF
--- a/docs/examples/single-process.md
+++ b/docs/examples/single-process.md
@@ -18,6 +18,7 @@ How to run Erigon in a single process (all parts of the system run as one).
      --ws \
      --http.api=eth,debug,net,trace,web3,erigon \
      --log.dir.path=/desired/path/to/logs
+     --log.dir.prefix=filename
      ```
 
 ## Notes

--- a/turbo/logging/flags.go
+++ b/turbo/logging/flags.go
@@ -38,6 +38,11 @@ var (
 		Usage: "Path to store user and error logs to disk",
 	}
 
+	LogDirPrefixFlag = cli.StringFlag{
+		Name:  "log.dir.prefix",
+		Usage: "The file name prefix for logs stored to disk",
+	}
+
 	LogDirVerbosityFlag = cli.StringFlag{
 		Name:  "log.dir.verbosity",
 		Usage: "Set the log verbosity for logs stored to disk",
@@ -52,5 +57,6 @@ var Flags = []cli.Flag{
 	&LogVerbosityFlag,
 	&LogConsoleVerbosityFlag,
 	&LogDirPathFlag,
+	&LogDirPrefixFlag,
 	&LogDirVerbosityFlag,
 }

--- a/turbo/logging/logging.go
+++ b/turbo/logging/logging.go
@@ -52,6 +52,11 @@ func SetupLoggerCtx(filePrefix string, ctx *cli.Context, rootHandler bool) log.L
 	} else {
 		logger = log.New()
 	}
+
+	if logDirPrefix := ctx.String(LogDirPrefixFlag.Name); len(logDirPrefix) > 0 {
+		filePrefix = logDirPrefix
+	}
+
 	initSeparatedLogging(logger, filePrefix, dirPath, consoleLevel, dirLevel, consoleJson, dirJson)
 	return logger
 }
@@ -100,6 +105,11 @@ func SetupLoggerCmd(filePrefix string, cmd *cobra.Command) log.Logger {
 			dirPath = filepath.Join(datadir, "logs")
 		}
 	}
+
+	if logDirPrefix := cmd.Flags().Lookup(LogDirPrefixFlag.Name).Value.String(); len(logDirPrefix) > 0 {
+		filePrefix = logDirPrefix
+	}
+
 	initSeparatedLogging(log.Root(), filePrefix, dirPath, consoleLevel, dirLevel, consoleJson, dirJson)
 	return log.Root()
 }
@@ -110,6 +120,7 @@ func SetupLogger(filePrefix string) log.Logger {
 	var logConsoleVerbosity = flag.String(LogConsoleVerbosityFlag.Name, "", LogConsoleVerbosityFlag.Usage)
 	var logDirVerbosity = flag.String(LogDirVerbosityFlag.Name, "", LogDirVerbosityFlag.Usage)
 	var logDirPath = flag.String(LogDirPathFlag.Name, "", LogDirPathFlag.Usage)
+	var logDirPrefix = flag.String(LogDirPrefixFlag.Name, "", LogDirPrefixFlag.Usage)
 	var logVerbosity = flag.String(LogVerbosityFlag.Name, "", LogVerbosityFlag.Usage)
 	var logConsoleJson = flag.Bool(LogConsoleJsonFlag.Name, false, LogConsoleJsonFlag.Usage)
 	var logJson = flag.Bool(LogJsonFlag.Name, false, LogJsonFlag.Usage)
@@ -131,6 +142,10 @@ func SetupLogger(filePrefix string) log.Logger {
 	dirLevel, dErr := tryGetLogLevel(*logDirVerbosity)
 	if dErr != nil {
 		dirLevel = log.LvlInfo
+	}
+
+	if logDirPrefix != nil && len(*logDirPrefix) > 0 {
+		filePrefix = *logDirPrefix
 	}
 
 	initSeparatedLogging(log.Root(), filePrefix, *logDirPath, consoleLevel, dirLevel, consoleJson, *dirJson)


### PR DESCRIPTION
This request adds an additional logging flag to change the name of the logfiles produced by erigon to be prefixed by a name other than 'erigon'.

This allows multiple nodes to log to the same directory without overwriting each others files.   It is requires so that the devnet when running can maintain all of its log files in a single consolidated directory which survives devnet restarts.
