### PR TITLE
tweak(plainstate): add close func to close cursors

### DIFF
--- a/core/state/plain_readonly.go
+++ b/core/state/plain_readonly.go
@@ -76,6 +76,13 @@ func NewPlainState(tx kv.Tx, blockNr uint64, systemContractLookup map[libcommon.
 	return ps
 }
 
+func (s *PlainState) Close() {
+	s.accHistoryC.Close()
+	s.storageHistoryC.Close()
+	s.accChangesC.Close()
+	s.accHistoryC.Close()
+}
+
 func (s *PlainState) SetTrace(trace bool) {
 	s.trace = trace
 }


### PR DESCRIPTION
If repeatedly using the plainstate in an iteration you can end up with so many cursors that tx.Rollback/Commit takes a very long time. The fix is to clean up the cursors as you go with Close() on the plainstate.