### PR TITLE
Show the default P2P discovery bools in --help

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -574,12 +574,14 @@ var (
 		Name:    "discovery.v4",
 		Aliases: []string{"discv4"},
 		Usage:   "Enables the V4 discovery mechanism",
+		Value:   nodecfg.DefaultConfig.P2P.DiscoveryV4,
 	}
 	DiscoveryV5Flag = cli.BoolFlag{
 		Name: "discovery.v5",
 		// The first is for old Geth style, and the second is Erigon backward compatibility.
 		Aliases: []string{"discv5", "v5disc"},
 		Usage:   "Enables the V5 discovery mechanism",
+		Value:   nodecfg.DefaultConfig.P2P.DiscoveryV5,
 	}
 	NetrestrictFlag = cli.StringFlag{
 		Name:  "netrestrict",


### PR DESCRIPTION
This should handle `--help` showing the wrong defaults, as they exist in the default nodecfg. If a user assigns these values on the CLI, it should clobber values used elsewhere via the "isset" methods. CI should catch this if not.