### PR TITLE
use less expensive signal for BuildMissedIndices

### DIFF
--- a/db/snapshotsync/snapshots.go
+++ b/db/snapshotsync/snapshots.go
@@ -1466,9 +1466,10 @@ func (s *RoSnapshots) buildMissedIndices(logPrefix string, ctx context.Context, 
 			for _, segment := range segs {
 				info := segment.FileInfo(dir)
 
-				if t.HasIndexFiles(info, logger) {
+				if segment.IsIndexed() {
 					continue
 				}
+
 				newIdxBuilt = true
 
 				segment.closeIdx()


### PR DESCRIPTION
- it's enough to check if seg has idx fields set or not.
- before: `HasIndexFiles` use - "idx file exists and it can be opened?" which is very expensive..
- this still loops through dirtyFiles - but that's a small number.