### PR TITLE
test: fix redundant fmt.Sprintf in txpool_api_test assertion

### DIFF
--- a/rpc/jsonrpc/txpool_api_test.go
+++ b/rpc/jsonrpc/txpool_api_test.go
@@ -18,7 +18,6 @@ package jsonrpc
 
 import (
 	"bytes"
-	"fmt"
 	"testing"
 
 	"github.com/holiman/uint256"
@@ -62,7 +61,7 @@ func TestTxPoolContent(t *testing.T) {
 	reply, err := txPool.Add(ctx, &txpoolproto.AddRequest{RlpTxs: [][]byte{buf.Bytes()}})
 	require.NoError(err)
 	for _, res := range reply.Imported {
-		require.Equal(txpoolproto.ImportResult_SUCCESS, res, fmt.Sprintf("%s", reply.Errors))
+		require.Equalf(txpoolproto.ImportResult_SUCCESS, res, "errors: %v", reply.Errors)
 	}
 
 	content, err := api.Content(ctx)


### PR DESCRIPTION
Removes unnecessary `fmt.Sprintf` call and simplifies test assertion in `txpool_api_test.go`.