### PR TITLE
fix blockReader decision logic to build missed indexes

### DIFF
--- a/db/snapshotsync/snapshots.go
+++ b/db/snapshotsync/snapshots.go
@@ -1336,6 +1336,9 @@ type snapshotNotifier interface {
 
 func (s *RoSnapshots) BuildMissedIndices(ctx context.Context, logPrefix string, notifier snapshotNotifier, dirs datadir.Dirs, cc *chain.Config, logger log.Logger) error {
 	if !s.Cfg().ProduceE2 && s.IndicesMax() == 0 {
+		if s.SegmentsMax() == 0 {
+			return nil
+		}
 		return errors.New("please remove --snap.stop, erigon can't work without creating basic indices")
 	}
 	if !s.Cfg().ProduceE2 {


### PR DESCRIPTION
- it only decides to generate the missing indices if latest idx files are missing. This is wrong, as sometimes we might delete earlier idxs and keep the latest ones. 
- This PR allows to check all seg files and see if they've corresponding idx files. 
- OpenFolder is expensive op, but it's done only when a new idx is created.