### PR TITLE
p2p/discover: cache error strings before incrementing counters

### DIFF
--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -710,7 +710,8 @@ func (t *UDPv4) readLoop(unhandled chan<- ReadPacket) {
 			// Ignore temporary read errors.
 			t.log.Trace("Temporary UDP read error", "err", err)
 			continue
-		} else if err != nil {
+		}
+		if err != nil {
 			// Shut down the loop for permament errors.
 			if err != io.EOF {
 				t.log.Trace("UDP read error", "err", err)
@@ -858,8 +859,9 @@ func (t *UDPv4) verifyPing(h *packetHandlerV4, from *net.UDPAddr, fromID enode.I
 
 	senderKey, err := v4wire.DecodePubkey(crypto.S256(), fromKey)
 	if err != nil {
+		errStr := err.Error()
 		t.mutex.Lock()
-		t.errors[err.Error()] = t.errors[err.Error()] + 1
+		t.errors[errStr] = t.errors[errStr] + 1
 		t.mutex.Unlock()
 		return err
 	}
@@ -1021,8 +1023,9 @@ func (t *UDPv4) handleENRRequest(h *packetHandlerV4, from *net.UDPAddr, fromID e
 	})
 
 	if err != nil {
+		errStr := err.Error()
 		t.mutex.Lock()
-		t.errors[err.Error()] = t.errors[err.Error()] + 1
+		t.errors[errStr] = t.errors[errStr] + 1
 		t.mutex.Unlock()
 	}
 }


### PR DESCRIPTION
Avoid repeated err.Error() conversions when updating UDPv4.errors in hot paths. Reuse the computed string key for map access to remove redundant allocations and map lookups during ping and ENR handling.