### PR TITLE
Refactor txNum ranges -> step ranges logic

### DIFF
--- a/db/state/dirty_files.go
+++ b/db/state/dirty_files.go
@@ -117,10 +117,33 @@ func (i *FilesItem) Range() (startTxNum, endTxNum uint64) {
 	return i.startTxNum, i.endTxNum
 }
 
+// warn: check the StepRange method docs for the details on how the step range is calculated.
+func (i *FilesItem) StartStep(stepSize uint64) kv.Step {
+	return kv.Step(i.startTxNum / stepSize)
+}
+
+// warn: check the StepRange method docs for the details on how the step range is calculated.
+func (i *FilesItem) EndStep(stepSize uint64) kv.Step {
+	return kv.Step(i.endTxNum / stepSize)
+}
+
 // Returns the [startTxNum, endTxNum) range converted to steps of a given size; FilesItem doesn't know about
 // step sizes (for now), hence the caller needs to provide it.
+//
+// IMPORTANT: the covered range in terms of steps is NOT intuitive as one should expect, due to historical reasons
+// and how this struct is built by callers, because the startTxNum/endTxNum are aligned to the beginning of the step.
+//
+// That means, the startStep is counted even if the startTxNum is not aligned to the step boundary, but that is not true
+// for the endTxNum. If the endTxNum is inside a certain step txNum range, the corresponding step is not considered in the returned range.
 func (i *FilesItem) StepRange(stepSize uint64) (startStep, endStep kv.Step) {
-	return kv.Step(i.startTxNum / stepSize), kv.Step(i.endTxNum / stepSize)
+	return i.StartStep(stepSize), i.EndStep(stepSize)
+}
+
+// Calculate how many steps are covered by [startTxNum, endTxNum) range. The number of steps follows the criteria
+// of the StepRange method, see its docs for the details.
+func (i *FilesItem) StepCount(stepSize uint64) uint64 {
+	fromStep, toStep := i.StepRange(stepSize)
+	return uint64(toStep - fromStep)
 }
 
 // isProperSubsetOf - when `j` covers `i` but not equal `i`
@@ -302,7 +325,7 @@ func (d *Domain) openDirtyFiles() (err error) {
 	invalidFileItemsLock := sync.Mutex{}
 	d.dirtyFiles.Walk(func(items []*FilesItem) bool {
 		for _, item := range items {
-			fromStep, toStep := kv.Step(item.startTxNum/d.stepSize), kv.Step(item.endTxNum/d.stepSize)
+			fromStep, toStep := item.StepRange(d.stepSize)
 			if item.decompressor == nil {
 				fPathMask := d.kvFilePathMask(fromStep, toStep)
 				fPath, fileVer, ok, err := version.FindFilesWithVersionsByPattern(fPathMask)
@@ -417,7 +440,7 @@ func (h *History) openDirtyFiles() error {
 	invalidFileItems := make([]*FilesItem, 0)
 	h.dirtyFiles.Walk(func(items []*FilesItem) bool {
 		for _, item := range items {
-			fromStep, toStep := kv.Step(item.startTxNum/h.stepSize), kv.Step(item.endTxNum/h.stepSize)
+			fromStep, toStep := item.StepRange(h.stepSize)
 			if item.decompressor == nil {
 				fPathMask := h.vFilePathMask(fromStep, toStep)
 				fPath, fileVer, ok, err := version.FindFilesWithVersionsByPattern(fPathMask)
@@ -505,7 +528,7 @@ func (ii *InvertedIndex) openDirtyFiles() error {
 	invalidFileItemsLock := sync.Mutex{}
 	ii.dirtyFiles.Walk(func(items []*FilesItem) bool {
 		for _, item := range items {
-			fromStep, toStep := kv.Step(item.startTxNum/ii.stepSize), kv.Step(item.endTxNum/ii.stepSize)
+			fromStep, toStep := item.StepRange(ii.stepSize)
 			if item.decompressor == nil {
 				fPathPattern := ii.efFilePathMask(fromStep, toStep)
 				fPath, fileVer, ok, err := version.FindFilesWithVersionsByPattern(fPathPattern)
@@ -741,8 +764,7 @@ func (files visibleFiles) VisibleFiles() []VisibleFile {
 // here "accessors" are generated dynamically by `accessorsFor`
 func fileItemsWithMissedAccessors(dirtyFiles []*FilesItem, aggregationStep uint64, accessorsFor func(fromStep, toStep kv.Step) []string) (l []*FilesItem) {
 	for _, item := range dirtyFiles {
-		fromStep, toStep := kv.Step(item.startTxNum/aggregationStep), kv.Step(item.endTxNum/aggregationStep)
-		for _, fName := range accessorsFor(fromStep, toStep) {
+		for _, fName := range accessorsFor(item.StepRange(aggregationStep)) {
 			exists, err := dir.FileExist(fName)
 			if err != nil {
 				panic(err)

--- a/db/state/dirty_files_test.go
+++ b/db/state/dirty_files_test.go
@@ -14,15 +14,18 @@ import (
 )
 
 func TestStepRange(t *testing.T) {
+	stepSize := uint64(4)
+
 	t.Run("simple range", func(t *testing.T) {
 		f := &FilesItem{
 			startTxNum: 1,
 			endTxNum:   10,
 		}
 
-		startStep, endStep := f.StepRange(4)
+		startStep, endStep := f.StepRange(stepSize)
 		require.Equal(t, kv.Step(0), startStep)
 		require.Equal(t, kv.Step(2), endStep)
+		require.Equal(t, uint64(2), f.StepCount(4))
 	})
 
 	t.Run("inner boundaries", func(t *testing.T) {
@@ -31,9 +34,10 @@ func TestStepRange(t *testing.T) {
 			endTxNum:   7,
 		}
 
-		startStep, endStep := f.StepRange(4)
+		startStep, endStep := f.StepRange(stepSize)
 		require.Equal(t, kv.Step(1), startStep)
 		require.Equal(t, kv.Step(1), endStep)
+		require.Equal(t, uint64(0), f.StepCount(stepSize))
 	})
 
 	t.Run("outer boundaries", func(t *testing.T) {
@@ -41,9 +45,10 @@ func TestStepRange(t *testing.T) {
 			startTxNum: 3,
 			endTxNum:   8,
 		}
-		startStep, endStep := f.StepRange(4)
+		startStep, endStep := f.StepRange(stepSize)
 		require.Equal(t, kv.Step(0), startStep)
 		require.Equal(t, kv.Step(2), endStep)
+		require.Equal(t, uint64(2), f.StepCount(stepSize))
 	})
 }
 
@@ -78,12 +83,12 @@ func TestFileItemWithMissedAccessor(t *testing.T) {
 	}
 
 	// create accesssor files for f1, f2
-	for _, fname := range accessorFor(kv.Step(f1.startTxNum/aggStep), kv.Step(f1.endTxNum/aggStep)) {
+	for _, fname := range accessorFor(f1.StepRange(aggStep)) {
 		os.WriteFile(fname, []byte("test"), 0644)
 		defer dir.RemoveFile(fname)
 	}
 
-	for _, fname := range accessorFor(kv.Step(f2.startTxNum/aggStep), kv.Step(f2.endTxNum/aggStep)) {
+	for _, fname := range accessorFor(f2.StepRange(aggStep)) {
 		os.WriteFile(fname, []byte("test"), 0644)
 		defer dir.RemoveFile(fname)
 	}

--- a/db/state/domain_committed.go
+++ b/db/state/domain_committed.go
@@ -248,7 +248,8 @@ func (dt *DomainRoTx) lookupDirtyFileByItsRange(txFrom uint64, txTo uint64) *Fil
 	if item == nil || item.bindex == nil {
 		fileStepsss := "" + dt.d.Name.String() + ": "
 		for _, item := range dt.d.dirtyFiles.Items() {
-			fileStepsss += fmt.Sprintf("%d-%d;", item.startTxNum/dt.d.stepSize, item.endTxNum/dt.d.stepSize)
+			fromStep, toStep := item.StepRange(dt.d.stepSize)
+			fileStepsss += fmt.Sprintf("%d-%d;", fromStep, toStep)
 		}
 		dt.d.logger.Warn("[agg] lookupDirtyFileByItsRange: file not found",
 			"stepFrom", txFrom/dt.d.stepSize, "stepTo", txTo/dt.d.stepSize,

--- a/db/state/history.go
+++ b/db/state/history.go
@@ -224,7 +224,8 @@ func (h *History) missedMapAccessors(source []*FilesItem) (l []*FilesItem) {
 
 func (h *History) buildVi(ctx context.Context, item *FilesItem, ps *background.ProgressSet) (err error) {
 	if item.decompressor == nil {
-		return fmt.Errorf("buildVI: passed item with nil decompressor %s %d-%d", h.FilenameBase, item.startTxNum/h.stepSize, item.endTxNum/h.stepSize)
+		fromStep, toStep := item.StepRange(h.stepSize)
+		return fmt.Errorf("buildVI: passed item with nil decompressor %s %d-%d", h.FilenameBase, fromStep, toStep)
 	}
 
 	search := &FilesItem{startTxNum: item.startTxNum, endTxNum: item.endTxNum}
@@ -234,10 +235,10 @@ func (h *History) buildVi(ctx context.Context, item *FilesItem, ps *background.P
 	}
 
 	if iiItem.decompressor == nil {
-		return fmt.Errorf("buildVI: got iiItem with nil decompressor %s %d-%d", h.FilenameBase, item.startTxNum/h.stepSize, item.endTxNum/h.stepSize)
+		fromStep, toStep := item.StepRange(h.stepSize)
+		return fmt.Errorf("buildVI: got iiItem with nil decompressor %s %d-%d", h.FilenameBase, fromStep, toStep)
 	}
-	fromStep, toStep := kv.Step(item.startTxNum/h.stepSize), kv.Step(item.endTxNum/h.stepSize)
-	idxPath := h.vAccessorNewFilePath(fromStep, toStep)
+	idxPath := h.vAccessorNewFilePath(item.StepRange(h.stepSize))
 
 	err = h.buildVI(ctx, idxPath, item.decompressor, iiItem.decompressor, iiItem.startTxNum, ps)
 	if err != nil {

--- a/db/state/integrity.go
+++ b/db/state/integrity.go
@@ -97,7 +97,7 @@ func (dt *DomainRoTx) IntegrityKey(k []byte) error {
 			}
 			accessor := item.index
 			if accessor == nil {
-				fPath, _, _, err := version.FindFilesWithVersionsByPattern(dt.d.efAccessorFilePathMask(kv.Step(item.startTxNum/dt.stepSize), kv.Step(item.endTxNum/dt.stepSize)))
+				fPath, _, _, err := version.FindFilesWithVersionsByPattern(dt.d.efAccessorFilePathMask(item.StepRange(dt.stepSize)))
 				if err != nil {
 					panic(err)
 				}

--- a/db/state/inverted_index.go
+++ b/db/state/inverted_index.go
@@ -253,10 +253,10 @@ func (ii *InvertedIndex) missedMapAccessors(source []*FilesItem) (l []*FilesItem
 }
 
 func (ii *InvertedIndex) buildEfAccessor(ctx context.Context, item *FilesItem, ps *background.ProgressSet) (err error) {
+	fromStep, toStep := item.StepRange(ii.stepSize)
 	if item.decompressor == nil {
-		return fmt.Errorf("buildEfAccessor: passed item with nil decompressor %s %d-%d", ii.FilenameBase, item.startTxNum/ii.stepSize, item.endTxNum/ii.stepSize)
+		return fmt.Errorf("buildEfAccessor: passed item with nil decompressor %s %d-%d", ii.FilenameBase, fromStep, toStep)
 	}
-	fromStep, toStep := kv.Step(item.startTxNum/ii.stepSize), kv.Step(item.endTxNum/ii.stepSize)
 	return ii.buildMapAccessor(ctx, fromStep, toStep, ii.dataReader(item.decompressor), ps)
 }
 func (ii *InvertedIndex) dataReader(f *seg.Decompressor) *seg.Reader {

--- a/db/state/squeeze.go
+++ b/db/state/squeeze.go
@@ -206,7 +206,7 @@ func SqueezeCommitmentFiles(ctx context.Context, at *AggregatorRoTx, logger log.
 		cf.decompressor.MadvNormal()
 
 		err = func() error {
-			steps := cf.endTxNum/stepSize - cf.startTxNum/stepSize
+			steps := cf.StepCount(stepSize)
 			compression := commitment.d.Compression
 			if steps < DomainMinStepsToCompress {
 				compression = seg.CompressNone
@@ -363,7 +363,9 @@ func RebuildCommitmentFiles(ctx context.Context, rwDb kv.TemporalRwDB, txNumsRea
 
 	ranges := make([]MergeRange, 0)
 	for fi, f := range sf.d[kv.AccountsDomain] {
-		logger.Info(fmt.Sprintf("[commitment_rebuild] shard to build #%d: steps %d-%d (based on %s)", fi, f.startTxNum/a.StepSize(), f.endTxNum/a.StepSize(), f.decompressor.FileName()))
+		fromStep, toStep := f.StepRange(a.StepSize())
+		logger.Info(fmt.Sprintf("[commitment_rebuild] shard to build #%d: steps %d-%d (based on %s)", fi, fromStep, toStep, f.decompressor.FileName()))
+
 		ranges = append(ranges, MergeRange{
 			from: f.startTxNum,
 			to:   f.endTxNum,


### PR DESCRIPTION
`FilesItem.startTxNum/endTxNum` -> `from/toStep` logic is used in quite a bunch of places in the code.

Although the math is simple, it makes sense to push such behavior into FilesItem itself. And the result can be embedded into a function call if it expects exactly (from, to), which is most of the places, making the code cleaner.

Also there is a trick in how start/endTxNum is calculated at struct initialization (and unchecked) that if not respected may lead to unexpected results; I added some docs explaining it.