### PR TITLE
fix: prevent index out of range during call trace

### DIFF
--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -172,13 +172,17 @@ func (t *callTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, sco
 
 		stack := scope.Stack
 		stackData := stack.Data
-
+		stackSize := len(stackData)
+		if stackSize < 2 {
+			return
+		}
 		// Don't modify the stack
-		mStart := stackData[len(stackData)-1]
-		mSize := stackData[len(stackData)-2]
+		mStart := stackData[stackSize-1]
+		mSize := stackData[stackSize-2]
 		topics := make([]libcommon.Hash, size)
-		for i := 0; i < size; i++ {
-			topic := stackData[len(stackData)-2-(i+1)]
+		dataStart := stackSize - 3
+		for i := 0; i < size && dataStart-i >= 0; i++ {
+			topic := stackData[dataStart-i]
 			topics[i] = libcommon.Hash(topic.Bytes32())
 		}
 


### PR DESCRIPTION
Previously the call tracer failed on this Ethereum transaction [0xecfc724f75e39fa9e882ec44a4d0985e099b7a3ac9415466196128770def5bc2](https://etherscan.io/tx/0xecfc724f75e39fa9e882ec44a4d0985e099b7a3ac9415466196128770def5bc2)

Querying with this request
```shell
curl  http://localhost:8545  -X POST  -H "Content-Type: application/json"  --data '{"method":"debug_traceTransaction","params":["0xecfc724f75e39fa9e882ec44a4d0985e099b7a3ac9415466196128770def5bc2", {"tracer": "callTracer",  "tracerConfig": {"withLog": true}}],"id":1,"jsonrpc":"2.0"}
```

Resulted in this response
```json
{"jsonrpc":"2.0","id":1,"result":null,"error":{"code":-32000,"message":"method handler crashed"}}
```

With this error message in the console:
`RPC method debug_traceTransaction crashed: runtime error: index out of range [-1]
[service.go:217 panic.go:884 panic.go:113 call.go:177 interpreter.go:234 interpreter.go:262 evm.go:55 evm.go:260 evm.go:303 instructions.go:800 interpreter.go:304 evm.go:55 evm.go:260 evm.go:283 state_transition.go:382 state_transition.go:186 tracing.go:206 tracing.go:263 value.go:584 value.go:368 service.go:222 handler.go:511 handler.go:444 handler.go:392 handler.go:223 handler.go:316 asm_arm64.s:1172]`