### PR TITLE
perf(cl/block_collector): optimize encodeBlock buffer allocation

### DIFF
--- a/cl/phase1/execution_client/block_collector/interface.go
+++ b/cl/phase1/execution_client/block_collector/interface.go
@@ -45,11 +45,20 @@ func encodeBlock(payload *cltypes.Eth1Block, parentRoot common.Hash, executionRe
 		// electra version
 		requestsHash := cltypes.ComputeExecutionRequestHash(executionRequestsList)
 		// version + parentRoot + requestsHash + encodedPayload
-		return utils.CompressSnappy(append([]byte{byte(payload.Version())}, append(append(parentRoot[:], requestsHash[:]...), encodedPayload...)...)), nil
+		buf := make([]byte, 1+32+32+len(encodedPayload))
+		buf[0] = byte(payload.Version())
+		copy(buf[1:], parentRoot[:])
+		copy(buf[33:], requestsHash[:])
+		copy(buf[65:], encodedPayload)
+		return utils.CompressSnappy(buf), nil
 	}
 	// Use snappy compression that the temporary files do not take too much disk.
 	// version + parentRoot + encodedPayload
-	return utils.CompressSnappy(append([]byte{byte(payload.Version())}, append(parentRoot[:], encodedPayload...)...)), nil
+	buf := make([]byte, 1+32+len(encodedPayload))
+	buf[0] = byte(payload.Version())
+	copy(buf[1:], parentRoot[:])
+	copy(buf[33:], encodedPayload)
+	return utils.CompressSnappy(buf), nil
 }
 
 // payloadKey returns the key for the payload: number + payload.HashTreeRoot()

--- a/cl/phase1/execution_client/block_collector/interface_bench_test.go
+++ b/cl/phase1/execution_client/block_collector/interface_bench_test.go
@@ -1,0 +1,55 @@
+// Copyright 2024 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package block_collector
+
+import (
+	"testing"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/common"
+)
+
+// BenchmarkEncodeBlockBuffer benchmarks buffer construction in encodeBlock.
+// Compares optimized (pre-allocated) vs old (nested append) approaches.
+func BenchmarkEncodeBlockBuffer(b *testing.B) {
+	version := byte(clparams.DenebVersion)
+	parentRoot := common.HexToHash("0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd")
+	requestsHash := common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+
+	// Typical block size (~100KB)
+	encodedPayload := make([]byte, 100*1024)
+
+	b.Run("Optimized", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			buf := make([]byte, 1+32+32+len(encodedPayload))
+			buf[0] = version
+			copy(buf[1:], parentRoot[:])
+			copy(buf[33:], requestsHash[:])
+			copy(buf[65:], encodedPayload)
+			_ = buf
+		}
+	})
+
+	b.Run("Old", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			buf := append([]byte{version}, append(append(parentRoot[:], requestsHash[:]...), encodedPayload...)...)
+			_ = buf
+		}
+	})
+}


### PR DESCRIPTION
 Replace nested append with pre-allocated buffer in encodeBlock, reducing allocations from 3 to 1 per block.

<img width="1994" height="390" alt="77f9debbe46a6f71fc2b2fd5ebc1a373" src="https://github.com/user-attachments/assets/41314769-7217-45f5-ad7c-76116e039e50" />
