### PR TITLE
`integration trigger_fcu` tool

### DIFF
--- a/cmd/integration/commands/trigger_fcu.go
+++ b/cmd/integration/commands/trigger_fcu.go
@@ -1,0 +1,70 @@
+package commands
+
+import (
+	"path/filepath"
+
+	"github.com/erigontech/erigon/cmd/rpcdaemon/cli"
+	"github.com/erigontech/erigon/cmd/rpcdaemon/cli/httpcfg"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/execution/engineapi"
+	"github.com/erigontech/erigon/execution/engineapi/engine_types"
+	"github.com/erigontech/erigon/node/debug"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	withDataDir(triggerFCU)
+
+	triggerFCU.Flags().StringVar(&blockHash, "blockhash", "", "head block hash")
+	must(triggerFCU.MarkFlagRequired("blockhash"))
+
+	triggerFCU.Flags().StringVar(&engineEndpoint, "engineendpoint", "", "engine API endpoint")
+	must(triggerFCU.MarkFlagRequired("engineendpoint"))
+
+	rootCmd.AddCommand(triggerFCU)
+}
+
+var blockHash string
+
+var engineEndpoint string
+
+var triggerFCU = &cobra.Command{
+	Use:   "trigger_fcu",
+	Short: "Trigger forkChoiceUpdate manually for testing purposes",
+	Long: `This command simulates a forkChoiceUpdate call from an external CL to a specific block hash.
+
+This is specially useful on devnets where there are network constraints (e.g. few slow peers), so you can test Erigon in isolation without having to rely on an external CL up to a certain known block.
+`,
+	Args: cobra.ArbitraryArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		logger := debug.SetupCobra(cmd, "integration")
+		ctx, _ := common.RootContext()
+		dirs := datadir.New(datadirCli)
+		jwt := filepath.Join(dirs.DataDir, "jwt.hex")
+
+		jwtConfig := &httpcfg.HttpCfg{JWTSecretPath: jwt}
+		jwtSecret, err := cli.ObtainJWTSecret(jwtConfig, logger)
+		if err != nil {
+			logger.Error("failed while reading jwt secret", "err", err)
+			panic(err)
+		}
+
+		engineApiClient, err := engineapi.DialJsonRpcClient(engineEndpoint, jwtSecret, logger)
+		if err != nil {
+			logger.Error("failed while connecting to engine API endpoint", "err", err)
+			panic(err)
+		}
+		hash := common.HexToHash(blockHash)
+		fcu := &engine_types.ForkChoiceState{
+			HeadHash:           hash,
+			SafeBlockHash:      hash,
+			FinalizedBlockHash: hash,
+		}
+		_, err = engineApiClient.ForkchoiceUpdatedV3(ctx, fcu, nil)
+		if err != nil {
+			logger.Error("failed while sending forkChoiceUpdate", "err", err)
+			panic(err)
+		}
+	},
+}


### PR DESCRIPTION
This is a small utility tool to trigger FCU. This is specially useful on devnets, I guess most people at Erigon has some variation of this tool scripted somewhere, this PR just automates it into the `integration` command.

Why it is useful?

- Triggering FCU directly on devnets allows for quick/easy/controlled testing; don't need to setup an external CL, don't need to waste time solving network issues (which sometimes are painful on devnets due to few/slow peers, etc.), just find a blockhash somewhere and shoot it.
- Triggering the FCU requires calling engine authenticated endpoint, which requires decoding the jwt secret; scripting it from CLI requires external non-standard tools, this utility just requires you to point to datadir and it does the magic of loading the secret.
- Triggering the blockhash directly allows for testing downloading/executing just a short range of blocks, which is specially useful like on bloatnet where I'm 3 months behind the tip and downloading blocks everytime requires up to 3 hours every test; need to solve execution speed first.