### PR TITLE
Remove duplicate `Min` call in `ReceiptsNoDupsRange`

### DIFF
--- a/db/integrity/receipts_no_duplicates.go
+++ b/db/integrity/receipts_no_duplicates.go
@@ -59,7 +59,7 @@ func ReceiptsNoDupsRange(ctx context.Context, fromBlock, toBlock uint64, tx kv.T
 	prevLogIdxAfterTx := uint32(0)
 	blockNum := fromBlock
 	var _min, _max uint64
-	_min, _ = txNumsReader.Min(tx, fromBlock)
+	_min = fromTxNum
 	_max, _ = txNumsReader.Max(tx, fromBlock)
 	for txNum := fromTxNum; txNum <= toTxNum; txNum++ {
 		cumUsedGas, _, logIdxAfterTx, err := rawtemporaldb.ReceiptAsOf(tx, txNum+1)


### PR DESCRIPTION


Eliminates redundant database call in `ReceiptsNoDupsRange` function. The `txNumsReader.Min(tx, fromBlock)` was being called twice with the same parameters: once to initialize `fromTxNum` and again to initialize `_min`, which is unnecessary since `fromTxNum` already contains the required value.

