### PR TITLE
Remove protocolBaseFee checks

### DIFF
--- a/erigon-lib/txpool/pool_fuzz_test.go
+++ b/erigon-lib/txpool/pool_fuzz_test.go
@@ -334,9 +334,6 @@ func FuzzOnNewBlocks(f *testing.F) {
 				if tx.subPool&NoNonceGaps > 0 {
 					assert.GreaterOrEqual(i.Nonce, senders[i.SenderID].nonce, msg, i.SenderID)
 				}
-				if tx.subPool&EnoughFeeCapProtocol > 0 {
-					assert.LessOrEqual(calcProtocolBaseFee(pendingBaseFee), tx.Tx.FeeCap, msg)
-				}
 				if tx.subPool&EnoughFeeCapBlock > 0 {
 					assert.LessOrEqual(pendingBaseFee, tx.Tx.FeeCap, msg)
 				}
@@ -370,9 +367,6 @@ func FuzzOnNewBlocks(f *testing.F) {
 				if tx.subPool&NoNonceGaps > 0 {
 					assert.GreaterOrEqual(i.Nonce, senders[i.SenderID].nonce, msg)
 				}
-				if tx.subPool&EnoughFeeCapProtocol > 0 {
-					assert.LessOrEqual(calcProtocolBaseFee(pendingBaseFee), tx.Tx.FeeCap, msg)
-				}
 				if tx.subPool&EnoughFeeCapBlock > 0 {
 					assert.LessOrEqual(pendingBaseFee, tx.Tx.FeeCap, msg)
 				}
@@ -390,9 +384,6 @@ func FuzzOnNewBlocks(f *testing.F) {
 				i := tx.Tx
 				if tx.subPool&NoNonceGaps > 0 {
 					assert.GreaterOrEqual(i.Nonce, senders[i.SenderID].nonce, msg, i.SenderID, senders[i.SenderID].nonce)
-				}
-				if tx.subPool&EnoughFeeCapProtocol > 0 {
-					assert.LessOrEqual(calcProtocolBaseFee(pendingBaseFee), tx.Tx.FeeCap, msg)
 				}
 				if tx.subPool&EnoughFeeCapBlock > 0 {
 					assert.LessOrEqual(pendingBaseFee, tx.Tx.FeeCap, msg)


### PR DESCRIPTION
As per [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) , there is only initial base fee after which it adjusts automatically. There are no current references to a minimum protocol base fee on Ethereum, Gnosis or Polygon.

The existing code would put a 7 wei minimum limit on transactions to be included in the pool. This PR removes this check within txPool. Any transaction can now be added to the `queued` sub-pool after which it could get promoted to `pending` or `baseFee` subpools.

The`pricelimit` flag still exists and acts on non-local transactions as a minimum feeCap for inclusion.