### PR TITLE
assert on bodies file

### DIFF
--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -1848,6 +1848,10 @@ func txsAmountBasedOnBodiesSnapshots(bodiesSegment *seg.Decompressor, len uint64
 		}
 	}
 
+	if lastBody.BaseTxId < firstBody.BaseTxId {
+		return 0, 0, fmt.Errorf("negative txs count %s: lastBody.BaseTxId=%d < firstBody.BaseTxId=%d", bodiesSegment.FileName(), lastBody.BaseTxId, firstBody.BaseTxId)
+	}
+
 	expectedCount = int(lastBody.BaseTxId+uint64(lastBody.TxAmount)) - int(firstBody.BaseTxId)
 	return
 }


### PR DESCRIPTION
i see error: 
```
[1/12 Snapshots] can't build missed indices: v1-032520-032530-transactions.seg: TransactionsIdx: at=32520000-32530000, pre index building, expect: -259243781, got 128116" 
```
I don't know why it happening yet.
Adding assert to catch it earlier with more meaningful error

