### PR TITLE
Speed up 'all-tests (with -race)' runs

### DIFF
--- a/.github/workflows/test-all-erigon-race.yml
+++ b/.github/workflows/test-all-erigon-race.yml
@@ -140,7 +140,7 @@ jobs:
               ;;
             *)
               echo "Error: Unknown test-group value '${{ matrix.test-group }}'"
-              echo "Expected one of: execution-tests, execution-other, consensus, p2p-rpc, core-db, other"
+              echo "Expected one of: execution-tests, execution-other, consensus, core-rpc, other"
               exit 1
               ;;
           esac


### PR DESCRIPTION
This PR aims to speed up the 'all-tests (with -race)' suite by splitting tests across different jobs.