### PR TITLE
fix flaky TestMergedFileGet (II)

### DIFF
--- a/db/state/forkable_agg_test.go
+++ b/db/state/forkable_agg_test.go
@@ -414,11 +414,7 @@ func TestMergedFileGet(t *testing.T) {
 
 	checkBuildFilesFn := func(mergeDisabled bool) {
 		agg.SetMergeDisabled(mergeDisabled)
-
-		for i := range amount {
-			err = agg.BuildFiles(RootNum(i + 1))
-			require.NoError(t, err)
-		}
+		require.NoError(t, agg.BuildFiles(RootNum(amount)))
 
 		snapCfg := Registry.SnapshotConfig(headerId)
 		var nDirtyFiles, nVisibleFiles int


### PR DESCRIPTION
turns out `BuildFiles` doesn't mean it'll get executed.
Which means later calls with higher `toTxNum` values might not get processed.