### PR TITLE
Fix unstable blob_sidecar_service_test issue

### DIFF
--- a/cl/cltypes/blob_sidecar.go
+++ b/cl/cltypes/blob_sidecar.go
@@ -141,6 +141,9 @@ func VerifyCommitmentInclusionProof(commitment libcommon.Bytes48, commitmentIncl
 	commitmentsDepth := uint64(13) // log2(4096) + 1 = 13
 	bIndex := uint64(11)
 
+	if commitmentInclusionProof == nil || commitmentInclusionProof.Length() < bodyDepth+int(commitmentsDepth) {
+		return false
+	}
 	// Start by constructing the commitments subtree
 	for i := uint64(0); i < commitmentsDepth; i++ {
 		curr := commitmentInclusionProof.Get(int(i))

--- a/cl/phase1/network/services/blob_sidecar_service_test.go
+++ b/cl/phase1/network/services/blob_sidecar_service_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ledgerwatch/erigon/cl/beacon/synced_data"
 	"github.com/ledgerwatch/erigon/cl/clparams"
 	"github.com/ledgerwatch/erigon/cl/cltypes"
+	"github.com/ledgerwatch/erigon/cl/cltypes/solid"
 	"github.com/ledgerwatch/erigon/cl/phase1/core/state"
 	"github.com/ledgerwatch/erigon/cl/phase1/forkchoice/mock_services"
 	"github.com/ledgerwatch/erigon/cl/utils"
@@ -40,11 +41,12 @@ func getObjectsForBlobSidecarServiceTests(t *testing.T) (*state.CachingBeaconSta
 	proofBytes := common.Hex2Bytes(proofStr[2:])
 	copy(proof[:], proofBytes)
 	sidecar := &cltypes.BlobSidecar{
-		Index:             uint64(0),
-		SignedBlockHeader: block.SignedBeaconBlockHeader(),
-		Blob:              blob,
-		KzgCommitment:     common.Bytes48(*block.Block.Body.BlobKzgCommitments.Get(0)),
-		KzgProof:          proof,
+		Index:                    uint64(0),
+		SignedBlockHeader:        block.SignedBeaconBlockHeader(),
+		Blob:                     blob,
+		KzgCommitment:            common.Bytes48(*block.Block.Body.BlobKzgCommitments.Get(0)),
+		KzgProof:                 proof,
+		CommitmentInclusionProof: solid.NewHashVector(cltypes.CommitmentBranchSize),
 	}
 	return stateObj, block, sidecar
 }


### PR DESCRIPTION
Fix:
https://github.com/ledgerwatch/erigon/issues/10762
I suspect the root cause is unexpectedly triggering the blobSidecarsScheduledForLaterExecution process loop every 5 milliseconds, which encounters a nil `CommitmentInclusionProof` value.