### PR TITLE
Remove Cost() from tx interface

### DIFF
--- a/core/types/blob_tx_wrapper.go
+++ b/core/types/blob_tx_wrapper.go
@@ -297,8 +297,6 @@ func (txw *BlobTxWrapper) GetEffectiveGasTip(baseFee *uint256.Int) *uint256.Int 
 }
 func (txw *BlobTxWrapper) GetFeeCap() *uint256.Int { return txw.Tx.GetFeeCap() }
 
-func (txw *BlobTxWrapper) Cost() *uint256.Int { return txw.Tx.GetFeeCap() }
-
 func (txw *BlobTxWrapper) GetBlobHashes() []libcommon.Hash { return txw.Tx.GetBlobHashes() }
 
 func (txw *BlobTxWrapper) GetGas() uint64            { return txw.Tx.GetGas() }

--- a/core/types/dynamic_fee_tx.go
+++ b/core/types/dynamic_fee_tx.go
@@ -61,13 +61,6 @@ func (tx DynamicFeeTransaction) GetEffectiveGasTip(baseFee *uint256.Int) *uint25
 	}
 }
 
-func (tx DynamicFeeTransaction) Cost() *uint256.Int {
-	total := new(uint256.Int).SetUint64(tx.Gas)
-	total.Mul(total, tx.Tip)
-	total.Add(total, tx.Value)
-	return total
-}
-
 func (tx *DynamicFeeTransaction) Unwrap() Transaction {
 	return tx
 }

--- a/core/types/legacy_tx.go
+++ b/core/types/legacy_tx.go
@@ -117,13 +117,6 @@ func (tx LegacyTx) GetEffectiveGasTip(baseFee *uint256.Int) *uint256.Int {
 	}
 }
 
-func (tx LegacyTx) Cost() *uint256.Int {
-	total := new(uint256.Int).SetUint64(tx.Gas)
-	total.Mul(total, tx.GasPrice)
-	total.Add(total, tx.Value)
-	return total
-}
-
 func (tx LegacyTx) GetAccessList() types2.AccessList {
 	return types2.AccessList{}
 }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -62,7 +62,6 @@ type Transaction interface {
 	GetTip() *uint256.Int
 	GetEffectiveGasTip(baseFee *uint256.Int) *uint256.Int
 	GetFeeCap() *uint256.Int
-	Cost() *uint256.Int
 	GetBlobHashes() []libcommon.Hash
 	GetGas() uint64
 	GetBlobGas() uint64


### PR DESCRIPTION
This call was likely necessary for the old transaction pool, but doesn't seem to be referenced anywhere now.  Removing as dead code.