### PR TITLE
refactor: remove obsolete Matches sort methods and add MatchFinder comment

### DIFF
--- a/db/seg/patricia/patricia.go
+++ b/db/seg/patricia/patricia.go
@@ -352,18 +352,8 @@ type Match struct {
 
 type Matches []Match
 
-func (m Matches) Len() int {
-	return len(m)
-}
-
-func (m Matches) Less(i, j int) bool {
-	return m[i].Start < m[j].Start
-}
-
-func (m *Matches) Swap(i, j int) {
-	(*m)[i], (*m)[j] = (*m)[j], (*m)[i]
-}
-
+// MatchFinder is the original implementation kept for validation purposes.
+// It's used in fuzz tests to compare results with MatchFinder2.
 type MatchFinder struct {
 	pt      *PatriciaTree
 	s       pathWalker
@@ -699,7 +689,6 @@ func (mf2 *MatchFinder2) FindLongestMatches(data []byte) []Match {
 	if len(mf2.matches) < 2 {
 		return mf2.matches
 	}
-	//sort.Sort(&mf2.matches)
 	slices.SortFunc(mf2.matches, func(i, j Match) int { return cmp.Compare(i.Start, j.Start) })
 
 	lastEnd := mf2.matches[0].End


### PR DESCRIPTION
Removed unused Len(), Less(), and Swap() methods from Matches type that were part of the old sort.Interface implementation. The code now uses slices.SortFunc instead. Also removed the commented-out sort.Sort call and added a clarifying comment explaining that MatchFinder is kept for validation in fuzz tests.