### PR TITLE
[E3] DB entries should have priority over files entries in HistoryRange iterator

### DIFF
--- a/erigon-lib/state/history.go
+++ b/erigon-lib/state/history.go
@@ -1807,7 +1807,7 @@ func (hc *HistoryContext) HistoryRange(fromTxNum, toTxNum int, asc order.By, lim
 		return nil, err
 	}
 
-	return iter.UnionKV(itOnFiles, itOnDB, limit), nil
+	return iter.UnionKV(itOnDB, itOnFiles, limit), nil
 }
 
 type HistoryChangesIterFiles struct {

--- a/erigon-lib/state/history.go
+++ b/erigon-lib/state/history.go
@@ -1806,8 +1806,10 @@ func (hc *HistoryContext) HistoryRange(fromTxNum, toTxNum int, asc order.By, lim
 	if err != nil {
 		return nil, err
 	}
-
-	return iter.UnionKV(itOnDB, itOnFiles, limit), nil
+	if bool(asc) {
+		return iter.UnionKV(itOnDB, itOnFiles, limit), nil
+	}
+	return iter.UnionKV(itOnFiles, itOnDB, limit), nil
 }
 
 type HistoryChangesIterFiles struct {

--- a/erigon-lib/state/history.go
+++ b/erigon-lib/state/history.go
@@ -1806,10 +1806,7 @@ func (hc *HistoryContext) HistoryRange(fromTxNum, toTxNum int, asc order.By, lim
 	if err != nil {
 		return nil, err
 	}
-	if bool(asc) {
-		return iter.UnionKV(itOnDB, itOnFiles, limit), nil
-	}
-	return iter.UnionKV(itOnFiles, itOnDB, limit), nil
+	return iter.MergeKV(itOnDB, itOnFiles, limit), nil
 }
 
 type HistoryChangesIterFiles struct {


### PR DESCRIPTION
According to the implementation of `UnionKV`, the first argument (`x`) receives priority when the keys are the same