### PR TITLE
Reuse configured client in PingErigonRpc and drop the nolint

### DIFF
--- a/rpc/requests/request_generator.go
+++ b/rpc/requests/request_generator.go
@@ -263,8 +263,19 @@ func (req *requestGenerator) PingErigonRpc() PingResult {
 		RequestID: req.reqID,
 	}
 
+	targetURL := req.target
+	if !strings.HasPrefix(targetURL, "http://") && !strings.HasPrefix(targetURL, "https://") {
+		targetURL = "http://" + targetURL
+	}
+	res.Target = targetURL
+
+	client := req.client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	
 	// return early if the http module has issue fetching the url
-	resp, err := http.Get("http://" + req.target) //nolint
+	resp, err := client.Get(targetURL)
 	if err != nil {
 		res.Took = time.Since(start)
 		res.Err = err


### PR DESCRIPTION
reuse requestGenerator’s HTTP client (with timeout) instead of the global http.Get, so PingErigonRpc no longer ignores its configured deadlines, accept pre-prefixed https:// targets and record the resolved URL in callResult.Target, letting diagnostics remain accurate without forcing http://, remove the //nolint suppression that hid the misuse of http.Get