### PR TITLE
all: ensure safe Keccak256Hash conversion

### DIFF
--- a/execution/state/triedb_state.go
+++ b/execution/state/triedb_state.go
@@ -649,7 +649,7 @@ func (tds *TrieDbState) ReadAccountData(address common.Address) (*accounts.Accou
 }
 
 func (tds *TrieDbState) ReadAccountStorage(address common.Address, key common.Hash) (uint256.Int, bool, error) {
-	addrHash := common.Hash(crypto.Keccak256(address.Bytes()))
+	addrHash := common.BytesToHash(crypto.Keccak256(address.Bytes()))
 	if tds.currentBuffer != nil {
 		if _, ok := tds.currentBuffer.deleted[addrHash]; ok {
 			return uint256.Int{}, false, nil
@@ -690,7 +690,7 @@ func (tds *TrieDbState) ReadAccountStorage(address common.Address, key common.Ha
 }
 
 func (tds *TrieDbState) HasStorage(address common.Address) (bool, error) {
-	addrHash := common.Hash(crypto.Keccak256(address.Bytes()))
+	addrHash := common.BytesToHash(crypto.Keccak256(address.Bytes()))
 	// check if we know about any storage updates with non-empty values
 	for _, v := range tds.currentBuffer.storageUpdates[addrHash] {
 		if len(v) > 0 {
@@ -714,7 +714,7 @@ func (tds *TrieDbState) readAccountCodeSizeFromTrie(addrHash []byte) (int, bool)
 }
 
 func (tds *TrieDbState) ReadAccountCode(address common.Address) (code []byte, err error) {
-	addrHash := common.Hash(crypto.Keccak256(address.Bytes()))
+	addrHash := common.BytesToHash(crypto.Keccak256(address.Bytes()))
 
 	if cached, ok := tds.readAccountCodeFromTrie(addrHash[:]); ok {
 		code, err = cached, nil
@@ -738,7 +738,7 @@ func (tds *TrieDbState) ReadAccountCode(address common.Address) (code []byte, er
 }
 
 func (tds *TrieDbState) ReadAccountCodeSize(address common.Address) (codeSize int, err error) {
-	addrHash := common.Hash(crypto.Keccak256(address.Bytes()))
+	addrHash := common.BytesToHash(crypto.Keccak256(address.Bytes()))
 	if cached, ok := tds.readAccountCodeSizeFromTrie(addrHash[:]); ok {
 		return cached, nil
 	} else {
@@ -792,7 +792,7 @@ func (tds *TrieDbState) TrieStateWriter() *TrieStateWriter {
 }
 
 func (tsw *TrieStateWriter) UpdateAccountData(address common.Address, original, account *accounts.Account) error {
-	addrHash := common.Hash(crypto.Keccak256(address.Bytes()))
+	addrHash := common.BytesToHash(crypto.Keccak256(address.Bytes()))
 	tsw.tds.currentBuffer.accountUpdates[addrHash] = witnesstypes.AccountWithAddress{Address: address, Account: account}
 	tsw.tds.currentBuffer.accountReads[addrHash] = address
 	if original != nil {
@@ -802,7 +802,7 @@ func (tsw *TrieStateWriter) UpdateAccountData(address common.Address, original, 
 }
 
 func (tsw *TrieStateWriter) DeleteAccount(address common.Address, original *accounts.Account) error {
-	addrHash := common.Hash(crypto.Keccak256(address.Bytes()))
+	addrHash := common.BytesToHash(crypto.Keccak256(address.Bytes()))
 	tsw.tds.currentBuffer.accountUpdates[addrHash] = witnesstypes.AccountWithAddress{Address: address, Account: original} // TODO: might be needed to use *AccountWithAddress to point to nil
 	tsw.tds.currentBuffer.accountReads[addrHash] = address
 	if original != nil {
@@ -831,7 +831,7 @@ func (tsw *TrieStateWriter) UpdateAccountCode(address common.Address, incarnatio
 }
 
 func (tsw *TrieStateWriter) WriteAccountStorage(address common.Address, incarnation uint64, key common.Hash, original, value uint256.Int) error {
-	addrHash := common.Hash(crypto.Keccak256(address.Bytes()))
+	addrHash := common.BytesToHash(crypto.Keccak256(address.Bytes()))
 
 	v := value.Bytes()
 	m, ok := tsw.tds.currentBuffer.storageUpdates[addrHash]
@@ -893,7 +893,7 @@ func (tds *TrieDbState) makeBlockWitness(trace bool, rl trie.RetainDecider, isBi
 }
 
 func (tsw *TrieStateWriter) CreateContract(address common.Address) error {
-	addrHash := common.Hash(crypto.Keccak256(address.Bytes()))
+	addrHash := common.BytesToHash(crypto.Keccak256(address.Bytes()))
 	tsw.tds.currentBuffer.created[addrHash] = address
 	tsw.tds.currentBuffer.accountReads[addrHash] = address
 	delete(tsw.tds.currentBuffer.storageUpdates, addrHash)


### PR DESCRIPTION
This change replaces the direct `common.Hash(...)` type cast with `common.ByteToHash(...)` when returning `Keccak256` results. `ByteToHash` makes sure the hash is always exactly 32 bytes long and handles any extra bytes safely. This avoids possible issues if the input size is not correct and keeps the behavior consistent with other parts of the codebase. There is no functional change for valid inputs, but it makes the code safer and cleaner.