### PR TITLE
refactor(stream): remove unnecessary comparable constraint from ExpectEqual

### DIFF
--- a/db/kv/stream/stream_helpers.go
+++ b/db/kv/stream/stream_helpers.go
@@ -50,7 +50,7 @@ func ExpectEqualU64(tb testing.TB, s1, s2 Uno[uint64]) {
 	tb.Helper()
 	ExpectEqual[uint64](tb, s1, s2)
 }
-func ExpectEqual[V comparable](tb testing.TB, s1, s2 Uno[V]) {
+func ExpectEqual[V any](tb testing.TB, s1, s2 Uno[V]) {
 	tb.Helper()
 	for s1.HasNext() && s2.HasNext() {
 		k1, e1 := s1.Next()


### PR DESCRIPTION
Removes the redundant comparable type constraint from the ExpectEqual generic test helper function.