### PR TITLE
rpc/jsonrpc: remove redundant dedup map in getModifiedAccounts

### DIFF
--- a/rpc/jsonrpc/debug_api.go
+++ b/rpc/jsonrpc/debug_api.go
@@ -294,17 +294,12 @@ func getModifiedAccounts(tx kv.TemporalTx, startTxNum, endTxNum uint64) ([]commo
 	defer it.Close()
 
 	var result []common.Address
-	saw := make(map[common.Address]struct{})
 	for it.HasNext() {
 		k, _, err := it.Next()
 		if err != nil {
 			return nil, err
 		}
-		//TODO: data is sorted, enough to compare with prevKey
-		if _, ok := saw[common.BytesToAddress(k)]; !ok {
-			saw[common.BytesToAddress(k)] = struct{}{}
-			result = append(result, common.BytesToAddress(k))
-		}
+		result = append(result, common.BytesToAddress(k))
 	}
 	return result, nil
 }


### PR DESCRIPTION
HistoryRange already returns unique sorted keys (dedup happens internally at the iterator level). The saw map and 3x BytesToAddress calls per key were unnecessary overhead — removed map, TODO comment, and reduced to a single BytesToAddress call.