### PR TITLE
chore: add TD to StatusPacket69 for eth handshake

### DIFF
--- a/p2p/protocols/eth/protocol.go
+++ b/p2p/protocols/eth/protocol.go
@@ -181,6 +181,7 @@ type StatusPacket struct {
 type StatusPacket69 struct {
 	ProtocolVersion           uint32
 	NetworkID                 uint64
+	TD                        *big.Int
 	Genesis                   common.Hash
 	ForkID                    forkid.ID
 	MinimumBlock, LatestBlock uint64

--- a/p2p/sentry/eth_handshake.go
+++ b/p2p/sentry/eth_handshake.go
@@ -172,10 +172,12 @@ func encodeStatusPacket(status *sentryproto.StatusData, version uint) eth.Status
 }
 
 func encodeStatusPacket69(status *sentryproto.StatusData, version uint) eth.StatusPacket69 {
+	ourTD := gointerfaces.ConvertH256ToUint256Int(status.TotalDifficulty)
 	genesisHash := gointerfaces.ConvertH256ToHash(status.ForkData.Genesis)
 	return eth.StatusPacket69{
 		ProtocolVersion: uint32(version),
 		NetworkID:       status.NetworkId,
+		TD:              ourTD.ToBig(),
 		Genesis:         genesisHash,
 		ForkID:          forkid.NewIDFromForks(status.ForkData.HeightForks, status.ForkData.TimeForks, genesisHash, status.MaxBlockHeight, status.MaxBlockTime),
 		MinimumBlock:    status.MinimumBlockHeight,


### PR DESCRIPTION
# Description

This addition is required for the `StatusPacket69` for a successful Ethereum handshake with Bor.