### PR TITLE
mode to produce block snapshots

### DIFF
--- a/erigon-lib/common/dbg/dbg_env.go
+++ b/erigon-lib/common/dbg/dbg_env.go
@@ -1,0 +1,57 @@
+package dbg
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/c2h5oh/datasize"
+)
+
+func EnvString(envVarName string, defaultVal string) string {
+	v, _ := os.LookupEnv(envVarName)
+	if v != "" {
+		fmt.Printf("[dbg] env %s=%s\n", envVarName, v)
+		return v
+	}
+	return defaultVal
+}
+func EnvBool(envVarName string, defaultVal bool) bool {
+	v, _ := os.LookupEnv(envVarName)
+	if v == "true" {
+		fmt.Printf("[dbg] env %s=%t\n", envVarName, true)
+		return true
+	}
+	if v == "false" {
+		fmt.Printf("[dbg] env %s=%t\n", envVarName, false)
+		return false
+	}
+	return defaultVal
+}
+func EnvInt(envVarName string, defaultVal int) int {
+	v, _ := os.LookupEnv(envVarName)
+	if v != "" {
+		i, err := strconv.Atoi(v)
+		if err != nil {
+			panic(err)
+		}
+		if i < 0 || i > 4 {
+			panic(i)
+		}
+		fmt.Printf("[dbg] env %s=%d\n", envVarName, i)
+		return i
+	}
+	return defaultVal
+}
+func EnvDataSize(envVarName string, defaultVal datasize.ByteSize) datasize.ByteSize {
+	v, _ := os.LookupEnv(envVarName)
+	if v != "" {
+		val, err := datasize.ParseString(v)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("[dbg] env %s=%s\n", envVarName, val)
+		return val
+	}
+	return defaultVal
+}

--- a/erigon-lib/common/dbg/experiments.go
+++ b/erigon-lib/common/dbg/experiments.go
@@ -26,6 +26,8 @@ import (
 	"github.com/ledgerwatch/log/v3"
 )
 
+var StagesOnlyBlocks = EnvBool("STAGES_ONLY_BLOCKS", false)
+
 var doMemstat = true
 
 func init() {

--- a/eth/stagedsync/default_stages.go
+++ b/eth/stagedsync/default_stages.go
@@ -3,6 +3,7 @@ package stagedsync
 import (
 	"context"
 
+	"github.com/ledgerwatch/erigon-lib/common/dbg"
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon/eth/ethconfig"
 	"github.com/ledgerwatch/erigon/eth/stagedsync/stages"
@@ -116,6 +117,7 @@ func DefaultStages(ctx context.Context,
 		{
 			ID:          stages.Execution,
 			Description: "Execute blocks w/o hash checks",
+			Disabled:    dbg.StagesOnlyBlocks,
 			Forward: func(firstCycle bool, badBlockUnwind bool, s *StageState, u Unwinder, tx kv.RwTx, logger log.Logger) error {
 				return SpawnExecuteBlocksStage(s, u, tx, 0, ctx, exec, firstCycle, logger)
 			},
@@ -129,7 +131,7 @@ func DefaultStages(ctx context.Context,
 		{
 			ID:          stages.HashState,
 			Description: "Hash the key in the state",
-			Disabled:    bodies.historyV3 && ethconfig.EnableHistoryV4InTest,
+			Disabled:    bodies.historyV3 || ethconfig.EnableHistoryV4InTest || dbg.StagesOnlyBlocks,
 			Forward: func(firstCycle bool, badBlockUnwind bool, s *StageState, u Unwinder, tx kv.RwTx, logger log.Logger) error {
 				return SpawnHashStateStage(s, tx, hashState, ctx, logger)
 			},
@@ -143,7 +145,7 @@ func DefaultStages(ctx context.Context,
 		{
 			ID:          stages.IntermediateHashes,
 			Description: "Generate intermediate hashes and computing state root",
-			Disabled:    bodies.historyV3 && ethconfig.EnableHistoryV4InTest,
+			Disabled:    bodies.historyV3 || ethconfig.EnableHistoryV4InTest || dbg.StagesOnlyBlocks,
 			Forward: func(firstCycle bool, badBlockUnwind bool, s *StageState, u Unwinder, tx kv.RwTx, logger log.Logger) error {
 				if exec.chainConfig.IsPrague(0) {
 					_, err := SpawnVerkleTrie(s, u, tx, trieCfg, ctx, logger)
@@ -166,7 +168,7 @@ func DefaultStages(ctx context.Context,
 			ID:                  stages.CallTraces,
 			Description:         "Generate call traces index",
 			DisabledDescription: "Work In Progress",
-			Disabled:            bodies.historyV3,
+			Disabled:            bodies.historyV3 || dbg.StagesOnlyBlocks,
 			Forward: func(firstCycle bool, badBlockUnwind bool, s *StageState, u Unwinder, tx kv.RwTx, logger log.Logger) error {
 				return SpawnCallTraces(s, tx, callTraces, ctx, logger)
 			},
@@ -180,7 +182,7 @@ func DefaultStages(ctx context.Context,
 		{
 			ID:          stages.AccountHistoryIndex,
 			Description: "Generate account history index",
-			Disabled:    bodies.historyV3,
+			Disabled:    bodies.historyV3 || dbg.StagesOnlyBlocks,
 			Forward: func(firstCycle bool, badBlockUnwind bool, s *StageState, u Unwinder, tx kv.RwTx, logger log.Logger) error {
 				return SpawnAccountHistoryIndex(s, tx, history, ctx, logger)
 			},
@@ -194,7 +196,7 @@ func DefaultStages(ctx context.Context,
 		{
 			ID:          stages.StorageHistoryIndex,
 			Description: "Generate storage history index",
-			Disabled:    bodies.historyV3,
+			Disabled:    bodies.historyV3 || dbg.StagesOnlyBlocks,
 			Forward: func(firstCycle bool, badBlockUnwind bool, s *StageState, u Unwinder, tx kv.RwTx, logger log.Logger) error {
 				return SpawnStorageHistoryIndex(s, tx, history, ctx, logger)
 			},
@@ -208,7 +210,7 @@ func DefaultStages(ctx context.Context,
 		{
 			ID:          stages.LogIndex,
 			Description: "Generate receipt logs index",
-			Disabled:    bodies.historyV3,
+			Disabled:    bodies.historyV3 || dbg.StagesOnlyBlocks,
 			Forward: func(firstCycle bool, badBlockUnwind bool, s *StageState, u Unwinder, tx kv.RwTx, logger log.Logger) error {
 				return SpawnLogIndex(s, tx, logIndex, ctx, 0, logger)
 			},
@@ -222,6 +224,7 @@ func DefaultStages(ctx context.Context,
 		{
 			ID:          stages.TxLookup,
 			Description: "Generate tx lookup index",
+			Disabled:    dbg.StagesOnlyBlocks,
 			Forward: func(firstCycle bool, badBlockUnwind bool, s *StageState, u Unwinder, tx kv.RwTx, logger log.Logger) error {
 				return SpawnTxLookup(s, tx, 0 /* toBlock */, txLookup, ctx, logger)
 			},


### PR DESCRIPTION
`STAGES_ONLY_BLOCKS=true` may help to produce BlockSnaps by Erigon2 on weak machines - it disabling all stages after StageSenders. 