### PR TITLE
Fix panic in isAgra check for txpool

### DIFF
--- a/erigon-lib/txpool/pool.go
+++ b/erigon-lib/txpool/pool.go
@@ -915,7 +915,7 @@ func (p *TxPool) isAgra() bool {
 	defer tx.Rollback()
 
 	head_block, err := chain.CurrentBlockNumber(tx)
-	if err != nil {
+	if head_block == nil || err != nil {
 		return false
 	}
 	// A new block is built on top of the head block, so when the head is agraBlock-1,


### PR DESCRIPTION
Fixes a nil pointer panic in the isagra check when running on an empty chain db.  In this case the block will return as nil with no error.