### PR TITLE
Small fixes to Holesky config

### DIFF
--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -261,7 +261,6 @@ type Sync struct {
 // Chains where snapshots are enabled by default
 var ChainsWithSnapshots = map[string]struct{}{
 	networkname.MainnetChainName:    {},
-	networkname.HoleskyChainName:    {},
 	networkname.SepoliaChainName:    {},
 	networkname.GoerliChainName:     {},
 	networkname.MumbaiChainName:     {},

--- a/params/chainspecs/holesky.json
+++ b/params/chainspecs/holesky.json
@@ -13,6 +13,5 @@
   "mergeForkBlock": 0,
   "terminalTotalDifficulty": 0,
   "terminalTotalDifficultyPassed": true,
-  "shanghaiTime": 1694884704,
-  "cancunTime": 2000000000
+  "shanghaiTime": 1694884704
 }

--- a/params/config.go
+++ b/params/config.go
@@ -286,6 +286,7 @@ func IsChainPoS(chainConfig *chain.Config, currentTDProvider func() *big.Int) bo
 func isChainIDPoS(chainID *big.Int) bool {
 	ids := []*big.Int{
 		MainnetChainConfig.ChainID,
+		HoleskyChainConfig.ChainID,
 		GoerliChainConfig.ChainID,
 		SepoliaChainConfig.ChainID,
 		GnosisChainConfig.ChainID,


### PR DESCRIPTION
Small fixes to PR #8064:

- Don't set cancunTime for Holesky – otherwise we'll have to overwrite it later using the `--override.cancun` flag
- We don't have block snapshots for Holesky yet
- Add Holesky to `isChainIDPoS`

See https://github.com/eth-clients/holesky/pull/68