### PR TITLE
[r3.2] execution: fix incorrect initialCycle=false on 1st FCU with empty db (#17515)

### DIFF
--- a/db/state/aggregator_ext_test.go
+++ b/db/state/aggregator_ext_test.go
@@ -728,6 +728,7 @@ func TestAggregatorV3_BuildFiles_WithReorgDepth(t *testing.T) {
 	t.Cleanup(tx.Rollback)
 	doms, err := state.NewSharedDomains(tx, logger)
 	require.NoError(t, err)
+	t.Cleanup(doms.Close)
 	txnNums := uint64(18)
 	txnsPerBlock := uint64(1)
 	blocks := txnNums / txnsPerBlock

--- a/execution/eth1/forkchoice.go
+++ b/execution/eth1/forkchoice.go
@@ -245,7 +245,7 @@ func (e *EthereumExecutionModule) updateForkChoice(ctx context.Context, original
 
 	var limitedBigJump bool
 	limitedBigJumpPadding := uint64(2)
-	if e.syncCfg.LoopBlockLimit > 0 && finishProgressBefore > 0 && fcuHeader.Number.Uint64() > finishProgressBefore {
+	if e.syncCfg.LoopBlockLimit > 0 && fcuHeader.Number.Uint64() > finishProgressBefore {
 		// note fcuHeader.Number.Uint64() may be < finishProgressBefore - protect from underflow by checking it is >
 		limitedBigJump = (fcuHeader.Number.Uint64()-finishProgressBefore)+limitedBigJumpPadding > uint64(e.syncCfg.LoopBlockLimit)
 	}


### PR DESCRIPTION
cherry-pick https://github.com/erigontech/erigon/pull/17515

---

noticed while testing a resync from 0 on fusaka-devnet-3

symptom: `initialCycle=false` when blocks to exec are equal to 5,000 (--sync.loop.block.limit) on 1st FCU (unexpected) - subsequent FCU with 5,000 block batches have `initialCycle=true` (expected)

this only happens on the very 1st FCU when starting on an empty dir because `finishProgressBefore` is 0 and we have `finishProgressBefore > 0` in the if statement (left over from previous logic - now it is safe to remove it because there is no underflow chance in the computation)

before fix:
```
[INFO] [10-17|16:10:09.136] [4/6 Execution] serial starting          from=1 to=5000 limit=5001 initialTxNum=1 initialBlockTxOffset=0 lastFrozenStep=0 initialCycle=false useExternalTx=true inMem=false
```

after fix:
```
[INFO] [10-17|17:27:38.505] [4/6 Execution] serial starting          from=1 to=5000 limit=5001 initialTxNum=1 initialBlockTxOffset=0 lastFrozenStep=0 initialCycle=true useExternalTx=true inMem=false
```