### PR TITLE
db/state: Remove unused valsTblKey2 helper from forkable

### DIFF
--- a/db/state/forkable.go
+++ b/db/state/forkable.go
@@ -174,17 +174,6 @@ func (a *Forkable[MarkedTxI]) valsTblKey(ts Num, hash []byte) []byte {
 	return k
 }
 
-func (a *Forkable[MarkedTxI]) valsTblKey2(ts []byte, hash []byte) []byte {
-	// key for valsTbl
-	// relevant only for marked forkable
-	// assuming hash is common.Hash which is 32 bytes
-	const HashBytes = 32
-	k := make([]byte, 8+HashBytes)
-	copy(k, ts)
-	copy(k[8:], hash)
-	return k
-}
-
 func (a *Forkable[T]) BeginTemporalTx() T {
 	return a.beginTxGen(true)
 }


### PR DESCRIPTION
The helper valsTblKey2([]byte, []byte) was never referenced across the codebase. Removing dead code improves readability and reduces maintenance surface. No functional changes.