### PR TITLE
txnprovider: cleanup unused code and simplify select

### DIFF
--- a/txnprovider/shutter/decryption_keys_source.go
+++ b/txnprovider/shutter/decryption_keys_source.go
@@ -164,11 +164,9 @@ func (dks *PubSubDecryptionKeysSource) Subscribe(ctx context.Context) (Decryptio
 		return nil, err
 	}
 	go func() {
-		select {
-		case <-ctx.Done():
-			dks.logger.Debug("cancelling pubsub decryption keys subscription")
-			sub.Cancel()
-		}
+		<-ctx.Done()
+		dks.logger.Debug("cancelling pubsub decryption keys subscription")
+		sub.Cancel()
 	}()
 	return sub, nil
 }

--- a/txnprovider/txpool/senders.go
+++ b/txnprovider/txpool/senders.go
@@ -194,11 +194,6 @@ func (sc *sendersBatch) getID(addr common.Address) (uint64, bool) {
 	return id, ok
 }
 
-func (sc *sendersBatch) getAddr(id uint64) (common.Address, bool) {
-	addr, ok := sc.senderID2Addr[id]
-	return addr, ok
-}
-
 var traceAllSenders = false
 
 func (sc *sendersBatch) getOrCreateID(addr common.Address, logger log.Logger) (uint64, bool) {


### PR DESCRIPTION
Removed the unused getAddr method in sendersBatch, and simplified a redundant single-case select statement in decryption_keys_source.