### PR TITLE
node/eth: remove unused engineAPISwitcher adapter

### DIFF
--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -1743,14 +1743,3 @@ func setBorDefaultTxPoolPriceLimit(chainConfig *chain.Config, config *txpoolcfg.
 func sentryMux(sentries []sentryproto.SentryClient) sentryproto.SentryClient {
 	return libsentry.NewSentryMultiplexer(sentries)
 }
-
-type engineAPISwitcher struct {
-	backend *Ethereum
-}
-
-func (e *engineAPISwitcher) SetConsuming(consuming bool) {
-	if e.backend.engineBackendRPC == nil {
-		return
-	}
-	e.backend.engineBackendRPC.SetConsuming(consuming)
-}


### PR DESCRIPTION
The engineAPISwitcher adapter in node/eth/backend.go was never instantiated and is effectively dead code. Polygon PoS sync already talks directly to EngineServer, which implements the EngineAPISwitcher interface via SetConsuming. Removing this unused type simplifies the backend wiring around the Engine API and avoids confusion about which component actually controls the consuming flag.