### PR TITLE
silkworm: make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,16 @@ git-submodules:
 	@git submodule sync --quiet --recursive || true
 	@git submodule update --quiet --init --recursive --force || true
 
+## install:                            copies binaries and libraries to DIST
+DIST ?= $(CURDIR)/build/dist
+.PHONY: install
+install:
+	mkdir -p "$(DIST)"
+	cp -f "$$($(CURDIR)/turbo/silkworm/silkworm_lib_path.sh)" "$(DIST)"
+	cp -f "$(GOBIN)/"* "$(DIST)"
+	@echo "Copied files to $(DIST):"
+	@ls -al "$(DIST)"
+
 PACKAGE_NAME          := github.com/ledgerwatch/erigon
 GOLANG_CROSS_VERSION  ?= v1.20.7
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/erigontech/mdbx-go v0.27.21
-	github.com/erigontech/silkworm-go v0.9.0
+	github.com/erigontech/silkworm-go v0.10.0
 	github.com/ledgerwatch/erigon-lib v1.0.0
 	github.com/ledgerwatch/log/v3 v3.9.0
 	github.com/ledgerwatch/secp256k1 v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -289,8 +289,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/erigontech/mdbx-go v0.27.21 h1:Pv47QIiRXR8Nv+nltZteLm4xkRwuvqmOCjzZj9X0s1A=
 github.com/erigontech/mdbx-go v0.27.21/go.mod h1:FAMxbOgqOnRDx51j8HjuJZIgznbDwjX7LItd+/UWyA4=
-github.com/erigontech/silkworm-go v0.9.0 h1:7f9DWkez2w9C2IbR/Dvx8iOknILzwUvuQ6sr+CUOyss=
-github.com/erigontech/silkworm-go v0.9.0/go.mod h1:O50ux0apICEVEGyRWiE488K8qz8lc3PA/SXbQQAc8SU=
+github.com/erigontech/silkworm-go v0.10.0 h1:oAoptLtJbQXk63mrKYs6qliQlbDrXTSNiZfzv1OMp+Q=
+github.com/erigontech/silkworm-go v0.10.0/go.mod h1:O50ux0apICEVEGyRWiE488K8qz8lc3PA/SXbQQAc8SU=
 github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c h1:CndMRAH4JIwxbW8KYq6Q+cGWcGHz0FjGR3QqcInWcW0=
 github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c/go.mod h1:AzA8Lj6YtixmJWL+wkKoBGsLWy9gFrAzi4g+5bCKwpY=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=

--- a/turbo/silkworm/silkworm_lib_path.sh
+++ b/turbo/silkworm/silkworm_lib_path.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -e
+set -u
+set -o pipefail
+
+script_dir=$(dirname "${BASH_SOURCE[0]}")
+project_dir=$(realpath "$script_dir/../..")
+go_cmd=go
+
+function os_name {
+	value=$(uname -s)
+	case $value in
+		Linux)
+			echo linux;;
+		Darwin)
+			echo macos;;
+		*)
+			echo "unsupported OS: $value"
+			exit 1;;
+	esac
+}
+
+function arch_name {
+	value=$(uname -m)
+	case $value in
+		arm64)
+			echo arm64;;
+		aarch64)
+			echo arm64;;
+		x86_64)
+			echo x64;;
+		*)
+			echo "unsupported CPU architecture: $value"
+			exit 1;;
+	esac
+}
+
+function lib_file_ext {
+    value=$(os_name)
+    case $value in
+        linux)
+            echo so;;
+        macos)
+            echo dylib;;
+		*)
+			echo "unsupported OS: $value"
+			exit 1;;
+    esac
+}
+
+function silkworm_go_version {
+    grep "silkworm-go" "$project_dir/go.mod" | awk '{ print $2 }'
+}
+
+function libsilkworm_path {
+    echo "$($go_cmd env GOMODCACHE)/github.com/erigontech/silkworm-go@$(silkworm_go_version)/lib/$(os_name)_$(arch_name)/libsilkworm_capi.$(lib_file_ext)"
+}
+
+libsilkworm_path


### PR DESCRIPTION
We've got a report from a user that erigon fails to run with this error:

```
/opt/erigon/releases/latest/bin/erigon: error while loading shared libraries: libsilkworm_capi.so: cannot open shared object file: No such file or directory
```

On this system erigon is executed using a service-account user which has no permission to access the build user's $HOME where the libsilkworm_capi.so resides (inside $GOPATH/pkg/mod).

This adds a support to silkworm-go to look for the library relative to the executable path on Linux:
https://github.com/erigontech/silkworm-go/commit/d4ec8a8bce96936a0cf8056dfafe790fa83ae486

and a new `make DIST=<path> install` command which copies both the library and erigon binary to any destination.
