### PR TITLE
polygon/p2p: fetcher validation followup

### DIFF
--- a/polygon/p2p/fetcher.go
+++ b/polygon/p2p/fetcher.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ledgerwatch/log/v3"
 	"modernc.org/mathutil"
 
-	"github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/gointerfaces/sentry"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/eth/protocols/eth"
@@ -83,7 +82,7 @@ func (f *fetcher) FetchHeaders(ctx context.Context, start uint64, end uint64, pe
 		headers = append(headers, headerChunk...)
 	}
 
-	if err := f.validateHeadersResponse(headers, start, end, amount); err != nil {
+	if err := f.validateHeadersResponse(headers, start, amount); err != nil {
 		return nil, err
 	}
 
@@ -175,58 +174,34 @@ func (f *fetcher) awaitHeadersResponse(
 	}
 }
 
-func (f *fetcher) validateHeadersResponse(headers []*types.Header, start, end, amount uint64) error {
-	if uint64(len(headers)) < amount {
-		var first, last uint64
-		if len(headers) > 0 {
-			first = headers[0].Number.Uint64()
-			last = headers[len(headers)-1].Number.Uint64()
-		}
-
-		return &ErrIncompleteHeaders{
-			requestStart: start,
-			requestEnd:   end,
-			first:        first,
-			last:         last,
-			amount:       len(headers),
-		}
-	}
-
-	if uint64(len(headers)) > amount {
+func (f *fetcher) validateHeadersResponse(headers []*types.Header, start, amount uint64) error {
+	headersLen := uint64(len(headers))
+	if headersLen > amount {
 		return &ErrTooManyHeaders{
 			requested: int(amount),
 			received:  len(headers),
 		}
 	}
 
-	if start != headers[0].Number.Uint64() {
-		return &ErrIncorrectOriginHeader{
-			requested: start,
-			received:  headers[0].Number.Uint64(),
-		}
-	}
-
-	var parentHeader *types.Header
+	expectedHeaderNum := start
 	for _, header := range headers {
-		if parentHeader == nil {
-			parentHeader = header
-			continue
-		}
-
-		parentHeaderHash := parentHeader.Hash()
-		currentHeaderNum := header.Number.Uint64()
-		parentHeaderNum := parentHeader.Number.Uint64()
-		if header.ParentHash != parentHeaderHash || currentHeaderNum != parentHeaderNum+1 {
-			return &ErrDisconnectedHeaders{
-				currentHash:       header.Hash(),
-				currentParentHash: header.ParentHash,
-				currentNum:        currentHeaderNum,
-				parentHash:        parentHeaderHash,
-				parentNum:         parentHeaderNum,
+		currentHeaderNumber := header.Number.Uint64()
+		if currentHeaderNumber != expectedHeaderNum {
+			return &ErrNonSequentialHeaderNumbers{
+				current:  currentHeaderNumber,
+				expected: expectedHeaderNum,
 			}
 		}
 
-		parentHeader = header
+		expectedHeaderNum++
+	}
+
+	if headersLen < amount {
+		return &ErrIncompleteHeaders{
+			start:     start,
+			requested: amount,
+			received:  headersLen,
+		}
 	}
 
 	return nil
@@ -242,26 +217,20 @@ func (e ErrInvalidFetchHeadersRange) Error() string {
 }
 
 type ErrIncompleteHeaders struct {
-	requestStart uint64
-	requestEnd   uint64
-	first        uint64
-	last         uint64
-	amount       int
+	start     uint64
+	requested uint64
+	received  uint64
 }
 
 func (e ErrIncompleteHeaders) Error() string {
 	return fmt.Sprintf(
-		"incomplete fetch headers response: first=%d, last=%d, amount=%d, requested [%d, %d)",
-		e.first, e.last, e.amount, e.requestStart, e.requestEnd,
+		"incomplete fetch headers response: start=%d, requested=%d, received=%d",
+		e.start, e.requested, e.received,
 	)
 }
 
 func (e ErrIncompleteHeaders) LowestMissingBlockNum() uint64 {
-	if e.last == 0 || e.first == 0 || e.first != e.requestStart {
-		return e.requestStart
-	}
-
-	return e.last + 1
+	return e.start + e.received
 }
 
 type ErrTooManyHeaders struct {
@@ -283,48 +252,22 @@ func (e ErrTooManyHeaders) Is(err error) bool {
 	}
 }
 
-type ErrDisconnectedHeaders struct {
-	currentHash       common.Hash
-	currentParentHash common.Hash
-	currentNum        uint64
-	parentHash        common.Hash
-	parentNum         uint64
+type ErrNonSequentialHeaderNumbers struct {
+	current  uint64
+	expected uint64
 }
 
-func (e ErrDisconnectedHeaders) Error() string {
+func (e ErrNonSequentialHeaderNumbers) Error() string {
 	return fmt.Sprintf(
-		"disconnected headers in fetch headers response: %s, %s, %s, %s, %s",
-		fmt.Sprintf("currentHash=%v", e.currentHash),
-		fmt.Sprintf("currentParentHash=%v", e.currentParentHash),
-		fmt.Sprintf("currentNum=%v", e.currentNum),
-		fmt.Sprintf("parentHash=%v", e.parentHash),
-		fmt.Sprintf("parentNum=%v", e.parentNum),
+		"non sequential header numbers in fetch headers response: current=%d, expected=%d",
+		e.current, e.expected,
 	)
 }
 
-func (e ErrDisconnectedHeaders) Is(err error) bool {
-	var errDisconnectedHeaders *ErrDisconnectedHeaders
+func (e ErrNonSequentialHeaderNumbers) Is(err error) bool {
+	var errDisconnectedHeaders *ErrNonSequentialHeaderNumbers
 	switch {
 	case errors.As(err, &errDisconnectedHeaders):
-		return true
-	default:
-		return false
-	}
-}
-
-type ErrIncorrectOriginHeader struct {
-	requested uint64
-	received  uint64
-}
-
-func (e ErrIncorrectOriginHeader) Error() string {
-	return fmt.Sprintf("incorrect origin header: requested=%d, received=%d", e.requested, e.received)
-}
-
-func (e ErrIncorrectOriginHeader) Is(err error) bool {
-	var errIncorrectOriginHeader *ErrIncorrectOriginHeader
-	switch {
-	case errors.As(err, &errIncorrectOriginHeader):
 		return true
 	default:
 		return false

--- a/polygon/p2p/fetcher_penalizing.go
+++ b/polygon/p2p/fetcher_penalizing.go
@@ -29,9 +29,8 @@ func (pf *penalizingFetcher) FetchHeaders(ctx context.Context, start uint64, end
 	headers, err := pf.Fetcher.FetchHeaders(ctx, start, end, peerId)
 	if err != nil {
 		shouldPenalize := rlp.IsInvalidRLPError(err) ||
-			errors.Is(err, &ErrIncorrectOriginHeader{}) ||
 			errors.Is(err, &ErrTooManyHeaders{}) ||
-			errors.Is(err, &ErrDisconnectedHeaders{})
+			errors.Is(err, &ErrNonSequentialHeaderNumbers{})
 
 		if shouldPenalize {
 			pf.logger.Debug("penalizing peer", "peerId", peerId, "err", err.Error())


### PR DESCRIPTION
Revisiting validations logic in fetcher after discussion with @battlmonstr:
1. Parent hash connectivity is checked in canonical chain builder - suggestion was that p2p fetcher should not do this validation
2. p2p fetcher now only validates that the header numbers in the response are sequential - invalid header hashes will be caught by the checkpoint/milestone merkle root calc we perform higher up the call stack in the header downloader
3. if we have requested range [1024, 2048) but peer returns [1600, 2048) we should penalise since that is invalid behaviour
4. it is still ok for a peer to return [1024, 1600) when we request [1024, 2048) - in this case we do not penalise but mark the peer as missing blockNum=1600