### PR TITLE
[r33] txnprovider/shutter: fix decryption keys processing when keys do not follow txnIndex order (#18951)

### DIFF
--- a/txnprovider/shutter/decryption_keys_processor.go
+++ b/txnprovider/shutter/decryption_keys_processor.go
@@ -19,7 +19,6 @@
 package shutter
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -150,9 +149,11 @@ func (dkp *DecryptionKeysProcessor) process(msg *proto.DecryptionKeys) error {
 		return err
 	}
 
-	txnIndexToKey := make(map[TxnIndex]*proto.Key, len(keys))
-	for i, key := range keys {
-		txnIndexToKey[from+TxnIndex(i)] = key
+	ipToKey := make(map[IdentityPreimage]*proto.Key, len(keys))
+	for _, key := range keys {
+		// note keys that have reached here are validated by NewDecryptionKeysExtendedValidator,
+		// so it is safe to cast directly without validating
+		ipToKey[IdentityPreimage(key.IdentityPreimage)] = key
 	}
 
 	var eg errgroup.Group
@@ -162,7 +163,7 @@ func (dkp *DecryptionKeysProcessor) process(msg *proto.DecryptionKeys) error {
 	var totalBytes atomic.Int64
 	for i, encryptedTxn := range encryptedTxns {
 		eg.Go(func() error {
-			txn, err := dkp.decryptTxn(txnIndexToKey, encryptedTxn)
+			txn, err := dkp.decryptTxn(ipToKey, encryptedTxn)
 			if err != nil {
 				dkp.logger.Debug(
 					"failed to decrypt transaction - skipping",
@@ -222,21 +223,17 @@ func (dkp *DecryptionKeysProcessor) process(msg *proto.DecryptionKeys) error {
 	return nil
 }
 
-func (dkp *DecryptionKeysProcessor) decryptTxn(keys map[TxnIndex]*proto.Key, sub EncryptedTxnSubmission) (types.Transaction, error) {
-	dkp.logger.Debug("decrypting txn", "txnIndex", sub.TxnIndex)
-	key, ok := keys[sub.TxnIndex]
+func (dkp *DecryptionKeysProcessor) decryptTxn(keys map[IdentityPreimage]*proto.Key, sub EncryptedTxnSubmission) (types.Transaction, error) {
+	submissionIp := sub.IdentityPreimage()
+	dkp.logger.Debug("decrypting txn", "txnIndex", sub.TxnIndex, "ip", submissionIp)
+	key, ok := keys[*submissionIp]
 	if !ok {
-		return nil, fmt.Errorf("key not found for txn index %d", sub.TxnIndex)
+		return nil, fmt.Errorf("decryption key not found for txn: index=%d, ip=%s", sub.TxnIndex, submissionIp)
 	}
 
 	epochSecretKey, err := EpochSecretKeyFromBytes(key.Key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode epoch secret key during txn decryption: %w", err)
-	}
-
-	submissionIdentityPreimage := sub.IdentityPreimageBytes()
-	if !bytes.Equal(key.IdentityPreimage, submissionIdentityPreimage) {
-		return nil, identityPreimageMismatchErr(key.IdentityPreimage, submissionIdentityPreimage)
 	}
 
 	encryptedMessage := new(shuttercrypto.EncryptedMessage)
@@ -349,26 +346,6 @@ func (dkp *DecryptionKeysProcessor) processBlockEventCleanup(blockEvent BlockEve
 	}
 
 	return nil
-}
-
-func identityPreimageMismatchErr(keyIpBytes, submissionIpBytes []byte) error {
-	err := errors.New("identity preimage mismatch")
-
-	keyIp, ipErr := IdentityPreimageFromBytes(keyIpBytes)
-	if ipErr != nil {
-		err = fmt.Errorf("%w: keyIp=%s", err, ipErr)
-	} else {
-		err = fmt.Errorf("%w: keyIp=%s", err, keyIp)
-	}
-
-	submissionIp, ipErr := IdentityPreimageFromBytes(submissionIpBytes)
-	if ipErr != nil {
-		err = fmt.Errorf("%w: submissionIp=%s", err, ipErr)
-	} else {
-		err = fmt.Errorf("%w: submissionIp=%s", err, submissionIp)
-	}
-
-	return err
 }
 
 type ProcessedMark struct {

--- a/txnprovider/shutter/encrypted_txn_submission.go
+++ b/txnprovider/shutter/encrypted_txn_submission.go
@@ -38,8 +38,8 @@ type EncryptedTxnSubmission struct {
 	BlockNum             uint64
 }
 
-func (ets EncryptedTxnSubmission) IdentityPreimageBytes() []byte {
-	return IdentityPreimageFromSenderPrefix(ets.IdentityPrefix, ets.Sender)[:]
+func (ets EncryptedTxnSubmission) IdentityPreimage() *IdentityPreimage {
+	return IdentityPreimageFromSenderPrefix(ets.IdentityPrefix, ets.Sender)
 }
 
 func EncryptedTxnSubmissionFromLogEvent(event *contracts.SequencerTransactionSubmitted) EncryptedTxnSubmission {

--- a/txnprovider/shutter/pool_test.go
+++ b/txnprovider/shutter/pool_test.go
@@ -56,6 +56,7 @@ import (
 	"github.com/erigontech/erigon/txnprovider/shutter/shuttercfg"
 )
 
+//goland:noinspection DuplicatedCode
 func TestPoolCleanup(t *testing.T) {
 	t.Parallel()
 	pt := PoolTest{t}
@@ -123,6 +124,7 @@ func TestPoolCleanup(t *testing.T) {
 
 func TestPoolCleanupShouldNotDeleteNewEncTxnsDueToConsecutiveEmptyDecrMsgs(t *testing.T) {
 	/*
+		see https://github.com/erigontech/erigon/issues/18263
 		Reproduces the following bug:
 			1. we were getting decryption key messages for our slots with 0 keys for transactions (valid behaviour when no transactions to decrypt)
 			2. we got an encrypted txn submission at block 19,182,545
@@ -196,6 +198,7 @@ func TestPoolCleanupShouldNotDeleteNewEncTxnsDueToConsecutiveEmptyDecrMsgs(t *te
 	})
 }
 
+//goland:noinspection DuplicatedCode
 func TestPoolSkipsBlobTxns(t *testing.T) {
 	t.Parallel()
 	pt := PoolTest{t}
@@ -242,6 +245,7 @@ func TestPoolSkipsBlobTxns(t *testing.T) {
 	})
 }
 
+//goland:noinspection DuplicatedCode
 func TestPoolProvideTxnsUsesGasTargetAndTxnsIdFilter(t *testing.T) {
 	t.Parallel()
 	pt := PoolTest{t}
@@ -298,6 +302,47 @@ func TestPoolProvideTxnsUsesGasTargetAndTxnsIdFilter(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, txnsRes2, 1)
 		require.Equal(t, 2, txnsIdFilter.Cardinality())
+	})
+}
+
+//goland:noinspection DuplicatedCode
+func TestPoolWithDecryptionKeysThatDoNotFollowTxnIndexOrder(t *testing.T) {
+	// see https://github.com/erigontech/erigon/issues/18780
+	t.Parallel()
+	pt := PoolTest{t}
+	pt.Run(func(ctx context.Context, t *testing.T, pool *shutter.Pool, handle PoolTestHandle) {
+		// simulate expected contract calls for reading the first ekg after the first block event
+		ekg, err := testhelpers.MockEonKeyGeneration(shutter.EonIndex(0), 1, 2, 1)
+		require.NoError(t, err)
+		handle.SimulateInitialEonRead(t, ekg)
+		// simulate loadSubmissions after the first block
+		handle.SimulateFilterLogs(common.HexToAddress(handle.config.SequencerContractAddress), []types.Log{})
+		// simulate the first block
+		err = handle.SimulateNewBlockChange(ctx)
+		require.NoError(t, err)
+		synctest.Wait()
+		require.Len(t, pool.AllEncryptedTxns(), 0)
+		require.Len(t, pool.AllDecryptedTxns(), 0)
+		// simulate some encrypted txn submissions and simulate a new block
+		encTxn1 := MockEncryptedTxn(t, handle.config.ChainId, ekg.Eon())
+		encTxn2 := MockEncryptedTxn(t, handle.config.ChainId, ekg.Eon())
+		err = handle.SimulateLogEvents(ctx, []types.Log{
+			MockTxnSubmittedEventLog(t, handle.config, ekg.Eon(), 1, encTxn1),
+			MockTxnSubmittedEventLog(t, handle.config, ekg.Eon(), 2, encTxn2),
+		})
+		require.NoError(t, err)
+		handle.SimulateCachedEonRead(t, ekg)
+		err = handle.SimulateNewBlockChange(ctx)
+		require.NoError(t, err)
+		synctest.Wait()
+		require.Len(t, pool.AllEncryptedTxns(), 2)
+		require.Len(t, pool.AllDecryptedTxns(), 0)
+		// simulate decryption keys but in reverse order
+		handle.SimulateCurrentSlot()
+		handle.SimulateDecryptionKeys(ctx, t, ekg, 1, encTxn2.IdentityPreimage, encTxn1.IdentityPreimage)
+		synctest.Wait()
+		require.Len(t, pool.AllEncryptedTxns(), 2)
+		require.Len(t, pool.AllDecryptedTxns(), 2)
 	})
 }
 
@@ -847,6 +892,7 @@ func MockTxnSubmittedEventData(
 	return data
 }
 
+//goland:noinspection DuplicatedCode
 func MockEncryptedTxn(t *testing.T, chainId *uint256.Int, eon shutter.Eon) testhelpers.EncryptedSubmission {
 	senderPrivKey, err := crypto.GenerateKey()
 	require.NoError(t, err)
@@ -885,6 +931,7 @@ func MockEncryptedTxn(t *testing.T, chainId *uint256.Int, eon shutter.Eon) testh
 	}
 }
 
+//goland:noinspection DuplicatedCode
 func MockEncryptedBlobTxn(t *testing.T, chainId *uint256.Int, eon shutter.Eon) testhelpers.EncryptedSubmission {
 	senderPrivKey, err := crypto.GenerateKey()
 	require.NoError(t, err)


### PR DESCRIPTION
cherry-pick of https://github.com/erigontech/erigon/pull/18951 