### PR TITLE
refactor: use b.Loop() in benchmark tests for better performance

### DIFF
--- a/p2p/discover/v5wire/encoding_test.go
+++ b/p2p/discover/v5wire/encoding_test.go
@@ -471,10 +471,9 @@ func BenchmarkV5_DecodeHandshakePingSecp256k1(b *testing.B) {
 		b.Fatal("can't encode handshake packet")
 	}
 	challenge.Node = nil // force ENR signature verification in decoder
-	b.ResetTimer()
 
 	input := make([]byte, len(enc))
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		copy(input, enc)
 		net.nodeB.c.sc.storeSentHandshake(idA, "", challenge)
 		_, _, _, err := net.nodeB.c.Decode(input, "")
@@ -503,10 +502,9 @@ func BenchmarkV5_DecodePing(b *testing.B) {
 	if err != nil {
 		b.Fatalf("can't encode: %v", err)
 	}
-	b.ResetTimer()
 
 	input := make([]byte, len(enc))
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		copy(input, enc)
 		_, _, packet, _ := net.nodeB.c.Decode(input, addrB)
 		if _, ok := packet.(*Ping); !ok {

--- a/p2p/netutil/net_test.go
+++ b/p2p/netutil/net_test.go
@@ -172,7 +172,7 @@ func TestCheckRelayIP(t *testing.T) {
 func BenchmarkCheckRelayIP(b *testing.B) {
 	sender := parseIP("23.55.1.242")
 	addr := parseIP("23.55.1.2")
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		CheckRelayIP(sender, addr)
 	}
 }

--- a/p2p/rlpx/rlpx_test.go
+++ b/p2p/rlpx/rlpx_test.go
@@ -374,7 +374,7 @@ func TestHandshakeForwardCompatibility(t *testing.T) {
 func BenchmarkHandshakeRead(b *testing.B) {
 	var input = unhex(eip8HandshakeAuthTests[0].input)
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		var (
 			h   handshakeState
 			r   = bytes.NewReader(input)
@@ -431,7 +431,7 @@ func BenchmarkThroughput(b *testing.B) {
 	// Read N messages.
 	b.SetBytes(int64(len(msgdata)))
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _, _, err := conn2.Read()
 		if err != nil {
 			b.Fatal("read error:", err)


### PR DESCRIPTION
Similar as https://github.com/erigontech/erigon/pull/17456.

Before change:

```shell
go test -run=^$ -bench=. ./p2p/discover/v5wire  
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/p2p/discover/v5wire
cpu: Apple M4
BenchmarkV5_DecodeHandshakePingSecp256k1-10    	   22908	     52697 ns/op
BenchmarkV5_DecodePing-10                      	 1260484	       942.6 ns/op
PASS
ok  	github.com/erigontech/erigon/p2p/discover/v5wire	4.735s

---


go test -run=^$ -bench=. ./p2p/netutil     
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/p2p/netutil
cpu: Apple M4
BenchmarkCheckRelayIP-10    	16706958	        71.50 ns/op
PASS
ok  	github.com/erigontech/erigon/p2p/netutil	2.099s


---

go test -run=^$ -bench=. ./p2p/rlpx  
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/p2p/rlpx
cpu: Apple M4
BenchmarkHandshakeRead-10    	   67416	     16181 ns/op
BenchmarkThroughput-10       	  205359	      5084 ns/op	 201.40 MB/s	       0 B/op	       0 allocs/op
PASS
ok  	github.com/erigontech/erigon/p2p/rlpx	2.859s

```


After change:


```shell
go test -run=^$ -bench=. ./p2p/discover/v5wire      
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/p2p/discover/v5wire
cpu: Apple M4
BenchmarkV5_DecodeHandshakePingSecp256k1-10    	   22466	     52738 ns/op
BenchmarkV5_DecodePing-10                      	 1277175	       939.2 ns/op
PASS
ok  	github.com/erigontech/erigon/p2p/discover/v5wire	3.672s

---


 go test -run=^$ -bench=. ./p2p/netutil     
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/p2p/netutil
cpu: Apple M4
BenchmarkCheckRelayIP-10    	12265167	        82.25 ns/op
PASS
ok  	github.com/erigontech/erigon/p2p/netutil	1.359s


---

go test -run=^$ -bench=. ./p2p/rlpx       
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/p2p/rlpx
cpu: Apple M4
BenchmarkHandshakeRead-10    	   66265	     16182 ns/op
BenchmarkThroughput-10       	  231204	      5152 ns/op	 198.74 MB/s	       0 B/op	       0 allocs/op
PASS
ok  	github.com/erigontech/erigon/p2p/rlpx	2.698s


```



