### PR TITLE
mdbx: use slices.Sort for bucket names

### DIFF
--- a/db/kv/mdbx/kv_mdbx.go
+++ b/db/kv/mdbx/kv_mdbx.go
@@ -26,8 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sort"
-	"strings"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1634,9 +1633,7 @@ func bucketSlice(b kv.TableCfg) []string {
 	for name := range b {
 		buckets = append(buckets, name)
 	}
-	sort.Slice(buckets, func(i, j int) bool {
-		return strings.Compare(buckets[i], buckets[j]) < 0
-	})
+	slices.Sort(buckets)
 	return buckets
 }
 


### PR DESCRIPTION
Replace sort.Slice with slices.Sort in bucketSlice() - same behavior, cleaner code.