### PR TITLE
sync: fix a memory leak when header verification fails

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -860,7 +860,7 @@ func (c *Bor) snapshot(chain consensus.ChainHeaderReader, number uint64, hash li
 			return nil, err
 		}
 
-		c.logger.Info("Stored proposer snapshot to disk", "number", snap.Number, "hash", snap.Hash)
+		c.logger.Trace("Stored proposer snapshot to disk", "number", snap.Number, "hash", snap.Hash)
 	}
 
 	return snap, err
@@ -1407,7 +1407,7 @@ func (c *Bor) getSpanForBlock(blockNum uint64) (*span.HeimdallSpan, error) {
 		return nil, fmt.Errorf("span with given block number is not loaded: %d", spanID)
 	}
 
-	c.logger.Info("Span with given block number is not loaded", "fetching span", spanID)
+	c.logger.Debug("Span with given block number is not loaded", "fetching span", spanID)
 
 	response, err := c.HeimdallClient.Span(c.execCtx, spanID)
 	if err != nil {

--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -536,6 +536,9 @@ func (hd *HeaderDownload) InsertHeader(hf FeedHeaderFunc, terminalTotalDifficult
 					hd.moveLinkToQueue(link, NoQueue)
 					delete(hd.links, link.hash)
 					hd.removeUpwards(link)
+					if parentLink, ok := hd.links[link.header.ParentHash]; ok {
+						parentLink.RemoveChild(link)
+					}
 					dataflow.HeaderDownloadStates.AddChange(link.blockHeight, dataflow.HeaderEvicted)
 					return true, false, 0, lastTime, nil
 				}

--- a/turbo/stages/headerdownload/header_data_struct.go
+++ b/turbo/stages/headerdownload/header_data_struct.go
@@ -47,6 +47,23 @@ type Link struct {
 	peerId      [64]byte
 }
 
+func (link *Link) ClearChildren() {
+	for child := link.fChild; child != nil; child, child.next = child.next, nil {
+	}
+}
+
+func (parentLink *Link) RemoveChild(link *Link) {
+	var prevChild *Link
+	for child := parentLink.fChild; child != nil && child != link; child = child.next {
+		prevChild = child
+	}
+	if prevChild == nil {
+		parentLink.fChild = link.next
+	} else {
+		prevChild.next = link.next
+	}
+}
+
 // LinkQueue is the priority queue of links. It is instantiated once for persistent links, and once for non-persistent links
 // In other instances, it is used to limit number of links of corresponding type (persistent and non-persistent) in memory
 type LinkQueue []*Link
@@ -110,6 +127,18 @@ type Anchor struct {
 	blockHeight   uint64
 	nextRetryTime time.Time // Zero when anchor has just been created, otherwise time when anchor needs to be check to see if retry is needed
 	timeouts      int       // Number of timeout that this anchor has experiences - after certain threshold, it gets invalidated
+}
+
+func (anchor *Anchor) RemoveChild(link *Link) {
+	var prevChild *Link
+	for child := anchor.fLink; child != nil && child != link; child = child.next {
+		prevChild = child
+	}
+	if prevChild == nil {
+		anchor.fLink = link.next
+	} else {
+		prevChild.next = link.next
+	}
 }
 
 type ChainSegmentHeader struct {

--- a/turbo/stages/headerdownload/header_data_struct.go
+++ b/turbo/stages/headerdownload/header_data_struct.go
@@ -253,6 +253,8 @@ type Stats struct {
 	SkeletonReqMaxBlock uint64
 	RespMinBlock        uint64
 	RespMaxBlock        uint64
+	InvalidHeaders      int
+	RejectedBadHeaders  int
 }
 
 type HeaderDownload struct {


### PR DESCRIPTION
If HeaderDownload.VerifyHeader always returns false, the memory usage grows at a fast pace
due to Link objects (containing headers) not deallocated even after the link queue pruning.
