### PR TITLE
p2p/sentry: status data provider refactoring

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -1613,16 +1613,12 @@ func newSync(ctx context.Context, db kv.RwDB, miningConfig *params.MiningConfig,
 	blockReader, blockWriter := blocksIO(db, logger)
 	engine, heimdallClient := initConsensusEngine(ctx, chainConfig, cfg.Dirs.DataDir, db, blockReader, logger)
 
-	statusDataProvider, err := sentry.NewStatusDataProvider(
-		ctx,
+	statusDataProvider := sentry.NewStatusDataProvider(
 		db,
 		chainConfig,
 		genesisBlock,
 		chainConfig.ChainID.Uint64(),
 	)
-	if err != nil {
-		panic(err)
-	}
 
 	maxBlockBroadcastPeers := func(header *types.Header) uint { return 0 }
 

--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -47,6 +47,7 @@ import (
 	"github.com/ledgerwatch/erigon/migrations"
 	"github.com/ledgerwatch/erigon/node/nodecfg"
 	"github.com/ledgerwatch/erigon/p2p"
+	"github.com/ledgerwatch/erigon/p2p/sentry"
 	"github.com/ledgerwatch/erigon/p2p/sentry/sentry_multi_client"
 	"github.com/ledgerwatch/erigon/params"
 	"github.com/ledgerwatch/erigon/polygon/bor"
@@ -1601,7 +1602,7 @@ func newSync(ctx context.Context, db kv.RwDB, miningConfig *params.MiningConfig,
 	cfg.Prune = pm
 	cfg.BatchSize = batchSize
 	cfg.DeprecatedTxPool.Disable = true
-	cfg.Genesis = core.GenesisBlockByChainName(chain)
+	cfg.Genesis = genesis
 	if miningConfig != nil {
 		cfg.Miner = *miningConfig
 	}
@@ -1612,20 +1613,28 @@ func newSync(ctx context.Context, db kv.RwDB, miningConfig *params.MiningConfig,
 	blockReader, blockWriter := blocksIO(db, logger)
 	engine, heimdallClient := initConsensusEngine(ctx, chainConfig, cfg.Dirs.DataDir, db, blockReader, logger)
 
+	statusDataProvider, err := sentry.NewStatusDataProvider(
+		ctx,
+		db,
+		chainConfig,
+		genesisBlock,
+		chainConfig.ChainID.Uint64(),
+	)
+	if err != nil {
+		panic(err)
+	}
+
 	maxBlockBroadcastPeers := func(header *types.Header) uint { return 0 }
 
 	sentryControlServer, err := sentry_multi_client.NewMultiClient(
 		db,
-		"",
 		chainConfig,
-		genesisBlock.Hash(),
-		genesisBlock.Time(),
 		engine,
-		1,
 		nil,
 		ethconfig.Defaults.Sync,
 		blockReader,
 		blockBufferSize,
+		statusDataProvider,
 		false,
 		maxBlockBroadcastPeers,
 		logger,

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -549,6 +549,17 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 	}
 	backend.forkValidator = engine_helpers.NewForkValidator(ctx, currentBlockNumber, inMemoryExecution, tmpdir, backend.blockReader)
 
+	statusDataProvider, err := sentry.NewStatusDataProvider(
+		ctx,
+		chainKv,
+		chainConfig,
+		genesis,
+		backend.config.NetworkID,
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	// limit "new block" broadcasts to at most 10 random peers at time
 	maxBlockBroadcastPeers := func(header *types.Header) uint { return 10 }
 
@@ -571,16 +582,13 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 
 	backend.sentriesClient, err = sentry_multi_client.NewMultiClient(
 		chainKv,
-		stack.Config().NodeName(),
 		chainConfig,
-		genesis.Hash(),
-		genesis.Time(),
 		backend.engine,
-		backend.config.NetworkID,
 		sentries,
 		config.Sync,
 		blockReader,
 		blockBufferSize,
+		statusDataProvider,
 		stack.Config().SentryLogPeerInfo,
 		maxBlockBroadcastPeers,
 		logger,
@@ -773,7 +781,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 	backend.syncPruneOrder = stagedsync.DefaultPruneOrder
 	backend.stagedSync = stagedsync.New(config.Sync, backend.syncStages, backend.syncUnwindOrder, backend.syncPruneOrder, logger)
 
-	hook := stages2.NewHook(backend.sentryCtx, backend.chainDB, backend.notifications, backend.stagedSync, backend.blockReader, backend.chainConfig, backend.logger, backend.sentriesClient.UpdateHead)
+	hook := stages2.NewHook(backend.sentryCtx, backend.chainDB, backend.notifications, backend.stagedSync, backend.blockReader, backend.chainConfig, backend.logger, backend.sentriesClient.SetStatus)
 
 	if !config.Sync.UseSnapshots && backend.downloaderClient != nil {
 		for _, p := range snaptype.AllTypes {
@@ -1356,7 +1364,7 @@ func (s *Ethereum) Start() error {
 	s.sentriesClient.StartStreamLoops(s.sentryCtx)
 	time.Sleep(10 * time.Millisecond) // just to reduce logs order confusion
 
-	hook := stages2.NewHook(s.sentryCtx, s.chainDB, s.notifications, s.stagedSync, s.blockReader, s.chainConfig, s.logger, s.sentriesClient.UpdateHead)
+	hook := stages2.NewHook(s.sentryCtx, s.chainDB, s.notifications, s.stagedSync, s.blockReader, s.chainConfig, s.logger, s.sentriesClient.SetStatus)
 
 	currentTDProvider := func() *big.Int {
 		currentTD, err := readCurrentTotalDifficulty(s.sentryCtx, s.chainDB, s.blockReader)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -549,16 +549,12 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 	}
 	backend.forkValidator = engine_helpers.NewForkValidator(ctx, currentBlockNumber, inMemoryExecution, tmpdir, backend.blockReader)
 
-	statusDataProvider, err := sentry.NewStatusDataProvider(
-		ctx,
+	statusDataProvider := sentry.NewStatusDataProvider(
 		chainKv,
 		chainConfig,
 		genesis,
 		backend.config.NetworkID,
 	)
-	if err != nil {
-		return nil, err
-	}
 
 	// limit "new block" broadcasts to at most 10 random peers at time
 	maxBlockBroadcastPeers := func(header *types.Header) uint { return 10 }

--- a/p2p/sentry/sentry_multi_client/broadcast.go
+++ b/p2p/sentry/sentry_multi_client/broadcast.go
@@ -7,9 +7,10 @@ import (
 	"strings"
 	"syscall"
 
-	proto_sentry "github.com/ledgerwatch/erigon-lib/gointerfaces/sentry"
 	"github.com/ledgerwatch/log/v3"
 	"google.golang.org/grpc"
+
+	proto_sentry "github.com/ledgerwatch/erigon-lib/gointerfaces/sentry"
 
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/eth/protocols/eth"
@@ -19,9 +20,6 @@ import (
 )
 
 func (cs *MultiClient) PropagateNewBlockHashes(ctx context.Context, announces []headerdownload.Announce) {
-	cs.lock.RLock()
-	defer cs.lock.RUnlock()
-
 	typedRequest := make(eth.NewBlockHashesPacket, len(announces))
 	for i := range announces {
 		typedRequest[i].Hash = announces[i].Hash
@@ -52,9 +50,6 @@ func (cs *MultiClient) PropagateNewBlockHashes(ctx context.Context, announces []
 }
 
 func (cs *MultiClient) BroadcastNewBlock(ctx context.Context, header *types.Header, body *types.RawBody, td *big.Int) {
-	cs.lock.RLock()
-	defer cs.lock.RUnlock()
-
 	block, err := types.RawBlock{Header: header, Body: body}.AsBlock()
 
 	if err != nil {

--- a/p2p/sentry/sentry_multi_client/sentry_api.go
+++ b/p2p/sentry/sentry_multi_client/sentry_api.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"math/rand"
 
-	"github.com/holiman/uint256"
+	"google.golang.org/grpc"
+
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/gointerfaces"
 	proto_sentry "github.com/ledgerwatch/erigon-lib/gointerfaces/sentry"
-	"google.golang.org/grpc"
 
 	"github.com/ledgerwatch/erigon/eth/protocols/eth"
 	"github.com/ledgerwatch/erigon/p2p/sentry"
@@ -19,14 +19,13 @@ import (
 
 // Methods of sentry called by Core
 
-func (cs *MultiClient) UpdateHead(ctx context.Context, height, time uint64, hash libcommon.Hash, td *uint256.Int) {
-	cs.lock.Lock()
-	defer cs.lock.Unlock()
-	cs.headHeight = height
-	cs.headTime = time
-	cs.headHash = hash
-	cs.headTd = td
-	statusMsg := cs.makeStatusData()
+func (cs *MultiClient) SetStatus(ctx context.Context) {
+	statusMsg, err := cs.statusDataProvider.RefreshStatusData(ctx)
+	if err != nil {
+		cs.logger.Error("MultiClient.SetStatus: RefreshStatusData error", "err", err)
+		return
+	}
+
 	for _, sentry := range cs.sentries {
 		if !sentry.Ready() {
 			continue

--- a/p2p/sentry/sentry_multi_client/sentry_api.go
+++ b/p2p/sentry/sentry_multi_client/sentry_api.go
@@ -20,9 +20,9 @@ import (
 // Methods of sentry called by Core
 
 func (cs *MultiClient) SetStatus(ctx context.Context) {
-	statusMsg, err := cs.statusDataProvider.RefreshStatusData(ctx)
+	statusMsg, err := cs.statusDataProvider.GetStatusData(ctx)
 	if err != nil {
-		cs.logger.Error("MultiClient.SetStatus: RefreshStatusData error", "err", err)
+		cs.logger.Error("MultiClient.SetStatus: GetStatusData error", "err", err)
 		return
 	}
 

--- a/p2p/sentry/sentry_multi_client/sentry_multi_client.go
+++ b/p2p/sentry/sentry_multi_client/sentry_multi_client.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/c2h5oh/datasize"
-	"github.com/holiman/uint256"
 	"github.com/ledgerwatch/log/v3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
@@ -21,10 +20,8 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/ledgerwatch/erigon-lib/chain"
-	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/common/dbg"
 	"github.com/ledgerwatch/erigon-lib/direct"
-	"github.com/ledgerwatch/erigon-lib/gointerfaces"
 	"github.com/ledgerwatch/erigon-lib/gointerfaces/grpcutil"
 	proto_sentry "github.com/ledgerwatch/erigon-lib/gointerfaces/sentry"
 	proto_types "github.com/ledgerwatch/erigon-lib/gointerfaces/types"
@@ -32,7 +29,6 @@ import (
 	"github.com/ledgerwatch/erigon-lib/kv/kvcfg"
 
 	"github.com/ledgerwatch/erigon/consensus"
-	"github.com/ledgerwatch/erigon/core/forkid"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/eth/ethconfig"
 	"github.com/ledgerwatch/erigon/eth/protocols/eth"
@@ -46,7 +42,7 @@ import (
 type (
 	SentryMessageStream        grpc.ClientStream
 	SentryMessageStreamFactory func(context.Context, direct.SentryClient) (SentryMessageStream, error)
-	StatusDataFactory          func() *proto_sentry.StatusData
+	StatusDataFactory          func(context.Context) (*proto_sentry.StatusData, error)
 	MessageFactory[T any]      func() T
 	MessageHandler[T any]      func(context.Context, T, direct.SentryClient) error
 )
@@ -157,7 +153,15 @@ func SentryReconnectAndPumpStreamLoop[TMessage interface{}](
 			continue
 		}
 
-		if _, err := sentry.SetStatus(ctx, statusDataFactory()); err != nil {
+		statusData, err := statusDataFactory(ctx)
+		if err != nil {
+			logger.Error("SentryReconnectAndPumpStreamLoop: statusDataFactory error", "stream", streamName, "err", err)
+			if statusData == nil {
+				panic("statusData is nil")
+			}
+		}
+
+		if _, err := sentry.SetStatus(ctx, statusData); err != nil {
 			if errors.Is(err, context.Canceled) {
 				continue
 			}
@@ -255,24 +259,15 @@ func pumpStreamLoop[TMessage interface{}](
 // MultiClient - does handle request/response/subscriptions to multiple sentries
 // each sentry may support same or different p2p protocol
 type MultiClient struct {
-	lock                              sync.RWMutex
 	Hd                                *headerdownload.HeaderDownload
 	Bd                                *bodydownload.BodyDownload
 	IsMock                            bool
-	nodeName                          string
 	sentries                          []direct.SentryClient
-	headHeight                        uint64
-	headTime                          uint64
-	headHash                          libcommon.Hash
-	headTd                            *uint256.Int
 	ChainConfig                       *chain.Config
-	heightForks                       []uint64
-	timeForks                         []uint64
-	genesisHash                       libcommon.Hash
-	networkId                         uint64
 	db                                kv.RwDB
 	Engine                            consensus.Engine
 	blockReader                       services.FullBlockReader
+	statusDataProvider                *sentry2.StatusDataProvider
 	logPeerInfo                       bool
 	sendHeaderRequestsToMultiplePeers bool
 	maxBlockBroadcastPeers            func(*types.Header) uint
@@ -283,22 +278,18 @@ type MultiClient struct {
 
 func NewMultiClient(
 	db kv.RwDB,
-	nodeName string,
 	chainConfig *chain.Config,
-	genesisHash libcommon.Hash,
-	genesisTime uint64,
 	engine consensus.Engine,
-	networkID uint64,
 	sentries []direct.SentryClient,
 	syncCfg ethconfig.Sync,
 	blockReader services.FullBlockReader,
 	blockBufferSize int,
+	statusDataProvider *sentry2.StatusDataProvider,
 	logPeerInfo bool,
 	maxBlockBroadcastPeers func(*types.Header) uint,
 	logger log.Logger,
 ) (*MultiClient, error) {
-	historyV3 := kvcfg.HistoryV3.FromDB(db)
-
+	// header downloader
 	hd := headerdownload.NewHeaderDownload(
 		512,       /* anchorLimit */
 		1024*1024, /* linkLimit */
@@ -309,36 +300,36 @@ func NewMultiClient(
 	if chainConfig.TerminalTotalDifficultyPassed {
 		hd.SetPOSSync(true)
 	}
-
 	if err := hd.RecoverFromDb(db); err != nil {
 		return nil, fmt.Errorf("recovery from DB failed: %w", err)
 	}
+
+	// body downloader
 	bd := bodydownload.NewBodyDownload(engine, blockBufferSize, int(syncCfg.BodyCacheLimit), blockReader, logger)
+	if err := db.View(context.Background(), func(tx kv.Tx) error {
+		_, _, _, _, err := bd.UpdateFromDb(tx)
+		return err
+	}); err != nil {
+		return nil, err
+	}
 
 	cs := &MultiClient{
-		nodeName:                          nodeName,
 		Hd:                                hd,
 		Bd:                                bd,
 		sentries:                          sentries,
+		ChainConfig:                       chainConfig,
 		db:                                db,
 		Engine:                            engine,
 		blockReader:                       blockReader,
+		statusDataProvider:                statusDataProvider,
 		logPeerInfo:                       logPeerInfo,
-		historyV3:                         historyV3,
 		sendHeaderRequestsToMultiplePeers: chainConfig.TerminalTotalDifficultyPassed,
 		maxBlockBroadcastPeers:            maxBlockBroadcastPeers,
+		historyV3:                         kvcfg.HistoryV3.FromDB(db),
 		logger:                            logger,
 	}
-	cs.ChainConfig = chainConfig
-	cs.heightForks, cs.timeForks = forkid.GatherForks(cs.ChainConfig, genesisTime)
-	cs.genesisHash = genesisHash
-	cs.networkId = networkID
-	var err error
-	err = db.View(context.Background(), func(tx kv.Tx) error {
-		cs.headHeight, cs.headTime, cs.headHash, cs.headTd, err = cs.Bd.UpdateFromDb(tx)
-		return err
-	})
-	return cs, err
+
+	return cs, nil
 }
 
 func (cs *MultiClient) Sentries() []direct.SentryClient { return cs.sentries }
@@ -786,20 +777,8 @@ func (cs *MultiClient) HandlePeerEvent(ctx context.Context, event *proto_sentry.
 	return nil
 }
 
-func (cs *MultiClient) makeStatusData() *proto_sentry.StatusData {
-	s := cs
-	return &proto_sentry.StatusData{
-		NetworkId:       s.networkId,
-		TotalDifficulty: gointerfaces.ConvertUint256IntToH256(s.headTd),
-		BestHash:        gointerfaces.ConvertHashToH256(s.headHash),
-		MaxBlockHeight:  s.headHeight,
-		MaxBlockTime:    s.headTime,
-		ForkData: &proto_sentry.Forks{
-			Genesis:     gointerfaces.ConvertHashToH256(s.genesisHash),
-			HeightForks: s.heightForks,
-			TimeForks:   s.timeForks,
-		},
-	}
+func (cs *MultiClient) makeStatusData(ctx context.Context) (*proto_sentry.StatusData, error) {
+	return cs.statusDataProvider.RefreshStatusData(ctx)
 }
 
 func GrpcClient(ctx context.Context, sentryAddr string) (*direct.SentryClientRemote, error) {

--- a/p2p/sentry/sentry_multi_client/sentry_multi_client.go
+++ b/p2p/sentry/sentry_multi_client/sentry_multi_client.go
@@ -156,9 +156,8 @@ func SentryReconnectAndPumpStreamLoop[TMessage interface{}](
 		statusData, err := statusDataFactory(ctx)
 		if err != nil {
 			logger.Error("SentryReconnectAndPumpStreamLoop: statusDataFactory error", "stream", streamName, "err", err)
-			if statusData == nil {
-				panic("statusData is nil")
-			}
+			time.Sleep(time.Second)
+			continue
 		}
 
 		if _, err := sentry.SetStatus(ctx, statusData); err != nil {
@@ -778,7 +777,7 @@ func (cs *MultiClient) HandlePeerEvent(ctx context.Context, event *proto_sentry.
 }
 
 func (cs *MultiClient) makeStatusData(ctx context.Context) (*proto_sentry.StatusData, error) {
-	return cs.statusDataProvider.RefreshStatusData(ctx)
+	return cs.statusDataProvider.GetStatusData(ctx)
 }
 
 func GrpcClient(ctx context.Context, sentryAddr string) (*direct.SentryClientRemote, error) {

--- a/p2p/sentry/status_data_provider.go
+++ b/p2p/sentry/status_data_provider.go
@@ -1,0 +1,143 @@
+package sentry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"sync"
+
+	"github.com/holiman/uint256"
+
+	"github.com/ledgerwatch/erigon-lib/chain"
+	libcommon "github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/gointerfaces"
+	proto_sentry "github.com/ledgerwatch/erigon-lib/gointerfaces/sentry"
+	"github.com/ledgerwatch/erigon-lib/kv"
+	"github.com/ledgerwatch/erigon/core/forkid"
+	"github.com/ledgerwatch/erigon/core/rawdb"
+	"github.com/ledgerwatch/erigon/core/types"
+)
+
+type ChainHead struct {
+	HeadHeight uint64
+	HeadTime   uint64
+	HeadHash   libcommon.Hash
+	HeadTd     *uint256.Int
+}
+
+type StatusDataProvider struct {
+	ChainHead
+
+	db kv.RoDB
+
+	networkId   uint64
+	genesisHash libcommon.Hash
+	heightForks []uint64
+	timeForks   []uint64
+
+	lock sync.RWMutex
+}
+
+func NewStatusDataProvider(
+	ctx context.Context,
+	db kv.RoDB,
+	chainConfig *chain.Config,
+	genesis *types.Block,
+	networkId uint64,
+) (*StatusDataProvider, error) {
+	chainHead, err := ReadChainHead(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &StatusDataProvider{
+		ChainHead:   chainHead,
+		db:          db,
+		networkId:   networkId,
+		genesisHash: genesis.Hash(),
+	}
+
+	s.heightForks, s.timeForks = forkid.GatherForks(chainConfig, genesis.Time())
+
+	return s, nil
+}
+
+func (s *StatusDataProvider) MakeStatusData() *proto_sentry.StatusData {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	return &proto_sentry.StatusData{
+		NetworkId:       s.networkId,
+		TotalDifficulty: gointerfaces.ConvertUint256IntToH256(s.HeadTd),
+		BestHash:        gointerfaces.ConvertHashToH256(s.HeadHash),
+		MaxBlockHeight:  s.HeadHeight,
+		MaxBlockTime:    s.HeadTime,
+		ForkData: &proto_sentry.Forks{
+			Genesis:     gointerfaces.ConvertHashToH256(s.genesisHash),
+			HeightForks: s.heightForks,
+			TimeForks:   s.timeForks,
+		},
+	}
+}
+
+func (s *StatusDataProvider) setHead(chainHead ChainHead) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	s.ChainHead = chainHead
+}
+
+func (s *StatusDataProvider) RefreshHead(ctx context.Context) error {
+	chainHead, err := ReadChainHead(ctx, s.db)
+	if err != nil {
+		return err
+	}
+	s.setHead(chainHead)
+	return nil
+}
+
+func (s *StatusDataProvider) RefreshStatusData(ctx context.Context) (*proto_sentry.StatusData, error) {
+	err := s.RefreshHead(ctx)
+	return s.MakeStatusData(), err
+}
+
+func ReadChainHeadWithTx(tx kv.Tx) (ChainHead, error) {
+	header := rawdb.ReadCurrentHeader(tx)
+	if header == nil {
+		return ChainHead{}, errors.New("ReadChainHead: ReadCurrentHeader error")
+	}
+
+	height := header.Number.Uint64()
+	hash := header.Hash()
+
+	var time uint64
+	if header != nil {
+		time = header.Time
+	}
+
+	td, err := rawdb.ReadTd(tx, hash, height)
+	if err != nil {
+		return ChainHead{}, fmt.Errorf("ReadChainHead: ReadTd error at height %d and hash %s: %w", height, hash, err)
+	}
+	if td == nil {
+		td = new(big.Int)
+	}
+	td256 := new(uint256.Int)
+	overflow := td256.SetFromBig(td)
+	if overflow {
+		return ChainHead{}, fmt.Errorf("ReadChainHead: total difficulty higher than 2^256-1")
+	}
+
+	return ChainHead{height, time, hash, td256}, nil
+}
+
+func ReadChainHead(ctx context.Context, db kv.RoDB) (ChainHead, error) {
+	var head ChainHead
+	var err error
+	err = db.View(ctx, func(tx kv.Tx) error {
+		head, err = ReadChainHeadWithTx(tx)
+		return err
+	})
+	return head, err
+}

--- a/polygon/p2p/message_listener.go
+++ b/polygon/p2p/message_listener.go
@@ -34,14 +34,25 @@ type MessageListener interface {
 	RegisterPeerEventObserver(observer MessageObserver[*sentry.PeerEvent]) UnregisterFunc
 }
 
-func NewMessageListener(logger log.Logger, sentryClient direct.SentryClient, peerPenalizer PeerPenalizer) MessageListener {
-	return newMessageListener(logger, sentryClient, peerPenalizer)
+func NewMessageListener(
+	logger log.Logger,
+	sentryClient direct.SentryClient,
+	statusDataFactory sentrymulticlient.StatusDataFactory,
+	peerPenalizer PeerPenalizer,
+) MessageListener {
+	return newMessageListener(logger, sentryClient, statusDataFactory, peerPenalizer)
 }
 
-func newMessageListener(logger log.Logger, sentryClient direct.SentryClient, peerPenalizer PeerPenalizer) *messageListener {
+func newMessageListener(
+	logger log.Logger,
+	sentryClient direct.SentryClient,
+	statusDataFactory sentrymulticlient.StatusDataFactory,
+	peerPenalizer PeerPenalizer,
+) *messageListener {
 	return &messageListener{
 		logger:                  logger,
 		sentryClient:            sentryClient,
+		statusDataFactory:       statusDataFactory,
 		peerPenalizer:           peerPenalizer,
 		newBlockObservers:       map[uint64]MessageObserver[*DecodedInboundMessage[*eth.NewBlockPacket]]{},
 		newBlockHashesObservers: map[uint64]MessageObserver[*DecodedInboundMessage[*eth.NewBlockHashesPacket]]{},
@@ -56,6 +67,7 @@ type messageListener struct {
 	observerIdSequence      uint64
 	logger                  log.Logger
 	sentryClient            direct.SentryClient
+	statusDataFactory       sentrymulticlient.StatusDataFactory
 	peerPenalizer           PeerPenalizer
 	observersMu             sync.Mutex
 	newBlockObservers       map[uint64]MessageObserver[*DecodedInboundMessage[*eth.NewBlockPacket]]
@@ -160,14 +172,6 @@ func (ml *messageListener) notifyPeerEventObservers(peerEvent *sentry.PeerEvent)
 	return nil
 }
 
-func (ml *messageListener) statusDataFactory() sentrymulticlient.StatusDataFactory {
-	return func() *sentry.StatusData {
-		// TODO add a "status data component" that message listener will use as a dependency to fetch status data
-		//      "status data component" will be responsible for providing a mechanism to provide up-to-date status data
-		return &sentry.StatusData{}
-	}
-}
-
 func (ml *messageListener) nextObserverId() uint64 {
 	id := ml.observerIdSequence
 	ml.observerIdSequence++
@@ -212,7 +216,7 @@ func streamMessages[TMessage any](
 	sentrymulticlient.SentryReconnectAndPumpStreamLoop(
 		ctx,
 		ml.sentryClient,
-		ml.statusDataFactory(),
+		ml.statusDataFactory,
 		name,
 		streamFactory,
 		func() *TMessage { return new(TMessage) },

--- a/polygon/p2p/message_listener_test.go
+++ b/polygon/p2p/message_listener_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ledgerwatch/erigon-lib/gointerfaces/sentry"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/eth/protocols/eth"
+	sentrymulticlient "github.com/ledgerwatch/erigon/p2p/sentry/sentry_multi_client"
 	"github.com/ledgerwatch/erigon/rlp"
 	"github.com/ledgerwatch/erigon/turbo/testlog"
 )
@@ -218,13 +219,16 @@ func newMessageListenerTest(t *testing.T) *messageListenerTest {
 	inboundMessagesStream := make(chan *delayedMessage[*sentry.InboundMessage])
 	peerEventsStream := make(chan *delayedMessage[*sentry.PeerEvent])
 	sentryClient := direct.NewMockSentryClient(ctrl)
+	statusDataFactory := sentrymulticlient.StatusDataFactory(func(ctx context.Context) (*sentry.StatusData, error) {
+		return &sentry.StatusData{}, nil
+	})
 	return &messageListenerTest{
 		ctx:                   ctx,
 		ctxCancel:             cancel,
 		t:                     t,
 		logger:                logger,
 		sentryClient:          sentryClient,
-		messageListener:       newMessageListener(logger, sentryClient, NewPeerPenalizer(sentryClient)),
+		messageListener:       newMessageListener(logger, sentryClient, statusDataFactory, NewPeerPenalizer(sentryClient)),
 		inboundMessagesStream: inboundMessagesStream,
 		peerEventsStream:      peerEventsStream,
 	}

--- a/polygon/p2p/service.go
+++ b/polygon/p2p/service.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ledgerwatch/log/v3"
 
 	"github.com/ledgerwatch/erigon-lib/direct"
+	sentrymulticlient "github.com/ledgerwatch/erigon/p2p/sentry/sentry_multi_client"
 )
 
 //go:generate mockgen -source=./service.go -destination=./service_mock.go -package=p2p . Service
@@ -18,14 +19,19 @@ type Service interface {
 	MaxPeers() int
 }
 
-func NewService(maxPeers int, logger log.Logger, sentryClient direct.SentryClient) Service {
+func NewService(
+	maxPeers int,
+	logger log.Logger,
+	sentryClient direct.SentryClient,
+	statusDataFactory sentrymulticlient.StatusDataFactory,
+) Service {
 	fetcherConfig := FetcherConfig{
 		responseTimeout: 5 * time.Second,
 		retryBackOff:    10 * time.Second,
 		maxRetries:      2,
 	}
 
-	return newService(maxPeers, fetcherConfig, logger, sentryClient, rand.Uint64)
+	return newService(maxPeers, fetcherConfig, logger, sentryClient, statusDataFactory, rand.Uint64)
 }
 
 func newService(
@@ -33,11 +39,12 @@ func newService(
 	fetcherConfig FetcherConfig,
 	logger log.Logger,
 	sentryClient direct.SentryClient,
+	statusDataFactory sentrymulticlient.StatusDataFactory,
 	requestIdGenerator RequestIdGenerator,
 ) *service {
 	peerTracker := NewPeerTracker()
 	peerPenalizer := NewPeerPenalizer(sentryClient)
-	messageListener := NewMessageListener(logger, sentryClient, peerPenalizer)
+	messageListener := NewMessageListener(logger, sentryClient, statusDataFactory, peerPenalizer)
 	messageListener.RegisterPeerEventObserver(NewPeerEventObserver(peerTracker))
 	messageSender := NewMessageSender(sentryClient)
 	fetcher := NewFetcher(fetcherConfig, logger, messageListener, messageSender, requestIdGenerator)

--- a/polygon/sync/service.go
+++ b/polygon/sync/service.go
@@ -44,7 +44,7 @@ func NewService(
 	storage := NewStorage(execution, maxPeers)
 	headersVerifier := VerifyAccumulatedHeaders
 	blocksVerifier := VerifyBlocks
-	p2pService := p2p.NewService(maxPeers, logger, sentryClient, statusDataProvider.RefreshStatusData)
+	p2pService := p2p.NewService(maxPeers, logger, sentryClient, statusDataProvider.GetStatusData)
 	heimdallClient := heimdall.NewHeimdallClient(heimdallURL, logger)
 	heimdallService := heimdall.NewHeimdallNoStore(heimdallClient, logger)
 	blockDownloader := NewBlockDownloader(

--- a/polygon/sync/service.go
+++ b/polygon/sync/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ledgerwatch/erigon/cl/phase1/execution_client"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/eth/stagedsync"
+	"github.com/ledgerwatch/erigon/p2p/sentry"
 	"github.com/ledgerwatch/erigon/polygon/bor/borcfg"
 	"github.com/ledgerwatch/erigon/polygon/heimdall"
 	"github.com/ledgerwatch/erigon/polygon/p2p"
@@ -36,13 +37,14 @@ func NewService(
 	heimdallURL string,
 	engine execution_client.ExecutionEngine,
 	sentryClient direct.SentryClient,
+	statusDataProvider *sentry.StatusDataProvider,
 	logger log.Logger,
 ) Service {
 	execution := NewExecutionClient(engine)
 	storage := NewStorage(execution, maxPeers)
 	headersVerifier := VerifyAccumulatedHeaders
 	blocksVerifier := VerifyBlocks
-	p2pService := p2p.NewService(maxPeers, logger, sentryClient)
+	p2pService := p2p.NewService(maxPeers, logger, sentryClient, statusDataProvider.RefreshStatusData)
 	heimdallClient := heimdall.NewHeimdallClient(heimdallURL, logger)
 	heimdallService := heimdall.NewHeimdallNoStore(heimdallClient, logger)
 	blockDownloader := NewBlockDownloader(

--- a/turbo/app/import_cmd.go
+++ b/turbo/app/import_cmd.go
@@ -224,7 +224,7 @@ func InsertChain(ethereum *eth.Ethereum, chain *core.ChainPack, logger log.Logge
 	sentryControlServer.Hd.MarkAllVerified()
 	blockReader, _ := ethereum.BlockIO()
 
-	hook := stages.NewHook(ethereum.SentryCtx(), ethereum.ChainDB(), ethereum.Notifications(), ethereum.StagedSync(), blockReader, ethereum.ChainConfig(), logger, sentryControlServer.UpdateHead)
+	hook := stages.NewHook(ethereum.SentryCtx(), ethereum.ChainDB(), ethereum.Notifications(), ethereum.StagedSync(), blockReader, ethereum.ChainConfig(), logger, sentryControlServer.SetStatus)
 	err := stages.StageLoopIteration(ethereum.SentryCtx(), ethereum.ChainDB(), wrap.TxContainer{}, ethereum.StagedSync(), initialCycle, logger, blockReader, hook, false)
 	if err != nil {
 		return err

--- a/turbo/jsonrpc/eth_subscribe_test.go
+++ b/turbo/jsonrpc/eth_subscribe_test.go
@@ -5,11 +5,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/direct"
 	"github.com/ledgerwatch/erigon-lib/gointerfaces/sentry"
 	"github.com/ledgerwatch/erigon-lib/wrap"
-	"github.com/stretchr/testify/require"
+
+	"github.com/ledgerwatch/log/v3"
 
 	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/rpcservices"
 	"github.com/ledgerwatch/erigon/core"
@@ -20,7 +23,6 @@ import (
 	"github.com/ledgerwatch/erigon/turbo/rpchelper"
 	"github.com/ledgerwatch/erigon/turbo/stages"
 	"github.com/ledgerwatch/erigon/turbo/stages/mock"
-	"github.com/ledgerwatch/log/v3"
 )
 
 func TestEthSubscribe(t *testing.T) {
@@ -55,7 +57,7 @@ func TestEthSubscribe(t *testing.T) {
 	initialCycle := mock.MockInsertAsInitialCycle
 	highestSeenHeader := chain.TopBlock.NumberU64()
 
-	hook := stages.NewHook(m.Ctx, m.DB, m.Notifications, m.Sync, m.BlockReader, m.ChainConfig, m.Log, m.UpdateHead)
+	hook := stages.NewHook(m.Ctx, m.DB, m.Notifications, m.Sync, m.BlockReader, m.ChainConfig, m.Log, nil)
 	if err := stages.StageLoopIteration(m.Ctx, m.DB, wrap.TxContainer{}, m.Sync, initialCycle, logger, m.BlockReader, hook, false); err != nil {
 		t.Fatal(err)
 	}

--- a/turbo/stages/bodydownload/body_algos.go
+++ b/turbo/stages/bodydownload/body_algos.go
@@ -65,7 +65,7 @@ func (bd *BodyDownload) UpdateFromDb(db kv.Tx) (headHeight, headTime uint64, hea
 	headTime = 0
 	headHeader, err := bd.br.Header(context.Background(), db, headHash, headHeight)
 	if err != nil {
-		return 0, 0, libcommon.Hash{}, nil, fmt.Errorf("reading total difficulty for head height %d and hash %x: %d, %w", headHeight, headHash, headTd, err)
+		return 0, 0, libcommon.Hash{}, nil, fmt.Errorf("reading header for head height %d and hash %x: %d, %w", headHeight, headHash, headTd, err)
 	}
 	if headHeader != nil {
 		headTime = headHeader.Time

--- a/turbo/stages/mock/mock_sentry.go
+++ b/turbo/stages/mock/mock_sentry.go
@@ -51,6 +51,7 @@ import (
 	"github.com/ledgerwatch/erigon/eth/stagedsync/stages"
 	"github.com/ledgerwatch/erigon/ethdb/prune"
 	"github.com/ledgerwatch/erigon/p2p"
+	"github.com/ledgerwatch/erigon/p2p/sentry"
 	"github.com/ledgerwatch/erigon/p2p/sentry/sentry_multi_client"
 	"github.com/ledgerwatch/erigon/params"
 	"github.com/ledgerwatch/erigon/polygon/bor"
@@ -91,7 +92,6 @@ type MockSentry struct {
 	Genesis              *types.Block
 	SentryClient         direct.SentryClient
 	PeerId               *ptypes.H512
-	UpdateHead           func(Ctx context.Context, headHeight, headTime uint64, hash libcommon.Hash, td *uint256.Int)
 	streams              map[proto_sentry.MessageId][]proto_sentry.Sentry_MessagesServer
 	sentMessages         []*proto_sentry.OutboundMessageData
 	StreamWg             sync.WaitGroup
@@ -276,8 +276,6 @@ func MockWithEverything(tb testing.TB, gspec *types.Genesis, key *ecdsa.PrivateK
 			Accumulator:          shards.NewAccumulator(),
 			StateChangesConsumer: erigonGrpcServeer,
 		},
-		UpdateHead: func(Ctx context.Context, headHeight, headTime uint64, hash libcommon.Hash, td *uint256.Int) {
-		},
 		PeerId:         gointerfaces.ConvertHashToH512([64]byte{0x12, 0x34, 0x50}), // "12345"
 		BlockSnapshots: allSnapshots,
 		BlockReader:    freezeblocks.NewBlockReader(allSnapshots, allBorSnapshots),
@@ -366,21 +364,29 @@ func MockWithEverything(tb testing.TB, gspec *types.Genesis, key *ecdsa.PrivateK
 		return nil
 	}
 	forkValidator := engine_helpers.NewForkValidator(ctx, 1, inMemoryExecution, dirs.Tmp, mock.BlockReader)
-	networkID := uint64(1)
+
+	statusDataProvider, err := sentry.NewStatusDataProvider(
+		ctx,
+		db,
+		mock.ChainConfig,
+		mock.Genesis,
+		mock.ChainConfig.ChainID.Uint64(),
+	)
+	if err != nil {
+		panic(err)
+	}
+
 	maxBlockBroadcastPeers := func(header *types.Header) uint { return 0 }
 
 	mock.sentriesClient, err = sentry_multi_client.NewMultiClient(
 		mock.DB,
-		"mock",
 		mock.ChainConfig,
-		mock.Genesis.Hash(),
-		mock.Genesis.Time(),
 		mock.Engine,
-		networkID,
 		sentries,
 		cfg.Sync,
 		mock.BlockReader,
 		blockBufferSize,
+		statusDataProvider,
 		false,
 		maxBlockBroadcastPeers,
 		logger,
@@ -667,7 +673,7 @@ func (ms *MockSentry) insertPoWBlocks(chain *core.ChainPack) error {
 		ms.ReceiveWg.Add(1)
 	}
 	initialCycle := MockInsertAsInitialCycle
-	hook := stages2.NewHook(ms.Ctx, ms.DB, ms.Notifications, ms.Sync, ms.BlockReader, ms.ChainConfig, ms.Log, ms.UpdateHead)
+	hook := stages2.NewHook(ms.Ctx, ms.DB, ms.Notifications, ms.Sync, ms.BlockReader, ms.ChainConfig, ms.Log, nil)
 
 	if err = stages2.StageLoopIteration(ms.Ctx, ms.DB, wrap.TxContainer{}, ms.Sync, initialCycle, ms.Log, ms.BlockReader, hook, false); err != nil {
 		return err

--- a/turbo/stages/mock/mock_sentry.go
+++ b/turbo/stages/mock/mock_sentry.go
@@ -365,16 +365,12 @@ func MockWithEverything(tb testing.TB, gspec *types.Genesis, key *ecdsa.PrivateK
 	}
 	forkValidator := engine_helpers.NewForkValidator(ctx, 1, inMemoryExecution, dirs.Tmp, mock.BlockReader)
 
-	statusDataProvider, err := sentry.NewStatusDataProvider(
-		ctx,
+	statusDataProvider := sentry.NewStatusDataProvider(
 		db,
 		mock.ChainConfig,
 		mock.Genesis,
 		mock.ChainConfig.ChainID.Uint64(),
 	)
-	if err != nil {
-		panic(err)
-	}
 
 	maxBlockBroadcastPeers := func(header *types.Header) uint { return 0 }
 

--- a/turbo/stages/mock/sentry_mock_test.go
+++ b/turbo/stages/mock/sentry_mock_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 
 	"github.com/holiman/uint256"
+	"github.com/ledgerwatch/log/v3"
+	"github.com/stretchr/testify/require"
+
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/gointerfaces/sentry"
 	"github.com/ledgerwatch/erigon-lib/wrap"
-	"github.com/ledgerwatch/log/v3"
-	"github.com/stretchr/testify/require"
 
 	"github.com/ledgerwatch/erigon/common/u256"
 	"github.com/ledgerwatch/erigon/core"
@@ -502,7 +503,7 @@ func TestAnchorReplace2(t *testing.T) {
 	m.ReceiveWg.Wait() // Wait for all messages to be processed before we proceeed
 
 	initialCycle := mock.MockInsertAsInitialCycle
-	hook := stages.NewHook(m.Ctx, m.DB, m.Notifications, m.Sync, m.BlockReader, m.ChainConfig, m.Log, m.UpdateHead)
+	hook := stages.NewHook(m.Ctx, m.DB, m.Notifications, m.Sync, m.BlockReader, m.ChainConfig, m.Log, nil)
 	if err := stages.StageLoopIteration(m.Ctx, m.DB, wrap.TxContainer{}, m.Sync, initialCycle, m.Log, m.BlockReader, hook, false); err != nil {
 		t.Fatal(err)
 	}

--- a/turbo/stages/stageloop.go
+++ b/turbo/stages/stageloop.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/big"
 	"time"
 
 	lru "github.com/hashicorp/golang-lru/arc/v2"
-	"github.com/holiman/uint256"
 	"github.com/ledgerwatch/log/v3"
 
 	"github.com/ledgerwatch/erigon-lib/chain"
@@ -234,11 +232,11 @@ type Hook struct {
 	chainConfig   *chain.Config
 	logger        log.Logger
 	blockReader   services.FullBlockReader
-	updateHead    func(ctx context.Context, headHeight uint64, headTime uint64, hash libcommon.Hash, td *uint256.Int)
+	updateHead    func(ctx context.Context)
 	db            kv.RoDB
 }
 
-func NewHook(ctx context.Context, db kv.RoDB, notifications *shards.Notifications, sync *stagedsync.Sync, blockReader services.FullBlockReader, chainConfig *chain.Config, logger log.Logger, updateHead func(ctx context.Context, headHeight uint64, headTime uint64, hash libcommon.Hash, td *uint256.Int)) *Hook {
+func NewHook(ctx context.Context, db kv.RoDB, notifications *shards.Notifications, sync *stagedsync.Sync, blockReader services.FullBlockReader, chainConfig *chain.Config, logger log.Logger, updateHead func(ctx context.Context)) *Hook {
 	return &Hook{ctx: ctx, db: db, notifications: notifications, sync: sync, blockReader: blockReader, chainConfig: chainConfig, logger: logger, updateHead: updateHead}
 }
 func (h *Hook) beforeRun(tx kv.Tx, inSync bool) error {
@@ -265,64 +263,44 @@ func (h *Hook) AfterRun(tx kv.Tx, finishProgressBefore uint64) error {
 	return h.afterRun(tx, finishProgressBefore)
 }
 func (h *Hook) afterRun(tx kv.Tx, finishProgressBefore uint64) error {
-	notifications := h.notifications
-	blockReader := h.blockReader
-	// -- send notifications START
-	//TODO: can this 2 headers be 1
-	var headHeader, currentHeader *types.Header
-
 	// Update sentry status for peers to see our sync status
-	var headTd *big.Int
-	var plainStateVersion, finalizedBlock uint64
-	head, err := stages.GetStageProgress(tx, stages.Headers)
-	if err != nil {
-		return err
+	if h.updateHead != nil {
+		h.updateHead(h.ctx)
 	}
-	headHash, err := rawdb.ReadCanonicalHash(tx, head)
-	if err != nil {
-		return err
+	if h.notifications != nil {
+		return h.sendNotifications(h.notifications, tx, finishProgressBefore)
 	}
-	if headTd, err = rawdb.ReadTd(tx, headHash, head); err != nil {
-		return err
-	}
-	headHeader = rawdb.ReadHeader(tx, headHash, head)
-	currentHeader = rawdb.ReadCurrentHeader(tx)
-	finalizedHeaderHash := rawdb.ReadForkchoiceFinalized(tx)
-	if fb := rawdb.ReadHeaderNumber(tx, finalizedHeaderHash); fb != nil {
-		finalizedBlock = *fb
-	}
+	return nil
+}
+func (h *Hook) sendNotifications(notifications *shards.Notifications, tx kv.Tx, finishProgressBefore uint64) error {
 	// update the accumulator with a new plain state version so the cache can be notified that
 	// state has moved on
-	if plainStateVersion, err = rawdb.GetStateVersion(tx); err != nil {
-		return err
-	}
-	if notifications != nil && notifications.Accumulator != nil {
+	if notifications.Accumulator != nil {
+		plainStateVersion, err := rawdb.GetStateVersion(tx)
+		if err != nil {
+			return err
+		}
+
 		notifications.Accumulator.SetStateID(plainStateVersion)
 	}
 
-	if headTd != nil && headHeader != nil {
-		headTd256, overflow := uint256.FromBig(headTd)
-		if overflow {
-			return fmt.Errorf("headTds higher than 2^256-1")
-		}
-		h.updateHead(h.ctx, head, headHeader.Time, headHash, headTd256)
-	}
-
-	if notifications != nil && notifications.Events != nil {
+	if notifications.Events != nil {
 		finishStageAfterSync, err := stages.GetStageProgress(tx, stages.Finish)
 		if err != nil {
 			return err
 		}
-		if err = stagedsync.NotifyNewHeaders(h.ctx, finishProgressBefore, finishStageAfterSync, h.sync.PrevUnwindPoint(), notifications.Events, tx, h.logger, blockReader); err != nil {
+		if err = stagedsync.NotifyNewHeaders(h.ctx, finishProgressBefore, finishStageAfterSync, h.sync.PrevUnwindPoint(), notifications.Events, tx, h.logger, h.blockReader); err != nil {
 			return nil
 		}
 	}
-	if notifications != nil && notifications.Accumulator != nil && currentHeader != nil {
 
-		pendingBaseFee := misc.CalcBaseFee(h.chainConfig, currentHeader)
+	currentHeader := rawdb.ReadCurrentHeader(tx)
+	if (notifications.Accumulator != nil) && (currentHeader != nil) {
 		if currentHeader.Number.Uint64() == 0 {
 			notifications.Accumulator.StartChange(0, currentHeader.Hash(), nil, false)
 		}
+
+		pendingBaseFee := misc.CalcBaseFee(h.chainConfig, currentHeader)
 		pendingBlobFee := h.chainConfig.GetMinBlobGasPrice()
 		if currentHeader.ExcessBlobGas != nil {
 			excessBlobGas := misc.CalcExcessBlobGas(h.chainConfig, currentHeader)
@@ -333,10 +311,14 @@ func (h *Hook) afterRun(tx kv.Tx, finishProgressBefore uint64) error {
 			pendingBlobFee = f.Uint64()
 		}
 
+		var finalizedBlock uint64
+		if fb := rawdb.ReadHeaderNumber(tx, rawdb.ReadForkchoiceFinalized(tx)); fb != nil {
+			finalizedBlock = *fb
+		}
+
 		//h.logger.Debug("[hook] Sending state changes", "currentBlock", currentHeader.Number.Uint64(), "finalizedBlock", finalizedBlock)
 		notifications.Accumulator.SendAndReset(h.ctx, notifications.StateChangesConsumer, pendingBaseFee.Uint64(), pendingBlobFee, currentHeader.GasLimit, finalizedBlock)
 	}
-	// -- send notifications END
 	return nil
 }
 


### PR DESCRIPTION
The responsibility to maintain the status data is moved from the stageloop Hook and MultiClient to the new StatusDataProvider. It reads the latest data from a RoDB when asked. That happens at the end of each stage loop iteration, and sometimes when any sentry stream loop reconnects a sentry client.

sync.Service and MultiClient require an instance of the StatusDataProvider now. The MessageListener is updated to depend on an external statusDataFactory.
