### PR TITLE
refactor(p2p): replace interface{} with any in generic type parameters

### DIFF
--- a/p2p/sentry/libsentry/loop.go
+++ b/p2p/sentry/libsentry/loop.go
@@ -40,7 +40,7 @@ type (
 	MessageHandler[T any] func(context.Context, T, sentryproto.SentryClient) error
 )
 
-func ReconnectAndPumpStreamLoop[TMessage interface{}](
+func ReconnectAndPumpStreamLoop[TMessage any](
 	ctx context.Context,
 	sentryClient sentryproto.SentryClient,
 	statusDataFactory StatusDataFactory,
@@ -107,7 +107,7 @@ func ReconnectAndPumpStreamLoop[TMessage interface{}](
 // It only exists until there are no more messages
 // to be received (end of process, or interruption, or end of test).
 // wg is used only in tests to avoid using waits, which is brittle. For non-test code wg == nil.
-func pumpStreamLoop[TMessage interface{}](
+func pumpStreamLoop[TMessage any](
 	ctx context.Context,
 	sentry sentryproto.SentryClient,
 	streamName string,


### PR DESCRIPTION
Replaced `interface{}` with `any` in generic type constraints for message handling functions in `p2p/sentry/libsentry/loop.go`.