### PR TITLE
execution/stagedsync: remove unreachable debug code

### DIFF
--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -343,10 +343,6 @@ func ExecV3(ctx context.Context,
 		lastCommittedTxNum = se.lastCommittedTxNum.Load()
 	}
 
-	if false && !isForkValidation {
-		dumpPlainStateDebug(applyTx, doms)
-	}
-
 	lastCommitedStep := kv.Step((lastCommittedTxNum) / doms.StepSize())
 	lastFrozenStep := applyTx.StepsInFiles(kv.CommitmentDomain)
 


### PR DESCRIPTION
Remove dead code behind `if false && !isForkValidation` condition in ExecV3. The `dumpPlainStateDebug` call was never executed and the function is commented out elsewhere in the codebase. This cleanup removes 4 lines of unreachable code without any functional changes.