### PR TITLE
Improved benchmarks for bt index

### DIFF
--- a/db/state/aggregator_bench_test.go
+++ b/db/state/aggregator_bench_test.go
@@ -172,12 +172,12 @@ func Benchmark_BTree_SeekVsGetCompressedV(b *testing.B) {
 		M:         1024,
 		KeySize:   64,
 		ValueSize: 1024,
-		KeyCount:  1000000, // .kv file size about 550 MB
+		KeyCount:  1_000_000, // .kv file size about 550 MB
 	}, compress)
 	rnd := newRnd(uint64(time.Now().UnixNano()))
 	getter := seg.NewReader(kv.MakeGetter(), compress)
 
-	b.Run("seek_only", func(b *testing.B) {
+	b.Run("seek_only_v", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			p := rnd.IntN(len(keys))
 
@@ -189,12 +189,10 @@ func Benchmark_BTree_SeekVsGetCompressedV(b *testing.B) {
 			if !bytes.Equal(keys[p], cur.Key()) {
 				panic("mistmatch")
 			}
-
-			cur.Close()
 		}
 	})
 
-	b.Run("get_only", func(b *testing.B) {
+	b.Run("get_only_v", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			p := rnd.IntN(len(keys))
 
@@ -216,12 +214,12 @@ func Benchmark_BTree_SeekVsGetCompressedK(b *testing.B) {
 		M:         1024,
 		KeySize:   64,
 		ValueSize: 1024,
-		KeyCount:  1000000, // .kv file size about 550 MB
+		KeyCount:  1_000_000, // .kv file size about 550 MB
 	}, compress)
 	rnd := newRnd(uint64(time.Now().UnixNano()))
 	getter := seg.NewReader(kv.MakeGetter(), compress)
 
-	b.Run("seek_only", func(b *testing.B) {
+	b.Run("seek_only_k", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			p := rnd.IntN(len(keys))
 
@@ -233,12 +231,10 @@ func Benchmark_BTree_SeekVsGetCompressedK(b *testing.B) {
 			if !bytes.Equal(keys[p], cur.Key()) {
 				panic("mistmatch")
 			}
-
-			cur.Close()
 		}
 	})
 
-	b.Run("get_only", func(b *testing.B) {
+	b.Run("get_only_k", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			p := rnd.IntN(len(keys))
 
@@ -260,12 +256,12 @@ func Benchmark_BTree_SeekVsGetCompressedKV(b *testing.B) {
 		M:         1024,
 		KeySize:   64,
 		ValueSize: 1024,
-		KeyCount:  1000000, // .kv file size about 550 MB
+		KeyCount:  1_000_000, // .kv file size about 550 MB
 	}, compress)
 	rnd := newRnd(uint64(time.Now().UnixNano()))
 	getter := seg.NewReader(kv.MakeGetter(), compress)
 
-	b.Run("seek_only", func(b *testing.B) {
+	b.Run("seek_only_kv", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			p := rnd.IntN(len(keys))
 
@@ -277,12 +273,10 @@ func Benchmark_BTree_SeekVsGetCompressedKV(b *testing.B) {
 			if !bytes.Equal(keys[p], cur.Key()) {
 				panic("mistmatch")
 			}
-
-			cur.Close()
 		}
 	})
 
-	b.Run("get_only", func(b *testing.B) {
+	b.Run("get_only_kv", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			p := rnd.IntN(len(keys))
 
@@ -304,7 +298,7 @@ func Benchmark_BTree_SeekVsGetUncompressed(b *testing.B) {
 		M:         1024,
 		KeySize:   64,
 		ValueSize: 1024,
-		KeyCount:  1000000, // .kv file size about 550 MB
+		KeyCount:  1_000_000, // .kv file size about 550 MB
 	}, compress)
 	rnd := newRnd(uint64(time.Now().UnixNano()))
 	getter := seg.NewReader(kv.MakeGetter(), compress)
@@ -321,8 +315,6 @@ func Benchmark_BTree_SeekVsGetUncompressed(b *testing.B) {
 			if !bytes.Equal(keys[p], cur.Key()) {
 				panic("mistmatch")
 			}
-
-			cur.Close()
 		}
 	})
 
@@ -348,7 +340,7 @@ func Benchmark_BTree_SeekThenNext(b *testing.B) {
 		M:         1024,
 		KeySize:   64,
 		ValueSize: 1024,
-		KeyCount:  1000000, // .kv file size about 550 MB
+		KeyCount:  1_000_000, // .kv file size about 550 MB
 	}, compress)
 	rnd := newRnd(uint64(time.Now().UnixNano()))
 	getter := seg.NewReader(kv.MakeGetter(), compress)


### PR DESCRIPTION
Continuation of this PR: https://github.com/erigontech/erigon/pull/17486 — specifically an attempt to understand why the number of allocations differs so much between `Seek` and `Get`

Removed `cur.Close` calls, which were masking part of the allocations, to get a more accurate measurement of the `Seek` operation. This is because `cur.Close` reuses state across benchmark iterations, which is not entirely correct ideologically — and doesn’t reflect the typical use case in real code.

The results of these benchmarks made two issues obvious (you can easily reproduce them locally by running the tests and generating a memory profiling graph):

1. `Seek` **performs about 2× more memory allocations than** `Get` in the `Benchmark_BTree_SeekVsGetCompressedV` test (where only values are compressed).

This happens because during the final stage of the Binary Search lookup, the function actually calls `readKV()` for each intermediate node:
```
if r-l <= DefaultBtreeStartSkip { // found small range, faster to scan now
    // m = l
    if cur.d == 0 {
        cur.Reset(l, g)
    } else {
        cur.Next()
    }
}
```

The `readKV()` function naturally reads not only the key but also the value — which causes allocations.

In reality, this is unnecessary for intermediate nodes since reading just the key is sufficient for traversal. That’s exactly what happens in the `Get` function, which doesn’t suffer from this problem.

2. **The** `Get` **function, on the other hand, shows ~2.5× more allocations than** `Seek` when keys are compressed — i.e., in the `Benchmark_BTree_SeekVsGetCompressedK` and `Benchmark_BTree_SeekVsGetCompressedKV` tests.

The memory profiling shows that in this case, intermediate bt nodes during `Get` traversal always lead to allocations, while `Seek` reuses the key buffer and typically performs only 1–2 allocations on average, instead of one per binary search step.

In both cases, we’re talking about the same type of allocations that are at the core of these two operations. (In `Seek`, the cursor allocation itself is negligible and already optimized via `sync.Pool`):
```
func (g *Getter) Next(buf []byte) ([]byte, uint64) {
    ...
    if len(buf)+int(wordLen) > cap(buf) {
        newBuf := make([]byte, len(buf)+int(wordLen))
        copy(newBuf, buf)
```
 
**How to run these benchmarks and view profiling results locally:**
```
go test -run=^$ -bench='Benchmark_BTree_SeekVsGetCompressedK/seek_only_k$' \
-benchmem -memprofile=mem.out -cpuprofile=cpu.out -count=1 -benchtime=1000000x

go tool pprof -alloc_objects -lines ./pkg.test mem.out

# visualization:
web   # graph view
top   # list view
```

As a result of this PR (and the findings from it), I created two follow-up tasks to optimize index search:
1. https://github.com/erigontech/erigon/issues/17585
2. https://github.com/erigontech/erigon/issues/17586

Both optimizations should reduce the average number of allocations roughly by half for `Seek`/`Get` operations in the bt index.
