### PR TITLE
print number first to match with new header notification order

### DIFF
--- a/turbo/execution/eth1/forkchoice.go
+++ b/turbo/execution/eth1/forkchoice.go
@@ -437,7 +437,7 @@ func (e *EthereumExecutionModule) updateForkChoice(ctx context.Context, original
 			}
 		}
 		if log {
-			e.logger.Info("head updated", "hash", headHash, "number", *headNumber)
+			e.logger.Info("head updated", "number", *headNumber, "hash", headHash)
 		}
 
 		var commitStart time.Time


### PR DESCRIPTION
before
```
INFO[05-22|16:23:12.719] RPC Daemon notified of new headers       from=19926586 to=19926587 amount=1 hash=0x983bf3221815287fe724f202acc956d3390bf7d20fff3524adbaddb4c4931385 header sending=8.413µs log sending=152ns
INFO[05-22|16:23:12.719] head updated                             hash=0x983bf3221815287fe724f202acc956d3390bf7d20fff3524adbaddb4c4931385 number=19926587
```

after

```
INFO[05-22|16:23:12.719] RPC Daemon notified of new headers       from=19926586 to=19926587 amount=1 hash=0x983bf3221815287fe724f202acc956d3390bf7d20fff3524adbaddb4c4931385 header sending=8.413µs log sending=152ns
INFO[05-22|16:23:12.719] head updated                             number=19926587 hash=0x983bf3221815287fe724f202acc956d3390bf7d20fff3524adbaddb4c4931385`
```

when latest log looks mostly like that on tip it's easier to read when blk number on both lines in front of hash