### PR TITLE
txpool: Respect updates to block gas limit

### DIFF
--- a/erigon-lib/txpool/pool.go
+++ b/erigon-lib/txpool/pool.go
@@ -402,7 +402,37 @@ func (p *TxPool) OnNewBlock(ctx context.Context, stateChanges *remote.StateChang
 	pendingBlobFee := stateChanges.PendingBlobFeePerGas
 	p.setBlobFee(pendingBlobFee)
 
-	p.blockGasLimit.Store(stateChanges.BlockGasLimit)
+	oldGasLimit := p.blockGasLimit.Swap(stateChanges.BlockGasLimit)
+	if oldGasLimit != stateChanges.BlockGasLimit {
+		p.all.ascendAll(func(mt *metaTx) bool {
+			var updated bool
+			if mt.Tx.Gas < stateChanges.BlockGasLimit {
+				updated = (mt.subPool & NotTooMuchGas) > 0
+				mt.subPool |= NotTooMuchGas
+			} else {
+				updated = (mt.subPool & NotTooMuchGas) == 0
+				mt.subPool &^= NotTooMuchGas
+			}
+
+			if mt.Tx.Traced {
+				p.logger.Info("TX TRACING: on block gas limit update", "idHash", fmt.Sprintf("%x", mt.Tx.IDHash), "senderId", mt.Tx.SenderID, "nonce", mt.Tx.Nonce, "subPool", mt.currentSubPool, "updated", updated)
+			}
+
+			if !updated {
+				return true
+			}
+
+			switch mt.currentSubPool {
+			case PendingSubPool:
+				p.pending.Updated(mt)
+			case BaseFeeSubPool:
+				p.baseFee.Updated(mt)
+			case QueuedSubPool:
+				p.queued.Updated(mt)
+			}
+			return true
+		})
+	}
 
 	for i, txn := range unwindBlobTxs.Txs {
 		if txn.Type == types.BlobTxType {


### PR DESCRIPTION
There is a bug in the txpool which can manifest either as a race condition, or in more novel network configurations.  When a transaction is classified as either having `NotTooMuchGas` or its complement, the classification will never change (unless a change to the sender account triggers reevaluation of that transaction).

If the block gas limit changes upwards, then any transactions previously not marked as `NotTooMuchGas` will remain ineligible for promotion. Similarly, if the block gas limit changes downwards, then any transactions previously marked as `NotTooMuchGas` may inappropriately remain as pending.

Although block gas limits may be relatively static in practice, there is additionally a race condition which can cause this bug to manifest. When the tx pool is first constructed, the gas limit is implicitly set to 0.  Until the first update arrives with the configured gas limit all transactions received will be categorized as using too much gas and will never recover.  This race condition was occurring in some integration tests we run.

This change adds a check in the `OnNewBlock` path which checks if the gas limit has changed, and if so triggers the re-evaluation of the `NotTooMuchGas` status for all transactions.

I am not an expert in the locking code for this path, but it looked like a lock was held and so these modifications should be safe.  But please ensure that aspect is adequately reviewed.