### PR TITLE
build: update golangci-lint-action to v8

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install golangci-lint
         if: runner.os == 'Linux'
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
           version: 'v2.1.6'
 


### PR DESCRIPTION
Maintenance update to golangci-lint-action@v8 to align with the current best practices; nothing else modified. Refer to [v8.0.0 release notes](https://github.com/golangci/golangci-lint-action/releases/tag/v8.0.0) for details.