### PR TITLE
fix `find` warning

### DIFF
--- a/erigon-lib/tools/licenses_check.sh
+++ b/erigon-lib/tools/licenses_check.sh
@@ -21,7 +21,7 @@ fi
 # enable build tags to cover maximum .go files
 export GOFLAGS="-tags=gorules,linux,tools"
 
-output=$(find "$projectDir" -type 'd' -maxdepth 1 \
+output=$(find "$projectDir" -maxdepth 1 -type 'd' \
     -not -name ".*" \
     -not -name tools \
     -not -name build \


### PR DESCRIPTION
```
find: warning: you have specified the global option -maxdepth after the argument -type, but global options are not positional, i.e., -maxdepth affects tests specified before it as well as those specified after it.  Please specify global options before other arguments.
```