### PR TITLE
ci: move TestExecutionSpec and TestMiningBenchmark to integration test suite

### DIFF
--- a/tests/bor/mining_test.go
+++ b/tests/bor/mining_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package bor
 
 import (

--- a/tests/exec_spec_test.go
+++ b/tests/exec_spec_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package tests
 
 import (


### PR DESCRIPTION
TestExecutionSpec takes significant time to run (12s for me),
and frequently timeouts on Windows PR builds:
https://github.com/ledgerwatch/erigon/actions/runs/5974942021/job/16235304043?pr=8077

Same with bor.TestMiningBenchmark:
https://github.com/ledgerwatch/erigon/actions/runs/6024465717/job/16343219099

Move it to the integration workflow where the timeout is longer.