### PR TITLE
hive: engine-cancun: fix return error code and bit of refactoring

### DIFF
--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -18,6 +18,22 @@ package rpc
 
 import "fmt"
 
+const (
+	// Engine API errors
+	SERVER_ERROR         = -32000
+	INVALID_REQUEST      = -32600
+	METHOD_NOT_FOUND     = -32601
+	INVALID_PARAMS_ERROR = -32602
+	INTERNAL_ERROR       = -32603
+	INVALID_JSON         = -32700
+
+	UNKNOWN_PAYLOAD            = -38001
+	INVALID_FORKCHOICE_STATE   = -38002
+	INVALID_PAYLOAD_ATTRIBUTES = -38003
+	TOO_LARGE_REQUEST          = -38004
+	UNSUPPORTED_FORK_ERROR     = -38005
+)
+
 var (
 	_ Error = new(methodNotFoundError)
 	_ Error = new(subscriptionNotFoundError)
@@ -89,3 +105,7 @@ type CustomError struct {
 func (e *CustomError) ErrorCode() int { return e.Code }
 
 func (e *CustomError) Error() string { return e.Message }
+
+func MakeError(errCode int, msg string) *CustomError {
+	return &CustomError{Code: errCode, Message: msg}
+}

--- a/turbo/engineapi/engine_helpers/constants.go
+++ b/turbo/engineapi/engine_helpers/constants.go
@@ -1,10 +1,3 @@
 package engine_helpers
 
-import "github.com/ledgerwatch/erigon/rpc"
-
 const MaxBuilders = 128
-
-var UnknownPayloadErr = rpc.CustomError{Code: -38001, Message: "Unknown payload"}
-var InvalidForkchoiceStateErr = rpc.CustomError{Code: -38002, Message: "Invalid forkchoice state"}
-var InvalidPayloadAttributesErr = rpc.CustomError{Code: -38003, Message: "Invalid payload attributes"}
-var TooLargeRequestErr = rpc.CustomError{Code: -38004, Message: "Too large request"}


### PR DESCRIPTION
In general it is a bad practice to keep 2 or more separate code parts that do the same thing. So in this PR I removed errors in engine_helpers and created a function in rpc that creates an error based on error code. Additionally I am thinking to remove all errors in rpc.errors except methodNotFoundError and subscriptionNotFoundError since they seem to have constant return message. 