### PR TITLE
Revert "Remove duplicates from AccHistory and StorageHistory"

### DIFF
--- a/db/kv/kvcache/cache_test.go
+++ b/db/kv/kvcache/cache_test.go
@@ -171,7 +171,6 @@ func TestEviction(t *testing.T) {
 }
 
 func TestAPI(t *testing.T) {
-	t.Skip()
 	require := require.New(t)
 
 	// Create a context with timeout for the entire test

--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -357,6 +357,7 @@ func (sd *SharedDomains) DomainPut(domain kv.Domain, roTx kv.TemporalTx, k, v []
 		return fmt.Errorf("DomainPut: %s, trying to put nil value. not allowed", domain)
 	}
 	ks := string(k)
+	sd.sdCtx.TouchKey(domain, ks, v)
 
 	if prevVal == nil {
 		var err error
@@ -366,19 +367,17 @@ func (sd *SharedDomains) DomainPut(domain kv.Domain, roTx kv.TemporalTx, k, v []
 		}
 	}
 	switch domain {
-	case kv.CodeDomain, kv.AccountsDomain, kv.StorageDomain:
+	case kv.CodeDomain:
 		if bytes.Equal(prevVal, v) {
 			return nil
 		}
-	case kv.RCacheDomain, kv.CommitmentDomain:
+	case kv.StorageDomain, kv.AccountsDomain, kv.CommitmentDomain, kv.RCacheDomain:
 		//noop
 	default:
 		if bytes.Equal(prevVal, v) {
 			return nil
 		}
 	}
-	sd.sdCtx.TouchKey(domain, ks, v)
-
 	return sd.mem.DomainPut(domain, ks, v, txNum, prevVal, prevStep)
 }
 

--- a/rpc/jsonrpc/debug_api_test.go
+++ b/rpc/jsonrpc/debug_api_test.go
@@ -383,7 +383,7 @@ func TestGetModifiedAccountsByNumber(t *testing.T) {
 		n, n2 = rpc.BlockNumber(5), rpc.BlockNumber(8)
 		result, err = api.GetModifiedAccountsByNumber(m.Ctx, n, &n2)
 		require.NoError(t, err)
-		require.Len(t, result, 37)
+		require.Len(t, result, 38)
 
 		n, n2 = rpc.BlockNumber(0), rpc.BlockNumber(10)
 		result, err = api.GetModifiedAccountsByNumber(m.Ctx, n, &n2)


### PR DESCRIPTION
Reverts erigontech/erigon#17962

<@525860938360815626> : Mike prepared a DB with commitments enabled for historical eth_getProof() verifications.
Upon executing the historical tests, we observed that the state root calculation failed for few tests with postState and so verification of receiptsRoot(the calculated receipt root doesn't match block.receiptRoot).
Previously, even when running the Hive tests (with commitment enabled), the state root calculation was correct.
By bisecting the commits, we identified that the failure was introduced after the merge of PR #17962.
PR #18108 enables historical tests with Erigon commitments and inserts two calls to TouchKey() in DomainPut(). This addition resolves the failed state root calculation and the verification of the receipts root.
Since I am not an expert in this specific code component, could you please verify if this is the correct fix?