### PR TITLE
refactor: remove unused All struct from services package

### DIFF
--- a/db/services/interfaces.go
+++ b/db/services/interfaces.go
@@ -30,10 +30,6 @@ import (
 	"github.com/erigontech/erigon/node/ethconfig"
 )
 
-type All struct {
-	BlockReader FullBlockReader
-}
-
 type BlockReader interface {
 	BlockByNumber(ctx context.Context, db kv.Tx, number uint64) (*types.Block, error)
 	BlockByHash(ctx context.Context, db kv.Tx, hash common.Hash) (*types.Block, error)


### PR DESCRIPTION
Remove the unused All struct that was never referenced in the codebase.

The current architecture uses FullBlockReader directly and doesn't require this container struct.