### PR TITLE
Refactor: Update bn256 Fuzzers to bn254 in oss-fuzz.sh

### DIFF
--- a/oss-fuzz.sh
+++ b/oss-fuzz.sh
@@ -90,9 +90,9 @@ function compile_fuzzer {
 }
 
 compile_fuzzer tests/fuzzers/bitutil  Fuzz      fuzzBitutilCompress
-compile_fuzzer tests/fuzzers/bn256    FuzzAdd   fuzzBn256Add
-compile_fuzzer tests/fuzzers/bn256    FuzzMul   fuzzBn256Mul
-compile_fuzzer tests/fuzzers/bn256    FuzzPair  fuzzBn256Pair
+compile_fuzzer tests/fuzzers/bn254    FuzzAdd   fuzzBn254Add
+compile_fuzzer tests/fuzzers/bn254    FuzzMul   fuzzBn254Mul
+compile_fuzzer tests/fuzzers/bn254    FuzzPair  fuzzBn254Pair
 compile_fuzzer tests/fuzzers/runtime  Fuzz      fuzzVmRuntime
 compile_fuzzer tests/fuzzers/txfetcher  Fuzz fuzzTxfetcher
 compile_fuzzer tests/fuzzers/rlp        Fuzz fuzzRlp


### PR DESCRIPTION


**Description:**  
- Replaced all references to bn256 fuzzers with bn254 equivalents in `oss-fuzz.sh`.
- Ensures consistency with updated cryptographic standards.
- Minor cleanup for improved clarity and maintainability.
