### PR TITLE
fix: return correct prune mode value instead of nil

### DIFF
--- a/rpc/jsonrpc/eth_api.go
+++ b/rpc/jsonrpc/eth_api.go
@@ -376,7 +376,7 @@ func (api *BaseAPI) pruneMode(tx kv.Tx) (*prune.Mode, error) {
 
 	api._pruneMode.Store(&mode)
 
-	return p, nil
+	return &mode, nil
 }
 
 type bridgeReader interface {


### PR DESCRIPTION
The pruneMode() function was returning the original nil value `p` instead of the newly fetched `&mode` after storing it in the cache. This caused the function to always return nil on cache miss, breaking prune history checks.