### PR TITLE
Chore: Rename `tx` to `txn` for eth transaction obj (part 2/n)

### DIFF
--- a/accounts/abi/method.go
+++ b/accounts/abi/method.go
@@ -45,8 +45,8 @@ const (
 // If the method is `Const` no transaction needs to be created for this
 // particular Method call. It can easily be simulated using a local VM.
 // For example a `Balance()` method only needs to retrieve something
-// from the storage and therefore requires no Tx to be sent to the
-// network. A method such as `Transact` does require a Tx and thus will
+// from the storage and therefore requires no Txn to be sent to the
+// network. A method such as `Transact` does require a Txn and thus will
 // be flagged `false`.
 // Input specifies the required input parameters for this gives method.
 type Method struct {

--- a/cmd/devnet/transactions/block.go
+++ b/cmd/devnet/transactions/block.go
@@ -118,7 +118,7 @@ func txHashInBlock(client *rpc.Client, hashmap map[libcommon.Hash]bool, blockNum
 		// check if txn is in the hash set and remove it from the set if it is present
 		if _, ok := hashmap[txnHash]; ok {
 			numFound++
-			logger.Info("SUCCESS => Tx included into block", "txHash", txnHash, "blockNum", blockNumber)
+			logger.Info("SUCCESS => Txn included into block", "txHash", txnHash, "blockNum", blockNumber)
 			// add the block number as an entry to the map
 			txToBlockMap[txnHash] = devnetutils.HexToInt(blockNumber)
 			delete(hashmap, txnHash)

--- a/cmd/evm/README.md
+++ b/cmd/evm/README.md
@@ -482,7 +482,7 @@ The transaction tool is used to perform static validity checks on transactions s
 * intrinsic gas calculation
 * max values on integers
 * fee semantics, such as `maxFeePerGas < maxPriorityFeePerGas`
-* newer tx types on old forks
+* newer txn types on old forks
 
 ### Examples
 

--- a/cmd/integration/commands/flags.go
+++ b/cmd/integration/commands/flags.go
@@ -173,7 +173,7 @@ func withStartTx(cmd *cobra.Command) {
 }
 
 func withTraceFromTx(cmd *cobra.Command) {
-	cmd.Flags().Uint64Var(&traceFromTx, "txtrace.from", 0, "start tracing from tx number")
+	cmd.Flags().Uint64Var(&traceFromTx, "txtrace.from", 0, "start tracing from txn number")
 }
 
 func withOutputCsvFile(cmd *cobra.Command) {

--- a/cmd/state/commands/opcode_tracer.go
+++ b/cmd/state/commands/opcode_tracer.go
@@ -171,8 +171,8 @@ func (ot *opcodeTracer) CaptureTxEnd(restGas uint64) {}
 func (ot *opcodeTracer) captureStartOrEnter(from, to libcommon.Address, create bool, input []byte) {
 	//fmt.Fprint(ot.summary, ot.lastLine)
 
-	// When a CaptureStart is called, a Tx is starting. Create its entry in our list and initialize it with the partial data available
-	//calculate the "address" of the Tx in its tree
+	// When a CaptureStart is called, a Txn is starting. Create its entry in our list and initialize it with the partial data available
+	//calculate the "address" of the Txn in its tree
 	ltid := len(ot.txsInDepth)
 	if ltid-1 != ot.depth {
 		panic(fmt.Sprintf("Wrong addr slice depth: d=%d, slice len=%d", ot.depth, ltid))
@@ -208,7 +208,7 @@ func (ot *opcodeTracer) CaptureEnter(typ vm.OpCode, from libcommon.Address, to l
 }
 
 func (ot *opcodeTracer) captureEndOrExit(err error) {
-	// When a CaptureEnd is called, a Tx has finished. Pop our stack
+	// When a CaptureEnd is called, a Txn has finished. Pop our stack
 	ls := len(ot.stack)
 	currentEntry := ot.stack[ls-1]
 	ot.stack = ot.stack[:ls-1]
@@ -216,7 +216,7 @@ func (ot *opcodeTracer) captureEndOrExit(err error) {
 
 	// sanity check: depth of stack == depth reported by system
 	if ls-1 != ot.depth || ot.depth != currentEntry.Depth {
-		panic(fmt.Sprintf("End of Tx at d=%d but stack has d=%d and entry has d=%d", ot.depth, ls, currentEntry.Depth))
+		panic(fmt.Sprintf("End of Txn at d=%d but stack has d=%d and entry has d=%d", ot.depth, ls, currentEntry.Depth))
 	}
 
 	// Close the last bblock
@@ -269,9 +269,9 @@ func (ot *opcodeTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, 
 		panic(fmt.Sprintf("Depth should be the same but isn't: current tx's %d, current entry's %d", currentTxDepth, currentEntry.Depth))
 	}
 
-	// is the Tx entry still not fully initialized?
+	// is the txn entry still not fully initialized?
 	if currentEntry.TxHash == nil {
-		// CaptureStart creates the entry for a new Tx, but doesn't have access to EVM data, like the Tx Hash
+		// CaptureStart creates the entry for a new Tx, but doesn't have access to EVM data, like the txn Hash
 		// here we ASSUME that the txn entry was recently created by CaptureStart
 		// AND that this is the first CaptureState that has happened since then
 		// AND that both Captures are for the same transaction

--- a/core/state/database_test.go
+++ b/core/state/database_test.go
@@ -90,37 +90,37 @@ func TestCreate2Revive(t *testing.T) {
 	// In the forth block, we create the second child contract, and we expect it to have a "clean slate" of storage,
 	// i.e. without any storage items that "inherited" from the first child contract by mistake
 	chain, err := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 4, func(i int, block *core.BlockGen) {
-		var tx types.Transaction
+		var txn types.Transaction
 
 		switch i {
 		case 0:
-			contractAddress, tx, revive, err = contracts.DeployRevive(transactOpts, contractBackend)
+			contractAddress, txn, revive, err = contracts.DeployRevive(transactOpts, contractBackend)
 			if err != nil {
 				t.Fatal(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		case 1:
-			tx, err = revive.Deploy(transactOpts, big.NewInt(0))
+			txn, err = revive.Deploy(transactOpts, big.NewInt(0))
 			if err != nil {
 				t.Fatal(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		case 2:
-			tx, err = types.SignTx(types.NewTransaction(block.TxNonce(address), create2address, uint256.NewInt(0), 1000000, new(uint256.Int), nil), *signer, key)
+			txn, err = types.SignTx(types.NewTransaction(block.TxNonce(address), create2address, uint256.NewInt(0), 1000000, new(uint256.Int), nil), *signer, key)
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = contractBackend.SendTransaction(context.Background(), tx)
+			err = contractBackend.SendTransaction(context.Background(), txn)
 			if err != nil {
 				t.Fatal(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		case 3:
-			tx, err = revive.Deploy(transactOpts, big.NewInt(0))
+			txn, err = revive.Deploy(transactOpts, big.NewInt(0))
 			if err != nil {
 				t.Fatal(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		}
 		contractBackend.Commit()
 	})
@@ -261,71 +261,71 @@ func TestCreate2Polymorth(t *testing.T) {
 	// In the forth block, we create the second child contract
 	// In the 5th block, we delete and re-create the child contract twice
 	chain, err := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 5, func(i int, block *core.BlockGen) {
-		var tx types.Transaction
+		var txn types.Transaction
 
 		switch i {
 		case 0:
-			contractAddress, tx, poly, err = contracts.DeployPoly(transactOpts, contractBackend)
+			contractAddress, txn, poly, err = contracts.DeployPoly(transactOpts, contractBackend)
 			if err != nil {
 				t.Fatal(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		case 1:
-			tx, err = poly.Deploy(transactOpts, big.NewInt(0))
+			txn, err = poly.Deploy(transactOpts, big.NewInt(0))
 			if err != nil {
 				t.Fatal(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		case 2:
 			// Trigger self-destruct
-			tx, err = types.SignTx(types.NewTransaction(block.TxNonce(address), create2address, uint256.NewInt(0), 1000000, new(uint256.Int), nil), *signer, key)
+			txn, err = types.SignTx(types.NewTransaction(block.TxNonce(address), create2address, uint256.NewInt(0), 1000000, new(uint256.Int), nil), *signer, key)
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = contractBackend.SendTransaction(context.Background(), tx)
+			err = contractBackend.SendTransaction(context.Background(), txn)
 			if err != nil {
 				t.Fatal(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		case 3:
-			tx, err = poly.Deploy(transactOpts, big.NewInt(0))
+			txn, err = poly.Deploy(transactOpts, big.NewInt(0))
 			if err != nil {
 				t.Fatal(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		case 4:
 			// Trigger self-destruct
-			tx, err = types.SignTx(types.NewTransaction(block.TxNonce(address), create2address, uint256.NewInt(0), 1000000, new(uint256.Int), nil), *signer, key)
+			txn, err = types.SignTx(types.NewTransaction(block.TxNonce(address), create2address, uint256.NewInt(0), 1000000, new(uint256.Int), nil), *signer, key)
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = contractBackend.SendTransaction(context.Background(), tx)
+			err = contractBackend.SendTransaction(context.Background(), txn)
 			if err != nil {
 				t.Fatal(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 			// Recreate in the same block
-			tx, err = poly.Deploy(transactOpts, big.NewInt(0))
+			txn, err = poly.Deploy(transactOpts, big.NewInt(0))
 			if err != nil {
 				t.Fatal(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 			// Trigger self-destruct
-			tx, err = types.SignTx(types.NewTransaction(block.TxNonce(address), create2address, uint256.NewInt(0), 1000000, new(uint256.Int), nil), *signer, key)
+			txn, err = types.SignTx(types.NewTransaction(block.TxNonce(address), create2address, uint256.NewInt(0), 1000000, new(uint256.Int), nil), *signer, key)
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = contractBackend.SendTransaction(context.Background(), tx)
+			err = contractBackend.SendTransaction(context.Background(), txn)
 			if err != nil {
 				t.Fatal(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 			// Recreate in the same block
-			tx, err = poly.Deploy(transactOpts, big.NewInt(0))
+			txn, err = poly.Deploy(transactOpts, big.NewInt(0))
 			if err != nil {
 				t.Fatal(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		}
 		contractBackend.Commit()
 	})
@@ -475,27 +475,27 @@ func TestReorgOverSelfDestruct(t *testing.T) {
 
 	// Here we generate 3 blocks, two of which (the one with "Change" invocation and "Destruct" invocation will be reverted during the reorg)
 	chain, err := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 3, func(i int, block *core.BlockGen) {
-		var tx types.Transaction
+		var txn types.Transaction
 
 		switch i {
 		case 0:
-			contractAddress, tx, selfDestruct, err = contracts.DeploySelfdestruct(transactOpts, contractBackend)
+			contractAddress, txn, selfDestruct, err = contracts.DeploySelfdestruct(transactOpts, contractBackend)
 			if err != nil {
 				t.Fatal(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		case 1:
-			tx, err = selfDestruct.Change(transactOpts)
+			txn, err = selfDestruct.Change(transactOpts)
 			if err != nil {
 				t.Fatal(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		case 2:
-			tx, err = selfDestruct.Destruct(transactOpts)
+			txn, err = selfDestruct.Destruct(transactOpts)
 			if err != nil {
 				t.Fatal(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		}
 		contractBackend.Commit()
 	})
@@ -510,15 +510,15 @@ func TestReorgOverSelfDestruct(t *testing.T) {
 	transactOptsLonger.GasLimit = 1000000
 
 	longerChain, err := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 4, func(i int, block *core.BlockGen) {
-		var tx types.Transaction
+		var txn types.Transaction
 
 		switch i {
 		case 0:
-			_, tx, _, err = contracts.DeploySelfdestruct(transactOptsLonger, contractBackendLonger)
+			_, txn, _, err = contracts.DeploySelfdestruct(transactOptsLonger, contractBackendLonger)
 			if err != nil {
 				t.Fatal(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		}
 		contractBackendLonger.Commit()
 	})
@@ -623,21 +623,21 @@ func TestReorgOverStateChange(t *testing.T) {
 
 	// Here we generate 3 blocks, two of which (the one with "Change" invocation and "Destruct" invocation will be reverted during the reorg)
 	chain, err := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 2, func(i int, block *core.BlockGen) {
-		var tx types.Transaction
+		var txn types.Transaction
 
 		switch i {
 		case 0:
-			contractAddress, tx, selfDestruct, err = contracts.DeploySelfdestruct(transactOpts, contractBackend)
+			contractAddress, txn, selfDestruct, err = contracts.DeploySelfdestruct(transactOpts, contractBackend)
 			if err != nil {
 				t.Fatal(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		case 1:
-			tx, err = selfDestruct.Change(transactOpts)
+			txn, err = selfDestruct.Change(transactOpts)
 			if err != nil {
 				t.Fatal(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		}
 		contractBackend.Commit()
 	})
@@ -651,15 +651,15 @@ func TestReorgOverStateChange(t *testing.T) {
 	require.NoError(t, err)
 	transactOptsLonger.GasLimit = 1000000
 	longerChain, err := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 3, func(i int, block *core.BlockGen) {
-		var tx types.Transaction
+		var txn types.Transaction
 
 		switch i {
 		case 0:
-			_, tx, _, err = contracts.DeploySelfdestruct(transactOptsLonger, contractBackendLonger)
+			_, txn, _, err = contracts.DeploySelfdestruct(transactOptsLonger, contractBackendLonger)
 			if err != nil {
 				t.Fatal(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		}
 		contractBackendLonger.Commit()
 	})
@@ -781,15 +781,15 @@ func TestCreateOnExistingStorage(t *testing.T) {
 	// On the address contractAddr, where there is a storage item in the genesis, but no contract code
 	// We expect the pre-existing storage items to be removed by the deployment
 	chain, err := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 4, func(i int, block *core.BlockGen) {
-		var tx types.Transaction
+		var txn types.Transaction
 
 		switch i {
 		case 0:
-			contractAddress, tx, _, err = contracts.DeployRevive(transactOpts, contractBackend)
+			contractAddress, txn, _, err = contracts.DeployRevive(transactOpts, contractBackend)
 			if err != nil {
 				t.Fatal(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		}
 		contractBackend.Commit()
 	})
@@ -918,22 +918,22 @@ func TestEip2200Gas(t *testing.T) {
 	// Here we generate 1 block with 2 transactions, first creates a contract with some initial values in the
 	// It activates the SSTORE pricing rules specific to EIP-2200 (istanbul)
 	chain, err := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 3, func(i int, block *core.BlockGen) {
-		var tx types.Transaction
+		var txn types.Transaction
 
 		switch i {
 		case 0:
-			contractAddress, tx, selfDestruct, err = contracts.DeploySelfdestruct(transactOpts, contractBackend)
+			contractAddress, txn, selfDestruct, err = contracts.DeploySelfdestruct(transactOpts, contractBackend)
 			if err != nil {
 				t.Fatal(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 
 			transactOpts.GasPrice = big.NewInt(1)
-			tx, err = selfDestruct.Change(transactOpts)
+			txn, err = selfDestruct.Change(transactOpts)
 			if err != nil {
 				t.Fatal(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		}
 		contractBackend.Commit()
 	})
@@ -1008,21 +1008,21 @@ func TestWrongIncarnation(t *testing.T) {
 	var changer *contracts.Changer
 
 	chain, err := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 2, func(i int, block *core.BlockGen) {
-		var tx types.Transaction
+		var txn types.Transaction
 
 		switch i {
 		case 0:
-			contractAddress, tx, changer, err = contracts.DeployChanger(transactOpts, contractBackend)
+			contractAddress, txn, changer, err = contracts.DeployChanger(transactOpts, contractBackend)
 			if err != nil {
 				t.Fatal(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		case 1:
-			tx, err = changer.Change(transactOpts)
+			txn, err = changer.Change(transactOpts)
 			if err != nil {
 				t.Fatal(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		}
 		contractBackend.Commit()
 	})
@@ -1124,25 +1124,25 @@ func TestWrongIncarnation2(t *testing.T) {
 	var contractAddress libcommon.Address
 
 	chain, err := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 2, func(i int, block *core.BlockGen) {
-		var tx types.Transaction
+		var txn types.Transaction
 
 		switch i {
 		case 0:
-			tx, err = types.SignTx(types.NewTransaction(block.TxNonce(address), knownContractAddress, uint256.NewInt(1000), 1000000, new(uint256.Int), nil), *signer, key)
+			txn, err = types.SignTx(types.NewTransaction(block.TxNonce(address), knownContractAddress, uint256.NewInt(1000), 1000000, new(uint256.Int), nil), *signer, key)
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = contractBackend.SendTransaction(context.Background(), tx)
+			err = contractBackend.SendTransaction(context.Background(), txn)
 			if err != nil {
 				t.Fatal(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		case 1:
-			contractAddress, tx, _, err = contracts.DeployChanger(transactOpts, contractBackend)
+			contractAddress, txn, _, err = contracts.DeployChanger(transactOpts, contractBackend)
 			if err != nil {
 				t.Fatal(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		}
 		contractBackend.Commit()
 	})
@@ -1160,19 +1160,19 @@ func TestWrongIncarnation2(t *testing.T) {
 	require.NoError(t, err)
 	transactOptsLonger.GasLimit = 1000000
 	longerChain, err := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 3, func(i int, block *core.BlockGen) {
-		var tx types.Transaction
+		var txn types.Transaction
 
 		switch i {
 		case 0:
-			tx, err = types.SignTx(types.NewTransaction(block.TxNonce(address), knownContractAddress, uint256.NewInt(1000), 1000000, new(uint256.Int), nil), *signer, key)
+			txn, err = types.SignTx(types.NewTransaction(block.TxNonce(address), knownContractAddress, uint256.NewInt(1000), 1000000, new(uint256.Int), nil), *signer, key)
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = contractBackendLonger.SendTransaction(context.Background(), tx)
+			err = contractBackendLonger.SendTransaction(context.Background(), txn)
 			if err != nil {
 				t.Fatal(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		}
 		contractBackendLonger.Commit()
 	})
@@ -1405,16 +1405,16 @@ func TestRecreateAndRewind(t *testing.T) {
 	var phoenixAddress libcommon.Address
 
 	chain, err1 := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 4, func(i int, block *core.BlockGen) {
-		var tx types.Transaction
+		var txn types.Transaction
 
 		switch i {
 		case 0:
 			// Deploy phoenix factory
-			reviveAddress, tx, revive, err = contracts.DeployRevive2(transactOpts, contractBackend)
+			reviveAddress, txn, revive, err = contracts.DeployRevive2(transactOpts, contractBackend)
 			if err != nil {
 				panic(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		case 1:
 			// Calculate the address of the Phoenix and create handle to phoenix contract
 			var codeHash libcommon.Hash
@@ -1426,35 +1426,35 @@ func TestRecreateAndRewind(t *testing.T) {
 				panic(err)
 			}
 			// Deploy phoenix
-			if tx, err = revive.Deploy(transactOpts, [32]byte{}); err != nil {
+			if txn, err = revive.Deploy(transactOpts, [32]byte{}); err != nil {
 				panic(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 			// Modify phoenix storage
-			if tx, err = phoenix.Increment(transactOpts); err != nil {
+			if txn, err = phoenix.Increment(transactOpts); err != nil {
 				panic(err)
 			}
-			block.AddTx(tx)
-			if tx, err = phoenix.Increment(transactOpts); err != nil {
+			block.AddTx(txn)
+			if txn, err = phoenix.Increment(transactOpts); err != nil {
 				panic(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		case 2:
 			// Destruct the phoenix
-			if tx, err = phoenix.Die(transactOpts); err != nil {
+			if txn, err = phoenix.Die(transactOpts); err != nil {
 				panic(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		case 3:
 			// Recreate the phoenix, and change the storage
-			if tx, err = revive.Deploy(transactOpts, [32]byte{}); err != nil {
+			if txn, err = revive.Deploy(transactOpts, [32]byte{}); err != nil {
 				panic(err)
 			}
-			block.AddTx(tx)
-			if tx, err = phoenix.Increment(transactOpts); err != nil {
+			block.AddTx(txn)
+			if txn, err = phoenix.Increment(transactOpts); err != nil {
 				panic(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		}
 		contractBackend.Commit()
 	})
@@ -1467,16 +1467,16 @@ func TestRecreateAndRewind(t *testing.T) {
 	require.NoError(t, err)
 	transactOptsLonger.GasLimit = 1000000
 	longerChain, err1 := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 5, func(i int, block *core.BlockGen) {
-		var tx types.Transaction
+		var txn types.Transaction
 
 		switch i {
 		case 0:
 			// Deploy phoenix factory
-			reviveAddress, tx, revive, err = contracts.DeployRevive2(transactOptsLonger, contractBackendLonger)
+			reviveAddress, txn, revive, err = contracts.DeployRevive2(transactOptsLonger, contractBackendLonger)
 			if err != nil {
 				panic(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		case 1:
 			// Calculate the address of the Phoenix and create handle to phoenix contract
 			var codeHash libcommon.Hash
@@ -1488,31 +1488,31 @@ func TestRecreateAndRewind(t *testing.T) {
 				panic(err)
 			}
 			// Deploy phoenix
-			if tx, err = revive.Deploy(transactOptsLonger, [32]byte{}); err != nil {
+			if txn, err = revive.Deploy(transactOptsLonger, [32]byte{}); err != nil {
 				panic(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 			// Modify phoenix storage
-			if tx, err = phoenix.Increment(transactOptsLonger); err != nil {
+			if txn, err = phoenix.Increment(transactOptsLonger); err != nil {
 				panic(err)
 			}
-			block.AddTx(tx)
-			if tx, err = phoenix.Increment(transactOptsLonger); err != nil {
+			block.AddTx(txn)
+			if txn, err = phoenix.Increment(transactOptsLonger); err != nil {
 				panic(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		case 2:
 			// Destruct the phoenix
-			if tx, err = phoenix.Die(transactOptsLonger); err != nil {
+			if txn, err = phoenix.Die(transactOptsLonger); err != nil {
 				panic(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		case 3:
 			// Recreate the phoenix, but now with the empty storage
-			if tx, err = revive.Deploy(transactOptsLonger, [32]byte{}); err != nil {
+			if txn, err = revive.Deploy(transactOptsLonger, [32]byte{}); err != nil {
 				panic(err)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		}
 		contractBackendLonger.Commit()
 	})
@@ -1603,15 +1603,15 @@ func TestTxLookupUnwind(t *testing.T) {
 
 	m := mock.MockWithGenesis(t, gspec, key, false)
 	chain1, err := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 2, func(i int, block *core.BlockGen) {
-		var tx types.Transaction
+		var txn types.Transaction
 		var e error
 		switch i {
 		case 1:
-			tx, e = types.SignTx(types.NewTransaction(block.TxNonce(address), address, uint256.NewInt(0), 1000000, new(uint256.Int), nil), *signer, key)
+			txn, e = types.SignTx(types.NewTransaction(block.TxNonce(address), address, uint256.NewInt(0), 1000000, new(uint256.Int), nil), *signer, key)
 			if e != nil {
 				t.Fatal(e)
 			}
-			block.AddTx(tx)
+			block.AddTx(txn)
 		}
 	})
 	if err != nil {

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -661,9 +661,9 @@ func (r RawBlock) AsBlock() (*Block, error) {
 	b.requests = r.Body.Requests
 
 	txs := make([]Transaction, len(r.Body.Transactions))
-	for i, tx := range r.Body.Transactions {
+	for i, txn := range r.Body.Transactions {
 		var err error
-		if txs[i], err = DecodeTransaction(tx); err != nil {
+		if txs[i], err = DecodeTransaction(txn); err != nil {
 			return nil, err
 		}
 	}
@@ -690,16 +690,16 @@ func (b *Body) SendersToTxs(senders []libcommon.Address) {
 	if senders == nil {
 		return
 	}
-	for i, tx := range b.Transactions {
-		tx.SetSender(senders[i])
+	for i, txn := range b.Transactions {
+		txn.SetSender(senders[i])
 	}
 }
 
 // Copy transaction senders from transactions to the body
 func (b *Body) SendersFromTxs() []libcommon.Address {
 	senders := make([]libcommon.Address, len(b.Transactions))
-	for i, tx := range b.Transactions {
-		if sender, ok := tx.GetSender(); ok {
+	for i, txn := range b.Transactions {
+		if sender, ok := txn.GetSender(); ok {
 			senders[i] = sender
 		}
 	}
@@ -713,8 +713,8 @@ func (rb RawBody) EncodingSize() int {
 
 func (rb RawBody) payloadSize() (payloadSize, txsLen, unclesLen, withdrawalsLen, requestsLen int) {
 	// size of Transactions
-	for _, tx := range rb.Transactions {
-		txsLen += len(tx)
+	for _, txn := range rb.Transactions {
+		txsLen += len(txn)
 	}
 	payloadSize += rlp2.ListPrefixLen(txsLen) + txsLen
 
@@ -748,8 +748,8 @@ func (rb RawBody) EncodeRLP(w io.Writer) error {
 	if err := EncodeStructSizePrefix(txsLen, w, b[:]); err != nil {
 		return err
 	}
-	for _, tx := range rb.Transactions {
-		if _, err := w.Write(tx); err != nil {
+	for _, txn := range rb.Transactions {
+		if _, err := w.Write(txn); err != nil {
 			return nil
 		}
 	}
@@ -779,12 +779,12 @@ func (rb *RawBody) DecodeRLP(s *rlp.Stream) error {
 	if _, err = s.List(); err != nil {
 		return err
 	}
-	var tx []byte
-	for tx, err = s.Raw(); err == nil; tx, err = s.Raw() {
-		if tx == nil {
-			return errors.New("RawBody.DecodeRLP tx nil")
+	var txn []byte
+	for txn, err = s.Raw(); err == nil; txn, err = s.Raw() {
+		if txn == nil {
+			return errors.New("RawBody.DecodeRLP txn nil")
 		}
-		rb.Transactions = append(rb.Transactions, tx)
+		rb.Transactions = append(rb.Transactions, txn)
 	}
 	if !errors.Is(err, rlp.EOL) {
 		return err
@@ -1289,8 +1289,8 @@ func (b *Block) SendersToTxs(senders []libcommon.Address) {
 	if len(senders) == 0 {
 		return
 	}
-	for i, tx := range b.transactions {
-		tx.SetSender(senders[i])
+	for i, txn := range b.transactions {
+		txn.SetSender(senders[i])
 	}
 }
 
@@ -1298,9 +1298,9 @@ func (b *Block) SendersToTxs(senders []libcommon.Address) {
 // will probably be removed in favour of RawBlock. Also it panics
 func (b *Block) RawBody() *RawBody {
 	br := &RawBody{Transactions: make([][]byte, len(b.transactions)), Uncles: b.uncles, Withdrawals: b.withdrawals, Requests: b.requests}
-	for i, tx := range b.transactions {
+	for i, txn := range b.transactions {
 		var err error
-		br.Transactions[i], err = rlp.EncodeToBytes(tx)
+		br.Transactions[i], err = rlp.EncodeToBytes(txn)
 		if err != nil {
 			panic(err)
 		}
@@ -1311,9 +1311,9 @@ func (b *Block) RawBody() *RawBody {
 // RawBody creates a RawBody based on the body.
 func (b *Body) RawBody() *RawBody {
 	br := &RawBody{Transactions: make([][]byte, len(b.Transactions)), Uncles: b.Uncles, Withdrawals: b.Withdrawals, Requests: b.Requests}
-	for i, tx := range b.Transactions {
+	for i, txn := range b.Transactions {
 		var err error
-		br.Transactions[i], err = rlp.EncodeToBytes(tx)
+		br.Transactions[i], err = rlp.EncodeToBytes(txn)
 		if err != nil {
 			panic(err)
 		}
@@ -1408,8 +1408,8 @@ func CopyTxs(in Transactions) Transactions {
 	if err != nil {
 		panic(fmt.Errorf("DecodeTransactions failed: %w", err))
 	}
-	for i, tx := range in {
-		if txWrapper, ok := tx.(*BlobTxWrapper); ok {
+	for i, txn := range in {
+		if txWrapper, ok := txn.(*BlobTxWrapper); ok {
 			blobTx := out[i].(*BlobTx)
 			out[i] = &BlobTxWrapper{
 				Tx:          *blobTx,
@@ -1547,10 +1547,10 @@ func decodeTxns(appendList *[]Transaction, s *rlp.Stream) error {
 	if _, err = s.List(); err != nil {
 		return err
 	}
-	var tx Transaction
+	var txn Transaction
 	blobTxnsAreWrappedWithBlobs := false
-	for tx, err = DecodeRLPTransaction(s, blobTxnsAreWrappedWithBlobs); err == nil; tx, err = DecodeRLPTransaction(s, blobTxnsAreWrappedWithBlobs) {
-		*appendList = append(*appendList, tx)
+	for txn, err = DecodeRLPTransaction(s, blobTxnsAreWrappedWithBlobs); err == nil; txn, err = DecodeRLPTransaction(s, blobTxnsAreWrappedWithBlobs) {
+		*appendList = append(*appendList, txn)
 	}
 	return checkErrListEnd(s, err)
 }

--- a/core/types/hashing.go
+++ b/core/types/hashing.go
@@ -193,7 +193,7 @@ func prefixedRlpHash(prefix byte, x interface{}) (h libcommon.Hash) {
 }
 
 // prefixedSSZHash writes the prefix into the hasher before SSZ encoding x.  It's used for
-// computing the tx id & signing hashes of signed blob transactions.
+// computing the txn id & signing hashes of signed blob transactions.
 func prefixedSSZHash(prefix byte, obj codec.Serializable) (h libcommon.Hash) {
 	sha := crypto.NewKeccakState()
 	sha.Write([]byte{prefix})

--- a/core/types/legacy_tx.go
+++ b/core/types/legacy_tx.go
@@ -292,7 +292,7 @@ func (tx *LegacyTx) EncodeRLP(w io.Writer) error {
 func (tx *LegacyTx) DecodeRLP(s *rlp.Stream) error {
 	_, err := s.List()
 	if err != nil {
-		return fmt.Errorf("legacy tx must be a list: %w", err)
+		return fmt.Errorf("legacy txn must be a list: %w", err)
 	}
 	if tx.Nonce, err = s.Uint(); err != nil {
 		return fmt.Errorf("read Nonce: %w", err)
@@ -335,7 +335,7 @@ func (tx *LegacyTx) DecodeRLP(s *rlp.Stream) error {
 	}
 	tx.S.SetBytes(b)
 	if err = s.ListEnd(); err != nil {
-		return fmt.Errorf("close tx struct: %w", err)
+		return fmt.Errorf("close txn struct: %w", err)
 	}
 	return nil
 }

--- a/core/types/log.go
+++ b/core/types/log.go
@@ -277,7 +277,7 @@ func (l *LogForStorage) EncodeRLP(w io.Writer) error {
 
 // DecodeRLP implements rlp.Decoder.
 //
-// Note some redundant fields(e.g. block number, tx hash etc) will be assembled later.
+// Note some redundant fields(e.g. block number, txn hash etc) will be assembled later.
 func (l *LogForStorage) DecodeRLP(s *rlp.Stream) error {
 	blob, err := s.Raw()
 	if err != nil {

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -215,7 +215,7 @@ func (r *Receipt) DecodeRLP(s *rlp.Stream) error {
 		}
 		r.Type = LegacyTxType
 	case rlp.String:
-		// It's an EIP-2718 typed tx receipt.
+		// It's an EIP-2718 typed txn receipt.
 		s.NewList(size) // Hack - convert String (envelope) into List
 		var b []byte
 		if b, err = s.Bytes(); err != nil {
@@ -385,10 +385,10 @@ func (rs Receipts) EncodeIndex(i int, w *bytes.Buffer) {
 func (r Receipts) DeriveFields(hash libcommon.Hash, number uint64, txs Transactions, senders []libcommon.Address) error {
 	logIndex := uint(0) // logIdx is unique within the block and starts from 0
 	if len(txs) != len(r) {
-		return fmt.Errorf("transaction and receipt count mismatch, tx count = %d, receipts count = %d", len(txs), len(r))
+		return fmt.Errorf("transaction and receipt count mismatch, txn count = %d, receipts count = %d", len(txs), len(r))
 	}
 	if len(senders) != len(txs) {
-		return fmt.Errorf("transaction and senders count mismatch, tx count = %d, senders count = %d", len(txs), len(senders))
+		return fmt.Errorf("transaction and senders count mismatch, txn count = %d, senders count = %d", len(txs), len(senders))
 	}
 
 	blockNumber := new(big.Int).SetUint64(number)

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -93,7 +93,7 @@ type Transaction interface {
 	GetSender() (libcommon.Address, bool)
 	SetSender(libcommon.Address)
 	IsContractDeploy() bool
-	Unwrap() Transaction // If this is a network wrapper, returns the unwrapped tx. Otherwise returns itself.
+	Unwrap() Transaction // If this is a network wrapper, returns the unwrapped txn. Otherwise returns itself.
 }
 
 // TransactionMisc is collection of miscellaneous fields for transaction that is supposed to be embedded into concrete
@@ -121,16 +121,16 @@ func DecodeRLPTransaction(s *rlp.Stream, blobTxnsAreWrappedWithBlobs bool) (Tran
 		return nil, err
 	}
 	if rlp.List == kind {
-		tx := &LegacyTx{}
-		if err = tx.DecodeRLP(s); err != nil {
+		txn := &LegacyTx{}
+		if err = txn.DecodeRLP(s); err != nil {
 			return nil, err
 		}
-		return tx, nil
+		return txn, nil
 	}
 	if rlp.String != kind {
 		return nil, fmt.Errorf("not an RLP encoded transaction. If this is a canonical encoded transaction, use UnmarshalTransactionFromBinary instead. Got %v for kind, expected String", kind)
 	}
-	// Decode the EIP-2718 typed TX envelope.
+	// Decode the EIP-2718 typed txn envelope.
 	var b []byte
 	if b, err = s.Bytes(); err != nil {
 		return nil, err
@@ -196,7 +196,7 @@ func UnmarshalTransactionFromBinary(data []byte, blobTxnsAreWrappedWithBlobs boo
 		}
 	default:
 		if data[0] >= 0x80 {
-			// Tx is type legacy which is RLP encoded
+			// txn is type legacy which is RLP encoded
 			return DecodeTransaction(data)
 		}
 		return nil, ErrTxTypeNotSupported
@@ -318,13 +318,13 @@ func TxDifference(a, b Transactions) Transactions {
 	keep := make(Transactions, 0, len(a))
 
 	remove := make(map[libcommon.Hash]struct{})
-	for _, tx := range b {
-		remove[tx.Hash()] = struct{}{}
+	for _, txn := range b {
+		remove[txn.Hash()] = struct{}{}
 	}
 
-	for _, tx := range a {
-		if _, ok := remove[tx.Hash()]; !ok {
-			keep = append(keep, tx)
+	for _, txn := range a {
+		if _, ok := remove[txn.Hash()]; !ok {
+			keep = append(keep, txn)
 		}
 	}
 

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -50,7 +50,7 @@ type txJSON struct {
 
 func (tx *LegacyTx) MarshalJSON() ([]byte, error) {
 	var enc txJSON
-	// These are set for all tx types.
+	// These are set for all txn types.
 	enc.Hash = tx.Hash()
 	enc.Type = hexutil.Uint64(tx.Type())
 	enc.Nonce = (*hexutil.Uint64)(&tx.Nonce)
@@ -70,7 +70,7 @@ func (tx *LegacyTx) MarshalJSON() ([]byte, error) {
 
 func (tx *AccessListTx) MarshalJSON() ([]byte, error) {
 	var enc txJSON
-	// These are set for all tx types.
+	// These are set for all txn types.
 	enc.Hash = tx.Hash()
 	enc.Type = hexutil.Uint64(tx.Type())
 	enc.ChainID = (*hexutil.Big)(tx.ChainID.ToBig())
@@ -89,7 +89,7 @@ func (tx *AccessListTx) MarshalJSON() ([]byte, error) {
 
 func (tx *DynamicFeeTransaction) MarshalJSON() ([]byte, error) {
 	var enc txJSON
-	// These are set for all tx types.
+	// These are set for all txn types.
 	enc.Hash = tx.Hash()
 	enc.Type = hexutil.Uint64(tx.Type())
 	enc.ChainID = (*hexutil.Big)(tx.ChainID.ToBig())
@@ -109,7 +109,7 @@ func (tx *DynamicFeeTransaction) MarshalJSON() ([]byte, error) {
 
 func toBlobTxJSON(tx *BlobTx) *txJSON {
 	var enc txJSON
-	// These are set for all tx types.
+	// These are set for all txn types.
 	enc.Hash = tx.Hash()
 	enc.Type = hexutil.Uint64(tx.Type())
 	enc.ChainID = (*hexutil.Big)(tx.ChainID.ToBig())

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -143,29 +143,29 @@ func LatestSignerForChainID(chainID *big.Int) *Signer {
 }
 
 // SignTx signs the transaction using the given signer and private key.
-func SignTx(tx Transaction, s Signer, prv *ecdsa.PrivateKey) (Transaction, error) {
-	h := tx.SigningHash(s.chainID.ToBig())
+func SignTx(txn Transaction, s Signer, prv *ecdsa.PrivateKey) (Transaction, error) {
+	h := txn.SigningHash(s.chainID.ToBig())
 	sig, err := crypto.Sign(h[:], prv)
 	if err != nil {
 		return nil, err
 	}
-	return tx.WithSignature(s, sig)
+	return txn.WithSignature(s, sig)
 }
 
 // SignNewTx creates a transaction and signs it.
-func SignNewTx(prv *ecdsa.PrivateKey, s Signer, tx Transaction) (Transaction, error) {
-	h := tx.SigningHash(s.chainID.ToBig())
+func SignNewTx(prv *ecdsa.PrivateKey, s Signer, txn Transaction) (Transaction, error) {
+	h := txn.SigningHash(s.chainID.ToBig())
 	sig, err := crypto.Sign(h[:], prv)
 	if err != nil {
 		return nil, err
 	}
-	return tx.WithSignature(s, sig)
+	return txn.WithSignature(s, sig)
 }
 
 // MustSignNewTx creates a transaction and signs it.
 // This panics if the transaction cannot be signed.
-func MustSignNewTx(prv *ecdsa.PrivateKey, s Signer, tx Transaction) Transaction {
-	tx1, err := SignNewTx(prv, s, tx)
+func MustSignNewTx(prv *ecdsa.PrivateKey, s Signer, txn Transaction) Transaction {
+	tx1, err := SignNewTx(prv, s, txn)
 	if err != nil {
 		panic(err)
 	}
@@ -199,22 +199,22 @@ func (sg Signer) Sender(tx Transaction) (libcommon.Address, error) {
 }
 
 // SenderWithContext returns the sender address of the transaction.
-func (sg Signer) SenderWithContext(context *secp256k1.Context, tx Transaction) (libcommon.Address, error) {
+func (sg Signer) SenderWithContext(context *secp256k1.Context, txn Transaction) (libcommon.Address, error) {
 	var V uint256.Int
 	var R, S *uint256.Int
-	signChainID := sg.chainID.ToBig() // This is reset to nil if tx is unprotected
+	signChainID := sg.chainID.ToBig() // This is reset to nil if txn is unprotected
 	// recoverPlain below will subract 27 from V
-	switch t := tx.(type) {
+	switch t := txn.(type) {
 	case *LegacyTx:
 		if !t.Protected() {
 			if !sg.unprotected {
-				return libcommon.Address{}, fmt.Errorf("unprotected tx is not supported by signer %s", sg)
+				return libcommon.Address{}, fmt.Errorf("unprotected txn is not supported by signer %s", sg)
 			}
 			signChainID = nil
 			V.Set(&t.V)
 		} else {
 			if !sg.protected {
-				return libcommon.Address{}, fmt.Errorf("protected tx is not supported by signer %s", sg)
+				return libcommon.Address{}, fmt.Errorf("protected txn is not supported by signer %s", sg)
 			}
 			if !DeriveChainId(&t.V).Eq(&sg.chainID) {
 				return libcommon.Address{}, ErrInvalidChainId
@@ -225,7 +225,7 @@ func (sg Signer) SenderWithContext(context *secp256k1.Context, tx Transaction) (
 		R, S = &t.R, &t.S
 	case *AccessListTx:
 		if !sg.accessList {
-			return libcommon.Address{}, fmt.Errorf("accessList tx is not supported by signer %s", sg)
+			return libcommon.Address{}, fmt.Errorf("accessList txn is not supported by signer %s", sg)
 		}
 		if t.ChainID == nil {
 			if !sg.chainID.IsZero() {
@@ -240,7 +240,7 @@ func (sg Signer) SenderWithContext(context *secp256k1.Context, tx Transaction) (
 		R, S = &t.R, &t.S
 	case *DynamicFeeTransaction:
 		if !sg.dynamicFee {
-			return libcommon.Address{}, fmt.Errorf("dynamicFee tx is not supported by signer %s", sg)
+			return libcommon.Address{}, fmt.Errorf("dynamicFee txn is not supported by signer %s", sg)
 		}
 		if t.ChainID == nil {
 			if !sg.chainID.IsZero() {
@@ -255,7 +255,7 @@ func (sg Signer) SenderWithContext(context *secp256k1.Context, tx Transaction) (
 		R, S = &t.R, &t.S
 	case *BlobTx:
 		if !sg.blob {
-			return libcommon.Address{}, fmt.Errorf("blob tx is not supported by signer %s", sg)
+			return libcommon.Address{}, fmt.Errorf("blob txn is not supported by signer %s", sg)
 		}
 		if t.ChainID == nil {
 			if !sg.chainID.IsZero() {
@@ -271,13 +271,13 @@ func (sg Signer) SenderWithContext(context *secp256k1.Context, tx Transaction) (
 	default:
 		return libcommon.Address{}, ErrTxTypeNotSupported
 	}
-	return recoverPlain(context, tx.SigningHash(signChainID), R, S, &V, !sg.malleable)
+	return recoverPlain(context, txn.SigningHash(signChainID), R, S, &V, !sg.malleable)
 }
 
 // SignatureValues returns the raw R, S, V values corresponding to the
 // given signature.
-func (sg Signer) SignatureValues(tx Transaction, sig []byte) (R, S, V *uint256.Int, err error) {
-	switch t := tx.(type) {
+func (sg Signer) SignatureValues(txn Transaction, sig []byte) (R, S, V *uint256.Int, err error) {
+	switch t := txn.(type) {
 	case *LegacyTx:
 		R, S, V = decodeSignature(sig)
 		if sg.chainID.IsZero() {
@@ -287,22 +287,22 @@ func (sg Signer) SignatureValues(tx Transaction, sig []byte) (R, S, V *uint256.I
 			V.Add(V, &sg.chainIDMul)
 		}
 	case *AccessListTx:
-		// Check that chain ID of tx matches the signer. We also accept ID zero here,
-		// because it indicates that the chain ID was not specified in the tx.
+		// Check that chain ID of txn matches the signer. We also accept ID zero here,
+		// because it indicates that the chain ID was not specified in the txn.
 		if t.ChainID != nil && !t.ChainID.IsZero() && !t.ChainID.Eq(&sg.chainID) {
 			return nil, nil, nil, ErrInvalidChainId
 		}
 		R, S, V = decodeSignature(sig)
 	case *DynamicFeeTransaction:
-		// Check that chain ID of tx matches the signer. We also accept ID zero here,
-		// because it indicates that the chain ID was not specified in the tx.
+		// Check that chain ID of txn matches the signer. We also accept ID zero here,
+		// because it indicates that the chain ID was not specified in the txn.
 		if t.ChainID != nil && !t.ChainID.IsZero() && !t.ChainID.Eq(&sg.chainID) {
 			return nil, nil, nil, ErrInvalidChainId
 		}
 		R, S, V = decodeSignature(sig)
 	case *BlobTx:
-		// Check that chain ID of tx matches the signer. We also accept ID zero here,
-		// because it indicates that the chain ID was not specified in the tx.
+		// Check that chain ID of txn matches the signer. We also accept ID zero here,
+		// because it indicates that the chain ID was not specified in the txn.
 		if t.ChainID != nil && !t.ChainID.IsZero() && !t.ChainID.Eq(&sg.chainID) {
 			return nil, nil, nil, ErrInvalidChainId
 		}

--- a/core/types/transaction_signing_test.go
+++ b/core/types/transaction_signing_test.go
@@ -33,12 +33,12 @@ func TestEIP1559Signing(t *testing.T) {
 
 	chainId := uint256.NewInt(18)
 	signer := LatestSignerForChainID(chainId.ToBig())
-	tx, err := SignTx(NewEIP1559Transaction(*chainId, 0, addr, new(uint256.Int), 0, new(uint256.Int), new(uint256.Int), new(uint256.Int), nil), *signer, key)
+	txn, err := SignTx(NewEIP1559Transaction(*chainId, 0, addr, new(uint256.Int), 0, new(uint256.Int), new(uint256.Int), new(uint256.Int), nil), *signer, key)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	from, err := tx.Sender(*signer)
+	from, err := txn.Sender(*signer)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,12 +53,12 @@ func TestEIP155Signing(t *testing.T) {
 	addr := crypto.PubkeyToAddress(key.PublicKey)
 
 	signer := LatestSignerForChainID(big.NewInt(18))
-	tx, err := SignTx(NewTransaction(0, addr, new(uint256.Int), 0, new(uint256.Int), nil), *signer, key)
+	txn, err := SignTx(NewTransaction(0, addr, new(uint256.Int), 0, new(uint256.Int), nil), *signer, key)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	from, err := tx.Sender(*signer)
+	from, err := txn.Sender(*signer)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,30 +73,30 @@ func TestEIP155ChainId(t *testing.T) {
 	addr := crypto.PubkeyToAddress(key.PublicKey)
 
 	signer := LatestSignerForChainID(big.NewInt(18))
-	tx, err := SignTx(NewTransaction(0, addr, new(uint256.Int), 0, new(uint256.Int), nil), *signer, key)
+	txn, err := SignTx(NewTransaction(0, addr, new(uint256.Int), 0, new(uint256.Int), nil), *signer, key)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !tx.Protected() {
-		t.Fatal("expected tx to be protected")
+	if !txn.Protected() {
+		t.Fatal("expected txn to be protected")
 	}
 
-	if !tx.GetChainID().Eq(&signer.chainID) {
-		t.Errorf("expected chainId to be %s, got %s", &signer.chainID, tx.GetChainID())
+	if !txn.GetChainID().Eq(&signer.chainID) {
+		t.Errorf("expected chainId to be %s, got %s", &signer.chainID, txn.GetChainID())
 	}
 
-	tx = NewTransaction(0, addr, new(uint256.Int), 0, new(uint256.Int), nil)
-	tx, err = SignTx(tx, *LatestSignerForChainID(nil), key)
+	txn = NewTransaction(0, addr, new(uint256.Int), 0, new(uint256.Int), nil)
+	txn, err = SignTx(txn, *LatestSignerForChainID(nil), key)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if tx.Protected() {
-		t.Error("didn't expect tx to be protected")
+	if txn.Protected() {
+		t.Error("didn't expect txn to be protected")
 	}
 
-	if !tx.GetChainID().IsZero() {
-		t.Error("expected chain id to be 0 got", tx.GetChainID())
+	if !txn.GetChainID().IsZero() {
+		t.Error("expected chain id to be 0 got", txn.GetChainID())
 	}
 }
 
@@ -119,13 +119,13 @@ func TestEIP155SigningVitalik(t *testing.T) {
 	} {
 		signer := LatestSignerForChainID(big.NewInt(1))
 
-		tx, err := DecodeTransaction(libcommon.Hex2Bytes(test.txRlp))
+		txn, err := DecodeTransaction(libcommon.Hex2Bytes(test.txRlp))
 		if err != nil {
 			t.Errorf("%d: %v", i, err)
 			continue
 		}
 
-		from, err := tx.Sender(*signer)
+		from, err := txn.Sender(*signer)
 		if err != nil {
 			t.Errorf("%d: %v", i, err)
 			continue
@@ -143,20 +143,20 @@ func TestChainId(t *testing.T) {
 	t.Parallel()
 	key, _ := defaultTestKey()
 
-	var tx Transaction = NewTransaction(0, libcommon.Address{}, new(uint256.Int), 0, new(uint256.Int), nil)
+	var txn Transaction = NewTransaction(0, libcommon.Address{}, new(uint256.Int), 0, new(uint256.Int), nil)
 
 	var err error
-	tx, err = SignTx(tx, *LatestSignerForChainID(big.NewInt(1)), key)
+	txn, err = SignTx(txn, *LatestSignerForChainID(big.NewInt(1)), key)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = tx.Sender(*LatestSignerForChainID(big.NewInt(2)))
+	_, err = txn.Sender(*LatestSignerForChainID(big.NewInt(2)))
 	if err != ErrInvalidChainId {
 		t.Error("expected error:", ErrInvalidChainId)
 	}
 
-	_, err = tx.Sender(*LatestSignerForChainID(big.NewInt(1)))
+	_, err = txn.Sender(*LatestSignerForChainID(big.NewInt(1)))
 	if err != nil {
 		t.Error("expected no error")
 	}

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -199,7 +199,7 @@ func TestEIP2930Signer(t *testing.T) {
 			wantHash:       libcommon.HexToHash("1ccd12d8bbdb96ea391af49a35ab641e219b2dd638dea375f2bc94dd290f2549"),
 		},
 		{
-			// This checks what happens when trying to sign an unsigned tx for the wrong chain.
+			// This checks what happens when trying to sign an unsigned txn for the wrong chain.
 			tx:             tx1,
 			signer:         signer2,
 			chainID:        big.NewInt(2),
@@ -208,7 +208,7 @@ func TestEIP2930Signer(t *testing.T) {
 			wantSignErr:    ErrInvalidChainId,
 		},
 		{
-			// This checks what happens when trying to re-sign a signed tx for the wrong chain.
+			// This checks what happens when trying to re-sign a signed txn for the wrong chain.
 			tx:             tx2,
 			signer:         signer1,
 			chainID:        big.NewInt(1),
@@ -236,7 +236,7 @@ func TestEIP2930Signer(t *testing.T) {
 		}
 		if signedTx != nil {
 			if signedTx.Hash() != test.wantHash {
-				t.Errorf("test %d: wrong tx hash after signing: got %x, want %x", i, signedTx.Hash(), test.wantHash)
+				t.Errorf("test %d: wrong txn hash after signing: got %x, want %x", i, signedTx.Hash(), test.wantHash)
 			}
 		}
 	}
@@ -394,7 +394,7 @@ func TestTransactionCoding(t *testing.T) {
 				GasPrice: u256.Num2,
 			}
 		case 1:
-			// Legacy tx contract creation.
+			// Legacy txn contract creation.
 			txdata = &LegacyTx{
 				CommonTx: CommonTx{
 					Nonce: i,
@@ -404,7 +404,7 @@ func TestTransactionCoding(t *testing.T) {
 				GasPrice: u256.Num2,
 			}
 		case 2:
-			// Tx with non-zero access list.
+			// txn with non-zero access list.
 			txdata = &AccessListTx{
 				ChainID: uint256.NewInt(1),
 				LegacyTx: LegacyTx{
@@ -419,7 +419,7 @@ func TestTransactionCoding(t *testing.T) {
 				AccessList: accesses,
 			}
 		case 3:
-			// Tx with empty access list.
+			// txn with empty access list.
 			txdata = &AccessListTx{
 				ChainID: uint256.NewInt(1),
 				LegacyTx: LegacyTx{
@@ -498,7 +498,7 @@ func encodeDecodeBinary(tx Transaction) (Transaction, error) {
 func assertEqual(orig Transaction, cpy Transaction) error {
 	// compare nonce, price, gaslimit, recipient, amount, payload, V, R, S
 	if want, got := orig.Hash(), cpy.Hash(); want != got {
-		return fmt.Errorf("parsed tx differs from original tx, want %v, got %v", want, got)
+		return fmt.Errorf("parsed txn differs from original tx, want %v, got %v", want, got)
 	}
 	if want, got := orig.GetChainID(), cpy.GetChainID(); want.Cmp(got) != 0 {
 		return fmt.Errorf("invalid chain id, want %d, got %d", want, got)
@@ -517,27 +517,27 @@ func assertEqual(orig Transaction, cpy Transaction) error {
 func assertEqualBlobWrapper(orig *BlobTxWrapper, cpy *BlobTxWrapper) error {
 	// compare commitments, blobs, proofs
 	if want, got := len(orig.Commitments), len(cpy.Commitments); want != got {
-		return fmt.Errorf("parsed tx commitments have unequal size: want%v, got %v", want, got)
+		return fmt.Errorf("parsed txn commitments have unequal size: want%v, got %v", want, got)
 	}
 
 	if want, got := len(orig.Blobs), len(cpy.Blobs); want != got {
-		return fmt.Errorf("parsed tx blobs have unequal size: want%v, got %v", want, got)
+		return fmt.Errorf("parsed txn blobs have unequal size: want%v, got %v", want, got)
 	}
 
 	if want, got := len(orig.Proofs), len(cpy.Proofs); want != got {
-		return fmt.Errorf("parsed tx proofs have unequal size: want%v, got %v", want, got)
+		return fmt.Errorf("parsed txn proofs have unequal size: want%v, got %v", want, got)
 	}
 
 	if want, got := orig.Commitments, cpy.Commitments; !reflect.DeepEqual(want, got) {
-		return fmt.Errorf("parsed tx commitments unequal: want%v, got %v", want, got)
+		return fmt.Errorf("parsed txn commitments unequal: want%v, got %v", want, got)
 	}
 
 	if want, got := orig.Blobs, cpy.Blobs; !reflect.DeepEqual(want, got) {
-		return fmt.Errorf("parsed tx blobs unequal: want%v, got %v", want, got)
+		return fmt.Errorf("parsed txn blobs unequal: want%v, got %v", want, got)
 	}
 
 	if want, got := orig.Proofs, cpy.Proofs; !reflect.DeepEqual(want, got) {
-		return fmt.Errorf("parsed tx proofs unequal: want%v, got %v", want, got)
+		return fmt.Errorf("parsed txn proofs unequal: want%v, got %v", want, got)
 	}
 
 	return nil

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -238,7 +238,7 @@ func (c *ecrecover) Run(input []byte) ([]byte, error) {
 	s := new(uint256.Int).SetBytes(input[96:128])
 	v := input[63] - 27
 
-	// tighter sig s values input homestead only apply to tx sigs
+	// tighter sig s values input homestead only apply to txn sigs
 	if !allZero(input[32:63]) || !crypto.ValidateSignatureValues(v, r, s, false) {
 		return nil, nil
 	}

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -247,7 +247,7 @@ func enable3860(jt *JumpTable) {
 }
 
 // enable4844 applies mini-danksharding (BLOBHASH opcode)
-// - Adds an opcode that returns the versioned blob hash of the tx at a index.
+// - Adds an opcode that returns the versioned blob hash of the txn at a index.
 func enable4844(jt *JumpTable) {
 	jt[BLOBHASH] = &operation{
 		execute:     opBlobHash,

--- a/docs/evm_semantics.md
+++ b/docs/evm_semantics.md
@@ -85,7 +85,7 @@ comes with these aspects:
 1. It allows matching a part of a sequence while ignoring the rest of that sequence.
 2. It can match types, letting us avoid the type-reflection functions in the semantics.
 3. It can bind variables, to be used in the other two parts of the rule - substitution and guard.
-We hope that the destructuring aspect of pattern matching will not be required for our purposes.
+   We hope that the destructuring aspect of pattern matching will not be required for our purposes.
 
 In the substitution, we describe how the part matched by the pattern in the initial state will look like
 in the end state. Substitution can use any variables bound by the pattern.
@@ -98,7 +98,7 @@ we expect that in a correct semantics, at most one rule is applicable in any giv
 Our gas purchasing transition can be expressed by the following rule:
 
 ```
-state, tx ==> store(state, tx.sender, account{
+state, txn ==> store(state, tx.sender, account{
                                           balance: prevbalance - cost,
                                           nonce: prevaccount.nonce,
                                           codelength: prevaccount.codelength,

--- a/erigon-lib/txpool/fetch.go
+++ b/erigon-lib/txpool/fetch.go
@@ -41,7 +41,7 @@ import (
 // Fetch connects to sentry and implements eth/66 protocol regarding the transaction
 // messages. It tries to "prime" the sentry with StatusData message containing given
 // genesis hash and list of forks, but with zero max block and total difficulty
-// Sentry should have a logic not to overwrite statusData with messages from tx pool
+// Sentry should have a logic not to overwrite statusData with messages from txn pool
 type Fetch struct {
 	ctx                      context.Context // Context used for cancellation and closing of the fetcher
 	pool                     Pool            // Transaction pool implementation
@@ -487,7 +487,7 @@ func (f *Fetch) handleStateChangesRequest(ctx context.Context, req *remote.State
 					return err
 				}); err != nil && !errors.Is(err, context.Canceled) {
 					f.logger.Warn("[txpool.fetch] stream.Recv", "err", err)
-					continue // 1 tx handling error must not stop batch processing
+					continue // 1 txn handling error must not stop batch processing
 				}
 			}
 		} else if change.Direction == remote.Direction_UNWIND {
@@ -507,7 +507,7 @@ func (f *Fetch) handleStateChangesRequest(ctx context.Context, req *remote.State
 					return nil
 				}); err != nil && !errors.Is(err, context.Canceled) {
 					f.logger.Warn("[txpool.fetch] stream.Recv", "err", err)
-					continue // 1 tx handling error must not stop batch processing
+					continue // 1 txn handling error must not stop batch processing
 				}
 			}
 		}

--- a/erigon-lib/txpool/pool_fuzz_test.go
+++ b/erigon-lib/txpool/pool_fuzz_test.go
@@ -223,7 +223,7 @@ func poolsFromFuzzBytes(rawTxNonce, rawValues, rawTips, rawFeeCap, rawSender []b
 	return sendersInfo, senderIDs, txs, true
 }
 
-// fakeRlpTx add anything what identifying tx to `data` to make hash unique
+// fakeRlpTx add anything what identifying txn to `data` to make hash unique
 func fakeRlpTx(slot *types.TxSlot, data []byte) []byte {
 	dataLen := rlp.U64Len(1) + //chainID
 		rlp.U64Len(slot.Nonce) + rlp.U256Len(&slot.Tip) + rlp.U256Len(&slot.FeeCap) +
@@ -339,7 +339,7 @@ func FuzzOnNewBlocks(f *testing.F) {
 			if worst != nil && worst.subPool < 0b1110 {
 				t.Fatalf("pending worst too small %b", worst.subPool)
 			}
-			for _, tx := range pending.best.ms {
+			for _, txn := range pending.best.ms {
 				i := tx.Tx
 				if tx.subPool&NoNonceGaps > 0 {
 					assert.GreaterOrEqual(i.Nonce, senders[i.SenderID].nonce, msg, i.SenderID)
@@ -353,7 +353,7 @@ func FuzzOnNewBlocks(f *testing.F) {
 				_, ok = pool.byHash[string(i.IDHash[:])]
 				assert.True(ok)
 
-				// pools can't have more then 1 tx with same SenderID+Nonce
+				// pools can't have more then 1 txn with same SenderID+Nonce
 				iterateSubPoolUnordered(baseFee, func(mtx2 *metaTx) {
 					tx2 := mtx2.Tx
 					assert.False(tx2.SenderID == i.SenderID && tx2.Nonce == i.Nonce, msg)

--- a/erigon-lib/txpool/pool_fuzz_test.go
+++ b/erigon-lib/txpool/pool_fuzz_test.go
@@ -340,16 +340,16 @@ func FuzzOnNewBlocks(f *testing.F) {
 				t.Fatalf("pending worst too small %b", worst.subPool)
 			}
 			for _, txn := range pending.best.ms {
-				i := tx.Tx
-				if tx.subPool&NoNonceGaps > 0 {
+				i := txn.Tx
+				if txn.subPool&NoNonceGaps > 0 {
 					assert.GreaterOrEqual(i.Nonce, senders[i.SenderID].nonce, msg, i.SenderID)
 				}
-				if tx.subPool&EnoughFeeCapBlock > 0 {
-					assert.LessOrEqual(pendingBaseFee, tx.Tx.FeeCap, msg)
+				if txn.subPool&EnoughFeeCapBlock > 0 {
+					assert.LessOrEqual(pendingBaseFee, txn.Tx.FeeCap, msg)
 				}
 
 				// side data structures must have all txs
-				assert.True(pool.all.has(tx), msg)
+				assert.True(pool.all.has(txn), msg)
 				_, ok = pool.byHash[string(i.IDHash[:])]
 				assert.True(ok)
 

--- a/erigon-lib/txpool/pool_test.go
+++ b/erigon-lib/txpool/pool_test.go
@@ -265,7 +265,7 @@ func TestReplaceWithHigherFee(t *testing.T) {
 		assert.True(ok)
 		assert.Equal(uint64(3), nonce)
 	}
-	// Bumped both tip and feeCap by 10%, tx accepted
+	// Bumped both tip and feeCap by 10%, txn accepted
 	{
 		txSlots := types.TxSlots{}
 		txSlot := &types.TxSlot{
@@ -344,7 +344,6 @@ func TestReverseNonces(t *testing.T) {
 			assert.Equal(txpoolcfg.Success, reason, reason.String())
 		}
 	}
-	fmt.Printf("AFTER TX 1\n")
 	select {
 	case annoucements := <-ch:
 		for i := 0; i < annoucements.Len(); i++ {
@@ -372,7 +371,6 @@ func TestReverseNonces(t *testing.T) {
 			assert.Equal(txpoolcfg.Success, reason, reason.String())
 		}
 	}
-	fmt.Printf("AFTER TX 2\n")
 	select {
 	case annoucements := <-ch:
 		for i := 0; i < annoucements.Len(); i++ {
@@ -400,7 +398,6 @@ func TestReverseNonces(t *testing.T) {
 			assert.Equal(txpoolcfg.Success, reason, reason.String())
 		}
 	}
-	fmt.Printf("AFTER TX 3\n")
 	select {
 	case annoucements := <-ch:
 		for i := 0; i < annoucements.Len(); i++ {
@@ -810,7 +807,7 @@ func TestBlobTxReplacement(t *testing.T) {
 	}
 
 	{
-		// try to replace it with 5% extra blob gas, 2x higher tx fee - should fail
+		// try to replace it with 5% extra blob gas, 2x higher txn fee - should fail
 		txSlots := types.TxSlots{}
 		blobTxn := makeBlobTx()
 		blobTxn.Nonce = 0x2
@@ -903,7 +900,7 @@ func TestBlobTxReplacement(t *testing.T) {
 	}
 }
 
-// Todo, make the tx more realistic with good values
+// Todo, make the txn more realistic with good values
 func makeBlobTx() types.TxSlot {
 
 	bodyRlp := hexutility.MustDecodeHex(BodyRlpHex)
@@ -1039,7 +1036,7 @@ func TestDropRemoteAtNoGossip(t *testing.T) {
 
 	}
 
-	// 2. Try same Tx, but as remote; tx must be dropped
+	// 2. Try same Tx, but as remote; txn must be dropped
 	{
 		var txSlots types.TxSlots
 		txSlot := &types.TxSlot{
@@ -1136,7 +1133,7 @@ func TestBlobSlots(t *testing.T) {
 		}
 	}
 
-	// Adding another blob tx should reject
+	// Adding another blob txn should reject
 	txSlots := types.TxSlots{}
 	addr[0] = 11
 	blobTxn := makeBlobTx()

--- a/erigon-lib/txpool/txpoolcfg/txpoolcfg.go
+++ b/erigon-lib/txpool/txpoolcfg/txpoolcfg.go
@@ -34,7 +34,7 @@ const BorDefaultTxPoolPriceLimit = 30 * common.GWei
 
 type Config struct {
 	DBDir               string
-	TracedSenders       []string // List of senders for which tx pool should print out debugging info
+	TracedSenders       []string // List of senders for which txn pool should print out debugging info
 	PendingSubPoolLimit int
 	BaseFeeSubPoolLimit int
 	QueuedSubPoolLimit  int
@@ -43,7 +43,7 @@ type Config struct {
 	BlobSlots           uint64 // Total number of blobs (not txs) allowed per account
 	TotalBlobPoolLimit  uint64 // Total number of blobs (not txs) allowed within the txpool
 	PriceBump           uint64 // Price bump percentage to replace an already existing transaction
-	BlobPriceBump       uint64 //Price bump percentage to replace an existing 4844 blob tx (type-3)
+	BlobPriceBump       uint64 //Price bump percentage to replace an existing 4844 blob txn (type-3)
 
 	// regular batch tasks processing
 	SyncToNewPeersEvery   time.Duration
@@ -162,7 +162,7 @@ func (r DiscardReason) String() string {
 	case NotReplaced:
 		return "could not replace existing tx"
 	case DuplicateHash:
-		return "existing tx with same hash"
+		return "existing txn with same hash"
 	case InitCodeTooLarge:
 		return "initcode too large"
 	case TypeNotActivated:

--- a/erigon-lib/types/txn.go
+++ b/erigon-lib/types/txn.go
@@ -220,7 +220,7 @@ func (ctx *TxParseContext) ParseTransaction(payload []byte, pos int, slot *TxSlo
 
 	if slot.Type == BlobTxType && wrappedWithBlobs {
 		if p != dataPos+dataLen {
-			return 0, fmt.Errorf("%w: unexpected leftover after blob tx body", ErrParseTxn)
+			return 0, fmt.Errorf("%w: unexpected leftover after blob txn body", ErrParseTxn)
 		}
 
 		dataPos, dataLen, err = rlp.List(payload, p)
@@ -985,7 +985,7 @@ func (al AccessList) StorageKeys() int {
 	return sum
 }
 
-// Removes everything but the payload body from blob tx and prepends 0x3 at the beginning - no copy
+// Removes everything but the payload body from blob txn and prepends 0x3 at the beginning - no copy
 // Doesn't change non-blob tx
 func UnwrapTxPlayloadRlp(blobTxRlp []byte) ([]byte, error) {
 	if blobTxRlp[0] != BlobTxType {
@@ -995,7 +995,7 @@ func UnwrapTxPlayloadRlp(blobTxRlp []byte) ([]byte, error) {
 	if err != nil || dataposPrev < 1 {
 		return nil, err
 	}
-	if !isList { // This is clearly not wrapped tx then
+	if !isList { // This is clearly not wrapped txn then
 		return blobTxRlp, nil
 	}
 

--- a/erigon-lib/types/txn_test.go
+++ b/erigon-lib/types/txn_test.go
@@ -203,7 +203,7 @@ func TestBlobTxParsing(t *testing.T) {
 	ctx := NewTxParseContext(*uint256.NewInt(5))
 	ctx.withSender = false
 
-	var thinTx TxSlot // only tx body, no blobs
+	var thinTx TxSlot // only txn body, no blobs
 	txType, err := PeekTransactionType(bodyEnvelope)
 	require.NoError(t, err)
 	assert.Equal(t, BlobTxType, txType)
@@ -219,7 +219,7 @@ func TestBlobTxParsing(t *testing.T) {
 	assert.Equal(t, 0, len(thinTx.Commitments))
 	assert.Equal(t, 0, len(thinTx.Proofs))
 
-	// Now parse the same tx body, but wrapped with blobs/commitments/proofs
+	// Now parse the same txn body, but wrapped with blobs/commitments/proofs
 	wrappedWithBlobs = true
 	hasEnvelope = false
 

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -162,7 +162,7 @@ func (b *EthAPIBackend) getReceiptsByReApplyingTransactions(block *types.Block, 
 	var usedGas = new(uint64)
 	var gp = new(core.GasPool).AddGas(block.GasLimit())
 	vmConfig := vm.Config{}
-	for i, tx := range block.Transactions() {
+	for i, txn := range block.Transactions() {
 		statedb.Prepare(tx.Hash(), block.Hash(), i)
 
 		receipt, err := core.ApplyTransaction(b.ChainConfig(), b.eth.blockchain.GetHeader, b.eth.blockchain.Engine(), nil, gp, statedb, dbstate, header, tx, usedGas, vmConfig)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1278,7 +1278,7 @@ func (s *Ethereum) StartMining(ctx context.Context, db kv.RwDB, stateDiffClient 
 					hasWork = true
 
 				case <-s.notifyMiningAboutNewTxs:
-					// Skip mining based on new tx notif for bor consensus
+					// Skip mining based on new txn notif for bor consensus
 					hasWork = s.chainConfig.Bor == nil
 					if hasWork {
 						s.logger.Debug("Start mining based on txpool notif")

--- a/eth/ethconfig/tx_pool.go
+++ b/eth/ethconfig/tx_pool.go
@@ -41,7 +41,7 @@ type DeprecatedTxPoolConfig struct {
 
 	Lifetime      time.Duration // Maximum amount of time non-executable transaction are queued
 	StartOnInit   bool
-	TracedSenders []string // List of senders for which tx pool should print out debugging info
+	TracedSenders []string // List of senders for which txn pool should print out debugging info
 	CommitEvery   time.Duration
 }
 

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -183,8 +183,8 @@ func (api *PublicFilterAPI) NewPendingTransactions(ctx context.Context) (*rpc.Su
 		for {
 			select {
 			case hashes := <-txHashes:
-				// To keep the original behaviour, send a single tx hash in one notification.
-				// TODO(rjl493456442) Send a batch of tx hashes in one notification
+				// To keep the original behaviour, send a single txn hash in one notification.
+				// TODO(rjl493456442) Send a batch of txn hashes in one notification
 				for _, h := range hashes {
 					notifier.Notify(rpcSub.ID, h)
 				}

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -77,7 +77,7 @@ func TestBlockSubscription(t *testing.T) {
 	<-sub1.Err()
 }
 
-// TestPendingTxFilter tests whether pending tx filters retrieve all pending transactions that are posted to the event mux.
+// TestPendingTxFilter tests whether pending txn filters retrieve all pending transactions that are posted to the event mux.
 func TestPendingTxFilter(t *testing.T) {
 	t.Parallel()
 
@@ -509,7 +509,7 @@ func TestPendingTxFilterDeadlock(t *testing.T) {
 	for i := 0; i < len(fids); i++ {
 		fid := api.NewPendingTransactionFilter()
 		fids[i] = fid
-		// Wait for at least one tx to arrive in filter
+		// Wait for at least one txn to arrive in filter
 		for {
 			hashes, err := api.GetFilterChanges(fid)
 			if err != nil {
@@ -525,7 +525,7 @@ func TestPendingTxFilterDeadlock(t *testing.T) {
 	// Wait until filters have timed out
 	time.Sleep(3 * timeout)
 
-	// If tx loop doesn't consume `done` after a second
+	// If txn loop doesn't consume `done` after a second
 	// it's hanging.
 	select {
 	case done <- struct{}{}:

--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -110,8 +110,8 @@ func (oracle *Oracle) processBlock(bf *blockFees, percentiles []float64) {
 	if bf.block.BaseFee() != nil {
 		baseFee.SetFromBig(bf.block.BaseFee())
 	}
-	for i, tx := range bf.block.Transactions() {
-		reward := tx.GetEffectiveGasTip(baseFee)
+	for i, txn := range bf.block.Transactions() {
+		reward := txn.GetEffectiveGasTip(baseFee)
 		sorter[i] = txGasAndReward{gasUsed: bf.receipts[i].GasUsed, reward: reward.ToBig()}
 	}
 	sort.Sort(sorter)

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -113,7 +113,7 @@ func NewOracle(backend OracleBackend, params gaspricecfg.Config, cache Cache, lo
 
 // SuggestTipCap returns a TipCap so that newly created transaction can
 // have a very high chance to be included in the following blocks.
-// NODE: if caller wants legacy tx SuggestedPrice, we need to add
+// NODE: if caller wants legacy txn SuggestedPrice, we need to add
 // baseFee to the returned bigInt
 func (oracle *Oracle) SuggestTipCap(ctx context.Context) (*big.Int, error) {
 	latestHead, latestPrice := oracle.cache.GetLatest()

--- a/eth/protocols/eth/protocol_test.go
+++ b/eth/protocols/eth/protocol_test.go
@@ -135,13 +135,13 @@ func TestEth66Messages(t *testing.T) {
 			"f867088504a817c8088302e2489435353535353535353535353535353535353535358202008025a064b1702d9298fee62dfeccc57d322a463ad55ca201256d01f62b45b2e1c21c12a064b1702d9298fee62dfeccc57d322a463ad55ca201256d01f62b45b2e1c21c10",
 			"f867098504a817c809830334509435353535353535353535353535353535353535358202d98025a052f8f61201b2b11a78d6e866abc9c3db2ae8631fa656bfe5cb53668255367afba052f8f61201b2b11a78d6e866abc9c3db2ae8631fa656bfe5cb53668255367afb",
 		} {
-			var tx types.Transaction
+			var txn types.Transaction
 			rlpdata := common.FromHex(hexrlp)
-			tx, err1 := types.DecodeTransaction(rlpdata)
+			txn, err1 := types.DecodeTransaction(rlpdata)
 			if err1 != nil {
 				t.Fatal(err1)
 			}
-			txs = append(txs, tx)
+			txs = append(txs, txn)
 		}
 	}
 	// init the block body data, both object and rlp form

--- a/eth/stagedsync/README.md
+++ b/eth/stagedsync/README.md
@@ -34,13 +34,13 @@ an idea.
 
 Sometimes the chain makes a reorg and we need to "undo" some parts of our sync.
 
-This happens backward from the last stage to the first one with one caveat that tx pool is updated after we already unwound the execution so we know the new nonces.
+This happens backward from the last stage to the first one with one caveat that txn pool is updated after we already unwound the execution so we know the new nonces.
 
 That is the example of stages order to be unwound (unwind happens from right to left).
 
 ```
 state.unwindOrder = []*Stage{
-		// Unwinding of tx pool (reinjecting transactions into the pool needs to happen after unwinding execution)
+		// Unwinding of txn pool (reinjecting transactions into the pool needs to happen after unwinding execution)
 		stages[0], stages[1], stages[2], stages[9], stages[3], stages[4], stages[5], stages[6], stages[7], stages[8],
 	}
 ```
@@ -125,7 +125,6 @@ This stage can spawn unwinds if the block execution fails.
 
 Translation each marked for translation contract (from EVM to TEVM)
 
-
 ### Stage 9: [VerkleTrie](/eth/stagedsync/stage_verkle_trie.go)
 
 [TODO]
@@ -155,7 +154,6 @@ Though, to make sure that some APIs work and keep the compatibility with the oth
 If the hashed state is not empty, then we are looking at the History ChangeSets and update only the items that were changed.
 
 This stage doesn't use a network connection.
-
 
 ### Stages [12, 13](/eth/stagedsync/stage_indexes.go), [14](/eth/stagedsync/stage_log_index.go), [15](/eth/stagedsync/stage_call_traces.go) and [16](/eth/stagedsync/stage_txlookup.go): Generate Indexes
 

--- a/eth/stagedsync/bor_heimdall_shared.go
+++ b/eth/stagedsync/bor_heimdall_shared.go
@@ -482,7 +482,7 @@ func fetchAndWriteHeimdallStateSyncEvents(
 
 		data, err := eventRecord.Pack(stateReceiverABI)
 		if err != nil {
-			logger.Error(fmt.Sprintf("[%s] Unable to pack tx for commitState", logPrefix), "err", err)
+			logger.Error(fmt.Sprintf("[%s] Unable to pack txn for commitState", logPrefix), "err", err)
 			return lastStateSyncEventID, i, time.Since(fetchStart), err
 		}
 

--- a/eth/stagedsync/default_stages.go
+++ b/eth/stagedsync/default_stages.go
@@ -104,7 +104,7 @@ func DefaultStages(ctx context.Context,
 		},
 		{
 			ID:          stages.Senders,
-			Description: "Recover senders from tx signatures",
+			Description: "Recover senders from txn signatures",
 			Forward: func(badBlockUnwind bool, s *StageState, u Unwinder, txc wrap.TxContainer, logger log.Logger) error {
 				return SpawnRecoverSendersStage(senders, s, u, txc.Tx, 0, ctx, logger)
 			},
@@ -241,7 +241,7 @@ func DefaultStages(ctx context.Context,
 		},
 		{
 			ID:          stages.TxLookup,
-			Description: "Generate tx lookup index",
+			Description: "Generate txn lookup index",
 			Disabled:    dbg.StagesOnlyBlocks,
 			Forward: func(badBlockUnwind bool, s *StageState, u Unwinder, txc wrap.TxContainer, logger log.Logger) error {
 				return SpawnTxLookup(s, txc.Tx, 0 /* toBlock */, txLookup, ctx, logger)
@@ -302,7 +302,7 @@ func PipelineStages(ctx context.Context, snapshots SnapshotsCfg, blockHashCfg Bl
 		},
 		{
 			ID:          stages.Senders,
-			Description: "Recover senders from tx signatures",
+			Description: "Recover senders from txn signatures",
 			Forward: func(badBlockUnwind bool, s *StageState, u Unwinder, txc wrap.TxContainer, logger log.Logger) error {
 				return SpawnRecoverSendersStage(senders, s, u, txc.Tx, 0, ctx, logger)
 			},
@@ -421,7 +421,7 @@ func PipelineStages(ctx context.Context, snapshots SnapshotsCfg, blockHashCfg Bl
 		},
 		{
 			ID:          stages.TxLookup,
-			Description: "Generate tx lookup index",
+			Description: "Generate txn lookup index",
 			Forward: func(badBlockUnwind bool, s *StageState, u Unwinder, txc wrap.TxContainer, logger log.Logger) error {
 				return SpawnTxLookup(s, txc.Tx, 0 /* toBlock */, txLookup, ctx, logger)
 			},
@@ -511,7 +511,7 @@ func UploaderPipelineStages(ctx context.Context, snapshots SnapshotsCfg, headers
 		},
 		{
 			ID:          stages.Senders,
-			Description: "Recover senders from tx signatures",
+			Description: "Recover senders from txn signatures",
 			Forward: func(badBlockUnwind bool, s *StageState, u Unwinder, txc wrap.TxContainer, logger log.Logger) error {
 				return SpawnRecoverSendersStage(senders, s, u, txc.Tx, 0, ctx, logger)
 			},
@@ -630,7 +630,7 @@ func UploaderPipelineStages(ctx context.Context, snapshots SnapshotsCfg, headers
 		},
 		{
 			ID:          stages.TxLookup,
-			Description: "Generate tx lookup index",
+			Description: "Generate txn lookup index",
 			Forward: func(badBlockUnwind bool, s *StageState, u Unwinder, txc wrap.TxContainer, logger log.Logger) error {
 				return SpawnTxLookup(s, txc.Tx, 0 /* toBlock */, txLookup, ctx, logger)
 			},
@@ -692,7 +692,7 @@ func StateStages(ctx context.Context, headers HeadersCfg, bodies BodiesCfg, bloc
 		},
 		{
 			ID:          stages.Senders,
-			Description: "Recover senders from tx signatures",
+			Description: "Recover senders from txn signatures",
 			Forward: func(badBlockUnwind bool, s *StageState, u Unwinder, txc wrap.TxContainer, logger log.Logger) error {
 				return SpawnRecoverSendersStage(senders, s, u, txc.Tx, 0, ctx, logger)
 			},
@@ -777,7 +777,7 @@ func PolygonSyncStages(
 		},
 		{
 			ID:          stages.Senders,
-			Description: "Recover senders from tx signatures",
+			Description: "Recover senders from txn signatures",
 			Forward: func(badBlockUnwind bool, s *StageState, u Unwinder, txc wrap.TxContainer, logger log.Logger) error {
 				return SpawnRecoverSendersStage(senders, s, u, txc.Tx, 0, ctx, logger)
 			},
@@ -804,7 +804,7 @@ func PolygonSyncStages(
 		},
 		{
 			ID:          stages.TxLookup,
-			Description: "Generate tx lookup index",
+			Description: "Generate txn lookup index",
 			Disabled:    dbg.StagesOnlyBlocks,
 			Forward: func(badBlockUnwind bool, s *StageState, u Unwinder, txc wrap.TxContainer, logger log.Logger) error {
 				return SpawnTxLookup(s, txc.Tx, 0 /* toBlock */, txLookup, ctx, logger)
@@ -854,7 +854,7 @@ var DefaultForwardOrder = UnwindOrder{
 
 // UnwindOrder represents the order in which the stages needs to be unwound.
 // The unwind order is important and not always just stages going backwards.
-// Let's say, there is tx pool can be unwound only after execution.
+// Let's say, there is txn pool can be unwound only after execution.
 // It's ok to remove some stage from here to disable only unwind of stage
 type UnwindOrder []stages.SyncStage
 type PruneOrder []stages.SyncStage

--- a/eth/stagedsync/stage_senders_test.go
+++ b/eth/stagedsync/stage_senders_test.go
@@ -41,7 +41,7 @@ func TestSenders(t *testing.T) {
 		return r
 	}
 
-	// prepare tx so it works with our test
+	// prepare txn so it works with our test
 	signer1 := types.MakeSigner(params.TestChainConfig, params.TestChainConfig.BerlinBlock.Uint64(), 0)
 	header := &types.Header{Number: libcommon.Big1}
 	hash := header.Hash()

--- a/eth/stagedsync/stage_trie3.go
+++ b/eth/stagedsync/stage_trie3.go
@@ -150,7 +150,7 @@ func countBlockByTxnum(ctx context.Context, tx kv.Tx, blockReader services.FullB
 
 	for i := uint64(0); i < math.MaxUint64; i++ {
 		if i%1000000 == 0 {
-			fmt.Printf("\r [%s] Counting block for tx %d: cur block %dM cur tx %d\n", "restoreCommit", txnum, i/1_000_000, txCounter)
+			fmt.Printf("\r [%s] Counting block for txn %d: cur block %dM cur txn %d\n", "restoreCommit", txnum, i/1_000_000, txCounter)
 		}
 
 		h, err := blockReader.HeaderByNumber(ctx, tx, i)
@@ -174,7 +174,7 @@ func countBlockByTxnum(ctx context.Context, tx kv.Tx, blockReader services.FullB
 			return bb, nil
 		}
 	}
-	return blockBorders{}, fmt.Errorf("block with tx %x not found", txnum)
+	return blockBorders{}, fmt.Errorf("block with txn %x not found", txnum)
 }
 
 func RebuildPatriciaTrieBasedOnFiles(rwTx kv.RwTx, cfg TrieCfg, ctx context.Context, logger log.Logger) (libcommon.Hash, error) {

--- a/eth/stagedsync/stagebuilder.go
+++ b/eth/stagedsync/stagebuilder.go
@@ -31,7 +31,7 @@ func MiningStages(
 	return []*Stage{
 		{
 			ID:          stages.MiningCreateBlock,
-			Description: "Mining: construct new block from tx pool",
+			Description: "Mining: construct new block from txn pool",
 			Forward: func(badBlockUnwind bool, s *StageState, u Unwinder, txc wrap.TxContainer, logger log.Logger) error {
 				return SpawnMiningCreateBlockStage(s, txc.Tx, createBlockCfg, ctx.Done(), logger)
 			},
@@ -58,7 +58,7 @@ func MiningStages(
 		},
 		{
 			ID:          stages.MiningExecution,
-			Description: "Mining: execute new block from tx pool",
+			Description: "Mining: execute new block from txn pool",
 			Forward: func(badBlockUnwind bool, s *StageState, u Unwinder, txc wrap.TxContainer, logger log.Logger) error {
 				return SpawnMiningExecStage(s, txc, execCfg, sendersCfg, executeBlockCfg, ctx, logger)
 			},

--- a/eth/stagedsync/stagedsynctest/harness.go
+++ b/eth/stagedsync/stagedsynctest/harness.go
@@ -445,7 +445,7 @@ func (h *Harness) generateChain(ctx context.Context, t *testing.T, ctrl *gomock.
 				t.Fatal(err)
 			}
 
-			h.logger.Info("Adding 1 mock tx to block", "blockNum", gen.GetHeader().Number)
+			h.logger.Info("Adding 1 mock txn to block", "blockNum", gen.GetHeader().Number)
 			chainID := uint256.Int{}
 			overflow := chainID.SetFromBig(h.chainConfig.ChainID)
 			require.False(t, overflow)

--- a/eth/stagedsync/sync_test.go
+++ b/eth/stagedsync/sync_test.go
@@ -36,7 +36,7 @@ func TestStagesSuccess(t *testing.T) {
 		},
 		{
 			ID:          stages.Senders,
-			Description: "Recovering senders from tx signatures",
+			Description: "Recovering senders from txn signatures",
 			Forward: func(badBlockUnwind bool, s *StageState, u Unwinder, txc wrap.TxContainer, logger log.Logger) error {
 				flow = append(flow, stages.Senders)
 				return nil
@@ -76,7 +76,7 @@ func TestDisabledStages(t *testing.T) {
 		},
 		{
 			ID:          stages.Senders,
-			Description: "Recovering senders from tx signatures",
+			Description: "Recovering senders from txn signatures",
 			Forward: func(badBlockUnwind bool, s *StageState, u Unwinder, txc wrap.TxContainer, logger log.Logger) error {
 				flow = append(flow, stages.Senders)
 				return nil
@@ -116,7 +116,7 @@ func TestErroredStage(t *testing.T) {
 		},
 		{
 			ID:          stages.Senders,
-			Description: "Recovering senders from tx signatures",
+			Description: "Recovering senders from txn signatures",
 			Forward: func(badBlockUnwind bool, s *StageState, u Unwinder, txc wrap.TxContainer, logger log.Logger) error {
 				flow = append(flow, stages.Senders)
 				return nil
@@ -170,7 +170,7 @@ func TestUnwindSomeStagesBehindUnwindPoint(t *testing.T) {
 		},
 		{
 			ID:          stages.Senders,
-			Description: "Recovering senders from tx signatures",
+			Description: "Recovering senders from txn signatures",
 			Forward: func(badBlockUnwind bool, s *StageState, u Unwinder, txc wrap.TxContainer, logger log.Logger) error {
 				if s.BlockNumber == 0 {
 					if err := s.Update(txc.Tx, 1700); err != nil {
@@ -268,7 +268,7 @@ func TestUnwind(t *testing.T) {
 		},
 		{
 			ID:          stages.Senders,
-			Description: "Recovering senders from tx signatures",
+			Description: "Recovering senders from txn signatures",
 			Forward: func(badBlockUnwind bool, s *StageState, u Unwinder, txc wrap.TxContainer, logger log.Logger) error {
 				flow = append(flow, stages.Senders)
 				if !unwound {
@@ -372,7 +372,7 @@ func TestUnwindEmptyUnwinder(t *testing.T) {
 		},
 		{
 			ID:          stages.Senders,
-			Description: "Recovering senders from tx signatures",
+			Description: "Recovering senders from txn signatures",
 			Forward: func(badBlockUnwind bool, s *StageState, u Unwinder, txc wrap.TxContainer, logger log.Logger) error {
 				flow = append(flow, stages.Senders)
 				if !unwound {
@@ -436,7 +436,7 @@ func TestSyncDoTwice(t *testing.T) {
 		},
 		{
 			ID:          stages.Senders,
-			Description: "Recovering senders from tx signatures",
+			Description: "Recovering senders from txn signatures",
 			Forward: func(badBlockUnwind bool, s *StageState, u Unwinder, txc wrap.TxContainer, logger log.Logger) error {
 				flow = append(flow, stages.Senders)
 				return s.Update(txc.Tx, s.BlockNumber+300)
@@ -494,7 +494,7 @@ func TestStateSyncInterruptRestart(t *testing.T) {
 		},
 		{
 			ID:          stages.Senders,
-			Description: "Recovering senders from tx signatures",
+			Description: "Recovering senders from txn signatures",
 			Forward: func(badBlockUnwind bool, s *StageState, u Unwinder, txc wrap.TxContainer, logger log.Logger) error {
 				flow = append(flow, stages.Senders)
 				return nil
@@ -560,7 +560,7 @@ func TestSyncInterruptLongUnwind(t *testing.T) {
 		},
 		{
 			ID:          stages.Senders,
-			Description: "Recovering senders from tx signatures",
+			Description: "Recovering senders from txn signatures",
 			Forward: func(badBlockUnwind bool, s *StageState, u Unwinder, txc wrap.TxContainer, logger log.Logger) error {
 				flow = append(flow, stages.Senders)
 				if !unwound {

--- a/eth/tracers/internal/tracetest/calltrace_test.go
+++ b/eth/tracers/internal/tracetest/calltrace_test.go
@@ -285,7 +285,7 @@ func benchTracer(b *testing.B, tracerName string, test *callTracerTest) {
 }
 
 // TestZeroValueToNotExitCall tests the calltracer(s) on the following:
-// Tx to A, A calls B with zero value. B does not already exist.
+// txn to A, A calls B with zero value. B does not already exist.
 // Expected: that enter/exit is invoked and the inner call is shown in the result
 func TestZeroValueToNotExitCall(t *testing.T) {
 	var to = libcommon.HexToAddress("0x00000000000000000000000000000000deadbeef")

--- a/eth/tracers/js/internal/tracers/prestate_tracer_legacy.js
+++ b/eth/tracers/js/internal/tracers/prestate_tracer_legacy.js
@@ -49,7 +49,7 @@
 	result: function(ctx, db) {
 		if (this.prestate === null) {
 			this.prestate = {};
-			// If tx is transfer-only, the recipient account
+			// If txn is transfer-only, the recipient account
 			// hasn't been populated.
 			this.lookupAccount(ctx.to, db);
 		}

--- a/eth/tracers/logger/access_list_tracer.go
+++ b/eth/tracers/logger/access_list_tracer.go
@@ -138,7 +138,7 @@ type AccessListTracer struct {
 	excl               map[libcommon.Address]struct{} // Set of account to exclude from the list
 	list               accessList                     // Set of accounts and storage slots touched
 	state              evmtypes.IntraBlockState       // State for nonce calculation of created contracts
-	createdContracts   map[libcommon.Address]struct{} // Set of all addresses of contracts created during tx execution
+	createdContracts   map[libcommon.Address]struct{} // Set of all addresses of contracts created during txn execution
 	usedBeforeCreation map[libcommon.Address]struct{} // Set of all contract addresses first used before creation
 }
 
@@ -257,7 +257,7 @@ func (a *AccessListTracer) AccessListSorted() types2.AccessList {
 	return a.list.accessListSorted()
 }
 
-// CreatedContracts returns the set of all addresses of contracts created during tx execution.
+// CreatedContracts returns the set of all addresses of contracts created during txn execution.
 func (a *AccessListTracer) CreatedContracts() map[libcommon.Address]struct{} {
 	return a.createdContracts
 }

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -126,7 +126,7 @@ func newCallTracer(ctx *tracers.Context, cfg json.RawMessage) (tracers.Tracer, e
 			return nil, err
 		}
 	}
-	// First callframe contains tx context info
+	// First callframe contains txn context info
 	// and is populated on start and end.
 	return &callTracer{callstack: make([]callFrame, 1), config: config}, nil
 }

--- a/eth/tracers/tracers.go
+++ b/eth/tracers/tracers.go
@@ -29,8 +29,8 @@ import (
 // Context contains some contextual infos for a transaction execution that is not
 // available from within the EVM object.
 type Context struct {
-	BlockHash libcommon.Hash // Hash of the block the tx is contained within (zero if dangling tx or call)
-	TxIndex   int            // Index of the transaction within a block (zero if dangling tx or call)
+	BlockHash libcommon.Hash // Hash of the block the txn is contained within (zero if dangling txn or call)
+	TxIndex   int            // Index of the transaction within a block (zero if dangling txn or call)
 	TxHash    libcommon.Hash // Hash of the transaction being traced (zero if dangling call)
 }
 

--- a/polygon/bor/genesis_contracts.go
+++ b/polygon/bor/genesis_contracts.go
@@ -70,7 +70,7 @@ func (gc *GenesisContractsClient) LastStateId(syscall consensus.SystemCall) (*bi
 
 	data, err := gc.stateReceiverABI.Pack(method)
 	if err != nil {
-		gc.logger.Error("[bor] Unable to pack tx for LastStateId", "err", err)
+		gc.logger.Error("[bor] Unable to pack txn for LastStateId", "err", err)
 		return nil, err
 	}
 

--- a/polygon/bor/spanner.go
+++ b/polygon/bor/spanner.go
@@ -56,7 +56,7 @@ func (c *ChainSpanner) GetCurrentSpan(syscall consensus.SystemCall) (*heimdall.S
 
 	data, err := c.validatorSet.Pack(method)
 	if err != nil {
-		c.logger.Error("[bor] Unable to pack tx for getCurrentSpan", "error", err)
+		c.logger.Error("[bor] Unable to pack txn for getCurrentSpan", "error", err)
 		return nil, err
 	}
 
@@ -163,7 +163,7 @@ func (c *ChainSpanner) CommitSpan(heimdallSpan heimdall.Span, syscall consensus.
 		producerBytes,
 	)
 	if err != nil {
-		c.logger.Error("[bor] Unable to pack tx for commitSpan", "error", err)
+		c.logger.Error("[bor] Unable to pack txn for commitSpan", "error", err)
 		return err
 	}
 

--- a/polygon/bor/types/bor_receipt.go
+++ b/polygon/bor/types/bor_receipt.go
@@ -17,7 +17,7 @@ func BorReceiptKey(number uint64) []byte {
 	return dbutils.EncodeBlockNumber(number)
 }
 
-// ComputeBorTxHash get derived tx hash from block number and hash
+// ComputeBorTxHash get derived txn hash from block number and hash
 func ComputeBorTxHash(blockNumber uint64, blockHash libcommon.Hash) libcommon.Hash {
 	txKeyPlain := make([]byte, 0, len(BorTxKeyPrefix)+8+32)
 	txKeyPlain = append(txKeyPlain, BorTxKeyPrefix...)
@@ -37,7 +37,7 @@ func DeriveFieldsForBorReceipt(receipt *types.Receipt, blockHash libcommon.Hash,
 	txHash := ComputeBorTxHash(blockNumber, blockHash)
 	txIndex := uint(len(receipts))
 
-	// set tx hash and tx index
+	// set txn hash and txn index
 	receipt.TxHash = txHash
 	receipt.TransactionIndex = txIndex
 	receipt.BlockHash = blockHash


### PR DESCRIPTION
We gradually shift to using `txn` to mean blockchain/ethereum transactions