### PR TITLE
Unnecessary Logs in sentry removed

### DIFF
--- a/p2p/sentry/sentry_multi_client/sentry_multi_client.go
+++ b/p2p/sentry/sentry_multi_client/sentry_multi_client.go
@@ -156,7 +156,9 @@ func SentryReconnectAndPumpStreamLoop[TMessage interface{}](
 		statusData, err := statusDataFactory(ctx)
 
 		if err != nil {
-			logger.Error("SentryReconnectAndPumpStreamLoop: statusDataFactory error", "stream", streamName, "err", err)
+			if errors.Is(err, sentry.ErrNoHead) {
+				logger.Error("SentryReconnectAndPumpStreamLoop: statusDataFactory error", "stream", streamName, "err", err)
+			}
 			time.Sleep(time.Second)
 			continue
 		}

--- a/p2p/sentry/sentry_multi_client/sentry_multi_client.go
+++ b/p2p/sentry/sentry_multi_client/sentry_multi_client.go
@@ -156,7 +156,7 @@ func SentryReconnectAndPumpStreamLoop[TMessage interface{}](
 		statusData, err := statusDataFactory(ctx)
 
 		if err != nil {
-			if errors.Is(err, sentry.ErrNoHead) {
+			if !errors.Is(err, sentry.ErrNoHead) {
 				logger.Error("SentryReconnectAndPumpStreamLoop: statusDataFactory error", "stream", streamName, "err", err)
 			}
 			time.Sleep(time.Second)

--- a/p2p/sentry/status_data_provider.go
+++ b/p2p/sentry/status_data_provider.go
@@ -18,6 +18,8 @@ import (
 	"github.com/ledgerwatch/erigon/core/types"
 )
 
+var ErrNoHead = errors.New("ReadChainHead: ReadCurrentHeader error")
+
 type ChainHead struct {
 	HeadHeight uint64
 	HeadTime   uint64
@@ -77,7 +79,7 @@ func (s *StatusDataProvider) GetStatusData(ctx context.Context) (*proto_sentry.S
 func ReadChainHeadWithTx(tx kv.Tx) (ChainHead, error) {
 	header := rawdb.ReadCurrentHeaderHavingBody(tx)
 	if header == nil {
-		return ChainHead{}, errors.New("ReadChainHead: ReadCurrentHeader error")
+		return ChainHead{}, ErrNoHead
 	}
 
 	height := header.Number.Uint64()


### PR DESCRIPTION
Steps to reproduce:
1) Sync snapshots and no other stage
2) Stop
3) No Head Header so hell break loose.