### PR TITLE
fix for some commitment.kv using more plainkeys than references

### DIFF
--- a/db/state/domain_committed.go
+++ b/db/state/domain_committed.go
@@ -329,7 +329,7 @@ func (dt *DomainRoTx) commitmentValTransformDomain(rng MergeRange, accounts, sto
 	dt.d.logger.Debug("prepare commitmentValTransformDomain", "merge", rng.String("range", dt.d.stepSize), "Mstorage", hadToLookupStorage, "Maccount", hadToLookupAccount)
 
 	vt := func(valBuf []byte, keyFromTxNum, keyEndTxNum uint64) (transValBuf []byte, err error) {
-		if !dt.d.ReplaceKeysInValues || len(valBuf) == 0 || !ValuesPlainKeyReferencingThresholdReached(dt.d.stepSize, keyFromTxNum, keyEndTxNum) {
+		if !dt.d.ReplaceKeysInValues || len(valBuf) == 0 || !ValuesPlainKeyReferencingThresholdReached(dt.d.stepSize, rng.from, rng.to) {
 			return valBuf, nil
 		}
 		if _, ok := storageFileMap[keyFromTxNum]; !ok {


### PR DESCRIPTION
issue: https://github.com/erigontech/erigon/issues/17772

existing scenario:
- 1step, 2step: no ref
- 4step: no ref (because 2,2 is being merged). But entire thing should work on ref, this pr fixes that.
- 8step: 4,2,1,1 - no ref in 2,1,1 step values
- 16step: 8,4,2,1,1 - no ref in 2,1,1 step values
- and so on..

so seems like the impact will be less on larger domain files. Which is consistent with the values I saw for 0-2048 file (it had high % of references vs plainkeys).

We don't need regen of commitment files for this, as they'll eventually use references when merged. 