### PR TITLE
Dump tool to print history snapshots content

### DIFF
--- a/cmd/integration/commands/state_history.go
+++ b/cmd/integration/commands/state_history.go
@@ -1,0 +1,100 @@
+// Copyright 2024 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package commands
+
+import (
+	"os"
+
+	"github.com/erigontech/erigon/db/config3"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/state"
+	"github.com/erigontech/erigon/db/state/statecfg"
+	"github.com/erigontech/erigon/node/debug"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	printCmd.Flags().Uint64Var(&fromStep, "from", 0, "step from which history to be printed")
+	printCmd.Flags().Uint64Var(&toStep, "to", 1e18, "step to which history to be printed")
+	withDataDir2(printCmd)
+	withHistoryDomain(printCmd)
+
+	historyCmd.AddCommand(printCmd)
+	rootCmd.AddCommand(historyCmd)
+}
+
+func withHistoryDomain(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&historyDomain, "domain", "", "Name of the domain (accounts, code, etc)")
+	must(cmd.MarkFlagRequired("domain"))
+}
+
+var (
+	fromStep      uint64
+	toStep        uint64
+	historyDomain string
+)
+
+var historyCmd = &cobra.Command{
+	Use: "history",
+}
+
+var printCmd = &cobra.Command{
+	Use: "print",
+	Run: func(cmd *cobra.Command, args []string) {
+		logger := debug.SetupCobra(cmd, "integration")
+
+		dirs, l, err := datadir.New(datadirCli).MustFlock()
+		if err != nil {
+			logger.Error("Opening Datadir", "error", err)
+			return
+		}
+		defer l.Unlock()
+
+		domainKV, err := kv.String2Domain(historyDomain)
+		if err != nil {
+			logger.Error("Failed to resolve domain", "error", err)
+			return
+		}
+
+		history, err := state.NewHistory(
+			statecfg.Schema.GetDomainCfg(domainKV).Hist,
+			config3.DefaultStepSize,
+			config3.DefaultStepsInFrozenFile,
+			dirs,
+			logger,
+		)
+		if err != nil {
+			logger.Error("Failed to init history", "error", err)
+			return
+		}
+		history.Scan(toStep * config3.DefaultStepSize)
+
+		roTx := history.BeginFilesRo()
+		defer roTx.Close()
+
+		err = roTx.HistoryDump(
+			int(fromStep)*config3.DefaultStepSize,
+			int(toStep)*config3.DefaultStepSize,
+			os.Stdout,
+		)
+		if err != nil {
+			logger.Error("Failed to print history", "error", err)
+			return
+		}
+	},
+}

--- a/db/state/history.go
+++ b/db/state/history.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"io"
 	"math"
 	"path/filepath"
 	"strings"
@@ -335,6 +336,20 @@ func (h *History) BuildMissedAccessors(ctx context.Context, g *errgroup.Group, p
 			return h.buildVi(ctx, item, ps)
 		})
 	}
+}
+
+func (h *History) Scan(toTxNum uint64) error {
+	scanResult, err := scanDirs(h.dirs)
+	if err != nil {
+		return err
+	}
+
+	if err := h.openFolder(scanResult); err != nil {
+		return err
+	}
+
+	h.reCalcVisibleFiles(toTxNum)
+	return nil
 }
 
 func (w *historyBufferedWriter) AddPrevValue(k []byte, txNum uint64, original []byte) (err error) {
@@ -1339,6 +1354,67 @@ func (ht *HistoryRoTx) HistoryRange(fromTxNum, toTxNum int, asc order.By, limit 
 		return nil, err
 	}
 	return stream.UnionKV(itOnDB, itOnFiles, limit), nil
+}
+
+func (ht *HistoryRoTx) HistoryDump(fromTxNum, toTxNum int, dumpTo io.Writer) error {
+	if len(ht.iit.files) == 0 {
+		return nil
+	}
+
+	if fromTxNum >= 0 && ht.iit.files.EndTxNum() <= uint64(fromTxNum) {
+		return nil
+	}
+
+	for _, item := range ht.iit.files {
+		if fromTxNum >= 0 && item.endTxNum <= uint64(fromTxNum) {
+			continue
+		}
+		if toTxNum >= 0 && item.startTxNum >= uint64(toTxNum) {
+			break
+		}
+
+		efGetter := ht.iit.dataReader(item.src.decompressor)
+		efGetter.Reset(0)
+
+		for efGetter.HasNext() {
+			key, _ := efGetter.Next(nil)
+			val, _ := efGetter.Next(nil) // encoded EF sequence
+
+			seq := multiencseq.ReadMultiEncSeq(item.startTxNum, val)
+			ss := seq.Iterator(0)
+
+			for ss.HasNext() {
+				txNum, _ := ss.Next()
+
+				var txNumKey [8]byte
+				binary.BigEndian.PutUint64(txNumKey[:], txNum)
+
+				viFile, ok := ht.getFile(txNum)
+				if !ok {
+					return fmt.Errorf("HistoryDump: no .vi %s file found for [%x]", ht.iit.name, txNum)
+				}
+
+				viReader := ht.statelessIdxReader(viFile.i)
+				vOffset, ok := viReader.Lookup2(txNumKey[:], key)
+				if !ok {
+					return fmt.Errorf("HistoryDump: failed to resolve offset in .vi %s file for key [%x]", viFile.Fullpath(), key)
+				}
+
+				vGetter := seg.NewPagedReader(
+					ht.statelessGetter(viFile.i),
+					ht.h.HistoryValuesOnCompressedPage,
+					true,
+				)
+
+				vGetter.Reset(vOffset)
+				val, _ := vGetter.Next(nil)
+
+				fmt.Fprintf(dumpTo, "key: %x, txn: %d, val: %x\n", key, txNum, val)
+			}
+		}
+	}
+
+	return nil
 }
 
 func (ht *HistoryRoTx) idxRangeOnDB(key []byte, startTxNum, endTxNum int, asc order.By, limit int, roTx kv.Tx) (stream.U64, error) {


### PR DESCRIPTION
This PR is related to the discussion in this task (comments: https://github.com/erigontech/erigon/issues/17370#issuecomment-3514260624 https://github.com/erigontech/erigon/issues/17370#issuecomment-3514571128)

Specifically, it concerns the issue I raised about history files containing a large number of unnecessary duplications that we can safely eliminate.

Snapshots often include transaction numbers even when no actual data change occurred (the value remained the same for the key).
This PR implements a helper command that makes it possible to detect such cases.

Regarding the `HistoryRange` method — It doesn’t show a stream of changes; instead, it returns only a single point for each key that changed. The function’s own description in the code reads:
```
// HistoryRange producing state-patch for Unwind - return state-patch for Unwind:
// "what keys changed between `[from, to)` and what was their value BEFORE txNum"
```

As a result, we can compress history files — not only `.v` but also `.ef` and accessor files — several times over. For Gnosis, the amount of redundant duplication is roughly **2×**.