### PR TITLE
[SharovBot] fix(rpc): count only matching logs in Filter and ContainingTopics

### DIFF
--- a/execution/types/log.go
+++ b/execution/types/log.go
@@ -148,11 +148,10 @@ func (logs Logs) Filter(addrMap map[common.Address]struct{}, topics [][]common.H
 		}
 		if found {
 			o = append(o, v)
-		}
-
-		logCount += 1
-		if maxLogs != 0 && logCount >= maxLogs {
-			break
+			logCount += 1
+			if maxLogs != 0 && logCount >= maxLogs {
+				break
+			}
 		}
 	}
 	return o
@@ -172,6 +171,10 @@ func (logs Logs) ContainingTopics(addrMap map[common.Address]struct{}, topicsMap
 		//topicsMap len zero match any topics
 		if len(topicsMap) == 0 {
 			o = append(o, v)
+			logCount += 1
+			if maxLogs != 0 && logCount >= maxLogs {
+				break
+			}
 		} else {
 			for i := range v.Topics {
 				//Contain any topics that matched
@@ -181,11 +184,11 @@ func (logs Logs) ContainingTopics(addrMap map[common.Address]struct{}, topicsMap
 			}
 			if found {
 				o = append(o, v)
+				logCount += 1
+				if maxLogs != 0 && logCount >= maxLogs {
+					break
+				}
 			}
-		}
-		logCount += 1
-		if maxLogs != 0 && logCount >= maxLogs {
-			break
 		}
 	}
 	return o


### PR DESCRIPTION
## [SharovBot] Automated Fix

Fixes #17097

### Problem
`eth_getLogs` (and `erigon_getLatestLogs`) could return different result counts between versions due to a bug in `Logs.Filter()` and `Logs.ContainingTopics()`.

### Root Cause
In both `Filter()` and `ContainingTopics()`, `logCount` was incremented for every log examined, not just those that matched the address/topic filters. When `maxLogs` was set (used by `erigon_getLatestLogs`), this caused early termination—returning fewer results than expected because non-matching logs consumed the quota.

### Fix
Move `logCount` increment inside the `if found` / `if matched` branches so only actual matching logs count toward the `maxLogs` limit.

### Changes
- `Logs.Filter()`: move logCount increment inside the matched branch
- `Logs.ContainingTopics()`: move logCount increment inside both the empty-topicsMap and found branches

### Testing
- All existing tests pass (`go test ./execution/types/... -race`)
- No test file modifications