### PR TITLE
cp: handles a bug in receipt values when there's only 1 tx in the block (query only)

### DIFF
--- a/rpc/jsonrpc/receipts/bor_receipts_generator.go
+++ b/rpc/jsonrpc/receipts/bor_receipts_generator.go
@@ -110,7 +110,14 @@ func getBorLogs(msgs []*types.Message, evm *vm.EVM, gp *core.GasPool, ibs *state
 	if receiptWithFirstLogIdx {
 		logIndex = logIdxAfterTx
 	} else {
-		logIndex = logIdxAfterTx - uint(len(receiptLogs))
+		// this check is a hack put in place because for cases where a block had only one tx, which was system
+		// e.g. 50075104 on bor.
+		// the receipt calculation stored 0 for logIdxAfterTx, which leads to underflow
+		// this check allows to adjust for that error (first logIndex is 0 for such cases)
+		// can be removed when receipt files fixed and all users are sure to have it (v2.2)
+		if logIdxAfterTx >= uint(len(receiptLogs)) {
+			logIndex = logIdxAfterTx - uint(len(receiptLogs))
+		}
 	}
 	for i, l := range receiptLogs {
 		l.TxIndex = txIndex


### PR DESCRIPTION
https://github.com/erigontech/erigon/issues/16944