### PR TITLE
remove NoncanonicalTxs table

### DIFF
--- a/cmd/integration/commands/reset_state.go
+++ b/cmd/integration/commands/reset_state.go
@@ -127,11 +127,11 @@ func printStages(tx kv.Tx, snapshots *freezeblocks.RoSnapshots, borSn *freezeblo
 	_, lastBlockInHistSnap, _ := rawdbv3.TxNums.FindBlockNum(tx, agg.EndTxNumMinimax())
 	_lb, _lt, _ := rawdbv3.TxNums.Last(tx)
 	fmt.Fprintf(w, "state.history: idx steps: %.02f, lastBlockInSnap=%d, TxNums_Index(%d,%d), filesAmount: %d\n\n", rawdbhelpers.IdxStepsCountV3(tx), lastBlockInHistSnap, _lb, _lt, agg.FilesAmount())
-	s1, err := tx.ReadSequence(kv.EthTx)
+	ethTxSequence, err := tx.ReadSequence(kv.EthTx)
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(w, "sequence: EthTx=%d\n\n", s1)
+	fmt.Fprintf(w, "sequence: EthTx=%d\n\n", ethTxSequence)
 
 	{
 		firstNonGenesisHeader, err := rawdbv3.SecondKey(tx, kv.Headers)

--- a/cmd/integration/commands/reset_state.go
+++ b/cmd/integration/commands/reset_state.go
@@ -131,11 +131,7 @@ func printStages(tx kv.Tx, snapshots *freezeblocks.RoSnapshots, borSn *freezeblo
 	if err != nil {
 		return err
 	}
-	s2, err := tx.ReadSequence(kv.NonCanonicalTxs)
-	if err != nil {
-		return err
-	}
-	fmt.Fprintf(w, "sequence: EthTx=%d, NonCanonicalTx=%d\n\n", s1, s2)
+	fmt.Fprintf(w, "sequence: EthTx=%d\n\n", s1)
 
 	{
 		firstNonGenesisHeader, err := rawdbv3.SecondKey(tx, kv.Headers)

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -441,27 +441,6 @@ func CanonicalTransactions(db kv.Getter, baseTxId uint64, amount uint32) ([]type
 	txs = txs[:i] // user may request big "amount", but db can return small "amount". Return as much as we found.
 	return txs, nil
 }
-
-func NonCanonicalTransactions(db kv.Getter, baseTxId uint64, amount uint32) ([]types.Transaction, error) {
-	if amount == 0 {
-		return []types.Transaction{}, nil
-	}
-	txs := make([]types.Transaction, amount)
-	i := uint32(0)
-	if err := db.ForAmount(kv.NonCanonicalTxs, hexutility.EncodeTs(baseTxId), amount, func(k, v []byte) error {
-		var decodeErr error
-		if txs[i], decodeErr = types.DecodeTransaction(v); decodeErr != nil {
-			return decodeErr
-		}
-		i++
-		return nil
-	}); err != nil {
-		return nil, err
-	}
-	txs = txs[:i] // user may request big "amount", but db can return small "amount". Return as much as we found.
-	return txs, nil
-}
-
 func WriteTransactions(db kv.RwTx, txs []types.Transaction, baseTxId uint64) error {
 	txId := baseTxId
 	txIdKey := make([]byte, 8)
@@ -1020,7 +999,7 @@ func WriteBlock(db kv.RwTx, block *types.Block) error {
 
 // PruneBlocks - delete [1, to) old blocks after moving it to snapshots.
 // keeps genesis in db: [1, to)
-// doesn't change sequences of kv.EthTx and kv.NonCanonicalTxs
+// doesn't change sequences of kv.EthTx
 // doesn't delete Receipts, Senders, Canonical markers, TotalDifficulty
 // Returns false if there is nothing to prune
 func PruneBlocks(tx kv.RwTx, blockTo uint64, blocksDeleteLimit int) (deleted int, err error) {
@@ -1094,7 +1073,7 @@ func TruncateCanonicalChain(ctx context.Context, db kv.RwTx, from uint64) error 
 }
 
 // TruncateBlocks - delete block >= blockFrom
-// does decrement sequences of kv.EthTx and kv.NonCanonicalTxs
+// does decrement sequences of kv.EthTx
 // doesn't delete Receipts, Senders, Canonical markers, TotalDifficulty
 func TruncateBlocks(ctx context.Context, tx kv.RwTx, blockFrom uint64) error {
 	logEvery := time.NewTicker(20 * time.Second)

--- a/core/rawdb/blockio/block_writer.go
+++ b/core/rawdb/blockio/block_writer.go
@@ -88,17 +88,12 @@ func (w *BlockWriter) TruncateBodies(db kv.RoDB, tx kv.RwTx, from uint64) error 
 	}
 
 	if err := backup.ClearTables(context.Background(), db, tx,
-		kv.NonCanonicalTxs,
 		kv.EthTx,
 		kv.MaxTxNum,
 	); err != nil {
 		return err
 	}
 	if err := rawdb.ResetSequence(tx, kv.EthTx, 0); err != nil {
-		return err
-	}
-
-	if err := rawdb.ResetSequence(tx, kv.NonCanonicalTxs, 0); err != nil {
 		return err
 	}
 	return nil
@@ -111,7 +106,7 @@ var (
 
 // PruneBlocks - [1, to) old blocks after moving it to snapshots.
 // keeps genesis in db
-// doesn't change sequences of kv.EthTx and kv.NonCanonicalTxs
+// doesn't change sequences of kv.EthTx
 // doesn't delete Receipts, Senders, Canonical markers, TotalDifficulty
 func (w *BlockWriter) PruneBlocks(ctx context.Context, tx kv.RwTx, blockTo uint64, blocksDeleteLimit int) (deleted int, err error) {
 	defer mxPruneTookBlocks.ObserveDuration(time.Now())
@@ -120,7 +115,7 @@ func (w *BlockWriter) PruneBlocks(ctx context.Context, tx kv.RwTx, blockTo uint6
 
 // PruneBorBlocks - [1, to) old blocks after moving it to snapshots.
 // keeps genesis in db
-// doesn't change sequences of kv.EthTx and kv.NonCanonicalTxs
+// doesn't change sequences of kv.EthTx
 // doesn't delete Receipts, Senders, Canonical markers, TotalDifficulty
 func (w *BlockWriter) PruneBorBlocks(ctx context.Context, tx kv.RwTx, blockTo uint64, blocksDeleteLimit int, SpanIdAt func(number uint64) uint64) (deleted int, err error) {
 	defer mxPruneTookBor.ObserveDuration(time.Now())

--- a/erigon-lib/kv/tables.go
+++ b/erigon-lib/kv/tables.go
@@ -271,9 +271,8 @@ const (
 	// block has no system-tx - records are absent, but TxnID increasing
 	//
 	// In Erigon3: table MaxTxNum storing TxNum (not TxnID). History/Indices are using TxNum (not TxnID).
-	EthTx           = "BlockTransaction"        // tx_id_u64 -> rlp(tx)
-	NonCanonicalTxs = "NonCanonicalTransaction" // tbl_sequence_u64 -> rlp(tx)
-	MaxTxNum        = "MaxTxNum"                // block_number_u64 -> max_tx_num_in_block_u64
+	EthTx    = "BlockTransaction" // tx_id_u64 -> rlp(tx)
+	MaxTxNum = "MaxTxNum"         // block_number_u64 -> max_tx_num_in_block_u64
 
 	Receipts = "Receipt"        // block_num_u64 -> canonical block receipts (non-canonical are not stored)
 	Log      = "TransactionLog" // block_num_u64 + txId -> logs of transaction
@@ -585,7 +584,6 @@ var ChaindataTables = []string{
 	Log,
 	Sequence,
 	EthTx,
-	NonCanonicalTxs,
 	TrieOfAccounts,
 	TrieOfStorage,
 	HashedAccounts,

--- a/polygon/bor/bordb/prune.go
+++ b/polygon/bor/bordb/prune.go
@@ -12,7 +12,7 @@ import (
 
 // PruneBorBlocks - delete [1, to) old blocks after moving it to snapshots.
 // keeps genesis in db: [1, to)
-// doesn't change sequences of kv.EthTx and kv.NonCanonicalTxs
+// doesn't change sequences of kv.EthTx
 // doesn't delete Receipts, Senders, Canonical markers, TotalDifficulty
 func PruneBorBlocks(tx kv.RwTx, blockTo uint64, blocksDeleteLimit int, SpanIdAt func(number uint64) uint64) (deleted int, err error) {
 	c, err := tx.Cursor(kv.BorEventNums)


### PR DESCRIPTION
because Txs now always stored in EthTx table: reorgs do not update/move txs.
