### PR TITLE
[r33] execution/execmodule: fix unwinding logic when side forks go back in height (#18993)

### DIFF
--- a/execution/eth1/forkchoice.go
+++ b/execution/eth1/forkchoice.go
@@ -396,6 +396,12 @@ func (e *EthereumExecutionModule) updateForkChoice(ctx context.Context, original
 				sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, err, false)
 				return
 			}
+			// make sure we truncate any previous canonical hashes that go beyond the current head height
+			// so that AppendCanonicalTxNums does not mess up the txNums index
+			if err := rawdb.TruncateCanonicalHash(tx, newCanonicals[0].number+1, false); err != nil {
+				sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, err, false)
+				return
+			}
 			if err := rawdb.AppendCanonicalTxNums(tx, newCanonicals[len(newCanonicals)-1].number); err != nil {
 				sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, err, false)
 				return


### PR DESCRIPTION
cherry-pick: https://github.com/erigontech/erigon/pull/18993

---

This was caught by some of the gas-benchmark tests which run a series of new payloads and FCUs for forks with different heights, and they jump from one fork to another.

The issue was that we were not calling `TruncateCanonicalHash` for heights after the new FCU head number. Which meant that `AppendCanonicalTxNums` was appending more txNums than it should for the given FCU fork (i.e. it was going beyond it) if the fork before it was longer in height. This messed up the txNums index and caused wrong trie roots.