### PR TITLE
Caplin: configurable checkpoint sync url

### DIFF
--- a/cl/clparams/config.go
+++ b/cl/clparams/config.go
@@ -1043,7 +1043,7 @@ func GetCheckpointSyncEndpoint(net NetworkType) string {
 		if len(checkpoints) == 1 {
 			return checkpoints[0]
 		}
-		n, err := rand.Int(rand.Reader, big.NewInt(int64(len(checkpoints)-1)))
+		n, err := rand.Int(rand.Reader, big.NewInt(int64(len(checkpoints))))
 		if err != nil {
 			panic(err)
 		}

--- a/cl/clparams/config.go
+++ b/cl/clparams/config.go
@@ -1044,13 +1044,15 @@ func GetAllCheckpointSyncEndpoints(net NetworkType) []string {
 		if len(urls) <= 1 {
 			return urls
 		}
-		ret := make([]string, len(urls))
+		retUrls := make([]string, len(urls))
 		perm := mathrand.Perm(len(urls))
 		for i, v := range perm {
-			ret[v] = urls[i]
+			retUrls[v] = urls[i]
 		}
-		return ret
+		return retUrls
 	}
+	// shuffle the list of URLs to avoid always using the same one
+	// order: custom URLs -> default URLs
 	urls := []string{}
 	urls = append(urls, shuffle(ConfigurableCheckpointsURLs)...)
 	if checkpoints, ok := CheckpointSyncEndpoints[net]; ok {

--- a/cl/clparams/config.go
+++ b/cl/clparams/config.go
@@ -1055,6 +1055,9 @@ func GetAllCheckpointSyncEndpoints(net NetworkType) []string {
 	// order: custom URLs -> default URLs
 	urls := []string{}
 	urls = append(urls, shuffle(ConfigurableCheckpointsURLs)...)
+	if len(ConfigurableCheckpointsURLs) > 0 {
+		return urls
+	}
 	if checkpoints, ok := CheckpointSyncEndpoints[net]; ok {
 		urls = append(urls, shuffle(checkpoints)...)
 	}

--- a/cl/clparams/config.go
+++ b/cl/clparams/config.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	mathrand "math/rand"
 	"os"
 	"path"
 	"time"
@@ -1036,6 +1037,26 @@ func GetConfigsByNetworkName(net string) (*NetworkConfig, *BeaconChainConfig, Ne
 	default:
 		return nil, nil, MainnetNetwork, fmt.Errorf("chain not found")
 	}
+}
+
+func GetAllCheckpointSyncEndpoints(net NetworkType) []string {
+	shuffle := func(urls []string) []string {
+		if len(urls) <= 1 {
+			return urls
+		}
+		ret := make([]string, len(urls))
+		perm := mathrand.Perm(len(urls))
+		for i, v := range perm {
+			ret[v] = urls[i]
+		}
+		return ret
+	}
+	urls := []string{}
+	urls = append(urls, shuffle(ConfigurableCheckpointsURLs)...)
+	if checkpoints, ok := CheckpointSyncEndpoints[net]; ok {
+		urls = append(urls, shuffle(checkpoints)...)
+	}
+	return urls
 }
 
 func GetCheckpointSyncEndpoint(net NetworkType) string {

--- a/cl/phase1/core/checkpoint.go
+++ b/cl/phase1/core/checkpoint.go
@@ -22,7 +22,9 @@ func extractSlotFromSerializedBeaconState(beaconState []byte) (uint64, error) {
 	return binary.LittleEndian.Uint64(beaconState[40:48]), nil
 }
 
-func RetrieveBeaconState(ctx context.Context, beaconConfig *clparams.BeaconChainConfig, uris []string) (*state.CachingBeaconState, error) {
+func RetrieveBeaconState(ctx context.Context, beaconConfig *clparams.BeaconChainConfig, net clparams.NetworkType) (*state.CachingBeaconState, error) {
+	uris := clparams.GetAllCheckpointSyncEndpoints(net)
+
 	fetchBeaconState := func(uri string) (*state.CachingBeaconState, error) {
 		log.Info("[Checkpoint Sync] Requesting beacon state", "uri", uri)
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)

--- a/cl/phase1/core/checkpoint.go
+++ b/cl/phase1/core/checkpoint.go
@@ -22,43 +22,57 @@ func extractSlotFromSerializedBeaconState(beaconState []byte) (uint64, error) {
 	return binary.LittleEndian.Uint64(beaconState[40:48]), nil
 }
 
-func RetrieveBeaconState(ctx context.Context, beaconConfig *clparams.BeaconChainConfig, uri string) (*state.CachingBeaconState, error) {
-	log.Info("[Checkpoint Sync] Requesting beacon state", "uri", uri)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
-	if err != nil {
-		return nil, err
+func RetrieveBeaconState(ctx context.Context, beaconConfig *clparams.BeaconChainConfig, uris []string) (*state.CachingBeaconState, error) {
+	fetchBeaconState := func(uri string) (*state.CachingBeaconState, error) {
+		log.Info("[Checkpoint Sync] Requesting beacon state", "uri", uri)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		req.Header.Set("Accept", "application/octet-stream")
+		if err != nil {
+			return nil, fmt.Errorf("checkpoint sync request failed %s", err)
+		}
+		r, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		defer func() {
+			err = r.Body.Close()
+		}()
+		if r.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("checkpoint sync failed, bad status code %d", r.StatusCode)
+		}
+		marshaled, err := io.ReadAll(r.Body)
+		if err != nil {
+			return nil, fmt.Errorf("checkpoint sync read failed %s", err)
+		}
+
+		epoch, err := extractSlotFromSerializedBeaconState(marshaled)
+		if err != nil {
+			return nil, fmt.Errorf("checkpoint sync read failed %s", err)
+		}
+
+		beaconState := state.New(beaconConfig)
+		err = beaconState.DecodeSSZ(marshaled, int(beaconConfig.GetCurrentStateVersion(epoch)))
+		if err != nil {
+			return nil, fmt.Errorf("checkpoint sync decode failed %s", err)
+		}
+		return beaconState, nil
 	}
 
-	req.Header.Set("Accept", "application/octet-stream")
-	if err != nil {
-		return nil, fmt.Errorf("checkpoint sync request failed %s", err)
+	// Try all uris until one succeeds
+	var err error
+	var beaconState *state.CachingBeaconState
+	for _, uri := range uris {
+		beaconState, err = fetchBeaconState(uri)
+		if err == nil {
+			return beaconState, nil
+		}
+		log.Warn("[Checkpoint Sync] Failed to fetch beacon state", "uri", uri, "err", err)
 	}
-	r, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		err = r.Body.Close()
-	}()
-	if r.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("checkpoint sync failed, bad status code %d", r.StatusCode)
-	}
-	marshaled, err := io.ReadAll(r.Body)
-	if err != nil {
-		return nil, fmt.Errorf("checkpoint sync read failed %s", err)
-	}
-
-	epoch, err := extractSlotFromSerializedBeaconState(marshaled)
-	if err != nil {
-		return nil, fmt.Errorf("checkpoint sync read failed %s", err)
-	}
-
-	beaconState := state.New(beaconConfig)
-	err = beaconState.DecodeSSZ(marshaled, int(beaconConfig.GetCurrentStateVersion(epoch)))
-	if err != nil {
-		return nil, fmt.Errorf("checkpoint sync decode failed %s", err)
-	}
-	return beaconState, nil
+	return nil, err
 }
 
 func RetrieveBlock(ctx context.Context, beaconConfig *clparams.BeaconChainConfig, uri string, expectedBlockRoot *libcommon.Hash) (*cltypes.SignedBeaconBlock, error) {

--- a/cl/phase1/core/checkpoint.go
+++ b/cl/phase1/core/checkpoint.go
@@ -24,6 +24,9 @@ func extractSlotFromSerializedBeaconState(beaconState []byte) (uint64, error) {
 
 func RetrieveBeaconState(ctx context.Context, beaconConfig *clparams.BeaconChainConfig, net clparams.NetworkType) (*state.CachingBeaconState, error) {
 	uris := clparams.GetAllCheckpointSyncEndpoints(net)
+	if len(uris) == 0 {
+		return nil, fmt.Errorf("no uris for checkpoint sync")
+	}
 
 	fetchBeaconState := func(uri string) (*state.CachingBeaconState, error) {
 		log.Info("[Checkpoint Sync] Requesting beacon state", "uri", uri)

--- a/cmd/capcli/cli.go
+++ b/cmd/capcli/cli.go
@@ -127,7 +127,7 @@ func (c *Chain) Run(ctx *Context) error {
 	dirs := datadir.New(c.Datadir)
 
 	csn := freezeblocks.NewCaplinSnapshots(ethconfig.BlocksFreezing{}, beaconConfig, dirs, log.Root())
-	bs, err := core.RetrieveBeaconState(ctx, beaconConfig, clparams.GetCheckpointSyncEndpoint(networkType))
+	bs, err := core.RetrieveBeaconState(ctx, beaconConfig, clparams.GetAllCheckpointSyncEndpoints(networkType))
 	if err != nil {
 		return err
 	}
@@ -177,7 +177,7 @@ func (c *ChainEndpoint) Run(ctx *Context) error {
 		return err
 	}
 	log.Root().SetHandler(log.LvlFilterHandler(log.LvlInfo, log.StderrHandler))
-	bs, err := core.RetrieveBeaconState(ctx, beaconConfig, clparams.GetCheckpointSyncEndpoint(ntype))
+	bs, err := core.RetrieveBeaconState(ctx, beaconConfig, clparams.GetAllCheckpointSyncEndpoints(ntype))
 	if err != nil {
 		return err
 	}

--- a/cmd/capcli/cli.go
+++ b/cmd/capcli/cli.go
@@ -127,7 +127,7 @@ func (c *Chain) Run(ctx *Context) error {
 	dirs := datadir.New(c.Datadir)
 
 	csn := freezeblocks.NewCaplinSnapshots(ethconfig.BlocksFreezing{}, beaconConfig, dirs, log.Root())
-	bs, err := core.RetrieveBeaconState(ctx, beaconConfig, clparams.GetAllCheckpointSyncEndpoints(networkType))
+	bs, err := core.RetrieveBeaconState(ctx, beaconConfig, networkType)
 	if err != nil {
 		return err
 	}
@@ -177,7 +177,7 @@ func (c *ChainEndpoint) Run(ctx *Context) error {
 		return err
 	}
 	log.Root().SetHandler(log.LvlFilterHandler(log.LvlInfo, log.StderrHandler))
-	bs, err := core.RetrieveBeaconState(ctx, beaconConfig, clparams.GetAllCheckpointSyncEndpoints(ntype))
+	bs, err := core.RetrieveBeaconState(ctx, beaconConfig, ntype)
 	if err != nil {
 		return err
 	}

--- a/cmd/caplin/caplincli/config.go
+++ b/cmd/caplin/caplincli/config.go
@@ -21,7 +21,6 @@ import (
 type CaplinCliCfg struct {
 	*sentinelcli.SentinelCliCfg
 
-	CheckpointUri         string        `json:"checkpoint_uri"`
 	Chaindata             string        `json:"chaindata"`
 	ErigonPrivateApi      string        `json:"erigon_private_api"`
 	TransitionChain       bool          `json:"transition_chain"`
@@ -99,10 +98,8 @@ func SetupCaplinCli(ctx *cli.Context) (cfg *CaplinCliCfg, err error) {
 		}
 	}
 
-	if ctx.String(caplinflags.CheckpointSyncUrlFlag.Name) != "" {
-		cfg.CheckpointUri = ctx.String(caplinflags.CheckpointSyncUrlFlag.Name)
-	} else {
-		cfg.CheckpointUri = clparams.GetCheckpointSyncEndpoint(cfg.NetworkType)
+	if checkpointUrls := ctx.StringSlice(caplinflags.CheckpointSyncUrlFlag.Name); len(checkpointUrls) > 0 {
+		clparams.ConfigurableCheckpointsURLs = checkpointUrls
 	}
 
 	cfg.Chaindata = ctx.String(caplinflags.ChaindataFlag.Name)

--- a/cmd/caplin/caplincli/config.go
+++ b/cmd/caplin/caplincli/config.go
@@ -98,7 +98,7 @@ func SetupCaplinCli(ctx *cli.Context) (cfg *CaplinCliCfg, err error) {
 		}
 	}
 
-	if checkpointUrls := ctx.StringSlice(caplinflags.CheckpointSyncUrlFlag.Name); len(checkpointUrls) > 0 {
+	if checkpointUrls := ctx.StringSlice(utils.CaplinCheckpointSyncUrlFlag.Name); len(checkpointUrls) > 0 {
 		clparams.ConfigurableCheckpointsURLs = checkpointUrls
 	}
 

--- a/cmd/caplin/caplinflags/flags.go
+++ b/cmd/caplin/caplinflags/flags.go
@@ -13,7 +13,6 @@ var CliFlags = []cli.Flag{
 	&BeaconApiAddr,
 	&ChaindataFlag,
 	&BeaconDBModeFlag,
-	&CheckpointSyncUrlFlag,
 	&TransitionChainFlag,
 	&InitSyncFlag,
 	&RecordModeDir,
@@ -26,6 +25,7 @@ var CliFlags = []cli.Flag{
 	&utils.BeaconApiAllowCredentialsFlag,
 	&utils.BeaconApiAllowMethodsFlag,
 	&utils.BeaconApiAllowOriginsFlag,
+	&utils.CaplinCheckpointSyncUrlFlag,
 }
 
 var (
@@ -63,11 +63,6 @@ var (
 		Name:  "beacon-db-mode",
 		Usage: "level of storing on beacon chain, minimal(only 500k blocks stored), full (all blocks stored), light (no blocks stored)",
 		Value: "full",
-	}
-	CheckpointSyncUrlFlag = cli.StringSliceFlag{
-		Name:  "checkpoint-sync-url",
-		Usage: "checkpoint sync endpoint",
-		Value: cli.NewStringSlice(),
 	}
 	TransitionChainFlag = cli.BoolFlag{
 		Name:  "transition-chain",

--- a/cmd/caplin/caplinflags/flags.go
+++ b/cmd/caplin/caplinflags/flags.go
@@ -64,10 +64,10 @@ var (
 		Usage: "level of storing on beacon chain, minimal(only 500k blocks stored), full (all blocks stored), light (no blocks stored)",
 		Value: "full",
 	}
-	CheckpointSyncUrlFlag = cli.StringFlag{
+	CheckpointSyncUrlFlag = cli.StringSliceFlag{
 		Name:  "checkpoint-sync-url",
 		Usage: "checkpoint sync endpoint",
-		Value: "",
+		Value: cli.NewStringSlice(),
 	}
 	TransitionChainFlag = cli.BoolFlag{
 		Name:  "transition-chain",

--- a/cmd/caplin/main.go
+++ b/cmd/caplin/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ledgerwatch/erigon-lib/common/disk"
 	"github.com/ledgerwatch/erigon-lib/common/mem"
 	"github.com/ledgerwatch/erigon/cl/beacon/beacon_router_configuration"
+	"github.com/ledgerwatch/erigon/cl/clparams"
 	"github.com/ledgerwatch/erigon/cl/phase1/core"
 	"github.com/ledgerwatch/erigon/cl/phase1/core/state"
 	execution_client2 "github.com/ledgerwatch/erigon/cl/phase1/execution_client"
@@ -86,7 +87,7 @@ func runCaplinNode(cliCtx *cli.Context) error {
 	if cfg.InitialSync {
 		state = cfg.InitalState
 	} else {
-		state, err = core.RetrieveBeaconState(ctx, cfg.BeaconCfg, cfg.CheckpointUri)
+		state, err = core.RetrieveBeaconState(ctx, cfg.BeaconCfg, clparams.GetCheckpointSyncEndpoint(cfg.NetworkType))
 		if err != nil {
 			return err
 		}

--- a/cmd/caplin/main.go
+++ b/cmd/caplin/main.go
@@ -87,7 +87,7 @@ func runCaplinNode(cliCtx *cli.Context) error {
 	if cfg.InitialSync {
 		state = cfg.InitalState
 	} else {
-		state, err = core.RetrieveBeaconState(ctx, cfg.BeaconCfg, clparams.GetCheckpointSyncEndpoint(cfg.NetworkType))
+		state, err = core.RetrieveBeaconState(ctx, cfg.BeaconCfg, clparams.GetAllCheckpointSyncEndpoints(cfg.NetworkType))
 		if err != nil {
 			return err
 		}

--- a/cmd/caplin/main.go
+++ b/cmd/caplin/main.go
@@ -20,7 +20,6 @@ import (
 	"github.com/ledgerwatch/erigon-lib/common/disk"
 	"github.com/ledgerwatch/erigon-lib/common/mem"
 	"github.com/ledgerwatch/erigon/cl/beacon/beacon_router_configuration"
-	"github.com/ledgerwatch/erigon/cl/clparams"
 	"github.com/ledgerwatch/erigon/cl/phase1/core"
 	"github.com/ledgerwatch/erigon/cl/phase1/core/state"
 	execution_client2 "github.com/ledgerwatch/erigon/cl/phase1/execution_client"
@@ -87,7 +86,7 @@ func runCaplinNode(cliCtx *cli.Context) error {
 	if cfg.InitialSync {
 		state = cfg.InitalState
 	} else {
-		state, err = core.RetrieveBeaconState(ctx, cfg.BeaconCfg, clparams.GetAllCheckpointSyncEndpoints(cfg.NetworkType))
+		state, err = core.RetrieveBeaconState(ctx, cfg.BeaconCfg, cfg.NetworkType)
 		if err != nil {
 			return err
 		}

--- a/cmd/sentinel/main.go
+++ b/cmd/sentinel/main.go
@@ -55,7 +55,7 @@ func runSentinelNode(cliCtx *cli.Context) error {
 	go mem.LogMemStats(cliCtx.Context, log.Root())
 	go disk.UpdateDiskStats(cliCtx.Context, log.Root())
 
-	bs, err := core.RetrieveBeaconState(context.Background(), cfg.BeaconCfg, clparams.GetCheckpointSyncEndpoint(cfg.NetworkType))
+	bs, err := core.RetrieveBeaconState(context.Background(), cfg.BeaconCfg, clparams.GetAllCheckpointSyncEndpoints(cfg.NetworkType))
 	if err != nil {
 		return err
 	}

--- a/cmd/sentinel/main.go
+++ b/cmd/sentinel/main.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/ledgerwatch/erigon-lib/common/disk"
 	"github.com/ledgerwatch/erigon-lib/common/mem"
-	"github.com/ledgerwatch/erigon/cl/clparams"
 	"github.com/ledgerwatch/erigon/cl/phase1/core"
 	"github.com/ledgerwatch/erigon/cl/sentinel"
 	"github.com/ledgerwatch/erigon/cl/sentinel/service"
@@ -55,7 +54,7 @@ func runSentinelNode(cliCtx *cli.Context) error {
 	go mem.LogMemStats(cliCtx.Context, log.Root())
 	go disk.UpdateDiskStats(cliCtx.Context, log.Root())
 
-	bs, err := core.RetrieveBeaconState(context.Background(), cfg.BeaconCfg, clparams.GetAllCheckpointSyncEndpoints(cfg.NetworkType))
+	bs, err := core.RetrieveBeaconState(context.Background(), cfg.BeaconCfg, cfg.NetworkType)
 	if err != nil {
 		return err
 	}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -833,6 +833,11 @@ var (
 		Usage: "TCP Port for Caplin DISCV5 protocol",
 		Value: 4001,
 	}
+	CaplinCheckpointSyncUrlFlag = cli.StringSliceFlag{
+		Name:  "caplin.checkpoint-sync-url",
+		Usage: "checkpoint sync endpoint",
+		Value: cli.NewStringSlice(),
+	}
 
 	SentinelAddrFlag = cli.StringFlag{
 		Name:  "sentinel.addr",
@@ -1658,6 +1663,9 @@ func setCaplin(ctx *cli.Context, cfg *ethconfig.Config) {
 	cfg.CaplinConfig.BlobBackfilling = ctx.Bool(CaplinBlobBackfillingFlag.Name)
 	cfg.CaplinConfig.BlobPruningDisabled = ctx.Bool(CaplinDisableBlobPruningFlag.Name)
 	cfg.CaplinConfig.Archive = ctx.Bool(CaplinArchiveFlag.Name)
+	if checkpointUrls := ctx.StringSlice(CaplinCheckpointSyncUrlFlag.Name); len(checkpointUrls) > 0 {
+		clparams.ConfigurableCheckpointsURLs = checkpointUrls
+	}
 }
 
 func setSilkworm(ctx *cli.Context, cfg *ethconfig.Config) {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -939,8 +939,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 		if err != nil {
 			return nil, err
 		}
-		state, err := clcore.RetrieveBeaconState(ctx, beaconCfg,
-			clparams.GetAllCheckpointSyncEndpoints(clparams.NetworkType(config.NetworkID)))
+		state, err := clcore.RetrieveBeaconState(ctx, beaconCfg, clparams.NetworkType(config.NetworkID))
 		if err != nil {
 			return nil, err
 		}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -940,7 +940,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 			return nil, err
 		}
 		state, err := clcore.RetrieveBeaconState(ctx, beaconCfg,
-			clparams.GetCheckpointSyncEndpoint(clparams.NetworkType(config.NetworkID)))
+			clparams.GetAllCheckpointSyncEndpoints(clparams.NetworkType(config.NetworkID)))
 		if err != nil {
 			return nil, err
 		}

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -164,6 +164,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.CaplinDiscoveryAddrFlag,
 	&utils.CaplinDiscoveryPortFlag,
 	&utils.CaplinDiscoveryTCPPortFlag,
+	&utils.CaplinCheckpointSyncUrlFlag,
 	&utils.SentinelAddrFlag,
 	&utils.SentinelPortFlag,
 


### PR DESCRIPTION
- Multiple checkpoint sync urls configured via CLI flag is supported.
- Randomly choose url to try until request gets success
- Failover to default urls (if exist) once all configured urls are failed