### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -122,9 +122,9 @@ type TxSyncTimeoutError struct {
 	Hash common.Hash
 }
 
-func (e *TxSyncTimeoutError) Error() string          { return e.Msg }
-func (e *TxSyncTimeoutError) ErrorCode() int         { return ErrCodeTxSyncTimeout }
-func (e *TxSyncTimeoutError) ErrorData() interface{} { return e.Hash.Hex() }
+func (e *TxSyncTimeoutError) Error() string  { return e.Msg }
+func (e *TxSyncTimeoutError) ErrorCode() int { return ErrCodeTxSyncTimeout }
+func (e *TxSyncTimeoutError) ErrorData() any { return e.Hash.Hex() }
 
 type CustomError struct {
 	Code    int

--- a/rpc/mcp/handlers_logs.go
+++ b/rpc/mcp/handlers_logs.go
@@ -246,7 +246,7 @@ func grepLog(filename, pattern string, maxLines int, caseInsensitive bool) ([]st
 }
 
 // getLogStats returns statistics about a log file
-func getLogStats(filename string) (map[string]interface{}, error) {
+func getLogStats(filename string) (map[string]any, error) {
 	file, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -284,7 +284,7 @@ func getLogStats(filename string) (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	stats := map[string]interface{}{
+	stats := map[string]any{
 		"file_name":    filepath.Base(filename),
 		"file_size":    fileInfo.Size(),
 		"file_size_mb": float64(fileInfo.Size()) / (1024 * 1024),

--- a/rpc/mcp/mcp_test.go
+++ b/rpc/mcp/mcp_test.go
@@ -10,7 +10,7 @@ import (
 func TestToJSONText(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    interface{}
+		input    any
 		expected string
 	}{
 		{
@@ -149,8 +149,8 @@ func TestMCPServerCreation(t *testing.T) {
 
 func TestJSONMarshaling(t *testing.T) {
 	// Test that our utility functions work with complex nested structures
-	complexData := map[string]interface{}{
-		"block": map[string]interface{}{
+	complexData := map[string]any{
+		"block": map[string]any{
 			"number":     12345,
 			"hash":       "0xabcdef",
 			"timestamp":  1234567890,
@@ -165,14 +165,14 @@ func TestJSONMarshaling(t *testing.T) {
 	result := toJSONText(complexData)
 
 	// Verify it's valid JSON
-	var parsed map[string]interface{}
+	var parsed map[string]any
 	err := json.Unmarshal([]byte(result), &parsed)
 	if err != nil {
 		t.Errorf("toJSONText produced invalid JSON: %v", err)
 	}
 
 	// Verify structure is preserved
-	if block, ok := parsed["block"].(map[string]interface{}); ok {
+	if block, ok := parsed["block"].(map[string]any); ok {
 		if number, ok := block["number"].(float64); !ok || number != 12345 {
 			t.Errorf("Block number not preserved correctly")
 		}

--- a/rpc/mcp/metrics/gather.go
+++ b/rpc/mcp/metrics/gather.go
@@ -26,13 +26,13 @@ func ListMetricNames() ([]string, error) {
 // GatherMetricsFiltered gathers metrics from the Prometheus default registry
 // with optional filtering by metric name pattern (supports wildcards like "db_*" or "*_size").
 // If pattern is empty, returns all metrics.
-func GatherMetricsFiltered(pattern string) (map[string]interface{}, error) {
+func GatherMetricsFiltered(pattern string) (map[string]any, error) {
 	metricFamilies, err := prometheus.DefaultGatherer.Gather()
 	if err != nil {
 		return nil, fmt.Errorf("failed to gather metrics: %w", err)
 	}
 
-	result := make(map[string]interface{})
+	result := make(map[string]any)
 
 	for _, mf := range metricFamilies {
 		if mf == nil || mf.Name == nil {
@@ -47,10 +47,10 @@ func GatherMetricsFiltered(pattern string) (map[string]interface{}, error) {
 		}
 
 		metricType := mf.Type.String()
-		metrics := make([]map[string]interface{}, 0, len(mf.Metric))
+		metrics := make([]map[string]any, 0, len(mf.Metric))
 
 		for _, m := range mf.Metric {
-			metricData := make(map[string]interface{})
+			metricData := make(map[string]any)
 
 			// Add labels
 			if len(m.Label) > 0 {
@@ -75,7 +75,7 @@ func GatherMetricsFiltered(pattern string) (map[string]interface{}, error) {
 				}
 			case dto.MetricType_HISTOGRAM:
 				if m.Histogram != nil {
-					histData := make(map[string]interface{})
+					histData := make(map[string]any)
 					if m.Histogram.SampleCount != nil {
 						histData["sample_count"] = *m.Histogram.SampleCount
 					}
@@ -83,9 +83,9 @@ func GatherMetricsFiltered(pattern string) (map[string]interface{}, error) {
 						histData["sample_sum"] = *m.Histogram.SampleSum
 					}
 					if len(m.Histogram.Bucket) > 0 {
-						buckets := make([]map[string]interface{}, 0, len(m.Histogram.Bucket))
+						buckets := make([]map[string]any, 0, len(m.Histogram.Bucket))
 						for _, bucket := range m.Histogram.Bucket {
-							b := make(map[string]interface{})
+							b := make(map[string]any)
 							if bucket.UpperBound != nil {
 								b["upper_bound"] = *bucket.UpperBound
 							}
@@ -100,7 +100,7 @@ func GatherMetricsFiltered(pattern string) (map[string]interface{}, error) {
 				}
 			case dto.MetricType_SUMMARY:
 				if m.Summary != nil {
-					summaryData := make(map[string]interface{})
+					summaryData := make(map[string]any)
 					if m.Summary.SampleCount != nil {
 						summaryData["sample_count"] = *m.Summary.SampleCount
 					}
@@ -108,9 +108,9 @@ func GatherMetricsFiltered(pattern string) (map[string]interface{}, error) {
 						summaryData["sample_sum"] = *m.Summary.SampleSum
 					}
 					if len(m.Summary.Quantile) > 0 {
-						quantiles := make([]map[string]interface{}, 0, len(m.Summary.Quantile))
+						quantiles := make([]map[string]any, 0, len(m.Summary.Quantile))
 						for _, quantile := range m.Summary.Quantile {
-							q := make(map[string]interface{})
+							q := make(map[string]any)
 							if quantile.Quantile != nil {
 								q["quantile"] = *quantile.Quantile
 							}
@@ -137,7 +137,7 @@ func GatherMetricsFiltered(pattern string) (map[string]interface{}, error) {
 			metrics = append(metrics, metricData)
 		}
 
-		result[metricName] = map[string]interface{}{
+		result[metricName] = map[string]any{
 			"type":    metricType,
 			"help":    getStringPtr(mf.Help),
 			"metrics": metrics,
@@ -185,7 +185,7 @@ func matchPattern(pattern, name string) bool {
 
 // GatherMetrics gathers all metrics from the Prometheus default registry
 // and returns them as a structured map for MCP consumption.
-func GatherMetrics() (map[string]interface{}, error) {
+func GatherMetrics() (map[string]any, error) {
 	return GatherMetricsFiltered("")
 }
 

--- a/rpc/mcp/metrics/gather_test.go
+++ b/rpc/mcp/metrics/gather_test.go
@@ -115,7 +115,7 @@ func TestGatherMetrics(t *testing.T) {
 
 	// Check counter
 	if counterData, ok := metrics["test_mcp_gather_counter"]; ok {
-		counterMap := counterData.(map[string]interface{})
+		counterMap := counterData.(map[string]any)
 		if counterMap["type"] != "COUNTER" {
 			t.Errorf("Counter type = %v, want COUNTER", counterMap["type"])
 		}
@@ -125,7 +125,7 @@ func TestGatherMetrics(t *testing.T) {
 
 	// Check gauge
 	if gaugeData, ok := metrics["test_mcp_gather_gauge"]; ok {
-		gaugeMap := gaugeData.(map[string]interface{})
+		gaugeMap := gaugeData.(map[string]any)
 		if gaugeMap["type"] != "GAUGE" {
 			t.Errorf("Gauge type = %v, want GAUGE", gaugeMap["type"])
 		}

--- a/rpc/mcp/resources.go
+++ b/rpc/mcp/resources.go
@@ -115,7 +115,7 @@ func (e *ErigonMCPServer) handleResourceChainConfig(ctx context.Context, req mcp
 		mcp.TextResourceContents{
 			URI:      "erigon://chain/config",
 			MIMEType: "application/json",
-			Text: toJSONText(map[string]interface{}{
+			Text: toJSONText(map[string]any{
 				"current_block": blockNum,
 				"note":          "Chain config details would come from Erigon's chain spec",
 			}),
@@ -130,7 +130,7 @@ func (e *ErigonMCPServer) handleResourceRecentBlocks(ctx context.Context, req mc
 		return nil, err
 	}
 
-	blocks := make([]interface{}, 0, 10)
+	blocks := make([]any, 0, 10)
 	for i := 0; i < 10; i++ {
 		blockNum := currentBlock - hexutil.Uint64(i)
 		block, err := e.ethAPI.GetBlockByNumber(ctx, rpc.BlockNumber(blockNum), false)
@@ -157,7 +157,7 @@ func (e *ErigonMCPServer) handleResourceNetworkStatus(ctx context.Context, req m
 
 	currentBlock, _ := e.ethAPI.BlockNumber(ctx)
 
-	status := map[string]interface{}{
+	status := map[string]any{
 		"node_info":     nodeInfo,
 		"current_block": currentBlock,
 		"syncing":       false, // Would check actual sync status
@@ -181,7 +181,7 @@ func (e *ErigonMCPServer) handleResourceGasInfo(ctx context.Context, req mcp.Rea
 	// Get latest block for base fee
 	block, _ := e.ethAPI.GetBlockByNumber(ctx, rpc.LatestBlockNumber, false)
 
-	gasInfo := map[string]interface{}{
+	gasInfo := map[string]any{
 		"gas_price": gasPrice,
 	}
 	if block != nil {
@@ -207,7 +207,7 @@ func (e *ErigonMCPServer) handleResourceAddressSummary(ctx context.Context, req 
 	nonce, _ := e.ethAPI.GetTransactionCount(ctx, common.HexToAddress(address), rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber))
 	code, _ := e.ethAPI.GetCode(ctx, common.HexToAddress(address), rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber))
 
-	summary := map[string]interface{}{
+	summary := map[string]any{
 		"address":     address,
 		"balance":     balance,
 		"nonce":       nonce,
@@ -254,7 +254,7 @@ func (e *ErigonMCPServer) handleResourceTransactionAnalysis(ctx context.Context,
 	tx, _ := e.ethAPI.GetTransactionByHash(ctx, common.HexToHash(txHash))
 	receipt, _ := e.ethAPI.GetTransactionReceipt(ctx, common.HexToHash(txHash))
 
-	analysis := map[string]interface{}{
+	analysis := map[string]any{
 		"transaction": tx,
 		"receipt":     receipt,
 		"status":      "success", // Would check receipt status


### PR DESCRIPTION
Inspired by https://github.com/erigontech/erigon/pull/18447 and replace more.

This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.

As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.