### PR TITLE
Fixes to re-download changed files with verify

### DIFF
--- a/erigon-lib/downloader/util.go
+++ b/erigon-lib/downloader/util.go
@@ -334,8 +334,14 @@ func _addTorrentFile(ctx context.Context, ts *torrent.TorrentSpec, torrentClient
 			return nil, false, fmt.Errorf("addTorrentFile %s: %w", ts.DisplayName, err)
 		}
 
-		if err := db.Update(ctx, torrentInfoUpdater(ts.DisplayName, ts.InfoHash.Bytes(), 0, nil)); err != nil {
-			return nil, false, fmt.Errorf("addTorrentFile %s: %w", ts.DisplayName, err)
+		if t.Complete.Bool() {
+			if err := db.Update(ctx, torrentInfoUpdater(ts.DisplayName, ts.InfoHash.Bytes(), 0, nil)); err != nil {
+				return nil, false, fmt.Errorf("addTorrentFile %s: update failed: %w", ts.DisplayName, err)
+			}
+		} else {
+			if err := db.Update(ctx, torrentInfoReset(ts.DisplayName, ts.InfoHash.Bytes(), 0)); err != nil {
+				return nil, false, fmt.Errorf("addTorrentFile %s: reset failed: %w", ts.DisplayName, err)
+			}
 		}
 
 		return t, true, nil
@@ -455,18 +461,52 @@ func IsLocal(path string) bool {
 }
 
 func ScheduleVerifyFile(ctx context.Context, t *torrent.Torrent, completePieces *atomic.Uint64) error {
-	wg, _ := errgroup.WithContext(ctx)
+	ctx, cancel := context.WithCancel(ctx)
+	wg, wgctx := errgroup.WithContext(ctx)
 	wg.SetLimit(16)
+
+	// piece changes happen asynchronously - we need to wait from them to complete
+	pieceChanges := t.SubscribePieceStateChanges()
+	inprogress := map[int]struct{}{}
+
 	for i := 0; i < t.NumPieces(); i++ {
+		inprogress[i] = struct{}{}
+
 		i := i
 		wg.Go(func() error {
 			t.Piece(i).VerifyData()
-
-			completePieces.Add(1)
 			return nil
 		})
 	}
-	return wg.Wait()
+
+	for {
+		select {
+		case <-wgctx.Done():
+			return wg.Wait()
+		case change := <-pieceChanges.Values:
+			if !change.Ok {
+				var err error
+
+				if change.Err != nil {
+					err = change.Err
+				} else {
+					err = fmt.Errorf("unexpected piece change error")
+				}
+
+				cancel()
+				return fmt.Errorf("piece %s:%d verify failed: %w", t.Name(), change.Index, err)
+			}
+
+			if change.Complete && !(change.Checking || change.Hashing || change.Hashing || change.QueuedForHash || change.Marking) {
+				completePieces.Add(1)
+				delete(inprogress, change.Index)
+			}
+
+			if len(inprogress) == 0 {
+				return wg.Wait()
+			}
+		}
+	}
 }
 
 func VerifyFileFailFast(ctx context.Context, t *torrent.Torrent, root string, completePieces *atomic.Uint64) error {


### PR DESCRIPTION
This PR has a series of fixes around re instating changed and deleted files:

* It includes an early check of file size & mod time - before these are updated by t.MergeSpec
* Tidies recalc stats to avoid unnecessary logging and actions
* Add a channel wait to ScheduleVerifyFile, to allow the verify process to complete before returning (this avoids transient t.Complete.Bool states which can confuse other sections of the code
* If verify does not complete - the file is marked as incomplete in the db to initiate a new download