### PR TITLE
mdbx: hard-limit of small db's dirty_space 

### DIFF
--- a/core/genesis_write.go
+++ b/core/genesis_write.go
@@ -540,6 +540,7 @@ func GenesisToBlock(g *types.Genesis, tmpDir string) (*types.Block, *state.Intra
 	go func() { // we may run inside write tx, can't open 2nd write tx in same goroutine
 		// TODO(yperbasis): use memdb.MemoryMutation instead
 		defer wg.Done()
+
 		genesisTmpDB := mdbx.NewMDBX(log.New()).InMem(tmpDir).MapSize(2 * datasize.GB).GrowthStep(1 * datasize.MB).MustOpen()
 		defer genesisTmpDB.Close()
 		var tx kv.RwTx

--- a/erigon-lib/kv/mdbx/kv_mdbx.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx.go
@@ -150,6 +150,7 @@ func (opts MdbxOpts) InMem(tmpDir string) MdbxOpts {
 	opts.flags = mdbx.UtterlyNoSync | mdbx.NoMetaSync | mdbx.NoMemInit
 	opts.growthStep = 2 * datasize.MB
 	opts.mapSize = 512 * datasize.MB
+	opts.dirtySpace = uint64(128 * datasize.MB)
 	opts.shrinkThreshold = 0 // disable
 	opts.label = kv.InMem
 	return opts

--- a/erigon-lib/txpool/txpooluitl/all_components.go
+++ b/erigon-lib/txpool/txpooluitl/all_components.go
@@ -107,6 +107,7 @@ func AllComponents(ctx context.Context, cfg txpoolcfg.Config, cache kvcache.Cach
 		WriteMergeThreshold(3 * 8192).
 		PageSize(uint64(16 * datasize.KB)).
 		GrowthStep(16 * datasize.MB).
+		DirtySpace(uint64(128 * datasize.MB)).
 		MapSize(1 * datasize.TB)
 
 	if cfg.MdbxPageSize.Bytes() > 0 {

--- a/p2p/enode/nodedb.go
+++ b/p2p/enode/nodedb.go
@@ -119,6 +119,7 @@ func newPersistentDB(ctx context.Context, logger log.Logger, path string) (*DB, 
 		WithTableCfg(bucketsConfig).
 		MapSize(8 * datasize.GB).
 		GrowthStep(16 * datasize.MB).
+		DirtySpace(uint64(128 * datasize.MB)).
 		Flags(func(f uint) uint { return f ^ mdbx1.Durable | mdbx1.SafeNoSync }).
 		SyncPeriod(2 * time.Second).
 		Open(ctx)


### PR DESCRIPTION
it didn't cause problems yet. but it seems a good idea in-general.