### PR TITLE
Performance: Faster prague finalizer

### DIFF
--- a/execution/protocol/rules/merge/merge.go
+++ b/execution/protocol/rules/merge/merge.go
@@ -198,8 +198,9 @@ func (s *Merge) Finalize(config *chain.Config, header *types.Header, state *stat
 		// Try to reuse buffer, fall back to allocation if concurrent access
 		var allLogs types.Logs
 		reuseBuffer := s.logsBufMu.TryLock()
-		defer s.logsBufMu.Unlock()
-
+		if reuseBuffer {
+			defer s.logsBufMu.Unlock()
+		}
 		if reuseBuffer {
 			allLogs = s.logsBuf[:0]
 		} else {


### PR DESCRIPTION
On some blocks (probably long ones...) Finalize appears on the profiler. this show as >5ms of CPU time so worth cutting

<img width="1710" height="778" alt="Screenshot 2026-01-31 alle 15 41 18" src="https://github.com/user-attachments/assets/8354b135-d30f-4392-b84c-0ef95e08e443" />
