### PR TITLE
[r33] fix(caplin): Fixes for DataColumnSidecar (#18268)

### DIFF
--- a/cl/beacon/beaconevents/model.go
+++ b/cl/beacon/beaconevents/model.go
@@ -37,8 +37,33 @@ type (
 	BlsToExecutionChangesData = cltypes.SignedBLSToExecutionChange
 	ContributionAndProofData  = cltypes.SignedContributionAndProof
 	BlobSidecarData           = cltypes.BlobSidecar
-	DataColumnSidecarData     = cltypes.DataColumnSidecar
 )
+
+// DataColumnSidecarData includes block_root and slot for SSE events
+type DataColumnSidecarData struct {
+	BlockRoot                    common.Hash                            `json:"block_root"`
+	Index                        uint64                                 `json:"index,string"`
+	Slot                         uint64                                 `json:"slot,string"`
+	Column                       *solid.ListSSZ[*cltypes.Cell]          `json:"column"`
+	KzgCommitments               *solid.ListSSZ[*cltypes.KZGCommitment] `json:"kzg_commitments"`
+	KzgProofs                    *solid.ListSSZ[*cltypes.KZGProof]      `json:"kzg_proofs"`
+	SignedBlockHeader            *cltypes.SignedBeaconBlockHeader       `json:"signed_block_header"`
+	KzgCommitmentsInclusionProof solid.HashVectorSSZ                    `json:"kzg_commitments_inclusion_proof"`
+}
+
+// NewDataColumnSidecarData creates a DataColumnSidecarData from a DataColumnSidecar
+func NewDataColumnSidecarData(sidecar *cltypes.DataColumnSidecar) *DataColumnSidecarData {
+	return &DataColumnSidecarData{
+		BlockRoot:                    sidecar.BlockRoot,
+		Index:                        sidecar.Index,
+		Slot:                         sidecar.Slot,
+		Column:                       sidecar.Column,
+		KzgCommitments:               sidecar.KzgCommitments,
+		KzgProofs:                    sidecar.KzgProofs,
+		SignedBlockHeader:            sidecar.SignedBlockHeader,
+		KzgCommitmentsInclusionProof: sidecar.KzgCommitmentsInclusionProof,
+	}
+}
 
 // State event topics
 const (

--- a/cl/beacon/handler/blobs.go
+++ b/cl/beacon/handler/blobs.go
@@ -163,6 +163,8 @@ func (a *ApiHandler) GetEthV1DebugBeaconDataColumnSidecars(w http.ResponseWriter
 			return nil, beaconhttp.NewEndpointError(http.StatusInternalServerError, err)
 		}
 		if sidecar != nil {
+			sidecar.BlockRoot = blockRoot
+			sidecar.Slot = *slot
 			dataColumnSidecars = append(dataColumnSidecars, sidecar)
 		}
 	}

--- a/cl/beacon/handler/handler.go
+++ b/cl/beacon/handler/handler.go
@@ -244,7 +244,7 @@ func (a *ApiHandler) init() {
 
 			if a.routerCfg.Debug {
 				r.Get("/debug/fork_choice", a.GetEthV1DebugBeaconForkChoice)
-				r.Get("/debug/data_column_sidecars/{block_id}", beaconhttp.HandleEndpointFunc(a.GetEthV1DebugBeaconDataColumnSidecars))
+				r.Get("/debug/beacon/data_column_sidecars/{block_id}", beaconhttp.HandleEndpointFunc(a.GetEthV1DebugBeaconDataColumnSidecars))
 			}
 			if a.routerCfg.Config {
 				r.Route("/config", func(r chi.Router) {

--- a/cl/cltypes/column_sidecar.go
+++ b/cl/cltypes/column_sidecar.go
@@ -32,7 +32,9 @@ var (
 )
 
 type DataColumnSidecar struct {
-	Index                        uint64                         `json:"index"` // index of the column
+	BlockRoot                    common.Hash                    `json:"-"`
+	Index                        uint64                         `json:"index,string"` // index of the column
+	Slot                         uint64                         `json:"-"`
 	Column                       *solid.ListSSZ[*Cell]          `json:"column"`
 	KzgCommitments               *solid.ListSSZ[*KZGCommitment] `json:"kzg_commitments"`
 	KzgProofs                    *solid.ListSSZ[*KZGProof]      `json:"kzg_proofs"`
@@ -47,7 +49,10 @@ func NewDataColumnSidecar() *DataColumnSidecar {
 }
 
 func (d *DataColumnSidecar) Clone() clonable.Clonable {
-	newSidecar := &DataColumnSidecar{}
+	newSidecar := &DataColumnSidecar{
+		BlockRoot: d.BlockRoot,
+		Slot:      d.Slot,
+	}
 	newSidecar.tryInit()
 	return newSidecar
 }

--- a/cl/persistence/blob_storage/data_column_db.go
+++ b/cl/persistence/blob_storage/data_column_db.go
@@ -67,6 +67,9 @@ func dataColumnFilePath(slot uint64, blockRoot common.Hash, columnIndex uint64) 
 }
 
 func (s *dataColumnStorageImpl) WriteColumnSidecars(ctx context.Context, blockRoot common.Hash, columnIndex int64, columnData *cltypes.DataColumnSidecar) error {
+	// Ensure BlockRoot and Slot are set (they're not part of SSZ schema)
+	columnData.BlockRoot = blockRoot
+	columnData.Slot = columnData.SignedBlockHeader.Header.Slot
 	lock := s.acquireLock(columnData.SignedBlockHeader.Header.Slot)
 	lock.Lock()
 	defer lock.Unlock()
@@ -95,7 +98,7 @@ func (s *dataColumnStorageImpl) WriteColumnSidecars(ctx context.Context, blockRo
 	}
 
 	fh.Close()
-	s.emitters.Operation().SendDataColumnSidecar(columnData)
+	s.emitters.Operation().SendDataColumnSidecar(beaconevents.NewDataColumnSidecarData(columnData))
 	log.Trace("wrote data column sidecar", "slot", columnData.SignedBlockHeader.Header.Slot, "block_root", blockRoot.String(), "column_index", columnIndex)
 	return nil
 }
@@ -115,6 +118,9 @@ func (s *dataColumnStorageImpl) ReadColumnSidecarByColumnIndex(ctx context.Conte
 	if err := ssz_snappy.DecodeAndReadNoForkDigest(fh, data, version); err != nil {
 		return nil, err
 	}
+	// BlockRoot and Slot are not part of SSZ schema, set them from parameters
+	data.BlockRoot = blockRoot
+	data.Slot = slot
 	return data, nil
 }
 


### PR DESCRIPTION
cherry-pick https://github.com/erigontech/erigon/pull/18268

---

Based on the spec, index should return as a string from the API

[Contributoor](https://github.com/ethpandaops/contributoor) is not working for Caplin because
[attestantio](https://github.com/attestantio/go-eth2-client/blob/v0.27.2/api/v1/datacolumnsidecarevent.go) assumes the index to be a string and panics because it's a integer.

The
[swagger](https://ethereum.github.io/beacon-APIs/#/Debug/getDebugDataColumnSidecars) also says index should be a string.

Additionally, the correct API path for `data_column_sidecars` is `/eth/v1/debug/beacon/data_column_sidecars`

I also added `block_root` and `slot` to the SSE events

Based on my testing caplin now mirrors the behavior of lighthouse, the REST API is matching the swagger/spec, and SSE is mirroring that of lighthouse and nimbus