### PR TITLE
fix(rlp): remove duplicate ErrCanonInt check

### DIFF
--- a/execution/rlp/decode.go
+++ b/execution/rlp/decode.go
@@ -69,7 +69,6 @@ func IsInvalidRLPError(err error) bool {
 	return errors.Is(err, ErrExpectedString) ||
 		errors.Is(err, ErrExpectedList) ||
 		errors.Is(err, ErrCanonInt) ||
-		errors.Is(err, ErrCanonInt) ||
 		errors.Is(err, ErrCanonSize) ||
 		errors.Is(err, ErrElemTooLarge) ||
 		errors.Is(err, ErrValueTooLarge) ||


### PR DESCRIPTION
Removed a duplicated ErrCanonInt condition in IsInvalidRLPError. This was an accidental duplication with no behavioral impact. Keeping a single check reduces noise and avoids confusion for maintainers while preserving the intended set of invalid RLP classifications used by peer penalization paths.