### PR TITLE
Allow to merge commitment separately of other domains

### DIFF
--- a/erigon-lib/state/domain_committed.go
+++ b/erigon-lib/state/domain_committed.go
@@ -224,18 +224,18 @@ func (dt *DomainRoTx) lookupByShortenedKey(shortKey []byte, getter ArchiveGetter
 func (dt *DomainRoTx) commitmentValTransformDomain(rng MergeRange, accounts, storage *DomainRoTx, mergedAccount, mergedStorage *filesItem) (valueTransformer, error) {
 	hadToLookupStorage := mergedStorage == nil
 	if mergedStorage == nil {
-		// mergedStorage = storage.lookupFileByItsRange(rng.from, rng.to)
-		// if mergedStorage == nil {
-		// TODO may allow to merge, but storage keys will be stored as plainkeys
-		return nil, fmt.Errorf("merged v1-account.%d-%d.kv file not found", rng.from, rng.to)
-		// }
+		mergedStorage = storage.lookupFileByItsRange(rng.from, rng.to)
+		if mergedStorage == nil {
+			// TODO may allow to merge, but storage keys will be stored as plainkeys
+			return nil, fmt.Errorf("merged v1-account.%d-%d.kv file not found", rng.from/dt.d.aggregationStep, rng.to/dt.d.aggregationStep)
+		}
 	}
 	hadToLookupAccount := mergedAccount == nil
 	if mergedAccount == nil {
-		// mergedAccount = accounts.lookupFileByItsRange(rng.from, rng.to)
-		// if mergedAccount == nil {
-		return nil, fmt.Errorf("merged v1-account.%d-%d.kv file not found", rng.from, rng.to)
-		// }
+		mergedAccount = accounts.lookupFileByItsRange(rng.from, rng.to)
+		if mergedAccount == nil {
+			return nil, fmt.Errorf("merged v1-account.%d-%d.kv file not found", rng.from/dt.d.aggregationStep, rng.to/dt.d.aggregationStep)
+		}
 	}
 
 	dr := DomainRanges{
@@ -265,8 +265,25 @@ func (dt *DomainRoTx) commitmentValTransformDomain(rng MergeRange, accounts, sto
 		if !dt.d.replaceKeysInValues || len(valBuf) == 0 || ((keyEndTxNum-keyFromTxNum)/dt.d.aggregationStep)%2 != 0 {
 			return valBuf, nil
 		}
-		sig := storageFileMap[fmt.Sprintf("%d-%d", keyFromTxNum, keyEndTxNum)]
-		aig := accountFileMap[fmt.Sprintf("%d-%d", keyFromTxNum, keyEndTxNum)]
+		sig, ok := storageFileMap[fmt.Sprintf("%d-%d", keyFromTxNum, keyEndTxNum)]
+		if !ok {
+			dirty := storage.lookupFileByItsRange(keyFromTxNum, keyEndTxNum)
+			if dirty == nil {
+				return nil, fmt.Errorf("dirty storage file not found %d-%d", keyFromTxNum/dt.d.aggregationStep, keyEndTxNum/dt.d.aggregationStep)
+			}
+			sig = NewArchiveGetter(dirty.decompressor.MakeGetter(), storage.d.compression)
+			storageFileMap[fmt.Sprintf("%d-%d", keyFromTxNum, keyEndTxNum)] = sig
+		}
+
+		aig, ok := accountFileMap[fmt.Sprintf("%d-%d", keyFromTxNum, keyEndTxNum)]
+		if !ok {
+			dirty := accounts.lookupFileByItsRange(keyFromTxNum, keyEndTxNum)
+			if dirty == nil {
+				return nil, fmt.Errorf("dirty account file not found %d-%d", keyFromTxNum/dt.d.aggregationStep, keyEndTxNum/dt.d.aggregationStep)
+			}
+			aig = NewArchiveGetter(dirty.decompressor.MakeGetter(), accounts.d.compression)
+			accountFileMap[fmt.Sprintf("%d-%d", keyFromTxNum, keyEndTxNum)] = aig
+		}
 
 		replacer := func(key []byte, isStorage bool) ([]byte, error) {
 			var found bool


### PR DESCRIPTION
Basically `commitment` waits for `accounts/storage` to be merged to be able to start replacements.
User can cancel execution at any point but for us that point had difference:
 - lucky: if predicate domains has not been merged yet - just start over (including situations when merge is not yet concluded and .kv files are not yet available)
 - unlucky: predicates are done but commitment is not yet finished, after restart commitment does not see required files (those ranges already merged)
 - semi-lucky: small deviations of cases above with Great Random to decide outcome

PR fixes #10729 and should cover #10733 as well since they are highly related.  