### PR TITLE
db/state: remove unused decomp from inverted index dedup

### DIFF
--- a/db/state/deduplicate.go
+++ b/db/state/deduplicate.go
@@ -202,16 +202,12 @@ func (iit *InvertedIndexRoTx) deduplicateFiles(ctx context.Context, files []*Fil
 
 	var outItem *FilesItem
 	var comp *seg.Compressor
-	var decomp *seg.Decompressor
 	var err error
 	var closeItem = true
 	defer func() {
 		if closeItem {
 			if comp != nil {
 				comp.Close()
-			}
-			if decomp != nil {
-				decomp.Close()
 			}
 			if outItem != nil {
 				outItem.closeFilesAndRemove()


### PR DESCRIPTION
The local decomp variable in InvertedIndexRoTx.deduplicateFiles was never initialized or used. Resource lifetime is already managed via the FilesItem and its closeFilesAndRemove method, so the extra variable and its close call were dead code. This change removes the unused variable to make the error-handling and cleanup logic clearer without affecting runtime behavior.