### PR TITLE
Fix download execution history eta calculation arguments

### DIFF
--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -260,9 +260,11 @@ func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Co
 				logger.Debug(logMsg, logArgs...)
 
 				if !isDownloadingForBeacon {
-					remaining := float64(highestBlockSeen - lowestBlockToReach)
+					toprocess := highestBlockSeen - lowestBlockToReach
+					processed := highestBlockSeen - uint64(currEth1Progress.Load())
+					remaining := float64(toprocess - processed)
 					log.Info("Downloading Execution History", "progress",
-						fmt.Sprintf("%d/%d", highestBlockSeen-uint64(currEth1Progress.Load()), highestBlockSeen-lowestBlockToReach),
+						fmt.Sprintf("%d/%d", processed, toprocess),
 						"ETA", (time.Duration(remaining/speed) * time.Second).String(),
 						"blk/sec", fmt.Sprintf("%.1f", speed))
 				} else {


### PR DESCRIPTION
This fixes the ETA calcation for the download execution history so it uses the diferrence between the blocks to process and the processed blocks for calculating the ETA so it diplays the time remaining to download rather than the time to download all blocks.

This makes the logging look like this:

```
[INFO] [10-27|11:35:45.656] Downloading Execution History            progress=18128/44357 ETA=28m1s blk/sec=15.6
[INFO] [10-27|11:36:15.654] Downloading Execution History            progress=18540/44357 ETA=27m39s blk/sec=15.6
[INFO] [10-27|11:36:45.654] Downloading Execution History            progress=18986/44357 ETA=27m12s blk/sec=15.5
[INFO] [10-27|11:37:15.654] Downloading Execution History            progress=19385/44357 ETA=26m52s blk/sec=15.5
[INFO] [10-27|11:37:45.653] Downloading Execution History            progress=19813/44357 ETA=26m27s blk/sec=15.5
[INFO] [10-27|11:38:15.654] Downloading Execution History            progress=20271/44357 ETA=25m57s blk/sec=15.5
[INFO] [10-27|11:38:45.653] Downloading Execution History            progress=20683/44357 ETA=25m34s blk/sec=15.4
[INFO] [10-27|11:39:15.653] Downloading Execution History            progress=21193/44357 ETA=24m58s blk/sec=15.5
[INFO] [10-27|11:39:45.654] Downloading Execution History            progress=21621/44357 ETA=24m32s blk/sec=15.4
...
[INFO] [10-27|12:06:45.653] Downloading Execution History            progress=42231/44357 ETA=2m31s blk/sec=14.1
[INFO] [10-27|12:07:15.653] Downloading Execution History            progress=42640/44357 ETA=2m2s blk/sec=14.1
[INFO] [10-27|12:07:45.654] Downloading Execution History            progress=42956/44357 ETA=1m39s blk/sec=14.0
[INFO] [10-27|12:08:15.653] Downloading Execution History            progress=43385/44357 ETA=1m9s blk/sec=14.0
[INFO] [10-27|12:08:45.653] Downloading Execution History            progress=43764/44357 ETA=42s blk/sec=14.0
[INFO] [10-27|12:09:15.653] Downloading Execution History            progress=44159/44357 ETA=14s blk/sec=14.0
```
So that by looking at the log you can see how long to wait before the download is finished.