### PR TITLE
perf(common): eliminate unnecessary allocation in isHex

### DIFF
--- a/common/bytes.go
+++ b/common/bytes.go
@@ -91,8 +91,8 @@ func isHex(str string) bool {
 	if len(str)%2 != 0 {
 		return false
 	}
-	for _, c := range []byte(str) {
-		if !isHexCharacter(c) {
+	for i := 0; i < len(str); i++ {
+		if !isHexCharacter(str[i]) {
 			return false
 		}
 	}


### PR DESCRIPTION
Remove unnecessary byte slice allocation in `isHex` function by using direct string indexing instead of converting to `[ ]byte`.