### PR TITLE
Add RPC daemon using Silkworm

### DIFF
--- a/erigon-lib/go.mod
+++ b/erigon-lib/go.mod
@@ -3,7 +3,7 @@ module github.com/ledgerwatch/erigon-lib
 go 1.20
 
 require (
-	github.com/erigontech/mdbx-go v0.27.17
+	github.com/erigontech/mdbx-go v0.27.19
 	github.com/ledgerwatch/interfaces v0.0.0-20231011121315-f58b806039f0
 	github.com/ledgerwatch/log/v3 v3.9.0
 	github.com/ledgerwatch/secp256k1 v1.0.0

--- a/erigon-lib/go.sum
+++ b/erigon-lib/go.sum
@@ -128,8 +128,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/erigontech/mdbx-go v0.27.17 h1:+LOuGmdrD74psBVHDaS3cFXzI9tTSfLcUvOUtMwX2Ok=
-github.com/erigontech/mdbx-go v0.27.17/go.mod h1:FAMxbOgqOnRDx51j8HjuJZIgznbDwjX7LItd+/UWyA4=
+github.com/erigontech/mdbx-go v0.27.19 h1:3jugN7wNmVZ4zDk4heLMPAGuOXuCG/0/DfzjlGB48kk=
+github.com/erigontech/mdbx-go v0.27.19/go.mod h1:FAMxbOgqOnRDx51j8HjuJZIgznbDwjX7LItd+/UWyA4=
 github.com/frankban/quicktest v1.9.0/go.mod h1:ui7WezCLWMWxVWr1GETZY3smRy0G4KWq9vcPtJmFl7Y=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/erigon-lib/kv/kv_interface.go
+++ b/erigon-lib/kv/kv_interface.go
@@ -256,6 +256,9 @@ type RoDB interface {
 	BeginRo(ctx context.Context) (Tx, error)
 	AllTables() TableCfg
 	PageSize() uint64
+
+	// Pointer to the underlying C environment handle, if applicable (e.g. *C.MDBX_env)
+	CHandle() unsafe.Pointer
 }
 
 // RwDB low-level database interface - main target is - to provide common abstraction over top of MDBX and RemoteKV.

--- a/erigon-lib/kv/mdbx/kv_mdbx.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx.go
@@ -448,6 +448,10 @@ func (db *MdbxKV) PageSize() uint64 { return db.opts.pageSize }
 func (db *MdbxKV) ReadOnly() bool   { return db.opts.HasFlag(mdbx.Readonly) }
 func (db *MdbxKV) Accede() bool     { return db.opts.HasFlag(mdbx.Accede) }
 
+func (db *MdbxKV) CHandle() unsafe.Pointer {
+	return db.env.CHandle()
+}
+
 // openDBIs - first trying to open existing DBI's in RO transaction
 // otherwise re-try by RW transaction
 // it allow open DB from another process - even if main process holding long RW transaction

--- a/erigon-lib/kv/mdbx/kv_mdbx_temporary.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx_temporary.go
@@ -19,6 +19,7 @@ package mdbx
 import (
 	"context"
 	"os"
+	"unsafe"
 
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/log/v3"
@@ -81,4 +82,8 @@ func (t *TemporaryMdbx) PageSize() uint64 {
 func (t *TemporaryMdbx) Close() {
 	t.db.Close()
 	os.RemoveAll(t.path)
+}
+
+func (t *TemporaryMdbx) CHandle() unsafe.Pointer {
+	panic("CHandle not implemented")
 }

--- a/erigon-lib/kv/remotedb/kv_remote.go
+++ b/erigon-lib/kv/remotedb/kv_remote.go
@@ -148,6 +148,10 @@ func (db *DB) EnsureVersionCompatibility() bool {
 
 func (db *DB) Close() {}
 
+func (db *DB) CHandle() unsafe.Pointer {
+	panic("CHandle not implemented")
+}
+
 func (db *DB) BeginRo(ctx context.Context) (txn kv.Tx, err error) {
 	select {
 	case <-ctx.Done():

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -861,7 +861,7 @@ func (s *Ethereum) Init(stack *node.Node, config *ethconfig.Config) error {
 	go func() {
 		if config.SilkwormEnabled && httpRpcCfg.Enabled {
 			go func() {
-				<- ctx.Done()
+				<-ctx.Done()
 				s.silkworm.StopRpcDaemon()
 			}()
 			err = s.silkworm.StartRpcDaemon(chainKv)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -860,13 +860,15 @@ func (s *Ethereum) Init(stack *node.Node, config *ethconfig.Config) error {
 	s.apiList = jsonrpc.APIList(chainKv, ethRpcClient, txPoolRpcClient, miningRpcClient, ff, stateCache, blockReader, s.agg, httpRpcCfg, s.engine, s.logger)
 	go func() {
 		if config.SilkwormEnabled && httpRpcCfg.Enabled {
+			go func() {
+				<- ctx.Done()
+				s.silkworm.StopRpcDaemon()
+			}()
 			err = s.silkworm.StartRpcDaemon(chainKv)
 			if err != nil {
 				s.logger.Error(err.Error())
 				return
 			}
-			defer s.silkworm.StopRpcDaemon()
-			<- ctx.Done()
 		} else {
 			if err := cli.StartRpcServer(ctx, httpRpcCfg, s.apiList, s.logger); err != nil {
 				s.logger.Error(err.Error())

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -859,9 +859,19 @@ func (s *Ethereum) Init(stack *node.Node, config *ethconfig.Config) error {
 
 	s.apiList = jsonrpc.APIList(chainKv, ethRpcClient, txPoolRpcClient, miningRpcClient, ff, stateCache, blockReader, s.agg, httpRpcCfg, s.engine, s.logger)
 	go func() {
-		if err := cli.StartRpcServer(ctx, httpRpcCfg, s.apiList, s.logger); err != nil {
-			s.logger.Error(err.Error())
-			return
+		if config.SilkwormEnabled && httpRpcCfg.Enabled {
+			err = s.silkworm.StartRpcDaemon(chainKv)
+			if err != nil {
+				s.logger.Error(err.Error())
+				return
+			}
+			defer s.silkworm.StopRpcDaemon()
+			<- ctx.Done()
+		} else {
+			if err := cli.StartRpcServer(ctx, httpRpcCfg, s.apiList, s.logger); err != nil {
+				s.logger.Error(err.Error())
+				return
+			}
 		}
 	}()
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ledgerwatch/erigon
 go 1.20
 
 require (
-	github.com/erigontech/mdbx-go v0.27.17
+	github.com/erigontech/mdbx-go v0.27.19
 	github.com/ledgerwatch/erigon-lib v1.0.0
 	github.com/ledgerwatch/erigon-snapshot v1.3.1-0.20231014011414-bfa3a30f55b2
 	github.com/ledgerwatch/log/v3 v3.9.0

--- a/go.sum
+++ b/go.sum
@@ -248,8 +248,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/erigontech/mdbx-go v0.27.17 h1:+LOuGmdrD74psBVHDaS3cFXzI9tTSfLcUvOUtMwX2Ok=
-github.com/erigontech/mdbx-go v0.27.17/go.mod h1:FAMxbOgqOnRDx51j8HjuJZIgznbDwjX7LItd+/UWyA4=
+github.com/erigontech/mdbx-go v0.27.19 h1:3jugN7wNmVZ4zDk4heLMPAGuOXuCG/0/DfzjlGB48kk=
+github.com/erigontech/mdbx-go v0.27.19/go.mod h1:FAMxbOgqOnRDx51j8HjuJZIgznbDwjX7LItd+/UWyA4=
 github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c h1:CndMRAH4JIwxbW8KYq6Q+cGWcGHz0FjGR3QqcInWcW0=
 github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c/go.mod h1:AzA8Lj6YtixmJWL+wkKoBGsLWy9gFrAzi4g+5bCKwpY=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=


### PR DESCRIPTION
This introduces _experimental_ RPC daemon run by embedded Silkworm library. Same notes as in PR #8353 apply here plus the following ones:

- activated if `http` command-line option is enabled and `silkworm.path` option is present, nothing more is required (i.e. currently, both block execution and RPC daemon run by Silkworm when specifying `silkworm.path`, just to keep things as simple as possible)
- only Execution API endpoints are implemented by Silkworm RPCDaemon, whilst Engine API endpoints are still served by Erigon RPCDaemon
- some features are still missing, in particular:
  - state change notification handling
  - custom JSON RPC settings (i.e. Erigon RPC settings are not passed to Silkworm yet)
