### PR TITLE
Caplin: support backfilling blobs through a remote beacon API.

### DIFF
--- a/cl/clparams/config.go
+++ b/cl/clparams/config.go
@@ -51,6 +51,8 @@ type CaplinConfig struct {
 	ImmediateBlobsBackfilling bool
 	BlobPruningDisabled       bool
 	SnapshotGenerationEnabled bool
+	// BlobBackfillerUrl is the URL of a remote beacon API to use for blob backfilling
+	BlobBackfillerUrl string
 	// Network related config
 	NetworkId NetworkType
 	// DisableCheckpointSync is optional and is used to disable checkpoint sync used by default in the node

--- a/cl/phase1/network/beacon_api_blob_downloader.go
+++ b/cl/phase1/network/beacon_api_blob_downloader.go
@@ -1,0 +1,391 @@
+// Copyright 2024 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package network
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/cl/das"
+	"github.com/erigontech/erigon/cl/persistence/blob_storage"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/snapshotsync/freezeblocks"
+)
+
+const (
+	beaconApiBlobDownloaderInterval = 500 * time.Millisecond
+	beaconApiBlobLogInterval        = 30 * time.Second
+	beaconApiBlobTimeout            = 60 * time.Second
+)
+
+// BeaconApiBlobDownloader downloads blob history using a remote beacon API via data column sidecars
+type BeaconApiBlobDownloader struct {
+	ctx context.Context
+
+	beaconCfg     *clparams.BeaconChainConfig
+	apiUrl        string
+	indiciesDB    kv.RoDB
+	blobStorage   blob_storage.BlobStorage
+	columnStorage blob_storage.DataColumnStorage
+	blockReader   freezeblocks.BeaconSnapshotReader
+	sn            *freezeblocks.CaplinSnapshots
+	peerDas       das.PeerDas
+
+	syncedChecker SyncedChecker
+
+	// headSlot is the slot we start downloading from (currentSlot + 1)
+	headSlot atomic.Uint64
+	// highestBackfilledSlot is the highest slot we've successfully backfilled to
+	highestBackfilledSlot atomic.Uint64
+	// targetSlot is the slot we're trying to reach (Deneb fork epoch start)
+	targetSlot uint64
+	// archiveBlobs indicates whether to archive all blobs or just recent ones
+	archiveBlobs bool
+
+	running              atomic.Bool
+	backfillCompleted    atomic.Bool
+	notifyBlobBackfilled func()
+	logger               log.Logger
+
+	httpClient *http.Client
+}
+
+// NewBeaconApiBlobDownloader creates a new BeaconApiBlobDownloader
+func NewBeaconApiBlobDownloader(
+	ctx context.Context,
+	beaconCfg *clparams.BeaconChainConfig,
+	apiUrl string,
+	indiciesDB kv.RoDB,
+	blobStorage blob_storage.BlobStorage,
+	columnStorage blob_storage.DataColumnStorage,
+	blockReader freezeblocks.BeaconSnapshotReader,
+	sn *freezeblocks.CaplinSnapshots,
+	syncedChecker SyncedChecker,
+	peerDas das.PeerDas,
+	archiveBlobs bool,
+	logger log.Logger,
+) *BeaconApiBlobDownloader {
+	targetSlot := beaconCfg.DenebForkEpoch * beaconCfg.SlotsPerEpoch
+	return &BeaconApiBlobDownloader{
+		ctx:           ctx,
+		beaconCfg:     beaconCfg,
+		apiUrl:        apiUrl,
+		indiciesDB:    indiciesDB,
+		blobStorage:   blobStorage,
+		columnStorage: columnStorage,
+		blockReader:   blockReader,
+		sn:            sn,
+		syncedChecker: syncedChecker,
+		peerDas:       peerDas,
+		targetSlot:    targetSlot,
+		archiveBlobs:  archiveBlobs,
+		logger:        logger,
+		httpClient: &http.Client{
+			Timeout: beaconApiBlobTimeout,
+		},
+	}
+}
+
+// SetHeadSlot sets the head slot to download from (should be currentSlot + 1)
+func (b *BeaconApiBlobDownloader) SetHeadSlot(slot uint64) {
+	b.headSlot.Store(slot)
+}
+
+// SetNotifyBlobBackfilled sets the callback to notify when blob backfilling is complete
+func (b *BeaconApiBlobDownloader) SetNotifyBlobBackfilled(notify func()) {
+	b.notifyBlobBackfilled = notify
+}
+
+// HeadSlot returns the current head slot
+func (b *BeaconApiBlobDownloader) HeadSlot() uint64 {
+	return b.headSlot.Load()
+}
+
+// HighestBackfilledSlot returns the highest slot that has been backfilled
+func (b *BeaconApiBlobDownloader) HighestBackfilledSlot() uint64 {
+	return b.highestBackfilledSlot.Load()
+}
+
+// Running returns whether the downloader is currently running
+func (b *BeaconApiBlobDownloader) Running() bool {
+	return b.running.Load()
+}
+
+// Start begins the blob history download loop using the beacon API
+func (b *BeaconApiBlobDownloader) Start() {
+	if !b.archiveBlobs {
+		return // nothing to do
+	}
+	if b.running.Swap(true) {
+		return // already running
+	}
+
+	go b.run()
+}
+
+func (b *BeaconApiBlobDownloader) run() {
+	defer b.running.Store(false)
+
+	b.logger.Info("[BeaconApiBlobDownloader] Starting blob backfill via beacon API (using data column sidecars)", "url", b.apiUrl)
+
+	// Do an initial download immediately
+	if err := b.downloadOnce(true); err != nil {
+		b.logger.Error("[BeaconApiBlobDownloader] Error downloading blobs", "err", err)
+	}
+
+	downloadTimer := time.NewTimer(beaconApiBlobDownloaderInterval)
+	defer downloadTimer.Stop()
+
+	for {
+		select {
+		case <-b.ctx.Done():
+			return
+		case <-downloadTimer.C:
+			if err := b.downloadOnce(false); err != nil {
+				b.logger.Debug("[BeaconApiBlobDownloader] Error downloading blobs", "err", err)
+			}
+			downloadTimer.Reset(beaconApiBlobDownloaderInterval)
+		}
+	}
+}
+
+// downloadOnce performs a single download pass
+func (b *BeaconApiBlobDownloader) downloadOnce(shouldLog bool) error {
+	currentSlot := b.headSlot.Load()
+	if currentSlot == 0 {
+		return nil // not initialized yet
+	}
+
+	tx, err := b.indiciesDB.BeginRo(b.ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	logInterval := time.NewTicker(beaconApiBlobLogInterval)
+	defer logInterval.Stop()
+
+	prevLogSlot := currentSlot
+	prevTime := time.Now()
+
+	targetSlot := b.targetSlot
+	// in case of non-archive mode, we only backfill the last relevant epochs
+	if !b.archiveBlobs {
+		targetSlot = currentSlot - min(currentSlot, b.beaconCfg.MinSlotsForBlobsSidecarsRequest())
+	}
+
+	if shouldLog {
+		b.logger.Info("[BeaconApiBlobDownloader] Downloading data columns backwards via beacon API", "slot", currentSlot, "target", targetSlot)
+	}
+
+	processed := 0
+	for currentSlot >= targetSlot {
+		if currentSlot <= b.sn.FrozenBlobs() {
+			break
+		}
+		if !b.syncedChecker.Synced() {
+			time.Sleep(5 * time.Second)
+			continue
+		}
+
+		// Read the block to get the expected blob count
+		block, err := b.blockReader.ReadBlindedBlockBySlot(b.ctx, tx, currentSlot)
+		if err != nil {
+			return err
+		}
+		if block == nil {
+			currentSlot--
+			continue
+		}
+		if block.Version() < clparams.DenebVersion {
+			break
+		}
+
+		blockRoot, err := block.Block.HashSSZ()
+		if err != nil {
+			return err
+		}
+
+		// Check if we already have blobs for this block
+		blobsCount, err := b.blobStorage.KzgCommitmentsCount(b.ctx, blockRoot)
+		if err != nil {
+			return err
+		}
+
+		expectedCount := block.Block.Body.BlobKzgCommitments.Len()
+		if expectedCount == 0 || int(blobsCount) == expectedCount {
+			// No blobs needed or already have them
+			currentSlot--
+			continue
+		}
+
+		// Check if we have enough columns to recover
+		if b.peerDas != nil && b.peerDas.IsColumnOverHalf(currentSlot, blockRoot) {
+			// We have enough columns, try to schedule recovery
+			if err := b.peerDas.TryScheduleRecover(currentSlot, blockRoot); err != nil {
+				b.logger.Debug("[BeaconApiBlobDownloader] Failed to schedule blob recovery", "slot", currentSlot, "err", err)
+			}
+			currentSlot--
+			continue
+		}
+
+		// Fetch data column sidecars from beacon API
+		columns, err := b.fetchDataColumnSidecars(currentSlot)
+		if err != nil {
+			b.logger.Debug("[BeaconApiBlobDownloader] Failed to fetch data columns from API", "slot", currentSlot, "err", err)
+			currentSlot--
+			continue
+		}
+
+		if len(columns) > 0 {
+			// Store the columns
+			storedCount := 0
+			for _, column := range columns {
+				if err := b.columnStorage.WriteColumnSidecars(b.ctx, blockRoot, int64(column.Index), column); err != nil {
+					b.logger.Debug("[BeaconApiBlobDownloader] Failed to store column sidecar", "slot", currentSlot, "index", column.Index, "err", err)
+					continue
+				}
+				storedCount++
+			}
+
+			if storedCount > 0 {
+				processed++
+				// Try to schedule blob recovery after storing columns
+				if b.peerDas != nil {
+					if err := b.peerDas.TryScheduleRecover(currentSlot, blockRoot); err != nil {
+						b.logger.Debug("[BeaconApiBlobDownloader] Failed to schedule blob recovery", "slot", currentSlot, "err", err)
+					}
+				}
+			}
+		}
+
+		select {
+		case <-b.ctx.Done():
+			return b.ctx.Err()
+		case <-logInterval.C:
+			if shouldLog {
+				blkSec := float64(prevLogSlot-currentSlot) / time.Since(prevTime).Seconds()
+				blkSecStr := fmt.Sprintf("%.1f", blkSec)
+				prevLogSlot = currentSlot
+				prevTime = time.Now()
+
+				b.logger.Info("[BeaconApiBlobDownloader] Downloading data columns backwards via beacon API", "slot", currentSlot, "blks/sec", blkSecStr, "processed", processed)
+			}
+		default:
+		}
+
+		// Update highest backfilled slot
+		b.highestBackfilledSlot.Store(currentSlot)
+		currentSlot--
+	}
+
+	if shouldLog {
+		b.logger.Info("[BeaconApiBlobDownloader] Data column history download finished successfully", "processed", processed)
+	}
+
+	b.backfillCompleted.Store(true)
+	if b.notifyBlobBackfilled != nil {
+		b.notifyBlobBackfilled()
+	}
+	return nil
+}
+
+// fetchDataColumnSidecars fetches data column sidecars from the beacon API for a given slot using SSZ encoding
+func (b *BeaconApiBlobDownloader) fetchDataColumnSidecars(slot uint64) ([]*cltypes.DataColumnSidecar, error) {
+	url := fmt.Sprintf("%s/eth/v1/beacon/data_column_sidecars/%d", b.apiUrl, slot)
+
+	ctx, cancel := context.WithTimeout(b.ctx, beaconApiBlobTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	// Request SSZ encoding for lower bandwidth and faster decoding
+	req.Header.Set("Accept", "application/octet-stream")
+
+	resp, err := b.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		// No columns for this slot
+		return nil, nil
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("beacon API returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(body) == 0 {
+		return nil, nil
+	}
+
+	// Decode SSZ list of data column sidecars
+	columns, err := b.decodeDataColumnSidecarsSSZ(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode SSZ data column sidecars: %w", err)
+	}
+
+	return columns, nil
+}
+
+// decodeDataColumnSidecarsSSZ decodes a SSZ-encoded list of data column sidecars
+func (b *BeaconApiBlobDownloader) decodeDataColumnSidecarsSSZ(data []byte) ([]*cltypes.DataColumnSidecar, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	// Use the solid library to decode the dynamic list
+	list := solid.NewDynamicListSSZ[*cltypes.DataColumnSidecar](int(b.beaconCfg.NumberOfColumns))
+	if err := list.DecodeSSZ(data, int(clparams.DenebVersion)); err != nil {
+		return nil, err
+	}
+
+	// Convert to slice
+	columns := make([]*cltypes.DataColumnSidecar, 0, list.Len())
+	for i := 0; i < list.Len(); i++ {
+		columns = append(columns, list.Get(i))
+	}
+
+	return columns, nil
+}
+
+// blockRootFromColumn extracts the block root from a data column sidecar
+func blockRootFromColumn(column *cltypes.DataColumnSidecar) (common.Hash, error) {
+	if column.SignedBlockHeader == nil || column.SignedBlockHeader.Header == nil {
+		return common.Hash{}, fmt.Errorf("column has no signed block header")
+	}
+	return column.SignedBlockHeader.Header.HashSSZ()
+}

--- a/cl/phase1/network/blob_downloader.go
+++ b/cl/phase1/network/blob_downloader.go
@@ -53,7 +53,17 @@ type PeerDasGetter interface {
 	GetPeerDas() das.PeerDas
 }
 
-// BlobHistoryDownloader downloads blob history backwards from a head slot
+// BlobBackfiller is an interface for downloading blob history
+type BlobBackfiller interface {
+	// SetHeadSlot sets the head slot to download from
+	SetHeadSlot(slot uint64)
+	// SetNotifyBlobBackfilled sets the callback to notify when blob backfilling is complete
+	SetNotifyBlobBackfilled(notify func())
+	// Start begins the blob history download loop
+	Start()
+}
+
+// BlobHistoryDownloader downloads blob history backwards from a head slot using P2P
 type BlobHistoryDownloader struct {
 	ctx context.Context
 

--- a/cl/phase1/stages/clstages.go
+++ b/cl/phase1/stages/clstages.go
@@ -61,7 +61,7 @@ type Cfg struct {
 	sn                      *freezeblocks.CaplinSnapshots
 	blobStore               blob_storage.BlobStorage
 	peerDas                 das.PeerDas
-	blobDownloader          *network2.BlobHistoryDownloader
+	blobBackfiller          network2.BlobBackfiller
 	attestationDataProducer attestation_producer.AttestationDataProducer
 	caplinConfig            clparams.CaplinConfig
 	hasDownloaded           bool
@@ -95,23 +95,43 @@ func ClStagesCfg(
 	syncedData *synced_data.SyncedDataManager,
 	emitters *beaconevents.EventEmitter,
 	blobStore blob_storage.BlobStorage,
+	columnStore blob_storage.DataColumnStorage,
 	attestationDataProducer attestation_producer.AttestationDataProducer,
 	peerDas das.PeerDas,
 ) *Cfg {
-	blobDownloader := network2.NewBlobHistoryDownloader(
-		ctx,
-		beaconCfg,
-		rpc,
-		indiciesDB,
-		blobStore,
-		blockReader,
-		sn,
-		forkChoice,
-		forkChoice,
-		caplinConfig.ArchiveBlobs,
-		caplinConfig.ImmediateBlobsBackfilling,
-		log.Root(),
-	)
+	// Select blob backfiller: use beacon API if URL is configured, otherwise use P2P
+	var blobBackfiller network2.BlobBackfiller
+	if caplinConfig.BlobBackfillerUrl != "" {
+		blobBackfiller = network2.NewBeaconApiBlobDownloader(
+			ctx,
+			beaconCfg,
+			caplinConfig.BlobBackfillerUrl,
+			indiciesDB,
+			blobStore,
+			columnStore,
+			blockReader,
+			sn,
+			forkChoice,
+			peerDas,
+			caplinConfig.ArchiveBlobs || caplinConfig.ImmediateBlobsBackfilling,
+			log.Root(),
+		)
+	} else {
+		blobBackfiller = network2.NewBlobHistoryDownloader(
+			ctx,
+			beaconCfg,
+			rpc,
+			indiciesDB,
+			blobStore,
+			blockReader,
+			sn,
+			forkChoice,
+			forkChoice,
+			caplinConfig.ArchiveBlobs,
+			caplinConfig.ImmediateBlobsBackfilling,
+			log.Root(),
+		)
+	}
 
 	return &Cfg{
 		rpc:                     rpc,
@@ -128,7 +148,7 @@ func ClStagesCfg(
 		sn:                      sn,
 		blockReader:             blockReader,
 		peerDas:                 peerDas,
-		blobDownloader:          blobDownloader,
+		blobBackfiller:          blobBackfiller,
 		syncedData:              syncedData,
 		emitter:                 emitters,
 		blobStore:               blobStore,
@@ -268,7 +288,7 @@ func ConsensusClStages(ctx context.Context,
 					startingSlot := cfg.state.LatestBlockHeader().Slot
 					downloader := network2.NewBackwardBeaconDownloader(ctx, cfg.rpc, cfg.sn, cfg.executionClient, cfg.indiciesDB)
 
-					if err := SpawnStageHistoryDownload(StageHistoryReconstruction(downloader, cfg.antiquary, cfg.sn, cfg.indiciesDB, cfg.executionClient, cfg.beaconCfg, cfg.caplinConfig, false, startingRoot, startingSlot, cfg.dirs.Tmp, 600*time.Millisecond, cfg.blockCollector, cfg.blockReader, cfg.blobStore, logger, cfg.forkChoice, cfg.blobDownloader), context.Background(), logger); err != nil {
+					if err := SpawnStageHistoryDownload(StageHistoryReconstruction(downloader, cfg.antiquary, cfg.sn, cfg.indiciesDB, cfg.executionClient, cfg.beaconCfg, cfg.caplinConfig, false, startingRoot, startingSlot, cfg.dirs.Tmp, 600*time.Millisecond, cfg.blockCollector, cfg.blockReader, cfg.blobStore, logger, cfg.forkChoice, cfg.blobBackfiller), context.Background(), logger); err != nil {
 						cfg.hasDownloaded = false
 						return err
 					}

--- a/cl/phase1/stages/forkchoice.go
+++ b/cl/phase1/stages/forkchoice.go
@@ -306,7 +306,9 @@ func postForkchoiceOperations(ctx context.Context, tx kv.RwTx, logger log.Logger
 	if headState == nil {
 		return nil
 	}
-	cfg.blobDownloader.SetHeadSlot(headSlot)
+	if cfg.blobBackfiller != nil {
+		cfg.blobBackfiller.SetHeadSlot(headSlot)
+	}
 	// First emit events that depend on the head state.
 	emitHeadEvent(cfg, headSlot, headRoot, headState)
 	emitNextPaylodAttributesEvent(cfg, headSlot, headRoot, headState)

--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -56,12 +56,12 @@ type StageHistoryReconstructionCfg struct {
 	blockReader              freezeblocks.BeaconSnapshotReader
 	blobStorage              blob_storage.BlobStorage
 	forkchoiceStore          forkchoice.ForkChoiceStorage
-	blobDownloader           *network.BlobHistoryDownloader
+	blobBackfiller           network.BlobBackfiller
 }
 
 const logIntervalTime = 30 * time.Second
 
-func StageHistoryReconstruction(downloader *network.BackwardBeaconDownloader, antiquary *antiquary.Antiquary, sn *freezeblocks.CaplinSnapshots, indiciesDB kv.RwDB, engine execution_client.ExecutionEngine, beaconCfg *clparams.BeaconChainConfig, caplinConfig clparams.CaplinConfig, waitForAllRoutines bool, startingRoot common.Hash, startinSlot uint64, tmpdir string, backfillingThrottling time.Duration, executionBlocksCollector block_collector.BlockCollector, blockReader freezeblocks.BeaconSnapshotReader, blobStorage blob_storage.BlobStorage, logger log.Logger, forkchoiceStore forkchoice.ForkChoiceStorage, blobDownloader *network.BlobHistoryDownloader) StageHistoryReconstructionCfg {
+func StageHistoryReconstruction(downloader *network.BackwardBeaconDownloader, antiquary *antiquary.Antiquary, sn *freezeblocks.CaplinSnapshots, indiciesDB kv.RwDB, engine execution_client.ExecutionEngine, beaconCfg *clparams.BeaconChainConfig, caplinConfig clparams.CaplinConfig, waitForAllRoutines bool, startingRoot common.Hash, startinSlot uint64, tmpdir string, backfillingThrottling time.Duration, executionBlocksCollector block_collector.BlockCollector, blockReader freezeblocks.BeaconSnapshotReader, blobStorage blob_storage.BlobStorage, logger log.Logger, forkchoiceStore forkchoice.ForkChoiceStorage, blobBackfiller network.BlobBackfiller) StageHistoryReconstructionCfg {
 	return StageHistoryReconstructionCfg{
 		beaconCfg:                beaconCfg,
 		downloader:               downloader,
@@ -80,7 +80,7 @@ func StageHistoryReconstruction(downloader *network.BackwardBeaconDownloader, an
 		blockReader:              blockReader,
 		blobStorage:              blobStorage,
 		forkchoiceStore:          forkchoiceStore,
-		blobDownloader:           blobDownloader,
+		blobBackfiller:           blobBackfiller,
 	}
 }
 
@@ -291,10 +291,10 @@ func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Co
 		}
 
 		close(finishCh)
-		if cfg.blobDownloader != nil {
-			cfg.blobDownloader.SetHeadSlot(cfg.startingSlot + 1)
-			cfg.blobDownloader.SetNotifyBlobBackfilled(cfg.antiquary.NotifyBlobBackfilled)
-			cfg.blobDownloader.Start()
+		if cfg.blobBackfiller != nil {
+			cfg.blobBackfiller.SetHeadSlot(cfg.startingSlot + 1)
+			cfg.blobBackfiller.SetNotifyBlobBackfilled(cfg.antiquary.NotifyBlobBackfilled)
+			cfg.blobBackfiller.Start()
 		}
 	}()
 	// We block until we are done with the EL side of the backfilling with 2000 blocks of safety margin.

--- a/cmd/caplin/caplin1/run.go
+++ b/cmd/caplin/caplin1/run.go
@@ -480,6 +480,7 @@ func RunCaplinService(ctx context.Context, engine execution_client.ExecutionEngi
 		syncedDataManager,
 		emitters,
 		blobStorage,
+		columnStorage,
 		attestationProducer,
 		peerDas,
 	)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1008,6 +1008,11 @@ var (
 		Usage: "disable blob pruning in caplin",
 		Value: false,
 	}
+	CaplinBlobBackfillerUrlFlag = cli.StringFlag{
+		Name:  "caplin.blobs-backfiller-url",
+		Usage: "URL of a remote beacon API to use for blob backfilling (e.g., http://localhost:5052)",
+		Value: "",
+	}
 	CaplinDisableCheckpointSyncFlag = cli.BoolFlag{
 		Name:  "caplin.checkpoint-sync.disable",
 		Usage: "disable checkpoint sync in caplin",
@@ -1731,6 +1736,7 @@ func setCaplin(ctx *cli.Context, cfg *ethconfig.Config) {
 	}
 
 	cfg.CaplinConfig.ImmediateBlobsBackfilling = ctx.Bool(CaplinImmediateBlobBackfillFlag.Name)
+	cfg.CaplinConfig.BlobBackfillerUrl = ctx.String(CaplinBlobBackfillerUrlFlag.Name)
 	cfg.CaplinConfig.SnapshotGenerationEnabled = ctx.Bool(CaplinEnableSnapshotGeneration.Name)
 	cfg.CaplinConfig.DisabledCheckpointSync = ctx.Bool(CaplinDisableCheckpointSyncFlag.Name)
 	// bunch of extra stuff

--- a/node/cli/default_flags.go
+++ b/node/cli/default_flags.go
@@ -220,6 +220,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.CaplinArchiveBlobsFlag,
 	&utils.CaplinArchiveStatesFlag,
 	&utils.CaplinImmediateBlobBackfillFlag,
+	&utils.CaplinBlobBackfillerUrlFlag,
 
 	&utils.CaplinDisableBlobPruningFlag,
 	&utils.CaplinDisableCheckpointSyncFlag,


### PR DESCRIPTION
Adds support for backfilling historical blob data through a remote Beacon API as an alternative to P2P synchronization.

## Implementation

- **BeaconApiBlobDownloader**: Fetches data column sidecars via Beacon API (`/eth/v1/beacon/data_column_sidecars/{slot}`) using SSZ encoding, stores columns, and triggers blob recovery via PeerDAS when sufficient columns are available
- **BlobHistoryDownloader**: Refactored P2P-based blob backfiller into standalone component implementing common `BlobBackfiller` interface
- **Automatic selection**: Stages layer selects Beacon API downloader when `--caplin.blobs-backfiller-url` is set, otherwise falls back to P2P

## Configuration

```bash
# Use remote Beacon API for blob backfilling
erigon --caplin.blobs-backfiller-url=http://beacon-node:5052 --caplin.blobs-archive

# Alternative: immediate backfill of recent 4096 epochs
erigon --caplin.blobs-immediate-backfill

# Disable blob pruning for archival
erigon --caplin.blobs-no-pruning
```

## Data Column Integration

- PeerDAS manages data column storage and blob recovery
- When ≥50% of columns are available for a block, schedules blob reconstruction
- Supports both direct blob download and column-based recovery paths

## Backfill Strategy

Both downloaders work backwards from current slot to Deneb fork epoch, skipping slots where:
- Blobs already exist in storage
- Block is pre-Deneb or has no blob commitments
- Slot is covered by frozen snapshots

<!-- START COPILOT CODING AGENT TIPS -->
---

✨ Let Copilot coding agent [set things up for you](https://github.com/erigontech/erigon/issues/new?title=✨+Set+up+Copilot+instructions&body=Configure%20instructions%20for%20this%20repository%20as%20documented%20in%20%5BBest%20practices%20for%20Copilot%20coding%20agent%20in%20your%20repository%5D%28https://gh.io/copilot-coding-agent-tips%29%2E%0A%0A%3COnboard%20this%20repo%3E&assignees=copilot) — coding agent works faster and does higher quality work when set up for your repo.
