### PR TITLE
Clarify decompressor opening errors

### DIFF
--- a/erigon-lib/seg/decompress.go
+++ b/erigon-lib/seg/decompress.go
@@ -448,6 +448,8 @@ func (d *Decompressor) Close() {
 		}
 		d.f = nil
 		d.data = nil
+		d.posDict = nil
+		d.dict = nil
 	}
 }
 

--- a/erigon-lib/seg/decompress.go
+++ b/erigon-lib/seg/decompress.go
@@ -197,6 +197,7 @@ func NewDecompressor(compressedFilePath string) (d *Decompressor, err error) {
 	}
 	d.size = stat.Size()
 	if d.size < compressedMinSize {
+		d.Close()
 		err = &ErrCompressedFileCorrupted{
 			FileName: fName,
 			Reason: fmt.Sprintf("invalid file size %s, expected at least %s",

--- a/erigon-lib/seg/decompress.go
+++ b/erigon-lib/seg/decompress.go
@@ -170,14 +170,15 @@ func SetDecompressionTableCondensity(fromBitSize int) {
 	condensePatternTableBitThreshold = fromBitSize
 }
 
-func NewDecompressor(compressedFilePath string) (d *Decompressor, err error) {
+func NewDecompressor(compressedFilePath string) (*Decompressor, error) {
 	_, fName := filepath.Split(compressedFilePath)
-	d = &Decompressor{
+	var err error
+	var closeDecompressor = true
+	d := &Decompressor{
 		filePath: compressedFilePath,
 		fileName: fName,
 	}
 
-	closeDecompressor := true
 	defer func() {
 		if rec := recover(); rec != nil {
 			err = fmt.Errorf("decompressing file: %s, %+v, trace: %s", compressedFilePath, rec, dbg.Stack())

--- a/erigon-lib/seg/decompress.go
+++ b/erigon-lib/seg/decompress.go
@@ -447,6 +447,7 @@ func (d *Decompressor) IsOpen() bool {
 }
 
 func (d *Decompressor) Close() {
+	fmt.Printf("closing decompressor %s f=%p\n", d.fileName, d.f)
 	if d.f != nil {
 		if err := mmap.Munmap(d.mmapHandle1, d.mmapHandle2); err != nil {
 			log.Log(dbg.FileCloseLogLevel, "unmap", "err", err, "file", d.FileName(), "stack", dbg.Stack())

--- a/erigon-lib/seg/decompress.go
+++ b/erigon-lib/seg/decompress.go
@@ -182,7 +182,7 @@ func NewDecompressor(compressedFilePath string) (d *Decompressor, err error) {
 		if rec := recover(); rec != nil {
 			err = fmt.Errorf("decompressing file: %s, %+v, trace: %s", compressedFilePath, rec, dbg.Stack())
 		}
-		if err != nil || closeDecompressor {
+		if err != nil || closeDecompressor && d != nil {
 			d.Close()
 			d = nil
 		}

--- a/erigon-lib/seg/decompress.go
+++ b/erigon-lib/seg/decompress.go
@@ -21,6 +21,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"github.com/ledgerwatch/erigon-lib/common/assert"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -264,7 +265,7 @@ func NewDecompressor(compressedFilePath string) (d *Decompressor, err error) {
 		}
 	}
 
-	if pos != 24 {
+	if assert.Enable && pos != 24 {
 		panic("pos != 24")
 	}
 	pos += dictSize // offset patterns

--- a/erigon-lib/seg/decompress.go
+++ b/erigon-lib/seg/decompress.go
@@ -182,7 +182,7 @@ func NewDecompressor(compressedFilePath string) (d *Decompressor, err error) {
 		if rec := recover(); rec != nil {
 			err = fmt.Errorf("decompressing file: %s, %+v, trace: %s", compressedFilePath, rec, dbg.Stack())
 		}
-		if err != nil || closeDecompressor && d != nil {
+		if (err != nil || closeDecompressor) && d != nil {
 			d.Close()
 			d = nil
 		}

--- a/erigon-lib/seg/decompress.go
+++ b/erigon-lib/seg/decompress.go
@@ -443,7 +443,6 @@ func (d *Decompressor) IsOpen() bool {
 }
 
 func (d *Decompressor) Close() {
-	fmt.Printf("closing decompressor %s f=%p\n", d.fileName, d.f)
 	if d.f != nil {
 		if err := mmap.Munmap(d.mmapHandle1, d.mmapHandle2); err != nil {
 			log.Log(dbg.FileCloseLogLevel, "unmap", "err", err, "file", d.FileName(), "stack", dbg.Stack())

--- a/erigon-lib/seg/decompress_test.go
+++ b/erigon-lib/seg/decompress_test.go
@@ -414,16 +414,14 @@ func TestDecompressor_OpenCorrupted(t *testing.T) {
 		require.NoError(t, err)
 
 		d, err := NewDecompressor(fpath)
-		e1 := &ErrCompressedFileCorrupted{}
-		require.Truef(t, e1.Is(err),
+		require.Truef(t, errors.Is(err, &ErrCompressedFileCorrupted{}),
 			"file is some garbage or smaller compressedMinSize(%d) bytes, got error %v", compressedMinSize, err)
 		require.Nil(t, d)
 
-		aux = make([]byte, compressedMinSize)
-		d.Close()
 		err = os.Remove(fpath)
 		require.NoError(t, err)
 
+		aux = make([]byte, compressedMinSize)
 		err = os.WriteFile(fpath, aux, 0644)
 		require.NoError(t, err)
 

--- a/erigon-lib/seg/decompress_test.go
+++ b/erigon-lib/seg/decompress_test.go
@@ -380,7 +380,6 @@ func TestDecompressor_OpenCorrupted(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, d)
 		d.Close()
-
 	})
 
 	t.Run("compressed_empty", func(t *testing.T) {

--- a/erigon-lib/seg/decompress_test.go
+++ b/erigon-lib/seg/decompress_test.go
@@ -344,8 +344,8 @@ func TestDecompressor_OpenCorrupted(t *testing.T) {
 
 		d, err := NewDecompressor(file)
 		require.NoError(t, err)
+		require.NotNil(t, d)
 		d.Close()
-
 	})
 
 	t.Run("uncompressed_empty", func(t *testing.T) {
@@ -359,6 +359,7 @@ func TestDecompressor_OpenCorrupted(t *testing.T) {
 		// this file is empty and its size will be 32 bytes, it's not corrupted
 		d, err := NewDecompressor(file)
 		require.NoError(t, err)
+		require.NotNil(t, d)
 		d.Close()
 	})
 
@@ -377,6 +378,7 @@ func TestDecompressor_OpenCorrupted(t *testing.T) {
 
 		d, err := NewDecompressor(file)
 		require.NoError(t, err)
+		require.NotNil(t, d)
 		d.Close()
 
 	})
@@ -391,6 +393,7 @@ func TestDecompressor_OpenCorrupted(t *testing.T) {
 
 		d, err := NewDecompressor(file)
 		require.NoError(t, err)
+		require.NotNil(t, d)
 		d.Close()
 	})
 
@@ -406,7 +409,7 @@ func TestDecompressor_OpenCorrupted(t *testing.T) {
 		_, err := rand.Read(aux)
 		require.NoError(t, err)
 
-		fpath := filepath.Join(tmpDir, "gibberish")
+		fpath := filepath.Join(tmpDir, "1gibberish")
 		err = os.WriteFile(fpath, aux, 0644)
 		require.NoError(t, err)
 
@@ -426,6 +429,7 @@ func TestDecompressor_OpenCorrupted(t *testing.T) {
 		d, err = NewDecompressor(fpath)
 		require.NoErrorf(t, err, "should read empty but correct file")
 		require.NotNil(t, d)
+		d.Close()
 	})
 	t.Run("invalidPatternDictionarySize", func(t *testing.T) {
 		aux := make([]byte, 32)
@@ -443,7 +447,6 @@ func TestDecompressor_OpenCorrupted(t *testing.T) {
 		require.Truef(t, e1.Is(err),
 			"file contains incorrect pattern dictionary size in bytes, got error %v", err)
 		require.Nil(t, d)
-		d.Close()
 	})
 	t.Run("invalidDictionarySize", func(t *testing.T) {
 		aux := make([]byte, 32)
@@ -461,7 +464,6 @@ func TestDecompressor_OpenCorrupted(t *testing.T) {
 		require.Truef(t, e1.Is(err),
 			"file contains incorrect dictionary size in bytes, got error %v", err)
 		require.Nil(t, d)
-		d.Close()
 	})
 	t.Run("fileSizeShouldBeMinimal", func(t *testing.T) {
 		aux := make([]byte, 33)
@@ -480,7 +482,6 @@ func TestDecompressor_OpenCorrupted(t *testing.T) {
 		require.Truef(t, e1.Is(err),
 			"file contains incorrect dictionary size in bytes, got error %v", err)
 		require.Nil(t, d)
-		d.Close()
 	})
 }
 

--- a/erigon-lib/seg/decompress_test.go
+++ b/erigon-lib/seg/decompress_test.go
@@ -401,7 +401,7 @@ func TestDecompressor_OpenCorrupted(t *testing.T) {
 		require.Nil(t, d)
 	})
 
-	t.Run("fileSize<compressedHeaderSize", func(t *testing.T) {
+	t.Run("fileSize<compressedMinSize", func(t *testing.T) {
 		aux := make([]byte, compressedMinSize-1)
 		_, err := rand.Read(aux)
 		require.NoError(t, err)
@@ -411,9 +411,9 @@ func TestDecompressor_OpenCorrupted(t *testing.T) {
 		require.NoError(t, err)
 
 		d, err := NewDecompressor(fpath)
-		e1 := &ErrCompressedFileIsTooShort{}
+		e1 := &ErrCompressedFileCorrupted{}
 		require.Truef(t, e1.Is(err),
-			"file is some garbage or smaller compressedHeaderSize(%d) bytes, got error %v", compressedHeaderSize, err)
+			"file is some garbage or smaller compressedMinSize(%d) bytes, got error %v", compressedMinSize, err)
 		require.Nil(t, d)
 
 		aux = make([]byte, compressedMinSize)
@@ -434,12 +434,12 @@ func TestDecompressor_OpenCorrupted(t *testing.T) {
 		// emptyWordCount=0
 		binary.BigEndian.PutUint64(aux[16:24], 10) // pattern dict size in bytes
 
-		fpath := filepath.Join(tmpDir, "gibberish")
+		fpath := filepath.Join(tmpDir, "invalidPatternDictionarySize")
 		err := os.WriteFile(fpath, aux, 0644)
 		require.NoError(t, err)
 
 		d, err := NewDecompressor(fpath)
-		e1 := &ErrCompressedFileInvalidDictionary{}
+		e1 := &ErrCompressedFileCorrupted{}
 		require.Truef(t, e1.Is(err),
 			"file contains incorrect pattern dictionary size in bytes, got error %v", err)
 		require.Nil(t, d)
@@ -451,12 +451,12 @@ func TestDecompressor_OpenCorrupted(t *testing.T) {
 		// emptyWordCount=0
 		binary.BigEndian.PutUint64(aux[24:32], 10) // dict size in bytes
 
-		fpath := filepath.Join(tmpDir, "gibberish")
+		fpath := filepath.Join(tmpDir, "invalidDictionarySize")
 		err := os.WriteFile(fpath, aux, 0644)
 		require.NoError(t, err)
 
 		d, err := NewDecompressor(fpath)
-		e1 := &ErrCompressedFileInvalidDictionary{}
+		e1 := &ErrCompressedFileCorrupted{}
 		require.Truef(t, e1.Is(err),
 			"file contains incorrect dictionary size in bytes, got error %v", err)
 		require.Nil(t, d)
@@ -469,12 +469,12 @@ func TestDecompressor_OpenCorrupted(t *testing.T) {
 		// pattern dict size in bytes 0
 		// dict size in bytes 0
 
-		fpath := filepath.Join(tmpDir, "gibberish")
+		fpath := filepath.Join(tmpDir, "fileSizeShouldBeMinimal")
 		err := os.WriteFile(fpath, aux, 0644)
 		require.NoError(t, err)
 
 		d, err := NewDecompressor(fpath)
-		e1 := &ErrCompressedFileHasNoWords{}
+		e1 := &ErrCompressedFileCorrupted{}
 		require.Truef(t, e1.Is(err),
 			"file contains incorrect dictionary size in bytes, got error %v", err)
 		require.Nil(t, d)

--- a/erigon-lib/seg/decompress_test.go
+++ b/erigon-lib/seg/decompress_test.go
@@ -420,6 +420,7 @@ func TestDecompressor_OpenCorrupted(t *testing.T) {
 		require.Nil(t, d)
 
 		aux = make([]byte, compressedMinSize)
+		d.Close()
 		err = os.Remove(fpath)
 		require.NoError(t, err)
 

--- a/erigon-lib/seg/decompress_test.go
+++ b/erigon-lib/seg/decompress_test.go
@@ -443,6 +443,7 @@ func TestDecompressor_OpenCorrupted(t *testing.T) {
 		require.Truef(t, e1.Is(err),
 			"file contains incorrect pattern dictionary size in bytes, got error %v", err)
 		require.Nil(t, d)
+		d.Close()
 	})
 	t.Run("invalidDictionarySize", func(t *testing.T) {
 		aux := make([]byte, 32)
@@ -460,6 +461,7 @@ func TestDecompressor_OpenCorrupted(t *testing.T) {
 		require.Truef(t, e1.Is(err),
 			"file contains incorrect dictionary size in bytes, got error %v", err)
 		require.Nil(t, d)
+		d.Close()
 	})
 	t.Run("fileSizeShouldBeMinimal", func(t *testing.T) {
 		aux := make([]byte, 33)
@@ -478,6 +480,7 @@ func TestDecompressor_OpenCorrupted(t *testing.T) {
 		require.Truef(t, e1.Is(err),
 			"file contains incorrect dictionary size in bytes, got error %v", err)
 		require.Nil(t, d)
+		d.Close()
 	})
 }
 

--- a/erigon-lib/seg/decompress_test.go
+++ b/erigon-lib/seg/decompress_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -442,8 +443,7 @@ func TestDecompressor_OpenCorrupted(t *testing.T) {
 		require.NoError(t, err)
 
 		d, err := NewDecompressor(fpath)
-		e1 := &ErrCompressedFileCorrupted{}
-		require.Truef(t, e1.Is(err),
+		require.Truef(t, errors.Is(err, &ErrCompressedFileCorrupted{}),
 			"file contains incorrect pattern dictionary size in bytes, got error %v", err)
 		require.Nil(t, d)
 	})
@@ -459,8 +459,7 @@ func TestDecompressor_OpenCorrupted(t *testing.T) {
 		require.NoError(t, err)
 
 		d, err := NewDecompressor(fpath)
-		e1 := &ErrCompressedFileCorrupted{}
-		require.Truef(t, e1.Is(err),
+		require.Truef(t, errors.Is(err, &ErrCompressedFileCorrupted{}),
 			"file contains incorrect dictionary size in bytes, got error %v", err)
 		require.Nil(t, d)
 	})
@@ -477,8 +476,7 @@ func TestDecompressor_OpenCorrupted(t *testing.T) {
 		require.NoError(t, err)
 
 		d, err := NewDecompressor(fpath)
-		e1 := &ErrCompressedFileCorrupted{}
-		require.Truef(t, e1.Is(err),
+		require.Truef(t, errors.Is(err, &ErrCompressedFileCorrupted{}),
 			"file contains incorrect dictionary size in bytes, got error %v", err)
 		require.Nil(t, d)
 	})

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -230,7 +230,7 @@ func (d *Domain) openFiles() (err error) {
 			}
 			if item.decompressor, err = seg.NewDecompressor(datPath); err != nil {
 				d.logger.Debug("Domain.openFiles: %w, %s", err, datPath)
-				if errors.Is(err, seg.ErrCompressedFileCorrupted{}) {
+				if errors.Is(err, &seg.ErrCompressedFileCorrupted{}) {
 					continue
 				}
 				return false

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -21,6 +21,7 @@ import (
 	"container/heap"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math"
 	"path/filepath"
@@ -228,6 +229,10 @@ func (d *Domain) openFiles() (err error) {
 				continue
 			}
 			if item.decompressor, err = seg.NewDecompressor(datPath); err != nil {
+				d.logger.Debug("Domain.openFiles: %w, %s", err, datPath)
+				if errors.Is(err, seg.ErrCompressedFileCorrupted{}) {
+					continue
+				}
 				return false
 			}
 

--- a/erigon-lib/state/history.go
+++ b/erigon-lib/state/history.go
@@ -21,6 +21,7 @@ import (
 	"container/heap"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math"
 	"path/filepath"
@@ -216,7 +217,10 @@ func (h *History) openFiles() error {
 				continue
 			}
 			if item.decompressor, err = seg.NewDecompressor(datPath); err != nil {
-				h.logger.Debug("Hisrory.openFiles: %w, %s", err, datPath)
+				h.logger.Debug("History.openFiles: %w, %s", err, datPath)
+				if errors.Is(err, seg.ErrCompressedFileCorrupted{}) {
+					continue
+				}
 				return false
 			}
 

--- a/erigon-lib/state/history.go
+++ b/erigon-lib/state/history.go
@@ -218,7 +218,7 @@ func (h *History) openFiles() error {
 			}
 			if item.decompressor, err = seg.NewDecompressor(datPath); err != nil {
 				h.logger.Debug("History.openFiles: %w, %s", err, datPath)
-				if errors.Is(err, seg.ErrCompressedFileCorrupted{}) {
+				if errors.Is(err, &seg.ErrCompressedFileCorrupted{}) {
 					continue
 				}
 				return false


### PR DESCRIPTION
Introduces `ErrCompressedFileCorrupted`.

Those errors should be handled properly inside aggregator and inside different utilities.
At least we do not open wrong compressed files but we sometimes want to do some extra on those files (eg during run of a `downloader`)
