### PR TITLE
BodyDownload: differentiate between empty vs nil withdrawals/requests

### DIFF
--- a/turbo/stages/bodydownload/body_algos.go
+++ b/turbo/stages/bodydownload/body_algos.go
@@ -172,13 +172,9 @@ func (bd *BodyDownload) RequestMoreBodies(tx kv.RwTx, blockReader services.FullB
 			copy(bodyHashes[length.Hash:], header.TxHash.Bytes())
 			if header.WithdrawalsHash != nil {
 				copy(bodyHashes[2*length.Hash:], header.WithdrawalsHash.Bytes())
-			} else {
-				copy(bodyHashes[2*length.Hash:], types.EmptyRootHash.Bytes())
 			}
 			if header.RequestsRoot != nil {
 				copy(bodyHashes[3*length.Hash:], header.RequestsRoot.Bytes())
-			} else {
-				copy(bodyHashes[3*length.Hash:], types.EmptyRootHash.Bytes())
 			}
 			bd.requestedMap[bodyHashes] = blockNum
 			blockNums = append(blockNums, blockNum)
@@ -312,15 +308,19 @@ Loop:
 		txs, uncles, withdrawals, requests, lenOfP2PMessage := delivery.txs, delivery.uncles, delivery.withdrawals, delivery.requests, delivery.lenOfP2PMessage
 
 		for i := range txs {
-			uncleHash := types.CalcUncleHash(uncles[i])
-			txHash := types.DeriveSha(RawTransactions(txs[i]))
-			withdrawalsHash := types.DeriveSha(withdrawals[i])
-			requestsRoot := types.DeriveSha(requests[i])
 			var bodyHashes BodyHashes
+			uncleHash := types.CalcUncleHash(uncles[i])
 			copy(bodyHashes[:], uncleHash.Bytes())
+			txHash := types.DeriveSha(RawTransactions(txs[i]))
 			copy(bodyHashes[length.Hash:], txHash.Bytes())
-			copy(bodyHashes[2*length.Hash:], withdrawalsHash.Bytes())
-			copy(bodyHashes[3*length.Hash:], requestsRoot.Bytes())
+			if withdrawals[i] != nil {
+				withdrawalsHash := types.DeriveSha(withdrawals[i])
+				copy(bodyHashes[2*length.Hash:], withdrawalsHash.Bytes())
+			}
+			if requests[i] != nil {
+				requestsRoot := types.DeriveSha(requests[i])
+				copy(bodyHashes[3*length.Hash:], requestsRoot.Bytes())
+			}
 
 			// Block numbers are added to the bd.delivered bitmap here, only for blocks for which the body has been received, and their double hashes are present in the bd.requestedMap
 			// Also, block numbers can be added to bd.delivered for empty blocks, above


### PR DESCRIPTION
With withdrawals we differentiate between missing (`nil`) and missing-but-empty cases. Pre-Shapella blocks should have no withdrawals (i.e. `nil`), while post-Shappela blocks must have withdrawals, even if empty. The same goes for [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) requests pre- and post-Pectra.

`BodyHashes` is used to map downloaded block bodies to corresponding headers. Prior to this change, it was possible to have a mismatch between block & header in terms of `nil` vs empty withdrawals or requests because both `nil` & empty were coded as an `EmptyRootHash`. With this change only empty withdrawals/requests are coded as an `EmptyRootHash`, while `nil` ones are coded as zeros, thus ensuring that blocks & headers are consistent in terms of `nil` vs empty. (This invariant is also checked in `(b *Block) HashCheck()`.)