### PR TITLE
perf(math): eliminate redundant allocation in RandInt64()

### DIFF
--- a/common/math/integer.go
+++ b/common/math/integer.go
@@ -44,6 +44,8 @@ const (
 	MaxUint64 = 1<<64 - 1
 )
 
+var maxInt64 = big.NewInt(math.MaxInt64)
+
 // HexOrDecimal64 marshals uint64 as hex or decimal.
 type HexOrDecimal64 uint64
 
@@ -104,7 +106,7 @@ func AbsoluteDifference(x, y uint64) uint64 {
 }
 
 func RandInt64() (int64, error) {
-	n, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
+	n, err := rand.Int(rand.Reader, maxInt64)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
Optimizes `RandInt64()` by eliminating redundant `big.Int` allocation on every function call.