### PR TITLE
Allow proxy paths in Heimdall URL

### DIFF
--- a/consensus/bor/heimdall/client.go
+++ b/consensus/bor/heimdall/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"path"
 	"sort"
 	"time"
 
@@ -415,7 +416,7 @@ func makeURL(urlString, rawPath, rawQuery string) (*url.URL, error) {
 		return nil, err
 	}
 
-	u.Path = rawPath
+	u.Path = path.Join(u.Path, rawPath)
 	u.RawQuery = rawQuery
 
 	return u, err


### PR DESCRIPTION
Add paths to the hiemdall config URL when creating calls so that extra paths needs by, for example proxy servers are not stripped from the flag value passed into the process.