### PR TITLE
[r3.3] hive: temporarily use older hive commit to fix ci (#18302)

### DIFF
--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -18,6 +18,8 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: ethereum/hive
+          # Temporary pin to fix CI issues with ethereum/hive (see https://github.com/ethereum/hive/issues/XXXX)
+          # TODO: Revert to 'main' once upstream issues are resolved
           ref: 73fb4440b1fe4b362bf66e6278ec7d46b254f362
           path: hive
 


### PR DESCRIPTION
See #18302

(cherry picked from commit b202139c50933045f76bb28c8ac8517e57df7d8d)