### PR TITLE
qa_tests: fix DUMP_RESPONSE in RPC latest test runner

### DIFF
--- a/.github/workflows/scripts/run_rpc_tests_ethereum_latest.sh
+++ b/.github/workflows/scripts/run_rpc_tests_ethereum_latest.sh
@@ -32,4 +32,4 @@ DISABLED_TEST_LIST=(
 DISABLED_TESTS=$(IFS=,; echo "${DISABLED_TEST_LIST[*]}")
 
 # Call the main test runner script with the required and optional parameters
-"$(dirname "$0")/run_rpc_tests.sh" mainnet v1.95.0 "$DISABLED_TESTS" "$WORKSPACE" "$RESULT_DIR" "latest" "$REFERENCE_HOST" "do-not-compare-error-message"
+"$(dirname "$0")/run_rpc_tests.sh" mainnet v1.95.0 "$DISABLED_TESTS" "$WORKSPACE" "$RESULT_DIR" "latest" "$REFERENCE_HOST" "do-not-compare-error-message" "$DUMP_RESPONSE"


### PR DESCRIPTION
Redo #17275 because it got lost after some merge/rebase