### PR TITLE
Remove duplicate Min call in CustomTraceMapReduce

### DIFF
--- a/execution/exec/historical_trace_worker.go
+++ b/execution/exec/historical_trace_worker.go
@@ -602,10 +602,7 @@ func CustomTraceMapReduce(ctx context.Context, fromBlock, toBlock uint64, consum
 	readAhead, clean := BlocksReadAhead(ctx, 2, cfg.ChainDB, cfg.Engine, cfg.BlockReader)
 	defer clean()
 
-	inputTxNum, err := txNumsReader.Min(tx, fromBlock)
-	if err != nil {
-		return err
-	}
+	inputTxNum := fromTxNum
 	for blockNum := fromBlock; blockNum <= toBlock && !workersExited.Load(); blockNum++ {
 		select {
 		case readAhead <- blockNum:


### PR DESCRIPTION
inputTxNum now reuses fromTxNum, eliminating redundant database call with identical parameters.