### PR TITLE
Respect caller context when reading tx numbers

### DIFF
--- a/execution/stagedsync/stage_txlookup.go
+++ b/execution/stagedsync/stage_txlookup.go
@@ -137,7 +137,7 @@ func SpawnTxLookup(s *StageState, tx kv.RwTx, toBlock uint64, cfg TxLookupCfg, c
 
 // txnLookupTransform - [startKey, endKey)
 func txnLookupTransform(logPrefix string, tx kv.RwTx, blockFrom, blockTo uint64, ctx context.Context, cfg TxLookupCfg, logger log.Logger) (err error) {
-	txNumReader := cfg.blockReader.TxnumReader(context.TODO())
+	txNumReader := cfg.blockReader.TxnumReader(ctx)
 	data := make([]byte, 16)
 	return etl.Transform(logPrefix, tx, kv.HeaderCanonical, kv.TxLookup, cfg.tmpdir, func(k, v []byte, next etl.ExtractNextFunc) error {
 		blocknum, blockHash := binary.BigEndian.Uint64(k), common.CastToHash(v)


### PR DESCRIPTION
Swap the hard-coded context.TODO() for the caller-provided ctx when creating the TxnumReader lets staged sync cancel DB reads promptly during shutdown or unwind