### PR TITLE
Compute infohash before creating .torrent file from webseeds

### DIFF
--- a/erigon-lib/downloader/util.go
+++ b/erigon-lib/downloader/util.go
@@ -333,7 +333,6 @@ func _addTorrentFile(ctx context.Context, ts *torrent.TorrentSpec, torrentClient
 	ts.Webseeds, _ = webseeds.ByFileName(ts.DisplayName)
 	var have bool
 	t, have = torrentClient.Torrent(ts.InfoHash)
-	log.Info("Added torrent", "name", ts.DisplayName, "hash", ts.InfoHash, "webseeds", ts.Webseeds)
 
 	if !have {
 		t, _, err := torrentClient.AddTorrentSpec(ts)

--- a/erigon-lib/downloader/util.go
+++ b/erigon-lib/downloader/util.go
@@ -333,6 +333,7 @@ func _addTorrentFile(ctx context.Context, ts *torrent.TorrentSpec, torrentClient
 	ts.Webseeds, _ = webseeds.ByFileName(ts.DisplayName)
 	var have bool
 	t, have = torrentClient.Torrent(ts.InfoHash)
+	log.Info("Added torrent", "name", ts.DisplayName, "hash", ts.InfoHash, "webseeds", ts.Webseeds)
 
 	if !have {
 		t, _, err := torrentClient.AddTorrentSpec(ts)

--- a/erigon-lib/downloader/webseed.go
+++ b/erigon-lib/downloader/webseed.go
@@ -205,7 +205,8 @@ func (d *WebSeeds) downloadTorrentFilesFromProviders(ctx context.Context, rootDi
 	e.SetLimit(1024)
 	urlsByName := d.TorrentUrls()
 
-	for name, tUrls := range urlsByName {
+	for fileName, tUrls := range urlsByName {
+		name := fileName
 		tPath := filepath.Join(rootDir, name)
 		if dir.FileExist(tPath) {
 			continue

--- a/erigon-lib/downloader/webseed.go
+++ b/erigon-lib/downloader/webseed.go
@@ -111,7 +111,7 @@ func (d *WebSeeds) makeWebSeedUrls(listsOfFiles []snaptype.WebSeedsFromProvider,
 			if strings.HasSuffix(name, ".torrent") {
 				continue
 			}
-			if _, ok := webSeedMap[wUrl]; ok {
+			if _, ok := webSeedMap[name]; ok {
 				webSeedUrls[name] = append(webSeedUrls[name], wUrl)
 			}
 		}

--- a/erigon-lib/downloader/webseed.go
+++ b/erigon-lib/downloader/webseed.go
@@ -94,7 +94,7 @@ func (d *WebSeeds) makeTorrentUrls(listsOfFiles []snaptype.WebSeedsFromProvider)
 				continue
 			}
 			torrentUrls[name] = append(torrentUrls[name], uri)
-			torrentMap[*uri] = name[:len(name)-len(".torrent")]
+			torrentMap[*uri] = strings.TrimSuffix(name, ".torrent")
 		}
 	}
 
@@ -216,13 +216,6 @@ func (d *WebSeeds) downloadTorrentFilesFromProviders(ctx context.Context, rootDi
 			d.logger.Log(d.verbosity, "[snapshots] webseed has .torrent, but we skip it because this file-type not supported yet", "name", fName)
 			continue
 		}
-		name := name
-		fOriginName := name[:len(name)-len(".torrent")]
-		item, ok := d.torrentsWhitelist.Get(fOriginName)
-		if !ok {
-			d.logger.Info("Skipping torrent as file not in the whitelist", "torrent name", name, "name", fOriginName)
-			continue
-		}
 
 		tUrls := tUrls
 		e.Go(func() error {
@@ -231,16 +224,6 @@ func (d *WebSeeds) downloadTorrentFilesFromProviders(ctx context.Context, rootDi
 				if err != nil {
 					d.logger.Log(d.verbosity, "[snapshots] got from webseed", "name", name, "err", err, "url", url)
 					continue
-				}
-				// Compute info-hash before creating the file
-				mi, err := metainfo.Load(bytes.NewReader(res))
-				if err != nil {
-					d.logger.Log(d.verbosity, "[snapshots] could not parse torrent to get infohash", "name", name, "err", err, "url", url)
-					continue
-				}
-				infoHash := mi.HashInfoBytes().HexString()
-				if infoHash != item.Hash {
-					d.logger.Info("Skipping torrent due to infohash mismatch", "name", name, "err", err, "url", url, "infohash", infoHash, "expected", item.Hash)
 				}
 				if err := d.torrentFiles.Create(tPath, res); err != nil {
 					d.logger.Log(d.verbosity, "[snapshots] .torrent from webseed rejected", "name", name, "err", err, "url", url)
@@ -304,6 +287,7 @@ func nameWhitelisted(fileName string, whitelist snapcfg.Preverified) bool {
 
 func nameAndHashWhitelisted(fileName, fileHash string, whitelist snapcfg.Preverified) bool {
 	fileName = strings.TrimSuffix(fileName, ".torrent")
+
 	for i := 0; i < len(whitelist); i++ {
 		if whitelist[i].Name == fileName && whitelist[i].Hash == fileHash {
 			return true

--- a/erigon-lib/downloader/webseed.go
+++ b/erigon-lib/downloader/webseed.go
@@ -41,26 +41,28 @@ type WebSeeds struct {
 }
 
 func (d *WebSeeds) Discover(ctx context.Context, urls []*url.URL, files []string, rootDir string) {
-	d.downloadWebseedTomlFromProviders(ctx, urls, files)
-	d.downloadTorrentFilesFromProviders(ctx, rootDir)
+	listsOfFiles := d.constructListsOfFiles(ctx, urls, files)
+	torrentMap := d.makeTorrentUrls(listsOfFiles)
+	webSeedMap := d.downloadTorrentFilesFromProviders(ctx, rootDir, torrentMap)
+	d.makeWebSeedUrls(listsOfFiles, webSeedMap)
 }
 
-func (d *WebSeeds) downloadWebseedTomlFromProviders(ctx context.Context, httpProviders []*url.URL, diskProviders []string) {
+func (d *WebSeeds) constructListsOfFiles(ctx context.Context, httpProviders []*url.URL, diskProviders []string) []snaptype.WebSeedsFromProvider {
 	log.Debug("[snapshots] webseed providers", "http", len(httpProviders), "disk", len(diskProviders))
-	list := make([]snaptype.WebSeedsFromProvider, 0, len(httpProviders)+len(diskProviders))
+	listsOfFiles := make([]snaptype.WebSeedsFromProvider, 0, len(httpProviders)+len(diskProviders))
 
 	for _, webSeedProviderURL := range httpProviders {
 		select {
 		case <-ctx.Done():
-			return
+			return listsOfFiles
 		default:
 		}
-		response, err := d.callHttpProvider(ctx, webSeedProviderURL)
+		manifestResponse, err := d.retrieveManifest(ctx, webSeedProviderURL)
 		if err != nil { // don't fail on error
 			d.logger.Debug("[snapshots.webseed] get from HTTP provider", "err", err, "url", webSeedProviderURL.EscapedPath())
 			continue
 		}
-		list = append(list, response)
+		listsOfFiles = append(listsOfFiles, manifestResponse)
 	}
 
 	// add to list files from disk
@@ -70,14 +72,17 @@ func (d *WebSeeds) downloadWebseedTomlFromProviders(ctx context.Context, httpPro
 			d.logger.Debug("[snapshots.webseed] get from File provider", "err", err)
 			continue
 		}
-		list = append(list, response)
+		listsOfFiles = append(listsOfFiles, response)
 	}
+	return listsOfFiles
+}
 
-	webSeedUrls, torrentUrls := snaptype.WebSeedUrls{}, snaptype.TorrentUrls{}
-	for _, urls := range list {
+func (d *WebSeeds) makeTorrentUrls(listsOfFiles []snaptype.WebSeedsFromProvider) map[url.URL]string {
+	torrentMap := map[url.URL]string{}
+	torrentUrls := snaptype.TorrentUrls{}
+	for _, urls := range listsOfFiles {
 		for name, wUrl := range urls {
 			if !strings.HasSuffix(name, ".torrent") {
-				webSeedUrls[name] = append(webSeedUrls[name], wUrl)
 				continue
 			}
 			if !nameWhitelisted(name, d.torrentsWhitelist) {
@@ -89,13 +94,32 @@ func (d *WebSeeds) downloadWebseedTomlFromProviders(ctx context.Context, httpPro
 				continue
 			}
 			torrentUrls[name] = append(torrentUrls[name], uri)
+			torrentMap[*uri] = name[:len(name)-len(".torrent")]
+		}
+	}
+
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	d.torrentUrls = torrentUrls
+	return torrentMap
+}
+
+func (d *WebSeeds) makeWebSeedUrls(listsOfFiles []snaptype.WebSeedsFromProvider, webSeedMap map[string]struct{}) {
+	webSeedUrls := snaptype.WebSeedUrls{}
+	for _, urls := range listsOfFiles {
+		for name, wUrl := range urls {
+			if strings.HasSuffix(name, ".torrent") {
+				continue
+			}
+			if _, ok := webSeedMap[wUrl]; ok {
+				webSeedUrls[name] = append(webSeedUrls[name], wUrl)
+			}
 		}
 	}
 
 	d.lock.Lock()
 	defer d.lock.Unlock()
 	d.byFileName = webSeedUrls
-	d.torrentUrls = torrentUrls
 }
 
 func (d *WebSeeds) TorrentUrls() snaptype.TorrentUrls {
@@ -116,7 +140,7 @@ func (d *WebSeeds) ByFileName(name string) (metainfo.UrlList, bool) {
 	v, ok := d.byFileName[name]
 	return v, ok
 }
-func (d *WebSeeds) callHttpProvider(ctx context.Context, webSeedProviderUrl *url.URL) (snaptype.WebSeedsFromProvider, error) {
+func (d *WebSeeds) retrieveManifest(ctx context.Context, webSeedProviderUrl *url.URL) (snaptype.WebSeedsFromProvider, error) {
 	baseUrl := webSeedProviderUrl.String()
 	ref, err := url.Parse("manifest.txt")
 	if err != nil {
@@ -164,15 +188,17 @@ func (d *WebSeeds) readWebSeedsFile(webSeedProviderPath string) (snaptype.WebSee
 }
 
 // downloadTorrentFilesFromProviders - if they are not exist on file-system
-func (d *WebSeeds) downloadTorrentFilesFromProviders(ctx context.Context, rootDir string) {
+func (d *WebSeeds) downloadTorrentFilesFromProviders(ctx context.Context, rootDir string, torrentMap map[url.URL]string) map[string]struct{} {
 	// TODO: need more tests, need handle more forward-compatibility and backward-compatibility case
 	//  - now, if add new type of .torrent files to S3 bucket - existing nodes will start downloading it. maybe need whitelist of file types
 	//  - maybe need download new files if --snap.stop=true
+	webSeedMap := map[string]struct{}{}
+	var webSeeMapLock sync.RWMutex
 	if !d.downloadTorrentFile {
-		return
+		return webSeedMap
 	}
 	if len(d.TorrentUrls()) == 0 {
-		return
+		return webSeedMap
 	}
 	var addedNew int
 	e, ctx := errgroup.WithContext(ctx)
@@ -191,6 +217,13 @@ func (d *WebSeeds) downloadTorrentFilesFromProviders(ctx context.Context, rootDi
 			continue
 		}
 		name := name
+		fOriginName := name[:len(name)-len(".torrent")]
+		item, ok := d.torrentsWhitelist.Get(fOriginName)
+		if !ok {
+			d.logger.Info("Skipping torrent as file not in the whitelist", "torrent name", name, "name", fOriginName)
+			continue
+		}
+
 		tUrls := tUrls
 		e.Go(func() error {
 			for _, url := range tUrls {
@@ -199,10 +232,23 @@ func (d *WebSeeds) downloadTorrentFilesFromProviders(ctx context.Context, rootDi
 					d.logger.Log(d.verbosity, "[snapshots] got from webseed", "name", name, "err", err, "url", url)
 					continue
 				}
+				// Compute info-hash before creating the file
+				mi, err := metainfo.Load(bytes.NewReader(res))
+				if err != nil {
+					d.logger.Log(d.verbosity, "[snapshots] could not parse torrent to get infohash", "name", name, "err", err, "url", url)
+					continue
+				}
+				infoHash := mi.HashInfoBytes().HexString()
+				if infoHash != item.Hash {
+					d.logger.Info("Skipping torrent due to infohash mismatch", "name", name, "err", err, "url", url, "infohash", infoHash, "expected", item.Hash)
+				}
 				if err := d.torrentFiles.Create(tPath, res); err != nil {
 					d.logger.Log(d.verbosity, "[snapshots] .torrent from webseed rejected", "name", name, "err", err, "url", url)
 					continue
 				}
+				webSeeMapLock.Lock()
+				webSeedMap[torrentMap[*url]] = struct{}{}
+				webSeeMapLock.Unlock()
 				return nil
 			}
 			return nil
@@ -211,6 +257,7 @@ func (d *WebSeeds) downloadTorrentFilesFromProviders(ctx context.Context, rootDi
 	if err := e.Wait(); err != nil {
 		d.logger.Debug("[snapshots] webseed discover", "err", err)
 	}
+	return webSeedMap
 }
 
 func (d *WebSeeds) callTorrentHttpProvider(ctx context.Context, url *url.URL, fileName string) ([]byte, error) {


### PR DESCRIPTION
Fixes for e35

Fix logging

Intermediate

Filter out webseeds according to the downloaded torrent files