### PR TITLE
Cherry-pick: Refactor: Extract BlobHistoryDownloader into dedicated struct (#18269)

### DIFF
--- a/cl/clparams/config.go
+++ b/cl/clparams/config.go
@@ -320,8 +320,8 @@ var NetworkConfigs map[NetworkType]NetworkConfig = map[NetworkType]NetworkConfig
 var CheckpointSyncEndpoints = map[NetworkType][]string{
 	chainspec.MainnetChainID: {
 		"https://sync.invis.tools/eth/v2/debug/beacon/states/finalized",
+		"https://sync-mainnet.beaconcha.in/eth/v2/debug/beacon/states/finalized",
 		"https://mainnet-checkpoint-sync.attestant.io/eth/v2/debug/beacon/states/finalized",
-		//"https://mainnet.checkpoint.sigp.io/eth/v2/debug/beacon/states/finalized",
 		"https://mainnet-checkpoint-sync.stakely.io/eth/v2/debug/beacon/states/finalized",
 		"https://checkpointz.pietjepuk.net/eth/v2/debug/beacon/states/finalized",
 	},

--- a/cl/phase1/network/backward_beacon_downloader.go
+++ b/cl/phase1/network/backward_beacon_downloader.go
@@ -59,7 +59,7 @@ func NewBackwardBeaconDownloader(ctx context.Context, rpc *rpc.BeaconRpcP2P, sn 
 		ctx:         ctx,
 		rpc:         rpc,
 		db:          db,
-		reqInterval: time.NewTicker(600 * time.Millisecond),
+		reqInterval: time.NewTicker(200 * time.Millisecond),
 		neverSkip:   true,
 		engine:      engine,
 		sn:          sn,
@@ -118,88 +118,113 @@ func (b *BackwardBeaconDownloader) Peers() (uint64, error) {
 }
 
 // RequestMore downloads a range of blocks in a backward manner.
-// The function sends a request for a range of blocks starting from a given slot and ending count blocks before it.
-// It then processes the response by iterating over the blocks in reverse order and calling a provided callback function onNewBlock on each block.
-// If the callback returns an error or signals that the download should be finished, the function will exit.
-// If the block's root hash does not match the expected root hash, it will be rejected and the function will continue to the next block.
+// It requests blocks, processes them in reverse order via the onNewBlock callback,
+// and rejects blocks whose root hash doesn't match the expected root.
 func (b *BackwardBeaconDownloader) RequestMore(ctx context.Context) error {
-	count := uint64(16)
+	responses, err := b.fetchBlockRange(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := b.processResponses(responses); err != nil {
+		return err
+	}
+
+	if !b.neverSkip {
+		return nil
+	}
+
+	return b.trySkipToExistingBlock(ctx)
+}
+
+// fetchBlockRange requests a range of blocks from peers and waits for a response.
+func (b *BackwardBeaconDownloader) fetchBlockRange(ctx context.Context) ([]*cltypes.SignedBeaconBlock, error) {
+	const count = uint64(64)
 	start := b.slotToDownload.Load() - count + 1
-	// Overflow? round to 0.
-	if start > b.slotToDownload.Load() {
+	if start > b.slotToDownload.Load() { // overflow check
 		start = 0
 	}
 
-	var responses []*cltypes.SignedBeaconBlock
-	var received = make(chan []*cltypes.SignedBeaconBlock)
+	// Buffered channel prevents goroutine leaks
+	received := make(chan []*cltypes.SignedBeaconBlock, 1)
+	var requestSent atomic.Bool
 
-Loop:
 	for {
 		select {
-		case <-b.reqInterval.C:
-			if len(received) == 0 {
-				go func() {
-					blocks, peerId, err := b.rpc.SendBeaconBlocksByRangeReq(ctx, start, count)
-					if err != nil {
-						b.rpc.BanPeer(peerId)
-						return
-					}
-					if blocks == nil {
-						b.rpc.BanPeer(peerId)
-						return
-					}
-					if len(blocks) == 0 {
-						b.rpc.BanPeer(peerId)
-						return
-					}
-					if len(received) == 0 {
-						received <- blocks
-					}
-				}()
-			}
 		case <-ctx.Done():
-			return ctx.Err()
-		case responses = <-received:
-			break Loop
+			return nil, ctx.Err()
+
+		case <-b.reqInterval.C:
+			if requestSent.Swap(true) {
+				continue // request already in flight
+			}
+			go b.sendBlockRequest(ctx, start, count, received, &requestSent)
+
+		case responses := <-received:
+			return responses, nil
 		}
 	}
+}
 
-	// Import new blocks, order is forward so reverse the whole packet
+// sendBlockRequest sends a block range request and writes the result to the channel.
+func (b *BackwardBeaconDownloader) sendBlockRequest(
+	ctx context.Context,
+	start, count uint64,
+	received chan<- []*cltypes.SignedBeaconBlock,
+	requestSent *atomic.Bool,
+) {
+	blocks, peerId, err := b.rpc.SendBeaconBlocksByRangeReq(ctx, start, count)
+	if err != nil || blocks == nil || len(blocks) == 0 {
+		b.rpc.BanPeer(peerId)
+		requestSent.Store(false)
+		return
+	}
+
+	select {
+	case received <- blocks:
+	default:
+		// Response already received, discard
+	}
+}
+
+// processResponses processes downloaded blocks in reverse order.
+func (b *BackwardBeaconDownloader) processResponses(responses []*cltypes.SignedBeaconBlock) error {
 	for i := len(responses) - 1; i >= 0; i-- {
 		if b.finished.Load() {
 			return nil
 		}
-		segment := responses[i]
-		// is this new block root equal to the expected root?
-		blockRoot, err := segment.Block.HashSSZ()
+
+		block := responses[i]
+		blockRoot, err := block.Block.HashSSZ()
 		if err != nil {
-			log.Debug("Could not compute block root while processing packet", "err", err)
+			log.Debug("Could not compute block root", "err", err)
 			continue
 		}
-		// No? Reject.
+
 		if blockRoot != b.expectedRoot {
-			log.Debug("Gotten unexpected root", "got", common.Hash(blockRoot), "expected", b.expectedRoot)
+			log.Debug("Unexpected root", "got", common.Hash(blockRoot), "expected", b.expectedRoot)
 			continue
 		}
-		// Yes? then go for the callback.
-		finished, err := b.onNewBlock(segment)
+
+		finished, err := b.onNewBlock(block)
 		b.finished.Store(finished)
 		if err != nil {
-			log.Warn("Found error while processing packet", "err", err)
+			log.Warn("Error processing block", "err", err)
 			continue
 		}
-		// set expected root to the segment parent root
-		b.expectedRoot = segment.Block.ParentRoot
-		if segment.Block.Slot == 0 {
+
+		b.expectedRoot = block.Block.ParentRoot
+		if block.Block.Slot == 0 {
 			b.finished.Store(true)
 			return nil
 		}
-		b.slotToDownload.Store(segment.Block.Slot - 1) // update slot (might be inexact but whatever)
+		b.slotToDownload.Store(block.Block.Slot - 1)
 	}
-	if !b.neverSkip {
-		return nil
-	}
-	// try skipping if the next slot is in db
+	return nil
+}
+
+// trySkipToExistingBlock attempts to skip ahead if the expected block already exists in the database.
+func (b *BackwardBeaconDownloader) trySkipToExistingBlock(ctx context.Context) error {
 	tx, err := b.db.BeginRw(b.ctx)
 	if err != nil {
 		return err
@@ -210,18 +235,19 @@ Loop:
 	if b.engine != nil && b.engine.SupportInsertion() {
 		elFrozenBlocks = b.engine.FrozenBlocks(ctx)
 	}
+
 	clFrozenBlocks := uint64(0)
 	if b.sn != nil {
 		clFrozenBlocks = b.sn.SegmentsMax()
 	}
 
-	updateFrozenBlocksTicker := time.NewTicker(5 * time.Second)
-	defer updateFrozenBlocksTicker.Stop()
-	// it will stop if we end finding a gap or if we reach the maxIterations
-	for {
+	refreshTicker := time.NewTicker(5 * time.Second)
+	defer refreshTicker.Stop()
 
+	for {
+		// Periodically refresh frozen block counts
 		select {
-		case <-updateFrozenBlocksTicker.C:
+		case <-refreshTicker.C:
 			if b.sn != nil {
 				clFrozenBlocks = b.sn.SegmentsMax()
 			}
@@ -231,61 +257,68 @@ Loop:
 		default:
 		}
 
-		// check if the expected root is in db
 		slot, err := beacon_indicies.ReadBlockSlotByBlockRoot(tx, b.expectedRoot)
 		if err != nil {
 			return err
 		}
-
 		if slot == nil || *slot == 0 {
 			break
 		}
 
-		if b.engine != nil && b.engine.SupportInsertion() {
-			blockHash, err := beacon_indicies.ReadExecutionBlockHash(tx, b.expectedRoot)
-			if err != nil {
-				return err
-			}
-			blockNumber, err := beacon_indicies.ReadExecutionBlockNumber(tx, b.expectedRoot)
-			if err != nil {
-				return err
-			}
-			if blockHash == (common.Hash{}) || blockNumber == nil {
-				break
-			}
-			if *blockNumber >= elFrozenBlocks {
-				has, err := b.engine.HasBlock(ctx, blockHash)
-				if err != nil {
-					return err
-				}
-				if !has {
-					break
-				}
-			}
-		}
-		if *slot <= clFrozenBlocks {
+		if !b.canSkipSlot(ctx, tx, elFrozenBlocks, clFrozenBlocks, *slot) {
 			break
 		}
+
 		b.slotToDownload.Store(*slot - 1)
 		if err := beacon_indicies.MarkRootCanonical(b.ctx, tx, *slot, b.expectedRoot); err != nil {
 			return err
 		}
+
 		b.expectedRoot, err = beacon_indicies.ReadParentBlockRoot(b.ctx, tx, b.expectedRoot)
 		if err != nil {
 			return err
 		}
-		// Some cleaning of possible ugly restarts
-		newSlotToDownload, err := beacon_indicies.ReadBlockSlotByBlockRoot(tx, b.expectedRoot)
+
+		// Clean up non-canonical slots
+		newSlot, err := beacon_indicies.ReadBlockSlotByBlockRoot(tx, b.expectedRoot)
 		if err != nil {
 			return err
 		}
-		if newSlotToDownload == nil || *newSlotToDownload == 0 {
+		if newSlot == nil || *newSlot == 0 {
 			continue
 		}
-		for i := *newSlotToDownload + 1; i < *slot; i++ {
+		for i := *newSlot + 1; i < *slot; i++ {
 			tx.Delete(kv.CanonicalBlockRoots, base_encoding.Encode64ToBytes4(i))
 		}
 	}
 
 	return tx.Commit()
+}
+
+// canSkipSlot checks if we can skip to an existing block at the given slot.
+func (b *BackwardBeaconDownloader) canSkipSlot(ctx context.Context, tx kv.Tx, elFrozenBlocks, clFrozenBlocks, slot uint64) bool {
+	if slot <= clFrozenBlocks {
+		return false
+	}
+
+	if b.engine == nil || !b.engine.SupportInsertion() {
+		return true
+	}
+
+	blockHash, err := beacon_indicies.ReadExecutionBlockHash(tx, b.expectedRoot)
+	if err != nil || blockHash == (common.Hash{}) {
+		return false
+	}
+
+	blockNumber, err := beacon_indicies.ReadExecutionBlockNumber(tx, b.expectedRoot)
+	if err != nil || blockNumber == nil {
+		return false
+	}
+
+	if *blockNumber < elFrozenBlocks {
+		return true
+	}
+
+	has, err := b.engine.HasBlock(ctx, blockHash)
+	return err == nil && has
 }

--- a/cl/phase1/network/blob_downloader.go
+++ b/cl/phase1/network/blob_downloader.go
@@ -1,0 +1,372 @@
+// Copyright 2024 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package network
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/das"
+	"github.com/erigontech/erigon/cl/persistence/blob_storage"
+	"github.com/erigontech/erigon/cl/rpc"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/snapshotsync/freezeblocks"
+)
+
+const (
+	blobDownloaderInterval      = 12 * time.Second
+	blobLogInterval             = 30 * time.Second
+	blobBackfillWarningInterval = 4 * time.Minute
+	blocksBatchSize             = uint64(8)
+	maxIterations               = uint64(32)
+	minPeersForBlobDownload     = 16
+)
+
+// SyncedChecker is an interface to check if the forkchoice is synced
+type SyncedChecker interface {
+	Synced() bool
+}
+
+// PeerDasGetter is an interface to get the PeerDas instance
+type PeerDasGetter interface {
+	GetPeerDas() das.PeerDas
+}
+
+// BlobHistoryDownloader downloads blob history backwards from a head slot
+type BlobHistoryDownloader struct {
+	ctx context.Context
+
+	beaconCfg   *clparams.BeaconChainConfig
+	rpc         *rpc.BeaconRpcP2P
+	indiciesDB  kv.RoDB
+	blobStorage blob_storage.BlobStorage
+	blockReader freezeblocks.BeaconSnapshotReader
+	sn          *freezeblocks.CaplinSnapshots
+
+	syncedChecker SyncedChecker
+	peerDasGetter PeerDasGetter
+
+	// headSlot is the slot we start downloading from (currentSlot + 1)
+	headSlot atomic.Uint64
+	// highestBackfilledSlot is the highest slot we've successfully backfilled to
+	highestBackfilledSlot atomic.Uint64
+	// targetSlot is the slot we're trying to reach (Deneb fork epoch start)
+	targetSlot uint64
+	// archiveBlobs indicates whether to archive all blobs or just recent ones
+	archiveBlobs bool
+	// immediateBlobsBackfilling indicates whether to backfill blobs immediately
+	immediateBlobsBackfilling bool
+
+	running           atomic.Bool
+	backfillCompleted atomic.Bool
+	logger            log.Logger
+
+	// notifyBlobBackfilled is called when blob backfilling is complete
+	notifyBlobBackfilled func()
+
+	mu sync.RWMutex
+}
+
+// NewBlobHistoryDownloader creates a new BlobHistoryDownloader
+func NewBlobHistoryDownloader(
+	ctx context.Context,
+	beaconCfg *clparams.BeaconChainConfig,
+	rpc *rpc.BeaconRpcP2P,
+	indiciesDB kv.RoDB,
+	blobStorage blob_storage.BlobStorage,
+	blockReader freezeblocks.BeaconSnapshotReader,
+	sn *freezeblocks.CaplinSnapshots,
+	syncedChecker SyncedChecker,
+	peerDasGetter PeerDasGetter,
+	archiveBlobs bool,
+	immediateBlobsBackfilling bool,
+	logger log.Logger,
+) *BlobHistoryDownloader {
+	targetSlot := beaconCfg.DenebForkEpoch * beaconCfg.SlotsPerEpoch
+	return &BlobHistoryDownloader{
+		ctx:                       ctx,
+		beaconCfg:                 beaconCfg,
+		rpc:                       rpc,
+		indiciesDB:                indiciesDB,
+		blobStorage:               blobStorage,
+		blockReader:               blockReader,
+		sn:                        sn,
+		syncedChecker:             syncedChecker,
+		peerDasGetter:             peerDasGetter,
+		targetSlot:                targetSlot,
+		archiveBlobs:              archiveBlobs,
+		immediateBlobsBackfilling: immediateBlobsBackfilling,
+		logger:                    logger,
+	}
+}
+
+// SetHeadSlot sets the head slot to download from (should be currentSlot + 1)
+func (b *BlobHistoryDownloader) SetHeadSlot(slot uint64) {
+	b.headSlot.Store(slot)
+}
+
+// SetNotifyBlobBackfilled sets the callback for when blob backfilling is complete
+func (b *BlobHistoryDownloader) SetNotifyBlobBackfilled(notify func()) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.notifyBlobBackfilled = notify
+}
+
+// HeadSlot returns the current head slot
+func (b *BlobHistoryDownloader) HeadSlot() uint64 {
+	return b.headSlot.Load()
+}
+
+// HighestBackfilledSlot returns the highest slot that has been backfilled
+func (b *BlobHistoryDownloader) HighestBackfilledSlot() uint64 {
+	return b.highestBackfilledSlot.Load()
+}
+
+// Running returns whether the downloader is currently running
+func (b *BlobHistoryDownloader) Running() bool {
+	return b.running.Load()
+}
+
+// Start begins the blob history download loop, querying every 12 seconds
+func (b *BlobHistoryDownloader) Start() {
+	if !b.archiveBlobs && !b.immediateBlobsBackfilling {
+		return // nothing to do
+	}
+	if b.running.Swap(true) {
+		return // already running
+	}
+
+	go b.run()
+}
+
+func (b *BlobHistoryDownloader) run() {
+	defer b.running.Store(false)
+
+	// Do an initial download immediately
+	if err := b.downloadOnce(true); err != nil {
+		b.logger.Error("[BlobHistoryDownloader] Error downloading blobs", "err", err)
+	}
+
+	downloadTimer := time.NewTimer(blobDownloaderInterval)
+	defer downloadTimer.Stop()
+
+	warningTimer := time.NewTimer(blobBackfillWarningInterval)
+	defer warningTimer.Stop()
+
+	for {
+		select {
+		case <-b.ctx.Done():
+			return
+		case <-downloadTimer.C:
+			if err := b.downloadOnce(false); err != nil {
+				b.logger.Error("[BlobHistoryDownloader] Error downloading blobs", "err", err)
+			}
+			downloadTimer.Reset(blobDownloaderInterval)
+		case <-warningTimer.C:
+			if !b.backfillCompleted.Load() {
+				b.logger.Warn("[BlobHistoryDownloader] Blob backfilling is not finished, some blobs might be unavailable", "currentSlot", b.headSlot.Load(), "highestBackfilled", b.highestBackfilledSlot.Load())
+			}
+			warningTimer.Reset(blobBackfillWarningInterval)
+		}
+	}
+}
+
+// downloadOnce performs a single download pass
+func (b *BlobHistoryDownloader) downloadOnce(shouldLog bool) error {
+	currentSlot := b.headSlot.Load()
+	if currentSlot == 0 {
+		return nil // not initialized yet
+	}
+
+	// Check peer count before proceeding
+	peers, err := b.rpc.Peers()
+	if err != nil {
+		b.logger.Warn("[BlobHistoryDownloader] Failed to get peer count", "err", err)
+		return nil
+	}
+	if peers < minPeersForBlobDownload {
+		b.logger.Warn("[BlobHistoryDownloader] Skipping iteration due to low peer count", "peers", peers, "required", minPeersForBlobDownload)
+		return nil
+	}
+
+	tx, err := b.indiciesDB.BeginRo(b.ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	logInterval := time.NewTicker(blobLogInterval)
+	defer logInterval.Stop()
+
+	prevLogSlot := currentSlot
+	prevTime := time.Now()
+
+	targetSlot := b.targetSlot
+	// in case of non-archive mode, we only backfill the last relevant epochs
+	if !b.archiveBlobs {
+		targetSlot = currentSlot - min(currentSlot, b.beaconCfg.MinSlotsForBlobsSidecarsRequest())
+	}
+
+	defer func() {
+		// set target slot back in case it was modified
+		b.targetSlot = currentSlot - b.beaconCfg.SlotsPerEpoch*2
+	}()
+
+	if shouldLog {
+		b.logger.Info("[BlobHistoryDownloader] Downloading blobs backwards", "slot", currentSlot)
+	}
+
+	for currentSlot >= targetSlot {
+		if currentSlot <= b.sn.FrozenBlobs() {
+			break
+		}
+		if !b.syncedChecker.Synced() {
+			time.Sleep(5 * time.Second)
+			continue
+		}
+
+		batch := make([]*cltypes.SignedBlindedBeaconBlock, 0, blocksBatchSize)
+		visited := uint64(0)
+		for ; visited < blocksBatchSize; visited++ {
+			if visited >= maxIterations {
+				break
+			}
+			if currentSlot-visited < targetSlot {
+				break
+			}
+			block, err := b.blockReader.ReadBlindedBlockBySlot(b.ctx, tx, currentSlot-visited)
+			if err != nil {
+				return err
+			}
+			if block == nil {
+				continue
+			}
+			if block.Version() < clparams.DenebVersion {
+				break
+			}
+			blockRoot, err := block.Block.HashSSZ()
+			if err != nil {
+				return err
+			}
+			blobsCount, err := b.blobStorage.KzgCommitmentsCount(b.ctx, blockRoot)
+			if err != nil {
+				return err
+			}
+
+			if block.Block.Body.BlobKzgCommitments.Len() == int(blobsCount) {
+				continue
+			}
+			batch = append(batch, block)
+		}
+		if len(batch) == 0 {
+			currentSlot -= visited
+			continue
+		}
+
+		select {
+		case <-b.ctx.Done():
+			return b.ctx.Err()
+		case <-logInterval.C:
+			if !shouldLog {
+				continue
+			}
+			blkSec := float64(prevLogSlot-currentSlot) / time.Since(prevTime).Seconds()
+			blkSecStr := fmt.Sprintf("%.1f", blkSec)
+			prevLogSlot = currentSlot
+			prevTime = time.Now()
+
+			b.logger.Info("[BlobHistoryDownloader] Downloading blobs backwards", "slot", currentSlot, "blks/sec", blkSecStr)
+		default:
+		}
+
+		// Generate the request
+		fuluBlocks := []*cltypes.SignedBlindedBeaconBlock{}
+		denebBlocks := []*cltypes.SignedBlindedBeaconBlock{}
+		for _, block := range batch {
+			if block.Version() >= clparams.FuluVersion {
+				fuluBlocks = append(fuluBlocks, block)
+			} else {
+				denebBlocks = append(denebBlocks, block)
+			}
+		}
+
+		if len(denebBlocks) > 0 {
+			req, err := BlobsIdentifiersFromBlindedBlocks(batch, b.beaconCfg)
+			if err != nil {
+				b.logger.Debug("[BlobHistoryDownloader] Error generating blob identifiers", "err", err)
+				continue
+			}
+			// Request the blobs
+			blobs, err := RequestBlobsFrantically(b.ctx, b.rpc, req)
+			if err != nil {
+				b.logger.Debug("[BlobHistoryDownloader] Error requesting blobs", "err", err)
+				continue
+			}
+			_, _, err = blob_storage.VerifyAgainstIdentifiersAndInsertIntoTheBlobStore(b.ctx, b.blobStorage, req, blobs.Responses, func(header *cltypes.SignedBeaconBlockHeader) error {
+				// The block is preverified so just check that the signature is correct against the block
+				for _, block := range batch {
+					if block.Block.Slot != header.Header.Slot {
+						continue
+					}
+					if block.Signature != header.Signature {
+						return errors.New("signature mismatch between blob and stored block")
+					}
+					return nil
+				}
+				return errors.New("block not in batch")
+			})
+			if err != nil {
+				b.rpc.BanPeer(blobs.Peer)
+				b.logger.Warn("[BlobHistoryDownloader] Error verifying blobs", "err", err)
+				continue
+			}
+		}
+		if len(fuluBlocks) > 0 {
+			peerDas := b.peerDasGetter.GetPeerDas()
+			for _, block := range fuluBlocks {
+				if err := peerDas.DownloadColumnsAndRecoverBlobs(b.ctx, []*cltypes.SignedBlindedBeaconBlock{block}); err != nil {
+					b.logger.Warn("[BlobHistoryDownloader] Error recovering blobs from block", "err", err, "slot", block.Block.Slot)
+				}
+			}
+		}
+
+		// Update highest backfilled slot
+		b.highestBackfilledSlot.Store(currentSlot)
+	}
+
+	if shouldLog {
+		b.logger.Info("[BlobHistoryDownloader] Blob history download finished successfully")
+	}
+
+	b.backfillCompleted.Store(true)
+
+	b.mu.RLock()
+	notify := b.notifyBlobBackfilled
+	b.mu.RUnlock()
+	if notify != nil {
+		notify()
+	}
+
+	return nil
+}

--- a/cl/phase1/stages/chain_tip_sync.go
+++ b/cl/phase1/stages/chain_tip_sync.go
@@ -2,14 +2,10 @@ package stages
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"time"
 
-	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
-	"github.com/erigontech/erigon/cl/persistence/blob_storage"
-	network2 "github.com/erigontech/erigon/cl/phase1/network"
 	"github.com/erigontech/erigon/cl/sentinel/peers"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
@@ -75,62 +71,6 @@ func fetchBlocksFromReqResp(ctx context.Context, cfg *Cfg, from uint64, count ui
 	sort.Slice(blocks, func(i, j int) bool {
 		return blocks[i].Block.Slot < blocks[j].Block.Slot
 	})
-
-	denebBlocks := []*cltypes.SignedBeaconBlock{}
-	fuluBlocks := []*cltypes.SignedBlindedBeaconBlock{}
-	for _, block := range blocks {
-		blindedBlock, err := block.Blinded()
-		if err != nil {
-			return nil, err
-		}
-		if block.Version() >= clparams.FuluVersion {
-			fuluBlocks = append(fuluBlocks, blindedBlock)
-		} else if block.Version() >= clparams.DenebVersion {
-			denebBlocks = append(denebBlocks, block)
-		}
-	}
-
-	if len(fuluBlocks) > 0 {
-		// download missing column data for the fulu blocks
-		if cfg.caplinConfig.ArchiveBlobs || cfg.caplinConfig.ImmediateBlobsBackfilling {
-			if err := cfg.peerDas.DownloadColumnsAndRecoverBlobs(ctx, fuluBlocks); err != nil {
-				log.Warn("[chainTipSync] failed to download columns and recover blobs", "err", err)
-			}
-		} else {
-			if err := cfg.peerDas.DownloadOnlyCustodyColumns(ctx, fuluBlocks); err != nil {
-				log.Warn("[chainTipSync] failed to download only custody columns", "err", err)
-			}
-		}
-	}
-
-	if len(denebBlocks) > 0 {
-		// Generate blob identifiers from the retrieved blocks
-		ids, err := network2.BlobsIdentifiersFromBlocks(denebBlocks, cfg.beaconCfg)
-		if err != nil {
-			return nil, err
-		}
-		var inserted uint64
-		// Loop until all blobs are inserted into the blob store
-		for inserted != uint64(ids.Len()) {
-			select {
-			case <-ctx.Done():
-				// Context canceled or timed out
-				return nil, ctx.Err()
-			default:
-			}
-
-			// Request blobs frantically from the execution client
-			blobs, err := network2.RequestBlobsFrantically(ctx, cfg.rpc, ids)
-			if err != nil {
-				return nil, fmt.Errorf("failed to request blobs frantically: %w", err)
-			}
-
-			// Verify the blobs against identifiers and insert them into the blob store
-			if _, inserted, err = blob_storage.VerifyAgainstIdentifiersAndInsertIntoTheBlobStore(ctx, cfg.blobStore, ids, blobs.Responses, nil); err != nil {
-				return nil, fmt.Errorf("failed to verify blobs against identifiers and insert into the blob store: %w", err)
-			}
-		}
-	}
 
 	// Return the blocks and the peer ID wrapped in a PeeredObject
 	return &peers.PeeredObject[[]*cltypes.SignedBeaconBlock]{
@@ -230,8 +170,8 @@ MainLoop:
 					continue
 				}
 
-				// Process the block
-				if err := processBlock(ctx, cfg, cfg.indiciesDB, block, true, true, true); err != nil {
+				// Process the block - DA can be downloaded later if we are behind (see blobHistoryDownloader)
+				if err := processBlock(ctx, cfg, cfg.indiciesDB, block, true, true, false); err != nil {
 					log.Debug("bad blocks segment received", "err", err, "blockSlot", block.Block.Slot)
 					continue
 				}

--- a/cl/phase1/stages/clstages.go
+++ b/cl/phase1/stages/clstages.go
@@ -61,6 +61,7 @@ type Cfg struct {
 	sn                      *freezeblocks.CaplinSnapshots
 	blobStore               blob_storage.BlobStorage
 	peerDas                 das.PeerDas
+	blobDownloader          *network2.BlobHistoryDownloader
 	attestationDataProducer attestation_producer.AttestationDataProducer
 	caplinConfig            clparams.CaplinConfig
 	hasDownloaded           bool
@@ -76,6 +77,7 @@ type Args struct {
 }
 
 func ClStagesCfg(
+	ctx context.Context,
 	rpc *rpc.BeaconRpcP2P,
 	antiquary *antiquary.Antiquary,
 	ethClock eth_clock.EthereumClock,
@@ -96,6 +98,21 @@ func ClStagesCfg(
 	attestationDataProducer attestation_producer.AttestationDataProducer,
 	peerDas das.PeerDas,
 ) *Cfg {
+	blobDownloader := network2.NewBlobHistoryDownloader(
+		ctx,
+		beaconCfg,
+		rpc,
+		indiciesDB,
+		blobStore,
+		blockReader,
+		sn,
+		forkChoice,
+		forkChoice,
+		caplinConfig.ArchiveBlobs,
+		caplinConfig.ImmediateBlobsBackfilling,
+		log.Root(),
+	)
+
 	return &Cfg{
 		rpc:                     rpc,
 		antiquary:               antiquary,
@@ -111,6 +128,7 @@ func ClStagesCfg(
 		sn:                      sn,
 		blockReader:             blockReader,
 		peerDas:                 peerDas,
+		blobDownloader:          blobDownloader,
 		syncedData:              syncedData,
 		emitter:                 emitters,
 		blobStore:               blobStore,
@@ -250,7 +268,7 @@ func ConsensusClStages(ctx context.Context,
 					startingSlot := cfg.state.LatestBlockHeader().Slot
 					downloader := network2.NewBackwardBeaconDownloader(ctx, cfg.rpc, cfg.sn, cfg.executionClient, cfg.indiciesDB)
 
-					if err := SpawnStageHistoryDownload(StageHistoryReconstruction(downloader, cfg.antiquary, cfg.sn, cfg.indiciesDB, cfg.executionClient, cfg.beaconCfg, cfg.caplinConfig, false, startingRoot, startingSlot, cfg.dirs.Tmp, 600*time.Millisecond, cfg.blockCollector, cfg.blockReader, cfg.blobStore, logger, cfg.forkChoice), context.Background(), logger); err != nil {
+					if err := SpawnStageHistoryDownload(StageHistoryReconstruction(downloader, cfg.antiquary, cfg.sn, cfg.indiciesDB, cfg.executionClient, cfg.beaconCfg, cfg.caplinConfig, false, startingRoot, startingSlot, cfg.dirs.Tmp, 600*time.Millisecond, cfg.blockCollector, cfg.blockReader, cfg.blobStore, logger, cfg.forkChoice, cfg.blobDownloader), context.Background(), logger); err != nil {
 						cfg.hasDownloaded = false
 						return err
 					}

--- a/cl/phase1/stages/forkchoice.go
+++ b/cl/phase1/stages/forkchoice.go
@@ -306,6 +306,7 @@ func postForkchoiceOperations(ctx context.Context, tx kv.RwTx, logger log.Logger
 	if headState == nil {
 		return nil
 	}
+	cfg.blobDownloader.SetHeadSlot(headSlot)
 	// First emit events that depend on the head state.
 	emitHeadEvent(cfg, headSlot, headRoot, headState)
 	emitNextPaylodAttributesEvent(cfg, headSlot, headRoot, headState)

--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -18,7 +18,6 @@ package stages
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math"
 	"sync/atomic"
@@ -57,11 +56,12 @@ type StageHistoryReconstructionCfg struct {
 	blockReader              freezeblocks.BeaconSnapshotReader
 	blobStorage              blob_storage.BlobStorage
 	forkchoiceStore          forkchoice.ForkChoiceStorage
+	blobDownloader           *network.BlobHistoryDownloader
 }
 
 const logIntervalTime = 30 * time.Second
 
-func StageHistoryReconstruction(downloader *network.BackwardBeaconDownloader, antiquary *antiquary.Antiquary, sn *freezeblocks.CaplinSnapshots, indiciesDB kv.RwDB, engine execution_client.ExecutionEngine, beaconCfg *clparams.BeaconChainConfig, caplinConfig clparams.CaplinConfig, waitForAllRoutines bool, startingRoot common.Hash, startinSlot uint64, tmpdir string, backfillingThrottling time.Duration, executionBlocksCollector block_collector.BlockCollector, blockReader freezeblocks.BeaconSnapshotReader, blobStorage blob_storage.BlobStorage, logger log.Logger, forkchoiceStore forkchoice.ForkChoiceStorage) StageHistoryReconstructionCfg {
+func StageHistoryReconstruction(downloader *network.BackwardBeaconDownloader, antiquary *antiquary.Antiquary, sn *freezeblocks.CaplinSnapshots, indiciesDB kv.RwDB, engine execution_client.ExecutionEngine, beaconCfg *clparams.BeaconChainConfig, caplinConfig clparams.CaplinConfig, waitForAllRoutines bool, startingRoot common.Hash, startinSlot uint64, tmpdir string, backfillingThrottling time.Duration, executionBlocksCollector block_collector.BlockCollector, blockReader freezeblocks.BeaconSnapshotReader, blobStorage blob_storage.BlobStorage, logger log.Logger, forkchoiceStore forkchoice.ForkChoiceStorage, blobDownloader *network.BlobHistoryDownloader) StageHistoryReconstructionCfg {
 	return StageHistoryReconstructionCfg{
 		beaconCfg:                beaconCfg,
 		downloader:               downloader,
@@ -80,6 +80,7 @@ func StageHistoryReconstruction(downloader *network.BackwardBeaconDownloader, an
 		blockReader:              blockReader,
 		blobStorage:              blobStorage,
 		forkchoiceStore:          forkchoiceStore,
+		blobDownloader:           blobDownloader,
 	}
 }
 
@@ -294,25 +295,10 @@ func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Co
 		}
 
 		close(finishCh)
-		if cfg.caplinConfig.ArchiveBlobs || cfg.caplinConfig.ImmediateBlobsBackfilling {
-			go func() {
-				if err := downloadBlobHistoryWorker(cfg, ctx, true, logger); err != nil {
-					logger.Error("Error downloading blobs", "err", err)
-				}
-				// set a timer every 15 minutes as a failsafe
-				ticker := time.NewTicker(15 * time.Minute)
-				defer ticker.Stop()
-				for {
-					select {
-					case <-ctx.Done():
-						return
-					case <-ticker.C:
-						if err := downloadBlobHistoryWorker(cfg, ctx, false, logger); err != nil {
-							logger.Error("Error downloading blobs", "err", err)
-						}
-					}
-				}
-			}()
+		if cfg.blobDownloader != nil {
+			cfg.blobDownloader.SetHeadSlot(cfg.startingSlot + 1)
+			cfg.blobDownloader.SetNotifyBlobBackfilled(cfg.antiquary.NotifyBlobBackfilled)
+			cfg.blobDownloader.Start()
 		}
 	}()
 	// We block until we are done with the EL side of the backfilling with 2000 blocks of safety margin.
@@ -329,147 +315,5 @@ func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Co
 
 	cfg.logger.Info("Ready to insert history, waiting for sync cycle to finish")
 
-	return nil
-}
-
-// downloadBlobHistoryWorker is a worker that downloads the blob history by using the already downloaded beacon blocks
-func downloadBlobHistoryWorker(cfg StageHistoryReconstructionCfg, ctx context.Context, shouldLog bool, logger log.Logger) error {
-	currentSlot := cfg.startingSlot + 1
-	blocksBatchSize := uint64(8) // requests 8 blocks worth of blobs at a time
-	tx, err := cfg.indiciesDB.BeginRo(ctx)
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback()
-	logInterval := time.NewTicker(logIntervalTime)
-
-	rpc := cfg.downloader.RPC()
-	prevLogSlot := currentSlot
-	prevTime := time.Now()
-	targetSlot := cfg.beaconCfg.DenebForkEpoch * cfg.beaconCfg.SlotsPerEpoch
-	// in case of immediate blobs backfilling we need to backfill the blobs for the last relevant epochs
-	if !cfg.caplinConfig.ArchiveBlobs && cfg.caplinConfig.ImmediateBlobsBackfilling {
-		targetSlot = currentSlot - min(currentSlot, cfg.beaconCfg.MinSlotsForBlobsSidecarsRequest())
-	}
-	logger.Info("[Blobs-Downloader] Downloading blobs backwards", "slot", currentSlot)
-
-	for currentSlot >= targetSlot {
-		if currentSlot <= cfg.sn.FrozenBlobs() {
-			break
-		}
-		if !cfg.forkchoiceStore.Synced() {
-			time.Sleep(5 * time.Second)
-			continue
-		}
-
-		batch := make([]*cltypes.SignedBlindedBeaconBlock, 0, blocksBatchSize)
-		visited := uint64(0)
-		maxIterations := uint64(32)
-		for ; visited < blocksBatchSize; visited++ {
-			if visited >= maxIterations {
-				break
-			}
-			if currentSlot-visited < targetSlot {
-				break
-			}
-			block, err := cfg.blockReader.ReadBlindedBlockBySlot(ctx, tx, currentSlot-visited)
-			if err != nil {
-				return err
-			}
-			if block == nil {
-				continue
-			}
-			if block.Version() < clparams.DenebVersion {
-				break
-			}
-			blockRoot, err := block.Block.HashSSZ()
-			if err != nil {
-				return err
-			}
-			blobsCount, err := cfg.blobStorage.KzgCommitmentsCount(ctx, blockRoot)
-			if err != nil {
-				return err
-			}
-
-			if block.Block.Body.BlobKzgCommitments.Len() == int(blobsCount) {
-				continue
-			}
-			batch = append(batch, block)
-		}
-		if len(batch) == 0 {
-			currentSlot -= visited
-			continue
-		}
-
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-logInterval.C:
-			if !shouldLog {
-				continue
-			}
-			blkSec := float64(prevLogSlot-currentSlot) / time.Since(prevTime).Seconds()
-			blkSecStr := fmt.Sprintf("%.1f", blkSec)
-			// round to 1 decimal place  and convert to string
-			prevLogSlot = currentSlot
-			prevTime = time.Now()
-
-			logger.Info("[Blobs-Downloader] Downloading blobs backwards", "slot", currentSlot, "blks/sec", blkSecStr)
-		default:
-		}
-		// Generate the request
-		fuluBlocks := []*cltypes.SignedBlindedBeaconBlock{}
-		denebBlocks := []*cltypes.SignedBlindedBeaconBlock{}
-		for _, block := range batch {
-			if block.Version() >= clparams.FuluVersion {
-				fuluBlocks = append(fuluBlocks, block)
-			} else {
-				denebBlocks = append(denebBlocks, block)
-			}
-		}
-
-		if len(denebBlocks) > 0 {
-			req, err := network.BlobsIdentifiersFromBlindedBlocks(batch, cfg.beaconCfg)
-			if err != nil {
-				cfg.logger.Debug("Error generating blob identifiers", "err", err)
-				continue
-			}
-			// Request the blobs
-			blobs, err := network.RequestBlobsFrantically(ctx, rpc, req)
-			if err != nil {
-				cfg.logger.Debug("Error requesting blobs", "err", err)
-				continue
-			}
-			_, _, err = blob_storage.VerifyAgainstIdentifiersAndInsertIntoTheBlobStore(ctx, cfg.blobStorage, req, blobs.Responses, func(header *cltypes.SignedBeaconBlockHeader) error {
-				// The block is preverified so just check that the signature is correct against the block
-				for _, block := range batch {
-					if block.Block.Slot != header.Header.Slot {
-						continue
-					}
-					if block.Signature != header.Signature {
-						return errors.New("signature mismatch between blob and stored block")
-					}
-					return nil
-				}
-				return errors.New("block not in batch")
-			})
-			if err != nil {
-				rpc.BanPeer(blobs.Peer)
-				cfg.logger.Warn("Error verifying blobs", "err", err)
-				continue
-			}
-		}
-		if len(fuluBlocks) > 0 {
-			for _, block := range fuluBlocks {
-				if err := cfg.forkchoiceStore.GetPeerDas().DownloadColumnsAndRecoverBlobs(ctx, []*cltypes.SignedBlindedBeaconBlock{block}); err != nil {
-					cfg.logger.Warn("Error recovering blobs from block", "err", err, "slot", block.Block.Slot)
-				}
-			}
-		}
-	}
-	if shouldLog {
-		logger.Info("[Blobs-Downloader] Blob history download finished successfully")
-	}
-	cfg.antiquary.NotifyBlobBackfilled()
 	return nil
 }

--- a/cmd/capcli/cli.go
+++ b/cmd/capcli/cli.go
@@ -187,7 +187,7 @@ func (c *Chain) Run(ctx *Context) error {
 	}
 
 	downloader := network.NewBackwardBeaconDownloader(ctx, beacon, nil, nil, db)
-	cfg := stages.StageHistoryReconstruction(downloader, antiquary.NewAntiquary(ctx, nil, nil, nil, nil, dirs, nil, nil, nil, nil, nil, nil, nil, false, false, false, false, nil), csn, db, nil, beaconConfig, clparams.CaplinConfig{}, true, bRoot, bs.Slot(), "/tmp", 300*time.Millisecond, nil, nil, blobStorage, log.Root(), nil)
+	cfg := stages.StageHistoryReconstruction(downloader, antiquary.NewAntiquary(ctx, nil, nil, nil, nil, dirs, nil, nil, nil, nil, nil, nil, nil, false, false, false, false, nil), csn, db, nil, beaconConfig, clparams.CaplinConfig{}, true, bRoot, bs.Slot(), "/tmp", 300*time.Millisecond, nil, nil, blobStorage, log.Root(), nil, nil)
 	return stages.SpawnStageHistoryDownload(cfg, ctx, log.Root())
 }
 

--- a/cmd/caplin/caplin1/run.go
+++ b/cmd/caplin/caplin1/run.go
@@ -462,6 +462,7 @@ func RunCaplinService(ctx context.Context, engine execution_client.ExecutionEngi
 	}
 
 	stageCfg := stages.ClStagesCfg(
+		ctx,
 		beaconRpc,
 		antiq,
 		ethClock,


### PR DESCRIPTION
This PR refactors the blob history downloading logic from `downloadBlobHistoryWorker` function into a dedicated `BlobHistoryDownloader` struct in the `cl/phase1/network` package. This provides better encapsulation, testability, and allows for dynamic control of the blob backfilling process.

## Changes

### New: `cl/phase1/network/blob_downloader.go`

Introduces `BlobHistoryDownloader` struct with the following features:

- **Configurable head slot**: The `headSlot` can be updated via `SetHeadSlot()` to target higher slots as the chain progresses
- **Periodic downloading**: Runs a download loop every 12 seconds when started
- **Peer count check**: Skips iterations if peer count is below 16 and logs a warning
- **Conditional start**: Only starts the goroutine if `archiveBlobs` or `immediateBlobsBackfilling` is enabled
- **Progress tracking**: Maintains `highestBackfilledSlot` to track backfilling progress
- **Callback support**: `SetNotifyBlobBackfilled()` allows setting a callback when backfilling completes

#### Key Methods

| Method | Description |
|--------|-------------|
| `NewBlobHistoryDownloader()` | Constructor with all dependencies | | `SetHeadSlot(slot)` | Sets the target head slot (currentSlot + 1) | | `SetNotifyBlobBackfilled(fn)` | Sets completion callback | | `HeadSlot()` | Returns current head slot |
| `HighestBackfilledSlot()` | Returns highest backfilled slot | | `Running()` | Returns whether downloader is active | | `Start()` | Begins the download loop |

### Modified: `cl/phase1/stages/clstages.go`

- Added `blobDownloader` field to `Cfg` struct
- Updated `ClStagesCfg()` to accept `ctx context.Context` parameter
- Creates `BlobHistoryDownloader` instance in the config constructor

### Modified: `cl/phase1/stages/stage_history_download.go`

- Added `blobDownloader` field to `StageHistoryReconstructionCfg`
- Updated `StageHistoryReconstruction()` to accept `blobDownloader` parameter
- Removed inline `downloadBlobHistoryWorker` function (~140 lines)
- Stage now uses the passed-in `blobDownloader` instance

## Migration Notes

This is a refactor with no behavioral changes to the blob downloading logic. The same functionality is preserved but now encapsulated in a reusable struct. Additionally, we can defer blob download everwhere except for gossip