### PR TITLE
refactor: use strings.Builder to improve performance

### DIFF
--- a/execution/abi/type.go
+++ b/execution/abi/type.go
@@ -164,9 +164,9 @@ func NewType(t string, internalType string, components []ArgumentMarshaling) (ty
 			fields     []reflect.StructField
 			elems      []*Type
 			names      []string
-			expression string // canonical parameter expression
+			expression strings.Builder // canonical parameter expression
 		)
-		expression += "("
+		expression.WriteString("(")
 		overloadedNames := make(map[string]string)
 		for idx, c := range components {
 			cType, err := NewType(c.Type, c.InternalType, c.Components)
@@ -185,18 +185,18 @@ func NewType(t string, internalType string, components []ArgumentMarshaling) (ty
 			})
 			elems = append(elems, &cType)
 			names = append(names, c.Name)
-			expression += cType.stringKind
+			expression.WriteString(cType.stringKind)
 			if idx != len(components)-1 {
-				expression += ","
+				expression.WriteString(",")
 			}
 		}
-		expression += ")"
+		expression.WriteString(")")
 
 		typ.TupleType = reflect.StructOf(fields)
 		typ.TupleElems = elems
 		typ.TupleRawNames = names
 		typ.T = TupleTy
-		typ.stringKind = expression
+		typ.stringKind = expression.String()
 
 		const structPrefix = "struct "
 		// After solidity 0.5.10, a new field of abi "internalType"

--- a/execution/commitment/trie/debug.go
+++ b/execution/commitment/trie/debug.go
@@ -26,6 +26,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/erigontech/erigon/common"
 )
@@ -59,15 +60,16 @@ func (t *Trie) PrintDiff(t2 *Trie, w io.Writer) {
 }
 
 func (n *FullNode) fstring(ind string) string {
-	resp := fmt.Sprintf("full\n%s  ", ind)
+	var resp strings.Builder
+	resp.WriteString(fmt.Sprintf("full\n%s  ", ind))
 	for i, node := range &n.Children {
 		if node == nil {
-			resp += indices[i] + ": <nil> "
+			resp.WriteString(indices[i] + ": <nil> ")
 		} else {
-			resp += indices[i] + ": " + node.fstring(ind+"  ")
+			resp.WriteString(indices[i] + ": " + node.fstring(ind+"  "))
 		}
 	}
-	return resp + "\n" + ind + "]"
+	return resp.String() + "\n" + ind + "]"
 }
 func (n *FullNode) print(w io.Writer) {
 	fmt.Fprintf(w, "f(")

--- a/execution/protocol/block_exec.go
+++ b/execution/protocol/block_exec.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	"golang.org/x/crypto/sha3"
@@ -400,13 +401,13 @@ var alwaysSkipReceiptCheck = dbg.EnvBool("EXEC_SKIP_RECEIPT_CHECK", false)
 
 func BlockPostValidation(gasUsed, blobGasUsed uint64, checkReceipts bool, receipts types.Receipts, h *types.Header, isMining bool, txns types.Transactions, chainConfig *chain.Config, logger log.Logger) error {
 	if gasUsed != h.GasUsed {
-		var txgas string
+		var txgas strings.Builder
 		sep := ""
 		for _, receipt := range receipts {
-			txgas += fmt.Sprintf("%s%d=%d", sep, receipt.TransactionIndex, receipt.GasUsed)
+			txgas.WriteString(fmt.Sprintf("%s%d=%d", sep, receipt.TransactionIndex, receipt.GasUsed))
 			sep = ", "
 		}
-		logger.Warn("gas used mismatch", "block", h.Number.Uint64(), "header", h.GasUsed, "execution", gasUsed, "txgas", txgas)
+		logger.Warn("gas used mismatch", "block", h.Number.Uint64(), "header", h.GasUsed, "execution", gasUsed, "txgas", txgas.String())
 		return fmt.Errorf("gas used by execution: %d, in header: %d, headerNum=%d, %x",
 			gasUsed, h.GasUsed, h.Number.Uint64(), h.Hash())
 	}

--- a/execution/vm/asm/compiler.go
+++ b/execution/vm/asm/compiler.go
@@ -109,16 +109,16 @@ func (c *Compiler) Compile() (string, []error) {
 	}
 
 	// turn the binary to hex
-	var bin string
+	var bin strings.Builder
 	for _, v := range c.binary {
 		switch v := v.(type) {
 		case vm.OpCode:
-			bin += hex.EncodeToString([]byte{byte(v)})
+			bin.WriteString(hex.EncodeToString([]byte{byte(v)}))
 		case []byte:
-			bin += hex.EncodeToString(v)
+			bin.WriteString(hex.EncodeToString(v))
 		}
 	}
-	return bin, errors
+	return bin.String(), errors
 }
 
 // next returns the next token and increments the

--- a/execution/vm/evm_test.go
+++ b/execution/vm/evm_test.go
@@ -18,6 +18,7 @@ package vm
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/holiman/uint256"
@@ -273,16 +274,17 @@ func TestReadonlyBasicCases(t *testing.T) {
 		copy(isEVMSliceTest, testCase.readonlySliceTest)
 		evmsTest[i].emvs = isEVMSliceTest
 
-		suffix := "-isEVMSliceTest"
+		var suffix strings.Builder
+		suffix.WriteString("-isEVMSliceTest")
 		for _, evmParam := range testCase.readonlySliceTest {
 			if evmParam {
-				suffix += "-true"
+				suffix.WriteString("-true")
 			} else {
-				suffix += "-false"
+				suffix.WriteString("-false")
 			}
 		}
 
-		evmsTest[i].suffix = suffix
+		evmsTest[i].suffix = suffix.String()
 	}
 
 	for _, testCase := range cases {
@@ -425,9 +427,10 @@ func (st *testSequential) Run(_ *Contract, _ []byte, _ bool) ([]byte, uint64, er
 }
 
 func trace(isEVMSlice []bool, readOnlySlice []*readOnlyState) string {
-	res := "trace:\n"
+	var res strings.Builder
+	res.WriteString("trace:\n")
 	for i := 0; i < len(isEVMSlice); i++ {
-		res += fmt.Sprintf("%d: EVM %t, readonly %t\n", i, isEVMSlice[i], readOnlySlice[i].in)
+		res.WriteString(fmt.Sprintf("%d: EVM %t, readonly %t\n", i, isEVMSlice[i], readOnlySlice[i].in))
 	}
-	return res
+	return res.String()
 }


### PR DESCRIPTION
strings.Builder has fewer memory allocations and better performance.
More info: https://github.com/golang/go/issues/75190

Inspired by https://github.com/erigontech/erigon/pull/17696 and replace all the case.