### PR TITLE
ethash: prevent hash rate overflow in remote sealer

### DIFF
--- a/execution/protocol/rules/ethash/sealer.go
+++ b/execution/protocol/rules/ethash/sealer.go
@@ -173,7 +173,10 @@ func (s *remoteSealer) loop() {
 			// Gather all hash rate submitted by remote sealer.
 			var total uint64
 			for _, rate := range s.rates {
-				// this could overflow
+				if math.MaxUint64-total < rate.rate {
+					total = math.MaxUint64
+					break
+				}
 				total += rate.rate
 			}
 			req <- total


### PR DESCRIPTION


Fixed potential integer overflow when aggregating hash rates from remote miners. The total hash rate calculation could silently wrap around due to unchecked addition, leading to incorrect metrics and monitoring data.

