### PR TITLE
hive: new rpc-compat tests added, bump allowed failures to 12

### DIFF
--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -3,13 +3,13 @@ name: Test Hive
 on:
   push:
     branches:
-        - main
-        - 'release/**'
+      - main
+      - 'release/**'
   schedule:
     - cron: "0 05 * * *" # daily at 5 am UTC
   workflow_dispatch:
 
-  
+
 jobs:
   test-hive:
     runs-on: ubuntu-latest
@@ -106,7 +106,8 @@ jobs:
           # 3 failures out of 8 tests at time of writing
           run_suite engine auth 3
           # 8 failures out of 194 tests, see https://github.com/ethereum/hive/pull/1355
-          run_suite rpc compat 8
+          # 12 failures out of 199 tests, see https://github.com/ethereum/execution-apis/pull/712 
+          run_suite rpc compat 12
         continue-on-error: true
 
       - name: Upload output log


### PR DESCRIPTION
this fixes our Hive rpc-compat CI failure which surfaced today - not due to our regression - but due to some new eth_getLogs tests that have been added and some eth_getStorageAt and eth_estimateGas tests that have been updated in https://github.com/ethereum/execution-apis/pull/712

increasing the allowed failures to 12 to make our CI green for the short term

added an issue to fix these new failures https://github.com/erigontech/erigon/issues/18181