### PR TITLE
refactor: remove dead fullDivergingPath allocation in toWitnessTrie

### DIFF
--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -1346,16 +1346,26 @@ func (hph *HexPatriciaHashed) toWitnessTrie(hashedKey []byte, codeReads map[comm
 				// path has diverged due to the hashedKey not leading to any account or storage
 				// the traversal can be stopped at this level
 				pathDivergenceFound = true
-				// // Code left commented out in case it might be needed in the future
-				// rowData, err := readBranchData(hph, fullDivergingPath)
-				// if err != nil {
-				// 	return nil, fmt.Errorf("failed to read branchdata: %w", err)
+				// special handling only if consuming the diverging hashed extension doesn't lead to account or storage
+				// Code left commented out in case it might be needed in the future:
+				// if pathDivergenceFound && fullPathLength != 64 && fullPathLength != 128 {
+				// 	fullDivergingPath := make([]byte, fullPathLength)
+				// 	for i := 0; i < int(keyPos+1); i++ {
+				// 		fullDivergingPath[i] = hashedKey[i]
+				// 	}
+				// 	for i := 0; i < len(hashedExtKey); i++ {
+				// 		fullDivergingPath[int(keyPos)+1+i] = hashedExtKey[i]
+				// 	}
+				// 	rowData, err := readBranchData(hph, fullDivergingPath)
+				// 	if err != nil {
+				// 		return nil, fmt.Errorf("failed to read branchdata: %w", err)
+				// 	}
+				// 	terminalNode, err := terminalRowToNode(hph, rowData, hph.depths[row])
+				// 	if err != nil {
+				// 		return nil, fmt.Errorf("failed to parse terminal node: %w", err)
+				// 	}
+				// 	nextNode = &trie.ShortNode{Key: hashedExtKey, Val: terminalNode}
 				// }
-				// terminalNode, err := terminalRowToNode(hph, rowData, hph.depths[row])
-				// if err != nil {
-				// 	return nil, fmt.Errorf("failed to parse terminal node: %w", err)
-				// }
-				// nextNode = &trie.ShortNode{Key: hashedExtKey, Val: terminalNode}
 
 				// Val will be set to HashNode with hash of branch node it points to when the current node is processed.
 				// Currently necessary, because the commented out code above which reads branch data and converts it


### PR DESCRIPTION
The witness builder no longer uses fullDivergingPath after switching to the ShortNode+HashNode scheme for diverging paths. The local buffer was still being allocated and filled but never read, which added unnecessary work in a hot code path. This change removes the unused allocation while preserving the existing witness construction logic and tests should remain unaffected.