### PR TITLE
fix TestDump flakiness

### DIFF
--- a/execution/stages/mock/mock_sentry.go
+++ b/execution/stages/mock/mock_sentry.go
@@ -271,7 +271,7 @@ func MockWithEverything(tb testing.TB, gspec *types.Genesis, key *ecdsa.PrivateK
 
 	cfg := ethconfig.Defaults
 	cfg.StateStream = true
-	cfg.BatchSize = 3 * datasize.MB
+	cfg.BatchSize = 5 * datasize.MB
 	cfg.Sync.BodyDownloadTimeoutSeconds = 10
 	cfg.TxPool.Disable = !withTxPool
 	cfg.Dirs = dirs


### PR DESCRIPTION
- `MockWithEverything` defines BatchSize; this is used in ExecV3 - "on chain-tip: if batch is full then stop execution - to allow stages commit" -- which means block execution doesn't happen all the way. Execution progress therefore is also some lesser number. 
- increased the batchSize to 5mb. It doesn't happen anymore (or atleast it happens less). I do think maybe the proper fix is having a "hasMore" loop somewhere in this stack trace, which can insert all the 2k blocks. Maybe in `StageLoopIteration` -- would appreciate some ideas here.


stack: `[stages.go:90 stage.go:88 exec3_serial.go:183 exec3.go:777 stage_execute.go:159 stage_execute.go:342 default_stages.go:116 sync.go:503 sync.go:412 stageloop.go:251 mock_sentry.go:798 mock_sentry.go:856 dump_test.go:298 dump_test.go:124 testing.go:1792 asm_arm64.s:1223]`