### PR TITLE
refactor(stagedsync): remove unused trace constant

### DIFF
--- a/execution/stagedsync/stage_execute.go
+++ b/execution/stagedsync/stage_execute.go
@@ -215,8 +215,6 @@ func unwindExec3(u *UnwindState, s *StageState, doms *execctx.SharedDomains, rwT
 
 var mxState3Unwind = metrics.GetOrCreateSummary("state3_unwind")
 
-const trace bool = true
-
 func unwindExec3State(ctx context.Context,
 	sd *execctx.SharedDomains, tx kv.TemporalRwTx,
 	blockUnwindTo, txUnwindTo uint64,


### PR DESCRIPTION
Removes unused `trace` constant from `stage_execute.go`.