### PR TITLE
db/kv: include blocks in ErrUnknownPruneMode

### DIFF
--- a/db/kv/prune/storage_mode.go
+++ b/db/kv/prune/storage_mode.go
@@ -57,7 +57,7 @@ var (
 		Blocks:      Distance(math.MaxUint64),
 	}
 
-	ErrUnknownPruneMode       = fmt.Errorf("--prune.mode must be one of %s, %s, %s", archiveModeStr, fullModeStr, minimalModeStr)
+	ErrUnknownPruneMode       = fmt.Errorf("--prune.mode must be one of %s, %s, %s, %s", fullModeStr, archiveModeStr, minimalModeStr, blockModeStr)
 	ErrDistanceOnlyForArchive = fmt.Errorf("--prune.distance and --prune.distance.blocks are only allowed with --prune.mode=%s", archiveModeStr)
 )
 


### PR DESCRIPTION
This change updates the user-facing error ErrUnknownPruneMode in db/kv/prune/storage_mode.go to include the blocks mode and to present the list of supported values in the same order used by the CLI help and documentation (full, archive, minimal, blocks). The blocks mode is officially supported in parsing (FromCli), exposed in node/cli/flags.go usage text, and documented in the GitBook pages. Omitting it in the error message misleads users and contradicts both the code and the docs; aligning the message ensures consistency and reduces confusion.