### PR TITLE
chore: migrate benchmarks to b.Loop()

### DIFF
--- a/cl/utils/eth2shuffle/shuffle_bench_test.go
+++ b/cl/utils/eth2shuffle/shuffle_bench_test.go
@@ -36,8 +36,10 @@ func BenchmarkPermuteIndex(b *testing.B) {
 	for _, listSize := range listSizes {
 		// benchmark!
 		b.Run(fmt.Sprintf("PermuteIndex_%d", listSize), func(ib *testing.B) {
-			for i := uint64(0); i < uint64(ib.N); i++ {
+			var i uint64
+			for ib.Loop() {
 				eth2shuffle.PermuteIndex(hashFn, rounds, i%listSize, listSize, seed)
+				i++
 			}
 		})
 	}
@@ -57,7 +59,7 @@ func BenchmarkIndexComparison(b *testing.B) {
 	for _, listSize := range listSizes {
 		// benchmark!
 		b.Run(fmt.Sprintf("Indexwise_ShuffleList_%d", listSize), func(ib *testing.B) {
-			for i := 0; i < ib.N; i++ {
+			for ib.Loop() {
 				// Simulate a list-shuffle by running permute-index listSize times.
 				for j := uint64(0); j < listSize; j++ {
 					eth2shuffle.PermuteIndex(hashFn, rounds, j, listSize, seed)
@@ -86,7 +88,7 @@ func BenchmarkShuffleList(b *testing.B) {
 		}
 		// benchmark!
 		b.Run(fmt.Sprintf("ShuffleList_%d", listSize), func(ib *testing.B) {
-			for i := 0; i < ib.N; i++ {
+			for ib.Loop() {
 				eth2shuffle.ShuffleList(hashFn, testIndices, rounds, seed)
 			}
 		})

--- a/rpc/jsonstream/stream_benchmark_test.go
+++ b/rpc/jsonstream/stream_benchmark_test.go
@@ -35,7 +35,7 @@ func newStream() *jsoniter.Stream {
 // benchmarkSimpleObject is used to compare writing a simple JSON object
 func benchmarkSimpleObject(b *testing.B, s Stream) {
 	b.Helper()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		s.WriteObjectStart()
 		s.WriteObjectField("name")
 		s.WriteString("John")
@@ -62,7 +62,7 @@ func BenchmarkSimpleObject_StackStream(b *testing.B) {
 // benchmarkNestedStructure is used to compare writing a nested JSON structure
 func benchmarkNestedStructure(b *testing.B, s Stream) {
 	b.Helper()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		s.WriteObjectStart()
 		s.WriteObjectField("person")
 		s.WriteObjectStart()
@@ -101,7 +101,7 @@ func BenchmarkNestedStructure_StackStream(b *testing.B) {
 // benchmarkLargeArray is used to compare writing a large array
 func benchmarkLargeArray(b *testing.B, s Stream) {
 	b.Helper()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		s.WriteArrayStart()
 		for j := 0; j < 1000; j++ {
 			if j > 0 {
@@ -129,7 +129,7 @@ func BenchmarkLargeArray_StackStream(b *testing.B) {
 // benchmarkMixedTypes is used to compare writing mixed data types
 func benchmarkMixedTypes(b *testing.B, s Stream) {
 	b.Helper()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		s.WriteObjectStart()
 		s.WriteObjectField("string")
 		s.WriteString("value")
@@ -166,7 +166,7 @@ func BenchmarkMixedTypes_StackStream(b *testing.B) {
 func benchmarkWriteToBuffer(b *testing.B, s Stream) {
 	b.Helper()
 	buf := bytes.NewBuffer(nil)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		s.Reset(buf)
 		s.WriteObjectStart()
 		s.WriteObjectField("name")
@@ -194,7 +194,7 @@ func BenchmarkWriteToBuffer_StackStream(b *testing.B) {
 // benchmarkIncompleteStructure is used to compare handling incomplete structures
 func benchmarkIncompleteStructure(b *testing.B, s Stream) {
 	b.Helper()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		// Create an incomplete structure
 		s.WriteObjectStart()
 		s.WriteObjectField("name")


### PR DESCRIPTION
Updated benchmark tests to use Go 1.24's `b.Loop()`.