### PR TITLE
fix: remove unused counter variable in DedupHashes

### DIFF
--- a/txnprovider/txpool/announcements.go
+++ b/txnprovider/txpool/announcements.go
@@ -121,13 +121,11 @@ func (a Announcements) DedupHashes() Hashes {
 	c := make(Hashes, unique*length.Hash)
 	copy(c[:], a.hashes[0:length.Hash])
 	dest := length.Hash
-	j := 1
 	origin := length.Hash
 	for i := 1; i < len(a.ts); i++ {
 		if !bytes.Equal(a.hashes[origin:origin+length.Hash], a.hashes[origin-length.Hash:origin]) {
 			copy(c[dest:dest+length.Hash], a.hashes[origin:origin+length.Hash])
 			dest += length.Hash
-			j++
 		}
 		origin += length.Hash
 	}


### PR DESCRIPTION


Removes an unused counter variable `j` from the `DedupHashes()` method in `announcements.go`. This variable was left over from the `DedupCopy()` implementation where it was needed to track indices for metadata arrays (`ts` and `sizes`). In `DedupHashes()`, which only processes hash data, this counter serves no purpose and adds unnecessary complexity.

