### PR TITLE
Fix incorrect committee count in process_attestation

### DIFF
--- a/cl/transition/impl/eth2/operations.go
+++ b/cl/transition/impl/eth2/operations.go
@@ -610,7 +610,7 @@ func (I *impl) processAttestationPostAltair(
 		committeeOffset := 0
 		for _, committeeIndex := range committeeIndices {
 			// assert committee_index < get_committee_count_per_slot(state, data.target.epoch)
-			if uint64(committeeIndex) >= s.CommitteeCount(currentEpoch) {
+			if uint64(committeeIndex) >= s.CommitteeCount(data.Target.Epoch) {
 				return nil, errors.New("processAttestationPostAltair: committee index out of bounds")
 			}
 			committee, err := s.GetBeaconCommitee(data.Slot, uint64(committeeIndex))


### PR DESCRIPTION
issue https://github.com/erigontech/erigon/issues/18308

https://beacon.chiadochain.net/slot/20031440
target epoch is `1251964` , but in our codebase, committee count is computed by current epoch `1251965`