### PR TITLE
execution/stagedsync: remove canPrune from serial_exec

### DIFF
--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -200,14 +200,12 @@ func (se *serialExecutor) exec(ctx context.Context, execStage *StageState, u Unw
 			resetCommitmentGauges(ctx)
 			se.txExecutor.lastCommittedBlockNum = b.NumberU64()
 			se.txExecutor.lastCommittedTxNum = inputTxNum
-			timeStart := time.Now()
 			se.logger.Info(
 				"periodic commit check",
 				"block", se.doms.BlockNum(),
 				"txNum", se.doms.TxNum(),
 				"step", fmt.Sprintf("%.1f", float64(se.doms.TxNum())/float64(se.agg.StepSize())),
 				"commitment", times.ComputeCommitment,
-				"prune", time.Since(timeStart),
 			)
 			if isBatchFull {
 				return b.HeaderNoCopy(), rwTx, &ErrLoopExhausted{From: startBlockNum, To: blockNum, Reason: "block batch is full"}


### PR DESCRIPTION
closes https://github.com/erigontech/erigon/issues/17604 (in particular addresses the comment https://github.com/erigontech/erigon/issues/17604#issuecomment-3441872206)

this is no longer needed because now:
- we *always* hold all exec updates in memory in SharedDomains
- we break the sync loop (using `ErrLoopExhausted`) to allow for `SharedDomains.Flush` + `tx.Commit` + `stageLoop.RunSync` whenever:
    - `--sync.loop.block.limit=5000` is reached
    - `--batchSize=512MB` is reached 
