### PR TITLE
cl/sentiel: remove unused shuffleSource random source

### DIFF
--- a/cl/sentinel/utils.go
+++ b/cl/sentinel/utils.go
@@ -28,7 +28,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
-	"github.com/pion/randutil"
 	"github.com/prysmaticlabs/go-bitfield"
 
 	"github.com/erigontech/erigon/cl/gossip"
@@ -110,8 +109,6 @@ func convertToMultiAddr(nodes []*enode.Node) []multiaddr.Multiaddr {
 	}
 	return multiAddrs
 }
-
-var shuffleSource = randutil.NewMathRandomGenerator()
 
 func (s *Sentinel) oneSlotDuration() time.Duration {
 	return time.Duration(s.cfg.BeaconConfig.SecondsPerSlot) * time.Second


### PR DESCRIPTION
Remove the unused global shuffleSource and its randutil import from cl/sentinel/utils.go. This generator was never referenced anywhere in the codebase and only incurred a small initialization cost at package load time. Dropping it simplifies the sentinel utils module and makes it clearer that there is no hidden randomization logic involved in peer or subnet handling.