### PR TITLE
chore: maintain stable LogsHash across executions

### DIFF
--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -347,6 +347,9 @@ func (sdb *IntraBlockState) Logs() types.Logs {
 	for _, lgs := range sdb.logs {
 		logs = append(logs, lgs...)
 	}
+	sort.Slice(logs, func(i, j int) bool {
+		return logs[i].Index < logs[j].Index
+	})
 	return logs
 }
 


### PR DESCRIPTION
Map iteration can lead to non-deterministic log ordering. By ordering logs based on their transaction index and keeping them aligned with receipt ordering, we ensure that the LogsHash remains reproducible across runs.