### PR TITLE
fix: rename prevBlock to prevEndBlock in span range index

### DIFF
--- a/polygon/heimdall/span_range_index.go
+++ b/polygon/heimdall/span_range_index.go
@@ -151,8 +151,8 @@ func (i *txSpanRangeIndex) Lookup(ctx context.Context, blockNum uint64) (uint64,
 			break
 		}
 		prevStartBlock := rangeIndexKeyParse(prevStartBlockRaw)
-		prevSpanId, prevBlock := rangeIndexValuePairParse(prevValuePair)
-		isInRange := blockNumInRange(blockNum, prevStartBlock, prevBlock)
+		prevSpanId, prevEndBlock := rangeIndexValuePairParse(prevValuePair)
+		isInRange := blockNumInRange(blockNum, prevStartBlock, prevEndBlock)
 		if !isInRange {
 			break // we have walked out of range, break to return current known lastSpanIdInRange
 		}


### PR DESCRIPTION
The variable name was inconsistent with the rest of the function. We use lastEndBlock and currEndBlock everywhere else, so prevBlock should be prevEndBlock too since it holds the end block number from the parsed value pair.