### PR TITLE
db/rawdb: use time.NewTicker for periodic progress in PruneTable

### DIFF
--- a/db/rawdb/accessors_chain.go
+++ b/db/rawdb/accessors_chain.go
@@ -1085,7 +1085,7 @@ func PruneTable(tx kv.RwTx, table string, pruneTo uint64, ctx context.Context, l
 	}
 	defer c.Close()
 
-	logEvery := time.NewTimer(30 * time.Second)
+	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
 
 	i := 0


### PR DESCRIPTION
Replace the one-shot time.NewTimer in PruneTable with time.NewTicker to ensure the "periodic progress" log actually emits repeatedly. The prior implementation would fire at most once (or never) depending on loop duration, which contradicts both the log message and established codebase conventions. This change matches how similar progress logs are implemented elsewhere (e.g., TruncateBlocks in the same file and multiple modules using tickers) and maintains the existing select pattern and Stop call for proper ticker cleanup.