### PR TITLE
perf(cl/utils): optimize KzgCommitmentToVersionedHash to eliminate redundant allocations

### DIFF
--- a/cl/utils/blob.go
+++ b/cl/utils/blob.go
@@ -24,9 +24,8 @@ func KzgCommitmentToVersionedHash(kzgCommitment common.Bytes48) (common.Hash, er
 	versionedHash := [32]byte{}
 	kzgCommitmentHash := Sha256(kzgCommitment[:])
 
-	buf := append([]byte{}, VERSIONED_HASH_VERSION_KZG)
-	buf = append(buf, kzgCommitmentHash[1:]...)
-	copy(versionedHash[:], buf)
+	versionedHash[0] = VERSIONED_HASH_VERSION_KZG
+	copy(versionedHash[1:], kzgCommitmentHash[1:])
 
 	return versionedHash, nil
 }


### PR DESCRIPTION
Removes unnecessary slice allocation and append operations in `KzgCommitmentToVersionedHash`.
