### PR TITLE
Refactor maxTxNumInFiles logic; rename cold param to clarify its meaning

### DIFF
--- a/erigon-lib/state/history.go
+++ b/erigon-lib/state/history.go
@@ -1598,7 +1598,7 @@ func (ht *HistoryRoTx) iterateChangedFrozen(fromTxNum, toTxNum int, asc order.By
 		return iter.EmptyKV, nil
 	}
 
-	if fromTxNum >= 0 && ht.iit.files[len(ht.iit.files)-1].endTxNum <= uint64(fromTxNum) {
+	if fromTxNum >= 0 && ht.iit.lastTxNumInFiles() <= uint64(fromTxNum) {
 		return iter.EmptyKV, nil
 	}
 
@@ -1635,7 +1635,7 @@ func (ht *HistoryRoTx) iterateChangedRecent(fromTxNum, toTxNum int, asc order.By
 	if asc == order.Desc {
 		panic("not supported yet")
 	}
-	rangeIsInFiles := toTxNum >= 0 && len(ht.iit.files) > 0 && ht.iit.files[len(ht.iit.files)-1].endTxNum >= uint64(toTxNum)
+	rangeIsInFiles := toTxNum >= 0 && len(ht.iit.files) > 0 && ht.iit.lastTxNumInFiles() >= uint64(toTxNum)
 	if rangeIsInFiles {
 		return iter.EmptyKVS, nil
 	}

--- a/erigon-lib/state/inverted_index.go
+++ b/erigon-lib/state/inverted_index.go
@@ -653,6 +653,11 @@ func (iit *InvertedIndexRoTx) seekInFiles(key []byte, txNum uint64) (found bool,
 	return false, 0
 }
 
+// it is assumed files are always sorted
+func (iit *InvertedIndexRoTx) lastTxNumInFiles() uint64 {
+	return iit.files[len(iit.files)-1].endTxNum
+}
+
 // IdxRange - return range of txNums for given `key`
 // is to be used in public API, therefore it relies on read-only transaction
 // so that iteration can be done even when the inverted index is being updated.
@@ -672,12 +677,12 @@ func (iit *InvertedIndexRoTx) IdxRange(key []byte, startTxNum, endTxNum int, asc
 func (iit *InvertedIndexRoTx) recentIterateRange(key []byte, startTxNum, endTxNum int, asc order.By, limit int, roTx kv.Tx) (iter.U64, error) {
 	//optimization: return empty pre-allocated iterator if range is frozen
 	if asc {
-		isFrozenRange := len(iit.files) > 0 && endTxNum >= 0 && iit.files[len(iit.files)-1].endTxNum >= uint64(endTxNum)
+		isFrozenRange := len(iit.files) > 0 && endTxNum >= 0 && iit.lastTxNumInFiles() >= uint64(endTxNum)
 		if isFrozenRange {
 			return iter.EmptyU64, nil
 		}
 	} else {
-		isFrozenRange := len(iit.files) > 0 && startTxNum >= 0 && iit.files[len(iit.files)-1].endTxNum >= uint64(startTxNum)
+		isFrozenRange := len(iit.files) > 0 && startTxNum >= 0 && iit.lastTxNumInFiles() >= uint64(startTxNum)
 		if isFrozenRange {
 			return iter.EmptyU64, nil
 		}

--- a/erigon-lib/state/merge.go
+++ b/erigon-lib/state/merge.go
@@ -311,12 +311,12 @@ func (dt *DomainRoTx) maxTxNumInDomainFiles(cold bool) uint64 {
 	return 0
 }
 
-func (ht *HistoryRoTx) maxTxNumInFiles(cold bool) uint64 {
+func (ht *HistoryRoTx) maxTxNumInFiles(onlyFrozen bool) uint64 {
 	if len(ht.files) == 0 {
 		return 0
 	}
 	var max uint64
-	if cold {
+	if onlyFrozen {
 		for i := len(ht.files) - 1; i >= 0; i-- {
 			if !ht.files[i].src.frozen {
 				continue
@@ -327,15 +327,18 @@ func (ht *HistoryRoTx) maxTxNumInFiles(cold bool) uint64 {
 	} else {
 		max = ht.files[len(ht.files)-1].endTxNum
 	}
-	return cmp.Min(max, ht.iit.maxTxNumInFiles(cold))
+	return cmp.Min(max, ht.iit.maxTxNumInFiles(onlyFrozen))
 }
-func (iit *InvertedIndexRoTx) maxTxNumInFiles(cold bool) uint64 {
+
+func (iit *InvertedIndexRoTx) maxTxNumInFiles(onlyFrozen bool) uint64 {
 	if len(iit.files) == 0 {
 		return 0
 	}
-	if !cold {
-		return iit.files[len(iit.files)-1].endTxNum
+	if !onlyFrozen {
+		return iit.lastTxNumInFiles()
 	}
+
+	// files contains [frozen..., cold...] in that order
 	for i := len(iit.files) - 1; i >= 0; i-- {
 		if !iit.files[i].src.frozen {
 			continue


### PR DESCRIPTION
This refactoring should not change any of current code behavior.

- Extract the "get last txNum in files" logic which is duplicated in several places.
- Rename the `cold` param name to `onlyFrozen` in `maxTxNumInFiles` because the current naming is misleading:
  - `cold == false`: returns the last txNum in [frozen..., cold...]  range.
  - `cold == true`: returns the last txNum in [frozen...] range.
