### PR TITLE
EngineBlockDownloader to not pass http-request-ctx in unbounded goroutines 

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -782,7 +782,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 	checkStateRoot := true
 	pipelineStages := stages2.NewPipelineStages(ctx, chainKv, config, stack.Config().P2P, backend.sentriesClient, backend.notifications, backend.downloaderClient, blockReader, blockRetire, backend.agg, backend.silkworm, backend.forkValidator, logger, checkStateRoot)
 	backend.pipelineStagedSync = stagedsync.New(config.Sync, pipelineStages, stagedsync.PipelineUnwindOrder, stagedsync.PipelinePruneOrder, logger)
-	backend.eth1ExecutionServer = eth1.NewEthereumExecutionModule(blockReader, chainKv, backend.pipelineStagedSync, backend.forkValidator, chainConfig, assembleBlockPOS, hook, backend.notifications.Accumulator, backend.notifications.StateChangesConsumer, logger, backend.engine, config.HistoryV3, config.Sync)
+	backend.eth1ExecutionServer = eth1.NewEthereumExecutionModule(blockReader, chainKv, backend.pipelineStagedSync, backend.forkValidator, chainConfig, assembleBlockPOS, hook, backend.notifications.Accumulator, backend.notifications.StateChangesConsumer, logger, backend.engine, config.HistoryV3, config.Sync, ctx)
 	executionRpc := direct.NewExecutionClientDirect(backend.eth1ExecutionServer)
 	engineBackendRPC := engineapi.NewEngineServer(
 		logger,

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -789,7 +789,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 		chainConfig,
 		executionRpc,
 		backend.sentriesClient.Hd,
-		engine_block_downloader.NewEngineBlockDownloader(
+		engine_block_downloader.NewEngineBlockDownloader(ctx,
 			logger, backend.sentriesClient.Hd, executionRpc,
 			backend.sentriesClient.Bd, backend.sentriesClient.BroadcastNewBlock, backend.sentriesClient.SendBodyRequest, blockReader,
 			chainKv, chainConfig, tmpdir, config.Sync.BodyDownloadTimeoutSeconds),

--- a/turbo/engineapi/engine_block_downloader/block_downloader.go
+++ b/turbo/engineapi/engine_block_downloader/block_downloader.go
@@ -38,6 +38,8 @@ type RequestBodyFunction func(context.Context, *bodydownload.BodyRequest) ([64]b
 
 // EngineBlockDownloader is responsible to download blocks in reverse, and then insert them in the database.
 type EngineBlockDownloader struct {
+	ctx context.Context
+
 	// downloaders
 	hd          *headerdownload.HeaderDownload
 	bd          *bodydownload.BodyDownload
@@ -66,13 +68,14 @@ type EngineBlockDownloader struct {
 	logger log.Logger
 }
 
-func NewEngineBlockDownloader(logger log.Logger, hd *headerdownload.HeaderDownload, executionClient execution.ExecutionClient,
+func NewEngineBlockDownloader(ctx context.Context, logger log.Logger, hd *headerdownload.HeaderDownload, executionClient execution.ExecutionClient,
 	bd *bodydownload.BodyDownload, blockPropagator adapter.BlockPropagator,
 	bodyReqSend RequestBodyFunction, blockReader services.FullBlockReader, db kv.RoDB, config *chain.Config,
 	tmpdir string, timeout int) *EngineBlockDownloader {
 	var s atomic.Value
 	s.Store(headerdownload.Idle)
 	return &EngineBlockDownloader{
+		ctx:             ctx,
 		hd:              hd,
 		bd:              bd,
 		db:              db,

--- a/turbo/engineapi/engine_block_downloader/block_downloader.go
+++ b/turbo/engineapi/engine_block_downloader/block_downloader.go
@@ -38,7 +38,7 @@ type RequestBodyFunction func(context.Context, *bodydownload.BodyRequest) ([64]b
 
 // EngineBlockDownloader is responsible to download blocks in reverse, and then insert them in the database.
 type EngineBlockDownloader struct {
-	ctx context.Context
+	bacgroundCtx context.Context
 
 	// downloaders
 	hd          *headerdownload.HeaderDownload
@@ -75,7 +75,7 @@ func NewEngineBlockDownloader(ctx context.Context, logger log.Logger, hd *header
 	var s atomic.Value
 	s.Store(headerdownload.Idle)
 	return &EngineBlockDownloader{
-		ctx:             ctx,
+		bacgroundCtx:    ctx,
 		hd:              hd,
 		bd:              bd,
 		db:              db,

--- a/turbo/engineapi/engine_block_downloader/core.go
+++ b/turbo/engineapi/engine_block_downloader/core.go
@@ -116,7 +116,7 @@ func (e *EngineBlockDownloader) StartDownloading(ctx context.Context, requestId 
 		return false
 	}
 	e.status.Store(headerdownload.Syncing)
-	go e.download(ctx, hashToDownload, requestId, blockTip)
+	go e.download(e.ctx, hashToDownload, requestId, blockTip)
 	return true
 }
 

--- a/turbo/engineapi/engine_block_downloader/core.go
+++ b/turbo/engineapi/engine_block_downloader/core.go
@@ -116,7 +116,7 @@ func (e *EngineBlockDownloader) StartDownloading(ctx context.Context, requestId 
 		return false
 	}
 	e.status.Store(headerdownload.Syncing)
-	go e.download(e.ctx, hashToDownload, requestId, blockTip)
+	go e.download(e.bacgroundCtx, hashToDownload, requestId, blockTip)
 	return true
 }
 

--- a/turbo/execution/eth1/ethereum_execution.go
+++ b/turbo/execution/eth1/ethereum_execution.go
@@ -34,6 +34,7 @@ const maxBlocksLookBehind = 32
 
 // EthereumExecutionModule describes ethereum execution logic and indexing.
 type EthereumExecutionModule struct {
+	ctx context.Context
 	// Snapshots + MDBX
 	blockReader services.FullBlockReader
 
@@ -72,6 +73,7 @@ func NewEthereumExecutionModule(blockReader services.FullBlockReader, db kv.RwDB
 	stateChangeConsumer shards.StateChangeConsumer,
 	logger log.Logger, engine consensus.Engine,
 	historyV3 bool, syncCfg ethconfig.Sync,
+	ctx context.Context,
 ) *EthereumExecutionModule {
 	return &EthereumExecutionModule{
 		blockReader:         blockReader,
@@ -90,6 +92,7 @@ func NewEthereumExecutionModule(blockReader services.FullBlockReader, db kv.RwDB
 
 		historyV3: historyV3,
 		syncCfg:   syncCfg,
+		ctx:       ctx,
 	}
 }
 

--- a/turbo/execution/eth1/ethereum_execution.go
+++ b/turbo/execution/eth1/ethereum_execution.go
@@ -34,7 +34,7 @@ const maxBlocksLookBehind = 32
 
 // EthereumExecutionModule describes ethereum execution logic and indexing.
 type EthereumExecutionModule struct {
-	ctx context.Context
+	bacgroundCtx context.Context
 	// Snapshots + MDBX
 	blockReader services.FullBlockReader
 
@@ -90,9 +90,9 @@ func NewEthereumExecutionModule(blockReader services.FullBlockReader, db kv.RwDB
 		stateChangeConsumer: stateChangeConsumer,
 		engine:              engine,
 
-		historyV3: historyV3,
-		syncCfg:   syncCfg,
-		ctx:       ctx,
+		historyV3:    historyV3,
+		syncCfg:      syncCfg,
+		bacgroundCtx: ctx,
 	}
 }
 

--- a/turbo/execution/eth1/forkchoice.go
+++ b/turbo/execution/eth1/forkchoice.go
@@ -74,7 +74,7 @@ func (e *EthereumExecutionModule) UpdateForkChoice(ctx context.Context, req *exe
 	outcomeCh := make(chan forkchoiceOutcome, 1)
 
 	// So we wait at most the amount specified by req.Timeout before just sending out
-	go e.updateForkChoice(ctx, blockHash, safeHash, finalizedHash, outcomeCh)
+	go e.updateForkChoice(e.ctx, blockHash, safeHash, finalizedHash, outcomeCh)
 	fcuTimer := time.NewTimer(time.Duration(req.Timeout) * time.Millisecond)
 
 	select {

--- a/turbo/execution/eth1/forkchoice.go
+++ b/turbo/execution/eth1/forkchoice.go
@@ -74,7 +74,7 @@ func (e *EthereumExecutionModule) UpdateForkChoice(ctx context.Context, req *exe
 	outcomeCh := make(chan forkchoiceOutcome, 1)
 
 	// So we wait at most the amount specified by req.Timeout before just sending out
-	go e.updateForkChoice(e.ctx, blockHash, safeHash, finalizedHash, outcomeCh)
+	go e.updateForkChoice(e.bacgroundCtx, blockHash, safeHash, finalizedHash, outcomeCh)
 	fcuTimer := time.NewTimer(time.Duration(req.Timeout) * time.Millisecond)
 
 	select {

--- a/turbo/stages/mock/mock_sentry.go
+++ b/turbo/stages/mock/mock_sentry.go
@@ -478,7 +478,7 @@ func MockWithEverything(tb testing.TB, gspec *types.Genesis, key *ecdsa.PrivateK
 		snapshotsDownloader, mock.BlockReader, blockRetire, mock.agg, nil, forkValidator, logger, checkStateRoot)
 	mock.posStagedSync = stagedsync.New(cfg.Sync, pipelineStages, stagedsync.PipelineUnwindOrder, stagedsync.PipelinePruneOrder, logger)
 
-	mock.Eth1ExecutionService = eth1.NewEthereumExecutionModule(mock.BlockReader, mock.DB, mock.posStagedSync, forkValidator, mock.ChainConfig, assembleBlockPOS, nil, mock.Notifications.Accumulator, mock.Notifications.StateChangesConsumer, logger, engine, histV3, cfg.Sync)
+	mock.Eth1ExecutionService = eth1.NewEthereumExecutionModule(mock.BlockReader, mock.DB, mock.posStagedSync, forkValidator, mock.ChainConfig, assembleBlockPOS, nil, mock.Notifications.Accumulator, mock.Notifications.StateChangesConsumer, logger, engine, histV3, cfg.Sync, ctx)
 
 	mock.sentriesClient.Hd.StartPoSDownloader(mock.Ctx, sendHeaderRequest, penalize)
 


### PR DESCRIPTION
holesky:
```
INFO[03-06|19:10:29.101] [downloader] Downloaded PoS Headers      now=57243 blk/sec=844.800
INFO[03-06|19:10:54.024] P2P                                      app=caplin peers=59
INFO[03-06|19:10:55.694] [EngineBlockDownloader] Flushed buffer file name=erigon-sortable-buf-4082436526
INFO[03-06|19:10:59.101] [downloader] Downloaded PoS Headers      now=32091 blk/sec=838.400
INFO[03-06|19:11:29.102] [downloader] Downloaded PoS Headers      now=6363 blk/sec=857.600
WARN[03-06|19:11:36.829] [EngineBlockDownloader] Could not begin tx err="context canceled"
INFO[03-06|19:11:49.012] [NewPayload] Handling new payload        height=1083958 hash=0x260c4c4a12ea518830241b38bf4860d3364ff65e349b8a6d216d0b5b313d5db5
INFO[03-06|19:11:49.013] [EngineBlockDownloader] Downloading PoS headers... hash=0x5dabd6b479c913db2e03e2521c57f14bcda9a3ea0773922848789f650e0f890b requestId=0
INFO[03-06|19:11:54.024] P2P                                      app=caplin peers=58
INFO[03-06|19:12:02.663] [p2p] GoodPeers                          eth68=8 eth67=6
INFO[03-06|19:12:02.663] [mem] memory stats                       alloc=3.4GB sys=7.6GB
INFO[03-06|19:12:02.672] [txpool] stat                            pending=4 baseFee=0 queued=59 alloc=3.4GB sys=7.6GB


INFO[03-06|19:12:29.102] [downloader] Downloaded PoS Headers      now=1051509 blk/sec=812.800
INFO[03-06|19:12:54.025] P2P                                      app=caplin peers=64
INFO[03-06|19:12:59.103] [downloader] Downloaded PoS Headers      now=1027125 blk/sec=812.800


INFO[03-06|19:13:29.125] [downloader] Downloaded PoS Headers      now=1002933 blk/sec=806.400
INFO[03-06|19:13:54.055] P2P                                      app=caplin peers=65
```