### PR TITLE
update outdated information

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,10 +194,7 @@ Support only remote-miners.
   , `--miner.gastarget`
 * JSON-RPC supports methods: eth_coinbase , eth_hashrate, eth_mining, eth_getWork, eth_submitWork, eth_submitHashrate
 * JSON-RPC supports websocket methods: newPendingTransaction
-* TODO:
-    + we don't broadcast mined blocks to p2p-network
-      yet, [but it's easy to accomplish](https://github.com/ledgerwatch/erigon/blob/9b8cdc0f2289a7cef78218a15043de5bdff4465e/eth/downloader/downloader.go#L673)
-    + websocket Logs
+
 
 <code> 🔬 Detailed explanation is [here](/docs/mining.md).</code>
 

--- a/README.md
+++ b/README.md
@@ -197,9 +197,6 @@ Support only remote-miners.
 * TODO:
     + we don't broadcast mined blocks to p2p-network
       yet, [but it's easy to accomplish](https://github.com/ledgerwatch/erigon/blob/9b8cdc0f2289a7cef78218a15043de5bdff4465e/eth/downloader/downloader.go#L673)
-    + eth_newPendingTransactionFilter
-    + eth_newBlockFilter
-    + eth_newFilter
     + websocket Logs
 
 <code> 🔬 Detailed explanation is [here](/docs/mining.md).</code>

--- a/docs/mining.md
+++ b/docs/mining.md
@@ -24,7 +24,3 @@ to `integration state_stages` command:
 ```
 ./build/bin/integration state_stages --datadir=<datadir> --unwind=1 --unwind.every=2 --integrity.fast=false --integrity.slow=false --mine --miner.etherbase=<etherbase>
 ```
-
-* TODO:
-  + we don't broadcast mined blocks to p2p-network yet, [but it's easy to accomplish](https://github.com/ledgerwatch/erigon/blob/9b8cdc0f2289a7cef78218a15043de5bdff4465e/eth/downloader/downloader.go#L673)
-  + websocket Logs

--- a/docs/mining.md
+++ b/docs/mining.md
@@ -27,7 +27,4 @@ to `integration state_stages` command:
 
 * TODO:
   + we don't broadcast mined blocks to p2p-network yet, [but it's easy to accomplish](https://github.com/ledgerwatch/erigon/blob/9b8cdc0f2289a7cef78218a15043de5bdff4465e/eth/downloader/downloader.go#L673)
-  + eth_newPendingTransactionFilter
-  + eth_newBlockFilter
-  + eth_newFilter
   + websocket Logs


### PR DESCRIPTION
1. When running locally, found that these **TODO** json-rpc have been implemented. Updating these outdated information can make the document clearer.
```
curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_newBlockFilter","params":[],"id":1}' http://loca
lhost:8545
{"jsonrpc":"2.0","id":1,"result":"0x02000000000000009c49b60f431cabc7"}
```
2. [but it's easy to accomplish] Points to an obsolete message (https://github.com/ledgerwatch/erigon/blob/9b8cdc0f2289a7cef78218a15043de5bdff4465e/eth/downloader/downloader.go#L673) 