### PR TITLE
core: Rename Deposit to DepositRequest for EIP-6110

### DIFF
--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -30,6 +30,7 @@ import (
 
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/common/hexutility"
+
 	// "github.com/ledgerwatch/erigon-lib/common/hexutility"
 	"github.com/ledgerwatch/erigon-lib/kv/memdb"
 	"github.com/ledgerwatch/erigon/core/rawdb"
@@ -587,7 +588,7 @@ func TestBlockWithdrawalsStorage(t *testing.T) {
 	copy(pk[:], libcommon.Hex2Bytes("3d1291c96ad36914068b56d93974c1b1d5afcb3fcd37b2ac4b144afd3f6fec5b"))
 	sig := [96]byte{}
 	copy(sig[:], libcommon.Hex2Bytes("20a0a807c717055ecb60dc9d5071fbd336f7f238d61a288173de20f33f79ebf4"))
-	r1 := types.Deposit{
+	r1 := types.DepositRequest{
 		Pubkey:                pk,
 		WithdrawalCredentials: libcommon.Hash(hexutility.Hex2Bytes("15095f80cde9763665d2eee3f8dfffc4a4405544c6fece33130e6e98809c4b98")),
 		Amount:                12324,
@@ -598,14 +599,14 @@ func TestBlockWithdrawalsStorage(t *testing.T) {
 	copy(pk2[:], libcommon.Hex2Bytes("d40ffb510bfc52b058d5e934026ce3eddaf0a4b1703920f03b32b97de2196a93"))
 	sig2 := [96]byte{}
 	copy(sig2[:], libcommon.Hex2Bytes("dc40cf2c33c6fb17e11e3ffe455063f1bf2280a3b08563f8b33aa359a16a383c"))
-	r2 := types.Deposit{
+	r2 := types.DepositRequest{
 		Pubkey:                pk2,
 		WithdrawalCredentials: libcommon.Hash(hexutility.Hex2Bytes("d73d9332eb1229e58aa7e33e9a5079d9474f68f747544551461bf3ff9f7ccd64")),
 		Amount:                12324,
 		Signature:             sig2,
 		Index:                 0,
 	}
-	deposits := make(types.Deposits, 0)
+	deposits := make(types.DepositRequests, 0)
 	deposits = append(deposits, &r1)
 	deposits = append(deposits, &r2)
 	var reqs types.Requests

--- a/core/types/encdec_test.go
+++ b/core/types/encdec_test.go
@@ -77,8 +77,8 @@ func (tr *TRand) RandWithdrawalRequest() *WithdrawalRequest {
 	}
 }
 
-func (tr *TRand) RandDeposit() *Deposit {
-	return &Deposit{
+func (tr *TRand) RandDeposit() *DepositRequest {
+	return &DepositRequest{
 		Pubkey:                [48]byte(tr.RandBytes(48)),
 		WithdrawalCredentials: tr.RandHash(),
 		Amount:                *tr.RandUint64(),
@@ -349,7 +349,7 @@ func compareTransactions(t *testing.T, a, b Transaction) {
 	check(t, "Tx.S", s1, s2)
 }
 
-func compareDeposits(t *testing.T, a, b *Deposit) {
+func compareDeposits(t *testing.T, a, b *DepositRequest) {
 	check(t, "Deposit.Pubkey", a.Pubkey, b.Pubkey)
 	check(t, "Deposit.WithdrawalCredentials", a.WithdrawalCredentials, b.WithdrawalCredentials)
 	check(t, "Deposit.Amount", a.Amount, b.Amount)
@@ -370,8 +370,8 @@ func checkRequests(t *testing.T, a, b Request) {
 
 	switch a.RequestType() {
 	case DepositRequestType:
-		a, aok := a.(*Deposit)
-		b, bok := b.(*Deposit)
+		a, aok := a.(*DepositRequest)
+		b, bok := b.(*DepositRequest)
 		if aok && bok {
 			compareDeposits(t, a, b)
 		} else {
@@ -520,7 +520,7 @@ func TestDepositEncodeDecode(t *testing.T) {
 		if err := a.EncodeRLP(&buf); err != nil {
 			t.Errorf("error: deposit.EncodeRLP(): %v", err)
 		}
-		b := new(Deposit)
+		b := new(DepositRequest)
 		if err := b.DecodeRLP(buf.Bytes()); err != nil {
 			t.Errorf("error: Deposit.DecodeRLP(): %v", err)
 		}

--- a/core/types/request.go
+++ b/core/types/request.go
@@ -30,7 +30,7 @@ func decode(data []byte) (Request, error) {
 	var req Request
 	switch data[0] {
 	case DepositRequestType:
-		req = new(Deposit)
+		req = new(DepositRequest)
 	case WithdrawalRequestType:
 		req = new(WithdrawalRequest)
 	default:
@@ -109,11 +109,11 @@ func (r *Requests) EncodingSize() int {
 	return c
 }
 
-func (r Requests) Deposits() Deposits {
-	deposits := make(Deposits, 0, len(r))
+func (r Requests) Deposits() DepositRequests {
+	deposits := make(DepositRequests, 0, len(r))
 	for _, req := range r {
 		if req.RequestType() == DepositRequestType {
-			deposits = append(deposits, req.(*Deposit))
+			deposits = append(deposits, req.(*DepositRequest))
 		}
 	}
 	return deposits
@@ -135,7 +135,7 @@ func UnmarshalRequestsFromBinary(requests [][]byte) (reqs Requests, err error) {
 	for _, b := range requests {
 		switch b[0] {
 		case DepositRequestType:
-			d := new(Deposit)
+			d := new(DepositRequest)
 			if err = d.DecodeRLP(b); err != nil {
 				return nil, err
 			}

--- a/turbo/engineapi/engine_types/jsonrpc.go
+++ b/turbo/engineapi/engine_types/jsonrpc.go
@@ -17,25 +17,25 @@ import (
 
 // ExecutionPayload represents an execution payload (aka block)
 type ExecutionPayload struct {
-	ParentHash         common.Hash         `json:"parentHash"    gencodec:"required"`
-	FeeRecipient       common.Address      `json:"feeRecipient"  gencodec:"required"`
-	StateRoot          common.Hash         `json:"stateRoot"     gencodec:"required"`
-	ReceiptsRoot       common.Hash         `json:"receiptsRoot"  gencodec:"required"`
-	LogsBloom          hexutility.Bytes    `json:"logsBloom"     gencodec:"required"`
-	PrevRandao         common.Hash         `json:"prevRandao"    gencodec:"required"`
-	BlockNumber        hexutil.Uint64      `json:"blockNumber"   gencodec:"required"`
-	GasLimit           hexutil.Uint64      `json:"gasLimit"      gencodec:"required"`
-	GasUsed            hexutil.Uint64      `json:"gasUsed"       gencodec:"required"`
-	Timestamp          hexutil.Uint64      `json:"timestamp"     gencodec:"required"`
-	ExtraData          hexutility.Bytes    `json:"extraData"     gencodec:"required"`
-	BaseFeePerGas      *hexutil.Big        `json:"baseFeePerGas" gencodec:"required"`
-	BlockHash          common.Hash         `json:"blockHash"     gencodec:"required"`
-	Transactions       []hexutility.Bytes  `json:"transactions"  gencodec:"required"`
-	Withdrawals        []*types.Withdrawal `json:"withdrawals"`
-	BlobGasUsed        *hexutil.Uint64     `json:"blobGasUsed"`
-	ExcessBlobGas      *hexutil.Uint64     `json:"excessBlobGas"`
-	DepositRequests    types.Deposits      `json:"depositRequests"` // do not forget to add it into erigon-lib/gointerfaces/types if needed
-	WithdrawalRequests types.Requests      `json:"withdrawalRequests"`
+	ParentHash         common.Hash           `json:"parentHash"    gencodec:"required"`
+	FeeRecipient       common.Address        `json:"feeRecipient"  gencodec:"required"`
+	StateRoot          common.Hash           `json:"stateRoot"     gencodec:"required"`
+	ReceiptsRoot       common.Hash           `json:"receiptsRoot"  gencodec:"required"`
+	LogsBloom          hexutility.Bytes      `json:"logsBloom"     gencodec:"required"`
+	PrevRandao         common.Hash           `json:"prevRandao"    gencodec:"required"`
+	BlockNumber        hexutil.Uint64        `json:"blockNumber"   gencodec:"required"`
+	GasLimit           hexutil.Uint64        `json:"gasLimit"      gencodec:"required"`
+	GasUsed            hexutil.Uint64        `json:"gasUsed"       gencodec:"required"`
+	Timestamp          hexutil.Uint64        `json:"timestamp"     gencodec:"required"`
+	ExtraData          hexutility.Bytes      `json:"extraData"     gencodec:"required"`
+	BaseFeePerGas      *hexutil.Big          `json:"baseFeePerGas" gencodec:"required"`
+	BlockHash          common.Hash           `json:"blockHash"     gencodec:"required"`
+	Transactions       []hexutility.Bytes    `json:"transactions"  gencodec:"required"`
+	Withdrawals        []*types.Withdrawal   `json:"withdrawals"`
+	BlobGasUsed        *hexutil.Uint64       `json:"blobGasUsed"`
+	ExcessBlobGas      *hexutil.Uint64       `json:"excessBlobGas"`
+	DepositRequests    types.DepositRequests `json:"depositRequests"` // do not forget to add it into erigon-lib/gointerfaces/types if needed
+	WithdrawalRequests types.Requests        `json:"withdrawalRequests"`
 }
 
 // PayloadAttributes represent the attributes required to start assembling a payload


### PR DESCRIPTION
This is for consistency and since `Withdrawals` is already a terminology used, to which the "deposits" in the context is not 1-to-1 counterpart.