### PR TITLE
execution/stagedsync/headerdownload: avoid redundant RLP encoding

### DIFF
--- a/execution/stagedsync/headerdownload/header_algos.go
+++ b/execution/stagedsync/headerdownload/header_algos.go
@@ -1296,18 +1296,11 @@ func (hd *HeaderDownload) AddHeadersFromSnapshot(tx kv.Tx, r services.FullBlockR
 		if header == nil {
 			continue
 		}
-		v, err := rlp.EncodeToBytes(header)
-		if err != nil {
-			return err
-		}
 		h := ChainSegmentHeader{
-			HeaderRaw: v,
-			Header:    header,
-			Hash:      header.Hash(),
-			Number:    header.Number.Uint64(),
+			Hash:   header.Hash(),
+			Number: header.Number.Uint64(),
 		}
-		link := hd.addHeaderAsLink(h, true /* persisted */)
-		link.verified = true
+		hd.addHeaderAsLink(h, true /* persisted */)
 	}
 	if hd.highestInDb < n {
 		hd.highestInDb = n


### PR DESCRIPTION
Persisted links immediately drop header and headerRaw fields and only keep hash and block number. AddHeadersFromSnapshot was still encoding headers to RLP and passing both header and headerRaw into addHeaderAsLink, even though this data was discarded for persisted links.   This change stops encoding headers to RLP and only initializes ChainSegmentHeader with hash and number for persisted links, keeping the behavior the same while removing unnecessary allocations and work during snapshot-based header prefill.
