### PR TITLE
sync: revert flawed dropUselessPeers logic and alleviate its issues

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -1523,7 +1523,6 @@ func newSync(ctx context.Context, db kv.RwDB, miningConfig *params.MiningConfig,
 		false,
 		nil,
 		maxBlockBroadcastPeers,
-		ethconfig.Defaults.DropUselessPeers,
 		logger,
 	)
 	if err != nil {

--- a/cmd/sentry/sentry/sentry_multi_client.go
+++ b/cmd/sentry/sentry/sentry_multi_client.go
@@ -269,9 +269,8 @@ type MultiClient struct {
 	sendHeaderRequestsToMultiplePeers bool
 	maxBlockBroadcastPeers            func(*types.Header) uint
 
-	historyV3        bool
-	dropUselessPeers bool
-	logger           log.Logger
+	historyV3 bool
+	logger    log.Logger
 }
 
 func NewMultiClient(
@@ -289,7 +288,6 @@ func NewMultiClient(
 	logPeerInfo bool,
 	forkValidator *engine_helpers.ForkValidator,
 	maxBlockBroadcastPeers func(*types.Header) uint,
-	dropUselessPeers bool,
 	logger log.Logger,
 ) (*MultiClient, error) {
 	historyV3 := kvcfg.HistoryV3.FromDB(db)
@@ -322,7 +320,6 @@ func NewMultiClient(
 		historyV3:                         historyV3,
 		sendHeaderRequestsToMultiplePeers: chainConfig.TerminalTotalDifficultyPassed,
 		maxBlockBroadcastPeers:            maxBlockBroadcastPeers,
-		dropUselessPeers:                  dropUselessPeers,
 		logger:                            logger,
 	}
 	cs.ChainConfig = chainConfig
@@ -406,15 +403,6 @@ func (cs *MultiClient) blockHeaders66(ctx context.Context, in *proto_sentry.Inbo
 
 func (cs *MultiClient) blockHeaders(ctx context.Context, pkt eth.BlockHeadersPacket, rlpStream *rlp.Stream, peerID *proto_types.H512, sentry direct.SentryClient) error {
 	if len(pkt) == 0 {
-		if cs.dropUselessPeers {
-			outreq := proto_sentry.PenalizePeerRequest{
-				PeerId: peerID,
-			}
-			if _, err := sentry.PenalizePeer(ctx, &outreq, &grpc.EmptyCallOption{}); err != nil {
-				return fmt.Errorf("sending peer useless request: %v", err)
-			}
-			cs.logger.Debug("Requested removal of peer for empty header response", "peerId", fmt.Sprintf("%x", ConvertH512ToPeerID(peerID))[:8])
-		}
 		// No point processing empty response
 		return nil
 	}
@@ -569,15 +557,6 @@ func (cs *MultiClient) blockBodies66(ctx context.Context, inreq *proto_sentry.In
 	}
 	txs, uncles, withdrawals := request.BlockRawBodiesPacket.Unpack()
 	if len(txs) == 0 && len(uncles) == 0 && len(withdrawals) == 0 {
-		if cs.dropUselessPeers {
-			outreq := proto_sentry.PenalizePeerRequest{
-				PeerId: inreq.PeerId,
-			}
-			if _, err := sentry.PenalizePeer(ctx, &outreq, &grpc.EmptyCallOption{}); err != nil {
-				return fmt.Errorf("sending peer useless request: %v", err)
-			}
-			cs.logger.Debug("Requested removal of peer for empty body response", "peerId", fmt.Sprintf("%x", ConvertH512ToPeerID(inreq.PeerId)))
-		}
 		// No point processing empty response
 		return nil
 	}

--- a/cmd/sentry/sentry/sentry_multi_client.go
+++ b/cmd/sentry/sentry/sentry_multi_client.go
@@ -584,6 +584,15 @@ func (cs *MultiClient) getBlockHeaders66(ctx context.Context, inreq *proto_sentr
 	}); err != nil {
 		return fmt.Errorf("querying BlockHeaders: %w", err)
 	}
+
+	// This is a hack to make us work with erigon 2.48 peers that have --sentry.drop-useless-peers
+	// If we reply with an empty list, we're going to be considered useless and kicked.
+	// Once enough of erigon nodes are updated in the network past this commit, this check should be removed,
+	// because it is totally acceptable to return an empty list.
+	if len(headers) == 0 {
+		return nil
+	}
+
 	b, err := rlp.EncodeToBytes(&eth.BlockHeadersPacket66{
 		RequestId:          query.RequestId,
 		BlockHeadersPacket: headers,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -510,11 +510,6 @@ var (
 		Name:  "sentry.log-peer-info",
 		Usage: "Log detailed peer info when a peer connects or disconnects. Enable to integrate with observer.",
 	}
-	SentryDropUselessPeers = cli.BoolFlag{
-		Name:  "sentry.drop-useless-peers",
-		Usage: "Drop useless peers, those returning empty body or header responses",
-		Value: false,
-	}
 	DownloaderAddrFlag = cli.StringFlag{
 		Name:  "downloader.api.addr",
 		Usage: "downloader address '<host>:<port>'",
@@ -1591,10 +1586,6 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 
 	if ctx.IsSet(InternalConsensusFlag.Name) && clparams.EmbeddedEnabledByDefault(cfg.NetworkID) {
 		cfg.InternalCL = ctx.Bool(InternalConsensusFlag.Name)
-	}
-
-	if ctx.IsSet(SentryDropUselessPeers.Name) {
-		cfg.DropUselessPeers = ctx.Bool(SentryDropUselessPeers.Name)
 	}
 
 	if ctx.IsSet(TrustedSetupFile.Name) {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -523,7 +523,6 @@ func New(stack *node.Node, config *ethconfig.Config, logger log.Logger) (*Ethere
 		stack.Config().SentryLogPeerInfo,
 		backend.forkValidator,
 		maxBlockBroadcastPeers,
-		config.DropUselessPeers,
 		logger,
 	)
 	if err != nil {

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -101,7 +101,6 @@ var Defaults = Config{
 		KeepBlocks: false,
 		Produce:    true,
 	},
-	DropUselessPeers: false,
 }
 
 func init() {
@@ -246,8 +245,6 @@ type Config struct {
 	SentinelPort                uint64
 
 	OverrideCancunTime *big.Int `toml:",omitempty"`
-
-	DropUselessPeers bool
 }
 
 type Sync struct {

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -133,7 +133,6 @@ var DefaultFlags = []cli.Flag{
 	&utils.MinerSigningKeyFileFlag,
 	&utils.SentryAddrFlag,
 	&utils.SentryLogPeerInfoFlag,
-	&utils.SentryDropUselessPeers,
 	&utils.DownloaderAddrFlag,
 	&utils.DisableIPV4,
 	&utils.DisableIPV6,

--- a/turbo/stages/mock/mock_sentry.go
+++ b/turbo/stages/mock/mock_sentry.go
@@ -377,7 +377,6 @@ func MockWithEverything(tb testing.TB, gspec *types.Genesis, key *ecdsa.PrivateK
 		false,
 		forkValidator,
 		maxBlockBroadcastPeers,
-		cfg.DropUselessPeers,
 		logger,
 	)
 	if err != nil {


### PR DESCRIPTION
The current logic is flawed, because it drops all peers that are less synced.
It is valid to return empty responses by the eth spec.
A proper logic should penalize from the context of the sync process,
where enough "reputation" data is collected about a peer.

In order to be able to connect to erigon 2.48 peers that have --sentry.drop-useless-peers enabled,
this adds a check to not reply with an empty headers list.
If we reply with an empty list, we're going to be considered useless and kicked.
Once enough of erigon nodes are updated in the network past this commit, this check should be removed,
because it is totally acceptable to return an empty list by the eth spec.
