### PR TITLE
qa-tests: remove Amoy from sync-from-scratch

### DIFF
--- a/.github/workflows/qa-sync-from-scratch.yml
+++ b/.github/workflows/qa-sync-from-scratch.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        chain: [ sepolia, hoodi, amoy, chiado ]  # Chain name as specified on the erigon command line
+        chain: [ sepolia, hoodi, chiado ]  # Chain name as specified on the erigon command line
     env:
       ERIGON_DATA_DIR: ${{ github.workspace }}/erigon_data
       ERIGON_QA_PATH: /home/qarunner/erigon-qa


### PR DESCRIPTION
The test started to [fail](https://github.com/erigontech/erigon/actions/runs/17935389511/job/51000529638) for Amoy.