### PR TITLE
Revert "Less verbose go tests (ci too crowded) (#15238)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,11 +191,11 @@ test-erigon-ext:
 
 ## test:                      run short tests with a 10m timeout
 test: test-erigon-lib test-erigon-db test-p2
-	$(GOTEST) -short --timeout 10m -coverprofile=coverage-test.out | grep -v '=== CONT ' | grep -v '=== RUN' | grep -v '=== PAUSE' | grep -v 'PASS: '
+	$(GOTEST) -short --timeout 10m -coverprofile=coverage-test.out
 
 ## test-all:                  run all tests with a 1h timeout
 test-all: test-erigon-lib-all test-erigon-db-all test-p2p-all
-	$(GOTEST) --timeout 60m -coverprofile=coverage-test-all.out -race | grep -v '=== CONT ' | grep -v '=== RUN' | grep -v '=== PAUSE' | grep -v 'PASS: '
+	$(GOTEST) --timeout 60m -coverprofile=coverage-test-all.out -race
 
 ## test-hive						run the hive tests locally off nektos/act workflows simulator
 test-hive:	

--- a/core/state/database_test.go
+++ b/core/state/database_test.go
@@ -1369,7 +1369,7 @@ func TestChangeAccountCodeBetweenBlocks(t *testing.T) {
 	}
 	rh1, err := sd.ComputeCommitment(context.Background(), true, blockNum, txNum, "")
 	require.NoError(t, err)
-	//t.Logf("stateRoot %x", rh1)
+	t.Logf("stateRoot %x", rh1)
 
 	trieCode, tcErr := r.ReadAccountCode(contract)
 	require.NoError(t, tcErr, "you can receive the new code")

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -658,12 +658,11 @@ func TestEip2929Cases(t *testing.T) {
 			}
 		}
 		ops := strings.Join(instrs, ", ")
-		//fmt.Printf("### Case %d\n\n", id)
-		//fmt.Printf("%v\n\nBytecode: \n```\n0x%x\n```\nOperations: \n```\n%v\n```\n\n",
-		//	comment,
-		//	code, ops)
-		_ = ops
+		fmt.Printf("### Case %d\n\n", id)
 		id++
+		fmt.Printf("%v\n\nBytecode: \n```\n0x%x\n```\nOperations: \n```\n%v\n```\n\n",
+			comment,
+			code, ops)
 		cfg := &Config{
 			EVMConfig: vm.Config{
 				Tracer:    logger.NewMarkdownLogger(nil, os.Stdout).Hooks(),


### PR DESCRIPTION
This reverts commit c8ad41fe899a695845f2b9020b16c19fd3f79c81.