### PR TITLE
chore: use strings.Builder for string concatenation

### DIFF
--- a/db/kv/prune/storage_mode.go
+++ b/db/kv/prune/storage_mode.go
@@ -89,14 +89,15 @@ func (m Mode) String() string {
 		return blockModeStr
 	}
 
-	short := archiveModeStr
+	var short strings.Builder
+	short.WriteString(archiveModeStr)
 	if m.History.toValue() != DefaultMode.History.toValue() {
-		short += fmt.Sprintf(" --prune.distance=%d", m.History.toValue())
+		short.WriteString(fmt.Sprintf(" --prune.distance=%d", m.History.toValue()))
 	}
 	if m.Blocks.toValue() != DefaultMode.Blocks.toValue() {
-		short += fmt.Sprintf(" --prune.distance.blocks=%d", m.Blocks.toValue())
+		short.WriteString(fmt.Sprintf(" --prune.distance.blocks=%d", m.Blocks.toValue()))
 	}
-	return strings.TrimLeft(short, " ")
+	return strings.TrimLeft(short.String(), " ")
 }
 
 func FromCli(pruneMode string, distanceHistory, distanceBlocks uint64) (Mode, error) {

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -289,32 +289,36 @@ type transport interface {
 }
 
 func (c *conn) String() string {
-	s := c.flags.String()
+	var s strings.Builder
+	s.WriteString(c.flags.String())
 	if (c.node.ID() != enode.ID{}) {
-		s += " " + c.node.ID().String()
+		s.WriteString(" ")
+		s.WriteString(c.node.ID().String())
 	}
-	s += " " + c.fd.RemoteAddr().String()
-	return s
+	s.WriteString(" ")
+	s.WriteString(c.fd.RemoteAddr().String())
+	return s.String()
 }
 
 func (f connFlag) String() string {
-	s := ""
+	var s strings.Builder
 	if f&trustedConn != 0 {
-		s += "-trusted"
+		s.WriteString("-trusted")
 	}
 	if f&dynDialedConn != 0 {
-		s += "-dyndial"
+		s.WriteString("-dyndial")
 	}
 	if f&staticDialedConn != 0 {
-		s += "-staticdial"
+		s.WriteString("-staticdial")
 	}
 	if f&inboundConn != 0 {
-		s += "-inbound"
+		s.WriteString("-inbound")
 	}
-	if s != "" {
-		s = s[1:]
+	str := s.String()
+	if str != "" {
+		return str[1:]
 	}
-	return s
+	return str
 }
 
 func (c *conn) is(f connFlag) bool {


### PR DESCRIPTION
Replace string concatenation with strings.Builder, avoids allocating new string objects on each + operation.