### PR TITLE
fix: close channel in TestSpeculativeHandler to prevent goroutine leak

### DIFF
--- a/common/log/v3/ext/ext_test.go
+++ b/common/log/v3/ext/ext_test.go
@@ -61,6 +61,7 @@ func TestSpeculativeHandler(t *testing.T) {
 
 		go func() {
 			defer close(done)
+			defer close(recs)
 			expectedCount := int(math.Min(float64(count), float64(100)))
 			expectedIdx := count - expectedCount
 			for r := range recs {
@@ -90,7 +91,7 @@ func TestSpeculativeHandler(t *testing.T) {
 			lg.Debug("test speculative", "i", i)
 		}
 
-		go spec.Flush()
+		spec.Flush()
 
 		// wait for the go routine to finish
 		<-done


### PR DESCRIPTION
## What

Fix goroutine leak in `TestSpeculativeHandler` by closing the channel after the reader finishes and calling `Flush()` synchronously.

## Why

The test had a race condition where `Flush()` could block indefinitely when writing to an unbuffered channel if the reader goroutine exited the range loop before all records were flushed. Closing the channel ensures proper cleanup, and synchronous `Flush()` guarantees all records are written before the reader exits.