### PR TITLE
E35 test commit fix

### DIFF
--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -471,9 +471,6 @@ func CalcHashRootForTests(tx kv.RwTx, header *types.Header, histV4, trace bool) 
 	}
 
 	if histV4 {
-		//if GenerateTrace {
-		//	panic("implement me")
-		//}
 		h := libcommon.NewHasher()
 		defer libcommon.ReturnHasherToPool(h)
 
@@ -515,6 +512,7 @@ func CalcHashRootForTests(tx kv.RwTx, header *types.Header, histV4, trace bool) 
 			if err != nil {
 				return hashRoot, fmt.Errorf("clear HashedStorage bucket: %w", err)
 			}
+			fmt.Printf("storage %x -> %x\n", k, newK)
 			if err := tx.Put(kv.HashedStorage, newK, v); err != nil {
 				return hashRoot, fmt.Errorf("clear HashedStorage bucket: %w", err)
 			}
@@ -522,6 +520,33 @@ func CalcHashRootForTests(tx kv.RwTx, header *types.Header, histV4, trace bool) 
 		}
 
 		if trace {
+			if GenerateTrace {
+				fmt.Printf("State after %d================\n", header.Number)
+				it, err := tx.Range(kv.HashedAccounts, nil, nil)
+				if err != nil {
+					return hashRoot, err
+				}
+				for it.HasNext() {
+					k, v, err := it.Next()
+					if err != nil {
+						return hashRoot, err
+					}
+					fmt.Printf("%x: %x\n", k, v)
+				}
+				fmt.Printf("..................\n")
+				it, err = tx.Range(kv.HashedStorage, nil, nil)
+				if err != nil {
+					return hashRoot, err
+				}
+				for it.HasNext() {
+					k, v, err := it.Next()
+					if err != nil {
+						return hashRoot, err
+					}
+					fmt.Printf("%x: %x\n", k, v)
+				}
+				fmt.Printf("===============================\n")
+			}
 			root, err := trie.CalcRootTrace("GenerateChain", tx)
 			return root, err
 		}

--- a/core/test/domains_restart_test.go
+++ b/core/test/domains_restart_test.go
@@ -466,7 +466,6 @@ func randomAccount(t *testing.T) (*accounts.Account, libcommon.Address) {
 }
 
 func TestCommit(t *testing.T) {
-	//t.Skip()
 	aggStep := uint64(100)
 
 	ctx := context.Background()
@@ -486,57 +485,25 @@ func TestCommit(t *testing.T) {
 
 	buf := types2.EncodeAccountBytesV3(0, uint256.NewInt(7), nil, 1)
 
-	addr2 := libcommon.Hex2Bytes("8e5476fc5990638a4fb0b5fd3f61bb4b5c5f395e")
-	loc1 := libcommon.Hex2Bytes("24f3a02dc65eda502dbf75919e795458413d3c45b38bb35b51235432707900ed")
-	loc3 := libcommon.Hex2Bytes("ed6f77b07d7e5b5f61ccd6e7f0f581304d9bf73ac3633ee9515397e7f501faed")
-	loc4 := libcommon.Hex2Bytes("e0b959bbc0455e4830370a3e8bced575e6e99495091c005fc3dad637cdf6e0ca")
-	//addr1 := libcommon.Hex2Bytes("68ee6c0e9cdc73b2b2d52dbd79f19d24fe25e2f9")
-	//err = domains.UpdateAccountData(addr2, buf, nil)
-	//require.NoError(t, err)
+	addr := libcommon.Hex2Bytes("8e5476fc5990638a4fb0b5fd3f61bb4b5c5f395e")
+	loc := libcommon.Hex2Bytes("24f3a02dc65eda502dbf75919e795458413d3c45b38bb35b51235432707900ed")
 
-	//for i := 1; i < 3; i++ {
-	ad := libcommon.CopyBytes(addr2)
-	//ad[0] = byte(i)
+	for i := 1; i < 3; i++ {
+		addr[0] = byte(i)
 
-	err = domains.DomainPut(kv.AccountsDomain, ad, nil, buf, nil, 0)
-	require.NoError(t, err)
-	_ = loc1
+		err = domains.DomainPut(kv.AccountsDomain, addr, nil, buf, nil, 0)
+		require.NoError(t, err)
+		loc[0] = byte(i)
 
-	err = domains.DomainPut(kv.StorageDomain, ad, loc1, []byte("0401"), nil, 0)
-	require.NoError(t, err)
-
-	loc2 := libcommon.CopyBytes(loc1)
-	loc2[0] = byte(0x01)
-	err = domains.DomainPut(kv.StorageDomain, ad, loc2, []byte("0401"), nil, 0)
-	require.NoError(t, err)
-
-	err = domains.DomainPut(kv.StorageDomain, ad, loc3, []byte("0401"), nil, 0)
-	require.NoError(t, err)
-	err = domains.DomainPut(kv.StorageDomain, ad, loc4, []byte("0401"), nil, 0)
-	require.NoError(t, err)
-	//}
-
-	//err = domains.WriteAccountStorage(addr2, loc1, []byte("0401"), nil)
-	//require.NoError(t, err)
+		err = domains.DomainPut(kv.StorageDomain, addr, loc, []byte("0401"), nil, 0)
+		require.NoError(t, err)
+	}
 
 	domains.SetTrace(true)
 	domainsHash, err := domains.ComputeCommitment(ctx, true, domains.BlockNum(), "")
 	require.NoError(t, err)
 	err = domains.Flush(ctx, tx)
 	require.NoError(t, err)
-
-	it, err := tx.(state.HasAggCtx).AggCtx().(*state.AggregatorV3Context).DomainRangeLatest(tx, kv.StorageDomain, nil, nil, -1)
-	if err != nil {
-		panic(err)
-	}
-	for it.HasNext() {
-		k, v, err := it.Next()
-		if err != nil {
-			panic(err)
-		}
-		fmt.Printf("SSTORAGE %x: %x\n", k, v)
-	}
-	fmt.Printf("storage iter done\n")
 
 	core.GenerateTrace = true
 	oldHash, err := core.CalcHashRootForTests(tx, &types.Header{Number: big.NewInt(1)}, true, true)

--- a/core/test/domains_restart_test.go
+++ b/core/test/domains_restart_test.go
@@ -484,10 +484,12 @@ func TestCommit(t *testing.T) {
 	domains := state.NewSharedDomains(tx, log.New())
 	defer domains.Close()
 
-	buf := types2.EncodeAccountBytesV3(0, uint256.NewInt(7), nil, 0)
+	buf := types2.EncodeAccountBytesV3(0, uint256.NewInt(7), nil, 1)
 
 	addr2 := libcommon.Hex2Bytes("8e5476fc5990638a4fb0b5fd3f61bb4b5c5f395e")
 	loc1 := libcommon.Hex2Bytes("24f3a02dc65eda502dbf75919e795458413d3c45b38bb35b51235432707900ed")
+	loc3 := libcommon.Hex2Bytes("ed6f77b07d7e5b5f61ccd6e7f0f581304d9bf73ac3633ee9515397e7f501faed")
+	loc4 := libcommon.Hex2Bytes("e0b959bbc0455e4830370a3e8bced575e6e99495091c005fc3dad637cdf6e0ca")
 	//addr1 := libcommon.Hex2Bytes("68ee6c0e9cdc73b2b2d52dbd79f19d24fe25e2f9")
 	//err = domains.UpdateAccountData(addr2, buf, nil)
 	//require.NoError(t, err)
@@ -503,8 +505,14 @@ func TestCommit(t *testing.T) {
 	err = domains.DomainPut(kv.StorageDomain, ad, loc1, []byte("0401"), nil, 0)
 	require.NoError(t, err)
 
-	loc1[0] = 0x01
-	err = domains.DomainPut(kv.StorageDomain, ad, loc1, []byte("0401"), nil, 0)
+	loc2 := libcommon.CopyBytes(loc1)
+	loc2[0] = byte(0x01)
+	err = domains.DomainPut(kv.StorageDomain, ad, loc2, []byte("0401"), nil, 0)
+	require.NoError(t, err)
+
+	err = domains.DomainPut(kv.StorageDomain, ad, loc3, []byte("0401"), nil, 0)
+	require.NoError(t, err)
+	err = domains.DomainPut(kv.StorageDomain, ad, loc4, []byte("0401"), nil, 0)
 	require.NoError(t, err)
 	//}
 

--- a/erigon-lib/state/domain_shared.go
+++ b/erigon-lib/state/domain_shared.go
@@ -531,6 +531,10 @@ func (sd *SharedDomains) SetBlockNum(blockNum uint64) {
 	sd.blockNum.Store(blockNum)
 }
 
+func (sd *SharedDomains) SetTrace(b bool) {
+	sd.trace = b
+}
+
 func (sd *SharedDomains) ComputeCommitment(ctx context.Context, saveStateAfter bool, blockNum uint64, logPrefix string) (rootHash []byte, err error) {
 	return sd.sdCtx.ComputeCommitment(ctx, saveStateAfter, blockNum, logPrefix)
 }


### PR DESCRIPTION
fix for skipped test. 

Problem was that i did not know that old trie algorithm requires account.Incarnation > 0 to also scan storage keys of that account. If incarnation 0, new algo uses storage keys but old ignores them.