### PR TITLE
fix udpOrHttpTrackers amount

### DIFF
--- a/erigon-lib/downloader/util.go
+++ b/erigon-lib/downloader/util.go
@@ -47,7 +47,7 @@ import (
 	"github.com/ledgerwatch/erigon-lib/kv"
 )
 
-// udpOrHttpTrackers - torrent library spawning several goroutines and producing many requests for each tracker. So we limit amout of trackers by 7
+// udpOrHttpTrackers - torrent library spawning several goroutines and producing many requests for each tracker. So we limit amout of trackers by 8
 var udpOrHttpTrackers = []string{
 	"udp://tracker.opentrackr.org:1337/announce",
 	"udp://9.rarbg.com:2810/announce",


### PR DESCRIPTION
seems we just choose the first 8 trackers in https://github.com/ledgerwatch/trackerslist/blob/master/trackers_best.txt.