### PR TITLE
rpcdaemon: debug_traceBlockByNumber(): add more clear error in case bn not found

### DIFF
--- a/rpc/jsonrpc/tracing.go
+++ b/rpc/jsonrpc/tracing.go
@@ -65,6 +65,11 @@ func (api *DebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rpc.Block
 		return err
 	}
 
+	if (blockNrOrHash.BlockHash == nil && hash == common.Hash{}) {
+		stream.WriteNil()
+		return fmt.Errorf("block #%d not found", *blockNrOrHash.BlockNumber)
+	}
+
 	if blockNumber == 0 {
 		stream.WriteNil()
 		return fmt.Errorf("genesis is not traceable")


### PR DESCRIPTION
Now in case of invalid bn the method fail with:
invalid arguments; block with hash 0000000000000000000000000000000000000000000000000000000000000000 not found