### PR TITLE
Remove unwanted call tracing

### DIFF
--- a/rpc/transactions/call.go
+++ b/rpc/transactions/call.go
@@ -27,7 +27,6 @@ import (
 	"github.com/holiman/uint256"
 
 	"github.com/erigontech/erigon/common"
-	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
@@ -288,9 +287,6 @@ func (r *ReusableCaller) DoCallWithNewGas(
 
 	gp := new(protocol.GasPool).AddGas(r.message.Gas()).AddBlobGas(r.message.BlobGas())
 
-	dbg.TraceInstructions = true
-	dbg.TraceTransactionIO = true
-	r.evm.IntraBlockState().SetTrace(true)
 	result, err := protocol.ApplyMessage(r.evm, r.message, gp, true /* refunds */, false /* gasBailout */, engine)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Removes unwanted debug traces from 

```
func (r *ReusableCaller) DoCallWithNewGas
```