### PR TITLE
downloader: revert BytesComplete variable logic

### DIFF
--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -1639,11 +1639,15 @@ func (d *Downloader) ReCalcStats(interval time.Duration) {
 			continue
 		}
 
-		var torrentComplete bool
 		torrentName := t.Name()
 
+		var torrentComplete bool
 		if _, ok := downloading[torrentName]; ok {
 			torrentComplete = t.Complete.Bool()
+		}
+		if torrentComplete {
+			tComplete++
+			delete(downloading, torrentName)
 		}
 
 		var progress float32
@@ -1655,19 +1659,9 @@ func (d *Downloader) ReCalcStats(interval time.Duration) {
 		peersOfThisFile := t.PeerConns()
 		weebseedPeersOfThisFile := t.WebseedPeerConns()
 
-		bytesRead := t.Stats().BytesReadData
 		tLen := t.Length()
 
-		var bytesCompleted int64
-
-		if torrentComplete {
-			tComplete++
-			bytesCompleted = t.Length()
-		} else {
-			bytesCompleted = bytesRead.Int64()
-		}
-
-		delete(downloading, torrentName)
+		bytesCompleted := t.BytesCompleted()
 
 		for _, peer := range peersOfThisFile {
 			stats.ConnectionsTotal++


### PR DESCRIPTION
I see progress > 100% and seems never ending: 
```
[DBUG] [03-10|03:18:21.910] [snapshots] progress                     file=v1-011000-011500-headers.seg progress=101.08% peers=0 webseeds=2
```