### PR TITLE
qa-tests: in sync-from-scratch use result file with chain in the name, add branch name

### DIFF
--- a/.github/workflows/qa-sync-from-scratch.yml
+++ b/.github/workflows/qa-sync-from-scratch.yml
@@ -81,7 +81,7 @@ jobs:
       if: steps.test_step.outputs.test_executed == 'true'
       env:
         TEST_RESULT: ${{ steps.test_step.outputs.TEST_RESULT }}
-      run: python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py --repo erigon --commit $(git rev-parse HEAD) --test_name sync-from-scratch --chain $CHAIN --outcome $TEST_RESULT --result_file ${{ github.workspace }}/result.json
+      run: python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py --repo erigon --commit $(git rev-parse HEAD) --branch ${{ github.ref_name }} --test_name sync-from-scratch --chain $CHAIN --outcome $TEST_RESULT --result_file ${{ github.workspace }}/result-$CHAIN.json
 
     - name: Upload test results
       if: steps.test_step.outputs.test_executed == 'true'


### PR DESCRIPTION
sync-from-scratch is now a workflow with multiple jobs each uploading a result file.
Those files need to have a unique name in the workflow.