### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/txnprovider/shutter/internal/crypto/helpers_test.go
+++ b/txnprovider/shutter/internal/crypto/helpers_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func EnsureGobable(t *testing.T, src, dst interface{}) {
+func EnsureGobable(t *testing.T, src, dst any) {
 	t.Helper()
 	buff := bytes.Buffer{}
 	err := gob.NewEncoder(&buff).Encode(src)

--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -2494,7 +2494,7 @@ func (p *TxPool) logStats() {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	ctx := []interface{}{
+	ctx := []any{
 		"pending", p.pending.Len(),
 		"baseFee", p.baseFee.Len(),
 		"queued", p.queued.Len(),

--- a/txnprovider/txpool/queues.go
+++ b/txnprovider/txpool/queues.go
@@ -69,14 +69,14 @@ func (p *BestQueue) Swap(i, j int) {
 	p.ms[j].bestIndex = j
 }
 
-func (p *BestQueue) Push(x interface{}) {
+func (p *BestQueue) Push(x any) {
 	n := len(p.ms)
 	item := x.(*metaTxn)
 	item.bestIndex = n
 	p.ms = append(p.ms, item)
 }
 
-func (p *BestQueue) Pop() interface{} {
+func (p *BestQueue) Pop() any {
 	old := p.ms
 	n := len(old)
 	item := old[n-1]
@@ -106,14 +106,14 @@ func (p *WorstQueue) Swap(i, j int) {
 	p.ms[j].worstIndex = j
 }
 
-func (p *WorstQueue) Push(x interface{}) {
+func (p *WorstQueue) Push(x any) {
 	n := len(p.ms)
 	item := x.(*metaTxn)
 	item.worstIndex = n
 	p.ms = append(p.ms, x.(*metaTxn))
 }
 
-func (p *WorstQueue) Pop() interface{} {
+func (p *WorstQueue) Pop() any {
 	old := p.ms
 	n := len(old)
 	item := old[n-1]


### PR DESCRIPTION
This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.
 
As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.