### PR TITLE
Re-enable docker login for tests if secrets are available

### DIFF
--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -27,7 +27,7 @@ jobs:
         # Only login if we can. Workflow works without it but we want to avoid
         # rate limiting by Docker Hub when possible. External repos don't
         # have access to our Docker secrets.
-        if: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_USERNAME != '' }}
+        if: github.repository_owner == 'erigontech'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_USERNAME }}
@@ -57,7 +57,7 @@ jobs:
         # Only login if we can. Workflow works without it but we want to avoid
         # rate limiting by Docker Hub when possible. External repos don't
         # have access to our Docker secrets.
-        if: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_USERNAME != '' }}
+        if: github.repository_owner == 'erigontech'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_USERNAME }}


### PR DESCRIPTION
Reenable docker login which was removed from fb74e8dfe1d30601eed298c57554a6462ff018d3 and raised in https://github.com/erigontech/erigon/pull/17175#pullrequestreview-3250866639. It's needed to avoid rate limiting from Docker. But this change means CI can run for external PRs.