### PR TITLE
`erigon seg info` tool

### DIFF
--- a/cmd/utils/app/seg_info_cmd.go
+++ b/cmd/utils/app/seg_info_cmd.go
@@ -1,0 +1,113 @@
+package app
+
+import (
+	"errors"
+	"path/filepath"
+	"slices"
+	"time"
+
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/node/debug"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
+)
+
+func segInfo(cliCtx *cli.Context) error {
+	logger, _, _, _, err := debug.Setup(cliCtx, true /* root logger */)
+	if err != nil {
+		return err
+	}
+
+	// Compression settings
+	compress := cliCtx.String("compress")
+	if compress != "all" && compress != "none" && compress != "keys" && compress != "values" {
+		return errors.New("invalid compression type: " + compress)
+	}
+
+	// Opens datadir/file
+	file := cliCtx.String("file")
+	if file == "" {
+		return errors.New("file is required")
+	}
+
+	dirs := datadir.Open(cliCtx.String("datadir"))
+	fullFilepath := filepath.Join(dirs.Snap, file)
+	logger.Info("Opening file...", "file", fullFilepath)
+
+	seg, err := seg.NewDecompressor(fullFilepath)
+	if err != nil {
+		return err
+	}
+	defer seg.Close()
+
+	// Scan entire file and collect statistics
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	logger.Info("Scanning file...")
+	g := seg.MakeGetter()
+	sizes := make([]int, 0, seg.Count())
+	i := 0
+	var w []byte
+	compressedKeys := compress == "all" || compress == "keys"
+	compressedValues := compress == "all" || compress == "values"
+	for g.HasNext() {
+		if (i%2 == 0 && compressedKeys) || (i%2 == 1 && compressedValues) {
+			w, _ = g.Next(w[:0])
+		} else {
+			w, _ = g.NextUncompressed()
+		}
+
+		i++
+		sizes = append(sizes, len(w))
+
+		select {
+		case <-ticker.C:
+			logger.Info("Still scanning file...", "i", i, "total", seg.Count())
+		default:
+		}
+	}
+	if len(sizes) != seg.Count() {
+		logger.Warn("Full scan of words doesn't match word count in file header", "header", seg.Count(), "scanned", len(sizes))
+	}
+	slices.Sort(sizes)
+	minWordLen := sizes[0]
+	maxWordLen := sizes[len(sizes)-1]
+
+	// Calculate length statistics
+	l := -1
+	uniqueLengths := 0
+	rawWordLen := 0
+	for _, v := range sizes {
+		if v != l {
+			l = v
+			uniqueLengths++
+		}
+		rawWordLen += v
+	}
+
+	// Print stats
+	p := message.NewPrinter(language.English)
+	p.Printf("\nFile statistics:\n\n")
+	p.Printf("File size: %d byte(s)\n", seg.Size())
+	p.Printf("Serialized dict size: %d byte(s)\n", seg.SerializedDictSize()) // word 3
+	p.Printf("Dict words: %d\n", seg.DictWords())
+	p.Printf("Serialized len size: %d byte(s)\n", seg.SerializedLenSize()) // word 4
+	p.Printf("Dict lens: %d\n", seg.DictLens())
+	p.Printf("Unique lengths: %d\n", uniqueLengths)
+	p.Printf("Data length: %d byte(s)\n", g.DataLen())
+	p.Printf("Total raw words length: %d byte(s)\n", rawWordLen)
+
+	p.Printf("\nWord count: %d\n", seg.Count())                // word 1
+	p.Printf("Empty words count: %d\n", seg.EmptyWordsCount()) // word 2
+	p.Printf("\nMin word length: %d byte(s)\n", minWordLen)
+	p.Printf("Max word length: %d byte(s)\n", maxWordLen)
+	p.Printf("Median word length: %d byte(s)\n", sizes[len(sizes)/2])
+	p.Printf("P90 word length: %d byte(s)\n", sizes[len(sizes)*90/100])
+	p.Printf("P95 word length: %d byte(s)\n", sizes[len(sizes)*95/100])
+	p.Printf("P99 word length: %d byte(s)\n", sizes[len(sizes)*99/100])
+
+	return nil
+}

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -391,6 +391,16 @@ var snapshotCommand = cli.Command{
 				&cli.Uint64Flag{Name: "new-step-size", Required: true, DefaultText: strconv.FormatUint(config3.DefaultStepSize, 10)},
 			}),
 		},
+		{
+			Name:        "info",
+			Action:      segInfo,
+			Description: "Show misc information about a segment file",
+			Flags: joinFlags([]cli.Flag{
+				&utils.DataDirFlag,
+				&cli.PathFlag{Name: "file", Required: true},
+				&cli.StringFlag{Name: "compress", Required: true, Usage: "Values compression type: all,none,keys,values"},
+			}),
+		},
 	},
 }
 

--- a/db/seg/decompress.go
+++ b/db/seg/decompress.go
@@ -135,7 +135,9 @@ type Decompressor struct {
 	metadata        []byte
 
 	serializedDictSize uint64
+	lenDictSize        uint64 // huffman encoded lengths
 	dictWords          int
+	dictLens           int
 
 	filePath, fileName string
 
@@ -305,6 +307,7 @@ func NewDecompressorWithMetadata(compressedFilePath string, hasMetadata bool) (*
 	pos += dictSize // offset patterns
 	// read positions
 	dictSize = binary.BigEndian.Uint64(d.data[pos : pos+8])
+	d.lenDictSize = dictSize
 	pos += 8
 
 	if pos+dictSize > uint64(d.size) {
@@ -335,6 +338,7 @@ func NewDecompressorWithMetadata(compressedFilePath string, hasMetadata bool) (*
 		dictPos += uint64(n)
 		poss = append(poss, dp)
 	}
+	d.dictLens = len(poss)
 
 	if dictSize > 0 {
 		var bitLen int
@@ -462,7 +466,9 @@ func (d *Decompressor) DataHandle() unsafe.Pointer {
 	return unsafe.Pointer(&d.data[0])
 }
 func (d *Decompressor) SerializedDictSize() uint64 { return d.serializedDictSize }
+func (d *Decompressor) SerializedLenSize() uint64  { return d.lenDictSize }
 func (d *Decompressor) DictWords() int             { return d.dictWords }
+func (d *Decompressor) DictLens() int              { return d.dictLens }
 
 func (d *Decompressor) Size() int64 {
 	return d.size
@@ -701,6 +707,10 @@ func (d *Decompressor) MakeGetter() *Getter {
 		patternDict: d.dict,
 		fName:       d.FileName(),
 	}
+}
+
+func (g *Getter) DataLen() int {
+	return len(g.data)
 }
 
 func (g *Getter) Reset(offset uint64) {


### PR DESCRIPTION
I quite often need to extract stats info from snapshots, decided to compile what I often use into a tool: `erigon seg info`.

Sample usage:

```
build/bin/erigon seg info --datadir ~/eth-nodes/erigon32-mainnet-stable --file domain/v1.1-commitment.0-1024.kv --compress=all
INFO[10-20|21:12:52.260] logging to file system                   log dir=/Users/wmitsuda/eth-nodes/erigon32-mainnet-stable/logs file prefix=erigon log level=info json=false
INFO[10-20|21:12:52.261] logging to file system                   log dir=/Users/wmitsuda/eth-nodes/erigon32-mainnet-stable/logs file prefix=erigon log level=info json=false
INFO[10-20|21:12:52.261] Opening file...                          file=/Users/wmitsuda/eth-nodes/erigon32-mainnet-stable/snapshots/domain/v1.1-commitment.0-1024.kv
INFO[10-20|21:12:52.263] Scanning file...
INFO[10-20|21:13:22.264] Still scanning file...                   i=115986374 total=455366174
INFO[10-20|21:13:52.264] Still scanning file...                   i=230873907 total=455366174
INFO[10-20|21:14:22.264] Still scanning file...                   i=340925540 total=455366174
INFO[10-20|21:14:52.264] Still scanning file...                   i=452999300 total=455366174

File statistics:

File size: 33,484,111,535 byte(s)
Serialized dict size: 396,432 byte(s)
Dict words: 12,138
Serialized len size: 2,405 byte(s)
Dict lens: 828
Unique lengths: 818
Data length: 33,483,712,666 byte(s)
Total raw words length: 35,599,970,947 byte(s)

Word count: 455,366,174
Empty words count: 0

Min word length: 4 byte(s)
Max word length: 1,256 byte(s)
Median word length: 36 byte(s)
P90 word length: 164 byte(s)
P95 word length: 244 byte(s)
P99 word length: 494 byte(s)
```
