### PR TITLE
fix mumbai execution when no borevents got for block

### DIFF
--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -1452,8 +1452,7 @@ func (c *Bor) CommitStates(
 ) error {
 	events := chain.Chain.BorEventsByBlock(header.Hash(), header.Number.Uint64())
 
-	//if len(events) == 50 || len(events) == 0 {
-	if len(events) == 50 {
+	if len(events) == 50 || len(events) == 0 { // we still sometime could get 0 events from borevent file
 		blockNum := header.Number.Uint64()
 
 		var to time.Time


### PR DESCRIPTION
reverts 799a9405bf50466e53280243d0011f9f7f0a4226