### PR TITLE
execution: fix Chiado re-exec from genesis

### DIFF
--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -962,10 +962,6 @@ func (sdb *IntraBlockState) refreshVersionedAccount(addr accounts.Address, readA
 // SubBalance subtracts amount from the account associated with addr.
 // DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) SubBalance(addr accounts.Address, amount uint256.Int, reason tracing.BalanceChangeReason) error {
-	if amount.IsZero() {
-		return nil
-	}
-
 	prev, wasCommited, _ := sdb.getBalance(addr)
 
 	if dbg.TraceTransactionIO && (sdb.trace || dbg.TraceAccount(addr.Handle())) {


### PR DESCRIPTION
Revert a change introduced by PR #15387 that was causing Issue #18276. Gnosis has some hacks for an empty `SystemAddress` (see https://github.com/erigontech/erigon/issues/18276#issuecomment-3804717962 & PR #5645).

TODO: add a test. (I created a test for Erigon 2 in PR #18844, but I haven't ported it to Erigon 3 yet.)