### PR TITLE
update mod to v1.54.2-alpha-28

### DIFF
--- a/erigon-lib/go.mod
+++ b/erigon-lib/go.mod
@@ -152,7 +152,7 @@ require (
 )
 
 replace (
-	github.com/anacrolix/torrent => github.com/erigontech/torrent v1.54.2-alpha-27
+	github.com/anacrolix/torrent => github.com/erigontech/torrent v1.54.2-alpha-28
 	github.com/holiman/bloomfilter/v2 => github.com/AskAlexSharov/bloomfilter/v2 v2.0.8
 	github.com/tidwall/btree => github.com/AskAlexSharov/btree v1.6.2
 )

--- a/erigon-lib/go.sum
+++ b/erigon-lib/go.sum
@@ -146,8 +146,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/erigontech/mdbx-go v0.38.4 h1:S9T7mTe9KPcFe4dOoOtVdI6gPzht9y7wMnYfUBgrQLo=
 github.com/erigontech/mdbx-go v0.38.4/go.mod h1:IcOLQDPw3VM/asP6T5JVPPN4FHHgJtY16XfYjzWKVNI=
-github.com/erigontech/torrent v1.54.2-alpha-27 h1:jsgEixzvZYh7nc5hAgGIpoIe9LRtgzJ9T+mIBfV2BwA=
-github.com/erigontech/torrent v1.54.2-alpha-27/go.mod h1:QtK2WLdEz1Iy1Dh/325UltdHU0nA1xujh2rN6aov6y0=
+github.com/erigontech/torrent v1.54.2-alpha-28 h1:lsPCnCIqsbwIu6JWlksNZWpH5uAZonPf3VPr/lr+NXc=
+github.com/erigontech/torrent v1.54.2-alpha-28/go.mod h1:QtK2WLdEz1Iy1Dh/325UltdHU0nA1xujh2rN6aov6y0=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/frankban/quicktest v1.9.0/go.mod h1:ui7WezCLWMWxVWr1GETZY3smRy0G4KWq9vcPtJmFl7Y=

--- a/go.mod
+++ b/go.mod
@@ -293,6 +293,6 @@ require (
 )
 
 replace (
-	github.com/anacrolix/torrent => github.com/erigontech/torrent v1.54.2-alpha-27
+	github.com/anacrolix/torrent => github.com/erigontech/torrent v1.54.2-alpha-28
 	github.com/holiman/bloomfilter/v2 => github.com/AskAlexSharov/bloomfilter/v2 v2.0.8
 )

--- a/go.sum
+++ b/go.sum
@@ -272,8 +272,8 @@ github.com/erigontech/mdbx-go v0.38.4 h1:S9T7mTe9KPcFe4dOoOtVdI6gPzht9y7wMnYfUBg
 github.com/erigontech/mdbx-go v0.38.4/go.mod h1:IcOLQDPw3VM/asP6T5JVPPN4FHHgJtY16XfYjzWKVNI=
 github.com/erigontech/silkworm-go v0.18.0 h1:j56p61xZHBFhZGH1OixlGU8KcfjHzcw9pjAfjmVsOZA=
 github.com/erigontech/silkworm-go v0.18.0/go.mod h1:O50ux0apICEVEGyRWiE488K8qz8lc3PA/SXbQQAc8SU=
-github.com/erigontech/torrent v1.54.2-alpha-27 h1:jsgEixzvZYh7nc5hAgGIpoIe9LRtgzJ9T+mIBfV2BwA=
-github.com/erigontech/torrent v1.54.2-alpha-27/go.mod h1:QtK2WLdEz1Iy1Dh/325UltdHU0nA1xujh2rN6aov6y0=
+github.com/erigontech/torrent v1.54.2-alpha-28 h1:lsPCnCIqsbwIu6JWlksNZWpH5uAZonPf3VPr/lr+NXc=
+github.com/erigontech/torrent v1.54.2-alpha-28/go.mod h1:QtK2WLdEz1Iy1Dh/325UltdHU0nA1xujh2rN6aov6y0=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c h1:CndMRAH4JIwxbW8KYq6Q+cGWcGHz0FjGR3QqcInWcW0=


### PR DESCRIPTION
Should fix:

https://github.com/ledgerwatch/erigon/issues/11070](https://github.com/ledgerwatch/erigon/issues/11070

Also fixes mainets stalls due to:

banned webpeers donimating small files
deadloc on peer reject