### PR TITLE
fix gas price not right problem

### DIFF
--- a/turbo/adapter/ethapi/api.go
+++ b/turbo/adapter/ethapi/api.go
@@ -112,7 +112,7 @@ func (args *CallArgs) ToMessage(globalGasCap uint64, baseFee *uint256.Int) (type
 			gasFeeCap, gasTipCap = gasPrice, gasPrice
 		} else {
 			// User specified 1559 gas fields (or none), use those
-			gasFeeCap = baseFee
+			gasFeeCap = uint256.MustFromBig(baseFee.ToBig())
 			if args.MaxFeePerGas != nil {
 				overflow := gasFeeCap.SetFromBig(args.MaxFeePerGas.ToInt())
 				if overflow {


### PR DESCRIPTION
old code has side affect, it will cause baseFee to be changed.
so if you set `maxFeePerGas` the gas price will always be `maxFeePerGas` even if `baseFee`+`maxPriorityFeePerGas` is less than `maxFeePerGas`.