### PR TITLE
eth, txpool: enforce 30gwei for gas related configs for polygon

### DIFF
--- a/erigon-lib/txpool/txpoolcfg/txpoolcfg.go
+++ b/erigon-lib/txpool/txpoolcfg/txpoolcfg.go
@@ -23,10 +23,14 @@ import (
 
 	"github.com/c2h5oh/datasize"
 
+	"github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/common/fixedgas"
 	emath "github.com/ledgerwatch/erigon-lib/common/math"
 	"github.com/ledgerwatch/erigon-lib/types"
 )
+
+// BorDefaultTxPoolPriceLimit defines the minimum gas price limit for bor to enforce txs acceptance into the pool.
+const BorDefaultTxPoolPriceLimit = 30 * common.GWei
 
 type Config struct {
 	DBDir               string

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -47,6 +47,9 @@ import (
 
 //const HistoryV3AggregationStep = 3_125_000 / 100 // use this to reduce step size for dev/debug
 
+// BorDefaultMinerGasPrice defines the minimum gas price for bor validators to mine a transaction.
+var BorDefaultMinerGasPrice = big.NewInt(30 * params.GWei)
+
 // FullNodeGPO contains default gasprice oracle settings for full node.
 var FullNodeGPO = gaspricecfg.Config{
 	Blocks:           20,

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -284,7 +284,7 @@ func (s *sortingHeap) Pop() interface{} {
 	return x
 }
 
-// // setBorDefaultGpoIgnorePrice enforces gpo IgnorePrice to be equal to BorDefaultGpoIgnorePrice  (30gwei by default)
+// setBorDefaultGpoIgnorePrice enforces gpo IgnorePrice to be equal to BorDefaultGpoIgnorePrice  (30gwei by default)
 func setBorDefaultGpoIgnorePrice(chainConfig *chain.Config, gasPriceConfig gaspricecfg.Config) {
 	if chainConfig.Bor != nil && gasPriceConfig.IgnorePrice != gaspricecfg.BorDefaultGpoIgnorePrice {
 		log.Warn("Sanitizing invalid bor gasprice oracle ignore price", "provided", gasPriceConfig.IgnorePrice, "updated", gaspricecfg.BorDefaultGpoIgnorePrice)

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -91,6 +91,9 @@ func NewOracle(backend OracleBackend, params gaspricecfg.Config, cache Cache) *O
 		ignorePrice = gaspricecfg.DefaultIgnorePrice
 		log.Warn("Sanitizing invalid gasprice oracle ignore price", "provided", params.IgnorePrice, "updated", ignorePrice)
 	}
+
+	setBorDefaultGpoIgnorePrice(backend.ChainConfig(), params)
+
 	return &Oracle{
 		backend:          backend,
 		lastPrice:        params.Default,
@@ -279,4 +282,12 @@ func (s *sortingHeap) Pop() interface{} {
 	old[n-1] = nil // avoid memory leak
 	*s = old[0 : n-1]
 	return x
+}
+
+// // setBorDefaultGpoIgnorePrice enforces gpo IgnorePrice to be equal to BorDefaultGpoIgnorePrice  (30gwei by default)
+func setBorDefaultGpoIgnorePrice(chainConfig *chain.Config, gasPriceConfig gaspricecfg.Config) {
+	if chainConfig.Bor != nil && gasPriceConfig.IgnorePrice != gaspricecfg.BorDefaultGpoIgnorePrice {
+		log.Warn("Sanitizing invalid bor gasprice oracle ignore price", "provided", gasPriceConfig.IgnorePrice, "updated", gaspricecfg.BorDefaultGpoIgnorePrice)
+		gasPriceConfig.IgnorePrice = gaspricecfg.BorDefaultGpoIgnorePrice
+	}
 }

--- a/eth/gasprice/gaspricecfg/gaspricecfg.go
+++ b/eth/gasprice/gaspricecfg/gaspricecfg.go
@@ -8,6 +8,9 @@ import (
 
 var DefaultIgnorePrice = big.NewInt(2 * params.Wei)
 
+// BorDefaultGpoIgnorePrice defines the minimum gas price below which bor gpo will ignore transactions.
+var BorDefaultGpoIgnorePrice = big.NewInt(30 * params.Wei)
+
 var (
 	DefaultMaxPrice = big.NewInt(500 * params.GWei)
 )


### PR DESCRIPTION
This PR enforces the params `txpool.pricelimit`, `miner.gasprice` and `gpo.ignoreprice` to be set to 30 gwei when running `erigon` for Polygon chains.

`bor` related PR: `https://github.com/maticnetwork/bor/pull/1231`
