### PR TITLE
batch: estimateSize more strict

### DIFF
--- a/db/state/temporal_mem_batch.go
+++ b/db/state/temporal_mem_batch.go
@@ -256,9 +256,9 @@ func (sd *TemporalMemBatch) SizeEstimate() uint64 {
 	defer sd.latestStateLock.RUnlock()
 
 	estimateRamUsage := uint64(sd.metrics.CachePutSize)
-	estimateRamUsage *= 2 // cover golang-data-structures overhead (and keep accounting cheap)
-	estimateRamUsage *= 2 // cover multiple versions of domains in-mem data - see `domains` field type
-	estimateRamUsage *= 2 // because Commitment storing copy of updated keys. And because Commitment will produce `trie` updates - when batch is full
+	estimateRamUsage *= 2 // cover golang-data-structures overhead (and keep accounting cheap). also multiple versions of domain updates stored in-mem - see `domains` field type
+	estimateRamUsage *= 2 // because Commitment storing copy of updated keys
+	estimateRamUsage *= 2 // because Commitment will produce `trie` updates - when batch is full
 	return estimateRamUsage
 }
 


### PR DESCRIPTION
now i see `buf=4.3GB/8.0GB alloc=18.3GB` (5G attributed to bloomfilters, 3G to Caplin). On `pprof` i see 8Gb in-use by exec at this time. 

Example pprof when `buf=7.0GB/8.0GB` bef:
<img width="725" height="973" alt="Screenshot 2026-01-15 at 11 08 04" src="https://github.com/user-attachments/assets/9c19b14f-92fe-49fc-ba41-0ade70b0ec27" />



--
after change `buf=7.0GB/8.0GB`:

<img width="587" height="940" alt="Screenshot 2026-01-15 at 11 18 54" src="https://github.com/user-attachments/assets/781e9d10-192b-42bb-9bc9-9d3efc51c91f" />


see also: https://github.com/erigontech/erigon/pull/18575#discussion_r2676058670
