### PR TITLE
fix eth_call 'method handler crashed' error when tx has set maxFeePerBlobGas

### DIFF
--- a/turbo/adapter/ethapi/api.go
+++ b/turbo/adapter/ethapi/api.go
@@ -133,7 +133,11 @@ func (args *CallArgs) ToMessage(globalGasCap uint64, baseFee *uint256.Int) (type
 			}
 		}
 		if args.MaxFeePerBlobGas != nil {
-			maxFeePerBlobGas.SetFromBig(args.MaxFeePerBlobGas.ToInt())
+			blobFee, overflow := uint256.FromBig(args.MaxFeePerBlobGas.ToInt())
+			if overflow {
+				return types.Message{}, fmt.Errorf("args.MaxFeePerBlobGas higher than 2^256-1")
+			}
+			maxFeePerBlobGas = blobFee
 		}
 	}
 


### PR DESCRIPTION
`maxFeePerBlobGas` is nil, can not call SetFromBig directly