### PR TITLE
Change Docker base and builder images in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,8 @@ env:
   TEST_TRACKING_TIME_SECONDS: 7200 # 2 hours
   TEST_TOTAL_TIME_SECONDS: 432000   # 5 days
   TEST_CHAIN: "mainnet"
-  DOCKER_BASE_IMAGE: "debian:13-slim"
+  BUILDER_IMAGE: "golang:1.25-bookworm"
+  TARGET_BASE_IMAGE: "debian:12-slim"
   APP_REPO: "erigontech/erigon"
   PACKAGE: "github.com/erigontech/erigon"
   BINARIES: "erigon downloader evm caplin capcli integration rpcdaemon sentry txpool"
@@ -138,9 +139,11 @@ jobs:
             --label org.opencontainers.image.vcs-ref-short=${{ steps.getCommitId.outputs.short-commit-id }} \
             --label org.opencontainers.image.vendor="${{ github.repository_owner }}" \
             --label org.opencontainers.image.description="${{ env.LABEL_DESCRIPTION }}" \
-            --label org.opencontainers.image.base.name="${{ env.DOCKER_BASE_IMAGE }}" \
+            --label org.opencontainers.image.base.name="${{ env.TARGET_BASE_IMAGE }}" \
             --build-arg VERSION=${RELEASE_VERSION} \
             --build-arg BINARIES='${{ env.BINARIES }}' \
+            --build-arg BUILDER_IMAGE='${{ env.BUILDER_IMAGE }}' \
+            --build-arg TARGET_BASE_IMAGE='${{ env.TARGET_BASE_IMAGE }}' \
             --tag ${DOCKER_URL}:${RELEASE_VERSION} \
             --push \
             .


### PR DESCRIPTION
For better compatibility build and base images switched to Debian Bookworm (12).

Mentioned in  #17989