### PR TITLE
refactor: use slices.Sort where appropriate

### DIFF
--- a/cl/das/utils/das_utils.go
+++ b/cl/das/utils/das_utils.go
@@ -4,7 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
-	"sort"
+	"slices"
 
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
@@ -62,9 +62,7 @@ func GetCustodyGroups(nodeID enode.ID, custodyGroupCount uint64) ([]CustodyIndex
 	}
 
 	// Sort custody groups
-	sort.Slice(custodyGroups, func(i, j int) bool {
-		return custodyGroups[i] < custodyGroups[j]
-	})
+	slices.Sort(custodyGroups)
 
 	return custodyGroups, nil
 }

--- a/cl/phase1/core/state/util.go
+++ b/cl/phase1/core/state/util.go
@@ -17,7 +17,7 @@
 package state
 
 import (
-	"sort"
+	"slices"
 
 	"github.com/erigontech/erigon/cl/utils/bls"
 
@@ -43,9 +43,7 @@ func copyLRU[K comparable, V any](dst *lru.Cache[K, V], src *lru.Cache[K, V]) *l
 
 func GetIndexedAttestation(attestation *solid.Attestation, attestingIndicies []uint64) *cltypes.IndexedAttestation {
 	// Sort the attestation indicies.
-	sort.Slice(attestingIndicies, func(i, j int) bool {
-		return attestingIndicies[i] < attestingIndicies[j]
-	})
+	slices.Sort(attestingIndicies)
 	return &cltypes.IndexedAttestation{
 		AttestingIndices: solid.NewRawUint64List(2048*64, attestingIndicies),
 		Data:             attestation.Data,

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -25,7 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1107,7 +1107,7 @@ func (as *AggregatorPruneStat) String() string {
 		names = append(names, k)
 	}
 
-	sort.Slice(names, func(i, j int) bool { return names[i] < names[j] })
+	slices.Sort(names)
 
 	var sb strings.Builder
 	for _, d := range names {
@@ -1120,7 +1120,7 @@ func (as *AggregatorPruneStat) String() string {
 	for k := range as.Indices {
 		names = append(names, k)
 	}
-	sort.Slice(names, func(i, j int) bool { return names[i] < names[j] })
+	slices.Sort(names)
 
 	for _, d := range names {
 		v, ok := as.Indices[d]


### PR DESCRIPTION
Replace older sort functions with slices.Sort to simplify code 