### PR TITLE
handle edge case for genesis block in SeekCommitment

### DIFF
--- a/execution/commitment/commitmentdb/commitment_context.go
+++ b/execution/commitment/commitmentdb/commitment_context.go
@@ -501,7 +501,10 @@ func (sdc *SharedDomainsCommitmentContext) SeekCommitment(ctx context.Context, t
 	}
 	if len(bnBytes) == 8 {
 		blockNum = binary.BigEndian.Uint64(bnBytes)
-		txNum, err = rawdbv3.TxNums.Max(ctx, tx, blockNum)
+		txNum = uint64(0)
+		if blockNum > 0 {
+			txNum, err = rawdbv3.TxNums.Max(ctx, tx, blockNum)
+		}
 		if err != nil {
 			return 0, 0, false, err
 		}


### PR DESCRIPTION
**issue:** 

while doing stage_exec from scratch, `SeekCommitment` restores state with (block=0, txNum=1). This skips over the txNum=0 tx, whose processing populates the ibs with genesis information in `TxTask#Execute`. Downstream, this leads to state root mismatch. 

**context:** 

i was doing stage_exec from genesis in gnosis.

**fix** 
- when SyncStageProgress is x, it typically means that block x is executed completely. Except when blockNum = 0, then it could either mean that block executed completely (so restored txnum = 1) or not (restored txnum=0)
- for block=0, we should consider the latter (txnum=0), because if we're doing execution from scratch, it'll typically be with txnum=0. Half block execution of genesis block (i.e. txnum=0 state is processed/persisted, but txnum=1 not) is a hard to reach state.

