### PR TITLE
qa-tests: fix rpc integration test

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 8 * * *'  # Run every day at 8:00 UTC
   workflow_dispatch:     # Run manually
+  push:
+    branches:
+      - qa_tests_rpc_integration  # only to debug the workflow
 
 jobs:
   integration-test-suite:
@@ -63,7 +66,7 @@ jobs:
           rm -rf ./mainnet/results/
           
           # Run RPC integration test runner via http
-          python3 ./run_tests.py --continue --blockchain mainnet --display-only-fail --port 8545 -x debug_trace,trace_ --transport_type http,websocket
+          python3 ./run_tests.py --continue --blockchain mainnet --display-only-fail --port 8545 -x debug_,trace_,admin_ --transport_type http,websocket
          
           # Capture test runner script exit status
           test_exit_status=$?

--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout RPC Tests Repository & Install Requirements
         run: |
           rm -rf ${{ runner.workspace }}/rpc-tests
-          git -c advice.detachedHead=false clone --depth 1 --branch v0.16.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
+          git -c advice.detachedHead=false clone --depth 1 --branch v0.26.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
           cd ${{ runner.workspace }}/rpc-tests
           pip3 install -r requirements.txt
 
@@ -34,7 +34,7 @@ jobs:
 
       - name: Build Erigon RPCDaemon
         run: |
-          make rpcdaemon
+          make erigon
         working-directory: ${{ github.workspace }}
 
       - name: Pause the Erigon instance dedicated to db maintenance
@@ -48,26 +48,28 @@ jobs:
       - name: Run RpcDaemon
         working-directory: ${{ github.workspace }}/build/bin
         run: |
-          echo "Erigon RpcDaemon starting..."
+          echo "Erigon (RpcDaemon) starting..."
           
-          ./rpcdaemon --datadir $ERIGON_TESTBED_DATA_DIR --http.api admin,debug,eth,parity,erigon,trace,web3,txpool,ots,net --verbosity 1 &
+          ./erigon --datadir $ERIGON_TESTBED_DATA_DIR --http.api admin,debug,eth,parity,erigon,trace,web3,txpool,ots,net --ws --verbosity 1 &
 
           RPC_DAEMON_PID=$!          
           echo "RPC_DAEMON_PID=$RPC_DAEMON_PID" >> $GITHUB_ENV
           
-          echo "Erigon RpcDaemon started"
+          echo "Erigon (RpcDaemon) started"
 
       - name: Run RPC Integration Tests
         id: test_step
         run: |
           set +e # Disable exit on error
-          
+          commit=$(git -C ${{runner.workspace}}/silkworm rev-parse --short HEAD)
+
           cd ${{ runner.workspace }}/rpc-tests/integration
           rm -rf ./mainnet/results/
           
           # Run RPC integration test runner via http
-          python3 ./run_tests.py --continue --blockchain mainnet --display-only-fail --port 8545 -x debug_,trace_,admin_ --transport_type http,websocket
-         
+          python3 ./run_tests.py --continue --blockchain mainnet --display-only-fail --port 8545 -x debug_,trace_ --transport_type http,websocket
+          #python3 ./run_tests.py --continue --blockchain mainnet --display-only-fail --port 8545 -x debug_,trace_,admin_,eth_mining,eth_getWork,eth_coinbase,eth_createAccessList/test_16.json,engine_,net_,web3_,txpool_,eth_submitWork,eth_submitHashrate,eth_protocolVersion,erigon_nodeInfo --transport_type http,websocket
+
           # Capture test runner script exit status
           test_exit_status=$?
           
@@ -84,7 +86,7 @@ jobs:
             echo "TEST_RESULT=failure" >> "$GITHUB_OUTPUT"
             
             # Save failed results to a directory with timestamp and commit hash
-            cp -r ${{ runner.workspace }}/rpc-tests/integration/mainnet/results/ $RPC_PAST_TEST_DIR/mainnet_$(date +%Y%m%d_%H%M%S)_integration_$(git -C ${{ github.workspace }} rev-parse --short HEAD)_http/
+            cp -r ${{ runner.workspace }}/rpc-tests/integration/mainnet/results/ $RPC_PAST_TEST_DIR/mainnet_$(date +%Y%m%d_%H%M%S)_integration_$commit_http/
           fi
 
       - name: Stop Erigon RpcDaemon

--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -61,7 +61,7 @@ jobs:
         id: test_step
         run: |
           set +e # Disable exit on error
-          commit=$(git -C ${{runner.workspace}}/silkworm rev-parse --short HEAD)
+          commit=$(git -C ${{runner.workspace}}/erigon rev-parse --short HEAD)
 
           cd ${{ runner.workspace }}/rpc-tests/integration
           rm -rf ./mainnet/results/

--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           echo "Erigon (RpcDaemon) starting..."
           
-          ./erigon --datadir $ERIGON_TESTBED_DATA_DIR --http.api admin,debug,eth,parity,erigon,trace,web3,txpool,ots,net --ws --verbosity 1 &
+          ./erigon --datadir $ERIGON_TESTBED_DATA_DIR --http.api admin,debug,eth,parity,erigon,trace,web3,txpool,ots,net --ws --verbosity 1 > erigon.log 2>&1 &
 
           RPC_DAEMON_PID=$!          
           echo "RPC_DAEMON_PID=$RPC_DAEMON_PID" >> $GITHUB_ENV


### PR DESCRIPTION
Import rpcdaemon tests from Silkworm.

Not supported on Erigon: 

- debug_,trace_ 

Not supported without a running Erigon instance: 

- admin_,eth_mining,eth_getWork,eth_coinbase,eth_createAccessList/test_16.json,engine_,net_,web3_,txpool_,eth_submitWork,eth_submitHashrate,eth_protocolVersion,erigon_nodeInfo
