### PR TITLE
[3.1] fix historical values on `eth_getProof`

### DIFF
--- a/erigon-lib/state/commitment_context.go
+++ b/erigon-lib/state/commitment_context.go
@@ -459,13 +459,16 @@ func (sdc *TrieContext) readDomain(d kv.Domain, plainKey []byte) (enc []byte, er
 
 	if sdc.limitReadAsOfTxNum > 0 {
 		if sdc.withHistory {
+			enc, _, err = sdc.roTtx.GetAsOf(d, plainKey, sdc.limitReadAsOfTxNum)
+		}
+
+		if enc == nil {
 			var ok bool
+			// reading from domain files this way will dereference domain key correctly, rotx.GetAsOf
 			enc, ok, _, _, err = sdc.roTtx.Debug().GetLatestFromFiles(d, plainKey, sdc.limitReadAsOfTxNum)
 			if !ok {
 				enc = nil
 			}
-		} else {
-			enc, _, err = sdc.roTtx.GetAsOf(d, plainKey, sdc.limitReadAsOfTxNum)
 		}
 	} else {
 		enc, _, err = sdc.getter.GetLatest(d, plainKey)

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -1609,6 +1609,11 @@ func (dt *DomainRoTx) GetAsOf(key []byte, txNum uint64, roTx kv.Tx) ([]byte, boo
 		}
 		return v, v != nil, nil
 	}
+	if dt.name == kv.CommitmentDomain {
+		// we need to dereference commitment keys to get actual value. DomainRoTx itself does not have
+		// pointers to storage and account domains to do the reference. Aggregator tx must be called instead
+		return nil, false, nil
+	}
 
 	var ok bool
 	v, _, ok, err = dt.GetLatest(key, roTx)


### PR DESCRIPTION
cherry-pick of [d984316](https://github.com/erigontech/erigon/pull/16564/commits/d984316fe5b60ad412bd67584876f7279797bd2a)