### PR TITLE
db/kb: fix error wrapping in renew to return errBegin

### DIFF
--- a/db/kv/remotedbserver/remotedbserver.go
+++ b/db/kv/remotedbserver/remotedbserver.go
@@ -159,7 +159,7 @@ func (s *KvServer) renew(ctx context.Context, id uint64) (err error) {
 	}
 	newTx, errBegin := s.kv.BeginTemporalRo(ctx) //nolint:gocritic
 	if errBegin != nil {
-		return fmt.Errorf("kvserver: %w", err)
+		return fmt.Errorf("kvserver: %w", errBegin)
 	}
 	s.txs[id] = &threadSafeTx{TemporalTx: newTx}
 	return nil


### PR DESCRIPTION
The renew method wrapped a nil named error instead of the actual errBegin, losing the original failure context from BeginTemporalRo. This change ensures the real error is propagated with proper wrapping, restoring diagnosability and preserving error chains.