### PR TITLE
[E3] structural changes (no-op) to support simplified unwinding

### DIFF
--- a/core/state/state_reader_v4.go
+++ b/core/state/state_reader_v4.go
@@ -17,7 +17,7 @@ func NewReaderV4(tx kv.TemporalGetter) *ReaderV4 {
 }
 
 func (r *ReaderV4) ReadAccountData(address libcommon.Address) (*accounts.Account, error) {
-	enc, err := r.tx.DomainGet(kv.AccountsDomain, address.Bytes(), nil)
+	enc, _, err := r.tx.DomainGet(kv.AccountsDomain, address.Bytes(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -32,7 +32,7 @@ func (r *ReaderV4) ReadAccountData(address libcommon.Address) (*accounts.Account
 }
 
 func (r *ReaderV4) ReadAccountStorage(address libcommon.Address, incarnation uint64, key *libcommon.Hash) (enc []byte, err error) {
-	enc, err = r.tx.DomainGet(kv.StorageDomain, address.Bytes(), key.Bytes())
+	enc, _, err = r.tx.DomainGet(kv.StorageDomain, address.Bytes(), key.Bytes())
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +46,7 @@ func (r *ReaderV4) ReadAccountCode(address libcommon.Address, incarnation uint64
 	if codeHash == emptyCodeHashH {
 		return nil, nil
 	}
-	code, err = r.tx.DomainGet(kv.CodeDomain, address.Bytes(), nil)
+	code, _, err = r.tx.DomainGet(kv.CodeDomain, address.Bytes(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func (r *ReaderV4) ReadAccountIncarnation(address libcommon.Address) (uint64, er
 }
 
 func (r *ReaderV4) ReadCommitment(prefix []byte) (enc []byte, err error) {
-	enc, err = r.tx.DomainGet(kv.CommitmentDomain, prefix, nil)
+	enc, _, err = r.tx.DomainGet(kv.CommitmentDomain, prefix, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/core/state/state_writer_v4.go
+++ b/core/state/state_writer_v4.go
@@ -29,39 +29,36 @@ func (w *WriterV4) UpdateAccountData(address libcommon.Address, original, accoun
 		fmt.Printf("account [%x]=>{Balance: %d, Nonce: %d, Root: %x, CodeHash: %x}\n", address, &account.Balance, account.Nonce, account.Root, account.CodeHash)
 	}
 	if original.Incarnation > account.Incarnation {
-		if err := w.tx.DomainDel(kv.CodeDomain, address.Bytes(), nil, nil); err != nil {
+		if err := w.tx.DomainDel(kv.CodeDomain, address.Bytes(), nil, nil, 0); err != nil {
 			return err
 		}
 		if err := w.tx.DomainDelPrefix(kv.StorageDomain, address[:]); err != nil {
 			return err
 		}
 	}
-	value, origValue := accounts.SerialiseV3(account), []byte{}
-	if original.Initialised {
-		origValue = accounts.SerialiseV3(original)
-	}
-	return w.tx.DomainPut(kv.AccountsDomain, address.Bytes(), nil, value, origValue)
+	value := accounts.SerialiseV3(account)
+	return w.tx.DomainPut(kv.AccountsDomain, address.Bytes(), nil, value, nil, 0)
 }
 
 func (w *WriterV4) UpdateAccountCode(address libcommon.Address, incarnation uint64, codeHash libcommon.Hash, code []byte) error {
 	if w.trace {
 		fmt.Printf("code: %x, %x, valLen: %d\n", address.Bytes(), codeHash, len(code))
 	}
-	return w.tx.DomainPut(kv.CodeDomain, address.Bytes(), nil, code, nil)
+	return w.tx.DomainPut(kv.CodeDomain, address.Bytes(), nil, code, nil, 0)
 }
 
 func (w *WriterV4) DeleteAccount(address libcommon.Address, original *accounts.Account) error {
 	if w.trace {
 		fmt.Printf("del account: %x\n", address)
 	}
-	return w.tx.DomainDel(kv.AccountsDomain, address.Bytes(), nil, nil)
+	return w.tx.DomainDel(kv.AccountsDomain, address.Bytes(), nil, nil, 0)
 }
 
 func (w *WriterV4) WriteAccountStorage(address libcommon.Address, incarnation uint64, key *libcommon.Hash, original, value *uint256.Int) error {
 	if w.trace {
 		fmt.Printf("storage: %x,%x,%x\n", address, *key, value.Bytes())
 	}
-	return w.tx.DomainPut(kv.StorageDomain, address.Bytes(), key.Bytes(), value.Bytes(), original.Bytes())
+	return w.tx.DomainPut(kv.StorageDomain, address.Bytes(), key.Bytes(), value.Bytes(), nil, 0)
 }
 
 func (w *WriterV4) CreateContract(address libcommon.Address) (err error) {

--- a/core/state/temporal/kv_temporal.go
+++ b/core/state/temporal/kv_temporal.go
@@ -236,15 +236,15 @@ func (tx *Tx) DomainRange(name kv.Domain, fromKey, toKey []byte, asOfTs uint64, 
 	return it, nil
 }
 
-func (tx *Tx) DomainGet(name kv.Domain, k, k2 []byte) (v []byte, err error) {
-	v, ok, err := tx.aggCtx.GetLatest(name, k, k2, tx.MdbxTx)
+func (tx *Tx) DomainGet(name kv.Domain, k, k2 []byte) (v []byte, step uint64, err error) {
+	v, step, ok, err := tx.aggCtx.GetLatest(name, k, k2, tx.MdbxTx)
 	if err != nil {
-		return nil, err
+		return nil, step, err
 	}
 	if !ok {
-		return nil, nil
+		return nil, step, nil
 	}
-	return v, nil
+	return v, step, nil
 }
 func (tx *Tx) DomainGetAsOf(name kv.Domain, key, key2 []byte, ts uint64) (v []byte, ok bool, err error) {
 	if key2 != nil {

--- a/core/test/domains_restart_test.go
+++ b/core/test/domains_restart_test.go
@@ -498,7 +498,7 @@ func TestCommit(t *testing.T) {
 		//err = domains.UpdateAccountData(ad, buf, nil)
 		//require.NoError(t, err)
 		//
-		err = domains.DomainPut(kv.StorageDomain, ad, loc1, []byte("0401"), nil)
+		err = domains.DomainPut(kv.StorageDomain, ad, loc1, []byte("0401"), nil, 0)
 		require.NoError(t, err)
 	}
 

--- a/erigon-lib/commitment/bin_patricia_hashed.go
+++ b/erigon-lib/commitment/bin_patricia_hashed.go
@@ -837,7 +837,7 @@ func (bph *BinPatriciaHashed) needUnfolding(hashedKey []byte) int {
 
 // unfoldBranchNode returns true if unfolding has been done
 func (bph *BinPatriciaHashed) unfoldBranchNode(row int, deleted bool, depth int) (bool, error) {
-	branchData, err := bph.ctx.GetBranch(binToCompact(bph.currentKey[:bph.currentKeyLen]))
+	branchData, _, err := bph.ctx.GetBranch(binToCompact(bph.currentKey[:bph.currentKeyLen]))
 	if err != nil {
 		return false, err
 	}

--- a/erigon-lib/commitment/commitment.go
+++ b/erigon-lib/commitment/commitment.go
@@ -52,7 +52,7 @@ type PatriciaContext interface {
 	// load branch node and fill up the cells
 	// For each cell, it sets the cell type, clears the modified flag, fills the hash,
 	// and for the extension, account, and leaf type, the `l` and `k`
-	GetBranch(prefix []byte) ([]byte, error)
+	GetBranch(prefix []byte) ([]byte, uint64, error)
 	// fetch account with given plain key
 	GetAccount(plainKey []byte, cell *Cell) error
 	// fetch storage with given plain key
@@ -60,7 +60,7 @@ type PatriciaContext interface {
 	// Returns temp directory to use for update collecting
 	TempDir() string
 	// store branch data
-	PutBranch(prefix []byte, data []byte, prevData []byte) error
+	PutBranch(prefix []byte, data []byte, prevData []byte, prevStep uint64) error
 }
 
 type TrieVariant string
@@ -166,7 +166,7 @@ func (be *BranchEncoder) initCollector() {
 // reads previous comitted value and merges current with it if needed.
 func loadToPatriciaContextFunc(pc PatriciaContext) etl.LoadFunc {
 	return func(prefix, update []byte, table etl.CurrentTableReader, next etl.LoadNextFunc) error {
-		stateValue, err := pc.GetBranch(prefix)
+		stateValue, stateStep, err := pc.GetBranch(prefix)
 		if err != nil {
 			return err
 		}
@@ -174,7 +174,7 @@ func loadToPatriciaContextFunc(pc PatriciaContext) etl.LoadFunc {
 		//fmt.Printf("commitment branch encoder merge prefix [%x] [%x]->[%x]\n%v\n", prefix, stateValue, update, BranchData(update).String())
 
 		cp, cu := common.Copy(prefix), common.Copy(update) // has to copy :(
-		if err = pc.PutBranch(cp, cu, stateValue); err != nil {
+		if err = pc.PutBranch(cp, cu, stateValue, stateStep); err != nil {
 			return err
 		}
 		return nil

--- a/erigon-lib/commitment/hex_patricia_hashed.go
+++ b/erigon-lib/commitment/hex_patricia_hashed.go
@@ -824,7 +824,7 @@ func (hph *HexPatriciaHashed) unfoldBranchNode(row int, deleted bool, depth int)
 	if len(key) == 0 {
 		key = temporalReplacementForEmpty
 	}
-	branchData, err := hph.ctx.GetBranch(key)
+	branchData, _, err := hph.ctx.GetBranch(key)
 	if err != nil {
 		return false, err
 	}
@@ -1280,7 +1280,7 @@ func (hph *HexPatriciaHashed) collectBranchUpdate(
 	if err != nil {
 		return 0, err
 	}
-	prev, err := hph.ctx.GetBranch(prefix) // prefix already compacted by fold
+	prev, prevStep, err := hph.ctx.GetBranch(prefix) // prefix already compacted by fold
 	if err != nil {
 		return 0, err
 	}
@@ -1296,7 +1296,7 @@ func (hph *HexPatriciaHashed) collectBranchUpdate(
 	//fmt.Printf("commitment branch encoder merge prefix [%x] [%x]->[%x]\n%update\n", prefix, stateValue, update, BranchData(update).String())
 
 	cp, cu := common.Copy(prefix), common.Copy(update) // has to copy :(
-	if err = hph.ctx.PutBranch(cp, cu, prev); err != nil {
+	if err = hph.ctx.PutBranch(cp, cu, prev, prevStep); err != nil {
 		return 0, err
 	}
 	mxCommitmentBranchUpdates.Inc()

--- a/erigon-lib/commitment/hex_patricia_hashed_test.go
+++ b/erigon-lib/commitment/hex_patricia_hashed_test.go
@@ -672,7 +672,7 @@ func Test_HexPatriciaHashed_StateRestoreAndContinue(t *testing.T) {
 	// Previously we did not apply updates in this test - trieTwo simply read same commitment data from ms.
 	// Now when branch data is written during ProcessKeys, need to use separated state for this exact case.
 	for ck, cv := range ms.cm {
-		err = ms2.PutBranch([]byte(ck), cv, nil)
+		err = ms2.PutBranch([]byte(ck), cv, nil, 0)
 		require.NoError(t, err)
 	}
 

--- a/erigon-lib/commitment/patricia_state_mock_test.go
+++ b/erigon-lib/commitment/patricia_state_mock_test.go
@@ -35,18 +35,18 @@ func (ms *MockState) TempDir() string {
 	return ms.t.TempDir()
 }
 
-func (ms *MockState) PutBranch(prefix []byte, data []byte, prevData []byte) error {
+func (ms *MockState) PutBranch(prefix []byte, data []byte, prevData []byte, prevStep uint64) error {
 	// updates already merged by trie
 	ms.cm[string(prefix)] = data
 	return nil
 }
 
-func (ms *MockState) GetBranch(prefix []byte) ([]byte, error) {
+func (ms *MockState) GetBranch(prefix []byte) ([]byte, uint64, error) {
 	if exBytes, ok := ms.cm[string(prefix)]; ok {
 		//fmt.Printf("GetBranch prefix %x, exBytes (%d) %x [%v]\n", prefix, len(exBytes), []byte(exBytes), BranchData(exBytes).String())
-		return exBytes, nil
+		return exBytes, 0, nil
 	}
-	return nil, nil
+	return nil, 0, nil
 }
 
 func (ms *MockState) GetAccount(plainKey []byte, cell *Cell) error {

--- a/erigon-lib/kv/kv_interface.go
+++ b/erigon-lib/kv/kv_interface.go
@@ -539,7 +539,7 @@ type (
 )
 
 type TemporalGetter interface {
-	DomainGet(name Domain, k, k2 []byte) (v []byte, err error)
+	DomainGet(name Domain, k, k2 []byte) (v []byte, step uint64, err error)
 }
 type TemporalTx interface {
 	Tx
@@ -567,14 +567,14 @@ type TemporalPutDel interface {
 	//   - user can prvide `prevVal != nil` - then it will not read prev value from storage
 	//   - user can append k2 into k1, then underlying methods will not preform append
 	//   - if `val == nil` it will call DomainDel
-	DomainPut(domain Domain, k1, k2 []byte, val, prevVal []byte) error
+	DomainPut(domain Domain, k1, k2 []byte, val, prevVal []byte, prevStep uint64) error
 
 	// DomainDel
 	// Optimizations:
 	//   - user can prvide `prevVal != nil` - then it will not read prev value from storage
 	//   - user can append k2 into k1, then underlying methods will not preform append
 	//   - if `val == nil` it will call DomainDel
-	DomainDel(domain Domain, k1, k2 []byte, prevVal []byte) error
+	DomainDel(domain Domain, k1, k2 []byte, prevVal []byte, prevStep uint64) error
 	DomainDelPrefix(domain Domain, prefix []byte) error
 }
 

--- a/erigon-lib/kv/kvcache/cache.go
+++ b/erigon-lib/kv/kvcache/cache.go
@@ -405,9 +405,9 @@ func (c *Coherent) Get(k []byte, tx kv.Tx, id uint64) (v []byte, err error) {
 
 	if c.cfg.StateV3 {
 		if len(k) == 20 {
-			v, err = tx.(kv.TemporalTx).DomainGet(kv.AccountsDomain, k, nil)
+			v, _, err = tx.(kv.TemporalTx).DomainGet(kv.AccountsDomain, k, nil)
 		} else {
-			v, err = tx.(kv.TemporalTx).DomainGet(kv.StorageDomain, k, nil)
+			v, _, err = tx.(kv.TemporalTx).DomainGet(kv.StorageDomain, k, nil)
 		}
 	} else {
 		v, err = tx.GetOne(kv.PlainState, k)
@@ -437,7 +437,7 @@ func (c *Coherent) GetCode(k []byte, tx kv.Tx, id uint64) (v []byte, err error) 
 	c.codeMiss.Inc()
 
 	if c.cfg.StateV3 {
-		v, err = tx.(kv.TemporalTx).DomainGet(kv.CodeDomain, k, nil)
+		v, _, err = tx.(kv.TemporalTx).DomainGet(kv.CodeDomain, k, nil)
 	} else {
 		v, err = tx.GetOne(kv.Code, k)
 	}

--- a/erigon-lib/kv/kvcache/dummy.go
+++ b/erigon-lib/kv/kvcache/dummy.go
@@ -40,15 +40,18 @@ func (c *DummyCache) Len() int                               { return 0 }
 func (c *DummyCache) Get(k []byte, tx kv.Tx, id uint64) ([]byte, error) {
 	if c.stateV3 {
 		if len(k) == 20 {
-			return tx.(kv.TemporalTx).DomainGet(kv.AccountsDomain, k, nil)
+			v, _, err := tx.(kv.TemporalTx).DomainGet(kv.AccountsDomain, k, nil)
+			return v, err
 		}
-		return tx.(kv.TemporalTx).DomainGet(kv.StorageDomain, k, nil)
+		v, _, err := tx.(kv.TemporalTx).DomainGet(kv.StorageDomain, k, nil)
+		return v, err
 	}
 	return tx.GetOne(kv.PlainState, k)
 }
 func (c *DummyCache) GetCode(k []byte, tx kv.Tx, id uint64) ([]byte, error) {
 	if c.stateV3 {
-		return tx.(kv.TemporalTx).DomainGet(kv.CodeDomain, k, nil)
+		v, _, err := tx.(kv.TemporalTx).DomainGet(kv.CodeDomain, k, nil)
+		return v, err
 	}
 	return tx.GetOne(kv.Code, k)
 }

--- a/erigon-lib/kv/membatchwithdb/memory_mutation.go
+++ b/erigon-lib/kv/membatchwithdb/memory_mutation.go
@@ -693,7 +693,7 @@ func (m *MemoryMutation) AggCtx() interface{} {
 	return m.db.(hasAggCtx).AggCtx()
 }
 
-func (m *MemoryMutation) DomainGet(name kv.Domain, k, k2 []byte) (v []byte, err error) {
+func (m *MemoryMutation) DomainGet(name kv.Domain, k, k2 []byte) (v []byte, step uint64, err error) {
 	return m.db.(kv.TemporalTx).DomainGet(name, k, k2)
 }
 

--- a/erigon-lib/kv/remotedb/kv_remote.go
+++ b/erigon-lib/kv/remotedb/kv_remote.go
@@ -656,12 +656,12 @@ func (tx *tx) DomainGetAsOf(name kv.Domain, k, k2 []byte, ts uint64) (v []byte, 
 	return reply.V, reply.Ok, nil
 }
 
-func (tx *tx) DomainGet(name kv.Domain, k, k2 []byte) (v []byte, err error) {
+func (tx *tx) DomainGet(name kv.Domain, k, k2 []byte) (v []byte, step uint64, err error) {
 	reply, err := tx.db.remoteKV.DomainGet(tx.ctx, &remote.DomainGetReq{TxId: tx.id, Table: string(name), K: k, K2: k2, Latest: true})
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	return reply.V, nil
+	return reply.V, 0, nil
 }
 
 func (tx *tx) DomainRange(name kv.Domain, fromKey, toKey []byte, ts uint64, asc order.By, limit int) (it iter.KV, err error) {

--- a/erigon-lib/kv/remotedbserver/remotedbserver.go
+++ b/erigon-lib/kv/remotedbserver/remotedbserver.go
@@ -519,7 +519,7 @@ func (s *KvServer) DomainGet(ctx context.Context, req *remote.DomainGetReq) (rep
 			return fmt.Errorf("server DB doesn't implement kv.Temporal interface")
 		}
 		if req.Latest {
-			reply.V, err = ttx.DomainGet(kv.Domain(req.Table), req.K, req.K2)
+			reply.V, _, err = ttx.DomainGet(kv.Domain(req.Table), req.K, req.K2)
 			if err != nil {
 				return err
 			}

--- a/erigon-lib/state/aggregator_bench_test.go
+++ b/erigon-lib/state/aggregator_bench_test.go
@@ -80,7 +80,7 @@ func BenchmarkAggregator_Processing(b *testing.B) {
 		val := <-vals
 		txNum := uint64(i)
 		domains.SetTxNum(txNum)
-		err := domains.DomainPut(kv.StorageDomain, key[:length.Addr], key[length.Addr:], val, prev)
+		err := domains.DomainPut(kv.StorageDomain, key[:length.Addr], key[length.Addr:], val, prev, 0)
 		prev = val
 		require.NoError(b, err)
 

--- a/erigon-lib/state/aggregator_v3.go
+++ b/erigon-lib/state/aggregator_v3.go
@@ -1525,7 +1525,7 @@ func (ac *AggregatorV3Context) DomainGetAsOf(tx kv.Tx, name kv.Domain, key []byt
 		panic(fmt.Sprintf("unexpected: %s", name))
 	}
 }
-func (ac *AggregatorV3Context) GetLatest(domain kv.Domain, k, k2 []byte, tx kv.Tx) (v []byte, ok bool, err error) {
+func (ac *AggregatorV3Context) GetLatest(domain kv.Domain, k, k2 []byte, tx kv.Tx) (v []byte, step uint64, ok bool, err error) {
 	switch domain {
 	case kv.AccountsDomain:
 		return ac.account.GetLatest(k, k2, tx)

--- a/erigon-lib/state/domain_shared_bench_test.go
+++ b/erigon-lib/state/domain_shared_bench_test.go
@@ -43,7 +43,7 @@ func Benchmark_SharedDomains_GetLatest(t *testing.B) {
 		v := make([]byte, 8)
 		binary.BigEndian.PutUint64(v, i)
 		for j := 0; j < len(keys); j++ {
-			err := domains.DomainPut(kv.AccountsDomain, keys[j], nil, v, nil)
+			err := domains.DomainPut(kv.AccountsDomain, keys[j], nil, v, nil, 0)
 			require.NoError(t, err)
 		}
 
@@ -77,7 +77,7 @@ func Benchmark_SharedDomains_GetLatest(t *testing.B) {
 	//t.Run("GetLatest", func(t *testing.B) {
 	for ik := 0; ik < t.N; ik++ {
 		for i := 0; i < len(keys); i++ {
-			v, ok, err := ac2.GetLatest(kv.AccountsDomain, keys[i], nil, rwTx)
+			v, _, ok, err := ac2.GetLatest(kv.AccountsDomain, keys[i], nil, rwTx)
 
 			require.True(t, ok)
 			require.EqualValuesf(t, latest, v, "unexpected %d, wanted %d", binary.BigEndian.Uint64(v), maxTx-1)

--- a/erigon-lib/state/domain_test.go
+++ b/erigon-lib/state/domain_test.go
@@ -128,11 +128,11 @@ func testCollationBuild(t *testing.T, compressDomainVals bool) {
 		p1, p2 []byte
 	)
 
-	err = writer.PutWithPrev(k1, nil, v1, p1)
+	err = writer.PutWithPrev(k1, nil, v1, p1, 0)
 	require.NoError(t, err)
 
 	writer.SetTxNum(3)
-	err = writer.PutWithPrev(k2, nil, v2, p2)
+	err = writer.PutWithPrev(k2, nil, v2, p2, 0)
 	require.NoError(t, err)
 
 	p1, p2 = v1, v2
@@ -141,23 +141,23 @@ func testCollationBuild(t *testing.T, compressDomainVals bool) {
 	v1, v2 = []byte("value1.2"), []byte("value2.2") //nolint
 
 	writer.SetTxNum(6)
-	err = writer.PutWithPrev(k1, nil, v1, p1)
+	err = writer.PutWithPrev(k1, nil, v1, p1, 0)
 	require.NoError(t, err)
 
 	p1, v1 = v1, []byte("value1.3")
 	writer.SetTxNum(d.aggregationStep + 2)
-	err = writer.PutWithPrev(k1, nil, v1, p1)
+	err = writer.PutWithPrev(k1, nil, v1, p1, 0)
 	require.NoError(t, err)
 
 	p1, v1 = v1, []byte("value1.4")
 	writer.SetTxNum(d.aggregationStep + 3)
-	err = writer.PutWithPrev(k1, nil, v1, p1)
+	err = writer.PutWithPrev(k1, nil, v1, p1, 0)
 	require.NoError(t, err)
 
 	p1, v1 = v1, []byte("value1.5")
 	expectedStep2 := uint64(2)
 	writer.SetTxNum(expectedStep2*d.aggregationStep + 2)
-	err = writer.PutWithPrev(k1, nil, v1, p1)
+	err = writer.PutWithPrev(k1, nil, v1, p1, 0)
 	require.NoError(t, err)
 
 	err = writer.Flush(ctx, tx)
@@ -260,19 +260,19 @@ func TestDomain_IterationBasic(t *testing.T) {
 	defer writer.close()
 
 	writer.SetTxNum(2)
-	err = writer.PutWithPrev([]byte("addr1"), []byte("loc1"), []byte("value1"), nil)
+	err = writer.PutWithPrev([]byte("addr1"), []byte("loc1"), []byte("value1"), nil, 0)
 	require.NoError(t, err)
-	err = writer.PutWithPrev([]byte("addr1"), []byte("loc2"), []byte("value1"), nil)
+	err = writer.PutWithPrev([]byte("addr1"), []byte("loc2"), []byte("value1"), nil, 0)
 	require.NoError(t, err)
-	err = writer.PutWithPrev([]byte("addr1"), []byte("loc3"), []byte("value1"), nil)
+	err = writer.PutWithPrev([]byte("addr1"), []byte("loc3"), []byte("value1"), nil, 0)
 	require.NoError(t, err)
-	err = writer.PutWithPrev([]byte("addr2"), []byte("loc1"), []byte("value1"), nil)
+	err = writer.PutWithPrev([]byte("addr2"), []byte("loc1"), []byte("value1"), nil, 0)
 	require.NoError(t, err)
-	err = writer.PutWithPrev([]byte("addr2"), []byte("loc2"), []byte("value1"), nil)
+	err = writer.PutWithPrev([]byte("addr2"), []byte("loc2"), []byte("value1"), nil, 0)
 	require.NoError(t, err)
-	err = writer.PutWithPrev([]byte("addr3"), []byte("loc1"), []byte("value1"), nil)
+	err = writer.PutWithPrev([]byte("addr3"), []byte("loc1"), []byte("value1"), nil, 0)
 	require.NoError(t, err)
-	err = writer.PutWithPrev([]byte("addr3"), []byte("loc2"), []byte("value1"), nil)
+	err = writer.PutWithPrev([]byte("addr3"), []byte("loc2"), []byte("value1"), nil, 0)
 	require.NoError(t, err)
 	err = writer.Flush(ctx, tx)
 	require.NoError(t, err)
@@ -332,30 +332,30 @@ func TestDomain_AfterPrune(t *testing.T) {
 	)
 
 	writer.SetTxNum(2)
-	err = writer.PutWithPrev(k1, nil, n1, p1)
+	err = writer.PutWithPrev(k1, nil, n1, p1, 0)
 	require.NoError(t, err)
 
 	writer.SetTxNum(3)
-	err = writer.PutWithPrev(k2, nil, n2, p2)
+	err = writer.PutWithPrev(k2, nil, n2, p2, 0)
 	require.NoError(t, err)
 
 	p1, p2 = n1, n2
 	n1, n2 = []byte("value1.2"), []byte("value2.2")
 
 	writer.SetTxNum(6)
-	err = writer.PutWithPrev(k1, nil, n1, p1)
+	err = writer.PutWithPrev(k1, nil, n1, p1, 0)
 	require.NoError(t, err)
 
 	p1, n1 = n1, []byte("value1.3")
 
 	writer.SetTxNum(17)
-	err = writer.PutWithPrev(k1, nil, n1, p1)
+	err = writer.PutWithPrev(k1, nil, n1, p1, 0)
 	require.NoError(t, err)
 
 	p1 = n1
 
 	writer.SetTxNum(18)
-	err = writer.PutWithPrev(k2, nil, n2, p2)
+	err = writer.PutWithPrev(k2, nil, n2, p2, 0)
 	require.NoError(t, err)
 	p2 = n2
 
@@ -372,11 +372,11 @@ func TestDomain_AfterPrune(t *testing.T) {
 	var v []byte
 	dc = d.MakeContext()
 	defer dc.Close()
-	v, found, err := dc.GetLatest(k1, nil, tx)
+	v, _, found, err := dc.GetLatest(k1, nil, tx)
 	require.Truef(t, found, "key1 not found")
 	require.NoError(t, err)
 	require.Equal(t, p1, v)
-	v, found, err = dc.GetLatest(k2, nil, tx)
+	v, _, found, err = dc.GetLatest(k2, nil, tx)
 	require.Truef(t, found, "key2 not found")
 	require.NoError(t, err)
 	require.Equal(t, p2, v)
@@ -388,12 +388,12 @@ func TestDomain_AfterPrune(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, isEmpty)
 
-	v, found, err = dc.GetLatest(k1, nil, tx)
+	v, _, found, err = dc.GetLatest(k1, nil, tx)
 	require.NoError(t, err)
 	require.Truef(t, found, "key1 not found")
 	require.Equal(t, p1, v)
 
-	v, found, err = dc.GetLatest(k2, nil, tx)
+	v, _, found, err = dc.GetLatest(k2, nil, tx)
 	require.NoError(t, err)
 	require.Truef(t, found, "key2 not found")
 	require.Equal(t, p2, v)
@@ -427,7 +427,7 @@ func filledDomain(t *testing.T, logger log.Logger) (kv.RwDB, *Domain, uint64) {
 				var v [8]byte
 				binary.BigEndian.PutUint64(k[:], keyNum)
 				binary.BigEndian.PutUint64(v[:], valNum)
-				err = writer.PutWithPrev(k[:], nil, v[:], prev[keyNum])
+				err = writer.PutWithPrev(k[:], nil, v[:], prev[keyNum], 0)
 				prev[keyNum] = v[:]
 
 				require.NoError(err)
@@ -478,7 +478,7 @@ func checkHistory(t *testing.T, db kv.RwDB, d *Domain, txs uint64) {
 				require.Nil(val, label)
 			}
 			if txNum == txs {
-				val, found, err := dc.GetLatest(k[:], nil, roTx)
+				val, _, found, err := dc.GetLatest(k[:], nil, roTx)
 				require.True(found, label)
 				require.NoError(err)
 				require.EqualValues(v[:], val, label)
@@ -516,33 +516,33 @@ func TestIterationMultistep(t *testing.T) {
 	defer writer.close()
 
 	writer.SetTxNum(2)
-	err = writer.PutWithPrev([]byte("addr1"), []byte("loc1"), []byte("value1"), nil)
+	err = writer.PutWithPrev([]byte("addr1"), []byte("loc1"), []byte("value1"), nil, 0)
 	require.NoError(t, err)
-	err = writer.PutWithPrev([]byte("addr1"), []byte("loc2"), []byte("value1"), nil)
+	err = writer.PutWithPrev([]byte("addr1"), []byte("loc2"), []byte("value1"), nil, 0)
 	require.NoError(t, err)
-	err = writer.PutWithPrev([]byte("addr1"), []byte("loc3"), []byte("value1"), nil)
+	err = writer.PutWithPrev([]byte("addr1"), []byte("loc3"), []byte("value1"), nil, 0)
 	require.NoError(t, err)
-	err = writer.PutWithPrev([]byte("addr2"), []byte("loc1"), []byte("value1"), nil)
+	err = writer.PutWithPrev([]byte("addr2"), []byte("loc1"), []byte("value1"), nil, 0)
 	require.NoError(t, err)
-	err = writer.PutWithPrev([]byte("addr2"), []byte("loc2"), []byte("value1"), nil)
+	err = writer.PutWithPrev([]byte("addr2"), []byte("loc2"), []byte("value1"), nil, 0)
 	require.NoError(t, err)
-	err = writer.PutWithPrev([]byte("addr3"), []byte("loc1"), []byte("value1"), nil)
+	err = writer.PutWithPrev([]byte("addr3"), []byte("loc1"), []byte("value1"), nil, 0)
 	require.NoError(t, err)
-	err = writer.PutWithPrev([]byte("addr3"), []byte("loc2"), []byte("value1"), nil)
+	err = writer.PutWithPrev([]byte("addr3"), []byte("loc2"), []byte("value1"), nil, 0)
 	require.NoError(t, err)
 
 	writer.SetTxNum(2 + 16)
-	err = writer.PutWithPrev([]byte("addr2"), []byte("loc1"), []byte("value1"), nil)
+	err = writer.PutWithPrev([]byte("addr2"), []byte("loc1"), []byte("value1"), nil, 0)
 	require.NoError(t, err)
-	err = writer.PutWithPrev([]byte("addr2"), []byte("loc2"), []byte("value1"), nil)
+	err = writer.PutWithPrev([]byte("addr2"), []byte("loc2"), []byte("value1"), nil, 0)
 	require.NoError(t, err)
-	err = writer.PutWithPrev([]byte("addr2"), []byte("loc3"), []byte("value1"), nil)
+	err = writer.PutWithPrev([]byte("addr2"), []byte("loc3"), []byte("value1"), nil, 0)
 	require.NoError(t, err)
-	err = writer.PutWithPrev([]byte("addr2"), []byte("loc4"), []byte("value1"), nil)
+	err = writer.PutWithPrev([]byte("addr2"), []byte("loc4"), []byte("value1"), nil, 0)
 	require.NoError(t, err)
 
 	writer.SetTxNum(2 + 16 + 16)
-	err = writer.DeleteWithPrev([]byte("addr2"), []byte("loc1"), nil)
+	err = writer.DeleteWithPrev([]byte("addr2"), []byte("loc1"), nil, 0)
 	require.NoError(t, err)
 
 	err = writer.Flush(ctx, tx)
@@ -731,12 +731,12 @@ func TestDomain_Delete(t *testing.T) {
 	// Put on even txNum, delete on odd txNum
 	for txNum := uint64(0); txNum < uint64(1000); txNum++ {
 		writer.SetTxNum(txNum)
-		original, _, err := dc.GetLatest([]byte("key1"), nil, tx)
+		original, originalStep, _, err := dc.GetLatest([]byte("key1"), nil, tx)
 		require.NoError(err)
 		if txNum%2 == 0 {
-			err = writer.PutWithPrev([]byte("key1"), nil, []byte("value1"), original)
+			err = writer.PutWithPrev([]byte("key1"), nil, []byte("value1"), original, originalStep)
 		} else {
-			err = writer.DeleteWithPrev([]byte("key1"), nil, original)
+			err = writer.DeleteWithPrev([]byte("key1"), nil, original, originalStep)
 		}
 		require.NoError(err)
 	}
@@ -818,7 +818,7 @@ func filledDomainFixedSize(t *testing.T, keysCount, txCount, aggStep uint64, log
 			binary.BigEndian.PutUint64(k[:], keyNum)
 			binary.BigEndian.PutUint64(v[:], txNum)
 			//v[0] = 3 // value marker
-			err = writer.PutWithPrev(k[:], nil, v[:], []byte(prev[string(k[:])]))
+			err = writer.PutWithPrev(k[:], nil, v[:], []byte(prev[string(k[:])]), 0)
 			require.NoError(t, err)
 			if _, ok := dat[keyNum]; !ok {
 				dat[keyNum] = make([]bool, txCount+1)
@@ -904,7 +904,7 @@ func TestDomain_Prune_AfterAllWrites(t *testing.T) {
 		label := fmt.Sprintf("txNum=%d, keyNum=%d\n", txCount-1, keyNum)
 		binary.BigEndian.PutUint64(k[:], keyNum)
 
-		storedV, found, err := dc.GetLatest(k[:], nil, roTx)
+		storedV, _, found, err := dc.GetLatest(k[:], nil, roTx)
 		require.Truef(t, found, label)
 		require.NoError(t, err, label)
 		require.EqualValues(t, v[:], storedV, label)
@@ -943,7 +943,7 @@ func TestDomain_PruneOnWrite(t *testing.T) {
 			var v [8]byte
 			binary.BigEndian.PutUint64(k[:], keyNum)
 			binary.BigEndian.PutUint64(v[:], txNum)
-			err = writer.PutWithPrev(k[:], nil, v[:], []byte(prev[string(k[:])]))
+			err = writer.PutWithPrev(k[:], nil, v[:], []byte(prev[string(k[:])]), 0)
 			require.NoError(t, err)
 
 			prev[string(k[:])] = string(v[:])
@@ -1007,7 +1007,7 @@ func TestDomain_PruneOnWrite(t *testing.T) {
 		label := fmt.Sprintf("txNum=%d, keyNum=%d\n", txCount, keyNum)
 		binary.BigEndian.PutUint64(k[:], keyNum)
 
-		storedV, found, err := dc.GetLatest(k[:], nil, tx)
+		storedV, _, found, err := dc.GetLatest(k[:], nil, tx)
 		require.Truef(t, found, label)
 		require.NoErrorf(t, err, label)
 		require.EqualValues(t, v[:], storedV, label)
@@ -1071,13 +1071,13 @@ func TestDomain_CollationBuildInMem(t *testing.T) {
 		s := []byte(fmt.Sprintf("longstorage2.%d", i))
 
 		writer.SetTxNum(uint64(i))
-		err = writer.PutWithPrev([]byte("key1"), nil, v1, preval1)
+		err = writer.PutWithPrev([]byte("key1"), nil, v1, preval1, 0)
 		require.NoError(t, err)
 
-		err = writer.PutWithPrev([]byte("key2"), nil, v2, preval2)
+		err = writer.PutWithPrev([]byte("key2"), nil, v2, preval2, 0)
 		require.NoError(t, err)
 
-		err = writer.PutWithPrev([]byte("key3"), l, s, preval3)
+		err = writer.PutWithPrev([]byte("key3"), l, s, preval3, 0)
 		require.NoError(t, err)
 
 		preval1, preval2, preval3 = v1, v2, s
@@ -1174,7 +1174,7 @@ func TestDomainContext_IteratePrefixAgain(t *testing.T) {
 		}
 
 		values[hex.EncodeToString(common.Append(key, loc))] = common.Copy(value)
-		err := writer.PutWithPrev(key, loc, value, nil)
+		err := writer.PutWithPrev(key, loc, value, nil, 0)
 		require.NoError(t, err)
 	}
 	err = writer.Flush(context.Background(), tx)
@@ -1243,7 +1243,7 @@ func TestDomainContext_IteratePrefix(t *testing.T) {
 		values[hex.EncodeToString(key)] = common.Copy(value)
 
 		writer.SetTxNum(uint64(i))
-		err := writer.PutWithPrev(key, nil, value, nil)
+		err := writer.PutWithPrev(key, nil, value, nil, 0)
 		require.NoError(t, err)
 	}
 	err = writer.Flush(context.Background(), tx)
@@ -1311,7 +1311,7 @@ func TestDomainContext_getFromFiles(t *testing.T) {
 		for j := 0; j < len(keys); j++ {
 			buf := types.EncodeAccountBytesV3(uint64(i), uint256.NewInt(uint64(i*100_000)), nil, 0)
 
-			err = writer.PutWithPrev(keys[j], nil, buf, prev)
+			err = writer.PutWithPrev(keys[j], nil, buf, prev, 0)
 			require.NoError(t, err)
 			prev = buf
 
@@ -1470,7 +1470,7 @@ func TestDomain_GetAfterAggregation(t *testing.T) {
 		p := []byte{}
 		for i := 0; i < len(updates); i++ {
 			writer.SetTxNum(updates[i].txNum)
-			writer.PutWithPrev([]byte(key), nil, updates[i].value, p)
+			writer.PutWithPrev([]byte(key), nil, updates[i].value, p, 0)
 			p = common.Copy(updates[i].value)
 		}
 	}
@@ -1502,7 +1502,7 @@ func TestDomain_GetAfterAggregation(t *testing.T) {
 		if len(updates) == 0 {
 			continue
 		}
-		v, ok, err := dc.GetLatest([]byte(key), nil, tx)
+		v, _, ok, err := dc.GetLatest([]byte(key), nil, tx)
 		require.NoError(t, err)
 		require.EqualValuesf(t, updates[len(updates)-1].value, v, "key %x latest", []byte(key))
 		require.True(t, ok)
@@ -1540,7 +1540,7 @@ func TestDomain_PruneAfterAggregation(t *testing.T) {
 		p := []byte{}
 		for i := 0; i < len(updates); i++ {
 			writer.SetTxNum(updates[i].txNum)
-			writer.PutWithPrev([]byte(key), nil, updates[i].value, p)
+			writer.PutWithPrev([]byte(key), nil, updates[i].value, p, 0)
 			p = common.Copy(updates[i].value)
 		}
 	}
@@ -1599,7 +1599,7 @@ func TestDomain_PruneAfterAggregation(t *testing.T) {
 		if len(updates) == 0 {
 			continue
 		}
-		v, ok, err := dc.GetLatest([]byte(key), nil, tx)
+		v, _, ok, err := dc.GetLatest([]byte(key), nil, tx)
 		require.NoError(t, err)
 		require.EqualValuesf(t, updates[len(updates)-1].value, v, "key %x latest", []byte(key))
 		require.True(t, ok)
@@ -1684,7 +1684,7 @@ func TestDomain_PruneProgress(t *testing.T) {
 		p := []byte{}
 		for i := 0; i < len(updates); i++ {
 			writer.SetTxNum(updates[i].txNum)
-			err = writer.PutWithPrev([]byte(key), nil, updates[i].value, p)
+			err = writer.PutWithPrev([]byte(key), nil, updates[i].value, p, 0)
 			require.NoError(t, err)
 			p = common.Copy(updates[i].value)
 		}
@@ -1795,14 +1795,14 @@ func TestDomain_Unwind(t *testing.T) {
 			writer.SetTxNum(i)
 			if i%3 == 0 && i > 0 { // once in 3 tx put key3 -> value3.i and skip other keys update
 				if i%12 == 0 { // once in 12 tx delete key3 before update
-					err = writer.DeleteWithPrev([]byte("key3"), nil, preval3)
+					err = writer.DeleteWithPrev([]byte("key3"), nil, preval3, 0)
 					require.NoError(t, err)
 					preval3 = nil
 
 					continue
 				}
 				v3 := []byte(fmt.Sprintf("value3.%d", i))
-				err = writer.PutWithPrev([]byte("key3"), nil, v3, preval3)
+				err = writer.PutWithPrev([]byte("key3"), nil, v3, preval3, 0)
 				require.NoError(t, err)
 				preval3 = v3
 				continue
@@ -1812,11 +1812,11 @@ func TestDomain_Unwind(t *testing.T) {
 			v2 := []byte(fmt.Sprintf("value2.%d", i))
 			nv3 := []byte(fmt.Sprintf("valuen3.%d", i))
 
-			err = writer.PutWithPrev([]byte("key1"), nil, v1, preval1)
+			err = writer.PutWithPrev([]byte("key1"), nil, v1, preval1, 0)
 			require.NoError(t, err)
-			err = writer.PutWithPrev([]byte("key2"), nil, v2, preval2)
+			err = writer.PutWithPrev([]byte("key2"), nil, v2, preval2, 0)
 			require.NoError(t, err)
-			err = writer.PutWithPrev([]byte("k4"), nil, nv3, preval4)
+			err = writer.PutWithPrev([]byte("k4"), nil, nv3, preval4, 0)
 			require.NoError(t, err)
 
 			preval1, preval2, preval4 = v1, v2, nv3

--- a/erigon-lib/state/history.go
+++ b/erigon-lib/state/history.go
@@ -438,7 +438,7 @@ func buildVi(ctx context.Context, historyItem, iiItem *filesItem, historyIdxPath
 	return nil
 }
 
-func (w *historyBufferedWriter) AddPrevValue(key1, key2, original []byte) (err error) {
+func (w *historyBufferedWriter) AddPrevValue(key1, key2, original []byte, originalStep uint64) (err error) {
 	if w.discard {
 		return nil
 	}

--- a/erigon-lib/state/history_test.go
+++ b/erigon-lib/state/history_test.go
@@ -101,26 +101,26 @@ func TestHistoryCollationBuild(t *testing.T) {
 		defer writer.close()
 
 		writer.SetTxNum(2)
-		err = writer.AddPrevValue([]byte("key1"), nil, nil)
+		err = writer.AddPrevValue([]byte("key1"), nil, nil, 0)
 		require.NoError(err)
 
 		writer.SetTxNum(3)
-		err = writer.AddPrevValue([]byte("key2"), nil, nil)
+		err = writer.AddPrevValue([]byte("key2"), nil, nil, 0)
 		require.NoError(err)
 
 		writer.SetTxNum(6)
-		err = writer.AddPrevValue([]byte("key1"), nil, []byte("value1.1"))
+		err = writer.AddPrevValue([]byte("key1"), nil, []byte("value1.1"), 0)
 		require.NoError(err)
-		err = writer.AddPrevValue([]byte("key2"), nil, []byte("value2.1"))
+		err = writer.AddPrevValue([]byte("key2"), nil, []byte("value2.1"), 0)
 		require.NoError(err)
 
 		flusher := writer
 		writer = hc.NewWriter()
 
 		writer.SetTxNum(7)
-		err = writer.AddPrevValue([]byte("key2"), nil, []byte("value2.2"))
+		err = writer.AddPrevValue([]byte("key2"), nil, []byte("value2.2"), 0)
 		require.NoError(err)
-		err = writer.AddPrevValue([]byte("key3"), nil, nil)
+		err = writer.AddPrevValue([]byte("key3"), nil, nil, 0)
 		require.NoError(err)
 
 		err = flusher.Flush(ctx, tx)
@@ -215,23 +215,23 @@ func TestHistoryAfterPrune(t *testing.T) {
 		defer writer.close()
 
 		writer.SetTxNum(2)
-		err = writer.AddPrevValue([]byte("key1"), nil, nil)
+		err = writer.AddPrevValue([]byte("key1"), nil, nil, 0)
 		require.NoError(err)
 
 		writer.SetTxNum(3)
-		err = writer.AddPrevValue([]byte("key2"), nil, nil)
+		err = writer.AddPrevValue([]byte("key2"), nil, nil, 0)
 		require.NoError(err)
 
 		writer.SetTxNum(6)
-		err = writer.AddPrevValue([]byte("key1"), nil, []byte("value1.1"))
+		err = writer.AddPrevValue([]byte("key1"), nil, []byte("value1.1"), 0)
 		require.NoError(err)
-		err = writer.AddPrevValue([]byte("key2"), nil, []byte("value2.1"))
+		err = writer.AddPrevValue([]byte("key2"), nil, []byte("value2.1"), 0)
 		require.NoError(err)
 
 		writer.SetTxNum(7)
-		err = writer.AddPrevValue([]byte("key2"), nil, []byte("value2.2"))
+		err = writer.AddPrevValue([]byte("key2"), nil, []byte("value2.2"), 0)
 		require.NoError(err)
-		err = writer.AddPrevValue([]byte("key3"), nil, nil)
+		err = writer.AddPrevValue([]byte("key3"), nil, nil, 0)
 		require.NoError(err)
 
 		err = writer.Flush(ctx, tx)
@@ -301,7 +301,7 @@ func filledHistory(tb testing.TB, largeValues bool, logger log.Logger) (kv.RwDB,
 				binary.BigEndian.PutUint64(v[:], valNum)
 				k[0] = 1   //mark key to simplify debug
 				v[0] = 255 //mark value to simplify debug
-				err = writer.AddPrevValue(k[:], nil, prevVal[keyNum])
+				err = writer.AddPrevValue(k[:], nil, prevVal[keyNum], 0)
 				require.NoError(tb, err)
 				prevVal[keyNum] = v[:]
 			}
@@ -976,14 +976,14 @@ func writeSomeHistory(tb testing.TB, largeValues bool, logger log.Logger) (kv.Rw
 			if ik == 0 && txNum%33 == 0 {
 				continue
 			}
-			err = writer.AddPrevValue(k, nil, prevVal[ik])
+			err = writer.AddPrevValue(k, nil, prevVal[ik], 0)
 			require.NoError(tb, err)
 
 			prevVal[ik] = v[:]
 		}
 
 		if txNum%33 == 0 {
-			err = writer.AddPrevValue(keys[0], nil, nil)
+			err = writer.AddPrevValue(keys[0], nil, nil, 0)
 			require.NoError(tb, err)
 		}
 


### PR DESCRIPTION
The purpose of this PR is to introduce necessary changes in the function signatures, to then allow recoding of the "step" attribute together with the history values. This extra attribute will make unwind operation on domains simpler, because it will not require searching through the history index.
This PR does not yet change the DB layout of the history, so it should be no-op