### PR TITLE
Fixed Bor Log appearing on Ethereum Mainnet (#10405)

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1643,7 +1643,7 @@ func (s *Ethereum) DataDir() string {
 
 // setBorDefaultMinerGasPrice enforces Miner.GasPrice to be equal to BorDefaultMinerGasPrice (30gwei by default)
 func setBorDefaultMinerGasPrice(chainConfig *chain.Config, config *ethconfig.Config, logger log.Logger) {
-	if chainConfig.Bor != nil && config.Miner.GasPrice == nil || config.Miner.GasPrice.Cmp(ethconfig.BorDefaultMinerGasPrice) != 0 {
+	if chainConfig.Bor != nil && (config.Miner.GasPrice == nil || config.Miner.GasPrice.Cmp(ethconfig.BorDefaultMinerGasPrice) != 0) {
 		logger.Warn("Sanitizing invalid bor miner gas price", "provided", config.Miner.GasPrice, "updated", ethconfig.BorDefaultMinerGasPrice)
 		config.Miner.GasPrice = ethconfig.BorDefaultMinerGasPrice
 	}


### PR DESCRIPTION
Cherry-pick: https://github.com/ledgerwatch/erigon/commit/be889f6250ffc599e04438d263a0a6515471fd24