### PR TITLE
snapshots: fix system tx hash in transactions indexes

### DIFF
--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -1988,6 +1988,7 @@ RETRY:
 		firstTxByteAndlengthOfAddress := 21
 		isSystemTx := len(word) == 0
 		if isSystemTx { // system-txs hash:pad32(txnID)
+			slot.IDHash = emptyHash
 			binary.BigEndian.PutUint64(slot.IDHash[:], firstTxID+i)
 		} else {
 			if _, err = parseCtx.ParseTransaction(word[firstTxByteAndlengthOfAddress:], 0, &slot, nil, true /* hasEnvelope */, false /* wrappedWithBlobs */, nil /* validateHash */); err != nil {


### PR DESCRIPTION
slot.IDHash is used as a tx key, but for isSystemTx case, its value is not fully reset on loop iterations.

PutUint64 only sets the first 8 bytes while the rest 24 bytes contained garbage - a partial hash of a previous tx.