### PR TITLE
Add cli tool to fetch and recover blobs from a remote beacon api.

### DIFF
--- a/cl/beacon/handler/blobs.go
+++ b/cl/beacon/handler/blobs.go
@@ -57,11 +57,6 @@ func (a *ApiHandler) GetEthV1BeaconBlobSidecars(w http.ResponseWriter, r *http.R
 		return nil, beaconhttp.NewEndpointError(http.StatusNotFound, errors.New("block not found"))
 	}
 
-	// reject after fulu fork
-	if a.beaconChainCfg.GetCurrentStateVersion(*slot/a.beaconChainCfg.SlotsPerEpoch) >= clparams.FuluVersion {
-		return nil, beaconhttp.NewEndpointError(http.StatusNotFound, errors.New("blobs are not supported after fulu fork"))
-	}
-
 	if a.caplinSnapshots != nil && *slot <= a.caplinSnapshots.FrozenBlobs() {
 		out, err := a.caplinSnapshots.ReadBlobSidecars(*slot)
 		if err != nil {

--- a/cmd/capcli/cli.go
+++ b/cmd/capcli/cli.go
@@ -368,6 +368,7 @@ func (c *ChainEndpoint) Run(ctx *Context) error {
 		defer tx.Rollback()
 
 		stringifiedRoot := common.Bytes2Hex(currentRoot[:])
+
 		// Let's fetch the head first
 		currentBlock, err := retrieveAndSanitizeBlockFromRemoteEndpoint(ctx, beaconConfig, fmt.Sprintf("%s/0x%s", baseUri, stringifiedRoot), (*common.Hash)(&currentRoot))
 		if err != nil {


### PR DESCRIPTION
Usage:

`make capcli`

`./build/bin/capcli chain-endpoint --blobs --chain=<sepolia,hoodi,etc...> --endpoint URL --datadir <DATADIR>`