### PR TITLE
Fix LogIndex Prune

### DIFF
--- a/eth/stagedsync/stage_log_index_test.go
+++ b/eth/stagedsync/stage_log_index_test.go
@@ -135,7 +135,7 @@ func TestPruneLogIndex(t *testing.T) {
 	require.NoError(err)
 
 	// Mode test
-	err = pruneLogIndex("", tx, tmpDir, 50, ctx, logger, nil)
+	err = pruneLogIndex("", tx, tmpDir, 0, 50, ctx, logger, nil)
 	require.NoError(err)
 
 	{
@@ -175,7 +175,7 @@ func TestUnwindLogIndex(t *testing.T) {
 	require.NoError(err)
 
 	// Mode test
-	err = pruneLogIndex("", tx, tmpDir, 50, ctx, logger, nil)
+	err = pruneLogIndex("", tx, tmpDir, 0, 50, ctx, logger, nil)
 	require.NoError(err)
 
 	// Unwind test


### PR DESCRIPTION
Earlier assumption was that `PruneLogIndex` would only have to deal with block numbers after the last prune. So it could work with `tx.cursor.First()`. Now, after prune hack, `kv.TransactionLog` contains older logs for `noPruneContracts`, so, it must seek to the point of last prune progress.

Without this, for every update of head block, the stages would run incrementally, but `LogIndex Prune` would run from the beginning of `TransactionLog` table, spending 1-2 hours.