### PR TITLE
diag: still see diag goroutines even no diag flags

### DIFF
--- a/cmd/erigon/main.go
+++ b/cmd/erigon/main.go
@@ -31,7 +31,6 @@ import (
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/version"
-	"github.com/erigontech/erigon/diagnostics"
 	"github.com/erigontech/erigon/diagnostics/metrics"
 	"github.com/erigontech/erigon/diagnostics/syscheck"
 	erigoncli "github.com/erigontech/erigon/node/cli"
@@ -99,7 +98,7 @@ func runErigon(cliCtx *cli.Context) (err error) {
 		return err
 	}
 
-	diagnostics.Setup(cliCtx, ethNode, metricsMux, pprofMux)
+	//diagnostics.Setup(cliCtx, ethNode, metricsMux, pprofMux)
 
 	err = ethNode.Serve()
 	if err != nil {


### PR DESCRIPTION
i didn't set any diag flags, but see: 
```

1 @ 0x4b76ae 0x4926f7 0x22517ef 0x4c02e1
#	0x22517ee	github.com/erigontech/erigon/diagnostics/diaglib.(*DiagnosticClient).runBlockExecutionListener.func1+0x18e	/home/erigon/erigon/diagnostics/diaglib/block_execution.go:71

1 @ 0x4b76ae 0x4926f7 0x2251d4c 0x4c02e1
#	0x2251d4b	github.com/erigontech/erigon/diagnostics/diaglib.(*DiagnosticClient).runBodiesBlockDownloadListener.func1+0x26b	/home/erigon/erigon/diagnostics/diaglib/bodies.go:41

1 @ 0x4b76ae 0x4926f7 0x22520df 0x4c02e1
#	0x22520de	github.com/erigontech/erigon/diagnostics/diaglib.(*DiagnosticClient).runBodiesBlockWriteListener.func1+0x23e	/home/erigon/erigon/diagnostics/diaglib/bodies.go:61

1 @ 0x4b76ae 0x4926f7 0x225248c 0x4c02e1
#	0x225248b	github.com/erigontech/erigon/diagnostics/diaglib.(*DiagnosticClient).runBodiesProcessedListener.func1+0x24b	/home/erigon/erigon/diagnostics/diaglib/bodies.go:81

1 @ 0x4b76ae 0x4926f7 0x22527ed 0x4c02e1
#	0x22527ec	github.com/erigontech/erigon/diagnostics/diaglib.(*DiagnosticClient).runBodiesProcessingListener.func1+0x20c	/home/erigon/erigon/diagnostics/diaglib/bodies.go:101

1 @ 0x4b76ae 0x4926f7 0x2254256 0x4c02e1
#	0x2254255	github.com/erigontech/erigon/diagnostics/diaglib.(*DiagnosticClient).runSaveProcess.func1+0x175	/home/erigon/erigon/diagnostics/diaglib/client.go:155

1 @ 0x4b76ae 0x4926f7 0x2258513 0x4c02e1
#	0x2258512	github.com/erigontech/erigon/diagnostics/diaglib.(*DiagnosticClient).runHeadersWaitingListener.func1+0x172	/home/erigon/erigon/diagnostics/diaglib/headers.go:49

1 @ 0x4b76ae 0x4926f7 0x2258865 0x4c02e1
#	0x2258864	github.com/erigontech/erigon/diagnostics/diaglib.(*DiagnosticClient).runWriteHeadersListener.func1+0x184	/home/erigon/erigon/diagnostics/diaglib/headers.go:70

1 @ 0x4b76ae 0x4926f7 0x2258c2e 0x4c02e1
#	0x2258c2d	github.com/erigontech/erigon/diagnostics/diaglib.(*DiagnosticClient).runCanonicalMarkerListener.func1+0x18d	/home/erigon/erigon/diagnostics/diaglib/headers.go:91

1 @ 0x4b76ae 0x4926f7 0x2258ff9 0x4c02e1
#	0x2258ff8	github.com/erigontech/erigon/diagnostics/diaglib.(*DiagnosticClient).runProcessedListener.func1+0x178	/home/erigon/erigon/diagnostics/diaglib/headers.go:112

1 @ 0x4b76ae 0x4926f7 0x225b0ee 0x4c02e1
#	0x225b0ed	github.com/erigontech/erigon/diagnostics/diaglib.(*DiagnosticClient).runCollectPeersStatistics.func1+0x24d	/home/erigon/erigon/diagnostics/diaglib/network.go:256

1 @ 0x4b76ae 0x4926f7 0x225d74e 0x4c02e1
#	0x225d74d	github.com/erigontech/erigon/diagnostics/diaglib.(*DiagnosticClient).runMemoryStatsListener.func1+0x1cd	/home/erigon/erigon/diagnostics/diaglib/resources_usage.go:50

1 @ 0x4b76ae 0x4926f7 0x225de26 0x4c02e1
#	0x225de25	github.com/erigontech/erigon/diagnostics/diaglib.(*DiagnosticClient).runFillDBListener.func1+0x305	/home/erigon/erigon/diagnostics/diaglib/snapshots.go:53

1 @ 0x4b76ae 0x4926f7 0x22603b2 0x4c02e1
#	0x22603b1	github.com/erigontech/erigon/diagnostics/diaglib.(*DiagnosticClient).runSegmentDownloadingListener.func1+0x1f1	/home/erigon/erigon/diagnostics/diaglib/snapshots_download.go:76

1 @ 0x4b76ae 0x4926f7 0x226109a 0x4c02e1
#	0x2261099	github.com/erigontech/erigon/diagnostics/diaglib.(*DiagnosticClient).runFileDownloadedListener.func1+0x1f9	/home/erigon/erigon/diagnostics/diaglib/snapshots_download.go:147

1 @ 0x4b76ae 0x4926f7 0x22621ec 0x4c02e1
#	0x22621eb	github.com/erigontech/erigon/diagnostics/diaglib.(*DiagnosticClient).runSegmentIndexingListener.func1+0x1ab	/home/erigon/erigon/diagnostics/diaglib/snapshots_indexing.go:33

1 @ 0x4b76ae 0x4926f7 0x22647e5 0x4c02e1
#	0x22647e4	github.com/erigontech/erigon/diagnostics/diaglib.(*DiagnosticClient).runSyncStagesListListener.func1+0x1c4	/home/erigon/erigon/diagnostics/diaglib/stages.go:118

1 @ 0x4b76ae 0x4926f7 0x2264aee 0x4c02e1
#	0x2264aed	github.com/erigontech/erigon/diagnostics/diaglib.(*DiagnosticClient).runCurrentSyncStageListener.func1+0x1ad	/home/erigon/erigon/diagnostics/diaglib/stages.go:135

1 @ 0x4b76ae 0x4926f7 0x2264dee 0x4c02e1
#	0x2264ded	github.com/erigontech/erigon/diagnostics/diaglib.(*DiagnosticClient).runCurrentSyncSubStageListener.func1+0x1ad	/home/erigon/erigon/diagnostics/diaglib/stages.go:152

1 @ 0x4b76ae 0x4926f7 0x226514f 0x4c02e1
#	0x226514e	github.com/erigontech/erigon/diagnostics/diaglib.(*DiagnosticClient).runSubStageListener.func1+0x20e	/home/erigon/erigon/diagnostics/diaglib/stages.go:169

1 @ 0x4b76ae 0x4926f7 0x2269745 0x4c02e1
#	0x2269744	github.com/erigontech/erigon/diagnostics/diaglib.(*DiagnosticClient).runOnIncommingTxnListener.func1+0x264	/home/erigon/erigon/diagnostics/diaglib/txpool.go:124

1 @ 0x4b76ae 0x4926f7 0x2269a5b 0x4c02e1
#	0x2269a5a	github.com/erigontech/erigon/diagnostics/diaglib.(*DiagnosticClient).runOnPoolChangeBatchEvent.func1+0x1ba	/home/erigon/erigon/diagnostics/diaglib/txpool.go:147

1 @ 0x4b76ae 0x4926f7 0x226a18e 0x4c02e1
#	0x226a18d	github.com/erigontech/erigon/diagnostics/diaglib.(*DiagnosticClient).runOnNewBlockListener.func1+0x26d	/home/erigon/erigon/diagnostics/diaglib/txpool.go:179

1 @ 0x4b76ae 0x4926f7 0x226a52c 0x4c02e1
#	0x226a52b	github.com/erigontech/erigon/diagnostics/diaglib.(*DiagnosticClient).runOnSenderUpdateListener.func1+0x24b	/home/erigon/erigon/diagnostics/diaglib/txpool.go:202

```

