### PR TITLE
handle case when account.kv is ahead of commitment.kv and we do `rm -rf chaindata`

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,33 +839,34 @@ datadir
 
 du -hsc /erigon/* 
 6G  	/erigon/caplin
-80G 	/erigon/chaindata
-1.7T	/erigon/snapshots
-1.8T	total
+50G 	/erigon/chaindata
+1.8T	/erigon/snapshots
+1.9T	total
 
 du -hsc /erigon/snapshots/* 
 100G 	/erigon/snapshots/accessor
-230G	/erigon/snapshots/domain
-250G	/erigon/snapshots/history
-400G	/erigon/snapshots/idx
+240G	/erigon/snapshots/domain
+260G	/erigon/snapshots/history
+410G	/erigon/snapshots/idx
 1.7T	/erigon/snapshots
 ```
 
 ```
-# bor-mainnet - archive - April 2024
+# bor-mainnet - archive - Jun 2024
 
 du -hsc /erigon/* 
+
 160M	/erigon/bor
-60G 	/erigon/chaindata
+50G 	/erigon/chaindata
 3.7T	/erigon/snapshots
 3.8T	total
 
 du -hsc /erigon/snapshots/* 
-24G	/erigon/snapshots/accessor
-680G	/erigon/snapshots/domain
-580G	/erigon/snapshots/history
-1.3T	/erigon/snapshots/idx
-3.7T	/erigon/snapshots
+260G	/erigon-data/snapshots/accessor
+850G	/erigon-data/snapshots/domain
+650G	/erigon-data/snapshots/history
+1.4T	/erigon-data/snapshots/idx
+4.1T	/erigon/snapshots
 ```
 
 ### E3 other perf trics

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -144,7 +144,7 @@ func NewAggregator(ctx context.Context, dirs datadir.Dirs, aggregationStep uint6
 		//  - problem! `commitment` domain doesn't have step X in DB
 		//  - means we must ignore step X in another domains
 		switch name {
-		case kv.AccountsDomain, kv.StorageDomain, kv.Code:
+		case kv.AccountsDomain, kv.StorageDomain, kv.CodeDomain:
 			if toStep-fromStep > 1 { // only recently built files
 				return true
 			}

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -142,7 +142,7 @@ func NewAggregator(ctx context.Context, dirs datadir.Dirs, aggregationStep uint6
 		// case2: `kill -9` during building new .kv and `rm -rf chaindata`
 		//  - `accounts` domain may be at step X and `commitment` domain at step X-1
 		//  - problem! `commitment` domain doesn't have step X in DB
-		//  - means we must ignore step X in another domains
+		// solution: ignore step X files in both cases
 		switch name {
 		case kv.AccountsDomain, kv.StorageDomain, kv.CodeDomain:
 			if toStep-fromStep > 1 { // only recently built files

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -145,7 +145,7 @@ func NewAggregator(ctx context.Context, dirs datadir.Dirs, aggregationStep uint6
 		//  - means we must ignore step X in another domains
 		switch name {
 		case kv.AccountsDomain, kv.StorageDomain, kv.CommitmentDomain:
-			if toStep-fromStep > 1 { //only recently built files
+			if toStep-fromStep > 1 { // only recently built files
 				return true
 			}
 			return commitmentFileMustExist(fromStep, toStep)

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -144,7 +144,7 @@ func NewAggregator(ctx context.Context, dirs datadir.Dirs, aggregationStep uint6
 		//  - problem! `commitment` domain doesn't have step X in DB
 		//  - means we must ignore step X in another domains
 		switch name {
-		case kv.AccountsDomain, kv.StorageDomain, kv.CommitmentDomain:
+		case kv.AccountsDomain, kv.StorageDomain, kv.Code:
 			if toStep-fromStep > 1 { // only recently built files
 				return true
 			}

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -299,7 +299,7 @@ func (d *Domain) scanStateFiles(fileNames []string) (garbageFiles []*filesItem) 
 		}
 
 		domainName, _ := kv.String2Domain(d.filenameBase)
-		if !d.integrityCheck(domainName, startStep, endStep) {
+		if d.integrityCheck != nil && !d.integrityCheck(domainName, startStep, endStep) {
 			d.logger.Debug("[agg] skip garbage file", "name", name)
 			continue
 		}

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -288,7 +288,7 @@ func (d *Domain) scanStateFiles(fileNames []string) (garbageFiles []*filesItem) 
 
 		domainName, _ := kv.String2Domain(d.filenameBase)
 		if !d.integrityCheck(domainName, startStep, endStep) {
-			d.logger.Debug("skip garbage file", "name", name)
+			d.logger.Debug("[agg] skip garbage file", "name", name)
 			continue
 		}
 

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -229,7 +229,11 @@ func (d *Domain) closeFilesAfterStep(lowerBound uint64) {
 	})
 	for _, item := range toClose {
 		d.dirtyFiles.Delete(item)
-		log.Debug(fmt.Sprintf("[snapshots] closing %s, because step %d has not enough files (was not complete). stack: %s", item.decompressor.FileName(), lowerBound, dbg.Stack()))
+		fName := ""
+		if item.decompressor != nil {
+			fName = item.decompressor.FileName()
+		}
+		log.Debug(fmt.Sprintf("[snapshots] closing %s, because step %d has not enough files (was not complete)", fName, lowerBound))
 		item.closeFiles()
 	}
 
@@ -242,7 +246,11 @@ func (d *Domain) closeFilesAfterStep(lowerBound uint64) {
 	})
 	for _, item := range toClose {
 		d.History.dirtyFiles.Delete(item)
-		log.Debug(fmt.Sprintf("[snapshots] closing some histor files - because step %d has not enough files (was not complete)", lowerBound))
+		fName := ""
+		if item.decompressor != nil {
+			fName = item.decompressor.FileName()
+		}
+		log.Debug(fmt.Sprintf("[snapshots] closing %s, because step %d has not enough files (was not complete)", fName, lowerBound))
 		item.closeFiles()
 	}
 
@@ -255,7 +263,11 @@ func (d *Domain) closeFilesAfterStep(lowerBound uint64) {
 	})
 	for _, item := range toClose {
 		d.History.InvertedIndex.dirtyFiles.Delete(item)
-		log.Debug(fmt.Sprintf("[snapshots] closing %s, because step %d has not enough files (was not complete)", item.decompressor.FileName(), lowerBound))
+		fName := ""
+		if item.decompressor != nil {
+			fName = item.decompressor.FileName()
+		}
+		log.Debug(fmt.Sprintf("[snapshots] closing %s, because step %d has not enough files (was not complete)", fName, lowerBound))
 		item.closeFiles()
 	}
 }

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -233,7 +233,7 @@ func (d *Domain) closeFilesAfterStep(lowerBound uint64) {
 		if item.decompressor != nil {
 			fName = item.decompressor.FileName()
 		}
-		log.Debug(fmt.Sprintf("[snapshots] closing %s, because step %d has not enough files (was not complete)", fName, lowerBound))
+		log.Debug(fmt.Sprintf("[snapshots] closing %s, because step %d was not complete", fName, lowerBound))
 		item.closeFiles()
 	}
 
@@ -250,7 +250,7 @@ func (d *Domain) closeFilesAfterStep(lowerBound uint64) {
 		if item.decompressor != nil {
 			fName = item.decompressor.FileName()
 		}
-		log.Debug(fmt.Sprintf("[snapshots] closing %s, because step %d has not enough files (was not complete)", fName, lowerBound))
+		log.Debug(fmt.Sprintf("[snapshots] closing %s, because step %d was not complete", fName, lowerBound))
 		item.closeFiles()
 	}
 
@@ -267,7 +267,7 @@ func (d *Domain) closeFilesAfterStep(lowerBound uint64) {
 		if item.decompressor != nil {
 			fName = item.decompressor.FileName()
 		}
-		log.Debug(fmt.Sprintf("[snapshots] closing %s, because step %d has not enough files (was not complete)", fName, lowerBound))
+		log.Debug(fmt.Sprintf("[snapshots] closing %s, because step %d was not complete", fName, lowerBound))
 		item.closeFiles()
 	}
 }

--- a/erigon-lib/state/domain_test.go
+++ b/erigon-lib/state/domain_test.go
@@ -83,7 +83,7 @@ func testDbAndDomainOfStep(t *testing.T, aggStep uint64, logger log.Logger) (kv.
 			iiCfg:             iiCfg{salt: &salt, dirs: dirs, db: db},
 			withLocalityIndex: false, withExistenceIndex: false, compression: CompressNone, historyLargeValues: true,
 		}}
-	d, err := NewDomain(cfg, aggStep, kv.AccountsDomain.String(), keysTable, valsTable, historyKeysTable, historyValsTable, indexTable, logger)
+	d, err := NewDomain(cfg, aggStep, kv.AccountsDomain.String(), keysTable, valsTable, historyKeysTable, historyValsTable, indexTable, nil, logger)
 	require.NoError(t, err)
 	d.DisableFsync()
 	d.compressWorkers = 1

--- a/erigon-lib/state/inverted_index.go
+++ b/erigon-lib/state/inverted_index.go
@@ -23,7 +23,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/ledgerwatch/erigon-lib/common"
 	"math"
 	"os"
 	"path"
@@ -33,6 +32,8 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/ledgerwatch/erigon-lib/common"
 
 	"github.com/RoaringBitmap/roaring/roaring64"
 	"github.com/spaolacci/murmur3"
@@ -204,6 +205,7 @@ func (ii *InvertedIndex) scanStateFiles(fileNames []string) (garbageFiles []*fil
 		var newFile = newFilesItem(startTxNum, endTxNum, ii.aggregationStep)
 
 		if ii.integrityCheck != nil && !ii.integrityCheck(startStep, endStep) {
+			ii.logger.Debug("[agg] skip garbage file", "name", name)
 			continue
 		}
 


### PR DESCRIPTION
for https://github.com/ledgerwatch/erigon/issues/10775