### PR TITLE
relax some publishable checks for blobsidecars

### DIFF
--- a/cmd/utils/app/publishable_check_test.go
+++ b/cmd/utils/app/publishable_check_test.go
@@ -51,6 +51,22 @@ func Test_CheckStartFrom0(t *testing.T) {
 	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs, false))
 }
 
+func Test_CheckAllowedNonStartFrom0(t *testing.T) {
+	dirs := datadir.New(t.TempDir())
+	touchFiles(t, dirs, []snapRange{
+		{0, 10}, {10, 20}, {20, 30},
+	})
+
+	delFile(t, dirs.Snap, "v1.0-000000-000010-blocksidecars.idx") // blobsidecars start at 1942 step on mainnet after dencun upgrade
+	delFile(t, dirs.Snap, "v1.0-000000-000010-blobsidecars.seg")
+	require.NoError(t, checkIfCaplinSnapshotsPublishable(dirs, false))
+
+	// but removing other files should still error
+	delFile(t, dirs.Snap, "v1.0-000000-000010-beaconblocks.idx")
+	delFile(t, dirs.Snap, "v1.0-000000-000010-beaconblocks.seg")
+	require.Error(t, checkIfCaplinSnapshotsPublishable(dirs, false))
+}
+
 func Test_CheckOverlaps(t *testing.T) {
 	dirs := datadir.New(t.TempDir())
 	touchFiles(t, dirs, []snapRange{

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -1215,7 +1215,11 @@ func checkIfCaplinSnapshotsPublishable(dirs datadir.Dirs, emptyOk bool) error {
 
 	to := int64(-1)
 	for _, snapt := range snaptype.CaplinSnapshotTypes {
-		uto, empty, err := CheckFilesForSchema(caplinSchema.Get(snapt.Enum()), to, emptyOk)
+		uto, empty, err := CheckFilesForSchema(caplinSchema.Get(snapt.Enum()), CheckFilesParams{
+			checkLastFileTo: to,
+			emptyOk:         emptyOk,
+			doesntStartAt0:  snapt.Enum() == snaptype.BlobSidecars.Enum(),
+		})
 		if err != nil {
 			return err
 		}
@@ -1229,7 +1233,10 @@ func checkIfCaplinSnapshotsPublishable(dirs datadir.Dirs, emptyOk bool) error {
 	to = int64(-1)
 	somethingPresent, somethingEmpty := false, false
 	for table := range stateSnapTypes.KeyValueGetters {
-		uto, empty, err := CheckFilesForSchema(caplinSchema.GetState(table), to, emptyOk)
+		uto, empty, err := CheckFilesForSchema(caplinSchema.GetState(table), CheckFilesParams{
+			checkLastFileTo: to,
+			emptyOk:         emptyOk,
+		})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
they're block sharded and start at non-zero point (e.g. 1942 step for sepolia)