### PR TITLE
cmd/erigoncustom: remove unused customBucketName constant

### DIFF
--- a/cmd/erigoncustom/main.go
+++ b/cmd/erigoncustom/main.go
@@ -30,11 +30,6 @@ import (
 var flag = cli.StringFlag{
 	Name:  "custom-stage-greeting",
 	Value: "default-value",
-}
-
-// defining a custom bucket name
-const (
-	customBucketName = "ch.torquem.demo.tgcustom.CUSTOM_BUCKET" //nolint
 )
 
 // the regular main function
@@ -54,7 +49,7 @@ func runErigon(ctx *cli.Context) error {
 	// running a node and initializing a custom bucket with all default settings
 	//eri := node.New(ctx, node.Params{
 	//	CustomBuckets: map[string]dbutils.BucketConfigItem{
-	//		customBucketName: {},
+	//		"ch.torquem.demo.tgcustom.CUSTOM_BUCKET": {},
 	//	},
 	//})
 


### PR DESCRIPTION

## Summary

Remove unused constant `customBucketName` from `cmd/erigoncustom/main.go` to clean up dead code.

