### PR TITLE
Dockerfile: bump base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ FROM docker.io/library/alpine:3.22
 RUN apk add --no-cache ca-certificates libstdc++ tzdata
 RUN apk add --no-cache curl jq bind-tools
 
-# Setup user and group
+# Setup user and group 
 #
 # from the perspective of the container, uid=1000, gid=1000 is a sensible choice
 # (mimicking Ubuntu Server), but if caller creates a .env (example in repo root),


### PR DESCRIPTION
1. bump base images (go 1.24.1 --> 1.24.3, alpine 3.20 --> 3.22)
2. add comments for a future binaries stripping we may want to make images slimmer (PROD only)
```
docker images | grep erigo
localhost/erigon_stripped  latest             a30d26e0fb19  28 minutes ago     187 MB
localhost/erigon           latest             43ff4bd4ff73  33 minutes ago     244 MB
```