### PR TITLE
stagedsync: polygon sync stage fix invalid baseFee error

### DIFF
--- a/eth/stagedsync/stage_polygon_sync.go
+++ b/eth/stagedsync/stage_polygon_sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
 	"time"
 
 	"github.com/ledgerwatch/log/v3"
@@ -289,10 +290,11 @@ func (s *polygonSyncStageService) handleInsertBlocks(ctx context.Context, tx kv.
 		metrics.UpdateBlockConsumerHeaderDownloadDelay(header.Time, height-1, s.logger)
 		metrics.UpdateBlockConsumerBodyDownloadDelay(header.Time, height-1, s.logger)
 
-		parentTd := common.Big0
+		var parentTd *big.Int
+		var err error
 		if height > 0 {
 			// Parent's total difficulty
-			parentTd, err := rawdb.ReadTd(tx, header.ParentHash, height-1)
+			parentTd, err = rawdb.ReadTd(tx, header.ParentHash, height-1)
 			if err != nil || parentTd == nil {
 				return fmt.Errorf(
 					"parent's total difficulty not found with hash %x and height %d: %v",
@@ -301,6 +303,8 @@ func (s *polygonSyncStageService) handleInsertBlocks(ctx context.Context, tx kv.
 					err,
 				)
 			}
+		} else {
+			parentTd = big.NewInt(0)
 		}
 
 		td := parentTd.Add(parentTd, header.Difficulty)

--- a/turbo/execution/eth1/inserters.go
+++ b/turbo/execution/eth1/inserters.go
@@ -3,9 +3,9 @@ package eth1
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"reflect"
 
-	"github.com/ledgerwatch/erigon-lib/common"
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/common/metrics"
 	execution "github.com/ledgerwatch/erigon-lib/gointerfaces/executionproto"
@@ -64,7 +64,7 @@ func (e *EthereumExecutionModule) InsertBlocks(ctx context.Context, req *executi
 		if err != nil {
 			return nil, fmt.Errorf("ethereumExecutionModule.InsertBlocks: cannot convert body: %s", err)
 		}
-		parentTd := common.Big0
+		var parentTd *big.Int
 		height := header.Number.Uint64()
 		if height > 0 {
 			// Parent's total difficulty
@@ -72,6 +72,8 @@ func (e *EthereumExecutionModule) InsertBlocks(ctx context.Context, req *executi
 			if err != nil || parentTd == nil {
 				return nil, fmt.Errorf("parent's total difficulty not found with hash %x and height %d: %v", header.ParentHash, height-1, err)
 			}
+		} else {
+			parentTd = big.NewInt(0)
 		}
 
 		metrics.UpdateBlockConsumerHeaderDownloadDelay(header.Time, height-1, e.logger)


### PR DESCRIPTION
One of those bugs...

We were getting the below error when syncing at the tip of the chain with the new polygon sync stage:
```
DBUG[06-06|17:47:24.707] [sync] onNewBlockEvent: couldn't connect a header to the local chain tip, ignoring err="canonicalChainBuilder.Connect: invalid header error invalid baseFee: have 15, want 14017, parentBaseFee 15, parentGasUsed 0"
```

This error is coming from the `VerifyEip1559Header` function and it is a very subtle one. There was nothing wrong with the calculation of Eip1559 base fee or the headers themselves. The issue was coming from the fact that we were unintentionally mutating the `common.Big0` static variable (of type `*big.Int`) which then interfered with subsequent calculations of `VerifyEip1559Header` which uses `common.Big0` [here](https://github.com/ledgerwatch/erigon/blob/main/consensus/misc/eip1559.go#L134-L137). I inspected all usages of `common.Big0` in the codebase and found 2 potential places where mutation can happen: [here](https://github.com/ledgerwatch/erigon/blob/main/turbo/execution/eth1/inserters.go#L81) (not the cause of this error but fixing just in case) and [here](https://github.com/ledgerwatch/erigon/blob/main/eth/stagedsync/stage_polygon_sync.go#L306) (causing this error) - for both check how the `parentTd` variable is initialised and changed.