### PR TITLE
db/seg: fix MatchPrefixUncompressed/MatchCmpUncompressed empty-input semantics

### DIFF
--- a/db/seg/decompress.go
+++ b/db/seg/decompress.go
@@ -991,10 +991,10 @@ func (g *Getter) MatchPrefixUncompressed(prefix []byte) bool {
 	wordLen-- // because when create huffman tree we do ++ , because 0 is terminator
 	prefixLen := len(prefix)
 	if wordLen == 0 && prefixLen != 0 {
-		return true
+		return false
 	}
 	if prefixLen == 0 {
-		return false
+		return true
 	}
 
 	g.nextPos(true)
@@ -1015,6 +1015,9 @@ func (g *Getter) MatchCmpUncompressed(buf []byte) int {
 		return 1
 	}
 	if bufLen == 0 {
+		if wordLen == 0 {
+			return 0
+		}
 		return -1
 	}
 

--- a/db/seg/decompress_test.go
+++ b/db/seg/decompress_test.go
@@ -351,6 +351,45 @@ func TestUncompressed(t *testing.T) {
 
 }
 
+func TestMatchPrefixUncompressed_EmptyCases(t *testing.T) {
+	d := prepareLoremDictUncompressed(t)
+	defer d.Close()
+	g := d.MakeGetter()
+
+	// At beginning, first word is empty string due to sorting in prepareLoremDictUncompressed
+	require.True(t, g.MatchPrefixUncompressed(nil))
+	require.True(t, g.MatchPrefixUncompressed([]byte{}))
+	require.False(t, g.MatchPrefixUncompressed([]byte("a")))
+
+	// Move to next (non-empty) word and verify empty prefix still matches
+	_, l := g.SkipUncompressed()
+	require.Equal(t, 0, l) // first was empty
+	_, l = g.SkipUncompressed()
+	require.Greater(t, l, 0)
+	require.True(t, g.MatchPrefixUncompressed(nil))
+	require.True(t, g.MatchPrefixUncompressed([]byte{}))
+}
+
+func TestMatchCmpUncompressed_EmptyCases(t *testing.T) {
+	d := prepareLoremDictUncompressed(t)
+	defer d.Close()
+	g := d.MakeGetter()
+
+	// First word is empty string; both empty should be equal
+	require.Equal(t, 0, g.MatchCmpUncompressed(nil))
+	require.Equal(t, 0, g.MatchCmpUncompressed([]byte{}))
+	// Non-empty buffer vs empty word: buffer > word -> 1
+	require.Equal(t, 1, g.MatchCmpUncompressed([]byte("a")))
+
+	// Move to a non-empty word and check empty buffer is less (-1)
+	_, l := g.SkipUncompressed()
+	require.Equal(t, 0, l) // first was empty
+	_, l = g.SkipUncompressed()
+	require.Greater(t, l, 0)
+	require.Equal(t, -1, g.MatchCmpUncompressed(nil))
+	require.Equal(t, -1, g.MatchCmpUncompressed([]byte{}))
+}
+
 func TestDecompressor_OpenCorrupted(t *testing.T) {
 	var loremStrings = append(strings.Split(rmNewLine(lorem), " "), "") // including emtpy string - to trigger corner cases
 	logger := log.New()


### PR DESCRIPTION
Problem: Uncompressed match helpers had inverted/incorrect handling of empty inputs. MatchPrefixUncompressed returned true for non-empty prefix against an empty word and false for an empty prefix. MatchCmpUncompressed returned -1 for an empty buffer even when the word was also empty (should be equal).
Reason for changes: Align uncompressed behavior with standard string semantics and with the compressed counterparts (MatchPrefix/MatchCmp). This ensures consistent API behavior regardless of compression mode and prevents false positives/negatives during prefix checks and comparisons.

Changes:
- MatchPrefixUncompressed: empty prefix now matches any word; non-empty prefix does not match an empty word.
- MatchCmpUncompressed: both-empty comparison now returns 0 (equal).