### PR TITLE
execution/exec: reuse EVM for AA txs and move resets into branches

### DIFF
--- a/execution/exec/trace_worker.go
+++ b/execution/exec/trace_worker.go
@@ -119,23 +119,23 @@ func (e *TraceWorker) ExecTxn(txNum uint64, txIndex int, txn types.Transaction, 
 	if e.vmConfig.TraceJumpDest {
 		txContext.TxHash = txn.Hash()
 	}
-	e.evm.ResetBetweenBlocks(*e.blockCtx, txContext, e.ibs, *e.vmConfig, e.rules)
 
 	gp := new(protocol.GasPool).AddGas(txn.GetGasLimit()).AddBlobGas(txn.GetBlobGas())
 
 	if txn.Type() == types.AccountAbstractionTxType {
 		aaTxn := txn.(*types.AccountAbstractionTransaction)
-		evm := vm.NewEVM(*e.blockCtx, txContext, e.ibs, e.chainConfig, *e.vmConfig)
-		paymasterContext, validationGasUsed, err := aa.ValidateAATransaction(aaTxn, e.ibs, gp, e.header, evm, e.chainConfig)
+		e.evm.ResetBetweenBlocks(*e.blockCtx, txContext, e.ibs, *e.vmConfig, e.rules)
+		paymasterContext, validationGasUsed, err := aa.ValidateAATransaction(aaTxn, e.ibs, gp, e.header, e.evm, e.chainConfig)
 		if err != nil {
 			return err
 		}
 
-		_, _, err = aa.ExecuteAATransaction(aaTxn, paymasterContext, validationGasUsed, gp, evm, e.header, e.ibs)
+		_, _, err = aa.ExecuteAATransaction(aaTxn, paymasterContext, validationGasUsed, gp, e.evm, e.header, e.ibs)
 		if err != nil {
 			return err
 		}
 	} else {
+		e.evm.ResetBetweenBlocks(*e.blockCtx, txContext, e.ibs, *e.vmConfig, e.rules)
 		result, err := protocol.ApplyMessage(e.evm, msg, gp, true /* refunds */, gasBailout /* gasBailout */, e.engine)
 		if err != nil {
 			if result == nil {


### PR DESCRIPTION
The AA execution path was allocating a new vm.EVM per transaction while also calling ResetBetweenBlocks() unconditionally beforehand. This made the initial reset wasted work and caused extra allocations (new interpreter and JumpDestCache).

Changes:
- Move ResetBetweenBlocks() into the AA and non-AA branches.
- Reuse the existing e.evm for AA helpers (ValidateAATransaction/ExecuteAATransaction).
- Remove per-AA vm.NewEVM() allocation.

Rationale:
- Avoid redundant reset work and reduce allocations.
- Preserve JumpDestCache and interpreter reuse for better performance.
- Align behavior with historical_trace_worker, which already reuses a single EVM.
- No functional changes; AA helpers already accept a prepared EVM and internally
  construct an inner EVM for validation tracing when needed.