### PR TITLE
abi: fix abigen issue with make devtools

### DIFF
--- a/accounts/abi/bind/template.go
+++ b/accounts/abi/bind/template.go
@@ -90,8 +90,21 @@ package {{.Package}}
 import (
 	"math/big"
 	"strings"
-	"fmt"
-	"reflect"
+
+{{range .Contracts}}
+	{{$stop := false}}
+	{{range .Transacts}}
+		{{if ne (len .Normalized.Inputs) 0}}
+			"fmt"
+			"reflect"
+			{{$stop = true}}
+			{{break}}
+		{{end}}
+	{{end}}
+	{{if $stop}}
+		{{break}}
+	{{end}}
+{{end}}
 
 	ethereum "github.com/ledgerwatch/erigon"
 	"github.com/ledgerwatch/erigon/accounts/abi"

--- a/consensus/aura/auraabi/gen_block_reward.go
+++ b/consensus/aura/auraabi/gen_block_reward.go
@@ -7,6 +7,9 @@ import (
 	"math/big"
 	"strings"
 
+	"fmt"
+	"reflect"
+
 	ethereum "github.com/ledgerwatch/erigon"
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon/accounts/abi"
@@ -190,4 +193,43 @@ func (_BlockReward *BlockRewardSession) Reward(benefactors []libcommon.Address, 
 // Solidity: function reward(address[] benefactors, uint16[] kind) returns(address[], uint256[])
 func (_BlockReward *BlockRewardTransactorSession) Reward(benefactors []libcommon.Address, kind []uint16) (types.Transaction, error) {
 	return _BlockReward.Contract.Reward(&_BlockReward.TransactOpts, benefactors, kind)
+}
+
+// RewardParams is an auto generated read-only Go binding of transcaction calldata params
+type RewardParams struct {
+	Param_benefactors []libcommon.Address
+	Param_kind        []uint16
+}
+
+// Parse Reward method from calldata of a transaction
+//
+// Solidity: function reward(address[] benefactors, uint16[] kind) returns(address[], uint256[])
+func ParseReward(calldata []byte) (*RewardParams, error) {
+	if len(calldata) <= 4 {
+		return nil, fmt.Errorf("invalid calldata input")
+	}
+
+	_abi, err := abi.JSON(strings.NewReader(BlockRewardABI))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get abi of registry metadata: %w", err)
+	}
+
+	out, err := _abi.Methods["reward"].Inputs.Unpack(calldata[4:])
+	if err != nil {
+		return nil, fmt.Errorf("failed to unpack reward params data: %w", err)
+	}
+
+	var paramsResult = new(RewardParams)
+	value := reflect.ValueOf(paramsResult).Elem()
+
+	if value.NumField() != len(out) {
+		return nil, fmt.Errorf("failed to match calldata with param field number")
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]libcommon.Address)).(*[]libcommon.Address)
+	out1 := *abi.ConvertType(out[1], new([]uint16)).(*[]uint16)
+
+	return &RewardParams{
+		Param_benefactors: out0, Param_kind: out1,
+	}, nil
 }


### PR DESCRIPTION
fixes https://github.com/ledgerwatch/erigon/pull/7593 

it introduced a regression: `"fmt"` and `"reflect"` imports were added for all files generated by `abigen` assuming that they will be used in all cases, however that assumption was wrong for some cases resulting in invalid code being generated (in this case after running `make devtools`):
<img width="982" alt="Screenshot 2024-04-27 at 10 50 37" src="https://github.com/ledgerwatch/erigon/assets/94537774/9a1b93a5-2141-40d9-8c9e-01a1ff6c031c">

