### PR TITLE
[ots] Fix incorrect return type and overflow on total block fees calc

### DIFF
--- a/turbo/jsonrpc/otterscan_block_details.go
+++ b/turbo/jsonrpc/otterscan_block_details.go
@@ -82,6 +82,6 @@ func (api *OtterscanAPIImpl) getBlockDetailsImpl(ctx context.Context, tx kv.Tx, 
 	response := map[string]interface{}{}
 	response["block"] = getBlockRes
 	response["issuance"] = getIssuanceRes
-	response["totalFees"] = hexutil.Uint64(feesRes)
+	response["totalFees"] = (*hexutil.Big)(feesRes)
 	return response, nil
 }


### PR DESCRIPTION
For E2: fix incorrect type + overflow in certain blocks

Corresponding otterscan issue: https://github.com/otterscan/otterscan/issues/1658