### PR TITLE
make CommitmentHistory integrity check non-default

### DIFF
--- a/db/integrity/integrity_action_type.go
+++ b/db/integrity/integrity_action_type.go
@@ -40,8 +40,8 @@ const (
 var AllChecks = []Check{
 	Blocks, HeaderNoGaps, BlocksTxnID, InvertedIndex, HistoryNoSystemTxs, ReceiptsNoDups, BorEvents,
 	BorSpans, BorCheckpoints, RCacheNoDups, CommitmentRoot,
-	CommitmentKvi, CommitmentKvDeref, CommitmentHistVal, StateProgress,
+	CommitmentKvi, CommitmentKvDeref, StateProgress,
 	Publishable,
 }
 
-var NonDefaultChecks = []Check{}
+var NonDefaultChecks = []Check{CommitmentHistVal}


### PR DESCRIPTION
there's some issue with the files generation for commitment history; but we want to unblock the snapshot automation until this is resolved