### PR TITLE
Do not skip TestService_ProcessNewBlocksWithOverride

### DIFF
--- a/polygon/bridge/service_test.go
+++ b/polygon/bridge/service_test.go
@@ -405,8 +405,6 @@ func setupOverrideTest(t *testing.T, ctx context.Context, borConfig borcfg.BorCo
 }
 
 func TestService_ProcessNewBlocksWithOverride(t *testing.T) {
-	t.Skip("until https://github.com/erigontech/erigon/issues/16062")
-
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 


### PR DESCRIPTION
The test has been fixed as of https://github.com/erigontech/erigon/pull/16044, so there is no need to skip it anymore.