### PR TITLE
Update Ethereum Mainnet storage requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ in `erigon --help`). We don't allow change this flag after first start.
 System Requirements
 ===================
 
-* For an Archive node of Ethereum Mainnet we recommend >=3TB storage space: 1.8TB state (as of March 2022),
-  200GB temp files (can symlink or mount folder `<datadir>/temp` to another disk). Ethereum Mainnet Full node (
+* For an Archive node of Ethereum Mainnet we recommend >=3.5TB storage space: 2.2TB state (as of December 2023),
+  470GB snapshots (can symlink or mount folder `<datadir>/snapshots` to another disk), 200GB temp files (can symlink or mount folder `<datadir>/temp` to another disk). Ethereum Mainnet Full node (
   see `--prune*` flags): 400Gb (April 2022).
 
 * Goerli Full node (see `--prune*` flags): 189GB on Beta, 114GB on Alpha (April 2022).


### PR DESCRIPTION
Sync from scratch took about 4 days 15 hours, with total disk used about 2.8TB

```
ubuntu@localhost:/erigon$ cast block-number
18825796
ubuntu@localhost:/erigon$ ls
chaindata  downloader  jwt.hex  LOCK  nodekey  nodes  snapshots  temp  txpool
ubuntu@localhost:/erigon$ du -hs chaindata
2.2T    chaindata
ubuntu@localhost:/erigon$ du -hs downloader
17M     downloader
ubuntu@localhost:/erigon$ du -hs snapshots
473G    snapshots
ubuntu@localhost:/erigon$ du -hs temp
79G     temp
```