### PR TITLE
e2: remove overlapped files only after merge

### DIFF
--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -1298,7 +1298,6 @@ func (br *BlockRetire) retireBlocks(ctx context.Context, minBlockNum uint64, max
 	if err := snapshots.removeOverlapsAfterMerge(); err != nil {
 		return ok, err
 	}
-
 	return ok, nil
 }
 

--- a/turbo/snapshotsync/freezeblocks/block_snapshots_test.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots_test.go
@@ -240,7 +240,7 @@ func TestRemoveOverlaps(t *testing.T) {
 	require.NoError(err)
 	require.Equal(45, len(list))
 
-	s.removeOverlaps()
+	s.removeOverlapsAfterMerge()
 
 	list, err = snaptype.Segments(s.dir)
 	require.NoError(err)

--- a/turbo/snapshotsync/freezeblocks/bor_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/bor_snapshots.go
@@ -101,14 +101,13 @@ func (br *BlockRetire) retireBorBlocks(ctx context.Context, minBlockNum uint64, 
 		return nil
 	}
 
-
 	err := merger.Merge(ctx, &snapshots.RoSnapshots, borsnaptype.BorSnapshotTypes(), rangesToMerge, snapshots.Dir(), true /* doIndex */, onMerge, onDelete)
 	if err != nil {
 		return blocksRetired, err
 	}
 
 	{
-		files, _, err := typedSegments(br.borSnapshots().dir, br.borSnapshots().segmentsMin.Load(), borsnaptype.BorSnapshotTypes, false)
+		files, _, err := typedSegments(br.borSnapshots().dir, br.borSnapshots().segmentsMin.Load(), borsnaptype.BorSnapshotTypes(), false)
 		if err != nil {
 			return blocksRetired, err
 		}


### PR DESCRIPTION
Otherwise: if start after `kill -9` in the middle of merge - may remove small files of 1 type of file, but leave small files of another type of files (which merge was not finished) - and leave node in un-mergable state: https://github.com/ledgerwatch/erigon/issues/10485