### PR TITLE
rpc: close ws handshake response body on error

### DIFF
--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -203,6 +203,9 @@ func DialWebsocketWithDialer(ctx context.Context, endpoint, origin string, diale
 		//nolint
 		conn, resp, err := dialer.DialContext(ctx, endpoint, header)
 		if err != nil {
+			if resp != nil {
+				resp.Body.Close()
+			}
 			hErr := wsHandshakeError{err: err}
 			if resp != nil {
 				hErr.status = resp.Status


### PR DESCRIPTION
Close the HTTP response body when the websocket dialer returns an error with a non‑nil response during the handshake. This prevents leaking HTTP response bodies and aligns the websocket client path with the existing pattern used in the diagnostics support code.

The change only affects the error path in DialWebsocketWithDialer; successful websocket connections are untouched and continue to be handled by NewWebsocketCodec.