### PR TITLE
Refactor worker count calculation to remove redundant bounds check

### DIFF
--- a/common/estimate/esitmated_ram.go
+++ b/common/estimate/esitmated_ram.go
@@ -27,8 +27,7 @@ type EstimatedRamPerWorker datasize.ByteSize
 // Workers - return max workers amount based on total Memory/CPU's and estimated RAM per worker
 func (r EstimatedRamPerWorker) Workers() int {
 	maxWorkersForGivenMemory := r.WorkersByRAMOnly()
-	res := min(AlmostAllCPUs(), maxWorkersForGivenMemory)
-	return max(1, res) // must have at-least 1 worker
+	return min(AlmostAllCPUs(), maxWorkersForGivenMemory)
 }
 
 // WorkersByRAMOnly - return max workers amount based on total Memory and estimated RAM per worker


### PR DESCRIPTION


- Simplified `EstimatedRamPerWorker.Workers` by removing a redundant `max(1, ...)` wrapper.
- The minimum worker count is already guaranteed by `WorkersByRAMOnly` and `AlmostAllCPUs`.

