### PR TITLE
db/migrations: fix typo in version downgrade error message

### DIFF
--- a/db/migrations/migrations.go
+++ b/db/migrations/migrations.go
@@ -149,7 +149,7 @@ func (m *Migrator) VerifyVersion(db kv.RwDB, chaindata string) error {
 				return fmt.Errorf("cannot downgrade major DB version from %d to %d", major, kv.DBSchemaVersion.Major)
 			} else if major == kv.DBSchemaVersion.Major {
 				if minor > kv.DBSchemaVersion.Minor {
-					return fmt.Errorf("cannot downgrade minor DB version from %d.%d to %d.%d", major, minor, kv.DBSchemaVersion.Major, kv.DBSchemaVersion.Major)
+					return fmt.Errorf("cannot downgrade minor DB version from %d.%d to %d.%d", major, minor, kv.DBSchemaVersion.Major, kv.DBSchemaVersion.Minor)
 				}
 			} else {
 				if kv.DBSchemaVersion.Major != major {


### PR DESCRIPTION
he error message for minor DB version downgrade contained a copy-paste typo: kv.DBSchemaVersion.Major was used twice instead of Major and Minor. This caused confusing error messages (e.g., "cannot downgrade from 7.5 to 7.7" when actually trying to downgrade to 7.0).

Fixed the formatting string to correctly display both major and minor version numbers in the downgrade error message.