### PR TITLE
makefile: unquote silkworm build tag - to make it concatenatable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ endif
 BUILD_TAGS = nosqlite,noboltdb
 
 ifneq ($(shell "$(CURDIR)/turbo/silkworm/silkworm_compat_check.sh"),)
-	BUILD_TAGS := "$(BUILD_TAGS),nosilkworm"
+	BUILD_TAGS := $(BUILD_TAGS),nosilkworm
 endif
 
 PACKAGE = github.com/ledgerwatch/erigon


### PR DESCRIPTION
`--tags "a,b,nosilkworm",integration` doesn't work