### PR TITLE
ci: bump hive test parallelism from 4 to 8

### DIFF
--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -123,7 +123,7 @@ jobs:
             echo -e "\n\n============================================================"
             echo "Running test: ${1}-${2}"
             echo -e "\n"
-            ./hive -docker.auth --sim ethereum/"${1}" --sim.limit="${2}" --sim.parallelism=4 --client erigon 2>&1 | tee output.log || {
+            ./hive -docker.auth --sim ethereum/"${1}" --sim.limit="${2}" --sim.parallelism=8 --client erigon 2>&1 | tee output.log || {
               if [ $? -gt 0 ]; then
                 echo "Exitcode gt 0"
               fi


### PR DESCRIPTION
## Summary

Bumps `--sim.parallelism` from **4 → 8** in `test-hive.yml`.

## Why

With 64GB RAM runners, CPU utilization was low — simulator container at ~50-60% CPU, each Erigon client container at ~5-15%. Increasing parallelism should improve utilization and reduce overall workflow time.

## What changed

- `.github/workflows/test-hive.yml`: `--sim.parallelism=4` → `--sim.parallelism=8`

## Note

`test-hive-eest.yml` already uses `--sim.parallelism=12`, no change needed there.