### PR TITLE
e35: helper to get latest Tx of step 

### DIFF
--- a/erigon-lib/state/aggregator_v3.go
+++ b/erigon-lib/state/aggregator_v3.go
@@ -125,7 +125,6 @@ func NewAggregatorV3(ctx context.Context, dirs datadir.Dirs, aggregationStep uin
 		tmpdir:                 tmpdir,
 		aggregationStep:        aggregationStep,
 		db:                     db,
-		keepInDB:               1 * aggregationStep,
 		leakDetector:           dbg.NewLeakDetector("agg", dbg.SlowTx()),
 		ps:                     background.NewProgressSet(),
 		backgroundResult:       &BackgroundResult{},
@@ -187,6 +186,7 @@ func NewAggregatorV3(ctx context.Context, dirs datadir.Dirs, aggregationStep uin
 	if a.tracesTo, err = NewInvertedIndex(idxCfg, aggregationStep, "tracesto", kv.TblTracesToKeys, kv.TblTracesToIdx, false, true, nil, logger); err != nil {
 		return nil, err
 	}
+	a.KeepStepsInDB(1)
 	a.recalcMaxTxNum()
 
 	if dbg.NoSync() {
@@ -252,7 +252,7 @@ func (a *AggregatorV3) OpenFolder(readonly bool) error {
 	if mx > 0 {
 		mx--
 	}
-	a.aggregatedStep.Store(mx / a.aggregationStep)
+	a.aggregatedStep.Store(mx / a.StepSize())
 	return nil
 }
 
@@ -278,7 +278,7 @@ func (a *AggregatorV3) OpenList(files []string, readonly bool) error {
 	if mx > 0 {
 		mx--
 	}
-	a.aggregatedStep.Store(mx / a.aggregationStep)
+	a.aggregatedStep.Store(mx / a.StepSize())
 	return nil
 }
 
@@ -492,20 +492,19 @@ func (a *AggregatorV3) buildFiles(ctx context.Context, step uint64) error {
 
 	var (
 		logEvery      = time.NewTicker(time.Second * 30)
-		txFrom        = step * a.aggregationStep
-		txTo          = (step + 1) * a.aggregationStep
+		txFrom        = a.FirstTxNumInStep(step)
+		txTo          = a.LastTxNumOfStep(step) + 1
 		stepStartedAt = time.Now()
+
+		static          AggV3StaticFiles
+		closeCollations = true
+		collListMu      = sync.Mutex{}
+		collations      = make([]Collation, 0)
 	)
 
 	defer logEvery.Stop()
-
 	defer a.needSaveFilesListInDB.Store(true)
 	defer a.recalcMaxTxNum()
-	var static AggV3StaticFiles
-
-	closeCollations := true
-	collListMu := sync.Mutex{}
-	collations := make([]Collation, 0)
 	defer func() {
 		if !closeCollations {
 			return
@@ -648,7 +647,7 @@ func (a *AggregatorV3) mergeLoopStep(ctx context.Context) (somethingDone bool, e
 	defer mxRunningMerges.Dec()
 
 	closeAll := true
-	maxSpan := a.aggregationStep * StepsInColdFile
+	maxSpan := StepsInColdFile * a.StepSize()
 	r := ac.findMergeRange(a.minimaxTxNumInFiles.Load(), maxSpan)
 	if !r.any() {
 		return false, nil
@@ -826,7 +825,6 @@ func (ac *AggregatorV3Context) PruneSmallBatches(ctx context.Context, timeout ti
 			return ctx.Err()
 		default:
 		}
-
 	}
 }
 
@@ -905,9 +903,9 @@ func (ac *AggregatorV3Context) Prune(ctx context.Context, tx kv.RwTx, limit uint
 		limit = uint64(math2.MaxUint64)
 	}
 
-	var txFrom, txTo uint64
+	var txFrom, txTo uint64 // txFrom is always 0 to avoid dangling keys in indices/hist
 	step := ac.a.aggregatedStep.Load()
-	txTo = (step + 1) * ac.a.aggregationStep
+	txTo = ac.a.LastTxNumOfStep(step) + 1 // +1 to preserve prune range as [txFrom, txTo)
 
 	if logEvery == nil {
 		logEvery = time.NewTicker(30 * time.Second)
@@ -972,7 +970,7 @@ func (ac *AggregatorV3Context) LogStats(tx kv.Tx, tx2block func(endTxNumMinimax 
 	str := make([]string, 0, len(ac.account.files))
 	for _, item := range ac.account.files {
 		bn := tx2block(item.endTxNum)
-		str = append(str, fmt.Sprintf("%d=%dK", item.endTxNum/ac.a.aggregationStep, bn/1_000))
+		str = append(str, fmt.Sprintf("%d=%dK", item.endTxNum/ac.a.StepSize(), bn/1_000))
 	}
 	//str2 := make([]string, 0, len(ac.storage.files))
 	//for _, item := range ac.storage.files {
@@ -987,7 +985,7 @@ func (ac *AggregatorV3Context) LogStats(tx kv.Tx, tx2block func(endTxNumMinimax 
 		lastCommitmentTxNum = ac.commitment.files[len(ac.commitment.files)-1].endTxNum
 		lastCommitmentBlockNum = tx2block(lastCommitmentTxNum)
 	}
-	firstHistoryIndexBlockInDB := tx2block(ac.a.accounts.FirstStepInDB(tx) * ac.a.aggregationStep)
+	firstHistoryIndexBlockInDB := tx2block(ac.a.accounts.FirstStepInDB(tx) * ac.a.StepSize())
 	var m runtime.MemStats
 	dbg.ReadMemStats(&m)
 	log.Info("[snapshots] History Stat",
@@ -1026,6 +1024,16 @@ func (a *AggregatorV3) FilesAmount() []int {
 		a.logAddrs.files.Len(),
 		a.logTopics.files.Len(),
 	}
+}
+
+func (a *AggregatorV3) FirstTxNumInStep(step uint64) uint64 {
+	return step * a.StepSize()
+}
+
+// step 0 is a range [0, stepSize). So last tx num in step 0 is stepSize-1.
+// We prune by step and range [a,b) so when pruning called need to add +1 to result
+func (a *AggregatorV3) LastTxNumOfStep(step uint64) uint64 {
+	return (step+1)*a.StepSize() - 1
 }
 
 func (a *AggregatorV3) EndTxNumDomainsFrozen() uint64 {
@@ -1398,7 +1406,7 @@ func (a *AggregatorV3) cleanAfterNewFreeze(in MergedFilesV3) {
 // KeepStepsInDB - usually equal to one a.aggregationStep, but when we exec blocks from snapshots
 // we can set it to 0, because no re-org on this blocks are possible
 func (a *AggregatorV3) KeepStepsInDB(steps uint64) *AggregatorV3 {
-	a.keepInDB = steps * a.aggregationStep
+	a.keepInDB = a.FirstTxNumInStep(steps)
 	return a
 }
 
@@ -1422,7 +1430,7 @@ func (a *AggregatorV3) BuildFilesInBackground(txNum uint64) chan struct{} {
 		return fin
 	}
 
-	step := a.minimaxTxNumInFiles.Load() / a.aggregationStep
+	step := a.minimaxTxNumInFiles.Load() / a.StepSize()
 	a.wg.Add(1)
 	go func() {
 		defer a.wg.Done()

--- a/erigon-lib/state/domain_shared.go
+++ b/erigon-lib/state/domain_shared.go
@@ -130,7 +130,7 @@ func (sd *SharedDomains) AggCtx() interface{} { return sd.aggCtx }
 
 // aggregator context should call aggCtx.Unwind before this one.
 func (sd *SharedDomains) Unwind(ctx context.Context, rwTx kv.RwTx, blockUnwindTo, txUnwindTo uint64) error {
-	step := txUnwindTo / sd.aggCtx.a.aggregationStep
+	step := txUnwindTo / sd.aggCtx.a.StepSize()
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
 	sd.aggCtx.a.logger.Info("aggregator unwind", "step", step,

--- a/erigon-lib/state/inverted_index.go
+++ b/erigon-lib/state/inverted_index.go
@@ -970,6 +970,7 @@ func (is *InvertedIndexPruneStat) Accumulate(other *InvertedIndexPruneStat) {
 }
 
 // [txFrom; txTo)
+// forced - prune even if CanPrune returns false, so its true only when we do Unwind.
 func (ic *InvertedIndexContext) Prune(ctx context.Context, rwTx kv.RwTx, txFrom, txTo, limit uint64, logEvery *time.Ticker, forced bool, fn func(key []byte, txnum []byte) error) (stat *InvertedIndexPruneStat, err error) {
 	stat = &InvertedIndexPruneStat{MinTxNum: math.MaxUint64}
 	if !forced && !ic.CanPrune(rwTx) {


### PR DESCRIPTION
added `LastTxNumOfStep` helper. It returns LATEST tx of given step (eg `stepSize=10; [0, 9]`).
So for Pruning we have to make +1 to preserve pruning range of [0;10) (in this example).