### PR TITLE
node/cli: remove unused chainId variable in ApplyFlagsForEthConfig

### DIFF
--- a/node/cli/flags.go
+++ b/node/cli/flags.go
@@ -234,12 +234,6 @@ var (
 )
 
 func ApplyFlagsForEthConfig(ctx *cli.Context, cfg *ethconfig.Config, logger log.Logger) {
-	chainId := cfg.NetworkID
-	if cfg.Genesis != nil {
-		chainId = cfg.Genesis.Config.ChainID.Uint64()
-	}
-	_ = chainId
-
 	blockDistance := ctx.Uint64(PruneBlocksDistanceFlag.Name)
 	distance := ctx.Uint64(PruneDistanceFlag.Name)
 


### PR DESCRIPTION
`chainId` was computed from `cfg.NetworkID` / `cfg.Genesis.Config.ChainID` but immediately discarded via `_ = chainId` — it was never used anywhere in the function. This was likely a leftover from PersistReceiptsV2 development, where chain-dependent logic was planned but never implemented.

Removed the dead code block (5 lines) to reduce noise and eliminate an unnecessary nil-dereference risk on `cfg.Genesis.Config.ChainID`.