### PR TITLE
erigon-lib/event: snapshot observers in Notify/NotifySync to prevent deadlock

### DIFF
--- a/common/event/observers.go
+++ b/common/event/observers.go
@@ -17,107 +17,87 @@
 package event
 
 import (
-	"sync/atomic"
 	"sync"
 )
 
 type Observer[TEvent any] func(event TEvent)
 type UnregisterFunc func()
 
-type observersState[TEvent any] struct {
-    observers map[uint64]Observer[TEvent]
-}
-
 type Observers[TEvent any] struct {
-    state              atomic.Pointer[observersState[TEvent]]
-    observerIdSequence atomic.Uint64
+	observers          map[uint64]Observer[TEvent]
+	observerIdSequence uint64
+	observersMu        sync.Mutex
 }
 
 func NewObservers[TEvent any]() *Observers[TEvent] {
-    o := &Observers[TEvent]{}
-    o.state.Store(&observersState[TEvent]{observers: map[uint64]Observer[TEvent]{}{}})
-    return o
+	return &Observers[TEvent]{
+		observers: map[uint64]Observer[TEvent]{},
+	}
 }
 
 func (o *Observers[TEvent]) nextObserverId() uint64 {
-    return o.observerIdSequence.Add(1)
+	o.observerIdSequence++
+	return o.observerIdSequence
 }
 
 // Register an observer. Call the returned function to unregister it.
 func (o *Observers[TEvent]) Register(observer Observer[TEvent]) UnregisterFunc {
-    observerId := o.nextObserverId()
-    for {
-        cur := o.state.Load()
-        var curMap map[uint64]Observer[TEvent]
-        if cur != nil {
-            curMap = cur.observers
-        }
-        newMap := make(map[uint64]Observer[TEvent], len(curMap)+1)
-        for k, v := range curMap {
-            newMap[k] = v
-        }
-        newMap[observerId] = observer
-        newState := &observersState[TEvent]{observers: newMap}
-        if o.state.CompareAndSwap(cur, newState) {
-            break
-        }
-    }
-    return o.unregisterFunc(observerId)
+	o.observersMu.Lock()
+	defer o.observersMu.Unlock()
+
+	observerId := o.nextObserverId()
+	o.observers[observerId] = observer
+	return o.unregisterFunc(observerId)
 }
 
 func (o *Observers[TEvent]) unregisterFunc(observerId uint64) UnregisterFunc {
-    return func() {
-        for {
-            cur := o.state.Load()
-            if cur == nil {
-                return
-            }
-            if _, ok := cur.observers[observerId]; !ok {
-                return
-            }
-            newMap := make(map[uint64]Observer[TEvent], len(cur.observers))
-            for k, v := range cur.observers {
-                if k != observerId {
-                    newMap[k] = v
-                }
-            }
-            newState := &observersState[TEvent]{observers: newMap}
-            if o.state.CompareAndSwap(cur, newState) {
-                return
-            }
-        }
-    }
+	return func() {
+		o.observersMu.Lock()
+		defer o.observersMu.Unlock()
+
+		delete(o.observers, observerId)
+	}
 }
 
 // Close unregisters all observers.
 func (o *Observers[TEvent]) Close() {
-    o.state.Store(&observersState[TEvent]{observers: map[uint64]Observer[TEvent][]{}})
+	o.observersMu.Lock()
+	defer o.observersMu.Unlock()
+
+	o.observers = map[uint64]Observer[TEvent]{}
 }
 
 // Notify all observers in parallel without waiting for them to process the event.
 func (o *Observers[TEvent]) Notify(event TEvent) {
-    cur := o.state.Load()
-    if cur == nil {
-        return
-    }
-    for _, observer := range cur.observers {
-        go observer(event)
-    }
+	o.observersMu.Lock()
+	observers := make([]Observer[TEvent], 0, len(o.observers))
+	for _, observer := range o.observers {
+		observers = append(observers, observer)
+	}
+	o.observersMu.Unlock()
+
+	for _, observer := range observers {
+		go observer(event)
+	}
 }
 
 // NotifySync all observers in parallel and wait until all of them process the event.
 func (o *Observers[TEvent]) NotifySync(event TEvent) {
-    cur := o.state.Load()
-    if cur == nil {
-        return
-    }
-    var wg sync.WaitGroup
-    for _, observer := range cur.observers {
-        wg.Add(1)
-        go func(observer Observer[TEvent]) {
-            defer wg.Done()
-            observer(event)
-        }(observer)
-    }
-    wg.Wait()
+	o.observersMu.Lock()
+	observers := make([]Observer[TEvent], 0, len(o.observers))
+	for _, observer := range o.observers {
+		observers = append(observers, observer)
+	}
+	o.observersMu.Unlock()
+
+	var wg sync.WaitGroup
+	for _, observer := range observers {
+		wg.Add(1)
+		go func(observer Observer[TEvent]) {
+			defer wg.Done()
+			observer(event)
+		}(observer)
+	}
+
+	wg.Wait()
 }


### PR DESCRIPTION
This change snapshots the current observer list under the mutex and releases the lock before invoking callbacks in both Notify and NotifySync. Previously, NotifySync held the lock while spawning goroutines and waiting (wg.Wait), which could deadlock if any observer attempted to Register, Unregister, or Close during callback execution. Snapshotting removes the reentrancy deadlock risk while preserving intended semantics: ordering across successive NotifySync calls and snapshot delivery for the current event.