### PR TITLE
turbo/snapshotsync/freezeblocks: move pending funcs to full block reader interface

### DIFF
--- a/cmd/rpcdaemon/rpcservices/eth_backend.go
+++ b/cmd/rpcdaemon/rpcservices/eth_backend.go
@@ -9,18 +9,18 @@ import (
 	"io"
 	"sync/atomic"
 
-	"github.com/ledgerwatch/erigon-lib/common"
-	"github.com/ledgerwatch/erigon-lib/gointerfaces"
-	"github.com/ledgerwatch/erigon-lib/gointerfaces/remote"
-	"github.com/ledgerwatch/erigon-lib/kv"
-	"github.com/ledgerwatch/erigon/eth/ethconfig"
 	"github.com/ledgerwatch/log/v3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	"github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/gointerfaces"
+	"github.com/ledgerwatch/erigon-lib/gointerfaces/remote"
+	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon/core/rawdb"
 	"github.com/ledgerwatch/erigon/core/types"
+	"github.com/ledgerwatch/erigon/eth/ethconfig"
 	"github.com/ledgerwatch/erigon/ethdb/privateapi"
 	"github.com/ledgerwatch/erigon/p2p"
 	"github.com/ledgerwatch/erigon/rlp"
@@ -51,12 +51,22 @@ func (back *RemoteBackend) CanPruneTo(currentBlockInDB uint64) (canPruneBlocksTo
 func (back *RemoteBackend) HeadersRange(ctx context.Context, walker func(header *types.Header) error) error {
 	panic("not implemented")
 }
+
+func (back *RemoteBackend) Integrity(_ context.Context) error {
+	panic("not implemented")
+}
+
 func (back *RemoteBackend) CurrentBlock(db kv.Tx) (*types.Block, error) {
 	panic("not implemented")
 }
 func (back *RemoteBackend) RawTransactions(ctx context.Context, tx kv.Getter, fromBlock, toBlock uint64) (txs [][]byte, err error) {
 	panic("not implemented")
 }
+
+func (back *RemoteBackend) FirstTxnNumNotInSnapshots() uint64 {
+	panic("not implemented")
+}
+
 func (back *RemoteBackend) ReadAncestor(db kv.Getter, hash common.Hash, number, ancestor uint64, maxNonCanonical *uint64) (common.Hash, uint64) {
 	panic("not implemented")
 }
@@ -241,6 +251,11 @@ func (back *RemoteBackend) BadHeaderNumber(ctx context.Context, tx kv.Getter, ha
 func (back *RemoteBackend) BlockWithSenders(ctx context.Context, tx kv.Getter, hash common.Hash, blockNum uint64) (block *types.Block, senders []common.Address, err error) {
 	return back.blockReader.BlockWithSenders(ctx, tx, hash, blockNum)
 }
+
+func (back *RemoteBackend) IterateFrozenBodies(_ func(blockNum uint64, baseTxNum uint64, txAmount uint64) error) error {
+	panic("not implemented")
+}
+
 func (back *RemoteBackend) BodyWithTransactions(ctx context.Context, tx kv.Getter, hash common.Hash, blockNum uint64) (body *types.Body, err error) {
 	return back.blockReader.BodyWithTransactions(ctx, tx, hash, blockNum)
 }
@@ -271,8 +286,25 @@ func (back *RemoteBackend) EventLookup(ctx context.Context, tx kv.Getter, txnHas
 func (back *RemoteBackend) EventsByBlock(ctx context.Context, tx kv.Tx, hash common.Hash, blockNum uint64) ([]rlp.RawValue, error) {
 	return back.blockReader.EventsByBlock(ctx, tx, hash, blockNum)
 }
+
+func (back *RemoteBackend) LastEventID(_ kv.RwTx) (uint64, error) {
+	panic("not implemented")
+}
+
+func (back *RemoteBackend) LastFrozenEventID() uint64 {
+	panic("not implemented")
+}
+
 func (back *RemoteBackend) Span(ctx context.Context, tx kv.Getter, spanId uint64) ([]byte, error) {
 	return back.blockReader.Span(ctx, tx, spanId)
+}
+
+func (back *RemoteBackend) LastSpanID(_ kv.RwTx) (uint64, bool, error) {
+	panic("not implemented")
+}
+
+func (back *RemoteBackend) LastFrozenSpanID() uint64 {
+	panic("not implemented")
 }
 
 func (back *RemoteBackend) NodeInfo(ctx context.Context, limit uint32) ([]p2p.NodeInfo, error) {

--- a/eth/integrity/no_gaps_in_canonical_headers.go
+++ b/eth/integrity/no_gaps_in_canonical_headers.go
@@ -5,24 +5,24 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/ledgerwatch/log/v3"
+
 	"github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon/core/rawdb"
 	"github.com/ledgerwatch/erigon/eth/stagedsync/stages"
 	"github.com/ledgerwatch/erigon/turbo/services"
-	"github.com/ledgerwatch/erigon/turbo/snapshotsync/freezeblocks"
-	"github.com/ledgerwatch/log/v3"
 )
 
-func NoGapsInCanonicalHeaders(tx kv.Tx, ctx context.Context, br services.BlockReader) {
+func NoGapsInCanonicalHeaders(tx kv.Tx, ctx context.Context, br services.FullBlockReader) {
 	logEvery := time.NewTicker(10 * time.Second)
 	defer logEvery.Stop()
 
-	if err := br.(*freezeblocks.BlockReader).Integrity(ctx); err != nil {
+	if err := br.Integrity(ctx); err != nil {
 		panic(err)
 	}
 
-	firstBlockInDB := br.(*freezeblocks.BlockReader).FrozenBlocks() + 1
+	firstBlockInDB := br.FrozenBlocks() + 1
 	lastBlockNum, err := stages.GetStageProgress(tx, stages.Headers)
 	if err != nil {
 		panic(err)

--- a/eth/stagedsync/bor_heimdall_shared.go
+++ b/eth/stagedsync/bor_heimdall_shared.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math/big"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/ledgerwatch/log/v3"
@@ -19,74 +18,13 @@ import (
 	"github.com/ledgerwatch/erigon/polygon/heimdall"
 	"github.com/ledgerwatch/erigon/rlp"
 	"github.com/ledgerwatch/erigon/turbo/services"
+	"github.com/ledgerwatch/erigon/turbo/snapshotsync/freezeblocks"
 )
 
 var (
 	ErrHeaderValidatorsLengthMismatch = errors.New("header validators length mismatch")
 	ErrHeaderValidatorsBytesMismatch  = errors.New("header validators bytes mismatch")
 )
-
-// LastSpanID TODO - move to block reader
-func LastSpanID(tx kv.RwTx, blockReader services.FullBlockReader) (uint64, bool, error) {
-	sCursor, err := tx.Cursor(kv.BorSpans)
-	if err != nil {
-		return 0, false, err
-	}
-
-	defer sCursor.Close()
-	k, _, err := sCursor.Last()
-	if err != nil {
-		return 0, false, err
-	}
-
-	var lastSpanId uint64
-	if k != nil {
-		lastSpanId = binary.BigEndian.Uint64(k)
-	}
-
-	// TODO tidy this out when moving to block reader
-	type LastFrozen interface {
-		LastFrozenSpanID() uint64
-	}
-
-	snapshotLastSpanId := blockReader.(LastFrozen).LastFrozenSpanID()
-	if snapshotLastSpanId > lastSpanId {
-		return snapshotLastSpanId, true, nil
-	}
-
-	return lastSpanId, k != nil, nil
-}
-
-// LastStateSyncEventID TODO - move to block reader
-func LastStateSyncEventID(tx kv.RwTx, blockReader services.FullBlockReader) (uint64, error) {
-	cursor, err := tx.Cursor(kv.BorEvents)
-	if err != nil {
-		return 0, err
-	}
-
-	defer cursor.Close()
-	k, _, err := cursor.Last()
-	if err != nil {
-		return 0, err
-	}
-
-	var lastEventId uint64
-	if k != nil {
-		lastEventId = binary.BigEndian.Uint64(k)
-	}
-
-	// TODO tidy this out when moving to block reader
-	type LastFrozen interface {
-		LastFrozenEventID() uint64
-	}
-
-	snapshotLastEventId := blockReader.(LastFrozen).LastFrozenEventID()
-	if snapshotLastEventId > lastEventId {
-		return snapshotLastEventId, nil
-	}
-
-	return lastEventId, nil
-}
 
 func FetchSpanZeroForMiningIfNeeded(
 	ctx context.Context,
@@ -97,18 +35,16 @@ func FetchSpanZeroForMiningIfNeeded(
 ) error {
 	return db.Update(ctx, func(tx kv.RwTx) error {
 		_, err := blockReader.Span(ctx, tx, 0)
-		if err == nil {
+		if err != nil {
+			if errors.Is(err, freezeblocks.SpanNotFoundErr) {
+				_, err = fetchAndWriteHeimdallSpan(ctx, 0, tx, heimdallClient, "FetchSpanZeroForMiningIfNeeded", logger)
+				return err
+			}
+
 			return err
 		}
 
-		// TODO refactor to use errors.Is
-		if !strings.Contains(err.Error(), "not found") {
-			// span exists, no need to fetch
-			return nil
-		}
-
-		_, err = fetchAndWriteHeimdallSpan(ctx, 0, tx, heimdallClient, "FetchSpanZeroForMiningIfNeeded", logger)
-		return err
+		return nil
 	})
 }
 
@@ -133,7 +69,7 @@ func fetchRequiredHeimdallSpansIfNeeded(
 		requiredSpanID++
 	}
 
-	lastSpanID, exists, err := LastSpanID(tx, cfg.blockReader)
+	lastSpanID, exists, err := cfg.blockReader.LastSpanID(tx)
 	if err != nil {
 		return 0, err
 	}

--- a/eth/stagedsync/stage_bor_heimdall.go
+++ b/eth/stagedsync/stage_bor_heimdall.go
@@ -181,7 +181,7 @@ func BorHeimdallForward(
 		return err
 	}
 
-	lastStateSyncEventID, err := LastStateSyncEventID(tx, cfg.blockReader)
+	lastStateSyncEventID, err := cfg.blockReader.LastEventID(tx)
 	if err != nil {
 		return err
 	}

--- a/eth/stagedsync/stage_mining_bor_heimdall.go
+++ b/eth/stagedsync/stage_mining_bor_heimdall.go
@@ -65,7 +65,7 @@ func MiningBorHeimdallForward(
 		logPrefix,
 		logger,
 		func() (uint64, error) {
-			return LastStateSyncEventID(tx, cfg.blockReader)
+			return cfg.blockReader.LastEventID(tx)
 		},
 	)
 	if err != nil {

--- a/eth/stagedsync/stage_snapshots.go
+++ b/eth/stagedsync/stage_snapshots.go
@@ -31,12 +31,11 @@ import (
 	"github.com/ledgerwatch/erigon-lib/downloader"
 	"github.com/ledgerwatch/erigon-lib/downloader/snaptype"
 	"github.com/ledgerwatch/erigon-lib/etl"
-	proto_downloader "github.com/ledgerwatch/erigon-lib/gointerfaces/downloader"
+	protodownloader "github.com/ledgerwatch/erigon-lib/gointerfaces/downloader"
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon-lib/kv/kvcfg"
 	"github.com/ledgerwatch/erigon-lib/kv/rawdbv3"
 	"github.com/ledgerwatch/erigon-lib/state"
-
 	"github.com/ledgerwatch/erigon/core/rawdb"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/eth/ethconfig"
@@ -56,7 +55,7 @@ type SnapshotsCfg struct {
 	dirs        datadir.Dirs
 
 	blockRetire        services.BlockRetire
-	snapshotDownloader proto_downloader.DownloaderClient
+	snapshotDownloader protodownloader.DownloaderClient
 	blockReader        services.FullBlockReader
 	notifier           *shards.Notifications
 
@@ -73,7 +72,7 @@ func StageSnapshotsCfg(db kv.RwDB,
 	syncConfig ethconfig.Sync,
 	dirs datadir.Dirs,
 	blockRetire services.BlockRetire,
-	snapshotDownloader proto_downloader.DownloaderClient,
+	snapshotDownloader protodownloader.DownloaderClient,
 	blockReader services.FullBlockReader,
 	notifier *shards.Notifications,
 	historyV3 bool,
@@ -348,10 +347,7 @@ func FillDBFromSnapshots(logPrefix string, ctx context.Context, tx kv.RwTx, dirs
 			}
 
 		case stages.Bodies:
-			type LastTxNumProvider interface {
-				FirstTxNumNotInSnapshots() uint64
-			}
-			firstTxNum := blockReader.(LastTxNumProvider).FirstTxNumNotInSnapshots()
+			firstTxNum := blockReader.FirstTxnNumNotInSnapshots()
 			// ResetSequence - allow set arbitrary value to sequence (for example to decrement it to exact value)
 			if err := rawdb.ResetSequence(tx, kv.EthTx, firstTxNum); err != nil {
 				return err
@@ -366,10 +362,7 @@ func FillDBFromSnapshots(logPrefix string, ctx context.Context, tx kv.RwTx, dirs
 			}
 			if historyV3 {
 				_ = tx.ClearBucket(kv.MaxTxNum)
-				type IterBody interface {
-					IterateFrozenBodies(f func(blockNum, baseTxNum, txAmount uint64) error) error
-				}
-				if err := blockReader.(IterBody).IterateFrozenBodies(func(blockNum, baseTxNum, txAmount uint64) error {
+				if err := blockReader.IterateFrozenBodies(func(blockNum, baseTxNum, txAmount uint64) error {
 					select {
 					case <-ctx.Done():
 						return ctx.Err()
@@ -448,7 +441,7 @@ func SnapshotsPrune(s *PruneState, initialCycle bool, cfg SnapshotsCfg, ctx cont
 				//}
 
 				if !(cfg.snapshotDownloader == nil || reflect.ValueOf(cfg.snapshotDownloader).IsNil()) {
-					_, err := cfg.snapshotDownloader.Delete(ctx, &proto_downloader.DeleteRequest{Paths: l})
+					_, err := cfg.snapshotDownloader.Delete(ctx, &protodownloader.DeleteRequest{Paths: l})
 					return err
 				}
 

--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -15,25 +15,23 @@ import (
 	"time"
 
 	"github.com/c2h5oh/datasize"
-	"github.com/ledgerwatch/erigon-lib/chain/snapcfg"
-	"github.com/ledgerwatch/erigon-lib/common/dbg"
-	"github.com/ledgerwatch/erigon-lib/common/dir"
-	"github.com/ledgerwatch/erigon-lib/metrics"
-	"github.com/ledgerwatch/erigon/eth/integrity"
 	"github.com/ledgerwatch/log/v3"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/sync/semaphore"
 
+	"github.com/ledgerwatch/erigon-lib/chain/snapcfg"
 	"github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/common/datadir"
+	"github.com/ledgerwatch/erigon-lib/common/dbg"
+	"github.com/ledgerwatch/erigon-lib/common/dir"
 	"github.com/ledgerwatch/erigon-lib/compress"
 	"github.com/ledgerwatch/erigon-lib/etl"
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon-lib/kv/kvcfg"
 	"github.com/ledgerwatch/erigon-lib/kv/mdbx"
 	"github.com/ledgerwatch/erigon-lib/kv/rawdbv3"
+	"github.com/ledgerwatch/erigon-lib/metrics"
 	libstate "github.com/ledgerwatch/erigon-lib/state"
-
 	"github.com/ledgerwatch/erigon/cmd/hack/tool/fromdb"
 	"github.com/ledgerwatch/erigon/cmd/utils"
 	"github.com/ledgerwatch/erigon/core/rawdb"
@@ -41,6 +39,7 @@ import (
 	"github.com/ledgerwatch/erigon/diagnostics"
 	"github.com/ledgerwatch/erigon/eth/ethconfig"
 	"github.com/ledgerwatch/erigon/eth/ethconfig/estimate"
+	"github.com/ledgerwatch/erigon/eth/integrity"
 	"github.com/ledgerwatch/erigon/eth/stagedsync/stages"
 	"github.com/ledgerwatch/erigon/params"
 	erigoncli "github.com/ledgerwatch/erigon/turbo/cli"
@@ -228,7 +227,7 @@ func doIntegrity(cliCtx *cli.Context) error {
 		return err
 	}
 
-	//if err := blockReader.(*freezeblocks.BlockReader).IntegrityTxnID(false); err != nil {
+	//if err := blockReader.IntegrityTxnID(false); err != nil {
 	//	return err
 	//}
 

--- a/turbo/services/interfaces.go
+++ b/turbo/services/interfaces.go
@@ -3,13 +3,14 @@ package services
 import (
 	"context"
 
+	"github.com/ledgerwatch/log/v3"
+
 	"github.com/ledgerwatch/erigon-lib/chain"
 	"github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/eth/ethconfig"
 	"github.com/ledgerwatch/erigon/rlp"
-	"github.com/ledgerwatch/log/v3"
 )
 
 type All struct {
@@ -21,6 +22,7 @@ type BlockReader interface {
 	BlockByHash(ctx context.Context, db kv.Tx, hash common.Hash) (*types.Block, error)
 	CurrentBlock(db kv.Tx) (*types.Block, error)
 	BlockWithSenders(ctx context.Context, tx kv.Getter, hash common.Hash, blockNum uint64) (block *types.Block, senders []common.Address, err error)
+	IterateFrozenBodies(f func(blockNum, baseTxNum, txAmount uint64) error) error
 }
 
 type HeaderReader interface {
@@ -29,17 +31,22 @@ type HeaderReader interface {
 	HeaderByHash(ctx context.Context, tx kv.Getter, hash common.Hash) (*types.Header, error)
 	ReadAncestor(db kv.Getter, hash common.Hash, number, ancestor uint64, maxNonCanonical *uint64) (common.Hash, uint64)
 
-	//TODO: change it to `iter`
+	// HeadersRange - TODO: change it to `iter`
 	HeadersRange(ctx context.Context, walker func(header *types.Header) error) error
+	Integrity(ctx context.Context) error
 }
 
 type BorEventReader interface {
 	EventLookup(ctx context.Context, tx kv.Getter, txnHash common.Hash) (uint64, bool, error)
 	EventsByBlock(ctx context.Context, tx kv.Tx, hash common.Hash, blockNum uint64) ([]rlp.RawValue, error)
+	LastEventID(tx kv.RwTx) (uint64, error)
+	LastFrozenEventID() uint64
 }
 
 type BorSpanReader interface {
 	Span(ctx context.Context, tx kv.Getter, spanNum uint64) ([]byte, error)
+	LastSpanID(tx kv.RwTx) (uint64, bool, error)
+	LastFrozenSpanID() uint64
 }
 
 type CanonicalReader interface {
@@ -58,7 +65,9 @@ type TxnReader interface {
 	TxnLookup(ctx context.Context, tx kv.Getter, txnHash common.Hash) (uint64, bool, error)
 	TxnByIdxInBlock(ctx context.Context, tx kv.Getter, blockNum uint64, i int) (txn types.Transaction, err error)
 	RawTransactions(ctx context.Context, tx kv.Getter, fromBlock, toBlock uint64) (txs [][]byte, err error)
+	FirstTxnNumNotInSnapshots() uint64
 }
+
 type HeaderAndCanonicalReader interface {
 	HeaderReader
 	CanonicalReader
@@ -66,7 +75,6 @@ type HeaderAndCanonicalReader interface {
 
 type BlockAndTxnReader interface {
 	BlockReader
-	//HeaderReader
 	TxnReader
 }
 
@@ -104,22 +112,6 @@ type BlockRetire interface {
 	BuildMissedIndicesIfNeed(ctx context.Context, logPrefix string, notifier DBEventNotifier, cc *chain.Config) error
 	SetWorkers(workers int)
 }
-
-/*
-type HeaderWriter interface {
-	WriteHeader(tx kv.RwTx, header *types.Header) error
-	WriteHeaderRaw(tx kv.StatelessRwTx, number uint64, hash libcommon.Hash, headerRlp []byte, skipIndexing bool) error
-	WriteCanonicalHash(tx kv.RwTx, hash libcommon.Hash, number uint64) error
-	WriteTd(db kv.Putter, hash libcommon.Hash, number uint64, td *big.Int) error
-	// [from,to)
-	FillHeaderNumberIndex(logPrefix string, tx kv.RwTx, tmpDir string, from, to uint64, ctx context.Context, logger log.Logger) error
-}
-type BlockWriter interface {
-	HeaderWriter
-	WriteRawBodyIfNotExists(tx kv.RwTx, hash libcommon.Hash, number uint64, body *types.RawBody) (ok bool, lastTxnNum uint64, err error)
-	WriteBody(tx kv.RwTx, hash libcommon.Hash, number uint64, body *types.Body) error
-}
-*/
 
 type DBEventNotifier interface {
 	OnNewSnapshot()

--- a/turbo/snapshotsync/freezeblocks/block_reader.go
+++ b/turbo/snapshotsync/freezeblocks/block_reader.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math"
 	"sort"
@@ -25,6 +26,8 @@ import (
 	"github.com/ledgerwatch/erigon/turbo/services"
 )
 
+var SpanNotFoundErr = errors.New("span not found")
+
 type RemoteBlockReader struct {
 	client remote.ETHBACKENDClient
 }
@@ -44,10 +47,19 @@ func (r *RemoteBlockReader) CurrentBlock(db kv.Tx) (*types.Block, error) {
 func (r *RemoteBlockReader) RawTransactions(ctx context.Context, tx kv.Getter, fromBlock, toBlock uint64) (txs [][]byte, err error) {
 	panic("not implemented")
 }
+
+func (r *RemoteBlockReader) FirstTxnNumNotInSnapshots() uint64 {
+	panic("not implemented")
+}
+
 func (r *RemoteBlockReader) ReadAncestor(db kv.Getter, hash common.Hash, number, ancestor uint64, maxNonCanonical *uint64) (common.Hash, uint64) {
 	panic("not implemented")
 }
 func (r *RemoteBlockReader) HeadersRange(ctx context.Context, walker func(header *types.Header) error) error {
+	panic("not implemented")
+}
+
+func (r *RemoteBlockReader) Integrity(_ context.Context) error {
 	panic("not implemented")
 }
 
@@ -170,6 +182,10 @@ func (r *RemoteBlockReader) BlockWithSenders(ctx context.Context, _ kv.Getter, h
 	return block, senders, nil
 }
 
+func (r *RemoteBlockReader) IterateFrozenBodies(_ func(blockNum uint64, baseTxNum uint64, txAmount uint64) error) error {
+	panic("not implemented")
+}
+
 func (r *RemoteBlockReader) Header(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (*types.Header, error) {
 	block, _, err := r.BlockWithSenders(ctx, tx, hash, blockHeight)
 	if err != nil {
@@ -237,8 +253,24 @@ func (r *RemoteBlockReader) EventsByBlock(ctx context.Context, tx kv.Tx, hash co
 	return result, nil
 }
 
-func (r *RemoteBlockReader) Span(ctx context.Context, tx kv.Getter, spanId uint64) ([]byte, error) {
-	return nil, nil
+func (r *RemoteBlockReader) LastEventID(_ kv.RwTx) (uint64, error) {
+	panic("not implemented")
+}
+
+func (r *RemoteBlockReader) LastFrozenEventID() uint64 {
+	panic("not implemented")
+}
+
+func (r *RemoteBlockReader) Span(_ context.Context, _ kv.Getter, _ uint64) ([]byte, error) {
+	panic("not implemented")
+}
+
+func (r *RemoteBlockReader) LastSpanID(_ kv.RwTx) (uint64, bool, error) {
+	panic("not implemented")
+}
+
+func (r *RemoteBlockReader) LastFrozenSpanID() uint64 {
+	panic("not implemented")
 }
 
 // BlockReader can read blocks from db and snapshots
@@ -834,7 +866,7 @@ func (r *BlockReader) TxnLookup(_ context.Context, tx kv.Getter, txnHash common.
 	return blockNum, ok, nil
 }
 
-func (r *BlockReader) FirstTxNumNotInSnapshots() uint64 {
+func (r *BlockReader) FirstTxnNumNotInSnapshots() uint64 {
 	view := r.sn.View()
 	defer view.Close()
 
@@ -1115,6 +1147,31 @@ func (r *BlockReader) EventsByBlock(ctx context.Context, tx kv.Tx, hash common.H
 	return result, nil
 }
 
+func (r *BlockReader) LastEventID(tx kv.RwTx) (uint64, error) {
+	cursor, err := tx.Cursor(kv.BorEvents)
+	if err != nil {
+		return 0, err
+	}
+
+	defer cursor.Close()
+	k, _, err := cursor.Last()
+	if err != nil {
+		return 0, err
+	}
+
+	var lastEventId uint64
+	if k != nil {
+		lastEventId = binary.BigEndian.Uint64(k)
+	}
+
+	snapshotLastEventId := r.LastFrozenEventID()
+	if snapshotLastEventId > lastEventId {
+		return snapshotLastEventId, nil
+	}
+
+	return lastEventId, nil
+}
+
 func (r *BlockReader) LastFrozenEventID() uint64 {
 	if r.borSn == nil {
 		return 0
@@ -1191,7 +1248,8 @@ func (r *BlockReader) Span(ctx context.Context, tx kv.Getter, spanId uint64) ([]
 			return nil, err
 		}
 		if v == nil {
-			return nil, fmt.Errorf("span %d not found (db), frozenBlocks=%d", spanId, maxBlockNumInFiles)
+			err := fmt.Errorf("span %d not found (db), frozenBlocks=%d", spanId, maxBlockNumInFiles)
+			return nil, fmt.Errorf("%w: %w", SpanNotFoundErr, err)
 		}
 		return common.Copy(v), nil
 	}
@@ -1220,7 +1278,33 @@ func (r *BlockReader) Span(ctx context.Context, tx kv.Getter, spanId uint64) ([]
 		result, _ := gg.Next(nil)
 		return common.Copy(result), nil
 	}
-	return nil, fmt.Errorf("span %d not found (snapshots)", spanId)
+	err := fmt.Errorf("span %d not found (snapshots)", spanId)
+	return nil, fmt.Errorf("%w: %w", SpanNotFoundErr, err)
+}
+
+func (r *BlockReader) LastSpanID(tx kv.RwTx) (uint64, bool, error) {
+	sCursor, err := tx.Cursor(kv.BorSpans)
+	if err != nil {
+		return 0, false, err
+	}
+
+	defer sCursor.Close()
+	k, _, err := sCursor.Last()
+	if err != nil {
+		return 0, false, err
+	}
+
+	var lastSpanId uint64
+	if k != nil {
+		lastSpanId = binary.BigEndian.Uint64(k)
+	}
+
+	snapshotLastSpanId := r.LastFrozenSpanID()
+	if snapshotLastSpanId > lastSpanId {
+		return snapshotLastSpanId, true, nil
+	}
+
+	return lastSpanId, k != nil, nil
 }
 
 // ---- Data Integrity part ----

--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -1641,7 +1641,7 @@ func DumpBlocks(ctx context.Context, version uint8, blockFrom, blockTo, blocksPe
 	}
 	chainConfig := fromdb.ChainConfig(chainDB)
 
-	firstTxNum := blockReader.(*BlockReader).FirstTxNumNotInSnapshots()
+	firstTxNum := blockReader.FirstTxnNumNotInSnapshots()
 	for i := blockFrom; i < blockTo; i = chooseSegmentEnd(i, blockTo, blocksPerFile) {
 		lastTxNum, err := dumpBlocksRange(ctx, version, i, chooseSegmentEnd(i, blockTo, blocksPerFile), tmpDir, snapDir, firstTxNum, chainDB, *chainConfig, workers, lvl, logger)
 		if err != nil {

--- a/turbo/snapshotsync/freezeblocks/bor_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/bor_snapshots.go
@@ -176,7 +176,7 @@ func (br *BlockRetire) retireBorBlocks(ctx context.Context, minBlockNum uint64, 
 	chainConfig := fromdb.ChainConfig(br.db)
 	notifier, logger, blockReader, tmpDir, db, workers := br.notifier, br.logger, br.blockReader, br.tmpDir, br.db, br.workers
 	snapshots := br.borSnapshots()
-	firstTxNum := blockReader.(*BlockReader).FirstTxNumNotInSnapshots()
+	firstTxNum := blockReader.FirstTxnNumNotInSnapshots()
 	blockFrom, blockTo, ok := CanRetire(maxBlockNum, minBlockNum)
 	if ok {
 		logger.Log(lvl, "[bor snapshots] Retire Bor Blocks", "range", fmt.Sprintf("%dk-%dk", blockFrom/1000, blockTo/1000))


### PR DESCRIPTION
- moves `LastSpanID`, `LastFrozenSpanID`, `LastStateSyncEventID`,  `LastFrozenEventID` bor related functionality to `BorSpanReader` and `BorEventReader` interfaces respectively
- introduces a `SpanNotFoundErr` in `BlockReader.Span` function for a more idiomatic Go handling of "not found" situations
- noticed a few random funcs that should have been moved to the block reader interfaces but have been hacked in - `IterateFrozenBodies`, `FirstTxnNumNotInSnapshots`, `Integrity` so added them to `BlockReader`, `HeaderReader` and `TxnReader` respectivelly
- note the remote block reader and remote backend currently would panic with "not implemented" for these functions - their implementations can be added on a "need to implement" basis