### PR TITLE
Tidy up test filtering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,32 +195,20 @@ db-tools:
 	rm -rf vendor
 	@echo "Run \"$(GOBIN)/mdbx_stat -h\" to get info about mdbx db file."
 
-## test-short:                run short tests with a 10m timeout
-test-short:
-	@{ \
-		$(GOTEST) -short > run.log 2>&1; \
-		STATUS=$$?; \
-		grep -v -e ' CONT ' -e 'RUN' -e 'PAUSE' -e 'PASS' run.log; \
-		exit $$STATUS; \
-	}
+FILTER_TESTS := grep -v -e '^=== CONT ' -e '^=== RUN ' -e '^=== PAUSE ' -e '^PASS' -e '--- PASS:'
 
-## test-all:                  run all tests with a 1h timeout
-test-all:
-	@{ \
-		$(GOTEST) --timeout 60m -coverprofile=coverage-test-all.out > run.log 2>&1; \
-		STATUS=$$?; \
-		grep -v -e ' CONT ' -e 'RUN' -e 'PAUSE' -e 'PASS' run.log; \
-		exit $$STATUS; \
-	}
+test-filtered:
+	$(GOTEST) | tee run.log | $(FILTER_TESTS)
 
-## test-all-race:             run all tests with the race flag
-test-all-race:
-	@{ \
-		$(GOTEST) --timeout 60m -race > run.log 2>&1; \
-		STATUS=$$?; \
-		grep -v -e ' CONT ' -e 'RUN' -e 'PAUSE' -e 'PASS' run.log; \
-		exit $$STATUS; \
-	}
+# Rather than add more special cases here, I'd suggest using GO_FLAGS and calling `make test-filtered GO_FLAGS='-cool flag' or `make test GO_FLAGS='-cool flag'`.
+test-short: override GO_FLAGS += -short -failfast
+test-short: test-filtered
+
+test-all: override GO_FLAGS += --timeout 60m -coverprofile=coverage-test-all.out
+test-all: test-filtered
+
+test-all-race: override GO_FLAGS += --timeout 60m -race
+test-all-race: test-filtered
 
 ## test-hive						run the hive tests locally off nektos/act workflows simulator
 test-hive:


### PR DESCRIPTION
I needed to get test output faster and noticed the filters aren't applied until the tests complete. I switched in a proper pipeline, which also fixes getting an early status code if you cancel.

I also fixed the cmd build line outputting the wrong thing if you override OUTPUT.