### PR TITLE
Remove dead debug block from ValidateBorEvents

### DIFF
--- a/polygon/bridge/snapshot_integrity.go
+++ b/polygon/bridge/snapshot_integrity.go
@@ -85,20 +85,6 @@ func ValidateBorEvents(ctx context.Context, db kv.TemporalRoDB, blockReader bloc
 
 	if db != nil {
 		err = db.View(ctx, func(tx kv.Tx) error {
-			if false {
-				lastEventId, err := NewSnapshotStore(NewTxStore(tx), snapshots, nil).LastEventId(ctx)
-				if err != nil {
-					return err
-				}
-
-				bodyProgress, err := stages.GetStageProgress(tx, stages.Bodies)
-				if err != nil {
-					return err
-				}
-
-				log.Info("[integrity] LAST Event", "event", lastEventId, "body-progress", bodyProgress)
-			}
-
 			return nil
 		})
 


### PR DESCRIPTION
drop the unreachable if false { … } branch in ValidateBorEvents keep the db.View call intact while eliminating misleading, never-executed logic leave runtime behaviour unchanged but improve readability and maintainability