### PR TITLE
Update check_time.go

### DIFF
--- a/cmd/rpcdaemon/health/check_time.go
+++ b/cmd/rpcdaemon/health/check_time.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/ledgerwatch/erigon-lib/common/hexutil"
 	"github.com/ledgerwatch/erigon/rpc"
 )
 
@@ -23,8 +24,8 @@ func checkTime(
 	}
 	timestamp := 0
 	if ts, ok := i["timestamp"]; ok {
-		if cs, ok := ts.(uint64); ok {
-			timestamp = int(cs)
+		if cs, ok := ts.(hexutil.Uint64); ok {
+			timestamp = int(uint64(cs))
 		}
 	}
 	if timestamp < seconds {


### PR DESCRIPTION
Changed type timestamp hexutil.Uint64 on health check_time

Actual behavior:
```
{
  "check_block": "DISABLED",
  "max_seconds_behind": "ERROR: timestamp too old: got ts: 0, need: 1714411978",
  "min_peer_count": "HEALTHY",
  "synced": "HEALTHY"
}
```

Expected behavior:
```
{
  "check_block": "DISABLED",
  "max_seconds_behind": "HEALTHY",
  "min_peer_count": "HEALTHY",
  "synced": "HEALTHY"
}
```

Refering issue: https://github.com/ledgerwatch/erigon/issues/9357