### PR TITLE
chore: remove unused NewPooledTransactionHashesPacket type

### DIFF
--- a/txnprovider/txpool/pool_txn_packets.go
+++ b/txnprovider/txpool/pool_txn_packets.go
@@ -25,8 +25,6 @@ import (
 	"github.com/erigontech/erigon/execution/rlp"
 )
 
-type NewPooledTransactionHashesPacket [][length.Hash]byte
-
 // ParseHashesCount looks at the RLP length Prefix for list of 32-byte hashes
 // and returns number of hashes in the list to expect
 func ParseHashesCount(payload []byte, pos int) (count int, dataPos int, err error) {


### PR DESCRIPTION
NewPooledTransactionHashesPacket is not referenced anywhere in the codebase and was effectively dead code. Removing it simplifies the txpool packet definitions slightly and avoids confusion about an unused packet type without changing any runtime behavior.