### PR TITLE
Expand home dir from tilda for integration tool settings

### DIFF
--- a/cmd/integration/commands/root.go
+++ b/cmd/integration/commands/root.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,10 +28,11 @@ import (
 func expandHomeDir(dirpath string) string {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		panic(err)
+		return dirpath
 	}
-	if strings.HasPrefix(dirpath, "~/") {
-		return filepath.Join(home, dirpath[2:])
+	prefix := fmt.Sprintf("~%c", os.PathSeparator)
+	if strings.HasPrefix(dirpath, prefix) {
+		return filepath.Join(home, dirpath[len(prefix):])
 	} else if dirpath == "~" {
 		return home
 	}

--- a/cmd/integration/commands/root.go
+++ b/cmd/integration/commands/root.go
@@ -2,7 +2,9 @@ package commands
 
 import (
 	"context"
+	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/c2h5oh/datasize"
 	"github.com/ledgerwatch/log/v3"
@@ -22,12 +24,28 @@ import (
 	"github.com/ledgerwatch/erigon/turbo/logging"
 )
 
+func expandHomeDir(dirpath string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		panic(err)
+	}
+	if strings.HasPrefix(dirpath, "~/") {
+		return filepath.Join(home, dirpath[2:])
+	} else if dirpath == "~" {
+		return home
+	}
+	return dirpath
+}
+
 var rootCmd = &cobra.Command{
 	Use:   "integration",
 	Short: "long and heavy integration tests for Erigon",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		datadirCli = expandHomeDir(datadirCli)
 		if chaindata == "" {
 			chaindata = filepath.Join(datadirCli, "chaindata")
+		} else {
+			chaindata = expandHomeDir(chaindata)
 		}
 	},
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Fixes https://github.com/ledgerwatch/erigon/issues/7814, it can be really confusing when `erigon` and `integration` process `~` in path in different ways.

I can't fix it for `integration` the same way it is done for `erigon`,  because in main app it is done with `urfave/cli` package that is not used in `integration`,  so I've used other simplest way to do it.

