### PR TITLE
execution/vm: optimize push2 opcode

### DIFF
--- a/execution/vm/instructions.go
+++ b/execution/vm/instructions.go
@@ -1369,12 +1369,11 @@ func opPush2(pc uint64, interpreter *EVMInterpreter, scope *CallContext) (uint64
 	)
 
 	if pc+2 < codeLen {
-		scope.Stack.push(*integer.SetBytes2(scope.Contract.Code[pc+1 : pc+3]))
+		integer.SetBytes2(scope.Contract.Code[pc+1 : pc+3])
 	} else if pc+1 < codeLen {
-		scope.Stack.push(*integer.SetUint64(uint64(scope.Contract.Code[pc+1]) << 8))
-	} else {
-		scope.Stack.push(uint256.Int{})
+		integer.SetUint64(uint64(scope.Contract.Code[pc+1]) << 8)
 	}
+	scope.Stack.push(*integer)
 	pc += 2
 	return pc, nil, nil
 }
@@ -1411,9 +1410,9 @@ func makePushStringer(size uint64, pushByteSize int) stringer {
 }
 
 // make dup instruction function
-func makeDup(size int64) executionFunc {
+func makeDup(size int) executionFunc {
 	return func(pc uint64, interpreter *EVMInterpreter, scope *CallContext) (uint64, []byte, error) {
-		scope.Stack.dup(int(size))
+		scope.Stack.dup(size)
 		return pc, nil, nil
 	}
 }


### PR DESCRIPTION
- Optimize `opPush2` 
- make types consistent in `makeDup`

```
goos: linux
goarch: amd64
pkg: github.com/erigontech/erigon/execution/vm
cpu: Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz
                │ new_bench.txt │             old_bench.txt             │
                │    sec/op     │    sec/op      vs base                │
Push/makePush-8     13.23n ± 6%    18.72n ± 12%  +41.53% (p=0.000 n=10)
Push/push-8         8.531n ± 4%   11.890n ± 44%  +39.37% (p=0.000 n=10)
geomean             10.62n         14.92n        +40.45%

                │ new_bench.txt │            old_bench.txt            │
                │     B/op      │    B/op     vs base                 │
Push/makePush-8    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Push/push-8        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                       ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                │ new_bench.txt │            old_bench.txt            │
                │   allocs/op   │ allocs/op   vs base                 │
Push/makePush-8    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Push/push-8        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                       ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

Benchmark Test
```
func BenchmarkPush(b *testing.B) {
	var (
		code        = common.FromHex("0011223344556677889900aabbccddeeff0102030405060708090a0b0c0d0e0ff1e1d1c1b1a19181716151413121")
		push2       = makePush(2, 2)
		callContext = &CallContext{Contract: Contract{
			Code: code,
		}}
		pc = new(uint64)
	)

	b.Run("makePush", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			push2(*pc, nil, callContext)
			callContext.Stack.pop()
		}
	})

	b.Run("push", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			opPush2(*pc, nil, callContext)
			callContext.Stack.pop()
		}
	})
}
```

