### PR TITLE
rpc: fix mix hash override in eth_simulateV1

### DIFF
--- a/rpc/transactions/call.go
+++ b/rpc/transactions/call.go
@@ -53,6 +53,7 @@ type BlockOverrides struct {
 	BlockHash   *map[uint64]common.Hash `json:"blockHash"`
 	BeaconRoot  *common.Hash            `json:"beaconRoot"`
 	Withdrawals *types.Withdrawals      `json:"withdrawals"`
+	PrevRandao  *common.Hash            `json:"prevRandao"`
 }
 
 type BlockHashOverrides map[uint64]common.Hash
@@ -76,6 +77,9 @@ func (o *BlockOverrides) OverrideHeader(header *types.Header) *types.Header {
 	}
 	if o.BaseFee != nil {
 		h.BaseFee = o.BaseFee.ToBig()
+	}
+	if o.PrevRandao != nil {
+		h.MixDigest = *o.PrevRandao
 	}
 	return h
 }


### PR DESCRIPTION
Fixes Hive test `ethSimulate-use-as-many-features-as-possible`