### PR TITLE
Revert "remove extra data from holesky genesis (#8207)"

### DIFF
--- a/core/genesis_write.go
+++ b/core/genesis_write.go
@@ -348,6 +348,7 @@ func HoleskyGenesisBlock() *types.Genesis {
 	return &types.Genesis{
 		Config:     params.HoleskyChainConfig,
 		Nonce:      4660,
+		ExtraData:  hexutil.MustDecode("0x686f77206d7563682069732074686520666973683f"),
 		GasLimit:   25000000,
 		Difficulty: big.NewInt(1),
 		Timestamp:  1694786100,


### PR DESCRIPTION
This reverts commit 438dd6bdb133048eafd67ceccae1cf8860701489.  Broke CI. Reverted. Will make another PR.