### PR TITLE
cl: disable spec-integration CI on mac - until flaky test fix

### DIFF
--- a/.github/workflows/test-integration-caplin.yml
+++ b/.github/workflows/test-integration-caplin.yml
@@ -20,7 +20,9 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [ ubuntu-20.04, macos-11 ] # list of os: https://github.com/actions/virtual-environments
+#        disable macos-11 until
+#        os: [ ubuntu-20.04, macos-11 ] # list of os: https://github.com/actions/virtual-environments
+        os: [ ubuntu-20.04 ] # list of os: https://github.com/actions/virtual-environments
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/test-integration-caplin.yml
+++ b/.github/workflows/test-integration-caplin.yml
@@ -20,7 +20,7 @@ jobs:
   tests:
     strategy:
       matrix:
-#        disable macos-11 until
+#        disable macos-11 until https://github.com/ledgerwatch/erigon/issues/8789
 #        os: [ ubuntu-20.04, macos-11 ] # list of os: https://github.com/actions/virtual-environments
         os: [ ubuntu-20.04 ] # list of os: https://github.com/actions/virtual-environments
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
See Issue #8789