### PR TITLE
Only reduce the consensus db size based on flags values (#8321)

### DIFF
--- a/erigon-lib/kv/mdbx/kv_mdbx.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx.go
@@ -70,6 +70,9 @@ type MdbxOpts struct {
 	inMem           bool
 }
 
+const DefaultMapSize = 2 * datasize.TB
+const DefaultGrowthStep = 2 * datasize.GB
+
 func NewMDBX(log log.Logger) MdbxOpts {
 	opts := MdbxOpts{
 		bucketsCfg: WithChaindataTables,
@@ -81,8 +84,8 @@ func NewMDBX(log log.Logger) MdbxOpts {
 		// but for reproducibility of benchmarks - please don't rely on Available RAM
 		dirtySpace: 2 * (memory.TotalMemory() / 42),
 
-		mapSize:         2 * datasize.TB,
-		growthStep:      2 * datasize.GB,
+		mapSize:         DefaultMapSize,
+		growthStep:      DefaultGrowthStep,
 		mergeThreshold:  3 * 8192,
 		shrinkThreshold: -1, // default
 		label:           kv.InMem,

--- a/node/node.go
+++ b/node/node.go
@@ -325,7 +325,7 @@ func OpenDatabase(config *nodecfg.Config, label kv.Label, name string, readonly 
 		}
 
 		switch label {
-		case kv.ChainDB, kv.ConsensusDB:
+		case kv.ChainDB:
 			if config.MdbxPageSize.Bytes() > 0 {
 				opts = opts.PageSize(config.MdbxPageSize.Bytes())
 			}
@@ -333,6 +333,18 @@ func OpenDatabase(config *nodecfg.Config, label kv.Label, name string, readonly 
 				opts = opts.MapSize(config.MdbxDBSizeLimit)
 			}
 			if config.MdbxGrowthStep > 0 {
+				opts = opts.GrowthStep(config.MdbxGrowthStep)
+			}
+		case kv.ConsensusDB:
+			if config.MdbxPageSize.Bytes() > 0 {
+				opts = opts.PageSize(config.MdbxPageSize.Bytes())
+			}
+			// Don't adjust up the consensus DB - this will lead to resource exhaustion lor large map sizes
+			if config.MdbxDBSizeLimit > 0 && config.MdbxDBSizeLimit < mdbx.DefaultMapSize {
+				opts = opts.MapSize(config.MdbxDBSizeLimit)
+			}
+			// Don't adjust up the consensus DB - to align with db size limit above
+			if config.MdbxGrowthStep > 0 && config.MdbxGrowthStep < mdbx.DefaultGrowthStep {
 				opts = opts.GrowthStep(config.MdbxGrowthStep)
 			}
 		default:

--- a/params/version.go
+++ b/params/version.go
@@ -33,7 +33,7 @@ var (
 const (
 	VersionMajor       = 2  // Major version component of the current release
 	VersionMinor       = 50 // Minor version component of the current release
-	VersionMicro       = 0  // Patch version component of the current release
+	VersionMicro       = 1  // Patch version component of the current release
 	VersionModifier    = "" // Modifier component of the current release
 	VersionKeyCreated  = "ErigonVersionCreated"
 	VersionKeyFinished = "ErigonVersionFinished"


### PR DESCRIPTION
This is to fix an issue with resource usage if the db.size.limit is increased from its default setting of 2TB. This is applied to the chain DB, but should not be used on the consensus DB which has smaller data requirements. Expanding both DBs results in excessive RAM being reserved by the underlying OS.