### PR TITLE
diagnostics: downloaded file details

### DIFF
--- a/cmd/diag/downloader/diag_downloader.go
+++ b/cmd/diag/downloader/diag_downloader.go
@@ -153,7 +153,7 @@ func printFile(cliCtx *cli.Context) error {
 				//Print file status
 				util.RenderTableWithHeader(
 					"File download info:",
-					table.Row{"File", "Average Download Rate", "Time Took"},
+					table.Row{"File", "Size", "Average Download Rate", "Time Took"},
 					[]table.Row{fileRow},
 				)
 			}
@@ -203,6 +203,7 @@ func getDownloadedFileRow(file diagnostics.SegmentDownloadStatistics) table.Row 
 
 	row := table.Row{
 		file.Name,
+		common.ByteCount(file.TotalBytes),
 		averageDownloadRate,
 		totalDownloadTimeString.String(),
 	}


### PR DESCRIPTION
If snapshot file downloaded diagnostics command will display sum of downloading process which includes: size, total download time and average download rate.

Example: 
![Screenshot 2024-05-14 at 11 38 35](https://github.com/ledgerwatch/erigon/assets/29065143/135821d2-c207-4262-9617-74ea8188859c)
