### PR TITLE
execution/types: fix panic on invalid signature length

### DIFF
--- a/execution/types/transaction_signing_test.go
+++ b/execution/types/transaction_signing_test.go
@@ -165,3 +165,28 @@ func TestChainId(t *testing.T) {
 		t.Error("expected no error")
 	}
 }
+
+func TestSignatureValuesError(t *testing.T) {
+	// 1. Setup a valid transaction
+	tx := NewTransaction(0, common.Address{}, new(uint256.Int), 0, new(uint256.Int), nil)
+	signer := LatestSignerForChainID(big.NewInt(18))
+
+	// 2. Call WithSignature with invalid length sig (not 65 bytes)
+	invalidSig := make([]byte, 64)
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("Panicked for invalid signature length, expected error: %v", r)
+			}
+		}()
+		_, err := tx.WithSignature(*signer, invalidSig)
+		if err == nil {
+			t.Fatal("Expected error for invalid signature length, got nil")
+		} else {
+			// This is just a sanity check to ensure we got an error,
+			// the exact error message is verified in unit tests elsewhere if needed.
+			t.Logf("Got expected error: %v", err)
+		}
+	}()
+}


### PR DESCRIPTION
Make `decodeSignature` fail gracefully by returning an error on invalid input, and adjust callers to handle the error accordingly.