### PR TITLE
txpool: Add a flag to disable TxPoolGossip

### DIFF
--- a/cmd/rpcdaemon/cli/httpcfg/http_cfg.go
+++ b/cmd/rpcdaemon/cli/httpcfg/http_cfg.go
@@ -67,4 +67,6 @@ type HttpCfg struct {
 
 	// Ots API
 	OtsMaxPageSize uint64
+
+	DisableTxPoolGossip bool
 }

--- a/cmd/txpool/main.go
+++ b/cmd/txpool/main.go
@@ -55,6 +55,8 @@ var (
 	priceBump     uint64
 	blobPriceBump uint64
 
+	noTxGossip bool
+
 	commitEvery time.Duration
 )
 
@@ -80,6 +82,7 @@ func init() {
 	rootCmd.PersistentFlags().Uint64Var(&priceBump, "txpool.pricebump", txpoolcfg.DefaultConfig.PriceBump, "Price bump percentage to replace an already existing transaction")
 	rootCmd.PersistentFlags().Uint64Var(&blobPriceBump, "txpool.blobpricebump", txpoolcfg.DefaultConfig.BlobPriceBump, "Price bump percentage to replace an existing blob (type-3) transaction")
 	rootCmd.PersistentFlags().DurationVar(&commitEvery, utils.TxPoolCommitEveryFlag.Name, utils.TxPoolCommitEveryFlag.Value, utils.TxPoolCommitEveryFlag.Usage)
+	rootCmd.PersistentFlags().BoolVar(&noTxGossip, "txpool.disabletxpoolgossip", txpoolcfg.DefaultConfig.NoTxGossip, "Disable transaction pool gossip")
 	rootCmd.Flags().StringSliceVar(&traceSenders, utils.TxPoolTraceSendersFlag.Name, []string{}, utils.TxPoolTraceSendersFlag.Usage)
 }
 
@@ -146,6 +149,7 @@ func doTxpool(ctx context.Context, logger log.Logger) error {
 	cfg.BlobSlots = blobSlots
 	cfg.PriceBump = priceBump
 	cfg.BlobPriceBump = blobPriceBump
+	cfg.NoTxGossip = noTxGossip
 
 	cacheConfig := kvcache.DefaultCoherentConfig
 	cacheConfig.MetricsLabel = "txpool"

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -20,12 +20,13 @@ package utils
 import (
 	"crypto/ecdsa"
 	"fmt"
-	"github.com/ledgerwatch/erigon/cl/clparams"
 	"math/big"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
+
+	"github.com/ledgerwatch/erigon/cl/clparams"
 
 	"github.com/c2h5oh/datasize"
 	"github.com/ledgerwatch/erigon-lib/chain/networkname"
@@ -834,6 +835,11 @@ var (
 		Name:  "silkworm.path",
 		Usage: "Path to the silkworm_api library (enables embedded Silkworm execution)",
 		Value: "",
+	}
+
+	DisableTxPoolGossipFlag = cli.BoolFlag{
+		Name:  "disable.txpool.gossip",
+		Usage: "Disable transaction pool gossip.",
 	}
 )
 
@@ -1648,6 +1654,10 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 
 	if ctx.IsSet(TrustedSetupFile.Name) {
 		libkzg.SetTrustedSetupFilePath(ctx.String(TrustedSetupFile.Name))
+	}
+
+	if ctx.IsSet(DisableTxPoolGossipFlag.Name) {
+		cfg.DisableTxPoolGossip = ctx.Bool(DisableTxPoolGossipFlag.Name)
 	}
 }
 

--- a/erigon-lib/txpool/pool_test.go
+++ b/erigon-lib/txpool/pool_test.go
@@ -941,3 +941,107 @@ func makeBlobTx() types.TxSlot {
 	blobTx.BlobFeeCap = *blobFeeCap
 	return blobTx
 }
+
+func TestDropRemote(t *testing.T) {
+	assert, require := assert.New(t), require.New(t)
+	ch := make(chan types.Announcements, 100)
+	db, coreDB := memdb.NewTestPoolDB(t), memdb.NewTestDB(t)
+
+	cfg := txpoolcfg.DefaultConfig
+	cfg.NoTxGossip = true
+
+	logger := log.New()
+	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
+
+	txPool, err := New(ch, coreDB, cfg, sendersCache, *u256.N1, big.NewInt(0), big.NewInt(0), nil, fixedgas.DefaultMaxBlobsPerBlock, logger)
+	assert.NoError(err)
+	require.True(txPool != nil)
+	txPoolDropRemote := NewTxPoolDropRemote(txPool)
+
+	ctx := context.Background()
+	var stateVersionID uint64 = 0
+	pendingBaseFee := uint64(1_000_000)
+	// start blocks from 0, set empty hash - then kvcache will also work on this
+	h1 := gointerfaces.ConvertHashToH256([32]byte{})
+	change := &remote.StateChangeBatch{
+		StateVersionId:      stateVersionID,
+		PendingBlockBaseFee: pendingBaseFee,
+		BlockGasLimit:       1000000,
+		ChangeBatch: []*remote.StateChange{
+			{BlockHeight: 0, BlockHash: h1},
+		},
+	}
+	var addr [20]byte
+	addr[0] = 1
+	v := make([]byte, types.EncodeSenderLengthForStorage(2, *uint256.NewInt(1 * common.Ether)))
+	types.EncodeSender(2, *uint256.NewInt(1 * common.Ether), v)
+	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remote.AccountChange{
+		Action:  remote.Action_UPSERT,
+		Address: gointerfaces.ConvertAddressToH160(addr),
+		Data:    v,
+	})
+	tx, err := db.BeginRw(ctx)
+	require.NoError(err)
+	defer tx.Rollback()
+	err = txPoolDropRemote.OnNewBlock(ctx, change, types.TxSlots{}, types.TxSlots{}, tx)
+	assert.NoError(err)
+	// 1. Try Local Tx
+	{
+		var txSlots types.TxSlots
+		txSlot := &types.TxSlot{
+			Tip:    *uint256.NewInt(500_000),
+			FeeCap: *uint256.NewInt(3_000_000),
+			Gas:    100000,
+			Nonce:  3,
+		}
+		txSlot.IDHash[0] = 1
+		txSlots.Append(txSlot, addr[:], true)
+
+		reasons, err := txPoolDropRemote.AddLocalTxs(ctx, txSlots, tx)
+		assert.NoError(err)
+		for _, reason := range reasons {
+			assert.Equal(txpoolcfg.Success, reason, reason.String())
+		}
+	}
+	select {
+	case annoucements := <-ch:
+		for i := 0; i < annoucements.Len(); i++ {
+			_, _, hash := annoucements.At(i)
+			fmt.Printf("propagated hash %x\n", hash)
+		}
+	default:
+
+	}
+
+	// 2. Try same Tx, but as remote; tx must be dropped
+	{
+		var txSlots types.TxSlots
+		txSlot := &types.TxSlot{
+			Tip:    *uint256.NewInt(500_000),
+			FeeCap: *uint256.NewInt(3_000_000),
+			Gas:    100000,
+			Nonce:  3,
+		}
+		txSlot.IDHash[0] = 1
+		txSlots.Append(txSlot, addr[:], true)
+
+		txPoolDropRemote.AddRemoteTxs(ctx, txSlots)
+	}
+
+	// empty because AddRemoteTxs logic is intentionally empty
+	assert.Equal(0, len(txPoolDropRemote.unprocessedRemoteByHash))
+	assert.Equal(0, len(txPoolDropRemote.unprocessedRemoteTxs.Txs))
+
+	assert.NoError(txPoolDropRemote.processRemoteTxs(ctx))
+
+	checkAnnouncementEmpty := func() bool {
+		select {
+		case <-ch:
+			return false
+		default:
+			return true
+		}
+	}
+	// no announcement because unprocessedRemoteTxs is already empty
+	assert.True(checkAnnouncementEmpty())
+}

--- a/erigon-lib/txpool/txpoolcfg/txpoolcfg.go
+++ b/erigon-lib/txpool/txpoolcfg/txpoolcfg.go
@@ -51,6 +51,8 @@ type Config struct {
 	MdbxPageSize    datasize.ByteSize
 	MdbxDBSizeLimit datasize.ByteSize
 	MdbxGrowthStep  datasize.ByteSize
+
+	NoTxGossip bool
 }
 
 var DefaultConfig = Config{
@@ -68,6 +70,8 @@ var DefaultConfig = Config{
 	BlobSlots:     48, // Default for a total of 8 txs for 6 blobs each - for hive tests
 	PriceBump:     10, // Price bump percentage to replace an already existing transaction
 	BlobPriceBump: 100,
+
+	NoTxGossip: false,
 }
 
 type DiscardReason uint8

--- a/erigon-lib/txpool/txpooluitl/all_components.go
+++ b/erigon-lib/txpool/txpooluitl/all_components.go
@@ -143,16 +143,21 @@ func AllComponents(ctx context.Context, cfg txpoolcfg.Config, cache kvcache.Cach
 		cancunTime = cfg.OverrideCancunTime
 	}
 
+	var pool txpool.Pool
 	txPool, err := txpool.New(newTxs, chainDB, cfg, cache, *chainID, shanghaiTime, agraBlock, cancunTime, maxBlobsPerBlock, logger)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
+	}
+	pool = txpool.Pool(txPool)
+	if cfg.NoTxGossip {
+		pool = txpool.Pool(txpool.NewTxPoolDropRemote(txPool))
 	}
 
 	fetch := txpool.NewFetch(ctx, sentryClients, txPool, stateChangesClient, chainDB, txPoolDB, *chainID, logger)
 	//fetch.ConnectCore()
 	//fetch.ConnectSentries()
 
-	send := txpool.NewSend(ctx, sentryClients, txPool, logger)
+	send := txpool.NewSend(ctx, sentryClients, pool, logger)
 	txpoolGrpcServer := txpool.NewGrpcServer(ctx, txPool, txPoolDB, *chainID, logger)
 	return txPoolDB, txPool, fetch, send, txpoolGrpcServer, nil
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -550,6 +550,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 		return nil, err
 	}
 
+	config.TxPool.NoTxGossip = config.DisableTxPoolGossip
 	var miningRPC txpool_proto.MiningServer
 	stateDiffClient := direct.NewStateDiffClientDirect(kvRPC)
 	if config.DeprecatedTxPool.Disable {

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -255,6 +255,8 @@ type Config struct {
 	// Embedded Silkworm support
 	SilkwormEnabled bool
 	SilkwormPath    string
+
+	DisableTxPoolGossip bool
 }
 
 type Sync struct {

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -166,4 +166,6 @@ var DefaultFlags = []cli.Flag{
 	&utils.SilkwormPathFlag,
 
 	&utils.TrustedSetupFile,
+
+	&utils.DisableTxPoolGossipFlag,
 }


### PR DESCRIPTION
This PR adds a new flag to TxPool that can disable the TxPoolGossip feature. This feature is designed for Optimistic Rollup. By disabling TxPoolGossip, the sequencer node can prevent MEV attacks. The default option is set to `false`, so it doesn't impact any existing functions.