### PR TITLE
Introduce VeBlop block in Bor config

### DIFF
--- a/erigon-lib/chain/chain_config.go
+++ b/erigon-lib/chain/chain_config.go
@@ -178,6 +178,8 @@ type BorConfig interface {
 	GetAhmedabadBlock() *big.Int
 	IsBhilai(num uint64) bool
 	GetBhilaiBlock() *big.Int
+	IsVeBlop(num uint64) bool
+	GetVeBlopBlock() *big.Int
 	StateReceiverContractAddress() common.Address
 	CalculateSprintNumber(number uint64) uint64
 	CalculateSprintLength(number uint64) uint64
@@ -195,12 +197,13 @@ func (c *Config) String() string {
 	engine := c.getEngine()
 
 	if c.Bor != nil {
-		return fmt.Sprintf("{ChainID: %v, Agra: %v, Napoli: %v, Ahmedabad: %v, Bhilai: %v, Engine: %v}",
+		return fmt.Sprintf("{ChainID: %v, Agra: %v, Napoli: %v, Ahmedabad: %v, Bhilai: %v, VeBlop: %v, Engine: %v}",
 			c.ChainID,
 			c.Bor.GetAgraBlock(),
 			c.Bor.GetNapoliBlock(),
 			c.Bor.GetAhmedabadBlock(),
 			c.Bor.GetBhilaiBlock(),
+			c.Bor.GetVeBlopBlock(),
 			engine,
 		)
 	}

--- a/polygon/bor/borcfg/bor_config.go
+++ b/polygon/bor/borcfg/bor_config.go
@@ -44,6 +44,7 @@ type BorConfig struct {
 	NapoliBlock                *big.Int          `json:"napoliBlock"`                // Napoli switch block (nil = no fork, 0 = already on Napoli)
 	AhmedabadBlock             *big.Int          `json:"ahmedabadBlock"`             // Ahmedabad switch block (nil = no fork, 0 = already on Ahmedabad)
 	BhilaiBlock                *big.Int          `json:"bhilaiBlock"`                // Bhilai switch block (nil = no fork, 0 = already on Ahmedabad)
+	VeBlopBlock                *big.Int          `json:"veblopBlock"`                // VeBlop switch block (nil = no fork, 0 = already on veblop)
 	StateSyncConfirmationDelay map[string]uint64 `json:"stateSyncConfirmationDelay"` // StateSync Confirmation Delay, in seconds, to calculate `to`
 
 	sprints sprints
@@ -175,6 +176,14 @@ func (c *BorConfig) IsBhilai(number uint64) bool {
 
 func (c *BorConfig) GetBhilaiBlock() *big.Int {
 	return c.BhilaiBlock
+}
+
+func (c *BorConfig) IsVeBlop(number uint64) bool {
+	return isForked(c.VeBlopBlock, number)
+}
+
+func (c *BorConfig) GetVeBlopBlock() *big.Int {
+	return c.VeBlopBlock
 }
 
 func (c *BorConfig) CalculateStateSyncDelay(number uint64) uint64 {


### PR DESCRIPTION
This just introduces the `VeBlopBlock` in the chainconfig for Bor in pereparation of the next hard fork which will include PIP-64:

https://github.com/maticnetwork/Polygon-Improvement-Proposals/blob/main/PIPs/PIP-64.md