### PR TITLE
reduce noise in `dbg.Stack()` output

### DIFF
--- a/common/dbg/log_panic.go
+++ b/common/dbg/log_panic.go
@@ -29,10 +29,10 @@ import (
 
 // Stack returns stack-trace in logger-friendly compact formatting
 func Stack() string {
-	return stack2.Trace().TrimBelow(stack2.Caller(1)).String()
+	return stack2.Trace().TrimBelow(stack2.Caller(1)).TrimAbove(stack2.Caller(1)).String()
 }
 func StackSkip(skip int) string {
-	return stack2.Trace().TrimBelow(stack2.Caller(skip)).String()
+	return stack2.Trace().TrimBelow(stack2.Caller(skip)).TrimAbove(stack2.Caller(1)).String()
 }
 
 var sigc atomic.Value


### PR DESCRIPTION
change from:
```
[block_snapshots.go:500 block_snapshots.go:440 asm_amd64.s:1693]
```

to:
```
[block_snapshots.go:500 block_snapshots.go:440]
```
