### PR TITLE
qa-tests: record the db version used for test

### DIFF
--- a/.github/workflows/qa-clean-exit-block-downloading.yml
+++ b/.github/workflows/qa-clean-exit-block-downloading.yml
@@ -102,7 +102,7 @@ jobs:
           --commit $(git rev-parse HEAD) \
           --branch ${{ github.ref_name }} \
           --test_name clean-exit-block-downloading \
-          --chain $CHAIN \ 
+          --chain $CHAIN \
           --runner ${{ runner.name }} \
           --db_version $db_version \
           --outcome $TEST_RESULT \

--- a/.github/workflows/qa-clean-exit-block-downloading.yml
+++ b/.github/workflows/qa-clean-exit-block-downloading.yml
@@ -89,7 +89,13 @@ jobs:
       env:
         TEST_RESULT: ${{ steps.test_step.outputs.TEST_RESULT }}
       run: |
+        python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/prod_info.py $ERIGON_REFERENCE_DATA_DIR/../production.ini production erigon_repo_commit
+        
         db_version=$(python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/prod_info.py $ERIGON_REFERENCE_DATA_DIR/../production.ini production erigon_repo_commit)
+        echo "DB version: $db_version"
+        if [ -z "$db_version" ]; then
+          db_version="no-version"
+        fi
         
         python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py \
           --repo erigon \

--- a/.github/workflows/qa-clean-exit-block-downloading.yml
+++ b/.github/workflows/qa-clean-exit-block-downloading.yml
@@ -4,14 +4,6 @@ on:
   schedule:
     - cron: '0 8 * * 1-6'  # Run every day at 08:00 AM UTC except Sunday
   workflow_dispatch:     # Run manually
-  pull_request:
-    branches:
-      - main
-      - 'release/3.*'
-    types:
-      - ready_for_review
-      - synchronize
-      - opened
 
 jobs:
   clean-exit-bd-test:
@@ -88,11 +80,8 @@ jobs:
       if: steps.test_step.outputs.test_executed == 'true'
       env:
         TEST_RESULT: ${{ steps.test_step.outputs.TEST_RESULT }}
-      run: |
-        python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/prod_info.py $ERIGON_REFERENCE_DATA_DIR/../production.ini production erigon_repo_commit
-        
+      run: |       
         db_version=$(python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/prod_info.py $ERIGON_REFERENCE_DATA_DIR/../production.ini production erigon_repo_commit)
-        echo "DB version: $db_version"
         if [ -z "$db_version" ]; then
           db_version="no-version"
         fi

--- a/.github/workflows/qa-clean-exit-block-downloading.yml
+++ b/.github/workflows/qa-clean-exit-block-downloading.yml
@@ -4,6 +4,14 @@ on:
   schedule:
     - cron: '0 8 * * 1-6'  # Run every day at 08:00 AM UTC except Sunday
   workflow_dispatch:     # Run manually
+  pull_request:
+    branches:
+      - main
+      - 'release/3.*'
+    types:
+      - ready_for_review
+      - synchronize
+      - opened
 
 jobs:
   clean-exit-bd-test:
@@ -81,6 +89,8 @@ jobs:
       env:
         TEST_RESULT: ${{ steps.test_step.outputs.TEST_RESULT }}
       run: |
+        db_version=$(python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/prod_info.py $ERIGON_REFERENCE_DATA_DIR/../production.ini production erigon_repo_commit)
+        
         python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py \
           --repo erigon \
           --commit $(git rev-parse HEAD) \
@@ -88,6 +98,7 @@ jobs:
           --test_name clean-exit-block-downloading \
           --chain $CHAIN \ 
           --runner ${{ runner.name }} \
+          --db_version $db_version \
           --outcome $TEST_RESULT \
           --result_file ${{ github.workspace }}/result.json
 

--- a/.github/workflows/qa-tip-tracking.yml
+++ b/.github/workflows/qa-tip-tracking.yml
@@ -85,6 +85,11 @@ jobs:
       env:
         TEST_RESULT: ${{ steps.test_step.outputs.TEST_RESULT }}
       run: |
+        db_version=$(python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/prod_info.py $ERIGON_REFERENCE_DATA_DIR/../production.ini production erigon_repo_commit)
+        if [ -z "$db_version" ]; then
+          db_version="no-version"
+        fi
+        
         python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py \
           --repo erigon \
           --commit $(git rev-parse HEAD) \
@@ -92,6 +97,7 @@ jobs:
           --test_name tip-tracking \
           --chain $CHAIN \
           --runner ${{ runner.name }} \
+          --db_version $db_version \
           --outcome $TEST_RESULT \
           --result_file ${{ github.workspace }}/result-$CHAIN.json
 


### PR DESCRIPTION
Some tests utilise a prebuilt database. 
To facilitate historical comparisons, it is useful to record the exact version of Erigon used to pre-build this database