### PR TITLE
A collection of small integration-related refactorings

### DIFF
--- a/cmd/integration/commands/flags.go
+++ b/cmd/integration/commands/flags.go
@@ -128,7 +128,7 @@ func withDataDir2(cmd *cobra.Command) {
 	must(cmd.MarkFlagDirname(utils.DataDirFlag.Name))
 	must(cmd.MarkFlagRequired(utils.DataDirFlag.Name))
 
-	cmd.Flags().IntVar(&databaseVerbosity, "database.verbosity", 2, "Enabling internal db logs. Very high verbosity levels may require recompile db. Default: 2, means warning.")
+	cmd.Flags().IntVar(&databaseVerbosity, "database.verbosity", 2, "Enable internal database logs. Very high verbosity levels may require recompiling the database. The default value is 2, which means warnings are shown.")
 	cmd.Flags().BoolVar(&dbWriteMap, utils.DbWriteMapFlag.Name, utils.DbWriteMapFlag.Value, utils.DbWriteMapFlag.Usage)
 	cmd.Flags().Uint64Var(&integStepSize, utils.ErigonDBStepSizeFlag.Name, utils.ErigonDBStepSizeFlag.Value, utils.ErigonDBStepSizeFlag.Usage)
 }


### PR DESCRIPTION
- Figured withDatadir/withDatadir2 are almost the same; can retrofit one as a function of the other one.
- Fixed unused param warn
- Fixed hardcoded param definition identified on review of https://github.com/erigontech/erigon/pull/17534