### PR TITLE
fix: Get(nil) fast-path and return correct first offset

### DIFF
--- a/db/state/bps_tree.go
+++ b/db/state/bps_tree.go
@@ -372,11 +372,11 @@ func (b *BpsTree) Get(g *seg.Reader, key []byte) (v []byte, ok bool, offset uint
 		fmt.Printf("get   %x\n", key)
 	}
 	if len(key) == 0 && b.offt.Count() > 0 {
-		k0, v0, _, err := b.dataLookupFunc(0, g)
-		if err != nil || k0 != nil {
+		_, v0, off0, err := b.dataLookupFunc(0, g)
+		if err != nil {
 			return nil, false, 0, err
 		}
-		return v0, true, 0, nil
+		return v0, true, off0, nil
 	}
 
 	n, l, r := b.bs(key) // l===r when key is found


### PR DESCRIPTION
BpsTree.Get(nil) incorrectly returned “not found” because the fast-path tested if err != nil || k0 != nil, which treats the presence of the first key as an error. This contradicts the function comment and the behavior of Seek(nil), both of which expect the first key to be returned when the key is empty. It also contradicts the dataLookup contract that a valid di returns a non-nil key/value. The fix removes the k0 != nil condition and returns the first record’s actual offset obtained from dataLookup. A new test asserts that Get(nil) returns found == true, the first key’s value, and the correct first offset, ensuring consistency with the index and preventing regressions.