### PR TITLE
fix: wrong URL used in CompareAccountRange

### DIFF
--- a/cmd/rpctest/rpctest/account_range_verify.go
+++ b/cmd/rpctest/rpctest/account_range_verify.go
@@ -122,7 +122,7 @@ func CompareAccountRange(logger log.Logger, erigonURL, gethURL, tmpDataDir, geth
 
 	if !notRegenerateGethData {
 		err = gethKV.Update(context.Background(), func(tx kv.RwTx) error {
-			return f(erigonURL, tx)
+			return f(gethURL, tx)
 		})
 		if err != nil {
 			log.Error(err.Error())


### PR DESCRIPTION
Fixed a copy-paste bug in CompareAccountRange function where gethKV database was being populated using erigonURL instead of gethURL. This made the comparison meaningless since both databases contained identical data from Erigon, rather than comparing Erigon data against Geth data as intended.