### PR TITLE
.github/workflows: only run test-hive jobs on latest PR commit

### DIFF
--- a/.github/workflows/test-all-erigon.yml
+++ b/.github/workflows/test-all-erigon.yml
@@ -113,7 +113,7 @@ jobs:
         if: needs.source-of-changes.outputs.changed_files == 'true'
         run: echo "This check does not make sense for changes within out-of-scope directories"
 
-#comment
+
   tests-windows:
     needs: source-of-changes
     concurrency:


### PR DESCRIPTION
Fresh commit on a PR cancels test-hive CI jobs triggered by previous commits.