### PR TITLE
CODEOWNERS: anchor matching at root

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 *            @AskAlexSharov @Giulio2002
-cl/          @domiwei @Giulio2002
-db/          @AskAlexSharov @sudeepdino008
-docs/        @bloxster @AskAlexSharov @yperbasis
-execution/   @yperbasis @mh0lt
-p2p/         @taratorio @yperbasis
-rpc/         @canepat @yperbasis
-txnprovider/ @taratorio @yperbasis
+/cl/          @domiwei @Giulio2002
+/db/          @AskAlexSharov @sudeepdino008
+/docs/        @bloxster @AskAlexSharov @yperbasis
+/execution/   @yperbasis @mh0lt
+/p2p/         @taratorio @yperbasis
+/rpc/         @canepat @yperbasis
+/txnprovider/ @taratorio @yperbasis


### PR DESCRIPTION
This is to prevent, for example, code changes in `cl/rpc` to be matched under `rpc` rather than `cl` (see PR #17792).