### PR TITLE
diagnostics: fix test db creation

### DIFF
--- a/erigon-lib/diagnostics/client.go
+++ b/erigon-lib/diagnostics/client.go
@@ -36,6 +36,10 @@ type DiagnosticClient struct {
 	networkSpeedMutex   sync.Mutex
 }
 
+func NewTestDiagnosticClient() (*DiagnosticClient, error) {
+	return &DiagnosticClient{}, nil
+}
+
 func NewDiagnosticClient(ctx context.Context, metricsMux *http.ServeMux, dataDirPath string, speedTest bool) (*DiagnosticClient, error) {
 	dirPath := filepath.Join(dataDirPath, "diagnostics")
 	db, err := createDb(ctx, dirPath)

--- a/erigon-lib/diagnostics/client.go
+++ b/erigon-lib/diagnostics/client.go
@@ -36,10 +36,6 @@ type DiagnosticClient struct {
 	networkSpeedMutex   sync.Mutex
 }
 
-func NewTestDiagnosticClient() (*DiagnosticClient, error) {
-	return &DiagnosticClient{}, nil
-}
-
 func NewDiagnosticClient(ctx context.Context, metricsMux *http.ServeMux, dataDirPath string, speedTest bool) (*DiagnosticClient, error) {
 	dirPath := filepath.Join(dataDirPath, "diagnostics")
 	db, err := createDb(ctx, dirPath)

--- a/erigon-lib/diagnostics/snapshots_test.go
+++ b/erigon-lib/diagnostics/snapshots_test.go
@@ -1,7 +1,6 @@
 package diagnostics_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/ledgerwatch/erigon-lib/diagnostics"
@@ -9,7 +8,7 @@ import (
 )
 
 func TestUpdateFileDownloadingStats(t *testing.T) {
-	d, err := diagnostics.NewDiagnosticClient(context.TODO(), nil, "test", true)
+	d, err := diagnostics.NewTestDiagnosticClient()
 
 	require.NoError(t, err)
 

--- a/erigon-lib/diagnostics/snapshots_test.go
+++ b/erigon-lib/diagnostics/snapshots_test.go
@@ -7,8 +7,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func NewTestDiagnosticClient() (*diagnostics.DiagnosticClient, error) {
+	return &diagnostics.DiagnosticClient{}, nil
+}
+
 func TestUpdateFileDownloadingStats(t *testing.T) {
-	d, err := diagnostics.NewTestDiagnosticClient()
+	d, err := NewTestDiagnosticClient()
 
 	require.NoError(t, err)
 


### PR DESCRIPTION
Added new constructor for diagnostics client to avoid DB creation while run test 