### PR TITLE
Ensure that filters that have been created always return the empty ar…

### DIFF
--- a/rpc/jsonrpc/eth_filters_test.go
+++ b/rpc/jsonrpc/eth_filters_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/erigontech/erigon/execution/stages/mock"
 	"github.com/erigontech/erigon/node/ethconfig"
 	"github.com/erigontech/erigon/node/gointerfaces/txpoolproto"
+	"github.com/erigontech/erigon/rpc"
 	"github.com/erigontech/erigon/rpc/filters"
 	"github.com/erigontech/erigon/rpc/rpccfg"
 	"github.com/erigontech/erigon/rpc/rpchelper"
@@ -113,4 +114,87 @@ func TestLogsSubscribeAndUnsubscribe_WithoutConcurrentMapIssue(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
+}
+
+func TestBlockFilterGetFilterChangesInitiallyEmpty(t *testing.T) {
+	assert := assert.New(t)
+
+	m, _, _ := rpcdaemontest.CreateTestSentry(t)
+	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
+	ctx, conn := rpcdaemontest.CreateTestGrpcConn(t, mock.Mock(t))
+	mining := txpoolproto.NewMiningClient(conn)
+	ff := rpchelper.New(ctx, rpchelper.DefaultFiltersConfig, nil, nil, mining, func() {}, m.Log)
+	api := NewEthAPI(NewBaseApi(ff, stateCache, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil), m.DB, nil, nil, nil, 5000000, ethconfig.Defaults.RPCTxFeeCap, 100_000, false, 100_000, 128, log.New())
+
+	// Create a new block filter
+	bf, err := api.NewBlockFilter(ctx)
+	assert.NoError(err)
+
+	// Immediately query changes; should be empty slice and no error
+	changes, err := api.GetFilterChanges(ctx, bf)
+	assert.NoError(err)
+	assert.Len(changes, 0)
+
+	// Cleanup
+	ok, err := api.UninstallFilter(ctx, bf)
+	assert.NoError(err)
+	assert.True(ok)
+}
+
+func TestCompositeFiltersGetFilterChangesInitiallyEmpty(t *testing.T) {
+	assert := assert.New(t)
+
+	m, _, _ := rpcdaemontest.CreateTestSentry(t)
+	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
+	ctx, conn := rpcdaemontest.CreateTestGrpcConn(t, mock.Mock(t))
+	mining := txpoolproto.NewMiningClient(conn)
+	ff := rpchelper.New(ctx, rpchelper.DefaultFiltersConfig, nil, nil, mining, func() {}, m.Log)
+	api := NewEthAPI(NewBaseApi(ff, stateCache, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil), m.DB, nil, nil, nil, 5000000, ethconfig.Defaults.RPCTxFeeCap, 100_000, false, 100_000, 128, log.New())
+
+	// Create all three filter types
+	ptf, err := api.NewPendingTransactionFilter(ctx)
+	assert.NoError(err)
+	lf, err := api.NewFilter(ctx, filters.FilterCriteria{})
+	assert.NoError(err)
+	bf, err := api.NewBlockFilter(ctx)
+	assert.NoError(err)
+
+	// Immediately query changes on each; expect empty and no error
+	changes, err := api.GetFilterChanges(ctx, ptf)
+	assert.NoError(err)
+	assert.Len(changes, 0)
+
+	changes, err = api.GetFilterChanges(ctx, lf)
+	assert.NoError(err)
+	assert.Len(changes, 0)
+
+	changes, err = api.GetFilterChanges(ctx, bf)
+	assert.NoError(err)
+	assert.Len(changes, 0)
+
+	// Cleanup
+	ok, err := api.UninstallFilter(ctx, ptf)
+	assert.NoError(err)
+	assert.True(ok)
+	ok, err = api.UninstallFilter(ctx, lf)
+	assert.NoError(err)
+	assert.True(ok)
+	ok, err = api.UninstallFilter(ctx, bf)
+	assert.NoError(err)
+	assert.True(ok)
+}
+
+func TestGetFilterChangesReturnsFilterNotFoundForUnknownID(t *testing.T) {
+	assert := assert.New(t)
+
+	m, _, _ := rpcdaemontest.CreateTestSentry(t)
+	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
+	ctx, conn := rpcdaemontest.CreateTestGrpcConn(t, mock.Mock(t))
+	mining := txpoolproto.NewMiningClient(conn)
+	ff := rpchelper.New(ctx, rpchelper.DefaultFiltersConfig, nil, nil, mining, func() {}, m.Log)
+	api := NewEthAPI(NewBaseApi(ff, stateCache, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil), m.DB, nil, nil, nil, 5000000, ethconfig.Defaults.RPCTxFeeCap, 100_000, false, 100_000, 128, log.New())
+
+	// Use a bogus id that does not correspond to any subscription
+	_, err := api.GetFilterChanges(ctx, "0xdeadbeefcafebabe")
+	assert.ErrorIs(err, rpc.ErrFilterNotFound)
 }

--- a/rpc/rpchelper/filters.go
+++ b/rpc/rpchelper/filters.go
@@ -521,6 +521,18 @@ func (ff *Filters) HasSubscription(id LogsSubID) bool {
 	return ff.logsSubs.hasLogsFilter(id)
 }
 
+// HasHeadsSubscription returns true if a heads (new block headers) subscription exists for the given ID.
+func (ff *Filters) HasHeadsSubscription(id HeadsSubID) bool {
+	_, ok := ff.headsSubs.Get(id)
+	return ok
+}
+
+// HasPendingTxsSubscription returns true if a pending transactions subscription exists for the given ID.
+func (ff *Filters) HasPendingTxsSubscription(id PendingTxsSubID) bool {
+	_, ok := ff.pendingTxsSubs.Get(id)
+	return ok
+}
+
 // UnsubscribeLogs unsubscribes from logs using the given subscription ID.
 // It returns true if the unsubscription was successful, otherwise false.
 func (ff *Filters) UnsubscribeLogs(id LogsSubID) bool {


### PR DESCRIPTION
When calling eth_getFilterChanges immediately after eth_blockFilter an error "no filter found" is returned. Instead the empty list should be returned.

This PR addresses the issue by first checking if the filter can be found in any of the lists. If it can not then the method returns early with filter not found, otherwise execution falls through to the existing code.

Testing has been updated to cover the changed method.

This is an extension of the previous fix for eth_newFilter that was resolved in 3.2.1: https://github.com/erigontech/erigon/commit/df39cf9c9a53c873f507d50014fe0fdb2547d0f8

This original fix used a similar approach but only tested the logsSub list and hence missed pending transaction filters and block filters.