### PR TITLE
fix: remove dead code in numEqual function

### DIFF
--- a/execution/chain/chain_config.go
+++ b/execution/chain/chain_config.go
@@ -643,7 +643,7 @@ func numEqual(x, y *big.Int) bool {
 		return y == nil
 	}
 	if y == nil {
-		return x == nil
+		return false
 	}
 	return x.Cmp(y) == 0
 }


### PR DESCRIPTION
The check `return x == nil` on line 646 was always false because we already verified x != nil on line 642. Replaced with explicit `return false` for clarity.