### PR TITLE
fix: use Max instead of Min for toBlock in BlkRangeToSteps

### DIFF
--- a/execution/exec/historical_trace_worker.go
+++ b/execution/exec/historical_trace_worker.go
@@ -695,7 +695,7 @@ func BlkRangeToSteps(tx kv.TemporalTx, fromBlock, toBlock uint64, txNumsReader r
 	if err != nil {
 		return 0, 0, err
 	}
-	toTxNum, err := txNumsReader.Min(tx, toBlock)
+	toTxNum, err := txNumsReader.Max(tx, toBlock)
 	if err != nil {
 		return 0, 0, err
 	}


### PR DESCRIPTION
BlkRangeToSteps incorrectly used Min() for the toBlock parameter, which returns the first transaction of the block instead of the last. This caused incorrect block range calculations for historical trace operations.