### PR TITLE
tests: gen test-chain once 

### DIFF
--- a/cmd/rpcdaemon/rpcdaemontest/test_util.go
+++ b/cmd/rpcdaemon/rpcdaemontest/test_util.go
@@ -88,7 +88,7 @@ var (
 	testOrphanedChain *blockgen.ChainPack
 )
 
-func CreateTestSentry(t *testing.T) (*mock.MockSentry, *blockgen.ChainPack, []*blockgen.ChainPack) {
+func genTestChainOnce(t *testing.T) {
 	testChainOnce.Do(func() {
 		addresses := makeTestAddresses()
 		gspec := &types.Genesis{
@@ -116,6 +116,10 @@ func CreateTestSentry(t *testing.T) (*mock.MockSentry, *blockgen.ChainPack, []*b
 			t.Fatalf("rpcdaemontest: failed to generate chain: %v", err)
 		}
 	})
+}
+
+func CreateTestSentry(t *testing.T) (*mock.MockSentry, *blockgen.ChainPack, []*blockgen.ChainPack) {
+	genTestChainOnce(t)
 
 	addresses := makeTestAddresses()
 	gspec := &types.Genesis{


### PR DESCRIPTION
`go test -count=1 ./rpc/jsonrpc`: 12sec -> 6sec,  30,397 MB → 5,869 MB allocs