### PR TITLE
rpc/jsonrpc: drop unused field from deprecated DB API stub

### DIFF
--- a/rpc/jsonrpc/db_api_deprecated.go
+++ b/rpc/jsonrpc/db_api_deprecated.go
@@ -33,14 +33,11 @@ type DBAPI interface {
 
 // DBAPIImpl data structure to store things needed for db_ commands
 type DBAPIImpl struct {
-	unused uint64
 }
 
 // NewDBAPIImpl returns NetAPIImplImpl instance
 func NewDBAPIImpl() *DBAPIImpl {
-	return &DBAPIImpl{
-		unused: uint64(0),
-	}
+	return &DBAPIImpl{}
 }
 
 // GetString implements db_getString. Returns string from the local database.


### PR DESCRIPTION
Remove the unused uint64 field from DBAPIImpl, eliminating dead state in the deprecated DB RPC surface. Simplify NewDBAPIImpl to return an empty struct literal, preserving existing behavior while avoiding pointless allocation/initialization.