### PR TITLE
increase peer tasks queue size

### DIFF
--- a/p2p/sentry/sentry_grpc_server.go
+++ b/p2p/sentry/sentry_grpc_server.go
@@ -125,7 +125,7 @@ func NewPeerInfo(peer *p2p.Peer, rw p2p.MsgReadWriter) *PeerInfo {
 		peer:      peer,
 		rw:        rw,
 		removed:   make(chan struct{}),
-		tasks:     make(chan func(), 16),
+		tasks:     make(chan func(), 32),
 		ctx:       ctx,
 		ctxCancel: cancel,
 	}


### PR DESCRIPTION
Current value: 16 was added by me 1 year ago and didn't mean anything. Never seen this field holding much data, probably can increase. 

Currently I see logs like (and 10x like this): 
```
[DBUG] [11-24|06:59:38.353] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.353] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.353] slow peer or too many requests, dropping its old requests name=bor/v1.0.0-beta/linu...
[DBUG] [11-24|06:59:38.467] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.469] slow peer or too many requests, dropping its old requests name=erigon/v2.51.0-a0160...
[DBUG] [11-24|06:59:38.469] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.469] slow peer or too many requests, dropping its old requests name=erigon/v2.53.4/linux...
[DBUG] [11-24|06:59:38.469] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.469] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0/linux...
[DBUG] [11-24|06:59:38.469] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.469] slow peer or too many requests, dropping its old requests name=bor/v1.1.0-beta4/lin...
[DBUG] [11-24|06:59:38.470] slow peer or too many requests, dropping its old requests name=erigon/v2.53.4/linux...
[DBUG] [11-24|06:59:38.470] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.470] slow peer or too many requests, dropping its old requests name=erigon/v2.53.4/linux...
[DBUG] [11-24|06:59:38.470] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.470] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=bor/v1.1.0-beta4/lin...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.53.4/linux...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=bor/v1.1.0/linux-amd...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=bor/v1.1.0-beta4/lin...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=bor/v1.1.0-beta4/lin...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.53.4/linux...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.53.4/linux...
[DBUG] [11-24|06:59:38.470] slow peer or too many requests, dropping its old requests name=bor/v1.0.0-beta/linu...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=bor/v1.1.0-beta4/lin...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=bor/v1.1.0/linux-amd...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=bor/v1.1.0-beta4/lin...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.469] slow peer or too many requests, dropping its old requests name=erigon/v2.51.0-a0160...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.53.4/linux...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.53.4-c4843...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=bor/v1.1.0/linux-amd...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=bor/v1.0.0-beta/linu...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.51.0-a0160...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=bor/v1.1.0-beta4/lin...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0/linux...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.51.0-a0160...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=bor/v1.0.0-beta/linu...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.53.4-c4843...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.53.4/linux...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=bor/v1.0.0-beta/linu...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.53.4/linux...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=bor/v1.0.0-beta/linu...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0/linux...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=bor/v1.1.0-beta4/lin...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v0.0.8-bor-04...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.51.0-a0160...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=bor/v1.1.0-beta4/lin...
[DBUG] [11-24|06:59:38.469] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0/linux...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.51.0-a0160...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=erigon/v2.53.4-c4843...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=erigon/v2.53.4/linux...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=bor/v1.1.0-beta4/lin...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=bor/v1.1.0/linux-amd...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=erigon/v2.51.0-a0160...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0/linux...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=bor/v1.0.0-beta/linu...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0/linux...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=bor/v1.1.0-beta4/lin...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=erigon/v2.53.4/linux...
[DBUG] [11-24|06:59:38.470] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=bor/v1.0.0-beta/linu...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=bor/v1.0.0-beta/linu...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=erigon/v2.53.4/linux...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=bor/v1.0.0-beta/linu...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=erigon/v2.51.0-a0160...
[DBUG] [11-24|06:59:38.473] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0/linux...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.471] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=erigon/v2.53.4-c4843...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.473] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.473] slow peer or too many requests, dropping its old requests name=erigon/v2.53.4-c4843...
[DBUG] [11-24|06:59:38.473] slow peer or too many requests, dropping its old requests name=bor/v1.0.0-beta/linu...
[DBUG] [11-24|06:59:38.473] slow peer or too many requests, dropping its old requests name=bor/v1.1.0-beta4/lin...
[DBUG] [11-24|06:59:38.473] slow peer or too many requests, dropping its old requests name=erigon/v2.53.4/linux...
[DBUG] [11-24|06:59:38.473] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.473] slow peer or too many requests, dropping its old requests name=bor/v1.0.0-beta/linu...
[DBUG] [11-24|06:59:38.473] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0/linux...
[DBUG] [11-24|06:59:38.473] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.473] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.473] slow peer or too many requests, dropping its old requests name=bor/v1.1.0-beta4/lin...
[DBUG] [11-24|06:59:38.473] slow peer or too many requests, dropping its old requests name=erigon/v2.53.4-c4843...
[DBUG] [11-24|06:59:38.473] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.473] slow peer or too many requests, dropping its old requests name=erigon/v2.53.4/linux...
[DBUG] [11-24|06:59:38.473] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.473] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.473] slow peer or too many requests, dropping its old requests name=bor/v1.1.0-beta4/lin...
[DBUG] [11-24|06:59:38.472] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.473] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.473] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.474] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.474] slow peer or too many requests, dropping its old requests name=erigon/v2.53.4-c4843...
[DBUG] [11-24|06:59:38.474] slow peer or too many requests, dropping its old requests name=erigon/v2.54.0-aeec5...
[DBUG] [11-24|06:59:38.473] slow peer or too many requests, dropping its old requests name=bor/v1.0.0-beta/linu...
```