### PR TITLE
rpc/debug: fix log memory limit format

### DIFF
--- a/rpc/jsonrpc/debug_api.go
+++ b/rpc/jsonrpc/debug_api.go
@@ -617,6 +617,6 @@ func (api *DebugAPIImpl) SetGCPercent(v int) int {
 //   - Geth also allocates memory off-heap, particularly for fastCache and Pebble,
 //     which can be non-trivial (a few gigabytes by default).
 func (api *DebugAPIImpl) SetMemoryLimit(limit int64) int64 {
-	log.Info("Setting memory limit", "size", common.PrettyDuration(limit))
+	log.Info("Setting memory limit", "size", common.StorageSize(limit))
 	return debug.SetMemoryLimit(limit)
 }


### PR DESCRIPTION
Changed the `SetMemoryLimit` log to use `StorageSize` instead of `PrettyDuration`, so the memory limit is shown in bytes. This fixes the confusing logs that previously showed the limit as “seconds” after GOMEMLIMIT was modified.