### PR TITLE
cl/rpc: Remove unnecessary CopyBytes

### DIFF
--- a/cl/rpc/rpc.go
+++ b/cl/rpc/rpc.go
@@ -128,7 +128,7 @@ func (b *BeaconRpcP2P) SendColumnSidecarsByRootIdentifierReq(
 		return nil, "", err
 	}
 
-	data := common.CopyBytes(buffer.Bytes())
+	data := buffer.Bytes()
 	responsePacket, pid, err := b.sendRequestWithPeer(ctx, communication.DataColumnSidecarsByRootProtocolV1, data, pid)
 	if err != nil {
 		return nil, pid, err
@@ -187,7 +187,7 @@ func (b *BeaconRpcP2P) SendBlobsSidecarByIdentifierReq(ctx context.Context, req 
 		return nil, "", err
 	}
 
-	data := common.CopyBytes(buffer.Bytes())
+	data := buffer.Bytes()
 	blobs, pid, err := b.sendBlobsSidecar(ctx, communication.BlobSidecarByRootProtocolV1, data, uint64(req.Len()))
 	if err != nil {
 		if strings.Contains(err.Error(), "invalid request") {
@@ -208,7 +208,7 @@ func (b *BeaconRpcP2P) SendBlobsSidecarByRangerReq(ctx context.Context, start, c
 		return nil, "", err
 	}
 
-	data := common.CopyBytes(buffer.Bytes())
+	data := buffer.Bytes()
 	return b.sendBlobsSidecar(ctx, communication.BlobSidecarByRangeProtocolV1, data, count*b.beaconConfig.MaxBlobsPerBlock)
 }
 
@@ -224,7 +224,7 @@ func (b *BeaconRpcP2P) SendBeaconBlocksByRangeReq(ctx context.Context, start, co
 		return nil, "", err
 	}
 
-	data := common.CopyBytes(buffer.Bytes())
+	data := buffer.Bytes()
 	return b.sendBlocksRequest(ctx, communication.BeaconBlocksByRangeProtocolV2, data)
 }
 
@@ -238,7 +238,7 @@ func (b *BeaconRpcP2P) SendBeaconBlocksByRootReq(ctx context.Context, roots [][3
 	if err := ssz_snappy.EncodeAndWrite(&buffer, req); err != nil {
 		return nil, "", err
 	}
-	data := common.CopyBytes(buffer.Bytes())
+	data := buffer.Bytes()
 	return b.sendBlocksRequest(ctx, communication.BeaconBlocksByRootProtocolV2, data)
 }
 


### PR DESCRIPTION
Summary
This PR removes redundant allocations by replacing common.CopyBytes(buffer.Bytes()) with direct buffer.Bytes() in the following functions in cl/rpc/rpc.go:
- SendColumnSidecarsByRootIdentifierReq
- SendBlobsSidecarByIdentifierReq
- SendBlobsSidecarByRangerReq
- SendBeaconBlocksByRangeReq
- SendBeaconBlocksByRootReq

Why
- gRPC unary calls (Invoke) serialize []byte synchronously and do not retain the original slice after the call.
- The zap buffer is not reused or freed between EncodeAndWrite and the RPC invocation; ssz_snappy.EncodeAndWrite flushes before return.
- The server side operates on a deserialized copy and does not mutate the caller’s buffer.
- One call site already used buffer.Bytes() directly (consistency).
- Removing copies reduces allocations and GC pressure without changing semantics.
