### PR TITLE
db/downloader: remove unused GetBwLimit method

### DIFF
--- a/db/downloader/rclone.go
+++ b/db/downloader/rclone.go
@@ -227,14 +227,6 @@ func (c *RCloneClient) Stats(ctx context.Context) (*RCloneStats, error) {
 	return &stats, nil
 }
 
-func (c *RCloneClient) GetBwLimit() rate.Limit {
-	if c.bwLimit != nil {
-		return *c.bwLimit
-	}
-
-	return 0
-}
-
 func (c *RCloneClient) SetBwLimit(ctx context.Context, limit rate.Limit) {
 	if c.bwLimit == nil || limit != *c.bwLimit {
 		c.bwLimit = &limit


### PR DESCRIPTION
`RCloneClient.GetBwLimit()` has no call sites in the codebase.