### PR TITLE
node/cli: simplify prune distance flags in Cobra path

### DIFF
--- a/node/cli/flags.go
+++ b/node/cli/flags.go
@@ -332,15 +332,7 @@ func ApplyFlagsForEthConfigCobra(f *pflag.FlagSet, cfg *ethconfig.Config) {
 	pruneBlockDistance := f.Uint64(PruneBlocksDistanceFlag.Name, PruneBlocksDistanceFlag.Value, PruneBlocksDistanceFlag.Usage)
 	pruneDistance := f.Uint64(PruneDistanceFlag.Name, PruneDistanceFlag.Value, PruneDistanceFlag.Usage)
 
-	var distance, blockDistance uint64 = math.MaxUint64, math.MaxUint64
-	if pruneBlockDistance != nil {
-		blockDistance = *pruneBlockDistance
-	}
-	if pruneDistance != nil {
-		distance = *pruneDistance
-	}
-
-	mode, err := prune.FromCli(*pruneMode, distance, blockDistance)
+	mode, err := prune.FromCli(*pruneMode, *pruneDistance, *pruneBlockDistance)
 	if err != nil {
 		utils.Fatalf(fmt.Sprintf("error while parsing mode: %v", err))
 	}


### PR DESCRIPTION
ApplyFlagsForEthConfigCobra previously initialized prune distances with math.MaxUint64 and then conditionally overwrote them based on *uint64 pointers returned by pflag. Those pointers are never nil, so the extra initialization and nil checks were dead code and did not affect behavior.