### PR TITLE
cl/phase1: use cancellable context for BatchSignatureVerifier to prevent goroutine leaks

### DIFF
--- a/cl/phase1/network/services/aggregate_and_proof_service_test.go
+++ b/cl/phase1/network/services/aggregate_and_proof_service_test.go
@@ -77,7 +77,9 @@ func setupAggregateAndProofTest(t *testing.T) (AggregateAndProofService, *synced
 	forkchoiceMock := mock_services.NewForkChoiceStorageMock(t)
 	p := pool.OperationsPool{}
 	p.AttestationsPool = pool.NewOperationPool[common.Bytes96, *solid.Attestation](100, "test")
-	batchSignatureVerifier := NewBatchSignatureVerifier(context.TODO(), nil)
+	verifierCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	batchSignatureVerifier := NewBatchSignatureVerifier(verifierCtx, nil)
 	go batchSignatureVerifier.Start()
 	blockService := NewAggregateAndProofService(ctx, syncedDataManager, forkchoiceMock, cfg, p, true, batchSignatureVerifier)
 	return blockService, syncedDataManager, forkchoiceMock


### PR DESCRIPTION
- Replace context.TODO() with context.WithCancel in aggregate_and_proof_service_test.go.
- Register t.Cleanup(cancel) to ensure verifier goroutines terminate after tests.
- Keep service under test in test mode; no functional changes to verification logic.