### PR TITLE
Fixup bittorrent/webseed download logs after refactoring

### DIFF
--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -375,7 +375,7 @@ func (d *Downloader) ReCalcStats(interval time.Duration) {
 
 			d.logger.Log(d.verbosity, "[snapshots] progress", "file", t.Name(), "progress", fmt.Sprintf("%.2f%%", progress), "peers", len(peersOfThisFile), "webseeds", len(weebseedPeersOfThisFile))
 			isDiagEnabled := diagnostics.TypeOf(diagnostics.SegmentDownloadStatistics{}).Enabled()
-			if d.verbosity < log.LvlInfo || isDiagEnabled {
+			if d.verbosity >= log.LvlInfo || isDiagEnabled {
 
 				// more detailed statistic: download rate of each peer (for each file)
 				websRates := uint64(0)


### PR DESCRIPTION
After a refactoring, the detailed bittorrent vs webseeds log has disappeared