### PR TITLE
chore: remove redundant Unsubscribe in resubscribe loop

### DIFF
--- a/p2p/event/subscription.go
+++ b/p2p/event/subscription.go
@@ -159,11 +159,7 @@ func (s *resubscribeSub) loop() {
 	defer close(s.err)
 	var done bool
 	for !done {
-		sub := s.subscribe()
-		if sub == nil {
-			break
-		}
-		done = s.waitForError(sub)
+		done = s.subscribeAndWaitForError()
 	}
 }
 
@@ -199,7 +195,11 @@ func (s *resubscribeSub) subscribe() Subscription {
 	}
 }
 
-func (s *resubscribeSub) waitForError(sub Subscription) bool {
+func (s *resubscribeSub) subscribeAndWaitForError() bool {
+	sub := s.subscribe()
+	if sub == nil {
+		return true
+	}
 	defer sub.Unsubscribe()
 	select {
 	case err := <-sub.Err():


### PR DESCRIPTION
Removed the extra Unsubscribe call in resubscribeSub.loop() and rely on the existing defer sub.Unsubscribe() inside waitForError() for cleanup. The Subscription interface permits multiple Unsubscribe calls and upstream code mirrored this redundancy, but a single authoritative cleanup path inside waitForError() is clearer and safer if the function changes in the future (early exits, panics). This reduces redundant work while preserving behavior and correctness.