### PR TITLE
replace ensureContext fallback with context.Background

### DIFF
--- a/execution/abi/bind/base.go
+++ b/execution/abi/bind/base.go
@@ -390,7 +390,7 @@ func (c *BoundContract) UnpackLogIntoMap(out map[string]interface{}, event strin
 // user specified it as such.
 func ensureContext(ctx context.Context) context.Context {
 	if ctx == nil {
-		return context.TODO()
+		return context.Background()
 	}
 	return ctx
 }


### PR DESCRIPTION
Replace the TODO marker with context.Background() when callers pass nil. Align helper with standard-library guidance and remove residual “unfinished” markers in production code. No behaviour change for contract bindings; all call sites keep receiving a non-nil context.