### PR TITLE
Benchmark commitment history lookup

### DIFF
--- a/cmd/integration/commands/commitment.go
+++ b/cmd/integration/commands/commitment.go
@@ -836,7 +836,7 @@ func benchMdbxHistoryLookup(ctx context.Context, tx kv.TemporalTx, compactKey []
 	}
 
 	mdbxStats := &HistoryBenchStats{
-		Name:        "MDBX (high txnums)",
+		Name:        "MDBX",
 		StartTxNum:  minTxNum,
 		EndTxNum:    maxTxNum,
 		SampleCount: len(durations),


### PR DESCRIPTION
Part 2 of https://github.com/erigontech/erigon/issues/18839

This adds the command: `integration commitment bench-history-lookup --sample-percentage 10.0 --prefix ""`   which will sample txnums from the range of each history file and from the txnum range in MDBX and gather statistics about the lookup performance of ` commitmentdb.NewHistoryStateReader(tx, txNum).Read(CompactKey(prefix))` .

 By default the prefix is empty, so the path to the root of the MPT will be used for lookup, but another trie path can be configured as well.
 
 Some results sampling 25% of txnums from each history file and from MDBX:
 
 ```
 ./build/bin/integration commitment bench-history-lookup --chain=mainnet --datadir ~/data/eth-mainnet-archive --seed=123456 --sample-percentage 25

================================================================================
  HISTORY LOOKUP BENCHMARK RESULTS
  Prefix: (empty - root lookup)
  Compact Key: 00
================================================================================

File                                            StartTxNum     EndTxNum  Samples       Mean        P50        P95        P99
-------------------------------------------------------------------------------------------------------------------------------
v1.1-commitment.1984-2048.v                     3100000000   3200000000 25000000    4.392µs    3.216µs    6.642µs    7.294µs
v1.1-commitment.2048-2080.v                     3200000000   3250000000 12500000    5.572µs     5.64µs    6.713µs    7.614µs
v2.0-commitment.2080-2088.v                     3250000000   3262500000  3125000     3.88µs    3.817µs    4.368µs     5.36µs
v2.0-commitment.2088-2092.v                     3262500000   3268750000  1562500    3.607µs    3.567µs    3.837µs    4.909µs
v2.0-commitment.2092-2094.v                     3268750000   3271875000   781250     3.51µs    3.477µs    3.697µs    4.638µs
v2.0-commitment.2094-2095.v                     3271875000   3273437500   390625      498ns      490ns      541ns      801ns
MDBX                                            3273437500   3274224383   196720      234ns      231ns      261ns      280ns
-------------------------------------------------------------------------------------------------------------------------------
```


