### PR TITLE
Use gnark for bn254 scalar mul

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -649,13 +649,13 @@ func (c *bn256AddByzantium) Run(input []byte) ([]byte, error) {
 // runBn256ScalarMul implements the Bn256ScalarMul precompile, referenced by
 // both Byzantium and Istanbul operations.
 func runBn256ScalarMul(input []byte) ([]byte, error) {
-	p, err := newCurvePoint(getData(input, 0, 64))
+	x := &bn254.G1Affine{}
+	_, err := x.SetBytes(getData(input, 0, 64))
 	if err != nil {
 		return nil, err
 	}
-	res := new(bn256.G1)
-	res.ScalarMult(p, new(big.Int).SetBytes(getData(input, 64, 32)))
-	return res.Marshal(), nil
+	x = x.ScalarMultiplication(x, new(big.Int).SetBytes(getData(input, 64, 32)))
+	return x.Marshal(), nil
 }
 
 // bn256ScalarMulIstanbul implements a native elliptic curve scalar


### PR DESCRIPTION
Before 
```
Running tool: /usr/bin/go test -benchmem -run=^$ -bench ^BenchmarkPrecompiledBn256ScalarMul$ github.com/erigontech/erigon/core/vm -v

goos: linux
goarch: amd64
pkg: github.com/erigontech/erigon/core/vm
cpu: Intel(R) Core(TM) Ultra 5 135H
BenchmarkPrecompiledBn256ScalarMul
BenchmarkPrecompiledBn256ScalarMul/chfast1-Gas=6000
BenchmarkPrecompiledBn256ScalarMul/chfast1-Gas=6000-18         	   15447	     77164 ns/op	      6000 gas/op	        77.74 mgas/s	    1280 B/op	      25 allocs/op
BenchmarkPrecompiledBn256ScalarMul/chfast2-Gas=6000
BenchmarkPrecompiledBn256ScalarMul/chfast2-Gas=6000-18         	   13015	     83975 ns/op	      6000 gas/op	        71.43 mgas/s	    1472 B/op	      26 allocs/op
BenchmarkPrecompiledBn256ScalarMul/chfast3-Gas=6000
BenchmarkPrecompiledBn256ScalarMul/chfast3-Gas=6000-18         	   14427	     82978 ns/op	      6000 gas/op	        72.30 mgas/s	    1472 B/op	      26 allocs/op
BenchmarkPrecompiledBn256ScalarMul/cdetrio1-Gas=6000
BenchmarkPrecompiledBn256ScalarMul/cdetrio1-Gas=6000-18        	   14325	     89791 ns/op	      6000 gas/op	        66.81 mgas/s	    1504 B/op	      26 allocs/op
BenchmarkPrecompiledBn256ScalarMul/cdetrio6-Gas=6000
BenchmarkPrecompiledBn256ScalarMul/cdetrio6-Gas=6000-18        	   13117	     97600 ns/op	      6000 gas/op	        61.47 mgas/s	    1504 B/op	      26 allocs/op
BenchmarkPrecompiledBn256ScalarMul/cdetrio11-Gas=6000
BenchmarkPrecompiledBn256ScalarMul/cdetrio11-Gas=6000-18       	   13942	     79415 ns/op	      6000 gas/op	        75.54 mgas/s	    1504 B/op	      26 allocs/op
PASS
ok  	github.com/erigontech/erigon/core/vm	13.363s
```

After:
```
Running tool: /usr/bin/go test -benchmem -run=^$ -bench ^BenchmarkPrecompiledBn256ScalarMul$ github.com/erigontech/erigon/core/vm -v

goos: linux
goarch: amd64
pkg: github.com/erigontech/erigon/core/vm
cpu: Intel(R) Core(TM) Ultra 5 135H
BenchmarkPrecompiledBn256ScalarMul
BenchmarkPrecompiledBn256ScalarMul/chfast1-Gas=6000
BenchmarkPrecompiledBn256ScalarMul/chfast1-Gas=6000-18         	   63962	     20546 ns/op	      6000 gas/op	       292.0 mgas/s	     328 B/op	       5 allocs/op
BenchmarkPrecompiledBn256ScalarMul/chfast2-Gas=6000
BenchmarkPrecompiledBn256ScalarMul/chfast2-Gas=6000-18         	   27216	     41158 ns/op	      6000 gas/op	       145.8 mgas/s	     544 B/op	       7 allocs/op
BenchmarkPrecompiledBn256ScalarMul/chfast3-Gas=6000
BenchmarkPrecompiledBn256ScalarMul/chfast3-Gas=6000-18         	   35234	     47288 ns/op	      6000 gas/op	       126.9 mgas/s	     544 B/op	       7 allocs/op
BenchmarkPrecompiledBn256ScalarMul/cdetrio1-Gas=6000
BenchmarkPrecompiledBn256ScalarMul/cdetrio1-Gas=6000-18        	   35221	     33985 ns/op	      6000 gas/op	       176.5 mgas/s	     576 B/op	       7 allocs/op
BenchmarkPrecompiledBn256ScalarMul/cdetrio6-Gas=6000
BenchmarkPrecompiledBn256ScalarMul/cdetrio6-Gas=6000-18        	   25897	     43311 ns/op	      6000 gas/op	       138.5 mgas/s	     576 B/op	       7 allocs/op
BenchmarkPrecompiledBn256ScalarMul/cdetrio11-Gas=6000
BenchmarkPrecompiledBn256ScalarMul/cdetrio11-Gas=6000-18       	   24289	     59165 ns/op	      6000 gas/op	       101.4 mgas/s	     576 B/op	       7 allocs/op
PASS
ok  	github.com/erigontech/erigon/core/vm	17.487s
```
