### PR TITLE
db/integrity: fix off-by-one in touchHistoricalKeys HistoryRange end bound

### DIFF
--- a/db/integrity/commitment.go
+++ b/db/integrity/commitment.go
@@ -660,7 +660,8 @@ func CheckCommitmentHistAtBlkRange(ctx context.Context, db kv.TemporalRoDB, br s
 }
 
 func touchHistoricalKeys(sd *execctx.SharedDomains, tx kv.TemporalTx, d kv.Domain, fromTxNum uint64, toTxNum uint64, visitor func(k []byte)) (uint64, error) {
-	stream, err := tx.HistoryRange(d, int(fromTxNum), int(toTxNum)+1, order.Asc, -1)
+	// toTxNum is exclusive per kv.TemporalTx.HistoryRange contract [from,to)
+	stream, err := tx.HistoryRange(d, int(fromTxNum), int(toTxNum), order.Asc, -1)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
This change corrects an off-by-one error in db/integrity/commitment.go within touchHistoricalKeys, where the end transaction number passed to kv.TemporalTx.HistoryRange was incremented by one despite HistoryRange being defined as [from,to) and callers already supplying an exclusive end, for example CheckCommitmentHistAtBlk passes maxTxNum+1 and checkCommitmentRootViaRecompute passes txNum+1, meaning adding another +1 resulted in touching one extra transaction beyond the intended range; the fix removes the redundant increment and adds a brief comment noting the contract to prevent regressions, aligning the helper with kv_interface.go documentation and other call sites such as rpc/jsonrpc/erigon_block.go and debug_api.go, and with state/history.go behavior which breaks when txNum >= toTxNum