### PR TITLE
Fix size calculation for downloader failfast

### DIFF
--- a/db/downloader/downloader.go
+++ b/db/downloader/downloader.go
@@ -583,7 +583,7 @@ func (d *Downloader) VerifyData(
 						d.log(log.LvlInfo, "Verify",
 							"progress", fmt.Sprintf("%.2f%%", 100*float64(completedBytes.Load())/float64(totalBytes)),
 							"files", fmt.Sprintf("%d/%d", completedFiles.Load(), len(toVerify)),
-							"sz_gb", downloadercfg.DefaultPieceSize*completedBytes.Load()/1024/1024/1024,
+							"sz_gib", completedBytes.Load()>>30,
 						)
 					}
 				}


### PR DESCRIPTION
Fixes the reported size logged when using `downloader --verify.failfast`

Spotted while testing https://github.com/erigontech/erigon/pull/18637