### PR TITLE
refactor: use strings.Builder to improve string concatenation perform…

### DIFF
--- a/db/state/merge.go
+++ b/db/state/merge.go
@@ -241,17 +241,17 @@ func NewHistoryRanges(history MergeRange, index MergeRange) HistoryRanges {
 }
 
 func (r HistoryRanges) String(aggStep uint64) string {
-	var str string
+	var str strings.Builder
 	if r.history.needMerge {
-		str += r.history.String("hist", aggStep)
+		str.WriteString(r.history.String("hist", aggStep))
 	}
 	if r.index.needMerge {
-		if str != "" {
-			str += ", "
+		if str.Len() > 0 {
+			str.WriteString(", ")
 		}
-		str += r.index.String("idx", aggStep)
+		str.WriteString(r.index.String("idx", aggStep))
 	}
-	return str
+	return str.String()
 }
 func (r HistoryRanges) any() bool {
 	return r.history.needMerge || r.index.needMerge

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -1109,25 +1109,26 @@ func (c *cell) IsEmpty() bool {
 }
 
 func (c *cell) String() string {
-	s := "("
+	var s strings.Builder
+	s.WriteString("(")
 	if c.hashLen > 0 {
-		s += fmt.Sprintf("hash(len=%d)=%x, ", c.hashLen, c.hash)
+		s.WriteString(fmt.Sprintf("hash(len=%d)=%x, ", c.hashLen, c.hash))
 	}
 	if c.hashedExtLen > 0 {
-		s += fmt.Sprintf("hashedExtension(len=%d)=%x, ", c.hashedExtLen, c.hashedExtension[:c.hashedExtLen])
+		s.WriteString(fmt.Sprintf("hashedExtension(len=%d)=%x, ", c.hashedExtLen, c.hashedExtension[:c.hashedExtLen]))
 	}
 	if c.extLen > 0 {
-		s += fmt.Sprintf("extension(len=%d)=%x, ", c.extLen, c.extension[:c.extLen])
+		s.WriteString(fmt.Sprintf("extension(len=%d)=%x, ", c.extLen, c.extension[:c.extLen]))
 	}
 	if c.accountAddrLen > 0 {
-		s += fmt.Sprintf("accountAddr=%x, ", c.accountAddr)
+		s.WriteString(fmt.Sprintf("accountAddr=%x, ", c.accountAddr))
 	}
 	if c.storageAddrLen > 0 {
-		s += fmt.Sprintf("storageAddr=%x, ", c.storageAddr)
+		s.WriteString(fmt.Sprintf("storageAddr=%x, ", c.storageAddr))
 	}
 
-	s += ")"
-	return s
+	s.WriteString(")")
+	return s.String()
 }
 
 func (hph *HexPatriciaHashed) PrintGrid() {

--- a/rpc/jsonrpc/trace_types.go
+++ b/rpc/jsonrpc/trace_types.go
@@ -18,6 +18,7 @@ package jsonrpc
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/hexutil"
@@ -129,16 +130,16 @@ type TraceResult struct {
 
 // Allows for easy printing of a geth trace for debugging
 func (p GethTrace) String() string {
-	var ret string
-	ret += fmt.Sprintf("Type: %s\n", p.Type)
-	ret += fmt.Sprintf("From: %s\n", p.From)
-	ret += fmt.Sprintf("To: %s\n", p.To)
-	ret += fmt.Sprintf("Value: %s\n", p.Value)
-	ret += fmt.Sprintf("Gas: %s\n", p.Gas)
-	ret += fmt.Sprintf("GasUsed: %s\n", p.GasUsed)
-	ret += fmt.Sprintf("Input: %s\n", p.Input)
-	ret += fmt.Sprintf("Output: %s\n", p.Output)
-	return ret
+	var ret strings.Builder
+	ret.WriteString(fmt.Sprintf("Type: %s\n", p.Type))
+	ret.WriteString(fmt.Sprintf("From: %s\n", p.From))
+	ret.WriteString(fmt.Sprintf("To: %s\n", p.To))
+	ret.WriteString(fmt.Sprintf("Value: %s\n", p.Value))
+	ret.WriteString(fmt.Sprintf("Gas: %s\n", p.Gas))
+	ret.WriteString(fmt.Sprintf("GasUsed: %s\n", p.GasUsed))
+	ret.WriteString(fmt.Sprintf("Input: %s\n", p.Input))
+	ret.WriteString(fmt.Sprintf("Output: %s\n", p.Output))
+	return ret.String()
 }
 
 // Allows for easy printing of a parity trace for debugging


### PR DESCRIPTION
Replaces inefficient string concatenation operations with strings.Builder 
for better performance and reduced memory allocations.

refer to #18189

Tried my best to find all the same issue.... let me know if there are more.