### PR TITLE
turbo/cli: register miner.recommit flag in cli

### DIFF
--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -139,6 +139,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.MinerExtraDataFlag,
 	&utils.MinerNoVerfiyFlag,
 	&utils.MinerSigningKeyFileFlag,
+	&utils.MinerRecommitIntervalFlag,
 	&utils.SentryAddrFlag,
 	&utils.SentryLogPeerInfoFlag,
 	&utils.DownloaderAddrFlag,


### PR DESCRIPTION
`miner.recommit` flag wasn't registered earlier to use in cli. This PR adds that. 

Note: This is for validator support on Polygon PoS. 