### PR TITLE
downloader: fix double-prefixed webseed metainfo URL

### DIFF
--- a/db/downloader/downloader.go
+++ b/db/downloader/downloader.go
@@ -1074,7 +1074,7 @@ func (d *Downloader) fetchMetainfoFromWebseeds(ctx context.Context, name string,
 		buf.Reset()
 		var mi metainfo.MetaInfo
 		var w io.Writer = &buf
-		mi, err = GetMetainfoFromWebseed(ctx, base, base, d.metainfoHttpClient, w)
+		mi, err = GetMetainfoFromWebseed(ctx, base, name, d.metainfoHttpClient, w)
 		if err != nil {
 			d.log(log.LvlDebug, "error fetching metainfo from webseed", "err", err, "name", name, "webseed", base)
 			// Whither error?


### PR DESCRIPTION
## Summary

- PR #18755 ("Add webseed checker") accidentally passed `base` for both `webseedUrlBase` and `name` in `GetMetainfoFromWebseed`, producing doubled URLs like `https://host/https://host/.torrent` which return HTTP 404
- Fix: pass the snapshot `name` instead of `base` as the second argument

Fixes https://github.com/erigontech/erigon/issues/19094

## Test plan

- [x] Built and ran an ephemeral mainnet instance for 2 minutes — no `"error fetching metainfo from webseeds"` warnings, all 305/305 file metadata fetched, webseed download steady at ~62-70 MB/s

🤖 Generated with [Claude Code](https://claude.com/claude-code)