### PR TITLE
refactor(rpctest): remove unused accounts map allocation in Bench1

### DIFF
--- a/cmd/rpctest/rpctest/bench1.go
+++ b/cmd/rpctest/rpctest/bench1.go
@@ -59,7 +59,6 @@ func Bench1(erigonURL, gethURL string, needCompare bool, fullTest bool, blockFro
 		return fmt.Errorf("Error getting block number: %d %s\n", blockNumber.Error.Code, blockNumber.Error.Message)
 	}
 	fmt.Printf("Last block: %d\n", blockNumber.Number)
-	accounts := make(map[common.Address]struct{})
 	prevBn := blockFrom
 	storageCounter := 0
 	for bn := blockFrom; bn <= blockTo; bn++ {
@@ -88,14 +87,7 @@ func Bench1(erigonURL, gethURL string, needCompare bool, fullTest bool, blockFro
 			}
 		}
 
-		accounts[b.Result.Miner] = struct{}{}
-
 		for i, txn := range b.Result.Transactions {
-			accounts[txn.From] = struct{}{}
-			if txn.To != nil {
-				accounts[*txn.To] = struct{}{}
-			}
-
 			if txn.To != nil && txn.Gas.ToInt().Uint64() > 21000 {
 				storageCounter++
 				if storageCounter == 100 {


### PR DESCRIPTION
Removes dead code from the RPC benchmarking tool that was allocating and populating a map without any subsequent usage.