### PR TITLE
hive: temporarily use older hive commit to fix ci

### DIFF
--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: ethereum/hive
-          # ref: master
+          ref: 73fb4440b1fe4b362bf66e6278ec7d46b254f362
           path: hive
 
       - name: Setup go env and cache


### PR DESCRIPTION
hive started failing since a recent change in the hive repo: https://github.com/ethereum/hive/commit/a378713f9212e8b3728ffc0c95b6885356e7993f

for us the fix should be https://github.com/erigontech/erigon/pull/18286, however there were some other errors that were uncovered (seemingly coming from Geth) due to the Geth version update in Hive

for now just using the Hive commit before the above change to get our CI back to green until the dust settles and we figure out all the issues