### PR TITLE
decomp: speedup `nextPos()` part2

### DIFF
--- a/db/seg/decompress.go
+++ b/db/seg/decompress.go
@@ -716,7 +716,7 @@ func (v *SequentialView) MakeGetter() *Getter {
 		fName:       v.d.FileName(),
 	}
 	if v.d.posDict != nil {
-		g.posMask = uint16(1)<<v.d.posDict.bitLen - 1
+		g.posMask = v.d.posDict.mask
 	}
 	return g
 }


### PR DESCRIPTION
based on https://github.com/erigontech/erigon/pull/19324 

- split `nextPos()` to `nextPosSubtable()` and `nextPos()` to make `nextPos()` inlinable. it also reduced amount of loops. also `nextPosSubtable` called rare. 
- added pre-computed `posTable.mask` field
- joinded 2 slices into 1 struct: `posEntry`
