### PR TITLE
Performance: make snapshot check chill out and do it once every 15mins.

### DIFF
--- a/db/snapshotsync/freezeblocks/block_snapshots.go
+++ b/db/snapshotsync/freezeblocks/block_snapshots.go
@@ -428,7 +428,7 @@ func (br *BlockRetire) RetireBlocksInBackground(
 	}
 
 	if br.skipLoop(minBlockNum, maxBlockNum) {
-		fmt.Println("TEST: passed", maxBlockNum, br.blockReader.FrozenBlocks()+snaptype.Erigon2MinSegmentSize)
+		fmt.Println("TEST: not passed", maxBlockNum, br.blockReader.FrozenBlocks()+snaptype.Erigon2MinSegmentSize)
 		return false
 	}
 


### PR DESCRIPTION
This decreases idle usage from 33% of CPU -> 8%. + we have minimal overhead