### PR TITLE
refactor: omit unnecessary reassignment

### DIFF
--- a/cmd/pics/state.go
+++ b/cmd/pics/state.go
@@ -141,7 +141,6 @@ func stateDatabaseComparison(first kv.RwDB, second kv.RwDB, number int) error {
 	if err = second.View(context.Background(), func(readTx kv.Tx) error {
 		return first.View(context.Background(), func(firstTx kv.Tx) error {
 			for bucketName := range bucketLabels {
-				bucketName := bucketName
 				if err := readTx.ForEach(bucketName, nil, func(k, v []byte) error {
 					if firstV, _ := firstTx.GetOne(bucketName, k); firstV != nil && bytes.Equal(v, firstV) {
 						// Skip the record that is the same as in the first Db

--- a/common/dir/rw_dir.go
+++ b/common/dir/rw_dir.go
@@ -161,7 +161,6 @@ func DeleteFiles(dirs ...string) error {
 			return err
 		}
 		for _, fPath := range files {
-			fPath := fPath
 			g.Go(func() error { return RemoveFile(fPath) })
 		}
 	}

--- a/common/tuples_test.go
+++ b/common/tuples_test.go
@@ -340,7 +340,6 @@ func Test2Tuple(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		test := test
 		t.Run(fmt.Sprintf("testcase %d", i), func(t *testing.T) {
 			tuples := NewTuples(len(test.putsBucket), 2, 1)
 			for _, value := range test.putsBucket {
@@ -702,7 +701,6 @@ func Test3Tuple(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		test := test
 		t.Run(fmt.Sprintf("testcase %d", i), func(t *testing.T) {
 			tuples := NewTuples(len(test.putsBucket), 3, 1)
 			for _, value := range test.putsBucket {

--- a/db/downloader/downloader.go
+++ b/db/downloader/downloader.go
@@ -866,7 +866,6 @@ func (d *Downloader) VerifyData(
 		// set limit here just to make load predictable, not to control Disk/CPU consumption
 		g.SetLimit(runtime.GOMAXPROCS(-1) * 4)
 		for _, t := range toVerify {
-			t := t
 			g.Go(func() error {
 				defer completedFiles.Add(1)
 				return VerifyFileFailFast(ctx, t, d.SnapDir(), &completedBytes)

--- a/db/downloader/util.go
+++ b/db/downloader/util.go
@@ -202,7 +202,6 @@ func BuildTorrentFilesIfNeed(ctx context.Context, dirs datadir.Dirs, torrentFile
 	var createdAmount atomic.Int32
 
 	for _, file := range files {
-		file := file
 
 		if ignore.Contains(file) {
 			i.Add(1)

--- a/db/integrity/e3_ef_files.go
+++ b/db/integrity/e3_ef_files.go
@@ -33,7 +33,6 @@ func E3EfFiles(ctx context.Context, db kv.TemporalRwDB, failFast bool, fromStep 
 	defer logEvery.Stop()
 	g := &errgroup.Group{}
 	for _, idx := range []kv.InvertedIdx{kv.AccountsHistoryIdx, kv.StorageHistoryIdx, kv.CodeHistoryIdx, kv.CommitmentHistoryIdx, kv.ReceiptHistoryIdx, kv.LogTopicIdx, kv.LogAddrIdx, kv.TracesFromIdx, kv.TracesToIdx} {
-		idx := idx
 		g.Go(func() error {
 			tx, err := db.BeginTemporalRo(ctx)
 			if err != nil {

--- a/db/kv/mdbx/kv_abstract_test.go
+++ b/db/kv/mdbx/kv_abstract_test.go
@@ -48,7 +48,6 @@ func TestSequence(t *testing.T) {
 	ctx := context.Background()
 
 	for _, db := range writeDBs {
-		db := db
 		tx, err := db.BeginRw(ctx)
 		require.NoError(t, err)
 		defer tx.Rollback()
@@ -101,7 +100,6 @@ func TestManagedTx(t *testing.T) {
 	ctx := context.Background()
 
 	for _, db := range writeDBs {
-		db := db
 		tx, err := db.BeginRw(ctx)
 		require.NoError(t, err)
 		defer tx.Rollback()
@@ -129,7 +127,6 @@ func TestManagedTx(t *testing.T) {
 	}
 
 	for _, db := range readDBs {
-		db := db
 		msg := fmt.Sprintf("%T", db)
 		switch db.(type) {
 		case *remotedb.DB:

--- a/db/snapshotsync/freezeblocks/block_reader.go
+++ b/db/snapshotsync/freezeblocks/block_reader.go
@@ -1302,7 +1302,6 @@ func (r *BlockReader) IterateFrozenBodies(f func(blockNum, baseTxNum, txCount ui
 	view := r.sn.View()
 	defer view.Close()
 	for _, sn := range view.Bodies() {
-		sn := sn
 		defer sn.Src().MadvSequential().DisableReadAhead()
 
 		var buf []byte

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -397,7 +397,6 @@ func (a *Aggregator) Close() {
 func (a *Aggregator) closeDirtyFiles() {
 	wg := &sync.WaitGroup{}
 	for _, d := range a.d {
-		d := d
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -405,7 +404,6 @@ func (a *Aggregator) closeDirtyFiles() {
 		}()
 	}
 	for _, ii := range a.iis {
-		ii := ii
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/db/state/dirty_files.go
+++ b/db/state/dirty_files.go
@@ -498,7 +498,6 @@ func (ii *InvertedIndex) openDirtyFiles() error {
 	invalidFileItemsLock := sync.Mutex{}
 	ii.dirtyFiles.Walk(func(items []*FilesItem) bool {
 		for _, item := range items {
-			item := item
 			fromStep, toStep := kv.Step(item.startTxNum/ii.stepSize), kv.Step(item.endTxNum/ii.stepSize)
 			if item.decompressor == nil {
 				fPathPattern := ii.efFilePathMask(fromStep, toStep)

--- a/db/state/history.go
+++ b/db/state/history.go
@@ -349,7 +349,6 @@ func (h *History) buildVI(ctx context.Context, historyIdxPath string, hist, efHi
 func (h *History) BuildMissedAccessors(ctx context.Context, g *errgroup.Group, ps *background.ProgressSet, historyFiles *MissedAccessorHistoryFiles) {
 	h.InvertedIndex.BuildMissedAccessors(ctx, g, ps, historyFiles.ii)
 	for _, item := range historyFiles.missedMapAccessors() {
-		item := item
 		g.Go(func() error {
 			return h.buildVi(ctx, item, ps)
 		})

--- a/db/state/inverted_index.go
+++ b/db/state/inverted_index.go
@@ -282,7 +282,6 @@ func (iit *InvertedIndexRoTx) dataWriter(f *seg.Compressor, forceNoCompress bool
 // BuildMissedAccessors - produce .efi/.vi/.kvi from .ef/.v/.kv
 func (ii *InvertedIndex) BuildMissedAccessors(ctx context.Context, g *errgroup.Group, ps *background.ProgressSet, iiFiles *MissedAccessorIIFiles) {
 	for _, item := range iiFiles.missedMapAccessors() {
-		item := item
 		g.Go(func() error {
 			return ii.buildEfAccessor(ctx, item, ps)
 		})


### PR DESCRIPTION
The new version of Go has been optimized, and variables do not need to be reassigned.

For more info: https://tip.golang.org/wiki/LoopvarExperiment#does-this-mean-i-dont-have-to-write-x--x-in-my-loops-anymore


```shell
Does this mean I don’t have to write x := x in my loops anymore?[¶](https://tip.golang.org/wiki/LoopvarExperiment#does-this-mean-i-dont-have-to-write-x--x-in-my-loops-anymore)

After you update your module to use go1.22 or a later version, yes.
```