### PR TITLE
Retain receipts pruning default on upgrade

### DIFF
--- a/ethdb/prune/storage_mode.go
+++ b/ethdb/prune/storage_mode.go
@@ -259,6 +259,11 @@ func EnsureNotChanged(tx kv.GetPut, pruneMode Mode) (Mode, error) {
 		return pruneMode, err
 	}
 
+	// Don't change from previous default as default for Receipts pruning has now changed
+	if pruneMode.Receipts.useDefaultValue() {
+		pruneMode.Receipts = pm.Receipts
+	}
+
 	if pruneMode.Initialised {
 		// If storage mode is not explicitly specified, we take whatever is in the database
 		if !reflect.DeepEqual(pm, pruneMode) {

--- a/ethdb/prune/storage_mode.go
+++ b/ethdb/prune/storage_mode.go
@@ -259,12 +259,12 @@ func EnsureNotChanged(tx kv.GetPut, pruneMode Mode) (Mode, error) {
 		return pruneMode, err
 	}
 
-	// Don't change from previous default as default for Receipts pruning has now changed
-	if pruneMode.Receipts.useDefaultValue() {
-		pruneMode.Receipts = pm.Receipts
-	}
-
 	if pruneMode.Initialised {
+		// Don't change from previous default as default for Receipts pruning has now changed
+		if pruneMode.Receipts.useDefaultValue() {
+			pruneMode.Receipts = pm.Receipts
+		}
+
 		// If storage mode is not explicitly specified, we take whatever is in the database
 		if !reflect.DeepEqual(pm, pruneMode) {
 			if bytes.Equal(pm.Receipts.dbType(), kv.PruneTypeOlder) && bytes.Equal(pruneMode.Receipts.dbType(), kv.PruneTypeBefore) {


### PR DESCRIPTION
The previous default for `prune=htrc` would be different after the prune hack. This would lead to error in the node. This PR is to retain the value in the database for `prune.r` value before checking for change.