### PR TITLE
Remove unused HalfCPUs helper from estimate package

### DIFF
--- a/common/estimate/esitmated_ram.go
+++ b/common/estimate/esitmated_ram.go
@@ -64,6 +64,3 @@ const (
 func AlmostAllCPUs() int {
 	return max(1, runtime.GOMAXPROCS(-1)-1)
 }
-func HalfCPUs() int {
-	return max(1, runtime.GOMAXPROCS(-1)/2)
-}


### PR DESCRIPTION
Drop the dead HalfCPUs helper from common/estimate/esitmated_ram.go since it has no call sites. Keep the public surface focused on the actively used CPU helpers.