### PR TITLE
hive: 23 max allowed failures for rpc compat

### DIFF
--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -38,7 +38,7 @@ jobs:
             max-allowed-failures: 0
           - sim: rpc
             sim-limit: compat
-            max-allowed-failures: 3
+            max-allowed-failures: 23
     steps:
       - name: Checkout Hive
         uses: actions/checkout@v6


### PR DESCRIPTION
Waiting for Hive tests to be upgraded to support:
- eth_simulateV1 changed error codes
- `blockTimestamp` in transaction objects