### PR TITLE
cl/das: remove unused local DataColumnsByRootIdentifier type

### DIFF
--- a/cl/das/p2p_utils.go
+++ b/cl/das/p2p_utils.go
@@ -21,11 +21,6 @@ const (
 	KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH = 4
 )
 
-type DataColumnsByRootIdentifier struct {
-	BlockRoot common.Hash
-	Columns   []cltypes.ColumnIndex
-}
-
 // VerifyDataColumnSidecar verifies if the data column sidecar is valid according to protocol rules.
 // This function is re-entrant and thread-safe.
 func VerifyDataColumnSidecar(sidecar *cltypes.DataColumnSidecar) bool {


### PR DESCRIPTION
All DAS, RPC and sentinel handlers use cltypes.DataColumnsByRootIdentifier as the canonical protocol container, including SSZ codecs and consensus tests. The local DataColumnsByRootIdentifier struct in cl/das/p2p_utils.go was never used and did not implement SSZ encoding, so it could only cause confusion for future changes; remove it to make the codebase consistent with the protocol type.