### PR TITLE
qa-tests: add base workflow to implement RPC performance tests

### DIFF
--- a/.github/workflows/qa-rpc-performance-comparison-tests.yml
+++ b/.github/workflows/qa-rpc-performance-comparison-tests.yml
@@ -7,8 +7,6 @@ concurrency:
   group: erigon-vs-geth-benchmark-${{ github.ref }}
   cancel-in-progress: false
 
-permissions:
-  contents: read
 
 env:
   CHAIN: mainnet
@@ -18,6 +16,8 @@ jobs:
   setup:
     name: Setup benchmark run
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       run_id: ${{ steps.vars.outputs.run_id }}
       redis_key_prefix: ${{ steps.vars.outputs.redis_key_prefix }}
@@ -72,6 +72,8 @@ jobs:
     needs: [setup]
     runs-on: [self-hosted, qa, Ethereum, rpc-latest-erigon]
     timeout-minutes: 120
+    permissions:
+      contents: read
     env:
       RUN_ID: ${{ needs.setup.outputs.run_id }}
       REDIS_KEY_PREFIX: ${{ needs.setup.outputs.redis_key_prefix }}
@@ -109,8 +111,9 @@ jobs:
     name: Benchmark Geth
     needs: [setup]
     runs-on: [self-hosted, qa, Ethereum, rpc-latest-geth]
-
     timeout-minutes: 120
+    permissions:
+      contents: read
     env:
       RUN_ID: ${{ needs.setup.outputs.run_id }}
       REDIS_KEY_PREFIX: ${{ needs.setup.outputs.redis_key_prefix }}


### PR DESCRIPTION
This is the basic workflow for implementing RPC performance tests.
First, a setup job will create the necessary infrastructure and context. Then, two parallel execution jobs will use a distributed barrier to find a common agreement time point, after which they will start executing performance tests on Erigon and Geth, which are running on self-hosted runners.