### PR TITLE
[SharovBot] fix: place validated-live nodes on slow revalidation list

### DIFF
--- a/p2p/discover/table_reval.go
+++ b/p2p/discover/table_reval.go
@@ -56,7 +56,13 @@ func (tr *tableRevalidation) init(cfg *Config) {
 
 // nodeAdded is called when the table receives a new node.
 func (tr *tableRevalidation) nodeAdded(tab *Table, n *tableNode) {
-	tr.fast.push(n, tab.cfg.Clock.Now(), &tab.rand)
+	// Nodes that are already validated live don't need fast revalidation.
+	// Place them on the slow list to avoid unnecessary ping traffic.
+	if n.isValidatedLive {
+		tr.slow.push(n, tab.cfg.Clock.Now(), &tab.rand)
+	} else {
+		tr.fast.push(n, tab.cfg.Clock.Now(), &tab.rand)
+	}
 }
 
 // nodeRemoved is called when a node was removed from the table.


### PR DESCRIPTION
## [SharovBot] Automated CI Fix

### Problem
`TestUDPv4_findnode` is flaky on Windows CI (`win (windows-2025)`). The test fails intermittently with:
```
sent packet type mismatch, got: *v4wire.Ping, want: *v4wire.Neighbors
wrong number of results: got 12, want 3
```

**Root cause:** Nodes added to the routing table with `forceSetLive=true` (already confirmed live) were placed on the **fast** revalidation list. This triggered immediate revalidation PINGs that raced with FINDNODE/NEIGHBORS responses on the test pipe.

### Fix
Place already-validated-live nodes on the **slow** revalidation list instead of fast. This is correct behavior — nodes known to be live don't need aggressive re-checking.

### Changes
- `p2p/discover/table_reval.go`: In `nodeAdded()`, route `isValidatedLive` nodes to `slow` list

### Testing
- `go test -run TestUDPv4_findnode -count=10 ./p2p/discover/` — all 10 pass
- Full `go test ./p2p/discover/` — passes

### CI failure
https://github.com/erigontech/erigon/actions/runs/22113827077/job/63916617401