### PR TITLE
e35 commitment updates to domain wal

### DIFF
--- a/cmd/state/exec3/state.go
+++ b/cmd/state/exec3/state.go
@@ -204,6 +204,7 @@ func (rw *Worker) RunTxTaskNoLock(txTask *state.TxTask) {
 			rules = &chain.Rules{}
 			break
 		}
+
 		// Block initialisation
 		//fmt.Printf("txNum=%d, blockNum=%d, initialisation of the block\n", txTask.TxNum, txTask.BlockNum)
 		syscall := func(contract libcommon.Address, data []byte, ibs *state.IntraBlockState, header *types.Header, constCall bool) ([]byte, error) {

--- a/erigon-lib/commitment/hex_patricia_hashed.go
+++ b/erigon-lib/commitment/hex_patricia_hashed.go
@@ -1056,7 +1056,7 @@ func (hph *HexPatriciaHashed) fold() (err error) {
 		upCell.extLen = 0
 		upCell.downHashedLen = 0
 		if hph.branchBefore[row] {
-			_, err := hph.branchEncoder.CollectUpdate(updateKey, 0, hph.touchMap[row], 0, RetrieveCellNoop)
+			_, err := hph.CollectUpdate(updateKey, 0, hph.touchMap[row], 0, RetrieveCellNoop)
 			if err != nil {
 				return fmt.Errorf("failed to encode leaf node update: %w", err)
 			}
@@ -1084,7 +1084,7 @@ func (hph *HexPatriciaHashed) fold() (err error) {
 		upCell.fillFromLowerCell(cell, depth, hph.currentKey[upDepth:hph.currentKeyLen], nibble)
 		// Delete if it existed
 		if hph.branchBefore[row] {
-			_, err := hph.branchEncoder.CollectUpdate(updateKey, 0, hph.touchMap[row], 0, RetrieveCellNoop)
+			_, err := hph.CollectUpdate(updateKey, 0, hph.touchMap[row], 0, RetrieveCellNoop)
 			if err != nil {
 				return fmt.Errorf("failed to encode leaf node update: %w", err)
 			}
@@ -1157,7 +1157,7 @@ func (hph *HexPatriciaHashed) fold() (err error) {
 		var lastNibble int
 		var err error
 
-		lastNibble, err = hph.branchEncoder.CollectUpdate(updateKey, bitmap, hph.touchMap[row], hph.afterMap[row], cellGetter)
+		lastNibble, err = hph.CollectUpdate(updateKey, bitmap, hph.touchMap[row], hph.afterMap[row], cellGetter)
 		if err != nil {
 			return fmt.Errorf("failed to encode branch update: %w", err)
 		}
@@ -1304,7 +1304,7 @@ func (hph *HexPatriciaHashed) ProcessKeys(ctx context.Context, plainKeys [][]byt
 			return nil, ctx.Err()
 		case <-logEvery.C:
 			dbg.ReadMemStats(&m)
-			log.Info(logPrefix+"[agg] trie", "progress", fmt.Sprintf("%dk/%dk", i/1000, len(hashedKeys)/1000), "alloc", common.ByteCount(m.Alloc), "sys", common.ByteCount(m.Sys))
+			log.Info(fmt.Sprintf("[%s][agg] computing trie", logPrefix), "progress", fmt.Sprintf("%dk/%dk", i/1000, len(hashedKeys)/1000), "alloc", common.ByteCount(m.Alloc), "sys", common.ByteCount(m.Sys))
 		default:
 		}
 		plainKey := plainKeys[pks[string(hashedKey)]]
@@ -1375,13 +1375,57 @@ func (hph *HexPatriciaHashed) ProcessKeys(ctx context.Context, plainKeys [][]byt
 
 	defer func(t time.Time) { mxCommitmentWriteTook.ObserveDuration(t) }(time.Now())
 
-	// TODO we're using domain wals which order writes, and here we preorder them. Need to measure which approach
-	// is better in speed and memory consumption
-	err = hph.branchEncoder.Load(loadToPatriciaContextFunc(hph.ctx), etl.TransformArgs{Quit: ctx.Done()})
-	if err != nil {
-		return nil, err
+	if !commitmentWriteNoETL {
+		// TODO we're using domain wals which order writes, and here we preorder them. Need to measure which approach
+		// is better in speed and memory consumption
+		err = hph.branchEncoder.Load(loadToPatriciaContextFunc(hph.ctx), etl.TransformArgs{Quit: ctx.Done()})
+		if err != nil {
+			return nil, err
+		}
 	}
 	return rootHash, nil
+}
+
+const commitmentWriteNoETL = true
+
+func (hph *HexPatriciaHashed) CollectUpdate(
+	prefix []byte,
+	bitmap, touchMap, afterMap uint16,
+	readCell func(nibble int, skip bool) (*Cell, error),
+) (lastNibble int, err error) {
+
+	update, ln, err := hph.branchEncoder.EncodeBranch(bitmap, touchMap, afterMap, readCell)
+	if err != nil {
+		return 0, err
+	}
+	prev, err := hph.ctx.GetBranch(prefix) // prefix already compacted by fold
+	if err != nil {
+		return 0, err
+	}
+	if len(prev) > 0 {
+		previous := BranchData(prev)
+		merged, err := hph.branchMerger.Merge(previous, update)
+		if err != nil {
+			return 0, err
+		}
+		update = merged
+	}
+	// this updates ensures that if commitment is present, each branch are also present in commitment state at that moment with costs of storage
+	//fmt.Printf("commitment branch encoder merge prefix [%x] [%x]->[%x]\n%update\n", prefix, stateValue, update, BranchData(update).String())
+
+	cp, cu := common.Copy(prefix), common.Copy(update) // has to copy :(
+	if commitmentWriteNoETL {
+		if err = hph.ctx.PutBranch(cp, cu, prev); err != nil {
+			return 0, err
+		}
+	} else {
+		//fmt.Printf("CollectUpdate [%x] -> [%x]\n", prefix, []byte(update))
+		if err := hph.branchEncoder.updates.Collect(prefix, update); err != nil {
+			return 0, err
+		}
+	}
+	mxCommitmentBranchUpdates.Inc()
+	return ln, nil
 }
 
 func (hph *HexPatriciaHashed) ProcessUpdates(ctx context.Context, plainKeys [][]byte, updates []Update) (rootHash []byte, err error) {

--- a/erigon-lib/commitment/hex_patricia_hashed.go
+++ b/erigon-lib/commitment/hex_patricia_hashed.go
@@ -1386,6 +1386,7 @@ func (hph *HexPatriciaHashed) ProcessKeys(ctx context.Context, plainKeys [][]byt
 	return rootHash, nil
 }
 
+// if commitmentWriteNoETL is true, puts updates directly into domain, instead of buffering in ETL
 const commitmentWriteNoETL = true
 
 func (hph *HexPatriciaHashed) CollectUpdate(
@@ -1413,8 +1414,8 @@ func (hph *HexPatriciaHashed) CollectUpdate(
 	// this updates ensures that if commitment is present, each branch are also present in commitment state at that moment with costs of storage
 	//fmt.Printf("commitment branch encoder merge prefix [%x] [%x]->[%x]\n%update\n", prefix, stateValue, update, BranchData(update).String())
 
-	cp, cu := common.Copy(prefix), common.Copy(update) // has to copy :(
 	if commitmentWriteNoETL {
+		cp, cu := common.Copy(prefix), common.Copy(update) // has to copy :(
 		if err = hph.ctx.PutBranch(cp, cu, prev); err != nil {
 			return 0, err
 		}

--- a/erigon-lib/state/aggregator_test.go
+++ b/erigon-lib/state/aggregator_test.go
@@ -633,7 +633,7 @@ func testDbAndAggregatorv3(t *testing.T, aggStep uint64) (kv.RwDB, *AggregatorV3
 	require := require.New(t)
 	dirs := datadir.New(t.TempDir())
 	logger := log.New()
-	db := mdbx.NewMDBX(logger).InMem(dirs.Chaindata).WithTableCfg(func(defaultBuckets kv.TableCfg) kv.TableCfg {
+	db := mdbx.NewMDBX(logger).InMem(dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).WithTableCfg(func(defaultBuckets kv.TableCfg) kv.TableCfg {
 		return kv.ChaindataTablesCfg
 	}).MustOpen()
 	t.Cleanup(db.Close)

--- a/erigon-lib/state/domain_shared.go
+++ b/erigon-lib/state/domain_shared.go
@@ -265,7 +265,7 @@ func (sd *SharedDomains) ClearRam(resetCommitment bool) {
 }
 
 func (sd *SharedDomains) put(table kv.Domain, key string, val []byte) {
-	// disable mutex - becuse work on parallel execution postponed after E3 release.
+	// disable mutex - because work on parallel execution postponed after E3 release.
 	//sd.muMaps.Lock()
 	switch table {
 	case kv.AccountsDomain:
@@ -538,6 +538,8 @@ func (sd *SharedDomains) ComputeCommitment(ctx context.Context, saveStateAfter b
 // Such iteration is not intended to be used in public API, therefore it uses read-write transaction
 // inside the domain. Another version of this for public API use needs to be created, that uses
 // roTx instead and supports ending the iterations before it reaches the end.
+//
+// k and v lifetime is bounded by the lifetime of the iterator
 func (sd *SharedDomains) IterateStoragePrefix(prefix []byte, it func(k []byte, v []byte) error) error {
 	sc := sd.Storage.MakeContext()
 	defer sc.Close()

--- a/erigon-lib/state/domain_shared_test.go
+++ b/erigon-lib/state/domain_shared_test.go
@@ -257,7 +257,7 @@ func TestSharedDomain_StorageIter(t *testing.T) {
 
 			err = domains.DomainPut(kv.AccountsDomain, k0, nil, v, pv)
 			require.NoError(t, err)
-			binary.BigEndian.PutUint64(l0[16:24], uint64(i))
+			binary.BigEndian.PutUint64(l0[16:24], uint64(accs))
 
 			for locs := 0; locs < 15000; locs++ {
 				binary.BigEndian.PutUint64(l0[24:], uint64(locs))
@@ -313,19 +313,19 @@ func TestSharedDomain_StorageIter(t *testing.T) {
 
 		existed := make(map[string]struct{})
 		err = domains.IterateStoragePrefix(k0, func(k []byte, v []byte) error {
-			//fmt.Printf("%x\n", k)
 			existed[string(k)] = struct{}{}
 			return nil
 		})
+		require.NoError(t, err)
 
 		missed := 0
 		err = domains.IterateStoragePrefix(k0, func(k []byte, v []byte) error {
-			//fmt.Printf("%x\n", k)
 			if _, been := existed[string(k)]; !been {
 				missed++
 			}
 			return nil
 		})
+		require.NoError(t, err)
 		require.Zero(t, missed)
 
 		err = domains.deleteAccount(k0, pv)

--- a/erigon-lib/state/domain_shared_test.go
+++ b/erigon-lib/state/domain_shared_test.go
@@ -2,8 +2,12 @@ package state
 
 import (
 	"context"
+	"encoding/binary"
+	"fmt"
+	"github.com/ledgerwatch/log/v3"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/holiman/uint256"
 	"github.com/ledgerwatch/erigon-lib/kv"
@@ -212,3 +216,139 @@ func TestSharedDomain_IteratePrefix(t *testing.T) {
 	}
 }
 */
+
+func TestSharedDomain_StorageIter(t *testing.T) {
+	log.Root().SetHandler(log.LvlFilterHandler(log.LvlDebug, log.StderrHandler))
+
+	stepSize := uint64(10)
+	db, agg := testDbAndAggregatorv3(t, stepSize)
+
+	ctx := context.Background()
+	rwTx, err := db.BeginRw(ctx)
+	require.NoError(t, err)
+	defer rwTx.Rollback()
+
+	ac := agg.MakeContext()
+	defer ac.Close()
+
+	domains := NewSharedDomains(WrapTxWithCtx(rwTx, ac))
+	defer domains.Close()
+
+	maxTx := 3*stepSize + 10
+	hashes := make([][]byte, maxTx)
+
+	domains = NewSharedDomains(WrapTxWithCtx(rwTx, ac))
+	defer domains.Close()
+
+	i := 0
+	k0 := make([]byte, length.Addr)
+	l0 := make([]byte, length.Hash)
+	commitStep := 3
+	accounts := 1
+
+	for ; i < int(maxTx); i++ {
+		domains.SetTxNum(uint64(i))
+		for accs := 0; accs < accounts; accs++ {
+			v := types.EncodeAccountBytesV3(uint64(i), uint256.NewInt(uint64(i*10e6)+uint64(accs*10e2)), nil, 0)
+			k0[0] = byte(accs)
+
+			pv, err := domains.LatestAccount(k0)
+			require.NoError(t, err)
+
+			err = domains.DomainPut(kv.AccountsDomain, k0, nil, v, pv)
+			require.NoError(t, err)
+			binary.BigEndian.PutUint64(l0[16:24], uint64(i))
+
+			for locs := 0; locs < 15000; locs++ {
+				binary.BigEndian.PutUint64(l0[24:], uint64(locs))
+				pv, err := domains.LatestStorage(append(k0, l0...))
+				require.NoError(t, err)
+
+				err = domains.DomainPut(kv.StorageDomain, k0, l0, l0[24:], pv)
+				require.NoError(t, err)
+			}
+		}
+
+		if i%commitStep == 0 {
+			rh, err := domains.ComputeCommitment(ctx, true, domains.BlockNum(), "")
+			require.NoError(t, err)
+			if hashes[uint64(i)] != nil {
+				require.Equal(t, hashes[uint64(i)], rh)
+			}
+			require.NotNil(t, rh)
+			hashes[uint64(i)] = rh
+		}
+
+	}
+	fmt.Printf("calling build files step %d\n", maxTx/stepSize)
+	err = domains.Flush(ctx, rwTx)
+	require.NoError(t, err)
+	err = rwTx.Commit()
+	require.NoError(t, err)
+
+	err = agg.BuildFiles(maxTx - stepSize)
+	require.NoError(t, err)
+
+	err = db.Update(ctx, func(tx kv.RwTx) error {
+		return ac.PruneWithTimeout(ctx, 60*time.Minute, tx)
+	})
+	require.NoError(t, err)
+
+	ac.Close()
+
+	ac = agg.MakeContext()
+	defer ac.Close()
+	domains.Close()
+
+	rwTx, err = db.BeginRw(ctx)
+	require.NoError(t, err)
+
+	domains = NewSharedDomains(WrapTxWithCtx(rwTx, ac))
+	defer domains.Close()
+
+	for accs := 0; accs < accounts; accs++ {
+		k0[0] = byte(accs)
+		pv, err := domains.LatestAccount(k0)
+		require.NoError(t, err)
+
+		existed := make(map[string]struct{})
+		err = domains.IterateStoragePrefix(k0, func(k []byte, v []byte) error {
+			//fmt.Printf("%x\n", k)
+			existed[string(k)] = struct{}{}
+			return nil
+		})
+
+		missed := 0
+		err = domains.IterateStoragePrefix(k0, func(k []byte, v []byte) error {
+			//fmt.Printf("%x\n", k)
+			if _, been := existed[string(k)]; !been {
+				missed++
+			}
+			return nil
+		})
+		require.Zero(t, missed)
+
+		err = domains.deleteAccount(k0, pv)
+		require.NoError(t, err)
+
+		notRemoved := 0
+		err = domains.IterateStoragePrefix(k0, func(k []byte, v []byte) error {
+			notRemoved++
+			if _, been := existed[string(k)]; !been {
+				missed++
+			}
+			return nil
+		})
+		require.NoError(t, err)
+		require.Zero(t, missed)
+		require.Zero(t, notRemoved)
+	}
+	fmt.Printf("deleted\n")
+
+	err = domains.Flush(ctx, rwTx)
+	require.NoError(t, err)
+	rwTx.Rollback()
+
+	domains.Close()
+	ac.Close()
+}

--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -202,19 +202,20 @@ func ExecV3(ctx context.Context,
 		}
 	}
 
-	stageProgress := execStage.BlockNumber
-	var blockNum uint64
-	var maxTxNum uint64
-	outputTxNum := atomic.Uint64{}
-	blockComplete := atomic.Bool{}
-	blockComplete.Store(true)
-
 	// MA setio
 	doms := state2.NewSharedDomains(applyTx)
 	defer doms.Close()
 
-	var inputTxNum = doms.TxNum()
-	var offsetFromBlockBeginning uint64
+	var (
+		inputTxNum    = doms.TxNum()
+		stageProgress = execStage.BlockNumber
+		outputTxNum   = atomic.Uint64{}
+		blockComplete = atomic.Bool{}
+
+		offsetFromBlockBeginning uint64
+		blockNum, maxTxNum       uint64
+	)
+	blockComplete.Store(true)
 
 	nothingToExec := func(applyTx kv.Tx) (bool, error) {
 		_, lastTxNum, err := rawdbv3.TxNums.Last(applyTx)


### PR DESCRIPTION
this adds switch to write commitment either through etl or directly to domain WAL without pre-ordering. 