### PR TITLE
txpool: limit transactions outgoing messages (#8271)

### DIFF
--- a/erigon-lib/txpool/fetch_test.go
+++ b/erigon-lib/txpool/fetch_test.go
@@ -74,19 +74,19 @@ func TestSendTxPropagate(t *testing.T) {
 	t.Run("few remote byHash", func(t *testing.T) {
 		m := NewMockSentry(ctx)
 		send := NewSend(ctx, []direct.SentryClient{direct.NewSentryClientDirect(direct.ETH68, m)}, nil, log.New())
-		send.BroadcastPooledTxs(testRlps(2))
-		send.AnnouncePooledTxs([]byte{0, 1}, []uint32{10, 15}, toHashes(1, 42))
+		send.BroadcastPooledTxs(testRlps(2), 100)
+		send.AnnouncePooledTxs([]byte{0, 1}, []uint32{10, 15}, toHashes(1, 42), 100)
 
-		calls1 := m.SendMessageToRandomPeersCalls()
-		require.Equal(t, 1, len(calls1))
-		calls2 := m.SendMessageToAllCalls()
-		require.Equal(t, 1, len(calls2))
-		first := calls1[0].SendMessageToRandomPeersRequest.Data
-		assert.Equal(t, sentry.MessageId_TRANSACTIONS_66, first.Id)
-		assert.Equal(t, 3, len(first.Data))
-		second := calls2[0].OutboundMessageData
-		assert.Equal(t, sentry.MessageId_NEW_POOLED_TRANSACTION_HASHES_68, second.Id)
-		assert.Equal(t, 76, len(second.Data))
+		calls := m.SendMessageToRandomPeersCalls()
+		require.Equal(t, 2, len(calls))
+
+		txsMessage := calls[0].SendMessageToRandomPeersRequest.Data
+		assert.Equal(t, sentry.MessageId_TRANSACTIONS_66, txsMessage.Id)
+		assert.Equal(t, 3, len(txsMessage.Data))
+
+		txnHashesMessage := calls[1].SendMessageToRandomPeersRequest.Data
+		assert.Equal(t, sentry.MessageId_NEW_POOLED_TRANSACTION_HASHES_68, txnHashesMessage.Id)
+		assert.Equal(t, 76, len(txnHashesMessage.Data))
 	})
 	t.Run("much remote byHash", func(t *testing.T) {
 		m := NewMockSentry(ctx)
@@ -96,20 +96,19 @@ func TestSendTxPropagate(t *testing.T) {
 			b := []byte(fmt.Sprintf("%x", i))
 			copy(list[i:i+32], b)
 		}
-		send.BroadcastPooledTxs(testRlps(len(list) / 32))
-		send.AnnouncePooledTxs([]byte{0, 1, 2}, []uint32{10, 12, 14}, list)
-		calls1 := m.SendMessageToRandomPeersCalls()
-		require.Equal(t, 1, len(calls1))
-		calls2 := m.SendMessageToAllCalls()
-		require.Equal(t, 1, len(calls2))
-		call1 := calls1[0].SendMessageToRandomPeersRequest.Data
-		require.Equal(t, sentry.MessageId_TRANSACTIONS_66, call1.Id)
-		require.True(t, len(call1.Data) > 0)
-		for i := 0; i < 1; i++ {
-			call2 := calls2[i].OutboundMessageData
-			require.Equal(t, sentry.MessageId_NEW_POOLED_TRANSACTION_HASHES_68, call2.Id)
-			require.True(t, len(call2.Data) > 0)
-		}
+		send.BroadcastPooledTxs(testRlps(len(list)/32), 100)
+		send.AnnouncePooledTxs([]byte{0, 1, 2}, []uint32{10, 12, 14}, list, 100)
+
+		calls := m.SendMessageToRandomPeersCalls()
+		require.Equal(t, 2, len(calls))
+
+		txsMessage := calls[0].SendMessageToRandomPeersRequest.Data
+		require.Equal(t, sentry.MessageId_TRANSACTIONS_66, txsMessage.Id)
+		require.True(t, len(txsMessage.Data) > 0)
+
+		txnHashesMessage := calls[1].SendMessageToRandomPeersRequest.Data
+		require.Equal(t, sentry.MessageId_NEW_POOLED_TRANSACTION_HASHES_68, txnHashesMessage.Id)
+		require.True(t, len(txnHashesMessage.Data) > 0)
 	})
 	t.Run("few local byHash", func(t *testing.T) {
 		m := NewMockSentry(ctx)
@@ -117,14 +116,19 @@ func TestSendTxPropagate(t *testing.T) {
 			return &sentry.SentPeers{Peers: make([]*types.H512, 5)}, nil
 		}
 		send := NewSend(ctx, []direct.SentryClient{direct.NewSentryClientDirect(direct.ETH68, m)}, nil, log.New())
-		send.BroadcastPooledTxs(testRlps(2))
-		send.AnnouncePooledTxs([]byte{0, 1}, []uint32{10, 15}, toHashes(1, 42))
+		send.BroadcastPooledTxs(testRlps(2), 100)
+		send.AnnouncePooledTxs([]byte{0, 1}, []uint32{10, 15}, toHashes(1, 42), 100)
 
-		calls := m.SendMessageToAllCalls()
-		require.Equal(t, 1, len(calls))
-		first := calls[0].OutboundMessageData
-		assert.Equal(t, sentry.MessageId_NEW_POOLED_TRANSACTION_HASHES_68, first.Id)
-		assert.Equal(t, 76, len(first.Data))
+		calls := m.SendMessageToRandomPeersCalls()
+		require.Equal(t, 2, len(calls))
+
+		txsMessage := calls[0].SendMessageToRandomPeersRequest.Data
+		assert.Equal(t, sentry.MessageId_TRANSACTIONS_66, txsMessage.Id)
+		assert.True(t, len(txsMessage.Data) > 0)
+
+		txnHashesMessage := calls[1].SendMessageToRandomPeersRequest.Data
+		assert.Equal(t, sentry.MessageId_NEW_POOLED_TRANSACTION_HASHES_68, txnHashesMessage.Id)
+		assert.Equal(t, 76, len(txnHashesMessage.Data))
 	})
 	t.Run("sync with new peer", func(t *testing.T) {
 		m := NewMockSentry(ctx)

--- a/erigon-lib/txpool/send.go
+++ b/erigon-lib/txpool/send.go
@@ -70,7 +70,7 @@ func (f *Send) notifyTests() {
 }
 
 // Broadcast given RLPs to random peers
-func (f *Send) BroadcastPooledTxs(rlps [][]byte) (txSentTo []int) {
+func (f *Send) BroadcastPooledTxs(rlps [][]byte, maxPeers uint64) (txSentTo []int) {
 	defer f.notifyTests()
 	if len(rlps) == 0 {
 		return
@@ -94,7 +94,7 @@ func (f *Send) BroadcastPooledTxs(rlps [][]byte) (txSentTo []int) {
 							Id:   sentry.MessageId_TRANSACTIONS_66,
 							Data: txsData,
 						},
-						MaxPeers: 100,
+						MaxPeers: maxPeers,
 					}
 				}
 				peers, err := sentryClient.SendMessageToRandomPeers(f.ctx, txs66)
@@ -114,7 +114,7 @@ func (f *Send) BroadcastPooledTxs(rlps [][]byte) (txSentTo []int) {
 	return
 }
 
-func (f *Send) AnnouncePooledTxs(types []byte, sizes []uint32, hashes types2.Hashes) (hashSentTo []int) {
+func (f *Send) AnnouncePooledTxs(types []byte, sizes []uint32, hashes types2.Hashes, maxPeers uint64) (hashSentTo []int) {
 	defer f.notifyTests()
 	hashSentTo = make([]int, len(types))
 	if len(types) == 0 {
@@ -149,11 +149,14 @@ func (f *Send) AnnouncePooledTxs(types []byte, sizes []uint32, hashes types2.Has
 			switch sentryClient.Protocol() {
 			case direct.ETH66, direct.ETH67:
 				if i > prevI {
-					req := &sentry.OutboundMessageData{
-						Id:   sentry.MessageId_NEW_POOLED_TRANSACTION_HASHES_66,
-						Data: iData,
+					req := &sentry.SendMessageToRandomPeersRequest{
+						Data: &sentry.OutboundMessageData{
+							Id:   sentry.MessageId_NEW_POOLED_TRANSACTION_HASHES_66,
+							Data: iData,
+						},
+						MaxPeers: maxPeers,
 					}
-					peers, err := sentryClient.SendMessageToAll(f.ctx, req, &grpc.EmptyCallOption{})
+					peers, err := sentryClient.SendMessageToRandomPeers(f.ctx, req)
 					if err != nil {
 						f.logger.Debug("[txpool.send] AnnouncePooledTxs", "err", err)
 					}
@@ -166,11 +169,14 @@ func (f *Send) AnnouncePooledTxs(types []byte, sizes []uint32, hashes types2.Has
 			case direct.ETH68:
 
 				if j > prevJ {
-					req := &sentry.OutboundMessageData{
-						Id:   sentry.MessageId_NEW_POOLED_TRANSACTION_HASHES_68,
-						Data: jData,
+					req := &sentry.SendMessageToRandomPeersRequest{
+						Data: &sentry.OutboundMessageData{
+							Id:   sentry.MessageId_NEW_POOLED_TRANSACTION_HASHES_68,
+							Data: jData,
+						},
+						MaxPeers: maxPeers,
 					}
-					peers, err := sentryClient.SendMessageToAll(f.ctx, req, &grpc.EmptyCallOption{})
+					peers, err := sentryClient.SendMessageToRandomPeers(f.ctx, req)
 					if err != nil {
 						f.logger.Debug("[txpool.send] AnnouncePooledTxs68", "err", err)
 					}


### PR DESCRIPTION
* limit remote transactions re-broadcast to 3-6 peers  
  Broadcasting to 100 peers generates too much outgoing traffic.
* limit transactions count/size in PooledTransactions replies

Before it was sending 5.5-6.5 MiB/sec:

![Screenshot 2023-11-17 at 15 50 15](https://github.com/ledgerwatch/erigon/assets/11477595/bd2f51c5-190b-4f3e-aabf-4ff42ab8972d)


With the fixes it stays at 3-3.5 MiB/sec:

![Screenshot 2023-11-17 at 15 39 10](https://github.com/ledgerwatch/erigon/assets/11477595/74b18037-6017-49f1-8c00-9d7f3d1818b3)

P.S. A baseline if everything is disabled (BroadcastPooledTxs, AnnouncePooledTxs, responses to GetPooledTransactions) is 0.5-1 MiB/sec.
