### PR TITLE
diagnostics: don't show percent downloaded until we get all metadata

### DIFF
--- a/erigon-lib/diagnostics/snapshots.go
+++ b/erigon-lib/diagnostics/snapshots.go
@@ -55,10 +55,16 @@ func (d *DiagnosticClient) runSnapshotListener(rootCtx context.Context) {
 				downloadTimeLeft := CalculateTime(remainingBytes, info.DownloadRate)
 				totalDownloadTimeString := time.Duration(info.TotalTime) * time.Second
 
+				progress := downloadedPercent
+
+				if info.TorrentMetadataReady < info.Files {
+					progress = "calculating..."
+				}
+
 				d.updateSnapshotStageStats(SyncStageStats{
 					TimeElapsed: totalDownloadTimeString.String(),
 					TimeLeft:    downloadTimeLeft,
-					Progress:    downloadedPercent,
+					Progress:    progress,
 				}, "Downloading snapshots")
 
 				if err := d.db.Update(d.ctx, SnapshotDownloadUpdater(d.syncStats.SnapshotDownload)); err != nil {

--- a/erigon-lib/diagnostics/snapshots_test.go
+++ b/erigon-lib/diagnostics/snapshots_test.go
@@ -55,3 +55,16 @@ var (
 		DownloadedStats: diagnostics.FileDownloadedStatistics{},
 	}
 )
+
+func TestPercentDiownloaded(t *testing.T) {
+	downloaded := uint64(10)
+	total := uint64(100)
+	files := int32(20)
+	torrentMetadataReady := int32(10)
+
+	progress := diagnostics.GetShanpshotsPercentDownloaded(downloaded, total, torrentMetadataReady, files)
+	require.Equal(t, progress, "calculating...")
+
+	progress = diagnostics.GetShanpshotsPercentDownloaded(downloaded, total, files, files)
+	require.Equal(t, progress, "10.00%")
+}

--- a/erigon-lib/diagnostics/snapshots_test.go
+++ b/erigon-lib/diagnostics/snapshots_test.go
@@ -62,9 +62,23 @@ func TestPercentDiownloaded(t *testing.T) {
 	files := int32(20)
 	torrentMetadataReady := int32(10)
 
+	//Test metadata not ready
 	progress := diagnostics.GetShanpshotsPercentDownloaded(downloaded, total, torrentMetadataReady, files)
 	require.Equal(t, progress, "calculating...")
 
+	//Test metadata ready
 	progress = diagnostics.GetShanpshotsPercentDownloaded(downloaded, total, files, files)
 	require.Equal(t, progress, "10.00%")
+
+	//Test 100 %
+	progress = diagnostics.GetShanpshotsPercentDownloaded(total, total, files, files)
+	require.Equal(t, progress, "100.00%")
+
+	//Test 0 %
+	progress = diagnostics.GetShanpshotsPercentDownloaded(0, total, files, files)
+	require.Equal(t, progress, "0.00%")
+
+	//Test more than 100 %
+	progress = diagnostics.GetShanpshotsPercentDownloaded(total+1, total, files, files)
+	require.Equal(t, progress, "100.00%")
 }


### PR DESCRIPTION
Don't display the percent downloaded until we have received all metadata and know the exact file size to avoid confusing users.