### PR TITLE
feat: support streaming JSON parsee for large genesis files

### DIFF
--- a/turbo/app/init_cmd.go
+++ b/turbo/app/init_cmd.go
@@ -19,6 +19,7 @@ package app
 import (
 	"bufio"
 	"os"
+	"unsafe"
 
 	"github.com/erigontech/erigon-lib/chain"
 	"github.com/erigontech/erigon-lib/common"
@@ -126,7 +127,9 @@ func initGenesis(cliCtx *cli.Context) error {
 						account.Storage = make(map[common.Hash]common.Hash)
 						for storageKey = iter.ReadObject(); storageKey != ""; storageKey = iter.ReadObject() {
 							storageValue = iter.ReadStringAsSlice()
-							account.Storage[common.HexToHash(storageKey)] = common.CastToHash(storageValue)
+							// unsafe []byte to string to avoid extra memory allocation
+							ss := unsafe.String((*byte)(unsafe.Pointer(&storageValue[0])), len(storageValue))
+							account.Storage[common.HexToHash(storageKey)] = common.HexToHash(ss)
 						}
 					default:
 						iter.Skip()


### PR DESCRIPTION
## **Summary**

This PR introduces a streaming JSON parser for `genesis.json` initialization, enabling efficient handling of large genesis files and significantly reducing memory usage. This enhancement is especially valuable for networks with extensive pre-allocated accounts.

## **WHY**

The current genesis initialization process loads the entire genesis JSON file into memory at once using `json.NewDecoder(file).Decode(genesis)`. This approach can lead to excessive memory consumption and even out-of-memory (OOM) errors when handling large genesis files (e.g., those containing millions of pre-allocated accounts), particularly on systems with limited RAM.


## **Performance Evaluation**

On  local MacBook Pro 16, I processed a 817MB [genesis.json(Endurance Network mainnet config)](https://github.com/OpenFusionist/network_config) file with the following results:

- **Correctness Verified:** The genesis state hash generated by the new streaming parser was identical to that produced by the original method, confirming the accuracy of the changes.
- **Performance Improvement:** Comparing the JSON decoding time and memory allocation before and after the modification, it shows significant performance improvement.

  | time to decode genesis json | memory allocs
-- | -- | --
before-optmized | ~18s | 6.52G
after-optimized | ~11s | 4.8G

**pprof flame graph:**

before:
![image](https://github.com/user-attachments/assets/545ea741-75c0-4933-9aa5-f722e5b2f943)[initgenesis_alloc_origin.prof.gz](https://github.com/user-attachments/files/20685601/initgenesis_alloc_origin.prof.gz)

after:

![image](https://github.com/user-attachments/assets/09c81c1a-3e19-4bc0-9606-0a95541531d2)

[initgenesis_alloc_optimized.prof.gz](https://github.com/user-attachments/files/20685597/initgenesis_alloc_optimized.prof.gz)

the optimized version still retains reflection in its storage handling. This is because, during an attempt to completely manually parse the storage, a significant scanner error issue was encountered in the `Token()→stateEndValue()` process, leading to approximately 1GB of additional memory allocation (as documented in [Go issue #56299](https://github.com/golang/go/issues/56299)).

Consequently, the performance gains from eliminating reflection through manual parsing were offset by the memory allocation from this scanner error. This resulted in negligible differences in both CPU time and memory allocation between the two approaches.

Considering that manual parsing would lead to considerably longer code, this optimized version was ultimately chosen.
