### PR TITLE
Add debug.SetupSimple, and improve torrent client status info log

### DIFF
--- a/cmd/caplin/main.go
+++ b/cmd/caplin/main.go
@@ -58,7 +58,7 @@ func runCaplinNode(cliCtx *cli.Context) error {
 		log.Error("[Phase1] Could not initialize caplin", "err", err)
 		return err
 	}
-	if _, _, _, _, err := debug.Setup(cliCtx, true /* root logger */); err != nil {
+	if _, err := debug.SetupSimple(cliCtx, true /* root logger */); err != nil {
 		return err
 	}
 	rcfg := beacon_router_configuration.RouterConfiguration{

--- a/cmd/silkworm_api/snapshot_idx.go
+++ b/cmd/silkworm_api/snapshot_idx.go
@@ -74,7 +74,7 @@ func FindIf(segments []snaptype.FileInfo, predicate func(snaptype.FileInfo) bool
 }
 
 func buildIndex(cliCtx *cli.Context, dataDir string, snapshotPaths []string, minBlock uint64) error {
-	logger, _, _, _, err := debug.Setup(cliCtx, true /* rootLogger */)
+	logger, err := debug.SetupSimple(cliCtx, true /* rootLogger */)
 	if err != nil {
 		return err
 	}

--- a/cmd/utils/app/backtest_commitment_cmd.go
+++ b/cmd/utils/app/backtest_commitment_cmd.go
@@ -50,7 +50,7 @@ var backtestCommitmentCommand = cli.Command{
 	}),
 	Action: func(cliCtx *cli.Context) error {
 		ctx := cliCtx.Context
-		logger, _, _, _, err := debug.Setup(cliCtx, true /* root logger */)
+		logger, err := debug.SetupSimple(cliCtx, true /* root logger */)
 		if err != nil {
 			panic(fmt.Errorf("backtest-commitment: could not setup logger: %w", err))
 		}
@@ -92,7 +92,7 @@ var backtestCommitmentCommand = cli.Command{
 				&cli.StringFlag{Name: "output-dir", Required: true, Usage: "directory to store comparison.html file"},
 			}),
 			Action: func(cliCtx *cli.Context) error {
-				logger, _, _, _, err := debug.Setup(cliCtx, true /* root logger */)
+				logger, err := debug.SetupSimple(cliCtx, true /* root logger */)
 				if err != nil {
 					panic(fmt.Errorf("backtest-commitment: compare-runs: could not setup logger: %w", err))
 				}

--- a/cmd/utils/app/domain_cmd.go
+++ b/cmd/utils/app/domain_cmd.go
@@ -18,7 +18,7 @@ import (
 )
 
 func domainStat(cliCtx *cli.Context) error {
-	_, _, _, _, err := debug.Setup(cliCtx, true /* root logger */)
+	_, err := debug.SetupSimple(cliCtx, true /* root logger */)
 	if err != nil {
 		return err
 	}

--- a/cmd/utils/app/seg_info_cmd.go
+++ b/cmd/utils/app/seg_info_cmd.go
@@ -15,7 +15,7 @@ import (
 )
 
 func segInfo(cliCtx *cli.Context) error {
-	logger, _, _, _, err := debug.Setup(cliCtx, true /* root logger */)
+	logger, err := debug.SetupSimple(cliCtx, true /* root logger */)
 	if err != nil {
 		return err
 	}

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -95,7 +95,7 @@ func joinFlags(lists ...[]cli.Flag) (res []cli.Flag) {
 func commonBeforeSnapshotCommand(cliCtx *cli.Context) error {
 	go mem.LogMemStats(cliCtx.Context, log.New())
 	go disk.UpdateDiskStats(cliCtx.Context, log.New())
-	_, _, _, _, err := debug.Setup(cliCtx, true /* rootLogger */)
+	_, err := debug.SetupSimple(cliCtx, true /* rootLogger */)
 	if err != nil {
 		return err
 	}
@@ -307,7 +307,7 @@ var snapshotCommand = cli.Command{
 				"It is useful for shadowforks, recovering broken nodes or chains, and/or for doing experiments that " +
 				"involve replaying certain blocks.",
 			Action: func(cliCtx *cli.Context) error {
-				logger, _, _, _, err := debug.Setup(cliCtx, true /* root logger */)
+				logger, err := debug.SetupSimple(cliCtx, true /* root logger */)
 				if err != nil {
 					panic(fmt.Errorf("rollback snapshots to block: could not setup logger: %w", err))
 				}
@@ -393,7 +393,7 @@ var snapshotCommand = cli.Command{
 		{
 			Name: "check-commitment-hist-at-blk",
 			Action: func(cliCtx *cli.Context) error {
-				logger, _, _, _, err := debug.Setup(cliCtx, true /* root logger */)
+				logger, err := debug.SetupSimple(cliCtx, true /* root logger */)
 				if err != nil {
 					panic(fmt.Errorf("check commitment history at block: could not setup logger: %w", err))
 				}
@@ -414,7 +414,7 @@ var snapshotCommand = cli.Command{
 		{
 			Name: "check-commitment-hist-at-blk-range",
 			Action: func(cliCtx *cli.Context) error {
-				logger, _, _, _, err := debug.Setup(cliCtx, true /* root logger */)
+				logger, err := debug.SetupSimple(cliCtx, true /* root logger */)
 				if err != nil {
 					panic(fmt.Errorf("check commitment history at block range: could not setup logger: %w", err))
 				}
@@ -908,7 +908,7 @@ func doBtSearch(cliCtx *cli.Context) error {
 		return err
 	}
 	defer l.Unlock()
-	logger, _, _, _, err := debug.Setup(cliCtx, true /* root logger */)
+	logger, err := debug.SetupSimple(cliCtx, true /* root logger */)
 	if err != nil {
 		return err
 	}
@@ -953,7 +953,7 @@ func doBtSearch(cliCtx *cli.Context) error {
 }
 
 func doDebugKey(cliCtx *cli.Context) error {
-	logger, _, _, _, err := debug.Setup(cliCtx, true /* root logger */)
+	logger, err := debug.SetupSimple(cliCtx, true /* root logger */)
 	if err != nil {
 		return err
 	}
@@ -1006,7 +1006,7 @@ func doDebugKey(cliCtx *cli.Context) error {
 }
 
 func doIntegrity(cliCtx *cli.Context) error {
-	logger, _, _, _, err := debug.Setup(cliCtx, true /* root logger */)
+	logger, err := debug.SetupSimple(cliCtx, true /* root logger */)
 	if err != nil {
 		return err
 	}
@@ -1772,7 +1772,7 @@ func deleteFilesWithExtensions(dir string, extensions []string) error {
 }
 
 func doBlkTxNum(cliCtx *cli.Context) error {
-	logger, _, _, _, err := debug.Setup(cliCtx, true /* rootLogger */)
+	logger, err := debug.SetupSimple(cliCtx, true /* rootLogger */)
 	if err != nil {
 		return err
 	}
@@ -1944,7 +1944,7 @@ func doMeta(cliCtx *cli.Context) error {
 }
 
 func doDecompressSpeed(cliCtx *cli.Context) error {
-	logger, _, _, _, err := debug.Setup(cliCtx, true /* rootLogger */)
+	logger, err := debug.SetupSimple(cliCtx, true /* rootLogger */)
 	if err != nil {
 		return err
 	}
@@ -1984,7 +1984,7 @@ func doDecompressSpeed(cliCtx *cli.Context) error {
 }
 
 func doIndicesCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
-	logger, _, _, _, err := debug.Setup(cliCtx, true /* rootLogger */)
+	logger, err := debug.SetupSimple(cliCtx, true /* rootLogger */)
 	if err != nil {
 		return err
 	}
@@ -2036,7 +2036,7 @@ func doIndicesCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 	return nil
 }
 func doLS(cliCtx *cli.Context, dirs datadir.Dirs) error {
-	logger, _, _, _, err := debug.Setup(cliCtx, true /* rootLogger */)
+	logger, err := debug.SetupSimple(cliCtx, true /* rootLogger */)
 	if err != nil {
 		return err
 	}
@@ -2169,7 +2169,7 @@ func doUncompress(cliCtx *cli.Context) error {
 	}
 	defer l.Unlock()
 	var logger log.Logger
-	if logger, _, _, _, err = debug.Setup(cliCtx, true /* rootLogger */); err != nil {
+	if logger, err = debug.SetupSimple(cliCtx, true /* rootLogger */); err != nil {
 		return err
 	}
 	ctx := cliCtx.Context
@@ -2233,7 +2233,7 @@ func doCompress(cliCtx *cli.Context) error {
 	}
 	defer lck.Unlock()
 
-	logger, _, _, _, err := debug.Setup(cliCtx, true /* rootLogger */)
+	logger, err := debug.SetupSimple(cliCtx, true /* rootLogger */)
 	if err != nil {
 		return err
 	}
@@ -2339,7 +2339,7 @@ func doCompress(cliCtx *cli.Context) error {
 }
 
 func doRemoveOverlap(cliCtx *cli.Context, dirs datadir.Dirs) error {
-	logger, _, _, _, err := debug.Setup(cliCtx, true /* rootLogger */)
+	logger, err := debug.SetupSimple(cliCtx, true /* rootLogger */)
 	if err != nil {
 		return err
 	}
@@ -2362,7 +2362,7 @@ func doRemoveOverlap(cliCtx *cli.Context, dirs datadir.Dirs) error {
 }
 
 func doUnmerge(cliCtx *cli.Context, dirs datadir.Dirs) error {
-	logger, _, _, _, err := debug.Setup(cliCtx, true /* rootLogger */)
+	logger, err := debug.SetupSimple(cliCtx, true /* rootLogger */)
 	if err != nil {
 		return err
 	}
@@ -2497,7 +2497,7 @@ func doUnmerge(cliCtx *cli.Context, dirs datadir.Dirs) error {
 }
 
 func doRetireCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
-	logger, _, _, _, err := debug.Setup(cliCtx, true /* rootLogger */)
+	logger, err := debug.SetupSimple(cliCtx, true /* rootLogger */)
 	if err != nil {
 		return err
 	}
@@ -2636,7 +2636,7 @@ func doRetireCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 func doCompareIdx(cliCtx *cli.Context) error {
 	// doesn't compare exact hashes offset,
 	// only sizes, counts, offsets, and ordinal lookups.
-	logger, _, _, _, err := debug.Setup(cliCtx, true /* root logger */)
+	logger, err := debug.SetupSimple(cliCtx, true /* root logger */)
 	if err != nil {
 		return err
 	}

--- a/cmd/utils/app/squeeze_cmd.go
+++ b/cmd/utils/app/squeeze_cmd.go
@@ -56,7 +56,7 @@ func doSqueeze(cliCtx *cli.Context) error {
 		return err
 	}
 	defer l.Unlock()
-	logger, _, _, _, err := debug.Setup(cliCtx, true /* rootLogger */)
+	logger, err := debug.SetupSimple(cliCtx, true /* rootLogger */)
 	if err != nil {
 		return err
 	}

--- a/cmd/utils/app/step_cmd.go
+++ b/cmd/utils/app/step_cmd.go
@@ -21,7 +21,7 @@ import (
 )
 
 func stepRebase(cliCtx *cli.Context) error {
-	logger, _, _, _, err := debug.Setup(cliCtx, true /* root logger */)
+	logger, err := debug.SetupSimple(cliCtx, true /* root logger */)
 	if err != nil {
 		return err
 	}

--- a/cmd/utils/app/support_cmd.go
+++ b/cmd/utils/app/support_cmd.go
@@ -79,7 +79,7 @@ var supportCommand = cli.Command{
 	Usage:     "Connect Erigon instance to a diagnostics system for support",
 	ArgsUsage: "--diagnostics.addr <URL for the diagnostics system> --ids <diagnostic session ids allowed to connect> --metrics.urls <http://erigon_host:metrics_port>",
 	Before: func(cliCtx *cli.Context) error {
-		_, _, _, _, err := debug.Setup(cliCtx, true /* rootLogger */)
+		_, err := debug.SetupSimple(cliCtx, true /* rootLogger */)
 		if err != nil {
 			return err
 		}

--- a/node/debug/flags.go
+++ b/node/debug/flags.go
@@ -291,7 +291,7 @@ func Setup(ctx *cli.Context, rootLogger bool) (log.Logger, *tracers.Tracer, *htt
 	}
 
 	if metricsEnabled || pprofEnabled {
-		torrentMsg := fmt.Sprintf("curl -s http://%s%s > torrentStatus.txt", torrentClientStatusAddr, downloader.TorrentClientStatusPath)
+		torrentMsg := fmt.Sprintf("curl -fSs http://%s%s > torrentStatus.txt", torrentClientStatusAddr, downloader.TorrentClientStatusPath)
 		log.Info("To get torrent client status", "command", torrentMsg)
 	}
 
@@ -321,6 +321,12 @@ func Setup(ctx *cli.Context, rootLogger bool) (log.Logger, *tracers.Tracer, *htt
 	}
 
 	return logger, tracer, metricsMux, pprofMux, nil
+}
+
+// SetupSimple is like Setup but only returns the logger, discarding the tracer and muxes.
+func SetupSimple(ctx *cli.Context, rootLogger bool) (log.Logger, error) {
+	logger, _, _, _, err := Setup(ctx, rootLogger)
+	return logger, err
 }
 
 func StartPProf(address string, metricsMux *http.ServeMux) *http.ServeMux {


### PR DESCRIPTION
As part of trying to figure out why I couldn't debug https://github.com/erigontech/erigon/issues/18348#issuecomment-3845318803.

Specifically if the debug muxes aren't configured correctly, curl would silently fail to fetch the downloader torrent client status.