### PR TITLE
fix(txpool): move prevJ update outside sentryClients loop

### DIFF
--- a/txnprovider/txpool/send.go
+++ b/txnprovider/txpool/send.go
@@ -156,8 +156,8 @@ func (f *Send) AnnouncePooledTxns(types []byte, sizes []uint32, hashes Hashes, m
 					}
 				}
 			}
-			prevJ = j
 		}
+		prevJ = j
 	}
 	return
 }


### PR DESCRIPTION

Fixed a bug in AnnouncePooledTxns where prevJ = j was inside the sentryClients loop.
If all sentry clients were skipped (not ready or protocol < 68), prevJ never got updated,
causing an infinite loop. Moved the assignment outside the loop to match PropagatePooledTxnsToPeersList behavior.