### PR TITLE
db/downloader: make FilesTotal reflect torrent count; remove dead accumulation

### DIFF
--- a/db/downloader/downloader.go
+++ b/db/downloader/downloader.go
@@ -662,7 +662,6 @@ func (d *Downloader) newStats(prevStats AggStats) AggStats {
 			noMetadata = append(noMetadata, t.Name())
 			continue
 		}
-		stats.FilesTotal += len(t.Files())
 
 		torrentName := t.Name()
 		torrentComplete := t.Complete().Bool()


### PR DESCRIPTION
Previously, FilesTotal was incremented per torrent using len(t.Files()) inside the loop, but then overwritten after the loop with len(torrents). This made the in-loop accumulation dead code and created inconsistent semantics if multi-file torrents appear in the future. The downloader currently treats files:torrents as 1:1 (per comments and logging), so FilesTotal should reflect the number of torrents. This change removes the redundant accumulation and keeps the single post-loop assignment, preventing confusion and ensuring the metric matches intended semantics. No functional behavior change beyond eliminating misleading intermediate state.