### PR TITLE
Remove dead BaseAPI.genesis helper

### DIFF
--- a/rpc/jsonrpc/eth_api.go
+++ b/rpc/jsonrpc/eth_api.go
@@ -183,12 +183,6 @@ func (api *BaseAPI) engine() consensus.EngineReader {
 	return api._engine
 }
 
-// nolint:unused
-func (api *BaseAPI) genesis(ctx context.Context, tx kv.Tx) (*types.Block, error) {
-	_, genesis, err := api.chainConfigWithGenesis(ctx, tx)
-	return genesis, err
-}
-
 func (api *BaseAPI) txnLookup(ctx context.Context, tx kv.Tx, txnHash common.Hash) (blockNum uint64, txNum uint64, ok bool, err error) {
 	return api._txnReader.TxnLookup(ctx, tx, txnHash)
 }


### PR DESCRIPTION
drop the private BaseAPI.genesis method in rpc/jsonrpc/eth_api.go, which had no call sites and was only retained via // nolint:unused
rely on the existing chainConfigWithGenesis helper directly to keep the API surface minimal
