### PR TITLE
chg: update the enforced 30gwei for gas related configs for polygon to 25gwei

### DIFF
--- a/erigon-lib/txpool/txpoolcfg/txpoolcfg.go
+++ b/erigon-lib/txpool/txpoolcfg/txpoolcfg.go
@@ -30,7 +30,7 @@ import (
 )
 
 // BorDefaultTxPoolPriceLimit defines the minimum gas price limit for bor to enforce txs acceptance into the pool.
-const BorDefaultTxPoolPriceLimit = 30 * common.GWei
+const BorDefaultTxPoolPriceLimit = 25 * common.GWei
 
 type Config struct {
 	DBDir               string

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1726,7 +1726,7 @@ func (s *Ethereum) DataDir() string {
 	return s.config.Dirs.DataDir
 }
 
-// setBorDefaultMinerGasPrice enforces Miner.GasPrice to be equal to BorDefaultMinerGasPrice (30gwei by default)
+// setBorDefaultMinerGasPrice enforces Miner.GasPrice to be equal to BorDefaultMinerGasPrice (25gwei by default)
 func setBorDefaultMinerGasPrice(chainConfig *chain.Config, config *ethconfig.Config, logger log.Logger) {
 	if chainConfig.Bor != nil && (config.Miner.GasPrice == nil || config.Miner.GasPrice.Cmp(ethconfig.BorDefaultMinerGasPrice) != 0) {
 		logger.Warn("Sanitizing invalid bor miner gas price", "provided", config.Miner.GasPrice, "updated", ethconfig.BorDefaultMinerGasPrice)
@@ -1734,7 +1734,7 @@ func setBorDefaultMinerGasPrice(chainConfig *chain.Config, config *ethconfig.Con
 	}
 }
 
-// setBorDefaultTxPoolPriceLimit enforces MinFeeCap to be equal to BorDefaultTxPoolPriceLimit  (30gwei by default)
+// setBorDefaultTxPoolPriceLimit enforces MinFeeCap to be equal to BorDefaultTxPoolPriceLimit  (25gwei by default)
 func setBorDefaultTxPoolPriceLimit(chainConfig *chain.Config, config txpoolcfg.Config, logger log.Logger) {
 	if chainConfig.Bor != nil && config.MinFeeCap != txpoolcfg.BorDefaultTxPoolPriceLimit {
 		logger.Warn("Sanitizing invalid bor min fee cap", "provided", config.MinFeeCap, "updated", txpoolcfg.BorDefaultTxPoolPriceLimit)

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -45,7 +45,7 @@ import (
 )
 
 // BorDefaultMinerGasPrice defines the minimum gas price for bor validators to mine a transaction.
-var BorDefaultMinerGasPrice = big.NewInt(30 * params.GWei)
+var BorDefaultMinerGasPrice = big.NewInt(25 * params.GWei)
 
 // FullNodeGPO contains default gasprice oracle settings for full node.
 var FullNodeGPO = gaspricecfg.Config{

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -290,7 +290,7 @@ func (s *sortingHeap) Pop() interface{} {
 	return x
 }
 
-// setBorDefaultGpoIgnorePrice enforces gpo IgnorePrice to be equal to BorDefaultGpoIgnorePrice  (30gwei by default)
+// setBorDefaultGpoIgnorePrice enforces gpo IgnorePrice to be equal to BorDefaultGpoIgnorePrice  (25gwei by default)
 func setBorDefaultGpoIgnorePrice(chainConfig *chain.Config, gasPriceConfig gaspricecfg.Config, log log.Logger) {
 	if chainConfig.Bor != nil && gasPriceConfig.IgnorePrice != gaspricecfg.BorDefaultGpoIgnorePrice {
 		log.Warn("Sanitizing invalid bor gasprice oracle ignore price", "provided", gasPriceConfig.IgnorePrice, "updated", gaspricecfg.BorDefaultGpoIgnorePrice)

--- a/eth/gasprice/gaspricecfg/gaspricecfg.go
+++ b/eth/gasprice/gaspricecfg/gaspricecfg.go
@@ -9,7 +9,7 @@ import (
 var DefaultIgnorePrice = big.NewInt(2 * params.Wei)
 
 // BorDefaultGpoIgnorePrice defines the minimum gas price below which bor gpo will ignore transactions.
-var BorDefaultGpoIgnorePrice = big.NewInt(30 * params.Wei)
+var BorDefaultGpoIgnorePrice = big.NewInt(25 * params.Wei)
 
 var (
 	DefaultMaxPrice = big.NewInt(500 * params.GWei)


### PR DESCRIPTION
**This is a draft PR, please do not merge it yet. Thanks!**

This PR updated the enforced 30gwei gas for txpool.pricelimit, miner.gasprice and gpo.ignoreprice to 25gwei for Polygon PoS chain.

Previous PR - [ledgerwatch/erigon#10119](https://github.com/ledgerwatch/erigon/pull/10119)
PR in Bor - [maticnetwork/bor#1280](https://github.com/maticnetwork/bor/pull/1280)