### PR TITLE
Strip labels when writing metric metadata

### DIFF
--- a/metrics/collector.go
+++ b/metrics/collector.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/VictoriaMetrics/metrics"
 )
@@ -84,13 +85,21 @@ func (c *collector) addTimer(name string, m *metrics.Summary) {
 }
 
 func (c *collector) writeGauge(name string, value interface{}) {
-	//c.buff.WriteString(fmt.Sprintf(typeGaugeTpl, name))
+	c.buff.WriteString(fmt.Sprintf(typeGaugeTpl, stripLabels(name)))
 	c.buff.WriteString(fmt.Sprintf(keyValueTpl, name, value))
 }
 
 func (c *collector) writeCounter(name string, value interface{}) {
-	//c.buff.WriteString(fmt.Sprintf(typeCounterTpl, name))
+	c.buff.WriteString(fmt.Sprintf(typeCounterTpl, stripLabels(name)))
 	c.buff.WriteString(fmt.Sprintf(keyValueTpl, name, value))
+}
+
+func stripLabels(name string) string {
+	if labelsIndex := strings.IndexByte(name, '{'); labelsIndex >= 0 {
+		return name[0:labelsIndex]
+	}
+
+	return name
 }
 
 func (c *collector) writeSummaryCounter(name string, value interface{}) {


### PR DESCRIPTION
This is a fix for 

```cache_total{target="acc_read"} counter it's invalid syntax of metric type. prometheus parsing error```

which does not remove the whole metadata tag