### PR TITLE
polygon/sync: process partially connected header chains after ccb.Connect err

### DIFF
--- a/polygon/sync/sync.go
+++ b/polygon/sync/sync.go
@@ -339,12 +339,13 @@ func (s *Sync) applyNewBlockOnTip(ctx context.Context, event EventNewBlock, ccb 
 	oldTip := ccb.Tip()
 	newConnectedHeaders, err := ccb.Connect(ctx, headerChain)
 	if err != nil {
+		// IMPORTANT: we just log the error and do not return
+		// to process the possibility of a partially connected header chain
 		s.logger.Debug(
-			syncLogPrefix("applyNewBlockOnTip: couldn't connect a header to the local chain tip, ignoring"),
+			syncLogPrefix("applyNewBlockOnTip: couldn't connect header chain to the local chain tip"),
+			"partiallyConnected", len(newConnectedHeaders),
 			"err", err,
 		)
-
-		return nil
 	}
 	if len(newConnectedHeaders) == 0 {
 		return nil


### PR DESCRIPTION
fixes
```
err="pos sync failed: block gap inserted: expected: 22257634, have: 22257681"
```

which Mark got at chain tip in an extreme case due to his machine clock being slow and causing a series of 20+ consecutive `ErrFutureBlock` scenarios when calling ccb.Connect

we were lucky because the slowness of his clock uncovered a very subtle bug