### PR TITLE
Disable discv4 by default on main

### DIFF
--- a/node/nodecfg/defaults.go
+++ b/node/nodecfg/defaults.go
@@ -52,7 +52,7 @@ var DefaultConfig = Config{
 		MaxPeers:        32,
 		MaxPendingPeers: 1000,
 		NAT:             nat.Any(),
-		DiscoveryV4:     true,
+		DiscoveryV4:     false,
 		DiscoveryV5:     true,
 	},
 }


### PR DESCRIPTION
Per https://notes.ethereum.org/@cskiraly/el-discovery-v5-tracker discv4 might by sunsetted by Glamsterdam. In preparation for this, this change disables discv4 by default on main to determine readiness for this requirement. discv5 is enabled and should do the work.

In the event of issues, it should be possible to pass `--discovery.v4=true`, or rollback until further changes are made to improve support.