### PR TITLE
downloader: remove deprecated manual fsync 

### DIFF
--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -808,23 +808,6 @@ type seedHash struct {
 	reported bool
 }
 
-// fsyncDB - to not loose results of downloading on power-off
-// See `erigon-lib/downloader/mdbx_piece_completion.go` for explanation
-func (d *Downloader) fsyncDB() error {
-	return d.db.Update(d.ctx, func(tx kv.RwTx) error {
-		v, err := tx.GetOne(kv.BittorrentInfo, []byte("_fsync"))
-		if err != nil {
-			return err
-		}
-		if len(v) == 0 || v[0] == 0 {
-			v = []byte{1}
-		} else {
-			v = []byte{0}
-		}
-		return tx.Put(kv.BittorrentInfo, []byte("_fsync"), v)
-	})
-}
-
 func (d *Downloader) mainLoop(silent bool) error {
 	if d.webseedsDiscover {
 		// CornerCase: no peers -> no anoncments to trackers -> no magnetlink resolution (but magnetlink has filename)
@@ -1317,7 +1300,6 @@ func (d *Downloader) mainLoop(silent bool) error {
 	defer statEvery.Stop()
 
 	var m runtime.MemStats
-	justCompleted := true
 	for {
 		select {
 		case <-d.ctx.Done():
@@ -1334,11 +1316,6 @@ func (d *Downloader) mainLoop(silent bool) error {
 
 			dbg.ReadMemStats(&m)
 			if stats.Completed {
-				if justCompleted {
-					justCompleted = false
-					_ = d.fsyncDB()
-				}
-
 				d.logger.Info("[snapshots] Seeding",
 					"up", common.ByteCount(stats.UploadRate)+"/s",
 					"peers", stats.PeersUnique,
@@ -2303,7 +2280,7 @@ func (d *Downloader) VerifyData(ctx context.Context, whiteList []string, failFas
 	if err := g.Wait(); err != nil {
 		return err
 	}
-	return d.fsyncDB()
+	return nil
 }
 
 // AddNewSeedableFile decides what we do depending on wether we have the .seg file or the .torrent file

--- a/erigon-lib/downloader/mdbx_piece_completion_test.go
+++ b/erigon-lib/downloader/mdbx_piece_completion_test.go
@@ -51,3 +51,28 @@ func TestMdbxPieceCompletion(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, storage.Completion{Complete: true, Ok: true}, b)
 }
+
+func TestMdbxPieceCompletionBatch(t *testing.T) {
+	db := memdb.NewTestDownloaderDB(t)
+	pc, err := NewMdbxPieceCompletionBatch(db)
+	require.NoError(t, err)
+	defer pc.Close()
+
+	pk := metainfo.PieceKey{}
+
+	b, err := pc.Get(pk)
+	require.NoError(t, err)
+	assert.False(t, b.Ok)
+
+	require.NoError(t, pc.Set(pk, false))
+
+	b, err = pc.Get(pk)
+	require.NoError(t, err)
+	assert.Equal(t, storage.Completion{Complete: false, Ok: true}, b)
+
+	require.NoError(t, pc.Set(pk, true))
+
+	b, err = pc.Get(pk)
+	require.NoError(t, err)
+	assert.Equal(t, storage.Completion{Complete: true, Ok: true}, b)
+}


### PR DESCRIPTION
After switching to more durable db mode https://github.com/ledgerwatch/erigon/pull/10010 - we don't need manual fsync anymore. 