### PR TITLE
protect domain merging range 

### DIFF
--- a/erigon-lib/state/domain_committed.go
+++ b/erigon-lib/state/domain_committed.go
@@ -182,7 +182,7 @@ func (dt *DomainRoTx) lookupFileByItsRange(txFrom uint64, txTo uint64) *filesIte
 		}
 		dt.d.logger.Warn("lookupFileByItsRange: file not found",
 			"stepFrom", txFrom/dt.d.aggregationStep, "stepTo", txTo/dt.d.aggregationStep,
-			"domain", dt.d.keysTable, "files", fileStepsss, "_visibleFiles", visibleFiles,
+			"domain", dt.d.filenameBase, "files", fileStepsss, "_visibleFiles", visibleFiles,
 			"visibleFilesCount", len(dt.files), "filesCount", dt.d.dirtyFiles.Len())
 		return nil
 	}

--- a/erigon-lib/state/domain_shared.go
+++ b/erigon-lib/state/domain_shared.go
@@ -408,12 +408,12 @@ func (sd *SharedDomains) replaceShortenedKeysInBranch(prefix []byte, branch comm
 	_ = commItem
 	storageItem := sto.lookupFileByItsRange(fStartTxNum, fEndTxNum)
 	if storageItem == nil {
-		sd.logger.Crit("storage file of steps %d-%d not found\n", fStartTxNum/sd.aggTx.a.aggregationStep, fEndTxNum/sd.aggTx.a.aggregationStep)
+		sd.logger.Crit(fmt.Sprintf("storage file of steps %d-%d not found\n", fStartTxNum/sd.aggTx.a.aggregationStep, fEndTxNum/sd.aggTx.a.aggregationStep))
 		return nil, fmt.Errorf("storage file not found")
 	}
 	accountItem := acc.lookupFileByItsRange(fStartTxNum, fEndTxNum)
 	if accountItem == nil {
-		sd.logger.Crit("storage file of steps %d-%d not found\n", fStartTxNum/sd.aggTx.a.aggregationStep, fEndTxNum/sd.aggTx.a.aggregationStep)
+		sd.logger.Crit(fmt.Sprintf("storage file of steps %d-%d not found\n", fStartTxNum/sd.aggTx.a.aggregationStep, fEndTxNum/sd.aggTx.a.aggregationStep))
 		return nil, fmt.Errorf("account file not found")
 	}
 	storageGetter := NewArchiveGetter(storageItem.decompressor.MakeGetter(), sto.d.compression)

--- a/erigon-lib/state/files_item.go
+++ b/erigon-lib/state/files_item.go
@@ -6,6 +6,7 @@ import (
 
 	btree2 "github.com/tidwall/btree"
 
+	"github.com/ledgerwatch/erigon-lib/config3"
 	"github.com/ledgerwatch/erigon-lib/kv/bitmapdb"
 	"github.com/ledgerwatch/erigon-lib/log/v3"
 	"github.com/ledgerwatch/erigon-lib/recsplit"
@@ -248,4 +249,17 @@ func (files visibleFiles) EndTxNum() uint64 {
 		return 0
 	}
 	return files[len(files)-1].endTxNum
+}
+
+func (files visibleFiles) LatestMergedRange() MergeRange {
+	if len(files) == 0 {
+		return MergeRange{}
+	}
+	for i := len(files) - 1; i >= 0; i-- {
+		shardSize := (files[i].endTxNum - files[i].startTxNum) / config3.HistoryV3AggregationStep
+		if shardSize > 2 {
+			return MergeRange{from: files[i].startTxNum, to: files[i].endTxNum}
+		}
+	}
+	return MergeRange{}
 }

--- a/erigon-lib/state/inverted_index.go
+++ b/erigon-lib/state/inverted_index.go
@@ -514,6 +514,10 @@ func (mr *MergeRange) String(prefix string, aggStep uint64) string {
 	return fmt.Sprintf("%s=%d-%d", prefix, mr.from/aggStep, mr.to/aggStep)
 }
 
+func (mr *MergeRange) Equal(other *MergeRange) bool {
+	return mr.from == other.from && mr.to == other.to
+}
+
 type InvertedIndexRoTx struct {
 	ii      *InvertedIndex
 	files   visibleFiles


### PR DESCRIPTION
Depends on #10980
Ensures that merge does not further progress if latest merge ranges are different for commitment/storage/accounts.
Allows to merge if range for required domain has been already merged and file presents on disk/in visible files.
If discrepancy found and no needed files found, whole range gets on hold which allows to continue execution but not merge files any further.

After #10980 it will be able to fetch previously merged account/storage and conclude the merge.