### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/cmd/capcli/cli.go
+++ b/cmd/capcli/cli.go
@@ -819,7 +819,7 @@ type ArchiveSanitizer struct {
 }
 
 func getHead(beaconApiURL string) (uint64, error) {
-	headResponse := map[string]interface{}{}
+	headResponse := map[string]any{}
 	req, err := http.NewRequest("GET", beaconApiURL+"/eth/v2/debug/beacon/heads", nil)
 	if err != nil {
 		return 0, err
@@ -833,11 +833,11 @@ func getHead(beaconApiURL string) (uint64, error) {
 	if err := json.NewDecoder(resp.Body).Decode(&headResponse); err != nil {
 		return 0, err
 	}
-	data := headResponse["data"].([]interface{})
+	data := headResponse["data"].([]any)
 	if len(data) == 0 {
 		return 0, errors.New("no head found")
 	}
-	head := data[0].(map[string]interface{})
+	head := data[0].(map[string]any)
 	slotStr, ok := head["slot"].(string)
 	if !ok {
 		return 0, errors.New("no slot found")
@@ -850,7 +850,7 @@ func getHead(beaconApiURL string) (uint64, error) {
 }
 
 func getStateRootAtSlot(beaconApiURL string, slot uint64) (common.Hash, error) {
-	response := map[string]interface{}{}
+	response := map[string]any{}
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/eth/v1/beacon/states/%d/root", beaconApiURL, slot), nil)
 	if err != nil {
 		return common.Hash{}, err
@@ -867,7 +867,7 @@ func getStateRootAtSlot(beaconApiURL string, slot uint64) (common.Hash, error) {
 	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
 		return common.Hash{}, err
 	}
-	data := response["data"].(map[string]interface{})
+	data := response["data"].(map[string]any)
 	if len(data) == 0 {
 		return common.Hash{}, errors.New("no head found")
 	}
@@ -1501,7 +1501,7 @@ func (m *MakeDepositArgs) Run(ctx *Context) error {
 	privateKey := privateKeyBls.Bytes()
 
 	// Print all the details in json format
-	depositDetails := map[string]interface{}{
+	depositDetails := map[string]any{
 		"deposit":           deposit,
 		"deposit_tree_root": common.Hash(depositTreeRoot),
 		"private_key":       "0x" + common.Bytes2Hex(privateKey),

--- a/cmd/diag/sysinfo/sysinfo.go
+++ b/cmd/diag/sysinfo/sysinfo.go
@@ -42,10 +42,10 @@ var Command = cli.Command{
 }
 
 type Flag struct {
-	Name    string      `json:"name"`
-	Value   interface{} `json:"value"`
-	Usage   string      `json:"usage"`
-	Default bool        `json:"default"`
+	Name    string `json:"name"`
+	Value   any    `json:"value"`
+	Usage   string `json:"usage"`
+	Default bool   `json:"default"`
 }
 
 type SortType int
@@ -181,7 +181,7 @@ func getData(cliCtx *cli.Context) (diaglib.HardwareInfo, error) {
 }
 
 func getFlagsData(cliCtx *cli.Context) ([]Flag, error) {
-	var rawData map[string]map[string]interface{}
+	var rawData map[string]map[string]any
 	url := "http://" + cliCtx.String(flags.DebugURLFlag.Name) + flags.ApiPath + "/flags"
 
 	err := util.MakeHttpGetCall(cliCtx.Context, url, &rawData)

--- a/cmd/diag/util/util.go
+++ b/cmd/diag/util/util.go
@@ -31,7 +31,7 @@ import (
 	"github.com/jedib0t/go-pretty/v6/text"
 )
 
-func MakeHttpGetCall(ctx context.Context, url string, data interface{}) error {
+func MakeHttpGetCall(ctx context.Context, url string, data any) error {
 	var client = &http.Client{
 		Timeout: time.Second * 20,
 	}
@@ -67,7 +67,7 @@ func MakeHttpGetCall(ctx context.Context, url string, data interface{}) error {
 	return nil
 }
 
-func RenderJson(data interface{}) {
+func RenderJson(data any) {
 	bytes, err := json.Marshal(data)
 
 	if err == nil {

--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -577,7 +577,7 @@ func (g Alloc) OnAccount(addr common.Address, dumpAccount state.DumpAccount) {
 }
 
 // saveFile marshalls the object to the given file
-func saveFile(baseDir, filename string, data interface{}) error {
+func saveFile(baseDir, filename string, data any) error {
 	b, err := json.MarshalIndent(data, "", " ")
 	if err != nil {
 		return NewError(ErrorJson, fmt.Errorf("failed marshalling output: %v", err))
@@ -593,9 +593,9 @@ func saveFile(baseDir, filename string, data interface{}) error {
 // dispatchOutput writes the output data to either stderr or stdout, or to the specified
 // files
 func dispatchOutput(ctx *cli.Context, baseDir string, result *protocol.EphemeralExecResult, alloc Alloc, body hexutil.Bytes) error {
-	stdOutObject := make(map[string]interface{})
-	stdErrObject := make(map[string]interface{})
-	dispatch := func(baseDir, fName, name string, obj interface{}) error {
+	stdOutObject := make(map[string]any)
+	stdErrObject := make(map[string]any)
+	dispatch := func(baseDir, fName, name string, obj any) error {
 		switch fName {
 		case "stdout":
 			stdOutObject[name] = obj

--- a/cmd/evm/t8n_test.go
+++ b/cmd/evm/t8n_test.go
@@ -329,7 +329,7 @@ func checkExpectedOutput(t *testing.T, output []byte, expectationFilePath string
 
 // cmpJson compares the JSON in two byte slices.
 func cmpJson(a, b []byte) (bool, error) {
-	var j, j2 interface{}
+	var j, j2 any
 	if err := json.Unmarshal(a, &j); err != nil {
 		return false, err
 	}

--- a/cmd/integration/commands/commitment.go
+++ b/cmd/integration/commands/commitment.go
@@ -167,7 +167,7 @@ Examples:
 }
 
 func readBranch(stateReader *commitmentdb.LatestStateReader, prefix []byte, logger interface {
-	Info(msg string, ctx ...interface{})
+	Info(msg string, ctx ...any)
 }) error {
 	compactKey := commitment.HexNibblesToCompactBytes(prefix)
 	val, step, err := stateReader.Read(kv.CommitmentDomain, compactKey, config3.DefaultStepSize)

--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -1295,7 +1295,7 @@ func initRulesEngine(ctx context.Context, cc *chain2.Config, dir string, db kv.R
 	var heimdallService *heimdall.Service
 	var heimdallClient heimdall.Client
 	var bridgeClient bridge.Client
-	var rulesConfig interface{}
+	var rulesConfig any
 	if cc.Clique != nil {
 		rulesConfig = chainspec.CliqueSnapshot
 	} else if cc.Aura != nil {

--- a/cmd/rlpgen/testing/encdec_test.go
+++ b/cmd/rlpgen/testing/encdec_test.go
@@ -63,7 +63,7 @@ func (tr *TRand) RandBloom() types.Bloom {
 	return types.Bloom(tr.RandBytes(types.BloomByteLength))
 }
 
-func check(t *testing.T, f string, want, got interface{}) {
+func check(t *testing.T, f string, want, got any) {
 	if !reflect.DeepEqual(want, got) {
 		t.Errorf("%s mismatch: want %v, got %v", f, want, got)
 	}

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -701,7 +701,7 @@ func startRegularRpcServer(ctx context.Context, cfg *httpcfg.HttpCfg, rpcAPI []r
 		return fmt.Errorf("could not start register RPC apis: %w", err)
 	}
 
-	info := []interface{}{
+	info := []any{
 		"grpc", cfg.GRPCServerEnabled,
 		"http", cfg.HttpServerEnabled,
 		"ws", cfg.WebsocketEnabled,
@@ -956,7 +956,7 @@ func createEngineListener(cfg *httpcfg.HttpCfg, engineApi []rpc.API, logger log.
 		return nil, nil, "", fmt.Errorf("could not start RPC api: %w", err)
 	}
 
-	engineInfo := []interface{}{"url", engineAddr}
+	engineInfo := []any{"url", engineAddr}
 	logger.Info("HTTP endpoint opened for Engine API", engineInfo...)
 
 	return engineListener, engineSrv, engineAddr.String(), nil

--- a/cmd/rpcdaemon/graphql/graph/helpers.go
+++ b/cmd/rpcdaemon/graphql/graph/helpers.go
@@ -13,7 +13,7 @@ import (
 	"github.com/erigontech/erigon/execution/types"
 )
 
-func convertDataToStringP(abstractMap map[string]interface{}, field string) *string {
+func convertDataToStringP(abstractMap map[string]any, field string) *string {
 	var result string
 
 	switch v := abstractMap[field].(type) {
@@ -60,7 +60,7 @@ func convertDataToStringP(abstractMap map[string]interface{}, field string) *str
 	return &result
 }
 
-func convertDataToIntP(abstractMap map[string]interface{}, field string) *int {
+func convertDataToIntP(abstractMap map[string]any, field string) *int {
 	var result int
 
 	switch v := abstractMap[field].(type) {
@@ -88,7 +88,7 @@ func convertDataToIntP(abstractMap map[string]interface{}, field string) *int {
 	return &result
 }
 
-func convertDataToUint64P(abstractMap map[string]interface{}, field string) *uint64 {
+func convertDataToUint64P(abstractMap map[string]any, field string) *uint64 {
 	var result uint64
 
 	switch v := abstractMap[field].(type) {

--- a/cmd/rpcdaemon/graphql/graph/schema.resolvers.go
+++ b/cmd/rpcdaemon/graphql/graph/schema.resolvers.go
@@ -72,7 +72,7 @@ func (r *queryResolver) Block(ctx context.Context, number *string, hash *string)
 	absBlk := res["block"]
 
 	if absBlk != nil {
-		blk := absBlk.(map[string]interface{})
+		blk := absBlk.(map[string]any)
 
 		block.Difficulty = *convertDataToStringP(blk, "difficulty")
 		block.ExtraData = *convertDataToStringP(blk, "extraData")
@@ -117,7 +117,7 @@ func (r *queryResolver) Block(ctx context.Context, number *string, hash *string)
 
 		// Transactions
 		absRcp := res["receipts"]
-		rcp := absRcp.([]map[string]interface{})
+		rcp := absRcp.([]map[string]any)
 		for _, transReceipt := range rcp {
 			trans := &model.Transaction{}
 			trans.CumulativeGasUsed = convertDataToUint64P(transReceipt, "cumulativeGasUsed")
@@ -167,7 +167,7 @@ func (r *queryResolver) Block(ctx context.Context, number *string, hash *string)
 		// Withdrawals
 		block.Withdrawals = []*model.Withdrawal{}
 		absWthd := res["withdrawals"]
-		wthd := absWthd.([]map[string]interface{})
+		wthd := absWthd.([]map[string]any)
 		for _, withdrawal := range wthd {
 			wthd := &model.Withdrawal{}
 			wthd.Index = *convertDataToIntP(withdrawal, "index")

--- a/cmd/rpcdaemon/health/health_test.go
+++ b/cmd/rpcdaemon/health/health_test.go
@@ -42,17 +42,17 @@ func (n *netApiStub) PeerCount(_ context.Context) (hexutil.Uint, error) {
 }
 
 type ethApiStub struct {
-	blockResult   map[string]interface{}
+	blockResult   map[string]any
 	blockError    error
-	syncingResult interface{}
+	syncingResult any
 	syncingError  error
 }
 
-func (e *ethApiStub) GetBlockByNumber(_ context.Context, _ rpc.BlockNumber, _ bool) (map[string]interface{}, error) {
+func (e *ethApiStub) GetBlockByNumber(_ context.Context, _ rpc.BlockNumber, _ bool) (map[string]any, error) {
 	return e.blockResult, e.blockError
 }
 
-func (e *ethApiStub) Syncing(_ context.Context) (interface{}, error) {
+func (e *ethApiStub) Syncing(_ context.Context) (any, error) {
 	return e.syncingResult, e.syncingError
 }
 
@@ -61,9 +61,9 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 		headers             []string
 		netApiResponse      hexutil.Uint
 		netApiError         error
-		ethApiBlockResult   map[string]interface{}
+		ethApiBlockResult   map[string]any
 		ethApiBlockError    error
-		ethApiSyncingResult interface{}
+		ethApiSyncingResult any
 		ethApiSyncingError  error
 		expectedStatusCode  int
 		expectedBody        map[string]string
@@ -73,7 +73,7 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			headers:             []string{"synced"},
 			netApiResponse:      hexutil.Uint(1),
 			netApiError:         nil,
-			ethApiBlockResult:   make(map[string]interface{}),
+			ethApiBlockResult:   make(map[string]any),
 			ethApiBlockError:    nil,
 			ethApiSyncingResult: false,
 			ethApiSyncingError:  nil,
@@ -90,7 +90,7 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			headers:             []string{"synced"},
 			netApiResponse:      hexutil.Uint(1),
 			netApiError:         nil,
-			ethApiBlockResult:   make(map[string]interface{}),
+			ethApiBlockResult:   make(map[string]any),
 			ethApiBlockError:    nil,
 			ethApiSyncingResult: struct{}{},
 			ethApiSyncingError:  nil,
@@ -107,7 +107,7 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			headers:             []string{"synced"},
 			netApiResponse:      hexutil.Uint(1),
 			netApiError:         nil,
-			ethApiBlockResult:   make(map[string]interface{}),
+			ethApiBlockResult:   make(map[string]any),
 			ethApiBlockError:    nil,
 			ethApiSyncingResult: struct{}{},
 			ethApiSyncingError:  errors.New("problem checking sync"),
@@ -124,7 +124,7 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			headers:             []string{"min_peer_count1"},
 			netApiResponse:      hexutil.Uint(1),
 			netApiError:         nil,
-			ethApiBlockResult:   make(map[string]interface{}),
+			ethApiBlockResult:   make(map[string]any),
 			ethApiBlockError:    nil,
 			ethApiSyncingResult: false,
 			ethApiSyncingError:  nil,
@@ -141,7 +141,7 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			headers:             []string{"min_peer_count10"},
 			netApiResponse:      hexutil.Uint(1),
 			netApiError:         nil,
-			ethApiBlockResult:   make(map[string]interface{}),
+			ethApiBlockResult:   make(map[string]any),
 			ethApiBlockError:    nil,
 			ethApiSyncingResult: false,
 			ethApiSyncingError:  nil,
@@ -158,7 +158,7 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			headers:             []string{"min_peer_count10"},
 			netApiResponse:      hexutil.Uint(1),
 			netApiError:         errors.New("problem checking peers"),
-			ethApiBlockResult:   make(map[string]interface{}),
+			ethApiBlockResult:   make(map[string]any),
 			ethApiBlockError:    nil,
 			ethApiSyncingResult: false,
 			ethApiSyncingError:  nil,
@@ -175,7 +175,7 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			headers:             []string{"min_peer_countABC"},
 			netApiResponse:      hexutil.Uint(1),
 			netApiError:         nil,
-			ethApiBlockResult:   make(map[string]interface{}),
+			ethApiBlockResult:   make(map[string]any),
 			ethApiBlockError:    nil,
 			ethApiSyncingResult: false,
 			ethApiSyncingError:  nil,
@@ -192,7 +192,7 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			headers:             []string{"check_block10"},
 			netApiResponse:      hexutil.Uint(1),
 			netApiError:         nil,
-			ethApiBlockResult:   map[string]interface{}{"test": struct{}{}},
+			ethApiBlockResult:   map[string]any{"test": struct{}{}},
 			ethApiBlockError:    nil,
 			ethApiSyncingResult: false,
 			ethApiSyncingError:  nil,
@@ -209,7 +209,7 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			headers:             []string{"check_block10"},
 			netApiResponse:      hexutil.Uint(1),
 			netApiError:         nil,
-			ethApiBlockResult:   map[string]interface{}{},
+			ethApiBlockResult:   map[string]any{},
 			ethApiBlockError:    nil,
 			ethApiSyncingResult: false,
 			ethApiSyncingError:  nil,
@@ -226,7 +226,7 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			headers:             []string{"check_block10"},
 			netApiResponse:      hexutil.Uint(1),
 			netApiError:         nil,
-			ethApiBlockResult:   map[string]interface{}{},
+			ethApiBlockResult:   map[string]any{},
 			ethApiBlockError:    errors.New("problem checking block"),
 			ethApiSyncingResult: false,
 			ethApiSyncingError:  nil,
@@ -243,7 +243,7 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			headers:             []string{"check_blockABC"},
 			netApiResponse:      hexutil.Uint(1),
 			netApiError:         nil,
-			ethApiBlockResult:   map[string]interface{}{},
+			ethApiBlockResult:   map[string]any{},
 			ethApiBlockError:    nil,
 			ethApiSyncingResult: false,
 			ethApiSyncingError:  nil,
@@ -260,7 +260,7 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			headers:        []string{"max_seconds_behind60"},
 			netApiResponse: hexutil.Uint(1),
 			netApiError:    nil,
-			ethApiBlockResult: map[string]interface{}{
+			ethApiBlockResult: map[string]any{
 				"timestamp": uint64(time.Now().Add(-10 * time.Second).Unix()),
 			},
 			ethApiBlockError:    nil,
@@ -279,7 +279,7 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			headers:        []string{"max_seconds_behind60"},
 			netApiResponse: hexutil.Uint(1),
 			netApiError:    nil,
-			ethApiBlockResult: map[string]interface{}{
+			ethApiBlockResult: map[string]any{
 				"timestamp": uint64(time.Now().Add(-1 * time.Hour).Unix()),
 			},
 			ethApiBlockError:    nil,
@@ -298,7 +298,7 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			headers:        []string{"max_seconds_behind-1"},
 			netApiResponse: hexutil.Uint(1),
 			netApiError:    nil,
-			ethApiBlockResult: map[string]interface{}{
+			ethApiBlockResult: map[string]any{
 				"timestamp": uint64(time.Now().Add(1 * time.Hour).Unix()),
 			},
 			ethApiBlockError:    nil,
@@ -317,7 +317,7 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			headers:             []string{"max_seconds_behindABC"},
 			netApiResponse:      hexutil.Uint(1),
 			netApiError:         nil,
-			ethApiBlockResult:   map[string]interface{}{},
+			ethApiBlockResult:   map[string]any{},
 			ethApiBlockError:    nil,
 			ethApiSyncingResult: false,
 			ethApiSyncingError:  nil,
@@ -334,7 +334,7 @@ func TestProcessHealthcheckIfNeeded_HeadersTests(t *testing.T) {
 			headers:        []string{"synced", "check_block10", "min_peer_count1", "max_seconds_behind60"},
 			netApiResponse: hexutil.Uint(10),
 			netApiError:    nil,
-			ethApiBlockResult: map[string]interface{}{
+			ethApiBlockResult: map[string]any{
 				"timestamp": uint64(time.Now().Add(1 * time.Second).Unix()),
 			},
 			ethApiBlockError:    nil,
@@ -423,7 +423,7 @@ func TestProcessHealthcheckIfNeeded_RequestBody(t *testing.T) {
 		body               string
 		netApiResponse     hexutil.Uint
 		netApiError        error
-		ethApiBlockResult  map[string]interface{}
+		ethApiBlockResult  map[string]any
 		ethApiBlockError   error
 		expectedStatusCode int
 		expectedBody       map[string]string
@@ -433,7 +433,7 @@ func TestProcessHealthcheckIfNeeded_RequestBody(t *testing.T) {
 			body:               "{\"min_peer_count\": 1, \"known_block\": 123}",
 			netApiResponse:     hexutil.Uint(1),
 			netApiError:        nil,
-			ethApiBlockResult:  map[string]interface{}{"test": struct{}{}},
+			ethApiBlockResult:  map[string]any{"test": struct{}{}},
 			ethApiBlockError:   nil,
 			expectedStatusCode: http.StatusOK,
 			expectedBody: map[string]string{
@@ -447,7 +447,7 @@ func TestProcessHealthcheckIfNeeded_RequestBody(t *testing.T) {
 			body:               "{\"min_peer_count\" 1, \"known_block\": 123}",
 			netApiResponse:     hexutil.Uint(1),
 			netApiError:        nil,
-			ethApiBlockResult:  map[string]interface{}{"test": struct{}{}},
+			ethApiBlockResult:  map[string]any{"test": struct{}{}},
 			ethApiBlockError:   nil,
 			expectedStatusCode: http.StatusInternalServerError,
 			expectedBody: map[string]string{
@@ -461,7 +461,7 @@ func TestProcessHealthcheckIfNeeded_RequestBody(t *testing.T) {
 			body:               "{\"min_peer_count\": 1, \"known_block\": 123}",
 			netApiResponse:     hexutil.Uint(1),
 			netApiError:        errors.New("problem getting peers"),
-			ethApiBlockResult:  map[string]interface{}{"test": struct{}{}},
+			ethApiBlockResult:  map[string]any{"test": struct{}{}},
 			ethApiBlockError:   nil,
 			expectedStatusCode: http.StatusInternalServerError,
 			expectedBody: map[string]string{
@@ -475,7 +475,7 @@ func TestProcessHealthcheckIfNeeded_RequestBody(t *testing.T) {
 			body:               "{\"min_peer_count\": 10, \"known_block\": 123}",
 			netApiResponse:     hexutil.Uint(1),
 			netApiError:        nil,
-			ethApiBlockResult:  map[string]interface{}{"test": struct{}{}},
+			ethApiBlockResult:  map[string]any{"test": struct{}{}},
 			ethApiBlockError:   nil,
 			expectedStatusCode: http.StatusInternalServerError,
 			expectedBody: map[string]string{
@@ -489,7 +489,7 @@ func TestProcessHealthcheckIfNeeded_RequestBody(t *testing.T) {
 			body:               "{\"min_peer_count\": 1, \"known_block\": 123}",
 			netApiResponse:     hexutil.Uint(1),
 			netApiError:        nil,
-			ethApiBlockResult:  map[string]interface{}{},
+			ethApiBlockResult:  map[string]any{},
 			ethApiBlockError:   nil,
 			expectedStatusCode: http.StatusInternalServerError,
 			expectedBody: map[string]string{
@@ -503,7 +503,7 @@ func TestProcessHealthcheckIfNeeded_RequestBody(t *testing.T) {
 			body:               "{\"min_peer_count\": 1, \"known_block\": 123}",
 			netApiResponse:     hexutil.Uint(1),
 			netApiError:        nil,
-			ethApiBlockResult:  map[string]interface{}{},
+			ethApiBlockResult:  map[string]any{},
 			ethApiBlockError:   errors.New("problem getting block"),
 			expectedStatusCode: http.StatusInternalServerError,
 			expectedBody: map[string]string{

--- a/cmd/rpcdaemon/health/interfaces.go
+++ b/cmd/rpcdaemon/health/interfaces.go
@@ -29,6 +29,6 @@ type NetAPI interface {
 }
 
 type EthAPI interface {
-	GetBlockByNumber(_ context.Context, number rpc.BlockNumber, fullTx bool) (map[string]interface{}, error)
-	Syncing(ctx context.Context) (interface{}, error)
+	GetBlockByNumber(_ context.Context, number rpc.BlockNumber, fullTx bool) (map[string]any, error)
+	Syncing(ctx context.Context) (any, error)
 }

--- a/cmd/rpcdaemon/rpcservices/eth_backend.go
+++ b/cmd/rpcdaemon/rpcservices/eth_backend.go
@@ -371,7 +371,7 @@ func (back *RemoteBackend) NodeInfo(ctx context.Context, limit uint32) ([]p2p.No
 			return nil, fmt.Errorf("cannot decode protocols metadata: %w", err)
 		}
 
-		protocols := make(map[string]interface{}, len(rawProtocols))
+		protocols := make(map[string]any, len(rawProtocols))
 		for k, v := range rawProtocols {
 			protocols[k] = v
 		}

--- a/cmd/rpctest/rpctest/request_generator.go
+++ b/cmd/rpctest/rpctest/request_generator.go
@@ -362,7 +362,7 @@ var client = &http.Client{
 	Timeout: 600 * time.Second, // Per-request timeout
 }
 
-func (g *RequestGenerator) call(target string, method, body string, response interface{}) CallResult {
+func (g *RequestGenerator) call(target string, method, body string, response any) CallResult {
 	start := time.Now()
 	err := post(client, routes[target], body, response)
 	return CallResult{
@@ -394,11 +394,11 @@ func (g *RequestGenerator) call2(target string, method, body string) CallResult 
 	}
 }
 
-func (g *RequestGenerator) Geth(method, body string, response interface{}) CallResult {
+func (g *RequestGenerator) Geth(method, body string, response any) CallResult {
 	return g.call(Geth, method, body, response)
 }
 
-func (g *RequestGenerator) Erigon(method, body string, response interface{}) CallResult {
+func (g *RequestGenerator) Erigon(method, body string, response any) CallResult {
 	return g.call(Erigon, method, body, response)
 }
 

--- a/cmd/rpctest/rpctest/type.go
+++ b/cmd/rpctest/rpctest/type.go
@@ -69,7 +69,7 @@ type EthSendRawTransaction struct {
 
 type EthTxPool struct {
 	CommonResponse
-	Result interface{} `json:"result"`
+	Result any `json:"result"`
 }
 
 type EthBlockByNumberResult struct {
@@ -151,9 +151,9 @@ type TraceCallTraceResult struct {
 }
 
 type TraceCallStateDiff struct {
-	Balance interface{}                                          `json:"balance"`
-	Nonce   interface{}                                          `json:"nonce"`
-	Code    interface{}                                          `json:"code"`
+	Balance any                                                  `json:"balance"`
+	Nonce   any                                                  `json:"nonce"`
+	Code    any                                                  `json:"code"`
 	Storage map[common.Hash]map[string]TraceCallStateDiffStorage `json:"storage"`
 }
 

--- a/cmd/rpctest/rpctest/utils.go
+++ b/cmd/rpctest/rpctest/utils.go
@@ -649,7 +649,7 @@ func compareProofs(proof, gethProof *EthGetProof) bool {
 	return equal
 }
 
-func post(client *http.Client, url, request string, response interface{}) error {
+func post(client *http.Client, url, request string, response any) error {
 	//fmt.Printf("Request=%s\n", request)
 	//log.Info("Getting", "url", url, "request", request)
 	//start := time.Now()

--- a/cmd/snapshots/genfromrpc/genfromrpc.go
+++ b/cmd/snapshots/genfromrpc/genfromrpc.go
@@ -76,9 +76,9 @@ type BlockJson struct {
 	ParentBeaconBlockRoot *common.Hash `json:"parentBeaconBlockRoot"` // EIP-4788
 	RequestsHash          *common.Hash `json:"requestsHash"`          // EIP-7685
 
-	Uncles       []*types.Header          `json:"uncles"`
-	Withdrawals  types.Withdrawals        `json:"withdrawals"`
-	Transactions []map[string]interface{} `json:"transactions"`
+	Uncles       []*types.Header   `json:"uncles"`
+	Withdrawals  types.Withdrawals `json:"withdrawals"`
+	Transactions []map[string]any  `json:"transactions"`
 }
 
 // --- Helper functions ---
@@ -92,7 +92,7 @@ func convertHexToBigInt(hexStr string) *big.Int {
 }
 
 // getUint256FromField returns a *uint256.Int from the rawTx field if present.
-func getUint256FromField(rawTx map[string]interface{}, field string) *uint256.Int {
+func getUint256FromField(rawTx map[string]any, field string) *uint256.Int {
 	if val, ok := rawTx[field].(string); ok {
 		i := new(uint256.Int)
 		i.SetFromBig(convertHexToBigInt(val))
@@ -102,11 +102,11 @@ func getUint256FromField(rawTx map[string]interface{}, field string) *uint256.In
 }
 
 // buildDynamicFeeFields sets the common dynamic fee fields from rawTx.
-func buildDynamicFeeFields(tx *types.DynamicFeeTransaction, rawTx map[string]interface{}) {
+func buildDynamicFeeFields(tx *types.DynamicFeeTransaction, rawTx map[string]any) {
 	if chainID := getUint256FromField(rawTx, "chainId"); chainID != nil {
 		tx.ChainID = chainID
 	}
-	if accessListRaw, ok := rawTx["accessList"].([]interface{}); ok {
+	if accessListRaw, ok := rawTx["accessList"].([]any); ok {
 		tx.AccessList = decodeAccessList(accessListRaw)
 	}
 	if tipCap := getUint256FromField(rawTx, "maxPriorityFeePerGas"); tipCap != nil {
@@ -118,7 +118,7 @@ func buildDynamicFeeFields(tx *types.DynamicFeeTransaction, rawTx map[string]int
 }
 
 // parseCommonTx extracts the shared fields from a raw transaction into a CommonTx.
-func parseCommonTx(rawTx map[string]interface{}) (*types.CommonTx, error) {
+func parseCommonTx(rawTx map[string]any) (*types.CommonTx, error) {
 	var commonTx types.CommonTx
 
 	nonceStr, ok := rawTx["nonce"].(string)
@@ -157,10 +157,10 @@ func parseCommonTx(rawTx map[string]interface{}) (*types.CommonTx, error) {
 }
 
 // decodeAccessList converts a raw access list (slice of interface{}) into types.AccessList.
-func decodeAccessList(rawAccessList []interface{}) types.AccessList {
+func decodeAccessList(rawAccessList []any) types.AccessList {
 	var accessList types.AccessList
 	for _, rawSlotInterface := range rawAccessList {
-		slot, ok := rawSlotInterface.(map[string]interface{})
+		slot, ok := rawSlotInterface.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -168,7 +168,7 @@ func decodeAccessList(rawAccessList []interface{}) types.AccessList {
 		if addrStr, ok := slot["address"].(string); ok {
 			tuple.Address = common.HexToAddress(addrStr)
 		}
-		if storageKeys, ok := slot["storageKeys"].([]interface{}); ok {
+		if storageKeys, ok := slot["storageKeys"].([]any); ok {
 			for _, keyIface := range storageKeys {
 				if keyStr, ok := keyIface.(string); ok {
 					tuple.StorageKeys = append(tuple.StorageKeys, common.HexToHash(keyStr))
@@ -192,7 +192,7 @@ func decodeBlobVersionedHashes(rawVersionedHashes []string) []common.Hash {
 // --- Transaction builders ---
 
 // makeLegacyTx builds a legacy transaction.
-func makeLegacyTx(commonTx *types.CommonTx, rawTx map[string]interface{}) types.Transaction {
+func makeLegacyTx(commonTx *types.CommonTx, rawTx map[string]any) types.Transaction {
 	tx := &types.LegacyTx{
 		CommonTx: types.CommonTx{
 			Nonce:    commonTx.Nonce,
@@ -210,7 +210,7 @@ func makeLegacyTx(commonTx *types.CommonTx, rawTx map[string]interface{}) types.
 }
 
 // makeAccessListTx builds an access-list transaction.
-func makeAccessListTx(commonTx *types.CommonTx, rawTx map[string]interface{}) types.Transaction {
+func makeAccessListTx(commonTx *types.CommonTx, rawTx map[string]any) types.Transaction {
 	tx := &types.AccessListTx{
 		LegacyTx: types.LegacyTx{
 			CommonTx: types.CommonTx{
@@ -229,14 +229,14 @@ func makeAccessListTx(commonTx *types.CommonTx, rawTx map[string]interface{}) ty
 	if chainID := getUint256FromField(rawTx, "chainId"); chainID != nil {
 		tx.ChainID = chainID
 	}
-	if accessListRaw, ok := rawTx["accessList"].([]interface{}); ok {
+	if accessListRaw, ok := rawTx["accessList"].([]any); ok {
 		tx.AccessList = decodeAccessList(accessListRaw)
 	}
 	return tx
 }
 
 // makeEip1559Tx builds an EIP-1559 dynamic fee transaction.
-func makeEip1559Tx(commonTx *types.CommonTx, rawTx map[string]interface{}) types.Transaction {
+func makeEip1559Tx(commonTx *types.CommonTx, rawTx map[string]any) types.Transaction {
 	tx := &types.DynamicFeeTransaction{CommonTx: types.CommonTx{
 		Nonce:    commonTx.Nonce,
 		GasLimit: commonTx.GasLimit,
@@ -252,7 +252,7 @@ func makeEip1559Tx(commonTx *types.CommonTx, rawTx map[string]interface{}) types
 }
 
 // makeEip4844Tx builds an EIP-4844 blob transaction.
-func makeEip4844Tx(commonTx *types.CommonTx, rawTx map[string]interface{}) types.Transaction {
+func makeEip4844Tx(commonTx *types.CommonTx, rawTx map[string]any) types.Transaction {
 	blobTx := &types.BlobTx{
 		DynamicFeeTransaction: types.DynamicFeeTransaction{CommonTx: types.CommonTx{
 			Nonce:    commonTx.Nonce,
@@ -268,7 +268,7 @@ func makeEip4844Tx(commonTx *types.CommonTx, rawTx map[string]interface{}) types
 	buildDynamicFeeFields(&blobTx.DynamicFeeTransaction, rawTx)
 	blobTx.MaxFeePerBlobGas = getUint256FromField(rawTx, "maxFeePerBlobGas")
 	// The raw JSON is expected to contain a slice of strings.
-	if rawHashes, ok := rawTx["blobVersionedHashes"].([]interface{}); ok {
+	if rawHashes, ok := rawTx["blobVersionedHashes"].([]any); ok {
 		var hashStrs []string
 		for _, h := range rawHashes {
 			if s, ok := h.(string); ok {
@@ -282,7 +282,7 @@ func makeEip4844Tx(commonTx *types.CommonTx, rawTx map[string]interface{}) types
 
 // makeEip7702Tx builds an EIP-7702 transaction.
 // (Implementation details remain to be determined.)
-func makeEip7702Tx(commonTx *types.CommonTx, rawTx map[string]interface{}) types.Transaction {
+func makeEip7702Tx(commonTx *types.CommonTx, rawTx map[string]any) types.Transaction {
 	tx := &types.SetCodeTransaction{
 		DynamicFeeTransaction: types.DynamicFeeTransaction{CommonTx: types.CommonTx{
 			Nonce:    commonTx.Nonce,
@@ -301,7 +301,7 @@ func makeEip7702Tx(commonTx *types.CommonTx, rawTx map[string]interface{}) types
 }
 
 // unMarshalTransactions decodes a slice of raw transactions into types.Transactions.
-func unMarshalTransactions(rawTxs []map[string]interface{}) (types.Transactions, error) {
+func unMarshalTransactions(rawTxs []map[string]any) (types.Transactions, error) {
 	var txs types.Transactions
 
 	for _, rawTx := range rawTxs {

--- a/cmd/txnbench/internal/rpcclient/client.go
+++ b/cmd/txnbench/internal/rpcclient/client.go
@@ -26,10 +26,10 @@ func New(url string, timeout time.Duration) *Client {
 }
 
 type rpcReq struct {
-	JsonRPC string      `json:"jsonrpc"`
-	ID      int         `json:"id"`
-	Method  string      `json:"method"`
-	Params  interface{} `json:"params"`
+	JsonRPC string `json:"jsonrpc"`
+	ID      int    `json:"id"`
+	Method  string `json:"method"`
+	Params  any    `json:"params"`
 }
 
 type rpcResp[T any] struct {
@@ -42,7 +42,7 @@ type rpcResp[T any] struct {
 	} `json:"error,omitempty"`
 }
 
-func (c *Client) Call(ctx context.Context, method string, params interface{}, out any) error {
+func (c *Client) Call(ctx context.Context, method string, params any, out any) error {
 	body, _ := json.Marshal(rpcReq{JsonRPC: "2.0", ID: 1, Method: method, Params: params})
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url, bytes.NewReader(body))
 	if err != nil {

--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -30,7 +30,7 @@ import (
 // Fatalf formats a message to standard error and exits the program.
 // The message is also printed to standard output if standard error
 // is redirected to a different file.
-func Fatalf(format string, args ...interface{}) {
+func Fatalf(format string, args ...any) {
 	w := io.MultiWriter(os.Stdout, os.Stderr)
 	if runtime.GOOS == "windows" {
 		// The SameFile check below doesn't work on Windows.

--- a/cmd/utils/cmdtest/test_cmd.go
+++ b/cmd/utils/cmdtest/test_cmd.go
@@ -40,7 +40,7 @@ import (
 	"github.com/erigontech/erigon/internal/reexec"
 )
 
-func NewTestCmd(t *testing.T, data interface{}) *TestCmd {
+func NewTestCmd(t *testing.T, data any) *TestCmd {
 	return &TestCmd{T: t, Data: data}
 }
 
@@ -49,7 +49,7 @@ type TestCmd struct {
 	*testing.T
 
 	Func    template.FuncMap
-	Data    interface{}
+	Data    any
 	Cleanup func()
 
 	cmd    *exec.Cmd
@@ -94,9 +94,9 @@ func (tt *TestCmd) InputLine(s string) string {
 	return ""
 }
 
-func (tt *TestCmd) SetTemplateFunc(name string, fn interface{}) {
+func (tt *TestCmd) SetTemplateFunc(name string, fn any) {
 	if tt.Func == nil {
-		tt.Func = make(map[string]interface{})
+		tt.Func = make(map[string]any)
 	}
 	tt.Func[name] = fn
 }

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1765,7 +1765,7 @@ func setSilkworm(ctx *cli.Context, cfg *ethconfig.Config) {
 // CheckExclusive verifies that only a single instance of the provided flags was
 // set by the user. Each flag might optionally be followed by a string type to
 // specialize it further.
-func CheckExclusive(ctx *cli.Context, args ...interface{}) {
+func CheckExclusive(ctx *cli.Context, args ...any) {
 	set := make([]string, 0, 1)
 	for i := 0; i < len(args); i++ {
 		// Make sure the next argument is a flag and skip if not set


### PR DESCRIPTION
This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.

As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.