### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/node/cli/config_file.go
+++ b/node/cli/config_file.go
@@ -32,7 +32,7 @@ import (
 func SetFlagsFromConfigFile(ctx *cli.Context, filePath string) error {
 	fileExtension := filepath.Ext(filePath)
 
-	fileConfig := make(map[string]interface{})
+	fileConfig := make(map[string]any)
 
 	if fileExtension == ".yml" || fileExtension == ".yaml" {
 		yamlFile, err := os.ReadFile(filePath)
@@ -59,7 +59,7 @@ func SetFlagsFromConfigFile(ctx *cli.Context, filePath string) error {
 	for key, value := range fileConfig {
 		if !ctx.IsSet(key) {
 			if reflect.ValueOf(value).Kind() == reflect.Slice {
-				sliceInterface := value.([]interface{})
+				sliceInterface := value.([]any)
 				s := make([]string, len(sliceInterface))
 				for i, v := range sliceInterface {
 					s[i] = fmt.Sprintf("%v", v)

--- a/node/cli/helpers.go
+++ b/node/cli/helpers.go
@@ -30,7 +30,7 @@ import (
 
 // HelpData is a one shot struct to pass to the usage template
 type HelpData struct {
-	App        interface{}
+	App        any
 	FlagGroups []FlagGroup
 }
 

--- a/node/debug/api.go
+++ b/node/debug/api.go
@@ -145,15 +145,15 @@ type pyroscopeLogger struct {
 	Logger log.Logger
 }
 
-func (l *pyroscopeLogger) Infof(format string, v ...interface{}) {
+func (l *pyroscopeLogger) Infof(format string, v ...any) {
 	l.Logger.Info(fmt.Sprintf(format, v...))
 }
 
-func (l *pyroscopeLogger) Debugf(format string, v ...interface{}) {
+func (l *pyroscopeLogger) Debugf(format string, v ...any) {
 	l.Logger.Debug(fmt.Sprintf(format, v...))
 }
 
-func (l *pyroscopeLogger) Errorf(format string, v ...interface{}) {
+func (l *pyroscopeLogger) Errorf(format string, v ...any) {
 	l.Logger.Error(fmt.Sprintf(format, v...))
 }
 

--- a/node/debug/flags.go
+++ b/node/debug/flags.go
@@ -442,10 +442,10 @@ func SetCobraFlagsFromConfigFile(cmd *cobra.Command) error {
 	return nil
 }
 
-func readConfigAsMap(filePath string) (map[string]interface{}, error) {
+func readConfigAsMap(filePath string) (map[string]any, error) {
 	fileExtension := filepath.Ext(filePath)
 
-	fileConfig := make(map[string]interface{})
+	fileConfig := make(map[string]any)
 
 	if fileExtension == ".yaml" || fileExtension == ".yml" {
 		yamlFile, err := os.ReadFile(filePath)

--- a/node/debug/loudpanic.go
+++ b/node/debug/loudpanic.go
@@ -22,7 +22,7 @@ package debug
 import "runtime/debug"
 
 // LoudPanic panics in a way that gets all goroutine stacks printed on stderr.
-func LoudPanic(x interface{}) {
+func LoudPanic(x any) {
 	debug.SetTraceback("all")
 	panic(x)
 }

--- a/node/direct/sentry_client.go
+++ b/node/direct/sentry_client.go
@@ -294,7 +294,7 @@ func (c *SentryMessagesStreamC) Recv() (*sentryproto.InboundMessage, error) {
 
 func (c *SentryMessagesStreamC) Context() context.Context { return c.ctx }
 
-func (c *SentryMessagesStreamC) RecvMsg(anyMessage interface{}) error {
+func (c *SentryMessagesStreamC) RecvMsg(anyMessage any) error {
 	m, err := c.Recv()
 	if err != nil {
 		return err
@@ -367,7 +367,7 @@ func (c *SentryPeersStreamC) Recv() (*sentryproto.PeerEvent, error) {
 
 func (c *SentryPeersStreamC) Context() context.Context { return c.ctx }
 
-func (c *SentryPeersStreamC) RecvMsg(anyMessage interface{}) error {
+func (c *SentryPeersStreamC) RecvMsg(anyMessage any) error {
 	m, err := c.Recv()
 	if err != nil {
 		return err

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -544,7 +544,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 			logEvery := time.NewTicker(90 * time.Second)
 			defer logEvery.Stop()
 
-			var logItems []interface{}
+			var logItems []any
 
 			for {
 				select {
@@ -592,7 +592,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 	}
 
 	logger.Info("Initialising Ethereum protocol", "network", config.NetworkID)
-	var rulesConfig interface{}
+	var rulesConfig any
 
 	if chainConfig.Clique != nil {
 		rulesConfig = &config.Clique

--- a/node/ethstats/ethstats.go
+++ b/node/ethstats/ethstats.go
@@ -104,7 +104,7 @@ func newConnectionWrapper(conn *websocket.Conn) *connWrapper {
 }
 
 // WriteJSON wraps corresponding method on the websocket but is safe for concurrent calling
-func (w *connWrapper) WriteJSON(v interface{}) error {
+func (w *connWrapper) WriteJSON(v any) error {
 	if w.conn == nil {
 		return nil
 	}
@@ -115,7 +115,7 @@ func (w *connWrapper) WriteJSON(v interface{}) error {
 }
 
 // ReadJSON wraps corresponding method on the websocket but is safe for concurrent calling
-func (w *connWrapper) ReadJSON(v interface{}) error {
+func (w *connWrapper) ReadJSON(v any) error {
 	w.rlock.Lock()
 	defer w.rlock.Unlock()
 
@@ -285,7 +285,7 @@ func (s *Service) readLoop(conn *connWrapper) {
 			continue
 		}
 		// Not a system ping, try to decode an actual state message
-		var msg map[string][]interface{}
+		var msg map[string][]any
 		if err := json.Unmarshal(blob, &msg); err != nil {
 			log.Warn("Failed to decode stats server message", "err", err)
 			return
@@ -315,7 +315,7 @@ func (s *Service) readLoop(conn *connWrapper) {
 		// If the message is a history request, forward to the event processor
 		if len(msg["emit"]) == 2 && command == "history" {
 			// Make sure the request is valid and doesn't crash us
-			request, ok := msg["emit"][1].(map[string]interface{})
+			request, ok := msg["emit"][1].(map[string]any)
 			if !ok {
 				log.Warn("Invalid stats history request", "msg", msg["emit"][1])
 				select {
@@ -324,7 +324,7 @@ func (s *Service) readLoop(conn *connWrapper) {
 				}
 				continue
 			}
-			list, ok := request["list"].([]interface{})
+			list, ok := request["list"].([]any)
 			if !ok {
 				log.Warn("Invalid stats history block list", "list", request["list"])
 				return
@@ -408,7 +408,7 @@ func (s *Service) login(conn *connWrapper) error {
 		},
 		Secret: s.pass,
 	}
-	login := map[string][]interface{}{
+	login := map[string][]any{
 		"emit": {"hello", auth},
 	}
 	if err := conn.WriteJSON(login); err != nil {
@@ -447,7 +447,7 @@ func (s *Service) reportLatency(conn *connWrapper) error {
 	// Send the current time to the ethstats server
 	start := time.Now()
 
-	ping := map[string][]interface{}{
+	ping := map[string][]any{
 		"emit": {"node-ping", map[string]string{
 			"id":         s.node,
 			"clientTime": start.String(),
@@ -469,7 +469,7 @@ func (s *Service) reportLatency(conn *connWrapper) error {
 	// Send back the measured latency
 	log.Trace("Sending measured latency to ethstats", "latency", latency)
 
-	stats := map[string][]interface{}{
+	stats := map[string][]any{
 		"emit": {"latency", map[string]string{
 			"id":      s.node,
 			"latency": latency,
@@ -538,11 +538,11 @@ func (s *Service) reportBlock(conn *connWrapper) error {
 	// Assemble the block report and send it to the server
 	log.Trace("Sending new block to ethstats", "number", details.Number, "hash", details.Hash)
 
-	stats := map[string]interface{}{
+	stats := map[string]any{
 		"id":    s.node,
 		"block": details,
 	}
-	report := map[string][]interface{}{
+	report := map[string][]any{
 		"emit": {"block", stats},
 	}
 	return conn.WriteJSON(report)
@@ -630,11 +630,11 @@ func (s *Service) reportHistory(conn *connWrapper, list []uint64) error {
 	} else {
 		log.Trace("No history to send to stats server")
 	}
-	stats := map[string]interface{}{
+	stats := map[string]any{
 		"id":      s.node,
 		"history": history,
 	}
-	report := map[string][]interface{}{
+	report := map[string][]any{
 		"emit": {"history", stats},
 	}
 	return conn.WriteJSON(report)
@@ -655,13 +655,13 @@ func (s *Service) reportPending(conn *connWrapper) error {
 	}
 	log.Trace("Sending pending transactions to ethstats", "count", status.PendingCount)
 
-	stats := map[string]interface{}{
+	stats := map[string]any{
 		"id": s.node,
 		"stats": &pendStats{
 			Pending: int(status.PendingCount),
 		},
 	}
-	report := map[string][]interface{}{
+	report := map[string][]any{
 		"emit": {"pending", stats},
 	}
 	return conn.WriteJSON(report)
@@ -702,7 +702,7 @@ func (s *Service) reportStats(conn *connWrapper) error {
 			peerCount += count
 		}
 	}
-	stats := map[string]interface{}{
+	stats := map[string]any{
 		"id": s.node,
 		"stats": &nodeStats{
 			Active:    true,
@@ -714,7 +714,7 @@ func (s *Service) reportStats(conn *connWrapper) error {
 			Uptime:    100,
 		},
 	}
-	report := map[string][]interface{}{
+	report := map[string][]any{
 		"emit": {"stats", stats},
 	}
 	return conn.WriteJSON(report)

--- a/node/nodecfg/config.go
+++ b/node/nodecfg/config.go
@@ -338,7 +338,7 @@ func (c *Config) parsePersistentNodes(w *bool, path string, logger log.Logger) [
 
 var warnLock sync.Mutex
 
-func (c *Config) warnOnce(logger log.Logger, w *bool, format string, args ...interface{}) {
+func (c *Config) warnOnce(logger log.Logger, w *bool, format string, args ...any) {
 	warnLock.Lock()
 	defer warnLock.Unlock()
 

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -419,7 +419,7 @@ func (h *virtualHostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 var gzPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		w := gzip.NewWriter(io.Discard)
 		return w
 	},

--- a/node/rulesconfig/config.go
+++ b/node/rulesconfig/config.go
@@ -43,7 +43,7 @@ import (
 	"github.com/erigontech/erigon/polygon/heimdall"
 )
 
-func CreateRulesEngine(ctx context.Context, nodeConfig *nodecfg.Config, chainConfig *chain.Config, config interface{}, noVerify bool,
+func CreateRulesEngine(ctx context.Context, nodeConfig *nodecfg.Config, chainConfig *chain.Config, config any, noVerify bool,
 	withoutHeimdall bool, blockReader services.FullBlockReader, readonly bool,
 	logger log.Logger, polygonBridge *bridge.Service, heimdallService *heimdall.Service,
 ) rules.Engine {
@@ -135,7 +135,7 @@ func CreateRulesEngine(ctx context.Context, nodeConfig *nodecfg.Config, chainCon
 }
 
 func CreateRulesEngineBareBones(ctx context.Context, chainConfig *chain.Config, logger log.Logger) rules.Engine {
-	var consensusConfig interface{}
+	var consensusConfig any
 
 	if chainConfig.Clique != nil {
 		consensusConfig = chainspec.CliqueSnapshot

--- a/node/shards/state_cache.go
+++ b/node/shards/state_cache.go
@@ -345,7 +345,7 @@ func (rh ReadHeap) Swap(i, j int) {
 	rh.items[i], rh.items[j] = rh.items[j], rh.items[i]
 }
 
-func (rh *ReadHeap) Push(x interface{}) {
+func (rh *ReadHeap) Push(x any) {
 	// Push and Pop use pointer receivers because they modify the slice's length,
 	// not just its contents.
 	cacheItem := x.(CacheItem)
@@ -353,7 +353,7 @@ func (rh *ReadHeap) Push(x interface{}) {
 	rh.items = append(rh.items, cacheItem)
 }
 
-func (rh *ReadHeap) Pop() interface{} {
+func (rh *ReadHeap) Pop() any {
 	cacheItem := rh.items[len(rh.items)-1]
 	rh.items = rh.items[:len(rh.items)-1]
 	return cacheItem
@@ -370,7 +370,7 @@ type StateCache struct {
 	sequence   int // Current sequence assigned to any item that has been "touched" (created, deleted, read). Incremented after every touch
 }
 
-func id(a interface{}) uint8 {
+func id(a any) uint8 {
 	switch a.(type) {
 	case *AccountItem, *AccountWriteItem, *AccountSeek:
 		return 0


### PR DESCRIPTION
This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.

As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.