### PR TITLE
fix(diagnostics): protect syncStats.SyncFinished read with mutex lock

### DIFF
--- a/diagnostics/diaglib/block_execution.go
+++ b/diagnostics/diaglib/block_execution.go
@@ -73,7 +73,10 @@ func (d *DiagnosticClient) runBlockExecutionListener(rootCtx context.Context) {
 				return
 			case info := <-ch:
 				d.BlockExecution.SetData(info)
-				if d.syncStats.SyncFinished {
+				d.mu.Lock()
+				syncFinished := d.syncStats.SyncFinished
+				d.mu.Unlock()
+				if syncFinished {
 					return
 				}
 			}


### PR DESCRIPTION
### What:
Added mutex lock when reading syncStats.SyncFinished in runBlockExecutionListener.
### Why:
The read was unprotected while other goroutines modify syncStats. This matches the pattern used elsewhere in the diagnostics package where all syncStats accesses are protected by d.mu.Lock().