### PR TITLE
rlp: halt listIterator on parse error to avoid loops

### DIFF
--- a/execution/rlp/iterator.go
+++ b/execution/rlp/iterator.go
@@ -41,15 +41,24 @@ func NewListIterator(data RawValue) (*listIterator, error) {
 
 }
 
-// Next forwards the iterator one step, returns true if it was not at end yet
+// Next moves the iterator forward by one element.
+// It returns true if another item is available, or if this step hit a parse error (check Err()).
+// If a parse error happens, the iterator is closed and all future calls will return false.
 func (it *listIterator) Next() bool {
 	if len(it.data) == 0 {
 		return false
 	}
 	_, t, c, err := readKind(it.data)
+	if err != nil {
+		it.next = nil
+		it.err = err
+		// Mark the iterator as done so future Next calls won't loop endlessly.
+		it.data = nil
+		return true
+	}
 	it.next = it.data[:t+c]
 	it.data = it.data[t+c:]
-	it.err = err
+	it.err = nil
 	return true
 }
 


### PR DESCRIPTION
Previously, if a parse error occurred, the list iterator returned `true` without consuming input, which could cause callers to loop forever if they didn’t check `Err()`. This change updates `Next()` so that when `readKind` fails, the iterator is marked as done: it still returns `true` once to surface the error, and then `false` on all following calls. The function’s documentation has been revised to explain this behavior and emphasize that callers must check `Err()`.