### PR TITLE
downloader: --seedbox doesn't init snaptypes

### DIFF
--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -14,7 +14,8 @@ import (
 	"time"
 
 	"github.com/ledgerwatch/erigon-lib/common/dbg"
-	_ "github.com/ledgerwatch/erigon/core/snaptype" //hack
+	_ "github.com/ledgerwatch/erigon/core/snaptype"        //hack
+	_ "github.com/ledgerwatch/erigon/polygon/bor/snaptype" //hack
 
 	"github.com/anacrolix/torrent/metainfo"
 	"github.com/c2h5oh/datasize"

--- a/cmd/integration/main.go
+++ b/cmd/integration/main.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	_ "github.com/ledgerwatch/erigon/core/snaptype" //hack
+	_ "github.com/ledgerwatch/erigon/core/snaptype"        //hack
+	_ "github.com/ledgerwatch/erigon/polygon/bor/snaptype" //hack
 
 	"github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon/cmd/integration/commands"

--- a/cmd/rpcdaemon/main.go
+++ b/cmd/rpcdaemon/main.go
@@ -12,6 +12,9 @@ import (
 	"github.com/ledgerwatch/erigon/turbo/debug"
 	"github.com/ledgerwatch/erigon/turbo/jsonrpc"
 	"github.com/spf13/cobra"
+
+	_ "github.com/ledgerwatch/erigon/core/snaptype"        //hack
+	_ "github.com/ledgerwatch/erigon/polygon/bor/snaptype" //hack
 )
 
 func main() {


### PR DESCRIPTION
@mh0lt please make it compile-time impossible to not register some types. because we have many binaries in `./cmd/*`

steps to reproduce:
- remove borevent.seg file
- start `downloader --seedbox`
- it will not re-download file (even if remove downloader folder)