### PR TITLE
db/preverified: remove redundant assertSorted in Get

### DIFF
--- a/db/preverified/preverified.go
+++ b/db/preverified/preverified.go
@@ -36,7 +36,6 @@ func preverifiedItemCompare(a, b Item) int {
 }
 
 func (me SortedItems) Get(name string) (item Item, found bool) {
-	me.assertSorted()
 	i, found := me.searchName(name)
 	if found {
 		item = me[i]


### PR DESCRIPTION
SortedItems.Get was calling assertSorted directly and then calling searchName, which also invokes assertSorted, resulting in two O(n) sortedness checks per lookup without adding extra safety.
This change removes the direct assertSorted call from Get and keeps the invariant check centralized inside searchName.