### PR TITLE
Move ChainID from CommonTx to DynamicFeeTransaction

### DIFF
--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -447,13 +447,13 @@ func getTransaction(txJson commands.RPCTransaction) (types.Transaction, error) {
 
 		dynamicFeeTx := types.DynamicFeeTransaction{
 			CommonTx: types.CommonTx{
-				ChainID: chainId,
-				Nonce:   uint64(txJson.Nonce),
-				To:      txJson.To,
-				Value:   value,
-				Gas:     uint64(txJson.Gas),
-				Data:    txJson.Input,
+				Nonce: uint64(txJson.Nonce),
+				To:    txJson.To,
+				Value: value,
+				Gas:   uint64(txJson.Gas),
+				Data:  txJson.Input,
 			},
+			ChainID:    chainId,
 			Tip:        tip,
 			FeeCap:     feeCap,
 			AccessList: *txJson.Accesses,

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -115,12 +115,12 @@ func TestEIP1559BlockEncoding(t *testing.T) {
 	feeCap, _ := uint256.FromBig(block.BaseFee())
 	var tx2 Transaction = &DynamicFeeTransaction{
 		CommonTx: CommonTx{
-			ChainID: u256.Num1,
-			Nonce:   0,
-			To:      &to,
-			Gas:     123457,
-			Data:    []byte{},
+			Nonce: 0,
+			To:    &to,
+			Gas:   123457,
+			Data:  []byte{},
 		},
+		ChainID:    u256.Num1,
 		FeeCap:     feeCap,
 		Tip:        u256.Num0,
 		AccessList: accesses,

--- a/core/types/dynamic_fee_tx.go
+++ b/core/types/dynamic_fee_tx.go
@@ -24,6 +24,7 @@ import (
 	"math/bits"
 
 	"github.com/holiman/uint256"
+
 	"github.com/ledgerwatch/erigon-lib/chain"
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	types2 "github.com/ledgerwatch/erigon-lib/types"
@@ -35,6 +36,7 @@ import (
 
 type DynamicFeeTransaction struct {
 	CommonTx
+	ChainID    *uint256.Int
 	Tip        *uint256.Int
 	FeeCap     *uint256.Int
 	AccessList types2.AccessList
@@ -78,14 +80,14 @@ func (tx DynamicFeeTransaction) copy() *DynamicFeeTransaction {
 			TransactionMisc: TransactionMisc{
 				time: tx.time,
 			},
-			ChainID: new(uint256.Int),
-			Nonce:   tx.Nonce,
-			To:      tx.To, // TODO: copy pointed-to address
-			Data:    common.CopyBytes(tx.Data),
-			Gas:     tx.Gas,
+			Nonce: tx.Nonce,
+			To:    tx.To, // TODO: copy pointed-to address
+			Data:  common.CopyBytes(tx.Data),
+			Gas:   tx.Gas,
 			// These are copied below.
 			Value: new(uint256.Int),
 		},
+		ChainID:    new(uint256.Int),
 		AccessList: make(types2.AccessList, len(tx.AccessList)),
 		Tip:        new(uint256.Int),
 		FeeCap:     new(uint256.Int),
@@ -471,14 +473,14 @@ func (tx *DynamicFeeTransaction) Sender(signer Signer) (libcommon.Address, error
 func NewEIP1559Transaction(chainID uint256.Int, nonce uint64, to libcommon.Address, amount *uint256.Int, gasLimit uint64, gasPrice *uint256.Int, gasTip *uint256.Int, gasFeeCap *uint256.Int, data []byte) *DynamicFeeTransaction {
 	return &DynamicFeeTransaction{
 		CommonTx: CommonTx{
-			ChainID: &chainID,
-			Nonce:   nonce,
-			To:      &to,
-			Value:   amount,
-			Gas:     gasLimit,
-			Data:    data,
+			Nonce: nonce,
+			To:    &to,
+			Value: amount,
+			Gas:   gasLimit,
+			Data:  data,
 		},
-		Tip:    gasTip,
-		FeeCap: gasFeeCap,
+		ChainID: &chainID,
+		Tip:     gasTip,
+		FeeCap:  gasFeeCap,
 	}
 }

--- a/core/types/legacy_tx.go
+++ b/core/types/legacy_tx.go
@@ -36,7 +36,6 @@ import (
 type CommonTx struct {
 	TransactionMisc
 
-	ChainID *uint256.Int
 	Nonce   uint64             // nonce of sender account
 	Gas     uint64             // gas limit
 	To      *libcommon.Address `rlp:"nil"` // nil means contract creation
@@ -46,7 +45,7 @@ type CommonTx struct {
 }
 
 func (ct CommonTx) GetChainID() *uint256.Int {
-	return ct.ChainID
+	return nil
 }
 
 func (ct CommonTx) GetNonce() uint64 {

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -62,6 +62,9 @@ func (tx LegacyTx) MarshalJSON() ([]byte, error) {
 	enc.V = (*hexutil.Big)(tx.V.ToBig())
 	enc.R = (*hexutil.Big)(tx.R.ToBig())
 	enc.S = (*hexutil.Big)(tx.S.ToBig())
+	if tx.Protected() {
+		enc.ChainID = (*hexutil.Big)(tx.GetChainID().ToBig())
+	}
 	return json.Marshal(&enc)
 }
 

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -336,6 +336,9 @@ func DeriveChainId(v *uint256.Int) *uint256.Int {
 		if v == 27 || v == 28 {
 			return new(uint256.Int)
 		}
+		if v < 35 {
+			return nil
+		}
 		return new(uint256.Int).SetUint64((v - 35) / 2)
 	}
 	r := new(uint256.Int).Sub(v, u256.Num35)

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -85,15 +85,15 @@ var (
 
 	dynFeeTx = &DynamicFeeTransaction{
 		CommonTx: CommonTx{
-			ChainID: u256.Num1,
-			Nonce:   3,
-			To:      &testAddr,
-			Value:   uint256.NewInt(10),
-			Gas:     25000,
-			Data:    common.FromHex("5544"),
+			Nonce: 3,
+			To:    &testAddr,
+			Value: uint256.NewInt(10),
+			Gas:   25000,
+			Data:  common.FromHex("5544"),
 		},
-		Tip:    uint256.NewInt(1),
-		FeeCap: uint256.NewInt(1),
+		ChainID: u256.Num1,
+		Tip:     uint256.NewInt(1),
+		FeeCap:  uint256.NewInt(1),
 	}
 
 	signedDynFeeTx, _ = dynFeeTx.WithSignature(

--- a/eth/stagedsync/stage_bodies_test.go
+++ b/eth/stagedsync/stage_bodies_test.go
@@ -26,7 +26,7 @@ func TestBodiesUnwind(t *testing.T) {
 	defer tx.Rollback()
 	_, bw := m.NewBlocksIO()
 
-	txn := &types.DynamicFeeTransaction{Tip: u256.N1, FeeCap: u256.N1, CommonTx: types.CommonTx{ChainID: u256.N1, Value: u256.N1, Gas: 1, Nonce: 1}}
+	txn := &types.DynamicFeeTransaction{Tip: u256.N1, FeeCap: u256.N1, ChainID: u256.N1, CommonTx: types.CommonTx{Value: u256.N1, Gas: 1, Nonce: 1}}
 	buf := bytes.NewBuffer(nil)
 	err = txn.MarshalBinary(buf)
 	require.NoError(err)

--- a/migrations/txs_begin_end_test.go
+++ b/migrations/txs_begin_end_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestTxsBeginEnd(t *testing.T) {
 	require, tmpDir, db := require.New(t), t.TempDir(), memdb.NewTestDB(t)
-	txn := &types.DynamicFeeTransaction{Tip: u256.N1, FeeCap: u256.N1, CommonTx: types.CommonTx{ChainID: u256.N1, Value: u256.N1, Gas: 1, Nonce: 1}}
+	txn := &types.DynamicFeeTransaction{Tip: u256.N1, FeeCap: u256.N1, ChainID: u256.N1, CommonTx: types.CommonTx{Value: u256.N1, Gas: 1, Nonce: 1}}
 	buf := bytes.NewBuffer(nil)
 	err := txn.MarshalBinary(buf)
 	require.NoError(err)

--- a/migrations/txs_v3_test.go
+++ b/migrations/txs_v3_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestTxsV3(t *testing.T) {
 	require, tmpDir, db := require.New(t), t.TempDir(), memdb.NewTestDB(t)
-	txn := &types.DynamicFeeTransaction{Tip: u256.N1, FeeCap: u256.N1, CommonTx: types.CommonTx{ChainID: u256.N1, Value: u256.N1, Gas: 1, Nonce: 1}}
+	txn := &types.DynamicFeeTransaction{Tip: u256.N1, FeeCap: u256.N1, ChainID: u256.N1, CommonTx: types.CommonTx{Value: u256.N1, Gas: 1, Nonce: 1}}
 	buf := bytes.NewBuffer(nil)
 	err := txn.MarshalBinary(buf)
 	require.NoError(err)

--- a/turbo/stages/blockchain_test.go
+++ b/turbo/stages/blockchain_test.go
@@ -26,6 +26,10 @@ import (
 	"testing"
 
 	"github.com/holiman/uint256"
+	"github.com/ledgerwatch/log/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ledgerwatch/erigon-lib/chain"
 	chain2 "github.com/ledgerwatch/erigon-lib/chain"
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
@@ -33,10 +37,6 @@ import (
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon-lib/kv/bitmapdb"
 	types2 "github.com/ledgerwatch/erigon-lib/types"
-	"github.com/ledgerwatch/erigon/turbo/services"
-	"github.com/ledgerwatch/log/v3"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/ledgerwatch/erigon/common/hexutil"
 	"github.com/ledgerwatch/erigon/common/u256"
@@ -49,6 +49,7 @@ import (
 	"github.com/ledgerwatch/erigon/crypto"
 	"github.com/ledgerwatch/erigon/ethdb/prune"
 	"github.com/ledgerwatch/erigon/params"
+	"github.com/ledgerwatch/erigon/turbo/services"
 	"github.com/ledgerwatch/erigon/turbo/stages"
 )
 
@@ -2128,12 +2129,12 @@ func TestEIP1559Transition(t *testing.T) {
 			chainID.SetFromBig(gspec.Config.ChainID)
 			var tx types.Transaction = &types.DynamicFeeTransaction{
 				CommonTx: types.CommonTx{
-					ChainID: &chainID,
-					Nonce:   0,
-					To:      &aa,
-					Gas:     30000,
-					Data:    []byte{},
+					Nonce: 0,
+					To:    &aa,
+					Gas:   30000,
+					Data:  []byte{},
 				},
+				ChainID:    &chainID,
 				FeeCap:     new(uint256.Int).Mul(new(uint256.Int).SetUint64(5), new(uint256.Int).SetUint64(params.GWei)),
 				Tip:        u256.Num2,
 				AccessList: accesses,


### PR DESCRIPTION
For legacy transactions ChainID is optional (missing in pre-[EIP155](https://eips.ethereum.org/EIPS/eip-155) transactions) and is derived from `V` anyway.

Also, cherry pick https://github.com/ethereum/go-ethereum/pull/27452.