### PR TITLE
refactor(rpc): remove redundant boolean comparison in AccountRange

### DIFF
--- a/rpc/jsonrpc/debug_api.go
+++ b/rpc/jsonrpc/debug_api.go
@@ -152,7 +152,7 @@ func (api *DebugAPIImpl) AccountRange(ctx context.Context, blockNrOrHash rpc.Blo
 		incompletes = *optional_incompletes
 	}
 
-	if incompletes == true {
+	if incompletes {
 		return state.IteratorDump{}, fmt.Errorf("not supported incompletes = true")
 	}
 


### PR DESCRIPTION
Removes unnecessary == true comparison for boolean variable in debug_api.go