### PR TITLE
retry make canonical bodies in case of txnums  append gap

### DIFF
--- a/core/rawdb/blockio/block_writer.go
+++ b/core/rawdb/blockio/block_writer.go
@@ -64,7 +64,7 @@ func (w *BlockWriter) MakeBodiesCanonical(tx kv.RwTx, from uint64) error {
 			var e1 rawdbv3.ErrTxNumsAppendWithGap
 			if ok := errors.As(err, &e1); ok {
 				// try again starting from latest available  block
-				return rawdb.AppendCanonicalTxNums(tx, e1.LastBlock())
+				return rawdb.AppendCanonicalTxNums(tx, e1.LastBlock()+1)
 			}
 			return err
 		}

--- a/core/rawdb/blockio/block_writer.go
+++ b/core/rawdb/blockio/block_writer.go
@@ -3,6 +3,7 @@ package blockio
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"time"
 
 	"github.com/ledgerwatch/erigon-lib/kv/backup"
@@ -60,6 +61,11 @@ func (w *BlockWriter) FillHeaderNumberIndex(logPrefix string, tx kv.RwTx, tmpDir
 func (w *BlockWriter) MakeBodiesCanonical(tx kv.RwTx, from uint64) error {
 	if w.historyV3 {
 		if err := rawdb.AppendCanonicalTxNums(tx, from); err != nil {
+			var e1 rawdbv3.ErrTxNumsAppendWithGap
+			if ok := errors.As(err, &e1); ok {
+				// try again starting from latest available  block
+				return rawdb.AppendCanonicalTxNums(tx, e1.LastBlock())
+			}
 			return err
 		}
 	}


### PR DESCRIPTION
This patch will retry `MakeBodiesCanonical` in case it meet the gap (but it tries only once)

Should heal 
`err="[5/15 Bodies] make block canonical: append with gap blockNum=54700000, but current heigh=54592384`