### PR TITLE
execution/stagedsync: tidy unnecessary leftover debug logging in 2 tests

### DIFF
--- a/execution/stagedsync/stage_custom_trace_test.go
+++ b/execution/stagedsync/stage_custom_trace_test.go
@@ -18,7 +18,6 @@ package stagedsync_test
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -36,7 +35,6 @@ func TestCustomTraceReceiptDomain(t *testing.T) {
 	assert := assert.New(t)
 	ctx := context.Background()
 
-	os.Setenv("MOCK_SENTRY_LOG_LEVEL", "info")
 	m, _, _ := rpcdaemontest.CreateTestSentry(t)
 
 	stageCfg := stagedsync.StageCustomTraceCfg([]string{"receipt"}, m.DB, m.Dirs, m.BlockReader, m.ChainConfig, m.Engine, m.Cfg().Genesis, m.Cfg().Sync)
@@ -91,7 +89,6 @@ func TestCustomTraceDomainProgressConsistency(t *testing.T) {
 	assert := assert.New(t)
 	ctx := context.Background()
 
-	os.Setenv("MOCK_SENTRY_LOG_LEVEL", "info")
 	m, _, _ := rpcdaemontest.CreateTestSentry(t)
 
 	require.NoError(m.DB.Update(m.Ctx, func(tx kv.RwTx) error {


### PR DESCRIPTION
cleaning up debug leftovers from a previous pr