### PR TITLE
Refine fsync write helper to remove redundant error handling

### DIFF
--- a/common/dir/rw_dir.go
+++ b/common/dir/rw_dir.go
@@ -133,15 +133,10 @@ func writeFileWithFsyncAndFlags(name string, data []byte, perm os.FileMode, flag
 		return err
 	}
 	defer f.Close()
-	_, err = f.Write(data)
-	if err != nil {
+	if _, err = f.Write(data); err != nil {
 		return err
 	}
-	err = f.Sync()
-	if err != nil {
-		return err
-	}
-	return err
+	return f.Sync()
 }
 
 // nolint


### PR DESCRIPTION
Simplify writeFileWithFsyncAndFlags by returning the Sync result directly after a single write check, removing duplicated error branches.
Behavior remains unchanged; only the control flow is tightened for clarity.