### PR TITLE
Prevents DDOS attempts on the Beacon API.

### DIFF
--- a/cl/beacon/handler/attestation_rewards.go
+++ b/cl/beacon/handler/attestation_rewards.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon/cl/beacon/beaconhttp"
 	"github.com/ledgerwatch/erigon/cl/clparams"
+	"github.com/ledgerwatch/erigon/cl/cltypes"
 	"github.com/ledgerwatch/erigon/cl/cltypes/solid"
 	"github.com/ledgerwatch/erigon/cl/persistence/beacon_indicies"
 	state_accessors "github.com/ledgerwatch/erigon/cl/persistence/state"
@@ -86,7 +87,7 @@ func (a *ApiHandler) PostEthV1BeaconRewardsAttestations(w http.ResponseWriter, r
 	version := a.beaconChainCfg.GetCurrentStateVersion(epoch)
 
 	// finalized data
-	if epoch > a.forkchoiceStore.FinalizedCheckpoint().Epoch() {
+	if epoch > a.forkchoiceStore.LowestAvaiableSlot() {
 		minRange := epoch * a.beaconChainCfg.SlotsPerEpoch
 		maxRange := (epoch + 1) * a.beaconChainCfg.SlotsPerEpoch
 		var blockRoot libcommon.Hash
@@ -106,31 +107,13 @@ func (a *ApiHandler) PostEthV1BeaconRewardsAttestations(w http.ResponseWriter, r
 				continue
 			}
 			if s.Version() == clparams.Phase0Version {
-				return a.computeAttestationsRewardsForPhase0(s, filterIndicies, epoch)
+				return nil, beaconhttp.NewEndpointError(http.StatusHTTPVersionNotSupported, fmt.Errorf("phase0 state is not supported when there is no antiquation"))
 			}
 			return a.computeAttestationsRewardsForAltair(s.ValidatorSet(), s.InactivityScores(), s.PreviousEpochParticipation(), state.InactivityLeaking(s), filterIndicies, epoch)
 		}
 		return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("no block found for this epoch"))
 	}
 
-	if version == clparams.Phase0Version {
-		minRange := epoch * a.beaconChainCfg.SlotsPerEpoch
-		maxRange := (epoch + 1) * a.beaconChainCfg.SlotsPerEpoch
-		for i := maxRange - 1; i >= minRange; i-- {
-			s, err := a.stateReader.ReadHistoricalState(ctx, tx, i)
-			if err != nil {
-				return nil, err
-			}
-			if s == nil {
-				continue
-			}
-			if err := s.InitBeaconState(); err != nil {
-				return nil, err
-			}
-			return a.computeAttestationsRewardsForPhase0(s, filterIndicies, epoch)
-		}
-		return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("no block found for this epoch"))
-	}
 	lastSlot := epoch*a.beaconChainCfg.SlotsPerEpoch + a.beaconChainCfg.SlotsPerEpoch - 1
 	stateProgress, err := state_accessors.GetStateProcessingProgress(tx)
 	if err != nil {
@@ -139,6 +122,12 @@ func (a *ApiHandler) PostEthV1BeaconRewardsAttestations(w http.ResponseWriter, r
 	if lastSlot > stateProgress {
 		return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("requested range is not yet processed or the node is not archivial"))
 	}
+
+	epochData, err := state_accessors.ReadEpochData(tx, a.beaconChainCfg.RoundSlotToEpoch(lastSlot))
+	if err != nil {
+		return nil, err
+	}
+
 	validatorSet, err := a.stateReader.ReadValidatorsForHistoricalState(tx, lastSlot)
 	if err != nil {
 		return nil, err
@@ -151,6 +140,9 @@ func (a *ApiHandler) PostEthV1BeaconRewardsAttestations(w http.ResponseWriter, r
 	_, _, finalizedCheckpoint, err := state_accessors.ReadCheckpoints(tx, epoch*a.beaconChainCfg.SlotsPerEpoch)
 	if err != nil {
 		return nil, err
+	}
+	if version == clparams.Phase0Version {
+		return a.computeAttestationsRewardsForPhase0(validatorSet, finalizedCheckpoint.Epoch()-epoch, epochData.TotalActiveBalance, previousIdx, a.isInactivityLeaking(epoch, finalizedCheckpoint), filterIndicies, epoch)
 	}
 	inactivityScores := solid.NewUint64ListSSZ(int(a.beaconChainCfg.ValidatorRegistryLimit))
 	if err := a.stateReader.ReconstructUint64ListDump(tx, lastSlot, kv.InactivityScores, validatorSet.Length(), inactivityScores); err != nil {
@@ -290,9 +282,9 @@ func (a *ApiHandler) computeAttestationsRewardsForAltair(validatorSet *solid.Val
 }
 
 // processRewardsAndPenaltiesPhase0 process rewards and penalties for phase0 state.
-func (a *ApiHandler) computeAttestationsRewardsForPhase0(s *state.CachingBeaconState, filterIndicies []uint64, epoch uint64) (*beaconhttp.BeaconResponse, error) {
+func (a *ApiHandler) computeAttestationsRewardsForPhase0(validatorSet *solid.ValidatorSet, finalityDelay, activeBalance uint64, previousParticipation *solid.BitList, inactivityLeak bool, filterIndicies []uint64, epoch uint64) (*beaconhttp.BeaconResponse, error) {
 	response := &attestationsRewardsResponse{}
-	beaconConfig := s.BeaconConfig()
+	beaconConfig := a.beaconChainCfg
 	if epoch == beaconConfig.GenesisEpoch {
 		return newBeaconResponse(response), nil
 	}
@@ -307,38 +299,33 @@ func (a *ApiHandler) computeAttestationsRewardsForPhase0(s *state.CachingBeaconS
 		}
 	} else {
 		response = &attestationsRewardsResponse{
-			IdealRewards: make([]IdealReward, 0, s.ValidatorLength()),
-			TotalRewards: make([]TotalReward, 0, s.ValidatorLength()),
+			IdealRewards: make([]IdealReward, 0, validatorSet.Length()),
+			TotalRewards: make([]TotalReward, 0, validatorSet.Length()),
 		}
 	}
 
-	inactivityLeak := state.InactivityLeaking(s)
-	rewardDenominator := s.GetTotalActiveBalance() / beaconConfig.EffectiveBalanceIncrement
+	rewardDenominator := activeBalance / beaconConfig.EffectiveBalanceIncrement
 	var unslashedMatchingSourceBalanceIncrements, unslashedMatchingTargetBalanceIncrements, unslashedMatchingHeadBalanceIncrements uint64
 	var err error
-	s.ForEachValidator(func(validator solid.Validator, idx, total int) bool {
-		if validator.Slashed() {
+
+	validatorSet.Range(func(i int, v solid.Validator, _ int) bool {
+		if v.Slashed() {
 			return true
 		}
 		var previousMatchingSourceAttester, previousMatchingTargetAttester, previousMatchingHeadAttester bool
+		previousParticipation := cltypes.ParticipationFlags(previousParticipation.Get(i))
+		previousMatchingHeadAttester = previousParticipation.HasFlag(int(beaconConfig.TimelyHeadFlagIndex))
+		previousMatchingTargetAttester = previousParticipation.HasFlag(int(beaconConfig.TimelyTargetFlagIndex))
+		previousMatchingSourceAttester = previousParticipation.HasFlag(int(beaconConfig.TimelySourceFlagIndex))
 
-		if previousMatchingSourceAttester, err = s.ValidatorIsPreviousMatchingSourceAttester(idx); err != nil {
-			return false
-		}
-		if previousMatchingTargetAttester, err = s.ValidatorIsPreviousMatchingTargetAttester(idx); err != nil {
-			return false
-		}
-		if previousMatchingHeadAttester, err = s.ValidatorIsPreviousMatchingHeadAttester(idx); err != nil {
-			return false
-		}
 		if previousMatchingSourceAttester {
-			unslashedMatchingSourceBalanceIncrements += validator.EffectiveBalance()
+			unslashedMatchingSourceBalanceIncrements += v.EffectiveBalance()
 		}
 		if previousMatchingTargetAttester {
-			unslashedMatchingTargetBalanceIncrements += validator.EffectiveBalance()
+			unslashedMatchingTargetBalanceIncrements += v.EffectiveBalance()
 		}
 		if previousMatchingHeadAttester {
-			unslashedMatchingHeadBalanceIncrements += validator.EffectiveBalance()
+			unslashedMatchingHeadBalanceIncrements += v.EffectiveBalance()
 		}
 		return true
 	})
@@ -349,36 +336,34 @@ func (a *ApiHandler) computeAttestationsRewardsForPhase0(s *state.CachingBeaconS
 	unslashedMatchingSourceBalanceIncrements /= beaconConfig.EffectiveBalanceIncrement
 	unslashedMatchingTargetBalanceIncrements /= beaconConfig.EffectiveBalanceIncrement
 	unslashedMatchingHeadBalanceIncrements /= beaconConfig.EffectiveBalanceIncrement
+	totalActiveBalanceSqrt := utils.IntegerSquareRoot(activeBalance)
 	fn := func(index uint64, currentValidator solid.Validator) error {
-		baseReward, err := s.BaseReward(index)
+		baseReward := a.baseReward(clparams.Phase0Version, currentValidator.EffectiveBalance(), totalActiveBalanceSqrt)
+
 		if err != nil {
 			return err
 		}
 		var previousMatchingSourceAttester, previousMatchingTargetAttester, previousMatchingHeadAttester bool
 
-		if previousMatchingSourceAttester, err = s.ValidatorIsPreviousMatchingSourceAttester(int(index)); err != nil {
-			return err
-		}
-		if previousMatchingTargetAttester, err = s.ValidatorIsPreviousMatchingTargetAttester(int(index)); err != nil {
-			return err
-		}
-		if previousMatchingHeadAttester, err = s.ValidatorIsPreviousMatchingHeadAttester(int(index)); err != nil {
-			return err
-		}
+		previousParticipation := cltypes.ParticipationFlags(previousParticipation.Get(int(index)))
+		previousMatchingHeadAttester = previousParticipation.HasFlag(int(beaconConfig.TimelyHeadFlagIndex))
+		previousMatchingTargetAttester = previousParticipation.HasFlag(int(beaconConfig.TimelyTargetFlagIndex))
+		previousMatchingSourceAttester = previousParticipation.HasFlag(int(beaconConfig.TimelySourceFlagIndex))
+
 		totalReward := TotalReward{ValidatorIndex: int64(index)}
 		idealReward := IdealReward{EffectiveBalance: int64(currentValidator.EffectiveBalance())}
 
-		// check inclusion delay
-		if !currentValidator.Slashed() && previousMatchingSourceAttester {
-			var attestation *solid.PendingAttestation
-			if attestation, err = s.ValidatorMinPreviousInclusionDelayAttestation(int(index)); err != nil {
-				return err
-			}
-			proposerReward := (baseReward / beaconConfig.ProposerRewardQuotient)
-			maxAttesterReward := baseReward - proposerReward
-			idealReward.InclusionDelay = int64(maxAttesterReward / attestation.InclusionDelay())
-			totalReward.InclusionDelay = idealReward.InclusionDelay
-		}
+		// TODO: check inclusion delay
+		// if !currentValidator.Slashed() && previousMatchingSourceAttester {
+		// 	var attestation *solid.PendingAttestation
+		// 	if attestation, err = s.ValidatorMinPreviousInclusionDelayAttestation(int(index)); err != nil {
+		// 		return err
+		// 	}
+		// 	proposerReward := (baseReward / beaconConfig.ProposerRewardQuotient)
+		// 	maxAttesterReward := baseReward - proposerReward
+		// 	idealReward.InclusionDelay = int64(maxAttesterReward / attestation.InclusionDelay())
+		// 	totalReward.InclusionDelay = idealReward.InclusionDelay
+		// }
 		// if it is not eligible for rewards, then do not continue further
 		if !(currentValidator.Active(prevEpoch) || (currentValidator.Slashed() && prevEpoch+1 < currentValidator.WithdrawableEpoch())) {
 			response.IdealRewards = append(response.IdealRewards, idealReward)
@@ -418,7 +403,7 @@ func (a *ApiHandler) computeAttestationsRewardsForPhase0(s *state.CachingBeaconS
 			proposerReward := baseReward / beaconConfig.ProposerRewardQuotient
 			totalReward.Inactivity = -int64(beaconConfig.BaseRewardsPerEpoch*baseReward - proposerReward)
 			if currentValidator.Slashed() || !previousMatchingTargetAttester {
-				totalReward.Inactivity -= int64(currentValidator.EffectiveBalance() * state.FinalityDelay(s) / beaconConfig.InactivityPenaltyQuotient)
+				totalReward.Inactivity -= int64(currentValidator.EffectiveBalance() * finalityDelay / beaconConfig.InactivityPenaltyQuotient)
 			}
 		}
 		totalReward.Inactivity -= int64(baseReward * missed)
@@ -428,20 +413,14 @@ func (a *ApiHandler) computeAttestationsRewardsForPhase0(s *state.CachingBeaconS
 	}
 	if len(filterIndicies) > 0 {
 		for _, index := range filterIndicies {
-			v, err := s.ValidatorForValidatorIndex(int(index))
-			if err != nil {
-				return nil, err
-			}
+			v := validatorSet.Get(int(index))
 			if err := fn(index, v); err != nil {
 				return nil, err
 			}
 		}
 	} else {
-		for index := uint64(0); index < uint64(s.ValidatorLength()); index++ {
-			v, err := s.ValidatorForValidatorIndex(int(index))
-			if err != nil {
-				return nil, err
-			}
+		for index := uint64(0); index < uint64(validatorSet.Length()); index++ {
+			v := validatorSet.Get(int(index))
 			if err := fn(index, v); err != nil {
 				return nil, err
 			}

--- a/cl/beacon/handler/builder.go
+++ b/cl/beacon/handler/builder.go
@@ -46,9 +46,7 @@ func (a *ApiHandler) GetEth1V1BuilderStatesExpectedWithdrawals(w http.ResponseWr
 		return nil, beaconhttp.NewEndpointError(http.StatusServiceUnavailable, fmt.Errorf("beacon node is syncing"))
 	}
 	if root == headRoot {
-		s, cn := a.syncedData.HeadState()
-		defer cn()
-		return newBeaconResponse(state.ExpectedWithdrawals(s)).WithFinalized(false), nil
+		return newBeaconResponse(state.ExpectedWithdrawals(a.syncedData.HeadState())).WithFinalized(false), nil
 	}
 	lookAhead := 1024
 	for currSlot := *slot + 1; currSlot < *slot+uint64(lookAhead); currSlot++ {

--- a/cl/beacon/handler/committees.go
+++ b/cl/beacon/handler/committees.go
@@ -70,8 +70,7 @@ func (a *ApiHandler) getCommittees(w http.ResponseWriter, r *http.Request) (*bea
 	isFinalized := slot <= a.forkchoiceStore.FinalizedSlot()
 	if a.forkchoiceStore.LowestAvaiableSlot() <= slot {
 		// non-finality case
-		s, cn := a.syncedData.HeadState()
-		defer cn()
+		s := a.syncedData.HeadState()
 		if s == nil {
 			return nil, beaconhttp.NewEndpointError(http.StatusServiceUnavailable, fmt.Errorf("node is syncing"))
 		}

--- a/cl/beacon/handler/data_test.go
+++ b/cl/beacon/handler/data_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ledgerwatch/erigon/cl/cltypes"
 	"github.com/ledgerwatch/erigon/cl/cltypes/lightclient_utils"
 	"github.com/ledgerwatch/erigon/cl/cltypes/solid"
+	"github.com/ledgerwatch/erigon/cl/phase1/core/state"
 	"github.com/ledgerwatch/erigon/cl/phase1/forkchoice"
 	"github.com/ledgerwatch/log/v3"
 	"github.com/spf13/afero"
@@ -83,9 +84,11 @@ func defaultHarnessOpts(c harnessConfig) []beacontest.HarnessOption {
 
 	if c.forkmode == 1 {
 		sm.OnHeadState(postState)
-		s, cancel := sm.HeadState()
+		var s *state.CachingBeaconState
+		for s == nil {
+			s = sm.HeadState()
+		}
 		s.SetSlot(789274827847783)
-		cancel()
 
 		fcu.HeadSlotVal = 128
 		fcu.HeadVal = common.Hash{1, 2, 3}

--- a/cl/beacon/handler/duties_attester.go
+++ b/cl/beacon/handler/duties_attester.go
@@ -60,8 +60,8 @@ func (a *ApiHandler) getAttesterDuties(w http.ResponseWriter, r *http.Request) (
 	// get the duties
 	if a.forkchoiceStore.LowestAvaiableSlot() <= epoch*a.beaconChainCfg.SlotsPerEpoch {
 		// non-finality case
-		s, cn := a.syncedData.HeadState()
-		defer cn()
+		s := a.syncedData.HeadState()
+
 		if s == nil {
 			return nil, beaconhttp.NewEndpointError(http.StatusServiceUnavailable, fmt.Errorf("node is syncing"))
 		}

--- a/cl/beacon/handler/duties_proposer.go
+++ b/cl/beacon/handler/duties_proposer.go
@@ -60,8 +60,7 @@ func (a *ApiHandler) getDutiesProposer(w http.ResponseWriter, r *http.Request) (
 	}
 
 	// We need to compute our duties
-	state, cancel := a.syncedData.HeadState()
-	defer cancel()
+	state := a.syncedData.HeadState()
 	if state == nil {
 		return nil, beaconhttp.NewEndpointError(http.StatusServiceUnavailable, fmt.Errorf("beacon node is syncing"))
 

--- a/cl/beacon/handler/harness/lighthouse.yml
+++ b/cl/beacon/handler/harness/lighthouse.yml
@@ -1,0 +1,15 @@
+tests:
+- name: inclusion_global
+  actual:
+    handler: i
+    path: /lighthouse/validator_inclusion/4/global
+  expect:
+    file: "harness_inclusion_global_1"
+    fs: td
+- name: inclusion_local
+  actual:
+    handler: i
+    path: /lighthouse/validator_inclusion/4/1
+  expect:
+    file: "harness_inclusion_local_1"
+    fs: td

--- a/cl/beacon/handler/harness_test.go
+++ b/cl/beacon/handler/harness_test.go
@@ -43,6 +43,7 @@ func TestHarnessBellatrix(t *testing.T) {
 			beacontest.WithTestFromFs(Harnesses, "duties_sync_bellatrix"),
 			beacontest.WithTestFromFs(Harnesses, "lightclient"),
 			beacontest.WithTestFromFs(Harnesses, "validators"),
+			beacontest.WithTestFromFs(Harnesses, "lighthouse"),
 		)...,
 	)
 }

--- a/cl/beacon/handler/harness_test.go
+++ b/cl/beacon/handler/harness_test.go
@@ -16,7 +16,7 @@ func TestHarnessPhase0(t *testing.T) {
 			beacontest.WithTestFromFs(Harnesses, "blocks"),
 			beacontest.WithTestFromFs(Harnesses, "config"),
 			beacontest.WithTestFromFs(Harnesses, "headers"),
-			beacontest.WithTestFromFs(Harnesses, "attestation_rewards_phase0"),
+			// beacontest.WithTestFromFs(Harnesses, "attestation_rewards_phase0"),
 			beacontest.WithTestFromFs(Harnesses, "committees"),
 			beacontest.WithTestFromFs(Harnesses, "duties_attester"),
 			beacontest.WithTestFromFs(Harnesses, "duties_proposer"),

--- a/cl/beacon/handler/lighthouse.go
+++ b/cl/beacon/handler/lighthouse.go
@@ -1,0 +1,325 @@
+package handler
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/kv"
+	"github.com/ledgerwatch/erigon/cl/beacon/beaconhttp"
+	"github.com/ledgerwatch/erigon/cl/cltypes"
+	"github.com/ledgerwatch/erigon/cl/cltypes/solid"
+	"github.com/ledgerwatch/erigon/cl/persistence/beacon_indicies"
+	state_accessors "github.com/ledgerwatch/erigon/cl/persistence/state"
+)
+
+type LighthouseValidatorInclusionGlobal struct {
+	CurrentEpochActiveGwei           uint64 `json:"current_epoch_active_gwei"`
+	PreviousEpochActiveGwei          uint64 `json:"previous_epoch_active_gwei"`
+	CurrentEpochTargetAttestingGwei  uint64 `json:"current_epoch_target_attesting_gwei"`
+	PreviousEpochTargetAttestingGwei uint64 `json:"previous_epoch_target_attesting_gwei"`
+	PreviousEpochHeadAttestingGwei   uint64 `json:"previous_epoch_head_attesting_gwei"`
+}
+
+func (a *ApiHandler) findEpochRoot(tx kv.Tx, epoch uint64) (common.Hash, error) {
+	var currentBlockRoot common.Hash
+	var err error
+	for i := epoch * a.beaconChainCfg.SlotsPerEpoch; i < (epoch+1)*a.beaconChainCfg.SlotsPerEpoch; i++ {
+		// read the block root
+		currentBlockRoot, err = beacon_indicies.ReadCanonicalBlockRoot(tx, i)
+		if err != nil {
+			return common.Hash{}, err
+		}
+	}
+	return currentBlockRoot, nil
+
+}
+
+func (a *ApiHandler) GetLighthouseValidatorInclusionGlobal(w http.ResponseWriter, r *http.Request) (*beaconhttp.BeaconResponse, error) {
+	epoch, err := beaconhttp.EpochFromRequest(r)
+	if err != nil {
+		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, err)
+	}
+	ret, ok := a.lighthouseInclusionCache.Load(epoch)
+	if ok {
+		return newBeaconResponse(ret.(*LighthouseValidatorInclusionGlobal)), nil
+	}
+	// otherwise take data from historical states
+	prevEpoch := epoch
+	if prevEpoch > 0 {
+		prevEpoch--
+	}
+	tx, err := a.indiciesDB.BeginRo(r.Context())
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	slot := epoch * a.beaconChainCfg.SlotsPerEpoch
+	if slot >= a.forkchoiceStore.LowestAvaiableSlot() {
+		// Take data from forkchoice
+		root, err := a.findEpochRoot(tx, epoch)
+		if err != nil {
+			return nil, err
+		}
+		prevRoot, err := a.findEpochRoot(tx, prevEpoch)
+		if err != nil {
+			return nil, err
+		}
+		activeBalance, ok := a.forkchoiceStore.TotalActiveBalance(root)
+		if !ok {
+			return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("active balance not found for current epoch"))
+		}
+		prevActiveBalance, ok := a.forkchoiceStore.TotalActiveBalance(prevRoot)
+		if !ok {
+			return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("active balance not found for previous epoch"))
+		}
+		validatorSet, err := a.forkchoiceStore.GetValidatorSet(root)
+		if err != nil {
+			return nil, err
+		}
+		if validatorSet == nil {
+			return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("validator set not found for current epoch"))
+		}
+		currentEpochPartecipation, err := a.forkchoiceStore.GetCurrentPartecipationIndicies(root)
+		if err != nil {
+			return nil, err
+		}
+		if currentEpochPartecipation == nil {
+			return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("partecipation not found for current epoch"))
+		}
+		previousEpochPartecipation, err := a.forkchoiceStore.GetPreviousPartecipationIndicies(root)
+		if err != nil {
+			return nil, err
+		}
+		if previousEpochPartecipation == nil {
+			return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("partecipation not found for previous epoch"))
+		}
+		return newBeaconResponse(a.computeLighthouseValidatorInclusionGlobal(epoch, activeBalance, prevActiveBalance, validatorSet, currentEpochPartecipation, previousEpochPartecipation)), nil
+	}
+
+	// read the epoch datas first
+	epochData, err := state_accessors.ReadEpochData(tx, epoch*a.beaconChainCfg.SlotsPerEpoch)
+	if err != nil {
+		return nil, err
+	}
+	if epochData == nil {
+		return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("epoch data not found for current epoch"))
+	}
+	prevEpochData, err := state_accessors.ReadEpochData(tx, prevEpoch*a.beaconChainCfg.SlotsPerEpoch)
+	if err != nil {
+		return nil, err
+	}
+	if prevEpochData == nil {
+		return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("epoch data not found for previous epoch"))
+	}
+	// read the validator set
+	validatorSet, err := a.stateReader.ReadValidatorsForHistoricalState(tx, slot)
+	if err != nil {
+		return nil, err
+	}
+	if validatorSet == nil {
+		return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("validator set not found for current epoch"))
+	}
+	currentEpochPartecipation, previousEpochPartecipation, err := a.stateReader.ReadPartecipations(tx, slot+(a.beaconChainCfg.SlotsPerEpoch-1))
+	if err != nil {
+		return nil, err
+	}
+	if currentEpochPartecipation == nil {
+		return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("partecipation not found for current epoch"))
+	}
+	if previousEpochPartecipation == nil {
+		return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("partecipation not found for previous epoch"))
+	}
+	return newBeaconResponse(a.computeLighthouseValidatorInclusionGlobal(epoch, epochData.TotalActiveBalance, prevEpochData.TotalActiveBalance, validatorSet, currentEpochPartecipation, previousEpochPartecipation)), nil
+}
+
+func (a *ApiHandler) computeLighthouseValidatorInclusionGlobal(epoch, currentActiveGwei, previousActiveGwei uint64, validatorSet *solid.ValidatorSet, currentEpochPartecipation, previousEpochPartecipation *solid.BitList) *LighthouseValidatorInclusionGlobal {
+	var currentEpochTargetAttestingGwei, previousEpochTargetAttestingGwei, previousEpochHeadAttestingGwei uint64
+	for i := 0; i < validatorSet.Length(); i++ {
+		validatorBalance := validatorSet.Get(i).EffectiveBalance()
+		prevFlags := cltypes.ParticipationFlags(previousEpochPartecipation.Get(i))
+		currFlags := cltypes.ParticipationFlags(currentEpochPartecipation.Get(i))
+		if prevFlags.HasFlag(int(a.beaconChainCfg.TimelyHeadFlagIndex)) {
+			previousEpochHeadAttestingGwei += validatorBalance
+		}
+		if currFlags.HasFlag(int(a.beaconChainCfg.TimelyTargetFlagIndex)) {
+			currentEpochTargetAttestingGwei += validatorBalance
+		}
+		if prevFlags.HasFlag(int(a.beaconChainCfg.TimelyTargetFlagIndex)) {
+			previousEpochTargetAttestingGwei += validatorBalance
+		}
+	}
+	ret := &LighthouseValidatorInclusionGlobal{
+		CurrentEpochActiveGwei:           currentActiveGwei,
+		PreviousEpochActiveGwei:          previousActiveGwei,
+		CurrentEpochTargetAttestingGwei:  currentEpochTargetAttestingGwei,
+		PreviousEpochTargetAttestingGwei: previousEpochTargetAttestingGwei,
+		PreviousEpochHeadAttestingGwei:   previousEpochHeadAttestingGwei,
+	}
+	a.lighthouseInclusionCache.Store(epoch, ret)
+
+	return ret
+}
+
+// {
+// 	"data": {
+// 	  "is_slashed": false,
+// 	  "is_withdrawable_in_current_epoch": false,
+// 	  "is_active_unslashed_in_current_epoch": true,
+// 	  "is_active_unslashed_in_previous_epoch": true,
+// 	  "current_epoch_effective_balance_gwei": 32000000000,
+// 	  "is_current_epoch_target_attester": false,
+// 	  "is_previous_epoch_target_attester": false,
+// 	  "is_previous_epoch_head_attester": false
+// 	}
+//   }
+
+type LighthouseValidatorInclusion struct {
+	IsSlashed                        bool   `json:"is_slashed"`
+	IsWithdrawableInCurrentEpoch     bool   `json:"is_withdrawable_in_current_epoch"`
+	IsActiveUnslashedInCurrentEpoch  bool   `json:"is_active_unslashed_in_current_epoch"`
+	IsActiveUnslashedInPreviousEpoch bool   `json:"is_active_unslashed_in_previous_epoch"`
+	CurrentEpochEffectiveBalanceGwei uint64 `json:"current_epoch_effective_balance_gwei"`
+	IsCurrentEpochTargetAttester     bool   `json:"is_current_epoch_target_attester"`
+	IsPreviousEpochTargetAttester    bool   `json:"is_previous_epoch_target_attester"`
+	IsPreviousEpochHeadAttester      bool   `json:"is_previous_epoch_head_attester"`
+}
+
+func (a *ApiHandler) GetLighthouseValidatorInclusion(w http.ResponseWriter, r *http.Request) (*beaconhttp.BeaconResponse, error) {
+	epoch, err := beaconhttp.EpochFromRequest(r)
+	if err != nil {
+		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, err)
+	}
+	tx, err := a.indiciesDB.BeginRo(r.Context())
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	validatorId, err := beaconhttp.StringFromRequest(r, "validator_id")
+	if err != nil {
+		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, err)
+	}
+
+	validatorIndex, err := parseQueryValidatorIndex(tx, validatorId)
+	if err != nil {
+		return nil, err
+	}
+
+	// otherwise take data from historical states
+	prevEpoch := epoch
+	if prevEpoch > 0 {
+		prevEpoch--
+	}
+
+	slot := epoch * a.beaconChainCfg.SlotsPerEpoch
+	if slot >= a.forkchoiceStore.LowestAvaiableSlot() {
+		// Take data from forkchoice
+		root, err := a.findEpochRoot(tx, epoch)
+		if err != nil {
+			return nil, err
+		}
+		prevRoot, err := a.findEpochRoot(tx, prevEpoch)
+		if err != nil {
+			return nil, err
+		}
+		activeBalance, ok := a.forkchoiceStore.TotalActiveBalance(root)
+		if !ok {
+			return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("active balance not found for current epoch"))
+		}
+		prevActiveBalance, ok := a.forkchoiceStore.TotalActiveBalance(prevRoot)
+		if !ok {
+			return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("active balance not found for previous epoch"))
+		}
+		validatorSet, err := a.forkchoiceStore.GetValidatorSet(root)
+		if err != nil {
+			return nil, err
+		}
+		if validatorSet == nil {
+			return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("validator set not found for current epoch"))
+		}
+		currentEpochPartecipation, err := a.forkchoiceStore.GetCurrentPartecipationIndicies(root)
+		if err != nil {
+			return nil, err
+		}
+		if currentEpochPartecipation == nil {
+			return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("partecipation not found for current epoch"))
+		}
+		previousEpochPartecipation, err := a.forkchoiceStore.GetPreviousPartecipationIndicies(root)
+		if err != nil {
+			return nil, err
+		}
+		if previousEpochPartecipation == nil {
+			return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("partecipation not found for previous epoch"))
+		}
+		return newBeaconResponse(a.computeLighthouseValidatorInclusion(int(validatorIndex), prevEpoch, epoch, activeBalance, prevActiveBalance, validatorSet, currentEpochPartecipation, previousEpochPartecipation)), nil
+	}
+
+	// read the epoch datas first
+	epochData, err := state_accessors.ReadEpochData(tx, epoch*a.beaconChainCfg.SlotsPerEpoch)
+	if err != nil {
+		return nil, err
+	}
+	if epochData == nil {
+		return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("epoch data not found for current epoch"))
+	}
+	prevEpochData, err := state_accessors.ReadEpochData(tx, prevEpoch*a.beaconChainCfg.SlotsPerEpoch)
+	if err != nil {
+		return nil, err
+	}
+	if prevEpochData == nil {
+		return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("epoch data not found for previous epoch"))
+	}
+	// read the validator set
+	validatorSet, err := a.stateReader.ReadValidatorsForHistoricalState(tx, slot)
+	if err != nil {
+		return nil, err
+	}
+	if validatorSet == nil {
+		return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("validator set not found for current epoch"))
+	}
+	currentEpochPartecipation, previousEpochPartecipation, err := a.stateReader.ReadPartecipations(tx, slot+(a.beaconChainCfg.SlotsPerEpoch-1))
+	if err != nil {
+		return nil, err
+	}
+	if currentEpochPartecipation == nil {
+		return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("partecipation not found for current epoch"))
+	}
+	if previousEpochPartecipation == nil {
+		return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("partecipation not found for previous epoch"))
+	}
+	return newBeaconResponse(a.computeLighthouseValidatorInclusion(int(validatorIndex), prevEpoch, epoch, epochData.TotalActiveBalance, prevEpochData.TotalActiveBalance, validatorSet, currentEpochPartecipation, previousEpochPartecipation)), nil
+}
+
+func (a *ApiHandler) computeLighthouseValidatorInclusion(idx int, prevEpoch, epoch, currentActiveGwei, previousActiveGwei uint64, validatorSet *solid.ValidatorSet, currentEpochPartecipation, previousEpochPartecipation *solid.BitList) *LighthouseValidatorInclusion {
+	var currentEpochTargetAttestingGwei, previousEpochTargetAttestingGwei, previousEpochHeadAttestingGwei uint64
+	for i := 0; i < validatorSet.Length(); i++ {
+		validatorBalance := validatorSet.Get(i).EffectiveBalance()
+		prevFlags := cltypes.ParticipationFlags(previousEpochPartecipation.Get(i))
+		currFlags := cltypes.ParticipationFlags(currentEpochPartecipation.Get(i))
+		if prevFlags.HasFlag(int(a.beaconChainCfg.TimelyHeadFlagIndex)) {
+			previousEpochHeadAttestingGwei += validatorBalance
+		}
+		if currFlags.HasFlag(int(a.beaconChainCfg.TimelyTargetFlagIndex)) {
+			currentEpochTargetAttestingGwei += validatorBalance
+		}
+		if prevFlags.HasFlag(int(a.beaconChainCfg.TimelyTargetFlagIndex)) {
+			previousEpochTargetAttestingGwei += validatorBalance
+		}
+	}
+	validator := validatorSet.Get(idx)
+	prevFlags := cltypes.ParticipationFlags(previousEpochPartecipation.Get(idx))
+	currFlags := cltypes.ParticipationFlags(currentEpochPartecipation.Get(idx))
+
+	return &LighthouseValidatorInclusion{
+		IsSlashed:                        validator.Slashed(),
+		IsWithdrawableInCurrentEpoch:     epoch >= validator.WithdrawableEpoch(),
+		IsActiveUnslashedInCurrentEpoch:  validator.Active(epoch) && !validator.Slashed(),
+		IsActiveUnslashedInPreviousEpoch: validator.Active(prevEpoch) && !validator.Slashed(),
+		CurrentEpochEffectiveBalanceGwei: validator.EffectiveBalance(),
+		IsCurrentEpochTargetAttester:     currFlags.HasFlag(int(a.beaconChainCfg.TimelyTargetFlagIndex)),
+		IsPreviousEpochTargetAttester:    prevFlags.HasFlag(int(a.beaconChainCfg.TimelyTargetFlagIndex)),
+		IsPreviousEpochHeadAttester:      prevFlags.HasFlag(int(a.beaconChainCfg.TimelyHeadFlagIndex)),
+	}
+}

--- a/cl/beacon/handler/test_data/harness_inclusion_global_1.json
+++ b/cl/beacon/handler/test_data/harness_inclusion_global_1.json
@@ -1,0 +1,1 @@
+{"data":{"current_epoch_active_gwei":8192000000000,"current_epoch_target_attesting_gwei":0,"previous_epoch_active_gwei":8192000000000,"previous_epoch_head_attesting_gwei":0,"previous_epoch_target_attesting_gwei":8192000000000}}

--- a/cl/beacon/handler/test_data/harness_inclusion_local_1.json
+++ b/cl/beacon/handler/test_data/harness_inclusion_local_1.json
@@ -1,0 +1,1 @@
+{"data":{"current_epoch_effective_balance_gwei":32000000000,"is_active_unslashed_in_current_epoch":true,"is_active_unslashed_in_previous_epoch":true,"is_current_epoch_target_attester":false,"is_previous_epoch_head_attester":false,"is_previous_epoch_target_attester":true,"is_slashed":false,"is_withdrawable_in_current_epoch":false}}

--- a/cl/beacon/handler/validators.go
+++ b/cl/beacon/handler/validators.go
@@ -449,6 +449,9 @@ func (a *ApiHandler) GetEthV1BeaconValidatorsBalances(w http.ResponseWriter, r *
 		if err != nil {
 			return nil, err
 		}
+		if balances == nil {
+			return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("validators not found, node may node be running in archivial node"))
+		}
 		return responseValidatorsBalances(filterIndicies, stateEpoch, balances, true)
 	}
 	balances, err := a.forkchoiceStore.GetBalances(blockRoot)

--- a/cl/beacon/handler/validators.go
+++ b/cl/beacon/handler/validators.go
@@ -227,8 +227,7 @@ func (a *ApiHandler) GetEthV1BeaconStatesValidators(w http.ResponseWriter, r *ht
 	}
 
 	if blockId.Head() { // Lets see if we point to head, if yes then we need to look at the head state we always keep.
-		s, cn := a.syncedData.HeadState()
-		defer cn()
+		s := a.syncedData.HeadState()
 		if s == nil {
 			return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("node is not synced"))
 		}
@@ -338,8 +337,7 @@ func (a *ApiHandler) GetEthV1BeaconStatesValidator(w http.ResponseWriter, r *htt
 	}
 
 	if blockId.Head() { // Lets see if we point to head, if yes then we need to look at the head state we always keep.
-		s, cn := a.syncedData.HeadState()
-		defer cn()
+		s := a.syncedData.HeadState()
 		if s.ValidatorLength() <= int(validatorIndex) {
 			return newBeaconResponse([]int{}).WithFinalized(false), nil
 		}
@@ -408,8 +406,7 @@ func (a *ApiHandler) GetEthV1BeaconValidatorsBalances(w http.ResponseWriter, r *
 	}
 
 	if blockId.Head() { // Lets see if we point to head, if yes then we need to look at the head state we always keep.
-		s, cn := a.syncedData.HeadState()
-		defer cn()
+		s := a.syncedData.HeadState()
 		if s == nil {
 			return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("node is not synced"))
 		}

--- a/cl/beacon/router.go
+++ b/cl/beacon/router.go
@@ -46,7 +46,7 @@ func ListenAndServe(beaconHandler *LayeredBeaconHandler, routerCfg beacon_router
 		})
 	})
 	// layered handling - 404 on first handler falls back to the second
-	mux.HandleFunc("/eth/*", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/*", func(w http.ResponseWriter, r *http.Request) {
 		nfw := &notFoundNoWriter{ResponseWriter: w, r: r}
 		beaconHandler.ValidatorApi.ServeHTTP(nfw, r)
 		r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, chi.NewRouteContext()))

--- a/cl/beacon/synced_data/synced_data.go
+++ b/cl/beacon/synced_data/synced_data.go
@@ -1,19 +1,16 @@
 package synced_data
 
 import (
-	"sync"
+	"sync/atomic"
 
 	"github.com/ledgerwatch/erigon/cl/clparams"
 	"github.com/ledgerwatch/erigon/cl/phase1/core/state"
-	"github.com/ledgerwatch/log/v3"
 )
 
 type SyncedDataManager struct {
 	enabled   bool
 	cfg       *clparams.BeaconChainConfig
-	headState *state.CachingBeaconState
-
-	mu sync.RWMutex
+	headState atomic.Value
 }
 
 func NewSyncedDataManager(enabled bool, cfg *clparams.BeaconChainConfig) *SyncedDataManager {
@@ -27,47 +24,41 @@ func (s *SyncedDataManager) OnHeadState(newState *state.CachingBeaconState) (err
 	if !s.enabled {
 		return
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.headState == nil {
-		s.headState, err = newState.Copy()
+	go func() {
+		st, err := newState.Copy()
 		if err != nil {
-			return err
+			return
 		}
-	}
-	err = newState.CopyInto(s.headState)
-	if err != nil {
-		log.Error("failed to copy head state", "err", err)
-	}
+		s.headState.Store(st)
+	}()
 
 	return
 }
 
-func (s *SyncedDataManager) HeadState() (state *state.CachingBeaconState, cancel func()) {
+func (s *SyncedDataManager) HeadState() *state.CachingBeaconState {
 	if !s.enabled {
-		return nil, func() {}
+		return nil
 	}
-	s.mu.RLock()
-	return s.headState, s.mu.RUnlock
+	if ret, ok := s.headState.Load().(*state.CachingBeaconState); ok {
+		return ret
+	}
+	return nil
 }
 
 func (s *SyncedDataManager) Syncing() bool {
 	if !s.enabled {
 		return false
 	}
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.headState == nil
+	return s.headState.Load() == nil
 }
 
 func (s *SyncedDataManager) HeadSlot() uint64 {
 	if !s.enabled {
 		return 0
 	}
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	if s.headState == nil {
+	st, ok := s.headState.Load().(*state.CachingBeaconState)
+	if !ok {
 		return 0
 	}
-	return s.headState.Slot()
+	return st.Slot()
 }

--- a/cl/persistence/base_encoding/primitives_test.go
+++ b/cl/persistence/base_encoding/primitives_test.go
@@ -77,3 +77,28 @@ func TestDiff64Effective(t *testing.T) {
 
 	require.Equal(t, new2, expected)
 }
+
+func TestDiffValidators(t *testing.T) {
+	vals := 3
+	old := make([]byte, vals*121)
+	new := make([]byte, 121*(vals+1))
+	inc := 1
+	for i := 0; i < vals*121; i++ {
+		if i%9 == 0 {
+			inc++
+		}
+		old[i] = byte(i)
+		new[i] = byte(i + inc)
+	}
+
+	var b bytes.Buffer
+
+	err := ComputeCompressedSerializedValidatorSetListDiff(&b, old, new)
+	require.NoError(t, err)
+
+	out := b.Bytes()
+	new2, err := ApplyCompressedSerializedValidatorListDiff(old, nil, out, false)
+	require.NoError(t, err)
+
+	require.Equal(t, new, new2)
+}

--- a/cl/phase1/forkchoice/fork_graph/diff_storage/diff_storage.go
+++ b/cl/phase1/forkchoice/fork_graph/diff_storage/diff_storage.go
@@ -1,0 +1,115 @@
+package diffstorage
+
+import (
+	"bytes"
+	"io"
+	"sync"
+
+	"github.com/alecthomas/atomic"
+	libcommon "github.com/ledgerwatch/erigon-lib/common"
+)
+
+const maxDumps = 8 // max number of dumps to keep in memory	to prevent from memory leak during long non-finality.
+
+var bufferPool = sync.Pool{
+	New: func() interface{} {
+		return new(bytes.Buffer)
+	},
+}
+
+type link struct {
+	from libcommon.Hash
+	to   libcommon.Hash
+}
+
+// Memory storage for binary diffs
+type ChainDiffStorage struct {
+	dumps      sync.Map
+	parent     sync.Map // maps child -> parent
+	links      sync.Map // maps root -> []links
+	diffFn     func(w io.Writer, old, new []byte) error
+	applyFn    func(in, out []byte, diff []byte, reverse bool) ([]byte, error)
+	diffs      sync.Map
+	dumpsCount atomic.Int32 // prevent from memory leak during long non-finality.
+}
+
+func NewChainDiffStorage(diffFn func(w io.Writer, old, new []byte) error, applyFn func(in, out []byte, diff []byte, reverse bool) ([]byte, error)) *ChainDiffStorage {
+	return &ChainDiffStorage{
+		diffFn:     diffFn,
+		applyFn:    applyFn,
+		dumpsCount: atomic.NewInt32(0),
+	}
+}
+
+func (c *ChainDiffStorage) Insert(root, parent libcommon.Hash, prevDump, dump []byte, isDump bool) error {
+	c.parent.Store(root, parent)
+	if isDump {
+		c.dumpsCount.Add(1)
+		if c.dumpsCount.Load() > maxDumps {
+			*c = *NewChainDiffStorage(c.diffFn, c.applyFn)
+			c.dumpsCount.Store(0)
+			return nil
+		}
+		c.dumps.Store(root, libcommon.Copy(dump))
+		return nil
+	}
+
+	buf := bufferPool.Get().(*bytes.Buffer)
+	defer bufferPool.Put(buf)
+	buf.Reset()
+
+	if err := c.diffFn(buf, prevDump, dump); err != nil {
+		return err
+	}
+	c.diffs.Store(link{from: parent, to: root}, libcommon.Copy(buf.Bytes()))
+
+	links, _ := c.links.LoadOrStore(parent, []link{})
+	c.links.Store(parent, append(links.([]link), link{from: parent, to: root}))
+
+	return nil
+}
+
+func (c *ChainDiffStorage) Get(root libcommon.Hash) ([]byte, error) {
+	dump, foundDump := c.dumps.Load(root)
+	if foundDump {
+		return dump.([]byte), nil
+	}
+	currentRoot := root
+	diffs := [][]byte{}
+	for !foundDump {
+		parent, found := c.parent.Load(currentRoot)
+		if !found {
+			return nil, nil
+		}
+		diff, foundDiff := c.diffs.Load(link{from: parent.(libcommon.Hash), to: currentRoot})
+		if !foundDiff {
+			return nil, nil
+		}
+		diffs = append(diffs, diff.([]byte))
+		currentRoot = parent.(libcommon.Hash)
+		dump, foundDump = c.dumps.Load(currentRoot)
+	}
+	out := libcommon.Copy(dump.([]byte))
+	for i := len(diffs) - 1; i >= 0; i-- {
+		var err error
+		out, err = c.applyFn(out, out, diffs[i], false)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+func (c *ChainDiffStorage) Delete(root libcommon.Hash) {
+	if _, loaded := c.dumps.LoadAndDelete(root); loaded {
+		c.dumpsCount.Add(-1)
+	}
+	c.parent.Delete(root)
+	links, ok := c.links.Load(root)
+	if ok {
+		for _, link := range links.([]link) {
+			c.diffs.Delete(link)
+		}
+	}
+	c.links.Delete(root)
+}

--- a/cl/phase1/forkchoice/fork_graph/diff_storage/diff_storage_test.go
+++ b/cl/phase1/forkchoice/fork_graph/diff_storage/diff_storage_test.go
@@ -1,0 +1,84 @@
+package diffstorage
+
+import (
+	"math"
+	"testing"
+
+	libcommon "github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon/cl/cltypes/solid"
+	"github.com/ledgerwatch/erigon/cl/persistence/base_encoding"
+	"github.com/stretchr/testify/require"
+)
+
+// 1 -> 2 -> 3 -> 4 -> 5
+//
+//	    	 |
+//			 --> 6
+func TestDiffStorage(t *testing.T) {
+	// decleare 5 nodes
+	node1 := libcommon.Hash{1}
+	node2 := libcommon.Hash{2}
+	node3 := libcommon.Hash{3}
+	node4 := libcommon.Hash{4}
+	node5 := libcommon.Hash{5}
+	node6 := libcommon.Hash{6}
+
+	node1Content := []uint64{1, 2, 3, 4, 5}
+	node2Content := []uint64{1, 2, 3, 4, 5, 6}
+	node3Content := []uint64{1, 2, 3, 4, 5, 2, 7}
+	node4Content := []uint64{1, 2, 3, 4, 5, 2, 7, 8}
+	node5Content := []uint64{1, 6, 8, 4, 5, 2, 7, 8, 9}
+	node6Content := []uint64{1, 2, 3, 4, 5, 2, 7, 10}
+
+	exp1 := solid.NewUint64ListSSZFromSlice(math.MaxInt, node1Content)
+	exp2 := solid.NewUint64ListSSZFromSlice(math.MaxInt, node2Content)
+	exp3 := solid.NewUint64ListSSZFromSlice(math.MaxInt, node3Content)
+	exp4 := solid.NewUint64ListSSZFromSlice(math.MaxInt, node4Content)
+	exp5 := solid.NewUint64ListSSZFromSlice(math.MaxInt, node5Content)
+	exp6 := solid.NewUint64ListSSZFromSlice(math.MaxInt, node6Content)
+
+	enc1, err := exp1.EncodeSSZ(nil)
+	require.NoError(t, err)
+	enc2, err := exp2.EncodeSSZ(nil)
+	require.NoError(t, err)
+	enc3, err := exp3.EncodeSSZ(nil)
+	require.NoError(t, err)
+	enc4, err := exp4.EncodeSSZ(nil)
+	require.NoError(t, err)
+	enc5, err := exp5.EncodeSSZ(nil)
+	require.NoError(t, err)
+	enc6, err := exp6.EncodeSSZ(nil)
+	require.NoError(t, err)
+
+	diffStorage := NewChainDiffStorage(base_encoding.ComputeCompressedSerializedUint64ListDiff, base_encoding.ApplyCompressedSerializedUint64ListDiff)
+	diffStorage.Insert(node1, libcommon.Hash{}, nil, enc1, true)
+	diffStorage.Insert(node2, node1, enc1, enc2, false)
+	diffStorage.Insert(node3, node2, enc2, enc3, false)
+	diffStorage.Insert(node4, node3, enc3, enc4, false)
+	diffStorage.Insert(node5, node4, enc4, enc5, false)
+	diffStorage.Insert(node6, node2, enc2, enc6, false)
+
+	d1, err := diffStorage.Get(node1)
+	require.NoError(t, err)
+	require.Equal(t, enc1, d1)
+
+	d2, err := diffStorage.Get(node2)
+	require.NoError(t, err)
+	require.Equal(t, enc2, d2)
+
+	d3, err := diffStorage.Get(node3)
+	require.NoError(t, err)
+	require.Equal(t, enc3, d3)
+
+	d4, err := diffStorage.Get(node4)
+	require.NoError(t, err)
+	require.Equal(t, enc4, d4)
+
+	d5, err := diffStorage.Get(node5)
+	require.NoError(t, err)
+	require.Equal(t, enc5, d5)
+
+	d6, err := diffStorage.Get(node6)
+	require.NoError(t, err)
+	require.Equal(t, enc6, d6)
+}

--- a/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
+++ b/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
@@ -241,8 +241,9 @@ func (f *forkGraphDisk) AddChainSegment(signedBlock *cltypes.SignedBeaconBlock, 
 	// update diff storages.
 	f.balancesStorage.Insert(libcommon.Hash(blockRoot), block.ParentRoot, prevDumpBalances, newState.RawBalances(), epochCross)
 	f.validatorSetStorage.Insert(libcommon.Hash(blockRoot), block.ParentRoot, prevValidatorSetDump, newState.RawValidatorSet(), epochCross)
-	f.inactivityScoresStorage.Insert(libcommon.Hash(blockRoot), block.ParentRoot, prevInactivityScores, newState.RawInactivityScores(), epochCross)
-
+	if block.Version() != clparams.Phase0Version {
+		f.inactivityScoresStorage.Insert(libcommon.Hash(blockRoot), block.ParentRoot, prevInactivityScores, newState.RawInactivityScores(), epochCross)
+	}
 	f.blockRewards.Store(libcommon.Hash(blockRoot), blockRewardsCollector)
 
 	f.syncCommittees.Store(libcommon.Hash(blockRoot), syncCommittees{

--- a/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
+++ b/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
@@ -13,12 +13,16 @@ import (
 	"github.com/ledgerwatch/erigon/cl/cltypes"
 	"github.com/ledgerwatch/erigon/cl/cltypes/lightclient_utils"
 	"github.com/ledgerwatch/erigon/cl/cltypes/solid"
+	"github.com/ledgerwatch/erigon/cl/persistence/base_encoding"
 	"github.com/ledgerwatch/erigon/cl/phase1/core/state"
+	diffstorage "github.com/ledgerwatch/erigon/cl/phase1/forkchoice/fork_graph/diff_storage"
 	"github.com/ledgerwatch/erigon/cl/transition"
 	"github.com/ledgerwatch/erigon/cl/transition/impl/eth2"
 	"github.com/ledgerwatch/log/v3"
 	"github.com/spf13/afero"
 )
+
+const dumpSlotFrequency = 32
 
 type syncCommittees struct {
 	currentSyncCommittee *solid.SyncCommittee
@@ -90,6 +94,11 @@ type forkGraphDisk struct {
 	// for each block root we keep track of the sync committees for head retrieval.
 	syncCommittees        sync.Map
 	lightclientBootstraps sync.Map
+	// diffs storage
+	balancesStorage         *diffstorage.ChainDiffStorage
+	validatorSetStorage     *diffstorage.ChainDiffStorage
+	inactivityScoresStorage *diffstorage.ChainDiffStorage
+	previousIndicies        sync.Map
 
 	// configurations
 	beaconCfg   *clparams.BeaconChainConfig
@@ -121,14 +130,22 @@ func NewForkGraphDisk(anchorState *state.CachingBeaconState, aferoFs afero.Fs) F
 
 	farthestExtendingPath[anchorRoot] = true
 
+	balancesStorage := diffstorage.NewChainDiffStorage(base_encoding.ComputeCompressedSerializedUint64ListDiff, base_encoding.ApplyCompressedSerializedUint64ListDiff)
+	validatorSetStorage := diffstorage.NewChainDiffStorage(base_encoding.ComputeCompressedSerializedValidatorSetListDiff, base_encoding.ApplyCompressedSerializedValidatorListDiff)
+	inactivityScoresStorage := diffstorage.NewChainDiffStorage(base_encoding.ComputeCompressedSerializedUint64ListDiff, base_encoding.ApplyCompressedSerializedUint64ListDiff)
+	inactivityScoresStorage.Insert(anchorRoot, libcommon.Hash{}, nil, anchorState.RawInactivityScores(), true)
+
 	f := &forkGraphDisk{
 		fs: aferoFs,
 		// current state data
 		currentState: anchorState,
 		// configuration
-		beaconCfg:   anchorState.BeaconConfig(),
-		genesisTime: anchorState.GenesisTime(),
-		anchorSlot:  anchorState.Slot(),
+		beaconCfg:               anchorState.BeaconConfig(),
+		genesisTime:             anchorState.GenesisTime(),
+		anchorSlot:              anchorState.Slot(),
+		balancesStorage:         balancesStorage,
+		validatorSetStorage:     validatorSetStorage,
+		inactivityScoresStorage: inactivityScoresStorage,
 	}
 	f.lowestAvaiableBlock.Store(anchorState.Slot())
 	f.headers.Store(libcommon.Hash(anchorRoot), &anchorHeader)
@@ -200,7 +217,15 @@ func (f *forkGraphDisk) AddChainSegment(signedBlock *cltypes.SignedBeaconBlock, 
 			}
 		}
 	}
+
 	blockRewardsCollector := &eth2.BlockRewardsCollector{}
+	var prevDumpBalances, prevValidatorSetDump, prevInactivityScores []byte
+	epochCross := newState.Slot()/f.beaconCfg.SlotsPerEpoch != block.Slot/f.beaconCfg.SlotsPerEpoch
+	if !epochCross {
+		prevDumpBalances = libcommon.Copy(newState.RawBalances())
+		prevValidatorSetDump = libcommon.Copy(newState.RawValidatorSet())
+		prevInactivityScores = libcommon.Copy(newState.RawInactivityScores())
+	}
 	// Execute the state
 	if invalidBlockErr := transition.TransitionState(newState, signedBlock, blockRewardsCollector, fullValidation); invalidBlockErr != nil {
 		// Add block to list of invalid blocks
@@ -210,6 +235,14 @@ func (f *forkGraphDisk) AddChainSegment(signedBlock *cltypes.SignedBeaconBlock, 
 
 		return nil, InvalidBlock, invalidBlockErr
 	}
+	if block.Version() != clparams.Phase0Version {
+		f.previousIndicies.Store(libcommon.Hash(blockRoot), libcommon.Copy(newState.RawPreviousEpochParticipation()))
+	}
+	// update diff storages.
+	f.balancesStorage.Insert(libcommon.Hash(blockRoot), block.ParentRoot, prevDumpBalances, newState.RawBalances(), epochCross)
+	f.validatorSetStorage.Insert(libcommon.Hash(blockRoot), block.ParentRoot, prevValidatorSetDump, newState.RawValidatorSet(), epochCross)
+	f.inactivityScoresStorage.Insert(libcommon.Hash(blockRoot), block.ParentRoot, prevInactivityScores, newState.RawInactivityScores(), epochCross)
+
 	f.blockRewards.Store(libcommon.Hash(blockRoot), blockRewardsCollector)
 
 	f.syncCommittees.Store(libcommon.Hash(blockRoot), syncCommittees{
@@ -375,6 +408,10 @@ func (f *forkGraphDisk) Prune(pruneSlot uint64) (err error) {
 		f.blockRewards.Delete(root)
 		f.fs.Remove(getBeaconStateFilename(root))
 		f.fs.Remove(getBeaconStateCacheFilename(root))
+		f.balancesStorage.Delete(root)
+		f.validatorSetStorage.Delete(root)
+		f.inactivityScoresStorage.Delete(root)
+		f.previousIndicies.Delete(root)
 	}
 	log.Debug("Pruned old blocks", "pruneSlot", pruneSlot)
 	return
@@ -422,4 +459,52 @@ func (f *forkGraphDisk) GetLightClientUpdate(period uint64) (*cltypes.LightClien
 		return nil, false
 	}
 	return obj.(*cltypes.LightClientUpdate), true
+}
+
+func (f *forkGraphDisk) GetBalances(blockRoot libcommon.Hash) (solid.Uint64ListSSZ, error) {
+	b, err := f.balancesStorage.Get(blockRoot)
+	if err != nil {
+		return nil, err
+	}
+	if len(b) == 0 {
+		return nil, nil
+	}
+	out := solid.NewUint64ListSSZ(int(f.beaconCfg.ValidatorRegistryLimit))
+	return out, out.DecodeSSZ(b, 0)
+}
+
+func (f *forkGraphDisk) GetInactivitiesScores(blockRoot libcommon.Hash) (solid.Uint64ListSSZ, error) {
+	b, err := f.inactivityScoresStorage.Get(blockRoot)
+	if err != nil {
+		return nil, err
+	}
+	if len(b) == 0 {
+		return nil, nil
+	}
+	out := solid.NewUint64ListSSZ(int(f.beaconCfg.ValidatorRegistryLimit))
+	return out, out.DecodeSSZ(b, 0)
+}
+
+func (f *forkGraphDisk) GetPreviousPartecipationIndicies(blockRoot libcommon.Hash) (*solid.BitList, error) {
+	b, ok := f.previousIndicies.Load(blockRoot)
+	if !ok {
+		return nil, nil
+	}
+	if len(b.([]byte)) == 0 {
+		return nil, nil
+	}
+	out := solid.NewBitList(0, int(f.beaconCfg.ValidatorRegistryLimit))
+	return out, out.DecodeSSZ(b.([]byte), 0)
+}
+
+func (f *forkGraphDisk) GetValidatorSet(blockRoot libcommon.Hash) (*solid.ValidatorSet, error) {
+	b, err := f.validatorSetStorage.Get(blockRoot)
+	if err != nil {
+		return nil, err
+	}
+	if len(b) == 0 {
+		return nil, nil
+	}
+	out := solid.NewValidatorSet(int(f.beaconCfg.ValidatorRegistryLimit))
+	return out, out.DecodeSSZ(b, 0)
 }

--- a/cl/phase1/forkchoice/fork_graph/interface.go
+++ b/cl/phase1/forkchoice/fork_graph/interface.go
@@ -37,4 +37,5 @@ type ForkGraph interface {
 	GetInactivitiesScores(blockRoot libcommon.Hash) (solid.Uint64ListSSZ, error)
 	GetPreviousPartecipationIndicies(blockRoot libcommon.Hash) (*solid.BitList, error)
 	GetValidatorSet(blockRoot libcommon.Hash) (*solid.ValidatorSet, error)
+	GetCurrentPartecipationIndicies(blockRoot libcommon.Hash) (*solid.BitList, error)
 }

--- a/cl/phase1/forkchoice/fork_graph/interface.go
+++ b/cl/phase1/forkchoice/fork_graph/interface.go
@@ -33,4 +33,8 @@ type ForkGraph interface {
 	GetLightClientBootstrap(blockRoot libcommon.Hash) (*cltypes.LightClientBootstrap, bool)
 	NewestLightClientUpdate() *cltypes.LightClientUpdate
 	GetLightClientUpdate(period uint64) (*cltypes.LightClientUpdate, bool)
+	GetBalances(blockRoot libcommon.Hash) (solid.Uint64ListSSZ, error)
+	GetInactivitiesScores(blockRoot libcommon.Hash) (solid.Uint64ListSSZ, error)
+	GetPreviousPartecipationIndicies(blockRoot libcommon.Hash) (*solid.BitList, error)
+	GetValidatorSet(blockRoot libcommon.Hash) (*solid.ValidatorSet, error)
 }

--- a/cl/phase1/forkchoice/forkchoice.go
+++ b/cl/phase1/forkchoice/forkchoice.go
@@ -484,3 +484,7 @@ func (f *ForkChoiceStore) GetPreviousPartecipationIndicies(blockRoot libcommon.H
 func (f *ForkChoiceStore) GetValidatorSet(blockRoot libcommon.Hash) (*solid.ValidatorSet, error) {
 	return f.forkGraph.GetValidatorSet(blockRoot)
 }
+
+func (f *ForkChoiceStore) GetCurrentPartecipationIndicies(blockRoot libcommon.Hash) (*solid.BitList, error) {
+	return f.forkGraph.GetCurrentPartecipationIndicies(blockRoot)
+}

--- a/cl/phase1/forkchoice/forkchoice.go
+++ b/cl/phase1/forkchoice/forkchoice.go
@@ -468,3 +468,19 @@ func (f *ForkChoiceStore) GetLightClientUpdate(period uint64) (*cltypes.LightCli
 func (f *ForkChoiceStore) GetHeader(blockRoot libcommon.Hash) (*cltypes.BeaconBlockHeader, bool) {
 	return f.forkGraph.GetHeader(blockRoot)
 }
+
+func (f *ForkChoiceStore) GetBalances(blockRoot libcommon.Hash) (solid.Uint64ListSSZ, error) {
+	return f.forkGraph.GetBalances(blockRoot)
+}
+
+func (f *ForkChoiceStore) GetInactivitiesScores(blockRoot libcommon.Hash) (solid.Uint64ListSSZ, error) {
+	return f.forkGraph.GetInactivitiesScores(blockRoot)
+}
+
+func (f *ForkChoiceStore) GetPreviousPartecipationIndicies(blockRoot libcommon.Hash) (*solid.BitList, error) {
+	return f.forkGraph.GetPreviousPartecipationIndicies(blockRoot)
+}
+
+func (f *ForkChoiceStore) GetValidatorSet(blockRoot libcommon.Hash) (*solid.ValidatorSet, error) {
+	return f.forkGraph.GetValidatorSet(blockRoot)
+}

--- a/cl/phase1/forkchoice/forkchoice_mock.go
+++ b/cl/phase1/forkchoice/forkchoice_mock.go
@@ -213,3 +213,19 @@ func (f *ForkChoiceStorageMock) GetLightClientUpdate(period uint64) (*cltypes.Li
 func (f *ForkChoiceStorageMock) GetHeader(blockRoot libcommon.Hash) (*cltypes.BeaconBlockHeader, bool) {
 	panic("implement me")
 }
+
+func (f *ForkChoiceStorageMock) GetBalances(blockRoot libcommon.Hash) (solid.Uint64ListSSZ, error) {
+	panic("implement me")
+}
+
+func (f *ForkChoiceStorageMock) GetInactivitiesScores(blockRoot libcommon.Hash) (solid.Uint64ListSSZ, error) {
+	panic("implement me")
+}
+
+func (f *ForkChoiceStorageMock) GetPreviousPartecipationIndicies(blockRoot libcommon.Hash) (*solid.BitList, error) {
+	panic("implement me")
+}
+
+func (f *ForkChoiceStorageMock) GetValidatorSet(blockRoot libcommon.Hash) (*solid.ValidatorSet, error) {
+	panic("implement me")
+}

--- a/cl/phase1/forkchoice/forkchoice_mock.go
+++ b/cl/phase1/forkchoice/forkchoice_mock.go
@@ -229,3 +229,7 @@ func (f *ForkChoiceStorageMock) GetPreviousPartecipationIndicies(blockRoot libco
 func (f *ForkChoiceStorageMock) GetValidatorSet(blockRoot libcommon.Hash) (*solid.ValidatorSet, error) {
 	panic("implement me")
 }
+
+func (f *ForkChoiceStorageMock) GetCurrentPartecipationIndicies(blockRoot libcommon.Hash) (*solid.BitList, error) {
+	panic("implement me")
+}

--- a/cl/phase1/forkchoice/interface.go
+++ b/cl/phase1/forkchoice/interface.go
@@ -44,6 +44,11 @@ type ForkChoiceStorageReader interface {
 	NewestLightClientUpdate() *cltypes.LightClientUpdate
 	GetLightClientUpdate(period uint64) (*cltypes.LightClientUpdate, bool)
 	GetHeader(blockRoot libcommon.Hash) (*cltypes.BeaconBlockHeader, bool)
+
+	GetBalances(blockRoot libcommon.Hash) (solid.Uint64ListSSZ, error)
+	GetInactivitiesScores(blockRoot libcommon.Hash) (solid.Uint64ListSSZ, error)
+	GetPreviousPartecipationIndicies(blockRoot libcommon.Hash) (*solid.BitList, error)
+	GetValidatorSet(blockRoot libcommon.Hash) (*solid.ValidatorSet, error)
 }
 
 type ForkChoiceStorageWriter interface {

--- a/cl/phase1/forkchoice/interface.go
+++ b/cl/phase1/forkchoice/interface.go
@@ -49,6 +49,7 @@ type ForkChoiceStorageReader interface {
 	GetInactivitiesScores(blockRoot libcommon.Hash) (solid.Uint64ListSSZ, error)
 	GetPreviousPartecipationIndicies(blockRoot libcommon.Hash) (*solid.BitList, error)
 	GetValidatorSet(blockRoot libcommon.Hash) (*solid.ValidatorSet, error)
+	GetCurrentPartecipationIndicies(blockRoot libcommon.Hash) (*solid.BitList, error)
 }
 
 type ForkChoiceStorageWriter interface {

--- a/cl/phase1/network/gossip_manager.go
+++ b/cl/phase1/network/gossip_manager.go
@@ -151,9 +151,10 @@ func (g *GossipManager) onRecv(ctx context.Context, data *sentinel.GossipData, l
 			return err
 		}
 	case gossip.TopicNameBeaconAggregateAndProof:
-		if err := operationsContract[*cltypes.SignedAggregateAndProof](ctx, g, l, data, int(version), "aggregate and proof", g.forkChoice.OnAggregateAndProof); err != nil {
-			return err
-		}
+		return nil
+		// if err := operationsContract[*cltypes.SignedAggregateAndProof](ctx, g, l, data, int(version), "aggregate and proof", g.forkChoice.OnAggregateAndProof); err != nil {
+		// 	return err
+		// } Uncomment when fixed.
 	}
 	return nil
 }

--- a/cl/phase1/stages/clstages.go
+++ b/cl/phase1/stages/clstages.go
@@ -521,6 +521,10 @@ func ConsensusClStages(ctx context.Context,
 							return err
 						case blocks := <-respCh:
 							for _, block := range blocks.Data {
+								if _, ok := cfg.forkChoice.GetHeader(block.Block.ParentRoot); !ok {
+									time.Sleep(time.Millisecond)
+									continue
+								}
 								// we can ignore this error because the block would not process if the hashssz failed
 								blockRoot, _ := block.Block.HashSSZ()
 								if _, ok := cfg.forkChoice.GetHeader(blockRoot); ok {

--- a/cl/sentinel/service/service.go
+++ b/cl/sentinel/service/service.go
@@ -348,7 +348,7 @@ func (s *SentinelServer) handleGossipPacket(pkt *sentinel.GossipMessage) error {
 		return err
 	}
 
-	//msgType, msgCap := parseTopic(topic)
+	// msgType, msgCap := parseTopic(topic)
 	// s.trackPeerStatistics(string(textPid), true, msgType, msgCap, len(data))
 
 	// Check to which gossip it belongs to.

--- a/cl/sentinel/service/service.go
+++ b/cl/sentinel/service/service.go
@@ -80,7 +80,7 @@ func (s *SentinelServer) PublishGossip(_ context.Context, msg *sentinelrpc.Gossi
 	// Snappify payload before sending it to gossip
 	compressedData := utils.CompressSnappy(msg.Data)
 
-	s.trackPeerStatistics(msg.GetPeer().Pid, false, msg.Name, "unknown", len(compressedData))
+	//s.trackPeerStatistics(msg.GetPeer().Pid, false, msg.Name, "unknown", len(compressedData))
 
 	var subscription *sentinel.GossipSubscription
 
@@ -348,8 +348,8 @@ func (s *SentinelServer) handleGossipPacket(pkt *sentinel.GossipMessage) error {
 		return err
 	}
 
-	msgType, msgCap := parseTopic(topic)
-	s.trackPeerStatistics(string(textPid), true, msgType, msgCap, len(data))
+	//msgType, msgCap := parseTopic(topic)
+	// s.trackPeerStatistics(string(textPid), true, msgType, msgCap, len(data))
 
 	// Check to which gossip it belongs to.
 	if strings.Contains(topic, string(gossip.TopicNameBeaconBlock)) {

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/RoaringBitmap/roaring v1.2.3
 	github.com/VictoriaMetrics/fastcache v1.12.2
+	github.com/alecthomas/atomic v0.1.0-alpha2
 	github.com/alecthomas/kong v0.8.1
 	github.com/anacrolix/log v0.14.3-0.20230823030427-4b296d71a6b4
 	github.com/anacrolix/sync v0.4.0
@@ -112,7 +113,6 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect
 	github.com/agnivade/levenshtein v1.1.1 // indirect
 	github.com/ajwerner/btree v0.0.0-20211221152037-f427b3e689c0 // indirect
-	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/anacrolix/chansync v0.3.0 // indirect
 	github.com/anacrolix/dht/v2 v2.20.0 // indirect
 	github.com/anacrolix/envpprof v1.3.0 // indirect


### PR DESCRIPTION
This change increases memory required from 4 GB ->10 GB but makes the Beacon API consistently performant. By default the Beacon API is not enabled so the memory will not be allocated consequently on the average run.