### PR TITLE
rpc: Use `yParity` for non-legacy transactions

### DIFF
--- a/turbo/adapter/ethapi/api.go
+++ b/turbo/adapter/ethapi/api.go
@@ -403,7 +403,7 @@ type RPCTransaction struct {
 	Type             hexutil.Uint64     `json:"type"`
 	Accesses         *types2.AccessList `json:"accessList,omitempty"`
 	ChainID          *hexutil.Big       `json:"chainId,omitempty"`
-	V                *hexutil.Big       `json:"v,omitempty"`
+	V                *hexutil.Big       `json:"v"`
 	YParity          *hexutil.Big       `json:"yParity,omitempty"`
 	R                *hexutil.Big       `json:"r"`
 	S                *hexutil.Big       `json:"s"`
@@ -444,6 +444,7 @@ func newRPCTransaction(tx types.Transaction, blockHash libcommon.Hash, blockNumb
 		result.ChainID = (*hexutil.Big)(chainId.ToBig())
 		result.GasPrice = (*hexutil.Big)(t.GasPrice.ToBig())
 		result.YParity = (*hexutil.Big)(t.V.ToBig())
+		result.V = (*hexutil.Big)(t.V.ToBig())
 		result.R = (*hexutil.Big)(t.R.ToBig())
 		result.S = (*hexutil.Big)(t.S.ToBig())
 		result.Accesses = &t.AccessList
@@ -453,6 +454,7 @@ func newRPCTransaction(tx types.Transaction, blockHash libcommon.Hash, blockNumb
 		result.Tip = (*hexutil.Big)(t.Tip.ToBig())
 		result.FeeCap = (*hexutil.Big)(t.FeeCap.ToBig())
 		result.YParity = (*hexutil.Big)(t.V.ToBig())
+		result.V = (*hexutil.Big)(t.V.ToBig())
 		result.R = (*hexutil.Big)(t.R.ToBig())
 		result.S = (*hexutil.Big)(t.S.ToBig())
 		result.Accesses = &t.AccessList
@@ -464,6 +466,7 @@ func newRPCTransaction(tx types.Transaction, blockHash libcommon.Hash, blockNumb
 		result.Tip = (*hexutil.Big)(t.Tip.ToBig())
 		result.FeeCap = (*hexutil.Big)(t.FeeCap.ToBig())
 		result.YParity = (*hexutil.Big)(t.V.ToBig())
+		result.V = (*hexutil.Big)(t.V.ToBig())
 		result.R = (*hexutil.Big)(t.R.ToBig())
 		result.S = (*hexutil.Big)(t.S.ToBig())
 		result.Accesses = &t.AccessList

--- a/turbo/adapter/ethapi/api.go
+++ b/turbo/adapter/ethapi/api.go
@@ -19,14 +19,16 @@ package ethapi
 import (
 	"errors"
 	"fmt"
-	"github.com/ledgerwatch/erigon-lib/common/hexutil"
 	"math/big"
 
+	"github.com/ledgerwatch/erigon-lib/common/hexutil"
+
 	"github.com/holiman/uint256"
+	"github.com/ledgerwatch/log/v3"
+
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/common/hexutility"
 	types2 "github.com/ledgerwatch/erigon-lib/types"
-	"github.com/ledgerwatch/log/v3"
 
 	"github.com/ledgerwatch/erigon/accounts/abi"
 	"github.com/ledgerwatch/erigon/common/math"
@@ -401,7 +403,8 @@ type RPCTransaction struct {
 	Type             hexutil.Uint64     `json:"type"`
 	Accesses         *types2.AccessList `json:"accessList,omitempty"`
 	ChainID          *hexutil.Big       `json:"chainId,omitempty"`
-	V                *hexutil.Big       `json:"v"`
+	V                *hexutil.Big       `json:"v,omitempty"`
+	YParity          *hexutil.Big       `json:"yParity,omitempty"`
 	R                *hexutil.Big       `json:"r"`
 	S                *hexutil.Big       `json:"s"`
 
@@ -440,7 +443,7 @@ func newRPCTransaction(tx types.Transaction, blockHash libcommon.Hash, blockNumb
 		chainId.Set(t.ChainID)
 		result.ChainID = (*hexutil.Big)(chainId.ToBig())
 		result.GasPrice = (*hexutil.Big)(t.GasPrice.ToBig())
-		result.V = (*hexutil.Big)(t.V.ToBig())
+		result.YParity = (*hexutil.Big)(t.V.ToBig())
 		result.R = (*hexutil.Big)(t.R.ToBig())
 		result.S = (*hexutil.Big)(t.S.ToBig())
 		result.Accesses = &t.AccessList
@@ -449,7 +452,7 @@ func newRPCTransaction(tx types.Transaction, blockHash libcommon.Hash, blockNumb
 		result.ChainID = (*hexutil.Big)(chainId.ToBig())
 		result.Tip = (*hexutil.Big)(t.Tip.ToBig())
 		result.FeeCap = (*hexutil.Big)(t.FeeCap.ToBig())
-		result.V = (*hexutil.Big)(t.V.ToBig())
+		result.YParity = (*hexutil.Big)(t.V.ToBig())
 		result.R = (*hexutil.Big)(t.R.ToBig())
 		result.S = (*hexutil.Big)(t.S.ToBig())
 		result.Accesses = &t.AccessList
@@ -460,7 +463,7 @@ func newRPCTransaction(tx types.Transaction, blockHash libcommon.Hash, blockNumb
 		result.ChainID = (*hexutil.Big)(chainId.ToBig())
 		result.Tip = (*hexutil.Big)(t.Tip.ToBig())
 		result.FeeCap = (*hexutil.Big)(t.FeeCap.ToBig())
-		result.V = (*hexutil.Big)(t.V.ToBig())
+		result.YParity = (*hexutil.Big)(t.V.ToBig())
 		result.R = (*hexutil.Big)(t.R.ToBig())
 		result.S = (*hexutil.Big)(t.S.ToBig())
 		result.Accesses = &t.AccessList

--- a/turbo/jsonrpc/eth_api.go
+++ b/turbo/jsonrpc/eth_api.go
@@ -372,7 +372,8 @@ type RPCTransaction struct {
 	ChainID             *hexutil.Big       `json:"chainId,omitempty"`
 	MaxFeePerBlobGas    *hexutil.Big       `json:"maxFeePerBlobGas,omitempty"`
 	BlobVersionedHashes []common.Hash      `json:"blobVersionedHashes,omitempty"`
-	V                   *hexutil.Big       `json:"v"`
+	V                   *hexutil.Big       `json:"v,omitempty"`
+	YParity             *hexutil.Big       `json:"yParity,omitempty"`
 	R                   *hexutil.Big       `json:"r"`
 	S                   *hexutil.Big       `json:"s"`
 }
@@ -409,7 +410,7 @@ func NewRPCTransaction(tx types.Transaction, blockHash common.Hash, blockNumber 
 		chainId.Set(t.ChainID)
 		result.ChainID = (*hexutil.Big)(chainId.ToBig())
 		result.GasPrice = (*hexutil.Big)(t.GasPrice.ToBig())
-		result.V = (*hexutil.Big)(t.V.ToBig())
+		result.YParity = (*hexutil.Big)(t.V.ToBig())
 		result.R = (*hexutil.Big)(t.R.ToBig())
 		result.S = (*hexutil.Big)(t.S.ToBig())
 		result.Accesses = &t.AccessList
@@ -418,7 +419,7 @@ func NewRPCTransaction(tx types.Transaction, blockHash common.Hash, blockNumber 
 		result.ChainID = (*hexutil.Big)(chainId.ToBig())
 		result.Tip = (*hexutil.Big)(t.Tip.ToBig())
 		result.FeeCap = (*hexutil.Big)(t.FeeCap.ToBig())
-		result.V = (*hexutil.Big)(t.V.ToBig())
+		result.YParity = (*hexutil.Big)(t.V.ToBig())
 		result.R = (*hexutil.Big)(t.R.ToBig())
 		result.S = (*hexutil.Big)(t.S.ToBig())
 		result.Accesses = &t.AccessList
@@ -428,7 +429,7 @@ func NewRPCTransaction(tx types.Transaction, blockHash common.Hash, blockNumber 
 		result.ChainID = (*hexutil.Big)(chainId.ToBig())
 		result.Tip = (*hexutil.Big)(t.Tip.ToBig())
 		result.FeeCap = (*hexutil.Big)(t.FeeCap.ToBig())
-		result.V = (*hexutil.Big)(t.V.ToBig())
+		result.YParity = (*hexutil.Big)(t.V.ToBig())
 		result.R = (*hexutil.Big)(t.R.ToBig())
 		result.S = (*hexutil.Big)(t.S.ToBig())
 		result.Accesses = &t.AccessList

--- a/turbo/jsonrpc/eth_api.go
+++ b/turbo/jsonrpc/eth_api.go
@@ -372,7 +372,7 @@ type RPCTransaction struct {
 	ChainID             *hexutil.Big       `json:"chainId,omitempty"`
 	MaxFeePerBlobGas    *hexutil.Big       `json:"maxFeePerBlobGas,omitempty"`
 	BlobVersionedHashes []common.Hash      `json:"blobVersionedHashes,omitempty"`
-	V                   *hexutil.Big       `json:"v,omitempty"`
+	V                   *hexutil.Big       `json:"v"`
 	YParity             *hexutil.Big       `json:"yParity,omitempty"`
 	R                   *hexutil.Big       `json:"r"`
 	S                   *hexutil.Big       `json:"s"`
@@ -411,6 +411,7 @@ func NewRPCTransaction(tx types.Transaction, blockHash common.Hash, blockNumber 
 		result.ChainID = (*hexutil.Big)(chainId.ToBig())
 		result.GasPrice = (*hexutil.Big)(t.GasPrice.ToBig())
 		result.YParity = (*hexutil.Big)(t.V.ToBig())
+		result.V = (*hexutil.Big)(t.V.ToBig())
 		result.R = (*hexutil.Big)(t.R.ToBig())
 		result.S = (*hexutil.Big)(t.S.ToBig())
 		result.Accesses = &t.AccessList
@@ -420,6 +421,7 @@ func NewRPCTransaction(tx types.Transaction, blockHash common.Hash, blockNumber 
 		result.Tip = (*hexutil.Big)(t.Tip.ToBig())
 		result.FeeCap = (*hexutil.Big)(t.FeeCap.ToBig())
 		result.YParity = (*hexutil.Big)(t.V.ToBig())
+		result.V = (*hexutil.Big)(t.V.ToBig())
 		result.R = (*hexutil.Big)(t.R.ToBig())
 		result.S = (*hexutil.Big)(t.S.ToBig())
 		result.Accesses = &t.AccessList
@@ -430,6 +432,7 @@ func NewRPCTransaction(tx types.Transaction, blockHash common.Hash, blockNumber 
 		result.Tip = (*hexutil.Big)(t.Tip.ToBig())
 		result.FeeCap = (*hexutil.Big)(t.FeeCap.ToBig())
 		result.YParity = (*hexutil.Big)(t.V.ToBig())
+		result.V = (*hexutil.Big)(t.V.ToBig())
 		result.R = (*hexutil.Big)(t.R.ToBig())
 		result.S = (*hexutil.Big)(t.S.ToBig())
 		result.Accesses = &t.AccessList


### PR DESCRIPTION
`v` is not used in any transaction types other than legacy transactions. 

Before:
```
{
...
		"type": "0x2",
		"accessList": [],
		"chainId": "0x13881",
		"v": "0x1",
		"r": "0x3b8d9ed8ccda5bc4ab0c9ec6165cec0052b2cf2fc77f19dc1daf6b349174080e",
		"s": "0x222f86d644ad797d9dc1be772adff862cfe499c5113ec3c0e14e0a63c75ca158"
	}
}
```

After:
```
...
		"type": "0x2",
		"accessList": [],
		"chainId": "0x13881",
		"yParity": "0x1",
		"v": "0x1",
		"r": "0x3b8d9ed8ccda5bc4ab0c9ec6165cec0052b2cf2fc77f19dc1daf6b349174080e",
		"s": "0x222f86d644ad797d9dc1be772adff862cfe499c5113ec3c0e14e0a63c75ca158"
	}
}
```