### PR TITLE
Revert "EIP-4788: set nonce of beacon root history address to nonzero…

### DIFF
--- a/consensus/misc/eip4788.go
+++ b/consensus/misc/eip4788.go
@@ -4,7 +4,6 @@ import (
 	"github.com/holiman/uint256"
 
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
-
 	"github.com/ledgerwatch/erigon/consensus"
 	"github.com/ledgerwatch/erigon/core/state"
 	"github.com/ledgerwatch/erigon/core/types"
@@ -21,11 +20,4 @@ func ApplyBeaconRootEip4788(chain consensus.ChainHeaderReader, header *types.Hea
 	parentBeaconBlockRootInt := *uint256.NewInt(0).SetBytes(header.ParentBeaconBlockRoot.Bytes())
 	state.SetState(historyStorageAddress, &timestampIndex, *uint256.NewInt(header.Time))
 	state.SetState(historyStorageAddress, &rootIndex, parentBeaconBlockRootInt)
-
-	// Ensure that the historyStorageAddress has nonzero nonce to prevent wipe-out of its storage stipulated by EIP-161
-	// (when the historyStorageAddress has zero balance).
-	// See https://github.com/ethereum/EIPs/pull/7431
-	if state.GetNonce(historyStorageAddress) == 0 {
-		state.SetNonce(historyStorageAddress, 1)
-	}
 }


### PR DESCRIPTION
[devnet-8](https://notes.ethereum.org/@ethpandaops/dencun-devnet-8) doesn't include https://github.com/ethereum/EIPs/pull/7431 since it's rendered obsolete by upcoming https://github.com/ethereum/EIPs/pull/7456 (to be implemented by PR #8038).

This reverts PR #7952.