### PR TITLE
Remove redundant fmt.Sprintf balance formatting in blockgen test

### DIFF
--- a/execution/tests/blockgen/chain_makers_test.go
+++ b/execution/tests/blockgen/chain_makers_test.go
@@ -135,7 +135,7 @@ func TestGenerateChain(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if fmt.Sprintf("%s", &balance) != "19687500000000001000" { //nolint
+	if balance.String() != "19687500000000001000" { //nolint
 		t.Errorf("wrong balance of addr3: %s", &balance)
 	}
 


### PR DESCRIPTION
replace fmt.Sprintf("%s", &balance) with direct balance.String() comparison in TestGenerateChain, eliminating an unnecessary format call while preserving the exact decimal check
no behavioral change; solely removes redundant work in the test helper