### PR TITLE
Fix metrics get perf regression

### DIFF
--- a/erigon-lib/metrics/register.go
+++ b/erigon-lib/metrics/register.go
@@ -45,6 +45,12 @@ func GetOrCreateCounter(s string, isGauge ...bool) Counter {
 		counter := defaultSet.GetOrCreateGauge(s)
 		return intCounter{counter}
 	} else {
+		if counter := DefaultRegistry.Get(s); counter != nil {
+			if counter, ok := counter.(Counter); ok {
+				return counter
+			}
+		}
+
 		counter := vm.GetOrCreateCounter(s, isGauge...)
 		DefaultRegistry.Register(s, counter)
 		vm.GetDefaultSet().UnregisterMetric(s)

--- a/erigon-lib/txpool/pool.go
+++ b/erigon-lib/txpool/pool.go
@@ -915,7 +915,7 @@ func (p *TxPool) isAgra() bool {
 	defer tx.Rollback()
 
 	head_block, err := chain.CurrentBlockNumber(tx)
-	if err != nil {
+	if head_block == nil || err != nil {
 		return false
 	}
 	// A new block is built on top of the head block, so when the head is agraBlock-1,


### PR DESCRIPTION
Calling vm to get a metric and then preregistering it to avoid duplication is expensive.

To avoid this we can make a local lookup first which is a map this quicker. This is a temporary fix
until vm is removed at which point we'll have a single prom_client registry

Fixes: https://github.com/ledgerwatch/erigon/issues/8558