### PR TITLE
refactor: use strings.Builder to improve performance

### DIFF
--- a/db/downloader/rclone.go
+++ b/db/downloader/rclone.go
@@ -525,12 +525,12 @@ func (c *RCloneSession) Download(ctx context.Context, files ...string) error {
 	var fileRequests []*rcloneRequest
 
 	if strings.HasPrefix(c.remoteFs, "http") {
-		var headers string
+		var headers strings.Builder
 		var comma string
 
 		for header, values := range c.headers {
 			for _, value := range values {
-				headers += fmt.Sprintf("%s%s=%s", comma, header, value)
+				headers.WriteString(fmt.Sprintf("%s%s=%s", comma, header, value))
 				comma = ","
 			}
 		}
@@ -545,7 +545,7 @@ func (c *RCloneSession) Download(ctx context.Context, files ...string) error {
 					SrcFs: rcloneFs{
 						Type:    "http",
 						Url:     c.remoteFs,
-						Headers: headers,
+						Headers: headers.String(),
 					},
 					SrcRemote: file,
 					DstFs:     c.localFs,

--- a/db/downloader/webseed.go
+++ b/db/downloader/webseed.go
@@ -128,11 +128,12 @@ func (d *WebSeeds) VerifyManifestedBuckets(ctx context.Context, failFast bool) e
 		fmt.Printf("%s\n", rep.ToString(false))
 	}
 	if failed {
-		merr := "error list:\n"
+		var merr strings.Builder
+		merr.WriteString("error list:\n")
 		for _, err := range supErr {
-			merr += fmt.Sprintf("%s\n", err)
+			merr.WriteString(fmt.Sprintf("%s\n", err))
 		}
-		return fmt.Errorf("webseed: some webseeds are not OK, details above| %s", merr)
+		return fmt.Errorf("webseed: some webseeds are not OK, details above| %s", merr.String())
 	}
 	return nil
 }

--- a/db/state/domain_committed.go
+++ b/db/state/domain_committed.go
@@ -228,14 +228,15 @@ func (dt *DomainRoTx) lookupDirtyFileByItsRange(txFrom uint64, txTo uint64) *Fil
 	}
 
 	if item == nil || item.bindex == nil {
-		fileStepsss := "" + dt.d.Name.String() + ": "
+		var fileStepsss strings.Builder
+		fileStepsss.WriteString("" + dt.d.Name.String() + ": ")
 		for _, item := range dt.d.dirtyFiles.Items() {
 			fromStep, toStep := item.StepRange(dt.d.stepSize)
-			fileStepsss += fmt.Sprintf("%d-%d;", fromStep, toStep)
+			fileStepsss.WriteString(fmt.Sprintf("%d-%d;", fromStep, toStep))
 		}
 		dt.d.logger.Warn("[agg] lookupDirtyFileByItsRange: file not found",
 			"stepFrom", txFrom/dt.d.stepSize, "stepTo", txTo/dt.d.stepSize,
-			"files", fileStepsss, "filesCount", dt.d.dirtyFiles.Len())
+			"files", fileStepsss.String(), "filesCount", dt.d.dirtyFiles.Len())
 
 		if item != nil && item.bindex == nil {
 			dt.d.logger.Warn("[agg] lookupDirtyFileByItsRange: file found but not indexed", "f", item.decompressor.FileName())

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -258,15 +258,15 @@ func convertToCamelCase(input string) string {
 		return input
 	}
 
-	var result string
+	var result strings.Builder
 
 	for _, part := range parts {
 		if len(part) > 0 && part != parts[len(parts)-1] {
-			result += makeFirstCharCap(part)
+			result.WriteString(makeFirstCharCap(part))
 		}
 	}
 
-	return result
+	return result.String()
 }
 
 func (p *Peer) run() (peerErr *PeerError) {

--- a/rpc/jsonstream/stack_stream.go
+++ b/rpc/jsonstream/stack_stream.go
@@ -19,6 +19,7 @@ package jsonstream
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	jsoniter "github.com/json-iterator/go"
 )
@@ -263,20 +264,20 @@ func (s *StackStream) StackSummary() string {
 		return "Empty"
 	}
 
-	result := ""
+	var result strings.Builder
 	for i, item := range s.stack {
 		switch item {
 		case ItemObject:
-			result += fmt.Sprintf("[%d] Object\n", i)
+			result.WriteString(fmt.Sprintf("[%d] Object\n", i))
 		case ItemArray:
-			result += fmt.Sprintf("[%d] Array\n", i)
+			result.WriteString(fmt.Sprintf("[%d] Array\n", i))
 		case ItemField:
-			result += fmt.Sprintf("[%d] Field\n", i)
+			result.WriteString(fmt.Sprintf("[%d] Field\n", i))
 		case ItemComma:
-			result += fmt.Sprintf("[%d] Comma\n", i)
+			result.WriteString(fmt.Sprintf("[%d] Comma\n", i))
 		}
 	}
-	return result
+	return result.String()
 }
 
 // ClosePending properly closes all pending JSON elements on the stack to ensure validity even when an error occurs.

--- a/tests/fuzzers/abi/abifuzzer.go
+++ b/tests/fuzzers/abi/abifuzzer.go
@@ -89,34 +89,35 @@ type args struct {
 }
 
 func createABI(name string, stateMutability, payable *string, inputs []args) (abi.ABI, error) {
-	sig := fmt.Sprintf(`[{ "type" : "function", "name" : "%v" `, name)
+	var sig strings.Builder
+	sig.WriteString(fmt.Sprintf(`[{ "type" : "function", "name" : "%v" `, name))
 	if stateMutability != nil {
-		sig += fmt.Sprintf(`, "stateMutability": "%v" `, *stateMutability)
+		sig.WriteString(fmt.Sprintf(`, "stateMutability": "%v" `, *stateMutability))
 	}
 	if payable != nil {
-		sig += fmt.Sprintf(`, "payable": %v `, *payable)
+		sig.WriteString(fmt.Sprintf(`, "payable": %v `, *payable))
 	}
 	if len(inputs) > 0 {
-		sig += `, "inputs" : [ {`
+		sig.WriteString(`, "inputs" : [ {`)
 		for i, inp := range inputs {
-			sig += fmt.Sprintf(`"name" : "%v", "type" : "%v" `, inp.name, inp.typ)
+			sig.WriteString(fmt.Sprintf(`"name" : "%v", "type" : "%v" `, inp.name, inp.typ))
 			if i+1 < len(inputs) {
-				sig += ","
+				sig.WriteString(",")
 			}
 		}
-		sig += "} ]" //nolint:goconst
-		sig += `, "outputs" : [ {`
+		sig.WriteString("} ]") //nolint:goconst
+		sig.WriteString(`, "outputs" : [ {`)
 		for i, inp := range inputs {
-			sig += fmt.Sprintf(`"name" : "%v", "type" : "%v" `, inp.name, inp.typ)
+			sig.WriteString(fmt.Sprintf(`"name" : "%v", "type" : "%v" `, inp.name, inp.typ))
 			if i+1 < len(inputs) {
-				sig += ","
+				sig.WriteString(",")
 			}
 		}
-		sig += "} ]"
+		sig.WriteString("} ]")
 	}
-	sig += `}]`
+	sig.WriteString(`}]`)
 
-	return abi.JSON(strings.NewReader(sig))
+	return abi.JSON(strings.NewReader(sig.String()))
 }
 
 func runFuzzer(input []byte) int {


### PR DESCRIPTION
strings.Builder has fewer memory allocations and better performance.
More info: [golang/go#75190](https://github.com/golang/go/issues/75190)