### PR TITLE
Remove extra --chain flag to snapshots reset

### DIFF
--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -277,7 +277,6 @@ var snapshotCommand = cli.Command{
 			// parent commands.
 			Flags: []cli.Flag{
 				&utils.DataDirFlag,
-				&utils.ChainFlag,
 				&dryRunFlag,
 				&removeLocalFlag,
 			},


### PR DESCRIPTION
It works for datadir because of a specially implemented flag type, but chain does not use the same thing. As a result, if you pass --chain before snapshots reset, it is silently ignored and you risk resetting to the wrong chain.

urfave/cli@v3 added interspersed flags for this, but we are on v2. I previously made a change to make it work as expected for datadir but didn't test chain.

If you run with `erigon --chain=chiado snapshots reset`, and then `erigon snapshots reset --chain=chiado` on the current code, you will see it resets using mainnet (the default) instead of chiado for the first example. However with `--datadir` before and after, it does the right thing.

I think the safer option is to not allow passing it in the wrong position for now and fix it properly at some point (or just keep it that way, or upgrade to urfave/cli@v3).