### PR TITLE
devnet: configuration fixes

### DIFF
--- a/cmd/devnet/accounts/accounts.go
+++ b/cmd/devnet/accounts/accounts.go
@@ -20,6 +20,14 @@ func init() {
 	core.DevnetSignKey = func(addr libcommon.Address) *ecdsa.PrivateKey {
 		return SigKey(addr)
 	}
+
+	devnetEtherbaseAccount := &Account{
+		"DevnetEtherbase",
+		core.DevnetEtherbase,
+		core.DevnetSignPrivateKey,
+	}
+	accountsByAddress[core.DevnetEtherbase] = devnetEtherbaseAccount
+	accountsByName[devnetEtherbaseAccount.Name] = devnetEtherbaseAccount
 }
 
 var accountsByAddress = map[libcommon.Address]*Account{}

--- a/cmd/devnet/args/node.go
+++ b/cmd/devnet/args/node.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"encoding/hex"
 	"fmt"
+	"github.com/ledgerwatch/erigon/core"
 	"github.com/ledgerwatch/erigon/crypto"
 	"github.com/ledgerwatch/erigon/p2p/enode"
 	"math/big"
@@ -141,6 +142,8 @@ func (m *BlockProducer) Configure(baseNode Node, nodeNumber int) (interface{}, e
 			m.DevPeriod = 30
 		}
 		m.account = accounts.NewAccount(m.Name() + "-etherbase")
+		core.DevnetEtherbase = m.account.Address
+		core.DevnetSignPrivateKey = m.account.SigKey()
 
 	case networkname.BorDevnetChainName:
 		m.account = accounts.NewAccount(m.Name() + "-etherbase")

--- a/cmd/devnet/args/node_args.go
+++ b/cmd/devnet/args/node_args.go
@@ -18,7 +18,7 @@ import (
 	"github.com/ledgerwatch/erigon/cmd/devnet/requests"
 )
 
-type Node struct {
+type NodeArgs struct {
 	requests.RequestGenerator `arg:"-"`
 	Name                      string `arg:"-"`
 	BuildDir                  string `arg:"positional" default:"./build/bin/devnet" json:"builddir"`
@@ -57,7 +57,7 @@ type Node struct {
 	NodeKeyHex string            `arg:"--nodekeyhex" json:"nodekeyhex,omitempty"`
 }
 
-func (node *Node) Configure(base Node, nodeNumber int) error {
+func (node *NodeArgs) Configure(base NodeArgs, nodeNumber int) error {
 	if len(node.Name) == 0 {
 		node.Name = fmt.Sprintf("%s-%d", base.Chain, nodeNumber)
 	}
@@ -105,11 +105,11 @@ func (node *Node) Configure(base Node, nodeNumber int) error {
 	return nil
 }
 
-func (node *Node) GetName() string {
+func (node *NodeArgs) GetName() string {
 	return node.Name
 }
 
-func (node *Node) ChainID() *big.Int {
+func (node *NodeArgs) ChainID() *big.Int {
 	config := params.ChainConfigByChainName(node.Chain)
 	if config == nil {
 		return nil
@@ -117,17 +117,17 @@ func (node *Node) ChainID() *big.Int {
 	return config.ChainID
 }
 
-func (node *Node) GetHttpPort() int {
+func (node *NodeArgs) GetHttpPort() int {
 	return node.HttpPort
 }
 
-func (node *Node) GetEnodeURL() string {
+func (node *NodeArgs) GetEnodeURL() string {
 	port := node.Port
 	return enode.NewV4(&node.NodeKey.PublicKey, net.ParseIP("127.0.0.1"), port, port).URLv4()
 }
 
 type BlockProducer struct {
-	Node
+	NodeArgs
 	Mine            bool   `arg:"--mine" flag:"true"`
 	Etherbase       string `arg:"--miner.etherbase"`
 	DevPeriod       int    `arg:"--dev.period"`
@@ -138,8 +138,8 @@ type BlockProducer struct {
 	account         *accounts.Account
 }
 
-func (m *BlockProducer) Configure(baseNode Node, nodeNumber int) error {
-	err := m.Node.Configure(baseNode, nodeNumber)
+func (m *BlockProducer) Configure(baseNode NodeArgs, nodeNumber int) error {
+	err := m.NodeArgs.Configure(baseNode, nodeNumber)
 	if err != nil {
 		return err
 	}
@@ -177,7 +177,7 @@ func (n *BlockProducer) IsBlockProducer() bool {
 }
 
 type NonBlockProducer struct {
-	Node
+	NodeArgs
 	HttpApi     string `arg:"--http.api" default:"admin,eth,debug,net,trace,web3,erigon,txpool" json:"http.api"`
 	TorrentPort string `arg:"--torrent.port" default:"42070" json:"torrent.port"`
 	NoDiscover  string `arg:"--nodiscover" flag:"" default:"true" json:"nodiscover"`

--- a/cmd/devnet/args/node_args_test.go
+++ b/cmd/devnet/args/node_args_test.go
@@ -13,7 +13,7 @@ func TestNodeArgs(t *testing.T) {
 	asMap := map[string]struct{}{}
 
 	nodeArgs, _ := args.AsArgs(args.BlockProducer{
-		Node: args.Node{
+		NodeArgs: args.NodeArgs{
 			DataDir:        filepath.Join("data", fmt.Sprintf("%d", 1)),
 			PrivateApiAddr: "localhost:9092",
 		},
@@ -37,7 +37,7 @@ func TestNodeArgs(t *testing.T) {
 	}
 
 	nodeArgs, _ = args.AsArgs(args.NonBlockProducer{
-		Node: args.Node{
+		NodeArgs: args.NodeArgs{
 			DataDir:        filepath.Join("data", fmt.Sprintf("%d", 2)),
 			StaticPeers:    "enode",
 			PrivateApiAddr: "localhost:9091",

--- a/cmd/devnet/devnet/context.go
+++ b/cmd/devnet/devnet/context.go
@@ -151,7 +151,7 @@ func CurrentNetwork(ctx context.Context) *Network {
 	}
 
 	if current := CurrentNode(ctx); current != nil {
-		if n, ok := current.(*node); ok {
+		if n, ok := current.(*devnetNode); ok {
 			return n.network
 		}
 	}

--- a/cmd/devnet/devnet/network.go
+++ b/cmd/devnet/devnet/network.go
@@ -2,11 +2,9 @@ package devnet
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/ledgerwatch/erigon/cmd/utils"
 	"math/big"
-	"net"
 	"os"
 	"reflect"
 	"strings"
@@ -15,7 +13,6 @@ import (
 
 	"github.com/ledgerwatch/erigon-lib/common/dbg"
 	"github.com/ledgerwatch/erigon/cmd/devnet/args"
-	"github.com/ledgerwatch/erigon/cmd/devnet/devnetutils"
 	"github.com/ledgerwatch/erigon/cmd/devnet/requests"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/params"
@@ -219,47 +216,6 @@ func (nw *Network) startNode(n Node) error {
 	}
 
 	return nil
-}
-
-func isConnectionError(err error) bool {
-	var opErr *net.OpError
-	if errors.As(err, &opErr) {
-		return opErr.Op == "dial"
-	}
-	return false
-}
-
-// getEnode returns the enode of the netowrk node
-func getEnode(n Node) (string, error) {
-	reqCount := 0
-
-	for {
-		nodeInfo, err := n.AdminNodeInfo()
-
-		if err != nil {
-			if r, ok := n.(*node); ok {
-				if !r.running() {
-					return "", err
-				}
-			}
-
-			if isConnectionError(err) && (reqCount < 10) {
-				reqCount++
-				time.Sleep(time.Duration(devnetutils.RandomInt(5)) * time.Second)
-				continue
-			}
-
-			return "", err
-		}
-
-		enode, err := devnetutils.UniqueIDFromEnode(nodeInfo.Enode)
-
-		if err != nil {
-			return "", err
-		}
-
-		return enode, nil
-	}
 }
 
 func (nw *Network) Stop() {

--- a/cmd/devnet/main.go
+++ b/cmd/devnet/main.go
@@ -346,7 +346,7 @@ func initDevnet(ctx *cli.Context, logger log.Logger) (devnet.Devnet, error) {
 					},
 					Nodes: []devnet.Node{
 						&args.BlockProducer{
-							Node: args.Node{
+							NodeArgs: args.NodeArgs{
 								ConsoleVerbosity: "0",
 								DirVerbosity:     "5",
 								WithoutHeimdall:  true,
@@ -354,7 +354,7 @@ func initDevnet(ctx *cli.Context, logger log.Logger) (devnet.Devnet, error) {
 							AccountSlots: 200,
 						},
 						&args.NonBlockProducer{
-							Node: args.Node{
+							NodeArgs: args.NodeArgs{
 								ConsoleVerbosity: "0",
 								DirVerbosity:     "5",
 								WithoutHeimdall:  true,
@@ -405,7 +405,7 @@ func initDevnet(ctx *cli.Context, logger log.Logger) (devnet.Devnet, error) {
 					},
 					Nodes: []devnet.Node{
 						&args.BlockProducer{
-							Node: args.Node{
+							NodeArgs: args.NodeArgs{
 								ConsoleVerbosity: "0",
 								DirVerbosity:     "5",
 								HeimdallGRpc:     heimdallGrpc,
@@ -413,7 +413,7 @@ func initDevnet(ctx *cli.Context, logger log.Logger) (devnet.Devnet, error) {
 							AccountSlots: 200,
 						},
 						&args.BlockProducer{
-							Node: args.Node{
+							NodeArgs: args.NodeArgs{
 								ConsoleVerbosity: "0",
 								DirVerbosity:     "5",
 								HeimdallGRpc:     heimdallGrpc,
@@ -429,7 +429,7 @@ func initDevnet(ctx *cli.Context, logger log.Logger) (devnet.Devnet, error) {
 							AccountSlots: 200,
 						},*/
 						&args.NonBlockProducer{
-							Node: args.Node{
+							NodeArgs: args.NodeArgs{
 								ConsoleVerbosity: "0",
 								DirVerbosity:     "5",
 								HeimdallGRpc:     heimdallGrpc,
@@ -452,7 +452,7 @@ func initDevnet(ctx *cli.Context, logger log.Logger) (devnet.Devnet, error) {
 					},
 					Nodes: []devnet.Node{
 						&args.BlockProducer{
-							Node: args.Node{
+							NodeArgs: args.NodeArgs{
 								ConsoleVerbosity: "0",
 								DirVerbosity:     "5",
 								VMDebug:          true,
@@ -462,7 +462,7 @@ func initDevnet(ctx *cli.Context, logger log.Logger) (devnet.Devnet, error) {
 							AccountSlots: 200,
 						},
 						&args.NonBlockProducer{
-							Node: args.Node{
+							NodeArgs: args.NodeArgs{
 								ConsoleVerbosity: "0",
 								DirVerbosity:     "3",
 							},
@@ -488,14 +488,14 @@ func initDevnet(ctx *cli.Context, logger log.Logger) (devnet.Devnet, error) {
 				},
 				Nodes: []devnet.Node{
 					&args.BlockProducer{
-						Node: args.Node{
+						NodeArgs: args.NodeArgs{
 							ConsoleVerbosity: "0",
 							DirVerbosity:     "5",
 						},
 						AccountSlots: 200,
 					},
 					&args.NonBlockProducer{
-						Node: args.Node{
+						NodeArgs: args.NodeArgs{
 							ConsoleVerbosity: "0",
 							DirVerbosity:     "5",
 						},

--- a/cmd/devnet/requests/account.go
+++ b/cmd/devnet/requests/account.go
@@ -36,7 +36,7 @@ type StorageResult struct {
 func (reqGen *requestGenerator) GetCode(address libcommon.Address, blockRef rpc.BlockReference) (hexutility.Bytes, error) {
 	var result hexutility.Bytes
 
-	if err := reqGen.callCli(&result, Methods.ETHGetCode, address, blockRef); err != nil {
+	if err := reqGen.rpcCall(&result, Methods.ETHGetCode, address, blockRef); err != nil {
 		return nil, err
 	}
 
@@ -46,7 +46,7 @@ func (reqGen *requestGenerator) GetCode(address libcommon.Address, blockRef rpc.
 func (reqGen *requestGenerator) GetBalance(address libcommon.Address, blockRef rpc.BlockReference) (*big.Int, error) {
 	var result hexutil.Big
 
-	if err := reqGen.callCli(&result, Methods.ETHGetBalance, address, blockRef); err != nil {
+	if err := reqGen.rpcCall(&result, Methods.ETHGetBalance, address, blockRef); err != nil {
 		return nil, err
 	}
 
@@ -56,7 +56,7 @@ func (reqGen *requestGenerator) GetBalance(address libcommon.Address, blockRef r
 func (reqGen *requestGenerator) GetTransactionCount(address libcommon.Address, blockRef rpc.BlockReference) (*big.Int, error) {
 	var result hexutil.Big
 
-	if err := reqGen.callCli(&result, Methods.ETHGetTransactionCount, address, blockRef); err != nil {
+	if err := reqGen.rpcCall(&result, Methods.ETHGetTransactionCount, address, blockRef); err != nil {
 		return nil, err
 	}
 
@@ -67,7 +67,7 @@ func (reqGen *requestGenerator) DebugAccountAt(blockHash libcommon.Hash, txIndex
 	var b DebugAccountAt
 
 	method, body := reqGen.debugAccountAt(blockHash, txIndex, account)
-	if res := reqGen.call(method, body, &b); res.Err != nil {
+	if res := reqGen.rpcCallJSON(method, body, &b); res.Err != nil {
 		return nil, fmt.Errorf("failed to get account: %v", res.Err)
 	}
 

--- a/cmd/devnet/requests/admin.go
+++ b/cmd/devnet/requests/admin.go
@@ -7,7 +7,7 @@ import (
 func (reqGen *requestGenerator) AdminNodeInfo() (p2p.NodeInfo, error) {
 	var result p2p.NodeInfo
 
-	if err := reqGen.callCli(&result, Methods.AdminNodeInfo); err != nil {
+	if err := reqGen.rpcCall(&result, Methods.AdminNodeInfo); err != nil {
 		return p2p.NodeInfo{}, err
 	}
 

--- a/cmd/devnet/requests/block.go
+++ b/cmd/devnet/requests/block.go
@@ -40,33 +40,63 @@ var BlockNumbers = struct {
 	Pending:  "pending",
 }
 
-type Block struct {
+type BlockWithTxHashes struct {
 	*types.Header
-	Hash         libcommon.Hash            `json:"hash"`
-	Transactions []*jsonrpc.RPCTransaction `json:"transactions"`
+	Hash              libcommon.Hash `json:"hash"`
+	TransactionHashes []libcommon.Hash
 }
 
-func (b *Block) UnmarshalJSON(input []byte) error {
-	type body struct {
-		Hash         libcommon.Hash            `json:"hash"`
-		Transactions []*jsonrpc.RPCTransaction `json:"transactions"`
+func (b *BlockWithTxHashes) UnmarshalJSON(input []byte) error {
+	var header types.Header
+	if err := json.Unmarshal(input, &header); err != nil {
+		return err
 	}
 
-	bd := body{}
-
+	var bd struct {
+		Hash              libcommon.Hash   `json:"hash"`
+		TransactionHashes []libcommon.Hash `json:"transactions"`
+	}
 	if err := json.Unmarshal(input, &bd); err != nil {
 		return err
 	}
 
-	header := types.Header{}
+	b.Header = &header
+	b.Hash = bd.Hash
+	b.TransactionHashes = bd.TransactionHashes
 
+	return nil
+}
+
+type Block struct {
+	BlockWithTxHashes
+	Transactions []*jsonrpc.RPCTransaction `json:"transactions"`
+}
+
+func (b *Block) UnmarshalJSON(input []byte) error {
+	var header types.Header
 	if err := json.Unmarshal(input, &header); err != nil {
+		return err
+	}
+
+	var bd struct {
+		Hash         libcommon.Hash            `json:"hash"`
+		Transactions []*jsonrpc.RPCTransaction `json:"transactions"`
+	}
+	if err := json.Unmarshal(input, &bd); err != nil {
 		return err
 	}
 
 	b.Header = &header
 	b.Hash = bd.Hash
 	b.Transactions = bd.Transactions
+
+	if bd.Transactions != nil {
+		b.TransactionHashes = make([]libcommon.Hash, len(b.Transactions))
+		for _, t := range bd.Transactions {
+			b.TransactionHashes = append(b.TransactionHashes, t.Hash)
+		}
+	}
+
 	return nil
 }
 
@@ -87,8 +117,15 @@ func (reqGen *requestGenerator) BlockNumber() (uint64, error) {
 
 func (reqGen *requestGenerator) GetBlockByNumber(blockNum rpc.BlockNumber, withTxs bool) (*Block, error) {
 	var result Block
+	var err error
 
-	if err := reqGen.rpcCall(&result, Methods.ETHGetBlockByNumber, blockNum, withTxs); err != nil {
+	if withTxs {
+		err = reqGen.rpcCall(&result, Methods.ETHGetBlockByNumber, blockNum, withTxs)
+	} else {
+		err = reqGen.rpcCall(&result.BlockWithTxHashes, Methods.ETHGetBlockByNumber, blockNum, withTxs)
+	}
+
+	if err != nil {
 		return nil, err
 	}
 

--- a/cmd/devnet/requests/block.go
+++ b/cmd/devnet/requests/block.go
@@ -78,7 +78,7 @@ type EthGetTransactionCount struct {
 func (reqGen *requestGenerator) BlockNumber() (uint64, error) {
 	var result hexutil2.Uint64
 
-	if err := reqGen.callCli(&result, Methods.ETHBlockNumber); err != nil {
+	if err := reqGen.rpcCall(&result, Methods.ETHBlockNumber); err != nil {
 		return 0, err
 	}
 
@@ -88,7 +88,7 @@ func (reqGen *requestGenerator) BlockNumber() (uint64, error) {
 func (reqGen *requestGenerator) GetBlockByNumber(blockNum rpc.BlockNumber, withTxs bool) (*Block, error) {
 	var result Block
 
-	if err := reqGen.callCli(&result, Methods.ETHGetBlockByNumber, blockNum, withTxs); err != nil {
+	if err := reqGen.rpcCall(&result, Methods.ETHGetBlockByNumber, blockNum, withTxs); err != nil {
 		return nil, err
 	}
 
@@ -98,7 +98,7 @@ func (reqGen *requestGenerator) GetBlockByNumber(blockNum rpc.BlockNumber, withT
 func (req *requestGenerator) GetRootHash(startBlock uint64, endBlock uint64) (libcommon.Hash, error) {
 	var result string
 
-	if err := req.callCli(&result, Methods.BorGetRootHash, startBlock, endBlock); err != nil {
+	if err := req.rpcCall(&result, Methods.BorGetRootHash, startBlock, endBlock); err != nil {
 		return libcommon.Hash{}, err
 	}
 

--- a/cmd/devnet/requests/event.go
+++ b/cmd/devnet/requests/event.go
@@ -50,7 +50,7 @@ func NewLog(hash libcommon.Hash, blockNum uint64, address libcommon.Address, top
 func (reqGen *requestGenerator) FilterLogs(ctx context.Context, query ethereum.FilterQuery) ([]types.Log, error) {
 	var result []types.Log
 
-	if err := reqGen.callCli(&result, Methods.ETHGetLogs, query); err != nil {
+	if err := reqGen.rpcCall(&result, Methods.ETHGetLogs, query); err != nil {
 		return nil, err
 	}
 

--- a/cmd/devnet/requests/request_generator.go
+++ b/cmd/devnet/requests/request_generator.go
@@ -151,7 +151,7 @@ var Methods = struct {
 	ETHCall:                  "eth_call",
 }
 
-func (req *requestGenerator) call(method RPCMethod, body string, response interface{}) callResult {
+func (req *requestGenerator) rpcCallJSON(method RPCMethod, body string, response interface{}) callResult {
 	start := time.Now()
 	targetUrl := "http://" + req.target
 	err := post(req.client, targetUrl, string(method), body, response, req.logger)
@@ -167,14 +167,14 @@ func (req *requestGenerator) call(method RPCMethod, body string, response interf
 	}
 }
 
-func (req *requestGenerator) callCli(result interface{}, method RPCMethod, args ...interface{}) error {
-	cli, err := req.cli(context.Background())
+func (req *requestGenerator) rpcCall(result interface{}, method RPCMethod, args ...interface{}) error {
+	client, err := req.rpcClient(context.Background())
 
 	if err != nil {
 		return err
 	}
 
-	return cli.Call(result, string(method), args...)
+	return client.Call(result, string(method), args...)
 }
 
 type PingResult callResult
@@ -237,7 +237,7 @@ func NewRequestGenerator(target string, logger log.Logger) RequestGenerator {
 	}
 }
 
-func (req *requestGenerator) cli(ctx context.Context) (*rpc.Client, error) {
+func (req *requestGenerator) rpcClient(ctx context.Context) (*rpc.Client, error) {
 	if req.requestClient == nil {
 		var err error
 		req.requestClient, err = rpc.DialContext(ctx, "http://"+req.target, req.logger)

--- a/cmd/devnet/requests/request_generator.go
+++ b/cmd/devnet/requests/request_generator.go
@@ -3,9 +3,11 @@ package requests
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
+	"net"
 	"net/http"
 	"strings"
 	"sync"
@@ -152,10 +154,14 @@ var Methods = struct {
 }
 
 func (req *requestGenerator) rpcCallJSON(method RPCMethod, body string, response interface{}) callResult {
+	ctx := context.Background()
+	req.reqID++
 	start := time.Now()
 	targetUrl := "http://" + req.target
-	err := post(req.client, targetUrl, string(method), body, response, req.logger)
-	req.reqID++
+
+	err := retryConnects(ctx, func(ctx context.Context) error {
+		return post(ctx, req.client, targetUrl, string(method), body, response, req.logger)
+	})
 
 	return callResult{
 		RequestBody: body,
@@ -168,13 +174,55 @@ func (req *requestGenerator) rpcCallJSON(method RPCMethod, body string, response
 }
 
 func (req *requestGenerator) rpcCall(result interface{}, method RPCMethod, args ...interface{}) error {
-	client, err := req.rpcClient(context.Background())
-
+	ctx := context.Background()
+	client, err := req.rpcClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	return client.Call(result, string(method), args...)
+	return retryConnects(ctx, func(ctx context.Context) error {
+		return client.CallContext(ctx, result, string(method), args...)
+	})
+}
+
+const connectionTimeout = time.Second * 5
+
+func isConnectionError(err error) bool {
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return opErr.Op == "dial"
+	}
+	return false
+}
+
+func retryConnects(ctx context.Context, op func(context.Context) error) error {
+	ctx, cancel := context.WithTimeout(ctx, connectionTimeout)
+	defer cancel()
+	return retry(ctx, op, isConnectionError, time.Millisecond*200, nil)
+}
+
+func retry(ctx context.Context, op func(context.Context) error, isRecoverableError func(error) bool, delay time.Duration, lastErr error) error {
+	err := op(ctx)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.DeadlineExceeded) && lastErr != nil {
+		return lastErr
+	}
+	if !isRecoverableError(err) {
+		return err
+	}
+
+	delayTimer := time.NewTimer(delay)
+	select {
+	case <-delayTimer.C:
+		return retry(ctx, op, isRecoverableError, delay, err)
+	case <-ctx.Done():
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return err
+		}
+		return ctx.Err()
+	}
 }
 
 type PingResult callResult
@@ -231,7 +279,6 @@ func NewRequestGenerator(target string, logger log.Logger) RequestGenerator {
 		client: &http.Client{
 			Timeout: time.Second * 10,
 		},
-		reqID:  1,
 		logger: logger,
 		target: target,
 	}
@@ -241,7 +288,6 @@ func (req *requestGenerator) rpcClient(ctx context.Context) (*rpc.Client, error)
 	if req.requestClient == nil {
 		var err error
 		req.requestClient, err = rpc.DialContext(ctx, "http://"+req.target, req.logger)
-
 		if err != nil {
 			return nil, err
 		}
@@ -250,14 +296,23 @@ func (req *requestGenerator) rpcClient(ctx context.Context) (*rpc.Client, error)
 	return req.requestClient, nil
 }
 
-func post(client *http.Client, url, method, request string, response interface{}, logger log.Logger) error {
+func post(ctx context.Context, client *http.Client, url, method, request string, response interface{}, logger log.Logger) error {
 	start := time.Now()
-	r, err := client.Post(url, "application/json", strings.NewReader(request)) // nolint:bodyclose
+
+	req, err := http.NewRequest("POST", url, strings.NewReader(request))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(ctx)
+
+	r, err := client.Do(req) // nolint:bodyclose
 	if err != nil {
 		return fmt.Errorf("client failed to make post request: %w", err)
 	}
-	defer func(Body io.ReadCloser) {
-		closeErr := Body.Close()
+
+	defer func(body io.ReadCloser) {
+		closeErr := body.Close()
 		if closeErr != nil {
 			logger.Warn("body close", "err", closeErr)
 		}
@@ -288,11 +343,12 @@ func post(client *http.Client, url, method, request string, response interface{}
 
 // subscribe connects to a websocket client and returns the subscription handler and a channel buffer
 func (req *requestGenerator) Subscribe(ctx context.Context, method SubMethod, subChan interface{}, args ...interface{}) (ethereum.Subscription, error) {
-	var err error
-
 	if req.subscriptionClient == nil {
-		req.subscriptionClient, err = rpc.DialWebsocket(ctx, "ws://"+req.target, "", req.logger)
-
+		err := retryConnects(ctx, func(ctx context.Context) error {
+			var err error
+			req.subscriptionClient, err = rpc.DialWebsocket(ctx, "ws://"+req.target, "", req.logger)
+			return err
+		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to dial websocket: %v", err)
 		}

--- a/cmd/devnet/requests/trace.go
+++ b/cmd/devnet/requests/trace.go
@@ -113,7 +113,7 @@ func (reqGen *requestGenerator) TraceCall(blockRef rpc.BlockReference, args etha
 	}
 
 	method, body := reqGen.traceCall(blockRef, string(argsVal), string(optsVal))
-	res := reqGen.call(method, body, &b)
+	res := reqGen.rpcCallJSON(method, body, &b)
 
 	if res.Err != nil {
 		return nil, fmt.Errorf("TraceCall rpc failed: %w", res.Err)
@@ -134,7 +134,7 @@ func (req *requestGenerator) traceCall(blockRef rpc.BlockReference, callArgs str
 func (reqGen *requestGenerator) TraceTransaction(hash libcommon.Hash) ([]TransactionTrace, error) {
 	var result []TransactionTrace
 
-	if err := reqGen.callCli(&result, Methods.TraceTransaction, hash); err != nil {
+	if err := reqGen.rpcCall(&result, Methods.TraceTransaction, hash); err != nil {
 		return nil, err
 	}
 

--- a/cmd/devnet/requests/transaction.go
+++ b/cmd/devnet/requests/transaction.go
@@ -78,7 +78,7 @@ func (reqGen *requestGenerator) EstimateGas(args ethereum.CallMsg, blockRef Bloc
 	}
 
 	method, body := reqGen.estimateGas(string(argsVal), blockRef)
-	res := reqGen.call(method, body, &b)
+	res := reqGen.rpcCallJSON(method, body, &b)
 
 	if res.Err != nil {
 		return 0, fmt.Errorf("EstimateGas rpc failed: %w", res.Err)
@@ -100,7 +100,7 @@ func (req *requestGenerator) estimateGas(callArgs string, blockRef BlockNumber) 
 func (reqGen *requestGenerator) GasPrice() (*big.Int, error) {
 	var result hexutil.Big
 
-	if err := reqGen.callCli(&result, Methods.ETHGasPrice); err != nil {
+	if err := reqGen.rpcCall(&result, Methods.ETHGasPrice); err != nil {
 		return nil, err
 	}
 
@@ -110,7 +110,7 @@ func (reqGen *requestGenerator) GasPrice() (*big.Int, error) {
 func (reqGen *requestGenerator) Call(args ethapi.CallArgs, blockRef rpc.BlockReference, overrides *ethapi.StateOverrides) ([]byte, error) {
 	var result hexutility.Bytes
 
-	if err := reqGen.callCli(&result, Methods.ETHCall, args, blockRef, overrides); err != nil {
+	if err := reqGen.rpcCall(&result, Methods.ETHCall, args, blockRef, overrides); err != nil {
 		return nil, err
 	}
 
@@ -125,7 +125,7 @@ func (reqGen *requestGenerator) SendTransaction(signedTx types.Transaction) (lib
 		return libcommon.Hash{}, fmt.Errorf("failed to marshal binary: %v", err)
 	}
 
-	if err := reqGen.callCli(&result, Methods.ETHSendRawTransaction, hexutility.Bytes(buf.Bytes())); err != nil {
+	if err := reqGen.rpcCall(&result, Methods.ETHSendRawTransaction, hexutility.Bytes(buf.Bytes())); err != nil {
 		return libcommon.Hash{}, err
 	}
 
@@ -148,7 +148,7 @@ func (reqGen *requestGenerator) SendTransaction(signedTx types.Transaction) (lib
 func (req *requestGenerator) GetTransactionByHash(hash libcommon.Hash) (*jsonrpc.RPCTransaction, error) {
 	var result jsonrpc.RPCTransaction
 
-	if err := req.callCli(&result, Methods.ETHGetTransactionByHash, hash); err != nil {
+	if err := req.rpcCall(&result, Methods.ETHGetTransactionByHash, hash); err != nil {
 		return nil, err
 	}
 
@@ -158,7 +158,7 @@ func (req *requestGenerator) GetTransactionByHash(hash libcommon.Hash) (*jsonrpc
 func (req *requestGenerator) GetTransactionReceipt(hash libcommon.Hash) (*types.Receipt, error) {
 	var result types.Receipt
 
-	if err := req.callCli(&result, Methods.ETHGetTransactionReceipt, hash); err != nil {
+	if err := req.rpcCall(&result, Methods.ETHGetTransactionReceipt, hash); err != nil {
 		return nil, err
 	}
 

--- a/cmd/devnet/requests/tx.go
+++ b/cmd/devnet/requests/tx.go
@@ -18,7 +18,7 @@ func (reqGen *requestGenerator) TxpoolContent() (int, int, int, error) {
 	)
 
 	method, body := reqGen.txpoolContent()
-	if res := reqGen.call(method, body, &b); res.Err != nil {
+	if res := reqGen.rpcCallJSON(method, body, &b); res.Err != nil {
 		return len(pending), len(queued), len(baseFee), fmt.Errorf("failed to fetch txpool content: %v", res.Err)
 	}
 

--- a/cmd/devnet/services/accounts/faucet.go
+++ b/cmd/devnet/services/accounts/faucet.go
@@ -214,7 +214,7 @@ func (f *Faucet) NodeCreated(ctx context.Context, node devnet.Node) {
 func (f *Faucet) NodeStarted(ctx context.Context, node devnet.Node) {
 	logger := devnet.Logger(ctx)
 
-	if strings.HasPrefix(node.Name(), f.chainName) && node.IsBlockProducer() {
+	if strings.HasPrefix(node.GetName(), f.chainName) && node.IsBlockProducer() {
 		f.Lock()
 		defer f.Unlock()
 

--- a/cmd/devnet/services/polygon/checkpoint.go
+++ b/cmd/devnet/services/polygon/checkpoint.go
@@ -126,7 +126,11 @@ func (h *Heimdall) startChildHeaderSubscription(ctx context.Context) {
 
 	for childHeader := range childHeaderChan {
 		if err := h.handleChildHeader(ctx, childHeader); err != nil {
-			h.logger.Error("L2 header processing failed", "header", childHeader.Number, "err", err)
+			if errors.Is(err, notEnoughChildChainTxConfirmationsError) {
+				h.logger.Info("L2 header processing skipped", "header", childHeader.Number, "err", err)
+			} else {
+				h.logger.Error("L2 header processing failed", "header", childHeader.Number, "err", err)
+			}
 		}
 	}
 }
@@ -149,6 +153,8 @@ func (h *Heimdall) startRootHeaderBlockSubscription() {
 	}
 }
 
+var notEnoughChildChainTxConfirmationsError = errors.New("the chain doesn't have enough blocks for ChildChainTxConfirmations")
+
 func (h *Heimdall) handleChildHeader(ctx context.Context, header *types.Header) error {
 
 	h.logger.Debug("no of checkpoint confirmations required", "childChainTxConfirmations", h.checkpointConfig.ChildChainTxConfirmations)
@@ -156,9 +162,7 @@ func (h *Heimdall) handleChildHeader(ctx context.Context, header *types.Header) 
 	latestConfirmedChildBlock := header.Number.Int64() - int64(h.checkpointConfig.ChildChainTxConfirmations)
 
 	if latestConfirmedChildBlock <= 0 {
-		h.logger.Error("no of blocks on childchain is less than confirmations required",
-			"childChainBlocks", header.Number.Uint64(), "confirmationsRequired", h.checkpointConfig.ChildChainTxConfirmations)
-		return errors.New("no of blocks on childchain is less than confirmations required")
+		return notEnoughChildChainTxConfirmationsError
 	}
 
 	timeStamp := uint64(time.Now().Unix())

--- a/cmd/devnet/services/polygon/heimdall.go
+++ b/cmd/devnet/services/polygon/heimdall.go
@@ -256,14 +256,18 @@ func (h *Heimdall) NodeCreated(ctx context.Context, node devnet.Node) {
 	h.Lock()
 	defer h.Unlock()
 
-	if strings.HasPrefix(node.Name(), "bor") && node.IsBlockProducer() && node.Account() != nil {
+	if strings.HasPrefix(node.GetName(), "bor") && node.IsBlockProducer() && node.Account() != nil {
 		// TODO configurable voting power
 		h.addValidator(node.Account().Address, 1000, 0)
 	}
 }
 
 func (h *Heimdall) NodeStarted(ctx context.Context, node devnet.Node) {
-	if !strings.HasPrefix(node.Name(), "bor") && node.IsBlockProducer() {
+	if h.validatorSet == nil {
+		panic("Heimdall devnet service: unexpected empty validator set! Call addValidator() before starting nodes.")
+	}
+
+	if !strings.HasPrefix(node.GetName(), "bor") && node.IsBlockProducer() {
 		h.Lock()
 		defer h.Unlock()
 

--- a/cmd/devnet/services/polygon/heimdall.go
+++ b/cmd/devnet/services/polygon/heimdall.go
@@ -280,7 +280,9 @@ func (h *Heimdall) NodeStarted(ctx context.Context, node devnet.Node) {
 		transactOpts, err := bind.NewKeyedTransactorWithChainID(accounts.SigKey(node.Account().Address), node.ChainID())
 
 		if err != nil {
+			h.Unlock()
 			h.unsubscribe()
+			h.Lock()
 			h.logger.Error("Failed to deploy state sender", "err", err)
 			return
 		}
@@ -324,7 +326,7 @@ func (h *Heimdall) NodeStarted(ctx context.Context, node devnet.Node) {
 			h.logger.Info("RootChain deployed", "chain", h.chainConfig.ChainName, "block", blocks[syncTx.Hash()].Number, "addr", h.rootChainAddress)
 			h.logger.Info("StateSender deployed", "chain", h.chainConfig.ChainName, "block", blocks[syncTx.Hash()].Number, "addr", h.syncSenderAddress)
 
-			go h.startStateSyncSubacription()
+			go h.startStateSyncSubscription()
 			go h.startChildHeaderSubscription(deployCtx)
 			go h.startRootHeaderBlockSubscription()
 		}()

--- a/cmd/devnet/services/polygon/proofgenerator.go
+++ b/cmd/devnet/services/polygon/proofgenerator.go
@@ -38,7 +38,7 @@ func NewProofGenerator() *ProofGenerator {
 func (pg *ProofGenerator) NodeCreated(ctx context.Context, node devnet.Node) {
 
 	if pg.heimdall == nil {
-		if strings.HasPrefix(node.Name(), "bor") {
+		if strings.HasPrefix(node.GetName(), "bor") {
 			if network := devnet.CurrentNetwork(ctx); network != nil {
 				for _, service := range network.Services {
 					if heimdall, ok := service.(*Heimdall); ok {

--- a/cmd/devnet/services/polygon/statesync.go
+++ b/cmd/devnet/services/polygon/statesync.go
@@ -23,7 +23,7 @@ type EventRecordWithBlock struct {
 	BlockNumber uint64
 }
 
-func (h *Heimdall) startStateSyncSubacription() {
+func (h *Heimdall) startStateSyncSubscription() {
 	var err error
 	syncChan := make(chan *contracts.TestStateSenderStateSynced, 100)
 

--- a/cmd/devnet/transactions/tx.go
+++ b/cmd/devnet/transactions/tx.go
@@ -335,7 +335,12 @@ func signEIP1559TxsHigherThanBaseFee(ctx context.Context, n int, baseFeePerGas u
 
 		devnet.Logger(ctx).Info("HIGHER", "transaction", i, "nonce", transaction.Nonce, "value", transaction.Value, "feecap", transaction.FeeCap)
 
-		signedTransaction, err := types.SignTx(transaction, signer, accounts.SigKey(fromAddress))
+		signerKey := accounts.SigKey(fromAddress)
+		if signerKey == nil {
+			return nil, fmt.Errorf("devnet.signEIP1559TxsHigherThanBaseFee failed to SignTx: private key not found for address %s", fromAddress)
+		}
+
+		signedTransaction, err := types.SignTx(transaction, signer, signerKey)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/devnet/transactions/tx.go
+++ b/cmd/devnet/transactions/tx.go
@@ -41,7 +41,7 @@ func CheckTxPoolContent(ctx context.Context, expectedPendingSize, expectedQueued
 	}
 
 	if expectedPendingSize >= 0 && pendingSize != expectedPendingSize {
-		logger.Error("FAILURE mismatched pending subpool size", "expected", expectedPendingSize, "got", pendingSize)
+		logger.Debug("FAILURE mismatched pending subpool size", "expected", expectedPendingSize, "got", pendingSize)
 		return
 	}
 
@@ -51,7 +51,7 @@ func CheckTxPoolContent(ctx context.Context, expectedPendingSize, expectedQueued
 	}
 
 	if expectedBaseFeeSize >= 0 && baseFeeSize != expectedBaseFeeSize {
-		logger.Error("FAILURE mismatched basefee subpool size", "expected", expectedBaseFeeSize, "got", baseFeeSize)
+		logger.Debug("FAILURE mismatched basefee subpool size", "expected", expectedBaseFeeSize, "got", baseFeeSize)
 	}
 
 	logger.Info("Subpool sizes", "pending", pendingSize, "queued", queuedSize, "basefee", baseFeeSize)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1625,7 +1625,7 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 		}
 	case networkname.DevChainName:
 		if !ctx.IsSet(NetworkIdFlag.Name) {
-			cfg.NetworkID = 1337
+			cfg.NetworkID = params.NetworkIDByChainName(chain)
 		}
 
 		// Create new developer account or reuse existing one

--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -1214,12 +1214,6 @@ func (c *Bor) Seal(chain consensus.ChainHeaderReader, block *types.Block, result
 	// wiggle was already accounted for in header.Time, this is just for logging
 	wiggle := time.Duration(successionNumber) * time.Duration(c.config.CalculateBackupMultiplier(number)) * time.Second
 
-	// temp for testing
-	if wiggle > 0 {
-		wiggle = 500 * time.Millisecond
-	}
-	// temp for testing
-
 	// Sign all the things!
 	sighash, err := signFn(signer, accounts.MimetypeBor, BorRLP(header, c.config))
 	if err != nil {

--- a/params/config.go
+++ b/params/config.go
@@ -195,6 +195,8 @@ func ChainConfigByChainName(chain string) *chain.Config {
 	switch chain {
 	case networkname.MainnetChainName:
 		return MainnetChainConfig
+	case networkname.DevChainName:
+		return AllCliqueProtocolChanges
 	case networkname.HoleskyChainName:
 		return HoleskyChainConfig
 	case networkname.SepoliaChainName:
@@ -267,16 +269,11 @@ func ChainConfigByGenesisHash(genesisHash libcommon.Hash) *chain.Config {
 }
 
 func NetworkIDByChainName(chain string) uint64 {
-	switch chain {
-	case networkname.DevChainName:
-		return 1337
-	default:
-		config := ChainConfigByChainName(chain)
-		if config == nil {
-			return 0
-		}
-		return config.ChainID.Uint64()
+	config := ChainConfigByChainName(chain)
+	if config == nil {
+		return 0
 	}
+	return config.ChainID.Uint64()
 }
 
 func IsChainPoS(chainConfig *chain.Config, currentTDProvider func() *big.Int) bool {

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -108,21 +108,11 @@ func DialHTTP(endpoint string, logger log.Logger) (*Client, error) {
 func (c *Client) sendHTTP(ctx context.Context, op *requestOp, msg interface{}) error {
 	hc := c.writeConn.(*httpConn)
 	respBody, err := hc.doRequest(ctx, msg)
-	if respBody != nil {
-		defer respBody.Close()
-	}
-
 	if err != nil {
-		if respBody != nil {
-			buf := new(bytes.Buffer)
-			if _, err2 := buf.ReadFrom(respBody); err2 == nil {
-				return fmt.Errorf("%w: %v", err, buf.String())
-			}
-		}
 		return err
 	}
 	var respmsg jsonrpcMessage
-	if err := json.NewDecoder(respBody).Decode(&respmsg); err != nil {
+	if err := json.Unmarshal(respBody, &respmsg); err != nil {
 		return err
 	}
 	op.resp <- &respmsg
@@ -135,9 +125,8 @@ func (c *Client) sendBatchHTTP(ctx context.Context, op *requestOp, msgs []*jsonr
 	if err != nil {
 		return err
 	}
-	defer respBody.Close()
 	var respmsgs []jsonrpcMessage
-	if err := json.NewDecoder(respBody).Decode(&respmsgs); err != nil {
+	if err := json.Unmarshal(respBody, &respmsgs); err != nil {
 		return err
 	}
 	for i := 0; i < len(respmsgs); i++ {
@@ -146,7 +135,7 @@ func (c *Client) sendBatchHTTP(ctx context.Context, op *requestOp, msgs []*jsonr
 	return nil
 }
 
-func (hc *httpConn) doRequest(ctx context.Context, msg interface{}) (io.ReadCloser, error) {
+func (hc *httpConn) doRequest(ctx context.Context, msg interface{}) ([]byte, error) {
 	body, err := json.Marshal(msg)
 	if err != nil {
 		return nil, err
@@ -167,10 +156,19 @@ func (hc *httpConn) doRequest(ctx context.Context, msg interface{}) (io.ReadClos
 	if err != nil {
 		return nil, err
 	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return resp.Body, errors.New(resp.Status)
+	defer func() { _ = resp.Body.Close() }()
+
+	// read the response body
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
 	}
-	return resp.Body, nil
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("%s: %s", resp.Status, string(respBody))
+	}
+
+	return respBody, nil
 }
 
 // httpServerConn turns a HTTP connection into a Conn.

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -125,6 +125,10 @@ func (e wsHandshakeError) Error() string {
 	return s
 }
 
+func (e wsHandshakeError) Unwrap() error {
+	return e.err
+}
+
 func originIsAllowed(allowedOrigins mapset.Set[string], browserOrigin string, logger log.Logger) bool {
 	it := allowedOrigins.Iterator()
 	for origin := range it.C {


### PR DESCRIPTION
* fix "genesis hash does not match" when dev nodes connect  
The "dev" nodes need to have the same --miner.etherbase in order to generate the same genesis ExtraData by DeveloperGenesisBlock(). Override DevnetEtherbase global var that's used if --miner.etherbase is not passed. (for NonBlockProducer case)

* fix missing private key for the hardcoded DevnetEtherbase  
Fixes panic if SigKey is not found. Bor non-producers will use a default `DevnetEtherbase` while Dev nodes modify it. Save hardcoded DevnetEtherbase/DevnetSignPrivateKey into accounts so that SigKey can recover it.

* refactor devnet.node to contain Node config  
This avoids interface{} type casts and fixes an error with Heimdall.validatorSet == nil

* add connection retries to rpcCall and Subscribe of requestGenerator  
Fixes "connection refused" errors due to node not ready to handle early RPC requests.

* fix deadlock in Heimdall.NodeStarted

* fix GetBlockByNumber
Fixes "cannot unmarshal string into Go struct field body.transactions of type jsonrpc.RPCTransaction"

* demote "no of blocks on childchain is less than confirmations required" to Info (#8626)

* demote "mismatched pending subpool size" to Debug (#8615)

* revert wiggle testing code