### PR TITLE
common/jwt: correct HttpRoundTripper error message

### DIFF
--- a/common/jwt/http_round_tripper.go
+++ b/common/jwt/http_round_tripper.go
@@ -40,7 +40,7 @@ func (t *HttpRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 
 	tokenString, err := token.SignedString(t.jwtSecret)
 	if err != nil {
-		return nil, fmt.Errorf("JwtRoundTripper failed to produce a JWT token, err: %w", err)
+		return nil, fmt.Errorf("HttpRoundTripper failed to produce a JWT token, err: %w", err)
 	}
 
 	req.Header.Set("Authorization", "Bearer "+tokenString)


### PR DESCRIPTION
Align the error message in HttpRoundTripper.RoundTrip with the actual type name. Previously it mentioned JwtRoundTripper, which could confuse log readers and make it harder to grep for issues related to this round tripper.