### PR TITLE
Caplin: Fixed archive node validator set lists.

### DIFF
--- a/cl/antiquary/state_antiquary.go
+++ b/cl/antiquary/state_antiquary.go
@@ -117,8 +117,6 @@ func (s *Antiquary) IncrementBeaconState(ctx context.Context, to uint64) error {
 	stateAntiquaryCollector := newBeaconStatesCollector(s.cfg, s.dirs.Tmp, s.logger)
 	defer stateAntiquaryCollector.close()
 
-	// buffers
-
 	if err := s.initializeStateAntiquaryIfNeeded(ctx, tx); err != nil {
 		return err
 	}
@@ -130,12 +128,13 @@ func (s *Antiquary) IncrementBeaconState(ctx context.Context, to uint64) error {
 		// Mark all validators as touched because we just initizialized the whole state.
 		s.currentState.ForEachValidator(func(v solid.Validator, index, total int) bool {
 			changedValidators[uint64(index)] = struct{}{}
-			if err = s.validatorsTable.AddValidator(v, uint64(index), 0); err != nil {
+			if err = s.validatorsTable.AddValidator(v, uint64(index), s.currentState.Slot()); err != nil {
 				return false
 			}
 			return true
 		})
 	}
+	s.validatorsTable.SetSlot(s.currentState.Slot())
 
 	logLvl := log.LvlInfo
 	if to-s.currentState.Slot() < 96 {
@@ -367,8 +366,6 @@ func (s *Antiquary) IncrementBeaconState(ctx context.Context, to uint64) error {
 	if err := state_accessors.SetStateProcessingProgress(rwTx, s.currentState.Slot()); err != nil {
 		return err
 	}
-
-	s.validatorsTable.SetSlot(s.currentState.Slot())
 
 	buf := &bytes.Buffer{}
 	s.validatorsTable.ForEach(func(validatorIndex uint64, validator *state_accessors.StaticValidator) bool {

--- a/cl/antiquary/state_antiquary.go
+++ b/cl/antiquary/state_antiquary.go
@@ -128,7 +128,7 @@ func (s *Antiquary) IncrementBeaconState(ctx context.Context, to uint64) error {
 		// Mark all validators as touched because we just initizialized the whole state.
 		s.currentState.ForEachValidator(func(v solid.Validator, index, total int) bool {
 			changedValidators[uint64(index)] = struct{}{}
-			if err = s.validatorsTable.AddValidator(v, uint64(index), s.currentState.Slot()); err != nil {
+			if err = s.validatorsTable.AddValidator(v, uint64(index), 0); err != nil {
 				return false
 			}
 			return true
@@ -368,6 +368,8 @@ func (s *Antiquary) IncrementBeaconState(ctx context.Context, to uint64) error {
 		return err
 	}
 
+	s.validatorsTable.SetSlot(s.currentState.Slot())
+
 	buf := &bytes.Buffer{}
 	s.validatorsTable.ForEach(func(validatorIndex uint64, validator *state_accessors.StaticValidator) bool {
 		if _, ok := changedValidators[validatorIndex]; !ok {
@@ -393,7 +395,6 @@ func (s *Antiquary) IncrementBeaconState(ctx context.Context, to uint64) error {
 	if err != nil {
 		return err
 	}
-	//s.validatorsTable.SetSlot(s.currentState.Slot())
 	log.Info("Historical states antiquated", "slot", s.currentState.Slot(), "root", libcommon.Hash(stateRoot), "latency", endTime)
 	return nil
 }

--- a/cl/antiquary/state_antiquary.go
+++ b/cl/antiquary/state_antiquary.go
@@ -357,6 +357,7 @@ func (s *Antiquary) IncrementBeaconState(ctx context.Context, to uint64) error {
 		return err
 	}
 	defer rwTx.Rollback()
+
 	start = time.Now()
 	// We now need to store the state
 	if err := stateAntiquaryCollector.flush(ctx, rwTx); err != nil {
@@ -392,6 +393,7 @@ func (s *Antiquary) IncrementBeaconState(ctx context.Context, to uint64) error {
 	if err != nil {
 		return err
 	}
+	//s.validatorsTable.SetSlot(s.currentState.Slot())
 	log.Info("Historical states antiquated", "slot", s.currentState.Slot(), "root", libcommon.Hash(stateRoot), "latency", endTime)
 	return nil
 }
@@ -473,6 +475,5 @@ func computeSlotToBeRequested(tx kv.Tx, cfg *clparams.BeaconChainConfig, genesis
 	if targetSlot > clparams.SlotsPerDump*backoffStep {
 		return findNearestSlotBackwards(tx, cfg, targetSlot-clparams.SlotsPerDump*backoffStep)
 	}
-	fmt.Println(genesisSlot)
 	return genesisSlot, nil
 }

--- a/cl/antiquary/state_antiquary.go
+++ b/cl/antiquary/state_antiquary.go
@@ -457,7 +457,7 @@ func (s *Antiquary) initializeStateAntiquaryIfNeeded(ctx context.Context, tx kv.
 			return err
 		}
 		if computedBlockRoot != expectedBlockRoot {
-			log.Warn("Block root mismatch, trying again", "slot", attempt, "expected", expectedBlockRoot)
+			log.Debug("Block root mismatch, trying again", "slot", attempt, "expected", expectedBlockRoot)
 			// backoff more
 			backoffStep += 10
 			continue

--- a/cl/persistence/state/historical_states_reader/historical_states_reader_test.go
+++ b/cl/persistence/state/historical_states_reader/historical_states_reader_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package historical_states_reader_test
 
 import (

--- a/cl/persistence/state/historical_states_reader/historical_states_reader_test.go
+++ b/cl/persistence/state/historical_states_reader/historical_states_reader_test.go
@@ -2,6 +2,7 @@ package historical_states_reader_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
@@ -41,6 +42,7 @@ func runTest(t *testing.T, blocks []*cltypes.SignedBeaconBlock, preState, postSt
 	require.NoError(t, err)
 	_, err = postState.HashSSZ()
 	require.NoError(t, err)
+	fmt.Println(s.Validators().Get(0).PublicKey(), postState.Validators().Get(0).PublicKey())
 	require.Equal(t, libcommon.Hash(postHash), blocks[len(blocks)-1].Block.StateRoot)
 }
 

--- a/cl/persistence/state/static_validator_table.go
+++ b/cl/persistence/state/static_validator_table.go
@@ -275,7 +275,7 @@ func (s *StaticValidatorTable) AddValidator(v solid.Validator, validatorIndex, s
 		return nil
 	}
 	s.validatorTable = append(s.validatorTable, NewStaticValidatorFromValidator(v, slot))
-	if validatorIndex != uint64(len(s.validatorTable)) {
+	if validatorIndex != uint64(len(s.validatorTable))-1 {
 		return fmt.Errorf("validator index mismatch")
 	}
 	return nil
@@ -421,15 +421,18 @@ func (s *StaticValidatorTable) GetStaticValidator(validatorIndex uint64) *Static
 func (s *StaticValidatorTable) SetSlot(slot uint64) {
 	s.sync.Lock()
 	defer s.sync.Unlock()
-	if slot <= s.slot && s.slot != 0 {
-		return
-	}
+	s.resetTable(slot)
 	s.slot = slot
 }
 
 func (s *StaticValidatorTable) resetTable(slot uint64) {
-	for _, v := range s.validatorTable {
+	for i, v := range s.validatorTable {
 		v.Reset(slot)
+		// if we remove all public keys, we can remove all subsequent fields
+		if len(v.publicKeys) == 0 {
+			s.validatorTable = s.validatorTable[:i]
+			break
+		}
 	}
 }
 

--- a/cl/persistence/state/static_validator_table.go
+++ b/cl/persistence/state/static_validator_table.go
@@ -421,7 +421,9 @@ func (s *StaticValidatorTable) GetStaticValidator(validatorIndex uint64) *Static
 func (s *StaticValidatorTable) SetSlot(slot uint64) {
 	s.sync.Lock()
 	defer s.sync.Unlock()
-	s.resetTable(slot)
+	if slot <= s.slot && s.slot != 0 {
+		return
+	}
 	s.slot = slot
 }
 

--- a/cl/persistence/state/static_validator_table.go
+++ b/cl/persistence/state/static_validator_table.go
@@ -203,6 +203,51 @@ func (s *StaticValidator) ToValidator(v solid.Validator, slot uint64) {
 	v.SetWithdrawableEpoch(s.WithdrawableEpoch(slot))
 }
 
+func (s *StaticValidator) Reset(slot uint64) {
+	for i := 0; i < len(s.publicKeys); i++ {
+		if s.publicKeys[i].Slot > slot {
+			s.publicKeys = s.publicKeys[:i]
+			break
+		}
+	}
+	for i := 0; i < len(s.withdrawalCredentials); i++ {
+		if s.withdrawalCredentials[i].Slot > slot {
+			s.withdrawalCredentials = s.withdrawalCredentials[:i]
+			break
+		}
+	}
+	for i := 0; i < len(s.slashed); i++ {
+		if s.slashed[i].Slot > slot {
+			s.slashed = s.slashed[:i]
+			break
+		}
+	}
+	for i := 0; i < len(s.activationEligibility); i++ {
+		if s.activationEligibility[i].Slot > slot {
+			s.activationEligibility = s.activationEligibility[:i]
+			break
+		}
+	}
+	for i := 0; i < len(s.activationEpoch); i++ {
+		if s.activationEpoch[i].Slot > slot {
+			s.activationEpoch = s.activationEpoch[:i]
+			break
+		}
+	}
+	for i := 0; i < len(s.exitEpoch); i++ {
+		if s.exitEpoch[i].Slot > slot {
+			s.exitEpoch = s.exitEpoch[:i]
+			break
+		}
+	}
+	for i := 0; i < len(s.withdrawableEpoch); i++ {
+		if s.withdrawableEpoch[i].Slot > slot {
+			s.withdrawableEpoch = s.withdrawableEpoch[:i]
+			break
+		}
+	}
+}
+
 type staticValidatorField[V any] struct {
 	Slot  uint64
 	Field V
@@ -230,7 +275,7 @@ func (s *StaticValidatorTable) AddValidator(v solid.Validator, validatorIndex, s
 		return nil
 	}
 	s.validatorTable = append(s.validatorTable, NewStaticValidatorFromValidator(v, slot))
-	if validatorIndex >= uint64(len(s.validatorTable)) {
+	if validatorIndex != uint64(len(s.validatorTable)) {
 		return fmt.Errorf("validator index mismatch")
 	}
 	return nil
@@ -376,10 +421,14 @@ func (s *StaticValidatorTable) GetStaticValidator(validatorIndex uint64) *Static
 func (s *StaticValidatorTable) SetSlot(slot uint64) {
 	s.sync.Lock()
 	defer s.sync.Unlock()
-	if slot <= s.slot && s.slot != 0 {
-		return
-	}
+	s.resetTable(slot)
 	s.slot = slot
+}
+
+func (s *StaticValidatorTable) resetTable(slot uint64) {
+	for _, v := range s.validatorTable {
+		v.Reset(slot)
+	}
 }
 
 func (s *StaticValidatorTable) Slot() uint64 {


### PR DESCRIPTION
Basically we keep the history of somewhat static fields in memory of our validatorset (this is cheap). however when restarting the node and reading these static fields, we do not reset them to the closes valid slot for incremental processing