### PR TITLE
Add bor init to txpool configuration

### DIFF
--- a/txnprovider/txpool/pool_db.go
+++ b/txnprovider/txpool/pool_db.go
@@ -107,7 +107,7 @@ func initBor(cc *chain.Config) *chain.Config {
 		borConfig := &borcfg.BorConfig{}
 		err := json.Unmarshal(cc.BorJSON, borConfig)
 		if err != nil {
-			panic(fmt.Sprintf("Could not parse 'bor' chainspec: %w", err))
+			panic(fmt.Errorf("Could not parse 'bor' chainspec: %w", err))
 		}
 		cc.Bor = borConfig
 	}


### PR DESCRIPTION
This is necessary for the txpool to process 7702 transactions for Bor