### PR TITLE
db/downloader: remove unused generic type parameter from strconvFromEnv

### DIFF
--- a/db/downloader/env.go
+++ b/db/downloader/env.go
@@ -12,7 +12,7 @@ func initIntFromEnv[T constraints.Signed](key string, defaultValue T, bitSize in
 	return strconvFromEnv(key, defaultValue, bitSize, strconv.ParseInt)
 }
 
-func strconvFromEnv[T, U constraints.Integer](key string, defaultValue T, bitSize int, conv func(s string, base, bitSize int) (U, error)) T {
+func strconvFromEnv[T constraints.Integer](key string, defaultValue T, bitSize int, conv func(s string, base, bitSize int) (int64, error)) T {
 	s := os.Getenv(key)
 	if s == "" {
 		return defaultValue


### PR DESCRIPTION
Remove redundant generic type parameter `U` from `strconvFromEnv` function.