### PR TITLE
Return error when no blob hashes in txn

### DIFF
--- a/core/types/blob_tx.go
+++ b/core/types/blob_tx.go
@@ -329,7 +329,9 @@ func (stx *BlobTx) DecodeRLP(s *rlp.Stream) error {
 	if err = decodeBlobVersionedHashes(&stx.BlobVersionedHashes, s); err != nil {
 		return err
 	}
-
+	if len(stx.BlobVersionedHashes) == 0 {
+		return fmt.Errorf("a blob tx must contain at least one blob")
+	}
 	// decode V
 	if b, err = s.Uint256Bytes(); err != nil {
 		return err


### PR DESCRIPTION
This was noticed when running a hive test targeted at failing when there are no versioned hashes in the tx