### PR TITLE
execution/stagedsync: remove dead debug code in ExecV3

### DIFF
--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -354,10 +354,6 @@ func ExecV3(ctx context.Context,
 		lastCommittedTxNum = se.lastCommittedTxNum.Load()
 	}
 
-	if false && !isForkValidation {
-		dumpPlainStateDebug(applyTx, doms)
-	}
-
 	lastCommitedStep := kv.Step((lastCommittedTxNum) / doms.StepSize())
 	lastFrozenStep := applyTx.StepsInFiles(kv.CommitmentDomain)
 


### PR DESCRIPTION
Remove unreachable `if false` block calling `dumpPlainStateDebug()`. This debug code was never executed in production and reduces readability. No behavior change.