### PR TITLE
Remove unused splitOntoHexNibbles helper

### DIFF
--- a/execution/commitment/keys_nibbles.go
+++ b/execution/commitment/keys_nibbles.go
@@ -97,11 +97,6 @@ func commonPrefixLen(b1, b2 []byte) int {
 	return i
 }
 
-// splits each byte in key slice onto 2 nibbles in the resulting slice
-func splitOntoHexNibbles(key, nibblized []byte) []byte { // nolint:unused
-	return nibblized
-}
-
 // compactKey takes a slice of nibbles and compacts them into the original byte slice.
 // It returns an error if the input contains invalid nibbles (values > 0xF).
 func compactKey(nibbles []byte) ([]byte, error) {


### PR DESCRIPTION
delete the dead splitOntoHexNibbles function from execution/commitment/keys_nibbles.go
drop the nolint:unused suppression so the linter no longer hides the unused-code warning