### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/db/compress/compress.go
+++ b/db/compress/compress.go
@@ -21,7 +21,7 @@ var (
 	// Encoder side: saw high mem use when using pool of encoders. And probably we don't need high-throughput on writes (they are usually in background). So, keep 1 encoder - it inside using GOMAXPROCS concurrency limit (see zstd.WithDecoderConcurrency).
 	zstdEnc, _  = zstd.NewWriter(nil, zstd.WithEncoderCRC(false), zstd.WithZeroFrames(true))
 	zstdDecPool = sync.Pool{
-		New: func() interface{} {
+		New: func() any {
 			dec, _ := zstd.NewReader(nil, zstd.IgnoreChecksum(true))
 			return dec
 		},

--- a/db/etl/buffers.go
+++ b/db/etl/buffers.go
@@ -49,13 +49,13 @@ var BufferOptimalSize = dbg.EnvDataSize("ETL_OPTIMAL", 256*datasize.MB) /*  var 
 // 3_domains * 2 + 3_history * 1 + 4_indices * 2 = 17 etl collectors, 17*(256Mb/8) = 512Mb - for all collectros
 var etlSmallBufRAM = dbg.EnvDataSize("ETL_SMALL", BufferOptimalSize/8)
 var SmallSortableBuffers = NewAllocator(&sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return NewSortableBuffer(etlSmallBufRAM).Prealloc(1_024, int(etlSmallBufRAM/32))
 	},
 })
 var etlLargeBufRAM = BufferOptimalSize
 var LargeSortableBuffers = NewAllocator(&sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return NewSortableBuffer(etlLargeBufRAM).Prealloc(1_024, int(etlLargeBufRAM/32))
 	},
 })

--- a/db/etl/etl.go
+++ b/db/etl/etl.go
@@ -62,7 +62,7 @@ func NextKey(key []byte) ([]byte, error) {
 // * `key`: last commited key to the database (use etl.NextKey helper to use in LoadStartKey)
 // * `isDone`: true, if everything is processed
 type LoadCommitHandler func(db kv.Putter, key []byte, isDone bool) error
-type AdditionalLogArguments func(k, v []byte) (additionalLogArguments []interface{})
+type AdditionalLogArguments func(k, v []byte) (additionalLogArguments []any)
 
 type TransformArgs struct {
 	Quit              <-chan struct{}
@@ -138,7 +138,7 @@ func extractBucketIntoFiles(
 		select {
 		default:
 		case <-logEvery.C:
-			logArs := []interface{}{"from", bucket}
+			logArs := []any{"from", bucket}
 			if additionalLogArguments != nil {
 				logArs = append(logArs, additionalLogArguments(k, v)...)
 			} else {

--- a/db/kv/kv_interface.go
+++ b/db/kv/kv_interface.go
@@ -452,7 +452,7 @@ type TemporalDebugTx interface {
 	Dirs() datadir.Dirs
 	AllForkableIds() []ForkableId
 
-	NewMemBatch(ioMetrics interface{}) TemporalMemBatch
+	NewMemBatch(ioMetrics any) TemporalMemBatch
 }
 
 type TemporalDebugDB interface {

--- a/db/kv/mdbx/kv_mdbx_batch.go
+++ b/db/kv/mdbx/kv_mdbx_batch.go
@@ -140,7 +140,7 @@ retry:
 var trySolo = errors.New("batch function returned an error and should be re-run solo")
 
 type panicked struct {
-	reason interface{}
+	reason any
 }
 
 func (p panicked) Error() string {

--- a/db/kv/mdbx/kv_mdbx_test.go
+++ b/db/kv/mdbx/kv_mdbx_test.go
@@ -801,7 +801,7 @@ func TestDB_Batch_Panic(t *testing.T) {
 
 	var sentinel int
 	var bork = &sentinel
-	var problem interface{}
+	var problem any
 	var err error
 
 	// Execute a function inside a batch that panics.

--- a/db/kv/remotedb/kv_remote.go
+++ b/db/kv/remotedb/kv_remote.go
@@ -188,17 +188,17 @@ func (db *DB) BeginRo(ctx context.Context) (txn kv.Tx, err error) {
 	}
 	return &tx{ctx: ctx, db: db, stream: stream, streamCancelFn: streamCancelFn, viewID: msg.ViewId, id: msg.TxId}, nil
 }
-func (db *DB) Debug() kv.TemporalDebugDB                             { return kv.TemporalDebugDB(db) }
-func (db *DB) NewMemBatch(ioMetrics interface{}) kv.TemporalMemBatch { panic("not implemented") }
-func (db *DB) DomainTables(domain ...kv.Domain) []string             { panic("not implemented") }
-func (db *DB) InvertedIdxTables(domain ...kv.InvertedIdx) []string   { panic("not implemented") }
-func (db *DB) ForkableTables(domain ...kv.ForkableId) []string       { panic("not implemented") }
-func (db *DB) ReloadFiles() error                                    { panic("not implemented") }
-func (db *DB) BuildMissedAccessors(_ context.Context, _ int) error   { panic("not implemented") }
-func (db *DB) EnableReadAhead() kv.TemporalDebugDB                   { panic("not implemented") }
-func (db *DB) DisableReadAhead()                                     { panic("not implemented") }
-func (db *DB) Files() []string                                       { panic("not implemented") }
-func (db *DB) MergeLoop(ctx context.Context) error                   { panic("not implemented") }
+func (db *DB) Debug() kv.TemporalDebugDB                           { return kv.TemporalDebugDB(db) }
+func (db *DB) NewMemBatch(ioMetrics any) kv.TemporalMemBatch       { panic("not implemented") }
+func (db *DB) DomainTables(domain ...kv.Domain) []string           { panic("not implemented") }
+func (db *DB) InvertedIdxTables(domain ...kv.InvertedIdx) []string { panic("not implemented") }
+func (db *DB) ForkableTables(domain ...kv.ForkableId) []string     { panic("not implemented") }
+func (db *DB) ReloadFiles() error                                  { panic("not implemented") }
+func (db *DB) BuildMissedAccessors(_ context.Context, _ int) error { panic("not implemented") }
+func (db *DB) EnableReadAhead() kv.TemporalDebugDB                 { panic("not implemented") }
+func (db *DB) DisableReadAhead()                                   { panic("not implemented") }
+func (db *DB) Files() []string                                     { panic("not implemented") }
+func (db *DB) MergeLoop(ctx context.Context) error                 { panic("not implemented") }
 func (db *DB) BeginTemporalRo(ctx context.Context) (kv.TemporalTx, error) {
 	t, err := db.BeginRo(ctx) //nolint:gocritic
 	if err != nil {
@@ -243,7 +243,7 @@ func (db *DB) UpdateNosync(ctx context.Context, f func(tx kv.RwTx) error) (err e
 	return errors.New("remote db provider doesn't support .UpdateNosync method")
 }
 
-func (tx *tx) NewMemBatch(ioMetrics interface{}) kv.TemporalMemBatch { panic("not implemented") }
+func (tx *tx) NewMemBatch(ioMetrics any) kv.TemporalMemBatch { panic("not implemented") }
 
 func (tx *tx) AggTx() any                                      { panic("not implemented") }
 func (tx *tx) Debug() kv.TemporalDebugTx                       { return kv.TemporalDebugTx(tx) }

--- a/db/kv/temporal/kv_temporal.go
+++ b/db/kv/temporal/kv_temporal.go
@@ -371,10 +371,10 @@ func (tx *RwTx) LockDBInRam() error {
 func (tx *RwTx) Debug() kv.TemporalDebugTx { return tx }
 func (tx *Tx) Debug() kv.TemporalDebugTx   { return tx }
 
-func (tx *RwTx) NewMemBatch(ioMetrics interface{}) kv.TemporalMemBatch {
+func (tx *RwTx) NewMemBatch(ioMetrics any) kv.TemporalMemBatch {
 	return state.NewTemporalMemBatch(tx, ioMetrics)
 }
-func (tx *Tx) NewMemBatch(ioMetrics interface{}) kv.TemporalMemBatch {
+func (tx *Tx) NewMemBatch(ioMetrics any) kv.TemporalMemBatch {
 	return state.NewTemporalMemBatch(tx, ioMetrics)
 }
 

--- a/db/recsplit/index.go
+++ b/db/recsplit/index.go
@@ -158,7 +158,7 @@ func OpenIndex(indexFilePath string) (idx *Index, err error) {
 	//}
 
 	idx.readers = &sync.Pool{
-		New: func() interface{} {
+		New: func() any {
 			return NewIndexReader(idx)
 		},
 	}

--- a/db/seg/compress.go
+++ b/db/seg/compress.go
@@ -400,11 +400,11 @@ func (db *DictionaryBuilder) Swap(i, j int) {
 }
 func (db *DictionaryBuilder) Sort() { slices.SortFunc(db.items, dictionaryBuilderCmp) }
 
-func (db *DictionaryBuilder) Push(x interface{}) {
+func (db *DictionaryBuilder) Push(x any) {
 	db.items = append(db.items, x.(*Pattern))
 }
 
-func (db *DictionaryBuilder) Pop() interface{} {
+func (db *DictionaryBuilder) Pop() any {
 	old := db.items
 	n := len(old)
 	x := old[n-1]
@@ -574,11 +574,11 @@ func (ph *PatternHeap) Swap(i, j int) {
 	(*ph)[i], (*ph)[j] = (*ph)[j], (*ph)[i]
 }
 
-func (ph *PatternHeap) Push(x interface{}) {
+func (ph *PatternHeap) Push(x any) {
 	*ph = append(*ph, x.(*PatternHuff))
 }
 
-func (ph *PatternHeap) Pop() interface{} {
+func (ph *PatternHeap) Pop() any {
 	old := *ph
 	n := len(old)
 	x := old[n-1]
@@ -685,11 +685,11 @@ func (ph *PositionHeap) Swap(i, j int) {
 	(*ph)[i], (*ph)[j] = (*ph)[j], (*ph)[i]
 }
 
-func (ph *PositionHeap) Push(x interface{}) {
+func (ph *PositionHeap) Push(x any) {
 	*ph = append(*ph, x.(*PositionHuff))
 }
 
-func (ph *PositionHeap) Pop() interface{} {
+func (ph *PositionHeap) Pop() any {
 	old := *ph
 	n := len(old)
 	x := old[n-1]

--- a/db/seg/parallel_compress.go
+++ b/db/seg/parallel_compress.go
@@ -223,11 +223,11 @@ func (cq *CompressionQueue) Swap(i, j int) {
 	(*cq)[i], (*cq)[j] = (*cq)[j], (*cq)[i]
 }
 
-func (cq *CompressionQueue) Push(x interface{}) {
+func (cq *CompressionQueue) Push(x any) {
 	*cq = append(*cq, x.(*CompressionWord))
 }
 
-func (cq *CompressionQueue) Pop() interface{} {
+func (cq *CompressionQueue) Pop() any {
 	old := *cq
 	n := len(old)
 	x := old[n-1]
@@ -471,7 +471,7 @@ func compressWithPatternCandidates(ctx context.Context, trace bool, cfg Cfg, log
 		}
 	}
 	slices.SortFunc(patternList, patternListCmp)
-	logCtx := make([]interface{}, 0, 8)
+	logCtx := make([]any, 0, 8)
 	logCtx = append(logCtx, "patternList.Len", patternList.Len())
 
 	i := 0

--- a/db/seg/patricia/patricia.go
+++ b/db/seg/patricia/patricia.go
@@ -28,7 +28,7 @@ import (
 
 // Implementation of paticia tree for efficient search of substrings from a dictionary in a given string
 type node struct {
-	val interface{} // value associated with the key
+	val any // value associated with the key
 	n0  *node
 	n1  *node
 	p0  uint32
@@ -287,7 +287,7 @@ func (s *pathWalker) diverge(divergence uint32) {
 	s.tail = 0
 }
 
-func (n *node) insert(key []byte, value interface{}) {
+func (n *node) insert(key []byte, value any) {
 	s := newPathWalker(n)
 	for _, b := range key {
 		divergence := s.transition(b, false /* readonly */)
@@ -298,7 +298,7 @@ func (n *node) insert(key []byte, value interface{}) {
 	s.insert(value)
 }
 
-func (s *pathWalker) insert(value interface{}) {
+func (s *pathWalker) insert(value any) {
 	if s.tail != 0 {
 		s.diverge(0)
 	}
@@ -316,7 +316,7 @@ func (s *pathWalker) insert(value interface{}) {
 	s.n.val = value
 }
 
-func (n *node) get(key []byte) (interface{}, bool) {
+func (n *node) get(key []byte) (any, bool) {
 	s := newPathWalker(n)
 	for _, b := range key {
 		divergence := s.transition(b, true /* readonly */)
@@ -335,17 +335,17 @@ type PatriciaTree struct {
 	root node
 }
 
-func (pt *PatriciaTree) Insert(key []byte, value interface{}) {
+func (pt *PatriciaTree) Insert(key []byte, value any) {
 	//fmt.Printf("%p Insert [%x]\n", pt, key)
 	pt.root.insert(key, value)
 }
 
-func (pt *PatriciaTree) Get(key []byte) (interface{}, bool) {
+func (pt *PatriciaTree) Get(key []byte) (any, bool) {
 	return pt.root.get(key)
 }
 
 type Match struct {
-	Val   interface{}
+	Val   any
 	Start int
 	End   int
 }

--- a/db/snapshotsync/caplin_state_snapshots.go
+++ b/db/snapshotsync/caplin_state_snapshots.go
@@ -444,7 +444,7 @@ func (s *CaplinStateSnapshots) recalcVisibleFiles() {
 	// for k := range s.visible {
 	// 	s.visible[k] = getNewVisibleSegments(s.dirty[k])
 	// }
-	s.visible.Range(func(k, v interface{}) bool {
+	s.visible.Range(func(k, v any) bool {
 		s.visible.Store(k, getNewVisibleSegments(s.dirty[k.(string)]))
 		return true
 	})
@@ -463,7 +463,7 @@ func (s *CaplinStateSnapshots) idxAvailability() uint64 {
 	// 		min = segs[len(segs)-1].to
 	// 	}
 	// }
-	s.visible.Range(func(_, v interface{}) bool {
+	s.visible.Range(func(_, v any) bool {
 		segs := v.([]*VisibleSegment)
 		if len(segs) == 0 {
 			min = 0
@@ -552,7 +552,7 @@ func (s *CaplinStateSnapshots) View() *CaplinStateView {
 	// for k, segments := range s.visible {
 	// 	v.roTxs[k] = segments.BeginRo()
 	// }
-	s.visible.Range(func(k, val interface{}) bool {
+	s.visible.Range(func(k, val any) bool {
 		v.roTxs[k.(string)] = VisibleSegments(val.([]*VisibleSegment)).BeginRo()
 		return true
 	})

--- a/db/snapshotsync/freezeblocks/beacon_block_reader.go
+++ b/db/snapshotsync/freezeblocks/beacon_block_reader.go
@@ -34,11 +34,11 @@ import (
 )
 
 var buffersPool = sync.Pool{
-	New: func() interface{} { return &bytes.Buffer{} },
+	New: func() any { return &bytes.Buffer{} },
 }
 
 var decompressorPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		r, err := zstd.NewReader(nil)
 		if err != nil {
 			panic(err)

--- a/db/state/domain_stream.go
+++ b/db/state/domain_stream.go
@@ -85,11 +85,11 @@ func (ch *CursorHeap) Swap(i, j int) {
 	(*ch)[i], (*ch)[j] = (*ch)[j], (*ch)[i]
 }
 
-func (ch *CursorHeap) Push(x interface{}) {
+func (ch *CursorHeap) Push(x any) {
 	*ch = append(*ch, x.(*CursorItem))
 }
 
-func (ch *CursorHeap) Pop() interface{} {
+func (ch *CursorHeap) Pop() any {
 	old := *ch
 	n := len(old)
 	x := old[n-1]

--- a/db/state/state_recon.go
+++ b/db/state/state_recon.go
@@ -58,7 +58,7 @@ func (rh ReconHeap) Swap(i, j int) {
 }
 
 // Push (part of heap.Interface) places a new link onto the end of queue. Note that idx attribute is set to the correct position of the new link
-func (rh *ReconHeap) Push(x interface{}) {
+func (rh *ReconHeap) Push(x any) {
 	// Push and Pop use pointer receivers because they modify the slice's length,
 	// not just its contents.
 	l := x.(*ReconItem)
@@ -66,7 +66,7 @@ func (rh *ReconHeap) Push(x interface{}) {
 }
 
 // Pop (part of heap.Interface) removes the first link from the queue
-func (rh *ReconHeap) Pop() interface{} {
+func (rh *ReconHeap) Pop() any {
 	old := *rh
 	n := len(old)
 	x := old[n-1]

--- a/db/state/temporal_mem_batch.go
+++ b/db/state/temporal_mem_batch.go
@@ -68,7 +68,7 @@ type TemporalMemBatch struct {
 	metrics *changeset.DomainMetrics
 }
 
-func NewTemporalMemBatch(tx kv.TemporalTx, ioMetrics interface{}) *TemporalMemBatch {
+func NewTemporalMemBatch(tx kv.TemporalTx, ioMetrics any) *TemporalMemBatch {
 	sd := &TemporalMemBatch{
 		storage: btree2.NewMap[string, dataWithStep](128),
 		metrics: ioMetrics.(*changeset.DomainMetrics),


### PR DESCRIPTION
This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.

As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.