### PR TITLE
Look up local registry rather than use vm

### DIFF
--- a/metrics/register.go
+++ b/metrics/register.go
@@ -45,6 +45,9 @@ func GetOrCreateCounter(s string, isGauge ...bool) Counter {
 		counter := defaultSet.GetOrCreateGauge(s)
 		return intCounter{counter}
 	} else {
+		if counter := DefaultRegistry.Get(s); counter != nil {
+			return counter.(Counter)
+		}
 		counter := vm.GetOrCreateCounter(s, isGauge...)
 		DefaultRegistry.Register(s, counter)
 		vm.GetDefaultSet().UnregisterMetric(s)


### PR DESCRIPTION
Calling vm to get a metric and then preregistering it to avoid duplication is expensive.

To avoid this we can make a local lookup first which is a map this quicker.  This is a temporary fix 
until vm is removed at which point we'll have a single prom_client registry 
