### PR TITLE
[r3.3] Caplin: to not use `type` field #18279

### DIFF
--- a/db/snaptype/type.go
+++ b/db/snaptype/type.go
@@ -557,7 +557,7 @@ func BuildIndexWithSnapName(ctx context.Context, info FileInfo, cfg recsplit.Rec
 		p.Total.Store(uint64(d.Count()))
 	}
 	cfg.KeyCount = d.Count()
-	cfg.IndexFile = info.Type.IdxFileName(info.Version, info.From, info.To, info.Type.Indexes()...)
+	cfg.IndexFile = filepath.Join(info.Dir(), IdxFileName(info.Version, info.From, info.To, info.CaplinTypeString))
 	rs, err := recsplit.NewRecSplit(cfg, logger)
 	if err != nil {
 		return err


### PR DESCRIPTION
cp of https://github.com/erigontech/erigon/pull/18279