### PR TITLE
execution/protocol: remove unnecessary block.Uncles() call

### DIFF
--- a/execution/protocol/block_exec.go
+++ b/execution/protocol/block_exec.go
@@ -90,7 +90,6 @@ func ExecuteBlockEphemerally(
 	logger log.Logger,
 ) (res *EphemeralExecResult, executeBlockErr error) {
 	defer blockExecutionTimer.ObserveDuration(time.Now())
-	block.Uncles()
 	ibs := state.New(stateReader)
 	ibs.SetHooks(vmConfig.Tracer)
 	header := block.Header()


### PR DESCRIPTION
block.Uncles() is a simple getter with no side effects and the result of the first call in ExecuteBlockEphemerally was unused. This made the code slightly more confusing and added a tiny bit of unnecessary work before block execution. The call is removed and the function now only uses block.Uncles() where the returned slice is actually needed.