### PR TITLE
rlp: make 32-byte buffer sufficient for EncodeBigInt

### DIFF
--- a/execution/rlp/encode.go
+++ b/execution/rlp/encode.go
@@ -621,8 +621,11 @@ func EncodeBigInt(i *big.Int, w io.Writer, buffer []byte) error {
 
 	size := common.BitLenToByteLen(bitLen)
 	buffer[0] = 0x80 + byte(size)
-	i.FillBytes(buffer[1 : 1+size])
-	_, err := w.Write(buffer[:1+size])
+	if _, err := w.Write(buffer[:1]); err != nil {
+		return err
+	}
+	i.FillBytes(buffer[:size])
+	_, err := w.Write(buffer[:size])
 	return err
 }
 

--- a/execution/types/encoding_buf.go
+++ b/execution/types/encoding_buf.go
@@ -18,7 +18,7 @@ package types
 
 import "sync"
 
-type encodingBuf [33]byte
+type encodingBuf [32]byte
 
 var pooledBuf = sync.Pool{
 	New: func() any { return new(encodingBuf) },
@@ -26,6 +26,6 @@ var pooledBuf = sync.Pool{
 
 func newEncodingBuf() *encodingBuf {
 	b := pooledBuf.Get().(*encodingBuf)
-	*b = [33]byte{} // reset, do we need to?
+	*b = [32]byte{} // reset, do we need to?
 	return b
 }


### PR DESCRIPTION
Follow up #18952. Rationale: a 32-byte buffer is probably faster than a 33-byte one. Also now `EncodeBigInt` is similar to `EncodeUint256`.