### PR TITLE
qa-tests: restore previous "RPC test latest" workflow

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests-latest.yml
+++ b/.github/workflows/qa-rpc-integration-tests-latest.yml
@@ -66,6 +66,7 @@ jobs:
 
           echo "Mirror datadir"
           if ! "$GITHUB_WORKSPACE/cmd/scripts/mirror-datadir.sh" "$ERIGON_REFERENCE_DATA_DIR" "$ERIGON_TESTBED_DATA_DIR" > /dev/null 2>&1; then
+            echo "::error::Failed to mirror datadir from $ERIGON_REFERENCE_DATA_DIR to $ERIGON_TESTBED_DATA_DIR"
             echo "Failed to mirror datadir from $ERIGON_REFERENCE_DATA_DIR to $ERIGON_TESTBED_DATA_DIR"
             exit 1
           fi


### PR DESCRIPTION
The new workflow caused long delays that are unacceptable for this test; we therefore reviewed the schedules and restored the old workflow.