### PR TITLE
Can't download preverified file

### DIFF
--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -404,14 +404,8 @@ func initSnapshotLock(ctx context.Context, cfg *downloadercfg.Cfg, db kv.RoDB, l
 	})
 
 	for _, item := range snapCfg.Preverified {
-		_, isStateFile, ok := snaptype.ParseFileName(snapDir, item.Name)
+		_, _, ok := snaptype.ParseFileName(snapDir, item.Name)
 		if !ok {
-			continue
-		}
-		if isStateFile {
-			if !downloads.Contains(item.Name, true) {
-				missingItems = append(missingItems, item)
-			}
 			continue
 		}
 

--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -403,10 +403,8 @@ func initSnapshotLock(ctx context.Context, cfg *downloadercfg.Cfg, db kv.RoDB, l
 		return true
 	})
 
-	maxDownloadBlock, _ := downloads.MaxBlock(0)
-
 	for _, item := range snapCfg.Preverified {
-		fileInfo, isStateFile, ok := snaptype.ParseFileName(snapDir, item.Name)
+		_, isStateFile, ok := snaptype.ParseFileName(snapDir, item.Name)
 		if !ok {
 			continue
 		}
@@ -417,14 +415,8 @@ func initSnapshotLock(ctx context.Context, cfg *downloadercfg.Cfg, db kv.RoDB, l
 			continue
 		}
 
-		if maxDownloadBlock > 0 {
-			if fileInfo.From > maxDownloadBlock {
-				missingItems = append(missingItems, item)
-			}
-		} else {
-			if !downloads.Contains(item.Name, true) {
-				missingItems = append(missingItems, item)
-			}
+		if !downloads.Contains(item.Name, true) {
+			missingItems = append(missingItems, item)
 		}
 	}
 


### PR DESCRIPTION
I did delete 1 preverified file, and did want to re-download it.
I delete `snapshots/*lock*` and started erigon, but it didn't download missed file because it was filtered out by next check:
```
if maxDownloadBlock > 0 {
	if fileInfo.From > maxDownloadBlock {
		missingItems = append(missingItems, item)
	}
}
```
