### PR TITLE
mdbx: Return err early in iter.Next()

### DIFF
--- a/erigon-lib/kv/mdbx/kv_mdbx.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx.go
@@ -2057,6 +2057,9 @@ func (s *cursor2iter) Next() (k, v []byte, err error) {
 		return nil, nil, s.ctx.Err()
 	default:
 	}
+	if s.err != nil {
+		return nil, nil, s.err
+	}
 	s.limit--
 	k, v, err = s.nextK, s.nextV, s.err
 	if s.orderAscend {

--- a/erigon-lib/kv/mdbx/kv_mdbx.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx.go
@@ -2168,6 +2168,9 @@ func (s *cursorDup2iter) Next() (k, v []byte, err error) {
 	default:
 	}
 	s.limit--
+	if s.err != nil {
+		return nil, nil, s.err
+	}
 	v, err = s.nextV, s.err
 	if s.orderAscend {
 		_, s.nextV, s.err = s.c.NextDup()

--- a/erigon-lib/kv/mdbx/kv_mdbx.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx.go
@@ -2065,10 +2065,11 @@ func (s *cursor2iter) Next() (k, v []byte, err error) {
 	default:
 	}
 	s.limit--
+	k, v = s.nextK, s.nextV
 	if err = s.advance(); err != nil {
 		return nil, nil, err
 	}
-	return s.nextK, s.nextV, nil
+	return k, v, nil
 }
 
 func (tx *MdbxTx) RangeDupSort(table string, key []byte, fromPrefix, toPrefix []byte, asc order.By, limit int) (iter.KV, error) {
@@ -2174,10 +2175,11 @@ func (s *cursorDup2iter) Next() (k, v []byte, err error) {
 	default:
 	}
 	s.limit--
+	v = s.nextV
 	if err = s.advance(); err != nil {
 		return nil, nil, err
 	}
-	return s.key, s.nextV, nil
+	return s.key, v, nil
 }
 
 func (tx *MdbxTx) ForAmount(bucket string, fromPrefix []byte, amount uint32, walker func(k, v []byte) error) error {

--- a/erigon-lib/kv/mdbx/kv_mdbx.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx.go
@@ -2065,11 +2065,10 @@ func (s *cursor2iter) Next() (k, v []byte, err error) {
 	default:
 	}
 	s.limit--
-	k, v = s.nextK, s.nextV
 	if err = s.advance(); err != nil {
 		return nil, nil, err
 	}
-	return k, v, nil
+	return s.nextK, s.nextV, nil
 }
 
 func (tx *MdbxTx) RangeDupSort(table string, key []byte, fromPrefix, toPrefix []byte, asc order.By, limit int) (iter.KV, error) {
@@ -2175,11 +2174,10 @@ func (s *cursorDup2iter) Next() (k, v []byte, err error) {
 	default:
 	}
 	s.limit--
-	v = s.nextV
 	if err = s.advance(); err != nil {
 		return nil, nil, err
 	}
-	return s.key, v, nil
+	return s.key, s.nextV, nil
 }
 
 func (tx *MdbxTx) ForAmount(bucket string, fromPrefix []byte, amount uint32, walker func(k, v []byte) error) error {

--- a/erigon-lib/kv/mdbx/kv_mdbx.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx.go
@@ -2067,7 +2067,7 @@ func (s *cursor2iter) Next() (k, v []byte, err error) {
 	} else {
 		s.nextK, s.nextV, s.err = s.c.Prev()
 	}
-	return k, v, s.err
+	return k, v, nil
 }
 
 func (tx *MdbxTx) RangeDupSort(table string, key []byte, fromPrefix, toPrefix []byte, asc order.By, limit int) (iter.KV, error) {
@@ -2177,7 +2177,7 @@ func (s *cursorDup2iter) Next() (k, v []byte, err error) {
 	} else {
 		_, s.nextV, s.err = s.c.PrevDup()
 	}
-	return s.key, v, s.err
+	return s.key, v, nil
 }
 
 func (tx *MdbxTx) ForAmount(bucket string, fromPrefix []byte, amount uint32, walker func(k, v []byte) error) error {

--- a/erigon-lib/kv/mdbx/kv_mdbx.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx.go
@@ -2061,13 +2061,13 @@ func (s *cursor2iter) Next() (k, v []byte, err error) {
 		return nil, nil, s.err
 	}
 	s.limit--
-	k, v, err = s.nextK, s.nextV, s.err
+	k, v = s.nextK, s.nextV
 	if s.orderAscend {
 		s.nextK, s.nextV, s.err = s.c.Next()
 	} else {
 		s.nextK, s.nextV, s.err = s.c.Prev()
 	}
-	return k, v, err
+	return k, v, s.err
 }
 
 func (tx *MdbxTx) RangeDupSort(table string, key []byte, fromPrefix, toPrefix []byte, asc order.By, limit int) (iter.KV, error) {
@@ -2167,17 +2167,17 @@ func (s *cursorDup2iter) Next() (k, v []byte, err error) {
 		return nil, nil, s.ctx.Err()
 	default:
 	}
-	s.limit--
 	if s.err != nil {
 		return nil, nil, s.err
 	}
-	v, err = s.nextV, s.err
+	s.limit--
+	v = s.nextV
 	if s.orderAscend {
 		_, s.nextV, s.err = s.c.NextDup()
 	} else {
 		_, s.nextV, s.err = s.c.PrevDup()
 	}
-	return s.key, v, err
+	return s.key, v, s.err
 }
 
 func (tx *MdbxTx) ForAmount(bucket string, fromPrefix []byte, amount uint32, walker func(k, v []byte) error) error {


### PR DESCRIPTION
`HasNext` will return true even with existing error and the application will expect a next entry. The `Next` function can get into an internal error (such as a `panic()`) while fetching the next cursor item and thus fail to return the error.
 https://github.com/ledgerwatch/erigon/blob/5ee7f3e2e8f8bc35a27978b14119b32e18fe163d/erigon-lib/kv/mdbx/kv_mdbx.go#L2035-L2039

Inspired by https://github.com/ledgerwatch/erigon/issues/9893, with the logs available at https://gist.github.com/banteg/14cc9193c7c78331e97b28b71dc695c3

This is triggered (as above) in the following section
https://github.com/ledgerwatch/erigon/blob/5ee7f3e2e8f8bc35a27978b14119b32e18fe163d/turbo/jsonrpc/eth_receipts.go#L181-L183

Requesting additional comments, as I don't have deeper understanding of mdbx internals