### PR TITLE
perf(execution): remove debug fmt.Printf from transaction execution hot path

### DIFF
--- a/execution/exec/txtask.go
+++ b/execution/exec/txtask.go
@@ -559,10 +559,6 @@ func (txTask *TxTask) Execute(evm *vm.EVM,
 	// Prepare read set, write set and balanceIncrease set and send for serialisation
 	if result.Err == nil {
 		txTask.BalanceIncreaseSet = ibs.BalanceIncreaseSet()
-		for addr, bal := range txTask.BalanceIncreaseSet {
-			fmt.Printf("BalanceIncreaseSet [%x]=>[%d]\n", addr, &bal)
-		}
-
 		if err = ibs.MakeWriteSet(rules, stateWriter); err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Removes debug print statement that was printing BalanceIncreaseSet on every successful transaction execution.