### PR TITLE
execution/vm: add tests for EIP-8024 missing immediate byte defaulting to 0x00

### DIFF
--- a/execution/vm/instructions_test.go
+++ b/execution/vm/instructions_test.go
@@ -962,8 +962,26 @@ func TestEIP8024_Execution(t *testing.T) {
 			},
 		},
 		{
+			name:    "DUPN_MISSING_IMMEDIATE",
+			codeHex: "60016000808080808080808080808080808080e6",
+			wantVals: []uint64{
+				1,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				1,
+			},
+		},
+		{
 			name:    "SWAPN",
 			codeHex: "600160008080808080808080808080808080806002e700",
+			wantVals: []uint64{
+				1,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				2,
+			},
+		},
+		{
+			name:    "SWAPN_MISSING_IMMEDIATE",
+			codeHex: "600160008080808080808080808080808080806002e7",
 			wantVals: []uint64{
 				1,
 				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -974,6 +992,15 @@ func TestEIP8024_Execution(t *testing.T) {
 			name:     "EXCHANGE",
 			codeHex:  "600060016002e801",
 			wantVals: []uint64{2, 0, 1},
+		},
+		{
+			name:    "EXCHANGE_MISSING_IMMEDIATE",
+			codeHex: "600060006000600060006000600060006000600060006000600060006000600060006000600060006000600060006000600060006000600060016002e8",
+			wantVals: []uint64{
+				2,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				1,
+			},
 		},
 		{
 			name:    "INVALID_SWAPN_LOW",
@@ -1027,21 +1054,6 @@ func TestEIP8024_Execution(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "MISSING_IMMEDIATE_DUPN",
-			codeHex: "e6", // no operand
-			wantErr: true,
-		},
-		{
-			name:    "MISSING_IMMEDIATE_SWAPN",
-			codeHex: "e7", // no operand
-			wantErr: true,
-		},
-		{
-			name:    "MISSING_IMMEDIATE_EXCHANGE",
-			codeHex: "e8", // no operand
-			wantErr: true,
-		},
-		{
 			name:     "PC_INCREMENT",
 			codeHex:  "600060006000e80115",
 			wantVals: []uint64{1, 0, 0},
@@ -1057,25 +1069,25 @@ func TestEIP8024_Execution(t *testing.T) {
 			var err error
 			for pc < uint64(len(code)) && err == nil {
 				op := code[pc]
-				switch op {
-				case 0x00:
+				switch OpCode(op) {
+				case STOP:
 					return
-				case 0x60:
+				case PUSH1:
 					pc, _, err = opPush1(pc, evm, callContext)
-				case 0x80:
+				case DUP1:
 					dup1 := makeDup(1)
 					pc, _, err = dup1(pc, evm, callContext)
-				case 0x56:
+				case JUMP:
 					pc, _, err = opJump(pc, evm, callContext)
-				case 0x5b:
+				case JUMPDEST:
 					pc, _, err = opJumpdest(pc, evm, callContext)
-				case 0xe6:
+				case DUPN:
 					pc, _, err = opDupN(pc, evm, callContext)
-				case 0x15:
+				case ISZERO:
 					pc, _, err = opIszero(pc, evm, callContext)
-				case 0xe7:
+				case SWAPN:
 					pc, _, err = opSwapN(pc, evm, callContext)
-				case 0xe8:
+				case EXCHANGE:
 					pc, _, err = opExchange(pc, evm, callContext)
 				default:
 					err = &ErrInvalidOpCode{opcode: OpCode(op)}


### PR DESCRIPTION
This PR updates the EIP-8024 tests to match the latest test specification clarifications by adding tests for the newly defined scenarios.