### PR TITLE
rpc: return error for eth_call on unexecuted blocks instead of stale data

### DIFF
--- a/rpc/jsonrpc/eth_accounts.go
+++ b/rpc/jsonrpc/eth_accounts.go
@@ -50,6 +50,17 @@ func (api *APIImpl) GetBalance(ctx context.Context, address common.Address, bloc
 		return nil, err
 	}
 
+	// Validate execution progress only for explicit block numbers/hashes
+	if rpchelper.ShouldValidateExecutionProgress(blockNrOrHash) {
+		executedBlock, err := rpchelper.GetLatestExecutedBlockNumber(tx)
+		if err != nil {
+			return nil, err
+		}
+		if blockNumber > executedBlock {
+			return nil, fmt.Errorf("state for block %d not available (execution at block %d)", blockNumber, executedBlock)
+		}
+	}
+
 	reader, err := rpchelper.CreateStateReaderFromBlockNumber(ctx, tx, blockNumber, latest, 0, api.stateCache, api._txNumReader)
 	if err != nil {
 		return nil, err
@@ -96,6 +107,17 @@ func (api *APIImpl) GetTransactionCount(ctx context.Context, address common.Addr
 		return nil, err
 	}
 
+	// Validate execution progress only for explicit block numbers/hashes
+	if rpchelper.ShouldValidateExecutionProgress(blockNrOrHash) {
+		executedBlock, err := rpchelper.GetLatestExecutedBlockNumber(tx)
+		if err != nil {
+			return nil, err
+		}
+		if blockNumber > executedBlock {
+			return nil, fmt.Errorf("state for block %d not available (execution at block %d)", blockNumber, executedBlock)
+		}
+	}
+
 	reader, err := rpchelper.CreateStateReaderFromBlockNumber(ctx, tx, blockNumber, latest, 0, api.stateCache, api._txNumReader)
 	if err != nil {
 		return nil, err
@@ -123,6 +145,17 @@ func (api *APIImpl) GetCode(ctx context.Context, address common.Address, blockNr
 	err = api.BaseAPI.checkPruneHistory(ctx, tx, blockNumber)
 	if err != nil {
 		return nil, err
+	}
+
+	// Validate execution progress only for explicit block numbers/hashes
+	if rpchelper.ShouldValidateExecutionProgress(blockNrOrHash) {
+		executedBlock, err := rpchelper.GetLatestExecutedBlockNumber(tx)
+		if err != nil {
+			return nil, err
+		}
+		if blockNumber > executedBlock {
+			return nil, fmt.Errorf("state for block %d not available (execution at block %d)", blockNumber, executedBlock)
+		}
 	}
 
 	reader, err := rpchelper.CreateStateReaderFromBlockNumber(ctx, tx, blockNumber, latest, 0, api.stateCache, api._txNumReader)
@@ -171,6 +204,17 @@ func (api *APIImpl) GetStorageAt(ctx context.Context, address common.Address, in
 		return hexutil.Encode(common.LeftPadBytes(empty, 32)), err
 	}
 
+	// Validate execution progress only for explicit block numbers/hashes
+	if rpchelper.ShouldValidateExecutionProgress(blockNrOrHash) {
+		executedBlock, err := rpchelper.GetLatestExecutedBlockNumber(tx)
+		if err != nil {
+			return hexutil.Encode(common.LeftPadBytes(empty, 32)), err
+		}
+		if blockNumber > executedBlock {
+			return "", fmt.Errorf("state for block %d not available (execution at block %d)", blockNumber, executedBlock)
+		}
+	}
+
 	reader, err := rpchelper.CreateStateReaderFromBlockNumber(ctx, tx, blockNumber, latest, 0, api.stateCache, api._txNumReader)
 	if err != nil {
 		return hexutil.Encode(common.LeftPadBytes(empty, 32)), err
@@ -206,6 +250,17 @@ func (api *APIImpl) Exist(ctx context.Context, address common.Address, blockNrOr
 	err = api.BaseAPI.checkPruneHistory(ctx, tx, blockNumber)
 	if err != nil {
 		return false, err
+	}
+
+	// Validate execution progress only for explicit block numbers/hashes
+	if rpchelper.ShouldValidateExecutionProgress(blockNrOrHash) {
+		executedBlock, err := rpchelper.GetLatestExecutedBlockNumber(tx)
+		if err != nil {
+			return false, err
+		}
+		if blockNumber > executedBlock {
+			return false, fmt.Errorf("state for block %d not available (execution at block %d)", blockNumber, executedBlock)
+		}
 	}
 
 	reader, err := rpchelper.CreateStateReaderFromBlockNumber(ctx, tx, blockNumber, latest, 0, api.stateCache, api._txNumReader)

--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -195,6 +195,18 @@ func (api *APIImpl) EstimateGas(ctx context.Context, argsOrNil *ethapi2.CallArgs
 		return 0, err
 	}
 
+	// Validate execution progress only for explicit block numbers/hashes
+	// Skip for semantic tags (latest, pending, safe, finalized, earliest)
+	if rpchelper.ShouldValidateExecutionProgress(*blockNrOrHash) {
+		executedBlock, err := rpchelper.GetLatestExecutedBlockNumber(dbtx)
+		if err != nil {
+			return 0, err
+		}
+		if blockNum.Uint64() > executedBlock {
+			return 0, fmt.Errorf("state for block %d not available (execution at block %d)", blockNum.Uint64(), executedBlock)
+		}
+	}
+
 	stateReader, err := rpchelper.CreateStateReaderFromBlockNumber(ctx, dbtx, blockNum.Uint64(), isLatest, 0, api.stateCache, api._txNumReader)
 	if err != nil {
 		return 0, err

--- a/rpc/jsonrpc/eth_call_test.go
+++ b/rpc/jsonrpc/eth_call_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/commitment/trie"
+	"github.com/erigontech/erigon/execution/stagedsync/stages"
 	"github.com/erigontech/erigon/execution/state"
 	"github.com/erigontech/erigon/execution/tests/blockgen"
 	"github.com/erigontech/erigon/execution/tests/mock"
@@ -682,5 +683,192 @@ func doPrune(t *testing.T, db kv.RwDB, pruneTo uint64) {
 	//require.NoError(t, err)
 
 	err = tx.Commit()
+	require.NoError(t, err)
+}
+
+// TestEthCallToUnexecutedBlock tests that eth_call returns an error when
+// requesting state from a block that has headers but hasn't been executed yet.
+func TestEthCallToUnexecutedBlock(t *testing.T) {
+	m, bankAddress, contractAddress, _ := chainWithDeployedContract(t)
+	api := newEthApiForTest(newBaseApiForTest(m), m.DB, nil, nil)
+
+	// Simulate a syncing node by setting execution stage progress to block 3
+	// while the chain has headers up to block 6
+	ctx := context.Background()
+	tx, err := m.DB.BeginRw(ctx)
+	require.NoError(t, err)
+	err = stages.SaveStageProgress(tx, stages.Execution, 3)
+	require.NoError(t, err)
+	err = tx.Commit()
+	require.NoError(t, err)
+
+	callData := hexutil.MustDecode("0x2e64cec1") // retrieve() function
+	callDataBytes := hexutil.Bytes(callData)
+
+	// Request block 5 which is beyond execution progress (3)
+	blockNr := rpc.BlockNumber(5)
+	blockNrOrHash := rpc.BlockNumberOrHashWithNumber(blockNr)
+
+	_, err = api.Call(ctx, ethapi.CallArgs{
+		From: &bankAddress,
+		To:   &contractAddress,
+		Data: &callDataBytes,
+	}, &blockNrOrHash, nil, nil)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "state for block 5 not available")
+	require.Contains(t, err.Error(), "execution at block 3")
+}
+
+// TestEthCallLatestDuringSync tests that eth_call with "latest" tag works
+// even when the node is syncing (forkchoiceHead > execution progress).
+func TestEthCallLatestDuringSync(t *testing.T) {
+	m, bankAddress, contractAddress, _ := chainWithDeployedContract(t)
+	api := newEthApiForTest(newBaseApiForTest(m), m.DB, nil, nil)
+
+	callData := hexutil.MustDecode("0x2e64cec1") // retrieve() function
+	callDataBytes := hexutil.Bytes(callData)
+
+	// Request with "latest" tag should work regardless of execution progress
+	blockNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
+
+	_, err := api.Call(context.Background(), ethapi.CallArgs{
+		From: &bankAddress,
+		To:   &contractAddress,
+		Data: &callDataBytes,
+	}, &blockNrOrHash, nil, nil)
+
+	require.NoError(t, err)
+}
+
+// TestGetBalanceUnexecutedBlock tests that eth_getBalance returns an error
+// when requesting state from a block that hasn't been executed yet.
+func TestGetBalanceUnexecutedBlock(t *testing.T) {
+	m, bankAddress, _, _ := chainWithDeployedContract(t)
+	api := newEthApiForTest(newBaseApiForTest(m), m.DB, nil, nil)
+
+	// Simulate a syncing node by setting execution stage progress to block 3
+	ctx := context.Background()
+	tx, err := m.DB.BeginRw(ctx)
+	require.NoError(t, err)
+	err = stages.SaveStageProgress(tx, stages.Execution, 3)
+	require.NoError(t, err)
+	err = tx.Commit()
+	require.NoError(t, err)
+
+	// Request block 5 which is beyond execution progress (3)
+	blockNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(5))
+
+	_, err = api.GetBalance(ctx, bankAddress, blockNrOrHash)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "state for block 5 not available")
+	require.Contains(t, err.Error(), "execution at block 3")
+}
+
+// TestGetCodeUnexecutedBlock tests that eth_getCode returns an error
+// when requesting state from a block that hasn't been executed yet.
+func TestGetCodeUnexecutedBlock(t *testing.T) {
+	m, _, contractAddress, _ := chainWithDeployedContract(t)
+	api := newEthApiForTest(newBaseApiForTest(m), m.DB, nil, nil)
+
+	// Simulate a syncing node by setting execution stage progress to block 3
+	ctx := context.Background()
+	tx, err := m.DB.BeginRw(ctx)
+	require.NoError(t, err)
+	err = stages.SaveStageProgress(tx, stages.Execution, 3)
+	require.NoError(t, err)
+	err = tx.Commit()
+	require.NoError(t, err)
+
+	// Request block 5 which is beyond execution progress (3)
+	blockNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(5))
+
+	_, err = api.GetCode(ctx, contractAddress, blockNrOrHash)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "state for block 5 not available")
+	require.Contains(t, err.Error(), "execution at block 3")
+}
+
+// TestGetStorageAtUnexecutedBlock tests that eth_getStorageAt returns an error
+// when requesting state from a block that hasn't been executed yet.
+func TestGetStorageAtUnexecutedBlock(t *testing.T) {
+	m, _, contractAddress, _ := chainWithDeployedContract(t)
+	api := newEthApiForTest(newBaseApiForTest(m), m.DB, nil, nil)
+
+	// Simulate a syncing node by setting execution stage progress to block 3
+	ctx := context.Background()
+	tx, err := m.DB.BeginRw(ctx)
+	require.NoError(t, err)
+	err = stages.SaveStageProgress(tx, stages.Execution, 3)
+	require.NoError(t, err)
+	err = tx.Commit()
+	require.NoError(t, err)
+
+	// Request block 5 which is beyond execution progress (3)
+	blockNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(5))
+
+	_, err = api.GetStorageAt(ctx, contractAddress, "0x0", blockNrOrHash)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "state for block 5 not available")
+	require.Contains(t, err.Error(), "execution at block 3")
+}
+
+// TestEstimateGasUnexecutedBlock tests that eth_estimateGas returns an error
+// when requesting state from a block that hasn't been executed yet.
+func TestEstimateGasUnexecutedBlock(t *testing.T) {
+	m, bankAddress, contractAddress, _ := chainWithDeployedContract(t)
+	ctx, conn := rpcdaemontest.CreateTestGrpcConn(t, mock.Mock(t))
+	mining := txpoolproto.NewMiningClient(conn)
+	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
+	ff := rpchelper.New(ctx, rpchelper.DefaultFiltersConfig, nil, nil, mining, func() {}, m.Log)
+	api := newEthApiForTest(newBaseApiWithFiltersForTest(ff, stateCache, m), m.DB, nil, nil)
+
+	// Simulate a syncing node by setting execution stage progress to block 3
+	tx, err := m.DB.BeginRw(ctx)
+	require.NoError(t, err)
+	err = stages.SaveStageProgress(tx, stages.Execution, 3)
+	require.NoError(t, err)
+	err = tx.Commit()
+	require.NoError(t, err)
+
+	callData := hexutil.MustDecode("0x2e64cec1") // retrieve() function
+	callDataBytes := hexutil.Bytes(callData)
+
+	// Request block 5 which is beyond execution progress (3)
+	blockNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(5))
+
+	_, err = api.EstimateGas(ctx, &ethapi.CallArgs{
+		From: &bankAddress,
+		To:   &contractAddress,
+		Data: &callDataBytes,
+	}, &blockNrOrHash, nil, nil)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "state for block 5 not available")
+	require.Contains(t, err.Error(), "execution at block 3")
+}
+
+// TestEstimateGasLatestDuringSync tests that eth_estimateGas with "latest" tag works
+// even when the node is syncing (forkchoiceHead > execution progress).
+func TestEstimateGasLatestDuringSync(t *testing.T) {
+	m, _, _ := rpcdaemontest.CreateTestSentry(t)
+	ctx, conn := rpcdaemontest.CreateTestGrpcConn(t, mock.Mock(t))
+	mining := txpoolproto.NewMiningClient(conn)
+	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
+	ff := rpchelper.New(ctx, rpchelper.DefaultFiltersConfig, nil, nil, mining, func() {}, m.Log)
+	api := newEthApiForTest(newBaseApiWithFiltersForTest(ff, stateCache, m), m.DB, nil, nil)
+
+	var from = common.HexToAddress("0x71562b71999873db5b286df957af199ec94617f7")
+	var to = common.HexToAddress("0x0d3ab14bbad3d99f4203bd7a11acb94882050e7e")
+
+	// Request with "latest" tag should work
+	_, err := api.EstimateGas(ctx, &ethapi.CallArgs{
+		From: &from,
+		To:   &to,
+	}, nil, nil, nil)
+
 	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary

Fixes #18912

When a node is syncing, `eth_call` and related RPC methods were returning stale/incorrect data from the Execution stage for blocks that have headers but haven't been executed yet. This fix adds validation to return a clear error message instead.

### Key Changes

- Added `ShouldValidateExecutionProgress()` helper in `rpc/rpchelper/helper.go` to determine if a block reference requires validation (explicit block number/hash vs semantic tags)
- Modified `CreateStateReader()` to validate execution progress for explicit block requests
- Added validation in methods that bypass `CreateStateReader` (`EstimateGas`, `GetBalance`, `GetTransactionCount`, `GetCode`, `GetStorageAt`)

### Behavior

| Request Type | During Sync (forkchoiceHead > Execution) | Behavior |
|--------------|------------------------------------------|----------|
| `latest` tag | Yes | ✅ Success - uses forkchoiceHead state |
| `pending` tag | Yes | ✅ Success - uses pending/latest state |
| `safe`/`finalized` tag | N/A | ✅ Success - always executed |
| Explicit block # > exec | Yes | ❌ Error - state not available |
| Block hash > exec | Yes | ❌ Error - state not available |

### Methods Fixed

- `eth_call`
- `eth_getBalance`
- `eth_getTransactionCount`
- `eth_getCode`
- `eth_getStorageAt`
- `eth_estimateGas`

### Error Response

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "error": {
    "code": -32000,
    "message": "state for block 24356887 not available (execution at block 24356849)"
  }
}
```

This is consistent with other clients (Geth, Reth) which return `-32000` for similar scenarios.

## Test Plan

- [x] Added 7 new unit tests for unexecuted block scenarios
- [x] All existing tests pass without modification
- [x] Build succeeds