### PR TITLE
perf(cl/sentinel): use stack allocation for light_client response prefix

### DIFF
--- a/cl/sentinel/handlers/light_client.go
+++ b/cl/sentinel/handlers/light_client.go
@@ -36,12 +36,14 @@ func (c *ConsensusHandlers) optimisticLightClientUpdateHandler(s network.Stream)
 		return err
 	}
 
-	prefix := append([]byte{SuccessfulResponsePrefix}, forkDigest[:]...)
+	var prefix [5]byte
+	prefix[0] = SuccessfulResponsePrefix
+	copy(prefix[1:], forkDigest[:])
 	return ssz_snappy.EncodeAndWrite(s, &cltypes.LightClientOptimisticUpdate{
 		AttestedHeader: lc.AttestedHeader,
 		SyncAggregate:  lc.SyncAggregate,
 		SignatureSlot:  lc.SignatureSlot,
-	}, prefix...)
+	}, prefix[:]...)
 }
 
 func (c *ConsensusHandlers) finalityLightClientUpdateHandler(s network.Stream) error {
@@ -54,14 +56,16 @@ func (c *ConsensusHandlers) finalityLightClientUpdateHandler(s network.Stream) e
 	if err != nil {
 		return err
 	}
-	prefix := append([]byte{SuccessfulResponsePrefix}, forkDigest[:]...)
+	var prefix [5]byte
+	prefix[0] = SuccessfulResponsePrefix
+	copy(prefix[1:], forkDigest[:])
 	return ssz_snappy.EncodeAndWrite(s, &cltypes.LightClientFinalityUpdate{
 		AttestedHeader:  lc.AttestedHeader,
 		SyncAggregate:   lc.SyncAggregate,
 		FinalizedHeader: lc.FinalizedHeader,
 		FinalityBranch:  lc.FinalityBranch,
 		SignatureSlot:   lc.SignatureSlot,
-	}, prefix...)
+	}, prefix[:]...)
 }
 
 func (c *ConsensusHandlers) lightClientBootstrapHandler(s network.Stream) error {
@@ -80,8 +84,10 @@ func (c *ConsensusHandlers) lightClientBootstrapHandler(s network.Stream) error 
 		return err
 	}
 
-	prefix := append([]byte{SuccessfulResponsePrefix}, forkDigest[:]...)
-	return ssz_snappy.EncodeAndWrite(s, lc, prefix...)
+	var prefix [5]byte
+	prefix[0] = SuccessfulResponsePrefix
+	copy(prefix[1:], forkDigest[:])
+	return ssz_snappy.EncodeAndWrite(s, lc, prefix[:]...)
 }
 
 func (c *ConsensusHandlers) lightClientUpdatesByRangeHandler(s network.Stream) error {

--- a/cl/sentinel/handlers/light_client_test.go
+++ b/cl/sentinel/handlers/light_client_test.go
@@ -400,3 +400,28 @@ func TestLightClientUpdates(t *testing.T) {
 	}
 
 }
+
+// BenchmarkLightClientPrefixConstruction benchmarks the prefix construction
+// for light client responses, comparing the optimized version (stack allocation)
+// against the old version (heap allocation with append).
+func BenchmarkLightClientPrefixConstruction(b *testing.B) {
+	forkDigest := common.Bytes4{0xAA, 0xBB, 0xCC, 0xDD}
+
+	b.Run("Optimized", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			var prefix [5]byte
+			prefix[0] = SuccessfulResponsePrefix
+			copy(prefix[1:], forkDigest[:])
+			_ = prefix
+		}
+	})
+
+	b.Run("Old", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			prefix := append([]byte{SuccessfulResponsePrefix}, forkDigest[:]...)
+			_ = prefix
+		}
+	})
+}


### PR DESCRIPTION
Replace heap-allocated slice with stack-allocated array for prefix construction, eliminating allocation overhead in light client handlers.

Benchmark results:
<img width="1074" height="278" alt="image" src="https://github.com/user-attachments/assets/3bc5a6d8-6103-4687-a21d-ff67cced633d" />
