### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/execution/rlp/internal/rlpstruct/rlpstruct.go
+++ b/execution/rlp/internal/rlpstruct/rlpstruct.go
@@ -160,7 +160,7 @@ func parseTag(field Field, lastPublic int) (Tags, error) {
 	name := field.Name
 	tag := reflect.StructTag(field.Tag)
 	var ts Tags
-	for _, t := range strings.Split(tag.Get("rlp"), ",") {
+	for t := range strings.SplitSeq(tag.Get("rlp"), ",") {
 		switch t = strings.TrimSpace(t); t {
 		case "":
 			// empty tag is allowed for some reason

--- a/p2p/discover/v5wire/encoding_test.go
+++ b/p2p/discover/v5wire/encoding_test.go
@@ -623,7 +623,7 @@ func hexFile(file string) []byte {
 
 	// Gather hex data, ignore comments.
 	var text []byte
-	for _, line := range bytes.Split(fileContent, []byte("\n")) {
+	for line := range bytes.SplitSeq(fileContent, []byte("\n")) {
 		line = bytes.TrimSpace(line)
 		if len(line) > 0 && line[0] == '#' {
 			continue
@@ -651,7 +651,7 @@ func writeTestVector(file, comment string, data []byte) {
 	defer fd.Close()
 
 	if len(comment) > 0 {
-		for _, line := range strings.Split(strings.TrimSpace(comment), "\n") {
+		for line := range strings.SplitSeq(strings.TrimSpace(comment), "\n") {
 			fmt.Fprintf(fd, "# %s\n", line)
 		}
 		fmt.Fprintln(fd)


### PR DESCRIPTION
Similar to https://github.com/erigontech/erigon/pull/17910 and I have refactored all the cases.

strings.SplitSeq (introduced in Go 1.23) returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

It significantly reduces memory allocations and can improve performance for long strings.