### PR TITLE
execution: parallel exec flow was missing BlockPostExecutionValidator.Wait()

### DIFF
--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -348,7 +348,8 @@ func (pe *parallelExecutor) exec(ctx context.Context, execStage *StageState, u U
 							}
 							resetCommitmentGauges(ctx)
 
-							// we run receipt root verification in parallel alongside commitment computation
+							// on chain tip we run receipt root verification in parallel alongside commitment computation
+							// make sure to wait for it to finish and check for an error
 							err = pe.getPostValidator().Wait()
 							if err != nil {
 								return err


### PR DESCRIPTION
https://github.com/erigontech/erigon/pull/18514 added receipt root verification parallel to commitment calculation (running the 2 at the same time) in the serial flow but accidentally missed adding the .Wait() in the parallel flow - this PR adds this in the right place for parallel exec