### PR TITLE
crypto/bn256: Use 8-byte stride in zero comparison

### DIFF
--- a/erigon-lib/crypto/bn256/gnark_bn254.go
+++ b/erigon-lib/crypto/bn256/gnark_bn254.go
@@ -17,6 +17,7 @@
 package bn256
 
 import (
+	"encoding/binary"
 	"errors"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254"
@@ -29,8 +30,8 @@ func UnmarshalCurvePoint(input []byte, point *bn254.G1Affine) error {
 	}
 
 	isAllZeroes := true
-	for b := range input {
-		if b != 0 {
+	for i := 0; i < 64; i += 8 {
+		if 0 != binary.BigEndian.Uint64(input[i:i+8]) {
 			isAllZeroes = false
 			break
 		}


### PR DESCRIPTION
Use 64-bit strides instead of 8-bit. Performance increase in some cases of ECADD benchmark as follows (existing ECMUL benches largely unaffected)

Before
```
Running tool: /usr/bin/go test -benchmem -run=^$ -bench ^BenchmarkPrecompiledBn256Add$ github.com/erigontech/erigon/core/vm -v

goos: linux
goarch: amd64
pkg: github.com/erigontech/erigon/core/vm
cpu: Intel(R) Core(TM) Ultra 5 135H
BenchmarkPrecompiledBn256Add
BenchmarkPrecompiledBn256Add/chfast1-Gas=150
BenchmarkPrecompiledBn256Add/chfast1-Gas=150-18         	  913560	      1278 ns/op	       150.0 gas/op	       117.4 mgas/s	      64 B/op	       1 allocs/op
BenchmarkPrecompiledBn256Add/chfast2-Gas=150
BenchmarkPrecompiledBn256Add/chfast2-Gas=150-18         	  951692	      1257 ns/op	       150.0 gas/op	       119.3 mgas/s	      64 B/op	       1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio1-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio1-Gas=150-18        	 9533280	       119.4 ns/op	       150.0 gas/op	      1256 mgas/s	      64 B/op	       1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio2-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio2-Gas=150-18        	 8281078	       141.7 ns/op	       150.0 gas/op	      1058 mgas/s	     128 B/op	       2 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio3-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio3-Gas=150-18        	 8245022	       142.3 ns/op	       150.0 gas/op	      1054 mgas/s	     128 B/op	       2 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio4-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio4-Gas=150-18        	 7265143	       156.8 ns/op	       150.0 gas/op	       956.8 mgas/s	     192 B/op	       3 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio5-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio5-Gas=150-18        	 8800574	       121.7 ns/op	       150.0 gas/op	      1232 mgas/s	      64 B/op	       1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio6-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio6-Gas=150-18        	 6734316	       170.5 ns/op	       150.0 gas/op	       879.9 mgas/s	      64 B/op	       1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio7-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio7-Gas=150-18        	 6534775	       174.0 ns/op	       150.0 gas/op	       862.0 mgas/s	      64 B/op	       1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio8-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio8-Gas=150-18        	 5887161	       198.3 ns/op	       150.0 gas/op	       756.4 mgas/s	     128 B/op	       2 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio9-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio9-Gas=150-18        	 6520120	       177.2 ns/op	       150.0 gas/op	       846.5 mgas/s	      64 B/op	       1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio10-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio10-Gas=150-18       	 6267020	       178.9 ns/op	       150.0 gas/op	       838.6 mgas/s	      64 B/op	       1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio11-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio11-Gas=150-18       	  781393	      1297 ns/op	       150.0 gas/op	       115.6 mgas/s	      64 B/op	       1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio12-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio12-Gas=150-18       	  914398	      1283 ns/op	       150.0 gas/op	       116.9 mgas/s	      64 B/op	       1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio13-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio13-Gas=150-18       	  811900	      1274 ns/op	       150.0 gas/op	       117.7 mgas/s	      64 B/op	       1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio14-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio14-Gas=150-18       	 5079699	       221.6 ns/op	       150.0 gas/op	       676.7 mgas/s	      64 B/op	       1 allocs/op
PASS
ok  	github.com/erigontech/erigon/core/vm	21.437s
```

After
```
Running tool: /usr/bin/go test -benchmem -run=^$ -bench ^BenchmarkPrecompiledBn256Add$ github.com/erigontech/erigon/core/vm -v

goos: linux
goarch: amd64
pkg: github.com/erigontech/erigon/core/vm
cpu: Intel(R) Core(TM) Ultra 5 135H
BenchmarkPrecompiledBn256Add
BenchmarkPrecompiledBn256Add/chfast1-Gas=150
BenchmarkPrecompiledBn256Add/chfast1-Gas=150-18         	  925886	      1261 ns/op	       150.0 gas/op	       119.0 mgas/s	      64 B/op	       1 allocs/op
BenchmarkPrecompiledBn256Add/chfast2-Gas=150
BenchmarkPrecompiledBn256Add/chfast2-Gas=150-18         	  938670	      1259 ns/op	       150.0 gas/op	       119.1 mgas/s	      64 B/op	       1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio1-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio1-Gas=150-18        	18294410	        63.43 ns/op	       150.0 gas/op	      2365 mgas/s	      64 B/op	       1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio2-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio2-Gas=150-18        	13416939	        80.87 ns/op	       150.0 gas/op	      1855 mgas/s	     128 B/op	       2 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio3-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio3-Gas=150-18        	14766973	        82.88 ns/op	       150.0 gas/op	      1810 mgas/s	     128 B/op	       2 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio4-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio4-Gas=150-18        	10745731	        99.47 ns/op	       150.0 gas/op	      1508 mgas/s	     192 B/op	       3 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio5-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio5-Gas=150-18        	18670928	        62.84 ns/op	       150.0 gas/op	      2387 mgas/s	      64 B/op	       1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio6-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio6-Gas=150-18        	 8110960	       146.6 ns/op	       150.0 gas/op	      1023 mgas/s	      64 B/op	       1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio7-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio7-Gas=150-18        	 8023107	       143.6 ns/op	       150.0 gas/op	      1045 mgas/s	      64 B/op	       1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio8-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio8-Gas=150-18        	 7265391	       163.2 ns/op	       150.0 gas/op	       918.8 mgas/s	     128 B/op	       2 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio9-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio9-Gas=150-18        	 7942299	       144.2 ns/op	       150.0 gas/op	      1040 mgas/s	      64 B/op	       1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio10-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio10-Gas=150-18       	 8055470	       145.0 ns/op	       150.0 gas/op	      1034 mgas/s	      64 B/op	       1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio11-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio11-Gas=150-18       	  904639	      1311 ns/op	       150.0 gas/op	       114.4 mgas/s	      64 B/op	       1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio12-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio12-Gas=150-18       	  911719	      1325 ns/op	       150.0 gas/op	       113.2 mgas/s	      64 B/op	       1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio13-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio13-Gas=150-18       	  937986	      1293 ns/op	       150.0 gas/op	       116.0 mgas/s	      64 B/op	       1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio14-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio14-Gas=150-18       	 5196010	       227.2 ns/op	       150.0 gas/op	       660.3 mgas/s	      64 B/op	       1 allocs/op
PASS
ok  	github.com/erigontech/erigon/core/vm	21.469s
```

