### PR TITLE
Fix bor_getAuthor by hash

### DIFF
--- a/turbo/jsonrpc/bor_snapshot.go
+++ b/turbo/jsonrpc/bor_snapshot.go
@@ -129,7 +129,7 @@ func (api *BorImpl) GetAuthor(blockNrOrHash *rpc.BlockNumberOrHash) (*common.Add
 			header, err = api._blockReader.HeaderByNumber(ctx, tx, uint64(blockNr))
 		} else {
 			if blockHash, ok := blockNrOrHash.Hash(); ok {
-				header, err = rawdb.ReadHeaderByHash(tx, blockHash)
+				header, err = api._blockReader.HeaderByHash(ctx, tx, blockHash)
 			}
 		}
 	}


### PR DESCRIPTION
The header needs to be read by hash using `FullBlockReader` which has access to snapshots and MDBX, instead of `rawdb` which has access only to MDBX data. 

This was fixed before when the input is a block number in https://github.com/erigontech/erigon/pull/15622 and in https://github.com/erigontech/erigon/pull/15630 .

This PR handles the case where the input is a block hash.

Issues fixed: 
- https://github.com/erigontech/erigon/issues/15285
- https://github.com/erigontech/erigon/issues/16020