### PR TITLE
[flags] override.balancer -> override.amsterdam

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -122,9 +122,9 @@ var (
 		Name:  "override.osaka",
 		Usage: "Manually specify the Osaka fork time, overriding the bundled setting",
 	}
-	OverrideBalancerFlag = flags.BigFlag{
-		Name:  "override.balancer",
-		Usage: "Manually specify the Balancer fork time, overriding the bundled setting",
+	OverrideAmsterdamFlag = flags.BigFlag{
+		Name:  "override.amsterdam",
+		Usage: "Manually specify the Amsterdam fork time, overriding the bundled setting",
 	}
 	KeepStoredChainConfigFlag = cli.BoolFlag{
 		Name:  "keep.stored.chain.config",
@@ -1945,8 +1945,8 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 	if ctx.IsSet(OverrideOsakaFlag.Name) {
 		cfg.OverrideOsakaTime = flags.GlobalBig(ctx, OverrideOsakaFlag.Name)
 	}
-	if ctx.IsSet(OverrideBalancerFlag.Name) {
-		cfg.OverrideBalancerTime = flags.GlobalBig(ctx, OverrideBalancerFlag.Name)
+	if ctx.IsSet(OverrideAmsterdamFlag.Name) {
+		cfg.OverrideAmsterdamTime = flags.GlobalBig(ctx, OverrideAmsterdamFlag.Name)
 	}
 	cfg.KeepStoredChainConfig = ctx.Bool(KeepStoredChainConfigFlag.Name)
 

--- a/execution/state/genesiswrite/genesis_write.go
+++ b/execution/state/genesiswrite/genesis_write.go
@@ -87,13 +87,13 @@ func CommitGenesisBlock(db kv.RwDB, genesis *types.Genesis, dirs datadir.Dirs, l
 	return CommitGenesisBlockWithOverride(db, genesis, nil, nil, false, dirs, logger)
 }
 
-func CommitGenesisBlockWithOverride(db kv.RwDB, genesis *types.Genesis, overrideOsakaTime, overrideBalancerTime *big.Int, keepStoredChainConfig bool, dirs datadir.Dirs, logger log.Logger) (*chain.Config, *types.Block, error) {
+func CommitGenesisBlockWithOverride(db kv.RwDB, genesis *types.Genesis, overrideOsakaTime, overrideAmsterdamTime *big.Int, keepStoredChainConfig bool, dirs datadir.Dirs, logger log.Logger) (*chain.Config, *types.Block, error) {
 	tx, err := db.BeginRw(context.Background())
 	if err != nil {
 		return nil, nil, err
 	}
 	defer tx.Rollback()
-	c, b, err := WriteGenesisBlock(tx, genesis, overrideOsakaTime, overrideBalancerTime, keepStoredChainConfig, dirs, logger)
+	c, b, err := WriteGenesisBlock(tx, genesis, overrideOsakaTime, overrideAmsterdamTime, keepStoredChainConfig, dirs, logger)
 	if err != nil {
 		return c, b, err
 	}
@@ -115,7 +115,7 @@ func configOrDefault(g *types.Genesis, genesisHash common.Hash) *chain.Config {
 	return spec.Config
 }
 
-func WriteGenesisBlock(tx kv.RwTx, genesis *types.Genesis, overrideOsakaTime, overrideBalancerTime *big.Int, keepStoredChainConfig bool, dirs datadir.Dirs, logger log.Logger) (*chain.Config, *types.Block, error) {
+func WriteGenesisBlock(tx kv.RwTx, genesis *types.Genesis, overrideOsakaTime, overrideAmsterdamTime *big.Int, keepStoredChainConfig bool, dirs datadir.Dirs, logger log.Logger) (*chain.Config, *types.Block, error) {
 	if err := rawdb.WriteGenesisIfNotExist(tx, genesis); err != nil {
 		return nil, nil, err
 	}
@@ -134,8 +134,8 @@ func WriteGenesisBlock(tx kv.RwTx, genesis *types.Genesis, overrideOsakaTime, ov
 		if overrideOsakaTime != nil {
 			config.OsakaTime = overrideOsakaTime
 		}
-		if overrideBalancerTime != nil {
-			config.BalancerTime = overrideBalancerTime
+		if overrideAmsterdamTime != nil {
+			config.AmsterdamTime = overrideAmsterdamTime
 		}
 	}
 

--- a/node/cli/default_flags.go
+++ b/node/cli/default_flags.go
@@ -174,7 +174,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.AAFlag,
 	&utils.EthStatsURLFlag,
 	&utils.OverrideOsakaFlag,
-	&utils.OverrideBalancerFlag,
+	&utils.OverrideAmsterdamFlag,
 	&utils.KeepStoredChainConfigFlag,
 
 	&utils.CaplinDiscoveryAddrFlag,

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -379,7 +379,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 			genesisSpec = nil
 		}
 		var genesisErr error
-		chainConfig, genesis, genesisErr = genesiswrite.WriteGenesisBlock(tx, genesisSpec, config.OverrideOsakaTime, config.OverrideBalancerTime, config.KeepStoredChainConfig, dirs, logger)
+		chainConfig, genesis, genesisErr = genesiswrite.WriteGenesisBlock(tx, genesisSpec, config.OverrideOsakaTime, config.OverrideAmsterdamTime, config.KeepStoredChainConfig, dirs, logger)
 		if _, ok := genesisErr.(*chain.ConfigCompatError); genesisErr != nil && !ok {
 			return genesisErr
 		}

--- a/node/ethconfig/config.go
+++ b/node/ethconfig/config.go
@@ -246,8 +246,8 @@ type Config struct {
 	// Consensus layer
 	InternalCL bool
 
-	OverrideOsakaTime    *big.Int `toml:",omitempty"`
-	OverrideBalancerTime *big.Int `toml:",omitempty"`
+	OverrideOsakaTime     *big.Int `toml:",omitempty"`
+	OverrideAmsterdamTime *big.Int `toml:",omitempty"`
 
 	// Whether to avoid overriding chain config already stored in the DB
 	KeepStoredChainConfig bool

--- a/node/ethconfig/gen_config.go
+++ b/node/ethconfig/gen_config.go
@@ -52,6 +52,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		Ethstats                            string
 		InternalCL                          bool
 		OverrideOsakaTime                   *big.Int `toml:",omitempty"`
+		OverrideAmsterdamTime               *big.Int `toml:",omitempty"`
 		KeepStoredChainConfig               bool
 		SilkwormExecution                   bool
 		SilkwormRpcDaemon                   bool
@@ -98,6 +99,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.Ethstats = c.Ethstats
 	enc.InternalCL = c.InternalCL
 	enc.OverrideOsakaTime = c.OverrideOsakaTime
+	enc.OverrideAmsterdamTime = c.OverrideAmsterdamTime
 	enc.KeepStoredChainConfig = c.KeepStoredChainConfig
 	enc.SilkwormExecution = c.SilkwormExecution
 	enc.SilkwormRpcDaemon = c.SilkwormRpcDaemon
@@ -149,6 +151,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		Ethstats                            *string
 		InternalCL                          *bool
 		OverrideOsakaTime                   *big.Int `toml:",omitempty"`
+		OverrideAmsterdamTime               *big.Int `toml:",omitempty"`
 		KeepStoredChainConfig               *bool
 		SilkwormExecution                   *bool
 		SilkwormRpcDaemon                   *bool
@@ -256,6 +259,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.OverrideOsakaTime != nil {
 		c.OverrideOsakaTime = dec.OverrideOsakaTime
+	}
+	if dec.OverrideAmsterdamTime != nil {
+		c.OverrideAmsterdamTime = dec.OverrideAmsterdamTime
 	}
 	if dec.KeepStoredChainConfig != nil {
 		c.KeepStoredChainConfig = *dec.KeepStoredChainConfig


### PR DESCRIPTION
Replace the no longer needed `--override.balancer` flag (introduced by PR #18122) with a flag to override the time of the upcoming Amsterdam HF.