### PR TITLE
Fix nil handling

### DIFF
--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -1495,7 +1495,7 @@ func (ac *AggregatorRoTx) mergeFiles(ctx context.Context, files SelectedStaticFi
 		if rng.needMerge {
 			g.Go(func() error {
 				var err error
-				mf.iis[id], err = ac.iis[id].mergeFiles(ctx, files.ii[id].fi, rng.from, rng.to, ac.a.ps)
+				mf.iis[id], err = ac.iis[id].mergeFiles(ctx, files.ii[id], rng.from, rng.to, ac.a.ps)
 				return err
 			})
 		}
@@ -1523,7 +1523,7 @@ func (a *Aggregator) integrateMergedDirtyFiles(outs SelectedStaticFilesV3, in Me
 	}
 
 	for id, ii := range a.iis {
-		ii.integrateMergedDirtyFiles(outs.ii[id].fi, in.iis[id])
+		ii.integrateMergedDirtyFiles(outs.ii[id], in.iis[id])
 	}
 	return frozen
 }

--- a/erigon-lib/state/aggregator_files.go
+++ b/erigon-lib/state/aggregator_files.go
@@ -35,7 +35,7 @@ type SelectedStaticFilesV3 struct {
 	dHist [kv.DomainLen][]*filesItem
 	dIdx  [kv.DomainLen][]*filesItem
 	dI    [kv.DomainLen]int
-	ii    [kv.StandaloneIdxLen]*filesItemI
+	ii    [kv.StandaloneIdxLen]filesItemI
 }
 
 func (sf SelectedStaticFilesV3) Close() {
@@ -45,9 +45,6 @@ func (sf SelectedStaticFilesV3) Close() {
 	}
 
 	for _, i := range sf.ii {
-		if i == nil {
-			continue
-		}
 		clist = append(clist, i.fi)
 	}
 	for _, group := range clist {
@@ -73,7 +70,8 @@ func (ac *AggregatorRoTx) staticFilesInRange(r RangesV3) (sf SelectedStaticFiles
 	for id, rng := range r.ranges {
 		if rng != nil && rng.needMerge {
 			fi, i := ac.iis[id].staticFilesInRange(rng.from, rng.to)
-			sf.ii[id] = &filesItemI{fi, i}
+			sf.ii[id].fi = fi
+			sf.ii[id].i = i
 		}
 	}
 	return sf, err

--- a/erigon-lib/state/aggregator_files.go
+++ b/erigon-lib/state/aggregator_files.go
@@ -25,17 +25,12 @@ import (
 	"github.com/ledgerwatch/erigon-lib/kv"
 )
 
-type filesItemI struct {
-	fi []*filesItem
-	i  int
-}
-
 type SelectedStaticFilesV3 struct {
 	d     [kv.DomainLen][]*filesItem
 	dHist [kv.DomainLen][]*filesItem
 	dIdx  [kv.DomainLen][]*filesItem
 	dI    [kv.DomainLen]int
-	ii    [kv.StandaloneIdxLen]filesItemI
+	ii    [kv.StandaloneIdxLen][]*filesItem
 }
 
 func (sf SelectedStaticFilesV3) Close() {
@@ -45,7 +40,7 @@ func (sf SelectedStaticFilesV3) Close() {
 	}
 
 	for _, i := range sf.ii {
-		clist = append(clist, i.fi)
+		clist = append(clist, i)
 	}
 	for _, group := range clist {
 		for _, item := range group {
@@ -69,9 +64,8 @@ func (ac *AggregatorRoTx) staticFilesInRange(r RangesV3) (sf SelectedStaticFiles
 	}
 	for id, rng := range r.ranges {
 		if rng != nil && rng.needMerge {
-			fi, i := ac.iis[id].staticFilesInRange(rng.from, rng.to)
-			sf.ii[id].fi = fi
-			sf.ii[id].i = i
+			fi, _ := ac.iis[id].staticFilesInRange(rng.from, rng.to)
+			sf.ii[id] = fi
 		}
 	}
 	return sf, err


### PR DESCRIPTION
A regression was introduced as part of https://github.com/ledgerwatch/erigon/pull/10402 during files merge process where a `nil` pointer can crash erigon.

```
INFO[05-27|15:38:55.343] [snapshots] state merge done accounts(val:148-150, hist:148-150, idx:148-150), storage(val:148-150, hist:148-150, idx:148-150), code(val:148-150, hist:148-150, idx:148-150), commitment(val:148-150)
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x103324dfb]

goroutine 832220 [running]:
github.com/ledgerwatch/erigon-lib/state.(*Aggregator).integrateMergedDirtyFiles(_, {{{0xfc002088040, 0x2, 0x2}, {0xfc002088070, 0x2, 0x2}, {0xfc0020880a0, 0x2, 0x2}, ...}, ...}, ...)
        github.com/ledgerwatch/erigon-lib@v1.0.0/state/aggregator.go:1526 +0x23b
github.com/ledgerwatch/erigon-lib/state.(*Aggregator).mergeLoopStep(0xc001a12200, {0x10530cca8, 0xc001a0c910})
        github.com/ledgerwatch/erigon-lib@v1.0.0/state/aggregator.go:685 +0x76a
github.com/ledgerwatch/erigon-lib/state.(*Aggregator).MergeLoop(...)
        github.com/ledgerwatch/erigon-lib@v1.0.0/state/aggregator.go:697
github.com/ledgerwatch/erigon-lib/state.(*Aggregator).BuildFilesInBackground.func1.1()
        github.com/ledgerwatch/erigon-lib@v1.0.0/state/aggregator.go:1632 +0x11b
created by github.com/ledgerwatch/erigon-lib/state.(*Aggregator).BuildFilesInBackground.func1 in goroutine 748468
        github.com/ledgerwatch/erigon-lib@v1.0.0/state/aggregator.go:1625 +0x4d3
```
