### PR TITLE
p2p: fix discovery shutdown (#8725) - alternative fix

### DIFF
--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -160,7 +160,7 @@ func ListenV4(ctx context.Context, protocol string, c UDPConn, ln *enode.LocalNo
 		localNode:           ln,
 		db:                  ln.Database(),
 		gotreply:            make(chan reply, 10),
-		addReplyMatcher:     make(chan *replyMatcher),
+		addReplyMatcher:     make(chan *replyMatcher, 10),
 		gotkey:              make(chan v4wire.Pubkey, 10),
 		gotnodes:            make(chan nodes, 10),
 		replyTimeout:        cfg.ReplyTimeout,


### PR DESCRIPTION
Making the addReplyMatcher channel unbuffered makes the loop
going too slow sometimes for serving parallel requests.
This is an alternative fix for keeping the channel buffered.