### PR TITLE
Log warn when there are no goodpeers

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -494,10 +494,14 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 							peerCountMap[protocol] += count
 						}
 					}
-					for protocol, count := range peerCountMap {
-						logItems = append(logItems, eth.ProtocolToString[protocol], strconv.Itoa(count))
+					if len(peerCountMap) == 0 {
+						logger.Warn("[p2p] No GoodPeers")
+					} else {
+						for protocol, count := range peerCountMap {
+							logItems = append(logItems, eth.ProtocolToString[protocol], strconv.Itoa(count))
+						}
+						logger.Info("[p2p] GoodPeers", logItems...)
 					}
-					logger.Info("[p2p] GoodPeers", logItems...)
 				}
 			}
 		}()


### PR DESCRIPTION
When there are no goodpeers, log a different message in a WARN level, in order to make the issue more evident as the node is not functional without peers.

I've been suffering of no peers on sepolia (no idea of root cause yet) recently and it took me some time + Daniel raising my attention to the current log msg to figure it out.

if there are no good peers, the current log is a very innocuous info with no count:

```
INFO[05-14|23:59:48.890] [p2p] GoodPeers
```
