### PR TITLE
Rename tx to txn for `transaction` obj (part 3/3)

### DIFF
--- a/cl/persistence/format/snapshot_format/getters/execution_snapshot.go
+++ b/cl/persistence/format/snapshot_format/getters/execution_snapshot.go
@@ -53,16 +53,16 @@ func (r *ExecutionSnapshotReader) Transactions(number uint64, hash libcommon.Has
 
 func convertTxsToBytesSSZ(txs [][]byte) []byte {
 	sumLenTxs := 0
-	for _, tx := range txs {
+	for _, txn := range txs {
 		sumLenTxs += len(tx)
 	}
 	flat := make([]byte, 0, 4*len(txs)+sumLenTxs)
 	offset := len(txs) * 4
-	for _, tx := range txs {
+	for _, txn := range txs {
 		flat = append(flat, ssz.OffsetSSZ(uint32(offset))...)
 		offset += len(tx)
 	}
-	for _, tx := range txs {
+	for _, txn := range txs {
 		flat = append(flat, tx...)
 	}
 	return flat

--- a/cl/persistence/format/snapshot_format/getters/execution_snapshot.go
+++ b/cl/persistence/format/snapshot_format/getters/execution_snapshot.go
@@ -54,16 +54,16 @@ func (r *ExecutionSnapshotReader) Transactions(number uint64, hash libcommon.Has
 func convertTxsToBytesSSZ(txs [][]byte) []byte {
 	sumLenTxs := 0
 	for _, txn := range txs {
-		sumLenTxs += len(tx)
+		sumLenTxs += len(txn)
 	}
 	flat := make([]byte, 0, 4*len(txs)+sumLenTxs)
 	offset := len(txs) * 4
 	for _, txn := range txs {
 		flat = append(flat, ssz.OffsetSSZ(uint32(offset))...)
-		offset += len(tx)
+		offset += len(txn)
 	}
 	for _, txn := range txs {
-		flat = append(flat, tx...)
+		flat = append(flat, txn...)
 	}
 	return flat
 }

--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -645,7 +645,7 @@ func trimTxs(chaindata string) error {
 			return err
 		}
 		// Remove from the map
-		toDelete.RemoveRange(body.BaseTxnID.U64(), body.BaseTxnID.LastSystemTx(body.TxCount)+1) //+1 to include last system tx in block into delete range
+		toDelete.RemoveRange(body.BaseTxnID.U64(), body.BaseTxnID.LastSystemTx(body.TxCount)+1) //+1 to include last system txn in block into delete range
 	}
 	fmt.Printf("Number of txn records to delete: %d\n", toDelete.GetCardinality())
 	// Takes 20min to iterate 1.4b

--- a/core/state/intra_block_state.go
+++ b/core/state/intra_block_state.go
@@ -685,8 +685,8 @@ func (sdb *IntraBlockState) FinalizeTx(chainRules *chain.Rules, stateWriter Stat
 	for addr := range sdb.journal.dirties {
 		so, exist := sdb.stateObjects[addr]
 		if !exist {
-			// ripeMD is 'touched' at block 1714175, in tx 0x1237f737031e40bcde4a8b7e717b2d15e3ecadfe49bb1bbc71ee9deb09c6fcf2
-			// That tx goes out of gas, and although the notion of 'touched' does not exist there, the
+			// ripeMD is 'touched' at block 1714175, in txn 0x1237f737031e40bcde4a8b7e717b2d15e3ecadfe49bb1bbc71ee9deb09c6fcf2
+			// That txn goes out of gas, and although the notion of 'touched' does not exist there, the
 			// touch-event will still be recorded in the journal. Since ripeMD is a special snowflake,
 			// it will persist in the journal even though the journal is reverted. In this special circumstance,
 			// it may exist in `sdb.journal.dirties` but not in `sdb.stateObjects`.
@@ -710,8 +710,8 @@ func (sdb *IntraBlockState) SoftFinalise() {
 	for addr := range sdb.journal.dirties {
 		_, exist := sdb.stateObjects[addr]
 		if !exist {
-			// ripeMD is 'touched' at block 1714175, in tx 0x1237f737031e40bcde4a8b7e717b2d15e3ecadfe49bb1bbc71ee9deb09c6fcf2
-			// That tx goes out of gas, and although the notion of 'touched' does not exist there, the
+			// ripeMD is 'touched' at block 1714175, in txn 0x1237f737031e40bcde4a8b7e717b2d15e3ecadfe49bb1bbc71ee9deb09c6fcf2
+			// That txn goes out of gas, and although the notion of 'touched' does not exist there, the
 			// touch-event will still be recorded in the journal. Since ripeMD is a special snowflake,
 			// it will persist in the journal even though the journal is reverted. In this special circumstance,
 			// it may exist in `sdb.journal.dirties` but not in `sdb.stateObjects`.
@@ -792,7 +792,7 @@ func (sdb *IntraBlockState) clearJournalAndRefund() {
 // - Add sender to access list (EIP-2929)
 // - Add destination to access list (EIP-2929)
 // - Add precompiles to access list (EIP-2929)
-// - Add the contents of the optional tx access list (EIP-2930)
+// - Add the contents of the optional txn access list (EIP-2930)
 //
 // Shanghai fork:
 // - Add coinbase to access list (EIP-3651)

--- a/core/state/txtask.go
+++ b/core/state/txtask.go
@@ -39,7 +39,7 @@ type TxTask struct {
 	TxAsMessage     types.Message
 	EvmBlockContext evmtypes.BlockContext
 
-	HistoryExecution bool // use history reader for that tx instead of state reader
+	HistoryExecution bool // use history reader for that txn instead of state reader
 
 	BalanceIncreaseSet map[libcommon.Address]uint256.Int
 	ReadLists          map[string]*state.KvList

--- a/core/tracing/hooks.go
+++ b/core/tracing/hooks.go
@@ -56,7 +56,7 @@ type VMContext struct {
 	BlockNumber uint64
 	Time        uint64
 	Random      *libcommon.Hash
-	// Effective tx gas price
+	// Effective txn gas price
 	GasPrice        *uint256.Int
 	ChainConfig     *chain.Config
 	IntraBlockState IntraBlockState
@@ -81,7 +81,7 @@ type (
 	// TxStartHook is called before the execution of a transaction starts.
 	// Call simulations don't come with a valid signature. `from` field
 	// to be used for address of the caller.
-	TxStartHook = func(vm *VMContext, tx types.Transaction, from libcommon.Address)
+	TxStartHook = func(vm *VMContext, txn types.Transaction, from libcommon.Address)
 
 	// TxEndHook is called after the execution of a transaction ends.
 	TxEndHook = func(receipt *types.Receipt, err error)
@@ -229,7 +229,7 @@ const (
 	// BalanceDecreaseSelfdestruct is deducted from a contract due to self-destruct.
 	BalanceDecreaseSelfdestruct BalanceChangeReason = 13
 	// BalanceDecreaseSelfdestructBurn is ether that is sent to an already self-destructed
-	// account within the same tx (captured at end of tx).
+	// account within the same txn (captured at end of tx).
 	// Note it doesn't account for a self-destruct which appoints itself as recipient.
 	BalanceDecreaseSelfdestructBurn BalanceChangeReason = 14
 )
@@ -255,7 +255,7 @@ const (
 	// GasChangeTxIntrinsicGas is the amount of gas that will be charged for the intrinsic cost of the transaction, there is
 	// always exactly one of those per transaction.
 	GasChangeTxIntrinsicGas GasChangeReason = 2
-	// GasChangeTxRefunds is the sum of all refunds which happened during the tx execution (e.g. storage slot being cleared)
+	// GasChangeTxRefunds is the sum of all refunds which happened during the txn execution (e.g. storage slot being cleared)
 	// this generates an increase in gas. There is at most one of such gas change per transaction.
 	GasChangeTxRefunds GasChangeReason = 3
 	// GasChangeTxLeftOverReturned is the amount of gas left over at the end of transaction's execution that will be returned

--- a/core/types/blob_tx_wrapper.go
+++ b/core/types/blob_tx_wrapper.go
@@ -259,7 +259,7 @@ func (txw *BlobTxWrapper) ValidateBlobTransactionWrapper() error {
 	blobTx := txw.Tx
 	l1 := len(blobTx.BlobVersionedHashes)
 	if l1 == 0 {
-		return fmt.Errorf("a blob tx must contain at least one blob")
+		return fmt.Errorf("a blob txn must contain at least one blob")
 	}
 	l2 := len(txw.Commitments)
 	l3 := len(txw.Blobs)

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -661,17 +661,17 @@ func (b BaseTxnID) U64() uint64 { return uint64(b) }
 
 func (b BaseTxnID) Bytes() []byte { return hexutility.EncodeTs(uint64(b)) }
 
-// First non-system tx number in block
+// First non-system txn number in block
 // as if baseTxnID is first original transaction in block
 func (b BaseTxnID) First() uint64 { return uint64(b + 1) }
 
-// At returns tx number at block position `ti`.
+// At returns txn number at block position `ti`.
 func (b BaseTxnID) At(ti int) uint64 { return b.First() + uint64(ti) }
 
-// FirstSystemTx returns first system tx number in block
+// FirstSystemTx returns first system txn number in block
 func (b BaseTxnID) FirstSystemTx() BaseTxnID { return b }
 
-// LastSystemTx returns last system tx number in block. result+1 will be baseID of next block a.k.a. beginning system tx number
+// LastSystemTx returns last system txn number in block. result+1 will be baseID of next block a.k.a. beginning system txn number
 // Supposed that txAmount includes 2 system txns.
 func (b BaseTxnID) LastSystemTx(txAmount uint32) uint64 { return b.U64() + uint64(txAmount) - 1 }
 

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -592,12 +592,12 @@ func TestCopyTxs(t *testing.T) {
 	})
 
 	populateBlobTxs()
-	for _, tx := range dummyBlobTxs {
+	for _, txn := range dummyBlobTxs {
 		txs = append(txs, tx)
 	}
 
 	populateBlobWrapperTxs()
-	for _, tx := range dummyBlobWrapperTxs {
+	for _, txn := range dummyBlobWrapperTxs {
 		txs = append(txs, tx)
 	}
 

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -593,12 +593,12 @@ func TestCopyTxs(t *testing.T) {
 
 	populateBlobTxs()
 	for _, txn := range dummyBlobTxs {
-		txs = append(txs, tx)
+		txs = append(txs, txn)
 	}
 
 	populateBlobWrapperTxs()
 	for _, txn := range dummyBlobWrapperTxs {
-		txs = append(txs, tx)
+		txs = append(txs, txn)
 	}
 
 	copies := CopyTxs(txs)

--- a/erigon-lib/rlp/encode.go
+++ b/erigon-lib/rlp/encode.go
@@ -267,7 +267,7 @@ func AnnouncementsLen(types []byte, sizes []uint32, hashes []byte) int {
 	return ListPrefixLen(totalLen) + totalLen
 }
 
-// EIP-5793: eth/68 - Add tx type to tx announcement
+// EIP-5793: eth/68 - Add txn type to txn announcement
 func EncodeAnnouncements(types []byte, sizes []uint32, hashes []byte, encodeBuf []byte) int {
 	if len(types) == 0 {
 		encodeBuf[0] = 0xc3

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -453,7 +453,7 @@ func (d *Domain) Close() {
 func (w *domainBufferedWriter) PutWithPrev(key1, key2, val, preval []byte, prevStep uint64) error {
 	// This call to update needs to happen before d.tx.Put() later, because otherwise the content of `preval`` slice is invalidated
 	if tracePutWithPrev != "" && tracePutWithPrev == w.h.ii.filenameBase {
-		fmt.Printf("PutWithPrev(%s, tx %d, key[%x][%x] value[%x] preval[%x])\n", w.h.ii.filenameBase, w.h.ii.txNum, key1, key2, val, preval)
+		fmt.Printf("PutWithPrev(%s, txn %d, key[%x][%x] value[%x] preval[%x])\n", w.h.ii.filenameBase, w.h.ii.txNum, key1, key2, val, preval)
 	}
 	if err := w.h.AddPrevValue(key1, key2, preval, prevStep); err != nil {
 		return err
@@ -467,7 +467,7 @@ func (w *domainBufferedWriter) PutWithPrev(key1, key2, val, preval []byte, prevS
 func (w *domainBufferedWriter) DeleteWithPrev(key1, key2, prev []byte, prevStep uint64) (err error) {
 	// This call to update needs to happen before d.tx.Delete() later, because otherwise the content of `original`` slice is invalidated
 	if tracePutWithPrev != "" && tracePutWithPrev == w.h.ii.filenameBase {
-		fmt.Printf("DeleteWithPrev(%s, tx %d, key[%x][%x] preval[%x])\n", w.h.ii.filenameBase, w.h.ii.txNum, key1, key2, prev)
+		fmt.Printf("DeleteWithPrev(%s, txn %d, key[%x][%x] preval[%x])\n", w.h.ii.filenameBase, w.h.ii.txNum, key1, key2, prev)
 	}
 	if err := w.h.AddPrevValue(key1, key2, prev, prevStep); err != nil {
 		return err
@@ -1862,7 +1862,7 @@ func (hi *DomainLatestIterFile) init(dc *DomainRoTx) error {
 	//     File endTxNum  = last txNum of file step
 	//     DB endTxNum    = first txNum of step in db
 	//     RAM endTxNum   = current txnum
-	//  Example: stepSize=8, file=0-2.kv, db has key of step 2, current tx num is 17
+	//  Example: stepSize=8, file=0-2.kv, db has key of step 2, current txn num is 17
 	//     File endTxNum  = 15, because `0-2.kv` has steps 0 and 1, last txNum of step 1 is 15
 	//     DB endTxNum    = 16, because db has step 2, and first txNum of step 2 is 16.
 	//     RAM endTxNum   = 17, because current tcurrent txNum is 17

--- a/erigon-lib/state/domain_test.go
+++ b/erigon-lib/state/domain_test.go
@@ -1125,7 +1125,7 @@ func TestDomainContext_getFromFiles(t *testing.T) {
 			ks, _ := hex.DecodeString(key)
 			val, err := dc.GetAsOf(ks, beforeTx, tx)
 			require.NoError(t, err)
-			require.EqualValuesf(t, bufs[i], val, "key %s, tx %d", key, beforeTx)
+			require.EqualValuesf(t, bufs[i], val, "key %s, txn %d", key, beforeTx)
 			beforeTx += d.aggregationStep
 		}
 	}
@@ -1389,7 +1389,7 @@ func TestDomain_GetAfterAggregation(t *testing.T) {
 		for i := 1; i < len(updates); i++ {
 			v, err := dc.GetAsOf([]byte(key), updates[i].txNum, tx)
 			require.NoError(t, err)
-			require.EqualValuesf(t, updates[i-1].value, v, "(%d/%d) key %x, tx %d", kc, len(data), []byte(key), updates[i-1].txNum)
+			require.EqualValuesf(t, updates[i-1].value, v, "(%d/%d) key %x, txn %d", kc, len(data), []byte(key), updates[i-1].txNum)
 		}
 		if len(updates) == 0 {
 			continue
@@ -1553,7 +1553,7 @@ func TestDomain_PruneAfterAggregation(t *testing.T) {
 		for i := 1; i < len(updates); i++ {
 			v, err := dc.GetAsOf([]byte(key), updates[i].txNum, tx)
 			require.NoError(t, err)
-			require.EqualValuesf(t, updates[i-1].value, v, "(%d/%d) key %x, tx %d", kc, len(data), []byte(key), updates[i-1].txNum)
+			require.EqualValuesf(t, updates[i-1].value, v, "(%d/%d) key %x, txn %d", kc, len(data), []byte(key), updates[i-1].txNum)
 		}
 		if len(updates) == 0 {
 			continue
@@ -1776,8 +1776,8 @@ func TestDomain_Unwind(t *testing.T) {
 		for i := uint64(0); i < maxTx; i++ {
 			writer.diff = &StateDiffDomain{}
 			writer.SetTxNum(i)
-			if i%3 == 0 && i > 0 { // once in 3 tx put key3 -> value3.i and skip other keys update
-				if i%12 == 0 { // once in 12 tx delete key3 before update
+			if i%3 == 0 && i > 0 { // once in 3 txn put key3 -> value3.i and skip other keys update
+				if i%12 == 0 { // once in 12 txn delete key3 before update
 					err = writer.DeleteWithPrev([]byte("key3"), nil, preval3, 0)
 					require.NoError(t, err)
 					preval3 = nil

--- a/erigon-lib/state/history.go
+++ b/erigon-lib/state/history.go
@@ -88,7 +88,7 @@ type History struct {
 
 	snapshotsDisabled bool   // don't produce .v and .ef files, keep in db table. old data will be pruned anyway.
 	historyDisabled   bool   // skip all write operations to this History (even in DB)
-	keepRecentTxnInDB uint64 // When dontProduceHistoryFiles=true, keepRecentTxInDB is used to keep this amount of tx in db before pruning
+	keepRecentTxnInDB uint64 // When dontProduceHistoryFiles=true, keepRecentTxInDB is used to keep this amount of txn in db before pruning
 }
 
 type histCfg struct {
@@ -104,7 +104,7 @@ type histCfg struct {
 	withExistenceIndex bool // move to iiCfg
 
 	snapshotsDisabled bool   // don't produce .v and .ef files. old data will be pruned anyway.
-	keepTxInDB        uint64 // When dontProduceHistoryFiles=true, keepTxInDB is used to keep this amount of tx in db before pruning
+	keepTxInDB        uint64 // When dontProduceHistoryFiles=true, keepTxInDB is used to keep this amount of txn in db before pruning
 }
 
 func NewHistory(cfg histCfg, aggregationStep uint64, filenameBase, indexKeysTable, indexTable, historyValsTable string, integrityCheck func(fromStep, toStep uint64) bool, logger log.Logger) (*History, error) {

--- a/erigon-lib/state/inverted_index.go
+++ b/erigon-lib/state/inverted_index.go
@@ -784,7 +784,7 @@ func (iit *InvertedIndexRoTx) Prune(ctx context.Context, rwTx kv.RwTx, txFrom, t
 	defer mxPruneInProgress.Dec()
 	defer func(t time.Time) { mxPruneTookIndex.ObserveDuration(t) }(time.Now())
 
-	if limit == 0 { // limits amount of Tx to be pruned
+	if limit == 0 { // limits amount of txn to be pruned
 		limit = math.MaxUint64
 	}
 
@@ -953,7 +953,7 @@ func (iit *InvertedIndexRoTx) DebugEFAllValuesAreInRange(ctx context.Context, fa
 	return nil
 }
 
-// FrozenInvertedIdxIter allows iteration over range of tx numbers
+// FrozenInvertedIdxIter allows iteration over range of txn numbers
 // Iteration is not implmented via callback function, because there is often
 // a requirement for interators to be composable (for example, to implement AND and OR for indices)
 // FrozenInvertedIdxIter must be closed after use to prevent leaking of resources like cursor
@@ -1084,7 +1084,7 @@ func (it *FrozenInvertedIdxIter) advanceInFiles() {
 	}
 }
 
-// RecentInvertedIdxIter allows iteration over range of tx numbers
+// RecentInvertedIdxIter allows iteration over range of txn numbers
 // Iteration is not implmented via callback function, because there is often
 // a requirement for interators to be composable (for example, to implement AND and OR for indices)
 type RecentInvertedIdxIter struct {

--- a/erigon-lib/txpool/fetch_test.go
+++ b/erigon-lib/txpool/fetch_test.go
@@ -67,7 +67,7 @@ func TestFetch(t *testing.T) {
 	})
 	for i, err := range errs {
 		if err != nil {
-			t.Errorf("sending new pool tx hashes 66 (%d): %v", i, err)
+			t.Errorf("sending new pool txn hashes 66 (%d): %v", i, err)
 		}
 	}
 	wg.Wait()

--- a/eth/stagedsync/stage_mining_exec.go
+++ b/eth/stagedsync/stage_mining_exec.go
@@ -285,7 +285,7 @@ func getNextTransactions(
 		var sender libcommon.Address
 		copy(sender[:], txSlots.Senders.At(i))
 
-		// Check if tx nonce is too low
+		// Check if txn nonce is too low
 		txs = append(txs, transaction)
 		txs[len(txs)-1].SetSender(sender)
 	}

--- a/eth/stagedsync/stage_senders.go
+++ b/eth/stagedsync/stage_senders.go
@@ -342,7 +342,7 @@ func recoverSenders(ctx context.Context, logPrefix string, cryptoContext *secp25
 		body := job.body
 		signer := types.MakeSigner(config, job.blockNumber, job.blockTime)
 		job.senders = make([]byte, len(body.Transactions)*length.Addr)
-		for i, tx := range body.Transactions {
+		for i, txn := range body.Transactions {
 			from, err := signer.SenderWithContext(cryptoContext, tx)
 			if err != nil {
 				job.err = fmt.Errorf("%w: error recovering sender for tx=%x, %v",

--- a/eth/stagedsync/stage_senders.go
+++ b/eth/stagedsync/stage_senders.go
@@ -343,10 +343,10 @@ func recoverSenders(ctx context.Context, logPrefix string, cryptoContext *secp25
 		signer := types.MakeSigner(config, job.blockNumber, job.blockTime)
 		job.senders = make([]byte, len(body.Transactions)*length.Addr)
 		for i, txn := range body.Transactions {
-			from, err := signer.SenderWithContext(cryptoContext, tx)
+			from, err := signer.SenderWithContext(cryptoContext, txn)
 			if err != nil {
 				job.err = fmt.Errorf("%w: error recovering sender for tx=%x, %v",
-					consensus.ErrInvalidBlock, tx.Hash(), err)
+					consensus.ErrInvalidBlock, txn.Hash(), err)
 				break
 			}
 			copy(job.senders[i*length.Addr:], from[:])

--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -555,7 +555,7 @@ func (s *Service) assembleBlockStats(block *types.Block, td *big.Int) *blockStat
 	// Gather the block infos from the local blockchain
 	txs := make([]txStats, 0, len(block.Transactions()))
 	for _, txn := range block.Transactions() {
-		txs = append(txs, txStats{tx.Hash()})
+		txs = append(txs, txStats{txn.Hash()})
 	}
 
 	return &blockStats{

--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -554,7 +554,7 @@ func (s *Service) assembleBlockStats(block *types.Block, td *big.Int) *blockStat
 	}
 	// Gather the block infos from the local blockchain
 	txs := make([]txStats, 0, len(block.Transactions()))
-	for _, tx := range block.Transactions() {
+	for _, txn := range block.Transactions() {
 		txs = append(txs, txStats{tx.Hash()})
 	}
 

--- a/tests/bor/mining_test.go
+++ b/tests/bor/mining_test.go
@@ -113,7 +113,7 @@ func TestMiningBenchmark(t *testing.T) {
 
 	start := time.Now()
 
-	for _, tx := range txs {
+	for _, txn := range txs {
 		buf := bytes.NewBuffer(nil)
 		txV := *tx
 		err := txV.MarshalBinary(buf)
@@ -144,7 +144,7 @@ func TestMiningBenchmark(t *testing.T) {
 
 // newRandomTxWithNonce creates a new transaction with the given nonce.
 func newRandomTxWithNonce(creation bool, nonce uint64, txPool txpool_proto.TxpoolServer) *types.Transaction {
-	var tx types.Transaction
+	var txn types.Transaction
 
 	gasPrice := uint256.NewInt(100 * params.InitialBaseFee)
 

--- a/tests/bor/mining_test.go
+++ b/tests/bor/mining_test.go
@@ -107,15 +107,15 @@ func TestMiningBenchmark(t *testing.T) {
 	initNonce := uint64(0)
 
 	for i := 0; i < txInTxpool; i++ {
-		tx := *newRandomTxWithNonce(false, initNonce+uint64(i), ethbackends[0].TxpoolServer())
-		txs = append(txs, &tx)
+		txn := *newRandomTxWithNonce(false, initNonce+uint64(i), ethbackends[0].TxpoolServer())
+		txs = append(txs, &txn)
 	}
 
 	start := time.Now()
 
 	for _, txn := range txs {
 		buf := bytes.NewBuffer(nil)
-		txV := *tx
+		txV := *txn
 		err := txV.MarshalBinary(buf)
 		if err != nil {
 			panic(err)
@@ -150,10 +150,10 @@ func newRandomTxWithNonce(creation bool, nonce uint64, txPool txpool_proto.Txpoo
 
 	if creation {
 		nonce, _ := txPool.Nonce(context.Background(), &txpool_proto.NonceRequest{Address: gointerfaces.ConvertAddressToH160(addr1)})
-		tx, _ = types.SignTx(types.NewContractCreation(nonce.Nonce, uint256.NewInt(0), testGas, gasPrice, common.FromHex(testCode)), *types.LatestSignerForChainID(nil), pkey1)
+		txn, _ = types.SignTx(types.NewContractCreation(nonce.Nonce, uint256.NewInt(0), testGas, gasPrice, common.FromHex(testCode)), *types.LatestSignerForChainID(nil), pkey1)
 	} else {
-		tx, _ = types.SignTx(types.NewTransaction(nonce, addr2, uint256.NewInt(1000), params.TxGas, gasPrice, nil), *types.LatestSignerForChainID(nil), pkey1)
+		txn, _ = types.SignTx(types.NewTransaction(nonce, addr2, uint256.NewInt(1000), params.TxGas, gasPrice, nil), *types.LatestSignerForChainID(nil), pkey1)
 	}
 
-	return &tx
+	return &txn
 }

--- a/tests/statedb_insert_chain_transaction_test.go
+++ b/tests/statedb_insert_chain_transaction_test.go
@@ -749,23 +749,23 @@ func GenerateBlocks(t *testing.T, gspec *types.Genesis, txs map[int]txn) (*mock.
 		signer := types.LatestSignerForChainID(nil)
 
 		if txToSend, ok := txs[i]; ok {
-			tx, isContractCall = txToSend.txFn(block, contractBackend)
+			txn, isContractCall = txToSend.txFn(block, contractBackend)
 			var err error
-			tx, err = types.SignTx(tx, *signer, txToSend.key)
+			txn, err = types.SignTx(txn, *signer, txToSend.key)
 			if err != nil {
 				return
 			}
 		}
 
-		if tx != nil {
+		if txn != nil {
 			if !isContractCall {
-				err := contractBackend.SendTransaction(context.Background(), tx)
+				err := contractBackend.SendTransaction(context.Background(), txn)
 				if err != nil {
 					return
 				}
 			}
 
-			block.AddTx(tx)
+			block.AddTx(txn)
 		}
 
 		contractBackend.Commit()

--- a/tests/statedb_insert_chain_transaction_test.go
+++ b/tests/statedb_insert_chain_transaction_test.go
@@ -744,7 +744,7 @@ func GenerateBlocks(t *testing.T, gspec *types.Genesis, txs map[int]txn) (*mock.
 	contractBackend := backends.NewTestSimulatedBackendWithConfig(t, gspec.Alloc, gspec.Config, gspec.GasLimit)
 
 	chain, err := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, len(txs), func(i int, block *core.BlockGen) {
-		var tx types.Transaction
+		var txn types.Transaction
 		var isContractCall bool
 		signer := types.LatestSignerForChainID(nil)
 

--- a/turbo/adapter/ethapi/api.go
+++ b/turbo/adapter/ethapi/api.go
@@ -336,7 +336,7 @@ func RPCMarshalBlockExDeprecated(block *types.Block, inclTx bool, fullTx bool, b
 		txs := block.Transactions()
 		transactions := make([]interface{}, len(txs), len(txs)+1)
 		var err error
-		for i, tx := range txs {
+		for i, txn := range txs {
 			if transactions[i], err = formatTx(tx, i); err != nil {
 				return nil, err
 			}
@@ -554,7 +554,7 @@ func newRPCTransactionFromBlockIndex(b *types.Block, index uint64) *RPCTransacti
 */
 
 // newRPCTransactionFromBlockAndTxGivenIndex returns a transaction that will serialize to the RPC representation.
-func newRPCTransactionFromBlockAndTxGivenIndex(b *types.Block, tx types.Transaction, index uint64) *RPCTransaction {
+func newRPCTransactionFromBlockAndTxGivenIndex(b *types.Block, txn types.Transaction, index uint64) *RPCTransaction {
 	return newRPCTransaction(tx, b.Hash(), b.NumberU64(), index, b.BaseFee())
 }
 
@@ -581,7 +581,7 @@ func newRPCRawTransactionFromBlockIndex(b *types.Block, index uint64) hexutil.By
 /*
 // newRPCTransactionFromBlockHash returns a transaction that will serialize to the RPC representation.
 func newRPCTransactionFromBlockHash(b *types.Block, hash libcommon.Hash) *RPCTransaction {
-	for idx, tx := range b.Transactions() {
+	for idx, txn := range b.Transactions() {
 		if tx.Hash() == hash {
 			return newRPCTransactionFromBlockIndex(b, uint64(idx))
 		}
@@ -682,11 +682,11 @@ func (s *PublicTransactionPoolAPI) GetTransactionByHash(ctx context.Context, has
 	if err != nil {
 		return nil, err
 	}
-	if tx != nil {
+	if txn != nil {
 		return newRPCTransaction(tx, blockHash, blockNumber, index), nil
 	}
 	// No finalized transaction, try to retrieve it from the pool
-	if tx := s.b.GetPoolTransaction(hash); tx != nil {
+	if txn := s.b.GetPoolTransaction(hash); txn != nil {
 		return newRPCPendingTransaction(tx), nil
 	}
 
@@ -701,8 +701,8 @@ func (s *PublicTransactionPoolAPI) GetRawTransactionByHash(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	if tx == nil {
-		if tx = s.b.GetPoolTransaction(hash); tx == nil {
+	if txn == nil {
+		if txn = s.b.GetPoolTransaction(hash); txn == nil {
 			// Transaction not found anywhere, abort
 			return nil, nil
 		}
@@ -790,7 +790,7 @@ type SendTxArgs struct {
 	ChainID    *hexutil.Big      `json:"chainId,omitempty"`
 }
 
-// setDefaults fills in default values for unspecified tx fields.
+// setDefaults fills in default values for unspecified txn fields.
 func (args *SendTxArgs) setDefaults(ctx context.Context, b Backend) error {
 	if args.GasPrice == nil {
 		price, err := b.SuggestPrice(ctx)
@@ -866,7 +866,7 @@ func (args *SendTxArgs) toTransaction() types.Transaction {
 		input = *args.Data
 	}
 
-	var tx types.Transaction
+	var txn types.Transaction
 	gasPrice, _ := uint256.FromBig((*big.Int)(args.GasPrice))
 	value, _ := uint256.FromBig((*big.Int)(args.Value))
 	if args.AccessList == nil {
@@ -918,8 +918,8 @@ func (args *SendTxArgs) toTransaction() types.Transaction {
 	return tx
 }
 
-// SubmitTransaction is a helper function that submits tx to txPool and logs a message.
-func SubmitTransaction(ctx context.Context, b Backend, tx types.Transaction) (libcommon.Hash, error) {
+// SubmitTransaction is a helper function that submits txn to txPool and logs a message.
+func SubmitTransaction(ctx context.Context, b Backend, txn types.Transaction) (libcommon.Hash, error) {
 	// If the transaction fee cap is already specified, ensure the
 	// fee of the given transaction is _reasonable_.
 	if err := checkTxFee(tx.GetPrice().ToBig(), tx.GetGas(), b.RPCTxFeeCap()); err != nil {
@@ -932,7 +932,7 @@ func SubmitTransaction(ctx context.Context, b Backend, tx types.Transaction) (li
 	if err := b.SendTx(ctx, tx); err != nil {
 		return libcommon.Hash{}, err
 	}
-	// Print a log with full tx details for manual investigations and interventions
+	// Print a log with full txn details for manual investigations and interventions
 	signer := types.MakeSigner(b.ChainConfig(), b.CurrentBlock().Number().Uint64())
 	from, err := tx.Sender(*signer)
 	if err != nil {

--- a/turbo/adapter/ethapi/api.go
+++ b/turbo/adapter/ethapi/api.go
@@ -337,7 +337,7 @@ func RPCMarshalBlockExDeprecated(block *types.Block, inclTx bool, fullTx bool, b
 		transactions := make([]interface{}, len(txs), len(txs)+1)
 		var err error
 		for i, txn := range txs {
-			if transactions[i], err = formatTx(tx, i); err != nil {
+			if transactions[i], err = formatTx(txn, i); err != nil {
 				return nil, err
 			}
 		}
@@ -555,7 +555,7 @@ func newRPCTransactionFromBlockIndex(b *types.Block, index uint64) *RPCTransacti
 
 // newRPCTransactionFromBlockAndTxGivenIndex returns a transaction that will serialize to the RPC representation.
 func newRPCTransactionFromBlockAndTxGivenIndex(b *types.Block, txn types.Transaction, index uint64) *RPCTransaction {
-	return newRPCTransaction(tx, b.Hash(), b.NumberU64(), index, b.BaseFee())
+	return newRPCTransaction(txn, b.Hash(), b.NumberU64(), index, b.BaseFee())
 }
 
 /*

--- a/turbo/execution/eth1/block_building.go
+++ b/turbo/execution/eth1/block_building.go
@@ -171,10 +171,10 @@ func (e *EthereumExecutionModule) GetAssembledBlock(ctx context.Context, req *ex
 
 	blobsBundle := &types2.BlobsBundleV1{}
 	for i, txn := range block.Transactions() {
-		if tx.Type() != types.BlobTxType {
+		if txn.Type() != types.BlobTxType {
 			continue
 		}
-		blobTx, ok := tx.(*types.BlobTxWrapper)
+		blobTx, ok := txn.(*types.BlobTxWrapper)
 		if !ok {
 			return nil, fmt.Errorf("expected blob transaction to be type BlobTxWrapper, got: %T", blobTx)
 		}

--- a/turbo/execution/eth1/block_building.go
+++ b/turbo/execution/eth1/block_building.go
@@ -170,7 +170,7 @@ func (e *EthereumExecutionModule) GetAssembledBlock(ctx context.Context, req *ex
 	blockValue := blockValue(blockWithReceipts, baseFee)
 
 	blobsBundle := &types2.BlobsBundleV1{}
-	for i, tx := range block.Transactions() {
+	for i, txn := range block.Transactions() {
 		if tx.Type() != types.BlobTxType {
 			continue
 		}

--- a/turbo/jsonrpc/eth_filters.go
+++ b/turbo/jsonrpc/eth_filters.go
@@ -92,7 +92,7 @@ func (api *APIImpl) GetFilterChanges(_ context.Context, index string) ([]any, er
 	}
 	if txs, ok := api.filters.ReadPendingTxs(rpchelper.PendingTxsSubID(cutIndex)); ok {
 		if len(txs) > 0 {
-			for _, tx := range txs[0] {
+			for _, txn := range txs[0] {
 				stub = append(stub, tx.Hash())
 			}
 			return stub, nil

--- a/turbo/jsonrpc/eth_filters.go
+++ b/turbo/jsonrpc/eth_filters.go
@@ -93,7 +93,7 @@ func (api *APIImpl) GetFilterChanges(_ context.Context, index string) ([]any, er
 	if txs, ok := api.filters.ReadPendingTxs(rpchelper.PendingTxsSubID(cutIndex)); ok {
 		if len(txs) > 0 {
 			for _, txn := range txs[0] {
-				stub = append(stub, tx.Hash())
+				stub = append(stub, txn.Hash())
 			}
 			return stub, nil
 		}

--- a/turbo/jsonrpc/otterscan_api.go
+++ b/turbo/jsonrpc/otterscan_api.go
@@ -402,7 +402,7 @@ func (api *OtterscanAPIImpl) GetBlockTransactions(ctx context.Context, number rp
 		prunedBlock[k] = getBlockRes[k]
 	}
 
-	// Crop tx input to 4bytes
+	// Crop txn input to 4bytes
 	var txs = getBlockRes["transactions"].([]interface{})
 	for _, rawTx := range txs {
 		rpcTx := rawTx.(*ethapi.RPCTransaction)

--- a/turbo/jsonrpc/otterscan_contract_creator.go
+++ b/turbo/jsonrpc/otterscan_contract_creator.go
@@ -164,7 +164,7 @@ func (api *OtterscanAPIImpl) GetContractCreator(ctx context.Context, addr common
 		txIndex = (idx + int(prevTxnID)) - int(minTxNum) - 1
 	}
 
-	// Trace block, find tx and contract creator
+	// Trace block, find txn and contract creator
 	tracer := NewCreateTracer(ctx, addr)
 	if err := api.genericTracer(tx, ctx, bn, creationTxnID, txIndex, chainConfig, tracer); err != nil {
 		return nil, err

--- a/turbo/jsonrpc/otterscan_generic_tracer.go
+++ b/turbo/jsonrpc/otterscan_generic_tracer.go
@@ -38,7 +38,7 @@ func (api *OtterscanAPIImpl) genericTracer(dbtx kv.Tx, ctx context.Context, bloc
 		return err
 	}
 	if txn == nil {
-		log.Warn("[rpc genericTracer] tx is nil", "blockNum", blockNum, "txIndex", txIndex)
+		log.Warn("[rpc genericTracer] txn is nil", "blockNum", blockNum, "txIndex", txIndex)
 		return nil
 	}
 	_, err = executor.ExecTxn(txnID, txIndex, txn)

--- a/turbo/jsonrpc/otterscan_search_trace.go
+++ b/turbo/jsonrpc/otterscan_search_trace.go
@@ -81,7 +81,7 @@ func (api *OtterscanAPIImpl) traceBlock(dbtx kv.Tx, ctx context.Context, blockNu
 	header := block.Header()
 	rules := chainConfig.Rules(block.NumberU64(), header.Time)
 	found := false
-	for idx, tx := range block.Transactions() {
+	for idx, txn := range block.Transactions() {
 		select {
 		case <-ctx.Done():
 			return false, nil, ctx.Err()

--- a/turbo/jsonrpc/otterscan_search_trace.go
+++ b/turbo/jsonrpc/otterscan_search_trace.go
@@ -87,16 +87,16 @@ func (api *OtterscanAPIImpl) traceBlock(dbtx kv.Tx, ctx context.Context, blockNu
 			return false, nil, ctx.Err()
 		default:
 		}
-		ibs.SetTxContext(tx.Hash(), block.Hash(), idx)
+		ibs.SetTxContext(txn.Hash(), block.Hash(), idx)
 
-		msg, _ := tx.AsMessage(*signer, header.BaseFee, rules)
+		msg, _ := txn.AsMessage(*signer, header.BaseFee, rules)
 
 		tracer := NewTouchTracer(searchAddr)
 		BlockContext := core.NewEVMBlockContext(header, core.GetHashFn(header, getHeader), engine, nil, chainConfig)
 		TxContext := core.NewEVMTxContext(msg)
 
 		vmenv := vm.NewEVM(BlockContext, TxContext, ibs, chainConfig, vm.Config{Debug: true, Tracer: tracer})
-		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.GetGas()).AddBlobGas(tx.GetBlobGas()), true /* refunds */, false /* gasBailout */); err != nil {
+		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(txn.GetGas()).AddBlobGas(txn.GetBlobGas()), true /* refunds */, false /* gasBailout */); err != nil {
 			return false, nil, err
 		}
 		_ = ibs.FinalizeTx(rules, cachedWriter)
@@ -110,8 +110,8 @@ func (api *OtterscanAPIImpl) traceBlock(dbtx kv.Tx, ctx context.Context, blockNu
 				}
 				return false, nil, fmt.Errorf("requested receipt idx %d, but have only %d", idx, len(blockReceipts)) // otherwise return some error for debugging
 			}
-			rpcTx := NewRPCTransaction(tx, block.Hash(), blockNum, uint64(idx), block.BaseFee())
-			mReceipt := ethutils.MarshalReceipt(blockReceipts[idx], tx, chainConfig, block.HeaderNoCopy(), tx.Hash(), true)
+			rpcTx := NewRPCTransaction(txn, block.Hash(), blockNum, uint64(idx), block.BaseFee())
+			mReceipt := ethutils.MarshalReceipt(blockReceipts[idx], txn, chainConfig, block.HeaderNoCopy(), txn.Hash(), true)
 			mReceipt["timestamp"] = block.Time()
 			rpcTxs = append(rpcTxs, rpcTx)
 			receipts = append(receipts, mReceipt)

--- a/turbo/jsonrpc/otterscan_transaction_by_sender_and_nonce.go
+++ b/turbo/jsonrpc/otterscan_transaction_by_sender_and_nonce.go
@@ -135,7 +135,7 @@ func (api *OtterscanAPIImpl) GetTransactionBySenderAndNonce(ctx context.Context,
 		return nil, err
 	}
 	if txn == nil {
-		log.Warn("[rpc] tx is nil", "blockNum", bn, "txIndex", txIndex)
+		log.Warn("[rpc] txn is nil", "blockNum", bn, "txIndex", txIndex)
 		return nil, nil
 	}
 	found := txn.GetNonce() == nonce

--- a/turbo/jsonrpc/overlay_api.go
+++ b/turbo/jsonrpc/overlay_api.go
@@ -104,7 +104,7 @@ func (api *OverlayAPIImpl) CallConstructor(ctx context.Context, address common.A
 	}
 
 	if !ok {
-		return nil, fmt.Errorf("contract construction tx not found")
+		return nil, fmt.Errorf("contract construction txn not found")
 	}
 
 	err = api.BaseAPI.checkPruneHistory(tx, blockNum)
@@ -128,7 +128,7 @@ func (api *OverlayAPIImpl) CallConstructor(ctx context.Context, address common.A
 	}
 
 	if transactionIndex == -1 {
-		return nil, fmt.Errorf("could not find tx hash")
+		return nil, fmt.Errorf("could not find txn hash")
 	}
 
 	replayTransactions = block.Transactions()[:transactionIndex]
@@ -481,7 +481,7 @@ func (api *OverlayAPIImpl) replayBlock(ctx context.Context, blockNum uint64, sta
 
 		receipt := receipts[uint64(idx)]
 		log.Debug("[replayBlock]", "receipt.TransactionIndex", receipt.TransactionIndex, "receipt.TxHash", receipt.TxHash, "receipt.Status", receipt.Status)
-		// check if this tx has failed in the original context
+		// check if this txn has failed in the original context
 		if receipt.Status == types.ReceiptStatusFailed {
 			log.Debug("[replayBlock] skipping transaction because it has status=failed", "transactionHash", txn.Hash())
 
@@ -519,9 +519,9 @@ func (api *OverlayAPIImpl) replayBlock(ctx context.Context, blockNum uint64, sta
 
 		if res.Failed() {
 			log.Debug("[replayBlock] res result for transaction", "transactionHash", txn.Hash(), "failed", res.Failed(), "revert", res.Revert(), "error", res.Err)
-			log.Debug("[replayBlock] discarding txLogs because tx has status=failed", "transactionHash", txn.Hash())
+			log.Debug("[replayBlock] discarding txLogs because txn has status=failed", "transactionHash", txn.Hash())
 		} else {
-			//append logs only if tx has not reverted
+			//append logs only if txn has not reverted
 			txLogs := statedb.GetLogs(txn.Hash())
 			log.Debug("[replayBlock]", "len(txLogs)", len(txLogs), "transactionHash", txn.Hash())
 			blockLogs = append(blockLogs, txLogs...)

--- a/turbo/jsonrpc/send_transaction_test.go
+++ b/turbo/jsonrpc/send_transaction_test.go
@@ -113,7 +113,7 @@ func TestSendRawTransaction(t *testing.T) {
 		require.Equal(expectedValue, jsonTx.Value.Uint64())
 	}
 
-	//send same tx second time and expect error
+	//send same txn second time and expect error
 	_, err = api.SendRawTransaction(ctx, buf.Bytes())
 	require.NotNil(err)
 	expectedErr := txpool_proto.ImportResult_name[int32(txpool_proto.ImportResult_ALREADY_EXISTS)] + ": " + txpoolcfg.AlreadyKnown.String()

--- a/turbo/jsonrpc/trace_adhoc.go
+++ b/turbo/jsonrpc/trace_adhoc.go
@@ -855,7 +855,7 @@ func (api *TraceAPIImpl) ReplayBlockTransactions(ctx context.Context, blockNrOrH
 
 	signer := types.MakeSigner(chainConfig, blockNumber, block.Time())
 	// Returns an array of trace arrays, one trace array for each transaction
-	traces, _, err := api.callManyTransactions(ctx, tx, block, traceTypes, -1 /* all tx indices */, *gasBailOut, signer, chainConfig)
+	traces, _, err := api.callManyTransactions(ctx, tx, block, traceTypes, -1 /* all txn indices */, *gasBailOut, signer, chainConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -1097,7 +1097,7 @@ func (api *TraceAPIImpl) CallMany(ctx context.Context, calls json.RawMessage, pa
 			return nil, fmt.Errorf("convert callParam to msg: %w", err)
 		}
 	}
-	results, _, err := api.doCallMany(ctx, dbtx, msgs, callParams, parentNrOrHash, nil, true /* gasBailout */, -1 /* all tx indices */)
+	results, _, err := api.doCallMany(ctx, dbtx, msgs, callParams, parentNrOrHash, nil, true /* gasBailout */, -1 /* all txn indices */)
 	return results, err
 }
 

--- a/turbo/jsonrpc/trace_filtering.go
+++ b/turbo/jsonrpc/trace_filtering.go
@@ -192,7 +192,7 @@ func (api *TraceAPIImpl) Block(ctx context.Context, blockNr rpc.BlockNumber, gas
 		return nil, err
 	}
 	signer := types.MakeSigner(cfg, blockNum, block.Time())
-	traces, syscall, err := api.callManyTransactions(ctx, tx, block, []string{TraceTypeTrace}, -1 /* all tx indices */, *gasBailOut /* gasBailOut */, signer, cfg)
+	traces, syscall, err := api.callManyTransactions(ctx, tx, block, []string{TraceTypeTrace}, -1 /* all txn indices */, *gasBailOut /* gasBailOut */, signer, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -735,8 +735,8 @@ func (api *TraceAPIImpl) callManyTransactions(
 	}
 
 	msgs := make([]types.Message, len(txs))
-	for i, tx := range txs {
-		isBorStateSyncTxn := tx == borStateSyncTxn
+	for i, txn := range txs {
+		isBorStateSyncTxn := txn == borStateSyncTxn
 		var txnHash common.Hash
 		var msg types.Message
 		var err error
@@ -747,7 +747,7 @@ func (api *TraceAPIImpl) callManyTransactions(
 			txnHash = tx.Hash()
 			msg, err = tx.AsMessage(*signer, header.BaseFee, rules)
 			if err != nil {
-				return nil, nil, fmt.Errorf("convert tx into msg: %w", err)
+				return nil, nil, fmt.Errorf("convert txn into msg: %w", err)
 			}
 
 			// gnosis might have a fee free account here

--- a/turbo/jsonrpc/trace_filtering.go
+++ b/turbo/jsonrpc/trace_filtering.go
@@ -744,8 +744,8 @@ func (api *TraceAPIImpl) callManyTransactions(
 			txnHash = borStateSyncTxnHash
 			// we use an empty message for bor state sync txn since it gets handled differently
 		} else {
-			txnHash = tx.Hash()
-			msg, err = tx.AsMessage(*signer, header.BaseFee, rules)
+			txnHash = txn.Hash()
+			msg, err = txn.AsMessage(*signer, header.BaseFee, rules)
 			if err != nil {
 				return nil, nil, fmt.Errorf("convert txn into msg: %w", err)
 			}

--- a/turbo/jsonrpc/trace_types.go
+++ b/turbo/jsonrpc/trace_types.go
@@ -157,7 +157,7 @@ func (t ParityTrace) String() string {
 
 // Takes a hierarchical Geth trace with fields of different meaning stored in the same named fields depending on 'type'. Parity traces
 // are flattened depth first and each field is put in its proper place
-func (api *TraceAPIImpl) convertToParityTrace(gethTrace GethTrace, blockHash common.Hash, blockNumber uint64, tx types.Transaction, txIndex uint64, depth []int) ParityTraces { //nolint: unused
+func (api *TraceAPIImpl) convertToParityTrace(gethTrace GethTrace, blockHash common.Hash, blockNumber uint64, txn types.Transaction, txIndex uint64, depth []int) ParityTraces { //nolint: unused
 	var traces ParityTraces // nolint prealloc
 	return traces
 }

--- a/turbo/jsonrpc/tracing.go
+++ b/turbo/jsonrpc/tracing.go
@@ -267,7 +267,7 @@ func (api *PrivateDebugAPIImpl) TraceTransaction(ctx context.Context, hash commo
 	}
 	if txn == nil {
 		if isBorStateSyncTxn {
-			// bor state sync tx is appended at the end of the block
+			// bor state sync txn is appended at the end of the block
 			txnIndex = block.Transactions().Len()
 		} else {
 			stream.WriteNil()

--- a/turbo/jsonrpc/txpool_api.go
+++ b/turbo/jsonrpc/txpool_api.go
@@ -222,7 +222,7 @@ func (s *PublicTxPoolAPI) Inspect() map[string]map[string]map[string]string {
 	// Flatten the pending transactions
 	for account, txs := range pending {
 		dump := make(map[string]string)
-		for _, tx := range txs {
+		for _, txn := range txs {
 			dump[fmt.Sprintf("%d", tx.Nonce())] = format(tx)
 		}
 		content["pending"][account.Hex()] = dump
@@ -230,7 +230,7 @@ func (s *PublicTxPoolAPI) Inspect() map[string]map[string]map[string]string {
 	// Flatten the queued transactions
 	for account, txs := range queue {
 		dump := make(map[string]string)
-		for _, tx := range txs {
+		for _, txn := range txs {
 			dump[fmt.Sprintf("%d", tx.Nonce())] = format(tx)
 		}
 		content["queued"][account.Hex()] = dump

--- a/turbo/mock/txpool.go
+++ b/turbo/mock/txpool.go
@@ -51,7 +51,7 @@ func (p *TestTxPool) add(txs []types.Transaction) {
 	defer p.lock.Unlock()
 
 	for _, txn := range txs {
-		p.pool[tx.Hash()] = tx
+		p.pool[txn.Hash()] = txn
 	}
 	p.txFeed.Send(core.NewTxsEvent{Txs: txs})
 }
@@ -75,8 +75,8 @@ func (p *TestTxPool) Pending() (types.TransactionsGroupedBySender, error) {
 
 	batches := make(map[libcommon.Address]types.Transactions)
 	for _, txn := range p.pool {
-		from, _ := tx.Sender(*types.LatestSignerForChainID(nil))
-		batches[from] = append(batches[from], tx)
+		from, _ := txn.Sender(*types.LatestSignerForChainID(nil))
+		batches[from] = append(batches[from], txn)
 	}
 	groups := types.TransactionsGroupedBySender{}
 	for _, batch := range batches {
@@ -93,8 +93,8 @@ func (p *TestTxPool) Content() (map[libcommon.Address]types.Transactions, map[li
 
 	batches := make(map[libcommon.Address]types.Transactions)
 	for _, txn := range p.pool {
-		from, _ := tx.Sender(*types.LatestSignerForChainID(nil))
-		batches[from] = append(batches[from], tx)
+		from, _ := txn.Sender(*types.LatestSignerForChainID(nil))
+		batches[from] = append(batches[from], txn)
 	}
 	return batches, nil
 }

--- a/turbo/mock/txpool.go
+++ b/turbo/mock/txpool.go
@@ -38,7 +38,7 @@ func (p *TestTxPool) Has(hash libcommon.Hash) bool {
 }
 
 // Get retrieves the transaction from local txpool with given
-// tx hash.
+// txn hash.
 func (p *TestTxPool) Get(hash libcommon.Hash) types.Transaction {
 	p.lock.Lock()
 	defer p.lock.Unlock()
@@ -50,7 +50,7 @@ func (p *TestTxPool) add(txs []types.Transaction) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	for _, tx := range txs {
+	for _, txn := range txs {
 		p.pool[tx.Hash()] = tx
 	}
 	p.txFeed.Send(core.NewTxsEvent{Txs: txs})
@@ -74,7 +74,7 @@ func (p *TestTxPool) Pending() (types.TransactionsGroupedBySender, error) {
 	defer p.lock.RUnlock()
 
 	batches := make(map[libcommon.Address]types.Transactions)
-	for _, tx := range p.pool {
+	for _, txn := range p.pool {
 		from, _ := tx.Sender(*types.LatestSignerForChainID(nil))
 		batches[from] = append(batches[from], tx)
 	}
@@ -92,7 +92,7 @@ func (p *TestTxPool) Content() (map[libcommon.Address]types.Transactions, map[li
 	defer p.lock.RUnlock()
 
 	batches := make(map[libcommon.Address]types.Transactions)
-	for _, tx := range p.pool {
+	for _, txn := range p.pool {
 		from, _ := tx.Sender(*types.LatestSignerForChainID(nil))
 		batches[from] = append(batches[from], tx)
 	}

--- a/turbo/rpchelper/filters_test.go
+++ b/turbo/rpchelper/filters_test.go
@@ -443,7 +443,7 @@ func TestFilters_AddPendingTxs(t *testing.T) {
 			config := FiltersConfig{RpcSubscriptionFiltersMaxTxs: tt.maxTxs}
 			f := New(context.TODO(), config, nil, nil, nil, func() {}, log.New())
 			txID := PendingTxsSubID("test-tx")
-			var tx types.Transaction = types.NewTransaction(0, libcommon.HexToAddress("095e7baea6a6c7c4c2dfeb977efac326af552d87"), uint256.NewInt(10), 50000, uint256.NewInt(10), nil)
+			var txn types.Transaction = types.NewTransaction(0, libcommon.HexToAddress("095e7baea6a6c7c4c2dfeb977efac326af552d87"), uint256.NewInt(10), 50000, uint256.NewInt(10), nil)
 			tx, _ = tx.WithSignature(*types.LatestSignerForChainID(nil), libcommon.Hex2Bytes("9bea4c4daac7c7c52e093e6a4c35dbbcf8856f1af7b059ba20253e70848d094f8a8fae537ce25ed8cb5af9adac3f141af69bd515bd2ba031522df09b97dd72b100"))
 
 			// Testing for panic

--- a/turbo/rpchelper/filters_test.go
+++ b/turbo/rpchelper/filters_test.go
@@ -444,7 +444,7 @@ func TestFilters_AddPendingTxs(t *testing.T) {
 			f := New(context.TODO(), config, nil, nil, nil, func() {}, log.New())
 			txID := PendingTxsSubID("test-tx")
 			var txn types.Transaction = types.NewTransaction(0, libcommon.HexToAddress("095e7baea6a6c7c4c2dfeb977efac326af552d87"), uint256.NewInt(10), 50000, uint256.NewInt(10), nil)
-			tx, _ = tx.WithSignature(*types.LatestSignerForChainID(nil), libcommon.Hex2Bytes("9bea4c4daac7c7c52e093e6a4c35dbbcf8856f1af7b059ba20253e70848d094f8a8fae537ce25ed8cb5af9adac3f141af69bd515bd2ba031522df09b97dd72b100"))
+			txn, _ = txn.WithSignature(*types.LatestSignerForChainID(nil), libcommon.Hex2Bytes("9bea4c4daac7c7c52e093e6a4c35dbbcf8856f1af7b059ba20253e70848d094f8a8fae537ce25ed8cb5af9adac3f141af69bd515bd2ba031522df09b97dd72b100"))
 
 			// Testing for panic
 			if tt.name == "TriggerPanic" {
@@ -457,23 +457,23 @@ func TestFilters_AddPendingTxs(t *testing.T) {
 				// Add transactions to trigger panic
 				// Initial batch to set the stage
 				for i := 0; i < 4; i++ {
-					f.AddPendingTxs(txID, []types.Transaction{tx})
+					f.AddPendingTxs(txID, []types.Transaction{txn})
 				}
 
 				// Adding more transactions in smaller increments to ensure the panic
 				for i := 0; i < 2; i++ {
-					f.AddPendingTxs(txID, []types.Transaction{tx})
+					f.AddPendingTxs(txID, []types.Transaction{txn})
 				}
 
 				// Adding another large batch to ensure it exceeds the limit and triggers the panic
 				largeBatch := make([]types.Transaction, 10)
 				for i := range largeBatch {
-					largeBatch[i] = tx
+					largeBatch[i] = txn
 				}
 				f.AddPendingTxs(txID, largeBatch)
 			} else {
 				for i := 0; i < tt.numToAdd; i++ {
-					f.AddPendingTxs(txID, []types.Transaction{tx})
+					f.AddPendingTxs(txID, []types.Transaction{txn})
 				}
 
 				txs, found := f.ReadPendingTxs(txID)

--- a/turbo/stages/blockchain_test.go
+++ b/turbo/stages/blockchain_test.go
@@ -2169,9 +2169,9 @@ func TestEIP1559Transition(t *testing.T) {
 				Tip:        u256.Num2,
 				AccessList: accesses,
 			}
-			tx, _ = types.SignTx(tx, *signer, key1)
+			txn, _ = types.SignTx(txn, *signer, key1)
 
-			b.AddTx(tx)
+			b.AddTx(txn)
 		}
 	})
 	if err != nil {
@@ -2219,9 +2219,9 @@ func TestEIP1559Transition(t *testing.T) {
 		b.SetCoinbase(libcommon.Address{2})
 
 		var txn types.Transaction = types.NewTransaction(0, aa, u256.Num0, 30000, new(uint256.Int).Mul(new(uint256.Int).SetUint64(5), new(uint256.Int).SetUint64(params.GWei)), nil)
-		tx, _ = types.SignTx(tx, *signer, key2)
+		txn, _ = types.SignTx(txn, *signer, key2)
 
-		b.AddTx(tx)
+		b.AddTx(txn)
 	})
 	if err != nil {
 		t.Fatalf("generate chain: %v", err)

--- a/turbo/stages/blockchain_test.go
+++ b/turbo/stages/blockchain_test.go
@@ -1381,8 +1381,8 @@ func TestDeleteCreateRevert(t *testing.T) {
 // TestDeleteRecreateSlots tests a state-transition that contains both deletion
 // and recreation of contract state.
 // Contract A exists, has slots 1 and 2 set
-// Tx 1: Selfdestruct A
-// Tx 2: Re-create A, set slots 3 and 4
+// txn 1: Selfdestruct A
+// txn 2: Re-create A, set slots 3 and 4
 // Expected outcome is that _all_ slots are cleared from A, due to the selfdestruct,
 // and then the new slots exist
 func TestDeleteRecreateSlots(t *testing.T) {
@@ -1692,8 +1692,8 @@ func TestDeleteRecreateAccount(t *testing.T) {
 // TestDeleteRecreateSlotsAcrossManyBlocks tests multiple state-transition that contains both deletion
 // and recreation of contract state.
 // Contract A exists, has slots 1 and 2 set
-// Tx 1: Selfdestruct A
-// Tx 2: Re-create A, set slots 3 and 4
+// txn 1: Selfdestruct A
+// txn 2: Re-create A, set slots 3 and 4
 // Expected outcome is that _all_ slots are cleared from A, due to the selfdestruct,
 // and then the new slots exist
 func TestDeleteRecreateSlotsAcrossManyBlocks(t *testing.T) {
@@ -1896,7 +1896,7 @@ func TestDeleteRecreateSlotsAcrossManyBlocks(t *testing.T) {
 //   - Block 7338110: a CREATE2 is attempted. The CREATE2 would deploy code on
 //     the same address e771789f5cccac282f23bb7add5690e1f6ca467c. However, the
 //     deployment fails due to OOG during initcode execution
-//   - Block 7338115: another tx checks the balance of
+//   - Block 7338115: another txn checks the balance of
 //     e771789f5cccac282f23bb7add5690e1f6ca467c, and the snapshotter returned it as
 //     zero.
 //
@@ -2157,7 +2157,7 @@ func TestEIP1559Transition(t *testing.T) {
 
 			var chainID uint256.Int
 			chainID.SetFromBig(gspec.Config.ChainID)
-			var tx types.Transaction = &types.DynamicFeeTransaction{
+			var txn types.Transaction = &types.DynamicFeeTransaction{
 				CommonTx: types.CommonTx{
 					Nonce: 0,
 					To:    &aa,
@@ -2204,7 +2204,7 @@ func TestEIP1559Transition(t *testing.T) {
 			t.Fatalf("miner balance incorrect: expected %d, got %d", expected, actual)
 		}
 
-		// 4: Ensure the tx sender paid for the gasUsed * (tip + block baseFee).
+		// 4: Ensure the txn sender paid for the gasUsed * (tip + block baseFee).
 		actual = new(uint256.Int).Sub(funds, statedb.GetBalance(addr1))
 		expected = new(uint256.Int).SetUint64(block.GasUsed() * (block.Transactions()[0].GetPrice().Uint64() + block.BaseFee().Uint64()))
 		if actual.Cmp(expected) != 0 {
@@ -2218,7 +2218,7 @@ func TestEIP1559Transition(t *testing.T) {
 	chain, err = core.GenerateChain(m.ChainConfig, block, m.Engine, m.DB, 1, func(i int, b *core.BlockGen) {
 		b.SetCoinbase(libcommon.Address{2})
 
-		var tx types.Transaction = types.NewTransaction(0, aa, u256.Num0, 30000, new(uint256.Int).Mul(new(uint256.Int).SetUint64(5), new(uint256.Int).SetUint64(params.GWei)), nil)
+		var txn types.Transaction = types.NewTransaction(0, aa, u256.Num0, 30000, new(uint256.Int).Mul(new(uint256.Int).SetUint64(5), new(uint256.Int).SetUint64(params.GWei)), nil)
 		tx, _ = types.SignTx(tx, *signer, key2)
 
 		b.AddTx(tx)
@@ -2246,7 +2246,7 @@ func TestEIP1559Transition(t *testing.T) {
 			t.Fatalf("miner balance incorrect: expected %d, got %d", expected, actual)
 		}
 
-		// 4: Ensure the tx sender paid for the gasUsed * (effectiveTip + block baseFee).
+		// 4: Ensure the txn sender paid for the gasUsed * (effectiveTip + block baseFee).
 		actual = new(uint256.Int).Sub(funds, statedb.GetBalance(addr2))
 		expected = new(uint256.Int).SetUint64(block.GasUsed() * (effectiveTip + block.BaseFee().Uint64()))
 		if actual.Cmp(expected) != 0 {


### PR DESCRIPTION
We gradually shift to using txn to mean blockchain/ethereum transactions