### PR TITLE
[r3.1] qa-tests: improve test reporting

### DIFF
--- a/.github/workflows/qa-sync-from-scratch-minimal-node.yml
+++ b/.github/workflows/qa-sync-from-scratch-minimal-node.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   minimal-node-sync-from-scratch-test:
     runs-on: [self-hosted, qa, long-running]
-    timeout-minutes: 1100  # 18 hours plus 20 minutes
+    timeout-minutes: 1440  # 24 hours
     strategy:
       fail-fast: false
       matrix:
@@ -25,7 +25,7 @@ jobs:
       ERIGON_QA_PATH: /home/qarunner/erigon-qa
       ERIGON_ASSERT: true
       TRACKING_TIME_SECONDS: 7200 # 2 hours
-      TOTAL_TIME_SECONDS: 86400 # 24 hours
+      TOTAL_TIME_SECONDS: 64800 # 18 hours
       CHAIN: ${{ matrix.chain }}
 
     steps:

--- a/.github/workflows/qa-sync-from-scratch.yml
+++ b/.github/workflows/qa-sync-from-scratch.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   sync-from-scratch-test:
     runs-on: [self-hosted, qa, long-running]
-    timeout-minutes: 740  # 12 hours plus 20 minutes
+    timeout-minutes: 1440  # 24 hours
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/qa-sync-with-externalcl.yml
+++ b/.github/workflows/qa-sync-with-externalcl.yml
@@ -29,7 +29,7 @@ jobs:
       CL_DATA_DIR: ${{ github.workspace }}/consensus
       ERIGON_QA_PATH: /home/qarunner/erigon-qa
       TRACKING_TIME_SECONDS: 3600 # 1 hour
-      TOTAL_TIME_SECONDS: 25200 # 7 hours
+      TOTAL_TIME_SECONDS: 28800 # 8 hours
       ERIGON_ASSERT: true
 
     steps:


### PR DESCRIPTION
Report cancelled test as cancelled only if cancelled before start due to test runner out of capacity; otherwise, if the test was cancelled due to execution timeout, report it as timed-out;
Adjust the GitHub timeouts versus the applicative timeouts so that the test fails rather than being cancelled.