### PR TITLE
Caplin: Implemented Attestation Data production

### DIFF
--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -1,0 +1,32 @@
+package handler
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/ledgerwatch/erigon/cl/beacon/beaconhttp"
+)
+
+func (a *ApiHandler) GetEthV1ValidatorAttestationData(w http.ResponseWriter, r *http.Request) (*beaconhttp.BeaconResponse, error) {
+	slot, err := beaconhttp.Uint64FromQueryParams(r, "slot")
+	if err != nil {
+		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, err)
+	}
+	committeeIndex, err := beaconhttp.Uint64FromQueryParams(r, "committee_index")
+	if err != nil {
+		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, err)
+	}
+	if slot == nil || committeeIndex == nil {
+		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, fmt.Errorf("slot and committee_index url params are required"))
+	}
+	headState := a.syncedData.HeadState()
+	if headState == nil {
+		return nil, beaconhttp.NewEndpointError(http.StatusServiceUnavailable, fmt.Errorf("beacon node is still syncing"))
+	}
+
+	attestationData, err := a.attestationProducer.ProduceAndCacheAttestationData(headState, *slot, *committeeIndex)
+	if err != nil {
+		return nil, beaconhttp.NewEndpointError(http.StatusInternalServerError, err)
+	}
+	return newBeaconResponse(attestationData), nil
+}

--- a/cl/beacon/handler/pool.go
+++ b/cl/beacon/handler/pool.go
@@ -44,7 +44,7 @@ func (a *ApiHandler) GetEthV1BeaconPoolAttestations(w http.ResponseWriter, r *ht
 		if slot != nil && atts[i].AttestantionData().Slot() != *slot {
 			continue
 		}
-		if committeeIndex != nil && atts[i].AttestantionData().ValidatorIndex() != *committeeIndex {
+		if committeeIndex != nil && atts[i].AttestantionData().CommitteeIndex() != *committeeIndex {
 			continue
 		}
 		ret = append(ret, atts[i])

--- a/cl/beacon/handler/utils_test.go
+++ b/cl/beacon/handler/utils_test.go
@@ -99,7 +99,7 @@ func setupTestingHandler(t *testing.T, v clparams.StateVersion, logger log.Logge
 			Events:     true,
 			Validator:  true,
 			Lighthouse: true,
-		}, nil, blobStorage, nil, vp)
+		}, nil, blobStorage, nil, vp, nil)
 	h.Init()
 	return
 }

--- a/cl/cltypes/solid/attestation_data.go
+++ b/cl/cltypes/solid/attestation_data.go
@@ -24,14 +24,14 @@ type AttestationData []byte
 
 func NewAttestionDataFromParameters(
 	slot uint64,
-	validatorIndex uint64,
+	committeeIndex uint64,
 	beaconBlockRoot libcommon.Hash,
 	source Checkpoint,
 	target Checkpoint,
 ) AttestationData {
 	a := NewAttestationData()
 	a.SetSlot(slot)
-	a.SetValidatorIndex(validatorIndex)
+	a.SetCommitteeIndex(committeeIndex)
 	a.SetBeaconBlockRoot(beaconBlockRoot)
 	a.SetSource(source)
 	a.SetTarget(target)
@@ -48,7 +48,7 @@ func (a AttestationData) MarshalJSON() ([]byte, error) {
 	}{
 		Slot:            a.Slot(),
 		BeaconBlockRoot: a.BeaconBlockRoot(),
-		Index:           a.ValidatorIndex(),
+		Index:           a.CommitteeIndex(),
 		Source:          a.Source(),
 		Target:          a.Target(),
 	})
@@ -68,7 +68,7 @@ func (a AttestationData) UnmarshalJSON(buf []byte) error {
 		return err
 	}
 	a.SetSlot(tmp.Slot)
-	a.SetValidatorIndex(tmp.Index)
+	a.SetCommitteeIndex(tmp.Index)
 	a.SetBeaconBlockRoot(tmp.BeaconBlockRoot)
 	a.SetSource(tmp.Source)
 	a.SetTarget(tmp.Target)
@@ -87,7 +87,7 @@ func (a AttestationData) Slot() uint64 {
 	return binary.LittleEndian.Uint64(a[:8])
 }
 
-func (a AttestationData) ValidatorIndex() uint64 {
+func (a AttestationData) CommitteeIndex() uint64 {
 	return binary.LittleEndian.Uint64(a[8:16])
 }
 
@@ -108,7 +108,7 @@ func (a AttestationData) SetSlot(slot uint64) {
 	binary.LittleEndian.PutUint64(a[:8], slot)
 }
 
-func (a AttestationData) SetValidatorIndex(validatorIndex uint64) {
+func (a AttestationData) SetCommitteeIndex(validatorIndex uint64) {
 	binary.LittleEndian.PutUint64(a[8:16], validatorIndex)
 }
 
@@ -120,7 +120,7 @@ func (a AttestationData) SetSlotWithRawBytes(b []byte) {
 	copy(a[:8], b)
 }
 
-func (a AttestationData) SetValidatorIndexWithRawBytes(b []byte) {
+func (a AttestationData) SetCommitteeIndexWithRawBytes(b []byte) {
 	copy(a[8:16], b)
 
 }

--- a/cl/cltypes/solid/attestation_test.go
+++ b/cl/cltypes/solid/attestation_test.go
@@ -18,7 +18,7 @@ func TestAttestationData(t *testing.T) {
 
 	// Ensure that the data was set correctly
 	assert.Equal(t, slot, attData.Slot())
-	assert.Equal(t, validatorIndex, attData.ValidatorIndex())
+	assert.Equal(t, validatorIndex, attData.CommitteeIndex())
 	assert.Equal(t, beaconBlockRoot, attData.BeaconBlockRoot())
 	assert.Equal(t, source, attData.Source())
 	assert.Equal(t, target, attData.Target())

--- a/cl/persistence/state/historical_states_reader/attesting_indicies.go
+++ b/cl/persistence/state/historical_states_reader/attesting_indicies.go
@@ -16,7 +16,7 @@ import (
 func (r *HistoricalStatesReader) attestingIndicies(attestation solid.AttestationData, aggregationBits []byte, checkBitsLength bool, mix libcommon.Hash, idxs []uint64) ([]uint64, error) {
 	slot := attestation.Slot()
 	committeesPerSlot := committeeCount(r.cfg, slot/r.cfg.SlotsPerEpoch, idxs)
-	committeeIndex := attestation.ValidatorIndex()
+	committeeIndex := attestation.CommitteeIndex()
 	index := (slot%r.cfg.SlotsPerEpoch)*committeesPerSlot + committeeIndex
 	count := committeesPerSlot * r.cfg.SlotsPerEpoch
 

--- a/cl/phase1/core/state/cache_accessors.go
+++ b/cl/phase1/core/state/cache_accessors.go
@@ -300,7 +300,7 @@ func (b *CachingBeaconState) GetAttestingIndicies(attestation solid.AttestationD
 	// if cached, ok := cache.LoadAttestatingIndicies(&attestation, aggregationBits); ok {
 	// 	return cached, nil
 	// }
-	committee, err := b.GetBeaconCommitee(attestation.Slot(), attestation.ValidatorIndex())
+	committee, err := b.GetBeaconCommitee(attestation.Slot(), attestation.CommitteeIndex())
 	if err != nil {
 		return nil, err
 	}

--- a/cl/phase1/forkchoice/checkpoint_state.go
+++ b/cl/phase1/forkchoice/checkpoint_state.go
@@ -109,7 +109,7 @@ func (c *checkpointState) getAttestingIndicies(attestation *solid.AttestationDat
 	lenIndicies := uint64(len(c.shuffledSet))
 	committeesPerSlot := c.committeeCount(epoch, lenIndicies)
 	count := committeesPerSlot * c.beaconConfig.SlotsPerEpoch
-	index := (slot%c.beaconConfig.SlotsPerEpoch)*committeesPerSlot + attestation.ValidatorIndex()
+	index := (slot%c.beaconConfig.SlotsPerEpoch)*committeesPerSlot + attestation.CommitteeIndex()
 	start := (lenIndicies * index) / count
 	end := (lenIndicies * (index + 1)) / count
 	committee := c.shuffledSet[start:end]

--- a/cl/phase1/forkchoice/on_attestation.go
+++ b/cl/phase1/forkchoice/on_attestation.go
@@ -87,7 +87,7 @@ func (f *ForkChoiceStore) OnAggregateAndProof(aggregateAndProof *cltypes.SignedA
 	}
 	slot := aggregateAndProof.Message.Aggregate.AttestantionData().Slot()
 	selectionProof := aggregateAndProof.Message.SelectionProof
-	committeeIndex := aggregateAndProof.Message.Aggregate.AttestantionData().ValidatorIndex()
+	committeeIndex := aggregateAndProof.Message.Aggregate.AttestantionData().CommitteeIndex()
 	epoch := state.GetEpochAtSlot(f.beaconCfg, slot)
 
 	if err := f.validateOnAttestation(aggregateAndProof.Message.Aggregate, false); err != nil {

--- a/cl/phase1/stages/clstages.go
+++ b/cl/phase1/stages/clstages.go
@@ -781,7 +781,7 @@ func ConsensusClStages(ctx context.Context,
 
 					copiedHeadState := cfg.syncedData.HeadState() // it is just copied, so we can use it without worrying about concurrency
 
-					if _, err = cfg.attestationDataProducer.ProduceAndCacheAttestationData(copiedHeadState, 0, 0); err != nil {
+					if _, err = cfg.attestationDataProducer.ProduceAndCacheAttestationData(copiedHeadState, copiedHeadState.Slot(), 0); err != nil {
 						logger.Warn("failed to produce and cache attestation data", "err", err)
 					}
 					// Incement some stuff here

--- a/cl/phase1/stages/clstages.go
+++ b/cl/phase1/stages/clstages.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ledgerwatch/erigon/cl/phase1/core/state"
 	"github.com/ledgerwatch/erigon/cl/phase1/execution_client"
 	"github.com/ledgerwatch/erigon/cl/phase1/forkchoice"
+	"github.com/ledgerwatch/erigon/cl/validator/attestation_producer"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/turbo/snapshotsync/freezeblocks"
 
@@ -44,24 +45,25 @@ import (
 )
 
 type Cfg struct {
-	rpc             *rpc.BeaconRpcP2P
-	genesisCfg      *clparams.GenesisConfig
-	beaconCfg       *clparams.BeaconChainConfig
-	executionClient execution_client.ExecutionEngine
-	state           *state.CachingBeaconState
-	gossipManager   *network2.GossipManager
-	forkChoice      *forkchoice.ForkChoiceStore
-	indiciesDB      kv.RwDB
-	tmpdir          string
-	dbConfig        db_config.DatabaseConfiguration
-	blockReader     freezeblocks.BeaconSnapshotReader
-	antiquary       *antiquary.Antiquary
-	syncedData      *synced_data.SyncedDataManager
-	emitter         *beaconevents.Emitters
-	prebuffer       *etl.Collector
-	gossipSource    persistence.BlockSource
-	sn              *freezeblocks.CaplinSnapshots
-	blobStore       blob_storage.BlobStorage
+	rpc                     *rpc.BeaconRpcP2P
+	genesisCfg              *clparams.GenesisConfig
+	beaconCfg               *clparams.BeaconChainConfig
+	executionClient         execution_client.ExecutionEngine
+	state                   *state.CachingBeaconState
+	gossipManager           *network2.GossipManager
+	forkChoice              *forkchoice.ForkChoiceStore
+	indiciesDB              kv.RwDB
+	tmpdir                  string
+	dbConfig                db_config.DatabaseConfiguration
+	blockReader             freezeblocks.BeaconSnapshotReader
+	antiquary               *antiquary.Antiquary
+	syncedData              *synced_data.SyncedDataManager
+	emitter                 *beaconevents.Emitters
+	prebuffer               *etl.Collector
+	gossipSource            persistence.BlockSource
+	sn                      *freezeblocks.CaplinSnapshots
+	blobStore               blob_storage.BlobStorage
+	attestationDataProducer attestation_producer.AttestationDataProducer
 
 	hasDownloaded, backfilling, blobBackfilling bool
 }
@@ -116,28 +118,30 @@ func ClStagesCfg(
 	emitters *beaconevents.Emitters,
 	gossipSource persistence.BlockSource,
 	blobStore blob_storage.BlobStorage,
+	attestationDataProducer attestation_producer.AttestationDataProducer,
 ) *Cfg {
 	return &Cfg{
-		rpc:             rpc,
-		antiquary:       antiquary,
-		genesisCfg:      genesisCfg,
-		beaconCfg:       beaconCfg,
-		state:           state,
-		executionClient: executionClient,
-		gossipManager:   gossipManager,
-		forkChoice:      forkChoice,
-		tmpdir:          tmpdir,
-		indiciesDB:      indiciesDB,
-		dbConfig:        dbConfig,
-		sn:              sn,
-		blockReader:     blockReader,
-		backfilling:     backfilling,
-		syncedData:      syncedData,
-		emitter:         emitters,
-		blobStore:       blobStore,
-		prebuffer:       etl.NewCollector("Caplin-blocks", tmpdir, etl.NewSortableBuffer(etl.BufferOptimalSize), log.Root()),
-		gossipSource:    gossipSource,
-		blobBackfilling: blobBackfilling,
+		rpc:                     rpc,
+		antiquary:               antiquary,
+		genesisCfg:              genesisCfg,
+		beaconCfg:               beaconCfg,
+		state:                   state,
+		executionClient:         executionClient,
+		gossipManager:           gossipManager,
+		forkChoice:              forkChoice,
+		tmpdir:                  tmpdir,
+		indiciesDB:              indiciesDB,
+		dbConfig:                dbConfig,
+		sn:                      sn,
+		blockReader:             blockReader,
+		backfilling:             backfilling,
+		syncedData:              syncedData,
+		emitter:                 emitters,
+		blobStore:               blobStore,
+		prebuffer:               etl.NewCollector("Caplin-blocks", tmpdir, etl.NewSortableBuffer(etl.BufferOptimalSize), log.Root()),
+		gossipSource:            gossipSource,
+		blobBackfilling:         blobBackfilling,
+		attestationDataProducer: attestationDataProducer,
 	}
 }
 
@@ -774,6 +778,12 @@ func ConsensusClStages(ctx context.Context,
 						return fmt.Errorf("failed to set head state: %w", err)
 					}
 					start := time.Now()
+
+					copiedHeadState := cfg.syncedData.HeadState() // it is just copied, so we can use it without worrying about concurrency
+
+					if _, err = cfg.attestationDataProducer.ProduceAndCacheAttestationData(copiedHeadState, 0, 0); err != nil {
+						logger.Warn("failed to produce and cache attestation data", "err", err)
+					}
 					// Incement some stuff here
 					preverifiedValidators := cfg.forkChoice.PreverifiedValidator(headState.FinalizedCheckpoint().BlockRoot())
 					preverifiedHistoricalSummary := cfg.forkChoice.PreverifiedHistoricalSummaries(headState.FinalizedCheckpoint().BlockRoot())

--- a/cl/transition/impl/eth2/operations.go
+++ b/cl/transition/impl/eth2/operations.go
@@ -549,7 +549,7 @@ func (I *impl) processAttestationPostAltair(s abstract.BeaconState, attestation 
 // processAttestationsPhase0 implements the rules for phase0 processing.
 func (I *impl) processAttestationPhase0(s abstract.BeaconState, attestation *solid.Attestation) ([]uint64, error) {
 	data := attestation.AttestantionData()
-	committee, err := s.GetBeaconCommitee(data.Slot(), data.ValidatorIndex())
+	committee, err := s.GetBeaconCommitee(data.Slot(), data.CommitteeIndex())
 	if err != nil {
 		return nil, err
 	}
@@ -674,7 +674,7 @@ func (I *impl) processAttestation(s abstract.BeaconState, attestation *solid.Att
 	if s.Version() >= clparams.DenebVersion && data.Slot()+beaconConfig.MinAttestationInclusionDelay > stateSlot {
 		return nil, errors.New("ProcessAttestation: attestation slot not in range")
 	}
-	if data.ValidatorIndex() >= s.CommitteeCount(data.Target().Epoch()) {
+	if data.CommitteeIndex() >= s.CommitteeCount(data.Target().Epoch()) {
 		return nil, errors.New("ProcessAttestation: attester index out of range")
 	}
 	// check if we need to use rules for phase0 or post-altair.

--- a/cl/validator/attestation_producer/attestation_producer.go
+++ b/cl/validator/attestation_producer/attestation_producer.go
@@ -48,8 +48,8 @@ func (ap *attestationProducer) ProduceAndCacheAttestationData(baseState *state.C
 			baseAttestationData.Target(),
 		), nil
 	}
-	if baseState.Slot() < slot {
-		return solid.AttestationData{}, errors.New("head state slot is less than requested slot, the attestation should have been cached, try again later.")
+	if baseState.Slot() > slot {
+		return solid.AttestationData{}, errors.New("head state slot is bigger than requested slot, the attestation should have been cached, try again later.")
 	}
 	baseStateBlockRoot, err := baseState.BlockRoot()
 	if err != nil {

--- a/cl/validator/attestation_producer/attestation_producer.go
+++ b/cl/validator/attestation_producer/attestation_producer.go
@@ -2,7 +2,6 @@ package attestation_producer
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/ledgerwatch/erigon/cl/clparams"
 	"github.com/ledgerwatch/erigon/cl/cltypes/solid"
@@ -71,7 +70,6 @@ func (ap *attestationProducer) ProduceAndCacheAttestationData(baseState *state.C
 	targetEpoch := state.Epoch(baseState)
 	epochStartTargetSlot := (targetEpoch * ap.beaconCfg.SlotsPerEpoch) - (ap.beaconCfg.SlotsPerEpoch - 1)
 	var targetRoot libcommon.Hash
-	fmt.Println(baseStateBlockRoot)
 	if epochStartTargetSlot == baseState.Slot() {
 		targetRoot = baseStateBlockRoot
 	} else {

--- a/cl/validator/attestation_producer/attestation_producer.go
+++ b/cl/validator/attestation_producer/attestation_producer.go
@@ -1,0 +1,105 @@
+package attestation_producer
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ledgerwatch/erigon/cl/clparams"
+	"github.com/ledgerwatch/erigon/cl/cltypes/solid"
+	"github.com/ledgerwatch/erigon/cl/phase1/core/state"
+	"github.com/ledgerwatch/erigon/cl/phase1/core/state/lru"
+	"github.com/ledgerwatch/erigon/cl/transition"
+
+	libcommon "github.com/ledgerwatch/erigon-lib/common"
+)
+
+var (
+	ErrHeadStateNotAvailable = errors.New("head state not available")
+)
+
+const attestationsCacheSize = 64
+
+type attestationProducer struct {
+	beaconCfg *clparams.BeaconChainConfig
+
+	attestationsCache *lru.Cache[uint64, solid.AttestationData] // Epoch => Base AttestationData
+}
+
+func New(beaconCfg *clparams.BeaconChainConfig) AttestationDataProducer {
+	attestationsCache, err := lru.New[uint64, solid.AttestationData]("attestations", attestationsCacheSize)
+	if err != nil {
+		panic(err)
+	}
+
+	return &attestationProducer{
+		beaconCfg:         beaconCfg,
+		attestationsCache: attestationsCache,
+	}
+}
+
+func (ap *attestationProducer) ProduceAndCacheAttestationData(baseState *state.CachingBeaconState, slot uint64, committeeIndex uint64) (solid.AttestationData, error) {
+	epoch := slot / ap.beaconCfg.SlotsPerEpoch
+
+	if baseAttestationData, ok := ap.attestationsCache.Get(epoch); ok {
+		return solid.NewAttestionDataFromParameters(
+			slot,
+			committeeIndex,
+			baseAttestationData.BeaconBlockRoot(),
+			baseAttestationData.Source(),
+			baseAttestationData.Target(),
+		), nil
+	}
+	if baseState.Slot() < slot {
+		return solid.AttestationData{}, errors.New("head state slot is less than requested slot, the attestation should have been cached, try again later.")
+	}
+	baseStateBlockRoot, err := baseState.BlockRoot()
+	if err != nil {
+		return solid.AttestationData{}, err
+	}
+	stateEpoch := state.Epoch(baseState)
+
+	if stateEpoch < epoch {
+		baseState, err = baseState.Copy()
+		if err != nil {
+			return solid.AttestationData{}, err
+		}
+		if err := transition.DefaultMachine.ProcessSlots(baseState, slot); err != nil {
+			return solid.AttestationData{}, err
+		}
+	}
+
+	targetEpoch := state.Epoch(baseState)
+	epochStartTargetSlot := (targetEpoch * ap.beaconCfg.SlotsPerEpoch) - (ap.beaconCfg.SlotsPerEpoch - 1)
+	var targetRoot libcommon.Hash
+	fmt.Println(baseStateBlockRoot)
+	if epochStartTargetSlot == baseState.Slot() {
+		targetRoot = baseStateBlockRoot
+	} else {
+		targetRoot, err = baseState.GetBlockRootAtSlot(epochStartTargetSlot)
+		if err != nil {
+			return solid.AttestationData{}, err
+		}
+		if targetRoot == (libcommon.Hash{}) {
+			targetRoot = baseStateBlockRoot
+		}
+	}
+
+	baseAttestationData := solid.NewAttestionDataFromParameters(
+		0,
+		0,
+		baseStateBlockRoot,
+		baseState.CurrentJustifiedCheckpoint(),
+		solid.NewCheckpointFromParameters(
+			targetRoot,
+			targetEpoch,
+		),
+	)
+	ap.attestationsCache.Add(epoch, baseAttestationData)
+	return solid.NewAttestionDataFromParameters(
+		slot,
+		committeeIndex,
+		baseAttestationData.BeaconBlockRoot(),
+		baseAttestationData.Source(),
+		baseAttestationData.Target(),
+	), nil
+}

--- a/cl/validator/attestation_producer/attestation_producer_test.go
+++ b/cl/validator/attestation_producer/attestation_producer_test.go
@@ -1,0 +1,24 @@
+package attestation_producer_test
+
+import (
+	"testing"
+
+	"github.com/ledgerwatch/erigon/cl/antiquary/tests"
+	"github.com/ledgerwatch/erigon/cl/clparams"
+	"github.com/ledgerwatch/erigon/cl/validator/attestation_producer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAttestationProducer(t *testing.T) {
+	attProducer := attestation_producer.New(&clparams.MainnetBeaconConfig)
+
+	_, _, headState := tests.GetPhase0Random()
+
+	att, err := attProducer.ProduceAndCacheAttestationData(headState, headState.Slot(), 0)
+	require.NoError(t, err)
+
+	attJson, err := att.MarshalJSON()
+	require.NoError(t, err)
+
+	require.Equal(t, string(attJson), `{"slot":"8322","index":"0","beacon_block_root":"0xeffdd8ef40c3c901f0724d48e04ce257967cf1da31929f3b6db614f89ef8d660","source":{"epoch":"258","root":"0x31885d5a2405876b7203f9cc1a7e115b9977412107c51c81ab4fd49bde93905e"},"target":{"epoch":"260","root":"0x86979f6f6dc7626064ef0d38d4dffb89e91d1d4c18492e3fb7d7ee93cedca3ed"}}`)
+}

--- a/cl/validator/attestation_producer/attestation_producer_test.go
+++ b/cl/validator/attestation_producer/attestation_producer_test.go
@@ -20,5 +20,6 @@ func TestAttestationProducer(t *testing.T) {
 	attJson, err := att.MarshalJSON()
 	require.NoError(t, err)
 
+	// check if the json match with the expected value
 	require.Equal(t, string(attJson), `{"slot":"8322","index":"0","beacon_block_root":"0xeffdd8ef40c3c901f0724d48e04ce257967cf1da31929f3b6db614f89ef8d660","source":{"epoch":"258","root":"0x31885d5a2405876b7203f9cc1a7e115b9977412107c51c81ab4fd49bde93905e"},"target":{"epoch":"260","root":"0x86979f6f6dc7626064ef0d38d4dffb89e91d1d4c18492e3fb7d7ee93cedca3ed"}}`)
 }

--- a/cl/validator/attestation_producer/interface.go
+++ b/cl/validator/attestation_producer/interface.go
@@ -1,0 +1,10 @@
+package attestation_producer
+
+import (
+	"github.com/ledgerwatch/erigon/cl/cltypes/solid"
+	"github.com/ledgerwatch/erigon/cl/phase1/core/state"
+)
+
+type AttestationDataProducer interface {
+	ProduceAndCacheAttestationData(baseState *state.CachingBeaconState, slot uint64, committeeIndex uint64) (solid.AttestationData, error)
+}

--- a/cmd/caplin/caplin1/run.go
+++ b/cmd/caplin/caplin1/run.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ledgerwatch/erigon/cl/rpc"
 	"github.com/ledgerwatch/erigon/cl/sentinel"
 	"github.com/ledgerwatch/erigon/cl/sentinel/service"
+	"github.com/ledgerwatch/erigon/cl/validator/attestation_producer"
 	"github.com/ledgerwatch/erigon/cl/validator/validator_params"
 	"github.com/ledgerwatch/erigon/eth/ethconfig"
 	"github.com/ledgerwatch/erigon/params"
@@ -113,6 +114,7 @@ func RunCaplinPhase1(ctx context.Context, engine execution_client.ExecutionEngin
 	rcsn := freezeblocks.NewBeaconSnapshotReader(csn, eth1Getter, beaconConfig)
 
 	pool := pool.NewOperationsPool(beaconConfig)
+	attestationProducer := attestation_producer.New(beaconConfig)
 
 	caplinFcuPath := path.Join(dirs.Tmp, "caplin-forkchoice")
 	os.RemoveAll(caplinFcuPath)
@@ -248,7 +250,7 @@ func RunCaplinPhase1(ctx context.Context, engine execution_client.ExecutionEngin
 	statesReader := historical_states_reader.NewHistoricalStatesReader(beaconConfig, rcsn, vTables, genesisState)
 	validatorParameters := validator_params.NewValidatorParams()
 	if cfg.Active {
-		apiHandler := handler.NewApiHandler(logger, genesisConfig, beaconConfig, indexDB, forkChoice, pool, rcsn, syncedDataManager, statesReader, sentinel, params.GitTag, &cfg, emitters, blobStorage, csn, validatorParameters)
+		apiHandler := handler.NewApiHandler(logger, genesisConfig, beaconConfig, indexDB, forkChoice, pool, rcsn, syncedDataManager, statesReader, sentinel, params.GitTag, &cfg, emitters, blobStorage, csn, validatorParameters, attestationProducer)
 		go beacon.ListenAndServe(&beacon.LayeredBeaconHandler{
 			ArchiveApi: apiHandler,
 		}, cfg)
@@ -257,7 +259,7 @@ func RunCaplinPhase1(ctx context.Context, engine execution_client.ExecutionEngin
 
 	forkChoice.StartJobsRTT(ctx)
 
-	stageCfg := stages.ClStagesCfg(beaconRpc, antiq, genesisConfig, beaconConfig, state, engine, gossipManager, forkChoice, indexDB, csn, rcsn, dirs.Tmp, dbConfig, backfilling, blobBackfilling, syncedDataManager, emitters, gossipSource, blobStorage)
+	stageCfg := stages.ClStagesCfg(beaconRpc, antiq, genesisConfig, beaconConfig, state, engine, gossipManager, forkChoice, indexDB, csn, rcsn, dirs.Tmp, dbConfig, backfilling, blobBackfilling, syncedDataManager, emitters, gossipSource, blobStorage, attestationProducer)
 	sync := stages.ConsensusClStages(ctx, stageCfg)
 
 	logger.Info("[Caplin] starting clstages loop")


### PR DESCRIPTION
# Caplin: Attestation Production Design

When we are required to produce an attestation data object. we first asses 2 things:

* What epoch is it from?
* Is it from a future epoch?
* Is it from a past epoch?

This attestationData object changes only within different epochs, it is extremely cheap to produce `AttestationData` for the current epoch, but extremely expensive for past and future epochs.

### Current Epoch case

```go
return solid.NewAttestionDataFromParameters(
		slot,                                  // slot requested
		committeeIndex,                        // committee_index request
		headBlockRoot,                         // current head block root
		baseState.CurrentJustifiedCheckpoint(),// current justified checkpoint
		solid.NewCheckpointFromParameters(     // finalization vote
			targetRoot,
			targetEpoch,
		),
	), nil
```

This works in 90 microseconds on an M1 machine so no problem here.

### Past Epoch case

There is no past epoch algorithm for attestation production, what we do instead is that we keep previously compute `AttestationData` in an internal cache so that we can just reuse the already computed ones.

### Future Epoch case

Unfortunately, there is no workaround here :(, we just simulate the next epoch which takes 500ms in case we need to build `AttestationData`s preemptively.
