### PR TITLE
Replace capcli TODO context with Background context

### DIFF
--- a/cmd/capcli/main.go
+++ b/cmd/capcli/main.go
@@ -32,7 +32,7 @@ func main() {
 	// Call the Run() method of the selected parsed command.
 	err := ctx.Run(&Context{
 		kctx:    ctx,
-		Context: context.TODO(),
+		Context: context.Background(),
 	})
 	ctx.FatalIfErrorf(err)
 }


### PR DESCRIPTION
replace the placeholder context.TODO() in cmd/capcli/main.go with context.Background() align the CLI entry point with Erigon’s guideline of avoiding TODO contexts in production paths