### PR TITLE
`bt.Seek` reduce amount of disk-reads and allocs

### DIFF
--- a/db/state/bps_tree.go
+++ b/db/state/bps_tree.go
@@ -320,19 +320,14 @@ func (b *BpsTree) Seek(g *seg.Reader, seekKey []byte) (cur *Cursor, err error) {
 		if r-l <= DefaultBtreeStartSkip { // found small range, faster to scan now
 			// m = l
 			if cur.d == 0 {
-				cur.d = l
-				cur.getter = g
-			} else if cur.d+1 < cur.ef.Count() {
-				cur.d++
+				cur.resetNoRead(l, g)
+			} else {
+				cur.nextNoRead()
 			}
-
-			offset := cur.ef.Get(l)
-			g.Reset(offset)
 
 			cur.key, _ = g.Next(cur.key[:0])
 
 			if cmp = bytes.Compare(cur.key, seekKey); cmp < 0 {
-				g.Skip()
 				l++
 				continue
 			}

--- a/db/state/btree_index.go
+++ b/db/state/btree_index.go
@@ -92,6 +92,19 @@ func (c *Cursor) Value() []byte {
 	return c.value
 }
 
+func (c *Cursor) nextNoRead() bool {
+	if c.d+1 >= c.ef.Count() {
+		return false
+	}
+
+	c.d++
+
+	offset := c.ef.Get(c.d)
+	c.getter.Reset(offset)
+
+	return true
+}
+
 func (c *Cursor) Next() bool { // could return error instead
 	if !c.next() {
 		// c.Close()
@@ -113,6 +126,20 @@ func (c *Cursor) next() bool {
 	}
 	c.d++
 	return true
+}
+
+func (c *Cursor) resetNoRead(di uint64, g *seg.Reader) error {
+	if c.d >= c.ef.Count() {
+		return fmt.Errorf("%w %d/%d", ErrBtIndexLookupBounds, c.d, c.ef.Count())
+	}
+
+	c.d = di
+	c.getter = g
+
+	offset := c.ef.Get(c.d)
+	c.getter.Reset(offset)
+
+	return nil
 }
 
 func (c *Cursor) Reset(di uint64, g *seg.Reader) error {


### PR DESCRIPTION
The binary search of a node inside the `Seek` function has been optimized — it now uses fewer memory allocations.

Benchmark tests show that the number of allocations has been reduced by roughly half. This improvement is visible not only in the test where only the values are compressed, but also in other tests, since we now preview only the key and decompress the value only when the key comparison is positive.

Additionally, within the `Seek` function, the `cur.key` parameter is now reused more efficiently, which sometimes allows us to avoid unnecessary allocations compared to the unconditional `Next(nil)` call.

**Benchmarks before:**
```
Benchmark_BTree_SeekVsGetUncompressed/seek_only-16         	 1000000	       608.2 ns/op	      80 B/op	       1 allocs/op
Benchmark_BTree_SeekVsGetCompressedK/seek_only_k-16         	 1000000	       784.5 ns/op	     255 B/op	       3 allocs/op
Benchmark_BTree_SeekVsGetCompressedV/seek_only_v-16         	 1000000	       958.9 ns/op	    1028 B/op	       2 allocs/op
Benchmark_BTree_SeekVsGetCompressedKV/seek_only_kv-16       	 1000000	       989.1 ns/op	    1205 B/op	       5 allocs/op

```

**Benchmarks after:**
```
Benchmark_BTree_SeekVsGetUncompressed/seek_only-16         	 1000000	       643.6 ns/op	      80 B/op	       1 allocs/op
Benchmark_BTree_SeekVsGetCompressedK/seek_only_k-16         	 1000000	       805.1 ns/op	     159 B/op	       2 allocs/op
Benchmark_BTree_SeekVsGetCompressedV/seek_only_v-16         	 1000000	       753.4 ns/op	     621 B/op	       2 allocs/op
Benchmark_BTree_SeekVsGetCompressedKV/seek_only_kv-16       	 1000000	       900.5 ns/op	     701 B/op	       3 allocs/op
```