### PR TITLE
Fix missing prune log index

### DIFF
--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -208,11 +208,20 @@ func executeBlock(
 func gatherNoPruneReceipts(receipts *types.Receipts, chainCfg *chain.Config) bool {
 	cr := types.Receipts{}
 	for _, r := range *receipts {
-		for _, l := range r.Logs {
-			if chainCfg.NoPruneContracts[l.Address] {
-				cr = append(cr, r)
-				break
+		toStore := false
+		if chainCfg.NoPruneContracts != nil && chainCfg.NoPruneContracts[r.ContractAddress] {
+			toStore = true
+		} else {
+			for _, l := range r.Logs {
+				if chainCfg.NoPruneContracts != nil && chainCfg.NoPruneContracts[l.Address] {
+					toStore = true
+					break
+				}
 			}
+		}
+
+		if toStore {
+			cr = append(cr, r)
 		}
 	}
 	receipts = &cr

--- a/eth/stagedsync/stage_log_index.go
+++ b/eth/stagedsync/stage_log_index.go
@@ -90,7 +90,6 @@ func SpawnLogIndex(s *StageState, tx kv.RwTx, cfg LogIndexCfg, ctx context.Conte
 	if startBlock > 0 {
 		startBlock++
 	}
-	logger.Info("Starting Promote log index with ", "startBlock", startBlock, "endBlock", endBlock, "pruneTo", pruneTo)
 	if err = promoteLogIndex(logPrefix, tx, startBlock, endBlock, pruneTo, cfg, ctx, logger); err != nil {
 		return err
 	}
@@ -183,18 +182,18 @@ func promoteLogIndex(logPrefix string, tx kv.RwTx, start uint64, endBlock uint64
 		// if pruning is enabled, and noPruneContracts isn't configured for the chain, don't index
 		if blockNum < pruneBlock {
 			toStore = false
-			if cfg.noPruneContracts == nil{
+			if cfg.noPruneContracts == nil {
 				continue
 			}
 			for _, l := range ll {
 				// if any of the log address is in noPrune, store and index all logs for this txId
-				if cfg.noPruneContracts[l.Address]{
-						toStore = true
-						break
+				if cfg.noPruneContracts[l.Address] {
+					toStore = true
+					break
 				}
 			}
 		}
-		
+
 		if !toStore {
 			continue
 		}
@@ -503,7 +502,7 @@ func pruneLogIndex(logPrefix string, tx kv.RwTx, tmpDir string, pruneFrom, prune
 					break
 				}
 			}
-			if toPrune{
+			if toPrune {
 				for _, l := range logs {
 					for _, topic := range l.Topics {
 						if err := topics.Collect(topic.Bytes(), nil); err != nil {

--- a/eth/stagedsync/stage_log_index.go
+++ b/eth/stagedsync/stage_log_index.go
@@ -513,7 +513,9 @@ func pruneLogIndex(logPrefix string, tx kv.RwTx, tmpDir string, pruneFrom, prune
 						return err
 					}
 				}
-				pruneLogKeyCollector.Collect(k, nil)
+				if err := pruneLogKeyCollector.Collect(k, nil); err != nil {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Existing prune had some confusing logic (thanks to me).

In PR, change the logic to:
if receipt, or any individual log in the receipt contains an address in `noPruneContracts` the entire log must be stored and indexed.

Also fixes a regression that logs were not getting indexed - this was due to 
```
if l.BlockNumber < pruneBlock && cfg.noPruneContracts != nil && !cfg.noPruneContracts[l.Address] {
```
Since the individual log object didn't have the block number - something that shouldn't matter.
In PR, change the logic to:
Use `blockNum` from outer loop