### PR TITLE
Support release/x.xx branches in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,12 @@ on:
     branches:
       - devel
       - alpha
-      - stable
+      - 'release/**'
   pull_request:
     branches:
       - devel
       - alpha
-      - stable
+      - 'release/**'
     types:
       - opened
       - reopened

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - devel
       - alpha
-      - stable
+      - 'release/**'
   schedule:
     - cron: '20 16 * * *' # daily at 16:20 UTC
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ Usage
 
 ### Getting Started
 
-For building the latest stable release (this will be suitable for most users just wanting to run a node):
+For building the latest release (this will be suitable for most users just wanting to run a node):
 
 ```sh
-git clone --branch stable --single-branch https://github.com/ledgerwatch/erigon.git
+git clone --branch release/<x.xx> --single-branch https://github.com/ledgerwatch/erigon.git
 cd erigon
 make erigon
 ./build/bin/erigon


### PR DESCRIPTION
It's safer to have branches for individual release series like `release/2.50` for 2.50.x releases instead of overwriting `stable`. geth does that already.