### PR TITLE
rpc: replace math/rand with crypto/rand for subscription ID generation

### DIFF
--- a/rpc/subscription.go
+++ b/rpc/subscription.go
@@ -23,15 +23,12 @@ import (
 	"container/list"
 	"context"
 	crand "crypto/rand"
-	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"math/rand"
 	"reflect"
 	"strings"
 	"sync"
-	"time"
 )
 
 var (
@@ -55,22 +52,10 @@ func NewID() ID {
 
 // randomIDGenerator returns a function generates a random IDs.
 func randomIDGenerator() func() ID {
-	var buf = make([]byte, 8)
-	var seed int64
-	if _, err := crand.Read(buf); err == nil {
-		seed = int64(binary.BigEndian.Uint64(buf))
-	} else {
-		seed = int64(time.Now().Nanosecond())
-	}
-	var (
-		mu  sync.Mutex
-		rng = rand.New(rand.NewSource(seed)) // nolint: gosec
-	)
+	// Use crypto/rand to generate unpredictable, collision-resistant IDs
 	return func() ID {
-		mu.Lock()
-		defer mu.Unlock()
 		id := make([]byte, 16)
-		rng.Read(id)
+		_, _ = crand.Read(id)
 		return encodeID(id)
 	}
 }


### PR DESCRIPTION

## Summary
Replace non-cryptographic random number generator with cryptographically secure random generation for RPC subscription IDs.

## Problem
- Subscription IDs were generated using `math/rand` with predictable sequences
- This creates potential security risks and increases collision probability
- Required `// nolint: gosec` suppression to bypass security warnings

## Solution
- Use `crypto/rand` directly for generating 16-byte IDs
- Remove unused imports (`encoding/binary`, `math/rand`, `time`)
- Eliminate unnecessary mutex synchronization in `randomIDGenerator`
- Remove gosec linter suppression

