### PR TITLE
Remove redundant block marshal map allocation in Otterscan API

### DIFF
--- a/rpc/jsonrpc/otterscan_api.go
+++ b/rpc/jsonrpc/otterscan_api.go
@@ -282,8 +282,7 @@ func (api *OtterscanAPIImpl) traceBlocks(ctx context.Context, addr common.Addres
 }
 
 func delegateGetBlockByNumber(tx kv.Tx, b *types.Block, number rpc.BlockNumber, inclTx bool) (map[string]any, error) {
-	additionalFields := make(map[string]any)
-	response, err := ethapi.RPCMarshalBlock(b, inclTx, inclTx, additionalFields)
+	response, err := ethapi.RPCMarshalBlock(b, inclTx, inclTx, nil)
 	if !inclTx {
 		delete(response, "transactions") // workaround for https://github.com/erigontech/erigon/issues/4989#issuecomment-1218415666
 	}


### PR DESCRIPTION
Stop creating an empty additionalFields map before calling RPCMarshalBlock; pass nil instead.
Eliminates a pointless allocation and copy while keeping response shaping unchanged (transactions removal, transactionCount, pending field nils, logsBloom drop remain intact).