### PR TITLE
db/rawdb: correct DeleteNewerEpochs to delete from PendingEpoch first

### DIFF
--- a/db/rawdb/accessors_chain.go
+++ b/db/rawdb/accessors_chain.go
@@ -977,7 +977,7 @@ func ReadHeaderByHash(db kv.Getter, hash common.Hash) (*types.Header, error) {
 
 func DeleteNewerEpochs(tx kv.RwTx, number uint64) error {
 	if err := tx.ForEach(kv.PendingEpoch, hexutil.EncodeTs(number), func(k, v []byte) error {
-		return tx.Delete(kv.Epoch, k)
+		return tx.Delete(kv.PendingEpoch, k)
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix DeleteNewerEpochs to delete entries from kv.PendingEpoch during the first pass instead of kv.Epoch. PendingEpoch stores unfinalized “epoch-end signal” records, while Epoch stores finalized transitions. On reorg/truncation we must clear newer records in each table independently. The previous implementation mistakenly iterated over kv.PendingEpoch but deleted from kv.Epoch, leaving stale PendingEpoch entries and risking accidental deletion mismatch. This change aligns deletion with the correct bucket and the AuRa lifecycle.