### PR TITLE
refactor: replace sort.Slice with slices.Sort for natural ordering

### DIFF
--- a/cmd/txnbench/internal/bench/compare.go
+++ b/cmd/txnbench/internal/bench/compare.go
@@ -2,7 +2,7 @@ package bench
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 )
 
 type agg struct {
@@ -27,7 +27,7 @@ func CompareResults(old BenchOutput, newer BenchOutput) string {
 	for k := range keys {
 		blocks = append(blocks, k)
 	}
-	sort.Slice(blocks, func(i, j int) bool { return blocks[i] < blocks[j] })
+	slices.Sort(blocks)
 
 	out := ""
 	out += "FIRST-LATENCY (cold)\n"


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices#Sort) added in the go1.21 standard library, which can make the code more concise and easy to read.