### PR TITLE
sonar: fix js warnings and exclude mocks

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,15 @@ sonar.organization=ledgerwatch
 sonar.projectName=erigon
 
 sonar.sources=.
-sonar.exclusions=**/*.pb.go,**/gen_*.go,**/graphql/graph/generated.go,**/*.sol,common/compiler/*.v.py
+sonar.exclusions=\
+  **/*.pb.go,\
+  **/gen_*.go,\
+  **/*_mock.go,\
+  **/graphql/graph/generated.go,\
+  **/*.sol,\
+  common/compiler/*.v.py,\
+  rpc/testdata/**.js,\
+  eth/tracers/js/internal/tracers/**.js
 
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go,tests/**


### PR DESCRIPTION
- Excludes go mock generated files from analysis
- Excludes broken js files (valid as they are used for tracers and test data) to fix below warnings
<img width="1658" alt="Screenshot 2024-04-24 at 11 12 04" src="https://github.com/ledgerwatch/erigon/assets/94537774/7925d07f-37f3-43c9-b34a-9a5361e48a8a">
