### PR TITLE
Add cleanup step in test-all-erigon workflow

### DIFF
--- a/.github/workflows/test-all-erigon.yml
+++ b/.github/workflows/test-all-erigon.yml
@@ -63,6 +63,14 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Cleanup space
+        run: |
+          rm -fr /opt/az \
+                 /opt/microsoft \
+                 /usr/share/dotnet \
+                 /usr/share/miniconda \
+                 /usr/share/swift
+
       - name: Declare runners
         if: needs.source-of-changes.outputs.changed_files != 'true'
         run: |


### PR DESCRIPTION
Added a cleanup step to remove unnecessary tools and cleanup 6+ GB extra space.