### PR TITLE
fix: remove unused code in MustParseUints

### DIFF
--- a/common/dbg/dbg_env.go
+++ b/common/dbg/dbg_env.go
@@ -161,7 +161,7 @@ func MustParseUints(strNum, separator string) []uint64 {
 	}
 	parts := strings.Split(strNum, separator)
 	ints := make([]uint64, 0, len(parts))
-	for str := range strings.SplitSeq(strNum, separator) {
+	for _, str := range parts {
 		ints = append(ints, MustParseUint(str))
 	}
 	return ints


### PR DESCRIPTION
Found that MustParseUints was creating a 'parts' slice with strings.Split() but then completely ignoring it and using strings.SplitSeq() in the loop instead. This left dead code and mixed two different splitting approaches.

Changed it to use strings.Split() consistently, matching how MustParseInts works. This removes the unused allocation and keeps the code consistent.