### PR TITLE
turbo/jsonrpc: fix GetBlockTransactionCountByNumber & ByHash for blocks with bor state sync event txn

### DIFF
--- a/turbo/jsonrpc/eth_block.go
+++ b/turbo/jsonrpc/eth_block.go
@@ -153,11 +153,10 @@ func (api *APIImpl) CallBundle(ctx context.Context, txHashes []common.Hash, stat
 	// and apply the message.
 	gp := new(core.GasPool).AddGas(math.MaxUint64).AddBlobGas(math.MaxUint64)
 
-	var results []map[string]interface{}
-
 	bundleHash := cryptopool.NewLegacyKeccak256()
 	defer cryptopool.ReturnToPoolKeccak256(bundleHash)
 
+	results := make([]map[string]interface{}, 0, len(txs))
 	for _, txn := range txs {
 		msg, err := txn.AsMessage(*signer, nil, rules)
 		msg.SetCheckNonce(false)

--- a/turbo/jsonrpc/eth_block.go
+++ b/turbo/jsonrpc/eth_block.go
@@ -6,16 +6,13 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/ledgerwatch/erigon-lib/common/hexutil"
-	"github.com/ledgerwatch/erigon/cl/clparams"
-	"github.com/ledgerwatch/erigon/polygon/bor/borcfg"
-
 	"github.com/ledgerwatch/log/v3"
 
 	"github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/common/hexutil"
 	"github.com/ledgerwatch/erigon-lib/common/hexutility"
 	"github.com/ledgerwatch/erigon-lib/kv"
-
+	"github.com/ledgerwatch/erigon/cl/clparams"
 	"github.com/ledgerwatch/erigon/common/math"
 	"github.com/ledgerwatch/erigon/core"
 	"github.com/ledgerwatch/erigon/core/rawdb"
@@ -23,6 +20,7 @@ import (
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/core/vm"
 	"github.com/ledgerwatch/erigon/crypto/cryptopool"
+	"github.com/ledgerwatch/erigon/polygon/bor/borcfg"
 	"github.com/ledgerwatch/erigon/rpc"
 	"github.com/ledgerwatch/erigon/turbo/adapter/ethapi"
 	"github.com/ledgerwatch/erigon/turbo/rpchelper"
@@ -155,7 +153,7 @@ func (api *APIImpl) CallBundle(ctx context.Context, txHashes []common.Hash, stat
 	// and apply the message.
 	gp := new(core.GasPool).AddGas(math.MaxUint64).AddBlobGas(math.MaxUint64)
 
-	results := []map[string]interface{}{}
+	var results []map[string]interface{}
 
 	bundleHash := cryptopool.NewLegacyKeccak256()
 	defer cryptopool.ReturnToPoolKeccak256(bundleHash)

--- a/turbo/jsonrpc/eth_block.go
+++ b/turbo/jsonrpc/eth_block.go
@@ -345,6 +345,23 @@ func (api *APIImpl) GetBlockTransactionCountByNumber(ctx context.Context, blockN
 	if err != nil {
 		return nil, err
 	}
+
+	chainConfig, err := api.chainConfig(tx)
+	if err != nil {
+		return nil, err
+	}
+
+	if chainConfig.Bor != nil {
+		borStateSyncTxHash := types.ComputeBorTxHash(blockNum, blockHash)
+		_, ok, err := api._blockReader.EventLookup(ctx, tx, borStateSyncTxHash)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			txAmount++
+		}
+	}
+
 	numOfTx := hexutil.Uint(txAmount)
 
 	return &numOfTx, nil
@@ -369,6 +386,23 @@ func (api *APIImpl) GetBlockTransactionCountByHash(ctx context.Context, blockHas
 	if err != nil {
 		return nil, err
 	}
+
+	chainConfig, err := api.chainConfig(tx)
+	if err != nil {
+		return nil, err
+	}
+
+	if chainConfig.Bor != nil {
+		borStateSyncTxHash := types.ComputeBorTxHash(blockNum, blockHash)
+		_, ok, err := api._blockReader.EventLookup(ctx, tx, borStateSyncTxHash)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			txAmount++
+		}
+	}
+
 	numOfTx := hexutil.Uint(txAmount)
 
 	return &numOfTx, nil


### PR DESCRIPTION
Fix for https://github.com/ledgerwatch/erigon/issues/7504#issuecomment-1891149390

Tests:

Prior to this fix the below endpoints were returning "0xa" (10) which is incorrect - should be "0xb" (11)
```
➜  ~ curl http://localhost:9545/ \                                                                                        
  -X POST \
  -H "Content-Type: application/json" \
  --data '{"method":"eth_getBlockTransactionCountByNumber","params":["0x7F3A00"],"id":1,"jsonrpc":"2.0"}'

{"jsonrpc":"2.0","id":1,"result":"0xb"}
````

```
➜  ~ curl http://localhost:9545/ \
  -X POST \
  -H "Content-Type: application/json" \
  --data '{"method":"eth_getBlockTransactionCountByHash","params":["0xb681901447981864462b5bf3004814c436b308150e6369341524b6e215092676"],"id":1,"jsonrpc":"2.0"}'

{"jsonrpc":"2.0","id":1,"result":"0xb"}
```