### PR TITLE
PersistentBlockCollector: assert on inserting gap

### DIFF
--- a/cl/phase1/execution_client/block_collector/persistent_block_collector.go
+++ b/cl/phase1/execution_client/block_collector/persistent_block_collector.go
@@ -159,7 +159,7 @@ func (p *PersistentBlockCollector) Flush(ctx context.Context) error {
 			}
 
 			if prevBlockNum > 0 && block.NumberU64() != prevBlockNum+1 {
-				panic(fmt.Sprintf("assert: PersistentBlockCollector inserting gap: %d -> %d. To fix try: `rm datadir/caplin/history datadir/chaindata`", prevBlockNum, block.NumberU64()))
+				panic(fmt.Sprintf("assert: BlockCollector inserting gap: %d -> %d. To fix try: `rm datadir/caplin/history datadir/chaindata`", prevBlockNum, block.NumberU64()))
 			}
 			prevBlockNum = block.NumberU64()
 			blocksBatch = append(blocksBatch, block)


### PR DESCRIPTION
reason: after `rm datadir/chaindata` 
Can's sync to chain tip - see: 
```
parent's total difficulty not found with hash 29a3136faf8197442a56e24d8840fd969f6edcf2c82fd60532de836cc7c04d15 and height 19753143: <nil>
```
Maybe it happening after next steps:
```
rm datadir/chaindata
erigon seg rm-state --latest --datadir your
```

adding earlier assert:
```
WARN[02-05|12:12:49.597] [BlockCollector] inserting              block=19683386
WARN[02-05|12:12:49.597] [BlockCollector] inserting              block=19684918
panic: BlockCollector inserting gap: 19683386 -> 19684918
```