### PR TITLE
evm transaction context not correct when txn is type 3 (EIP-4844)

### DIFF
--- a/turbo/jsonrpc/tracing.go
+++ b/turbo/jsonrpc/tracing.go
@@ -144,6 +144,7 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 			TxHash:   txnHash,
 			Origin:   msg.From(),
 			GasPrice: msg.GasPrice(),
+			BlobHashes: msg.BlobHashes(),
 		}
 
 		if isBorStateSyncTxn {

--- a/turbo/jsonrpc/tracing.go
+++ b/turbo/jsonrpc/tracing.go
@@ -141,9 +141,9 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 		}
 
 		txCtx := evmtypes.TxContext{
-			TxHash:   txnHash,
-			Origin:   msg.From(),
-			GasPrice: msg.GasPrice(),
+			TxHash:     txnHash,
+			Origin:     msg.From(),
+			GasPrice:   msg.GasPrice(),
 			BlobHashes: msg.BlobHashes(),
 		}
 


### PR DESCRIPTION
evm transaction context not correct when txn is type 3 (EIP-4844)