### PR TITLE
downloader: `stats.Completed == true` too early 

### DIFF
--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -2041,7 +2041,7 @@ func (d *Downloader) AddMagnetLink(ctx context.Context, infoHash metainfo.Hash, 
 		return nil
 	}
 
-	if d.torrentFiles.newDownloadsAreProhibited() {
+	if d.torrentFiles.newDownloadsAreProhibited() && !d.torrentFiles.Exists(name) {
 		return nil
 	}
 

--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -1639,55 +1639,58 @@ func (d *Downloader) ReCalcStats(interval time.Duration) {
 
 		var progress float32
 
-		if t.Info() != nil {
-			torrentInfo++
-			stats.MetadataReady++
-
-			// call methods once - to reduce internal mutex contention
-			peersOfThisFile := t.PeerConns()
-			weebseedPeersOfThisFile := t.WebseedPeerConns()
-
-			bytesRead := t.Stats().BytesReadData
-			tLen := t.Length()
-
-			var bytesCompleted int64
-
-			if torrentComplete {
-				tComplete++
-				bytesCompleted = t.Length()
-			} else {
-				bytesCompleted = bytesRead.Int64()
-			}
-
-			delete(downloading, torrentName)
-
-			for _, peer := range peersOfThisFile {
-				stats.ConnectionsTotal++
-				peers[peer.PeerID] = struct{}{}
-			}
-
-			stats.BytesCompleted += uint64(bytesCompleted)
-			stats.BytesTotal += uint64(tLen)
-
-			progress = float32(float64(100) * (float64(bytesCompleted) / float64(tLen)))
-
-			webseedRates, webseeds := getWebseedsRatesForlogs(weebseedPeersOfThisFile, torrentName, t.Complete.Bool())
-			rates, peers := getPeersRatesForlogs(peersOfThisFile, torrentName)
-			// more detailed statistic: download rate of each peer (for each file)
-			if !torrentComplete && progress != 0 {
-				d.logger.Log(d.verbosity, "[snapshots] progress", "file", torrentName, "progress", fmt.Sprintf("%.2f%%", progress), "peers", len(peersOfThisFile), "webseeds", len(weebseedPeersOfThisFile))
-				d.logger.Log(d.verbosity, "[snapshots] webseed peers", webseedRates...)
-				d.logger.Log(d.verbosity, "[snapshots] bittorrent peers", rates...)
-			}
-
-			diagnostics.Send(diagnostics.SegmentDownloadStatistics{
-				Name:            torrentName,
-				TotalBytes:      uint64(tLen),
-				DownloadedBytes: uint64(bytesCompleted),
-				Webseeds:        webseeds,
-				Peers:           peers,
-			})
+		if t.Info() == nil {
+			stats.Completed = false
+			continue
 		}
+
+		torrentInfo++
+		stats.MetadataReady++
+
+		// call methods once - to reduce internal mutex contention
+		peersOfThisFile := t.PeerConns()
+		weebseedPeersOfThisFile := t.WebseedPeerConns()
+
+		bytesRead := t.Stats().BytesReadData
+		tLen := t.Length()
+
+		var bytesCompleted int64
+
+		if torrentComplete {
+			tComplete++
+			bytesCompleted = t.Length()
+		} else {
+			bytesCompleted = bytesRead.Int64()
+		}
+
+		delete(downloading, torrentName)
+
+		for _, peer := range peersOfThisFile {
+			stats.ConnectionsTotal++
+			peers[peer.PeerID] = struct{}{}
+		}
+
+		stats.BytesCompleted += uint64(bytesCompleted)
+		stats.BytesTotal += uint64(tLen)
+
+		progress = float32(float64(100) * (float64(bytesCompleted) / float64(tLen)))
+
+		webseedRates, webseeds := getWebseedsRatesForlogs(weebseedPeersOfThisFile, torrentName, t.Complete.Bool())
+		rates, peers := getPeersRatesForlogs(peersOfThisFile, torrentName)
+		// more detailed statistic: download rate of each peer (for each file)
+		if !torrentComplete && progress != 0 {
+			d.logger.Log(d.verbosity, "[snapshots] progress", "file", torrentName, "progress", fmt.Sprintf("%.2f%%", progress), "peers", len(peersOfThisFile), "webseeds", len(weebseedPeersOfThisFile))
+			d.logger.Log(d.verbosity, "[snapshots] webseed peers", webseedRates...)
+			d.logger.Log(d.verbosity, "[snapshots] bittorrent peers", rates...)
+		}
+
+		diagnostics.Send(diagnostics.SegmentDownloadStatistics{
+			Name:            torrentName,
+			TotalBytes:      uint64(tLen),
+			DownloadedBytes: uint64(bytesCompleted),
+			Webseeds:        webseeds,
+			Peers:           peers,
+		})
 
 		if !torrentComplete {
 			if info, err := d.torrentInfo(torrentName); err == nil {

--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -1630,6 +1630,11 @@ func (d *Downloader) ReCalcStats(interval time.Duration) {
 	var torrentInfo int
 
 	for _, t := range torrents {
+		if t.Info() == nil {
+			stats.Completed = false
+			continue
+		}
+
 		var torrentComplete bool
 		torrentName := t.Name()
 
@@ -1638,11 +1643,6 @@ func (d *Downloader) ReCalcStats(interval time.Duration) {
 		}
 
 		var progress float32
-
-		if t.Info() == nil {
-			stats.Completed = false
-			continue
-		}
 
 		torrentInfo++
 		stats.MetadataReady++

--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -1630,7 +1630,9 @@ func (d *Downloader) ReCalcStats(interval time.Duration) {
 	var torrentInfo int
 
 	for _, t := range torrents {
-		if t.Info() == nil {
+		select {
+		case <-t.GotInfo():
+		default:
 			stats.Completed = false
 			continue
 		}

--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -1632,7 +1632,7 @@ func (d *Downloader) ReCalcStats(interval time.Duration) {
 	for _, t := range torrents {
 		select {
 		case <-t.GotInfo():
-		default:
+		default: // if some torrents have no metadata, we are for-sure uncomplete
 			stats.Completed = false
 			continue
 		}


### PR DESCRIPTION
if erigon `kill -9` in the middle of downloading and re-start: 
it will too early set `stats.Completed = true`

Example: 
```
WARN[03-09|05:06:17.502] [dbg] stats.Complete                     stats.FilesTotal=6 stats.Completed=true
```
`stats.FilesTotal=6` but I have hundreds of files. 


2 cases: 
- `kill -9` in the middle of downloading and re-start - must download ALL preverified files - must "add new files"
- upgrade erigon version - must NOT downlaod new files

Solution: move prohibit_new_downloads.lock again AFTER downloads completed, not BEFORE. 
