### PR TITLE
nodedb: set `dbSyncPeriod=5mb`

### DIFF
--- a/p2p/enode/nodedb.go
+++ b/p2p/enode/nodedb.go
@@ -63,10 +63,12 @@ const (
 )
 
 const (
-	dbNodeExpiration     = 24 * time.Hour // Time after which an unseen node should be dropped.
-	dbCleanupCycle       = time.Hour      // Time period for running the expiration task.
-	dbVersion            = 10
-	dbSyncBytesThreshold = 20_000 // if we have about 20kb of dirty data , then flush to disk
+	dbNodeExpiration = 24 * time.Hour // Time after which an unseen node should be dropped.
+	dbCleanupCycle   = time.Hour      // Time period for running the expiration task.
+	dbVersion        = 10
+
+	dbSyncBytesThreshold = 5 * datasize.MB // see BenchmarkSyncPeriodDefault
+	dbSyncPeriod         = 2 * time.Second
 )
 
 var (
@@ -128,7 +130,7 @@ func newPersistentDB(ctx context.Context, logger log.Logger, path string) (*DB, 
 		GrowthStep(16 * datasize.MB).
 		Flags(func(f uint) uint { return f&^mdbx1.Durable | mdbx1.SafeNoSync }).
 		SyncBytes(dbSyncBytesThreshold).
-		SyncPeriod(2 * time.Second).
+		SyncPeriod(dbSyncPeriod).
 		DirtySpace(uint64(32 * datasize.MB)).
 		// WithMetrics().
 		Open(ctx)


### PR DESCRIPTION
current benchmarks show that after 5mb speed doesn't grow - but benchmarks are very unreliable yet (don't know yet why).
form another side - user reported best performance at 20mb. 
So, setting to 5mb for now - until getting more bench-driven evidence. 
```
BenchmarkSyncPeriodDefault/20kb-16         	    1383	   4112960 ns/op	        20.00 ms_worst
BenchmarkSyncPeriodDefault/200kb-16        	    7178	   1106435 ns/op	        15.00 ms_worst
BenchmarkSyncPeriodDefault/1mb-16          	   18532	    328017 ns/op	        14.00 ms_worst
BenchmarkSyncPeriodDefault/2mb-16          	   33478	    193897 ns/op	        12.00 ms_worst
BenchmarkSyncPeriodDefault/5mb-16          	   72160	    100291 ns/op	        13.00 ms_worst
BenchmarkSyncPeriodDefault/10mb-16         	   77170	     99663 ns/op	        12.00 ms_worst
BenchmarkSyncPeriodDefault/20mb-16         	   67716	     97053 ns/op	        15.00 ms_worst
BenchmarkSyncPeriodDefault/40mb-16         	   74607	     97140 ns/op	        13.00 ms_worst
```
for https://github.com/erigontech/erigon/issues/14182

it also depends on: https://github.com/erigontech/erigon/pull/17284 (because it fixing bug of wrong `WANNA_RECOVERY` assert - Erigon can't start without this fix). But unlikely we will port new mdbx to `3.2` (will see how it work in `main`).

will continue work on benches in https://github.com/erigontech/erigon/pull/17405 