### PR TITLE
Handle downloader request failure better

### DIFF
--- a/db/downloader/download-batch.go
+++ b/db/downloader/download-batch.go
@@ -64,7 +64,7 @@ func (me *downloadBatch) addAllItems(ctx context.Context, items []preverifiedSna
 		}
 		err := me.addDownload(it)
 		if err != nil {
-			err = fmt.Errorf("adding %q: %w", it.Name, err)
+			err = fmt.Errorf("downloading snapshot %s (infohash %s): %w", it.Name, it.InfoHash.HexString(), err)
 			return err
 		}
 	}

--- a/db/snapshotsync/snapshotsync.go
+++ b/db/snapshotsync/snapshotsync.go
@@ -38,6 +38,7 @@ import (
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/node/ethconfig"
 	"github.com/erigontech/erigon/node/gointerfaces/downloaderproto"
+	"github.com/erigontech/erigon/node/gointerfaces/grpcutil"
 )
 
 var GreatOtterBanner = `
@@ -497,9 +498,12 @@ func SyncSnapshots(
 				break
 			}
 			if ctx.Err() != nil {
-				return context.Cause(ctx)
+				return err
 			}
-			log.Error(fmt.Sprintf("[%s] call downloader", logPrefix), "err", err)
+			if !grpcutil.IsRetryLater(err) {
+				return err
+			}
+			log.Error(fmt.Sprintf("[%s] error requesting snapshots download from downloader", logPrefix), "err", err)
 			select {
 			case <-ctx.Done():
 				return context.Cause(ctx)


### PR DESCRIPTION
When snapshots are requested and there's an unretryable error, it would loop inside the sync stage, rather than propagate out.