### PR TITLE
chore: Rename txAmount to txCount

### DIFF
--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -541,11 +541,11 @@ func extractBodies(datadir string) error {
 			var lastBlockNum, lastBaseTxNum, lastAmount uint64
 			var prevBlockNum, prevBaseTxNum, prevAmount uint64
 			first := true
-			sn.Iterate(func(blockNum uint64, baseTxNum uint64, txAmount uint64) error {
+			sn.Iterate(func(blockNum uint64, baseTxNum uint64, txCount uint64) error {
 				if first {
 					firstBlockNum = blockNum
 					firstBaseTxNum = baseTxNum
-					firstAmount = txAmount
+					firstAmount = txCount
 					first = false
 				} else {
 					if blockNum != prevBlockNum+1 {
@@ -559,8 +559,8 @@ func extractBodies(datadir string) error {
 				lastBlockNum = blockNum
 				prevBaseTxNum = baseTxNum
 				lastBaseTxNum = baseTxNum
-				prevAmount = txAmount
-				lastAmount = txAmount
+				prevAmount = txCount
+				lastAmount = txCount
 				return nil
 			})
 			fmt.Printf("Seg: [%d, %d, %d] => [%d, %d, %d]\n", firstBlockNum, firstBaseTxNum, firstAmount, lastBlockNum, lastBaseTxNum, lastAmount)
@@ -594,8 +594,8 @@ func extractBodies(datadir string) error {
 		if hash, err = br.CanonicalHash(context.Background(), tx, blockNumber); err != nil {
 			return err
 		}
-		_, baseTxId, txAmount := rawdb.ReadBody(tx, blockHash, blockNumber)
-		fmt.Printf("Body %d %x: baseTxId %d, txAmount %d\n", blockNumber, blockHash, baseTxId, txAmount)
+		_, baseTxId, txCount := rawdb.ReadBody(tx, blockHash, blockNumber)
+		fmt.Printf("Body %d %x: baseTxId %d, txCount %d\n", blockNumber, blockHash, baseTxId, txCount)
 		if hash != blockHash {
 			fmt.Printf("Non-canonical\n")
 			continue
@@ -606,7 +606,7 @@ func extractBodies(datadir string) error {
 				fmt.Printf("Mismatch txId for block %d, txId = %d, baseTxId = %d\n", blockNumber, txId, baseTxId)
 			}
 		}
-		txId = baseTxId + uint64(txAmount) + 2
+		txId = baseTxId + uint64(txCount) + 2
 		if i == 50 {
 			break
 		}
@@ -901,7 +901,7 @@ func trimTxs(chaindata string) error {
 			return err
 		}
 		// Remove from the map
-		toDelete.RemoveRange(body.BaseTxId, body.BaseTxId+uint64(body.TxAmount))
+		toDelete.RemoveRange(body.BaseTxId, body.BaseTxId+uint64(body.TxCount))
 	}
 	fmt.Printf("Number of tx records to delete: %d\n", toDelete.GetCardinality())
 	// Takes 20min to iterate 1.4b

--- a/cmd/rpcdaemon/rpcservices/eth_backend.go
+++ b/cmd/rpcdaemon/rpcservices/eth_backend.go
@@ -256,7 +256,7 @@ func (back *RemoteBackend) BlockWithSenders(ctx context.Context, tx kv.Getter, h
 	return back.blockReader.BlockWithSenders(ctx, tx, hash, blockNum)
 }
 
-func (back *RemoteBackend) IterateFrozenBodies(_ func(blockNum uint64, baseTxNum uint64, txAmount uint64) error) error {
+func (back *RemoteBackend) IterateFrozenBodies(_ func(blockNum uint64, baseTxNum uint64, txCount uint64) error) error {
 	panic("not implemented")
 }
 
@@ -266,7 +266,7 @@ func (back *RemoteBackend) BodyWithTransactions(ctx context.Context, tx kv.Gette
 func (back *RemoteBackend) BodyRlp(ctx context.Context, tx kv.Getter, hash common.Hash, blockNum uint64) (bodyRlp rlp.RawValue, err error) {
 	return back.blockReader.BodyRlp(ctx, tx, hash, blockNum)
 }
-func (back *RemoteBackend) Body(ctx context.Context, tx kv.Getter, hash common.Hash, blockNum uint64) (body *types.Body, txAmount uint32, err error) {
+func (back *RemoteBackend) Body(ctx context.Context, tx kv.Getter, hash common.Hash, blockNum uint64) (body *types.Body, txCount uint32, err error) {
 	return back.blockReader.Body(ctx, tx, hash, blockNum)
 }
 func (back *RemoteBackend) Header(ctx context.Context, tx kv.Getter, hash common.Hash, blockNum uint64) (*types.Header, error) {

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -513,17 +513,17 @@ func ReadBodyByNumber(db kv.Tx, number uint64) (*types.Body, uint64, uint32, err
 	if hash == (common.Hash{}) {
 		return nil, 0, 0, nil
 	}
-	body, baseTxId, txAmount := ReadBody(db, hash, number)
-	return body, baseTxId, txAmount, nil
+	body, baseTxId, txCount := ReadBody(db, hash, number)
+	return body, baseTxId, txCount, nil
 }
 
 func ReadBodyWithTransactions(db kv.Getter, hash common.Hash, number uint64) (*types.Body, error) {
-	body, baseTxId, txAmount := ReadBody(db, hash, number)
+	body, baseTxId, txCount := ReadBody(db, hash, number)
 	if body == nil {
 		return nil, nil
 	}
 	var err error
-	body.Transactions, err = CanonicalTransactions(db, baseTxId, txAmount)
+	body.Transactions, err = CanonicalTransactions(db, baseTxId, txCount)
 	if err != nil {
 		return nil, err
 	}
@@ -552,13 +552,13 @@ func RawTransactionsRange(db kv.Getter, from, to uint64) (res [][]byte, err erro
 		if len(bodyRlp) == 0 {
 			continue
 		}
-		baseTxId, txAmount, err := types.DecodeOnlyTxMetadataFromBody(bodyRlp)
+		baseTxId, txCount, err := types.DecodeOnlyTxMetadataFromBody(bodyRlp)
 		if err != nil {
 			return nil, err
 		}
 
 		binary.BigEndian.PutUint64(encNum, baseTxId)
-		if err = db.ForAmount(kv.EthTx, encNum, txAmount, func(k, v []byte) error {
+		if err = db.ForAmount(kv.EthTx, encNum, txCount, func(k, v []byte) error {
 			res = append(res, v)
 			return nil
 		}); err != nil {
@@ -610,10 +610,10 @@ func ReadBody(db kv.Getter, hash common.Hash, number uint64) (*types.Body, uint6
 	body.Withdrawals = bodyForStorage.Withdrawals
 	body.Requests = bodyForStorage.Requests
 
-	if bodyForStorage.TxAmount < 2 {
-		panic(fmt.Sprintf("block body hash too few txs amount: %d, %d", number, bodyForStorage.TxAmount))
+	if bodyForStorage.TxCount < 2 {
+		panic(fmt.Sprintf("block body hash too few txs amount: %d, %d", number, bodyForStorage.TxCount))
 	}
-	return body, bodyForStorage.BaseTxId + 1, bodyForStorage.TxAmount - 2 // 1 system txn in the begining of block, and 1 at the end
+	return body, bodyForStorage.BaseTxId + 1, bodyForStorage.TxCount - 2 // 1 system txn in the begining of block, and 1 at the end
 }
 
 func HasSenders(db kv.Getter, hash common.Hash, number uint64) (bool, error) {
@@ -650,7 +650,7 @@ func WriteRawBody(db kv.RwTx, hash common.Hash, number uint64, body *types.RawBo
 	}
 	data := types.BodyForStorage{
 		BaseTxId:    baseTxnID,
-		TxAmount:    uint32(len(body.Transactions)) + 2, /*system txs*/
+		TxCount:     uint32(len(body.Transactions)) + 2, /*system txs*/
 		Uncles:      body.Uncles,
 		Withdrawals: body.Withdrawals,
 		Requests:    body.Requests,
@@ -674,7 +674,7 @@ func WriteBody(db kv.RwTx, hash common.Hash, number uint64, body *types.Body) (e
 	}
 	data := types.BodyForStorage{
 		BaseTxId:    baseTxId,
-		TxAmount:    uint32(len(body.Transactions)) + 2,
+		TxCount:     uint32(len(body.Transactions)) + 2,
 		Uncles:      body.Uncles,
 		Withdrawals: body.Withdrawals,
 		Requests:    body.Requests,
@@ -734,7 +734,7 @@ func AppendCanonicalTxNums(tx kv.RwTx, from uint64) (err error) {
 			return err
 		}
 
-		nextBaseTxNum += int(bodyForStorage.TxAmount)
+		nextBaseTxNum += int(bodyForStorage.TxCount)
 		err = rawdbv3.TxNums.Append(tx, blockNum, uint64(nextBaseTxNum-1))
 		if err != nil {
 			return err
@@ -1060,7 +1060,7 @@ func PruneBlocks(tx kv.RwTx, blockTo uint64, blocksDeleteLimit int) (deleted int
 			log.Debug("PruneBlocks: block body not found", "height", n)
 		} else {
 			txIDBytes := make([]byte, 8)
-			for txID := b.BaseTxId; txID < b.BaseTxId+uint64(b.TxAmount); txID++ {
+			for txID := b.BaseTxId; txID < b.BaseTxId+uint64(b.TxCount); txID++ {
 				binary.BigEndian.PutUint64(txIDBytes, txID)
 				if err = tx.Delete(kv.EthTx, txIDBytes); err != nil {
 					return deleted, err
@@ -1108,7 +1108,7 @@ func TruncateBlocks(ctx context.Context, tx kv.RwTx, blockFrom uint64) error {
 		}
 		if b != nil {
 			txIDBytes := make([]byte, 8)
-			for txID := b.BaseTxId; txID < b.BaseTxId+uint64(b.TxAmount); txID++ {
+			for txID := b.BaseTxId; txID < b.BaseTxId+uint64(b.TxCount); txID++ {
 				binary.BigEndian.PutUint64(txIDBytes, txID)
 				if err = tx.Delete(kv.EthTx, txIDBytes); err != nil {
 					return err

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -773,7 +773,7 @@ func TestPreShanghaiBodyForStorageNoPanicOnWithdrawals(t *testing.T) {
 	rlp.DecodeBytes(bstring, body)
 
 	require.Nil(body.Withdrawals)
-	require.Equal(uint32(2), body.TxAmount)
+	require.Equal(uint32(2), body.TxCount)
 }
 
 // Tests shanghai bodyForStorage to make sure withdrawals are present
@@ -789,7 +789,7 @@ func TestShanghaiBodyForStorageHasWithdrawals(t *testing.T) {
 
 	require.NotNil(body.Withdrawals)
 	require.Equal(2, len(body.Withdrawals))
-	require.Equal(uint32(2), body.TxAmount)
+	require.Equal(uint32(2), body.TxCount)
 }
 
 // Tests shanghai bodyForStorage to make sure when no withdrawals the slice is empty (not nil)
@@ -805,7 +805,7 @@ func TestShanghaiBodyForStorageNoWithdrawals(t *testing.T) {
 
 	require.NotNil(body.Withdrawals)
 	require.Equal(0, len(body.Withdrawals))
-	require.Equal(uint32(2), body.TxAmount)
+	require.Equal(uint32(2), body.TxCount)
 }
 
 func checkReceiptsRLP(have, want types.Receipts) error {

--- a/core/rawdb/accessors_iter.go
+++ b/core/rawdb/accessors_iter.go
@@ -130,9 +130,9 @@ func (s *CanonicalTxnIds) advance() (err error) {
 
 	if s.orderAscend {
 		s.currentTxNum = int(body.BaseTxId)
-		s.endOfCurrentBlock = body.BaseTxId + uint64(body.TxAmount) // 2 system txs already included in TxAmount
+		s.endOfCurrentBlock = body.BaseTxId + uint64(body.TxCount) // 2 system txs already included in TxAmount
 	} else {
-		s.currentTxNum = int(body.BaseTxId) + int(body.TxAmount) - 1 // 2 system txs already included in TxAmount
+		s.currentTxNum = int(body.BaseTxId) + int(body.TxCount) - 1 // 2 system txs already included in TxAmount
 		s.endOfCurrentBlock = body.BaseTxId - 1                      // and one of them is baseTxId
 	}
 	return nil

--- a/core/rawdb/accessors_iter.go
+++ b/core/rawdb/accessors_iter.go
@@ -133,7 +133,7 @@ func (s *CanonicalTxnIds) advance() (err error) {
 		s.endOfCurrentBlock = body.BaseTxId + uint64(body.TxCount) // 2 system txs already included in TxAmount
 	} else {
 		s.currentTxNum = int(body.BaseTxId) + int(body.TxCount) - 1 // 2 system txs already included in TxAmount
-		s.endOfCurrentBlock = body.BaseTxId - 1                      // and one of them is baseTxId
+		s.endOfCurrentBlock = body.BaseTxId - 1                     // and one of them is baseTxId
 	}
 	return nil
 }

--- a/core/snaptype/block_types.go
+++ b/core/snaptype/block_types.go
@@ -231,7 +231,7 @@ var (
 						default:
 						}
 
-						for body.BaseTxId+uint64(body.TxAmount) <= firstTxID+i { // skip empty blocks
+						for body.BaseTxId+uint64(body.TxCount) <= firstTxID+i { // skip empty blocks
 							if !bodyGetter.HasNext() {
 								return fmt.Errorf("not enough bodies")
 							}
@@ -327,6 +327,6 @@ func txsAmountBasedOnBodiesSnapshots(bodiesSegment *seg.Decompressor, len uint64
 		return 0, 0, fmt.Errorf("negative txs count %s: lastBody.BaseTxId=%d < firstBody.BaseTxId=%d", bodiesSegment.FileName(), lastBody.BaseTxId, firstBody.BaseTxId)
 	}
 
-	expectedCount = int(lastBody.BaseTxId+uint64(lastBody.TxAmount)) - int(firstBody.BaseTxId)
+	expectedCount = int(lastBody.BaseTxId+uint64(lastBody.TxCount)) - int(firstBody.BaseTxId)
 	return
 }

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -642,7 +642,7 @@ type RawBody struct {
 
 type BodyForStorage struct {
 	BaseTxId    uint64
-	TxAmount    uint32
+	TxCount     uint32
 	Uncles      []*Header
 	Withdrawals []*Withdrawal
 	Requests    Requests
@@ -812,10 +812,10 @@ func (rb *RawBody) DecodeRLP(s *rlp.Stream) error {
 
 func (bfs BodyForStorage) payloadSize() (payloadSize, unclesLen, withdrawalsLen, requestsLen int) {
 	baseTxIdLen := 1 + rlp.IntLenExcludingHead(bfs.BaseTxId)
-	txAmountLen := 1 + rlp.IntLenExcludingHead(uint64(bfs.TxAmount))
+	txCountLen := 1 + rlp.IntLenExcludingHead(uint64(bfs.TxCount))
 
 	payloadSize += baseTxIdLen
-	payloadSize += txAmountLen
+	payloadSize += txCountLen
 
 	// size of Uncles
 	unclesLen += encodingSizeGeneric(bfs.Uncles)
@@ -850,8 +850,8 @@ func (bfs BodyForStorage) EncodeRLP(w io.Writer) error {
 		return err
 	}
 
-	// encode TxAmount
-	if err := rlp.Encode(w, bfs.TxAmount); err != nil {
+	// encode TxCount
+	if err := rlp.Encode(w, bfs.TxCount); err != nil {
 		return err
 	}
 
@@ -883,8 +883,8 @@ func (bfs *BodyForStorage) DecodeRLP(s *rlp.Stream) error {
 	if err = s.Decode(&bfs.BaseTxId); err != nil {
 		return err
 	}
-	// decode TxAmount
-	if err = s.Decode(&bfs.TxAmount); err != nil {
+	// decode TxCount
+	if err = s.Decode(&bfs.TxCount); err != nil {
 		return err
 	}
 	// decode Uncles
@@ -1496,18 +1496,18 @@ func (b *Block) Hash() libcommon.Hash {
 
 type Blocks []*Block
 
-func DecodeOnlyTxMetadataFromBody(payload []byte) (baseTxId uint64, txAmount uint32, err error) {
+func DecodeOnlyTxMetadataFromBody(payload []byte) (baseTxId uint64, txCount uint32, err error) {
 	pos, _, err := rlp2.List(payload, 0)
 	if err != nil {
-		return baseTxId, txAmount, err
+		return baseTxId, txCount, err
 	}
 	pos, baseTxId, err = rlp2.U64(payload, pos)
 	if err != nil {
-		return baseTxId, txAmount, err
+		return baseTxId, txCount, err
 	}
-	_, txAmount, err = rlp2.U32(payload, pos)
+	_, txCount, err = rlp2.U32(payload, pos)
 	if err != nil {
-		return baseTxId, txAmount, err
+		return baseTxId, txCount, err
 	}
 	return
 }

--- a/erigon-lib/state/inverted_index_test.go
+++ b/erigon-lib/state/inverted_index_test.go
@@ -548,7 +548,7 @@ func TestInvIndexScanFiles(t *testing.T) {
 	ii, err = NewInvertedIndex(cfg, ii.aggregationStep, ii.filenameBase, ii.indexKeysTable, ii.indexTable, nil, logger)
 	require.NoError(err)
 	defer ii.Close()
-	err = ii.OpenFolder(true)
+	err = ii.OpenFolder()
 	require.NoError(err)
 
 	mergeInverted(t, db, ii, txs)

--- a/turbo/jsonrpc/eth_block.go
+++ b/turbo/jsonrpc/eth_block.go
@@ -339,7 +339,7 @@ func (api *APIImpl) GetBlockTransactionCountByNumber(ctx context.Context, blockN
 		return nil, nil
 	}
 
-	_, txAmount, err := api._blockReader.Body(ctx, tx, blockHash, blockNum)
+	_, txCount, err := api._blockReader.Body(ctx, tx, blockHash, blockNum)
 	if err != nil {
 		return nil, err
 	}
@@ -356,11 +356,11 @@ func (api *APIImpl) GetBlockTransactionCountByNumber(ctx context.Context, blockN
 			return nil, err
 		}
 		if ok {
-			txAmount++
+			txCount++
 		}
 	}
 
-	numOfTx := hexutil.Uint(txAmount)
+	numOfTx := hexutil.Uint(txCount)
 
 	return &numOfTx, nil
 }
@@ -380,7 +380,7 @@ func (api *APIImpl) GetBlockTransactionCountByHash(ctx context.Context, blockHas
 		return nil, nil
 	}
 
-	_, txAmount, err := api._blockReader.Body(ctx, tx, blockHash, blockNum)
+	_, txCount, err := api._blockReader.Body(ctx, tx, blockHash, blockNum)
 	if err != nil {
 		return nil, err
 	}
@@ -397,11 +397,11 @@ func (api *APIImpl) GetBlockTransactionCountByHash(ctx context.Context, blockHas
 			return nil, err
 		}
 		if ok {
-			txAmount++
+			txCount++
 		}
 	}
 
-	numOfTx := hexutil.Uint(txAmount)
+	numOfTx := hexutil.Uint(txCount)
 
 	return &numOfTx, nil
 }

--- a/turbo/jsonrpc/eth_block_test.go
+++ b/turbo/jsonrpc/eth_block_test.go
@@ -200,12 +200,12 @@ func TestGetBlockTransactionCountByHash(t *testing.T) {
 
 	expectedAmount := hexutil.Uint(len(bodyWithTx.Transactions))
 
-	txAmount, err := api.GetBlockTransactionCountByHash(ctx, blockHash)
+	txCount, err := api.GetBlockTransactionCountByHash(ctx, blockHash)
 	if err != nil {
 		t.Errorf("failed getting the transaction count, err=%s", err)
 	}
 
-	assert.Equal(t, expectedAmount, *txAmount)
+	assert.Equal(t, expectedAmount, *txCount)
 }
 
 func TestGetBlockTransactionCountByHash_ZeroTx(t *testing.T) {
@@ -232,12 +232,12 @@ func TestGetBlockTransactionCountByHash_ZeroTx(t *testing.T) {
 
 	expectedAmount := hexutil.Uint(len(bodyWithTx.Transactions))
 
-	txAmount, err := api.GetBlockTransactionCountByHash(ctx, blockHash)
+	txCount, err := api.GetBlockTransactionCountByHash(ctx, blockHash)
 	if err != nil {
 		t.Errorf("failed getting the transaction count, err=%s", err)
 	}
 
-	assert.Equal(t, expectedAmount, *txAmount)
+	assert.Equal(t, expectedAmount, *txCount)
 }
 
 func TestGetBlockTransactionCountByNumber(t *testing.T) {
@@ -264,12 +264,12 @@ func TestGetBlockTransactionCountByNumber(t *testing.T) {
 
 	expectedAmount := hexutil.Uint(len(bodyWithTx.Transactions))
 
-	txAmount, err := api.GetBlockTransactionCountByNumber(ctx, rpc.BlockNumber(header.Number.Uint64()))
+	txCount, err := api.GetBlockTransactionCountByNumber(ctx, rpc.BlockNumber(header.Number.Uint64()))
 	if err != nil {
 		t.Errorf("failed getting the transaction count, err=%s", err)
 	}
 
-	assert.Equal(t, expectedAmount, *txAmount)
+	assert.Equal(t, expectedAmount, *txCount)
 }
 
 func TestGetBlockTransactionCountByNumber_ZeroTx(t *testing.T) {
@@ -297,10 +297,10 @@ func TestGetBlockTransactionCountByNumber_ZeroTx(t *testing.T) {
 
 	expectedAmount := hexutil.Uint(len(bodyWithTx.Transactions))
 
-	txAmount, err := api.GetBlockTransactionCountByNumber(ctx, rpc.BlockNumber(header.Number.Uint64()))
+	txCount, err := api.GetBlockTransactionCountByNumber(ctx, rpc.BlockNumber(header.Number.Uint64()))
 	if err != nil {
 		t.Errorf("failed getting the transaction count, err=%s", err)
 	}
 
-	assert.Equal(t, expectedAmount, *txAmount)
+	assert.Equal(t, expectedAmount, *txCount)
 }

--- a/turbo/services/interfaces.go
+++ b/turbo/services/interfaces.go
@@ -23,7 +23,7 @@ type BlockReader interface {
 	BlockByHash(ctx context.Context, db kv.Tx, hash common.Hash) (*types.Block, error)
 	CurrentBlock(db kv.Tx) (*types.Block, error)
 	BlockWithSenders(ctx context.Context, tx kv.Getter, hash common.Hash, blockNum uint64) (block *types.Block, senders []common.Address, err error)
-	IterateFrozenBodies(f func(blockNum, baseTxNum, txAmount uint64) error) error
+	IterateFrozenBodies(f func(blockNum, baseTxNum, txCount uint64) error) error
 }
 
 type HeaderReader interface {
@@ -69,7 +69,7 @@ type CanonicalReader interface {
 type BodyReader interface {
 	BodyWithTransactions(ctx context.Context, tx kv.Getter, hash common.Hash, blockNum uint64) (body *types.Body, err error)
 	BodyRlp(ctx context.Context, tx kv.Getter, hash common.Hash, blockNum uint64) (bodyRlp rlp.RawValue, err error)
-	Body(ctx context.Context, tx kv.Getter, hash common.Hash, blockNum uint64) (body *types.Body, txAmount uint32, err error)
+	Body(ctx context.Context, tx kv.Getter, hash common.Hash, blockNum uint64) (body *types.Body, txCount uint32, err error)
 	HasSenders(ctx context.Context, tx kv.Getter, hash common.Hash, blockNum uint64) (bool, error)
 }
 

--- a/turbo/snapshotsync/freezeblocks/block_reader.go
+++ b/turbo/snapshotsync/freezeblocks/block_reader.go
@@ -191,7 +191,7 @@ func (r *RemoteBlockReader) BlockWithSenders(ctx context.Context, _ kv.Getter, h
 	return block, senders, nil
 }
 
-func (r *RemoteBlockReader) IterateFrozenBodies(_ func(blockNum uint64, baseTxNum uint64, txAmount uint64) error) error {
+func (r *RemoteBlockReader) IterateFrozenBodies(_ func(blockNum uint64, baseTxNum uint64, txCount uint64) error) error {
 	panic("not implemented")
 }
 
@@ -205,7 +205,7 @@ func (r *RemoteBlockReader) Header(ctx context.Context, tx kv.Getter, hash commo
 	}
 	return block.Header(), nil
 }
-func (r *RemoteBlockReader) Body(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (body *types.Body, txAmount uint32, err error) {
+func (r *RemoteBlockReader) Body(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (body *types.Body, txCount uint32, err error) {
 	block, _, err := r.BlockWithSenders(ctx, tx, hash, blockHeight)
 	if err != nil {
 		return nil, 0, err
@@ -504,7 +504,7 @@ func (r *BlockReader) BodyWithTransactions(ctx context.Context, tx kv.Getter, ha
 	defer view.Close()
 
 	var baseTxnID uint64
-	var txsAmount uint32
+	var txCount uint32
 	var buf []byte
 	seg, ok := view.BodiesSegment(blockHeight)
 	if !ok {
@@ -513,7 +513,7 @@ func (r *BlockReader) BodyWithTransactions(ctx context.Context, tx kv.Getter, ha
 		}
 		return nil, nil
 	}
-	body, baseTxnID, txsAmount, buf, err = r.bodyFromSnapshot(blockHeight, seg, buf)
+	body, baseTxnID, txCount, buf, err = r.bodyFromSnapshot(blockHeight, seg, buf)
 	if err != nil {
 		return nil, err
 	}
@@ -530,7 +530,7 @@ func (r *BlockReader) BodyWithTransactions(ctx context.Context, tx kv.Getter, ha
 		}
 		return nil, nil
 	}
-	txs, senders, err := r.txsFromSnapshot(baseTxnID, txsAmount, txnSeg, buf)
+	txs, senders, err := r.txsFromSnapshot(baseTxnID, txCount, txnSeg, buf)
 	if err != nil {
 		return nil, err
 	}
@@ -560,14 +560,14 @@ func (r *BlockReader) BodyRlp(ctx context.Context, tx kv.Getter, hash common.Has
 	return bodyRlp, nil
 }
 
-func (r *BlockReader) Body(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (body *types.Body, txAmount uint32, err error) {
+func (r *BlockReader) Body(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (body *types.Body, txCount uint32, err error) {
 	maxBlockNumInFiles := r.sn.BlocksAvailable()
 	if maxBlockNumInFiles == 0 || blockHeight > maxBlockNumInFiles {
 		if tx == nil {
 			return nil, 0, nil
 		}
-		body, _, txAmount = rawdb.ReadBody(tx, hash, blockHeight)
-		return body, txAmount, nil
+		body, _, txCount = rawdb.ReadBody(tx, hash, blockHeight)
+		return body, txCount, nil
 	}
 	view := r.sn.View()
 	defer view.Close()
@@ -576,11 +576,11 @@ func (r *BlockReader) Body(ctx context.Context, tx kv.Getter, hash common.Hash, 
 	if !ok {
 		return
 	}
-	body, _, txAmount, _, err = r.bodyFromSnapshot(blockHeight, seg, nil)
+	body, _, txCount, _, err = r.bodyFromSnapshot(blockHeight, seg, nil)
 	if err != nil {
 		return nil, 0, err
 	}
-	return body, txAmount, nil
+	return body, txCount, nil
 }
 
 func (r *BlockReader) HasSenders(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (bool, error) {
@@ -663,7 +663,7 @@ func (r *BlockReader) blockWithSenders(ctx context.Context, tx kv.Getter, hash c
 
 	var b *types.Body
 	var baseTxnId uint64
-	var txsAmount uint32
+	var txCount uint32
 	bodySeg, ok := view.BodiesSegment(blockHeight)
 	if !ok {
 		if dbgLogs {
@@ -671,7 +671,7 @@ func (r *BlockReader) blockWithSenders(ctx context.Context, tx kv.Getter, hash c
 		}
 		return
 	}
-	b, baseTxnId, txsAmount, buf, err = r.bodyFromSnapshot(blockHeight, bodySeg, buf)
+	b, baseTxnId, txCount, buf, err = r.bodyFromSnapshot(blockHeight, bodySeg, buf)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -681,7 +681,7 @@ func (r *BlockReader) blockWithSenders(ctx context.Context, tx kv.Getter, hash c
 		}
 		return
 	}
-	if txsAmount == 0 {
+	if txCount == 0 {
 		block = types.NewBlockFromStorage(hash, h, nil, b.Uncles, b.Withdrawals, b.Requests)
 		if len(senders) != block.Transactions().Len() {
 			if dbgLogs {
@@ -701,7 +701,7 @@ func (r *BlockReader) blockWithSenders(ctx context.Context, tx kv.Getter, hash c
 		return
 	}
 	var txs []types.Transaction
-	txs, senders, err = r.txsFromSnapshot(baseTxnId, txsAmount, txnSeg, buf)
+	txs, senders, err = r.txsFromSnapshot(baseTxnId, txCount, txnSeg, buf)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -794,11 +794,11 @@ func (r *BlockReader) bodyFromSnapshot(blockHeight uint64, sn *Segment, buf []by
 	body.Uncles = b.Uncles
 	body.Withdrawals = b.Withdrawals
 	body.Requests = b.Requests
-	var txsAmount uint32
-	if b.TxAmount >= 2 {
-		txsAmount = b.TxAmount - 2
+	var txCount uint32
+	if b.TxCount >= 2 {
+		txCount = b.TxCount - 2
 	}
-	return body, b.BaseTxId + 1, txsAmount, buf, nil // empty txs in the beginning and end of block
+	return body, b.BaseTxId + 1, txCount, buf, nil // empty txs in the beginning and end of block
 }
 
 func (r *BlockReader) bodyForStorageFromSnapshot(blockHeight uint64, sn *Segment, buf []byte) (*types.BodyForStorage, []byte, error) {
@@ -834,7 +834,7 @@ func (r *BlockReader) bodyForStorageFromSnapshot(blockHeight uint64, sn *Segment
 	return b, buf, nil
 }
 
-func (r *BlockReader) txsFromSnapshot(baseTxnID uint64, txsAmount uint32, txsSeg *Segment, buf []byte) (txs []types.Transaction, senders []common.Address, err error) {
+func (r *BlockReader) txsFromSnapshot(baseTxnID uint64, txCount uint32, txsSeg *Segment, buf []byte) (txs []types.Transaction, senders []common.Address, err error) {
 	defer func() {
 		if rec := recover(); rec != nil {
 			panic(fmt.Errorf("%+v, snapshot: %d-%d, trace: %s", rec, txsSeg.from, txsSeg.to, dbg.Stack()))
@@ -850,15 +850,15 @@ func (r *BlockReader) txsFromSnapshot(baseTxnID uint64, txsAmount uint32, txsSeg
 		return nil, nil, fmt.Errorf(".idx file has wrong baseDataID? %d<%d, %s", baseTxnID, idxTxnHash.BaseDataID(), txsSeg.FilePath())
 	}
 
-	txs = make([]types.Transaction, txsAmount)
-	senders = make([]common.Address, txsAmount)
-	if txsAmount == 0 {
+	txs = make([]types.Transaction, txCount)
+	senders = make([]common.Address, txCount)
+	if txCount == 0 {
 		return txs, senders, nil
 	}
 	txnOffset := idxTxnHash.OrdinalLookup(baseTxnID - idxTxnHash.BaseDataID())
 	gg := txsSeg.MakeGetter()
 	gg.Reset(txnOffset)
-	for i := uint32(0); i < txsAmount; i++ {
+	for i := uint32(0); i < txCount; i++ {
 		if !gg.HasNext() {
 			return nil, nil, nil
 		}
@@ -923,7 +923,7 @@ func (r *BlockReader) txnByHash(txnHash common.Hash, segments []*Segment, buf []
 		}
 		buf, _ = gg.Next(buf[:0])
 		senderByte, txnRlp := buf[1:1+20], buf[1+20:]
-		sender := *(*common.Address)(senderByte)
+		sender := (common.Address)(senderByte)
 
 		txn, err := types.DecodeTransaction(txnRlp)
 		if err != nil {
@@ -948,7 +948,7 @@ func (r *BlockReader) txnByHash(txnHash common.Hash, segments []*Segment, buf []
 }
 
 // TxnByIdxInBlock - doesn't include system-transactions in the begin/end of block
-// return nil if 0 < i < body.TxAmount
+// return nil if 0 < i < body.txCount
 func (r *BlockReader) TxnByIdxInBlock(ctx context.Context, tx kv.Getter, blockNum uint64, txIdxInBlock int) (txn types.Transaction, err error) {
 	maxBlockNumInFiles := r.sn.BlocksAvailable()
 	if maxBlockNumInFiles == 0 || blockNum > maxBlockNumInFiles {
@@ -976,7 +976,7 @@ func (r *BlockReader) TxnByIdxInBlock(ctx context.Context, tx kv.Getter, blockNu
 	}
 
 	// if block has no transactions, or requested txNum out of non-system transactions length
-	if b.TxAmount == 2 || txIdxInBlock == -1 || txIdxInBlock >= int(b.TxAmount-2) {
+	if b.TxCount == 2 || txIdxInBlock == -1 || txIdxInBlock >= int(b.TxCount-2) {
 		return nil, nil
 	}
 
@@ -1023,7 +1023,7 @@ func (r *BlockReader) FirstTxnNumNotInSnapshots() uint64 {
 	return lastTxnID
 }
 
-func (r *BlockReader) IterateFrozenBodies(f func(blockNum, baseTxNum, txAmount uint64) error) error {
+func (r *BlockReader) IterateFrozenBodies(f func(blockNum, baseTxNum, txCount uint64) error) error {
 	view := r.sn.View()
 	defer view.Close()
 	for _, sn := range view.Bodies() {
@@ -1039,7 +1039,7 @@ func (r *BlockReader) IterateFrozenBodies(f func(blockNum, baseTxNum, txAmount u
 			if err := rlp.DecodeBytes(buf, &b); err != nil {
 				return err
 			}
-			if err := f(blockNum, b.BaseTxId, uint64(b.TxAmount)); err != nil {
+			if err := f(blockNum, b.BaseTxId, uint64(b.TxCount)); err != nil {
 				return err
 			}
 			blockNum++

--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -1646,7 +1646,7 @@ func DumpTxs(ctx context.Context, db kv.RoDB, chainConfig *chain.Config, blockFr
 		if e := rlp.DecodeBytes(dataRLP, &body); e != nil {
 			return false, e
 		}
-		if body.TxAmount == 0 {
+		if body.TxCount == 0 {
 			return true, nil
 		}
 
@@ -1669,9 +1669,9 @@ func DumpTxs(ctx context.Context, db kv.RoDB, chainConfig *chain.Config, blockFr
 			workers = workers / 3 * 2
 		}
 
-		if workers > int(body.TxAmount-2) {
-			if int(body.TxAmount-2) > 1 {
-				workers = int(body.TxAmount - 2)
+		if workers > int(body.TxCount-2) {
+			if int(body.TxCount-2) > 1 {
+				workers = int(body.TxCount - 2)
 			} else {
 				workers = 1
 			}
@@ -1702,7 +1702,7 @@ func DumpTxs(ctx context.Context, db kv.RoDB, chainConfig *chain.Config, blockFr
 
 		var j int
 
-		if err := tx.ForAmount(kv.EthTx, numBuf, body.TxAmount-2, func(_, tv []byte) error {
+		if err := tx.ForAmount(kv.EthTx, numBuf, body.TxCount-2, func(_, tv []byte) error {
 			tx := j
 			j++
 
@@ -1745,7 +1745,7 @@ func DumpTxs(ctx context.Context, db kv.RoDB, chainConfig *chain.Config, blockFr
 			return false, fmt.Errorf("ForAmount parser: %w", err)
 		}
 
-		if err := addSystemTx(parseCtxs[0], tx, body.BaseTxId+uint64(body.TxAmount)-1); err != nil {
+		if err := addSystemTx(parseCtxs[0], tx, body.BaseTxId+uint64(body.TxCount)-1); err != nil {
 			return false, err
 		}
 
@@ -1857,7 +1857,7 @@ func DumpBodies(ctx context.Context, db kv.RoDB, _ *chain.Config, blockFrom, blo
 		}
 
 		body.BaseTxId = lastTxNum
-		lastTxNum += uint64(body.TxAmount)
+		lastTxNum += uint64(body.TxCount)
 
 		dataRLP, err := rlp.EncodeToBytes(body)
 		if err != nil {

--- a/turbo/snapshotsync/freezeblocks/dump_test.go
+++ b/turbo/snapshotsync/freezeblocks/dump_test.go
@@ -194,7 +194,7 @@ func TestDump(t *testing.T) {
 					i++
 					body := &types.BodyForStorage{}
 					require.NoError(rlp.DecodeBytes(v, body))
-					txsAmount += uint64(body.TxAmount)
+					txsAmount += uint64(body.TxCount)
 					baseIdList = append(baseIdList, body.BaseTxId)
 					return nil
 				}, 1, log.LvlInfo, log.New())
@@ -210,7 +210,7 @@ func TestDump(t *testing.T) {
 				i++
 				body := &types.BodyForStorage{}
 				require.NoError(rlp.DecodeBytes(v, body))
-				txsAmount += uint64(body.TxAmount)
+				txsAmount += uint64(body.TxCount)
 				baseIdList = append(baseIdList, body.BaseTxId)
 				return nil
 			}, 1, log.LvlInfo, log.New())


### PR DESCRIPTION
To avoid confusion, this PR renames occurrences of `txAmount` and `txsAmount` in the code base to `txCount`. The word amount has a different meaning, in general. Before this PR, no meaning of the word is being utilized with `txAmount` and can be confused with amount of gas utilized.