### PR TITLE
fix seed call of merged files to downloader

### DIFF
--- a/db/snapshotsync/freezeblocks/block_snapshots.go
+++ b/db/snapshotsync/freezeblocks/block_snapshots.go
@@ -320,13 +320,17 @@ func (br *BlockRetire) MergeBlocks(ctx context.Context, lvl log.Lvl, seedNewSnap
 		return false, nil
 	}
 	merged = true
-	onMerge := func(r snapshotsync.Range) error {
+	onMerge := func(mergedFileNames []string) error {
 		if notifier != nil && !reflect.ValueOf(notifier).IsNil() { // notify about new snapshots of any size
 			notifier.OnNewSnapshot()
 		}
 
 		if seedNewSnapshots != nil {
-			downloadRequest := []services.DownloadRequest{{Path: "", TorrentHash: ""}}
+			downloadRequest := make([]services.DownloadRequest, 0, len(mergedFileNames))
+			for _, filePath := range mergedFileNames {
+				downloadRequest = append(downloadRequest, services.DownloadRequest{Path: filePath, TorrentHash: ""})
+			}
+
 			if err := seedNewSnapshots(downloadRequest); err != nil {
 				return err
 			}

--- a/db/snapshotsync/freezeblocks/bor_snapshots.go
+++ b/db/snapshotsync/freezeblocks/bor_snapshots.go
@@ -115,13 +115,16 @@ func (br *BlockRetire) MergeBorBlocks(ctx context.Context, lvl log.Lvl, seedNewS
 	if len(rangesToMerge) == 0 {
 		return false, nil
 	}
-	onMerge := func(r snapshotsync.Range) error {
+	onMerge := func(mergedFiles []string) error {
 		if notifier != nil && !reflect.ValueOf(notifier).IsNil() { // notify about new snapshots of any size
 			notifier.OnNewSnapshot()
 		}
 
 		if seedNewSnapshots != nil {
-			downloadRequest := []services.DownloadRequest{{Path: "", TorrentHash: ""}}
+			downloadRequest := make([]services.DownloadRequest, 0, len(mergedFiles))
+			for _, filePath := range mergedFiles {
+				downloadRequest = append(downloadRequest, services.DownloadRequest{Path: filePath, TorrentHash: ""})
+			}
 			if err := seedNewSnapshots(downloadRequest); err != nil {
 				return err
 			}


### PR DESCRIPTION
fixes: `field 'path' is required` messages
issue: https://github.com/erigontech/erigon/issues/18149