### PR TITLE
refactor(rpc): remove redundant variable in deprecated db API initialization

### DIFF
--- a/rpc/jsonrpc/daemon.go
+++ b/rpc/jsonrpc/daemon.go
@@ -122,11 +122,10 @@ func APIList(db kv.TemporalRoDB, eth rpchelper.ApiBackend, txPool txpoolproto.Tx
 				Version:   "1.0",
 			})
 		case "db": /* Deprecated */
-			dbImpl := NewDBAPIImpl() /* deprecated */
 			list = append(list, rpc.API{
 				Namespace: "db",
 				Public:    true,
-				Service:   DBAPI(dbImpl),
+			Service:   DBAPI(NewDBAPIImpl()), /* deprecated */
 				Version:   "1.0",
 			})
 		case "erigon":


### PR DESCRIPTION
Removes an unnecessary intermediate variable dbImpl in the deprecated db API case handler within the JSON-RPC daemon.