### PR TITLE
Fix gocoroutine leak

### DIFF
--- a/cl/sentinel/httpreqresp/server.go
+++ b/cl/sentinel/httpreqresp/server.go
@@ -45,21 +45,21 @@ the following headers have meaning when passed in to the request:
 		REQRESP-TOPIC - the topic to request with
 		REQRESP-EXPECTED-CHUNKS - this is an integer, which will be multiplied by 10 to calculate the amount of seconds the peer has to respond with all the data
 */
-func Do(handler http.Handler, r *http.Request) (*http.Response, error) {
+func Do(handler http.Handler, r *http.Request) (resp *http.Response, err error) {
 	// TODO: there potentially extra alloc here (responses are bufferd)
 	// is that a big deal? not sure. maybe can reuse these buffers since they are read once (and known when close) if so
-	ans := make(chan *http.Response, 1)
+	ok := make(chan struct{})
 	go func() {
 		res := httptest.NewRecorder()
 		handler.ServeHTTP(res, r)
 		// linter does not know we are passing the resposne through channel.
 		// nolint: bodyclose
-		resp := res.Result()
-		ans <- resp
+		resp = res.Result()
+		close(ok)
 	}()
 	select {
-	case res := <-ans:
-		return res, nil
+	case <-ok:
+		return resp, nil
 	case <-r.Context().Done():
 		return nil, r.Context().Err()
 	}


### PR DESCRIPTION
Change the channel to a buffered channel with capacity 1. This ensures that the goroutine can always complete the send, even if the caller has already returned due to context cancellation. The response will simply sit in the channel until it is garbage collected, avoiding the leak.