### PR TITLE
Caplin: fixed attestation broadcasting

### DIFF
--- a/cl/beacon/handler/pool.go
+++ b/cl/beacon/handler/pool.go
@@ -88,21 +88,21 @@ func (a *ApiHandler) PostEthV1BeaconPoolAttestations(w http.ResponseWriter, r *h
 			})
 			continue
 		}
-		// if a.sentinel != nil {
-		// 	encodedSSZ, err := attestation.EncodeSSZ(nil)
-		// 	if err != nil {
-		// 		beaconhttp.NewEndpointError(http.StatusInternalServerError, err).WriteTo(w)
-		// 		return
-		// 	}
-		// 	if _, err := a.sentinel.PublishGossip(r.Context(), &sentinel.GossipData{
-		// 		Data:     encodedSSZ,
-		// 		Name:     gossip.TopicNamePrefixBeaconAttestation,
-		// 		SubnetId: &subnet,
-		// 	}); err != nil {
-		// 		beaconhttp.NewEndpointError(http.StatusInternalServerError, err).WriteTo(w)
-		// 		return
-		// 	}
-		// }
+		if a.sentinel != nil {
+			encodedSSZ, err := attestation.EncodeSSZ(nil)
+			if err != nil {
+				beaconhttp.NewEndpointError(http.StatusInternalServerError, err).WriteTo(w)
+				return
+			}
+			if _, err := a.sentinel.PublishGossip(r.Context(), &sentinel.GossipData{
+				Data:     encodedSSZ,
+				Name:     gossip.TopicNamePrefixBeaconAttestation,
+				SubnetId: &subnet,
+			}); err != nil {
+				beaconhttp.NewEndpointError(http.StatusInternalServerError, err).WriteTo(w)
+				return
+			}
+		}
 	}
 	if len(failures) > 0 {
 		errResp := poolingError{

--- a/cl/cltypes/solid/attestation.go
+++ b/cl/cltypes/solid/attestation.go
@@ -50,6 +50,7 @@ func NewAttestionFromParameters(
 	signature [96]byte,
 ) *Attestation {
 	a := &Attestation{}
+	binary.LittleEndian.PutUint32(a.staticBuffer[:4], aggregationBitsOffset)
 	a.SetAttestationData(attestationData)
 	a.SetSignature(signature)
 	a.SetAggregationBits(aggregationBits)

--- a/cl/cltypes/solid/attestation.go
+++ b/cl/cltypes/solid/attestation.go
@@ -1,6 +1,7 @@
 package solid
 
 import (
+	"encoding/binary"
 	"encoding/json"
 
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
@@ -77,6 +78,7 @@ func (a *Attestation) UnmarshalJSON(buf []byte) error {
 	if err := json.Unmarshal(buf, &tmp); err != nil {
 		return err
 	}
+	binary.LittleEndian.PutUint32(a.staticBuffer[:4], aggregationBitsOffset)
 	a.SetAggregationBits(tmp.AggregationBits)
 	a.SetSignature(tmp.Signature)
 	a.SetAttestationData(tmp.Data)

--- a/cl/phase1/network/services/attestation_service.go
+++ b/cl/phase1/network/services/attestation_service.go
@@ -2,10 +2,12 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/Giulio2002/bls"
+	"github.com/ledgerwatch/erigon/cl/aggregation"
 	"github.com/ledgerwatch/erigon/cl/beacon/synced_data"
 	"github.com/ledgerwatch/erigon/cl/clparams"
 	"github.com/ledgerwatch/erigon/cl/cltypes/solid"
@@ -71,7 +73,7 @@ func (s *attestationService) ProcessMessage(ctx context.Context, subnet *uint64,
 	// [REJECT] The committee index is within the expected range
 	committeeCount := computeCommitteeCountPerSlot(headState, slot, s.beaconCfg.SlotsPerEpoch)
 	if committeeIndex >= committeeCount {
-		return fmt.Errorf("committee index out of range")
+		return fmt.Errorf("committee index out of range, %d >= %d", committeeIndex, committeeCount)
 	}
 	// [REJECT] The attestation is for the correct subnet -- i.e. compute_subnet_for_attestation(committees_per_slot, attestation.data.slot, index) == subnet_id
 	subnetId := computeSubnetForAttestation(committeeCount, slot, committeeIndex, s.beaconCfg.SlotsPerEpoch, s.netCfg.AttestationSubnetCount)
@@ -175,5 +177,9 @@ func (s *attestationService) ProcessMessage(ctx context.Context, subnet *uint64,
 		return fmt.Errorf("invalid finalized checkpoint %w", ErrIgnore)
 	}
 
-	return s.committeeSubscribe.CheckAggregateAttestation(att)
+	err = s.committeeSubscribe.CheckAggregateAttestation(att)
+	if errors.Is(err, aggregation.ErrIsSuperset) {
+		return ErrIgnore
+	}
+	return err
 }


### PR DESCRIPTION
This PR fixes 2 things:
* Superset handling (should ignore)
* SSZ offset not set for custom ssz in attestation encoding after json unmarshalling