### PR TITLE
rpc: replace sort.Slice with slices.SortFunc in rankMapDifficulties

### DIFF
--- a/rpc/jsonrpc/bor_helper.go
+++ b/rpc/jsonrpc/bor_helper.go
@@ -18,10 +18,11 @@ package jsonrpc
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/crypto"
@@ -173,8 +174,8 @@ func rankMapDifficulties(values map[common.Address]uint64) []difficultiesKV {
 		ss = append(ss, difficultiesKV{k, v})
 	}
 
-	sort.Slice(ss, func(i, j int) bool {
-		return ss[i].Difficulty > ss[j].Difficulty
+	slices.SortFunc(ss, func(a, b difficultiesKV) int {
+		return cmp.Compare(b.Difficulty, a.Difficulty)
 	})
 
 	return ss


### PR DESCRIPTION
Replace `sort.Slice` with `slices.SortFunc` in `rankMapDifficulties` helper function. This modernizes the codebase to use the standard library slices package (introduced in Go 1.21, we're on 1.24).