### PR TITLE
nil ptr `bor.close()`

### DIFF
--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -622,6 +622,9 @@ func (s *RoSnapshots) ReopenWithDB(db kv.RoDB) error {
 }
 
 func (s *RoSnapshots) Close() {
+	if s == nil {
+		return
+	}
 	s.lockSegments()
 	defer s.unlockSegments()
 	s.closeWhatNotInList(nil)

--- a/turbo/snapshotsync/snapshotsync.go
+++ b/turbo/snapshotsync/snapshotsync.go
@@ -83,7 +83,9 @@ func WaitForDownloader(ctx context.Context, logPrefix string, histV3, blobs bool
 	}
 
 	snapshots.Close()
-	borSnapshots.Close()
+	if cc.Bor != nil {
+		borSnapshots.Close()
+	}
 
 	//Corner cases:
 	// - Erigon generated file X with hash H1. User upgraded Erigon. New version has preverified file X with hash H2. Must ignore H2 (don't send to Downloader)


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x2a53ec4]

goroutine 2683 [running]:
github.com/ledgerwatch/erigon/turbo/snapshotsync.WaitForDownloader({0x4d19e28, 0xc000c27950}, {0xc0297bd902, 0xe}, 0x1, 0x0, 0x1, 0x468e91?, {0x4d4bb70, 0xc02be71e60}, ...)
	github.com/ledgerwatch/erigon/turbo/snapshotsync/snapshotsync.go:86 +0x264
github.com/ledgerwatch/erigon/eth/stagedsync.DownloadAndIndexSnapshotsIfNeed(_, {_, _}, {_, _}, {{0x4d2e7a8, 0xc0018f9ec0}, {{0xc000a539a9, 0x7}, 0xc000a1f0e0, ...}, ...}, ...)
	github.com/ledgerwatch/erigon/eth/stagedsync/stage_snapshots.go:234 +0x9d2
github.com/ledgerwatch/erigon/eth/stagedsync.SpawnStageSnapshots(_, {_, _}, {_, _}, {{0x4d2e7a8, 0xc0018f9ec0}, {{0xc000a539a9, 0x7}, 0xc000a1f0e0, ...}, ...}, ...)
	github.com/ledgerwatch/erigon/eth/stagedsync/stage_snapshots.go:155 +0x1ef
```