### PR TITLE
silkworm: dev env using local silkworm-go

### DIFF
--- a/turbo/silkworm/silkworm_go_devenv.sh
+++ b/turbo/silkworm/silkworm_go_devenv.sh
@@ -7,43 +7,52 @@ TARGET="silkworm_capi"
 script_dir=$(dirname "${BASH_SOURCE[0]}")
 project_dir=$(realpath "$script_dir/../..")
 
-src_dir="$1"
-build_dir="$2"
+silkworm_dir="$1"
+silkworm_build_dir="$2"
+silkworm_go_dir="$3"
 
-if [[ ! -d "$src_dir" ]]
+if [[ ! -d "$silkworm_dir" ]]
 then
-    echo "source directory '$src_dir' not found"
+    echo "silkworm source directory '$silkworm_dir' not found"
     exit 1
 fi
 
-if [[ -z "$build_dir" ]]
+if [[ -z "$silkworm_build_dir" ]]
 then
-    build_dir="$src_dir/build"
+    silkworm_build_dir="$silkworm_dir/build"
 fi
 
-if [[ ! -d "$build_dir" ]]
+if [[ ! -d "$silkworm_build_dir" ]]
 then
-    echo "build directory '$build_dir' not found"
+    echo "silkworm build directory '$silkworm_build_dir' not found"
     exit 1
 fi
 
-replace_dir=$(mktemp -d -t silkworm-go 2> /dev/null || mktemp -d -t silkworm-go.XXXXXXXX)
+if [[ -z "$silkworm_go_dir" ]]
+then
+    silkworm_go_dir=$(mktemp -d -t silkworm-go 2> /dev/null || mktemp -d -t silkworm-go.XXXXXXXX)
+    git clone --depth 1 "https://github.com/erigontech/silkworm-go" "$silkworm_go_dir"
+fi
 
-git clone --depth 1 "https://github.com/erigontech/silkworm-go" "$replace_dir"
+if [[ ! -d "$silkworm_go_dir" ]]
+then
+    echo "silkworm-go directory '$silkworm_go_dir' not found"
+    exit 1
+fi
 
-ln -s "$src_dir/silkworm/capi/silkworm.h" "$replace_dir/include/"
+ln -s "$silkworm_dir/silkworm/capi/silkworm.h" "$silkworm_go_dir/include/"
 
-product_dir="$build_dir/silkworm/capi"
+product_dir="$silkworm_build_dir/silkworm/capi"
 product_path=$(echo "$product_dir/"*$TARGET*)
 product_file_name=$(basename "$product_path")
 
 for platform in macos_arm64 macos_x64 linux_arm64 linux_x64
 do
-    mkdir "$replace_dir/lib/$platform"
-    ln -s "$product_path" "$replace_dir/lib/$platform/$product_file_name"
+    mkdir "$silkworm_go_dir/lib/$platform"
+    ln -s "$product_path" "$silkworm_go_dir/lib/$platform/$product_file_name"
 done
 
 cd "$project_dir/.."
 rm -f "go.work"
 go work init "$project_dir"
-go work use "$replace_dir"
+go work use "$silkworm_go_dir"


### PR DESCRIPTION
This PR add support to optionally use a local `silkworm-go` repo during development. If not available, a temporary repo clone is used as before.

The typical setup we use during Silkworm-for-Erigon development is described [here](https://github.com/erigontech/silkworm/blob/master/docs/CONTRIBUTING.md#c-api-for-erigon).