### PR TITLE
cmd/integration: call debug.Exit() directly in PersistentPostRun

### DIFF
--- a/cmd/integration/commands/root.go
+++ b/cmd/integration/commands/root.go
@@ -64,7 +64,7 @@ var rootCmd = &cobra.Command{
 		}
 	},
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
-		defer debug.Exit()
+		debug.Exit()
 	},
 }
 


### PR DESCRIPTION
Replaced a redundant deferred call to debug.Exit() with a direct invocation inside PersistentPostRun. Using defer here provides no semantic benefit because there are no subsequent statements and the hook is already at the end of the command lifecycle. The rest of the codebase consistently calls debug.Exit() directly in similar hooks (e.g., cmd/downloader/main.go, cmd/sentry/main.go, cmd/state/commands/root.go, cmd/rpctest/main.go), so this aligns integration with established practice and removes unnecessary indirection without altering behavior.