### PR TITLE
Do not define ChaosMonkey flag twice in `integration state_stages`

### DIFF
--- a/node/cli/flags.go
+++ b/node/cli/flags.go
@@ -372,7 +372,7 @@ func ApplyFlagsForEthConfigCobra(f *pflag.FlagSet, cfg *ethconfig.Config) {
 		cfg.ExperimentalBAL = *v
 	}
 
-	if v := f.Bool(utils.ChaosMonkeyFlag.Name, true, utils.ChaosMonkeyFlag.Usage); v != nil {
+	if v, _ := f.GetBool(utils.ChaosMonkeyFlag.Name); v {
 		cfg.ChaosMonkey = true
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/erigontech/erigon/issues/18233

The ChaosMonkey flag was being defined twice (once in `	withChaosMonkey(stateStages)`  ) and again in `ApplyFlagsForEthConfigCobra()` (which incidentally was using a default value of `true` , which seems unintentional).