### PR TITLE
fix: show stack for push0

### DIFF
--- a/turbo/jsonrpc/trace_adhoc.go
+++ b/turbo/jsonrpc/trace_adhoc.go
@@ -453,7 +453,7 @@ func (ot *OeTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scop
 			// Set the "push" of the last operation
 			var showStack int
 			switch {
-			case ot.lastOp >= vm.PUSH1 && ot.lastOp <= vm.PUSH32:
+			case ot.lastOp >= vm.PUSH0 && ot.lastOp <= vm.PUSH32:
 				showStack = 1
 			case ot.lastOp >= vm.SWAP1 && ot.lastOp <= vm.SWAP16:
 				showStack = int(ot.lastOp-vm.SWAP1) + 2


### PR DESCRIPTION
this fixes vmtrace after shanghai

before:
```python
VMOperation(pc=24, cost=2, ex=VMExecutedOperation(used=1942085, push=[], mem=None, store=None), sub=None, op='PUSH0', idx='14-644-13')
```

after:
```python
VMOperation(pc=24, cost=2, ex=VMExecutedOperation(used=1942085, push=[HexBytes('0x00')], mem=None, store=None), sub=None, op='PUSH0', idx='14-644-13')
```