### PR TITLE
fix: prevent Exp() from mutating input base parameter

### DIFF
--- a/common/math/big.go
+++ b/common/math/big.go
@@ -259,13 +259,14 @@ func S256(x *big.Int) *big.Int {
 // Courtesy @karalabe and @chfast
 func Exp(base, exponent *big.Int) *big.Int {
 	result := big.NewInt(1)
+	baseCopy := new(big.Int).Set(base)
 
 	for _, word := range exponent.Bits() {
 		for i := 0; i < wordBits; i++ {
 			if word&1 == 1 {
-				U256(result.Mul(result, base))
+				U256(result.Mul(result, baseCopy))
 			}
-			U256(base.Mul(base, base))
+			U256(baseCopy.Mul(baseCopy, baseCopy))
 			word >>= 1
 		}
 	}


### PR DESCRIPTION
The Exp function in common/math/big.go was modifying the input base parameter despite the documentation explicitly stating "does not change base or exponent". This caused unexpected behavior when the same base value was reused after calling Exp(). Fixed by creating a copy of base before performing operations.