### PR TITLE
Added `CurrentFinalizedHeader` and `CurrentSafeHeader` in chain reader interface

### DIFF
--- a/consensus/chain_header_reader_mock.go
+++ b/consensus/chain_header_reader_mock.go
@@ -118,6 +118,44 @@ func (c *MockChainHeaderReaderConfigCall) DoAndReturn(f func() *chain.Config) *M
 	return c
 }
 
+// CurrentFinalizedHeader mocks base method.
+func (m *MockChainHeaderReader) CurrentFinalizedHeader() *types.Header {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CurrentFinalizedHeader")
+	ret0, _ := ret[0].(*types.Header)
+	return ret0
+}
+
+// CurrentFinalizedHeader indicates an expected call of CurrentFinalizedHeader.
+func (mr *MockChainHeaderReaderMockRecorder) CurrentFinalizedHeader() *MockChainHeaderReaderCurrentFinalizedHeaderCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentFinalizedHeader", reflect.TypeOf((*MockChainHeaderReader)(nil).CurrentFinalizedHeader))
+	return &MockChainHeaderReaderCurrentFinalizedHeaderCall{Call: call}
+}
+
+// MockChainHeaderReaderCurrentFinalizedHeaderCall wrap *gomock.Call
+type MockChainHeaderReaderCurrentFinalizedHeaderCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockChainHeaderReaderCurrentFinalizedHeaderCall) Return(arg0 *types.Header) *MockChainHeaderReaderCurrentFinalizedHeaderCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockChainHeaderReaderCurrentFinalizedHeaderCall) Do(f func() *types.Header) *MockChainHeaderReaderCurrentFinalizedHeaderCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockChainHeaderReaderCurrentFinalizedHeaderCall) DoAndReturn(f func() *types.Header) *MockChainHeaderReaderCurrentFinalizedHeaderCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // CurrentHeader mocks base method.
 func (m *MockChainHeaderReader) CurrentHeader() *types.Header {
 	m.ctrl.T.Helper()
@@ -152,6 +190,44 @@ func (c *MockChainHeaderReaderCurrentHeaderCall) Do(f func() *types.Header) *Moc
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockChainHeaderReaderCurrentHeaderCall) DoAndReturn(f func() *types.Header) *MockChainHeaderReaderCurrentHeaderCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// CurrentSafeHeader mocks base method.
+func (m *MockChainHeaderReader) CurrentSafeHeader() *types.Header {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CurrentSafeHeader")
+	ret0, _ := ret[0].(*types.Header)
+	return ret0
+}
+
+// CurrentSafeHeader indicates an expected call of CurrentSafeHeader.
+func (mr *MockChainHeaderReaderMockRecorder) CurrentSafeHeader() *MockChainHeaderReaderCurrentSafeHeaderCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentSafeHeader", reflect.TypeOf((*MockChainHeaderReader)(nil).CurrentSafeHeader))
+	return &MockChainHeaderReaderCurrentSafeHeaderCall{Call: call}
+}
+
+// MockChainHeaderReaderCurrentSafeHeaderCall wrap *gomock.Call
+type MockChainHeaderReaderCurrentSafeHeaderCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockChainHeaderReaderCurrentSafeHeaderCall) Return(arg0 *types.Header) *MockChainHeaderReaderCurrentSafeHeaderCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockChainHeaderReaderCurrentSafeHeaderCall) Do(f func() *types.Header) *MockChainHeaderReaderCurrentSafeHeaderCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockChainHeaderReaderCurrentSafeHeaderCall) DoAndReturn(f func() *types.Header) *MockChainHeaderReaderCurrentSafeHeaderCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -42,6 +42,12 @@ type ChainHeaderReader interface {
 	// CurrentHeader retrieves the current header from the local chain.
 	CurrentHeader() *types.Header
 
+	// CurrentFinalizedHeader retrieves the current finalized header from the local chain.
+	CurrentFinalizedHeader() *types.Header
+
+	// CurrentSafeHeader retrieves the current safe header from the local chain.
+	CurrentSafeHeader() *types.Header
+
 	// GetHeader retrieves a block header from the database by hash and number.
 	GetHeader(hash libcommon.Hash, number uint64) *types.Header
 

--- a/consensus/merge/merge_test.go
+++ b/consensus/merge/merge_test.go
@@ -21,6 +21,14 @@ func (r readerMock) CurrentHeader() *types.Header {
 	return nil
 }
 
+func (cr readerMock) CurrentFinalizedHeader() *types.Header {
+	return nil
+}
+
+func (cr readerMock) CurrentSafeHeader() *types.Header {
+	return nil
+}
+
 func (r readerMock) GetHeader(libcommon.Hash, uint64) *types.Header {
 	return nil
 }

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -691,7 +691,13 @@ func (cr *FakeChainReader) Config() *chain.Config {
 	return cr.Cfg
 }
 
-func (cr *FakeChainReader) CurrentHeader() *types.Header                               { return cr.current.Header() }
+func (cr *FakeChainReader) CurrentHeader() *types.Header { return cr.current.Header() }
+func (cr *FakeChainReader) CurrentFinalizedHeader() *types.Header {
+	return nil
+}
+func (cr *FakeChainReader) CurrentSafeHeader() *types.Header {
+	return nil
+}
 func (cr *FakeChainReader) GetHeaderByNumber(number uint64) *types.Header              { return nil }
 func (cr *FakeChainReader) GetHeaderByHash(hash libcommon.Hash) *types.Header          { return nil }
 func (cr *FakeChainReader) GetHeader(hash libcommon.Hash, number uint64) *types.Header { return nil }

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -300,8 +300,10 @@ func (cr *FakeChainHeaderReader) GetHeaderByHash(hash libcommon.Hash) *types.Hea
 func (cr *FakeChainHeaderReader) GetHeaderByNumber(number uint64) *types.Header {
 	return cr.GetHeaderByHash(libcommon.BigToHash(big.NewInt(int64(number))))
 }
-func (cr *FakeChainHeaderReader) Config() *chain.Config        { return nil }
-func (cr *FakeChainHeaderReader) CurrentHeader() *types.Header { return nil }
+func (cr *FakeChainHeaderReader) Config() *chain.Config                 { return nil }
+func (cr *FakeChainHeaderReader) CurrentHeader() *types.Header          { return nil }
+func (cr *FakeChainHeaderReader) CurrentFinalizedHeader() *types.Header { return nil }
+func (cr *FakeChainHeaderReader) CurrentSafeHeader() *types.Header      { return nil }
 
 // GetHeader returns a fake header with the parentHash equal to the number - 1
 func (cr *FakeChainHeaderReader) GetHeader(hash libcommon.Hash, number uint64) *types.Header {

--- a/eth/consensuschain/consensus_chain_reader.go
+++ b/eth/consensuschain/consensus_chain_reader.go
@@ -32,6 +32,18 @@ func (cr Reader) CurrentHeader() *types.Header {
 	h, _ := cr.blockReader.Header(context.Background(), cr.tx, hash, *number)
 	return h
 }
+func (cr Reader) CurrentFinalizedHeader() *types.Header {
+	hash := rawdb.ReadForkchoiceFinalized(cr.tx)
+	number := rawdb.ReadHeaderNumber(cr.tx, hash)
+	h, _ := cr.blockReader.Header(context.Background(), cr.tx, hash, *number)
+	return h
+}
+func (cr Reader) CurrentSafeHeader() *types.Header {
+	hash := rawdb.ReadForkchoiceSafe(cr.tx)
+	number := rawdb.ReadHeaderNumber(cr.tx, hash)
+	h, _ := cr.blockReader.Header(context.Background(), cr.tx, hash, *number)
+	return h
+}
 func (cr Reader) GetHeader(hash common.Hash, number uint64) *types.Header {
 	if cr.blockReader != nil {
 		h, _ := cr.blockReader.Header(context.Background(), cr.tx, hash, number)

--- a/eth/stagedsync/chain_reader.go
+++ b/eth/stagedsync/chain_reader.go
@@ -36,6 +36,35 @@ func (cr ChainReader) CurrentHeader() *types.Header {
 	return h
 }
 
+// CurrentFinalizedHeader retrieves the current finalized header from the local chain.
+func (cr ChainReader) CurrentFinalizedHeader() *types.Header {
+	hash := rawdb.ReadForkchoiceFinalized(cr.Db)
+	if hash == (libcommon.Hash{}) {
+		return nil
+	}
+
+	number := rawdb.ReadHeaderNumber(cr.Db, hash)
+	if number == nil {
+		return nil
+	}
+
+	return rawdb.ReadHeader(cr.Db, hash, *number)
+}
+
+func (cr ChainReader) CurrentSafeHeader() *types.Header {
+	hash := rawdb.ReadForkchoiceSafe(cr.Db)
+	if hash == (libcommon.Hash{}) {
+		return nil
+	}
+
+	number := rawdb.ReadHeaderNumber(cr.Db, hash)
+	if number == nil {
+		return nil
+	}
+
+	return rawdb.ReadHeader(cr.Db, hash, *number)
+}
+
 // GetHeader retrieves a block header from the database by hash and number.
 func (cr ChainReader) GetHeader(hash libcommon.Hash, number uint64) *types.Header {
 	h, _ := cr.BlockReader.Header(context.Background(), cr.Db, hash, number)

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -585,6 +585,32 @@ func NewChainReaderImpl(config *chain.Config, tx kv.Tx, blockReader services.Ful
 
 func (cr ChainReaderImpl) Config() *chain.Config        { return cr.config }
 func (cr ChainReaderImpl) CurrentHeader() *types.Header { panic("") }
+func (cr ChainReaderImpl) CurrentFinalizedHeader() *types.Header {
+	hash := rawdb.ReadForkchoiceFinalized(cr.tx)
+	if hash == (libcommon.Hash{}) {
+		return nil
+	}
+
+	number := rawdb.ReadHeaderNumber(cr.tx, hash)
+	if number == nil {
+		return nil
+	}
+
+	return rawdb.ReadHeader(cr.tx, hash, *number)
+}
+func (cr ChainReaderImpl) CurrentSafeHeader() *types.Header {
+	hash := rawdb.ReadForkchoiceSafe(cr.tx)
+	if hash == (libcommon.Hash{}) {
+		return nil
+	}
+
+	number := rawdb.ReadHeaderNumber(cr.tx, hash)
+	if number == nil {
+		return nil
+	}
+
+	return rawdb.ReadHeader(cr.tx, hash, *number)
+}
 func (cr ChainReaderImpl) GetHeader(hash libcommon.Hash, number uint64) *types.Header {
 	if cr.blockReader != nil {
 		h, _ := cr.blockReader.Header(context.Background(), cr.tx, hash, number)

--- a/polygon/bor/bor_test.go
+++ b/polygon/bor/bor_test.go
@@ -175,6 +175,13 @@ func (r headerReader) CurrentHeader() *types.Header {
 	return nil
 }
 
+func (r headerReader) CurrentFinalizedHeader() *types.Header {
+	return nil
+}
+func (r headerReader) CurrentSafeHeader() *types.Header {
+	return nil
+}
+
 func (r headerReader) GetHeader(_ libcommon.Hash, blockNo uint64) *types.Header {
 	return r.GetHeaderByNumber(blockNo)
 }


### PR DESCRIPTION
The 2 new methods are made available in `consensus.ChainHeaderReader` interface to future usage in tracing revamp.

This is a split PR off of https://github.com/ledgerwatch/erigon/pull/10757.