### PR TITLE
RPC: Receipts LRU cache

### DIFF
--- a/turbo/jsonrpc/erigon_receipts.go
+++ b/turbo/jsonrpc/erigon_receipts.go
@@ -29,11 +29,6 @@ func (api *ErigonImpl) GetLogsByHash(ctx context.Context, hash common.Hash) ([][
 	}
 	defer tx.Rollback()
 
-	chainConfig, err := api.chainConfig(ctx, tx)
-	if err != nil {
-		return nil, err
-	}
-
 	block, err := api.blockByHashWithSenders(ctx, tx, hash)
 	if err != nil {
 		return nil, err
@@ -41,7 +36,7 @@ func (api *ErigonImpl) GetLogsByHash(ctx context.Context, hash common.Hash) ([][
 	if block == nil {
 		return nil, nil
 	}
-	receipts, err := api.getReceipts(ctx, tx, chainConfig, block, block.Body().SendersFromTxs())
+	receipts, err := api.getReceipts(ctx, tx, block, block.Body().SendersFromTxs())
 	if err != nil {
 		return nil, fmt.Errorf("getReceipts error: %w", err)
 	}
@@ -426,7 +421,7 @@ func (api *ErigonImpl) GetBlockReceiptsByBlockHash(ctx context.Context, cannonic
 	if err != nil {
 		return nil, err
 	}
-	receipts, err := api.getReceipts(ctx, tx, chainConfig, block, block.Body().SendersFromTxs())
+	receipts, err := api.getReceipts(ctx, tx, block, block.Body().SendersFromTxs())
 	if err != nil {
 		return nil, fmt.Errorf("getReceipts error: %w", err)
 	}

--- a/turbo/jsonrpc/eth_api.go
+++ b/turbo/jsonrpc/eth_api.go
@@ -134,6 +134,7 @@ func NewBaseApi(f *rpchelper.Filters, stateCache kvcache.Cache, blockReader serv
 		blocksLRUSize      = 128 // ~32Mb
 		receiptsCacheLimit = 32
 	)
+	// if RPCDaemon deployed as independent process: increase cache sizes
 	if !singleNodeMode {
 		blocksLRUSize *= 5
 		receiptsCacheLimit *= 5

--- a/turbo/jsonrpc/eth_api.go
+++ b/turbo/jsonrpc/eth_api.go
@@ -109,8 +109,11 @@ type EthAPI interface {
 }
 
 type BaseAPI struct {
-	stateCache   kvcache.Cache                         // thread-safe
-	blocksLRU    *lru.Cache[common.Hash, *types.Block] // thread-safe
+	// all caches are thread-safe
+	stateCache    kvcache.Cache
+	blocksLRU     *lru.Cache[common.Hash, *types.Block]
+	receiptsCache *lru.Cache[common.Hash, []*types.Receipt]
+
 	filters      *rpchelper.Filters
 	_chainConfig atomic.Pointer[chain.Config]
 	_genesis     atomic.Pointer[types.Block]
@@ -127,16 +130,35 @@ type BaseAPI struct {
 }
 
 func NewBaseApi(f *rpchelper.Filters, stateCache kvcache.Cache, blockReader services.FullBlockReader, agg *libstate.Aggregator, singleNodeMode bool, evmCallTimeout time.Duration, engine consensus.EngineReader, dirs datadir.Dirs) *BaseAPI {
-	blocksLRUSize := 128 // ~32Mb
+	var (
+		blocksLRUSize      = 128 // ~32Mb
+		receiptsCacheLimit = 32
+	)
 	if !singleNodeMode {
-		blocksLRUSize = 512
+		blocksLRUSize *= 5
+		receiptsCacheLimit *= 5
 	}
 	blocksLRU, err := lru.New[common.Hash, *types.Block](blocksLRUSize)
 	if err != nil {
 		panic(err)
 	}
+	receiptsCache, err := lru.New[common.Hash, []*types.Receipt](receiptsCacheLimit)
+	if err != nil {
+		panic(err)
+	}
 
-	return &BaseAPI{filters: f, stateCache: stateCache, blocksLRU: blocksLRU, _blockReader: blockReader, _txnReader: blockReader, _agg: agg, evmCallTimeout: evmCallTimeout, _engine: engine, dirs: dirs}
+	return &BaseAPI{
+		filters:        f,
+		stateCache:     stateCache,
+		blocksLRU:      blocksLRU,
+		receiptsCache:  receiptsCache,
+		_blockReader:   blockReader,
+		_txnReader:     blockReader,
+		_agg:           agg,
+		evmCallTimeout: evmCallTimeout,
+		_engine:        engine,
+		dirs:           dirs,
+	}
 }
 
 func (api *BaseAPI) chainConfig(ctx context.Context, tx kv.Tx) (*chain.Config, error) {

--- a/turbo/jsonrpc/eth_receipts.go
+++ b/turbo/jsonrpc/eth_receipts.go
@@ -98,11 +98,10 @@ func (api *APIImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria) (t
 	defer tx.Rollback()
 
 	if crit.BlockHash != nil {
-		block, err := api._blockReader.BlockByHash(ctx, tx, *crit.BlockHash)
+		block, err := api.blockByHashWithSenders(ctx, tx, *crit.BlockHash)
 		if err != nil {
 			return nil, err
 		}
-
 		if block == nil {
 			return nil, fmt.Errorf("block not found: %x", *crit.BlockHash)
 		}

--- a/turbo/jsonrpc/graphql_api.go
+++ b/turbo/jsonrpc/graphql_api.go
@@ -73,7 +73,7 @@ func (api *GraphQLAPIImpl) GetBlockDetails(ctx context.Context, blockNumber rpc.
 		return nil, err
 	}
 
-	receipts, err := api.getReceipts(ctx, tx, chainConfig, block, senders)
+	receipts, err := api.getReceipts(ctx, tx, block, senders)
 	if err != nil {
 		return nil, fmt.Errorf("getReceipts error: %w", err)
 	}

--- a/turbo/jsonrpc/graphql_api.go
+++ b/turbo/jsonrpc/graphql_api.go
@@ -107,8 +107,14 @@ func (api *GraphQLAPIImpl) getBlockWithSenders(ctx context.Context, number rpc.B
 		return nil, nil, err
 	}
 
-	block, senders, err := api._blockReader.BlockWithSenders(ctx, tx, blockHash, blockHeight)
-	return block, senders, err
+	block, err := api.blockWithSenders(ctx, tx, blockHash, blockHeight)
+	if err != nil {
+		return nil, nil, err
+	}
+	if block == nil {
+		return nil, nil, nil
+	}
+	return block, block.Body().SendersFromTxs(), nil
 }
 
 func (api *GraphQLAPIImpl) delegateGetBlockByNumber(tx kv.Tx, b *types.Block, number rpc.BlockNumber, inclTx bool) (map[string]interface{}, error) {

--- a/turbo/jsonrpc/otterscan_api.go
+++ b/turbo/jsonrpc/otterscan_api.go
@@ -573,8 +573,14 @@ func (api *OtterscanAPIImpl) getBlockWithSenders(ctx context.Context, number rpc
 		return nil, nil, err
 	}
 
-	block, senders, err := api._blockReader.BlockWithSenders(ctx, tx, hash, n)
-	return block, senders, err
+	block, err := api.blockWithSenders(ctx, tx, hash, n)
+	if err != nil {
+		return nil, nil, err
+	}
+	if block == nil {
+		return nil, nil, nil
+	}
+	return block, block.Body().SendersFromTxs(), nil
 }
 
 func (api *OtterscanAPIImpl) GetBlockTransactions(ctx context.Context, number rpc.BlockNumber, pageNumber uint8, pageSize uint8) (map[string]interface{}, error) {

--- a/turbo/jsonrpc/otterscan_api.go
+++ b/turbo/jsonrpc/otterscan_api.go
@@ -603,7 +603,7 @@ func (api *OtterscanAPIImpl) GetBlockTransactions(ctx context.Context, number rp
 	}
 
 	// Receipts
-	receipts, err := api.getReceipts(ctx, tx, chainConfig, b, senders)
+	receipts, err := api.getReceipts(ctx, tx, b, senders)
 	if err != nil {
 		return nil, fmt.Errorf("getReceipts error: %v", err)
 	}

--- a/turbo/jsonrpc/otterscan_block_details.go
+++ b/turbo/jsonrpc/otterscan_block_details.go
@@ -70,7 +70,7 @@ func (api *OtterscanAPIImpl) getBlockDetailsImpl(ctx context.Context, tx kv.Tx, 
 	if err != nil {
 		return nil, err
 	}
-	receipts, err := api.getReceipts(ctx, tx, chainConfig, b, senders)
+	receipts, err := api.getReceipts(ctx, tx, b, senders)
 	if err != nil {
 		return nil, fmt.Errorf("getReceipts error: %v", err)
 	}

--- a/turbo/jsonrpc/otterscan_block_details.go
+++ b/turbo/jsonrpc/otterscan_block_details.go
@@ -44,7 +44,7 @@ func (api *OtterscanAPIImpl) GetBlockDetailsByHash(ctx context.Context, hash com
 	if blockNumber == nil {
 		return nil, fmt.Errorf("couldn't find block number for hash %v", hash.Bytes())
 	}
-	b, senders, err := api._blockReader.BlockWithSenders(ctx, tx, hash, *blockNumber)
+	b, err := api.blockWithSenders(ctx, tx, hash, *blockNumber)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func (api *OtterscanAPIImpl) GetBlockDetailsByHash(ctx context.Context, hash com
 	}
 	number := rpc.BlockNumber(b.Number().Int64())
 
-	return api.getBlockDetailsImpl(ctx, tx, b, number, senders)
+	return api.getBlockDetailsImpl(ctx, tx, b, number, b.Body().SendersFromTxs())
 }
 
 func (api *OtterscanAPIImpl) getBlockDetailsImpl(ctx context.Context, tx kv.Tx, b *types.Block, number rpc.BlockNumber, senders []common.Address) (map[string]interface{}, error) {

--- a/turbo/jsonrpc/otterscan_search_trace.go
+++ b/turbo/jsonrpc/otterscan_search_trace.go
@@ -51,7 +51,6 @@ func (api *OtterscanAPIImpl) traceBlock(dbtx kv.Tx, ctx context.Context, blockNu
 	if err != nil {
 		return false, nil, err
 	}
-	senders := block.Body().SendersFromTxs()
 
 	reader, err := rpchelper.CreateHistoryStateReader(dbtx, blockNum, 0, api.historyV3(dbtx), chainConfig.ChainName)
 	if err != nil {
@@ -74,7 +73,7 @@ func (api *OtterscanAPIImpl) traceBlock(dbtx kv.Tx, ctx context.Context, blockNu
 	}
 	engine := api.engine()
 
-	blockReceipts, err := api.getReceipts(ctx, dbtx, block, senders)
+	blockReceipts, err := api.getReceipts(ctx, dbtx, block, block.Body().SendersFromTxs())
 	if err != nil {
 		return false, nil, err
 	}

--- a/turbo/jsonrpc/otterscan_transaction_by_sender_and_nonce.go
+++ b/turbo/jsonrpc/otterscan_transaction_by_sender_and_nonce.go
@@ -276,10 +276,11 @@ func (api *OtterscanAPIImpl) findNonce(ctx context.Context, tx kv.Tx, addr commo
 	if err != nil {
 		return false, common.Hash{}, err
 	}
-	block, senders, err := api._blockReader.BlockWithSenders(ctx, tx, hash, blockNum)
+	block, err := api.blockWithSenders(ctx, tx, hash, blockNum)
 	if err != nil {
 		return false, common.Hash{}, err
 	}
+	senders := block.Body().SendersFromTxs()
 
 	txs := block.Transactions()
 	for i, s := range senders {

--- a/turbo/jsonrpc/overlay_api.go
+++ b/turbo/jsonrpc/overlay_api.go
@@ -496,7 +496,7 @@ func (api *OverlayAPIImpl) replayBlock(ctx context.Context, blockNum uint64, sta
 	gp := new(core.GasPool).AddGas(math.MaxUint64).AddBlobGas(math.MaxUint64)
 	vmConfig := vm.Config{Debug: false}
 	evm = vm.NewEVM(blockCtx, evmtypes.TxContext{}, statedb, chainConfig, vmConfig)
-	receipts, err := api.getReceipts(ctx, tx, chainConfig, block, block.Body().SendersFromTxs())
+	receipts, err := api.getReceipts(ctx, tx, block, block.Body().SendersFromTxs())
 	if err != nil {
 		return nil, err
 	}

--- a/turbo/jsonrpc/overlay_api.go
+++ b/turbo/jsonrpc/overlay_api.go
@@ -566,7 +566,7 @@ func (api *OverlayAPIImpl) replayBlock(ctx context.Context, blockNum uint64, sta
 func getBeginEnd(ctx context.Context, tx kv.Tx, api *OverlayAPIImpl, crit filters.FilterCriteria) (uint64, uint64, error) {
 	var begin, end uint64
 	if crit.BlockHash != nil {
-		block, err := api._blockReader.BlockByHash(ctx, tx, *crit.BlockHash)
+		block, err := api.blockByHashWithSenders(ctx, tx, *crit.BlockHash)
 		if err != nil {
 			return 0, 0, err
 		}


### PR DESCRIPTION
for https://github.com/ledgerwatch/erigon/issues/10099
for things like `eth_getTransactionReceipt`, `ots_searchTransactionsAfter`, etc...

Also moved:
- moved `api.chainConfig()` inside `api.getReceipts()`
- switched `ots` to use blocks/receipts lru
- switched price oracle to use blocks/receipts 