### PR TITLE
Add lock for downloader version map

### DIFF
--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -286,6 +286,7 @@ func initSnapshotLock(ctx context.Context, cfg *downloadercfg.Cfg, db kv.RoDB, l
 	// is no matching version just use the one discovered for the file
 
 	versionedCfg := map[snaptype.Version]*snapcfg.Cfg{}
+	versionedCfgLock := sync.Mutex{}
 
 	snapDir := cfg.Dirs.Snap
 
@@ -328,12 +329,14 @@ func initSnapshotLock(ctx context.Context, cfg *downloadercfg.Cfg, db kv.RoDB, l
 						downloadMap.Set(fileInfo.Name(), snapcfg.PreverifiedItem{Name: fileInfo.Name(), Hash: hash})
 					}
 				} else {
+					versionedCfgLock.Lock()
 					versioned, ok := versionedCfg[fileInfo.Version]
 
 					if !ok {
 						versioned = snapcfg.VersionedCfg(cfg.ChainName, fileInfo.Version, fileInfo.Version)
 						versionedCfg[fileInfo.Version] = versioned
 					}
+					versionedCfgLock.Unlock()
 
 					hashBytes, err := localHashBytes(ctx, fileInfo, db, logger)
 


### PR DESCRIPTION
Fix for:

fatal error: concurrent map read and map write

goroutine 213 [running]:
github.com/ledgerwatch/erigon-lib/downloader.initSnapshotLock.func1()
    github.com/ledgerwatch/erigon-lib@v1.0.0/downloader/downloader.go:329 +0x3a7