### PR TITLE
fix: make SharedDomains.txNum atomic to fix data race

### DIFF
--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -90,7 +90,7 @@ type SharedDomains struct {
 
 	logger log.Logger
 
-	txNum             uint64
+	txNum             atomic.Uint64
 	blockNum          atomic.Uint64
 	trace             bool //nolint
 	commitmentCapture bool
@@ -156,8 +156,8 @@ type changesetSwitcher interface {
 }
 
 func (sd *SharedDomains) Merge(other *SharedDomains) error {
-	if sd.txNum > other.txNum {
-		return fmt.Errorf("can't merge backwards: txnum: %d > %d", sd.txNum, other.txNum)
+	if sd.txNum.Load() > other.txNum.Load() {
+		return fmt.Errorf("can't merge backwards: txnum: %d > %d", sd.txNum.Load(), other.txNum.Load())
 	}
 
 	if err := sd.mem.Merge(other.mem); err != nil {
@@ -169,7 +169,7 @@ func (sd *SharedDomains) Merge(other *SharedDomains) error {
 		sd.sdCtx.SetPendingUpdate(otherUpd)
 	}
 
-	sd.txNum = other.txNum
+	sd.txNum.Store(other.txNum.Load())
 	sd.blockNum.Store(other.blockNum.Load())
 	return nil
 }
@@ -316,10 +316,10 @@ func (sd *SharedDomains) StepSize() uint64 { return sd.stepSize }
 // SetTxNum sets txNum for all domains as well as common txNum for all domains
 // Requires for sd.rwTx because of commitment evaluation in shared domains if stepSize is reached
 func (sd *SharedDomains) SetTxNum(txNum uint64) {
-	sd.txNum = txNum
+	sd.txNum.Store(txNum)
 }
 
-func (sd *SharedDomains) TxNum() uint64 { return sd.txNum }
+func (sd *SharedDomains) TxNum() uint64 { return sd.txNum.Load() }
 
 func (sd *SharedDomains) BlockNum() uint64 { return sd.blockNum.Load() }
 
@@ -411,7 +411,7 @@ func (sd *SharedDomains) GetLatest(domain kv.Domain, tx kv.TemporalTx, k []byte)
 		// files merge so this is not a problem in practice. file 0-1 will be non-deterministic
 		// but file 0-2 will be deterministic as it will include all entries from file 0-1 and so on.
 		if v, ok := sd.stateCache.Get(domain, k); ok {
-			return v, kv.Step(sd.txNum / sd.stepSize), nil
+			return v, kv.Step(sd.txNum.Load() / sd.stepSize), nil
 		}
 	}
 


### PR DESCRIPTION
## Problem

The `-race` CI workflow (`test-all-erigon-race`) fails on commit `08830f1` with a data race in `SharedDomains`:

```
WARNING: DATA RACE
Write at 0x00c012bd48e0 by goroutine 3210947:
  github.com/erigontech/erigon/db/state/execctx.(*SharedDomains).SetTxNum()
      db/state/execctx/domain_shared.go:319
  github.com/erigontech/erigon/db/state/execctx.(*SharedDomains).Close()
      db/state/execctx/domain_shared.go:365
  github.com/erigontech/erigon/execution/execmodule.(*EthereumExecutionModule).updateForkChoice.func3()
      execution/execmodule/forkchoice.go:267

Previous read at 0x00c012bd48e0 by goroutine 3210964:
  github.com/erigontech/erigon/db/state/execctx.(*SharedDomains).GetLatest()
      db/state/execctx/domain_shared.go:414
  ...
  github.com/erigontech/erigon/execution/commitment.(*Warmuper).Start.func1()
      execution/commitment/warmuper.go:185
```

The `updateForkChoice` goroutine calls `SharedDomains.Close()` → `SetTxNum(0)` (write), while the **Warmuper** goroutine concurrently reads `sd.txNum` in `GetLatest()` to compute the cache step.

## Fix

Change `SharedDomains.txNum` from plain `uint64` to `atomic.Uint64`. This matches the existing pattern already used by `blockNum` (the very next field in the struct).

Single file changed: `db/state/execctx/domain_shared.go` — 6 sites updated to use `.Load()`/`.Store()`.

## CI Reference

Failing run: https://github.com/erigontech/erigon/actions/runs/22076800678/job/63793559969