### PR TITLE
qa-tests: update tip-tracking workflow to follow the new version 

### DIFF
--- a/.github/workflows/qa-tip-tracking-gnosis.yml
+++ b/.github/workflows/qa-tip-tracking-gnosis.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: [self-hosted, qa, Gnosis, tip-tracking]
     timeout-minutes: 1200
     env:
-      ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version-3.2/datadir
+      ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version-3.3/datadir
       ERIGON_TESTBED_DATA_DIR: /opt/erigon-testbed/datadir
       ERIGON_QA_PATH: /home/qarunner/erigon-qa
       TRACKING_TIME_SECONDS: 7200 # 2 hours

--- a/.github/workflows/qa-tip-tracking.yml
+++ b/.github/workflows/qa-tip-tracking.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: [self-hosted, qa, Ethereum, tip-tracking]
     timeout-minutes: 1300 # 21.66667 hours
     env:
-      ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version-3.2/datadir
+      ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version-3.3/datadir
       ERIGON_TESTBED_DATA_DIR: /opt/erigon-testbed/datadir
       ERIGON_QA_PATH: /home/qarunner/erigon-qa
       TRACKING_TIME_SECONDS: 7200 # 2 hours


### PR DESCRIPTION
The tip-tracking test includes an upgrade step. Now that version 3.3 has been released and the main branch is preparing version 3.4, the test must require a v3.3 version database.