### PR TITLE
Secure gRPC TLS: remove InsecureSkipVerify and enable proper CA verification

### DIFF
--- a/erigon-lib/gointerfaces/grpcutil/utils.go
+++ b/erigon-lib/gointerfaces/grpcutil/utils.go
@@ -59,12 +59,14 @@ func TLS(tlsCACert, tlsCertFile, tlsKeyFile string) (credentials.TransportCreden
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM(caCert)
 	return credentials.NewTLS(&tls.Config{
+		// Certificates are used both by servers (to present to clients) and by clients (for mTLS)
 		Certificates: []tls.Certificate{peerCert},
-		ClientCAs:    caCertPool,
-		ClientAuth:   tls.RequireAndVerifyClientCert,
-		MinVersion:   tls.VersionTLS12,
-		//nolint:gosec
-		InsecureSkipVerify: true, // This is to make it work when Common Name does not match - remove when procedure is updated for common name
+		// Server side: verify client certificates against provided CA pool
+		ClientCAs: caCertPool,
+		// Client side: verify server certificate chain against provided CA pool
+		RootCAs:    caCertPool,
+		ClientAuth: tls.RequireAndVerifyClientCert,
+		MinVersion: tls.VersionTLS12,
 	}), nil
 }
 


### PR DESCRIPTION


### Description
- Removed insecure `InsecureSkipVerify: true` and set `RootCAs` to the provided CA pool to restore server certificate verification.
- Kept mTLS settings intact (`ClientCAs`, `ClientAuth: RequireAndVerifyClientCert`) and enforced `MinVersion: TLS1.2`.
- Improves security against MitM by validating the server’s cert chain.

### Impact
- More secure client connections; no interface changes required.
- If hostname verification is desired, consider a follow-up to set `tls.Config.ServerName` via a dedicated `ClientTLS(...)`.

