### PR TITLE
ci: run macOS jobs on macos-13 instead of macos-13-xlarge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,10 @@ jobs:
     if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
     strategy:
       matrix:
-        os: [ ubuntu-22.04, macos-13-xlarge ] # list of os: https://github.com/actions/virtual-environments
+        # list of os: https://github.com/actions/virtual-environments
+        os:
+          - ubuntu-22.04
+          - macos-13
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/qa-clean-exit.yml
+++ b/.github/workflows/qa-clean-exit.yml
@@ -19,11 +19,6 @@ on:
 
 jobs:
   long-running-test:
-    #if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
-    #strategy:
-    #  matrix:
-    #    os: [ ubuntu-22.04, macos-13-xlarge ]
-    #runs-on: ${{ matrix.os }}
     runs-on: self-hosted
     env:
       ERIGON_DATA_DIR: ${{ github.workspace }}/erigon_data

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -13,7 +13,10 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [ ubuntu-22.04, macos-13-xlarge ] # list of os: https://github.com/actions/virtual-environments
+        # list of os: https://github.com/actions/virtual-environments
+        os:
+          - ubuntu-22.04
+          - macos-13
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
macos-13-xlarge was needed to use M1 CPU,
because previously silkworm-go didn't have macOS Intel support