### PR TITLE
downloader: calling wrong url to download .torrent

### DIFF
--- a/erigon-lib/downloader/torrent_files.go
+++ b/erigon-lib/downloader/torrent_files.go
@@ -51,6 +51,10 @@ func (tf *TorrentFiles) delete(name string) error {
 }
 
 func (tf *TorrentFiles) Create(name string, res []byte) error {
+	if !strings.HasSuffix(name, ".torrent") {
+		name += ".torrent"
+	}
+
 	tf.lock.Lock()
 	defer tf.lock.Unlock()
 	return tf.create(filepath.Join(tf.dir, name), res)


### PR DESCRIPTION
- calling wrong url to download .torrent
- save value to disk without `.torrent` suffix 
- size attack prevention - did return nil err and it stopped webseed scanning