### PR TITLE
allow to gracefully exit from CL downloading stage

### DIFF
--- a/cl/clstages/clstages.go
+++ b/cl/clstages/clstages.go
@@ -32,14 +32,12 @@ func (s *StageGraph[CONFIG, ARGUMENTS]) StartWithStage(ctx context.Context, star
 		errch := make(chan error)
 		start := time.Now()
 		go func() {
-			sctx, cn := context.WithCancel(ctx)
-			defer cn()
 			// we run this is a goroutine so that the process can exit in the middle of a stage
 			// since caplin is designed to always be able to recover regardless of db state, this should be safe
 			select {
-			case errch <- currentStage.ActionFunc(sctx, lg, cfg, args):
-			case <-sctx.Done():
-				errch <- sctx.Err()
+			case errch <- currentStage.ActionFunc(ctx, lg, cfg, args):
+			case <-ctx.Done(): // we are not sure if actionFunc exits on ctx
+				errch <- ctx.Err()
 			}
 		}()
 		err := <-errch

--- a/cl/phase1/stages/clstages.go
+++ b/cl/phase1/stages/clstages.go
@@ -249,7 +249,7 @@ func ConsensusClStages(ctx context.Context,
 					}
 					// This stage is special so use context.Background() TODO(Giulio2002): make the context be passed in
 					startingSlot := cfg.state.LatestBlockHeader().Slot
-					downloader := network2.NewBackwardBeaconDownloader(context.Background(), cfg.rpc, cfg.executionClient, cfg.indiciesDB)
+					downloader := network2.NewBackwardBeaconDownloader(ctx, cfg.rpc, cfg.executionClient, cfg.indiciesDB)
 
 					if err := SpawnStageHistoryDownload(StageHistoryReconstruction(downloader, cfg.antiquary, cfg.sn, cfg.indiciesDB, cfg.executionClient, cfg.beaconCfg, cfg.backfilling, cfg.blobBackfilling, false, startingRoot, startingSlot, cfg.tmpdir, 600*time.Millisecond, cfg.blockCollector, cfg.blockReader, cfg.blobStore, logger), context.Background(), logger); err != nil {
 						cfg.hasDownloaded = false


### PR DESCRIPTION
There is comment that preferred way to use different context not bounded to general app context. But through it we propagate cancellations by signal. @Giulio2002 could you please clarify if we still need separated context or it's okay to pass ctx. 