### PR TITLE
Remove unused ReceiptsFilter.Send

### DIFF
--- a/rpc/rpchelper/receiptsfilter.go
+++ b/rpc/rpchelper/receiptsfilter.go
@@ -38,11 +38,6 @@ type ReceiptsFilter struct {
 	sender            Sub[*remoteproto.SubscribeReceiptsReply]
 }
 
-// Send sends a receipt to the subscriber
-func (f *ReceiptsFilter) Send(receipt *remoteproto.SubscribeReceiptsReply) {
-	f.sender.Send(receipt)
-}
-
 // Close closes the sender
 func (f *ReceiptsFilter) Close() {
 	f.sender.Close()


### PR DESCRIPTION
Removed unused ReceiptsFilter.Send helper from internal/rpchelper/receiptsfilter.go, the method is unused and receipts are sent directly via the sender interface.