### PR TITLE
Improved perofrmance of Get operation in bt index

### DIFF
--- a/db/state/bps_tree.go
+++ b/db/state/bps_tree.go
@@ -408,7 +408,7 @@ func (b *BpsTree) Get(g *seg.Reader, key []byte) (v []byte, ok bool, offset uint
 			return v, true, offset, nil
 		}
 
-		cmp, _, err = b.keyCmpFunc(key, m, g, v[:0])
+		cmp, v, err = b.keyCmpFunc(key, m, g, v[:0])
 		if err != nil {
 			return nil, false, 0, err
 		}


### PR DESCRIPTION
The binary search of a node inside the `Get` function has been optimized — it now uses from **3x-6x** times fewer memory allocations.

This improvement works if keys are compressed, because we efficiently reuse buffer in `Next(buf)` call.

**Benchmarks before:**
```
Benchmark_BTree_SeekVsGetUncompressed/get_only-16                1000000               546.8 ns/op             0 B/op          0 allocs/op
Benchmark_BTree_SeekVsGetCompressedK/get_only_k-16               1000000               804.6 ns/op           416 B/op          6 allocs/op
Benchmark_BTree_SeekVsGetCompressedV/get_only_v-16               1000000               752.6 ns/op           541 B/op          1 allocs/op
Benchmark_BTree_SeekVsGetCompressedKV/get_only_kv-16             1000000               928.7 ns/op           958 B/op          7 allocs/op
```

**Benchmarks after:**
```
Benchmark_BTree_SeekVsGetUncompressed/get_only-16                1000000               507.6 ns/op             0 B/op          0 allocs/op
Benchmark_BTree_SeekVsGetCompressedK/get_only_k-16               1000000               774.0 ns/op            64 B/op          1 allocs/op
Benchmark_BTree_SeekVsGetCompressedV/get_only_v-16               1000000               664.9 ns/op           541 B/op          1 allocs/op
Benchmark_BTree_SeekVsGetCompressedKV/get_only_kv-16             1000000               920.9 ns/op           606 B/op          2 allocs/op
```