### PR TITLE
fix(rpchelper): enforce canonicality in GetCanonicalBlockNumber

### DIFF
--- a/rpc/rpchelper/helper.go
+++ b/rpc/rpchelper/helper.go
@@ -54,7 +54,7 @@ func GetBlockNumber(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash, tx
 }
 
 func GetCanonicalBlockNumber(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash, tx kv.Tx, br services.FullBlockReader, filters *Filters) (uint64, common.Hash, bool, error) {
-	bn, bh, latest, _, err := _GetBlockNumber(ctx, blockNrOrHash.RequireCanonical, blockNrOrHash, tx, br, filters)
+	bn, bh, latest, _, err := _GetBlockNumber(ctx, true, blockNrOrHash, tx, br, filters)
 	return bn, bh, latest, err
 }
 


### PR DESCRIPTION
This change makes GetCanonicalBlockNumber() always require canonical blocks by passing requireCanonical=true to _GetBlockNumber(). The function name and its call sites in the JSON-RPC layer rely on canonical-only behavior, for example eth_call and tracing paths explicitly assume non-canonical blocks are rejected. Tests around EIP-1898 semantics indicate that while requireCanonical defaults to false for the generic parameter format, several RPC methods in Erigon intentionally disallow operating on non-canonical blocks for correctness and consistency. Aligning the helper with its intended semantics removes ambiguity, prevents accidental acceptance of non-canonical hashes when callers expect canonical results, and matches the existing pattern where CreateStateReader enforces canonicality regardless of the incoming flag.