### PR TITLE
remove batch limit heuristic for prunes>5h, added stateful prune cursors

### DIFF
--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -807,19 +807,20 @@ func (ac *AggregatorRoTx) PruneSmallBatches(ctx context.Context, timeout time.Du
 	// On tip-of-chain timeout is about `3sec`
 	//  On tip of chain:     must be real-time - prune by small batches and prioritize exact-`timeout`
 	//  Not on tip of chain: must be aggressive (prune as much as possible) by bigger batches
-	aggressivePrune := timeout >= 1*time.Minute
+
+	furiousPrune := timeout > 5*time.Hour
+	aggressivePrune := !furiousPrune && timeout >= 1*time.Minute
 
 	var pruneLimit uint64 = 1_000
 	var withWarmup bool = false //nolint
-	/* disabling this feature for now - seems it doesn't cancel even after prune finished
-	if timeout >= 1*time.Minute {
+	if furiousPrune {
+		pruneLimit = 1_000_000
+		/* disabling this feature for now - seems it doesn't cancel even after prune finished
 		// start from a bit high limit to give time for warmup
 		// will disable warmup after first iteration and will adjust pruneLimit based on `time`
-		pruneLimit = 100_000
 		withWarmup = true
+		*/
 	}
-	withWarmup = false // disabling this feature for now - seems it doesn't cancel even after prune finished
-	*/
 
 	started := time.Now()
 	localTimeout := time.NewTicker(timeout)

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -1898,6 +1898,12 @@ func (dt *DomainRoTx) Prune(ctx context.Context, rwTx kv.RwTx, step, txFrom, txT
 	}
 	defer keysCursor.Close()
 
+	valsCursor, err := rwTx.RwCursor(dt.d.valsTable)
+	if err != nil {
+		return stat, fmt.Errorf("create %s domain values cursor: %w", dt.d.filenameBase, err)
+	}
+	defer valsCursor.Close()
+
 	//fmt.Printf("prune domain %s from %d to %d step %d limit %d\n", dt.d.filenameBase, txFrom, txTo, step, limit)
 	//defer func() {
 	//	dt.d.logger.Info("[snapshots] prune domain",
@@ -1946,7 +1952,7 @@ func (dt *DomainRoTx) Prune(ctx context.Context, rwTx kv.RwTx, step, txFrom, txT
 		limit--
 
 		seek = append(append(seek[:0], k...), v...)
-		err = rwTx.Delete(dt.d.valsTable, seek)
+		err = valsCursor.Delete(seek)
 		if err != nil {
 			return stat, fmt.Errorf("prune domain value: %w", err)
 		}


### PR DESCRIPTION
when execution is finished we call pruning with 12h time limit while heuristic could limit pruning throughput (but in this exact case better to increase batch size)