### PR TITLE
`TestSetupGenesis` less concurrency

### DIFF
--- a/execution/state/genesiswrite/genesis_test.go
+++ b/execution/state/genesiswrite/genesis_test.go
@@ -294,7 +294,6 @@ func TestSetupGenesis(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 			tmpdir := t.TempDir()
 			dirs := datadir.New(tmpdir)
 			db := temporaltest.NewTestDB(t, dirs)


### PR DESCRIPTION
because caused on Win:
```
    --- FAIL: TestSetupGenesis/custom_block_in_DB,_genesis_==_sepolia (0.54s)
panic: fail to open mdbx: mdbx_env_open: The paging file is too small for this operation to complete., label: temporary, trace: [kv_mdbx.go:310 kv_mdbx.go:424 genesis_write.go:312 genesis_write.go:222 genesis_write.go:259 genesis_write.go:245 genesis_test.go:247 genesis_test.go:305 testing.go:1792 asm_amd64.s:1700] [recovered]
```