### PR TITLE
chore: remove commented out code in gorules linter rules

### DIFF
--- a/rules.go
+++ b/rules.go
@@ -53,7 +53,6 @@ func txDeferRollback(m dsl.Matcher) {
 		`$tx, $err = $db.BeginRwNosync($ctx); $chk; $rollback`,
 	).
 		Where(!m["rollback"].Text.Matches(`defer .*\.Rollback()`)).
-		//At(m["rollback"]).
 		Report(`Add "defer $tx.Rollback()" right after transaction creation error check. 
 			If you are in the loop - consider using "$db.View" or "$db.Update" or extract whole transaction to function.
 			Without rollback in defer - app can deadlock on error or panic.
@@ -73,7 +72,6 @@ func cursorDeferClose(m dsl.Matcher) {
 		`$c, $err := $db.RwCursorDupSort($table); $chk; $close`,
 	).
 		Where(!m["close"].Text.Matches(`defer .*\.Close()`)).
-		//At(m["close"]).
 		Report(`Add "defer $c.Close()" right after cursor creation error check`)
 }
 
@@ -87,7 +85,6 @@ func streamDeferClose(m dsl.Matcher) {
 		`$c, $err := $db.Prefix($params); $chk; $close`,
 	).
 		Where(!m["close"].Text.Matches(`defer .*\.Close()`)).
-		//At(m["close"]).
 		Report(`Add "defer $c.Close()" right after cursor creation error check`)
 }
 


### PR DESCRIPTION
Removes 3 commented-out `At()` method calls in `rules.go` that have been left over from previous iterations of the ruleguard rules.