### PR TITLE
fix: add execution check to GetLogs to prevent empty results during sync

### DIFF
--- a/rpc/jsonrpc/eth_receipts.go
+++ b/rpc/jsonrpc/eth_receipts.go
@@ -142,6 +142,16 @@ func (api *APIImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria) (t
 		end = latest
 	}
 
+	// Check if the requested blocks have been executed.
+	// This prevents returning empty results when blocks exist but haven't been executed yet.
+	latestExecuted, err := rpchelper.GetLatestExecutedBlockNumber(tx)
+	if err != nil {
+		return nil, err
+	}
+	if begin > latestExecuted || end > latestExecuted {
+		return nil, fmt.Errorf("requested block range [%d, %d] is beyond latest executed block %d (node is still syncing)", begin, end, latestExecuted)
+	}
+
 	erigonLogs, err := api.getLogsV3(ctx, tx, begin, end, crit)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Adds validation to `eth_getLogs` to detect when requested blocks haven't been executed yet, preventing silent empty log returns and providing clear user feedback during node synchronization.

## Problem

Tries to address #17624

Currently, there's a race condition between block insertion and block execution in Erigon. When `eth_getLogs` is called for blocks that exist in the database but haven't been executed yet, it silently returns an empty logs array instead of providing meaningful feedback. This creates confusion for users who see a valid block from `eth_getBlockByNumber` but get no logs from `eth_getLogs` for the same block.

The issue mentioned above better describes the problem.

## Implementation Details

  - Added GetLatestExecutedBlockNumber() call before processing logs
  - Validates that both begin and end of the requested range are within executed blocks
  - Returns descriptive error message indicating sync status

## Limitations & Future Considerations

This PR does NOT eliminate the race condition, but makes it explicit to users. The race still exists because execution could complete between our check and the actual log retrieval.

Partial results consideration: Technically, we could return logs when begin <= latestExecuted < end (i.e., return partial logs for the executed portion of the range). However, this was intentionally not implemented because:

  1. User confusion: Returning partial results without clear indication would still be misleading - users wouldn't understand why they only got some logs
  2. API semantics: It's unclear whether partial results would violate user expectations for the requested range
  3. Consistency: Failing fast with a clear error is more predictable than silently returning incomplete data

A complete fix would require deeper changes to ensure atomicity between block insertion and execution visibility in the RPC layer, which is beyond the scope of this PR.