### PR TITLE
unalign CaplinSnapshotTypes publishable checks

### DIFF
--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -1213,24 +1213,24 @@ func checkIfCaplinSnapshotsPublishable(dirs datadir.Dirs, emptyOk bool) error {
 	stateSnapTypes := snapshotsync.MakeCaplinStateSnapshotsTypes(nil)
 	caplinSchema := snapshotsync.NewCaplinSchema(dirs, 1000, stateSnapTypes)
 
-	to := int64(-1)
+	//to := int64(-1)
 	for _, snapt := range snaptype.CaplinSnapshotTypes {
-		uto, empty, err := CheckFilesForSchema(caplinSchema.Get(snapt.Enum()), CheckFilesParams{
-			checkLastFileTo: to,
+		_, _, err := CheckFilesForSchema(caplinSchema.Get(snapt.Enum()), CheckFilesParams{
+			checkLastFileTo: -1,
 			emptyOk:         emptyOk,
 			doesntStartAt0:  snapt.Enum() == snaptype.BlobSidecars.Enum(),
 		})
 		if err != nil {
 			return err
 		}
-		if empty {
-			continue
-		}
+		// if empty {
+		// 	continue
+		// }
 
-		to = int64(uto)
+		// to = int64(uto)
 	}
 
-	to = int64(-1)
+	to := int64(-1)
 	somethingPresent, somethingEmpty := false, false
 	for table := range stateSnapTypes.KeyValueGetters {
 		uto, empty, err := CheckFilesForSchema(caplinSchema.GetState(table), CheckFilesParams{


### PR DESCRIPTION
found that blobs was one step range behind in sepolia. 
```
ubuntu@snapshotter-bm-v34-sepolia-n1:/opt/erigon-node/erigon$ ls /erigon-data/snapshots/|grep 9270
v1.1-009260-009270-beaconblocks.idx
v1.1-009260-009270-beaconblocks.idx.torrent
v1.1-009260-009270-beaconblocks.seg
v1.1-009260-009270-beaconblocks.seg.torrent

ubuntu@snapshotter-bm-v34-sepolia-n1:/opt/erigon-node/erigon$ ls /erigon-data/snapshots/|grep 9260
v1.1-009250-009260-beaconblocks.idx
v1.1-009250-009260-beaconblocks.idx.torrent
v1.1-009250-009260-beaconblocks.seg
v1.1-009250-009260-beaconblocks.seg.torrent
v1.1-009250-009260-blobsidecars.seg
v1.1-009250-009260-blobsidecars.seg.torrent
v1.1-009250-009260-blocksidecars.idx
v1.1-009250-009260-blocksidecars.idx.torrent
v1.1-009260-009270-beaconblocks.idx
v1.1-009260-009270-beaconblocks.idx.torrent
v1.1-009260-009270-beaconblocks.seg
v1.1-009260-009270-beaconblocks.seg.torrent
```

- is this expected? 260-270 (last snapshot range) for blobsidecars is missing -- maybe it's just a delay in triggering build for blobsidecar files. (`seg retire` doesn't build anything new)
- The publishable check assumed both go together (snapshot automation runs `seg retire` before), so there was a check - "beaconblock LastFrozenStep = blobsidecar LastFrozenStep"
- but clearly the above is not the case. So I relaxed the condition here.
