### PR TITLE
chore(cmd/evm):fix link jump in cmd/evm/README.md

### DIFF
--- a/cmd/evm/README.md
+++ b/cmd/evm/README.md
@@ -214,7 +214,7 @@ exitcode:3 OK
 
 The chain configuration to be used for a transition is specified via the
 `--state.fork` CLI flag. A list of possible values and configurations can be
-found in [`tests/init.go`](tests/init.go).
+found in [`tests/init.go`](../../tests/init.go).
 
 #### Examples
 ##### Basic usage


### PR DESCRIPTION
fix the relative path in cmd/evm/README.md

![image](https://github.com/ledgerwatch/erigon/assets/24953789/058b0486-f8cf-4fa3-ad53-e01b5ea6f0c3)
