### PR TITLE
db/rawdb: fix incorrect log message in ReadStorageBodyRLP

### DIFF
--- a/db/rawdb/accessors_chain.go
+++ b/db/rawdb/accessors_chain.go
@@ -406,7 +406,7 @@ func ReadBodyRLP(db kv.Tx, hash common.Hash, number uint64) rlp.RawValue {
 func ReadStorageBodyRLP(db kv.Getter, hash common.Hash, number uint64) rlp.RawValue {
 	bodyRlp, err := db.GetOne(kv.BlockBody, dbutils.BlockBodyKey(number, hash))
 	if err != nil {
-		log.Error("ReadBodyRLP failed", "err", err)
+		log.Error("ReadStorageBodyRLP failed", "err", err)
 	}
 	return bodyRlp
 }


### PR DESCRIPTION
Replace misleading "ReadBodyRLP failed" with "ReadStorageBodyRLP failed" to match the function name and improve log clarity.