### PR TITLE
Extend gas optimization for eth_createAccessList

### DIFF
--- a/turbo/jsonrpc/eth_call.go
+++ b/turbo/jsonrpc/eth_call.go
@@ -504,9 +504,9 @@ func (api *APIImpl) CreateAccessList(ctx context.Context, args ethapi2.CallArgs,
 	precompiles := vm.ActivePrecompiles(chainConfig.Rules(blockNumber, header.Time))
 
 	// Create an initial tracer
-	prevTracer := logger.NewAccessListTracer(nil, *args.From, to, precompiles)
+	prevTracer := logger.NewAccessListTracer(nil, nil, nil)
 	if args.AccessList != nil {
-		prevTracer = logger.NewAccessListTracer(*args.AccessList, *args.From, to, precompiles)
+		prevTracer = logger.NewAccessListTracer(*args.AccessList, nil, nil)
 	}
 	for {
 		state := state.New(stateReader)
@@ -537,7 +537,7 @@ func (api *APIImpl) CreateAccessList(ctx context.Context, args ethapi2.CallArgs,
 		}
 
 		// Apply the transaction with the access list tracer
-		tracer := logger.NewAccessListTracer(accessList, *args.From, to, precompiles)
+		tracer := logger.NewAccessListTracer(accessList, nil, state)
 		config := vm.Config{Tracer: tracer, Debug: true, NoBaseFee: true}
 		blockCtx := transactions.NewEVMBlockContext(engine, header, bNrOrHash.RequireCanonical, tx, api._blockReader)
 		txCtx := core.NewEVMTxContext(msg)
@@ -555,7 +555,17 @@ func (api *APIImpl) CreateAccessList(ctx context.Context, args ethapi2.CallArgs,
 			}
 			accessList := &accessListResult{Accesslist: &accessList, Error: errString, GasUsed: hexutil.Uint64(res.UsedGas)}
 			if optimizeGas != nil && *optimizeGas {
-				optimizeToInAccessList(accessList, to)
+				optimizeWarmAddrInAccessList(accessList, *args.From)
+				optimizeWarmAddrInAccessList(accessList, to)
+				optimizeWarmAddrInAccessList(accessList, header.Coinbase)
+				for _, pc := range precompiles {
+					optimizeWarmAddrInAccessList(accessList, pc)
+				}
+				for addr := range tracer.CreatedContracts() {
+					if !tracer.UsedBeforeCreation(addr) {
+						optimizeWarmAddrInAccessList(accessList, addr)
+					}
+				}
 			}
 			return accessList, nil
 		}
@@ -563,14 +573,15 @@ func (api *APIImpl) CreateAccessList(ctx context.Context, args ethapi2.CallArgs,
 	}
 }
 
-// to address is warm already, so we can save by adding it to the access list
-// only if we are adding a lot of its storage slots as well
-func optimizeToInAccessList(accessList *accessListResult, to libcommon.Address) {
+// some addresses (like sender, recipient, block producer, precompiles, and created contracts)
+// are considered warm already, so we can save by adding these to the access list
+// only if we are adding a lot of their respective storage slots as well
+func optimizeWarmAddrInAccessList(accessList *accessListResult, addr libcommon.Address) {
 	indexToRemove := -1
 
 	for i := 0; i < len(*accessList.Accesslist); i++ {
 		entry := (*accessList.Accesslist)[i]
-		if entry.Address != to {
+		if entry.Address != addr {
 			continue
 		}
 


### PR DESCRIPTION
This builds upon #3453 and #3524, which previously implemented gas optimizations for the access lists generated by Erigon's implementation of the `eth_createAccessList` RPC call.

Erigon currently optimizes inclusion of the recipient address based on how many storage keys are accessed, but does not perform the same optimization for sender address and precompiled contract addresses. These changes make the same optimization available for all of these cases.

Additionally, this handles the cases of block producer address and created smart contract addresses. If these cases were omitted on purpose since they heavily rely on state, it may still make sense to offer them to users but disable them by default.