### PR TITLE
E3: Fixed import cmd and made Hive tests Runnable

### DIFF
--- a/cmd/state/exec3/state.go
+++ b/cmd/state/exec3/state.go
@@ -177,7 +177,7 @@ func (rw *Worker) RunTxTaskNoLock(txTask *state.TxTask) {
 	switch {
 	case txTask.TxIndex == -1:
 		if txTask.BlockNum == 0 {
-			// Genesis block
+
 			//fmt.Printf("txNum=%d, blockNum=%d, Genesis\n", txTask.TxNum, txTask.BlockNum)
 			_, ibs, err = core.GenesisToBlock(rw.genesis, rw.dirs.Tmp, rw.logger)
 			if err != nil {

--- a/core/genesis_write.go
+++ b/core/genesis_write.go
@@ -86,6 +86,10 @@ func CommitGenesisBlockWithOverride(db kv.RwDB, genesis *types.Genesis, override
 }
 
 func WriteGenesisBlock(tx kv.RwTx, genesis *types.Genesis, overridePragueTime *big.Int, tmpDir string, logger log.Logger) (*chain.Config, *types.Block, error) {
+	if err := rawdb.WriteGenesis(tx, genesis); err != nil {
+		return nil, nil, err
+	}
+	
 	var storedBlock *types.Block
 	if genesis != nil && genesis.Config == nil {
 		return params.AllProtocolChanges, nil, types.ErrGenesisNoConfig

--- a/core/genesis_write.go
+++ b/core/genesis_write.go
@@ -89,7 +89,7 @@ func WriteGenesisBlock(tx kv.RwTx, genesis *types.Genesis, overridePragueTime *b
 	if err := rawdb.WriteGenesis(tx, genesis); err != nil {
 		return nil, nil, err
 	}
-	
+
 	var storedBlock *types.Block
 	if genesis != nil && genesis.Config == nil {
 		return params.AllProtocolChanges, nil, types.ErrGenesisNoConfig

--- a/core/rawdb/accessors_metadata.go
+++ b/core/rawdb/accessors_metadata.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/polygon/bor/borcfg"
 
 	"github.com/ledgerwatch/erigon-lib/chain"
@@ -81,4 +82,28 @@ func WriteChainConfig(db kv.Putter, hash libcommon.Hash, cfg *chain.Config) erro
 // DeleteChainConfig retrieves the consensus settings based on the given genesis hash.
 func DeleteChainConfig(db kv.Deleter, hash libcommon.Hash) error {
 	return db.Delete(kv.ConfigTable, hash[:])
+}
+
+func WriteGenesis(db kv.Putter, g *types.Genesis) error {
+	// Marshal json g
+	val, err := json.Marshal(g)
+	if err != nil {
+		return err
+	}
+	return db.Put(kv.ConfigTable, kv.GenesisKey, val)
+}
+
+func ReadGenesis(db kv.Getter) (*types.Genesis, error) {
+	val, err := db.GetOne(kv.ConfigTable, kv.GenesisKey)
+	if err != nil {
+		return nil, err
+	}
+	if len(val) == 0 {
+		return nil, nil
+	}
+	var g types.Genesis
+	if err := json.Unmarshal(val, &g); err != nil {
+		return nil, err
+	}
+	return &g, nil
 }

--- a/erigon-lib/kv/tables.go
+++ b/erigon-lib/kv/tables.go
@@ -532,6 +532,7 @@ var (
 	PruneBlocksType     = []byte("pruneBlocksType")
 
 	DBSchemaVersionKey = []byte("dbVersion")
+	GenesisKey         = []byte("genesis")
 
 	BittorrentPeerID            = "peerID"
 	CurrentHeadersSnapshotHash  = []byte("CurrentHeadersSnapshotHash")

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -290,6 +290,14 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 	var chainConfig *chain.Config
 	var genesis *types.Block
 	if err := backend.chainDB.Update(context.Background(), func(tx kv.RwTx) error {
+		genesisConfig, err := rawdb.ReadGenesis(tx)
+		if err != nil {
+			return err
+		}
+		if config.Genesis == nil {
+			config.Genesis = genesisConfig
+		}
+
 		h, err := rawdb.ReadCanonicalHash(tx, 0)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
E3 needs the genesis for the first block, so we save the genesis config to the database during the chain import and then if we could not recover it, check the DB.