### PR TITLE
etl: make `SortAndFlushInBackground` feature optional 

### DIFF
--- a/erigon-lib/kv/membatch/mapmutation.go
+++ b/erigon-lib/kv/membatch/mapmutation.go
@@ -202,8 +202,11 @@ func (m *Mapmutation) doCommit(tx kv.RwTx) error {
 	for table, bucket := range m.puts {
 		collector := etl.NewCollector("", m.tmpdir, etl.NewSortableBuffer(etl.BufferOptimalSize/2), m.logger)
 		defer collector.Close()
+		collector.SortAndFlushInBackground(true)
 		for key, value := range bucket {
-			collector.Collect([]byte(key), value)
+			if err := collector.Collect([]byte(key), value); err != nil {
+				return err
+			}
 			count++
 			select {
 			default:


### PR DESCRIPTION
```
// sortAndFlushInBackground increase insert performance, but make RAM use less-predictable:
	//   - if disk is over-loaded - app may have much background threads which waiting for flush - and each thread whill hold own `buf` (can't free RAM until flush is done)
	//   - enable it only when writing to `etl` is a bottleneck and unlikely to have many parallel collectors (to not overload CPU/Disk)
```

I will enable it in: 
- e2 batch flush	
- e3 execution (it writing to 7 etl collectors) and batch flush

Example of bad behavior of this feature: I did run erigon on 112 core machine with slow disk and 1Tb RAM - did `erigon snapshots index`, it overloaded CPU and Disk and got OOM kill (and 10K-threads-limit golang's panic). Without this feature - erigon eat 24gb RAM

So, better make Erigon predictable/controllable/stable by default and enable this feature in several critical places.  
