### PR TITLE
cl/beacon: add single_attestation event topic support

### DIFF
--- a/cl/beacon/beaconevents/model.go
+++ b/cl/beacon/beaconevents/model.go
@@ -17,6 +17,7 @@ type EventTopic string
 // Operation event topics
 const (
 	OpAttestation       EventTopic = "attestation"
+	OpSingleAttestation EventTopic = "single_attestation"
 	OpVoluntaryExit     EventTopic = "voluntary_exit"
 	OpProposerSlashing  EventTopic = "proposer_slashing"
 	OpAttesterSlashing  EventTopic = "attester_slashing"

--- a/cl/beacon/beaconevents/operation_feed.go
+++ b/cl/beacon/beaconevents/operation_feed.go
@@ -25,7 +25,7 @@ func (f *operationFeed) SendAttestation(value *AttestationData) int {
 
 func (f *operationFeed) SendSingleAttestation(value *SingleAttestationData) int {
 	return f.feed.Send(&EventStream{
-		Event: OpAttestation,
+		Event: OpSingleAttestation,
 		Data:  value,
 	})
 }

--- a/cl/beacon/handler/events.go
+++ b/cl/beacon/handler/events.go
@@ -33,6 +33,7 @@ import (
 var validTopics = map[event.EventTopic]struct{}{
 	// operation events
 	event.OpAttestation:       {},
+	event.OpSingleAttestation: {},
 	event.OpAttesterSlashing:  {},
 	event.OpBlobSidecar:       {},
 	event.OpDataColumnSidecar: {},


### PR DESCRIPTION
This PR fixes the Beacon API events endpoint to publish SingleAttestation objects (introduced in Electra) under the `single_attestation` topic instead of `attestation`.

Currently, Caplin publishes all attestations under the `attestation` topic, regardless of whether they are pre-Electra `Attestation` objects or post-Electra `SingleAttestation` objects. 

**References:**
- https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/p2p-interface.md#beacon_attestation_subnet_id
- https://github.com/ethereum/beacon-APIs/blob/master/apis/eventstream/index.yaml#L71
- https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#singleattestation

**For context:**

We'd love to see this added. We have some contributoors pushing to the ethPandaOps Xatu dataset using Caplin - but we're not capturing attestations because of it. **For example:** https://lab.ethpandaops.io/xatu/contributors/abstractdrank74#attestation-latency