### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/db/seg/decompress.go
+++ b/db/seg/decompress.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"sync/atomic"
@@ -634,12 +635,7 @@ func (g *Getter) nextPattern() []byte {
 var condensedWordDistances = buildCondensedWordDistances()
 
 func checkDistance(power int, d int) bool {
-	for _, dist := range condensedWordDistances[power] {
-		if dist == d {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(condensedWordDistances[power], d)
 }
 
 func buildCondensedWordDistances() [][]int {

--- a/db/snapshotsync/snapshots.go
+++ b/db/snapshotsync/snapshots.go
@@ -703,12 +703,7 @@ func (s *RoSnapshots) LogStat(label string) {
 
 func (s *RoSnapshots) Types() []snaptype.Type { return s.types }
 func (s *RoSnapshots) HasType(in snaptype.Type) bool {
-	for _, t := range s.enums {
-		if t == in.Enum() {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(s.enums, in.Enum())
 }
 
 type ready struct {

--- a/db/snaptype/type.go
+++ b/db/snaptype/type.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 
@@ -351,14 +352,7 @@ func (s snapType) IdxFileName(ver version.Version, from uint64, to uint64, index
 		index = []Index{s.indexes[0]}
 	} else {
 		i := index[0]
-		found := false
-
-		for _, index := range s.indexes {
-			if i == index {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(s.indexes, i)
 
 		if !found {
 			return ""

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -176,10 +177,8 @@ func (p *Peer) Caps() []Cap {
 // versions is supported by both this node and the peer p.
 func (p *Peer) RunningCap(protocol string, versions []uint) bool {
 	if proto, ok := p.running[protocol]; ok {
-		for _, ver := range versions {
-			if proto.Version == ver {
-				return true
-			}
+		if slices.Contains(versions, proto.Version) {
+			return true
 		}
 	}
 	return false


### PR DESCRIPTION
The new pr for https://github.com/erigontech/erigon/pull/16800


There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.

