### PR TITLE
Fill ommers hash in graphQL response

### DIFF
--- a/cmd/rpcdaemon/graphql/graph/schema.resolvers.go
+++ b/cmd/rpcdaemon/graphql/graph/schema.resolvers.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/common/hexutil"
 	"github.com/ledgerwatch/erigon/cmd/rpcdaemon/graphql/graph/model"
 	"github.com/ledgerwatch/erigon/core/types"
@@ -93,7 +94,6 @@ func (r *queryResolver) Block(ctx context.Context, number *string, hash *string)
 			block.Nonce = *blockNonce
 		}
 		block.Number = *convertDataToUint64P(blk, "number")
-		block.Ommers = []*model.Block{}
 		block.Parent = &model.Block{}
 		block.Parent.Hash = *convertDataToStringP(blk, "parentHash")
 		block.ReceiptsRoot = *convertDataToStringP(blk, "receiptsRoot")
@@ -108,6 +108,16 @@ func (r *queryResolver) Block(ctx context.Context, number *string, hash *string)
 		block.LogsBloom = "0x" + *convertDataToStringP(blk, "logsBloom")
 		block.OmmerHash = *convertDataToStringP(blk, "sha3Uncles")
 
+		// Ommers
+		block.Ommers = []*model.Block{}
+		for _, ommerHash := range blk["uncles"].([]common.Hash) {
+			block.Ommers = append(block.Ommers, &model.Block{Hash: ommerHash.String()})
+		}
+
+		ommerCount := len(block.Ommers)
+		block.OmmerCount = &ommerCount
+
+		// Transactions
 		absRcp := res["receipts"]
 		rcp := absRcp.([]map[string]interface{})
 		for _, transReceipt := range rcp {

--- a/cmd/rpcdaemon/graphql/graphql_test.go
+++ b/cmd/rpcdaemon/graphql/graphql_test.go
@@ -87,9 +87,14 @@ func TestGraphQLQueryBlock(t *testing.T) {
 		},
 		{ // Should return baseFeePerGas
 			body: `{"query": "{block{number,baseFeePerGas}}","variables": null}`,
-			want: `{"data":{"block":{"number":\d{8,},"baseFeePerGas":\w+}}`,
+			want: `{"data":{"block":{"number":\d{8,},"baseFeePerGas":"\w+"}}`,
 			code: 200,
 			comp: "regexp",
+		},
+		{ // Should return ommerHash, ommerCount and ommers
+			body: `{"query": "{block(number:15537381){ommerHash,ommerCount,ommers{hash}}}","variables": null}`,
+			want: `{"data":{"block":{"ommerHash":"0x22f29046fa689683c504ad6fd9a7a9d5803f8e6bb66de435438b563f586651fe","ommerCount":1,"ommers":[{"hash":"0xf4af15465ca81e65866c6e64cbc446b735a06fb2118dda69a7c21d4ab0b1e217"}]}}}`,
+			code: 200,
 		},
 		// should return `estimateGas` as decimal
 		/*

--- a/cmd/rpcdaemon/graphql/query_block.graphql
+++ b/cmd/rpcdaemon/graphql/query_block.graphql
@@ -8,6 +8,7 @@
     baseFeePerGas
     logsBloom
     ommerHash
+    ommerCount
     ommers {
       hash
     }


### PR DESCRIPTION
Currently ommers hash is not filled in graphQL response.
I need ommers hash for historical data and have to make an additional request to retrieve the block with its uncles.