### PR TITLE
state/merge: use iit.files instead of dirtyFiles in staticFilesInRange

### DIFF
--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -337,7 +337,7 @@ func (a *Aggregator) AddDependencyBtwnDomains(dependency kv.Domain, dependent kv
 	// only corresponding files should be included. e.g. commitment + account -
 	// cannot have merged account visibleFile, and unmerged commitment visibleFile for same step range.
 	if a.checker == nil {
-		a.checker = NewDependencyIntegrityChecker(a.dirs, a.logger)
+		a.checker = NewDependencyIntegrityChecker(a.logger)
 	}
 
 	a.checker.AddDependency(FromDomain(dependency), &DependentInfo{
@@ -357,7 +357,7 @@ func (a *Aggregator) AddDependencyBtwnHistoryII(domain kv.Domain) {
 	}
 
 	if a.checker == nil {
-		a.checker = NewDependencyIntegrityChecker(a.dirs, a.logger)
+		a.checker = NewDependencyIntegrityChecker(a.logger)
 	}
 
 	h := dd.History

--- a/db/state/entity_integrity_check.go
+++ b/db/state/entity_integrity_check.go
@@ -6,7 +6,6 @@ import (
 	btree2 "github.com/tidwall/btree"
 
 	"github.com/erigontech/erigon/common/log/v3"
-	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/state/statecfg"
 )
@@ -73,7 +72,6 @@ type DirtyFilesGetter func() *btree2.BTreeG[*FilesItem]
 // (accounts in this example)
 type DependencyIntegrityChecker struct {
 	dependencyMap map[UniversalEntity][]*DependentInfo
-	dirs          datadir.Dirs
 	trace         bool
 	logger        log.Logger
 	disable       bool
@@ -87,10 +85,9 @@ type DependentInfo struct {
 
 // dependency/referred: account/storage
 // dependent/referencing: commitment
-func NewDependencyIntegrityChecker(dirs datadir.Dirs, logger log.Logger) *DependencyIntegrityChecker {
+func NewDependencyIntegrityChecker(logger log.Logger) *DependencyIntegrityChecker {
 	return &DependencyIntegrityChecker{
 		dependencyMap: make(map[UniversalEntity][]*DependentInfo),
-		dirs:          dirs,
 		logger:        logger,
 		//		trace:         true,
 	}

--- a/db/state/integrity_checker_test.go
+++ b/db/state/integrity_checker_test.go
@@ -39,7 +39,7 @@ func TestDependency(t *testing.T) {
 		accessors:   statecfg.AccessorHashMap,
 	}
 
-	checker := NewDependencyIntegrityChecker(dirs, logger)
+	checker := NewDependencyIntegrityChecker(logger)
 	checker.AddDependency(AccountDomainUniversal, dinfo)
 	// not adding dependency for storage
 
@@ -81,7 +81,7 @@ func TestDependency_UnindexedMerged(t *testing.T) {
 		accessors:   statecfg.AccessorHashMap,
 	}
 
-	checker := NewDependencyIntegrityChecker(dirs, logger)
+	checker := NewDependencyIntegrityChecker(logger)
 	checker.AddDependency(AccountDomainUniversal, dinfo)
 	// not adding dependency for storage
 

--- a/db/state/merge.go
+++ b/db/state/merge.go
@@ -327,8 +327,6 @@ func (ht *HistoryRoTx) staticFilesInRange(r HistoryRanges) (indexFiles, historyF
 	}
 
 	if r.history.needMerge {
-		// Get history files from HistoryRoTx (no "garbage/overalps"), but index files not from InvertedIndexRoTx
-		// because index files may already be merged (before `kill -9`) and it means not visible in InvertedIndexRoTx
 		for _, item := range ht.files {
 			if item.startTxNum < r.history.from {
 				continue
@@ -338,13 +336,21 @@ func (ht *HistoryRoTx) staticFilesInRange(r HistoryRanges) (indexFiles, historyF
 			}
 
 			historyFiles = append(historyFiles, item.src)
-			idxFile, ok := ht.h.InvertedIndex.dirtyFiles.Get(item.src)
-			if ok {
-				indexFiles = append(indexFiles, idxFile)
-			} else {
-				walkErr := fmt.Errorf("History.staticFilesInRange: required file not found: %s-%s.%d-%d.efi", ht.h.InvertedIndex.FileVersion.AccessorEFI.String(), ht.h.FilenameBase, item.startTxNum/ht.stepSize, item.endTxNum/ht.stepSize)
-				return nil, nil, walkErr
+
+			found := false
+			for _, iiItem := range ht.iit.files {
+				if iiItem.startTxNum == item.startTxNum && iiItem.endTxNum == item.endTxNum {
+					indexFiles = append(indexFiles, iiItem.src)
+					found = true
+					break
+				}
 			}
+			if found {
+				continue
+			}
+
+			walkErr := fmt.Errorf("History.staticFilesInRange: required file not found: %s-%s.%d-%d.efi", ht.h.InvertedIndex.FileVersion.AccessorEFI.String(), ht.h.FilenameBase, item.startTxNum/ht.stepSize, item.endTxNum/ht.stepSize)
+			return nil, nil, walkErr
 		}
 
 		for _, f := range historyFiles {

--- a/db/state/merge_test.go
+++ b/db/state/merge_test.go
@@ -133,14 +133,28 @@ func emptyTestInvertedIndex(t testing.TB, aggStep uint64) *InvertedIndex {
 func TestFindMergeRangeCornerCases(t *testing.T) {
 	t.Parallel()
 
-	newTestDomain := func() (*InvertedIndex, *History) {
+	newTestDomain := func(withDependency bool) (*InvertedIndex, *History) {
 		d := emptyTestDomain(t, 1)
 		d.History.InvertedIndex.Accessors = 0
 		d.History.Accessors = 0
+
+		if withDependency {
+			checker := NewDependencyIntegrityChecker(log.New())
+			universalEntity := FromII(d.InvertedIndex.InvIdxCfg.Name)
+			checker.AddDependency(universalEntity, &DependentInfo{
+				entity: universalEntity,
+				filesGetter: func() *btree2.BTreeG[*FilesItem] {
+					return d.History.dirtyFiles
+				},
+				accessors: d.History.Accessors,
+			})
+			d.History.InvertedIndex.SetChecker(checker)
+		}
+
 		return d.History.InvertedIndex, d.History
 	}
 	t.Run("ii: > 2 unmerged files", func(t *testing.T) {
-		ii, _ := newTestDomain()
+		ii, _ := newTestDomain(false)
 		ii.scanDirtyFiles([]string{
 			"v1.0-accounts.0-2.ef",
 			"v1.0-accounts.2-3.ef",
@@ -165,7 +179,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 		assert.Len(t, idxF, 3)
 	})
 	t.Run("hist: > 2 unmerged files", func(t *testing.T) {
-		ii, h := newTestDomain()
+		ii, h := newTestDomain(true)
 		ii.scanDirtyFiles([]string{
 			"v1.0-accounts.0-1.ef",
 			"v1.0-accounts.1-2.ef",
@@ -198,7 +212,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 		assert.Equal(t, 4, int(r.index.to))
 	})
 	t.Run("not equal amount of files", func(t *testing.T) {
-		ii, h := newTestDomain()
+		ii, h := newTestDomain(true)
 		ii.scanDirtyFiles([]string{
 			"v1.0-accounts.0-1.ef",
 			"v1.0-accounts.1-2.ef",
@@ -232,7 +246,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 		assert.Equal(t, 2, int(r.index.to))
 	})
 	t.Run("idx merged, history not yet", func(t *testing.T) {
-		ii, h := newTestDomain()
+		ii, h := newTestDomain(true)
 		ii.scanDirtyFiles([]string{
 			"v1.0-accounts.0-2.ef",
 			"v1.0-accounts.2-3.ef",
@@ -264,7 +278,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 		assert.Equal(t, 2, int(r.history.to))
 	})
 	t.Run("idx merged, history not yet, 2", func(t *testing.T) {
-		ii, h := newTestDomain()
+		ii, h := newTestDomain(true)
 		ii.scanDirtyFiles([]string{
 			"v1.0-accounts.0-1.ef",
 			"v1.0-accounts.1-2.ef",
@@ -294,7 +308,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 		defer hc.Close()
 
 		r := hc.findMergeRange(4, 32)
-		assert.False(t, r.index.needMerge)
+		assert.True(t, r.index.needMerge)
 		assert.True(t, r.history.needMerge)
 		assert.Equal(t, 4, int(r.history.to))
 		idxFiles, histFiles, err := hc.staticFilesInRange(r)
@@ -303,7 +317,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 		require.Len(t, histFiles, 4)
 	})
 	t.Run("idx merged and small files lost", func(t *testing.T) {
-		ii, h := newTestDomain()
+		ii, h := newTestDomain(true)
 		ii.scanDirtyFiles([]string{
 			"v1.0-accounts.0-4.ef",
 		})
@@ -337,7 +351,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 	})
 
 	t.Run("history merged, but index not and history garbage left", func(t *testing.T) {
-		ii, h := newTestDomain()
+		ii, h := newTestDomain(true)
 		ii.scanDirtyFiles([]string{
 			"v1.0-accounts.0-1.ef",
 			"v1.0-accounts.1-2.ef",
@@ -373,7 +387,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 		require.Empty(t, histFiles)
 	})
 	t.Run("history merge progress ahead of idx", func(t *testing.T) {
-		ii, h := newTestDomain()
+		ii, h := newTestDomain(true)
 		ii.scanDirtyFiles([]string{
 			"v1.0-accounts.0-1.ef",
 			"v1.0-accounts.1-2.ef",
@@ -413,7 +427,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 		require.Len(t, histFiles, 3)
 	})
 	t.Run("idx merge progress ahead of history", func(t *testing.T) {
-		ii, h := newTestDomain()
+		ii, h := newTestDomain(true)
 		ii.scanDirtyFiles([]string{
 			"v1.0-accounts.0-1.ef",
 			"v1.0-accounts.1-2.ef",
@@ -441,7 +455,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 		defer hc.Close()
 
 		r := hc.findMergeRange(4, 32)
-		assert.False(t, r.index.needMerge)
+		assert.True(t, r.index.needMerge)
 		assert.True(t, r.history.needMerge)
 		assert.Equal(t, 2, int(r.history.to))
 		idxFiles, histFiles, err := hc.staticFilesInRange(r)
@@ -450,7 +464,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 		require.Len(t, histFiles, 2)
 	})
 	t.Run("idx merged, but garbage left", func(t *testing.T) {
-		ii, h := newTestDomain()
+		ii, h := newTestDomain(true)
 		ii.scanDirtyFiles([]string{
 			"v1.0-accounts.0-1.ef",
 			"v1.0-accounts.1-2.ef",
@@ -481,7 +495,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 		assert.False(t, r.history.needMerge)
 	})
 	t.Run("idx merged, but garbage left2", func(t *testing.T) {
-		ii, _ := newTestDomain()
+		ii, _ := newTestDomain(false)
 		ii.scanDirtyFiles([]string{
 			"v1.0-accounts.0-1.ef",
 			"v1.0-accounts.1-2.ef",
@@ -865,7 +879,7 @@ func TestMergeFilesWithDependency(t *testing.T) {
 
 	setup := func() (account, storage, commitment *Domain) {
 		account, storage, commitment = newTestDomain(0), newTestDomain(1), newTestDomain(3)
-		checker := NewDependencyIntegrityChecker(account.dirs, log.New())
+		checker := NewDependencyIntegrityChecker(log.New())
 		info := &DependentInfo{
 			entity: FromDomain(commitment.Name),
 			filesGetter: func() *btree2.BTreeG[*FilesItem] {

--- a/db/state/snap_repo_test.go
+++ b/db/state/snap_repo_test.go
@@ -360,7 +360,7 @@ func TestReferencingIntegrityChecker(t *testing.T) {
 		return name, schema
 	})
 
-	accountsR.integrity = NewDependencyIntegrityChecker(dirs, log.New())
+	accountsR.integrity = NewDependencyIntegrityChecker(log.New())
 	accountsR.integrity.AddDependency(FromDomain(kv.AccountsDomain), &DependentInfo{
 		entity: FromDomain(kv.CommitmentDomain),
 		//filesGetter: ,


### PR DESCRIPTION
- Replace `dirtyFiles.Get()` lookup in `HistoryRoTx.staticFilesInRange` with a linear scan of `iit.files` (visible files from the RoTx, no garbage/overlaps)
- Remove unused `dirs` field from `DependencyIntegrityChecker`