### PR TITLE
eth/68: always announce tx sizes with envelopes

### DIFF
--- a/erigon-lib/types/txn.go
+++ b/erigon-lib/types/txn.go
@@ -100,7 +100,7 @@ type TxSlot struct {
 	Traced         bool     // Whether transaction needs to be traced throughout transaction pool code and generate debug printing
 	Creation       bool     // Set to true if "To" field of the transaction is not set
 	Type           byte     // Transaction type
-	Size           uint32   // Size of the payload
+	Size           uint32   // Size of the payload, always including the envelope for typed transactions
 
 	// EIP-4844: Shard Blob Transactions
 	BlobFeeCap  uint256.Int // max_fee_per_blob_gas
@@ -287,6 +287,12 @@ func (ctx *TxParseContext) ParseTransaction(payload []byte, pos int, slot *TxSlo
 	}
 
 	slot.Size = uint32(p - pos)
+	if !legacy && !hasEnvelope {
+		// Normalize the size so that it accounts for the envelope bytes
+		// See https://github.com/ledgerwatch/erigon/issues/8456
+		slot.Size = uint32(rlp.ListPrefixLen(int(slot.Size))) + slot.Size
+	}
+
 	return p, err
 }
 

--- a/erigon-lib/types/txn_test.go
+++ b/erigon-lib/types/txn_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/ledgerwatch/erigon-lib/common/fixedgas"
 	"github.com/ledgerwatch/erigon-lib/common/hexutility"
+	"github.com/ledgerwatch/erigon-lib/rlp"
 )
 
 func TestParseTransactionRLP(t *testing.T) {
@@ -261,7 +262,8 @@ func TestBlobTxParsing(t *testing.T) {
 	p, err = ctx.ParseTransaction(wrapperRlp, 0, &fatTx, nil, hasEnvelope, wrappedWithBlobs, nil)
 	require.NoError(t, err)
 	assert.Equal(t, len(wrapperRlp), p)
-	assert.Equal(t, len(wrapperRlp), int(fatTx.Size))
+	wrapperLenWithEnvelope := rlp.ListPrefixLen(len(wrapperRlp)) + len(wrapperRlp)
+	assert.Equal(t, wrapperLenWithEnvelope, int(fatTx.Size))
 	assert.Equal(t, wrapperRlp, fatTx.Rlp)
 	assert.Equal(t, BlobTxType, fatTx.Type)
 


### PR DESCRIPTION
N.B. [eth/68](https://eips.ethereum.org/EIPS/eip-5793) is implemented by `EncodeAnnouncements` in `erigon-lib/rlp/encodel.go`