### PR TITLE
qa-tests: fix TEST_RESULT_DIR in RPC Integration workflows

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests-gnosis.yml
+++ b/.github/workflows/qa-rpc-integration-tests-gnosis.yml
@@ -155,7 +155,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-results
-          path: $TEST_RESULT_DIR
+          path: ${{ env.TEST_RESULT_DIR }}
 
       - name: Save test results
         if: steps.test_step.outputs.test_executed == 'true'

--- a/.github/workflows/qa-rpc-integration-tests-polygon.yml
+++ b/.github/workflows/qa-rpc-integration-tests-polygon.yml
@@ -155,7 +155,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-results
-          path: $TEST_RESULT_DIR
+          path: ${{ env.TEST_RESULT_DIR }}
 
       - name: Save test results
         if: steps.test_step.outputs.test_executed == 'true'

--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -155,7 +155,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-results
-          path: $TEST_RESULT_DIR
+          path: ${{ env.TEST_RESULT_DIR }}
 
       - name: Save test results
         if: steps.test_step.outputs.test_executed == 'true'


### PR DESCRIPTION
Fix upload of failed tests broken after #15978 and #15991