### PR TITLE
refactor: use b.Loop() in benchmark tests for better performance

### DIFF
--- a/cmd/rlpgen/testing/encdec_test.go
+++ b/cmd/rlpgen/testing/encdec_test.go
@@ -244,8 +244,8 @@ func BenchmarkTestingStructRLP(b *testing.B) {
 	tr := NewTRand()
 	header := randTestingStruct(tr)
 	var buf bytes.Buffer
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		buf.Reset()
 		header.EncodeRLP(&buf)
 	}

--- a/rpc/websocket_bench_test.go
+++ b/rpc/websocket_bench_test.go
@@ -43,8 +43,7 @@ func BenchmarkWebsocketEmptyCall(b *testing.B) {
 	}
 	defer client.Close()
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if err := client.Call(nil, "test_ping"); err != nil {
 			panic(err)
 		}
@@ -68,9 +67,8 @@ func BenchmarkWebsocket16kb(b *testing.B) {
 	defer client.Close()
 
 	payload16kb := strings.Repeat("x", 4096*4)
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		err := client.Call(nil, "test_echo", payload16kb, 5, nil)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
Similar as https://github.com/erigontech/erigon/pull/17456.

Before change:


```shell

go test -run=^$ -bench=. ./cmd/rlpgen/testing/             
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/cmd/rlpgen/testing
cpu: Apple M4
BenchmarkTestingStructRLP-10    	 2136613	       576.9 ns/op
PASS
ok  	github.com/erigontech/erigon/cmd/rlpgen/testing	2.137s


---

  go test -run=^$ -bench=. ./rpc  
WARN[10-15|12:53:24.366] Cannot register RPC callback [invalidRets1] - error must the last return value 
WARN[10-15|12:53:24.366] Cannot register RPC callback [invalidRets2] - error must the last return value 
WARN[10-15|12:53:24.366] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
WARN[10-15|12:53:24.367] [rpc] served                             method=test_ping reqid=1 err="the method test_ping does not exist/is not available"
panic: the method test_ping does not exist/is not available

goroutine 35 [running]:
github.com/erigontech/erigon/rpc.BenchmarkWebsocketEmptyCall(0x140001b8b08)
	/Users/zhetaicheleba/erigon/rpc/websocket_bench_test.go:49 +0x254
testing.(*B).runN(0x140001b8b08, 0x1)
	/usr/local/go/src/testing/benchmark.go:219 +0x184
testing.(*B).run1.func1()
	/usr/local/go/src/testing/benchmark.go:245 +0x4c
created by testing.(*B).run1 in goroutine 1
	/usr/local/go/src/testing/benchmark.go:238 +0x88
exit status 2
FAIL	github.com/erigontech/erigon/rpc	0.389s
FAIL

```

After change:


```shell
go test -run=^$ -bench=. ./cmd/rlpgen/testing/ 
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/cmd/rlpgen/testing
cpu: Apple M4
BenchmarkTestingStructRLP-10    	 2508294	       476.7 ns/op
PASS
ok  	github.com/erigontech/erigon/cmd/rlpgen/testing	2.064s

---


 go test -run=^$ -bench=. ./rpc                
WARN[10-15|12:53:06.103] Cannot register RPC callback [invalidRets1] - error must the last return value 
WARN[10-15|12:53:06.103] Cannot register RPC callback [invalidRets2] - error must the last return value 
WARN[10-15|12:53:06.103] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
WARN[10-15|12:53:06.104] [rpc] served                             method=test_ping reqid=1 err="the method test_ping does not exist/is not available"
panic: the method test_ping does not exist/is not available

goroutine 6 [running]:
github.com/erigontech/erigon/rpc.BenchmarkWebsocketEmptyCall(0x140001dab08)
	/Users/zhetaicheleba/erigon_old/rpc/websocket_bench_test.go:48 +0x25c
testing.(*B).runN(0x140001dab08, 0x1)
	/usr/local/go/src/testing/benchmark.go:219 +0x184
testing.(*B).run1.func1()
	/usr/local/go/src/testing/benchmark.go:245 +0x4c
created by testing.(*B).run1 in goroutine 1
	/usr/local/go/src/testing/benchmark.go:238 +0x88
exit status 2
FAIL	github.com/erigontech/erigon/rpc	0.388s
FAIL


```