### PR TITLE
eth/ethconfig: Add --snap.state.stop to BlocksFreezing.String() when ProduceE3 is false

### DIFF
--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -165,6 +165,9 @@ func (s BlocksFreezing) String() string {
 	if !s.ProduceE2 {
 		out = append(out, "--"+FlagSnapStop+"=true")
 	}
+	if !s.ProduceE3 {
+		out = append(out, "--"+FlagSnapStateStop+"=true")
+	}
 	return strings.Join(out, " ")
 }
 


### PR DESCRIPTION
- Include --snap.state.stop=true in BlocksFreezing.String() when ProduceE3 is disabled.
- This aligns the stringified config with the existing CLI flag snap.state.stop, which maps to ProduceE3, and with runtime behavior that relies on ProduceE3 to control state snapshot production.
- Without this, the printed/config-derived flags could mislead users or scripts by omitting the state snapshot stop flag when it is actually in effect.