### PR TITLE
perf: reuse hash buffer in witness storage leaf hash

### DIFF
--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -911,7 +911,7 @@ func (hph *HexPatriciaHashed) witnessComputeCellHashWithStorage(cell *cell, dept
 				if hph.trace {
 					fmt.Printf("leafHashWithKeyVal(singleton) for [%x]=>[%x]\n", cell.hashedExtension[:64-hashedKeyOffset+1], cell.Storage[:cell.StorageLen])
 				}
-				aux := make([]byte, 0, 33)
+				aux := hph.hashAuxBuffer[:0]
 				if aux, err = hph.leafHashWithKeyVal(aux, cell.hashedExtension[:64-hashedKeyOffset+1], cell.Storage[:cell.StorageLen], true); err != nil {
 					return nil, storageRootHashIsSet, nil, err
 				}


### PR DESCRIPTION
<!-- в чем причина правок? тоесть понятным образом обьясняешь что не так было до наших правок -->
Previously witnessComputeCellHashWithStorage allocated a fresh []byte with make([]byte, 0, 33) for every singleton storage leaf when computing the leaf hash. This added a small but unnecessary allocation on a hot path during witness generation.

<!-- Четкое и лаконичное общее описание изменений, вносимых этим PR -->
This change reuses the existing hph.hashAuxBuffer slice as the target buffer for leafHashWithKeyVal in the singleton storage branch. The hash encoding semantics stay the same, but we avoid per-call allocations in the witness storage leaf hashing path.