### PR TITLE
integrity: fix descending block boundary reset in HistoryNoSystemTxs

### DIFF
--- a/eth/integrity/e3_history_no_system_txs.go
+++ b/eth/integrity/e3_history_no_system_txs.go
@@ -112,7 +112,7 @@ func HistoryCheckNoSystemTxsRange(ctx context.Context, prefixFrom, prefixTo []by
 			return err
 		}
 
-		blk, _min, _max := int64(-1), int64(-1), int64(-1)
+		blk, _min := int64(-1), int64(-1)
 
 		for it.HasNext() {
 			txNum, err := it.Next()
@@ -146,11 +146,7 @@ func HistoryCheckNoSystemTxsRange(ctx context.Context, prefixFrom, prefixTo []by
 					return err
 				}
 				_min = int64(minT)
-				maxT, err := rawdbv3.TxNums.Max(tx, blockNum)
-				if err != nil {
-					return err
-				}
-				_max = int64(maxT)
+
 			}
 
 			if int64(txNum) == _min {


### PR DESCRIPTION
Switch boundary check from txNum > max to txNum < _min to correctly detect transitions between blocks during descending iteration over history index. This ensures per-block Min/Max are recomputed when crossing into an older block, making the “no system txs” check reliable across the full scan.