### PR TITLE
cl/rpc: remove unused count param in blobs sidecar helper

### DIFF
--- a/cl/rpc/rpc.go
+++ b/cl/rpc/rpc.go
@@ -96,7 +96,7 @@ func (b *BeaconRpcP2P) sendBlocksRequest(ctx context.Context, topic string, reqD
 	return responsePacket, pid, nil
 }
 
-func (b *BeaconRpcP2P) sendBlobsSidecar(ctx context.Context, topic string, reqData []byte, count uint64) ([]*cltypes.BlobSidecar, string, error) {
+func (b *BeaconRpcP2P) sendBlobsSidecar(ctx context.Context, topic string, reqData []byte) ([]*cltypes.BlobSidecar, string, error) {
 	responses, pid, err := b.sendRequest(ctx, topic, reqData)
 	if err != nil {
 		return nil, pid, err
@@ -188,7 +188,7 @@ func (b *BeaconRpcP2P) SendBlobsSidecarByIdentifierReq(ctx context.Context, req 
 	}
 
 	data := buffer.Bytes()
-	blobs, pid, err := b.sendBlobsSidecar(ctx, communication.BlobSidecarByRootProtocolV1, data, uint64(req.Len()))
+	blobs, pid, err := b.sendBlobsSidecar(ctx, communication.BlobSidecarByRootProtocolV1, data)
 	if err != nil {
 		if strings.Contains(err.Error(), "invalid request") {
 			b.BanPeer(pid)
@@ -209,7 +209,7 @@ func (b *BeaconRpcP2P) SendBlobsSidecarByRangerReq(ctx context.Context, start, c
 	}
 
 	data := buffer.Bytes()
-	return b.sendBlobsSidecar(ctx, communication.BlobSidecarByRangeProtocolV1, data, count*b.beaconConfig.MaxBlobsPerBlock)
+	return b.sendBlobsSidecar(ctx, communication.BlobSidecarByRangeProtocolV1, data)
 }
 
 // SendBeaconBlocksByRangeReq retrieves blocks range from beacon chain.


### PR DESCRIPTION
The internal helper sendBlobsSidecar was carrying an unused count parameter while callers computed and passed values that were never used. This patch drops the parameter and simplifies the call sites, eliminating dead code and unnecessary calculations without affecting the wire protocol or sentinel-side limits.