### PR TITLE
e3 - increase defatults: batchSize from 256Mb to 512mb and default sync.loop.block.limit from 2K to 5K

### DIFF
--- a/turbo/cli/flags.go
+++ b/turbo/cli/flags.go
@@ -38,7 +38,7 @@ var (
 	BatchSizeFlag = cli.StringFlag{
 		Name:  "batchSize",
 		Usage: "Batch size for the execution stage",
-		Value: "256M",
+		Value: "512M",
 	}
 	EtlBufferSizeFlag = cli.StringFlag{
 		Name:  "etl.bufferSize",
@@ -173,7 +173,7 @@ var (
 	SyncLoopBlockLimitFlag = cli.UintFlag{
 		Name:  "sync.loop.block.limit",
 		Usage: "Sets the maximum number of blocks to process per loop iteration",
-		Value: 2_000, // unlimited
+		Value: 5_000,
 	}
 
 	UploadLocationFlag = cli.StringFlag{


### PR DESCRIPTION
Seems on all networks better have bigger defaults -> less commitments need to calc. 
gnosis has ~10 txs per block, polygon has ~100 txs per block. step is ~1.5M transactions. 
best performance we can show if compute commitment only 1 time per step (at end of step). 

