### PR TITLE
BlockReader: handle nil-body 

### DIFF
--- a/turbo/snapshotsync/freezeblocks/block_reader.go
+++ b/turbo/snapshotsync/freezeblocks/block_reader.go
@@ -611,6 +611,9 @@ func (r *BlockReader) bodyFromSnapshot(blockHeight uint64, sn *BodySegment, buf 
 	if err != nil {
 		return nil, 0, 0, buf, err
 	}
+	if b == nil {
+		return nil, 0, 0, buf, nil
+	}
 
 	body := new(types.Body)
 	body.Uncles = b.Uncles


### PR DESCRIPTION
```
EROR] [11-16|07:33:02.592] RPC method eth_getLogs crashed: runtime error: invalid memory address or nil pointer dereference
Nov 16 07:33:02 i-0e4d4ce2636f49d8a erigon.sh[1739584]: [service.go:219 panic.go:914 panic.go:261 signal_unix.go:861 block_reader.go:615 block_reader.go:405 eth_receipts.go:228 value.go:596 value.go:380 service.go:224 handler.go:493 handler.go:443 handler.go:391 handler.go:222 handler.go:315 asm_amd64.s:1650]
```