### PR TITLE
rpc/transactions: propagate AsMessage error in ComputeTxContext

### DIFF
--- a/rpc/transactions/tracing.go
+++ b/rpc/transactions/tracing.go
@@ -79,7 +79,10 @@ func ComputeBlockContext(ctx context.Context, engine rules.EngineReader, header 
 func ComputeTxContext(statedb *state.IntraBlockState, engine rules.EngineReader, rules *chain.Rules, signer *types.Signer, block *types.Block, cfg *chain.Config, txIndex int) (protocol.Message, evmtypes.TxContext, error) {
 	txn := block.Transactions()[txIndex]
 	statedb.SetTxContext(block.NumberU64(), txIndex)
-	msg, _ := txn.AsMessage(*signer, block.BaseFee(), rules)
+	msg, err := txn.AsMessage(*signer, block.BaseFee(), rules)
+	if err != nil {
+		return protocol.Message{}, evmtypes.TxContext{}, err
+	}
 	txContext := protocol.NewEVMTxContext(msg)
 	return msg, txContext, nil
 }


### PR DESCRIPTION
This change ensures ComputeTxContext correctly surfaces failures from txn.AsMessage (e.g., invalid signature or tx type not permitted by current fork rules) instead of proceeding with an invalid message and returning a nil error. Downstream consumers (e.g., jsonrpc tracing and otterscan tracing paths) already expect an error-returning ComputeTxContext and construct TxContext from a valid Message; by propagating the error we prevent building inconsistent EVM contexts (wrong Origin/GasPrice/BlobHashes) and align behavior with other call sites that properly check AsMessage errors like overlay_api and trace_worker. This is a correctness fix for tracing semantics and does not affect AA txs whose AsMessage does not error.