### PR TITLE
Limit ethstats NodeInfo call with timeout

### DIFF
--- a/node/ethstats/ethstats.go
+++ b/node/ethstats/ethstats.go
@@ -385,7 +385,9 @@ func (s *Service) login(conn *connWrapper) error {
 	}
 	nodeName := "Erigon"
 	if len(s.servers) > 0 {
-		nodeInfo, err := s.servers[0].NodeInfo(context.TODO(), nil)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		nodeInfo, err := s.servers[0].NodeInfo(ctx, nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Replace context.TODO() in ethstats login with a bounded context.WithTimeout to avoid hanging NodeInfo requests and ensure timely cleanup
Keep existing behavior otherwise unchanged