### PR TITLE
TxPool: map reduce and batch load

### DIFF
--- a/txnprovider/txpool/fetch.go
+++ b/txnprovider/txpool/fetch.go
@@ -204,6 +204,15 @@ func (f *Fetch) receiveMessage(ctx context.Context, sentryClient sentryproto.Sen
 			return
 		}
 
+		if f.db == nil {
+			for range toProcess {
+				if f.wg != nil {
+					f.wg.Done()
+				}
+			}
+			return
+		}
+
 		tx, txErr := f.db.BeginRo(streamCtx)
 		if txErr != nil {
 			f.logger.Warn("[txpool.fetch] failed to begin batch transaction", "err", txErr)


### PR DESCRIPTION
Batches and deduplicates incoming transaction messages to reduce redundant computation and MDBX transaction overhead.

### Architecture & Rationale

Two problems were identified in profiling:

1. **Blob verification allocations**: Duplicate transactions arriving from multiple peers caused the same expensive blob verification to run multiple times, leading to excessive allocations.

2. **MDBX transaction overhead**: Each incoming message opened its own read transaction. Profiling showed this accounted for ~15% of CPU time.

The fix introduces:

- **LRU-based deduplication**: An LRU cache (4096 entries) filters duplicate messages before they enter the processing batch. Uses `maphash` on the raw message data to avoid string allocations (we dont need to care about collision as it is a random seed for each instance and this is not a consensus component anyways).

- **1-second batching window**: Instead of processing messages immediately, they accumulate in a batch and are flushed every second (or on stream close). A single MDBX read transaction is opened per batch and reused for all messages in that batch.

This ensures each unique transaction is processed exactly once per batch window, and the MDBX transaction cost is amortized across potentially hundreds of messages.