### PR TITLE
execution/engineapi: allow for configurable retryable errs in engineapi jsonrpc client

### DIFF
--- a/execution/engineapi/engine_api_jsonrpc_client.go
+++ b/execution/engineapi/engine_api_jsonrpc_client.go
@@ -18,7 +18,9 @@ package engineapi
 
 import (
 	"context"
+	"errors"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -45,10 +47,31 @@ func WithJsonRpcClientRetryBackOff(retryBackOff time.Duration) JsonRpcClientOpti
 	}
 }
 
+func WithRetryableErrCheckers(retryableErrCheckers ...RetryableErrChecker) JsonRpcClientOption {
+	return func(client *JsonRpcClient) {
+		client.retryableErrCheckers = retryableErrCheckers
+	}
+}
+
 type JsonRpcClient struct {
-	rpcClient    *rpc.Client
-	maxRetries   uint64
-	retryBackOff time.Duration
+	rpcClient            *rpc.Client
+	maxRetries           uint64
+	retryBackOff         time.Duration
+	retryableErrCheckers []RetryableErrChecker
+}
+
+type RetryableErrChecker func(err error) bool
+
+func ErrIsRetryableErrChecker(target error) RetryableErrChecker {
+	return func(err error) bool {
+		return errors.Is(err, target)
+	}
+}
+
+func ErrContainsRetryableErrChecker(sub string) RetryableErrChecker {
+	return func(err error) bool {
+		return err != nil && strings.Contains(err.Error(), sub)
+	}
 }
 
 func DialJsonRpcClient(url string, jwtSecret []byte, logger log.Logger, opts ...JsonRpcClientOption) (*JsonRpcClient, error) {
@@ -77,7 +100,7 @@ func (c *JsonRpcClient) NewPayloadV1(ctx context.Context, payload *enginetypes.E
 		var result enginetypes.PayloadStatus
 		err := c.rpcClient.CallContext(ctx, &result, "engine_newPayloadV1", payload)
 		if err != nil {
-			return nil, err
+			return nil, c.maybeMakePermanent(err)
 		}
 		return &result, nil
 	}, c.backOff(ctx))
@@ -88,7 +111,7 @@ func (c *JsonRpcClient) NewPayloadV2(ctx context.Context, payload *enginetypes.E
 		var result enginetypes.PayloadStatus
 		err := c.rpcClient.CallContext(ctx, &result, "engine_newPayloadV2", payload)
 		if err != nil {
-			return nil, err
+			return nil, c.maybeMakePermanent(err)
 		}
 		return &result, nil
 	}, c.backOff(ctx))
@@ -111,7 +134,7 @@ func (c *JsonRpcClient) NewPayloadV3(
 			parentBeaconBlockRoot,
 		)
 		if err != nil {
-			return nil, err
+			return nil, c.maybeMakePermanent(err)
 		}
 		return &result, nil
 	}, c.backOff(ctx))
@@ -136,7 +159,7 @@ func (c *JsonRpcClient) NewPayloadV4(
 			executionRequests,
 		)
 		if err != nil {
-			return nil, err
+			return nil, c.maybeMakePermanent(err)
 		}
 		return &result, nil
 	}, c.backOff(ctx))
@@ -151,7 +174,7 @@ func (c *JsonRpcClient) ForkchoiceUpdatedV1(
 		var result enginetypes.ForkChoiceUpdatedResponse
 		err := c.rpcClient.CallContext(ctx, &result, "engine_forkchoiceUpdatedV1", forkChoiceState, payloadAttributes)
 		if err != nil {
-			return nil, err
+			return nil, c.maybeMakePermanent(err)
 		}
 		return &result, nil
 	}, c.backOff(ctx))
@@ -166,7 +189,7 @@ func (c *JsonRpcClient) ForkchoiceUpdatedV2(
 		var result enginetypes.ForkChoiceUpdatedResponse
 		err := c.rpcClient.CallContext(ctx, &result, "engine_forkchoiceUpdatedV2", forkChoiceState, payloadAttributes)
 		if err != nil {
-			return nil, err
+			return nil, c.maybeMakePermanent(err)
 		}
 		return &result, nil
 	}, c.backOff(ctx))
@@ -181,7 +204,7 @@ func (c *JsonRpcClient) ForkchoiceUpdatedV3(
 		var result enginetypes.ForkChoiceUpdatedResponse
 		err := c.rpcClient.CallContext(ctx, &result, "engine_forkchoiceUpdatedV3", forkChoiceState, payloadAttributes)
 		if err != nil {
-			return nil, err
+			return nil, c.maybeMakePermanent(err)
 		}
 		return &result, nil
 	}, c.backOff(ctx))
@@ -192,7 +215,7 @@ func (c *JsonRpcClient) GetPayloadV1(ctx context.Context, payloadID hexutil.Byte
 		var result enginetypes.ExecutionPayload
 		err := c.rpcClient.CallContext(ctx, &result, "engine_getPayloadV1", payloadID)
 		if err != nil {
-			return nil, err
+			return nil, c.maybeMakePermanent(err)
 		}
 		return &result, nil
 	}, c.backOff(ctx))
@@ -203,7 +226,7 @@ func (c *JsonRpcClient) GetPayloadV2(ctx context.Context, payloadID hexutil.Byte
 		var result enginetypes.GetPayloadResponse
 		err := c.rpcClient.CallContext(ctx, &result, "engine_getPayloadV2", payloadID)
 		if err != nil {
-			return nil, err
+			return nil, c.maybeMakePermanent(err)
 		}
 		return &result, nil
 	}, c.backOff(ctx))
@@ -214,7 +237,7 @@ func (c *JsonRpcClient) GetPayloadV3(ctx context.Context, payloadID hexutil.Byte
 		var result enginetypes.GetPayloadResponse
 		err := c.rpcClient.CallContext(ctx, &result, "engine_getPayloadV3", payloadID)
 		if err != nil {
-			return nil, err
+			return nil, c.maybeMakePermanent(err)
 		}
 		return &result, nil
 	}, c.backOff(ctx))
@@ -225,7 +248,7 @@ func (c *JsonRpcClient) GetPayloadV4(ctx context.Context, payloadID hexutil.Byte
 		var result enginetypes.GetPayloadResponse
 		err := c.rpcClient.CallContext(ctx, &result, "engine_getPayloadV4", payloadID)
 		if err != nil {
-			return nil, err
+			return nil, c.maybeMakePermanent(err)
 		}
 		return &result, nil
 	}, c.backOff(ctx))
@@ -236,7 +259,7 @@ func (c *JsonRpcClient) GetPayloadBodiesByHashV1(ctx context.Context, hashes []c
 		var result []*enginetypes.ExecutionPayloadBody
 		err := c.rpcClient.CallContext(ctx, &result, "engine_getPayloadBodiesByHashV1", hashes)
 		if err != nil {
-			return nil, err
+			return nil, c.maybeMakePermanent(err)
 		}
 		return result, nil
 	}, c.backOff(ctx))
@@ -247,7 +270,7 @@ func (c *JsonRpcClient) GetPayloadBodiesByRangeV1(ctx context.Context, start, co
 		var result []*enginetypes.ExecutionPayloadBody
 		err := c.rpcClient.CallContext(ctx, &result, "engine_getPayloadBodiesByRangeV1", start, count)
 		if err != nil {
-			return nil, err
+			return nil, c.maybeMakePermanent(err)
 		}
 		return result, nil
 	}, c.backOff(ctx))
@@ -258,7 +281,7 @@ func (c *JsonRpcClient) GetClientVersionV1(ctx context.Context, callerVersion *e
 		var result []enginetypes.ClientVersionV1
 		err := c.rpcClient.CallContext(ctx, &result, "engine_getClientVersionV1", callerVersion)
 		if err != nil {
-			return nil, err
+			return nil, c.maybeMakePermanent(err)
 		}
 		return result, nil
 	}, c.backOff(ctx))
@@ -269,4 +292,21 @@ func (c *JsonRpcClient) backOff(ctx context.Context) backoff.BackOff {
 	backOff = backoff.NewConstantBackOff(c.retryBackOff)
 	backOff = backoff.WithMaxRetries(backOff, c.maxRetries)
 	return backoff.WithContext(backOff, ctx)
+}
+
+func (c *JsonRpcClient) maybeMakePermanent(err error) error {
+	if err == nil {
+		return nil
+	}
+	var retryableErr bool
+	for _, checker := range c.retryableErrCheckers {
+		if checker(err) {
+			retryableErr = true
+			break
+		}
+	}
+	if retryableErr {
+		return err
+	}
+	return backoff.Permanent(err)
 }

--- a/execution/tests/engine_api_tester.go
+++ b/execution/tests/engine_api_tester.go
@@ -210,6 +210,7 @@ func InitialiseEngineApiTester(t *testing.T, args EngineApiTesterInitArgs) Engin
 		// requests should not take more than 5 secs in a test env, yet we can spam frequently
 		engineapi.WithJsonRpcClientRetryBackOff(50*time.Millisecond),
 		engineapi.WithJsonRpcClientMaxRetries(100),
+		engineapi.WithRetryableErrCheckers(engineapi.ErrContainsRetryableErrChecker("connection refused")),
 	)
 	require.NoError(t, err)
 	var mockCl *MockCl


### PR DESCRIPTION
needed in a follow up PR for further reorg tests - doing separately for a smaller diff

the retry logic in the engine api jsonrpc client (only used in tests currently)  was added in https://github.com/erigontech/erigon/issues/14417 to help with a "connection refused" flakiness at test initialisation

however the retrying is currently done for all errors, even ones that are permanent and should not be retried like a bad block err for example, which makes it difficult to debug failing tests during development 

this PR changes this by adding support for specifying retry-able errors in the jsonrpc client (a collection of those can be built over time as necessary but for now we only retry on the "connection refused" one)
