### PR TITLE
Disable deferred updates during commitment integrity check

### DIFF
--- a/db/integrity/commitment.go
+++ b/db/integrity/commitment.go
@@ -747,6 +747,7 @@ func CheckCommitmentHistAtBlk(ctx context.Context, db kv.TemporalRoDB, br servic
 	}
 	sd.GetCommitmentCtx().SetHistoryStateReader(tx, toTxNum)
 	sd.GetCommitmentCtx().SetTrace(logger.Enabled(ctx, log.LvlTrace))
+	sd.GetCommitmentContext().SetDeferBranchUpdates(false)
 	err = sd.SeekCommitment(ctx, tx) // seek commitment again with new history state reader
 	if err != nil {
 		return err


### PR DESCRIPTION
If not disabled, this error appears:

```
./build/bin/erigon snapshots check-commitment-hist-at-blk --datadir=~/data/eth-mainnet-archive  --block=23575409 

EROR[02-06|13:48:19.570] [check-commitment-hist-at-blk] failure   err="apply deferred updates: MergeHexBranches branch1 is too small: expected at least 457820 got 169 bytes"
Error: apply deferred updates: MergeHexBranches branch1 is too small: expected at least 457820 got 169 bytes
```