### PR TITLE
rpc: support entire state override in eth_simulateV1

### DIFF
--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -1525,7 +1525,7 @@ func updateAccount(EIP161Enabled bool, isAura bool, stateWriter StateWriter, add
 				return err
 			}
 		}
-		if err := stateObject.updateStotage(stateWriter); err != nil {
+		if err := stateObject.updateStorage(stateWriter); err != nil {
 			return err
 		}
 		if dbg.TraceTransactionIO && (trace || dbg.TraceAccount(addr)) {


### PR DESCRIPTION
Fixes Hive tests `ethSimulate-override-storage-slots` and `ethSimulate-simple-state-diff`