### PR TITLE
refactor: replace []byte(fmt.Sprintf) with fmt.Appendf

### DIFF
--- a/db/etl/etl_test.go
+++ b/db/etl/etl_test.go
@@ -123,8 +123,8 @@ func TestWriteAndReadBufferEntry(t *testing.T) {
 
 	entries := make([]sortableBufferEntry, 100)
 	for i := range entries {
-		entries[i].key = []byte(fmt.Sprintf("key-%d", i))
-		entries[i].value = []byte(fmt.Sprintf("value-%d", i))
+		entries[i].key = fmt.Appendf(nil, "key-%d", i)
+		entries[i].value = fmt.Appendf(nil, "value-%d", i)
 		b.Put(entries[i].key, entries[i].value)
 	}
 
@@ -287,11 +287,11 @@ func TestTransformExtractStartKey(t *testing.T) {
 		"", // temp dir
 		testExtractToMapFunc,
 		testLoadFromMapFunc,
-		TransformArgs{ExtractStartKey: []byte(fmt.Sprintf("%10d-key-%010d", 5, 5))},
+		TransformArgs{ExtractStartKey: fmt.Appendf(nil, "%10d-key-%010d", 5, 5)},
 		logger,
 	)
 	require.NoError(t, err)
-	compareBuckets(t, tx, sourceBucket, destBucket, []byte(fmt.Sprintf("%10d-key-%010d", 5, 5)))
+	compareBuckets(t, tx, sourceBucket, destBucket, fmt.Appendf(nil, "%10d-key-%010d", 5, 5))
 }
 
 func TestTransformThroughFiles(t *testing.T) {
@@ -365,8 +365,8 @@ func TestTransformDoubleOnLoad(t *testing.T) {
 func generateTestData(t *testing.T, db kv.Putter, bucket string, count int) {
 	t.Helper()
 	for i := 0; i < count; i++ {
-		k := []byte(fmt.Sprintf("%10d-key-%010d", i, i))
-		v := []byte(fmt.Sprintf("val-%099d", i))
+		k := fmt.Appendf(nil, "%10d-key-%010d", i, i)
+		v := fmt.Appendf(nil, "val-%099d", i)
 		err := db.Put(bucket, k, v)
 		require.NoError(t, err)
 	}

--- a/db/kv/stream/stream_helpers.go
+++ b/db/kv/stream/stream_helpers.go
@@ -89,7 +89,7 @@ func (m *PairsWithErrorIter) Next() ([]byte, []byte, error) {
 		return nil, nil, fmt.Errorf("expected error at iteration: %d", m.errorAt)
 	}
 	m.i++
-	return []byte(fmt.Sprintf("%x", m.i)), []byte(fmt.Sprintf("%x", m.i)), nil
+	return fmt.Appendf(nil, "%x", m.i), fmt.Appendf(nil, "%x", m.i), nil
 }
 
 func Count[T any](s Uno[T]) (cnt int, err error) {

--- a/db/recsplit/index_test.go
+++ b/db/recsplit/index_test.go
@@ -48,7 +48,7 @@ func TestReWriteIndex(t *testing.T) {
 	}
 	defer rs.Close()
 	for i := 0; i < 100; i++ {
-		if err = rs.AddKey([]byte(fmt.Sprintf("key %d", i)), uint64(i*17)); err != nil {
+		if err = rs.AddKey(fmt.Appendf(nil, "key %d", i), uint64(i*17)); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -76,7 +76,7 @@ func TestReWriteIndex(t *testing.T) {
 	defer reidx.Close()
 	for i := 0; i < 100; i++ {
 		reader := NewIndexReader(reidx)
-		offset, _ := reader.Lookup([]byte(fmt.Sprintf("key %d", i)))
+		offset, _ := reader.Lookup(fmt.Appendf(nil, "key %d", i))
 		if offset != uint64(i*3965) {
 			t.Errorf("expected offset: %d, looked up: %d", i*3965, offset)
 		}

--- a/db/recsplit/recsplit_test.go
+++ b/db/recsplit/recsplit_test.go
@@ -119,7 +119,7 @@ func TestIndexLookup(t *testing.T) {
 		}
 		defer rs.Close()
 		for i := 0; i < 100; i++ {
-			if err = rs.AddKey([]byte(fmt.Sprintf("key %d", i)), uint64(i*17)); err != nil {
+			if err = rs.AddKey(fmt.Appendf(nil, "key %d", i), uint64(i*17)); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -130,7 +130,7 @@ func TestIndexLookup(t *testing.T) {
 		defer idx.Close()
 		for i := 0; i < 100; i++ {
 			reader := NewIndexReader(idx)
-			offset, ok := reader.Lookup([]byte(fmt.Sprintf("key %d", i)))
+			offset, ok := reader.Lookup(fmt.Appendf(nil, "key %d", i))
 			assert.True(t, ok)
 			if offset != uint64(i*17) {
 				t.Errorf("expected offset: %d, looked up: %d", i*17, offset)
@@ -172,7 +172,7 @@ func TestTwoLayerIndex(t *testing.T) {
 		}
 		defer rs.Close()
 		for i := 0; i < N; i++ {
-			if err = rs.AddKey([]byte(fmt.Sprintf("key %d", i)), uint64(i*17)); err != nil {
+			if err = rs.AddKey(fmt.Appendf(nil, "key %d", i), uint64(i*17)); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -184,7 +184,7 @@ func TestTwoLayerIndex(t *testing.T) {
 		defer idx.Close()
 		for i := 0; i < N; i++ {
 			reader := NewIndexReader(idx)
-			e, _ := reader.Lookup([]byte(fmt.Sprintf("key %d", i)))
+			e, _ := reader.Lookup(fmt.Appendf(nil, "key %d", i))
 			if e != uint64(i) {
 				t.Errorf("expected enumeration: %d, lookup up: %d", i, e)
 			}

--- a/db/seg/compress_test.go
+++ b/db/seg/compress_test.go
@@ -111,7 +111,7 @@ func prepareDictMetadata(t *testing.T, multiplier int, hasMetadata bool, metadat
 		if err = c.AddWord(v); err != nil {
 			t.Fatal(err)
 		}
-		if err = c.AddWord(bytes.Repeat([]byte(fmt.Sprintf("%d longlongword %d", i, i)), multiplier)); err != nil {
+		if err = c.AddWord(bytes.Repeat(fmt.Appendf(nil, "%d longlongword %d", i, i), multiplier)); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -167,7 +167,7 @@ func TestCompressDict1(t *testing.T) {
 		// next word is `longlongword %d`
 		expectPrefix := fmt.Sprintf("%d long", i)
 
-		require.True(t, g.MatchPrefix([]byte(fmt.Sprintf("%d", i))))
+		require.True(t, g.MatchPrefix(fmt.Appendf(nil, "%d", i)))
 		require.True(t, g.MatchPrefix([]byte(expectPrefix)))
 		require.True(t, g.MatchPrefix([]byte(expectPrefix+"long")))
 		require.True(t, g.MatchPrefix([]byte(expectPrefix+"longword ")))
@@ -238,7 +238,7 @@ func TestCompressDictCmp(t *testing.T) {
 		// next word is `longlongword %d`
 		expectPrefix := fmt.Sprintf("%d long", i)
 
-		require.Equal(t, -1, g.MatchCmp([]byte(fmt.Sprintf("%d", i))))
+		require.Equal(t, -1, g.MatchCmp(fmt.Appendf(nil, "%d", i)))
 		require.Equal(t, -1, g.MatchCmp([]byte(expectPrefix)))
 		require.Equal(t, -1, g.MatchCmp([]byte(expectPrefix+"long")))
 		require.Equal(t, -1, g.MatchCmp([]byte(expectPrefix+"longword ")))
@@ -305,7 +305,7 @@ func Test_CompressWithMetadata(t *testing.T) {
 		// next word is `longlongword %d`
 		expectPrefix := fmt.Sprintf("%d long", i)
 
-		require.True(t, g.MatchPrefix([]byte(fmt.Sprintf("%d", i))))
+		require.True(t, g.MatchPrefix(fmt.Appendf(nil, "%d", i)))
 		require.True(t, g.MatchPrefix([]byte(expectPrefix)))
 		require.True(t, g.MatchPrefix([]byte(expectPrefix+"long")))
 		require.True(t, g.MatchPrefix([]byte(expectPrefix+"longword ")))

--- a/db/seg/decompress_test.go
+++ b/db/seg/decompress_test.go
@@ -50,7 +50,7 @@ func prepareLoremDict(t *testing.T) *Decompressor {
 	}
 	defer c.Close()
 	for k, w := range loremStrings {
-		if err = c.AddWord([]byte(fmt.Sprintf("%s %d", w, k))); err != nil {
+		if err = c.AddWord(fmt.Appendf(nil, "%s %d", w, k)); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -155,7 +155,7 @@ func prepareStupidDict(t *testing.T, size int) *Decompressor {
 	}
 	defer c.Close()
 	for i := 0; i < size; i++ {
-		if err = c.AddWord([]byte(fmt.Sprintf("word-%d", i))); err != nil {
+		if err = c.AddWord(fmt.Appendf(nil, "word-%d", i)); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -226,7 +226,7 @@ func TestDecompressMatchPrefix(t *testing.T) {
 	skipCount := 0
 	for g.HasNext() {
 		w := loremStrings[i]
-		expected := []byte(fmt.Sprintf("%s %d", w, i+1))
+		expected := fmt.Appendf(nil, "%s %d", w, i+1)
 		expected = expected[:len(expected)/2]
 		if !g.MatchPrefix(expected) {
 			t.Errorf("expexted match with %s", expected)
@@ -243,7 +243,7 @@ func TestDecompressMatchPrefix(t *testing.T) {
 	i = 0
 	for g.HasNext() {
 		w := loremStrings[i]
-		expected := []byte(fmt.Sprintf("%s %d", w, i+1))
+		expected := fmt.Appendf(nil, "%s %d", w, i+1)
 		expected = expected[:len(expected)/2]
 		if len(expected) > 0 {
 			expected[len(expected)-1]++
@@ -277,7 +277,7 @@ func prepareLoremDictUncompressed(t *testing.T) *Decompressor {
 			require.NoError(t, err)
 			continue
 		}
-		err = c.AddUncompressedWord([]byte(fmt.Sprintf("%s %d", w, k)))
+		err = c.AddUncompressedWord(fmt.Appendf(nil, "%s %d", w, k))
 		require.NoError(t, err)
 	}
 	err = c.Compress()
@@ -298,7 +298,7 @@ func TestUncompressed(t *testing.T) {
 	offsets = append(offsets, 0)
 	for g.HasNext() {
 		w := loremStrings[i]
-		expected := []byte(fmt.Sprintf("%s %d", w, i+1))
+		expected := fmt.Appendf(nil, "%s %d", w, i+1)
 		expected = expected[:len(expected)/2]
 		actual, offset := g.NextUncompressed()
 		if bytes.Equal(expected, actual) {
@@ -364,7 +364,7 @@ func TestDecompressor_OpenCorrupted(t *testing.T) {
 		require.NoError(t, err)
 		defer c.Close()
 		for k, w := range loremStrings {
-			if err = c.AddUncompressedWord([]byte(fmt.Sprintf("%s %d", w, k))); err != nil {
+			if err = c.AddUncompressedWord(fmt.Appendf(nil, "%s %d", w, k)); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -404,7 +404,7 @@ func TestDecompressor_OpenCorrupted(t *testing.T) {
 		require.NoError(t, err)
 		defer c.Close()
 		for k, w := range loremStrings {
-			if err = c.AddWord([]byte(fmt.Sprintf("%s %d", w, k))); err != nil {
+			if err = c.AddWord(fmt.Appendf(nil, "%s %d", w, k)); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -1127,9 +1127,9 @@ func TestDomain_CollationBuildInMem(t *testing.T) {
 	l := []byte("asd9s9af0afa9sfh9afha")
 
 	for i := 0; i < int(maxTx); i++ {
-		v1 := []byte(fmt.Sprintf("value1.%d", i))
-		v2 := []byte(fmt.Sprintf("value2.%d", i))
-		s := []byte(fmt.Sprintf("longstorage2.%d", i))
+		v1 := fmt.Appendf(nil, "value1.%d", i)
+		v2 := fmt.Appendf(nil, "value2.%d", i)
+		s := fmt.Appendf(nil, "longstorage2.%d", i)
 
 		err = writer.PutWithPrev([]byte("key1"), v1, uint64(i), preval1, 0)
 		require.NoError(t, err)
@@ -2028,7 +2028,7 @@ func TestDomain_Unwind(t *testing.T) {
 					diffSetMap[i] = writer.diff.GetDiffSet()
 					continue
 				}
-				v3 := []byte(fmt.Sprintf("value3.%d", i))
+				v3 := fmt.Appendf(nil, "value3.%d", i)
 				err = writer.PutWithPrev([]byte("key3"), v3, i, preval3, 0)
 				require.NoError(t, err)
 				preval3 = v3
@@ -2036,9 +2036,9 @@ func TestDomain_Unwind(t *testing.T) {
 				continue
 			}
 
-			v1 := []byte(fmt.Sprintf("value1.%d", i))
-			v2 := []byte(fmt.Sprintf("value2.%d", i))
-			nv3 := []byte(fmt.Sprintf("valuen3.%d", i))
+			v1 := fmt.Appendf(nil, "value1.%d", i)
+			v2 := fmt.Appendf(nil, "value2.%d", i)
+			nv3 := fmt.Appendf(nil, "valuen3.%d", i)
 
 			err = writer.PutWithPrev([]byte("key1"), v1, i, preval1, 0)
 			require.NoError(t, err)
@@ -2254,7 +2254,7 @@ func TestDomain_PruneSimple(t *testing.T) {
 		defer writer.Close()
 
 		for i := 0; uint64(i) < maxTx; i++ {
-			err = writer.PutWithPrev(pruningKey, []byte(fmt.Sprintf("value.%d", i)), uint64(i), nil, kv.Step(uint64(i-1)/d.stepSize))
+			err = writer.PutWithPrev(pruningKey, fmt.Appendf(nil, "value.%d", i), uint64(i), nil, kv.Step(uint64(i-1)/d.stepSize))
 			require.NoError(t, err)
 		}
 

--- a/db/test/unmarked_forkable_test.go
+++ b/db/test/unmarked_forkable_test.go
@@ -108,7 +108,7 @@ func TestUnmarkedPrune(t *testing.T) {
 			require.NoError(t, err)
 
 			getData := func(i int) (Num, state.Bytes) {
-				return Num(i), state.Bytes(fmt.Sprintf("data%d", i))
+				return Num(i), fmt.Appendf(nil, "data%d", i)
 			}
 
 			for i := range int(entries_count) {
@@ -191,7 +191,7 @@ func TestBuildFiles_Unmarked(t *testing.T) {
 	entries_count := num_files*cfg.MinimumSize + cfg.SafetyMargin + /** in db **/ 5
 
 	getData := func(i int) (Num, state.Bytes) {
-		return Num(i), state.Bytes(fmt.Sprintf("data%d", i))
+		return Num(i), fmt.Appendf(nil, "data%d", i)
 	}
 
 	for i := range int(entries_count) {
@@ -288,7 +288,7 @@ func TestBuildFiles_PagedUnmarked(t *testing.T) {
 	entries_count := num_files*cfg.MinimumSize + cfg.SafetyMargin + /** in db **/ 5
 
 	getData := func(i int) (Num, state.Bytes) {
-		return Num(i), state.Bytes(fmt.Sprintf("data%d", i))
+		return Num(i), fmt.Appendf(nil, "data%d", i)
 	}
 
 	for i := range int(entries_count) {


### PR DESCRIPTION
 I modified the return statement to utilize `fmt.Appendf` instead of `fmt.Sprintf` for creating the formatted byte slice. 
 
 The resulting code is cleaner and more efficient, maintaining the same functionality while improving resource usage.
 
 More info can see https://github.com/golang/go/issues/47579