### PR TITLE
E35 bt cleanup

### DIFF
--- a/erigon-lib/state/btree_index_test.go
+++ b/erigon-lib/state/btree_index_test.go
@@ -83,7 +83,8 @@ func Test_BtreeIndex_Seek(t *testing.T) {
 	keys, err := pivotKeysFromKV(dataPath)
 	require.NoError(t, err)
 
-	getter := NewArchiveGetter(bt.decompressor.MakeGetter(), compressFlags)
+	//getter := NewArchiveGetter(bt.decompressor.MakeGetter(), compressFlags)
+	getter := bt.kvGetter
 
 	t.Run("seek beyond the last key", func(t *testing.T) {
 		_, _, err := bt.dataLookup(bt.ef.Count()+1, getter)
@@ -189,7 +190,8 @@ func Test_BtreeIndex_Seek2(t *testing.T) {
 	keys, err := pivotKeysFromKV(dataPath)
 	require.NoError(t, err)
 
-	getter := NewArchiveGetter(bt.decompressor.MakeGetter(), compressFlags)
+	//getter := NewArchiveGetter(bt.decompressor.MakeGetter(), compressFlags)
+	getter := bt.kvGetter
 
 	t.Run("seek beyond the last key", func(t *testing.T) {
 		_, _, err := bt.dataLookup(bt.ef.Count()+1, getter)

--- a/erigon-lib/state/domain_shared.go
+++ b/erigon-lib/state/domain_shared.go
@@ -669,16 +669,14 @@ func (sd *SharedDomains) IterateStoragePrefix(prefix []byte, it func(k []byte, v
 	}
 
 	sctx := sd.aggCtx.d[kv.StorageDomain]
-	for _, item := range sctx.files {
-		gg := NewArchiveGetter(item.src.decompressor.MakeGetter(), sd.aggCtx.a.d[kv.StorageDomain].compression)
-		cursor, err := item.src.bindex.Seek(gg, prefix)
+	for i, item := range sctx.files {
+		cursor, err := item.src.bindex.Seek(sctx.statelessGetter(i), prefix)
 		if err != nil {
 			return err
 		}
 		if cursor == nil {
 			continue
 		}
-		cursor.getter = gg
 
 		key := cursor.Key()
 		if key != nil && bytes.HasPrefix(key, prefix) {

--- a/erigon-lib/state/domain_test.go
+++ b/erigon-lib/state/domain_test.go
@@ -225,7 +225,7 @@ func testCollationBuild(t *testing.T, compressDomainVals bool) {
 		//}
 
 		for i := 0; i < len(words); i += 2 {
-			c, _ := sf.valuesBt.SeekDeprecated([]byte(words[i]))
+			c, _ := sf.valuesBt.Seek(g, []byte(words[i]))
 			require.Equal(t, words[i], string(c.Key()))
 			require.Equal(t, words[i+1], string(c.Value()))
 		}
@@ -249,7 +249,7 @@ func testCollationBuild(t *testing.T, compressDomainVals bool) {
 		// Check index
 		require.Equal(t, 1, int(sf.valuesBt.KeyCount()))
 		for i := 0; i < len(words); i += 2 {
-			c, _ := sf.valuesBt.SeekDeprecated([]byte(words[i]))
+			c, _ := sf.valuesBt.Seek(g, []byte(words[i]))
 			require.Equal(t, words[i], string(c.Key()))
 			require.Equal(t, words[i+1], string(c.Value()))
 		}
@@ -1055,7 +1055,7 @@ func TestDomain_CollationBuildInMem(t *testing.T) {
 	defer sf.CleanupOnError()
 	c.Close()
 
-	g := sf.valuesDecomp.MakeGetter()
+	g := NewArchiveGetter(sf.valuesDecomp.MakeGetter(), d.compression)
 	g.Reset(0)
 	var words []string
 	for g.HasNext() {
@@ -1066,7 +1066,7 @@ func TestDomain_CollationBuildInMem(t *testing.T) {
 	// Check index
 	require.Equal(t, 3, int(sf.valuesBt.KeyCount()))
 	for i := 0; i < len(words); i += 2 {
-		c, _ := sf.valuesBt.SeekDeprecated([]byte(words[i]))
+		c, _ := sf.valuesBt.Seek(g, []byte(words[i]))
 		require.Equal(t, words[i], string(c.Key()))
 		require.Equal(t, words[i+1], string(c.Value()))
 	}


### PR DESCRIPTION
- Do not store data file pointer linked to index inside index itself
- ask external ArchiveGetter to be provided.
- use existing getters during storage iteration
- move functions suitable for testing to test
