### PR TITLE
Bor fix rpcdeamon engine initialization

### DIFF
--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -793,6 +793,14 @@ type remoteConsensusEngine struct {
 	engine consensus.EngineReader
 }
 
+func (e *remoteConsensusEngine) HasEngine() bool {
+	return e.engine != nil
+}
+
+func (e *remoteConsensusEngine) Engine() consensus.EngineReader {
+	return e.engine
+}
+
 func (e *remoteConsensusEngine) init(db kv.RoDB, blockReader services.FullBlockReader, remoteKV remote.KVClient, logger log.Logger) bool {
 	var cc *chain.Config
 

--- a/cmd/rpcdaemon/main.go
+++ b/cmd/rpcdaemon/main.go
@@ -6,9 +6,6 @@ import (
 
 	"github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/cli"
-	"github.com/ledgerwatch/erigon/consensus"
-	"github.com/ledgerwatch/erigon/consensus/bor"
-	"github.com/ledgerwatch/erigon/consensus/ethash"
 	"github.com/ledgerwatch/erigon/rpc"
 	"github.com/ledgerwatch/erigon/turbo/debug"
 	"github.com/ledgerwatch/erigon/turbo/jsonrpc"
@@ -21,22 +18,13 @@ func main() {
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 		logger := debug.SetupCobra(cmd, "sentry")
-		db, borDb, backend, txPool, mining, stateCache, blockReader, ff, agg, err := cli.RemoteServices(ctx, *cfg, logger, rootCancel)
+		db, backend, txPool, mining, stateCache, blockReader, engine, ff, agg, err := cli.RemoteServices(ctx, *cfg, logger, rootCancel)
 		if err != nil {
 			logger.Error("Could not connect to DB", "err", err)
 			return nil
 		}
 		defer db.Close()
-
-		var engine consensus.EngineReader
-
-		if borDb != nil {
-			defer borDb.Close()
-			engine = bor.NewRo(borDb, blockReader, logger)
-		} else {
-			// TODO: Replace with correct consensus Engine
-			engine = ethash.NewFaker()
-		}
+		defer engine.Close()
 
 		apiList := jsonrpc.APIList(db, backend, txPool, mining, ff, stateCache, blockReader, agg, *cfg, engine, logger)
 		rpc.PreAllocateRPCMetricLabels(apiList)

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -119,6 +119,9 @@ type EngineReader interface {
 
 	CalculateRewards(config *chain.Config, header *types.Header, uncles []*types.Header, syscall SystemCall,
 	) ([]Reward, error)
+
+	// Close terminates any background threads, DB's etc maintained by the consensus engine.
+	Close() error
 }
 
 // EngineReader are write methods of the consensus engine
@@ -179,9 +182,6 @@ type EngineWriter interface {
 
 	// APIs returns the RPC APIs this consensus engine provides.
 	APIs(chain ChainHeaderReader) []rpc.API
-
-	// Close terminates any background threads maintained by the consensus engine.
-	Close() error
 }
 
 // PoW is a consensus engine based on proof-of-work.

--- a/erigon-lib/kv/remotedb/kv_remote.go
+++ b/erigon-lib/kv/remotedb/kv_remote.go
@@ -34,14 +34,13 @@ import (
 	"github.com/ledgerwatch/erigon-lib/gointerfaces/grpcutil"
 	"github.com/ledgerwatch/erigon-lib/gointerfaces/remote"
 	"github.com/ledgerwatch/erigon-lib/kv"
-	"github.com/ledgerwatch/erigon-lib/kv/mdbx"
 )
 
 // generate the messages and services
 type remoteOpts struct {
 	remoteKV    remote.KVClient
 	log         log.Logger
-	bucketsCfg  mdbx.TableCfgFunc
+	bucketsCfg  kv.TableCfg
 	DialAddress string
 	version     gointerfaces.Version
 }
@@ -85,8 +84,8 @@ func (opts remoteOpts) ReadOnly() remoteOpts {
 	return opts
 }
 
-func (opts remoteOpts) WithBucketsConfig(f mdbx.TableCfgFunc) remoteOpts {
-	opts.bucketsCfg = f
+func (opts remoteOpts) WithBucketsConfig(c kv.TableCfg) remoteOpts {
+	opts.bucketsCfg = c
 	return opts
 }
 
@@ -103,7 +102,7 @@ func (opts remoteOpts) Open() (*DB, error) {
 		buckets:      kv.TableCfg{},
 		roTxsLimiter: semaphore.NewWeighted(targetSemCount), // 1 less than max to allow unlocking
 	}
-	customBuckets := opts.bucketsCfg(kv.ChaindataTablesCfg)
+	customBuckets := opts.bucketsCfg
 	for name, cfg := range customBuckets { // copy map to avoid changing global variable
 		db.buckets[name] = cfg
 	}
@@ -123,7 +122,7 @@ func (opts remoteOpts) MustOpen() kv.RwDB {
 // version parameters represent the version the KV client is expecting,
 // compatibility check will be performed when the KV connection opens
 func NewRemote(v gointerfaces.Version, logger log.Logger, remoteKV remote.KVClient) remoteOpts {
-	return remoteOpts{bucketsCfg: mdbx.WithChaindataTables, version: v, log: logger, remoteKV: remoteKV}
+	return remoteOpts{bucketsCfg: kv.ChaindataTablesCfg, version: v, log: logger, remoteKV: remoteKV}
 }
 
 func (db *DB) PageSize() uint64       { panic("not implemented") }

--- a/erigon-lib/kv/tables.go
+++ b/erigon-lib/kv/tables.go
@@ -356,7 +356,6 @@ const (
 	StateCommitment = "StateCommitment"
 
 	// BOR
-
 	BorReceipts  = "BorReceipt"
 	BorFinality  = "BorFinality"
 	BorTxLookup  = "BlockBorTransactionLookup" // transaction_hash -> block_num_u64
@@ -704,6 +703,15 @@ var ChaindataTablesCfg = TableCfg{
 	RStorageIdx:              {Flags: DupSort},
 	RCodeKeys:                {Flags: DupSort},
 	RCodeIdx:                 {Flags: DupSort},
+}
+
+var BorTablesCfg = TableCfg{
+	BorReceipts:  {Flags: DupSort},
+	BorFinality:  {Flags: DupSort},
+	BorTxLookup:  {Flags: DupSort},
+	BorEvents:    {Flags: DupSort},
+	BorEventNums: {Flags: DupSort},
+	BorSpans:     {Flags: DupSort},
 }
 
 var TxpoolTablesCfg = TableCfg{}

--- a/turbo/jsonrpc/bor_api.go
+++ b/turbo/jsonrpc/bor_api.go
@@ -1,9 +1,12 @@
 package jsonrpc
 
 import (
+	"fmt"
+
 	"github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/kv"
 
+	"github.com/ledgerwatch/erigon/consensus"
 	"github.com/ledgerwatch/erigon/consensus/bor"
 	"github.com/ledgerwatch/erigon/consensus/bor/valset"
 	"github.com/ledgerwatch/erigon/rpc"
@@ -26,15 +29,33 @@ type BorAPI interface {
 // BorImpl is implementation of the BorAPI interface
 type BorImpl struct {
 	*BaseAPI
-	db  kv.RoDB // the chain db
-	bor *bor.Bor
+	db kv.RoDB // the chain db
 }
 
 // NewBorAPI returns BorImpl instance
-func NewBorAPI(base *BaseAPI, db kv.RoDB, bor *bor.Bor) *BorImpl {
+func NewBorAPI(base *BaseAPI, db kv.RoDB) *BorImpl {
 	return &BorImpl{
 		BaseAPI: base,
 		db:      db,
-		bor:     bor,
 	}
+}
+
+func (api *BorImpl) bor() (*bor.Bor, error) {
+	type lazy interface {
+		HasEngine() bool
+		Engine() consensus.EngineReader
+	}
+
+	switch engine := api.engine().(type) {
+	case *bor.Bor:
+		return engine, nil
+	case lazy:
+		if engine.HasEngine() {
+			if bor, ok := engine.Engine().(*bor.Bor); ok {
+				return bor, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("unknown or invalid consensus engine: %T", api.engine())
 }

--- a/turbo/jsonrpc/bor_snapshot.go
+++ b/turbo/jsonrpc/bor_snapshot.go
@@ -52,7 +52,13 @@ func (api *BorImpl) GetSnapshot(number *rpc.BlockNumber) (*Snapshot, error) {
 	}
 
 	// init consensus db
-	borTx, err := api.bor.DB.BeginRo(ctx)
+	bor, err := api.bor()
+
+	if err != nil {
+		return nil, err
+	}
+
+	borTx, err := bor.DB.BeginRo(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +109,13 @@ func (api *BorImpl) GetSnapshotAtHash(hash common.Hash) (*Snapshot, error) {
 	}
 
 	// init consensus db
-	borTx, err := api.bor.DB.BeginRo(ctx)
+	bor, err := api.bor()
+
+	if err != nil {
+		return nil, err
+	}
+
+	borTx, err := bor.DB.BeginRo(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +146,13 @@ func (api *BorImpl) GetSigners(number *rpc.BlockNumber) ([]common.Address, error
 	}
 
 	// init consensus db
-	borTx, err := api.bor.DB.BeginRo(ctx)
+	bor, err := api.bor()
+
+	if err != nil {
+		return nil, err
+	}
+
+	borTx, err := bor.DB.BeginRo(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +180,13 @@ func (api *BorImpl) GetSignersAtHash(hash common.Hash) ([]common.Address, error)
 	}
 
 	// init consensus db
-	borTx, err := api.bor.DB.BeginRo(ctx)
+	bor, err := api.bor()
+
+	if err != nil {
+		return nil, err
+	}
+
+	borTx, err := bor.DB.BeginRo(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -294,7 +318,13 @@ func (api *BorImpl) GetSnapshotProposerSequence(blockNrOrHash *rpc.BlockNumberOr
 	}
 
 	// init consensus db
-	borTx, err := api.bor.DB.BeginRo(ctx)
+	bor, err := api.bor()
+
+	if err != nil {
+		return BlockSigners{}, err
+	}
+
+	borTx, err := bor.DB.BeginRo(ctx)
 	if err != nil {
 		return BlockSigners{}, err
 	}
@@ -344,6 +374,12 @@ func (api *BorImpl) GetSnapshotProposerSequence(blockNrOrHash *rpc.BlockNumberOr
 
 // GetRootHash returns the merkle root of the start to end block headers
 func (api *BorImpl) GetRootHash(start, end uint64) (string, error) {
+	bor, err := api.bor()
+
+	if err != nil {
+		return "", err
+	}
+
 	ctx := context.Background()
 	tx, err := api.db.BeginRo(ctx)
 	if err != nil {
@@ -351,7 +387,7 @@ func (api *BorImpl) GetRootHash(start, end uint64) (string, error) {
 	}
 	defer tx.Rollback()
 
-	return api.bor.GetRootHash(ctx, tx, start, end)
+	return bor.GetRootHash(ctx, tx, start, end)
 }
 
 // Helper functions for Snapshot Type

--- a/turbo/jsonrpc/bor_snapshot.go
+++ b/turbo/jsonrpc/bor_snapshot.go
@@ -224,7 +224,7 @@ func (api *BorImpl) GetVoteOnHash(ctx context.Context, starBlockNr uint64, endBl
 	service := whitelist.GetWhitelistingService()
 
 	if service == nil {
-		return false, errors.New("Only available in Bor engine")
+		return false, errors.New("only available in Bor engine")
 	}
 
 	//Confirmation of 16 blocks on the endblock

--- a/turbo/jsonrpc/daemon.go
+++ b/turbo/jsonrpc/daemon.go
@@ -35,8 +35,18 @@ func APIList(db kv.RoDB, eth rpchelper.ApiBackend, txPool txpool.TxpoolClient, m
 
 	var borImpl *BorImpl
 
-	if bor, ok := engine.(*bor.Bor); ok {
-		borImpl = NewBorAPI(base, db, bor) // bor (consensus) specific
+	type lazy interface {
+		HasEngine() bool
+		Engine() consensus.EngineReader
+	}
+
+	switch engine := engine.(type) {
+	case *bor.Bor:
+		borImpl = NewBorAPI(base, db)
+	case lazy:
+		if _, ok := engine.Engine().(*bor.Bor); ok {
+			borImpl = NewBorAPI(base, db)
+		}
 	}
 
 	otsImpl := NewOtterscanAPI(base, db, cfg.OtsMaxPageSize)

--- a/turbo/jsonrpc/erigon_api.go
+++ b/turbo/jsonrpc/erigon_api.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ledgerwatch/erigon-lib/common"
 
 	"github.com/ledgerwatch/erigon/eth/filters"
-	ethFilters "github.com/ledgerwatch/erigon/eth/filters"
 
 	"github.com/ledgerwatch/erigon-lib/kv"
 
@@ -32,8 +31,8 @@ type ErigonAPI interface {
 	// Receipt related (see ./erigon_receipts.go)
 	GetLogsByHash(ctx context.Context, hash common.Hash) ([][]*types.Log, error)
 	//GetLogsByNumber(ctx context.Context, number rpc.BlockNumber) ([][]*types.Log, error)
-	GetLogs(ctx context.Context, crit ethFilters.FilterCriteria) (types.ErigonLogs, error)
-	GetLatestLogs(ctx context.Context, crit filters.FilterCriteria, logOptions ethFilters.LogFilterOptions) (types.ErigonLogs, error)
+	GetLogs(ctx context.Context, crit filters.FilterCriteria) (types.ErigonLogs, error)
+	GetLatestLogs(ctx context.Context, crit filters.FilterCriteria, logOptions filters.LogFilterOptions) (types.ErigonLogs, error)
 	// Gets cannonical block receipt through hash. If the block is not cannonical returns error
 	GetBlockReceiptsByBlockHash(ctx context.Context, cannonicalBlockHash common.Hash) ([]map[string]interface{}, error)
 


### PR DESCRIPTION
This fixes 2 related issues:

* Now that the bor consensus engine is required for queries it can't be created based on the pretense of a db directory, but must be based on chain config read from the db.  Using the DB presence causes Bor to get instantiated for non bor chains which breaks.
* At the moment eth_calls on a remote daemon don't check Bor headers prior to calling the EVM code as it was just using a fake ETHash instance - which performs ETH header validation only.

The current version is mostly working but needs adapting to perform lazy initialization of the engine.