### PR TITLE
eth/68: always announce tx sizes without envelopes

### DIFF
--- a/erigon-lib/types/txn.go
+++ b/erigon-lib/types/txn.go
@@ -100,7 +100,7 @@ type TxSlot struct {
 	Traced         bool     // Whether transaction needs to be traced throughout transaction pool code and generate debug printing
 	Creation       bool     // Set to true if "To" field of the transaction is not set
 	Type           byte     // Transaction type
-	Size           uint32   // Size of the payload, always including the envelope for typed transactions
+	Size           uint32   // Size of the payload (without the RLP string envelope for typed transactions)
 
 	// EIP-4844: Shard Blob Transactions
 	BlobFeeCap  uint256.Int // max_fee_per_blob_gas
@@ -286,12 +286,7 @@ func (ctx *TxParseContext) ParseTransaction(payload []byte, pos int, slot *TxSlo
 		}
 	}
 
-	slot.Size = uint32(p - pos)
-	if !legacy && !hasEnvelope {
-		// Normalize the size so that it accounts for the envelope bytes
-		// See https://github.com/ledgerwatch/erigon/issues/8456
-		slot.Size = uint32(rlp.ListPrefixLen(int(slot.Size))) + slot.Size
-	}
+	slot.Size = uint32(len(slot.Rlp))
 
 	return p, err
 }


### PR DESCRIPTION
It turns out that Marius got it the other way round in Issue #8456. See https://discord.com/channels/595666850260713488/1162151688816308245