### PR TITLE
Flaky test: Cap amount of time spent block building as to risking timing out

### DIFF
--- a/execution/execmodule/block_building.go
+++ b/execution/execmodule/block_building.go
@@ -98,7 +98,7 @@ func (e *EthereumExecutionModule) AssembleBlock(ctx context.Context, req *execut
 	param.PayloadId = e.nextPayloadId
 	e.lastParameters = &param
 
-	e.builders[e.nextPayloadId] = builder.NewBlockBuilder(e.builderFunc, &param, e.config.SecondsPerSlot())
+	e.builders[e.nextPayloadId] = builder.NewBlockBuilder(e.builderFunc, &param, e.config.SecondsPerSlot()/4)
 	e.logger.Info("[ForkChoiceUpdated] BlockBuilder added", "payload", e.nextPayloadId)
 
 	return &executionproto.AssembleBlockResponse{


### PR DESCRIPTION
Basically waiting 12s for building a block is bad. should be probably slot_time/3 for good measure