### PR TITLE
add alias for `http.dbg.single`

### DIFF
--- a/cmd/rpcdaemon/README.md
+++ b/cmd/rpcdaemon/README.md
@@ -173,7 +173,7 @@ to test the RPC.
 
 ### Debugging
 
-To print more detailed logs for 1 request - add `--http.dbg.single=true` flag. Then can send HTTP header `"dbg: true"`:
+To print more detailed logs for 1 request - add `--rpc.dbg.single=true` flag. Then can send HTTP header `"dbg: true"`:
 
 ```
 curl -X POST -H "dbg: true" -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "eth_blockNumber", "params": [], "id":1}' localhost:8545

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -395,8 +395,9 @@ var (
 		Usage: "Print all HTTP requests to logs with INFO level",
 	}
 	HTTPDebugSingleFlag = cli.BoolFlag{
-		Name:  "http.dbg.single",
-		Usage: "Allow pass HTTP header 'dbg: true' to printt more detailed logs - how this request was executed",
+		Name:    "http.dbg.single",
+		Aliases: []string{"rpc.dbg.single"},
+		Usage:   "Allow pass HTTP header 'dbg: true' to printt more detailed logs - how this request was executed",
 	}
 	DBReadConcurrencyFlag = cli.IntFlag{
 		Name:  "db.read.concurrency",


### PR DESCRIPTION
- readme specified `rpc.dbg.single`, which doesn't work now.
- both `http.dbg.single` and `rpc.dbg.single` seem valid
