### PR TITLE
Return proper error when no snapshot files exist

### DIFF
--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -1076,7 +1076,9 @@ func checkIfStateSnapshotsPublishable(dirs datadir.Dirs) error {
 	sort.Slice(accFiles, func(i, j int) bool {
 		return (accFiles[i].From < accFiles[j].From) || (accFiles[i].From == accFiles[j].From && accFiles[i].To < accFiles[j].To)
 	})
-
+	if len(accFiles) == 0 {
+		return fmt.Errorf("no account snapshot files (.kv) found in %s", dirs.SnapDomain)
+	}
 	if accFiles[0].From != 0 {
 		return fmt.Errorf("gap at start: state snaps start at (%d-%d). snaptype: accounts", accFiles[0].From, accFiles[0].To)
 	}
@@ -1176,6 +1178,9 @@ func checkIfStateSnapshotsPublishable(dirs datadir.Dirs) error {
 	sort.Slice(accFiles, func(i, j int) bool {
 		return (accFiles[i].From < accFiles[j].From) || (accFiles[i].From == accFiles[j].From && accFiles[i].To < accFiles[j].To)
 	})
+	if len(accFiles) == 0 {
+		return fmt.Errorf("no account inverted index files (.ef) found in %s", dirs.SnapIdx)
+	}
 	if accFiles[0].From != 0 {
 		return fmt.Errorf("gap at start: state ef snaps start at (%d-%d). snaptype: accounts", accFiles[0].From, accFiles[0].To)
 	}


### PR DESCRIPTION
Added `len(intervals) == 0` check in `doBlockSnapshotsRangeCheck()` function.
Returns descriptive error instead of panicking when no snapshot files exist.

```bash
# Before
$ ./build/bin/erigon seg integrity --datadir ~/Library/Erigon --failFast
...
panic: runtime error: index out of range [0] with length 0

# After
$ ./build/bin/erigon seg integrity --datadir ~/Library/Erigon --failFast
...
Error: no snapshot files found in /Users/.../Erigon/snapshots for type: headers
```

resolve https://github.com/erigontech/erigon/issues/17227