### PR TITLE
clean-exit test: increase test time

### DIFF
--- a/.github/workflows/qa-clean-exit-snapshot-downloading.yml
+++ b/.github/workflows/qa-clean-exit-snapshot-downloading.yml
@@ -1,4 +1,4 @@
-name: QA - Clean exit on Ctrl-C
+name: QA - Clean exit (snapshot downloading)
 
 on:
   push:
@@ -22,6 +22,7 @@ jobs:
     runs-on: self-hosted
     env:
       ERIGON_DATA_DIR: ${{ github.workspace }}/erigon_data
+      WORKING_TIME_SECONDS: 300
 
     steps:
     - name: Check out repository
@@ -58,7 +59,7 @@ jobs:
     - name: Run Erigon, send ctrl-c and check for clean exiting
       run: |
         # Run Erigon, send ctrl-c and check logs
-        python3 ${{ github.workspace }}/../../../../erigon-qa/test_system/qa-tests/clean-exit/run_and_check_clean_exit.py ${{ github.workspace }}/build/bin $ERIGON_DATA_DIR
+        python3 ${{ github.workspace }}/../../../../erigon-qa/test_system/qa-tests/clean-exit/run_and_check_clean_exit.py ${{ github.workspace }}/build/bin $ERIGON_DATA_DIR $WORKING_TIME_SECONDS
   
         # Capture monitoring script exit status
         monitoring_exit_status=$?

--- a/.github/workflows/qa-clean-exit-snapshot-downloading.yml
+++ b/.github/workflows/qa-clean-exit-snapshot-downloading.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: self-hosted
     env:
       ERIGON_DATA_DIR: ${{ github.workspace }}/erigon_data
-      WORKING_TIME_SECONDS: 300
+      WORKING_TIME_SECONDS: 600
 
     steps:
     - name: Check out repository


### PR DESCRIPTION
This PR
- increase the test time
- use the updated python scripts that reports as an issue a long exit time
- change the test name to states that it is runned in the snapshot downloading phase 
(a later PR will add a similar test on the block downloading phase)