### PR TITLE
txnprovider/txpool: remove unused db transaction in GetBlobs

### DIFF
--- a/txnprovider/txpool/txpool_grpc_server.go
+++ b/txnprovider/txpool/txpool_grpc_server.go
@@ -226,12 +226,6 @@ func (s *GrpcServer) Add(ctx context.Context, in *txpoolproto.AddRequest) (*txpo
 }
 
 func (s *GrpcServer) GetBlobs(ctx context.Context, in *txpoolproto.GetBlobsRequest) (*txpoolproto.GetBlobsReply, error) {
-	tx, err := s.db.BeginRo(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
-
 	hashes := make([]common.Hash, len(in.BlobHashes))
 	for i := range in.BlobHashes {
 		hashes[i] = gointerfaces.ConvertH256ToHash(in.BlobHashes[i])


### PR DESCRIPTION
Reason:
The GetBlobs gRPC handler was opening a read-only DB transaction that was never used, adding unnecessary overhead and complexity without affecting behaviour.

Summary:
Remove the unused BeginRo/rollback from GrpcServer.GetBlobs, leaving the in-memory txpool lookup and response marshalling logic unchanged.