### PR TITLE
[3.1] avoid panic in case ASSERT_ERIGON is enabled in GetReceipts

### DIFF
--- a/rpc/jsonrpc/receipts/receipts_generator.go
+++ b/rpc/jsonrpc/receipts/receipts_generator.go
@@ -338,10 +338,12 @@ func (g *Generator) GetReceipts(ctx context.Context, cfg *chain.Config, tx kv.Te
 		receipt.BlockHash = blockHash
 		if len(receipt.Logs) > 0 {
 			receipt.FirstLogIndexWithinBlock = uint32(receipt.Logs[0].Index)
+		} else if i > 0 {
+			receipt.FirstLogIndexWithinBlock = receipts[i-1].FirstLogIndexWithinBlock + uint32(len(receipts[i-1].Logs))
 		}
 		receipts[i] = receipt
 
-		if dbg.AssertEnabled && receiptsFromDB != nil && len(receipts) > 0 {
+		if dbg.AssertEnabled && receiptsFromDB != nil {
 			g.assertEqualReceipts(receipt, receiptsFromDB[i])
 		}
 	}


### PR DESCRIPTION
(#16908)

Assign correctly the receipt.FirstLogIndexWithinBlock when the receipt contains zero logs to avoid panic() if ASSERT_ERIGON is enabled