### PR TITLE
Amend DecodeWrappedTransaction

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -415,7 +415,7 @@ func CanonicalTransactions(db kv.Getter, baseTxId uint64, amount uint32) ([]type
 	i := uint32(0)
 	if err := db.ForAmount(kv.EthTx, hexutility.EncodeTs(baseTxId), amount, func(k, v []byte) error {
 		var decodeErr error
-		if txs[i], decodeErr = types.UnmarshalTransactionFromBinary(v); decodeErr != nil {
+		if txs[i], decodeErr = types.UnmarshalTransactionFromBinary(v, false /* blobTxnsAreWrappedWithBlobs */); decodeErr != nil {
 			return decodeErr
 		}
 		i++

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -1024,7 +1024,8 @@ func (bb *Body) DecodeRLP(s *rlp.Stream) error {
 		return err
 	}
 	var tx Transaction
-	for tx, err = DecodeRLPTransaction(s); err == nil; tx, err = DecodeRLPTransaction(s) {
+	blobTxnsAreWrappedWithBlobs := false
+	for tx, err = DecodeRLPTransaction(s, blobTxnsAreWrappedWithBlobs); err == nil; tx, err = DecodeRLPTransaction(s, blobTxnsAreWrappedWithBlobs) {
 		bb.Transactions = append(bb.Transactions, tx)
 	}
 	if !errors.Is(err, rlp.EOL) {
@@ -1213,7 +1214,8 @@ func (bb *Block) DecodeRLP(s *rlp.Stream) error {
 		return err
 	}
 	var tx Transaction
-	for tx, err = DecodeRLPTransaction(s); err == nil; tx, err = DecodeRLPTransaction(s) {
+	blobTxnsAreWrappedWithBlobs := false
+	for tx, err = DecodeRLPTransaction(s, blobTxnsAreWrappedWithBlobs); err == nil; tx, err = DecodeRLPTransaction(s, blobTxnsAreWrappedWithBlobs) {
 		bb.transactions = append(bb.transactions, tx)
 	}
 	if !errors.Is(err, rlp.EOL) {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -97,7 +97,7 @@ type Transaction interface {
 	Unwrap() Transaction // If this is a network wrapper, returns the unwrapped tx. Otherwise returns itself.
 }
 
-// TransactionMisc is collection of miscelaneous fields for transaction that is supposed to be embedded into concrete
+// TransactionMisc is collection of miscellaneous fields for transaction that is supposed to be embedded into concrete
 // implementations of different transaction types
 type TransactionMisc struct {
 	time time.Time // Time first seen locally (spam avoidance)
@@ -126,7 +126,7 @@ func (tm TransactionMisc) From() *atomic.Value {
 	return &tm.from
 }
 
-func DecodeRLPTransaction(s *rlp.Stream) (Transaction, error) {
+func DecodeRLPTransaction(s *rlp.Stream, blobTxnsAreWrappedWithBlobs bool) (Transaction, error) {
 	kind, size, err := s.Kind()
 	if err != nil {
 		return nil, err
@@ -149,38 +149,39 @@ func DecodeRLPTransaction(s *rlp.Stream) (Transaction, error) {
 	if len(b) == 0 {
 		return nil, rlp.EOL
 	}
-	return UnmarshalTransactionFromBinary(b)
+	return UnmarshalTransactionFromBinary(b, blobTxnsAreWrappedWithBlobs)
 }
 
-// DecodeWrappedTransaction decodes network encoded transaction with or without
-// envelope. When transaction is not network encoded use DecodeTransaction.
+// DecodeWrappedTransaction as similar to DecodeTransaction,
+// but type-3 (blob) transactions are expected to be wrapped with blobs/commitments/proofs.
+// See https://eips.ethereum.org/EIPS/eip-4844#networking
 func DecodeWrappedTransaction(data []byte) (Transaction, error) {
+	blobTxnsAreWrappedWithBlobs := true
 	if len(data) == 0 {
 		return nil, io.EOF
 	}
 	if data[0] < 0x80 { // the encoding is canonical, not RLP
-
-		return UnmarshalWrappedTransactionFromBinary(data)
+		return UnmarshalTransactionFromBinary(data, blobTxnsAreWrappedWithBlobs)
 	}
 	s := rlp.NewStream(bytes.NewReader(data), uint64(len(data)))
-	return DecodeRLPTransaction(s)
+	return DecodeRLPTransaction(s, blobTxnsAreWrappedWithBlobs)
 }
 
 // DecodeTransaction decodes a transaction either in RLP or canonical format
 func DecodeTransaction(data []byte) (Transaction, error) {
+	blobTxnsAreWrappedWithBlobs := false
 	if len(data) == 0 {
 		return nil, io.EOF
 	}
-	if data[0] < 0x80 {
-		// the encoding is canonical, not RLP
-		return UnmarshalTransactionFromBinary(data)
+	if data[0] < 0x80 { // the encoding is canonical, not RLP
+		return UnmarshalTransactionFromBinary(data, blobTxnsAreWrappedWithBlobs)
 	}
 	s := rlp.NewStream(bytes.NewReader(data), uint64(len(data)))
-	return DecodeRLPTransaction(s)
+	return DecodeRLPTransaction(s, blobTxnsAreWrappedWithBlobs)
 }
 
 // Parse transaction without envelope.
-func UnmarshalTransactionFromBinary(data []byte) (Transaction, error) {
+func UnmarshalTransactionFromBinary(data []byte, blobTxnsAreWrappedWithBlobs bool) (Transaction, error) {
 	if len(data) <= 1 {
 		return nil, fmt.Errorf("short input: %v", len(data))
 	}
@@ -201,11 +202,19 @@ func UnmarshalTransactionFromBinary(data []byte) (Transaction, error) {
 		return t, nil
 	case BlobTxType:
 		s := rlp.NewStream(bytes.NewReader(data[1:]), uint64(len(data)-1))
-		t := &BlobTx{}
-		if err := t.DecodeRLP(s); err != nil {
-			return nil, err
+		if blobTxnsAreWrappedWithBlobs {
+			t := &BlobTxWrapper{}
+			if err := t.DecodeRLP(s); err != nil {
+				return nil, err
+			}
+			return t, nil
+		} else {
+			t := &BlobTx{}
+			if err := t.DecodeRLP(s); err != nil {
+				return nil, err
+			}
+			return t, nil
 		}
-		return t, nil
 	default:
 		if data[0] >= 0x80 {
 			// Tx is type legacy which is RLP encoded
@@ -213,22 +222,6 @@ func UnmarshalTransactionFromBinary(data []byte) (Transaction, error) {
 		}
 		return nil, ErrTxTypeNotSupported
 	}
-}
-
-// Parse network encoded transaction without envelope.
-func UnmarshalWrappedTransactionFromBinary(data []byte) (Transaction, error) {
-	if len(data) <= 1 {
-		return nil, fmt.Errorf("short input: %v", len(data))
-	}
-	if data[0] != BlobTxType {
-		return UnmarshalTransactionFromBinary(data)
-	}
-	s := rlp.NewStream(bytes.NewReader(data[1:]), uint64(len(data)-1))
-	t := &BlobTxWrapper{}
-	if err := t.DecodeRLP(s); err != nil {
-		return nil, err
-	}
-	return t, nil
 }
 
 // Remove everything but the payload body from the wrapper - this is not used, for reference only
@@ -268,7 +261,7 @@ func DecodeTransactions(txs [][]byte) ([]Transaction, error) {
 	result := make([]Transaction, len(txs))
 	var err error
 	for i := range txs {
-		result[i], err = UnmarshalTransactionFromBinary(txs[i])
+		result[i], err = UnmarshalTransactionFromBinary(txs[i], false /* blobTxnsAreWrappedWithBlobs*/)
 		if err != nil {
 			return nil, err
 		}

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -574,7 +574,7 @@ func encodeDecodeBinary(tx Transaction) (Transaction, error) {
 		return nil, fmt.Errorf("rlp encoding failed: %w", err)
 	}
 	var parsedTx Transaction
-	if parsedTx, err = UnmarshalTransactionFromBinary(buf.Bytes()); err != nil {
+	if parsedTx, err = UnmarshalTransactionFromBinary(buf.Bytes(), false /* blobTxnsAreWrappedWithBlobs */); err != nil {
 		return nil, fmt.Errorf("rlp decoding failed: %w", err)
 	}
 	return parsedTx, nil

--- a/eth/tracers/internal/tracetest/calltrace_test.go
+++ b/eth/tracers/internal/tracetest/calltrace_test.go
@@ -126,7 +126,7 @@ func testCallTracer(tracerName string, dirPath string, t *testing.T) {
 			} else if err := json.Unmarshal(blob, test); err != nil {
 				t.Fatalf("failed to parse testcase: %v", err)
 			}
-			tx, err := types.UnmarshalTransactionFromBinary(common.FromHex(test.Input))
+			tx, err := types.UnmarshalTransactionFromBinary(common.FromHex(test.Input), false /* blobTxnsAreWrappedWithBlobs */)
 			if err != nil {
 				t.Fatalf("failed to parse testcase input: %v", err)
 			}

--- a/eth/tracers/internal/tracetest/prestate_test.go
+++ b/eth/tracers/internal/tracetest/prestate_test.go
@@ -91,7 +91,7 @@ func testPrestateDiffTracer(tracerName string, dirPath string, t *testing.T) {
 			} else if err := json.Unmarshal(blob, test); err != nil {
 				t.Fatalf("failed to parse testcase: %v", err)
 			}
-			tx, err := types.UnmarshalTransactionFromBinary(common.FromHex(test.Input))
+			tx, err := types.UnmarshalTransactionFromBinary(common.FromHex(test.Input), false /* blobTxnsAreWrappedWithBlobs */)
 			if err != nil {
 				t.Fatalf("failed to parse testcase input: %v", err)
 			}

--- a/migrations/txs_begin_end.go
+++ b/migrations/txs_begin_end.go
@@ -347,7 +347,7 @@ func canonicalTransactions(db kv.Getter, baseTxId uint64, amount uint32) ([]type
 
 	if err := db.ForAmount(kv.EthTx, txIdKey, amount, func(k, v []byte) error {
 		var decodeErr error
-		if txs[i], decodeErr = types.UnmarshalTransactionFromBinary(v); decodeErr != nil {
+		if txs[i], decodeErr = types.UnmarshalTransactionFromBinary(v, false /* blobTxnsAreWrappedWithBlobs */); decodeErr != nil {
 			return decodeErr
 		}
 		i++

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -221,7 +221,7 @@ func (t *StateTest) RunNoVerify(tx kv.RwTx, subtest StateSubtest, vmconfig vm.Co
 		return nil, libcommon.Hash{}, err
 	}
 	if len(post.Tx) != 0 {
-		txn, err := types.UnmarshalTransactionFromBinary(post.Tx)
+		txn, err := types.UnmarshalTransactionFromBinary(post.Tx, false /* blobTxnsAreWrappedWithBlobs */)
 		if err != nil {
 			return nil, libcommon.Hash{}, err
 		}


### PR DESCRIPTION
While reviewing PR #9471, I realized that `DecodeWrappedTransaction` was inconsistent. In one case it'd call `UnmarshalWrappedTransactionFromBinary`, which deserialized type-3 transactions into `BlobTxWrapper`, and in another case it'd call DecodeRLPTransaction, which deserialized type-3 transactions into `BlobTx`. This PR makes sure that `DecodeWrappedTransaction` always deserializes into `BlobTxWrapper`.