### PR TITLE
cmd/integration: remove unnecessary print stages cmd flags

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -462,8 +462,6 @@ var cmdRunMigrations = &cobra.Command{
 func init() {
 	withConfig(cmdPrintStages)
 	withDataDir(cmdPrintStages)
-	withChain(cmdPrintStages)
-	withHeimdall(cmdPrintStages)
 	rootCmd.AddCommand(cmdPrintStages)
 
 	rootCmd.AddCommand(cmdAlloc)


### PR DESCRIPTION
noticed while debugging something on devnets
I think `cmdPrintStages` doesn't need a required --chain flag (no usages of it inside this cmd)
also noticed heimdall url flag is unnecessary here too