### PR TITLE
cp: Optimised snapshot read operations for BorEvents (#15993)

### DIFF
--- a/cmd/devnet/services/polygon/heimdallsim/heimdall_simulator.go
+++ b/cmd/devnet/services/polygon/heimdallsim/heimdall_simulator.go
@@ -106,7 +106,7 @@ func (noopBridgeStore) Unwind(ctx context.Context, blockNum uint64) error {
 func (noopBridgeStore) BorStartEventId(ctx context.Context, hash common.Hash, blockHeight uint64) (uint64, error) {
 	return 0, errors.New("noop")
 }
-func (noopBridgeStore) EventsByBlock(ctx context.Context, hash common.Hash, blockNum uint64) ([]rlp.RawValue, error) {
+func (noopBridgeStore) EventsByBlock(ctx context.Context, blockNum uint64) ([]rlp.RawValue, error) {
 	return nil, errors.New("noop")
 }
 func (noopBridgeStore) EventsByIdFromSnapshot(from uint64, to time.Time, limit int) ([]*heimdall.EventRecordWithTime, bool, error) {

--- a/polygon/bridge/mdbx_store.go
+++ b/polygon/bridge/mdbx_store.go
@@ -259,17 +259,6 @@ func (s *MdbxStore) EventsByTimeframe(ctx context.Context, timeFrom, timeTo uint
 	return txStore{tx}.EventsByTimeframe(ctx, timeFrom, timeTo)
 }
 
-// Events gets raw events, start inclusive, end exclusive
-func (s *MdbxStore) Events(ctx context.Context, start, end uint64) ([][]byte, error) {
-	tx, err := s.db.BeginRo(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
-
-	return txStore{tx}.Events(ctx, start, end)
-}
-
 func (s *MdbxStore) PutBlockNumToEventId(ctx context.Context, blockNumToEventId map[uint64]uint64) error {
 	if len(blockNumToEventId) == 0 {
 		return nil
@@ -332,14 +321,14 @@ func (s *MdbxStore) BorStartEventId(ctx context.Context, hash common.Hash, block
 	return txStore{tx}.BorStartEventId(ctx, hash, blockHeight)
 }
 
-func (s *MdbxStore) EventsByBlock(ctx context.Context, hash common.Hash, blockHeight uint64) ([]rlp.RawValue, error) {
+func (s *MdbxStore) EventsByBlock(ctx context.Context, blockHeight uint64) ([]rlp.RawValue, error) {
 	tx, err := s.db.BeginRo(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer tx.Rollback()
 
-	return txStore{tx}.EventsByBlock(ctx, hash, blockHeight)
+	return txStore{tx}.EventsByBlock(ctx, blockHeight)
 }
 
 func (s *MdbxStore) EventsByIdFromSnapshot(from uint64, to time.Time, limit int) ([]*heimdall.EventRecordWithTime, bool, error) {
@@ -557,7 +546,7 @@ func (s txStore) EventsByTimeframe(ctx context.Context, timeFrom, timeTo uint64)
 }
 
 // Events gets raw events, start inclusive, end exclusive
-func (s txStore) Events(ctx context.Context, start, end uint64) ([][]byte, error) {
+func (s txStore) events(ctx context.Context, start, end uint64) ([][]byte, error) {
 	var events [][]byte
 
 	kStart := make([]byte, 8)
@@ -662,7 +651,7 @@ func (s txStore) BorStartEventId(ctx context.Context, hash common.Hash, blockHei
 	return startEventId, nil
 }
 
-func (s txStore) EventsByBlock(ctx context.Context, hash common.Hash, blockHeight uint64) ([]rlp.RawValue, error) {
+func (s txStore) EventsByBlock(ctx context.Context, blockHeight uint64) ([]rlp.RawValue, error) {
 	startEventId, endEventId, ok, err := s.blockEventIdsRange(ctx, blockHeight, 0)
 	if err != nil {
 		return nil, err
@@ -670,7 +659,7 @@ func (s txStore) EventsByBlock(ctx context.Context, hash common.Hash, blockHeigh
 	if !ok {
 		return []rlp.RawValue{}, nil
 	}
-	bytevals, err := s.Events(ctx, startEventId, endEventId+1)
+	bytevals, err := s.events(ctx, startEventId, endEventId+1)
 	if err != nil {
 		return nil, err
 	}

--- a/polygon/bridge/reader.go
+++ b/polygon/bridge/reader.go
@@ -113,24 +113,16 @@ func (r *Reader) EventsWithinTime(ctx context.Context, timeFrom, timeTo time.Tim
 
 // Events returns all sync events at blockNum
 func (r *Reader) Events(ctx context.Context, blockNum uint64) ([]*types.Message, error) {
-	start, end, ok, err := r.store.BlockEventIdsRange(ctx, blockNum)
-	if err != nil {
-		return nil, err
-	}
-	if !ok {
-		return nil, nil
-	}
-
-	eventsRaw := make([]*types.Message, 0, end-start+1)
-
-	events, err := r.store.Events(ctx, start, end+1)
+	events, err := r.store.EventsByBlock(ctx, blockNum)
 	if err != nil {
 		return nil, err
 	}
 
 	if len(events) > 0 && dbg.Enabled(ctx) {
-		r.logger.Debug(bridgeLogPrefix("events for block"), "block", blockNum, "start", start, "end", end, "len", len(events))
+		r.logger.Debug(bridgeLogPrefix("events for block"), "block", blockNum, "len", len(events))
 	}
+
+	eventsRaw := make([]*types.Message, 0, len(events))
 
 	// convert to message
 	for _, event := range events {

--- a/polygon/bridge/snapshot_store.go
+++ b/polygon/bridge/snapshot_store.go
@@ -251,12 +251,7 @@ func (s *SnapshotStore) BlockEventIdsRange(ctx context.Context, blockNum uint64)
 	return 0, 0, false, nil
 }
 
-func (s *SnapshotStore) Events(ctx context.Context, start, end uint64) ([][]byte, error) {
-	lastFrozenEventId := s.LastFrozenEventId()
-	if start > lastFrozenEventId || lastFrozenEventId == 0 {
-		return s.Store.Events(ctx, start, end)
-	}
-
+func (s *SnapshotStore) events(ctx context.Context, start, end, blockNumber uint64) ([][]byte, error) {
 	tx := s.snapshots.ViewType(heimdall.Events)
 	defer tx.Close()
 	segments := tx.Segments
@@ -265,6 +260,13 @@ func (s *SnapshotStore) Events(ctx context.Context, start, end uint64) ([][]byte
 	var result [][]byte
 
 	for i := len(segments) - 1; i >= 0; i-- {
+		if segments[i].From() > blockNumber {
+			continue
+		}
+		if segments[i].To() <= blockNumber {
+			break
+		}
+
 		gg0 := segments[i].Src().MakeGetter()
 
 		if !gg0.HasNext() {
@@ -335,7 +337,7 @@ func (s *SnapshotStore) BorStartEventId(ctx context.Context, hash common.Hash, b
 	return startEventId, nil
 }
 
-func (s *SnapshotStore) EventsByBlock(ctx context.Context, hash common.Hash, blockHeight uint64) ([]rlp.RawValue, error) {
+func (s *SnapshotStore) EventsByBlock(ctx context.Context, blockHeight uint64) ([]rlp.RawValue, error) {
 	startEventId, endEventId, ok, err := s.BlockEventIdsRange(ctx, blockHeight)
 	if err != nil {
 		return nil, err
@@ -343,7 +345,13 @@ func (s *SnapshotStore) EventsByBlock(ctx context.Context, hash common.Hash, blo
 	if !ok {
 		return []rlp.RawValue{}, nil
 	}
-	bytevals, err := s.Events(ctx, startEventId, endEventId+1)
+
+	lastFrozenEventId := s.LastFrozenEventId()
+	if startEventId > lastFrozenEventId || lastFrozenEventId == 0 {
+		return s.Store.EventsByBlock(ctx, blockHeight)
+	}
+
+	bytevals, err := s.events(ctx, startEventId, endEventId+1, blockHeight)
 	if err != nil {
 		return nil, err
 	}

--- a/polygon/bridge/store.go
+++ b/polygon/bridge/store.go
@@ -37,7 +37,6 @@ type Store interface {
 	LastFrozenEventBlockNum() uint64
 
 	EventTxnToBlockNum(ctx context.Context, borTxHash common.Hash) (uint64, bool, error)
-	Events(ctx context.Context, start, end uint64) ([][]byte, error)
 	BlockEventIdsRange(ctx context.Context, blockNum uint64) (start uint64, end uint64, ok bool, err error)         // [start,end]
 	EventsByTimeframe(ctx context.Context, timeFrom, timeTo uint64) (events [][]byte, eventIds []uint64, err error) // [timeFrom, timeTo)
 
@@ -50,7 +49,7 @@ type Store interface {
 
 	// block reader compatibility
 	BorStartEventId(ctx context.Context, hash common.Hash, blockHeight uint64) (uint64, error)
-	EventsByBlock(ctx context.Context, hash common.Hash, blockNum uint64) ([]rlp.RawValue, error)
+	EventsByBlock(ctx context.Context, blockNum uint64) ([]rlp.RawValue, error)
 	EventsByIdFromSnapshot(from uint64, to time.Time, limit int) ([]*heimdall.EventRecordWithTime, bool, error)
 	PruneEvents(ctx context.Context, blocksTo uint64, blocksDeleteLimit int) (deleted int, err error)
 }

--- a/turbo/snapshotsync/freezeblocks/block_reader.go
+++ b/turbo/snapshotsync/freezeblocks/block_reader.go
@@ -23,7 +23,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/hashicorp/golang-lru/v2"
+	lru "github.com/hashicorp/golang-lru/v2"
 
 	"github.com/erigontech/erigon-db/rawdb"
 	coresnaptype "github.com/erigontech/erigon-db/snaptype"
@@ -1467,7 +1467,7 @@ func (r *BlockReader) EventsByBlock(ctx context.Context, tx kv.Tx, hash common.H
 		return nil, fmt.Errorf("%T has no WithTx converter", r.borBridgeStore)
 	}
 
-	return txHandler.WithTx(tx).EventsByBlock(ctx, hash, blockHeight)
+	return txHandler.WithTx(tx).EventsByBlock(ctx, blockHeight)
 }
 
 // EventsByIdFromSnapshot returns the list of records limited by time, or the number of records along with a bool value to signify if the records were limited by time


### PR DESCRIPTION
slight change from the release cherry-pick: in particular the removal of (not required) blockHash from `EventsByBlock` all across. 