### PR TITLE
refactor: replace strings.Split in loops with more efficient strings.SplitSeq

### DIFF
--- a/cmd/utils/cmdtest/test_cmd.go
+++ b/cmd/utils/cmdtest/test_cmd.go
@@ -272,8 +272,8 @@ type testlogger struct {
 }
 
 func (tl *testlogger) Write(b []byte) (n int, err error) {
-	lines := bytes.Split(b, []byte("\n"))
-	for _, line := range lines {
+	lines := bytes.SplitSeq(b, []byte("\n"))
+	for line := range lines {
 		if len(line) > 0 {
 			tl.t.Logf("(stderr:%v) %s", tl.name, line)
 		}

--- a/common/dbg/dbg_env.go
+++ b/common/dbg/dbg_env.go
@@ -161,7 +161,7 @@ func MustParseUints(strNum, separator string) []uint64 {
 	}
 	parts := strings.Split(strNum, separator)
 	ints := make([]uint64, 0, len(parts))
-	for _, str := range strings.Split(strNum, separator) {
+	for str := range strings.SplitSeq(strNum, separator) {
 		ints = append(ints, MustParseUint(str))
 	}
 	return ints

--- a/execution/rlp/internal/rlpstruct/rlpstruct.go
+++ b/execution/rlp/internal/rlpstruct/rlpstruct.go
@@ -151,7 +151,7 @@ func parseTag(field Field, lastPublic int) (Tags, error) {
 	name := field.Name
 	tag := reflect.StructTag(field.Tag)
 	var ts Tags
-	for _, t := range strings.Split(tag.Get("rlp"), ",") {
+	for t := range strings.SplitSeq(tag.Get("rlp"), ",") {
 		switch t = strings.TrimSpace(t); t {
 		case "":
 			// empty tag is allowed for some reason

--- a/execution/rlp/typecache.go
+++ b/execution/rlp/typecache.go
@@ -205,7 +205,7 @@ func (e structTagError) Error() string {
 func parseStructTag(typ reflect.Type, fi, lastPublic int) (tags, error) {
 	f := typ.Field(fi)
 	var ts tags
-	for _, t := range strings.Split(f.Tag.Get("rlp"), ",") {
+	for t := range strings.SplitSeq(f.Tag.Get("rlp"), ",") {
 		switch t = strings.TrimSpace(t); t {
 		case "":
 		case "-":

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -89,7 +89,7 @@ func runTestScript(t *testing.T, file string, logger log.Logger) {
 	defer clientConn.Close()
 	go server.ServeCodec(NewCodec(serverConn), 0)
 	readbuf := bufio.NewReader(clientConn)
-	for _, line := range strings.Split(string(content), "\n") {
+	for line := range strings.SplitSeq(string(content), "\n") {
 		line = strings.TrimSpace(line)
 		switch {
 		case len(line) == 0 || strings.HasPrefix(line, "//"):


### PR DESCRIPTION


strings.SplitSeq (introduced in Go 1.23)  returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

It significantly reduces memory allocations and can improve performance for long strings.