### PR TITLE
refactor: remove unused SSZ bitlist overlap helpers

### DIFF
--- a/cl/utils/bytes.go
+++ b/cl/utils/bytes.go
@@ -166,42 +166,6 @@ func IsNonStrictSupersetBitlist(a, b []byte) bool {
 	return true
 }
 
-// IsOverlappingSSZBitlist checks if bitlist 'a' and bitlist 'b' have any overlapping bits
-// However, it ignores the last bits in the last byte.
-func IsOverlappingSSZBitlist(a, b []byte) bool {
-	length := min(len(a), len(b))
-	for i := range length {
-
-		if a[i]&b[i] != 0 {
-			if i != length-1 {
-				return true
-			}
-			var foundOverlap bool
-			// check the overlap bit by bit
-			for j := 0; j < 8; j++ {
-				if (a[i]>>j)&(b[i]>>j)&1 == 1 {
-					if foundOverlap {
-						return true
-					}
-					foundOverlap = true
-				}
-			}
-		}
-	}
-	return false
-
-}
-
-// func IsOverlappingBitlist(a, b []byte) bool {
-// 	length := min(len(a), len(b))
-// 	for i := range length {
-// 		if a[i]&b[i] != 0 {
-// 			return true
-// 		}
-// 	}
-// 	return false
-// }
-
 func BitsOnCount(b []byte) int {
 	count := 0
 	for _, v := range b {


### PR DESCRIPTION
Remove the unused helpers IsOverlappingSSZBitlist and the commented-out IsOverlappingBitlist from cl/utils/bytes.go. These functions implement non-trivial logic that relies on SSZ bitlist invariants but are not referenced anywhere in the codebase, which makes them dead and potentially misleading for future reuse. Dropping them keeps the bytes utilities focused on actively used helpers and avoids the risk of silent misbehaviour if someone later tries to apply these functions to arbitrary byte slices.