### PR TITLE
change --db.pagesize default to 8KB

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -38,7 +38,6 @@ import (
 	"github.com/ledgerwatch/erigon-lib/common/metrics"
 	"github.com/ledgerwatch/erigon-lib/direct"
 	downloadercfg2 "github.com/ledgerwatch/erigon-lib/downloader/downloadercfg"
-	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon-lib/txpool/txpoolcfg"
 
 	"github.com/ledgerwatch/erigon/cl/clparams"
@@ -710,7 +709,7 @@ var (
 	DbPageSizeFlag = cli.StringFlag{
 		Name:  "db.pagesize",
 		Usage: "DB is splitted to 'pages' of fixed size. Can't change DB creation. Must be power of 2 and '256b <= pagesize <= 64kb'. Default: equal to OperationSystem's pageSize. Bigger pageSize causing: 1. More writes to disk during commit 2. Smaller b-tree high 3. Less fragmentation 4. Less overhead on 'free-pages list' maintainance (a bit faster Put/Commit) 5. If expecting DB-size > 8Tb then set pageSize >= 8Kb",
-		Value: datasize.ByteSize(kv.DefaultPageSize()).String(),
+		Value: "8KB",
 	}
 	DbSizeLimitFlag = cli.StringFlag{
 		Name:  "db.size.limit",


### PR DESCRIPTION
reasons:
- mainnet: even nodes with small FreeList - still have millions of pages there `GC: 46446830 5.8%`. Probability of getting into state where space re-use will be slower than free-list grow is > 0% (we now using db version which limiting  freelist-overhead, but increasing such probability)
- polygon: size is > 8Tb
- hardware slowly moving towards bigger pageSizes (because for OS/Hardware) maintenance of pages metadata is also not free (metadata, lists, LRU, etc...). Macbook's default pagesize now is 16Kb. Network disks in cloud are also likely working with 16Kb pages. 

pros:
- less db fragmentation (better FS-level compression)
- less overflow pages in DB (which also reducing free-list overhead)
- smaller free-list 
- bigger key-size-limit 
- no 8Tb db size limit
- can setup FS - to also use bigger pagesize - it will reduce FS overhead also
- reducing amount of page-faults during batch-reads (if FS pagesize match)
- less write syscalls during commit (when WriteMap disabled)

cons:
- ~10% more IO: because of more RAM waste and just because need read/write bigger pages (not all updates are co-located). 