### PR TITLE
execution: refactor long args in intrinsic gas funcs

### DIFF
--- a/execution/protocol/fixedgas/intrinsic_gas.go
+++ b/execution/protocol/fixedgas/intrinsic_gas.go
@@ -39,8 +39,8 @@ type IntrinsicGasCalcArgs struct {
 }
 
 type IntrinsicGasCalcResult struct {
-	Gas          uint64
-	FloorGas7623 uint64
+	RegularGas   uint64
+	FloorGasCost uint64
 }
 
 // IntrinsicGas computes the 'intrinsic gas' for a message with the given data.
@@ -64,13 +64,13 @@ func CalcIntrinsicGas(args IntrinsicGasCalcArgs) (IntrinsicGasCalcResult, bool) 
 	dataLen := uint64(len(args.Data))
 	// Set the starting gas for the raw transaction
 	if args.IsContractCreation && args.IsEIP2 {
-		result.Gas = params.TxGasContractCreation
+		result.RegularGas = params.TxGasContractCreation
 	} else if args.IsAATxn {
-		result.Gas = params.TxAAGas
+		result.RegularGas = params.TxAAGas
 	} else {
-		result.Gas = params.TxGas
+		result.RegularGas = params.TxGas
 	}
-	result.FloorGas7623 = params.TxGas
+	result.FloorGasCost = params.TxGas
 	// Bump the required gas by the amount of transactional data
 	if dataLen > 0 {
 		// Zero and non-zero bytes are priced differently
@@ -85,7 +85,7 @@ func CalcIntrinsicGas(args IntrinsicGasCalcArgs) (IntrinsicGasCalcResult, bool) 
 		if overflow {
 			return IntrinsicGasCalcResult{}, true
 		}
-		result.Gas, overflow = math.SafeAdd(result.Gas, product)
+		result.RegularGas, overflow = math.SafeAdd(result.RegularGas, product)
 		if overflow {
 			return IntrinsicGasCalcResult{}, true
 		}
@@ -96,7 +96,7 @@ func CalcIntrinsicGas(args IntrinsicGasCalcArgs) (IntrinsicGasCalcResult, bool) 
 		if overflow {
 			return IntrinsicGasCalcResult{}, true
 		}
-		result.Gas, overflow = math.SafeAdd(result.Gas, product)
+		result.RegularGas, overflow = math.SafeAdd(result.RegularGas, product)
 		if overflow {
 			return IntrinsicGasCalcResult{}, true
 		}
@@ -107,7 +107,7 @@ func CalcIntrinsicGas(args IntrinsicGasCalcArgs) (IntrinsicGasCalcResult, bool) 
 			if overflow {
 				return IntrinsicGasCalcResult{}, true
 			}
-			result.Gas, overflow = math.SafeAdd(result.Gas, product)
+			result.RegularGas, overflow = math.SafeAdd(result.RegularGas, product)
 			if overflow {
 				return IntrinsicGasCalcResult{}, true
 			}
@@ -119,7 +119,7 @@ func CalcIntrinsicGas(args IntrinsicGasCalcArgs) (IntrinsicGasCalcResult, bool) 
 			if overflow {
 				return IntrinsicGasCalcResult{}, true
 			}
-			result.FloorGas7623, overflow = math.SafeAdd(result.FloorGas7623, dataGas)
+			result.FloorGasCost, overflow = math.SafeAdd(result.FloorGasCost, dataGas)
 			if overflow {
 				return IntrinsicGasCalcResult{}, true
 			}
@@ -130,7 +130,7 @@ func CalcIntrinsicGas(args IntrinsicGasCalcArgs) (IntrinsicGasCalcResult, bool) 
 		if overflow {
 			return IntrinsicGasCalcResult{}, true
 		}
-		result.Gas, overflow = math.SafeAdd(result.Gas, product)
+		result.RegularGas, overflow = math.SafeAdd(result.RegularGas, product)
 		if overflow {
 			return IntrinsicGasCalcResult{}, true
 		}
@@ -139,7 +139,7 @@ func CalcIntrinsicGas(args IntrinsicGasCalcArgs) (IntrinsicGasCalcResult, bool) 
 		if overflow {
 			return IntrinsicGasCalcResult{}, true
 		}
-		result.Gas, overflow = math.SafeAdd(result.Gas, product)
+		result.RegularGas, overflow = math.SafeAdd(result.RegularGas, product)
 		if overflow {
 			return IntrinsicGasCalcResult{}, true
 		}
@@ -151,7 +151,7 @@ func CalcIntrinsicGas(args IntrinsicGasCalcArgs) (IntrinsicGasCalcResult, bool) 
 		return IntrinsicGasCalcResult{}, true
 	}
 
-	result.Gas, overflow = math.SafeAdd(result.Gas, product)
+	result.RegularGas, overflow = math.SafeAdd(result.RegularGas, product)
 	if overflow {
 		return IntrinsicGasCalcResult{}, true
 	}

--- a/execution/protocol/fixedgas/intrinsic_gas_test.go
+++ b/execution/protocol/fixedgas/intrinsic_gas_test.go
@@ -89,8 +89,8 @@ func TestShanghaiIntrinsicGas(t *testing.T) {
 			if overflow {
 				t.Errorf("expected success but got uint overflow")
 			}
-			if result.Gas != c.expected {
-				t.Errorf("expected %v but got %v", c.expected, result.Gas)
+			if result.RegularGas != c.expected {
+				t.Errorf("expected %v but got %v", c.expected, result.RegularGas)
 			}
 		})
 	}
@@ -105,6 +105,6 @@ func TestZeroDataIntrinsicGas(t *testing.T) {
 		IsEIP7623: true,
 	})
 	assert.False(overflow)
-	assert.Equal(params.TxGas, result.Gas)
-	assert.Equal(params.TxGas, result.FloorGas7623)
+	assert.Equal(params.TxGas, result.RegularGas)
+	assert.Equal(params.TxGas, result.FloorGasCost)
 }

--- a/execution/tests/testutil/transaction_test_util.go
+++ b/execution/tests/testutil/transaction_test_util.go
@@ -91,9 +91,9 @@ func (tt *TransactionTest) Run(chainID *big.Int) error {
 			IsEIP3860:          rules.IsShanghai,
 			IsEIP7623:          rules.IsPrague,
 		})
-		requiredGas := intrinsicGasResult.Gas
-		if rules.IsPrague && intrinsicGasResult.FloorGas7623 > requiredGas {
-			requiredGas = intrinsicGasResult.FloorGas7623
+		requiredGas := intrinsicGasResult.RegularGas
+		if rules.IsPrague && intrinsicGasResult.FloorGasCost > requiredGas {
+			requiredGas = intrinsicGasResult.FloorGasCost
 		}
 		if overflow {
 			return nil, nil, 0, protocol.ErrGasUintOverflow

--- a/execution/types/aa_transaction.go
+++ b/execution/types/aa_transaction.go
@@ -545,7 +545,7 @@ func (tx *AccountAbstractionTransaction) PreTransactionGasCost(rules *chain.Rule
 		return 0, errors.New("overflow")
 	}
 
-	return intrinsicGasResult.Gas, nil
+	return intrinsicGasResult.RegularGas, nil
 }
 
 func (tx *AccountAbstractionTransaction) DeployerFrame(rules *chain.Rules, hasEIP3860 bool) *Message {

--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -831,9 +831,9 @@ func (p *TxPool) best(ctx context.Context, n int, txns *TxnsRlp, onTopOf, availa
 			IsEIP7623:          isEIP7623,
 			IsAATxn:            isAATxn,
 		})
-		intrinsicGas := intrinsicGasResult.Gas
-		if isEIP7623 && intrinsicGasResult.FloorGas7623 > intrinsicGas {
-			intrinsicGas = intrinsicGasResult.FloorGas7623
+		intrinsicGas := intrinsicGasResult.RegularGas
+		if isEIP7623 && intrinsicGasResult.FloorGasCost > intrinsicGas {
+			intrinsicGas = intrinsicGasResult.FloorGasCost
 		}
 		if intrinsicGas > availableGas {
 			// we might find another txn with a low enough intrinsic gas to include so carry on
@@ -995,9 +995,9 @@ func (p *TxPool) validateTx(txn *TxnSlot, isLocal bool, stateCache kvcache.Cache
 		IsEIP7623:          isPrague,
 		IsAATxn:            isAATxn,
 	})
-	gas := intrinsicGasResult.Gas
-	if isPrague && intrinsicGasResult.FloorGas7623 > gas {
-		gas = intrinsicGasResult.FloorGas7623
+	gas := intrinsicGasResult.RegularGas
+	if isPrague && intrinsicGasResult.FloorGasCost > gas {
+		gas = intrinsicGasResult.FloorGasCost
 	}
 
 	if txn.Traced {


### PR DESCRIPTION
## Summary

This minor refactor is done before changes to intrinsic gas are made as part of https://github.com/erigontech/erigon/issues/19102.

`IntrinsicGas` and `CalcIntrinsicGas` had too many positional arguments (11 inputs and 3 outputs), making call sites hard to read and error-prone. This replaces them with two structs:

- **`IntrinsicGasCalcArgs`** — groups all input parameters (`Data`, `DataNonZeroLen`, `AuthorizationsLen`, `AccessListLen`, `StorageKeysLen`, and the EIP boolean flags)
- **`IntrinsicGasCalcResult`** — groups the output values (`RegularGas`, `FloorGasCost`), with `overflow bool` kept as a separate return value

Also removes the `TODO: convert the input to a struct` comment that this addresses.

### Changes

- Added `IntrinsicGasCalcArgs` and `IntrinsicGasCalcResult` structs in `execution/protocol/fixedgas/intrinsic_gas.go`
- Updated `IntrinsicGas` and `CalcIntrinsicGas` signatures to use the new structs
- Updated all call sites across 6 files: `state_transition.go`, `transaction_test_util.go`, `aa_transaction.go`, `pool.go` (2 calls), `intrinsic_gas_test.go` (2 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)