### PR TITLE
Revert "eth/68: always announce tx sizes with envelopes"

### DIFF
--- a/erigon-lib/types/txn.go
+++ b/erigon-lib/types/txn.go
@@ -100,7 +100,7 @@ type TxSlot struct {
 	Traced         bool     // Whether transaction needs to be traced throughout transaction pool code and generate debug printing
 	Creation       bool     // Set to true if "To" field of the transaction is not set
 	Type           byte     // Transaction type
-	Size           uint32   // Size of the payload, always including the envelope for typed transactions
+	Size           uint32   // Size of the payload
 
 	// EIP-4844: Shard Blob Transactions
 	BlobFeeCap  uint256.Int // max_fee_per_blob_gas
@@ -287,12 +287,6 @@ func (ctx *TxParseContext) ParseTransaction(payload []byte, pos int, slot *TxSlo
 	}
 
 	slot.Size = uint32(p - pos)
-	if !legacy && !hasEnvelope {
-		// Normalize the size so that it accounts for the envelope bytes
-		// See https://github.com/ledgerwatch/erigon/issues/8456
-		slot.Size = uint32(rlp.ListPrefixLen(int(slot.Size))) + slot.Size
-	}
-
 	return p, err
 }
 

--- a/erigon-lib/types/txn_test.go
+++ b/erigon-lib/types/txn_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/ledgerwatch/erigon-lib/common/fixedgas"
 	"github.com/ledgerwatch/erigon-lib/common/hexutility"
-	"github.com/ledgerwatch/erigon-lib/rlp"
 )
 
 func TestParseTransactionRLP(t *testing.T) {
@@ -262,8 +261,7 @@ func TestBlobTxParsing(t *testing.T) {
 	p, err = ctx.ParseTransaction(wrapperRlp, 0, &fatTx, nil, hasEnvelope, wrappedWithBlobs, nil)
 	require.NoError(t, err)
 	assert.Equal(t, len(wrapperRlp), p)
-	wrapperLenWithEnvelope := rlp.ListPrefixLen(len(wrapperRlp)) + len(wrapperRlp)
-	assert.Equal(t, wrapperLenWithEnvelope, int(fatTx.Size))
+	assert.Equal(t, len(wrapperRlp), int(fatTx.Size))
 	assert.Equal(t, wrapperRlp, fatTx.Rlp)
 	assert.Equal(t, BlobTxType, fatTx.Type)
 


### PR DESCRIPTION
Reverts ledgerwatch/erigon#8502 because it might cause the[ following issue](https://discord.com/channels/687972960811745322/738982866670714901/1164291343745568858):
```
git_branch=devel git_tag=v2.52.0-50-g82f1e9f34-dirty git_commit=82f1e9f342ae46d38f41b0561f879f192cdd8fa0
[WARN] [10-18|19:40:19.892] newPayload failed                        err="rlp: element is larger than containing list"
[WARN] [10-18|19:40:19.892] fail to process block                    reason="rlp: element is larger than containing list" slot=7569470
```