### PR TITLE
(r *Receipt) decodeTyped: Add eip7702 case

### DIFF
--- a/execution/types/receipt.go
+++ b/execution/types/receipt.go
@@ -215,7 +215,7 @@ func (r *Receipt) decodeTyped(b []byte) error {
 		return errShortTypedReceipt
 	}
 	switch b[0] {
-	case DynamicFeeTxType, AccessListTxType, BlobTxType:
+	case DynamicFeeTxType, AccessListTxType, BlobTxType, SetCodeTxType:
 		var data receiptRLP
 		err := rlp.DecodeBytes(b[1:], &data)
 		if err != nil {


### PR DESCRIPTION
The unmarshalling of receipts was missing the case for EIP 7702 transactions, failing where it should not. I'm opening a PR as this function is not used, so it is not a bug atm.