### PR TITLE
add rollback tx at GetVoteOnHash #8637

### DIFF
--- a/turbo/jsonrpc/bor_snapshot.go
+++ b/turbo/jsonrpc/bor_snapshot.go
@@ -241,6 +241,7 @@ func (api *BorImpl) GetVoteOnHash(ctx context.Context, starBlockNr uint64, endBl
 	if err != nil {
 		return false, err
 	}
+	defer tx.Rollback()
 
 	service := whitelist.GetWhitelistingService()
 


### PR DESCRIPTION
At `turbo/jsonrpc/bor_snapshot.go:239` creates read only transaction and acquire semaphore but does not rollback or commit transaction and unrelease semaphore lock. Over time, this will result in the locking all of semaphore resources. Any other resources can't acquire semaphore. 

I added defer function to rollback transaction to release semaphore.