### PR TITLE
Remove unused slots metadata read in consensus sanity test

### DIFF
--- a/cl/spectest/consensus_tests/sanity.go
+++ b/cl/spectest/consensus_tests/sanity.go
@@ -30,11 +30,6 @@ import (
 )
 
 var SanitySlots = spectest.HandlerFunc(func(t *testing.T, root fs.FS, c spectest.TestCase) (err error) {
-	// TODO: this is unused, why?
-	var slots int
-	err = spectest.ReadMeta(root, "slots.yaml", &slots)
-	require.NoError(t, err)
-
 	testState, err := spectest.ReadBeaconState(root, c.Version(), spectest.PreSsz)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Drop dead slots.yaml read from SanitySlots spectest handler
Avoid redundant I/O while keeping slot processing and hash assertions intact




