### PR TITLE
rpc/gasprice: remove unused Oracle state fields

### DIFF
--- a/rpc/gasprice/gasprice.go
+++ b/rpc/gasprice/gasprice.go
@@ -56,8 +56,6 @@ type Cache interface {
 // blocks. Suitable for both light and full clients.
 type Oracle struct {
 	backend     OracleBackend
-	lastHead    common.Hash
-	lastPrice   *big.Int
 	maxPrice    *big.Int
 	ignorePrice *big.Int
 	cache       Cache
@@ -101,7 +99,6 @@ func NewOracle(backend OracleBackend, params gaspricecfg.Config, cache Cache, lo
 
 	return &Oracle{
 		backend:          backend,
-		lastPrice:        params.Default,
 		maxPrice:         maxPrice,
 		ignorePrice:      ignorePrice,
 		checkBlocks:      blocks,


### PR DESCRIPTION
The Oracle struct was still carrying lastHead and lastPrice fields from the pre-cache design, but they were never read anywhere in the codebase. All state about the latest head and gas price is now consistently stored in the shared Cache implementation, so keeping these fields only adds noise and confusion.