### PR TITLE
execution/types: avoid unused EIP-7623 floor gas in AA pre-transaction cost

### DIFF
--- a/execution/types/aa_transaction.go
+++ b/execution/types/aa_transaction.go
@@ -529,7 +529,7 @@ func (tx *AccountAbstractionTransaction) PreTransactionGasCost(rules *chain.Rule
 	data = append(data, tx.DeployerData...)
 	data = append(data, tx.ExecutionData...)
 	data = append(data, tx.PaymasterData...)
-	gas, _, overflow := fixedgas.IntrinsicGas(data, uint64(len(tx.AccessList)), uint64(tx.AccessList.StorageKeys()), false, rules.IsHomestead, rules.IsIstanbul, hasEIP3860, rules.IsPrague, true, uint64(len(tx.Authorizations)))
+	gas, _, overflow := fixedgas.IntrinsicGas(data, uint64(len(tx.AccessList)), uint64(tx.AccessList.StorageKeys()), false, rules.IsHomestead, rules.IsIstanbul, hasEIP3860, false, true, uint64(len(tx.Authorizations)))
 
 	if overflow {
 		return 0, errors.New("overflow")


### PR DESCRIPTION
PreTransactionGasCost for account abstraction transactions called IntrinsicGas with isEIP7623 enabled but discarded the floorGas7623 value, so the extra EIP-7623 calldata floor computations were never observable. This change disables the EIP-7623 flag in that call, preserving the returned gas value while avoiding unnecessary work for AA transactions.