### PR TITLE
Erigon: fixed sender recovery race

### DIFF
--- a/execution/stagedsync/stage_senders.go
+++ b/execution/stagedsync/stage_senders.go
@@ -276,6 +276,7 @@ Loop:
 			if err := collectorSenders.Collect(dbutils.BlockBodyKey(s.BlockNumber+uint64(blockIndex)+1, blockHash), nil); err != nil {
 				return err
 			}
+			pendingMu.Unlock()
 			continue
 		}
 		pendingBlocks[blockIndex] = &pendingBlock{


### PR DESCRIPTION
Simply put the lock around the 0 txs case