### PR TITLE
e3 commitment history backpressure

### DIFF
--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -190,7 +190,7 @@ func NewAggregator(ctx context.Context, dirs datadir.Dirs, aggregationStep uint6
 	if err := a.registerII(kv.TracesToIdxPos, salt, dirs, db, aggregationStep, "tracesto", kv.TblTracesToKeys, kv.TblTracesToIdx, logger); err != nil {
 		return nil, err
 	}
-	a.KeepHistoryRecentTxInDB(aggregationStep)
+	a.KeepHistoryRecentTxInDB(aggregationStep / 2)
 	a.recalcVisibleFiles()
 
 	if dbg.NoSync() {
@@ -1040,6 +1040,7 @@ func (as *AggregatorPruneStat) Accumulate(other *AggregatorPruneStat) {
 }
 
 func (ac *AggregatorRoTx) PruneCommitHistory(ctx context.Context, tx kv.RwTx, limitTxNums uint64, withWarmup bool, logEvery *time.Ticker) error {
+	return nil
 	defer mxPruneTookAgg.ObserveDuration(time.Now())
 
 	cd := ac.d[kv.CommitmentDomain]

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -1061,7 +1061,7 @@ func (ac *AggregatorRoTx) PruneCommitHistory(ctx context.Context, tx kv.RwTx, li
 	commitsInDB := 0
 	minTx, maxTx := uint64(math.MaxUint64), uint64(0)
 	for idxc.HasNext() {
-		_, txn, err := idxc.Next()
+		txn, err := idxc.Next()
 		if err != nil {
 			return err
 		}

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -190,7 +190,7 @@ func NewAggregator(ctx context.Context, dirs datadir.Dirs, aggregationStep uint6
 	if err := a.registerII(kv.TracesToIdxPos, salt, dirs, db, aggregationStep, "tracesto", kv.TblTracesToKeys, kv.TblTracesToIdx, logger); err != nil {
 		return nil, err
 	}
-	a.KeepStepsInDB(1)
+	a.KeepHistoryRecentTxInDB(aggregationStep)
 	a.recalcVisibleFiles()
 
 	if dbg.NoSync() {
@@ -1570,11 +1570,11 @@ func (a *Aggregator) cleanAfterMerge(in MergedFilesV3) {
 	}
 }
 
-// KeepStepsInDB - usually equal to one a.aggregationStep, but when we exec blocks from snapshots
+// KeepHistoryRecentTxInDB - usually equal to one a.aggregationStep, but when we exec blocks from snapshots
 // we can set it to 0, because no re-org on this blocks are possible
-func (a *Aggregator) KeepStepsInDB(steps uint64) *Aggregator {
-	a.keepInDB = a.FirstTxNumOfStep(steps)
-	a.logger.Warn("[snapshots] KeepStepsInDB", "steps", steps, "txn", a.keepInDB)
+func (a *Aggregator) KeepHistoryRecentTxInDB(recentTxs uint64) *Aggregator {
+	a.keepInDB = recentTxs
+	a.logger.Warn("[snapshots] KeepHistoryRecentTxInDB", "txn", a.keepInDB)
 	for _, d := range a.d {
 		if d == nil {
 			continue

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -1039,7 +1039,7 @@ func (as *AggregatorPruneStat) Accumulate(other *AggregatorPruneStat) {
 }
 
 // temporal function to prune history straight after commitment is done - reduce history size in db until we build
-// pruning in background
+// pruning in background. This helps on chain-tip performance (while full pruning is not available we can prune at least commit)
 func (ac *AggregatorRoTx) PruneCommitHistory(ctx context.Context, tx kv.RwTx, withWarmup bool, logEvery *time.Ticker) error {
 	cd := ac.d[kv.CommitmentDomain]
 	if cd.ht.h.historyDisabled {

--- a/erigon-lib/state/inverted_index.go
+++ b/erigon-lib/state/inverted_index.go
@@ -719,7 +719,7 @@ type InvertedIndexPruneStat struct {
 }
 
 func (is *InvertedIndexPruneStat) String() string {
-	if is.MinTxNum == math.MaxUint64 && is.PruneCountTx == 0 {
+	if is == nil || is.MinTxNum == math.MaxUint64 && is.PruneCountTx == 0 {
 		return ""
 	}
 	return fmt.Sprintf("ii %d txs and %d vals in %.2fM-%.2fM", is.PruneCountTx, is.PruneCountValues, float64(is.MinTxNum)/1_000_000.0, float64(is.MaxTxNum)/1_000_000.0)

--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -1056,10 +1056,7 @@ func flushAndCheckCommitmentV3(ctx context.Context, header *types.Header, applyT
 			if err := doms.Flush(ctx, applyTx); err != nil {
 				return false, err
 			}
-			aggTx := applyTx.(state2.HasAggTx).AggTx().(*state2.AggregatorRoTx)
-			commitsToPrune := uint64(1)
-
-			if err = aggTx.PruneCommitHistory(ctx, applyTx, false, nil); err != nil {
+			if err = applyTx.(state2.HasAggTx).AggTx().(*state2.AggregatorRoTx).PruneCommitHistory(ctx, applyTx, false, nil); err != nil {
 				return false, err
 			}
 		}

--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -563,7 +563,7 @@ func ExecV3(ctx context.Context,
 	}
 
 	if useExternalTx && blockNum < cfg.blockReader.FrozenBlocks() {
-		defer agg.KeepHistoryRecentTxInDB(0).KeepHistoryRecentTxInDB(agg.StepSize() - (agg.StepSize() / 4))
+		defer agg.KeepHistoryRecentTxInDB(0).KeepHistoryRecentTxInDB(agg.StepSize() / 2)
 	}
 
 	getHeaderFunc := func(hash common.Hash, number uint64) (h *types.Header) {

--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -1056,7 +1056,7 @@ func flushAndCheckCommitmentV3(ctx context.Context, header *types.Header, applyT
 			aggTx := applyTx.(state2.HasAggTx).AggTx().(*state2.AggregatorRoTx)
 			commitsToPrune := uint64(1)
 
-			if err = aggTx.PruneCommitHistory(ctx, applyTx, commitsToPrune, false, nil); err != nil {
+			if err = aggTx.PruneCommitHistory(ctx, applyTx, false, nil); err != nil {
 				return false, err
 			}
 		}

--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -563,7 +563,7 @@ func ExecV3(ctx context.Context,
 	}
 
 	if useExternalTx && blockNum < cfg.blockReader.FrozenBlocks() {
-		defer agg.KeepStepsInDB(0).KeepStepsInDB(1)
+		defer agg.KeepHistoryRecentTxInDB(0).KeepHistoryRecentTxInDB(agg.StepSize() - (agg.StepSize() / 4))
 	}
 
 	getHeaderFunc := func(hash common.Hash, number uint64) (h *types.Header) {

--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -290,7 +290,6 @@ func ExecV3(ctx context.Context,
 	}
 
 	blockNum = doms.BlockNum()
-	initialBlockNum := blockNum
 	outputTxNum.Store(doms.TxNum())
 	if maxBlockNum-blockNum > 16 {
 		log.Info(fmt.Sprintf("[%s] starting", execStage.LogPrefix()),

--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -766,7 +766,7 @@ func doRetireCommand(cliCtx *cli.Context) error {
 		return err
 	}
 
-	//agg.KeepStepsInDB(0)
+	//agg.KeepHistoryRecentTxInDB(0)
 
 	var forwardProgress uint64
 	if to == 0 {


### PR DESCRIPTION
temporal ability to prune commitment history after commitment happened. This decouples overall pruning and hist commitment pruning and helps reduce db size on chain tip. 
I allowed to prune half step right now.