### PR TITLE
tests: update teku to 25.9.1 to fix failing kurtosis ci

### DIFF
--- a/.github/workflows/kurtosis/pectra.io
+++ b/.github/workflows/kurtosis/pectra.io
@@ -5,7 +5,7 @@ participants_matrix:
       el_log_level: "debug"
   cl:
     - cl_type: teku
-      cl_image: consensys/teku:25.7
+      cl_image: consensys/teku:25.9.1
     - cl_type: lighthouse
       cl_image: sigp/lighthouse:v7.0.1
 

--- a/.github/workflows/kurtosis/regular-assertoor.io
+++ b/.github/workflows/kurtosis/regular-assertoor.io
@@ -6,7 +6,7 @@ participants_matrix:
     - cl_type: lighthouse
       cl_image: sigp/lighthouse:v7.0.1
     - cl_type: teku
-      cl_image: consensys/teku:25.7
+      cl_image: consensys/teku:25.9.1
 network_params:
   #electra_fork_epoch: 1
   min_validator_withdrawability_delay: 1


### PR DESCRIPTION
recent changes in https://github.com/ethpandaops/ethereum-package are incompatible with consensys/teku:25.7 and caused failures in our kurtosis CI since yesterday:
```
FATAL - The specified network configuration had missing or invalid values for constants RESP_TIMEOUT, TTFB_TIMEOUT
```
updating to consensys/teku:25.9.1 fixes this  