### PR TITLE
execution/execmodule: avoid BaseFeePerGas allocation in GetAssembledBlock

### DIFF
--- a/execution/execmodule/chainreader/chain_reader.go
+++ b/execution/execmodule/chainreader/chain_reader.go
@@ -438,6 +438,10 @@ func (c ChainReaderWriterEth1) GetAssembledBlock(id uint64) (*cltypes.Eth1Block,
 	extraData := solid.NewExtraData()
 	extraData.SetBytes(payloadRpc.ExtraData)
 	blockHash := gointerfaces.ConvertH256ToHash(payloadRpc.BlockHash)
+	baseFeePerGas := gointerfaces.ConvertH256ToHash(payloadRpc.BaseFeePerGas)
+	for i, j := 0, len(baseFeePerGas)-1; i < j; i, j = i+1, j-1 {
+		baseFeePerGas[i], baseFeePerGas[j] = baseFeePerGas[j], baseFeePerGas[i]
+	}
 	block := &cltypes.Eth1Block{
 		ParentHash:    gointerfaces.ConvertH256ToHash(payloadRpc.ParentHash),
 		FeeRecipient:  gointerfaces.ConvertH160toAddress(payloadRpc.Coinbase),
@@ -452,9 +456,8 @@ func (c ChainReaderWriterEth1) GetAssembledBlock(id uint64) (*cltypes.Eth1Block,
 		PrevRandao:    gointerfaces.ConvertH256ToHash(payloadRpc.PrevRandao),
 		Transactions:  solid.NewTransactionsSSZFromTransactions(payloadRpc.Transactions),
 		BlockHash:     blockHash,
-		BaseFeePerGas: gointerfaces.ConvertH256ToHash(payloadRpc.BaseFeePerGas),
+		BaseFeePerGas: baseFeePerGas,
 	}
-	copy(block.BaseFeePerGas[:], utils.ReverseOfByteSlice(block.BaseFeePerGas[:])) // reverse the byte slice
 	if payloadRpc.ExcessBlobGas != nil {
 		block.ExcessBlobGas = *payloadRpc.ExcessBlobGas
 	}


### PR DESCRIPTION
Previously GetAssembledBlock converted BaseFeePerGas by calling utils.ReverseOfByteSlice, which allocates a new 32-byte slice, and then copied it back into the destination [32]byte. This caused an unnecessary allocation and extra copy on a hot path (called for each assembled block).

This change replaces the allocate-and-copy reversal with an in-place byte swap on a local [32]byte, and assigns the result directly to Eth1Block.BaseFeePerGas, preserving the existing endianness semantics while removing the extra allocation and redundant work.