### PR TITLE
execution/types: using defined struct to optimize sigHash

### DIFF
--- a/execution/types/access_list_tx.go
+++ b/execution/types/access_list_tx.go
@@ -462,18 +462,29 @@ func (tx *AccessListTx) Hash() common.Hash {
 	return hash
 }
 
+type accessListTxSigHash struct {
+	ChainID    *big.Int
+	Nonce      uint64
+	GasPrice   *uint256.Int
+	Gas        uint64
+	To         *common.Address `rlp:"nil"`
+	Value      *uint256.Int
+	Data       []byte
+	AccessList AccessList
+}
+
 func (tx *AccessListTx) SigningHash(chainID *big.Int) common.Hash {
 	return prefixedRlpHash(
 		AccessListTxType,
-		[]any{
-			chainID,
-			tx.Nonce,
-			tx.GasPrice,
-			tx.GasLimit,
-			tx.To,
-			tx.Value,
-			tx.Data,
-			tx.AccessList,
+		&accessListTxSigHash{
+			ChainID:    chainID,
+			Nonce:      tx.Nonce,
+			GasPrice:   tx.GasPrice,
+			Gas:        tx.GasLimit,
+			To:         tx.To,
+			Value:      tx.Value,
+			Data:       tx.Data,
+			AccessList: tx.AccessList,
 		})
 }
 

--- a/execution/types/blob_tx.go
+++ b/execution/types/blob_tx.go
@@ -135,21 +135,35 @@ func (stx *BlobTx) Hash() common.Hash {
 	return hash
 }
 
+type blobTxSigHash struct {
+	ChainID    *big.Int
+	Nonce      uint64
+	GasTipCap  *uint256.Int
+	GasFeeCap  *uint256.Int
+	Gas        uint64
+	To         *common.Address
+	Value      *uint256.Int
+	Data       []byte
+	AccessList AccessList
+	BlobFeeCap *uint256.Int
+	BlobHashes []common.Hash
+}
+
 func (stx *BlobTx) SigningHash(chainID *big.Int) common.Hash {
 	return prefixedRlpHash(
 		BlobTxType,
-		[]any{
-			chainID,
-			stx.Nonce,
-			stx.TipCap,
-			stx.FeeCap,
-			stx.GasLimit,
-			stx.To,
-			stx.Value,
-			stx.Data,
-			stx.AccessList,
-			stx.MaxFeePerBlobGas,
-			stx.BlobVersionedHashes,
+		&blobTxSigHash{
+			ChainID:    chainID,
+			Nonce:      stx.Nonce,
+			GasTipCap:  stx.TipCap,
+			GasFeeCap:  stx.FeeCap,
+			Gas:        stx.GasLimit,
+			To:         stx.To,
+			Value:      stx.Value,
+			Data:       stx.Data,
+			AccessList: stx.AccessList,
+			BlobFeeCap: stx.MaxFeePerBlobGas,
+			BlobHashes: stx.BlobVersionedHashes,
 		})
 }
 

--- a/execution/types/dynamic_fee_tx.go
+++ b/execution/types/dynamic_fee_tx.go
@@ -379,19 +379,31 @@ func (tx *DynamicFeeTransaction) Hash() common.Hash {
 	return hash
 }
 
+type dynamicFeeTxSigHash struct {
+	ChainID    *big.Int
+	Nonce      uint64
+	GasTipCap  *uint256.Int
+	GasFeeCap  *uint256.Int
+	Gas        uint64
+	To         *common.Address `rlp:"nil"`
+	Value      *uint256.Int
+	Data       []byte
+	AccessList AccessList
+}
+
 func (tx *DynamicFeeTransaction) SigningHash(chainID *big.Int) common.Hash {
 	return prefixedRlpHash(
 		DynamicFeeTxType,
-		[]any{
-			chainID,
-			tx.Nonce,
-			tx.TipCap,
-			tx.FeeCap,
-			tx.GasLimit,
-			tx.To,
-			tx.Value,
-			tx.Data,
-			tx.AccessList,
+		&dynamicFeeTxSigHash{
+			ChainID:    chainID,
+			Nonce:      tx.Nonce,
+			GasTipCap:  tx.TipCap,
+			GasFeeCap:  tx.FeeCap,
+			Gas:        tx.GasLimit,
+			To:         tx.To,
+			Value:      tx.Value,
+			Data:       tx.Data,
+			AccessList: tx.AccessList,
 		})
 }
 

--- a/execution/types/legacy_tx.go
+++ b/execution/types/legacy_tx.go
@@ -384,16 +384,30 @@ func (tx *LegacyTx) Hash() common.Hash {
 	return hash
 }
 
+type legacyTxSigHash struct {
+	Nonce    uint64
+	GasPrice *uint256.Int
+	Gas      uint64
+	To       *common.Address `rlp:"nil"`
+	Value    *uint256.Int
+	Data     []byte
+	ChainID  *big.Int
+	V        uint
+	R        uint
+}
+
 func (tx *LegacyTx) SigningHash(chainID *big.Int) common.Hash {
 	if chainID != nil && chainID.Sign() != 0 {
-		return rlpHash([]any{
-			tx.Nonce,
-			tx.GasPrice,
-			tx.GasLimit,
-			tx.To,
-			tx.Value,
-			tx.Data,
-			chainID, uint(0), uint(0),
+		return rlpHash(&legacyTxSigHash{
+			Nonce:    tx.Nonce,
+			GasPrice: tx.GasPrice,
+			Gas:      tx.GasLimit,
+			To:       tx.To,
+			Value:    tx.Value,
+			Data:     tx.Data,
+			ChainID:  chainID,
+			V:        uint(0),
+			R:        uint(0),
 		})
 	}
 	return rlpHash([]any{

--- a/execution/types/set_code_tx.go
+++ b/execution/types/set_code_tx.go
@@ -196,20 +196,33 @@ func (tx *SetCodeTransaction) Hash() common.Hash {
 	return hash
 }
 
+type setCodeTxSigHash struct {
+	ChainID    *big.Int
+	Nonce      uint64
+	GasTipCap  *uint256.Int
+	GasFeeCap  *uint256.Int
+	Gas        uint64
+	To         *common.Address
+	Value      *uint256.Int
+	Data       []byte
+	AccessList AccessList
+	AuthList   []Authorization
+}
+
 func (tx *SetCodeTransaction) SigningHash(chainID *big.Int) common.Hash {
 	return prefixedRlpHash(
 		SetCodeTxType,
-		[]any{
-			chainID,
-			tx.Nonce,
-			tx.TipCap,
-			tx.FeeCap,
-			tx.GasLimit,
-			tx.To,
-			tx.Value,
-			tx.Data,
-			tx.AccessList,
-			tx.Authorizations,
+		&setCodeTxSigHash{
+			ChainID:    chainID,
+			Nonce:      tx.Nonce,
+			GasTipCap:  tx.TipCap,
+			GasFeeCap:  tx.FeeCap,
+			Gas:        tx.GasLimit,
+			To:         tx.To,
+			Value:      tx.Value,
+			Data:       tx.Data,
+			AccessList: tx.AccessList,
+			AuthList:   tx.Authorizations,
 		})
 }
 


### PR DESCRIPTION
Benchmark Code:
```
package types

import (
	"testing"

	"github.com/erigontech/erigon/common"
	"github.com/erigontech/erigon/common/u256"
	"github.com/holiman/uint256"
)

// BenchmarkSigHash_DynamicFeeTx benchmarks the sigHash method for DynamicFeeTx
// with all fields populated.
func BenchmarkSigHash_DynamicFeeTx(b *testing.B) {
	to := common.HexToAddress("0x000000000000000000000000000000000000dead")

	tx := &DynamicFeeTransaction{
		CommonTx: CommonTx{
			Nonce:    3,
			To:       &to,
			Value:    uint256.NewInt(10),
			GasLimit: 25000,
			Data:     common.FromHex("5544"),
			V:        *uint256.NewInt(27),
			R:        *uint256.NewInt(123456789),
			S:        *uint256.NewInt(987654321),
		},
		ChainID: uint256.NewInt(1),
		TipCap:  uint256.NewInt(1_000_000_000), // 1 gwei
		FeeCap:  uint256.NewInt(2_000_000_000), // 2 gwei
		AccessList: AccessList{
			AccessTuple{
				Address: common.HexToAddress("0x0000000000000000000000000000000000000001"),
				StorageKeys: []common.Hash{
					common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
					common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
				},
			},
			AccessTuple{
				Address: common.HexToAddress("0x0000000000000000000000000000000000000002"),
				StorageKeys: []common.Hash{
					common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000003"),
				},
			},
		},
	}

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		_ = tx.SigningHash(tx.ChainID.ToBig())
	}
}

// BenchmarkSigHash_AccessListTx benchmarks the sigHash method for AccessListTx
// with all fields populated.
func BenchmarkSigHash_AccessListTx(b *testing.B) {
	to := common.HexToAddress("0x000000000000000000000000000000000000dead")

	tx := &AccessListTx{
		LegacyTx: LegacyTx{
			CommonTx: CommonTx{
				Nonce:    3,
				To:       &to,
				Value:    uint256.NewInt(10),
				GasLimit: 25000,
				Data:     common.FromHex("5544"),
				V:        *uint256.NewInt(27),
				R:        *uint256.NewInt(123456789),
				S:        *uint256.NewInt(987654321),
			},
			GasPrice: uint256.NewInt(2_000_000_000), // 2 gwei
		},
		ChainID: uint256.NewInt(1),
		AccessList: AccessList{
			AccessTuple{
				Address: common.HexToAddress("0x0000000000000000000000000000000000000001"),
				StorageKeys: []common.Hash{
					common.HexToHash("0x01"),
					common.HexToHash("0x02"),
				},
			},
			AccessTuple{
				Address: common.HexToAddress("0x0000000000000000000000000000000000000002"),
				StorageKeys: []common.Hash{
					common.HexToHash("0x03"),
				},
			},
		},
	}

	chainID := tx.ChainID.ToBig()

	for b.Loop() {
		_ = tx.SigningHash(chainID)
	}
}

// BenchmarkSigHash_LegacyTx benchmarks the sigHash method for LegacyTx
// with all fields populated.
func BenchmarkSigHash_LegacyTx(b *testing.B) {
	to := common.HexToAddress("0x000000000000000000000000000000000000dead")

	tx := &LegacyTx{
		CommonTx: CommonTx{
			Nonce:    42,
			To:       &to,
			Value:    uint256.NewInt(1_000_000_000_000_000_000), // 1 ether
			GasLimit: 21000,
			Data:     []byte{0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0},
			V:        *uint256.NewInt(27),
			R:        *uint256.NewInt(123456789),
			S:        *uint256.NewInt(987654321),
		},
		GasPrice: uint256.NewInt(2_000_000_000), // 2 gwei
	}

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		_ = tx.SigningHash(u256.Num1.ToBig())
	}
}

// BenchmarkSigHash_BlobTx benchmarks the sigHash method for BlobTx
// with all fields populated.
func BenchmarkSigHash_BlobTx(b *testing.B) {
	to := common.HexToAddress("0x000000000000000000000000000000000000dead")

	tx := &BlobTx{
		DynamicFeeTransaction: DynamicFeeTransaction{
			CommonTx: CommonTx{
				Nonce:    42,
				To:       &to,
				Value:    uint256.NewInt(1_000_000_000_000_000_000), // 1 ether
				GasLimit: 21000,
				Data:     []byte{0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0},
				V:        *uint256.NewInt(27),
				R:        *uint256.NewInt(123456789),
				S:        *uint256.NewInt(987654321),
			},
			ChainID: &u256.Num1,
			TipCap:  uint256.NewInt(1_000_000_000), // 1 gwei
			FeeCap:  uint256.NewInt(2_000_000_000), // 2 gwei
			AccessList: AccessList{
				{
					Address: common.HexToAddress("0x0000000000000000000000000000000000000001"),
					StorageKeys: []common.Hash{
						common.HexToHash("0x01"),
						common.HexToHash("0x02"),
					},
				},
				{
					Address: common.HexToAddress("0x0000000000000000000000000000000000000002"),
					StorageKeys: []common.Hash{
						common.HexToHash("0x03"),
					},
				},
			},
		},
		MaxFeePerBlobGas: uint256.NewInt(100_000_000),
		BlobVersionedHashes: []common.Hash{
			common.HexToHash("0x01"),
			common.HexToHash("0x02"),
		},
	}

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		_ = tx.SigningHash(tx.ChainID.ToBig())
	}
}
```
Result:
```
goos: linux
goarch: amd64
pkg: github.com/erigontech/erigon/execution/types
cpu: Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz
                       │ old_bench.txt │            new_bench.txt            │
                       │    sec/op     │   sec/op     vs base                │
SigHash_DynamicFeeTx-8     2.274µ ± 2%   1.849µ ± 3%  -18.69% (p=0.000 n=10)
SigHash_AccessListTx-8     2.125µ ± 1%   1.755µ ± 3%  -17.39% (p=0.000 n=10)
SigHash_LegacyTx-8        1379.5n ± 5%   913.4n ± 2%  -33.79% (p=0.000 n=10)
SigHash_BlobTx-8           3.079µ ± 2%   2.599µ ± 5%  -15.58% (p=0.000 n=10)
geomean                    2.128µ        1.666µ       -21.72%

                       │ old_bench.txt │           new_bench.txt            │
                       │     B/op      │    B/op     vs base                │
SigHash_DynamicFeeTx-8      328.0 ± 0%   209.0 ± 0%  -36.28% (p=0.000 n=10)
SigHash_AccessListTx-8      248.0 ± 0%   129.0 ± 0%  -47.98% (p=0.000 n=10)
SigHash_LegacyTx-8          296.0 ± 0%   192.0 ± 0%  -35.14% (p=0.000 n=10)
SigHash_BlobTx-8            384.0 ± 0%   241.0 ± 0%  -37.24% (p=0.000 n=10)
geomean                     310.1        187.9       -39.39%

                       │ old_bench.txt │           new_bench.txt            │
                       │   allocs/op   │ allocs/op   vs base                │
SigHash_DynamicFeeTx-8      9.000 ± 0%   5.000 ± 0%  -44.44% (p=0.000 n=10)
SigHash_AccessListTx-8      7.000 ± 0%   3.000 ± 0%  -57.14% (p=0.000 n=10)
SigHash_LegacyTx-8          7.000 ± 0%   4.000 ± 0%  -42.86% (p=0.000 n=10)
SigHash_BlobTx-8           10.000 ± 0%   5.000 ± 0%  -50.00% (p=0.000 n=10)
geomean                     8.149        4.162       -48.93%
```