### PR TITLE
Fix uncle processing in historical POW blocks

### DIFF
--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -589,10 +589,12 @@ func (cr ChainReaderImpl) FrozenBlocks() uint64 {
 	return cr.blockReader.FrozenBlocks()
 }
 func (cr ChainReaderImpl) GetBlock(hash libcommon.Hash, number uint64) *types.Block {
-	panic("")
+	b, _, _ := cr.blockReader.BlockWithSenders(context.Background(), cr.tx, hash, number)
+	return b
 }
 func (cr ChainReaderImpl) HasBlock(hash libcommon.Hash, number uint64) bool {
-	panic("")
+	b, _ := cr.blockReader.BodyRlp(context.Background(), cr.tx, hash, number)
+	return b != nil
 }
 func (cr ChainReaderImpl) BorEventsByBlock(hash libcommon.Hash, number uint64) []rlp.RawValue {
 	events, err := cr.blockReader.EventsByBlock(context.Background(), cr.tx, hash, number)

--- a/turbo/engineapi/engine_block_downloader/block_downloader.go
+++ b/turbo/engineapi/engine_block_downloader/block_downloader.go
@@ -243,7 +243,7 @@ func (e *EngineBlockDownloader) insertHeadersAndBodies(tx kv.Tx, fromBlock uint6
 		if body == nil {
 			return fmt.Errorf("missing body at block=%d", number)
 		}
-		blocksBatch = append(blocksBatch, types.NewBlockFromStorage(hash, header, body.Transactions, nil, body.Withdrawals))
+		blocksBatch = append(blocksBatch, types.NewBlockFromStorage(hash, header, body.Transactions, body.Uncles, body.Withdrawals))
 		if number%uint64(blockWrittenLogSize) == 0 {
 			e.logger.Info("[insertHeadersAndBodies] Written blocks", "progress", number, "to", toBlock)
 		}

--- a/turbo/execution/eth1/eth1_chain_reader.go/chain_reader.go
+++ b/turbo/execution/eth1/eth1_chain_reader.go/chain_reader.go
@@ -93,7 +93,11 @@ func (c ChainReaderWriterEth1) GetBlockByHash(hash libcommon.Hash) *types.Block 
 	if resp == nil || resp.Body == nil {
 		return nil
 	}
-	body := eth1_utils.ConvertRawBlockBodyFromRpc(resp.Body)
+	body, err := eth1_utils.ConvertRawBlockBodyFromRpc(resp.Body)
+	if err != nil {
+		log.Error("GetBlockByHash failed", "err", err)
+		return nil
+	}
 	txs, err := types.DecodeTransactions(body.Transactions)
 	if err != nil {
 		log.Error("GetBlockByHash failed", "err", err)
@@ -118,7 +122,11 @@ func (c ChainReaderWriterEth1) GetBlockByNumber(number uint64) *types.Block {
 	if resp == nil || resp.Body == nil {
 		return nil
 	}
-	body := eth1_utils.ConvertRawBlockBodyFromRpc(resp.Body)
+	body, err := eth1_utils.ConvertRawBlockBodyFromRpc(resp.Body)
+	if err != nil {
+		log.Error("GetBlockByNumber failed", "err", err)
+		return nil
+	}
 	txs, err := types.DecodeTransactions(body.Transactions)
 	if err != nil {
 		log.Error("GetBlockByNumber failed", "err", err)
@@ -195,7 +203,10 @@ func (c ChainReaderWriterEth1) GetBodiesByHashes(hashes []libcommon.Hash) ([]*ty
 	}
 	ret := make([]*types.RawBody, len(resp.Bodies))
 	for i := range ret {
-		ret[i] = eth1_utils.ConvertRawBlockBodyFromRpc(resp.Bodies[i])
+		ret[i], err = eth1_utils.ConvertRawBlockBodyFromRpc(resp.Bodies[i])
+		if err != nil {
+			return nil, err
+		}
 	}
 	return ret, nil
 }
@@ -210,7 +221,10 @@ func (c ChainReaderWriterEth1) GetBodiesByRange(start, count uint64) ([]*types.R
 	}
 	ret := make([]*types.RawBody, len(resp.Bodies))
 	for i := range ret {
-		ret[i] = eth1_utils.ConvertRawBlockBodyFromRpc(resp.Bodies[i])
+		ret[i], err = eth1_utils.ConvertRawBlockBodyFromRpc(resp.Bodies[i])
+		if err != nil {
+			return nil, err
+		}
 	}
 	return ret, nil
 }

--- a/turbo/execution/eth1/eth1_utils/grpc.go
+++ b/turbo/execution/eth1/eth1_utils/grpc.go
@@ -65,7 +65,10 @@ func HeaderToHeaderRPC(header *types.Header) *execution.Header {
 }
 
 func HeadersToHeadersRPC(headers []*types.Header) []*execution.Header {
-	ret := []*execution.Header{}
+	if headers == nil {
+		return nil
+	}
+	ret := make([]*execution.Header, 0, len(headers))
 	for _, header := range headers {
 		ret = append(ret, HeaderToHeaderRPC(header))
 	}
@@ -136,6 +139,21 @@ func HeaderRpcToHeader(header *execution.Header) (*types.Header, error) {
 	return h, nil
 }
 
+func HeadersRpcToHeaders(headers []*execution.Header) ([]*types.Header, error) {
+	if headers == nil {
+		return nil, nil
+	}
+	out := make([]*types.Header, 0, len(headers))
+	for _, h := range headers {
+		header, err := HeaderRpcToHeader(h)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, header)
+	}
+	return out, nil
+}
+
 func ConvertWithdrawalsFromRpc(in []*types2.Withdrawal) []*types.Withdrawal {
 	if in == nil {
 		return nil
@@ -177,6 +195,7 @@ func ConvertRawBlockBodyToRpc(in *types.RawBody, blockNumber uint64, blockHash l
 		BlockNumber:  blockNumber,
 		BlockHash:    gointerfaces.ConvertHashToH256(blockHash),
 		Transactions: in.Transactions,
+		Uncles:       HeadersToHeadersRPC(in.Uncles),
 		Withdrawals:  ConvertWithdrawalsToRpc(in.Withdrawals),
 	}
 }
@@ -190,14 +209,19 @@ func ConvertRawBlockBodiesToRpc(in []*types.RawBody, blockNumbers []uint64, bloc
 	return ret
 }
 
-func ConvertRawBlockBodyFromRpc(in *execution.BlockBody) *types.RawBody {
+func ConvertRawBlockBodyFromRpc(in *execution.BlockBody) (*types.RawBody, error) {
 	if in == nil {
-		return nil
+		return nil, nil
+	}
+	uncles, err := HeadersRpcToHeaders(in.Uncles)
+	if err != nil {
+		return nil, err
 	}
 	return &types.RawBody{
 		Transactions: in.Transactions,
+		Uncles:       uncles,
 		Withdrawals:  ConvertWithdrawalsFromRpc(in.Withdrawals),
-	}
+	}, nil
 }
 
 func ConvertBigIntFromRpc(in *types2.H256) *big.Int {

--- a/turbo/execution/eth1/eth1_utils/grpc_test.go
+++ b/turbo/execution/eth1/eth1_utils/grpc_test.go
@@ -1,0 +1,95 @@
+package eth1_utils
+
+import (
+	"testing"
+
+	"github.com/holiman/uint256"
+	libcommon "github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon/common/math"
+	"github.com/ledgerwatch/erigon/core/types"
+	"github.com/ledgerwatch/erigon/crypto"
+	"github.com/ledgerwatch/erigon/params"
+	"github.com/stretchr/testify/require"
+)
+
+func makeBlock(txCount, uncleCount, withdrawalCount int) *types.Block {
+	var (
+		key, _      = crypto.GenerateKey()
+		txs         = make([]types.Transaction, txCount)
+		receipts    = make([]*types.Receipt, len(txs))
+		signer      = types.LatestSigner(params.TestChainConfig)
+		uncles      = make([]*types.Header, uncleCount)
+		withdrawals = make([]*types.Withdrawal, withdrawalCount)
+	)
+	header := &types.Header{
+		Difficulty: math.BigPow(11, 11),
+		Number:     math.BigPow(2, 9),
+		GasLimit:   12345678,
+		GasUsed:    1476322,
+		Time:       9876543,
+		Extra:      []byte("test block"),
+	}
+	for i := range txs {
+		amount, _ := uint256.FromBig(math.BigPow(2, int64(i)))
+		price := uint256.NewInt(300000)
+		data := make([]byte, 100)
+		tx := types.NewTransaction(uint64(i), libcommon.Address{}, amount, 123457, price, data)
+		signedTx, err := types.SignTx(tx, *signer, key)
+		if err != nil {
+			panic(err)
+		}
+		txs[i] = signedTx
+		receipts[i] = types.NewReceipt(false, tx.GetGas())
+	}
+	for i := range uncles {
+		uncles[i] = &types.Header{
+			Difficulty: math.BigPow(11, 11),
+			Number:     math.BigPow(2, 9),
+			GasLimit:   12345678,
+			GasUsed:    1476322,
+			Time:       9876543,
+			Extra:      []byte("test uncle"),
+		}
+	}
+	for i := range withdrawals {
+		withdrawals[i] = &types.Withdrawal{
+			Index:     uint64(i),
+			Validator: uint64(i),
+			Amount:    uint64(10 * i),
+		}
+	}
+	return types.NewBlock(header, txs, uncles, receipts, withdrawals)
+}
+
+func TestBlockRpcConversion(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	testBlock := makeBlock(50, 2, 3)
+
+	// header conversions
+	rpcHeader := HeaderToHeaderRPC(testBlock.Header())
+	roundTripHeader, err := HeaderRpcToHeader(rpcHeader)
+	if err != nil {
+		panic(err)
+	}
+	require.Equal(testBlock.Header(), roundTripHeader)
+
+	// body conversions
+	rpcBlock := ConvertBlockToRPC(testBlock)
+	roundTripBody := ConvertRawBlockBodyFromRpc(rpcBlock.Body)
+	testBlockRaw := testBlock.RawBody()
+	require.Greater(len(testBlockRaw.Transactions), 0)
+	require.Greater(len(testBlockRaw.Uncles), 0)
+	require.Greater(len(testBlockRaw.Withdrawals), 0)
+	require.Equal(testBlockRaw, roundTripBody) // validates txns, uncles, and withdrawals
+}
+
+func TestBigIntConversion(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	val := math.BigPow(2, 32)
+	rpcVal := ConvertBigIntToRpc(val)
+	roundTripVal := ConvertBigIntFromRpc(rpcVal)
+	require.Equal(val, roundTripVal)
+}

--- a/turbo/execution/eth1/eth1_utils/grpc_test.go
+++ b/turbo/execution/eth1/eth1_utils/grpc_test.go
@@ -76,7 +76,10 @@ func TestBlockRpcConversion(t *testing.T) {
 
 	// body conversions
 	rpcBlock := ConvertBlockToRPC(testBlock)
-	roundTripBody := ConvertRawBlockBodyFromRpc(rpcBlock.Body)
+	roundTripBody, err := ConvertRawBlockBodyFromRpc(rpcBlock.Body)
+	if err != nil {
+		panic(err)
+	}
 	testBlockRaw := testBlock.RawBody()
 	require.Greater(len(testBlockRaw.Transactions), 0)
 	require.Greater(len(testBlockRaw.Uncles), 0)

--- a/turbo/execution/eth1/inserters.go
+++ b/turbo/execution/eth1/inserters.go
@@ -51,7 +51,10 @@ func (e *EthereumExecutionModule) InsertBlocks(ctx context.Context, req *executi
 		if err != nil {
 			return nil, fmt.Errorf("ethereumExecutionModule.InsertBlocks: cannot convert headers: %s", err)
 		}
-		body := eth1_utils.ConvertRawBlockBodyFromRpc(block.Body)
+		body, err := eth1_utils.ConvertRawBlockBodyFromRpc(block.Body)
+		if err != nil {
+			return nil, fmt.Errorf("ethereumExecutionModule.InsertBlocks: cannot convert body: %s", err)
+		}
 		height := header.Number.Uint64()
 		// Parent's total difficulty
 		parentTd, err := rawdb.ReadTd(tx, header.ParentHash, height-1)


### PR DESCRIPTION
Since the merge of https://github.com/ledgerwatch/erigon/pull/7936, released in version `v2.49.0` and onward, Erigon has been unable to properly download and process historical Ethereum POW blocks. This makes a mainnet sync from block 0 with snapshotting disabled (`--snapshots=false`) impossible.

I discovered this issue while working on the Erigon-Pulse fork for PulseChain, but the issue remains here, and has been verified with a vanilla version of Erigon v2.57.3 against Ethereum Mainnet.

## Detail
When doing a full sync from block zero with snapshotting disabled, the following error will occur:

```log
[INFO] [02-08|09:06:11.859] [3/12 Senders] DONE                      in=7h55m24.504489889s
[INFO] [02-08|09:06:11.861] [4/12 Execution] Blocks execution        from=0 to=19180016
[WARN] [02-08|09:06:12.599] [4/12 Execution] Execution failed        block=46274 hash=0x8252137084baebea389ddb826c4e7a63cbef2effc0d6526a5394377e5e8dada0 err="invalid block: could not apply tx 0 from block 46274 [0x669890439f5093b7dfbca9b06de1d6da78ceacf1ec0753252b3e6cf10ff81a3e]: insufficient funds for gas * price + value: address 0xdC49b9dc1AbB93Ebb856547a1C0578D65f4A32DE have 15000000000000000000 want 15024629952223800000"
[INFO] [02-08|09:06:12.602] [4/12 Execution] Completed on            block=46273
```

This failure is deterministic and the process will revert back to the beginning of the `[3/12 Senders]` stage. After reprocessing senders, it will eventually fail execution on the same transaction every time.

Looking into this issue, I discovered that the balance for the sender at the parent block `46273` was too low. The sender should in fact have `15156250000000000000`, enough to cover the transaction costs shown in the error message.

Digging further into the history of this account, I found that the balance was too low because uncle rewards for an earlier mined block had not been properly awarded. The `15 ETH` in the chain state was the result of 3 blocks previously mined by the account, but the uncle reward of `0.15625 ETH` had not been awarded for block `2839`.

**This led me to discover the issue, that uncles are being dropped entirely in the new downloader:**
1. Uncles aren't being passed from the engineapi block downloader (nil is passed).
2. Uncles aren't being considered when mapping from native types to the execution engine's GRPC types.
3. Uncles aren't being considered when mapping back from execution engine's GRPC types to the native types.
4. The header stage is lacking an implementation for `GetBlock()`, which is required for uncle verification. After passing uncles through properly, the panic() here was triggered.

It's a little surprising this has gone overlooked for so long, but I suspect that almost nobody is doing a full sync w/o snapshots. It is painfully slow afterall.

> *Note that because the issue originates in the downloader, once the execution failure has been encountered, the entire db must be deleted and a fresh sync started. Erigon cannot recover from the downloaded blocks being inserted into the DB w/ missing uncles.*

## Fixed

This PR adds 3 commits fixing the issue. The first is a broken test, followed by the missing uncles fix which also resolves the broken test. The final commit adds the missing implementations in the header stage.

This fix has been verified with a fresh sync.
