### PR TITLE
fix flags parsing 

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1912,6 +1912,8 @@ func CobraFlags(cmd *cobra.Command, urfaveCliFlagsLists ...[]cli.Flag) {
 			switch f := flag.(type) {
 			case *cli.IntFlag:
 				flags.Int(f.Name, f.Value, f.Usage)
+			case *cli.UintFlag:
+				flags.Uint(f.Name, f.Value, f.Usage)
 			case *cli.StringFlag:
 				flags.String(f.Name, f.Value, f.Usage)
 			case *cli.BoolFlag:


### PR DESCRIPTION
`go run ./cmd/downloader torrent_create --datadir=/Users/alex.sharov/data/sepolia34 --chain=sepolia --pprof`

```
panic: unexpected type: *cli.UintFlag

goroutine 1 [running]:
github.com/ledgerwatch/erigon/cmd/utils.CobraFlags(0x2?, {0xc0009ebdc8, 0x3, 0x7660?})
	github.com/ledgerwatch/erigon/cmd/utils/flags.go:1920 +0x20e
main.init.0()
	github.com/ledgerwatch/erigon/cmd/downloader/main.go:85 +0xc9
exit status 2
```