### PR TITLE
Replace snaptype.AllTypes with local definitions

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -794,11 +794,18 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 	hook := stages2.NewHook(backend.sentryCtx, backend.chainDB, backend.notifications, backend.stagedSync, backend.blockReader, backend.chainConfig, backend.logger, backend.sentriesClient.SetStatus)
 
 	if !config.Sync.UseSnapshots && backend.downloaderClient != nil {
-		for _, p := range snaptype.AllTypes {
+		for _, p := range blockReader.AllTypes() {
 			backend.downloaderClient.ProhibitNewDownloads(ctx, &protodownloader.ProhibitNewDownloadsRequest{
 				Type: p.String(),
 			})
 		}
+
+		for _, p := range snaptype.CaplinSnapshotTypes {
+			backend.downloaderClient.ProhibitNewDownloads(ctx, &protodownloader.ProhibitNewDownloadsRequest{
+				Type: p.String(),
+			})
+		}
+
 	}
 
 	checkStateRoot := true

--- a/migrations/prohibit_new_downloads2.go
+++ b/migrations/prohibit_new_downloads2.go
@@ -12,6 +12,8 @@ import (
 	"github.com/ledgerwatch/erigon-lib/downloader"
 	"github.com/ledgerwatch/erigon-lib/downloader/snaptype"
 	"github.com/ledgerwatch/erigon-lib/kv"
+	coresnaptype "github.com/ledgerwatch/erigon/core/snaptype"
+	borsnaptype "github.com/ledgerwatch/erigon/polygon/bor/snaptype"
 	"github.com/ledgerwatch/log/v3"
 )
 
@@ -38,12 +40,21 @@ var ProhibitNewDownloadsLock2 = Migration{
 		}
 		if len(content) == 0 { // old format, need to change to all snaptypes except blob sidecars
 			locked := []string{}
-			ts := snaptype.AllTypes
-			for _, t := range ts {
+
+			for _, t := range coresnaptype.BlockSnapshotTypes {
+				locked = append(locked, t.String())
+			}
+
+			for _, t := range borsnaptype.BorSnapshotTypes {
+				locked = append(locked, t.String())
+			}
+
+			for _, t := range snaptype.CaplinSnapshotTypes {
 				if t.String() != snaptype.BlobSidecars.String() {
 					locked = append(locked, t.String())
 				}
 			}
+
 			newContent, err := json.Marshal(locked)
 			if err != nil {
 				return err

--- a/turbo/snapshotsync/snapshotsync.go
+++ b/turbo/snapshotsync/snapshotsync.go
@@ -207,17 +207,25 @@ func WaitForDownloader(ctx context.Context, logPrefix string, histV3, blobs bool
 	//
 
 	// prohibits further downloads, except some exceptions
-	for _, p := range snaptype.AllTypes {
-		if (p.Enum() == snaptype.BeaconBlocks.Enum() || p.Enum() == snaptype.BlobSidecars.Enum()) && caplin == NoCaplin {
-			continue
-		}
-		if p.Enum() == snaptype.BlobSidecars.Enum() && !blobs {
-			continue
-		}
+	for _, p := range blockReader.AllTypes() {
 		if _, err := snapshotDownloader.ProhibitNewDownloads(ctx, &proto_downloader.ProhibitNewDownloadsRequest{
 			Type: p.String(),
 		}); err != nil {
 			return err
+		}
+	}
+
+	if caplin != NoCaplin {
+		for _, p := range snaptype.CaplinSnapshotTypes {
+			if p.Enum() == snaptype.BlobSidecars.Enum() && !blobs {
+				continue
+			}
+
+			if _, err := snapshotDownloader.ProhibitNewDownloads(ctx, &proto_downloader.ProhibitNewDownloadsRequest{
+				Type: p.String(),
+			}); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
When adding bor waypont types I have removed snaptype.AllTypes because it causes package cross-dependencies.

This fixes the places where all types have been used post the merge changes.