### PR TITLE
execution/rlp: remove unused IsRLPError helper

### DIFF
--- a/execution/rlp/parse.go
+++ b/execution/rlp/parse.go
@@ -29,8 +29,6 @@ var (
 	ErrDecode = fmt.Errorf("%w decode", ErrBase)
 )
 
-func IsRLPError(err error) bool { return errors.Is(err, ErrBase) }
-
 // BeInt parses Big Endian representation of an integer from given payload at given position
 func BeInt(payload []byte, pos, length int) (int, error) {
 	var r int


### PR DESCRIPTION
`IsRLPError` was an exported helper that wrapped the internal `ErrBase` marker but was never used anywhere in the Erigon codebase and is not part of the documented rlp package API. A full repository and GitHub search also did not reveal any external consumers of this symbol. Keeping it around only increases the public surface area and can be confusing next to the existing IsInvalidRLPError and the concrete RLP error types. This change removes the dead helper while leaving the existing error hierarchy (`ErrBase`, `ErrParse`, `ErrDecode`) intact.