### PR TITLE
Fix datadir execution permissions for multi-user setups

### DIFF
--- a/erigon-lib/common/dir/rw_dir.go
+++ b/erigon-lib/common/dir/rw_dir.go
@@ -25,7 +25,10 @@ import (
 )
 
 func MustExist(path ...string) {
-	const perm = 0764 // user rwx, group rw, other r
+	// user rwx, group rwx, other rx
+	// x is required to navigate through directories. umask 0o022 is the default and will mask final
+	// permissions to 0o755 for newly created files (and directories).
+	const perm = 0o775
 	for _, p := range path {
 		exist, err := Exist(p)
 		if err != nil {


### PR DESCRIPTION
Per https://github.com/erigontech/devops-metarepo-for-issues/issues/80, Erigon creates data directories without executable permissions preventing group members from reading the contents.

https://github.com/erigontech/devops-metarepo-for-issues/issues/80 fixes retroactively, but this PR will fix going forward too.

Note that umask 0o022 is the default on most systems and will mask newly created directories to 0o755 which I believe is the intended default (consider the trailing `4` in the original 0o764).

Further note that to have the behaviour intended by 0o764, the umask would need to be modified to 0o002 but that's out of the scope of this fix.

This should be backported to release as well.