### PR TITLE
[wip] e35: caplin support `--sync.loop.block.limit` 

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -802,7 +802,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 		backend.sentriesClient.Hd,
 		engine_block_downloader.NewEngineBlockDownloader(ctx, logger, backend.sentriesClient.Hd, executionRpc,
 			backend.sentriesClient.Bd, backend.sentriesClient.BroadcastNewBlock, backend.sentriesClient.SendBodyRequest, blockReader,
-			backend.chainDB, chainConfig, tmpdir, config.Sync.BodyDownloadTimeoutSeconds),
+			backend.chainDB, chainConfig, tmpdir, config.Sync),
 		false,
 		config.Miner.EnabledPOS)
 	backend.engineBackendRPC = engineBackendRPC

--- a/turbo/engineapi/engine_block_downloader/core.go
+++ b/turbo/engineapi/engine_block_downloader/core.go
@@ -2,6 +2,7 @@ package engine_block_downloader
 
 import (
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/common/cmp"
 	"github.com/ledgerwatch/erigon-lib/gointerfaces/execution"
 	"github.com/ledgerwatch/erigon-lib/kv/mdbx"
 	"github.com/ledgerwatch/erigon-lib/kv/membatchwithdb"
@@ -61,6 +62,10 @@ func (e *EngineBlockDownloader) download(hashToDownload libcommon.Hash, requestI
 		e.logger.Warn("[EngineBlockDownloader] Could load headers", "err", err)
 		e.status.Store(headerdownload.Idle)
 		return
+	}
+
+	if e.syncCfg.LoopBlockLimit > 0 {
+		endBlock = cmp.Min(endBlock, startBlock+uint64(e.syncCfg.LoopBlockLimit))
 	}
 
 	// bodiesCollector := etl.NewCollector("EngineBlockDownloader", e.tmpdir, etl.NewSortableBuffer(etl.BufferOptimalSize), e.logger)


### PR DESCRIPTION
hmmm... current implementation doesn't work - after downloading 1K of bodies erigon does download all headers again... @Giulio2002, hi, maybe you can advise better implementation?  
