### PR TITLE
refactor: use b.Loop() in benchmark tests for better performance

### DIFF
--- a/common/hexutil/json_test.go
+++ b/common/hexutil/json_test.go
@@ -101,7 +101,7 @@ func TestUnmarshalBig(t *testing.T) {
 
 func BenchmarkUnmarshalBig(b *testing.B) {
 	input := []byte(`"0x123456789abcdef123456789abcdef"`)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		var v Big
 		if err := v.UnmarshalJSON(input); err != nil {
 			b.Fatal(err)
@@ -160,7 +160,7 @@ func TestUnmarshalUint64(t *testing.T) {
 
 func BenchmarkUnmarshalUint64(b *testing.B) {
 	input := []byte(`"0x123456789abcdf"`)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		var v Uint64
 		_ = v.UnmarshalJSON(input)
 	}

--- a/common/log/v3/bench_test.go
+++ b/common/log/v3/bench_test.go
@@ -14,7 +14,7 @@ func BenchmarkStreamNoCtx(b *testing.B) {
 	buf := bytes.Buffer{}
 	lg.SetHandler(StreamHandler(&buf, LogfmtFormat()))
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		lg.Info("test message")
 		buf.Reset()
 	}
@@ -24,7 +24,7 @@ func BenchmarkDiscard(b *testing.B) {
 	lg := New()
 	lg.SetHandler(DiscardHandler())
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		lg.Info("test message")
 	}
 }
@@ -33,7 +33,7 @@ func BenchmarkCallerFileHandler(b *testing.B) {
 	lg := New()
 	lg.SetHandler(CallerFileHandler(DiscardHandler()))
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		lg.Info("test message")
 	}
 }
@@ -42,7 +42,7 @@ func BenchmarkCallerFuncHandler(b *testing.B) {
 	lg := New()
 	lg.SetHandler(CallerFuncHandler(DiscardHandler()))
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		lg.Info("test message")
 	}
 }
@@ -56,7 +56,7 @@ func BenchmarkLogfmtNoCtx(b *testing.B) {
 	}
 
 	logfmt := LogfmtFormat()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		logfmt.Format(&r)
 	}
 }
@@ -70,7 +70,7 @@ func BenchmarkJsonNoCtx(b *testing.B) {
 	}
 
 	jsonfmt := JsonFormat()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		jsonfmt.Format(&r)
 	}
 }
@@ -83,7 +83,7 @@ func BenchmarkMultiLevelFilter(b *testing.B) {
 
 	lg := New()
 	lg.SetHandler(handler)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		lg.Info("test message")
 	}
 }
@@ -92,7 +92,7 @@ func BenchmarkDescendant1(b *testing.B) {
 	lg := New()
 	lg.SetHandler(DiscardHandler())
 	lg = lg.New()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		lg.Info("test message")
 	}
 }
@@ -103,7 +103,7 @@ func BenchmarkDescendant2(b *testing.B) {
 	for i := 0; i < 2; i++ {
 		lg = lg.New()
 	}
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		lg.Info("test message")
 	}
 }
@@ -114,7 +114,7 @@ func BenchmarkDescendant4(b *testing.B) {
 	for i := 0; i < 4; i++ {
 		lg = lg.New()
 	}
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		lg.Info("test message")
 	}
 }
@@ -125,7 +125,7 @@ func BenchmarkDescendant8(b *testing.B) {
 	for i := 0; i < 8; i++ {
 		lg = lg.New()
 	}
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		lg.Info("test message")
 	}
 }

--- a/common/math/big_test.go
+++ b/common/math/big_test.go
@@ -140,35 +140,35 @@ func TestPaddedBigBytes(t *testing.T) {
 
 func BenchmarkPaddedBigBytesLargePadding(b *testing.B) {
 	bigint := MustParseBig256("123456789123456789123456789123456789")
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		PaddedBigBytes(bigint, 200)
 	}
 }
 
 func BenchmarkPaddedBigBytesSmallPadding(b *testing.B) {
 	bigint := MustParseBig256("0x18F8F8F1000111000110011100222004330052300000000000000000FEFCF3CC")
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		PaddedBigBytes(bigint, 5)
 	}
 }
 
 func BenchmarkPaddedBigBytesSmallOnePadding(b *testing.B) {
 	bigint := MustParseBig256("0x18F8F8F1000111000110011100222004330052300000000000000000FEFCF3CC")
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		PaddedBigBytes(bigint, 32)
 	}
 }
 
 func BenchmarkByteAtBrandNew(b *testing.B) {
 	bigint := MustParseBig256("0x18F8F8F1000111000110011100222004330052300000000000000000FEFCF3CC")
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		bigEndianByteAt(bigint, 15)
 	}
 }
 
 func BenchmarkByteAt(b *testing.B) {
 	bigint := MustParseBig256("0x18F8F8F1000111000110011100222004330052300000000000000000FEFCF3CC")
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		bigEndianByteAt(bigint, 15)
 	}
 }
@@ -176,7 +176,7 @@ func BenchmarkByteAt(b *testing.B) {
 func BenchmarkByteAtOld(b *testing.B) {
 
 	bigint := MustParseBig256("0x18F8F8F1000111000110011100222004330052300000000000000000FEFCF3CC")
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		PaddedBigBytes(bigint, 32)
 	}
 }

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -152,7 +152,7 @@ func TestAddressHexChecksum(t *testing.T) {
 
 func BenchmarkAddressHex(b *testing.B) {
 	testAddr := HexToAddress("0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed")
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		testAddr.Hex()
 	}
 }


### PR DESCRIPTION



Similar as https://github.com/erigontech/erigon/pull/17456.  Search more case by `grep -E 'for.*b\.N;\s*i.*{' *_test.go`

However, after my testing, not all changes lead to performance improvements. Here are some examples that I have clearly identified as providing performance gains after multiple tests.


Before change:



```shell
➜  erigon git:(main) ✗ go test -run=^$ -bench=. ./common/hexutil        
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/common/hexutil
cpu: Apple M4
BenchmarkUnmarshalBig-10       	19647660	        56.86 ns/op
BenchmarkUnmarshalUint64-10    	55390580	        21.36 ns/op
PASS
ok  	github.com/erigontech/erigon/common/hexutil	3.251s
➜  erigon git:(main) ✗ 
➜  erigon git:(main) ✗ 
➜  erigon git:(main) ✗ go test -run=^$ -bench=. ./common/log/v3       
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/common/log/v3
cpu: Apple M4
BenchmarkStreamNoCtx-10                    	 2828414	       387.1 ns/op
BenchmarkDiscard-10                        	24033506	        57.59 ns/op
BenchmarkCallerFileHandler-10              	 1550744	       848.3 ns/op
BenchmarkCallerFuncHandler-10              	 1441629	       745.6 ns/op
BenchmarkLogfmtNoCtx-10                    	 4504915	       261.9 ns/op
BenchmarkJsonNoCtx-10                      	 3913816	       280.9 ns/op
BenchmarkMultiLevelFilter-10               	21766485	        58.84 ns/op
BenchmarkDescendant1-10                    	24348651	        54.07 ns/op
BenchmarkDescendant2-10                    	23152353	        55.63 ns/op
BenchmarkDescendant4-10                    	20376958	        58.26 ns/op
BenchmarkDescendant8-10                    	15625957	        74.51 ns/op
BenchmarkLog15AddingFields-10              	  406122	      3377 ns/op
BenchmarkLog15WithAccumulatedContext-10    	  397718	      3421 ns/op
BenchmarkLog15WithoutFields-10             	 1504342	      1134 ns/op
PASS
ok  	github.com/erigontech/erigon/common/log/v3	24.062s
➜  erigon git:(main) ✗ 
➜  erigon git:(main) ✗ go test -run=^$ -bench=. ./common/math      
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/common/math
cpu: Apple M4
BenchmarkPaddedBigBytesLargePadding-10       	34453161	        32.85 ns/op
BenchmarkPaddedBigBytesSmallPadding-10       	40621569	        30.07 ns/op
BenchmarkPaddedBigBytesSmallOnePadding-10    	48152322	        31.72 ns/op
BenchmarkByteAtBrandNew-10                   	628011402	         1.976 ns/op
BenchmarkByteAt-10                           	307810640	         3.565 ns/op
BenchmarkByteAtOld-10                        	47062436	        31.10 ns/op
PASS
ok  	github.com/erigontech/erigon/common/math	10.085s
➜  erigon git:(main) ✗ 
➜  erigon git:(main) ✗ 
➜  erigon git:(main) ✗ go test -run=^$ -bench=. ./common     
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/common
cpu: Apple M4
BenchmarkAddressHex-10    	 3579056	       353.7 ns/op
PASS
ok  	github.com/erigontech/erigon/common	4.369s

```


After change:

```shell
➜  erigon git:(main)  go test -run=^$ -bench=. ./common/hexutil     
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/common/hexutil
cpu: Apple M4
BenchmarkUnmarshalBig-10       	20897367	        54.07 ns/op
BenchmarkUnmarshalUint64-10    	52084557	        31.48 ns/op
PASS
ok  	github.com/erigontech/erigon/common/hexutil	3.003s
➜  erigon git:(main) 
➜  erigon git:(main) 
➜  erigon git:(main)  go test -run=^$ -bench=. ./common/log/v3     
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/common/log/v3
cpu: Apple M4
BenchmarkStreamNoCtx-10                    	 2771562	       388.0 ns/op
BenchmarkDiscard-10                        	24939015	        57.19 ns/op
BenchmarkCallerFileHandler-10              	 1577967	       760.4 ns/op
BenchmarkCallerFuncHandler-10              	 1556740	       744.8 ns/op
BenchmarkLogfmtNoCtx-10                    	 4970947	       292.9 ns/op
BenchmarkJsonNoCtx-10                      	 3133178	       358.3 ns/op
BenchmarkMultiLevelFilter-10               	20310955	       105.8 ns/op
BenchmarkDescendant1-10                    	21327471	       106.7 ns/op
BenchmarkDescendant2-10                    	11312496	        98.16 ns/op
BenchmarkDescendant4-10                    	12644632	        84.68 ns/op
BenchmarkDescendant8-10                    	12966970	        96.89 ns/op
BenchmarkLog15AddingFields-10              	  340780	      3262 ns/op
BenchmarkLog15WithAccumulatedContext-10    	  430981	      3215 ns/op
BenchmarkLog15WithoutFields-10             	 1531549	       988.7 ns/op
PASS
ok  	github.com/erigontech/erigon/common/log/v3	21.062s
➜  erigon git:(main) 
➜  erigon git:(main)  go test -run=^$ -bench=. ./common/math      
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/common/math
cpu: Apple M4
BenchmarkPaddedBigBytesLargePadding-10       	43122667	        26.73 ns/op
BenchmarkPaddedBigBytesSmallPadding-10       	48520870	        24.66 ns/op
BenchmarkPaddedBigBytesSmallOnePadding-10    	46560876	        23.62 ns/op
BenchmarkByteAtBrandNew-10                   	1000000000	         0.2707 ns/op
BenchmarkByteAt-10                           	1000000000	         0.2759 ns/op
BenchmarkByteAtOld-10                        	48834582	        32.27 ns/op
PASS
ok  	github.com/erigontech/erigon/common/math	9.613s
➜  erigon git:(main) 
➜  erigon git:(main)  go test -run=^$ -bench=. ./common     
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/common
cpu: Apple M4
BenchmarkAddressHex-10    	 3726703	       337.9 ns/op
PASS
ok  	github.com/erigontech/erigon/common	2.564s


```



