### PR TITLE
rpcdaemon:  hive eth_getTransactionReceipt with postState in case of cache hits

### DIFF
--- a/rpc/jsonrpc/receipts/receipts_generator.go
+++ b/rpc/jsonrpc/receipts/receipts_generator.go
@@ -180,8 +180,8 @@ func (g *Generator) GetReceipt(ctx context.Context, cfg *chain.Config, tx kv.Tem
 	mu := g.txnExecMutex.lock(txnHash)
 	defer g.txnExecMutex.unlock(mu, txnHash)
 	if receipt, ok := g.receiptCache.Get(txnHash); ok {
-		if receipt.BlockHash == blockHash &&  // elegant way to handle reorgs
-		   calculatePostState == (len(receipt.PostState) != 0)  { // verify if the expected postState matches the actual postState on cache. Otherwise re-calculate it
+		if receipt.BlockHash == blockHash && // elegant way to handle reorgs
+			calculatePostState == (len(receipt.PostState) != 0) { // verify if the expected postState matches the actual postState on cache. Otherwise re-calculate it
 			return receipt, nil
 		}
 


### PR DESCRIPTION
The receipt is now returned from the cache if and only if the caller's request for the post-state (calculatePostState) matches the actual status of the cached data (len(receipt.PostState) != 0).

if this condition is not met,  remove the entry from the cache and forces the receipt to be fully recomputed. 
This ensures the caller always receives a receipt matching the requested PostState requirement.