### PR TITLE
Remove unused convertToParityTrace helper

### DIFF
--- a/rpc/jsonrpc/trace_types.go
+++ b/rpc/jsonrpc/trace_types.go
@@ -168,10 +168,3 @@ func (t ParityTrace) String() string {
 	ret += fmt.Sprintf("Type: %s\n", t.Type)
 	return ret
 }
-
-// Takes a hierarchical Geth trace with fields of different meaning stored in the same named fields depending on 'type'. Parity traces
-// are flattened depth first and each field is put in its proper place
-func (api *TraceAPIImpl) convertToParityTrace(gethTrace GethTrace, blockHash common.Hash, blockNumber uint64, txn types.Transaction, txIndex uint64, depth []int) ParityTraces { //nolint: unused
-	var traces ParityTraces // nolint prealloc
-	return traces
-}


### PR DESCRIPTION
removed the dead TraceAPIImpl.convertToParityTrace method that was never invoked and contained no logic
dropped the //nolint: unused guard now that the method is gone, keeping the file lint-clean
