### PR TITLE
integrity: fix check for spans and checkpoints

### DIFF
--- a/polygon/heimdall/snapshot_store.go
+++ b/polygon/heimdall/snapshot_store.go
@@ -510,10 +510,11 @@ func validateSnapshots[T Entity](
 			}
 
 			accumulatedErr = fmt.Errorf("%w: snap [%d, %d)", accumulatedErr, expectedId, entity.RawId())
-			expectedId = entity.RawId() + 1
 			if failFast {
 				return accumulatedErr
 			}
+
+			expectedId = entity.RawId() + 1
 		}
 	}
 


### PR DESCRIPTION
related to discussion from last week: https://discord.com/channels/1133875232453693480/1133875633819242526/1377999996875571331

fixes 2 issues in "seg integrity":
- if first entity in snapshots (e.g. 10) is greater than first expected entity (e.g. 1) and all are consecutive there will be no error - it should err because there is a gap from e.g. 1 to 10
- fixes a bug in the integrity code which prevented us from catching a gap in Spans snapshots `unexpected span gap: last=3454,new=3456` (e.g. issue [here](https://github.com/erigontech/erigon/issues/15316#issuecomment-2920187952)) 
