### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -146,7 +146,7 @@ func SealHash(header *types.Header, c *borcfg.BorConfig) (hash common.Hash) {
 }
 
 func encodeSigHeader(w io.Writer, header *types.Header, c *borcfg.BorConfig) {
-	enc := []interface{}{
+	enc := []any{
 		header.ParentHash,
 		header.UncleHash,
 		header.Coinbase,

--- a/polygon/bor/borcfg/bor_config.go
+++ b/polygon/bor/borcfg/bor_config.go
@@ -35,8 +35,8 @@ type BorConfig struct {
 	ValidatorContract     string            `json:"validatorContract"`     // Validator set contract
 	StateReceiverContract string            `json:"stateReceiverContract"` // State receiver contract
 
-	OverrideStateSyncRecords map[string]int         `json:"overrideStateSyncRecords"` // override state records count
-	BlockAlloc               map[string]interface{} `json:"blockAlloc"`
+	OverrideStateSyncRecords map[string]int `json:"overrideStateSyncRecords"` // override state records count
+	BlockAlloc               map[string]any `json:"blockAlloc"`
 
 	JaipurBlock                *big.Int                  `json:"jaipurBlock"`                // Jaipur switch block (nil = no fork, 0 = already on Jaipur)
 	DelhiBlock                 *big.Int                  `json:"delhiBlock"`                 // Delhi switch block (nil = no fork, 0 = already on Delhi)

--- a/polygon/bor/spanner.go
+++ b/polygon/bor/spanner.go
@@ -38,8 +38,8 @@ type Spanner interface {
 }
 
 type ABI interface {
-	Pack(name string, args ...interface{}) ([]byte, error)
-	UnpackIntoInterface(v interface{}, name string, data []byte) error
+	Pack(name string, args ...any) ([]byte, error)
+	UnpackIntoInterface(v any, name string, data []byte) error
 }
 
 type ChainSpanner struct {

--- a/polygon/heimdall/service_test.go
+++ b/polygon/heimdall/service_test.go
@@ -346,7 +346,7 @@ func (suite *ServiceTestSuite) producersSubTest(blockNum uint64) {
 		haveProducers, err := svc.Producers(ctx, blockNum)
 		require.NoError(t, err)
 
-		errInfoMsgArgs := []interface{}{"wantProducers: %v\nhaveProducers: %v\n", wantProducers, haveProducers}
+		errInfoMsgArgs := []any{"wantProducers: %v\nhaveProducers: %v\n", wantProducers, haveProducers}
 		require.Len(t, haveProducers.Validators, len(wantProducers.Signers), errInfoMsgArgs...)
 		for _, signer := range wantProducers.Signers {
 			wantDifficulty := signer.Difficulty
@@ -354,7 +354,7 @@ func (suite *ServiceTestSuite) producersSubTest(blockNum uint64) {
 			haveDifficulty, err := haveProducers.Difficulty(accounts.InternAddress(producer.Address))
 			require.NoError(t, err)
 
-			errInfoMsgArgs = []interface{}{
+			errInfoMsgArgs = []any{
 				"signer:%v\nwantDifficulty: %v\nhaveDifficulty: %v\nwantProducers: %v\nhaveProducers: %v",
 				signer,
 				wantDifficulty,

--- a/polygon/sync/block_downloader.go
+++ b/polygon/sync/block_downloader.go
@@ -181,7 +181,7 @@ func (d *BlockDownloader) downloadBlocksUsingWaypoints(
 	waypoints = d.limitWaypoints(waypoints)
 	waypoints = limitWaypointsEndBlock(waypoints, end)
 
-	initialInfoLogArgs := []interface{}{
+	initialInfoLogArgs := []any{
 		"start", start,
 		"waypointsLen", len(waypoints),
 		"waypointsStart", waypoints[0].StartBlock().Uint64(),


### PR DESCRIPTION
This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.

As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.