### PR TITLE
Adds clear_bad_blocks command

### DIFF
--- a/cmd/integration/Readme.md
+++ b/cmd/integration/Readme.md
@@ -88,3 +88,9 @@ make all
 4. Build integration: cd erigon; make integration
 5. Run: ./build/bin/integration mdbx_to_mdbx --chaindata /existing/erigon/path/chaindata/ --chaindata.to /path/to/copy-to/chaindata/
 ```
+
+## Clear bad blocks table in the case some block was marked as invalid after some error 
+It allows to process this blocks again
+```
+1. ./build/bin/integration clear_bad_blocks --datadir=<datadir>
+```

--- a/cmd/integration/commands/reset_state.go
+++ b/cmd/integration/commands/reset_state.go
@@ -53,7 +53,7 @@ var cmdResetState = &cobra.Command{
 			}
 			return
 		}
-		
+
 		// set genesis after reset all buckets
 		fmt.Printf("After reset: \n")
 		if err := db.View(ctx, func(tx kv.Tx) error { return printStages(tx, sn, agg) }); err != nil {
@@ -67,7 +67,7 @@ var cmdResetState = &cobra.Command{
 
 var cmdClearBadBlocks = &cobra.Command{
 	Use:   "clear_bad_blocks",
-	Short: "Clear bad blocks",
+	Short: "Clear table with bad block hashes to allow to process this blocks one more time",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		logger := debug.SetupCobra(cmd, "integration")
 		ctx, _ := common.RootContext()


### PR DESCRIPTION
Adds `clear_bad_blocks` command to integration tool. This command allows to re-process blocks that were erroneously marked as bad. 

Command just clears `BadHeaderNumber` table. It can be safer in some cases than
```
./integration state_stages —unwind=<some_number>
./integration stage_headers —unwind=<some_number>
```
and can be used in the cases like this one https://github.com/ledgerwatch/erigon/issues/7892%20 

Command syntax:
```
./integration clear_bad_blocks --datadir=<datadir>
```