### PR TITLE
refactor: replace []byte(fmt.Sprintf) with fmt.Appendf

### DIFF
--- a/execution/stagedsync/exec3_parallel_test.go
+++ b/execution/stagedsync/exec3_parallel_test.go
@@ -188,7 +188,7 @@ func (t *testExecTask) Sender() accounts.Address {
 }
 
 func (t *testExecTask) Hash() common.Hash {
-	return common.BytesToHash([]byte(fmt.Sprintf("%d", t.TxIndex)))
+	return common.BytesToHash(fmt.Appendf(nil, "%d", t.TxIndex))
 }
 
 func (t *testExecTask) Dependencies() []int {

--- a/execution/stagedsync/testutil.go
+++ b/execution/stagedsync/testutil.go
@@ -74,7 +74,7 @@ func generateBlocks2(t *testing.T, from uint64, numberOfBlocks uint64, blockWrit
 			}
 			if blockNumber == 1 || updateIncarnation || difficulty == changeCodeIndepenentlyOfIncarnations {
 				if newAcc.Incarnation > 0 {
-					code := []byte(fmt.Sprintf("acc-code-%v", blockNumber))
+					code := fmt.Appendf(nil, "acc-code-%v", blockNumber)
 					codeHashValue, _ := common.HashData(code)
 					codeHash := accounts.InternCodeHash(codeHashValue)
 					if blockNumber >= from {

--- a/execution/state/versionmap_test.go
+++ b/execution/state/versionmap_test.go
@@ -16,7 +16,7 @@ var randomness = rand.Intn(10) + 10
 
 // create test data for a given txIdx and incarnation
 func valueFor(txIdx, inc int) []byte {
-	return []byte(fmt.Sprintf("%ver:%ver:%ver", txIdx*5, txIdx+inc, inc*5))
+	return fmt.Appendf(nil, "%ver:%ver:%ver", txIdx*5, txIdx+inc, inc*5)
 }
 
 func getAddress(i int) accounts.Address {

--- a/execution/types/hashing_test.go
+++ b/execution/types/hashing_test.go
@@ -32,7 +32,7 @@ func genTransactions(n uint64) Transactions {
 	txs := Transactions{}
 
 	for i := uint64(0); i < n; i++ {
-		tx := NewTransaction(i, common.Address{}, uint256.NewInt(1000+i), 10+i, uint256.NewInt(1000+i), []byte(fmt.Sprintf("hello%d", i)))
+		tx := NewTransaction(i, common.Address{}, uint256.NewInt(1000+i), 10+i, uint256.NewInt(1000+i), fmt.Appendf(nil, "hello%d", i))
 		txs = append(txs, tx)
 	}
 


### PR DESCRIPTION
I modified the return statement to utilize fmt.Appendf instead of fmt.Sprintf for creating the formatted byte slice.

The resulting code is cleaner and more efficient, maintaining the same functionality while improving resource usage.

More info can see https://github.com/golang/go/issues/47579