### PR TITLE
rpc/requests: check JSON-RPC error in TxpoolContent

### DIFF
--- a/rpc/requests/tx.go
+++ b/rpc/requests/tx.go
@@ -38,6 +38,10 @@ func (reqGen *requestGenerator) TxpoolContent() (int, int, int, error) {
 		return len(pending), len(queued), len(baseFee), fmt.Errorf("failed to fetch txpool content: %v", res.Err)
 	}
 
+	if b.Error != nil {
+		return 0, 0, 0, fmt.Errorf("txpool_content rpc failed: %w", b.Error)
+	}
+
 	resp, ok := b.Result.(map[string]interface{})
 
 	if !ok {


### PR DESCRIPTION
This change adds a missing JSON-RPC error check in rpc/requests/tx.go TxpoolContent(), aligning it with the established pattern used by other rpcCallJSON callers like EstimateGas, TraceCall, and DebugAccountAt. Without checking b.Error, error responses from the node skip early exit and lead to confusing follow-up failures when attempting to interpret result. By validating b.Error immediately after the HTTP call, we surface RPC failures consistently and prevent misclassification of errors during result parsing.