### PR TITLE
Pass slice of versionedHashes by value

### DIFF
--- a/cl/persistence/block_saver_test.go
+++ b/cl/persistence/block_saver_test.go
@@ -37,7 +37,7 @@ func (m *mockEngine) FrozenBlocks() uint64 {
 	panic("unimplemented")
 }
 
-func (m *mockEngine) NewPayload(payload *cltypes.Eth1Block, beaconParentRoot *libcommon.Hash, expectedBlobsHashes *[]libcommon.Hash) (bool, error) {
+func (m *mockEngine) NewPayload(payload *cltypes.Eth1Block, beaconParentRoot *libcommon.Hash, expectedBlobsHashes []libcommon.Hash) (bool, error) {
 	panic("unimplemented")
 }
 

--- a/cl/phase1/execution_client/execution_client_direct.go
+++ b/cl/phase1/execution_client/execution_client_direct.go
@@ -23,7 +23,7 @@ func NewExecutionClientDirect(ctx context.Context, chainRW eth1_chain_reader.Cha
 	}, nil
 }
 
-func (cc *ExecutionClientDirect) NewPayload(payload *cltypes.Eth1Block, beaconParentRoot *libcommon.Hash, versionedHashes *[]libcommon.Hash) (invalid bool, err error) {
+func (cc *ExecutionClientDirect) NewPayload(payload *cltypes.Eth1Block, beaconParentRoot *libcommon.Hash, versionedHashes []libcommon.Hash) (invalid bool, err error) {
 	if payload == nil {
 		return
 	}

--- a/cl/phase1/execution_client/execution_client_rpc.go
+++ b/cl/phase1/execution_client/execution_client_rpc.go
@@ -54,7 +54,7 @@ func NewExecutionClientRPC(ctx context.Context, jwtSecret []byte, addr string, p
 	}, nil
 }
 
-func (cc *ExecutionClientRpc) NewPayload(payload *cltypes.Eth1Block, beaconParentRoot *libcommon.Hash, versionedHashes *[]libcommon.Hash) (invalid bool, err error) {
+func (cc *ExecutionClientRpc) NewPayload(payload *cltypes.Eth1Block, beaconParentRoot *libcommon.Hash, versionedHashes []libcommon.Hash) (invalid bool, err error) {
 	if payload == nil {
 		return
 	}
@@ -114,7 +114,7 @@ func (cc *ExecutionClientRpc) NewPayload(payload *cltypes.Eth1Block, beaconParen
 	log.Debug("[ExecutionClientRpc] Calling EL", "method", engineMethod)
 	args := []interface{}{request}
 	if versionedHashes != nil {
-		args = append(args, *versionedHashes, *beaconParentRoot)
+		args = append(args, versionedHashes, *beaconParentRoot)
 	}
 	err = cc.client.CallContext(cc.ctx, &payloadStatus, engineMethod, args...)
 	if err != nil {

--- a/cl/phase1/execution_client/interface.go
+++ b/cl/phase1/execution_client/interface.go
@@ -12,7 +12,7 @@ var errContextExceeded = "rpc error: code = DeadlineExceeded desc = context dead
 // ExecutionEngine is used only for syncing up very close to chain tip and to stay in sync.
 // It pretty much mimics engine API.
 type ExecutionEngine interface {
-	NewPayload(payload *cltypes.Eth1Block, beaconParentRoot *libcommon.Hash, versionedHashes *[]libcommon.Hash) (bool, error)
+	NewPayload(payload *cltypes.Eth1Block, beaconParentRoot *libcommon.Hash, versionedHashes []libcommon.Hash) (bool, error)
 	ForkChoiceUpdate(finalized libcommon.Hash, head libcommon.Hash) error
 	SupportInsertion() bool
 	InsertBlocks([]*types.Block) error

--- a/cl/phase1/forkchoice/on_block.go
+++ b/cl/phase1/forkchoice/on_block.go
@@ -48,15 +48,15 @@ func (f *ForkChoiceStore) OnBlock(block *cltypes.SignedBeaconBlock, newPayload, 
 		return nil
 	}
 	// Now we find the versioned hashes
-	var versionedHashes *[]libcommon.Hash
+	var versionedHashes []libcommon.Hash
 	if newPayload && f.engine != nil && block.Version() >= clparams.DenebVersion {
-		versionedHashes = &[]libcommon.Hash{}
+		versionedHashes = []libcommon.Hash{}
 		solid.RangeErr[*cltypes.KZGCommitment](block.Block.Body.BlobKzgCommitments, func(i1 int, k *cltypes.KZGCommitment, i2 int) error {
 			versionedHash, err := kzgCommitmentToVersionedHash(k)
 			if err != nil {
 				return err
 			}
-			*versionedHashes = append(*versionedHashes, versionedHash)
+			versionedHashes = append(versionedHashes, versionedHash)
 			return nil
 		})
 	}

--- a/turbo/engineapi/engine_server.go
+++ b/turbo/engineapi/engine_server.go
@@ -212,7 +212,7 @@ func (s *EngineServer) newPayload(ctx context.Context, req *engine_types.Executi
 	s.logger.Debug("[NewPayload] sending block", "height", header.Number, "hash", blockHash)
 	block := types.NewBlockFromStorage(blockHash, &header, transactions, nil /* uncles */, withdrawals)
 
-	payloadStatus, err := s.HandleNewPayload("NewPayload", block, &expectedBlobHashes)
+	payloadStatus, err := s.HandleNewPayload("NewPayload", block, expectedBlobHashes)
 	if err != nil {
 		if errors.Is(err, consensus.ErrInvalidBlock) {
 			return &engine_types.PayloadStatus{
@@ -689,7 +689,7 @@ func compareCapabilities(from []string, to []string) []string {
 func (e *EngineServer) HandleNewPayload(
 	logPrefix string,
 	block *types.Block,
-	versionedHashes *[]libcommon.Hash,
+	versionedHashes []libcommon.Hash,
 ) (*engine_types.PayloadStatus, error) {
 	header := block.Header()
 	headerNumber := header.Number.Uint64()

--- a/turbo/execution/eth1/eth1_chain_reader.go/chain_reader.go
+++ b/turbo/execution/eth1/eth1_chain_reader.go/chain_reader.go
@@ -282,7 +282,7 @@ func (c ChainReaderWriterEth1) InsertBlocksAndWait(blocks []*types.Block) error 
 	return nil
 }
 
-func (c ChainReaderWriterEth1) InsertBlockAndWait(block *types.Block, versionedHashes *[]libcommon.Hash) error {
+func (c ChainReaderWriterEth1) InsertBlockAndWait(block *types.Block, versionedHashes []libcommon.Hash) error {
 	blocks := []*types.Block{block}
 	request := &execution.InsertBlocksRequest{
 		Blocks: eth1_utils.ConvertBlocksToRPC(blocks),
@@ -290,8 +290,8 @@ func (c ChainReaderWriterEth1) InsertBlockAndWait(block *types.Block, versionedH
 
 	if versionedHashes != nil {
 		request.Blocks[0].CheckExpectedBlobHashes = true
-		request.Blocks[0].ExpectedBlobHashes = make([]*types2.H256, len(*versionedHashes))
-		for i, h := range *versionedHashes {
+		request.Blocks[0].ExpectedBlobHashes = make([]*types2.H256, len(versionedHashes))
+		for i, h := range versionedHashes {
 			request.Blocks[0].ExpectedBlobHashes[i] = gointerfaces.ConvertHashToH256(h)
 		}
 	}


### PR DESCRIPTION
golang slice can be `nil`. There's no reason to pass it by pointer.

This is a fix to PR #9257. It fixes the following error in Hive test "Withdrawals Fork on Block 1 (Paris)":
```
<< (0953747c) {"jsonrpc":"2.0","id":5,"error":{"code":-32000,"message":"ethereumExecutionModule.InsertBlocks: blob gas used is nil"}}
CLMocker: Could not ExecutePayloadV1: ethereumExecutionModule.InsertBlocks: blob gas used is nil
CLMocker: BroadcastNewPayload Error (0953747c): ethereumExecutionModule.InsertBlocks: blob gas used is nil
```