### PR TITLE
Improved `eth_syncing`

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -1575,10 +1575,6 @@ func ReadDBSchemaVersion(tx kv.Tx) (major, minor, patch uint32, ok bool, err err
 	return major, minor, patch, true, nil
 }
 
-func ResetLastNewBlockSeen(tx kv.RwTx) error {
-	return tx.Delete(kv.SyncStageProgress, kv.LastNewBlockSeen)
-}
-
 func WriteLastNewBlockSeen(tx kv.RwTx, blockNum uint64) error {
 	return tx.Put(kv.SyncStageProgress, kv.LastNewBlockSeen, dbutils.EncodeBlockNumber(blockNum))
 }

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -1574,3 +1574,22 @@ func ReadDBSchemaVersion(tx kv.Tx) (major, minor, patch uint32, ok bool, err err
 	patch = binary.BigEndian.Uint32(existingVersion[8:])
 	return major, minor, patch, true, nil
 }
+
+func ResetLastNewBlockSeen(tx kv.RwTx) error {
+	return tx.Delete(kv.SyncStageProgress, kv.LastNewBlockSeen)
+}
+
+func WriteLastNewBlockSeen(tx kv.RwTx, blockNum uint64) error {
+	return tx.Put(kv.SyncStageProgress, kv.LastNewBlockSeen, dbutils.EncodeBlockNumber(blockNum))
+}
+
+func ReadLastNewBlockSeen(tx kv.Tx) (uint64, error) {
+	v, err := tx.GetOne(kv.SyncStageProgress, kv.LastNewBlockSeen)
+	if err != nil {
+		return 0, err
+	}
+	if len(v) == 0 {
+		return 0, nil
+	}
+	return dbutils.DecodeBlockNumber(v)
+}

--- a/erigon-lib/kv/tables.go
+++ b/erigon-lib/kv/tables.go
@@ -544,6 +544,7 @@ var (
 	LightClientStore            = []byte("LightClientStore")
 	LightClientFinalityUpdate   = []byte("LightClientFinalityUpdate")
 	LightClientOptimisticUpdate = []byte("LightClientOptimisticUpdate")
+	LastNewBlockSeen            = []byte("LastNewBlockSeen") // last seen block hash
 
 	StatesProcessingKey = []byte("StatesProcessing")
 )

--- a/erigon-lib/txpool/pool_test.go
+++ b/erigon-lib/txpool/pool_test.go
@@ -47,7 +47,6 @@ import (
 )
 
 func TestNonceFromAddress(t *testing.T) {
-	t.Skip("TODO")
 	assert, require := assert.New(t), require.New(t)
 	ch := make(chan types.Announcements, 100)
 
@@ -74,8 +73,7 @@ func TestNonceFromAddress(t *testing.T) {
 	}
 	var addr [20]byte
 	addr[0] = 1
-	v := make([]byte, types.EncodeSenderLengthForStorage(2, *uint256.NewInt(1 * common.Ether)))
-	types.EncodeSender(2, *uint256.NewInt(1 * common.Ether), v)
+	v := types.EncodeAccountBytesV3(2, uint256.NewInt(1*common.Ether), make([]byte, 32), 1)
 	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remote.AccountChange{
 		Action:  remote.Action_UPSERT,
 		Address: gointerfaces.ConvertAddressToH160(addr),

--- a/turbo/execution/eth1/ethereum_execution.go
+++ b/turbo/execution/eth1/ethereum_execution.go
@@ -161,6 +161,15 @@ func (e *EthereumExecutionModule) ValidateChain(ctx context.Context, req *execut
 		}, nil
 	}
 	defer e.semaphore.Release(1)
+
+	// Update the last new block seen.
+	// This is used by eth_syncing as an heuristic to determine if the node is syncing or not.
+	if err := e.db.Update(ctx, func(tx kv.RwTx) error {
+		return rawdb.WriteLastNewBlockSeen(tx, req.Number)
+	}); err != nil {
+		return nil, err
+	}
+
 	tx, err := e.db.BeginRw(ctx)
 	if err != nil {
 		return nil, err

--- a/turbo/jsonrpc/eth_system.go
+++ b/turbo/jsonrpc/eth_system.go
@@ -56,7 +56,7 @@ func (api *APIImpl) Syncing(ctx context.Context) (interface{}, error) {
 		highestBlock = frozenBlocks
 	}
 
-	// Maybe it is still downloading snapshots.
+	// Maybe it is still downloading snapshots. Impossible to determine the highest block.
 	if highestBlock == 0 {
 		return map[string]interface{}{
 			"startingBlock": "0x0", // TODO: this is a placeholder, I do not think it matters what we return here, but 0x0 is probably a good placeholder.

--- a/turbo/jsonrpc/eth_system.go
+++ b/turbo/jsonrpc/eth_system.go
@@ -45,7 +45,7 @@ func (api *APIImpl) Syncing(ctx context.Context) (interface{}, error) {
 		return nil, err
 	}
 
-	currentBlock, err := stages.GetStageProgress(tx, stages.Finish)
+	currentBlock, err := stages.GetStageProgress(tx, stages.Execution)
 	if err != nil {
 		return false, err
 	}

--- a/turbo/jsonrpc/eth_system.go
+++ b/turbo/jsonrpc/eth_system.go
@@ -2,6 +2,7 @@ package jsonrpc
 
 import (
 	"context"
+	"math"
 	"math/big"
 
 	"github.com/ledgerwatch/erigon-lib/common/hexutil"
@@ -57,7 +58,11 @@ func (api *APIImpl) Syncing(ctx context.Context) (interface{}, error) {
 
 	// Maybe it is still downloading snapshots.
 	if highestBlock == 0 {
-		return false, nil
+		return map[string]interface{}{
+			"startingBlock": "0x0", // TODO: this is a placeholder, I do not think it matters what we return here, but 0x0 is probably a good placeholder.
+			"currentBlock":  hexutil.Uint64(currentBlock),
+			"highestBlock":  hexutil.Uint64(math.MaxUint64),
+		}, nil
 	}
 
 	if highestBlock > 0 && currentBlock >= highestBlock { // Return not syncing if the synchronisation already completed

--- a/turbo/jsonrpc/eth_system.go
+++ b/turbo/jsonrpc/eth_system.go
@@ -39,9 +39,10 @@ func (api *APIImpl) Syncing(ctx context.Context) (interface{}, error) {
 		return nil, err
 	}
 	defer tx.Rollback()
-	highestBlock, err := stages.GetStageProgress(tx, stages.Headers)
+
+	highestBlock, err := rawdb.ReadLastNewBlockSeen(tx)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 
 	currentBlock, err := stages.GetStageProgress(tx, stages.Finish)

--- a/turbo/jsonrpc/eth_system.go
+++ b/turbo/jsonrpc/eth_system.go
@@ -43,7 +43,7 @@ func (api *APIImpl) Syncing(ctx context.Context) (interface{}, error) {
 
 	highestBlock, err := rawdb.ReadLastNewBlockSeen(tx)
 	if err != nil {
-		return nil, err
+		return false, err
 	}
 
 	currentBlock, err := stages.GetStageProgress(tx, stages.Execution)

--- a/turbo/jsonrpc/eth_system.go
+++ b/turbo/jsonrpc/eth_system.go
@@ -64,8 +64,10 @@ func (api *APIImpl) Syncing(ctx context.Context) (interface{}, error) {
 			"highestBlock":  hexutil.Uint64(math.MaxUint64),
 		}, nil
 	}
+	reorgRange := 8
 
-	if highestBlock > 0 && currentBlock >= highestBlock { // Return not syncing if the synchronisation already completed
+	// If the distance between the current block and the highest block is less than the reorg range, we are not syncing. abs(highestBlock - currentBlock) < reorgRange
+	if math.Abs(float64(highestBlock)-float64(currentBlock)) < float64(reorgRange) {
 		return false, nil
 	}
 

--- a/turbo/jsonrpc/eth_system.go
+++ b/turbo/jsonrpc/eth_system.go
@@ -2,7 +2,6 @@ package jsonrpc
 
 import (
 	"context"
-	"math"
 	"math/big"
 
 	"github.com/ledgerwatch/erigon-lib/common/hexutil"
@@ -58,11 +57,7 @@ func (api *APIImpl) Syncing(ctx context.Context) (interface{}, error) {
 
 	// Maybe it is still downloading snapshots.
 	if highestBlock == 0 {
-		return map[string]interface{}{
-			"startingBlock": "0x0", // TODO: this is a placeholder, I do not think it matters what we return here, but 0x0 is probably a good placeholder.
-			"currentBlock":  hexutil.Uint64(currentBlock),
-			"highestBlock":  hexutil.Uint64(math.MaxUint64),
-		}, nil
+		return false, nil
 	}
 
 	if highestBlock > 0 && currentBlock >= highestBlock { // Return not syncing if the synchronisation already completed

--- a/turbo/jsonrpc/eth_system.go
+++ b/turbo/jsonrpc/eth_system.go
@@ -70,9 +70,10 @@ func (api *APIImpl) Syncing(ctx context.Context) (interface{}, error) {
 	}
 
 	return map[string]interface{}{
-		"currentBlock": hexutil.Uint64(currentBlock),
-		"highestBlock": hexutil.Uint64(highestBlock),
-		"stages":       stagesMap,
+		"startingBlock": "0x0", // TODO: this is a placeholder, I do not think it matters what we return here, but 0x0 is probably a good placeholder.
+		"currentBlock":  hexutil.Uint64(currentBlock),
+		"highestBlock":  hexutil.Uint64(highestBlock),
+		"stages":        stagesMap,
 	}, nil
 }
 


### PR DESCRIPTION
The approach is simple, every time the `Execution` module sees a block it saves the number in DB. That number is the heuristics for the "tip of the chain".

Also changes from stages.Finish to stages.Execution. the issue was that  for syncing up everything (stages.Headers as well) is in a single mdbx tx. Now we have separate key which is committed in a small `Update` before the processing. 