### PR TITLE
db/seg: fix MatchPrefixUncompressed empty prefix/word semantics

### DIFF
--- a/db/seg/decompress.go
+++ b/db/seg/decompress.go
@@ -1025,10 +1025,13 @@ func (g *Getter) MatchPrefixUncompressed(prefix []byte) bool {
 	wordLen := g.nextPos(true /* clean */)
 	wordLen-- // because when create huffman tree we do ++ , because 0 is terminator
 	prefixLen := len(prefix)
-	if wordLen == 0 && prefixLen != 0 {
+	if prefixLen == 0 {
 		return true
 	}
-	if prefixLen == 0 {
+	if wordLen == 0 {
+		return false
+	}
+	if uint64(prefixLen) > wordLen {
 		return false
 	}
 


### PR DESCRIPTION
This change fixes the inverted semantics in Getter.MatchPrefixUncompressed for empty prefix and empty word. Previously the function returned true when the word was empty and the prefix was non-empty, and returned false when the prefix was empty, which contradicts standard prefix semantics and the behavior of the compressed path (Getter.MatchPrefix). The fix makes an empty prefix always match, a non-empty prefix never match an empty word, and adds a safe early return when the prefix is longer than the word, ensuring consistent behavior between compressed and uncompressed readers.