### PR TITLE
diagnostics: fix marking completed stage as running

### DIFF
--- a/erigon-lib/diagnostics/resources_usage.go
+++ b/erigon-lib/diagnostics/resources_usage.go
@@ -31,7 +31,7 @@ func (d *DiagnosticClient) runMemoryStatsListener(rootCtx context.Context) {
 				return
 			case info := <-ch:
 				d.resourcesUsageMutex.Lock()
-				info.StageIndex = d.getCurrentSyncIdxs()
+				info.StageIndex = d.GetCurrentSyncIdxs()
 				d.resourcesUsage.MemoryUsage = append(d.resourcesUsage.MemoryUsage, info)
 				d.resourcesUsageMutex.Unlock()
 			}

--- a/erigon-lib/diagnostics/snapshots.go
+++ b/erigon-lib/diagnostics/snapshots.go
@@ -92,7 +92,7 @@ func GetShanpshotsPercentDownloaded(downloaded uint64, total uint64, torrentMeta
 }
 
 func (d *DiagnosticClient) updateSnapshotStageStats(stats SyncStageStats, subStageInfo string) {
-	idxs := d.getCurrentSyncIdxs()
+	idxs := d.GetCurrentSyncIdxs()
 	if idxs.Stage == -1 || idxs.SubStage == -1 {
 		log.Warn("[Diagnostics] Can't find running stage or substage while updating Snapshots stage stats.", "stages:", d.syncStages, "stats:", stats, "subStageInfo:", subStageInfo)
 		return
@@ -102,12 +102,13 @@ func (d *DiagnosticClient) updateSnapshotStageStats(stats SyncStageStats, subSta
 }
 
 func (d *DiagnosticClient) snapshotStageFinished() bool {
-	idx := d.getCurrentSyncIdxs()
-	if idx.Stage > 0 {
+	state, err := d.GetStageState("Snapshots")
+	if err != nil {
+		log.Error("[Diagnostics] Failed to get Snapshots stage state", "err", err)
 		return true
-	} else {
-		return false
 	}
+
+	return state == Completed
 }
 
 func (d *DiagnosticClient) runSegmentDownloadingListener(rootCtx context.Context) {

--- a/erigon-lib/diagnostics/stages.go
+++ b/erigon-lib/diagnostics/stages.go
@@ -3,6 +3,7 @@ package diagnostics
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon-lib/log/v3"
@@ -122,7 +123,10 @@ func (d *DiagnosticClient) runCurrentSyncStageListener(rootCtx context.Context) 
 				return
 			case info := <-ch:
 				d.mu.Lock()
-				d.SetCurrentSyncStage(info)
+				err := d.SetCurrentSyncStage(info)
+				if err != nil {
+					log.Error("[Diagnostics] Failed to set current stage", "err", err)
+				}
 				d.mu.Unlock()
 
 				d.saveSyncStagesToDB()
@@ -179,7 +183,7 @@ func (d *DiagnosticClient) saveSyncStagesToDB() {
 	}
 }
 
-func (d *DiagnosticClient) getCurrentSyncIdxs() CurrentSyncStagesIdxs {
+func (d *DiagnosticClient) GetCurrentSyncIdxs() CurrentSyncStagesIdxs {
 	currentIdxs := CurrentSyncStagesIdxs{
 		Stage:    -1,
 		SubStage: -1,
@@ -218,7 +222,16 @@ func (d *DiagnosticClient) SetSubStagesList(stageId string, subStages []SyncSubS
 	}
 }
 
-func (d *DiagnosticClient) SetCurrentSyncStage(css CurrentSyncStage) {
+func (d *DiagnosticClient) SetCurrentSyncStage(css CurrentSyncStage) error {
+	stageState, err := d.GetStageState(css.Stage)
+	if err != nil {
+		return err
+	}
+
+	if stageState == Completed {
+		return nil
+	}
+
 	isSet := false
 	for idx, stage := range d.syncStages {
 		if !isSet {
@@ -232,6 +245,8 @@ func (d *DiagnosticClient) SetCurrentSyncStage(css CurrentSyncStage) {
 			d.setStagesState(idx, Queued)
 		}
 	}
+
+	return nil
 }
 
 func (d *DiagnosticClient) setStagesState(stadeIdx int, state StageState) {
@@ -265,6 +280,21 @@ func (d *DiagnosticClient) SetCurrentSyncSubStage(css CurrentSyncSubStage) {
 			break
 		}
 	}
+}
+
+func (d *DiagnosticClient) GetStageState(stageId string) (StageState, error) {
+	for _, stage := range d.syncStages {
+		if stage.ID == stageId {
+			return stage.State, nil
+		}
+	}
+
+	stagesIdsList := make([]string, 0, len(d.syncStages))
+	for _, stage := range d.syncStages {
+		stagesIdsList = append(stagesIdsList, stage.ID)
+	}
+
+	return 0, fmt.Errorf("stage %s not found in stages list %s", stageId, stagesIdsList)
 }
 
 func ReadSyncStages(db kv.RoDB) []SyncStage {

--- a/erigon-lib/diagnostics/stages_test.go
+++ b/erigon-lib/diagnostics/stages_test.go
@@ -31,17 +31,25 @@ func TestSetCurrentSyncStage(t *testing.T) {
 	subStages := diagnostics.InitSubStagesFromList(snapshotsSubStages)
 	d.SetSubStagesList("Snapshots", subStages)
 
-	d.SetCurrentSyncStage(diagnostics.CurrentSyncStage{Stage: "Snapshots"})
+	err = d.SetCurrentSyncStage(diagnostics.CurrentSyncStage{Stage: "Snapshots"})
+	require.NoError(t, err)
 	require.Equal(t, d.GetSyncStages()[0].State, diagnostics.Running)
 
-	d.SetCurrentSyncStage(diagnostics.CurrentSyncStage{Stage: "BlockHashes"})
+	err = d.SetCurrentSyncStage(diagnostics.CurrentSyncStage{Stage: "BlockHashes"})
+	require.NoError(t, err)
 	require.Equal(t, d.GetSyncStages()[0].State, diagnostics.Completed)
 	require.Equal(t, d.GetSyncStages()[1].State, diagnostics.Running)
 
-	d.SetCurrentSyncStage(diagnostics.CurrentSyncStage{Stage: "Snapshots"})
-	require.Equal(t, d.GetSyncStages()[0].State, diagnostics.Running)
-	require.Equal(t, d.GetSyncStages()[1].State, diagnostics.Queued)
+	err = d.SetCurrentSyncStage(diagnostics.CurrentSyncStage{Stage: "Snapshots"})
+	require.NoError(t, err)
+	require.Equal(t, d.GetSyncStages()[0].State, diagnostics.Completed)
+	require.Equal(t, d.GetSyncStages()[1].State, diagnostics.Running)
 	require.Equal(t, d.GetSyncStages()[2].State, diagnostics.Queued)
+
+	//test not existed stage
+	err = d.SetCurrentSyncStage(diagnostics.CurrentSyncStage{Stage: "NotExistedStage"})
+	require.Error(t, err)
+
 }
 
 func TestSetCurrentSyncSubStage(t *testing.T) {
@@ -53,7 +61,8 @@ func TestSetCurrentSyncSubStage(t *testing.T) {
 	subStages := diagnostics.InitSubStagesFromList(snapshotsSubStages)
 	d.SetSubStagesList("Snapshots", subStages)
 
-	d.SetCurrentSyncStage(diagnostics.CurrentSyncStage{Stage: "Snapshots"})
+	err = d.SetCurrentSyncStage(diagnostics.CurrentSyncStage{Stage: "Snapshots"})
+	require.NoError(t, err)
 	d.SetCurrentSyncSubStage(diagnostics.CurrentSyncSubStage{SubStage: "Download header-chain"})
 	require.Equal(t, d.GetSyncStages()[0].SubStages[0].State, diagnostics.Running)
 
@@ -65,6 +74,66 @@ func TestSetCurrentSyncSubStage(t *testing.T) {
 	require.Equal(t, d.GetSyncStages()[0].SubStages[0].State, diagnostics.Completed)
 	require.Equal(t, d.GetSyncStages()[0].SubStages[1].State, diagnostics.Running)
 	require.Equal(t, d.GetSyncStages()[0].SubStages[2].State, diagnostics.Queued)
+}
+
+func TestGetStageState(t *testing.T) {
+	d, err := NewTestDiagnosticClient()
+	require.NoError(t, err)
+
+	stages := diagnostics.InitStagesFromList(nodeStages)
+	d.SetStagesList(stages)
+
+	// Test get stage state
+	for _, stageId := range nodeStages {
+		state, err := d.GetStageState(stageId)
+		require.NoError(t, err)
+		require.Equal(t, state, diagnostics.Queued)
+	}
+
+	//Test get not existed stage state
+	_, err = d.GetStageState("NotExistedStage")
+	require.Error(t, err)
+
+	//Test Snapshots Running state
+	err = d.SetCurrentSyncStage(diagnostics.CurrentSyncStage{Stage: "Snapshots"})
+	require.NoError(t, err)
+	state, err := d.GetStageState("Snapshots")
+	require.NoError(t, err)
+	require.Equal(t, state, diagnostics.Running)
+
+	//Test Snapshots Completed and BlockHashes running state
+	err = d.SetCurrentSyncStage(diagnostics.CurrentSyncStage{Stage: "BlockHashes"})
+	require.NoError(t, err)
+	state, err = d.GetStageState("Snapshots")
+	require.NoError(t, err)
+	require.Equal(t, state, diagnostics.Completed)
+	state, err = d.GetStageState("BlockHashes")
+	require.NoError(t, err)
+	require.Equal(t, state, diagnostics.Running)
+}
+
+func TestGetStageIndexes(t *testing.T) {
+	d, err := NewTestDiagnosticClient()
+	require.NoError(t, err)
+
+	stages := diagnostics.InitStagesFromList(nodeStages)
+	d.SetStagesList(stages)
+	subStages := diagnostics.InitSubStagesFromList(snapshotsSubStages)
+	d.SetSubStagesList("Snapshots", subStages)
+
+	err = d.SetCurrentSyncStage(diagnostics.CurrentSyncStage{Stage: "Snapshots"})
+	require.NoError(t, err)
+	d.SetCurrentSyncSubStage(diagnostics.CurrentSyncSubStage{SubStage: "Download header-chain"})
+
+	idxs := d.GetCurrentSyncIdxs()
+	require.Equal(t, idxs, diagnostics.CurrentSyncStagesIdxs{Stage: 0, SubStage: 0})
+}
+
+func TestStagesState(t *testing.T) {
+	//Test StageState to string
+	require.Equal(t, diagnostics.StageState(0).String(), "Queued")
+	require.Equal(t, diagnostics.StageState(1).String(), "Running")
+	require.Equal(t, diagnostics.StageState(2).String(), "Completed")
 }
 
 var (


### PR DESCRIPTION
Fixed warn: 
`[WARN] [06-21|01:46:52.502] [Diagnostics] Can't find running stage or substage while updating Snapshots stage stats. stages:="[{ID:Snapshots State:Running SubStages:[{ID:Download header-chain State:Completed Stats:{TimeElapsed: TimeLeft: Progress:}} {ID:Download snapshots State:Completed Stats:{TimeElapsed:2m40s TimeLeft:999hrs:99m Progress:100.00%}} {ID:Indexing State:Completed Stats:{TimeElapsed: TimeLeft: Progress:}} {ID:Fill DB State:Completed Stats:{TimeElapsed: TimeLeft: Progress:}}] Stats:{TimeElapsed: TimeLeft: Progress:}} {ID:BlockHashes State:Queued SubStages:[] Stats:{TimeElapsed: TimeLeft: Progress:}} {ID:Senders State:Queued SubStages:[] Stats:{TimeElapsed: TimeLeft: Progress:}} {ID:Execution State:Queued SubStages:[] Stats:{TimeElapsed: TimeLeft: Progress:}} {ID:HashState State:Queued SubStages:[] Stats:{TimeElapsed: TimeLeft: Progress:}} {ID:IntermediateHashes State:Queued SubStages:[] Stats:{TimeElapsed: TimeLeft: Progress:}} {ID:CallTraces State:Queued SubStages:[] Stats:{TimeElapsed: TimeLeft: Progress:}} {ID:AccountHistoryIndex State:Queued SubStages:[] Stats:{TimeElapsed: TimeLeft: Progress:}} {ID:StorageHistoryIndex State:Queued SubStages:[] Stats:{TimeElapsed: TimeLeft: Progress:}} {ID:LogIndex State:Queued SubStages:[] Stats:{TimeElapsed: TimeLeft: Progress:}} {ID:TxLookup State:Queued SubStages:[] Stats:{TimeElapsed: TimeLeft: Progress:}} {ID:Finish State:Queued SubStages:[] Stats:{TimeElapsed: TimeLeft: Progress:}}]" stats:="{TimeElapsed:1m20s TimeLeft:999hrs:99m Progress:100.00%}" subStageInfo:="Downloading snapshots"`