### PR TITLE
Fixed seg_paged_rw to use correct config parameter for page size

### DIFF
--- a/db/seg/seg_paged_rw.go
+++ b/db/seg/seg_paged_rw.go
@@ -227,11 +227,11 @@ func (g *PagedReader) Skip() (uint64, int) {
 	return offset, len(v)
 }
 
-func NewPagedWriter(parent CompressorI, compressionEnabled bool) *PagedWriter {
+func NewPagedWriter(parent CompressorI, pageSize int, compressionEnabled bool) *PagedWriter {
 
 	return &PagedWriter{
 		parent:             parent,
-		pageSize:           parent.GetValuesOnCompressedPage(),
+		pageSize:           pageSize,
 		compressionEnabled: compressionEnabled,
 	}
 }

--- a/db/state/history.go
+++ b/db/state/history.go
@@ -864,7 +864,7 @@ func (h *History) dataWriter(f *seg.Compressor) *seg.PagedWriter {
 	if !strings.Contains(f.FileName(), ".v") {
 		panic("assert: miss-use " + f.FileName())
 	}
-	return seg.NewPagedWriter(seg.NewWriter(f, h.Compression), f.GetValuesOnCompressedPage() > 0)
+	return seg.NewPagedWriter(seg.NewWriter(f, h.Compression), h.HistoryValuesOnCompressedPage, true)
 }
 func (ht *HistoryRoTx) dataReader(f *seg.Decompressor) *seg.Reader { return ht.h.dataReader(f) }
 func (ht *HistoryRoTx) datarWriter(f *seg.Compressor) *seg.PagedWriter {

--- a/db/state/proto_forkable.go
+++ b/db/state/proto_forkable.go
@@ -111,7 +111,8 @@ func (a *ProtoForkable) BuildFile(ctx context.Context, from, to RootNum, db kv.R
 	}
 
 	if !exists {
-		segCfg := seg.DefaultCfg.WithValuesOnCompressedPage(a.cfg.ValuesOnCompressedPage)
+		segCfg := seg.DefaultCfg
+
 		segCfg.Workers = compressionWorkers
 		segCfg.ExpectMetadata = true
 		sn, err := seg.NewCompressor(ctx, "Snapshot "+Registry.Name(a.id), path, a.dirs.Tmp, segCfg, log.LvlTrace, a.logger)
@@ -166,7 +167,7 @@ func (a *ProtoForkable) BuildFile(ctx context.Context, from, to RootNum, db kv.R
 }
 
 func (a *ProtoForkable) DataWriter(f *seg.Compressor, compress bool) *seg.PagedWriter {
-	return seg.NewPagedWriter(seg.NewWriter(f, a.cfg.Compression), compress)
+	return seg.NewPagedWriter(seg.NewWriter(f, a.cfg.Compression), a.cfg.ValuesOnCompressedPage, compress)
 }
 
 func (a *ProtoForkable) DataReader(f *seg.Decompressor, compress bool) *seg.Reader {


### PR DESCRIPTION
Two domains can be affected by this bug -- rcache + commitment.

How to fix/regen rcache domain:
```
./build/bin/integration stage_custom_trace --domain=rcache --reset --chain chiado --datadir /erigon-data/chiado
./build/bin/erigon seg rm-state --datadir /erigon-data/chiado --domain=rcache —step 32-40
./build/bin/integration stage_custom_trace --domain=rcache --chain chiado --datadir /erigon-data/chiado
```