### PR TITLE
refactor: remove unreachable debug code in exec3

### DIFF
--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -352,10 +352,6 @@ func ExecV3(ctx context.Context,
 		lastCommittedTxNum = se.lastCommittedTxNum
 	}
 
-	if false && !isForkValidation {
-		dumpPlainStateDebug(applyTx, doms)
-	}
-
 	lastCommitedStep := kv.Step((lastCommittedTxNum) / doms.StepSize())
 	lastFrozenStep := applyTx.StepsInFiles(kv.CommitmentDomain)
 


### PR DESCRIPTION
Removed dead code block in `execution/stagedsync/exec3.go` that was guarded by `if false` condition and never executed.