### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/cl/antiquary/state_antiquary.go
+++ b/cl/antiquary/state_antiquary.go
@@ -45,7 +45,7 @@ import (
 
 // pool for buffers
 var bufferPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &bytes.Buffer{}
 	},
 }

--- a/cl/beacon/beaconevents/model.go
+++ b/cl/beacon/beaconevents/model.go
@@ -8,8 +8,8 @@ import (
 )
 
 type EventStream struct {
-	Event EventTopic  `json:"event"`
-	Data  interface{} `json:"data"`
+	Event EventTopic `json:"event"`
+	Data  any        `json:"data"`
 }
 
 type EventTopic string

--- a/cl/beacon/handler/forkchoice.go
+++ b/cl/beacon/handler/forkchoice.go
@@ -34,8 +34,8 @@ func (a *ApiHandler) GetEthV2DebugBeaconHeads(w http.ResponseWriter, r *http.Req
 		return nil, beaconhttp.NewEndpointError(statusCode, err)
 	}
 	return newBeaconResponse(
-		[]interface{}{
-			map[string]interface{}{
+		[]any{
+			map[string]any{
 				"slot":                 strconv.FormatUint(slot, 10),
 				"root":                 root,
 				"execution_optimistic": false,
@@ -47,7 +47,7 @@ func (a *ApiHandler) GetEthV1DebugBeaconForkChoice(w http.ResponseWriter, r *htt
 	justifiedCheckpoint := a.forkchoiceStore.JustifiedCheckpoint()
 	finalizedCheckpoint := a.forkchoiceStore.FinalizedCheckpoint()
 	forkNodes := a.forkchoiceStore.ForkNodes()
-	if err := json.NewEncoder(w).Encode(map[string]interface{}{
+	if err := json.NewEncoder(w).Encode(map[string]any{
 		"justified_checkpoint": justifiedCheckpoint,
 		"finalized_checkpoint": finalizedCheckpoint,
 		"fork_choice_nodes":    forkNodes,

--- a/cl/beacon/handler/handler.go
+++ b/cl/beacon/handler/handler.go
@@ -180,7 +180,7 @@ func NewApiHandler(
 		caplinStateSnapshots:               caplinStateSnapshots,
 		peerDas:                            peerDas,
 		slotWaitedForAttestationProduction: slotWaitedForAttestationProduction,
-		randaoMixesPool: sync.Pool{New: func() interface{} {
+		randaoMixesPool: sync.Pool{New: func() any {
 			return solid.NewHashVector(int(beaconChainConfig.EpochsPerHistoricalVector))
 		}},
 		sentinel:                         sentinel,

--- a/cl/beacon/handler/lightclient.go
+++ b/cl/beacon/handler/lightclient.go
@@ -99,7 +99,7 @@ func (a *ApiHandler) GetEthV1BeaconLightClientUpdates(w http.ResponseWriter, r *
 		return
 	}
 
-	resp := []interface{}{}
+	resp := []any{}
 	endPeriod := *startPeriod + *count
 	currentSlot := a.ethClock.GetCurrentSlot()
 	if endPeriod > a.beaconChainCfg.SyncCommitteePeriod(currentSlot) {
@@ -109,14 +109,14 @@ func (a *ApiHandler) GetEthV1BeaconLightClientUpdates(w http.ResponseWriter, r *
 	notFoundPrev := false
 	// Fetch from [start_period, start_period + count]
 	for i := *startPeriod; i <= endPeriod; i++ {
-		respUpdate := map[string]interface{}{}
+		respUpdate := map[string]any{}
 		update, has := a.forkchoiceStore.GetLightClientUpdate(i)
 		if !has {
 			notFoundPrev = true
 			continue
 		}
 		if notFoundPrev {
-			resp = []interface{}{}
+			resp = []any{}
 			notFoundPrev = false
 		}
 		respUpdate["data"] = update

--- a/cl/beacon/handler/node.go
+++ b/cl/beacon/handler/node.go
@@ -62,7 +62,7 @@ func (a *ApiHandler) GetEthV1NodeHealth(w http.ResponseWriter, r *http.Request) 
 
 func (a *ApiHandler) GetEthV1NodeVersion(w http.ResponseWriter, r *http.Request) (*beaconhttp.BeaconResponse, error) {
 	// Get OS and Arch
-	return newBeaconResponse(map[string]interface{}{
+	return newBeaconResponse(map[string]any{
 		"version": fmt.Sprintf("Caplin/%s %s/%s", a.version, runtime.GOOS, runtime.GOARCH),
 	}), nil
 }
@@ -74,7 +74,7 @@ func (a *ApiHandler) GetEthV1NodePeerCount(w http.ResponseWriter, r *http.Reques
 	}
 
 	// all fields should be converted to string
-	return newBeaconResponse(map[string]interface{}{
+	return newBeaconResponse(map[string]any{
 		"connected":     strconv.FormatUint(ret.Connected, 10),
 		"disconnected":  strconv.FormatUint(ret.Disconnected, 10),
 		"connecting":    strconv.FormatUint(ret.Connecting, 10),
@@ -154,12 +154,12 @@ func (a *ApiHandler) GetEthV1NodeIdentity(w http.ResponseWriter, r *http.Request
 		return nil, beaconhttp.NewEndpointError(http.StatusInternalServerError, err)
 	}
 
-	return newBeaconResponse(map[string]interface{}{
+	return newBeaconResponse(map[string]any{
 		"peer_id":             id.Pid,
 		"enr":                 id.Enr,
 		"p2p_addresses":       id.P2PAddresses,
 		"discovery_addresses": id.DiscoveryAddresses,
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"seq":      strconv.FormatUint(id.Metadata.Seq, 10),
 			"attnets":  id.Metadata.Attnets,
 			"syncnets": id.Metadata.Syncnets,
@@ -171,7 +171,7 @@ func (a *ApiHandler) GetEthV1NodeSyncing(w http.ResponseWriter, r *http.Request)
 	currentSlot := a.ethClock.GetCurrentSlot()
 
 	return newBeaconResponse(
-		map[string]interface{}{
+		map[string]any{
 			"head_slot":     strconv.FormatUint(a.syncedData.HeadSlot(), 10),
 			"sync_distance": strconv.FormatUint(currentSlot-a.syncedData.HeadSlot(), 10),
 			"is_syncing":    a.syncedData.Syncing(),

--- a/cl/beacon/handler/states_test.go
+++ b/cl/beacon/handler/states_test.go
@@ -81,10 +81,10 @@ func TestGetStateFork(t *testing.T) {
 			if resp.StatusCode != http.StatusOK {
 				return
 			}
-			jsonVal := make(map[string]interface{})
+			jsonVal := make(map[string]any)
 			// unmarshal the json
 			require.NoError(t, json.NewDecoder(resp.Body).Decode(&jsonVal))
-			data := jsonVal["data"].(map[string]interface{})
+			data := jsonVal["data"].(map[string]any)
 			require.Equal(t, "0x00000000", data["current_version"])
 			require.Equal(t, "0x00000000", data["previous_version"])
 			require.Equal(t, "0", data["epoch"])
@@ -146,10 +146,10 @@ func TestGetStateRoot(t *testing.T) {
 			if resp.StatusCode != http.StatusOK {
 				return
 			}
-			jsonVal := make(map[string]interface{})
+			jsonVal := make(map[string]any)
 			// unmarshal the json
 			require.NoError(t, json.NewDecoder(resp.Body).Decode(&jsonVal))
-			data := jsonVal["data"].(map[string]interface{})
+			data := jsonVal["data"].(map[string]any)
 			require.Equal(t, data["root"], "0x"+common.Bytes2Hex(postRoot[:]))
 		})
 	}

--- a/cl/beacon/handler/validators.go
+++ b/cl/beacon/handler/validators.go
@@ -43,7 +43,7 @@ import (
 )
 
 var stringsBuilderPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return new(strings.Builder)
 	},
 }

--- a/cl/cltypes/beacon_block.go
+++ b/cl/cltypes/beacon_block.go
@@ -372,8 +372,8 @@ func (b *BeaconBody) HashSSZ() ([32]byte, error) {
 	return merkle_tree.HashTreeRoot(b.getSchema(false)...)
 }
 
-func (b *BeaconBody) getSchema(storage bool) []interface{} {
-	s := []interface{}{b.RandaoReveal[:], b.Eth1Data, b.Graffiti[:], b.ProposerSlashings, b.AttesterSlashings, b.Attestations, b.Deposits, b.VoluntaryExits}
+func (b *BeaconBody) getSchema(storage bool) []any {
+	s := []any{b.RandaoReveal[:], b.Eth1Data, b.Graffiti[:], b.ProposerSlashings, b.AttesterSlashings, b.Attestations, b.Deposits, b.VoluntaryExits}
 	if b.Version >= clparams.AltairVersion {
 		s = append(s, b.SyncAggregate)
 	}

--- a/cl/cltypes/beacon_block_blinded.go
+++ b/cl/cltypes/beacon_block_blinded.go
@@ -357,8 +357,8 @@ func (b *BlindedBeaconBody) HashSSZ() ([32]byte, error) {
 	return merkle_tree.HashTreeRoot(b.getSchema(false)...)
 }
 
-func (b *BlindedBeaconBody) getSchema(storage bool) []interface{} {
-	s := []interface{}{b.RandaoReveal[:], b.Eth1Data, b.Graffiti[:], b.ProposerSlashings, b.AttesterSlashings, b.Attestations, b.Deposits, b.VoluntaryExits}
+func (b *BlindedBeaconBody) getSchema(storage bool) []any {
+	s := []any{b.RandaoReveal[:], b.Eth1Data, b.Graffiti[:], b.ProposerSlashings, b.AttesterSlashings, b.Attestations, b.Deposits, b.VoluntaryExits}
 	if b.Version >= clparams.AltairVersion {
 		s = append(s, b.SyncAggregate)
 	}

--- a/cl/cltypes/beacon_block_test.go
+++ b/cl/cltypes/beacon_block_test.go
@@ -119,8 +119,8 @@ func TestBeaconBlockJson(t *testing.T) {
 	block.Block.Body.Version = clparams.DenebVersion
 	err := json.Unmarshal(beaconBodyJSON, block)
 	require.NoError(t, err)
-	map1 := make(map[string]interface{})
-	map2 := make(map[string]interface{})
+	map1 := make(map[string]any)
+	map2 := make(map[string]any)
 	err = json.Unmarshal(beaconBodyJSON, &map1)
 	require.NoError(t, err)
 	out, err := json.Marshal(block)

--- a/cl/cltypes/blob_sidecar.go
+++ b/cl/cltypes/blob_sidecar.go
@@ -97,8 +97,8 @@ func (b *BlobSidecar) Clone() clonable.Clonable {
 	return NewBlobSidecar(b.Index, blob, b.KzgCommitment, b.KzgProof, b.SignedBlockHeader, b.CommitmentInclusionProof)
 }
 
-func (b *BlobSidecar) getSchema() []interface{} {
-	s := []interface{}{&b.Index, b.Blob[:], b.KzgCommitment[:], b.KzgProof[:]}
+func (b *BlobSidecar) getSchema() []any {
+	s := []any{&b.Index, b.Blob[:], b.KzgCommitment[:], b.KzgProof[:]}
 	if b.SignedBlockHeader != nil {
 		s = append(s, b.SignedBlockHeader)
 	}
@@ -140,8 +140,8 @@ func (*BlobIdentifier) Clone() clonable.Clonable {
 	return &BlobIdentifier{}
 }
 
-func (b *BlobIdentifier) getSchema() []interface{} {
-	return []interface{}{
+func (b *BlobIdentifier) getSchema() []any {
+	return []any{
 		b.BlockRoot[:],
 		&b.Index,
 	}

--- a/cl/cltypes/column_sidecar.go
+++ b/cl/cltypes/column_sidecar.go
@@ -85,9 +85,9 @@ func (d *DataColumnSidecar) EncodeSSZ(buf []byte) ([]byte, error) {
 	return ssz2.MarshalSSZ(buf, d.getSchema()...)
 }
 
-func (d *DataColumnSidecar) getSchema() []interface{} {
+func (d *DataColumnSidecar) getSchema() []any {
 	d.tryInit()
-	return []interface{}{&d.Index, d.Column, d.KzgCommitments, d.KzgProofs, d.SignedBlockHeader, d.KzgCommitmentsInclusionProof}
+	return []any{&d.Index, d.Column, d.KzgCommitments, d.KzgProofs, d.SignedBlockHeader, d.KzgCommitmentsInclusionProof}
 }
 
 func (d *DataColumnSidecar) EncodingSizeSSZ() int {

--- a/cl/cltypes/eth1_block.go
+++ b/cl/cltypes/eth1_block.go
@@ -293,8 +293,8 @@ func (b *Eth1Block) HashSSZ() ([32]byte, error) {
 	return merkle_tree.HashTreeRoot(b.getSchema()...)
 }
 
-func (b *Eth1Block) getSchema() []interface{} {
-	s := []interface{}{b.ParentHash[:], b.FeeRecipient[:], b.StateRoot[:], b.ReceiptsRoot[:], b.LogsBloom[:],
+func (b *Eth1Block) getSchema() []any {
+	s := []any{b.ParentHash[:], b.FeeRecipient[:], b.StateRoot[:], b.ReceiptsRoot[:], b.LogsBloom[:],
 		b.PrevRandao[:], &b.BlockNumber, &b.GasLimit, &b.GasUsed, &b.Time, b.Extra, b.BaseFeePerGas[:], b.BlockHash[:], b.Transactions}
 	if b.version >= clparams.CapellaVersion {
 		s = append(s, b.Withdrawals)

--- a/cl/cltypes/eth1_header.go
+++ b/cl/cltypes/eth1_header.go
@@ -139,8 +139,8 @@ func (h *Eth1Header) HashSSZ() ([32]byte, error) {
 	return merkle_tree.HashTreeRoot(h.getSchema()...)
 }
 
-func (h *Eth1Header) getSchema() []interface{} {
-	s := []interface{}{
+func (h *Eth1Header) getSchema() []any {
+	s := []any{
 		h.ParentHash[:], h.FeeRecipient[:], h.StateRoot[:], h.ReceiptsRoot[:], h.LogsBloom[:],
 		h.PrevRandao[:], &h.BlockNumber, &h.GasLimit, &h.GasUsed, &h.Time, h.Extra, h.BaseFeePerGas[:], h.BlockHash[:], h.TransactionsRoot[:],
 	}

--- a/cl/cltypes/light_client.go
+++ b/cl/cltypes/light_client.go
@@ -104,8 +104,8 @@ func (l *LightClientHeader) Clone() clonable.Clonable {
 	return NewLightClientHeader(l.version)
 }
 
-func (l *LightClientHeader) getSchema() []interface{} {
-	schema := []interface{}{
+func (l *LightClientHeader) getSchema() []any {
+	schema := []any{
 		l.Beacon,
 	}
 	if l.version >= clparams.CapellaVersion {

--- a/cl/cltypes/network.go
+++ b/cl/cltypes/network.go
@@ -36,7 +36,7 @@ type Metadata struct {
 }
 
 func (m *Metadata) EncodeSSZ(buf []byte) ([]byte, error) {
-	schema := []interface{}{
+	schema := []any{
 		m.SeqNumber,
 		m.Attnets[:],
 	}
@@ -83,7 +83,7 @@ func (m *Metadata) DecodeSSZ(buf []byte, _ int) error {
 }
 
 func (m *Metadata) MarshalJSON() ([]byte, error) {
-	out := map[string]interface{}{
+	out := map[string]any{
 		"seq_number": strconv.FormatUint(m.SeqNumber, 10),
 		"attnets":    hexutil.Bytes(m.Attnets[:]),
 	}
@@ -194,7 +194,7 @@ func (s *Status) EncodeSSZ(buf []byte) ([]byte, error) {
 }
 
 func (s *Status) DecodeSSZ(buf []byte, version int) error {
-	schema := []interface{}{
+	schema := []any{
 		s.ForkDigest[:],
 		s.FinalizedRoot[:],
 		&s.FinalizedEpoch,
@@ -210,8 +210,8 @@ func (s *Status) DecodeSSZ(buf []byte, version int) error {
 	return ssz2.UnmarshalSSZ(buf, version, schema...)
 }
 
-func (s *Status) schema() []interface{} {
-	schema := []interface{}{
+func (s *Status) schema() []any {
+	schema := []any{
 		s.ForkDigest[:],
 		s.FinalizedRoot[:],
 		&s.FinalizedEpoch,

--- a/cl/cltypes/solid/list_ssz.go
+++ b/cl/cltypes/solid/list_ssz.go
@@ -182,7 +182,7 @@ func (l *ListSSZ[T]) Cut(length int) {
 }
 
 func (l *ListSSZ[T]) ElementProof(i int) [][32]byte {
-	leaves := make([]interface{}, l.limit)
+	leaves := make([]any, l.limit)
 	for i := range leaves {
 		leaves[i] = make([]byte, 32)
 	}

--- a/cl/merkle_tree/merkle_root.go
+++ b/cl/merkle_tree/merkle_root.go
@@ -34,7 +34,7 @@ import (
 // HashTreeRoot returns the hash for a given schema of objects.
 // IMPORTANT: DATA TYPE MUST IMPLEMENT HASHABLE
 // SUPPORTED PRIMITIVES: uint64, *uint64 and []byte
-func HashTreeRoot(schema ...interface{}) ([32]byte, error) {
+func HashTreeRoot(schema ...any) ([32]byte, error) {
 	// Calculate the total number of leaves needed based on the schema length
 	leaves := make([]byte, NextPowerOfTwo(uint64(len(schema)*length.Hash)))
 	pos := 0
@@ -148,7 +148,7 @@ func MerkleRootFromFlatLeavesWithLimit(leaves []byte, out []byte, limit uint64) 
 }
 
 // Merkle Proof computes the merkle proof for a given schema of objects.
-func MerkleProof(depth, proofIndex int, schema ...interface{}) ([][32]byte, error) {
+func MerkleProof(depth, proofIndex int, schema ...any) ([][32]byte, error) {
 	// Calculate the total number of leaves needed based on the schema length
 	maxDepth := GetDepth(uint64(len(schema)))
 	if utils.PowerOf2(uint64(maxDepth)) != uint64(len(schema)) {

--- a/cl/persistence/base_encoding/uint64_diff.go
+++ b/cl/persistence/base_encoding/uint64_diff.go
@@ -29,7 +29,7 @@ import (
 
 // make a sync.pool of compressors (zstd)
 var compressorPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		compressor, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedFastest))
 		if err != nil {
 			panic(err)
@@ -44,27 +44,27 @@ func putComp(v *zstd.Encoder) {
 }
 
 var bufferPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &bytes.Buffer{}
 	},
 }
 
 var plainUint64BufferPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		b := make([]uint64, 1028)
 		return &b
 	},
 }
 
 var plainBytesBufferPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		b := make([]byte, 1028)
 		return &b
 	},
 }
 
 var repeatedPatternBufferPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		b := make([]repeatedPatternEntry, 1028)
 		return &b
 	},

--- a/cl/persistence/beacon_indicies/indicies.go
+++ b/cl/persistence/beacon_indicies/indicies.go
@@ -35,14 +35,14 @@ import (
 
 // make a buffer pool
 var bufferPool = &sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return new(bytes.Buffer)
 	},
 }
 
 // make a zstd writer pool
 var zstdWriterPool = &sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		encoder, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedBetterCompression))
 		if err != nil {
 			panic(err)

--- a/cl/persistence/format/snapshot_format/blocks.go
+++ b/cl/persistence/format/snapshot_format/blocks.go
@@ -35,7 +35,7 @@ type ExecutionBlockReaderByNumber interface {
 }
 
 var buffersPool = sync.Pool{
-	New: func() interface{} { return &bytes.Buffer{} },
+	New: func() any { return &bytes.Buffer{} },
 }
 
 // WriteBlockForSnapshot writes a block to the given writer in the format expected by the snapshot.

--- a/cl/persistence/state/epoch_data.go
+++ b/cl/persistence/state/epoch_data.go
@@ -99,11 +99,11 @@ func (m *EpochData) ReadFrom(r io.Reader) error {
 	return ssz2.UnmarshalSSZ(buf, 0, m.getSchema()...)
 }
 
-func (m *EpochData) getSchema() []interface{} {
+func (m *EpochData) getSchema() []any {
 	if m.Version < clparams.FuluVersion {
-		return []interface{}{&m.TotalActiveBalance, m.JustificationBits, &m.CurrentJustifiedCheckpoint, &m.PreviousJustifiedCheckpoint, &m.FinalizedCheckpoint, &m.HistoricalSummariesLength, &m.HistoricalRootsLength}
+		return []any{&m.TotalActiveBalance, m.JustificationBits, &m.CurrentJustifiedCheckpoint, &m.PreviousJustifiedCheckpoint, &m.FinalizedCheckpoint, &m.HistoricalSummariesLength, &m.HistoricalRootsLength}
 	}
-	return []interface{}{
+	return []any{
 		&m.TotalActiveBalance,
 		m.JustificationBits,
 		&m.CurrentJustifiedCheckpoint,

--- a/cl/persistence/state/historical_states_reader/historical_states_reader.go
+++ b/cl/persistence/state/historical_states_reader/historical_states_reader.go
@@ -43,7 +43,7 @@ import (
 )
 
 var buffersPool = sync.Pool{
-	New: func() interface{} { return &bytes.Buffer{} },
+	New: func() any { return &bytes.Buffer{} },
 }
 
 type HistoricalStatesReader struct {

--- a/cl/persistence/state/slot_data.go
+++ b/cl/persistence/state/slot_data.go
@@ -131,8 +131,8 @@ func (m *SlotData) ReadFrom(r io.Reader, cfg *clparams.BeaconChainConfig) error 
 	return ssz2.UnmarshalSSZ(buf, int(m.Version), m.getSchema()...)
 }
 
-func (m *SlotData) getSchema() []interface{} {
-	schema := []interface{}{m.Eth1Data, m.Fork, &m.Eth1DepositIndex, &m.ValidatorLength, &m.Eth1DataLength, &m.AttestationsRewards, &m.SyncAggregateRewards, &m.ProposerSlashings, &m.AttesterSlashings}
+func (m *SlotData) getSchema() []any {
+	schema := []any{m.Eth1Data, m.Fork, &m.Eth1DepositIndex, &m.ValidatorLength, &m.Eth1DataLength, &m.AttestationsRewards, &m.SyncAggregateRewards, &m.ProposerSlashings, &m.AttesterSlashings}
 	if m.Version >= clparams.CapellaVersion {
 		schema = append(schema, &m.NextWithdrawalIndex, &m.NextWithdrawalValidatorIndex)
 	}

--- a/cl/phase1/core/state/raw/hashing.go
+++ b/cl/phase1/core/state/raw/hashing.go
@@ -69,7 +69,7 @@ func (b *BeaconState) CurrentSyncCommitteeBranch() ([][32]byte, error) {
 		leafSize = StateLeafSizeFulu
 	}
 
-	schema := []interface{}{}
+	schema := []any{}
 	for i := 0; i < leafSize*32; i += 32 {
 		schema = append(schema, b.leaves[i:i+32])
 	}
@@ -92,7 +92,7 @@ func (b *BeaconState) NextSyncCommitteeBranch() ([][32]byte, error) {
 		leafSize = StateLeafSizeFulu
 	}
 
-	schema := []interface{}{}
+	schema := []any{}
 	for i := 0; i < leafSize*32; i += 32 {
 		schema = append(schema, b.leaves[i:i+32])
 	}
@@ -114,7 +114,7 @@ func (b *BeaconState) FinalityRootBranch() ([][32]byte, error) {
 		leafSize = StateLeafSizeFulu
 	}
 
-	schema := []interface{}{}
+	schema := []any{}
 	for i := 0; i < leafSize*32; i += 32 {
 		schema = append(schema, b.leaves[i:i+32])
 	}

--- a/cl/phase1/core/state/raw/ssz.go
+++ b/cl/phase1/core/state/raw/ssz.go
@@ -69,8 +69,8 @@ func (b *BeaconState) EncodeSSZ(buf []byte) ([]byte, error) {
 }
 
 // getSchema gives the schema for the current beacon state version according to ETH 2.0 specs.
-func (b *BeaconState) getSchema() []interface{} {
-	s := []interface{}{&b.genesisTime, b.genesisValidatorsRoot[:], &b.slot, b.fork, b.latestBlockHeader, b.blockRoots, b.stateRoots, b.historicalRoots,
+func (b *BeaconState) getSchema() []any {
+	s := []any{&b.genesisTime, b.genesisValidatorsRoot[:], &b.slot, b.fork, b.latestBlockHeader, b.blockRoots, b.stateRoots, b.historicalRoots,
 		b.eth1Data, b.eth1DataVotes, &b.eth1DepositIndex, b.validators, b.balances, b.randaoMixes, b.slashings}
 	if b.version == clparams.Phase0Version {
 		return append(s, b.previousEpochAttestations, b.currentEpochAttestations, &b.justificationBits, &b.previousJustifiedCheckpoint, &b.currentJustifiedCheckpoint,

--- a/cl/phase1/core/state/raw/state.go
+++ b/cl/phase1/core/state/raw/state.go
@@ -145,7 +145,7 @@ func (b *BeaconState) init() error {
 }
 
 func (b *BeaconState) MarshalJSON() ([]byte, error) {
-	obj := map[string]interface{}{
+	obj := map[string]any{
 		"genesis_time":                  strconv.FormatInt(int64(b.genesisTime), 10),
 		"genesis_validators_root":       b.genesisValidatorsRoot,
 		"slot":                          strconv.FormatInt(int64(b.slot), 10),

--- a/cl/phase1/execution_client/execution_client_rpc.go
+++ b/cl/phase1/execution_client/execution_client_rpc.go
@@ -136,7 +136,7 @@ func (cc *ExecutionClientRpc) NewPayload(
 
 	payloadStatus := &engine_types.PayloadStatus{} // As it is done in the rpcdaemon
 	log.Debug("[ExecutionClientRpc] Calling EL", "method", engineMethod)
-	args := []interface{}{request}
+	args := []any{request}
 	if versionedHashes != nil {
 		args = append(args, versionedHashes, *beaconParentRoot)
 	}
@@ -162,7 +162,7 @@ func (cc *ExecutionClientRpc) ForkChoiceUpdate(ctx context.Context, finalized, s
 	}
 	forkChoiceResp := &engine_types.ForkChoiceUpdatedResponse{}
 	log.Debug("[ExecutionClientRpc] Calling EL", "method", rpc_helper.ForkChoiceUpdatedV1)
-	args := []interface{}{forkChoiceRequest}
+	args := []any{forkChoiceRequest}
 	if attributes != nil {
 		args = append(args, attributes)
 	}

--- a/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
+++ b/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
@@ -493,7 +493,7 @@ func (f *forkGraphDisk) hasBeaconState(blockRoot common.Hash) bool {
 func (f *forkGraphDisk) Prune(pruneSlot uint64) (err error) {
 	oldRoots := make([]common.Hash, 0, f.beaconCfg.SlotsPerEpoch)
 	highestStoredBeaconStateSlot := uint64(0)
-	f.blocks.Range(func(key, value interface{}) bool {
+	f.blocks.Range(func(key, value any) bool {
 		hash := key.(common.Hash)
 		signedBlock := value.(*cltypes.SignedBeaconBlock)
 		if f.hasBeaconState(hash) && highestStoredBeaconStateSlot < signedBlock.Block.Slot {

--- a/cl/phase1/forkchoice/fork_graph/participation_indicies_store.go
+++ b/cl/phase1/forkchoice/fork_graph/participation_indicies_store.go
@@ -32,7 +32,7 @@ func (p *participationIndiciesStore) add(epoch uint64, participations []byte) {
 
 func (p *participationIndiciesStore) prune(epoch uint64) {
 	// iterate over the map and delete all keys less or equal than epoch
-	p.s.Range(func(key, value interface{}) bool {
+	p.s.Range(func(key, value any) bool {
 		if key.(uint64) <= epoch {
 			p.s.Delete(key)
 		}

--- a/cl/phase1/forkchoice/optimistic/optimistic_impl.go
+++ b/cl/phase1/forkchoice/optimistic/optimistic_impl.go
@@ -100,7 +100,7 @@ func (impl *optimisticStoreImpl) ValidateBlock(block *cltypes.BeaconBlock) error
 	// for _, root := range toRemoves {
 	// 	delete(impl.optimisticRoots, root)
 	// }
-	impl.optimisticRoots.Range(func(root, node interface{}) bool {
+	impl.optimisticRoots.Range(func(root, node any) bool {
 		if node.(*opNode).execBlockNum < blockNum {
 			toRemoves = append(toRemoves, root.(common.Hash))
 		}

--- a/cl/phase1/forkchoice/optimistic/optimistic_test.go
+++ b/cl/phase1/forkchoice/optimistic/optimistic_test.go
@@ -81,7 +81,7 @@ func (t *optimisticTestSuite) TearDownTest() {
 
 func checkSyncMapLength(m *sync.Map, length int) bool {
 	l := 0
-	m.Range(func(_, _ interface{}) bool {
+	m.Range(func(_, _ any) bool {
 		l++
 		return true
 	})

--- a/cl/phase1/network/services/sync_committee_messages_service.go
+++ b/cl/phase1/network/services/sync_committee_messages_service.go
@@ -176,7 +176,7 @@ func (s *syncCommitteeMessagesService) cleanupOldSyncCommitteeMessages() {
 	headSlot := s.syncedDataManager.HeadSlot()
 
 	entriesToRemove := []seenSyncCommitteeMessage{}
-	s.seenSyncCommitteeMessages.Range(func(key, value interface{}) bool {
+	s.seenSyncCommitteeMessages.Range(func(key, value any) bool {
 		k := key.(seenSyncCommitteeMessage)
 		if headSlot > k.slot+1 {
 			entriesToRemove = append(entriesToRemove, k)

--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -210,7 +210,7 @@ func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Co
 					}
 
 				}
-				logArgs := []interface{}{}
+				logArgs := []any{}
 				currProgress := cfg.downloader.Progress()
 				speed := math.Abs(float64(currProgress)-float64(initialProgress)) / time.Since(startTimeLoop).Seconds()
 				if speed > 1000.0 { // to avoid spamming logs on fast syncs

--- a/cl/pool/operation_pool.go
+++ b/cl/pool/operation_pool.go
@@ -51,7 +51,7 @@ func (o *OperationPool[K, T]) Insert(k K, operation T) {
 	o.pool.Add(k, operation)
 	o.recentlySeen.Store(k, time.Now())
 	if time.Since(o.lastPruned) > lifeSpan {
-		o.recentlySeen.Range(func(k, v interface{}) bool {
+		o.recentlySeen.Range(func(k, v any) bool {
 			if time.Since(v.(time.Time)) > lifeSpan {
 				o.recentlySeen.Delete(k)
 			}

--- a/cl/sentinel/gossip.go
+++ b/cl/sentinel/gossip.go
@@ -64,7 +64,7 @@ func (s *Sentinel) Unsubscribe(topic GossipTopic, opts ...pubsub.TopicOpt) (err 
 }
 
 func (g *GossipManager) Close() {
-	g.subscriptions.Range(func(key, value interface{}) bool {
+	g.subscriptions.Range(func(key, value any) bool {
 		if value != nil {
 			value.(*GossipSubscription).Close()
 		}

--- a/cl/ssz/decode.go
+++ b/cl/ssz/decode.go
@@ -52,7 +52,7 @@ The Decode function is used to decode an SSZ-encoded byte slice into the specifi
 types such as uint64, []byte, and objects that implement the SizedObjectSSZ interface.
 It handles both static (fixed size) and dynamic (variable size) objects based on their respective decoding methods and offsets.
 */
-func UnmarshalSSZ(buf []byte, version int, schema ...interface{}) (err error) {
+func UnmarshalSSZ(buf []byte, version int, schema ...any) (err error) {
 	// defer func() {
 	// 	if err2 := recover(); err2 != nil {
 	// 		err = fmt.Errorf("panic while decoding: %v", err2)

--- a/cl/utils/crypto.go
+++ b/cl/utils/crypto.go
@@ -25,7 +25,7 @@ import (
 type HashFunc func(data []byte, extras ...[]byte) [32]byte
 
 var hasherPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return sha256.New()
 	},
 }

--- a/cl/validator/validator_params/validator_params.go
+++ b/cl/validator/validator_params/validator_params.go
@@ -44,7 +44,7 @@ func (vp *ValidatorParams) GetFeeRecipient(validatorIndex uint64) (common.Addres
 
 func (vp *ValidatorParams) GetValidators() []uint64 {
 	validators := []uint64{}
-	vp.feeRecipients.Range(func(key, value interface{}) bool {
+	vp.feeRecipients.Range(func(key, value any) bool {
 		validators = append(validators, key.(uint64))
 		return true
 	})


### PR DESCRIPTION
This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.

As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.