### PR TITLE
[DO-NOT-MERGE] Feedback request: e3 flexible custom indexers prototype

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -854,6 +854,11 @@ var (
 		Usage: "Max allowed page size for search methods",
 		Value: 25,
 	}
+	OtsV2Flag = cli.BoolFlag{
+		Name:  "experimental.ots2",
+		Usage: "Enable experimental Otterscan API V2",
+		Value: false,
+	}
 
 	DiagnosticsURLFlag = cli.StringFlag{
 		Name:  "diagnostics.addr",
@@ -1873,6 +1878,8 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 	if ctx.IsSet(TxPoolGossipDisableFlag.Name) {
 		cfg.DisableTxPoolGossip = ctx.Bool(TxPoolGossipDisableFlag.Name)
 	}
+
+	cfg.Ots2 = ctx.Bool(OtsV2Flag.Name)
 }
 
 // SetDNSDiscoveryDefaults configures DNS discovery with the given URL if

--- a/core/rawdb/rawdbreset/reset_stages.go
+++ b/core/rawdb/rawdbreset/reset_stages.go
@@ -185,6 +185,8 @@ var Tables = map[stages.SyncStage][]string{
 	stages.StorageHistoryIndex: {kv.E2StorageHistory},
 	stages.CustomTrace:         {},
 	stages.Finish:              {},
+
+	stages.OtsTestStage: {kv.TblTestIIKeys, kv.TblTestIIIdx},
 }
 var stateBuckets = []string{
 	kv.PlainState, kv.HashedAccounts, kv.HashedStorage, kv.TrieOfAccounts, kv.TrieOfStorage,

--- a/erigon-lib/kv/files.go
+++ b/erigon-lib/kv/files.go
@@ -28,4 +28,5 @@ const (
 	FileLogTopicsIdx  = "logtopics"
 	FileTracesFromIdx = "tracesfrom"
 	FileTracesToIdx   = "tracesto"
+	FileTestIIIdx     = "testii"
 )

--- a/erigon-lib/kv/tables.go
+++ b/erigon-lib/kv/tables.go
@@ -416,6 +416,9 @@ const (
 	TblTracesToKeys   = "TracesToKeys"
 	TblTracesToIdx    = "TracesToIdx"
 
+	TblTestIIKeys = "TestIIKeys"
+	TblTestIIIdx  = "TestIIIdx"
+
 	// Prune progress of execution: tableName -> [8bytes of invStep]latest pruned key
 	// Could use table constants `Tbl{Account,Storage,Code,Commitment}Keys` for domains
 	// corresponding history tables `Tbl{Account,Storage,Code,Commitment}HistoryKeys` for history
@@ -662,6 +665,8 @@ var ChaindataTables = []string{
 	TblTracesFromIdx,
 	TblTracesToKeys,
 	TblTracesToIdx,
+	TblTestIIKeys,
+	TblTestIIIdx,
 
 	TblPruningProgress,
 
@@ -840,6 +845,8 @@ var ChaindataTablesCfg = TableCfg{
 	TblTracesFromIdx:   {Flags: DupSort},
 	TblTracesToKeys:    {Flags: DupSort},
 	TblTracesToIdx:     {Flags: DupSort},
+	TblTestIIKeys:      {Flags: DupSort},
+	TblTestIIIdx:       {Flags: DupSort},
 	TblPruningProgress: {Flags: DupSort},
 
 	RAccountKeys: {Flags: DupSort},
@@ -986,12 +993,16 @@ const (
 	LogAddrIdx    InvertedIdx = "LogAddrIdx"
 	TracesFromIdx InvertedIdx = "TracesFromIdx"
 	TracesToIdx   InvertedIdx = "TracesToIdx"
+	TestIIIdx     InvertedIdx = "TestIIIdx"
 
 	LogAddrIdxPos    InvertedIdxPos = 0
 	LogTopicIdxPos   InvertedIdxPos = 1
 	TracesFromIdxPos InvertedIdxPos = 2
 	TracesToIdxPos   InvertedIdxPos = 3
 	StandaloneIdxLen uint16         = 4
+
+	TestIIIdxPos            InvertedIdxPos = 0
+	StandaloneDerivedIdxLen uint16         = 1
 )
 
 const (

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -57,6 +57,7 @@ type Aggregator struct {
 	d                [kv.DomainLen]*Domain
 	iis              [kv.StandaloneIdxLen]*InvertedIndex
 	ap               [kv.AppendableLen]*Appendable //nolint
+	diis             [kv.StandaloneDerivedIdxLen]*InvertedIndex
 	backgroundResult *BackgroundResult
 	dirs             datadir.Dirs
 	tmpdir           string
@@ -189,6 +190,9 @@ func NewAggregator(ctx context.Context, dirs datadir.Dirs, aggregationStep uint6
 	if err := a.registerII(kv.TracesToIdxPos, salt, dirs, db, aggregationStep, kv.FileTracesToIdx, kv.TblTracesToKeys, kv.TblTracesToIdx, logger); err != nil {
 		return nil, err
 	}
+	if err := a.registerDerivedII(kv.TestIIIdxPos, salt, dirs, db, aggregationStep, kv.FileTestIIIdx, kv.TblTestIIKeys, kv.TblTestIIIdx, logger); err != nil {
+		return nil, err
+	}
 	a.LimitRecentHistoryWithoutFiles(aggregationStep / 2)
 	a.recalcVisibleFiles()
 
@@ -236,12 +240,25 @@ func (a *Aggregator) registerII(idx kv.InvertedIdxPos, salt *uint32, dirs datadi
 	return nil
 }
 
+func (a *Aggregator) registerDerivedII(idx kv.InvertedIdxPos, salt *uint32, dirs datadir.Dirs, db kv.RoDB, aggregationStep uint64, filenameBase, indexKeysTable, indexTable string, logger log.Logger) error {
+	idxCfg := iiCfg{salt: salt, dirs: dirs, db: db}
+	var err error
+	a.diis[idx], err = NewInvertedIndex(idxCfg, aggregationStep, filenameBase, indexKeysTable, indexTable, nil, logger)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (a *Aggregator) OnFreeze(f OnFreezeFunc) { a.onFreeze = f }
 func (a *Aggregator) DisableFsync() {
 	for _, d := range a.d {
 		d.DisableFsync()
 	}
 	for _, ii := range a.iis {
+		ii.DisableFsync()
+	}
+	for _, ii := range a.diis {
 		ii.DisableFsync()
 	}
 }
@@ -267,6 +284,10 @@ func (a *Aggregator) OpenFolder() error {
 		ii := ii
 		eg.Go(func() error { return ii.OpenFolder() })
 	}
+	for _, ii := range a.diis {
+		ii := ii
+		eg.Go(func() error { return ii.OpenFolder() })
+	}
 	if err := eg.Wait(); err != nil {
 		return fmt.Errorf("OpenFolder: %w", err)
 	}
@@ -284,6 +305,10 @@ func (a *Aggregator) OpenList(files []string, readonly bool) error {
 		eg.Go(func() error { return d.OpenFolder() })
 	}
 	for _, ii := range a.iis {
+		ii := ii
+		eg.Go(func() error { return ii.OpenFolder() })
+	}
+	for _, ii := range a.diis {
 		ii := ii
 		eg.Go(func() error { return ii.OpenFolder() })
 	}
@@ -315,6 +340,9 @@ func (a *Aggregator) closeDirtyFiles() {
 	for _, ii := range a.iis {
 		ii.Close()
 	}
+	for _, ii := range a.diis {
+		ii.Close()
+	}
 }
 
 func (a *Aggregator) SetCollateAndBuildWorkers(i int) { a.collateAndBuildWorkers = i }
@@ -324,6 +352,9 @@ func (a *Aggregator) SetCompressWorkers(i int) {
 		d.compressWorkers = i
 	}
 	for _, ii := range a.iis {
+		ii.compressWorkers = i
+	}
+	for _, ii := range a.diis {
 		ii.compressWorkers = i
 	}
 }
@@ -349,6 +380,9 @@ func (ac *AggregatorRoTx) Files() []string {
 		res = append(res, d.Files()...)
 	}
 	for _, ii := range ac.iis {
+		res = append(res, ii.Files()...)
+	}
+	for _, ii := range ac.diis {
 		res = append(res, ii.Files()...)
 	}
 	return res
@@ -434,6 +468,9 @@ func (a *Aggregator) BuildMissedIndices(ctx context.Context, workers int) error 
 		for _, ii := range a.iis {
 			ii.BuildMissedAccessors(ctx, g, ps)
 		}
+		for _, ii := range a.diis {
+			ii.BuildMissedAccessors(ctx, g, ps)
+		}
 
 		if err := g.Wait(); err != nil {
 			return err
@@ -496,8 +533,9 @@ func (c AggV3Collation) Close() {
 }
 
 type AggV3StaticFiles struct {
-	d    [kv.DomainLen]StaticFiles
-	ivfs [kv.StandaloneIdxLen]InvertedFiles
+	d     [kv.DomainLen]StaticFiles
+	ivfs  [kv.StandaloneIdxLen]InvertedFiles
+	divfs [kv.StandaloneDerivedIdxLen]InvertedFiles
 }
 
 // CleanupOnError - call it on collation fail. It's closing all files
@@ -506,6 +544,9 @@ func (sf AggV3StaticFiles) CleanupOnError() {
 		d.CleanupOnError()
 	}
 	for _, ivf := range sf.ivfs {
+		ivf.CleanupOnError()
+	}
+	for _, ivf := range sf.divfs {
 		ivf.CleanupOnError()
 	}
 }
@@ -602,6 +643,77 @@ func (a *Aggregator) buildFiles(ctx context.Context, step uint64) error {
 				static.ivfs[kv.TracesFromIdxPos] = sf
 			case kv.TblTracesToKeys:
 				static.ivfs[kv.TracesToIdxPos] = sf
+			default:
+				panic("unknown index " + ii.indexKeysTable)
+			}
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		static.CleanupOnError()
+		return fmt.Errorf("domain collate-build: %w", err)
+	}
+	mxStepTook.ObserveDuration(stepStartedAt)
+	a.integrateDirtyFiles(static, txFrom, txTo)
+	a.logger.Info("[snapshots] aggregated", "step", step, "took", time.Since(stepStartedAt))
+
+	return nil
+}
+
+func (a *Aggregator) buildDerivedIndexFiles(ctx context.Context, step uint64) error {
+	a.logger.Debug("[agg] collate and build", "step", step, "collate_workers", a.collateAndBuildWorkers, "merge_workers", a.mergeWorkers, "compress_workers", a.d[kv.AccountsDomain].compressWorkers)
+
+	var (
+		logEvery      = time.NewTicker(time.Second * 30)
+		txFrom        = a.FirstTxNumOfStep(step)
+		txTo          = a.FirstTxNumOfStep(step + 1)
+		stepStartedAt = time.Now()
+
+		static          AggV3StaticFiles
+		closeCollations = true
+		// collListMu      = sync.Mutex{}
+		collations = make([]Collation, 0)
+	)
+
+	defer logEvery.Stop()
+	defer func() {
+		if !closeCollations {
+			return
+		}
+		for _, c := range collations {
+			c.Close()
+		}
+	}()
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(a.collateAndBuildWorkers)
+	closeCollations = false
+
+	// indices are built concurrently
+	for _, ii := range a.diis {
+		ii := ii
+		a.wg.Add(1)
+		g.Go(func() error {
+			defer a.wg.Done()
+
+			var collation InvertedIndexCollation
+			err := a.db.View(ctx, func(tx kv.Tx) (err error) {
+				collation, err = ii.collate(ctx, step, tx)
+				return err
+			})
+			if err != nil {
+				return fmt.Errorf("index collation %q has failed: %w", ii.filenameBase, err)
+			}
+			sf, err := ii.buildFiles(ctx, step, collation, a.ps)
+			if err != nil {
+				sf.CleanupOnError()
+				return err
+			}
+
+			switch ii.indexKeysTable {
+			case kv.TblTestIIKeys:
+				static.divfs[kv.TestIIIdxPos] = sf
 			default:
 				panic("unknown index " + ii.indexKeysTable)
 			}
@@ -718,6 +830,9 @@ func (a *Aggregator) integrateDirtyFiles(sf AggV3StaticFiles, txNumFrom, txNumTo
 	for id, ii := range a.iis {
 		ii.integrateDirtyFiles(sf.ivfs[id], txNumFrom, txNumTo)
 	}
+	for id, ii := range a.diis {
+		ii.integrateDirtyFiles(sf.divfs[id], txNumFrom, txNumTo)
+	}
 }
 
 func (a *Aggregator) HasNewFrozenFiles() bool {
@@ -750,6 +865,11 @@ func (ac *AggregatorRoTx) CanPrune(tx kv.Tx, untilTx uint64) bool {
 		}
 	}
 	for _, ii := range ac.iis {
+		if ii.CanPrune(tx) {
+			return true
+		}
+	}
+	for _, ii := range ac.diis {
 		if ii.CanPrune(tx) {
 			return true
 		}
@@ -797,6 +917,7 @@ func (ac *AggregatorRoTx) CanUnwindBeforeBlockNum(blockNum uint64, tx kv.Tx) (ui
 }
 
 func (ac *AggregatorRoTx) PruneSmallBatchesDb(ctx context.Context, timeout time.Duration, db kv.RwDB) (haveMore bool, err error) {
+	log.Info("************ PRUNE SMALL BATCHES DB")
 	// On tip-of-chain timeout is about `3sec`
 	//  On tip of chain:     must be real-time - prune by small batches and prioritize exact-`timeout`
 	//  Not on tip of chain: must be aggressive (prune as much as possible) by bigger batches
@@ -862,7 +983,7 @@ func (ac *AggregatorRoTx) PruneSmallBatchesDb(ctx context.Context, timeout time.
 
 			select {
 			case <-logEvery.C:
-				ac.a.logger.Info("[snapshots] pruning state",
+				ac.a.logger.Info("[snapshots] pruning state DB",
 					"until commit", time.Until(started.Add(timeout)).String(),
 					"pruneLimit", pruneLimit,
 					"aggregatedStep", (ac.minimaxTxNumInDomainFiles(false)-1)/ac.a.StepSize(),
@@ -892,6 +1013,7 @@ func (ac *AggregatorRoTx) PruneSmallBatchesDb(ctx context.Context, timeout time.
 // PruneSmallBatches is not cancellable, it's over when it's over or failed.
 // It fills whole timeout with pruning by small batches (of 100 keys) and making some progress
 func (ac *AggregatorRoTx) PruneSmallBatches(ctx context.Context, timeout time.Duration, tx kv.RwTx) (haveMore bool, err error) {
+	log.Info("************ PRUNE SMALL BATCHES")
 	// On tip-of-chain timeout is about `3sec`
 	//  On tip of chain:     must be real-time - prune by small batches and prioritize exact-`timeout`
 	//  Not on tip of chain: must be aggressive (prune as much as possible) by bigger batches
@@ -955,7 +1077,7 @@ func (ac *AggregatorRoTx) PruneSmallBatches(ctx context.Context, timeout time.Du
 		case <-localTimeout.C: //must be first to improve responsivness
 			return true, nil
 		case <-logEvery.C:
-			ac.a.logger.Info("[snapshots] pruning state",
+			ac.a.logger.Info("[snapshots] pruning state S",
 				"until commit", time.Until(started.Add(timeout)).String(),
 				"pruneLimit", pruneLimit,
 				"aggregatedStep", (ac.minimaxTxNumInDomainFiles(false)-1)/ac.a.StepSize(),
@@ -1087,8 +1209,10 @@ func (ac *AggregatorRoTx) Prune(ctx context.Context, tx kv.RwTx, limit uint64, w
 	}
 
 	if txFrom == txTo || !ac.CanPrune(tx, txTo) {
+		log.Info("******************* NO PRUNE", "txTo", txTo)
 		return nil, nil
 	}
+	log.Info("******************* PRUNE", "txTo", txTo)
 
 	if logEvery == nil {
 		logEvery = time.NewTicker(30 * time.Second)
@@ -1102,22 +1226,28 @@ func (ac *AggregatorRoTx) Prune(ctx context.Context, tx kv.RwTx, limit uint64, w
 		var err error
 		aggStat.Domains[ac.d[id].d.filenameBase], err = d.Prune(ctx, tx, step, txFrom, txTo, limit, withWarmup, logEvery)
 		if err != nil {
+			log.Info("******************* PRUNE RET DOMAIN", "err", err)
 			return aggStat, err
 		}
 	}
-	var stats [kv.StandaloneIdxLen]*InvertedIndexPruneStat
 	for i := 0; i < int(kv.StandaloneIdxLen); i++ {
 		stat, err := ac.iis[i].Prune(ctx, tx, txFrom, txTo, limit, logEvery, false, withWarmup, nil)
 		if err != nil {
+			log.Info("******************* PRUNE RET IDX", "err", err)
 			return nil, err
 		}
-		stats[i] = stat
+		aggStat.Indices[ac.iis[i].ii.filenameBase] = stat
+	}
+	for i := 0; i < int(kv.StandaloneDerivedIdxLen); i++ {
+		stat, err := ac.diis[i].Prune(ctx, tx, txFrom, txTo, limit, logEvery, false, withWarmup, nil)
+		if err != nil {
+			log.Info("******************* PRUNE RET DIDX", "err", err)
+			return nil, err
+		}
+		aggStat.Indices[ac.diis[i].ii.filenameBase] = stat
 	}
 
-	for i := 0; i < int(kv.StandaloneIdxLen); i++ {
-		aggStat.Indices[ac.iis[i].ii.filenameBase] = stats[i]
-	}
-
+	log.Info("******************* PRUNE RET OK")
 	return aggStat, nil
 }
 
@@ -1234,6 +1364,9 @@ func (a *Aggregator) recalcVisibleFiles() {
 	for _, ii := range a.iis {
 		ii.reCalcVisibleFiles()
 	}
+	for _, ii := range a.diis {
+		ii.reCalcVisibleFiles()
+	}
 }
 
 func (a *Aggregator) recalcVisibleFilesMinimaxTxNum() {
@@ -1242,9 +1375,16 @@ func (a *Aggregator) recalcVisibleFilesMinimaxTxNum() {
 	a.visibleFilesMinimaxTxNum.Store(aggTx.minimaxTxNumInDomainFiles(false))
 }
 
+func (a *Aggregator) maxTxNumInDerivedIndex(diis kv.InvertedIdxPos) uint64 {
+	aggTx := a.BeginFilesRo()
+	defer aggTx.Close()
+	return aggTx.diis[diis].maxTxNumInFiles(false)
+}
+
 type RangesV3 struct {
-	d      [kv.DomainLen]DomainRanges
-	ranges [kv.StandaloneIdxLen]*MergeRange
+	d       [kv.DomainLen]DomainRanges
+	ranges  [kv.StandaloneIdxLen]*MergeRange
+	dranges [kv.StandaloneDerivedIdxLen]*MergeRange
 }
 
 func (r RangesV3) String() string {
@@ -1257,6 +1397,11 @@ func (r RangesV3) String() string {
 
 	aggStep := r.d[kv.AccountsDomain].aggStep
 	for p, mr := range r.ranges {
+		if mr != nil && mr.needMerge {
+			ss = append(ss, mr.String(kv.InvertedIdxPos(p).String(), aggStep))
+		}
+	}
+	for p, mr := range r.dranges {
 		if mr != nil && mr.needMerge {
 			ss = append(ss, mr.String(kv.InvertedIdxPos(p).String(), aggStep))
 		}
@@ -1275,6 +1420,11 @@ func (r RangesV3) any() bool {
 			return true
 		}
 	}
+	for _, ii := range r.dranges {
+		if ii.needMerge {
+			return true
+		}
+	}
 	return false
 }
 
@@ -1285,6 +1435,9 @@ func (ac *AggregatorRoTx) findMergeRange(maxEndTxNum, maxSpan uint64) RangesV3 {
 	}
 	for id, ii := range ac.iis {
 		r.ranges[id] = ii.findMergeRange(maxEndTxNum, maxSpan)
+	}
+	for id, ii := range ac.diis {
+		r.dranges[id] = ii.findMergeRange(maxEndTxNum, maxSpan)
 	}
 	//log.Info(fmt.Sprintf("findMergeRange(%d, %d)=%s\n", maxEndTxNum/ac.a.aggregationStep, maxSpan/ac.a.aggregationStep, r))
 	return r
@@ -1523,6 +1676,17 @@ func (ac *AggregatorRoTx) mergeFiles(ctx context.Context, files SelectedStaticFi
 			})
 		}
 	}
+	for id, rng := range r.dranges {
+		id := id
+		rng := rng
+		if rng.needMerge {
+			g.Go(func() error {
+				var err error
+				mf.diis[id], err = ac.diis[id].mergeFiles(ctx, files.dii[id], rng.from, rng.to, ac.a.ps)
+				return err
+			})
+		}
+	}
 
 	err := g.Wait()
 	if err == nil {
@@ -1548,6 +1712,9 @@ func (a *Aggregator) integrateMergedDirtyFiles(outs SelectedStaticFilesV3, in Me
 	for id, ii := range a.iis {
 		ii.integrateMergedDirtyFiles(outs.ii[id], in.iis[id])
 	}
+	for id, ii := range a.diis {
+		ii.integrateMergedDirtyFiles(outs.dii[id], in.diis[id])
+	}
 }
 
 func (a *Aggregator) cleanAfterMerge(in MergedFilesV3) {
@@ -1562,6 +1729,9 @@ func (a *Aggregator) cleanAfterMerge(in MergedFilesV3) {
 	}
 	for id, ii := range at.iis {
 		ii.cleanAfterMerge(in.iis[id])
+	}
+	for id, ii := range at.diis {
+		ii.cleanAfterMerge(in.diis[id])
 	}
 }
 
@@ -1664,6 +1834,91 @@ func (a *Aggregator) BuildFilesInBackground(txNum uint64) chan struct{} {
 	return fin
 }
 
+func (a *Aggregator) BuildDerivedIndexFiles(txNum uint64) chan struct{} {
+	a.logger.Info("********************************* BUILD DERI IDX", "txNum", txNum)
+	fin := make(chan struct{})
+
+	diis := kv.TestIIIdxPos
+	maxTxNum := a.maxTxNumInDerivedIndex(diis)
+	if (txNum + 1) <= maxTxNum+a.aggregationStep {
+		close(fin)
+		return fin
+	}
+
+	if ok := a.buildingFiles.CompareAndSwap(false, true); !ok {
+		close(fin)
+		return fin
+	}
+
+	// step := a.visibleFilesMinimaxTxNum.Load() / a.StepSize()
+	step := maxTxNum / a.StepSize()
+	a.wg.Add(1)
+	go func() {
+		defer a.wg.Done()
+		defer a.buildingFiles.Store(false)
+
+		if a.snapshotBuildSema != nil {
+			//we are inside own goroutine - it's fine to block here
+			if err := a.snapshotBuildSema.Acquire(a.ctx, 1); err != nil {
+				log.Warn("[snapshots] buildFilesInBackground", "err", err)
+				return //nolint
+			}
+			defer a.snapshotBuildSema.Release(1)
+		}
+
+		// check if db has enough data (maybe we didn't commit them yet or all keys are unique so history is empty)
+		lastInDB := lastIdInDB(a.db, a.d[kv.AccountsDomain])
+		hasData := lastInDB > step // `step` must be fully-written - means `step+1` records must be visible
+		if !hasData {
+			close(fin)
+			return
+		}
+
+		// trying to create as much small-step-files as possible:
+		// - to reduce amount of small merges
+		// - to remove old data from db as early as possible
+		// - during files build, may happen commit of new data. on each loop step getting latest id in db
+		for ; step < lastIdInDB(a.db, a.d[kv.AccountsDomain]); step++ { //`step` must be fully-written - means `step+1` records must be visible
+			if err := a.buildDerivedIndexFiles(a.ctx, step); err != nil {
+				if errors.Is(err, context.Canceled) || errors.Is(err, common2.ErrStopped) {
+					close(fin)
+					return
+				}
+				log.Warn("[snapshots] buildFilesInBackground", "err", err)
+				break
+			}
+		}
+		a.BuildOptionalMissedIndicesInBackground(a.ctx, 1)
+
+		if dbg.NoMerge() {
+			close(fin)
+			return
+		}
+		if ok := a.mergingFiles.CompareAndSwap(false, true); !ok {
+			close(fin)
+			return
+		}
+		a.wg.Add(1)
+		go func() {
+			defer a.wg.Done()
+			defer a.mergingFiles.Store(false)
+
+			//TODO: merge must have own semphore
+
+			defer func() { close(fin) }()
+			if err := a.MergeLoop(a.ctx); err != nil {
+				if errors.Is(err, context.Canceled) || errors.Is(err, common2.ErrStopped) {
+					return
+				}
+				log.Warn("[snapshots] merge", "err", err)
+			}
+
+			a.BuildOptionalMissedIndicesInBackground(a.ctx, 1)
+		}()
+	}()
+	return fin
+}
+
 func (ac *AggregatorRoTx) IndexRange(name kv.InvertedIdx, k []byte, fromTs, toTs int, asc order.By, limit int, tx kv.Tx) (timestamps iter.U64, err error) {
 	switch name {
 	case kv.AccountsHistoryIdx:
@@ -1684,6 +1939,8 @@ func (ac *AggregatorRoTx) IndexRange(name kv.InvertedIdx, k []byte, fromTs, toTs
 		return ac.iis[kv.TracesFromIdxPos].IdxRange(k, fromTs, toTs, asc, limit, tx)
 	case kv.TracesToIdx:
 		return ac.iis[kv.TracesToIdxPos].IdxRange(k, fromTs, toTs, asc, limit, tx)
+	case kv.TestIIIdx:
+		return ac.diis[kv.TestIIIdxPos].IdxRange(k, fromTs, toTs, asc, limit, tx)
 	default:
 		return nil, fmt.Errorf("unexpected history name: %s", name)
 	}
@@ -1751,9 +2008,10 @@ func (a *Aggregator) Stats() FilesStats22 {
 //   - user will not see "partial writes" or "new files appearance"
 //   - last reader removing garbage files inside `Close` method
 type AggregatorRoTx struct {
-	a   *Aggregator
-	d   [kv.DomainLen]*DomainRoTx
-	iis [kv.StandaloneIdxLen]*InvertedIndexRoTx
+	a    *Aggregator
+	d    [kv.DomainLen]*DomainRoTx
+	iis  [kv.StandaloneIdxLen]*InvertedIndexRoTx
+	diis [kv.StandaloneDerivedIdxLen]*InvertedIndexRoTx
 
 	id      uint64 // auto-increment id of ctx for logs
 	_leakID uint64 // set only if TRACE_AGG=true
@@ -1767,6 +2025,9 @@ func (a *Aggregator) BeginFilesRo() *AggregatorRoTx {
 	}
 
 	a.visibleFilesLock.RLock()
+	for id, ii := range a.diis {
+		ac.diis[id] = ii.BeginFilesRo()
+	}
 	for id, ii := range a.iis {
 		ac.iis[id] = ii.BeginFilesRo()
 	}
@@ -1879,6 +2140,9 @@ func (ac *AggregatorRoTx) Close() {
 		}
 	}
 	for _, ii := range ac.iis {
+		ii.Close()
+	}
+	for _, ii := range ac.diis {
 		ii.Close()
 	}
 }

--- a/erigon-lib/state/domain_shared.go
+++ b/erigon-lib/state/domain_shared.go
@@ -80,8 +80,9 @@ type SharedDomains struct {
 	domains [kv.DomainLen]map[string]dataWithPrevStep
 	storage *btree2.Map[string, dataWithPrevStep]
 
-	dWriter   [kv.DomainLen]*domainBufferedWriter
-	iiWriters [kv.StandaloneIdxLen]*invertedIndexBufferedWriter
+	dWriter    [kv.DomainLen]*domainBufferedWriter
+	iiWriters  [kv.StandaloneIdxLen]*invertedIndexBufferedWriter
+	diiWriters [kv.StandaloneDerivedIdxLen]*invertedIndexBufferedWriter
 
 	currentChangesAccumulator *StateChangeSet
 	pastChangesAccumulator    map[string]*StateChangeSet
@@ -102,6 +103,9 @@ func NewSharedDomains(tx kv.Tx, logger log.Logger) (*SharedDomains, error) {
 
 	sd.aggTx.a.DiscardHistory(kv.CommitmentDomain)
 
+	for id, ii := range sd.aggTx.diis {
+		sd.diiWriters[id] = ii.NewWriter()
+	}
 	for id, ii := range sd.aggTx.iis {
 		sd.iiWriters[id] = ii.NewWriter()
 	}
@@ -172,6 +176,11 @@ func (sd *SharedDomains) Unwind(ctx context.Context, rwTx kv.RwTx, blockUnwindTo
 		}
 	}
 	for _, ii := range sd.aggTx.iis {
+		if _, err := ii.Prune(ctx, rwTx, txUnwindTo, math.MaxUint64, math.MaxUint64, logEvery, true, withWarmup, nil); err != nil {
+			return err
+		}
+	}
+	for _, ii := range sd.aggTx.diis {
 		if _, err := ii.Prune(ctx, rwTx, txUnwindTo, math.MaxUint64, math.MaxUint64, logEvery, true, withWarmup, nil); err != nil {
 			return err
 		}
@@ -554,6 +563,8 @@ func (sd *SharedDomains) IndexAdd(table kv.InvertedIdx, key []byte) (err error) 
 		err = sd.iiWriters[kv.TracesToIdxPos].Add(key)
 	case kv.TblTracesFromIdx:
 		err = sd.iiWriters[kv.TracesFromIdxPos].Add(key)
+	case kv.TblTestIIIdx:
+		err = sd.diiWriters[kv.TestIIIdxPos].Add(key)
 	default:
 		panic(fmt.Errorf("unknown shared index %s", table))
 	}
@@ -589,6 +600,11 @@ func (sd *SharedDomains) SetTxNum(txNum uint64) {
 		}
 	}
 	for _, iiWriter := range sd.iiWriters {
+		if iiWriter != nil {
+			iiWriter.SetTxNum(txNum)
+		}
+	}
+	for _, iiWriter := range sd.diiWriters {
 		if iiWriter != nil {
 			iiWriter.SetTxNum(txNum)
 		}
@@ -779,6 +795,9 @@ func (sd *SharedDomains) Close() {
 		for _, iiWriter := range sd.iiWriters {
 			iiWriter.close()
 		}
+		for _, iiWriter := range sd.diiWriters {
+			iiWriter.close()
+		}
 	}
 
 	if sd.sdCtx != nil {
@@ -787,6 +806,7 @@ func (sd *SharedDomains) Close() {
 }
 
 func (sd *SharedDomains) Flush(ctx context.Context, tx kv.RwTx) error {
+	sd.logger.Info("********************* SD FLUSH")
 	if sd.noFlush > 0 {
 		sd.noFlush--
 	}
@@ -821,6 +841,11 @@ func (sd *SharedDomains) Flush(ctx context.Context, tx kv.RwTx) error {
 				return err
 			}
 		}
+		for _, iiWriter := range sd.diiWriters {
+			if err := iiWriter.Flush(ctx, tx); err != nil {
+				return err
+			}
+		}
 		if dbg.PruneOnFlushTimeout != 0 {
 			_, err = sd.aggTx.PruneSmallBatches(ctx, dbg.PruneOnFlushTimeout, tx)
 			if err != nil {
@@ -834,6 +859,9 @@ func (sd *SharedDomains) Flush(ctx context.Context, tx kv.RwTx) error {
 			}
 		}
 		for _, iiWriter := range sd.iiWriters {
+			iiWriter.close()
+		}
+		for _, iiWriter := range sd.diiWriters {
 			iiWriter.close()
 		}
 	}

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -265,6 +265,8 @@ type Config struct {
 	SilkwormRpcJsonCompatibility bool
 
 	DisableTxPoolGossip bool
+
+	Ots2 bool
 }
 
 type Sync struct {

--- a/eth/stagedsync/default_stages.go
+++ b/eth/stagedsync/default_stages.go
@@ -26,8 +26,10 @@ func DefaultStages(ctx context.Context,
 	callTraces CallTracesCfg,
 	txLookup TxLookupCfg,
 	finish FinishCfg,
+	caCfg ContractAnalyzerCfg,
+	ots2Enabled bool,
 	test bool) []*Stage {
-	return []*Stage{
+	defaultStages := []*Stage{
 		{
 			ID:          stages.Snapshots,
 			Description: "Download snapshots",
@@ -267,10 +269,23 @@ func DefaultStages(ctx context.Context,
 			},
 		},
 	}
+
+	// If ots2 is enabled, inject ots2 stages before finish stage
+	if ots2Enabled {
+		ots2Stages := OtsStages(ctx, caCfg)
+
+		newStages := make([]*Stage, 0, len(defaultStages)+1)
+		newStages = append(newStages, defaultStages[:len(defaultStages)-1]...)
+		newStages = append(newStages, ots2Stages...)
+		newStages = append(newStages, defaultStages[len(defaultStages)-1])
+		defaultStages = newStages
+	}
+
+	return defaultStages
 }
 
-func PipelineStages(ctx context.Context, snapshots SnapshotsCfg, blockHashCfg BlockHashesCfg, senders SendersCfg, exec ExecuteBlockCfg, hashState HashStateCfg, trieCfg TrieCfg, history HistoryCfg, logIndex LogIndexCfg, callTraces CallTracesCfg, txLookup TxLookupCfg, finish FinishCfg, test bool) []*Stage {
-	return []*Stage{
+func PipelineStages(ctx context.Context, snapshots SnapshotsCfg, blockHashCfg BlockHashesCfg, senders SendersCfg, exec ExecuteBlockCfg, hashState HashStateCfg, trieCfg TrieCfg, history HistoryCfg, logIndex LogIndexCfg, callTraces CallTracesCfg, txLookup TxLookupCfg, finish FinishCfg, caCfg ContractAnalyzerCfg, ots2Enabled bool, test bool) []*Stage {
+	defaultStages := []*Stage{
 		{
 			ID:          stages.Snapshots,
 			Description: "Download snapshots",
@@ -446,6 +461,19 @@ func PipelineStages(ctx context.Context, snapshots SnapshotsCfg, blockHashCfg Bl
 			},
 		},
 	}
+
+	// If ots2 is enabled, inject ots2 stages before finish stage
+	if ots2Enabled {
+		ots2Stages := OtsStages(ctx, caCfg)
+
+		newStages := make([]*Stage, 0, len(defaultStages)+1)
+		newStages = append(newStages, defaultStages[:len(defaultStages)-1]...)
+		newStages = append(newStages, ots2Stages...)
+		newStages = append(newStages, defaultStages[len(defaultStages)-1])
+		defaultStages = newStages
+	}
+
+	return defaultStages
 }
 
 // when uploading - potentially from zero we need to include headers and bodies stages otherwise we won't recover the POW portion of the chain

--- a/eth/stagedsync/ots_stage_generic.go
+++ b/eth/stagedsync/ots_stage_generic.go
@@ -1,0 +1,275 @@
+package stagedsync
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ledgerwatch/erigon-lib/chain"
+	"github.com/ledgerwatch/erigon-lib/kv"
+	"github.com/ledgerwatch/erigon-lib/kv/rawdbv3"
+	"github.com/ledgerwatch/erigon-lib/state"
+	state2 "github.com/ledgerwatch/erigon-lib/state"
+	"github.com/ledgerwatch/erigon-lib/wrap"
+	"github.com/ledgerwatch/erigon/consensus"
+	"github.com/ledgerwatch/erigon/eth/stagedsync/stages"
+	"github.com/ledgerwatch/erigon/turbo/services"
+	"github.com/ledgerwatch/log/v3"
+)
+
+type ContractAnalyzerCfg struct {
+	db          kv.RwDB
+	agg         *state.Aggregator
+	tmpDir      string
+	chainConfig *chain.Config
+	blockReader services.FullBlockReader
+	engine      consensus.Engine
+}
+
+func StageDbAwareCfg(db kv.RwDB, agg *state.Aggregator, tmpDir string, chainConfig *chain.Config, blockReader services.FullBlockReader, engine consensus.Engine) ContractAnalyzerCfg {
+	return ContractAnalyzerCfg{
+		db,
+		agg,
+		tmpDir,
+		chainConfig,
+		blockReader,
+		engine,
+	}
+}
+
+// This is a hint to supress verbose info logs if the stage block range to be executed is <= this number
+// of blocks.
+const SHORT_RANGE_EXECUTION_THRESHOLD = 16
+
+// Defines a stage executor function to be called back by GenericStageForwardFunc.
+//
+// It should implement the stage business logic.
+//
+// Implementation should rely on the tx param for DB access. The db param is provided for a specific
+// use-case and should be used with caution.
+//
+// The db param should be used by concurrent implementations that are optimized for the first sync, hence
+// there is no risk of trying to read uncommited data. In this case, the implementation can span several
+// goroutines to process data saved by a previous stages concurrently.
+type StageExecutor = func(ctx context.Context, db kv.RoDB, agg *state.Aggregator, tx kv.RwTx, doms *state.SharedDomains, isInternalTx bool, tmpDir string, chainConfig *chain.Config, blockReader services.FullBlockReader, engine consensus.Engine, startBlock, endBlock uint64, isShortInterval bool, logEvery *time.Ticker, s *StageState, logger log.Logger) (uint64, error)
+
+// Defines a stage executor function to be called back by GenericStageUnwindFunc.
+//
+// It should implement the stage unwind business logic.
+//
+// Implementation should rely on the tx param for DB access.
+type UnwindExecutor = func(ctx context.Context, tx kv.RwTx, u *UnwindState, blockReader services.FullBlockReader, isShortInterval bool, logEvery *time.Ticker) error
+
+// This is a template factory function of stage forward execution implementation.
+//
+// This implementation handles most common tasks performed by stage execution and allows custom logic
+// to be plugged via an executor param.
+//
+// Tasks performed by this generic implementation:
+//
+//   - It handles the lack of parent tx param meaning stage must begin/commit its own db tx.
+//   - It provides a standard log ticker.
+//   - It determines the block range so verbose logs may be supressed.
+//   - It handles execution completion automatically (db save of last successful block).
+func GenericStageForwardFunc(ctx context.Context, cfg ContractAnalyzerCfg, parentStage stages.SyncStage, executor StageExecutor) ExecFunc {
+	return func(badBlockUnwind bool, s *StageState, u Unwinder, txc wrap.TxContainer, logger log.Logger) error {
+		return genericStageForwardImpl(ctx, cfg, s, txc, executor, parentStage, logger, false, 0, 0)
+	}
+}
+
+func GenericStageForwardFuncWithDebug(ctx context.Context, cfg ContractAnalyzerCfg, parentStage stages.SyncStage, executor StageExecutor, _debugStartBlock, _debugEndBlock uint64) ExecFunc {
+	return func(badBlockUnwind bool, s *StageState, u Unwinder, txc wrap.TxContainer, logger log.Logger) error {
+		if s.BlockNumber > 0 {
+			return nil
+		}
+		return genericStageForwardImpl(ctx, cfg, s, txc, executor, parentStage, logger, true, _debugStartBlock, _debugEndBlock)
+	}
+}
+
+func genericStageForwardImpl(ctx context.Context, cfg ContractAnalyzerCfg, s *StageState, txc wrap.TxContainer, executor StageExecutor, parentStage stages.SyncStage, logger log.Logger, _debug bool, _debugStartBlock, _debugEndBlock uint64) error {
+	tx := txc.Tx
+	useExternalTx := tx != nil
+
+	if !useExternalTx {
+		var err error
+		tx, err = cfg.db.BeginRw(ctx)
+		if err != nil {
+			return err
+		}
+		defer tx.Rollback()
+	}
+
+	inMemExec := txc.Doms != nil
+	var doms *state.SharedDomains
+	if inMemExec {
+		logger.Info("********************************* Using inmem sd")
+		doms = txc.Doms
+	} else {
+		logger.Info("********************************* Using NEW sd")
+		var err error
+		doms, err = state2.NewSharedDomains(tx, logger)
+		if err != nil {
+			return err
+		}
+		defer doms.Close()
+	}
+
+	logEvery := time.NewTicker(logInterval)
+	defer logEvery.Stop()
+
+	// Determine [startBlock, endBlock]
+	//
+	// If saved block number == 0, it means stage was never run and it must start at 0, otherwise
+	// it represents the latest ran block number, so it must start at block+1.
+	//
+	// End block is bound to latest run block number from the parent stage. Must not go further.
+	startBlock := s.BlockNumber
+	if startBlock > 0 {
+		startBlock++
+	}
+	endBlock, err := stages.GetStageProgress(tx, parentStage)
+	if err != nil {
+		return err
+	}
+
+	///////////////////////////
+	// DEBUG OVERRIDES
+	if _debug {
+		startBlock = _debugStartBlock
+		endBlock = _debugEndBlock
+	}
+	///////////////////////////
+
+	// startBlock > endBlock means parent stage progress was forcefully reset
+	// just skip this stage silently
+	if startBlock > endBlock {
+		return nil
+	}
+
+	// Don't display verbose start/finish logs on short range executions; given short == <= N blocks
+	isShortInterval := endBlock-startBlock+1 <= SHORT_RANGE_EXECUTION_THRESHOLD
+
+	///////////////////////////
+	// DEBUG OVERRIDES
+	if _debug {
+		isShortInterval = false
+	}
+	///////////////////////////
+
+	if !isShortInterval {
+		log.Info(fmt.Sprintf("[%s] Started", s.LogPrefix()), "from", startBlock, "to", endBlock)
+	}
+	lastFinishedBlock, err := executor(ctx, cfg.db, cfg.agg, tx, doms, !useExternalTx, cfg.tmpDir, cfg.chainConfig, cfg.blockReader, cfg.engine, startBlock, endBlock, isShortInterval, logEvery, s, logger)
+	if err != nil {
+		return err
+	}
+	if !isShortInterval {
+		log.Info(fmt.Sprintf("[%s] Finished", s.LogPrefix()), "latest", lastFinishedBlock)
+	}
+	if !inMemExec {
+		if err := doms.Flush(ctx, tx); err != nil {
+			return err
+		}
+	}
+	endTxNum, err := rawdbv3.TxNums.Max(tx, lastFinishedBlock)
+	if err != nil {
+		return err
+	}
+
+	if err := s.Update(tx, lastFinishedBlock); err != nil {
+		return err
+	}
+	if !useExternalTx {
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+	}
+	// if blocksFreezeCfg.Produce {
+	cfg.agg.BuildDerivedIndexFiles(endTxNum)
+	// }
+	return nil
+}
+
+// This is a template factory function of stage Unwind implementation.
+//
+// This implementation handles most common tasks performed by unwind and allows custom logic
+// to be plugged via an executor param.
+//
+// Tasks performed by this generic implementation:
+//
+//   - It handles the lack of parent tx param meaning stage must begin/commit its own db tx.
+//   - It provides a standard log ticker.
+//   - It determines the block range so verbose logs may be supressed.
+//   - It handles unwind completion automatically (db saves).
+func GenericStageUnwindFunc(ctx context.Context, cfg ContractAnalyzerCfg, executor UnwindExecutor) UnwindFunc {
+	return func(u *UnwindState, s *StageState, txc wrap.TxContainer, logger log.Logger) error {
+		return GenericStageUnwindImpl(ctx, txc.Tx, cfg, u, executor)
+	}
+}
+
+// That shouldn't be module exported, but we use this function on integration
+// tool for manual unwinds.
+func GenericStageUnwindImpl(ctx context.Context, tx kv.RwTx, cfg ContractAnalyzerCfg, u *UnwindState, executor UnwindExecutor) (err error) {
+	useExternalTx := tx != nil
+
+	if !useExternalTx {
+		tx, err = cfg.db.BeginRw(ctx)
+		if err != nil {
+			return err
+		}
+		defer tx.Rollback()
+	}
+
+	logEvery := time.NewTicker(logInterval)
+	defer logEvery.Stop()
+
+	// Don't display verbose start/finish logs on short range executions; given short == <= N blocks
+	isShortInterval := u.CurrentBlockNumber-u.UnwindPoint <= SHORT_RANGE_EXECUTION_THRESHOLD
+
+	if !isShortInterval {
+		log.Info(fmt.Sprintf("[%s] Unwind started", u.LogPrefix()), "from", u.CurrentBlockNumber, "to", u.UnwindPoint)
+	}
+	if executor == nil {
+		log.Warn("Unwinder executor is nil; this should only happen on test/dev code, otherwise this msg must be considered a bug")
+	} else {
+		if err := executor(ctx, tx, u, cfg.blockReader, isShortInterval, logEvery); err != nil {
+			return err
+		}
+	}
+	if !isShortInterval {
+		log.Info(fmt.Sprintf("[%s] Unwind finished", u.LogPrefix()), "latest", u.UnwindPoint)
+	}
+
+	if err = u.Done(tx); err != nil {
+		return err
+	}
+
+	if !useExternalTx {
+		if err = tx.Commit(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// This is a no-op implementation of stage pruning function to be used as
+// a filler for stages that don't support pruning.
+func NoopStagePrune(ctx context.Context, cfg ContractAnalyzerCfg) PruneFunc {
+	return func(p *PruneState, tx kv.RwTx, logger log.Logger) (err error) {
+		useExternalTx := tx != nil
+		if !useExternalTx {
+			tx, err = cfg.db.BeginRw(ctx)
+			if err != nil {
+				return err
+			}
+			defer tx.Rollback()
+		}
+
+		if !useExternalTx {
+			if err = tx.Commit(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}

--- a/eth/stagedsync/ots_stages.go
+++ b/eth/stagedsync/ots_stages.go
@@ -1,0 +1,22 @@
+package stagedsync
+
+import (
+	"context"
+
+	"github.com/ledgerwatch/erigon/eth/stagedsync/stages"
+)
+
+// Standard Otterscan V2 stages; if opted-in, they must be inserted before finish stage.
+func OtsStages(ctx context.Context, caCfg ContractAnalyzerCfg) []*Stage {
+	return []*Stage{
+		{
+			ID:          stages.OtsTestStage,
+			Description: "Test stage workflow",
+			Forward:     GenericStageForwardFunc(ctx, caCfg, stages.Execution, CustomTestExecutor),
+			Unwind: GenericStageUnwindFunc(ctx, caCfg,
+				nil,
+			),
+			Prune: NoopStagePrune(ctx, caCfg),
+		},
+	}
+}

--- a/eth/stagedsync/ots_stg_executor_test_custom.go
+++ b/eth/stagedsync/ots_stg_executor_test_custom.go
@@ -1,0 +1,58 @@
+package stagedsync
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ledgerwatch/erigon-lib/chain"
+	libcommon "github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/kv"
+	"github.com/ledgerwatch/erigon-lib/kv/rawdbv3"
+	"github.com/ledgerwatch/erigon-lib/state"
+	"github.com/ledgerwatch/erigon/consensus"
+	"github.com/ledgerwatch/erigon/turbo/services"
+	"github.com/ledgerwatch/log/v3"
+)
+
+var testKey = []byte("test")
+
+func CustomTestExecutor(ctx context.Context, db kv.RoDB, agg *state.Aggregator, tx kv.RwTx, dom *state.SharedDomains, isInternalTx bool, tmpDir string, chainConfig *chain.Config, blockReader services.FullBlockReader, engine consensus.Engine, startBlock, endBlock uint64, isShortInterval bool, logEvery *time.Ticker, s *StageState, logger log.Logger) (uint64, error) {
+	if !isShortInterval {
+		log.Info(fmt.Sprintf("[%s] Using incremental executor", s.LogPrefix()))
+	}
+
+	startTxNum, err := rawdbv3.TxNums.Min(tx, startBlock)
+	if err != nil {
+		return startBlock, err
+	}
+	endTxNum, err := rawdbv3.TxNums.Max(tx, endBlock)
+	if err != nil {
+		return startBlock, err
+	}
+
+	currentTxNum := startTxNum
+	count := 0
+	for ; currentTxNum <= endTxNum; currentTxNum++ {
+		if currentTxNum%10_000_000 == 0 {
+			dom.SetTxNum(currentTxNum)
+			if err := dom.IndexAdd(kv.TblTestIIIdx, testKey); err != nil {
+				return startBlock, err
+			}
+			count++
+		}
+
+		select {
+		default:
+		case <-ctx.Done():
+			return startBlock, libcommon.ErrStopped
+		case <-logEvery.C:
+			log.Info(fmt.Sprintf("[%s]", s.LogPrefix()), "currentTxNum", currentTxNum, "c", count)
+		}
+	}
+	if count > 0 {
+		log.Info(fmt.Sprintf("[%s] new test indexes generated", s.LogPrefix()), "txNum", currentTxNum, "c", count)
+	}
+
+	return endBlock, nil
+}

--- a/eth/stagedsync/stages/stages.go
+++ b/eth/stagedsync/stages/stages.go
@@ -60,6 +60,7 @@ var (
 	BeaconState                 SyncStage = "BeaconState"                 // Beacon blocks are sent to the state transition function
 	BeaconIndexes               SyncStage = "BeaconIndexes"               // Fills up Beacon indexes
 
+	OtsTestStage SyncStage = "OtsTestStage"
 )
 
 var AllStages = []SyncStage{

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -170,6 +170,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.SentinelPortFlag,
 
 	&utils.OtsSearchMaxCapFlag,
+	&utils.OtsV2Flag,
 
 	&utils.SilkwormExecutionFlag,
 	&utils.SilkwormRpcDaemonFlag,

--- a/turbo/stages/mock/mock_sentry.go
+++ b/turbo/stages/mock/mock_sentry.go
@@ -524,6 +524,8 @@ func MockWithEverything(tb testing.TB, gspec *types.Genesis, key *ecdsa.PrivateK
 			stagedsync.StageCallTracesCfg(mock.DB, prune, 0, dirs.Tmp),
 			stagedsync.StageTxLookupCfg(mock.DB, prune, dirs.Tmp, mock.ChainConfig.Bor, mock.BlockReader),
 			stagedsync.StageFinishCfg(mock.DB, dirs.Tmp, forkValidator),
+			stagedsync.StageDbAwareCfg(mock.DB, mock.agg, dirs.Tmp, mock.ChainConfig, mock.BlockReader, mock.Engine),
+			false,
 			!withPosDownloader),
 		stagedsync.DefaultUnwindOrder,
 		stagedsync.DefaultPruneOrder,

--- a/turbo/stages/stageloop.go
+++ b/turbo/stages/stageloop.go
@@ -168,6 +168,10 @@ func StageLoopIteration(ctx context.Context, db kv.RwDB, txc wrap.TxContainer, s
 	}() // avoid crash because Erigon's core does many things
 
 	externalTx := txc.Tx != nil
+	otsProgressBefore, err := stagesOtsIndexers(db, txc.Tx)
+	if err != nil {
+		return err
+	}
 	finishProgressBefore, borProgressBefore, headersProgressBefore, err := stagesHeadersAndFinish(db, txc.Tx)
 	if err != nil {
 		return err
@@ -175,7 +179,7 @@ func StageLoopIteration(ctx context.Context, db kv.RwDB, txc wrap.TxContainer, s
 	// Sync from scratch must be able Commit partial progress
 	// In all other cases - process blocks batch in 1 RwTx
 	// 2 corner-cases: when sync with --snapshots=false and when executed only blocks from snapshots (in this case all stages progress is equal and > 0, but node is not synced)
-	isSynced := finishProgressBefore > 0 && finishProgressBefore > blockReader.FrozenBlocks() && finishProgressBefore == headersProgressBefore
+	isSynced := finishProgressBefore > 0 && finishProgressBefore > blockReader.FrozenBlocks() && finishProgressBefore == headersProgressBefore && otsProgressBefore == headersProgressBefore
 	if blockReader.BorSnapshots() != nil {
 		isSynced = isSynced && borProgressBefore > blockReader.FrozenBorBlocks()
 	}
@@ -259,6 +263,26 @@ func StageLoopIteration(ctx context.Context, db kv.RwDB, txc wrap.TxContainer, s
 	}
 
 	return nil
+}
+
+var lastOtsStage = stages.OtsTestStage
+
+func stagesOtsIndexers(db kv.RoDB, tx kv.Tx) (lastIdx uint64, err error) {
+	if tx != nil {
+		if lastIdx, err = stages.GetStageProgress(tx, lastOtsStage); err != nil {
+			return lastIdx, err
+		}
+		return lastIdx, nil
+	}
+	if err := db.View(context.Background(), func(tx kv.Tx) error {
+		if lastIdx, err = stages.GetStageProgress(tx, lastOtsStage); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return lastIdx, err
+	}
+	return lastIdx, nil
 }
 
 func stagesHeadersAndFinish(db kv.RoDB, tx kv.Tx) (head, bor, fin uint64, err error) {
@@ -641,6 +665,8 @@ func NewDefaultStages(ctx context.Context,
 		stagedsync.StageCallTracesCfg(db, cfg.Prune, 0, dirs.Tmp),
 		stagedsync.StageTxLookupCfg(db, cfg.Prune, dirs.Tmp, controlServer.ChainConfig.Bor, blockReader),
 		stagedsync.StageFinishCfg(db, dirs.Tmp, forkValidator),
+		stagedsync.StageDbAwareCfg(db, agg, dirs.Tmp, controlServer.ChainConfig, blockReader, controlServer.Engine),
+		cfg.Ots2,
 		runInTestMode)
 }
 
@@ -704,6 +730,8 @@ func NewPipelineStages(ctx context.Context,
 			stagedsync.StageCallTracesCfg(db, cfg.Prune, 0, dirs.Tmp),
 			stagedsync.StageTxLookupCfg(db, cfg.Prune, dirs.Tmp, controlServer.ChainConfig.Bor, blockReader),
 			stagedsync.StageFinishCfg(db, dirs.Tmp, forkValidator),
+			stagedsync.StageDbAwareCfg(db, agg, dirs.Tmp, controlServer.ChainConfig, blockReader, controlServer.Engine),
+			cfg.Ots2,
 			runInTestMode)
 	}
 


### PR DESCRIPTION
Goal:

- Allow custom domain/history/indexers to be plugged dynamically along with the "core" models.

This PR's contents:

- Add an example/test inverted index for testing purposes, and this index gets set every 10M txNums, just to make some artificial activity and force DB/files to be written.
- Please ignore the debug comments for now.
- This extra index is activated through a CLI flag `--experimental.ots2`.
- This extra flag activates a custom stage, insert before "finish stage".
- The extra stage does the writing of the index; in a real world scenario, let's imagine some custom stage does some chain analysis on top of current block and set domain/history/idx data.
- In order to better separate the custom idx from the "core" idxs; I created another slice in Aggregator called `diis` (derived idxs).
- This data can later be exposed through custom RPC APIs (not in the scope of this PR).

Challenges:

- Current code assumes everything moves together at the same step in the execution stage.
- A new stage plugged in dynamically will not be in sync. A workaround was made by modifying the collate/merge invocation code at the end of the custom stage to trigger the buildFilesInBackground not with the current step, but to calculate the earliest step of the custom index files, loop from it to current step, effectively backfilling the files, merging them and pruning the DB.
  - Apparently this approach works, but I'm not sure this is the right place/approach to do that.
  - Not sure if I'm handling the SharedDomains lifecycle correctly, apparently everything works for some time until the node gets corrupted (see logs below). So the question is: what is the correct way to modify Shareddomains outside the execution stage?
  - Even ignoring the fact that I'm calling things inadvertely when I shouldn't (code can be improved to handle those situations), I'd like a temperature checking to see if I should keep improving on that approach.
 
Corruption logs: at this point the node gets messed and needs to be restore from a backup. I'm probably modifying SharedDomains at some point I shouldn't and it ends up writing bad data.

```
INFO[06-12|19:13:14.196] [EngineBlockDownloader] Processed        highest=6095147
INFO[06-12|19:13:14.196] Beginning downloaded blocks insertion
INFO[06-12|19:13:14.231] [EngineBlockDownloader] Finished downloading blocks from=6095145 to=6095147
WARN[06-12|19:13:14.376] [5/7 Execution] Execution failed         block=6095146 txNum=248564060 hash=0xf579e98ad9e735e90ae52a49b5232780934d7ee83e149e87897a06805c8594ff err="invalid block, txnIdx=89, nonce too high: address 0xbC6B0248ccb88437b67C57856638e5385a14D6F5, tx: 2 state: 1"
WARN[06-12|19:13:14.377] Could not validate block                 err="[5/7 Execution] ExecV3: invalid block, txnIdx=89, nonce too high: address 0xbC6B0248ccb88437b67C57856638e5385a14D6F5, tx: 2 state: 1"
WARN[06-12|19:13:14.378] ethereumExecutionModule.ValidateChain: chain is invalid hash=0x842fa708ed1e30848ba15c3be98a0d94492f2446cd19a121415927e3460a7ea3
WARN[06-12|19:13:14.380] [EngineBlockDownloader] block segments downloaded are invalid
WARN[06-12|19:13:24.108] [NewPayload] Previously known bad block  hash=0xaaddbe59f36ef7ea0a29e746e6f04700873ce2894ca18b088cf6ebc0bff8b962 parentHash=0x842fa708ed1e30848ba15c3be98a0d94492f2446cd19a121415927e3460a7ea3
INFO[06-12|19:14:52.741] [mem] memory stats                       alloc=2.1GB sys=3.1GB
INFO[06-12|19:14:52.741] [p2p] GoodPeers                          eth68=1
```
