### PR TITLE
[Devop Bot] release workflow: validate release_version against db/version/app.go

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,11 @@ on:
         type: boolean
         default: false
         description: 'Skip tests during release build (not recommended)'
+      disable_version_check:
+        required: false
+        type: boolean
+        default: false
+        description: 'Skip validation that db/version/app.go Major.Minor.Micro matches release_version.'
 
 jobs:
 
@@ -103,6 +108,30 @@ jobs:
           echo "id=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
           echo "short_commit_id=$(git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
           echo "parsed_version=$(echo ${RELEASE_VERSION} | sed -e 's/^v//g')" >> $GITHUB_OUTPUT
+
+      - name: Validate release version against db/version/app.go
+        if: ${{ ! inputs.disable_version_check }}
+        env:
+          RELEASE_VERSION: ${{ inputs.release_version }}
+        run: |
+          cd erigon
+          APP_VERSION=$(awk '
+            /Major\s*=/{major=$3}
+            /Minor\s*=/{minor=$3}
+            /Micro\s*=/{micro=$3}
+            END{printf "%s.%s.%s", major, minor, micro}
+          ' db/version/app.go)
+          INPUT_VERSION=$(echo "${RELEASE_VERSION}" | sed -e 's/^v//')
+
+          echo "Version from db/version/app.go: ${APP_VERSION}"
+          echo "Version from workflow input: ${INPUT_VERSION} (raw: ${RELEASE_VERSION})"
+
+          if [ "${APP_VERSION}" != "${INPUT_VERSION}" ]; then
+            echo "ERROR: release_version (${RELEASE_VERSION}) does not match db/version/app.go version (${APP_VERSION})."
+            exit 1
+          fi
+
+          echo "OK: release_version matches db/version/app.go."
 
       - name: Login to Docker Hub
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567  ## v3.3.0


### PR DESCRIPTION
## Summary
- added a new `workflow_dispatch` input `disable_version_check` (default: `false`) at the end of the input list
- added a validation step in `.github/workflows/release.yml` that compares `Major.Minor.Micro` from `db/version/app.go` with the workflow `release_version` input after stripping optional leading `v`
- workflow now fails with a clear error if versions do not match
- validation is skipped when `disable_version_check` is set to `true`

## Notes
This keeps existing behavior unchanged when versions match and makes version mismatch explicit before build/publish steps.