### PR TITLE
polygon/sync: demote log for failed block download to warn

### DIFF
--- a/polygon/sync/sync.go
+++ b/polygon/sync/sync.go
@@ -579,7 +579,7 @@ func (s *Sync) asyncBackwardDownloadBlockBatches(
 	go func() {
 		err := s.backwardDownloadBlockBatches(ctx, fromHash, fromNum, fromPeerId, eventSource, ccb)
 		if err != nil {
-			s.logger.Error(
+			s.logger.Warn(
 				syncLogPrefix("failed to backward download blocks"),
 				"blockNum", fromNum,
 				"blockHash", fromHash,


### PR DESCRIPTION
causes sync to tip test to fail due to its error detection - but this is not a fatal error, we just skip the block event and move on to the next