### PR TITLE
Correct aggregation pool

### DIFF
--- a/cl/aggregation/pool_impl.go
+++ b/cl/aggregation/pool_impl.go
@@ -126,6 +126,8 @@ func findBestAggregation(attestations []*solid.Attestation) (*solid.Attestation,
 				return nil, fmt.Errorf("merged signature is too long")
 			}
 			copy(bestSig[:], mergedSig)
+
+			// update best aggregation
 			bestAggregation.SetAggregationBits(bits)
 			bestAggregation.SetSignature(bestSig)
 		}
@@ -140,7 +142,7 @@ func (p *aggregationPoolImpl) GetAggregatationByRoot(root common.Hash) *solid.At
 	if !ok {
 		return nil
 	}
-	return agg.bestAggregation
+	return agg.bestAggregation.Copy()
 }
 
 func (p *aggregationPoolImpl) sweepStaleAtt(ctx context.Context) {

--- a/cl/aggregation/pool_impl.go
+++ b/cl/aggregation/pool_impl.go
@@ -1,8 +1,10 @@
 package aggregation
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -26,7 +28,12 @@ type aggregationPoolImpl struct {
 	netConfig      *clparams.NetworkConfig
 	ethClock       eth_clock.EthereumClock
 	aggregatesLock sync.RWMutex
-	aggregates     map[common.Hash]*solid.Attestation
+	aggregates     map[common.Hash]*aggregate
+}
+
+type aggregate struct {
+	attCandidates   []*solid.Attestation
+	bestAggregation *solid.Attestation
 }
 
 func NewAggregationPool(
@@ -40,7 +47,7 @@ func NewAggregationPool(
 		beaconConfig:   beaconConfig,
 		netConfig:      netConfig,
 		aggregatesLock: sync.RWMutex{},
-		aggregates:     make(map[common.Hash]*solid.Attestation),
+		aggregates:     make(map[common.Hash]*aggregate),
 	}
 	go p.sweepStaleAtt(ctx)
 	return p
@@ -52,55 +59,88 @@ func (p *aggregationPoolImpl) AddAttestation(inAtt *solid.Attestation) error {
 	if err != nil {
 		return err
 	}
+	inAttCopy := inAtt.Copy()
 
 	p.aggregatesLock.Lock()
 	defer p.aggregatesLock.Unlock()
-	att, ok := p.aggregates[hashRoot]
+	aggr, ok := p.aggregates[hashRoot]
 	if !ok {
-		p.aggregates[hashRoot] = inAtt.Copy()
+		p.aggregates[hashRoot] = &aggregate{
+			attCandidates:   []*solid.Attestation{inAttCopy},
+			bestAggregation: inAttCopy,
+		}
 		return nil
 	}
-
-	if utils.IsNonStrictSupersetBitlist(att.AggregationBits(), inAtt.AggregationBits()) {
-		return ErrIsSuperset
+	// check if attestation with same bits already exists
+	for _, att := range aggr.attCandidates {
+		if bytes.Equal(att.AggregationBits(), inAtt.AggregationBits()) {
+			return nil
+		}
 	}
-
-	// merge signature
-	baseSig := att.Signature()
-	inSig := inAtt.Signature()
-	merged, err := blsAggregate([][]byte{baseSig[:], inSig[:]})
+	p.aggregates[hashRoot].attCandidates = append(p.aggregates[hashRoot].attCandidates, inAttCopy)
+	p.aggregates[hashRoot].bestAggregation, err = findBestAggregation(p.aggregates[hashRoot].attCandidates)
 	if err != nil {
 		return err
 	}
-	if len(merged) != 96 {
-		return fmt.Errorf("merged signature is too long")
-	}
-	var mergedSig [96]byte
-	copy(mergedSig[:], merged)
-
-	// merge aggregation bits
-	mergedBits := make([]byte, len(att.AggregationBits()))
-	for i := range att.AggregationBits() {
-		mergedBits[i] = att.AggregationBits()[i] | inAtt.AggregationBits()[i]
-	}
-
-	// update attestation
-	p.aggregates[hashRoot] = solid.NewAttestionFromParameters(
-		mergedBits,
-		inAtt.AttestantionData(),
-		mergedSig,
-	)
 	return nil
+}
+
+func findBestAggregation(attestations []*solid.Attestation) (*solid.Attestation, error) {
+	// find the largest set of attestations that are disjoint. It's essentially a max disjoint set coverage problem,
+	// which is NP-hard. We use a greedy algorithm to approximate the solution.
+	// The algorithm is as follows:
+	// 1. Sort the attestations by the number of bits set in the aggregation bits.
+	// 2. Iterate through the attestations in order, adding each attestation to the set if it is disjoint from the
+	//    attestations already in the set.
+	// 3. The set of attestations at the end of the iteration is the best aggregation.
+
+	if len(attestations) == 0 {
+		return nil, fmt.Errorf("no attestations to aggregate")
+	}
+
+	// sort attestations by number of bits set in aggregation bits (descending)
+	sort.Slice(attestations, func(i, j int) bool {
+		return utils.BitsOnCount(attestations[i].AggregationBits()) >
+			utils.BitsOnCount(attestations[j].AggregationBits())
+	})
+
+	// naive greedy algorithm to find the best aggregation
+	//bestBits := make([]byte, len(attestations[0].AggregationBits()))
+	//bestSig := attestations[0].Signature()
+	bestAggregation := attestations[0].Copy()
+	for _, att := range attestations {
+		if utils.IsDisjoint(att.AggregationBits(), bestAggregation.AggregationBits()) {
+			// merge bits
+			bits := make([]byte, len(bestAggregation.AggregationBits()))
+			copy(bits, bestAggregation.AggregationBits())
+			utils.MergeBitlists(bits, att.AggregationBits())
+
+			// merge signatures
+			sig := att.Signature()
+			bestSig := bestAggregation.Signature()
+			mergedSig, err := blsAggregate([][]byte{bestSig[:], sig[:]})
+			if err != nil {
+				return nil, err
+			}
+			if len(mergedSig) != 96 {
+				return nil, fmt.Errorf("merged signature is too long")
+			}
+			copy(bestSig[:], mergedSig)
+			bestAggregation.SetAggregationBits(bits)
+			bestAggregation.SetSignature(bestSig)
+		}
+	}
+	return bestAggregation, nil
 }
 
 func (p *aggregationPoolImpl) GetAggregatationByRoot(root common.Hash) *solid.Attestation {
 	p.aggregatesLock.RLock()
 	defer p.aggregatesLock.RUnlock()
-	att := p.aggregates[root]
-	if att == nil {
+	agg, ok := p.aggregates[root]
+	if !ok {
 		return nil
 	}
-	return att.Copy()
+	return agg.bestAggregation
 }
 
 func (p *aggregationPoolImpl) sweepStaleAtt(ctx context.Context) {
@@ -114,7 +154,7 @@ func (p *aggregationPoolImpl) sweepStaleAtt(ctx context.Context) {
 			toRemoves := make([][32]byte, 0)
 			for hashRoot := range p.aggregates {
 				att := p.aggregates[hashRoot]
-				if p.slotIsStale(att.AttestantionData().Slot()) {
+				if p.slotIsStale(att.bestAggregation.AttestantionData().Slot()) {
 					toRemoves = append(toRemoves, hashRoot)
 				}
 			}

--- a/cl/aggregation/pool_test.go
+++ b/cl/aggregation/pool_test.go
@@ -2,7 +2,6 @@ package aggregation
 
 import (
 	"context"
-	"log"
 	"testing"
 
 	"github.com/ledgerwatch/erigon/cl/cltypes/solid"
@@ -32,7 +31,7 @@ var (
 		[96]byte{'g', 'h', 'i', 'j', 'k', 'l'},
 	)
 	att1_4 = solid.NewAttestionFromParameters(
-		[]byte{0b00111010, 0, 0, 0},
+		[]byte{0b00110000, 0, 0, 0b00000011},
 		attData1,
 		[96]byte{'m', 'n', 'o', 'p', 'q', 'r'},
 	)
@@ -99,14 +98,13 @@ func (t *PoolTestSuite) TestAddAttestation() {
 			},
 			hashRoot: attData1Root,
 			expect: solid.NewAttestionFromParameters(
-				[]byte{0b00111111, 0b00000011, 0, 0}, // merge of att1_2, att1_3 and att1_4
+				[]byte{0b00111111, 0b00000011, 0, 0b00000011}, // merge of att1_2, att1_3 and att1_4
 				attData1,
 				mockAggrResult),
 		},
 	}
 
 	for _, tc := range testcases {
-		log.Printf("test case: %s", tc.name)
 		pool := NewAggregationPool(context.Background(), nil, nil, nil)
 		for _, att := range tc.atts {
 			pool.AddAttestation(att)

--- a/cl/utils/bytes.go
+++ b/cl/utils/bytes.go
@@ -152,3 +152,12 @@ func MergeBitlists(a, b []byte) {
 		a[i] |= b[i]
 	}
 }
+
+func IsDisjoint(a, b []byte) bool {
+	for i := range a {
+		if a[i]&b[i] != 0 {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
In the previous version, we simply performed BLS aggregation on any received attestation without checking the aggregation bits, but it turned out to be incorrect for this approach.
the problem we are solving is essentially a max disjoint set coverage problem. 
In this pr provide a naive greedy way to do it.
