### PR TITLE
fix: Bor txpool MinFeeCap sanitization by passing txpoolcfg.Config by pointer

### DIFF
--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -394,7 +394,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 	backend.genesisHash = genesis.Hash()
 
 	setDefaultMinerGasLimit(chainConfig, config, logger)
-	setBorDefaultTxPoolPriceLimit(chainConfig, config.TxPool, logger)
+	setBorDefaultTxPoolPriceLimit(chainConfig, &config.TxPool, logger)
 
 	logger.Info("Initialised chain configuration", "config", chainConfig, "genesis", genesis.Hash())
 	if dbg.OnlyCreateDB {
@@ -1733,7 +1733,7 @@ func setDefaultMinerGasLimit(chainConfig *chain.Config, config *ethconfig.Config
 }
 
 // setBorDefaultTxPoolPriceLimit enforces MinFeeCap to be equal to BorDefaultTxPoolPriceLimit (25gwei by default)
-func setBorDefaultTxPoolPriceLimit(chainConfig *chain.Config, config txpoolcfg.Config, logger log.Logger) {
+func setBorDefaultTxPoolPriceLimit(chainConfig *chain.Config, config *txpoolcfg.Config, logger log.Logger) {
 	if chainConfig.Bor != nil && config.MinFeeCap != txpoolcfg.BorDefaultTxPoolPriceLimit {
 		logger.Warn("Sanitizing invalid bor min fee cap", "provided", config.MinFeeCap, "updated", txpoolcfg.BorDefaultTxPoolPriceLimit)
 		config.MinFeeCap = txpoolcfg.BorDefaultTxPoolPriceLimit


### PR DESCRIPTION
On Bor networks, MinFeeCap must be enforced to a fixed default so the txpool rejects underpriced transactions. The previous implementation passed txpoolcfg.Config by value into setBorDefaultTxPoolPriceLimit, which only logged a warning without actually mutating the effective configuration, causing the txpool to run with an unsanitized MinFeeCap. This change switches the helper to take a *txpoolcfg.Config and updates the call site to pass &config.TxPool, ensuring the mutation is applied before txpool.Assemble consumes the config. This matches the existing pointer-based sanitization pattern used elsewhere and guarantees the intended behavior at runtime.