### PR TITLE
eth/stagedsync: fix span fetch logic for span 0 and 1

### DIFF
--- a/eth/stagedsync/bor_heimdall_shared.go
+++ b/eth/stagedsync/bor_heimdall_shared.go
@@ -58,7 +58,7 @@ func fetchRequiredHeimdallSpansIfNeeded(
 ) (uint64, error) {
 	requiredSpanID := bor.SpanIDAt(toBlockNum)
 	if requiredSpanID == 0 && toBlockNum >= cfg.borConfig.CalculateSprintLength(toBlockNum) {
-		// when in span 0 we fetch the next span (span 1) at the beginning of the sprint 2 (block 16 or later)
+		// when in span 0 we fetch the next span (span 1) at the beginning of sprint 2 (block 16 or later)
 		requiredSpanID++
 	} else if bor.IsBlockInLastSprintOfSpan(toBlockNum, cfg.borConfig) {
 		// for subsequent spans, we always fetch the next span at the beginning of the last sprint of a span

--- a/eth/stagedsync/bor_heimdall_shared.go
+++ b/eth/stagedsync/bor_heimdall_shared.go
@@ -57,15 +57,11 @@ func fetchRequiredHeimdallSpansIfNeeded(
 	logger log.Logger,
 ) (uint64, error) {
 	requiredSpanID := bor.SpanIDAt(toBlockNum)
-	// This check handles the case when we're in the last sprint of the current span
-	// and need to commit next span.
-	if bor.IsBlockInLastSprintOfSpan(toBlockNum, cfg.borConfig) {
+	if requiredSpanID == 0 && toBlockNum >= cfg.borConfig.CalculateSprintLength(toBlockNum) {
+		// when in span 0 we fetch the next span (span 1) at the beginning of the sprint 2 (block 16 or later)
 		requiredSpanID++
-	}
-
-	// This check handles the case when we need to fetch 1st span when we're starting
-	// the second sprint (of span 0, a special case to fetch span 1).
-	if bor.IsSecondSprintStart(toBlockNum, cfg.borConfig) {
+	} else if bor.IsBlockInLastSprintOfSpan(toBlockNum, cfg.borConfig) {
+		// for subsequent spans, we always fetch the next span at the beginning of the last sprint of a span
 		requiredSpanID++
 	}
 

--- a/eth/stagedsync/stage_bor_heimdall_test.go
+++ b/eth/stagedsync/stage_bor_heimdall_test.go
@@ -80,6 +80,41 @@ func TestBorHeimdallForwardFetchesFirstSpanDuringSecondSprintStart(t *testing.T)
 	require.Equal(t, uint64(6655), spans[1].EndBlock)
 }
 
+func TestBorHeimdallForwardFetchesFirstSpanAfterSecondSprintStart(t *testing.T) {
+	// Note this test differs from TestBorHeimdallForwardFetchesFirstSpanDuringSecondSprintStart
+	// since we should be able to handle both scenarios:
+	//   - calling the stage with toBlockNum=16
+	//   - calling the stage with toBlockNum=20 (some block num after second sprint start)
+	//
+	// span 0 and 1 are required at and after the start of second sprint (of 0th span) to commit
+	// in genesis contracts. we need span 1 at that time to mimic behaviour in bor.
+	t.Parallel()
+
+	ctx := context.Background()
+	numBlocks := 20 // After the start of 2nd sprint of 0th span
+	testHarness := stagedsynctest.InitHarness(ctx, t, stagedsynctest.HarnessCfg{
+		ChainConfig:            stagedsynctest.BorDevnetChainConfigWithNoBlockSealDelays(),
+		GenerateChainNumBlocks: numBlocks,
+		LogLvl:                 log.LvlInfo,
+	})
+	// pretend-update previous stage progress
+	testHarness.SaveStageProgress(ctx, t, stages.Headers, uint64(numBlocks))
+
+	// run stage under test
+	testHarness.RunStateSyncStageForward(t, stages.BorHeimdall)
+
+	// asserts
+	spans, err := testHarness.ReadSpansFromDB(ctx)
+	require.NoError(t, err)
+	require.Len(t, spans, 2)
+	require.Equal(t, heimdall.SpanId(0), spans[0].Id)
+	require.Equal(t, uint64(0), spans[0].StartBlock)
+	require.Equal(t, uint64(255), spans[0].EndBlock)
+	require.Equal(t, heimdall.SpanId(1), spans[1].Id)
+	require.Equal(t, uint64(256), spans[1].StartBlock)
+	require.Equal(t, uint64(6655), spans[1].EndBlock)
+}
+
 func TestBorHeimdallForwardFetchesNextSpanDuringLastSprintOfCurrentSpan(t *testing.T) {
 	// heimdall prepares the next span a number of sprints before the end of the current one
 	// we should be fetching the next span once we reach the last sprint of the current span

--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -1315,12 +1315,16 @@ func (c *Bor) checkAndCommitSpan(
 		return err
 	}
 
-	// check span is not set initially
+	// Whenever `checkAndCommitSpan` is called for the first time, during the start of 'technically'
+	// second sprint, we need the 0th as well as the 1st span. The contract returns an empty
+	// span (i.e. all fields set to 0). Span 0 doesn't need to be committed explicitly and
+	// is committed eventually when we commit 1st span (as per the contract). The check below
+	// takes care of that and commits the 1st span (hence the `currentSpan.Id+1` param).
 	if currentSpan.EndBlock == 0 {
-		return c.fetchAndCommitSpan(uint64(currentSpan.Id), state, header, chain, syscall)
+		return c.fetchAndCommitSpan(uint64(currentSpan.Id+1), state, header, chain, syscall)
 	}
 
-	// if current block is first block of last sprint in current span
+	// For subsequent calls, commit the next span on the first block of the last sprint of a span
 	sprintLength := c.config.CalculateSprintLength(headerNumber)
 	if currentSpan.EndBlock > sprintLength && currentSpan.EndBlock-sprintLength+1 == headerNumber {
 		return c.fetchAndCommitSpan(uint64(currentSpan.Id+1), state, header, chain, syscall)

--- a/polygon/bor/span_id.go
+++ b/polygon/bor/span_id.go
@@ -33,10 +33,3 @@ func IsBlockInLastSprintOfSpan(blockNum uint64, config *borcfg.BorConfig) bool {
 	startBlockNum := endBlockNum - sprintLen + 1
 	return startBlockNum <= blockNum && blockNum <= endBlockNum
 }
-
-// IsSecondSprintStart returns true if the block num is first block of second sprint
-// E.g. for sprint length 16, it will return true only for block 16. This is
-// to handle a special case for fetching 1st span.
-func IsSecondSprintStart(blockNum uint64, config *borcfg.BorConfig) bool {
-	return blockNum == config.CalculateSprintLength(blockNum)
-}


### PR DESCRIPTION
2 issues found when syncing from scratch on mumbai/bor-mainnet
- Issue is that `bor.IsSecondSprintStart` only checks if `toBlockNum` == `second sprint start` but doesn't handle the case of `toBlockNum` being after `second sprint start` - e.g. consider the case where the stage is called with fromBlockNum=57 and toBlockNum=67 as in the logs
- a previous bad merge had accidentally reverted a change in `polygon/bor/bor.go checkAndCommitSpan`

```
[INFO] [02-02|18:03:13.416] [3/15 BorHeimdall] Processing sync events... from=57 to=67
[INFO] [02-02|18:03:13.558] [3/15 BorHeimdall] Sync events processed progress=66 lastSpanID=0 lastStateSyncEventID=0 total records=0 fetch time=132.744042ms process time=142.111667ms
[EROR] [02-02|18:03:13.559] [staged sync] BorSpan failed             err="span 1 not found (db), frozenBlocks=0"
[EROR] [02-02|18:03:13.559] [bor] committing span                    err="Finalize.checkAndCommitSpan: unexpected end of JSON input"
[WARN] [02-02|18:03:13.559] [7/15 Execution] Execution failed        block=64 hash=0x1282336579c65abd423e2d5a647099d863dd38b082c0dce3c29e29bc77b3df0a err="invalid block: Finalize.checkAndCommitSpan: unexpected end of JSON input"
```