### PR TITLE
fix: disable background FCU commit/prune in test mock to prevent flaky hangs

### DIFF
--- a/execution/tests/mock/mock_sentry.go
+++ b/execution/tests/mock/mock_sentry.go
@@ -326,8 +326,8 @@ func MockWithEverything(tb testing.TB, gspec *types.Genesis, key *ecdsa.PrivateK
 	cfg.Snapshot.ChainName = gspec.Config.ChainName
 	cfg.Genesis = gspec
 	cfg.Prune = prune
-	cfg.FcuBackgroundCommit = true
-	cfg.FcuBackgroundPrune = true
+	cfg.FcuBackgroundCommit = false
+	cfg.FcuBackgroundPrune = false
 	cfg.ExperimentalBAL = opt.experimentalBAL
 
 	logLvl := log.LvlError


### PR DESCRIPTION
## Problem

`TestExecutionSpecBlockchain` flakily hangs in CI (both `tests-mac-linux` and `test-all-erigon-race` workflows). The test times out after ~1h with goroutines stuck in `insertPoSBlocks` → `stream.Recv()` waiting for state change notifications.

**Root cause:** `mock_sentry.go` sets `FcuBackgroundCommit=true` and `FcuBackgroundPrune=true`, which makes `UpdateForkChoice` return `Success` before state change notifications are sent — they fire later in a background goroutine via `runPostForkchoice` → `runForkchoiceCommit` → `hook.AfterRun` → `Accumulator.SendAndReset`. Under CI load with parallel tests, the goroutine scheduling delay causes `insertPoSBlocks` to block indefinitely on `stream.Recv()`.

## Fix

Set `FcuBackgroundCommit=false` and `FcuBackgroundPrune=false` in the test mock. This makes the post-forkchoice work (flush, commit, notifications) run synchronously within `updateForkChoice`, so notifications are in the channel before `insertPoSBlocks` calls `Recv()`.

The background commit/prune is a production optimization — unit tests that depend on synchronous notification delivery should not use it.

## Evidence

- Failure is intermittent: same test passes on one commit, fails on the next (even when the only change is boot node configs)
- Goroutine dumps show `insertPoSBlocks` stuck on `StateDiffStreamC.Recv()` while the background goroutine is `[runnable]` but not scheduled
- Reproduces locally under load, never in isolation

## CI References

- https://github.com/erigontech/erigon/actions/runs/22077300073/job/63795064836 (macos-15 timeout)
- https://github.com/erigontech/erigon/actions/runs/22076800678/job/63793559969 (ubuntu race timeout)