### PR TITLE
fix no filter found on block filters

### DIFF
--- a/rpc/jsonrpc/eth_filters.go
+++ b/rpc/jsonrpc/eth_filters.go
@@ -99,9 +99,6 @@ func (api *APIImpl) GetFilterChanges(_ context.Context, index string) ([]any, er
 	stub := make([]any, 0)
 	// remove 0x
 	cutIndex := strings.TrimPrefix(index, "0x")
-	if found := api.filters.HasSubscription(rpchelper.LogsSubID(cutIndex)); !found {
-		return nil, rpc.ErrFilterNotFound
-	}
 	if blocks, ok := api.filters.ReadPendingBlocks(rpchelper.HeadsSubID(cutIndex)); ok {
 		for _, v := range blocks {
 			stub = append(stub, v.Hash())


### PR DESCRIPTION
Fixes - https://github.com/erigontech/erigon/issues/17610

Removes check for existing subscription for LogFilter when we are trying to check filter changes for blocks or pending transctions