### PR TITLE
refactor: use reflect.TypeFor

### DIFF
--- a/execution/abi/reflect_test.go
+++ b/execution/abi/reflect_test.go
@@ -204,12 +204,12 @@ func TestConvertType(t *testing.T) {
 	var fields []reflect.StructField
 	fields = append(fields, reflect.StructField{
 		Name: "X",
-		Type: reflect.TypeOf(new(big.Int)),
+		Type: reflect.TypeFor[*big.Int](),
 		Tag:  "json:\"" + "x" + "\"",
 	})
 	fields = append(fields, reflect.StructField{
 		Name: "Y",
-		Type: reflect.TypeOf(new(big.Int)),
+		Type: reflect.TypeFor[*big.Int](),
 		Tag:  "json:\"" + "y" + "\"",
 	})
 	val := reflect.New(reflect.StructOf(fields))

--- a/execution/abi/type_test.go
+++ b/execution/abi/type_test.go
@@ -98,13 +98,13 @@ func TestTypeRegexp(t *testing.T) {
 		// {"fixed[2]", nil, Type{}},
 		// {"fixed128x128[]", nil, Type{}},
 		// {"fixed128x128[2]", nil, Type{}},
-		{"tuple", []ArgumentMarshaling{{Name: "a", Type: "int64"}}, Type{T: TupleTy, TupleType: reflect.TypeOf(struct {
-			A int64 `json:"a"`
-		}{}), stringKind: "(int64)",
+		{"tuple", []ArgumentMarshaling{{Name: "a", Type: "int64"}}, Type{T: TupleTy, TupleType: reflect.TypeFor[struct {
+			A int64 "json:\"a\""
+		}](), stringKind: "(int64)",
 			TupleElems: []*Type{{T: IntTy, Size: 64, stringKind: "int64"}}, TupleRawNames: []string{"a"}}},
-		{"tuple with long name", []ArgumentMarshaling{{Name: "aTypicalParamName", Type: "int64"}}, Type{T: TupleTy, TupleType: reflect.TypeOf(struct {
-			ATypicalParamName int64 `json:"aTypicalParamName"`
-		}{}), stringKind: "(int64)",
+		{"tuple with long name", []ArgumentMarshaling{{Name: "aTypicalParamName", Type: "int64"}}, Type{T: TupleTy, TupleType: reflect.TypeFor[struct {
+			ATypicalParamName int64 "json:\"aTypicalParamName\""
+		}](), stringKind: "(int64)",
 			TupleElems: []*Type{{T: IntTy, Size: 64, stringKind: "int64"}}, TupleRawNames: []string{"aTypicalParamName"}}},
 	}
 
@@ -315,9 +315,9 @@ func TestInternalType(t *testing.T) {
 	internalType := "struct a.b[]"
 	kind := Type{
 		T: TupleTy,
-		TupleType: reflect.TypeOf(struct {
-			A int64 `json:"a"`
-		}{}),
+		TupleType: reflect.TypeFor[struct {
+			A int64 "json:\"a\""
+		}](),
 		stringKind:    "(int64)",
 		TupleRawName:  "ab[]",
 		TupleElems:    []*Type{{T: IntTy, Size: 64, stringKind: "int64"}},

--- a/execution/rlp/decode.go
+++ b/execution/rlp/decode.go
@@ -203,7 +203,7 @@ func addErrorContext(err error, ctx string) error {
 }
 
 var (
-	decoderInterface = reflect.TypeOf(new(Decoder)).Elem()
+	decoderInterface = reflect.TypeFor[Decoder]()
 	bigInt           = reflect.TypeFor[big.Int]()
 	uint256Int       = reflect.TypeFor[uint256.Int]()
 )
@@ -578,7 +578,7 @@ func makeNilPtrDecoder(etype reflect.Type, etypeinfo *typeinfo, nilKind Kind) de
 	}
 }
 
-var ifsliceType = reflect.TypeOf([]interface{}{})
+var ifsliceType = reflect.TypeFor[[]interface{}]()
 
 func decodeInterface(s *Stream, val reflect.Value) error {
 	if val.Type().NumMethod() != 0 {

--- a/execution/rlp/encode.go
+++ b/execution/rlp/encode.go
@@ -153,7 +153,7 @@ func puthead(buf []byte, smalltag, largetag byte, size uint64) int {
 	return sizesize + 1
 }
 
-var encoderInterface = reflect.TypeOf(new(Encoder)).Elem()
+var encoderInterface = reflect.TypeFor[Encoder]()
 
 // makeWriter creates a writer function for the given type.
 func makeWriter(typ reflect.Type, ts tags) (writer, error) {

--- a/p2p/event/feed_test.go
+++ b/p2p/event/feed_test.go
@@ -49,7 +49,7 @@ func TestFeedPanics(t *testing.T) {
 	{
 		var f Feed
 		f.Send(2)
-		want := feedTypeError{op: "Subscribe", got: reflect.TypeOf(make(chan uint64)), want: reflect.TypeOf(make(chan<- int))}
+		want := feedTypeError{op: "Subscribe", got: reflect.TypeFor[chan uint64](), want: reflect.TypeFor[chan<- int]()}
 		if err := checkPanic(want, func() { f.Subscribe(make(chan uint64)) }); err != nil {
 			t.Error(err)
 		}

--- a/p2p/forkid/forkid.go
+++ b/p2p/forkid/forkid.go
@@ -229,7 +229,7 @@ func GatherForks(config *chain.Config, genesisTime uint64) (heightForks []uint64
 			}
 			time = true
 		}
-		if field.Type != reflect.TypeOf(new(big.Int)) {
+		if field.Type != reflect.TypeFor[*big.Int]() {
 			continue
 		}
 		// Extract the fork rule block number and aggregate it


### PR DESCRIPTION


Try to use better api reflect.TypeFor instead of reflect.TypeOf when we have known the type.
More info https://github.com/golang/go/issues/60088

Similar as https://github.com/erigontech/erigon/pull/17347