### PR TITLE
ports finder's loop: remove unnecessary checks

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -453,7 +453,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 
 			// pick port from allowed list
 			var picked bool
-			for ; pi < len(cfg.AllowedPorts) && !picked; pi++ {
+			for ; pi < len(cfg.AllowedPorts); pi++ {
 				pc := int(cfg.AllowedPorts[pi])
 				if pc == 0 {
 					// For ephemeral ports probing to see if the port is taken does not


### PR DESCRIPTION
Found that there was some unnecessary condition: because `break`'s are everywhere
