### PR TITLE
linter: exclude `./build` and `./vendor`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -138,7 +138,7 @@ linters:
     paths:
       - build/
       - vendor/
-      - third_party
+      - third_party$
       - builtin$
       - examples$
       - testdata


### PR DESCRIPTION
also i found bug: `execution-spec-tests$` didn't filter sub-folders