### PR TITLE
stagedsync: polygon sync stage to append canonical tx nums

### DIFF
--- a/eth/stagedsync/default_stages.go
+++ b/eth/stagedsync/default_stages.go
@@ -765,8 +765,8 @@ func PolygonSyncStages(
 		{
 			ID:          stages.PolygonSync,
 			Description: "Use polygon sync component to sync headers, bodies and heimdall data",
-			Forward: func(badBlockUnwind bool, s *StageState, unwinder Unwinder, txc wrap.TxContainer, logger log.Logger) error {
-				return SpawnPolygonSyncStage(ctx, txc.Tx, s, polygonSyncStageCfg)
+			Forward: func(badBlockUnwind bool, s *StageState, u Unwinder, txc wrap.TxContainer, logger log.Logger) error {
+				return SpawnPolygonSyncStage(ctx, txc.Tx, s, u, polygonSyncStageCfg)
 			},
 			Unwind: func(u *UnwindState, s *StageState, txc wrap.TxContainer, logger log.Logger) error {
 				return UnwindPolygonSyncStage()

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -135,7 +135,7 @@ func HeadersPOW(s *StageState, u Unwinder, ctx context.Context, tx kv.RwTx, cfg 
 	}
 	if hash == (libcommon.Hash{}) { // restore canonical markers after unwind
 		headHash := rawdb.ReadHeadHeaderHash(tx)
-		if err = fixCanonicalChain(logPrefix, logEvery, startProgress, headHash, tx, cfg.blockReader, logger); err != nil {
+		if _, _, err = fixCanonicalChain(logPrefix, logEvery, startProgress, headHash, tx, cfg.blockReader, logger); err != nil {
 			return err
 		}
 		hash, err = cfg.blockReader.CanonicalHash(ctx, tx, startProgress)
@@ -326,7 +326,7 @@ Loop:
 	}
 	if headerInserter.GetHighest() != 0 {
 		if !headerInserter.Unwind() {
-			if err := fixCanonicalChain(logPrefix, logEvery, headerInserter.GetHighest(), headerInserter.GetHighestHash(), tx, cfg.blockReader, logger); err != nil {
+			if _, _, err := fixCanonicalChain(logPrefix, logEvery, headerInserter.GetHighest(), headerInserter.GetHighestHash(), tx, cfg.blockReader, logger); err != nil {
 				return fmt.Errorf("fix canonical chain: %w", err)
 			}
 		}
@@ -369,26 +369,33 @@ Loop:
 	return nil
 }
 
-func fixCanonicalChain(logPrefix string, logEvery *time.Ticker, height uint64, hash libcommon.Hash, tx kv.StatelessRwTx, headerReader services.FullBlockReader, logger log.Logger) error {
+type chainNode struct {
+	hash   libcommon.Hash
+	number uint64
+}
+
+func fixCanonicalChain(logPrefix string, logEvery *time.Ticker, height uint64, hash libcommon.Hash, tx kv.StatelessRwTx, headerReader services.FullBlockReader, logger log.Logger) ([]chainNode, []chainNode, error) {
 	if height == 0 {
-		return nil
+		return nil, nil, nil
 	}
 	ancestorHash := hash
 	ancestorHeight := height
 
+	var newNodes, badNodes []chainNode
+	var emptyHash libcommon.Hash
 	var ch libcommon.Hash
 	var err error
 	for ch, err = headerReader.CanonicalHash(context.Background(), tx, ancestorHeight); err == nil && ch != ancestorHash; ch, err = headerReader.CanonicalHash(context.Background(), tx, ancestorHeight) {
 		if err = rawdb.WriteCanonicalHash(tx, ancestorHash, ancestorHeight); err != nil {
-			return fmt.Errorf("marking canonical header %d %x: %w", ancestorHeight, ancestorHash, err)
+			return nil, nil, fmt.Errorf("marking canonical header %d %x: %w", ancestorHeight, ancestorHash, err)
 		}
 
 		ancestor, err := headerReader.Header(context.Background(), tx, ancestorHash, ancestorHeight)
 		if err != nil {
-			return err
+			return nil, nil, err
 		}
 		if ancestor == nil {
-			return fmt.Errorf("ancestor is nil. height %d, hash %x", ancestorHeight, ancestorHash)
+			return nil, nil, fmt.Errorf("ancestor is nil. height %d, hash %x", ancestorHeight, ancestorHash)
 		}
 
 		select {
@@ -397,14 +404,27 @@ func fixCanonicalChain(logPrefix string, logEvery *time.Ticker, height uint64, h
 			logger.Info(fmt.Sprintf("[%s] write canonical markers", logPrefix), "ancestor", ancestorHeight, "hash", ancestorHash)
 		default:
 		}
+
+		if ch != emptyHash {
+			badNodes = append(badNodes, chainNode{
+				hash:   ch,
+				number: ancestorHeight,
+			})
+		}
+
+		newNodes = append(newNodes, chainNode{
+			hash:   ancestorHash,
+			number: ancestorHeight,
+		})
+
 		ancestorHash = ancestor.ParentHash
 		ancestorHeight--
 	}
 	if err != nil {
-		return fmt.Errorf("reading canonical hash for %d: %w", ancestorHeight, err)
+		return nil, nil, fmt.Errorf("reading canonical hash for %d: %w", ancestorHeight, err)
 	}
 
-	return nil
+	return newNodes, badNodes, nil
 }
 
 func HeadersUnwind(u *UnwindState, s *StageState, tx kv.RwTx, cfg HeadersCfg, test bool) (err error) {


### PR DESCRIPTION
While testing the new polygon sync stage I run into the below error:
```
[EROR] [05-29|21:26:54.099] Staged Sync                              err="[4/6 Execution] ExecV3: TxNums index is at block 6399999 and behind commitment 6426107: behind commitment"
```

This is because we weren't appending the canonical tx numbers to the TxNums index. 

This PR fixes this by extending `fixCanonicalChain` to return `newNodes` and `badNodes` on the path to the connecting point from the new fork choice update. `newNodes` can be used to append the right tx nums to the tx nums index while the `badNodes` can be used to unwind (this will be properly handled in a subsequent PR).