### PR TITLE
refactor(state): remove redundant dedup map in Stateless.Finalize

### DIFF
--- a/execution/state/stateless.go
+++ b/execution/state/stateless.go
@@ -323,16 +323,9 @@ func (s *Stateless) CheckRoot(expected common.Hash) error {
 
 // Finalize the execution of a block and computes the resulting state root
 func (s *Stateless) Finalize() common.Hash {
-	// The following map is to prevent repeated clearouts of the storage
-	alreadyCreated := make(map[common.Hash]struct{})
 	// New contracts are being created at these addresses. Therefore, we need to clear the storage items
 	// that might be remaining in the trie and figure out the next incarnations
 	for addrHash := range s.created {
-		// Prevent repeated storage clearouts
-		if _, ok := alreadyCreated[addrHash]; ok {
-			continue
-		}
-		alreadyCreated[addrHash] = struct{}{}
 		if account, ok := s.accountUpdates[addrHash]; ok && account != nil {
 			account.Root = trie.EmptyRoot
 		}


### PR DESCRIPTION
The alreadyCreated map in Stateless.Finalize() was used to “prevent repeated clearouts,” but s.created is a map acting as a set, so iteration cannot produce duplicates. This extra map only allocated memory and added lookups without any semantic benefit. Simplified the loop to iterate s.created once. Mirrors the approach used in TrieDbState.updateTrieRoots() and keeps behavior identical.