### PR TITLE
Remove unreachable staged sync debug dump

### DIFF
--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -372,11 +372,7 @@ func ExecV3(ctx context.Context,
 		lastCommittedTxNum = se.lastCommittedTxNum
 	}
 
-	if false && !inMemExec {
-		dumpPlainStateDebug(applyTx, doms)
-	}
-
-	lastCommitedStep := kv.Step((lastCommittedTxNum) / doms.StepSize())
+	stCommitedStep := kv.Step((lastCommittedTxNum) / doms.StepSize())
 	lastFrozenStep := applyTx.StepsInFiles(kv.CommitmentDomain)
 
 	if lastCommitedStep > 0 && lastCommitedStep <= lastFrozenStep && !dbg.DiscardCommitment() {


### PR DESCRIPTION
delete the if false && !inMemExec guard that prevented dumpPlainStateDebug from ever running keep the surrounding commitment logic intact to avoid unused debug code paths