### PR TITLE
fix: return nil instead of empty string in Error.Unpack on error

### DIFF
--- a/erigon-lib/abi/error.go
+++ b/erigon-lib/abi/error.go
@@ -84,10 +84,10 @@ func (e *Error) String() string {
 
 func (e *Error) Unpack(data []byte) (interface{}, error) {
 	if len(data) < 4 {
-		return "", errors.New("invalid data for unpacking")
+		return nil, errors.New("invalid data for unpacking")
 	}
 	if !bytes.Equal(data[:4], e.ID[:4]) {
-		return "", errors.New("invalid data for unpacking")
+		return nil, errors.New("invalid data for unpacking")
 	}
 	return e.Inputs.Unpack(data[4:])
 }


### PR DESCRIPTION
Fix logical inconsistency in Error.Unpack method where it was returning
an empty string ("") instead of nil when encountering errors. This
change makes the function behavior consistent with Go conventions for
functions returning (interface{}, error) pairs.

Changes:
- Return nil instead of empty string when data length is less than 4 bytes
- Return nil instead of empty string when ID validation fails
- Improves error handling consistency and prevents confusion in error processing

This fix maintains backward compatibility while making the code more
idiomatic and predictable.