### PR TITLE
p2p/discover: optimize findnodeByID

### DIFF
--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -482,47 +482,32 @@ func (tab *Table) copyLiveNodes() {
 // preferLive is true and the table contains any verified nodes, the result will not
 // contain unverified nodes. However, if there are no verified nodes at all, the result
 // will contain unverified nodes.
-func (tab *Table) findnodeByID(target enode.ID, nresults int, preferLive bool) *nodesByDistance {
+func (tab *Table) findnodeByID(target enode.ID, nresults int, preferLive bool) (nodes nodesByDistance) {
+	nodes.target = target
 	tab.mutex.Lock()
 	defer tab.mutex.Unlock()
 
 	// Scan all buckets. There might be a better way to do this, but there aren't that many
 	// buckets, so this solution should be fine. The worst-case complexity of this loop
 	// is O(tab.len() * nresults).
-	nodes := &nodesByDistance{target: target}
-	liveNodes := &nodesByDistance{target: target}
-	var liveNodesFound = false
 	if preferLive {
-	outer:
 		for _, b := range &tab.buckets {
 			for _, n := range b.entries {
 				if n.livenessChecks > 0 {
-					liveNodesFound = true
-					break outer
+					nodes.push(n, nresults)
 				}
 			}
 		}
-	}
-	if liveNodesFound {
-		for _, b := range &tab.buckets {
-			for _, n := range b.entries {
-				if n.livenessChecks > 0 {
-					liveNodes.push(n, nresults)
-				}
-			}
-		}
-	} else {
-		for _, b := range &tab.buckets {
-			for _, n := range b.entries {
-				nodes.push(n, nresults)
-			}
+		if len(nodes.entries) > 0 {
+			return
 		}
 	}
-
-	if preferLive && len(liveNodes.entries) > 0 {
-		return liveNodes
+	for _, b := range &tab.buckets {
+		for _, n := range b.entries {
+			nodes.push(n, nresults)
+		}
 	}
-	return nodes
+	return
 }
 
 // len returns the number of nodes in the table.

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -491,11 +491,29 @@ func (tab *Table) findnodeByID(target enode.ID, nresults int, preferLive bool) *
 	// is O(tab.len() * nresults).
 	nodes := &nodesByDistance{target: target}
 	liveNodes := &nodesByDistance{target: target}
-	for _, b := range &tab.buckets {
-		for _, n := range b.entries {
-			nodes.push(n, nresults)
-			if preferLive && n.livenessChecks > 0 {
-				liveNodes.push(n, nresults)
+	var liveNodesFound = false
+	if preferLive {
+		for _, b := range &tab.buckets {
+			for _, n := range b.entries {
+				if n.livenessChecks > 0 {
+					liveNodesFound = true
+					break
+				}
+			}
+		}
+	}
+	if liveNodesFound {
+		for _, b := range &tab.buckets {
+			for _, n := range b.entries {
+				if n.livenessChecks > 0 {
+					liveNodes.push(n, nresults)
+				}
+			}
+		}
+	} else {
+		for _, b := range &tab.buckets {
+			for _, n := range b.entries {
+				nodes.push(n, nresults)
 			}
 		}
 	}

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -493,11 +493,12 @@ func (tab *Table) findnodeByID(target enode.ID, nresults int, preferLive bool) *
 	liveNodes := &nodesByDistance{target: target}
 	var liveNodesFound = false
 	if preferLive {
+	outer:
 		for _, b := range &tab.buckets {
 			for _, n := range b.entries {
 				if n.livenessChecks > 0 {
 					liveNodesFound = true
-					break
+					break outer
 				}
 			}
 		}

--- a/p2p/discover/table_test.go
+++ b/p2p/discover/table_test.go
@@ -559,9 +559,10 @@ func Benchmark_findnodeByID(b *testing.B) {
 
 			b.ResetTimer()
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				_ = tab.findnodeByID(target, bm.nresults, bm.preferLive)
 			}
+			b.StopTimer()
 		})
 	}
 }

--- a/p2p/discover/table_test.go
+++ b/p2p/discover/table_test.go
@@ -506,15 +506,13 @@ func newkey() *ecdsa.PrivateKey {
 	return key
 }
 
-// BenchmarkTable_findnodeByID benchmarks the findnodeByID function with different
-
-func BenchmarkTable_findnodeByID(b *testing.B) {
+func Benchmark_findnodeByID(b *testing.B) {
 	benchmarks := []struct {
 		name       string
 		tableSize  int
 		nresults   int
 		preferLive bool
-		liveRatio  float64 // ratio of live nodes (0.0 to 1.0)
+		liveRatio  float64
 	}{
 		{"SmallTable_5Results_NoPreferLive", 50, 5, false, 0.0},
 		{"SmallTable_16Results_NoPreferLive", 50, 16, false, 0.0},
@@ -548,19 +546,15 @@ func BenchmarkTable_findnodeByID(b *testing.B) {
 			defer db.Close()
 			defer tab.close()
 
-			// Wait for table initialization
 			<-tab.initDone
 
-			// Fill table with nodes (returns []*node — the internal wrapper)
 			nodes := generateTestNodes(bm.tableSize, tab.self().ID())
 			fillTable(tab, nodes)
 
-			// Set some nodes as live based on liveRatio
 			if bm.preferLive && bm.liveRatio > 0 {
 				setNodesLive(tab, nodes, bm.liveRatio)
 			}
 
-			// Generate a random target ID once per benchmark run
 			target := generateRandomID()
 
 			b.ResetTimer()
@@ -572,7 +566,6 @@ func BenchmarkTable_findnodeByID(b *testing.B) {
 	}
 }
 
-// generateTestNodes creates a slice of test *node (internal wrapper) with random IDs.
 func generateTestNodes(count int, baseID enode.ID) []*node {
 	nodes := make([]*node, count)
 	for i := 0; i < count; i++ {
@@ -586,7 +579,6 @@ func generateTestNodes(count int, baseID enode.ID) []*node {
 	return nodes
 }
 
-// setNodesLive sets a percentage of nodes in the table as live.
 func setNodesLive(tab *Table, nodes []*node, liveRatio float64) {
 	tab.mutex.Lock()
 	defer tab.mutex.Unlock()
@@ -603,7 +595,6 @@ func setNodesLive(tab *Table, nodes []*node, liveRatio float64) {
 	}
 }
 
-// generateRandomID generates a random enode.ID for use as a target.
 func generateRandomID() enode.ID {
 	var id enode.ID
 	rand.Read(id[:])


### PR DESCRIPTION
Optimize findnodeByID function and improve benchmark

```
goos: linux
goarch: amd64
pkg: github.com/erigontech/erigon/p2p/discover
cpu: Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz
                                                          │ new_bench.txt │             old_bench.txt             │
                                                          │    sec/op     │    sec/op     vs base                 │
_findnodeByID/SmallTable_5Results_NoPreferLive-8             1.270µ ± 10%   1.223µ ±  5%         ~ (p=0.240 n=10)
_findnodeByID/SmallTable_16Results_NoPreferLive-8            1.566µ ± 13%   1.605µ ±  8%         ~ (p=1.000 n=10)
_findnodeByID/SmallTable_5Results_PreferLive_AllLive-8       1.234µ ± 13%   2.255µ ±  7%   +82.77% (p=0.000 n=10)
_findnodeByID/SmallTable_16Results_PreferLive_AllLive-8      1.701µ ±  5%   3.006µ ±  3%   +76.74% (p=0.000 n=10)
_findnodeByID/SmallTable_5Results_PreferLive_HalfLive-8      1.330µ ± 12%   2.200µ ±  8%   +65.44% (p=0.000 n=10)
_findnodeByID/SmallTable_16Results_PreferLive_HalfLive-8     1.725µ ± 10%   3.232µ ±  8%   +87.42% (p=0.000 n=10)
_findnodeByID/MediumTable_5Results_NoPreferLive-8            1.260µ ± 13%   1.279µ ±  6%         ~ (p=0.897 n=10)
_findnodeByID/MediumTable_16Results_NoPreferLive-8           1.828µ ±  6%   1.583µ ± 13%   -13.38% (p=0.001 n=10)
_findnodeByID/MediumTable_5Results_PreferLive_AllLive-8      1.297µ ±  8%   2.228µ ±  7%   +71.81% (p=0.000 n=10)
_findnodeByID/MediumTable_16Results_PreferLive_AllLive-8     1.712µ ±  4%   3.056µ ±  6%   +78.50% (p=0.000 n=10)
_findnodeByID/MediumTable_5Results_PreferLive_HalfLive-8     1.255µ ± 13%   2.199µ ±  7%   +75.22% (p=0.000 n=10)
_findnodeByID/MediumTable_16Results_PreferLive_HalfLive-8    1.630µ ±  5%   2.944µ ± 11%   +80.61% (p=0.000 n=10)
_findnodeByID/LargeTable_5Results_NoPreferLive-8             1.592µ ±  9%   1.670µ ± 11%         ~ (p=0.109 n=10)
_findnodeByID/LargeTable_16Results_NoPreferLive-8            2.090µ ±  8%   2.162µ ± 10%         ~ (p=0.315 n=10)
_findnodeByID/LargeTable_5Results_PreferLive_AllLive-8       1.481µ ± 12%   3.218µ ±  7%  +117.25% (p=0.000 n=10)
_findnodeByID/LargeTable_16Results_PreferLive_AllLive-8      1.970µ ±  9%   3.964µ ±  4%  +101.19% (p=0.000 n=10)
_findnodeByID/LargeTable_5Results_PreferLive_HalfLive-8      1.361µ ±  7%   2.723µ ±  8%  +100.15% (p=0.000 n=10)
_findnodeByID/LargeTable_16Results_PreferLive_HalfLive-8     1.802µ ±  6%   3.655µ ±  6%  +102.91% (p=0.000 n=10)
_findnodeByID/FullTable_5Results_NoPreferLive-8              1.438µ ± 17%   1.563µ ± 13%         ~ (p=0.247 n=10)
_findnodeByID/FullTable_16Results_NoPreferLive-8             1.954µ ±  7%   2.290µ ± 13%   +17.23% (p=0.000 n=10)
_findnodeByID/FullTable_5Results_PreferLive_AllLive-8        1.477µ ±  5%   3.304µ ±  7%  +123.74% (p=0.000 n=10)
_findnodeByID/FullTable_16Results_PreferLive_AllLive-8       1.958µ ±  6%   4.172µ ±  7%  +113.07% (p=0.000 n=10)
geomean                                                      1.566µ         2.379µ         +51.90%

                                                          │ new_bench.txt │            old_bench.txt             │
                                                          │     B/op      │    B/op     vs base                  │
_findnodeByID/SmallTable_5Results_NoPreferLive-8               248.0 ± 0%   248.0 ± 0%        ~ (p=1.000 n=10) ¹
_findnodeByID/SmallTable_16Results_NoPreferLive-8              376.0 ± 0%   376.0 ± 0%        ~ (p=1.000 n=10) ¹
_findnodeByID/SmallTable_5Results_PreferLive_AllLive-8         248.0 ± 0%   368.0 ± 0%  +48.39% (p=0.000 n=10)
_findnodeByID/SmallTable_16Results_PreferLive_AllLive-8        376.0 ± 0%   624.0 ± 0%  +65.96% (p=0.000 n=10)
_findnodeByID/SmallTable_5Results_PreferLive_HalfLive-8        248.0 ± 0%   368.0 ± 0%  +48.39% (p=0.000 n=10)
_findnodeByID/SmallTable_16Results_PreferLive_HalfLive-8       376.0 ± 0%   624.0 ± 0%  +65.96% (p=0.000 n=10)
_findnodeByID/MediumTable_5Results_NoPreferLive-8              248.0 ± 0%   248.0 ± 0%        ~ (p=1.000 n=10) ¹
_findnodeByID/MediumTable_16Results_NoPreferLive-8             376.0 ± 0%   376.0 ± 0%        ~ (p=1.000 n=10) ¹
_findnodeByID/MediumTable_5Results_PreferLive_AllLive-8        248.0 ± 0%   368.0 ± 0%  +48.39% (p=0.000 n=10)
_findnodeByID/MediumTable_16Results_PreferLive_AllLive-8       376.0 ± 0%   624.0 ± 0%  +65.96% (p=0.000 n=10)
_findnodeByID/MediumTable_5Results_PreferLive_HalfLive-8       248.0 ± 0%   368.0 ± 0%  +48.39% (p=0.000 n=10)
_findnodeByID/MediumTable_16Results_PreferLive_HalfLive-8      376.0 ± 0%   624.0 ± 0%  +65.96% (p=0.000 n=10)
_findnodeByID/LargeTable_5Results_NoPreferLive-8               248.0 ± 0%   248.0 ± 0%        ~ (p=1.000 n=10) ¹
_findnodeByID/LargeTable_16Results_NoPreferLive-8              376.0 ± 0%   376.0 ± 0%        ~ (p=1.000 n=10) ¹
_findnodeByID/LargeTable_5Results_PreferLive_AllLive-8         248.0 ± 0%   368.0 ± 0%  +48.39% (p=0.000 n=10)
_findnodeByID/LargeTable_16Results_PreferLive_AllLive-8        376.0 ± 0%   624.0 ± 0%  +65.96% (p=0.000 n=10)
_findnodeByID/LargeTable_5Results_PreferLive_HalfLive-8        248.0 ± 0%   368.0 ± 0%  +48.39% (p=0.000 n=10)
_findnodeByID/LargeTable_16Results_PreferLive_HalfLive-8       376.0 ± 0%   624.0 ± 0%  +65.96% (p=0.000 n=10)
_findnodeByID/FullTable_5Results_NoPreferLive-8                248.0 ± 0%   248.0 ± 0%        ~ (p=1.000 n=10) ¹
_findnodeByID/FullTable_16Results_NoPreferLive-8               376.0 ± 0%   376.0 ± 0%        ~ (p=1.000 n=10) ¹
_findnodeByID/FullTable_5Results_PreferLive_AllLive-8          248.0 ± 0%   368.0 ± 0%  +48.39% (p=0.000 n=10)
_findnodeByID/FullTable_16Results_PreferLive_AllLive-8         376.0 ± 0%   624.0 ± 0%  +65.96% (p=0.000 n=10)
geomean                                                        305.4        406.8       +33.21%
¹ all samples are equal

                                                          │ new_bench.txt │             old_bench.txt             │
                                                          │   allocs/op   │  allocs/op   vs base                  │
_findnodeByID/SmallTable_5Results_NoPreferLive-8               6.000 ± 0%    6.000 ± 0%        ~ (p=1.000 n=10) ¹
_findnodeByID/SmallTable_16Results_NoPreferLive-8              7.000 ± 0%    7.000 ± 0%        ~ (p=1.000 n=10) ¹
_findnodeByID/SmallTable_5Results_PreferLive_AllLive-8         6.000 ± 0%   10.000 ± 0%  +66.67% (p=0.000 n=10)
_findnodeByID/SmallTable_16Results_PreferLive_AllLive-8        7.000 ± 0%   12.000 ± 0%  +71.43% (p=0.000 n=10)
_findnodeByID/SmallTable_5Results_PreferLive_HalfLive-8        6.000 ± 0%   10.000 ± 0%  +66.67% (p=0.000 n=10)
_findnodeByID/SmallTable_16Results_PreferLive_HalfLive-8       7.000 ± 0%   12.000 ± 0%  +71.43% (p=0.000 n=10)
_findnodeByID/MediumTable_5Results_NoPreferLive-8              6.000 ± 0%    6.000 ± 0%        ~ (p=1.000 n=10) ¹
_findnodeByID/MediumTable_16Results_NoPreferLive-8             7.000 ± 0%    7.000 ± 0%        ~ (p=1.000 n=10) ¹
_findnodeByID/MediumTable_5Results_PreferLive_AllLive-8        6.000 ± 0%   10.000 ± 0%  +66.67% (p=0.000 n=10)
_findnodeByID/MediumTable_16Results_PreferLive_AllLive-8       7.000 ± 0%   12.000 ± 0%  +71.43% (p=0.000 n=10)
_findnodeByID/MediumTable_5Results_PreferLive_HalfLive-8       6.000 ± 0%   10.000 ± 0%  +66.67% (p=0.000 n=10)
_findnodeByID/MediumTable_16Results_PreferLive_HalfLive-8      7.000 ± 0%   12.000 ± 0%  +71.43% (p=0.000 n=10)
_findnodeByID/LargeTable_5Results_NoPreferLive-8               6.000 ± 0%    6.000 ± 0%        ~ (p=1.000 n=10) ¹
_findnodeByID/LargeTable_16Results_NoPreferLive-8              7.000 ± 0%    7.000 ± 0%        ~ (p=1.000 n=10) ¹
_findnodeByID/LargeTable_5Results_PreferLive_AllLive-8         6.000 ± 0%   10.000 ± 0%  +66.67% (p=0.000 n=10)
_findnodeByID/LargeTable_16Results_PreferLive_AllLive-8        7.000 ± 0%   12.000 ± 0%  +71.43% (p=0.000 n=10)
_findnodeByID/LargeTable_5Results_PreferLive_HalfLive-8        6.000 ± 0%   10.000 ± 0%  +66.67% (p=0.000 n=10)
_findnodeByID/LargeTable_16Results_PreferLive_HalfLive-8       7.000 ± 0%   12.000 ± 0%  +71.43% (p=0.000 n=10)
_findnodeByID/FullTable_5Results_NoPreferLive-8                6.000 ± 0%    6.000 ± 0%        ~ (p=1.000 n=10) ¹
_findnodeByID/FullTable_16Results_NoPreferLive-8               7.000 ± 0%    7.000 ± 0%        ~ (p=1.000 n=10) ¹
_findnodeByID/FullTable_5Results_PreferLive_AllLive-8          6.000 ± 0%   10.000 ± 0%  +66.67% (p=0.000 n=10)
_findnodeByID/FullTable_16Results_PreferLive_AllLive-8         7.000 ± 0%   12.000 ± 0%  +71.43% (p=0.000 n=10)
geomean                                                        6.481         9.051       +39.66%
¹ all samples are equal
```