### PR TITLE
Fix case when there are more than one matching libraries

### DIFF
--- a/turbo/silkworm/silkworm_compat_check.sh
+++ b/turbo/silkworm/silkworm_compat_check.sh
@@ -12,7 +12,7 @@ function glibc_version {
 }
 
 function glibcpp_version {
-    link_path=$(/sbin/ldconfig -p | grep libstdc++ | awk '{ print $NF }')
+    link_path=$(/sbin/ldconfig -p | grep libstdc++ | awk '{ print $NF }' | head -1)
     if [[ ! -L "$link_path" ]]
     then
         echo "0"


### PR DESCRIPTION
Small fix to the script for the scenario where more than one matching library can be returned. 
For example, the command `/sbin/ldconfig -p | grep libstdc++ | awk '{ print $NF }'` can result in

```
/lib/x86_64-linux-gnu/libstdc++.so.6
/lib32/libstdc++.so.6
```

which then fails the check `if [[ ! -L "$link_path" ]]`