### PR TITLE
metrics: Fix smaps unit

### DIFF
--- a/erigon-lib/common/mem/mem_linux.go
+++ b/erigon-lib/common/mem/mem_linux.go
@@ -4,6 +4,7 @@ package mem
 
 import (
 	"os"
+	"reflect"
 
 	"github.com/shirou/gopsutil/v3/process"
 
@@ -33,6 +34,18 @@ func ReadVirtualMemStats() (process.MemoryMapsStat, error) {
 	memoryMaps, err := proc.MemoryMaps(true)
 	if err != nil {
 		return process.MemoryMapsStat{}, err
+	}
+
+	m := (*memoryMaps)[0]
+
+	// convert from kilobytes to bytes
+	val := reflect.ValueOf(m)
+	for i := 0; i < val.NumField(); i++ {
+		field := val.Field(i)
+
+		if field.Kind() == reflect.Uint64 {
+			field.Set(reflect.ValueOf(field.Interface().(uint64) * 1000))
+		}
 	}
 
 	return (*memoryMaps)[0], nil

--- a/erigon-lib/common/mem/mem_linux.go
+++ b/erigon-lib/common/mem/mem_linux.go
@@ -39,16 +39,16 @@ func ReadVirtualMemStats() (process.MemoryMapsStat, error) {
 	m := (*memoryMaps)[0]
 
 	// convert from kilobytes to bytes
-	val := reflect.ValueOf(m)
+	val := reflect.ValueOf(&m).Elem()
 	for i := 0; i < val.NumField(); i++ {
 		field := val.Field(i)
 
 		if field.Kind() == reflect.Uint64 {
-			field.Set(reflect.ValueOf(field.Interface().(uint64) * 1000))
+			field.SetUint(field.Interface().(uint64) * 1000)
 		}
 	}
 
-	return (*memoryMaps)[0], nil
+	return m, nil
 }
 
 func UpdatePrometheusVirtualMemStats(p process.MemoryMapsStat) {


### PR DESCRIPTION
`gopsutil` returns values in kilobytes, but `common.ByteCount` expects bytes, which led to incorrect values being displayed in logs. This PR addresses the issue by converting all outputs in `ReadVirtualMemStats` to return in bytes.