### PR TITLE
fix: correct variable name in commented code in rules.go

### DIFF
--- a/rules.go
+++ b/rules.go
@@ -73,7 +73,7 @@ func cursorDeferClose(m dsl.Matcher) {
 		`$c, $err := $db.RwCursorDupSort($table); $chk; $close`,
 	).
 		Where(!m["close"].Text.Matches(`defer .*\.Close()`)).
-		//At(m["rollback"]).
+		//At(m["close"]).
 		Report(`Add "defer $c.Close()" right after cursor creation error check`)
 }
 
@@ -87,7 +87,7 @@ func streamDeferClose(m dsl.Matcher) {
 		`$c, $err := $db.Prefix($params); $chk; $close`,
 	).
 		Where(!m["close"].Text.Matches(`defer .*\.Close()`)).
-		//At(m["rollback"]).
+		//At(m["close"]).
 		Report(`Add "defer $c.Close()" right after cursor creation error check`)
 }
 


### PR DESCRIPTION
Fixed copy-paste bug in cursorDeferClose and streamDeferClose functions. The commented At() calls referenced m["rollback"] which doesn't exist in these functions - should be m["close"] to match the actual variable used.