### PR TITLE
cl: fix for periodic retry of not-ready response

### DIFF
--- a/cl/phase1/stages/chain_tip_sync.go
+++ b/cl/phase1/stages/chain_tip_sync.go
@@ -22,7 +22,7 @@ func waitForExecutionEngineToBeFinished(ctx context.Context, cfg *Cfg) (ready bo
 
 	// Setup the timers
 	readyTimeout := time.NewTimer(10 * time.Second)
-	readyInterval := time.NewTimer(50 * time.Millisecond)
+	readyInterval := time.NewTicker(50 * time.Millisecond)
 
 	// Ensure the timers are stopped to release resources
 	defer readyTimeout.Stop()


### PR DESCRIPTION
when exec responds with !ready (say due to pruning) Caplin should try again before it gives up

that seems to be the intent in the code but the implementation has a bug - it uses a `Timer` instead of a `Ticker`

we're getting missed (orphaned) blocks due to this 