### PR TITLE
[wip][discuss] downloader: increase default net chunk size

### DIFF
--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/anacrolix/torrent"
 	"github.com/anacrolix/torrent/metainfo"
+	pp "github.com/anacrolix/torrent/peer_protocol"
 	"github.com/anacrolix/torrent/storage"
 	"github.com/anacrolix/torrent/types/infohash"
 	"github.com/c2h5oh/datasize"
@@ -1413,7 +1414,7 @@ func (d *Downloader) webDownload(peerUrls []*url.URL, t *torrent.Torrent, i *web
 		return session, fmt.Errorf("can't get torrent spec for %s from info: %w", t.Info().Name, err)
 	}
 
-	spec.ChunkSize = downloadercfg.DefaultNetworkChunkSize
+	spec.ChunkSize = pp.Integer(downloadercfg.DefaultNetworkChunkSize)
 	spec.DisallowDataDownload = true
 
 	info, _, ok := snaptype.ParseFileName(d.SnapDir(), name)

--- a/erigon-lib/downloader/downloadercfg/downloadercfg.go
+++ b/erigon-lib/downloader/downloadercfg/downloadercfg.go
@@ -31,6 +31,7 @@ import (
 	"github.com/c2h5oh/datasize"
 	"github.com/ledgerwatch/erigon-lib/chain/snapcfg"
 	"github.com/ledgerwatch/erigon-lib/common/datadir"
+	"github.com/ledgerwatch/erigon-lib/common/dbg"
 	"github.com/ledgerwatch/erigon-lib/common/dir"
 	"github.com/ledgerwatch/log/v3"
 	"golang.org/x/time/rate"
@@ -42,8 +43,10 @@ import (
 const DefaultPieceSize = 2 * 1024 * 1024
 
 // DefaultNetworkChunkSize - how much data request per 1 network call to peer.
+// `256 * 1024` is home-routers-friendly value
+// `2 * 1024 * 1024` is webseed-friendly value (webseed implementation is not feature-complete yet in lib and increase of net chunk improving speed)
 // default: 16Kb
-const DefaultNetworkChunkSize = 256 * 1024
+var DefaultNetworkChunkSize = dbg.EnvInt("DOWNLOADER_NET_CHUNK_KB", 2*1024) * 1024
 
 type Cfg struct {
 	ClientConfig  *torrent.ClientConfig

--- a/erigon-lib/downloader/downloadercfg/downloadercfg.go
+++ b/erigon-lib/downloader/downloadercfg/downloadercfg.go
@@ -46,7 +46,7 @@ const DefaultPieceSize = 2 * 1024 * 1024
 // `256 * 1024` is home-routers-friendly value
 // `2 * 1024 * 1024` is webseed-friendly value (webseed implementation is not feature-complete yet in lib and increase of net chunk improving speed)
 // default: 16Kb
-var DefaultNetworkChunkSize = dbg.EnvInt("DOWNLOADER_NET_CHUNK_KB", 2*1024) * 1024
+var DefaultNetworkChunkSize = dbg.EnvInt("DOWNLOADER_NET_CHUNK_KB", 256) * 1024
 
 type Cfg struct {
 	ClientConfig  *torrent.ClientConfig

--- a/erigon-lib/downloader/util.go
+++ b/erigon-lib/downloader/util.go
@@ -33,6 +33,7 @@ import (
 	"github.com/anacrolix/torrent"
 	"github.com/anacrolix/torrent/bencode"
 	"github.com/anacrolix/torrent/metainfo"
+	pp "github.com/anacrolix/torrent/peer_protocol"
 	"github.com/ledgerwatch/log/v3"
 	"golang.org/x/sync/errgroup"
 
@@ -295,7 +296,7 @@ func IsSnapNameAllowed(name string) bool {
 // kept in `piece completion storage` (surviving reboot). Once it done - no disk IO needed again.
 // Don't need call torrent.VerifyData manually
 func addTorrentFile(ctx context.Context, ts *torrent.TorrentSpec, torrentClient *torrent.Client, db kv.RwDB, webseeds *WebSeeds) (t *torrent.Torrent, ok bool, err error) {
-	ts.ChunkSize = downloadercfg.DefaultNetworkChunkSize
+	ts.ChunkSize = pp.Integer(downloadercfg.DefaultNetworkChunkSize)
 	ts.DisallowDataDownload = true
 	ts.DisableInitialPieceCheck = true
 	//re-try on panic, with 0 ChunkSize (lib doesn't allow change this field for existing torrents)

--- a/erigon-lib/downloader/webseed.go
+++ b/erigon-lib/downloader/webseed.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/anacrolix/torrent"
 	"io"
 	"net/http"
 	"net/url"
@@ -14,6 +13,8 @@ import (
 	"sort"
 	"strings"
 	"sync"
+
+	"github.com/anacrolix/torrent"
 
 	"github.com/c2h5oh/datasize"
 	"github.com/ledgerwatch/erigon-lib/chain/snapcfg"


### PR DESCRIPTION
```
// DefaultNetworkChunkSize - how much data request per 1 network call to peer.
// `256 * 1024` is home-routers-friendly - otherwise wifi is not usable by other devices (but I know it only for p2p traffic, not for http) 
// `2 * 1024 * 1024` is webseed-friendly (it's implementation in lib is not feature-complete yet, but doable, and increase of net chunk improving speed)
// default: 16Kb
```

my experiments with file which exists only on webseed - shows: 
- it creasing net chunk size helps with speed (2x increasing of value -> 2x increasing of speed. speed stop grow when DefaultNetworkChunkSize > DefaultPieceSize, I see speed 8mb/s)
- amount of webseeds (buckets with same file) also increasing downloading speed (8mb/s from each bucket)

alternatively: 
- can leave defaults and make it parametrizable
- can increase default `--torrent.download.slots` to download more files in parallel


@awskii @mh0lt what do you think? 
