### PR TITLE
clean-exit test: avoid disk space exhaustion 

### DIFF
--- a/.github/workflows/qa-clean-exit-block-downloading.yml
+++ b/.github/workflows/qa-clean-exit-block-downloading.yml
@@ -40,6 +40,7 @@ jobs:
 
     - name: Restore Erigon Testbed Data Directory
       run: |
+        rm -rf $ERIGON_TESTBED_DATA_DIR/chaindata
         rsync -a --delete $ERIGON_REFERENCE_DATA_DIR/ $ERIGON_TESTBED_DATA_DIR/
 
     - name: Clean Erigon Build Directory


### PR DESCRIPTION
Delete destination chaindata before rsyncing to avoid "No space left on device"