### PR TITLE
refactor: use the built-in max to simplify the code

### DIFF
--- a/execution/commitment/trie/gen_struct_step.go
+++ b/execution/commitment/trie/gen_struct_step.go
@@ -128,11 +128,7 @@ func GenStructStepEx(
 		}
 		succLen := prefixLen(succ, curr)
 		var maxLen int
-		if precLen > succLen {
-			maxLen = precLen
-		} else {
-			maxLen = succLen
-		}
+		maxLen = max(precLen, succLen)
 		if trace || maxLen >= len(curr) {
 			fmt.Printf("curr: %x, succ: %x, maxLen %d, groups: %b, precLen: %d, succLen: %d, buildExtensions: %t\n", curr, succ, maxLen, groups, precLen, succLen, buildExtensions)
 		}
@@ -376,11 +372,7 @@ func GenStructStepOld(
 		}
 		succLen := prefixLen(succ, curr)
 		var maxLen int
-		if precLen > succLen {
-			maxLen = precLen
-		} else {
-			maxLen = succLen
-		}
+		maxLen = max(precLen, succLen)
 		if trace || maxLen >= len(curr) {
 			fmt.Printf("curr: %x, succ: %x, maxLen %d, groups: %b, precLen: %d, succLen: %d, buildExtensions: %t\n", curr, succ, maxLen, groups, precLen, succLen, buildExtensions)
 		}

--- a/execution/commitment/trie/witness.go
+++ b/execution/commitment/trie/witness.go
@@ -147,10 +147,7 @@ func (w *Witness) WriteDiff(w2 *Witness, output io.Writer) {
 		fmt.Fprintf(output, "w1 operands: %d; w2 operands: %d\n", len(w.Operators), len(w2.Operators))
 	}
 
-	length := len(w.Operators)
-	if len(w2.Operators) > length {
-		length = len(w2.Operators)
-	}
+	length := max(len(w2.Operators), len(w.Operators))
 
 	for i := 0; i < length; i++ {
 		var op WitnessOperator

--- a/execution/consensus/ethash/algorithm.go
+++ b/execution/consensus/ethash/algorithm.go
@@ -377,10 +377,7 @@ func generateDataset(dest []uint32, epoch uint64, cache []uint32) {
 			// Calculate the data segment this thread should generate
 			batch := (size + hashBytes*uint64(threads) - 1) / (hashBytes * uint64(threads))
 			first := uint64(id) * batch
-			limit := first + batch
-			if limit > size/hashBytes {
-				limit = size / hashBytes
-			}
+			limit := min(first+batch, size/hashBytes)
 			// Calculate the dataset segment
 			percent := size / hashBytes / 100
 			for index := first; index < limit; index++ {

--- a/execution/rlp/decode.go
+++ b/execution/rlp/decode.go
@@ -385,10 +385,7 @@ func decodeSliceElems(s *Stream, val reflect.Value, elemdec decoder) error {
 	for ; ; i++ {
 		// grow slice if necessary
 		if i >= val.Cap() {
-			newcap := val.Cap() + val.Cap()/2
-			if newcap < 4 {
-				newcap = 4
-			}
+			newcap := max(val.Cap()+val.Cap()/2, 4)
 			newv := reflect.MakeSlice(val.Type(), val.Len(), newcap)
 			reflect.Copy(newv, val)
 			val.Set(newv)

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -366,10 +366,7 @@ func (se *serialExecutor) executeBlock(ctx context.Context, tasks []exec.Task, i
 		// During the first block execution, we may have half-block data in the snapshots.
 		// Thus, we need to skip the first txs in the block, however, this causes the GasUsed to be incorrect.
 		// So we need to skip that check for the first block, if we find half-executed data (startTxIndex>0).
-		startTxIndex = tasks[0].(*exec.TxTask).TxIndex
-		if startTxIndex < 0 {
-			startTxIndex = 0
-		}
+		startTxIndex = max(tasks[0].(*exec.TxTask).TxIndex, 0)
 	}
 
 	var gasPool *core.GasPool

--- a/execution/stages/stageloop.go
+++ b/execution/stages/stageloop.go
@@ -484,10 +484,7 @@ func (h *Hook) sendNotifications(tx kv.Tx, finishStageBeforeSync, finishStageAft
 			notifyFrom = *unwindTo
 			isUnwind = true
 		} else {
-			heightSpan := finishStageAfterSync - finishStageBeforeSync
-			if heightSpan > 1024 {
-				heightSpan = 1024
-			}
+			heightSpan := min(finishStageAfterSync-finishStageBeforeSync, 1024)
 			notifyFrom = finishStageAfterSync - heightSpan
 		}
 		notifyFrom++

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -188,10 +188,7 @@ func valueString(path AccountPath, value any) string {
 	case NoncePath:
 		return strconv.FormatUint(value.(uint64), 10)
 	case CodePath:
-		l := len(value.([]byte))
-		if l > 40 {
-			l = 40
-		}
+		l := min(len(value.([]byte)), 40)
 		return hex.EncodeToString(value.([]byte)[0:l])
 	}
 

--- a/execution/vm/absint_cfg_proof_check.go
+++ b/execution/vm/absint_cfg_proof_check.go
@@ -67,14 +67,8 @@ func NewCfgAbsSem() *CfgAbsSem {
 
 func getPushValue(code []byte, pc int, opsem0 *CfgOpSem) uint256.Int {
 	pushByteSize := opsem0.opNum
-	startMin := pc + 1
-	if startMin >= len(code) {
-		startMin = len(code)
-	}
-	endMin := startMin + pushByteSize
-	if startMin+pushByteSize >= len(code) {
-		endMin = len(code)
-	}
+	startMin := min(pc+1, len(code))
+	endMin := min(startMin+pushByteSize, len(code))
 	integer := new(uint256.Int)
 	integer.SetBytes(code[startMin:endMin])
 	return *integer

--- a/execution/vm/absint_cfg_proof_gen.go
+++ b/execution/vm/absint_cfg_proof_gen.go
@@ -110,14 +110,8 @@ func toProgram(code []byte) *Program {
 
 		if op.IsPushWithImmediateArgs() {
 			pushByteSize := stmt.operation.opNum
-			startMin := pc + 1
-			if startMin >= codeLen {
-				startMin = codeLen
-			}
-			endMin := startMin + pushByteSize
-			if startMin+pushByteSize >= codeLen {
-				endMin = codeLen
-			}
+			startMin := min(pc+1, codeLen)
+			endMin := min(startMin+pushByteSize, codeLen)
 			integer := new(uint256.Int)
 			integer.SetBytes(code[startMin:endMin])
 			stmt.value = *integer

--- a/execution/vm/contracts_test.go
+++ b/execution/vm/contracts_test.go
@@ -183,10 +183,7 @@ func benchmarkPrecompiled(b *testing.B, addr string, test precompiledTest) {
 			res, _, err = RunPrecompiledContract(p, data, reqGas, nil)
 		}
 		bench.StopTimer()
-		elapsed := uint64(time.Since(start))
-		if elapsed < 1 {
-			elapsed = 1
-		}
+		elapsed := max(uint64(time.Since(start)), 1)
 		gasUsed := reqGas * uint64(bench.N)
 		bench.ReportMetric(float64(reqGas), "gas/op")
 		// Keep it as uint64, multiply 100 to get two digit float later

--- a/execution/vm/instructions.go
+++ b/execution/vm/instructions.go
@@ -1361,14 +1361,8 @@ func makePush(size uint64, pushByteSize int) executionFunc {
 	return func(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 		codeLen := len(scope.Contract.Code)
 
-		startMin := int(*pc + 1)
-		if startMin >= codeLen {
-			startMin = codeLen
-		}
-		endMin := startMin + pushByteSize
-		if startMin+pushByteSize >= codeLen {
-			endMin = codeLen
-		}
+		startMin := min(int(*pc+1), codeLen)
+		endMin := min(startMin+pushByteSize, codeLen)
 
 		integer := new(uint256.Int)
 		scope.Stack.push(integer.SetBytes(common.RightPadBytes(
@@ -1384,14 +1378,8 @@ func makePushStringer(size uint64, pushByteSize int) stringer {
 	return func(pc uint64, scope *ScopeContext) string {
 		codeLen := len(scope.Contract.Code)
 
-		startMin := int(pc + 1)
-		if startMin >= codeLen {
-			startMin = codeLen
-		}
-		endMin := startMin + pushByteSize
-		if startMin+pushByteSize >= codeLen {
-			endMin = codeLen
-		}
+		startMin := min(int(pc+1), codeLen)
+		endMin := min(startMin+pushByteSize, codeLen)
 
 		integer := new(uint256.Int)
 		integer.SetBytes(common.RightPadBytes(scope.Contract.Code[startMin:endMin], pushByteSize))


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.

Inspired by https://github.com/erigontech/erigon/pull/16213 and replace more.