### PR TITLE
polygon/heimdall: heimdall improvements after astrid sync tests

### DIFF
--- a/polygon/heimdall/client.go
+++ b/polygon/heimdall/client.go
@@ -132,16 +132,16 @@ func (c *Client) FetchStateSyncEvents(ctx context.Context, fromID uint64, to tim
 			return nil, err
 		}
 
-		c.logger.Debug("[bor.heimdall] Fetching state sync events", "queryParams", url.RawQuery)
+		c.logger.Debug(heimdallLogPrefix("Fetching state sync events"), "queryParams", url.RawQuery)
 
 		ctx = withRequestType(ctx, stateSyncRequest)
 
-		response, err := FetchWithRetry[StateSyncEventsResponse](ctx, c, url)
+		response, err := FetchWithRetry[StateSyncEventsResponse](ctx, c, url, c.logger)
 		if err != nil {
 			if errors.Is(err, ErrNoResponse) {
 				// for more info check https://github.com/maticnetwork/heimdall/pull/993
 				c.logger.Warn(
-					"[bor.heimdall] check heimdall logs to see if it is in sync - no response when querying state sync events",
+					heimdallLogPrefix("check heimdall logs to see if it is in sync - no response when querying state sync events"),
 					"path", url.Path,
 					"queryParams", url.RawQuery,
 				)
@@ -178,7 +178,7 @@ func (c *Client) FetchLatestSpan(ctx context.Context) (*Span, error) {
 
 	ctx = withRequestType(ctx, spanRequest)
 
-	response, err := FetchWithRetry[SpanResponse](ctx, c, url)
+	response, err := FetchWithRetry[SpanResponse](ctx, c, url, c.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -194,7 +194,7 @@ func (c *Client) FetchSpan(ctx context.Context, spanID uint64) (*Span, error) {
 
 	ctx = withRequestType(ctx, spanRequest)
 
-	response, err := FetchWithRetry[SpanResponse](ctx, c, url)
+	response, err := FetchWithRetry[SpanResponse](ctx, c, url, c.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +211,7 @@ func (c *Client) FetchCheckpoint(ctx context.Context, number int64) (*Checkpoint
 
 	ctx = withRequestType(ctx, checkpointRequest)
 
-	response, err := FetchWithRetry[CheckpointResponse](ctx, c, url)
+	response, err := FetchWithRetry[CheckpointResponse](ctx, c, url, c.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -237,7 +237,7 @@ func (c *Client) FetchMilestone(ctx context.Context, number int64) (*Milestone, 
 		return !isInvalidMilestoneIndexError(err)
 	}
 
-	response, err := FetchWithRetryEx[MilestoneResponse](ctx, c, url, isRecoverableError)
+	response, err := FetchWithRetryEx[MilestoneResponse](ctx, c, url, isRecoverableError, c.logger)
 	if err != nil {
 		if isInvalidMilestoneIndexError(err) {
 			return nil, fmt.Errorf("%w: number %d", ErrNotInMilestoneList, number)
@@ -257,7 +257,7 @@ func (c *Client) FetchCheckpointCount(ctx context.Context) (int64, error) {
 
 	ctx = withRequestType(ctx, checkpointCountRequest)
 
-	response, err := FetchWithRetry[CheckpointCountResponse](ctx, c, url)
+	response, err := FetchWithRetry[CheckpointCountResponse](ctx, c, url, c.logger)
 	if err != nil {
 		return 0, err
 	}
@@ -274,7 +274,7 @@ func (c *Client) FetchMilestoneCount(ctx context.Context) (int64, error) {
 
 	ctx = withRequestType(ctx, milestoneCountRequest)
 
-	response, err := FetchWithRetry[MilestoneCountResponse](ctx, c, url)
+	response, err := FetchWithRetry[MilestoneCountResponse](ctx, c, url, c.logger)
 	if err != nil {
 		return 0, err
 	}
@@ -291,7 +291,7 @@ func (c *Client) FetchLastNoAckMilestone(ctx context.Context) (string, error) {
 
 	ctx = withRequestType(ctx, milestoneLastNoAckRequest)
 
-	response, err := FetchWithRetry[MilestoneLastNoAckResponse](ctx, c, url)
+	response, err := FetchWithRetry[MilestoneLastNoAckResponse](ctx, c, url, c.logger)
 	if err != nil {
 		return "", err
 	}
@@ -308,7 +308,7 @@ func (c *Client) FetchNoAckMilestone(ctx context.Context, milestoneID string) er
 
 	ctx = withRequestType(ctx, milestoneNoAckRequest)
 
-	response, err := FetchWithRetry[MilestoneNoAckResponse](ctx, c, url)
+	response, err := FetchWithRetry[MilestoneNoAckResponse](ctx, c, url, c.logger)
 	if err != nil {
 		return err
 	}
@@ -330,7 +330,7 @@ func (c *Client) FetchMilestoneID(ctx context.Context, milestoneID string) error
 
 	ctx = withRequestType(ctx, milestoneIDRequest)
 
-	response, err := FetchWithRetry[MilestoneIDResponse](ctx, c, url)
+	response, err := FetchWithRetry[MilestoneIDResponse](ctx, c, url, c.logger)
 
 	if err != nil {
 		return err
@@ -344,12 +344,18 @@ func (c *Client) FetchMilestoneID(ctx context.Context, milestoneID string) error
 }
 
 // FetchWithRetry returns data from heimdall with retry
-func FetchWithRetry[T any](ctx context.Context, client *Client, url *url.URL) (*T, error) {
-	return FetchWithRetryEx[T](ctx, client, url, nil)
+func FetchWithRetry[T any](ctx context.Context, client *Client, url *url.URL, logger log.Logger) (*T, error) {
+	return FetchWithRetryEx[T](ctx, client, url, nil, logger)
 }
 
 // FetchWithRetryEx returns data from heimdall with retry
-func FetchWithRetryEx[T any](ctx context.Context, client *Client, url *url.URL, isRecoverableError func(error) bool) (result *T, err error) {
+func FetchWithRetryEx[T any](
+	ctx context.Context,
+	client *Client,
+	url *url.URL,
+	isRecoverableError func(error) bool,
+	logger log.Logger,
+) (result *T, err error) {
 	attempt := 0
 	// create a new ticker for retrying the request
 	ticker := time.NewTicker(client.retryBackOff)
@@ -359,7 +365,7 @@ func FetchWithRetryEx[T any](ctx context.Context, client *Client, url *url.URL, 
 		attempt++
 
 		request := &Request{client: client.client, url: url, start: time.Now()}
-		result, err = Fetch[T](ctx, request)
+		result, err = Fetch[T](ctx, request, logger)
 		if err == nil {
 			return result, nil
 		}
@@ -368,7 +374,7 @@ func FetchWithRetryEx[T any](ctx context.Context, client *Client, url *url.URL, 
 		// yet in heimdall. E.g. when the hard fork hasn't hit yet but heimdall
 		// is upgraded.
 		if errors.Is(err, ErrServiceUnavailable) {
-			client.logger.Debug("[bor.heimdall] service unavailable at the moment", "path", url.Path, "queryParams", url.RawQuery, "attempt", attempt, "err", err)
+			client.logger.Debug(heimdallLogPrefix("service unavailable at the moment"), "path", url.Path, "queryParams", url.RawQuery, "attempt", attempt, "err", err)
 			return nil, err
 		}
 
@@ -376,14 +382,14 @@ func FetchWithRetryEx[T any](ctx context.Context, client *Client, url *url.URL, 
 			return nil, err
 		}
 
-		client.logger.Warn("[bor.heimdall] an error while fetching", "path", url.Path, "queryParams", url.RawQuery, "attempt", attempt, "err", err)
+		client.logger.Warn(heimdallLogPrefix("an error while fetching"), "path", url.Path, "queryParams", url.RawQuery, "attempt", attempt, "err", err)
 
 		select {
 		case <-ctx.Done():
-			client.logger.Debug("[bor.heimdall] request canceled", "reason", ctx.Err(), "path", url.Path, "queryParams", url.RawQuery, "attempt", attempt)
+			client.logger.Debug(heimdallLogPrefix("request canceled"), "reason", ctx.Err(), "path", url.Path, "queryParams", url.RawQuery, "attempt", attempt)
 			return nil, ctx.Err()
 		case <-client.closeCh:
-			client.logger.Debug("[bor.heimdall] shutdown detected, terminating request", "path", url.Path, "queryParams", url.RawQuery)
+			client.logger.Debug(heimdallLogPrefix("shutdown detected, terminating request"), "path", url.Path, "queryParams", url.RawQuery)
 			return nil, ErrShutdownDetected
 		case <-ticker.C:
 			// retry
@@ -394,7 +400,7 @@ func FetchWithRetryEx[T any](ctx context.Context, client *Client, url *url.URL, 
 }
 
 // Fetch fetches response from heimdall
-func Fetch[T any](ctx context.Context, request *Request) (*T, error) {
+func Fetch[T any](ctx context.Context, request *Request, logger log.Logger) (*T, error) {
 	isSuccessful := false
 
 	defer func() {
@@ -405,7 +411,7 @@ func Fetch[T any](ctx context.Context, request *Request) (*T, error) {
 
 	result := new(T)
 
-	body, err := internalFetchWithTimeout(ctx, request.client, request.url)
+	body, err := internalFetchWithTimeout(ctx, request.client, request.url, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -489,11 +495,13 @@ func makeURL(urlString, rawPath, rawQuery string) (*url.URL, error) {
 }
 
 // internal fetch method
-func internalFetch(ctx context.Context, client HttpClient, u *url.URL) ([]byte, error) {
+func internalFetch(ctx context.Context, client HttpClient, u *url.URL, logger log.Logger) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, err
 	}
+
+	logger.Trace(heimdallLogPrefix("http client get request"), "uri", u.RequestURI())
 
 	res, err := client.Do(req)
 	if err != nil {
@@ -527,12 +535,12 @@ func internalFetch(ctx context.Context, client HttpClient, u *url.URL) ([]byte, 
 	return body, nil
 }
 
-func internalFetchWithTimeout(ctx context.Context, client HttpClient, url *url.URL) ([]byte, error) {
+func internalFetchWithTimeout(ctx context.Context, client HttpClient, url *url.URL, logger log.Logger) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(ctx, apiHeimdallTimeout)
 	defer cancel()
 
 	// request data once
-	return internalFetch(ctx, client, url)
+	return internalFetch(ctx, client, url, logger)
 }
 
 // Close sends a signal to stop the running process

--- a/polygon/heimdall/heimdall.go
+++ b/polygon/heimdall/heimdall.go
@@ -65,7 +65,7 @@ func (h *heimdall) LastCheckpointId(ctx context.Context, _ CheckpointStore) (Che
 }
 
 func (h *heimdall) FetchCheckpointsFromBlock(ctx context.Context, store CheckpointStore, startBlock uint64) (Waypoints, error) {
-	h.logger.Info(heimdallLogPrefix("fetching checkpoints from block"), "start", startBlock)
+	h.logger.Trace(heimdallLogPrefix("fetching checkpoints from block"), "start", startBlock)
 	startFetchTime := time.Now()
 
 	count, _, err := h.LastCheckpointId(ctx, store)
@@ -119,7 +119,7 @@ func (h *heimdall) FetchCheckpointsFromBlock(ctx context.Context, store Checkpoi
 
 	common.SliceReverse(checkpoints)
 
-	h.logger.Info(
+	h.logger.Trace(
 		heimdallLogPrefix("finished fetching checkpoints from block"),
 		"count", len(checkpoints),
 		"start", startBlock,
@@ -189,7 +189,7 @@ func (h *heimdall) LastMilestoneId(ctx context.Context, _ MilestoneStore) (Miles
 }
 
 func (h *heimdall) FetchMilestonesFromBlock(ctx context.Context, store MilestoneStore, startBlock uint64) (Waypoints, error) {
-	h.logger.Info(heimdallLogPrefix("fetching milestones from block"), "start", startBlock)
+	h.logger.Trace(heimdallLogPrefix("fetching milestones from block"), "start", startBlock)
 	startFetchTime := time.Now()
 
 	last, _, err := h.LastMilestoneId(ctx, store)
@@ -243,7 +243,7 @@ func (h *heimdall) FetchMilestonesFromBlock(ctx context.Context, store Milestone
 
 	common.SliceReverse(milestones)
 
-	h.logger.Info(
+	h.logger.Trace(
 		heimdallLogPrefix("finished fetching milestones from block"),
 		"count", len(milestones),
 		"start", startBlock,

--- a/polygon/heimdall/heimdall.go
+++ b/polygon/heimdall/heimdall.go
@@ -37,14 +37,14 @@ var ErrIncompleteMilestoneRange = errors.New("milestone range doesn't contain th
 var ErrIncompleteCheckpointRange = errors.New("checkpoint range doesn't contain the start block")
 var ErrIncompleteSpanRange = errors.New("span range doesn't contain the start block")
 
-type heimdallImpl struct {
+type heimdall struct {
 	client    HeimdallClient
 	pollDelay time.Duration
 	logger    log.Logger
 }
 
 func NewHeimdall(client HeimdallClient, logger log.Logger) Heimdall {
-	h := heimdallImpl{
+	h := heimdall{
 		client:    client,
 		pollDelay: time.Second,
 		logger:    logger,
@@ -52,7 +52,7 @@ func NewHeimdall(client HeimdallClient, logger log.Logger) Heimdall {
 	return &h
 }
 
-func (h *heimdallImpl) LastCheckpointId(ctx context.Context, store CheckpointStore) (CheckpointId, bool, error) {
+func (h *heimdall) LastCheckpointId(ctx context.Context, _ CheckpointStore) (CheckpointId, bool, error) {
 	// todo get this from store if its likely not changed (need timeout)
 
 	count, err := h.client.FetchCheckpointCount(ctx)
@@ -64,16 +64,33 @@ func (h *heimdallImpl) LastCheckpointId(ctx context.Context, store CheckpointSto
 	return CheckpointId(count), true, nil
 }
 
-func (h *heimdallImpl) FetchCheckpointsFromBlock(ctx context.Context, store CheckpointStore, startBlock uint64) (Waypoints, error) {
-	count, _, err := h.LastCheckpointId(ctx, store)
+func (h *heimdall) FetchCheckpointsFromBlock(ctx context.Context, store CheckpointStore, startBlock uint64) (Waypoints, error) {
+	h.logger.Info(heimdallLogPrefix("fetching checkpoints from block"), "start", startBlock)
+	startFetchTime := time.Now()
 
+	count, _, err := h.LastCheckpointId(ctx, store)
 	if err != nil {
 		return nil, err
 	}
 
-	var checkpoints []Waypoint
+	progressLogTicker := time.NewTicker(30 * time.Second)
+	defer progressLogTicker.Stop()
 
+	var checkpoints []Waypoint
+	var endBlock uint64
 	for i := count; i >= 1; i-- {
+		select {
+		case <-progressLogTicker.C:
+			h.logger.Info(
+				heimdallLogPrefix("fetch checkpoints from block progress (backwards)"),
+				"checkpoint number", i,
+				"start", startBlock,
+				"last", count,
+			)
+		default:
+			// carry on
+		}
+
 		c, err := h.FetchCheckpoints(ctx, store, i, i)
 		if err != nil {
 			if errors.Is(err, ErrNotInCheckpointList) {
@@ -91,6 +108,7 @@ func (h *heimdallImpl) FetchCheckpointsFromBlock(ctx context.Context, store Chec
 
 		for _, c := range c {
 			checkpoints = append(checkpoints, c)
+			endBlock = c.EndBlock().Uint64()
 		}
 
 		// the checkpoint contains the start block
@@ -100,10 +118,19 @@ func (h *heimdallImpl) FetchCheckpointsFromBlock(ctx context.Context, store Chec
 	}
 
 	common.SliceReverse(checkpoints)
+
+	h.logger.Info(
+		heimdallLogPrefix("finished fetching checkpoints from block"),
+		"count", len(checkpoints),
+		"start", startBlock,
+		"end", endBlock,
+		"time", time.Since(startFetchTime),
+	)
+
 	return checkpoints, nil
 }
 
-func (h *heimdallImpl) FetchCheckpoints(ctx context.Context, store CheckpointStore, start CheckpointId, end CheckpointId) ([]*Checkpoint, error) {
+func (h *heimdall) FetchCheckpoints(ctx context.Context, store CheckpointStore, start CheckpointId, end CheckpointId) ([]*Checkpoint, error) {
 	var checkpoints []*Checkpoint
 
 	lastCheckpointId, exists, err := store.LastCheckpointId(ctx)
@@ -149,7 +176,7 @@ func (h *heimdallImpl) FetchCheckpoints(ctx context.Context, store CheckpointSto
 	return checkpoints, nil
 }
 
-func (h *heimdallImpl) LastMilestoneId(ctx context.Context, store MilestoneStore) (MilestoneId, bool, error) {
+func (h *heimdall) LastMilestoneId(ctx context.Context, _ MilestoneStore) (MilestoneId, bool, error) {
 	// todo get this from store if its likely not changed (need timeout)
 
 	count, err := h.client.FetchMilestoneCount(ctx)
@@ -161,16 +188,33 @@ func (h *heimdallImpl) LastMilestoneId(ctx context.Context, store MilestoneStore
 	return MilestoneId(count), true, nil
 }
 
-func (h *heimdallImpl) FetchMilestonesFromBlock(ctx context.Context, store MilestoneStore, startBlock uint64) (Waypoints, error) {
-	last, _, err := h.LastMilestoneId(ctx, store)
+func (h *heimdall) FetchMilestonesFromBlock(ctx context.Context, store MilestoneStore, startBlock uint64) (Waypoints, error) {
+	h.logger.Info(heimdallLogPrefix("fetching milestones from block"), "start", startBlock)
+	startFetchTime := time.Now()
 
+	last, _, err := h.LastMilestoneId(ctx, store)
 	if err != nil {
 		return nil, err
 	}
 
-	var milestones Waypoints
+	progressLogTicker := time.NewTicker(30 * time.Second)
+	defer progressLogTicker.Stop()
 
+	var milestones Waypoints
+	var endBlock uint64
 	for i := last; i >= 1; i-- {
+		select {
+		case <-progressLogTicker.C:
+			h.logger.Info(
+				heimdallLogPrefix("fetching milestones from block progress (backwards)"),
+				"milestone id", i,
+				"last", last,
+				"start", startBlock,
+			)
+		default:
+			// carry on
+		}
+
 		m, err := h.FetchMilestones(ctx, store, i, i)
 		if err != nil {
 			if errors.Is(err, ErrNotInMilestoneList) {
@@ -188,6 +232,7 @@ func (h *heimdallImpl) FetchMilestonesFromBlock(ctx context.Context, store Miles
 
 		for _, m := range m {
 			milestones = append(milestones, m)
+			endBlock = m.EndBlock().Uint64()
 		}
 
 		// the checkpoint contains the start block
@@ -197,10 +242,19 @@ func (h *heimdallImpl) FetchMilestonesFromBlock(ctx context.Context, store Miles
 	}
 
 	common.SliceReverse(milestones)
+
+	h.logger.Info(
+		heimdallLogPrefix("finished fetching milestones from block"),
+		"count", len(milestones),
+		"start", startBlock,
+		"end", endBlock,
+		"time", time.Since(startFetchTime),
+	)
+
 	return milestones, nil
 }
 
-func (h *heimdallImpl) FetchMilestones(ctx context.Context, store MilestoneStore, start MilestoneId, end MilestoneId) ([]*Milestone, error) {
+func (h *heimdall) FetchMilestones(ctx context.Context, store MilestoneStore, start MilestoneId, end MilestoneId) ([]*Milestone, error) {
 	var milestones []*Milestone
 
 	lastMilestoneId, exists, err := store.LastMilestoneId(ctx)
@@ -246,7 +300,7 @@ func (h *heimdallImpl) FetchMilestones(ctx context.Context, store MilestoneStore
 	return milestones, nil
 }
 
-func (h *heimdallImpl) LastSpanId(ctx context.Context, store SpanStore) (SpanId, bool, error) {
+func (h *heimdall) LastSpanId(ctx context.Context, store SpanStore) (SpanId, bool, error) {
 	span, err := h.FetchLatestSpan(ctx, store)
 
 	if err != nil {
@@ -256,11 +310,11 @@ func (h *heimdallImpl) LastSpanId(ctx context.Context, store SpanStore) (SpanId,
 	return span.Id, true, nil
 }
 
-func (h *heimdallImpl) FetchLatestSpan(ctx context.Context, store SpanStore) (*Span, error) {
+func (h *heimdall) FetchLatestSpan(ctx context.Context, _ SpanStore) (*Span, error) {
 	return h.client.FetchLatestSpan(ctx)
 }
 
-func (h *heimdallImpl) FetchSpansFromBlock(ctx context.Context, store SpanStore, startBlock uint64) ([]*Span, error) {
+func (h *heimdall) FetchSpansFromBlock(ctx context.Context, store SpanStore, startBlock uint64) ([]*Span, error) {
 	last, _, err := h.LastSpanId(ctx, store)
 
 	if err != nil {
@@ -297,7 +351,7 @@ func (h *heimdallImpl) FetchSpansFromBlock(ctx context.Context, store SpanStore,
 	return spans, nil
 }
 
-func (h *heimdallImpl) FetchSpans(ctx context.Context, store SpanStore, start SpanId, end SpanId) ([]*Span, error) {
+func (h *heimdall) FetchSpans(ctx context.Context, store SpanStore, start SpanId, end SpanId) ([]*Span, error) {
 	var spans []*Span
 
 	lastSpanId, exists, err := store.LastSpanId(ctx)
@@ -343,155 +397,175 @@ func (h *heimdallImpl) FetchSpans(ctx context.Context, store SpanStore, start Sp
 	return spans, nil
 }
 
-func (h *heimdallImpl) OnSpanEvent(ctx context.Context, store SpanStore, callback func(*Span)) error {
-	currentCount, ok, err := store.LastSpanId(ctx)
-
+func (h *heimdall) OnSpanEvent(ctx context.Context, store SpanStore, cb func(*Span)) error {
+	tip, ok, err := store.LastSpanId(ctx)
 	if err != nil {
 		return err
 	}
 
 	if !ok {
-		currentCount, _, err = h.LastSpanId(ctx, store)
-
+		tip, _, err = h.LastSpanId(ctx, store)
 		if err != nil {
 			return err
 		}
 	}
 
-	go func() {
-		for {
-			latestSpan, err := h.client.FetchLatestSpan(ctx)
-			if err != nil {
-				if !errors.Is(err, context.Canceled) {
-					h.logger.Error("heimdallImpl.OnSpanEvent FetchSpanCount error", "err", err)
-				}
-				break
-			}
-
-			if latestSpan.Id <= currentCount {
-				pollDelayTimer := time.NewTimer(h.pollDelay)
-				select {
-				case <-ctx.Done():
-					return
-				case <-pollDelayTimer.C:
-				}
-			} else {
-				m, err := h.FetchSpans(ctx, store, currentCount+1, latestSpan.Id)
-				currentCount = latestSpan.Id
-
-				if err != nil {
-					if !errors.Is(err, context.Canceled) {
-						h.logger.Error("heimdallImpl.OnSpanEvent FetchSpan error", "err", err)
-					}
-					break
-				}
-
-				go callback(m[len(m)-1])
-			}
-		}
-	}()
+	go h.pollSpans(ctx, store, tip, cb)
 
 	return nil
 }
 
-func (h *heimdallImpl) OnCheckpointEvent(ctx context.Context, store CheckpointStore, callback func(*Checkpoint)) error {
-	currentCount, ok, err := store.LastCheckpointId(ctx)
+func (h *heimdall) pollSpans(ctx context.Context, store SpanStore, tip SpanId, cb func(*Span)) {
+	for ctx.Err() == nil {
+		latestSpan, err := h.client.FetchLatestSpan(ctx)
+		if err != nil {
+			h.logger.Warn(
+				heimdallLogPrefix("heimdall.OnSpanEvent FetchSpanCount failed"),
+				"err", err,
+			)
 
+			h.waitPollingDelay(ctx)
+			// keep background goroutine alive in case of heimdall errors
+			continue
+		}
+
+		if latestSpan.Id <= tip {
+			h.waitPollingDelay(ctx)
+			continue
+		}
+
+		m, err := h.FetchSpans(ctx, store, tip+1, latestSpan.Id)
+		if err != nil {
+			h.logger.Warn(
+				heimdallLogPrefix("heimdall.OnSpanEvent FetchSpan failed"),
+				"err", err,
+			)
+
+			h.waitPollingDelay(ctx)
+			// keep background goroutine alive in case of heimdall errors
+			continue
+		}
+
+		tip = latestSpan.Id
+		go cb(m[len(m)-1])
+	}
+}
+
+func (h *heimdall) OnCheckpointEvent(ctx context.Context, store CheckpointStore, cb func(*Checkpoint)) error {
+	tip, ok, err := store.LastCheckpointId(ctx)
 	if err != nil {
 		return err
 	}
 
 	if !ok {
-		currentCount, _, err = h.LastCheckpointId(ctx, store)
-
+		tip, _, err = h.LastCheckpointId(ctx, store)
 		if err != nil {
 			return err
 		}
 	}
 
-	go func() {
-		for {
-			count, err := h.client.FetchCheckpointCount(ctx)
-			if err != nil {
-				if !errors.Is(err, context.Canceled) {
-					h.logger.Error("heimdallImpl.OnMilestoneEvent FetchMilestoneCount error", "err", err)
-				}
-				break
-			}
-
-			if count <= int64(currentCount) {
-				pollDelayTimer := time.NewTimer(h.pollDelay)
-				select {
-				case <-ctx.Done():
-					return
-				case <-pollDelayTimer.C:
-				}
-			} else {
-				m, err := h.FetchCheckpoints(ctx, store, currentCount+1, CheckpointId(count))
-				currentCount = CheckpointId(count)
-
-				if err != nil {
-					if !errors.Is(err, context.Canceled) {
-						h.logger.Error("heimdallImpl.OnMilestoneEvent FetchMilestone error", "err", err)
-					}
-					break
-				}
-
-				go callback(m[len(m)-1])
-			}
-		}
-	}()
+	go h.pollCheckpoints(ctx, store, tip, cb)
 
 	return nil
 }
 
-func (h *heimdallImpl) OnMilestoneEvent(ctx context.Context, store MilestoneStore, callback func(*Milestone)) error {
-	currentCount, ok, err := store.LastMilestoneId(ctx)
+func (h *heimdall) pollCheckpoints(ctx context.Context, store CheckpointStore, tip CheckpointId, cb func(*Checkpoint)) {
+	for ctx.Err() == nil {
+		count, err := h.client.FetchCheckpointCount(ctx)
+		if err != nil {
+			h.logger.Warn(
+				heimdallLogPrefix("OnCheckpointEvent.OnCheckpointEvent FetchCheckpointCount failed"),
+				"err", err,
+			)
 
+			h.waitPollingDelay(ctx)
+			// keep background goroutine alive in case of heimdall errors
+			continue
+		}
+
+		if count <= int64(tip) {
+			h.waitPollingDelay(ctx)
+			continue
+		}
+
+		m, err := h.FetchCheckpoints(ctx, store, tip+1, CheckpointId(count))
+		if err != nil {
+			h.logger.Warn(
+				heimdallLogPrefix("heimdall.OnCheckpointEvent FetchCheckpoints failed"),
+				"err", err,
+			)
+
+			h.waitPollingDelay(ctx)
+			// keep background goroutine alive in case of heimdall errors
+			continue
+		}
+
+		tip = CheckpointId(count)
+		go cb(m[len(m)-1])
+	}
+}
+
+func (h *heimdall) OnMilestoneEvent(ctx context.Context, store MilestoneStore, cb func(*Milestone)) error {
+	tip, ok, err := store.LastMilestoneId(ctx)
 	if err != nil {
 		return err
 	}
 
 	if !ok {
-		currentCount, _, err = h.LastMilestoneId(ctx, store)
-
+		tip, _, err = h.LastMilestoneId(ctx, store)
 		if err != nil {
 			return err
 		}
 	}
 
-	go func() {
-		for {
-			count, err := h.client.FetchMilestoneCount(ctx)
-			if err != nil {
-				if !errors.Is(err, context.Canceled) {
-					h.logger.Error("heimdallImpl.OnMilestoneEvent FetchMilestoneCount error", "err", err)
-				}
-				break
-			}
-
-			if count <= int64(currentCount) {
-				pollDelayTimer := time.NewTimer(h.pollDelay)
-				select {
-				case <-ctx.Done():
-					return
-				case <-pollDelayTimer.C:
-				}
-			} else {
-				m, err := h.FetchMilestones(ctx, store, currentCount+1, MilestoneId(count))
-				currentCount = MilestoneId(count)
-
-				if err != nil {
-					if !errors.Is(err, context.Canceled) {
-						h.logger.Error("heimdallImpl.OnMilestoneEvent FetchMilestone error", "err", err)
-					}
-					break
-				}
-
-				go callback(m[len(m)-1])
-			}
-		}
-	}()
+	go h.pollMilestones(ctx, store, tip, cb)
 
 	return nil
+}
+
+func (h *heimdall) pollMilestones(ctx context.Context, store MilestoneStore, tip MilestoneId, cb func(*Milestone)) {
+	for ctx.Err() == nil {
+		count, err := h.client.FetchMilestoneCount(ctx)
+		if err != nil {
+			h.logger.Warn(
+				heimdallLogPrefix("heimdall.OnMilestoneEvent FetchMilestoneCount failed"),
+				"err", err,
+			)
+
+			h.waitPollingDelay(ctx)
+			// keep background goroutine alive in case of heimdall errors
+			continue
+		}
+
+		if count <= int64(tip) {
+			h.waitPollingDelay(ctx)
+			continue
+		}
+
+		m, err := h.FetchMilestones(ctx, store, tip+1, MilestoneId(count))
+		if err != nil {
+			h.logger.Warn(
+				heimdallLogPrefix("heimdall.OnMilestoneEvent FetchMilestone failed"),
+				"err", err,
+			)
+
+			h.waitPollingDelay(ctx)
+			// keep background goroutine alive in case of heimdall errors
+			continue
+		}
+
+		tip = MilestoneId(count)
+		go cb(m[len(m)-1])
+	}
+}
+
+func (h *heimdall) waitPollingDelay(ctx context.Context) {
+	pollDelayTimer := time.NewTimer(h.pollDelay)
+	defer pollDelayTimer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return
+	case <-pollDelayTimer.C:
+	}
 }

--- a/polygon/heimdall/log_prefix.go
+++ b/polygon/heimdall/log_prefix.go
@@ -1,0 +1,7 @@
+package heimdall
+
+import "fmt"
+
+func heimdallLogPrefix(message string) string {
+	return fmt.Sprintf("[bor.heimdall] %s", message)
+}

--- a/polygon/heimdall/waypoint.go
+++ b/polygon/heimdall/waypoint.go
@@ -35,7 +35,7 @@ func (a *WaypointFields) CmpRange(n uint64) int {
 	if num.Cmp(a.StartBlock) < 0 {
 		return -1
 	}
-	if num.Cmp(a.StartBlock) > 0 {
+	if num.Cmp(a.EndBlock) > 0 {
 		return 1
 	}
 	return 0


### PR DESCRIPTION
- fixes an issue where heimdall polling goroutines get terminated upon a heimdall http err which is incorrect - these polling routines should be kept alive upon errors and errors should simply be logged
- adds logging
- reduces cyclomatic complexity by extracting logic for polling events, spans, checkpoints  