### PR TITLE
check difficulty for nil

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1254,5 +1254,7 @@ func isChainPoS(chainConfig *chain.Config, currentTD *big.Int) bool {
 		id == 5 ||
 		id == 11155111 ||
 		id == 100 ||
-		id == 10200 || chainConfig.TerminalTotalDifficulty.Cmp(currentTD) <= 0 || chainConfig.TerminalTotalDifficultyPassed
+		id == 10200 ||
+		(chainConfig.TerminalTotalDifficulty != nil && chainConfig.TerminalTotalDifficulty.Cmp(currentTD) <= 0) ||
+		chainConfig.TerminalTotalDifficultyPassed
 }


### PR DESCRIPTION
Fix checks  `chainConfig.TerminalTotalDifficulty` for nil in  `isChainPoS`.  Not doing so causes the Bor startup flow to panic.