### PR TITLE
fix: use errors.Is for ErrExecutionReverted check in TransitionDb

### DIFF
--- a/execution/protocol/state_transition.go
+++ b/execution/protocol/state_transition.go
@@ -601,7 +601,7 @@ func (st *StateTransition) TransitionDb(refunds bool, gasBailout bool) (result *
 	result = &evmtypes.ExecutionResult{
 		GasUsed:             st.gasUsed(),
 		Err:                 vmerr,
-		Reverted:            vmerr == vm.ErrExecutionReverted,
+		Reverted:            errors.Is(vmerr, vm.ErrExecutionReverted),
 		ReturnData:          ret,
 		SenderInitBalance:   senderInitBalance,
 		CoinbaseInitBalance: coinbaseInitBalance,


### PR DESCRIPTION
TransitionDb uses direct == comparison for ErrExecutionReverted (line 604), while ApplyFrame in the same file already uses errors.Is() for the same check (line 393). Changed to errors.Is() for consistency.