### PR TITLE
Fix mapmutation size update

### DIFF
--- a/erigon-lib/kv/membatch/mapmutation.go
+++ b/erigon-lib/kv/membatch/mapmutation.go
@@ -149,7 +149,7 @@ func (m *Mapmutation) Put(table string, k, v []byte) error {
 	stringKey := string(k)
 
 	var ok bool
-	if _, ok = m.puts[table][stringKey]; !ok {
+	if _, ok = m.puts[table][stringKey]; ok {
 		m.size += len(v) - len(m.puts[table][stringKey])
 		m.puts[table][stringKey] = v
 		return nil

--- a/erigon-lib/kv/membatch/mapmutation_test.go
+++ b/erigon-lib/kv/membatch/mapmutation_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon-lib/kv/memdb"
 	"github.com/ledgerwatch/log/v3"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,10 +23,16 @@ func TestMapmutation_Flush_Close(t *testing.T) {
 	defer func() {
 		batch.Close()
 	}()
+	assert.Equal(t, batch.size, 0)
 	err = batch.Put(kv.ChaindataTables[0], []byte{1}, []byte{1})
 	require.NoError(t, err)
+	assert.Equal(t, batch.size, 2)
 	err = batch.Put(kv.ChaindataTables[0], []byte{2}, []byte{2})
 	require.NoError(t, err)
+	assert.Equal(t, batch.size, 4)
+	err = batch.Put(kv.ChaindataTables[0], []byte{1}, []byte{3, 2, 1, 0})
+	require.NoError(t, err)
+	assert.Equal(t, batch.size, 7)
 	err = batch.Flush(context.Background(), tx)
 	require.NoError(t, err)
 	batch.Close()


### PR DESCRIPTION
When putting a `key, value` pair into the memory batch, the size count in bytes must be updated accordingly (i.e. add key length plus value length when key is not present, add value length diff when key is already present) but the presence check logic is inverted.