### PR TITLE
Caplin: to not insert frozen blocks

### DIFF
--- a/cl/phase1/execution_client/block_collector/persistent_block_collector.go
+++ b/cl/phase1/execution_client/block_collector/persistent_block_collector.go
@@ -136,6 +136,7 @@ func (p *PersistentBlockCollector) Flush(ctx context.Context) error {
 	blocksBatch := []*types.Block{}
 	inserted := uint64(0)
 
+	minInsertableBlockNumber := p.engine.FrozenBlocks(ctx)
 	var prevBlockNum uint64
 	if err := p.db.View(ctx, func(tx kv.Tx) error {
 		cursor, err := tx.Cursor(kv.Headers)
@@ -155,6 +156,9 @@ func (p *PersistentBlockCollector) Flush(ctx context.Context) error {
 				continue
 			}
 			if block == nil {
+				continue
+			}
+			if block.NumberU64() < minInsertableBlockNumber {
 				continue
 			}
 


### PR DESCRIPTION
we were actually inserting a block that was too old... probably a remnant of a previous run.