### PR TITLE
Enable DNS p2p discovery on holesky

### DIFF
--- a/params/bootnodes.go
+++ b/params/bootnodes.go
@@ -151,6 +151,8 @@ func KnownDNSNetwork(genesis libcommon.Hash, protocol string) string {
 		net = "goerli"
 	case SepoliaGenesisHash:
 		net = "sepolia"
+	case HoleskyGenesisHash:
+		net = "holesky"
 	default:
 		return ""
 	}


### PR DESCRIPTION
see: https://github.com/ethereum/discv4-dns-lists

also proof it is functional:

```
dig TXT all.holesky.ethdisco.net

; <<>> DiG 9.10.6 <<>> TXT all.holesky.ethdisco.net
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 6114
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1280
;; QUESTION SECTION:
;all.holesky.ethdisco.net.      IN      TXT

;; ANSWER SECTION:
all.holesky.ethdisco.net. 1568  IN      TXT     "enrtree-root:v1 e=72BET3MB7DRDRE2J56WNO6YGPM l=FDXN3SN67NA5DKA4J2GOK7BVQI seq=920 sig=0IQu7ccrToT22F8Mawd1DhMscWrwuRZThKg9y9txXZ90xL5Wq0tCxLF3wt-mX307VSm93gXl8I1wPiP0SLbXUQA"

;; Query time: 5 msec
;; SERVER: 189.38.95.96#53(189.38.95.96)
;; WHEN: Fri May 24 04:01:02 -03 2024
;; MSG SIZE  rcvd: 239
```
