### PR TITLE
[Doc] bucket.go no longer exists

### DIFF
--- a/docs/programmers_guide/db_faq.md
+++ b/docs/programmers_guide/db_faq.md
@@ -8,7 +8,7 @@ There are 2 options exist:
    etc... Interface is here: https://github.com/ledgerwatch/interfaces/blob/master/remote/kv.proto
    Go/C++/Rust libs already exist. Names of buckets and their format you can find in `erigon-lib/kv/tables.go` You can
    do such calls by network.
-3. Read Erigon's db while Erigon is running - it's also ok - just need be careful - do not run too long read
+2. Read Erigon's db while Erigon is running - it's also ok - just need be careful - do not run too long read
    transactions (long read transactions do block free space in DB). Then your app will share with Erigon same OS-level
    PageCache where hot part of db stored. It may be great - if you read hot data (for example do incremental update of
    graph node) - then your reads will be super fast and almost never touch disk. But if you wanna read cold data - then

--- a/docs/programmers_guide/db_faq.md
+++ b/docs/programmers_guide/db_faq.md
@@ -6,9 +6,9 @@ There are 2 options exist:
 
 1. call --private.api.addr there is grpc interface with low-level data access methods - can read any data in any order,
    etc... Interface is here: https://github.com/ledgerwatch/interfaces/blob/master/remote/kv.proto
-   Go/C++/Rust libs already exist. Names of buckets and their format you can find in `bucket.go` You can do such calls
-   by network.
-2. Read Erigon's db while Erigon is running - it's also ok - just need be careful - do not run too long read
+   Go/C++/Rust libs already exist. Names of buckets and their format you can find in `erigon-lib/kv/tables.go` You can
+   do such calls by network.
+3. Read Erigon's db while Erigon is running - it's also ok - just need be careful - do not run too long read
    transactions (long read transactions do block free space in DB). Then your app will share with Erigon same OS-level
    PageCache where hot part of db stored. It may be great - if you read hot data (for example do incremental update of
    graph node) - then your reads will be super fast and almost never touch disk. But if you wanna read cold data - then


### PR DESCRIPTION
Update db_faq.md because `bucket.go` no longer exists.