### PR TITLE
execution: fix log level for LogReceipts

### DIFF
--- a/execution/protocol/block_exec.go
+++ b/execution/protocol/block_exec.go
@@ -156,7 +156,7 @@ func ExecuteBlockEphemerally(
 	receiptSha := types.DeriveSha(receipts)
 	if !vmConfig.StatelessExec && chainConfig.IsByzantium(header.Number.Uint64()) && !vmConfig.NoReceipts && receiptSha != block.ReceiptHash() {
 		if dbg.LogHashMismatchReason() {
-			ethutils.LogReceipts("receipt hash mismatch in ExecuteBlockEphemerally", receipts, includedTxs, chainConfig, header, logger)
+			ethutils.LogReceipts(log.LvlWarn, "receipt hash mismatch in ExecuteBlockEphemerally", receipts, includedTxs, chainConfig, header, logger)
 		}
 
 		return nil, fmt.Errorf("mismatched receipt headers for block %d (%s != %s)", block.NumberU64(), receiptSha.Hex(), block.ReceiptHash().Hex())
@@ -395,7 +395,7 @@ func BlockPostValidation(blockGasUsed, blobGasUsed uint64, checkReceipts bool, r
 				return nil
 			}
 			if dbg.LogHashMismatchReason() {
-				ethutils.LogReceipts("receipt hash mismatch in BlockPostValidation", receipts, txns, chainConfig, h, logger)
+				ethutils.LogReceipts(log.LvlWarn, "receipt hash mismatch in BlockPostValidation", receipts, txns, chainConfig, h, logger)
 			}
 			return fmt.Errorf("receiptHash mismatch: %x != %x, headerNum=%d, %x",
 				receiptHash, h.ReceiptHash, h.Number.Uint64(), h.Hash())
@@ -408,7 +408,7 @@ func BlockPostValidation(blockGasUsed, blobGasUsed uint64, checkReceipts bool, r
 	}
 
 	if dbg.TraceLogs && dbg.TraceBlock(h.Number.Uint64()) {
-		ethutils.LogReceipts("trace logs", receipts, txns, chainConfig, h, logger)
+		ethutils.LogReceipts(log.LvlInfo, "trace logs", receipts, txns, chainConfig, h, logger)
 	}
 
 	return nil

--- a/execution/stagedsync/stage_mining_finish.go
+++ b/execution/stagedsync/stage_mining_finish.go
@@ -78,7 +78,7 @@ func SpawnMiningFinishStage(s *StageState, sd *execctx.SharedDomains, tx kv.Temp
 	}
 	blockWithReceipts := &types.BlockWithReceipts{Block: block, Receipts: current.Receipts, Requests: current.Requests}
 	if dbg.LogHashMismatchReason() {
-		ethutils.LogReceipts("Block built", current.Receipts, current.Txns, cfg.chainConfig, current.Header, logger)
+		ethutils.LogReceipts(log.LvlInfo, "Block built", current.Receipts, current.Txns, cfg.chainConfig, current.Header, logger)
 	}
 
 	*current = MiningBlock{} // hack to clean global data

--- a/execution/types/ethutils/receipt.go
+++ b/execution/types/ethutils/receipt.go
@@ -215,10 +215,10 @@ func MarshalSubscribeReceipt(protoReceipt *remoteproto.SubscribeReceiptsReply) m
 	return receipt
 }
 
-func LogReceipts(msg string, receipts types.Receipts, txns types.Transactions, cc *chain.Config, header *types.Header, logger log.Logger) {
+func LogReceipts(level log.Lvl, msg string, receipts types.Receipts, txns types.Transactions, cc *chain.Config, header *types.Header, logger log.Logger) {
 	if len(receipts) == 0 {
 		// no-op, can happen if vmConfig.NoReceipts=true or vmConfig.StatelessExec=true
-		logger.Info(msg, "block", header.Number.Uint64(), "receipts", "")
+		logger.Log(level, msg, "block", header.Number.Uint64(), "receipts", "")
 		return
 	}
 
@@ -240,5 +240,5 @@ func LogReceipts(msg string, receipts types.Receipts, txns types.Transactions, c
 		logger.Error("marshalling error when logging receipts", "err", err)
 		return
 	}
-	logger.Info(msg, "block", header.Number.Uint64(), "receipts", string(result))
+	logger.Log(level, msg, "block", header.Number.Uint64(), "receipts", string(result))
 }


### PR DESCRIPTION
Follow up PR #19116. Have to raise the log level to WARN because of the `terseLogger` in `inMemoryExecution`.