### PR TITLE
refactor: use b.Loop() in benchmark tests for better performance

### DIFF
--- a/db/kv/mdbx/kv_mdbx_test.go
+++ b/db/kv/mdbx/kv_mdbx_test.go
@@ -1102,8 +1102,8 @@ func BenchmarkDB_ResetSequence(b *testing.B) {
 
 	tx, err := _db.BeginRw(ctx)
 	require.NoError(b, err)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for i := 0; b.Loop(); i++ {
 		err = tx.ResetSequence(table, uint64(i))
 		if err != nil {
 			b.Fatal(err)

--- a/db/state/aggregator_bench_test.go
+++ b/db/state/aggregator_bench_test.go
@@ -70,10 +70,10 @@ func BenchmarkAggregator_Processing(b *testing.B) {
 	defer domains.Close()
 
 	b.ReportAllocs()
-	b.ResetTimer()
+
 	var blockNum uint64
 	var prev []byte
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		key := <-longKeys
 		val := <-vals
 		txNum := uint64(i)
@@ -127,7 +127,7 @@ func Benchmark_BtreeIndex_Search(b *testing.B) {
 	require.NoError(b, err)
 	getter := seg.NewReader(kv.MakeGetter(), comp)
 
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		p := rnd.IntN(len(keys))
 		cur, err := bt.Seek(getter, keys[p])
 		require.NoErrorf(b, err, "i=%d", i)
@@ -239,7 +239,7 @@ func Benchmark_Recsplit_Find_ExternalFile(b *testing.B) {
 	keys, err := pivotKeysFromKV(dataPath)
 	require.NoError(b, err)
 
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		p := rnd.IntN(len(keys))
 
 		offset, _ := idxr.Lookup(keys[p])

--- a/db/state/bpstree_bench_test.go
+++ b/db/state/bpstree_bench_test.go
@@ -33,10 +33,9 @@ func BenchmarkBpsTreeSeek(t *testing.B) {
 	getter := seg.NewReader(kv.MakeGetter(), compressFlags)
 	getter.Reset(0)
 
-	t.ResetTimer()
 	t.ReportAllocs()
 	//r := rand.New(rand.NewSource(0))
-	for i := 0; i < t.N; i++ {
+	for t.Loop() {
 		if !getter.HasNext() {
 			getter.Reset(0)
 		}


### PR DESCRIPTION
Similar as https://github.com/erigontech/erigon/pull/17456.

Before change:

```shell

go test -run=^$ -bench=. ./db/kv/mdbx
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/db/kv/mdbx
cpu: Apple M4
BenchmarkDB_Get-10              	22121326	        55.08 ns/op
BenchmarkDB_Put-10              	--- FAIL: BenchmarkDB_Put-10
    kv_mdbx_test.go:983: mdbx_put: MDBX_MAP_FULL(-30792)The allocated database storage size limit has been reached. You can try remove the database files (e.g., by running rm -rf /path/to/db)
BenchmarkDB_PutRandom-10        	 1338993	      1145 ns/op
BenchmarkDB_Delete-10           	--- FAIL: BenchmarkDB_Delete-10
    kv_mdbx_test.go:1030: mdbx_put: MDBX_MAP_FULL(-30792)The allocated database storage size limit has been reached. You can try remove the database files (e.g., by running rm -rf /path/to/db)
BenchmarkDB_ResetSequence-10    	17780235	        71.19 ns/op
FAIL
exit status 1
FAIL	github.com/erigontech/erigon/db/kv/mdbx	10.215s
FAIL

---

go test -run=^$ -bench=. ./db/state
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/db/state
cpu: Apple M4
BenchmarkBpsTreeSeek-10                           	
 1838980	       652.5 ns/op	     282 B/op	       3 allocs/op
--- BENCH: BenchmarkBpsTreeSeek-10
    bpstree_bench_test.go:17: N: 12000000, M: 256 skip since shard <= 4
    bpstree_bench_test.go:17: N: 12000000, M: 256 skip since shard <= 4
    bpstree_bench_test.go:17: N: 12000000, M: 256 skip since shard <= 4
    bpstree_bench_test.go:17: N: 12000000, M: 256 skip since shard <= 4
    bpstree_bench_test.go:17: N: 12000000, M: 256 skip since shard <= 4
BenchmarkAggregator_Processing-10                 	   28994	     43402 ns/op	    3033 B/op	       6 allocs/op
--- FAIL: Benchmark_BtreeIndex_Search
    aggregator_bench_test.go:118: 
        	Error Trace:	/Users/zhetaicheleba/erigon/db/state/aggregator_bench_test.go:488
        	            				/Users/zhetaicheleba/erigon/db/state/aggregator_bench_test.go:118
        	Error:      	Received unexpected error:
        	            	open ../../data/storage.256-288.kv: no such file or directory
        	Test:       	Benchmark_BtreeIndex_Search
Benchmark_BTree_Seek/seek_only-10                 	 1477519	       807.8 ns/op
next_access_last[of 5000 keys] 55ns
Benchmark_BTree_Seek/seek_then_next-10            	next_access_last[of 5000 keys] 54ns
next_access_last[of 5000 keys] 55ns
next_access_last[of 5000 keys] 55ns
next_access_last[of 5000 keys] 58ns
    2774	    436118 ns/op
BenchmarkAggregator_BeginFilesRo_Latency/begin_files_ro-10         	 1658054	       718.8 ns/op
BenchmarkAggregator_BeginFilesRo_Throughput-10                     	  274266	      3892 ns/op
BenchmarkDb_BeginFiles_Throughput-10                               	       1	100009740250 ns/op
BenchmarkDb_BeginFiles_Throughput_IO-10                            	
    2104	    563819 ns/op
Benchmark_SharedDomains_GetLatest/GetLatest-10                     	1000000000	         0.0000073 ns/op
Benchmark_SharedDomains_GetLatest/HistorySeek-10                   	1000000000	         0.0000165 ns/op
BenchmarkSharedDomains_ComputeCommitment/ComputeCommitment-10      	 3771055	       367.4 ns/op
FAIL
exit status 1
FAIL	github.com/erigontech/erigon/db/state	409.576s
FAIL

```


After this change:


```shell
go test -run=^$ -bench=. ./db/kv/mdbx
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/db/kv/mdbx
cpu: Apple M4
BenchmarkDB_Get-10              	21338674	        55.86 ns/op
BenchmarkDB_Put-10              	--- FAIL: BenchmarkDB_Put-10
    kv_mdbx_test.go:983: mdbx_put: MDBX_MAP_FULL(-30792)The allocated database storage size limit has been reached. You can try remove the database files (e.g., by running rm -rf /path/to/db)
BenchmarkDB_PutRandom-10        	 1318980	      1165 ns/op
BenchmarkDB_Delete-10           	--- FAIL: BenchmarkDB_Delete-10
    kv_mdbx_test.go:1030: mdbx_put: MDBX_MAP_FULL(-30792)The allocated database storage size limit has been reached. You can try remove the database files (e.g., by running rm -rf /path/to/db)
BenchmarkDB_ResetSequence-10    	17026106	        66.67 ns/op
FAIL
exit status 1
FAIL	github.com/erigontech/erigon/db/kv/mdbx	9.568s
FAIL

---


go test -run=^$ -bench=. ./db/state
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/db/state
cpu: Apple M4
BenchmarkBpsTreeSeek-10                           	 1826077	       662.7 ns/op	     282 B/op	       3 allocs/op
--- BENCH: BenchmarkBpsTreeSeek-10
    bpstree_bench_test.go:17: N: 12000000, M: 256 skip since shard <= 4
BenchmarkAggregator_Processing-10                 	   33522	     34892 ns/op	    2871 B/op	       6 allocs/op
--- FAIL: Benchmark_BtreeIndex_Search
    aggregator_bench_test.go:118: 
        	Error Trace:	/Users/zhetaicheleba/erigon/db/state/aggregator_bench_test.go:488
        	            				/Users/zhetaicheleba/erigon/db/state/aggregator_bench_test.go:118
        	Error:      	Received unexpected error:
        	            	open ../../data/storage.256-288.kv: no such file or directory
        	Test:       	Benchmark_BtreeIndex_Search
Benchmark_BTree_Seek/seek_only-10                 	 1477753	       797.3 ns/op
next_access_last[of 5000 keys] 55ns
Benchmark_BTree_Seek/seek_then_next-10            	next_access_last[of 5000 keys] 56ns
next_access_last[of 5000 keys] 52ns
next_access_last[of 5000 keys] 55ns
next_access_last[of 5000 keys] 55ns
    2823	    429837 ns/op
BenchmarkAggregator_BeginFilesRo_Latency/begin_files_ro-10         	 1671117	       702.4 ns/op
BenchmarkAggregator_BeginFilesRo_Throughput-10                     	  262884	      3856 ns/op
BenchmarkDb_BeginFiles_Throughput-10                               	       1	100010489083 ns/op
BenchmarkDb_BeginFiles_Throughput_IO-10                            	    1936	    566868 ns/op
Benchmark_SharedDomains_GetLatest/GetLatest-10                     	1000000000	         0.0000097 ns/op
Benchmark_SharedDomains_GetLatest/HistorySeek-10                   	1000000000	         0.0000163 ns/op
BenchmarkSharedDomains_ComputeCommitment/ComputeCommitment-10      	 3154058	       348.9 ns/op
FAIL
exit status 1
FAIL	github.com/erigontech/erigon/db/state	219.691s
FAIL


```
