### PR TITLE
Fix reverse nil check

### DIFF
--- a/turbo/execution/eth1/forkchoice.go
+++ b/turbo/execution/eth1/forkchoice.go
@@ -333,7 +333,7 @@ TooBigJumpStep:
 			return
 		}
 		defer func() {
-			if tx == nil {
+			if tx != nil {
 				tx.Rollback()
 			}
 		}()


### PR DESCRIPTION
fixes https://github.com/ledgerwatch/erigon/issues/10285

however, looking at the code, a few lines above, I'm wondering why `tx` actually is nil here, can `tx, err = e.db.BeginRwNosync(ctx)` return `tx == nil` when there is no error?

not clear to me what value `tx` is capturing inside the closure, I'm afraid this fix may hide another bug, I'm a little confused.