### PR TITLE
qa-tests: save runner name 

### DIFF
--- a/.github/workflows/qa-clean-exit-block-downloading.yml
+++ b/.github/workflows/qa-clean-exit-block-downloading.yml
@@ -42,7 +42,8 @@ jobs:
         set +e # Disable exit on error
         
         # Run Erigon, send ctrl-c and check logs
-        python3 $ERIGON_QA_PATH/test_system/qa-tests/clean-exit/run_and_check_clean_exit.py ${{ github.workspace }}/build/bin $ERIGON_TESTBED_DATA_DIR $WORKING_TIME_SECONDS Erigon3
+        python3 $ERIGON_QA_PATH/test_system/qa-tests/clean-exit/run_and_check_clean_exit.py \
+            ${{ github.workspace }}/build/bin $ERIGON_TESTBED_DATA_DIR $WORKING_TIME_SECONDS Erigon3
   
         # Capture monitoring script exit status
         test_exit_status=$?
@@ -79,7 +80,16 @@ jobs:
       if: steps.test_step.outputs.test_executed == 'true'
       env:
         TEST_RESULT: ${{ steps.test_step.outputs.TEST_RESULT }}
-      run: python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py --repo erigon --commit $(git rev-parse HEAD) --branch ${{ github.ref_name }} --test_name clean-exit-block-downloading --chain $CHAIN --outcome $TEST_RESULT --result_file ${{ github.workspace }}/result.json
+      run: |
+        python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py \
+          --repo erigon \
+          --commit $(git rev-parse HEAD) \
+          --branch ${{ github.ref_name }} \
+          --test_name clean-exit-block-downloading \
+          --chain $CHAIN \ 
+          --runner ${{ runner.name }} \
+          --outcome $TEST_RESULT \
+          --result_file ${{ github.workspace }}/result.json
 
     - name: Upload test results
       if: steps.test_step.outputs.test_executed == 'true'

--- a/.github/workflows/qa-clean-exit-snapshot-downloading.yml
+++ b/.github/workflows/qa-clean-exit-snapshot-downloading.yml
@@ -11,6 +11,8 @@ on:
       - 'release/3.*'
     types:
       - ready_for_review
+      - opened
+      - synchronize
   workflow_dispatch:     # Run manually
 
 jobs:
@@ -46,7 +48,8 @@ jobs:
         set +e # Disable exit on error
         
         # Run Erigon, send ctrl-c and check logs
-        python3 $ERIGON_QA_PATH/test_system/qa-tests/clean-exit/run_and_check_clean_exit.py ${{ github.workspace }}/build/bin $ERIGON_DATA_DIR $WORKING_TIME_SECONDS Erigon3
+        python3 $ERIGON_QA_PATH/test_system/qa-tests/clean-exit/run_and_check_clean_exit.py \
+          ${{ github.workspace }}/build/bin $ERIGON_DATA_DIR $WORKING_TIME_SECONDS Erigon3
   
         # Capture monitoring script exit status
         test_exit_status=$?
@@ -83,7 +86,16 @@ jobs:
       if: steps.test_step.outputs.test_executed == 'true'
       env:
         TEST_RESULT: ${{ steps.test_step.outputs.TEST_RESULT }}
-      run: python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py --repo erigon --commit $(git rev-parse HEAD) --branch ${{ github.ref_name }} --test_name clean-exit-snapshot-downloading --chain $CHAIN --outcome $TEST_RESULT --result_file ${{ github.workspace }}/result.json
+      run: | 
+        python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py \
+          --repo erigon \
+          --commit $(git rev-parse HEAD) \
+          --branch ${{ github.ref_name }} \
+          --test_name clean-exit-snapshot-downloading \
+          --chain $CHAIN \
+          --runner ${{ runner.name }} \
+          --outcome $TEST_RESULT \
+          --result_file ${{ github.workspace }}/result.json
 
     - name: Upload test results
       if: steps.test_step.outputs.test_executed == 'true'

--- a/.github/workflows/qa-clean-exit-snapshot-downloading.yml
+++ b/.github/workflows/qa-clean-exit-snapshot-downloading.yml
@@ -11,8 +11,6 @@ on:
       - 'release/3.*'
     types:
       - ready_for_review
-      - opened
-      - synchronize
   workflow_dispatch:     # Run manually
 
 jobs:

--- a/.github/workflows/qa-snap-download.yml
+++ b/.github/workflows/qa-snap-download.yml
@@ -39,7 +39,8 @@ jobs:
         set +e # Disable exit on error
              
         # Run Erigon, monitor snapshot downloading and check logs
-        python3 $ERIGON_QA_PATH/test_system/qa-tests/snap-download/run_and_check_snap_download.py ${{ github.workspace }}/build/bin $ERIGON_DATA_DIR $TOTAL_TIME_SECONDS Erigon3 $CHAIN
+        python3 $ERIGON_QA_PATH/test_system/qa-tests/snap-download/run_and_check_snap_download.py \
+          ${{ github.workspace }}/build/bin $ERIGON_DATA_DIR $TOTAL_TIME_SECONDS Erigon3 $CHAIN
   
         # Capture monitoring script exit status
         test_exit_status=$?
@@ -76,7 +77,16 @@ jobs:
       if: steps.test_step.outputs.test_executed == 'true'
       env:
         TEST_RESULT: ${{ steps.test_step.outputs.TEST_RESULT }}
-      run: python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py --repo erigon --commit $(git rev-parse HEAD) --branch ${{ github.ref_name }} --test_name snap-download --chain $CHAIN --outcome $TEST_RESULT --result_file ${{ github.workspace }}/result-$CHAIN.json
+      run: |
+        python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py \
+          --repo erigon \
+          --commit $(git rev-parse HEAD) \
+          --branch ${{ github.ref_name }} \
+          --test_name snap-download \
+          --chain $CHAIN \
+          --runner ${{ runner.name }} \
+          --outcome $TEST_RESULT \
+          --result_file ${{ github.workspace }}/result-$CHAIN.json
 
     - name: Upload test results
       if: steps.test_step.outputs.test_executed == 'true'

--- a/.github/workflows/qa-sync-from-scratch.yml
+++ b/.github/workflows/qa-sync-from-scratch.yml
@@ -44,7 +44,8 @@ jobs:
         set +e # Disable exit on error
              
         # Run Erigon, wait sync and check ability to maintain sync
-        python3 $ERIGON_QA_PATH/test_system/qa-tests/tip-tracking/run_and_check_tip_tracking.py ${{ github.workspace }}/build/bin $ERIGON_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 $CHAIN
+        python3 $ERIGON_QA_PATH/test_system/qa-tests/tip-tracking/run_and_check_tip_tracking.py \
+          ${{ github.workspace }}/build/bin $ERIGON_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 $CHAIN
         
         # Capture monitoring script exit status
         test_exit_status=$?
@@ -81,7 +82,16 @@ jobs:
       if: steps.test_step.outputs.test_executed == 'true'
       env:
         TEST_RESULT: ${{ steps.test_step.outputs.TEST_RESULT }}
-      run: python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py --repo erigon --commit $(git rev-parse HEAD) --branch ${{ github.ref_name }} --test_name sync-from-scratch --chain $CHAIN --outcome $TEST_RESULT --result_file ${{ github.workspace }}/result-$CHAIN.json
+      run: |
+        python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py \
+          --repo erigon \
+          --commit $(git rev-parse HEAD) \
+          --branch ${{ github.ref_name }} \
+          --test_name sync-from-scratch \
+          --chain $CHAIN \
+          --runner ${{ runner.name }} \
+          --outcome $TEST_RESULT \
+          --result_file ${{ github.workspace }}/result-$CHAIN.json
 
     - name: Upload test results
       if: steps.test_step.outputs.test_executed == 'true'

--- a/.github/workflows/qa-tip-tracking.yml
+++ b/.github/workflows/qa-tip-tracking.yml
@@ -46,7 +46,8 @@ jobs:
         # 1. Launch the testbed Erigon instance
         # 2. Allow time for the Erigon to achieve synchronization
         # 3. Begin timing the duration that Erigon maintains synchronization
-        python3 $ERIGON_QA_PATH/test_system/qa-tests/tip-tracking/run_and_check_tip_tracking.py ${{ github.workspace }}/build/bin $ERIGON_TESTBED_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 $CHAIN
+        python3 $ERIGON_QA_PATH/test_system/qa-tests/tip-tracking/run_and_check_tip_tracking.py \
+          ${{ github.workspace }}/build/bin $ERIGON_TESTBED_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 $CHAIN
   
         # Capture monitoring script exit status
         test_exit_status=$?
@@ -83,7 +84,16 @@ jobs:
       if: steps.test_step.outputs.test_executed == 'true'
       env:
         TEST_RESULT: ${{ steps.test_step.outputs.TEST_RESULT }}
-      run: python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py --repo erigon --commit $(git rev-parse HEAD) --branch ${{ github.ref_name }} --test_name tip-tracking --chain $CHAIN --outcome $TEST_RESULT --result_file ${{ github.workspace }}/result-$CHAIN.json
+      run: |
+        python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py \
+          --repo erigon \
+          --commit $(git rev-parse HEAD) \
+          --branch ${{ github.ref_name }} \
+          --test_name tip-tracking \
+          --chain $CHAIN \
+          --runner ${{ runner.name }} \
+          --outcome $TEST_RESULT \
+          --result_file ${{ github.workspace }}/result-$CHAIN.json
 
     - name: Upload test results
       if: steps.test_step.outputs.test_executed == 'true'


### PR DESCRIPTION
Store the self-hosted runner name in the MongoDB database of test results to better compare performance between test runs. The runner name is associated with its hardware configuration in a MongoDB table.