### PR TITLE
execution/stagedsync: remove unused sortByBytes helper

### DIFF
--- a/execution/stagedsync/bal_create.go
+++ b/execution/stagedsync/bal_create.go
@@ -333,12 +333,6 @@ func sortByIndex[T interface{ GetIndex() uint16 }](changes []T) {
 	})
 }
 
-func sortByBytes[T interface{ GetBytes() []byte }](items []T) {
-	sort.Slice(items, func(i, j int) bool {
-		return bytes.Compare(items[i].GetBytes(), items[j].GetBytes()) < 0
-	})
-}
-
 func sortHashes(hashes []accounts.StorageKey) {
 	sort.Slice(hashes, func(i, j int) bool {
 		return hashes[i].Cmp(hashes[j]) < 0


### PR DESCRIPTION
The generic sortByBytes helper was never used and no types implement the GetBytes() []byte contract in this codebase. Keeping it around adds dead code and suggests a non-existent abstraction. This change removes the helper to keep the stagedsync BAL implementation minimal and easier to maintain.