### PR TITLE
db migration: if stage_snapshots > 0, then create prohibit_new_downloads.lock file

### DIFF
--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -140,13 +140,13 @@ func New(ctx context.Context, cfg *downloadercfg.Cfg, dirs datadir.Dirs, logger 
 	return d, nil
 }
 
-const prohibitNewDownloadsFileName = "prohibit_new_downloads.lock"
+const ProhibitNewDownloadsFileName = "prohibit_new_downloads.lock"
 
 // Erigon "download once" - means restart/upgrade/downgrade will not download files (and will be fast)
 // After "download once" - Erigon will produce and seed new files
 // Downloader will able: seed new files (already existing on FS), download uncomplete parts of existing files (if Verify found some bad parts)
 func (d *Downloader) prohibitNewDownloads() error {
-	fPath := filepath.Join(d.SnapDir(), prohibitNewDownloadsFileName)
+	fPath := filepath.Join(d.SnapDir(), ProhibitNewDownloadsFileName)
 	f, err := os.Create(fPath)
 	if err != nil {
 		return err
@@ -158,7 +158,7 @@ func (d *Downloader) prohibitNewDownloads() error {
 	return nil
 }
 func (d *Downloader) newDownloadsAreProhibited() bool {
-	return dir.FileExist(filepath.Join(d.SnapDir(), prohibitNewDownloadsFileName))
+	return dir.FileExist(filepath.Join(d.SnapDir(), ProhibitNewDownloadsFileName))
 }
 
 func (d *Downloader) MainLoopInBackground(silent bool) {

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/ledgerwatch/erigon-lib/common"
 	"path/filepath"
+
+	"github.com/ledgerwatch/erigon-lib/common"
 
 	"github.com/ledgerwatch/erigon-lib/common/datadir"
 	"github.com/ledgerwatch/erigon-lib/kv"
@@ -35,6 +36,7 @@ var migrations = map[kv.Label][]Migration{
 		dbSchemaVersion5,
 		TxsBeginEnd,
 		TxsV3,
+		ProhibitNewDownloadsLock,
 	},
 	kv.TxPoolDB: {},
 	kv.SentryDB: {},

--- a/migrations/prohibit_new_downloads_lock.go
+++ b/migrations/prohibit_new_downloads_lock.go
@@ -1,0 +1,42 @@
+package migrations
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/ledgerwatch/erigon-lib/common/datadir"
+	"github.com/ledgerwatch/erigon-lib/common/dir"
+	"github.com/ledgerwatch/erigon-lib/downloader"
+	"github.com/ledgerwatch/erigon-lib/kv"
+	"github.com/ledgerwatch/log/v3"
+)
+
+var ProhibitNewDownloadsLock = Migration{
+	Name: "prohibit_new_downloads_lock",
+	Up: func(db kv.RwDB, dirs datadir.Dirs, progress []byte, BeforeCommit Callback, logger log.Logger) (err error) {
+		tx, err := db.BeginRw(context.Background())
+		if err != nil {
+			return err
+		}
+		defer tx.Rollback()
+
+		fPath := filepath.Join(dirs.Snap, downloader.ProhibitNewDownloadsFileName)
+		if !dir.FileExist(fPath) {
+			f, err := os.Create(fPath)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			if err := f.Sync(); err != nil {
+				return err
+			}
+		}
+
+		// This migration is no-op, but it forces the migration mechanism to apply it and thus write the DB schema version info
+		if err := BeforeCommit(tx, nil, true); err != nil {
+			return err
+		}
+		return tx.Commit()
+	},
+}

--- a/migrations/prohibit_new_downloads_lock.go
+++ b/migrations/prohibit_new_downloads_lock.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ledgerwatch/erigon-lib/common/dir"
 	"github.com/ledgerwatch/erigon-lib/downloader"
 	"github.com/ledgerwatch/erigon-lib/kv"
+	"github.com/ledgerwatch/erigon/eth/stagedsync/stages"
 	"github.com/ledgerwatch/log/v3"
 )
 
@@ -21,15 +22,21 @@ var ProhibitNewDownloadsLock = Migration{
 		}
 		defer tx.Rollback()
 
-		fPath := filepath.Join(dirs.Snap, downloader.ProhibitNewDownloadsFileName)
-		if !dir.FileExist(fPath) {
-			f, err := os.Create(fPath)
-			if err != nil {
-				return err
-			}
-			defer f.Close()
-			if err := f.Sync(); err != nil {
-				return err
+		snapshotsStageProgress, err := stages.GetStageProgress(tx, stages.Snapshots)
+		if err != nil {
+			return err
+		}
+		if snapshotsStageProgress > 0 {
+			fPath := filepath.Join(dirs.Snap, downloader.ProhibitNewDownloadsFileName)
+			if !dir.FileExist(fPath) {
+				f, err := os.Create(fPath)
+				if err != nil {
+					return err
+				}
+				defer f.Close()
+				if err := f.Sync(); err != nil {
+					return err
+				}
 			}
 		}
 


### PR DESCRIPTION
it will protect existing nodes from downloading `v2` files - even if they do upgrade