### PR TITLE
allow disable file logging

### DIFF
--- a/turbo/logging/flags.go
+++ b/turbo/logging/flags.go
@@ -32,7 +32,10 @@ var (
 		Usage: "Set the log level for console logs",
 		Value: log.LvlInfo.String(),
 	}
-
+	LogDirDisableFlag = cli.BoolFlag{
+		Name:  "log.dir.disable",
+		Usage: "disable disk logging",
+	}
 	LogDirPathFlag = cli.StringFlag{
 		Name:  "log.dir.path",
 		Usage: "Path to store user and error logs to disk",
@@ -56,6 +59,7 @@ var Flags = []cli.Flag{
 	&LogDirJsonFlag,
 	&LogVerbosityFlag,
 	&LogConsoleVerbosityFlag,
+	&LogDirDisableFlag,
 	&LogDirPathFlag,
 	&LogDirPrefixFlag,
 	&LogDirVerbosityFlag,

--- a/turbo/logging/logging.go
+++ b/turbo/logging/logging.go
@@ -39,22 +39,25 @@ func SetupLoggerCtx(filePrefix string, ctx *cli.Context, rootHandler bool) log.L
 		dirLevel = log.LvlInfo
 	}
 
-	dirPath := ctx.String(LogDirPathFlag.Name)
-	if dirPath == "" {
-		datadir := ctx.String("datadir")
-		if datadir != "" {
-			dirPath = filepath.Join(datadir, "logs")
+	dirPath := ""
+	if !ctx.Bool(LogDirDisableFlag.Name) && dirPath != "/dev/null" {
+		dirPath = ctx.String(LogDirPathFlag.Name)
+		if dirPath == "" {
+			datadir := ctx.String("datadir")
+			if datadir != "" {
+				dirPath = filepath.Join(datadir, "logs")
+			}
+		}
+		if logDirPrefix := ctx.String(LogDirPrefixFlag.Name); len(logDirPrefix) > 0 {
+			filePrefix = logDirPrefix
 		}
 	}
+
 	var logger log.Logger
 	if rootHandler {
 		logger = log.Root()
 	} else {
 		logger = log.New()
-	}
-
-	if logDirPrefix := ctx.String(LogDirPrefixFlag.Name); len(logDirPrefix) > 0 {
-		filePrefix = logDirPrefix
 	}
 
 	initSeparatedLogging(logger, filePrefix, dirPath, consoleLevel, dirLevel, consoleJson, dirJson)
@@ -98,19 +101,25 @@ func SetupLoggerCmd(filePrefix string, cmd *cobra.Command) log.Logger {
 		dirLevel = log.LvlInfo
 	}
 
-	dirPath := cmd.Flags().Lookup(LogDirPathFlag.Name).Value.String()
-	if dirPath == "" {
-		datadirFlag := cmd.Flags().Lookup("datadir")
-		if datadirFlag != nil {
-			datadir := datadirFlag.Value.String()
-			if datadir != "" {
-				dirPath = filepath.Join(datadir, "logs")
+	dirPath := ""
+	disableFileLogging, err := cmd.Flags().GetBool(LogDirDisableFlag.Name)
+	if err != nil {
+		disableFileLogging = false
+	}
+	if !disableFileLogging && dirPath != "/dev/null" {
+		dirPath = cmd.Flags().Lookup(LogDirPathFlag.Name).Value.String()
+		if dirPath == "" {
+			datadirFlag := cmd.Flags().Lookup("datadir")
+			if datadirFlag != nil {
+				datadir := datadirFlag.Value.String()
+				if datadir != "" {
+					dirPath = filepath.Join(datadir, "logs")
+				}
 			}
 		}
-	}
-
-	if logDirPrefix := cmd.Flags().Lookup(LogDirPrefixFlag.Name).Value.String(); len(logDirPrefix) > 0 {
-		filePrefix = logDirPrefix
+		if logDirPrefix := cmd.Flags().Lookup(LogDirPrefixFlag.Name).Value.String(); len(logDirPrefix) > 0 {
+			filePrefix = logDirPrefix
+		}
 	}
 
 	initSeparatedLogging(log.Root(), filePrefix, dirPath, consoleLevel, dirLevel, consoleJson, dirJson)
@@ -177,7 +186,7 @@ func initSeparatedLogging(
 	logger.SetHandler(consoleHandler)
 
 	if len(dirPath) == 0 {
-		logger.Warn("no log dir set, console logging only")
+		logger.Info("console logging only")
 		return
 	}
 


### PR DESCRIPTION
allows the disabling of file logging using the new flag `--log.dir.disable`



NOTE: diagnostics tool logs WILL NOT function if this is set.

