### PR TITLE
fix: Include system address in BAL when it has actual state cha…

### DIFF
--- a/execution/stagedsync/bal_create.go
+++ b/execution/stagedsync/bal_create.go
@@ -50,14 +50,15 @@ func CreateBAL(blockNum uint64, txIO *state.VersionedIO, dataDir string) types.B
 
 	bal := make([]*types.AccountChanges, 0, len(ac))
 	for _, account := range ac {
-		// The system address shows up as a touched address due to a balance check in IBS
-		// during a system call, however this should not be included in the BAL.
-		if isSystemBALAddress(account.changes.Address) {
-			continue
-		}
-
 		account.finalize()
 		normalizeAccountChanges(account.changes)
+		// The system address is touched during system calls (EIP-4788 beacon root)
+		// because it is msg.sender. Exclude it when it has no actual state changes,
+		// but keep it when a user tx sends real ETH to it (e.g. SELFDESTRUCT to
+		// the system address or a plain value transfer).
+		if isSystemBALAddress(account.changes.Address) && !hasAccountChanges(account.changes) {
+			continue
+		}
 		bal = append(bal, account.changes)
 	}
 
@@ -169,6 +170,11 @@ func updateAccountWrite(account *accountState, vw *state.VersionedWrite, accessI
 
 func isSystemBALAddress(addr accounts.Address) bool {
 	return addr == params.SystemAddress
+}
+
+func hasAccountChanges(ac *types.AccountChanges) bool {
+	return len(ac.StorageChanges) > 0 || len(ac.StorageReads) > 0 ||
+		len(ac.BalanceChanges) > 0 || len(ac.NonceChanges) > 0 || len(ac.CodeChanges) > 0
 }
 
 func hasStorageWrite(ac *types.AccountChanges, slot accounts.StorageKey) bool {

--- a/execution/tests/block_test.go
+++ b/execution/tests/block_test.go
@@ -118,10 +118,10 @@ func TestExecutionSpecBlockchainDevnet(t *testing.T) {
 	bt.whitelist(`.*amsterdam.*`)                                                                              // TODO run tests for older forks too once we fix amsterdam eips, for now focus only on amsterdam eips
 	bt.skipLoad(`.*eip7708_eth_transfer_logs/test_finalization_selfdestruct_logs.json`)                        // TODO fix error: receiptHash mismatch
 	bt.skipLoad(`.*eip7708_eth_transfer_logs/test_selfdestruct_finalization_after_priority_fee.json`)          // TODO fix error: block access list mismatch
-	bt.skipLoad(`.*eip7708_eth_transfer_logs/test_selfdestruct_to_self_cross_tx_no_log.json`)                  // TODO fix error: block access list mismatch
+	bt.skipLoad(`.*eip7708_eth_transfer_logs/test_selfdestruct_to_self_cross_tx_no_log.json`)                  // TODO fix error: block access list mismatch (parallel executor gas accounting)
+	bt.skipLoad(`.*eip7708_eth_transfer_logs/test_selfdestruct_to_system_address.json`)                        // TODO fix error: can't find diffsets for: 2 (BAL now correct, state root issue)
+	bt.skipLoad(`.*eip7708_eth_transfer_logs/test_transfer_to_special_address.json`)                           // TODO fix error: can't find diffsets for: 2 (BAL now correct, state root issue)
 	bt.skipLoad(`.*eip7708_eth_transfer_logs/test_selfdestruct_same_tx_via_call.json`)                         // TODO fix error: block #1 insertion into chain failed
-	bt.skipLoad(`.*eip7708_eth_transfer_logs/test_selfdestruct_to_system_address.json`)                        // TODO fix error: block access list mismatch
-	bt.skipLoad(`.*eip7708_eth_transfer_logs/test_transfer_to_special_address.json`)                           // TODO fix error: block access list mismatch
 	bt.skipLoad(`.*eip7708_eth_transfer_logs/test_selfdestruct_to_self_same_tx.json`)                          // TODO fix error:  block #1 insertion into chain failed
 	bt.skipLoad(`.*eip7708_eth_transfer_logs/test_selfdestruct_log_at_fork_transition.json`)                   // TODO file error: block #2 insertion into chain failed: insertion failed for block 2, code: BadBlock
 	bt.skipLoad(`.*eip7928_block_level_access_lists/test_bal_7702_delegation_clear.json`)                      // TODO fix error: block access list mismatch


### PR DESCRIPTION
The system address (0xfff...ffe) was unconditionally filtered from the Block Access List. This is correct when it's merely touched as msg.sender during system calls (EIP-4788 beacon root), but wrong when a user transaction sends real ETH to it (e.g. SELFDESTRUCT to the system address or a plain value transfer).

Move the filter after finalize() and only exclude the system address when it has no actual balance/nonce/code/storage changes.

Fixes BAL mismatch for:
  test_selfdestruct_to_system_address
  test_transfer_to_special_address (system_address subtest)