### PR TITLE
Refactor inverted indexes instances

### DIFF
--- a/erigon-lib/kv/tables.go
+++ b/erigon-lib/kv/tables.go
@@ -962,6 +962,12 @@ const (
 	LogAddrIdx    InvertedIdx = "LogAddrIdx"
 	TracesFromIdx InvertedIdx = "TracesFromIdx"
 	TracesToIdx   InvertedIdx = "TracesToIdx"
+
+	LogAddrIdxPos           = 0
+	LogTopicIdxPos          = 1
+	TracesFromIdxPos        = 2
+	TracesToIdxPos          = 3
+	StandaloneIdxLen uint16 = 4
 )
 
 func (d Domain) String() string {

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -55,10 +55,7 @@ import (
 type Aggregator struct {
 	db               kv.RoDB
 	d                [kv.DomainLen]*Domain
-	tracesTo         *InvertedIndex
-	logAddrs         *InvertedIndex
-	logTopics        *InvertedIndex
-	tracesFrom       *InvertedIndex
+	iis              [kv.StandaloneIdxLen]*InvertedIndex
 	backgroundResult *BackgroundResult
 	dirs             datadir.Dirs
 	tmpdir           string
@@ -180,20 +177,16 @@ func NewAggregator(ctx context.Context, dirs datadir.Dirs, aggregationStep uint6
 	//if a.d[kv.GasUsedDomain], err = NewDomain(cfg, aggregationStep, "gasused", kv.TblGasUsedKeys, kv.TblGasUsedVals, kv.TblGasUsedHistoryKeys, kv.TblGasUsedHistoryVals, kv.TblGasUsedIdx, logger); err != nil {
 	//	return nil, err
 	//}
-	idxCfg := iiCfg{salt: salt, dirs: dirs, db: db}
-	if a.logAddrs, err = NewInvertedIndex(idxCfg, aggregationStep, "logaddrs", kv.TblLogAddressKeys, kv.TblLogAddressIdx, nil, logger); err != nil {
+	if err := a.registerII(kv.LogAddrIdxPos, salt, dirs, db, aggregationStep, "logaddrs", kv.TblLogAddressKeys, kv.TblLogAddressIdx, logger); err != nil {
 		return nil, err
 	}
-	idxCfg = iiCfg{salt: salt, dirs: dirs, db: db}
-	if a.logTopics, err = NewInvertedIndex(idxCfg, aggregationStep, "logtopics", kv.TblLogTopicsKeys, kv.TblLogTopicsIdx, nil, logger); err != nil {
+	if err := a.registerII(kv.LogTopicIdxPos, salt, dirs, db, aggregationStep, "logtopics", kv.TblLogTopicsKeys, kv.TblLogTopicsIdx, logger); err != nil {
 		return nil, err
 	}
-	idxCfg = iiCfg{salt: salt, dirs: dirs, db: db}
-	if a.tracesFrom, err = NewInvertedIndex(idxCfg, aggregationStep, "tracesfrom", kv.TblTracesFromKeys, kv.TblTracesFromIdx, nil, logger); err != nil {
+	if err := a.registerII(kv.TracesFromIdxPos, salt, dirs, db, aggregationStep, "tracesfrom", kv.TblTracesFromKeys, kv.TblTracesFromIdx, logger); err != nil {
 		return nil, err
 	}
-	idxCfg = iiCfg{salt: salt, dirs: dirs, db: db}
-	if a.tracesTo, err = NewInvertedIndex(idxCfg, aggregationStep, "tracesto", kv.TblTracesToKeys, kv.TblTracesToIdx, nil, logger); err != nil {
+	if err := a.registerII(kv.TracesToIdxPos, salt, dirs, db, aggregationStep, "tracesto", kv.TblTracesToKeys, kv.TblTracesToIdx, logger); err != nil {
 		return nil, err
 	}
 	a.KeepStepsInDB(1)
@@ -233,15 +226,24 @@ func getStateIndicesSalt(baseDir string) (salt *uint32, err error) {
 	return salt, nil
 }
 
+func (a *Aggregator) registerII(idx uint16, salt *uint32, dirs datadir.Dirs, db kv.RoDB, aggregationStep uint64, filenameBase, indexKeysTable, indexTable string, logger log.Logger) error {
+	idxCfg := iiCfg{salt: salt, dirs: dirs, db: db}
+	var err error
+	a.iis[idx], err = NewInvertedIndex(idxCfg, aggregationStep, filenameBase, indexKeysTable, indexTable, nil, logger)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (a *Aggregator) OnFreeze(f OnFreezeFunc) { a.onFreeze = f }
 func (a *Aggregator) DisableFsync() {
 	for _, d := range a.d {
 		d.DisableFsync()
 	}
-	a.logAddrs.DisableFsync()
-	a.logTopics.DisableFsync()
-	a.tracesFrom.DisableFsync()
-	a.tracesTo.DisableFsync()
+	for _, ii := range a.iis {
+		ii.DisableFsync()
+	}
 }
 
 func (a *Aggregator) OpenFolder(readonly bool) error {
@@ -261,10 +263,10 @@ func (a *Aggregator) OpenFolder(readonly bool) error {
 			return d.OpenFolder(readonly)
 		})
 	}
-	eg.Go(func() error { return a.logAddrs.OpenFolder(readonly) })
-	eg.Go(func() error { return a.logTopics.OpenFolder(readonly) })
-	eg.Go(func() error { return a.tracesFrom.OpenFolder(readonly) })
-	eg.Go(func() error { return a.tracesTo.OpenFolder(readonly) })
+	for _, ii := range a.iis {
+		ii := ii
+		eg.Go(func() error { return ii.OpenFolder(readonly) })
+	}
 	if err := eg.Wait(); err != nil {
 		return fmt.Errorf("OpenFolder: %w", err)
 	}
@@ -281,10 +283,10 @@ func (a *Aggregator) OpenList(files []string, readonly bool) error {
 		d := d
 		eg.Go(func() error { return d.OpenFolder(readonly) })
 	}
-	eg.Go(func() error { return a.logAddrs.OpenFolder(readonly) })
-	eg.Go(func() error { return a.logTopics.OpenFolder(readonly) })
-	eg.Go(func() error { return a.tracesFrom.OpenFolder(readonly) })
-	eg.Go(func() error { return a.tracesTo.OpenFolder(readonly) })
+	for _, ii := range a.iis {
+		ii := ii
+		eg.Go(func() error { return ii.OpenFolder(readonly) })
+	}
 	if err := eg.Wait(); err != nil {
 		return fmt.Errorf("OpenList: %w", err)
 	}
@@ -310,10 +312,9 @@ func (a *Aggregator) closeDirtyFiles() {
 	for _, d := range a.d {
 		d.Close()
 	}
-	a.logAddrs.Close()
-	a.logTopics.Close()
-	a.tracesFrom.Close()
-	a.tracesTo.Close()
+	for _, ii := range a.iis {
+		ii.Close()
+	}
 }
 
 func (a *Aggregator) SetCollateAndBuildWorkers(i int) { a.collateAndBuildWorkers = i }
@@ -322,10 +323,9 @@ func (a *Aggregator) SetCompressWorkers(i int) {
 	for _, d := range a.d {
 		d.compressWorkers = i
 	}
-	a.logAddrs.compressWorkers = i
-	a.logTopics.compressWorkers = i
-	a.tracesFrom.compressWorkers = i
-	a.tracesTo.compressWorkers = i
+	for _, ii := range a.iis {
+		ii.compressWorkers = i
+	}
 }
 
 func (a *Aggregator) DiscardHistory(name kv.Domain) *Aggregator {
@@ -348,10 +348,9 @@ func (ac *AggregatorRoTx) Files() []string {
 	for _, d := range ac.d {
 		res = append(res, d.Files()...)
 	}
-	res = append(res, ac.logAddrs.Files()...)
-	res = append(res, ac.logTopics.Files()...)
-	res = append(res, ac.tracesFrom.Files()...)
-	res = append(res, ac.tracesTo.Files()...)
+	for _, ii := range ac.iis {
+		res = append(res, ii.Files()...)
+	}
 	return res
 }
 func (a *Aggregator) Files() []string {
@@ -432,10 +431,9 @@ func (a *Aggregator) BuildMissedIndices(ctx context.Context, workers int) error 
 		for _, d := range a.d {
 			d.BuildMissedIndices(ctx, g, ps)
 		}
-		a.logAddrs.BuildMissedIndices(ctx, g, ps)
-		a.logTopics.BuildMissedIndices(ctx, g, ps)
-		a.tracesFrom.BuildMissedIndices(ctx, g, ps)
-		a.tracesTo.BuildMissedIndices(ctx, g, ps)
+		for _, ii := range a.iis {
+			ii.BuildMissedIndices(ctx, g, ps)
+		}
 
 		if err := g.Wait(); err != nil {
 			return err
@@ -498,11 +496,8 @@ func (c AggV3Collation) Close() {
 }
 
 type AggV3StaticFiles struct {
-	d          [kv.DomainLen]StaticFiles
-	logAddrs   InvertedFiles
-	logTopics  InvertedFiles
-	tracesFrom InvertedFiles
-	tracesTo   InvertedFiles
+	d    [kv.DomainLen]StaticFiles
+	ivfs [kv.StandaloneIdxLen]InvertedFiles
 }
 
 // CleanupOnError - call it on collation fail. It's closing all files
@@ -510,10 +505,9 @@ func (sf AggV3StaticFiles) CleanupOnError() {
 	for _, d := range sf.d {
 		d.CleanupOnError()
 	}
-	sf.logAddrs.CleanupOnError()
-	sf.logTopics.CleanupOnError()
-	sf.tracesFrom.CleanupOnError()
-	sf.tracesTo.CleanupOnError()
+	for _, ivf := range sf.ivfs {
+		ivf.CleanupOnError()
+	}
 }
 
 func (a *Aggregator) buildFiles(ctx context.Context, step uint64) error {
@@ -579,7 +573,7 @@ func (a *Aggregator) buildFiles(ctx context.Context, step uint64) error {
 	closeCollations = false
 
 	// indices are built concurrently
-	for _, d := range []*InvertedIndex{a.logTopics, a.logAddrs, a.tracesFrom, a.tracesTo} {
+	for _, d := range a.iis {
 		d := d
 		a.wg.Add(1)
 		g.Go(func() error {
@@ -601,13 +595,13 @@ func (a *Aggregator) buildFiles(ctx context.Context, step uint64) error {
 
 			switch d.indexKeysTable {
 			case kv.TblLogTopicsKeys:
-				static.logTopics = sf
+				static.ivfs[kv.LogTopicIdxPos] = sf
 			case kv.TblLogAddressKeys:
-				static.logAddrs = sf
+				static.ivfs[kv.LogAddrIdxPos] = sf
 			case kv.TblTracesFromKeys:
-				static.tracesFrom = sf
+				static.ivfs[kv.TracesFromIdxPos] = sf
 			case kv.TblTracesToKeys:
-				static.tracesTo = sf
+				static.ivfs[kv.TracesToIdxPos] = sf
 			default:
 				panic("unknown index " + d.indexKeysTable)
 			}
@@ -721,10 +715,9 @@ func (a *Aggregator) integrateDirtyFiles(sf AggV3StaticFiles, txNumFrom, txNumTo
 	for id, d := range a.d {
 		d.integrateDirtyFiles(sf.d[id], txNumFrom, txNumTo)
 	}
-	a.logAddrs.integrateDirtyFiles(sf.logAddrs, txNumFrom, txNumTo)
-	a.logTopics.integrateDirtyFiles(sf.logTopics, txNumFrom, txNumTo)
-	a.tracesFrom.integrateDirtyFiles(sf.tracesFrom, txNumFrom, txNumTo)
-	a.tracesTo.integrateDirtyFiles(sf.tracesTo, txNumFrom, txNumTo)
+	for id, ii := range a.iis {
+		ii.integrateDirtyFiles(sf.ivfs[id], txNumFrom, txNumTo)
+	}
 }
 
 func (a *Aggregator) HasNewFrozenFiles() bool {
@@ -756,10 +749,12 @@ func (ac *AggregatorRoTx) CanPrune(tx kv.Tx, untilTx uint64) bool {
 			return true
 		}
 	}
-	return ac.logAddrs.CanPrune(tx) ||
-		ac.logTopics.CanPrune(tx) ||
-		ac.tracesFrom.CanPrune(tx) ||
-		ac.tracesTo.CanPrune(tx)
+	for _, ii := range ac.iis {
+		if ii.CanPrune(tx) {
+			return true
+		}
+	}
+	return false
 }
 
 func (ac *AggregatorRoTx) CanUnwindDomainsToBlockNum(tx kv.Tx) (uint64, error) {
@@ -974,12 +969,9 @@ func (a *Aggregator) StepsRangeInDBAsStr(tx kv.Tx) string {
 	for _, d := range a.d {
 		steps = append(steps, d.stepsRangeInDBAsStr(tx))
 	}
-	steps = append(steps,
-		a.logAddrs.stepsRangeInDBAsStr(tx),
-		a.logTopics.stepsRangeInDBAsStr(tx),
-		a.tracesFrom.stepsRangeInDBAsStr(tx),
-		a.tracesTo.stepsRangeInDBAsStr(tx),
-	)
+	for _, ii := range a.iis {
+		steps = append(steps, ii.stepsRangeInDBAsStr(tx))
+	}
 	return strings.Join(steps, ", ")
 }
 
@@ -1079,26 +1071,18 @@ func (ac *AggregatorRoTx) Prune(ctx context.Context, tx kv.RwTx, limit uint64, w
 			return aggStat, err
 		}
 	}
-	lap, err := ac.logAddrs.Prune(ctx, tx, txFrom, txTo, limit, logEvery, false, withWarmup, nil)
-	if err != nil {
-		return nil, err
+	var stats [kv.StandaloneIdxLen]*InvertedIndexPruneStat
+	for i := 0; i < int(kv.StandaloneIdxLen); i++ {
+		stat, err := ac.iis[i].Prune(ctx, tx, txFrom, txTo, limit, logEvery, false, withWarmup, nil)
+		if err != nil {
+			return nil, err
+		}
+		stats[i] = stat
 	}
-	ltp, err := ac.logTopics.Prune(ctx, tx, txFrom, txTo, limit, logEvery, false, withWarmup, nil)
-	if err != nil {
-		return nil, err
+
+	for i := 0; i < int(kv.StandaloneIdxLen); i++ {
+		aggStat.Indices[ac.iis[i].ii.filenameBase] = stats[i]
 	}
-	tfp, err := ac.tracesFrom.Prune(ctx, tx, txFrom, txTo, limit, logEvery, false, withWarmup, nil)
-	if err != nil {
-		return nil, err
-	}
-	ttp, err := ac.tracesTo.Prune(ctx, tx, txFrom, txTo, limit, logEvery, false, withWarmup, nil)
-	if err != nil {
-		return nil, err
-	}
-	aggStat.Indices[ac.logAddrs.ii.filenameBase] = lap
-	aggStat.Indices[ac.logTopics.ii.filenameBase] = ltp
-	aggStat.Indices[ac.tracesFrom.ii.filenameBase] = tfp
-	aggStat.Indices[ac.tracesTo.ii.filenameBase] = ttp
 
 	return aggStat, nil
 }
@@ -1157,12 +1141,10 @@ func (a *Aggregator) FilesAmount() (res []int) {
 	for _, d := range a.d {
 		res = append(res, d.dirtyFiles.Len())
 	}
-	return append(res,
-		a.tracesFrom.dirtyFiles.Len(),
-		a.tracesTo.dirtyFiles.Len(),
-		a.logAddrs.dirtyFiles.Len(),
-		a.logTopics.dirtyFiles.Len(),
-	)
+	for _, ii := range a.iis {
+		res = append(res, ii.dirtyFiles.Len())
+	}
+	return res
 }
 
 func FirstTxNumOfStep(step, size uint64) uint64 {
@@ -1198,10 +1180,9 @@ func (a *Aggregator) recalcVisibleFiles() {
 	for _, domain := range a.d {
 		domain.reCalcVisibleFiles()
 	}
-	a.logTopics.reCalcVisibleFiles()
-	a.logAddrs.reCalcVisibleFiles()
-	a.tracesFrom.reCalcVisibleFiles()
-	a.tracesTo.reCalcVisibleFiles()
+	for _, ii := range a.iis {
+		ii.reCalcVisibleFiles()
+	}
 }
 
 func (a *Aggregator) recalcVisibleFilesMinimaxTxNum() {
@@ -1211,19 +1192,8 @@ func (a *Aggregator) recalcVisibleFilesMinimaxTxNum() {
 }
 
 type RangesV3 struct {
-	d                    [kv.DomainLen]DomainRanges
-	logTopicsStartTxNum  uint64
-	logAddrsEndTxNum     uint64
-	logAddrsStartTxNum   uint64
-	logTopicsEndTxNum    uint64
-	tracesFromStartTxNum uint64
-	tracesFromEndTxNum   uint64
-	tracesToStartTxNum   uint64
-	tracesToEndTxNum     uint64
-	logAddrs             bool
-	logTopics            bool
-	tracesFrom           bool
-	tracesTo             bool
+	d      [kv.DomainLen]DomainRanges
+	ranges [kv.StandaloneIdxLen]*MergeRange
 }
 
 func (r RangesV3) String() string {
@@ -1233,27 +1203,35 @@ func (r RangesV3) String() string {
 			ss = append(ss, fmt.Sprintf("%s(%s)", d.name, d.String()))
 		}
 	}
-	if r.logAddrs {
-		ss = append(ss, fmt.Sprintf("logAddr=%d-%d", r.logAddrsStartTxNum/r.d[kv.AccountsDomain].aggStep, r.logAddrsEndTxNum/r.d[kv.AccountsDomain].aggStep))
+
+	aggStep := r.d[kv.AccountsDomain].aggStep
+	if r.ranges[kv.LogAddrIdxPos] != nil && r.ranges[kv.LogAddrIdxPos].needMerge {
+		ss = append(ss, r.ranges[kv.LogAddrIdxPos].String("logAddr", aggStep))
 	}
-	if r.logTopics {
-		ss = append(ss, fmt.Sprintf("logTopic=%d-%d", r.logTopicsStartTxNum/r.d[kv.AccountsDomain].aggStep, r.logTopicsEndTxNum/r.d[kv.AccountsDomain].aggStep))
+	if r.ranges[kv.LogTopicIdxPos] != nil && r.ranges[kv.LogTopicIdxPos].needMerge {
+		ss = append(ss, r.ranges[kv.LogTopicIdxPos].String("logTopic", aggStep))
 	}
-	if r.tracesFrom {
-		ss = append(ss, fmt.Sprintf("traceFrom=%d-%d", r.tracesFromStartTxNum/r.d[kv.AccountsDomain].aggStep, r.tracesFromEndTxNum/r.d[kv.AccountsDomain].aggStep))
+	if r.ranges[kv.TracesFromIdxPos] != nil && r.ranges[kv.TracesFromIdxPos].needMerge {
+		ss = append(ss, r.ranges[kv.TracesFromIdxPos].String("traceFrom", aggStep))
 	}
-	if r.tracesTo {
-		ss = append(ss, fmt.Sprintf("traceTo=%d-%d", r.tracesToStartTxNum/r.d[kv.AccountsDomain].aggStep, r.tracesToEndTxNum/r.d[kv.AccountsDomain].aggStep))
+	if r.ranges[kv.TracesToIdxPos] != nil && r.ranges[kv.TracesToIdxPos].needMerge {
+		ss = append(ss, r.ranges[kv.TracesToIdxPos].String("traceTo", aggStep))
 	}
 	return strings.Join(ss, ", ")
 }
+
 func (r RangesV3) any() bool {
 	for _, d := range r.d {
 		if d.any() {
 			return true
 		}
 	}
-	return r.logAddrs || r.logTopics || r.tracesFrom || r.tracesTo
+	for _, ii := range r.ranges {
+		if ii.needMerge {
+			return true
+		}
+	}
+	return false
 }
 
 func (ac *AggregatorRoTx) findMergeRange(maxEndTxNum, maxSpan uint64) RangesV3 {
@@ -1261,10 +1239,9 @@ func (ac *AggregatorRoTx) findMergeRange(maxEndTxNum, maxSpan uint64) RangesV3 {
 	for id, d := range ac.d {
 		r.d[id] = d.findMergeRange(maxEndTxNum, maxSpan)
 	}
-	r.logAddrs, r.logAddrsStartTxNum, r.logAddrsEndTxNum = ac.logAddrs.findMergeRange(maxEndTxNum, maxSpan)
-	r.logTopics, r.logTopicsStartTxNum, r.logTopicsEndTxNum = ac.logTopics.findMergeRange(maxEndTxNum, maxSpan)
-	r.tracesFrom, r.tracesFromStartTxNum, r.tracesFromEndTxNum = ac.tracesFrom.findMergeRange(maxEndTxNum, maxSpan)
-	r.tracesTo, r.tracesToStartTxNum, r.tracesToEndTxNum = ac.tracesTo.findMergeRange(maxEndTxNum, maxSpan)
+	for id, ii := range ac.iis {
+		r.ranges[id] = ii.findMergeRange(maxEndTxNum, maxSpan)
+	}
 	//log.Info(fmt.Sprintf("findMergeRange(%d, %d)=%s\n", maxEndTxNum/ac.a.aggregationStep, maxSpan/ac.a.aggregationStep, r))
 	return r
 }
@@ -1490,34 +1467,18 @@ func (ac *AggregatorRoTx) mergeFiles(ctx context.Context, files SelectedStaticFi
 		}
 	}
 
-	if r.logAddrs {
-		g.Go(func() error {
-			var err error
-			mf.logAddrs, err = ac.logAddrs.mergeFiles(ctx, files.logAddrs, r.logAddrsStartTxNum, r.logAddrsEndTxNum, ac.a.ps)
-			return err
-		})
+	for id, rng := range r.ranges {
+		id := id
+		rng := rng
+		if rng.needMerge {
+			g.Go(func() error {
+				var err error
+				mf.iis[id], err = ac.iis[id].mergeFiles(ctx, files.ii[id].fi, rng.from, rng.to, ac.a.ps)
+				return err
+			})
+		}
 	}
-	if r.logTopics {
-		g.Go(func() error {
-			var err error
-			mf.logTopics, err = ac.logTopics.mergeFiles(ctx, files.logTopics, r.logTopicsStartTxNum, r.logTopicsEndTxNum, ac.a.ps)
-			return err
-		})
-	}
-	if r.tracesFrom {
-		g.Go(func() error {
-			var err error
-			mf.tracesFrom, err = ac.tracesFrom.mergeFiles(ctx, files.tracesFrom, r.tracesFromStartTxNum, r.tracesFromEndTxNum, ac.a.ps)
-			return err
-		})
-	}
-	if r.tracesTo {
-		g.Go(func() error {
-			var err error
-			mf.tracesTo, err = ac.tracesTo.mergeFiles(ctx, files.tracesTo, r.tracesToStartTxNum, r.tracesToEndTxNum, ac.a.ps)
-			return err
-		})
-	}
+
 	err := g.Wait()
 	if err == nil {
 		closeFiles = false
@@ -1539,10 +1500,9 @@ func (a *Aggregator) integrateMergedDirtyFiles(outs SelectedStaticFilesV3, in Me
 		d.integrateMergedDirtyFiles(outs.d[id], outs.dIdx[id], outs.dHist[id], in.d[id], in.dIdx[id], in.dHist[id])
 	}
 
-	a.logAddrs.integrateMergedDirtyFiles(outs.logAddrs, in.logAddrs)
-	a.logTopics.integrateMergedDirtyFiles(outs.logTopics, in.logTopics)
-	a.tracesFrom.integrateMergedDirtyFiles(outs.tracesFrom, in.tracesFrom)
-	a.tracesTo.integrateMergedDirtyFiles(outs.tracesTo, in.tracesTo)
+	for id, ii := range a.iis {
+		ii.integrateMergedDirtyFiles(outs.ii[id].fi, in.iis[id])
+	}
 	return frozen
 }
 
@@ -1556,10 +1516,9 @@ func (a *Aggregator) cleanAfterMerge(in MergedFilesV3) {
 	for id, d := range at.d {
 		d.cleanAfterMerge(in.d[id], in.dHist[id], in.dIdx[id])
 	}
-	at.logAddrs.cleanAfterMerge(in.logAddrs)
-	at.logTopics.cleanAfterMerge(in.logTopics)
-	at.tracesFrom.cleanAfterMerge(in.tracesFrom)
-	at.tracesTo.cleanAfterMerge(in.tracesTo)
+	for id, ii := range at.iis {
+		ii.cleanAfterMerge(in.iis[id])
+	}
 }
 
 // KeepStepsInDB - usually equal to one a.aggregationStep, but when we exec blocks from snapshots
@@ -1677,13 +1636,13 @@ func (ac *AggregatorRoTx) IndexRange(name kv.InvertedIdx, k []byte, fromTs, toTs
 	//case kv.GasUsedHistoryIdx:
 	//	return ac.d[kv.GasUsedDomain].ht.IdxRange(k, fromTs, toTs, asc, limit, tx)
 	case kv.LogTopicIdx:
-		return ac.logTopics.IdxRange(k, fromTs, toTs, asc, limit, tx)
+		return ac.iis[kv.LogTopicIdxPos].IdxRange(k, fromTs, toTs, asc, limit, tx)
 	case kv.LogAddrIdx:
-		return ac.logAddrs.IdxRange(k, fromTs, toTs, asc, limit, tx)
+		return ac.iis[kv.LogAddrIdxPos].IdxRange(k, fromTs, toTs, asc, limit, tx)
 	case kv.TracesFromIdx:
-		return ac.tracesFrom.IdxRange(k, fromTs, toTs, asc, limit, tx)
+		return ac.iis[kv.TracesFromIdxPos].IdxRange(k, fromTs, toTs, asc, limit, tx)
 	case kv.TracesToIdx:
-		return ac.tracesTo.IdxRange(k, fromTs, toTs, asc, limit, tx)
+		return ac.iis[kv.TracesToIdxPos].IdxRange(k, fromTs, toTs, asc, limit, tx)
 	default:
 		return nil, fmt.Errorf("unexpected history name: %s", name)
 	}
@@ -1751,12 +1710,9 @@ func (a *Aggregator) Stats() FilesStats22 {
 //   - user will not see "partial writes" or "new files appearance"
 //   - last reader removing garbage files inside `Close` method
 type AggregatorRoTx struct {
-	a          *Aggregator
-	d          [kv.DomainLen]*DomainRoTx
-	logAddrs   *InvertedIndexRoTx
-	logTopics  *InvertedIndexRoTx
-	tracesFrom *InvertedIndexRoTx
-	tracesTo   *InvertedIndexRoTx
+	a   *Aggregator
+	d   [kv.DomainLen]*DomainRoTx
+	iis [kv.StandaloneIdxLen]*InvertedIndexRoTx
 
 	id      uint64 // auto-increment id of ctx for logs
 	_leakID uint64 // set only if TRACE_AGG=true
@@ -1770,10 +1726,9 @@ func (a *Aggregator) BeginFilesRo() *AggregatorRoTx {
 	}
 
 	a.visibleFilesLock.RLock()
-	ac.logAddrs = a.logAddrs.BeginFilesRo()
-	ac.logTopics = a.logTopics.BeginFilesRo()
-	ac.tracesFrom = a.tracesFrom.BeginFilesRo()
-	ac.tracesTo = a.tracesTo.BeginFilesRo()
+	for id, ii := range a.iis {
+		ac.iis[id] = ii.BeginFilesRo()
+	}
 	for id, d := range a.d {
 		ac.d[id] = d.BeginFilesRo()
 	}
@@ -1843,22 +1798,22 @@ func (ac *AggregatorRoTx) DebugEFAllValuesAreInRange(ctx context.Context, name k
 	//		return err
 	//	}
 	case kv.TracesFromIdx:
-		err := ac.tracesFrom.DebugEFAllValuesAreInRange(ctx)
+		err := ac.iis[kv.TracesFromIdxPos].DebugEFAllValuesAreInRange(ctx)
 		if err != nil {
 			return err
 		}
 	case kv.TracesToIdx:
-		err := ac.tracesTo.DebugEFAllValuesAreInRange(ctx)
+		err := ac.iis[kv.TracesToIdxPos].DebugEFAllValuesAreInRange(ctx)
 		if err != nil {
 			return err
 		}
 	case kv.LogAddrIdx:
-		err := ac.logAddrs.DebugEFAllValuesAreInRange(ctx)
+		err := ac.iis[kv.LogAddrIdxPos].DebugEFAllValuesAreInRange(ctx)
 		if err != nil {
 			return err
 		}
 	case kv.LogTopicIdx:
-		err := ac.logTopics.DebugEFAllValuesAreInRange(ctx)
+		err := ac.iis[kv.LogTopicIdxPos].DebugEFAllValuesAreInRange(ctx)
 		if err != nil {
 			return err
 		}
@@ -1882,10 +1837,9 @@ func (ac *AggregatorRoTx) Close() {
 			d.Close()
 		}
 	}
-	ac.logAddrs.Close()
-	ac.logTopics.Close()
-	ac.tracesFrom.Close()
-	ac.tracesTo.Close()
+	for _, ii := range ac.iis {
+		ii.Close()
+	}
 }
 
 // BackgroundResult - used only indicate that some work is done

--- a/erigon-lib/state/aggregator_files.go
+++ b/erigon-lib/state/aggregator_files.go
@@ -25,28 +25,28 @@ import (
 	"github.com/ledgerwatch/erigon-lib/kv"
 )
 
+type filesItemI struct {
+	fi []*filesItem
+	i  int
+}
+
 type SelectedStaticFilesV3 struct {
-	d           [kv.DomainLen][]*filesItem
-	dHist       [kv.DomainLen][]*filesItem
-	dIdx        [kv.DomainLen][]*filesItem
-	logTopics   []*filesItem
-	tracesTo    []*filesItem
-	tracesFrom  []*filesItem
-	logAddrs    []*filesItem
-	dI          [kv.DomainLen]int
-	logAddrsI   int
-	logTopicsI  int
-	tracesFromI int
-	tracesToI   int
+	d     [kv.DomainLen][]*filesItem
+	dHist [kv.DomainLen][]*filesItem
+	dIdx  [kv.DomainLen][]*filesItem
+	dI    [kv.DomainLen]int
+	ii    [kv.StandaloneIdxLen]*filesItemI
 }
 
 func (sf SelectedStaticFilesV3) Close() {
-	clist := make([][]*filesItem, 0, kv.DomainLen+4)
+	clist := make([][]*filesItem, 0, uint16(kv.DomainLen)+kv.StandaloneIdxLen)
 	for id := range sf.d {
 		clist = append(clist, sf.d[id], sf.dIdx[id], sf.dHist[id])
 	}
 
-	clist = append(clist, sf.logAddrs, sf.logTopics, sf.tracesFrom, sf.tracesTo)
+	for _, i := range sf.ii {
+		clist = append(clist, i.fi)
+	}
 	for _, group := range clist {
 		for _, item := range group {
 			if item != nil {
@@ -67,29 +67,20 @@ func (ac *AggregatorRoTx) staticFilesInRange(r RangesV3) (sf SelectedStaticFiles
 			sf.d[id], sf.dIdx[id], sf.dHist[id], sf.dI[id] = ac.d[id].staticFilesInRange(r.d[id])
 		}
 	}
-	if r.logAddrs {
-		sf.logAddrs, sf.logAddrsI = ac.logAddrs.staticFilesInRange(r.logAddrsStartTxNum, r.logAddrsEndTxNum)
-	}
-	if r.logTopics {
-		sf.logTopics, sf.logTopicsI = ac.logTopics.staticFilesInRange(r.logTopicsStartTxNum, r.logTopicsEndTxNum)
-	}
-	if r.tracesFrom {
-		sf.tracesFrom, sf.tracesFromI = ac.tracesFrom.staticFilesInRange(r.tracesFromStartTxNum, r.tracesFromEndTxNum)
-	}
-	if r.tracesTo {
-		sf.tracesTo, sf.tracesToI = ac.tracesTo.staticFilesInRange(r.tracesToStartTxNum, r.tracesToEndTxNum)
+	for id, rng := range r.ranges {
+		if rng != nil && rng.needMerge {
+			fi, i := ac.iis[id].staticFilesInRange(rng.from, rng.to)
+			sf.ii[id] = &filesItemI{fi, i}
+		}
 	}
 	return sf, err
 }
 
 type MergedFilesV3 struct {
-	d          [kv.DomainLen]*filesItem
-	dHist      [kv.DomainLen]*filesItem
-	dIdx       [kv.DomainLen]*filesItem
-	logAddrs   *filesItem
-	logTopics  *filesItem
-	tracesFrom *filesItem
-	tracesTo   *filesItem
+	d     [kv.DomainLen]*filesItem
+	dHist [kv.DomainLen]*filesItem
+	dIdx  [kv.DomainLen]*filesItem
+	iis   [kv.StandaloneIdxLen]*filesItem
 }
 
 func (mf MergedFilesV3) FrozenList() (frozen []string) {
@@ -107,17 +98,10 @@ func (mf MergedFilesV3) FrozenList() (frozen []string) {
 		}
 	}
 
-	if mf.logAddrs != nil && mf.logAddrs.frozen {
-		frozen = append(frozen, mf.logAddrs.decompressor.FileName())
-	}
-	if mf.logTopics != nil && mf.logTopics.frozen {
-		frozen = append(frozen, mf.logTopics.decompressor.FileName())
-	}
-	if mf.tracesFrom != nil && mf.tracesFrom.frozen {
-		frozen = append(frozen, mf.tracesFrom.decompressor.FileName())
-	}
-	if mf.tracesTo != nil && mf.tracesTo.frozen {
-		frozen = append(frozen, mf.tracesTo.decompressor.FileName())
+	for _, ii := range mf.iis {
+		if ii != nil && ii.frozen {
+			frozen = append(frozen, ii.decompressor.FileName())
+		}
 	}
 	return frozen
 }
@@ -126,7 +110,7 @@ func (mf MergedFilesV3) Close() {
 	for id := range mf.d {
 		clist = append(clist, mf.d[id], mf.dHist[id], mf.dIdx[id])
 	}
-	clist = append(clist, mf.logAddrs, mf.logTopics, mf.tracesFrom, mf.tracesTo)
+	clist = append(clist, mf.iis[:]...)
 
 	for _, item := range clist {
 		if item != nil {

--- a/erigon-lib/state/inverted_index.go
+++ b/erigon-lib/state/inverted_index.go
@@ -487,6 +487,16 @@ func (iit *InvertedIndexRoTx) Close() {
 	}
 }
 
+type MergeRange struct {
+	needMerge bool
+	from      uint64
+	to        uint64
+}
+
+func (mr *MergeRange) String(prefix string, aggStep uint64) string {
+	return fmt.Sprintf("%s=%d-%d", prefix, mr.from/aggStep, mr.to/aggStep)
+}
+
 type InvertedIndexRoTx struct {
 	ii      *InvertedIndex
 	files   []ctxItem // have no garbage (overlaps, etc...)

--- a/erigon-lib/state/inverted_index_test.go
+++ b/erigon-lib/state/inverted_index_test.go
@@ -385,7 +385,8 @@ func mergeInverted(tb testing.TB, db kv.RwDB, ii *InvertedIndex, txs uint64) {
 				if stop := func() bool {
 					ic := ii.BeginFilesRo()
 					defer ic.Close()
-					found, startTxNum, endTxNum = ic.findMergeRange(maxEndTxNum, maxSpan)
+					mr := ic.findMergeRange(maxEndTxNum, maxSpan)
+					found, startTxNum, endTxNum = mr.needMerge, mr.from, mr.to
 					if !found {
 						return true
 					}

--- a/erigon-lib/state/merge.go
+++ b/erigon-lib/state/merge.go
@@ -186,7 +186,8 @@ func (dt *DomainRoTx) findMergeRange(maxEndTxNum, maxSpan uint64) DomainRanges {
 
 func (ht *HistoryRoTx) findMergeRange(maxEndTxNum, maxSpan uint64) HistoryRanges {
 	var r HistoryRanges
-	r.index, r.indexStartTxNum, r.indexEndTxNum = ht.iit.findMergeRange(maxEndTxNum, maxSpan)
+	mr := ht.iit.findMergeRange(maxEndTxNum, maxSpan)
+	r.index, r.indexStartTxNum, r.indexEndTxNum = mr.needMerge, mr.from, mr.to
 	for _, item := range ht.files {
 		if item.endTxNum > maxEndTxNum {
 			continue
@@ -233,7 +234,7 @@ func (ht *HistoryRoTx) findMergeRange(maxEndTxNum, maxSpan uint64) HistoryRanges
 // 0-1,1-2,2-3: allow merge 0-2
 //
 // 0-2,2-3: nothing to merge
-func (iit *InvertedIndexRoTx) findMergeRange(maxEndTxNum, maxSpan uint64) (bool, uint64, uint64) {
+func (iit *InvertedIndexRoTx) findMergeRange(maxEndTxNum, maxSpan uint64) *MergeRange {
 	var minFound bool
 	var startTxNum, endTxNum uint64
 	for _, item := range iit.files {
@@ -257,7 +258,7 @@ func (iit *InvertedIndexRoTx) findMergeRange(maxEndTxNum, maxSpan uint64) (bool,
 			}
 		}
 	}
-	return minFound, startTxNum, endTxNum
+	return &MergeRange{minFound, startTxNum, endTxNum}
 }
 
 type HistoryRanges struct {

--- a/erigon-lib/state/merge_test.go
+++ b/erigon-lib/state/merge_test.go
@@ -39,12 +39,12 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 		ic := ii.BeginFilesRo()
 		defer ic.Close()
 
-		needMerge, from, to := ic.findMergeRange(4, 32)
-		assert.True(t, needMerge)
-		assert.Equal(t, 0, int(from))
-		assert.Equal(t, 4, int(to))
+		mr := ic.findMergeRange(4, 32)
+		assert.True(t, mr.needMerge)
+		assert.Equal(t, 0, int(mr.from))
+		assert.Equal(t, 4, int(mr.to))
 
-		idxF, _ := ic.staticFilesInRange(from, to)
+		idxF, _ := ic.staticFilesInRange(mr.from, mr.to)
 		assert.Equal(t, 3, len(idxF))
 
 		ii = emptyTestInvertedIndex(1)
@@ -63,10 +63,10 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 		ic = ii.BeginFilesRo()
 		defer ic.Close()
 
-		needMerge, from, to = ic.findMergeRange(4, 32)
-		assert.True(t, needMerge)
-		assert.Equal(t, 0, int(from))
-		assert.Equal(t, 2, int(to))
+		mr = ic.findMergeRange(4, 32)
+		assert.True(t, mr.needMerge)
+		assert.Equal(t, 0, int(mr.from))
+		assert.Equal(t, 2, int(mr.to))
 
 		h := &History{InvertedIndex: ii, dirtyFiles: btree2.NewBTreeG[*filesItem](filesItemLess)}
 		h.scanStateFiles([]string{
@@ -414,11 +414,11 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 		ii.reCalcVisibleFiles()
 		ic := ii.BeginFilesRo()
 		defer ic.Close()
-		needMerge, from, to := ic.findMergeRange(4, 32)
-		assert.True(t, needMerge)
-		require.Equal(t, 0, int(from))
-		require.Equal(t, 4, int(to))
-		idxFiles, _ := ic.staticFilesInRange(from, to)
+		mr := ic.findMergeRange(4, 32)
+		assert.True(t, mr.needMerge)
+		require.Equal(t, 0, int(mr.from))
+		require.Equal(t, 4, int(mr.to))
+		idxFiles, _ := ic.staticFilesInRange(mr.from, mr.to)
 		require.Equal(t, 3, len(idxFiles))
 	})
 }


### PR DESCRIPTION
This is a 1 of N refactoring, I think there is room to improve the code even more, but this PR is already big, so for now just removing duplicated code and grouping some abstractions.

This PR does NOT change any code semantics.

- Remove lots of duplicated code.
- Makes the internal management of the inverted indexes which are not associated with domains more like how domains are arranged.
- Main driver here is to make the code easier to add more inverted indexes, the current code requires touching a lot of places and encourage copy/pasting and repeating code.