### PR TITLE
fix: trace_callMany ignores parent block header

### DIFF
--- a/rpc/jsonrpc/trace_adhoc.go
+++ b/rpc/jsonrpc/trace_adhoc.go
@@ -1287,7 +1287,7 @@ func (api *TraceAPIImpl) CallMany(ctx context.Context, calls json.RawMessage, pa
 	ibs := state.New(cachedReader)
 
 	trace, _, err := api.doCallBlock(ctx, dbtx, stateReader, stateCache, cachedWriter, ibs,
-		txns, msgs, callParams, parentNrOrHash, nil, true /* gasBailout */, traceConfig)
+		txns, msgs, callParams, parentNrOrHash, parentHeader, true /* gasBailout */, traceConfig)
 
 	return trace, err
 }


### PR DESCRIPTION
I've noticed that for some reason `trace_callMany` doesn't pass on the parent header, which may cause bugs and inconsistencies with `debug_traceCallMany` that does not have this behaviour