### PR TITLE
enable cli RPCGlobalTxFeeCapFlag

### DIFF
--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"github.com/urfave/cli/v2"
+
 	"github.com/ledgerwatch/erigon/cmd/utils"
 )
 

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"github.com/urfave/cli/v2"
-
 	"github.com/ledgerwatch/erigon/cmd/utils"
 )
 
@@ -72,6 +70,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.RpcGasCapFlag,
 	&utils.RpcBatchLimit,
 	&utils.RpcReturnDataLimit,
+	&utils.RPCGlobalTxFeeCapFlag,
 	&utils.TxpoolApiAddrFlag,
 	&utils.TraceMaxtracesFlag,
 	&HTTPReadTimeoutFlag,


### PR DESCRIPTION
enable -rpc.txfeecap flag on the RPC daemon in the default sets of CLI flags