### PR TITLE
qa-tests: relax requirements for the snap-download test regarding the runner it should run on

### DIFF
--- a/.github/workflows/qa-snap-download.yml
+++ b/.github/workflows/qa-snap-download.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   snap-download-test:
-    runs-on: [self-hosted, Erigon3]
+    runs-on: self-hosted
     timeout-minutes: 800
     env:
       ERIGON_DATA_DIR: ${{ github.workspace }}/erigon_data


### PR DESCRIPTION
snap-download test doesn't require a pre-built db so can run on any self-hosted runner