### PR TITLE
qa-tests: keep pre-built db synced in RPC Integration Test Latest

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests-latest.yml
+++ b/.github/workflows/qa-rpc-integration-tests-latest.yml
@@ -63,11 +63,7 @@ jobs:
           else
             echo "Found Erigon process dedicated to db maintenance, PID: $ERIGON_PID"
             python3 $ERIGON_QA_PATH/test_system/qa-tests/tip-sync/run_and_chase_tip.py \
-              --build-dir=${{ github.workspace }}/build/bin \
-              --data-dir=$ERIGON_REFERENCE_DATA_DIR \
               --total-time=$TOTAL_TIME_SECONDS \
-              --chain=$CHAIN \
-              --node-type=minimal_node \
               --stop-erigon=False \
               --erigon-pid=$ERIGON_PID
           fi


### PR DESCRIPTION
Currently, when the test runner has to execute a large number of tests, the pre-built database remains well below the tip of the chain, resulting in failed tests.
This PR adds a step to delay test execution if the Erigon instance dedicated to the db maintenance is not on the chain tip.