### PR TITLE
[r32] polygon: Set Rio Hard Fork Block for bor-mainnet

### DIFF
--- a/polygon/chain/chainspecs/bor-mainnet.json
+++ b/polygon/chain/chainspecs/bor-mainnet.json
@@ -82,7 +82,12 @@
     "agraBlock": 50523000,
     "napoliBlock": 54876000,
     "ahmedabadBlock": 62278656,
-    "bhilaiBlock": 73440256
+    "bhilaiBlock": 73440256,
+    "rioBlock": 77414656,
+    "coinbase": {
+      "0": "0x0000000000000000000000000000000000000000",
+      "77414656": "0x7Ee41D8A25641000661B1EF5E6AE8A00400466B0"
+    }
   },
   "defaultBlockGasLimit": 45000000
 }


### PR DESCRIPTION
Cherry pick #17254 into `release/3.2`