### PR TITLE
move from e2 to e3 primitives

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ledgerwatch/erigon-lib/chain"
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/kv"
+	state3 "github.com/ledgerwatch/erigon-lib/state"
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/common/math"
 	"github.com/ledgerwatch/erigon/consensus/ethash"
@@ -76,9 +77,12 @@ type stEnvMarshaling struct {
 	BaseFee          *math.HexOrDecimal256
 }
 
-func MakePreState(chainRules *chain.Rules, tx kv.RwTx, accounts types.GenesisAlloc) (state.StateReader, *state.PlainStateWriter) {
+func MakePreState(chainRules *chain.Rules, tx kv.RwTx, sd *state3.SharedDomains, accounts types.GenesisAlloc) (state.StateReader, state.WriterWithChangeSets) {
 	var blockNr uint64 = 0
-	stateReader, stateWriter := rpchelper.NewLatestStateReader(tx), state.NewPlainStateWriter(tx, tx, blockNr)
+
+	stateReader, stateWriter := rpchelper.NewLatestStateReader(tx), state.NewWriterV4(sd)
+	sd.SetBlockNum(blockNr)
+
 	statedb := state.New(stateReader) //ibs
 	for addr, a := range accounts {
 		statedb.SetCode(addr, a.Code)
@@ -99,10 +103,11 @@ func MakePreState(chainRules *chain.Rules, tx kv.RwTx, accounts types.GenesisAll
 		}
 	}
 	// Commit and re-open to start with a clean state.
-	if err := statedb.FinalizeTx(chainRules, state.NewPlainStateWriter(tx, tx, blockNr+1)); err != nil {
+	sd.SetBlockNum(blockNr + 1)
+	if err := statedb.FinalizeTx(chainRules, stateWriter); err != nil {
 		panic(err)
 	}
-	if err := statedb.CommitBlock(chainRules, state.NewPlainStateWriter(tx, tx, blockNr+1)); err != nil {
+	if err := statedb.CommitBlock(chainRules, stateWriter); err != nil {
 		panic(err)
 	}
 	return stateReader, stateWriter

--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -39,6 +39,7 @@ import (
 	"github.com/ledgerwatch/erigon-lib/common/hexutility"
 	"github.com/ledgerwatch/erigon-lib/common/length"
 	"github.com/ledgerwatch/erigon-lib/kv"
+	state3 "github.com/ledgerwatch/erigon-lib/state"
 	"github.com/ledgerwatch/erigon/common/math"
 	"github.com/ledgerwatch/erigon/consensus/ethash"
 	"github.com/ledgerwatch/erigon/consensus/merge"
@@ -306,7 +307,13 @@ func Main(ctx *cli.Context) error {
 	}
 	defer tx.Rollback()
 
-	reader, writer := MakePreState(chainConfig.Rules(0, 0), tx, prestate.Pre)
+	sd, err := state3.NewSharedDomains(tx, log.New())
+	if err != nil {
+		return err
+	}
+	defer sd.Close()
+
+	reader, writer := MakePreState(chainConfig.Rules(0, 0), tx, sd, prestate.Pre)
 	// Merge engine can be used for pre-merge blocks as well, as it
 	// redirects to the ethash engine based on the block number
 	engine := merge.New(&ethash.FakeEthash{})

--- a/core/state/database_test.go
+++ b/core/state/database_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/ledgerwatch/erigon-lib/chain"
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/kv"
-	state2 "github.com/ledgerwatch/erigon-lib/state"
+	state3 "github.com/ledgerwatch/erigon-lib/state"
 	"github.com/ledgerwatch/log/v3"
 
 	"github.com/ledgerwatch/erigon/accounts/abi/bind"
@@ -847,17 +847,17 @@ func TestReproduceCrash(t *testing.T) {
 	storageKey2 := libcommon.HexToHash("0x0e4c0e7175f9d22279a4f63ff74f7fa28b7a954a6454debaa62ce43dd9132542")
 	value2 := uint256.NewInt(0x58c00a51)
 
-	//_, tx := memdb.NewTestTx(t)
 	_, tx, _ := state.NewTestTemporalDb(t)
-	sd, err := state2.NewSharedDomains(tx, log.New())
+	sd, err := state3.NewSharedDomains(tx, log.New())
 	require.NoError(t, err)
 	t.Cleanup(sd.Close)
 
 	tsw := state.NewWriterV4(sd)
+	tsr := state.NewReaderV4(sd)
 	sd.SetTxNum(1)
 	sd.SetBlockNum(1)
 
-	intraBlockState := state.New(state.NewPlainState(tx, 1, nil))
+	intraBlockState := state.New(tsr)
 	// Start the 1st transaction
 	intraBlockState.CreateAccount(contract, true)
 	if err := intraBlockState.FinalizeTx(&chain.Rules{}, tsw); err != nil {
@@ -1248,7 +1248,7 @@ func TestChangeAccountCodeBetweenBlocks(t *testing.T) {
 	contract := libcommon.HexToAddress("0x71dd1027069078091B3ca48093B00E4735B20624")
 
 	_, tx, _ := state.NewTestTemporalDb(t)
-	sd, err := state2.NewSharedDomains(tx, log.New())
+	sd, err := state3.NewSharedDomains(tx, log.New())
 	require.NoError(t, err)
 	t.Cleanup(sd.Close)
 
@@ -1300,7 +1300,7 @@ func TestCacheCodeSizeSeparately(t *testing.T) {
 	//root := libcommon.HexToHash("0xb939e5bcf5809adfb87ab07f0795b05b95a1d64a90f0eddd0c3123ac5b433854")
 
 	_, tx, _ := state.NewTestTemporalDb(t)
-	sd, err := state2.NewSharedDomains(tx, log.New())
+	sd, err := state3.NewSharedDomains(tx, log.New())
 	require.NoError(t, err)
 	t.Cleanup(sd.Close)
 
@@ -1339,7 +1339,7 @@ func TestCacheCodeSizeInTrie(t *testing.T) {
 	root := libcommon.HexToHash("0xb939e5bcf5809adfb87ab07f0795b05b95a1d64a90f0eddd0c3123ac5b433854")
 
 	_, tx, _ := state.NewTestTemporalDb(t)
-	sd, err := state2.NewSharedDomains(tx, log.New())
+	sd, err := state3.NewSharedDomains(tx, log.New())
 	require.NoError(t, err)
 	t.Cleanup(sd.Close)
 

--- a/core/state/state_writer_v4.go
+++ b/core/state/state_writer_v4.go
@@ -2,7 +2,6 @@ package state
 
 import (
 	"fmt"
-
 	"github.com/holiman/uint256"
 
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
@@ -23,6 +22,9 @@ func NewWriterV4(tx kv.TemporalPutDel) *WriterV4 {
 		trace: false,
 	}
 }
+
+func (cw *WriterV4) WriteChangeSets() error { return nil }
+func (cw *WriterV4) WriteHistory() error    { return nil }
 
 func (w *WriterV4) UpdateAccountData(address libcommon.Address, original, account *accounts.Account) error {
 	if w.trace {

--- a/core/vm/gas_table_test.go
+++ b/core/vm/gas_table_test.go
@@ -24,11 +24,13 @@ import (
 	"testing"
 
 	"github.com/ledgerwatch/erigon-lib/common/hexutil"
+	"github.com/ledgerwatch/erigon-lib/kv"
+	"github.com/ledgerwatch/erigon-lib/kv/temporal"
 	"github.com/ledgerwatch/erigon-lib/kv/temporal/temporaltest"
 	"github.com/ledgerwatch/erigon-lib/wrap"
 	"github.com/ledgerwatch/log/v3"
 
-	state2 "github.com/ledgerwatch/erigon-lib/state"
+	state3 "github.com/ledgerwatch/erigon-lib/state"
 	"github.com/stretchr/testify/require"
 
 	"github.com/holiman/uint256"
@@ -92,23 +94,52 @@ var eip2200Tests = []struct {
 	{1, 2307, "0x6001600055", 806, 0, nil},                                     // 1 -> 1 (2301 sentry + 2xPUSH)
 }
 
-func TestEIP2200(t *testing.T) {
+func testTemporalDB(t *testing.T) *temporal.DB {
+	db := memdb.NewStateDB(t.TempDir())
 
+	t.Cleanup(db.Close)
+
+	agg, err := state3.NewAggregator(context.Background(), datadir.New(t.TempDir()), 16, db, log.New())
+	require.NoError(t, err)
+	t.Cleanup(agg.Close)
+
+	_db, err := temporal.New(db, agg)
+	require.NoError(t, err)
+	return _db
+}
+
+func testTemporalTxSD(t *testing.T, db *temporal.DB) (kv.RwTx, *state3.SharedDomains) {
+	tx, err := db.BeginTemporalRw(context.Background()) //nolint:gocritic
+	require.NoError(t, err)
+	t.Cleanup(tx.Rollback)
+
+	sd, err := state3.NewSharedDomains(tx, log.New())
+	require.NoError(t, err)
+	t.Cleanup(sd.Close)
+
+	return tx, sd
+}
+
+func TestEIP2200(t *testing.T) {
 	for i, tt := range eip2200Tests {
 		tt := tt
 		i := i
 
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
-			address := libcommon.BytesToAddress([]byte("contract"))
-			_, tx := memdb.NewTestTx(t)
 
-			s := state.New(state.NewPlainStateReader(tx))
+			tx, sd := testTemporalTxSD(t, testTemporalDB(t))
+			defer tx.Rollback()
+
+			r, w := state.NewReaderV4(sd), state.NewWriterV4(sd)
+			s := state.New(r)
+
+			address := libcommon.BytesToAddress([]byte("contract"))
 			s.CreateAccount(address, true)
 			s.SetCode(address, hexutil.MustDecode(tt.input))
 			s.SetState(address, &libcommon.Hash{}, *uint256.NewInt(uint64(tt.original)))
 
-			_ = s.CommitBlock(params.AllProtocolChanges.Rules(0, 0), state.NewPlainStateWriter(tx, tx, 0))
+			_ = s.CommitBlock(params.AllProtocolChanges.Rules(0, 0), w)
 			vmctx := evmtypes.BlockContext{
 				CanTransfer: func(evmtypes.IntraBlockState, libcommon.Address, *uint256.Int) bool { return true },
 				Transfer:    func(evmtypes.IntraBlockState, libcommon.Address, libcommon.Address, *uint256.Int, bool) {},
@@ -159,7 +190,7 @@ func TestCreateGas(t *testing.T) {
 		var txc wrap.TxContainer
 		txc.Tx = tx
 
-		domains, err := state2.NewSharedDomains(tx, log.New())
+		domains, err := state3.NewSharedDomains(tx, log.New())
 		require.NoError(t, err)
 		defer domains.Close()
 		txc.Doms = domains

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -20,13 +20,21 @@ import (
 	"context"
 	"math"
 	"math/big"
+	"os"
+	"path/filepath"
 	"time"
+
+	"github.com/ledgerwatch/log/v3"
 
 	"github.com/holiman/uint256"
 	"github.com/ledgerwatch/erigon-lib/chain"
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/common/datadir"
+	"github.com/ledgerwatch/erigon-lib/config3"
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon-lib/kv/memdb"
+	"github.com/ledgerwatch/erigon-lib/kv/temporal"
+	state3 "github.com/ledgerwatch/erigon-lib/state"
 	"github.com/ledgerwatch/erigon/core/state"
 	"github.com/ledgerwatch/erigon/core/vm"
 	"github.com/ledgerwatch/erigon/crypto"
@@ -118,15 +126,32 @@ func Execute(code, input []byte, cfg *Config, bn uint64) ([]byte, *state.IntraBl
 	var tx kv.RwTx
 	var err error
 	if !externalState {
-		db := memdb.New("")
+		tmp := filepath.Join(os.TempDir(), "execute-vm")
+		defer os.RemoveAll(tmp) //nolint
+
+		db := memdb.NewStateDB(tmp)
 		defer db.Close()
-		tx, err = db.BeginRw(context.Background())
+		agg, err := state3.NewAggregator(context.Background(), datadir.New(tmp), config3.HistoryV3AggregationStep, db, log.New())
+		if err != nil {
+			return nil, nil, err
+		}
+		defer agg.Close()
+		_db, err := temporal.New(db, agg)
+		if err != nil {
+			return nil, nil, err
+		}
+		tx, err = _db.BeginTemporalRw(context.Background()) //nolint:gocritic
 		if err != nil {
 			return nil, nil, err
 		}
 		defer tx.Rollback()
-		cfg.r = state.NewPlainStateReader(tx)
-		cfg.w = state.NewPlainStateWriter(tx, tx, 0)
+		sd, err := state3.NewSharedDomains(tx, log.New())
+		if err != nil {
+			return nil, nil, err
+		}
+		defer sd.Close()
+		cfg.r = state.NewReaderV4(sd)
+		cfg.w = state.NewWriterV4(sd)
 		cfg.State = state.New(cfg.r)
 	}
 	var (
@@ -163,15 +188,32 @@ func Create(input []byte, cfg *Config, blockNr uint64) ([]byte, libcommon.Addres
 	var tx kv.RwTx
 	var err error
 	if !externalState {
-		db := memdb.New("")
+		tmp := filepath.Join(os.TempDir(), "create-vm")
+		defer os.RemoveAll(tmp) //nolint
+
+		db := memdb.NewStateDB(tmp)
 		defer db.Close()
-		tx, err = db.BeginRw(context.Background())
+		agg, err := state3.NewAggregator(context.Background(), datadir.New(tmp), config3.HistoryV3AggregationStep, db, log.New())
+		if err != nil {
+			return nil, [20]byte{}, 0, err
+		}
+		defer agg.Close()
+		_db, err := temporal.New(db, agg)
+		if err != nil {
+			return nil, [20]byte{}, 0, err
+		}
+		tx, err = _db.BeginTemporalRw(context.Background()) //nolint:gocritic
 		if err != nil {
 			return nil, [20]byte{}, 0, err
 		}
 		defer tx.Rollback()
-		cfg.r = state.NewPlainStateReader(tx)
-		cfg.w = state.NewPlainStateWriter(tx, tx, 0)
+		sd, err := state3.NewSharedDomains(tx, log.New())
+		if err != nil {
+			return nil, [20]byte{}, 0, err
+		}
+		defer sd.Close()
+		cfg.r = state.NewReaderV4(sd)
+		cfg.w = state.NewWriterV4(sd)
 		cfg.State = state.New(cfg.r)
 	}
 	var (

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -24,9 +24,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/holiman/uint256"
 	"github.com/ledgerwatch/erigon-lib/chain"
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/common/datadir"
+	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon-lib/kv/memdb"
+	"github.com/ledgerwatch/erigon-lib/kv/temporal"
+	state3 "github.com/ledgerwatch/erigon-lib/state"
 	"github.com/ledgerwatch/erigon/accounts/abi"
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/consensus"
@@ -39,6 +44,8 @@ import (
 	"github.com/ledgerwatch/erigon/eth/tracers/logger"
 	"github.com/ledgerwatch/erigon/params"
 	"github.com/ledgerwatch/erigon/rlp"
+	"github.com/ledgerwatch/log/v3"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDefaults(t *testing.T) {
@@ -136,6 +143,32 @@ func TestCall(t *testing.T) {
 	}
 }
 
+func testTemporalDB(t testing.TB) *temporal.DB {
+	db := memdb.NewStateDB(t.TempDir())
+
+	t.Cleanup(db.Close)
+
+	agg, err := state3.NewAggregator(context.Background(), datadir.New(t.TempDir()), 16, db, log.New())
+	require.NoError(t, err)
+	t.Cleanup(agg.Close)
+
+	_db, err := temporal.New(db, agg)
+	require.NoError(t, err)
+	return _db
+}
+
+func testTemporalTxSD(t testing.TB, db *temporal.DB) (kv.RwTx, *state3.SharedDomains) {
+	tx, err := db.BeginTemporalRw(context.Background()) //nolint:gocritic
+	require.NoError(t, err)
+	t.Cleanup(tx.Rollback)
+
+	sd, err := state3.NewSharedDomains(tx, log.New())
+	require.NoError(t, err)
+	t.Cleanup(sd.Close)
+
+	return tx, sd
+}
+
 func BenchmarkCall(b *testing.B) {
 	var definition = `[{"constant":true,"inputs":[],"name":"seller","outputs":[{"name":"","type":"address"}],"type":"function"},{"constant":false,"inputs":[],"name":"abort","outputs":[],"type":"function"},{"constant":true,"inputs":[],"name":"value","outputs":[{"name":"","type":"uint256"}],"type":"function"},{"constant":false,"inputs":[],"name":"refund","outputs":[],"type":"function"},{"constant":true,"inputs":[],"name":"buyer","outputs":[{"name":"","type":"address"}],"type":"function"},{"constant":false,"inputs":[],"name":"confirmReceived","outputs":[],"type":"function"},{"constant":true,"inputs":[],"name":"state","outputs":[{"name":"","type":"uint8"}],"type":"function"},{"constant":false,"inputs":[],"name":"confirmPurchase","outputs":[],"type":"function"},{"inputs":[],"type":"constructor"},{"anonymous":false,"inputs":[],"name":"Aborted","type":"event"},{"anonymous":false,"inputs":[],"name":"PurchaseConfirmed","type":"event"},{"anonymous":false,"inputs":[],"name":"ItemReceived","type":"event"},{"anonymous":false,"inputs":[],"name":"Refunded","type":"event"}]`
 
@@ -158,16 +191,12 @@ func BenchmarkCall(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	cfg := &Config{}
-	db := memdb.New("")
-	defer db.Close()
-	tx, err := db.BeginRw(context.Background())
-	if err != nil {
-		panic(err)
-	}
+	cfg := &Config{ChainConfig: &chain.Config{}, BlockNumber: big.NewInt(0), Time: big.NewInt(0), Value: uint256.MustFromBig(big.NewInt(13377))}
+	db := testTemporalDB(b)
+	tx, sd := testTemporalTxSD(b, db)
 	defer tx.Rollback()
-	cfg.r = state.NewPlainStateReader(tx)
-	cfg.w = state.NewPlainStateWriter(tx, tx, 0)
+	cfg.r = state.NewReaderV4(sd)
+	cfg.w = state.NewWriterV4(sd)
 	cfg.State = state.New(cfg.r)
 
 	cfg.Debug = true
@@ -427,8 +456,29 @@ func TestBlockHashEip2935(t *testing.T) {
 	}
 	setDefaults(cfg)
 	cfg.ChainConfig.PragueTime = big.NewInt(10000)
-	_, tx := memdb.NewTestTx(t)
-	cfg.State = state.New(state.NewPlainStateReader(tx))
+
+	db := memdb.NewStateDB(t.TempDir())
+	defer db.Close()
+
+	agg, err := state3.NewAggregator(context.Background(), datadir.New(t.TempDir()), 16, db, log.New())
+	require.NoError(t, err)
+	defer agg.Close()
+
+	_db, err := temporal.New(db, agg)
+	defer _db.Close()
+	require.NoError(t, err)
+
+	tx, err := _db.BeginTemporalRw(context.Background())
+	defer tx.Rollback()
+	require.NoError(t, err)
+
+	sd, err := state3.NewSharedDomains(tx, log.New())
+	defer sd.Close()
+	require.NoError(t, err)
+
+	cfg.r = state.NewReaderV4(sd)
+	cfg.w = state.NewWriterV4(sd)
+	cfg.State = state.New(cfg.r)
 	cfg.State.CreateAccount(params.HistoryStorageAddress, true)
 	misc.StoreBlockHashesEip2935(header, cfg.State, cfg.ChainConfig, &FakeChainHeaderReader{})
 

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -465,16 +465,16 @@ func TestBlockHashEip2935(t *testing.T) {
 	defer agg.Close()
 
 	_db, err := temporal.New(db, agg)
-	defer _db.Close()
 	require.NoError(t, err)
+	defer _db.Close()
 
 	tx, err := _db.BeginTemporalRw(context.Background())
-	defer tx.Rollback()
 	require.NoError(t, err)
+	defer tx.Rollback()
 
 	sd, err := state3.NewSharedDomains(tx, log.New())
-	defer sd.Close()
 	require.NoError(t, err)
+	defer sd.Close()
 
 	cfg.r = state.NewReaderV4(sd)
 	cfg.w = state.NewWriterV4(sd)


### PR DESCRIPTION
closes https://github.com/ledgerwatch/erigon/issues/10639

rest of usages seems to be e2 calls.