### PR TITLE
Add flag for bor waypoint types

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -60,6 +60,7 @@ import (
 	"github.com/ledgerwatch/erigon/p2p/nat"
 	"github.com/ledgerwatch/erigon/p2p/netutil"
 	"github.com/ledgerwatch/erigon/params"
+	borsnaptype "github.com/ledgerwatch/erigon/polygon/bor/snaptype"
 	"github.com/ledgerwatch/erigon/rpc/rpccfg"
 	"github.com/ledgerwatch/erigon/turbo/logging"
 )
@@ -1578,6 +1579,7 @@ func setBorConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 	cfg.WithoutHeimdall = ctx.Bool(WithoutHeimdallFlag.Name)
 	cfg.WithHeimdallMilestones = ctx.Bool(WithHeimdallMilestones.Name)
 	cfg.WithHeimdallWaypointRecording = ctx.Bool(WithHeimdallWaypoints.Name)
+	borsnaptype.RecordWayPoints(cfg.WithHeimdallWaypointRecording)
 	cfg.PolygonSync = ctx.Bool(PolygonSyncFlag.Name)
 	cfg.PolygonSyncStage = ctx.Bool(PolygonSyncStageFlag.Name)
 }

--- a/migrations/prohibit_new_downloads2.go
+++ b/migrations/prohibit_new_downloads2.go
@@ -45,7 +45,7 @@ var ProhibitNewDownloadsLock2 = Migration{
 				locked = append(locked, t.Name())
 			}
 
-			for _, t := range borsnaptype.BorSnapshotTypes {
+			for _, t := range borsnaptype.BorSnapshotTypes() {
 				locked = append(locked, t.Name())
 			}
 

--- a/polygon/bor/snaptype/types.go
+++ b/polygon/bor/snaptype/types.go
@@ -31,7 +31,11 @@ import (
 )
 
 func init() {
-	borTypes := append(coresnaptype.BlockSnapshotTypes, BorSnapshotTypes...)
+	initTypes()
+}
+
+func initTypes() {
+	borTypes := append(coresnaptype.BlockSnapshotTypes, BorSnapshotTypes()...)
 
 	snapcfg.RegisterKnownTypes(networkname.MumbaiChainName, borTypes)
 	snapcfg.RegisterKnownTypes(networkname.AmoyChainName, borTypes)
@@ -402,9 +406,22 @@ var (
 				return buildValueIndex(ctx, sn, salt, d, firstMilestoneId, tmpDir, p, lvl, logger)
 			}),
 	)
-
-	BorSnapshotTypes = []snaptype.Type{BorEvents, BorSpans, BorCheckpoints, BorMilestones}
 )
+
+var recordWaypoints bool
+
+func RecordWayPoints(value bool) {
+	recordWaypoints = value
+	initTypes()
+}
+
+func BorSnapshotTypes() []snaptype.Type {
+	if recordWaypoints {
+		return []snaptype.Type{BorEvents, BorSpans, BorCheckpoints, BorMilestones}
+	}
+
+	return []snaptype.Type{BorEvents, BorSpans}
+}
 
 func extractValueRange(ctx context.Context, table string, valueFrom, valueTo uint64, db kv.RoDB, collect func([]byte) error, workers int, lvl log.Lvl, logger log.Logger) (uint64, error) {
 	logEvery := time.NewTicker(20 * time.Second)

--- a/turbo/snapshotsync/freezeblocks/bor_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/bor_snapshots.go
@@ -101,7 +101,7 @@ func (br *BlockRetire) retireBorBlocks(ctx context.Context, minBlockNum uint64, 
 		return nil
 	}
 
-	err := merger.Merge(ctx, &snapshots.RoSnapshots, borsnaptype.BorSnapshotTypes, rangesToMerge, snapshots.Dir(), true /* doIndex */, onMerge, onDelete)
+	err := merger.Merge(ctx, &snapshots.RoSnapshots, borsnaptype.BorSnapshotTypes(), rangesToMerge, snapshots.Dir(), true /* doIndex */, onMerge, onDelete)
 
 	if err != nil {
 		return blocksRetired, err
@@ -127,7 +127,7 @@ type BorRoSnapshots struct {
 //   - gaps are not allowed
 //   - segment have [from:to] semantic
 func NewBorRoSnapshots(cfg ethconfig.BlocksFreezing, snapDir string, segmentsMin uint64, logger log.Logger) *BorRoSnapshots {
-	return &BorRoSnapshots{*newRoSnapshots(cfg, snapDir, borsnaptype.BorSnapshotTypes, segmentsMin, logger)}
+	return &BorRoSnapshots{*newRoSnapshots(cfg, snapDir, borsnaptype.BorSnapshotTypes(), segmentsMin, logger)}
 }
 
 func (s *BorRoSnapshots) Ranges() []Range {
@@ -199,7 +199,7 @@ func removeBorOverlaps(dir string, active []snaptype.FileInfo, max uint64) {
 }
 
 func (s *BorRoSnapshots) ReopenFolder() error {
-	files, _, err := typedSegments(s.dir, s.segmentsMin.Load(), borsnaptype.BorSnapshotTypes, false)
+	files, _, err := typedSegments(s.dir, s.segmentsMin.Load(), borsnaptype.BorSnapshotTypes(), false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This adds additional flag processing to disable waypoint snaps is `bor.waypoints` is not set