### PR TITLE
txnprovider/shutter: preallocate buffers in Marshal() to reduce allocations

### DIFF
--- a/txnprovider/shutter/validator_registry_msg.go
+++ b/txnprovider/shutter/validator_registry_msg.go
@@ -39,7 +39,9 @@ type AggregateRegistrationMessage struct {
 }
 
 func (m *AggregateRegistrationMessage) Marshal() []byte {
-	b := make([]byte, 0)
+	// Fixed-size message: preallocate to avoid growth reallocations during appends.
+	expectedLength := 1 + 8 + 20 + 8 + 4 + 4 + 1
+	b := make([]byte, 0, expectedLength)
 	b = append(b, m.Version)
 	b = binary.BigEndian.AppendUint64(b, m.ChainId)
 	b = append(b, m.ValidatorRegistryAddress.Bytes()...)
@@ -98,7 +100,9 @@ type LegacyRegistrationMessage struct {
 }
 
 func (m *LegacyRegistrationMessage) Marshal() []byte {
-	b := make([]byte, 0)
+	// Fixed-size message: preallocate to avoid growth reallocations during appends.
+	expectedLength := 1 + 8 + 20 + 8 + 8 + 1
+	b := make([]byte, 0, expectedLength)
 	b = append(b, m.Version)
 	b = binary.BigEndian.AppendUint64(b, m.ChainId)
 	b = append(b, m.ValidatorRegistryAddress.Bytes()...)


### PR DESCRIPTION
Optimize memory allocation in validator_registry_msg.go by preallocating byte slice capacity in Marshal() methods for fixed-size messages.