### PR TITLE
comment out brittle case in integrity check

### DIFF
--- a/db/integrity/receipts_no_duplicates.go
+++ b/db/integrity/receipts_no_duplicates.go
@@ -137,15 +137,16 @@ func ValidateDomainProgress(db kv.TemporalRoDB, domain kv.Domain, txNumsReader r
 		msg := fmt.Sprintf("[integrity] %s=%d (%d) is behind AccountDomain=%d(%d); this might be okay, please check", domain.String(), receiptProgress, e1, accProgress, e2)
 		log.Warn(msg)
 		return nil
-	} else if accProgress < receiptProgress {
-		// something very wrong
-		e1, _, _ := txNumsReader.FindBlockNum(tx, receiptProgress)
-		e2, _, _ := txNumsReader.FindBlockNum(tx, accProgress)
-
-		err := fmt.Errorf("[integrity] %s=%d (%d) is ahead of AccountDomain=%d(%d)", domain.String(), receiptProgress, e1, accProgress, e2)
-		log.Error(err.Error())
-		return err
-
 	}
+	// else if accProgress < receiptProgress {
+	// 	// something very wrong
+	// 	e1, _, _ := txNumsReader.FindBlockNum(tx, receiptProgress)
+	// 	e2, _, _ := txNumsReader.FindBlockNum(tx, accProgress)
+
+	// 	err := fmt.Errorf("[integrity] %s=%d (%d) is ahead of AccountDomain=%d(%d)", domain.String(), receiptProgress, e1, accProgress, e2)
+	// 	log.Error(err.Error())
+	// 	return err
+
+	// }
 	return nil
 }


### PR DESCRIPTION
- acc progress < rcache/receipt progress is possible now, because we add nil (or 0) (for receipt/rcache) in  last system tx. 
- overall comparison of acc progress and rcache progress needs more thought about which cases are okay vs which are not...right now it's too brittle and can fail in perfectly relevant scenarios too..