### PR TITLE
execution/vm: EIP-8024 tests add PUSH0 handler and enforce explicit errors

### DIFF
--- a/execution/vm/instructions_test.go
+++ b/execution/vm/instructions_test.go
@@ -23,6 +23,7 @@ package vm
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -947,10 +948,11 @@ func TestEIP8024_Execution(t *testing.T) {
 	evm := NewEVM(evmtypes.BlockContext{}, evmtypes.TxContext{}, nil, chain.TestChainConfig, Config{})
 
 	tests := []struct {
-		name     string
-		codeHex  string
-		wantErr  bool
-		wantVals []uint64
+		name       string
+		codeHex    string
+		wantErr    error
+		wantOpcode OpCode
+		wantVals   []uint64
 	}{
 		{
 			name:    "DUPN",
@@ -1003,55 +1005,70 @@ func TestEIP8024_Execution(t *testing.T) {
 			},
 		},
 		{
-			name:    "INVALID_SWAPN_LOW",
-			codeHex: "e75b",
-			wantErr: true,
+			name:       "INVALID_SWAPN_LOW",
+			codeHex:    "e75b",
+			wantErr:    &ErrInvalidOpCode{},
+			wantOpcode: SWAPN,
 		},
 		{
 			name:    "JUMP over INVALID_DUPN",
 			codeHex: "600456e65b",
-			wantErr: false,
+			wantErr: nil,
+		},
+		{
+			name:       "UNDERFLOW_DUPN_1",
+			codeHex:    "6000808080808080808080808080808080e600",
+			wantErr:    &ErrStackUnderflow{},
+			wantOpcode: DUPN,
 		},
 		// Additional test cases
 		{
-			name:    "INVALID_DUPN_LOW",
-			codeHex: "e65b",
-			wantErr: true,
+			name:       "INVALID_DUPN_LOW",
+			codeHex:    "e65b",
+			wantErr:    &ErrInvalidOpCode{},
+			wantOpcode: DUPN,
 		},
 		{
-			name:    "INVALID_EXCHANGE_LOW",
-			codeHex: "e850",
-			wantErr: true,
+			name:       "INVALID_EXCHANGE_LOW",
+			codeHex:    "e850",
+			wantErr:    &ErrInvalidOpCode{},
+			wantOpcode: EXCHANGE,
 		},
 		{
-			name:    "INVALID_DUPN_HIGH",
-			codeHex: "e67f",
-			wantErr: true,
+			name:       "INVALID_DUPN_HIGH",
+			codeHex:    "e67f",
+			wantErr:    &ErrInvalidOpCode{},
+			wantOpcode: DUPN,
 		},
 		{
-			name:    "INVALID_SWAPN_HIGH",
-			codeHex: "e77f",
-			wantErr: true,
+			name:       "INVALID_SWAPN_HIGH",
+			codeHex:    "e77f",
+			wantErr:    &ErrInvalidOpCode{},
+			wantOpcode: SWAPN,
 		},
 		{
-			name:    "INVALID_EXCHANGE_HIGH",
-			codeHex: "e87f",
-			wantErr: true,
+			name:       "INVALID_EXCHANGE_HIGH",
+			codeHex:    "e87f",
+			wantErr:    &ErrInvalidOpCode{},
+			wantOpcode: EXCHANGE,
 		},
 		{
-			name:    "UNDERFLOW_DUPN",
-			codeHex: "5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5fe600", // (n=17, need 17 items, have 16)
-			wantErr: true,
+			name:       "UNDERFLOW_DUPN_2",
+			codeHex:    "5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5fe600", // (n=17, need 17 items, have 16)
+			wantErr:    &ErrStackUnderflow{},
+			wantOpcode: DUPN,
 		},
 		{
-			name:    "UNDERFLOW_SWAPN",
-			codeHex: "5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5fe700", // (n=17, need 18 items, have 17)
-			wantErr: true,
+			name:       "UNDERFLOW_SWAPN",
+			codeHex:    "5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5fe700", // (n=17, need 18 items, have 17)
+			wantErr:    &ErrStackUnderflow{},
+			wantOpcode: SWAPN,
 		},
 		{
-			name:    "UNDERFLOW_EXCHANGE",
-			codeHex: "60016002e801", // (n,m)=(1,2), need 3 items, have 2
-			wantErr: true,
+			name:       "UNDERFLOW_EXCHANGE",
+			codeHex:    "60016002e801", // (n,m)=(1,2), need 3 items, have 2
+			wantErr:    &ErrStackUnderflow{},
+			wantOpcode: EXCHANGE,
 		},
 		{
 			name:     "PC_INCREMENT",
@@ -1067,6 +1084,7 @@ func TestEIP8024_Execution(t *testing.T) {
 			callContext := new(CallContext)
 			callContext.Contract.Code = code
 			var err error
+			var errOp OpCode
 			for pc < uint64(len(code)) && err == nil {
 				op := code[pc]
 				switch OpCode(op) {
@@ -1085,18 +1103,43 @@ func TestEIP8024_Execution(t *testing.T) {
 					pc, _, err = opDupN(pc, evm, callContext)
 				case ISZERO:
 					pc, _, err = opIszero(pc, evm, callContext)
+				case PUSH0:
+					pc, _, err = opPush0(pc, evm, callContext)
 				case SWAPN:
 					pc, _, err = opSwapN(pc, evm, callContext)
 				case EXCHANGE:
 					pc, _, err = opExchange(pc, evm, callContext)
 				default:
-					err = &ErrInvalidOpCode{opcode: OpCode(op)}
+					t.Fatalf("unexpected opcode %s at pc=%d", OpCode(op), pc)
+				}
+				if err != nil {
+					errOp = OpCode(op)
 				}
 				pc++
 			}
-			if tc.wantErr {
+			if tc.wantErr != nil {
+				// Fail because we wanted an error, but didn't get one.
 				if err == nil {
 					t.Fatalf("expected error, got nil")
+				}
+				// Fail if the wrong opcode threw an error.
+				if errOp != tc.wantOpcode {
+					t.Fatalf("expected error from opcode %s, got %s", tc.wantOpcode, errOp)
+				}
+				// Fail if we don't get the error we expect.
+				switch tc.wantErr.(type) {
+				case *ErrInvalidOpCode:
+					var want *ErrInvalidOpCode
+					if !errors.As(err, &want) {
+						t.Fatalf("expected ErrInvalidOpCode, got %v", err)
+					}
+				case *ErrStackUnderflow:
+					var want *ErrStackUnderflow
+					if !errors.As(err, &want) {
+						t.Fatalf("expected ErrStackUnderflow, got %v", err)
+					}
+				default:
+					t.Fatalf("unsupported wantErr type %T", tc.wantErr)
 				}
 				return
 			}


### PR DESCRIPTION
This PR strengthens `TestEIP8024_Execution` by checking for specific error types (such as stack underflow vs invalid opcode) instead of treating any error as a pass. It also makes the mini-interpreter fail immediately when it encounters an unexpected opcode, preventing tests from passing for the wrong reason.

While reviewing the tests, it was found that the underflow cases for `DUPN` and `SWAPN` were using `PUSH0 (0x5f)` to prepare the stack, but the mini-interpreter did not handle this opcode. As a result, the test failed early with an invalid-opcode error and never actually executed the target instruction.

This PR adds proper `PUSH0` handling to the mini-interpreter so the tests now reach `DUPN`/`SWAPN` and correctly verify the intended stack-underflow behavior.