### PR TITLE
Add zero check in tx.Sender func

### DIFF
--- a/core/types/access_list_tx.go
+++ b/core/types/access_list_tx.go
@@ -506,7 +506,10 @@ func (tx *AccessListTx) GetChainID() *uint256.Int {
 
 func (tx *AccessListTx) Sender(signer Signer) (libcommon.Address, error) {
 	if sc := tx.from.Load(); sc != nil {
-		return sc.(libcommon.Address), nil
+		zeroAddr := libcommon.Address{}
+		if sc.(libcommon.Address) != zeroAddr { // Sender address can never be zero in a transaction with a valid signer
+			return sc.(libcommon.Address), nil
+		}
 	}
 	addr, err := signer.Sender(tx)
 	if err != nil {

--- a/core/types/blob_tx.go
+++ b/core/types/blob_tx.go
@@ -82,7 +82,10 @@ func (stx *BlobTx) AsMessage(s Signer, baseFee *big.Int, rules *chain.Rules) (Me
 
 func (stx *BlobTx) Sender(signer Signer) (libcommon.Address, error) {
 	if sc := stx.from.Load(); sc != nil {
-		return sc.(libcommon.Address), nil
+		zeroAddr := libcommon.Address{}
+		if sc.(libcommon.Address) != zeroAddr { // Sender address can never be zero in a transaction with a valid signer
+			return sc.(libcommon.Address), nil
+		}
 	}
 	addr, err := signer.Sender(stx)
 	if err != nil {

--- a/core/types/dynamic_fee_tx.go
+++ b/core/types/dynamic_fee_tx.go
@@ -429,7 +429,7 @@ func (tx *DynamicFeeTransaction) GetChainID() *uint256.Int {
 func (tx *DynamicFeeTransaction) Sender(signer Signer) (libcommon.Address, error) {
 	if sc := tx.from.Load(); sc != nil {
 		zeroAddr := libcommon.Address{}
-		if sc.(libcommon.Address) != zeroAddr{		// Sender address can never be zero in a transaction with a valid signer
+		if sc.(libcommon.Address) != zeroAddr { // Sender address can never be zero in a transaction with a valid signer
 			return sc.(libcommon.Address), nil
 		}
 	}

--- a/core/types/dynamic_fee_tx.go
+++ b/core/types/dynamic_fee_tx.go
@@ -428,7 +428,10 @@ func (tx *DynamicFeeTransaction) GetChainID() *uint256.Int {
 
 func (tx *DynamicFeeTransaction) Sender(signer Signer) (libcommon.Address, error) {
 	if sc := tx.from.Load(); sc != nil {
-		return sc.(libcommon.Address), nil
+		zeroAddr := libcommon.Address{}
+		if sc.(libcommon.Address) != zeroAddr{		// Sender address can never be zero in a transaction with a valid signer
+			return sc.(libcommon.Address), nil
+		}
 	}
 	addr, err := signer.Sender(tx)
 	if err != nil {

--- a/core/types/legacy_tx.go
+++ b/core/types/legacy_tx.go
@@ -432,7 +432,10 @@ func (tx *LegacyTx) GetChainID() *uint256.Int {
 
 func (tx *LegacyTx) Sender(signer Signer) (libcommon.Address, error) {
 	if sc := tx.from.Load(); sc != nil {
-		return sc.(libcommon.Address), nil
+		zeroAddr := libcommon.Address{}
+		if sc.(libcommon.Address) != zeroAddr { // Sender address can never be zero in a transaction with a valid signer
+			return sc.(libcommon.Address), nil
+		}
 	}
 	addr, err := signer.Sender(tx)
 	if err != nil {


### PR DESCRIPTION
This is an additional check as #9990 could not be reliably reproduced.
The conjecture is that at some point there is a race condition somewhere related to either storing snapshot file for an older block or updating the DB for a more recent block.
Somewhere the code sets sender value directly to zero or overwrites a pointer, leading to sender address being incorrectly assigned to ZERO.