### PR TITLE
db/integrity: remove unused ticker in CheckReceiptsNoDups

### DIFF
--- a/db/integrity/receipts_no_duplicates.go
+++ b/db/integrity/receipts_no_duplicates.go
@@ -3,7 +3,6 @@ package integrity
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
@@ -18,9 +17,6 @@ func CheckReceiptsNoDups(ctx context.Context, db kv.TemporalRoDB, blockReader se
 	defer func() {
 		log.Info("[integrity] ReceiptsNoDups: done", "err", err)
 	}()
-
-	logEvery := time.NewTicker(10 * time.Second)
-	defer logEvery.Stop()
 
 	txNumsReader := blockReader.TxnumReader(ctx)
 


### PR DESCRIPTION


Remove unused `logEvery` ticker that was created but never consumed in `CheckReceiptsNoDups`.


