### PR TITLE
opening domains/hsit/indices with corrupted files on disk

### DIFF
--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -124,7 +124,7 @@ func (d *Domain) openList(fNames []string) error {
 	d.closeWhatNotInList(fNames)
 	d.garbageFiles = d.scanStateFiles(fNames)
 	if err := d.openFiles(); err != nil {
-		return fmt.Errorf("History.OpenList: %s, %w", d.filenameBase, err)
+		return fmt.Errorf("Domain.openList: %w, %s", err, d.filenameBase)
 	}
 	return nil
 }
@@ -229,8 +229,9 @@ func (d *Domain) openFiles() (err error) {
 				continue
 			}
 			if item.decompressor, err = seg.NewDecompressor(datPath); err != nil {
-				d.logger.Debug("Domain.openFiles: %w, %s", err, datPath)
+				d.logger.Debug("Domain.openFiles:", "err", err, "file", datPath)
 				if errors.Is(err, &seg.ErrCompressedFileCorrupted{}) {
+					err = nil
 					continue
 				}
 				return false
@@ -242,7 +243,7 @@ func (d *Domain) openFiles() (err error) {
 			idxPath := filepath.Join(d.dir, fmt.Sprintf("%s.%d-%d.kvi", d.filenameBase, fromStep, toStep))
 			if dir.FileExist(idxPath) {
 				if item.index, err = recsplit.OpenIndex(idxPath); err != nil {
-					d.logger.Debug("InvertedIndex.openFiles: %w, %s", err, idxPath)
+					d.logger.Debug("InvertedIndex.openFiles:", "err", err, "file", idxPath)
 					return false
 				}
 				totalKeys += item.index.KeyCount()
@@ -250,7 +251,11 @@ func (d *Domain) openFiles() (err error) {
 			if item.bindex == nil {
 				bidxPath := filepath.Join(d.dir, fmt.Sprintf("%s.%d-%d.bt", d.filenameBase, fromStep, toStep))
 				if item.bindex, err = OpenBtreeIndexWithDecompressor(bidxPath, 2048, item.decompressor); err != nil {
-					d.logger.Debug("InvertedIndex.openFiles: %w, %s", err, bidxPath)
+					d.logger.Debug("InvertedIndex.openFiles:", "err", err, "file", bidxPath)
+					if errors.Is(err, &seg.ErrCompressedFileCorrupted{}) {
+						err = nil
+						continue
+					}
 					return false
 				}
 				//totalKeys += item.bindex.KeyCount()

--- a/erigon-lib/state/history.go
+++ b/erigon-lib/state/history.go
@@ -118,7 +118,7 @@ func (h *History) openList(fNames []string) error {
 	h.closeWhatNotInList(fNames)
 	h.garbageFiles = h.scanStateFiles(fNames)
 	if err := h.openFiles(); err != nil {
-		return fmt.Errorf("History.OpenList: %s, %w", h.filenameBase, err)
+		return fmt.Errorf("History.OpenList: %w, %s", err, h.filenameBase)
 	}
 	return nil
 }
@@ -217,8 +217,9 @@ func (h *History) openFiles() error {
 				continue
 			}
 			if item.decompressor, err = seg.NewDecompressor(datPath); err != nil {
-				h.logger.Debug("History.openFiles: %w, %s", err, datPath)
+				h.logger.Debug("History.openFiles:", "err", err, "file", datPath)
 				if errors.Is(err, &seg.ErrCompressedFileCorrupted{}) {
+					err = nil
 					continue
 				}
 				return false
@@ -230,7 +231,7 @@ func (h *History) openFiles() error {
 			idxPath := filepath.Join(h.dir, fmt.Sprintf("%s.%d-%d.vi", h.filenameBase, fromStep, toStep))
 			if dir.FileExist(idxPath) {
 				if item.index, err = recsplit.OpenIndex(idxPath); err != nil {
-					h.logger.Debug(fmt.Errorf("Hisrory.openFiles: %w, %s", err, idxPath).Error())
+					h.logger.Debug("History.openFiles:", "err", err, "file", idxPath)
 					return false
 				}
 				totalKeys += item.index.KeyCount()

--- a/erigon-lib/state/history_test.go
+++ b/erigon-lib/state/history_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -832,4 +833,28 @@ func TestScanStaticFilesH(t *testing.T) {
 	h.scanStateFiles(files)
 	require.Equal(t, 0, h.dirtyFiles.Len())
 
+}
+
+func TestHistory_OpenFolder(t *testing.T) {
+	fp, db, h, txs := filledHistory(t, false, log.New())
+	defer db.Close()
+	defer h.Close()
+	defer os.RemoveAll(fp)
+
+	collateAndMergeHistory(t, db, h, txs)
+
+	list := h.visibleFiles.Load()
+	require.NotEmpty(t, list)
+	ff := (*list)[len(*list)-1]
+	fn := ff.src.decompressor.FilePath()
+	h.Close()
+
+	err := os.Remove(fn)
+	require.NoError(t, err)
+	err = os.WriteFile(fn, make([]byte, 33), 0644)
+	require.NoError(t, err)
+
+	err = h.OpenFolder()
+	require.NoError(t, err)
+	h.Close()
 }

--- a/erigon-lib/state/inverted_index.go
+++ b/erigon-lib/state/inverted_index.go
@@ -21,6 +21,7 @@ import (
 	"container/heap"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -126,7 +127,7 @@ func (ii *InvertedIndex) OpenList(fNames []string) error {
 	ii.closeWhatNotInList(fNames)
 	ii.garbageFiles = ii.scanStateFiles(fNames)
 	if err := ii.openFiles(); err != nil {
-		return fmt.Errorf("NewHistory.openFiles: %s, %w", ii.filenameBase, err)
+		return fmt.Errorf("NewHistory.openFiles: %w, %s", err, ii.filenameBase)
 	}
 	return nil
 }
@@ -299,7 +300,10 @@ func (ii *InvertedIndex) openFiles() error {
 			}
 
 			if item.decompressor, err = seg.NewDecompressor(datPath); err != nil {
-				ii.logger.Debug("InvertedIndex.openFiles: %w, %s", err, datPath)
+				ii.logger.Debug("InvertedIndex.openFiles:", "err", err, "file", datPath)
+				if errors.Is(err, &seg.ErrCompressedFileCorrupted{}) {
+					err = nil
+				}
 				continue
 			}
 
@@ -309,7 +313,7 @@ func (ii *InvertedIndex) openFiles() error {
 			idxPath := filepath.Join(ii.dir, fmt.Sprintf("%s.%d-%d.efi", ii.filenameBase, fromStep, toStep))
 			if dir.FileExist(idxPath) {
 				if item.index, err = recsplit.OpenIndex(idxPath); err != nil {
-					ii.logger.Debug("InvertedIndex.openFiles: %w, %s", err, idxPath)
+					ii.logger.Debug("InvertedIndex.openFiles:", "err", err, "file", idxPath)
 					return false
 				}
 				totalKeys += item.index.KeyCount()

--- a/erigon-lib/state/inverted_index_test.go
+++ b/erigon-lib/state/inverted_index_test.go
@@ -564,3 +564,27 @@ func TestCtxFiles(t *testing.T) {
 	require.Equal(t, 480, int(roFiles[2].startTxNum))
 	require.Equal(t, 512, int(roFiles[2].endTxNum))
 }
+
+func TestInvIndex_OpenFolder(t *testing.T) {
+	fp, db, ii, txs := filledInvIndex(t, log.New())
+	defer db.Close()
+	defer ii.Close()
+	defer os.RemoveAll(fp)
+
+	mergeInverted(t, db, ii, txs)
+
+	list := ii.visibleFiles.Load()
+	require.NotEmpty(t, list)
+	ff := (*list)[len(*list)-1]
+	fn := ff.src.decompressor.FilePath()
+	ii.Close()
+
+	err := os.Remove(fn)
+	require.NoError(t, err)
+	err = os.WriteFile(fn, make([]byte, 33), 0644)
+	require.NoError(t, err)
+
+	err = ii.OpenFolder()
+	require.NoError(t, err)
+	ii.Close()
+}


### PR DESCRIPTION
Fixes panic and log prints
```
DBUG[04-17|03:03:11.204] [agg] History.openFiles                  err="compressed file \"v1-accounts.1344-1408.v\" dictionary is corrupted: size 9.3 GB but no words in it" f=/mnt/erigon/snapshots/history/v1-accounts.1344-1408.v
panic: History(code).openFiles: compressed file "v1-code.1344-1408.v" dictionary is corrupted: size 3.9 MB but no words in it

goroutine 1 [running]:
github.com/ledgerwatch/erigon/cmd/integration/commands.allSnapshots.func1()
	github.com/ledgerwatch/erigon/cmd/integration/commands/stages.go:1743 +0x4c8
sync.(*Once).doSlow(0xc00102fbc0?, 0xc00102b870?)
	sync/once.go:74 +0xc2
sync.(*Once).Do(...)
	sync/once.go:65
github.com/ledgerwatch/erigon/cmd/integration/commands.allSnapshots({0x1ebbe30?, 0x2c90460?}, {0x1ec32a0?, 0xc0004d68c0?}, {0x1ec6508?, 0xc000519f00?})
	github.com/ledgerwatch/erigon/cmd/integration/commands/stages.go:1717 +0x90
github.com/ledgerwatch/erigon/cmd/integration/commands.openDB({{0x1ec6508, 0xc0000f1800}, 0xc000df6410, 0x1cb3c98, {0xc000a25290, 0x15}, 0x0, 0x20000000000, 0x40000000, 0xffffffffffffffff, ...}, ...)
	github.com/ledgerwatch/erigon/cmd/integration/commands/root.go:108 +0x4a5
github.com/ledgerwatch/erigon/cmd/integration/commands.init.func11(0x2b5cbe0, {0x1a0b51f?, 0x4?, 0x1a0b3df?})
	github.com/ledgerwatch/erigon/cmd/integration/commands/stages.go:366 +0xea
github.com/spf13/cobra.(*Command).execute(0x2b5cbe0, {0xc000895470, 0x3, 0x3})
	github.com/spf13/cobra@v1.8.0/command.go:987 +0xab1
github.com/spf13/cobra.(*Command).ExecuteC(0x2b5c340)
	github.com/spf13/cobra@v1.8.0/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.8.0/command.go:1039
github.com/spf13/cobra.(*Command).ExecuteContext(0x0?, {0x1ebbf90?, 0xc000df63c0?})
	github.com/spf13/cobra@v1.8.0/command.go:1032 +0x47
main.main()
	github.com/ledgerwatch/erigon/cmd/integration/main.go:15 +0xe6
```