### PR TITLE
integration: execute run_migrations also on consensus db

### DIFF
--- a/cmd/integration/commands/root.go
+++ b/cmd/integration/commands/root.go
@@ -88,7 +88,13 @@ func dbCfg(label kv.Label, path string) kv2.MdbxOpts {
 }
 
 func openDB(opts kv2.MdbxOpts, applyMigrations bool, logger log.Logger) (tdb kv.TemporalRwDB, err error) {
-	if opts.GetLabel() != kv.ChainDB && opts.GetLabel() != kv.ConsensusDB {
+	migrationDBs := map[kv.Label]bool{
+		kv.ChainDB:         true,
+		kv.ConsensusDB:     true,
+		kv.HeimdallDB:      true,
+		kv.PolygonBridgeDB: true,
+	}
+	if _, ok := migrationDBs[opts.GetLabel()]; !ok {
 		panic(opts.GetLabel())
 	}
 

--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -403,6 +403,15 @@ var cmdRunMigrations = &cobra.Command{
 				dbPaths[kv.ConsensusDB] = consensus
 			}
 		}
+		// Migrations must be applied also to the Bor heimdall and polygon-bridge DBs.
+		heimdall := strings.Replace(chaindata, "chaindata", "heimdall", 1)
+		if exists, err := dir.Exist(heimdall); err == nil && exists {
+			dbPaths[kv.HeimdallDB] = heimdall
+		}
+		polygonBridge := strings.Replace(chaindata, "chaindata", "polygon-bridge", 1)
+		if exists, err := dir.Exist(polygonBridge); err == nil && exists {
+			dbPaths[kv.PolygonBridgeDB] = polygonBridge
+		}
 		for dbLabel, dbPath := range dbPaths {
 			//non-accede and exclusive mode - to apply create new tables if need.
 			cfg := dbCfg(dbLabel, dbPath).RemoveFlags(mdbx.Accede).Exclusive(true)

--- a/db/kv/tables.go
+++ b/db/kv/tables.go
@@ -475,8 +475,8 @@ var ConsensusTables = append([]string{
 },
 	ChaindataTables..., //TODO: move bor tables from chaintables to `ConsensusTables`
 )
-var HeimdallTables = []string{}
-var PolygonBridgeTables = []string{}
+var HeimdallTables = ChaindataTables
+var PolygonBridgeTables = ChaindataTables
 var DownloaderTables = []string{
 	BittorrentCompletion,
 	BittorrentInfo,


### PR DESCRIPTION
Starting from #16678, we've tried using `integration run_migrations` within RPC Integration Tests CI workflows to handle creation of new tables automatically: it worked immediately for Ethereum, but failed for both Gnosis and Polygon.

Some changes to `integration run_migrations` are necessary to make it work for them:

- Gnosis: migrations must work also for `consensus` database, which is used there because pre-Merge consensus was AuRa. `ConsensusTables` used within `consensus` database already contained all `ChaindataTables`, so just running the migrations on the `consensus` database is sufficient.
- Polygon: migrations must work also for both `heimdall` and `polygon-bridge` databases, which are used by internal Polygon components. In order to use exactly the same run migration procedure, we need to create all `ChaindataTables` also there. Of course, this is not ideal but IMO should be addressed as a separate issue (namely, refactoring and improvement of run migration procedure not to require the same tables in all databases).