### PR TITLE
refactor: remove legacy TxLookupEntry struct

### DIFF
--- a/db/rawdb/accessors_indexes.go
+++ b/db/rawdb/accessors_indexes.go
@@ -28,14 +28,6 @@ import (
 	"github.com/erigontech/erigon/execution/types"
 )
 
-// TxLookupEntry is a positional metadata to help looking up the data content of
-// a transaction or receipt given only its hash.
-type TxLookupEntry struct {
-	BlockHash  common.Hash
-	BlockIndex uint64
-	Index      uint64
-}
-
 // ReadTxLookupEntry retrieves the positional metadata associated with a transaction
 // hash to allow retrieving the transaction or receipt by hash.
 func ReadTxLookupEntry(db kv.Getter, txnHash common.Hash) (blockNumber *uint64, txNum *uint64, err error) {


### PR DESCRIPTION
`TxLookupEntry` was a leftover from geth’s legacy tx lookup format and is not used anywhere in Erigon. Its fields (block hash, block index, index) do not match the current TxLookup storage format, which is a fixed 16-byte payload containing blockNumber and txNum encoded as two big-endian uint64 values. Keeping this struct around is misleading and suggests a different encoding than the one actually used by ReadTxLookupEntry and WriteTxLookupEntries. This change removes the unused struct and its comment without touching the existing binary format or lookup logic.