### PR TITLE
execution/tests: minor fix chainmaker add withdrawals in shanghai

### DIFF
--- a/execution/tests/blockgen/chain_makers.go
+++ b/execution/tests/blockgen/chain_makers.go
@@ -349,7 +349,7 @@ func GenerateChain(config *chain.Config, parent *types.Block, engine rules.Engin
 				txNumIncrement()
 			},
 		}
-		if chainreader.Config().IsPrague(parent.Time()) {
+		if chainreader.Config().IsShanghai(parent.Time()) {
 			b.withdrawals = []*types.Withdrawal{}
 		}
 		b.header = makeHeader(chainreader, parent, ibs, b.engine)


### PR DESCRIPTION
minor change for correctness and consistency with main (I only noticed this when I ported it to main as the tests there caught it) - the withdrawals hash should be present in Shanghai onwards (confused it with Prague earlier)