### PR TITLE
Switch docker images to debian 13 "trixie".

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,7 @@ env:
   TEST_TRACKING_TIME_SECONDS: 7200 # 2 hours
   TEST_TOTAL_TIME_SECONDS: 432000   # 5 days
   TEST_CHAIN: "mainnet"
-  BUILDER_IMAGE: "golang:1.24-bookworm"
-  DOCKER_BASE_IMAGE: "debian:12-slim"
+  DOCKER_BASE_IMAGE: "debian:13-slim"
   APP_REPO: "erigontech/erigon"
   PACKAGE: "github.com/erigontech/erigon"
   BINARIES: "erigon downloader evm caplin capcli integration rpcdaemon sentry txpool"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@
 ##
 ##   5. DOCKER_BINARIES='erigon downloader rpcdaemon' make docker
 
-ARG BUILDER_IMAGE="golang:1.24-bookworm" \
-    TARGET_BASE_IMAGE="debian:12-slim" \
+ARG BUILDER_IMAGE="golang:1.24-trixie" \
+    TARGET_BASE_IMAGE="debian:13-slim" \
     BINARIES="erigon" \
     BUILD_DBTOOLS="false" \
     BUILD_DATE="Not defined" \
@@ -123,8 +123,8 @@ SHELL ["/bin/bash", "-c"]
 
 RUN --mount=type=bind,from=builder,source=/build,target=/tmp/build \
     echo Installing on ${TARGETARCH} with variant ${TARGETVARIANT} && \
-    addgroup --gid ${GID_ERIGON} ${GROUP} && \
-    adduser --system --uid ${UID_ERIGON} --ingroup ${GROUP} --home /home/${USER} --shell /bin/bash ${USER} && \
+    groupadd --gid ${GID_ERIGON} ${GROUP} && \
+    useradd --system --uid ${UID_ERIGON} -g ${GROUP} --home /home/${USER} --shell /bin/bash ${USER} && \
     apt update -y && \
     apt install -y --no-install-recommends ca-certificates && \
     apt clean && \


### PR DESCRIPTION
Switch our docker builds and base images to the new stable version 13 (code name trixie).