### PR TITLE
fix: txCtx TxHash missing

### DIFF
--- a/turbo/transactions/tracing.go
+++ b/turbo/transactions/tracing.go
@@ -85,7 +85,12 @@ func ComputeTxEnv(ctx context.Context, engine consensus.EngineReader, block *typ
 		msg.SetIsFree(engine.IsServiceTransaction(msg.From(), syscall))
 	}
 
-	TxContext := core.NewEVMTxContext(msg)
+	TxContext := evmtypes.TxContext{
+		TxHash:     txn.Hash(),
+		Origin:     msg.From(),
+		GasPrice:   msg.GasPrice(),
+		BlobHashes: msg.BlobHashes(),
+	}
 	return msg, blockContext, TxContext, statedb, reader, nil
 }
 


### PR DESCRIPTION
`NewEVMTxContext` missed the `TxHash`
https://github.com/ledgerwatch/erigon/blob/4bcfa59f7ebdab9888e13f2fb8344c694a589ea8/core/evm.go#L97-L104
https://github.com/ledgerwatch/erigon/blob/4bcfa59f7ebdab9888e13f2fb8344c694a589ea8/core/vm/evmtypes/evmtypes.go#L58-L64

The `TxHash` will be used in the tracer:
https://github.com/ledgerwatch/erigon/blob/4bcfa59f7ebdab9888e13f2fb8344c694a589ea8/turbo/transactions/tracing.go#L95-L107
