### PR TITLE
chore: remove unused variables in golangci_lint.sh

### DIFF
--- a/tools/golangci_lint.sh
+++ b/tools/golangci_lint.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-scriptDir=$(dirname "${BASH_SOURCE[0]}")
-scriptName=$(basename "${BASH_SOURCE[0]}")
 version="v2.6.2"
 
 if [[ "$1" == "--install-deps" ]]


### PR DESCRIPTION
Removes unused `scriptDir` and `scriptName` variables from the `tools/golangci_lint.sh` script.