### PR TITLE
rpc/jsonrpc: drop redundant boolean comparison in tracing assertion

### DIFF
--- a/rpc/jsonrpc/tracing.go
+++ b/rpc/jsonrpc/tracing.go
@@ -215,7 +215,7 @@ func (api *DebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rpc.Block
 			refunds = false
 		}
 
-		if refunds == true && block.GasUsed() != gasUsed {
+		if refunds && block.GasUsed() != gasUsed {
 			panic(fmt.Errorf("assert: block.GasUsed() %d != gasUsed %d. blockNum=%d", block.GasUsed(), gasUsed, blockNumber))
 		}
 	}


### PR DESCRIPTION
Clarify the refunds guard in traceBlock by checking the boolean flag directly instead of comparing it to true. Eliminates a redundant comparison without affecting behaviour; keeps the assertion readable for maintainers.