### PR TITLE
comment unsupported by arbitrum methods

### DIFF
--- a/rpc/jsonrpc/eth_mining.go
+++ b/rpc/jsonrpc/eth_mining.go
@@ -29,33 +29,33 @@ import (
 )
 
 // Coinbase implements eth_coinbase. Returns the current client coinbase address.
-func (api *APIImpl) Coinbase(ctx context.Context) (common.Address, error) {
-	return api.ethBackend.Etherbase(ctx)
-}
+// func (api *APIImpl) Coinbase(ctx context.Context) (common.Address, error) {
+// 	return api.ethBackend.Etherbase(ctx)
+// }
 
 // Hashrate implements eth_hashrate. Returns the number of hashes per second that the node is mining with.
-func (api *APIImpl) Hashrate(ctx context.Context) (uint64, error) {
-	repl, err := api.mining.HashRate(ctx, &txpool.HashRateRequest{})
-	if err != nil {
-		if s, ok := status.FromError(err); ok {
-			return 0, errors.New(s.Message())
-		}
-		return 0, err
-	}
-	return repl.HashRate, err
-}
+// func (api *APIImpl) Hashrate(ctx context.Context) (uint64, error) {
+// 	repl, err := api.mining.HashRate(ctx, &txpool.HashRateRequest{})
+// 	if err != nil {
+// 		if s, ok := status.FromError(err); ok {
+// 			return 0, errors.New(s.Message())
+// 		}
+// 		return 0, err
+// 	}
+// 	return repl.HashRate, err
+// }
 
 // Mining returns an indication if this node is currently mining.
-func (api *APIImpl) Mining(ctx context.Context) (bool, error) {
-	repl, err := api.mining.Mining(ctx, &txpool.MiningRequest{})
-	if err != nil {
-		if s, ok := status.FromError(err); ok {
-			return false, errors.New(s.Message())
-		}
-		return false, err
-	}
-	return repl.Enabled && repl.Running, err
-}
+// func (api *APIImpl) Mining(ctx context.Context) (bool, error) {
+// 	repl, err := api.mining.Mining(ctx, &txpool.MiningRequest{})
+// 	if err != nil {
+// 		if s, ok := status.FromError(err); ok {
+// 			return false, errors.New(s.Message())
+// 		}
+// 		return false, err
+// 	}
+// 	return repl.Enabled && repl.Running, err
+// }
 
 // GetWork returns a work package for external miner.
 //

--- a/rpc/jsonrpc/eth_system.go
+++ b/rpc/jsonrpc/eth_system.go
@@ -106,13 +106,13 @@ func (api *APIImpl) ChainID(ctx context.Context) (hexutil.Uint64, error) {
 }
 
 // ProtocolVersion implements eth_protocolVersion. Returns the current ethereum protocol version.
-func (api *APIImpl) ProtocolVersion(ctx context.Context) (hexutil.Uint, error) {
-	ver, err := api.ethBackend.ProtocolVersion(ctx)
-	if err != nil {
-		return 0, err
-	}
-	return hexutil.Uint(ver), nil
-}
+// func (api *APIImpl) ProtocolVersion(ctx context.Context) (hexutil.Uint, error) {
+// 	ver, err := api.ethBackend.ProtocolVersion(ctx)
+// 	if err != nil {
+// 		return 0, err
+// 	}
+// 	return hexutil.Uint(ver), nil
+// }
 
 // GasPrice implements eth_gasPrice. Returns the current price per gas in wei.
 func (api *APIImpl) GasPrice(ctx context.Context) (*hexutil.Big, error) {

--- a/rpc/jsonrpc/net_api.go
+++ b/rpc/jsonrpc/net_api.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/erigontech/erigon-lib/common/hexutil"
 	"github.com/erigontech/erigon/rpc/rpchelper"
 )
 
@@ -46,13 +45,13 @@ func NewNetAPIImpl(eth rpchelper.ApiBackend) *NetAPIImpl {
 
 // Listening implements net_listening. Returns true if client is actively listening for network connections.
 // If we can get peers info, it means the network interface is up and listening
-func (api *NetAPIImpl) Listening(ctx context.Context) (bool, error) {
-	_, err := api.ethBackend.Peers(ctx)
-	if err != nil {
-		return false, nil
-	}
-	return true, nil
-}
+// func (api *NetAPIImpl) Listening(ctx context.Context) (bool, error) {
+// 	_, err := api.ethBackend.Peers(ctx)
+// 	if err != nil {
+// 		return false, nil
+// 	}
+// 	return true, nil
+// }
 
 // Version implements net_version. Returns the current network id.
 func (api *NetAPIImpl) Version(ctx context.Context) (string, error) {
@@ -71,16 +70,16 @@ func (api *NetAPIImpl) Version(ctx context.Context) (string, error) {
 
 // PeerCount implements net_peerCount. Returns number of peers currently
 // connected to the first sentry server.
-func (api *NetAPIImpl) PeerCount(ctx context.Context) (hexutil.Uint, error) {
-	if api.ethBackend == nil {
-		// We're running in --datadir mode or otherwise cannot get the backend
-		return 0, fmt.Errorf(NotAvailableChainData, "net_peerCount")
-	}
+// func (api *NetAPIImpl) PeerCount(ctx context.Context) (hexutil.Uint, error) {
+// 	if api.ethBackend == nil {
+// 		// We're running in --datadir mode or otherwise cannot get the backend
+// 		return 0, fmt.Errorf(NotAvailableChainData, "net_peerCount")
+// 	}
 
-	res, err := api.ethBackend.NetPeerCount(ctx)
-	if err != nil {
-		return 0, err
-	}
+// 	res, err := api.ethBackend.NetPeerCount(ctx)
+// 	if err != nil {
+// 		return 0, err
+// 	}
 
-	return hexutil.Uint(res), nil
-}
+// 	return hexutil.Uint(res), nil
+// }


### PR DESCRIPTION
arb nodes return `the method ... does not exist/is not available` for this methods, so we can comment them to get same response