### PR TITLE
print gaps in files to debug logs

### DIFF
--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -995,6 +995,10 @@ func SegmentsCaplin(dir string, minBlock uint64) (res []snaptype.FileInfo, missi
 			l = append(l, f)
 		}
 		l, m = noGaps(noOverlaps(l), minBlock)
+		if len(m) > 0 {
+			lst := m[len(m)-1]
+			log.Debug("[snapshots] see gap", "type", snaptype.Enums.BeaconBlocks, "from", lst.from)
+		}
 		res = append(res, l...)
 		missingSnapshots = append(missingSnapshots, m...)
 	}
@@ -1027,6 +1031,10 @@ func typedSegments(dir string, minBlock uint64, types []snaptype.Type) (res []sn
 				l = append(l, f)
 			}
 			l, m = noGaps(noOverlaps(segmentsTypeCheck(dir, l)), minBlock)
+			if len(m) > 0 {
+				lst := m[len(m)-1]
+				log.Debug("[snapshots] see gap", "type", segType, "from", lst.from)
+			}
 			res = append(res, l...)
 			missingSnapshots = append(missingSnapshots, m...)
 		}


### PR DESCRIPTION
Maybe you saw error messages like `[WARN] [03-01|02:31:17.630] [snapshots] retire blocks                err="DumpBlocks: DumpBodies: header missed in db: block_num=38500000` - i found 1 reason. If there is "absense of 1 sap file" (gap in files list) - for example if file manually deleted, erigon will ignore all files after gap and will try to create snapshots starting from "block number before gap" (38500000 in my case) and of-course doesn't have such blocks (erigon already created older snapshots in the past and removed such block). 

So, there is no bug in prune/retirement code of blocks, but just absence of some snapshot file. I will print it to debug logs now and maybe we will do something else about it in future. 

you can see this log for example by `integration print_stages --log.console.verbosity=4`