### PR TITLE
Use block's number for heightToDownload when downloading headers

### DIFF
--- a/turbo/engineapi/engine_block_downloader/core.go
+++ b/turbo/engineapi/engine_block_downloader/core.go
@@ -15,7 +15,11 @@ import (
 func (e *EngineBlockDownloader) download(ctx context.Context, hashToDownload libcommon.Hash, requestId int, block *types.Block) {
 	/* Start download process*/
 	// First we schedule the headers download process
-	if !e.scheduleHeadersDownload(requestId, hashToDownload, 0) {
+	heightToDownload := uint64(0)
+	if block != nil {
+		heightToDownload = block.NumberU64()
+	}
+	if !e.scheduleHeadersDownload(requestId, hashToDownload, heightToDownload) {
 		e.logger.Warn("[EngineBlockDownloader] could not begin header download")
 		// could it be scheduled? if not nevermind.
 		e.status.Store(headerdownload.Idle)


### PR DESCRIPTION
Currently, blockDownloader uses 0 as a hard-coded value for `heightToDownload`. This isn't necessarily a problem because we are using `hashToDownload` to download the headers.

I modified the code to use `block.Number()` for `heightToDownload` because:
1. in some random cases where `hashToDownload` is empty
2. we can see blockHeight in logs rather than just hashes
3. otherwise, we can also choose to just use `0` as default value when the hash is not available and remove unnecessary code. 

I'd be open to go to #3 and rewrite this PR if you think it's more appropriate :) 