### PR TITLE
txnprovider/txpool: remove redundant hashes loop

### DIFF
--- a/txnprovider/txpool/send.go
+++ b/txnprovider/txpool/send.go
@@ -112,25 +112,14 @@ func (f *Send) AnnouncePooledTxns(types []byte, sizes []uint32, hashes Hashes, m
 	if len(types) == 0 {
 		return
 	}
-	prevI := 0
 	prevJ := 0
-	for prevI < len(hashes) || prevJ < len(types) {
-		// Prepare two versions of the announcement message, one for pre-eth/68 peers, another for post-eth/68 peers
-		i := prevI
-		for i < len(hashes) && rlp.HashesLen(hashes[prevI:i+32]) < p2pTxPacketLimit {
-			i += 32
-		}
+	for prevJ < len(types) {
 		j := prevJ
 		for j < len(types) && rlp.AnnouncementsLen(types[prevJ:j+1], sizes[prevJ:j+1], hashes[32*prevJ:32*j+32]) < p2pTxPacketLimit {
 			j++
 		}
-		iSize := rlp.HashesLen(hashes[prevI:i])
 		jSize := rlp.AnnouncementsLen(types[prevJ:j], sizes[prevJ:j], hashes[32*prevJ:32*j])
-		iData := make([]byte, iSize)
 		jData := make([]byte, jSize)
-		if s := rlp.EncodeHashes(hashes[prevI:i], iData); s != iSize {
-			panic(fmt.Sprintf("Serialised hashes encoding len mismatch, expected %d, got %d", iSize, s))
-		}
 		if s := rlp.EncodeAnnouncements(types[prevJ:j], sizes[prevJ:j], hashes[32*prevJ:32*j], jData); s != jSize {
 			panic(fmt.Sprintf("Serialised announcements encoding len mismatch, expected %d, got %d", jSize, s))
 		}
@@ -167,7 +156,6 @@ func (f *Send) AnnouncePooledTxns(types []byte, sizes []uint32, hashes Hashes, m
 					}
 				}
 			}
-			prevI = i
 			prevJ = j
 		}
 	}


### PR DESCRIPTION
The propagation loop only needs to batch by types, sizes and their corresponding hashes. The hashes batching cursor (prevI) was a leftover from a pre-eth/68 implementation and could cause one extra no-op iteration when hashes outnumbered types in RLP terms. This change simplifies the loop to iterate solely over types, removes the unused prevI/i logic and avoids the redundant iteration without changing the content or batching of propagated announcements.