### PR TITLE
cmd/evm/t8ntool: remove dead code in getTransaction

### DIFF
--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -414,21 +414,6 @@ func getTransaction(txJson ethapi.RPCTransaction) (types.Transaction, error) {
 		}
 	}
 
-	commonTx := types.CommonTx{
-		Nonce:    uint64(txJson.Nonce),
-		To:       txJson.To,
-		Value:    value,
-		GasLimit: uint64(txJson.Gas),
-		Data:     txJson.Input,
-	}
-
-	commonTx.V.SetFromBig(txJson.V.ToInt())
-	commonTx.R.SetFromBig(txJson.R.ToInt())
-	commonTx.S.SetFromBig(txJson.S.ToInt())
-
-	//TODO: remove after https://github.com/erigontech/erigon/issues/17942
-	_, _, _, _, _, _, _, _ = commonTx.V, commonTx.R, commonTx.S, commonTx.Data, commonTx.Value, commonTx.To, commonTx.GasLimit, commonTx.Nonce
-
 	if txJson.Type == types.LegacyTxType || txJson.Type == types.AccessListTxType {
 		if txJson.Type == types.LegacyTxType {
 			return &types.LegacyTx{


### PR DESCRIPTION
Removes unused transaction prebuild logic in `getTransaction` function that was creating a redundant `CommonTx` object.