### PR TITLE
qa-tests: correct coordination between the two RPC Test on Latest

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests-latest.yml
+++ b/.github/workflows/qa-rpc-integration-tests-latest.yml
@@ -338,11 +338,11 @@ jobs:
           exit 1
 
       - name: Action for Success
-        if: steps.test_step.outputs.TEST_RESULT == 'success'
+        if: steps.test_step.outputs.TEST_RESULT == 'success' && matrix.client == 'erigon'
         run: echo "::notice::Tests completed successfully"
 
       - name: Action for Failure
-        if: steps.test_step.outputs.TEST_RESULT != 'success'
+        if: steps.test_step.outputs.TEST_RESULT != 'success' && matrix.client == 'erigon'
         run: |
           echo "::error::Error detected during tests: some tests failed, check the logs or the artifacts for more details"
           exit 1


### PR DESCRIPTION
Now that we are activating the new RPC Comparison Test Latest, which uses a test runner with Geth, we need better coordination with the other tests that implicitly use this test runner, the RPC Integration Test Latest.

This PR 
- add a job on the Geth test runner to reserve a free time frame; 
- use the coordinated_barrier as in the RPC Comparison Test Latest to sync the client instances (Erigon and Geth)
