### PR TITLE
protect files during commitment

### DIFF
--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -1415,6 +1415,12 @@ func (ac *AggregatorRoTx) SqueezeCommitmentFiles() error {
 	return nil
 }
 
+func (ac *AggregatorRoTx) RestrictSubsetFileDeletions(b bool) {
+	ac.a.d[kv.AccountsDomain].restrictSubsetFileDeletions = b
+	ac.a.d[kv.StorageDomain].restrictSubsetFileDeletions = b
+	ac.a.d[kv.CommitmentDomain].restrictSubsetFileDeletions = b
+}
+
 func (ac *AggregatorRoTx) mergeFiles(ctx context.Context, files SelectedStaticFilesV3, r RangesV3) (MergedFilesV3, error) {
 	var mf MergedFilesV3
 	g, ctx := errgroup.WithContext(ctx)
@@ -1441,10 +1447,7 @@ func (ac *AggregatorRoTx) mergeFiles(ctx context.Context, files SelectedStaticFi
 			g.Go(func() (err error) {
 				var vt valueTransformer
 				if ac.a.commitmentValuesTransform && kid == kv.CommitmentDomain {
-					ac.a.d[kv.AccountsDomain].restrictSubsetFileDeletions = true
-					ac.a.d[kv.StorageDomain].restrictSubsetFileDeletions = true
-					ac.a.d[kv.CommitmentDomain].restrictSubsetFileDeletions = true
-
+					ac.RestrictSubsetFileDeletions(true)
 					accStorageMerged.Wait()
 
 					vt = ac.d[kv.CommitmentDomain].commitmentValTransformDomain(ac.d[kv.AccountsDomain], ac.d[kv.StorageDomain],
@@ -1457,9 +1460,7 @@ func (ac *AggregatorRoTx) mergeFiles(ctx context.Context, files SelectedStaticFi
 						accStorageMerged.Done()
 					}
 					if err == nil && kid == kv.CommitmentDomain {
-						ac.a.d[kv.AccountsDomain].restrictSubsetFileDeletions = false
-						ac.a.d[kv.StorageDomain].restrictSubsetFileDeletions = false
-						ac.a.d[kv.CommitmentDomain].restrictSubsetFileDeletions = false
+						ac.RestrictSubsetFileDeletions(false)
 					}
 				}
 				return err

--- a/erigon-lib/state/domain_shared.go
+++ b/erigon-lib/state/domain_shared.go
@@ -311,7 +311,7 @@ func (sd *SharedDomains) LatestCommitment(prefix []byte) ([]byte, uint64, error)
 	}
 
 	if !sd.aggTx.a.commitmentValuesTransform || bytes.Equal(prefix, keyCommitmentState) {
-		return v, endTx, nil
+		return v, endTx / sd.aggTx.a.StepSize(), nil
 	}
 
 	// replace shortened keys in the branch with full keys to allow HPH work seamlessly

--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -1048,7 +1048,12 @@ func flushAndCheckCommitmentV3(ctx context.Context, header *types.Header, applyT
 	if doms.BlockNum() != header.Number.Uint64() {
 		panic(fmt.Errorf("%d != %d", doms.BlockNum(), header.Number.Uint64()))
 	}
+
+	aggTx := applyTx.(state2.HasAggTx).AggTx().(*state2.AggregatorRoTx)
+
+	aggTx.RestrictSubsetFileDeletions(true)
 	rh, err := doms.ComputeCommitment(ctx, true, header.Number.Uint64(), u.LogPrefix())
+	aggTx.RestrictSubsetFileDeletions(false)
 	if err != nil {
 		return false, fmt.Errorf("StateV3.Apply: %w", err)
 	}


### PR DESCRIPTION
Maybe it's time to introduce another lock file stored on disk protecting some ranges against their deletion. For now it's just in-memory boolean, which obviously could fault on restart. 

Storing such a lock in DB also doesn't cover corner case when DB empty/doesn't exist. 

This PR just sets in-mem lock during commitment evaluation (since merging is happening in background). 