### PR TITLE
polygon/sync: use a direct execution API client

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -922,7 +922,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 			p2pConfig.MaxPeers,
 			statusDataProvider,
 			config.HeimdallURL,
-			executionEngine,
+			executionRpc,
 		)
 	}
 

--- a/polygon/sync/execution_client.go
+++ b/polygon/sync/execution_client.go
@@ -2,8 +2,16 @@ package sync
 
 import (
 	"context"
+	"fmt"
+	"runtime"
+	"time"
 
-	executionclient "github.com/ledgerwatch/erigon/cl/phase1/execution_client"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/ledgerwatch/erigon-lib/gointerfaces"
+	execution_proto "github.com/ledgerwatch/erigon-lib/gointerfaces/execution"
+	"github.com/ledgerwatch/erigon/turbo/execution/eth1/eth1_utils"
+
 	"github.com/ledgerwatch/erigon/core/types"
 )
 
@@ -14,23 +22,77 @@ type ExecutionClient interface {
 }
 
 type executionClient struct {
-	engine executionclient.ExecutionEngine
+	client execution_proto.ExecutionClient
 }
 
-func NewExecutionClient(engine executionclient.ExecutionEngine) ExecutionClient {
-	return &executionClient{engine}
+func NewExecutionClient(client execution_proto.ExecutionClient) ExecutionClient {
+	return &executionClient{client}
 }
 
 func (e *executionClient) InsertBlocks(ctx context.Context, blocks []*types.Block) error {
-	return e.engine.InsertBlocks(ctx, blocks, true)
+	request := &execution_proto.InsertBlocksRequest{
+		Blocks: eth1_utils.ConvertBlocksToRPC(blocks),
+	}
+
+	for {
+		response, err := e.client.InsertBlocks(ctx, request)
+		if err != nil {
+			return err
+		}
+
+		status := response.Result
+		switch status {
+		case execution_proto.ExecutionStatus_Success:
+			return nil
+		case execution_proto.ExecutionStatus_Busy:
+			// retry after sleep
+			delayTimer := time.NewTimer(time.Second)
+			defer delayTimer.Stop()
+
+			select {
+			case <-delayTimer.C:
+			case <-ctx.Done():
+			}
+		default:
+			return fmt.Errorf("executionClient.InsertBlocks failed with response status: %s", status.String())
+		}
+	}
 }
 
-func (e *executionClient) UpdateForkChoice(_ context.Context, _ *types.Header, _ *types.Header) error {
+func (e *executionClient) UpdateForkChoice(ctx context.Context, tip *types.Header, finalizedHeader *types.Header) error {
 	// TODO - not ready for execution - missing state sync event and span data - uncomment once ready
-	//return e.engine.ForkChoiceUpdate(ctx, finalizedHeader.Hash(), tip.Hash())
+	if runtime.GOOS != "TODO" {
+		return nil
+	}
+
+	tipHash := tip.Hash()
+	const timeout = 5 * time.Second
+
+	request := execution_proto.ForkChoice{
+		HeadBlockHash:      gointerfaces.ConvertHashToH256(tipHash),
+		SafeBlockHash:      gointerfaces.ConvertHashToH256(tipHash),
+		FinalizedBlockHash: gointerfaces.ConvertHashToH256(finalizedHeader.Hash()),
+		Timeout:            uint64(timeout.Milliseconds()),
+	}
+
+	response, err := e.client.UpdateForkChoice(ctx, &request)
+	if err != nil {
+		return err
+	}
+
+	if len(response.ValidationError) > 0 {
+		return fmt.Errorf("executionClient.UpdateForkChoice failed with a validation error: %s", response.ValidationError)
+	}
 	return nil
 }
 
 func (e *executionClient) CurrentHeader(ctx context.Context) (*types.Header, error) {
-	return e.engine.CurrentHeader(ctx)
+	response, err := e.client.CurrentHeader(ctx, &emptypb.Empty{})
+	if err != nil {
+		return nil, err
+	}
+	if (response == nil) || (response.Header == nil) {
+		return nil, nil
+	}
+	return eth1_utils.HeaderRpcToHeader(response.Header)
 }

--- a/polygon/sync/execution_client.go
+++ b/polygon/sync/execution_client.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/ledgerwatch/erigon-lib/gointerfaces"
-	execution_proto "github.com/ledgerwatch/erigon-lib/gointerfaces/execution"
+	executionproto "github.com/ledgerwatch/erigon-lib/gointerfaces/execution"
 	"github.com/ledgerwatch/erigon/turbo/execution/eth1/eth1_utils"
 
 	"github.com/ledgerwatch/erigon/core/types"
@@ -22,15 +22,15 @@ type ExecutionClient interface {
 }
 
 type executionClient struct {
-	client execution_proto.ExecutionClient
+	client executionproto.ExecutionClient
 }
 
-func NewExecutionClient(client execution_proto.ExecutionClient) ExecutionClient {
+func NewExecutionClient(client executionproto.ExecutionClient) ExecutionClient {
 	return &executionClient{client}
 }
 
 func (e *executionClient) InsertBlocks(ctx context.Context, blocks []*types.Block) error {
-	request := &execution_proto.InsertBlocksRequest{
+	request := &executionproto.InsertBlocksRequest{
 		Blocks: eth1_utils.ConvertBlocksToRPC(blocks),
 	}
 
@@ -42,9 +42,9 @@ func (e *executionClient) InsertBlocks(ctx context.Context, blocks []*types.Bloc
 
 		status := response.Result
 		switch status {
-		case execution_proto.ExecutionStatus_Success:
+		case executionproto.ExecutionStatus_Success:
 			return nil
-		case execution_proto.ExecutionStatus_Busy:
+		case executionproto.ExecutionStatus_Busy:
 			// retry after sleep
 			delayTimer := time.NewTimer(time.Second)
 			defer delayTimer.Stop()
@@ -68,7 +68,7 @@ func (e *executionClient) UpdateForkChoice(ctx context.Context, tip *types.Heade
 	tipHash := tip.Hash()
 	const timeout = 5 * time.Second
 
-	request := execution_proto.ForkChoice{
+	request := executionproto.ForkChoice{
 		HeadBlockHash:      gointerfaces.ConvertHashToH256(tipHash),
 		SafeBlockHash:      gointerfaces.ConvertHashToH256(tipHash),
 		FinalizedBlockHash: gointerfaces.ConvertHashToH256(finalizedHeader.Hash()),

--- a/polygon/sync/service.go
+++ b/polygon/sync/service.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ledgerwatch/erigon-lib/chain"
 	"github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/direct"
-	execution_proto "github.com/ledgerwatch/erigon-lib/gointerfaces/execution"
+	executionproto "github.com/ledgerwatch/erigon-lib/gointerfaces/execution"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/eth/stagedsync"
 	"github.com/ledgerwatch/erigon/p2p/sentry"
@@ -37,7 +37,7 @@ func NewService(
 	maxPeers int,
 	statusDataProvider *sentry.StatusDataProvider,
 	heimdallUrl string,
-	executionClient execution_proto.ExecutionClient,
+	executionClient executionproto.ExecutionClient,
 ) Service {
 	borConfig := chainConfig.Bor.(*borcfg.BorConfig)
 	execution := NewExecutionClient(executionClient)

--- a/polygon/sync/service.go
+++ b/polygon/sync/service.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ledgerwatch/erigon-lib/chain"
 	"github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/direct"
-	executionclient "github.com/ledgerwatch/erigon/cl/phase1/execution_client"
+	execution_proto "github.com/ledgerwatch/erigon-lib/gointerfaces/execution"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/eth/stagedsync"
 	"github.com/ledgerwatch/erigon/p2p/sentry"
@@ -37,10 +37,10 @@ func NewService(
 	maxPeers int,
 	statusDataProvider *sentry.StatusDataProvider,
 	heimdallUrl string,
-	executionEngine executionclient.ExecutionEngine,
+	executionClient execution_proto.ExecutionClient,
 ) Service {
 	borConfig := chainConfig.Bor.(*borcfg.BorConfig)
-	execution := NewExecutionClient(executionEngine)
+	execution := NewExecutionClient(executionClient)
 	storage := NewStorage(logger, execution, maxPeers)
 	headersVerifier := VerifyAccumulatedHeaders
 	blocksVerifier := VerifyBlocks


### PR DESCRIPTION
ExecutionEngine was meant for the engine API compatibility mode. Switch to using a generated ExecutionClient interface. We never need a remote mode and it always ends up being an instance of ExecutionClientDirect implemented by EthereumExecutionModule.

If we want to add custom methods to it we could:
1) make our own PolygonExecution interface with the methods we need
2) make EthereumExecutionModule conform to PolygonExecution (add new methods there - it already implements all current execution.proto)
3) pass `backend.eth1ExecutionServer` as an instance of PolygonExecution
I can do this in the next PR if we want this.