### PR TITLE
fix(rpc): return cached prune mode on first load in BaseAPI.pruneMode

### DIFF
--- a/rpc/jsonrpc/eth_api.go
+++ b/rpc/jsonrpc/eth_api.go
@@ -376,7 +376,7 @@ func (api *BaseAPI) pruneMode(tx kv.Tx) (*prune.Mode, error) {
 
 	api._pruneMode.Store(&mode)
 
-	return p, nil
+	return &mode, nil
 }
 
 type bridgeReader interface {


### PR DESCRIPTION
Fixes a bug in `BaseAPI.pruneMode()` where the first invocation would incorrectly return `nil` instead of the freshly loaded prune mode configuration.