### PR TITLE
Finalize cancun/napoli HF block number for polygon mainnet

### DIFF
--- a/core/forkid/forkid_test.go
+++ b/core/forkid/forkid_test.go
@@ -185,7 +185,8 @@ func TestCreation(t *testing.T) {
 				{3395000, 0, ID{Hash: checksumToBytes(0x27806576), Next: 14750000}},  // First Istanbul block
 				{14750000, 0, ID{Hash: checksumToBytes(0x66e26adb), Next: 23850000}}, // First Berlin block
 				{23850000, 0, ID{Hash: checksumToBytes(0x4f2f71cc), Next: 50523000}}, // First London block
-				{50523000, 0, ID{Hash: checksumToBytes(0xdc08865c), Next: 0}},        // First Agra block
+				{50523000, 0, ID{Hash: checksumToBytes(0xdc08865c), Next: 54876000}}, // First Agra block
+				{54876000, 0, ID{Hash: checksumToBytes(0xf097bc13), Next: 0}},        // First Napoli block
 			},
 		},
 	}

--- a/params/chainspecs/bor-devnet.json
+++ b/params/chainspecs/bor-devnet.json
@@ -51,6 +51,7 @@
     "jaipurBlock": 0,
     "delhiBlock": 0,
     "indoreBlock": 0,
-    "agraBlock": 100
+    "agraBlock": 100,
+    "napoliBlock": 100
   }
 }

--- a/params/chainspecs/bor-mainnet.json
+++ b/params/chainspecs/bor-mainnet.json
@@ -64,6 +64,7 @@
     "jaipurBlock": 23850000,
     "delhiBlock": 38189056,
     "indoreBlock": 44934656,
-    "agraBlock": 50523000
+    "agraBlock": 50523000,
+    "napoliBlock": 54876000
   }
 }


### PR DESCRIPTION
Block number: 54876000 (March 20th, 2024 at around 10.30 AM UTC)