### PR TITLE
flag to enable madv_normal for some type of .kv 

### DIFF
--- a/erigon-lib/common/dbg/experiments.go
+++ b/erigon-lib/common/dbg/experiments.go
@@ -56,8 +56,10 @@ var (
 
 	BuildSnapshotAllowance = EnvInt("SNAPSHOT_BUILD_SEMA_SIZE", 1)
 
-	SnapshotMadvRnd = EnvBool("SNAPSHOT_MADV_RND", true)
-	OnlyCreateDB    = EnvBool("ONLY_CREATE_DB", false)
+	SnapshotMadvRnd       = EnvBool("SNAPSHOT_MADV_RND", true)
+	KvMadvNormalNoLastLvl = EnvString("KV_MADV_NORMAL_NO_LAST_LVL", "")
+	KvMadvNormal          = EnvString("KV_MADV_NORMAL", "")
+	OnlyCreateDB          = EnvBool("ONLY_CREATE_DB", false)
 )
 
 func ReadMemStats(m *runtime.MemStats) {

--- a/erigon-lib/seg/decompress.go
+++ b/erigon-lib/seg/decompress.go
@@ -515,7 +515,6 @@ func (d *Decompressor) DisableReadAhead() {
 		return
 	}
 
-	fmt.Printf("rnd: %s\n", d.FileName())
 	_ = mmap.MadviseRandom(d.mmapHandle1)
 }
 

--- a/erigon-lib/seg/decompress.go
+++ b/erigon-lib/seg/decompress.go
@@ -492,26 +492,30 @@ func (d *Decompressor) DisableReadAhead() {
 	}
 
 	if dbg.KvMadvNormal != "" && strings.HasSuffix(d.FileName(), ".kv") { //all .kv files
-		types := strings.Split(dbg.KvMadvNormal, ",")
-		for _, t := range types {
-			if strings.Contains(d.FileName(), t) {
-				_ = mmap.MadviseNormal(d.mmapHandle1)
-				return
+		for _, t := range strings.Split(dbg.KvMadvNormal, ",") {
+			if !strings.Contains(d.FileName(), t) {
+				continue
 			}
+			_ = mmap.MadviseNormal(d.mmapHandle1)
+			return
 		}
 	}
 
 	if dbg.KvMadvNormalNoLastLvl != "" && strings.HasSuffix(d.FileName(), ".kv") { //all .kv files - except last-level `v1-storage.0-1024.kv` - starting from step 0
-		types := strings.Split(dbg.KvMadvNormal, ",")
-		for _, t := range types {
-			if strings.Contains(d.FileName(), t) && !strings.Contains(d.FileName(), t+".0-") {
-				_ = mmap.MadviseNormal(d.mmapHandle1)
-				return
+		for _, t := range strings.Split(dbg.KvMadvNormalNoLastLvl, ",") {
+			if !strings.Contains(d.FileName(), t) {
+				continue
 			}
+			if strings.Contains(d.FileName(), t+".0-") {
+				continue
+			}
+			_ = mmap.MadviseNormal(d.mmapHandle1)
+			return
 		}
 		return
 	}
 
+	fmt.Printf("rnd: %s\n", d.FileName())
 	_ = mmap.MadviseRandom(d.mmapHandle1)
 }
 

--- a/erigon-lib/seg/decompress.go
+++ b/erigon-lib/seg/decompress.go
@@ -491,7 +491,7 @@ func (d *Decompressor) DisableReadAhead() {
 		return
 	}
 
-	if dbg.KvMadvNormal != "" && strings.HasSuffix(d.FileName(), ".kv") {
+	if dbg.KvMadvNormal != "" && strings.HasSuffix(d.FileName(), ".kv") { //all .kv files
 		types := strings.Split(dbg.KvMadvNormal, ",")
 		for _, t := range types {
 			if strings.Contains(d.FileName(), t) {
@@ -501,10 +501,9 @@ func (d *Decompressor) DisableReadAhead() {
 		}
 	}
 
-	if dbg.KvMadvNormalNoLastLvl != "" && strings.HasSuffix(d.FileName(), ".kv") {
+	if dbg.KvMadvNormalNoLastLvl != "" && strings.HasSuffix(d.FileName(), ".kv") { //all .kv files - except last-level `v1-storage.0-1024.kv` - starting from step 0
 		types := strings.Split(dbg.KvMadvNormal, ",")
 		for _, t := range types {
-			//v1-storage.0-1024.kv
 			if strings.Contains(d.FileName(), t) && !strings.Contains(d.FileName(), t+".0-") {
 				_ = mmap.MadviseNormal(d.mmapHandle1)
 				return

--- a/erigon-lib/seg/decompress.go
+++ b/erigon-lib/seg/decompress.go
@@ -486,8 +486,8 @@ func (d *Decompressor) DisableReadAhead() {
 		return
 	}
 
-	if dbg.SnapshotMadvRnd {
-		_ = mmap.MadviseRandom(d.mmapHandle1)
+	if !dbg.SnapshotMadvRnd { // all files
+		_ = mmap.MadviseNormal(d.mmapHandle1)
 		return
 	}
 
@@ -495,11 +495,10 @@ func (d *Decompressor) DisableReadAhead() {
 		types := strings.Split(dbg.KvMadvNormal, ",")
 		for _, t := range types {
 			if strings.Contains(d.FileName(), t) {
-				_ = mmap.MadviseRandom(d.mmapHandle1)
+				_ = mmap.MadviseNormal(d.mmapHandle1)
 				return
 			}
 		}
-		return
 	}
 
 	if dbg.KvMadvNormalNoLastLvl != "" && strings.HasSuffix(d.FileName(), ".kv") {
@@ -507,14 +506,14 @@ func (d *Decompressor) DisableReadAhead() {
 		for _, t := range types {
 			//v1-storage.0-1024.kv
 			if strings.Contains(d.FileName(), t) && !strings.Contains(d.FileName(), t+".0-") {
-				_ = mmap.MadviseRandom(d.mmapHandle1)
+				_ = mmap.MadviseNormal(d.mmapHandle1)
 				return
 			}
 		}
 		return
 	}
 
-	_ = mmap.MadviseNormal(d.mmapHandle1)
+	_ = mmap.MadviseRandom(d.mmapHandle1)
 }
 
 func (d *Decompressor) EnableReadAhead() *Decompressor {


### PR DESCRIPTION
`KV_MADV_NORMAL=accounts,storage` - to enable MADVISE_NORMAL for all accounts.kv and storage.kv
`KV_MADV_NORMAL_NO_LAST_LVL=accounts,storage` - same, but don't enable for last-level-file - example: `v1-accounts.0-1024.kv`. Because last-level in-theory must receive lowest read-rate.  
`SNAPSHOT_MADV_RND=false` - can enable MADV_NORMAL for all files (including Blocks snaps)

I think we need enable `KV_MADV_NORMAL_NO_LAST_LVL=accounts,storage` by default - because it's useful for exec and commitment (code - not useful for commitment. commitment itself - seems is not a bottleneck). Let's collect evidences. 

Mainnet: 
```
du -hsc /mnt/erigon/snapshots/domain/*.0-*.kv
5.6G	/mnt/erigon/snapshots/domain/v1-accounts.0-1024.kv
19G	/mnt/erigon/snapshots/domain/v1-code.0-1024.kv
26G	/mnt/erigon/snapshots/domain/v1-commitment.0-1024.kv
42G	/mnt/erigon/snapshots/domain/v1-storage.0-1024.kv
92G	total



du -hsc /mnt/erigon/snapshots/domain/!(*.0-*).kv
2.0G	/mnt/erigon/snapshots/domain/v1-accounts.1024-1280.kv
1.1G	/mnt/erigon/snapshots/domain/v1-accounts.1280-1408.kv
289M	/mnt/erigon/snapshots/domain/v1-accounts.1408-1440.kv
21M	/mnt/erigon/snapshots/domain/v1-accounts.1440-1441.kv
37M	/mnt/erigon/snapshots/domain/v1-accounts.1440-1442.kv
23M	/mnt/erigon/snapshots/domain/v1-accounts.1442-1443.kv
4.9G	/mnt/erigon/snapshots/domain/v1-code.1024-1280.kv
3.2G	/mnt/erigon/snapshots/domain/v1-code.1280-1408.kv
430M	/mnt/erigon/snapshots/domain/v1-code.1408-1440.kv
13M	/mnt/erigon/snapshots/domain/v1-code.1440-1441.kv
26M	/mnt/erigon/snapshots/domain/v1-code.1440-1442.kv
11M	/mnt/erigon/snapshots/domain/v1-code.1442-1443.kv
25G	/mnt/erigon/snapshots/domain/v1-commitment.1024-1280.kv
19G	/mnt/erigon/snapshots/domain/v1-commitment.1280-1408.kv
10G	/mnt/erigon/snapshots/domain/v1-commitment.1408-1440.kv
1.4G	/mnt/erigon/snapshots/domain/v1-commitment.1440-1441.kv
2.2G	/mnt/erigon/snapshots/domain/v1-commitment.1440-1442.kv
1.5G	/mnt/erigon/snapshots/domain/v1-commitment.1442-1443.kv
23G	/mnt/erigon/snapshots/domain/v1-storage.1024-1280.kv
9.5G	/mnt/erigon/snapshots/domain/v1-storage.1280-1408.kv
2.1G	/mnt/erigon/snapshots/domain/v1-storage.1408-1440.kv
89M	/mnt/erigon/snapshots/domain/v1-storage.1440-1441.kv
167M	/mnt/erigon/snapshots/domain/v1-storage.1440-1442.kv
96M	/mnt/erigon/snapshots/domain/v1-storage.1442-1443.kv
105G	total
```