### PR TITLE
Guard `SliceTakeLast` against negative limits

### DIFF
--- a/common/collections.go
+++ b/common/collections.go
@@ -46,6 +46,9 @@ func SliceShuffle[T any](s []T) {
 }
 
 func SliceTakeLast[T any](s []T, count int) []T {
+	if count < 0 {
+		return s[:0]
+	}
 	length := len(s)
 	if length > count {
 		return s[length-count:]


### PR DESCRIPTION


## Description
- add early return when `count < 0` in `common/collections.go` to avoid slice-bounds panic  
- this keeps Heimdall observers safe from malformed `eventsLimit` values