### PR TITLE
dl: discover webseeds even if this file type is prohibited by .lock

### DIFF
--- a/erigon-lib/downloader/webseed.go
+++ b/erigon-lib/downloader/webseed.go
@@ -366,14 +366,6 @@ func (d *WebSeeds) constructListsOfFiles(ctx context.Context, httpProviders []*u
 			d.logger.Debug("[snapshots.webseed] get from HTTP provider", "err", err, "url", webSeedProviderURL.String())
 			continue
 		}
-		// check if we need to prohibit new downloads for some files
-		for name := range manifestResponse {
-			prohibited, err := d.torrentFiles.NewDownloadsAreProhibited(name)
-			if prohibited || err != nil {
-				delete(manifestResponse, name)
-			}
-		}
-
 		listsOfFiles = append(listsOfFiles, manifestResponse)
 	}
 
@@ -383,13 +375,6 @@ func (d *WebSeeds) constructListsOfFiles(ctx context.Context, httpProviders []*u
 		if err != nil { // don't fail on error
 			d.logger.Debug("[snapshots.webseed] get from File provider", "err", err)
 			continue
-		}
-		// check if we need to prohibit new downloads for some files
-		for name := range response {
-			prohibited, err := d.torrentFiles.NewDownloadsAreProhibited(name)
-			if prohibited || err != nil {
-				delete(response, name)
-			}
 		}
 		listsOfFiles = append(listsOfFiles, response)
 	}


### PR DESCRIPTION
- not-finished downloads must be finished even if they are prohibited. (seems this filter was added as an optimization of HTTP calls amounts - of synced node startup).
- .lock must prohibit new .torrent creation, not webseeds discovery


cons: it will increase amount of HTTP calls at startup. will think about it in future