### PR TITLE
Add torrentDownload to default downloader case

### DIFF
--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -993,7 +993,6 @@ func (d *Downloader) mainLoop(silent bool) error {
 
 							continue
 						}
-
 					} else {
 						d.logger.Debug("[snapshots] Downloading from torrent", "file", t.Name(), "peers", len(t.PeerConns()), "webpeers", len(t.WebseedPeerConns()))
 						delete(waiting, t.Name())
@@ -1040,6 +1039,9 @@ func (d *Downloader) mainLoop(silent bool) error {
 						continue
 					}
 
+					d.logger.Debug("[snapshots] Downloading from torrent", "file", t.Name(), "peers", len(t.PeerConns()))
+					delete(waiting, t.Name())
+					d.torrentDownload(t, downloadComplete, sem)
 				}
 			}
 


### PR DESCRIPTION
This removes a never ending loop when the downloader db is removed and the web downloader is not present