### PR TITLE
fix: prevent resource leak in txpool p2p test helper polling loop

### DIFF
--- a/txnprovider/txpool/tests/helper/p2p_client.go
+++ b/txnprovider/txpool/tests/helper/p2p_client.go
@@ -174,11 +174,11 @@ func (p *p2pClient) notifyWhenReady() (<-chan struct{}, error) {
 			if err != nil {
 				continue
 			}
-			defer r.Body.Close()
-
 			if err := json.NewDecoder(r.Body).Decode(&resp); err != nil {
+				r.Body.Close()
 				continue
 			}
+			r.Body.Close()
 
 			if len(resp.Result) > numConn {
 				ready <- struct{}{}


### PR DESCRIPTION
The `notifyWhenReady()` function in txpool p2p test helper contained a resource leak.  Inside an infinite polling loop, each HTTP request used `defer r.Body.Close()`, which  causes deferred calls to accumulate without being executed until the function returns.