### PR TITLE
Fix new_heads Events Emission on Block Forks

### DIFF
--- a/eth/stagedsync/stage_finish.go
+++ b/eth/stagedsync/stage_finish.go
@@ -143,8 +143,8 @@ func NotifyNewHeaders(ctx context.Context, finishStageBeforeSync uint64, finishS
 			heightSpan = 1024
 		}
 		notifyFrom = finishStageAfterSync - heightSpan
+		notifyFrom++
 	}
-	notifyFrom++
 
 	var notifyTo = notifyFrom
 	var notifyToHash libcommon.Hash


### PR DESCRIPTION
TL;DR: on a reorg, the common ancestor block is not being published to subscribers of newHeads

#### Expected behavior

if the reorg's common ancestor is 2, I expect 2 to be republished

1, 2, **2**, **3**, **4**

#### Actual behavior

2 is not republished, and 3's parentHash points to a 2 header that was never received

1, 2, **3**, **4**

This PR is the same thing as https://github.com/ledgerwatch/erigon/pull/9738 except with a test.

Note... the test passes, but **this does not actually work in production** (for Ethereum mainnet with prysm as external CL).

Why? Because in production, `h.sync.PrevUnwindPoint()` is always nil: https://github.com/ledgerwatch/erigon/blob/a5270bccf5e69a6beaaab9a0663bdad80e989505/turbo/stages/stageloop.go#L291 which means the initial "if block" is never entered, and thus we have **no control** of increment/decrement `notifyFrom` during reorgs https://github.com/ledgerwatch/erigon/blob/a5270bccf5e69a6beaaab9a0663bdad80e989505/eth/stagedsync/stage_finish.go#L137-L146

I don't know why `h.sync.PrevUnwindPoint()` is seemingly always nil, or how the test can pass if it fails in prod. I'm hoping to pass the baton to someone who might. Thank you @indanielo for original fix.

If we can figure this bug out, it closes #8848 and closes #9568 and closes #10056

