### PR TITLE
Re-enable in process HTTP server

### DIFF
--- a/turbo/cli/flags.go
+++ b/turbo/cli/flags.go
@@ -2,9 +2,9 @@ package cli
 
 import (
 	"fmt"
-	"github.com/ledgerwatch/erigon-lib/common/hexutil"
 	"time"
 
+	"github.com/ledgerwatch/erigon-lib/common/hexutil"
 	"github.com/ledgerwatch/erigon-lib/txpool/txpoolcfg"
 
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
@@ -356,8 +356,9 @@ func setEmbeddedRpcDaemon(ctx *cli.Context, cfg *nodecfg.Config, logger log.Logg
 	logger.Info("starting HTTP APIs", "APIs", apis)
 
 	c := &httpcfg.HttpCfg{
-		Enabled: ctx.Bool(utils.HTTPEnabledFlag.Name),
-		Dirs:    cfg.Dirs,
+		Enabled:           ctx.Bool(utils.HTTPEnabledFlag.Name),
+		HttpServerEnabled: ctx.Bool(utils.HTTPEnabledFlag.Name),
+		Dirs:              cfg.Dirs,
 
 		TLSKeyFile:  cfg.TLSKeyFile,
 		TLSCACert:   cfg.TLSCACert,


### PR DESCRIPTION
Thanks to PR #8590 the HTTP server must be explicitly enabled (because it could be bound either to TCP or UNIX sockets).  Consequently, the built-in HTTP server no longer starts by default.  This change simply sets the new HTTP config variable true, when HTTP is enabled.