### PR TITLE
chore: remove unused script metadata from golangci lint runner

### DIFF
--- a/tools/golangci_lint.sh
+++ b/tools/golangci_lint.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-scriptDir=$(dirname "${BASH_SOURCE[0]}")
-scriptName=$(basename "${BASH_SOURCE[0]}")
+
 version="v2.6.2"
 
 if [[ "$1" == "--install-deps" ]]


### PR DESCRIPTION
drop the unused scriptDir and scriptName assignments from tools/golangci_lint.sh to simplify the wrapper