### PR TITLE
rpc/jsonrpc: avoid redundant error string allocation in overlay getLogs

### DIFF
--- a/rpc/jsonrpc/overlay_api.go
+++ b/rpc/jsonrpc/overlay_api.go
@@ -295,7 +295,7 @@ func (api *OverlayAPIImpl) GetLogs(ctx context.Context, crit filters.FilterCrite
 			defer pend.Done()
 			tx, err := api.db.BeginTemporalRo(ctx)
 			if err != nil {
-				log.Error("Error", "error", err.Error())
+				log.Error("Error", "error", err)
 				return
 			}
 			defer tx.Rollback()


### PR DESCRIPTION
replace err.Error() with the raw error when logging DB open failures inside OverlayAPIImpl.GetLogs, keeps full error context and removes an unnecessary string allocation in the hot path