### PR TITLE
fix: remove duplicate TxPoolBlobPriceBumpFlag check in setTxPool

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1527,9 +1527,6 @@ func setTxPool(ctx *cli.Context, dbDir string, fullCfg *ethconfig.Config) {
 			cfg.TracedSenders[i] = string(sender[:])
 		}
 	}
-	if ctx.IsSet(TxPoolBlobPriceBumpFlag.Name) {
-		cfg.BlobPriceBump = ctx.Uint64(TxPoolBlobPriceBumpFlag.Name)
-	}
 	if ctx.IsSet(DbWriteMapFlag.Name) {
 		cfg.MdbxWriteMap = ctx.Bool(DbWriteMapFlag.Name)
 	}


### PR DESCRIPTION
Remove duplicate TxPoolBlobPriceBumpFlag check and assignment in setTxPool function. The same flag was checked and cfg.BlobPriceBump was set twice with identical logic, making the second occurrence redundant.