### PR TITLE
snapshots: fix filesByRange (#9472)

### DIFF
--- a/erigon-lib/downloader/snaptype/type.go
+++ b/erigon-lib/downloader/snaptype/type.go
@@ -325,4 +325,13 @@ var (
 	BorSnapshotTypes = []Type{BorEvents, BorSpans}
 
 	CaplinSnapshotTypes = []Type{BeaconBlocks}
+
+	AllTypes = []Type{
+		Headers,
+		Bodies,
+		Transactions,
+		BorEvents,
+		BorSpans,
+		BeaconBlocks,
+	}
 )


### PR DESCRIPTION
The method was iterating over snapshots.segments.Min().segments, but passing the index to view.Segments().

This might lead to a crash, because those 2 collections are different, and the indexes might not match.

view.Segments() only contains the snapshot files that are fully downloaded and indexed.

The code is changed to only use the view files (as it was before).