### PR TITLE
[SharovBot] ci: remove assertoor pectra test

### DIFF
--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -57,43 +57,6 @@ jobs:
             kurtosis_extra_args: --verbosity detailed --cli-log-level trace
             persistent_logs: "true"
 
-  assertoor_pectra_test:
-    runs-on: ubuntu-latest
-    concurrency:
-      group: >-
-        ${{
-          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) &&
-          format('{0}-{1}-{2}', github.workflow, 'pectra', github.run_id) ||
-          format('{0}-{1}-{2}', github.workflow, 'pectra', github.ref)
-        }}
-      cancel-in-progress: true
-
-    steps:
-      - name: Fast checkout git repository
-        uses: actions/checkout@v6
-
-      - name: Conditional Docker Login
-        # Only login if we can. Workflow works without it but we want to avoid
-        # rate limiting by Docker Hub when possible. External repos don't
-        # have access to our Docker secrets.
-        if: |
-          github.repository == 'erigontech/erigon' &&
-          github.actor != 'dependabot[bot]' &&
-          (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_USERNAME }}
-          password: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_TOKEN }}
-
-      - name: Docker build current branch
-        run: |
-          docker build -t test/erigon:current .
-
-      - name: Run Pectra Kurtosis + assertoor tests
-        uses: ethpandaops/kurtosis-assertoor-github-action@v1
-        with:
-            enclave_name: "kurtosis-run2-${{ github.run_id }}"
-            ethereum_package_args: ".github/workflows/kurtosis/pectra.io"
-            ethereum_package_branch: "5.0.1"
-            kurtosis_extra_args: --verbosity detailed --cli-log-level trace
-            persistent_logs: "true"
+  # assertoor_pectra_test: removed — Pectra fork-transition test is out of scope
+  # and flaky due to CL fork-choice issues under CI resource contention.
+  # See: https://github.com/erigontech/erigon/actions/runs/22107650514/job/63894868179


### PR DESCRIPTION
**[SharovBot]**

Remove the Pectra assertoor kurtosis test from CI — it is out of scope and flaky.

## Why
The `assertoor_pectra_test` job tests Deneb→Electra fork transitions, which is a CL concern, not an EL one. Under CI resource contention, both CLs (Teku + Lighthouse) fail to advance finality despite 100% attestation — a fork-choice issue at the epoch 1 fork boundary.

See failure: https://github.com/erigontech/erigon/actions/runs/22107650514/job/63894868179

## What remains
- `assertoor_regular_test` — still runs, covers core EL functionality
- Pectra config (`pectra.io`) preserved for manual/local testing

## Alternative
PR #19269 fixes the flake by setting `electra_fork_epoch: 0`. Pick one or both.