### PR TITLE
webseed: .torrent file validation must check - fileName and hash 

### DIFF
--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -102,7 +102,7 @@ func New(ctx context.Context, cfg *downloadercfg.Cfg, dirs datadir.Dirs, logger 
 		folder:            m,
 		torrentClient:     torrentClient,
 		statsLock:         &sync.RWMutex{},
-		webseeds:          &WebSeeds{logger: logger, verbosity: verbosity, downloadTorrentFile: cfg.DownloadTorrentFilesFromWebseed, torrentHashes: cfg.ExpectedTorrentFilesHashes},
+		webseeds:          &WebSeeds{logger: logger, verbosity: verbosity, downloadTorrentFile: cfg.DownloadTorrentFilesFromWebseed, torrentsWhitelist: cfg.ExpectedTorrentFilesHashes},
 		logger:            logger,
 		verbosity:         verbosity,
 	}

--- a/erigon-lib/downloader/downloadercfg/downloadercfg.go
+++ b/erigon-lib/downloader/downloadercfg/downloadercfg.go
@@ -109,12 +109,6 @@ func New(dirs datadir.Dirs, version string, verbosity lg.Level, downloadRate, up
 		torrentConfig.DownloadRateLimiter = rate.NewLimiter(rate.Limit(downloadRate.Bytes()), DefaultNetworkChunkSize) // default: unlimited
 	}
 
-	torrentsHashes := []string{}
-	snapCfg := snapcfg.KnownCfg(chainName, nil, nil)
-	for _, item := range snapCfg.Preverified {
-		torrentsHashes = append(torrentsHashes, item.Hash)
-	}
-
 	// debug
 	//torrentConfig.Debug = true
 	torrentConfig.Logger = torrentConfig.Logger.WithFilterLevel(verbosity)

--- a/erigon-lib/downloader/downloadercfg/downloadercfg.go
+++ b/erigon-lib/downloader/downloadercfg/downloadercfg.go
@@ -52,7 +52,7 @@ type Cfg struct {
 	WebSeedUrls                     []*url.URL
 	WebSeedFiles                    []string
 	WebSeedS3Tokens                 []string
-	ExpectedTorrentFilesHashes      []string
+	ExpectedTorrentFilesHashes      snapcfg.Preverified
 	DownloadTorrentFilesFromWebseed bool
 	ChainName                       string
 
@@ -181,7 +181,7 @@ func New(dirs datadir.Dirs, version string, verbosity lg.Level, downloadRate, up
 	return &Cfg{Dirs: dirs, ChainName: chainName,
 		ClientConfig: torrentConfig, DownloadSlots: downloadSlots,
 		WebSeedUrls: webseedHttpProviders, WebSeedFiles: webseedFileProviders, WebSeedS3Tokens: webseedS3Providers,
-		DownloadTorrentFilesFromWebseed: false, ExpectedTorrentFilesHashes: torrentsHashes,
+		DownloadTorrentFilesFromWebseed: false, ExpectedTorrentFilesHashes: snapCfg.Preverified,
 	}, nil
 }
 

--- a/erigon-lib/downloader/downloadercfg/downloadercfg.go
+++ b/erigon-lib/downloader/downloadercfg/downloadercfg.go
@@ -172,6 +172,8 @@ func New(dirs datadir.Dirs, version string, verbosity lg.Level, downloadRate, up
 	if dir.FileExist(localCfgFile) {
 		webseedFileProviders = append(webseedFileProviders, localCfgFile)
 	}
+	//TODO: if don't pass "downloaded files list here" (which we store in db) - synced erigon will download new .torrent files. And erigon can't work with "unfinished" files.
+	snapCfg := snapcfg.KnownCfg(chainName, nil, nil)
 	return &Cfg{Dirs: dirs, ChainName: chainName,
 		ClientConfig: torrentConfig, DownloadSlots: downloadSlots,
 		WebSeedUrls: webseedHttpProviders, WebSeedFiles: webseedFileProviders, WebSeedS3Tokens: webseedS3Providers,

--- a/erigon-lib/downloader/webseed.go
+++ b/erigon-lib/downloader/webseed.go
@@ -241,7 +241,7 @@ func (d *WebSeeds) downloadTorrentFilesFromProviders(ctx context.Context, rootDi
 		addedNew++
 		if !strings.HasSuffix(name, ".seg.torrent") {
 			_, fName := filepath.Split(name)
-			d.logger.Log(d.verbosity, "[snapshots] webseed has .torrent, but we skip it because this type not supported yet", "name", fName)
+			d.logger.Log(d.verbosity, "[snapshots] webseed has .torrent, but we skip it because this file-type not supported yet", "name", fName)
 			continue
 		}
 		name := name
@@ -250,10 +250,10 @@ func (d *WebSeeds) downloadTorrentFilesFromProviders(ctx context.Context, rootDi
 			for _, url := range tUrls {
 				res, err := d.callTorrentHttpProvider(ctx, url, name)
 				if err != nil {
-					d.logger.Debug("[snapshots] callTorrentHttpProvider", "err", err)
+					d.logger.Log(d.verbosity, "[snapshots] get .torrent file from webseed", "name", name, "err", err)
 					continue
 				}
-				d.logger.Log(d.verbosity, "[snapshots] downloaded .torrent file from webseed", "name", name)
+				d.logger.Log(d.verbosity, "[snapshots] get .torrent file from webseed", "name", name)
 				if err := saveTorrent(tPath, res); err != nil {
 					d.logger.Debug("[snapshots] saveTorrent", "err", err)
 					continue

--- a/erigon-lib/downloader/webseed.go
+++ b/erigon-lib/downloader/webseed.go
@@ -17,7 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/c2h5oh/datasize"
-	"golang.org/x/exp/slices"
+	"github.com/ledgerwatch/erigon-lib/chain/snapcfg"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/anacrolix/torrent/bencode"
@@ -36,7 +36,7 @@ type WebSeeds struct {
 	byFileName          snaptype.WebSeedUrls // HTTP urls of data files
 	torrentUrls         snaptype.TorrentUrls // HTTP urls of .torrent files
 	downloadTorrentFile bool
-	torrentHashes       []string
+	torrentsWhitelist   snapcfg.Preverified
 
 	logger    log.Logger
 	verbosity log.Lvl
@@ -89,16 +89,19 @@ func (d *WebSeeds) downloadWebseedTomlFromProviders(ctx context.Context, s3Provi
 	webSeedUrls, torrentUrls := snaptype.WebSeedUrls{}, snaptype.TorrentUrls{}
 	for _, urls := range list {
 		for name, wUrl := range urls {
-			if strings.HasSuffix(name, ".torrent") {
-				uri, err := url.ParseRequestURI(wUrl)
-				if err != nil {
-					d.logger.Debug("[snapshots] url is invalid", "url", wUrl, "err", err)
-					continue
-				}
-				torrentUrls[name] = append(torrentUrls[name], uri)
+			if !strings.HasSuffix(name, ".torrent") {
+				webSeedUrls[name] = append(webSeedUrls[name], wUrl)
 				continue
 			}
-			webSeedUrls[name] = append(webSeedUrls[name], wUrl)
+			if !d.isWhitelistedName(name) {
+				continue
+			}
+			uri, err := url.ParseRequestURI(wUrl)
+			if err != nil {
+				d.logger.Debug("[snapshots] url is invalid", "url", wUrl, "err", err)
+				continue
+			}
+			torrentUrls[name] = append(torrentUrls[name], uri)
 		}
 	}
 
@@ -106,6 +109,15 @@ func (d *WebSeeds) downloadWebseedTomlFromProviders(ctx context.Context, s3Provi
 	defer d.lock.Unlock()
 	d.byFileName = webSeedUrls
 	d.torrentUrls = torrentUrls
+}
+
+func (d *WebSeeds) isWhitelistedName(fileName string) bool {
+	for i := 0; i < len(d.torrentsWhitelist); i++ {
+		if d.torrentsWhitelist[i].Name == fileName {
+			return true
+		}
+	}
+	return false
 }
 
 func (d *WebSeeds) TorrentUrls() snaptype.TorrentUrls {
@@ -236,7 +248,7 @@ func (d *WebSeeds) downloadTorrentFilesFromProviders(ctx context.Context, rootDi
 		tUrls := tUrls
 		e.Go(func() error {
 			for _, url := range tUrls {
-				res, err := d.callTorrentHttpProvider(ctx, url)
+				res, err := d.callTorrentHttpProvider(ctx, url, name)
 				if err != nil {
 					d.logger.Debug("[snapshots] callTorrentHttpProvider", "err", err)
 					continue
@@ -256,7 +268,7 @@ func (d *WebSeeds) downloadTorrentFilesFromProviders(ctx context.Context, rootDi
 	}
 }
 
-func (d *WebSeeds) callTorrentHttpProvider(ctx context.Context, url *url.URL) ([]byte, error) {
+func (d *WebSeeds) callTorrentHttpProvider(ctx context.Context, url *url.URL, fileName string) ([]byte, error) {
 	request, err := http.NewRequest(http.MethodGet, url.String(), nil)
 	if err != nil {
 		return nil, err
@@ -275,22 +287,31 @@ func (d *WebSeeds) callTorrentHttpProvider(ctx context.Context, url *url.URL) ([
 	if err != nil {
 		return nil, fmt.Errorf("webseed.downloadTorrentFile: host=%s, url=%s, %w", url.Hostname(), url.EscapedPath(), err)
 	}
-	if err = validateTorrentBytes(res, d.torrentHashes); err != nil {
+	if err = validateTorrentBytes(fileName, res, d.torrentsWhitelist); err != nil {
 		return nil, fmt.Errorf("webseed.downloadTorrentFile: host=%s, url=%s, %w", url.Hostname(), url.EscapedPath(), err)
 	}
 	return res, nil
 }
 
-func validateTorrentBytes(b []byte, torrentHashes []string) error {
+func validateTorrentBytes(fileName string, b []byte, torrentWhitelist snapcfg.Preverified) error {
 	var mi metainfo.MetaInfo
-	if len(torrentHashes) == 0 {
+	if len(torrentWhitelist) == 0 {
 		return nil
 	}
 	if err := bencode.NewDecoder(bytes.NewBuffer(b)).Decode(&mi); err != nil {
 		return err
 	}
 	torrentHash := mi.HashInfoBytes()
-	if !slices.Contains(torrentHashes, torrentHash.String()) {
+	torrentHashString := torrentHash.String()
+	var whitelisted bool
+	for _, it := range torrentWhitelist {
+		// files with different names can have same hash. means need check AND name AND hash.
+		if it.Name == fileName && it.Hash == torrentHashString {
+			whitelisted = true
+			break
+		}
+	}
+	if !whitelisted {
 		return fmt.Errorf("skipping torrent file, hash not found: %s", torrentHash.String())
 	}
 	return nil

--- a/erigon-lib/downloader/webseed.go
+++ b/erigon-lib/downloader/webseed.go
@@ -293,20 +293,17 @@ func (d *WebSeeds) callTorrentHttpProvider(ctx context.Context, url *url.URL, fi
 	return res, nil
 }
 
-func validateTorrentBytes(fileName string, b []byte, torrentWhitelist snapcfg.Preverified) error {
+func validateTorrentBytes(fileName string, b []byte, whitelist snapcfg.Preverified) error {
 	var mi metainfo.MetaInfo
-	if len(torrentWhitelist) == 0 {
-		return nil
-	}
 	if err := bencode.NewDecoder(bytes.NewBuffer(b)).Decode(&mi); err != nil {
 		return err
 	}
 	torrentHash := mi.HashInfoBytes()
 	torrentHashString := torrentHash.String()
 	var whitelisted bool
-	for _, it := range torrentWhitelist {
+	for i := 0; i < len(whitelist); i++ {
 		// files with different names can have same hash. means need check AND name AND hash.
-		if it.Name == fileName && it.Hash == torrentHashString {
+		if whitelist[i].Name == fileName && whitelist[i].Hash == torrentHashString {
 			whitelisted = true
 			break
 		}

--- a/erigon-lib/downloader/webseed.go
+++ b/erigon-lib/downloader/webseed.go
@@ -312,7 +312,7 @@ func validateTorrentBytes(fileName string, b []byte, torrentWhitelist snapcfg.Pr
 		}
 	}
 	if !whitelisted {
-		return fmt.Errorf("skipping torrent file, hash not found: %s", torrentHash.String())
+		return fmt.Errorf(".torrent file is not whitelisted")
 	}
 	return nil
 }


### PR DESCRIPTION
because files with different name can have same hash: BitTorrent is content-addressable. 

