### PR TITLE
devnet: skip TestStateSync until fixed (#9290)

### DIFF
--- a/cmd/devnet/tests/bor_devnet_test.go
+++ b/cmd/devnet/tests/bor_devnet_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestStateSync(t *testing.T) {
+	t.Skip()
+
 	runCtx, err := ContextStart(t, networkname.BorDevnetChainName)
 	require.Nil(t, err)
 	var ctx context.Context = runCtx


### PR DESCRIPTION
see https://github.com/ledgerwatch/erigon/issues/9290

I don't have enough knowledge about this flow of events, in particular, why pendingCheckpoint is expected to be present as soon as rootHeaderBlockChan produces a value.
Before we figure this out, I suggest to skip the test, because it currently ruins the CI integration tests suite for the others:
https://github.com/ledgerwatch/erigon/actions/workflows/test-integration.yml?query=branch%3Adevel