### PR TITLE
use t.TempDir() in tests

### DIFF
--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -116,7 +116,7 @@ func setDefaults(cfg *Config) {
 //
 // Execute sets up an in-memory, temporary, environment for the execution of
 // the given code. It makes sure that it's restored to its original state afterwards.
-func Execute(code, input []byte, cfg *Config, bn uint64) ([]byte, *state.IntraBlockState, error) {
+func Execute(code, input []byte, cfg *Config, tempdir string) ([]byte, *state.IntraBlockState, error) {
 	if cfg == nil {
 		cfg = new(Config)
 		setDefaults(cfg)
@@ -126,12 +126,9 @@ func Execute(code, input []byte, cfg *Config, bn uint64) ([]byte, *state.IntraBl
 	var tx kv.RwTx
 	var err error
 	if !externalState {
-		tmp := filepath.Join(os.TempDir(), "execute-vm")
-		defer os.RemoveAll(tmp) //nolint
-
-		db := memdb.NewStateDB(tmp)
+		db := memdb.NewStateDB(tempdir)
 		defer db.Close()
-		agg, err := state3.NewAggregator(context.Background(), datadir.New(tmp), config3.HistoryV3AggregationStep, db, log.New())
+		agg, err := state3.NewAggregator(context.Background(), datadir.New(tempdir), config3.HistoryV3AggregationStep, db, log.New())
 		if err != nil {
 			return nil, nil, err
 		}

--- a/core/vm/runtime/runtime_example_test.go
+++ b/core/vm/runtime/runtime_example_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func ExampleExecute() {
-	ret, _, err := runtime.Execute(common.Hex2Bytes("6060604052600a8060106000396000f360606040526008565b00"), nil, nil, 0)
+	ret, _, err := runtime.Execute(common.Hex2Bytes("6060604052600a8060106000396000f360606040526008565b00"), nil, nil, "")
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -93,7 +93,7 @@ func TestEVM(t *testing.T) {
 		byte(vm.ORIGIN),
 		byte(vm.BLOCKHASH),
 		byte(vm.COINBASE),
-	}, nil, nil, 0); err != nil {
+	}, nil, nil, t.TempDir()); err != nil {
 		t.Fatal("didn't expect error", err)
 	}
 }
@@ -107,7 +107,7 @@ func TestExecute(t *testing.T) {
 		byte(vm.PUSH1), 32,
 		byte(vm.PUSH1), 0,
 		byte(vm.RETURN),
-	}, nil, nil, 0)
+	}, nil, nil, t.TempDir())
 	if err != nil {
 		t.Fatal("didn't expect error", err)
 	}
@@ -199,13 +199,14 @@ func BenchmarkCall(b *testing.B) {
 	cfg.w = state.NewWriterV4(sd)
 	cfg.State = state.New(cfg.r)
 
+	tmpdir := b.TempDir()
 	cfg.Debug = true
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < 400; j++ {
-			_, _, _ = Execute(code, cpurchase, cfg, 0)
-			_, _, _ = Execute(code, creceived, cfg, 0)
-			_, _, _ = Execute(code, refund, cfg, 0)
+			_, _, _ = Execute(code, cpurchase, cfg, tmpdir)
+			_, _, _ = Execute(code, creceived, cfg, tmpdir)
+			_, _, _ = Execute(code, refund, cfg, tmpdir)
 		}
 	}
 }
@@ -392,7 +393,7 @@ func TestBlockhash(t *testing.T) {
 	}
 	setDefaults(cfg)
 	cfg.ChainConfig.PragueTime = big.NewInt(1)
-	ret, _, err := Execute(data, input, cfg, header.Number.Uint64())
+	ret, _, err := Execute(data, input, cfg, t.TempDir())
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -482,7 +483,7 @@ func TestBlockHashEip2935(t *testing.T) {
 	cfg.State.CreateAccount(params.HistoryStorageAddress, true)
 	misc.StoreBlockHashesEip2935(header, cfg.State, cfg.ChainConfig, &FakeChainHeaderReader{})
 
-	ret, _, err := Execute(data, input, cfg, header.Number.Uint64())
+	ret, _, err := Execute(data, input, cfg, t.TempDir())
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -667,6 +668,7 @@ func BenchmarkSimpleLoop(b *testing.B) {
 // EIP-2929 about gas repricings
 func TestEip2929Cases(t *testing.T) {
 
+	tmpdir := t.TempDir()
 	id := 1
 	prettyPrint := func(comment string, code []byte) {
 
@@ -694,7 +696,7 @@ func TestEip2929Cases(t *testing.T) {
 		}
 		setDefaults(cfg)
 		//nolint:errcheck
-		Execute(code, nil, cfg, 0)
+		Execute(code, nil, cfg, tmpdir)
 	}
 
 	{ // First eip testcase

--- a/tests/fuzzers/runtime/runtime_fuzz.go
+++ b/tests/fuzzers/runtime/runtime_fuzz.go
@@ -27,7 +27,7 @@ import (
 func Fuzz(input []byte) int {
 	_, _, err := runtime.Execute(input, input, &runtime.Config{
 		GasLimit: 12000000,
-	}, 1)
+	})
 	// invalid opcode
 	if err != nil && len(err.Error()) > 6 && err.Error()[:7] == "invalid" {
 		return 0

--- a/tests/fuzzers/runtime/runtime_fuzz.go
+++ b/tests/fuzzers/runtime/runtime_fuzz.go
@@ -18,6 +18,7 @@ package runtime
 
 import (
 	"github.com/ledgerwatch/erigon/core/vm/runtime"
+	"os"
 )
 
 // Fuzz is the basic entry point for the go-fuzz tool
@@ -27,7 +28,7 @@ import (
 func Fuzz(input []byte) int {
 	_, _, err := runtime.Execute(input, input, &runtime.Config{
 		GasLimit: 12000000,
-	})
+	}, os.TempDir())
 	// invalid opcode
 	if err != nil && len(err.Error()) > 6 && err.Error()[:7] == "invalid" {
 		return 0


### PR DESCRIPTION
for https://github.com/ledgerwatch/erigon/actions/runs/9517264736/job/26259577369?pr=10753#step:11:542
```
--- FAIL: TestBlockhash (0.01s)
    runtime_test.go:397: expected no error, got open /tmp/execute-vm/snapshots/salt-state.txt: no such file or directory
FAIL
```
don't use `/tmp` / `os.TempDir()` - because tests are run in-parallel. 