### PR TITLE
docs: fix ReceiptsFilterCriteria type name in comment

### DIFF
--- a/rpc/filters/api.go
+++ b/rpc/filters/api.go
@@ -48,7 +48,7 @@ func DefaultLogFilterOptions() LogFilterOptions {
 	}
 }
 
-// TransactionReceiptsFilter defines criteria for transaction receipts subscription.
+// ReceiptsFilterCriteria defines criteria for transaction receipts subscription.
 // If TransactionHashes is nil or empty, receipts for all transactions included in new blocks will be delivered.
 // Otherwise, only receipts for the specified transactions will be delivered.
 type ReceiptsFilterCriteria struct {


### PR DESCRIPTION
### Motivation
The documentation comment for ReceiptsFilterCriteria incorrectly referenced a non-existent type name TransactionReceiptsFilter, which could mislead developers searching for the type definition.
### Solution
Updated the comment to correctly reference ReceiptsFilterCriteria, matching the actual type name defined in the code.