### PR TITLE
Fix buffer overwrite on ttx.HistoryRange

### DIFF
--- a/erigon-lib/kv/iter/iter_exact.go
+++ b/erigon-lib/kv/iter/iter_exact.go
@@ -218,39 +218,22 @@ func (m *WrapKVSIter) Close() {
 }
 
 type WrapKVIter struct {
-	x              KVS
-	xHasNext       bool
-	xNextK, xNextV []byte
-	err            error
+	x KVS
 }
 
 func WrapKV(x KVS) KV {
 	if x == nil {
 		return EmptyKV
 	}
-	m := &WrapKVIter{x: x}
-	m.advance()
-	return m
+	return &WrapKVIter{x: x}
 }
 
 func (m *WrapKVIter) HasNext() bool {
-	return m.err != nil || m.xHasNext
+	return m.x.HasNext()
 }
-func (m *WrapKVIter) advance() {
-	if m.err != nil {
-		return
-	}
-	m.xHasNext = m.x.HasNext()
-	if m.xHasNext {
-		m.xNextK, m.xNextV, _, m.err = m.x.Next()
-	}
-}
+
 func (m *WrapKVIter) Next() ([]byte, []byte, error) {
-	if m.err != nil {
-		return nil, nil, m.err
-	}
-	k, v, err := m.xNextK, m.xNextV, m.err
-	m.advance()
+	k, v, _, err := m.x.Next()
 	return k, v, err
 }
 


### PR DESCRIPTION
fixes `ttx.HistoryRange` iterator returning wrong results.

repro logs, for block 5528581, history == `kv.CodeHistory` on sepolia:

```
[INFO] [05-04|18:02:46.612] Min of                                   blockNum=5528581 minTxNum=189735001 maxTxNum=189735097 diff=96
[INFO] [05-04|18:02:47.645] contract                                 k=0xd1d2f378c8442782dc19acdc23d229e543dc9fc3 v=0x count=1
[INFO] [05-04|18:02:47.764] contract                                 k=0xe24403f5ff942dba1b2130835201c973547a08d3 v=0x count=2
[INFO] [05-04|18:02:47.764] contract                                 k=0xd1d2f378c8442782dc19acdc23d229e543dc9fc3 v=0x count=3
[INFO] [05-04|18:02:47.764] contract                                 k=0xe24403f5ff942dba1b2130835201c973547a08d3 v=0x count=4
[INFO] [05-04|18:02:47.764] all contracts                            count=4
```

notice the repeating addresses.

logs after the fix applied:

```
[INFO] [05-04|18:00:30.487] Min of                                   blockNum=5528581 minTxNum=189735001 maxTxNum=189735097 diff=96
[INFO] [05-04|18:00:31.280] contract                                 k=0x235f47a0adaf094d47a2ff85943d538367961913 v=0x count=1
[INFO] [05-04|18:00:31.350] contract                                 k=0xb24696afae649023d95f46eca348e4482ad77dfd v=0x count=2
[INFO] [05-04|18:00:31.478] contract                                 k=0xd1d2f378c8442782dc19acdc23d229e543dc9fc3 v=0x count=3
[INFO] [05-04|18:00:31.478] contract                                 k=0xe24403f5ff942dba1b2130835201c973547a08d3 v=0x count=4
[INFO] [05-04|18:00:31.478] all contracts                            count=4
```

problem is: the double caching between `WrapKVIter` and `MergeKV` is breaking the `kv.Duo` invariant 2, issuing more than 2 `Next()` and reusing the first `k`, leading to a buffer rewrite.

summary:

- MergeKV constructor -> (1) advance() -> cache Next() in MergeKV
- WrapKVIter constructor -> advance() -> cache (1) in WrapKVIter -> advance() -> cache Next() in MergeKV
- then 1st WrapKVIter.Next() -> return (1) -> advance() -> cache (2) in WrapKVIIter -> advance() -> cache Next() in MergeKV, but overwrites (1) buffer

it seems the general effect of this bug is that all iterators returned by HistoryRange are subject to:

- first 2 elements are skipped
- last 2 elements are duplicated at the end of iterator

this PR eliminates the double caching by removing the `WrapKVIter` code almost completely. I think all the caching inside it is not necessary anymore, so I turned it into a simple passthrough adapter between KVS -> KV.