### PR TITLE
qa-tests: fix rpc-tests on main

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -33,6 +33,7 @@ jobs:
         run: |
           rm -rf ${{ runner.workspace }}/rpc-tests
           git -c advice.detachedHead=false clone --depth 1 --branch v1.14.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
+          cd ${{ runner.workspace }}/rpc-tests
           pip3 install -r requirements.txt
 
       - name: Clean Erigon Build Directory


### PR DESCRIPTION
This PR fix the RPC Test workflow and bump the version of the rpc-tests library