### PR TITLE
node/direct: forward grpc opts in SentryClientRemote.PeerCount

### DIFF
--- a/node/direct/sentry_client.go
+++ b/node/direct/sentry_client.go
@@ -140,7 +140,7 @@ func (c *SentryClientRemote) Messages(ctx context.Context, in *sentryproto.Messa
 }
 
 func (c *SentryClientRemote) PeerCount(ctx context.Context, in *sentryproto.PeerCountRequest, opts ...grpc.CallOption) (*sentryproto.PeerCountReply, error) {
-	return c.SentryClient.PeerCount(ctx, in)
+	return c.SentryClient.PeerCount(ctx, in, opts...)
 }
 
 // Contains implementations of SentryServer, SentryClient, ControlClient, and ControlServer, that may be linked to each other


### PR DESCRIPTION
The remote wrapper for the Sentry client was dropping variadic grpc.CallOption parameters in SentryClientRemote.PeerCount by delegating as PeerCount(ctx, in) instead of PeerCount(ctx, in, opts...). This diverged from the generated SentryClient interface and from other methods in the same type (HandShake, SetStatus, Messages), and could silently ignore per-RPC options such as metadata, credentials, wait-for-ready, and timeouts. The change forwards opts... to the embedded client to restore consistency and ensure per-RPC options are respected.