### PR TITLE
Add context to make function Ctrl+C friendly; add activity logs

### DIFF
--- a/turbo/engineapi/engine_block_downloader/block_downloader.go
+++ b/turbo/engineapi/engine_block_downloader/block_downloader.go
@@ -126,11 +126,25 @@ func (e *EngineBlockDownloader) scheduleHeadersDownload(
 }
 
 // waitForEndOfHeadersDownload waits until the download of headers ends and returns the outcome.
-func (e *EngineBlockDownloader) waitForEndOfHeadersDownload() headerdownload.SyncStatus {
-	for e.hd.PosStatus() == headerdownload.Syncing {
-		time.Sleep(10 * time.Millisecond)
+func (e *EngineBlockDownloader) waitForEndOfHeadersDownload(ctx context.Context) (headerdownload.SyncStatus, error) {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	logEvery := time.NewTicker(30 * time.Second)
+	defer logEvery.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if e.hd.PosStatus() != headerdownload.Syncing {
+				return e.hd.PosStatus(), nil
+			}
+		case <-ctx.Done():
+			return e.hd.PosStatus(), ctx.Err()
+		case <-logEvery.C:
+			e.logger.Info("[EngineBlockDownloader] Waiting for headers download to finish")
+		}
 	}
-	return e.hd.PosStatus()
 }
 
 // waitForEndOfHeadersDownload waits until the download of headers ends and returns the outcome.

--- a/turbo/engineapi/engine_block_downloader/core.go
+++ b/turbo/engineapi/engine_block_downloader/core.go
@@ -22,7 +22,12 @@ func (e *EngineBlockDownloader) download(ctx context.Context, hashToDownload lib
 		return
 	}
 	// see the outcome of header download
-	headersStatus := e.waitForEndOfHeadersDownload()
+	headersStatus, err := e.waitForEndOfHeadersDownload(ctx)
+	if err != nil {
+		e.logger.Warn("[EngineBlockDownloader] Could not finish headers download", "err", err)
+		e.status.Store(headerdownload.Idle)
+		return
+	}
 
 	if headersStatus != headerdownload.Synced {
 		// Could not sync. Set to idle


### PR DESCRIPTION
For some reason, at least for the last 2 weeks I've seen some strange behavior, first on 2.60 branch and now on E3 main (not sure if it is related to some recent change or it randomly started manifesting < 2 weeks ago), when I start Erigon and it keep stuck in the "Downloading PoS headers" forever.

Sometimes it takes +15 min to start downloading headers, but most times it gets stuck forever (have left it overnight with no success).

While this PR doesn't fix the actual issue, while trying to do some debug I noticed:

- there is no activity log, it looks like the node is doing nothing.
- can't Ctrl+C to stop it when it gets in this state, have to kill it.

This PR:

- Replaces a for + sleep with a select channel + ticker + check
- Adds a logEvery ticker
- Listens to ctx.Done() in order to make it Ctrl+C cancellable.

Logs before this PR (3 min without any activity + can't Ctrl+C):

```
INFO[05-10|16:20:16.399] [EngineBlockDownloader] Downloading PoS headers... hash=0x563f6871a197cef99b5c0bde819faa171d27a2a2d3ce8a8b86a9a3344b43501e requestId=0
INFO[05-10|16:23:06.121] [p2p] GoodPeers
INFO[05-10|16:23:06.121] [mem] memory stats                       alloc=1.1GB sys=1.6GB
INFO[05-10|16:23:07.949] [txpool] stat                            pending=0 baseFee=0 queued=0 alloc=1.1GB sys=1.6GB
^CINFO[05-10|16:25:54.723] Got interrupt, shutting down...          sig=interrupt
INFO[05-10|16:25:54.723] Got interrupt, shutting down...
INFO[05-10|16:25:54.723] Exiting Engine...
INFO[05-10|16:25:54.723] RPC server shutting down
INFO[05-10|16:25:54.723] Exiting...
INFO[05-10|16:25:54.723] RPC server shutting down
INFO[05-10|16:25:54.724] HTTP endpoint closed                     url=[::]:8745
INFO[05-10|16:25:54.724] HTTP endpoint closed                     url=[::]:8546
INFO[05-10|16:25:54.724] RPC server shutting down
INFO[05-10|16:25:54.724] Engine HTTP endpoint close               url=127.0.0.1:8551
WARN[05-10|16:25:54.725] [EngineBlockDownloader] Header download did not yield success
^CWARN[05-10|16:26:02.793] Already shutting down, interrupt more to panic. times=9
^CWARN[05-10|16:26:03.015] Already shutting down, interrupt more to panic. times=8
^CWARN[05-10|16:26:03.197] Already shutting down, interrupt more to panic. times=7
^CWARN[05-10|16:26:03.330] Already shutting down, interrupt more to panic. times=6
^CWARN[05-10|16:26:03.458] Already shutting down, interrupt more to panic. times=5
```

Logs after this PR (still no headers download :( , but now has activity logs every 30s + can Ctrl+C):

```
INFO[05-10|16:32:44.620] [EngineBlockDownloader] Downloading PoS headers... hash=0xdc9eb5145d75660d3a84e3ab2d302614bfcc57fa7eb6293305d6717b5f143a79 requestId=0
INFO[05-10|16:33:14.620] [EngineBlockDownloader] Waiting for headers download to finish
INFO[05-10|16:33:44.620] [EngineBlockDownloader] Waiting for headers download to finish
^CINFO[05-10|16:34:13.139] Got interrupt, shutting down...          sig=interrupt
INFO[05-10|16:34:13.139] Got interrupt, shutting down...
WARN[05-10|16:34:13.139] [EngineBlockDownloader] Could not finish headers download err="context canceled"
INFO[05-10|16:34:13.139] Exiting Engine...
INFO[05-10|16:34:13.139] Exiting...
INFO[05-10|16:34:13.139] RPC server shutting down
INFO[05-10|16:34:13.139] HTTP endpoint closed                     url=[::]:8745
INFO[05-10|16:34:13.139] RPC server shutting down
INFO[05-10|16:34:13.139] HTTP endpoint closed                     url=[::]:8546
INFO[05-10|16:34:13.139] Engine HTTP endpoint close               url=127.0.0.1:8551
INFO[05-10|16:34:13.139] RPC server shutting down
```
