### PR TITLE
bor: finality race - step 2

### DIFF
--- a/polygon/bor/finality/whitelist/milestone.go
+++ b/polygon/bor/finality/whitelist/milestone.go
@@ -168,8 +168,8 @@ func (m *milestone) UnlockSprint(endBlockNum uint64) {
 		return
 	}
 
-	if m.TryLock() {
-		defer m.Unlock()
+	if m.finality.TryLock() {
+		defer m.finality.Unlock()
 	}
 
 	m.Locked = false

--- a/polygon/bor/finality/whitelist/milestone.go
+++ b/polygon/bor/finality/whitelist/milestone.go
@@ -275,8 +275,8 @@ func (m *milestone) ProcessFutureMilestone(num uint64, hash common.Hash) {
 		return
 	}
 
-	m.Lock()
-	defer m.Unlock()
+	m.finality.Lock()
+	defer m.finality.Unlock()
 	m.Locked = false
 	m.purgeMilestoneIDsList()
 	purgedMilestoneIDs := map[string]struct{}{}

--- a/polygon/bor/finality/whitelist/milestone.go
+++ b/polygon/bor/finality/whitelist/milestone.go
@@ -168,6 +168,10 @@ func (m *milestone) UnlockSprint(endBlockNum uint64) {
 		return
 	}
 
+	if m.TryLock() {
+		defer m.Unlock()
+	}
+
 	m.Locked = false
 
 	m.purgeMilestoneIDsList()

--- a/polygon/bor/finality/whitelist/milestone.go
+++ b/polygon/bor/finality/whitelist/milestone.go
@@ -271,6 +271,8 @@ func (m *milestone) ProcessFutureMilestone(num uint64, hash common.Hash) {
 		return
 	}
 
+	m.Lock()
+	defer m.Unlock()
 	m.Locked = false
 	m.purgeMilestoneIDsList()
 	purgedMilestoneIDs := map[string]struct{}{}

--- a/polygon/bor/finality/whitelist/milestone.go
+++ b/polygon/bor/finality/whitelist/milestone.go
@@ -267,6 +267,9 @@ func (m *milestone) IsFutureMilestoneCompatible(chain []*types.Header) bool {
 }
 
 func (m *milestone) ProcessFutureMilestone(num uint64, hash common.Hash) {
+	m.finality.Lock()
+	defer m.finality.Unlock()
+
 	if len(m.FutureMilestoneOrder) < m.MaxCapacity {
 		m.enqueueFutureMilestone(num, hash)
 	}
@@ -275,8 +278,6 @@ func (m *milestone) ProcessFutureMilestone(num uint64, hash common.Hash) {
 		return
 	}
 
-	m.finality.Lock()
-	defer m.finality.Unlock()
 	m.Locked = false
 	m.purgeMilestoneIDsList()
 	purgedMilestoneIDs := map[string]struct{}{}


### PR DESCRIPTION
```
==================
WARNING: DATA RACE
Write at 0x00c015bf2208 by goroutine 110:
  github.com/ledgerwatch/erigon/polygon/bor/finality/whitelist.(*milestone).RemoveMilestoneID()
      /home/ubuntu/erigon/polygon/bor/finality/whitelist/milestone.go:190 +0x164
  github.com/ledgerwatch/erigon/polygon/bor/finality.handleNoAckMilestone()
      /home/ubuntu/erigon/polygon/bor/finality/whitelist.go:237 +0x12c
  github.com/ledgerwatch/erigon/polygon/bor/finality.retryHeimdallHandler()
      /home/ubuntu/erigon/polygon/bor/finality/whitelist.go:159 +0x5c4
  github.com/ledgerwatch/erigon/polygon/bor/finality.RetryHeimdallHandler()
      /home/ubuntu/erigon/polygon/bor/finality/whitelist.go:117 +0x57
  github.com/ledgerwatch/erigon/polygon/bor/finality.startNoAckMilestoneService()
      /home/ubuntu/erigon/polygon/bor/finality/whitelist.go:102 +0x2a
  github.com/ledgerwatch/erigon/polygon/bor/finality.Whitelist.gowrap3()
      /home/ubuntu/erigon/polygon/bor/finality/whitelist.go:65 +0x17

Previous read at 0x00c015bf2208 by goroutine 109:
  github.com/ledgerwatch/erigon/polygon/bor/finality/whitelist.(*milestone).ProcessFutureMilestone()
      /home/ubuntu/erigon/polygon/bor/finality/whitelist/milestone.go:277 +0x166
  github.com/ledgerwatch/erigon/polygon/bor/finality.handleMilestone()
      /home/ubuntu/erigon/polygon/bor/finality/whitelist.go:208 +0x1e5
  github.com/ledgerwatch/erigon/polygon/bor/finality.retryHeimdallHandler()
      /home/ubuntu/erigon/polygon/bor/finality/whitelist.go:159 +0x5c4
  github.com/ledgerwatch/erigon/polygon/bor/finality.RetryHeimdallHandler()
      /home/ubuntu/erigon/polygon/bor/finality/whitelist.go:117 +0x5c
  github.com/ledgerwatch/erigon/polygon/bor/finality.startMilestoneWhitelistService()
      /home/ubuntu/erigon/polygon/bor/finality/whitelist.go:93 +0x2a
  github.com/ledgerwatch/erigon/polygon/bor/finality.Whitelist.gowrap2()
      /home/ubuntu/erigon/polygon/bor/finality/whitelist.go:64 +0x17
```