### PR TITLE
qa-tests: fix workflows for release 2.60

### DIFF
--- a/.github/workflows/qa-clean-exit-block-downloading.yml
+++ b/.github/workflows/qa-clean-exit-block-downloading.yml
@@ -3,11 +3,9 @@ name: QA - Clean exit (block downloading)
 on:
   push:
     branches:
-      - main
       - 'release/2.*'
   pull_request:
     branches:
-      - main
       - 'release/2.*'
     types:
       - ready_for_review

--- a/.github/workflows/qa-clean-exit-snapshot-downloading.yml
+++ b/.github/workflows/qa-clean-exit-snapshot-downloading.yml
@@ -3,11 +3,9 @@ name: QA - Clean exit (snapshot downloading)
 on:
   push:
     branches:
-      - main
       - 'release/2.*'
   pull_request:
     branches:
-      - main
       - 'release/2.*'
     types:
       - ready_for_review

--- a/.github/workflows/qa-snap-download.yml
+++ b/.github/workflows/qa-snap-download.yml
@@ -1,8 +1,14 @@
 name: QA - Snapshot Download
 
 on:
-  schedule:
-    - cron: '5 0 * * *'  # Run every day at 05:00 AM UTC
+  push:
+    branches:
+      - 'release/2.*'
+  pull_request:
+    branches:
+      - 'release/2.*'
+    types:
+      - ready_for_review
   workflow_dispatch:     # Run manually
 
 jobs:

--- a/.github/workflows/qa-tip-tracking.yml
+++ b/.github/workflows/qa-tip-tracking.yml
@@ -1,8 +1,14 @@
 name: QA - Tip tracking
 
 on:
-  schedule:
-    - cron: '0 0 * * *'  # Run every day at 00:00 AM UTC
+  push:
+    branches:
+      - 'release/2.*'
+  pull_request:
+    branches:
+      - 'release/2.*'
+    types:
+      - ready_for_review
   workflow_dispatch:     # Run manually
 
 jobs:


### PR DESCRIPTION
Running a test every day doesn't make sense on an inactive branch. 
It also seems that the schedule trigger favours the main branch if the test workflow has the same name on the main and other branches.
So this PR changes the test trigger to "push events".