### PR TITLE
qa-tests: run sync-from-scratch only on sunday

### DIFF
--- a/.github/workflows/qa-clean-exit-block-downloading.yml
+++ b/.github/workflows/qa-clean-exit-block-downloading.yml
@@ -2,7 +2,7 @@ name: QA - Clean exit (block downloading)
 
 on:
   schedule:
-    - cron: '0 8 * * *'  # Run every day at 08:00 AM UTC
+    - cron: '0 8 * * 1-6'  # Run every day at 08:00 AM UTC except Sunday
   workflow_dispatch:     # Run manually
 
 jobs:

--- a/.github/workflows/qa-snap-download.yml
+++ b/.github/workflows/qa-snap-download.yml
@@ -2,7 +2,7 @@ name: QA - Snapshot Download
 
 on:
   schedule:
-    - cron: '0 5 * * *'  # Run every day at 05:00 AM UTC
+    - cron: '0 5 * * 1-6'  # Run every day at 05:00 AM UTC except Sunday
   workflow_dispatch:     # Run manually
 
 jobs:

--- a/.github/workflows/qa-sync-from-scratch.yml
+++ b/.github/workflows/qa-sync-from-scratch.yml
@@ -2,7 +2,7 @@ name: QA - Sync from scratch
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Run every day at 05:00 AM UTC
+    - cron: '0 0 * * 0'  # Run on Sunday at 00:00 AM UTC
   workflow_dispatch:     # Run manually
 
 jobs:

--- a/.github/workflows/qa-tip-tracking.yml
+++ b/.github/workflows/qa-tip-tracking.yml
@@ -2,7 +2,7 @@ name: QA - Tip tracking
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Run every day at 00:00 AM UTC
+    - cron: '0 0 * * 1-6'  # Run every day at 00:00 AM UTC except Sunday
   workflow_dispatch:     # Run manually
 
 jobs:


### PR DESCRIPTION
The sync-from-scratch test takes 12 hours per job (amoy job, sepolia job).
The two jobs can be run on different runners but still risk blocking the other tests.
Since this test does not pass at the moment, we decide to run it only once a week, on Sunday, the day on which we suspend the others.