### PR TITLE
Remove touchmap serialization

### DIFF
--- a/cl/phase1/stages/clstages.go
+++ b/cl/phase1/stages/clstages.go
@@ -268,7 +268,7 @@ func ConsensusClStages(ctx context.Context,
 					startingSlot := cfg.state.LatestBlockHeader().Slot
 					downloader := network2.NewBackwardBeaconDownloader(ctx, cfg.rpc, cfg.sn, cfg.executionClient, cfg.indiciesDB)
 
-					if err := SpawnStageHistoryDownload(StageHistoryReconstruction(downloader, cfg.antiquary, cfg.sn, cfg.indiciesDB, cfg.executionClient, cfg.beaconCfg, cfg.caplinConfig, false, startingRoot, startingSlot, cfg.dirs.Tmp, 600*time.Millisecond, cfg.blockCollector, cfg.blockReader, cfg.blobStore, logger, cfg.forkChoice, cfg.blobDownloader), context.Background(), logger); err != nil {
+					if err := SpawnStageHistoryDownload(StageHistoryReconstruction(downloader, cfg.antiquary, cfg.sn, cfg.indiciesDB, cfg.executionClient, cfg.beaconCfg, cfg.caplinConfig, false, startingRoot, startingSlot, cfg.dirs.Tmp, 5*time.Millisecond, cfg.blockCollector, cfg.blockReader, cfg.blobStore, logger, cfg.forkChoice, cfg.blobDownloader), context.Background(), logger); err != nil {
 						cfg.hasDownloaded = false
 						return err
 					}

--- a/execution/commitment/commitment.go
+++ b/execution/commitment/commitment.go
@@ -225,16 +225,11 @@ func (be *BranchEncoder) CollectUpdate(
 		return 0, err
 	}
 
-	if len(prev) > 0 {
-		if bytes.Equal(prev, update) {
-			//fmt.Printf("skip collectBranchUpdate [%x]\n", prefix)
-			return lastNibble, nil // do not write the same data for prefix
-		}
-		update, err = be.merger.Merge(prev, update)
-		if err != nil {
-			return 0, err
-		}
+	if len(prev) > 0 && bytes.Equal(prev, update) {
+		//fmt.Printf("skip collectBranchUpdate [%x]\n", prefix)
+		return lastNibble, nil // do not write the same data for prefix
 	}
+	// No merge needed - updates are complete (contain all existing cells)
 	// fmt.Printf("\ncollectBranchUpdate [%x] -> %s\n", prefix, BranchData(update).String())
 	// has to copy :(
 	if err = ctx.PutBranch(common.Copy(prefix), common.Copy(update), prev, prevStep); err != nil {

--- a/execution/commitment/commitment.go
+++ b/execution/commitment/commitment.go
@@ -212,7 +212,7 @@ func (be *BranchEncoder) setMetrics(metrics *Metrics) {
 func (be *BranchEncoder) CollectUpdate(
 	ctx PatriciaContext,
 	prefix []byte,
-	bitmap, touchMap, afterMap uint16,
+	afterMap uint16,
 	readCell func(nibble int, skip bool) (*cell, error),
 ) (lastNibble int, err error) {
 
@@ -220,7 +220,7 @@ func (be *BranchEncoder) CollectUpdate(
 	if err != nil {
 		return 0, err
 	}
-	update, lastNibble, err := be.EncodeBranch(bitmap, touchMap, afterMap, readCell)
+	update, lastNibble, err := be.EncodeBranch(afterMap, readCell)
 	if err != nil {
 		return 0, err
 	}
@@ -259,12 +259,12 @@ func (be *BranchEncoder) putUvarAndVal(size uint64, val []byte) error {
 }
 
 // Encoded result should be copied before next call to EncodeBranch, underlying slice is reused
-func (be *BranchEncoder) EncodeBranch(bitmap, touchMap, afterMap uint16, readCell func(nibble int, skip bool) (*cell, error)) (BranchData, int, error) {
+func (be *BranchEncoder) EncodeBranch(afterMap uint16, readCell func(nibble int, skip bool) (*cell, error)) (BranchData, int, error) {
 	be.buf.Reset()
 
-	var encoded [4]byte
-	binary.BigEndian.PutUint16(encoded[:], touchMap)
-	binary.BigEndian.PutUint16(encoded[2:], afterMap)
+	// Write header: cells that exist after this update
+	var encoded [2]byte
+	binary.BigEndian.PutUint16(encoded[:], afterMap)
 	if _, err := be.buf.Write(encoded[:]); err != nil {
 		return nil, 0, err
 	}
@@ -285,50 +285,48 @@ func (be *BranchEncoder) EncodeBranch(bitmap, touchMap, afterMap uint16, readCel
 			return nil, 0, err
 		}
 
-		if bitmap&bit != 0 {
-			var fields cellFields
-			if cell.extLen > 0 && cell.storageAddrLen == 0 {
-				fields |= fieldExtension
-			}
-			if cell.accountAddrLen > 0 {
-				fields |= fieldAccountAddr
-			}
-			if cell.storageAddrLen > 0 {
-				fields |= fieldStorageAddr
-			}
-			if cell.hashLen > 0 {
-				fields |= fieldHash
-			}
-			if cell.stateHashLen == 32 && (cell.accountAddrLen > 0 || cell.storageAddrLen > 0) {
-				fields |= fieldStateHash
-			}
-			if err := be.buf.WriteByte(byte(fields)); err != nil {
+		var fields cellFields
+		if cell.extLen > 0 && cell.storageAddrLen == 0 {
+			fields |= fieldExtension
+		}
+		if cell.accountAddrLen > 0 {
+			fields |= fieldAccountAddr
+		}
+		if cell.storageAddrLen > 0 {
+			fields |= fieldStorageAddr
+		}
+		if cell.hashLen > 0 {
+			fields |= fieldHash
+		}
+		if cell.stateHashLen == 32 && (cell.accountAddrLen > 0 || cell.storageAddrLen > 0) {
+			fields |= fieldStateHash
+		}
+		if err := be.buf.WriteByte(byte(fields)); err != nil {
+			return nil, 0, err
+		}
+		if fields&fieldExtension != 0 {
+			if err := be.putUvarAndVal(uint64(cell.extLen), cell.extension[:cell.extLen]); err != nil {
 				return nil, 0, err
 			}
-			if fields&fieldExtension != 0 {
-				if err := be.putUvarAndVal(uint64(cell.extLen), cell.extension[:cell.extLen]); err != nil {
-					return nil, 0, err
-				}
+		}
+		if fields&fieldAccountAddr != 0 {
+			if err := be.putUvarAndVal(uint64(cell.accountAddrLen), cell.accountAddr[:cell.accountAddrLen]); err != nil {
+				return nil, 0, err
 			}
-			if fields&fieldAccountAddr != 0 {
-				if err := be.putUvarAndVal(uint64(cell.accountAddrLen), cell.accountAddr[:cell.accountAddrLen]); err != nil {
-					return nil, 0, err
-				}
+		}
+		if fields&fieldStorageAddr != 0 {
+			if err := be.putUvarAndVal(uint64(cell.storageAddrLen), cell.storageAddr[:cell.storageAddrLen]); err != nil {
+				return nil, 0, err
 			}
-			if fields&fieldStorageAddr != 0 {
-				if err := be.putUvarAndVal(uint64(cell.storageAddrLen), cell.storageAddr[:cell.storageAddrLen]); err != nil {
-					return nil, 0, err
-				}
+		}
+		if fields&fieldHash != 0 {
+			if err := be.putUvarAndVal(uint64(cell.hashLen), cell.hash[:cell.hashLen]); err != nil {
+				return nil, 0, err
 			}
-			if fields&fieldHash != 0 {
-				if err := be.putUvarAndVal(uint64(cell.hashLen), cell.hash[:cell.hashLen]); err != nil {
-					return nil, 0, err
-				}
-			}
-			if fields&fieldStateHash != 0 {
-				if err := be.putUvarAndVal(uint64(cell.stateHashLen), cell.stateHash[:cell.stateHashLen]); err != nil {
-					return nil, 0, err
-				}
+		}
+		if fields&fieldStateHash != 0 {
+			if err := be.putUvarAndVal(uint64(cell.stateHashLen), cell.stateHash[:cell.stateHashLen]); err != nil {
+				return nil, 0, err
 			}
 		}
 		bitset ^= bit
@@ -342,51 +340,46 @@ func RetrieveCellNoop(nibble int, skip bool) (*cell, error) { return nil, nil }
 type BranchData []byte
 
 func (branchData BranchData) String() string {
-	if len(branchData) == 0 {
+	if len(branchData) < 2 {
 		return ""
 	}
-	touchMap := binary.BigEndian.Uint16(branchData[0:])
-	afterMap := binary.BigEndian.Uint16(branchData[2:])
-	pos := 4
+	afterMap := binary.BigEndian.Uint16(branchData[0:])
+	pos := 2
 	var sb strings.Builder
 	var cell cell
-	fmt.Fprintf(&sb, "touchMap %016b, afterMap %016b\n", touchMap, afterMap)
-	for bitset, j := touchMap, 0; bitset != 0; j++ {
+	fmt.Fprintf(&sb, "afterMap %016b\n", afterMap)
+	for bitset, j := afterMap, 0; bitset != 0; j++ {
 		bit := bitset & -bitset
 		nibble := bits.TrailingZeros16(bit)
 		fmt.Fprintf(&sb, "   %x => ", nibble)
-		if afterMap&bit == 0 {
-			sb.WriteString("{DELETED}\n")
-		} else {
-			fields := cellFields(branchData[pos])
-			pos++
-			var err error
-			if pos, err = cell.fillFromFields(branchData, pos, fields); err != nil {
-				// This is used for test output, so ok to panic
-				panic(err)
-			}
-			sb.WriteString("{")
-			var comma string
-			if cell.hashedExtLen > 0 {
-				fmt.Fprintf(&sb, "hashedExtension=[%x]", cell.hashedExtension[:cell.hashedExtLen])
-				comma = ","
-			}
-			if cell.accountAddrLen > 0 {
-				fmt.Fprintf(&sb, "%saccountAddr=[%x]", comma, cell.accountAddr[:cell.accountAddrLen])
-				comma = ","
-			}
-			if cell.storageAddrLen > 0 {
-				fmt.Fprintf(&sb, "%sstorageAddr=[%x]", comma, cell.storageAddr[:cell.storageAddrLen])
-				comma = ","
-			}
-			if cell.hashLen > 0 {
-				fmt.Fprintf(&sb, "%shash=[%x]", comma, cell.hash[:cell.hashLen])
-			}
-			if cell.stateHashLen > 0 {
-				fmt.Fprintf(&sb, "%sleafHash=[%x]", comma, cell.stateHash[:cell.stateHashLen])
-			}
-			sb.WriteString("}\n")
+		fields := cellFields(branchData[pos])
+		pos++
+		var err error
+		if pos, err = cell.fillFromFields(branchData, pos, fields); err != nil {
+			// This is used for test output, so ok to panic
+			panic(err)
 		}
+		sb.WriteString("{")
+		var comma string
+		if cell.hashedExtLen > 0 {
+			fmt.Fprintf(&sb, "hashedExtension=[%x]", cell.hashedExtension[:cell.hashedExtLen])
+			comma = ","
+		}
+		if cell.accountAddrLen > 0 {
+			fmt.Fprintf(&sb, "%saccountAddr=[%x]", comma, cell.accountAddr[:cell.accountAddrLen])
+			comma = ","
+		}
+		if cell.storageAddrLen > 0 {
+			fmt.Fprintf(&sb, "%sstorageAddr=[%x]", comma, cell.storageAddr[:cell.storageAddrLen])
+			comma = ","
+		}
+		if cell.hashLen > 0 {
+			fmt.Fprintf(&sb, "%shash=[%x]", comma, cell.hash[:cell.hashLen])
+		}
+		if cell.stateHashLen > 0 {
+			fmt.Fprintf(&sb, "%sleafHash=[%x]", comma, cell.stateHash[:cell.stateHashLen])
+		}
+		sb.WriteString("}\n")
 		bitset ^= bit
 	}
 	return sb.String()
@@ -394,19 +387,18 @@ func (branchData BranchData) String() string {
 
 // if fn returns nil, the original key will be copied from branchData
 func (branchData BranchData) ReplacePlainKeys(newData []byte, fn func(key []byte, isStorage bool) (newKey []byte, err error)) (BranchData, error) {
-	if len(branchData) < 4 {
+	if len(branchData) < 2 {
 		return branchData, nil
 	}
 
 	var numBuf [binary.MaxVarintLen64]byte
-	touchMap := binary.BigEndian.Uint16(branchData[0:])
-	afterMap := binary.BigEndian.Uint16(branchData[2:])
-	if touchMap&afterMap == 0 {
+	afterMap := binary.BigEndian.Uint16(branchData[0:])
+	if afterMap == 0 {
 		return branchData, nil
 	}
-	pos := 4
-	newData = append(newData[:0], branchData[:4]...)
-	for bitset, j := touchMap&afterMap, 0; bitset != 0; j++ {
+	pos := 2
+	newData = append(newData[:0], branchData[:2]...)
+	for bitset, j := afterMap, 0; bitset != 0; j++ {
 		bit := bitset & -bitset
 		fields := cellFields(branchData[pos])
 		newData = append(newData, byte(fields))
@@ -536,13 +528,9 @@ func (branchData BranchData) ReplacePlainKeys(newData []byte, fn func(key []byte
 }
 
 // IsComplete determines whether given branch data is complete, meaning that all information about all the children is present
-// Each of 16 children of a branch node have two attributes
-// touch - whether this child has been modified or deleted in this branchData (corresponding bit in touchMap is set)
-// after - whether after this branchData application, the child is present in the tree or not (corresponding bit in afterMap is set)
+// Without touchMap, branch data is always considered complete since it contains all children in afterMap
 func (branchData BranchData) IsComplete() bool {
-	touchMap := binary.BigEndian.Uint16(branchData[0:])
-	afterMap := binary.BigEndian.Uint16(branchData[2:])
-	return ^touchMap&afterMap == 0
+	return true
 }
 
 // MergeHexBranches combines two branchData, number 2 coming after (and potentially shadowing) number 1
@@ -554,22 +542,17 @@ func (branchData BranchData) MergeHexBranches(branchData2 BranchData, newData []
 		return branchData2, nil
 	}
 
-	touchMap1 := binary.BigEndian.Uint16(branchData[0:])
-	afterMap1 := binary.BigEndian.Uint16(branchData[2:])
-	bitmap1 := touchMap1 & afterMap1
-	pos1 := 4
-	touchMap2 := binary.BigEndian.Uint16(branchData2[0:])
-	afterMap2 := binary.BigEndian.Uint16(branchData2[2:])
-	bitmap2 := touchMap2 & afterMap2
-	pos2 := 4
-	var bitmapBuf [4]byte
-	binary.BigEndian.PutUint16(bitmapBuf[0:], touchMap1|touchMap2)
-	binary.BigEndian.PutUint16(bitmapBuf[2:], afterMap2)
+	afterMap1 := binary.BigEndian.Uint16(branchData[0:])
+	pos1 := 2
+	afterMap2 := binary.BigEndian.Uint16(branchData2[0:])
+	pos2 := 2
+	var bitmapBuf [2]byte
+	binary.BigEndian.PutUint16(bitmapBuf[0:], afterMap1|afterMap2)
 	newData = append(newData[:0], bitmapBuf[:]...)
-	for bitset, j := bitmap1|bitmap2, 0; bitset != 0; j++ {
+	for bitset, j := afterMap1|afterMap2, 0; bitset != 0; j++ {
 		bit := bitset & -bitset
-		if bitmap2&bit != 0 {
-			// Add fields from branchData2
+		if afterMap2&bit != 0 {
+			// Add fields from branchData2 (newer, takes precedence)
 			fields := cellFields(branchData2[pos2])
 			newData = append(newData, byte(fields))
 			pos2++
@@ -591,8 +574,8 @@ func (branchData BranchData) MergeHexBranches(branchData2 BranchData, newData []
 				}
 			}
 		}
-		if bitmap1&bit != 0 {
-			add := (touchMap2&bit == 0) && (afterMap2&bit != 0) // Add fields from branchData1
+		if afterMap1&bit != 0 {
+			add := afterMap2&bit == 0 // Add fields from branchData1 only if not in branchData2
 			fields := cellFields(branchData[pos1])
 			if add {
 				newData = append(newData, byte(fields))
@@ -625,21 +608,18 @@ func (branchData BranchData) MergeHexBranches(branchData2 BranchData, newData []
 	return newData, nil
 }
 
-func (branchData BranchData) decodeCells() (touchMap, afterMap uint16, row [16]*cell, err error) {
-	touchMap = binary.BigEndian.Uint16(branchData[0:])
-	afterMap = binary.BigEndian.Uint16(branchData[2:])
-	pos := 4
-	for bitset, j := touchMap, 0; bitset != 0; j++ {
+func (branchData BranchData) decodeCells() (afterMap uint16, row [16]*cell, err error) {
+	afterMap = binary.BigEndian.Uint16(branchData[0:])
+	pos := 2
+	for bitset, j := afterMap, 0; bitset != 0; j++ {
 		bit := bitset & -bitset
 		nibble := bits.TrailingZeros16(bit)
-		if afterMap&bit != 0 {
-			fields := cellFields(branchData[pos])
-			pos++
-			row[nibble] = new(cell)
-			if pos, err = row[nibble].fillFromFields(branchData, pos, fields); err != nil {
-				err = fmt.Errorf("failed to fill cell at nibble %x: %w", nibble, err)
-				return
-			}
+		fields := cellFields(branchData[pos])
+		pos++
+		row[nibble] = new(cell)
+		if pos, err = row[nibble].fillFromFields(branchData, pos, fields); err != nil {
+			err = fmt.Errorf("failed to fill cell at nibble %x: %w", nibble, err)
+			return
 		}
 		bitset ^= bit
 	}
@@ -650,7 +630,7 @@ func (branchData BranchData) Validate(branchKey []byte) error {
 	if len(branchData) == 0 {
 		return nil
 	}
-	_, afterMap, row, err := branchData.decodeCells()
+	afterMap, row, err := branchData.decodeCells()
 	if err != nil {
 		return err
 	}
@@ -734,7 +714,7 @@ func validatePlainKeys(branchKey []byte, row [16]*cell, keccak keccakState) erro
 
 type BranchMerger struct {
 	buf []byte
-	num [4]byte
+	num [2]byte
 }
 
 func NewHexBranchMerger(capacity uint64) *BranchMerger {
@@ -750,26 +730,20 @@ func (m *BranchMerger) Merge(branch1 BranchData, branch2 BranchData) (BranchData
 		return branch2, nil
 	}
 
-	touchMap1 := binary.BigEndian.Uint16(branch1[0:])
-	afterMap1 := binary.BigEndian.Uint16(branch1[2:])
-	bitmap1 := touchMap1 & afterMap1
-	pos1 := 4
+	afterMap1 := binary.BigEndian.Uint16(branch1[0:])
+	pos1 := 2
 
-	touchMap2 := binary.BigEndian.Uint16(branch2[0:])
-	afterMap2 := binary.BigEndian.Uint16(branch2[2:])
-	bitmap2 := touchMap2 & afterMap2
-	pos2 := 4
+	afterMap2 := binary.BigEndian.Uint16(branch2[0:])
+	pos2 := 2
 
-	binary.BigEndian.PutUint16(m.num[0:], touchMap1|touchMap2)
-	binary.BigEndian.PutUint16(m.num[2:], afterMap2)
-	dataPos := 4
+	binary.BigEndian.PutUint16(m.num[0:], afterMap1|afterMap2)
 
 	m.buf = append(m.buf[:0], m.num[:]...)
 
-	for bitset, j := bitmap1|bitmap2, 0; bitset != 0; j++ {
+	for bitset, j := afterMap1|afterMap2, 0; bitset != 0; j++ {
 		bit := bitset & -bitset
-		if bitmap2&bit != 0 {
-			// Add fields from branch2
+		if afterMap2&bit != 0 {
+			// Add fields from branch2 (newer, takes precedence)
 			fields := cellFields(branch2[pos2])
 			m.buf = append(m.buf, byte(fields))
 			pos2++
@@ -784,19 +758,17 @@ func (m *BranchMerger) Merge(branch1 BranchData, branch2 BranchData) (BranchData
 
 				m.buf = append(m.buf, branch2[pos2:pos2+n]...)
 				pos2 += n
-				dataPos += n
 				if len(branch2) < pos2+int(l) {
 					return nil, fmt.Errorf("MergeHexBranches branch2 is too small: expected at least %d got %d bytes", pos2+int(l), len(branch2))
 				}
 				if l > 0 {
 					m.buf = append(m.buf, branch2[pos2:pos2+int(l)]...)
 					pos2 += int(l)
-					dataPos += int(l)
 				}
 			}
 		}
-		if bitmap1&bit != 0 {
-			add := (touchMap2&bit == 0) && (afterMap2&bit != 0) // Add fields from branchData1
+		if afterMap1&bit != 0 {
+			add := afterMap2&bit == 0 // Add fields from branch1 only if not in branch2
 			fields := cellFields(branch1[pos1])
 			if add {
 				m.buf = append(m.buf, byte(fields))
@@ -927,12 +899,12 @@ func DecodeBranchAndCollectStat(key, branch []byte, tv TrieVariant) *BranchStat 
 	if !bytes.Equal(key, []byte("state")) {
 		stat.IsRoot = false
 
-		tm, am, cells, err := BranchData(branch).decodeCells()
+		am, cells, err := BranchData(branch).decodeCells()
 		if err != nil {
 			return nil
 		}
-		stat.TAMapsSize = uint64(2 + 2) // touchMap + afterMap
-		stat.CellCount = uint64(bits.OnesCount16(tm & am))
+		stat.TAMapsSize = uint64(2) // afterMap only
+		stat.CellCount = uint64(bits.OnesCount16(am))
 
 		medians := make(map[string][]int16)
 		for _, c := range cells {

--- a/execution/commitment/commitment_bench_test.go
+++ b/execution/commitment/commitment_bench_test.go
@@ -29,19 +29,18 @@ func BenchmarkBranchMerger_Merge(b *testing.B) {
 	row, bm := generateCellRow(b, 16)
 
 	be := NewBranchEncoder(1024)
-	enc, _, err := be.EncodeBranch(bm, bm, bm, func(i int, skip bool) (*cell, error) {
+	enc, _, err := be.EncodeBranch(bm, func(i int, skip bool) (*cell, error) {
 		return row[i], nil
 	})
 	require.NoError(b, err)
 
 	var copies [16][]byte
-	var tm uint16
 	am := bm
 
 	for i := 15; i >= 0; i-- {
 		row[i] = nil
-		tm, bm, am = uint16(1<<i), bm>>1, am>>1
-		enc1, _, err := be.EncodeBranch(bm, tm, am, func(i int, skip bool) (*cell, error) {
+		am = am >> 1
+		enc1, _, err := be.EncodeBranch(am, func(i int, skip bool) (*cell, error) {
 			return row[i], nil
 		})
 		require.NoError(b, err)
@@ -66,7 +65,7 @@ func BenchmarkBranchMerger_Merge(b *testing.B) {
 func BenchmarkBranchData_ReplacePlainKeys(b *testing.B) {
 	row, bm := generateCellRow(b, 16)
 
-	cells, am := unfoldBranchDataFromString(b, "86e586e5082035e72a782b51d9c98548467e3f868294d923cdbbdf4ce326c867bd972c4a2395090109203b51781a76dc87640aea038e3fdd8adca94049aaa436735b162881ec159f6fb408201aa2fa41b5fb019e8abf8fc32800805a2743cfa15373cf64ba16f4f70e683d8e0404a192d9050404f993d9050404e594d90508208642542ff3ce7d63b9703e85eb924ab3071aa39c25b1651c6dda4216387478f10404bd96d905")
+	cells, am := unfoldBranchDataFromString(b, "86e5082035e72a782b51d9c98548467e3f868294d923cdbbdf4ce326c867bd972c4a2395090109203b51781a76dc87640aea038e3fdd8adca94049aaa436735b162881ec159f6fb408201aa2fa41b5fb019e8abf8fc32800805a2743cfa15373cf64ba16f4f70e683d8e0404a192d9050404f993d9050404e594d90508208642542ff3ce7d63b9703e85eb924ab3071aa39c25b1651c6dda4216387478f10404bd96d905")
 	for i, c := range cells {
 		if c == nil {
 			continue
@@ -89,7 +88,7 @@ func BenchmarkBranchData_ReplacePlainKeys(b *testing.B) {
 	}
 
 	be := NewBranchEncoder(1024)
-	enc, _, err := be.EncodeBranch(bm, bm, bm, cg)
+	enc, _, err := be.EncodeBranch(bm, cg)
 	require.NoError(b, err)
 
 	original := common.Copy(enc)

--- a/execution/commitment/commitment_test.go
+++ b/execution/commitment/commitment_test.go
@@ -69,7 +69,7 @@ func TestBranchData_MergeHexBranches2(t *testing.T) {
 	row, bm := generateCellRow(t, 16)
 
 	be := NewBranchEncoder(1024)
-	enc, _, err := be.EncodeBranch(bm, bm, bm, func(i int, skip bool) (*cell, error) {
+	enc, _, err := be.EncodeBranch(bm, func(i int, skip bool) (*cell, error) {
 		return row[i], nil
 	})
 
@@ -82,9 +82,9 @@ func TestBranchData_MergeHexBranches2(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, enc, res)
 
-	tm, am, origins, err := res.decodeCells()
+	am, origins, err := res.decodeCells()
 	require.NoError(t, err)
-	require.Equal(t, tm, am)
+	_ = am
 	require.Equal(t, bm, am)
 
 	i := 0
@@ -153,7 +153,7 @@ func TestDecodeBranchWithLeafHashes(t *testing.T) {
 	}
 
 	be := NewBranchEncoder(1024)
-	enc, _, err := be.EncodeBranch(bm, bm, bm, func(i int, skip bool) (*cell, error) {
+	enc, _, err := be.EncodeBranch(bm, func(i int, skip bool) (*cell, error) {
 		return row[i], nil
 	})
 	require.NoError(t, err)
@@ -171,9 +171,9 @@ func unfoldBranchDataFromString(tb testing.TB, encs string) (row []*cell, am uin
 	enc, err := hex.DecodeString(encs)
 	require.NoError(tb, err)
 
-	tm, am, origins, err := BranchData(enc).decodeCells()
+	am, origins, err := BranchData(enc).decodeCells()
 	require.NoError(tb, err)
-	_, _ = tm, am
+	_ = am
 
 	tb.Logf("%s", BranchData(enc).String())
 	//require.EqualValues(tb, tm, am)
@@ -191,7 +191,7 @@ func TestBranchData_ReplacePlainKeys(t *testing.T) {
 
 	row, bm := generateCellRow(t, 16)
 
-	cells, am := unfoldBranchDataFromString(t, "86e586e5082035e72a782b51d9c98548467e3f868294d923cdbbdf4ce326c867bd972c4a2395090109203b51781a76dc87640aea038e3fdd8adca94049aaa436735b162881ec159f6fb408201aa2fa41b5fb019e8abf8fc32800805a2743cfa15373cf64ba16f4f70e683d8e0404a192d9050404f993d9050404e594d90508208642542ff3ce7d63b9703e85eb924ab3071aa39c25b1651c6dda4216387478f10404bd96d905")
+	cells, am := unfoldBranchDataFromString(t, "86e5082035e72a782b51d9c98548467e3f868294d923cdbbdf4ce326c867bd972c4a2395090109203b51781a76dc87640aea038e3fdd8adca94049aaa436735b162881ec159f6fb408201aa2fa41b5fb019e8abf8fc32800805a2743cfa15373cf64ba16f4f70e683d8e0404a192d9050404f993d9050404e594d90508208642542ff3ce7d63b9703e85eb924ab3071aa39c25b1651c6dda4216387478f10404bd96d905")
 	for i, c := range cells {
 		if c == nil {
 			continue
@@ -214,7 +214,7 @@ func TestBranchData_ReplacePlainKeys(t *testing.T) {
 	}
 
 	be := NewBranchEncoder(1024)
-	enc, _, err := be.EncodeBranch(bm, bm, bm, cg)
+	enc, _, err := be.EncodeBranch(bm, cg)
 	require.NoError(t, err)
 
 	original := common.Copy(enc)
@@ -263,7 +263,7 @@ func TestBranchData_ReplacePlainKeys_WithEmpty(t *testing.T) {
 	}
 
 	be := NewBranchEncoder(1024)
-	enc, _, err := be.EncodeBranch(bm, bm, bm, cg)
+	enc, _, err := be.EncodeBranch(bm, cg)
 	require.NoError(t, err)
 
 	original := common.Copy(enc)

--- a/execution/commitment/hex_patricia_hashed_test.go
+++ b/execution/commitment/hex_patricia_hashed_test.go
@@ -888,9 +888,6 @@ func Test_HexPatriciaHashed_StateEncode(t *testing.T) {
 	for i := 0; i < len(s.Depths); i++ {
 		s.Depths[i] = int16(rnd.Intn(256))
 	}
-	for i := 0; i < len(s.TouchMap); i++ {
-		s.TouchMap[i] = uint16(rnd.Intn(1<<16 - 1))
-	}
 	for i := 0; i < len(s.AfterMap); i++ {
 		s.AfterMap[i] = uint16(rnd.Intn(1<<16 - 1))
 	}
@@ -911,7 +908,6 @@ func Test_HexPatriciaHashed_StateEncode(t *testing.T) {
 	require.Equal(t, s.Root[:], s1.Root[:])
 	require.Equal(t, s.Depths[:], s1.Depths[:])
 	require.Equal(t, s.AfterMap[:], s1.AfterMap[:])
-	require.Equal(t, s.TouchMap[:], s1.TouchMap[:])
 	require.Equal(t, s.BranchBefore[:], s1.BranchBefore[:])
 	require.Equal(t, s.RootTouched, s1.RootTouched)
 	require.Equal(t, s.RootPresent, s1.RootPresent)

--- a/execution/commitment/hex_patricia_hashed_test.go
+++ b/execution/commitment/hex_patricia_hashed_test.go
@@ -1677,16 +1677,15 @@ func TestCell_fillFromFields(t *testing.T) {
 	}
 
 	be := NewBranchEncoder(1024)
-	enc, _, err := be.EncodeBranch(bm, bm, bm, cg)
+	enc, _, err := be.EncodeBranch(bm, cg)
 	require.NoError(t, err)
 
 	//original := common.Copy(enc)
 	fmt.Printf("%s\n", enc.String())
 
-	tm, am, decRow, err := enc.decodeCells()
+	am, decRow, err := enc.decodeCells()
 	require.NoError(t, err)
 	require.Equal(t, bm, am)
-	require.Equal(t, bm, tm)
 
 	for i := 0; i < len(decRow); i++ {
 		t.Logf("cell %d\n", i)


### PR DESCRIPTION
https://github.com/erigontech/erigon/issues/18667

This PR removes the touchmap field from the branchdata serialization format. This simplifies the code and saves 2 bytes per branch serialization.

Using this git branch I was able to successfully sync hoodi from scratch (using `--no-downloader`, and with commitment history enabled) which produced state snapshots with a new version of commitment snapshots (where touchmap is not serialized).

### Space savings (as of recent block 2043962 )

|                            | With touchmap (before) | Without touchmap (after) | Space reduction |
|----------------------------|------------------------|---------------------------|-----------------|
| Commitment domain size     | 24.24 GiB              | 23.85 GiB                 | 1.6%            |
| Commitment history size    | 110.82 GiB             | 110.02 GiB                | 0.72%           |

The space savings for domain and history snapshots are modest, but given that the code gets simplified, it might be worth considering for a future version of snapshots (potentially with other schema changes).

