### PR TITLE
Remove unused convertToParityTrace stub from JSON-RPC traces

### DIFF
--- a/rpc/jsonrpc/trace_types.go
+++ b/rpc/jsonrpc/trace_types.go
@@ -168,10 +168,3 @@ func (t ParityTrace) String() string {
 	ret += fmt.Sprintf("Type: %s\n", t.Type)
 	return ret
 }
-
-// Takes a hierarchical Geth trace with fields of different meaning stored in the same named fields depending on 'type'. Parity traces
-// are flattened depth first and each field is put in its proper place
-func (api *TraceAPIImpl) convertToParityTrace(gethTrace GethTrace, blockHash common.Hash, blockNumber uint64, txn types.Transaction, txIndex uint64, depth []int) ParityTraces { //nolint: unused
-	var traces ParityTraces // nolint prealloc
-	return traces
-}


### PR DESCRIPTION
Delete the unimplemented TraceAPIImpl.convertToParityTrace helper that returned an empty ParityTraces value drop the lingering //nolint: unused suppression and tighten the JSON-RPC trace API surface no functional change; only dead code removal