### PR TITLE
fixed bitmap performance when write index

### DIFF
--- a/core/state/db_state_writer.go
+++ b/core/state/db_state_writer.go
@@ -183,7 +183,7 @@ func writeIndex(blocknum uint64, changes *historyv2.ChangeSet, bucket string, ch
 	for _, change := range changes.Changes {
 		k := dbutils.CompositeKeyWithoutIncarnation(change.Key)
 
-		index, err := bitmapdb.Get64(changeDb, bucket, k, 0, math.MaxUint32)
+		index, err := bitmapdb.Get64(changeDb, bucket, k, math.MaxUint32, math.MaxUint32)
 		if err != nil {
 			return fmt.Errorf("find chunk failed: %w", err)
 		}


### PR DESCRIPTION
Here is my case:

writeIndex function takes about 39% in pprof flame graph.  I dive into it and find out that we use POA consensus, therefore mining addresses have a big bitmap.  

```
func writeIndex(blocknum uint64, changes *historyv2.ChangeSet, bucket string, changeDb kv.RwTx) error {
	buf := bytes.NewBuffer(nil)
	for _, change := range changes.Changes {
		k := dbutils.CompositeKeyWithoutIncarnation(change.Key)
		index, err := bitmapdb.Get64(changeDb, bucket, k, math.MaxUint32, math.MaxUint32)
		if err != nil {
			return fmt.Errorf("find chunk failed: %w", err)
		}
		index.Add(blocknum)
		if err = bitmapdb.WalkChunkWithKeys64(k, index, bitmapdb.ChunkLimit, func(chunkKey []byte, chunk *roaring64.Bitmap) error {
			buf.Reset()
			if _, err = chunk.WriteTo(buf); err != nil {
				return err
			}
			return changeDb.Put(bucket, chunkKey, common.CopyBytes(buf.Bytes()))
		}); err != nil {
			return err
		}
	}
	return nil
}
```
assume that a mining address has a big bitmap (Cardinality 400000), then "writeIndex" will split it into 300 small bitmaps according to ”ChunkLimit“ and next time  "writeIndex"  will union all small bitmaps into a big bitmap， then use binary search to split it into 300 small bitmaps. over and over again.

I think blockNum > index.Maximum(), so that we only need get the last one of  300 small bitmaps .

