### PR TITLE
support state override for debug_traceTransaction ("offchain events")

### DIFF
--- a/turbo/jsonrpc/tracing.go
+++ b/turbo/jsonrpc/tracing.go
@@ -319,6 +319,100 @@ func (api *PrivateDebugAPIImpl) TraceCall(ctx context.Context, args ethapi.CallA
 	return transactions.TraceTx(ctx, msg, blockCtx, txCtx, ibs, config, chainConfig, stream, api.evmCallTimeout)
 }
 
+// TraceTransaction implements debug_traceTransaction. Returns Geth style transaction traces.
+func (api *PrivateDebugAPIImpl) TraceTransactionOverrides(ctx context.Context, hash common.Hash, config *tracers.TraceConfig, stream *jsoniter.Stream) error {
+	tx, err := api.db.BeginRo(ctx)
+	if err != nil {
+		stream.WriteNil()
+		return err
+	}
+	defer tx.Rollback()
+	chainConfig, err := api.chainConfig(tx)
+	if err != nil {
+		stream.WriteNil()
+		return err
+	}
+	// Retrieve the transaction and assemble its EVM context
+	blockNum, ok, err := api.txnLookup(tx, hash)
+	if err != nil {
+		stream.WriteNil()
+		return err
+	}
+	if !ok {
+		stream.WriteNil()
+		return nil
+	}
+
+	// check pruning to ensure we have history at this block level
+	err = api.BaseAPI.checkPruneHistory(tx, blockNum)
+	if err != nil {
+		stream.WriteNil()
+		return err
+	}
+
+	// Private API returns 0 if transaction is not found.
+	if blockNum == 0 && chainConfig.Bor != nil {
+		blockNumPtr, err := rawdb.ReadBorTxLookupEntry(tx, hash)
+		if err != nil {
+			stream.WriteNil()
+			return err
+		}
+		if blockNumPtr == nil {
+			stream.WriteNil()
+			return nil
+		}
+		blockNum = *blockNumPtr
+	}
+	block, err := api.blockByNumberWithSenders(tx, blockNum)
+	if err != nil {
+		stream.WriteNil()
+		return err
+	}
+	if block == nil {
+		stream.WriteNil()
+		return nil
+	}
+	var txnIndex uint64
+	var txn types.Transaction
+	for i, transaction := range block.Transactions() {
+		if transaction.Hash() == hash {
+			txnIndex = uint64(i)
+			txn = transaction
+			break
+		}
+	}
+	if txn == nil {
+		var borTx types.Transaction
+		borTx, err = rawdb.ReadBorTransaction(tx, hash)
+		if err != nil {
+			return err
+		}
+
+		if borTx != nil {
+			stream.WriteNil()
+			return nil
+		}
+		stream.WriteNil()
+		return fmt.Errorf("transaction %#x not found", hash)
+	}
+	engine := api.engine()
+
+	msg, blockCtx, txCtx, ibs, _, err := transactions.ComputeTxEnv(ctx, engine, block, chainConfig, api._blockReader, tx, int(txnIndex), api.historyV3(tx))
+	if err != nil {
+		stream.WriteNil()
+		return err
+	}
+
+	if config != nil && config.StateOverrides != nil {
+		if err := config.StateOverrides.Override(ibs); err != nil {
+			return fmt.Errorf("override state: %v", err)
+		}
+	}
+
+	// Trace the transaction and return
+	return transactions.TraceTx(ctx, msg, blockCtx, txCtx, ibs, config, chainConfig, stream, api.evmCallTimeout)
+}
+
 func (api *PrivateDebugAPIImpl) TraceCallMany(ctx context.Context, bundles []Bundle, simulateContext StateContext, config *tracers.TraceConfig, stream *jsoniter.Stream) error {
 	var (
 		hash               common.Hash


### PR DESCRIPTION
the `debug_traceCall` function supports state overrides, but `debug_traceTransaction` does not - it only accepts a transaction hash.

I wrote this originally as the backbone for generating "offchain events" (as developed by shadow / ghost logs)

to prevent confusion with nodes that don't implement this feature I created a distinct function `debug_traceTransactionOverrides`.
by overriding contracts bytecode it is possible to reexecute onchain transactions in different context, specifically to emit so called "offchain events" but not limited to this.

usage:
```sh
cast rpc debug_traceTransactionOverrides $txhash '{ "stateOverrides": { "$addr": { "code": "$bytecode" } } }'
```

eg for mainnet:
```sh
cast rpc debug_traceTransactionOverrides 0xc9ab90a1796613b0fbccb33827de583901d4c0775e89c0f25d604b7c3a71771e '{ "stateOverrides": { "0x0000001D0000F38CC10d0028474a9c180058B091": { "code": "0x6000ff" } } }' | jq .
```


see equivalent implementations:

geth: https://github.com/ethereum/go-ethereum/pull/29423
reth: https://github.com/paradigmxyz/reth/pull/7410

