### PR TITLE
cl/utils: remove unused ReverseOfByteSlice helper

### DIFF
--- a/cl/utils/bytes.go
+++ b/cl/utils/bytes.go
@@ -130,15 +130,6 @@ func GetBitlistLength(b []byte) int {
 	// bit. Subtract this value by 1 to determine the length of the bitlist.
 	return 8*(len(b)-1) + msb - 1
 }
-
-func ReverseOfByteSlice(b []byte) (out []byte) {
-	out = make([]byte, len(b))
-	for i := range b {
-		out[i] = b[len(b)-1-i]
-	}
-	return
-}
-
 func FlipBitOn(b []byte, i int) {
 	b[i/8] |= 1 << (i % 8)
 }


### PR DESCRIPTION
Removed ReverseOfByteSlice from cl/utils/bytes.go as dead code. The helper is not referenced anywhere in the current codebase, including tests, reflection, or linkname usage, and there are no public traces of external consumers