### PR TITLE
Optimize the timer allocation in FairMix.Next

### DIFF
--- a/p2p/enode/iter.go
+++ b/p2p/enode/iter.go
@@ -207,42 +207,35 @@ func (m *FairMix) Close() {
 // Next returns a node from a random source.
 func (m *FairMix) Next() bool {
 	m.cur = nil
+	var timer *time.Timer
+	// Since Go 1.23, GC will clean up timers and this is likely faster than Stopping them ourselves.
 	for {
 		source := m.pickSource()
 		if source == nil {
 			return m.nextFromAny()
 		}
-		var (
-			timer   *time.Timer
-			timeout <-chan time.Time
-		)
+		var timeout <-chan time.Time
 		if source.timeout >= 0 {
-			timer = time.NewTimer(source.timeout)
+			if timer == nil {
+				timer = time.NewTimer(source.timeout)
+			} else {
+				// Since Go 1.23, this will guarantee not to let us receive an old value.
+				timer.Reset(source.timeout)
+			}
 			timeout = timer.C
 		}
 		select {
 		case n, ok := <-source.next:
 			if ok {
-				if timer != nil {
-					if !timer.Stop() {
-						<-timer.C
-					}
-				}
 				// Here, the timeout is reset to the configured value
 				// because the source delivered a node.
 				source.timeout = m.timeout
 				m.cur = n
 				return true
 			}
-			if timer != nil {
-				timer.Stop()
-			}
 			// This source has ended.
 			m.deleteSource(source)
 		case <-timeout:
-			if timer != nil {
-				timer.Stop()
-			}
 			// The selected source did not deliver a node within the timeout, so the
 			// timeout duration is halved for next time. This is supposed to improve
 			// latency with stuck sources.


### PR DESCRIPTION
#18732 correctly identifies timer cleanup defers stacking unnecessarily. This handles the cleanup and channel management per Go 1.23.