### PR TITLE
disable block timestamp in receipt for rpc for Arbitrum

### DIFF
--- a/rpc/jsonrpc/eth_receipts.go
+++ b/rpc/jsonrpc/eth_receipts.go
@@ -535,7 +535,11 @@ func (api *APIImpl) GetBlockReceipts(ctx context.Context, numberOrHash rpc.Block
 	result := make([]map[string]interface{}, 0, len(receipts))
 	for _, receipt := range receipts {
 		txn := block.Transactions()[receipt.TransactionIndex]
-		result = append(result, ethutils.MarshalReceipt(receipt, txn, chainConfig, block.HeaderNoCopy(), txn.Hash(), true, true))
+		withBlockTimestamp := true
+		if chainConfig.IsArbitrum() {
+			withBlockTimestamp = false
+		}
+		result = append(result, ethutils.MarshalReceipt(receipt, txn, chainConfig, block.HeaderNoCopy(), txn.Hash(), true, withBlockTimestamp))
 	}
 
 	if chainConfig.Bor != nil {


### PR DESCRIPTION
arbitrum doesn't have this field in `GetBlockReceipts`