### PR TITLE
execution/vm: migrate benchmarks to b.Loop()

### DIFF
--- a/execution/vm/analysis_test.go
+++ b/execution/vm/analysis_test.go
@@ -93,16 +93,14 @@ func BenchmarkJumpDest(b *testing.B) {
 	hash := common.Hash{1, 2, 3, 4, 5}
 
 	//c := NewJumpDestCache(16)
+	contract := NewContract(accounts.ZeroAddress, accounts.ZeroAddress, accounts.ZeroAddress, uint256.Int{})
+	contract.Code = code
+	contract.CodeHash = accounts.InternCodeHash(hash)
 
+	b.ResetTimer()
 	for b.Loop() {
-		contract := NewContract(accounts.ZeroAddress, accounts.ZeroAddress, accounts.ZeroAddress, uint256.Int{})
-		contract.Code = code
-		contract.CodeHash = accounts.InternCodeHash(hash)
-
-		b.StartTimer()
 		for i := range contract.Code {
 			contract.validJumpdest(*pc.SetUint64(uint64(i)))
 		}
-		b.StopTimer()
 	}
 }

--- a/execution/vm/instructions_test.go
+++ b/execution/vm/instructions_test.go
@@ -316,7 +316,7 @@ func opBenchmark(b *testing.B, op executionFunc, args ...string) {
 	}
 	pc := uint64(0)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		for _, arg := range byteArgs {
 			a := *new(uint256.Int).SetBytes(arg)
 			callContext.Stack.push(a)

--- a/execution/vm/memory_test.go
+++ b/execution/vm/memory_test.go
@@ -87,7 +87,9 @@ func TestMemoryCopy(t *testing.T) {
 
 func BenchmarkResize(b *testing.B) {
 	memory := NewMemory()
-	for i := range b.N {
-		memory.Resize(uint64(i))
+	var i uint64
+	for b.Loop() {
+		memory.Resize(i)
+		i++
 	}
 }


### PR DESCRIPTION
Updated benchmark tests to use Go 1.24's `b.Loop()`.