### PR TITLE
Add totalBlobPoolLimit flag

### DIFF
--- a/cmd/txpool/main.go
+++ b/cmd/txpool/main.go
@@ -50,11 +50,12 @@ var (
 	baseFeePoolLimit int
 	queuedPoolLimit  int
 
-	priceLimit    uint64
-	accountSlots  uint64
-	blobSlots     uint64
-	priceBump     uint64
-	blobPriceBump uint64
+	priceLimit         uint64
+	accountSlots       uint64
+	blobSlots          uint64
+	totalBlobPoolLimit uint64
+	priceBump          uint64
+	blobPriceBump      uint64
 
 	noTxGossip bool
 
@@ -80,6 +81,7 @@ func init() {
 	rootCmd.PersistentFlags().Uint64Var(&priceLimit, "txpool.pricelimit", txpoolcfg.DefaultConfig.MinFeeCap, "Minimum gas price (fee cap) limit to enforce for acceptance into the pool")
 	rootCmd.PersistentFlags().Uint64Var(&accountSlots, "txpool.accountslots", txpoolcfg.DefaultConfig.AccountSlots, "Minimum number of executable transaction slots guaranteed per account")
 	rootCmd.PersistentFlags().Uint64Var(&blobSlots, "txpool.blobslots", txpoolcfg.DefaultConfig.BlobSlots, "Max allowed total number of blobs (within type-3 txs) per account")
+	rootCmd.PersistentFlags().Uint64Var(&totalBlobPoolLimit, "txpool.totalblobpoollimit", txpoolcfg.DefaultConfig.TotalBlobPoolLimit, "Total limit of number of all blobs in txs within the txpool")
 	rootCmd.PersistentFlags().Uint64Var(&priceBump, "txpool.pricebump", txpoolcfg.DefaultConfig.PriceBump, "Price bump percentage to replace an already existing transaction")
 	rootCmd.PersistentFlags().Uint64Var(&blobPriceBump, "txpool.blobpricebump", txpoolcfg.DefaultConfig.BlobPriceBump, "Price bump percentage to replace an existing blob (type-3) transaction")
 	rootCmd.PersistentFlags().DurationVar(&commitEvery, utils.TxPoolCommitEveryFlag.Name, utils.TxPoolCommitEveryFlag.Value, utils.TxPoolCommitEveryFlag.Usage)
@@ -148,6 +150,7 @@ func doTxpool(ctx context.Context, logger log.Logger) error {
 	cfg.MinFeeCap = priceLimit
 	cfg.AccountSlots = accountSlots
 	cfg.BlobSlots = blobSlots
+	cfg.TotalBlobPoolLimit = totalBlobPoolLimit
 	cfg.PriceBump = priceBump
 	cfg.BlobPriceBump = blobPriceBump
 	cfg.NoGossip = noTxGossip

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -188,6 +188,11 @@ var (
 		Usage: "Max allowed total number of blobs (within type-3 txs) per account",
 		Value: txpoolcfg.DefaultConfig.BlobSlots,
 	}
+	TxPoolTotalBlobPoolLimit = cli.Uint64Flag{
+		Name:  "txpool.totalblobpoollimit",
+		Usage: "Total limit of number of all blobs in txs within the txpool",
+		Value: txpoolcfg.DefaultConfig.TotalBlobPoolLimit,
+	}
 	TxPoolGlobalSlotsFlag = cli.Uint64Flag{
 		Name:  "txpool.globalslots",
 		Usage: "Maximum number of executable transaction slots for all accounts",
@@ -1376,6 +1381,9 @@ func setTxPool(ctx *cli.Context, fullCfg *ethconfig.Config) {
 	}
 	if ctx.IsSet(TxPoolBlobSlotsFlag.Name) {
 		fullCfg.TxPool.BlobSlots = ctx.Uint64(TxPoolBlobSlotsFlag.Name)
+	}
+	if ctx.IsSet(TxPoolTotalBlobPoolLimit.Name) {
+		fullCfg.TxPool.TotalBlobPoolLimit = ctx.Uint64(TxPoolTotalBlobPoolLimit.Name)
 	}
 	if ctx.IsSet(TxPoolGlobalSlotsFlag.Name) {
 		cfg.GlobalSlots = ctx.Uint64(TxPoolGlobalSlotsFlag.Name)

--- a/erigon-lib/txpool/pool_test.go
+++ b/erigon-lib/txpool/pool_test.go
@@ -19,6 +19,7 @@ package txpool
 import (
 	"bytes"
 	"context"
+	"runtime"
 
 	// "crypto/rand"
 	"fmt"
@@ -33,6 +34,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/common/dbg"
 	"github.com/ledgerwatch/erigon-lib/common/fixedgas"
 	"github.com/ledgerwatch/erigon-lib/common/hexutility"
 	"github.com/ledgerwatch/erigon-lib/common/u256"
@@ -1047,4 +1049,91 @@ func TestDropRemoteAtNoGossip(t *testing.T) {
 	}
 	// no announcement because unprocessedRemoteTxs is already empty
 	assert.True(checkAnnouncementEmpty())
+}
+
+func TestBlobSlots(t *testing.T) {
+	assert, require := assert.New(t), require.New(t)
+	ch := make(chan types.Announcements, 5)
+	db, coreDB := memdb.NewTestPoolDB(t), memdb.NewTestDB(t)
+	cfg := txpoolcfg.DefaultConfig
+
+	//Setting limits for blobs in the pool
+	cfg.TotalBlobPoolLimit = 20
+
+	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
+	pool, err := New(ch, coreDB, cfg, sendersCache, *u256.N1, common.Big0, nil, common.Big0, fixedgas.DefaultMaxBlobsPerBlock, nil, log.New())
+	assert.NoError(err)
+	require.True(pool != nil)
+	ctx := context.Background()
+	var stateVersionID uint64 = 0
+
+	h1 := gointerfaces.ConvertHashToH256([32]byte{})
+	change := &remote.StateChangeBatch{
+		StateVersionId:       stateVersionID,
+		PendingBlockBaseFee:  200_000,
+		BlockGasLimit:        1000000,
+		PendingBlobFeePerGas: 100_000,
+		ChangeBatch: []*remote.StateChange{
+			{BlockHeight: 0, BlockHash: h1},
+		},
+	}
+	var addr [20]byte
+
+	// Add 1 eth to the user account, as a part of change
+	v := make([]byte, types.EncodeSenderLengthForStorage(0, *uint256.NewInt(10 * common.Ether)))
+	types.EncodeSender(0, *uint256.NewInt(1 * common.Ether), v)
+
+	for i := 0; i < 11; i++ {
+		addr[0] = uint8(i + 1)
+		change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remote.AccountChange{
+			Action:  remote.Action_UPSERT,
+			Address: gointerfaces.ConvertAddressToH160(addr),
+			Data:    v,
+		})
+	}
+
+	tx, err := db.BeginRw(ctx)
+	require.NoError(err)
+	defer tx.Rollback()
+	err = pool.OnNewBlock(ctx, change, types.TxSlots{}, types.TxSlots{}, types.TxSlots{}, tx)
+	assert.NoError(err)
+
+	var m1, m2 runtime.MemStats
+
+	runtime.GC()
+
+	dbg.ReadMemStats(&m1)
+	//Adding 20 blobs from 10 different accounts
+	for i := 0; i < int(cfg.TotalBlobPoolLimit/2); i++ {
+		txSlots := types.TxSlots{}
+		addr[0] = uint8(i + 1)
+		blobTxn := makeBlobTx()
+		blobTxn.IDHash[0] = uint8(2*i + 1)
+		blobTxn.Nonce = 0
+		txSlots.Append(&blobTxn, addr[:], true)
+		reasons, err := pool.AddLocalTxs(ctx, txSlots, tx)
+		assert.NoError(err)
+		for _, reason := range reasons {
+			assert.Equal(txpoolcfg.Success, reason, reason.String())
+		}
+	}
+
+	dbg.ReadMemStats(&m2)
+
+	// Adding another blob tx should reject
+	txSlots := types.TxSlots{}
+	addr[0] = 11
+	blobTxn := makeBlobTx()
+	blobTxn.IDHash[0] = uint8(21)
+	blobTxn.Nonce = 0x0
+	t.Logf("Total blobs in pool %d", pool.totalBlobsInPool.Load())
+
+	txSlots.Append(&blobTxn, addr[:], true)
+	reasons, err := pool.AddLocalTxs(ctx, txSlots, tx)
+	assert.NoError(err)
+	t.Logf("Reasons %v", reasons)
+	for _, reason := range reasons {
+		assert.Equal(txpoolcfg.TooManyBlobs, reason, reason.String())
+	}
+
 }

--- a/erigon-lib/txpool/txpoolcfg/txpoolcfg.go
+++ b/erigon-lib/txpool/txpoolcfg/txpoolcfg.go
@@ -172,6 +172,8 @@ func (r DiscardReason) String() string {
 		return "max number of blobs exceeded"
 	case BlobTxReplace:
 		return "can't replace blob-txn with a non-blob-txn"
+	case BlobPoolOverflow:
+		return "blobs limit in txpool is full"
 	default:
 		panic(fmt.Sprintf("discard reason: %d", r))
 	}

--- a/erigon-lib/txpool/txpoolcfg/txpoolcfg.go
+++ b/erigon-lib/txpool/txpoolcfg/txpoolcfg.go
@@ -37,6 +37,7 @@ type Config struct {
 	MinFeeCap           uint64
 	AccountSlots        uint64 // Number of executable transaction slots guaranteed per account
 	BlobSlots           uint64 // Total number of blobs (not txs) allowed per account
+	TotalBlobPoolLimit  uint64 // Total number of blobs (not txs) allowed within the txpool
 	PriceBump           uint64 // Price bump percentage to replace an already existing transaction
 	BlobPriceBump       uint64 //Price bump percentage to replace an existing 4844 blob tx (type-3)
 	OverrideCancunTime  *big.Int
@@ -65,11 +66,12 @@ var DefaultConfig = Config{
 	BaseFeeSubPoolLimit: 10_000,
 	QueuedSubPoolLimit:  10_000,
 
-	MinFeeCap:     1,
-	AccountSlots:  16, //TODO: to choose right value (16 to be compatible with Geth)
-	BlobSlots:     48, // Default for a total of 8 txs for 6 blobs each - for hive tests
-	PriceBump:     10, // Price bump percentage to replace an already existing transaction
-	BlobPriceBump: 100,
+	MinFeeCap:          1,
+	AccountSlots:       16,  //TODO: to choose right value (16 to be compatible with Geth)
+	BlobSlots:          48,  // Default for a total of 8 txs for 6 blobs each - for hive tests
+	TotalBlobPoolLimit: 480, // Default for a total of 10 different accounts hitting the above limit
+	PriceBump:          10,  // Price bump percentage to replace an already existing transaction
+	BlobPriceBump:      100,
 
 	NoGossip: false,
 }
@@ -108,6 +110,8 @@ const (
 	BlobHashCheckFail   DiscardReason = 28 // KZGcommitment's versioned hash has to be equal to blob_versioned_hash at the same index
 	UnmatchedBlobTxExt  DiscardReason = 29 // KZGcommitments must match the corresponding blobs and proofs
 	BlobTxReplace       DiscardReason = 30 // Cannot replace type-3 blob txn with another type of txn
+	BlobPoolOverflow    DiscardReason = 31 // The total number of blobs (through blob txs) in the pool has reached its limit
+
 )
 
 func (r DiscardReason) String() string {

--- a/eth/ethconfig/tx_pool.go
+++ b/eth/ethconfig/tx_pool.go
@@ -71,6 +71,7 @@ var DefaultTxPool2Config = func(fullCfg *Config) txpoolcfg.Config {
 	cfg.MinFeeCap = pool1Cfg.PriceLimit
 	cfg.AccountSlots = pool1Cfg.AccountSlots
 	cfg.BlobSlots = fullCfg.TxPool.BlobSlots
+	cfg.TotalBlobPoolLimit = fullCfg.TxPool.TotalBlobPoolLimit
 	cfg.LogEvery = 3 * time.Minute
 	cfg.CommitEvery = 5 * time.Minute
 	cfg.TracedSenders = pool1Cfg.TracedSenders

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -20,6 +20,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.TxPoolBlobPriceBumpFlag,
 	&utils.TxPoolAccountSlotsFlag,
 	&utils.TxPoolBlobSlotsFlag,
+	&utils.TxPoolTotalBlobPoolLimit,
 	&utils.TxPoolGlobalSlotsFlag,
 	&utils.TxPoolGlobalBaseFeeSlotsFlag,
 	&utils.TxPoolAccountQueueFlag,


### PR DESCRIPTION
**Summary**
Adds a new flag/parameter `totalBlobPoolLimit` to the txpool. 
Any time the number of blobs (total of all blobs in all type-3 txs) exceeds this number, the pool won't accept any more blob txs.
This is a very straightforward way to prevent blob spamming. It also gives a node operator the freedom to stay away from too many blobs in their own pool.

**More background**: Blob txs take a huge toll on the txpool and the rest of the system because of their size and cryptography involved.