### PR TITLE
flags: bump default value of db.size.limit to 12TB

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -746,7 +746,7 @@ var (
 	DbSizeLimitFlag = cli.StringFlag{
 		Name:  "db.size.limit",
 		Usage: "Runtime limit of chaindata db size. You can change value of this flag at any time.",
-		Value: (8 * datasize.TB).String(),
+		Value: (12 * datasize.TB).String(),
 	}
 	ForcePartialCommitFlag = cli.BoolFlag{
 		Name:  "force.partial.commit",


### PR DESCRIPTION
As per the [comment](https://github.com/ledgerwatch/erigon/pull/8869#issuecomment-1836645516) in PR #8869, 8 TB is actually not enough for Polygon.