### PR TITLE
fix: update broken link to gnosis

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Use `--datadir` to choose where to store data.
 Use `--chain=gnosis` for [Gnosis Chain](https://www.gnosis.io/), `--chain=bor-mainnet` for Polygon Mainnet, 
 `--chain=mumbai` for Polygon Mumbai and `--chain=amoy` for Polygon Amoy.
 For Gnosis Chain you need a [Consensus Layer](#beacon-chain-consensus-layer) client alongside
-Erigon (https://docs.gnosischain.com/node/guide/beacon).
+Erigon (https://docs.gnosischain.com/node/manual/beacon).
 
 Running `make help` will list and describe the convenience commands available in the [Makefile](./Makefile).
 


### PR DESCRIPTION
I've found broken link to gnosis docs, this PR fixes the issue.