### PR TITLE
downloader: don't skip webseed if .torrent file exists (because download maybe not completed yet)

### DIFF
--- a/erigon-lib/downloader/torrent_files.go
+++ b/erigon-lib/downloader/torrent_files.go
@@ -47,10 +47,10 @@ func (tf *TorrentFiles) delete(name string) error {
 	return os.Remove(filepath.Join(tf.dir, name))
 }
 
-func (tf *TorrentFiles) Create(torrentFilePath string, res []byte) error {
+func (tf *TorrentFiles) Create(name string, res []byte) error {
 	tf.lock.Lock()
 	defer tf.lock.Unlock()
-	return tf.create(torrentFilePath, res)
+	return tf.create(filepath.Join(tf.dir, name), res)
 }
 func (tf *TorrentFiles) create(torrentFilePath string, res []byte) error {
 	if len(res) == 0 {

--- a/erigon-lib/downloader/webseed.go
+++ b/erigon-lib/downloader/webseed.go
@@ -40,6 +40,9 @@ type WebSeeds struct {
 }
 
 func (d *WebSeeds) Discover(ctx context.Context, urls []*url.URL, files []string, rootDir string) {
+	if d.torrentFiles.newDownloadsAreProhibited() {
+		return
+	}
 	listsOfFiles := d.constructListsOfFiles(ctx, urls, files)
 	torrentMap := d.makeTorrentUrls(listsOfFiles)
 	webSeedMap := d.downloadTorrentFilesFromProviders(ctx, rootDir, torrentMap)


### PR DESCRIPTION
- don't skip webseed if .torrent file exists (because download maybe not completed yet)
- don't discover webseed if `prohibit_new_downloads.lock` exists - it's "download completed"
