### PR TITLE
Fix reading blob transaction from PoolTransaction

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -113,10 +113,6 @@ func (t BinaryTransactions) EncodeIndex(i int, w *bytes.Buffer) {
 	w.Write(t[i])
 }
 
-func (tm TransactionMisc) From() *atomic.Value {
-	return &tm.from
-}
-
 func DecodeRLPTransaction(s *rlp.Stream, blobTxnsAreWrappedWithBlobs bool) (Transaction, error) {
 	kind, size, err := s.Kind()
 	if err != nil {

--- a/erigon-lib/kv/tables.go
+++ b/erigon-lib/kv/tables.go
@@ -693,7 +693,7 @@ var ChaindataTables = []string{
 
 const (
 	RecentLocalTransaction = "RecentLocalTransaction" // sequence_u64 -> tx_hash
-	PoolTransaction        = "PoolTransaction"        // txHash -> sender_id_u64+tx_rlp
+	PoolTransaction        = "PoolTransaction"        // txHash -> sender+tx_rlp
 	PoolInfo               = "PoolInfo"               // option_key -> option_value
 )
 

--- a/erigon-lib/txpool/pool.go
+++ b/erigon-lib/txpool/pool.go
@@ -682,14 +682,15 @@ func (p *TxPool) getCachedBlobTxnLocked(tx kv.Tx, hash []byte) (*metaTx, error) 
 		return nil, nil
 	}
 
-	txn, err := tx.GetOne(kv.PoolTransaction, hash)
+	v, err := tx.GetOne(kv.PoolTransaction, hash)
 	if err != nil {
 		return nil, err
 	}
+	txRlp := common.Copy(v[20:])
 	parseCtx := types.NewTxParseContext(p.chainID)
 	parseCtx.WithSender(false)
 	txSlot := &types.TxSlot{}
-	parseCtx.ParseTransaction(txn, 0, txSlot, nil, false, true, nil)
+	parseCtx.ParseTransaction(txRlp, 0, txSlot, nil, false, true, nil)
 	return newMetaTx(txSlot, false, 0), nil
 }
 
@@ -2065,7 +2066,7 @@ func (p *TxPool) fromDB(ctx context.Context, tx kv.Tx, coreTx kv.Tx) error {
 		p.lastSeenBlock.Store(lastSeenBlock)
 	}
 
-	// this is neccessary as otherwise best - which waits for sync events
+	// this is necessary as otherwise best - which waits for sync events
 	// may wait for ever if blocks have been process before the txpool
 	// starts with an empty db
 	lastSeenProgress, err := getExecutionProgress(coreTx)


### PR DESCRIPTION
In `PoolTransaction` txn RLP is prefixed with the sender.