### PR TITLE
tests: use hive fork to enable commitment history

### DIFF
--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout Hive
         uses: actions/checkout@v5
         with:
-          repository: ethereum/hive
+          repository: erigontech/hive
           # ref: master
           path: hive
 


### PR DESCRIPTION
Temporarily use our fork of Hive repo to enable commitment history on erigon nodes