### PR TITLE
db/snapshotsync: fix snap.download.to.block incorrect bodies view

### DIFF
--- a/db/snapshotsync/snapshotsync.go
+++ b/db/snapshotsync/snapshotsync.go
@@ -484,7 +484,6 @@ func SyncSnapshots(
 			}
 
 			if filterToBlock(p.Name, toBlock, toStep, headerchain) {
-				log.Debug("filtering to block", "name", p.Name, "toBlock", toBlock, "toStep", toStep)
 				continue
 			}
 


### PR DESCRIPTION
part of https://github.com/erigontech/erigon/issues/17711

fixes an issue that came up during testing of `--snap.download.to.block` functionality on chiado

after deleting the extra header and body files at the front in the 2nd pass after header chain we need to re-open the segments with `alignMin=false` otherwise the remainder of the code sees empty bodies (since only headers and bodies but no transaction segs are populated after the header chain sync pass) and causes wrong filtering of domain files as a result 