### PR TITLE
fixed downloading of unnecessary blocks when `--caplin.backfilling`=f…

### DIFF
--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -142,6 +142,9 @@ func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Co
 					return false, tx.Commit()
 				}
 			}
+			if hasELBlock && !cfg.backfilling {
+				return true, tx.Commit()
+			}
 		}
 		isInElSnapshots := true
 		if blk.Version() >= clparams.BellatrixVersion && cfg.engine != nil && cfg.engine.SupportInsertion() {


### PR DESCRIPTION
…alse

 Cherry pick PR #9794 into the release