### PR TITLE
VeBlop: change span scraper timeout to 200 ms

### DIFF
--- a/polygon/heimdall/service.go
+++ b/polygon/heimdall/service.go
@@ -92,7 +92,7 @@ func NewService(config ServiceConfig) *Service {
 		"spans",
 		store.Spans(),
 		spanFetcher,
-		1*time.Second,
+		200*time.Millisecond,
 		TransientErrors,
 		logger,
 	)


### PR DESCRIPTION
Per VeBlop specs (https://hackmd.io/pG_1DC3YSoaFTOngy92ffw) the span check interval is 200 ms.