### PR TITLE
moved metrics sub packages types to metrics

### DIFF
--- a/cl/phase1/core/state/lru/lru.go
+++ b/cl/phase1/core/state/lru/lru.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	lru "github.com/hashicorp/golang-lru/v2"
-	metrics "github.com/ledgerwatch/erigon/metrics/methelp"
+	"github.com/ledgerwatch/erigon/metrics"
 )
 
 // Cache is a wrapper around hashicorp lru but with metric for Get

--- a/cl/phase1/core/state/ssz.go
+++ b/cl/phase1/core/state/ssz.go
@@ -1,29 +1,28 @@
 package state
 
 import (
-	"github.com/ledgerwatch/erigon/metrics/methelp"
-
 	"github.com/ledgerwatch/erigon-lib/types/clonable"
+	"github.com/ledgerwatch/erigon/metrics"
 )
 
 func (b *CachingBeaconState) EncodeSSZ(buf []byte) ([]byte, error) {
-	h := methelp.NewHistTimer("encode_ssz_beacon_state_dur")
+	h := metrics.NewHistTimer("encode_ssz_beacon_state_dur")
 	bts, err := b.BeaconState.EncodeSSZ(buf)
 	if err != nil {
 		return nil, err
 	}
 	h.PutSince()
-	sz := methelp.NewHistTimer("encode_ssz_beacon_state_size")
+	sz := metrics.NewHistTimer("encode_ssz_beacon_state_size")
 	sz.Update(float64(len(bts)))
 	return bts, err
 }
 
 func (b *CachingBeaconState) DecodeSSZ(buf []byte, version int) error {
-	h := methelp.NewHistTimer("decode_ssz_beacon_state_dur")
+	h := metrics.NewHistTimer("decode_ssz_beacon_state_dur")
 	if err := b.BeaconState.DecodeSSZ(buf, version); err != nil {
 		return err
 	}
-	sz := methelp.NewHistTimer("decode_ssz_beacon_state_size")
+	sz := metrics.NewHistTimer("decode_ssz_beacon_state_size")
 	sz.Update(float64(len(buf)))
 	h.PutSince()
 	return b.initBeaconState()

--- a/cl/transition/impl/eth2/operations.go
+++ b/cl/transition/impl/eth2/operations.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	"github.com/ledgerwatch/erigon/cl/abstract"
+	"github.com/ledgerwatch/erigon/metrics"
 
 	"github.com/ledgerwatch/erigon/cl/transition/impl/eth2/statechange"
-	"github.com/ledgerwatch/erigon/metrics/methelp"
 	"golang.org/x/exp/slices"
 
 	"github.com/ledgerwatch/erigon-lib/common"
@@ -480,7 +480,7 @@ func (I *impl) VerifyKzgCommitmentsAgainstTransactions(transactions *solid.Trans
 
 func (I *impl) ProcessAttestations(s abstract.BeaconState, attestations *solid.ListSSZ[*solid.Attestation]) error {
 	attestingIndiciesSet := make([][]uint64, attestations.Len())
-	h := methelp.NewHistTimer("beacon_process_attestations")
+	h := metrics.NewHistTimer("beacon_process_attestations")
 	baseRewardPerIncrement := s.BaseRewardPerIncrement()
 
 	c := h.Tag("attestation_step", "process")
@@ -519,7 +519,7 @@ func processAttestationPostAltair(s abstract.BeaconState, attestation *solid.Att
 	stateSlot := s.Slot()
 	beaconConfig := s.BeaconConfig()
 
-	h := methelp.NewHistTimer("beacon_process_attestation_post_altair")
+	h := metrics.NewHistTimer("beacon_process_attestation_post_altair")
 
 	c := h.Tag("step", "get_participation_flag")
 	participationFlagsIndicies, err := s.GetAttestationParticipationFlagIndicies(attestation.AttestantionData(), stateSlot-data.Slot())

--- a/cl/transition/machine/block.go
+++ b/cl/transition/machine/block.go
@@ -3,12 +3,13 @@ package machine
 import (
 	"errors"
 	"fmt"
+
 	"github.com/ledgerwatch/erigon/cl/abstract"
+	"github.com/ledgerwatch/erigon/metrics"
 
 	"github.com/ledgerwatch/erigon/cl/clparams"
 	"github.com/ledgerwatch/erigon/cl/cltypes"
 	"github.com/ledgerwatch/erigon/cl/cltypes/solid"
-	"github.com/ledgerwatch/erigon/metrics/methelp"
 )
 
 // ProcessBlock processes a block with the block processor
@@ -19,7 +20,7 @@ func ProcessBlock(impl BlockProcessor, s abstract.BeaconState, signedBlock *clty
 	if signedBlock.Version() != version {
 		return fmt.Errorf("processBlock: wrong state version for block at slot %d", block.Slot)
 	}
-	h := methelp.NewHistTimer("beacon_process_block")
+	h := metrics.NewHistTimer("beacon_process_block")
 	// Process the block header.
 	if err := impl.ProcessBlockHeader(s, block); err != nil {
 		return fmt.Errorf("processBlock: failed to process block header: %v", err)

--- a/cmd/caplin-regression/main.go
+++ b/cmd/caplin-regression/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 
-	"github.com/ledgerwatch/erigon/metrics/exp"
+	"github.com/ledgerwatch/erigon/metrics"
 	"github.com/ledgerwatch/erigon/turbo/debug"
 
 	"github.com/ledgerwatch/erigon/cl/cltypes"
@@ -43,7 +43,7 @@ func main() {
 	)
 	if *pprof {
 		// Server for pprof
-		debug.StartPProf("localhost:6060", exp.Setup("localhost:6060", log.Root()))
+		debug.StartPProf("localhost:6060", metrics.Setup("localhost:6060", log.Root()))
 	}
 
 	if err != nil {

--- a/cmd/erigon/main.go
+++ b/cmd/erigon/main.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/ledgerwatch/erigon-lib/common/dbg"
-	metrics "github.com/ledgerwatch/erigon/metrics/methelp"
+	"github.com/ledgerwatch/erigon/metrics"
 	"github.com/ledgerwatch/log/v3"
 	"github.com/pelletier/go-toml"
 	"github.com/urfave/cli/v2"

--- a/cmd/integration/commands/state_domains.go
+++ b/cmd/integration/commands/state_domains.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/holiman/uint256"
-	metrics "github.com/ledgerwatch/erigon/metrics/methelp"
+	"github.com/ledgerwatch/erigon/metrics"
 	"github.com/ledgerwatch/log/v3"
 	"github.com/spf13/cobra"
 

--- a/cmd/sentinel/sentinel/peers/manager.go
+++ b/cmd/sentinel/sentinel/peers/manager.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/ledgerwatch/erigon/cl/phase1/core/state/lru"
-	"github.com/ledgerwatch/erigon/metrics/methelp"
+	"github.com/ledgerwatch/erigon/metrics"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
@@ -120,7 +120,7 @@ func (m *Manager) run(ctx context.Context) {
 func (m *Manager) gc() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	t := methelp.NewHistTimer("beacon_peer_manager_gc_time")
+	t := metrics.NewHistTimer("beacon_peer_manager_gc_time")
 	defer t.PutSince()
 	deleted := 0
 	saw := 0

--- a/consensus/bor/heimdall/metrics.go
+++ b/consensus/bor/heimdall/metrics.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/VictoriaMetrics/metrics"
 	metrics2 "github.com/VictoriaMetrics/metrics"
-	"github.com/ledgerwatch/erigon/metrics/methelp"
-	metrics "github.com/ledgerwatch/erigon/metrics/methelp"
 )
 
 type (
@@ -56,7 +55,7 @@ var (
 				true:  metrics.GetOrCreateCounter("client_requests_checkpoint_valid"),
 				false: metrics.GetOrCreateCounter("client_requests_checkpoint_invalid"),
 			},
-			timer: methelp.GetOrCreateSummary("client_requests_checkpoint_duration"),
+			timer: metrics.GetOrCreateSummary("client_requests_checkpoint_duration"),
 		},
 		checkpointCountRequest: {
 			request: map[bool]*metrics2.Counter{

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"time"
 
-	metrics "github.com/ledgerwatch/erigon/metrics/methelp"
+	"github.com/ledgerwatch/erigon/metrics"
 	"golang.org/x/crypto/sha3"
 	"golang.org/x/exp/slices"
 

--- a/eth/stagedsync/all_stages.go
+++ b/eth/stagedsync/all_stages.go
@@ -7,7 +7,7 @@ import (
 	"github.com/huandu/xstrings"
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon/eth/stagedsync/stages"
-	metrics "github.com/ledgerwatch/erigon/metrics/methelp"
+	"github.com/ledgerwatch/erigon/metrics"
 )
 
 var syncMetrics = map[stages.SyncStage]*metrics2.Counter{}

--- a/metrics/collector.go
+++ b/metrics/collector.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-package prometheus
+package metrics
 
 import (
 	"bytes"

--- a/metrics/exp.go
+++ b/metrics/exp.go
@@ -1,13 +1,11 @@
 // Hook go-metrics into expvar
 // on any /debug/metrics request, load all vars from the registry into expvar, and execute regular expvar handler
-package exp
+package metrics
 
 import (
 	"fmt"
 	"net/http"
 
-	"github.com/ledgerwatch/erigon/metrics"
-	"github.com/ledgerwatch/erigon/metrics/prometheus"
 	"github.com/ledgerwatch/log/v3"
 )
 
@@ -16,7 +14,7 @@ import (
 func Setup(address string, logger log.Logger) *http.ServeMux {
 	prometheusMux := http.NewServeMux()
 
-	prometheusMux.Handle("/debug/metrics/prometheus", prometheus.Handler(metrics.DefaultRegistry))
+	prometheusMux.Handle("/debug/metrics/prometheus", Handler(DefaultRegistry))
 
 	promServer := &http.Server{
 		Addr:    address,

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -15,7 +15,7 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 // Package prometheus exposes go-metrics into a Prometheus format.
-package prometheus
+package metrics
 
 import (
 	"fmt"
@@ -23,14 +23,13 @@ import (
 	"sort"
 
 	metrics2 "github.com/VictoriaMetrics/metrics"
-	"github.com/ledgerwatch/erigon/metrics"
 	"github.com/ledgerwatch/log/v3"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/expfmt"
 )
 
 // Handler returns an HTTP handler which dump metrics in Prometheus format.
-func Handler(reg metrics.Registry) http.Handler {
+func Handler(reg Registry) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Gather and pre-sort the metrics to avoid random listings
 		var names []string

--- a/metrics/register.go
+++ b/metrics/register.go
@@ -1,36 +1,35 @@
-package methelp
+package metrics
 
 import (
 	metrics2 "github.com/VictoriaMetrics/metrics"
-	metrics "github.com/ledgerwatch/erigon/metrics"
 )
 
 func GetOrCreateCounter(s string, isGauge ...bool) *metrics2.Counter {
 	counter := metrics2.GetOrCreateCounter(s, isGauge...)
-	metrics.DefaultRegistry.Register(s, counter)
+	DefaultRegistry.Register(s, counter)
 	return counter
 }
 
 func GetOrCreateGauge(s string, f func() float64) *metrics2.Gauge {
 	gauge := metrics2.GetOrCreateGauge(s, f)
-	metrics.DefaultRegistry.Register(s, gauge)
+	DefaultRegistry.Register(s, gauge)
 	return gauge
 }
 
 func GetOrCreateFloatCounter(s string) *metrics2.FloatCounter {
 	floatCounter := metrics2.GetOrCreateFloatCounter(s)
-	metrics.DefaultRegistry.Register(s, floatCounter)
+	DefaultRegistry.Register(s, floatCounter)
 	return floatCounter
 }
 
 func GetOrCreateSummary(s string) *metrics2.Summary {
 	summary := metrics2.GetOrCreateSummary(s)
-	metrics.DefaultRegistry.Register(s, summary)
+	DefaultRegistry.Register(s, summary)
 	return summary
 }
 
 func GetOrCreateHistogram(s string) *metrics2.Histogram {
 	histogram := metrics2.GetOrCreateHistogram(s)
-	metrics.DefaultRegistry.Register(s, histogram)
+	DefaultRegistry.Register(s, histogram)
 	return histogram
 }

--- a/metrics/timer.go
+++ b/metrics/timer.go
@@ -1,4 +1,4 @@
-package methelp
+package metrics
 
 import (
 	"fmt"

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -21,7 +21,7 @@ package p2p
 import (
 	"net"
 
-	metrics "github.com/ledgerwatch/erigon/metrics/methelp"
+	"github.com/ledgerwatch/erigon/metrics"
 )
 
 const (

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -30,7 +30,7 @@ import (
 	"github.com/ledgerwatch/erigon/common/debug"
 	"github.com/ledgerwatch/erigon/common/mclock"
 	"github.com/ledgerwatch/erigon/event"
-	metrics "github.com/ledgerwatch/erigon/metrics/methelp"
+	"github.com/ledgerwatch/erigon/metrics"
 	"github.com/ledgerwatch/erigon/p2p/enode"
 	"github.com/ledgerwatch/erigon/p2p/enr"
 	"github.com/ledgerwatch/erigon/rlp"

--- a/p2p/transport_test.go
+++ b/p2p/transport_test.go
@@ -19,10 +19,11 @@ package p2p
 import (
 	"bytes"
 	"errors"
-	"github.com/ledgerwatch/erigon/rlp"
 	"reflect"
 	"sync"
 	"testing"
+
+	"github.com/ledgerwatch/erigon/rlp"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/ledgerwatch/erigon/crypto"

--- a/rpc/metrics.go
+++ b/rpc/metrics.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	metrics2 "github.com/VictoriaMetrics/metrics"
-	metrics "github.com/ledgerwatch/erigon/metrics/methelp"
+	"github.com/ledgerwatch/erigon/metrics"
 )
 
 var (

--- a/turbo/debug/flags.go
+++ b/turbo/debug/flags.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/ledgerwatch/erigon/common/fdlimit"
 	"github.com/ledgerwatch/erigon/diagnostics"
-	"github.com/ledgerwatch/erigon/metrics/exp"
+	"github.com/ledgerwatch/erigon/metrics"
 	"github.com/ledgerwatch/erigon/turbo/logging"
 )
 
@@ -159,7 +159,7 @@ func SetupCobra(cmd *cobra.Command, filePrefix string) log.Logger {
 
 	if metricsEnabled && metricsAddr != "" {
 		metricsAddress = fmt.Sprintf("%s:%d", metricsAddr, metricsPort)
-		metricsMux = exp.Setup(metricsAddress, logger)
+		metricsMux = metrics.Setup(metricsAddress, logger)
 	}
 
 	if pprof {
@@ -207,7 +207,7 @@ func Setup(ctx *cli.Context, rootLogger bool) (log.Logger, error) {
 	if metricsEnabled && (!pprofEnabled || metricsAddr != "") {
 		metricsPort := ctx.Int(metricsPortFlag.Name)
 		metricsAddress = fmt.Sprintf("%s:%d", metricsAddr, metricsPort)
-		metricsMux = exp.Setup(metricsAddress, logger)
+		metricsMux = metrics.Setup(metricsAddress, logger)
 		diagnostics.SetupLogsAccess(ctx, metricsMux)
 		diagnostics.SetupDbAccess(ctx, metricsMux)
 		diagnostics.SetupCmdLineAccess(metricsMux)

--- a/turbo/shards/state_cache.go
+++ b/turbo/shards/state_cache.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/btree"
 	"github.com/holiman/uint256"
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
-	metrics "github.com/ledgerwatch/erigon/metrics/methelp"
+	"github.com/ledgerwatch/erigon/metrics"
 
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/core/types/accounts"


### PR DESCRIPTION
This is a non functional change which consolidates the various packages under metrics into the top level package now that the dead code is removed.

It is a precursor to the removal of Victoria metrics after which all erigon metrics code will be contained in this single package.