### PR TITLE
execution: fix TestExecutionSpecBlockchain deadlock with background FCU

### DIFF
--- a/cmd/utils/app/import_cmd.go
+++ b/cmd/utils/app/import_cmd.go
@@ -255,7 +255,7 @@ func InsertChain(ethereum *eth.Ethereum, chain *blockgen.ChainPack, setHead bool
 		insertedBlocks[block.NumberU64()] = struct{}{}
 	}
 
-	chainRW := chainreader.NewChainReaderEth1(ethereum.ChainConfig(), direct.NewExecutionClientDirect(ethereum.ExecutionModule()), uint64(time.Hour))
+	chainRW := chainreader.NewChainReaderEth1(ethereum.ChainConfig(), direct.NewExecutionClientDirect(ethereum.ExecutionModule()), uint64(time.Hour.Milliseconds()))
 
 	ctx := context.Background()
 	if err := chainRW.InsertBlocksAndWait(ctx, chain.Blocks); err != nil {

--- a/execution/execmodule/ethereum_execution.go
+++ b/execution/execmodule/ethereum_execution.go
@@ -196,6 +196,7 @@ type EthereumExecutionModule struct {
 
 	fcuBackgroundPrune      bool
 	fcuBackgroundCommit     bool
+	backgroundPostFcuErr    chan error // receives error (or nil) when background post-forkchoice completes
 	onlySnapDownloadOnStart bool
 	// metrics for average mgas/sec
 	avgMgasSec float64
@@ -250,6 +251,10 @@ func NewEthereumExecutionModule(ctx context.Context, blockReader services.FullBl
 		stateCache.execModule = em
 	}
 	return em
+}
+
+func (e *EthereumExecutionModule) BackgroundPostFcuErr() <-chan error {
+	return e.backgroundPostFcuErr
 }
 
 func (e *EthereumExecutionModule) getHeader(ctx context.Context, tx kv.Tx, blockHash common.Hash, blockNumber uint64) (*types.Header, error) {


### PR DESCRIPTION
## Summary

Fixes `TestExecutionSpecBlockchain` frequently hanging when run with `-tags goexperiment.synctest`. The test runs hundreds of subtests in parallel, each creating a `MockSentry` with `FcuBackgroundCommit=true` and `FcuBackgroundPrune=true`.

Three independent deadlock sites were identified:

### 1. Timer bug creating 114-year timeout

`uint64(time.Hour)` = 3,600,000,000,000 (nanoseconds cast to uint64), but this value is used as **milliseconds** in `NewChainReaderEth1`. This results in a ~114-year FCU timer instead of 1 hour:
```go
fcuTimer := time.NewTimer(time.Duration(req.Timeout) * time.Millisecond)
// = time.NewTimer(3.6e18 ns) ≈ 114 years
```

**Fix:** `uint64(time.Hour)` → `uint64(time.Hour.Milliseconds())` in `import_cmd.go`, and reduced to `uint64((10 * time.Second).Milliseconds())` in `mock_sentry.go` for test use (production default is 1 second).

### 2. No Busy retry for UpdateForkChoice

With hundreds of parallel tests contending on MDBX, `UpdateForkChoice` can return `Busy` (semaphore held by a previous block's background goroutine). `insertPoSBlocks` had no retry logic — it would just fail.

**Fix:** Added a Busy retry loop matching the existing pattern in `InsertBlocksAndWaitWithAccessLists`.

### 3. stream.Recv() blocks forever on background error

After `UpdateForkChoice` returns `Success` with `FcuBackgroundCommit=true`, the `stream.Recv()` loop waits for state change notifications. If the background goroutine errors before sending notifications, `stream.Recv()` blocks forever.

**Fix:** Added `backgroundPostFcuErr` channel to `EthereumExecutionModule` that receives the background goroutine's error. A watcher goroutine in `insertPoSBlocks` cancels the stream context if the background goroutine fails, unblocking `stream.Recv()`.

## Files changed

| File | Change |
|------|--------|
| `execution/tests/mock/mock_sentry.go` | Reduced FCU timeout to 10s, added Busy retry loop, added background error watcher |
| `cmd/utils/app/import_cmd.go` | Fixed timer bug: `uint64(time.Hour)` → `uint64(time.Hour.Milliseconds())` |
| `execution/execmodule/ethereum_execution.go` | Added `backgroundPostFcuErr` channel field + accessor |
| `execution/execmodule/forkchoice.go` | Initialize channel + non-blocking send in background goroutine |

## Test plan

- [x] `go test -v -count 1 -tags goexperiment.synctest -timeout 15m -run TestExecutionSpecBlockchain ./execution/tests/...` — **16,427 PASS, 0 FAIL** (738s)
- [x] `make lint` — 0 issues
- [x] `make erigon` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)