### PR TITLE
vm: remove redundant fmt.Errorf wrapping in VMErrorFromErr

### DIFF
--- a/execution/vm/errors.go
+++ b/execution/vm/errors.go
@@ -118,7 +118,7 @@ func VMErrorFromErr(err error) error {
 	}
 
 	return &VMError{
-		error: fmt.Errorf("%w", err),
+		error: err,
 		code:  vmErrorCodeFromErr(err),
 	}
 }


### PR DESCRIPTION
Stop re-wrapping errors inside VMErrorFromErr, preserving the original error value and avoiding an extra allocation.