### PR TITLE
execution/types: avoid prefix escape to heap

### DIFF
--- a/execution/types/create_address.go
+++ b/execution/types/create_address.go
@@ -38,10 +38,12 @@ func CreateAddress(a common.Address, nonce uint64) common.Address {
 	return common.BytesToAddress(crypto.Keccak256(data)[12:])
 }
 
+var createAddress2Prefix = []byte{0xff}
+
 // CreateAddress2 creates an ethereum address given the address bytes, initial
 // contract code hash and a salt.
 // DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func CreateAddress2(b common.Address, salt [32]byte, inithash accounts.CodeHash) common.Address {
 	initHashValue := inithash.Value()
-	return common.BytesToAddress(crypto.Keccak256([]byte{0xff}, b[:], salt[:], initHashValue[:])[12:])
+	return common.BytesToAddress(crypto.Keccak256(createAddress2Prefix, b[:], salt[:], initHashValue[:])[12:])
 }


### PR DESCRIPTION
Benchmark Test:
```
var (
	benchAddr = common.HexToAddress(
		"0x970e8128ab834e8eac17ab8e3812f010678cf791",
	)

	benchSalt = [32]byte{
		0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
		0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
		0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
		0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
	}

	benchInitHash = accounts.InternCodeHash(
		common.BytesToHash(
			crypto.Keccak256([]byte("test init code hash")),
		),
	)
)

func BenchmarkCreateAddress2(b *testing.B) {
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		_ = CreateAddress2(benchAddr, benchSalt, benchInitHash)
	}
}

// BenchmarkCreateAddress2_ZeroSalt benchmarks CreateAddress2 with zero salt
func BenchmarkCreateAddress2_ZeroSalt(b *testing.B) {
	var zeroSalt [32]byte

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		_ = CreateAddress2(benchAddr, zeroSalt, benchInitHash)
	}
}

// BenchmarkCreateAddress2_RandomSalt benchmarks CreateAddress2 with random salt
func BenchmarkCreateAddress2_RandomSalt(b *testing.B) {
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		var salt [32]byte
		_, _ = rand.Read(salt[:])
		_ = CreateAddress2(benchAddr, salt, benchInitHash)
	}
}

// BenchmarkCreateAddress2_RandomInputs benchmarks CreateAddress2
// with fully random inputs (address, salt, codehash)
func BenchmarkCreateAddress2_RandomInputs(b *testing.B) {
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		var addr common.Address
		var salt [32]byte
		var h common.Hash

		_, _ = rand.Read(addr[:])
		_, _ = rand.Read(salt[:])
		_, _ = rand.Read(h[:])

		codeHash := accounts.InternCodeHash(h)
		_ = CreateAddress2(addr, salt, codeHash)
	}
}
```

Result:
```goos: linux
goarch: amd64
pkg: github.com/erigontech/erigon/execution/types
cpu: Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz
                              │ old_bench.txt │            new_bench.txt            │
                              │    sec/op     │    sec/op     vs base               │
CreateAddress2-8                  612.7n ± 4%   585.5n ±  3%  -4.44% (p=0.000 n=10)
CreateAddress2_ZeroSalt-8         627.5n ± 5%   596.7n ± 15%       ~ (p=0.052 n=10)
CreateAddress2_RandomSalt-8       708.9n ± 2%   675.8n ±  6%  -4.68% (p=0.004 n=10)
CreateAddress2_RandomInputs-8     1.788µ ± 5%   1.721µ ±  9%       ~ (p=0.123 n=10)
geomean                           835.5n        798.4n        -4.44%

                              │ old_bench.txt │           new_bench.txt           │
                              │     B/op      │    B/op     vs base               │
CreateAddress2-8                   121.0 ± 0%   120.0 ± 0%  -0.83% (p=0.000 n=10)
CreateAddress2_ZeroSalt-8          121.0 ± 0%   120.0 ± 0%  -0.83% (p=0.000 n=10)
CreateAddress2_RandomSalt-8        121.0 ± 0%   120.0 ± 0%  -0.83% (p=0.000 n=10)
CreateAddress2_RandomInputs-8      281.0 ± 1%   272.5 ± 1%  -3.02% (p=0.000 n=10)
geomean                            149.4        147.3       -1.38%

                              │ old_bench.txt │           new_bench.txt            │
                              │   allocs/op   │ allocs/op   vs base                │
CreateAddress2-8                   5.000 ± 0%   4.000 ± 0%  -20.00% (p=0.000 n=10)
CreateAddress2_ZeroSalt-8          5.000 ± 0%   4.000 ± 0%  -20.00% (p=0.000 n=10)
CreateAddress2_RandomSalt-8        5.000 ± 0%   4.000 ± 0%  -20.00% (p=0.000 n=10)
CreateAddress2_RandomInputs-8      8.000 ± 0%   7.000 ± 0%  -12.50% (p=0.000 n=10)
geomean                            5.623        4.601       -18.19%
```