### PR TITLE
Added benchmark test for random access history state of accounts

### DIFF
--- a/cmd/rpctest/main.go
+++ b/cmd/rpctest/main.go
@@ -56,6 +56,7 @@ func main() {
 		erigonURL        string
 		blockFrom        uint64
 		blockTo          uint64
+		randBlocks       uint64
 		latest           bool
 		recordFile       string
 		errorFile        string
@@ -72,6 +73,9 @@ func main() {
 	withBlockNum := func(cmd *cobra.Command) {
 		cmd.Flags().Uint64Var(&blockFrom, "blockFrom", 2000000, "Block number to start test generation from")
 		cmd.Flags().Uint64Var(&blockTo, "blockTo", 2101000, "Block number to end test generation at")
+	}
+	withRandBlockNum := func(cmd *cobra.Command) {
+		cmd.Flags().Uint64Var(&randBlocks, "randBlocks", 1000, "Number of random blocks to process")
 	}
 	withLatest := func(cmd *cobra.Command) {
 		cmd.Flags().BoolVar(&latest, "latest", false, "Exec on latest ")
@@ -504,6 +508,19 @@ func main() {
 	}
 	with(benchEthGetBalanceCmd, withErigonUrl, withGethUrl, withNeedCompare, withBlockNum)
 
+	var BenchEthGetBalanceRandomAccountCmd = &cobra.Command{
+		Use:   "benchEthGetBalanceRandomAccount",
+		Short: "",
+		Long:  ``,
+		Run: func(cmd *cobra.Command, args []string) {
+			err := rpctest.BenchEthGetBalanceRandomAccount(erigonURL, int(randBlocks))
+			if err != nil {
+				logger.Error(err.Error())
+			}
+		},
+	}
+	with(BenchEthGetBalanceRandomAccountCmd, withErigonUrl, withRandBlockNum)
+
 	var replayCmd = &cobra.Command{
 		Use:   "replay",
 		Short: "",
@@ -566,6 +583,7 @@ func main() {
 		benchTraceTransactionCmd,
 		benchEthBlockByNumberCmd,
 		benchEthGetBalanceCmd,
+		BenchEthGetBalanceRandomAccountCmd,
 		benchOtsGetBlockTransactions,
 		replayCmd,
 	)


### PR DESCRIPTION
This test iterates over N random blocks in history to select accounts, which are then used for eth_getBalance RPC calls.
```
./build/bin/rpctest benchEthGetBalanceRandomAccount --randBlocks=10000
```

For Sepolia (1.7 TB for the archive node and 82 GB for account history snapshots), it takes about **0.6–0.8 ms** per account on average. The fluctuations in average access speed (20-25% range) for the test are quite large, even when a large number of blocks are sampled with `--randBlocks`.

The access speed is influenced by the size of the snapshot files — for example, in the case of deduplication (which reduces the size by almost 1.5×), the average access time improves to about **0.5–0.6** ms per account.

Page-level compression (set to 16) did not produce any change in access speed, even though the snapshots became about 1.5x as small.