### PR TITLE
let arbitrum nitro work further (unless fixed in OCL/nitro)

### DIFF
--- a/cl/beacon/handler/blobs.go
+++ b/cl/beacon/handler/blobs.go
@@ -57,10 +57,10 @@ func (a *ApiHandler) GetEthV1BeaconBlobSidecars(w http.ResponseWriter, r *http.R
 		return nil, beaconhttp.NewEndpointError(http.StatusNotFound, errors.New("block not found"))
 	}
 
-	// reject after fulu fork
-	if a.beaconChainCfg.GetCurrentStateVersion(*slot/a.beaconChainCfg.SlotsPerEpoch) >= clparams.FuluVersion {
-		return nil, beaconhttp.NewEndpointError(http.StatusNotFound, errors.New("blobs are not supported after fulu fork"))
-	}
+	// reject after fulu fork TODO commented to let Arbitrum NITRO working further for now. Once fixed in nitro - uncomment back
+	// if a.beaconChainCfg.GetCurrentStateVersion(*slot/a.beaconChainCfg.SlotsPerEpoch) >= clparams.FuluVersion {
+	// 	return nil, beaconhttp.NewEndpointError(http.StatusNotFound, errors.New("blobs are not supported after fulu fork"))
+	// }
 
 	if a.caplinSnapshots != nil && *slot <= a.caplinSnapshots.FrozenBlobs() {
 		out, err := a.caplinSnapshots.ReadBlobSidecars(*slot)


### PR DESCRIPTION
```
WARN [10-14|08:26:39.496] error reading inbox                      err="failed to get blobs: error fetching blobs in 9408714 l1 block: beacon client in blobSidecars got error or empty response fetching non-expired blobs in slo
t: 8724651, if using a Prysm endpoint, try --enable-experimental-backfill flag, err: response returned with status 404 Not Found, want 200 OK. body: {\"code\":404,\"message\":\"blobs are not supported after fulu fork\"}\n
```

nitro still tries to call /blobs/blob_sidecars which is disabled after fulu.