### PR TITLE
db/integrity: propagate ValidateDomainProgress error in CheckReceiptsNoDups

### DIFF
--- a/db/integrity/receipts_no_duplicates.go
+++ b/db/integrity/receipts_no_duplicates.go
@@ -25,7 +25,7 @@ func CheckReceiptsNoDups(ctx context.Context, db kv.TemporalRoDB, blockReader se
 	txNumsReader := blockReader.TxnumReader(ctx)
 
 	if err := ValidateDomainProgress(db, kv.ReceiptDomain, txNumsReader); err != nil {
-		return nil
+		return err
 	}
 
 	tx, err := db.BeginTemporalRo(ctx)


### PR DESCRIPTION
This change fixes an inconsistency where CheckReceiptsNoDups swallowed non-nil errors returned by ValidateDomainProgress and returned nil instead. The function now returns the error directly, matching other call sites and ensuring that fatal DB or transaction errors are not masked during integrity checks. This prevents false-positive success logs and makes failure handling consistent across integrity check implementations.