### PR TITLE
ots: fix GetBlockDetails rewards calculation on post-merge blocks

### DIFF
--- a/turbo/jsonrpc/otterscan_api.go
+++ b/turbo/jsonrpc/otterscan_api.go
@@ -514,6 +514,14 @@ func delegateIssuance(tx kv.Tx, block *types.Block, chainConfig *chain.Config) (
 		return internalIssuance{}, nil
 	}
 
+	if chainConfig.TerminalTotalDifficulty != nil {
+		isPos := block.HeaderNoCopy().Difficulty.Cmp(common.Big0) == 0 || block.HeaderNoCopy().Difficulty.Cmp(chainConfig.TerminalTotalDifficulty) >= 0
+		if isPos {
+			// No execution layer issuance in PoS
+			return internalIssuance{}, nil
+		}
+	}
+
 	minerReward, uncleRewards := ethash.AccumulateRewards(chainConfig, block.Header(), block.Uncles())
 	issuance := minerReward
 	for _, r := range uncleRewards {


### PR DESCRIPTION
Uses a PoS check identical to the one used by the other invocation of `AccumulateRewards` (https://github.com/ledgerwatch/erigon/blob/devel/turbo/jsonrpc/trace_filtering.go) to disable rewards after the TTD block has been reached.

This makes the block rewards returned by `ots_getBlockDetails` accurate.

For example, merge block 15537394:
```bash
curl -s --data '{"jsonrpc":"2.0","method":"ots_getBlockDetails","params":["0xed14f2"],"id":"1"}' -H "Content-Type: application/json" -X POST http://localhost:8545
```
will return
```
...
  "issuance": {},
...
```

Note: the PR merges into ots2-alpha4 rather than develop.

@wmitsuda 