### PR TITLE
turbo/adapter/ethapi: Add `CallArgs.Input` attribute

### DIFF
--- a/turbo/adapter/ethapi/api.go
+++ b/turbo/adapter/ethapi/api.go
@@ -47,6 +47,7 @@ type CallArgs struct {
 	Value                *hexutil.Big       `json:"value"`
 	Nonce                *hexutil.Uint64    `json:"nonce"`
 	Data                 *hexutility.Bytes  `json:"data"`
+	Input                *hexutility.Bytes  `json:"input"`
 	AccessList           *types2.AccessList `json:"accessList"`
 	ChainID              *hexutil.Big       `json:"chainId,omitempty"`
 }
@@ -142,7 +143,9 @@ func (args *CallArgs) ToMessage(globalGasCap uint64, baseFee *uint256.Int) (type
 		}
 	}
 	var data []byte
-	if args.Data != nil {
+	if args.Input != nil {
+		data = *args.Input
+	} else if args.Data != nil {
 		data = *args.Data
 	}
 	var accessList types2.AccessList


### PR DESCRIPTION
This PR adds the ability to pass `input` instead of `data` in `eth_call`.

Go-ethereum has support for the `input`-attribute (instead of the `data`) in `eth_call` for some time. The recent go-ethereum release v1.13.0 changed the ethclient to do a `eth_call` with the `input` attribute rather than "data". This makes the latest go-ethereum ethclient incompatible with erigon.