### PR TITLE
refactor: use maps.Copy to simplify the code

### DIFF
--- a/execution/consensus/clique/api.go
+++ b/execution/consensus/clique/api.go
@@ -22,6 +22,7 @@ package clique
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
@@ -147,9 +148,7 @@ func (api *API) Proposals() map[common.Address]bool {
 	defer api.clique.lock.RUnlock()
 
 	proposals := make(map[common.Address]bool)
-	for address, auth := range api.clique.proposals {
-		proposals[address] = auth
-	}
+	maps.Copy(proposals, api.clique.proposals)
 	return proposals
 }
 

--- a/execution/rlp/typecache.go
+++ b/execution/rlp/typecache.go
@@ -21,6 +21,7 @@ package rlp
 
 import (
 	"fmt"
+	"maps"
 	"reflect"
 	"strings"
 	"sync"
@@ -111,9 +112,7 @@ func (c *typeCache) generate(typ reflect.Type, tags tags) *typeinfo {
 
 	// Copy cur to next.
 	c.next = make(map[typekey]*typeinfo, len(cur)+1)
-	for k, v := range cur {
-		c.next[k] = v
-	}
+	maps.Copy(c.next, cur)
 
 	// Generate.
 	info := c.infoWhileGenerating(typ, tags)

--- a/execution/stages/blockchain_test.go
+++ b/execution/stages/blockchain_test.go
@@ -24,6 +24,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"math/big"
 	"testing"
@@ -1869,9 +1870,7 @@ func TestDeleteRecreateSlotsAcrossManyBlocks(t *testing.T) {
 		var exp = new(expectation)
 		exp.blocknum = i + 1
 		exp.values = make(map[int]int)
-		for k, v := range current.values {
-			exp.values[k] = v
-		}
+		maps.Copy(exp.values, current.values)
 		exp.exist = current.exist
 
 		b.SetCoinbase(common.Address{1})

--- a/execution/state/triedb_state.go
+++ b/execution/state/triedb_state.go
@@ -80,17 +80,11 @@ func (b *Buffer) detachAccounts() {
 
 // Merges the content of another buffer into this one
 func (b *Buffer) merge(other *Buffer) {
-	for addrHash, codeWithHash := range other.codeReads {
-		b.codeReads[addrHash] = codeWithHash
-	}
+	maps.Copy(b.codeReads, other.codeReads)
 
-	for addrHash, code := range other.codeUpdates {
-		b.codeUpdates[addrHash] = code
-	}
+	maps.Copy(b.codeUpdates, other.codeUpdates)
 
-	for address, codeHash := range other.codeSizeReads {
-		b.codeSizeReads[address] = codeHash
-	}
+	maps.Copy(b.codeSizeReads, other.codeSizeReads)
 
 	for addrHash := range other.deleted {
 		b.deleted[addrHash] = other.deleted[addrHash]
@@ -111,21 +105,15 @@ func (b *Buffer) merge(other *Buffer) {
 		}
 		maps.Copy(m, om)
 	}
-	for addrHash, incarnation := range other.storageIncarnation {
-		b.storageIncarnation[addrHash] = incarnation
-	}
+	maps.Copy(b.storageIncarnation, other.storageIncarnation)
 	for storageKey := range other.storageReads {
 		b.storageReads[storageKey] = other.storageReads[storageKey]
 	}
-	for addrHash, accountAddr := range other.accountUpdates {
-		b.accountUpdates[addrHash] = accountAddr
-	}
+	maps.Copy(b.accountUpdates, other.accountUpdates)
 	for addrHash := range other.accountReads {
 		b.accountReads[addrHash] = other.accountReads[addrHash]
 	}
-	for addrHash, incarnation := range other.accountReadsIncarnation {
-		b.accountReadsIncarnation[addrHash] = incarnation
-	}
+	maps.Copy(b.accountReadsIncarnation, other.accountReadsIncarnation)
 }
 
 // TrieDbState implements StateReader by wrapping a trie and a database, where trie acts as a cache for the database


### PR DESCRIPTION


There is a [new function](https://pkg.go.dev/maps@go1.21.1#Copy) added in the go1.21 standard library, which can make the code more concise and easy to read.

Inspired by https://github.com/erigontech/erigon/pull/17347 and replace all.

