### PR TITLE
Remove unused uint env helper in downloader

### DIFF
--- a/db/downloader/env.go
+++ b/db/downloader/env.go
@@ -12,11 +12,6 @@ func initIntFromEnv[T constraints.Signed](key string, defaultValue T, bitSize in
 	return strconvFromEnv(key, defaultValue, bitSize, strconv.ParseInt)
 }
 
-//nolint:unused
-func initUIntFromEnv[T constraints.Unsigned](key string, defaultValue T, bitSize int) T {
-	return strconvFromEnv(key, defaultValue, bitSize, strconv.ParseUint)
-}
-
 func strconvFromEnv[T, U constraints.Integer](key string, defaultValue T, bitSize int, conv func(s string, base, bitSize int) (U, error)) T {
 	s := os.Getenv(key)
 	if s == "" {


### PR DESCRIPTION
delete the dead initUIntFromEnv helper and its //nolint:unused suppression in db/downloader/env.go, leaving only the used signed variant and shared converter
keeps env parsing surface minimal and removes dead code noise