### PR TITLE
keep snapshot download listener

### DIFF
--- a/erigon-lib/diagnostics/snapshots.go
+++ b/erigon-lib/diagnostics/snapshots.go
@@ -54,9 +54,9 @@ func (d *DiagnosticClient) runSnapshotListener(rootCtx context.Context) {
 
 				d.mu.Unlock()
 
-				if info.DownloadFinished {
+				/*if info.DownloadFinished {
 					return
-				}
+				}*/
 			}
 		}
 


### PR DESCRIPTION
Keep listening for snapshot download events even after receiving the download finished event, as it looks like the download now consists of at least two parts:
- downloading the header chain
- download
So, there's a need to keep track of the downloading progress.