### PR TITLE
Update Makefile (GIT_TAG)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,12 @@ GIT_COMMIT ?= $(shell git rev-list -1 HEAD)
 SHORT_COMMIT := $(shell echo $(GIT_COMMIT) | cut -c 1-8)
 GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 GIT_TAG    ?= $(shell git describe --tags '--match=*.*.*' --abbrev=7 --dirty)
+
+# Use git tag value for "release/" branches only. Otherwise it make no sense.
+ifeq (,$(findstring release/,$(GIT_BRANCH)))
+  GIT_TAG	:= .
+endif
+
 ERIGON_USER ?= erigon
 # if using volume-mounting data dir, then must exist on host OS
 DOCKER_UID ?= $(shell id -u)


### PR DESCRIPTION
`GIT_TAG` Makefile variable will be set by default to `.` for non-release branches, and latest git tag for release branches.

For example, in case of current main branch:

> INFO[11-05|17:33:22.128] Build info git_branch=main git_tag=v3.0.0-beta1-1972-ge19a005 git_commit=e19a005b927ee3e49cc245e40182a68f70002c33

Note: `git_tag=v3.0.0-beta1-1972-ge19a005` is useless.