### PR TITLE
refactor: use maps.Copy to simplify the code

### DIFF
--- a/db/state/temporal_mem_batch.go
+++ b/db/state/temporal_mem_batch.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"maps"
 	"sort"
 	"sync"
 	"unsafe"
@@ -402,9 +403,7 @@ func (sd *TemporalMemBatch) Merge(o kv.TemporalMemBatch) error {
 
 	for domain, otherEntries := range other.domains {
 		entries := sd.domains[domain]
-		for key, value := range otherEntries {
-			entries[key] = value
-		}
+		maps.Copy(entries, otherEntries)
 	}
 
 	other.storage.Scan(func(key string, value []dataWithTxNum) bool {


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/maps@go1.21.1#Copy) added in the go1.21 standard library, which can make the code more concise and easy to read.

Inspired by https://github.com/erigontech/erigon/pull/17347 and replace all.