### PR TITLE
fix(state): correct (TxIndex, Incarnation) ordering in refreshVersionedAccount

### DIFF
--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -901,7 +901,7 @@ func (sdb *IntraBlockState) refreshVersionedAccount(addr accounts.Address, readA
 	if err != nil {
 		return nil, UnknownSource, UnknownVersion, err
 	}
-	if bversion.TxIndex >= readVersion.TxIndex {
+	if bversion.TxIndex > readVersion.TxIndex || (bversion.TxIndex == readVersion.TxIndex && bversion.Incarnation >= readVersion.Incarnation) {
 		if balance.Cmp(&account.Balance) != 0 {
 			if account == readAccount {
 				account = &accounts.Account{}
@@ -909,7 +909,7 @@ func (sdb *IntraBlockState) refreshVersionedAccount(addr accounts.Address, readA
 			}
 			account.Balance = balance
 		}
-		if bversion.TxIndex > version.TxIndex || (bversion.TxIndex > version.TxIndex && bversion.Incarnation > version.Incarnation) {
+		if bversion.TxIndex > version.TxIndex || (bversion.TxIndex == version.TxIndex && bversion.Incarnation > version.Incarnation) {
 			version = bversion
 			if bsource != source {
 				source = bsource
@@ -921,7 +921,7 @@ func (sdb *IntraBlockState) refreshVersionedAccount(addr accounts.Address, readA
 	if err != nil {
 		return nil, UnknownSource, UnknownVersion, err
 	}
-	if nversion.TxIndex >= readVersion.TxIndex {
+	if nversion.TxIndex > readVersion.TxIndex || (nversion.TxIndex == readVersion.TxIndex && nversion.Incarnation >= readVersion.Incarnation) {
 		if nonce > account.Nonce {
 			if account == readAccount {
 				account = &accounts.Account{}
@@ -929,7 +929,7 @@ func (sdb *IntraBlockState) refreshVersionedAccount(addr accounts.Address, readA
 			}
 			account.Nonce = nonce
 		}
-		if nversion.TxIndex > version.TxIndex || (nversion.TxIndex > version.TxIndex && nversion.Incarnation > version.Incarnation) {
+		if nversion.TxIndex > version.TxIndex || (nversion.TxIndex == version.TxIndex && nversion.Incarnation > version.Incarnation) {
 			version = nversion
 			if nsource != source {
 				source = nsource
@@ -942,7 +942,7 @@ func (sdb *IntraBlockState) refreshVersionedAccount(addr accounts.Address, readA
 		return nil, UnknownSource, UnknownVersion, err
 	}
 
-	if cversion.TxIndex >= readVersion.TxIndex {
+	if cversion.TxIndex > readVersion.TxIndex || (cversion.TxIndex == readVersion.TxIndex && cversion.Incarnation >= readVersion.Incarnation) {
 		if codeHash != account.CodeHash {
 			if account == readAccount {
 				account = &accounts.Account{}
@@ -950,7 +950,7 @@ func (sdb *IntraBlockState) refreshVersionedAccount(addr accounts.Address, readA
 			}
 			account.CodeHash = codeHash
 		}
-		if cversion.TxIndex > version.TxIndex || (cversion.TxIndex > version.TxIndex && cversion.Incarnation > version.Incarnation) {
+		if cversion.TxIndex > version.TxIndex || (cversion.TxIndex == version.TxIndex && cversion.Incarnation > version.Incarnation) {
 			version = cversion
 			if csource != source {
 				source = csource


### PR DESCRIPTION
The previous logic mistakenly used > in both sides of a disjunction for TxIndex, which ignored cases where TxIndex was equal and Incarnation was higher. This led to stale composite versions and could cause spurious invalidations under parallel execution.
This aligns with VersionMap semantics and validation in execution/stagedsync/exec3_parallel.go, where correctness depends on treating (TxIndex, Incarnation) as the version identity/order.