### PR TITLE
use chainID instead of name for startup assers

### DIFF
--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -641,14 +641,11 @@ func checkChainName(ctx context.Context, dirs datadir.Dirs, chainName string) er
 		return err
 	}
 	defer db.Close()
-	if err := db.View(context.Background(), func(tx kv.Tx) error {
-		cc := tool.ChainConfig(tx)
-		if cc != nil && cc.ChainName != chainName {
+
+	if cc := tool.ChainConfigFromDB(db); cc != nil {
+		if params.ChainConfigByChainName(chainName).ChainID.Uint64() != cc.ChainID.Uint64() {
 			return fmt.Errorf("datadir already was configured with --chain=%s. can't change to '%s'", cc.ChainName, chainName)
 		}
-		return nil
-	}); err != nil {
-		return err
 	}
 	return nil
 }

--- a/cmd/hack/tool/tool.go
+++ b/cmd/hack/tool/tool.go
@@ -1,6 +1,7 @@
 package tool
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/ledgerwatch/erigon-lib/chain"
@@ -25,4 +26,13 @@ func ChainConfig(tx kv.Tx) *chain.Config {
 	chainConfig, err := rawdb.ReadChainConfig(tx, genesisBlockHash)
 	Check(err)
 	return chainConfig
+}
+
+func ChainConfigFromDB(db kv.RoDB) (cc *chain.Config) {
+	err := db.View(context.Background(), func(tx kv.Tx) error {
+		cc = ChainConfig(tx)
+		return nil
+	})
+	Check(err)
+	return cc
 }

--- a/core/rawdb/accessors_metadata.go
+++ b/core/rawdb/accessors_metadata.go
@@ -50,7 +50,6 @@ func ReadChainConfig(db kv.Getter, hash libcommon.Hash) (*chain.Config, error) {
 		}
 		config.Bor = borConfig
 	}
-
 	return &config, nil
 }
 


### PR DESCRIPTION
reason: chainName is just for users. we don't store it in db. geth even removed this field. 