### PR TITLE
cmd/sentry: remove empty headers check

### DIFF
--- a/cmd/sentry/sentry/sentry_multi_client.go
+++ b/cmd/sentry/sentry/sentry_multi_client.go
@@ -585,13 +585,11 @@ func (cs *MultiClient) getBlockHeaders66(ctx context.Context, inreq *proto_sentr
 		return fmt.Errorf("querying BlockHeaders: %w", err)
 	}
 
-	// This is a hack to make us work with erigon 2.48 peers that have --sentry.drop-useless-peers
-	// If we reply with an empty list, we're going to be considered useless and kicked.
-	// Once enough of erigon nodes are updated in the network past this commit, this check should be removed,
-	// because it is totally acceptable to return an empty list.
-	if len(headers) == 0 {
-		return nil
-	}
+	// Even if we get empty headers list from db, we'll respond with that. Nodes
+	// running on erigon 2.48 with --sentry.drop-useless-peers will kick us out
+	// because of certain checks. But, nodes post that will not kick us out. This
+	// is useful as currently with no response, we're anyways getting kicked due
+	// to request timeout and EOF.
 
 	b, err := rlp.EncodeToBytes(&eth.BlockHeadersPacket66{
 		RequestId:          query.RequestId,


### PR DESCRIPTION
This PR removes the empty headers check when responding to `GetBlockHeaders` p2p request. Currently, as we return from the function, the requests on the caller's end gets timed out causing peer drop. This will prevent that from happening by sending empty header list which will be of no use but still helps in maintaining the peer connection. 

With this change, those running erigon 2.48 with `--sentry.drop-useless-peers` will drop peers as they consider receiving empty headers a harsh move which is fine. 

We have also discovered that if we don't remove this check maintaining connectivity to Bor is not maintained.  This is  significant as Erigon becomes a minority validator, as bor chain stability (reducing forks) is dependent upon good validator connectivity. 