### PR TITLE
Revert "Fix new_heads Events Emission on Block Forks (#9738)"

### DIFF
--- a/eth/stagedsync/stage_finish.go
+++ b/eth/stagedsync/stage_finish.go
@@ -143,8 +143,8 @@ func NotifyNewHeaders(ctx context.Context, finishStageBeforeSync uint64, finishS
 			heightSpan = 1024
 		}
 		notifyFrom = finishStageAfterSync - heightSpan
-		notifyFrom++
 	}
+	notifyFrom++
 
 	var notifyTo = notifyFrom
 	var notifyToHash libcommon.Hash


### PR DESCRIPTION
This reverts commit f4aefdc32a711d8b776673934ab1d9bb5f02025f.

See PR #9738