### PR TITLE
p2p/sentry/sentry_multi_client: flag to disable block download code

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -1554,6 +1554,7 @@ func newSync(ctx context.Context, db kv.RwDB, miningConfig *params.MiningConfig,
 		statusDataProvider,
 		false,
 		maxBlockBroadcastPeers,
+		false, /* disableBlockDownload */
 		logger,
 	)
 	if err != nil {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -580,6 +580,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 		}
 	}
 
+	sentryMcDisableBlockDownload := config.PolygonSync
 	backend.sentriesClient, err = sentry_multi_client.NewMultiClient(
 		chainKv,
 		chainConfig,
@@ -591,6 +592,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 		statusDataProvider,
 		stack.Config().SentryLogPeerInfo,
 		maxBlockBroadcastPeers,
+		sentryMcDisableBlockDownload,
 		logger,
 	)
 	if err != nil {

--- a/p2p/sentry/sentry_multi_client/sentry_multi_client.go
+++ b/p2p/sentry/sentry_multi_client/sentry_multi_client.go
@@ -314,7 +314,7 @@ func NewMultiClient(
 	// body downloader
 	var bd *bodydownload.BodyDownload
 	if !disableBlockDownload {
-		bd := bodydownload.NewBodyDownload(engine, blockBufferSize, int(syncCfg.BodyCacheLimit), blockReader, logger)
+		bd = bodydownload.NewBodyDownload(engine, blockBufferSize, int(syncCfg.BodyCacheLimit), blockReader, logger)
 		if err := db.View(context.Background(), func(tx kv.Tx) error {
 			_, _, _, _, err := bd.UpdateFromDb(tx)
 			return err

--- a/p2p/sentry/sentry_multi_client/sentry_multi_client.go
+++ b/p2p/sentry/sentry_multi_client/sentry_multi_client.go
@@ -309,6 +309,8 @@ func NewMultiClient(
 		if err := hd.RecoverFromDb(db); err != nil {
 			return nil, fmt.Errorf("recovery from DB failed: %w", err)
 		}
+	} else {
+		hd = &headerdownload.HeaderDownload{}
 	}
 
 	// body downloader
@@ -321,6 +323,8 @@ func NewMultiClient(
 		}); err != nil {
 			return nil, err
 		}
+	} else {
+		bd = &bodydownload.BodyDownload{}
 	}
 
 	cs := &MultiClient{

--- a/turbo/stages/mock/mock_sentry.go
+++ b/turbo/stages/mock/mock_sentry.go
@@ -385,6 +385,7 @@ func MockWithEverything(tb testing.TB, gspec *types.Genesis, key *ecdsa.PrivateK
 		statusDataProvider,
 		false,
 		maxBlockBroadcastPeers,
+		false, /* disableBlockDownload */
 		logger,
 	)
 	if err != nil {


### PR DESCRIPTION
### Change ### 
Adds a `disableBlockDownload` boolean flag to current implementation of sentry multi client to disable built in header and body download funcitonality.

### Long Term ###
Long term we are planning to refactor sentry multi client and de-couple it from custom header and body download logic.

### Context ### 
Astrid uses its own body download logic which is de-coupled from sentry multi client. 

When both are used at the same time (using `--polygon.sync=true`) there are 2 problematic scenarios:
- restarting Astrid takes a very long time due to the init logic of sentry multi client. It calls `HeaderDownload.RecoverFromDb` which is coupled to the Headers stage in the stage loop. So if Astrid has fetched 1 million headers but hasn't committed execution yet then this will result in very slow start up since all 1 million blocks have to be read from the DB. Example logs:
```
[INFO] [04-16|12:55:42.254] [downloader] recover headers from db     left=65536
...
[INFO] [04-16|13:03:42.254] [downloader] recover headers from db     left=65536
```

- debug log messages warning about sentry consuming being slow since Astrid does not use `HeaderDownload` and `BodyDownload` so there is nothing consuming the headers and bodies from these data structures. This has no logical impact, however clogs resources. Example logs:
```
[DBUG] [04-16|14:03:15.311] [sentry] consuming is slow, drop 50% of old messages msgID=BLOCK_HEADERS_66
[DBUG] [04-16|14:03:15.311] [sentry] consuming is slow, drop 50% of old messages msgID=BLOCK_HEADERS_66
```