### PR TITLE
fix(txpool): remove redundant Worst() calls in queued pool discard loop

### DIFF
--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -1990,7 +1990,7 @@ func (p *TxPool) promote(pendingBaseFee uint64, pendingBlobFee uint64, announcem
 	}
 
 	// Discard worst transactions from the queued sub pool until it is within its capacity limits
-	for _ = p.queued.Worst(); p.queued.Len() > p.queued.limit; _ = p.queued.Worst() {
+	for p.queued.Len() > p.queued.limit {
 		tx := p.queued.PopWorst()
 		p.discardLocked(tx, txpoolcfg.QueuedPoolOverflow)
 	}


### PR DESCRIPTION
The loop for discarding transactions from queued sub pool was calling Worst() twice per iteration with results discarded. This is dead code since Worst() has no side effects - it just returns the first element.

The two similar loops above (for pending and baseFee pools) don't have this issue, so this also makes the code consistent.