### PR TITLE
Update builder image to golang:1.25-trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 ##
 ##   5. DOCKER_BINARIES='erigon downloader rpcdaemon' make docker
 
-ARG BUILDER_IMAGE="golang:1.24-trixie" \
+ARG BUILDER_IMAGE="golang:1.25-trixie" \
     TARGET_BASE_IMAGE="debian:13-slim" \
     BINARIES="erigon" \
     BUILD_DBTOOLS="false" \


### PR DESCRIPTION
Switch to go 1.25.

Requested in https://github.com/erigontech/erigon/pull/17774#issuecomment-3489901535