### PR TITLE
execution/protocol: add zero-value check in Transfer()

### DIFF
--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -622,6 +622,8 @@ func (pe *parallelExecutor) execLoop(ctx context.Context) (err error) {
 							reader = state.NewReaderV3(pe.rs.Domains().AsGetter(applyTx))
 						}
 						ibs := state.New(state.NewBufferedReader(pe.rs, reader))
+						ibs.SetIsAura(pe.cfg.chainConfig.Aura != nil)
+
 						ibs.SetVersion(finalVersion.Incarnation)
 						localVersionMap := state.NewVersionMap(nil)
 						ibs.SetVersionMap(localVersionMap)
@@ -982,6 +984,7 @@ func (result *execResult) finalize(prevReceipt *types.Receipt, engine rules.Engi
 	}
 
 	ibs := state.New(state.NewVersionedStateReader(txIndex, result.TxIn, vm, stateReader))
+	ibs.SetIsAura(txTask.Config.Aura != nil)
 	ibs.SetTxContext(blockNum, txIndex)
 	ibs.SetVersion(txIncarnation)
 	ibs.SetVersionMap(&state.VersionMap{})

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -348,6 +348,7 @@ func (se *serialExecutor) executeBlock(ctx context.Context, tasks []exec.Task, i
 				//fmt.Printf("txNum=%d, blockNum=%d, finalisation of the block\n", txTask.TxNum, txTask.BlockNum)
 				// End of block transaction in a block
 				ibs := state.New(state.NewReaderV3(se.rs.Domains().AsGetter(se.applyTx)))
+				ibs.SetIsAura(se.cfg.chainConfig.Aura != nil)
 				ibs.SetTxContext(txTask.BlockNumber(), txTask.TxIndex)
 				syscall := func(contract accounts.Address, data []byte) ([]byte, error) {
 					ret, err := protocol.SysCallContract(contract, data, se.cfg.chainConfig, ibs, txTask.Header, se.cfg.engine, false /* constCall */, *se.cfg.vmConfig)


### PR DESCRIPTION
Add early return for zero-value transfers to avoid unnecessary state operations. This restores performance that was regressed by PR #18846 which removed the zero-check from SubBalance() for Gnosis compatibility.

The fix is safe because:
- Account creation/touching is handled by CreateAccount() before Transfer()
- EIP-7708 log emission is already guarded by !amount.IsZero()

Benchmark improvement:
- call-identity: 176ms -> 128ms (27% faster)
- call-EOA: 194ms -> 144ms (26% faster)
