### PR TITLE
txnprovider/shutter: hoist ToListSSZ() out of signature verification loop

### DIFF
--- a/txnprovider/shutter/decryption_keys_validator.go
+++ b/txnprovider/shutter/decryption_keys_validator.go
@@ -169,6 +169,8 @@ func (v DecryptionKeysValidator) validateSignatures(msg *proto.DecryptionKeys, e
 		identityPreimages[i] = ip
 	}
 
+	identityPreimagesSSZ := identityPreimages.ToListSSZ()
+
 	for i, sig := range extraData.Signatures {
 		signerIdx := extraData.SignerIndices[i]
 		signer, err := eon.KeyperAt(signerIdx)
@@ -181,7 +183,7 @@ func (v DecryptionKeysValidator) validateSignatures(msg *proto.DecryptionKeys, e
 			Eon:               EonIndex(msg.Eon),
 			Slot:              extraData.Slot,
 			TxnPointer:        extraData.TxPointer,
-			IdentityPreimages: identityPreimages.ToListSSZ(),
+			IdentityPreimages: identityPreimagesSSZ,
 		}
 
 		ok, err := signatureData.Verify(sig, signer)


### PR DESCRIPTION
`identityPreimages.ToListSSZ()` was called inside the signatures loop in `validateSignatures`, creating a new `*ListSSZ` heap allocation on every iteration. Since the underlying data never changes between iterations, this also discarded the Merkle root cache (`ListSSZ.HashSSZ()` caches in `l.root`), forcing a full recomputation each time.

Moved the call before the loop so we allocate once and let the built-in cache work for subsequent iterations.