### PR TITLE
downloader: check exiting while downloading

### DIFF
--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -784,6 +784,8 @@ func (d *Downloader) mainLoop(silent bool) error {
 			}
 
 			select {
+			case <-d.ctx.Done():
+				return
 			case status := <-downloadComplete:
 				d.lock.Lock()
 				delete(d.downloading, status.name)


### PR DESCRIPTION
This PR prevents Erigon from freezing when downloading torrents if the user asks to exit with ctrl-c.

Some tests highlight this with downloader related messages on exiting 
(see https://github.com/ledgerwatch/erigon/actions/runs/8168975069/job/22332103530)
other do not but Erigon remains stuck in the same manner. The simple insertion of this line has solved both.

Please check that this doesn't break some invariant.
