### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/common/address.go
+++ b/common/address.go
@@ -160,7 +160,7 @@ func (a *Address) UnmarshalJSON(input []byte) error {
 }
 
 // Scan implements Scanner for database/sql.
-func (a *Address) Scan(src interface{}) error {
+func (a *Address) Scan(src any) error {
 	srcB, ok := src.([]byte)
 	if !ok {
 		return fmt.Errorf("can't scan %T into Address", src)

--- a/common/cbor/marshal.go
+++ b/common/cbor/marshal.go
@@ -20,14 +20,14 @@ import (
 	"io"
 )
 
-func Marshal(dst io.Writer, v interface{}) error {
+func Marshal(dst io.Writer, v any) error {
 	e := Encoder(dst)
 	err := e.Encode(v)
 	returnEncoderToPool(e)
 	return err
 }
 
-func Unmarshal(dst interface{}, data io.Reader) error {
+func Unmarshal(dst any, data io.Reader) error {
 	d := Decoder(data)
 	err := d.Decode(dst)
 	returnDecoderToPool(d)

--- a/common/crypto/crypto.go
+++ b/common/crypto/crypto.go
@@ -305,7 +305,7 @@ func PubkeyToAddress(p ecdsa.PublicKey) common.Address {
 
 // hasherPool holds LegacyKeccak hashers.
 var hasherPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return sha3.NewLegacyKeccak256()
 	},
 }

--- a/common/hash.go
+++ b/common/hash.go
@@ -153,7 +153,7 @@ func (h Hash) Generate(rand *rand.Rand, size int) reflect.Value {
 }
 
 // Scan implements Scanner for database/sql.
-func (h *Hash) Scan(src interface{}) error {
+func (h *Hash) Scan(src any) error {
 	srcB, ok := src.([]byte)
 	if !ok {
 		return fmt.Errorf("can't scan %T into Hash", src)
@@ -174,7 +174,7 @@ func (h Hash) Value() (driver.Value, error) {
 func (Hash) ImplementsGraphQLType(name string) bool { return name == "Bytes32" }
 
 // UnmarshalGraphQL unmarshals the provided GraphQL query data.
-func (h *Hash) UnmarshalGraphQL(input interface{}) error {
+func (h *Hash) UnmarshalGraphQL(input any) error {
 	var err error
 	switch input := input.(type) {
 	case string:

--- a/common/hexutil/hexutil_test.go
+++ b/common/hexutil/hexutil_test.go
@@ -25,13 +25,13 @@ import (
 )
 
 type marshalTest struct {
-	input interface{}
+	input any
 	want  string
 }
 
 type unmarshalTest struct {
 	input        string
-	want         interface{}
+	want         any
 	wantErr      error // if set, decoding must fail on any platform
 	wantErr32bit error // if set, decoding must fail on 32bit platforms (used for Uint tests)
 }

--- a/common/log/v3/bench_test.go
+++ b/common/log/v3/bench_test.go
@@ -52,7 +52,7 @@ func BenchmarkLogfmtNoCtx(b *testing.B) {
 		Time: time.Now(),
 		Lvl:  LvlInfo,
 		Msg:  "test message",
-		Ctx:  []interface{}{},
+		Ctx:  []any{},
 	}
 
 	logfmt := LogfmtFormat()
@@ -66,7 +66,7 @@ func BenchmarkJsonNoCtx(b *testing.B) {
 		Time: time.Now(),
 		Lvl:  LvlInfo,
 		Msg:  "test message",
-		Ctx:  []interface{}{},
+		Ctx:  []any{},
 	}
 
 	jsonfmt := JsonFormat()

--- a/common/log/v3/format.go
+++ b/common/log/v3/format.go
@@ -112,14 +112,14 @@ func TerminalFormatNoColor() Format {
 // For more details see: http://godoc.org/github.com/kr/logfmt
 func LogfmtFormat() Format {
 	return FormatFunc(func(r *Record) []byte {
-		common := []interface{}{r.KeyNames.Time, r.Time, r.KeyNames.Lvl, r.Lvl, r.KeyNames.Msg, r.Msg}
+		common := []any{r.KeyNames.Time, r.Time, r.KeyNames.Lvl, r.Lvl, r.KeyNames.Msg, r.Msg}
 		buf := &bytes.Buffer{}
 		logfmt(buf, append(common, r.Ctx...), 0)
 		return buf.Bytes()
 	})
 }
 
-func logfmt(buf *bytes.Buffer, ctx []interface{}, color int) {
+func logfmt(buf *bytes.Buffer, ctx []any, color int) {
 	for i := 0; i < len(ctx); i += 2 {
 		if i != 0 {
 			buf.WriteByte(' ')
@@ -156,13 +156,13 @@ func JsonFormat() Format {
 func JsonFormatEx(pretty, lineSeparated bool) Format {
 	jsonMarshal := json.Marshal
 	if pretty {
-		jsonMarshal = func(v interface{}) ([]byte, error) {
+		jsonMarshal = func(v any) ([]byte, error) {
 			return json.MarshalIndent(v, "", "    ")
 		}
 	}
 
 	return FormatFunc(func(r *Record) []byte {
-		props := make(map[string]interface{})
+		props := make(map[string]any)
 
 		props[r.KeyNames.Time] = r.Time
 		props[r.KeyNames.Lvl] = r.Lvl.String()
@@ -192,7 +192,7 @@ func JsonFormatEx(pretty, lineSeparated bool) Format {
 	})
 }
 
-func formatShared(value interface{}) (result interface{}) {
+func formatShared(value any) (result any) {
 	defer func() {
 		if err := recover(); err != nil {
 			if v := reflect.ValueOf(value); v.Kind() == reflect.Ptr && v.IsNil() {
@@ -218,13 +218,13 @@ func formatShared(value interface{}) (result interface{}) {
 	}
 }
 
-func formatJSONValue(value interface{}) interface{} {
+func formatJSONValue(value any) any {
 	value = formatShared(value)
 
 	switch value.(type) {
 	case int, int8, int16, int32, int64, float32, float64, uint, uint8, uint16, uint32, uint64, string:
 		return value
-	case map[string]interface{}, []interface{}, interface{}:
+	case map[string]any, []any, any:
 		return value
 	default:
 		return fmt.Sprintf("%+v", value)
@@ -232,7 +232,7 @@ func formatJSONValue(value interface{}) interface{} {
 }
 
 // formatValue formats a value for serialization
-func formatLogfmtValue(value interface{}) string {
+func formatLogfmtValue(value any) string {
 	if value == nil {
 		return "nil"
 	}
@@ -261,7 +261,7 @@ func formatLogfmtValue(value interface{}) string {
 }
 
 var stringBufPool = sync.Pool{
-	New: func() interface{} { return new(bytes.Buffer) },
+	New: func() any { return new(bytes.Buffer) },
 }
 
 func escapeString(s string) string {

--- a/common/log/v3/handler.go
+++ b/common/log/v3/handler.go
@@ -253,7 +253,7 @@ func (h filterHandler) Enabled(ctx context.Context, lvl Lvl) bool {
 // from your ui package:
 //
 //	log.MatchFilterHandler("pkg", "app/ui", log.StdoutHandler)
-func MatchFilterHandler(key string, value interface{}, h Handler) Handler {
+func MatchFilterHandler(key string, value any, h Handler) Handler {
 	return FilterHandler(func(r *Record) (pass bool) {
 		switch key {
 		case r.KeyNames.Lvl:
@@ -482,7 +482,7 @@ func (h lazyHandler) Enabled(ctx context.Context, lvl Lvl) bool {
 	return h.h.Enabled(ctx, lvl)
 }
 
-func evaluateLazy(lz Lazy) (interface{}, error) {
+func evaluateLazy(lz Lazy) (any, error) {
 	t := reflect.TypeOf(lz.Fn)
 
 	if t.Kind() != reflect.Func {
@@ -502,7 +502,7 @@ func evaluateLazy(lz Lazy) (interface{}, error) {
 	if len(results) == 1 {
 		return results[0].Interface(), nil
 	}
-	values := make([]interface{}, len(results))
+	values := make([]any, len(results))
 	for i, v := range results {
 		values[i] = v.Interface()
 	}

--- a/common/log/v3/log_test.go
+++ b/common/log/v3/log_test.go
@@ -109,13 +109,13 @@ func TestJson(t *testing.T) {
 	l, buf := testFormatter(JsonFormat())
 	l.Error("some message", "x", 1, "y", 3.2)
 
-	var v map[string]interface{}
+	var v map[string]any
 	decoder := json.NewDecoder(buf)
 	if err := decoder.Decode(&v); err != nil {
 		t.Fatalf("Error decoding JSON: %v", v)
 	}
 
-	validate := func(key string, expected interface{}) {
+	validate := func(key string, expected any) {
 		if v[key] != expected {
 			t.Fatalf("Got %v expected %v for %v", v[key], expected, key)
 		}
@@ -128,7 +128,7 @@ func TestJson(t *testing.T) {
 }
 
 func TestJSONMap(t *testing.T) {
-	m := map[string]interface{}{
+	m := map[string]any{
 		"name":     "gopher",
 		"age":      float64(5),
 		"language": "go",
@@ -137,19 +137,19 @@ func TestJSONMap(t *testing.T) {
 	l, buf := testFormatter(JsonFormat())
 	l.Error("logging structs", "struct", m)
 
-	var v map[string]interface{}
+	var v map[string]any
 	decoder := json.NewDecoder(buf)
 	if err := decoder.Decode(&v); err != nil {
 		t.Fatalf("Error decoding JSON: %v", v)
 	}
 
-	checkMap := func(key string, expected interface{}) {
+	checkMap := func(key string, expected any) {
 		if m[key] != expected {
 			t.Fatalf("Got %v expected %v for %v", m[key], expected, key)
 		}
 	}
 
-	mv := v["struct"].(map[string]interface{})
+	mv := v["struct"].(map[string]any)
 	checkMap("name", mv["name"])
 	checkMap("age", mv["age"])
 	checkMap("language", mv["language"])
@@ -590,7 +590,7 @@ func TestConcurrent(t *testing.T) {
 	// go to allocate extra capacity in the logger's context slice which
 	// was necessary to trigger the bug
 	const ctxLen = 34
-	l := root.New(make([]interface{}, ctxLen)...)
+	l := root.New(make([]any, ctxLen)...)
 	const goroutines = 8
 	var res [goroutines]int
 	l.SetHandler(SyncHandler(concurrentCaptureTestHandler{res: res[:], ctxLen: ctxLen}))

--- a/common/log/v3/logger.go
+++ b/common/log/v3/logger.go
@@ -78,7 +78,7 @@ type Record struct {
 	Time     time.Time
 	Lvl      Lvl
 	Msg      string
-	Ctx      []interface{}
+	Ctx      []any
 	KeyNames RecordKeyNames
 }
 
@@ -96,7 +96,7 @@ type RecordKeyNames struct {
 // A Logger writes key/value pairs to a Handler
 type Logger interface {
 	// New returns a new Logger that has this logger's context plus the given context
-	New(ctx ...interface{}) Logger
+	New(ctx ...any) Logger
 
 	// GetHandler gets the handler associated with the logger.
 	GetHandler() Handler
@@ -108,21 +108,21 @@ type Logger interface {
 	Enabled(ctx context.Context, lvl Lvl) bool
 
 	// Log a message at the given level with context key/value pairs
-	Trace(msg string, ctx ...interface{})
-	Debug(msg string, ctx ...interface{})
-	Info(msg string, ctx ...interface{})
-	Warn(msg string, ctx ...interface{})
-	Error(msg string, ctx ...interface{})
-	Crit(msg string, ctx ...interface{})
-	Log(level Lvl, msg string, ctx ...interface{})
+	Trace(msg string, ctx ...any)
+	Debug(msg string, ctx ...any)
+	Info(msg string, ctx ...any)
+	Warn(msg string, ctx ...any)
+	Error(msg string, ctx ...any)
+	Crit(msg string, ctx ...any)
+	Log(level Lvl, msg string, ctx ...any)
 }
 
 type logger struct {
-	ctx []interface{}
+	ctx []any
 	h   *swapHandler
 }
 
-func (l *logger) write(msg string, lvl Lvl, ctx []interface{}) {
+func (l *logger) write(msg string, lvl Lvl, ctx []any) {
 	l.h.Log(&Record{
 		Time: time.Now(),
 		Lvl:  lvl,
@@ -136,46 +136,46 @@ func (l *logger) write(msg string, lvl Lvl, ctx []interface{}) {
 	})
 }
 
-func (l *logger) New(ctx ...interface{}) Logger {
+func (l *logger) New(ctx ...any) Logger {
 	child := &logger{newContext(l.ctx, ctx), new(swapHandler)}
 	child.SetHandler(l.h)
 	return child
 }
 
-func newContext(prefix []interface{}, suffix []interface{}) []interface{} {
+func newContext(prefix []any, suffix []any) []any {
 	normalizedSuffix := normalize(suffix)
-	newCtx := make([]interface{}, len(prefix)+len(normalizedSuffix))
+	newCtx := make([]any, len(prefix)+len(normalizedSuffix))
 	n := copy(newCtx, prefix)
 	copy(newCtx[n:], normalizedSuffix)
 	return newCtx
 }
 
-func (l *logger) Trace(msg string, ctx ...interface{}) {
+func (l *logger) Trace(msg string, ctx ...any) {
 	l.write(msg, LvlTrace, ctx)
 }
 
-func (l *logger) Debug(msg string, ctx ...interface{}) {
+func (l *logger) Debug(msg string, ctx ...any) {
 	l.write(msg, LvlDebug, ctx)
 }
 
-func (l *logger) Info(msg string, ctx ...interface{}) {
+func (l *logger) Info(msg string, ctx ...any) {
 	l.write(msg, LvlInfo, ctx)
 }
 
-func (l *logger) Warn(msg string, ctx ...interface{}) {
+func (l *logger) Warn(msg string, ctx ...any) {
 	l.write(msg, LvlWarn, ctx)
 }
 
-func (l *logger) Error(msg string, ctx ...interface{}) {
+func (l *logger) Error(msg string, ctx ...any) {
 	l.write(msg, LvlError, ctx)
 }
 
-func (l *logger) Crit(msg string, ctx ...interface{}) {
+func (l *logger) Crit(msg string, ctx ...any) {
 	l.write(msg, LvlCrit, ctx)
 }
 
 // Log method to route configurable log level
-func (l *logger) Log(level Lvl, msg string, ctx ...interface{}) {
+func (l *logger) Log(level Lvl, msg string, ctx ...any) {
 	l.write(msg, level, ctx)
 }
 
@@ -191,7 +191,7 @@ func (l *logger) SetHandler(h Handler) {
 	l.h.Swap(h)
 }
 
-func normalize(ctx []interface{}) []interface{} {
+func normalize(ctx []any) []any {
 	// if the caller passed a Ctx object, then expand it
 	if len(ctx) == 1 {
 		if ctxMap, ok := ctx[0].(Ctx); ok {
@@ -221,16 +221,16 @@ func normalize(ctx []interface{}) []interface{} {
 // You may wrap any function which takes no arguments to Lazy. It may return any
 // number of values of any type.
 type Lazy struct {
-	Fn interface{}
+	Fn any
 }
 
 // Ctx is a map of key/value pairs to pass as context to a log function
 // Use this only if you really need greater safety around the arguments you pass
 // to the logging functions.
-type Ctx map[string]interface{}
+type Ctx map[string]any
 
-func (c Ctx) toArray() []interface{} {
-	arr := make([]interface{}, len(c)*2)
+func (c Ctx) toArray() []any {
+	arr := make([]any, len(c)*2)
 
 	i := 0
 	for k, v := range c {

--- a/common/log/v3/root.go
+++ b/common/log/v3/root.go
@@ -23,13 +23,13 @@ func init() {
 		StderrHandler = StreamHandler(colorable.NewColorableStderr(), TerminalFormat())
 	}
 
-	root = &logger{[]interface{}{}, new(swapHandler)}
+	root = &logger{[]any{}, new(swapHandler)}
 	root.SetHandler(LvlFilterHandler(LvlWarn, StdoutHandler))
 }
 
 // New returns a new logger with the given context.
 // New is a convenient alias for Root().New
-func New(ctx ...interface{}) Logger {
+func New(ctx ...any) Logger {
 	return root.New(ctx...)
 }
 
@@ -43,43 +43,43 @@ func Root() Logger {
 // runtime.Caller(2) always refers to the call site in client code.
 
 // Trace is a convenient alias for Root().Trace
-func Trace(msg string, ctx ...interface{}) {
+func Trace(msg string, ctx ...any) {
 	root.write(msg, LvlTrace, ctx)
 }
 
 // Debug is a convenient alias for Root().Debug
-func Debug(msg string, ctx ...interface{}) {
+func Debug(msg string, ctx ...any) {
 	root.write(msg, LvlDebug, ctx)
 }
 
 // Info is a convenient alias for Root().Info
-func Info(msg string, ctx ...interface{}) {
+func Info(msg string, ctx ...any) {
 	root.write(msg, LvlInfo, ctx)
 }
 
 // Warn is a convenient alias for Root().Warn
-func Warn(msg string, ctx ...interface{}) {
+func Warn(msg string, ctx ...any) {
 	root.write(msg, LvlWarn, ctx)
 }
 
 // Error is a convenient alias for Root().Error
-func Error(msg string, ctx ...interface{}) {
+func Error(msg string, ctx ...any) {
 	root.write(msg, LvlError, ctx)
 }
 
 // Crit is a convenient alias for Root().Crit
-func Crit(msg string, ctx ...interface{}) {
+func Crit(msg string, ctx ...any) {
 	root.write(msg, LvlCrit, ctx)
 }
 
 // Log method to route configurable log level
-func Log(level Lvl, msg string, ctx ...interface{}) {
+func Log(level Lvl, msg string, ctx ...any) {
 	root.write(msg, level, ctx)
 }
 
 // SetRootHandler recreates root logger and set h as multihandler along with existed root handler
 func SetRootHandler(h Handler) {
 	oldHandler := root.GetHandler()
-	root = &logger{[]interface{}{}, new(swapHandler)}
+	root = &logger{[]any{}, new(swapHandler)}
 	root.SetHandler(MultiHandler(oldHandler, h))
 }

--- a/common/mclock/simclock.go
+++ b/common/mclock/simclock.go
@@ -196,13 +196,13 @@ func (h *simTimerHeap) Swap(i, j int) {
 	(*h)[j].index = j
 }
 
-func (h *simTimerHeap) Push(x interface{}) {
+func (h *simTimerHeap) Push(x any) {
 	t := x.(*simTimer)
 	t.index = len(*h)
 	*h = append(*h, t)
 }
 
-func (h *simTimerHeap) Pop() interface{} {
+func (h *simTimerHeap) Pop() any {
 	end := len(*h) - 1
 	t := (*h)[end]
 	t.index = -1

--- a/common/test_utils.go
+++ b/common/test_utils.go
@@ -27,7 +27,7 @@ import (
 )
 
 // LoadJSON reads the given file and unmarshals its content.
-func LoadJSON(file string, val interface{}) error {
+func LoadJSON(file string, val any) error {
 	content, err := os.ReadFile(file)
 	if err != nil {
 		return err

--- a/common/testlog/testlog.go
+++ b/common/testlog/testlog.go
@@ -87,7 +87,7 @@ func Logger(t *testing.T, level log.Lvl) log.Logger {
 	return l
 }
 
-func (l *logger) Trace(msg string, ctx ...interface{}) {
+func (l *logger) Trace(msg string, ctx ...any) {
 	l.t.Helper()
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -95,7 +95,7 @@ func (l *logger) Trace(msg string, ctx ...interface{}) {
 	l.flush()
 }
 
-func (l *logger) Debug(msg string, ctx ...interface{}) {
+func (l *logger) Debug(msg string, ctx ...any) {
 	l.t.Helper()
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -103,7 +103,7 @@ func (l *logger) Debug(msg string, ctx ...interface{}) {
 	l.flush()
 }
 
-func (l *logger) Info(msg string, ctx ...interface{}) {
+func (l *logger) Info(msg string, ctx ...any) {
 	l.t.Helper()
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -111,7 +111,7 @@ func (l *logger) Info(msg string, ctx ...interface{}) {
 	l.flush()
 }
 
-func (l *logger) Warn(msg string, ctx ...interface{}) {
+func (l *logger) Warn(msg string, ctx ...any) {
 	l.t.Helper()
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -119,7 +119,7 @@ func (l *logger) Warn(msg string, ctx ...interface{}) {
 	l.flush()
 }
 
-func (l *logger) Error(msg string, ctx ...interface{}) {
+func (l *logger) Error(msg string, ctx ...any) {
 	l.t.Helper()
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -127,7 +127,7 @@ func (l *logger) Error(msg string, ctx ...interface{}) {
 	l.flush()
 }
 
-func (l *logger) Crit(msg string, ctx ...interface{}) {
+func (l *logger) Crit(msg string, ctx ...any) {
 	l.t.Helper()
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -135,7 +135,7 @@ func (l *logger) Crit(msg string, ctx ...interface{}) {
 	l.flush()
 }
 
-func (l *logger) Log(level log.Lvl, msg string, ctx ...interface{}) {
+func (l *logger) Log(level log.Lvl, msg string, ctx ...any) {
 	l.t.Helper()
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -147,7 +147,7 @@ func (l *logger) Enabled(ctx context.Context, lvl log.Lvl) bool {
 	return l.log.Enabled(ctx, lvl)
 }
 
-func (l *logger) New(ctx ...interface{}) log.Logger {
+func (l *logger) New(ctx ...any) log.Logger {
 	return &logger{l.t, l.log.New(ctx...), l.mu, l.h}
 }
 

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -202,7 +202,7 @@ func TestMixedcaseAccount_Address(t *testing.T) {
 
 func TestHash_Scan(t *testing.T) {
 	type args struct {
-		src interface{}
+		src any
 	}
 	tests := []struct {
 		name    string
@@ -293,7 +293,7 @@ func TestHash_Value(t *testing.T) {
 
 func TestAddress_Scan(t *testing.T) {
 	type args struct {
-		src interface{}
+		src any
 	}
 	tests := []struct {
 		name    string


### PR DESCRIPTION
This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.

As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.