### PR TITLE
Update config.go - remove holesky.beaconstate.ethstaker.cc

### DIFF
--- a/cl/clparams/config.go
+++ b/cl/clparams/config.go
@@ -354,7 +354,6 @@ var CheckpointSyncEndpoints = map[NetworkType][]string{
 		"https://checkpoint.chiadochain.net/eth/v2/debug/beacon/states/finalized",
 	},
 	chainspec.HoleskyChainID: {
-		"https://holesky.beaconstate.ethstaker.cc/eth/v2/debug/beacon/states/finalized",
 		"https://beaconstate-holesky.chainsafe.io/eth/v2/debug/beacon/states/finalized",
 		"https://holesky.beaconstate.info/eth/v2/debug/beacon/states/finalized",
 		"https://checkpoint-sync.holesky.ethpandaops.io/eth/v2/debug/beacon/states/finalized",


### PR DESCRIPTION
DNS name is not resolvable anymore.

```
Host holesky.beaconstate.ethstaker.cc. not found: 3(NXDOMAIN)
```