### PR TITLE
execution: enable engine auth and rpc compat hive tests with fixed failures count

### DIFF
--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -96,8 +96,10 @@ jobs:
           run_suite engine withdrawals 0
           run_suite engine cancun 0
           run_suite engine api 0
-          # run_suite engine auth 0
-          # run_suite rpc compat 0
+          # 3 failures out of 8 tests at time of writing
+          run_suite engine auth 3
+          # 100 failures out of 190 tests at time of writing
+          run_suite rpc compat 100
         continue-on-error: true
 
       - name: Upload output log


### PR DESCRIPTION
green hive run: https://github.com/erigontech/erigon/actions/runs/17954705858/job/51062867181
added issues:
- https://github.com/erigontech/erigon/issues/17225 to fix rpc-compat (geth passes 190/190 - can check here https://hive.ethpandaops.io/#/group/generic)
- https://github.com/erigontech/erigon/issues/17226 to fix engine auth 

adding to CI so we at least dont introduce new regressions