### PR TITLE
[3.2] prune: 500ms pruning timeout for stage_exec on ChainTiptar

### DIFF
--- a/execution/stagedsync/stage_execute.go
+++ b/execution/stagedsync/stage_execute.go
@@ -436,7 +436,7 @@ func PruneExecutionStage(s *PruneState, tx kv.RwTx, cfg ExecuteBlockCfg, ctx con
 	//  - stop prune when `tx.SpaceDirty()` is big
 	//  - and set ~500ms timeout
 	// because on slow disks - prune is slower. but for now - let's tune for nvme first, and add `tx.SpaceDirty()` check later https://github.com/erigontech/erigon/issues/11635
-	quickPruneTimeout := 250 * time.Millisecond
+	quickPruneTimeout := 500 * time.Millisecond
 
 	if s.ForwardProgress > cfg.syncCfg.MaxReorgDepth && !cfg.syncCfg.AlwaysGenerateChangesets {
 		// (chunkLen is 8Kb) * (1_000 chunks) = 8mb


### PR DESCRIPTION
to increase prune timeout 2x as a hotfix for reported prune issue on ethmainnet 
will create bigger epic today