### PR TITLE
Fix no valid record error on Bor Event Purge

### DIFF
--- a/polygon/bridge/mdbx_store.go
+++ b/polygon/bridge/mdbx_store.go
@@ -722,12 +722,14 @@ func (s txStore) PruneEvents(ctx context.Context, blocksTo uint64, blocksDeleteL
 		if eventId >= eventIdTo {
 			break
 		}
-		if err = c1.DeleteCurrent(); err != nil {
-			return deleted, err
-		}
 
 		var event heimdall.EventRecordWithTime
 		if err := event.UnmarshallBytes(v); err != nil {
+			return deleted, err
+		}
+
+		// this needs to be called after v is unmarshalled - it may alter the contents of v
+		if err = c1.DeleteCurrent(); err != nil {
 			return deleted, err
 		}
 


### PR DESCRIPTION
UnmarshallBytes was failing because mdbx cursor DeleteCurrent() alters the values it returns, so this is delayed until the event is locally unmarshalled.

Fixes: https://github.com/erigontech/erigon/issues/15639