### PR TITLE
Change default log directory permissions from 0764 to 0755

### DIFF
--- a/node/logging/logging.go
+++ b/node/logging/logging.go
@@ -234,7 +234,7 @@ func initSeparatedLogging(
 		return
 	}
 
-	err := os.MkdirAll(dirPath, 0764)
+	err := os.MkdirAll(dirPath, 0755)
 	if err != nil {
 		logger.Warn("failed to create log dir, console logging only")
 		return


### PR DESCRIPTION
Before that change `logs` sub-directory created with following permissions:
```
ls -l ${datadir}/
drwxrw-r--  2 user user   4096 Nov 10 14:06 logs
```

Which does not grant others access to see logs.

With this change others can see logs:
```
ls -l ${datadir}/
drwxr-xr-x  2 user user  4096 Nov 11 15:23 logs
```