### PR TITLE
Raise the limit of debug_accountRange to 8192 (if storage not requested)

### DIFF
--- a/turbo/jsonrpc/debug_api.go
+++ b/turbo/jsonrpc/debug_api.go
@@ -25,7 +25,7 @@ import (
 )
 
 // AccountRangeMaxResults is the maximum number of results to be returned per call
-const AccountRangeMaxResults = 256
+const AccountRangeMaxResults = 8192
 
 // PrivateDebugAPI Exposed RPC endpoints for debugging use
 type PrivateDebugAPI interface {


### PR DESCRIPTION
`debug_accountRange` is one of the cool rpc methods erigon provides. However, the hardcoded limit 256 makes it supper inefficient. In my personal benchmark, raising the limit to 8192 could boost the indexing process 3-4x faster and thus this PR raises the default limit.

I could understand the security consideration of the DDoS attack on this parameter. But it's an RPC method under the `debug` namespace, which is not common for external usage, and both limits impose similar database pressure. Therefore, it should be mostly safe to raise the limit to a moderate value. 