### PR TITLE
txnprovider/txpool: remove redundant pooled txn parse lock

### DIFF
--- a/txnprovider/txpool/fetch.go
+++ b/txnprovider/txpool/fetch.go
@@ -332,12 +332,6 @@ func (f *Fetch) handleInboundMessage(ctx context.Context, req *sentryproto.Inbou
 		}
 	case sentryproto.MessageId_POOLED_TRANSACTIONS_66, sentryproto.MessageId_TRANSACTIONS_66:
 		txns := TxnSlots{}
-		if err := f.threadSafeParsePooledTxn(func(parseContext *TxnParseContext) error {
-			return nil
-		}); err != nil {
-			return err
-		}
-
 		switch req.Id {
 		case sentryproto.MessageId_TRANSACTIONS_66:
 			if err := f.threadSafeParsePooledTxn(func(parseContext *TxnParseContext) error {


### PR DESCRIPTION
Removed a no-op threadSafeParsePooledTxn call before handling POOLED_TRANSACTIONS_66/TRANSACTIONS_66. The callback was always returning nil and had no side effects on TxnParseContext, so it only added an extra lock/unlock without changing behavior. This keeps the handler simpler and avoids unnecessary synchronization.