### PR TITLE
[ots] Fix block rewards calculation on post-merge blocks

### DIFF
--- a/turbo/jsonrpc/otterscan_block_details.go
+++ b/turbo/jsonrpc/otterscan_block_details.go
@@ -3,6 +3,7 @@ package jsonrpc
 import (
 	"context"
 	"fmt"
+
 	"github.com/ledgerwatch/erigon-lib/common/hexutil"
 
 	"github.com/ledgerwatch/erigon-lib/common"
@@ -65,7 +66,7 @@ func (api *OtterscanAPIImpl) getBlockDetailsImpl(ctx context.Context, tx kv.Tx, 
 	if err != nil {
 		return nil, err
 	}
-	getIssuanceRes, err := delegateIssuance(tx, b, chainConfig)
+	getIssuanceRes, err := delegateIssuance(tx, b, chainConfig, api.engine())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is for E2.

The block rewards returned by Otterscan API is incorrect since the merge. It replaces very old code with the same calculation used for trace_block.

this code probably won't work with Aura consensus, but that's ok since the current one doesn't work as well. It would actually require exposing more code from block execution and I don't want to handle it for now, let's fix only the post-merge calc for now.