### PR TITLE
remove nils from p2p logs

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -1221,7 +1221,7 @@ func (srv *Server) listErrors() []interface{} {
 	srv.errorsMu.Lock()
 	defer srv.errorsMu.Unlock()
 
-	list := make([]interface{}, len(srv.errors)*2)
+	list := make([]interface{}, 0, len(srv.errors)*2)
 	for err, count := range srv.errors {
 		list = append(list, err, count)
 	}


### PR DESCRIPTION
fix for 
```
[p2p] Server                             protocol=68 peers=2 trusted=0 inbound=1 LOG15_ERROR= LOG15_ERROR= LOG15_ERROR= LOG15_ERROR= LOG15_ERROR= i/o timeout=53 EOF=65 closed by remote=215 too many peers=6 ecies: invalid message=5
```