### PR TITLE
refactor: use strings.Builder to improve performance

### DIFF
--- a/cmd/bumper/cmd/selector.go
+++ b/cmd/bumper/cmd/selector.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"slices"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -125,7 +126,8 @@ func (m *SelectorModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m *SelectorModel) View() string {
 	header := "←/→ to switch columns or OK/Cancel, ↑/↓ to move, enter/space to toggle, tab to confirm"
-	s := lipgloss.NewStyle().Margin(1, 2).Render(header) + "\n"
+	var s strings.Builder
+	s.WriteString(lipgloss.NewStyle().Margin(1, 2).Render(header) + "\n")
 	maxRows := max(len(m.domains), len(m.exts))
 	for i := 0; i < maxRows; i++ {
 		left := "   "
@@ -153,9 +155,9 @@ func (m *SelectorModel) View() string {
 			}
 			right = fmt.Sprintf("%s %s %s", prefix, checked, e)
 		}
-		s += fmt.Sprintf("%-30s %s\n", left, right)
+		s.WriteString(fmt.Sprintf("%-30s %s\n", left, right))
 	}
-	s += "\n"
+	s.WriteString("\n")
 	if m.confirmMode {
 		opts := []string{"OK", "Cancel"}
 		for idx, opt := range opts {
@@ -163,13 +165,13 @@ func (m *SelectorModel) View() string {
 			if m.confirmCursor == idx {
 				prefix = "> "
 			}
-			s += fmt.Sprintf("%s%s   ", prefix, opt)
+			s.WriteString(fmt.Sprintf("%s%s   ", prefix, opt))
 		}
-		s += "\n"
+		s.WriteString("\n")
 	} else {
-		s += "(Tab to switch to OK/Cancel)\n"
+		s.WriteString("(Tab to switch to OK/Cancel)\n")
 	}
-	return s
+	return s.String()
 }
 
 func (m *SelectorModel) toggleCurrent() {

--- a/cmd/txnbench/internal/bench/compare.go
+++ b/cmd/txnbench/internal/bench/compare.go
@@ -3,6 +3,7 @@ package bench
 import (
 	"fmt"
 	"slices"
+	"strings"
 )
 
 type agg struct {
@@ -92,19 +93,20 @@ func CompareResults(old BenchOutput, newer BenchOutput) string {
 		})
 	}
 
-	out := "LATENCY COMPARISON (averaged over clusters)\n"
-	out += "cluster_range\tblocks\told_cold_ms\tnew_cold_ms\tdelta_cold\told_warm_ms\tnew_warm_ms\tdelta_warm\n"
+	var out strings.Builder
+	out.WriteString("LATENCY COMPARISON (averaged over clusters)\n")
+	out.WriteString("cluster_range\tblocks\told_cold_ms\tnew_cold_ms\tdelta_cold\told_warm_ms\tnew_warm_ms\tdelta_warm\n")
 
 	for i, c := range results {
-		out += fmt.Sprintf(
+		out.WriteString(fmt.Sprintf(
 			"%2d: %d–%d\t%d\t%.3f\t%.3f\t%+.1f%%\t%.3f\t%.3f\t%+.1f%%\n",
 			i+1, c.start, c.end, c.count,
 			c.oldCold, c.newCold, c.deltaCold,
 			c.oldWarm, c.newWarm, c.deltaWarm,
-		)
+		))
 	}
 
-	return out
+	return out.String()
 }
 
 func aggregateByBlock(out BenchOutput) map[uint64]agg {


### PR DESCRIPTION


strings.Builder has fewer memory allocations and better performance.
More info: https://github.com/golang/go/issues/75190

Inspired by https://github.com/erigontech/erigon/pull/17696 and replace more case.