### PR TITLE
p2p/sentry: StatusDataProvider ReadCurrentHeader error

### DIFF
--- a/p2p/sentry/status_data_provider.go
+++ b/p2p/sentry/status_data_provider.go
@@ -75,7 +75,7 @@ func (s *StatusDataProvider) GetStatusData(ctx context.Context) (*proto_sentry.S
 }
 
 func ReadChainHeadWithTx(tx kv.Tx) (ChainHead, error) {
-	header := rawdb.ReadCurrentHeader(tx)
+	header := rawdb.ReadCurrentHeaderHavingBody(tx)
 	if header == nil {
 		return ChainHead{}, errors.New("ReadChainHead: ReadCurrentHeader error")
 	}


### PR DESCRIPTION
P2P fails on restart because rawdb.ReadCurrentHeader returns a nil header. It looks like ReadHeadHeaderHash fails to find the current header hash. However the correct hash is returned by ReadHeadBlockHash.

![IMG_0901](https://github.com/ledgerwatch/erigon/assets/11477595/c37e3499-77d8-4115-8008-0dce2617362a)

