### PR TITLE
bor: don't hide `ctx.Err()`

### DIFF
--- a/consensus/bor/finality/bor_verifier.go
+++ b/consensus/bor/finality/bor_verifier.go
@@ -59,7 +59,7 @@ func borVerify(ctx context.Context, config *config, start uint64, end uint64, ha
 	// check if we have the given blocks
 	currentBlock := rawdb.ReadCurrentBlockNumber(roTx)
 	if currentBlock == nil {
-		log.Debug("[bor] Failed to fetch current block from blockchain while verifying incoming", "str", str)
+		log.Debug("[bor] Failed to fetch current block while verifying", "incoming", str)
 		return hash, errMissingBlocks
 	}
 

--- a/consensus/bor/heimdall/client.go
+++ b/consensus/bor/heimdall/client.go
@@ -308,7 +308,7 @@ retryLoop:
 
 		select {
 		case <-ctx.Done():
-			logger.Debug("Shutdown detected, terminating request by context.Done")
+			logger.Debug("Shutdown detected, terminating request", "err", ctx.Err())
 
 			return nil, ctx.Err()
 		case <-closeCh:


### PR DESCRIPTION
log `ctx.Err()` - it can be canceled by many reasons: timeout, etc...