### PR TITLE
Remove unused Params stub from cmd/erigon node

### DIFF
--- a/cmd/erigon/node/node.go
+++ b/cmd/erigon/node/node.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/erigontech/erigon/cmd/utils"
 	"github.com/erigontech/erigon/common/log/v3"
-	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/version"
 	"github.com/erigontech/erigon/execution/chain/networkname"
 	"github.com/erigontech/erigon/execution/tracing/tracers"
@@ -77,15 +76,6 @@ func (eri *ErigonNode) run() {
 	// we don't have accounts locally and we don't do mining
 	// so these parts are ignored
 	// see cmd/geth/daemon.go#startNode for full implementation
-}
-
-// Params contains optional parameters for creating a node.
-// * GitCommit is a commit from which then node was built.
-// * CustomBuckets is a `map[string]dbutils.TableCfgItem`, that contains bucket name and its properties.
-//
-// NB: You have to declare your custom buckets here to be able to use them in the app.
-type Params struct {
-	CustomBuckets kv.TableCfg
 }
 
 func NewNodConfigUrfave(ctx *cli.Context, debugMux *http.ServeMux, logger log.Logger) (*nodecfg.Config, error) {
@@ -140,9 +130,10 @@ func NewEthConfigUrfave(ctx *cli.Context, nodeConfig *nodecfg.Config, logger log
 }
 
 // New creates a new `ErigonNode`.
-// * ctx - `*cli.Context` from the main function. Necessary to be able to configure the node based on the command-line flags
-// * sync - `stagedsync.StagedSync`, an instance of staged sync, setup just as needed.
-// * optionalParams - additional parameters for running a node.
+// * ctx - `*cli.Context` from the main function. Necessary to configure the node from CLI flags.
+// * nodeConfig - runtime options for the node stack.
+// * ethConfig - Ethereum protocol configuration.
+// * logger/tracer - runtime instrumentation.
 func New(
 	ctx context.Context,
 	nodeConfig *nodecfg.Config,
@@ -150,7 +141,6 @@ func New(
 	logger log.Logger,
 	tracer *tracers.Tracer,
 ) (*ErigonNode, error) {
-	//prepareBuckets(optionalParams.CustomBuckets)
 	node, err := node.New(ctx, nodeConfig, logger)
 	if err != nil {
 		utils.Fatalf("Failed to create Erigon node: %v", err)


### PR DESCRIPTION
Remove dead Params struct and unused kv import in cmd/erigon/node/node.go. Refresh New doc comment to reflect actual parameters; drop stale optional params note. Keep node creation path unchanged while trimming unused code