### PR TITLE
qa-tests: always upload test results in rpc integration tests

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests-gnosis.yml
+++ b/.github/workflows/qa-rpc-integration-tests-gnosis.yml
@@ -168,7 +168,7 @@ jobs:
           fi
 
       - name: Restore Erigon Chaindata Directory
-        if: ${{ always() }}
+        if: always()
         run: |
           if [ -d "$ERIGON_TESTBED_AREA/chaindata-prev" ] && [ "${{ steps.save_chaindata_step.outcome }}" == "success" ]; then
           rm -rf $ERIGON_REFERENCE_DATA_DIR/chaindata
@@ -177,12 +177,12 @@ jobs:
           fi
 
       - name: Resume the Erigon instance dedicated to db maintenance
-        if: ${{ always() }}
+        if: always()
         run: |
           python3 $ERIGON_QA_PATH/test_system/db-producer/resume_production.py || true
 
       - name: Upload test results
-        if: steps.test_step.outputs.test_executed == 'true'
+        if: always() && steps.test_step.outputs.test_executed == 'true'
         uses: actions/upload-artifact@v6
         with:
           name: test-results
@@ -191,7 +191,7 @@ jobs:
             ${{ env.ERIGON_REFERENCE_DATA_DIR }}/logs/
 
       - name: Save test results
-        if: steps.test_step.outputs.test_executed == 'true'
+        if: always() && steps.test_step.outputs.test_executed == 'true'
         working-directory: ${{ github.workspace }}
         env:
           TEST_RESULT: ${{ steps.test_step.outputs.TEST_RESULT }}

--- a/.github/workflows/qa-rpc-integration-tests-latest.yml
+++ b/.github/workflows/qa-rpc-integration-tests-latest.yml
@@ -179,7 +179,7 @@ jobs:
           fi
 
       - name: Upload test results
-        if: steps.test_step.outputs.test_executed == 'true'
+        if: always() && steps.test_step.outputs.test_executed == 'true'
         uses: actions/upload-artifact@v6
         with:
           name: test-results
@@ -188,7 +188,7 @@ jobs:
             ${{ env.ERIGON_TESTBED_DATA_DIR }}/logs/
 
       - name: Save test results
-        if: steps.test_step.outputs.test_executed == 'true'
+        if: always() && steps.test_step.outputs.test_executed == 'true'
         working-directory: ${{ github.workspace }}
         env:
           TEST_RESULT: ${{ steps.test_step.outputs.TEST_RESULT }}

--- a/.github/workflows/qa-rpc-integration-tests-remote.yml
+++ b/.github/workflows/qa-rpc-integration-tests-remote.yml
@@ -198,7 +198,7 @@ jobs:
           fi
 
       - name: Restore Erigon Chaindata Directory
-        if: ${{ always() }}
+        if: always()
         run: |
           if [ -d "$ERIGON_TESTBED_AREA/chaindata-prev" ] && [ "${{ steps.save_chaindata_step.outcome }}" == "success" ]; then
           rm -rf $ERIGON_REFERENCE_DATA_DIR/chaindata
@@ -207,12 +207,12 @@ jobs:
           fi
 
       - name: Resume the Erigon instance dedicated to db maintenance
-        if: ${{ always() }}
+        if: always()
         run: |
           python3 $ERIGON_QA_PATH/test_system/db-producer/resume_production.py || true
 
       - name: Upload test results
-        if: steps.test_step.outputs.test_executed == 'true'
+        if: always() && steps.test_step.outputs.test_executed == 'true'
         uses: actions/upload-artifact@v6
         with:
           name: test-results
@@ -222,7 +222,7 @@ jobs:
             ${{ github.workspace }}/build/bin/erigon.log 
 
       - name: Save test results
-        if: steps.test_step.outputs.test_executed == 'true'
+        if: always() && steps.test_step.outputs.test_executed == 'true'
         working-directory: ${{ github.workspace }}
         env:
           TEST_RESULT: ${{ steps.test_step.outputs.TEST_RESULT }}

--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -168,7 +168,7 @@ jobs:
           fi
 
       - name: Restore Erigon Chaindata Directory
-        if: ${{ always() }}
+        if: always()
         run: |
           if [ -d "$ERIGON_TESTBED_AREA/chaindata-prev" ] && [ "${{ steps.save_chaindata_step.outcome }}" == "success" ]; then
           rm -rf $ERIGON_REFERENCE_DATA_DIR/chaindata
@@ -177,12 +177,12 @@ jobs:
           fi
 
       - name: Resume the Erigon instance dedicated to db maintenance
-        if: ${{ always() }}
+        if: always()
         run: |
           python3 $ERIGON_QA_PATH/test_system/db-producer/resume_production.py || true
 
       - name: Upload test results
-        if: steps.test_step.outputs.test_executed == 'true'
+        if: always() && steps.test_step.outputs.test_executed == 'true'
         uses: actions/upload-artifact@v6
         with:
           name: test-results
@@ -191,7 +191,7 @@ jobs:
             ${{ github.workspace }}/build/bin/rpcdaemon.log
 
       - name: Save test results
-        if: steps.test_step.outputs.test_executed == 'true'
+        if: always() && steps.test_step.outputs.test_executed == 'true'
         working-directory: ${{ github.workspace }}
         env:
           TEST_RESULT: ${{ steps.test_step.outputs.TEST_RESULT }}


### PR DESCRIPTION
After PR #18878, some workflows need an `always` guard to always upload test results