### PR TITLE
diagnostics: protect Send from panic 

### DIFF
--- a/erigon-lib/diagnostics/provider.go
+++ b/erigon-lib/diagnostics/provider.go
@@ -143,7 +143,7 @@ func startProvider(ctx context.Context, infoType Type, provider Provider, logger
 func Send[I Info](info I) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("panic recovered: %v", r)
+			err = fmt.Errorf("diagnostic Send panic recovered: %v, stack: %s", r, dbg.Stack())
 		}
 	}()
 

--- a/erigon-lib/diagnostics/provider.go
+++ b/erigon-lib/diagnostics/provider.go
@@ -140,7 +140,13 @@ func startProvider(ctx context.Context, infoType Type, provider Provider, logger
 	}
 }
 
-func Send[I Info](info I) error {
+func Send[I Info](info I) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic recovered: %v", r)
+		}
+	}()
+
 	ctx := info.Type().Context()
 
 	if ctx.Err() != nil {


### PR DESCRIPTION
On the exit of Erigon the Send function can be found sending on a closed channel causing panic. 
Given the nature of diagnostic messages, this can be avoided with a workaround.