### PR TITLE
Added sentry simulator implementation

### DIFF
--- a/cmd/silkworm_api/snapshot_idx.go
+++ b/cmd/silkworm_api/snapshot_idx.go
@@ -97,7 +97,7 @@ func buildIndex(cliCtx *cli.Context, dataDir string, snapshotPaths []string) err
 				jobProgress := &background.Progress{}
 				ps.Add(jobProgress)
 				defer ps.Delete(jobProgress)
-				return freezeblocks.HeadersIdx(ctx, chainConfig, segment.Path, segment.From, dirs.Tmp, jobProgress, logLevel, logger)
+				return freezeblocks.HeadersIdx(ctx, segment.Path, segment.From, dirs.Tmp, jobProgress, logLevel, logger)
 			})
 		case snaptype.Bodies:
 			g.Go(func() error {

--- a/p2p/sentry/simulator/sentry_simulator.go
+++ b/p2p/sentry/simulator/sentry_simulator.go
@@ -1,0 +1,454 @@
+package simulator
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/ledgerwatch/erigon-lib/chain/snapcfg"
+	"github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/downloader/snaptype"
+	"github.com/ledgerwatch/erigon-lib/gointerfaces"
+	sentry_if "github.com/ledgerwatch/erigon-lib/gointerfaces/sentry"
+	"github.com/ledgerwatch/erigon-lib/gointerfaces/types"
+	core_types "github.com/ledgerwatch/erigon/core/types"
+	"github.com/ledgerwatch/erigon/crypto"
+	"github.com/ledgerwatch/erigon/eth/ethconfig"
+	"github.com/ledgerwatch/erigon/eth/protocols/eth"
+	"github.com/ledgerwatch/erigon/p2p"
+	"github.com/ledgerwatch/erigon/p2p/discover/v4wire"
+	"github.com/ledgerwatch/erigon/p2p/enode"
+	"github.com/ledgerwatch/erigon/p2p/sentry"
+	"github.com/ledgerwatch/erigon/rlp"
+	"github.com/ledgerwatch/erigon/turbo/snapshotsync/freezeblocks"
+	"github.com/ledgerwatch/log/v3"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+type server struct {
+	sentry_if.UnimplementedSentryServer
+	ctx              context.Context
+	peers            map[[64]byte]*p2p.Peer
+	messageReceivers map[sentry_if.MessageId][]sentry_if.Sentry_MessagesServer
+	logger           log.Logger
+	//snapshotVersion  uint8
+	knownSnapshots  *freezeblocks.RoSnapshots
+	activeSnapshots *freezeblocks.RoSnapshots
+	blockReader     *freezeblocks.BlockReader
+	downloader      *TorrentClient
+}
+
+func newPeer(name string, caps []p2p.Cap) (*p2p.Peer, error) {
+	key, err := crypto.GenerateKey()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return p2p.NewPeer(enode.PubkeyToIDV4(&key.PublicKey), v4wire.EncodePubkey(&key.PublicKey), name, caps, true), nil
+}
+
+func NewSentry(ctx context.Context, chain string, snapshotLocation string, peerCount int, logger log.Logger) (sentry_if.SentryServer, error) {
+	peers := map[[64]byte]*p2p.Peer{}
+
+	for i := 0; i < peerCount; i++ {
+		peer, err := newPeer(fmt.Sprint("peer-", i), nil)
+
+		if err != nil {
+			return nil, err
+		}
+		peers[peer.Pubkey()] = peer
+	}
+
+	cfg := snapcfg.KnownCfg(chain)
+
+	knownSnapshots := freezeblocks.NewRoSnapshots(ethconfig.BlocksFreezing{
+		Enabled:      true,
+		Produce:      false,
+		NoDownloader: true,
+	}, "" /*s.snapshotVersion,*/, logger)
+
+	files := make([]string, 0, len(cfg.Preverified))
+
+	for _, item := range cfg.Preverified {
+		files = append(files, item.Name)
+	}
+
+	knownSnapshots.InitSegments(files)
+
+	//s.knownSnapshots.ReopenList([]string{ent2.Name()}, false)
+	activeSnapshots := freezeblocks.NewRoSnapshots(ethconfig.BlocksFreezing{
+		Enabled:      true,
+		Produce:      false,
+		NoDownloader: true,
+	}, snapshotLocation /*s.snapshotVersion,*/, logger)
+
+	if err := activeSnapshots.ReopenFolder(); err != nil {
+		return nil, err
+	}
+
+	downloader, err := NewTorrentClient(ctx, chain, snapshotLocation, logger)
+
+	if err != nil {
+		return nil, err
+	}
+
+	s := &server{
+		ctx:              ctx,
+		peers:            peers,
+		messageReceivers: map[sentry_if.MessageId][]sentry_if.Sentry_MessagesServer{},
+		knownSnapshots:   knownSnapshots,
+		activeSnapshots:  activeSnapshots,
+		blockReader:      freezeblocks.NewBlockReader(activeSnapshots, nil),
+		logger:           logger,
+		downloader:       downloader,
+	}
+
+	go func() {
+		<-ctx.Done()
+		s.Close()
+	}()
+
+	return s, nil
+}
+
+func (s *server) Close() {
+	s.downloader.Close()
+	if closer, ok := s.downloader.cfg.DefaultStorage.(interface{ Close() error }); ok {
+		closer.Close()
+	}
+	s.activeSnapshots.Close()
+}
+
+func (s *server) NodeInfo(context.Context, *emptypb.Empty) (*types.NodeInfoReply, error) {
+	return nil, fmt.Errorf("TODO")
+}
+
+func (s *server) PeerById(ctx context.Context, in *sentry_if.PeerByIdRequest) (*sentry_if.PeerByIdReply, error) {
+	peerId := sentry.ConvertH512ToPeerID(in.PeerId)
+
+	peer, ok := s.peers[peerId]
+
+	if !ok {
+		return nil, fmt.Errorf("unknown peer")
+	}
+
+	info := peer.Info()
+
+	return &sentry_if.PeerByIdReply{
+		Peer: &types.PeerInfo{
+			Id:             info.ID,
+			Name:           info.Name,
+			Enode:          info.Enode,
+			Enr:            info.ENR,
+			Caps:           info.Caps,
+			ConnLocalAddr:  info.Network.LocalAddress,
+			ConnRemoteAddr: info.Network.RemoteAddress,
+			ConnIsInbound:  info.Network.Inbound,
+			ConnIsTrusted:  info.Network.Trusted,
+			ConnIsStatic:   info.Network.Static,
+		},
+	}, nil
+}
+
+func (s *server) PeerCount(context.Context, *sentry_if.PeerCountRequest) (*sentry_if.PeerCountReply, error) {
+	return &sentry_if.PeerCountReply{Count: uint64(len(s.peers))}, nil
+}
+
+func (s *server) PeerEvents(*sentry_if.PeerEventsRequest, sentry_if.Sentry_PeerEventsServer) error {
+	return fmt.Errorf("TODO")
+}
+
+func (s *server) PeerMinBlock(context.Context, *sentry_if.PeerMinBlockRequest) (*emptypb.Empty, error) {
+	return nil, fmt.Errorf("TODO")
+}
+
+func (s *server) Peers(context.Context, *emptypb.Empty) (*sentry_if.PeersReply, error) {
+	reply := &sentry_if.PeersReply{}
+
+	for _, peer := range s.peers {
+		info := peer.Info()
+
+		reply.Peers = append(reply.Peers,
+			&types.PeerInfo{
+				Id:             info.ID,
+				Name:           info.Name,
+				Enode:          info.Enode,
+				Enr:            info.ENR,
+				Caps:           info.Caps,
+				ConnLocalAddr:  info.Network.LocalAddress,
+				ConnRemoteAddr: info.Network.RemoteAddress,
+				ConnIsInbound:  info.Network.Inbound,
+				ConnIsTrusted:  info.Network.Trusted,
+				ConnIsStatic:   info.Network.Static,
+			})
+	}
+
+	return reply, nil
+}
+
+func (s *server) SendMessageById(ctx context.Context, in *sentry_if.SendMessageByIdRequest) (*sentry_if.SentPeers, error) {
+	peerId := sentry.ConvertH512ToPeerID(in.PeerId)
+
+	if err := s.sendMessageById(ctx, peerId, in.Data); err != nil {
+		return nil, err
+	}
+
+	return &sentry_if.SentPeers{
+		Peers: []*types.H512{in.PeerId},
+	}, nil
+}
+
+func (s *server) sendMessageById(ctx context.Context, peerId [64]byte, messageData *sentry_if.OutboundMessageData) error {
+	peer, ok := s.peers[peerId]
+
+	if !ok {
+		return fmt.Errorf("unknown peer")
+	}
+
+	switch messageData.Id {
+	case sentry_if.MessageId_GET_BLOCK_HEADERS_65:
+		packet := &eth.GetBlockHeadersPacket{}
+		if err := rlp.DecodeBytes(messageData.Data, packet); err != nil {
+			return fmt.Errorf("failed to decode packet: %w", err)
+		}
+
+		go s.processGetBlockHeaders(ctx, peer, 0, packet)
+
+	case sentry_if.MessageId_GET_BLOCK_HEADERS_66:
+		packet := &eth.GetBlockHeadersPacket66{}
+		if err := rlp.DecodeBytes(messageData.Data, packet); err != nil {
+			return fmt.Errorf("failed to decode packet: %w", err)
+		}
+
+		go s.processGetBlockHeaders(ctx, peer, packet.RequestId, packet.GetBlockHeadersPacket)
+
+	default:
+		return fmt.Errorf("unhandled message id: %s", messageData.Id)
+	}
+
+	return nil
+}
+
+func (s *server) SendMessageByMinBlock(ctx context.Context, request *sentry_if.SendMessageByMinBlockRequest) (*sentry_if.SentPeers, error) {
+	return s.UnimplementedSentryServer.SendMessageByMinBlock(ctx, request)
+}
+
+func (s *server) SendMessageToAll(ctx context.Context, data *sentry_if.OutboundMessageData) (*sentry_if.SentPeers, error) {
+	sentPeers := &sentry_if.SentPeers{}
+
+	for _, peer := range s.peers {
+		peerKey := peer.Pubkey()
+
+		if err := s.sendMessageById(ctx, peerKey, data); err != nil {
+			return sentPeers, err
+		}
+
+		sentPeers.Peers = append(sentPeers.Peers, gointerfaces.ConvertBytesToH512(peerKey[:]))
+	}
+
+	return sentPeers, nil
+}
+
+func (s *server) SendMessageToRandomPeers(ctx context.Context, request *sentry_if.SendMessageToRandomPeersRequest) (*sentry_if.SentPeers, error) {
+	sentPeers := &sentry_if.SentPeers{}
+
+	var i uint64
+
+	for _, peer := range s.peers {
+		peerKey := peer.Pubkey()
+
+		if err := s.sendMessageById(ctx, peerKey, request.Data); err != nil {
+			return sentPeers, err
+		}
+
+		sentPeers.Peers = append(sentPeers.Peers, gointerfaces.ConvertBytesToH512(peerKey[:]))
+
+		i++
+
+		if i == request.MaxPeers {
+			break
+		}
+	}
+
+	return sentPeers, nil
+
+}
+
+func (s *server) Messages(request *sentry_if.MessagesRequest, receiver sentry_if.Sentry_MessagesServer) error {
+	for _, messageId := range request.Ids {
+		receivers := s.messageReceivers[messageId]
+		s.messageReceivers[messageId] = append(receivers, receiver)
+	}
+
+	<-s.ctx.Done()
+
+	return nil
+}
+
+func (s *server) processGetBlockHeaders(ctx context.Context, peer *p2p.Peer, requestId uint64, request *eth.GetBlockHeadersPacket) {
+	r65 := s.messageReceivers[sentry_if.MessageId_BLOCK_HEADERS_65]
+	r66 := s.messageReceivers[sentry_if.MessageId_BLOCK_HEADERS_66]
+
+	if len(r65)+len(r66) > 0 {
+
+		peerKey := peer.Pubkey()
+		peerId := gointerfaces.ConvertBytesToH512(peerKey[:])
+
+		headers, err := s.getHeaders(ctx, request.Origin, request.Amount, request.Skip, request.Reverse)
+
+		if err != nil {
+			s.logger.Warn("Can't get headers", "error", err)
+			return
+		}
+
+		if len(r65) > 0 {
+			var data bytes.Buffer
+
+			err := rlp.Encode(&data, headers)
+
+			if err != nil {
+				s.logger.Warn("Can't encode headers", "error", err)
+				return
+			}
+
+			for _, receiver := range r65 {
+				receiver.Send(&sentry_if.InboundMessage{
+					Id:     sentry_if.MessageId_BLOCK_HEADERS_65,
+					Data:   data.Bytes(),
+					PeerId: peerId,
+				})
+			}
+		}
+
+		if len(r66) > 0 {
+			var data bytes.Buffer
+
+			err := rlp.Encode(&data, &eth.BlockHeadersPacket66{
+				RequestId:          requestId,
+				BlockHeadersPacket: headers,
+			})
+
+			if err != nil {
+				fmt.Printf("Error (move to logger): %s", err)
+				return
+			}
+
+			for _, receiver := range r66 {
+				receiver.Send(&sentry_if.InboundMessage{
+					Id:     sentry_if.MessageId_BLOCK_HEADERS_66,
+					Data:   data.Bytes(),
+					PeerId: peerId,
+				})
+			}
+		}
+	}
+}
+
+func (s *server) getHeaders(ctx context.Context, origin eth.HashOrNumber, amount uint64, skip uint64, reverse bool) (eth.BlockHeadersPacket, error) {
+
+	var headers eth.BlockHeadersPacket
+
+	var next uint64
+
+	nextBlockNum := func(blockNum uint64) uint64 {
+		inc := uint64(1)
+
+		if skip != 0 {
+			inc = skip
+		}
+
+		if reverse {
+			return blockNum - inc
+		} else {
+			return blockNum + inc
+		}
+	}
+
+	if origin.Hash != (common.Hash{}) {
+		header, err := s.getHeaderByHash(ctx, origin.Hash)
+
+		if err != nil {
+			return nil, err
+		}
+
+		headers = append(headers, header)
+
+		next = nextBlockNum(header.Number.Uint64())
+	} else {
+		header, err := s.getHeader(ctx, origin.Number)
+
+		if err != nil {
+			return nil, err
+		}
+
+		headers = append(headers, header)
+
+		next = nextBlockNum(header.Number.Uint64())
+	}
+
+	for len(headers) < int(amount) {
+		header, err := s.getHeader(ctx, next)
+
+		if err != nil {
+			return nil, err
+		}
+
+		headers = append(headers, header)
+
+		next = nextBlockNum(header.Number.Uint64())
+	}
+
+	return headers, nil
+}
+
+func (s *server) getHeader(ctx context.Context, blockNum uint64) (*core_types.Header, error) {
+	header, err := s.blockReader.Header(ctx, nil, common.Hash{}, blockNum)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if header == nil {
+		view := s.knownSnapshots.View()
+		defer view.Close()
+
+		if seg, ok := view.HeadersSegment(blockNum); ok {
+			if err := s.downloadHeaders(ctx, seg); err != nil {
+				return nil, err
+			}
+		}
+
+		s.activeSnapshots.ReopenSegments([]snaptype.Type{snaptype.Headers})
+
+		header, err = s.blockReader.Header(ctx, nil, common.Hash{}, blockNum)
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return header, nil
+}
+
+func (s *server) getHeaderByHash(ctx context.Context, hash common.Hash) (*core_types.Header, error) {
+	return s.blockReader.HeaderByHash(ctx, nil, hash)
+}
+
+func (s *server) downloadHeaders(ctx context.Context, header *freezeblocks.HeaderSegment) error {
+	fileName := snaptype.SegmentFileName(header.From(), header.To(), snaptype.Headers)
+
+	s.logger.Info(fmt.Sprintf("Downloading %s", fileName))
+
+	err := s.downloader.Download(ctx, fileName)
+
+	if err != nil {
+		return fmt.Errorf("can't download %s: %w", fileName, err)
+	}
+
+	s.logger.Info(fmt.Sprintf("Indexing %s", fileName))
+
+	return freezeblocks.HeadersIdx(ctx,
+		filepath.Join(s.downloader.LocalFsRoot(), fileName), header.From(), s.downloader.LocalFsRoot(), nil, log.LvlDebug, s.logger)
+}

--- a/p2p/sentry/simulator/simulator_test.go
+++ b/p2p/sentry/simulator/simulator_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package simulator_test
 
 import (
@@ -15,6 +17,7 @@ import (
 )
 
 func TestSimulatorStart(t *testing.T) {
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	defer cancel()

--- a/p2p/sentry/simulator/simulator_test.go
+++ b/p2p/sentry/simulator/simulator_test.go
@@ -1,0 +1,200 @@
+package simulator_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/ledgerwatch/erigon-lib/direct"
+	"github.com/ledgerwatch/erigon-lib/gointerfaces/sentry"
+	sentry_if "github.com/ledgerwatch/erigon-lib/gointerfaces/sentry"
+	"github.com/ledgerwatch/erigon/eth/protocols/eth"
+	"github.com/ledgerwatch/erigon/p2p/sentry/simulator"
+	"github.com/ledgerwatch/erigon/rlp"
+	"github.com/ledgerwatch/log/v3"
+)
+
+func TestSimulatorStart(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	defer cancel()
+
+	logger := log.New()
+	logger.SetHandler(log.StdoutHandler)
+	dataDir := t.TempDir()
+
+	sim, err := simulator.NewSentry(ctx, "mumbai", dataDir, 1, logger)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	simClient := direct.NewSentryClientDirect(66, sim)
+
+	peerCount, err := simClient.PeerCount(ctx, &sentry.PeerCountRequest{})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if peerCount.Count != 1 {
+		t.Fatal("Invalid response count: expected:", 1, "got:", peerCount.Count)
+	}
+
+	receiver, err := simClient.Messages(ctx, &sentry.MessagesRequest{
+		Ids: []sentry.MessageId{sentry.MessageId_BLOCK_HEADERS_66},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	getHeaders66 := &eth.GetBlockHeadersPacket66{
+		RequestId: 1,
+		GetBlockHeadersPacket: &eth.GetBlockHeadersPacket{
+			Origin: eth.HashOrNumber{Number: 10},
+			Amount: 10,
+		},
+	}
+
+	var data bytes.Buffer
+
+	err = rlp.Encode(&data, getHeaders66)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	peers, err := simClient.SendMessageToAll(ctx, &sentry.OutboundMessageData{
+		Id:   sentry_if.MessageId_GET_BLOCK_HEADERS_66,
+		Data: data.Bytes(),
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(peers.Peers) != int(peerCount.Count) {
+		t.Fatal("Unexpected peer count expected:", peerCount.Count, len(peers.Peers))
+	}
+
+	message, err := receiver.Recv()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if message.Id != sentry_if.MessageId_BLOCK_HEADERS_66 {
+		t.Fatal("unexpected message id expected:", sentry_if.MessageId_BLOCK_HEADERS_66, "got:", message.Id)
+	}
+
+	var expectedPeer bool
+
+	for _, peer := range peers.Peers {
+		if message.PeerId.String() == peer.String() {
+			expectedPeer = true
+			break
+		}
+	}
+
+	if !expectedPeer {
+		t.Fatal("message received from unexpected peer:", message.PeerId)
+	}
+
+	packet := &eth.BlockHeadersPacket66{}
+
+	if err := rlp.DecodeBytes(message.Data, packet); err != nil {
+		t.Fatal("failed to decode packet:", err)
+	}
+
+	if len(packet.BlockHeadersPacket) != 10 {
+		t.Fatal("unexpected header count: expected:", 10, "got:", len(packet.BlockHeadersPacket))
+	}
+
+	blockNum := uint64(10)
+
+	for _, header := range packet.BlockHeadersPacket {
+		if header.Number.Uint64() != blockNum {
+			t.Fatal("unexpected block number: expected:", blockNum, "got:", header.Number)
+		}
+
+		blockNum++
+	}
+
+	simClient65 := direct.NewSentryClientDirect(65, sim)
+
+	getHeaders65 := &eth.GetBlockHeadersPacket{
+		Origin: eth.HashOrNumber{Number: 100},
+		Amount: 50,
+	}
+
+	data.Reset()
+
+	err = rlp.Encode(&data, getHeaders65)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	peers65, err := simClient65.SendMessageById(ctx, &sentry_if.SendMessageByIdRequest{
+		Data: &sentry.OutboundMessageData{
+			Id:   sentry_if.MessageId_GET_BLOCK_HEADERS_65,
+			Data: data.Bytes(),
+		},
+		PeerId: peers.Peers[0],
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(peers65.Peers) != 1 {
+		t.Fatal("message sent to unexpected number of peers:", len(peers65.Peers))
+	}
+
+	if peers65.Peers[0].String() != peers.Peers[0].String() {
+		t.Fatal("message sent to unexpected number of peers", peers65.Peers[0])
+	}
+
+	receiver65, err := simClient65.Messages(ctx, &sentry.MessagesRequest{
+		Ids: []sentry.MessageId{sentry.MessageId_BLOCK_HEADERS_65},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	message, err = receiver65.Recv()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if message.Id != sentry_if.MessageId_BLOCK_HEADERS_65 {
+		t.Fatal("unexpected message id expected:", sentry_if.MessageId_BLOCK_HEADERS_65, "got:", message.Id)
+	}
+
+	if message.PeerId.String() != peers.Peers[0].String() {
+		t.Fatal("message received from unexpected peer:", message.PeerId)
+	}
+
+	packet65 := eth.BlockHeadersPacket{}
+
+	if err := rlp.DecodeBytes(message.Data, &packet65); err != nil {
+		t.Fatal("failed to decode packet:", err)
+	}
+
+	if len(packet65) != 50 {
+		t.Fatal("unexpected header count: expected:", 50, "got:", len(packet.BlockHeadersPacket))
+	}
+
+	blockNum = uint64(100)
+
+	for _, header := range packet65 {
+		if header.Number.Uint64() != blockNum {
+			t.Fatal("unexpected block number: expected:", blockNum, "got:", header.Number)
+		}
+
+		blockNum++
+	}
+}

--- a/p2p/sentry/simulator/syncutil.go
+++ b/p2p/sentry/simulator/syncutil.go
@@ -1,0 +1,195 @@
+package simulator
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/anacrolix/torrent"
+	"github.com/anacrolix/torrent/metainfo"
+	"github.com/anacrolix/torrent/storage"
+	"github.com/c2h5oh/datasize"
+	"github.com/ledgerwatch/erigon-lib/chain/snapcfg"
+	"github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/common/datadir"
+	"github.com/ledgerwatch/erigon-lib/downloader"
+	"github.com/ledgerwatch/erigon-lib/downloader/downloadercfg"
+	"github.com/ledgerwatch/erigon-lib/downloader/snaptype"
+	"github.com/ledgerwatch/erigon/cmd/downloader/downloadernat"
+	"github.com/ledgerwatch/erigon/cmd/utils"
+	"github.com/ledgerwatch/erigon/p2p/nat"
+	"github.com/ledgerwatch/erigon/params"
+	"github.com/ledgerwatch/log/v3"
+	"golang.org/x/sync/errgroup"
+)
+
+// The code in this file is taken from cmd/snapshots - which is yet to be merged
+// to devel - once tthat is done this file can be removed
+
+type TorrentClient struct {
+	*torrent.Client
+	cfg   *torrent.ClientConfig
+	items map[string]snapcfg.PreverifiedItem
+}
+
+func NewTorrentClient(ctx context.Context, chain string, torrentDir string, logger log.Logger) (*TorrentClient, error) {
+
+	relativeDataDir := torrentDir
+	if torrentDir != "" {
+		var err error
+		absdatadir, err := filepath.Abs(torrentDir)
+		if err != nil {
+			panic(err)
+		}
+		torrentDir = absdatadir
+	}
+
+	dirs := datadir.Dirs{
+		RelativeDataDir: relativeDataDir,
+		DataDir:         torrentDir,
+		Snap:            torrentDir,
+	}
+
+	webseedsList := common.CliString2Array(utils.WebSeedsFlag.Value)
+
+	if known, ok := snapcfg.KnownWebseeds[chain]; ok {
+		webseedsList = append(webseedsList, known...)
+	}
+
+	var downloadRate, uploadRate datasize.ByteSize
+
+	if err := downloadRate.UnmarshalText([]byte(utils.TorrentDownloadRateFlag.Value)); err != nil {
+		return nil, err
+	}
+
+	if err := uploadRate.UnmarshalText([]byte(utils.TorrentUploadRateFlag.Value)); err != nil {
+		return nil, err
+	}
+
+	logLevel, _, err := downloadercfg.Int2LogLevel(utils.TorrentVerbosityFlag.Value)
+
+	if err != nil {
+		return nil, err
+	}
+
+	version := "erigon: " + params.VersionWithCommit(params.GitCommit)
+
+	cfg, err := downloadercfg.New(dirs, version, logLevel, downloadRate, uploadRate,
+		utils.TorrentPortFlag.Value, utils.TorrentConnsPerFileFlag.Value, 0, nil, webseedsList, chain)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if err := os.MkdirAll(torrentDir, 0755); err != nil {
+		return nil, err
+	}
+
+	cfg.ClientConfig.DataDir = torrentDir
+
+	cfg.ClientConfig.PieceHashersPerTorrent = 32 * runtime.NumCPU()
+	cfg.ClientConfig.DisableIPv6 = utils.DisableIPV6.Value
+	cfg.ClientConfig.DisableIPv4 = utils.DisableIPV4.Value
+
+	natif, err := nat.Parse(utils.NATFlag.Value)
+
+	if err != nil {
+		return nil, fmt.Errorf("invalid nat option %s: %w", utils.NATFlag.Value, err)
+	}
+
+	downloadernat.DoNat(natif, cfg.ClientConfig, logger)
+
+	cfg.ClientConfig.DefaultStorage = storage.NewMMap(torrentDir)
+
+	cli, err := torrent.NewClient(cfg.ClientConfig)
+
+	if err != nil {
+		return nil, fmt.Errorf("can't create torrent client: %w", err)
+	}
+
+	items := map[string]snapcfg.PreverifiedItem{}
+	for _, it := range snapcfg.KnownCfg(chain).Preverified {
+		items[it.Name] = it
+	}
+
+	return &TorrentClient{cli, cfg.ClientConfig, items}, nil
+}
+
+func (s *TorrentClient) LocalFsRoot() string {
+	return s.cfg.DataDir
+}
+
+func (s *TorrentClient) Download(ctx context.Context, files ...string) error {
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(len(files))
+
+	for _, f := range files {
+		file := f
+
+		g.Go(func() error {
+			it, ok := s.items[file]
+
+			if !ok {
+				return fs.ErrNotExist
+			}
+
+			t, err := func() (*torrent.Torrent, error) {
+				infoHash := snaptype.Hex2InfoHash(it.Hash)
+
+				for _, t := range s.Torrents() {
+					if t.Name() == file {
+						return t, nil
+					}
+				}
+
+				mi := &metainfo.MetaInfo{AnnounceList: downloader.Trackers}
+				magnet := mi.Magnet(&infoHash, &metainfo.Info{Name: file})
+				spec, err := torrent.TorrentSpecFromMagnetUri(magnet.String())
+
+				if err != nil {
+					return nil, err
+				}
+
+				spec.DisallowDataDownload = true
+
+				t, _, err := s.AddTorrentSpec(spec)
+				if err != nil {
+					return nil, err
+				}
+
+				return t, nil
+			}()
+
+			if err != nil {
+				return err
+			}
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-t.GotInfo():
+			}
+
+			if !t.Complete.Bool() {
+				t.AllowDataDownload()
+				t.DownloadAll()
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-t.Complete.On():
+				}
+			}
+
+			closed := t.Closed()
+			t.Drop()
+			<-closed
+
+			return nil
+		})
+	}
+
+	return g.Wait()
+}

--- a/turbo/snapshotsync/freezeblocks/block_snapshots_test.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots_test.go
@@ -200,11 +200,11 @@ func TestOpenAllSnapshot(t *testing.T) {
 
 	seg, ok := view.TxsSegment(10)
 	require.True(ok)
-	require.Equal(int(seg.ranges.to), 500_000)
+	require.Equal(int(seg.to), 500_000)
 
 	seg, ok = view.TxsSegment(500_000)
 	require.True(ok)
-	require.Equal(int(seg.ranges.to), 1_000_000)
+	require.Equal(int(seg.to), 1_000_000)
 
 	_, ok = view.TxsSegment(1_000_000)
 	require.False(ok)

--- a/turbo/snapshotsync/freezeblocks/bor_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/bor_snapshots.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/ledgerwatch/erigon/consensus/bor"
 	"os"
 	"path"
 	"path/filepath"
@@ -15,6 +14,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/ledgerwatch/erigon/consensus/bor"
 
 	"github.com/ledgerwatch/erigon-lib/chain"
 	"github.com/ledgerwatch/erigon-lib/chain/snapcfg"
@@ -40,7 +41,7 @@ import (
 type BorEventSegment struct {
 	seg           *compress.Decompressor // value: event_rlp
 	IdxBorTxnHash *recsplit.Index        // bor_transaction_hash  -> bor_event_segment_offset
-	ranges        Range
+	Range
 }
 
 func (sn *BorEventSegment) closeIdx() {
@@ -61,7 +62,7 @@ func (sn *BorEventSegment) close() {
 }
 func (sn *BorEventSegment) reopenSeg(dir string) (err error) {
 	sn.closeSeg()
-	fileName := snaptype.SegmentFileName(sn.ranges.from, sn.ranges.to, snaptype.BorEvents)
+	fileName := snaptype.SegmentFileName(sn.from, sn.to, snaptype.BorEvents)
 	sn.seg, err = compress.NewDecompressor(path.Join(dir, fileName))
 	if err != nil {
 		return fmt.Errorf("%w, fileName: %s", err, fileName)
@@ -74,7 +75,7 @@ func (sn *BorEventSegment) reopenIdx(dir string) (err error) {
 		return nil
 	}
 
-	fileName := snaptype.IdxFileName(sn.ranges.from, sn.ranges.to, snaptype.BorEvents.String())
+	fileName := snaptype.IdxFileName(sn.from, sn.to, snaptype.BorEvents.String())
 	sn.IdxBorTxnHash, err = recsplit.OpenIndex(path.Join(dir, fileName))
 	if err != nil {
 		return fmt.Errorf("%w, fileName: %s", err, fileName)
@@ -105,9 +106,9 @@ type borEventSegments struct {
 }
 
 type BorSpanSegment struct {
-	seg    *compress.Decompressor // value: span_json
-	idx    *recsplit.Index        // span_id -> offset
-	ranges Range
+	seg *compress.Decompressor // value: span_json
+	idx *recsplit.Index        // span_id -> offset
+	Range
 }
 
 func (sn *BorSpanSegment) closeIdx() {
@@ -128,7 +129,7 @@ func (sn *BorSpanSegment) close() {
 }
 func (sn *BorSpanSegment) reopenSeg(dir string) (err error) {
 	sn.closeSeg()
-	fileName := snaptype.SegmentFileName(sn.ranges.from, sn.ranges.to, snaptype.BorSpans)
+	fileName := snaptype.SegmentFileName(sn.from, sn.to, snaptype.BorSpans)
 	sn.seg, err = compress.NewDecompressor(path.Join(dir, fileName))
 	if err != nil {
 		return fmt.Errorf("%w, fileName: %s", err, fileName)
@@ -140,7 +141,7 @@ func (sn *BorSpanSegment) reopenIdx(dir string) (err error) {
 	if sn.seg == nil {
 		return nil
 	}
-	fileName := snaptype.IdxFileName(sn.ranges.from, sn.ranges.to, snaptype.BorSpans.String())
+	fileName := snaptype.IdxFileName(sn.from, sn.to, snaptype.BorSpans.String())
 	sn.idx, err = recsplit.OpenIndex(path.Join(dir, fileName))
 	if err != nil {
 		return fmt.Errorf("%w, fileName: %s", err, fileName)
@@ -689,13 +690,13 @@ func (s *BorRoSnapshots) idxAvailability() uint64 {
 		if seg.IdxBorTxnHash == nil {
 			break
 		}
-		events = seg.ranges.to - 1
+		events = seg.to - 1
 	}
 	for _, seg := range s.Spans.segments {
 		if seg.idx == nil {
 			break
 		}
-		spans = seg.ranges.to - 1
+		spans = seg.to - 1
 	}
 	return cmp.Min(events, spans)
 }
@@ -723,7 +724,7 @@ func (s *BorRoSnapshots) Files() (list []string) {
 		if seg.seg == nil {
 			continue
 		}
-		if seg.ranges.from > max {
+		if seg.from > max {
 			continue
 		}
 		_, fName := filepath.Split(seg.seg.FilePath())
@@ -733,7 +734,7 @@ func (s *BorRoSnapshots) Files() (list []string) {
 		if seg.seg == nil {
 			continue
 		}
-		if seg.ranges.from > max {
+		if seg.from > max {
 			continue
 		}
 		_, fName := filepath.Split(seg.seg.FilePath())
@@ -777,7 +778,7 @@ Loop:
 				}
 			}
 			if !exists {
-				sn = &BorEventSegment{ranges: Range{f.From, f.To}}
+				sn = &BorEventSegment{Range: Range{f.From, f.To}}
 			}
 			if err := sn.reopenSeg(s.dir); err != nil {
 				if errors.Is(err, os.ErrNotExist) {
@@ -817,7 +818,7 @@ Loop:
 				}
 			}
 			if !exists {
-				sn = &BorSpanSegment{ranges: Range{f.From, f.To}}
+				sn = &BorSpanSegment{Range: Range{f.From, f.To}}
 			}
 			if err := sn.reopenSeg(s.dir); err != nil {
 				if errors.Is(err, os.ErrNotExist) {
@@ -871,7 +872,7 @@ func (s *BorRoSnapshots) Ranges() (ranges []Range) {
 	defer view.Close()
 
 	for _, sn := range view.Events() {
-		ranges = append(ranges, sn.ranges)
+		ranges = append(ranges, sn.Range)
 	}
 	return ranges
 }
@@ -970,11 +971,11 @@ func (s *BorRoSnapshots) PrintDebug() {
 	defer s.Spans.lock.RUnlock()
 	fmt.Println("    == BorSnapshots, Event")
 	for _, sn := range s.Events.segments {
-		fmt.Printf("%d,  %t\n", sn.ranges.from, sn.IdxBorTxnHash == nil)
+		fmt.Printf("%d,  %t\n", sn.from, sn.IdxBorTxnHash == nil)
 	}
 	fmt.Println("    == BorSnapshots, Span")
 	for _, sn := range s.Spans.segments {
-		fmt.Printf("%d,  %t\n", sn.ranges.from, sn.idx == nil)
+		fmt.Printf("%d,  %t\n", sn.from, sn.idx == nil)
 	}
 }
 
@@ -1002,7 +1003,7 @@ func (v *BorView) Events() []*BorEventSegment { return v.s.Events.segments }
 func (v *BorView) Spans() []*BorSpanSegment   { return v.s.Spans.segments }
 func (v *BorView) EventsSegment(blockNum uint64) (*BorEventSegment, bool) {
 	for _, seg := range v.Events() {
-		if !(blockNum >= seg.ranges.from && blockNum < seg.ranges.to) {
+		if !(blockNum >= seg.from && blockNum < seg.to) {
 			continue
 		}
 		return seg, true
@@ -1011,7 +1012,7 @@ func (v *BorView) EventsSegment(blockNum uint64) (*BorEventSegment, bool) {
 }
 func (v *BorView) SpansSegment(blockNum uint64) (*BorSpanSegment, bool) {
 	for _, seg := range v.Spans() {
-		if !(blockNum >= seg.ranges.from && blockNum < seg.ranges.to) {
+		if !(blockNum >= seg.from && blockNum < seg.to) {
 			continue
 		}
 		return seg, true
@@ -1068,10 +1069,10 @@ func (m *BorMerger) filesByRange(snapshots *BorRoSnapshots, from, to uint64) (ma
 	sSegments := view.Spans()
 
 	for i, sn := range eSegments {
-		if sn.ranges.from < from {
+		if sn.from < from {
 			continue
 		}
-		if sn.ranges.to > to {
+		if sn.to > to {
 			break
 		}
 		toMerge[snaptype.BorEvents] = append(toMerge[snaptype.BorEvents], eSegments[i].seg.FilePath())


### PR DESCRIPTION
This adds a simulator object with implements the SentryServer api but takes objects from a pre-existing snapshot file.

If the snapshot is not available locally it will download and index the .seg file for the header range being asked for.

It is created as follows: 

```go
sim, err := simulator.NewSentry(ctx, "mumbai", dataDir, 1, logger)
```

Where the arguments are:

* ctx - a callable context where cancel will close the simulator torrent and file connections (it also has a Close method)
* chain - the name of the chain to take the snapshots from
 * datadir - a directory potentially containing snapshot .seg files.  If not files exist in this directory they will be downloaded
 *  num peers - the number of peers the simulator should create
 *  logger - the loger to log actions to

It can be attached to a client as follows:

```go
simClient := direct.NewSentryClientDirect(66, sim)
```

At the moment only very basic functionality is implemented:

* get headers will return headers by range or hash (hash assumes a pre-downloaded .seg as it needs an index
* the header replay semantics need to be confirmed
* eth 65 and 66(+) messaging is supported
* For details see: `simulator_test.go

More advanced peer behavior (e.g. header rewriting) can be added
Bodies/Transactions handling can be added
 