### PR TITLE
core/vm: move TSTORE,TLOAD to correct opcode nums

### DIFF
--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -100,7 +100,8 @@ func newPragueInstructionSet() JumpTable {
 // and cancun instructions.
 func newCancunInstructionSet() JumpTable {
 	instructionSet := newShanghaiInstructionSet()
-	enable4844(&instructionSet) // DATAHASH
+	enable4844(&instructionSet) // BLOBHASH opcode
+	enable1153(&instructionSet) // Transient storage opcodes
 	validateAndFillMaxStack(&instructionSet)
 	return instructionSet
 }

--- a/core/vm/opcodes.go
+++ b/core/vm/opcodes.go
@@ -121,6 +121,8 @@ const (
 	MSIZE    OpCode = 0x59
 	GAS      OpCode = 0x5a
 	JUMPDEST OpCode = 0x5b
+	TLOAD    OpCode = 0x5c
+	TSTORE   OpCode = 0x5d
 	PUSH0    OpCode = 0x5f
 )
 
@@ -215,12 +217,6 @@ const (
 	SELFDESTRUCT OpCode = 0xff
 )
 
-// 0xb0 range.
-const (
-	TLOAD  OpCode = 0xb3
-	TSTORE OpCode = 0xb4
-)
-
 // Since the opcodes aren't all in order we can't use a regular slice.
 var opCodeToString = map[OpCode]string{
 	// 0x0 range - arithmetic ops.
@@ -301,6 +297,8 @@ var opCodeToString = map[OpCode]string{
 	MSIZE:    "MSIZE",
 	GAS:      "GAS",
 	JUMPDEST: "JUMPDEST",
+	TLOAD:    "TLOAD",
+	TSTORE:   "TSTORE",
 	PUSH0:    "PUSH0",
 
 	// 0x60 range - push.
@@ -375,10 +373,6 @@ var opCodeToString = map[OpCode]string{
 	LOG2:   "LOG2",
 	LOG3:   "LOG3",
 	LOG4:   "LOG4",
-
-	// 0xb0 range.
-	TLOAD:  "TLOAD",
-	TSTORE: "TSTORE",
 
 	// 0xf0 range.
 	CREATE:       "CREATE",
@@ -470,9 +464,9 @@ var stringToOp = map[string]OpCode{
 	"MSIZE":          MSIZE,
 	"GAS":            GAS,
 	"JUMPDEST":       JUMPDEST,
-	"PUSH0":          PUSH0,
 	"TLOAD":          TLOAD,
 	"TSTORE":         TSTORE,
+	"PUSH0":          PUSH0,
 	"PUSH1":          PUSH1,
 	"PUSH2":          PUSH2,
 	"PUSH3":          PUSH3,


### PR DESCRIPTION
See https://github.com/ethereum/EIPs/pull/7074. Also enable [EIP-1153](https://eips.ethereum.org/EIPS/eip-1153) in [Cancun](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/cancun.md).