### PR TITLE
eth_getProof: Verify proof for non-existent account before returning response

### DIFF
--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -471,6 +471,10 @@ func (api *APIImpl) getProof(ctx context.Context, roTx kv.TemporalTx, address co
 				Proof: []hexutil.Bytes{},
 			}
 		}
+		err = trie.VerifyAccountProof(header.Root, proof)
+		if err != nil {
+			return nil, err
+		}
 		return proof, nil
 	}
 


### PR DESCRIPTION
Doesn't fix the examples in https://github.com/erigontech/erigon/issues/17801 , but helps detect situations where the proof is not correct before returning the result, which we are doing in the main code flow but weren't doing when `acc ==nil`. This allowed some incorrect responses to be returned.