### PR TITLE
fix: Correct pendingBaseFee field name in BestQueue struct

### DIFF
--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -382,9 +382,9 @@ func (p *TxPool) OnNewBlock(ctx context.Context, stateChanges *remoteproto.State
 	if baseFeeChanged {
 		p.pending.best.pendingBaseFee = pendingBaseFee
 		p.pending.worst.pendingBaseFee = pendingBaseFee
-		p.baseFee.best.pendingBastFee = pendingBaseFee
+		p.baseFee.best.pendingBaseFee = pendingBaseFee
 		p.baseFee.worst.pendingBaseFee = pendingBaseFee
-		p.queued.best.pendingBastFee = pendingBaseFee
+		p.queued.best.pendingBaseFee = pendingBaseFee
 		p.queued.worst.pendingBaseFee = pendingBaseFee
 	}
 

--- a/txnprovider/txpool/queues.go
+++ b/txnprovider/txpool/queues.go
@@ -52,7 +52,7 @@ func (s *bestSlice) UnsafeAdd(i *metaTxn) {
 
 type BestQueue struct {
 	ms             []*metaTxn
-	pendingBastFee uint64
+	pendingBaseFee uint64
 }
 
 func (p *BestQueue) Len() int {
@@ -60,7 +60,7 @@ func (p *BestQueue) Len() int {
 }
 
 func (p *BestQueue) Less(i, j int) bool {
-	return p.ms[i].better(p.ms[j], *uint256.NewInt(p.pendingBastFee))
+	return p.ms[i].better(p.ms[j], *uint256.NewInt(p.pendingBaseFee))
 }
 
 func (p *BestQueue) Swap(i, j int) {


### PR DESCRIPTION
Fixed a copy-paste error where the BestQueue struct field was incorrectly named `pendingBastFee` instead of `pendingBaseFee`. This inconsistency caused field assignments in pool.go to reference the wrong field name.