### PR TITLE
refactor(db/integrity): remove duplicate Min call in RCacheNoDupsRange

### DIFF
--- a/db/integrity/rcache_no_duplicates.go
+++ b/db/integrity/rcache_no_duplicates.go
@@ -65,7 +65,7 @@ func RCacheNoDupsRange(ctx context.Context, fromBlock, toBlock uint64, tx kv.Tem
 	expectedFirstLogIdx := uint32(0)
 	blockNum := fromBlock
 	var _min, _max uint64
-	_min, _ = txNumsReader.Min(tx, fromBlock)
+	_min = fromTxNum
 	_max, _ = txNumsReader.Max(tx, fromBlock)
 
 	it, err := rawdb.ReceiptCacheV2Stream(tx, fromTxNum, toTxNum)


### PR DESCRIPTION
Eliminates redundant database call in RCacheNoDupsRange function. The txNumsReader.Min(tx, fromBlock) was being called twice with the same parameters: once to initialize fromTxNum and again to initialize _min, which is unnecessary since fromTxNum already contains the required value. This mirrors the fix applied to ReceiptsNoDupsRange in #18391.