### PR TITLE
diag: thread-safety step4 - remove dedicated shutdown listener goroutine

### DIFF
--- a/erigon-lib/diagnostics/client.go
+++ b/erigon-lib/diagnostics/client.go
@@ -123,12 +123,10 @@ func (d *DiagnosticClient) Setup() {
 
 // Save diagnostic data by time interval to reduce save events
 func (d *DiagnosticClient) runSaveProcess(rootCtx context.Context) {
-	ticker := time.NewTicker(5 * time.Minute)
 	go func() {
-		defer ticker.Stop()
 		for {
 			select {
-			case <-ticker.C:
+			case <-time.Tick(5 * time.Minute):
 				d.SaveData()
 			case <-rootCtx.Done():
 				d.SaveData()

--- a/erigon-lib/diagnostics/client.go
+++ b/erigon-lib/diagnostics/client.go
@@ -19,11 +19,8 @@ package diagnostics
 import (
 	"context"
 	"net/http"
-	"os"
-	"os/signal"
 	"path/filepath"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/c2h5oh/datasize"
@@ -120,21 +117,8 @@ func (d *DiagnosticClient) Setup() {
 	d.setupResourcesUsageDiagnostics(rootCtx)
 	d.setupSpeedtestDiagnostics(rootCtx)
 	d.runSaveProcess(rootCtx)
-	d.runStopNodeListener(rootCtx)
 
 	//d.logDiagMsgs()
-}
-
-func (d *DiagnosticClient) runStopNodeListener(rootCtx context.Context) {
-	go func() {
-		ch := make(chan os.Signal, 1)
-		signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
-		select {
-		case <-ch:
-			d.SaveData()
-		case <-rootCtx.Done():
-		}
-	}()
 }
 
 // Save diagnostic data by time interval to reduce save events

--- a/erigon-lib/diagnostics/client.go
+++ b/erigon-lib/diagnostics/client.go
@@ -123,10 +123,12 @@ func (d *DiagnosticClient) Setup() {
 
 // Save diagnostic data by time interval to reduce save events
 func (d *DiagnosticClient) runSaveProcess(rootCtx context.Context) {
+	ticker := time.NewTicker(5 * time.Minute)
 	go func() {
+		defer ticker.Stop()
 		for {
 			select {
-			case <-time.Tick(5 * time.Minute):
+			case <-ticker.C:
 				d.SaveData()
 			case <-rootCtx.Done():
 				d.SaveData()

--- a/erigon-lib/diagnostics/client.go
+++ b/erigon-lib/diagnostics/client.go
@@ -125,12 +125,13 @@ func (d *DiagnosticClient) Setup() {
 func (d *DiagnosticClient) runSaveProcess(rootCtx context.Context) {
 	ticker := time.NewTicker(5 * time.Minute)
 	go func() {
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
 				d.SaveData()
 			case <-rootCtx.Done():
-				ticker.Stop()
+				d.SaveData()
 				return
 			}
 		}


### PR DESCRIPTION
reason: 
- we already have 1 goroutine for saving data:
```
func (d *DiagnosticClient) runSaveProcess(rootCtx context.Context) {
	ticker := time.NewTicker(5 * time.Minute)
	go func() {
		for {
			select {
			case <-ticker.C:
				d.SaveData()
			case <-rootCtx.Done():
				ticker.Stop()
				return
			}
		}
	}()
}
```
no reason to save it from one more goroutine. just save it right here - in `case <-rootCtx.Done()` section. less concurrency - better. 

rootContext already subscribed to sigterm