### PR TITLE
Cleaned up error handling in network and node start-up

### DIFF
--- a/cmd/devnet/devnetutils/utils.go
+++ b/cmd/devnet/devnetutils/utils.go
@@ -3,6 +3,7 @@ package devnetutils
 import (
 	"crypto/rand"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -18,6 +19,8 @@ import (
 	"github.com/ledgerwatch/erigon/crypto"
 	"github.com/ledgerwatch/log/v3"
 )
+
+var ErrInvalidEnodeString = errors.New("invalid enode string")
 
 // ClearDevDB cleans up the dev folder used for the operations
 func ClearDevDB(dataDir string, logger log.Logger) error {
@@ -56,7 +59,7 @@ func HexToInt(hexStr string) uint64 {
 // UniqueIDFromEnode returns the unique ID from a node's enode, removing the `?discport=0` part
 func UniqueIDFromEnode(enode string) (string, error) {
 	if len(enode) == 0 {
-		return "", fmt.Errorf("invalid enode string")
+		return "", ErrInvalidEnodeString
 	}
 
 	// iterate through characters in the string until we reach '?'
@@ -73,14 +76,14 @@ func UniqueIDFromEnode(enode string) (string, error) {
 	}
 
 	if ati == 0 {
-		return "", fmt.Errorf("invalid enode string")
+		return "", ErrInvalidEnodeString
 	}
 
 	if _, apiPort, err := net.SplitHostPort(enode[ati+1 : i]); err != nil {
-		return "", fmt.Errorf("invalid enode string")
+		return "", ErrInvalidEnodeString
 	} else {
 		if _, err := strconv.Atoi(apiPort); err != nil {
-			return "", fmt.Errorf("invalid enode string")
+			return "", ErrInvalidEnodeString
 		}
 	}
 

--- a/cmd/devnet/main.go
+++ b/cmd/devnet/main.go
@@ -175,7 +175,7 @@ func action(ctx *cli.Context) error {
 			network.Stop()
 
 		case syscall.SIGINT:
-			log.Info("Terminating network")
+			logger.Info("Terminating network")
 			os.Exit(-int(syscall.SIGINT))
 		}
 	}()

--- a/cmd/devnet/requests/request_generator.go
+++ b/cmd/devnet/requests/request_generator.go
@@ -175,7 +175,7 @@ func (req *requestGenerator) PingErigonRpc() CallResult {
 func NewRequestGenerator(target string, logger log.Logger) RequestGenerator {
 	return &requestGenerator{
 		client: &http.Client{
-			Timeout: time.Second * 600,
+			Timeout: time.Second * 10,
 		},
 		reqID:  1,
 		logger: logger,

--- a/node/endpoints.go
+++ b/node/endpoints.go
@@ -51,7 +51,8 @@ func StartHTTPEndpoint(endpoint string, timeouts rpccfg.HTTPTimeouts, handler ht
 	}
 	go func() {
 		serveErr := httpSrv.Serve(listener)
-		if serveErr != nil && !errors.Is(serveErr, context.Canceled) && !errors.Is(serveErr, libcommon.ErrStopped) {
+		if serveErr != nil &&
+			!(errors.Is(serveErr, context.Canceled) || errors.Is(serveErr, libcommon.ErrStopped) || errors.Is(serveErr, http.ErrServerClosed)) {
 			log.Warn("Failed to serve http endpoint", "err", serveErr)
 		}
 	}()


### PR DESCRIPTION
The check in catches errors in the node start-up code and makes sure that the network is stopped if any node fails to start cleanly, and that5 it returns an error - so that any calling code can take appropriate action. 