### PR TITLE
beacon: set Eth-Consensus-Version header when versioned

### DIFF
--- a/cl/beacon/beaconhttp/api.go
+++ b/cl/beacon/beaconhttp/api.go
@@ -131,6 +131,11 @@ func HandleEndpoint[T any](h EndpointHandler[T]) http.HandlerFunc {
 			for key, value := range beaconResponse.Headers() {
 				w.Header().Set(key, value)
 			}
+			// If the JSON body includes "version", also expose it via the standard header.
+			// Many consumers rely on this header for fork-specific types.
+			if beaconResponse.Version != nil && w.Header().Get("Eth-Consensus-Version") == "" {
+				w.Header().Set("Eth-Consensus-Version", beaconResponse.Version.String())
+			}
 		}
 		switch {
 		case contentType == "*/*", contentType == "", strings.Contains(contentType, "text/html"), strings.Contains(contentType, "application/json"):

--- a/cl/beacon/beaconhttp/api_test.go
+++ b/cl/beacon/beaconhttp/api_test.go
@@ -1,0 +1,48 @@
+package beaconhttp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/erigontech/erigon/cl/clparams"
+)
+
+func TestHandleEndpoint_SetsEthConsensusVersionHeaderFromBodyVersion(t *testing.T) {
+	h := HandleEndpointFunc(func(w http.ResponseWriter, r *http.Request) (*BeaconResponse, error) {
+		return NewBeaconResponse(map[string]any{"ok": true}).WithVersion(clparams.DenebVersion), nil
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	rr := httptest.NewRecorder()
+	h(rr, req)
+
+	if got := rr.Header().Get("Eth-Consensus-Version"); got != "deneb" {
+		t.Fatalf("Eth-Consensus-Version = %q, want %q", got, "deneb")
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode response json: %v", err)
+	}
+	if got := body["version"]; got != "deneb" {
+		t.Fatalf("body.version = %#v, want %q", got, "deneb")
+	}
+}
+
+func TestHandleEndpoint_DoesNotOverrideEthConsensusVersionHeader(t *testing.T) {
+	h := HandleEndpointFunc(func(w http.ResponseWriter, r *http.Request) (*BeaconResponse, error) {
+		return NewBeaconResponse(map[string]any{"ok": true}).
+			WithHeader("Eth-Consensus-Version", "capella").
+			WithVersion(clparams.DenebVersion), nil
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	rr := httptest.NewRecorder()
+	h(rr, req)
+
+	if got := rr.Header().Get("Eth-Consensus-Version"); got != "capella" {
+		t.Fatalf("Eth-Consensus-Version = %q, want %q", got, "capella")
+	}
+}


### PR DESCRIPTION
- Adds Eth-Consensus-Version response header automatically for all beaconhttp.BeaconResponse that include a version field in the JSON body (BeaconResponse.Version != nil).
- Does not override an explicitly set Eth-Consensus-Version header.
- Improves compatibility for endpoints like /eth/v2/beacon/blocks/{block_id} which already return "version" in the body but previously missed the header.
- Includes unit tests for the new behavior (cl/beacon/beaconhttp/api_test.go).
