### PR TITLE
polygon/heimdall: heimdall.Service

### DIFF
--- a/erigon-lib/common/collections.go
+++ b/erigon-lib/common/collections.go
@@ -21,3 +21,11 @@ func SliceShuffle[T any](s []T) {
 		s[i], s[j] = s[j], s[i]
 	})
 }
+
+func SliceTakeLast[T any](s []T, count int) []T {
+	length := len(s)
+	if length > count {
+		return s[length-count:]
+	}
+	return s
+}

--- a/polygon/heimdall/heimdall_mock.go
+++ b/polygon/heimdall/heimdall_mock.go
@@ -157,78 +157,78 @@ func (c *MockHeimdallFetchMilestonesFromBlockCall) DoAndReturn(f func(context.Co
 	return c
 }
 
-// OnMilestoneEvent mocks base method.
-func (m *MockHeimdall) OnMilestoneEvent(arg0 func(*Milestone)) polygoncommon.UnregisterFunc {
+// RegisterMilestoneObserver mocks base method.
+func (m *MockHeimdall) RegisterMilestoneObserver(arg0 func(*Milestone)) polygoncommon.UnregisterFunc {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "OnMilestoneEvent", arg0)
+	ret := m.ctrl.Call(m, "RegisterMilestoneObserver", arg0)
 	ret0, _ := ret[0].(polygoncommon.UnregisterFunc)
 	return ret0
 }
 
-// OnMilestoneEvent indicates an expected call of OnMilestoneEvent.
-func (mr *MockHeimdallMockRecorder) OnMilestoneEvent(arg0 any) *MockHeimdallOnMilestoneEventCall {
+// RegisterMilestoneObserver indicates an expected call of RegisterMilestoneObserver.
+func (mr *MockHeimdallMockRecorder) RegisterMilestoneObserver(arg0 any) *MockHeimdallRegisterMilestoneObserverCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnMilestoneEvent", reflect.TypeOf((*MockHeimdall)(nil).OnMilestoneEvent), arg0)
-	return &MockHeimdallOnMilestoneEventCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterMilestoneObserver", reflect.TypeOf((*MockHeimdall)(nil).RegisterMilestoneObserver), arg0)
+	return &MockHeimdallRegisterMilestoneObserverCall{Call: call}
 }
 
-// MockHeimdallOnMilestoneEventCall wrap *gomock.Call
-type MockHeimdallOnMilestoneEventCall struct {
+// MockHeimdallRegisterMilestoneObserverCall wrap *gomock.Call
+type MockHeimdallRegisterMilestoneObserverCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockHeimdallOnMilestoneEventCall) Return(arg0 polygoncommon.UnregisterFunc) *MockHeimdallOnMilestoneEventCall {
+func (c *MockHeimdallRegisterMilestoneObserverCall) Return(arg0 polygoncommon.UnregisterFunc) *MockHeimdallRegisterMilestoneObserverCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockHeimdallOnMilestoneEventCall) Do(f func(func(*Milestone)) polygoncommon.UnregisterFunc) *MockHeimdallOnMilestoneEventCall {
+func (c *MockHeimdallRegisterMilestoneObserverCall) Do(f func(func(*Milestone)) polygoncommon.UnregisterFunc) *MockHeimdallRegisterMilestoneObserverCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockHeimdallOnMilestoneEventCall) DoAndReturn(f func(func(*Milestone)) polygoncommon.UnregisterFunc) *MockHeimdallOnMilestoneEventCall {
+func (c *MockHeimdallRegisterMilestoneObserverCall) DoAndReturn(f func(func(*Milestone)) polygoncommon.UnregisterFunc) *MockHeimdallRegisterMilestoneObserverCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
-// OnSpanEvent mocks base method.
-func (m *MockHeimdall) OnSpanEvent(arg0 func(*Span)) polygoncommon.UnregisterFunc {
+// RegisterSpanObserver mocks base method.
+func (m *MockHeimdall) RegisterSpanObserver(arg0 func(*Span)) polygoncommon.UnregisterFunc {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "OnSpanEvent", arg0)
+	ret := m.ctrl.Call(m, "RegisterSpanObserver", arg0)
 	ret0, _ := ret[0].(polygoncommon.UnregisterFunc)
 	return ret0
 }
 
-// OnSpanEvent indicates an expected call of OnSpanEvent.
-func (mr *MockHeimdallMockRecorder) OnSpanEvent(arg0 any) *MockHeimdallOnSpanEventCall {
+// RegisterSpanObserver indicates an expected call of RegisterSpanObserver.
+func (mr *MockHeimdallMockRecorder) RegisterSpanObserver(arg0 any) *MockHeimdallRegisterSpanObserverCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnSpanEvent", reflect.TypeOf((*MockHeimdall)(nil).OnSpanEvent), arg0)
-	return &MockHeimdallOnSpanEventCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterSpanObserver", reflect.TypeOf((*MockHeimdall)(nil).RegisterSpanObserver), arg0)
+	return &MockHeimdallRegisterSpanObserverCall{Call: call}
 }
 
-// MockHeimdallOnSpanEventCall wrap *gomock.Call
-type MockHeimdallOnSpanEventCall struct {
+// MockHeimdallRegisterSpanObserverCall wrap *gomock.Call
+type MockHeimdallRegisterSpanObserverCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockHeimdallOnSpanEventCall) Return(arg0 polygoncommon.UnregisterFunc) *MockHeimdallOnSpanEventCall {
+func (c *MockHeimdallRegisterSpanObserverCall) Return(arg0 polygoncommon.UnregisterFunc) *MockHeimdallRegisterSpanObserverCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockHeimdallOnSpanEventCall) Do(f func(func(*Span)) polygoncommon.UnregisterFunc) *MockHeimdallOnSpanEventCall {
+func (c *MockHeimdallRegisterSpanObserverCall) Do(f func(func(*Span)) polygoncommon.UnregisterFunc) *MockHeimdallRegisterSpanObserverCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockHeimdallOnSpanEventCall) DoAndReturn(f func(func(*Span)) polygoncommon.UnregisterFunc) *MockHeimdallOnSpanEventCall {
+func (c *MockHeimdallRegisterSpanObserverCall) DoAndReturn(f func(func(*Span)) polygoncommon.UnregisterFunc) *MockHeimdallRegisterSpanObserverCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/polygon/heimdall/heimdall_mock.go
+++ b/polygon/heimdall/heimdall_mock.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	polygoncommon "github.com/ledgerwatch/erigon/polygon/polygoncommon"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -157,17 +158,17 @@ func (c *MockHeimdallFetchMilestonesFromBlockCall) DoAndReturn(f func(context.Co
 }
 
 // OnMilestoneEvent mocks base method.
-func (m *MockHeimdall) OnMilestoneEvent(arg0 context.Context, arg1 func(*Milestone)) error {
+func (m *MockHeimdall) OnMilestoneEvent(arg0 func(*Milestone)) polygoncommon.UnregisterFunc {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "OnMilestoneEvent", arg0, arg1)
-	ret0, _ := ret[0].(error)
+	ret := m.ctrl.Call(m, "OnMilestoneEvent", arg0)
+	ret0, _ := ret[0].(polygoncommon.UnregisterFunc)
 	return ret0
 }
 
 // OnMilestoneEvent indicates an expected call of OnMilestoneEvent.
-func (mr *MockHeimdallMockRecorder) OnMilestoneEvent(arg0, arg1 any) *MockHeimdallOnMilestoneEventCall {
+func (mr *MockHeimdallMockRecorder) OnMilestoneEvent(arg0 any) *MockHeimdallOnMilestoneEventCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnMilestoneEvent", reflect.TypeOf((*MockHeimdall)(nil).OnMilestoneEvent), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnMilestoneEvent", reflect.TypeOf((*MockHeimdall)(nil).OnMilestoneEvent), arg0)
 	return &MockHeimdallOnMilestoneEventCall{Call: call}
 }
 
@@ -177,35 +178,35 @@ type MockHeimdallOnMilestoneEventCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockHeimdallOnMilestoneEventCall) Return(arg0 error) *MockHeimdallOnMilestoneEventCall {
+func (c *MockHeimdallOnMilestoneEventCall) Return(arg0 polygoncommon.UnregisterFunc) *MockHeimdallOnMilestoneEventCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockHeimdallOnMilestoneEventCall) Do(f func(context.Context, func(*Milestone)) error) *MockHeimdallOnMilestoneEventCall {
+func (c *MockHeimdallOnMilestoneEventCall) Do(f func(func(*Milestone)) polygoncommon.UnregisterFunc) *MockHeimdallOnMilestoneEventCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockHeimdallOnMilestoneEventCall) DoAndReturn(f func(context.Context, func(*Milestone)) error) *MockHeimdallOnMilestoneEventCall {
+func (c *MockHeimdallOnMilestoneEventCall) DoAndReturn(f func(func(*Milestone)) polygoncommon.UnregisterFunc) *MockHeimdallOnMilestoneEventCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // OnSpanEvent mocks base method.
-func (m *MockHeimdall) OnSpanEvent(arg0 context.Context, arg1 func(*Span)) error {
+func (m *MockHeimdall) OnSpanEvent(arg0 func(*Span)) polygoncommon.UnregisterFunc {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "OnSpanEvent", arg0, arg1)
-	ret0, _ := ret[0].(error)
+	ret := m.ctrl.Call(m, "OnSpanEvent", arg0)
+	ret0, _ := ret[0].(polygoncommon.UnregisterFunc)
 	return ret0
 }
 
 // OnSpanEvent indicates an expected call of OnSpanEvent.
-func (mr *MockHeimdallMockRecorder) OnSpanEvent(arg0, arg1 any) *MockHeimdallOnSpanEventCall {
+func (mr *MockHeimdallMockRecorder) OnSpanEvent(arg0 any) *MockHeimdallOnSpanEventCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnSpanEvent", reflect.TypeOf((*MockHeimdall)(nil).OnSpanEvent), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnSpanEvent", reflect.TypeOf((*MockHeimdall)(nil).OnSpanEvent), arg0)
 	return &MockHeimdallOnSpanEventCall{Call: call}
 }
 
@@ -215,19 +216,19 @@ type MockHeimdallOnSpanEventCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockHeimdallOnSpanEventCall) Return(arg0 error) *MockHeimdallOnSpanEventCall {
+func (c *MockHeimdallOnSpanEventCall) Return(arg0 polygoncommon.UnregisterFunc) *MockHeimdallOnSpanEventCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockHeimdallOnSpanEventCall) Do(f func(context.Context, func(*Span)) error) *MockHeimdallOnSpanEventCall {
+func (c *MockHeimdallOnSpanEventCall) Do(f func(func(*Span)) polygoncommon.UnregisterFunc) *MockHeimdallOnSpanEventCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockHeimdallOnSpanEventCall) DoAndReturn(f func(context.Context, func(*Span)) error) *MockHeimdallOnSpanEventCall {
+func (c *MockHeimdallOnSpanEventCall) DoAndReturn(f func(func(*Span)) polygoncommon.UnregisterFunc) *MockHeimdallOnSpanEventCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/polygon/heimdall/heimdall_test.go
+++ b/polygon/heimdall/heimdall_test.go
@@ -287,7 +287,7 @@ func TestFetchMilestonesStartingBeforeEvictionPoint(t *testing.T) {
 	}
 }
 
-func TestOnMilestoneEvent(t *testing.T) {
+func TestRegisterMilestoneObserver(t *testing.T) {
 	test := newHeimdallTest(t)
 
 	var cancel context.CancelFunc
@@ -322,7 +322,7 @@ func TestOnMilestoneEvent(t *testing.T) {
 		}).AnyTimes()
 
 	eventChan := make(chan *Milestone)
-	subscriptionCancel := test.heimdall.OnMilestoneEvent(func(m *Milestone) {
+	subscriptionCancel := test.heimdall.RegisterMilestoneObserver(func(m *Milestone) {
 		eventChan <- m
 	})
 	defer subscriptionCancel()

--- a/polygon/heimdall/heimdall_test.go
+++ b/polygon/heimdall/heimdall_test.go
@@ -322,10 +322,10 @@ func TestOnMilestoneEvent(t *testing.T) {
 		}).AnyTimes()
 
 	eventChan := make(chan *Milestone)
-	err := test.heimdall.OnMilestoneEvent(test.ctx, func(m *Milestone) {
+	subscriptionCancel := test.heimdall.OnMilestoneEvent(func(m *Milestone) {
 		eventChan <- m
 	})
-	require.Nil(t, err)
+	defer subscriptionCancel()
 
 	m := <-eventChan
 	assert.Equal(t, expectedMilestone.Timestamp(), m.Timestamp())

--- a/polygon/heimdall/service.go
+++ b/polygon/heimdall/service.go
@@ -1,0 +1,158 @@
+package heimdall
+
+import (
+	"context"
+	"time"
+
+	"github.com/ledgerwatch/log/v3"
+	"golang.org/x/sync/errgroup"
+
+	libcommon "github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/kv"
+	"github.com/ledgerwatch/erigon/polygon/polygoncommon"
+	"github.com/ledgerwatch/erigon/turbo/services"
+)
+
+type Service interface {
+	Heimdall
+	Run(ctx context.Context) error
+}
+
+type service struct {
+	scraper *Scraper
+
+	checkpointStore entityStore
+	milestoneStore  entityStore
+	spanStore       entityStore
+}
+
+func newCheckpointStore(tx kv.RwTx, reader services.BorCheckpointReader, blockNumToIdIndexFactory func(context.Context) (*RangeIndex, error)) entityStore {
+	makeEntity := func() Entity { return new(Checkpoint) }
+	return newEntityStore(tx, kv.BorCheckpoints, makeEntity, reader.LastCheckpointId, reader.Checkpoint, blockNumToIdIndexFactory)
+}
+
+func newMilestoneStore(tx kv.RwTx, reader services.BorMilestoneReader, blockNumToIdIndexFactory func(context.Context) (*RangeIndex, error)) entityStore {
+	makeEntity := func() Entity { return new(Milestone) }
+	return newEntityStore(tx, kv.BorMilestones, makeEntity, reader.LastMilestoneId, reader.Milestone, blockNumToIdIndexFactory)
+}
+
+func newSpanStore(tx kv.RwTx, reader services.BorSpanReader, blockNumToIdIndexFactory func(context.Context) (*RangeIndex, error)) entityStore {
+	makeEntity := func() Entity { return new(Span) }
+	return newEntityStore(tx, kv.BorSpans, makeEntity, reader.LastSpanId, reader.Span, blockNumToIdIndexFactory)
+}
+
+func NewService(
+	heimdallUrl string,
+	tmpDir string,
+	logger log.Logger,
+) Service {
+	// TODO: implementing these is an upcoming task
+	txProvider := func() kv.RwTx { /* TODO */ return nil }
+	readerProvider := func() reader { /* TODO */ return nil }
+
+	tx := txProvider()
+	if tx == nil {
+		// TODO: implement and remove
+		logger.Warn("heimdall.Service txProvider is not implemented yet")
+		return nil
+	}
+	reader := readerProvider()
+	if reader == nil {
+		// TODO: implement and remove
+		logger.Warn("heimdall.Service readerProvider is not implemented yet")
+		return nil
+	}
+
+	blockNumToIdIndexFactory := func(ctx context.Context) (*RangeIndex, error) {
+		return NewRangeIndex(ctx, tmpDir, logger)
+	}
+
+	checkpointStore := newCheckpointStore(tx, reader, blockNumToIdIndexFactory)
+	milestoneStore := newMilestoneStore(tx, reader, blockNumToIdIndexFactory)
+	spanStore := newSpanStore(tx, reader, blockNumToIdIndexFactory)
+
+	client := NewHeimdallClient(heimdallUrl, logger)
+	scraper := NewScraper(
+		checkpointStore,
+		milestoneStore,
+		spanStore,
+		client,
+		1*time.Second,
+		logger,
+	)
+
+	return &service{
+		scraper: scraper,
+
+		checkpointStore: checkpointStore,
+		milestoneStore:  milestoneStore,
+		spanStore:       spanStore,
+	}
+}
+
+func (s *service) FetchLatestSpan(ctx context.Context) (*Span, error) {
+	s.scraper.Synchronize(ctx)
+	entity, err := s.spanStore.GetLastEntity(ctx)
+	return downcastSpanEntity(entity), err
+}
+
+func castEntityToWaypoint(entity Entity) Waypoint {
+	return entity.(Waypoint)
+}
+
+func (s *service) FetchCheckpointsFromBlock(ctx context.Context, startBlock uint64) (Waypoints, error) {
+	s.scraper.Synchronize(ctx)
+	entities, err := s.checkpointStore.RangeFromBlockNum(ctx, startBlock)
+	return libcommon.SliceMap(entities, castEntityToWaypoint), err
+}
+
+func (s *service) FetchMilestonesFromBlock(ctx context.Context, startBlock uint64) (Waypoints, error) {
+	s.scraper.Synchronize(ctx)
+	entities, err := s.milestoneStore.RangeFromBlockNum(ctx, startBlock)
+	return libcommon.SliceMap(entities, castEntityToWaypoint), err
+}
+
+func sliceTakeLast[T any](s []T, count int) []T {
+	length := len(s)
+	if length > count {
+		return s[length-count:]
+	}
+	return s
+}
+
+// TODO: this limit is a temporary solution to avoid piping thousands of events
+// during the first sync. Let's discuss alternatives. Hopefully we can remove this limit.
+const maxEntityEvents = 5
+
+func (s *service) OnMilestoneEvent(callback func(*Milestone)) polygoncommon.UnregisterFunc {
+	return s.scraper.RegisterMilestoneObserver(func(entities []*Milestone) {
+		for _, entity := range sliceTakeLast(entities, maxEntityEvents) {
+			callback(entity)
+		}
+	})
+}
+
+func (s *service) OnSpanEvent(callback func(*Span)) polygoncommon.UnregisterFunc {
+	return s.scraper.RegisterSpanObserver(func(entities []*Span) {
+		for _, entity := range sliceTakeLast(entities, maxEntityEvents) {
+			callback(entity)
+		}
+	})
+}
+
+func (s *service) Run(ctx context.Context) error {
+	defer s.checkpointStore.Close()
+	defer s.milestoneStore.Close()
+	defer s.spanStore.Close()
+
+	prepareStoresGroup, prepareStoresGroupCtx := errgroup.WithContext(ctx)
+	prepareStoresGroup.Go(func() error { return s.checkpointStore.Prepare(prepareStoresGroupCtx) })
+	prepareStoresGroup.Go(func() error { return s.milestoneStore.Prepare(prepareStoresGroupCtx) })
+	prepareStoresGroup.Go(func() error { return s.spanStore.Prepare(prepareStoresGroupCtx) })
+	err := prepareStoresGroup.Wait()
+	if err != nil {
+		return err
+	}
+
+	return s.scraper.Run(ctx)
+}

--- a/polygon/heimdall/service.go
+++ b/polygon/heimdall/service.go
@@ -112,21 +112,13 @@ func (s *service) FetchMilestonesFromBlock(ctx context.Context, startBlock uint6
 	return libcommon.SliceMap(entities, castEntityToWaypoint), err
 }
 
-func sliceTakeLast[T any](s []T, count int) []T {
-	length := len(s)
-	if length > count {
-		return s[length-count:]
-	}
-	return s
-}
-
 // TODO: this limit is a temporary solution to avoid piping thousands of events
 // during the first sync. Let's discuss alternatives. Hopefully we can remove this limit.
 const maxEntityEvents = 5
 
 func (s *service) OnMilestoneEvent(callback func(*Milestone)) polygoncommon.UnregisterFunc {
 	return s.scraper.RegisterMilestoneObserver(func(entities []*Milestone) {
-		for _, entity := range sliceTakeLast(entities, maxEntityEvents) {
+		for _, entity := range libcommon.SliceTakeLast(entities, maxEntityEvents) {
 			callback(entity)
 		}
 	})
@@ -134,7 +126,7 @@ func (s *service) OnMilestoneEvent(callback func(*Milestone)) polygoncommon.Unre
 
 func (s *service) OnSpanEvent(callback func(*Span)) polygoncommon.UnregisterFunc {
 	return s.scraper.RegisterSpanObserver(func(entities []*Span) {
-		for _, entity := range sliceTakeLast(entities, maxEntityEvents) {
+		for _, entity := range libcommon.SliceTakeLast(entities, maxEntityEvents) {
 			callback(entity)
 		}
 	})

--- a/polygon/heimdall/service.go
+++ b/polygon/heimdall/service.go
@@ -116,7 +116,7 @@ func (s *service) FetchMilestonesFromBlock(ctx context.Context, startBlock uint6
 // during the first sync. Let's discuss alternatives. Hopefully we can remove this limit.
 const maxEntityEvents = 5
 
-func (s *service) OnMilestoneEvent(callback func(*Milestone)) polygoncommon.UnregisterFunc {
+func (s *service) RegisterMilestoneObserver(callback func(*Milestone)) polygoncommon.UnregisterFunc {
 	return s.scraper.RegisterMilestoneObserver(func(entities []*Milestone) {
 		for _, entity := range libcommon.SliceTakeLast(entities, maxEntityEvents) {
 			callback(entity)
@@ -124,7 +124,7 @@ func (s *service) OnMilestoneEvent(callback func(*Milestone)) polygoncommon.Unre
 	})
 }
 
-func (s *service) OnSpanEvent(callback func(*Span)) polygoncommon.UnregisterFunc {
+func (s *service) RegisterSpanObserver(callback func(*Span)) polygoncommon.UnregisterFunc {
 	return s.scraper.RegisterSpanObserver(func(entities []*Span) {
 		for _, entity := range libcommon.SliceTakeLast(entities, maxEntityEvents) {
 			callback(entity)

--- a/polygon/sync/tip_events.go
+++ b/polygon/sync/tip_events.go
@@ -118,7 +118,7 @@ func (te *TipEvents) Run(ctx context.Context) error {
 	})
 	defer newBlockHashesObserverCancel()
 
-	milestoneObserverCancel := te.heimdallService.OnMilestoneEvent(func(milestone *heimdall.Milestone) {
+	milestoneObserverCancel := te.heimdallService.RegisterMilestoneObserver(func(milestone *heimdall.Milestone) {
 		te.events.PushEvent(Event{
 			Type:         EventTypeNewMilestone,
 			newMilestone: milestone,
@@ -126,7 +126,7 @@ func (te *TipEvents) Run(ctx context.Context) error {
 	})
 	defer milestoneObserverCancel()
 
-	spanObserverCancel := te.heimdallService.OnSpanEvent(func(span *heimdall.Span) {
+	spanObserverCancel := te.heimdallService.RegisterSpanObserver(func(span *heimdall.Span) {
 		te.events.PushEvent(Event{
 			Type:    EventTypeNewSpan,
 			newSpan: span,

--- a/polygon/sync/tip_events.go
+++ b/polygon/sync/tip_events.go
@@ -118,25 +118,21 @@ func (te *TipEvents) Run(ctx context.Context) error {
 	})
 	defer newBlockHashesObserverCancel()
 
-	err := te.heimdallService.OnMilestoneEvent(ctx, func(milestone *heimdall.Milestone) {
+	milestoneObserverCancel := te.heimdallService.OnMilestoneEvent(func(milestone *heimdall.Milestone) {
 		te.events.PushEvent(Event{
 			Type:         EventTypeNewMilestone,
 			newMilestone: milestone,
 		})
 	})
-	if err != nil {
-		return err
-	}
+	defer milestoneObserverCancel()
 
-	err = te.heimdallService.OnSpanEvent(ctx, func(span *heimdall.Span) {
+	spanObserverCancel := te.heimdallService.OnSpanEvent(func(span *heimdall.Span) {
 		te.events.PushEvent(Event{
 			Type:    EventTypeNewSpan,
 			newSpan: span,
 		})
 	})
-	if err != nil {
-		return err
-	}
+	defer spanObserverCancel()
 
 	return te.events.Run(ctx)
 }


### PR DESCRIPTION
* add a new Service for the HeimdallComponent. It will replace `heimdall.go` once everything is ready.
* move entity stores from Scraper to the Service
* implement missing Heimdall interface methods
