### PR TITLE
execution: fix for --snap.download.to.block

### DIFF
--- a/db/snapshotsync/snapshotsync.go
+++ b/db/snapshotsync/snapshotsync.go
@@ -393,7 +393,7 @@ func SyncSnapshots(
 			if _, err = snapshotDownloader.Delete(ctx, &downloaderproto.DeleteRequest{Paths: toDeleteDownloader}); err != nil {
 				return err
 			}
-			if err = blockReader.Snapshots().ForceDelete(toDeleteSeg...); err != nil {
+			if err = blockReader.Snapshots().Delete(toDeleteSeg...); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
part of https://github.com/erigontech/erigon/issues/17711

fixes an issue with the --snap.download.to.block flag where the 1 extra 100k header and body segments (needed for calculating the max tx num for the block) weren't getting properly deleted in the 2nd snapshot sync pass after the 1st "headerchain" sync pass

also found an issue with RoSnapshots.Delete - it wasn't correctly following refcounts for frozen files which was preventing their deletion - it is now a needed use case in snap.download.block.to but also in minimal mode when we delete frozen transaction segment files

tested on chiado with `--snap.download.to.block=16207731` and it worked correctly
also tested with a fresh sync from block 0 on fusaka-devnet-3 to test the changes to RoSnapshots.Delete, all snapshot files were correct, there were no unintended deletions of frozen files