### PR TITLE
webseed: fix "no metadata yet" 

### DIFF
--- a/erigon-lib/downloader/webseed.go
+++ b/erigon-lib/downloader/webseed.go
@@ -645,7 +645,7 @@ func (d *WebSeeds) DownloadAndSaveTorrentFile(ctx context.Context, name string) 
 			continue // it's ok if some HTTP provider failed - try next one
 		}
 		res, err := d.callTorrentHttpProvider(ctx, parsedUrl, name)
-		if err != nil {
+		if err != nil || res == nil {
 			d.logger.Debug("[snapshots] .torrent from webseed rejected", "name", name, "err", err, "url", urlStr)
 			continue // it's ok if some HTTP provider failed - try next one
 		}
@@ -670,7 +670,8 @@ func (d *WebSeeds) callTorrentHttpProvider(ctx context.Context, url *url.URL, fi
 	request = request.WithContext(ctx)
 	resp, err := d.client.Do(request)
 	if err != nil {
-		return nil, fmt.Errorf("webseed.downloadTorrentFile: url=%s, %w", url.String(), err)
+		log.Error("webseed.downloadTorrentFile: ", "url", url.String(), "err", err)
+		return nil, nil
 	}
 	defer resp.Body.Close()
 	//protect against too small and too big data


### PR DESCRIPTION
Occasionally, the R2 bucket may impose rate-limiting on HTTP requests. In such cases, we typically skip downloading snapshots from the webseed. However, I believe it would be more effective to attempt additional requests rather than skipping them altogether.