### PR TITLE
fix: add panic recovery for Caplin SSZ decoding in gossip pipeline

### DIFF
--- a/cl/phase1/network/gossip/gossip_manager.go
+++ b/cl/phase1/network/gossip/gossip_manager.go
@@ -101,7 +101,18 @@ func (g *GossipManager) Close() error {
 }
 
 func (g *GossipManager) newPubsubValidator(service serviceintf.Service[any], conditions ...ConditionFunc) pubsub.ValidatorEx {
-	return func(ctx context.Context, pid peer.ID, msg *pubsub.Message) pubsub.ValidationResult {
+	return func(ctx context.Context, pid peer.ID, msg *pubsub.Message) (result pubsub.ValidationResult) {
+		// Recover from any panics during gossip message processing (e.g., malformed SSZ payloads).
+		// This prevents a single malformed gossip message from crashing the entire erigon process.
+		defer func() {
+			if r := recover(); r != nil {
+				topic := msg.GetTopic()
+				name := extractTopicName(topic)
+				log.Warn("[GossipManager] recovered from panic during message processing", "topic", name, "peer", pid, "panic", r)
+				g.stats.addReject(name)
+				result = pubsub.ValidationReject
+			}
+		}()
 		curVersion := g.beaconConfig.GetCurrentStateVersion(g.ethClock.GetCurrentEpoch())
 		// parse the topic and subnet
 		topic := msg.GetTopic()

--- a/cl/ssz/decode.go
+++ b/cl/ssz/decode.go
@@ -53,11 +53,11 @@ types such as uint64, []byte, and objects that implement the SizedObjectSSZ inte
 It handles both static (fixed size) and dynamic (variable size) objects based on their respective decoding methods and offsets.
 */
 func UnmarshalSSZ(buf []byte, version int, schema ...any) (err error) {
-	// defer func() {
-	// 	if err2 := recover(); err2 != nil {
-	// 		err = fmt.Errorf("panic while decoding: %v", err2)
-	// 	}
-	// }()
+	defer func() {
+		if err2 := recover(); err2 != nil {
+			err = fmt.Errorf("panic while decoding: %v", err2)
+		}
+	}()
 	position := 0
 	offsets := []int{}
 	dynamicObjs := []SizedObjectSSZ{}


### PR DESCRIPTION
## Summary

Fixes a security vulnerability where a single malformed SSZ gossip message on the libp2p port (TCP 4001) can crash the entire erigon process.

## Changes

Two layers of defense against malformed gossip messages:

1. **Re-enable SSZ decode panic recovery** (`cl/ssz/decode.go`): The `UnmarshalSSZ` function had a panic recovery `defer` that was commented out. This catches panics from out-of-bounds slice access during SSZ decoding and converts them to proper errors.

2. **Add gossip validator panic recovery** (`cl/phase1/network/gossip/gossip_manager.go`): Added a `defer recover()` in the pubsub validator function that wraps the entire message decode + process pipeline. Any panic from `DecodeGossipMessage` or `ProcessMessage` is caught, logged as a warning, and the message is rejected.

## Testing

- All existing tests pass (`cl/ssz`, `cl/phase1/network/gossip`)
- Build succeeds

Fixes erigontech/security#66