### PR TITLE
Remove duplicate commitment domain entry in state compaction command

### DIFF
--- a/cmd/integration/commands/state_domains.go
+++ b/cmd/integration/commands/state_domains.go
@@ -210,7 +210,7 @@ var compactDomains = &cobra.Command{
 			logger.Error("No domains specified")
 			return
 		}
-		supportedDomain := []kv.Domain{kv.CommitmentDomain, kv.AccountsDomain, kv.StorageDomain, kv.CommitmentDomain}
+		supportedDomain := []kv.Domain{kv.CommitmentDomain, kv.AccountsDomain, kv.StorageDomain}
 		var compactionDomains []kv.Domain
 
 		for _, domain := range domainsStr {


### PR DESCRIPTION
drop the redundant kv.CommitmentDomain value from the supportedDomain slice so each supported domain is listed exactly once