### PR TITLE
qa-tests: save rpcdaemon log in the rpc performance test 

### DIFF
--- a/.github/workflows/qa-rpc-performance-tests.yml
+++ b/.github/workflows/qa-rpc-performance-tests.yml
@@ -55,6 +55,7 @@ jobs:
           rm -rf $ERIGON_TESTBED_AREA/chaindata-prev || true
           echo "Backup chaindata"
           cp -r $ERIGON_REFERENCE_DATA_DIR/chaindata $ERIGON_TESTBED_AREA/chaindata-prev
+          rm -f $ERIGON_REFERENCE_DATA_DIR/logs/rpcdaemon.log || true
 
       - name: Run RpcDaemon
         id: rpcdaemon_running_step
@@ -225,6 +226,13 @@ jobs:
           else
             echo "RpcDaemon has already terminated"
           fi
+
+      - name: Upload RpcDaemon logs
+        if: steps.test_step.outputs.test_executed == 'true'
+        uses: actions/upload-artifact@v5
+        with:
+          name: rpcdaemon-logs
+          path: $ERIGON_REFERENCE_DATA_DIR/logs/rpcdaemon.log
 
       - name: Restore Erigon Chaindata Directory
         if: ${{ always() }}


### PR DESCRIPTION
The RPC daemon log is useful for identifying the cause of a crash during testing.