### PR TITLE
chore(downloader): remove unused SnapInfo interface

### DIFF
--- a/db/downloader/rclone.go
+++ b/db/downloader/rclone.go
@@ -629,13 +629,6 @@ type remoteInfo struct {
 	ModTime time.Time
 }
 
-type SnapInfo interface {
-	Version() snaptype.Version
-	From() uint64
-	To() uint64
-	Type() snaptype.Type
-}
-
 type fileInfo struct {
 	*rcloneInfo
 }


### PR DESCRIPTION
Removed the unused downloader.SnapInfo interface
The interface was not referenced anywhere in the codebase and conflicted conceptually with the existing db/state.SnapInfo struct, increasing cognitive overhead.