### PR TITLE
p2p: refactor peer errors to propagate with a DiscReason

### DIFF
--- a/cmd/sentry/sentry/sentry_grpc_server_test.go
+++ b/cmd/sentry/sentry/sentry_grpc_server_test.go
@@ -59,7 +59,7 @@ func startHandshake(
 	status *proto_sentry.StatusData,
 	pipe *p2p.MsgPipeRW,
 	protocolVersion uint,
-	errChan chan error,
+	errChan chan *p2p.PeerError,
 ) {
 	go func() {
 		_, err := handShake(ctx, status, pipe, protocolVersion, protocolVersion)
@@ -110,7 +110,7 @@ func testForkIDSplit(t *testing.T, protocol uint) {
 	defer p2pNoFork.Close()
 	defer p2pProFork.Close()
 
-	errc := make(chan error, 2)
+	errc := make(chan *p2p.PeerError, 2)
 	startHandshake(ctx, s1.GetStatus(), p2pNoFork, protocol, errc)
 	startHandshake(ctx, s2.GetStatus(), p2pProFork, protocol, errc)
 

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -56,7 +56,7 @@ type Msg struct {
 func (msg Msg) Decode(val interface{}) error {
 	s := rlp.NewStream(msg.Payload, uint64(msg.Size))
 	if err := s.Decode(val); err != nil {
-		return newPeerError(errInvalidMsg, "(code %x) (size %d) %v", msg.Code, msg.Size, err)
+		return NewPeerError(PeerErrorInvalidMessage, DiscProtocolError, err, fmt.Sprintf("(code %x) (size %d)", msg.Code, msg.Size))
 	}
 	return nil
 }

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -112,9 +112,9 @@ type Peer struct {
 	created mclock.AbsTime
 
 	wg       sync.WaitGroup
-	protoErr chan error
+	protoErr chan *PeerError
 	closed   chan struct{}
-	disc     chan DiscReason
+	disc     chan *PeerError
 
 	// events receives message send / receive events if set
 	events         *event.Feed
@@ -192,9 +192,9 @@ func (p *Peer) LocalAddr() net.Addr {
 
 // Disconnect terminates the peer connection with the given reason.
 // It returns immediately and does not wait until the connection is closed.
-func (p *Peer) Disconnect(reason DiscReason) {
+func (p *Peer) Disconnect(err *PeerError) {
 	select {
-	case p.disc <- reason:
+	case p.disc <- err:
 	case <-p.closed:
 	}
 }
@@ -216,8 +216,8 @@ func newPeer(logger log.Logger, conn *conn, protocols []Protocol, pubkey [64]byt
 		rw:             conn,
 		running:        protomap,
 		created:        mclock.Now(),
-		disc:           make(chan DiscReason),
-		protoErr:       make(chan error, len(protomap)+1), // protocols + pingLoop
+		disc:           make(chan *PeerError),
+		protoErr:       make(chan *PeerError, len(protomap)+1), // protocols + pingLoop
 		closed:         make(chan struct{}),
 		log:            logger.New("id", conn.node.ID(), "conn", conn.flags),
 		pubkey:         pubkey,
@@ -230,13 +230,13 @@ func (p *Peer) Log() log.Logger {
 	return p.log
 }
 
-func (p *Peer) run() (remoteRequested bool, err error) {
+func (p *Peer) run() (peerErr *PeerError) {
 	var (
 		writeStart = make(chan struct{}, 1)
 		writeErr   = make(chan error, 1)
 		readErr    = make(chan error, 1)
-		reason     DiscReason // sent to the peer
 	)
+
 	p.wg.Add(2)
 	go p.readLoop(readErr)
 	go p.pingLoop()
@@ -245,39 +245,33 @@ func (p *Peer) run() (remoteRequested bool, err error) {
 	writeStart <- struct{}{}
 	p.startProtocols(writeStart, writeErr)
 
+	defer func() {
+		close(p.closed)
+		p.rw.close(peerErr.Reason)
+		p.wg.Wait()
+	}()
+
 	// Wait for an error or disconnect.
-loop:
 	for {
 		select {
-		case err = <-writeErr:
-			// A write finished. Allow the next write to start if
-			// there was no error.
+		case err := <-writeErr:
 			if err != nil {
-				reason = DiscNetworkError
-				break loop
+				return NewPeerError(PeerErrorDiscReason, DiscNetworkError, err, "Peer.run writeErr")
 			}
+			// Allow the next write to start if there was no error.
 			writeStart <- struct{}{}
-		case err = <-readErr:
-			if r, ok := err.(DiscReason); ok {
-				remoteRequested = true
-				reason = r
+		case err := <-readErr:
+			if reason, ok := err.(DiscReason); ok {
+				return NewPeerError(PeerErrorDiscReasonRemote, reason, nil, "Peer.run got a remote DiscReason")
 			} else {
-				reason = DiscNetworkError
+				return NewPeerError(PeerErrorDiscReason, DiscNetworkError, err, "Peer.run readErr")
 			}
-			break loop
-		case err = <-p.protoErr:
-			reason = discReasonForError(err)
-			break loop
-		case err = <-p.disc:
-			reason = discReasonForError(err)
-			break loop
+		case err := <-p.protoErr:
+			return err
+		case err := <-p.disc:
+			return err
 		}
 	}
-
-	close(p.closed)
-	p.rw.close(reason)
-	p.wg.Wait()
-	return remoteRequested, err
 }
 
 func (p *Peer) pingLoop() {
@@ -289,7 +283,7 @@ func (p *Peer) pingLoop() {
 		select {
 		case <-ping.C:
 			if err := SendItems(p.rw, pingMsg); err != nil {
-				p.protoErr <- err
+				p.protoErr <- NewPeerError(PeerErrorPingFailure, DiscNetworkError, err, "Failed to send pingMsg")
 				return
 			}
 			ping.Reset(pingInterval)
@@ -407,11 +401,9 @@ func (p *Peer) startProtocols(writeStart <-chan struct{}, writeErr chan<- error)
 			defer debug.LogPanic()
 			defer p.wg.Done()
 			err := proto.Run(p, rw)
+			// only unit test protocols can return nil
 			if err == nil {
-				p.log.Trace(fmt.Sprintf("Protocol %s/%d returned", proto.Name, proto.Version))
-				err = errProtocolReturned
-			} else if err != io.EOF {
-				p.log.Trace(fmt.Sprintf("Protocol %s/%d failed", proto.Name, proto.Version), "err", err)
+				err = NewPeerError(PeerErrorTest, DiscQuitting, nil, fmt.Sprintf("Protocol %s/%d returned", proto.Name, proto.Version))
 			}
 			p.protoErr <- err
 		}()
@@ -426,7 +418,7 @@ func (p *Peer) getProto(code uint64) (*protoRW, error) {
 			return proto, nil
 		}
 	}
-	return nil, newPeerError(errInvalidMsgCode, "%d", code)
+	return nil, NewPeerError(PeerErrorInvalidMessageCode, DiscProtocolError, nil, fmt.Sprintf("code=%d", code))
 }
 
 type protoRW struct {
@@ -441,7 +433,7 @@ type protoRW struct {
 
 func (rw *protoRW) WriteMsg(msg Msg) (err error) {
 	if msg.Code >= rw.Length {
-		return newPeerError(errInvalidMsgCode, "not handled")
+		return NewPeerError(PeerErrorInvalidMessageCode, DiscProtocolError, nil, fmt.Sprintf("not handled code=%d", msg.Code))
 	}
 	msg.meterCap = rw.cap()
 	msg.meterCode = msg.Code

--- a/p2p/protocol.go
+++ b/p2p/protocol.go
@@ -43,7 +43,7 @@ type Protocol struct {
 	// The peer connection is closed when Start returns. It should return
 	// any protocol-level error (such as an I/O error) that is
 	// encountered.
-	Run func(peer *Peer, rw MsgReadWriter) error
+	Run func(peer *Peer, rw MsgReadWriter) *PeerError
 
 	// NodeInfo is an optional helper method to retrieve protocol specific metadata
 	// about the host node.

--- a/p2p/simulations/test.go
+++ b/p2p/simulations/test.go
@@ -43,7 +43,7 @@ func (t *NoopService) Protocols() []p2p.Protocol {
 			Name:    "noop",
 			Version: 666,
 			Length:  0,
-			Run: func(peer *p2p.Peer, rw p2p.MsgReadWriter) error {
+			Run: func(peer *p2p.Peer, rw p2p.MsgReadWriter) *p2p.PeerError {
 				if t.c != nil {
 					t.c[peer.ID()] = make(chan struct{})
 					close(t.c[peer.ID()])

--- a/p2p/transport_test.go
+++ b/p2p/transport_test.go
@@ -19,6 +19,7 @@ package p2p
 import (
 	"bytes"
 	"errors"
+	"github.com/ledgerwatch/erigon/rlp"
 	"reflect"
 	"sync"
 	"testing"
@@ -129,7 +130,7 @@ func TestProtocolHandshakeErrors(t *testing.T) {
 		{
 			code: handshakeMsg,
 			msg:  []byte{1, 2, 3},
-			err:  newPeerError(errInvalidMsg, "(code 0) (size 4) rlp: expected input list for p2p.protoHandshake"),
+			err:  NewPeerError(PeerErrorInvalidMessage, DiscProtocolError, rlp.WrapStreamError(rlp.ErrExpectedList, reflect.TypeOf(protoHandshake{})), "(code 0) (size 4)"),
 		},
 		{
 			code: handshakeMsg,

--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -171,6 +171,10 @@ func wrapStreamError(err error, typ reflect.Type) error {
 	return err
 }
 
+func WrapStreamError(err error, typ reflect.Type) error {
+	return wrapStreamError(err, typ)
+}
+
 func addErrorContext(err error, ctx string) error {
 	if decErr, ok := err.(*decodeError); ok {
 		decErr.ctx = append(decErr.ctx, ctx)


### PR DESCRIPTION
Improve p2p error handling to propagate errors
from the origin up the call chain the Server peer removal code
using a new PeerError type containing a DiscReason and a more detailed description.

The origin can be tracked down using PeerErrorCode (code) and DiscReason (reason)
which looks like this in the log:

> [TRACE] [08-28|16:33:40.205] Removing p2p peer                        peercount=0 url=enode://d399f4b...@1.2.3.4:30303 duration=6.901ms err="PeerError(code=remote disconnect reason, reason=too many peers, err=<nil>, message=Peer.run got a remote DiscReason)"