### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/execution/abi/abi.go
+++ b/execution/abi/abi.go
@@ -63,7 +63,7 @@ func JSON(reader io.Reader) (ABI, error) {
 // of 4 bytes and arguments are all 32 bytes.
 // Method ids are created from the first 4 bytes of the hash of the
 // methods string signature. (signature = baz(uint32,string32))
-func (abi ABI) Pack(name string, args ...interface{}) ([]byte, error) {
+func (abi ABI) Pack(name string, args ...any) ([]byte, error) {
 	// Fetch the ABI of the requested method
 	if name == "" {
 		// constructor
@@ -105,7 +105,7 @@ func (abi ABI) getArguments(name string, data []byte) (Arguments, error) {
 }
 
 // Unpack unpacks the output according to the abi specification.
-func (abi ABI) Unpack(name string, data []byte) ([]interface{}, error) {
+func (abi ABI) Unpack(name string, data []byte) ([]any, error) {
 	args, err := abi.getArguments(name, data)
 	if err != nil {
 		return nil, err
@@ -116,7 +116,7 @@ func (abi ABI) Unpack(name string, data []byte) ([]interface{}, error) {
 // UnpackIntoInterface unpacks the output in v according to the abi specification.
 // It performs an additional copy. Please only use, if you want to unpack into a
 // structure that does not strictly conform to the abi structure (e.g. has additional arguments)
-func (abi ABI) UnpackIntoInterface(v interface{}, name string, data []byte) error {
+func (abi ABI) UnpackIntoInterface(v any, name string, data []byte) error {
 	args, err := abi.getArguments(name, data)
 	if err != nil {
 		return err
@@ -129,7 +129,7 @@ func (abi ABI) UnpackIntoInterface(v interface{}, name string, data []byte) erro
 }
 
 // UnpackIntoMap unpacks a log into the provided map[string]interface{}.
-func (abi ABI) UnpackIntoMap(v map[string]interface{}, name string, data []byte) (err error) {
+func (abi ABI) UnpackIntoMap(v map[string]any, name string, data []byte) (err error) {
 	args, err := abi.getArguments(name, data)
 	if err != nil {
 		return err

--- a/execution/abi/abi_test.go
+++ b/execution/abi/abi_test.go
@@ -780,8 +780,8 @@ func TestUnpackEventIntoMap(t *testing.T) {
 		t.Errorf("len(data) is %d, want a non-multiple of 32", len(data))
 	}
 
-	receivedMap := map[string]interface{}{}
-	expectedReceivedMap := map[string]interface{}{
+	receivedMap := map[string]any{}
+	expectedReceivedMap := map[string]any{
 		"sender": common.HexToAddress("0x376c47978271565f56DEB45495afa69E59c16Ab2"),
 		"amount": big.NewInt(1),
 		"memo":   []byte{88},
@@ -802,7 +802,7 @@ func TestUnpackEventIntoMap(t *testing.T) {
 		t.Error("unpacked `received` map does not match expected map")
 	}
 
-	receivedAddrMap := map[string]interface{}{}
+	receivedAddrMap := map[string]any{}
 	if err = abi.UnpackIntoMap(receivedAddrMap, "receivedAddr", data); err != nil {
 		t.Error(err)
 	}
@@ -830,7 +830,7 @@ func TestUnpackMethodIntoMap(t *testing.T) {
 	}
 
 	// Tests a method with no outputs
-	receiveMap := map[string]interface{}{}
+	receiveMap := map[string]any{}
 	if err = abi.UnpackIntoMap(receiveMap, "receive", data); err != nil {
 		t.Error(err)
 	}
@@ -839,7 +839,7 @@ func TestUnpackMethodIntoMap(t *testing.T) {
 	}
 
 	// Tests a method with only outputs
-	sendMap := map[string]interface{}{}
+	sendMap := map[string]any{}
 	if err = abi.UnpackIntoMap(sendMap, "send", data); err != nil {
 		t.Error(err)
 	}
@@ -851,7 +851,7 @@ func TestUnpackMethodIntoMap(t *testing.T) {
 	}
 
 	// Tests a method with outputs and inputs
-	getMap := map[string]interface{}{}
+	getMap := map[string]any{}
 	if err = abi.UnpackIntoMap(getMap, "get", data); err != nil {
 		t.Error(err)
 	}
@@ -879,7 +879,7 @@ func TestUnpackIntoMapNamingConflict(t *testing.T) {
 	if len(data)%32 == 0 {
 		t.Errorf("len(data) is %d, want a non-multiple of 32", len(data))
 	}
-	getMap := map[string]interface{}{}
+	getMap := map[string]any{}
 	if err = abi.UnpackIntoMap(getMap, "get", data); err == nil {
 		t.Error("naming conflict between two methods; error expected")
 	}
@@ -898,7 +898,7 @@ func TestUnpackIntoMapNamingConflict(t *testing.T) {
 	if len(data)%32 == 0 {
 		t.Errorf("len(data) is %d, want a non-multiple of 32", len(data))
 	}
-	receivedMap := map[string]interface{}{}
+	receivedMap := map[string]any{}
 	if err = abi.UnpackIntoMap(receivedMap, "received", data); err != nil {
 		t.Error("naming conflict between two events; no error expected")
 	}
@@ -925,7 +925,7 @@ func TestUnpackIntoMapNamingConflict(t *testing.T) {
 	if len(data)%32 == 0 {
 		t.Errorf("len(data) is %d, want a non-multiple of 32", len(data))
 	}
-	expectedReceivedMap := map[string]interface{}{
+	expectedReceivedMap := map[string]any{
 		"sender": common.HexToAddress("0x376c47978271565f56DEB45495afa69E59c16Ab2"),
 		"amount": big.NewInt(1),
 		"memo":   []byte{88},

--- a/execution/abi/abifuzzer_test.go
+++ b/execution/abi/abifuzzer_test.go
@@ -64,7 +64,7 @@ var (
 		"bytes32", "bytes"}
 )
 
-func unpackPack(abi ABI, method string, input []byte) ([]interface{}, bool) {
+func unpackPack(abi ABI, method string, input []byte) ([]any, bool) {
 	if out, err := abi.Unpack(method, input); err == nil {
 		_, err := abi.Pack(method, out...)
 		if err != nil {
@@ -80,9 +80,9 @@ func unpackPack(abi ABI, method string, input []byte) ([]interface{}, bool) {
 	return nil, false
 }
 
-func packUnpack(abi ABI, method string, input *[]interface{}) bool {
+func packUnpack(abi ABI, method string, input *[]any) bool {
 	if packed, err := abi.Pack(method, input); err == nil {
-		outptr := reflect.New(reflect.TypeFor[*[]interface{}]())
+		outptr := reflect.New(reflect.TypeFor[*[]any]())
 		err := abi.UnpackIntoInterface(outptr.Interface(), method, packed)
 		if err != nil {
 			panic(err)

--- a/execution/abi/argument.go
+++ b/execution/abi/argument.go
@@ -80,14 +80,14 @@ func (arguments Arguments) isTuple() bool {
 }
 
 // Unpack performs the operation hexdata -> Go format.
-func (arguments Arguments) Unpack(data []byte) ([]interface{}, error) {
+func (arguments Arguments) Unpack(data []byte) ([]any, error) {
 	if len(data) == 0 {
 		if len(arguments) != 0 {
 			return nil, errors.New("abi: attempting to unmarshall an empty string while arguments are expected")
 		}
 		// Nothing to unmarshal, return default variables
 		nonIndexedArgs := arguments.NonIndexed()
-		defaultVars := make([]interface{}, len(nonIndexedArgs))
+		defaultVars := make([]any, len(nonIndexedArgs))
 		for index, arg := range nonIndexedArgs {
 			defaultVars[index] = reflect.New(arg.Type.GetType())
 		}
@@ -97,7 +97,7 @@ func (arguments Arguments) Unpack(data []byte) ([]interface{}, error) {
 }
 
 // UnpackIntoMap performs the operation hexdata -> mapping of argument name to argument value.
-func (arguments Arguments) UnpackIntoMap(v map[string]interface{}, data []byte) error {
+func (arguments Arguments) UnpackIntoMap(v map[string]any, data []byte) error {
 	// Make sure map is not nil
 	if v == nil {
 		return errors.New("abi: cannot unpack into a nil map")
@@ -119,7 +119,7 @@ func (arguments Arguments) UnpackIntoMap(v map[string]interface{}, data []byte) 
 }
 
 // Copy performs the operation go format -> provided struct.
-func (arguments Arguments) Copy(v interface{}, values []interface{}) error {
+func (arguments Arguments) Copy(v any, values []any) error {
 	// make sure the passed value is arguments pointer
 	if reflect.Ptr != reflect.ValueOf(v).Kind() {
 		return fmt.Errorf("abi: Unpack(non-pointer %T)", v)
@@ -137,7 +137,7 @@ func (arguments Arguments) Copy(v interface{}, values []interface{}) error {
 }
 
 // unpackAtomic unpacks ( hexdata -> go ) a single value
-func (arguments Arguments) copyAtomic(v interface{}, marshalledValues interface{}) error {
+func (arguments Arguments) copyAtomic(v any, marshalledValues any) error {
 	dst := reflect.ValueOf(v).Elem()
 	src := reflect.ValueOf(marshalledValues)
 
@@ -148,7 +148,7 @@ func (arguments Arguments) copyAtomic(v interface{}, marshalledValues interface{
 }
 
 // copyTuple copies a batch of values from marshalledValues to v.
-func (arguments Arguments) copyTuple(v interface{}, marshalledValues []interface{}) error {
+func (arguments Arguments) copyTuple(v any, marshalledValues []any) error {
 	value := reflect.ValueOf(v).Elem()
 	nonIndexedArgs := arguments.NonIndexed()
 
@@ -190,9 +190,9 @@ func (arguments Arguments) copyTuple(v interface{}, marshalledValues []interface
 // UnpackValues can be used to unpack ABI-encoded hexdata according to the ABI-specification,
 // without supplying a struct to unpack into. Instead, this method returns a list containing the
 // values. An atomic argument will be a list with one element.
-func (arguments Arguments) UnpackValues(data []byte) ([]interface{}, error) {
+func (arguments Arguments) UnpackValues(data []byte) ([]any, error) {
 	nonIndexedArgs := arguments.NonIndexed()
-	retval := make([]interface{}, 0, len(nonIndexedArgs))
+	retval := make([]any, 0, len(nonIndexedArgs))
 	virtualArgs := 0
 	for index, arg := range nonIndexedArgs {
 		marshalledValue, err := toGoType((index+virtualArgs)*32, arg.Type, data)
@@ -223,12 +223,12 @@ func (arguments Arguments) UnpackValues(data []byte) ([]interface{}, error) {
 
 // PackValues performs the operation Go format -> Hexdata.
 // It is the semantic opposite of UnpackValues.
-func (arguments Arguments) PackValues(args []interface{}) ([]byte, error) {
+func (arguments Arguments) PackValues(args []any) ([]byte, error) {
 	return arguments.Pack(args...)
 }
 
 // Pack performs the operation Go format -> Hexdata.
-func (arguments Arguments) Pack(args ...interface{}) ([]byte, error) {
+func (arguments Arguments) Pack(args ...any) ([]byte, error) {
 	// Make sure arguments match up and pack them
 	abiArgs := arguments
 	if len(args) != len(abiArgs) {

--- a/execution/abi/bind/backends/simulated.go
+++ b/execution/abi/bind/backends/simulated.go
@@ -543,7 +543,7 @@ func (e *revertError) ErrorCode() int {
 }
 
 // ErrorData returns the hex encoded revert reason.
-func (e *revertError) ErrorData() interface{} {
+func (e *revertError) ErrorData() any {
 	return e.reason
 }
 

--- a/execution/abi/bind/backends/simulated_test.go
+++ b/execution/abi/bind/backends/simulated_test.go
@@ -451,7 +451,7 @@ func TestSimulatedBackend_EstimateGas(t *testing.T) {
 		message     ethereum.CallMsg
 		expect      uint64
 		expectError error
-		expectData  interface{}
+		expectData  any
 	}{
 		{"plain transfer(valid)", ethereum.CallMsg{
 			From:     addr,
@@ -1067,7 +1067,7 @@ func TestSimulatedBackend_CallContractRevert(t *testing.T) {
 		t.Errorf("could not deploy contract: %v", err)
 	}
 
-	inputs := make(map[string]interface{}, 3)
+	inputs := make(map[string]any, 3)
 	inputs["revertASM"] = nil
 	inputs["revertNoString"] = ""
 	inputs["revertString"] = "some error"

--- a/execution/abi/bind/base.go
+++ b/execution/abi/bind/base.go
@@ -101,7 +101,7 @@ func NewBoundContract(address common.Address, abi abi.ABI, caller ContractCaller
 
 // DeployContract deploys a contract onto the Ethereum blockchain and binds the
 // deployment address with a Go wrapper.
-func DeployContract(opts *TransactOpts, abi abi.ABI, bytecode []byte, backend ContractBackend, params ...interface{}) (common.Address, types.Transaction, *BoundContract, error) {
+func DeployContract(opts *TransactOpts, abi abi.ABI, bytecode []byte, backend ContractBackend, params ...any) (common.Address, types.Transaction, *BoundContract, error) {
 	// Otherwise try to deploy the contract
 	c := NewBoundContract(common.Address{}, abi, backend, backend, backend)
 
@@ -121,13 +121,13 @@ func DeployContract(opts *TransactOpts, abi abi.ABI, bytecode []byte, backend Co
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (c *BoundContract) Call(opts *CallOpts, results *[]interface{}, method string, params ...interface{}) error {
+func (c *BoundContract) Call(opts *CallOpts, results *[]any, method string, params ...any) error {
 	// Don't crash on a lazy user
 	if opts == nil {
 		opts = new(CallOpts)
 	}
 	if results == nil {
-		results = new([]interface{})
+		results = new([]any)
 	}
 	// Pack the input, call and unpack the results
 	input, err := c.abi.Pack(method, params...)
@@ -179,7 +179,7 @@ func (c *BoundContract) Call(opts *CallOpts, results *[]interface{}, method stri
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (c *BoundContract) Transact(opts *TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (c *BoundContract) Transact(opts *TransactOpts, method string, params ...any) (types.Transaction, error) {
 	// Otherwise pack up the parameters and invoke the contract
 	input, err := c.abi.Pack(method, params...)
 	if err != nil {
@@ -279,13 +279,13 @@ func (c *BoundContract) transact(opts *TransactOpts, contract *common.Address, i
 
 // FilterLogs filters contract logs for past blocks, returning the necessary
 // channels to construct a strongly typed bound iterator on top of them.
-func (c *BoundContract) FilterLogs(opts *FilterOpts, name string, query ...[]interface{}) (chan types.Log, event.Subscription, error) {
+func (c *BoundContract) FilterLogs(opts *FilterOpts, name string, query ...[]any) (chan types.Log, event.Subscription, error) {
 	// Don't crash on a lazy user
 	if opts == nil {
 		opts = new(FilterOpts)
 	}
 	// Append the event selector to the query parameters and construct the topic set
-	query = append([][]interface{}{{c.abi.Events[name].ID}}, query...)
+	query = append([][]any{{c.abi.Events[name].ID}}, query...)
 
 	topics, err := abi.MakeTopics(query...)
 	if err != nil {
@@ -325,13 +325,13 @@ func (c *BoundContract) FilterLogs(opts *FilterOpts, name string, query ...[]int
 
 // WatchLogs filters subscribes to contract logs for future blocks, returning a
 // subscription object that can be used to tear down the watcher.
-func (c *BoundContract) WatchLogs(opts *WatchOpts, name string, query ...[]interface{}) (chan types.Log, event.Subscription, error) {
+func (c *BoundContract) WatchLogs(opts *WatchOpts, name string, query ...[]any) (chan types.Log, event.Subscription, error) {
 	// Don't crash on a lazy user
 	if opts == nil {
 		opts = new(WatchOpts)
 	}
 	// Append the event selector to the query parameters and construct the topic set
-	query = append([][]interface{}{{c.abi.Events[name].ID}}, query...)
+	query = append([][]any{{c.abi.Events[name].ID}}, query...)
 
 	topics, err := abi.MakeTopics(query...)
 	if err != nil {
@@ -355,7 +355,7 @@ func (c *BoundContract) WatchLogs(opts *WatchOpts, name string, query ...[]inter
 }
 
 // UnpackLog unpacks a retrieved log into the provided output structure.
-func (c *BoundContract) UnpackLog(out interface{}, event string, log types.Log) error {
+func (c *BoundContract) UnpackLog(out any, event string, log types.Log) error {
 	if len(log.Data) > 0 {
 		if err := c.abi.UnpackIntoInterface(out, event, log.Data); err != nil {
 			return err
@@ -371,7 +371,7 @@ func (c *BoundContract) UnpackLog(out interface{}, event string, log types.Log) 
 }
 
 // UnpackLogIntoMap unpacks a retrieved log into the provided map.
-func (c *BoundContract) UnpackLogIntoMap(out map[string]interface{}, event string, log types.Log) error {
+func (c *BoundContract) UnpackLogIntoMap(out map[string]any, event string, log types.Log) error {
 	if len(log.Data) > 0 {
 		if err := c.abi.UnpackIntoMap(out, event, log.Data); err != nil {
 			return err

--- a/execution/abi/bind/base_test.go
+++ b/execution/abi/bind/base_test.go
@@ -123,7 +123,7 @@ func TestUnpackIndexedStringTyLogIntoMap(t *testing.T) {
 	parsedAbi, _ := abi.JSON(strings.NewReader(abiString))
 	bc := bind.NewBoundContract(common.HexToAddress("0x0"), parsedAbi, nil, nil, nil)
 
-	expectedReceivedMap := map[string]interface{}{
+	expectedReceivedMap := map[string]any{
 		"name":   hash,
 		"sender": common.HexToAddress("0x376c47978271565f56DEB45495afa69E59c16Ab2"),
 		"amount": big.NewInt(1),
@@ -148,7 +148,7 @@ func TestUnpackIndexedSliceTyLogIntoMap(t *testing.T) {
 	parsedAbi, _ := abi.JSON(strings.NewReader(abiString))
 	bc := bind.NewBoundContract(common.HexToAddress("0x0"), parsedAbi, nil, nil, nil)
 
-	expectedReceivedMap := map[string]interface{}{
+	expectedReceivedMap := map[string]any{
 		"names":  hash,
 		"sender": common.HexToAddress("0x376c47978271565f56DEB45495afa69E59c16Ab2"),
 		"amount": big.NewInt(1),
@@ -173,7 +173,7 @@ func TestUnpackIndexedArrayTyLogIntoMap(t *testing.T) {
 	parsedAbi, _ := abi.JSON(strings.NewReader(abiString))
 	bc := bind.NewBoundContract(common.HexToAddress("0x0"), parsedAbi, nil, nil, nil)
 
-	expectedReceivedMap := map[string]interface{}{
+	expectedReceivedMap := map[string]any{
 		"addresses": hash,
 		"sender":    common.HexToAddress("0x376c47978271565f56DEB45495afa69E59c16Ab2"),
 		"amount":    big.NewInt(1),
@@ -199,7 +199,7 @@ func TestUnpackIndexedFuncTyLogIntoMap(t *testing.T) {
 	parsedAbi, _ := abi.JSON(strings.NewReader(abiString))
 	bc := bind.NewBoundContract(common.HexToAddress("0x0"), parsedAbi, nil, nil, nil)
 
-	expectedReceivedMap := map[string]interface{}{
+	expectedReceivedMap := map[string]any{
 		"function": functionTy,
 		"sender":   common.HexToAddress("0x376c47978271565f56DEB45495afa69E59c16Ab2"),
 		"amount":   big.NewInt(1),
@@ -221,7 +221,7 @@ func TestUnpackIndexedBytesTyLogIntoMap(t *testing.T) {
 	parsedAbi, _ := abi.JSON(strings.NewReader(abiString))
 	bc := bind.NewBoundContract(common.HexToAddress("0x0"), parsedAbi, nil, nil, nil)
 
-	expectedReceivedMap := map[string]interface{}{
+	expectedReceivedMap := map[string]any{
 		"content": hash,
 		"sender":  common.HexToAddress("0x376c47978271565f56DEB45495afa69E59c16Ab2"),
 		"amount":  big.NewInt(1),
@@ -230,8 +230,8 @@ func TestUnpackIndexedBytesTyLogIntoMap(t *testing.T) {
 	unpackAndCheck(t, bc, expectedReceivedMap, mockLog)
 }
 
-func unpackAndCheck(t *testing.T, bc *bind.BoundContract, expected map[string]interface{}, mockLog types.Log) {
-	received := make(map[string]interface{})
+func unpackAndCheck(t *testing.T, bc *bind.BoundContract, expected map[string]any, mockLog types.Log) {
+	received := make(map[string]any)
 	if err := bc.UnpackLogIntoMap(received, "received", mockLog); err != nil {
 		t.Error(err)
 	}

--- a/execution/abi/bind/bind.go
+++ b/execution/abi/bind/bind.go
@@ -265,7 +265,7 @@ func Bind(types []string, abis []string, bytecodes []string, fsigs []map[string]
 	}
 	buffer := new(bytes.Buffer)
 
-	funcs := map[string]interface{}{
+	funcs := map[string]any{
 		"bindtype":      bindType[lang],
 		"bindtopictype": bindTopicType[lang],
 		"namedtype":     namedType[lang],

--- a/execution/abi/compiler/helpers.go
+++ b/execution/abi/compiler/helpers.go
@@ -34,15 +34,15 @@ type Contract struct {
 // Depending on the source, language version, compiler version, and compiler
 // options will provide information about how the contract was compiled.
 type ContractInfo struct {
-	Source          string      `json:"source"`
-	Language        string      `json:"language"`
-	LanguageVersion string      `json:"languageVersion"`
-	CompilerVersion string      `json:"compilerVersion"`
-	CompilerOptions string      `json:"compilerOptions"`
-	SrcMap          interface{} `json:"srcMap"`
-	SrcMapRuntime   string      `json:"srcMapRuntime"`
-	AbiDefinition   interface{} `json:"abiDefinition"`
-	UserDoc         interface{} `json:"userDoc"`
-	DeveloperDoc    interface{} `json:"developerDoc"`
-	Metadata        string      `json:"metadata"`
+	Source          string `json:"source"`
+	Language        string `json:"language"`
+	LanguageVersion string `json:"languageVersion"`
+	CompilerVersion string `json:"compilerVersion"`
+	CompilerOptions string `json:"compilerOptions"`
+	SrcMap          any    `json:"srcMap"`
+	SrcMapRuntime   string `json:"srcMapRuntime"`
+	AbiDefinition   any    `json:"abiDefinition"`
+	UserDoc         any    `json:"userDoc"`
+	DeveloperDoc    any    `json:"developerDoc"`
+	Metadata        string `json:"metadata"`
 }

--- a/execution/abi/compiler/solidity.go
+++ b/execution/abi/compiler/solidity.go
@@ -44,9 +44,9 @@ type solcOutputV8 struct {
 		BinRuntime            string `json:"bin-runtime"`
 		SrcMapRuntime         string `json:"srcmap-runtime"`
 		Bin, SrcMap, Metadata string
-		Abi                   interface{}
-		Devdoc                interface{}
-		Userdoc               interface{}
+		Abi                   any
+		Devdoc                any
+		Userdoc               any
 		Hashes                map[string]string
 	}
 	Version string
@@ -71,12 +71,12 @@ func ParseCombinedJSON(combinedJSON []byte, source string, languageVersion strin
 	contracts := make(map[string]*Contract)
 	for name, info := range output.Contracts {
 		// Parse the individual compilation results.
-		var abi interface{}
+		var abi any
 		if err := json.Unmarshal([]byte(info.Abi), &abi); err != nil {
 			return nil, fmt.Errorf("solc: error reading abi definition (%w)", err)
 		}
 
-		var userdoc, devdoc interface{}
+		var userdoc, devdoc any
 		marshalErr := json.Unmarshal([]byte(info.Userdoc), &userdoc)
 		if marshalErr != nil {
 			log.Warn("Failed to unmarshal info.Devdoc", "", marshalErr)

--- a/execution/abi/error.go
+++ b/execution/abi/error.go
@@ -82,7 +82,7 @@ func (e *Error) String() string {
 	return e.str
 }
 
-func (e *Error) Unpack(data []byte) (interface{}, error) {
+func (e *Error) Unpack(data []byte) (any, error) {
 	if len(data) < 4 {
 		return "", errors.New("invalid data for unpacking")
 	}
@@ -147,6 +147,6 @@ func typeCheck(t Type, value reflect.Value) error {
 }
 
 // typeErr returns a formatted type casting error.
-func typeErr(expected, got interface{}) error {
+func typeErr(expected, got any) error {
 	return fmt.Errorf("abi: cannot use %v as type %v as argument", got, expected)
 }

--- a/execution/abi/event_test.go
+++ b/execution/abi/event_test.go
@@ -217,8 +217,8 @@ func TestEventTupleUnpack(t *testing.T) {
 	addr := common.HexToAddress("0x00Ce0d46d924CC8437c806721496599FC3FFA268")
 	var testCases = []struct {
 		data     string
-		dest     interface{}
-		expected interface{}
+		dest     any
+		expected any
 		jsonLog  []byte
 		error    string
 		name     string
@@ -231,8 +231,8 @@ func TestEventTupleUnpack(t *testing.T) {
 		"Can unpack ERC20 Transfer event into structure",
 	}, {
 		transferData1,
-		&[]interface{}{&bigint},
-		&[]interface{}{&bigintExpected},
+		&[]any{&bigint},
+		&[]any{&bigintExpected},
 		jsonEventTransfer,
 		"",
 		"Can unpack ERC20 Transfer event into slice",
@@ -276,8 +276,8 @@ func TestEventTupleUnpack(t *testing.T) {
 		"Can unpack Pledge event into structure",
 	}, {
 		pledgeData1,
-		&[]interface{}{&common.Address{}, &bigint, &[3]byte{}},
-		&[]interface{}{
+		&[]any{&common.Address{}, &bigint, &[3]byte{}},
+		&[]any{
 			&addr,
 			&bigintExpected2,
 			&[3]byte{'u', 's', 'd'}},
@@ -286,8 +286,8 @@ func TestEventTupleUnpack(t *testing.T) {
 		"Can unpack Pledge event into slice",
 	}, {
 		pledgeData1,
-		&[3]interface{}{&common.Address{}, &bigint, &[3]byte{}},
-		&[3]interface{}{
+		&[3]any{&common.Address{}, &bigint, &[3]byte{}},
+		&[3]any{
 			&addr,
 			&bigintExpected2,
 			&[3]byte{'u', 's', 'd'}},
@@ -296,8 +296,8 @@ func TestEventTupleUnpack(t *testing.T) {
 		"Can unpack Pledge event into an array",
 	}, {
 		pledgeData1,
-		&[]interface{}{new(int), 0, 0},
-		&[]interface{}{},
+		&[]any{new(int), 0, 0},
+		&[]any{},
 		jsonEventPledge,
 		"abi: cannot unmarshal common.Address in to int",
 		"Can not unpack Pledge event into slice with wrong types",
@@ -310,15 +310,15 @@ func TestEventTupleUnpack(t *testing.T) {
 		"Can not unpack Pledge event into struct with wrong filed types",
 	}, {
 		pledgeData1,
-		&[]interface{}{common.Address{}, new(big.Int)},
-		&[]interface{}{},
+		&[]any{common.Address{}, new(big.Int)},
+		&[]any{},
 		jsonEventPledge,
 		"abi: insufficient number of arguments for unpack, want 3, got 2",
 		"Can not unpack Pledge event into too short slice",
 	}, {
 		pledgeData1,
-		new(map[string]interface{}),
-		&[]interface{}{},
+		new(map[string]any),
+		&[]any{},
 		jsonEventPledge,
 		"abi:[2] cannot unmarshal tuple in to map[string]interface {}",
 		"Can not unpack Pledge event into map",
@@ -346,7 +346,7 @@ func TestEventTupleUnpack(t *testing.T) {
 	}
 }
 
-func unpackTestEventData(dest interface{}, hexData string, jsonEvent []byte, assert *assert.Assertions) error {
+func unpackTestEventData(dest any, hexData string, jsonEvent []byte, assert *assert.Assertions) error {
 	data, err := hex.DecodeString(hexData)
 	assert.NoError(err, "Hex data should be a correct hex-string")
 	var e Event

--- a/execution/abi/packing_test.go
+++ b/execution/abi/packing_test.go
@@ -27,7 +27,7 @@ import (
 
 type packUnpackTest struct {
 	def      string
-	unpacked interface{}
+	unpacked any
 	packed   string
 }
 

--- a/execution/abi/reflect.go
+++ b/execution/abi/reflect.go
@@ -40,7 +40,7 @@ import (
 //
 // into
 // type TupleT struct { X *big.Int }
-func ConvertType(in interface{}, proto interface{}) interface{} {
+func ConvertType(in any, proto any) any {
 	protoType := reflect.TypeOf(proto)
 	if reflect.TypeOf(in).ConvertibleTo(protoType) {
 		return reflect.ValueOf(in).Convert(protoType).Interface()

--- a/execution/abi/reflect_test.go
+++ b/execution/abi/reflect_test.go
@@ -28,7 +28,7 @@ import (
 type reflectTest struct {
 	name  string
 	args  []string
-	struc interface{}
+	struc any
 	want  map[string]string
 	err   string
 }

--- a/execution/abi/topics.go
+++ b/execution/abi/topics.go
@@ -32,7 +32,7 @@ import (
 )
 
 // MakeTopics converts a filter query argument list into a filter topic set.
-func MakeTopics(query ...[]interface{}) ([][]common.Hash, error) {
+func MakeTopics(query ...[]any) ([][]common.Hash, error) {
 	topics := make([][]common.Hash, len(query))
 	for i, filter := range query {
 		for _, rule := range filter {
@@ -116,18 +116,18 @@ func genIntType(rule int64, size uint) []byte {
 }
 
 // ParseTopics converts the indexed topic fields into actual log field values.
-func ParseTopics(out interface{}, fields Arguments, topics []common.Hash) error {
+func ParseTopics(out any, fields Arguments, topics []common.Hash) error {
 	return parseTopicWithSetter(fields, topics,
-		func(arg Argument, reconstr interface{}) {
+		func(arg Argument, reconstr any) {
 			field := reflect.ValueOf(out).Elem().FieldByName(ToCamelCase(arg.Name))
 			field.Set(reflect.ValueOf(reconstr))
 		})
 }
 
 // ParseTopicsIntoMap converts the indexed topic field-value pairs into map key-value pairs.
-func ParseTopicsIntoMap(out map[string]interface{}, fields Arguments, topics []common.Hash) error {
+func ParseTopicsIntoMap(out map[string]any, fields Arguments, topics []common.Hash) error {
 	return parseTopicWithSetter(fields, topics,
-		func(arg Argument, reconstr interface{}) {
+		func(arg Argument, reconstr any) {
 			out[arg.Name] = reconstr
 		})
 }
@@ -137,7 +137,7 @@ func ParseTopicsIntoMap(out map[string]interface{}, fields Arguments, topics []c
 //
 // Note, dynamic types cannot be reconstructed since they get mapped to Keccak256
 // hashes as the topic value!
-func parseTopicWithSetter(fields Arguments, topics []common.Hash, setter func(Argument, interface{})) error {
+func parseTopicWithSetter(fields Arguments, topics []common.Hash, setter func(Argument, any)) error {
 	// Sanity check that the fields and topics match up
 	if len(fields) != len(topics) {
 		return errors.New("topic/field count mismatch")
@@ -147,7 +147,7 @@ func parseTopicWithSetter(fields Arguments, topics []common.Hash, setter func(Ar
 		if !arg.Indexed {
 			return errors.New("non-indexed field in topic reconstruction")
 		}
-		var reconstr interface{}
+		var reconstr any
 		switch arg.Type.T {
 		case TupleTy:
 			return errors.New("tuple type in topic reconstruction")

--- a/execution/abi/topics_test.go
+++ b/execution/abi/topics_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestMakeTopics(t *testing.T) {
 	type args struct {
-		query [][]interface{}
+		query [][]any
 	}
 	tests := []struct {
 		name    string
@@ -40,31 +40,31 @@ func TestMakeTopics(t *testing.T) {
 	}{
 		{
 			"support fixed byte types, right padded to 32 bytes",
-			args{[][]interface{}{{[5]byte{1, 2, 3, 4, 5}}}},
+			args{[][]any{{[5]byte{1, 2, 3, 4, 5}}}},
 			[][]common.Hash{{common.Hash{1, 2, 3, 4, 5}}},
 			false,
 		},
 		{
 			"support common.Hash types in topics",
-			args{[][]interface{}{{common.Hash{1, 2, 3, 4, 5}}}},
+			args{[][]any{{common.Hash{1, 2, 3, 4, 5}}}},
 			[][]common.Hash{{common.Hash{1, 2, 3, 4, 5}}},
 			false,
 		},
 		{
 			"support address types in topics",
-			args{[][]interface{}{{common.Address{1, 2, 3, 4, 5}}}},
+			args{[][]any{{common.Address{1, 2, 3, 4, 5}}}},
 			[][]common.Hash{{common.Hash{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5}}},
 			false,
 		},
 		{
 			"support *big.Int types in topics",
-			args{[][]interface{}{{big.NewInt(1).Lsh(big.NewInt(2), 254)}}},
+			args{[][]any{{big.NewInt(1).Lsh(big.NewInt(2), 254)}}},
 			[][]common.Hash{{common.Hash{128}}},
 			false,
 		},
 		{
 			"support boolean types in topics",
-			args{[][]interface{}{
+			args{[][]any{
 				{true},
 				{false},
 			}},
@@ -76,7 +76,7 @@ func TestMakeTopics(t *testing.T) {
 		},
 		{
 			"support int/uint(8/16/32/64) types in topics",
-			args{[][]interface{}{
+			args{[][]any{
 				{int8(-2)},
 				{int16(-3)},
 				{int32(-4)},
@@ -108,13 +108,13 @@ func TestMakeTopics(t *testing.T) {
 		},
 		{
 			"support string types in topics",
-			args{[][]interface{}{{"hello world"}}},
+			args{[][]any{{"hello world"}}},
 			[][]common.Hash{{crypto.Keccak256Hash([]byte("hello world"))}},
 			false,
 		},
 		{
 			"support byte slice types in topics",
-			args{[][]interface{}{{[]byte{1, 2, 3}}}},
+			args{[][]any{{[]byte{1, 2, 3}}}},
 			[][]common.Hash{{crypto.Keccak256Hash([]byte{1, 2, 3})}},
 			false,
 		},
@@ -134,9 +134,9 @@ func TestMakeTopics(t *testing.T) {
 }
 
 type args struct {
-	createObj func() interface{}
-	resultObj func() interface{}
-	resultMap func() map[string]interface{}
+	createObj func() any
+	resultObj func() any
+	resultMap func() map[string]any
 	fields    Arguments
 	topics    []common.Hash
 }
@@ -177,10 +177,10 @@ func setupTopicsTests() []topicTest {
 		{
 			name: "support fixed byte types, right padded to 32 bytes",
 			args: args{
-				createObj: func() interface{} { return &bytesStruct{} },
-				resultObj: func() interface{} { return &bytesStruct{StaticBytes: [5]byte{1, 2, 3, 4, 5}} },
-				resultMap: func() map[string]interface{} {
-					return map[string]interface{}{"staticBytes": [5]byte{1, 2, 3, 4, 5}}
+				createObj: func() any { return &bytesStruct{} },
+				resultObj: func() any { return &bytesStruct{StaticBytes: [5]byte{1, 2, 3, 4, 5}} },
+				resultMap: func() map[string]any {
+					return map[string]any{"staticBytes": [5]byte{1, 2, 3, 4, 5}}
 				},
 				fields: Arguments{Argument{
 					Name:    "staticBytes",
@@ -196,10 +196,10 @@ func setupTopicsTests() []topicTest {
 		{
 			name: "int8 with negative value",
 			args: args{
-				createObj: func() interface{} { return &int8Struct{} },
-				resultObj: func() interface{} { return &int8Struct{Int8Value: -1} },
-				resultMap: func() map[string]interface{} {
-					return map[string]interface{}{"int8Value": int8(-1)}
+				createObj: func() any { return &int8Struct{} },
+				resultObj: func() any { return &int8Struct{Int8Value: -1} },
+				resultMap: func() map[string]any {
+					return map[string]any{"int8Value": int8(-1)}
 				},
 				fields: Arguments{Argument{
 					Name:    "int8Value",
@@ -216,10 +216,10 @@ func setupTopicsTests() []topicTest {
 		{
 			name: "int256 with negative value",
 			args: args{
-				createObj: func() interface{} { return &int256Struct{} },
-				resultObj: func() interface{} { return &int256Struct{Int256Value: big.NewInt(-1)} },
-				resultMap: func() map[string]interface{} {
-					return map[string]interface{}{"int256Value": big.NewInt(-1)}
+				createObj: func() any { return &int256Struct{} },
+				resultObj: func() any { return &int256Struct{Int256Value: big.NewInt(-1)} },
+				resultMap: func() map[string]any {
+					return map[string]any{"int256Value": big.NewInt(-1)}
 				},
 				fields: Arguments{Argument{
 					Name:    "int256Value",
@@ -236,10 +236,10 @@ func setupTopicsTests() []topicTest {
 		{
 			name: "hash type",
 			args: args{
-				createObj: func() interface{} { return &hashStruct{} },
-				resultObj: func() interface{} { return &hashStruct{crypto.Keccak256Hash([]byte("stringtopic"))} },
-				resultMap: func() map[string]interface{} {
-					return map[string]interface{}{"hashValue": crypto.Keccak256Hash([]byte("stringtopic"))}
+				createObj: func() any { return &hashStruct{} },
+				resultObj: func() any { return &hashStruct{crypto.Keccak256Hash([]byte("stringtopic"))} },
+				resultMap: func() map[string]any {
+					return map[string]any{"hashValue": crypto.Keccak256Hash([]byte("stringtopic"))}
 				},
 				fields: Arguments{Argument{
 					Name:    "hashValue",
@@ -255,13 +255,13 @@ func setupTopicsTests() []topicTest {
 		{
 			name: "function type",
 			args: args{
-				createObj: func() interface{} { return &funcStruct{} },
-				resultObj: func() interface{} {
+				createObj: func() any { return &funcStruct{} },
+				resultObj: func() any {
 					return &funcStruct{[24]byte{255, 255, 255, 255, 255, 255, 255, 255,
 						255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255}}
 				},
-				resultMap: func() map[string]interface{} {
-					return map[string]interface{}{"funcValue": [24]byte{255, 255, 255, 255, 255, 255, 255, 255,
+				resultMap: func() map[string]any {
+					return map[string]any{"funcValue": [24]byte{255, 255, 255, 255, 255, 255, 255, 255,
 						255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255}}
 				},
 				fields: Arguments{Argument{
@@ -279,9 +279,9 @@ func setupTopicsTests() []topicTest {
 		{
 			name: "error on topic/field count mismatch",
 			args: args{
-				createObj: func() interface{} { return nil },
-				resultObj: func() interface{} { return nil },
-				resultMap: func() map[string]interface{} { return make(map[string]interface{}) },
+				createObj: func() any { return nil },
+				resultObj: func() any { return nil },
+				resultMap: func() map[string]any { return make(map[string]any) },
 				fields: Arguments{Argument{
 					Name:    "tupletype",
 					Type:    tupleType,
@@ -294,9 +294,9 @@ func setupTopicsTests() []topicTest {
 		{
 			name: "error on unindexed arguments",
 			args: args{
-				createObj: func() interface{} { return &int256Struct{} },
-				resultObj: func() interface{} { return &int256Struct{} },
-				resultMap: func() map[string]interface{} { return make(map[string]interface{}) },
+				createObj: func() any { return &int256Struct{} },
+				resultObj: func() any { return &int256Struct{} },
+				resultMap: func() map[string]any { return make(map[string]any) },
 				fields: Arguments{Argument{
 					Name:    "int256Value",
 					Type:    int256Type,
@@ -312,9 +312,9 @@ func setupTopicsTests() []topicTest {
 		{
 			name: "error on tuple in topic reconstruction",
 			args: args{
-				createObj: func() interface{} { return &tupleType },
-				resultObj: func() interface{} { return &tupleType },
-				resultMap: func() map[string]interface{} { return make(map[string]interface{}) },
+				createObj: func() any { return &tupleType },
+				resultObj: func() any { return &tupleType },
+				resultMap: func() map[string]any { return make(map[string]any) },
 				fields: Arguments{Argument{
 					Name:    "tupletype",
 					Type:    tupleType,
@@ -327,10 +327,10 @@ func setupTopicsTests() []topicTest {
 		{
 			name: "error on improper encoded function",
 			args: args{
-				createObj: func() interface{} { return &funcStruct{} },
-				resultObj: func() interface{} { return &funcStruct{} },
-				resultMap: func() map[string]interface{} {
-					return make(map[string]interface{})
+				createObj: func() any { return &funcStruct{} },
+				resultObj: func() any { return &funcStruct{} },
+				resultMap: func() map[string]any {
+					return make(map[string]any)
 				},
 				fields: Arguments{Argument{
 					Name:    "funcValue",
@@ -371,7 +371,7 @@ func TestParseTopicsIntoMap(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			outMap := make(map[string]interface{})
+			outMap := make(map[string]any)
 			if err := ParseTopicsIntoMap(outMap, tt.args.fields, tt.args.topics); (err != nil) != tt.wantErr {
 				t.Errorf("parseTopicsIntoMap() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/execution/abi/type_test.go
+++ b/execution/abi/type_test.go
@@ -123,7 +123,7 @@ func TestTypeCheck(t *testing.T) {
 	for i, test := range []struct {
 		typ        string
 		components []ArgumentMarshaling
-		input      interface{}
+		input      any
 		err        string
 	}{
 		{"uint", nil, big.NewInt(1), "unsupported arg type: uint"},

--- a/execution/abi/unpack.go
+++ b/execution/abi/unpack.go
@@ -37,7 +37,7 @@ var (
 )
 
 // ReadInteger reads the integer based on its kind and returns the appropriate value.
-func ReadInteger(typ Type, b []byte) interface{} {
+func ReadInteger(typ Type, b []byte) any {
 	if typ.T == UintTy {
 		switch typ.Size {
 		case 8:
@@ -110,7 +110,7 @@ func readFunctionType(t Type, word []byte) (funcTy [24]byte, err error) {
 }
 
 // ReadFixedBytes uses reflection to create a fixed array to be read from.
-func ReadFixedBytes(t Type, word []byte) (interface{}, error) {
+func ReadFixedBytes(t Type, word []byte) (any, error) {
 	if t.T != FixedBytesTy {
 		return nil, errors.New("abi: invalid type in call to make fixed byte array")
 	}
@@ -123,7 +123,7 @@ func ReadFixedBytes(t Type, word []byte) (interface{}, error) {
 }
 
 // forEachUnpack iteratively unpack elements.
-func forEachUnpack(t Type, output []byte, start, size int) (interface{}, error) {
+func forEachUnpack(t Type, output []byte, start, size int) (any, error) {
 	if size < 0 {
 		return nil, fmt.Errorf("cannot marshal input to array, size is negative (%d)", size)
 	}
@@ -162,7 +162,7 @@ func forEachUnpack(t Type, output []byte, start, size int) (interface{}, error) 
 	return refSlice.Interface(), nil
 }
 
-func forTupleUnpack(t Type, output []byte) (interface{}, error) {
+func forTupleUnpack(t Type, output []byte) (any, error) {
 	retval := reflect.New(t.GetType()).Elem()
 	virtualArgs := 0
 	for index, elem := range t.TupleElems {
@@ -194,7 +194,7 @@ func forTupleUnpack(t Type, output []byte) (interface{}, error) {
 
 // toGoType parses the output bytes and recursively assigns the value of these bytes
 // into a go type with accordance with the ABI spec.
-func toGoType(index int, t Type, output []byte) (interface{}, error) {
+func toGoType(index int, t Type, output []byte) (any, error) {
 	if index+32 > len(output) {
 		return nil, fmt.Errorf("abi: cannot marshal in to go type: length insufficient %d require %d", len(output), index+32)
 	}

--- a/execution/abi/unpack_test.go
+++ b/execution/abi/unpack_test.go
@@ -60,10 +60,10 @@ func TestUnpack(t *testing.T) {
 }
 
 type unpackTest struct {
-	def  string      // ABI definition JSON
-	enc  string      // evm return data
-	want interface{} // the expected output
-	err  string      // empty or error if expected
+	def  string // ABI definition JSON
+	enc  string // evm return data
+	want any    // the expected output
+	err  string // empty or error if expected
 }
 
 func (test unpackTest) checkError(err error) error {
@@ -326,16 +326,16 @@ func TestMethodMultiReturn(t *testing.T) {
 		Int    *big.Int
 	}
 
-	newInterfaceSlice := func(l int) interface{} {
-		slice := make([]interface{}, l)
+	newInterfaceSlice := func(l int) any {
+		slice := make([]any, l)
 		return &slice
 	}
 
 	abi, data, expected := methodMultiReturn(require.New(t))
 	bigint := new(big.Int)
 	var testCases = []struct {
-		dest     interface{}
-		expected interface{}
+		dest     any
+		expected any
 		error    string
 		name     string
 	}{{
@@ -349,33 +349,33 @@ func TestMethodMultiReturn(t *testing.T) {
 		"",
 		"Can unpack into reversed structure",
 	}, {
-		&[]interface{}{&bigint, new(string)},
-		&[]interface{}{&expected.Int, &expected.String},
+		&[]any{&bigint, new(string)},
+		&[]any{&expected.Int, &expected.String},
 		"",
 		"Can unpack into a slice",
 	}, {
-		&[2]interface{}{&bigint, new(string)},
-		&[2]interface{}{&expected.Int, &expected.String},
+		&[2]any{&bigint, new(string)},
+		&[2]any{&expected.Int, &expected.String},
 		"",
 		"Can unpack into an array",
 	}, {
-		&[2]interface{}{},
-		&[2]interface{}{expected.Int, expected.String},
+		&[2]any{},
+		&[2]any{expected.Int, expected.String},
 		"",
 		"Can unpack into interface array",
 	}, {
 		newInterfaceSlice(2),
-		&[]interface{}{expected.Int, expected.String},
+		&[]any{expected.Int, expected.String},
 		"",
 		"Can unpack into interface slice",
 	}, {
-		&[]interface{}{new(int), new(int)},
-		&[]interface{}{&expected.Int, &expected.String},
+		&[]any{new(int), new(int)},
+		&[]any{&expected.Int, &expected.String},
 		"abi: cannot unmarshal *big.Int in to int",
 		"Can not unpack into a slice with wrong types",
 	}, {
-		&[]interface{}{new(int)},
-		&[]interface{}{},
+		&[]any{new(int)},
+		&[]any{},
 		"abi: insufficient number of arguments for unpack, want 2, got 1",
 		"Can not unpack into a slice with wrong types",
 	}}
@@ -405,7 +405,7 @@ func TestMultiReturnWithArray(t *testing.T) {
 
 	ret1, ret1Exp := new([3]uint64), [3]uint64{9, 9, 9}
 	ret2, ret2Exp := new(uint64), uint64(8)
-	if err := abi.UnpackIntoInterface(&[]interface{}{ret1, ret2}, "multi", buff.Bytes()); err != nil {
+	if err := abi.UnpackIntoInterface(&[]any{ret1, ret2}, "multi", buff.Bytes()); err != nil {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(*ret1, ret1Exp) {
@@ -429,7 +429,7 @@ func TestMultiReturnWithStringArray(t *testing.T) {
 	ret2, ret2Exp := new(common.Address), common.HexToAddress("ab1257528b3782fb40d7ed5f72e624b744dffb2f")
 	ret3, ret3Exp := new([2]string), [2]string{"Ethereum", "Hello, Ethereum!"}
 	ret4, ret4Exp := new(bool), false
-	if err := abi.UnpackIntoInterface(&[]interface{}{ret1, ret2, ret3, ret4}, "multi", buff.Bytes()); err != nil {
+	if err := abi.UnpackIntoInterface(&[]any{ret1, ret2, ret3, ret4}, "multi", buff.Bytes()); err != nil {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(*ret1, ret1Exp) {
@@ -467,7 +467,7 @@ func TestMultiReturnWithStringSlice(t *testing.T) {
 	buff.Write(common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000065")) // output[1][1] value
 	ret1, ret1Exp := new([]string), []string{"ethereum", "go-ethereum"}
 	ret2, ret2Exp := new([]*big.Int), []*big.Int{big.NewInt(100), big.NewInt(101)}
-	if err := abi.UnpackIntoInterface(&[]interface{}{ret1, ret2}, "multi", buff.Bytes()); err != nil {
+	if err := abi.UnpackIntoInterface(&[]any{ret1, ret2}, "multi", buff.Bytes()); err != nil {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(*ret1, ret1Exp) {
@@ -507,7 +507,7 @@ func TestMultiReturnWithDeeplyNestedArray(t *testing.T) {
 		{{0x411, 0x412, 0x413}, {0x421, 0x422, 0x423}},
 	}
 	ret2, ret2Exp := new(uint64), uint64(0x9876)
-	if err := abi.UnpackIntoInterface(&[]interface{}{ret1, ret2}, "multi", buff.Bytes()); err != nil {
+	if err := abi.UnpackIntoInterface(&[]any{ret1, ret2}, "multi", buff.Bytes()); err != nil {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(*ret1, ret1Exp) {
@@ -539,7 +539,7 @@ func TestUnmarshal(t *testing.T) {
 	// marshall mixed bytes (mixedBytes)
 	p0, p0Exp := []byte{}, common.Hex2Bytes("01020000000000000000")
 	p1, p1Exp := [32]byte{}, common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000ddeeff")
-	mixedBytes := []interface{}{&p0, &p1}
+	mixedBytes := []any{&p0, &p1}
 
 	buff.Write(common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000040"))
 	buff.Write(common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000ddeeff"))

--- a/execution/commitment/trie/trie_test.go
+++ b/execution/commitment/trie/trie_test.go
@@ -237,7 +237,7 @@ func BenchmarkHash(b *testing.B) {
 			root    = EmptyRoot
 			code    = crypto.Keccak256(nil)
 		)
-		accounts[i], _ = rlp.EncodeToBytes([]interface{}{nonce, balance, root, code})
+		accounts[i], _ = rlp.EncodeToBytes([]any{nonce, balance, root, code})
 	}
 	// Insert the accounts into the trie and hash it
 	trie := newEmpty()

--- a/execution/engineapi/engine_block_downloader/block_downloader.go
+++ b/execution/engineapi/engine_block_downloader/block_downloader.go
@@ -196,7 +196,7 @@ func (e *EngineBlockDownloader) downloadBlocks(ctx context.Context, req Backward
 	var blocks []*types.Block
 	var insertedBlocksWithoutExec int
 	for blocks, err = feed.Next(ctx); err == nil && len(blocks) > 0; blocks, err = feed.Next(ctx) {
-		progressLogArgs := []interface{}{
+		progressLogArgs := []any{
 			"from", blocks[0].NumberU64(),
 			"fromHash", blocks[0].Hash(),
 			"to", blocks[len(blocks)-1].NumberU64(),

--- a/execution/engineapi/engine_block_downloader/download_request.go
+++ b/execution/engineapi/engine_block_downloader/download_request.go
@@ -15,8 +15,8 @@ type BackwardDownloadRequest struct {
 	ValidateChainTip *types.Block
 }
 
-func (r BackwardDownloadRequest) LogArgs() []interface{} {
-	args := []interface{}{"hash", r.MissingHash, "trigger", r.Trigger}
+func (r BackwardDownloadRequest) LogArgs() []any {
+	args := []any{"hash", r.MissingHash, "trigger", r.Trigger}
 	if r.ValidateChainTip != nil {
 		args = append(args, "chainTipNum", r.ValidateChainTip.Number().Uint64(), "chainTipHash", r.ValidateChainTip.Hash())
 	}

--- a/execution/execmodule/forkchoice.go
+++ b/execution/execmodule/forkchoice.go
@@ -615,7 +615,7 @@ func (e *EthereumExecutionModule) runPostForkchoiceInBackground(initialCycle boo
 	}
 	go func() {
 		defer e.doingPostForkchoice.Store(false)
-		var timings []interface{}
+		var timings []any
 		// Wait for semaphore to be available
 		if e.semaphore.Acquire(e.bacgroundCtx, 1) != nil {
 			return
@@ -650,7 +650,7 @@ func (e *EthereumExecutionModule) logHeadUpdated(blockHash common.Hash, fcuHeade
 	dbg.ReadMemStats(&m)
 	blockTimings := e.forkValidator.GetTimings(blockHash)
 
-	logArgs := []interface{}{"hash", blockHash, "number", fcuHeader.Number.Uint64()}
+	logArgs := []any{"hash", blockHash, "number", fcuHeader.Number.Uint64()}
 	if txnum != 0 {
 		logArgs = append(logArgs, "txnum", txnum)
 	}

--- a/execution/p2p/bbd.go
+++ b/execution/p2p/bbd.go
@@ -296,7 +296,7 @@ func (bbd *BackwardBlockDownloader) downloadHeaderChainBackwards(
 			)
 		}
 
-		progressLogArgs := []interface{}{
+		progressLogArgs := []any{
 			"num", parentNum,
 			"hash", parentHash,
 			"amount", amount,
@@ -415,7 +415,7 @@ func (bbd *BackwardBlockDownloader) downloadBlocksForHeaders(
 	}
 	batchSize := (len(headers) + len(availablePeers) - 1) / len(availablePeers)
 	batchesCount := (len(headers) + batchSize - 1) / batchSize
-	progressLogArgs := []interface{}{
+	progressLogArgs := []any{
 		"fromNum", headers[0].Number.Uint64(),
 		"fromHash", headers[0].Hash(),
 		"toNum", headers[len(headers)-1].Number.Uint64(),

--- a/execution/protocol/aa/aa_exec.go
+++ b/execution/protocol/aa/aa_exec.go
@@ -422,7 +422,7 @@ type ValidationPhaseError struct {
 	frameReverted    bool
 }
 
-func (v *ValidationPhaseError) ErrorData() interface{} {
+func (v *ValidationPhaseError) ErrorData() any {
 	return v.reason
 }
 

--- a/execution/protocol/block_exec.go
+++ b/execution/protocol/block_exec.go
@@ -240,7 +240,7 @@ func logReceipts(receipts types.Receipts, txns types.Transactions, cc *chain.Con
 		return ""
 	}
 
-	marshalled := make([]map[string]interface{}, 0, len(receipts))
+	marshalled := make([]map[string]any, 0, len(receipts))
 	for i, receipt := range receipts {
 		txn := txns[i]
 		marshalled = append(marshalled, ethutils.MarshalReceipt(receipt, txn, cc, header, txn.Hash(), true, false))
@@ -255,7 +255,7 @@ func logReceipts(receipts types.Receipts, txns types.Transactions, cc *chain.Con
 	return string(result)
 }
 
-func rlpHash(x interface{}) (h common.Hash) {
+func rlpHash(x any) (h common.Hash) {
 	hw := sha3.NewLegacyKeccak256()
 	rlp.Encode(hw, x) //nolint:errcheck
 	hw.Sum(h[:0])

--- a/execution/protocol/rules/aura/aurainterfaces/interface.go
+++ b/execution/protocol/rules/aura/aurainterfaces/interface.go
@@ -28,7 +28,7 @@ type BlockRewardABI interface {
 	Reward(benefactors []common.Address, kind []rules.RewardKind) ([]common.Address, []*uint256.Int, error)
 }
 
-type abiDecoder func([]byte, interface{}) error
+type abiDecoder func([]byte, any) error
 
 // see openethereum/crates/ethcore/res/contracts/validator_set.json
 type ValidatorSetABI interface {

--- a/execution/protocol/rules/clique/clique.go
+++ b/execution/protocol/rules/clique/clique.go
@@ -571,7 +571,7 @@ func CliqueRLP(header *types.Header) []byte {
 }
 
 func encodeSigHeader(w io.Writer, header *types.Header) {
-	enc := []interface{}{
+	enc := []any{
 		header.ParentHash,
 		header.UncleHash,
 		header.Coinbase,

--- a/execution/protocol/rules/ethash/algorithm.go
+++ b/execution/protocol/rules/ethash/algorithm.go
@@ -282,13 +282,13 @@ func fnvHash32(mix []uint32, data []uint32) {
 }
 
 var bytes64Pool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		buf := make([]byte, hashBytes)
 		return &buf
 	},
 }
 var bytes40Pool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		buf := make([]byte, 40)
 		return &buf
 	},

--- a/execution/protocol/rules/ethash/ethash.go
+++ b/execution/protocol/rules/ethash/ethash.go
@@ -184,22 +184,22 @@ func memoryMapAndGenerate(path string, size uint64, lock bool, generator func(bu
 // lru tracks caches or datasets by their last use time, keeping at most N of them.
 type lru struct {
 	what string
-	new  func(epoch uint64) interface{}
+	new  func(epoch uint64) any
 	mu   sync.Mutex
 	// Items are kept in a LRU cache, but there is a special case:
 	// We always keep an item for (highest seen epoch) + 1 as the 'future item'.
 	cache      *simplelru.LRU[uint64, any]
 	future     uint64
-	futureItem interface{}
+	futureItem any
 }
 
 // newlru create a new least-recently-used cache for either the verification caches
 // or the mining datasets.
-func newlru(what string, maxItems int, new func(epoch uint64) interface{}) *lru {
+func newlru(what string, maxItems int, new func(epoch uint64) any) *lru {
 	if maxItems <= 0 {
 		maxItems = 1
 	}
-	cache, _ := simplelru.NewLRU[uint64, any](maxItems, func(key uint64, value interface{}) {
+	cache, _ := simplelru.NewLRU[uint64, any](maxItems, func(key uint64, value any) {
 		log.Trace("Evicted ethash "+what, "epoch", key)
 	})
 	return &lru{what: what, new: new, cache: cache}
@@ -208,7 +208,7 @@ func newlru(what string, maxItems int, new func(epoch uint64) interface{}) *lru 
 // get retrieves or creates an item for the given epoch. The first return value is always
 // non-nil. The second return value is non-nil if lru thinks that an item will be useful in
 // the near future.
-func (lru *lru) get(epoch uint64) (item, future interface{}) {
+func (lru *lru) get(epoch uint64) (item, future any) {
 	lru.mu.Lock()
 	defer lru.mu.Unlock()
 
@@ -244,7 +244,7 @@ type cache struct {
 
 // newCache creates a new ethash verification cache and returns it as a plain Go
 // interface to be usable in an LRU cache.
-func newCache(epoch uint64) interface{} {
+func newCache(epoch uint64) any {
 	return &cache{epoch: epoch}
 }
 
@@ -322,7 +322,7 @@ type dataset struct {
 
 // newDataset creates a new ethash mining dataset and returns it as a plain Go
 // interface to be usable in an LRU cache.
-func newDataset(epoch uint64) interface{} {
+func newDataset(epoch uint64) any {
 	return &dataset{epoch: epoch}
 }
 

--- a/execution/protocol/rules/ethash/rules.go
+++ b/execution/protocol/rules/ethash/rules.go
@@ -599,7 +599,7 @@ func (ethash *Ethash) FinalizeAndAssemble(chainConfig *chain.Config, header *typ
 func (ethash *Ethash) SealHash(header *types.Header) (hash common.Hash) {
 	hasher := sha3.NewLegacyKeccak256()
 
-	enc := []interface{}{
+	enc := []any{
 		header.ParentHash,
 		header.UncleHash,
 		header.Coinbase,

--- a/execution/rlp/decode.go
+++ b/execution/rlp/decode.go
@@ -61,7 +61,7 @@ var (
 	errDecodeIntoNil = errors.New("rlp: pointer given to Decode must not be nil")
 
 	streamPool = sync.Pool{
-		New: func() interface{} { return new(Stream) },
+		New: func() any { return new(Stream) },
 	}
 )
 
@@ -106,7 +106,7 @@ type Decoder interface {
 // panics cause by huge value sizes. If you need an input limit, use
 //
 //	NewStream(r, limit).Decode(val)
-func Decode(r io.Reader, val interface{}) error {
+func Decode(r io.Reader, val any) error {
 	stream, ok := streamPool.Get().(*Stream)
 	if !ok {
 		log.Warn("Failed to type convert to Stream pointer")
@@ -119,7 +119,7 @@ func Decode(r io.Reader, val interface{}) error {
 
 // DecodeBytes parses RLP data from b into val. Please see package-level documentation for
 // the decoding rules. The input must contain exactly one value and no trailing data.
-func DecodeBytes(b []byte, val interface{}) error {
+func DecodeBytes(b []byte, val any) error {
 	r := (*sliceReader)(&b)
 
 	stream, ok := streamPool.Get().(*Stream)
@@ -138,7 +138,7 @@ func DecodeBytes(b []byte, val interface{}) error {
 	return nil
 }
 
-func DecodeBytesPartial(b []byte, val interface{}) error {
+func DecodeBytesPartial(b []byte, val any) error {
 	r := (*sliceReader)(&b)
 
 	stream, ok := streamPool.Get().(*Stream)
@@ -577,7 +577,7 @@ func makeNilPtrDecoder(etype reflect.Type, etypeinfo *typeinfo, nilKind Kind) de
 	}
 }
 
-var ifsliceType = reflect.TypeFor[[]interface{}]()
+var ifsliceType = reflect.TypeFor[[]any]()
 
 func decodeInterface(s *Stream, val reflect.Value) error {
 	if val.Type().NumMethod() != 0 {
@@ -1001,7 +1001,7 @@ func (s *Stream) ListEnd() error {
 // Decode decodes a value and stores the result in the value pointed
 // to by val. Please see the documentation for the Decode function
 // to learn about the decoding rules.
-func (s *Stream) Decode(val interface{}) error {
+func (s *Stream) Decode(val any) error {
 	if val == nil {
 		return errDecodeIntoNil
 	}

--- a/execution/rlp/decode_test.go
+++ b/execution/rlp/decode_test.go
@@ -315,8 +315,8 @@ func TestDecodeErrors(t *testing.T) {
 
 type decodeTest struct {
 	input string
-	ptr   interface{}
-	value interface{}
+	ptr   any
+	value any
 	error string
 }
 
@@ -560,7 +560,7 @@ var decodeTests = []decodeTest{
 	{
 		input: "C103",
 		ptr:   new(intField),
-		value: func() interface{} {
+		value: func() any {
 			return intField{X: 3}
 		}(),
 	},
@@ -628,7 +628,7 @@ var decodeTests = []decodeTest{
 	{
 		input: "C103",
 		ptr:   new(nilListUint),
-		value: func() interface{} {
+		value: func() any {
 			v := uint(3)
 			return nilListUint{X: &v}
 		}(),
@@ -774,12 +774,12 @@ var decodeTests = []decodeTest{
 	{input: "C3808005", ptr: new([]*uint), value: []*uint{uintp(0), uintp(0), uintp(5)}},
 
 	// interface{}
-	{input: "00", ptr: new(interface{}), value: []byte{0}},
-	{input: "01", ptr: new(interface{}), value: []byte{1}},
-	{input: "80", ptr: new(interface{}), value: []byte{}},
-	{input: "850505050505", ptr: new(interface{}), value: []byte{5, 5, 5, 5, 5}},
-	{input: "C0", ptr: new(interface{}), value: []interface{}{}},
-	{input: "C50183040404", ptr: new(interface{}), value: []interface{}{[]byte{1}, []byte{4, 4, 4}}},
+	{input: "00", ptr: new(any), value: []byte{0}},
+	{input: "01", ptr: new(any), value: []byte{1}},
+	{input: "80", ptr: new(any), value: []byte{}},
+	{input: "850505050505", ptr: new(any), value: []byte{5, 5, 5, 5, 5}},
+	{input: "C0", ptr: new(any), value: []any{}},
+	{input: "C50183040404", ptr: new(any), value: []any{[]byte{1}, []byte{4, 4, 4}}},
 	{
 		input: "C3010203",
 		ptr:   new([]io.Reader),
@@ -789,14 +789,14 @@ var decodeTests = []decodeTest{
 	// fuzzer crashes
 	{
 		input: "c330f9c030f93030ce3030303030303030bd303030303030",
-		ptr:   new(interface{}),
+		ptr:   new(any),
 		error: "rlp: element is larger than containing list",
 	},
 }
 
 func uintp(i uint) *uint { return &i }
 
-func runTests(t *testing.T, decode func([]byte, interface{}) error) {
+func runTests(t *testing.T, decode func([]byte, any) error) {
 	for i, test := range decodeTests {
 		input, err := hex.DecodeString(test.input)
 		if err != nil {
@@ -823,7 +823,7 @@ func runTests(t *testing.T, decode func([]byte, interface{}) error) {
 }
 
 func TestDecodeWithByteReader(t *testing.T) {
-	runTests(t, func(input []byte, into interface{}) error {
+	runTests(t, func(input []byte, into any) error {
 		return DecodeBytes(input, into)
 	})
 }
@@ -868,14 +868,14 @@ func (r *plainReader) Read(buf []byte) (n int, err error) {
 }
 
 func TestDecodeWithNonByteReader(t *testing.T) {
-	runTests(t, func(input []byte, into interface{}) error {
+	runTests(t, func(input []byte, into any) error {
 		return Decode(newPlainReader(input), into)
 	})
 }
 
 func TestDecodeStreamReset(t *testing.T) {
 	s := NewStream(nil, 0)
-	runTests(t, func(input []byte, into interface{}) error {
+	runTests(t, func(input []byte, into any) error {
 		s.Reset(bytes.NewReader(input), 0)
 		return s.Decode(into)
 	})
@@ -1001,7 +1001,7 @@ func TestInvalidOptionalField(t *testing.T) {
 	)
 
 	tests := []struct {
-		v   interface{}
+		v   any
 		err string
 	}{
 		{v: new(invalid1), err: `rlp: struct field rlp.invalid1.B needs "optional" tag`},

--- a/execution/rlp/encbuffer.go
+++ b/execution/rlp/encbuffer.go
@@ -35,7 +35,7 @@ type encBuffer struct {
 
 // encbufs are pooled.
 var encBufferPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		var bytes []byte
 		return &encBuffer{bufvalue: reflect.ValueOf(&bytes).Elem()}
 	},
@@ -53,7 +53,7 @@ func (w *encBuffer) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 
-func (w *encBuffer) encode(val interface{}) error {
+func (w *encBuffer) encode(val any) error {
 	rval := reflect.ValueOf(val)
 	writer, err := cachedWriter(rval.Type())
 	if err != nil {

--- a/execution/rlp/encode.go
+++ b/execution/rlp/encode.go
@@ -68,7 +68,7 @@ type Encoder interface {
 // buffered.
 //
 // Please see package-level documentation of encoding rules.
-func Encode(w io.Writer, val interface{}) error {
+func Encode(w io.Writer, val any) error {
 	if outer, ok := w.(*encBuffer); ok {
 		// Encode was called by some type's EncodeRLP.
 		// Avoid copying by writing to the outer encBuffer directly.
@@ -97,7 +97,7 @@ func Write(w io.Writer, val []byte) error {
 
 // EncodeToBytes returns the RLP encoding of val.
 // Please see package-level documentation for the encoding rules.
-func EncodeToBytes(val interface{}) ([]byte, error) {
+func EncodeToBytes(val any) ([]byte, error) {
 	eb := encBufferPool.Get().(*encBuffer)
 	defer encBufferPool.Put(eb)
 	eb.reset()
@@ -112,7 +112,7 @@ func EncodeToBytes(val interface{}) ([]byte, error) {
 // data.
 //
 // Please see the documentation of Encode for the encoding rules.
-func EncodeToReader(val interface{}) (size int, r io.Reader, err error) {
+func EncodeToReader(val any) (size int, r io.Reader, err error) {
 	eb := encBufferPool.Get().(*encBuffer)
 	eb.reset()
 	if err := eb.encode(val); err != nil {

--- a/execution/rlp/encode_test.go
+++ b/execution/rlp/encode_test.go
@@ -95,7 +95,7 @@ var (
 )
 
 type encTest struct {
-	val           interface{}
+	val           any
 	output, error string
 }
 
@@ -229,7 +229,7 @@ var encTests = []encTest{
 	{val: []uint{1, 2, 3}, output: "C3010203"},
 	{
 		// [ [], [[]], [ [], [[]] ] ]
-		val:    []interface{}{[]interface{}{}, [][]interface{}{{}}, []interface{}{[]interface{}{}, [][]interface{}{{}}}},
+		val:    []any{[]any{}, [][]any{{}}, []any{[]any{}, [][]any{{}}}},
 		output: "C7C0C1C0C3C0C1C0",
 	},
 	{
@@ -237,7 +237,7 @@ var encTests = []encTest{
 		output: "F83C836161618362626283636363836464648365656583666666836767678368686883696969836A6A6A836B6B6B836C6C6C836D6D6D836E6E6E836F6F6F",
 	},
 	{
-		val:    []interface{}{uint(1), uint(0xFFFFFF), []interface{}{[]uint{4, 5, 5}}, "abc"},
+		val:    []any{uint(1), uint(0xFFFFFF), []any{[]uint{4, 5, 5}}, "abc"},
 		output: "CE0183FFFFFFC4C304050583616263",
 	},
 	{
@@ -323,9 +323,9 @@ var encTests = []encTest{
 	{val: (*uint256.Int)(nil), output: "80"},
 	{val: (*[]string)(nil), output: "C0"},
 	{val: (*[10]string)(nil), output: "C0"},
-	{val: (*[]interface{})(nil), output: "C0"},
+	{val: (*[]any)(nil), output: "C0"},
 	{val: (*[]struct{ uint })(nil), output: "C0"},
-	{val: (*interface{})(nil), output: "C0"},
+	{val: (*any)(nil), output: "C0"},
 
 	// nil struct fields
 	{
@@ -390,7 +390,7 @@ var encTests = []encTest{
 	{val: []byteEncoder{0, 1, 2, 3, 4}, output: "C5C0C0C0C0C0"},
 }
 
-func runEncTests(t *testing.T, f func(val interface{}) ([]byte, error)) {
+func runEncTests(t *testing.T, f func(val any) ([]byte, error)) {
 	for i, test := range encTests {
 		output, err := f(test.val)
 		if err != nil && test.error == "" {
@@ -411,7 +411,7 @@ func runEncTests(t *testing.T, f func(val interface{}) ([]byte, error)) {
 }
 
 func TestEncode(t *testing.T) {
-	runEncTests(t, func(val interface{}) ([]byte, error) {
+	runEncTests(t, func(val any) ([]byte, error) {
 		b := new(bytes.Buffer)
 		err := Encode(b, val)
 		return b.Bytes(), err
@@ -423,7 +423,7 @@ func TestEncodeToBytes(t *testing.T) {
 }
 
 func TestEncodeToReader(t *testing.T) {
-	runEncTests(t, func(val interface{}) ([]byte, error) {
+	runEncTests(t, func(val any) ([]byte, error) {
 		_, r, err := EncodeToReader(val)
 		if err != nil {
 			return nil, err
@@ -433,7 +433,7 @@ func TestEncodeToReader(t *testing.T) {
 }
 
 func TestEncodeToReaderPiecewise(t *testing.T) {
-	runEncTests(t, func(val interface{}) ([]byte, error) {
+	runEncTests(t, func(val any) ([]byte, error) {
 		size, r, err := EncodeToReader(val)
 		if err != nil {
 			return nil, err
@@ -481,7 +481,7 @@ func TestEncodeToReaderReturnToPool(t *testing.T) {
 	wg.Wait()
 }
 
-var sink interface{}
+var sink any
 
 func BenchmarkIntsize(b *testing.B) {
 	for b.Loop() {
@@ -578,7 +578,7 @@ func BenchmarkEncodeConcurrentInterface(b *testing.B) {
 		B *big.Int
 		C [20]byte
 	}
-	value := []interface{}{
+	value := []any{
 		uint(999),
 		&struct1{A: "hello", B: big.NewInt(0xFFFFFFFF)},
 		[10]byte{1, 2, 3, 4, 5, 6},

--- a/execution/stagedsync/exec3_metrics.go
+++ b/execution/stagedsync/exec3_metrics.go
@@ -509,7 +509,7 @@ func (p *Progress) LogExecution(rs *state.StateV3, ex executor) {
 	seconds := interval.Seconds()
 
 	var suffix string
-	var execVals []interface{}
+	var execVals []any
 	var te *txExecutor
 
 	switch ex := ex.(type) {
@@ -633,7 +633,7 @@ func (p *Progress) LogExecution(rs *state.StateV3, ex executor) {
 		mxTaskMgasSec.Set(float64(curTaskGasPerSec / 1e6))
 		mxExecCPUs.Set(float64(curTaskDur) / float64(interval))
 
-		execVals = []interface{}{
+		execVals = []any{
 			"exec", common.PrettyCounter(execDiff),
 			"repeat%", fmt.Sprintf("%.2f", repeatRatio),
 			"abort", common.PrettyCounter(abortCount - p.prevAbortCount),
@@ -664,7 +664,7 @@ func (p *Progress) LogExecution(rs *state.StateV3, ex executor) {
 		curReadCount := readCount - p.prevReadCount
 		p.prevReadCount = readCount
 
-		execVals = []interface{}{
+		execVals = []any{
 			"tgas/s", fmt.Sprintf("%s(%s)", common.PrettyCounter(curTaskGasPerSec), common.PrettyCounter(avgTaskGasPerSec)),
 			"aratio", fmt.Sprintf("%.1f", float64(curTaskDur)/float64(interval)),
 			"tdur", common.Round(avgTaskDur, 0),
@@ -859,7 +859,7 @@ func (p *Progress) LogComplete(rs *state.StateV3, ex executor, stepsInDb float64
 }
 
 func (p *Progress) log(mode string, suffix string, te *txExecutor, rs *state.StateV3, interval time.Duration,
-	blk uint64, blks int64, txs uint64, txsSec uint64, gasSec uint64, uncommitedGas uint64, stepsInDb float64, extraVals []interface{}) {
+	blk uint64, blks int64, txs uint64, txsSec uint64, gasSec uint64, uncommitedGas uint64, stepsInDb float64, extraVals []any) {
 
 	var m runtime.MemStats
 	dbg.ReadMemStats(&m)
@@ -869,13 +869,13 @@ func (p *Progress) log(mode string, suffix string, te *txExecutor, rs *state.Sta
 		suffix += " "
 	}
 
-	var vals []interface{}
+	var vals []any
 
 	if mode == "done" {
-		vals = []interface{}{"in", interval}
+		vals = []any{"in", interval}
 	}
 
-	vals = append(vals, []interface{}{
+	vals = append(vals, []any{
 		"blk", blk,
 		"blks", blks,
 		"blk/s", common.PrettyCounter(float64(blks) / interval.Seconds()),
@@ -889,19 +889,19 @@ func (p *Progress) log(mode string, suffix string, te *txExecutor, rs *state.Sta
 	}
 
 	if stepsInDb > 0 {
-		vals = append(vals, []interface{}{
+		vals = append(vals, []any{
 			"stepsInDB", fmt.Sprintf("%.2f", stepsInDb),
 			"step", fmt.Sprintf("%.1f", float64(te.lastCommittedTxNum)/float64(te.agg.StepSize())),
 		}...)
 	}
 
 	if uncommitedGas > 0 {
-		vals = append(vals, []interface{}{
+		vals = append(vals, []any{
 			"ucgas", common.PrettyCounter(uncommitedGas),
 		}...)
 	}
 
-	vals = append(vals, []interface{}{
+	vals = append(vals, []any{
 		"alloc", common.ByteCount(m.Alloc), "sys", common.ByteCount(m.Sys),
 		"inMem", te.inMemExec,
 	}...)

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -877,8 +877,7 @@ func (pe *parallelExecutor) wait(ctx context.Context) error {
 	}
 }
 
-type applyResult interface {
-}
+type applyResult any
 
 type blockResult struct {
 	BlockNum    uint64

--- a/execution/stagedsync/headerdownload/header_data_struct.go
+++ b/execution/stagedsync/headerdownload/header_data_struct.go
@@ -110,7 +110,7 @@ func (lq LinkQueue) Swap(i, j int) {
 }
 
 // Push (part of heap.Interface) places a new link onto the end of queue. Note that idx attribute is set to the correct position of the new link
-func (lq *LinkQueue) Push(x interface{}) {
+func (lq *LinkQueue) Push(x any) {
 	// Push and Pop use pointer receivers because they modify the slice's length,
 	// not just its contents.
 	l := x.(*Link)
@@ -119,7 +119,7 @@ func (lq *LinkQueue) Push(x interface{}) {
 }
 
 // Pop (part of heap.Interface) removes the first link from the queue
-func (lq *LinkQueue) Pop() interface{} {
+func (lq *LinkQueue) Pop() any {
 	old := *lq
 	n := len(old)
 	x := old[n-1]
@@ -233,14 +233,14 @@ func (iq InsertQueue) Swap(i, j int) {
 	iq[i].idx, iq[j].idx = i, j // Restore indices after the swap
 }
 
-func (iq *InsertQueue) Push(x interface{}) {
+func (iq *InsertQueue) Push(x any) {
 	// Push and Pop use pointer receivers because they modify the slice's length,
 	// not just its contents.
 	x.(*Link).idx = len(*iq)
 	*iq = append(*iq, x.(*Link))
 }
 
-func (iq *InsertQueue) Pop() interface{} {
+func (iq *InsertQueue) Pop() any {
 	old := *iq
 	n := len(old)
 	x := old[n-1]

--- a/execution/stagedsync/stage_senders.go
+++ b/execution/stagedsync/stage_senders.go
@@ -345,8 +345,8 @@ Loop:
 	} else {
 		if err := collectorSenders.Load(tx, kv.Senders, etl.IdentityLoadFunc, etl.TransformArgs{
 			Quit: quitCh,
-			LogDetailsLoad: func(k, v []byte) (additionalLogArguments []interface{}) {
-				return []interface{}{"block", binary.BigEndian.Uint64(k)}
+			LogDetailsLoad: func(k, v []byte) (additionalLogArguments []any) {
+				return []any{"block", binary.BigEndian.Uint64(k)}
 			},
 		}); err != nil {
 			return err

--- a/execution/stagedsync/stage_txlookup.go
+++ b/execution/stagedsync/stage_txlookup.go
@@ -169,8 +169,8 @@ func txnLookupTransform(logPrefix string, tx kv.RwTx, blockFrom, blockTo uint64,
 		Quit:            ctx.Done(),
 		ExtractStartKey: hexutil.EncodeTs(blockFrom),
 		ExtractEndKey:   hexutil.EncodeTs(blockTo),
-		LogDetailsExtract: func(k, v []byte) (additionalLogArguments []interface{}) {
-			return []interface{}{"block", binary.BigEndian.Uint64(k)}
+		LogDetailsExtract: func(k, v []byte) (additionalLogArguments []any) {
+			return []any{"block", binary.BigEndian.Uint64(k)}
 		},
 	}, logger)
 }
@@ -340,8 +340,8 @@ func deleteTxLookupRange(tx kv.RwTx, logPrefix string, blockFrom, blockTo uint64
 		Quit:            ctx.Done(),
 		ExtractStartKey: hexutil.EncodeTs(blockFrom),
 		ExtractEndKey:   hexutil.EncodeTs(blockTo),
-		LogDetailsExtract: func(k, v []byte) (additionalLogArguments []interface{}) {
-			return []interface{}{"block", binary.BigEndian.Uint64(k)}
+		LogDetailsExtract: func(k, v []byte) (additionalLogArguments []any) {
+			return []any{"block", binary.BigEndian.Uint64(k)}
 		},
 	}, logger)
 	if err != nil {

--- a/execution/stagedsync/sync.go
+++ b/execution/stagedsync/sync.go
@@ -510,8 +510,8 @@ func (s *Sync) RunPrune(db kv.RwDB, tx kv.RwTx, initialCycle bool) error {
 	return nil
 }
 
-func (s *Sync) PrintTimings() []interface{} {
-	var logCtx []interface{}
+func (s *Sync) PrintTimings() []any {
+	var logCtx []any
 	count := 0
 	for i := range s.timings {
 		if s.timings[i].took < 100*time.Millisecond {

--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -112,7 +112,7 @@ func (r *revisions) revertToSnapshot(revid int) int {
 }
 
 var revisionsPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &revisions{0, make([]revision, 0, 2048)}
 	},
 }

--- a/execution/state/intra_block_state_test.go
+++ b/execution/state/intra_block_state_test.go
@@ -279,7 +279,7 @@ func (test *snapshotTest) run(t *testing.T) bool {
 func (test *snapshotTest) checkEqual(state, checkstate *IntraBlockState) error {
 	for _, addr := range test.addrs {
 		var err error
-		checkeq := func(op string, a, b interface{}) bool {
+		checkeq := func(op string, a, b any) bool {
 			if err == nil && !reflect.DeepEqual(a, b) {
 				err = fmt.Errorf("got %s(%s) == %v, want %v", op, addr, a, b)
 				return false

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -151,7 +151,7 @@ type VersionedRead struct {
 	Key     accounts.StorageKey
 	Source  ReadSource
 	Version Version
-	Val     interface{}
+	Val     any
 }
 
 func (vr VersionedRead) String() string {
@@ -163,7 +163,7 @@ type VersionedWrite struct {
 	Path    AccountPath
 	Key     accounts.StorageKey
 	Version Version
-	Val     interface{}
+	Val     any
 	Reason  tracing.BalanceChangeReason
 }
 

--- a/execution/state/versionmap.go
+++ b/execution/state/versionmap.go
@@ -117,7 +117,7 @@ func (vm *VersionMap) WriteChanges(changes []*types.AccountChanges) {
 
 }
 
-func (vm *VersionMap) Write(addr accounts.Address, path AccountPath, key accounts.StorageKey, v Version, data interface{}, complete bool) {
+func (vm *VersionMap) Write(addr accounts.Address, path AccountPath, key accounts.StorageKey, v Version, data any, complete bool) {
 	vm.mu.Lock()
 	defer vm.mu.Unlock()
 
@@ -371,7 +371,7 @@ func (vm *VersionMap) ValidateVersion(txIdx int, lastIO *VersionedIO, checkVersi
 type WriteCell struct {
 	flag        statusFlag
 	incarnation int
-	data        interface{}
+	data        any
 }
 
 type Version struct {
@@ -392,7 +392,7 @@ const (
 type ReadResult struct {
 	depIdx      int
 	incarnation int
-	value       interface{}
+	value       any
 }
 
 func (res *ReadResult) DepIdx() int {
@@ -403,7 +403,7 @@ func (res *ReadResult) Incarnation() int {
 	return res.incarnation
 }
 
-func (res *ReadResult) Value() interface{} {
+func (res *ReadResult) Value() any {
 	return res.value
 }
 

--- a/execution/tests/init_test.go
+++ b/execution/tests/init_test.go
@@ -43,7 +43,7 @@ var (
 	cornersDir = filepath.Join(".", "test-corners")
 )
 
-func readJSONFile(fn string, value interface{}) error {
+func readJSONFile(fn string, value any) error {
 	data, err := os.ReadFile(fn)
 	if err != nil {
 		return fmt.Errorf("error reading JSON file: %w", err)
@@ -168,7 +168,7 @@ func (tm *testMatcher) checkFailureWithName(t *testing.T, name string, err error
 //
 // runTest should be a function of type func(t *testing.T, name string, x <TestType>),
 // where TestType is the type of the test contained in test files.
-func (tm *testMatcher) walk(t *testing.T, dir string, runTest interface{}) {
+func (tm *testMatcher) walk(t *testing.T, dir string, runTest any) {
 	// Walk the directory.
 	dirinfo, err := os.Stat(dir)
 	if os.IsNotExist(err) || !dirinfo.IsDir() {
@@ -203,7 +203,7 @@ func (tm *testMatcher) walk(t *testing.T, dir string, runTest interface{}) {
 	//panic(fmt.Sprintf("[dbg] mem info: alloc=%s, sys=%s", common.ByteCount(m.Alloc), common.ByteCount(m.Sys)))
 }
 
-func (tm *testMatcher) runTestFile(t *testing.T, path, name string, runTest interface{}) {
+func (tm *testMatcher) runTestFile(t *testing.T, path, name string, runTest any) {
 	t.Parallel()
 	if r, _ := tm.findSkip(name); r != "" {
 		t.Skip(r)
@@ -243,7 +243,7 @@ func (tm *testMatcher) runTestFile(t *testing.T, path, name string, runTest inte
 	}
 }
 
-func makeMapFromTestFunc(f interface{}) reflect.Value {
+func makeMapFromTestFunc(f any) reflect.Value {
 	stringT := reflect.TypeFor[string]()
 	testingT := reflect.TypeFor[*testing.T]()
 	ftyp := reflect.TypeOf(f)
@@ -264,7 +264,7 @@ func sortedMapKeys(m reflect.Value) []string {
 	return keys
 }
 
-func runTestFunc(runTest interface{}, t *testing.T, name string, m reflect.Value, key string) {
+func runTestFunc(runTest any, t *testing.T, name string, m reflect.Value, key string) {
 	reflect.ValueOf(runTest).Call([]reflect.Value{
 		reflect.ValueOf(t),
 		reflect.ValueOf(name),

--- a/execution/tests/statedb_insert_chain_transaction_test.go
+++ b/execution/tests/statedb_insert_chain_transaction_test.go
@@ -949,7 +949,7 @@ func getBlockDeployTestContractTx(transactOpts *bind.TransactOpts, contractAddre
 	}
 }
 
-func getBlockTestContractTx(transactOpts *bind.TransactOpts, contractCall interface{}, newBalance ...*big.Int) blockTx {
+func getBlockTestContractTx(transactOpts *bind.TransactOpts, contractCall any, newBalance ...*big.Int) blockTx {
 	return func(_ *blockgen.BlockGen, backend bind.ContractBackend) (types.Transaction, bool) {
 		var (
 			tx  types.Transaction

--- a/execution/tests/testutil/rlp_test_util.go
+++ b/execution/tests/testutil/rlp_test_util.go
@@ -39,7 +39,7 @@ type RLPTest struct {
 	// For other JSON values, In is treated as a driver for
 	// calls to rlp.Stream. The test also verifies that encoding
 	// In produces the bytes in Out.
-	In interface{}
+	In any
 
 	// Out is a hex-encoded RLP value.
 	Out string
@@ -85,7 +85,7 @@ func (t *RLPTest) Run() error {
 }
 
 func checkDecodeInterface(b []byte, isValid bool) error {
-	err := rlp.DecodeBytes(b, new(interface{}))
+	err := rlp.DecodeBytes(b, new(any))
 	switch {
 	case isValid && err != nil:
 		return fmt.Errorf("decoding failed: %w", err)
@@ -96,7 +96,7 @@ func checkDecodeInterface(b []byte, isValid bool) error {
 }
 
 // translateJSON makes test json values encodable with RLP.
-func translateJSON(v interface{}) interface{} {
+func translateJSON(v any) any {
 	switch v := v.(type) {
 	case float64:
 		return uint64(v)
@@ -109,8 +109,8 @@ func translateJSON(v interface{}) interface{} {
 			return big
 		}
 		return []byte(v)
-	case []interface{}:
-		newJson := make([]interface{}, len(v))
+	case []any:
+		newJson := make([]any, len(v))
 		for i := range v {
 			newJson[i] = translateJSON(v[i])
 		}
@@ -124,7 +124,7 @@ func translateJSON(v interface{}) interface{} {
 // Stream by invoking decoding operations (Uint, Big, List, ...) based
 // on the type of each value. The value decoded from the RLP stream
 // must match the JSON value.
-func checkDecodeFromJSON(s *rlp.Stream, exp interface{}) error {
+func checkDecodeFromJSON(s *rlp.Stream, exp any) error {
 	switch exp := exp.(type) {
 	case uint64:
 		i, err := s.Uint()
@@ -150,7 +150,7 @@ func checkDecodeFromJSON(s *rlp.Stream, exp interface{}) error {
 		if !bytes.Equal(b, exp) {
 			return addStack("Bytes", exp, fmt.Errorf("result mismatch: got %x", b))
 		}
-	case []interface{}:
+	case []any:
 		if _, err := s.List(); err != nil {
 			return addStack("List", exp, err)
 		}
@@ -168,7 +168,7 @@ func checkDecodeFromJSON(s *rlp.Stream, exp interface{}) error {
 	return nil
 }
 
-func addStack(op string, val interface{}, err error) error {
+func addStack(op string, val any, err error) error {
 	lines := strings.Split(err.Error(), "\n")
 	lines = append(lines, fmt.Sprintf("\t%s: %v", op, val))
 	return errors.New(strings.Join(lines, "\n"))

--- a/execution/tests/testutil/state_test_util.go
+++ b/execution/tests/testutil/state_test_util.go
@@ -360,7 +360,7 @@ func (t *StateTest) genesis(config *chain.Config) *types.Genesis {
 	}
 }
 
-func rlpHash(x interface{}) (h common.Hash) {
+func rlpHash(x any) (h common.Hash) {
 	hw := sha3.NewLegacyKeccak256()
 	if err := rlp.Encode(hw, x); err != nil {
 		panic(err)

--- a/execution/tracing/tracers/internal/tracetest/prestate_test.go
+++ b/execution/tracing/tracers/internal/tracetest/prestate_test.go
@@ -60,7 +60,7 @@ type testcase struct {
 	Context      *callContext    `json:"context"`
 	Input        string          `json:"input"`
 	TracerConfig json.RawMessage `json:"tracerConfig"`
-	Result       interface{}     `json:"result"`
+	Result       any             `json:"result"`
 }
 
 func TestPrestateTracerLegacy(t *testing.T) {

--- a/execution/tracing/tracers/tracers_test.go
+++ b/execution/tracing/tracers/tracers_test.go
@@ -132,7 +132,7 @@ func TestPrestateTracerCreate2(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to retrieve trace result: %v", err)
 	}
-	ret := make(map[string]interface{})
+	ret := make(map[string]any)
 	if err := json.Unmarshal(res, &ret); err != nil {
 		t.Fatalf("failed to unmarshal trace result: %v", err)
 	}

--- a/execution/types/aa_abi.go
+++ b/execution/types/aa_abi.go
@@ -30,7 +30,7 @@ var AccountAbstractionABI = func() abi.ABI {
 
 const PaymasterMaxContextSize = 65536
 
-func decodeMethodParamsToInterface(output interface{}, methodName string, input []byte) error {
+func decodeMethodParamsToInterface(output any, methodName string, input []byte) error {
 	m, err := AccountAbstractionABI.MethodById(input)
 	if err != nil {
 		return fmt.Errorf("unable to decode %s: %w", methodName, err)

--- a/execution/types/aa_transaction.go
+++ b/execution/types/aa_transaction.go
@@ -180,7 +180,7 @@ func (tx *AccountAbstractionTransaction) Hash() common.Hash {
 	if hash := tx.hash.Load(); hash != nil {
 		return *hash
 	}
-	hash := prefixedRlpHash(AccountAbstractionTxType, []interface{}{
+	hash := prefixedRlpHash(AccountAbstractionTxType, []any{
 		tx.ChainID,
 		tx.NonceKey, tx.Nonce,
 		tx.SenderAddress, tx.SenderValidationData,
@@ -200,7 +200,7 @@ func (tx *AccountAbstractionTransaction) Hash() common.Hash {
 }
 
 func (tx *AccountAbstractionTransaction) SigningHash(chainID *big.Int) common.Hash {
-	hash := prefixedRlpHash(AccountAbstractionTxType, []interface{}{
+	hash := prefixedRlpHash(AccountAbstractionTxType, []any{
 		chainID,
 		tx.NonceKey, tx.Nonce,
 		tx.SenderAddress, tx.SenderValidationData,

--- a/execution/types/access_list_tx.go
+++ b/execution/types/access_list_tx.go
@@ -447,7 +447,7 @@ func (tx *AccessListTx) Hash() common.Hash {
 	if hash := tx.hash.Load(); hash != nil {
 		return *hash
 	}
-	hash := prefixedRlpHash(AccessListTxType, []interface{}{
+	hash := prefixedRlpHash(AccessListTxType, []any{
 		tx.ChainID,
 		tx.Nonce,
 		tx.GasPrice,
@@ -465,7 +465,7 @@ func (tx *AccessListTx) Hash() common.Hash {
 func (tx *AccessListTx) SigningHash(chainID *big.Int) common.Hash {
 	return prefixedRlpHash(
 		AccessListTxType,
-		[]interface{}{
+		[]any{
 			chainID,
 			tx.Nonce,
 			tx.GasPrice,

--- a/execution/types/accounts/account.go
+++ b/execution/types/accounts/account.go
@@ -162,7 +162,7 @@ func decodeLengthForHashing(buffer []byte, pos int) (length int, structure bool,
 }
 
 var rlpEncodingBufPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		buf := make([]byte, 0, 128)
 		return &buf
 	},

--- a/execution/types/blob_tx.go
+++ b/execution/types/blob_tx.go
@@ -117,7 +117,7 @@ func (stx *BlobTx) Hash() common.Hash {
 	if hash := stx.hash.Load(); hash != nil {
 		return *hash
 	}
-	hash := prefixedRlpHash(BlobTxType, []interface{}{
+	hash := prefixedRlpHash(BlobTxType, []any{
 		stx.ChainID,
 		stx.Nonce,
 		stx.TipCap,
@@ -138,7 +138,7 @@ func (stx *BlobTx) Hash() common.Hash {
 func (stx *BlobTx) SigningHash(chainID *big.Int) common.Hash {
 	return prefixedRlpHash(
 		BlobTxType,
-		[]interface{}{
+		[]any{
 			chainID,
 			stx.Nonce,
 			stx.TipCap,

--- a/execution/types/block_access_list_test.go
+++ b/execution/types/block_access_list_test.go
@@ -46,7 +46,7 @@ func TestAccountChangesEncodeRejectsUnsortedReads(t *testing.T) {
 }
 
 func TestDecodeBalanceChangesRejectsOutOfOrderIndices(t *testing.T) {
-	payload, err := rlp.EncodeToBytes([][]interface{}{
+	payload, err := rlp.EncodeToBytes([][]any{
 		{uint64(2), []byte{0x01}},
 		{uint64(1), []byte{0x01}},
 	})

--- a/execution/types/block_test.go
+++ b/execution/types/block_test.go
@@ -96,7 +96,7 @@ func TestTxDependencyBlockDecoding(t *testing.T) {
 	if err := rlp.DecodeBytes(blockEnc, &block); err != nil {
 		t.Fatal("decode error: ", err)
 	}
-	check := func(f string, got, want interface{}) {
+	check := func(f string, got, want any) {
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("%s mismatch: got %v, want %v", f, got, want)
 		}
@@ -132,7 +132,7 @@ func TestBlockEncoding(t *testing.T) {
 		t.Fatal("decode error: ", err)
 	}
 
-	check := func(f string, got, want interface{}) {
+	check := func(f string, got, want any) {
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("%s mismatch: got %v, want %v", f, got, want)
 		}
@@ -169,7 +169,7 @@ func TestEIP1559BlockEncoding(t *testing.T) {
 		t.Fatal("decode error: ", err)
 	}
 
-	check := func(f string, got, want interface{}) {
+	check := func(f string, got, want any) {
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("%s mismatch: got %v, want %v", f, got, want)
 		}
@@ -237,7 +237,7 @@ func TestEIP2718BlockEncoding(t *testing.T) {
 		t.Fatal("decode error: ", err)
 	}
 
-	check := func(f string, got, want interface{}) {
+	check := func(f string, got, want any) {
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("%s mismatch: got %v, want %v", f, got, want)
 		}

--- a/execution/types/dynamic_fee_tx.go
+++ b/execution/types/dynamic_fee_tx.go
@@ -363,7 +363,7 @@ func (tx *DynamicFeeTransaction) Hash() common.Hash {
 	if hash := tx.hash.Load(); hash != nil {
 		return *hash
 	}
-	hash := prefixedRlpHash(DynamicFeeTxType, []interface{}{
+	hash := prefixedRlpHash(DynamicFeeTxType, []any{
 		tx.ChainID,
 		tx.Nonce,
 		tx.TipCap,
@@ -382,7 +382,7 @@ func (tx *DynamicFeeTransaction) Hash() common.Hash {
 func (tx *DynamicFeeTransaction) SigningHash(chainID *big.Int) common.Hash {
 	return prefixedRlpHash(
 		DynamicFeeTxType,
-		[]interface{}{
+		[]any{
 			chainID,
 			tx.Nonce,
 			tx.TipCap,

--- a/execution/types/encdec_test.go
+++ b/execution/types/encdec_test.go
@@ -404,7 +404,7 @@ func isEqualBytes(a, b []byte) bool {
 	return true
 }
 
-func check(t *testing.T, f string, want, got interface{}) {
+func check(t *testing.T, f string, want, got any) {
 	t.Helper()
 
 	if !reflect.DeepEqual(want, got) {

--- a/execution/types/ethutils/receipt.go
+++ b/execution/types/ethutils/receipt.go
@@ -40,7 +40,7 @@ func MarshalReceipt(
 	txnHash common.Hash,
 	signed bool,
 	withBlockTimestamp bool,
-) map[string]interface{} {
+) map[string]any {
 	var chainId *big.Int
 	switch t := txn.(type) {
 	case *types.LegacyTx:
@@ -57,7 +57,7 @@ func MarshalReceipt(
 		from, _ = txn.Sender(*signer)
 	}
 
-	var logsToMarshal interface{}
+	var logsToMarshal any
 
 	if withBlockTimestamp {
 		if receipt.Logs != nil {
@@ -77,7 +77,7 @@ func MarshalReceipt(
 		}
 	}
 
-	fields := map[string]interface{}{
+	fields := map[string]any{
 		"blockHash":         receipt.BlockHash,
 		"blockNumber":       hexutil.Uint64(receipt.BlockNumber.Uint64()),
 		"transactionHash":   txnHash,
@@ -131,8 +131,8 @@ func MarshalReceipt(
 	return fields
 }
 
-func MarshalSubscribeReceipt(protoReceipt *remoteproto.SubscribeReceiptsReply) map[string]interface{} {
-	receipt := make(map[string]interface{})
+func MarshalSubscribeReceipt(protoReceipt *remoteproto.SubscribeReceiptsReply) map[string]any {
+	receipt := make(map[string]any)
 
 	// Basic metadata - convert to proper hex strings
 	blockHash := common.Hash(gointerfaces.ConvertH256ToHash(protoReceipt.BlockHash))
@@ -178,9 +178,9 @@ func MarshalSubscribeReceipt(protoReceipt *remoteproto.SubscribeReceiptsReply) m
 		receipt["logsBloom"] = hexutil.Bytes(protoReceipt.LogsBloom)
 	}
 
-	logs := make([]map[string]interface{}, 0, len(protoReceipt.Logs))
+	logs := make([]map[string]any, 0, len(protoReceipt.Logs))
 	for _, protoLog := range protoReceipt.Logs {
-		logEntry := make(map[string]interface{})
+		logEntry := make(map[string]any)
 
 		if protoLog.Address != nil {
 			logEntry["address"] = common.Address(gointerfaces.ConvertH160toAddress(protoLog.Address))

--- a/execution/types/genesis.go
+++ b/execution/types/genesis.go
@@ -98,7 +98,7 @@ func (ga *GenesisAlloc) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func DecodeGenesisAlloc(i interface{}) (GenesisAlloc, error) {
+func DecodeGenesisAlloc(i any) (GenesisAlloc, error) {
 	var alloc GenesisAlloc
 
 	b, err := json.Marshal(i)

--- a/execution/types/hashing.go
+++ b/execution/types/hashing.go
@@ -33,7 +33,7 @@ import (
 
 // encodeBufferPool holds temporary encoder buffers for DeriveSha and TX encoding.
 var encodeBufferPool = sync.Pool{
-	New: func() interface{} { return new(bytes.Buffer) },
+	New: func() any { return new(bytes.Buffer) },
 }
 
 type DerivableList interface {
@@ -174,7 +174,7 @@ func RawRlpHash(rawRlpData rlp.RawValue) (h common.Hash) {
 	return h
 }
 
-func rlpHash(x interface{}) (h common.Hash) {
+func rlpHash(x any) (h common.Hash) {
 	sha := crypto.NewKeccakState()
 	rlp.Encode(sha, x) //nolint:errcheck
 	sha.Read(h[:])     //nolint:errcheck
@@ -184,7 +184,7 @@ func rlpHash(x interface{}) (h common.Hash) {
 
 // prefixedRlpHash writes the prefix into the hasher before rlp-encoding the
 // given interface. It's used for typed transactions.
-func prefixedRlpHash(prefix byte, x interface{}) (h common.Hash) {
+func prefixedRlpHash(prefix byte, x any) (h common.Hash) {
 	sha := crypto.NewKeccakState()
 	//nolint:errcheck
 	sha.Write([]byte{prefix})

--- a/execution/types/legacy_tx.go
+++ b/execution/types/legacy_tx.go
@@ -371,7 +371,7 @@ func (tx *LegacyTx) Hash() common.Hash {
 	if hash := tx.hash.Load(); hash != nil {
 		return *hash
 	}
-	hash := rlpHash([]interface{}{
+	hash := rlpHash([]any{
 		tx.Nonce,
 		tx.GasPrice,
 		tx.GasLimit,
@@ -386,7 +386,7 @@ func (tx *LegacyTx) Hash() common.Hash {
 
 func (tx *LegacyTx) SigningHash(chainID *big.Int) common.Hash {
 	if chainID != nil && chainID.Sign() != 0 {
-		return rlpHash([]interface{}{
+		return rlpHash([]any{
 			tx.Nonce,
 			tx.GasPrice,
 			tx.GasLimit,
@@ -396,7 +396,7 @@ func (tx *LegacyTx) SigningHash(chainID *big.Int) common.Hash {
 			chainID, uint(0), uint(0),
 		})
 	}
-	return rlpHash([]interface{}{
+	return rlpHash([]any{
 		tx.Nonce,
 		tx.GasPrice,
 		tx.GasLimit,

--- a/execution/types/rlp_fuzzer_test.go
+++ b/execution/types/rlp_fuzzer_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/erigontech/erigon/execution/rlp"
 )
 
-func decodeEncode(input []byte, val interface{}) error {
+func decodeEncode(input []byte, val any) error {
 	if err := rlp.DecodeBytes(input, val); err != nil {
 		// not valid rlp, nothing to do
 		return nil
@@ -58,8 +58,8 @@ func fuzzRlp(t *testing.T, input []byte) {
 	if elems, _, err := rlp.SplitList(input); err == nil {
 		rlp.CountValues(elems)
 	}
-	rlp.NewStream(bytes.NewReader(input), 0).Decode(new(interface{}))
-	if err := decodeEncode(input, new(interface{})); err != nil {
+	rlp.NewStream(bytes.NewReader(input), 0).Decode(new(any))
+	if err := decodeEncode(input, new(any)); err != nil {
 		t.Fatal(err)
 	}
 	{
@@ -77,7 +77,7 @@ func fuzzRlp(t *testing.T, input []byte) {
 			Bool  bool
 			Raw   rlp.RawValue
 			Slice []*Types
-			Iface []interface{}
+			Iface []any
 		}
 		var v Types
 		if err := decodeEncode(input, &v); err != nil {
@@ -93,7 +93,7 @@ func fuzzRlp(t *testing.T, input []byte) {
 			Raw    rlp.RawValue
 			Slice  []*AllTypes
 			Array  [3]*AllTypes
-			Iface  []interface{}
+			Iface  []any
 		}
 		var v AllTypes
 		if err := decodeEncode(input, &v); err != nil {

--- a/execution/types/set_code_tx.go
+++ b/execution/types/set_code_tx.go
@@ -179,7 +179,7 @@ func (tx *SetCodeTransaction) Hash() common.Hash {
 	if hash := tx.hash.Load(); hash != nil {
 		return *hash
 	}
-	hash := prefixedRlpHash(SetCodeTxType, []interface{}{
+	hash := prefixedRlpHash(SetCodeTxType, []any{
 		tx.ChainID,
 		tx.Nonce,
 		tx.TipCap,
@@ -199,7 +199,7 @@ func (tx *SetCodeTransaction) Hash() common.Hash {
 func (tx *SetCodeTransaction) SigningHash(chainID *big.Int) common.Hash {
 	return prefixedRlpHash(
 		SetCodeTxType,
-		[]interface{}{
+		[]any{
 			chainID,
 			tx.Nonce,
 			tx.TipCap,

--- a/execution/types/withdrawal.go
+++ b/execution/types/withdrawal.go
@@ -34,7 +34,7 @@ import (
 type encodingBuf [32]byte
 
 var pooledBuf = sync.Pool{
-	New: func() interface{} { return new(encodingBuf) },
+	New: func() any { return new(encodingBuf) },
 }
 
 func newEncodingBuf() *encodingBuf {

--- a/execution/vm/asm/compiler.go
+++ b/execution/vm/asm/compiler.go
@@ -34,7 +34,7 @@ import (
 // and holds the tokens for the program.
 type Compiler struct {
 	tokens []token
-	binary []interface{}
+	binary []any
 
 	labels map[string]int
 
@@ -237,7 +237,7 @@ func (c *Compiler) compileLabel() {
 }
 
 // pushBin pushes the value v to the binary stack.
-func (c *Compiler) pushBin(v interface{}) {
+func (c *Compiler) pushBin(v any) {
 	if c.debug {
 		fmt.Printf("%d: %v\n", len(c.binary), v)
 	}

--- a/execution/vm/interpreter.go
+++ b/execution/vm/interpreter.go
@@ -81,7 +81,7 @@ type CallContext struct {
 }
 
 var contextPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &CallContext{
 			Stack: Stack{data: make([]uint256.Int, 0, 16)},
 		}

--- a/execution/vm/program/program_test.go
+++ b/execution/vm/program/program_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestPush(t *testing.T) {
 	tests := []struct {
-		input    interface{}
+		input    any
 		expected string
 	}{
 		// native ints

--- a/execution/vm/stack.go
+++ b/execution/vm/stack.go
@@ -28,7 +28,7 @@ import (
 )
 
 var stackPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &Stack{data: make([]uint256.Int, 0, 16)}
 	},
 }


### PR DESCRIPTION
This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.

As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.