### PR TITLE
fix flaky TestMergedFileGet

### DIFF
--- a/db/state/forkable_agg_test.go
+++ b/db/state/forkable_agg_test.go
@@ -414,13 +414,10 @@ func TestMergedFileGet(t *testing.T) {
 
 	checkBuildFilesFn := func(mergeDisabled bool) {
 		agg.SetMergeDisabled(mergeDisabled)
+
 		for i := range amount {
-			ch := agg.BuildFilesInBackground(RootNum(i + 1))
-			select {
-			case <-ch:
-			case <-time.After(time.Second * 30):
-				t.Fatal("timeout")
-			}
+			err = agg.BuildFiles(RootNum(i + 1))
+			require.NoError(t, err)
 		}
 
 		snapCfg := Registry.SnapshotConfig(headerId)


### PR DESCRIPTION
change ensures the "BuildFiles" for higher rootNums are processed, rather than returned because there's already a buildFiles in progress.

issue: https://github.com/erigontech/erigon/issues/17532