### PR TITLE
rpc: increase TestSendRawTransactionSync timeout in race tests

### DIFF
--- a/execution/tests/send_raw_transaction_sync_test.go
+++ b/execution/tests/send_raw_transaction_sync_test.go
@@ -54,7 +54,7 @@ func TestSendRawTransactionSync(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		timeoutMillis := uint64(60000)
+		timeoutMillis := uint64(3600000) // 1hr
 		receipt, errSend = eat.RpcApiClient.SendRawTransactionSync(tx, &timeoutMillis)
 	}()
 


### PR DESCRIPTION
Failed runs in tests with `-race` take approximately 20s and timeout was 10s.

This raises the guard timeout to 1 hour because it must not happen.