### PR TITLE
node: add HTTP/2 cleartext (h2c) support to RPC server

### DIFF
--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -131,6 +131,9 @@ func (h *httpServer) start() error {
 
 	// Initialize the server.
 	h.server = &http.Server{Handler: h} // nolint
+	h.server.Protocols = new(http.Protocols)
+	h.server.Protocols.SetHTTP1(true)
+	h.server.Protocols.SetUnencryptedHTTP2(true)
 	if h.timeouts != (rpccfg.HTTPTimeouts{}) {
 		CheckTimeouts(&h.timeouts)
 		h.server.ReadTimeout = h.timeouts.ReadTimeout


### PR DESCRIPTION
This PR adds HTTP/2 (h2c) support to the internal JSON-RPC server. The JSON-RPC API is meant for internal use. When it is exposed publicly, it is usually placed behind a reverse proxy that handles TLS encryption. Because of this, using cleartext HTTP/2 (h2c) here is enough and avoids adding TLS handling inside the node. Tests have been added to confirm that HTTP/2 cleartext works correctly.