### PR TITLE
p2p/nat: simplify UPnP error handling in natupnp

### DIFF
--- a/p2p/nat/natupnp.go
+++ b/p2p/nat/natupnp.go
@@ -57,25 +57,22 @@ type upnpClient interface {
 func (n *upnp) natEnabled() bool {
 	var ok bool
 	var err error
-	err1 := n.withRateLimit(func() error {
+	err = n.withRateLimit(func() error {
 		_, ok, err = n.client.GetNATRSIPStatus()
 		return err
 	})
-	return err1 == nil && err == nil && ok
+	return err == nil && ok
 }
 
 func (n *upnp) ExternalIP() (addr net.IP, err error) {
 	var ipString string
-	err1 := n.withRateLimit(func() error {
+	err = n.withRateLimit(func() error {
 		ipString, err = n.client.GetExternalIPAddress()
 		return err
 	})
 
 	if err != nil {
 		return nil, err
-	}
-	if err1 != nil {
-		return nil, err1
 	}
 	ip := net.ParseIP(ipString)
 	if ip == nil {


### PR DESCRIPTION
Simplify error handling in natEnabled and ExternalIP by removing the redundant err1 variable and relying solely on the named err result. This keeps the behavior aligned with the original go-ethereum implementation, avoids the illusion of two independent error sources from withRateLimit, and makes the code easier to read without changing runtime semantics.