### PR TITLE
eth, consensus/bor: handle 503 response from heimdall

### DIFF
--- a/consensus/bor/heimdall/client.go
+++ b/consensus/bor/heimdall/client.go
@@ -26,6 +26,7 @@ var (
 	ErrNotSuccessfulResponse = errors.New("error while fetching data from Heimdall")
 	ErrNotInRejectedList     = errors.New("milestoneID doesn't exist in rejected list")
 	ErrNotInMilestoneList    = errors.New("milestoneID doesn't exist in Heimdall")
+	ErrServiceUnavailable    = errors.New("service unavailable")
 )
 
 const (
@@ -279,10 +280,18 @@ func FetchWithRetry[T any](ctx context.Context, client http.Client, url *url.URL
 		return result, nil
 	}
 
+	// 503 (Service Unavailable) is thrown when an endpoint isn't activated
+	// yet in heimdall. E.g. when the hardfork hasn't hit yet but heimdall
+	// is upgraded.
+	if errors.Is(err, ErrServiceUnavailable) {
+		log.Debug("Heimdall service unavailable at the moment", "path", url.Path, "error", err)
+		return nil, err
+	}
+
 	// attempt counter
 	attempt := 1
 
-	logger.Warn("an error while trying fetching from Heimdall", "attempt", attempt, "error", err)
+	log.Warn("an error while trying fetching from Heimdall", "path", url.Path, "attempt", attempt, "error", err)
 
 	// create a new ticker for retrying the request
 	ticker := time.NewTicker(retryCall)
@@ -309,9 +318,14 @@ retryLoop:
 			request = &Request{client: client, url: url, start: time.Now()}
 			result, err = Fetch[T](ctx, request)
 
+			if errors.Is(err, ErrServiceUnavailable) {
+				log.Debug("Heimdall service unavailable at the moment", "path", url.Path, "error", err)
+				return nil, err
+			}
+
 			if err != nil {
 				if attempt%logEach == 0 {
-					logger.Warn("an error while trying fetching from Heimdall", "attempt", attempt, "error", err)
+					log.Warn("an error while trying fetching from Heimdall", "path", url.Path, "attempt", attempt, "error", err)
 				}
 
 				continue retryLoop
@@ -423,6 +437,10 @@ func internalFetch(ctx context.Context, client http.Client, u *url.URL) ([]byte,
 	}
 
 	defer res.Body.Close()
+
+	if res.StatusCode == http.StatusServiceUnavailable {
+		return nil, fmt.Errorf("%w: response code %d", ErrServiceUnavailable, res.StatusCode)
+	}
 
 	// check status code
 	if res.StatusCode != 200 && res.StatusCode != 204 {

--- a/consensus/bor/heimdall/client.go
+++ b/consensus/bor/heimdall/client.go
@@ -284,14 +284,14 @@ func FetchWithRetry[T any](ctx context.Context, client http.Client, url *url.URL
 	// yet in heimdall. E.g. when the hardfork hasn't hit yet but heimdall
 	// is upgraded.
 	if errors.Is(err, ErrServiceUnavailable) {
-		log.Debug("Heimdall service unavailable at the moment", "path", url.Path, "error", err)
+		logger.Debug("Heimdall service unavailable at the moment", "path", url.Path, "error", err)
 		return nil, err
 	}
 
 	// attempt counter
 	attempt := 1
 
-	log.Warn("an error while trying fetching from Heimdall", "path", url.Path, "attempt", attempt, "error", err)
+	logger.Warn("an error while trying fetching from Heimdall", "path", url.Path, "attempt", attempt, "error", err)
 
 	// create a new ticker for retrying the request
 	ticker := time.NewTicker(retryCall)
@@ -319,13 +319,13 @@ retryLoop:
 			result, err = Fetch[T](ctx, request)
 
 			if errors.Is(err, ErrServiceUnavailable) {
-				log.Debug("Heimdall service unavailable at the moment", "path", url.Path, "error", err)
+				logger.Debug("Heimdall service unavailable at the moment", "path", url.Path, "error", err)
 				return nil, err
 			}
 
 			if err != nil {
 				if attempt%logEach == 0 {
-					log.Warn("an error while trying fetching from Heimdall", "path", url.Path, "attempt", attempt, "error", err)
+					logger.Warn("an error while trying fetching from Heimdall", "path", url.Path, "attempt", attempt, "error", err)
 				}
 
 				continue retryLoop

--- a/eth/borfinality/whitelist.go
+++ b/eth/borfinality/whitelist.go
@@ -189,7 +189,7 @@ func handleMilestone(ctx context.Context, heimdall heimdall.IHeimdallClient, con
 
 func handleNoAckMilestone(ctx context.Context, heimdall heimdall.IHeimdallClient, config *config) error {
 	service := whitelist.GetWhitelistingService()
-	milestoneID, err := fetchNoAckMilestone(ctx, heimdall)
+	milestoneID, err := fetchNoAckMilestone(ctx, heimdall, config.logger)
 
 	//If failed to fetch the no-ack milestone then it give the error.
 	if err != nil {
@@ -206,7 +206,7 @@ func handleNoAckMilestoneByID(ctx context.Context, heimdall heimdall.IHeimdallCl
 	milestoneIDs := service.GetMilestoneIDsList()
 
 	for _, milestoneID := range milestoneIDs {
-		err := fetchNoAckMilestoneByID(ctx, heimdall, milestoneID)
+		err := fetchNoAckMilestoneByID(ctx, heimdall, milestoneID, config.logger)
 		if err == nil {
 			service.RemoveMilestoneID(milestoneID)
 		}

--- a/eth/borfinality/whitelist_helpers.go
+++ b/eth/borfinality/whitelist_helpers.go
@@ -33,18 +33,18 @@ func fetchWhitelistCheckpoint(ctx context.Context, heimdallClient heimdall.IHeim
 	// fetch the latest checkpoint from Heimdall
 	checkpoint, err := heimdallClient.FetchCheckpoint(ctx, -1)
 	if err != nil {
-		log.Debug("Failed to fetch latest checkpoint for whitelisting", "err", err)
+		config.logger.Debug("Failed to fetch latest checkpoint for whitelisting", "err", err)
 		return blockNum, blockHash, errCheckpoint
 	}
 
-	log.Info("Got new checkpoint from heimdall", "start", checkpoint.StartBlock.Uint64(), "end", checkpoint.EndBlock.Uint64(), "rootHash", checkpoint.RootHash.String())
+	config.logger.Info("Got new checkpoint from heimdall", "start", checkpoint.StartBlock.Uint64(), "end", checkpoint.EndBlock.Uint64(), "rootHash", checkpoint.RootHash.String())
 
 	// Verify if the checkpoint fetched can be added to the local whitelist entry or not
 	// If verified, it returns the hash of the end block of the checkpoint. If not,
 	// it will return appropriate error.
 	hash, err := verifier.verify(ctx, config, checkpoint.StartBlock.Uint64(), checkpoint.EndBlock.Uint64(), checkpoint.RootHash.String()[2:], true)
 	if err != nil {
-		log.Warn("Failed to whitelist checkpoint", "err", err)
+		config.logger.Warn("Failed to whitelist checkpoint", "err", err)
 		return blockNum, blockHash, err
 	}
 
@@ -65,16 +65,16 @@ func fetchWhitelistMilestone(ctx context.Context, heimdallClient heimdall.IHeimd
 	// fetch latest milestone
 	milestone, err := heimdallClient.FetchMilestone(ctx)
 	if errors.Is(err, heimdall.ErrServiceUnavailable) {
-		log.Debug("Failed to fetch latest milestone for whitelisting", "err", err)
+		config.logger.Debug("Failed to fetch latest milestone for whitelisting", "err", err)
 		return num, hash, errMilestone
 	}
 
 	if err != nil {
-		log.Error("Failed to fetch latest milestone for whitelisting", "err", err)
+		config.logger.Error("Failed to fetch latest milestone for whitelisting", "err", err)
 		return num, hash, errMilestone
 	}
 
-	log.Info("Got new milestone from heimdall", "start", milestone.StartBlock.Uint64(), "end", milestone.EndBlock.Uint64(), "hash", milestone.Hash.String())
+	config.logger.Info("Got new milestone from heimdall", "start", milestone.StartBlock.Uint64(), "end", milestone.EndBlock.Uint64(), "hash", milestone.Hash.String())
 
 	num = milestone.EndBlock.Uint64()
 	hash = milestone.Hash
@@ -91,40 +91,40 @@ func fetchWhitelistMilestone(ctx context.Context, heimdallClient heimdall.IHeimd
 	return num, hash, nil
 }
 
-func fetchNoAckMilestone(ctx context.Context, heimdallClient heimdall.IHeimdallClient) (string, error) {
+func fetchNoAckMilestone(ctx context.Context, heimdallClient heimdall.IHeimdallClient, logger log.Logger) (string, error) {
 	var (
 		milestoneID string
 	)
 
 	milestoneID, err := heimdallClient.FetchLastNoAckMilestone(ctx)
 	if errors.Is(err, heimdall.ErrServiceUnavailable) {
-		log.Debug("Failed to fetch latest no-ack milestone", "err", err)
+		logger.Debug("Failed to fetch latest no-ack milestone", "err", err)
 		return milestoneID, errMilestone
 	}
 
 	if err != nil {
-		log.Error("Failed to fetch latest no-ack milestone", "err", err)
+		logger.Error("Failed to fetch latest no-ack milestone", "err", err)
 		return milestoneID, errMilestone
 	}
 
 	return milestoneID, nil
 }
 
-func fetchNoAckMilestoneByID(ctx context.Context, heimdallClient heimdall.IHeimdallClient, milestoneID string) error {
+func fetchNoAckMilestoneByID(ctx context.Context, heimdallClient heimdall.IHeimdallClient, milestoneID string, logger log.Logger) error {
 	err := heimdallClient.FetchNoAckMilestone(ctx, milestoneID)
 	if errors.Is(err, heimdall.ErrServiceUnavailable) {
-		log.Debug("Failed to fetch no-ack milestone by ID", "milestoneID", milestoneID, "err", err)
+		logger.Debug("Failed to fetch no-ack milestone by ID", "milestoneID", milestoneID, "err", err)
 		return err
 	}
 
 	// fixme: handle different types of errors
 	if errors.Is(err, ErrNotInRejectedList) {
-		log.Warn("MilestoneID not in rejected list", "milestoneID", milestoneID, "err", err)
+		logger.Warn("MilestoneID not in rejected list", "milestoneID", milestoneID, "err", err)
 		return err
 	}
 
 	if err != nil {
-		log.Error("Failed to fetch no-ack milestone by ID ", "milestoneID", milestoneID, "err", err)
+		logger.Error("Failed to fetch no-ack milestone by ID ", "milestoneID", milestoneID, "err", err)
 		return errMilestone
 	}
 


### PR DESCRIPTION
When a new feature (like for the upcoming `Aalborg` hard fork) for Polygon hasn't kicked in (in heimdall), the endpoints of heimdall will now return 503 (Service Unavailable) status code. This PR makes sure that erigon handles that code separately and doesn't keep retying to fetch info. It also acts as a notifier of the HF in erigon. 

Similar reference PR in bor: https://github.com/maticnetwork/bor/pull/1023