### PR TITLE
txpool: fix initial blockGasLimit and setBlobFee()

### DIFF
--- a/consensus/misc/eip1559.go
+++ b/consensus/misc/eip1559.go
@@ -63,17 +63,17 @@ var Eip1559FeeCalculator eip1559Calculator
 
 type eip1559Calculator struct{}
 
-func (f eip1559Calculator) CurrentFees(chainConfig *chain.Config, db kv.Getter) (baseFee uint64, blobFee uint64, minBlobGasPrice uint64, err error) {
+func (f eip1559Calculator) CurrentFees(chainConfig *chain.Config, db kv.Getter) (baseFee, blobFee, minBlobGasPrice, blockGasLimit uint64, err error) {
 	hash := rawdb.ReadHeadHeaderHash(db)
 
 	if hash == (libcommon.Hash{}) {
-		return 0, 0, 0, fmt.Errorf("can't get head header hash")
+		return 0, 0, 0, 0, fmt.Errorf("can't get head header hash")
 	}
 
 	currentHeader, err := rawdb.ReadHeaderByHash(db, hash)
 
 	if err != nil {
-		return 0, 0, 0, err
+		return 0, 0, 0, 0, err
 	}
 
 	if chainConfig != nil {
@@ -92,7 +92,7 @@ func (f eip1559Calculator) CurrentFees(chainConfig *chain.Config, db kv.Getter) 
 
 	minBlobGasPrice = chainConfig.GetMinBlobGasPrice()
 
-	return baseFee, blobFee, minBlobGasPrice, nil
+	return baseFee, blobFee, minBlobGasPrice, currentHeader.GasLimit, nil
 }
 
 // CalcBaseFee calculates the basefee of the header.

--- a/erigon-lib/txpool/pool.go
+++ b/erigon-lib/txpool/pool.go
@@ -1317,7 +1317,7 @@ func (p *TxPool) setBaseFee(baseFee uint64) (uint64, bool) {
 
 func (p *TxPool) setBlobFee(blobFee uint64) {
 	if blobFee > 0 {
-		p.pendingBaseFee.Store(blobFee)
+		p.pendingBlobFee.Store(blobFee)
 	}
 }
 

--- a/erigon-lib/txpool/pool.go
+++ b/erigon-lib/txpool/pool.go
@@ -2090,7 +2090,10 @@ func (p *TxPool) fromDB(ctx context.Context, tx kv.Tx, coreTx kv.Tx) error {
 
 	if p.feeCalculator != nil {
 		if chainConfig, _ := ChainConfig(tx); chainConfig != nil {
-			pendingBaseFee, pendingBlobFee, minBlobGasPrice, _ = p.feeCalculator.CurrentFees(chainConfig, coreTx)
+			pendingBaseFee, pendingBlobFee, minBlobGasPrice, err = p.feeCalculator.CurrentFees(chainConfig, coreTx)
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
PR #9219 missed blockGasLimit.

This PR fixes a failure in Hive test "Withdrawals Fork on Block 1 (Paris)"  due to transactions excluded from block 1 because of failing `NotTooMuchGas` check.