### PR TITLE
cmd/downloader: fix MarkFlagFilename for --file flag in withFile()

### DIFF
--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -179,7 +179,7 @@ func withChainFlag(cmd *cobra.Command) {
 }
 func withFile(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&filePath, "file", "", "")
-	if err := cmd.MarkFlagFilename(utils.DataDirFlag.Name); err != nil {
+	if err := cmd.MarkFlagFilename("file"); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
This change corrects the flag name passed to MarkFlagFilename in cmd/downloader/main.go::withFile(). The function defines a --file flag, but previously marked utils.DataDirFlag.Name (the --datadir flag) as a filename. That was inconsistent with both the local flag definition and the established pattern elsewhere in the codebase (e.g., cmd/integration/commands/flags.go and printTorrentHashes which correctly mark the specific flag they define). The incorrect mark also conflicted with withDataDir(), which marks --datadir as a directory with MarkFlagDirname. Updating the argument to "file" restores correct shell completion metadata and avoids confusing UX without changing runtime behavior.