### PR TITLE
p2p/rlpx: grow writeBuffer.appendZero in-place to avoid extra allocations

### DIFF
--- a/p2p/rlpx/buffer.go
+++ b/p2p/rlpx/buffer.go
@@ -96,8 +96,17 @@ func (b *writeBuffer) reset() {
 
 func (b *writeBuffer) appendZero(n int) []byte {
 	offset := len(b.data)
+	newLen := offset + n
+	if cap(b.data) >= newLen {
+		// Grow in place and ensure the new region is zero-filled.
+		b.data = b.data[:newLen]
+		for i := offset; i < newLen; i++ {
+			b.data[i] = 0
+		}
+		return b.data[offset:newLen]
+	}
 	b.data = append(b.data, make([]byte, n)...)
-	return b.data[offset : offset+n]
+	return b.data[offset:newLen]
 }
 
 func (b *writeBuffer) Write(data []byte) (int, error) {


### PR DESCRIPTION
The previous implementation of writeBuffer.appendZero used append(b.data, make([]byte, n)...), which always allocated a temporary zero-filled slice and copied it into the buffer. This caused 1–2 small but steady allocations per written frame on the hot path (header and optional padding), and one larger allocation during the EIP-8 handshake padding. The call sites require the appended region to be zero-filled: the RLPx frame header’s trailing bytes must be zeros (only the first 6 bytes are overwritten by size and zeroHeader), the frame padding must be zeros to reach a 16-byte boundary, and EIP-8 requires a random amount of padding bytes whose contents are zeros. The change grows the slice in place when capacity permits, explicitly zeroing the newly exposed region to preserve semantics, and falls back to the existing allocate-and-append path otherwise. This maintains exact behavior while reducing unnecessary allocations and copies in writeFrame and sealEIP8, lowering GC pressure and CPU overhead without changing any external API or protocol behavior.