### PR TITLE
try to fix 'method handler crashed' for debug_traceCall of #9090

### DIFF
--- a/turbo/jsonrpc/tracing.go
+++ b/turbo/jsonrpc/tracing.go
@@ -325,7 +325,7 @@ func (api *PrivateDebugAPIImpl) TraceCall(ctx context.Context, args ethapi.CallA
 	}
 
 	var stateReader state.StateReader
-	if config.TxIndex == nil || isLatest {
+	if config == nil || config.TxIndex == nil || isLatest {
 		stateReader, err = rpchelper.CreateStateReader(ctx, dbtx, blockNrOrHash, 0, api.filters, api.stateCache, chainConfig.ChainName)
 	} else {
 		stateReader, err = rpchelper.CreateHistoryStateReader(dbtx, blockNumber, int(*config.TxIndex), chainConfig.ChainName)


### PR DESCRIPTION
try to fix 'method handler crashed' for debug_traceCall of #9090 

To get 'method handler crashed' because the call not put config parameter, so the `config` is `nil`.
we need to check if `config` is `nil`