### PR TITLE
db/mdbx: remove dead debug code and migrate to slices.Sort

### DIFF
--- a/db/kv/mdbx/kv_mdbx.go
+++ b/db/kv/mdbx/kv_mdbx.go
@@ -26,8 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sort"
-	"strings"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1010,14 +1009,6 @@ func (tx *MdbxTx) Commit() error {
 	}()
 	tx.closeCursors()
 
-	//slowTx := 10 * time.Second
-	//if debug.SlowCommit() > 0 {
-	//	slowTx = debug.SlowCommit()
-	//}
-	//
-	//if debug.BigRoTxKb() > 0 || debug.BigRwTxKb() > 0 {
-	//	tx.PrintDebugInfo()
-	//}
 	tx.CollectMetrics()
 
 	latency, err := tx.tx.Commit()
@@ -1634,9 +1625,7 @@ func bucketSlice(b kv.TableCfg) []string {
 	for name := range b {
 		buckets = append(buckets, name)
 	}
-	sort.Slice(buckets, func(i, j int) bool {
-		return strings.Compare(buckets[i], buckets[j]) < 0
-	})
+	slices.Sort(buckets)
 	return buckets
 }
 


### PR DESCRIPTION
Remove dead debug code in Commit()**: Deleted 8 lines of commented-out debug logic for SlowCommit/BigRoTxKb checks that haven't been active. Migrate sort.Slice to slices.Sort in bucketSlice()**: Replace sort.Slice with strings.Compare logic with simpler slices.Sort. This aligns with the codebase pattern (already used in 18+ places) and reduces allocations by avoiding closure capture.
