### PR TITLE
db/integrity: remove unused ticker in RCache integrity check

### DIFF
--- a/db/integrity/rcache_no_duplicates.go
+++ b/db/integrity/rcache_no_duplicates.go
@@ -20,9 +20,6 @@ func CheckRCacheNoDups(ctx context.Context, db kv.TemporalRoDB, blockReader serv
 		log.Info("[integrity] RCacheNoDups: done", "err", err)
 	}()
 
-	logEvery := time.NewTicker(10 * time.Second)
-	defer logEvery.Stop()
-
 	txNumsReader := blockReader.TxnumReader(ctx)
 
 	tx, err := db.BeginTemporalRo(ctx)


### PR DESCRIPTION
CheckRCacheNoDups was creating a time.Ticker that was never read from or passed down, so it had no effect on logging or cancellation. Progress for this integrity check is already reported inside parallelChunkCheck, so the extra ticker was just dead code and an unnecessary resource. This change removes the unused ticker to keep the RCache integrity check simpler and avoid redundant work.