### PR TITLE
refactor: improve string concatenation performance

### DIFF
--- a/db/state/changeset/state_changeset.go
+++ b/db/state/changeset/state_changeset.go
@@ -273,18 +273,20 @@ func WriteDiffSet(tx kv.RwTx, blockNumber uint64, blockHash common.Hash, diffSet
 	writeDiffsetBuf.Lock()
 	defer writeDiffsetBuf.Unlock()
 	if dbg.TraceUnwinds {
-		diffStats := ""
+		var diffStats strings.Builder
 		if diffSet != nil {
+			first := true
 			for d, diff := range &diffSet.Diffs {
-				if diffStats == "" {
-					diffStats += " "
+				if first {
+					diffStats.WriteString(" ")
+					first = false
 				} else {
-					diffStats += ", "
+					diffStats.WriteString(", ")
 				}
-				diffStats += fmt.Sprintf("%s: %d", kv.Domain(d), diff.Len())
+				diffStats.WriteString(fmt.Sprintf("%s: %d", kv.Domain(d), diff.Len()))
 			}
 		}
-		fmt.Printf("diffset (Block:%d) %x:%s %s\n", blockNumber, blockHash, diffStats, dbg.Stack())
+		fmt.Printf("diffset (Block:%d) %x:%s %s\n", blockNumber, blockHash, diffStats.String(), dbg.Stack())
 	}
 	writeDiffsetBuf.b = diffSet.serializeKeys(writeDiffsetBuf.b[:0], blockNumber)
 	keys := writeDiffsetBuf.b

--- a/db/state/squeeze.go
+++ b/db/state/squeeze.go
@@ -6,13 +6,14 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/erigontech/erigon/db/version"
 	"math"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/erigontech/erigon/db/version"
 
 	"github.com/c2h5oh/datasize"
 
@@ -328,9 +329,10 @@ func CheckCommitmentForPrint(ctx context.Context, rwDb kv.TemporalRwDB) (string,
 	if err != nil {
 		return "", err
 	}
-	s := fmt.Sprintf("[commitment] Latest: blockNum: %d txNum: %d latestRootHash: %x\n", domains.BlockNum(), domains.TxNum(), rootHash)
-	s += fmt.Sprintf("[commitment] stepSize %d, ReplaceKeysInValues enabled %t\n", rwTx.Debug().StepSize(), a.Cfg(kv.CommitmentDomain).ReplaceKeysInValues)
-	return s, nil
+	var s strings.Builder
+	s.WriteString(fmt.Sprintf("[commitment] Latest: blockNum: %d txNum: %d latestRootHash: %x\n", domains.BlockNum(), domains.TxNum(), rootHash))
+	s.WriteString(fmt.Sprintf("[commitment] stepSize %d, ReplaceKeysInValues enabled %t\n", rwTx.Debug().StepSize(), a.Cfg(kv.CommitmentDomain).ReplaceKeysInValues))
+	return s.String(), nil
 }
 
 // RebuildCommitmentFiles recreates commitment files from existing accounts and storage kv files

--- a/diagnostics/metrics/register.go
+++ b/diagnostics/metrics/register.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"fmt"
+	"strings"
 )
 
 // NewCounter registers and returns new counter with the given name.
@@ -171,14 +172,16 @@ func buildLabeledName(baseName string, labelNames, labelValues []string) string 
 	if len(labelNames) == 0 {
 		return baseName
 	}
-	baseName += "{"
-	baseName += fmt.Sprintf(`%s="%s"`, labelNames[0], labelValues[0])
+	var result strings.Builder
+	result.WriteString(baseName)
+	result.WriteString("{")
+	result.WriteString(fmt.Sprintf(`%s="%s"`, labelNames[0], labelValues[0]))
 
 	for i := 1; i < len(labelNames); i++ {
-		baseName += fmt.Sprintf(`,%s="%s"`, labelNames[i], labelValues[i])
+		result.WriteString(fmt.Sprintf(`,%s="%s"`, labelNames[i], labelValues[i]))
 	}
-	baseName += "}"
-	return baseName
+	result.WriteString("}")
+	return result.String()
 }
 
 func GetOrCreateSummaryWithLabels(name string, labelNames, labelValues []string) Summary {

--- a/execution/commitment/trie/debug.go
+++ b/execution/commitment/trie/debug.go
@@ -83,11 +83,13 @@ func (n *FullNode) print(w io.Writer) {
 }
 
 func (n *DuoNode) fstring(ind string) string {
-	resp := fmt.Sprintf("duo[\n%s  ", ind)
+	var resp strings.Builder
+	resp.WriteString(fmt.Sprintf("duo[\n%s  ", ind))
 	i1, i2 := n.childrenIdx()
-	resp += fmt.Sprintf("%s: %v", indices[i1], n.child1.fstring(ind+"  "))
-	resp += fmt.Sprintf("%s: %v", indices[i2], n.child2.fstring(ind+"  "))
-	return resp + fmt.Sprintf("\n%s] ", ind)
+	resp.WriteString(fmt.Sprintf("%s: %v", indices[i1], n.child1.fstring(ind+"  ")))
+	resp.WriteString(fmt.Sprintf("%s: %v", indices[i2], n.child2.fstring(ind+"  ")))
+	resp.WriteString(fmt.Sprintf("\n%s] ", ind))
+	return resp.String()
 }
 func (n *DuoNode) print(w io.Writer) {
 	fmt.Fprintf(w, "d(")


### PR DESCRIPTION
Replaces inefficient string concatenation operations with strings.Builder 
for better performance and reduced memory allocations.