### PR TITLE
More info in dbug torrent progess

### DIFF
--- a/erigon-db/downloader/downloader.go
+++ b/erigon-db/downloader/downloader.go
@@ -646,7 +646,8 @@ func (d *Downloader) newStats(prevStats AggStats) AggStats {
 
 		// more detailed statistic: download rate of each peer (for each file)
 		if !torrentComplete && progress != 0 {
-			logger.Log(verbosity, "[snapshots] progress", "file", torrentName, "progress", fmt.Sprintf("%.2f%%", progress), "peers", len(peersOfThisFile), "webseeds", len(weebseedPeersOfThisFile))
+			logger.Log(verbosity, "[snapshots] progress", "file", torrentName, "progress", fmt.Sprintf("%.2f%%", progress),
+				"peers", len(peersOfThisFile), "webseeds", len(weebseedPeersOfThisFile), "size", common.ByteCount(uint64(t.Info().TotalLength())))
 			logger.Log(verbosity, "[snapshots] webseed peers", webseedRates...)
 			logger.Log(verbosity, "[snapshots] bittorrent peers", rates...)
 		}


### PR DESCRIPTION
For my adhd added size to progress debug info, now I can understand file of what size I am downloading

For example:
`DBUG[07-23|14:14:02.877] [snapshots] progress                     file=v1.0-000600-000700-headers.seg progress=16.60% peers=0 webseeds=1 size=27.1MB`