### PR TITLE
[3.3] Torrent client fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/anacrolix/go-libutp v1.3.2
 	github.com/anacrolix/log v0.17.1-0.20251118025802-918f1157b7bb
 	github.com/anacrolix/missinggo/v2 v2.10.0
-	github.com/anacrolix/torrent v1.59.2-0.20251119114223-afe9ca172f7f
+	github.com/anacrolix/torrent v1.59.2-0.20251205045338-b2eefa0c4346
 	github.com/benesch/cgosymbolizer v0.0.0-20190515212042-bec6fe6e597b
 	github.com/c2h5oh/datasize v0.0.0-20231215233829-aa82cc1e6500
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,8 @@ github.com/anacrolix/sync v0.5.5-0.20251119100342-d78dd1f686f1/go.mod h1:21cUWer
 github.com/anacrolix/tagflag v0.0.0-20180109131632-2146c8d41bf0/go.mod h1:1m2U/K6ZT+JZG0+bdMK6qauP49QT4wE5pmhJXOKKCHw=
 github.com/anacrolix/tagflag v1.0.0/go.mod h1:1m2U/K6ZT+JZG0+bdMK6qauP49QT4wE5pmhJXOKKCHw=
 github.com/anacrolix/tagflag v1.1.0/go.mod h1:Scxs9CV10NQatSmbyjqmqmeQNwGzlNe0CMUMIxqHIG8=
-github.com/anacrolix/torrent v1.59.2-0.20251119114223-afe9ca172f7f h1:flif7SWg0eGGu1QwqzIdgUeYtIk6XRmGn5K2HNl7DHk=
-github.com/anacrolix/torrent v1.59.2-0.20251119114223-afe9ca172f7f/go.mod h1:tAKR6fnCaTDIVsri9k8549Q4lFR4EiWSfmBVlU2AtNU=
+github.com/anacrolix/torrent v1.59.2-0.20251205045338-b2eefa0c4346 h1:SnBZGXl9fQJmXKemZVsEB4ERHK6djrM86wW90cTST9E=
+github.com/anacrolix/torrent v1.59.2-0.20251205045338-b2eefa0c4346/go.mod h1:BWy89pugMV1NcfJEvyYw7iztb/w7pTshbMfgE2qqMH4=
 github.com/anacrolix/upnp v0.1.4 h1:+2t2KA6QOhm/49zeNyeVwDu1ZYS9dB9wfxyVvh/wk7U=
 github.com/anacrolix/upnp v0.1.4/go.mod h1:Qyhbqo69gwNWvEk1xNTXsS5j7hMHef9hdr984+9fIic=
 github.com/anacrolix/utp v0.1.0 h1:FOpQOmIwYsnENnz7tAGohA+r6iXpRjrq8ssKSre2Cp4=


### PR DESCRIPTION
Pulls minimal fix for thrashing in the announce code caused when there's a lot of already completed torrents added.

Should fix https://github.com/erigontech/erigon-qa/issues/320 and https://github.com/erigontech/erigon/issues/18162.

Also fixes a rate limiter bug I mentioned to @AskAlexSharov, and an ancient spammy log line.

I minimized the fix identified on the development branch of anacrolix/torrent, if this isn't enough I can just pull the full fix. The 3.3 changes: https://github.com/anacrolix/torrent/compare/downstreams/erigon/release/3.3...erigon/release/3.3?expand=1.