### PR TITLE
execution: fix block limit exhausted regression

### DIFF
--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -676,7 +676,7 @@ func (te *txExecutor) executeBlocks(ctx context.Context, tx kv.TemporalTx, start
 			// if we're in the initialCycle before we consider the blockLimit we need to make sure we keep executing
 			// until we reach a transaction whose comittement which is writable to the db, otherwise the update will get lost
 			if !initialCycle || lastExecutedStep > 0 && lastExecutedStep > lastFrozenStep && !dbg.DiscardCommitment() {
-				if blockLimit > 0 && blockNum-startBlockNum+1 > blockLimit {
+				if blockLimit > 0 && blockNum-startBlockNum+1 >= blockLimit && blockNum != maxBlockNum {
 					return &ErrLoopExhausted{From: blockNum, To: blockNum, Reason: "block limit reached"}
 				}
 			}

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -291,7 +291,7 @@ func (se *serialExecutor) exec(ctx context.Context, execStage *StageState, u Unw
 		// if we're in the initialCycle before we consider the blockLimit we need to make sure we keep executing
 		// until we reach a transaction whose comittement which is writable to the db, otherwise the update will get lost
 		if !initialCycle || lastExecutedStep > 0 && lastExecutedStep > lastFrozenStep && !dbg.DiscardCommitment() {
-			if blockLimit > 0 && blockNum-startBlockNum+1 > blockLimit {
+			if blockLimit > 0 && blockNum-startBlockNum+1 >= blockLimit && blockNum != maxBlockNum {
 				return b.HeaderNoCopy(), rwTx, &ErrLoopExhausted{From: startBlockNum, To: blockNum, Reason: "block limit reached"}
 			}
 		}


### PR DESCRIPTION
fixes a regression introduced by recent parallel exec commits:
- EL downloader/Caplin download and exec batches of exactly 5,000 blocks (our --sync.loop.block.limit)
- when they do that, there should be no "block limit exhausted" exec iterations
- however, this has been broken as I noticed we get
```
[DBUG] [10-17|17:36:33.083] [4/6 Execution] loop exhausted           msg="loop exhausted: from=5001, to=10000, reason=block limit reached"
```
- this causes 2 exec loop iterations on a batch of 5,000 blocks instead of just 1 loop iteration
- note that here we've exec-ed exactly 5,000 and we error out on the last one
- this is not an issue on `3.2.*` as this is handled with a check whether we're exec-ing the last block of the batch before returning this error
- however that check got lost for the serial flow on `main` and this PR adds it back

also while doing that I noticed that the parallel exec code has the check the other way roung which always will cause an underflow, so fixed that as well