### PR TITLE
revisit history pruning

### DIFF
--- a/erigon-lib/state/history_test.go
+++ b/erigon-lib/state/history_test.go
@@ -496,6 +496,76 @@ func TestHistoryCanPrune(t *testing.T) {
 	})
 }
 
+func TestHistoryPruneCorrectness(t *testing.T) {
+	values := generateTestData(t, length.Addr, length.Addr, 1000, 1000, 1)
+	db, h := filledHistoryValues(t, true, values, log.New())
+	defer db.Close()
+	defer h.Close()
+
+	logEvery := time.NewTicker(30 * time.Second)
+	defer logEvery.Stop()
+
+	pruneLimit := uint64(10)
+	pruneIters := 8
+
+	rwTx, err := db.BeginRw(context.Background())
+	require.NoError(t, err)
+	defer rwTx.Rollback()
+
+	var from, to [8]byte
+	binary.BigEndian.PutUint64(from[:], uint64(0))
+	binary.BigEndian.PutUint64(to[:], uint64(pruneIters)*pruneLimit)
+
+	icc, err := rwTx.CursorDupSort(h.historyValsTable)
+	require.NoError(t, err)
+
+	count := 0
+	for key, _, err := icc.Seek(from[:]); key != nil; key, _, err = icc.Next() {
+		require.NoError(t, err)
+		//t.Logf("key %x\n", key)
+		if bytes.Compare(key[len(key)-8:], to[:]) >= 0 {
+			break
+		}
+		count++
+	}
+	require.EqualValues(t, pruneIters*int(pruneLimit), count)
+	icc.Close()
+
+	hc := h.BeginFilesRo()
+	defer hc.Close()
+
+	// this one should not prune anything due to forced=false but no files built
+	stat, err := hc.Prune(context.Background(), rwTx, 0, 10, pruneLimit, false, false, logEvery)
+	require.NoError(t, err)
+	require.Nil(t, stat)
+
+	// this one should prune value of tx=0 due to given range [0,1) (we have first value at tx=0) even it is forced
+	stat, err = hc.Prune(context.Background(), rwTx, 0, 1, pruneLimit, true, false, logEvery)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, stat.PruneCountValues)
+	require.EqualValues(t, 1, stat.PruneCountTx)
+
+	// this should prune exactly pruneLimit*pruneIter transactions
+	for i := 0; i < pruneIters; i++ {
+		stat, err = hc.Prune(context.Background(), rwTx, 0, 1000, pruneLimit, true, false, logEvery)
+		require.NoError(t, err)
+		t.Logf("[%d] stats: %v", i, stat)
+	}
+
+	icc, err = rwTx.CursorDupSort(h.historyValsTable)
+	require.NoError(t, err)
+	defer icc.Close()
+
+	key, _, err := icc.First()
+	require.NoError(t, err)
+	require.NotNil(t, key)
+	require.EqualValues(t, pruneIters*int(pruneLimit), binary.BigEndian.Uint64(key[len(key)-8:])-1)
+
+	icc, err = rwTx.CursorDupSort(h.indexTable)
+	require.NoError(t, err)
+	defer icc.Close()
+}
+
 func filledHistoryValues(tb testing.TB, largeValues bool, values map[string][]upd, logger log.Logger) (kv.RwDB, *History) {
 	tb.Helper()
 
@@ -506,46 +576,49 @@ func filledHistoryValues(tb testing.TB, largeValues bool, values map[string][]up
 
 	// history closed inside tb.Cleanup
 	db, h := testDbAndHistory(tb, largeValues, logger)
-	ctx := context.Background()
-	tx, err := db.BeginRw(ctx)
-	require.NoError(tb, err)
-	defer tx.Rollback()
-	hc := h.BeginFilesRo()
-	defer hc.Close()
-	writer := hc.NewWriter()
-	defer writer.close()
+	tb.Cleanup(db.Close)
+	tb.Cleanup(h.Close)
 
-	// keys are encodings of numbers 1..31
-	// each key changes value on every txNum which is multiple of the key
-	var flusher flusher
-	var keyFlushCount, ps = 0, uint64(0)
-	for key, upds := range values {
-		for i := 0; i < len(upds); i++ {
-			writer.SetTxNum(upds[i].txNum)
-			if i > 0 {
-				ps = upds[i].txNum / hc.h.aggregationStep
+	ctx := context.Background()
+	//tx, err := db.BeginRw(ctx)
+	//require.NoError(tb, err)
+	//defer tx.Rollback()
+
+	err := db.Update(ctx, func(tx kv.RwTx) error {
+		hc := h.BeginFilesRo()
+		defer hc.Close()
+		writer := hc.NewWriter()
+		defer writer.close()
+		// keys are encodings of numbers 1..31
+		// each key changes value on every txNum which is multiple of the key
+		var flusher flusher
+		var keyFlushCount, ps = 0, uint64(0)
+		for key, upds := range values {
+			for i := 0; i < len(upds); i++ {
+				writer.SetTxNum(upds[i].txNum)
+				if i > 0 {
+					ps = upds[i].txNum / hc.h.aggregationStep
+				}
+				err := writer.AddPrevValue([]byte(key), nil, upds[i].value, ps)
+				require.NoError(tb, err)
 			}
-			err = writer.AddPrevValue([]byte(key), nil, upds[i].value, ps)
+			keyFlushCount++
+			if keyFlushCount%10 == 0 {
+				if flusher != nil {
+					err := flusher.Flush(ctx, tx)
+					require.NoError(tb, err)
+					flusher = nil //nolint
+				}
+				flusher = writer
+				writer = hc.NewWriter()
+			}
+		}
+		if flusher != nil {
+			err := flusher.Flush(ctx, tx)
 			require.NoError(tb, err)
 		}
-		keyFlushCount++
-		if keyFlushCount%10 == 0 {
-			if flusher != nil {
-				err = flusher.Flush(ctx, tx)
-				require.NoError(tb, err)
-				flusher = nil //nolint
-			}
-			flusher = writer
-			writer = hc.NewWriter()
-		}
-	}
-	if flusher != nil {
-		err = flusher.Flush(ctx, tx)
-		require.NoError(tb, err)
-	}
-	err = writer.Flush(ctx, tx)
-	require.NoError(tb, err)
-	err = tx.Commit()
+		return writer.Flush(ctx, tx)
+	})
 	require.NoError(tb, err)
 
 	return db, h

--- a/erigon-lib/state/inverted_index.go
+++ b/erigon-lib/state/inverted_index.go
@@ -576,6 +576,8 @@ func (iit *InvertedIndexRoTx) lastTxNumInFiles() uint64 {
 // is to be used in public API, therefore it relies on read-only transaction
 // so that iteration can be done even when the inverted index is being updated.
 // [startTxNum; endNumTx)
+
+// todo IdxRange operates over ii.indexTable . Passing `nil` as a key will not return all keys
 func (iit *InvertedIndexRoTx) IdxRange(key []byte, startTxNum, endTxNum int, asc order.By, limit int, roTx kv.Tx) (iter.U64, error) {
 	frozenIt, err := iit.iterateRangeFrozen(key, startTxNum, endTxNum, asc, limit)
 	if err != nil {
@@ -765,7 +767,7 @@ func (iit *InvertedIndexRoTx) Prune(ctx context.Context, rwTx kv.RwTx, txFrom, t
 		defer cleanup()
 	}
 
-	if limit == 0 {
+	if limit == 0 { // limits amount of Tx to be pruned
 		limit = math.MaxUint64
 	}
 
@@ -779,26 +781,16 @@ func (iit *InvertedIndexRoTx) Prune(ctx context.Context, rwTx kv.RwTx, txFrom, t
 	//		"tx until limit", limit)
 	//}()
 
-	keysCursor, err := rwTx.RwCursorDupSort(ii.indexKeysTable)
+	keysCursor, err := rwTx.CursorDupSort(ii.indexKeysTable)
 	if err != nil {
 		return stat, fmt.Errorf("create %s keys cursor: %w", ii.filenameBase, err)
 	}
 	defer keysCursor.Close()
-	keysCursorForDel, err := rwTx.RwCursorDupSort(ii.indexKeysTable)
-	if err != nil {
-		return stat, fmt.Errorf("create %s keys cursor: %w", ii.filenameBase, err)
-	}
-	defer keysCursorForDel.Close()
-	idxCForDeletes, err := rwTx.RwCursorDupSort(ii.indexTable)
+	idxDelCursor, err := rwTx.RwCursorDupSort(ii.indexTable)
 	if err != nil {
 		return nil, err
 	}
-	defer idxCForDeletes.Close()
-	idxValuesCount, err := idxCForDeletes.Count()
-	if err != nil {
-		return nil, err
-	}
-	indexWithValues := idxValuesCount != 0 || fn != nil
+	defer idxDelCursor.Close()
 
 	collector := etl.NewCollector("prune idx "+ii.filenameBase, ii.dirs.Tmp, etl.NewSortableBuffer(etl.BufferOptimalSize/8), ii.logger)
 	defer collector.Close()
@@ -819,46 +811,35 @@ func (iit *InvertedIndexRoTx) Prune(ctx context.Context, rwTx kv.RwTx, txFrom, t
 		if txNum >= txTo || limit == 0 {
 			break
 		}
-		if txNum < txFrom {
+		if asserts && txNum < txFrom {
 			panic(fmt.Errorf("assert: index pruning txn=%d [%d-%d)", txNum, txFrom, txTo))
 		}
+
 		limit--
 		stat.MinTxNum = min(stat.MinTxNum, txNum)
 		stat.MaxTxNum = max(stat.MaxTxNum, txNum)
 
-		if indexWithValues {
-			for ; v != nil; _, v, err = keysCursor.NextDup() {
-				if err != nil {
-					return nil, fmt.Errorf("iterate over %s index keys: %w", ii.filenameBase, err)
-				}
-				if err := collector.Collect(v, k); err != nil {
-					return nil, err
-				}
+		for ; k != nil; _, k, err = keysCursor.NextDup() {
+			if err != nil {
+				return nil, fmt.Errorf("iterate over %s index keys: %w", ii.filenameBase, err)
 			}
-		}
-
-		stat.PruneCountTx++
-		// This DeleteCurrent needs to the last in the loop iteration, because it invalidates k and v
-		if err = rwTx.Delete(ii.indexKeysTable, k); err != nil {
-			return nil, err
+			if err := collector.Collect(v, k); err != nil {
+				return nil, err
+			}
 		}
 
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
 	}
-	if !indexWithValues {
-		return stat, nil
-	}
 
-	binary.BigEndian.PutUint64(txKey[:], txFrom)
 	err = collector.Load(nil, "", func(key, txnm []byte, table etl.CurrentTableReader, next etl.LoadNextFunc) error {
 		if fn != nil {
 			if err = fn(key, txnm); err != nil {
 				return fmt.Errorf("fn error: %w", err)
 			}
 		}
-		if err = idxCForDeletes.DeleteExact(key, txnm); err != nil {
+		if err = idxDelCursor.DeleteExact(key, txnm); err != nil {
 			return err
 		}
 		mxPruneSizeIndex.Inc()
@@ -874,6 +855,23 @@ func (iit *InvertedIndexRoTx) Prune(ctx context.Context, rwTx kv.RwTx, txFrom, t
 		}
 		return nil
 	}, etl.TransformArgs{Quit: ctx.Done()})
+
+	if stat.MinTxNum != math.MaxUint64 {
+		binary.BigEndian.PutUint64(txKey[:], stat.MinTxNum)
+		// This deletion iterator goes last to preserve invariant: if some `txNum=N` pruned - it's pruned Fully
+		for txnb, _, err := keysCursor.Seek(txKey[:]); txnb != nil; txnb, _, err = keysCursor.NextNoDup() {
+			if err != nil {
+				return nil, fmt.Errorf("iterate over %s index keys: %w", ii.filenameBase, err)
+			}
+			if binary.BigEndian.Uint64(txnb) > stat.MaxTxNum {
+				break
+			}
+			stat.PruneCountTx++
+			if err = rwTx.Delete(ii.indexKeysTable, txnb); err != nil {
+				return nil, err
+			}
+		}
+	}
 
 	return stat, err
 }

--- a/erigon-lib/state/inverted_index.go
+++ b/erigon-lib/state/inverted_index.go
@@ -819,7 +819,7 @@ func (iit *InvertedIndexRoTx) Prune(ctx context.Context, rwTx kv.RwTx, txFrom, t
 		stat.MinTxNum = min(stat.MinTxNum, txNum)
 		stat.MaxTxNum = max(stat.MaxTxNum, txNum)
 
-		for ; k != nil; _, k, err = keysCursor.NextDup() {
+		for ; v != nil; _, v, err = keysCursor.NextDup() {
 			if err != nil {
 				return nil, fmt.Errorf("iterate over %s index keys: %w", ii.filenameBase, err)
 			}

--- a/erigon-lib/state/inverted_index_test.go
+++ b/erigon-lib/state/inverted_index_test.go
@@ -17,6 +17,7 @@
 package state
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"fmt"
@@ -59,6 +60,94 @@ func testDbAndInvertedIndex(tb testing.TB, aggStep uint64, logger log.Logger) (k
 	ii.DisableFsync()
 	tb.Cleanup(ii.Close)
 	return db, ii
+}
+
+func TestInvIndexPruningCorrectness(t *testing.T) {
+	db, ii, _ := filledInvIndexOfSize(t, 1000, 16, 1, log.New())
+	defer ii.Close()
+
+	ic := ii.BeginFilesRo()
+	defer ic.Close()
+
+	logEvery := time.NewTicker(30 * time.Second)
+	defer logEvery.Stop()
+
+	pruneLimit := uint64(10)
+	pruneIters := 8
+
+	rwTx, err := db.BeginRw(context.Background())
+	require.NoError(t, err)
+	defer rwTx.Rollback()
+
+	var from, to [8]byte
+	binary.BigEndian.PutUint64(from[:], uint64(0))
+	binary.BigEndian.PutUint64(to[:], uint64(pruneIters)*pruneLimit)
+
+	icc, err := rwTx.CursorDupSort(ii.indexKeysTable)
+	require.NoError(t, err)
+
+	count := 0
+	for txn, _, err := icc.Seek(from[:]); txn != nil; txn, _, err = icc.Next() {
+		require.NoError(t, err)
+		if bytes.Compare(txn, to[:]) > 0 {
+			break
+		}
+		count++
+	}
+	icc.Close()
+	require.EqualValues(t, count, pruneIters*int(pruneLimit))
+
+	// this one should not prune anything due to forced=false but no files built
+	stat, err := ic.Prune(context.Background(), rwTx, 0, 10, pruneLimit, logEvery, false, false, nil)
+	require.NoError(t, err)
+	require.Zero(t, stat.PruneCountTx)
+	require.Zero(t, stat.PruneCountValues)
+
+	// this one should not prune anything as well due to given range [0,1) even it is forced
+	stat, err = ic.Prune(context.Background(), rwTx, 0, 1, pruneLimit, logEvery, true, false, nil)
+	require.NoError(t, err)
+	require.Zero(t, stat.PruneCountTx)
+	require.Zero(t, stat.PruneCountValues)
+
+	// this should prune exactly pruneLimit*pruneIter transactions
+	for i := 0; i < pruneIters; i++ {
+		stat, err = ic.Prune(context.Background(), rwTx, 0, 1000, pruneLimit, logEvery, true, false, nil)
+		require.NoError(t, err)
+		t.Logf("[%d] stats: %v", i, stat)
+	}
+
+	// ascending - empty
+	it, err := ic.IdxRange(nil, 0, pruneIters*int(pruneLimit), order.Asc, -1, rwTx)
+	require.NoError(t, err)
+	require.False(t, it.HasNext())
+	it.Close()
+
+	// descending - empty
+	it, err = ic.IdxRange(nil, pruneIters*int(pruneLimit), 0, order.Desc, -1, rwTx)
+	require.NoError(t, err)
+	require.False(t, it.HasNext())
+	it.Close()
+
+	// straight from pruned - not empty
+	icc, err = rwTx.CursorDupSort(ii.indexKeysTable)
+	require.NoError(t, err)
+	txn, _, err := icc.Seek(from[:])
+	require.NoError(t, err)
+	// we pruned by limit so next transaction after prune should be equal to `pruneIters*pruneLimit+1`
+	// If we would prune by txnum then txTo prune should be available after prune is finished
+	require.EqualValues(t, pruneIters*int(pruneLimit), binary.BigEndian.Uint64(txn)-1)
+	icc.Close()
+
+	// check second table
+	icc, err = rwTx.CursorDupSort(ii.indexTable)
+	require.NoError(t, err)
+	key, txn, err := icc.First()
+	t.Logf("key: %x, txn: %x", key, txn)
+	require.NoError(t, err)
+	// we pruned by limit so next transaction after prune should be equal to `pruneIters*pruneLimit+1`
+	// If we would prune by txnum then txTo prune should be available after prune is finished
+	require.EqualValues(t, pruneIters*int(pruneLimit), binary.BigEndian.Uint64(txn)-1)
+	icc.Close()
 }
 
 func TestInvIndexCollationBuild(t *testing.T) {
@@ -228,46 +317,49 @@ func filledInvIndex(tb testing.TB, logger log.Logger) (kv.RwDB, *InvertedIndex, 
 	return filledInvIndexOfSize(tb, uint64(1000), 16, 31, logger)
 }
 
+// Creates InvertedIndex instance and fills it with generated data.
+// Txs - amount of transactions to generate
+// AggStep - aggregation step for InvertedIndex
+// Module - amount of keys to generate
 func filledInvIndexOfSize(tb testing.TB, txs, aggStep, module uint64, logger log.Logger) (kv.RwDB, *InvertedIndex, uint64) {
 	tb.Helper()
 	db, ii := testDbAndInvertedIndex(tb, aggStep, logger)
 	ctx, require := context.Background(), require.New(tb)
-	tx, err := db.BeginRw(ctx)
-	require.NoError(err)
-	defer tx.Rollback()
-	ic := ii.BeginFilesRo()
-	defer ic.Close()
-	writer := ic.NewWriter()
-	defer writer.close()
+	tb.Cleanup(db.Close)
 
-	var flusher flusher
+	err := db.Update(ctx, func(tx kv.RwTx) error {
+		ic := ii.BeginFilesRo()
+		defer ic.Close()
+		writer := ic.NewWriter()
+		defer writer.close()
 
-	// keys are encodings of numbers 1..31
-	// each key changes value on every txNum which is multiple of the key
-	for txNum := uint64(1); txNum <= txs; txNum++ {
-		writer.SetTxNum(txNum)
-		for keyNum := uint64(1); keyNum <= module; keyNum++ {
-			if txNum%keyNum == 0 {
-				var k [8]byte
-				binary.BigEndian.PutUint64(k[:], keyNum)
-				err = writer.Add(k[:])
-				require.NoError(err)
+		var flusher flusher
+
+		// keys are encodings of numbers 1..31
+		// each key changes value on every txNum which is multiple of the key
+		for txNum := uint64(1); txNum <= txs; txNum++ {
+			writer.SetTxNum(txNum)
+			for keyNum := uint64(1); keyNum <= module; keyNum++ {
+				if txNum%keyNum == 0 {
+					var k [8]byte
+					binary.BigEndian.PutUint64(k[:], keyNum)
+					err := writer.Add(k[:])
+					require.NoError(err)
+				}
+			}
+			if flusher != nil {
+				require.NoError(flusher.Flush(ctx, tx))
+			}
+			if txNum%10 == 0 {
+				flusher = writer
+				writer = ic.NewWriter()
 			}
 		}
 		if flusher != nil {
 			require.NoError(flusher.Flush(ctx, tx))
 		}
-		if txNum%10 == 0 {
-			flusher = writer
-			writer = ic.NewWriter()
-		}
-	}
-	if flusher != nil {
-		require.NoError(flusher.Flush(ctx, tx))
-	}
-	err = writer.Flush(ctx, tx)
-	require.NoError(err)
-	err = tx.Commit()
+		return writer.Flush(ctx, tx)
+	})
 	require.NoError(err)
 	return db, ii, txs
 }


### PR DESCRIPTION
- Remove useless RWCursor
- fix invariant `if indexed txNum is pruned, no keys in indexValues table should contain that txNum in values, therefore it's pruned fully`
- remove "smart" exit 
relates to https://github.com/ledgerwatch/erigon/issues/10484