### PR TITLE
polygon/sync: span updates

### DIFF
--- a/polygon/sync/canonical_chain_builder.go
+++ b/polygon/sync/canonical_chain_builder.go
@@ -36,20 +36,21 @@ type canonicalChainBuilderImpl struct {
 	root *forkTreeNode
 	tip  *forkTreeNode
 
-	difficultyCalc DifficultyCalculator
-
+	difficultyCalc  DifficultyCalculator
 	headerValidator HeaderValidator
+	spansCache      *SpansCache
 }
 
 func NewCanonicalChainBuilder(
 	root *types.Header,
 	difficultyCalc DifficultyCalculator,
 	headerValidator HeaderValidator,
+	spansCache *SpansCache,
 ) CanonicalChainBuilder {
 	impl := &canonicalChainBuilderImpl{
-		difficultyCalc: difficultyCalc,
-
+		difficultyCalc:  difficultyCalc,
 		headerValidator: headerValidator,
+		spansCache:      spansCache,
 	}
 	impl.Reset(root)
 	return impl
@@ -62,6 +63,9 @@ func (impl *canonicalChainBuilderImpl) Reset(root *types.Header) {
 		headerHash: root.Hash(),
 	}
 	impl.tip = impl.root
+	if impl.spansCache != nil {
+		impl.spansCache.Prune(root.Number.Uint64())
+	}
 }
 
 // depth-first search
@@ -137,8 +141,11 @@ func (impl *canonicalChainBuilderImpl) Prune(newRootNum uint64) error {
 	for newRoot.header.Number.Uint64() > newRootNum {
 		newRoot = newRoot.parent
 	}
-
 	impl.root = newRoot
+
+	if impl.spansCache != nil {
+		impl.spansCache.Prune(newRootNum)
+	}
 	return nil
 }
 

--- a/polygon/sync/canonical_chain_builder_test.go
+++ b/polygon/sync/canonical_chain_builder_test.go
@@ -34,7 +34,7 @@ func makeRoot() *types.Header {
 
 func makeCCB(root *types.Header) CanonicalChainBuilder {
 	difficultyCalc := testDifficultyCalculator{}
-	builder := NewCanonicalChainBuilder(root, &difficultyCalc, nil)
+	builder := NewCanonicalChainBuilder(root, &difficultyCalc, nil, nil)
 	return builder
 }
 

--- a/polygon/sync/spans_cache.go
+++ b/polygon/sync/spans_cache.go
@@ -1,0 +1,36 @@
+package sync
+
+import heimdallspan "github.com/ledgerwatch/erigon/polygon/heimdall/span"
+
+type SpansCache struct {
+	spans map[uint64]*heimdallspan.HeimdallSpan
+}
+
+func NewSpansCache() *SpansCache {
+	return &SpansCache{
+		spans: make(map[uint64]*heimdallspan.HeimdallSpan),
+	}
+}
+
+func (cache *SpansCache) Add(span *heimdallspan.HeimdallSpan) {
+	cache.spans[span.StartBlock] = span
+}
+
+// SpanAt finds a span that contains blockNum.
+func (cache *SpansCache) SpanAt(blockNum uint64) *heimdallspan.HeimdallSpan {
+	for _, span := range cache.spans {
+		if (span.StartBlock <= blockNum) && (blockNum <= span.EndBlock) {
+			return span
+		}
+	}
+	return nil
+}
+
+// Prune removes spans that ended before blockNum.
+func (cache *SpansCache) Prune(blockNum uint64) {
+	for key, span := range cache.spans {
+		if span.EndBlock < blockNum {
+			delete(cache.spans, key)
+		}
+	}
+}


### PR DESCRIPTION
It is possible that a span update happens during a milestone.
A headers slice might cross to the new span.
Also if 2 forks evolve simulaneously, a shorter fork can still be in the previous span.
In these cases we need access to the previous span to calculate difficulty and validate header times.

SpansCache will keep recent spans.
The cache will be updated on new span events from the heimdall.
The cache is pruned on new milestone events and in practice no more than 2 spans are kept.

The header difficulty calculation and time validation depends on having a span for that header in the cache.
