### PR TITLE
fix nil-ptr in txpool fee calc

### DIFF
--- a/consensus/misc/eip1559.go
+++ b/consensus/misc/eip1559.go
@@ -74,7 +74,7 @@ func (f eip1559Calculator) CurrentFees(chainConfig *chain.Config, db kv.Getter) 
 	if err != nil {
 		return 0, 0, 0, 0, err
 	}
-	if currentHeader != nil {
+	if currentHeader == nil {
 		return 0, 0, 0, 0, nil
 	}
 

--- a/consensus/misc/eip1559.go
+++ b/consensus/misc/eip1559.go
@@ -71,9 +71,11 @@ func (f eip1559Calculator) CurrentFees(chainConfig *chain.Config, db kv.Getter) 
 	}
 
 	currentHeader, err := rawdb.ReadHeaderByHash(db, hash)
-
 	if err != nil {
 		return 0, 0, 0, 0, err
+	}
+	if currentHeader != nil {
+		return 0, 0, 0, 0, nil
 	}
 
 	if chainConfig != nil {


### PR DESCRIPTION
```
[INFO] [02-08|22:58:28.974] new subscription to logs established
[INFO] [02-08|22:58:28.975] rpc filters: subscribing to Erigon events
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x240 pc=0x122572f]

goroutine 2343 [running]:
github.com/ledgerwatch/erigon/consensus/misc.eip1559Calculator.CurrentFees({}, 0xc046591900, {0x7f1202466db8, 0xc0341b7d40})
        github.com/ledgerwatch/erigon/consensus/misc/eip1559.go:80 +0xcf
github.com/ledgerwatch/erigon-lib/txpool.(*TxPool).fromDB(0xc000936c80, {0x3277f60, 0xc000cd8eb0}, {0x3299818?, 0xc0341b7ce0}, {0x3299818?, 0xc0341b7d40?})  
        github.com/ledgerwatch/erigon-lib@v1.0.0/txpool/pool.go:2095 +0x8b3
github.com/ledgerwatch/erigon-lib/txpool.(*TxPool).Start.func1({0x3299818, 0xc0341b7ce0})
        github.com/ledgerwatch/erigon-lib@v1.0.0/txpool/pool.go:329 +0xfe
github.com/ledgerwatch/erigon-lib/kv/mdbx.(*MdbxKV).View(0x29e8d60800?, {0x3277f60?, 0xc000cd8eb0?}, 0xc03412f7a0)
        github.com/ledgerwatch/erigon-lib@v1.0.0/kv/mdbx/kv_mdbx.go:749 +0xa6
github.com/ledgerwatch/erigon-lib/txpool.(*TxPool).Start(0xc000936c80, {0x3277f60?, 0xc000cd8eb0}, {0x328d2d0, 0xc0161ad0a0})
        github.com/ledgerwatch/erigon-lib@v1.0.0/txpool/pool.go:319 +0xc9
github.com/ledgerwatch/erigon-lib/txpool.MainLoop({0x3277f60?, 0xc000cd8eb0}, {0x328d2d0, 0xc0161ad0a0}, 0xc000936c80, 0xc0340750e0, 0xc017e1e0a0, 0xc034088c60, 0xc03459f190)
        github.com/ledgerwatch/erigon-lib@v1.0.0/txpool/pool.go:1729 +0x205
created by github.com/ledgerwatch/erigon/eth.New
        github.com/ledgerwatch/erigon/eth/backend.go:718 +0x3fbd
```