### PR TITLE
[cherry-pick] Create .torrent for erigondb.toml as well starting from E3.4

### DIFF
--- a/db/downloader/util.go
+++ b/db/downloader/util.go
@@ -48,6 +48,7 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/snapcfg"
 	"github.com/erigontech/erigon/db/snaptype"
+	"github.com/erigontech/erigon/db/state"
 )
 
 // TODO: Update this list, or pull from common location (central manifest or canonical multi-file torrent).
@@ -91,6 +92,14 @@ func seedableSegmentFiles(dir string, chainName string, skipSeedableCheck bool) 
 		}
 		if strings.HasPrefix(name, "salt") && strings.HasSuffix(name, "txt") {
 			res = append(res, name)
+			continue
+		}
+		if name == state.ERIGONDB_SETTINGS_FILE {
+			res = append(res, name)
+			continue
+		}
+		// Skip any other .toml files
+		if strings.HasSuffix(name, ".toml") {
 			continue
 		}
 		if !skipSeedableCheck && !snaptype.IsCorrectFileName(name) {

--- a/db/snaptype/files.go
+++ b/db/snaptype/files.go
@@ -360,7 +360,7 @@ func SeedableV2Extensions() []string {
 }
 
 func AllV2Extensions() []string {
-	return []string{".seg", ".idx", ".txt"}
+	return []string{".seg", ".idx", ".txt", ".toml"}
 }
 
 func SeedableV3Extensions() []string {


### PR DESCRIPTION
This is a cherry pick of https://github.com/erigontech/erigon/pull/19019 , tested primarily on `performance-stable` branch + bloatnet snapshotter

After merging this one on `main` we expect the file `erigondb.toml` will appear as a new publishable file the next time automation runs.

Note: this is not enough to properly consume the `erigondb.toml` from torrent, another PR is coming to guarantee correct download or local generation.