### PR TITLE
qa-tests: on RPC latest test suite, temporary disable flaky debug_traceBlockByNumber/test_43 test

### DIFF
--- a/.github/workflows/scripts/run_rpc_tests_ethereum_latest.sh
+++ b/.github/workflows/scripts/run_rpc_tests_ethereum_latest.sh
@@ -19,6 +19,7 @@ fi
 # Disabled tests for Ethereum mainnet
 DISABLED_TEST_LIST=(
    debug_traceBlockByNumber/test_30.json # huge JSON response => slow diff
+   debug_traceBlockByNumber/test_43.json # flaky test
    debug_traceCall/test_22.json
    debug_traceCall/test_38.json # see https://github.com/erigontech/erigon-qa/issues/274
    debug_traceCallMany


### PR DESCRIPTION
Disable temporary latest test (debug_traceBlockByNumber/test_43.json)  because obtain sometimes different response from Geth 