### PR TITLE
Adds access list sorting

### DIFF
--- a/eth/tracers/logger/access_list_tracer_test.go
+++ b/eth/tracers/logger/access_list_tracer_test.go
@@ -1,0 +1,40 @@
+package logger
+
+import (
+	"testing"
+
+	"github.com/ledgerwatch/erigon-lib/common"
+	types2 "github.com/ledgerwatch/erigon-lib/types"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	addr = common.BytesToAddress([]byte{0x01, 0x71})
+
+	slot1 = common.BytesToHash([]byte{0x01})
+	slot2 = common.BytesToHash([]byte{0x02})
+	slot3 = common.BytesToHash([]byte{0x03})
+	slot4 = common.BytesToHash([]byte{0x04})
+
+	ordered = types2.AccessList{{
+		Address: addr,
+		StorageKeys: []common.Hash{
+			slot1,
+			slot2,
+			slot3,
+			slot4,
+		},
+	}}
+)
+
+func TestTracer_AccessList_Order(t *testing.T) {
+	al := newAccessList()
+	al.addAddress(addr)
+	al.addSlot(addr, slot1)
+	al.addSlot(addr, slot4)
+	al.addSlot(addr, slot3)
+	al.addSlot(addr, slot2)
+	require.NotEqual(t, ordered, al.accessList())
+	require.Equal(t, ordered, al.accessListSorted())
+	require.True(t, al.Equal(al))
+}


### PR DESCRIPTION
Because access lists use maps with the `StorageKey` as the key, they are subject to inconsistent ordering in the results of the `.accessList()` method.

To get around this, an `accessListSorted` method has been added, and exposed with the same name. The `equal` method has also been exposed to allow for equality checks at this level outside of this module.