### PR TITLE
Deactivate osaka on perfnet-2

### DIFF
--- a/execution/chain/spec/chainspecs/mainnet.json
+++ b/execution/chain/spec/chainspecs/mainnet.json
@@ -21,9 +21,6 @@
   "shanghaiTime": 1681338455,
   "cancunTime": 1710338135,
   "pragueTime": 1746612311,
-  "osakaTime": 1764798551,
-  "bpo1Time": 1765290071,
-  "bpo2Time": 1767747671,
   "blobSchedule": {
     "cancun": {
       "target": 3,
@@ -34,16 +31,6 @@
       "target": 6,
       "max": 9,
       "baseFeeUpdateFraction": 5007716
-    },
-    "bpo1": {
-      "target": 10,
-      "max": 15,
-      "baseFeeUpdateFraction": 8346193
-    },
-    "bpo2": {
-      "target": 14,
-      "max": 21,
-      "baseFeeUpdateFraction": 11684671
     }
   },
   "depositContractAddress": "0x00000000219ab540356cBB839Cbe05303d7705Fa",

--- a/p2p/forkid/forkid_test.go
+++ b/p2p/forkid/forkid_test.go
@@ -80,11 +80,11 @@ func TestCreation(t *testing.T) {
 				{19426586, 1710338123, ID{Hash: ChecksumToBytes(0xdce96c2d), Activation: 1681338455, Next: 1710338135}}, // Last Shanghai block
 				{19426587, 1710338135, ID{Hash: ChecksumToBytes(0x9f3d2254), Activation: 1710338135, Next: 1746612311}}, // First Cancun block
 				{22431083, 1746612299, ID{Hash: ChecksumToBytes(0x9f3d2254), Activation: 1710338135, Next: 1746612311}}, // Last Cancun block
-				{22431084, 1746612311, ID{Hash: ChecksumToBytes(0xc376cf8b), Activation: 1746612311, Next: 1764798551}}, // First Prague block
-				{futureBn, 1764798551, ID{Hash: ChecksumToBytes(0x5167e2a6), Activation: 1764798551, Next: 1765290071}}, // First Osaka block
-				{futureBn, 1765290071, ID{Hash: ChecksumToBytes(0xcba2a1c0), Activation: 1765290071, Next: 1767747671}}, // First BPO1 block
-				{futureBn, 1767747671, ID{Hash: ChecksumToBytes(0x07c9462e), Activation: 1767747671, Next: 0}},          // First BPO2 block
-				{30000000, 1900000000, ID{Hash: ChecksumToBytes(0x07c9462e), Activation: 1767747671, Next: 0}},          // Future block (mock)
+				{22431084, 1746612311, ID{Hash: ChecksumToBytes(0xc376cf8b), Activation: 1746612311, Next: 0}},          // First Prague block
+				// {futureBn, 1764798551, ID{Hash: ChecksumToBytes(0x5167e2a6), Activation: 1764798551, Next: 1765290071}}, // First Osaka block
+				// {futureBn, 1765290071, ID{Hash: ChecksumToBytes(0xcba2a1c0), Activation: 1765290071, Next: 1767747671}}, // First BPO1 block
+				// {futureBn, 1767747671, ID{Hash: ChecksumToBytes(0x07c9462e), Activation: 1767747671, Next: 0}},          // First BPO2 block
+				{30000000, 1900000000, ID{Hash: ChecksumToBytes(0xc376cf8b), Activation: 1746612311, Next: 0}}, // Future block (mock)
 			},
 		},
 		{


### PR DESCRIPTION
NOTE: this PR is for `performance` branch

Bloatnet is still on prague. This PR deactivates osaka otherwise it can't sync.