### PR TITLE
eth/borfinality: handle errors to prevent access logging

### DIFF
--- a/eth/borfinality/whitelist_helpers.go
+++ b/eth/borfinality/whitelist_helpers.go
@@ -66,7 +66,7 @@ func fetchWhitelistMilestone(ctx context.Context, heimdallClient heimdall.IHeimd
 	milestone, err := heimdallClient.FetchMilestone(ctx)
 	if errors.Is(err, heimdall.ErrServiceUnavailable) {
 		config.logger.Debug("Failed to fetch latest milestone for whitelisting", "err", err)
-		return num, hash, errMilestone
+		return num, hash, err
 	}
 
 	if err != nil {
@@ -99,7 +99,7 @@ func fetchNoAckMilestone(ctx context.Context, heimdallClient heimdall.IHeimdallC
 	milestoneID, err := heimdallClient.FetchLastNoAckMilestone(ctx)
 	if errors.Is(err, heimdall.ErrServiceUnavailable) {
 		logger.Debug("Failed to fetch latest no-ack milestone", "err", err)
-		return milestoneID, errMilestone
+		return milestoneID, err
 	}
 
 	if err != nil {


### PR DESCRIPTION
This PR adds a few checks on top of https://github.com/ledgerwatch/erigon/pull/8364 to prevent access logging. Moreover, fixes a bug which sent wrong error to parent function. 