### PR TITLE
execution/bodydownload: remove dead debug code

### DIFF
--- a/execution/stagedsync/bodydownload/body_algos.go
+++ b/execution/stagedsync/bodydownload/body_algos.go
@@ -283,7 +283,6 @@ Loop:
 			continue
 		}
 
-		//var deliveredNums []uint64
 		toClean := map[uint64]struct{}{}
 		txs, uncles, withdrawals, lenOfP2PMessage := delivery.txs, delivery.uncles, delivery.withdrawals, delivery.lenOfP2PMessage
 
@@ -305,7 +304,6 @@ Loop:
 				undelivered++
 				continue
 			}
-			//deliveredNums = append(deliveredNums, blockNum)
 			if req, ok := bd.requests[blockNum]; ok {
 				for _, blockNum := range req.BlockNums {
 					toClean[blockNum] = struct{}{}
@@ -319,18 +317,13 @@ Loop:
 			dataflow.BlockBodyDownloadStates.AddChange(blockNum, dataflow.BlockBodyReceived)
 		}
 		// Clean up the requests
-		//var clearedNums []uint64
 		for blockNum := range toClean {
 			delete(bd.requests, blockNum)
 			if !bd.delivered.Contains(blockNum) {
 				// Delivery was requested but was skipped due to the limitation on the size of the response
 				dataflow.BlockBodyDownloadStates.AddChange(blockNum, dataflow.BlockBodySkipped)
 			}
-			//clearedNums = append(clearedNums, blockNum)
 		}
-		//sort.Slice(deliveredNums, func(i, j int) bool { return deliveredNums[i] < deliveredNums[j] })
-		//sort.Slice(clearedNums, func(i, j int) bool { return clearedNums[i] < clearedNums[j] })
-		//log.Debug("Delivered", "blockNums", fmt.Sprintf("%d", deliveredNums), "clearedNums", fmt.Sprintf("%d", clearedNums))
 		total := delivered + undelivered
 		if total > 0 {
 			// Approximate numbers


### PR DESCRIPTION
Removes 6 lines of commented-out debug code from `body_algos.go` that has been dead since January 2023 (commit 092c75f83e).