### PR TITLE
all: big.Int use Sign() to compare with zero

### DIFF
--- a/execution/consensus/aura/aura.go
+++ b/execution/consensus/aura/aura.go
@@ -727,7 +727,7 @@ func (c *AuRa) Finalize(config *chain.Config, header *types.Header, state *state
 	if header.Number.Uint64() >= DEBUG_LOG_FROM {
 		fmt.Printf("finalize1: %d,%d\n", header.Number.Uint64(), len(receipts))
 	}
-	pendingTransitionProof, err := c.cfg.Validators.signalEpochEnd(header.Number.Uint64() == 0, header, receipts)
+	pendingTransitionProof, err := c.cfg.Validators.signalEpochEnd(header.Number.Sign() == 0, header, receipts)
 	if err != nil {
 		return nil, err
 	}
@@ -844,7 +844,7 @@ func allHeadersUntil(chain consensus.ChainHeaderReader, from *types.Header, to c
 		if header == nil {
 			panic("not found header")
 		}
-		if header.Number.Uint64() == 0 {
+		if header.Number.Sign() == 0 {
 			break
 		}
 		if to == header.Hash() {

--- a/execution/eth1/forkchoice.go
+++ b/execution/eth1/forkchoice.go
@@ -260,7 +260,7 @@ func (e *EthereumExecutionModule) updateForkChoice(ctx context.Context, original
 		sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, err, false)
 		return
 	}
-	if fcuHeader.Number.Uint64() > 0 {
+	if fcuHeader.Number.Sign() > 0 {
 		if canonicalHash == blockHash {
 			// if block hash is part of the canonical chain treat it as no-op.
 			writeForkChoiceHashes(tx, blockHash, safeHash, finalizedHash)
@@ -314,7 +314,7 @@ func (e *EthereumExecutionModule) updateForkChoice(ctx context.Context, original
 				return
 			}
 			currentParentHash = currentHeader.ParentHash
-			if currentHeader.Number.Uint64() == 0 {
+			if currentHeader.Number.Sign() == 0 {
 				panic("assert:uint64 underflow") //uint-underflow
 			}
 			currentParentNumber = currentHeader.Number.Uint64() - 1

--- a/execution/p2p/bbd.go
+++ b/execution/p2p/bbd.go
@@ -259,7 +259,7 @@ func (bbd *BackwardBlockDownloader) downloadHeaderChainBackwards(
 		connectionPoint = initialHeader
 	}
 	// if not, then continue fetching headers backwards until we find a connecting point
-	for connectionPoint == nil && lastHeader.Number.Uint64() > 0 {
+	for connectionPoint == nil && lastHeader.Number.Sign() > 0 {
 		if chainLen > config.chainLengthLimit {
 			return nil, fmt.Errorf(
 				"%w: num=%d, hash=%s, len=%d, limit=%d",

--- a/execution/stages/stageloop.go
+++ b/execution/stages/stageloop.go
@@ -469,7 +469,7 @@ func (h *Hook) sendNotifications(tx kv.Tx, finishStageBeforeSync uint64) error {
 
 	currentHeader := rawdb.ReadCurrentHeader(tx)
 	if (h.notifications.Accumulator != nil) && (currentHeader != nil) {
-		if currentHeader.Number.Uint64() == 0 {
+		if currentHeader.Number.Sign() == 0 {
 			h.notifications.Accumulator.StartChange(currentHeader, nil, false)
 		}
 

--- a/polygon/sync/block_downloader.go
+++ b/polygon/sync/block_downloader.go
@@ -312,7 +312,7 @@ func (d *BlockDownloader) downloadBlocksUsingWaypoints(
 				break
 			}
 
-			if blockBatch[0].Number().Uint64() == 0 {
+			if blockBatch[0].Number().Sign() == 0 {
 				// we do not want to insert block 0 (genesis)
 				blockBatch = blockBatch[1:]
 			}

--- a/txnprovider/txpool/pool_db.go
+++ b/txnprovider/txpool/pool_db.go
@@ -136,7 +136,7 @@ func SaveChainConfigIfNeed(
 	}
 
 	if cc != nil && !force {
-		if cc.ChainID.Uint64() == 0 {
+		if cc.ChainID.Sign() == 0 {
 			return nil, 0, errors.New("wrong chain config")
 		}
 		return initBor(cc), blockNum, nil
@@ -179,7 +179,7 @@ func SaveChainConfigIfNeed(
 	}); err != nil {
 		return nil, 0, err
 	}
-	if cc.ChainID.Uint64() == 0 {
+	if cc.ChainID.Sign() == 0 {
 		return nil, 0, errors.New("wrong chain config")
 	}
 	return initBor(cc), blockNum, nil


### PR DESCRIPTION
This PR uses `Sign()` to compare big.Int with zero, reasons:

- `Sign()` has better performance
- prevent overflow when converting to 64 bit integers
