### PR TITLE
db/kv/mdbx: remove redundant empty-key Put in mdbx TestPutGet

### DIFF
--- a/db/kv/mdbx/kv_mdbx_test.go
+++ b/db/kv/mdbx/kv_mdbx_test.go
@@ -286,8 +286,6 @@ func TestLastDup(t *testing.T) {
 func TestPutGet(t *testing.T) {
 	_, tx, c := BaseCase(t)
 
-	require.NoError(t, c.Put([]byte(""), []byte("value1.1")))
-
 	var v []byte
 	v, err := tx.GetOne("Table", []byte("key1"))
 	require.NoError(t, err)


### PR DESCRIPTION
TestPutGet already relies on data inserted by BaseCase, where key1 has value1.1 as the first dupsort value. The extra Put with an empty key neither affects the semantics of GetOne("Table", "key1") nor is used elsewhere, but makes the test harder to read. Removing this write keeps the intended assertion intact while avoiding unnecessary work and confusion around the empty key.