### PR TITLE
unalign CaplinSnapshotTypes publishable checks 

### DIFF
--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -1215,7 +1215,7 @@ func checkIfCaplinSnapshotsPublishable(dirs datadir.Dirs, emptyOk bool) error {
 
 	//to := int64(-1)
 	for _, snapt := range snaptype.CaplinSnapshotTypes {
-		_, empty, err := CheckFilesForSchema(caplinSchema.Get(snapt.Enum()), CheckFilesParams{
+		_, _, err := CheckFilesForSchema(caplinSchema.Get(snapt.Enum()), CheckFilesParams{
 			checkLastFileTo: -1,
 			emptyOk:         emptyOk,
 			doesntStartAt0:  snapt.Enum() == snaptype.BlobSidecars.Enum(),
@@ -1223,9 +1223,9 @@ func checkIfCaplinSnapshotsPublishable(dirs datadir.Dirs, emptyOk bool) error {
 		if err != nil {
 			return err
 		}
-		if empty {
-			continue
-		}
+		// if empty {
+		// 	continue
+		// }
 
 		//to = int64(uto)
 	}


### PR DESCRIPTION
found that blobs was one step range behind in sepolia. 
```
ubuntu@snapshotter-bm-v34-sepolia-n1:/opt/erigon-node/erigon$ ls /erigon-data/snapshots/|grep 9270
v1.1-009260-009270-beaconblocks.idx
v1.1-009260-009270-beaconblocks.idx.torrent
v1.1-009260-009270-beaconblocks.seg
v1.1-009260-009270-beaconblocks.seg.torrent

ubuntu@snapshotter-bm-v34-sepolia-n1:/opt/erigon-node/erigon$ ls /erigon-data/snapshots/|grep 9260
v1.1-009250-009260-beaconblocks.idx
v1.1-009250-009260-beaconblocks.idx.torrent
v1.1-009250-009260-beaconblocks.seg
v1.1-009250-009260-beaconblocks.seg.torrent
v1.1-009250-009260-blobsidecars.seg
v1.1-009250-009260-blobsidecars.seg.torrent
v1.1-009250-009260-blocksidecars.idx
v1.1-009250-009260-blocksidecars.idx.torrent
v1.1-009260-009270-beaconblocks.idx
v1.1-009260-009270-beaconblocks.idx.torrent
v1.1-009260-009270-beaconblocks.seg
v1.1-009260-009270-beaconblocks.seg.torrent
```

- @Giulio2002  @domiwei is this expected? 260-270 (last snapshot range) for blobsidecars is missing -- maybe it's just a delay in triggering build for blobsidecar files. (`seg retire` doesn't build anything new)
- The publishable check assumed both go together (snapshot automation runs `seg retire` before), so there was a check - "beaconblock LastFrozenStep = blobsidecar LastFrozenStep"
- but clearly the above is not the case. So I relaxed the condition here.
