### PR TITLE
chore: remove redundant fileScanner.Err() check

### DIFF
--- a/cmd/integration/commands/refetence_db.go
+++ b/cmd/integration/commands/refetence_db.go
@@ -372,10 +372,6 @@ MainLoop:
 		if err != nil {
 			panic(err)
 		}
-		err = fileScanner.Err()
-		if err != nil {
-			panic(err)
-		}
 		if bucket == "" {
 			panic("bucket not parse")
 		}


### PR DESCRIPTION
remove the duplicated fileScanner.Err() invocation after the header loop in fToMdbx, keep the single error guard that already panics when the scanner reports an error