### PR TITLE
[wip] HOTFIX: avoid rpcdaemon call_tracer crash in debug_traceBlockByNumber call

### DIFF
--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -153,8 +153,6 @@ func (t *callTracer) CaptureStart(env vm.VMInterface, from libcommon.Address, to
 // CaptureEnd is called after the call finishes to finalize the tracing.
 func (t *callTracer) CaptureEnd(output []byte, gasUsed uint64, err error) {
 	t.callstack[0].processOutput(output, err)
-	t.logIndex = 0
-	t.logGaps = nil
 }
 
 // CaptureState implements the EVMLogger interface to trace a single step of VM execution.


### PR DESCRIPTION
HOTFIX: avoid rpcdaemon call_tracer crash while debug_traceBlockByNumber is called and top level ERROR tx in block.
Bug was included in [#8195](https://github.com/ledgerwatch/erigon/pull/8195) by me

A test case is :
```
curl http://<IP>:<PORT> \
-X POST \
-H "Content-Type: application/json" \
--data '{"method":"debug_traceBlockByNumber","params":["0x116E138", {"tracer": "callTracer", "tracerConfig": {"withlog": true}}], "id":1,"jsonrpc":"2.0"}'
```