### PR TITLE
Optimize WriteTransactions to avoid intermediate buffer and extra copy

### DIFF
--- a/db/rawdb/accessors_chain.go
+++ b/db/rawdb/accessors_chain.go
@@ -472,13 +472,12 @@ func CanonicalTransactions(db kv.Getter, txnID uint64, amount uint32) ([]types.T
 // Write transactions into DB and use txnID as first identifier
 func WriteTransactions(rwTx kv.RwTx, txs []types.Transaction, baseTxnID types.BaseTxnID) error {
 	rawTxs := make([][]byte, len(txs))
-	buf := bytes.NewBuffer(nil)
 	for i, txn := range txs {
-		buf.Reset()
-		if err := rlp.Encode(buf, txn); err != nil {
+		raw, err := rlp.EncodeToBytes(txn)
+		if err != nil {
 			return fmt.Errorf("broken txn rlp: %w", err)
 		}
-		rawTxs[i] = common.Copy(buf.Bytes())
+		rawTxs[i] = raw
 	}
 	return WriteRawTransactions(rwTx, rawTxs, baseTxnID)
 }


### PR DESCRIPTION
The WriteTransactions path encoded each transaction into a shared bytes.Buffer and then created a new slice via common.Copy before calling WriteRawTransactions. Since our KV backends (MDBX and in-memory batch) copy values during Put/Append, retaining the caller’s slice after the call is unnecessary. Switching to rlp.EncodeToBytes per transaction eliminates the redundant copy and buffer reuse, reducing allocations without changing the stored format. ReadBodyRLP remains untouched because it intentionally re-encodes a full types.Body RLP for test validation rather than returning the BodyForStorage bytes.