### PR TITLE
execution/engineapi: fix flaky tests due to engine api tester regression

### DIFF
--- a/execution/engineapi/engine_api_jsonrpc_client.go
+++ b/execution/engineapi/engine_api_jsonrpc_client.go
@@ -103,9 +103,10 @@ func DialJsonRpcClient(url string, jwtSecret []byte, logger log.Logger, opts ...
 		return nil, err
 	}
 	res := &JsonRpcClient{
-		rpcClient:    client,
-		maxRetries:   options.maxRetries,
-		retryBackOff: options.retryBackOff,
+		rpcClient:            client,
+		maxRetries:           options.maxRetries,
+		retryBackOff:         options.retryBackOff,
+		retryableErrCheckers: options.retryableErrCheckers,
 	}
 	return res, nil
 }


### PR DESCRIPTION
fixes flakes like: https://github.com/erigontech/erigon/actions/runs/21738296086/job/62708027554

```
engine_api_tester.go:243: 
        	Error Trace:	/home/runner/work/erigon/erigon/execution/tests/engine_api_tester.go:243
        	            				/home/runner/work/erigon/erigon/execution/tests/engine_api_tester.go:63
        	            				/home/runner/work/erigon/erigon/execution/tests/engine_api_reorg_test.go:40
        	Error:      	Received unexpected error:
        	            	build new payload failed: build new payload: fcu error: Post "http://127.0.0.1:6025/": dial tcp 127.0.0.1:6025: connect: connection refused
        	Test:       	TestEngineApiInvalidPayloadThenValidCanonicalFcuWithPayloadShouldSucceed
```

there is a retry for this race condition, but I accidentally broke it in https://github.com/erigontech/erigon/pull/18921