### PR TITLE
fix(txpool): remove double PopWorst() in pending pool overflow

### DIFF
--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -2154,7 +2154,7 @@ func (p *TxPool) promote(pendingBaseFee uint64, pendingBlobFee uint64, announcem
 	// Discard worst transactions from pending pool until it is within capacity limit
 	for p.pending.Len() > p.pending.limit {
 		tx := p.pending.PopWorst()
-		p.discardLocked(p.pending.PopWorst(), txpoolcfg.PendingPoolOverflow)
+		p.discardLocked(tx, txpoolcfg.PendingPoolOverflow)
 		sendChangeBatchEventToDiagnostics("Pending", "remove", []diaglib.TxnHashOrder{
 			{
 				OrderMarker: uint8(tx.subPool),


### PR DESCRIPTION
PopWorst() called twice per loop iteration when pending pool exceeds limit.
First tx leaks, second gets discarded. Copy-paste mistake from diagnostics commit 53dc6c7e977 - baseFee and queued were fixed to use tx variable, pending was missed.