### PR TITLE
Initialize empty maps to avoid nil references for Arbitrum

### DIFF
--- a/execution/stages/headerdownload/header_data_struct.go
+++ b/execution/stages/headerdownload/header_data_struct.go
@@ -354,6 +354,13 @@ func NewHeaderDownload(
 	return hd
 }
 
+func (hd *HeaderDownload) InitDefaults() {
+	hd.badHeaders = make(map[common.Hash]struct{})
+	hd.anchors = make(map[common.Hash]*Anchor)
+	hd.links = make(map[common.Hash]*Link)
+	hd.badPoSHeaders = make(map[common.Hash]common.Hash)
+}
+
 func (p Penalty) String() string {
 	switch p {
 	case NoPenalty:

--- a/p2p/sentry/sentry_multi_client/sentry_multi_client.go
+++ b/p2p/sentry/sentry_multi_client/sentry_multi_client.go
@@ -327,6 +327,7 @@ func NewMultiClient(
 		}
 	} else {
 		hd = &headerdownload.HeaderDownload{}
+		hd.InitDefaults()
 	}
 
 	// body downloader


### PR DESCRIPTION
As title says - to avoid further crashes in stage headers. 