### PR TITLE
p2p: bad p2p server port in the log

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -542,15 +542,19 @@ func (srv *Server) setupLocalNode() error {
 		return err
 	}
 	srv.nodedb = db
+
 	srv.localnode = enode.NewLocalNode(db, srv.PrivateKey, srv.logger)
 	srv.localnode.SetFallbackIP(net.IP{127, 0, 0, 1})
-	srv.updateLocalNodeStaticAddrCache()
+
 	// TODO: check conflicts
 	for _, p := range srv.Protocols {
 		for _, e := range p.Attributes {
 			srv.localnode.Set(e)
 		}
 	}
+
+	srv.updateLocalNodeStaticAddrCache()
+
 	switch srv.NAT.(type) {
 	case nil:
 		// No NAT interface, do nothing.
@@ -616,6 +620,7 @@ func (srv *Server) setupDiscovery(ctx context.Context) error {
 		}
 	}
 	srv.localnode.SetFallbackUDP(realaddr.Port)
+	srv.updateLocalNodeStaticAddrCache()
 
 	// Discovery V4
 	var unhandled chan discover.ReadPacket
@@ -718,6 +723,8 @@ func (srv *Server) setupListening(ctx context.Context) error {
 	// Update the local node record and map the TCP listening port if NAT is configured.
 	if tcp, ok := listener.Addr().(*net.TCPAddr); ok {
 		srv.localnode.Set(enr.TCP(tcp.Port))
+		srv.updateLocalNodeStaticAddrCache()
+
 		if !tcp.IP.IsLoopback() && (srv.NAT != nil) && srv.NAT.SupportsMapping() {
 			srv.loopWG.Add(1)
 			go func() {


### PR DESCRIPTION
Problem:
"Started P2P networking" log message contains port zero on startup, e.g.: 127.0.0.1:0 because of the outdated localnodeAddrCache.

Solution:
Call updateLocalNodeStaticAddrCache after updating the port.