### PR TITLE
rpc/requests: correct TransactionHashes population in Block.UnmarshalJSON

### DIFF
--- a/rpc/requests/block.go
+++ b/rpc/requests/block.go
@@ -107,9 +107,9 @@ func (b *Block) UnmarshalJSON(input []byte) error {
 	b.Transactions = bd.Transactions
 
 	if bd.Transactions != nil {
-		b.TransactionHashes = make([]common.Hash, len(b.Transactions))
-		for _, t := range bd.Transactions {
-			b.TransactionHashes = append(b.TransactionHashes, t.Hash)
+		b.TransactionHashes = make([]common.Hash, len(bd.Transactions))
+		for i, t := range bd.Transactions {
+			b.TransactionHashes[i] = t.Hash
 		}
 	}
 


### PR DESCRIPTION
This change fixes an incorrect slice construction in rpc/requests/block.go within Block.UnmarshalJSON(), where TransactionHashes was preallocated with length and then appended to, producing a 2×n slice with leading zero hashes and causing an extra allocation. The fix preallocates the slice to the exact length of bd.Transactions and assigns by index, aligning with the Ethereum JSON-RPC expectation of a one-to-one mapping between returned transactions and their hashes and matching existing repository style where pre-sized slices are filled via index. This ensures correct data and avoids unnecessary allocations.