### PR TITLE
fix: make SharedDomains.txNum atomic to prevent data race with warmuper goroutines

### DIFF
--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -90,7 +90,7 @@ type SharedDomains struct {
 
 	logger log.Logger
 
-	txNum             uint64
+	txNum             atomic.Uint64
 	blockNum          atomic.Uint64
 	trace             bool //nolint
 	commitmentCapture bool
@@ -156,8 +156,8 @@ type changesetSwitcher interface {
 }
 
 func (sd *SharedDomains) Merge(other *SharedDomains) error {
-	if sd.txNum > other.txNum {
-		return fmt.Errorf("can't merge backwards: txnum: %d > %d", sd.txNum, other.txNum)
+	if sd.txNum.Load() > other.txNum.Load() {
+		return fmt.Errorf("can't merge backwards: txnum: %d > %d", sd.txNum.Load(), other.txNum.Load())
 	}
 
 	if err := sd.mem.Merge(other.mem); err != nil {
@@ -169,7 +169,7 @@ func (sd *SharedDomains) Merge(other *SharedDomains) error {
 		sd.sdCtx.SetPendingUpdate(otherUpd)
 	}
 
-	sd.txNum = other.txNum
+	sd.txNum.Store(other.txNum.Load())
 	sd.blockNum.Store(other.blockNum.Load())
 	return nil
 }
@@ -316,10 +316,10 @@ func (sd *SharedDomains) StepSize() uint64 { return sd.stepSize }
 // SetTxNum sets txNum for all domains as well as common txNum for all domains
 // Requires for sd.rwTx because of commitment evaluation in shared domains if stepSize is reached
 func (sd *SharedDomains) SetTxNum(txNum uint64) {
-	sd.txNum = txNum
+	sd.txNum.Store(txNum)
 }
 
-func (sd *SharedDomains) TxNum() uint64 { return sd.txNum }
+func (sd *SharedDomains) TxNum() uint64 { return sd.txNum.Load() }
 
 func (sd *SharedDomains) BlockNum() uint64 { return sd.blockNum.Load() }
 
@@ -411,7 +411,7 @@ func (sd *SharedDomains) GetLatest(domain kv.Domain, tx kv.TemporalTx, k []byte)
 		// files merge so this is not a problem in practice. file 0-1 will be non-deterministic
 		// but file 0-2 will be deterministic as it will include all entries from file 0-1 and so on.
 		if v, ok := sd.stateCache.Get(domain, k); ok {
-			return v, kv.Step(sd.txNum / sd.stepSize), nil
+			return v, kv.Step(sd.txNum.Load() / sd.stepSize), nil
 		}
 	}
 


### PR DESCRIPTION
## Problem

`SharedDomains.txNum` is a plain `uint64` field that is accessed concurrently by multiple goroutines:

1. **Main goroutine**: `Close()` → `SetTxNum(0)` during deferred cleanup in `forkchoice.go:267`
2. **Warmuper background goroutines**: `GetLatest()` reads `sd.txNum` at `domain_shared.go:414`

This causes data races detected by `-race` in `TestExecutionSpecBlockchain` (CI run [#22100421579](https://github.com/erigontech/erigon/actions/runs/22100421579)), and manifests as **Wrong trie root** errors in non-race builds (CI run [#22099748870](https://github.com/erigontech/erigon/actions/runs/22099748870)) due to state corruption from unsynchronized concurrent access.

## Race Trace

```
WARNING: DATA RACE
Write at ... by goroutine ...:
  SharedDomains.SetTxNum()     ← Close() in forkchoice.go:267

Previous read at ... by goroutine ...:
  SharedDomains.GetLatest()    ← Warmuper.accountFromCacheOrDB()
```

## Fix

Make `txNum` an `atomic.Uint64`, consistent with how `blockNum` is already handled in the same struct. All 6 access sites updated to use `Load()`/`Store()`.

## Changes

- `db/state/execctx/domain_shared.go`: Change `txNum uint64` → `txNum atomic.Uint64`, update all accesses

## Testing

- `go build ./...` — clean
- `go test -race ./db/state/execctx/...` — pass
- `go test -race ./execution/commitment/...` — pass