### PR TITLE
rpc: wrap json marshal errors as internal server error

### DIFF
--- a/rpc/json.go
+++ b/rpc/json.go
@@ -111,8 +111,7 @@ func (msg *jsonrpcMessage) errorResponse(err error) *jsonrpcMessage {
 func (msg *jsonrpcMessage) response(result any) *jsonrpcMessage {
 	enc, err := json.Marshal(result)
 	if err != nil {
-		// TODO: wrap with 'internal server error'
-		return msg.errorResponse(err)
+		return msg.errorResponse(errors.New("internal server error"))
 	}
 	return &jsonrpcMessage{Version: vsn, ID: msg.ID, Result: enc}
 }


### PR DESCRIPTION
Avoid leaking internal marshal errors to RPC clients by returning a proper internal error.