### PR TITLE
cl/phase1/forkchoice: remove unused computeSyncPeriod helper

### DIFF
--- a/cl/phase1/forkchoice/utils.go
+++ b/cl/phase1/forkchoice/utils.go
@@ -95,10 +95,6 @@ func (f *ForkChoiceStore) computeEpochAtSlot(slot uint64) uint64 {
 	return slot / f.beaconCfg.SlotsPerEpoch
 }
 
-func (f *ForkChoiceStore) computeSyncPeriod(epoch uint64) uint64 {
-	return epoch / f.beaconCfg.EpochsPerSyncCommitteePeriod
-}
-
 // computeStartSlotAtEpoch calculates the starting slot of a given epoch.
 func (f *ForkChoiceStore) computeStartSlotAtEpoch(epoch uint64) uint64 {
 	return epoch * f.beaconCfg.SlotsPerEpoch


### PR DESCRIPTION
The ForkChoiceStore.computeSyncPeriod helper was never called anywhere in the codebase and duplicated the sync committee period calculation that is already implemented on BeaconChainConfig. Removing this dead code simplifies the forkchoice utils, avoids confusion with the canonical SyncCommitteePeriod helpers and reduces the surface for future maintenance mistakes.