### PR TITLE
fun: Add Erigon 3 graffiti

### DIFF
--- a/cmd/erigon/main.go
+++ b/cmd/erigon/main.go
@@ -53,6 +53,18 @@ func runErigon(cliCtx *cli.Context) error {
 	// initializing the node and providing the current git commit there
 
 	logger.Info("Build info", "git_branch", params.GitBranch, "git_tag", params.GitTag, "git_commit", params.GitCommit)
+	if params.VersionMajor == 3 {
+		logger.Info(`
+	########b          oo                               d####b. 
+	##                                                      '## 
+	##aaaa    ##d###b. dP .d####b. .d####b. ##d###b.     aaad#' 
+	##        ##'  '## ## ##'  '## ##'  '## ##'  '##        '## 
+	##        ##       ## ##.  .## ##.  .## ##    ##        .## 
+	########P dP       dP '####P## '#####P' dP    dP    d#####P 
+	                           .##                              
+	                       d####P                               
+		`)
+	}
 	erigonInfoGauge := metrics.GetOrCreateGauge(fmt.Sprintf(`erigon_info{version="%s",commit="%s"}`, params.Version, params.GitCommit))
 	erigonInfoGauge.Set(1)
 


### PR DESCRIPTION
Simply prints a character graffiti of "Erigon 3"
It has the added benefits of 
- instantly alerting users and developers that they may need to change their ways 
- cross checking that it's the right version, if (like me) folks are switching between E2 and E3 multiple times during the day
- Letting users know that they're using a cool software :)