### PR TITLE
refactor: remove obsolete // +build tag

### DIFF
--- a/common/crypto/signature_nocgo.go
+++ b/common/crypto/signature_nocgo.go
@@ -18,7 +18,6 @@
 // along with Erigon. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build nacl || js || !cgo || gofuzz
-// +build nacl js !cgo gofuzz
 
 package crypto
 

--- a/common/dbg/pprof_cgo.go
+++ b/common/dbg/pprof_cgo.go
@@ -15,7 +15,6 @@
 // along with Erigon. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build debug
-// +build debug
 
 package dbg
 

--- a/common/log/v3/syslog.go
+++ b/common/log/v3/syslog.go
@@ -1,5 +1,4 @@
 //go:build !windows && !plan9
-// +build !windows,!plan9
 
 package log
 

--- a/common/log/v3/term/terminal_appengine.go
+++ b/common/log/v3/term/terminal_appengine.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build appengine
-// +build appengine
 
 package term
 

--- a/common/log/v3/term/terminal_darwin.go
+++ b/common/log/v3/term/terminal_darwin.go
@@ -3,7 +3,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 //go:build !appengine
-// +build !appengine
 
 package term
 

--- a/common/log/v3/term/terminal_linux.go
+++ b/common/log/v3/term/terminal_linux.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !appengine
-// +build !appengine
 
 package term
 

--- a/common/log/v3/term/terminal_notwindows.go
+++ b/common/log/v3/term/terminal_notwindows.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build (linux && !appengine) || darwin || freebsd || openbsd || netbsd
-// +build linux,!appengine darwin freebsd openbsd netbsd
 
 package term
 

--- a/common/log/v3/term/terminal_windows.go
+++ b/common/log/v3/term/terminal_windows.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build windows
-// +build windows
 
 package term
 


### PR DESCRIPTION
From Go 1.17, the preferred syntax for build constraints is `//go:build`,
which replaces the old `// +build` form. The old style is now considered
deprecated but still supported for backward compatibility.

This change removes the obsolete `// +build xxx` line, keeping only the
modern `//go:build xxx` directive.

More info: https://github.com/golang/go/issues/41184 and https://go.dev/doc/go1.17#build-lines

Design Doc / Proposal：
https://go.dev/design/draft-gobuild
