### PR TITLE
Engine API: NewPayload fails with a "context canceled" error when calling CurrentHeader/GetHeader (#9786)

### DIFF
--- a/erigon-lib/common/chan.go
+++ b/erigon-lib/common/chan.go
@@ -16,10 +16,26 @@
 
 package common
 
-import "errors"
+import (
+	"errors"
+
+	"golang.org/x/net/context"
+)
 
 var ErrStopped = errors.New("stopped")
 var ErrUnwind = errors.New("unwound")
+
+// FastContextErr is faster than ctx.Err() because usually it doesn't lock an internal mutex.
+// It locks it only if the context is done and at the first call.
+// See implementation of cancelCtx in context/context.go.
+func FastContextErr(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		return nil
+	}
+}
 
 func Stopped(ch <-chan struct{}) error {
 	if ch == nil {

--- a/erigon-lib/go.mod
+++ b/erigon-lib/go.mod
@@ -135,7 +135,7 @@ require (
 	go.etcd.io/bbolt v1.3.6 // indirect
 	go.opentelemetry.io/otel v1.8.0 // indirect
 	go.opentelemetry.io/otel/trace v1.8.0 // indirect
-	golang.org/x/net v0.24.0 // indirect
+	golang.org/x/net v0.24.0
 	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240227224415-6ceb2ff114de // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/erigon-lib/kv/mdbx/kv_mdbx.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx.go
@@ -750,7 +750,7 @@ func (db *MdbxKV) BeginRo(ctx context.Context) (txn kv.Tx, err error) {
 	// will return nil err if context is cancelled (may appear to acquire the semaphore)
 	if semErr := db.roTxsLimiter.Acquire(ctx, 1); semErr != nil {
 		db.trackTxEnd()
-		return nil, semErr
+		return nil, fmt.Errorf("mdbx.MdbxKV.BeginRo: roTxsLimiter error %w", semErr)
 	}
 
 	defer func() {

--- a/erigon-lib/kv/remotedb/kv_remote.go
+++ b/erigon-lib/kv/remotedb/kv_remote.go
@@ -24,12 +24,13 @@ import (
 	"runtime"
 	"unsafe"
 
-	"github.com/ledgerwatch/erigon-lib/kv/iter"
-	"github.com/ledgerwatch/erigon-lib/kv/order"
 	"github.com/ledgerwatch/log/v3"
 	"golang.org/x/sync/semaphore"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/ledgerwatch/erigon-lib/kv/iter"
+	"github.com/ledgerwatch/erigon-lib/kv/order"
 
 	"github.com/ledgerwatch/erigon-lib/gointerfaces"
 	"github.com/ledgerwatch/erigon-lib/gointerfaces/grpcutil"
@@ -160,7 +161,7 @@ func (db *DB) BeginRo(ctx context.Context) (txn kv.Tx, err error) {
 	}
 
 	if semErr := db.roTxsLimiter.Acquire(ctx, 1); semErr != nil {
-		return nil, semErr
+		return nil, fmt.Errorf("remotedb.DB.BeginRo: roTxsLimiter error %w", semErr)
 	}
 
 	defer func() {

--- a/turbo/execution/eth1/block_building.go
+++ b/turbo/execution/eth1/block_building.go
@@ -42,6 +42,7 @@ func (e *EthereumExecutionModule) evictOldBuilders() {
 // Missing: NewPayload, AssembleBlock
 func (e *EthereumExecutionModule) AssembleBlock(ctx context.Context, req *execution.AssembleBlockRequest) (*execution.AssembleBlockResponse, error) {
 	if !e.semaphore.TryAcquire(1) {
+		e.logger.Warn("ethereumExecutionModule.AssembleBlock: ExecutionStatus_Busy")
 		return &execution.AssembleBlockResponse{
 			Id:   0,
 			Busy: true,
@@ -108,6 +109,7 @@ func blockValue(br *types.BlockWithReceipts, baseFee *uint256.Int) *uint256.Int 
 
 func (e *EthereumExecutionModule) GetAssembledBlock(ctx context.Context, req *execution.GetAssembledBlockRequest) (*execution.GetAssembledBlockResponse, error) {
 	if !e.semaphore.TryAcquire(1) {
+		e.logger.Warn("ethereumExecutionModule.GetAssembledBlock: ExecutionStatus_Busy")
 		return &execution.GetAssembledBlockResponse{
 			Busy: true,
 		}, nil

--- a/turbo/execution/eth1/ethereum_execution.go
+++ b/turbo/execution/eth1/ethereum_execution.go
@@ -5,15 +5,16 @@ import (
 	"errors"
 	"math/big"
 
+	"github.com/ledgerwatch/log/v3"
+	"golang.org/x/sync/semaphore"
+	"google.golang.org/protobuf/types/known/emptypb"
+
 	"github.com/ledgerwatch/erigon-lib/chain"
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/gointerfaces"
 	"github.com/ledgerwatch/erigon-lib/gointerfaces/execution"
 	"github.com/ledgerwatch/erigon-lib/kv/dbutils"
 	"github.com/ledgerwatch/erigon-lib/wrap"
-	"github.com/ledgerwatch/log/v3"
-	"golang.org/x/sync/semaphore"
-	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon/common/math"
@@ -150,6 +151,7 @@ func (e *EthereumExecutionModule) canonicalHash(ctx context.Context, tx kv.Tx, b
 
 func (e *EthereumExecutionModule) ValidateChain(ctx context.Context, req *execution.ValidationRequest) (*execution.ValidationReceipt, error) {
 	if !e.semaphore.TryAcquire(1) {
+		e.logger.Warn("ethereumExecutionModule.ValidateChain: ExecutionStatus_Busy")
 		return &execution.ValidationReceipt{
 			LatestValidHash:  gointerfaces.ConvertHashToH256(libcommon.Hash{}),
 			ValidationStatus: execution.ExecutionStatus_Busy,
@@ -267,6 +269,7 @@ func (e *EthereumExecutionModule) Start(ctx context.Context) {
 
 func (e *EthereumExecutionModule) Ready(context.Context, *emptypb.Empty) (*execution.ReadyResponse, error) {
 	if !e.semaphore.TryAcquire(1) {
+		e.logger.Warn("ethereumExecutionModule.Ready: ExecutionStatus_Busy")
 		return &execution.ReadyResponse{Ready: false}, nil
 	}
 	defer e.semaphore.Release(1)

--- a/turbo/execution/eth1/forkchoice.go
+++ b/turbo/execution/eth1/forkchoice.go
@@ -103,6 +103,7 @@ func writeForkChoiceHashes(tx kv.RwTx, blockHash, safeHash, finalizedHash libcom
 
 func (e *EthereumExecutionModule) updateForkChoice(ctx context.Context, blockHash, safeHash, finalizedHash libcommon.Hash, outcomeCh chan forkchoiceOutcome) {
 	if !e.semaphore.TryAcquire(1) {
+		e.logger.Warn("ethereumExecutionModule.updateForkChoice: ExecutionStatus_Busy")
 		sendForkchoiceReceiptWithoutWaiting(outcomeCh, &execution.ForkChoiceReceipt{
 			LatestValidHash: gointerfaces.ConvertHashToH256(libcommon.Hash{}),
 			Status:          execution.ExecutionStatus_Busy,

--- a/turbo/execution/eth1/getters.go
+++ b/turbo/execution/eth1/getters.go
@@ -5,10 +5,11 @@ import (
 	"errors"
 	"fmt"
 
+	"google.golang.org/protobuf/types/known/emptypb"
+
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/gointerfaces"
 	"github.com/ledgerwatch/erigon-lib/kv"
-	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/ledgerwatch/erigon-lib/gointerfaces/execution"
 	types2 "github.com/ledgerwatch/erigon-lib/gointerfaces/types"
@@ -52,7 +53,7 @@ func (e *EthereumExecutionModule) GetBody(ctx context.Context, req *execution.Ge
 	}
 	tx, err := e.db.BeginRo(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("ethereumExecutionModule.GetHeader: could not open database: %s", err)
+		return nil, fmt.Errorf("ethereumExecutionModule.GetBody: could not begin database tx %w", err)
 	}
 	defer tx.Rollback()
 
@@ -61,18 +62,18 @@ func (e *EthereumExecutionModule) GetBody(ctx context.Context, req *execution.Ge
 		return &execution.GetBodyResponse{Body: nil}, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("ethereumExecutionModule.GetBody: %s", err)
+		return nil, fmt.Errorf("ethereumExecutionModule.GetBody: parseSegmentRequest error %w", err)
 	}
 	td, err := rawdb.ReadTd(tx, blockHash, blockNumber)
 	if err != nil {
-		return nil, fmt.Errorf("ethereumExecutionModule.GetBody: %s", err)
+		return nil, fmt.Errorf("ethereumExecutionModule.GetBody: ReadTd error %w", err)
 	}
 	if td == nil {
 		return &execution.GetBodyResponse{Body: nil}, nil
 	}
 	body, err := e.getBody(ctx, tx, blockHash, blockNumber)
 	if err != nil {
-		return nil, fmt.Errorf("ethereumExecutionModule.GetBody: coild not read body: %s", err)
+		return nil, fmt.Errorf("ethereumExecutionModule.GetBody: getBody error %w", err)
 	}
 	if body == nil {
 		return &execution.GetBodyResponse{Body: nil}, nil
@@ -89,7 +90,7 @@ func (e *EthereumExecutionModule) GetHeader(ctx context.Context, req *execution.
 	}
 	tx, err := e.db.BeginRo(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("ethereumExecutionModule.GetHeader: could not open database: %s", err)
+		return nil, fmt.Errorf("ethereumExecutionModule.GetHeader: could not begin database tx %w", err)
 	}
 	defer tx.Rollback()
 
@@ -99,14 +100,14 @@ func (e *EthereumExecutionModule) GetHeader(ctx context.Context, req *execution.
 	}
 	td, err := rawdb.ReadTd(tx, blockHash, blockNumber)
 	if err != nil {
-		return nil, fmt.Errorf("ethereumExecutionModule.GetHeader: %s", err)
+		return nil, fmt.Errorf("ethereumExecutionModule.GetHeader: ReadTd error %w", err)
 	}
 	if td == nil {
 		return &execution.GetHeaderResponse{Header: nil}, nil
 	}
 	header, err := e.getHeader(ctx, tx, blockHash, blockNumber)
 	if err != nil {
-		return nil, fmt.Errorf("ethereumExecutionModule.GetHeader: coild not read body: %s", err)
+		return nil, fmt.Errorf("ethereumExecutionModule.GetHeader: getHeader error %w", err)
 	}
 	if header == nil {
 		return &execution.GetHeaderResponse{Header: nil}, nil
@@ -118,7 +119,7 @@ func (e *EthereumExecutionModule) GetHeader(ctx context.Context, req *execution.
 func (e *EthereumExecutionModule) GetBodiesByHashes(ctx context.Context, req *execution.GetBodiesByHashesRequest) (*execution.GetBodiesBatchResponse, error) {
 	tx, err := e.db.BeginRo(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("ethereumExecutionModule.GetBodiesByHashes: could not begin database tx %w", err)
 	}
 	defer tx.Rollback()
 
@@ -133,7 +134,7 @@ func (e *EthereumExecutionModule) GetBodiesByHashes(ctx context.Context, req *ex
 		}
 		body, err := e.getBody(ctx, tx, h, *number)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("ethereumExecutionModule.GetBodiesByHashes: getBody error %w", err)
 		}
 		if body == nil {
 			bodies = append(bodies, nil)
@@ -141,7 +142,7 @@ func (e *EthereumExecutionModule) GetBodiesByHashes(ctx context.Context, req *ex
 		}
 		txs, err := types.MarshalTransactionsBinary(body.Transactions)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("ethereumExecutionModule.GetBodiesByHashes: MarshalTransactionsBinary error %w", err)
 		}
 		bodies = append(bodies, &execution.BlockBody{
 			Transactions: txs,
@@ -155,7 +156,7 @@ func (e *EthereumExecutionModule) GetBodiesByHashes(ctx context.Context, req *ex
 func (e *EthereumExecutionModule) GetBodiesByRange(ctx context.Context, req *execution.GetBodiesByRangeRequest) (*execution.GetBodiesBatchResponse, error) {
 	tx, err := e.db.BeginRo(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("ethereumExecutionModule.GetBodiesByRange: could not begin database tx %w", err)
 	}
 	defer tx.Rollback()
 
@@ -164,7 +165,7 @@ func (e *EthereumExecutionModule) GetBodiesByRange(ctx context.Context, req *exe
 	for i := uint64(0); i < req.Count; i++ {
 		hash, err := rawdb.ReadCanonicalHash(tx, req.Start+i)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("ethereumExecutionModule.GetBodiesByRange: ReadCanonicalHash error %w", err)
 		}
 		if hash == (libcommon.Hash{}) {
 			// break early if beyond the last known canonical header
@@ -173,7 +174,7 @@ func (e *EthereumExecutionModule) GetBodiesByRange(ctx context.Context, req *exe
 
 		body, err := e.getBody(ctx, tx, hash, req.Start+i)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("ethereumExecutionModule.GetBodiesByRange: getBody error %w", err)
 		}
 		if body == nil {
 			// Append nil and no further processing
@@ -183,7 +184,7 @@ func (e *EthereumExecutionModule) GetBodiesByRange(ctx context.Context, req *exe
 
 		txs, err := types.MarshalTransactionsBinary(body.Transactions)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("ethereumExecutionModule.GetBodiesByRange: MarshalTransactionsBinary error %w", err)
 		}
 		bodies = append(bodies, &execution.BlockBody{
 			Transactions: txs,
@@ -206,7 +207,7 @@ func (e *EthereumExecutionModule) GetBodiesByRange(ctx context.Context, req *exe
 func (e *EthereumExecutionModule) GetHeaderHashNumber(ctx context.Context, req *types2.H256) (*execution.GetHeaderHashNumberResponse, error) {
 	tx, err := e.db.BeginRo(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("ethereumExecutionModule.GetBody: could not open database: %s", err)
+		return nil, fmt.Errorf("ethereumExecutionModule.GetHeaderHashNumber: could not begin database tx %w", err)
 	}
 	defer tx.Rollback()
 	blockNumber := rawdb.ReadHeaderNumber(tx, gointerfaces.ConvertH256ToHash(req))
@@ -223,11 +224,11 @@ func (e *EthereumExecutionModule) isCanonicalHash(ctx context.Context, tx kv.Tx,
 	}
 	expectedHash, err := e.canonicalHash(ctx, tx, *blockNumber)
 	if err != nil {
-		return false, fmt.Errorf("ethereumExecutionModule.CanonicalHash: could not read canonical hash")
+		return false, fmt.Errorf("ethereumExecutionModule.isCanonicalHash: could not read canonical hash %w", err)
 	}
 	td, err := rawdb.ReadTd(tx, hash, *blockNumber)
 	if err != nil {
-		return false, fmt.Errorf("ethereumExecutionModule.GetBody: %s", err)
+		return false, fmt.Errorf("ethereumExecutionModule.isCanonicalHash: ReadTd error %w", err)
 	}
 	if td == nil {
 		return false, nil
@@ -238,13 +239,13 @@ func (e *EthereumExecutionModule) isCanonicalHash(ctx context.Context, tx kv.Tx,
 func (e *EthereumExecutionModule) IsCanonicalHash(ctx context.Context, req *types2.H256) (*execution.IsCanonicalResponse, error) {
 	tx, err := e.db.BeginRo(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("ethereumExecutionModule.CanonicalHash: could not open database: %s", err)
+		return nil, fmt.Errorf("ethereumExecutionModule.CanonicalHash: could not begin database tx %w", err)
 	}
 	defer tx.Rollback()
 
 	isCanonical, err := e.isCanonicalHash(ctx, tx, gointerfaces.ConvertH256ToHash(req))
 	if err != nil {
-		return nil, fmt.Errorf("ethereumExecutionModule.CanonicalHash: could not read canonical hash")
+		return nil, fmt.Errorf("ethereumExecutionModule.CanonicalHash: could not read canonical hash %w", err)
 	}
 
 	return &execution.IsCanonicalResponse{Canonical: isCanonical}, nil
@@ -253,14 +254,14 @@ func (e *EthereumExecutionModule) IsCanonicalHash(ctx context.Context, req *type
 func (e *EthereumExecutionModule) CurrentHeader(ctx context.Context, _ *emptypb.Empty) (*execution.GetHeaderResponse, error) {
 	tx, err := e.db.BeginRo(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("ethereumExecutionModule.CurrentHeader: could not open database: %s", err)
+		return nil, fmt.Errorf("ethereumExecutionModule.CurrentHeader: could not begin database tx %w", err)
 	}
 	defer tx.Rollback()
 	hash := rawdb.ReadHeadHeaderHash(tx)
 	number := rawdb.ReadHeaderNumber(tx, hash)
 	h, err := e.blockReader.Header(context.Background(), tx, hash, *number)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("ethereumExecutionModule.CurrentHeader: blockReader.Header error %w", err)
 	}
 	if h == nil {
 		return nil, fmt.Errorf("ethereumExecutionModule.CurrentHeader: no current header yet - probabably node not synced yet")
@@ -273,11 +274,11 @@ func (e *EthereumExecutionModule) CurrentHeader(ctx context.Context, _ *emptypb.
 func (e *EthereumExecutionModule) GetTD(ctx context.Context, req *execution.GetSegmentRequest) (*execution.GetTDResponse, error) {
 	// Invalid case: request is invalid.
 	if req == nil || (req.BlockHash == nil && req.BlockNumber == nil) {
-		return nil, errors.New("ethereumExecutionModule.GetHeader: bad request")
+		return nil, errors.New("ethereumExecutionModule.GetTD: bad request")
 	}
 	tx, err := e.db.BeginRo(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("ethereumExecutionModule.GetHeader: could not open database: %s", err)
+		return nil, fmt.Errorf("ethereumExecutionModule.GetTD: could not begin database tx %w", err)
 	}
 	defer tx.Rollback()
 
@@ -286,11 +287,11 @@ func (e *EthereumExecutionModule) GetTD(ctx context.Context, req *execution.GetS
 		return &execution.GetTDResponse{Td: nil}, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("ethereumExecutionModule.GetHeader: %s", err)
+		return nil, fmt.Errorf("ethereumExecutionModule.GetTD: parseSegmentRequest error %w", err)
 	}
 	td, err := e.getTD(ctx, tx, blockHash, blockNumber)
 	if err != nil {
-		return nil, fmt.Errorf("ethereumExecutionModule.GetHeader: coild not read body: %s", err)
+		return nil, fmt.Errorf("ethereumExecutionModule.GetTD: getTD error %w", err)
 	}
 	if td == nil {
 		return &execution.GetTDResponse{Td: nil}, nil
@@ -302,7 +303,7 @@ func (e *EthereumExecutionModule) GetTD(ctx context.Context, req *execution.GetS
 func (e *EthereumExecutionModule) GetForkChoice(ctx context.Context, _ *emptypb.Empty) (*execution.ForkChoice, error) {
 	tx, err := e.db.BeginRo(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("ethereumExecutionModule.GetHeader: could not open database: %s", err)
+		return nil, fmt.Errorf("ethereumExecutionModule.GetForkChoice: could not begin database tx %w", err)
 	}
 	defer tx.Rollback()
 	return &execution.ForkChoice{

--- a/turbo/execution/eth1/getters.go
+++ b/turbo/execution/eth1/getters.go
@@ -259,7 +259,7 @@ func (e *EthereumExecutionModule) CurrentHeader(ctx context.Context, _ *emptypb.
 	defer tx.Rollback()
 	hash := rawdb.ReadHeadHeaderHash(tx)
 	number := rawdb.ReadHeaderNumber(tx, hash)
-	h, err := e.blockReader.Header(context.Background(), tx, hash, *number)
+	h, err := e.blockReader.Header(ctx, tx, hash, *number)
 	if err != nil {
 		return nil, fmt.Errorf("ethereumExecutionModule.CurrentHeader: blockReader.Header error %w", err)
 	}

--- a/turbo/execution/eth1/inserters.go
+++ b/turbo/execution/eth1/inserters.go
@@ -35,6 +35,7 @@ func (s *EthereumExecutionModule) validatePayloadBlobs(expectedBlobHashes []libc
 
 func (e *EthereumExecutionModule) InsertBlocks(ctx context.Context, req *execution.InsertBlocksRequest) (*execution.InsertionResult, error) {
 	if !e.semaphore.TryAcquire(1) {
+		e.logger.Warn("ethereumExecutionModule.InsertBlocks: ExecutionStatus_Busy")
 		return &execution.InsertionResult{
 			Result: execution.ExecutionStatus_Busy,
 		}, nil


### PR DESCRIPTION
see https://github.com/ledgerwatch/erigon/issues/9786

Changes:
* improved logging
* check ctx in ServeHTTP: The context might be cancelled if the client's connection was closed while waiting for ServeHTTP. 
* If execution API returns ExecutionStatus_Busy, limit retry attempts to 10 seconds. This timeout must be lower than a typical client timeout (30 sec), in order to give the client feedback about the server status.
* If execution API returns ExecutionStatus_Busy, increase retry delay from 10 ms to 100 ms to avoid stalling ourselves with multiple busy loops. IMO this delay should be higher (e.g. 1 sec). Ideally we shouldn't do polling at all, but doing a blocking ctx call requires rearchitecting the ExecutionStatus_Busy logic.
