### PR TITLE
refactor(rpc): improve error message formatting in txpool API test

### DIFF
--- a/rpc/jsonrpc/txpool_api_test.go
+++ b/rpc/jsonrpc/txpool_api_test.go
@@ -18,7 +18,7 @@ package jsonrpc
 
 import (
 	"bytes"
-	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/holiman/uint256"


### PR DESCRIPTION
Refactors the error message formatting in `txpool_api_test.go` to use, `strings.Join()` instead of redundant `fmt.Sprintf()` for string slice, formatting.