### PR TITLE
 remove dead snapshot integrity debug block

### DIFF
--- a/polygon/bridge/snapshot_integrity.go
+++ b/polygon/bridge/snapshot_integrity.go
@@ -9,7 +9,6 @@ import (
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/execution/chain"
-	"github.com/erigontech/erigon/execution/stagedsync/stages"
 	"github.com/erigontech/erigon/polygon/bor/borcfg"
 	polychain "github.com/erigontech/erigon/polygon/chain"
 	"github.com/erigontech/erigon/polygon/heimdall"
@@ -85,20 +84,6 @@ func ValidateBorEvents(ctx context.Context, db kv.TemporalRoDB, blockReader bloc
 
 	if db != nil {
 		err = db.View(ctx, func(tx kv.Tx) error {
-			if false {
-				lastEventId, err := NewSnapshotStore(NewTxStore(tx), snapshots, nil).LastEventId(ctx)
-				if err != nil {
-					return err
-				}
-
-				bodyProgress, err := stages.GetStageProgress(tx, stages.Bodies)
-				if err != nil {
-					return err
-				}
-
-				log.Info("[integrity] LAST Event", "event", lastEventId, "body-progress", bodyProgress)
-			}
-
 			return nil
 		})
 


### PR DESCRIPTION
drop the disabled `if false` block in `ValidateBorEvents`, eliminating unused snapshot and stage lookups. Remove the now-unused `stagedsync/stages` import from `snapshot_integrity.go`