### PR TITLE
Removed `MergeLimit`

### DIFF
--- a/erigon-lib/chain/snapcfg/util.go
+++ b/erigon-lib/chain/snapcfg/util.go
@@ -283,32 +283,6 @@ func (c Cfg) Seedable(info snaptype.FileInfo) bool {
 	return info.To-info.From == snaptype.Erigon2MergeLimit || info.To-info.From == snaptype.Erigon2OldMergeLimit
 }
 
-func (c Cfg) MergeLimit(fromBlock uint64) uint64 {
-	for _, p := range c.Preverified {
-		info, _, ok := snaptype.ParseFileName("", p.Name)
-		if !ok {
-			continue
-		}
-		if info.Ext != ".seg" {
-			continue
-		}
-		if fromBlock < info.From {
-			continue
-		}
-		if fromBlock >= info.To {
-			continue
-		}
-		if info.Len() == snaptype.Erigon2MergeLimit ||
-			info.Len() == snaptype.Erigon2OldMergeLimit {
-			return info.Len()
-		}
-
-		break
-	}
-
-	return snaptype.Erigon2MergeLimit
-}
-
 var knownPreverified = map[string]Preverified{
 	networkname.MainnetChainName: Mainnet,
 	// networkname.HoleskyChainName:    HoleskyChainSnapshotCfg,
@@ -343,10 +317,6 @@ func Seedable(networkName string, info snaptype.FileInfo) bool {
 	return KnownCfg(networkName).Seedable(info)
 }
 
-func MergeLimit(networkName string, fromBlock uint64) uint64 {
-	return KnownCfg(networkName).MergeLimit(fromBlock)
-}
-
 func MaxSeedableSegment(chain string, dir string) uint64 {
 	var max uint64
 
@@ -361,15 +331,7 @@ func MaxSeedableSegment(chain string, dir string) uint64 {
 	return max
 }
 
-var oldMergeSteps = append([]uint64{snaptype.Erigon2OldMergeLimit}, snaptype.MergeSteps...)
-
 func MergeSteps(networkName string, fromBlock uint64) []uint64 {
-	mergeLimit := MergeLimit(networkName, fromBlock)
-
-	if mergeLimit == snaptype.Erigon2OldMergeLimit {
-		return oldMergeSteps
-	}
-
 	return snaptype.MergeSteps
 }
 

--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -1058,12 +1058,7 @@ func typedSegments(dir string, minBlock uint64, types []snaptype.Type) (res []sn
 }
 
 func chooseSegmentEnd(from, to uint64, chainConfig *chain.Config) uint64 {
-	var chainName string
-
-	if chainConfig != nil {
-		chainName = chainConfig.ChainName
-	}
-	blocksPerFile := snapcfg.MergeLimit(chainName, from)
+	blocksPerFile := uint64(snaptype.Erigon2MergeLimit)
 
 	next := (from/blocksPerFile + 1) * blocksPerFile
 	to = cmp.Min(next, to)
@@ -1132,13 +1127,7 @@ func canRetire(from, to uint64, chainConfig *chain.Config) (blockFrom, blockTo u
 	roundedTo1K := (to / 1_000) * 1_000
 	var maxJump uint64 = 1_000
 
-	var chainName string
-
-	if chainConfig != nil {
-		chainName = chainConfig.ChainName
-	}
-
-	mergeLimit := snapcfg.MergeLimit(chainName, blockFrom)
+	mergeLimit := uint64(snaptype.Erigon2MergeLimit)
 
 	if blockFrom%mergeLimit == 0 {
 		maxJump = mergeLimit
@@ -2190,7 +2179,7 @@ func (m *Merger) DisableFsync() { m.noFsync = true }
 func (m *Merger) FindMergeRanges(currentRanges []Range, maxBlockNum uint64) (toMerge []Range) {
 	for i := len(currentRanges) - 1; i > 0; i-- {
 		r := currentRanges[i]
-		mergeLimit := snapcfg.MergeLimit(m.chainConfig.ChainName, r.from)
+		mergeLimit := uint64(snaptype.Erigon2MergeLimit)
 		if r.to-r.from >= mergeLimit {
 			continue
 		}

--- a/turbo/snapshotsync/freezeblocks/block_snapshots_test.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots_test.go
@@ -65,12 +65,12 @@ func TestFindMergeRange(t *testing.T) {
 	merger.DisableFsync()
 	t.Run("big", func(t *testing.T) {
 		var rangesOld []Range
-		for i := 0; i < 24; i++ {
-			rangesOld = append(rangesOld, Range{from: uint64(i * 100_000), to: uint64((i + 1) * 100_000)})
+		for i := 0; i < 8; i++ {
+			rangesOld = append(rangesOld, Range{from: uint64(i * 50_000), to: uint64((i + 1) * 50_000)})
 		}
 		found := merger.FindMergeRanges(rangesOld, uint64(24*100_000))
 
-		expect := Ranges{{0, 500000}, {500000, 1000000}, {1000000, 1500000}, {1500000, 2000000}}
+		expect := Ranges{{0, 100000}, {100000, 200000}, {200000, 300000}, {300000, 400000}}
 		require.Equal(t, expect.String(), Ranges(found).String())
 
 		var rangesNew []Range
@@ -91,11 +91,8 @@ func TestFindMergeRange(t *testing.T) {
 		}
 		found := merger.FindMergeRanges(rangesOld, uint64(240*10_000))
 		var expect Ranges
-		for i := uint64(0); i < 4; i++ {
-			expect = append(expect, Range{from: i * snaptype.Erigon2OldMergeLimit, to: (i + 1) * snaptype.Erigon2OldMergeLimit})
-		}
-		for i := uint64(0); i < 4; i++ {
-			expect = append(expect, Range{from: 2_000_000 + i*snaptype.Erigon2MergeLimit, to: 2_000_000 + (i+1)*snaptype.Erigon2MergeLimit})
+		for i := uint64(0); i < 24; i++ {
+			expect = append(expect, Range{from: i * snaptype.Erigon2MergeLimit, to: (i + 1) * snaptype.Erigon2MergeLimit})
 		}
 
 		require.Equal(t, expect.String(), Ranges(found).String())
@@ -142,12 +139,12 @@ func TestMergeSnapshots(t *testing.T) {
 		require.NoError(err)
 	}
 
-	expectedFileName := snaptype.SegmentFileName(snaptype.Transactions.Versions().Current, 0, 500_000, snaptype.Transactions.Enum())
+	expectedFileName := snaptype.SegmentFileName(snaptype.Transactions.Versions().Current, 0, 100_000, snaptype.Transactions.Enum())
 	d, err := seg.NewDecompressor(filepath.Join(dir, expectedFileName))
 	require.NoError(err)
 	defer d.Close()
 	a := d.Count()
-	require.Equal(50, a)
+	require.Equal(10, a)
 
 	{
 		merger := NewMerger(dir, 1, log.LvlInfo, nil, params.MainnetChainConfig, logger)

--- a/turbo/snapshotsync/freezeblocks/caplin_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/caplin_snapshots.go
@@ -14,7 +14,6 @@ import (
 	"github.com/klauspost/compress/zstd"
 	"github.com/ledgerwatch/log/v3"
 
-	"github.com/ledgerwatch/erigon-lib/chain/snapcfg"
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/common/background"
 	"github.com/ledgerwatch/erigon-lib/common/cmp"
@@ -461,7 +460,7 @@ func dumpBlobSidecarsRange(ctx context.Context, db kv.RoDB, storage blob_storage
 
 func DumpBeaconBlocks(ctx context.Context, db kv.RoDB, fromSlot, toSlot uint64, tmpDir, snapDir string, workers int, lvl log.Lvl, logger log.Logger) error {
 	for i := fromSlot; i < toSlot; i = chooseSegmentEnd(i, toSlot, nil) {
-		blocksPerFile := snapcfg.MergeLimit("", i)
+		blocksPerFile := uint64(snaptype.Erigon2MergeLimit)
 
 		if toSlot-i < blocksPerFile {
 			break
@@ -477,7 +476,7 @@ func DumpBeaconBlocks(ctx context.Context, db kv.RoDB, fromSlot, toSlot uint64, 
 
 func DumpBlobsSidecar(ctx context.Context, blobStorage blob_storage.BlobStorage, db kv.RoDB, fromSlot, toSlot uint64, tmpDir, snapDir string, workers int, lvl log.Lvl, logger log.Logger) error {
 	for i := fromSlot; i < toSlot; i = chooseSegmentEnd(i, toSlot, nil) {
-		blocksPerFile := snapcfg.MergeLimit("", i)
+		blocksPerFile := uint64(snaptype.Erigon2MergeLimit)
 
 		if toSlot-i < blocksPerFile {
 			break


### PR DESCRIPTION
This PR removes the merging and expectation to merge 500k ranges. 500k ranges can be supported, HOWEVER, cannot be generated anymore. I removed a test because it was testing whether some ranges can be merged with 100k mode vs 500k mode, which is something removed by this PR.