### PR TITLE
IterateFrozenBodies: don't deserialize withdrawals and uncles

### DIFF
--- a/erigon-lib/types/block.go
+++ b/erigon-lib/types/block.go
@@ -638,10 +638,13 @@ func (b BaseTxnID) FirstSystemTx() BaseTxnID { return b }
 // Supposed that txAmount includes 2 system txns.
 func (b BaseTxnID) LastSystemTx(txAmount uint32) uint64 { return b.U64() + uint64(txAmount) - 1 }
 
+// BodyOnlyTxn txn-related part of BodyForStorage
+// 50% of BodyForStorage spent on withdrawal
+// this structure does rlp decode only for
+// "tx related" data
+//
+// must use `rlp.DecodeBytesPartial` to decode
 type BodyOnlyTxn struct {
-	// 50% of BodyForStorage spent on withdrawal
-	// this structure does rlp decode only for
-	// "tx related" data
 	BaseTxnID BaseTxnID
 	TxCount   uint32
 }

--- a/turbo/snapshotsync/freezeblocks/block_reader.go
+++ b/turbo/snapshotsync/freezeblocks/block_reader.go
@@ -1319,7 +1319,7 @@ func (r *BlockReader) IterateFrozenBodies(f func(blockNum, baseTxNum, txCount ui
 		var b types.BodyOnlyTxn
 		for g.HasNext() {
 			buf, _ = g.Next(buf[:0])
-			if err := rlp.DecodeBytes(buf, &b); err != nil {
+			if err := rlp.DecodeBytesPartial(buf, &b); err != nil {
 				return err
 			}
 			if err := f(blockNum, b.BaseTxnID.U64(), uint64(b.TxCount)); err != nil {


### PR DESCRIPTION
use `types.BodyOnlyTxn` optimized for deserializing only txnum info.

for https://github.com/erigontech/erigon/issues/16170