### PR TITLE
downloader: step towards atomic fs

### DIFF
--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -2373,7 +2373,7 @@ func (d *Downloader) AddMagnetLink(ctx context.Context, infoHash metainfo.Hash, 
 		}
 
 		mi := t.Metainfo()
-		if err := CreateTorrentFileIfNotExists(d.SnapDir(), t.Info(), &mi, d.torrentFiles); err != nil {
+		if _, err := d.torrentFiles.CreateWithMetaInfo(t.Info(), &mi); err != nil {
 			d.logger.Warn("[snapshots] create torrent file", "err", err)
 			return
 		}

--- a/erigon-lib/downloader/util.go
+++ b/erigon-lib/downloader/util.go
@@ -159,7 +159,7 @@ func BuildTorrentIfNeed(ctx context.Context, fName, root string, torrentFiles *T
 	}
 	info.Name = fName
 
-	return true, CreateTorrentFileFromInfo(root, info, nil, torrentFiles)
+	return torrentFiles.CreateWithMetaInfo(info, nil)
 }
 
 // BuildTorrentFilesIfNeed - create .torrent files from .seg files (big IO) - if .seg files were added manually
@@ -216,16 +216,6 @@ Loop:
 	return int(createdAmount.Load()), nil
 }
 
-func CreateTorrentFileIfNotExists(root string, info *metainfo.Info, mi *metainfo.MetaInfo, torrentFiles *TorrentFiles) error {
-	if torrentFiles.Exists(info.Name) {
-		return nil
-	}
-	if err := CreateTorrentFileFromInfo(root, info, mi, torrentFiles); err != nil {
-		return err
-	}
-	return nil
-}
-
 func CreateMetaInfo(info *metainfo.Info, mi *metainfo.MetaInfo) (*metainfo.MetaInfo, error) {
 	if mi == nil {
 		infoBytes, err := bencode.Marshal(info)
@@ -242,14 +232,6 @@ func CreateMetaInfo(info *metainfo.Info, mi *metainfo.MetaInfo) (*metainfo.MetaI
 		mi.AnnounceList = Trackers
 	}
 	return mi, nil
-}
-func CreateTorrentFileFromInfo(root string, info *metainfo.Info, mi *metainfo.MetaInfo, torrentFiles *TorrentFiles) (err error) {
-	mi, err = CreateMetaInfo(info, mi)
-	if err != nil {
-		return err
-	}
-	fPath := filepath.Join(root, info.Name+".torrent")
-	return torrentFiles.CreateTorrentFromMetaInfo(fPath, mi)
 }
 
 func AllTorrentPaths(dirs datadir.Dirs) ([]string, error) {

--- a/erigon-lib/downloader/webseed.go
+++ b/erigon-lib/downloader/webseed.go
@@ -598,7 +598,7 @@ func (d *WebSeeds) DownloadAndSaveTorrentFile(ctx context.Context, name string) 
 			d.logger.Log(d.verbosity, "[snapshots] .torrent from webseed rejected", "name", name, "err", err)
 			continue // it's ok if some HTTP provider failed - try next one
 		}
-		ts, _, _, err = d.torrentFiles.CreateIfNotProhibited(name, res)
+		ts, _, _, err = d.torrentFiles.Create(name, res)
 		return ts, ts != nil, err
 	}
 


### PR DESCRIPTION
- existence check and creation must be inside same `mutex.Lock`
- use ".tmp + rename" trick

Example of possible race: 
```
[EROR] [04-19|03:33:12.908] Erigon startup                           err="rename /mnt/erigon/snapshots/v1-000900-001000-transactions.seg.torrent.tmp /mnt/erigon/snapshots/v1-000900-001000-transactions.seg.torrent: no such file or directory"
```