### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/rpc/batch_limit_ws_test.go
+++ b/rpc/batch_limit_ws_test.go
@@ -43,7 +43,7 @@ func TestBatchLimit_WebSocket_Exceeded(t *testing.T) {
 	for i := 0; i < batchSize; i++ {
 		batch = append(batch, BatchElem{
 			Method: "test_echo",
-			Args:   []interface{}{"hello"},
+			Args:   []any{"hello"},
 			Result: new(echoResult),
 		})
 	}

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -80,7 +80,7 @@ func TestClientErrorData(t *testing.T) {
 	client := DialInProc(server, logger)
 	defer client.Close()
 
-	var resp interface{}
+	var resp any
 	err := client.Call(&resp, "test_returnError")
 	if err == nil {
 		t.Fatal("expected error")
@@ -110,17 +110,17 @@ func TestClientBatchRequest(t *testing.T) {
 	batch := []BatchElem{
 		{
 			Method: "test_echo",
-			Args:   []interface{}{"hello", 10, &echoArgs{"world"}},
+			Args:   []any{"hello", 10, &echoArgs{"world"}},
 			Result: new(echoResult),
 		},
 		{
 			Method: "test_echo",
-			Args:   []interface{}{"hello2", 11, &echoArgs{"world"}},
+			Args:   []any{"hello2", 11, &echoArgs{"world"}},
 			Result: new(echoResult),
 		},
 		{
 			Method: "no_such_method",
-			Args:   []interface{}{1, 2, 3},
+			Args:   []any{1, 2, 3},
 			Result: new(int),
 		},
 	}
@@ -130,17 +130,17 @@ func TestClientBatchRequest(t *testing.T) {
 	wantResult := []BatchElem{
 		{
 			Method: "test_echo",
-			Args:   []interface{}{"hello", 10, &echoArgs{"world"}},
+			Args:   []any{"hello", 10, &echoArgs{"world"}},
 			Result: &echoResult{"hello", 10, &echoArgs{"world"}},
 		},
 		{
 			Method: "test_echo",
-			Args:   []interface{}{"hello2", 11, &echoArgs{"world"}},
+			Args:   []any{"hello2", 11, &echoArgs{"world"}},
 			Result: &echoResult{"hello2", 11, &echoArgs{"world"}},
 		},
 		{
 			Method: "no_such_method",
-			Args:   []interface{}{1, 2, 3},
+			Args:   []any{1, 2, 3},
 			Result: new(int),
 			Error:  &jsonError{Code: -32601, Message: "the method no_such_method does not exist/is not available"},
 		},
@@ -262,7 +262,7 @@ func TestClientSubscribeInvalidArg(t *testing.T) {
 	client := DialInProc(server, logger)
 	defer client.Close()
 
-	check := func(shouldPanic bool, arg interface{}) {
+	check := func(shouldPanic bool, arg any) {
 		defer func() {
 			err := recover()
 			if shouldPanic && err == nil {

--- a/rpc/ethapi/api.go
+++ b/rpc/ethapi/api.go
@@ -358,7 +358,7 @@ func (e *RevertError) ErrorCode() int {
 }
 
 // ErrorData returns the hex encoded revert reason.
-func (e *RevertError) ErrorData() interface{} {
+func (e *RevertError) ErrorData() any {
 	return e.reason
 }
 
@@ -424,8 +424,8 @@ func FormatLogs(logs []logger.StructLog) []StructLogRes {
 }
 
 // RPCMarshalHeader converts the given header to the RPC output .
-func RPCMarshalHeader(head *types.Header) map[string]interface{} {
-	result := map[string]interface{}{
+func RPCMarshalHeader(head *types.Header) map[string]any {
+	result := map[string]any{
 		"number":           (*hexutil.Big)(head.Number),
 		"hash":             head.Hash(),
 		"parentHash":       head.ParentHash,
@@ -475,28 +475,28 @@ func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 // RPCMarshalBlock converts the given block to the RPC output which depends on fullTx. If inclTx is true transactions are
 // returned. When fullTx is true the returned block contains full transaction details, otherwise it will only contain
 // transaction hashes.
-func RPCMarshalBlockDeprecated(block *types.Block, inclTx bool, fullTx bool) (map[string]interface{}, error) {
+func RPCMarshalBlockDeprecated(block *types.Block, inclTx bool, fullTx bool) (map[string]any, error) {
 	return RPCMarshalBlockExDeprecated(block, inclTx, fullTx, nil, common.Hash{})
 }
 
-func RPCMarshalBlockExDeprecated(block *types.Block, inclTx bool, fullTx bool, borTx types.Transaction, borTxHash common.Hash) (map[string]interface{}, error) {
+func RPCMarshalBlockExDeprecated(block *types.Block, inclTx bool, fullTx bool, borTx types.Transaction, borTxHash common.Hash) (map[string]any, error) {
 	fields := RPCMarshalHeader(block.Header())
 	fields["size"] = hexutil.Uint64(block.Size())
 	if _, ok := fields["transactions"]; !ok {
-		fields["transactions"] = make([]interface{}, 0)
+		fields["transactions"] = make([]any, 0)
 	}
 
 	if inclTx {
-		formatTx := func(tx types.Transaction, index int) (interface{}, error) {
+		formatTx := func(tx types.Transaction, index int) (any, error) {
 			return tx.Hash(), nil
 		}
 		if fullTx {
-			formatTx = func(tx types.Transaction, index int) (interface{}, error) {
+			formatTx = func(tx types.Transaction, index int) (any, error) {
 				return newRPCTransactionFromBlockAndTxGivenIndex(block, tx, uint64(index)), nil
 			}
 		}
 		txs := block.Transactions()
-		transactions := make([]interface{}, len(txs), len(txs)+1)
+		transactions := make([]any, len(txs), len(txs)+1)
 		var err error
 		for i, txn := range txs {
 			if transactions[i], err = formatTx(txn, i); err != nil {

--- a/rpc/ethapi/internal.go
+++ b/rpc/ethapi/internal.go
@@ -25,7 +25,7 @@ import (
 )
 
 // nolint
-func RPCMarshalBlock(b *types.Block, inclTx bool, fullTx bool, additional map[string]interface{}) (map[string]interface{}, error) {
+func RPCMarshalBlock(b *types.Block, inclTx bool, fullTx bool, additional map[string]any) (map[string]any, error) {
 	fields, err := RPCMarshalBlockDeprecated(b, inclTx, fullTx)
 	if err != nil {
 		return nil, err
@@ -37,7 +37,7 @@ func RPCMarshalBlock(b *types.Block, inclTx bool, fullTx bool, additional map[st
 }
 
 // nolint
-func RPCMarshalBlockEx(b *types.Block, inclTx bool, fullTx bool, borTx types.Transaction, borTxHash common.Hash, additional map[string]interface{}) (map[string]interface{}, error) {
+func RPCMarshalBlockEx(b *types.Block, inclTx bool, fullTx bool, borTx types.Transaction, borTxHash common.Hash, additional map[string]any) (map[string]any, error) {
 	fields, err := RPCMarshalBlockExDeprecated(b, inclTx, fullTx, borTx, borTxHash)
 	if err != nil {
 		return nil, err

--- a/rpc/filters/api.go
+++ b/rpc/filters/api.go
@@ -492,8 +492,8 @@ func (args *FilterCriteria) UnmarshalJSON(data []byte) error {
 		BlockHash *common.Hash     `json:"blockHash"`
 		FromBlock *rpc.BlockNumber `json:"fromBlock"`
 		ToBlock   *rpc.BlockNumber `json:"toBlock"`
-		Addresses interface{}      `json:"address"`
-		Topics    []interface{}    `json:"topics"`
+		Addresses any              `json:"address"`
+		Topics    []any            `json:"topics"`
 	}
 
 	var raw input
@@ -522,7 +522,7 @@ func (args *FilterCriteria) UnmarshalJSON(data []byte) error {
 	if raw.Addresses != nil {
 		// raw.Address can contain a single address or an array of addresses
 		switch rawAddr := raw.Addresses.(type) {
-		case []interface{}:
+		case []any:
 			for i, addr := range rawAddr {
 				if strAddr, ok := addr.(string); ok {
 					addr, err := decodeAddress(strAddr)
@@ -562,7 +562,7 @@ func (args *FilterCriteria) UnmarshalJSON(data []byte) error {
 				}
 				args.Topics[i] = []common.Hash{top}
 
-			case []interface{}:
+			case []any:
 				// or case e.g. [null, "topic0", "topic1"]
 				for _, rawTopic := range topic {
 					if rawTopic == nil {

--- a/rpc/gasprice/gasprice.go
+++ b/rpc/gasprice/gasprice.go
@@ -193,7 +193,7 @@ func (t transactionsByGasPrice) Less(i, j int) bool {
 }
 
 // Push (part of heap.Interface) places a new link onto the end of queue
-func (t *transactionsByGasPrice) Push(x interface{}) {
+func (t *transactionsByGasPrice) Push(x any) {
 	// Push and Pop use pointer receivers because they modify the slice's length,
 	// not just its contents.
 	l, ok := x.(types.Transaction)
@@ -204,7 +204,7 @@ func (t *transactionsByGasPrice) Push(x interface{}) {
 }
 
 // Pop (part of heap.Interface) removes the first link from the queue
-func (t *transactionsByGasPrice) Pop() interface{} {
+func (t *transactionsByGasPrice) Pop() any {
 	old := t.txs
 	n := len(old)
 	x := old[n-1]
@@ -275,7 +275,7 @@ func (s sortingHeap) Less(i, j int) bool { return s[i].Lt(s[j]) }
 func (s sortingHeap) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 
 // Push (part of heap.Interface) places a new link onto the end of queue
-func (s *sortingHeap) Push(x interface{}) {
+func (s *sortingHeap) Push(x any) {
 	// Push and Pop use pointer receivers because they modify the slice's length,
 	// not just its contents.
 	l := x.(*uint256.Int)
@@ -283,7 +283,7 @@ func (s *sortingHeap) Push(x interface{}) {
 }
 
 // Pop (part of heap.Interface) removes the first link from the queue
-func (s *sortingHeap) Pop() interface{} {
+func (s *sortingHeap) Pop() any {
 	old := *s
 	n := len(old)
 	x := old[n-1]

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -142,11 +142,11 @@ func (err *jsonError) ErrorData() any {
 	return err.Data
 }
 
-func NewJsonError(code int, message string, data interface{}) interface{} {
+func NewJsonError(code int, message string, data any) any {
 	return &jsonError{Code: code, Message: message, Data: data}
 }
 
-func NewJsonErrorFromErr(err error) interface{} {
+func NewJsonErrorFromErr(err error) any {
 	return newJsonError(err)
 }
 

--- a/rpc/jsonrpc/erigon_api.go
+++ b/rpc/jsonrpc/erigon_api.go
@@ -38,7 +38,7 @@ type ErigonAPI interface {
 	// Blocks related (see ./erigon_blocks.go)
 	GetHeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error)
 	GetHeaderByHash(_ context.Context, hash common.Hash) (*types.Header, error)
-	GetBlockByTimestamp(ctx context.Context, timeStamp rpc.Timestamp, fullTx bool) (map[string]interface{}, error)
+	GetBlockByTimestamp(ctx context.Context, timeStamp rpc.Timestamp, fullTx bool) (map[string]any, error)
 	GetBalanceChangesInBlock(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (map[common.Address]*hexutil.Big, error)
 
 	// Receipt related (see ./erigon_receipts.go)
@@ -47,7 +47,7 @@ type ErigonAPI interface {
 	GetLogs(ctx context.Context, crit filters.FilterCriteria) (types.ErigonLogs, error)
 	GetLatestLogs(ctx context.Context, crit filters.FilterCriteria, logOptions filters.LogFilterOptions) (types.ErigonLogs, error)
 	// Gets cannonical block receipt through hash. If the block is not cannonical returns error
-	GetBlockReceiptsByBlockHash(ctx context.Context, cannonicalBlockHash common.Hash) ([]map[string]interface{}, error)
+	GetBlockReceiptsByBlockHash(ctx context.Context, cannonicalBlockHash common.Hash) ([]map[string]any, error)
 
 	// NodeInfo returns a collection of metadata known about the host.
 	NodeInfo(ctx context.Context) ([]p2p.NodeInfo, error)

--- a/rpc/jsonrpc/erigon_block.go
+++ b/rpc/jsonrpc/erigon_block.go
@@ -85,7 +85,7 @@ func (api *ErigonImpl) GetHeaderByHash(ctx context.Context, hash common.Hash) (*
 	return header, nil
 }
 
-func (api *ErigonImpl) GetBlockByTimestamp(ctx context.Context, timeStamp rpc.Timestamp, fullTx bool) (map[string]interface{}, error) {
+func (api *ErigonImpl) GetBlockByTimestamp(ctx context.Context, timeStamp rpc.Timestamp, fullTx bool) (map[string]any, error) {
 	tx, err := api.db.BeginTemporalRo(ctx)
 	if err != nil {
 		return nil, err
@@ -174,7 +174,7 @@ func (api *ErigonImpl) GetBlockByTimestamp(ctx context.Context, timeStamp rpc.Ti
 	return response, nil
 }
 
-func buildBlockResponse(ctx context.Context, br services.FullBlockReader, db kv.Tx, blockNum uint64, fullTx bool) (map[string]interface{}, error) {
+func buildBlockResponse(ctx context.Context, br services.FullBlockReader, db kv.Tx, blockNum uint64, fullTx bool) (map[string]any, error) {
 	header, err := br.HeaderByNumber(ctx, db, blockNum)
 	if err != nil {
 		return nil, err
@@ -191,7 +191,7 @@ func buildBlockResponse(ctx context.Context, br services.FullBlockReader, db kv.
 		return nil, nil
 	}
 
-	additionalFields := make(map[string]interface{})
+	additionalFields := make(map[string]any)
 
 	response, err := ethapi.RPCMarshalBlockEx(block, true, fullTx, nil, common.Hash{}, additionalFields)
 

--- a/rpc/jsonrpc/erigon_receipts.go
+++ b/rpc/jsonrpc/erigon_receipts.go
@@ -348,7 +348,7 @@ func (api *ErigonImpl) GetLatestLogs(ctx context.Context, crit filters.FilterCri
 	return erigonLogs, nil
 }
 
-func (api *ErigonImpl) GetBlockReceiptsByBlockHash(ctx context.Context, cannonicalBlockHash common.Hash) ([]map[string]interface{}, error) {
+func (api *ErigonImpl) GetBlockReceiptsByBlockHash(ctx context.Context, cannonicalBlockHash common.Hash) ([]map[string]any, error) {
 	tx, err := api.db.BeginTemporalRo(ctx)
 	if err != nil {
 		return nil, err
@@ -392,7 +392,7 @@ func (api *ErigonImpl) GetBlockReceiptsByBlockHash(ctx context.Context, cannonic
 		return nil, fmt.Errorf("getReceipts error: %w", err)
 	}
 
-	result := make([]map[string]interface{}, 0, len(receipts))
+	result := make([]map[string]any, 0, len(receipts))
 	for _, receipt := range receipts {
 		txn := block.Transactions()[receipt.TransactionIndex]
 		result = append(result, ethutils.MarshalReceipt(receipt, txn, chainConfig, block.HeaderNoCopy(), txn.Hash(), true, false))

--- a/rpc/jsonrpc/eth_api.go
+++ b/rpc/jsonrpc/eth_api.go
@@ -55,8 +55,8 @@ import (
 // EthAPI is a collection of functions that are exposed in the
 type EthAPI interface {
 	// Block related (proposed file: ./eth_blocks.go)
-	GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (map[string]interface{}, error)
-	GetBlockByHash(ctx context.Context, hash rpc.BlockNumberOrHash, fullTx bool) (map[string]interface{}, error)
+	GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (map[string]any, error)
+	GetBlockByHash(ctx context.Context, hash rpc.BlockNumberOrHash, fullTx bool) (map[string]any, error)
 	GetBlockTransactionCountByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*hexutil.Uint, error)
 	GetBlockTransactionCountByHash(ctx context.Context, blockHash common.Hash) (*hexutil.Uint, error)
 
@@ -69,13 +69,13 @@ type EthAPI interface {
 	GetRawTransactionByHash(ctx context.Context, hash common.Hash) (hexutil.Bytes, error)
 
 	// Receipt related (see ./eth_receipts.go)
-	GetTransactionReceipt(ctx context.Context, hash common.Hash) (map[string]interface{}, error)
+	GetTransactionReceipt(ctx context.Context, hash common.Hash) (map[string]any, error)
 	GetLogs(ctx context.Context, crit filters.FilterCriteria) (types.RPCLogs, error)
-	GetBlockReceipts(ctx context.Context, numberOrHash rpc.BlockNumberOrHash) ([]map[string]interface{}, error)
+	GetBlockReceipts(ctx context.Context, numberOrHash rpc.BlockNumberOrHash) ([]map[string]any, error)
 
 	// Uncle related (see ./eth_uncles.go)
-	GetUncleByBlockNumberAndIndex(ctx context.Context, blockNr rpc.BlockNumber, index hexutil.Uint) (map[string]interface{}, error)
-	GetUncleByBlockHashAndIndex(ctx context.Context, hash common.Hash, index hexutil.Uint) (map[string]interface{}, error)
+	GetUncleByBlockNumberAndIndex(ctx context.Context, blockNr rpc.BlockNumber, index hexutil.Uint) (map[string]any, error)
+	GetUncleByBlockHashAndIndex(ctx context.Context, hash common.Hash, index hexutil.Uint) (map[string]any, error)
 	GetUncleCountByBlockNumber(ctx context.Context, number rpc.BlockNumber) (*hexutil.Uint, error)
 	GetUncleCountByBlockHash(ctx context.Context, hash common.Hash) (*hexutil.Uint, error)
 
@@ -97,7 +97,7 @@ type EthAPI interface {
 
 	// System related (see ./eth_system.go)
 	BlockNumber(ctx context.Context) (hexutil.Uint64, error)
-	Syncing(ctx context.Context) (interface{}, error)
+	Syncing(ctx context.Context) (any, error)
 	ChainId(ctx context.Context) (hexutil.Uint64, error) /* called eth_protocolVersion elsewhere */
 	ProtocolVersion(_ context.Context) (hexutil.Uint, error)
 	GasPrice(_ context.Context) (*hexutil.Big, error)
@@ -107,9 +107,9 @@ type EthAPI interface {
 	Call(ctx context.Context, args ethapi.CallArgs, blockNrOrHash *rpc.BlockNumberOrHash, overrides *ethapi.StateOverrides, blockOverrides *ethapi.BlockOverrides) (hexutil.Bytes, error)
 	EstimateGas(ctx context.Context, argsOrNil *ethapi.CallArgs, blockNrOrHash *rpc.BlockNumberOrHash, overrides *ethapi.StateOverrides, blockOverrides *ethapi.BlockOverrides) (hexutil.Uint64, error)
 	SendRawTransaction(ctx context.Context, encodedTx hexutil.Bytes) (common.Hash, error)
-	SendTransaction(_ context.Context, txObject interface{}) (common.Hash, error)
+	SendTransaction(_ context.Context, txObject any) (common.Hash, error)
 	Sign(ctx context.Context, _ common.Address, _ hexutil.Bytes) (hexutil.Bytes, error)
-	SignTransaction(_ context.Context, txObject interface{}) (common.Hash, error)
+	SignTransaction(_ context.Context, txObject any) (common.Hash, error)
 	GetProof(ctx context.Context, address common.Address, storageKeys []hexutil.Bytes, blockNr rpc.BlockNumberOrHash) (*accounts.AccProofResult, error)
 	CreateAccessList(ctx context.Context, args ethapi.CallArgs, blockNrOrHash *rpc.BlockNumberOrHash, overrides *ethapi2.StateOverrides, optimizeGas *bool) (*accessListResult, error)
 

--- a/rpc/jsonrpc/eth_block.go
+++ b/rpc/jsonrpc/eth_block.go
@@ -39,7 +39,7 @@ import (
 	"github.com/erigontech/erigon/rpc/transactions"
 )
 
-func (api *APIImpl) CallBundle(ctx context.Context, txHashes []common.Hash, stateBlockNumberOrHash rpc.BlockNumberOrHash, timeoutMilliSecondsPtr *int64) (map[string]interface{}, error) {
+func (api *APIImpl) CallBundle(ctx context.Context, txHashes []common.Hash, stateBlockNumberOrHash rpc.BlockNumberOrHash, timeoutMilliSecondsPtr *int64) (map[string]any, error) {
 	tx, err := api.db.BeginTemporalRo(ctx)
 	if err != nil {
 		return nil, err
@@ -168,7 +168,7 @@ func (api *APIImpl) CallBundle(ctx context.Context, txHashes []common.Hash, stat
 	bundleHash := crypto.NewKeccakState()
 	defer crypto.ReturnToPool(bundleHash)
 
-	results := make([]map[string]interface{}, 0, len(txs))
+	results := make([]map[string]any, 0, len(txs))
 	for _, txn := range txs {
 		msg, err := txn.AsMessage(*signer, nil, rules)
 		msg.SetCheckNonce(false)
@@ -187,7 +187,7 @@ func (api *APIImpl) CallBundle(ctx context.Context, txHashes []common.Hash, stat
 		}
 
 		txHash := txn.Hash().String()
-		jsonResult := map[string]interface{}{
+		jsonResult := map[string]any{
 			"txHash":  txHash,
 			"gasUsed": result.GasUsed,
 		}
@@ -201,14 +201,14 @@ func (api *APIImpl) CallBundle(ctx context.Context, txHashes []common.Hash, stat
 		results = append(results, jsonResult)
 	}
 
-	ret := map[string]interface{}{}
+	ret := map[string]any{}
 	ret["results"] = results
 	ret["bundleHash"] = hexutil.Encode(bundleHash.Sum(nil))
 	return ret, nil
 }
 
 // GetBlockByNumber implements eth_getBlockByNumber. Returns information about a block given the block's number.
-func (api *APIImpl) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (map[string]interface{}, error) {
+func (api *APIImpl) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (map[string]any, error) {
 	tx, err := api.db.BeginTemporalRo(ctx)
 	if err != nil {
 		return nil, err
@@ -221,7 +221,7 @@ func (api *APIImpl) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber
 	if b == nil {
 		return nil, nil
 	}
-	additionalFields := make(map[string]interface{})
+	additionalFields := make(map[string]any)
 
 	chainConfig, err := api.chainConfig(ctx, tx)
 	if err != nil {
@@ -253,7 +253,7 @@ func (api *APIImpl) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber
 }
 
 // GetBlockByHash implements eth_getBlockByHash. Returns information about a block given the block's hash.
-func (api *APIImpl) GetBlockByHash(ctx context.Context, numberOrHash rpc.BlockNumberOrHash, fullTx bool) (map[string]interface{}, error) {
+func (api *APIImpl) GetBlockByHash(ctx context.Context, numberOrHash rpc.BlockNumberOrHash, fullTx bool) (map[string]any, error) {
 	if numberOrHash.BlockHash == nil {
 		// some web3.js based apps (like ethstats client) for some reason call
 		// eth_getBlockByHash with a block number as a parameter
@@ -271,7 +271,7 @@ func (api *APIImpl) GetBlockByHash(ctx context.Context, numberOrHash rpc.BlockNu
 	}
 	defer tx.Rollback()
 
-	additionalFields := make(map[string]interface{})
+	additionalFields := make(map[string]any)
 
 	block, err := api.blockByHashWithSenders(ctx, tx, hash)
 	if err != nil {

--- a/rpc/jsonrpc/eth_callMany.go
+++ b/rpc/jsonrpc/eth_callMany.go
@@ -51,7 +51,7 @@ type StateContext struct {
 	TransactionIndex *int
 }
 
-func (api *APIImpl) CallMany(ctx context.Context, bundles []Bundle, simulateContext StateContext, stateOverride *ethapi.StateOverrides, timeoutMilliSecondsPtr *int64) ([][]map[string]interface{}, error) {
+func (api *APIImpl) CallMany(ctx context.Context, bundles []Bundle, simulateContext StateContext, stateOverride *ethapi.StateOverrides, timeoutMilliSecondsPtr *int64) ([][]map[string]any, error) {
 	var (
 		hash               common.Hash
 		replayTransactions types.Transactions
@@ -203,7 +203,7 @@ func (api *APIImpl) CallMany(ctx context.Context, bundles []Bundle, simulateCont
 		}
 	}
 
-	ret := make([][]map[string]interface{}, 0)
+	ret := make([][]map[string]any, 0)
 
 	for _, bundle := range bundles {
 		// first change blockContext
@@ -228,7 +228,7 @@ func (api *APIImpl) CallMany(ctx context.Context, bundles []Bundle, simulateCont
 		if bundle.BlockOverride.BlockHash != nil {
 			maps.Copy(overrideBlockHash, *bundle.BlockOverride.BlockHash)
 		}
-		results := []map[string]interface{}{}
+		results := []map[string]any{}
 		for _, txn := range bundle.Transactions {
 			if txn.Gas == nil || *(txn.Gas) == 0 {
 				txn.Gas = (*hexutil.Uint64)(&api.GasCap)
@@ -250,11 +250,11 @@ func (api *APIImpl) CallMany(ctx context.Context, bundles []Bundle, simulateCont
 			if evm.Cancelled() {
 				return nil, fmt.Errorf("execution aborted (timeout = %v)", timeout)
 			}
-			jsonResult := make(map[string]interface{})
+			jsonResult := make(map[string]any)
 			if result.Err != nil {
 				if len(result.Revert()) > 0 {
 					revertErr := ethapi.NewRevertError(result)
-					jsonResult["error"] = map[string]interface{}{
+					jsonResult["error"] = map[string]any{
 						"message": revertErr.Error(),
 						"data":    revertErr.ErrorData(),
 					}

--- a/rpc/jsonrpc/eth_deprecated.go
+++ b/rpc/jsonrpc/eth_deprecated.go
@@ -37,6 +37,6 @@ func (api *APIImpl) Sign(ctx context.Context, _ common.Address, _ hexutil.Bytes)
 }
 
 // SignTransaction deprecated
-func (api *APIImpl) SignTransaction(_ context.Context, txObject interface{}) (common.Hash, error) {
+func (api *APIImpl) SignTransaction(_ context.Context, txObject any) (common.Hash, error) {
 	return common.Hash{0}, fmt.Errorf(NotAvailableDeprecated, "eth_signTransaction")
 }

--- a/rpc/jsonrpc/eth_filters.go
+++ b/rpc/jsonrpc/eth_filters.go
@@ -337,7 +337,7 @@ func (api *APIImpl) TransactionReceipts(ctx context.Context, crit filters.Receip
 			case protoReceipt, ok := <-receipts:
 				if protoReceipt != nil {
 					receipt := ethutils.MarshalSubscribeReceipt(protoReceipt)
-					err := notifier.Notify(rpcSub.ID, []map[string]interface{}{receipt})
+					err := notifier.Notify(rpcSub.ID, []map[string]any{receipt})
 					if err != nil {
 						log.Warn("[rpc] error while notifying subscription", "err", err)
 					}

--- a/rpc/jsonrpc/eth_receipts.go
+++ b/rpc/jsonrpc/eth_receipts.go
@@ -441,7 +441,7 @@ func getAddrsBitmapV3(tx kv.TemporalTx, addrs []common.Address, from, to uint64,
 }
 
 // GetTransactionReceipt implements eth_getTransactionReceipt. Returns the receipt of a transaction given the transaction's hash.
-func (api *APIImpl) GetTransactionReceipt(ctx context.Context, txnHash common.Hash) (map[string]interface{}, error) {
+func (api *APIImpl) GetTransactionReceipt(ctx context.Context, txnHash common.Hash) (map[string]any, error) {
 	tx, err := api.db.BeginTemporalRo(ctx)
 	if err != nil {
 		return nil, err
@@ -552,7 +552,7 @@ func (api *APIImpl) GetTransactionReceipt(ctx context.Context, txnHash common.Ha
 }
 
 // GetBlockReceipts - receipts for individual block
-func (api *APIImpl) GetBlockReceipts(ctx context.Context, numberOrHash rpc.BlockNumberOrHash) ([]map[string]interface{}, error) {
+func (api *APIImpl) GetBlockReceipts(ctx context.Context, numberOrHash rpc.BlockNumberOrHash) ([]map[string]any, error) {
 	tx, err := api.db.BeginTemporalRo(ctx)
 	if err != nil {
 		return nil, err
@@ -581,7 +581,7 @@ func (api *APIImpl) GetBlockReceipts(ctx context.Context, numberOrHash rpc.Block
 	if err != nil {
 		return nil, fmt.Errorf("getReceipts error: %w", err)
 	}
-	result := make([]map[string]interface{}, 0, len(receipts))
+	result := make([]map[string]any, 0, len(receipts))
 	for _, receipt := range receipts {
 		txn := block.Transactions()[receipt.TransactionIndex]
 		result = append(result, ethutils.MarshalReceipt(receipt, txn, chainConfig, block.HeaderNoCopy(), txn.Hash(), true, true))

--- a/rpc/jsonrpc/eth_simulation.go
+++ b/rpc/jsonrpc/eth_simulation.go
@@ -79,11 +79,11 @@ type CallResult struct {
 	Logs       []*types.RPCLog `json:"logs"`
 	GasUsed    hexutil.Uint64  `json:"gasUsed"`
 	Status     hexutil.Uint64  `json:"status"`
-	Error      interface{}     `json:"error,omitempty"`
+	Error      any             `json:"error,omitempty"`
 }
 
 // SimulatedBlockResult represents the result of the simulated calls for a single block (i.e. one SimulatedBlock).
-type SimulatedBlockResult map[string]interface{}
+type SimulatedBlockResult map[string]any
 
 // SimulationResult represents the result contained in an eth_simulateV1 response.
 type SimulationResult []SimulatedBlockResult
@@ -543,7 +543,7 @@ func (s *simulator) simulateBlock(
 	}
 
 	// Marshal the block in RPC format including the call results in a custom field.
-	additionalFields := make(map[string]interface{})
+	additionalFields := make(map[string]any)
 	blockResult, err := ethapi.RPCMarshalBlock(block, true, s.fullTransactions, additionalFields)
 	if err != nil {
 		return nil, nil, err

--- a/rpc/jsonrpc/eth_system.go
+++ b/rpc/jsonrpc/eth_system.go
@@ -54,7 +54,7 @@ func (api *APIImpl) BlockNumber(ctx context.Context) (hexutil.Uint64, error) {
 }
 
 // Syncing implements eth_syncing. Returns a data object detailing the status of the sync process or false if not syncing.
-func (api *APIImpl) Syncing(ctx context.Context) (interface{}, error) {
+func (api *APIImpl) Syncing(ctx context.Context) (any, error) {
 	reply, err := api.ethBackend.Syncing(ctx)
 	if err != nil {
 		return false, err
@@ -76,7 +76,7 @@ func (api *APIImpl) Syncing(ctx context.Context) (interface{}, error) {
 		stagesMap[i].BlockNumber = hexutil.Uint64(stage.BlockNumber)
 	}
 
-	return map[string]interface{}{
+	return map[string]any{
 		"startingBlock": "0x0", // 0x0 is a placeholder, I do not think it matters what we return here
 		"currentBlock":  hexutil.Uint64(currentBlock),
 		"highestBlock":  hexutil.Uint64(highestBlock),

--- a/rpc/jsonrpc/eth_uncles.go
+++ b/rpc/jsonrpc/eth_uncles.go
@@ -29,7 +29,7 @@ import (
 )
 
 // GetUncleByBlockNumberAndIndex implements eth_getUncleByBlockNumberAndIndex. Returns information about an uncle given a block's number and the index of the uncle.
-func (api *APIImpl) GetUncleByBlockNumberAndIndex(ctx context.Context, number rpc.BlockNumber, index hexutil.Uint) (map[string]interface{}, error) {
+func (api *APIImpl) GetUncleByBlockNumberAndIndex(ctx context.Context, number rpc.BlockNumber, index hexutil.Uint) (map[string]any, error) {
 	tx, err := api.db.BeginTemporalRo(ctx)
 	if err != nil {
 		return nil, err
@@ -47,7 +47,7 @@ func (api *APIImpl) GetUncleByBlockNumberAndIndex(ctx context.Context, number rp
 	if block == nil {
 		return nil, nil // not error, see https://github.com/erigontech/erigon/issues/1645
 	}
-	additionalFields := make(map[string]interface{})
+	additionalFields := make(map[string]any)
 
 	uncles := block.Uncles()
 	if index >= hexutil.Uint(len(uncles)) {
@@ -59,7 +59,7 @@ func (api *APIImpl) GetUncleByBlockNumberAndIndex(ctx context.Context, number rp
 }
 
 // GetUncleByBlockHashAndIndex implements eth_getUncleByBlockHashAndIndex. Returns information about an uncle given a block's hash and the index of the uncle.
-func (api *APIImpl) GetUncleByBlockHashAndIndex(ctx context.Context, hash common.Hash, index hexutil.Uint) (map[string]interface{}, error) {
+func (api *APIImpl) GetUncleByBlockHashAndIndex(ctx context.Context, hash common.Hash, index hexutil.Uint) (map[string]any, error) {
 	tx, err := api.db.BeginTemporalRo(ctx)
 	if err != nil {
 		return nil, err
@@ -73,7 +73,7 @@ func (api *APIImpl) GetUncleByBlockHashAndIndex(ctx context.Context, hash common
 	if block == nil {
 		return nil, nil // not error, see https://github.com/erigontech/erigon/issues/1645
 	}
-	additionalFields := make(map[string]interface{})
+	additionalFields := make(map[string]any)
 
 	uncles := block.Uncles()
 	if index >= hexutil.Uint(len(uncles)) {

--- a/rpc/jsonrpc/gen_traces_test.go
+++ b/rpc/jsonrpc/gen_traces_test.go
@@ -58,7 +58,7 @@ func TestGeneratedDebugApi(t *testing.T) {
 	if err = stream.Flush(); err != nil {
 		t.Fatalf("error flushing: %v", err)
 	}
-	var result interface{}
+	var result any
 	if err = json.Unmarshal(buf.Bytes(), &result); err != nil {
 		t.Fatalf("parsing result: %v", err)
 	}
@@ -121,7 +121,7 @@ func TestGeneratedDebugApi(t *testing.T) {
 		  }
 		}
 	]`
-	var expected interface{}
+	var expected any
 	if err = json.Unmarshal([]byte(expectedJSON), &expected); err != nil {
 		t.Fatalf("parsing expected: %v", err)
 	}
@@ -143,7 +143,7 @@ func TestGeneratedTraceApi(t *testing.T) {
 	if err != nil {
 		t.Errorf("marshall result into JSON: %v", err)
 	}
-	var result interface{}
+	var result any
 	if err = json.Unmarshal(buf, &result); err != nil {
 		t.Fatalf("parsing result: %v", err)
 	}
@@ -278,7 +278,7 @@ func TestGeneratedTraceApi(t *testing.T) {
 		  "type": "reward"
 		}
 	  ]`
-	var expected interface{}
+	var expected any
 	if err = json.Unmarshal([]byte(expectedJSON), &expected); err != nil {
 		t.Fatalf("parsing expected: %v", err)
 	}
@@ -298,7 +298,7 @@ func TestGeneratedTraceApiCollision(t *testing.T) {
 	if err != nil {
 		t.Errorf("marshall result into JSON: %v", err)
 	}
-	var result interface{}
+	var result any
 	if err = json.Unmarshal(buf, &result); err != nil {
 		t.Fatalf("parsing result: %v", err)
 	}
@@ -347,7 +347,7 @@ func TestGeneratedTraceApiCollision(t *testing.T) {
     }
 ]
 `
-	var expected interface{}
+	var expected any
 	if err = json.Unmarshal([]byte(expectedJSON), &expected); err != nil {
 		t.Fatalf("parsing expected: %v", err)
 	}

--- a/rpc/jsonrpc/graphql_api.go
+++ b/rpc/jsonrpc/graphql_api.go
@@ -32,7 +32,7 @@ import (
 )
 
 type GraphQLAPI interface {
-	GetBlockDetails(ctx context.Context, number rpc.BlockNumber) (map[string]interface{}, error)
+	GetBlockDetails(ctx context.Context, number rpc.BlockNumber) (map[string]any, error)
 	GetChainID(ctx context.Context) (*big.Int, error)
 }
 
@@ -63,7 +63,7 @@ func (api *GraphQLAPIImpl) GetChainID(ctx context.Context) (*big.Int, error) {
 	return response.ChainID, nil
 }
 
-func (api *GraphQLAPIImpl) GetBlockDetails(ctx context.Context, blockNumber rpc.BlockNumber) (map[string]interface{}, error) {
+func (api *GraphQLAPIImpl) GetBlockDetails(ctx context.Context, blockNumber rpc.BlockNumber) (map[string]any, error) {
 	tx, err := api.db.BeginTemporalRo(ctx)
 	if err != nil {
 		return nil, err
@@ -93,7 +93,7 @@ func (api *GraphQLAPIImpl) GetBlockDetails(ctx context.Context, blockNumber rpc.
 		return nil, fmt.Errorf("getReceipts error: %w", err)
 	}
 
-	result := make([]map[string]interface{}, 0, len(receipts))
+	result := make([]map[string]any, 0, len(receipts))
 	for _, receipt := range receipts {
 		txn := block.Transactions()[receipt.TransactionIndex]
 
@@ -105,14 +105,14 @@ func (api *GraphQLAPIImpl) GetBlockDetails(ctx context.Context, blockNumber rpc.
 		result = append(result, transaction)
 	}
 
-	response := map[string]interface{}{}
+	response := map[string]any{}
 	response["block"] = getBlockRes
 	response["receipts"] = result
 
 	// Withdrawals
-	wresult := make([]map[string]interface{}, 0, len(block.Withdrawals()))
+	wresult := make([]map[string]any, 0, len(block.Withdrawals()))
 	for _, withdrawal := range block.Withdrawals() {
-		wmap := make(map[string]interface{})
+		wmap := make(map[string]any)
 		wmap["index"] = hexutil.Uint64(withdrawal.Index)
 		wmap["validator"] = hexutil.Uint64(withdrawal.Validator)
 		wmap["address"] = withdrawal.Address
@@ -146,8 +146,8 @@ func (api *GraphQLAPIImpl) getBlockWithSenders(ctx context.Context, number rpc.B
 	return block, block.Body().SendersFromTxs(), nil
 }
 
-func (api *GraphQLAPIImpl) delegateGetBlockByNumber(tx kv.Tx, b *types.Block, number rpc.BlockNumber, inclTx bool) (map[string]interface{}, error) {
-	additionalFields := make(map[string]interface{})
+func (api *GraphQLAPIImpl) delegateGetBlockByNumber(tx kv.Tx, b *types.Block, number rpc.BlockNumber, inclTx bool) (map[string]any, error) {
+	additionalFields := make(map[string]any)
 	response, err := ethapi.RPCMarshalBlock(b, inclTx, inclTx, additionalFields)
 	if !inclTx {
 		delete(response, "transactions") // workaround for https://github.com/erigontech/erigon/issues/4989#issuecomment-1218415666

--- a/rpc/jsonrpc/otterscan_block_details.go
+++ b/rpc/jsonrpc/otterscan_block_details.go
@@ -27,7 +27,7 @@ import (
 	"github.com/erigontech/erigon/rpc"
 )
 
-func (api *OtterscanAPIImpl) GetBlockDetails(ctx context.Context, number rpc.BlockNumber) (map[string]interface{}, error) {
+func (api *OtterscanAPIImpl) GetBlockDetails(ctx context.Context, number rpc.BlockNumber) (map[string]any, error) {
 	tx, err := api.db.BeginTemporalRo(ctx)
 	if err != nil {
 		return nil, err
@@ -45,7 +45,7 @@ func (api *OtterscanAPIImpl) GetBlockDetails(ctx context.Context, number rpc.Blo
 	return api.getBlockDetailsImpl(ctx, tx, b, number, senders)
 }
 
-func (api *OtterscanAPIImpl) GetBlockDetailsByHash(ctx context.Context, hash common.Hash) (map[string]interface{}, error) {
+func (api *OtterscanAPIImpl) GetBlockDetailsByHash(ctx context.Context, hash common.Hash) (map[string]any, error) {
 	tx, err := api.db.BeginTemporalRo(ctx)
 	if err != nil {
 		return nil, err
@@ -72,7 +72,7 @@ func (api *OtterscanAPIImpl) GetBlockDetailsByHash(ctx context.Context, hash com
 	return api.getBlockDetailsImpl(ctx, tx, b, number, b.Body().SendersFromTxs())
 }
 
-func (api *OtterscanAPIImpl) getBlockDetailsImpl(ctx context.Context, tx kv.TemporalTx, b *types.Block, number rpc.BlockNumber, senders []common.Address) (map[string]interface{}, error) {
+func (api *OtterscanAPIImpl) getBlockDetailsImpl(ctx context.Context, tx kv.TemporalTx, b *types.Block, number rpc.BlockNumber, senders []common.Address) (map[string]any, error) {
 	chainConfig, err := api.chainConfig(ctx, tx)
 	if err != nil {
 		return nil, err
@@ -95,7 +95,7 @@ func (api *OtterscanAPIImpl) getBlockDetailsImpl(ctx context.Context, tx kv.Temp
 		return nil, err
 	}
 
-	response := map[string]interface{}{}
+	response := map[string]any{}
 	response["block"] = getBlockRes
 	response["issuance"] = getIssuanceRes
 	response["totalFees"] = (*hexutil.Big)(feesRes)

--- a/rpc/jsonrpc/otterscan_search_trace.go
+++ b/rpc/jsonrpc/otterscan_search_trace.go
@@ -55,7 +55,7 @@ func (api *OtterscanAPIImpl) searchTraceBlock(ctx context.Context, addr common.A
 
 func (api *OtterscanAPIImpl) traceBlock(dbtx kv.TemporalTx, ctx context.Context, blockNum uint64, searchAddr common.Address, chainConfig *chain.Config) (bool, *TransactionsWithReceipts, error) {
 	rpcTxs := make([]*ethapi.RPCTransaction, 0)
-	receipts := make([]map[string]interface{}, 0)
+	receipts := make([]map[string]any, 0)
 
 	// Retrieve the transaction and assemble its EVM context
 	blockHash, ok, err := api._blockReader.CanonicalHash(ctx, dbtx, blockNum)

--- a/rpc/jsonrpc/otterscan_search_v3.go
+++ b/rpc/jsonrpc/otterscan_search_v3.go
@@ -33,7 +33,7 @@ import (
 
 type txNumsIterFactory func(tx kv.TemporalTx, txNumsReader rawdbv3.TxNumsReader, addr common.Address, fromTxNum int) (*rawdbv3.MapTxNum2BlockNumIter, error)
 
-func (api *OtterscanAPIImpl) buildSearchResults(ctx context.Context, tx kv.TemporalTx, txNumsReader rawdbv3.TxNumsReader, iterFactory txNumsIterFactory, addr common.Address, fromTxNum int, pageSize uint16) ([]*ethapi.RPCTransaction, []map[string]interface{}, bool, error) {
+func (api *OtterscanAPIImpl) buildSearchResults(ctx context.Context, tx kv.TemporalTx, txNumsReader rawdbv3.TxNumsReader, iterFactory txNumsIterFactory, addr common.Address, fromTxNum int, pageSize uint16) ([]*ethapi.RPCTransaction, []map[string]any, bool, error) {
 	chainConfig, err := api.chainConfig(ctx, tx)
 	if err != nil {
 		return nil, nil, false, err
@@ -46,7 +46,7 @@ func (api *OtterscanAPIImpl) buildSearchResults(ctx context.Context, tx kv.Tempo
 
 	var block *types.Block
 	txs := make([]*ethapi.RPCTransaction, 0, pageSize)
-	receipts := make([]map[string]interface{}, 0, pageSize)
+	receipts := make([]map[string]any, 0, pageSize)
 	resultCount := uint16(0)
 
 	mustReadBlock := true

--- a/rpc/jsonrpc/send_transaction.go
+++ b/rpc/jsonrpc/send_transaction.go
@@ -65,7 +65,7 @@ func (api *APIImpl) SendRawTransaction(ctx context.Context, encodedTx hexutil.By
 }
 
 // SendTransaction implements eth_sendTransaction. Creates new message call transaction or a contract creation if the data field contains code.
-func (api *APIImpl) SendTransaction(_ context.Context, txObject interface{}) (common.Hash, error) {
+func (api *APIImpl) SendTransaction(_ context.Context, txObject any) (common.Hash, error) {
 	return common.Hash{0}, fmt.Errorf(NotImplemented, "eth_sendTransaction")
 }
 

--- a/rpc/jsonrpc/trace_adhoc.go
+++ b/rpc/jsonrpc/trace_adhoc.go
@@ -90,10 +90,10 @@ type TraceCallResult struct {
 
 // StateDiffAccount is the part of `trace_call` response that is under "stateDiff" tag
 type StateDiffAccount struct {
-	Balance interface{}                            `json:"balance"` // Can be either string "=" or mapping "*" => {"from": "hex", "to": "hex"}
-	Code    interface{}                            `json:"code"`
-	Nonce   interface{}                            `json:"nonce"`
-	Storage map[common.Hash]map[string]interface{} `json:"storage"`
+	Balance any                            `json:"balance"` // Can be either string "=" or mapping "*" => {"from": "hex", "to": "hex"}
+	Code    any                            `json:"code"`
+	Nonce   any                            `json:"nonce"`
+	Storage map[common.Hash]map[string]any `json:"storage"`
 }
 
 type StateDiffBalance struct {
@@ -695,21 +695,21 @@ type StateDiff struct {
 
 func (sd *StateDiff) UpdateAccountData(address accounts.Address, original, account *accounts.Account) error {
 	if _, ok := sd.sdMap[address]; !ok {
-		sd.sdMap[address] = &StateDiffAccount{Storage: make(map[common.Hash]map[string]interface{})}
+		sd.sdMap[address] = &StateDiffAccount{Storage: make(map[common.Hash]map[string]any)}
 	}
 	return nil
 }
 
 func (sd *StateDiff) UpdateAccountCode(address accounts.Address, incarnation uint64, codeHash accounts.CodeHash, code []byte) error {
 	if _, ok := sd.sdMap[address]; !ok {
-		sd.sdMap[address] = &StateDiffAccount{Storage: make(map[common.Hash]map[string]interface{})}
+		sd.sdMap[address] = &StateDiffAccount{Storage: make(map[common.Hash]map[string]any)}
 	}
 	return nil
 }
 
 func (sd *StateDiff) DeleteAccount(address accounts.Address, original *accounts.Account) error {
 	if _, ok := sd.sdMap[address]; !ok {
-		sd.sdMap[address] = &StateDiffAccount{Storage: make(map[common.Hash]map[string]interface{})}
+		sd.sdMap[address] = &StateDiffAccount{Storage: make(map[common.Hash]map[string]any)}
 	}
 	return nil
 }
@@ -720,10 +720,10 @@ func (sd *StateDiff) WriteAccountStorage(address accounts.Address, incarnation u
 	}
 	accountDiff := sd.sdMap[address]
 	if accountDiff == nil {
-		accountDiff = &StateDiffAccount{Storage: make(map[common.Hash]map[string]interface{})}
+		accountDiff = &StateDiffAccount{Storage: make(map[common.Hash]map[string]any)}
 		sd.sdMap[address] = accountDiff
 	}
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 	m["*"] = &StateDiffStorage{From: common.BytesToHash(original.Bytes()), To: common.BytesToHash(value.Bytes())}
 	accountDiff.Storage[key.Value()] = m
 	return nil
@@ -731,7 +731,7 @@ func (sd *StateDiff) WriteAccountStorage(address accounts.Address, incarnation u
 
 func (sd *StateDiff) CreateContract(address accounts.Address) error {
 	if _, ok := sd.sdMap[address]; !ok {
-		sd.sdMap[address] = &StateDiffAccount{Storage: make(map[common.Hash]map[string]interface{})}
+		sd.sdMap[address] = &StateDiffAccount{Storage: make(map[common.Hash]map[string]any)}
 	}
 	return nil
 }
@@ -1713,7 +1713,7 @@ func (api *TraceAPIImpl) doCall(ctx context.Context, dbtx kv.Tx, stateReader sta
 }
 
 // RawTransaction implements trace_rawTransaction.
-func (api *TraceAPIImpl) RawTransaction(ctx context.Context, txHash common.Hash, traceTypes []string) ([]interface{}, error) {
-	var stub []interface{}
+func (api *TraceAPIImpl) RawTransaction(ctx context.Context, txHash common.Hash, traceTypes []string) ([]any, error) {
+	var stub []any
 	return stub, fmt.Errorf(NotImplemented, "trace_rawTransaction")
 }

--- a/rpc/jsonrpc/trace_api.go
+++ b/rpc/jsonrpc/trace_api.go
@@ -37,7 +37,7 @@ type TraceAPI interface {
 	ReplayTransaction(ctx context.Context, txHash common.Hash, traceTypes []string, gasBailOut *bool, traceConfig *config.TraceConfig) (*TraceCallResult, error)
 	Call(ctx context.Context, call TraceCallParam, types []string, blockNr *rpc.BlockNumberOrHash, traceConfig *config.TraceConfig) (*TraceCallResult, error)
 	CallMany(ctx context.Context, calls json.RawMessage, blockNr *rpc.BlockNumberOrHash, traceConfig *config.TraceConfig) ([]*TraceCallResult, error)
-	RawTransaction(ctx context.Context, txHash common.Hash, traceTypes []string) ([]interface{}, error)
+	RawTransaction(ctx context.Context, txHash common.Hash, traceTypes []string) ([]any, error)
 
 	// Filtering (see ./trace_filtering.go)
 

--- a/rpc/jsonrpc/trace_types.go
+++ b/rpc/jsonrpc/trace_types.go
@@ -53,11 +53,11 @@ type GethTraces []*GethTrace
 // ParityTrace A trace in the desired format (Parity/OpenEthereum) See: https://openethereum.github.io/JSONRPC-trace-module
 type ParityTrace struct {
 	// Do not change the ordering of these fields -- allows for easier comparison with other clients
-	Action              interface{}  `json:"action"` // Can be either CallTraceAction or CreateTraceAction
+	Action              any          `json:"action"` // Can be either CallTraceAction or CreateTraceAction
 	BlockHash           *common.Hash `json:"blockHash,omitempty"`
 	BlockNumber         *uint64      `json:"blockNumber,omitempty"`
 	Error               string       `json:"error,omitempty"`
-	Result              interface{}  `json:"result"`
+	Result              any          `json:"result"`
 	Subtraces           int          `json:"subtraces"`
 	TraceAddress        []int        `json:"traceAddress"`
 	TransactionHash     *common.Hash `json:"transactionHash,omitempty"`

--- a/rpc/jsonstream/stack_stream_test.go
+++ b/rpc/jsonstream/stack_stream_test.go
@@ -721,7 +721,7 @@ func TestStackStream_ExtremeNesting(t *testing.T) {
 	assert.Equal(t, 0, ss.CurrentDepth())
 
 	// Verify the JSON is valid by parsing it back
-	var result interface{}
+	var result any
 	err := jsoniter.Unmarshal(ss.Buffer(), &result)
 	assert.NoError(t, err)
 }

--- a/rpc/requests/event.go
+++ b/rpc/requests/event.go
@@ -77,7 +77,7 @@ func (reqGen *requestGenerator) SubscribeFilterLogs(ctx context.Context, query e
 }
 
 // ParseResponse converts any of the models interfaces to a string for readability
-func parseResponse(resp interface{}) (string, error) {
+func parseResponse(resp any) (string, error) {
 	result, err := json.Marshal(resp)
 	if err != nil {
 		return "", fmt.Errorf("error trying to marshal response: %v", err)

--- a/rpc/requests/nopgenerator.go
+++ b/rpc/requests/nopgenerator.go
@@ -83,7 +83,7 @@ func (n NopRequestGenerator) SubscribeFilterLogs(ctx context.Context, query ethe
 	return nil, ErrNotImplemented
 }
 
-func (n NopRequestGenerator) Subscribe(ctx context.Context, method SubMethod, subChan interface{}, args ...interface{}) (ethereum.Subscription, error) {
+func (n NopRequestGenerator) Subscribe(ctx context.Context, method SubMethod, subChan any, args ...any) (ethereum.Subscription, error) {
 	return nil, ErrNotImplemented
 }
 

--- a/rpc/requests/request_generator.go
+++ b/rpc/requests/request_generator.go
@@ -80,7 +80,7 @@ type RequestGenerator interface {
 	SendTransaction(signedTx types.Transaction) (common.Hash, error)
 	FilterLogs(ctx context.Context, query ethereum.FilterQuery) ([]types.Log, error)
 	SubscribeFilterLogs(ctx context.Context, query ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error)
-	Subscribe(ctx context.Context, method SubMethod, subChan interface{}, args ...interface{}) (ethereum.Subscription, error)
+	Subscribe(ctx context.Context, method SubMethod, subChan any, args ...any) (ethereum.Subscription, error)
 	TxpoolContent() (int, int, int, error)
 	Call(args ethapi.CallArgs, blockRef rpc.BlockReference, overrides *ethapi.StateOverrides) ([]byte, error)
 	TraceCall(blockRef rpc.BlockReference, args ethapi.CallArgs, traceOpts ...TraceOpt) (*TraceCallResult, error)
@@ -168,7 +168,7 @@ var Methods = struct {
 	ETHCall:                  "eth_call",
 }
 
-func (req *requestGenerator) rpcCallJSON(method RPCMethod, body string, response interface{}) callResult {
+func (req *requestGenerator) rpcCallJSON(method RPCMethod, body string, response any) callResult {
 	ctx := context.Background()
 	req.reqID++
 	start := time.Now()
@@ -188,7 +188,7 @@ func (req *requestGenerator) rpcCallJSON(method RPCMethod, body string, response
 	}
 }
 
-func (req *requestGenerator) rpcCall(ctx context.Context, result interface{}, method RPCMethod, args ...interface{}) error {
+func (req *requestGenerator) rpcCall(ctx context.Context, result any, method RPCMethod, args ...any) error {
 	client, err := req.rpcClient(ctx)
 	if err != nil {
 		return err
@@ -332,7 +332,7 @@ func (req *requestGenerator) rpcClient(ctx context.Context) (*rpc.Client, error)
 	return req.requestClient, nil
 }
 
-func post(ctx context.Context, client *http.Client, url, method, request string, response interface{}, logger log.Logger) error {
+func post(ctx context.Context, client *http.Client, url, method, request string, response any, logger log.Logger) error {
 	start := time.Now()
 
 	req, err := http.NewRequest("POST", url, strings.NewReader(request))
@@ -378,7 +378,7 @@ func post(ctx context.Context, client *http.Client, url, method, request string,
 }
 
 // subscribe connects to a websocket client and returns the subscription handler and a channel buffer
-func (req *requestGenerator) Subscribe(ctx context.Context, method SubMethod, subChan interface{}, args ...interface{}) (ethereum.Subscription, error) {
+func (req *requestGenerator) Subscribe(ctx context.Context, method SubMethod, subChan any, args ...any) (ethereum.Subscription, error) {
 	if req.subscriptionClient == nil {
 		err := retryConnects(ctx, func(ctx context.Context) error {
 			var err error
@@ -396,7 +396,7 @@ func (req *requestGenerator) Subscribe(ctx context.Context, method SubMethod, su
 		return nil, fmt.Errorf("cannot get namespace and submethod from method: %v", err)
 	}
 
-	args = append([]interface{}{subMethod}, args...)
+	args = append([]any{subMethod}, args...)
 
 	return req.subscriptionClient.Subscribe(ctx, namespace, subChan, args...)
 }

--- a/rpc/requests/request_generator_test.go
+++ b/rpc/requests/request_generator_test.go
@@ -53,7 +53,7 @@ func TestParseResponse(t *testing.T) {
 	}
 
 	testCases := []struct {
-		input    interface{}
+		input    any
 		expected string
 	}{
 		{

--- a/rpc/requests/trace.go
+++ b/rpc/requests/trace.go
@@ -69,9 +69,9 @@ type CallResult struct {
 }
 
 type TraceCallStateDiff struct {
-	Balance interface{}                                          `json:"balance"`
-	Nonce   interface{}                                          `json:"nonce"`
-	Code    interface{}                                          `json:"code"`
+	Balance any                                                  `json:"balance"`
+	Nonce   any                                                  `json:"nonce"`
+	Code    any                                                  `json:"code"`
 	Storage map[common.Hash]map[string]TraceCallStateDiffStorage `json:"storage"`
 }
 

--- a/rpc/requests/tx.go
+++ b/rpc/requests/tx.go
@@ -22,15 +22,15 @@ import (
 
 type EthTxPool struct {
 	CommonResponse
-	Result interface{} `json:"result"`
+	Result any `json:"result"`
 }
 
 func (reqGen *requestGenerator) TxpoolContent() (int, int, int, error) {
 	var (
 		b       EthTxPool
-		pending map[string]interface{}
-		queued  map[string]interface{}
-		baseFee map[string]interface{}
+		pending map[string]any
+		queued  map[string]any
+		baseFee map[string]any
 	)
 
 	method, body := reqGen.txpoolContent()
@@ -42,7 +42,7 @@ func (reqGen *requestGenerator) TxpoolContent() (int, int, int, error) {
 		return 0, 0, 0, fmt.Errorf("txpool_content rpc failed: %w", b.Error)
 	}
 
-	resp, ok := b.Result.(map[string]interface{})
+	resp, ok := b.Result.(map[string]any)
 
 	if !ok {
 		return 0, 0, 0, fmt.Errorf("unexpected result type: %T", b.Result)
@@ -53,23 +53,23 @@ func (reqGen *requestGenerator) TxpoolContent() (int, int, int, error) {
 	baseFeeLen := 0
 
 	if resp["pending"] != nil {
-		pending = resp["pending"].(map[string]interface{})
+		pending = resp["pending"].(map[string]any)
 		for _, txs := range pending { // iterate over senders
-			pendingLen += len(txs.(map[string]interface{}))
+			pendingLen += len(txs.(map[string]any))
 		}
 	}
 
 	if resp["queue"] != nil {
-		queued = resp["queue"].(map[string]interface{})
+		queued = resp["queue"].(map[string]any)
 		for _, txs := range queued {
-			queuedLen += len(txs.(map[string]interface{}))
+			queuedLen += len(txs.(map[string]any))
 		}
 	}
 
 	if resp["baseFee"] != nil {
-		baseFee = resp["baseFee"].(map[string]interface{})
+		baseFee = resp["baseFee"].(map[string]any)
 		for _, txs := range baseFee {
-			baseFeeLen += len(txs.(map[string]interface{}))
+			baseFeeLen += len(txs.(map[string]any))
 		}
 	}
 

--- a/rpc/subscription_test.go
+++ b/rpc/subscription_test.go
@@ -82,11 +82,11 @@ func TestSubscriptions(t *testing.T) {
 
 	// create subscriptions one by one
 	for i, namespace := range namespaces {
-		request := map[string]interface{}{
+		request := map[string]any{
 			"id":      i,
 			"method":  fmt.Sprintf("%s_subscribe", namespace),
 			"version": "2.0",
-			"params":  []interface{}{"someSubscription", notificationCount, i},
+			"params":  []any{"someSubscription", notificationCount, i},
 		}
 		if err := out.Encode(&request); err != nil {
 			t.Fatalf("Could not create subscription: %v", err)

--- a/rpc/testservice_test.go
+++ b/rpc/testservice_test.go
@@ -71,9 +71,9 @@ type echoResult struct {
 
 type testError struct{}
 
-func (testError) Error() string          { return "testError" }
-func (testError) ErrorCode() int         { return 444 }
-func (testError) ErrorData() interface{} { return "testError data" }
+func (testError) Error() string  { return "testError" }
+func (testError) ErrorCode() int { return 444 }
+func (testError) ErrorData() any { return "testError data" }
 
 func (s *testService) NoArgsRets() {}
 
@@ -119,24 +119,24 @@ func (s *testService) ReturnError() error {
 	return testError{}
 }
 
-func (s *testService) CallMeBack(ctx context.Context, method string, args []interface{}) (interface{}, error) {
+func (s *testService) CallMeBack(ctx context.Context, method string, args []any) (any, error) {
 	c, ok := ClientFromContext(ctx, log.New())
 	if !ok {
 		return nil, errors.New("no client")
 	}
-	var result interface{}
+	var result any
 	err := c.Call(&result, method, args...)
 	return result, err
 }
 
-func (s *testService) CallMeBackLater(ctx context.Context, method string, args []interface{}) error {
+func (s *testService) CallMeBackLater(ctx context.Context, method string, args []any) error {
 	c, ok := ClientFromContext(ctx, log.New())
 	if !ok {
 		return errors.New("no client")
 	}
 	go func() {
 		<-ctx.Done()
-		var result interface{}
+		var result any
 		c.Call(&result, method, args...)
 	}()
 	return nil


### PR DESCRIPTION
This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.

As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.