### PR TITLE
fix(eth_getLogs): handle "latest" range correctly to avoid empty results

### DIFF
--- a/rpc/jsonrpc/eth_receipts.go
+++ b/rpc/jsonrpc/eth_receipts.go
@@ -108,7 +108,7 @@ func (api *APIImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria) (t
 				}
 			}
 
-			if uint64(fromBlock) > latest {
+			if begin > latest {
 				return types.RPCLogs{}, nil
 			}
 		}


### PR DESCRIPTION
eth_getLogs incorrectly returned empty results when fromBlock/toBlock was `latest` due to comparing uint64(-1) against the latest height.
