### PR TITLE
remove redundant AppendReceipt call

### DIFF
--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -117,9 +117,6 @@ func (se *serialExecutor) execute(ctx context.Context, tasks []*state.TxTask, gp
 			if txTask.TxIndex >= 0 {
 				receipt = txTask.BlockReceipts[txTask.TxIndex]
 			}
-			if err := rawtemporaldb.AppendReceipt(se.doms.AsPutDel(se.applyTx), receipt, se.blobGasUsed, txTask.TxNum); err != nil {
-				return false, err
-			}
 		} else {
 			if se.cfg.chainConfig.Bor != nil && txTask.TxIndex >= 1 {
 				// get last receipt and store the last log index + 1


### PR DESCRIPTION
another `AppendReceipt` is there after the if-else check; don't need this call.