### PR TITLE
Added ComputeBorTxHash to subscription reader

### DIFF
--- a/eth/stagedsync/stage_finish.go
+++ b/eth/stagedsync/stage_finish.go
@@ -211,8 +211,18 @@ func ReadLogs(tx kv.Tx, from uint64, isUnwind bool, blockReader services.FullBlo
 				return nil, err
 			}
 		}
+
 		txIndex := uint64(binary.BigEndian.Uint32(k[8:]))
-		txHash := block.Transactions()[txIndex].Hash()
+
+		var txHash libcommon.Hash
+
+		// bor transactions are at the end of the bodies transactions (added manually but not actually part of the block)
+		if txIndex == uint64(len(block.Transactions())) {
+			txHash = types.ComputeBorTxHash(blockNum, block.Hash())
+		} else {
+			txHash = block.Transactions()[txIndex].Hash()
+		}
+
 		var ll types.Logs
 		reader.Reset(v)
 		if err := cbor.Unmarshal(&ll, reader); err != nil {


### PR DESCRIPTION
This fixes an indexing panic when bor sync event logs are returned via a subscription.

It applies the same tx computation that is used by the getlogs rpc call 
