### PR TITLE
Set existing torrent webseeds after download

### DIFF
--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -1853,10 +1853,6 @@ func (d *Downloader) ReCalcStats(interval time.Duration) {
 		peersOfThisFile := t.PeerConns()
 		weebseedPeersOfThisFile := t.WebseedPeerConns()
 
-		if len(weebseedPeersOfThisFile) == 0 {
-			t.WebseedPeerConns()
-		}
-
 		tLen := t.Length()
 
 		var bytesCompleted int64

--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -318,7 +318,7 @@ func New(ctx context.Context, cfg *downloadercfg.Cfg, logger log.Logger, verbosi
 		downloading:         map[string]struct{}{},
 		webseedsDiscover:    discover,
 	}
-	d.webseeds.SetTorrent(d.torrentFS, lock.Downloads, cfg.DownloadTorrentFilesFromWebseed)
+	d.webseeds.SetTorrent(d, lock.Downloads, cfg.DownloadTorrentFilesFromWebseed)
 
 	requestHandler.downloader = d
 
@@ -1852,6 +1852,10 @@ func (d *Downloader) ReCalcStats(interval time.Duration) {
 		// call methods once - to reduce internal mutex contention
 		peersOfThisFile := t.PeerConns()
 		weebseedPeersOfThisFile := t.WebseedPeerConns()
+
+		if len(weebseedPeersOfThisFile) == 0 {
+			t.WebseedPeerConns()
+		}
 
 		tLen := t.Length()
 


### PR DESCRIPTION
Fix a timing hole where torrents that get created before webseeds have been downloaded don't get webseeds set.