### PR TITLE
fix: use AuthRpcIdleTimeoutFlag instead of HTTPIdleTimeoutFlag for AuthRpcTimeouts

### DIFF
--- a/node/cli/flags.go
+++ b/node/cli/flags.go
@@ -426,7 +426,7 @@ func setEmbeddedRpcDaemon(ctx *cli.Context, cfg *nodecfg.Config, logger log.Logg
 		AuthRpcTimeouts: rpccfg.HTTPTimeouts{
 			ReadTimeout:  ctx.Duration(AuthRpcReadTimeoutFlag.Name),
 			WriteTimeout: ctx.Duration(AuthRpcWriteTimeoutFlag.Name),
-			IdleTimeout:  ctx.Duration(HTTPIdleTimeoutFlag.Name),
+			IdleTimeout:  ctx.Duration(AuthRpcIdleTimeoutFlag.Name),
 		},
 		EvmCallTimeout:            ctx.Duration(EvmCallTimeoutFlag.Name),
 		OverlayGetLogsTimeout:     ctx.Duration(OverlayGetLogsFlag.Name),


### PR DESCRIPTION
AuthRpcTimeouts.IdleTimeout was using HTTPIdleTimeoutFlag instead of AuthRpcIdleTimeoutFlag, making - authrpc.timeouts.idle flag ineffective.

This fix allows independent AuthRPC timeout configuration.