### PR TITLE
CI: eth_getProof: enabled previous exclude tests for root mismatch

### DIFF
--- a/.github/workflows/scripts/run_rpc_tests_ethereum_latest.sh
+++ b/.github/workflows/scripts/run_rpc_tests_ethereum_latest.sh
@@ -23,9 +23,6 @@ DISABLED_TEST_LIST=(
    erigon_
    eth_blobBaseFee/test_01.json # debug mismatch
    eth_callBundle
-   eth_getProof/test_04.json
-   eth_getProof/test_08.json
-   eth_getProof/test_09.json
    ots_
    parity_
    trace_


### PR DESCRIPTION
After fixes on eth_getProof()  I have re-enable few disabled tests