### PR TITLE
execution: fix bad log for limited big jump (#15796)

### DIFF
--- a/turbo/execution/eth1/forkchoice.go
+++ b/turbo/execution/eth1/forkchoice.go
@@ -281,14 +281,17 @@ func (e *EthereumExecutionModule) updateForkChoice(ctx context.Context, original
 	defer metrics.UpdateBlockConsumerPostExecutionDelay(fcuHeader.Time, fcuHeader.Number.Uint64(), e.logger)
 
 	var limitedBigJump bool
+	limitedBigJumpPadding := uint64(2)
 	if e.syncCfg.LoopBlockLimit > 0 && finishProgressBefore > 0 && fcuHeader.Number.Uint64() > finishProgressBefore {
 		// note fcuHeader.Number.Uint64() may be < finishProgressBefore - protect from underflow by checking it is >
-		extraPadding := uint64(2)
-		limitedBigJump = (fcuHeader.Number.Uint64()-finishProgressBefore)+extraPadding > uint64(e.syncCfg.LoopBlockLimit)
-		e.logger.Info("[sync] limited big jump", "from", finishProgressBefore, "to", fcuHeader.Number.Uint64(), "amount", uint64(e.syncCfg.LoopBlockLimit), "padding", extraPadding)
+		limitedBigJump = (fcuHeader.Number.Uint64()-finishProgressBefore)+limitedBigJumpPadding > uint64(e.syncCfg.LoopBlockLimit)
 	}
 
-	isSynced := !limitedBigJump && finishProgressBefore > 0 && finishProgressBefore > e.blockReader.FrozenBlocks() && finishProgressBefore == headersProgressBefore
+	isSynced := finishProgressBefore > 0 && finishProgressBefore > e.blockReader.FrozenBlocks() && finishProgressBefore == headersProgressBefore
+	if limitedBigJump {
+		isSynced = false
+		e.logger.Info("[sync] limited big jump", "from", finishProgressBefore, "to", fcuHeader.Number.Uint64(), "amount", uint64(e.syncCfg.LoopBlockLimit), "padding", limitedBigJumpPadding)
+	}
 
 	canonicalHash, err := e.canonicalHash(ctx, tx, fcuHeader.Number.Uint64())
 	if err != nil {


### PR DESCRIPTION
cherry-pick: https://github.com/erigontech/erigon/commit/5a8491bdeb36ab774ffe4ddb0e32785113b4aeaa

not expected to log this:
```
[INFO] [06-27|11:43:39.256] [sync] limited big jump                  from=4072008 to=4072009 amount=5000 padding=2
```

note the value and calculation of limitedBigJump is correct (false in this case) but the logging should not be happening a regression after
https://github.com/erigontech/erigon/commit/29378d42dfb874d88bf91ce84b924b47253ff13e