### PR TITLE
refactor: use the built-in max to simplify the code

### DIFF
--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -392,10 +392,7 @@ func (d *dialScheduler) expireHistory() {
 // freeDialSlots returns the number of free dial slots. The result can be negative
 // when peers are connected while their task is still running.
 func (d *dialScheduler) freeDialSlots() int {
-	slots := (d.maxDialPeers - d.dialPeers) * 2
-	if slots > d.maxActiveDials {
-		slots = d.maxActiveDials
-	}
+	slots := min((d.maxDialPeers-d.dialPeers)*2, d.maxActiveDials)
 	free := slots - len(d.dialing)
 	return free
 }

--- a/p2p/dnsdisc/tree.go
+++ b/p2p/dnsdisc/tree.go
@@ -175,10 +175,7 @@ func (t *Tree) build(entries []entry) entry {
 	}
 	var subtrees []entry
 	for len(entries) > 0 {
-		n := maxChildren
-		if len(entries) < n {
-			n = len(entries)
-		}
+		n := min(len(entries), maxChildren)
 		sub := t.build(entries[:n])
 		entries = entries[n:]
 		subtrees = append(subtrees, sub)

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -144,10 +144,7 @@ func (r *eofSignal) Read(buf []byte) (int, error) {
 		return 0, io.EOF
 	}
 
-	max := len(buf)
-	if int(r.count) < len(buf) {
-		max = int(r.count)
-	}
+	max := min(int(r.count), len(buf))
 	n, err := r.wrapped.Read(buf[:max])
 	r.count -= uint32(n)
 	if (err != nil || r.count == 0) && r.eof != nil {

--- a/p2p/sentry/sentry_multi_client/sentry_multi_client.go
+++ b/p2p/sentry/sentry_multi_client/sentry_multi_client.go
@@ -765,14 +765,8 @@ func (cs *MultiClient) getBlockWitnesses(ctx context.Context, inreq *sentryproto
 				totalCached += len(queriedBytes)
 			}
 
-			start := wit.PageSize * witnessPage.Page
-			if start > uint64(len(witnessBytes)) {
-				start = uint64(len(witnessBytes))
-			}
-			end := start + wit.PageSize
-			if end > uint64(len(witnessBytes)) {
-				end = uint64(len(witnessBytes))
-			}
+			start := min(wit.PageSize*witnessPage.Page, uint64(len(witnessBytes)))
+			end := min(start+wit.PageSize, uint64(len(witnessBytes)))
 			witnessPageResponse.Data = witnessBytes[start:end]
 			totalResponsePayloadDataAmount += len(witnessPageResponse.Data)
 		}

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -470,10 +470,7 @@ func (s *sharedUDPConn) ReadFromUDP(b []byte) (n int, addr *net.UDPAddr, err err
 	if !ok {
 		return 0, nil, errors.New("connection was closed")
 	}
-	l := len(packet.Data)
-	if l > len(b) {
-		l = len(b)
-	}
+	l := min(len(packet.Data), len(b))
 	copy(b[:l], packet.Data[:l])
 	return l, packet.Addr, nil
 }


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.

Inspired by https://github.com/erigontech/erigon/pull/16213 and replace more.