### PR TITLE
devnet: integration tests port clash fix

### DIFF
--- a/cmd/devnet/tests/bor_devnet_test.go
+++ b/cmd/devnet/tests/bor_devnet_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package bor
+package tests
 
 import (
 	"context"
@@ -13,11 +13,10 @@ import (
 	contracts_steps "github.com/ledgerwatch/erigon/cmd/devnet/contracts/steps"
 	"github.com/ledgerwatch/erigon/cmd/devnet/requests"
 	"github.com/ledgerwatch/erigon/cmd/devnet/services"
-	"github.com/ledgerwatch/erigon/cmd/devnet/tests"
 )
 
 func TestStateSync(t *testing.T) {
-	runCtx, err := tests.ContextStart(t, networkname.BorDevnetChainName)
+	runCtx, err := ContextStart(t, networkname.BorDevnetChainName)
 	require.Nil(t, err)
 	var ctx context.Context = runCtx
 
@@ -56,7 +55,7 @@ func TestStateSync(t *testing.T) {
 func TestChildChainExit(t *testing.T) {
 	t.Skip("FIXME: step CreateAccountWithFunds fails: Failed to get transfer tx: failed to search reserves for hashes: no block heads subscription")
 
-	runCtx, err := tests.ContextStart(t, networkname.BorDevnetChainName)
+	runCtx, err := ContextStart(t, networkname.BorDevnetChainName)
 	require.Nil(t, err)
 	var ctx context.Context = runCtx
 

--- a/cmd/devnet/tests/context.go
+++ b/cmd/devnet/tests/context.go
@@ -5,7 +5,10 @@ import (
 	"os"
 	"runtime"
 	"strconv"
+	"sync/atomic"
 	"testing"
+
+	"github.com/ledgerwatch/log/v3"
 
 	"github.com/ledgerwatch/erigon-lib/chain/networkname"
 	"github.com/ledgerwatch/erigon/cmd/devnet/devnet"
@@ -13,12 +16,24 @@ import (
 	"github.com/ledgerwatch/erigon/cmd/devnet/services"
 	"github.com/ledgerwatch/erigon/cmd/devnet/services/polygon"
 	"github.com/ledgerwatch/erigon/turbo/debug"
-	"github.com/ledgerwatch/log/v3"
 )
+
+//
+// TODO - do below or actually move all devnet tests in same package so they can run sequentially?
+//        (another part of the problem may be that the ports are not properly released?)
+//
+
+var basePort atomic.Int32
+
+func init() {
+	basePort.Store(40_000)
+}
 
 func initDevnet(chainName string, dataDir string, producerCount int, logger log.Logger) (devnet.Devnet, error) {
 	const baseRpcHost = "localhost"
-	const baseRpcPort = 8545
+	// initDevnet is used for tests across several test packages which may be run in parallel
+	// hence, we use an atomically incremented base port value to minimise port clashes
+	baseRpcPort := int(basePort.Add(50))
 
 	switch chainName {
 	case networkname.BorDevnetChainName:

--- a/cmd/devnet/tests/context.go
+++ b/cmd/devnet/tests/context.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"runtime"
 	"strconv"
-	"sync/atomic"
 	"testing"
 
 	"github.com/ledgerwatch/log/v3"
@@ -18,22 +17,9 @@ import (
 	"github.com/ledgerwatch/erigon/turbo/debug"
 )
 
-//
-// TODO - do below or actually move all devnet tests in same package so they can run sequentially?
-//        (another part of the problem may be that the ports are not properly released?)
-//
-
-var basePort atomic.Int32
-
-func init() {
-	basePort.Store(40_000)
-}
-
 func initDevnet(chainName string, dataDir string, producerCount int, logger log.Logger) (devnet.Devnet, error) {
 	const baseRpcHost = "localhost"
-	// initDevnet is used for tests across several test packages which may be run in parallel
-	// hence, we use an atomically incremented base port value to minimise port clashes
-	baseRpcPort := int(basePort.Add(50))
+	const baseRpcPort = 9545
 
 	switch chainName {
 	case networkname.BorDevnetChainName:
@@ -57,6 +43,7 @@ func initDevnet(chainName string, dataDir string, producerCount int, logger log.
 }
 
 func ContextStart(t *testing.T, chainName string) (devnet.Context, error) {
+	//goland:noinspection GoBoolExpressions
 	if runtime.GOOS == "windows" {
 		t.Skip("FIXME: TempDir RemoveAll cleanup error: remove dev-0\\clique\\db\\clique\\mdbx.dat: The process cannot access the file because it is being used by another process")
 	}

--- a/cmd/devnet/tests/generic_devnet_test.go
+++ b/cmd/devnet/tests/generic_devnet_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package generic
+package tests
 
 import (
 	"context"
@@ -14,7 +14,6 @@ import (
 	"github.com/ledgerwatch/erigon/cmd/devnet/contracts/steps"
 	"github.com/ledgerwatch/erigon/cmd/devnet/requests"
 	"github.com/ledgerwatch/erigon/cmd/devnet/services"
-	"github.com/ledgerwatch/erigon/cmd/devnet/tests"
 	"github.com/ledgerwatch/erigon/cmd/devnet/transactions"
 )
 
@@ -40,19 +39,19 @@ func testDynamicTx(t *testing.T, ctx context.Context) {
 }
 
 func TestDynamicTxNode0(t *testing.T) {
-	runCtx, err := tests.ContextStart(t, "")
+	runCtx, err := ContextStart(t, "")
 	require.Nil(t, err)
 	testDynamicTx(t, runCtx.WithCurrentNetwork(0).WithCurrentNode(0))
 }
 
 func TestDynamicTxAnyNode(t *testing.T) {
-	runCtx, err := tests.ContextStart(t, "")
+	runCtx, err := ContextStart(t, "")
 	require.Nil(t, err)
 	testDynamicTx(t, runCtx.WithCurrentNetwork(0))
 }
 
 func TestCallContract(t *testing.T) {
-	runCtx, err := tests.ContextStart(t, "")
+	runCtx, err := ContextStart(t, "")
 	require.Nil(t, err)
 	ctx := runCtx.WithCurrentNetwork(0)
 


### PR DESCRIPTION
Integration tests CI is failing due to a port clash in devnet tests. I believe this is because there are 2 packages of devnet integration tests and go can run tests from separate packages in parallel (by default it does package level parallelism). A simple fix would be to just have all devnet integration tests in 1 package and run all these tests sequentially within the package (ie not use t.Parallel).  This PR moves all devnet integration tests in 1 package.

`"ContextStart devnet start failed: private api: could not create listener: listen top 127.0.0.1:10090: bind: address already in use, addr=localhost:10090"`

![Screenshot 2024-01-10 at 13 38 37](https://github.com/ledgerwatch/erigon/assets/94537774/06bda987-45e5-46ef-9e0b-3876b3f85c01)
