### PR TITLE
support `--sync.loop.block.limit` in newHeads notification

### DIFF
--- a/eth/stagedsync/stage_finish.go
+++ b/eth/stagedsync/stage_finish.go
@@ -5,8 +5,9 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"github.com/ledgerwatch/erigon-lib/kv/dbutils"
 	"time"
+
+	"github.com/ledgerwatch/erigon-lib/kv/dbutils"
 
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/common/hexutility"
@@ -148,18 +149,21 @@ func NotifyNewHeaders(ctx context.Context, finishStageBeforeSync uint64, finishS
 	var notifyTo = notifyFrom
 	var notifyToHash libcommon.Hash
 	var headersRlp [][]byte
-	if err := tx.ForEach(kv.Headers, hexutility.EncodeTs(notifyFrom), func(k, headerRLP []byte) error {
-		if len(headerRLP) == 0 {
+	if err := tx.ForEach(kv.HeaderCanonical, hexutility.EncodeTs(notifyFrom), func(k, hash []byte) (err error) {
+		if len(hash) == 0 {
 			return nil
 		}
-		notifyTo = binary.BigEndian.Uint64(k)
-		var err error
-		if notifyToHash, err = blockReader.CanonicalHash(ctx, tx, notifyTo); err != nil {
+		blockNum := binary.BigEndian.Uint64(k)
+		if blockNum > finishStageAfterSync {
+			return nil
+		}
+		notifyTo = blockNum
+		notifyToHash, err = blockReader.CanonicalHash(ctx, tx, notifyTo)
+		if err != nil {
 			logger.Warn("[Finish] failed checking if header is cannonical")
 		}
-
-		headerHash := libcommon.BytesToHash(k[8:])
-		if notifyToHash == headerHash {
+		headerRLP := rawdb.ReadHeaderRLP(tx, libcommon.BytesToHash(hash), notifyTo)
+		if headerRLP != nil {
 			headersRlp = append(headersRlp, libcommon.CopyBytes(headerRLP))
 		}
 

--- a/eth/stagedsync/stage_finish.go
+++ b/eth/stagedsync/stage_finish.go
@@ -158,11 +158,8 @@ func NotifyNewHeaders(ctx context.Context, finishStageBeforeSync uint64, finishS
 			return nil
 		}
 		notifyTo = blockNum
-		notifyToHash, err = blockReader.CanonicalHash(ctx, tx, notifyTo)
-		if err != nil {
-			logger.Warn("[Finish] failed checking if header is cannonical")
-		}
-		headerRLP := rawdb.ReadHeaderRLP(tx, libcommon.BytesToHash(hash), notifyTo)
+		notifyToHash = libcommon.BytesToHash(hash)
+		headerRLP := rawdb.ReadHeaderRLP(tx, notifyToHash, notifyTo)
 		if headerRLP != nil {
 			headersRlp = append(headersRlp, libcommon.CopyBytes(headerRLP))
 		}

--- a/eth/stagedsync/stage_finish.go
+++ b/eth/stagedsync/stage_finish.go
@@ -154,7 +154,7 @@ func NotifyNewHeaders(ctx context.Context, finishStageBeforeSync uint64, finishS
 			return nil
 		}
 		blockNum := binary.BigEndian.Uint64(k)
-		if blockNum > finishStageAfterSync {
+		if blockNum > finishStageAfterSync { //[from,to)
 			return nil
 		}
 		notifyTo = blockNum
@@ -186,7 +186,7 @@ func NotifyNewHeaders(ctx context.Context, finishStageBeforeSync uint64, finishS
 			notifier.OnLogs(logs)
 		}
 		logTiming := time.Since(t)
-		logger.Info("RPC Daemon notified of new headers", "from", notifyFrom-1, "to", notifyTo, "hash", notifyToHash, "header sending", headerTiming, "log sending", logTiming)
+		logger.Info("RPC Daemon notified of new headers", "from", notifyFrom-1, "to", notifyTo, "hash", notifyToHash, "header sending", headerTiming, "log sending", logTiming, "amount", len(headersRlp))
 	}
 	return nil
 }

--- a/eth/stagedsync/stage_finish.go
+++ b/eth/stagedsync/stage_finish.go
@@ -186,7 +186,7 @@ func NotifyNewHeaders(ctx context.Context, finishStageBeforeSync uint64, finishS
 			notifier.OnLogs(logs)
 		}
 		logTiming := time.Since(t)
-		logger.Info("RPC Daemon notified of new headers", "from", notifyFrom-1, "to", notifyTo, "hash", notifyToHash, "header sending", headerTiming, "log sending", logTiming, "amount", len(headersRlp))
+		logger.Info("RPC Daemon notified of new headers", "from", notifyFrom-1, "to", notifyTo, "amount", len(headersRlp), "hash", notifyToHash, "header sending", headerTiming, "log sending", logTiming)
 	}
 	return nil
 }

--- a/turbo/stages/stageloop.go
+++ b/turbo/stages/stageloop.go
@@ -310,7 +310,11 @@ func (h *Hook) afterRun(tx kv.Tx, finishProgressBefore uint64) error {
 	}
 
 	if notifications != nil && notifications.Events != nil {
-		if err = stagedsync.NotifyNewHeaders(h.ctx, finishProgressBefore, head, h.sync.PrevUnwindPoint(), notifications.Events, tx, h.logger, blockReader); err != nil {
+		finishStageAfterSync, err := stages.GetStageProgress(tx, stages.Finish)
+		if err != nil {
+			return err
+		}
+		if err = stagedsync.NotifyNewHeaders(h.ctx, finishProgressBefore, finishStageAfterSync, h.sync.PrevUnwindPoint(), notifications.Events, tx, h.logger, blockReader); err != nil {
 			return nil
 		}
 	}


### PR DESCRIPTION
now, if `--sync.loop.block.limit=10` erigon may send all headers - because doesn't check jump end. Added:
- check that headerNum < `finishStageAfterSync` (it was missed)
- log amount of sent headers
- iterate over canonical markers instead of headers - it's cheaper and don't need additional hash check


related to https://github.com/ledgerwatch/erigon/issues/8721