### PR TITLE
txnprovider/txpool: cache pendingBaseFee for queue comparisons

### DIFF
--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -382,12 +382,14 @@ func (p *TxPool) OnNewBlock(ctx context.Context, stateChanges *remoteproto.State
 	pendingBaseFee, baseFeeChanged := p.setBaseFee(baseFee)
 	// Update pendingBase for all pool queues and slices
 	if baseFeeChanged {
-		p.pending.best.pendingBaseFee = pendingBaseFee
-		p.pending.worst.pendingBaseFee = pendingBaseFee
-		p.baseFee.best.pendingBaseFee = pendingBaseFee
-		p.baseFee.worst.pendingBaseFee = pendingBaseFee
-		p.queued.best.pendingBaseFee = pendingBaseFee
-		p.queued.worst.pendingBaseFee = pendingBaseFee
+		var pendingBaseFee256 uint256.Int
+		pendingBaseFee256.SetUint64(pendingBaseFee)
+		p.pending.best.pendingBaseFee = pendingBaseFee256
+		p.pending.worst.pendingBaseFee = pendingBaseFee256
+		p.baseFee.best.pendingBaseFee = pendingBaseFee256
+		p.baseFee.worst.pendingBaseFee = pendingBaseFee256
+		p.queued.best.pendingBaseFee = pendingBaseFee256
+		p.queued.worst.pendingBaseFee = pendingBaseFee256
 	}
 
 	pendingBlobFee := stateChanges.PendingBlobFeePerGas
@@ -2656,6 +2658,16 @@ func (p *TxPool) fromDB(ctx context.Context, tx kv.Tx, coreTx kv.TemporalTx) err
 		pendingBaseFee, pendingBlobFee, blockGasLimit, false, p.logger); err != nil {
 		return err
 	}
+	// Initialise cached pendingBaseFee values in all queues so that their
+	// comparators use the correct base fee even before the first OnNewBlock.
+	var pendingBaseFee256 uint256.Int
+	pendingBaseFee256.SetUint64(pendingBaseFee)
+	p.pending.best.pendingBaseFee = pendingBaseFee256
+	p.pending.worst.pendingBaseFee = pendingBaseFee256
+	p.baseFee.best.pendingBaseFee = pendingBaseFee256
+	p.baseFee.worst.pendingBaseFee = pendingBaseFee256
+	p.queued.best.pendingBaseFee = pendingBaseFee256
+	p.queued.worst.pendingBaseFee = pendingBaseFee256
 	p.pendingBaseFee.Store(pendingBaseFee)
 	p.pendingBlobFee.Store(pendingBlobFee)
 	p.blockGasLimit.Store(blockGasLimit)

--- a/txnprovider/txpool/queues.go
+++ b/txnprovider/txpool/queues.go
@@ -22,7 +22,7 @@ import "github.com/holiman/uint256"
 // it maintains element.bestIndex field
 type bestSlice struct {
 	ms             []*metaTxn
-	pendingBaseFee uint64
+	pendingBaseFee uint256.Int
 }
 
 func (s *bestSlice) Len() int {
@@ -35,7 +35,7 @@ func (s *bestSlice) Swap(i, j int) {
 }
 
 func (s *bestSlice) Less(i, j int) bool {
-	return s.ms[i].better(s.ms[j], *uint256.NewInt(s.pendingBaseFee))
+	return s.ms[i].better(s.ms[j], s.pendingBaseFee)
 }
 
 func (s *bestSlice) UnsafeRemove(i *metaTxn) {
@@ -52,7 +52,7 @@ func (s *bestSlice) UnsafeAdd(i *metaTxn) {
 
 type BestQueue struct {
 	ms             []*metaTxn
-	pendingBaseFee uint64
+	pendingBaseFee uint256.Int
 }
 
 func (p *BestQueue) Len() int {
@@ -60,7 +60,7 @@ func (p *BestQueue) Len() int {
 }
 
 func (p *BestQueue) Less(i, j int) bool {
-	return p.ms[i].better(p.ms[j], *uint256.NewInt(p.pendingBaseFee))
+	return p.ms[i].better(p.ms[j], p.pendingBaseFee)
 }
 
 func (p *BestQueue) Swap(i, j int) {
@@ -89,7 +89,7 @@ func (p *BestQueue) Pop() interface{} {
 
 type WorstQueue struct {
 	ms             []*metaTxn
-	pendingBaseFee uint64
+	pendingBaseFee uint256.Int
 }
 
 func (p *WorstQueue) Len() int {
@@ -97,7 +97,7 @@ func (p *WorstQueue) Len() int {
 }
 
 func (p *WorstQueue) Less(i, j int) bool {
-	return p.ms[i].worse(p.ms[j], *uint256.NewInt(p.pendingBaseFee))
+	return p.ms[i].worse(p.ms[j], p.pendingBaseFee)
 }
 
 func (p *WorstQueue) Swap(i, j int) {


### PR DESCRIPTION
The queue comparators in txpool were calling uint256.NewInt on every Less invocation to convert pendingBaseFee from uint64 to uint256.Int. This happens in both sort.Sort (bestSlice) and heap operations (BestQueue/WorstQueue), so it ends up on a very hot path and causes unnecessary work and allocations. 
This change stores pendingBaseFee as uint256.Int in bestSlice, BestQueue and WorstQueue and updates it once per base fee change. OnNewBlock converts the current base fee to uint256.Int and propagates it to all queues, and LoadFromDB now initializes the same cached value when reconstructing the pool from disk. As a result, comparisons reuse the cached uint256.Int and no longer need to call uint256.NewInt inside Less.