### PR TITLE
fix for missing rcache at stepBoundary

### DIFF
--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -543,7 +543,7 @@ func (se *serialExecutor) executeBlock(ctx context.Context, tasks []exec.Task, i
 		}
 
 		var applyReceipt *types.Receipt
-		if txTask.TxIndex >= 0 {
+		if txTask.TxIndex >= 0 && txTask.TxIndex-startTxIndex < len(blockReceipts) {
 			applyReceipt = blockReceipts[txTask.TxIndex-startTxIndex]
 		}
 


### PR DESCRIPTION
- bug got introduces in https://github.com/erigontech/erigon/commit/ec7e6d31d657c8519d74b00218004d558f856725, which changed 
```
blockReceipts := make([]*types.Receipt, len(tasks))
```
to
```
blockReceipts := make([]*types.Receipt, 0, len(tasks))
```

- seriously need tests for "rm chaindata" and start with snapshots case.