### PR TITLE
refactor: use b.Loop() in benchmark tests for better performance

### DIFF
--- a/execution/commitment/commitment_bench_test.go
+++ b/execution/commitment/commitment_bench_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func BenchmarkBranchMerger_Merge(b *testing.B) {
-	b.StopTimer()
+
 	row, bm := generateCellRow(b, 16)
 
 	be := NewBranchEncoder(1024)
@@ -49,10 +49,9 @@ func BenchmarkBranchMerger_Merge(b *testing.B) {
 		copies[i] = common.Copy(enc1)
 	}
 
-	b.StartTimer()
 	bmg := NewHexBranchMerger(4096)
 	var ci int
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := bmg.Merge(enc, copies[ci])
 		if err != nil {
 			b.Fatal(err)
@@ -93,10 +92,8 @@ func BenchmarkBranchData_ReplacePlainKeys(b *testing.B) {
 	enc, _, err := be.EncodeBranch(bm, bm, bm, cg)
 	require.NoError(b, err)
 
-	b.ResetTimer()
-
 	original := common.Copy(enc)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		target := make([]byte, 0, len(enc))
 		oldKeys := make([][]byte, 0)
 		replaced, err := enc.ReplacePlainKeys(target, func(key []byte, isStorage bool) ([]byte, error) {

--- a/execution/commitment/hex_patricia_hashed_bench_test.go
+++ b/execution/commitment/hex_patricia_hashed_bench_test.go
@@ -53,10 +53,8 @@ func Benchmark_HexPatriciaHashed_Process(b *testing.B) {
 	upds := WrapKeyUpdates(b, ModeDirect, KeyToHexNibbleHash, nil, nil)
 	defer upds.Close()
 
-	b.ResetTimer()
-
 	ctx := context.Background()
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		if i+5 >= len(pk) {
 			i = 0
 		}

--- a/execution/rlp/decode_test.go
+++ b/execution/rlp/decode_test.go
@@ -1099,9 +1099,8 @@ func BenchmarkDecode(b *testing.B) {
 	enc := encodeTestSlice(90000)
 	b.SetBytes(int64(len(enc)))
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		var s []uint
 		if err := DecodeBytes(enc, &s); err != nil {
 			b.Fatalf("Decode error: %v", err)
@@ -1113,10 +1112,9 @@ func BenchmarkDecodeIntSliceReuse(b *testing.B) {
 	enc := encodeTestSlice(100000)
 	b.SetBytes(int64(len(enc)))
 	b.ReportAllocs()
-	b.ResetTimer()
 
 	var s []uint
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if err := DecodeBytes(enc, &s); err != nil {
 			b.Fatalf("Decode error: %v", err)
 		}

--- a/execution/rlp/encode_test.go
+++ b/execution/rlp/encode_test.go
@@ -484,14 +484,14 @@ func TestEncodeToReaderReturnToPool(t *testing.T) {
 var sink interface{}
 
 func BenchmarkIntsize(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		sink = intsize(0x12345678)
 	}
 }
 
 func BenchmarkPutint(b *testing.B) {
 	buf := make([]byte, 8)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		putint(buf, 0x12345678)
 		sink = buf
 	}
@@ -503,10 +503,10 @@ func BenchmarkEncodeBigInts(b *testing.B) {
 		ints[i] = math.BigPow(2, int64(i))
 	}
 	out := bytes.NewBuffer(make([]byte, 0, 4096))
-	b.ResetTimer()
+
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		out.Reset()
 		if err := Encode(out, ints); err != nil {
 			b.Fatal(err)

--- a/execution/state/state_object_test.go
+++ b/execution/state/state_object_test.go
@@ -28,7 +28,7 @@ import (
 
 func BenchmarkCutOriginal(b *testing.B) {
 	value := common.HexToHash("0x01")
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		bytes.TrimLeft(value[:], "\x00")
 	}
 }
@@ -36,14 +36,14 @@ func BenchmarkCutOriginal(b *testing.B) {
 func BenchmarkCutsetterFn(b *testing.B) {
 	value := common.HexToHash("0x01")
 	cutSetFn := func(r rune) bool { return r == 0 }
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		bytes.TrimLeftFunc(value[:], cutSetFn)
 	}
 }
 
 func BenchmarkCutCustomTrim(b *testing.B) {
 	value := common.HexToHash("0x01")
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		common.TrimLeftZeroes(value[:])
 	}
 }

--- a/execution/state/versionmap_test.go
+++ b/execution/state/versionmap_test.go
@@ -270,7 +270,7 @@ func BenchmarkReadTimeSameLocationDifferentTxIdx(b *testing.B) {
 	ap2 := getCommonAddress(2)
 	txIdxSlice := []int{}
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		txIdx := rand.Intn(1000000000000000)
 		txIdxSlice = append(txIdxSlice, txIdx)
 		mvh2.Write(ap2, AddressPath, common.Hash{}, Version{0, 0, txIdx, 1}, valueFor(txIdx, 1), true)


### PR DESCRIPTION
replace `for i := range b.N` or `for range b.N` in a benchmark with `for b.Loop()`, and remove any preceding calls to `b.StopTimer`,` b.StartTimer`, and `b.ResetTimer`.

Supported by Go Team, more info: https://go.dev/blog/testing-b-loop

Before this change:

```shell
go test -run=^$ -bench=. ./execution/commitment   
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/execution/commitment
cpu: Apple M4
BenchmarkBranchMerger_Merge-10             	308274999	         3.742 ns/op
BenchmarkBranchData_ReplacePlainKeys-10    	  204972	      5411 ns/op
--- BENCH: BenchmarkBranchData_ReplacePlainKeys-10
    commitment_bench_test.go:70: touchMap 1000011011100101, afterMap 1000011011100101
           0 => {hash=[35e72a782b51d9c98548467e3f868294d923cdbbdf4ce326c867bd972c4a2395]}
           2 => {hashedExtension=[09],hash=[3b51781a76dc87640aea038e3fdd8adca94049aaa436735b162881ec159f6fb4]}
           5 => {hash=[1aa2fa41b5fb019e8abf8fc32800805a2743cfa15373cf64ba16f4f70e683d8e]}
           6 => {storageAddr=[a192d905]}
           7 => {storageAddr=[f993d905]}
           9 => {storageAddr=[e594d905]}
           a => {hash=[8642542ff3ce7d63b9703e85eb924ab3071aa39c25b1651c6dda4216387478f1]}
           f => {storageAddr=[bd96d905]}
    commitment_bench_test.go:81: 6 spk a192d905 offt 11946273
	... [output truncated]
Benchmark_HexPatriciaHashed_Process-10     	
   62445	     22628 ns/op
--- BENCH: Benchmark_HexPatriciaHashed_Process-10
    hex_patricia_hashed_bench_test.go:38: keys count: 841274
    hex_patricia_hashed_bench_test.go:47: 841274 keys generated
    hex_patricia_hashed_bench_test.go:38: keys count: 841274
    hex_patricia_hashed_bench_test.go:47: 841274 keys generated
    hex_patricia_hashed_bench_test.go:38: keys count: 841274
    hex_patricia_hashed_bench_test.go:47: 841274 keys generated
    hex_patricia_hashed_bench_test.go:38: keys count: 841274
    hex_patricia_hashed_bench_test.go:47: 841274 keys generated
PASS
ok  	github.com/erigontech/erigon/execution/commitment	9.388s



 go test -run=^$ -bench=. ./execution/rlp
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/execution/rlp
cpu: Apple M4
BenchmarkDecode-10                       	     582	   1929317 ns/op	 152.43 MB/s	 2259247 B/op	      57 allocs/op
BenchmarkDecodeIntSliceReuse-10          	     601	   1962337 ns/op	 170.25 MB/s	    5649 B/op	       2 allocs/op
BenchmarkIntsize-10                      	1000000000	         0.9943 ns/op
BenchmarkPutint-10                       	74961156	        15.00 ns/op
BenchmarkEncodeBigInts-10                	  368191	      3245 ns/op	      24 B/op	       1 allocs/op
BenchmarkEncodeConcurrentInterface-10    	 2493554	       477.5 ns/op
PASS
ok  	github.com/erigontech/erigon/execution/rlp	9.221s



go test -run=^$ -bench=. ./execution/state   
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/execution/state
cpu: Apple M4
BenchmarkCutOriginal-10                            	100000000	        10.08 ns/op
BenchmarkCutsetterFn-10                            	35489570	        33.78 ns/op
BenchmarkCutCustomTrim-10                          	127907928	         9.220 ns/op
BenchmarkWriteTimeSameLocationDifferentTxIdx-10    	 2196718	       610.9 ns/op
BenchmarkReadTimeSameLocationDifferentTxIdx-10     	 3642621	       361.7 ns/op
PASS
ok  	github.com/erigontech/erigon/execution/state	12.403s
```


After:


```shell
go test -run=^$ -bench=. ./execution/commitment            
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/execution/commitment
cpu: Apple M4
BenchmarkBranchMerger_Merge-10             	303972283	         3.844 ns/op
BenchmarkBranchData_ReplacePlainKeys-10    	  202100	      5829 ns/op
--- BENCH: BenchmarkBranchData_ReplacePlainKeys-10
    commitment_bench_test.go:69: touchMap 1000011011100101, afterMap 1000011011100101
           0 => {hash=[35e72a782b51d9c98548467e3f868294d923cdbbdf4ce326c867bd972c4a2395]}
           2 => {hashedExtension=[09],hash=[3b51781a76dc87640aea038e3fdd8adca94049aaa436735b162881ec159f6fb4]}
           5 => {hash=[1aa2fa41b5fb019e8abf8fc32800805a2743cfa15373cf64ba16f4f70e683d8e]}
           6 => {storageAddr=[a192d905]}
           7 => {storageAddr=[f993d905]}
           9 => {storageAddr=[e594d905]}
           a => {hash=[8642542ff3ce7d63b9703e85eb924ab3071aa39c25b1651c6dda4216387478f1]}
           f => {storageAddr=[bd96d905]}
    commitment_bench_test.go:80: 6 spk a192d905 offt 11946273
	... [output truncated]
Benchmark_HexPatriciaHashed_Process-10     	   64748	     19746 ns/op
--- BENCH: Benchmark_HexPatriciaHashed_Process-10
    hex_patricia_hashed_bench_test.go:38: keys count: 841274
    hex_patricia_hashed_bench_test.go:47: 841274 keys generated
PASS
ok  	github.com/erigontech/erigon/execution/commitment	5.995s



go test -run=^$ -bench=. ./execution/rlp       
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/execution/rlp
cpu: Apple M4
BenchmarkDecode-10                       	     574	   1930921 ns/op	 152.30 MB/s	 2259254 B/op	      57 allocs/op
BenchmarkDecodeIntSliceReuse-10          	     616	   1926797 ns/op	 173.39 MB/s	    5512 B/op	       2 allocs/op
BenchmarkIntsize-10                      	686429968	         1.763 ns/op
BenchmarkPutint-10                       	89950531	        13.13 ns/op
BenchmarkEncodeBigInts-10                	  362244	      3291 ns/op	      24 B/op	       1 allocs/op
BenchmarkEncodeConcurrentInterface-10    	 2595249	       465.4 ns/op
PASS
ok  	github.com/erigontech/erigon/execution/rlp	8.014s


go test -run=^$ -bench=. ./execution/state   
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/execution/state
cpu: Apple M4
BenchmarkCutOriginal-10                            	100000000	        10.66 ns/op
BenchmarkCutsetterFn-10                            	35131204	        34.67 ns/op
BenchmarkCutCustomTrim-10                          	126863348	         9.456 ns/op
BenchmarkWriteTimeSameLocationDifferentTxIdx-10    	 2177864	       610.6 ns/op
BenchmarkReadTimeSameLocationDifferentTxIdx-10     	 2131498
PASS
ok  	github.com/erigontech/erigon/execution/state	10.211s


```

