### PR TITLE
Revert "tests: fix deadlock in TestWebsocketLargeCall"

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -592,9 +592,6 @@ func (c *Client) dispatch(codec ServerCodec) {
 			conn.handler.logger.Trace("RPC connection read error", "err", err)
 			// A read error is fatal for the connection, and all pending requests must be cancelled, including any
 			// that might still be considered in-flight.
-			if lastOp != nil {
-				conn.handler.removeRequestOp(lastOp)
-			}
 			conn.close(err, nil)
 			reading = false
 

--- a/rpc/websocket_test.go
+++ b/rpc/websocket_test.go
@@ -85,6 +85,10 @@ func TestWebsocketOriginCheck(t *testing.T) {
 
 // This test checks whether calls exceeding the request size limit are rejected.
 func TestWebsocketLargeCall(t *testing.T) {
+	//if runtime.GOOS == "darwin" {
+	t.Skip("issue #16875")
+	//}
+
 	if testing.Short() {
 		t.Skip()
 	}


### PR DESCRIPTION
Reverts erigontech/erigon#17706

This change makes #16382 happen again, e.g.:
https://github.com/erigontech/erigon/actions/runs/18944843817/job/54093162581
https://github.com/erigontech/erigon/actions/runs/18947097784/job/54101405709?pr=17718
