### PR TITLE
Update EIP-2935: Adjust gas-costs for 2935

### DIFF
--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -29,7 +29,6 @@ import (
 )
 
 var activators = map[int]func(*JumpTable){
-	2935: enable2935,
 	7516: enable7516,
 	6780: enable6780,
 	5656: enable5656,
@@ -38,6 +37,7 @@ var activators = map[int]func(*JumpTable){
 	3855: enable3855,
 	3529: enable3529,
 	3198: enable3198,
+	2935: enable2935,
 	2929: enable2929,
 	2200: enable2200,
 	1884: enable1884,
@@ -298,13 +298,7 @@ func opMcopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 
 // enable6780 applies EIP-6780 (deactivate SELFDESTRUCT)
 func enable6780(jt *JumpTable) {
-	jt[SELFDESTRUCT] = &operation{
-		execute:     opSelfdestruct6780,
-		dynamicGas:  gasSelfdestructEIP3529,
-		constantGas: params.SelfdestructGasEIP150,
-		numPop:      1,
-		numPush:     0,
-	}
+	jt[SELFDESTRUCT].execute = opSelfdestruct6780
 }
 
 // opBlobBaseFee implements the BLOBBASEFEE opcode
@@ -331,11 +325,5 @@ func enable7516(jt *JumpTable) {
 
 // enable2935 applies EIP-2935 (Historical block hashes in state)
 func enable2935(jt *JumpTable) {
-	jt[BLOCKHASH] = &operation{
-		execute:     opBlockhash2935,
-		constantGas: GasExtStep,
-		dynamicGas:  gasOpBlockhashEIP2935,
-		numPop:      1,
-		numPush:     1,
-	}
+	jt[BLOCKHASH].execute = opBlockhash2935
 }

--- a/core/vm/operations_acl.go
+++ b/core/vm/operations_acl.go
@@ -235,22 +235,3 @@ func makeSelfdestructGasFn(refundsEnabled bool) gasFunc {
 	}
 	return gasFunc
 }
-
-// gasOpBlockhashEIP2935 returns the gas for the new BLOCKHASH operation post EIP-2935
-// If arg is outside of the params.BlockHashHistoryServeWindow, zero dynamic gas is returned
-// EIP-2929 Cold/Warm storage read cost is applicable here similar to SLOAD
-func gasOpBlockhashEIP2935(evm *EVM, contract *Contract, stack *stack.Stack, mem *Memory, memorySize uint64) (uint64, error) {
-	arg := stack.Peek()
-	arg64, overflow := arg.Uint64WithOverflow()
-	if overflow {
-		return 0, nil
-	}
-	if arg64 >= evm.Context.BlockNumber || arg64+params.BlockHashHistoryServeWindow < evm.Context.BlockNumber {
-		return 0, nil
-	}
-	storageSlot := libcommon.BytesToHash(uint256.NewInt(arg64 % params.BlockHashHistoryServeWindow).Bytes())
-	if _, slotMod := evm.IntraBlockState().AddSlotToAccessList(params.HistoryStorageAddress, storageSlot); slotMod {
-		return params.ColdSloadCostEIP2929, nil
-	}
-	return params.WarmStorageReadCostEIP2929, nil
-}


### PR DESCRIPTION
Today it was decided to retroactively include https://github.com/ethereum/EIPs/pull/8564 into pectra-devnet-0 (or certainly for devnet-1).