### PR TITLE
Fix typo in reset stages command

### DIFF
--- a/core/rawdb/rawdbreset/reset_stages.go
+++ b/core/rawdb/rawdbreset/reset_stages.go
@@ -87,7 +87,7 @@ func ResetBlocks(tx kv.RwTx, db kv.RoDB, agg *state.AggregatorV3,
 	}
 
 	if br.FreezingCfg().Enabled && br.FrozenBlocks() > 0 {
-		if err := stagedsync.FillDBFromSnapshots("fillind_db_from_snapshots", context.Background(), tx, dirs, br, agg, logger); err != nil {
+		if err := stagedsync.FillDBFromSnapshots("filling_db_from_snapshots", context.Background(), tx, dirs, br, agg, logger); err != nil {
 			return err
 		}
 		_ = stages.SaveStageProgress(tx, stages.Snapshots, br.FrozenBlocks())


### PR DESCRIPTION
Sample logs:
```
[INFO] [03-05|13:31:16.918] [fillind_db_from_snapshots] Total difficulty index: 2817k/50499k
[INFO] [03-05|13:31:46.920] [fillind_db_from_snapshots] Total difficulty index: 5320k/50499k
[INFO] [03-05|13:32:16.920] [fillind_db_from_snapshots] Total difficulty index: 7363k/50499k
[INFO] [03-05|13:32:46.919] [fillind_db_from_snapshots] Total difficulty index: 9731k/50499k
[INFO] [03-05|13:33:16.919] [fillind_db_from_snapshots] Total difficulty index: 11957k/50499k
[INFO] [03-05|13:33:46.920] [fillind_db_from_snapshots] Total difficulty index: 13829k/50499k
[INFO] [03-05|13:34:16.919] [fillind_db_from_snapshots] Total difficulty index: 16594k/50499k
[INFO] [03-05|13:34:46.920] [fillind_db_from_snapshots] Total difficulty index: 19482k/50499k
[INFO] [03-05|13:35:16.920] [fillind_db_from_snapshots] Total difficulty index: 22433k/50499k
```