### PR TITLE
p2p: fix RLPx disconnect message decoding

### DIFF
--- a/cmd/observer/observer/handshake.go
+++ b/cmd/observer/observer/handshake.go
@@ -1,12 +1,12 @@
 package observer
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"fmt"
 	"math/big"
 	"net"
-	"strings"
 	"time"
 
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
@@ -215,15 +215,11 @@ func readMessage(conn *rlpx.Conn, expectedMessageID uint64, decodeError Handshak
 		return readMessage(conn, expectedMessageID, decodeError, message)
 	}
 	if messageID == RLPxMessageIDDisconnect {
-		var reason [1]p2p.DiscReason
-		err = rlp.DecodeBytes(data, &reason)
-		if (err != nil) && strings.Contains(err.Error(), "rlp: expected input list") {
-			err = rlp.DecodeBytes(data, &reason[0])
-		}
+		reason, err := p2p.DisconnectMessagePayloadDecode(bytes.NewBuffer(data))
 		if err != nil {
 			return NewHandshakeError(HandshakeErrorIDDisconnectDecode, err, 0)
 		}
-		return NewHandshakeError(HandshakeErrorIDDisconnect, reason[0], uint64(reason[0]))
+		return NewHandshakeError(HandshakeErrorIDDisconnect, reason, uint64(reason))
 	}
 	if messageID != expectedMessageID {
 		return NewHandshakeError(HandshakeErrorIDUnexpectedMessage, nil, messageID)

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -322,11 +322,13 @@ func (p *Peer) handle(msg Msg) error {
 		msg.Discard()
 		go SendItems(p.rw, pongMsg)
 	case msg.Code == discMsg:
-		// This is the last message. We don't need to discard or
-		// check errors because, the connection will be closed after it.
-		var m struct{ R DiscReason }
-		rlp.Decode(msg.Payload, &m)
-		return m.R
+		// This is the last message.
+		// We don't need to discard because the connection will be closed after it.
+		reason, err := DisconnectMessagePayloadDecode(msg.Payload)
+		if err != nil {
+			p.log.Debug("Peer.handle: failed to rlp.Decode msg.Payload", "err", err)
+		}
+		return reason
 	case msg.Code < baseProtocolLength:
 		// ignore other base protocol messages
 		msg.Discard()


### PR DESCRIPTION
The disconnect message could either be a plain integer, or a list with one integer element. We were encoding it as a plain integer, but decoding as a list. Change this to be able to decode any format.