### PR TITLE
polygon/heimdall: fix checkpoint json marshalling

### DIFF
--- a/polygon/heimdall/checkpoint.go
+++ b/polygon/heimdall/checkpoint.go
@@ -62,7 +62,7 @@ func (c *Checkpoint) MarshalJSON() ([]byte, error) {
 		Proposer   libcommon.Address `json:"proposer"`
 		StartBlock *big.Int          `json:"start_block"`
 		EndBlock   *big.Int          `json:"end_block"`
-		RootHash   libcommon.Hash    `json:"hash"`
+		RootHash   libcommon.Hash    `json:"root_hash"`
 		ChainID    string            `json:"bor_chain_id"`
 		Timestamp  uint64            `json:"timestamp"`
 	}{
@@ -79,7 +79,7 @@ func (c *Checkpoint) MarshalJSON() ([]byte, error) {
 func (c *Checkpoint) UnmarshalJSON(b []byte) error {
 	dto := struct {
 		WaypointFields
-		RootHash libcommon.Hash `json:"hash"`
+		RootHash libcommon.Hash `json:"root_hash"`
 		Id       CheckpointId   `json:"id"`
 	}{}
 


### PR DESCRIPTION
Fixes a recent regression causing unwinds due to checkpoints having zero root hash:
```
[WARN] [05-18|23:58:54.662] [bor] Root hash mismatch while whitelisting checkpoint expected=ac1c57270479250af3ce8eee90075cd8b2ba1bac55353105e063d9a4c87c743e got=0000000000000000000000000000000000000000000000000000000000000000
[WARN] [05-18|23:58:54.662] [bor] Rewinding chain due to checkpoint root hash mismatch number=57125727
```

Note this has already been fixed on Erigon 3 branch but as part of a non-related PR - https://github.com/ledgerwatch/erigon/pull/10124/files#diff-47d4532f399f2d6a45e6f19944a45c80bac573b4d1b5cb51485d0254229d1b16