### PR TITLE
dvovk/limit mem usage

### DIFF
--- a/erigon-lib/diagnostics/client.go
+++ b/erigon-lib/diagnostics/client.go
@@ -16,7 +16,7 @@ type DiagnosticClient struct {
 	mu                  sync.Mutex
 	headerMutex         sync.Mutex
 	hardwareInfo        HardwareInfo
-	peersSyncMap        sync.Map
+	peersStats          PeerStats
 	headers             Headers
 	bodies              BodiesInfo
 	bodiesMutex         sync.Mutex
@@ -37,6 +37,7 @@ func NewDiagnosticClient(metricsMux *http.ServeMux, dataDirPath string) *Diagnos
 		resourcesUsage: ResourcesUsage{
 			MemoryUsage: []MemoryStats{},
 		},
+		peersStats: *NewPeerStats(1000), // 1000 is the limit of peers; TODO: make it configurable through a flag
 	}
 }
 

--- a/erigon-lib/diagnostics/client.go
+++ b/erigon-lib/diagnostics/client.go
@@ -16,7 +16,7 @@ type DiagnosticClient struct {
 	mu                  sync.Mutex
 	headerMutex         sync.Mutex
 	hardwareInfo        HardwareInfo
-	peersStats          PeerStats
+	peersStats          *PeerStats
 	headers             Headers
 	bodies              BodiesInfo
 	bodiesMutex         sync.Mutex
@@ -37,7 +37,7 @@ func NewDiagnosticClient(metricsMux *http.ServeMux, dataDirPath string) *Diagnos
 		resourcesUsage: ResourcesUsage{
 			MemoryUsage: []MemoryStats{},
 		},
-		peersStats: *NewPeerStats(1000), // 1000 is the limit of peers; TODO: make it configurable through a flag
+		peersStats: NewPeerStats(1000), // 1000 is the limit of peers; TODO: make it configurable through a flag
 	}
 }
 

--- a/erigon-lib/diagnostics/entities.go
+++ b/erigon-lib/diagnostics/entities.go
@@ -16,7 +16,9 @@
 
 package diagnostics
 
-import "time"
+import (
+	"time"
+)
 
 type PeerStatisticsGetter interface {
 	GetPeersStatistics() map[string]*PeerStatistics

--- a/erigon-lib/diagnostics/network.go
+++ b/erigon-lib/diagnostics/network.go
@@ -146,7 +146,7 @@ type PeerUpdTime struct {
 	Time   time.Time
 }
 
-func (p *PeerStats) GetOldestPeersWithAmountOfPeers(size int) []PeerUpdTime {
+func (p *PeerStats) GetOldestUpdatedPeersWithSize(size int) []PeerUpdTime {
 	var timeArray []PeerUpdTime
 	for k, v := range p.lastUpdateMap {
 		timeArray = append(timeArray, PeerUpdTime{k, v})
@@ -166,7 +166,7 @@ func (p *PeerStats) GetOldestPeersWithAmountOfPeers(size int) []PeerUpdTime {
 func (p *PeerStats) RemovePeersWhichExceedLimit(limit int) {
 	peersToRemove := p.GetPeersCount() - limit
 	if peersToRemove > 0 {
-		peers := p.GetOldestPeersWithAmountOfPeers(peersToRemove)
+		peers := p.GetOldestUpdatedPeersWithSize(peersToRemove)
 		for _, peer := range peers {
 			p.RemovePeer(peer.PeerID)
 		}

--- a/erigon-lib/diagnostics/network.go
+++ b/erigon-lib/diagnostics/network.go
@@ -147,7 +147,7 @@ type PeerUpdTime struct {
 }
 
 func (p *PeerStats) GetOldestUpdatedPeersWithSize(size int) []PeerUpdTime {
-	var timeArray []PeerUpdTime
+	timeArray := make([]PeerUpdTime, 0, p.GetPeersCount())
 	for k, v := range p.lastUpdateMap {
 		timeArray = append(timeArray, PeerUpdTime{k, v})
 	}

--- a/erigon-lib/diagnostics/network.go
+++ b/erigon-lib/diagnostics/network.go
@@ -2,9 +2,176 @@ package diagnostics
 
 import (
 	"context"
+	"sort"
+	"sync"
+	"time"
 
 	"github.com/ledgerwatch/log/v3"
 )
+
+type PeerStats struct {
+	peersInfo     sync.Map
+	recordsCount  int
+	lastUpdateMap map[string]time.Time
+	limit         int
+}
+
+func NewPeerStats(peerLimit int) *PeerStats {
+	return &PeerStats{
+		peersInfo:     sync.Map{},
+		recordsCount:  0,
+		lastUpdateMap: make(map[string]time.Time),
+		limit:         peerLimit,
+	}
+}
+
+func (p *PeerStats) AddOrUpdatePeer(peerID string, peerInfo PeerStatisticMsgUpdate) {
+	if value, ok := p.peersInfo.Load(peerID); ok {
+		p.UpdatePeer(peerID, peerInfo, value)
+	} else {
+		p.AddPeer(peerID, peerInfo)
+		if p.GetPeersCount() > p.limit {
+			p.RemovePeersWhichExceedLimit(p.limit)
+		}
+	}
+}
+
+func (p *PeerStats) AddPeer(peerID string, peerInfo PeerStatisticMsgUpdate) {
+	pv := PeerStatisticsFromMsgUpdate(peerInfo, nil)
+	p.peersInfo.Store(peerID, pv)
+	p.recordsCount++
+	p.lastUpdateMap[peerID] = time.Now()
+}
+
+func (p *PeerStats) UpdatePeer(peerID string, peerInfo PeerStatisticMsgUpdate, prevValue any) {
+	pv := PeerStatisticsFromMsgUpdate(peerInfo, prevValue)
+
+	p.peersInfo.Store(peerID, pv)
+	p.lastUpdateMap[peerID] = time.Now()
+}
+
+func PeerStatisticsFromMsgUpdate(msg PeerStatisticMsgUpdate, prevValue any) PeerStatistics {
+	ps := PeerStatistics{
+		PeerType:     msg.PeerType,
+		BytesIn:      0,
+		BytesOut:     0,
+		CapBytesIn:   make(map[string]uint64),
+		CapBytesOut:  make(map[string]uint64),
+		TypeBytesIn:  make(map[string]uint64),
+		TypeBytesOut: make(map[string]uint64),
+	}
+
+	if stats, ok := prevValue.(PeerStatistics); ok {
+		if msg.Inbound {
+			ps.BytesIn = stats.BytesIn + uint64(msg.Bytes)
+			ps.CapBytesIn[msg.MsgCap] = stats.CapBytesIn[msg.MsgCap] + uint64(msg.Bytes)
+			ps.TypeBytesIn[msg.MsgType] = stats.TypeBytesIn[msg.MsgType] + uint64(msg.Bytes)
+		} else {
+			ps.BytesOut = stats.BytesOut + uint64(msg.Bytes)
+			ps.CapBytesOut[msg.MsgCap] = stats.CapBytesOut[msg.MsgCap] + uint64(msg.Bytes)
+			ps.TypeBytesOut[msg.MsgType] = stats.TypeBytesOut[msg.MsgType] + uint64(msg.Bytes)
+		}
+	} else {
+		if msg.Inbound {
+			ps.BytesIn += uint64(msg.Bytes)
+			ps.CapBytesIn[msg.MsgCap] += uint64(msg.Bytes)
+			ps.TypeBytesIn[msg.MsgType] += uint64(msg.Bytes)
+		} else {
+			ps.BytesOut += uint64(msg.Bytes)
+			ps.CapBytesOut[msg.MsgCap] += uint64(msg.Bytes)
+			ps.TypeBytesOut[msg.MsgType] += uint64(msg.Bytes)
+		}
+
+	}
+
+	return ps
+}
+
+func (p *PeerStats) GetPeersCount() int {
+	return p.recordsCount
+}
+
+func (p *PeerStats) GetPeers() map[string]*PeerStatistics {
+	stats := make(map[string]*PeerStatistics)
+
+	p.peersInfo.Range(func(key, value interface{}) bool {
+		if loadedKey, ok := key.(string); ok {
+			if loadedValue, ok := value.(PeerStatistics); ok {
+				stats[loadedKey] = &loadedValue
+			} else {
+				log.Debug("Failed to cast value to PeerStatistics struct", value)
+			}
+		} else {
+			log.Debug("Failed to cast key to string", key)
+		}
+
+		return true
+	})
+
+	return stats
+}
+
+func (p *PeerStats) GetPeerStatistics(peerID string) PeerStatistics {
+	if value, ok := p.peersInfo.Load(peerID); ok {
+		if peerStats, ok := value.(PeerStatistics); ok {
+			return peerStats
+		}
+	}
+
+	return PeerStatistics{}
+}
+
+func (p *PeerStats) GetLastUpdate(peerID string) time.Time {
+	if lastUpdate, ok := p.lastUpdateMap[peerID]; ok {
+		return lastUpdate
+	}
+
+	return time.Time{}
+}
+
+func (p *PeerStats) Reset() {
+	p.peersInfo = sync.Map{}
+	p.recordsCount = 0
+	p.lastUpdateMap = make(map[string]time.Time)
+}
+
+func (p *PeerStats) RemovePeer(peerID string) {
+	p.peersInfo.Delete(peerID)
+	p.recordsCount--
+	delete(p.lastUpdateMap, peerID)
+}
+
+type PeerUpdTime struct {
+	PeerID string
+	Time   time.Time
+}
+
+func (p *PeerStats) GetOldestPeersWithAmountOfPeers(size int) []PeerUpdTime {
+	var timeArray []PeerUpdTime
+	for k, v := range p.lastUpdateMap {
+		timeArray = append(timeArray, PeerUpdTime{k, v})
+	}
+
+	sort.Slice(timeArray, func(i, j int) bool {
+		return timeArray[i].Time.Before(timeArray[j].Time)
+	})
+
+	if len(timeArray) < size {
+		return timeArray
+	} else {
+		return timeArray[:size]
+	}
+}
+
+func (p *PeerStats) RemovePeersWhichExceedLimit(limit int) {
+	peersToRemove := p.GetPeersCount() - limit
+	if peersToRemove > 0 {
+		peers := p.GetOldestPeersWithAmountOfPeers(peersToRemove)
+		for _, peer := range peers {
+			p.RemovePeer(peer.PeerID)
+		}
+	}
+}
 
 func (d *DiagnosticClient) setupNetworkDiagnostics(rootCtx context.Context) {
 	d.runCollectPeersStatistics(rootCtx)
@@ -21,74 +188,14 @@ func (d *DiagnosticClient) runCollectPeersStatistics(rootCtx context.Context) {
 			case <-rootCtx.Done():
 				return
 			case info := <-ch:
-				if value, ok := d.peersSyncMap.Load(info.PeerID); ok {
-					if stats, ok := value.(PeerStatistics); ok {
-						if info.Inbound {
-							stats.BytesIn += uint64(info.Bytes)
-							stats.CapBytesIn[info.MsgCap] += uint64(info.Bytes)
-							stats.TypeBytesIn[info.MsgType] += uint64(info.Bytes)
-						} else {
-							stats.BytesOut += uint64(info.Bytes)
-							stats.CapBytesOut[info.MsgCap] += uint64(info.Bytes)
-							stats.TypeBytesOut[info.MsgType] += uint64(info.Bytes)
-						}
-
-						d.peersSyncMap.Store(info.PeerID, stats)
-					} else {
-						log.Debug("Failed to cast value to PeerStatistics struct", value)
-					}
-				} else {
-					d.peersSyncMap.Store(info.PeerID, PeerStatistics{
-						PeerType:     info.PeerType,
-						CapBytesIn:   make(map[string]uint64),
-						CapBytesOut:  make(map[string]uint64),
-						TypeBytesIn:  make(map[string]uint64),
-						TypeBytesOut: make(map[string]uint64),
-					})
-				}
+				d.peersStats.AddOrUpdatePeer(info.PeerID, info)
 			}
 		}
 	}()
 }
 
 func (d *DiagnosticClient) Peers() map[string]*PeerStatistics {
-	stats := make(map[string]*PeerStatistics)
-
-	d.peersSyncMap.Range(func(key, value interface{}) bool {
-
-		if loadedKey, ok := key.(string); ok {
-			if loadedValue, ok := value.(PeerStatistics); ok {
-				stats[loadedKey] = &loadedValue
-			} else {
-				log.Debug("Failed to cast value to PeerStatistics struct", value)
-			}
-		} else {
-			log.Debug("Failed to cast key to string", key)
-		}
-
-		return true
-	})
-
-	d.PeerDataResetStatistics()
-
-	return stats
-}
-
-func (d *DiagnosticClient) PeerDataResetStatistics() {
-	d.peersSyncMap.Range(func(key, value interface{}) bool {
-		if stats, ok := value.(PeerStatistics); ok {
-			stats.BytesIn = 0
-			stats.BytesOut = 0
-			stats.CapBytesIn = make(map[string]uint64)
-			stats.CapBytesOut = make(map[string]uint64)
-			stats.TypeBytesIn = make(map[string]uint64)
-			stats.TypeBytesOut = make(map[string]uint64)
-
-			d.peersSyncMap.Store(key, stats)
-		} else {
-			log.Debug("Failed to cast value to PeerStatistics struct", value)
-		}
-
-		return true
-	})
+	peers := d.peersStats.GetPeers()
+	d.peersStats.Reset()
+	return peers
 }

--- a/erigon-lib/diagnostics/network.go
+++ b/erigon-lib/diagnostics/network.go
@@ -129,12 +129,6 @@ func (p *PeerStats) GetLastUpdate(peerID string) time.Time {
 	return time.Time{}
 }
 
-func (p *PeerStats) Reset() {
-	p.peersInfo = sync.Map{}
-	p.recordsCount = 0
-	p.lastUpdateMap = make(map[string]time.Time)
-}
-
 func (p *PeerStats) RemovePeer(peerID string) {
 	p.peersInfo.Delete(peerID)
 	p.recordsCount--
@@ -195,7 +189,5 @@ func (d *DiagnosticClient) runCollectPeersStatistics(rootCtx context.Context) {
 }
 
 func (d *DiagnosticClient) Peers() map[string]*PeerStatistics {
-	peers := d.peersStats.GetPeers()
-	d.peersStats.Reset()
-	return peers
+	return d.peersStats.GetPeers()
 }

--- a/erigon-lib/diagnostics/network.go
+++ b/erigon-lib/diagnostics/network.go
@@ -10,7 +10,7 @@ import (
 )
 
 type PeerStats struct {
-	peersInfo     sync.Map
+	peersInfo     *sync.Map
 	recordsCount  int
 	lastUpdateMap map[string]time.Time
 	limit         int
@@ -18,7 +18,7 @@ type PeerStats struct {
 
 func NewPeerStats(peerLimit int) *PeerStats {
 	return &PeerStats{
-		peersInfo:     sync.Map{},
+		peersInfo:     &sync.Map{},
 		recordsCount:  0,
 		lastUpdateMap: make(map[string]time.Time),
 		limit:         peerLimit,

--- a/erigon-lib/diagnostics/network_test.go
+++ b/erigon-lib/diagnostics/network_test.go
@@ -112,7 +112,7 @@ func TestLastUpdated(t *testing.T) {
 
 	require.True(t, peerStats.GetLastUpdate("test2").After(peerStats.GetLastUpdate("test1")))
 
-	oldestPeers := peerStats.GetOldestPeersWithAmountOfPeers(10)
+	oldestPeers := peerStats.GetOldestUpdatedPeersWithSize(10)
 
 	// we have 100 peers, but we should get only 10 oldest
 	require.Equal(t, len(oldestPeers), 10)
@@ -121,7 +121,7 @@ func TestLastUpdated(t *testing.T) {
 
 	// update test1 to
 	peerStats.AddOrUpdatePeer("test1", testUpdMsg)
-	oldestPeers = peerStats.GetOldestPeersWithAmountOfPeers(10)
+	oldestPeers = peerStats.GetOldestUpdatedPeersWithSize(10)
 
 	// the oldest peer should not be test1
 	require.NotEqual(t, "test1", oldestPeers[0].PeerID)

--- a/erigon-lib/diagnostics/network_test.go
+++ b/erigon-lib/diagnostics/network_test.go
@@ -110,7 +110,7 @@ func TestLastUpdated(t *testing.T) {
 		peerStats.AddOrUpdatePeer(pid, testUpdMsg)
 	}
 
-	require.True(t, peerStats.GetLastUpdate("test2").After(peerStats.GetLastUpdate("test1")))
+	require.True(t, peerStats.GetLastUpdate("test50").After(peerStats.GetLastUpdate("test1")))
 
 	oldestPeers := peerStats.GetOldestUpdatedPeersWithSize(10)
 

--- a/erigon-lib/diagnostics/network_test.go
+++ b/erigon-lib/diagnostics/network_test.go
@@ -51,9 +51,6 @@ func TestAddPeer(t *testing.T) {
 	require.Equal(t, 1, peerStats.GetPeersCount())
 
 	require.Equal(t, testPeerStats, peerStats.GetPeerStatistics("test1"))
-
-	peerStats.Reset()
-	require.Equal(t, 0, peerStats.GetPeersCount())
 }
 
 func TestUpdatePeer(t *testing.T) {

--- a/erigon-lib/diagnostics/network_test.go
+++ b/erigon-lib/diagnostics/network_test.go
@@ -1,0 +1,163 @@
+package diagnostics_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/ledgerwatch/erigon-lib/diagnostics"
+	"github.com/stretchr/testify/require"
+)
+
+var testPeerStats = diagnostics.PeerStatistics{
+	PeerType:     "Sentinel",
+	BytesIn:      10,
+	CapBytesIn:   map[string]uint64{"msgCap1": 10},
+	TypeBytesIn:  map[string]uint64{"msgType1": 10},
+	BytesOut:     0,
+	CapBytesOut:  map[string]uint64{},
+	TypeBytesOut: map[string]uint64{},
+}
+
+var testUpdMsg = diagnostics.PeerStatisticMsgUpdate{
+	PeerType: "Sentinel",
+	PeerID:   "test1",
+	Inbound:  true,
+	MsgType:  "msgType1",
+	MsgCap:   "msgCap1",
+	Bytes:    10,
+}
+
+func TestPeerStatisticsFromMsgUpdate(t *testing.T) {
+	ps := diagnostics.PeerStatisticsFromMsgUpdate(testUpdMsg, nil)
+	require.Equal(t, testPeerStats, ps)
+
+	ps1 := diagnostics.PeerStatisticsFromMsgUpdate(testUpdMsg, ps)
+
+	require.Equal(t, diagnostics.PeerStatistics{
+		PeerType:     "Sentinel",
+		BytesIn:      20,
+		CapBytesIn:   map[string]uint64{"msgCap1": 20},
+		TypeBytesIn:  map[string]uint64{"msgType1": 20},
+		BytesOut:     0,
+		CapBytesOut:  map[string]uint64{},
+		TypeBytesOut: map[string]uint64{},
+	}, ps1)
+}
+
+func TestAddPeer(t *testing.T) {
+	var peerStats = diagnostics.NewPeerStats(100)
+
+	peerStats.AddPeer("test1", testUpdMsg)
+	require.Equal(t, 1, peerStats.GetPeersCount())
+
+	require.Equal(t, testPeerStats, peerStats.GetPeerStatistics("test1"))
+
+	peerStats.Reset()
+	require.Equal(t, 0, peerStats.GetPeersCount())
+}
+
+func TestUpdatePeer(t *testing.T) {
+	peerStats := diagnostics.NewPeerStats(1000)
+
+	peerStats.AddPeer("test1", testUpdMsg)
+	peerStats.UpdatePeer("test1", testUpdMsg, testPeerStats)
+	require.Equal(t, 1, peerStats.GetPeersCount())
+
+	require.Equal(t, diagnostics.PeerStatistics{
+		PeerType:     "Sentinel",
+		BytesIn:      20,
+		CapBytesIn:   map[string]uint64{"msgCap1": 20},
+		TypeBytesIn:  map[string]uint64{"msgType1": 20},
+		BytesOut:     0,
+		CapBytesOut:  map[string]uint64{},
+		TypeBytesOut: map[string]uint64{},
+	}, peerStats.GetPeerStatistics("test1"))
+}
+
+func TestAddOrUpdatePeer(t *testing.T) {
+	peerStats := diagnostics.NewPeerStats(100)
+
+	peerStats.AddOrUpdatePeer("test1", testUpdMsg)
+	require.Equal(t, 1, peerStats.GetPeersCount())
+
+	require.Equal(t, testPeerStats, peerStats.GetPeerStatistics("test1"))
+
+	peerStats.AddOrUpdatePeer("test1", testUpdMsg)
+	require.Equal(t, 1, peerStats.GetPeersCount())
+
+	require.Equal(t, diagnostics.PeerStatistics{
+		PeerType:     "Sentinel",
+		BytesIn:      20,
+		CapBytesIn:   map[string]uint64{"msgCap1": 20},
+		TypeBytesIn:  map[string]uint64{"msgType1": 20},
+		BytesOut:     0,
+		CapBytesOut:  map[string]uint64{},
+		TypeBytesOut: map[string]uint64{},
+	}, peerStats.GetPeerStatistics("test1"))
+
+	peerStats.AddOrUpdatePeer("test2", testUpdMsg)
+	require.Equal(t, 2, peerStats.GetPeersCount())
+}
+
+func TestLastUpdated(t *testing.T) {
+	peerStats := diagnostics.NewPeerStats(1000)
+
+	peerStats.AddOrUpdatePeer("test1", testUpdMsg)
+	require.NotEmpty(t, peerStats.GetLastUpdate("test1"))
+
+	for i := 1; i < 100; i++ {
+		pid := "test" + strconv.Itoa(i)
+		peerStats.AddOrUpdatePeer(pid, testUpdMsg)
+	}
+
+	require.True(t, peerStats.GetLastUpdate("test2").After(peerStats.GetLastUpdate("test1")))
+
+	oldestPeers := peerStats.GetOldestPeersWithAmountOfPeers(10)
+
+	// we have 100 peers, but we should get only 10 oldest
+	require.Equal(t, len(oldestPeers), 10)
+	// the oldest peer should be test1
+	require.Equal(t, "test1", oldestPeers[0].PeerID)
+
+	// update test1 to
+	peerStats.AddOrUpdatePeer("test1", testUpdMsg)
+	oldestPeers = peerStats.GetOldestPeersWithAmountOfPeers(10)
+
+	// the oldest peer should not be test1
+	require.NotEqual(t, "test1", oldestPeers[0].PeerID)
+}
+
+func TestRemovePeersWhichExceedLimit(t *testing.T) {
+	limit := 100
+	peerStats := diagnostics.NewPeerStats(limit)
+
+	for i := 1; i < 105; i++ {
+		pid := "test" + strconv.Itoa(i)
+		peerStats.AddOrUpdatePeer(pid, testUpdMsg)
+	}
+
+	peerStats.RemovePeersWhichExceedLimit(limit)
+
+	require.Equal(t, limit, peerStats.GetPeersCount())
+
+	limit = 1000
+	peerStats.RemovePeersWhichExceedLimit(limit)
+
+	require.Equal(t, 100, peerStats.GetPeersCount())
+}
+
+func TestAddingPeersAboveTheLimit(t *testing.T) {
+	limit := 100
+	peerStats := diagnostics.NewPeerStats(limit)
+
+	for i := 1; i < 105; i++ {
+		pid := "test" + strconv.Itoa(i)
+		peerStats.AddOrUpdatePeer(pid, testUpdMsg)
+	}
+
+	require.Equal(t, limit, peerStats.GetPeersCount())
+
+	peerStats.AddOrUpdatePeer("test105", testUpdMsg)
+
+	require.Equal(t, limit, peerStats.GetPeersCount())
+}

--- a/erigon-lib/diagnostics/network_test.go
+++ b/erigon-lib/diagnostics/network_test.go
@@ -3,6 +3,7 @@ package diagnostics_test
 import (
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/ledgerwatch/erigon-lib/diagnostics"
 	"github.com/stretchr/testify/require"
@@ -102,12 +103,14 @@ func TestLastUpdated(t *testing.T) {
 	peerStats.AddOrUpdatePeer("test1", testUpdMsg)
 	require.NotEmpty(t, peerStats.GetLastUpdate("test1"))
 
-	for i := 1; i < 100; i++ {
+	for i := 1; i < 20; i++ {
 		pid := "test" + strconv.Itoa(i)
 		peerStats.AddOrUpdatePeer(pid, testUpdMsg)
+		//wait for 1 milisecond to make sure that the last update time is different
+		time.Sleep(10 * time.Millisecond)
 	}
 
-	require.True(t, peerStats.GetLastUpdate("test50").After(peerStats.GetLastUpdate("test1")))
+	require.True(t, peerStats.GetLastUpdate("test2").After(peerStats.GetLastUpdate("test1")))
 
 	oldestPeers := peerStats.GetOldestUpdatedPeersWithSize(10)
 


### PR DESCRIPTION
Implemented limit for saving peers in an Erigon node memory to be able to turn on diagnostics data collection by default.