### PR TITLE
refactor(rpc): use common.CopyBytes for slice copying in otterscan tracer

### DIFF
--- a/rpc/jsonrpc/otterscan_trace_transaction.go
+++ b/rpc/jsonrpc/otterscan_trace_transaction.go
@@ -91,8 +91,7 @@ func (t *TransactionTracer) OnEnter(depth int, typRaw byte, from common.Address,
 	typ := vm.OpCode(typRaw)
 	// t.captureStartOrEnter(vm.OpCode(typ), from, to, precompile, input, value)
 
-	inputCopy := make([]byte, len(input))
-	copy(inputCopy, input)
+	inputCopy := common.CopyBytes(input)
 	_value := new(big.Int)
 	_value.Set(value.ToBig())
 
@@ -134,7 +133,5 @@ func (t *TransactionTracer) OnExit(depth int, output []byte, gasUsed uint64, err
 	pop := t.stack[lastIdx]
 	t.stack = t.stack[:lastIdx]
 
-	outputCopy := make([]byte, len(output))
-	copy(outputCopy, output)
-	pop.Output = outputCopy
+	pop.Output = common.CopyBytes(output)
 }


### PR DESCRIPTION
Refactors byte slice copying in the Otterscan transaction tracer to use the existing `common.CopyBytes` utility function instead of manual allocation and copying.