### PR TITLE
Unbound variable error in silkworm_compat_check

### DIFF
--- a/turbo/silkworm/silkworm_compat_check.sh
+++ b/turbo/silkworm/silkworm_compat_check.sh
@@ -40,6 +40,10 @@ case $(uname -s) in
 			exit 2
 		fi
 
+        # The os-release file does not require any variables to be set
+        # so we define these two to avoid 'unbound variable' errors.
+        ID=""
+        VERSION_ID=""
 		source "$OS_RELEASE_PATH"
 
         if [[ -n "$ID" ]] && [[ -n "$VERSION_ID" ]]


### PR DESCRIPTION
The silkworm_compat_check.sh script assumes that the os-release file declares both VERSION and VERSION_ID.  However, in the specification at:

https://www.freedesktop.org/software/systemd/man/latest/os-release.html

All of the variables simply _may_ be declared, and none are strictly required.  In particular, for Archlinux the file looks like:

```
NAME="Arch Linux"
PRETTY_NAME="Arch Linux"
ID=arch
BUILD_ID=rolling
ANSI_COLOR="38;2;23;147;209"
HOME_URL="https://archlinux.org/"
DOCUMENTATION_URL="https://wiki.archlinux.org/"
SUPPORT_URL="https://bbs.archlinux.org/"
BUG_REPORT_URL="https://gitlab.archlinux.org/groups/archlinux/-/issues"
PRIVACY_POLICY_URL="https://terms.archlinux.org/docs/privacy-policy/"
LOGO=archlinux-logo
```

And although an up to date Archlinux system has adequate library versions for silkworm, the script ends up terminating with an:

```
silkworm_compat_check.sh: line 45: VERSION_ID: unbound variable
```

This change simply defines those variables before sourcing to avoid the error.  If the preference is not to support silkworm on distros other than ubuntu/debian, then additional script changes are required. However, given that the variables are being checked for 'non-empty' first, I believe simply defining them to be empty strings is the correct behavior.