### PR TITLE
devnet: fix infinite recursion & enable TestStateSync & TestCallContract integration tests

### DIFF
--- a/cmd/devnet/devnet/context.go
+++ b/cmd/devnet/devnet/context.go
@@ -139,10 +139,8 @@ func CurrentNetwork(ctx context.Context) *Network {
 		return cn.network
 	}
 
-	if current := CurrentNode(ctx); current != nil {
-		if n, ok := current.(*devnetNode); ok {
-			return n.network
-		}
+	if cn, ok := ctx.Value(ckNode).(*cnode); ok && cn.node != nil {
+		return cn.node.(*devnetNode).network
 	}
 
 	if devnet, ok := ctx.Value(ckDevnet).(Devnet); ok {

--- a/cmd/devnet/tests/bor/devnet_test.go
+++ b/cmd/devnet/tests/bor/devnet_test.go
@@ -6,18 +6,17 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ledgerwatch/erigon-lib/chain/networkname"
 	accounts_steps "github.com/ledgerwatch/erigon/cmd/devnet/accounts/steps"
 	contracts_steps "github.com/ledgerwatch/erigon/cmd/devnet/contracts/steps"
 	"github.com/ledgerwatch/erigon/cmd/devnet/requests"
 	"github.com/ledgerwatch/erigon/cmd/devnet/services"
 	"github.com/ledgerwatch/erigon/cmd/devnet/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func TestStateSync(t *testing.T) {
-	t.Skip("FIXME: hangs in GenerateSyncEvents without any visible progress")
-
 	runCtx, err := tests.ContextStart(t, networkname.BorDevnetChainName)
 	require.Nil(t, err)
 	var ctx context.Context = runCtx

--- a/cmd/devnet/tests/generic/devnet_test.go
+++ b/cmd/devnet/tests/generic/devnet_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ledgerwatch/erigon/cmd/devnet/accounts"
 	"github.com/ledgerwatch/erigon/cmd/devnet/admin"
 	"github.com/ledgerwatch/erigon/cmd/devnet/contracts/steps"
@@ -14,7 +16,6 @@ import (
 	"github.com/ledgerwatch/erigon/cmd/devnet/services"
 	"github.com/ledgerwatch/erigon/cmd/devnet/tests"
 	"github.com/ledgerwatch/erigon/cmd/devnet/transactions"
-	"github.com/stretchr/testify/require"
 )
 
 func testDynamicTx(t *testing.T, ctx context.Context) {
@@ -51,8 +52,6 @@ func TestDynamicTxAnyNode(t *testing.T) {
 }
 
 func TestCallContract(t *testing.T) {
-	t.Skip("FIXME: DeployAndCallLogSubscriber step fails: Log result is incorrect expected txIndex: 1, actual txIndex 2")
-
 	runCtx, err := tests.ContextStart(t, "")
 	require.Nil(t, err)
 	ctx := runCtx.WithCurrentNetwork(0)


### PR DESCRIPTION
This PR fixes an infinite recursion (stack overflow) error in devnet integration tests that surfaced in our integration CI a week or more ago and additionally enables some integration tests that are now fixed - `TestStateSync` & `TestCallContract`.

![Screenshot 2024-01-09 at 17 10 24](https://github.com/ledgerwatch/erigon/assets/94537774/a5a8c9c9-9f68-4084-9e08-1bf3c1601cab)
