### PR TITLE
execution/exec: remove duplicated historyMode switch in RunTxTaskNoLock

### DIFF
--- a/execution/exec/state.go
+++ b/execution/exec/state.go
@@ -338,15 +338,6 @@ func (rw *Worker) SetReader(reader state.StateReader) {
 }
 
 func (rw *Worker) RunTxTaskNoLock(txTask Task) *TxResult {
-	if txTask.IsHistoric() && !rw.historyMode {
-		// in case if we cancelled execution and commitment happened in the middle of the block, we have to process block
-		// from the beginning until committed txNum and only then disable history mode.
-		// Needed to correctly evaluate spent gas and other things.
-		rw.SetReader(state.NewHistoryReaderV3())
-	} else if !txTask.IsHistoric() && rw.historyMode {
-		rw.SetReader(state.NewBufferedReader(rw.rs, state.NewReaderV3(rw.rs.Domains().AsGetter(rw.chainTx))))
-	}
-
 	if rw.background && rw.chainTx == nil {
 		chainTx, err := rw.chainDb.BeginTemporalRo(rw.ctx) //nolint
 


### PR DESCRIPTION
This change removes a duplicated IsHistoric()/historyMode conditional at the start of RunTxTaskNoLock, leaving a single switch after the optional chainTx initialisation. The upper block was logically dead: after it runs, the second block with the same condition never changes historyMode again, so it only adds noise and confusion.

By keeping the lower block we ensure that the choice between HistoryReaderV3 and buffered ReaderV3 is made after chainTx is opened in background workers, which is the more natural place to reconfigure the state reader. Behaviour is otherwise unchanged, but the control flow is simpler and easier to reason about.