### PR TITLE
fix chaintip mode in stage_exec

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -837,6 +837,9 @@ func stageSenders(db kv.TemporalRwDB, ctx context.Context, logger log.Logger) er
 }
 
 func stageExec(db kv.TemporalRwDB, ctx context.Context, logger log.Logger) error {
+	if chainTipMode && noCommit {
+		return errors.New("--sync.mode.chaintip cannot work with --no-commit to be false")
+	}
 	dirs := datadir.New(datadirCli)
 	if err := datadir.ApplyMigrations(dirs); err != nil {
 		return err


### PR DESCRIPTION
- fix: handle block limit error in chaintip mode
- commit tx after each block exec (actually what happens at chaintip today)
- when `chainTipMode = true`, `newSync` sets noCommit=false; so case `chainTipMode && noCommit` doesn't need to be handled.