### PR TITLE
execution/commitment: remove dead DeleteUpdate logic from TouchCode

### DIFF
--- a/execution/commitment/commitment.go
+++ b/execution/commitment/commitment.go
@@ -1196,9 +1196,6 @@ func (t *Updates) TouchStorage(c *KeyUpdate, val []byte) {
 func (t *Updates) TouchCode(c *KeyUpdate, code []byte) {
 	c.update.Flags |= CodeUpdate
 	if len(code) == 0 {
-		if c.update.Flags == 0 {
-			c.update.Flags = DeleteUpdate
-		}
 		c.update.CodeHash = empty.CodeHash
 		return
 	}


### PR DESCRIPTION
TouchCode previously contained a dead conditional that attempted to set DeleteUpdate when the code was empty. In practice this branch was never reachable because CodeUpdate is ORed into Flags before the check, and semantically DeleteUpdate is used across the codebase to mean “the key is absent” (account or storage), not “code is empty”. This change removes that unreachable assignment so that TouchCode only updates CodeUpdate and CodeHash, leaving deletion semantics exclusively to TouchAccount and TouchStorage.