### PR TITLE
RPC: close `tx.Prefix` iterator for early release memory

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -798,6 +798,11 @@ func ReadRawReceipts(db kv.Tx, blockNum uint64) types.Receipts {
 		log.Error("logs fetching failed", "err", err)
 		return nil
 	}
+	defer func() {
+		if casted, ok := it.(kv.Closer); ok {
+			casted.Close()
+		}
+	}()
 	for it.HasNext() {
 		k, v, err := it.Next()
 		if err != nil {
@@ -817,9 +822,6 @@ func ReadRawReceipts(db kv.Tx, blockNum uint64) types.Receipts {
 		if txIndex < len(receipts) {
 			receipts[txIndex].Logs = logs
 		}
-	}
-	if casted, ok := it.(kv.Closer); ok {
-		casted.Close()
 	}
 
 	return receipts

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -818,6 +818,9 @@ func ReadRawReceipts(db kv.Tx, blockNum uint64) types.Receipts {
 			receipts[txIndex].Logs = logs
 		}
 	}
+	if casted, ok := it.(kv.Closer); ok {
+		casted.Close()
+	}
 
 	return receipts
 }

--- a/erigon-lib/kv/mdbx/kv_mdbx.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx.go
@@ -1860,6 +1860,7 @@ func (s *cursor2iter) init(table string, tx kv.Tx) (*cursor2iter, error) {
 func (s *cursor2iter) Close() {
 	if s.c != nil {
 		s.c.Close()
+		s.c = nil
 	}
 }
 func (s *cursor2iter) HasNext() bool {
@@ -1958,6 +1959,7 @@ func (s *cursorDup2iter) init(table string, tx kv.Tx) (*cursorDup2iter, error) {
 func (s *cursorDup2iter) Close() {
 	if s.c != nil {
 		s.c.Close()
+		s.c = nil
 	}
 }
 func (s *cursorDup2iter) HasNext() bool {

--- a/erigon-lib/kv/mdbx/kv_mdbx.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx.go
@@ -655,14 +655,17 @@ func (db *MdbxKV) beginRw(ctx context.Context, flags uint) (txn kv.RwTx, err err
 
 type MdbxTx struct {
 	tx               *mdbx.Txn
+	id               uint64 // set only if TRACE_TX=true
 	db               *MdbxKV
-	cursors          map[uint64]*mdbx.Cursor
-	streams          []kv.Closer
 	statelessCursors map[string]kv.RwCursor
 	readOnly         bool
-	cursorID         uint64
 	ctx              context.Context
-	id               uint64 // set only if TRACE_TX=true
+
+	cursors  map[uint64]*mdbx.Cursor
+	cursorID uint64
+
+	streams  map[int]kv.Closer
+	streamID int
 }
 
 type MdbxCursor struct {
@@ -995,6 +998,7 @@ func (tx *MdbxTx) closeCursors() {
 			c.Close()
 		}
 	}
+	tx.streams = nil
 	tx.statelessCursors = nil
 }
 
@@ -1802,7 +1806,10 @@ func (tx *MdbxTx) RangeDescend(table string, fromPrefix, toPrefix []byte, limit 
 }
 
 type cursor2iter struct {
-	c                                  kv.Cursor
+	c  kv.Cursor
+	id int
+	tx *MdbxTx
+
 	fromPrefix, toPrefix, nextK, nextV []byte
 	err                                error
 	orderAscend                        order.By
@@ -1811,8 +1818,12 @@ type cursor2iter struct {
 }
 
 func (tx *MdbxTx) rangeOrderLimit(table string, fromPrefix, toPrefix []byte, orderAscend order.By, limit int) (*cursor2iter, error) {
-	s := &cursor2iter{ctx: tx.ctx, fromPrefix: fromPrefix, toPrefix: toPrefix, orderAscend: orderAscend, limit: int64(limit)}
-	tx.streams = append(tx.streams, s)
+	s := &cursor2iter{ctx: tx.ctx, tx: tx, fromPrefix: fromPrefix, toPrefix: toPrefix, orderAscend: orderAscend, limit: int64(limit), id: tx.streamID}
+	tx.streamID++
+	if tx.streams == nil {
+		tx.streams = map[int]kv.Closer{}
+	}
+	tx.streams[s.id] = s
 	return s.init(table, tx)
 }
 func (s *cursor2iter) init(table string, tx kv.Tx) (*cursor2iter, error) {
@@ -1860,6 +1871,7 @@ func (s *cursor2iter) init(table string, tx kv.Tx) (*cursor2iter, error) {
 func (s *cursor2iter) Close() {
 	if s.c != nil {
 		s.c.Close()
+		delete(s.tx.streams, s.id)
 		s.c = nil
 	}
 }
@@ -1899,13 +1911,20 @@ func (s *cursor2iter) Next() (k, v []byte, err error) {
 }
 
 func (tx *MdbxTx) RangeDupSort(table string, key []byte, fromPrefix, toPrefix []byte, asc order.By, limit int) (iter.KV, error) {
-	s := &cursorDup2iter{ctx: tx.ctx, key: key, fromPrefix: fromPrefix, toPrefix: toPrefix, orderAscend: bool(asc), limit: int64(limit)}
-	tx.streams = append(tx.streams, s)
+	s := &cursorDup2iter{ctx: tx.ctx, tx: tx, key: key, fromPrefix: fromPrefix, toPrefix: toPrefix, orderAscend: bool(asc), limit: int64(limit), id: tx.streamID}
+	tx.streamID++
+	if tx.streams == nil {
+		tx.streams = map[int]kv.Closer{}
+	}
+	tx.streams[s.id] = s
 	return s.init(table, tx)
 }
 
 type cursorDup2iter struct {
-	c                           kv.CursorDupSort
+	c  kv.CursorDupSort
+	id int
+	tx *MdbxTx
+
 	key                         []byte
 	fromPrefix, toPrefix, nextV []byte
 	err                         error
@@ -1959,6 +1978,7 @@ func (s *cursorDup2iter) init(table string, tx kv.Tx) (*cursorDup2iter, error) {
 func (s *cursorDup2iter) Close() {
 	if s.c != nil {
 		s.c.Close()
+		delete(s.tx.streams, s.id)
 		s.c = nil
 	}
 }

--- a/turbo/jsonrpc/erigon_receipts.go
+++ b/turbo/jsonrpc/erigon_receipts.go
@@ -333,8 +333,11 @@ func (api *ErigonImpl) GetLatestLogs(ctx context.Context, crit filters.FilterCri
 			if logOptions.LogCount != 0 && logOptions.LogCount <= logCount {
 				break
 			}
-
 		}
+		if casted, ok := it.(kv.Closer); ok {
+			casted.Close()
+		}
+
 		blockCount++
 		if len(blockLogs) == 0 {
 			continue

--- a/turbo/jsonrpc/erigon_receipts.go
+++ b/turbo/jsonrpc/erigon_receipts.go
@@ -152,6 +152,9 @@ func (api *ErigonImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria)
 			}
 			blockLogs = append(blockLogs, filtered...)
 		}
+		if casted, ok := it.(kv.Closer); ok {
+			casted.Close()
+		}
 		if len(blockLogs) == 0 {
 			continue
 		}

--- a/turbo/jsonrpc/eth_receipts.go
+++ b/turbo/jsonrpc/eth_receipts.go
@@ -202,6 +202,9 @@ func (api *APIImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria) (t
 			}
 			blockLogs = append(blockLogs, filtered...)
 		}
+		if casted, ok := it.(kv.Closer); ok {
+			casted.Close()
+		}
 		if len(blockLogs) == 0 {
 			continue
 		}


### PR DESCRIPTION
- currently manually closing iterator, but later I may auto-close it when `it.HasNext()` turn false
- FYI: all iterators are also auto-closed now when `tx.Rollback/Commit` 

![mem](https://github.com/ledgerwatch/erigon/assets/46885206/40372932-3e7b-4648-be09-7c16d620592c)

