### PR TITLE
remove unused ReportQueue code and dead imports

### DIFF
--- a/execution/protocol/rules/aura/validators.go
+++ b/execution/protocol/rules/aura/validators.go
@@ -17,14 +17,11 @@
 package aura
 
 import (
-	"container/list"
 	"errors"
 	"fmt"
 	"math"
 	"sort"
 	"strings"
-	"sync"
-	"sync/atomic"
 
 	lru "github.com/hashicorp/golang-lru/v2"
 
@@ -35,7 +32,6 @@ import (
 	"github.com/erigontech/erigon/execution/abi/bind"
 	"github.com/erigontech/erigon/execution/protocol/rules"
 	"github.com/erigontech/erigon/execution/protocol/rules/aura/auraabi"
-	"github.com/erigontech/erigon/execution/protocol/rules/aura/aurainterfaces"
 	"github.com/erigontech/erigon/execution/rlp"
 	"github.com/erigontech/erigon/execution/types"
 )
@@ -353,85 +349,11 @@ func NewSimpleList(validators []common.Address) *SimpleList {
 	return &SimpleList{validators: validators}
 }
 
-// nolint
-type ReportQueueItem struct {
-	addr     common.Address
-	blockNum uint64
-	data     []byte
-}
-
-// nolint
-type ReportQueue struct {
-	mu   sync.RWMutex
-	list *list.List
-}
-
-// nolint
-func (q *ReportQueue) push(addr common.Address, blockNum uint64, data []byte) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.list.PushBack(&ReportQueueItem{addr: addr, blockNum: blockNum, data: data})
-}
-
-// Filters reports of validators that have already been reported or are banned.
-// nolint
-func (q *ReportQueue) filter(abi aurainterfaces.ValidatorSetABI, client client, ourAddr, contractAddr common.Address) error {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	for e := q.list.Front(); e != nil; e = e.Next() {
-		el := e.Value.(*ReportQueueItem)
-		// Check if the validator should be reported.
-		maliciousValidatorAddress := el.addr
-		data, decoder := abi.ShouldValidatorReport(ourAddr, maliciousValidatorAddress, el.blockNum)
-		res, err := client.CallAtLatestBlock(contractAddr, data)
-		if err != nil {
-			return err
-		}
-		if res.execError != "" {
-			log.Warn("Failed to query report status, dropping pending report.", "reason", res.execError)
-			continue
-		}
-		var shouldReport bool
-		err = decoder(res.data, &res)
-		if err != nil {
-			return err
-		}
-		if !shouldReport {
-			q.list.Remove(e)
-		}
-	}
-	return nil
-}
-
-// Removes reports from the queue if it contains more than `MAX_QUEUED_REPORTS` entries.
-// nolint
-func (q *ReportQueue) truncate() {
-	// The maximum number of reports to keep queued.
-	const MaxQueuedReports = 10
-
-	q.mu.RLock()
-	defer q.mu.RUnlock()
-	// Removes reports from the queue if it contains more than `MAX_QUEUED_REPORTS` entries.
-	if q.list.Len() > MaxQueuedReports {
-		log.Warn("Removing reports from report cache, even though it has not been finalized", "amount", q.list.Len()-MaxQueuedReports)
-	}
-	i := 0
-	for e := q.list.Front(); e != nil; e = e.Next() {
-		if i > MaxQueuedReports {
-			q.list.Remove(e)
-		}
-		i++
-	}
-}
-
 // The validator contract should have the following interface:
 // nolint
 type ValidatorSafeContract struct {
 	contractAddress common.Address
 	validators      *lru.Cache[common.Hash, *SimpleList] // RwLock<MemoryLruCache<H256, SimpleList>>,
-	reportQueue     ReportQueue                          //Mutex<ReportQueue>,
-	// The block number where we resent the queued reports last time.
-	resentReportsInBlock atomic.Uint64
 	// If set, this is the block number at which the rules engine switches from AuRa to AuRa
 	// with POSDAO modifications.
 	posdaoTransition *uint64


### PR DESCRIPTION
Removes 78 lines of dead code from `validators.go` that was hidden behind `// nolint` directives.