### PR TITLE
rpcdaemon: read genesis block if not loaded

### DIFF
--- a/turbo/jsonrpc/eth_api.go
+++ b/turbo/jsonrpc/eth_api.go
@@ -232,6 +232,8 @@ func (api *BaseAPI) chainConfigWithGenesis(tx kv.Tx) (*chain.Config, *types.Bloc
 	if err != nil {
 		return nil, nil, err
 	}
+
+	genesisBlock, err = api.blockByRPCNumber(context.Background(), 0, tx)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
if genesis load is not loaded it is necessary read from storage