### PR TITLE
silkworm: check glibcpp compatibility

### DIFF
--- a/turbo/silkworm/silkworm_compat_check.sh
+++ b/turbo/silkworm/silkworm_compat_check.sh
@@ -11,6 +11,17 @@ function glibc_version {
     $cmd | head -1 | awk '{ print $NF }'
 }
 
+function glibcpp_version {
+    link_path=$(/sbin/ldconfig -p | grep libstdc++ | awk '{ print $NF }')
+    if [[ ! -L "$link_path" ]]
+    then
+        echo "0"
+    else
+        file_name=$(readlink "$link_path")
+        echo "${file_name##*.}"
+    fi
+}
+
 function version_major {
     IFS='.' read -a components <<< "$1"
     echo "${components[0]}"
@@ -57,6 +68,13 @@ case $(uname -s) in
         then
             echo "not supported glibc version: $version"
             exit 4
+        fi
+
+        version=$(glibcpp_version)
+        if (( version < 30 ))
+        then
+            echo "not supported glibcpp version: $version"
+            exit 5
         fi
 
 		;;


### PR DESCRIPTION
libsilkworm requires libstdc++.so.6.0.30, but Rocky Linux 9.3 has only libstdc++.so.6.0.29,
and `make erigon` produces an error about the GLIBCXX Version needed 3.4.30 (available 3.4.29).

see:
https://stackoverflow.com/questions/10354636/how-do-you-find-what-version-of-libstdc-library-is-installed-on-your-linux-mac
https://gcc.gnu.org/onlinedocs/libstdc++/manual/abi.html
