### PR TITLE
dvovk/fix speedtest

### DIFF
--- a/erigon-lib/diagnostics/speedtest.go
+++ b/erigon-lib/diagnostics/speedtest.go
@@ -8,17 +8,17 @@ import (
 )
 
 func (d *DiagnosticClient) setupSpeedtestDiagnostics(rootCtx context.Context) {
-	ticker := time.NewTicker(180 * time.Second)
+	ticker := time.NewTicker(30 * time.Minute)
 	go func() {
 		d.networkSpeedMutex.Lock()
-		d.networkSpeed = d.runSpeedTest()
+		d.networkSpeed = d.runSpeedTest(rootCtx)
 		d.networkSpeedMutex.Unlock()
 
 		for {
 			select {
 			case <-ticker.C:
 				d.networkSpeedMutex.Lock()
-				d.networkSpeed = d.runSpeedTest()
+				d.networkSpeed = d.runSpeedTest(rootCtx)
 				d.networkSpeedMutex.Unlock()
 			case <-rootCtx.Done():
 				ticker.Stop()
@@ -28,7 +28,7 @@ func (d *DiagnosticClient) setupSpeedtestDiagnostics(rootCtx context.Context) {
 	}()
 }
 
-func (d *DiagnosticClient) runSpeedTest() NetworkSpeedTestResult {
+func (d *DiagnosticClient) runSpeedTest(rootCtx context.Context) NetworkSpeedTestResult {
 	var speedtestClient = speedtest.New()
 	serverList, _ := speedtestClient.FetchServers()
 	targets, _ := serverList.FindServer([]int{})
@@ -39,17 +39,17 @@ func (d *DiagnosticClient) runSpeedTest() NetworkSpeedTestResult {
 
 	if len(targets) > 0 {
 		s := targets[0]
-		err := s.PingTest(nil)
+		err := s.PingTestContext(rootCtx, nil)
 		if err == nil {
 			latency = s.Latency
 		}
 
-		err = s.DownloadTest()
+		err = s.DownloadTestContext(rootCtx)
 		if err == nil {
 			downloadSpeed = s.DLSpeed
 		}
 
-		err = s.UploadTest()
+		err = s.UploadTestContext(rootCtx)
 		if err == nil {
 			uploadSpeed = s.ULSpeed
 		}

--- a/erigon-lib/diagnostics/speedtest.go
+++ b/erigon-lib/diagnostics/speedtest.go
@@ -8,12 +8,12 @@ import (
 )
 
 func (d *DiagnosticClient) setupSpeedtestDiagnostics(rootCtx context.Context) {
-	d.networkSpeedMutex.Lock()
-	d.networkSpeed = d.runSpeedTest()
-	d.networkSpeedMutex.Unlock()
-
 	ticker := time.NewTicker(180 * time.Second)
 	go func() {
+		d.networkSpeedMutex.Lock()
+		d.networkSpeed = d.runSpeedTest()
+		d.networkSpeedMutex.Unlock()
+
 		for {
 			select {
 			case <-ticker.C:


### PR DESCRIPTION
- put initial speed test inside go routine
- passed context to download, upload, latency tests to stop if parent context cancelled
- increased test interval to 30 minutes