### PR TITLE
turbo/jsonrpc: handle panics due to missed block==nil checks

### DIFF
--- a/turbo/jsonrpc/trace_adhoc.go
+++ b/turbo/jsonrpc/trace_adhoc.go
@@ -1132,6 +1132,9 @@ func (api *TraceAPIImpl) doCallMany(ctx context.Context, dbtx kv.Tx, msgs []type
 	if err != nil {
 		return nil, nil, err
 	}
+	if parentBlock == nil {
+		return nil, nil, fmt.Errorf("parent block %d(%x) not found", blockNumber, hash)
+	}
 	parentHeader := parentBlock.Header()
 	if parentHeader == nil {
 		return nil, nil, fmt.Errorf("parent header %d(%x) not found", blockNumber, hash)

--- a/turbo/jsonrpc/tracing.go
+++ b/turbo/jsonrpc/tracing.go
@@ -436,6 +436,10 @@ func (api *PrivateDebugAPIImpl) TraceCallMany(ctx context.Context, bundles []Bun
 		stream.WriteNil()
 		return err
 	}
+	if block == nil {
+		stream.WriteNil()
+		return fmt.Errorf("block %d not found", blockNum)
+	}
 
 	// -1 is a default value for transaction index.
 	// If it's -1, we will try to replay every single transaction in that block


### PR DESCRIPTION
relates to https://github.com/ledgerwatch/erigon/issues/9507