### PR TITLE
silkworm: disable on incompatible Linux versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,11 @@ CGO_CFLAGS += -Wno-unknown-warning-option -Wno-enum-int-mismatch -Wno-strict-pro
 
 # about netgo see: https://github.com/golang/go/issues/30310#issuecomment-471669125 and https://github.com/golang/go/issues/57757
 BUILD_TAGS = nosqlite,noboltdb
+
+ifneq ($(shell "$(CURDIR)/turbo/silkworm/silkworm_compat_check.sh"),)
+	BUILD_TAGS := "$(BUILD_TAGS),nosilkworm"
+endif
+
 PACKAGE = github.com/ledgerwatch/erigon
 
 GO_FLAGS += -trimpath -tags $(BUILD_TAGS) -buildvcs=false

--- a/turbo/silkworm/silkworm_compat_check.sh
+++ b/turbo/silkworm/silkworm_compat_check.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -e
+set -u
+set -o pipefail
+
+OS_RELEASE_PATH=/etc/os-release
+
+function glibc_version {
+    cmd="ldd --version"
+    $cmd | head -1 | awk '{ print $NF }'
+}
+
+function version_major {
+    IFS='.' read -a components <<< "$1"
+    echo "${components[0]}"
+}
+
+function version_minor {
+    IFS='.' read -a components <<< "$1"
+    echo "${components[1]}"
+}
+
+case $(uname -s) in
+	Linux)
+		if [[ ! -f "$OS_RELEASE_PATH" ]]
+		then
+			echo "not supported Linux without $OS_RELEASE_PATH"
+			exit 2
+		fi
+
+		source "$OS_RELEASE_PATH"
+
+        if [[ -n "$ID" ]] && [[ -n "$VERSION_ID" ]]
+        then
+            version=$(version_major "$VERSION_ID")
+            case "$ID" in
+                "debian")
+                    if (( version < 12 ))
+                    then
+                        echo "not supported Linux version: $ID $VERSION_ID"
+                        exit 3
+                    fi
+                    ;;
+                "ubuntu")
+                    if (( version < 22 ))
+                    then
+                        echo "not supported Linux version: $ID $VERSION_ID"
+                        exit 3
+                    fi
+                    ;;
+            esac
+        fi
+
+        version=$(version_minor "$(glibc_version)")
+        if (( version < 34 ))
+        then
+            echo "not supported glibc version: $version"
+            exit 4
+        fi
+
+		;;
+	Darwin)
+		;;
+	*)
+		echo "unsupported OS"
+		exit 1
+		;;
+esac


### PR DESCRIPTION
Silkworm built on Ubuntu 22 depends on glibc 2.34. In order to run on an older OS, Silkworm needs to be built and linked with an older glibc, but to build on an older OS we need a compatible compiler. Silkworm requires gcc 11+ that is not available on Ubuntu 20 or Debian 11.

To simplify the deployment disable Silkworm support on versions before Ubuntu 22, Debian 12, and glibc prior to 2.34. The check for Ubuntu and Debian is explicit, because some Ubuntu 16 installations report glibc 2.35 with ldd, but `go build` still uses an older system one and fails.
