### PR TITLE
Improve `Msg.Discard` Error Handling to Prevent DoS

### DIFF
--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -357,7 +357,9 @@ func (p *Peer) readLoop(errc chan<- error) {
 func (p *Peer) handle(msg Msg) error {
 	switch {
 	case msg.Code == pingMsg:
-		msg.Discard()
+		if err := msg.Discard(); err != nil {
+			return NewPeerError(PeerErrorInvalidMessage, DiscNetworkError, err, "failed to discard ping payload")
+		}
 		select {
 		case p.pingRecv <- struct{}{}:
 		case <-p.closed:
@@ -372,7 +374,9 @@ func (p *Peer) handle(msg Msg) error {
 		return reason
 	case msg.Code < baseProtocolLength:
 		// ignore other base protocol messages
-		msg.Discard()
+		if err := msg.Discard(); err != nil {
+			return NewPeerError(PeerErrorInvalidMessage, DiscNetworkError, err, "failed to discard base protocol payload")
+		}
 		return nil
 	default:
 		// it's a subprotocol message

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -46,7 +46,9 @@ var discard = Protocol{
 				return NewPeerError(PeerErrorTest, DiscProtocolError, err, "peer_test: 'discard' protocol ReadMsg error")
 			}
 			fmt.Printf("discarding %d\n", msg.Code)
-			msg.Discard()
+			if err := msg.Discard(); err != nil {
+				return NewPeerError(PeerErrorInvalidMessage, DiscNetworkError, err, "peer_test: failed to discard message payload")
+			}
 		}
 	},
 }

--- a/p2p/sentry/eth_handshake.go
+++ b/p2p/sentry/eth_handshake.go
@@ -42,7 +42,9 @@ func readAndValidatePeerStatus[T StatusPacket](
 	if err != nil {
 		return zero, p2p.NewPeerError(p2p.PeerErrorStatusReceive, p2p.DiscNetworkError, err, "readAndValidatePeerStatus rw.ReadMsg error")
 	}
-	defer msg.Discard()
+	defer func() {
+		_ = msg.Discard()
+	}()
 	if msg.Code != eth.StatusMsg {
 		return zero, p2p.NewPeerError(p2p.PeerErrorStatusDecode, p2p.DiscProtocolError, fmt.Errorf("first msg has code %x (!= %x)", msg.Code, eth.StatusMsg), "readAndValidatePeerStatus wrong code")
 	}


### PR DESCRIPTION


## Description
- Refactored `Msg.Discard` to return errors instead of calling `log.Fatal`, avoiding node-wide crashes on malformed payloads.
- Propagated the new error contract through `p2p` consumers (peer handling, sentry handshake/server, tests) with precise diagnostics.
- Added formatting and ensured `go test ./p2p/...` passes to validate the change.