### PR TITLE
snaps: fix lost file path 

### DIFF
--- a/cmd/snapshots/cmp/cmp.go
+++ b/cmd/snapshots/cmp/cmp.go
@@ -618,14 +618,12 @@ func (c comparitor) compareBodies(ctx context.Context, f1ents []*BodyEntry, f2en
 
 				g.Go(func() error {
 					info, _, ok := snaptype.ParseFileName(c.session1.LocalFsRoot(), ent1.Transactions.Name())
+					if !ok {
+						return fmt.Errorf("can't parse file name %s", ent1.Transactions.Name())
+					}
 
 					err := func() error {
 						startTime := time.Now()
-
-						if !ok {
-							return fmt.Errorf("can't parse file name %s", ent1.Transactions.Name())
-						}
-
 						defer func() {
 							atomic.AddUint64(&downloadTime, uint64(time.Since(startTime)))
 						}()

--- a/erigon-lib/downloader/snaptype/files.go
+++ b/erigon-lib/downloader/snaptype/files.go
@@ -222,6 +222,19 @@ func (f FileInfo) CompareTo(o FileInfo) int {
 	return strings.Compare(f.Type.String(), o.Type.String())
 }
 
+func (f FileInfo) As(t Type) FileInfo {
+	name := fmt.Sprintf("v%d-%06d-%06d-%s%s", f.Version, f.From/1_000, f.To/1_000, f.Type, f.Ext)
+	return FileInfo{
+		Version: f.Version,
+		From:    f.From,
+		To:      f.To,
+		Ext:     f.Ext,
+		Type:    t,
+		name:    name,
+		Path:    filepath.Join(f.Dir(), name),
+	}
+}
+
 func IdxFiles(dir string) (res []FileInfo, err error) {
 	return FilesWithExt(dir, ".idx")
 }

--- a/erigon-lib/downloader/snaptype/files.go
+++ b/erigon-lib/downloader/snaptype/files.go
@@ -114,11 +114,13 @@ func parseFileName(dir, fileName string) (res FileInfo, ok bool) {
 	ext := filepath.Ext(fileName)
 	onlyName := fileName[:len(fileName)-len(ext)]
 	parts := strings.Split(onlyName, "-")
+	res = FileInfo{Path: filepath.Join(dir, fileName), name: fileName, Ext: ext}
 	if len(parts) < 4 {
 		return res, ok
 	}
 
-	version, err := ParseVersion(parts[0])
+	var err error
+	res.Version, err = ParseVersion(parts[0])
 	if err != nil {
 		return
 	}
@@ -127,16 +129,17 @@ func parseFileName(dir, fileName string) (res FileInfo, ok bool) {
 	if err != nil {
 		return
 	}
+	res.From = from * 1_000
 	to, err := strconv.ParseUint(parts[2], 10, 64)
 	if err != nil {
 		return
 	}
-	ft, ok := ParseFileType(parts[3])
+	res.To = to * 1_000
+	res.Type, ok = ParseFileType(parts[3])
 	if !ok {
 		return res, ok
 	}
-
-	return FileInfo{Version: version, From: from * 1_000, To: to * 1_000, Path: filepath.Join(dir, fileName), Type: ft, Ext: ext}, ok
+	return res, ok
 }
 
 var stateFileRegex = regexp.MustCompile("^v([0-9]+)-([[:lower:]]+).([0-9]+)-([0-9]+).(.*)$")
@@ -219,20 +222,6 @@ func (f FileInfo) CompareTo(o FileInfo) int {
 	}
 
 	return strings.Compare(f.Type.String(), o.Type.String())
-}
-
-func (f FileInfo) As(t Type) FileInfo {
-	as := FileInfo{
-		Version: f.Version,
-		From:    f.From,
-		To:      f.To,
-		Ext:     f.Ext,
-		Type:    t,
-	}
-
-	as.Path = filepath.Join(f.Dir(), as.Name())
-
-	return as
 }
 
 func IdxFiles(dir string) (res []FileInfo, err error) {

--- a/erigon-lib/downloader/snaptype/files.go
+++ b/erigon-lib/downloader/snaptype/files.go
@@ -198,19 +198,17 @@ var MergeSteps = []uint64{100_000, 10_000}
 
 // FileInfo - parsed file metadata
 type FileInfo struct {
-	Version   Version
-	From, To  uint64
-	Path, Ext string
-	Type      Type
+	Version         Version
+	From, To        uint64
+	name, Path, Ext string
+	Type            Type
 }
 
 func (f FileInfo) TorrentFileExists() bool { return dir.FileExist(f.Path + ".torrent") }
 
-func (f FileInfo) Name() string {
-	return fmt.Sprintf("v%d-%06d-%06d-%s%s", f.Version, f.From/1_000, f.To/1_000, f.Type, f.Ext)
-}
-func (f FileInfo) Dir() string { return filepath.Dir(f.Path) }
-func (f FileInfo) Len() uint64 { return f.To - f.From }
+func (f FileInfo) Name() string { return f.name }
+func (f FileInfo) Dir() string  { return filepath.Dir(f.Path) }
+func (f FileInfo) Len() uint64  { return f.To - f.From }
 
 func (f FileInfo) CompareTo(o FileInfo) int {
 	if res := cmp.Compare(f.From, o.From); res != 0 {

--- a/erigon-lib/downloader/snaptype/files.go
+++ b/erigon-lib/downloader/snaptype/files.go
@@ -223,7 +223,7 @@ func (f FileInfo) CompareTo(o FileInfo) int {
 }
 
 func (f FileInfo) As(t Type) FileInfo {
-	name := fmt.Sprintf("v%d-%06d-%06d-%s%s", f.Version, f.From/1_000, f.To/1_000, f.Type, f.Ext)
+	name := fmt.Sprintf("v%d-%06d-%06d-%s%s", f.Version, f.From/1_000, f.To/1_000, t, f.Ext)
 	return FileInfo{
 		Version: f.Version,
 		From:    f.From,

--- a/erigon-lib/downloader/snaptype/type.go
+++ b/erigon-lib/downloader/snaptype/type.go
@@ -130,6 +130,7 @@ func (s snapType) FileName(version Version, from uint64, to uint64) string {
 
 func (s snapType) FileInfo(dir string, from uint64, to uint64) FileInfo {
 	f, _, _ := ParseFileName(dir, s.FileName(s.versions.Current, from, to))
+	fmt.Printf("alex: %s, %#v\n", s.FileName(s.versions.Current, from, to), f)
 	return f
 }
 

--- a/erigon-lib/downloader/snaptype/type.go
+++ b/erigon-lib/downloader/snaptype/type.go
@@ -130,7 +130,6 @@ func (s snapType) FileName(version Version, from uint64, to uint64) string {
 
 func (s snapType) FileInfo(dir string, from uint64, to uint64) FileInfo {
 	f, _, _ := ParseFileName(dir, s.FileName(s.versions.Current, from, to))
-	fmt.Printf("alex: %s, %#v\n", s.FileName(s.versions.Current, from, to), f)
 	return f
 }
 

--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -1864,7 +1864,7 @@ func TransactionsIdx(ctx context.Context, chainConfig *chain.Config, sn snaptype
 	}()
 	firstBlockNum := sn.From
 
-	bodiesSegment, err := seg.NewDecompressor(sn.As(snaptype.Bodies).Path)
+	bodiesSegment, err := seg.NewDecompressor(sn.Path)
 	if err != nil {
 		return fmt.Errorf("can't open %s for indexing: %w", sn.Name(), err)
 	}

--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -1864,14 +1864,12 @@ func TransactionsIdx(ctx context.Context, chainConfig *chain.Config, sn snaptype
 	}()
 	firstBlockNum := sn.From
 
-	fmt.Printf("[dbg] here1 %s %s\n", sn.Path, sn.As(snaptype.Bodies).Path)
 	bodiesSegment, err := seg.NewDecompressor(sn.As(snaptype.Bodies).Path)
 	if err != nil {
 		return fmt.Errorf("can't open %s for indexing: %w", sn.As(snaptype.Bodies).Name(), err)
 	}
 	defer bodiesSegment.Close()
 
-	fmt.Printf("[dbg] here2 %s\n", bodiesSegment.FileName())
 	firstTxID, expectedCount, err := txsAmountBasedOnBodiesSnapshots(bodiesSegment, sn.Len()-1)
 	if err != nil {
 		return err
@@ -1879,8 +1877,6 @@ func TransactionsIdx(ctx context.Context, chainConfig *chain.Config, sn snaptype
 
 	d, err := seg.NewDecompressor(sn.Path)
 	if err != nil {
-		fmt.Printf("[dbg] %s %s\n", sn.Path, sn.As(snaptype.Bodies).Path)
-		panic(3)
 		return fmt.Errorf("can't open %s for indexing: %w", sn.Path, err)
 	}
 	defer d.Close()

--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -778,7 +778,7 @@ func buildIdx(ctx context.Context, sn snaptype.FileInfo, chainConfig *chain.Conf
 		}
 	case snaptype.Enums.Transactions:
 		if err := TransactionsIdx(ctx, chainConfig, sn, tmpDir, p, lvl, logger); err != nil {
-			return err
+			return fmt.Errorf("TransactionsIdx: %s", err)
 		}
 	case snaptype.Enums.BorEvents:
 		if err := BorEventsIdx(ctx, sn, tmpDir, p, lvl, logger); err != nil {
@@ -1864,12 +1864,14 @@ func TransactionsIdx(ctx context.Context, chainConfig *chain.Config, sn snaptype
 	}()
 	firstBlockNum := sn.From
 
+	fmt.Printf("[dbg] here1 %s %s\n", sn.Path, sn.As(snaptype.Bodies).Path)
 	bodiesSegment, err := seg.NewDecompressor(sn.As(snaptype.Bodies).Path)
 	if err != nil {
 		return fmt.Errorf("can't open %s for indexing: %w", sn.As(snaptype.Bodies).Name(), err)
 	}
 	defer bodiesSegment.Close()
 
+	fmt.Printf("[dbg] here2 %s\n", bodiesSegment.FileName())
 	firstTxID, expectedCount, err := txsAmountBasedOnBodiesSnapshots(bodiesSegment, sn.Len()-1)
 	if err != nil {
 		return err
@@ -1877,6 +1879,8 @@ func TransactionsIdx(ctx context.Context, chainConfig *chain.Config, sn snaptype
 
 	d, err := seg.NewDecompressor(sn.Path)
 	if err != nil {
+		fmt.Printf("[dbg] %s %s\n", sn.Path, sn.As(snaptype.Bodies).Path)
+		panic(3)
 		return fmt.Errorf("can't open %s for indexing: %w", sn.Path, err)
 	}
 	defer d.Close()

--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -1396,19 +1396,16 @@ func dumpBlocksRange(ctx context.Context, blockFrom, blockTo uint64, tmpDir, sna
 
 	if _, err = dumpRange(ctx, snaptype.Headers.FileInfo(snapDir, blockFrom, blockTo),
 		DumpHeaders, nil, chainDB, chainConfig, tmpDir, workers, lvl, logger); err != nil {
-		panic(err)
 		return 0, err
 	}
 
 	if lastTxNum, err = dumpRange(ctx, snaptype.Bodies.FileInfo(snapDir, blockFrom, blockTo),
 		DumpBodies, func(context.Context) uint64 { return firstTxNum }, chainDB, chainConfig, tmpDir, workers, lvl, logger); err != nil {
-		panic(err)
 		return lastTxNum, err
 	}
 
 	if _, err = dumpRange(ctx, snaptype.Transactions.FileInfo(snapDir, blockFrom, blockTo),
 		DumpTxs, func(context.Context) uint64 { return firstTxNum }, chainDB, chainConfig, tmpDir, workers, lvl, logger); err != nil {
-		panic(err)
 		return lastTxNum, err
 	}
 
@@ -1420,11 +1417,10 @@ type dumpFunc func(ctx context.Context, db kv.RoDB, chainConfig *chain.Config, b
 
 func dumpRange(ctx context.Context, f snaptype.FileInfo, dumper dumpFunc, firstKey firstKeyGetter, chainDB kv.RoDB, chainConfig *chain.Config, tmpDir string, workers int, lvl log.Lvl, logger log.Logger) (uint64, error) {
 	var lastKeyValue uint64
+
 	sn, err := seg.NewCompressor(ctx, "Snapshot "+f.Type.String(), f.Path, tmpDir, seg.MinPatternScore, workers, log.LvlTrace, logger)
 
 	if err != nil {
-		fmt.Printf("a: %s\n", f.Path)
-		panic(err)
 		return lastKeyValue, err
 	}
 	defer sn.Close()
@@ -1434,8 +1430,6 @@ func dumpRange(ctx context.Context, f snaptype.FileInfo, dumper dumpFunc, firstK
 	}, workers, lvl, logger)
 
 	if err != nil {
-		fmt.Printf("b: %s\n", f.Path)
-		panic(err)
 		return lastKeyValue, fmt.Errorf("DumpBodies: %w", err)
 	}
 
@@ -1449,8 +1443,6 @@ func dumpRange(ctx context.Context, f snaptype.FileInfo, dumper dumpFunc, firstK
 	p := &background.Progress{}
 
 	if err := buildIdx(ctx, f, chainConfig, tmpDir, p, lvl, logger); err != nil {
-		fmt.Printf("c: %s\n", f.Path)
-		panic(err)
 		return lastKeyValue, err
 	}
 

--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -1396,16 +1396,19 @@ func dumpBlocksRange(ctx context.Context, blockFrom, blockTo uint64, tmpDir, sna
 
 	if _, err = dumpRange(ctx, snaptype.Headers.FileInfo(snapDir, blockFrom, blockTo),
 		DumpHeaders, nil, chainDB, chainConfig, tmpDir, workers, lvl, logger); err != nil {
+		panic(err)
 		return 0, err
 	}
 
 	if lastTxNum, err = dumpRange(ctx, snaptype.Bodies.FileInfo(snapDir, blockFrom, blockTo),
 		DumpBodies, func(context.Context) uint64 { return firstTxNum }, chainDB, chainConfig, tmpDir, workers, lvl, logger); err != nil {
+		panic(err)
 		return lastTxNum, err
 	}
 
 	if _, err = dumpRange(ctx, snaptype.Transactions.FileInfo(snapDir, blockFrom, blockTo),
 		DumpTxs, func(context.Context) uint64 { return firstTxNum }, chainDB, chainConfig, tmpDir, workers, lvl, logger); err != nil {
+		panic(err)
 		return lastTxNum, err
 	}
 
@@ -1417,10 +1420,11 @@ type dumpFunc func(ctx context.Context, db kv.RoDB, chainConfig *chain.Config, b
 
 func dumpRange(ctx context.Context, f snaptype.FileInfo, dumper dumpFunc, firstKey firstKeyGetter, chainDB kv.RoDB, chainConfig *chain.Config, tmpDir string, workers int, lvl log.Lvl, logger log.Logger) (uint64, error) {
 	var lastKeyValue uint64
-
 	sn, err := seg.NewCompressor(ctx, "Snapshot "+f.Type.String(), f.Path, tmpDir, seg.MinPatternScore, workers, log.LvlTrace, logger)
 
 	if err != nil {
+		fmt.Printf("a: %s\n", f.Path)
+		panic(err)
 		return lastKeyValue, err
 	}
 	defer sn.Close()
@@ -1430,6 +1434,8 @@ func dumpRange(ctx context.Context, f snaptype.FileInfo, dumper dumpFunc, firstK
 	}, workers, lvl, logger)
 
 	if err != nil {
+		fmt.Printf("b: %s\n", f.Path)
+		panic(err)
 		return lastKeyValue, fmt.Errorf("DumpBodies: %w", err)
 	}
 
@@ -1443,6 +1449,8 @@ func dumpRange(ctx context.Context, f snaptype.FileInfo, dumper dumpFunc, firstK
 	p := &background.Progress{}
 
 	if err := buildIdx(ctx, f, chainConfig, tmpDir, p, lvl, logger); err != nil {
+		fmt.Printf("c: %s\n", f.Path)
+		panic(err)
 		return lastKeyValue, err
 	}
 
@@ -1864,9 +1872,9 @@ func TransactionsIdx(ctx context.Context, chainConfig *chain.Config, sn snaptype
 	}()
 	firstBlockNum := sn.From
 
-	bodiesSegment, err := seg.NewDecompressor(sn.Path)
+	bodiesSegment, err := seg.NewDecompressor(sn.As(snaptype.Bodies).Path)
 	if err != nil {
-		return fmt.Errorf("can't open %s for indexing: %w", sn.Name(), err)
+		return fmt.Errorf("can't open %s for indexing: %w", sn.As(snaptype.Bodies).Name(), err)
 	}
 	defer bodiesSegment.Close()
 


### PR DESCRIPTION
```
[1/15 Snapshots] can't build missed indices: v1-000000-000500-transactions.seg: can't open /mnt/erigon/snapshots for indexing: no such device
```