### PR TITLE
mdbx: chaindata enable read-ahead by default

### DIFF
--- a/erigon-lib/kv/mdbx/kv_mdbx.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx.go
@@ -245,6 +245,10 @@ func (opts MdbxOpts) Open(ctx context.Context) (kv.RwDB, error) {
 	}
 	if dbg.MdbxReadAhead() {
 		opts = opts.Flags(func(u uint) uint { return u &^ mdbx.NoReadahead }) //nolint
+	} else {
+		if opts.label == kv.ChainDB {
+			opts = opts.Flags(func(u uint) uint { return u &^ mdbx.NoReadahead }) //nolint
+		}
 	}
 	if opts.flags&mdbx.Accede != 0 || opts.flags&mdbx.Readonly != 0 {
 		for retry := 0; ; retry++ {

--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -880,7 +880,7 @@ Loop:
 				pruneBlockMargin := uint64(100)
 
 				if blockNum-initialBlockNum > pruneBlockMargin {
-					if _, err := applyTx.(state2.HasAggTx).AggTx().(*state2.AggregatorRoTx).PruneSmallBatches(ctx, 10*time.Hour, applyTx); err != nil {
+					if _, err := applyTx.(state2.HasAggTx).AggTx().(*state2.AggregatorRoTx).PruneSmallBatches(ctx, 10*time.Minute, applyTx); err != nil {
 						return err
 					}
 				}

--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -880,7 +880,7 @@ Loop:
 				pruneBlockMargin := uint64(100)
 
 				if blockNum-initialBlockNum > pruneBlockMargin {
-					if _, err := applyTx.(state2.HasAggTx).AggTx().(*state2.AggregatorRoTx).PruneSmallBatches(ctx, 10*time.Minute, applyTx); err != nil {
+					if _, err := applyTx.(state2.HasAggTx).AggTx().(*state2.AggregatorRoTx).PruneSmallBatches(ctx, 10*time.Hour, applyTx); err != nil {
 						return err
 					}
 				}


### PR DESCRIPTION
- on any disks - it will allow remove `pagefault-amounts` bottleneck and focus on next bottlenecks (like some data is too big, or merge_threshold is too big, etc...)
- it will allow speedup flush and prune on slow disks
- it will increase IO (because db will evict .kv files from page-cache - depends on RAM size)
- it will improve cold-start problem
- on chain-tip - much higher chance that prune will get slow (because old data may be much colder there).

-----

- it also "make sense" because chaindb now is "very hot data"