### PR TITLE
eth/tracers: always pop precompiles stack in callTracer

### DIFF
--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -251,8 +251,13 @@ func (t *callTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 		return
 	}
 	precompilesLastIdx := len(t.precompiles) - 1
-	if !t.config.IncludePrecompiles && precompilesLastIdx > -1 && t.precompiles[precompilesLastIdx] {
-		t.precompiles = t.precompiles[:precompilesLastIdx]
+	if precompilesLastIdx < 0 {
+		return
+	}
+	// pop precompile
+	precompile := t.precompiles[precompilesLastIdx]
+	t.precompiles = t.precompiles[:precompilesLastIdx]
+	if precompile && !t.config.IncludePrecompiles {
 		return
 	}
 	// pop call


### PR DESCRIPTION
made a mistake in previous PR https://github.com/ledgerwatch/erigon/pull/10986
should always pop the precompiles stack for correctness