### PR TITLE
[wip] e35: 4kb pagesize

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -748,12 +748,12 @@ var (
 	DbPageSizeFlag = cli.StringFlag{
 		Name:  "db.pagesize",
 		Usage: "DB is splitted to 'pages' of fixed size. Can't change DB creation. Must be power of 2 and '256b <= pagesize <= 64kb'. Default: equal to OperationSystem's pageSize. Bigger pageSize causing: 1. More writes to disk during commit 2. Smaller b-tree high 3. Less fragmentation 4. Less overhead on 'free-pages list' maintainance (a bit faster Put/Commit) 5. If expecting DB-size > 8Tb then set pageSize >= 8Kb",
-		Value: "8KB",
+		Value: "4KB",
 	}
 	DbSizeLimitFlag = cli.StringFlag{
 		Name:  "db.size.limit",
 		Usage: "Runtime limit of chaindata db size. You can change value of this flag at any time.",
-		Value: (12 * datasize.TB).String(),
+		Value: (1 * datasize.TB).String(),
 	}
 
 	HealthCheckFlag = cli.BoolFlag{

--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -1801,7 +1801,7 @@ func ReconstituteState(ctx context.Context, s *StageState, dirs datadir.Dirs, wo
 		Flags(func(u uint) uint {
 			return mdbx.UtterlyNoSync | mdbx.NoMetaSync | mdbx.NoMemInit | mdbx.LifoReclaim | mdbx.WriteMap
 		}).
-		PageSize(uint64(8 * datasize.KB)).
+		PageSize(uint64(4 * datasize.KB)).
 		WithTableCfg(func(defaultBuckets kv.TableCfg) kv.TableCfg { return kv.ReconTablesCfg }).
 		Open(ctx)
 	if err != nil {


### PR DESCRIPTION
e3 db is ~30gb-100gb. with ~30% of it is FreeList. probably we can afford 4kb pagesize - to reduce io and db size. waiting for comparison test results.

on `pd-ssd` 8kb win in speed, will test on nvme