### PR TITLE
polygon/heimdall: batch fetch checkpoint empty return and id fixes

### DIFF
--- a/polygon/heimdall/entity_fetcher.go
+++ b/polygon/heimdall/entity_fetcher.go
@@ -116,6 +116,11 @@ func (f *entityFetcherImpl[TEntity]) FetchAllEntities(ctx context.Context) ([]TE
 		}
 
 		for _, entity := range entitiesPage {
+			if entity.RawId() == 0 {
+				// TODO use workaround from heimdall.Heimdall FetchCheckpointsFromBlock
+				//      to set entity id or fix heimdall API to return "id" as part of json
+				panic("unexpected 0 id for entity - pending fix")
+			}
 			entities = append(entities, entity)
 		}
 

--- a/polygon/heimdall/heimdall.go
+++ b/polygon/heimdall/heimdall.go
@@ -82,6 +82,13 @@ func (h *heimdall) FetchCheckpointsFromBlock(ctx context.Context, startBlock uin
 		if err != nil {
 			return nil, err
 		}
+		if len(checkpoints) == 0 {
+			return nil, errors.New("unexpected empty checkpoints")
+		}
+		if checkpoints[len(checkpoints)-1].CmpRange(startBlock) > 0 {
+			// the start block is past the last checkpoint
+			return nil, nil
+		}
 
 		startCheckpointIdx, found := sort.Find(len(checkpoints), func(i int) int {
 			return checkpoints[i].CmpRange(startBlock)

--- a/polygon/heimdall/heimdall.go
+++ b/polygon/heimdall/heimdall.go
@@ -586,7 +586,9 @@ func (h *heimdall) batchFetchCheckpoints(
 	sort.Sort(checkpoints)
 
 	for i, checkpoint := range checkpoints[lastStored:] {
-		err := store.PutCheckpoint(ctx, CheckpointId(i+1), checkpoint)
+		// checkpoint list API does not return "id" in the json response
+		checkpoint.Id = CheckpointId(i + 1)
+		err := store.PutCheckpoint(ctx, checkpoint.Id, checkpoint)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fixes 2 problems with batch fetch checkpoint that I run into during testing of the new polygon sync stage:
- when the tip is after the latest checkpoint.EndBlock we returned error which caused the sync to be stuck - we should return empty list
- turns out the checkpoints/list API has a bug that wasn't noticed - it does not include the "id" field in the json response - have a look at this for example https://heimdall-api-amoy.polygon.technology/checkpoints/list?page=1&limit=2 - this PR works around this by manually setting it within the batch fetch checkpoints logic