### PR TITLE
Change default eth_getProof to 100k

### DIFF
--- a/cmd/rpcdaemon/README.md
+++ b/cmd/rpcdaemon/README.md
@@ -301,7 +301,7 @@ The following table shows the current implementation status of Erigon's RPC daem
 | eth_signTransaction                        | -       | not yet implemented                  |
 | eth_signTypedData                          | -       | ????                                 |
 |                                            |         |                                      |
-| eth_getProof                               | Yes     | Limited to last 1000 blocks          |
+| eth_getProof                               | Yes     | Limited to last 100000 blocks          |
 |                                            |         |                                      |
 | eth_mining                                 | Yes     | returns true if --mine flag provided |
 | eth_coinbase                               | Yes     |                                      |


### PR DESCRIPTION
The default range for `eth_getProof` seems be the past 100k blocks instead of 1k as per https://github.com/ledgerwatch/erigon/blob/36b331100e7b31cf4b7469c00412bc0ebcdb610d/cmd/utils/flags.go#L515