### PR TITLE
rpc: fix timeout param in eth_sendRawTransactionSync

### DIFF
--- a/execution/tests/send_raw_transaction_sync_test.go
+++ b/execution/tests/send_raw_transaction_sync_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/node/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon/txnprovider/txpool/txpoolcfg"
 	"github.com/stretchr/testify/require"
@@ -55,7 +54,7 @@ func TestSendRawTransactionSync(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		timeoutMillis := hexutil.Uint64(10000)
+		timeoutMillis := uint64(10000)
 		receipt, errSend = eat.RpcApiClient.SendRawTransactionSync(tx, &timeoutMillis)
 	}()
 
@@ -97,7 +96,7 @@ func TestSendRawTransactionSyncTimeout(t *testing.T) {
 	assert.NoError(err)
 
 	// Send the txn first time and just wait for timeout
-	timeoutMillis := hexutil.Uint64(100)
+	timeoutMillis := uint64(100)
 	receipt, err := eat.RpcApiClient.SendRawTransactionSync(tx, &timeoutMillis)
 	assert.Error(err)
 	assert.Equal("the transaction was added to the mempool but wasn't processed in 100ms", err.Error())

--- a/rpc/jsonrpc/eth_api.go
+++ b/rpc/jsonrpc/eth_api.go
@@ -108,7 +108,7 @@ type EthAPI interface {
 	Call(ctx context.Context, args ethapi.CallArgs, blockNrOrHash *rpc.BlockNumberOrHash, overrides *ethapi.StateOverrides, blockOverrides *ethapi.BlockOverrides) (hexutil.Bytes, error)
 	EstimateGas(ctx context.Context, argsOrNil *ethapi.CallArgs, blockNrOrHash *rpc.BlockNumberOrHash, overrides *ethapi.StateOverrides, blockOverrides *ethapi.BlockOverrides) (hexutil.Uint64, error)
 	SendRawTransaction(ctx context.Context, encodedTx hexutil.Bytes) (common.Hash, error)
-	SendRawTransactionSync(ctx context.Context, encodedTx hexutil.Bytes, timeoutMs *hexutil.Uint64) (map[string]any, error)
+	SendRawTransactionSync(ctx context.Context, encodedTx hexutil.Bytes, timeoutMs *uint64) (map[string]any, error)
 	SendTransaction(_ context.Context, txObject any) (common.Hash, error)
 	Sign(ctx context.Context, _ common.Address, _ hexutil.Bytes) (hexutil.Bytes, error)
 	SignTransaction(_ context.Context, txObject any) (common.Hash, error)

--- a/rpc/jsonrpc/send_transaction.go
+++ b/rpc/jsonrpc/send_transaction.go
@@ -71,7 +71,7 @@ func (api *APIImpl) SendRawTransaction(ctx context.Context, encodedTx hexutil.By
 
 // SendRawTransactionSync implements eth_sendRawTransactionSync (https://eips.ethereum.org/EIPS/eip-7966).
 // Creates a new message call or contract creation for a previously signed transaction waiting for the transaction to be processed and the receipt to be available.
-func (api *APIImpl) SendRawTransactionSync(ctx context.Context, encodedTx hexutil.Bytes, timeoutMs *hexutil.Uint64) (map[string]any, error) {
+func (api *APIImpl) SendRawTransactionSync(ctx context.Context, encodedTx hexutil.Bytes, timeoutMs *uint64) (map[string]any, error) {
 	// If timeout is not specified or zero, we use the default, otherwise we use the passed one capped by max.
 	timeout := api.RpcTxSyncDefaultTimeout
 	if timeoutMs != nil && *timeoutMs > 0 {

--- a/rpc/requests/request_generator.go
+++ b/rpc/requests/request_generator.go
@@ -78,7 +78,7 @@ type RequestGenerator interface {
 	GetTransactionCount(address common.Address, blockRef rpc.BlockReference) (*big.Int, error)
 	BlockNumber() (uint64, error)
 	SendTransaction(signedTx types.Transaction) (common.Hash, error)
-	SendRawTransactionSync(signedTx types.Transaction, timeoutMs *hexutil.Uint64) (*types.Receipt, error)
+	SendRawTransactionSync(signedTx types.Transaction, timeoutMs *uint64) (*types.Receipt, error)
 	FilterLogs(ctx context.Context, query ethereum.FilterQuery) ([]types.Log, error)
 	SubscribeFilterLogs(ctx context.Context, query ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error)
 	Subscribe(ctx context.Context, method SubMethod, subChan any, args ...any) (ethereum.Subscription, error)

--- a/rpc/requests/transaction.go
+++ b/rpc/requests/transaction.go
@@ -159,7 +159,7 @@ func (reqGen *requestGenerator) SendTransaction(signedTx types.Transaction) (com
 	return result, nil
 }
 
-func (reqGen *requestGenerator) SendRawTransactionSync(signedTx types.Transaction, timeoutMs *hexutil.Uint64) (*types.Receipt, error) {
+func (reqGen *requestGenerator) SendRawTransactionSync(signedTx types.Transaction, timeoutMs *uint64) (*types.Receipt, error) {
 	var result *types.Receipt
 
 	var buf bytes.Buffer


### PR DESCRIPTION
As per [spec](https://eips.ethereum.org/EIPS/eip-7966#parameters), optional `timeout` parameter must be integer