### PR TITLE
node/ethstats: remove dead engine parameter

### DIFF
--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -1144,7 +1144,7 @@ func (s *Ethereum) Init(stack *node.Node, config *ethconfig.Config, chainConfig 
 	if config.Ethstats != "" {
 		var headCh chan [][]byte
 		headCh, s.unsubscribeEthstat = s.notifications.Events.AddHeaderSubscription()
-		if err := ethstats.New(stack, s.sentryServers, chainKv, s.blockReader, s.engine, config.Ethstats, s.networkID, ctx.Done(), headCh, s.txPoolRpcClient); err != nil {
+		if err := ethstats.New(stack, s.sentryServers, chainKv, s.blockReader, config.Ethstats, s.networkID, ctx.Done(), headCh, s.txPoolRpcClient); err != nil {
 			return err
 		}
 	}

--- a/node/ethstats/ethstats.go
+++ b/node/ethstats/ethstats.go
@@ -41,7 +41,6 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/rawdb"
 	"github.com/erigontech/erigon/db/services"
-	"github.com/erigontech/erigon/execution/protocol/rules"
 	"github.com/erigontech/erigon/execution/stagedsync/stages"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/node"
@@ -66,7 +65,6 @@ type Service struct {
 	servers   []*sentry.GrpcServer // Peer-to-peer server to retrieve networking infos
 	chaindb   kv.RoDB
 	networkid uint64
-	engine    rules.Engine // Rules engine to retrieve variadic block fields
 
 	node string // Name of the node to display on the monitoring page
 	pass string // Password to authorize access to the monitoring page
@@ -133,7 +131,7 @@ func (w *connWrapper) Close() error {
 
 // New returns a monitoring service ready for stats reporting.
 func New(node *node.Node, servers []*sentry.GrpcServer, chainDB kv.RoDB, blockReader services.FullBlockReader,
-	engine rules.Engine, url string, networkid uint64, quitCh <-chan struct{}, headCh chan [][]byte, txPoolRpcClient txpoolproto.TxpoolClient) error {
+	url string, networkid uint64, quitCh <-chan struct{}, headCh chan [][]byte, txPoolRpcClient txpoolproto.TxpoolClient) error {
 	// Parse the netstats connection url
 	parts := urlRegex.FindStringSubmatch(url)
 	if len(parts) != 5 {
@@ -141,7 +139,6 @@ func New(node *node.Node, servers []*sentry.GrpcServer, chainDB kv.RoDB, blockRe
 	}
 	ethstats := &Service{
 		blockReader: blockReader,
-		engine:      engine,
 		servers:     servers,
 		node:        parts[1],
 		pass:        parts[3],


### PR DESCRIPTION
The ethstats Service kept a rules.Engine field and constructor parameter that were never used after the Erigon fork from geth. The original geth implementation relied on the consensus engine to derive block authors, but Erigon’s ethstats now reads all necessary fields directly from the block header and DB.  