### PR TITLE
refactor: remove redundant variable declarations in for loops

### DIFF
--- a/execution/abi/bind/util_test.go
+++ b/execution/abi/bind/util_test.go
@@ -62,8 +62,6 @@ func TestWaitDeployed(t *testing.T) {
 		t.Skip("fix me on win please")
 	}
 	for name, test := range waitDeployedTests {
-		name := name
-		test := test
 
 		t.Run(name, func(t *testing.T) {
 			backend := backends.NewSimulatedBackend(t,

--- a/execution/abi/unpack_test.go
+++ b/execution/abi/unpack_test.go
@@ -380,7 +380,6 @@ func TestMethodMultiReturn(t *testing.T) {
 		"Can not unpack into a slice with wrong types",
 	}}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 			err := abi.UnpackIntoInterface(tc.dest, "multi", data)

--- a/execution/consensus/clique/snapshot_test.go
+++ b/execution/consensus/clique/snapshot_test.go
@@ -399,8 +399,6 @@ func TestClique(t *testing.T) {
 	}
 	// Run through the scenarios and test them
 	for i, tt := range tests {
-		i := i
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			logger := testlog.Logger(t, log.LvlInfo)

--- a/execution/stages/genesis_test.go
+++ b/execution/stages/genesis_test.go
@@ -171,7 +171,6 @@ func TestSetupGenesis(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			tmpdir := t.TempDir()

--- a/execution/stages/headerdownload/header_algo_test.go
+++ b/execution/stages/headerdownload/header_algo_test.go
@@ -97,7 +97,6 @@ func TestSideChainInsert(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		for i, h := range tc.chain {
 			data, _ := rlp.EncodeToBytes(h)
 			if _, err = hi.FeedHeaderPoW(tx, br, h, data, h.Hash(), uint64(i+1)); err != nil {

--- a/execution/stages/mock/accessors_indexes_test.go
+++ b/execution/stages/mock/accessors_indexes_test.go
@@ -54,7 +54,6 @@ func TestLookupStorage(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			m := mock.Mock(t)

--- a/execution/state/rw_v3.go
+++ b/execution/state/rw_v3.go
@@ -143,7 +143,6 @@ func (rs *StateV3) applyUpdates(roTx kv.TemporalTx, blockNum, txNum uint64, stat
 	var acc accounts.Account
 	emptyRemoval := rules.IsSpuriousDragon
 	for addr, increase := range balanceIncreases {
-		increase := increase
 		addrBytes := addr.Bytes()
 		enc0, step0, err := domains.GetLatest(kv.AccountsDomain, roTx, addrBytes)
 		if err != nil {

--- a/execution/tests/state_test.go
+++ b/execution/tests/state_test.go
@@ -52,7 +52,6 @@ func TestStateCornerCases(t *testing.T) {
 	db := temporaltest.NewTestDB(t, dirs)
 	st.walk(t, cornersDir, func(t *testing.T, name string, test *testutil.StateTest) {
 		for _, subtest := range test.Subtests() {
-			subtest := subtest
 			key := fmt.Sprintf("%s/%d", subtest.Fork, subtest.Index)
 			t.Run(key, func(t *testing.T) {
 				withTrace(t, func(vmconfig vm.Config) error {
@@ -101,7 +100,6 @@ func TestState(t *testing.T) {
 	db := temporaltest.NewTestDB(t, dirs)
 	st.walk(t, dir, func(t *testing.T, name string, test *testutil.StateTest) {
 		for _, subtest := range test.Subtests() {
-			subtest := subtest
 			key := fmt.Sprintf("%s/%d", subtest.Fork, subtest.Index)
 			t.Run(key, func(t *testing.T) {
 				withTrace(t, func(vmconfig vm.Config) error {

--- a/execution/types/accounts/account_benchmark_test.go
+++ b/execution/types/accounts/account_benchmark_test.go
@@ -66,7 +66,6 @@ func BenchmarkEncodingLengthForStorage(b *testing.B) {
 
 	b.ResetTimer()
 	for _, test := range accountCases {
-		test := test
 		b.Run(fmt.Sprint(test.name), func(b *testing.B) {
 			lengths := make([]uint, b.N)
 
@@ -119,7 +118,6 @@ func BenchmarkEncodingLengthForHashing(b *testing.B) {
 
 	b.ResetTimer()
 	for _, test := range accountCases {
-		test := test
 		b.Run(fmt.Sprint(test.name), func(bn *testing.B) {
 			lengths := make([]uint, bn.N)
 
@@ -174,7 +172,6 @@ func BenchmarkEncodingAccountForStorage(b *testing.B) {
 
 	b.ResetTimer()
 	for _, test := range accountCases {
-		test := test
 
 		//buf := make([]byte, test.acc.EncodingLengthForStorage())
 		b.Run(fmt.Sprint(test.name), func(b *testing.B) {
@@ -230,7 +227,6 @@ func BenchmarkEncodingAccountForHashing(b *testing.B) {
 
 	b.ResetTimer()
 	for _, test := range accountCases {
-		test := test
 		buf := make([]byte, test.acc.EncodingLengthForStorage())
 		b.Run(fmt.Sprint(test.name), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
@@ -285,7 +281,6 @@ func BenchmarkDecodingAccount(b *testing.B) {
 	var decodedAccounts []Account
 	b.ResetTimer()
 	for _, test := range accountCases {
-		test := test
 		b.Run(fmt.Sprint(test.name), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				println(test.name, i, b.N) //TODO: it just stucks w/o that print
@@ -354,7 +349,6 @@ func BenchmarkDecodingIncarnation(b *testing.B) { // V2 version of bench was a p
 	var decodedIncarnations []uint64
 	b.ResetTimer()
 	for _, test := range accountCases {
-		test := test
 		b.Run(fmt.Sprint(test.name), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				println(test.name, i, b.N) //TODO: it just stucks w/o that print
@@ -424,7 +418,6 @@ func BenchmarkRLPEncodingAccount(b *testing.B) {
 
 	b.ResetTimer()
 	for _, test := range accountCases {
-		test := test
 		b.Run(fmt.Sprint(test.name), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				if err := test.acc.EncodeRLP(io.Discard); err != nil {

--- a/execution/types/receipt_test.go
+++ b/execution/types/receipt_test.go
@@ -86,7 +86,6 @@ func TestLegacyReceiptDecoding(t *testing.T) {
 	receipt.Bloom = CreateBloom(Receipts{receipt})
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			enc, err := tc.encode(receipt)

--- a/txnprovider/txpool/pool_txn_parser_test.go
+++ b/txnprovider/txpool/pool_txn_parser_test.go
@@ -38,13 +38,11 @@ import (
 
 func TestParseTransactionRLP(t *testing.T) {
 	for _, testSet := range allNetsTestCases {
-		testSet := testSet
 		t.Run(strconv.Itoa(int(testSet.chainID.Uint64())), func(t *testing.T) {
 			require := require.New(t)
 			ctx := NewTxnParseContext(testSet.chainID)
 			txn, txnSender := &TxnSlot{}, [20]byte{}
 			for i, tt := range testSet.tests {
-				tt := tt
 				t.Run(strconv.Itoa(i), func(t *testing.T) {
 					payload := hexutil.MustDecodeHex(tt.PayloadStr)
 					parseEnd, err := ctx.ParseTransaction(payload, 0, txn, txnSender[:], false /* hasEnvelope */, true /* wrappedWithBlobs */, nil)


### PR DESCRIPTION
Inspired by https://github.com/erigontech/erigon/pull/17147 and replace all.


The new version of Go has been optimized, and variables do not need to be reassigned.

For more info: https://tip.golang.org/wiki/LoopvarExperiment#does-this-mean-i-dont-have-to-write-x--x-in-my-loops-anymore