### PR TITLE
[wip] E3: added command to verify local files against webseed and manifest

### DIFF
--- a/cmd/capcli/cli.go
+++ b/cmd/capcli/cli.go
@@ -578,7 +578,7 @@ func (d *DownloadSnapshots) Run(ctx *Context) error {
 	if err != nil {
 		return err
 	}
-	downlo, err := downloader.New(ctx, downloaderCfg, dirs, log.Root(), log.LvlInfo, true)
+	downlo, err := downloader.New(ctx, downloaderCfg, log.Root(), log.LvlInfo, true)
 	if err != nil {
 		return err
 	}

--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -96,6 +96,7 @@ type Downloader struct {
 type webDownloadInfo struct {
 	url     *url.URL
 	length  int64
+	md5     string
 	torrent *torrent.Torrent
 }
 
@@ -118,7 +119,7 @@ type AggStats struct {
 	LocalFileHashTime          time.Duration
 }
 
-func New(ctx context.Context, cfg *downloadercfg.Cfg, dirs datadir.Dirs, logger log.Logger, verbosity log.Lvl, discover bool) (*Downloader, error) {
+func New(ctx context.Context, cfg *downloadercfg.Cfg, logger log.Logger, verbosity log.Lvl, discover bool) (*Downloader, error) {
 	db, c, m, torrentClient, err := openClient(ctx, cfg.Dirs.Downloader, cfg.Dirs.Snap, cfg.ClientConfig)
 	if err != nil {
 		return nil, fmt.Errorf("openClient: %w", err)
@@ -152,7 +153,7 @@ func New(ctx context.Context, cfg *downloadercfg.Cfg, dirs datadir.Dirs, logger 
 		torrentClient:       torrentClient,
 		lock:                mutex,
 		stats:               stats,
-		webseeds:            &WebSeeds{logger: logger, verbosity: verbosity, downloadTorrentFile: cfg.DownloadTorrentFilesFromWebseed, torrentsWhitelist: lock.Downloads},
+		webseeds:            NewWebSeeds(cfg.WebSeedUrls, verbosity, logger),
 		logger:              logger,
 		verbosity:           verbosity,
 		torrentFiles:        &TorrentFiles{dir: cfg.Dirs.Snap},
@@ -162,13 +163,13 @@ func New(ctx context.Context, cfg *downloadercfg.Cfg, dirs datadir.Dirs, logger 
 		downloading:         map[string]struct{}{},
 		webseedsDiscover:    discover,
 	}
+	d.webseeds.SetTorrent(d.torrentFiles, lock.Downloads, cfg.DownloadTorrentFilesFromWebseed)
 
 	if cfg.ClientConfig.DownloadRateLimiter != nil {
 		downloadLimit := cfg.ClientConfig.DownloadRateLimiter.Limit()
 		d.downloadLimit = &downloadLimit
 	}
 
-	d.webseeds.torrentFiles = d.torrentFiles
 	d.ctx, d.stopMainLoop = context.WithCancel(ctx)
 
 	if cfg.AddTorrentsFromDisk {
@@ -655,7 +656,7 @@ func (d *Downloader) mainLoop(silent bool) error {
 		d.wg.Add(1)
 		go func() {
 			defer d.wg.Done()
-			d.webseeds.Discover(d.ctx, d.cfg.WebSeedUrls, d.cfg.WebSeedFiles, d.cfg.Dirs.Snap)
+			d.webseeds.Discover(d.ctx, d.cfg.WebSeedFiles, d.cfg.Dirs.Snap)
 			// webseeds.Discover may create new .torrent files on disk
 			if err := d.addTorrentFilesFromDisk(true); err != nil && !errors.Is(err, context.Canceled) {
 				d.logger.Warn("[snapshots] addTorrentFilesFromDisk", "err", err)
@@ -1271,8 +1272,6 @@ func (d *Downloader) checkComplete(name string) (bool, int64, *time.Time) {
 }
 
 func (d *Downloader) getWebDownloadInfo(t *torrent.Torrent) (webDownloadInfo, []*seedHash, error) {
-	torrentHash := t.InfoHash()
-
 	d.lock.RLock()
 	info, ok := d.webDownloadInfo[t.Name()]
 	d.lock.RUnlock()
@@ -1281,46 +1280,16 @@ func (d *Downloader) getWebDownloadInfo(t *torrent.Torrent) (webDownloadInfo, []
 		return info, nil, nil
 	}
 
-	seedHashMismatches := make([]*seedHash, 0, len(d.cfg.WebSeedUrls))
-
-	for _, webseed := range d.cfg.WebSeedUrls {
-		downloadUrl := webseed.JoinPath(t.Name())
-
-		if headRequest, err := http.NewRequestWithContext(d.ctx, "HEAD", downloadUrl.String(), nil); err == nil {
-			headResponse, err := http.DefaultClient.Do(headRequest)
-
-			if err != nil {
-				continue
-			}
-
-			headResponse.Body.Close()
-
-			if headResponse.StatusCode == http.StatusOK {
-				if meta, err := getWebpeerTorrentInfo(d.ctx, downloadUrl); err == nil {
-					if bytes.Equal(torrentHash.Bytes(), meta.HashInfoBytes().Bytes()) {
-						// TODO check the torrent's hash matches this hash
-						return webDownloadInfo{
-							url:     downloadUrl,
-							length:  headResponse.ContentLength,
-							torrent: t,
-						}, seedHashMismatches, nil
-					} else {
-						hash := meta.HashInfoBytes()
-						seedHashMismatches = append(seedHashMismatches, &seedHash{url: webseed, hash: &hash})
-						continue
-					}
-				}
-			}
-		}
-
-		seedHashMismatches = append(seedHashMismatches, &seedHash{url: webseed})
+	// todo this function does not exit on first matched webseed hash, could make unexpected results
+	infos, seedHashMismatches, err := d.webseeds.getWebDownloadInfo(d.ctx, t)
+	if err != nil || len(infos) == 0 {
+		return webDownloadInfo{}, seedHashMismatches, fmt.Errorf("can't find download info: %w", err)
 	}
-
-	return webDownloadInfo{}, seedHashMismatches, fmt.Errorf("can't find download info")
+	return infos[0], seedHashMismatches, nil
 }
 
 func getWebpeerTorrentInfo(ctx context.Context, downloadUrl *url.URL) (*metainfo.MetaInfo, error) {
-	torrentRequest, err := http.NewRequestWithContext(ctx, "GET", downloadUrl.String()+".torrent", nil)
+	torrentRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadUrl.String()+".torrent", nil)
 
 	if err != nil {
 		return nil, err

--- a/erigon-lib/downloader/downloader_test.go
+++ b/erigon-lib/downloader/downloader_test.go
@@ -23,7 +23,7 @@ func TestChangeInfoHashOfSameFile(t *testing.T) {
 	dirs := datadir.New(t.TempDir())
 	cfg, err := downloadercfg2.New(dirs, "", lg.Info, 0, 0, 0, 0, 0, nil, nil, "testnet", false)
 	require.NoError(err)
-	d, err := New(context.Background(), cfg, dirs, log.New(), log.LvlInfo, true)
+	d, err := New(context.Background(), cfg, log.New(), log.LvlInfo, true)
 	require.NoError(err)
 	defer d.Close()
 	err = d.AddMagnetLink(d.ctx, snaptype.Hex2InfoHash("aa"), "a.seg")

--- a/erigon-lib/downloader/webseed.go
+++ b/erigon-lib/downloader/webseed.go
@@ -3,12 +3,18 @@ package downloader
 import (
 	"bytes"
 	"context"
+	"crypto/md5"
+	"encoding/hex"
 	"fmt"
+	"github.com/anacrolix/torrent"
+	"github.com/ledgerwatch/erigon-lib/common/datadir"
 	"io"
+	"io/fs"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 
@@ -34,21 +40,275 @@ type WebSeeds struct {
 	downloadTorrentFile bool
 	torrentsWhitelist   snapcfg.Preverified
 
+	seeds []*url.URL
+
 	logger    log.Logger
 	verbosity log.Lvl
 
 	torrentFiles *TorrentFiles
 }
 
-func (d *WebSeeds) Discover(ctx context.Context, urls []*url.URL, files []string, rootDir string) {
-	listsOfFiles := d.constructListsOfFiles(ctx, urls, files)
+func NewWebSeeds(seeds []*url.URL, verbosity log.Lvl, logger log.Logger) *WebSeeds {
+	return &WebSeeds{
+		seeds:     seeds,
+		logger:    logger,
+		verbosity: verbosity,
+	}
+}
+
+func (d *WebSeeds) getWebDownloadInfo(ctx context.Context, t *torrent.Torrent) ([]webDownloadInfo, []*seedHash, error) {
+	var seedHashMismatches []*seedHash
+	var infos []webDownloadInfo
+	torrentHash := t.InfoHash().Bytes()
+
+	for _, webseed := range d.seeds {
+		downloadUrl := webseed.JoinPath(t.Name())
+
+		if headRequest, err := http.NewRequestWithContext(ctx, http.MethodHead, downloadUrl.String(), nil); err == nil {
+			headResponse, err := http.DefaultClient.Do(headRequest)
+
+			if err != nil {
+				continue
+			}
+
+			headResponse.Body.Close()
+
+			if headResponse.StatusCode != http.StatusOK {
+				d.logger.Warn("[snapshots] webseed HEAD request failed", "url", downloadUrl, "status", headResponse.Status)
+				continue
+			}
+			if meta, err := getWebpeerTorrentInfo(ctx, downloadUrl); err == nil {
+				if bytes.Equal(torrentHash, meta.HashInfoBytes().Bytes()) {
+					md5tag := headResponse.Header.Get("Etag")
+					if md5tag != "" {
+						md5tag = strings.Trim(md5tag, "\"")
+					}
+
+					infos = append(infos, webDownloadInfo{
+						url:     downloadUrl,
+						length:  headResponse.ContentLength,
+						md5:     md5tag,
+						torrent: t,
+					})
+				} else {
+					hash := meta.HashInfoBytes()
+					seedHashMismatches = append(seedHashMismatches, &seedHash{url: webseed, hash: &hash})
+				}
+			}
+		}
+		seedHashMismatches = append(seedHashMismatches, &seedHash{url: webseed})
+	}
+
+	return infos, seedHashMismatches, nil
+}
+
+func (d *WebSeeds) SetTorrent(t *TorrentFiles, whiteList snapcfg.Preverified, downloadTorrentFile bool) {
+	d.downloadTorrentFile = downloadTorrentFile
+	d.torrentsWhitelist = whiteList
+	d.torrentFiles = t
+}
+
+func (d *WebSeeds) checkHasTorrents(manifestResponse snaptype.WebSeedsFromProvider, webSeedProviderURL *url.URL) {
+	// check that for each file in the manifest, there is a corresponding .torrent file
+	count := len(manifestResponse)
+	for name := range manifestResponse {
+		if !strings.HasSuffix(name, ".torrent") {
+			continue
+		}
+		fn := strings.TrimSuffix(name, ".torrent")
+		if !nameWhitelisted(name, d.torrentsWhitelist) {
+			delete(manifestResponse, fn)
+			delete(manifestResponse, name)
+			continue
+		}
+		if _, ok := manifestResponse[fn]; !ok {
+			d.logger.Warn("[snapshots.webseed] .torrent file not found for file in manifest",
+				"file", name, "seed", webSeedProviderURL.String())
+			continue
+		}
+		delete(manifestResponse, fn)
+		delete(manifestResponse, name)
+	}
+
+	if len(manifestResponse) > 0 {
+		d.logger.Warn("[snapshots.webseed] manifested .torrent files was not found",
+			"missing", len(manifestResponse), "totalFiles", count, "seed", webSeedProviderURL.String())
+
+		files := make([]string, 0, len(manifestResponse))
+		for file := range manifestResponse {
+			files = append(files, file)
+		}
+		sort.Strings(files)
+		for _, file := range files {
+			fmt.Printf("%s\n", file)
+		}
+		//return fmt.Errorf("missing %d .torrent files", len(files))
+	}
+	//return nil
+}
+
+func (d *WebSeeds) fetchFileEtags(ctx context.Context, manifestResponse snaptype.WebSeedsFromProvider) (map[string]string, error) {
+	tags := make(map[string]string)
+	for name, wurl := range manifestResponse {
+		if strings.HasSuffix(name, ".torrent") {
+			continue
+		}
+		//if !nameWhitelisted(name, d.torrentsWhitelist) {
+		//	continue
+		//}
+
+		u, err := url.Parse(wurl)
+		if err != nil {
+			return nil, fmt.Errorf("webseed.fetchFileEtags: %w", err)
+		}
+		md5Tag, err := d.retrieveFileEtag(ctx, u)
+		if err != nil {
+			d.logger.Debug("[snapshots.webseed] get file ETag", "err", err, "url", u.String())
+			return nil, fmt.Errorf("webseed.fetchFileEtags: %w", err)
+		}
+		tags[name] = md5Tag
+	}
+	return tags, nil
+}
+
+func (d *WebSeeds) VerifyManifestedBuckets(ctx context.Context, dirs datadir.Dirs, failFast bool) error {
+	var supErr error
+	for _, webSeedProviderURL := range d.seeds {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		if err := d.VerifyManifestedBucket(ctx, dirs, webSeedProviderURL); err != nil {
+			d.logger.Warn("[snapshots.webseed] verify manifest", "err", err)
+			if failFast {
+				return err
+			} else {
+				supErr = err
+			}
+		}
+	}
+	return supErr
+}
+
+func (d *WebSeeds) findLocalFileAndCheckMD5(ctx context.Context, dirs datadir.Dirs, manifestResponse snaptype.WebSeedsFromProvider) error {
+	etags, err := d.fetchFileEtags(ctx, manifestResponse)
+	if err != nil {
+		return err
+	}
+
+	notFounds := make([]string, 0, len(etags))
+
+	hasher := md5.New()
+
+	walker := func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		if strings.HasSuffix(d.Name(), ".torrent") || strings.HasPrefix(d.Name(), ".") {
+			return nil
+		}
+		hasher.Reset()
+		f, err := os.OpenFile(filepath.Join(dirs.Snap, path), os.O_RDONLY, 0640)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		webHash, found := etags[d.Name()]
+		if !found {
+			fmt.Printf("file %s not found in webseed\n", d.Name())
+			notFounds = append(notFounds, path)
+			return nil
+			//return fmt.Errorf("file %s not found in webseed", d.Name())
+		}
+
+		n, err := io.Copy(hasher, f)
+		if err != nil {
+			return err
+		}
+		finf, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if n != finf.Size() {
+			return fmt.Errorf("hashed file size mismatch %d != expeced %d", n, finf.Size())
+		}
+
+		hashOnDisk := hex.EncodeToString(hasher.Sum(nil))
+		if hashOnDisk != webHash {
+			return fmt.Errorf("file %s has invalid md5 %s != %s (webseed)", d.Name(), hashOnDisk, webHash)
+		}
+		delete(etags, d.Name())
+		return nil
+	}
+
+	for _, d := range []string{dirs.Snap /*, dirs.SnapDomain, dirs.SnapIdx, dirs.SnapHistory*/} {
+		sfs := os.DirFS(d)
+		if err = fs.WalkDir(sfs, ".", walker); err != nil {
+			return err
+		}
+	}
+
+	if len(etags) > 0 {
+		fmt.Printf("Files not found on disk:\n")
+		for n, e := range etags {
+			fmt.Printf("%s %s\n", e, n)
+		}
+	}
+
+	if len(notFounds) > 0 {
+		sort.Strings(notFounds)
+		fmt.Printf("Files not found on webseed:\n")
+		for _, n := range notFounds {
+			fmt.Printf("%s\n", n)
+		}
+	}
+
+	return err
+}
+
+func (d *WebSeeds) VerifyManifestedBucket(ctx context.Context, dir datadir.Dirs, webSeedProviderURL *url.URL) error {
+	manifestResponse, err := d.retrieveManifest(ctx, webSeedProviderURL)
+	if err != nil {
+		d.logger.Debug("[snapshots.webseed] get from HTTP provider", "err", err, "url", webSeedProviderURL.String())
+		return err
+	}
+
+	d.checkHasTorrents(manifestResponse, webSeedProviderURL)
+
+	err = d.findLocalFileAndCheckMD5(ctx, dir, manifestResponse)
+	if err != nil {
+		return err
+	}
+
+	//// add to list files from disk
+	//for _, webSeedFile := range diskProviders {
+	//	response, err := d.readWebSeedsFile(webSeedFile)
+	//	if err != nil { // don't fail on error
+	//		d.logger.Debug("[snapshots.webseed] get from File provider", "err", err)
+	//		continue
+	//	}
+	//	listsOfFiles = append(listsOfFiles, response)
+	//}
+	//return listsOfFiles
+	return nil
+}
+
+func (d *WebSeeds) Discover(ctx context.Context, files []string, rootDir string) {
+	listsOfFiles := d.constructListsOfFiles(ctx, d.seeds, files)
 	torrentMap := d.makeTorrentUrls(listsOfFiles)
 	webSeedMap := d.downloadTorrentFilesFromProviders(ctx, rootDir, torrentMap)
 	d.makeWebSeedUrls(listsOfFiles, webSeedMap)
 }
 
 func (d *WebSeeds) constructListsOfFiles(ctx context.Context, httpProviders []*url.URL, diskProviders []string) []snaptype.WebSeedsFromProvider {
-	log.Debug("[snapshots] webseed providers", "http", len(httpProviders), "disk", len(diskProviders))
+	log.Debug("[snapshots.webseed] providers", "http", len(httpProviders), "disk", len(diskProviders))
 	listsOfFiles := make([]snaptype.WebSeedsFromProvider, 0, len(httpProviders)+len(diskProviders))
 
 	for _, webSeedProviderURL := range httpProviders {
@@ -138,6 +398,42 @@ func (d *WebSeeds) ByFileName(name string) (metainfo.UrlList, bool) {
 	v, ok := d.byFileName[name]
 	return v, ok
 }
+
+func (d *WebSeeds) retrieveFileEtag(ctx context.Context, file *url.URL) (string, error) {
+	request, err := http.NewRequest(http.MethodHead, file.String(), nil)
+	if err != nil {
+		return "", err
+	}
+
+	request = request.WithContext(ctx)
+	resp, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return "", fmt.Errorf("webseed.http: %w, url=%s", err, file.String())
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("webseed.http: status code %d, url=%s", resp.StatusCode, file.String())
+	}
+
+	etag := resp.Header.Get("Etag") // file md5
+	if etag == "" {
+		return "", fmt.Errorf("webseed.http: file has no etag, url=%s", file.String())
+	}
+	etag = strings.Trim(etag, "\"")
+	if strings.Contains(etag, "-") {
+		fmt.Printf("invalid etag (md5): %s %s\n", etag, file.Path)
+		etag = strings.Split(etag, "-")[0]
+	}
+
+	return etag, nil
+	//buuuuf, err := httputil.DumpResponse(resp, true)
+	//if err != nil {
+	//	panic(err)
+	//}
+	//fmt.Println(string(buuuuf))
+	//return "", nil
+}
+
 func (d *WebSeeds) retrieveManifest(ctx context.Context, webSeedProviderUrl *url.URL) (snaptype.WebSeedsFromProvider, error) {
 	baseUrl := webSeedProviderUrl.String()
 	ref, err := url.Parse("manifest.txt")
@@ -153,22 +449,32 @@ func (d *WebSeeds) retrieveManifest(ctx context.Context, webSeedProviderUrl *url
 	request = request.WithContext(ctx)
 	resp, err := http.DefaultClient.Do(request)
 	if err != nil {
-		return nil, fmt.Errorf("webseed.http: %w, host=%s, url=%s", err, webSeedProviderUrl.Hostname(), webSeedProviderUrl.EscapedPath())
+		return nil, fmt.Errorf("webseed.http: %w, url=%s", err, u.String())
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("webseed.http: status=%d, url=%s", resp.StatusCode, u.String())
+	}
+
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("webseed.http: %w, host=%s, url=%s, ", err, webSeedProviderUrl.Hostname(), webSeedProviderUrl.EscapedPath())
+		return nil, fmt.Errorf("webseed.http: %w, url=%s, ", err, u.String())
 	}
+
 	response := snaptype.WebSeedsFromProvider{}
 	fileNames := strings.Split(string(b), "\n")
-	for _, f := range fileNames {
+	for fi, f := range fileNames {
+		if strings.TrimSpace(f) == "" {
+			fmt.Printf("empty line in manifest %q at line %d\n", f, fi)
+			continue
+		}
+
 		response[f], err = url.JoinPath(baseUrl, f)
 		if err != nil {
 			return nil, err
 		}
 	}
-	d.logger.Debug("[snapshots.webseed] get from HTTP provider", "urls", len(response), "host", webSeedProviderUrl.Hostname(), "url", webSeedProviderUrl.EscapedPath())
+	d.logger.Debug("[snapshots.webseed] get from HTTP provider", "urls", len(response), "url", webSeedProviderUrl.EscapedPath())
 	return response, nil
 }
 func (d *WebSeeds) readWebSeedsFile(webSeedProviderPath string) (snaptype.WebSeedsFromProvider, error) {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1254,7 +1254,7 @@ func (s *Ethereum) setUpSnapDownloader(ctx context.Context, downloaderCfg *downl
 		}
 
 		discover := true
-		s.downloader, err = downloader.New(ctx, downloaderCfg, s.config.Dirs, s.logger, log.LvlDebug, discover)
+		s.downloader, err = downloader.New(ctx, downloaderCfg, s.logger, log.LvlDebug, discover)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- check that all files in manifesto present in bucket
- each file has own `.torrent`
- each webseed file etag is equal to same file on host in `datadir`

Command supposed to be started from uploader host (which build `manifest.txt` and uploaded files to webseed from)

For now I found:
 - not every bucket has `manifest.txt` available
 - not every file has it's own torrent
 - we have file entry of spaces/empty name
 - we have some files with invalid `ETag` field which is usually set up right after file uploading (by loader or by service provider). 
 
Our `etag` is md5 (current) which could be changed to sha1 to be compatible with bittorrent protocol. For some files we got invalid etags like `ecebcb2afaaa4327da972ea20cc7d98d-967 /domain/v1-commitment.64-80.kv` for sepolia rn.
So, wrong etags during download should be also addressed.