### PR TITLE
execution: fix operational err logging when err=nil

### DIFF
--- a/execution/stagedsync/stage.go
+++ b/execution/stagedsync/stage.go
@@ -119,7 +119,10 @@ func (u UnwindReason) Err() error {
 	if u.ErrBadBlock != nil {
 		return fmt.Errorf("bad block err: %w", u.ErrBadBlock)
 	}
-	return fmt.Errorf("operational err: %w", u.ErrOperational)
+	if u.ErrOperational != nil {
+		return fmt.Errorf("operational err: %w", u.ErrOperational)
+	}
+	return nil
 }
 
 var StagedUnwind = UnwindReason{}


### PR DESCRIPTION
follow up improvement to logs
seeing:
```
[DBUG] [09-09|15:18:23.613] UnwindTo                                 block=141000 err="operational err: %!w(<nil>)" stack="[sync.go:174 forkchoice.go:341 asm_amd64.s:1700]"
```

when err is nil

instead it should just log
```
[DBUG] [09-09|15:18:23.613] UnwindTo                                 block=141000 err=nil stack="[sync.go:174 forkchoice.go:341 asm_amd64.s:1700]"
```