### PR TITLE
execution/p2p: avoid redundant empty batch in backward block downloader

### DIFF
--- a/execution/p2p/bbd.go
+++ b/execution/p2p/bbd.go
@@ -391,7 +391,7 @@ func (bbd *BackwardBlockDownloader) downloadBlocks(
 		return err
 	}
 	if len(headers) == 0 {
-		return feed.consumeData(ctx, nil)
+		return nil
 	}
 	// make sure to download blocks for the remaining incomplete header batch after the etl collector has been loaded
 	return bbd.downloadBlocksForHeaders(ctx, headers, peers, config, logProgressTicker, feed)


### PR DESCRIPTION
The backward block downloader was sending an explicit empty block batch when no headers remained after loading from the ETL collector. Consumers already treat a closed result feed channel as end-of-stream and stop on zero-length batches, so this extra send did not change observable behavior and only added protocol noise. The code now simply returns when no headers are left, relying on channel closure to signal completion.