### PR TITLE
node/eth: drop unused chain config from setUpSnapDownloader

### DIFF
--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -414,7 +414,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 	backend.chainDB = temporalDb
 
 	// Can happen in some configurations
-	if err := backend.setUpSnapDownloader(ctx, stack.Config(), config.Downloader, chainConfig); err != nil {
+	if err := backend.setUpSnapDownloader(ctx, stack.Config(), config.Downloader); err != nil {
 		return nil, err
 	}
 
@@ -1267,7 +1267,6 @@ func (s *Ethereum) setUpSnapDownloader(
 	ctx context.Context,
 	nodeCfg *nodecfg.Config,
 	downloaderCfg *downloadercfg.Cfg,
-	cc *chain.Config,
 ) (err error) {
 	s.chainDB.OnFilesChange(func(frozenFileNames []string) {
 		s.logger.Debug("files changed...sending notification")


### PR DESCRIPTION
setUpSnapDownloader was taking a chain.Config argument that was never used inside the function. The only consumer of chain name for snapshots and downloader is downloaderCfg.ChainName, so the extra parameter was dead and only made the API harder to read.

Removed the unused parameter from both the function signature and its only call site in New, without touching any other logic. Behavior of the snapshot downloader remains unchanged; this is a small internal cleanup that also brings the helper closer to the upstream Erigon shape.