### PR TITLE
Mumbai uploader regression fixes

### DIFF
--- a/eth/stagedsync/stage_bor_heimdall.go
+++ b/eth/stagedsync/stage_bor_heimdall.go
@@ -559,7 +559,11 @@ func checkBorHeaderExtraData(chr consensus.ChainHeaderReader, header *types.Head
 		return err
 	}
 
-	if len(producerSet) != len(headerVals) {
+	// span 0 at least for mumbai has a header mismatch in
+	// its first spam.  Since we control neither the span, not the
+	// the headers (they are external data) - we just don't do the
+	// check as it will hault further processing
+	if len(producerSet) != len(headerVals) && spanID > 0 {
 		return ErrHeaderValidatorsLengthMismatch
 	}
 

--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -101,14 +101,24 @@ var snapshotCommand = cli.Command{
 					&erigoncli.UploadFromFlag,
 					&erigoncli.FrozenBlockLimitFlag,
 				}),
-			Before: func(context *cli.Context) error {
-				erigoncli.SyncLoopBreakAfterFlag.Value = "Senders"
-				erigoncli.SyncLoopBlockLimitFlag.Value = 100000
-				erigoncli.SyncLoopPruneLimitFlag.Value = 100000
-				erigoncli.FrozenBlockLimitFlag.Value = 1500000
-				utils.NoDownloaderFlag.Value = true
-				utils.HTTPEnabledFlag.Value = false
-				utils.TxPoolDisableFlag.Value = true
+			Before: func(ctx *cli.Context) error {
+				ctx.Set(erigoncli.SyncLoopBreakAfterFlag.Name, "Senders")
+				ctx.Set(utils.NoDownloaderFlag.Name, "true")
+				ctx.Set(utils.HTTPEnabledFlag.Name, "false")
+				ctx.Set(utils.TxPoolDisableFlag.Name, "true")
+
+				if !ctx.IsSet(erigoncli.SyncLoopBlockLimitFlag.Name) {
+					ctx.Set(erigoncli.SyncLoopBlockLimitFlag.Name, "100000")
+				}
+
+				if !ctx.IsSet(erigoncli.FrozenBlockLimitFlag.Name) {
+					ctx.Set(erigoncli.FrozenBlockLimitFlag.Name, "1500000")
+				}
+
+				if !ctx.IsSet(erigoncli.SyncLoopPruneLimitFlag.Name) {
+					ctx.Set(erigoncli.SyncLoopPruneLimitFlag.Name, "100000")
+				}
+
 				return nil
 			},
 		},


### PR DESCRIPTION
This fixes a couple of regressions for running the uploader for mumbai

* Now flags have moved to a higher context they need to be set in the context not the flag values
* Span 0 of mumbai has a header/span mismatch for span zero sprint 0.  So the check here needs to be suppressed