### PR TITLE
security: remove InsecureSkipVerify from TLS configuration

### DIFF
--- a/node/gointerfaces/grpcutil/utils.go
+++ b/node/gointerfaces/grpcutil/utils.go
@@ -63,8 +63,6 @@ func TLS(tlsCACert, tlsCertFile, tlsKeyFile string) (credentials.TransportCreden
 		ClientCAs:    caCertPool,
 		ClientAuth:   tls.RequireAndVerifyClientCert,
 		MinVersion:   tls.VersionTLS12,
-		//nolint:gosec
-		InsecureSkipVerify: true, // This is to make it work when Common Name does not match - remove when procedure is updated for common name
 	}), nil
 }
 


### PR DESCRIPTION

The previous configuration disabled server certificate verification, making connections vulnerable to man-in-the-middle attacks. This change restores proper TLS authentication while maintaining encryption.

