### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GO = go # if using docker, should not need to be installed/linked
+GO ?= go # if using docker, should not need to be installed/linked
 GOBIN = $(CURDIR)/build/bin
 UNAME = $(shell uname) # Supported: Darwin, Linux
 DOCKER := $(shell command -v docker 2> /dev/null)


### PR DESCRIPTION
Allow overriding go binary

On FreeBSD go binaries are installed as go118, go119, go120, etc.

This fixes the ability to build erigon with a command like:

GO=go120 gmake