### PR TITLE
execution: remove dead code behind `if false` in ExecV3

### DIFF
--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -352,10 +352,6 @@ func ExecV3(ctx context.Context,
 		lastCommittedTxNum = se.lastCommittedTxNum.Load()
 	}
 
-	if false && !isForkValidation {
-		dumpPlainStateDebug(applyTx, doms)
-	}
-
 	lastCommitedStep := kv.Step((lastCommittedTxNum) / doms.StepSize())
 	lastFrozenStep := applyTx.StepsInFiles(kv.CommitmentDomain)
 


### PR DESCRIPTION
Summary
Remove unreachable debug block in `ExecV3` (execution/stagedsync/exec3.go).
 Change
- Delete the `if false && !isForkValidation { dumpPlainStateDebug(applyTx, doms) }` block.
- The condition is always false, so the block never ran; behavior is unchanged.