### PR TITLE
execution/types: avoid escape to heap

### DIFF
--- a/execution/types/hashing.go
+++ b/execution/types/hashing.go
@@ -182,8 +182,10 @@ func rlpHash(x any) (h common.Hash) {
 	return h
 }
 
-// prefixSlices holds pre-allocated byte slices for each possible prefix value.
-// This avoids heap allocation when writing the prefix byte to the hasher.
+// prefixSlices contains one-byte slices for all possible prefix values (0–255).
+// Each entry is pre-allocated once during init so we can write a single prefix
+// byte into the hasher without creating a new slice every time.
+// This avoids per-call heap allocations when hashing typed transactions.
 var prefixSlices [256][]byte
 
 func init() {


### PR DESCRIPTION
Benchmark Test:
```
package types

import (
	"math/big"
	"testing"

	"github.com/erigontech/erigon/common"
)

// ExampleTxData simulates a typical typed transaction inner data for benchmarking.
type ExampleTxData struct {
	ChainID    *big.Int
	Nonce      uint64
	GasTipCap  *big.Int
	GasFeeCap  *big.Int
	Gas        uint64
	To         *common.Address
	Value      *big.Int
	Data       []byte
	AccessList []AccessTuple
}

// BenchmarkPrefixedRlpHash benchmarks the prefixedRlpHash function with various input sizes.
//
// This function is used for typed transaction (EIP-2718) hash calculation:
// 1. Get a KeccakState hasher from sync.Pool
// 2. Reset the hasher
// 3. Write a prefix byte (transaction type)
// 4. RLP encode the transaction data and write to hasher
// 5. Read the resulting 32-byte hash
func BenchmarkPrefixedRlpHash(b *testing.B) {
	addr := common.HexToAddress("0x5a8eafc1cf62bfbeb1741769dae1a9dd47996199")

	// Small data: minimal transaction
	smallTx := &ExampleTxData{
		ChainID:   big.NewInt(1),
		Nonce:     7,
		GasTipCap: big.NewInt(2_000_000_000), 
		GasFeeCap: big.NewInt(5_000_000_000),
		Gas:       22000,
		To:        &addr,
		Value:     big.NewInt(5_000_000_000_000_000),
		Data:      nil,
	}

	// Medium data: transaction with some calldata (512B)
	mediumData := make([]byte, 512)
	for i := range mediumData {
		mediumData[i] = byte(255 - i%256)
	}
	mediumTx := &ExampleTxData{
		ChainID:   big.NewInt(11155111),
		Nonce:     42,
		GasTipCap: big.NewInt(3_000_000_000),
		GasFeeCap: big.NewInt(60_000_000_000),
		Gas:       150000,
		To:        &addr,
		Value:     big.NewInt(0),
		Data:      mediumData,
	}

	// Large data: transaction with large calldata (8KB)
	largeData := make([]byte, 8192)
	for i := range largeData {
		largeData[i] = byte(i & 0xff)
	}
	largeTx := &ExampleTxData{
		ChainID:   big.NewInt(1),
		Nonce:     2048,
		GasTipCap: big.NewInt(5_000_000_000),
		GasFeeCap: big.NewInt(120_000_000_000),
		Gas:       800000,
		To:        &addr,
		Value:     big.NewInt(0),
		Data:      largeData,
		AccessList: []AccessTuple{
			{
				Address: addr,
				StorageKeys: []common.Hash{
					common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000005"),
					common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000009"),
					common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000012"),
				},
			},
		},
	}

	// Prefix byte 0x02 = EIP-1559 transaction type
	const prefix byte = 0x02

	b.Run("small_tx", func(b *testing.B) {
		b.ReportAllocs()
		var h common.Hash
		for b.Loop() {
			h = prefixedRlpHash(prefix, smallTx)
		}
		_ = h // prevent compiler optimization
	})

	b.Run("medium_tx_512B_data", func(b *testing.B) {
		b.ReportAllocs()
		var h common.Hash
		for b.Loop() {
			h = prefixedRlpHash(prefix, mediumTx)
		}
		_ = h
	})

	b.Run("large_tx_8KB_data", func(b *testing.B) {
		b.ReportAllocs()
		var h common.Hash
		for b.Loop() {
			h = prefixedRlpHash(prefix, largeTx)
		}
		_ = h
	})
}

// BenchmarkPrefixedRlpHashVsRlpHash compares prefixedRlpHash with rlpHash
// to measure the overhead of writing the prefix byte.
func BenchmarkPrefixedRlpHashVsRlpHash(b *testing.B) {
	addr := common.HexToAddress("0x3f5ce5fbfe3e9af3971dd833d26ba9b5c936f0be")
	tx := &ExampleTxData{
		ChainID:   big.NewInt(1),
		Nonce:     99,
		GasTipCap: big.NewInt(1_500_000_000),
		GasFeeCap: big.NewInt(40_000_000_000),
		Gas:       30000,
		To:        &addr,
		Value:     big.NewInt(10_000_000_000_000_000),
		Data:      nil,
	}

	b.Run("rlpHash", func(b *testing.B) {
		b.ReportAllocs()
		var h common.Hash
		for b.Loop() {
			h = rlpHash(tx)
		}
		_ = h
	})

	b.Run("prefixedRlpHash", func(b *testing.B) {
		b.ReportAllocs()
		var h common.Hash
		for b.Loop() {
			h = prefixedRlpHash(0x02, tx)
		}
		_ = h
	})
}

// BenchmarkPrefixedRlpHashDifferentPrefixes tests if different prefix values affect performance.
func BenchmarkPrefixedRlpHashDifferentPrefixes(b *testing.B) {
	addr := common.HexToAddress("0x8a8eafb1cf62bfbeb1741769dae1a9dd47996192")
	tx := &ExampleTxData{
		ChainID:   big.NewInt(1),
		Nonce:     1,
		GasTipCap: big.NewInt(5_000_000_000),
		GasFeeCap: big.NewInt(120_000_000_000),
		Gas:       800000,
		To:        &addr,
		Value:     big.NewInt(0),
	}

	prefixes := []struct {
		name   string
		prefix byte
	}{
		{"EIP2930_0x01", 0x01},
		{"EIP1559_0x02", 0x02},
		{"EIP4844_0x03", 0x03},
		{"EIP7702_0x04", 0x04},
	}

	for _, p := range prefixes {
		b.Run(p.name, func(b *testing.B) {
			b.ReportAllocs()
			var h common.Hash
			for b.Loop() {
				h = prefixedRlpHash(p.prefix, tx)
			}
			_ = h
		})
	}
}
```

Result:
```
goos: linux
goarch: amd64
pkg: github.com/erigontech/erigon/execution/types
cpu: Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz
                                                │ old_bench.txt │           new_bench.txt            │
                                                │    sec/op     │   sec/op     vs base               │
PrefixedRlpHash/small_tx-8                          872.2n ± 2%   824.5n ± 1%  -5.47% (p=0.000 n=10)
PrefixedRlpHash/medium_tx_512B_data-8               1.771µ ± 5%   1.661µ ± 2%  -6.18% (p=0.000 n=10)
PrefixedRlpHash/large_tx_8KB_data-8                 14.62µ ± 3%   14.48µ ± 6%       ~ (p=0.684 n=10)
PrefixedRlpHashVsRlpHash/rlpHash-8                  865.2n ± 3%   848.1n ± 5%       ~ (p=0.631 n=10)
PrefixedRlpHashVsRlpHash/prefixedRlpHash-8          900.4n ± 2%   844.7n ± 4%  -6.18% (p=0.000 n=10)
PrefixedRlpHashDifferentPrefixes/EIP2930_0x01-8     896.3n ± 6%   854.8n ± 4%  -4.64% (p=0.007 n=10)
PrefixedRlpHashDifferentPrefixes/EIP1559_0x02-8     898.2n ± 3%   855.8n ± 2%  -4.73% (p=0.000 n=10)
PrefixedRlpHashDifferentPrefixes/EIP4844_0x03-8     917.2n ± 4%   861.6n ± 3%  -6.06% (p=0.000 n=10)
PrefixedRlpHashDifferentPrefixes/EIP7702_0x04-8     900.2n ± 5%   853.1n ± 3%  -5.24% (p=0.000 n=10)
geomean                                             1.314µ        1.253µ       -4.62%

                                                │ old_bench.txt │            new_bench.txt            │
                                                │     B/op      │    B/op     vs base                 │
PrefixedRlpHash/small_tx-8                           33.00 ± 0%   32.00 ± 0%  -3.03% (p=0.000 n=10)
PrefixedRlpHash/medium_tx_512B_data-8                33.00 ± 0%   32.00 ± 0%  -3.03% (p=0.000 n=10)
PrefixedRlpHash/large_tx_8KB_data-8                  33.00 ± 0%   32.00 ± 0%  -3.03% (p=0.000 n=10)
PrefixedRlpHashVsRlpHash/rlpHash-8                   32.00 ± 0%   32.00 ± 0%       ~ (p=1.000 n=10) ¹
PrefixedRlpHashVsRlpHash/prefixedRlpHash-8           33.00 ± 0%   32.00 ± 0%  -3.03% (p=0.000 n=10)
PrefixedRlpHashDifferentPrefixes/EIP2930_0x01-8      33.00 ± 0%   32.00 ± 0%  -3.03% (p=0.000 n=10)
PrefixedRlpHashDifferentPrefixes/EIP1559_0x02-8      33.00 ± 0%   32.00 ± 0%  -3.03% (p=0.000 n=10)
PrefixedRlpHashDifferentPrefixes/EIP4844_0x03-8      33.00 ± 0%   32.00 ± 0%  -3.03% (p=0.000 n=10)
PrefixedRlpHashDifferentPrefixes/EIP7702_0x04-8      33.00 ± 0%   32.00 ± 0%  -3.03% (p=0.000 n=10)
geomean                                              32.89        32.00       -2.70%
¹ all samples are equal

                                                │ old_bench.txt │            new_bench.txt             │
                                                │   allocs/op   │ allocs/op   vs base                  │
PrefixedRlpHash/small_tx-8                           2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
PrefixedRlpHash/medium_tx_512B_data-8                2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
PrefixedRlpHash/large_tx_8KB_data-8                  2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
PrefixedRlpHashVsRlpHash/rlpHash-8                   1.000 ± 0%   1.000 ± 0%        ~ (p=1.000 n=10) ¹
PrefixedRlpHashVsRlpHash/prefixedRlpHash-8           2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
PrefixedRlpHashDifferentPrefixes/EIP2930_0x01-8      2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
PrefixedRlpHashDifferentPrefixes/EIP1559_0x02-8      2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
PrefixedRlpHashDifferentPrefixes/EIP4844_0x03-8      2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
PrefixedRlpHashDifferentPrefixes/EIP7702_0x04-8      2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
geomean                                              1.852        1.000       -46.00%
¹ all samples are equal
```