### PR TITLE
cherry-pick: Patch bad sprints on Amoy (#17078)

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -638,10 +638,11 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 		}
 
 		heimdallService = heimdall.NewService(heimdall.ServiceConfig{
-			Store:     heimdallStore,
-			BorConfig: borConfig,
-			Client:    heimdallClient,
-			Logger:    logger,
+			Store:       heimdallStore,
+			ChainConfig: chainConfig,
+			BorConfig:   borConfig,
+			Client:      heimdallClient,
+			Logger:      logger,
 		})
 
 		bridgeRPC = bridge.NewBackendServer(ctx, polygonBridge)

--- a/polygon/heimdall/reader.go
+++ b/polygon/heimdall/reader.go
@@ -10,6 +10,7 @@ import (
 	"github.com/erigontech/erigon-lib/gointerfaces"
 	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
 	"github.com/erigontech/erigon-lib/log/v3"
+	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/polygon/bor/borcfg"
 )
 
@@ -20,15 +21,16 @@ type Reader struct {
 }
 
 type ReaderConfig struct {
-	Store     Store
-	BorConfig *borcfg.BorConfig
-	DataDir   string
-	Logger    log.Logger
+	Store       Store
+	ChainConfig *chain.Config
+	BorConfig   *borcfg.BorConfig
+	DataDir     string
+	Logger      log.Logger
 }
 
 // AssembleReader creates and opens the MDBX store. For use cases where the store is only being read from. Must call Close.
 func AssembleReader(ctx context.Context, config ReaderConfig) (*Reader, error) {
-	reader := NewReader(config.BorConfig, config.Store, config.Logger)
+	reader := NewReader(config.ChainConfig, config.BorConfig, config.Store, config.Logger)
 
 	err := reader.Prepare(ctx)
 	if err != nil {
@@ -38,11 +40,11 @@ func AssembleReader(ctx context.Context, config ReaderConfig) (*Reader, error) {
 	return reader, nil
 }
 
-func NewReader(borConfig *borcfg.BorConfig, store Store, logger log.Logger) *Reader {
+func NewReader(chainConfig *chain.Config, borConfig *borcfg.BorConfig, store Store, logger log.Logger) *Reader {
 	return &Reader{
 		logger:                    logger,
 		store:                     store,
-		spanBlockProducersTracker: newSpanBlockProducersTracker(logger, borConfig, store.SpanBlockProducerSelections()),
+		spanBlockProducersTracker: newSpanBlockProducersTracker(logger, chainConfig, borConfig, store.SpanBlockProducerSelections()),
 	}
 }
 

--- a/polygon/heimdall/service.go
+++ b/polygon/heimdall/service.go
@@ -28,6 +28,7 @@ import (
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/event"
 	"github.com/erigontech/erigon-lib/log/v3"
+	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/polygon/bor/borcfg"
 	"github.com/erigontech/erigon/polygon/heimdall/poshttp"
 )
@@ -37,10 +38,11 @@ const (
 )
 
 type ServiceConfig struct {
-	Store     Store
-	BorConfig *borcfg.BorConfig
-	Client    Client
-	Logger    log.Logger
+	Store       Store
+	ChainConfig *chain.Config
+	BorConfig   *borcfg.BorConfig
+	Client      Client
+	Logger      log.Logger
 }
 
 type Service struct {
@@ -57,6 +59,7 @@ type Service struct {
 
 func NewService(config ServiceConfig) *Service {
 	logger := config.Logger
+	chainConfig := config.ChainConfig
 	borConfig := config.BorConfig
 	store := config.Store
 	client := config.Client
@@ -100,11 +103,11 @@ func NewService(config ServiceConfig) *Service {
 	return &Service{
 		logger:                    logger,
 		store:                     store,
-		reader:                    NewReader(borConfig, store, logger),
+		reader:                    NewReader(chainConfig, borConfig, store, logger),
 		checkpointScraper:         checkpointScraper,
 		milestoneScraper:          milestoneScraper,
 		spanScraper:               spanScraper,
-		spanBlockProducersTracker: newSpanBlockProducersTracker(logger, borConfig, store.SpanBlockProducerSelections()),
+		spanBlockProducersTracker: newSpanBlockProducersTracker(logger, chainConfig, borConfig, store.SpanBlockProducerSelections()),
 		client:                    client,
 	}
 }

--- a/polygon/heimdall/service_test.go
+++ b/polygon/heimdall/service_test.go
@@ -175,10 +175,11 @@ func (suite *ServiceTestSuite) SetupSuite() {
 	suite.setupCheckpoints()
 	suite.setupMilestones()
 	suite.service = NewService(ServiceConfig{
-		Store:     store,
-		BorConfig: borConfig,
-		Client:    suite.client,
-		Logger:    suite.logger,
+		Store:       store,
+		ChainConfig: suite.chainConfig,
+		BorConfig:   borConfig,
+		Client:      suite.client,
+		Logger:      suite.logger,
 	})
 
 	err := suite.service.store.Prepare(suite.ctx)

--- a/polygon/heimdall/validator_set.go
+++ b/polygon/heimdall/validator_set.go
@@ -420,7 +420,7 @@ func (vals *ValidatorSet) Copy() *ValidatorSet {
 
 	return &ValidatorSet{
 		Validators:       validatorListCopy(vals.Validators),
-		Proposer:         vals.Proposer,
+		Proposer:         vals.Proposer.Copy(),
 		totalVotingPower: vals.totalVotingPower,
 		validatorsMap:    validatorsMap,
 	}

--- a/polygon/sync/header_time_validator.go
+++ b/polygon/sync/header_time_validator.go
@@ -57,7 +57,7 @@ func (htv *HeaderTimeValidator) ValidateHeaderTime(
 	if err != nil {
 		return err
 	}
-	htv.logger.Debug("validating header time:", "blockNum", header.Number.Uint64(), "blockHash", header.Hash(), "parentHash", parent.Hash(), "signer", signer, "producers", producers.ValidatorAddresses())
+	htv.logger.Debug("validating header time:", "blockNum", header.Number.Uint64(), "blockHash", header.Hash(), "parentHash", parent.Hash(), "signer", signer, "producers", producers)
 
 	// Rio/VeBlop checks for new span if block signer is different from producer
 	if htv.borConfig.IsRio(header.Number.Uint64()) {


### PR DESCRIPTION
cherry-pick of : https://github.com/erigontech/erigon/pull/17078

This patches the validator set for new sprints at the following block numbers on Amoy : 26160368, 26161088, 26171568, 26173744, 26175648

Bor clients accepted invalid validator set transitions for those sprints via invalid validator bytes in header extra data. Since Erigon doesn't rely on headers as a source of validator data, but only on heimdall span data, it wasn't affected by the invalid transitions, but since those blocks made it to the canonical chain, they need to be patched in Erigon.

---------