### PR TITLE
Remove unused HalfCPUs helper from estimate package

### DIFF
--- a/common/estimate/esitmated_ram.go
+++ b/common/estimate/esitmated_ram.go
@@ -64,6 +64,4 @@ const (
 func AlmostAllCPUs() int {
 	return max(1, runtime.GOMAXPROCS(-1)-1)
 }
-func HalfCPUs() int {
-	return max(1, runtime.GOMAXPROCS(-1)/2)
-}
+


### PR DESCRIPTION
delete the dead HalfCPUs() helper in common/estimate/esitmated_ram.go, keep the API surface minimal; AlmostAllCPUs() remains the single exported CPU helper