### PR TITLE
cl/rpc: use count param for blob sidecar slice preallocation

### DIFF
--- a/cl/rpc/rpc.go
+++ b/cl/rpc/rpc.go
@@ -102,7 +102,7 @@ func (b *BeaconRpcP2P) sendBlobsSidecar(ctx context.Context, topic string, reqDa
 		return nil, pid, err
 	}
 
-	responsePacket := []*cltypes.BlobSidecar{}
+	responsePacket := make([]*cltypes.BlobSidecar, 0, count)
 	for _, data := range responses {
 		responseChunk := &cltypes.BlobSidecar{}
 		if err := responseChunk.DecodeSSZ(data.raw, int(data.version)); err != nil {


### PR DESCRIPTION
The `count` parameter in `sendBlobsSidecar`https://github.com/erigontech/erigon/blob/d2f7395f8b370246727ddc8eba96bae46a5ce10f/cl/rpc/rpc.go#L99-L114 was accepted but never used - both callers correctly compute the expected max number of blob sidecars, but the result slice was initialized as an empty literal `[]*BlobSidecar{}` ignoring this value entirely.

Use `make([]*cltypes.BlobSidecar, 0, count)` to preallocate the response slice, avoiding unnecessary grow-and-copy cycles during append.