### PR TITLE
Maximize build space for goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,13 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
+      - name: Maximize build space
+        uses: AdityaGarg8/remove-unwanted-software@v1
+        with:
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+
       - name: Checkout
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Mitigate [no space left on device](https://github.com/ledgerwatch/erigon/actions/runs/6493703302/job/17639876934). Simplified version of PR #8451 (there I had to add `root-reserve-mb: 16384` to make it work).