### PR TITLE
cl/fork: remove dead fork helpers from CL fork package

### DIFF
--- a/cl/fork/fork.go
+++ b/cl/fork/fork.go
@@ -18,7 +18,6 @@ package fork
 
 import (
 	"errors"
-	"sort"
 
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/utils"
@@ -28,21 +27,6 @@ import (
 
 var NO_GENESIS_TIME_ERR error = errors.New("genesis time is not set")
 var NO_VALIDATOR_ROOT_HASH error = errors.New("genesis validators root is not set")
-
-type fork struct {
-	epoch   uint64
-	version [4]byte
-}
-
-func forkList(schedule map[common.Bytes4]uint64) (f []fork) {
-	for version, epoch := range schedule {
-		f = append(f, fork{epoch: epoch, version: version})
-	}
-	sort.Slice(f, func(i, j int) bool {
-		return f[i].epoch < f[j].epoch
-	})
-	return
-}
 
 func ComputeDomain(
 	domainType []byte,


### PR DESCRIPTION
Removed the unused local fork struct and forkList helper from the cl/fork package and dropped the now-unused sort import. These helpers are not referenced anywhere in the codebase and the actual fork scheduling logic lives in cl/utils/eth_clock, so keeping this duplicate implementation only adds confusion without any benefit.