### PR TITLE
snaps: use hardcoded list of types - to protect borSnapshots impact on block snaps 

### DIFF
--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -255,6 +255,7 @@ type RoSnapshots struct {
 	indicesReady  atomic.Bool
 	segmentsReady atomic.Bool
 
+	types    []snaptype.Type
 	segments btree.Map[snaptype.Enum, *segments]
 
 	dir         string
@@ -283,7 +284,7 @@ func newRoSnapshots(cfg ethconfig.BlocksFreezing, snapDir string, types []snapty
 		segs.Set(snapType.Enum(), &segments{})
 	}
 
-	s := &RoSnapshots{dir: snapDir, cfg: cfg, segments: segs, logger: logger}
+	s := &RoSnapshots{dir: snapDir, cfg: cfg, segments: segs, logger: logger, types: types}
 	s.segmentsMin.Store(segmentsMin)
 
 	return s
@@ -320,15 +321,14 @@ func (s *RoSnapshots) EnsureExpectedBlocksAreAvailable(cfg *snapcfg.Cfg) error {
 	return nil
 }
 
-func (s *RoSnapshots) Types() []snaptype.Type {
-	types := make([]snaptype.Type, 0, s.segments.Len())
-
-	s.segments.Scan(func(segtype snaptype.Enum, value *segments) bool {
-		types = append(types, segtype.Type())
-		return true
-	})
-
-	return types
+func (s *RoSnapshots) Types() []snaptype.Type { return s.types }
+func (s *RoSnapshots) HasType(in snaptype.Type) bool {
+	for _, t := range s.types {
+		if t.Enum() == in.Enum() {
+			return true
+		}
+	}
+	return false
 }
 
 // DisableReadAhead - usage: `defer d.EnableReadAhead().DisableReadAhead()`. Please don't use this funcs without `defer` to avoid leak.
@@ -383,11 +383,12 @@ func (s *RoSnapshots) EnableMadvNormal() *RoSnapshots {
 }
 
 func (s *RoSnapshots) idxAvailability() uint64 {
-	max := make([]uint64, s.segments.Len())
-
+	max := make([]uint64, len(s.Types()))
 	i := 0
-
 	s.segments.Scan(func(segtype snaptype.Enum, value *segments) bool {
+		if !s.HasType(segtype.Type()) {
+			return true
+		}
 		for _, seg := range value.segments {
 			if !seg.IsIndexed() {
 				break
@@ -400,9 +401,8 @@ func (s *RoSnapshots) idxAvailability() uint64 {
 	})
 
 	var min uint64 = math.MaxUint64
-
-	for _, max := range max {
-		min = cmp.Min(min, max)
+	for _, maxEl := range max {
+		min = cmp.Min(min, maxEl)
 	}
 
 	return min
@@ -460,11 +460,17 @@ func (s *RoSnapshots) OpenFiles() (list []string) {
 
 // ReopenList stops on optimistic=false, continue opening files on optimistic=true
 func (s *RoSnapshots) ReopenList(fileNames []string, optimistic bool) error {
-	return s.rebuildSegments(fileNames, true, optimistic)
+	if err := s.rebuildSegments(fileNames, true, optimistic); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (s *RoSnapshots) InitSegments(fileNames []string) error {
-	return s.rebuildSegments(fileNames, false, true)
+	if err := s.rebuildSegments(fileNames, false, true); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (s *RoSnapshots) lockSegments() {
@@ -495,8 +501,11 @@ func (s *RoSnapshots) rebuildSegments(fileNames []string, open bool, optimistic 
 			continue
 		}
 
-		segtype, ok := s.segments.Get(f.Type.Enum())
+		if !s.HasType(f.Type) {
+			continue
+		}
 
+		segtype, ok := s.segments.Get(f.Type.Enum())
 		if !ok {
 			segtype = &segments{}
 			s.segments.Set(f.Type.Enum(), segtype)

--- a/turbo/snapshotsync/freezeblocks/bor_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/bor_snapshots.go
@@ -480,7 +480,10 @@ func (s *BorRoSnapshots) ReopenFolder() error {
 		_, fName := filepath.Split(f.Path)
 		list = append(list, fName)
 	}
-	return s.ReopenList(list, false)
+	if err := s.ReopenList(list, false); err != nil {
+		return err
+	}
+	return nil
 }
 
 type BorView struct {


### PR DESCRIPTION
- list of types must not depend on "disk content" (having 0 snaps is valid case for some networks). 
- double-check snaptype in several places

fixing bug of `idxAvailability` return 0 because `rebuildSegments` of borSnaps added block types to segments map 