### PR TITLE
refactor: replace []byte(fmt.Sprintf) with fmt.Appendf

### DIFF
--- a/common/math/big.go
+++ b/common/math/big.go
@@ -78,7 +78,7 @@ func (i *HexOrDecimal256) MarshalText() ([]byte, error) {
 	if i == nil {
 		return []byte("0x0"), nil
 	}
-	return []byte(fmt.Sprintf("%#x", (*big.Int)(i))), nil
+	return fmt.Appendf(nil, "%#x", (*big.Int)(i)), nil
 }
 
 // Decimal256 unmarshals big.Int as a decimal string. When unmarshalling,

--- a/common/math/integer.go
+++ b/common/math/integer.go
@@ -71,7 +71,7 @@ func (i *HexOrDecimal64) UnmarshalText(input []byte) error {
 }
 
 func (i HexOrDecimal64) MarshalText() ([]byte, error) {
-	return []byte(fmt.Sprintf("%#x", uint64(i))), nil
+	return fmt.Appendf(nil, "%#x", uint64(i)), nil
 }
 
 // ParseUint64 parses s as an integer in decimal or hexadecimal syntax.

--- a/node/rpcstack_test.go
+++ b/node/rpcstack_test.go
@@ -296,7 +296,7 @@ func TestAllowList(t *testing.T) {
 }
 
 func testCustomRequest(t *testing.T, srv *httpServer, method string) bool {
-	body := bytes.NewReader([]byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":"%s"}`, method)))
+	body := bytes.NewReader(fmt.Appendf(nil, `{"jsonrpc":"2.0","id":1,"method":"%s"}`, method))
 	req, _ := http.NewRequest("POST", "http://"+srv.listenAddr(), body)
 	req.Header.Set("content-type", "application/json")
 

--- a/p2p/enode/nodedb_test.go
+++ b/p2p/enode/nodedb_test.go
@@ -51,8 +51,8 @@ import (
 func BenchmarkNodeDBGeometry(b *testing.B) {
 	keys, vals := make([][]byte, 100_000), make([][]byte, 100_000)
 	for i := range keys {
-		keys[i] = []byte(fmt.Sprintf("key %d", i))
-		vals[i] = []byte(fmt.Sprintf("val %d", i))
+		keys[i] = fmt.Appendf(nil, "key %d", i)
+		vals[i] = fmt.Appendf(nil, "val %d", i)
 	}
 	cfg := mdbx.New(dbcfg.ChainDB, log.New()).
 		PageSize(4 * datasize.KB).

--- a/polygon/sync/block_downloader_test.go
+++ b/polygon/sync/block_downloader_test.go
@@ -147,7 +147,7 @@ func (hdt blockDownloaderTest) fakeCheckpoints(count int) []*heimdall.Checkpoint
 			Fields: heimdall.WaypointFields{
 				StartBlock: big.NewInt(int64(start)),
 				EndBlock:   big.NewInt(int64(end)),
-				RootHash:   common.BytesToHash([]byte(fmt.Sprintf("0x%d", i+1))),
+				RootHash:   common.BytesToHash(fmt.Appendf(nil, "0x%d", i+1)),
 			},
 		}
 	}
@@ -164,7 +164,7 @@ func (hdt blockDownloaderTest) fakeMilestones(count int) []*heimdall.Milestone {
 			Fields: heimdall.WaypointFields{
 				StartBlock: big.NewInt(int64(start)),
 				EndBlock:   big.NewInt(int64(end)),
-				RootHash:   common.BytesToHash([]byte(fmt.Sprintf("0x%d", i+1))),
+				RootHash:   common.BytesToHash(fmt.Appendf(nil, "0x%d", i+1)),
 			},
 		}
 	}

--- a/txnprovider/txpool/fetch_test.go
+++ b/txnprovider/txpool/fetch_test.go
@@ -137,7 +137,7 @@ func TestSendTxnPropagate(t *testing.T) {
 		send := NewSend(ctx, []sentryproto.SentryClient{sentryClient}, log.New())
 		list := make(Hashes, p2pTxPacketLimit*3)
 		for i := 0; i < len(list); i += 32 {
-			b := []byte(fmt.Sprintf("%x", i))
+			b := fmt.Appendf(nil, "%x", i)
 			copy(list[i:i+32], b)
 		}
 		send.BroadcastPooledTxns(testRlps(len(list)/32), 100)


### PR DESCRIPTION
I modified the return statement to utilize fmt.Appendf instead of fmt.Sprintf for creating the formatted byte slice.

The resulting code is cleaner and more efficient, maintaining the same functionality while improving resource usage.

More info can see https://github.com/golang/go/issues/47579