### PR TITLE
cp: reuse already prepared heimdall store in integrity check (#16634)

### DIFF
--- a/polygon/heimdall/snapshot_integrity.go
+++ b/polygon/heimdall/snapshot_integrity.go
@@ -7,9 +7,8 @@ import (
 	"github.com/erigontech/erigon/db/datadir"
 )
 
-func ValidateBorSpans(ctx context.Context, logger log.Logger, dirs datadir.Dirs, snaps *RoSnapshots, failFast bool) error {
-	baseStore := NewMdbxStore(logger, dirs.DataDir, true, 32)
-	snapshotStore := NewSpanSnapshotStore(baseStore.Spans(), snaps)
+func ValidateBorSpans(ctx context.Context, logger log.Logger, dirs datadir.Dirs, heimdallStore Store, snaps *RoSnapshots, failFast bool) error {
+	snapshotStore := NewSpanSnapshotStore(heimdallStore.Spans(), snaps)
 	err := snapshotStore.Prepare(ctx)
 	if err != nil {
 		return err
@@ -20,9 +19,8 @@ func ValidateBorSpans(ctx context.Context, logger log.Logger, dirs datadir.Dirs,
 	return err
 }
 
-func ValidateBorCheckpoints(ctx context.Context, logger log.Logger, dirs datadir.Dirs, snaps *RoSnapshots, failFast bool) error {
-	baseStore := NewMdbxStore(logger, dirs.DataDir, true, 32)
-	snapshotStore := NewCheckpointSnapshotStore(baseStore.Checkpoints(), snaps)
+func ValidateBorCheckpoints(ctx context.Context, logger log.Logger, dirs datadir.Dirs, heimdallStore Store, snaps *RoSnapshots, failFast bool) error {
+	snapshotStore := NewCheckpointSnapshotStore(heimdallStore.Checkpoints(), snaps)
 	err := snapshotStore.Prepare(ctx)
 	if err != nil {
 		return err

--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -768,6 +768,7 @@ func doIntegrity(cliCtx *cli.Context) error {
 	}
 
 	blockReader, _ := blockRetire.IO()
+	heimdallStore, _ := blockRetire.BorStore()
 	found := false
 	for _, chk := range checks {
 		if requestedCheck != "" && requestedCheck != chk {
@@ -810,7 +811,7 @@ func doIntegrity(cliCtx *cli.Context) error {
 				logger.Info("BorSpans skipped because not bor chain")
 				continue
 			}
-			if err := heimdall.ValidateBorSpans(ctx, logger, dirs, borSnaps, failFast); err != nil {
+			if err := heimdall.ValidateBorSpans(ctx, logger, dirs, heimdallStore, borSnaps, failFast); err != nil {
 				return err
 			}
 		case integrity.BorCheckpoints:
@@ -818,7 +819,11 @@ func doIntegrity(cliCtx *cli.Context) error {
 				logger.Info("BorCheckpoints skipped because not bor chain")
 				continue
 			}
-			if err := heimdall.ValidateBorCheckpoints(ctx, logger, dirs, borSnaps, failFast); err != nil {
+			if err := heimdall.ValidateBorCheckpoints(ctx, logger, dirs, heimdallStore, borSnaps, failFast); err != nil {
+				return err
+			}
+		case integrity.ReceiptsNoDups:
+			if err := integrity.CheckReceiptsNoDups(ctx, db, blockReader, failFast); err != nil {
 				return err
 			}
 		case integrity.RCacheNoDups:

--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -209,6 +209,10 @@ func (br *BlockRetire) IO() (services.FullBlockReader, *blockio.BlockWriter) {
 	return br.blockReader, br.blockWriter
 }
 
+func (br *BlockRetire) BorStore() (heimdall.Store, bridge.Store) {
+	return br.heimdallStore, br.bridgeStore
+}
+
 func (br *BlockRetire) Writer() *RoSnapshots { return br.blockReader.Snapshots().(*RoSnapshots) }
 
 func (br *BlockRetire) snapshots() *RoSnapshots { return br.blockReader.Snapshots().(*RoSnapshots) }


### PR DESCRIPTION
getting "temporarily unavailable" heimdall store error because it was opened twice (once in `openSnaps` then in `ValidateBorSpans` etc.)