### PR TITLE
rpc: add canonical hash cache

### DIFF
--- a/db/snapshotsync/freezeblocks/block_reader.go
+++ b/db/snapshotsync/freezeblocks/block_reader.go
@@ -627,17 +627,16 @@ func (r *BlockReader) HeaderByHash(ctx context.Context, tx kv.Getter, hash commo
 var emptyHash = common.Hash{}
 
 func (r *BlockReader) CanonicalHash(ctx context.Context, tx kv.Getter, blockHeight uint64) (h common.Hash, ok bool, err error) {
-	if cached, ok := r.canonicalHashCache.Get(blockHeight); ok {
-		return cached, true, nil
-	}
-
 	h, err = rawdb.ReadCanonicalHash(tx, blockHeight)
 	if err != nil {
 		return emptyHash, false, err
 	}
 	if h != emptyHash {
-		r.canonicalHashCache.Add(blockHeight, h)
 		return h, true, nil
+	}
+
+	if cached, ok := r.canonicalHashCache.Get(blockHeight); ok {
+		return cached, true, nil
 	}
 
 	seg, ok, release := r.sn.ViewSingleFile(snaptype2.Headers, blockHeight)

--- a/db/snapshotsync/freezeblocks/block_reader.go
+++ b/db/snapshotsync/freezeblocks/block_reader.go
@@ -368,16 +368,19 @@ type BlockReader struct {
 	txNumsReader rawdbv3.TxNumsReader
 
 	//files are immutable: no reorgs, on updates - means no invalidation needed
-	headerByNumCache *lru.Cache[uint64, *types.Header]
+	headerByNumCache   *lru.Cache[uint64, *types.Header]
+	canonicalHashCache *lru.Cache[uint64, common.Hash]
 }
 
 var headerByNumCacheSize = dbg.EnvInt("RPC_HEADER_BY_NUM_LRU", 1_000)
+var canonicalHashCacheSize = dbg.EnvInt("RPC_CANONICAL_HASH_LRU", 10_000)
 
 func NewBlockReader(snapshots services.BlockSnapshots, borSnapshots services.BlockSnapshots) *BlockReader {
 	borSn, _ := borSnapshots.(*heimdall.RoSnapshots)
 	sn, _ := snapshots.(*RoSnapshots)
 	br := &BlockReader{sn: sn, borSn: borSn}
 	br.headerByNumCache, _ = lru.New[uint64, *types.Header](headerByNumCacheSize)
+	br.canonicalHashCache, _ = lru.New[uint64, common.Hash](canonicalHashCacheSize)
 	br.txNumsReader = rawdbv3.TxNums.WithCustomReadTxNumFunc(TxBlockIndexFromBlockReader(br))
 	return br
 }
@@ -624,11 +627,16 @@ func (r *BlockReader) HeaderByHash(ctx context.Context, tx kv.Getter, hash commo
 var emptyHash = common.Hash{}
 
 func (r *BlockReader) CanonicalHash(ctx context.Context, tx kv.Getter, blockHeight uint64) (h common.Hash, ok bool, err error) {
+	if cached, ok := r.canonicalHashCache.Get(blockHeight); ok {
+		return cached, true, nil
+	}
+
 	h, err = rawdb.ReadCanonicalHash(tx, blockHeight)
 	if err != nil {
 		return emptyHash, false, err
 	}
 	if h != emptyHash {
+		r.canonicalHashCache.Add(blockHeight, h)
 		return h, true, nil
 	}
 
@@ -646,6 +654,7 @@ func (r *BlockReader) CanonicalHash(ctx context.Context, tx kv.Getter, blockHeig
 		return h, false, nil
 	}
 	h = header.Hash()
+	r.canonicalHashCache.Add(blockHeight, h)
 	return h, true, nil
 }
 

--- a/db/snapshotsync/freezeblocks/block_reader_bench_test.go
+++ b/db/snapshotsync/freezeblocks/block_reader_bench_test.go
@@ -32,10 +32,9 @@ package freezeblocks
 // These benchmarks isolate each component so the saving is measurable
 // without needing real snapshot files:
 //
-//   BenchmarkCanonicalHash_MDBXLookup         – step 1: raw MDBX read; identical on both branches.
-//   BenchmarkCanonicalHash_HeaderHash_Minimal  – step 3 on a trivial header (not representative).
-//   BenchmarkCanonicalHash_HeaderHash_Realistic– step 3 on a full mainnet-like header.
-//   BenchmarkCanonicalHash_LRUCacheHit         – LRU lookup replacing steps 2+3 on this branch.
+//   BenchmarkCanonicalHash_MDBXLookup          – step 1: raw MDBX read; identical on both branches.
+//   BenchmarkCanonicalHash_HeaderHash_Realistic – step 3 on a full mainnet-like header.
+//   BenchmarkCanonicalHash_LRUCacheHit          – LRU lookup replacing steps 2+3 on this branch.
 //
 // Run with:
 //   go test -bench=BenchmarkCanonicalHash -benchmem ./db/snapshotsync/freezeblocks/

--- a/db/snapshotsync/freezeblocks/block_reader_bench_test.go
+++ b/db/snapshotsync/freezeblocks/block_reader_bench_test.go
@@ -32,9 +32,10 @@ package freezeblocks
 // These benchmarks isolate each component so the saving is measurable
 // without needing real snapshot files:
 //
-//   BenchmarkCanonicalHash_MDBXLookup          – step 1: raw MDBX read; identical on both branches.
-//   BenchmarkCanonicalHash_HeaderHash_Realistic – step 3 on a full mainnet-like header.
-//   BenchmarkCanonicalHash_LRUCacheHit          – LRU lookup replacing steps 2+3 on this branch.
+//   BenchmarkCanonicalHash_MDBXLookup                  – step 1: raw MDBX read; identical on both branches.
+//   BenchmarkCanonicalHash_HeaderHash_Realistic         – step 3 on a full mainnet-like header.
+//   BenchmarkCanonicalHash_LRUCacheHit                  – LRU lookup replacing steps 2+3 on this branch.
+//   BenchmarkCanonicalHash_RealSnapshot_MainEquivalent  – main steady-state: headerByNumCache warm, no hash cache.
 //
 // Run with:
 //   go test -bench=BenchmarkCanonicalHash -benchmem ./db/snapshotsync/freezeblocks/
@@ -238,10 +239,79 @@ func BenchmarkCanonicalHash_RealSnapshot(b *testing.B) {
 	}
 }
 
+// BenchmarkCanonicalHash_RealSnapshot_MainEquivalent measures the steady-state cost
+// on main: headerByNumCache warm (full *Header cached), no canonicalHashCache.
+// Each call pays MDBX miss + headerByNumCache.Get + Header.Hash() atomic load.
+// Compare against BenchmarkCanonicalHash_RealSnapshot to see the actual per-call
+// delta this PR delivers when the working set fits in headerByNumCache (≤1,000 blocks).
+//
+//	ERIGON_SNAP_DIR=/datadisk/erigon34/datadir/snapshots \
+//	  go test -bench=BenchmarkCanonicalHash_RealSnapshot_MainEquivalent -benchmem -benchtime=5s \
+//	  ./db/snapshotsync/freezeblocks/
+func BenchmarkCanonicalHash_RealSnapshot_MainEquivalent(b *testing.B) {
+	snapDir := os.Getenv("ERIGON_SNAP_DIR")
+	if snapDir == "" {
+		b.Skip("set ERIGON_SNAP_DIR to a mainnet snapshots directory to run this benchmark")
+	}
+	if _, err := os.Stat(snapDir); err != nil {
+		b.Skipf("snapshot dir not accessible: %v", err)
+	}
+
+	logger := log.New()
+	cfg := ethconfig.Defaults.Snapshot
+	cfg.ChainName = networkname.Mainnet
+	snapshots := NewRoSnapshots(cfg, snapDir, logger)
+	if err := snapshots.OpenFolder(); err != nil {
+		b.Fatal(err)
+	}
+	defer snapshots.Close()
+
+	available := snapshots.BlocksAvailable()
+	if available == 0 {
+		b.Skip("no blocks available in snapshot dir")
+	}
+
+	blockReader := NewBlockReader(snapshots, nil)
+
+	db := memdb.NewTestDB(b, dbcfg.ChainDB)
+	ctx := context.Background()
+	tx, err := db.BeginRo(ctx)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer tx.Rollback()
+
+	const startBlock = 500_000
+	const numBlocks = 1_000
+	if available < startBlock+numBlocks {
+		b.Skipf("need at least %d blocks in snapshots, got %d", startBlock+numBlocks, available)
+	}
+
+	// Warm headerByNumCache for all numBlocks via the full snapshot path.
+	for i := uint64(startBlock); i < startBlock+numBlocks; i++ {
+		if _, _, err := blockReader.CanonicalHash(ctx, tx, i); err != nil {
+			b.Fatal(err)
+		}
+	}
+	// Replace canonicalHashCache with a size-1 cache so it always misses when
+	// cycling through numBlocks distinct blocks — simulating main's steady state
+	// where only headerByNumCache is warm.
+	blockReader.canonicalHashCache, _ = lru.New[uint64, common.Hash](1)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		blockNum := uint64(startBlock + (i % numBlocks))
+		if _, _, err := blockReader.CanonicalHash(ctx, tx, blockNum); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 // BenchmarkCanonicalHash_RealSnapshot_Cold measures the full snapshot path with
-// no cache warmup. This is what every call costs on main (which has no LRU cache)
-// and what the first call costs on this branch. It cycles through enough distinct
-// block numbers to exceed the LRU cache capacity, forcing cache misses.
+// no cache warmup. This is what every call costs on main when the working set
+// exceeds headerByNumCache capacity, and what the first call costs on this branch.
+// It cycles through enough distinct block numbers to exceed both cache capacities.
 //
 //	ERIGON_SNAP_DIR=/datadisk/erigon34/datadir/snapshots \
 //	  go test -bench=BenchmarkCanonicalHash_RealSnapshot_Cold -benchmem -benchtime=5s \

--- a/db/snapshotsync/freezeblocks/block_reader_bench_test.go
+++ b/db/snapshotsync/freezeblocks/block_reader_bench_test.go
@@ -18,20 +18,26 @@ package freezeblocks
 
 // Benchmarks for BlockReader.CanonicalHash hot path.
 //
-// The LRU cache introduced by PR #19173 only populates from snapshot data
-// (immutable, post-finalized blocks). For blocks still in the DB the code
-// path is identical on main and on this branch.
+// Context: CanonicalHash is called on every eth_getBlockByNumber / eth_getTransactionByHash
+// RPC request. For blocks in snapshots (the vast majority of historical blocks),
+// the code path on main is:
 //
-// The three benchmarks below isolate the components that change:
+//   1. rawdb.ReadCanonicalHash (MDBX miss)        ~200 ns
+//   2. headerFromSnapshot (decompress + RLP)      ~several µs (from memory-mapped file)
+//   3. header.Hash() (keccak256 of full RLP)      ~300–500 ns on a real header
 //
-//   BenchmarkCanonicalHash_DBPath          – raw MDBX lookup; same on both branches.
-//   BenchmarkCanonicalHash_SnapshotNoCache – header.Hash() per call; what main
-//                                            pays for every snapshot-range lookup.
-//   BenchmarkCanonicalHash_SnapshotCacheHit – LRU Get() per call; what this branch
-//                                             pays after the first snapshot lookup.
+// On this branch (PR #19173), after the first call the cache is populated and
+// steps 2+3 are replaced by a single LRU lookup (~30–40 ns).
 //
-// Running on main vs. this branch:
+// These benchmarks isolate each component so the saving is measurable
+// without needing real snapshot files:
 //
+//   BenchmarkCanonicalHash_MDBXLookup         – step 1: raw MDBX read; identical on both branches.
+//   BenchmarkCanonicalHash_HeaderHash_Minimal  – step 3 on a trivial header (not representative).
+//   BenchmarkCanonicalHash_HeaderHash_Realistic– step 3 on a full mainnet-like header.
+//   BenchmarkCanonicalHash_LRUCacheHit         – LRU lookup replacing steps 2+3 on this branch.
+//
+// Run with:
 //   go test -bench=BenchmarkCanonicalHash -benchmem ./db/snapshotsync/freezeblocks/
 
 import (
@@ -50,11 +56,40 @@ import (
 
 const benchBlockCount = 1_000
 
-// BenchmarkCanonicalHash_DBPath measures a raw MDBX canonical-hash lookup.
-// This path is taken when the block is in the DB (not yet in snapshots) and
-// is identical on main and on this branch — the cache is never populated from
-// DB data.
-func BenchmarkCanonicalHash_DBPath(b *testing.B) {
+// realisticHeader returns a header that resembles a post-Merge mainnet block:
+// all hash/bloom fields are non-zero so the RLP encoding is representative
+// of real data (~500 bytes), making header.Hash() cost comparable to production.
+func realisticHeader(blockNum uint64) *types.Header {
+	seed := blockNum + 1
+	fill32 := func(offset uint64) (h common.Hash) {
+		for i := range h {
+			h[i] = byte(seed + offset + uint64(i))
+		}
+		return
+	}
+	h := &types.Header{
+		Number:      *uint256.NewInt(blockNum),
+		ParentHash:  fill32(0),
+		UncleHash:   fill32(7),
+		Coinbase:    common.BytesToAddress(fill32(1).Bytes()),
+		Root:        fill32(2),
+		TxHash:      fill32(8),
+		ReceiptHash: fill32(3),
+		GasLimit:    30_000_000,
+		GasUsed:     seed % 30_000_000,
+		Time:        1_700_000_000 + seed,
+		Extra:       fill32(4).Bytes(),
+		MixDigest:   fill32(5),
+		BaseFee:     uint256.NewInt(seed % 1_000_000_000),
+	}
+	copy(h.Bloom[:], fill32(6).Bytes())
+	return h
+}
+
+// BenchmarkCanonicalHash_MDBXLookup measures a raw MDBX canonical-hash read.
+// This is the first step of CanonicalHash on every call; it is identical on
+// main and on this branch.
+func BenchmarkCanonicalHash_MDBXLookup(b *testing.B) {
 	db := memdb.NewTestDB(b, dbcfg.ChainDB)
 
 	rwTx, err := db.BeginRw(context.Background())
@@ -62,8 +97,7 @@ func BenchmarkCanonicalHash_DBPath(b *testing.B) {
 		b.Fatal(err)
 	}
 	for i := uint64(0); i < benchBlockCount; i++ {
-		h := &types.Header{Number: *uint256.NewInt(i)}
-		if err := rawdb.WriteCanonicalHash(rwTx, h.Hash(), i); err != nil {
+		if err := rawdb.WriteCanonicalHash(rwTx, realisticHeader(i).Hash(), i); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -86,39 +120,38 @@ func BenchmarkCanonicalHash_DBPath(b *testing.B) {
 	}
 }
 
-// BenchmarkCanonicalHash_SnapshotNoCache measures the per-call cost of
-// computing a canonical hash from a header object. On main, CanonicalHash
-// calls headerFromSnapshot + header.Hash() on every invocation for blocks
-// that live in snapshots (not in the DB). This benchmark isolates the
-// header.Hash() cost only; in production the full per-call cost also includes
-// headerFromSnapshot (mmap read + decompression + RLP decode), and header.Hash()
-// itself is more expensive because real headers carry more fields.
-func BenchmarkCanonicalHash_SnapshotNoCache(b *testing.B) {
+// BenchmarkCanonicalHash_HeaderHash_Realistic measures the cost of computing a
+// canonical hash from a full mainnet-like header (~500-byte RLP). On main,
+// CanonicalHash pays this cost on EVERY call for snapshot-range blocks because
+// headerFromSnapshot produces a fresh *Header each time (no per-object caching
+// across calls). CalcHash is used here instead of Hash to bypass the per-object
+// atomic cache and reflect the true first-call cost.
+// The real per-call cost on main also includes headerFromSnapshot (decompress +
+// RLP decode from the memory-mapped snapshot file), which is not measured here.
+func BenchmarkCanonicalHash_HeaderHash_Realistic(b *testing.B) {
 	headers := make([]*types.Header, benchBlockCount)
 	for i := uint64(0); i < benchBlockCount; i++ {
-		headers[i] = &types.Header{Number: *uint256.NewInt(i)}
+		headers[i] = realisticHeader(i)
 	}
-
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_ = headers[i%benchBlockCount].Hash()
+		_ = headers[i%benchBlockCount].CalcHash()
 	}
 }
 
-// BenchmarkCanonicalHash_SnapshotCacheHit measures the steady-state cost on
-// this branch: after the first request populates the LRU cache, every
-// subsequent CanonicalHash call for a snapshot-range block is a single
-// cache lookup. Compare this against BenchmarkCanonicalHash_SnapshotNoCache
-// to see the per-call saving.
-func BenchmarkCanonicalHash_SnapshotCacheHit(b *testing.B) {
+// BenchmarkCanonicalHash_LRUCacheHit measures the steady-state cost of a cache
+// lookup on this branch. After the first CanonicalHash call for a snapshot-range
+// block, all subsequent calls return here instead of calling headerFromSnapshot
+// + header.Hash(). Compare this against BenchmarkCanonicalHash_HeaderHash_Realistic
+// to see the per-call saving (headerFromSnapshot decompression is additional).
+func BenchmarkCanonicalHash_LRUCacheHit(b *testing.B) {
 	cache, err := lru.New[uint64, common.Hash](10_000)
 	if err != nil {
 		b.Fatal(err)
 	}
 	for i := uint64(0); i < benchBlockCount; i++ {
-		h := &types.Header{Number: *uint256.NewInt(i)}
-		cache.Add(i, h.Hash())
+		cache.Add(i, realisticHeader(i).Hash())
 	}
 
 	b.ResetTimer()

--- a/db/snapshotsync/freezeblocks/block_reader_bench_test.go
+++ b/db/snapshotsync/freezeblocks/block_reader_bench_test.go
@@ -42,16 +42,20 @@ package freezeblocks
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	lru "github.com/hashicorp/golang-lru/v2"
 	uint256 "github.com/holiman/uint256"
 
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv/dbcfg"
 	"github.com/erigontech/erigon/db/kv/memdb"
 	"github.com/erigontech/erigon/db/rawdb"
+	"github.com/erigontech/erigon/execution/chain/networkname"
 	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/node/ethconfig"
 )
 
 const benchBlockCount = 1_000
@@ -96,6 +100,7 @@ func BenchmarkCanonicalHash_MDBXLookup(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
+	defer rwTx.Rollback() //nolint:gocritic
 	for i := uint64(0); i < benchBlockCount; i++ {
 		if err := rawdb.WriteCanonicalHash(rwTx, realisticHeader(i).Hash(), i); err != nil {
 			b.Fatal(err)
@@ -158,5 +163,136 @@ func BenchmarkCanonicalHash_LRUCacheHit(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		_, _ = cache.Get(uint64(i % benchBlockCount))
+	}
+}
+
+// BenchmarkCanonicalHash_RealSnapshot is an end-to-end benchmark using real
+// snapshot files from disk. It measures the full CanonicalHash call path
+// including MDBX lookup (miss) + snapshot decompression + RLP decode +
+// header.Hash() on main, vs. MDBX lookup (miss) + LRU cache hit on this branch.
+//
+// Requires a local Erigon mainnet datadir with snapshots. Set ERIGON_SNAP_DIR
+// to the snapshots directory, or the benchmark is skipped.
+//
+//	ERIGON_SNAP_DIR=/home/user/.local/share/erigon/snapshots \
+//	  go test -bench=BenchmarkCanonicalHash_RealSnapshot -benchmem -benchtime=5s \
+//	  ./db/snapshotsync/freezeblocks/
+//
+// Run on both main and this branch to compare:
+//
+//	main:        every call pays full snapshot I/O + decompression + hash
+//	this branch: after warmup, every call is a single LRU lookup
+func BenchmarkCanonicalHash_RealSnapshot(b *testing.B) {
+	snapDir := os.Getenv("ERIGON_SNAP_DIR")
+	if snapDir == "" {
+		b.Skip("set ERIGON_SNAP_DIR to a mainnet snapshots directory to run this benchmark")
+	}
+	if _, err := os.Stat(snapDir); err != nil {
+		b.Skipf("snapshot dir not accessible: %v", err)
+	}
+
+	logger := log.New()
+	cfg := ethconfig.Defaults.Snapshot
+	cfg.ChainName = networkname.Mainnet
+	snapshots := NewRoSnapshots(cfg, snapDir, logger)
+	if err := snapshots.OpenFolder(); err != nil {
+		b.Fatal(err)
+	}
+	defer snapshots.Close()
+
+	available := snapshots.BlocksAvailable()
+	if available == 0 {
+		b.Skip("no blocks available in snapshot dir")
+	}
+
+	blockReader := NewBlockReader(snapshots, nil)
+
+	// Use an empty memdb so every lookup misses the DB and falls through to snapshots.
+	db := memdb.NewTestDB(b, dbcfg.ChainDB)
+	tx, err := db.BeginRo(context.Background())
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer tx.Rollback()
+
+	// Pick blocks well inside the available range.
+	const startBlock = 500_000
+	const numBlocks = 1_000
+	if available < startBlock+numBlocks {
+		b.Skipf("need at least %d blocks in snapshots, got %d", startBlock+numBlocks, available)
+	}
+
+	// Warmup: on this branch this populates the cache; on main it is a no-op.
+	for i := uint64(startBlock); i < startBlock+numBlocks; i++ {
+		if _, _, err := blockReader.CanonicalHash(context.Background(), tx, i); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		blockNum := uint64(startBlock + (i % numBlocks))
+		if _, _, err := blockReader.CanonicalHash(context.Background(), tx, blockNum); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkCanonicalHash_RealSnapshot_Cold measures the full snapshot path with
+// no cache warmup. This is what every call costs on main (which has no LRU cache)
+// and what the first call costs on this branch. It cycles through enough distinct
+// block numbers to exceed the LRU cache capacity, forcing cache misses.
+//
+//	ERIGON_SNAP_DIR=/datadisk/erigon34/datadir/snapshots \
+//	  go test -bench=BenchmarkCanonicalHash_RealSnapshot_Cold -benchmem -benchtime=5s \
+//	  ./db/snapshotsync/freezeblocks/
+func BenchmarkCanonicalHash_RealSnapshot_Cold(b *testing.B) {
+	snapDir := os.Getenv("ERIGON_SNAP_DIR")
+	if snapDir == "" {
+		b.Skip("set ERIGON_SNAP_DIR to a mainnet snapshots directory to run this benchmark")
+	}
+	if _, err := os.Stat(snapDir); err != nil {
+		b.Skipf("snapshot dir not accessible: %v", err)
+	}
+
+	logger := log.New()
+	cfg := ethconfig.Defaults.Snapshot
+	cfg.ChainName = networkname.Mainnet
+	snapshots := NewRoSnapshots(cfg, snapDir, logger)
+	if err := snapshots.OpenFolder(); err != nil {
+		b.Fatal(err)
+	}
+	defer snapshots.Close()
+
+	available := snapshots.BlocksAvailable()
+	if available == 0 {
+		b.Skip("no blocks available in snapshot dir")
+	}
+
+	blockReader := NewBlockReader(snapshots, nil)
+
+	db := memdb.NewTestDB(b, dbcfg.ChainDB)
+	tx, err := db.BeginRo(context.Background())
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer tx.Rollback()
+
+	const startBlock = 500_000
+	// Use a range larger than the LRU cache size (10_000) to guarantee cache misses.
+	const coldRange = 20_000
+	if available < startBlock+coldRange {
+		b.Skipf("need at least %d blocks in snapshots, got %d", startBlock+coldRange, available)
+	}
+
+	// No warmup — every call is a cold snapshot read.
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		blockNum := uint64(startBlock + (i % coldRange))
+		if _, _, err := blockReader.CanonicalHash(context.Background(), tx, blockNum); err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/db/snapshotsync/freezeblocks/block_reader_bench_test.go
+++ b/db/snapshotsync/freezeblocks/block_reader_bench_test.go
@@ -1,0 +1,129 @@
+// Copyright 2024 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package freezeblocks
+
+// Benchmarks for BlockReader.CanonicalHash hot path.
+//
+// The LRU cache introduced by PR #19173 only populates from snapshot data
+// (immutable, post-finalized blocks). For blocks still in the DB the code
+// path is identical on main and on this branch.
+//
+// The three benchmarks below isolate the components that change:
+//
+//   BenchmarkCanonicalHash_DBPath          – raw MDBX lookup; same on both branches.
+//   BenchmarkCanonicalHash_SnapshotNoCache – header.Hash() per call; what main
+//                                            pays for every snapshot-range lookup.
+//   BenchmarkCanonicalHash_SnapshotCacheHit – LRU Get() per call; what this branch
+//                                             pays after the first snapshot lookup.
+//
+// Running on main vs. this branch:
+//
+//   go test -bench=BenchmarkCanonicalHash -benchmem ./db/snapshotsync/freezeblocks/
+
+import (
+	"context"
+	"testing"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+	uint256 "github.com/holiman/uint256"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/db/kv/dbcfg"
+	"github.com/erigontech/erigon/db/kv/memdb"
+	"github.com/erigontech/erigon/db/rawdb"
+	"github.com/erigontech/erigon/execution/types"
+)
+
+const benchBlockCount = 1_000
+
+// BenchmarkCanonicalHash_DBPath measures a raw MDBX canonical-hash lookup.
+// This path is taken when the block is in the DB (not yet in snapshots) and
+// is identical on main and on this branch — the cache is never populated from
+// DB data.
+func BenchmarkCanonicalHash_DBPath(b *testing.B) {
+	db := memdb.NewTestDB(b, dbcfg.ChainDB)
+
+	rwTx, err := db.BeginRw(context.Background())
+	if err != nil {
+		b.Fatal(err)
+	}
+	for i := uint64(0); i < benchBlockCount; i++ {
+		h := &types.Header{Number: *uint256.NewInt(i)}
+		if err := rawdb.WriteCanonicalHash(rwTx, h.Hash(), i); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if err := rwTx.Commit(); err != nil {
+		b.Fatal(err)
+	}
+
+	tx, err := db.BeginRo(context.Background())
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer tx.Rollback()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := rawdb.ReadCanonicalHash(tx, uint64(i%benchBlockCount)); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkCanonicalHash_SnapshotNoCache measures the per-call cost of
+// computing a canonical hash from a header object. On main, CanonicalHash
+// calls headerFromSnapshot + header.Hash() on every invocation for blocks
+// that live in snapshots (not in the DB). This benchmark isolates the
+// header.Hash() cost only; in production the full per-call cost also includes
+// headerFromSnapshot (mmap read + decompression + RLP decode), and header.Hash()
+// itself is more expensive because real headers carry more fields.
+func BenchmarkCanonicalHash_SnapshotNoCache(b *testing.B) {
+	headers := make([]*types.Header, benchBlockCount)
+	for i := uint64(0); i < benchBlockCount; i++ {
+		headers[i] = &types.Header{Number: *uint256.NewInt(i)}
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = headers[i%benchBlockCount].Hash()
+	}
+}
+
+// BenchmarkCanonicalHash_SnapshotCacheHit measures the steady-state cost on
+// this branch: after the first request populates the LRU cache, every
+// subsequent CanonicalHash call for a snapshot-range block is a single
+// cache lookup. Compare this against BenchmarkCanonicalHash_SnapshotNoCache
+// to see the per-call saving.
+func BenchmarkCanonicalHash_SnapshotCacheHit(b *testing.B) {
+	cache, err := lru.New[uint64, common.Hash](10_000)
+	if err != nil {
+		b.Fatal(err)
+	}
+	for i := uint64(0); i < benchBlockCount; i++ {
+		h := &types.Header{Number: *uint256.NewInt(i)}
+		cache.Add(i, h.Hash())
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = cache.Get(uint64(i % benchBlockCount))
+	}
+}

--- a/db/snapshotsync/freezeblocks/block_reader_test.go
+++ b/db/snapshotsync/freezeblocks/block_reader_test.go
@@ -297,10 +297,10 @@ func TestCanonicalHashCache_SnapshotPath(t *testing.T) {
 	compressCfg.MinPatternScore = 100
 	c, err := seg.NewCompressor(t.Context(), "test", segPath, tmpDir, compressCfg, log.LvlDebug, logger)
 	require.NoError(t, err)
-	defer c.Close()
 	c.DisableFsync()
 	require.NoError(t, c.AddWord(word))
 	require.NoError(t, c.Compress())
+	c.Close()
 
 	// Build index with BaseDataID=from so OrdinalLookup(blockNum-from)=OrdinalLookup(0).
 	idxPath := filepath.Join(tmpDir, snaptype.IdxFileName(ver, from, to, snaptype2.Enums.Headers.String()))
@@ -314,10 +314,10 @@ func TestCanonicalHashCache_SnapshotPath(t *testing.T) {
 		Enums:      true,
 	}, logger)
 	require.NoError(t, err)
-	defer idx.Close()
 	idx.DisableFsync()
 	require.NoError(t, idx.AddKey([]byte{0}, 0))
 	require.NoError(t, idx.Build(t.Context()))
+	idx.Close()
 
 	// Bodies and Transactions segments are required for OpenFolder to recognise the range.
 	createTestSegmentFile(t, from, to, snaptype2.Enums.Bodies, tmpDir, ver, logger)

--- a/db/snapshotsync/freezeblocks/block_reader_test.go
+++ b/db/snapshotsync/freezeblocks/block_reader_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/erigontech/erigon/db/snaptype2"
 	"github.com/erigontech/erigon/db/version"
 	"github.com/erigontech/erigon/execution/chain/networkname"
+	"github.com/erigontech/erigon/execution/rlp"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/node/ethconfig"
 )
@@ -251,7 +252,7 @@ func TestCanonicalHashCache_MultipleBlocks(t *testing.T) {
 	require.NoError(t, err)
 	defer tx.Rollback()
 
-	// Read all blocks to populate cache
+	// Read all blocks — results come from DB, not snapshots, so the cache stays empty.
 	for i := uint64(0); i < 5; i++ {
 		hash, ok, err := blockReader.CanonicalHash(context.Background(), tx, i)
 		require.NoError(t, err)
@@ -264,4 +265,90 @@ func TestCanonicalHashCache_MultipleBlocks(t *testing.T) {
 		_, found := blockReader.canonicalHashCache.Get(i)
 		assert.False(t, found, "block %d should not be cached (DB data)", i)
 	}
+}
+
+// TestCanonicalHashCache_SnapshotPath verifies that CanonicalHash populates
+// canonicalHashCache when the hash is read from a snapshot segment (not from DB),
+// and that subsequent calls are served from the cache without touching the snapshot.
+func TestCanonicalHashCache_SnapshotPath(t *testing.T) {
+	// Use the same from/to range as the other snapshot tests so OpenFolder
+	// recognises the segment (naming convention: v1.0-000000-000001-headers.seg).
+	const (
+		from     = uint64(1)
+		to       = uint64(1000)
+		blockNum = from // first block in the segment; OrdinalLookup(from-from)=OrdinalLookup(0)
+	)
+	tmpDir := t.TempDir()
+	logger := log.New()
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+
+	ver := version.V1_0
+
+	// Build a header and RLP-encode it.
+	// Snapshot word format: 1 prefix byte (skipped by the decoder) + RLP bytes.
+	header := &types.Header{Number: *uint256.NewInt(blockNum)}
+	rlpBytes, err := rlp.EncodeToBytes(header)
+	require.NoError(t, err)
+	word := append([]byte{0}, rlpBytes...)
+
+	// Write the headers segment with a single valid entry.
+	segPath := filepath.Join(tmpDir, snaptype.SegmentFileName(ver, from, to, snaptype2.Enums.Headers))
+	compressCfg := seg.DefaultCfg
+	compressCfg.MinPatternScore = 100
+	c, err := seg.NewCompressor(t.Context(), "test", segPath, tmpDir, compressCfg, log.LvlDebug, logger)
+	require.NoError(t, err)
+	defer c.Close()
+	c.DisableFsync()
+	require.NoError(t, c.AddWord(word))
+	require.NoError(t, c.Compress())
+
+	// Build index with BaseDataID=from so OrdinalLookup(blockNum-from)=OrdinalLookup(0).
+	idxPath := filepath.Join(tmpDir, snaptype.IdxFileName(ver, from, to, snaptype2.Enums.Headers.String()))
+	idx, err := recsplit.NewRecSplit(recsplit.RecSplitArgs{
+		KeyCount:   1,
+		BucketSize: 10,
+		TmpDir:     tmpDir,
+		IndexFile:  idxPath,
+		LeafSize:   8,
+		BaseDataID: from,
+		Enums:      true,
+	}, logger)
+	require.NoError(t, err)
+	defer idx.Close()
+	idx.DisableFsync()
+	require.NoError(t, idx.AddKey([]byte{0}, 0))
+	require.NoError(t, idx.Build(t.Context()))
+
+	// Bodies and Transactions segments are required for OpenFolder to recognise the range.
+	createTestSegmentFile(t, from, to, snaptype2.Enums.Bodies, tmpDir, ver, logger)
+	createTestSegmentFile(t, from, to, snaptype2.Enums.Transactions, tmpDir, ver, logger)
+
+	cfg := ethconfig.Defaults.Snapshot
+	cfg.ChainName = networkname.Mainnet
+	snapshots := NewRoSnapshots(cfg, tmpDir, logger)
+	require.NoError(t, snapshots.OpenFolder())
+	defer snapshots.Close()
+
+	blockReader := NewBlockReader(snapshots, nil)
+
+	// No canonical hash written to DB → CanonicalHash must fall through to snapshot path.
+	tx, err := db.BeginRo(context.Background())
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	// First call: DB miss → snapshot read → cache populated.
+	hash1, ok, err := blockReader.CanonicalHash(context.Background(), tx, blockNum)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, header.Hash(), hash1)
+
+	cached, found := blockReader.canonicalHashCache.Get(blockNum)
+	assert.True(t, found, "canonicalHashCache must be populated after a snapshot read")
+	assert.Equal(t, header.Hash(), cached)
+
+	// Second call: must be served from cache (no snapshot I/O).
+	hash2, ok2, err := blockReader.CanonicalHash(context.Background(), tx, blockNum)
+	require.NoError(t, err)
+	assert.True(t, ok2)
+	assert.Equal(t, header.Hash(), hash2)
 }

--- a/db/snapshotsync/freezeblocks/block_reader_test.go
+++ b/db/snapshotsync/freezeblocks/block_reader_test.go
@@ -181,18 +181,17 @@ func TestCanonicalHashCache_DBHit(t *testing.T) {
 	require.NoError(t, err)
 	defer tx.Rollback()
 
-	// First call: should read from DB and populate cache
+	// First call: should read from DB (DB results are not cached, only snapshot results are)
 	hash, ok, err := blockReader.CanonicalHash(context.Background(), tx, 0)
 	require.NoError(t, err)
 	assert.True(t, ok)
 	assert.Equal(t, expectedHash, hash)
 
-	// Verify the cache is populated
-	cached, found := blockReader.canonicalHashCache.Get(uint64(0))
-	assert.True(t, found)
-	assert.Equal(t, expectedHash, cached)
+	// DB results should NOT be cached (only snapshot data is immutable and cacheable)
+	_, found := blockReader.canonicalHashCache.Get(uint64(0))
+	assert.False(t, found)
 
-	// Second call: should return from cache (same result)
+	// Second call: should still return correct result from DB
 	hash2, ok2, err := blockReader.CanonicalHash(context.Background(), tx, 0)
 	require.NoError(t, err)
 	assert.True(t, ok2)
@@ -258,10 +257,9 @@ func TestCanonicalHashCache_MultipleBlocks(t *testing.T) {
 		assert.Equal(t, hashes[i], hash)
 	}
 
-	// All should be cached
+	// DB results should NOT be cached (only snapshot data is immutable and cacheable)
 	for i := uint64(0); i < 5; i++ {
-		cached, found := blockReader.canonicalHashCache.Get(i)
-		assert.True(t, found, "block %d should be cached", i)
-		assert.Equal(t, hashes[i], cached)
+		_, found := blockReader.canonicalHashCache.Get(i)
+		assert.False(t, found, "block %d should not be cached (DB data)", i)
 	}
 }

--- a/db/snapshotsync/freezeblocks/block_reader_test.go
+++ b/db/snapshotsync/freezeblocks/block_reader_test.go
@@ -166,6 +166,7 @@ func TestCanonicalHashCache_DBHit(t *testing.T) {
 	// Write a canonical hash to the DB
 	rwTx, err := db.BeginRw(context.Background())
 	require.NoError(t, err)
+	defer rwTx.Rollback()
 	header := &types.Header{Number: *uint256.NewInt(0)}
 	expectedHash := header.Hash()
 	require.NoError(t, rawdb.WriteCanonicalHash(rwTx, expectedHash, 0))
@@ -230,6 +231,7 @@ func TestCanonicalHashCache_MultipleBlocks(t *testing.T) {
 	// Write multiple canonical hashes
 	rwTx, err := db.BeginRw(context.Background())
 	require.NoError(t, err)
+	defer rwTx.Rollback()
 
 	hashes := make([]common.Hash, 5)
 	for i := uint64(0); i < 5; i++ {

--- a/db/snapshotsync/freezeblocks/block_reader_test.go
+++ b/db/snapshotsync/freezeblocks/block_reader_test.go
@@ -17,9 +17,11 @@
 package freezeblocks
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
+	uint256 "github.com/holiman/uint256"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -155,4 +157,111 @@ func TestBlockReaderGenesisBlockWithSnapshots(t *testing.T) {
 	hasSenders, err := blockReader.HasSenders(t.Context(), tx, genesisHash, 0)
 	assert.NoError(t, err)
 	assert.False(t, hasSenders) // should be false because genesis block does not have senders
+}
+
+func TestCanonicalHashCache_DBHit(t *testing.T) {
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	logger := log.New()
+
+	// Write a canonical hash to the DB
+	rwTx, err := db.BeginRw(context.Background())
+	require.NoError(t, err)
+	header := &types.Header{Number: *uint256.NewInt(0)}
+	expectedHash := header.Hash()
+	require.NoError(t, rawdb.WriteCanonicalHash(rwTx, expectedHash, 0))
+	require.NoError(t, rwTx.Commit())
+
+	cfg := ethconfig.Defaults.Snapshot
+	cfg.ChainName = networkname.Mainnet
+	snapshots := NewRoSnapshots(cfg, t.TempDir(), logger)
+	defer snapshots.Close()
+	blockReader := NewBlockReader(snapshots, nil)
+
+	tx, err := db.BeginRo(context.Background())
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	// First call: should read from DB and populate cache
+	hash, ok, err := blockReader.CanonicalHash(context.Background(), tx, 0)
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, expectedHash, hash)
+
+	// Verify the cache is populated
+	cached, found := blockReader.canonicalHashCache.Get(uint64(0))
+	assert.True(t, found)
+	assert.Equal(t, expectedHash, cached)
+
+	// Second call: should return from cache (same result)
+	hash2, ok2, err := blockReader.CanonicalHash(context.Background(), tx, 0)
+	require.NoError(t, err)
+	assert.True(t, ok2)
+	assert.Equal(t, expectedHash, hash2)
+}
+
+func TestCanonicalHashCache_Miss(t *testing.T) {
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	logger := log.New()
+
+	cfg := ethconfig.Defaults.Snapshot
+	cfg.ChainName = networkname.Mainnet
+	snapshots := NewRoSnapshots(cfg, t.TempDir(), logger)
+	defer snapshots.Close()
+	blockReader := NewBlockReader(snapshots, nil)
+
+	tx, err := db.BeginRo(context.Background())
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	// Block 999 doesn't exist in DB or snapshots
+	hash, ok, err := blockReader.CanonicalHash(context.Background(), tx, 999)
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Equal(t, common.Hash{}, hash)
+
+	// Should not be cached
+	_, found := blockReader.canonicalHashCache.Get(uint64(999))
+	assert.False(t, found)
+}
+
+func TestCanonicalHashCache_MultipleBlocks(t *testing.T) {
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	logger := log.New()
+
+	// Write multiple canonical hashes
+	rwTx, err := db.BeginRw(context.Background())
+	require.NoError(t, err)
+
+	hashes := make([]common.Hash, 5)
+	for i := uint64(0); i < 5; i++ {
+		header := &types.Header{Number: *uint256.NewInt(i)}
+		hashes[i] = header.Hash()
+		require.NoError(t, rawdb.WriteCanonicalHash(rwTx, hashes[i], i))
+	}
+	require.NoError(t, rwTx.Commit())
+
+	cfg := ethconfig.Defaults.Snapshot
+	cfg.ChainName = networkname.Mainnet
+	snapshots := NewRoSnapshots(cfg, t.TempDir(), logger)
+	defer snapshots.Close()
+	blockReader := NewBlockReader(snapshots, nil)
+
+	tx, err := db.BeginRo(context.Background())
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	// Read all blocks to populate cache
+	for i := uint64(0); i < 5; i++ {
+		hash, ok, err := blockReader.CanonicalHash(context.Background(), tx, i)
+		require.NoError(t, err)
+		assert.True(t, ok)
+		assert.Equal(t, hashes[i], hash)
+	}
+
+	// All should be cached
+	for i := uint64(0); i < 5; i++ {
+		cached, found := blockReader.canonicalHashCache.Get(i)
+		assert.True(t, found, "block %d should be cached", i)
+		assert.Equal(t, hashes[i], cached)
+	}
 }


### PR DESCRIPTION
Adds a `canonicalHashCache` LRU (10,000 entries, 32 bytes/entry, ~320 KB) to `BlockReader` to cache `blockNum → hash` lookups for snapshot-range blocks.

**Why a separate cache instead of increasing `headerByNumCache`:**
`headerByNumCache` stores full `*Header` objects (~500 bytes/entry, 1,000 slots, ~500 KB). To cover the same 10,000-block working set it would require ~5 MB. `canonicalHashCache` achieves the same coverage at 16× less memory by storing only the 32-byte hash.

**Two regimes:**

- **Working set ≤ 1,000 blocks** (`headerByNumCache` warm): `canonicalHashCache` short-circuits `ViewSingleFile` (refcount increments + closure allocation) which main always pays even when the `*Header` is cached → **~3.3×** (572 → 167 ns)
- **Working set > 1,000 and ≤ 10,000 blocks** (`headerByNumCache` evicted, `canonicalHashCache` still warm): main falls back to full snapshot path → **~33×** (5,119 → 167 ns)

Results (real mainnet snapshots, i9-14900HX):

| Benchmark | ns/op | B/op | allocs/op | Notes |
|-----------|------:|-----:|----------:|-------|
| `BenchmarkCanonicalHash_RealSnapshot` | 167 | 8 | 1 | this PR — `canonicalHashCache` hit |
| `BenchmarkCanonicalHash_RealSnapshot_MainEquivalent` | 572 | 176 | 5 | main equivalent — `headerByNumCache` warm |
| `BenchmarkCanonicalHash_RealSnapshot_Cold` | 5,119 | 1,657 | 11 | working set > 1,000 blocks |

> **Why MainEquivalent (572 ns) is higher than the theoretical estimate (~235 ns):** `ViewSingleFile` is called on every `CanonicalHash` invocation even when `headerByNumCache` is warm. It atomically increments the refcount of each non-frozen segment and allocates a release closure — 5 allocs, 176 B per call. The theoretical estimate only counted MDBX miss + LRU lookup + atomic hash load and did not account for this overhead.