### PR TITLE
Reuse random packet buffer in discovery codec

### DIFF
--- a/p2p/discover/v5wire/encoding.go
+++ b/p2p/discover/v5wire/encoding.go
@@ -278,7 +278,11 @@ func (c *Codec) encodeRandom(toID enode.ID) (Header, []byte, error) {
 	head.AuthData = c.headbuf.Bytes()
 
 	// Fill message ciphertext buffer with random bytes.
-	c.msgctbuf = append(c.msgctbuf[:0], make([]byte, randomPacketMsgSize)...)
+	if cap(c.msgctbuf) < randomPacketMsgSize {
+		c.msgctbuf = make([]byte, randomPacketMsgSize)
+	} else {
+		c.msgctbuf = c.msgctbuf[:randomPacketMsgSize]
+	}
 	crand.Read(c.msgctbuf) //nolint:errcheck
 	return head, c.msgctbuf, nil
 }


### PR DESCRIPTION
 reuse `c.msgctbuf` when encoding random DISCv5 packets instead of appending a freshly allocated slice
 eliminate an unnecessary allocation while preserving the exact ciphertext fill logic

