### PR TITLE
cl/rpc: send filtered DataColumnsByRootIdentifier to selected peer

### DIFF
--- a/cl/rpc/rpc.go
+++ b/cl/rpc/rpc.go
@@ -118,13 +118,13 @@ func (b *BeaconRpcP2P) SendColumnSidecarsByRootIdentifierReq(
 	ctx context.Context,
 	req *solid.ListSSZ[*cltypes.DataColumnsByRootIdentifier],
 ) ([]*cltypes.DataColumnSidecar, string, error) {
-	_, pid, _, err := b.columnDataPeers.pickPeerRoundRobin(ctx, req)
+	filteredReq, pid, _, err := b.columnDataPeers.pickPeerRoundRobin(ctx, req)
 	if err != nil {
 		return nil, pid, err
 	}
 
 	var buffer buffer.Buffer
-	if err := ssz_snappy.EncodeAndWrite(&buffer, req); err != nil {
+	if err := ssz_snappy.EncodeAndWrite(&buffer, filteredReq); err != nil {
 		return nil, "", err
 	}
 


### PR DESCRIPTION
The column download client performed peer-aware filtering in pickPeerRoundRobin() by intersecting requested columns with the selected peer’s custody mask, but SendColumnSidecarsByRootIdentifierReq() encoded and sent the original unfiltered request, negating the benefits of that filtering. Server handlers (dataColumnSidecarsByRootHandler) tolerate extra columns by skipping missing ones, so functional correctness was unaffected; however, this led to unnecessary payload and lowered hit-rate per request. This change serializes and sends the filtered request produced by pickPeerRoundRobin(), aligning the payload with the chosen peer’s capabilities and improving efficiency without altering protocol semantics or server behavior.