### PR TITLE
refactor: use b.Loop() to simplify the code and improve performance

### DIFF
--- a/execution/types/accounts/account_benchmark_test.go
+++ b/execution/types/accounts/account_benchmark_test.go
@@ -444,8 +444,8 @@ func BenchmarkIsEmptyCodeHash(b *testing.B) {
 	}
 
 	var isEmpty bool
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		isEmpty = acc.IsEmptyCodeHash()
 	}
 	b.StopTimer()
@@ -462,8 +462,8 @@ func BenchmarkIsEmptyRoot(b *testing.B) {
 	}
 
 	var isEmpty bool
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		isEmpty = acc.IsEmptyRoot()
 	}
 	b.StopTimer()

--- a/execution/types/block_test.go
+++ b/execution/types/block_test.go
@@ -313,9 +313,8 @@ var benchBuffer = bytes.NewBuffer(make([]byte, 0, 32000))
 
 func BenchmarkEncodeBlock(b *testing.B) {
 	block := makeBenchBlock()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		benchBuffer.Reset()
 		if err := rlp.Encode(benchBuffer, block); err != nil {
 			b.Fatal(err)

--- a/execution/types/bloom9_test.go
+++ b/execution/types/bloom9_test.go
@@ -85,7 +85,7 @@ func TestBloomExtensively(t *testing.T) {
 
 func BenchmarkBloom9(b *testing.B) {
 	test := []byte("testestestest")
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		Bloom9(test)
 	}
 }
@@ -93,7 +93,7 @@ func BenchmarkBloom9(b *testing.B) {
 func BenchmarkBloom9Lookup(b *testing.B) {
 	toTest := []byte("testtest")
 	bloom := new(Bloom)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		bloom.Test(toTest)
 	}
 }

--- a/execution/types/encdec_test.go
+++ b/execution/types/encdec_test.go
@@ -679,8 +679,8 @@ func BenchmarkLegacyTxRLP(b *testing.B) {
 	tr := NewTRand()
 	txn := tr.RandTransaction(LegacyTxType)
 	var buf bytes.Buffer
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		buf.Reset()
 		txn.EncodeRLP(&buf)
 	}
@@ -690,8 +690,8 @@ func BenchmarkAccessListTxRLP(b *testing.B) {
 	tr := NewTRand()
 	txn := tr.RandTransaction(AccessListTxType)
 	var buf bytes.Buffer
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		buf.Reset()
 		txn.EncodeRLP(&buf)
 	}
@@ -701,8 +701,8 @@ func BenchmarkDynamicFeeTxRLP(b *testing.B) {
 	tr := NewTRand()
 	txn := tr.RandTransaction(DynamicFeeTxType)
 	var buf bytes.Buffer
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		buf.Reset()
 		txn.EncodeRLP(&buf)
 	}
@@ -712,8 +712,8 @@ func BenchmarkBlobTxRLP(b *testing.B) {
 	tr := NewTRand()
 	txn := tr.RandTransaction(BlobTxType)
 	var buf bytes.Buffer
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		buf.Reset()
 		txn.EncodeRLP(&buf)
 	}
@@ -723,8 +723,8 @@ func BenchmarkSetCodeTxRLP(b *testing.B) {
 	tr := NewTRand()
 	txn := tr.RandTransaction(SetCodeTxType)
 	var buf bytes.Buffer
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		buf.Reset()
 		txn.EncodeRLP(&buf)
 	}
@@ -734,8 +734,8 @@ func BenchmarkWithdrawalRLP(b *testing.B) {
 	tr := NewTRand()
 	w := tr.RandWithdrawal()
 	var buf bytes.Buffer
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		buf.Reset()
 		w.EncodeRLP(&buf)
 	}

--- a/execution/types/hashing_test.go
+++ b/execution/types/hashing_test.go
@@ -114,25 +114,25 @@ var (
 )
 
 func BenchmarkLegacySmallList(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		legacyDeriveSha(smallTxList)
 	}
 }
 
 func BenchmarkCurrentSmallList(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		DeriveSha(smallTxList)
 	}
 }
 
 func BenchmarkLegacyLargeList(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		legacyDeriveSha(largeTxList)
 	}
 }
 
 func BenchmarkCurrentLargeList(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		DeriveSha(largeTxList)
 	}
 }


### PR DESCRIPTION
replace `for i := range b.N` or `for range b.N` in a benchmark with `for b.Loop()`, and remove any preceding calls to `b.StopTimer`,` b.StartTimer`, and `b.ResetTimer`.

Supported by Go Team, more info: https://go.dev/blog/testing-b-loop


Before:

```shell
go test -run=^$ -bench=. ./execution/types -timeout=1h  
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/execution/types
cpu: Apple M4
BenchmarkEncodeBlock-10         	  173065	      6771 ns/op
BenchmarkBloom9-10              	368839657	         3.256 ns/op
BenchmarkBloom9Lookup-10        	 4975617	       240.6 ns/op
BenchmarkCreateBloom/small-10   	 1242428	       964.7 ns/op	       8 B/op	       1 allocs/op
BenchmarkCreateBloom/large-10   	   12807	     93468 ns/op	       8 B/op	       1 allocs/op
BenchmarkHeaderRLP/Encode-10    	 9562680	       124.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkHeaderRLP/Decode-10    	 2297347	       518.4 ns/op	     504 B/op	      15 allocs/op
BenchmarkLegacyTxRLP-10         	16128363	        72.30 ns/op
BenchmarkAccessListTxRLP-10     	 7349416	       185.0 ns/op
BenchmarkDynamicFeeTxRLP-10     	 5958285	       195.3 ns/op
BenchmarkBlobTxRLP-10           	100000000	       148.9 ns/op
BenchmarkSetCodeTxRLP-10        	100000000	       341.8 ns/op
BenchmarkWithdrawalRLP-10       	46775037	        24.73 ns/op
BenchmarkLegacySmallList-10     	   22819	     52377 ns/op
BenchmarkCurrentSmallList-10    	   26280	     45301 ns/op
BenchmarkLegacyLargeList-10     	      21	  53830175 ns/op
BenchmarkCurrentLargeList-10    	      25	  44664355 ns/op
PASS
ok  	github.com/erigontech/erigon/execution/types	74.201s
```

After this change:

```shell
go test -run=^$ -bench=. ./execution/types -timeout=1h  
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/execution/types
cpu: Apple M4
BenchmarkEncodeBlock-10         	  160569	      7002 ns/op
BenchmarkBloom9-10              	33985428	        30.14 ns/op
BenchmarkBloom9Lookup-10        	 4995614	       243.7 ns/op
BenchmarkCreateBloom/small-10   	 1238462	       965.2 ns/op	       8 B/op	       1 allocs/op
BenchmarkCreateBloom/large-10   	   12829	     94128 ns/op	       8 B/op	       1 allocs/op
BenchmarkHeaderRLP/Encode-10    	 9330062	       128.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkHeaderRLP/Decode-10    	 2145024	       572.4 ns/op	     936 B/op	      15 allocs/op
BenchmarkLegacyTxRLP-10         	17637829	        67.74 ns/op
BenchmarkAccessListTxRLP-10     	10397460	       114.7 ns/op
BenchmarkDynamicFeeTxRLP-10     	 5630047	       211.0 ns/op
BenchmarkBlobTxRLP-10           	 8582659	       138.2 ns/op
BenchmarkSetCodeTxRLP-10        	 3109618	       384.2 ns/op
BenchmarkWithdrawalRLP-10       	48780487	        23.98 ns/op
BenchmarkLegacySmallList-10     	   23052	     52040 ns/op
BenchmarkCurrentSmallList-10    	   26418	     45358 ns/op
BenchmarkLegacyLargeList-10     	      21	  53593482 ns/op
BenchmarkCurrentLargeList-10    	      26	  44445859 ns/op
PASS
ok  	github.com/erigontech/erigon/execution/types	24.190s
```