### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/diagnostics/diaglib/entities.go
+++ b/diagnostics/diaglib/entities.go
@@ -272,7 +272,7 @@ type ResourcesUsage struct {
 type MemoryStats struct {
 	Alloc       uint64 `json:"alloc"`
 	Sys         uint64 `json:"sys"`
-	OtherFields []interface{}
+	OtherFields []any
 	Timestamp   time.Time             `json:"timestamp"`
 	StageIndex  CurrentSyncStagesIdxs `json:"stageIndex"`
 }

--- a/diagnostics/diaglib/network.go
+++ b/diagnostics/diaglib/network.go
@@ -148,7 +148,7 @@ func (p *PeerStats) GetPeers() map[string]PeerStatistics {
 
 func (p *PeerStats) getPeers() map[string]PeerStatistics {
 	stats := make(map[string]PeerStatistics)
-	p.peersInfo.Range(func(key, value interface{}) bool {
+	p.peersInfo.Range(func(key, value any) bool {
 		loadedKey, ok := key.(string)
 		if !ok {
 			log.Debug("Failed to cast key to string", key)

--- a/diagnostics/diaglib/notifier.go
+++ b/diagnostics/diaglib/notifier.go
@@ -8,8 +8,8 @@ import (
 )
 
 type DiagMessages struct {
-	MessageType string      `json:"messageType"`
-	Message     interface{} `json:"message"`
+	MessageType string `json:"messageType"`
+	Message     any    `json:"message"`
 }
 
 var upgrader = websocket.Upgrader{

--- a/diagnostics/diaglib/txpool.go
+++ b/diagnostics/diaglib/txpool.go
@@ -101,8 +101,8 @@ func (ti SenderInfoUpdate) Type() Type {
 }
 
 type TxpoolDiagMessage struct {
-	Type    string      `json:"type"`
-	Message interface{} `json:"message"`
+	Type    string `json:"type"`
+	Message any    `json:"message"`
 }
 
 func (d *DiagnosticClient) setupTxPoolDiagnostics(rootCtx context.Context) {

--- a/diagnostics/diaglib/utils.go
+++ b/diagnostics/diaglib/utils.go
@@ -107,7 +107,7 @@ func SecondsToHHMMString(seconds uint64) string {
 	return fmt.Sprintf("%dhrs:%dm", hours, minutes)
 }
 
-func ParseData(data []byte, v interface{}) {
+func ParseData(data []byte, v any) {
 	if len(data) == 0 {
 		return
 	}

--- a/diagnostics/flags.go
+++ b/diagnostics/flags.go
@@ -30,7 +30,7 @@ func SetupFlagsAccess(ctx *cli.Context, metricsMux *http.ServeMux) {
 
 	metricsMux.HandleFunc("/flags", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		flags := map[string]interface{}{}
+		flags := map[string]any{}
 
 		ctxFlags := map[string]struct{}{}
 
@@ -60,9 +60,9 @@ func SetupFlagsAccess(ctx *cli.Context, metricsMux *http.ServeMux) {
 			_, inCtx := ctxFlags[name]
 
 			flags[name] = struct {
-				Value   interface{} `json:"value,omitempty"`
-				Usage   string      `json:"usage,omitempty"`
-				Default bool        `json:"default"`
+				Value   any    `json:"value,omitempty"`
+				Usage   string `json:"usage,omitempty"`
+				Default bool   `json:"default"`
 			}{
 				Value:   value,
 				Usage:   usage,

--- a/diagnostics/mem/common.go
+++ b/diagnostics/mem/common.go
@@ -37,11 +37,11 @@ type VirtualMemStat struct {
 }
 
 // Fields converts VirtualMemStat to slice
-func (m VirtualMemStat) Fields() []interface{} {
+func (m VirtualMemStat) Fields() []any {
 	typ := reflect.TypeFor[process.MemoryMapsStat]()
 	val := reflect.ValueOf(m.MemoryMapsStat)
 
-	var s []interface{}
+	var s []any
 	for i := 0; i < typ.NumField(); i++ {
 		t := typ.Field(i).Name
 		if t == "Path" { // always empty for aggregated smap statistics

--- a/diagnostics/peers.go
+++ b/diagnostics/peers.go
@@ -41,16 +41,16 @@ type PeerNetworkInfo struct {
 }
 
 type PeerResponse struct {
-	ENR           string                 `json:"enr,omitempty"` // Ethereum Node Record
-	Enode         string                 `json:"enode"`         // Node URL
-	ID            string                 `json:"id"`            // Unique node identifier
-	Name          string                 `json:"name"`          // Name of the node, including client type, version, OS, custom data
-	ErrorCount    int                    `json:"errorCount"`    // Number of errors
-	LastSeenError string                 `json:"lastSeenError"` // Last seen error
-	Type          string                 `json:"type"`          // Type of connection
-	Caps          []string               `json:"caps"`          // Protocols advertised by this peer
-	Network       PeerNetworkInfo        `json:"network"`
-	Protocols     map[string]interface{} `json:"protocols"` // Sub-protocol specific metadata fields
+	ENR           string          `json:"enr,omitempty"` // Ethereum Node Record
+	Enode         string          `json:"enode"`         // Node URL
+	ID            string          `json:"id"`            // Unique node identifier
+	Name          string          `json:"name"`          // Name of the node, including client type, version, OS, custom data
+	ErrorCount    int             `json:"errorCount"`    // Number of errors
+	LastSeenError string          `json:"lastSeenError"` // Last seen error
+	Type          string          `json:"type"`          // Type of connection
+	Caps          []string        `json:"caps"`          // Protocols advertised by this peer
+	Network       PeerNetworkInfo `json:"network"`
+	Protocols     map[string]any  `json:"protocols"` // Sub-protocol specific metadata fields
 }
 
 func SetupPeersAccess(ctxclient *cli.Context, metricsMux *http.ServeMux, node *node.ErigonNode, diag *diaglib.DiagnosticClient) {


### PR DESCRIPTION
This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.

As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.