### PR TITLE
turbo/jsonrpc: fix accidental regression in ReplayBlockTransactions

### DIFF
--- a/turbo/jsonrpc/trace_adhoc.go
+++ b/turbo/jsonrpc/trace_adhoc.go
@@ -874,6 +874,7 @@ func (api *TraceAPIImpl) ReplayBlockTransactions(ctx context.Context, blockNrOrH
 		if traceTypeVmTrace {
 			tr.VmTrace = trace.VmTrace
 		}
+		tr.TransactionHash = trace.TransactionHash
 		result[i] = tr
 	}
 


### PR DESCRIPTION
Context: accidentally removed this line in https://github.com/ledgerwatch/erigon/pull/9276/files#diff-6d65959a2517f728bf3c59ed6bb41c1d71528e80fd0f8c9e155d4fde65e0b006L867-L868 - adding back