### PR TITLE
Normalize naming prevStep -> step

### DIFF
--- a/db/kv/kv_interface.go
+++ b/db/kv/kv_interface.go
@@ -468,7 +468,7 @@ type TemporalDebugDB interface {
 type TemporalMemBatch interface {
 	DomainPut(domain Domain, k string, v []byte, txNum uint64, preval []byte, prevStep Step) error
 	DomainDel(domain Domain, k string, txNum uint64, preval []byte, prevStep Step) error
-	GetLatest(table Domain, key []byte) (v []byte, prevStep Step, ok bool)
+	GetLatest(domain Domain, key []byte) (v []byte, step Step, ok bool)
 	GetDiffset(tx RwTx, blockHash common.Hash, blockNumber uint64) ([DomainLen][]DomainEntryDiff, bool, error)
 	ClearRam()
 	IndexAdd(table InvertedIdx, key []byte, txNum uint64) (err error)

--- a/db/state/domain_stream.go
+++ b/db/state/domain_stream.go
@@ -49,7 +49,7 @@ type CursorItem struct {
 	cDup    kv.CursorDupSort
 	cNonDup kv.Cursor
 
-	iter         btree2.MapIter[string, dataWithPrevStep]
+	iter         btree2.MapIter[string, dataWithStep]
 	idx          *seg.Reader
 	hist         *seg.PagedReader
 	btCursor     *Cursor
@@ -313,7 +313,7 @@ func (hi *DomainLatestIterFile) Next() ([]byte, []byte, error) {
 // debugIteratePrefix iterates over key-value pairs of the storage domain that start with given prefix
 //
 // k and v lifetime is bounded by the lifetime of the iterator
-func (dt *DomainRoTx) debugIteratePrefixLatest(prefix []byte, ramIter btree2.MapIter[string, dataWithPrevStep], it func(k []byte, v []byte, step kv.Step) (cont bool, err error), roTx kv.Tx) error {
+func (dt *DomainRoTx) debugIteratePrefixLatest(prefix []byte, ramIter btree2.MapIter[string, dataWithStep], it func(k []byte, v []byte, step kv.Step) (cont bool, err error), roTx kv.Tx) error {
 	// Implementation:
 	//     File endTxNum  = last txNum of file step
 	//     DB endTxNum    = first txNum of step in db

--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -274,9 +274,9 @@ func (sd *SharedDomains) GetLatest(domain kv.Domain, tx kv.TemporalTx, k []byte)
 		return nil, 0, errors.New("sd.GetLatest: unexpected nil tx")
 	}
 	start := time.Now()
-	if v, prevStep, ok := sd.mem.GetLatest(domain, k); ok {
+	if v, _step, ok := sd.mem.GetLatest(domain, k); ok {
 		sd.metrics.UpdateCacheReads(domain, start)
-		return v, prevStep, nil
+		return v, _step, nil
 	}
 	//if aggTx, ok := tx.AggTx().(*state.AggregatorRoTx); ok {
 	//	v, step, _, err = aggTx.getLatest(domain, k, tx, &sd.metrics, start)


### PR DESCRIPTION
Small rename refactoring to clarify meaning in the code:

- The concept of "prev step" is only used in SharedDomains as GetLatest() is used as prev value of next mutation
- Inside GetLatest() chain of calls it is actually just the step whose that latest mutation occurred, "prev step" sounds strange and confusing when reading the code
- Most of GetLatest() chain of calls are already using only "step" as the named variable, so this PR just completes the standardization of naming.