### PR TITLE
Fix rlp.EncodeString for length 56

### DIFF
--- a/erigon-lib/rlp/encode.go
+++ b/erigon-lib/rlp/encode.go
@@ -186,7 +186,7 @@ func EncodeU64(i uint64, to []byte) int {
 func StringLen(s []byte) int {
 	sLen := len(s)
 	switch {
-	case sLen > 56:
+	case sLen >= 56:
 		beLen := common.BitLenToByteLen(bits.Len(uint(sLen)))
 		return 1 + beLen + sLen
 	case sLen == 0:
@@ -202,7 +202,7 @@ func StringLen(s []byte) int {
 }
 func EncodeString(s []byte, to []byte) int {
 	switch {
-	case len(s) > 56:
+	case len(s) >= 56:
 		beLen := common.BitLenToByteLen(bits.Len(uint(len(s))))
 		binary.BigEndian.PutUint64(to[1:], uint64(len(s)))
 		_ = to[beLen+len(s)]

--- a/erigon-lib/rlp/encode_test.go
+++ b/erigon-lib/rlp/encode_test.go
@@ -1,0 +1,44 @@
+/*
+   Copyright 2023 The Erigon contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package rlp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ledgerwatch/erigon-lib/common/hexutility"
+)
+
+// Strings of length 56 are a boundary case.
+// See https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/#definition
+func TestStringLen56(t *testing.T) {
+	str := hexutility.MustDecodeHex("7907ca011864321def1e92a3021868f397516ce37c959f25f8dddd3161d7b8301152b35f135c814fae9f487206471b6b0d713cd51a2d3598")
+	require.Equal(t, 56, len(str))
+
+	strLen := StringLen(str)
+	assert.Equal(t, 56+2, strLen)
+
+	encoded := make([]byte, strLen)
+	EncodeString(str, encoded)
+
+	dataPos, dataLen, err := String(encoded, 0)
+	require.NoError(t, err)
+	assert.Equal(t, dataPos, 2)
+	assert.Equal(t, dataLen, 56)
+}


### PR DESCRIPTION
Should fix the [following issue](https://discord.com/channels/687972960811745322/738982866670714901/1164291343745568858):
```
git_branch=devel git_tag=v2.52.0-50-g82f1e9f34-dirty git_commit=82f1e9f342ae46d38f41b0561f879f192cdd8fa0
[WARN] [10-18|19:40:19.892] newPayload failed                        err="rlp: element is larger than containing list"
[WARN] [10-18|19:40:19.892] fail to process block                    reason="rlp: element is larger than containing list" slot=7569470
```