### PR TITLE
execution/eth1: fix flake in TestValidateChainWithLastTxNumOfBlockAtStepBoundary

### DIFF
--- a/execution/eth1/ethereum_execution_test.go
+++ b/execution/eth1/ethereum_execution_test.go
@@ -98,8 +98,8 @@ func retryBusy[T any](ctx context.Context, f func() (T, executionproto.Execution
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 	var b backoff.BackOff
-	b = backoff.WithContext(b, ctx)
 	b = backoff.NewConstantBackOff(time.Millisecond)
+	b = backoff.WithContext(b, ctx)
 	return backoff.RetryWithData(
 		func() (T, error) {
 			r, s, err := f()


### PR DESCRIPTION
fixes a flaky test I introduced in https://github.com/erigontech/erigon/pull/18858

CI run: https://github.com/erigontech/erigon/actions/runs/21483225590/job/61885074571
```
--- FAIL: TestValidateChainWithLastTxNumOfBlockAtStepBoundary (0.04s)
    ethereum_execution_test.go:57: 
        	Error Trace:	/Users/runner/work/erigon/erigon/execution/eth1/ethereum_execution_test.go:57
        	Error:      	Not equal: 
        	            	expected: 0
        	            	actual  : 5
        	Test:       	TestValidateChainWithLastTxNumOfBlockAtStepBoundary
```