### PR TITLE
fix: remove duplicate RootHash assignment in checkpoint.go

### DIFF
--- a/polygon/heimdall/checkpoint.go
+++ b/polygon/heimdall/checkpoint.go
@@ -258,7 +258,6 @@ func (v *CheckpointListResponseV2) ToList() ([]*Checkpoint, error) {
 
 		r.Id = CheckpointId(id)
 		r.Fields.RootHash = common.BytesToHash(decoded)
-		r.Fields.RootHash = common.BytesToHash(decoded)
 		r.Fields.StartBlock = big.NewInt(int64(startBlock))
 		r.Fields.EndBlock = big.NewInt(int64(endBlock))
 


### PR DESCRIPTION
Removed duplicate line in CheckpointListResponseV2.ToList() where RootHash was assigned twice with the same value. Classic copy-paste mistake that slipped through review.