### PR TITLE
Remove deprecated hashed StateCache helpers

### DIFF
--- a/node/shards/state_cache.go
+++ b/node/shards/state_cache.go
@@ -577,15 +577,7 @@ func (sc *StateCache) SetAccountRead(address []byte, account *accounts.Account) 
 	h.Sha.Read(ai.addrHash[:])
 	ai.account.Copy(account)
 	sc.setRead(&ai, false /* absent */)
-}
-
-// hack to set hashed addr - we don't have another one in trie stage
-func (sc *StateCache) DeprecatedSetAccountRead(addrHash common.Hash, account *accounts.Account) {
-	var ai AccountItem
-	ai.addrHash.SetBytes(addrHash.Bytes())
-	ai.account.Copy(account)
-	sc.setRead(&ai, false /* absent */)
-}
+}	
 
 func (sc *StateCache) GetAccountByHashedAddress(addrHash common.Hash) (*accounts.Account, bool) {
 	var key AccountItem
@@ -744,59 +736,6 @@ func (sc *StateCache) SetStorageRead(address []byte, incarnation uint64, locatio
 	sc.setRead(&si, false /* absent */)
 }
 
-// hack to set hashed addr - we don't have another one in trie stage
-func (sc *StateCache) DeprecatedSetStorageRead(addrHash common.Hash, incarnation uint64, locHash common.Hash, val []byte) {
-	var i StorageItem
-	h := common.NewHasher()
-	defer common.ReturnHasherToPool(h)
-	copy(i.addrHash[:], addrHash.Bytes())
-	i.incarnation = incarnation
-	i.locHash.SetBytes(locHash.Bytes())
-	i.value.SetBytes(val)
-	sc.setRead(&i, false /* absent */)
-}
-
-// hack to set hashed addr - we don't have another one in trie stage
-func (sc *StateCache) DeprecatedSetAccountWrite(addrHash common.Hash, account *accounts.Account) {
-	var ai AccountItem
-	copy(ai.addrHash[:], addrHash.Bytes())
-	ai.account.Copy(account)
-	var awi AccountWriteItem
-	awi.ai = &ai
-	sc.setWrite(&ai, &awi, false /* delete */)
-}
-
-// hack to set hashed addr - we don't have another one in trie stage
-func (sc *StateCache) DeprecatedSetAccountDelete(addrHash common.Hash) {
-	var ai AccountItem
-	copy(ai.addrHash[:], addrHash.Bytes())
-	var awi AccountWriteItem
-	awi.ai = &ai
-	sc.setWrite(&ai, &awi, true /* delete */)
-}
-
-// hack to set hashed addr - we don't have another one in trie stage
-func (sc *StateCache) DeprecatedSetStorageDelete(addrHash common.Hash, incarnation uint64, locHash common.Hash) {
-	var si StorageItem
-	copy(si.addrHash[:], addrHash.Bytes())
-	si.incarnation = incarnation
-	copy(si.locHash[:], locHash.Bytes())
-	var swi StorageWriteItem
-	swi.si = &si
-	sc.setWrite(&si, &swi, true /* delete */)
-}
-
-// hack to set hashed addr - we don't have another one in trie stage
-func (sc *StateCache) DeprecatedSetStorageWrite(addrHash common.Hash, incarnation uint64, locHash common.Hash, v []byte) {
-	var si StorageItem
-	copy(si.addrHash[:], addrHash.Bytes())
-	si.incarnation = incarnation
-	copy(si.locHash[:], locHash.Bytes())
-	si.value.SetBytes(v)
-	var swi StorageWriteItem
-	swi.si = &si
-	sc.setWrite(&si, &swi, false /* delete */)
-}
 
 func (sc *StateCache) SetStorageAbsent(address []byte, incarnation uint64, location []byte) {
 	var si StorageItem


### PR DESCRIPTION
delete the six DeprecatedSet* cache helpers that were never referenced in the repo, rely on the existing SetAccount*/SetStorage* APIs plus hashed accessors (GetAccountByHashedAddress, etc.), keep the cache surface lean so reviewers don’t trip over unused “hack” entry points