### PR TITLE
agg: logStat to `log.Warn` instead of panic

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -1803,9 +1803,9 @@ func allSnapshots(ctx context.Context, db kv.RoDB, logger log.Logger) (*freezebl
 			_ = db.View(context.Background(), func(tx kv.Tx) error {
 				ac := _aggSingleton.BeginFilesRo()
 				defer ac.Close()
-				ac.LogStats(tx, func(endTxNumMinimax uint64) uint64 {
-					_, histBlockNumProgress, _ := rawdbv3.TxNums.FindBlockNum(tx, endTxNumMinimax)
-					return histBlockNumProgress
+				ac.LogStats(tx, func(endTxNumMinimax uint64) (uint64, error) {
+					_, histBlockNumProgress, err := rawdbv3.TxNums.FindBlockNum(tx, endTxNumMinimax)
+					return histBlockNumProgress, err
 				})
 				return nil
 			})

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -391,9 +391,9 @@ func RemoteServices(ctx context.Context, cfg *httpcfg.HttpCfg, logger log.Logger
 		db.View(context.Background(), func(tx kv.Tx) error {
 			aggTx := agg.BeginFilesRo()
 			defer aggTx.Close()
-			aggTx.LogStats(tx, func(endTxNumMinimax uint64) uint64 {
-				_, histBlockNumProgress, _ := rawdbv3.TxNums.FindBlockNum(tx, endTxNumMinimax)
-				return histBlockNumProgress
+			aggTx.LogStats(tx, func(endTxNumMinimax uint64) (uint64, error) {
+				_, histBlockNumProgress, err := rawdbv3.TxNums.FindBlockNum(tx, endTxNumMinimax)
+				return histBlockNumProgress, err
 			})
 			return nil
 		})
@@ -422,9 +422,9 @@ func RemoteServices(ctx context.Context, cfg *httpcfg.HttpCfg, logger log.Logger
 					db.View(context.Background(), func(tx kv.Tx) error {
 						ac := agg.BeginFilesRo()
 						defer ac.Close()
-						ac.LogStats(tx, func(endTxNumMinimax uint64) uint64 {
-							_, histBlockNumProgress, _ := rawdbv3.TxNums.FindBlockNum(tx, endTxNumMinimax)
-							return histBlockNumProgress
+						ac.LogStats(tx, func(endTxNumMinimax uint64) (uint64, error) {
+							_, histBlockNumProgress, err := rawdbv3.TxNums.FindBlockNum(tx, endTxNumMinimax)
+							return histBlockNumProgress, err
 						})
 						return nil
 					})

--- a/erigon-lib/kv/rawdbv3/txnum.go
+++ b/erigon-lib/kv/rawdbv3/txnum.go
@@ -175,9 +175,16 @@ func (txNums) FindBlockNum(tx kv.Tx, endTxNumMinimax uint64) (ok bool, blockNum 
 	lastBlockNum := binary.BigEndian.Uint64(lastK)
 
 	blockNum = uint64(sort.Search(int(lastBlockNum+1), func(i int) bool {
+		if err != nil { // don't loose errors from prev iterations
+			return true
+		}
+
 		binary.BigEndian.PutUint64(seek[:], uint64(i))
 		var v, found []byte
 		found, v, err = c.SeekExact(seek[:])
+		if err != nil {
+			return true
+		}
 		if len(v) != 8 {
 			_lb, _lt, _ := TxNums.Last(tx)
 			err = fmt.Errorf("FindBlockNum(%d): seems broken TxNum value: %x -> (%x, %x); last in db: (%d, %d)", endTxNumMinimax, seek, found, v, _lb, _lt)

--- a/erigon-lib/kv/rawdbv3/txnum.go
+++ b/erigon-lib/kv/rawdbv3/txnum.go
@@ -176,10 +176,12 @@ func (txNums) FindBlockNum(tx kv.Tx, endTxNumMinimax uint64) (ok bool, blockNum 
 
 	blockNum = uint64(sort.Search(int(lastBlockNum+1), func(i int) bool {
 		binary.BigEndian.PutUint64(seek[:], uint64(i))
-		var v []byte
-		_, v, err = c.SeekExact(seek[:])
+		var v, found []byte
+		found, v, err = c.SeekExact(seek[:])
 		if len(v) != 8 {
-			panic(fmt.Errorf("seems broken TxNum value: %x -> %x", seek, v))
+			_lb, _lt, _ := TxNums.Last(tx)
+			err = fmt.Errorf("FindBlockNum(%d): seems broken TxNum value: %x -> (%x, %x); last in db: (%d, %d)", endTxNumMinimax, seek, found, v, _lb, _lt)
+			return true
 		}
 		return binary.BigEndian.Uint64(v) >= endTxNumMinimax
 	}))

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -1146,9 +1146,18 @@ func (ac *AggregatorRoTx) LogStats(tx kv.Tx, tx2block func(endTxNumMinimax uint6
 	var lastCommitmentBlockNum, lastCommitmentTxNum uint64
 	if len(ac.d[kv.CommitmentDomain].files) > 0 {
 		lastCommitmentTxNum = ac.d[kv.CommitmentDomain].files[len(ac.d[kv.CommitmentDomain].files)-1].endTxNum
-		lastCommitmentBlockNum = tx2block(lastCommitmentTxNum)
+		lastCommitmentBlockNum, err = tx2block(lastCommitmentTxNum)
+		if err != nil {
+			log.Info("[snapshots] History Stat", "err", err)
+			return
+		}
 	}
-	firstHistoryIndexBlockInDB := tx2block(ac.d[kv.AccountsDomain].d.FirstStepInDB(tx) * ac.a.StepSize())
+	firstHistoryIndexBlockInDB, err := tx2block(ac.d[kv.AccountsDomain].d.FirstStepInDB(tx) * ac.a.StepSize())
+	if err != nil {
+		log.Info("[snapshots] History Stat", "err", err)
+		return
+	}
+
 	var m runtime.MemStats
 	dbg.ReadMemStats(&m)
 	log.Info("[snapshots] History Stat",

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -372,7 +372,7 @@ func (a *Aggregator) BuildOptionalMissedIndicesInBackground(ctx context.Context,
 			if errors.Is(err, context.Canceled) || errors.Is(err, common2.ErrStopped) {
 				return
 			}
-			log.Warn("[snapshots] BuildOptionalMissedIndicesInBackground", "err", err)
+			a.logger.Warn("[snapshots] BuildOptionalMissedIndicesInBackground", "err", err)
 		}
 	}()
 }
@@ -423,7 +423,7 @@ func (a *Aggregator) BuildMissedIndices(ctx context.Context, workers int) error 
 				case <-logEvery.C:
 					var m runtime.MemStats
 					dbg.ReadMemStats(&m)
-					log.Info("[snapshots] Indexing", "progress", ps.String(), "total-indexing-time", time.Since(startIndexingTime).Round(time.Second).String(), "alloc", common2.ByteCount(m.Alloc), "sys", common2.ByteCount(m.Sys))
+					a.logger.Info("[snapshots] Indexing", "progress", ps.String(), "total-indexing-time", time.Since(startIndexingTime).Round(time.Second).String(), "alloc", common2.ByteCount(m.Alloc), "sys", common2.ByteCount(m.Sys))
 				}
 			}
 		}()
@@ -458,7 +458,7 @@ func (a *Aggregator) BuildMissedIndicesInBackground(ctx context.Context, workers
 			if errors.Is(err, context.Canceled) || errors.Is(err, common2.ErrStopped) {
 				return
 			}
-			log.Warn("[snapshots] BuildOptionalMissedIndicesInBackground", "err", err)
+			a.logger.Warn("[snapshots] BuildOptionalMissedIndicesInBackground", "err", err)
 		}
 	}()
 }
@@ -640,7 +640,7 @@ Loop:
 				break Loop
 			}
 			if a.HasBackgroundFilesBuild() {
-				log.Info("[snapshots] Files build", "progress", a.BackgroundProgress())
+				a.logger.Info("[snapshots] Files build", "progress", a.BackgroundProgress())
 			}
 		}
 	}
@@ -1123,14 +1123,14 @@ func (ac *AggregatorRoTx) LogStats(tx kv.Tx, tx2block func(endTxNumMinimax uint6
 
 	domainBlockNumProgress, err := tx2block(maxTxNum)
 	if err != nil {
-		log.Info("[snapshots] History Stat", "err", err)
+		ac.a.logger.Info("[snapshots] History Stat", "err", err)
 		return
 	}
 	str := make([]string, 0, len(ac.d[kv.AccountsDomain].files))
 	for _, item := range ac.d[kv.AccountsDomain].files {
 		bn, err := tx2block(item.endTxNum)
 		if err != nil {
-			log.Info("[snapshots] History Stat", "err", err)
+			ac.a.logger.Info("[snapshots] History Stat", "err", err)
 			return
 		}
 		str = append(str, fmt.Sprintf("%d=%dK", item.endTxNum/ac.a.StepSize(), bn/1_000))
@@ -1148,19 +1148,19 @@ func (ac *AggregatorRoTx) LogStats(tx kv.Tx, tx2block func(endTxNumMinimax uint6
 		lastCommitmentTxNum = ac.d[kv.CommitmentDomain].files[len(ac.d[kv.CommitmentDomain].files)-1].endTxNum
 		lastCommitmentBlockNum, err = tx2block(lastCommitmentTxNum)
 		if err != nil {
-			log.Info("[snapshots] History Stat", "err", err)
+			ac.a.logger.Info("[snapshots] History Stat", "err", err)
 			return
 		}
 	}
 	firstHistoryIndexBlockInDB, err := tx2block(ac.d[kv.AccountsDomain].d.FirstStepInDB(tx) * ac.a.StepSize())
 	if err != nil {
-		log.Info("[snapshots] History Stat", "err", err)
+		ac.a.logger.Info("[snapshots] History Stat", "err", err)
 		return
 	}
 
 	var m runtime.MemStats
 	dbg.ReadMemStats(&m)
-	log.Info("[snapshots] History Stat",
+	ac.a.logger.Info("[snapshots] History Stat",
 		"blocks", fmt.Sprintf("%dk", (domainBlockNumProgress+1)/1000),
 		"txs", fmt.Sprintf("%dm", ac.a.visibleFilesMinimaxTxNum.Load()/1_000_000),
 		"txNum2blockNum", strings.Join(str, ","),
@@ -1336,13 +1336,13 @@ func (ac *AggregatorRoTx) SqueezeCommitmentFiles() error {
 			}
 		}
 		if ai == len(accountFiles) || si == len(storageFiles) {
-			log.Info("SqueezeCommitmentFiles: commitment file has no corresponding account or storage file", "commitment", cf.decompressor.FileName())
+			ac.a.logger.Info("SqueezeCommitmentFiles: commitment file has no corresponding account or storage file", "commitment", cf.decompressor.FileName())
 			continue
 		}
 		af, sf := accountFiles[ai], storageFiles[si]
 
 		err := func() error {
-			log.Info("SqueezeCommitmentFiles: file start", "original", cf.decompressor.FileName(),
+			ac.a.logger.Info("SqueezeCommitmentFiles: file start", "original", cf.decompressor.FileName(),
 				"progress", fmt.Sprintf("%d/%d", ci+1, len(accountFiles)))
 
 			originalPath := cf.decompressor.FilePath()
@@ -1389,7 +1389,7 @@ func (ac *AggregatorRoTx) SqueezeCommitmentFiles() error {
 
 				select {
 				case <-logEvery.C:
-					log.Info("SqueezeCommitmentFiles", "file", cf.decompressor.FileName(), "k", fmt.Sprintf("%x", k),
+					ac.a.logger.Info("SqueezeCommitmentFiles", "file", cf.decompressor.FileName(), "k", fmt.Sprintf("%x", k),
 						"progress", fmt.Sprintf("%d/%d", i, cf.decompressor.Count()))
 				default:
 				}
@@ -1412,7 +1412,7 @@ func (ac *AggregatorRoTx) SqueezeCommitmentFiles() error {
 			}
 			sizeDelta += delta
 
-			log.Info("SqueezeCommitmentFiles: file done", "original", filepath.Base(originalPath),
+			ac.a.logger.Info("SqueezeCommitmentFiles: file done", "original", filepath.Base(originalPath),
 				"sizeDelta", fmt.Sprintf("%s (%.1f%%)", delta.HR(), deltaP))
 
 			fromStep, toStep := af.startTxNum/ac.a.StepSize(), af.endTxNum/ac.a.StepSize()
@@ -1432,23 +1432,23 @@ func (ac *AggregatorRoTx) SqueezeCommitmentFiles() error {
 		}
 	}
 
-	log.Info("SqueezeCommitmentFiles: squeezed files has been produced, removing obsolete files",
+	ac.a.logger.Info("SqueezeCommitmentFiles: squeezed files has been produced, removing obsolete files",
 		"toRemove", len(obsoleteFiles), "processed", fmt.Sprintf("%d/%d", processedFiles, len(commitFiles)))
 	for _, path := range obsoleteFiles {
 		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
-		log.Debug("SqueezeCommitmentFiles: obsolete file removal", "path", path)
+		ac.a.logger.Debug("SqueezeCommitmentFiles: obsolete file removal", "path", path)
 	}
-	log.Info("SqueezeCommitmentFiles: indices removed, renaming temporal files ")
+	ac.a.logger.Info("SqueezeCommitmentFiles: indices removed, renaming temporal files ")
 
 	for _, path := range temporalFiles {
 		if err := os.Rename(path, strings.TrimSuffix(path, sqExt)); err != nil {
 			return err
 		}
-		log.Debug("SqueezeCommitmentFiles: temporal file renaming", "path", path)
+		ac.a.logger.Debug("SqueezeCommitmentFiles: temporal file renaming", "path", path)
 	}
-	log.Info("SqueezeCommitmentFiles: done", "sizeDelta", sizeDelta.HR(), "files", len(accountFiles))
+	ac.a.logger.Info("SqueezeCommitmentFiles: done", "sizeDelta", sizeDelta.HR(), "files", len(accountFiles))
 
 	return nil
 }
@@ -1600,7 +1600,7 @@ func (a *Aggregator) BuildFilesInBackground(txNum uint64) chan struct{} {
 		if a.snapshotBuildSema != nil {
 			//we are inside own goroutine - it's fine to block here
 			if err := a.snapshotBuildSema.Acquire(a.ctx, 1); err != nil {
-				log.Warn("[snapshots] buildFilesInBackground", "err", err)
+				a.logger.Warn("[snapshots] buildFilesInBackground", "err", err)
 				return //nolint
 			}
 			defer a.snapshotBuildSema.Release(1)
@@ -1624,7 +1624,7 @@ func (a *Aggregator) BuildFilesInBackground(txNum uint64) chan struct{} {
 					close(fin)
 					return
 				}
-				log.Warn("[snapshots] buildFilesInBackground", "err", err)
+				a.logger.Warn("[snapshots] buildFilesInBackground", "err", err)
 				break
 			}
 		}
@@ -1650,7 +1650,7 @@ func (a *Aggregator) BuildFilesInBackground(txNum uint64) chan struct{} {
 				if errors.Is(err, context.Canceled) || errors.Is(err, common2.ErrStopped) {
 					return
 				}
-				log.Warn("[snapshots] merge", "err", err)
+				a.logger.Warn("[snapshots] merge", "err", err)
 			}
 
 			a.BuildOptionalMissedIndicesInBackground(a.ctx, 1)
@@ -1798,7 +1798,7 @@ func (ac *AggregatorRoTx) DebugKey(domain kv.Domain, k []byte) error {
 		return err
 	}
 	if len(l) > 0 {
-		log.Info("[dbg] found in", "files", l)
+		ac.a.logger.Info("[dbg] found in", "files", l)
 	}
 	return nil
 }

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -1123,14 +1123,14 @@ func (ac *AggregatorRoTx) LogStats(tx kv.Tx, tx2block func(endTxNumMinimax uint6
 
 	domainBlockNumProgress, err := tx2block(maxTxNum)
 	if err != nil {
-		ac.a.logger.Info("[snapshots] History Stat", "err", err)
+		ac.a.logger.Warn("[snapshots:history] Stat", "err", err)
 		return
 	}
 	str := make([]string, 0, len(ac.d[kv.AccountsDomain].files))
 	for _, item := range ac.d[kv.AccountsDomain].files {
 		bn, err := tx2block(item.endTxNum)
 		if err != nil {
-			ac.a.logger.Info("[snapshots] History Stat", "err", err)
+			ac.a.logger.Warn("[snapshots:history] Stat", "err", err)
 			return
 		}
 		str = append(str, fmt.Sprintf("%d=%dK", item.endTxNum/ac.a.StepSize(), bn/1_000))
@@ -1148,19 +1148,19 @@ func (ac *AggregatorRoTx) LogStats(tx kv.Tx, tx2block func(endTxNumMinimax uint6
 		lastCommitmentTxNum = ac.d[kv.CommitmentDomain].files[len(ac.d[kv.CommitmentDomain].files)-1].endTxNum
 		lastCommitmentBlockNum, err = tx2block(lastCommitmentTxNum)
 		if err != nil {
-			ac.a.logger.Info("[snapshots] History Stat", "err", err)
+			ac.a.logger.Warn("[snapshots:history] Stat", "err", err)
 			return
 		}
 	}
 	firstHistoryIndexBlockInDB, err := tx2block(ac.d[kv.AccountsDomain].d.FirstStepInDB(tx) * ac.a.StepSize())
 	if err != nil {
-		ac.a.logger.Info("[snapshots] History Stat", "err", err)
+		ac.a.logger.Warn("[snapshots:history] Stat", "err", err)
 		return
 	}
 
 	var m runtime.MemStats
 	dbg.ReadMemStats(&m)
-	ac.a.logger.Info("[snapshots] History Stat",
+	ac.a.logger.Info("[snapshots:history] Stat",
 		"blocks", fmt.Sprintf("%dk", (domainBlockNumProgress+1)/1000),
 		"txs", fmt.Sprintf("%dm", ac.a.visibleFilesMinimaxTxNum.Load()/1_000_000),
 		"txNum2blockNum", strings.Join(str, ","),

--- a/eth/stagedsync/stage_snapshots.go
+++ b/eth/stagedsync/stage_snapshots.go
@@ -292,9 +292,9 @@ func DownloadAndIndexSnapshotsIfNeed(s *StageState, ctx context.Context, tx kv.R
 
 	{
 		cfg.blockReader.Snapshots().LogStat("download")
-		tx.(state.HasAggTx).AggTx().(*state.AggregatorRoTx).LogStats(tx, func(endTxNumMinimax uint64) uint64 {
-			_, histBlockNumProgress, _ := rawdbv3.TxNums.FindBlockNum(tx, endTxNumMinimax)
-			return histBlockNumProgress
+		tx.(state.HasAggTx).AggTx().(*state.AggregatorRoTx).LogStats(tx, func(endTxNumMinimax uint64) (uint64, error) {
+			_, histBlockNumProgress, err := rawdbv3.TxNums.FindBlockNum(tx, endTxNumMinimax)
+			return histBlockNumProgress, err
 		})
 	}
 

--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -604,9 +604,9 @@ func openSnaps(ctx context.Context, cfg ethconfig.BlocksFreezing, dirs datadir.D
 	err = chainDB.View(ctx, func(tx kv.Tx) error {
 		ac := agg.BeginFilesRo()
 		defer ac.Close()
-		ac.LogStats(tx, func(endTxNumMinimax uint64) uint64 {
-			_, histBlockNumProgress, _ := rawdbv3.TxNums.FindBlockNum(tx, endTxNumMinimax)
-			return histBlockNumProgress
+		ac.LogStats(tx, func(endTxNumMinimax uint64) (uint64, error) {
+			_, histBlockNumProgress, err := rawdbv3.TxNums.FindBlockNum(tx, endTxNumMinimax)
+			return histBlockNumProgress, err
 		})
 		return nil
 	})


### PR DESCRIPTION
```
 ./build/bin/integration stage_headers --reset --datadir=/erigon-data/ --chain=bor-mainet
INFO[05-31|04:16:21.773] logging to file system                   log dir=/erigon-data/logs file prefix=integration log level=info json=false
INFO[05-31|04:16:21.776] [db] open                                label=chaindata sizeLimit=12TB pageSize=8192
INFO[05-31|04:16:47.715] [snapshots:blocks] Stat                  blocks=56900k indices=56900k alloc=14.0GB sys=14.1GB
INFO[05-31|04:16:47.715] [snapshots:bor] Stat                     blocks=56300k indices=56300k alloc=14.0GB sys=14.1GB
panic: FindBlockNum(4014062500): seems broken TxNum value: 0000000001b21cee -> (, ); last in db: (56900059, 5593)

goroutine 1 [running]:
github.com/ledgerwatch/erigon-lib/kv/rawdbv3.txNums.FindBlockNum.func1(0x8?)
	github.com/ledgerwatch/erigon-lib@v1.0.0/kv/rawdbv3/txnum.go:183 +0x22e
sort.Search(0xc3316cec60?, 0xc07e04fb20)
	sort/search.go:65 +0x46
github.com/ledgerwatch/erigon-lib/kv/rawdbv3.txNums.FindBlockNum({}, {0x1f02838, 0xc3316ce8a0}, 0xef41bba4)
	github.com/ledgerwatch/erigon-lib@v1.0.0/kv/rawdbv3/txnum.go:177 +0x1cc
github.com/ledgerwatch/erigon/cmd/integration/commands.allSnapshots.func1.5.1(0x3a2b442b8?)
	github.com/ledgerwatch/erigon/cmd/integration/commands/stages.go:1816 +0x25
github.com/ledgerwatch/erigon-lib/state.(*AggregatorRoTx).LogStats(0xc3316ce900, {0x1f02838, 0xc3316ce8a0}, 0xc07e0514e8)
	github.com/ledgerwatch/erigon-lib@v1.0.0/state/aggregator.go:1124 +0x5e
github.com/ledgerwatch/erigon/cmd/integration/commands.allSnapshots.func1.5({0x1f02838, 0xc3316ce8a0})
	github.com/ledgerwatch/erigon/cmd/integration/commands/stages.go:1815 +0xa7
github.com/ledgerwatch/erigon-lib/kv/mdbx.(*MdbxKV).View(0xc000eba160?, {0x1eeedf0?, 0x2cef5e0?}, 0x1ce0b08)
	github.com/ledgerwatch/erigon-lib@v1.0.0/kv/mdbx/kv_mdbx.go:934 +0x93
github.com/ledgerwatch/erigon/cmd/integration/commands.allSnapshots.func1()
	github.com/ledgerwatch/erigon/cmd/integration/commands/stages.go:1812 +0x3f4
sync.(*Once).doSlow(0xc0000def00?, 0xc00151f898?)
	sync/once.go:74 +0xc2
sync.(*Once).Do(...)
	sync/once.go:65
github.com/ledgerwatch/erigon/cmd/integration/commands.allSnapshots({0x1eeedf0?, 0x2cef5e0?}, {0x1ef6660?, 0xc000056200?}, {0x1ef9ae8?, 0xc00083e160?})
	github.com/ledgerwatch/erigon/cmd/integration/commands/stages.go:1775 +0x90
github.com/ledgerwatch/erigon/cmd/integration/commands.openDB({{0x1ef9ae8, 0xc000a8cba0}, 0xc0013e8eb0, 0x1ce1650, 
```