### PR TITLE
[3.3] cherry-pick fix eth_getLogs() for hive

### DIFF
--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -105,8 +105,8 @@ jobs:
           run_suite engine api 0
           # 3 failures out of 8 tests at time of writing
           run_suite engine auth 3
-          # 10 failures out of 199 tests, see https://github.com/ethereum/hive/pull/1355
-          run_suite rpc compat 10
+          # 8 failures out of 199 tests, see https://github.com/ethereum/hive/pull/1355
+          run_suite rpc compat 8
         continue-on-error: true
 
       - name: Upload output log

--- a/rpc/jsonrpc/eth_receipts.go
+++ b/rpc/jsonrpc/eth_receipts.go
@@ -40,6 +40,18 @@ import (
 	"github.com/erigontech/erigon/rpc/rpchelper"
 )
 
+var (
+	errInvalidBlockRange    = "invalid block range params"
+	errBlockRangeIntoFuture = "block range extends beyond current head block"
+	errBlockHashWithRange   = "can't specify fromBlock/toBlock with blockHash"
+	errExceedMaxTopics      = "exceed max topics"
+)
+
+const (
+	// The maximum number of topic criteria allowed, vm.LOG4 - vm.LOG0
+	maxTopics = 4
+)
+
 // getReceipts - checking in-mem cache, or else fallback to db, or else fallback to re-exec of block to re-gen receipts
 func (api *BaseAPI) getReceipts(ctx context.Context, tx kv.TemporalTx, block *types.Block) (types.Receipts, error) {
 	chainConfig, err := api.chainConfig(ctx, tx)
@@ -77,7 +89,15 @@ func (api *APIImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria) (t
 	}
 	defer tx.Rollback()
 
+	if len(crit.Topics) > maxTopics {
+		return nil, &rpc.CustomError{Message: errExceedMaxTopics, Code: rpc.ErrCodeInvalidParams}
+	}
+
 	if crit.BlockHash != nil {
+		if crit.FromBlock != nil || crit.ToBlock != nil {
+			return nil, &rpc.CustomError{Message: errBlockHashWithRange, Code: rpc.ErrCodeInvalidParams}
+		}
+
 		block, err := api.blockByHashWithSenders(ctx, tx, *crit.BlockHash)
 		if err != nil {
 			return nil, err
@@ -110,7 +130,7 @@ func (api *APIImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria) (t
 			}
 
 			if begin > latest {
-				return types.RPCLogs{}, nil
+				return nil, &rpc.CustomError{Message: errBlockRangeIntoFuture, Code: rpc.ErrCodeInvalidParams}
 			}
 		}
 		end = latest
@@ -125,11 +145,15 @@ func (api *APIImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria) (t
 					return nil, err
 				}
 			}
+
+			if end > latest {
+				return nil, &rpc.CustomError{Message: errBlockRangeIntoFuture, Code: rpc.ErrCodeInvalidParams}
+			}
 		}
 	}
 
 	if end < begin {
-		return nil, fmt.Errorf("end (%d) < begin (%d)", end, begin)
+		return nil, &rpc.CustomError{Message: errInvalidBlockRange, Code: rpc.ErrCodeInvalidParams}
 	}
 	if end > roaring.MaxUint32 {
 		latest, err := rpchelper.GetLatestBlockNumber(tx)


### PR DESCRIPTION


This PR fixes errorCodes for Hive tests:
- eth_getLogs/filter-error-future-block-range (erigon_default)
- eth_getLogs/filter-error-reversed-block-range (erigon_default)

And align few errors code with Geth

waiting workflow on Hive tests is completed