### PR TITLE
warmuper: smaller non-blocking chan

### DIFF
--- a/execution/commitment/warmuper.go
+++ b/execution/commitment/warmuper.go
@@ -275,7 +275,7 @@ func (w *Warmuper) WarmKey(hashedKey []byte, startDepth int) {
 	select {
 	case w.work <- warmupWorkItem{hashedKey: hashedKey, startDepth: startDepth}:
 	case <-w.ctx.Done():
-	default: // drop if workers are busy; warmup is best-effort
+	default: // non-blocking
 	}
 }
 


### PR DESCRIPTION
- reduce chan size - to reduce ram usage in tests (each test creating own warmuper)
- i feel that write channel must be non-buffered - because if we don't warmup some keys - it's fine
