### PR TITLE
Remove unused convertToParityTrace stub

### DIFF
--- a/rpc/jsonrpc/trace_types.go
+++ b/rpc/jsonrpc/trace_types.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/hexutil"
-	"github.com/erigontech/erigon/execution/types"
 )
 
 // TODO:(tjayrush)


### PR DESCRIPTION
delete the never-used TraceAPIImpl.convertToParityTrace helper, drop the nolint suppression that was masking the dead code

