### PR TITLE
refactor: use the built-in max to simplify the code

### DIFF
--- a/db/integrity/rcache_no_duplicates.go
+++ b/db/integrity/rcache_no_duplicates.go
@@ -174,10 +174,7 @@ func parallelChunkCheck(ctx context.Context, fromBlock, toBlock uint64, db kv.Te
 
 	// Process chunks in parallel
 	for start := fromBlock; start <= toBlock; start += chunkSize {
-		end := start + chunkSize - 1
-		if end > toBlock {
-			end = toBlock
-		}
+		end := min(start+chunkSize-1, toBlock)
 
 		chunkStart := start // Capture loop variable
 		chunkEnd := end     // Capture loop variable

--- a/db/recsplit/index.go
+++ b/db/recsplit/index.go
@@ -398,11 +398,7 @@ func (idx *Index) Lookup(bucketHash, fingerprint uint64) (uint64, bool) {
 		d := gr.ReadNext(idx.golombParam(m))
 		hmod := remap16(remix(fingerprint+idx.startSeed[level]+d), m)
 		part := hmod / idx.primaryAggrBound
-		if idx.primaryAggrBound < m-part*idx.primaryAggrBound {
-			m = idx.primaryAggrBound
-		} else {
-			m = m - part*idx.primaryAggrBound
-		}
+		m = min(idx.primaryAggrBound, m-part*idx.primaryAggrBound)
 		cumKeys += uint64(idx.primaryAggrBound * part)
 		if part != 0 {
 			gr.SkipSubtree(idx.skipNodes(idx.primaryAggrBound)*int(part), idx.skipBits(idx.primaryAggrBound)*int(part))
@@ -414,11 +410,7 @@ func (idx *Index) Lookup(bucketHash, fingerprint uint64) (uint64, bool) {
 		d := gr.ReadNext(idx.golombParam(m))
 		hmod := remap16(remix(fingerprint+idx.startSeed[level]+d), m)
 		part := hmod / idx.leafSize
-		if idx.leafSize < m-part*idx.leafSize {
-			m = idx.leafSize
-		} else {
-			m = m - part*idx.leafSize
-		}
+		m = min(idx.leafSize, m-part*idx.leafSize)
 		cumKeys += uint64(idx.leafSize * part)
 		if part != 0 {
 			gr.SkipSubtree(int(part), idx.skipBits(idx.leafSize)*int(part))

--- a/db/snapcfg/util.go
+++ b/db/snapcfg/util.go
@@ -292,11 +292,7 @@ func ExtractBlockFromName(name string, v ver.Version) (block uint64, err error) 
 		i++
 	}
 
-	end := i
-
-	if i > len(name) {
-		end = len(name)
-	}
+	end := min(i, len(name))
 
 	block, err = strconv.ParseUint(name[start:end], 10, 64)
 	if err != nil {

--- a/db/snapshotsync/freezeblocks/block_snapshots.go
+++ b/db/snapshotsync/freezeblocks/block_snapshots.go
@@ -758,11 +758,7 @@ func DumpTxs(ctx context.Context, db kv.RoDB, chainConfig *chain.Config, blockFr
 		}
 
 		if workers > int(body.TxCount-2) {
-			if int(body.TxCount-2) > 1 {
-				workers = int(body.TxCount - 2)
-			} else {
-				workers = 1
-			}
+			workers = max(int(body.TxCount-2), 1)
 		}
 
 		parsers := errgroup.Group{}

--- a/db/state/changeset/state_changeset.go
+++ b/db/state/changeset/state_changeset.go
@@ -224,10 +224,7 @@ func WriteDiffSet(tx kv.RwTx, blockNumber uint64, blockHash common.Hash, diffSet
 
 	for i := 0; i < chunkCount; i++ {
 		start := i * DiffChunkLen
-		end := (i + 1) * DiffChunkLen
-		if end > len(keys) {
-			end = len(keys)
-		}
+		end := min((i+1)*DiffChunkLen, len(keys))
 		binary.BigEndian.PutUint64(key[40:], uint64(i))
 
 		if err := tx.Put(kv.ChangeSets3, key, keys[start:end]); err != nil {

--- a/node/ethstats/ethstats.go
+++ b/node/ethstats/ethstats.go
@@ -601,10 +601,7 @@ func (s *Service) reportHistory(conn *connWrapper, list []uint64) error {
 		if headNumber == nil || err != nil {
 			return err
 		}
-		start := int(*headNumber - historyUpdateRange + 1)
-		if start < 0 {
-			start = 0
-		}
+		start := max(int(*headNumber-historyUpdateRange+1), 0)
 		for i := uint64(start); i <= *headNumber; i++ {
 			indexes = append(indexes, i)
 		}

--- a/rpc/jsonrpc/overlay_api.go
+++ b/rpc/jsonrpc/overlay_api.go
@@ -287,10 +287,7 @@ func (api *OverlayAPIImpl) GetLogs(ctx context.Context, crit filters.FilterCrite
 		pend    sync.WaitGroup
 	)
 
-	threads := runtime.NumCPU()
-	if threads > int(numBlocks) {
-		threads = int(numBlocks)
-	}
+	threads := min(runtime.NumCPU(), int(numBlocks))
 	jobs := make(chan *blockReplayTask, threads)
 	for th := 0; th < threads; th++ {
 		pend.Add(1)


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.

Inspired by https://github.com/erigontech/erigon/pull/16213 and replace all.