### PR TITLE
rpc: add `txHash` to  `debug_traceBlock*` results

### DIFF
--- a/turbo/jsonrpc/gen_traces_test.go
+++ b/turbo/jsonrpc/gen_traces_test.go
@@ -49,6 +49,7 @@ func TestGeneratedDebugApi(t *testing.T) {
 	expectedJSON := `
 	[
 		{
+		  "txHash": "0xb42edc1d46932ef34be0ba49402dc94e3d2319c066f02945f6828cd344fcfa7b",
 		  "result": {
 			"calls": [
 			  {

--- a/turbo/jsonrpc/tracing.go
+++ b/turbo/jsonrpc/tracing.go
@@ -111,6 +111,9 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 
 	for idx, txn := range txns {
 		stream.WriteObjectStart()
+		stream.WriteObjectField("txHash")
+		stream.WriteString(txn.Hash().Hex())
+		stream.WriteMore()
 		stream.WriteObjectField("result")
 		select {
 		default:


### PR DESCRIPTION
See https://github.com/ethereum/go-ethereum/pull/27183