### PR TITLE
publishable in caplin snapshot: allow no files 

### DIFF
--- a/cmd/utils/app/publishable_check.go
+++ b/cmd/utils/app/publishable_check.go
@@ -16,7 +16,7 @@ import (
 // publishable check using snapnameschema
 
 // checkLastFileTo = -1 if don't need this check
-func CheckFilesForSchema(schema state.SnapNameSchema, checkLastFileTo int64) (lastFileTo uint64, err error) {
+func CheckFilesForSchema(schema state.SnapNameSchema, checkLastFileTo int64, emptyOk bool) (lastFileTo uint64, empty bool, err error) {
 	// check in schema specific directory (and accessor directories)
 
 	// checks:
@@ -60,7 +60,7 @@ func CheckFilesForSchema(schema state.SnapNameSchema, checkLastFileTo int64) (la
 
 		return nil
 	}); err != nil {
-		return 0, err
+		return 0, false, err
 	}
 
 	sort.Slice(dataFiles, func(i, j int) bool {
@@ -68,33 +68,37 @@ func CheckFilesForSchema(schema state.SnapNameSchema, checkLastFileTo int64) (la
 	})
 
 	if len(dataFiles) == 0 {
-		return 0, fmt.Errorf("no %s snapshot files found in %s", schema.DataTag(), schema.DataDirectory())
+		if !emptyOk {
+			return 0, true, fmt.Errorf("no %s snapshot files found in %s", schema.DataTag(), schema.DataDirectory())
+		} else {
+			return 0, true, nil
+		}
 	}
 
 	if dataFiles[0].From != 0 {
-		return 0, fmt.Errorf("first %s snapshot file must start from 0, found from %d", schema.DataTag(), dataFiles[0].From)
+		return 0, false, fmt.Errorf("first %s snapshot file must start from 0, found from %d", schema.DataTag(), dataFiles[0].From)
 	}
 
 	if checkLastFileTo >= 0 && int64(dataFiles[len(dataFiles)-1].To) != checkLastFileTo {
-		return 0, fmt.Errorf("last %s snapshot file must end at %d, found at %d (file: %s)", schema.DataTag(), checkLastFileTo, dataFiles[len(dataFiles)-1].To, dataFiles[len(dataFiles)-1].Name)
+		return 0, false, fmt.Errorf("last %s snapshot file must end at %d, found at %d (file: %s)", schema.DataTag(), checkLastFileTo, dataFiles[len(dataFiles)-1].To, dataFiles[len(dataFiles)-1].Name)
 	}
 
 	if sumRange != dataFiles[len(dataFiles)-1].To {
-		return 0, fmt.Errorf("sum of ranges of %s snapshot files (%d) does not match last 'to' value (%d)", schema.DataTag(), sumRange, dataFiles[len(dataFiles)-1].To)
+		return 0, false, fmt.Errorf("sum of ranges of %s snapshot files (%d) does not match last 'to' value (%d)", schema.DataTag(), sumRange, dataFiles[len(dataFiles)-1].To)
 	}
 
 	prevFrom, prevTo := dataFiles[0].From, dataFiles[0].To
 	for i := 1; i < len(dataFiles); i++ {
 		df := dataFiles[i]
 		if prevFrom == df.From {
-			return 0, fmt.Errorf("overlapping %s snapshot files found: %s and %s", schema.DataTag(), dataFiles[i-1].Name, df.Name)
+			return 0, false, fmt.Errorf("overlapping %s snapshot files found: %s and %s", schema.DataTag(), dataFiles[i-1].Name, df.Name)
 		}
 
 		if df.From < prevTo {
-			return 0, fmt.Errorf("overlapping %s snapshot files found: %s and %s", schema.DataTag(), dataFiles[i-1].Name, df.Name)
+			return 0, false, fmt.Errorf("overlapping %s snapshot files found: %s and %s", schema.DataTag(), dataFiles[i-1].Name, df.Name)
 		}
 		if df.From > prevTo {
-			return 0, fmt.Errorf("gap in %s snapshot files found between %s and %s", schema.DataTag(), dataFiles[i-1].Name, df.Name)
+			return 0, false, fmt.Errorf("gap in %s snapshot files found between %s and %s", schema.DataTag(), dataFiles[i-1].Name, df.Name)
 		}
 		prevFrom, prevTo = df.From, df.To
 	}
@@ -107,14 +111,14 @@ func CheckFilesForSchema(schema state.SnapNameSchema, checkLastFileTo int64) (la
 		// should get the same name as dataFile...
 		// this checks the version is correct (between min and current), and that there's only one such data file
 		if _, err := schema.DataFile(version.StrictSearchVersion, from, to); err != nil {
-			return 0, fmt.Errorf("unsupported data file version: %s: %v", dataFile.Name, err)
+			return 0, false, fmt.Errorf("unsupported data file version: %s: %v", dataFile.Name, err)
 		}
 
 		if accessors.Has(statecfg.AccessorHashMap) {
 			for idxPos := uint16(0); idxPos < schema.AccessorIdxCount(); idxPos++ {
 				_, err := schema.AccessorIdxFile(version.StrictSearchVersion, from, to, idxPos)
 				if err != nil {
-					return 0, fmt.Errorf("missing %s accessor idx file for data file %s (idx tag: %d): %v", schema.DataTag(), dataFile.Name, idxPos, err)
+					return 0, false, fmt.Errorf("missing %s accessor idx file for data file %s (idx tag: %d): %v", schema.DataTag(), dataFile.Name, idxPos, err)
 				}
 			}
 		}
@@ -122,17 +126,17 @@ func CheckFilesForSchema(schema state.SnapNameSchema, checkLastFileTo int64) (la
 		if accessors.Has(statecfg.AccessorBTree) {
 			_, err := schema.BtIdxFile(version.StrictSearchVersion, from, to)
 			if err != nil {
-				return 0, fmt.Errorf("missing %s bt tree file for data file %s: %v", schema.DataTag(), dataFile.Name, err)
+				return 0, false, fmt.Errorf("missing %s bt tree file for data file %s: %v", schema.DataTag(), dataFile.Name, err)
 			}
 		}
 
 		if accessors.Has(statecfg.AccessorExistence) {
 			_, err := schema.ExistenceFile(version.StrictSearchVersion, from, to)
 			if err != nil {
-				return 0, fmt.Errorf("missing %s existence filter for data file %s: %v", schema.DataTag(), dataFile.Name, err)
+				return 0, false, fmt.Errorf("missing %s existence filter for data file %s: %v", schema.DataTag(), dataFile.Name, err)
 			}
 		}
 	}
 
-	return dataFiles[len(dataFiles)-1].To, nil
+	return dataFiles[len(dataFiles)-1].To, false, nil
 }

--- a/cmd/utils/app/publishable_check_test.go
+++ b/cmd/utils/app/publishable_check_test.go
@@ -24,7 +24,7 @@ import (
 
 func Test_CheckEmpty(t *testing.T) {
 	dirs := datadir.New(t.TempDir())
-	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs))
+	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs, false))
 }
 
 func Test_CheckNormal(t *testing.T) {
@@ -32,7 +32,7 @@ func Test_CheckNormal(t *testing.T) {
 	touchFiles(t, dirs, []snapRange{
 		{0, 10}, {10, 20}, {20, 30},
 	})
-	require.NoError(t, checkIfCaplinSnapshotsPublishable(dirs))
+	require.NoError(t, checkIfCaplinSnapshotsPublishable(dirs, false))
 }
 
 func Test_CheckGaps(t *testing.T) {
@@ -40,7 +40,7 @@ func Test_CheckGaps(t *testing.T) {
 	touchFiles(t, dirs, []snapRange{
 		{0, 10}, {20, 30},
 	})
-	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs))
+	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs, false))
 }
 
 func Test_CheckStartFrom0(t *testing.T) {
@@ -48,7 +48,7 @@ func Test_CheckStartFrom0(t *testing.T) {
 	touchFiles(t, dirs, []snapRange{
 		{10, 20}, {20, 30},
 	})
-	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs))
+	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs, false))
 }
 
 func Test_CheckOverlaps(t *testing.T) {
@@ -56,7 +56,7 @@ func Test_CheckOverlaps(t *testing.T) {
 	touchFiles(t, dirs, []snapRange{
 		{0, 15}, {10, 30},
 	})
-	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs))
+	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs, false))
 }
 
 func Test_OneFileMissing(t *testing.T) {
@@ -66,15 +66,15 @@ func Test_OneFileMissing(t *testing.T) {
 	})
 	// delete one idx file
 	delFile(t, dirs.Snap, "v1.0-000010-000020-beaconblocks.idx")
-	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs))
+	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs, false))
 
 	touchFiles(t, dirs, []snapRange{
 		{0, 10}, {10, 20}, {20, 30},
 	})
-	require.NoError(t, checkIfCaplinSnapshotsPublishable(dirs))
+	require.NoError(t, checkIfCaplinSnapshotsPublishable(dirs, false))
 	// delete seg file
 	delFile(t, dirs.SnapCaplin, "v1.0-000010-000020-ActiveValidatorIndicies.seg")
-	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs))
+	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs, false))
 }
 
 func Test_LastFileMissingForOneEnum(t *testing.T) {
@@ -85,7 +85,7 @@ func Test_LastFileMissingForOneEnum(t *testing.T) {
 	// delete one idx file
 	delFile(t, dirs.SnapCaplin, "v1.0-000020-000030-BlockRoot.idx")
 	delFile(t, dirs.SnapCaplin, "v1.0-000020-000030-BlockRoot.seg")
-	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs))
+	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs, false))
 }
 
 func Test_VersionLessThanMin(t *testing.T) {
@@ -94,28 +94,28 @@ func Test_VersionLessThanMin(t *testing.T) {
 		{0, 10}, {10, 20}, {20, 30},
 	})
 	touchFile(t, dirs.Snap, "v0.9-000010-000020-beaconblocks.idx")
-	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs))
+	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs, false))
 
 	delFile(t, dirs.Snap, "v0.9-000010-000020-beaconblocks.idx")
-	require.NoError(t, checkIfCaplinSnapshotsPublishable(dirs))
+	require.NoError(t, checkIfCaplinSnapshotsPublishable(dirs, false))
 
 	touchFile(t, dirs.Snap, "v0.9-000010-000020-beaconblocks.seg")
-	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs))
+	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs, false))
 
 	delFile(t, dirs.Snap, "v0.9-000010-000020-beaconblocks.seg")
-	require.NoError(t, checkIfCaplinSnapshotsPublishable(dirs))
+	require.NoError(t, checkIfCaplinSnapshotsPublishable(dirs, false))
 
 	touchFile(t, dirs.SnapCaplin, "v0.9-000010-000020-ActiveValidatorIndicies.seg")
-	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs))
+	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs, false))
 
 	delFile(t, dirs.SnapCaplin, "v0.9-000010-000020-ActiveValidatorIndicies.seg")
-	require.NoError(t, checkIfCaplinSnapshotsPublishable(dirs))
+	require.NoError(t, checkIfCaplinSnapshotsPublishable(dirs, false))
 
 	touchFile(t, dirs.SnapCaplin, "v0.9-000010-000020-ActiveValidatorIndicies.idx")
-	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs))
+	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs, false))
 
 	delFile(t, dirs.SnapCaplin, "v0.9-000010-000020-ActiveValidatorIndicies.idx")
-	require.NoError(t, checkIfCaplinSnapshotsPublishable(dirs))
+	require.NoError(t, checkIfCaplinSnapshotsPublishable(dirs, false))
 }
 
 func Test_VersionMoreThanCurrent(t *testing.T) {
@@ -124,28 +124,28 @@ func Test_VersionMoreThanCurrent(t *testing.T) {
 		{0, 10}, {10, 20}, {20, 30},
 	})
 	touchFile(t, dirs.Snap, "v20.0-000010-000020-beaconblocks.idx")
-	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs))
+	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs, false))
 
 	delFile(t, dirs.Snap, "v20.0-000010-000020-beaconblocks.idx")
-	require.NoError(t, checkIfCaplinSnapshotsPublishable(dirs))
+	require.NoError(t, checkIfCaplinSnapshotsPublishable(dirs, false))
 
 	touchFile(t, dirs.Snap, "v20.0-000010-000020-beaconblocks.seg")
-	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs))
+	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs, false))
 
 	delFile(t, dirs.Snap, "v20.0-000010-000020-beaconblocks.seg")
-	require.NoError(t, checkIfCaplinSnapshotsPublishable(dirs))
+	require.NoError(t, checkIfCaplinSnapshotsPublishable(dirs, false))
 
 	touchFile(t, dirs.SnapCaplin, "v20.0-000010-000020-ActiveValidatorIndicies.seg")
-	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs))
+	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs, false))
 
 	delFile(t, dirs.SnapCaplin, "v20.0-000010-000020-ActiveValidatorIndicies.seg")
-	require.NoError(t, checkIfCaplinSnapshotsPublishable(dirs))
+	require.NoError(t, checkIfCaplinSnapshotsPublishable(dirs, false))
 
 	touchFile(t, dirs.SnapCaplin, "v20.0-000010-000020-ActiveValidatorIndicies.idx")
-	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs))
+	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs, false))
 
 	delFile(t, dirs.SnapCaplin, "v20.0-000010-000020-ActiveValidatorIndicies.idx")
-	require.NoError(t, checkIfCaplinSnapshotsPublishable(dirs))
+	require.NoError(t, checkIfCaplinSnapshotsPublishable(dirs, false))
 }
 
 type snapRange struct {

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -1182,27 +1182,37 @@ func CheckBorChain(chainName string) bool {
 	return slices.Contains([]string{networkname.BorMainnet, networkname.Amoy, networkname.BorE2ETestChain2Val, networkname.BorDevnet}, chainName)
 }
 
-func checkIfCaplinSnapshotsPublishable(dirs datadir.Dirs) error {
+func checkIfCaplinSnapshotsPublishable(dirs datadir.Dirs, emptyOk bool) error {
 	stateSnapTypes := snapshotsync.MakeCaplinStateSnapshotsTypes(nil)
 	caplinSchema := snapshotsync.NewCaplinSchema(dirs, 1000, stateSnapTypes)
 
 	to := int64(-1)
 	for _, snapt := range snaptype.CaplinSnapshotTypes {
-		uto, err := CheckFilesForSchema(caplinSchema.Get(snapt.Enum()), to)
+		uto, empty, err := CheckFilesForSchema(caplinSchema.Get(snapt.Enum()), to, emptyOk)
 		if err != nil {
 			return err
+		}
+		if empty {
+			continue
 		}
 
 		to = int64(uto)
 	}
 
+	somethingPresent, somethingEmpty := false, false
 	for table := range stateSnapTypes.KeyValueGetters {
-		uto, err := CheckFilesForSchema(caplinSchema.GetState(table), to)
+		uto, empty, err := CheckFilesForSchema(caplinSchema.GetState(table), to, emptyOk)
 		if err != nil {
 			return err
 		}
+		somethingPresent = somethingPresent || !empty
+		somethingEmpty = somethingEmpty || empty
 
 		to = int64(uto)
+	}
+
+	if somethingEmpty && somethingPresent {
+		return fmt.Errorf("some state snapshot files are empty while others are present")
 	}
 
 	return nil
@@ -1599,7 +1609,7 @@ func doPublishable(cliCtx *cli.Context) error {
 	if err := checkIfStateSnapshotsPublishable(dat); err != nil {
 		return err
 	}
-	if err := checkIfCaplinSnapshotsPublishable(dat); err != nil {
+	if err := checkIfCaplinSnapshotsPublishable(dat, true); err != nil {
 		return err
 	}
 	// check if salt-state.txt and salt-blocks.txt exist


### PR DESCRIPTION
some chains don't publish caplin files. Hoodi doesn't publish blobs file. 
No good way to detect it (we don't store flags like caplin.snapgen). So relying on some heuristics to determine if we should check a particular caplin enum or not.