### PR TITLE
sentry: fix eth handshake sequence

### DIFF
--- a/cmd/sentry/sentry/sentry_grpc_server.go
+++ b/cmd/sentry/sentry/sentry_grpc_server.go
@@ -270,18 +270,13 @@ func makeP2PServer(
 func handShake(
 	ctx context.Context,
 	status *proto_sentry.StatusData,
-	peerID [64]byte,
 	rw p2p.MsgReadWriter,
 	version uint,
 	minVersion uint,
-	startSync func(bestHash libcommon.Hash) error,
-) error {
-	if status == nil {
-		return fmt.Errorf("could not get status message from core for peer %s connection", peerID)
-	}
-
+) (*libcommon.Hash, error) {
 	// Send out own handshake in a new thread
-	errc := make(chan error, 2)
+	errChan := make(chan error, 2)
+	resultChan := make(chan *eth.StatusPacket, 1)
 
 	ourTD := gointerfaces.ConvertH256ToUint256Int(status.TotalDifficulty)
 	// Convert proto status data into the one required by devp2p
@@ -289,7 +284,7 @@ func handShake(
 
 	go func() {
 		defer debug.LogPanic()
-		s := &eth.StatusPacket{
+		status := &eth.StatusPacket{
 			ProtocolVersion: uint32(version),
 			NetworkID:       status.NetworkId,
 			TD:              ourTD.ToBig(),
@@ -297,34 +292,45 @@ func handShake(
 			Genesis:         genesisHash,
 			ForkID:          forkid.NewIDFromForks(status.ForkData.HeightForks, status.ForkData.TimeForks, genesisHash, status.MaxBlockHeight, status.MaxBlockTime),
 		}
-		errc <- p2p.Send(rw, eth.StatusMsg, s)
+		err := p2p.Send(rw, eth.StatusMsg, status)
+
+		if err != nil {
+			err = fmt.Errorf("sentry.handShake failed to send eth Status: %w", err)
+		}
+
+		errChan <- err
 	}()
 
 	go func() {
-		reply, err := readAndValidatePeerStatusMessage(rw, status, version, minVersion)
-		if (err == nil) && (startSync != nil) {
-			err = startSync(reply.Head)
+		defer debug.LogPanic()
+		status, err := readAndValidatePeerStatusMessage(rw, status, version, minVersion)
+
+		if err == nil {
+			resultChan <- status
+		} else {
+			err = fmt.Errorf("sentry.handShake failed to receive/validate a remote peer eth Status: %w", err)
 		}
 
-		errc <- err
+		errChan <- err
 	}()
 
 	timeout := time.NewTimer(handshakeTimeout)
 	defer timeout.Stop()
 	for i := 0; i < 2; i++ {
 		select {
-		case err := <-errc:
+		case err := <-errChan:
 			if err != nil {
-				return err
+				return nil, err
 			}
 		case <-timeout.C:
-			return p2p.DiscReadTimeout
+			return nil, p2p.DiscReadTimeout
 		case <-ctx.Done():
-			return ctx.Err()
+			return nil, ctx.Err()
 		}
 	}
 
-	return nil
+	peerStatus := <-resultChan
+	return &peerStatus.Head, nil
 }
 
 func runPeer(
@@ -589,20 +595,36 @@ func NewGrpcServer(ctx context.Context, dialCandidates func() enode.Iterator, re
 				defer peerInfo.Close()
 
 				defer ss.GoodPeers.Delete(peerID)
-				err := handShake(ctx, ss.GetStatus(), peerID, rw, protocol, protocol, func(bestHash libcommon.Hash) error {
-					ss.GoodPeers.Store(peerID, peerInfo)
-					ss.sendNewPeerToClients(gointerfaces.ConvertHashToH512(peerID))
-					return ss.startSync(ctx, bestHash, peerID)
-				})
+
+				status := ss.GetStatus()
+
+				if status == nil {
+					err := fmt.Errorf("could not get status message from core for peer %s connection", printablePeerID)
+					logger.Trace("[p2p] Handshake failure", "peer", printablePeerID, "local", peer.LocalAddr(), "remote", peer.RemoteAddr(), "err", err)
+					return err
+				}
+
+				peerBestHash, err := handShake(ctx, status, rw, protocol, protocol)
+
 				if err != nil {
 					if errors.Is(err, NetworkIdMissmatchErr) || errors.Is(err, io.EOF) || errors.Is(err, p2p.ErrShuttingDown) {
 						logger.Trace("[p2p] Handshake failure", "peer", printablePeerID, "err", err)
 					} else {
 						logger.Debug("[p2p] Handshake failure", "peer", printablePeerID, "err", err)
 					}
-					return fmt.Errorf("[p2p]handshake to peer %s: %w", printablePeerID, err)
+					return fmt.Errorf("[p2p] handshake to peer %s: %w", printablePeerID, err)
 				}
+
+				// handshake is successful
 				logger.Trace("[p2p] Received status message OK", "peerId", printablePeerID, "name", peer.Name())
+
+				ss.GoodPeers.Store(peerID, peerInfo)
+				ss.sendNewPeerToClients(gointerfaces.ConvertHashToH512(peerID))
+				err = ss.startSync(ctx, *peerBestHash, peerID)
+				if err != nil {
+					logger.Error("[p2p] p2p.Protocol.Run startSync failure", "peer", printablePeerID, "err", err)
+					return fmt.Errorf("[p2p] startSync for peer %s: %w", printablePeerID, err)
+				}
 
 				err = runPeer(
 					ctx,


### PR DESCRIPTION
problem: it was possible to call startSync
and start sending messages before our Status is sent

solution: wait for the sender goroutine to finish
before calling startSync

refactor handShake parameters to not require peerID and a startSync callback