### PR TITLE
downloader: got sigbus on writemap

### DIFF
--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -2254,8 +2254,8 @@ func openClient(ctx context.Context, dbDir, snapDir string, cfg *torrent.ClientC
 		GrowthStep(16 * datasize.MB).
 		MapSize(16 * datasize.GB).
 		PageSize(uint64(4 * datasize.KB)).
-		WriteMap().
-		LifoReclaim().
+		//WriteMap().
+		//LifoReclaim().
 		RoTxsLimiter(semaphore.NewWeighted(9_000)).
 		Path(dbDir).
 		Open(ctx)


### PR DESCRIPTION
don't know why yet: 
```
SIGBUS: bus error
PC=0x40d3f7 m=9 sigcode=2
signal arrived during cgo execution

goroutine 344 [syscall, locked to thread]:
runtime.cgocall(0x10b3360, 0xc0014818f8)
	runtime/cgocall.go:157 +0x4b fp=0xc0014818d0 sp=0xc001481898 pc=0x42788b
github.com/erigontech/mdbx-go/mdbx._Cfunc_mdbxgo_cursor_put2(0x7faeec000b70, 0xc002520ac0, 0x1b, 0xc0009cec00, 0x76, 0x0)
	_cgo_gotypes.go:1110 +0x4b fp=0xc0014818f8 sp=0xc0014818d0 pc=0xc4bdeb
github.com/erigontech/mdbx-go/mdbx.(*Cursor).Put.func1(0x0?, 0xc0014819d0?, {0xc002520ac0?, 0x1b, 0x120?}, 0x110?, {0xc0009cec00?, 0x76, 0x7faf0cbfa7a8?}, 0x0)
	github.com/erigontech/mdbx-go@v0.27.24/mdbx/cursor.go:267 +0x9f fp=0xc001481958 sp=0xc0014818f8 pc=0xc4e25f
github.com/erigontech/mdbx-go/mdbx.(*Cursor).Put(0x0?, {0xc002520ac0?, 0x436465?, 0x110?}, {0xc0009cec00?, 0x1?, 0x5e0000000000000e?}, 0x0?)
	github.com/erigontech/mdbx-go@v0.27.24/mdbx/cursor.go:267 +0x5f fp=0xc0014819c8 sp=0xc001481958 pc=0xc4e05f
github.com/ledgerwatch/erigon-lib/kv/mdbx.(*MdbxCursor).put(...)
	github.com/ledgerwatch/erigon-lib@v1.0.0/kv/mdbx/kv_mdbx.go:1202
github.com/ledgerwatch/erigon-lib/kv/mdbx.(*MdbxCursor).Put(0xc00253c8a0, {0xc002520ac0?, 0xe?, 0x21aba20?}, {0xc0009cec00?, 0x20?, 0xc002520ac0?})
	github.com/ledgerwatch/erigon-lib@v1.0.0/kv/mdbx/kv_mdbx.go:1475 +0x15e fp=0xc001481a90 sp=0xc0014819c8 pc=0xd7233e
github.com/ledgerwatch/erigon-lib/kv/mdbx.(*MdbxTx).Put(0x132dfe0?, {0x13f52ea?, 0x1b?}, {0xc002520ac0, 0x1b, 0x20}, {0xc0009cec00, 0x76, 0x80})
	github.com/ledgerwatch/erigon-lib@v1.0.0/kv/mdbx/kv_mdbx.go:1022 +0x7e fp=0xc001481ad8 sp=0xc001481a90 pc=0xd6f6be
github.com/ledgerwatch/erigon-lib/downloader._addTorrentFile.torrentInfoReset.func2({0x17f8050, 0xc00253c840})
	github.com/ledgerwatch/erigon-lib@v1.0.0/downloader/util.go:434 +0x1c8 fp=0xc001481bc0 sp=0xc001481ad8 pc=0xdaa188
github.com/ledgerwatch/erigon-lib/kv/mdbx.(*MdbxKV).Update(0xc0005b4500?, {0x17e2af0?, 0xc00078e460?}, 0xc002523640)
	github.com/ledgerwatch/erigon-lib@v1.0.0/kv/mdbx/kv_mdbx.go:779 +0xa5 fp=0xc001481c38 sp=0xc001481bc0 pc=0xd6e105
github.com/ledgerwatch/erigon-lib/downloader._addTorrentFile({0x17e2af0, 0xc00078e460}, 0xc0010cc0e0, 0x0?, {0x17eb7b8, 0xc0000309a0}, 0x0?)
	github.com/ledgerwatch/erigon-lib@v1.0.0/downloader/util.go:342 +0xa1a fp=0xc001481df8 sp=0xc001481c38 pc=0xda96da
github.com/ledgerwatch/erigon-lib/downloader.addTorrentFile({0x17e2af0?, 0xc00078e460}, 0xc0010cc0e0, 0xc0005b4500, {0x17eb7b8?, 0xc0000309a0}, 0xc000701bc0)
	github.com/ledgerwatch/erigon-lib@v1.0.0/downloader/util.go:309 +0x13b fp=0xc001481ed0 sp=0xc001481df8 pc=0xda8a3b
github.com/ledgerwatch/erigon-lib/downloader.(*Downloader).addTorrentFilesFromDisk.func2()
	github.com/ledgerwatch/erigon-lib@v1.0.0/downloader/downloader.go:2220 +0x65 fp=0xc001481f78 sp=0xc001481ed0 pc=0xd9c9a5
```