### PR TITLE
Added write of vm default set to metrics

### DIFF
--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -39,6 +39,9 @@ func Handler(reg Registry) http.Handler {
 		sort.Strings(names)
 
 		w.Header().Set("Access-Control-Allow-Origin", "*")
+
+		metrics2.WritePrometheus(w, false)
+
 		contentType := expfmt.Negotiate(r.Header)
 		enc := expfmt.NewEncoder(w, contentType)
 		mf, err := prometheus.DefaultGatherer.Gather()

--- a/metrics/register.go
+++ b/metrics/register.go
@@ -7,29 +7,34 @@ import (
 func GetOrCreateCounter(s string, isGauge ...bool) *metrics2.Counter {
 	counter := metrics2.GetOrCreateCounter(s, isGauge...)
 	DefaultRegistry.Register(s, counter)
+	metrics2.GetDefaultSet().UnregisterMetric(s)
 	return counter
 }
 
 func GetOrCreateGauge(s string, f func() float64) *metrics2.Gauge {
 	gauge := metrics2.GetOrCreateGauge(s, f)
 	DefaultRegistry.Register(s, gauge)
+	metrics2.GetDefaultSet().UnregisterMetric(s)
 	return gauge
 }
 
 func GetOrCreateFloatCounter(s string) *metrics2.FloatCounter {
 	floatCounter := metrics2.GetOrCreateFloatCounter(s)
 	DefaultRegistry.Register(s, floatCounter)
+	metrics2.GetDefaultSet().UnregisterMetric(s)
 	return floatCounter
 }
 
 func GetOrCreateSummary(s string) *metrics2.Summary {
 	summary := metrics2.GetOrCreateSummary(s)
 	DefaultRegistry.Register(s, summary)
+	metrics2.GetDefaultSet().UnregisterMetric(s)
 	return summary
 }
 
 func GetOrCreateHistogram(s string) *metrics2.Histogram {
 	histogram := metrics2.GetOrCreateHistogram(s)
 	DefaultRegistry.Register(s, histogram)
+	metrics2.GetDefaultSet().UnregisterMetric(s)
 	return histogram
 }


### PR DESCRIPTION
Metrics handler was missing erigon-lib metrics - which where added to the VM default set 

This fixes that whilst avoiding duplicates from erigon registrations