### PR TITLE
txnprovider/shutter: preallocate slices in encryption functions

### DIFF
--- a/txnprovider/shutter/internal/crypto/encryption.go
+++ b/txnprovider/shutter/internal/crypto/encryption.go
@@ -114,12 +114,12 @@ func fp12Exp(base *blst.Fp12, exp *big.Int) *blst.Fp12 {
 }
 
 func computeC3(blocks []Block, sigma Block) []Block {
-	encryptedBlocks := []Block{}
 	numBlocks := len(blocks)
+	encryptedBlocks := make([]Block, numBlocks)
 	for i := 0; i < numBlocks; i++ {
 		key := computeBlockKey(sigma, uint64(i))
 		encryptedBlock := XORBlocks(key, blocks[i])
-		encryptedBlocks = append(encryptedBlocks, encryptedBlock)
+		encryptedBlocks[i] = encryptedBlock
 	}
 	return encryptedBlocks
 }
@@ -172,11 +172,11 @@ func (m *EncryptedMessage) Sigma(epochSecretKey *EpochSecretKey) Block {
 
 func DecryptBlocks(encryptedBlocks []Block, sigma Block) []Block {
 	numBlocks := len(encryptedBlocks)
-	decryptedBlocks := []Block{}
+	decryptedBlocks := make([]Block, numBlocks)
 	for i := 0; i < numBlocks; i++ {
 		key := computeBlockKey(sigma, uint64(i))
 		decryptedBlock := XORBlocks(encryptedBlocks[i], key)
-		decryptedBlocks = append(decryptedBlocks, decryptedBlock)
+		decryptedBlocks[i] = decryptedBlock
 	}
 	return decryptedBlocks
 }
@@ -188,12 +188,10 @@ func PadMessage(m []byte) []Block {
 	padding := bytes.Repeat([]byte{byte(paddingLength)}, paddingLength)
 	m = append(m, padding...)
 
-	blocks := []Block{}
 	numBlocks := len(m) / BlockSize
+	blocks := make([]Block, numBlocks)
 	for i := 0; i < numBlocks; i++ {
-		var block Block
-		copy(block[:], m[i*BlockSize:(i+1)*BlockSize])
-		blocks = append(blocks, block)
+		copy(blocks[i][:], m[i*BlockSize:(i+1)*BlockSize])
 	}
 	return blocks
 }


### PR DESCRIPTION
Optimize memory allocations in computeC3, DecryptBlocks, and PadMessage by preallocating slices with known capacity instead of using append.