### PR TITLE
chore(node/shards): remove unused RpcEventType typedef

### DIFF
--- a/node/shards/events.go
+++ b/node/shards/events.go
@@ -27,8 +27,6 @@ import (
 	"github.com/erigontech/erigon/node/gointerfaces/typesproto"
 )
 
-type RpcEventType uint64
-
 type NewSnapshotSubscription func() error
 type HeaderSubscription func(headerRLP []byte) error
 type PendingLogsSubscription func(types.Logs) error


### PR DESCRIPTION
The alias was not referenced anywhere in the repository. Removing this dead code simplifies the API surface and avoids confusion about unused RPC event typing.