### PR TITLE
devnet: fix ws port clash for state-sync scenario

### DIFF
--- a/cmd/devnet/args/node_args.go
+++ b/cmd/devnet/args/node_args.go
@@ -9,14 +9,13 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/ledgerwatch/erigon-lib/chain/networkname"
+	"github.com/ledgerwatch/erigon/cmd/devnet/accounts"
+	"github.com/ledgerwatch/erigon/cmd/devnet/requests"
 	"github.com/ledgerwatch/erigon/core"
 	"github.com/ledgerwatch/erigon/crypto"
 	"github.com/ledgerwatch/erigon/p2p/enode"
 	"github.com/ledgerwatch/erigon/params"
-
-	"github.com/ledgerwatch/erigon-lib/chain/networkname"
-	"github.com/ledgerwatch/erigon/cmd/devnet/accounts"
-	"github.com/ledgerwatch/erigon/cmd/devnet/requests"
 )
 
 type NodeArgs struct {
@@ -42,7 +41,7 @@ type NodeArgs struct {
 	HttpCorsDomain            string `arg:"--http.corsdomain" json:"http.corsdomain"`
 	AuthRpcPort               int    `arg:"--authrpc.port" default:"8551" json:"authrpc.port"`
 	AuthRpcVHosts             string `arg:"--authrpc.vhosts" json:"authrpc.vhosts"`
-	WSPort                    int    `arg:"-" default:"8546" json:"-"` // flag not defined
+	WSPort                    int    `arg:"--ws.port" default:"8546" json:"ws.port"`
 	GRPCPort                  int    `arg:"-" default:"8547" json:"-"` // flag not defined
 	TCPPort                   int    `arg:"-" default:"8548" json:"-"` // flag not defined
 	Metrics                   bool   `arg:"--metrics" flag:"" default:"false" json:"metrics"`

--- a/cmd/devnet/args/node_args_test.go
+++ b/cmd/devnet/args/node_args_test.go
@@ -159,6 +159,7 @@ func producingNodeArgs(dataDir string, nodeNumber int) []string {
 	p2pProtocol, _ := parameterFromArgument("--p2p.protocol", "68")
 	downloaderArg, _ := parameterFromArgument("--no-downloader", "true")
 	httpPortArg, _ := parameterFromArgument("--http.port", "8545")
+	wsPortArg, _ := parameterFromArgument("--ws.port", "8546")
 	authrpcPortArg, _ := parameterFromArgument("--authrpc.port", "8551")
 	natArg, _ := parameterFromArgument("--nat", "none")
 	accountSlotsArg, _ := parameterFromArgument("--txpool.accountslots", "16")
@@ -170,6 +171,7 @@ func producingNodeArgs(dataDir string, nodeNumber int) []string {
 		chainType,
 		privateApiAddr,
 		httpPortArg,
+		wsPortArg,
 		authrpcPortArg,
 		mine,
 		httpApi,
@@ -196,6 +198,7 @@ func nonProducingNodeArgs(dataDir string, nodeNumber int, enode string) []string
 	p2pProtocol, _ := parameterFromArgument("--p2p.protocol", "68")
 	downloaderArg, _ := parameterFromArgument("--no-downloader", "true")
 	httpPortArg, _ := parameterFromArgument("--http.port", "8545")
+	wsPortArg, _ := parameterFromArgument("--ws.port", "8546")
 	httpApi, _ := parameterFromArgument(httpApiArg, "admin,eth,debug,net,trace,web3,erigon,txpool")
 	authrpcPortArg, _ := parameterFromArgument("--authrpc.port", "8551")
 	natArg, _ := parameterFromArgument("--nat", "none")
@@ -208,6 +211,7 @@ func nonProducingNodeArgs(dataDir string, nodeNumber int, enode string) []string
 		chainType,
 		privateApiAddr,
 		httpPortArg,
+		wsPortArg,
 		authrpcPortArg,
 		httpApi,
 		ws,

--- a/cmd/devnet/services/accounts/faucet.go
+++ b/cmd/devnet/services/accounts/faucet.go
@@ -60,7 +60,7 @@ func (d *deployer) deploy(ctx context.Context, node devnet.Node) {
 
 		d.faucet.deployer = nil
 		d.faucet.transactOpts = nil
-		logger.Error("failed to deploy faucet", "chain", d.faucet.chainName, "err", err)
+		logger.Error("failed while waiting to deploy faucet", "chain", d.faucet.chainName, "err", err)
 		return
 	}
 
@@ -92,7 +92,7 @@ func (d *deployer) deploy(ctx context.Context, node devnet.Node) {
 
 		d.faucet.deployer = nil
 		d.faucet.transactOpts = nil
-		logger.Error("failed to deploy faucet", "chain", d.faucet.chainName, "err", err)
+		logger.Error("failed while waiting to receive faucet funds", "chain", d.faucet.chainName, "err", err)
 		return
 	}
 
@@ -111,7 +111,7 @@ func NewFaucet(chainName string, source *accounts.Account) *Faucet {
 	}
 }
 
-func (f *Faucet) Start(context context.Context) error {
+func (f *Faucet) Start(_ context.Context) error {
 	return nil
 }
 
@@ -157,7 +157,7 @@ func (f *Faucet) Send(ctx context.Context, destination *accounts.Account, eth fl
 	}
 
 	if f.transactOpts == nil {
-		return nil, libcommon.Hash{}, fmt.Errorf("Faucet not initialized")
+		return nil, libcommon.Hash{}, fmt.Errorf("faucet not initialized")
 	}
 
 	node := devnet.SelectNode(ctx)
@@ -208,7 +208,7 @@ func (f *Faucet) Receive(ctx context.Context, source *accounts.Account, eth floa
 	return transactOpts.Value, trn.Hash(), nil
 }
 
-func (f *Faucet) NodeCreated(ctx context.Context, node devnet.Node) {
+func (f *Faucet) NodeCreated(_ context.Context, _ devnet.Node) {
 }
 
 func (f *Faucet) NodeStarted(ctx context.Context, node devnet.Node) {

--- a/cmd/devnet/services/polygon/heimdall.go
+++ b/cmd/devnet/services/polygon/heimdall.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ledgerwatch/log/v3"
+
 	ethereum "github.com/ledgerwatch/erigon"
 	"github.com/ledgerwatch/erigon-lib/chain"
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
@@ -21,7 +23,6 @@ import (
 	"github.com/ledgerwatch/erigon/consensus/bor/heimdall/span"
 	"github.com/ledgerwatch/erigon/consensus/bor/heimdallgrpc"
 	"github.com/ledgerwatch/erigon/consensus/bor/valset"
-	"github.com/ledgerwatch/log/v3"
 )
 
 type BridgeEvent string
@@ -292,7 +293,7 @@ func (h *Heimdall) NodeStarted(ctx context.Context, node devnet.Node) {
 			h.Unlock()
 			h.unsubscribe()
 			h.Lock()
-			h.logger.Error("Failed to deploy state sender", "err", err)
+			h.logger.Error("Failed to create transact opts for deploying state sender", "err", err)
 			return
 		}
 


### PR DESCRIPTION
Getting an error in one of the bor nodes in devnet when trying to run the "state-sync" scenario:
```
[EROR] [01-03|16:55:44.179] cli.StartRpcServer error                 err="could not start separate Websocket RPC api at port 8546: listen tcp 127.0.0.1:8546: bind: address already in use"
```

This happens for scenarios with more than 1 node.

Digging further this regressions has happened due to this change: https://github.com/ledgerwatch/erigon/pull/8909

This PR fixes this by updating the devnet `NodeArgs` struct to set the corresponding `--ws.port` `arg` tag which now exists.