### PR TITLE
fix: make SharedDomains.txNum atomic to prevent data race

### DIFF
--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -90,7 +90,7 @@ type SharedDomains struct {
 
 	logger log.Logger
 
-	txNum             uint64
+	txNum             atomic.Uint64
 	blockNum          atomic.Uint64
 	trace             bool //nolint
 	commitmentCapture bool
@@ -156,8 +156,8 @@ type changesetSwitcher interface {
 }
 
 func (sd *SharedDomains) Merge(other *SharedDomains) error {
-	if sd.txNum > other.txNum {
-		return fmt.Errorf("can't merge backwards: txnum: %d > %d", sd.txNum, other.txNum)
+	if sd.txNum.Load() > other.txNum.Load() {
+		return fmt.Errorf("can't merge backwards: txnum: %d > %d", sd.txNum.Load(), other.txNum.Load())
 	}
 
 	if err := sd.mem.Merge(other.mem); err != nil {
@@ -169,7 +169,7 @@ func (sd *SharedDomains) Merge(other *SharedDomains) error {
 		sd.sdCtx.SetPendingUpdate(otherUpd)
 	}
 
-	sd.txNum = other.txNum
+	sd.txNum.Store(other.txNum.Load())
 	sd.blockNum.Store(other.blockNum.Load())
 	return nil
 }
@@ -316,10 +316,10 @@ func (sd *SharedDomains) StepSize() uint64 { return sd.stepSize }
 // SetTxNum sets txNum for all domains as well as common txNum for all domains
 // Requires for sd.rwTx because of commitment evaluation in shared domains if stepSize is reached
 func (sd *SharedDomains) SetTxNum(txNum uint64) {
-	sd.txNum = txNum
+	sd.txNum.Store(txNum)
 }
 
-func (sd *SharedDomains) TxNum() uint64 { return sd.txNum }
+func (sd *SharedDomains) TxNum() uint64 { return sd.txNum.Load() }
 
 func (sd *SharedDomains) BlockNum() uint64 { return sd.blockNum.Load() }
 
@@ -411,7 +411,7 @@ func (sd *SharedDomains) GetLatest(domain kv.Domain, tx kv.TemporalTx, k []byte)
 		// files merge so this is not a problem in practice. file 0-1 will be non-deterministic
 		// but file 0-2 will be deterministic as it will include all entries from file 0-1 and so on.
 		if v, ok := sd.stateCache.Get(domain, k); ok {
-			return v, kv.Step(sd.txNum / sd.stepSize), nil
+			return v, kv.Step(sd.txNum.Load() / sd.stepSize), nil
 		}
 	}
 


### PR DESCRIPTION
## Problem

CI on `main` is failing with DATA RACE errors in the `All tests (with -race)` workflow ([run #22100421579](https://github.com/erigontech/erigon/actions/runs/22100421579)).

The race is between:
- **Write**: `SharedDomains.Close()` → `SetTxNum(0)` called from the deferred cleanup in `updateForkChoice` (forkchoice.go:267)
- **Read**: Warmuper goroutines calling `SharedDomains.GetLatest()` which reads `sd.txNum` via `temporalGetter`/`LatestStateReader`

This causes:
- `WARNING: DATA RACE` on the race detector
- `Wrong trie root` errors in `TestExecutionSpecBlockchain`
- Flaky failures on both Linux and Windows CI

## Fix

Changed `txNum` field from `uint64` to `atomic.Uint64`, consistent with how `blockNum` is already handled in the same struct. All accesses to `txNum` now use `Load()`/`Store()` for thread safety.

## Testing

- `go build ./...` passes
- `go test -race -count=3 -run TestExecutionSpecBlockchain/frontier/scenarios/test_scenarios ./execution/tests/` — 3 consecutive runs pass with no races detected