### PR TITLE
downloader: prohibit_new_downloads.lock check missed download .torrent from WebSeed

### DIFF
--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -21,8 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"os"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -41,7 +39,6 @@ import (
 	"github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/common/datadir"
 	"github.com/ledgerwatch/erigon-lib/common/dbg"
-	"github.com/ledgerwatch/erigon-lib/common/dir"
 	"github.com/ledgerwatch/erigon-lib/diagnostics"
 	"github.com/ledgerwatch/erigon-lib/downloader/downloadercfg"
 	"github.com/ledgerwatch/erigon-lib/downloader/snaptype"
@@ -145,27 +142,6 @@ func New(ctx context.Context, cfg *downloadercfg.Cfg, dirs datadir.Dirs, logger 
 		}
 	}()
 	return d, nil
-}
-
-const ProhibitNewDownloadsFileName = "prohibit_new_downloads.lock"
-
-// Erigon "download once" - means restart/upgrade/downgrade will not download files (and will be fast)
-// After "download once" - Erigon will produce and seed new files
-// Downloader will able: seed new files (already existing on FS), download uncomplete parts of existing files (if Verify found some bad parts)
-func (d *Downloader) prohibitNewDownloads() error {
-	fPath := filepath.Join(d.SnapDir(), ProhibitNewDownloadsFileName)
-	f, err := os.Create(fPath)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	if err := f.Sync(); err != nil {
-		return err
-	}
-	return nil
-}
-func (d *Downloader) newDownloadsAreProhibited() bool {
-	return dir.FileExist(filepath.Join(d.SnapDir(), ProhibitNewDownloadsFileName))
 }
 
 func (d *Downloader) MainLoopInBackground(silent bool) {
@@ -605,7 +581,7 @@ func (d *Downloader) AddMagnetLink(ctx context.Context, infoHash metainfo.Hash, 
 	if d.alreadyHaveThisName(name) {
 		return nil
 	}
-	if d.newDownloadsAreProhibited() {
+	if d.torrentFiles.newDownloadsAreProhibited() {
 		return nil
 	}
 

--- a/erigon-lib/downloader/downloader_grpc_server.go
+++ b/erigon-lib/downloader/downloader_grpc_server.go
@@ -46,7 +46,7 @@ type GrpcServer struct {
 }
 
 func (s *GrpcServer) ProhibitNewDownloads(context.Context, *proto_downloader.ProhibitNewDownloadsRequest) (*emptypb.Empty, error) {
-	if err := s.d.prohibitNewDownloads(); err != nil {
+	if err := s.d.torrentFiles.prohibitNewDownloads(); err != nil {
 		return nil, err
 	}
 	return nil, nil

--- a/erigon-lib/downloader/torrent_files.go
+++ b/erigon-lib/downloader/torrent_files.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/anacrolix/torrent"
@@ -28,8 +29,10 @@ func (tf *TorrentFiles) Exists(name string) bool {
 }
 
 func (tf *TorrentFiles) exists(name string) bool {
-	fPath := filepath.Join(tf.dir, name)
-	return dir2.FileExist(fPath + ".torrent")
+	if !strings.HasSuffix(name, ".torrent") {
+		name += ".torrent"
+	}
+	return dir2.FileExist(filepath.Join(tf.dir, name))
 }
 func (tf *TorrentFiles) Delete(name string) error {
 	tf.lock.Lock()

--- a/erigon-lib/downloader/torrent_files.go
+++ b/erigon-lib/downloader/torrent_files.go
@@ -128,7 +128,15 @@ const ProhibitNewDownloadsFileName = "prohibit_new_downloads.lock"
 func (tf *TorrentFiles) prohibitNewDownloads() error {
 	tf.lock.Lock()
 	defer tf.lock.Unlock()
-	fPath := filepath.Join(tf.dir, ProhibitNewDownloadsFileName)
+	return CreateProhibitNewDownloadsFile(tf.dir)
+}
+func (tf *TorrentFiles) newDownloadsAreProhibited() bool {
+	tf.lock.Lock()
+	defer tf.lock.Unlock()
+	return dir2.FileExist(filepath.Join(tf.dir, ProhibitNewDownloadsFileName))
+}
+func CreateProhibitNewDownloadsFile(dir string) error {
+	fPath := filepath.Join(dir, ProhibitNewDownloadsFileName)
 	f, err := os.Create(fPath)
 	if err != nil {
 		return err
@@ -138,9 +146,4 @@ func (tf *TorrentFiles) prohibitNewDownloads() error {
 		return err
 	}
 	return nil
-}
-func (tf *TorrentFiles) newDownloadsAreProhibited() bool {
-	tf.lock.Lock()
-	defer tf.lock.Unlock()
-	return dir2.FileExist(filepath.Join(tf.dir, ProhibitNewDownloadsFileName))
 }

--- a/erigon-lib/downloader/torrent_files.go
+++ b/erigon-lib/downloader/torrent_files.go
@@ -41,8 +41,10 @@ func (tf *TorrentFiles) Delete(name string) error {
 }
 
 func (tf *TorrentFiles) delete(name string) error {
-	fPath := filepath.Join(tf.dir, name)
-	return os.Remove(fPath + ".torrent")
+	if !strings.HasSuffix(name, ".torrent") {
+		name += ".torrent"
+	}
+	return os.Remove(filepath.Join(tf.dir, name))
 }
 
 func (tf *TorrentFiles) Create(torrentFilePath string, res []byte) error {
@@ -94,11 +96,10 @@ func (tf *TorrentFiles) createTorrentFromMetaInfo(fPath string, mi *metainfo.Met
 	return nil
 }
 
-func (tf *TorrentFiles) LoadByName(fName string) (*torrent.TorrentSpec, error) {
+func (tf *TorrentFiles) LoadByName(name string) (*torrent.TorrentSpec, error) {
 	tf.lock.Lock()
 	defer tf.lock.Unlock()
-	fPath := filepath.Join(tf.dir, fName+".torrent")
-	return tf.load(fPath)
+	return tf.load(filepath.Join(tf.dir, name))
 }
 
 func (tf *TorrentFiles) LoadByPath(fPath string) (*torrent.TorrentSpec, error) {
@@ -108,6 +109,9 @@ func (tf *TorrentFiles) LoadByPath(fPath string) (*torrent.TorrentSpec, error) {
 }
 
 func (tf *TorrentFiles) load(fPath string) (*torrent.TorrentSpec, error) {
+	if !strings.HasSuffix(fPath, ".torrent") {
+		fPath += ".torrent"
+	}
 	mi, err := metainfo.LoadFromFile(fPath)
 	if err != nil {
 		return nil, fmt.Errorf("LoadFromFile: %w, file=%s", err, fPath)

--- a/erigon-lib/downloader/webseed.go
+++ b/erigon-lib/downloader/webseed.go
@@ -237,6 +237,9 @@ func (d *WebSeeds) downloadTorrentFilesFromProviders(ctx context.Context, rootDi
 	if len(d.TorrentUrls()) == 0 {
 		return
 	}
+	if d.torrentFiles.newDownloadsAreProhibited() {
+		return
+	}
 	var addedNew int
 	e, ctx := errgroup.WithContext(ctx)
 	e.SetLimit(1024)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -266,15 +266,14 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 			config.Sync.UseSnapshots = useSnapshots
 			config.Snapshot.Enabled = ethconfig.UseSnapshotsByChainName(config.Genesis.Config.ChainName) && useSnapshots
 		}
-		if !config.Sync.UseSnapshots {
-			if err := downloader.CreateProhibitNewDownloadsFile(dirs.Snap); err != nil {
-				return err
-			}
-		}
-
 		return nil
 	}); err != nil {
 		return nil, err
+	}
+	if !config.Sync.UseSnapshots {
+		if err := downloader.CreateProhibitNewDownloadsFile(dirs.Snap); err != nil {
+			return nil, err
+		}
 	}
 
 	ctx, ctxCancel := context.WithCancel(context.Background())

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -266,6 +266,11 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 			config.Sync.UseSnapshots = useSnapshots
 			config.Snapshot.Enabled = ethconfig.UseSnapshotsByChainName(config.Genesis.Config.ChainName) && useSnapshots
 		}
+		if !config.Sync.UseSnapshots {
+			if err := downloader.CreateProhibitNewDownloadsFile(dirs.Snap); err != nil {
+				return err
+			}
+		}
 
 		return nil
 	}); err != nil {


### PR DESCRIPTION
moved `.lock` file handling inside `TorrentFiles` class - which is available everywhere and guarded by mutex. 

fixing: https://github.com/ledgerwatch/erigon/issues/9294