### PR TITLE
defaults change: increase default --db.read.concurrency 4 times

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -394,7 +394,7 @@ var (
 	DBReadConcurrencyFlag = cli.IntFlag{
 		Name:  "db.read.concurrency",
 		Usage: "Does limit amount of parallel db reads. Default: equal to GOMAXPROCS (or number of CPU)",
-		Value: cmp.Min(cmp.Max(10, runtime.GOMAXPROCS(-1)*16), 9_000),
+		Value: cmp.Min(cmp.Max(10, runtime.GOMAXPROCS(-1)*64), 9_000),
 	}
 	RpcAccessListFlag = cli.StringFlag{
 		Name:  "rpc.accessList",


### PR DESCRIPTION
we plan step-by-step keep increasing this default
still see users for who it helped to handle more rpc 
tradeoff: increasing of this flag - increasing "historical rpc" throughput and decreasing "recent data rpc" throughput