### PR TITLE
webseed: remove dependency on db state

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1190,22 +1190,12 @@ func (s *Ethereum) setUpSnapDownloader(ctx context.Context, downloaderCfg *downl
 	if s.config.Snapshot.NoDownloader {
 		return nil
 	}
-	var discover bool
-	if err := s.chainDB.View(ctx, func(tx kv.Tx) error {
-		p, err := stages.GetStageProgress(tx, stages.Snapshots)
-		if err != nil {
-			return err
-		}
-		discover = p == 0
-		return nil
-	}); err != nil {
-		return err
-	}
 	if s.config.Snapshot.DownloaderAddr != "" {
 		// connect to external Downloader
 		s.downloaderClient, err = downloadergrpc.NewClient(ctx, s.config.Snapshot.DownloaderAddr)
 	} else {
 		// start embedded Downloader
+		discover := true
 		s.downloader, err = downloader3.New(ctx, downloaderCfg, s.config.Dirs, s.logger, log.LvlDebug, discover)
 		if err != nil {
 			return err


### PR DESCRIPTION
erigon didn't download form webseeds if StageSnapshots progress > 0. but sometime we want "just delete files and re-download them"