### PR TITLE
erigon-db/rawdb: fix prune table periodic log (#16095)

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -1119,7 +1119,7 @@ func PruneTable(tx kv.RwTx, table string, pruneTo uint64, ctx context.Context, l
 
 		select {
 		case <-logEvery.C:
-			logger.Info(fmt.Sprintf("[%s] pruning table periodic progress", logPrefix), table, "blockNum", blockNum)
+			logger.Info(fmt.Sprintf("[%s] pruning table periodic progress", logPrefix), "table", table, "blockNum", blockNum)
 		default:
 		}
 


### PR DESCRIPTION
cherry-pick from main https://github.com/erigontech/erigon/commit/3c4cc5e54d8094b856393e8dabd53f8d6662a055

fixes:
```
[INFO] [07-14|10:52:37.471] [4/6 Execution Prune] pruning table periodic progress ChangeSets3=blockNum LOG15_ERROR= LOG15_ERROR="Normalized odd number of arguments by adding nil"
```