### PR TITLE
harness test: to use `Mock` for genesis write - for e35 compatibility 

### DIFF
--- a/erigon-lib/state/aggregator_v3.go
+++ b/erigon-lib/state/aggregator_v3.go
@@ -242,6 +242,9 @@ func (a *AggregatorV3) HasBackgroundFilesBuild() bool { return a.ps.Has() }
 func (a *AggregatorV3) BackgroundProgress() string    { return a.ps.String() }
 
 func (a *AggregatorV3) Files() (res []string) {
+	if a == nil {
+		return res
+	}
 	a.filesMutationLock.Lock()
 	defer a.filesMutationLock.Unlock()
 
@@ -656,6 +659,9 @@ func (a *AggregatorV3) integrateFiles(sf AggV3StaticFiles, txNumFrom, txNumTo ui
 }
 
 func (a *AggregatorV3) HasNewFrozenFiles() bool {
+	if a == nil {
+		return false
+	}
 	return a.needSaveFilesListInDB.CompareAndSwap(true, false)
 }
 

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -99,7 +99,7 @@ var Defaults = Config{
 
 	ImportMode: false,
 	Snapshot: BlocksFreezing{
-		Enabled:    false,
+		Enabled:    true,
 		KeepBlocks: false,
 		Produce:    true,
 	},

--- a/eth/stagedsync/test/harness.go
+++ b/eth/stagedsync/test/harness.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/holiman/uint256"
+	"github.com/ledgerwatch/erigon/turbo/services"
+	"github.com/ledgerwatch/erigon/turbo/stages/mock"
 	"github.com/ledgerwatch/log/v3"
 	"github.com/stretchr/testify/require"
 
@@ -35,21 +37,16 @@ import (
 	"github.com/ledgerwatch/erigon/eth/ethconfig"
 	"github.com/ledgerwatch/erigon/eth/stagedsync"
 	"github.com/ledgerwatch/erigon/eth/stagedsync/stages"
-	"github.com/ledgerwatch/erigon/turbo/snapshotsync/freezeblocks"
 )
 
 func InitHarness(ctx context.Context, t *testing.T, logger log.Logger, cfg HarnessCfg) Harness {
-	chainDataDb := memdb.NewTestDB(t)
+	genesisInit := createGenesisInitData(t, cfg.ChainConfig)
+	m := mock.MockWithGenesis(t, genesisInit.genesis, genesisInit.genesisAllocPrivateKey, false)
+	chainDataDb := m.DB
+	blockReader := m.BlockReader
 	borConsensusDb := memdb.NewTestDB(t)
 	ctrl := gomock.NewController(t)
 	heimdallClient := heimdallmock.NewMockIHeimdallClient(ctrl)
-	snapshotsDir := t.TempDir()
-	blocksFreezingCfg := ethconfig.NewSnapCfg(true, true, true)
-	allRoSnapshots := freezeblocks.NewRoSnapshots(blocksFreezingCfg, snapshotsDir, logger)
-	allRoSnapshots.OptimisticalyReopenWithDB(chainDataDb)
-	allBorRoSnapshots := freezeblocks.NewBorRoSnapshots(blocksFreezingCfg, snapshotsDir, logger)
-	allBorRoSnapshots.OptimisticalyReopenWithDB(chainDataDb)
-	blockReader := freezeblocks.NewBlockReader(allRoSnapshots, allBorRoSnapshots)
 	bhCfg := stagedsync.StageBorHeimdallCfg(
 		chainDataDb,
 		borConsensusDb,
@@ -98,6 +95,7 @@ func InitHarness(ctx context.Context, t *testing.T, logger log.Logger, cfg Harne
 		borSpanner:       bormock.NewMockSpanner(ctrl),
 		validatorAddress: validatorAddress,
 		validatorKey:     validatorKey,
+		genesisInitData:  genesisInit,
 	}
 
 	if cfg.ChainConfig.Bor != nil {
@@ -113,6 +111,7 @@ func InitHarness(ctx context.Context, t *testing.T, logger log.Logger, cfg Harne
 
 type genesisInitData struct {
 	genesis                 *types.Genesis
+	genesisAllocPrivateKey  *ecdsa.PrivateKey
 	genesisAllocPrivateKeys map[libcommon.Address]*ecdsa.PrivateKey
 	fundedAddresses         []libcommon.Address
 }
@@ -127,7 +126,7 @@ type Harness struct {
 	chainDataDb                kv.RwDB
 	borConsensusDb             kv.RwDB
 	chainConfig                *chain.Config
-	blockReader                *freezeblocks.BlockReader
+	blockReader                services.BlockReader
 	stateSyncStages            []*stagedsync.Stage
 	stateSync                  *stagedsync.Sync
 	bhCfg                      stagedsync.BorHeimdallCfg
@@ -255,14 +254,16 @@ func (h *Harness) ReadFirstStateSyncEventNumPerBlockFromDb(ctx context.Context) 
 	return nums, nil
 }
 
-func (h *Harness) createGenesisInitData(t *testing.T) *genesisInitData {
+func createGenesisInitData(t *testing.T, chainConfig *chain.Config) *genesisInitData {
+	t.Helper()
 	accountPrivateKey, err := crypto.GenerateKey()
 	require.NoError(t, err)
 	accountAddress := crypto.PubkeyToAddress(accountPrivateKey.PublicKey)
 
-	h.genesisInitData = &genesisInitData{
+	return &genesisInitData{
+		genesisAllocPrivateKey: accountPrivateKey,
 		genesis: &types.Genesis{
-			Config: h.chainConfig,
+			Config: chainConfig,
 			Alloc: types.GenesisAlloc{
 				accountAddress: {
 					Balance: new(big.Int).Exp(big.NewInt(1_000), big.NewInt(18), nil),
@@ -276,15 +277,15 @@ func (h *Harness) createGenesisInitData(t *testing.T) *genesisInitData {
 			accountAddress,
 		},
 	}
-
-	return h.genesisInitData
 }
 
 func (h *Harness) generateChain(ctx context.Context, t *testing.T, ctrl *gomock.Controller, cfg HarnessCfg) {
-	genInitData := h.createGenesisInitData(t)
 	consensusEngine := h.consensusEngine(t, cfg)
-	genesisTmpDbDir := t.TempDir()
-	_, parentBlock, err := core.CommitGenesisBlock(h.chainDataDb, genInitData.genesis, genesisTmpDbDir, h.logger)
+	var parentBlock *types.Block
+	err := h.chainDataDb.View(ctx, func(tx kv.Tx) (err error) {
+		parentBlock, err = h.blockReader.BlockByNumber(ctx, tx, 0)
+		return err
+	})
 	require.NoError(t, err)
 	h.sealedHeaders[parentBlock.Number().Uint64()] = parentBlock.Header()
 	mockChainHR := h.mockChainHeaderReader(ctrl)


### PR DESCRIPTION
`e35` doesn't write genesis state by special func anymore - and Mock using `m.InsertBlocks` to process genesis block (as any other block). 