### PR TITLE
docs: for `trace_filter`, add `mode` introduction(Clarify trace_filter behavior with from_address and to_address)

### DIFF
--- a/docs/gitbook/src/interacting-with-erigon/trace.md
+++ b/docs/gitbook/src/interacting-with-erigon/trace.md
@@ -485,6 +485,8 @@ Returns traces matching given filter
    * `toAddress`: `Address` - (optional) Sent to these addresses.
    * `after`: `Quantity` - (optional) The offset trace number
    * `count`: `Quantity` - (optional) Integer number of traces to display in a batch.
+   * `mode`: `String` - (optional) Default is `"union"`, meaning traces matching either address filter are returned. Set to `"intersection"` to only return traces that satisfy both `fromAddress` and `toAddress` filters simultaneously.
+
 
 ```js
 params: [{


### PR DESCRIPTION

Hi! While using trace_filter, I was confusied since the docs don’t mention how filtering behaves when both from_address and to_address are provided: https://docs.erigon.tech/interacting-with-erigon/interacting-with-erigon/trace#trace_filter

I initially assumed it defaults to an AND condition. However, the implementation shows that filtering depends on an internal mode setting:

https://github.com/erigontech/erigon/blob/692d5be499974ad71d0146226e1b3bc08db793c8/rpc/jsonrpc/trace_filtering.go#L987-L993

This PR updates the documentation to clarify the filtering behavior and default semantics when both fields are present.

Hope it is helpful :>