### PR TITLE
integrity, verify: add snapshot verification tools

### DIFF
--- a/db/integrity/commitment.go
+++ b/db/integrity/commitment.go
@@ -17,13 +17,19 @@
 package integrity
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/rand"
+	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
+	"sort"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -33,6 +39,7 @@ import (
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dbg"
+	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/estimate"
 	"github.com/erigontech/erigon/common/length"
 	"github.com/erigontech/erigon/common/log/v3"
@@ -830,6 +837,1153 @@ func CheckCommitmentHistAtBlkRange(ctx context.Context, db kv.TemporalRoDB, br s
 	rate := float64(blks) / dur.Seconds()
 	logger.Info("checked commitment hist at blk range", "dur", dur, "blks", blks, "blks/s", rate, "from", from, "to", to)
 	return nil
+}
+
+func CheckStateVerify(ctx context.Context, db kv.TemporalRoDB, failFast bool, fromStep uint64, logger log.Logger) error {
+	start := time.Now()
+	tx, err := db.BeginTemporalRo(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	aggTx := state.AggTx(tx)
+	files := aggTx.Files(kv.CommitmentDomain)
+	stepSize := aggTx.StepSize()
+	var integrityErr error
+	var totalFiles int
+	for _, file := range files {
+		if !strings.HasSuffix(file.Fullpath(), ".kv") {
+			continue
+		}
+		startTxNum := file.StartRootNum()
+		fileStep := startTxNum / stepSize
+		if fileStep < fromStep {
+			continue
+		}
+		totalFiles++
+
+		var checkErr error
+		if startTxNum == 0 {
+			// Base file: forward check (commitment refs count <= domain entries count)
+			checkErr = checkStateCorrespondenceBase(ctx, file, stepSize, failFast, logger)
+		} else {
+			// Non-base file: reverse check (every domain key is in commitment refs)
+			// Include the next commitment file's refs to handle step boundary effects:
+			// accounts written near the end of a step may have their commitment branch
+			// data in the next step's file.
+			// Collect all previous files for no-op write detection.
+			var nextFile state.VisibleFile
+			var prevFiles []state.VisibleFile
+			for j := 0; j < len(files); j++ {
+				if files[j].StartRootNum() == file.EndRootNum() && strings.HasSuffix(files[j].Fullpath(), ".kv") {
+					nextFile = files[j]
+				}
+				if files[j].EndRootNum() <= file.StartRootNum() && strings.HasSuffix(files[j].Fullpath(), ".kv") {
+					prevFiles = append(prevFiles, files[j])
+				}
+			}
+			checkErr = checkStateCorrespondenceReverse(ctx, file, nextFile, prevFiles, stepSize, failFast, logger)
+		}
+		if checkErr != nil {
+			if !errors.Is(checkErr, ErrIntegrity) {
+				return checkErr
+			}
+			if failFast {
+				return checkErr
+			}
+			logger.Warn(checkErr.Error())
+			integrityErr = checkErr
+			continue
+		}
+	}
+	logger.Info("[verify-state] done", "dur", time.Since(start), "files", totalFiles)
+	return integrityErr
+}
+
+// checkStateCorrespondenceBase verifies base files (startTxNum==0) where commitment
+// branches reference ALL keys in the trie, and the accounts/storage files contain
+// all those keys. Forward check: commitment ref count <= domain entry count.
+func checkStateCorrespondenceBase(ctx context.Context, file state.VisibleFile, stepSize uint64, failFast bool, logger log.Logger) error {
+	start := time.Now()
+	fileName := filepath.Base(file.Fullpath())
+	startTxNum := file.StartRootNum()
+	endTxNum := file.EndRootNum()
+
+	logger.Info("[verify-state] checking base file", "kv", fileName, "startTxNum", startTxNum, "endTxNum", endTxNum)
+
+	// Open commitment decompressor + reader
+	commDecomp, err := seg.NewDecompressor(file.Fullpath())
+	if err != nil {
+		return err
+	}
+	defer commDecomp.Close()
+	commDecomp.MadvSequential()
+	commCompression := statecfg.Schema.GetDomainCfg(kv.CommitmentDomain).Compression
+	commReader := seg.NewReader(commDecomp.MakeGetter(), commCompression)
+
+	// Open accounts decompressor + reader
+	accDecomp, accReader, accClose, err := deriveDecompAndReaderForOtherDomain(file.Fullpath(), kv.CommitmentDomain, kv.AccountsDomain)
+	if err != nil {
+		return err
+	}
+	defer accClose()
+
+	// Open storage decompressor + reader
+	stoDecomp, storageReader, storageClose, err := deriveDecompAndReaderForOtherDomain(file.Fullpath(), kv.CommitmentDomain, kv.StorageDomain)
+	if err != nil {
+		return err
+	}
+	defer storageClose()
+
+	// Count domain entries (key/value pairs, so divide by 2)
+	expectedAccounts := uint64(accDecomp.Count()) / 2
+	expectedStorages := uint64(stoDecomp.Count()) / 2
+
+	isReferencing := state.MayContainValuesPlainKeyReferencing(stepSize, startTxNum, endTxNum)
+
+	// Track unique keys found in commitment branches
+	accountOffsets := make(map[uint64]struct{}) // for referenced files
+	storageOffsets := make(map[uint64]struct{}) // for referenced files
+	accountPlain := make(map[string]struct{})   // for plain key files
+	storagePlain := make(map[string]struct{})   // for plain key files
+
+	totalKeys := uint64(commDecomp.Count()) / 2
+	logTicker := time.NewTicker(30 * time.Second)
+	defer logTicker.Stop()
+	branchKeyBuf := make([]byte, 0, 128)
+	branchValueBuf := make([]byte, 0, datasize.MB.Bytes())
+	plainKeyBuf := make([]byte, 0, length.Addr+length.Hash)
+	var branchKeys uint64
+	var integrityErr error
+
+	for commReader.HasNext() {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-logTicker.C:
+			at := fmt.Sprintf("%d/%d", branchKeys, totalKeys)
+			percent := fmt.Sprintf("%.1f%%", float64(branchKeys)/float64(totalKeys)*100)
+			logger.Info("[verify-state] progress", "at", at, "p", percent, "kv", fileName)
+		default:
+		}
+
+		branchKey, _ := commReader.Next(branchKeyBuf[:0])
+		if !commReader.HasNext() {
+			err = errors.New("invalid key/value pair during decompression")
+			if failFast {
+				return fmt.Errorf("%w: %s in %s", ErrIntegrity, err, fileName)
+			}
+			integrityErr = fmt.Errorf("%w: %s in %s", ErrIntegrity, err, fileName)
+			logger.Warn(err.Error())
+			continue
+		}
+		branchValue, _ := commReader.Next(branchValueBuf[:0])
+
+		if bytes.Equal(branchKey, commitmentdb.KeyCommitmentState) {
+			continue
+		}
+		branchKeys++
+
+		branchData := commitment.BranchData(branchValue)
+
+		// Check completeness
+		if !branchData.IsComplete() {
+			touchMap := uint16(0)
+			afterMap := uint16(0)
+			if len(branchData) >= 4 {
+				touchMap = binary.BigEndian.Uint16(branchData[0:])
+				afterMap = binary.BigEndian.Uint16(branchData[2:])
+			}
+			err := fmt.Errorf("%w: incomplete branch at key=%x (touchMap=0x%04x afterMap=0x%04x) in %s", ErrIntegrity, branchKey, touchMap, afterMap, fileName)
+			if failFast {
+				return err
+			}
+			logger.Warn(err.Error())
+			integrityErr = err
+			continue
+		}
+
+		// Walk the branch to extract all referenced keys
+		_, err := branchData.ReplacePlainKeys(nil, func(key []byte, isStorage bool) ([]byte, error) {
+			if isStorage {
+				if len(key) == length.Addr+length.Hash {
+					// Plain key
+					storagePlain[string(key)] = struct{}{}
+					return key, nil
+				}
+				if isReferencing {
+					// Referenced key — decode offset
+					offset := state.DecodeReferenceKey(key)
+					if offset >= uint64(storageReader.Size()) {
+						err := fmt.Errorf("%w: storage reference key %x out of bounds for branch %x in %s: %d vs %d", ErrIntegrity, key, branchKey, fileName, offset, storageReader.Size())
+						if failFast {
+							return nil, err
+						}
+						logger.Warn(err.Error())
+						return key, nil
+					}
+					storageOffsets[offset] = struct{}{}
+					// Also dereference and validate key length
+					storageReader.Reset(offset)
+					plainKey, _ := storageReader.Next(plainKeyBuf[:0])
+					if len(plainKey) != length.Addr+length.Hash {
+						err := fmt.Errorf("%w: storage reference key %x has invalid plainKey len=%d for branch %x in %s", ErrIntegrity, key, len(plainKey), branchKey, fileName)
+						if failFast {
+							return nil, err
+						}
+						logger.Warn(err.Error())
+					}
+					return plainKey, nil
+				}
+				// Unknown key format
+				err := fmt.Errorf("%w: unexpected storage key len=%d for branch %x in %s", ErrIntegrity, len(key), branchKey, fileName)
+				if failFast {
+					return nil, err
+				}
+				logger.Warn(err.Error())
+				return key, nil
+			}
+
+			// Account key
+			if len(key) == length.Addr {
+				// Plain key
+				accountPlain[string(key)] = struct{}{}
+				return key, nil
+			}
+			if isReferencing {
+				// Referenced key — decode offset
+				offset := state.DecodeReferenceKey(key)
+				if offset >= uint64(accReader.Size()) {
+					err := fmt.Errorf("%w: account reference key %x out of bounds for branch %x in %s: %d vs %d", ErrIntegrity, key, branchKey, fileName, offset, accReader.Size())
+					if failFast {
+						return nil, err
+					}
+					logger.Warn(err.Error())
+					return key, nil
+				}
+				accountOffsets[offset] = struct{}{}
+				// Also dereference and validate key length
+				accReader.Reset(offset)
+				plainKey, _ := accReader.Next(plainKeyBuf[:0])
+				if len(plainKey) != length.Addr {
+					err := fmt.Errorf("%w: account reference key %x has invalid plainKey len=%d for branch %x in %s", ErrIntegrity, key, len(plainKey), branchKey, fileName)
+					if failFast {
+						return nil, err
+					}
+					logger.Warn(err.Error())
+				}
+				return plainKey, nil
+			}
+			// Unknown key format
+			err := fmt.Errorf("%w: unexpected account key len=%d for branch %x in %s", ErrIntegrity, len(key), branchKey, fileName)
+			if failFast {
+				return nil, err
+			}
+			logger.Warn(err.Error())
+			return key, nil
+		})
+		if err != nil {
+			if failFast {
+				return err
+			}
+			logger.Warn(err.Error())
+			integrityErr = err
+		}
+	}
+
+	// Compare counts
+	var foundAccounts, foundStorages uint64
+	if isReferencing {
+		foundAccounts = uint64(len(accountOffsets))
+		foundStorages = uint64(len(storageOffsets))
+	} else {
+		foundAccounts = uint64(len(accountPlain))
+		foundStorages = uint64(len(storagePlain))
+	}
+
+	// Forward check: commitment must not reference MORE keys than exist in domain files.
+	// Commitment may reference FEWER keys because branch data for accounts written near
+	// step boundaries may land in the next step's commitment file.
+	if foundAccounts > expectedAccounts {
+		err := fmt.Errorf("%w: FAIL %s accounts_in_commitment=%d > accounts_in_file=%d (extra=%d)", ErrIntegrity, fileName, foundAccounts, expectedAccounts, foundAccounts-expectedAccounts)
+		if failFast {
+			return err
+		}
+		logger.Warn(err.Error())
+		integrityErr = err
+	}
+	if foundStorages > expectedStorages {
+		err := fmt.Errorf("%w: FAIL %s storage_in_commitment=%d > storage_in_file=%d (extra=%d)", ErrIntegrity, fileName, foundStorages, expectedStorages, foundStorages-expectedStorages)
+		if failFast {
+			return err
+		}
+		logger.Warn(err.Error())
+		integrityErr = err
+	}
+
+	dur := time.Since(start)
+	if integrityErr == nil {
+		logger.Info("[verify-state] key correspondence PASS (base)", "kv", fileName,
+			"accounts", fmt.Sprintf("%d/%d", foundAccounts, expectedAccounts),
+			"storage", fmt.Sprintf("%d/%d", foundStorages, expectedStorages),
+			"dur", dur)
+
+		// Phase 2: Hash verification — only runs if key correspondence passes.
+		numWorkers := dbg.EnvInt("CHECK_VERIFY_STATE_WORKERS", runtime.NumCPU())
+		hashErr := checkHashVerification(ctx, file, stepSize, failFast, numWorkers, logger)
+		if hashErr != nil {
+			integrityErr = hashErr
+		}
+	}
+	return integrityErr
+}
+
+// checkStateCorrespondenceReverse verifies non-base files (startTxNum > 0) by checking
+// that every key in accounts.kv and storage.kv is referenced by some commitment branch.
+//
+// nextFile (optional) is the next commitment .kv file. Refs from it are also extracted
+// to handle boundary effects: accounts written near the end of a step may have their
+// commitment branch data in the next step's file.
+//
+// Approach: walk commitment branches → write all extracted plain keys to temp files →
+// sort+dedup → merge-join with domain .kv files (which are also sorted by key).
+func checkStateCorrespondenceReverse(ctx context.Context, file state.VisibleFile, nextFile state.VisibleFile, prevFiles []state.VisibleFile, stepSize uint64, failFast bool, logger log.Logger) error {
+	start := time.Now()
+	fileName := filepath.Base(file.Fullpath())
+	startTxNum := file.StartRootNum()
+	endTxNum := file.EndRootNum()
+
+	logger.Info("[verify-state] checking non-base file", "kv", fileName, "startTxNum", startTxNum, "endTxNum", endTxNum)
+
+	// Open commitment decompressor + reader
+	commDecomp, err := seg.NewDecompressor(file.Fullpath())
+	if err != nil {
+		return err
+	}
+	defer commDecomp.Close()
+	commDecomp.MadvSequential()
+	commCompression := statecfg.Schema.GetDomainCfg(kv.CommitmentDomain).Compression
+	commReader := seg.NewReader(commDecomp.MakeGetter(), commCompression)
+
+	// Open accounts decompressor + reader (for dereferencing and reverse check)
+	accDecomp, accReader, accClose, err := deriveDecompAndReaderForOtherDomain(file.Fullpath(), kv.CommitmentDomain, kv.AccountsDomain)
+	if err != nil {
+		return err
+	}
+	defer accClose()
+
+	// Open storage decompressor + reader
+	stoDecomp, storageReader, storageClose, err := deriveDecompAndReaderForOtherDomain(file.Fullpath(), kv.CommitmentDomain, kv.StorageDomain)
+	if err != nil {
+		return err
+	}
+	defer storageClose()
+
+	expectedAccounts := uint64(accDecomp.Count()) / 2
+	expectedStorages := uint64(stoDecomp.Count()) / 2
+
+	// Create temp files for commitment-extracted keys (hex-encoded, one per line)
+	accKeysFile, err := os.CreateTemp("", "verify-acc-*.hex")
+	if err != nil {
+		return err
+	}
+	accKeysPath := accKeysFile.Name()
+	defer dir.RemoveFile(accKeysPath)
+
+	stoKeysFile, err := os.CreateTemp("", "verify-sto-*.hex")
+	if err != nil {
+		return err
+	}
+	stoKeysPath := stoKeysFile.Name()
+	defer dir.RemoveFile(stoKeysPath)
+
+	accBuf := bufio.NewWriterSize(accKeysFile, 1<<20)
+	stoBuf := bufio.NewWriterSize(stoKeysFile, 1<<20)
+
+	totalKeys := uint64(commDecomp.Count()) / 2
+	logTicker := time.NewTicker(30 * time.Second)
+	defer logTicker.Stop()
+	branchKeyBuf := make([]byte, 0, 128)
+	branchValueBuf := make([]byte, 0, datasize.MB.Bytes())
+	plainKeyBuf := make([]byte, 0, length.Addr+length.Hash)
+	hexBuf := make([]byte, (length.Addr+length.Hash)*2) // big enough for any hex-encoded key
+	var branchKeys uint64
+	var integrityErr error
+	var extractedAccKeys, extractedStoKeys, skippedAccKeys, skippedStoKeys uint64
+
+	// Phase 1: Walk commitment branches, write extracted plain keys to temp files
+	for commReader.HasNext() {
+		select {
+		case <-ctx.Done():
+			accKeysFile.Close()
+			stoKeysFile.Close()
+			return ctx.Err()
+		case <-logTicker.C:
+			logger.Info("[verify-state] extracting refs", "at", fmt.Sprintf("%d/%d", branchKeys, totalKeys),
+				"p", fmt.Sprintf("%.1f%%", float64(branchKeys)/float64(totalKeys)*100), "kv", fileName)
+		default:
+		}
+
+		branchKey, _ := commReader.Next(branchKeyBuf[:0])
+		if !commReader.HasNext() {
+			break
+		}
+		branchValue, _ := commReader.Next(branchValueBuf[:0])
+
+		if bytes.Equal(branchKey, commitmentdb.KeyCommitmentState) {
+			continue
+		}
+		branchKeys++
+
+		branchData := commitment.BranchData(branchValue)
+
+		if !branchData.IsComplete() {
+			touchMap := uint16(0)
+			afterMap := uint16(0)
+			if len(branchData) >= 4 {
+				touchMap = binary.BigEndian.Uint16(branchData[0:])
+				afterMap = binary.BigEndian.Uint16(branchData[2:])
+			}
+			err := fmt.Errorf("%w: incomplete branch at key=%x (touchMap=0x%04x afterMap=0x%04x) in %s", ErrIntegrity, branchKey, touchMap, afterMap, fileName)
+			if failFast {
+				accKeysFile.Close()
+				stoKeysFile.Close()
+				return err
+			}
+			logger.Warn(err.Error())
+			integrityErr = err
+			continue
+		}
+
+		_, err := branchData.ReplacePlainKeys(nil, func(key []byte, isStorage bool) ([]byte, error) {
+			if isStorage {
+				plainKey := key
+				if len(key) == length.Addr+length.Hash {
+					// Plain key (52 bytes)
+				} else {
+					// Try to decode as file offset reference
+					offset := state.DecodeReferenceKey(key)
+					if offset < uint64(storageReader.Size()) {
+						storageReader.Reset(offset)
+						plainKey, _ = storageReader.Next(plainKeyBuf[:0])
+					} else {
+						skippedStoKeys++
+						return key, nil
+					}
+				}
+				if len(plainKey) == length.Addr+length.Hash {
+					extractedStoKeys++
+					n := hex.Encode(hexBuf, plainKey)
+					stoBuf.Write(hexBuf[:n])
+					stoBuf.WriteByte('\n')
+				}
+				return plainKey, nil
+			}
+			// Account key
+			plainKey := key
+			if len(key) == length.Addr {
+				// Plain key (20 bytes)
+			} else {
+				// Try to decode as file offset reference
+				offset := state.DecodeReferenceKey(key)
+				if offset < uint64(accReader.Size()) {
+					accReader.Reset(offset)
+					plainKey, _ = accReader.Next(plainKeyBuf[:0])
+				} else {
+					skippedAccKeys++
+					return key, nil
+				}
+			}
+			if len(plainKey) == length.Addr {
+				extractedAccKeys++
+				n := hex.Encode(hexBuf, plainKey)
+				accBuf.Write(hexBuf[:n])
+				accBuf.WriteByte('\n')
+			}
+			return plainKey, nil
+		})
+		if err != nil {
+			if failFast {
+				accKeysFile.Close()
+				stoKeysFile.Close()
+				return err
+			}
+			integrityErr = err
+		}
+	}
+
+	// Also extract refs from the next commitment file (handles step boundary effects)
+	if nextFile != nil {
+		if err := extractCommitmentRefsToTempFiles(ctx, nextFile, stepSize, accBuf, stoBuf, hexBuf, logger); err != nil {
+			logger.Warn("[verify-state] failed to extract refs from next file", "err", err)
+			// Non-fatal: proceed with what we have
+		}
+	}
+
+	accBuf.Flush()
+	stoBuf.Flush()
+	accKeysFile.Close()
+	stoKeysFile.Close()
+
+	logger.Info("[verify-state] extracted refs, sorting", "kv", fileName,
+		"extractedAcc", extractedAccKeys, "extractedSto", extractedStoKeys,
+		"skippedAcc", skippedAccKeys, "skippedSto", skippedStoKeys,
+		"branches", branchKeys, "dur", time.Since(start))
+
+	// Phase 2: Sort + dedup temp files using system sort (handles external sorting for large files)
+	if err := sortUniqueTempFile(accKeysPath); err != nil {
+		return fmt.Errorf("sorting account keys: %w", err)
+	}
+	if err := sortUniqueTempFile(stoKeysPath); err != nil {
+		return fmt.Errorf("sorting storage keys: %w", err)
+	}
+
+	logger.Info("[verify-state] sorted refs, verifying domains", "kv", fileName, "dur", time.Since(start))
+
+	// Phase 3: Reverse check — merge-join domain .kv with sorted commitment refs.
+	// Collect previous file paths for no-op write detection.
+	var prevCommitmentPaths []string
+	for _, pf := range prevFiles {
+		prevCommitmentPaths = append(prevCommitmentPaths, pf.Fullpath())
+	}
+	// Sort newest-first so we check the most recent previous file first.
+	sort.Slice(prevCommitmentPaths, func(i, j int) bool {
+		return prevCommitmentPaths[i] > prevCommitmentPaths[j]
+	})
+	accMissing, err := reverseCheckDomainKeys(accDecomp, kv.AccountsDomain, accKeysPath, prevCommitmentPaths, fileName, failFast, logger)
+	if err != nil && !errors.Is(err, ErrIntegrity) {
+		return err
+	}
+	if err != nil {
+		integrityErr = err
+	}
+	stoMissing, err := reverseCheckDomainKeys(stoDecomp, kv.StorageDomain, stoKeysPath, prevCommitmentPaths, fileName, failFast, logger)
+	if err != nil && !errors.Is(err, ErrIntegrity) {
+		return err
+	}
+	if err != nil {
+		integrityErr = err
+	}
+
+	dur := time.Since(start)
+	if integrityErr == nil {
+		logger.Info("[verify-state] key correspondence PASS", "kv", fileName,
+			"accounts", fmt.Sprintf("%d/%d", expectedAccounts-accMissing, expectedAccounts),
+			"storage", fmt.Sprintf("%d/%d", expectedStorages-stoMissing, expectedStorages),
+			"dur", dur)
+
+		// Phase 2: Hash verification — only runs if key correspondence passes.
+		numWorkers := dbg.EnvInt("CHECK_VERIFY_STATE_WORKERS", runtime.NumCPU())
+		hashErr := checkHashVerification(ctx, file, stepSize, failFast, numWorkers, logger)
+		if hashErr != nil {
+			integrityErr = hashErr
+		}
+	}
+	return integrityErr
+}
+
+// sortUniqueTempFile sorts and deduplicates a text file in-place using the system's sort command.
+func sortUniqueTempFile(path string) error {
+	cmd := exec.Command("sort", "-u", "-o", path, path)
+	cmd.Env = append(os.Environ(), "LC_ALL=C") // binary sort order for hex strings
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("sort -u %s: %w: %s", path, err, string(out))
+	}
+	return nil
+}
+
+// missingEntry holds a domain key+value that wasn't found in commitment refs.
+type missingEntry struct {
+	key []byte
+	val []byte
+}
+
+// reverseCheckDomainKeys opens a domain .kv decompressor and checks that every key
+// appears in the sorted hex keys file (produced from commitment refs).
+// Both the domain .kv and the sorted file are in ascending order, enabling a merge-join.
+//
+// prevCommitmentPaths are commitment file paths for previous steps (newest-first).
+// When a key is missing from refs, its value is compared with previous domain files
+// to detect no-op writes (same value recorded redundantly).
+func reverseCheckDomainKeys(decomp *seg.Decompressor, domain kv.Domain, sortedKeysPath string, prevCommitmentPaths []string, commitFileName string, failFast bool, logger log.Logger) (missing uint64, retErr error) {
+	compression := statecfg.Schema.GetDomainCfg(domain).Compression
+	reader := seg.NewReader(decomp.MakeGetter(), compression)
+	reader.Reset(0) // start from beginning
+
+	f, err := os.Open(sortedKeysPath)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+
+	// Advance to first ref key
+	var refKey string
+	hasRef := scanner.Scan()
+	if hasRef {
+		refKey = scanner.Text()
+	}
+
+	keyBuf := make([]byte, 0, length.Addr+length.Hash)
+	valBuf := make([]byte, 0, 128)
+	var checked, skippedEmpty uint64
+	var missingEntries []missingEntry
+	for reader.HasNext() {
+		key, _ := reader.Next(keyBuf[:0])
+		if !reader.HasNext() {
+			break // malformed: key without value
+		}
+		val, _ := reader.Next(valBuf[:0])
+
+		// Entries with empty values represent deletions — the key was removed
+		// from the state trie. Commitment branches only reference live entries,
+		// so we skip these.
+		if len(val) == 0 {
+			skippedEmpty++
+			continue
+		}
+
+		domainKeyHex := hex.EncodeToString(key)
+		checked++
+
+		// Advance sorted refs until >= domainKeyHex
+		for hasRef && refKey < domainKeyHex {
+			hasRef = scanner.Scan()
+			if hasRef {
+				refKey = scanner.Text()
+			}
+		}
+
+		if !hasRef || refKey != domainKeyHex {
+			// Collect for no-op verification against previous files.
+			missingEntries = append(missingEntries, missingEntry{
+				key: common.Copy(key),
+				val: common.Copy(val),
+			})
+		}
+	}
+
+	if skippedEmpty > 0 {
+		logger.Info("[verify-state] skipped empty-value entries (deletions)",
+			"domain", domain, "skipped", skippedEmpty, "kv", commitFileName)
+	}
+
+	if len(missingEntries) == 0 {
+		return 0, nil
+	}
+
+	// Check missing entries against previous domain files to detect no-op writes.
+	genuineMissing := verifyMissingAgainstPrevFiles(missingEntries, domain, prevCommitmentPaths, commitFileName, failFast, logger)
+	missing = uint64(genuineMissing)
+
+	if missing > 0 {
+		retErr = fmt.Errorf("%w: %s %d/%d keys not referenced by commitment in %s",
+			ErrIntegrity, domain, missing, checked, commitFileName)
+		logger.Warn(retErr.Error())
+	}
+	return missing, retErr
+}
+
+// verifyMissingAgainstPrevFiles checks each missing entry against previous domain files.
+// For each missing key, it scans previous files (newest-first) to find the same key.
+// If the value matches, it's a no-op write (not an error). If the value differs or
+// the key isn't found in any previous file, it's a genuine missing entry.
+//
+// Uses merge-join within each file: missing entries are sorted by key, and the file
+// is scanned sequentially, advancing both cursors in lockstep.
+func verifyMissingAgainstPrevFiles(entries []missingEntry, domain kv.Domain, prevCommitmentPaths []string, commitFileName string, failFast bool, logger log.Logger) int {
+	if len(prevCommitmentPaths) == 0 {
+		// No previous files to check — all are genuine.
+		for i, e := range entries {
+			if i < 10 {
+				logger.Warn("[verify-state] domain key not in commitment refs (no previous files)",
+					"domain", domain, "key", hex.EncodeToString(e.key), "kv", commitFileName)
+			}
+		}
+		return len(entries)
+	}
+
+	// Sort missing entries by key for merge-join.
+	sort.Slice(entries, func(i, j int) bool {
+		return bytes.Compare(entries[i].key, entries[j].key) < 0
+	})
+
+	// Track which entries are confirmed as no-ops.
+	confirmed := make([]bool, len(entries))
+	remaining := len(entries)
+
+	compression := statecfg.Schema.GetDomainCfg(domain).Compression
+
+	for _, prevCommitPath := range prevCommitmentPaths {
+		if remaining == 0 {
+			break
+		}
+
+		// Derive the domain file path from the commitment file path.
+		prevDomainReader, prevClose, err := deriveReaderForOtherDomain(prevCommitPath, kv.CommitmentDomain, domain)
+		if err != nil {
+			logger.Warn("[verify-state] could not open previous domain file",
+				"domain", domain, "err", err)
+			continue
+		}
+
+		// Merge-join: walk the previous file and check all unconfirmed entries.
+		_ = compression // reader already has compression configured
+		keyBuf := make([]byte, 0, length.Addr+length.Hash)
+		valBuf := make([]byte, 0, 128)
+		ei := 0 // index into sorted entries
+
+		for prevDomainReader.HasNext() && ei < len(entries) {
+			// Skip already confirmed entries.
+			for ei < len(entries) && confirmed[ei] {
+				ei++
+			}
+			if ei >= len(entries) {
+				break
+			}
+
+			prevKey, _ := prevDomainReader.Next(keyBuf[:0])
+			if !prevDomainReader.HasNext() {
+				break
+			}
+			prevVal, _ := prevDomainReader.Next(valBuf[:0])
+
+			// Advance entries index past keys that are < prevKey.
+			for ei < len(entries) && bytes.Compare(entries[ei].key, prevKey) < 0 {
+				ei++
+			}
+			if ei >= len(entries) {
+				break
+			}
+
+			if bytes.Equal(entries[ei].key, prevKey) {
+				if bytes.Equal(entries[ei].val, prevVal) {
+					// No-op write confirmed.
+					confirmed[ei] = true
+					remaining--
+					logger.Info("[verify-state] no-op write confirmed (same value in previous file)",
+						"domain", domain, "key", hex.EncodeToString(entries[ei].key),
+						"kv", commitFileName, "prevKv", filepath.Base(prevCommitPath))
+				}
+				ei++
+			}
+		}
+
+		prevClose()
+	}
+
+	// Report genuinely missing entries.
+	genuine := 0
+	for i, e := range entries {
+		if !confirmed[i] {
+			genuine++
+			if genuine <= 10 {
+				logger.Warn("[verify-state] domain key not in commitment refs",
+					"domain", domain, "key", hex.EncodeToString(e.key), "kv", commitFileName)
+			}
+		}
+	}
+	return genuine
+}
+
+// extractCommitmentRefsToTempFiles walks a commitment .kv file and appends all
+// extracted plain keys (hex-encoded) to the provided writers. This is used to
+// include refs from the "next" commitment file for boundary coverage.
+// Opens its own domain readers for dereferencing (the next file's offsets point
+// into its own domain files, not the current file's).
+func extractCommitmentRefsToTempFiles(ctx context.Context, file state.VisibleFile, stepSize uint64, accBuf *bufio.Writer, stoBuf *bufio.Writer, hexBuf []byte, logger log.Logger) error {
+	nextFileName := filepath.Base(file.Fullpath())
+	logger.Info("[verify-state] also extracting refs from next file", "kv", nextFileName)
+
+	commDecomp, err := seg.NewDecompressor(file.Fullpath())
+	if err != nil {
+		return err
+	}
+	defer commDecomp.Close()
+	commDecomp.MadvSequential()
+	commCompression := statecfg.Schema.GetDomainCfg(kv.CommitmentDomain).Compression
+	commReader := seg.NewReader(commDecomp.MakeGetter(), commCompression)
+
+	// Always open domain readers for dereferencing (commitment files may contain
+	// reference keys regardless of MayContainValuesPlainKeyReferencing result)
+	_, nextAccReader, nextAccClose, err := deriveDecompAndReaderForOtherDomain(file.Fullpath(), kv.CommitmentDomain, kv.AccountsDomain)
+	if err != nil {
+		return err
+	}
+	defer nextAccClose()
+	_, nextStoReader, nextStoClose, err := deriveDecompAndReaderForOtherDomain(file.Fullpath(), kv.CommitmentDomain, kv.StorageDomain)
+	if err != nil {
+		return err
+	}
+	defer nextStoClose()
+
+	branchKeyBuf := make([]byte, 0, 128)
+	branchValueBuf := make([]byte, 0, datasize.MB.Bytes())
+	plainKeyBuf := make([]byte, 0, length.Addr+length.Hash)
+
+	for commReader.HasNext() {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		branchKey, _ := commReader.Next(branchKeyBuf[:0])
+		if !commReader.HasNext() {
+			break
+		}
+		branchValue, _ := commReader.Next(branchValueBuf[:0])
+
+		if bytes.Equal(branchKey, commitmentdb.KeyCommitmentState) {
+			continue
+		}
+
+		branchData := commitment.BranchData(branchValue)
+		if !branchData.IsComplete() {
+			continue
+		}
+
+		branchData.ReplacePlainKeys(nil, func(key []byte, isStorage bool) ([]byte, error) {
+			if isStorage {
+				plainKey := key
+				if len(key) != length.Addr+length.Hash {
+					offset := state.DecodeReferenceKey(key)
+					if offset >= uint64(nextStoReader.Size()) {
+						return key, nil
+					}
+					nextStoReader.Reset(offset)
+					plainKey, _ = nextStoReader.Next(plainKeyBuf[:0])
+				}
+				if len(plainKey) == length.Addr+length.Hash {
+					n := hex.Encode(hexBuf, plainKey)
+					stoBuf.Write(hexBuf[:n])
+					stoBuf.WriteByte('\n')
+				}
+				return plainKey, nil
+			}
+			plainKey := key
+			if len(key) != length.Addr {
+				offset := state.DecodeReferenceKey(key)
+				if offset >= uint64(nextAccReader.Size()) {
+					return key, nil
+				}
+				nextAccReader.Reset(offset)
+				plainKey, _ = nextAccReader.Next(plainKeyBuf[:0])
+			}
+			if len(plainKey) == length.Addr {
+				n := hex.Encode(hexBuf, plainKey)
+				accBuf.Write(hexBuf[:n])
+				accBuf.WriteByte('\n')
+			}
+			return plainKey, nil
+		})
+	}
+	return nil
+}
+
+// hashWorkItem holds a single commitment branch entry for hash verification.
+type hashWorkItem struct {
+	branchKey   []byte
+	branchValue []byte
+}
+
+// checkHashVerification verifies that stateHash stored in each commitment branch cell
+// matches the hash recomputed from the actual domain values. Uses a producer-consumer
+// pattern: 1 producer reads the commitment file sequentially, N workers each open their
+// own domain readers and verify hashes in parallel.
+func checkHashVerification(ctx context.Context, file state.VisibleFile, stepSize uint64, failFast bool, numWorkers int, logger log.Logger) error {
+	start := time.Now()
+	fileName := filepath.Base(file.Fullpath())
+	startTxNum := file.StartRootNum()
+	endTxNum := file.EndRootNum()
+
+	isReferencing := state.MayContainValuesPlainKeyReferencing(stepSize, startTxNum, endTxNum)
+
+	logger.Info("[verify-state] hash verification starting",
+		"kv", fileName, "workers", numWorkers, "referencing", isReferencing)
+
+	if numWorkers < 1 {
+		numWorkers = 1
+	}
+
+	// For non-referencing files, preload domain key→value maps so workers
+	// can look up values for plain keys. These files are small enough to fit in memory.
+	var preloadedAccValues, preloadedStoValues map[string][]byte
+	if !isReferencing {
+		var err error
+		preloadedAccValues, err = preloadDomainValues(file.Fullpath(), kv.CommitmentDomain, kv.AccountsDomain, length.Addr)
+		if err != nil {
+			return fmt.Errorf("preload accounts: %w", err)
+		}
+		preloadedStoValues, err = preloadDomainValues(file.Fullpath(), kv.CommitmentDomain, kv.StorageDomain, length.Addr+length.Hash)
+		if err != nil {
+			return fmt.Errorf("preload storage: %w", err)
+		}
+		logger.Info("[verify-state] preloaded domain values",
+			"accounts", len(preloadedAccValues), "storage", len(preloadedStoValues), "kv", fileName)
+	}
+
+	// Channel for sending work items from producer to workers.
+	workCh := make(chan hashWorkItem, numWorkers*4)
+	var hashMismatches atomic.Uint64
+	var hashChecked atomic.Uint64
+
+	// Set up errgroup with context for cancellation on failure.
+	var eg *errgroup.Group
+	if failFast {
+		eg, ctx = errgroup.WithContext(ctx)
+	} else {
+		eg = &errgroup.Group{}
+	}
+
+	// Launch N worker goroutines.
+	for w := 0; w < numWorkers; w++ {
+		eg.Go(func() error {
+			// Each worker opens its own domain readers for referencing files.
+			var accReader, stoReader *seg.Reader
+			var accClose, stoClose func()
+			if isReferencing {
+				var err error
+				accReader, accClose, err = deriveReaderForOtherDomain(file.Fullpath(), kv.CommitmentDomain, kv.AccountsDomain)
+				if err != nil {
+					return fmt.Errorf("worker: open accounts reader: %w", err)
+				}
+				defer accClose()
+				stoReader, stoClose, err = deriveReaderForOtherDomain(file.Fullpath(), kv.CommitmentDomain, kv.StorageDomain)
+				if err != nil {
+					return fmt.Errorf("worker: open storage reader: %w", err)
+				}
+				defer stoClose()
+			}
+
+			plainKeyBuf := make([]byte, 0, length.Addr+length.Hash)
+			valBuf := make([]byte, 0, 128)
+
+			for item := range workCh {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				default:
+				}
+
+				branchData := commitment.BranchData(item.branchValue)
+
+				// Build maps of accountValues and storageValues by resolving
+				// keys/values from domain files.
+				accountValues := make(map[string][]byte)
+				storageValues := make(map[string][]byte)
+
+				// We need branch data with plain keys for VerifyBranchHashes.
+				// Walk the branch to extract + resolve all keys and read values.
+				resolvedBranchData, err := branchData.ReplacePlainKeys(nil, func(key []byte, isStorage bool) ([]byte, error) {
+					if isStorage {
+						plainKey := key
+						isRef := len(key) != length.Addr+length.Hash
+						if isRef {
+							if !isReferencing {
+								return key, nil
+							}
+							offset := state.DecodeReferenceKey(key)
+							if offset >= uint64(stoReader.Size()) {
+								return key, nil
+							}
+							stoReader.Reset(offset)
+							plainKey, _ = stoReader.Next(plainKeyBuf[:0])
+							if len(plainKey) != length.Addr+length.Hash {
+								return key, nil
+							}
+							val, _ := stoReader.Next(valBuf[:0])
+							storageValues[hex.EncodeToString(plainKey)] = common.Copy(val)
+						} else if preloadedStoValues != nil {
+							hexKey := hex.EncodeToString(plainKey)
+							if val, ok := preloadedStoValues[hexKey]; ok {
+								storageValues[hexKey] = val
+							}
+						}
+						return plainKey, nil
+					}
+
+					// Account key
+					plainKey := key
+					isRef := len(key) != length.Addr
+					if isRef {
+						if !isReferencing {
+							return key, nil
+						}
+						offset := state.DecodeReferenceKey(key)
+						if offset >= uint64(accReader.Size()) {
+							return key, nil
+						}
+						accReader.Reset(offset)
+						plainKey, _ = accReader.Next(plainKeyBuf[:0])
+						if len(plainKey) != length.Addr {
+							return key, nil
+						}
+						val, _ := accReader.Next(valBuf[:0])
+						accountValues[hex.EncodeToString(plainKey)] = common.Copy(val)
+					} else if preloadedAccValues != nil {
+						hexKey := hex.EncodeToString(plainKey)
+						if val, ok := preloadedAccValues[hexKey]; ok {
+							accountValues[hexKey] = val
+						}
+					}
+					return plainKey, nil
+				})
+				if err != nil {
+					if failFast {
+						return err
+					}
+					logger.Warn("[verify-state] hash: ReplacePlainKeys error", "err", err, "kv", fileName)
+					continue
+				}
+
+				// Only verify if we have at least one value to check.
+				if len(accountValues) == 0 && len(storageValues) == 0 {
+					continue
+				}
+
+				err = commitment.VerifyBranchHashes(item.branchKey, resolvedBranchData, accountValues, storageValues)
+				if err != nil {
+					hashMismatches.Add(1)
+					if failFast {
+						return fmt.Errorf("%w: %s in %s", ErrIntegrity, err.Error(), fileName)
+					}
+					logger.Warn("[verify-state] hash mismatch", "err", err, "kv", fileName)
+				}
+				hashChecked.Add(1)
+			}
+			return nil
+		})
+	}
+
+	// Producer: read commitment file and send work items.
+	eg.Go(func() error {
+		defer close(workCh)
+
+		commDecomp, err := seg.NewDecompressor(file.Fullpath())
+		if err != nil {
+			return err
+		}
+		defer commDecomp.Close()
+		commDecomp.MadvSequential()
+		commCompression := statecfg.Schema.GetDomainCfg(kv.CommitmentDomain).Compression
+		commReader := seg.NewReader(commDecomp.MakeGetter(), commCompression)
+
+		branchKeyBuf := make([]byte, 0, 128)
+		branchValueBuf := make([]byte, 0, datasize.MB.Bytes())
+		logTicker := time.NewTicker(30 * time.Second)
+		defer logTicker.Stop()
+		var produced uint64
+
+		for commReader.HasNext() {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-logTicker.C:
+				logger.Info("[verify-state] hash verification progress",
+					"produced", produced,
+					"checked", hashChecked.Load(),
+					"mismatches", hashMismatches.Load(),
+					"kv", fileName)
+			default:
+			}
+
+			branchKey, _ := commReader.Next(branchKeyBuf[:0])
+			if !commReader.HasNext() {
+				break
+			}
+			branchValue, _ := commReader.Next(branchValueBuf[:0])
+
+			if bytes.Equal(branchKey, commitmentdb.KeyCommitmentState) {
+				continue
+			}
+
+			branchData := commitment.BranchData(branchValue)
+			if !branchData.IsComplete() {
+				continue
+			}
+
+			produced++
+
+			// Copy data since buffers are reused.
+			item := hashWorkItem{
+				branchKey:   common.Copy(branchKey),
+				branchValue: common.Copy(branchValue),
+			}
+
+			select {
+			case workCh <- item:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		return nil
+	})
+
+	err := eg.Wait()
+	dur := time.Since(start)
+
+	checked := hashChecked.Load()
+	mismatches := hashMismatches.Load()
+
+	if err != nil {
+		logger.Warn("[verify-state] hash verification FAIL",
+			"checked", checked, "mismatches", mismatches,
+			"dur", dur, "kv", fileName, "err", err)
+		return err
+	}
+
+	logger.Info("[verify-state] hash verification PASS",
+		"checked", checked, "mismatches", mismatches,
+		"dur", dur, "kv", fileName)
+	return nil
+}
+
+// preloadDomainValues reads all key-value pairs from a domain .kv file into a map.
+// Used for non-referencing files where keys are plain (not file offsets).
+func preloadDomainValues(commitmentFile string, oldDomain, newDomain kv.Domain, expectedKeyLen int) (map[string][]byte, error) {
+	reader, closeFn, err := deriveReaderForOtherDomain(commitmentFile, oldDomain, newDomain)
+	if err != nil {
+		return nil, err
+	}
+	defer closeFn()
+
+	values := make(map[string][]byte)
+	keyBuf := make([]byte, 0, expectedKeyLen)
+	valBuf := make([]byte, 0, 128)
+	for reader.HasNext() {
+		key, _ := reader.Next(keyBuf[:0])
+		if !reader.HasNext() {
+			break
+		}
+		val, _ := reader.Next(valBuf[:0])
+		if len(key) == expectedKeyLen {
+			values[hex.EncodeToString(key)] = common.Copy(val)
+		}
+	}
+	return values, nil
+}
+
+func deriveDecompAndReaderForOtherDomain(baseFile string, oldDomain, newDomain kv.Domain) (*seg.Decompressor, *seg.Reader, func(), error) {
+	fileVersionMask, err := version.ReplaceVersionWithMask(baseFile)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	fileVersionMask = strings.Replace(fileVersionMask, oldDomain.String(), newDomain.String(), 1)
+	newFile, _, ok, err := version.FindFilesWithVersionsByPattern(fileVersionMask)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if !ok {
+		return nil, nil, nil, fmt.Errorf("could not derive reader for other domain due to file not found: %s,%s->%s", baseFile, oldDomain, newDomain)
+	}
+	decomp, err := seg.NewDecompressor(newFile)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	compression := statecfg.Schema.GetDomainCfg(newDomain).Compression
+	return decomp, seg.NewReader(decomp.MakeGetter(), compression), decomp.Close, nil
 }
 
 func touchHistoricalKeys(sd *execctx.SharedDomains, tx kv.TemporalTx, d kv.Domain, fromTxNum uint64, toTxNum uint64, visitor func(k []byte)) (uint64, error) {

--- a/db/integrity/commitment_state_verify_test.go
+++ b/db/integrity/commitment_state_verify_test.go
@@ -1,0 +1,347 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package integrity_test
+
+import (
+	"context"
+	"encoding/hex"
+	"math/rand"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/length"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/integrity"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/order"
+	"github.com/erigontech/erigon/db/kv/temporal/temporaltest"
+	"github.com/erigontech/erigon/db/state"
+	"github.com/erigontech/erigon/db/state/execctx"
+	"github.com/erigontech/erigon/execution/commitment"
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+func TestCheckStateVerify(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
+	logger := log.New()
+	ctx := context.Background()
+	stepSize := uint64(100)
+
+	dirs := datadir.New(t.TempDir())
+	db := temporaltest.NewTestDBWithStepSize(t, dirs, stepSize)
+	agg := db.(state.HasAgg).Agg().(*state.Aggregator)
+
+	tx, err := db.BeginTemporalRw(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	domains, err := execctx.NewSharedDomains(ctx, tx, logger)
+	require.NoError(t, err)
+	defer domains.Close()
+
+	// Generate 500 txs (5 steps with stepSize=100).
+	// Compute commitment at EVERY txNum to ensure all accounts/storage entries
+	// have their trie branch data in the same step (no boundary effects).
+	txs := stepSize * 5
+	rnd := rand.New(rand.NewSource(42))
+
+	for txNum := uint64(1); txNum <= txs; txNum++ {
+		domains.SetTxNum(txNum)
+
+		addr := make([]byte, length.Addr)
+		loc := make([]byte, length.Hash)
+		rnd.Read(addr)
+		rnd.Read(loc)
+
+		acc := accounts.Account{
+			Nonce:       txNum,
+			Balance:     *uint256.NewInt(txNum * 1000),
+			CodeHash:    accounts.EmptyCodeHash,
+			Incarnation: 0,
+		}
+		buf := accounts.SerialiseV3(&acc)
+		err = domains.DomainPut(kv.AccountsDomain, tx, addr, buf, txNum, nil, 0)
+		require.NoError(t, err)
+
+		storageKey := append(common.Copy(addr), loc...)
+		err = domains.DomainPut(kv.StorageDomain, tx, storageKey, []byte{addr[0], loc[0]}, txNum, nil, 0)
+		require.NoError(t, err)
+
+		// Compute commitment after each write to ensure trie branch data
+		// is in the same step as the domain entry.
+		blockNum := txNum
+		_, err = domains.ComputeCommitment(ctx, tx, true /* saveStateAfter */, blockNum, txNum, "test", nil)
+		require.NoError(t, err)
+	}
+
+	// Flush data and commit
+	err = domains.Flush(ctx, tx)
+	require.NoError(t, err)
+	err = tx.Commit()
+	require.NoError(t, err)
+
+	// Build snapshot files
+	err = agg.BuildFiles(txs)
+	require.NoError(t, err)
+
+	endTxNum := agg.EndTxNumMinimax()
+	t.Logf("BuildFiles produced files up to txNum=%d (step=%d)", endTxNum, endTxNum/stepSize)
+	require.Greater(t, endTxNum, uint64(0), "expected BuildFiles to produce snapshot files")
+
+	// Run the state verification check
+	err = integrity.CheckStateVerify(ctx, db, true /* failFast */, 0 /* fromStep */, logger)
+	require.NoError(t, err)
+}
+
+// TestCheckStateVerify_NoopWrite verifies that no-op writes (same value re-written)
+// are detected and not flagged as correspondence failures.
+// It writes entries in two step ranges, re-writes one entry with the same value in
+// the second range, builds snapshots, and checks that verify-state passes.
+func TestCheckStateVerify_NoopWrite(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
+	logger := log.New()
+	ctx := context.Background()
+	stepSize := uint64(100)
+
+	dirs := datadir.New(t.TempDir())
+	db := temporaltest.NewTestDBWithStepSize(t, dirs, stepSize)
+	agg := db.(state.HasAgg).Agg().(*state.Aggregator)
+
+	tx, err := db.BeginTemporalRw(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	domains, err := execctx.NewSharedDomains(ctx, tx, logger)
+	require.NoError(t, err)
+	defer domains.Close()
+
+	rnd := rand.New(rand.NewSource(99))
+
+	// --- Step range 1: txNum 1..200 (steps 0-1) ---
+	// Write 5 unique entries per txNum.
+	var noopAddr, noopStorageKey []byte
+	var noopAccBuf []byte
+	var noopStorageVal []byte
+
+	for txNum := uint64(1); txNum <= 200; txNum++ {
+		domains.SetTxNum(txNum)
+
+		addr := make([]byte, length.Addr)
+		loc := make([]byte, length.Hash)
+		rnd.Read(addr)
+		rnd.Read(loc)
+
+		acc := accounts.Account{
+			Nonce:    txNum,
+			Balance:  *uint256.NewInt(txNum * 1000),
+			CodeHash: accounts.EmptyCodeHash,
+		}
+		buf := accounts.SerialiseV3(&acc)
+		err = domains.DomainPut(kv.AccountsDomain, tx, addr, buf, txNum, nil, 0)
+		require.NoError(t, err)
+
+		storageKey := append(common.Copy(addr), loc...)
+		storageVal := []byte{addr[0], loc[0]}
+		err = domains.DomainPut(kv.StorageDomain, tx, storageKey, storageVal, txNum, nil, 0)
+		require.NoError(t, err)
+
+		// Save one entry from step 1 (txNum 100-199) for re-writing in step range 2.
+		if txNum == 150 {
+			noopAddr = common.Copy(addr)
+			noopStorageKey = common.Copy(storageKey)
+			noopAccBuf = common.Copy(buf)
+			noopStorageVal = common.Copy(storageVal)
+		}
+
+		blockNum := txNum
+		_, err = domains.ComputeCommitment(ctx, tx, true, blockNum, txNum, "test", nil)
+		require.NoError(t, err)
+	}
+
+	// --- Step range 2: txNum 201..400 (steps 2-3) ---
+	// Write unique entries PLUS re-write the saved entry with the same value (no-op).
+	for txNum := uint64(201); txNum <= 400; txNum++ {
+		domains.SetTxNum(txNum)
+
+		addr := make([]byte, length.Addr)
+		loc := make([]byte, length.Hash)
+		rnd.Read(addr)
+		rnd.Read(loc)
+
+		acc := accounts.Account{
+			Nonce:    txNum,
+			Balance:  *uint256.NewInt(txNum * 1000),
+			CodeHash: accounts.EmptyCodeHash,
+		}
+		buf := accounts.SerialiseV3(&acc)
+		err = domains.DomainPut(kv.AccountsDomain, tx, addr, buf, txNum, nil, 0)
+		require.NoError(t, err)
+
+		storageKey := append(common.Copy(addr), loc...)
+		err = domains.DomainPut(kv.StorageDomain, tx, storageKey, []byte{addr[0], loc[0]}, txNum, nil, 0)
+		require.NoError(t, err)
+
+		// At txNum=250, re-write the saved entry with the SAME value (no-op).
+		if txNum == 250 {
+			err = domains.DomainPut(kv.AccountsDomain, tx, noopAddr, noopAccBuf, txNum, nil, 0)
+			require.NoError(t, err)
+			err = domains.DomainPut(kv.StorageDomain, tx, noopStorageKey, noopStorageVal, txNum, nil, 0)
+			require.NoError(t, err)
+		}
+
+		blockNum := txNum
+		_, err = domains.ComputeCommitment(ctx, tx, true, blockNum, txNum, "test", nil)
+		require.NoError(t, err)
+	}
+
+	// Flush and commit
+	err = domains.Flush(ctx, tx)
+	require.NoError(t, err)
+	err = tx.Commit()
+	require.NoError(t, err)
+
+	// Build snapshot files for all steps
+	err = agg.BuildFiles(400)
+	require.NoError(t, err)
+
+	endTxNum := agg.EndTxNumMinimax()
+	t.Logf("BuildFiles produced files up to txNum=%d (step=%d)", endTxNum, endTxNum/stepSize)
+	require.Greater(t, endTxNum, uint64(0))
+
+	// Run verify-state — should pass, detecting the no-op write.
+	err = integrity.CheckStateVerify(ctx, db, true /* failFast */, 0 /* fromStep */, logger)
+	require.NoError(t, err)
+}
+
+// TestVerifyBranchHashesFromDB writes accounts+storage, computes commitment,
+// then reads the branch data directly from the DB and verifies the hash.
+// This tests whether hash verification works on DB-level data before snapshot creation.
+func TestVerifyBranchHashesFromDB(t *testing.T) {
+	t.Parallel()
+
+	logger := log.New()
+	ctx := context.Background()
+	stepSize := uint64(100)
+
+	dirs := datadir.New(t.TempDir())
+	db := temporaltest.NewTestDBWithStepSize(t, dirs, stepSize)
+
+	tx, err := db.BeginTemporalRw(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	domains, err := execctx.NewSharedDomains(ctx, tx, logger)
+	require.NoError(t, err)
+	defer domains.Close()
+
+	// Write 5 accounts + storage entries, compute commitment after each
+	type entry struct {
+		addr       []byte
+		loc        []byte
+		storageKey []byte
+		acc        accounts.Account
+		storageVal []byte
+	}
+
+	var entries []entry
+	rnd := rand.New(rand.NewSource(42))
+
+	for txNum := uint64(1); txNum <= 5; txNum++ {
+		domains.SetTxNum(txNum)
+
+		addr := make([]byte, length.Addr)
+		loc := make([]byte, length.Hash)
+		rnd.Read(addr)
+		rnd.Read(loc)
+
+		acc := accounts.Account{
+			Nonce:    txNum,
+			Balance:  *uint256.NewInt(txNum * 1000),
+			CodeHash: accounts.EmptyCodeHash,
+		}
+		accBuf := accounts.SerialiseV3(&acc)
+		err = domains.DomainPut(kv.AccountsDomain, tx, addr, accBuf, txNum, nil, 0)
+		require.NoError(t, err)
+
+		storageKey := append(common.Copy(addr), loc...)
+		storageVal := []byte{addr[0], loc[0]}
+		err = domains.DomainPut(kv.StorageDomain, tx, storageKey, storageVal, txNum, nil, 0)
+		require.NoError(t, err)
+
+		entries = append(entries, entry{addr: addr, loc: loc, storageKey: storageKey, acc: acc, storageVal: storageVal})
+
+		_, err = domains.ComputeCommitment(ctx, tx, true, txNum, txNum, "test", nil)
+		require.NoError(t, err)
+	}
+
+	// Flush so data is in the DB
+	err = domains.Flush(ctx, tx)
+	require.NoError(t, err)
+
+	// Build value maps for all entries
+	accountValues := make(map[string][]byte)
+	storageValues := make(map[string][]byte)
+	for _, e := range entries {
+		accBuf := accounts.SerialiseV3(&e.acc)
+		accountValues[hex.EncodeToString(e.addr)] = accBuf
+		storageValues[hex.EncodeToString(e.storageKey)] = e.storageVal
+	}
+
+	// Read commitment branch entries from DB using RangeAsOf
+	it, err := tx.RangeAsOf(kv.CommitmentDomain, nil, nil, 1000, order.Asc, -1)
+	require.NoError(t, err)
+
+	var checked, passed, failed int
+	for it.HasNext() {
+		k, v, err := it.Next()
+		require.NoError(t, err)
+
+		// Skip the state key (keyCommitmentState)
+		if string(k) == "state" || (len(k) > 0 && k[0] == 'S') {
+			continue
+		}
+
+		bd := commitment.BranchData(v)
+		t.Logf("Branch key=%x data=%s", k, bd.String())
+
+		err = commitment.VerifyBranchHashes(k, bd, accountValues, storageValues)
+		checked++
+		if err != nil {
+			t.Errorf("VerifyBranchHashes FAILED for key=%x: %v", k, err)
+			failed++
+		} else {
+			t.Logf("VerifyBranchHashes PASSED for key=%x", k)
+			passed++
+		}
+	}
+	it.Close()
+
+	t.Logf("Checked %d branches: %d passed, %d failed", checked, passed, failed)
+	require.Zero(t, failed, "expected all branch hashes to verify")
+}

--- a/db/integrity/integrity_action_type.go
+++ b/db/integrity/integrity_action_type.go
@@ -33,6 +33,7 @@ const (
 	CommitmentKvi      Check = "CommitmentKvi"
 	CommitmentKvDeref  Check = "CommitmentKvDeref"
 	CommitmentHistVal  Check = "CommitmentHistVal"
+	StateVerify        Check = "StateVerify"
 	StateProgress      Check = "StateProgress" // state files is not ahead of blocks files
 	Publishable        Check = "Publishable"
 )
@@ -40,7 +41,7 @@ const (
 var AllChecks = []Check{
 	Blocks, HeaderNoGaps, BlocksTxnID, InvertedIndex, StateProgress, Publishable, HistoryNoSystemTxs,
 	BorEvents, BorSpans, BorCheckpoints, ReceiptsNoDups, RCacheNoDups, CommitmentRoot,
-	CommitmentKvi, CommitmentKvDeref,
+	CommitmentKvi, CommitmentKvDeref, StateVerify,
 }
 
 var NonDefaultChecks = []Check{CommitmentHistVal}

--- a/execution/commitment/verify.go
+++ b/execution/commitment/verify.go
@@ -1,0 +1,151 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package commitment
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/empty"
+	"github.com/erigontech/erigon/common/length"
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+// VerifyBranchHashes checks that stateHash in each cell of a branch
+// matches the hash recomputed from the provided domain values.
+//
+// branchKey: compacted trie path from commitment.kv
+// branchData: raw branch data (with PLAIN keys, already dereferenced)
+// accountValues: plainKey(hex) → serialised account value (V3 format)
+// storageValues: plainKey(hex) → raw storage value
+//
+// Returns nil if all hashes match, or an error listing mismatches.
+func VerifyBranchHashes(
+	branchKey []byte,
+	branchData BranchData,
+	accountValues map[string][]byte,
+	storageValues map[string][]byte,
+) error {
+	_, _, row, err := branchData.decodeCells()
+	if err != nil {
+		return fmt.Errorf("decodeCells: %w", err)
+	}
+
+	// Derive depth from branchKey (compacted nibble path).
+	// The branch node identified by N nibbles was folded at depth = N + 1,
+	// because the branch stores children one level deeper than its prefix path.
+	// E.g., root branch (0 nibbles) → depth=1; branch at "3a" (2 nibbles) → depth=3.
+	nibbles := uncompactNibbles(branchKey)
+	if HasTerm(nibbles) {
+		nibbles = nibbles[:len(nibbles)-1]
+	}
+	depth := int16(len(nibbles)) + 1
+
+	var mismatches []string
+
+	for nibble := 0; nibble < 16; nibble++ {
+		c := row[nibble]
+		if c == nil {
+			continue
+		}
+		if c.stateHashLen == 0 {
+			continue // no stored hash to verify
+		}
+
+		// Save the original stateHash for comparison.
+		var origHash common.Hash
+		copy(origHash[:], c.stateHash[:c.stateHashLen])
+		origLen := c.stateHashLen
+
+		// Load domain values into cell fields and mark as loaded.
+		// If a value is missing or empty (deletion), skip this cell — it's not verifiable.
+		canVerify := true
+		if c.storageAddrLen > 0 {
+			stoKey := hex.EncodeToString(c.storageAddr[:c.storageAddrLen])
+			stoVal, ok := storageValues[stoKey]
+			if !ok || len(stoVal) == 0 {
+				canVerify = false
+			} else {
+				// Storage value is stored raw in the cell's Storage field.
+				copy(c.Storage[:], stoVal)
+				c.StorageLen = int8(len(stoVal))
+				c.loaded = c.loaded.addFlag(cellLoadStorage)
+			}
+		}
+		if c.accountAddrLen > 0 && canVerify {
+			accKey := hex.EncodeToString(c.accountAddr[:c.accountAddrLen])
+			accVal, ok := accountValues[accKey]
+			if !ok || len(accVal) == 0 {
+				canVerify = false
+			} else {
+				var acc accounts.Account
+				if err := accounts.DeserialiseV3(&acc, accVal); err != nil {
+					mismatches = append(mismatches, fmt.Sprintf(
+						"nibble %x: failed to deserialise account %s: %v", nibble, accKey, err))
+					continue
+				}
+				c.Nonce = acc.Nonce
+				c.Balance.Set(&acc.Balance)
+				c.CodeHash = acc.CodeHash.Value()
+				if c.CodeHash == (common.Hash{}) {
+					c.CodeHash = empty.CodeHash
+				}
+				c.Flags = BalanceUpdate | NonceUpdate | CodeUpdate
+				c.loaded = c.loaded.addFlag(cellLoadAccount)
+			}
+		}
+		if !canVerify {
+			continue
+		}
+
+		// Clear stateHash to force recomputation.
+		c.stateHashLen = 0
+
+		// Create a fresh HexPatriciaHashed for each cell to avoid any shared state issues.
+		hph := NewHexPatriciaHashed(length.Addr, nil)
+		hph.memoizationOff = true
+
+		computed, err := hph.computeCellHash(c, depth, nil)
+		if err != nil {
+			mismatches = append(mismatches, fmt.Sprintf(
+				"nibble %x: computeCellHash error: %v", nibble, err))
+			continue
+		}
+
+		// computed is [0xa0, hash...] (33 bytes) for non-embedded leaves.
+		// origHash is just the 32-byte hash (without the 0xa0 prefix).
+		if len(computed) >= 33 && computed[0] == 0xa0 {
+			computed = computed[1:]
+		}
+
+		if origLen != int16(len(computed)) || common.Hash(computed[:origLen]) != origHash {
+			mismatches = append(mismatches, fmt.Sprintf(
+				"nibble %x: stateHash mismatch: stored=%x computed=%x (branchKey=%x)",
+				nibble, origHash[:origLen], computed[:min(int(origLen), len(computed))], branchKey))
+		}
+	}
+
+	if len(mismatches) > 0 {
+		msg := fmt.Sprintf("hash verification failed with %d mismatch(es) at branchKey=%x:", len(mismatches), branchKey)
+		for _, m := range mismatches {
+			msg += "\n  " + m
+		}
+		return fmt.Errorf("%s", msg)
+	}
+	return nil
+}

--- a/execution/commitment/verify_test.go
+++ b/execution/commitment/verify_test.go
@@ -1,0 +1,355 @@
+package commitment
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/sha3"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/length"
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+func TestVerifyBranchHashes_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	hph := NewHexPatriciaHashed(length.Addr, nil)
+
+	// Build a cell with account data.
+	c := new(cell)
+	addr := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
+	copy(c.accountAddr[:], addr[:])
+	c.accountAddrLen = length.Addr
+
+	acc := accounts.Account{
+		Nonce:    42,
+		Balance:  *uint256.NewInt(1000000),
+		CodeHash: accounts.EmptyCodeHash,
+	}
+	c.Nonce = acc.Nonce
+	c.Balance.Set(&acc.Balance)
+	c.CodeHash = acc.CodeHash.Value()
+	c.Flags = BalanceUpdate | NonceUpdate | CodeUpdate
+	c.loaded = cellLoadAccount
+
+	// Hash the account key to get the hashed extension.
+	// In production, root branch is folded at depth=1 (branchKey has 0 nibbles, depth = 0+1).
+	keccak := sha3.NewLegacyKeccak256().(keccakState)
+	depth := int16(1) // root branch fold depth
+	hashBuf := make([]byte, length.Hash)
+	if err := c.hashAccKey(keccak, depth, hashBuf); err != nil {
+		t.Fatal(err)
+	}
+	c.hashedExtension[64-depth] = terminatorHexByte
+
+	// Compute the cell hash
+	hph.memoizationOff = false // allow memoization
+	hash, err := hph.computeCellHash(c, depth, nil)
+	require.NoError(t, err)
+	require.True(t, c.stateHashLen > 0, "stateHash should be set after computeCellHash")
+
+	t.Logf("stateHash: %x (len=%d)", c.stateHash[:c.stateHashLen], c.stateHashLen)
+	t.Logf("computed hash: %x", hash)
+
+	// Now encode this cell into branch data using EncodeBranch.
+	encoder := NewBranchEncoder(1024)
+	// First nibble of the hashed key at depth=1 starts from index 1
+	// But the cell's hashedExtension was filled from depth=1, so [0] is the first extension nibble
+	nibble := int(c.hashedExtension[0]) // first nibble of the hashed extension
+	touchMap := uint16(1 << nibble)
+	afterMap := touchMap
+
+	row := [16]*cell{}
+	row[nibble] = c
+	readCell := func(nib int, skip bool) (*cell, error) {
+		return row[nib], nil
+	}
+	branchData, _, err := encoder.EncodeBranch(touchMap, afterMap, touchMap, readCell)
+	require.NoError(t, err)
+	require.True(t, len(branchData) > 0)
+
+	// Build the branchKey (compacted nibbles for depth=0 means empty path)
+	branchKey := HexNibblesToCompactBytes(nil) // empty path
+
+	// Serialize the account value
+	accVal := accounts.SerialiseV3(&acc)
+
+	// Verify the branch hashes
+	accountValues := map[string][]byte{
+		hex.EncodeToString(addr[:]): accVal,
+	}
+	storageValues := map[string][]byte{}
+
+	err = VerifyBranchHashes(branchKey, BranchData(branchData), accountValues, storageValues)
+	require.NoError(t, err)
+
+	// Now corrupt the value and verify mismatch
+	corruptedAcc := accounts.Account{
+		Nonce:    43, // different nonce
+		Balance:  *uint256.NewInt(1000000),
+		CodeHash: accounts.EmptyCodeHash,
+	}
+	corruptedVal := accounts.SerialiseV3(&corruptedAcc)
+	corruptedAccountValues := map[string][]byte{
+		hex.EncodeToString(addr[:]): corruptedVal,
+	}
+
+	err = VerifyBranchHashes(branchKey, BranchData(branchData), corruptedAccountValues, storageValues)
+	require.Error(t, err)
+	t.Logf("Expected mismatch error: %v", err)
+}
+
+func TestVerifyBranchHashes_Singleton(t *testing.T) {
+	t.Parallel()
+
+	hph := NewHexPatriciaHashed(length.Addr, nil)
+
+	// Build a singleton cell with BOTH account and storage data at depth=2.
+	c := new(cell)
+	addr := common.HexToAddress("0x4c888535841acbe0709b0758083f61d375bc02b4")
+	loc := common.HexToHash("0x1df4f91929e18fda9e6f82e54e748e81e79e4bbd6fe34cdcba843ee8d63e8c4f")
+	copy(c.accountAddr[:], addr[:])
+	c.accountAddrLen = length.Addr
+	copy(c.storageAddr[:length.Addr], addr[:])
+	copy(c.storageAddr[length.Addr:], loc[:])
+	c.storageAddrLen = length.Addr + length.Hash
+
+	acc := accounts.Account{
+		Nonce:    2,
+		Balance:  *uint256.NewInt(2000),
+		CodeHash: accounts.EmptyCodeHash,
+	}
+	c.Nonce = acc.Nonce
+	c.Balance.Set(&acc.Balance)
+	c.CodeHash = acc.CodeHash.Value()
+	c.Flags = BalanceUpdate | NonceUpdate | CodeUpdate | StorageUpdate
+	c.loaded = cellLoadAccount | cellLoadStorage
+
+	storageVal := []byte{0x4c, 0x1d}
+	copy(c.Storage[:], storageVal)
+	c.StorageLen = int8(len(storageVal))
+
+	// Hash keys at depth=2
+	keccak := sha3.NewLegacyKeccak256().(keccakState)
+	depth := int16(2)
+
+	// First hash storage key
+	hashedKeyOffset := int16(0)
+	if depth >= 64 {
+		hashedKeyOffset = depth - 64
+	}
+	hashBuf := make([]byte, length.Hash)
+	if err := c.hashStorageKey(keccak, length.Addr, 0, hashedKeyOffset, hashBuf); err != nil {
+		t.Fatal(err)
+	}
+	c.hashedExtension[64-hashedKeyOffset] = terminatorHexByte
+
+	// Compute storage leaf hash (as part of computeCellHash for singleton)
+	hph.memoizationOff = false
+	hash, err := hph.computeCellHash(c, depth, nil)
+	require.NoError(t, err)
+	require.True(t, c.stateHashLen > 0, "stateHash should be set for singleton")
+
+	t.Logf("singleton stateHash: %x (len=%d)", c.stateHash[:c.stateHashLen], c.stateHashLen)
+	t.Logf("computed hash: %x", hash)
+
+	// Encode into branch data
+	encoder := NewBranchEncoder(1024)
+	// The nibble is determined by the hashed account key at depth=2
+	if err := c.hashAccKey(keccak, depth, hashBuf); err != nil {
+		t.Fatal(err)
+	}
+	nibble := int(c.hashedExtension[0])
+	touchMap := uint16(1 << nibble)
+	afterMap := touchMap
+
+	row := [16]*cell{}
+	row[nibble] = c
+	readCell := func(nib int, skip bool) (*cell, error) {
+		return row[nib], nil
+	}
+	branchData, _, err := encoder.EncodeBranch(touchMap, afterMap, touchMap, readCell)
+	require.NoError(t, err)
+
+	// branchKey for depth=2: depth-1 = 1 nibble of the hashed account key path
+	if err := c.hashAccKey(keccak, 0, hashBuf); err != nil {
+		t.Fatal(err)
+	}
+	branchNibbles := []byte{c.hashedExtension[0]}
+	branchKey := HexNibblesToCompactBytes(branchNibbles)
+
+	// Build domain values maps
+	accVal := accounts.SerialiseV3(&acc)
+	accountValues := map[string][]byte{
+		hex.EncodeToString(addr[:]): accVal,
+	}
+	stoKey := hex.EncodeToString(c.storageAddr[:c.storageAddrLen])
+	storageValues := map[string][]byte{
+		stoKey: storageVal,
+	}
+
+	err = VerifyBranchHashes(branchKey, BranchData(branchData), accountValues, storageValues)
+	require.NoError(t, err)
+}
+
+// TestVerifyBranchHashes_SingletonDepth1 tests singleton at depth=1 (root branch).
+// In production, the root branch is folded at depth=1 (branchKey has 0 nibbles).
+func TestVerifyBranchHashes_SingletonDepth1(t *testing.T) {
+	t.Parallel()
+
+	hph := NewHexPatriciaHashed(length.Addr, nil)
+
+	c := new(cell)
+	addr := common.HexToAddress("0x4c888535841acbe0709b0758083f61d375bc02b4")
+	loc := common.HexToHash("0x1df4f91929e18fda9e6f82e54e748e81e79e4bbd6fe34cdcba843ee8d63e8c4f")
+	copy(c.accountAddr[:], addr[:])
+	c.accountAddrLen = length.Addr
+	copy(c.storageAddr[:length.Addr], addr[:])
+	copy(c.storageAddr[length.Addr:], loc[:])
+	c.storageAddrLen = length.Addr + length.Hash
+
+	acc := accounts.Account{
+		Nonce:    2,
+		Balance:  *uint256.NewInt(2000),
+		CodeHash: accounts.EmptyCodeHash,
+	}
+	c.Nonce = acc.Nonce
+	c.Balance.Set(&acc.Balance)
+	c.CodeHash = acc.CodeHash.Value()
+	c.Flags = BalanceUpdate | NonceUpdate | CodeUpdate | StorageUpdate
+	c.loaded = cellLoadAccount | cellLoadStorage
+
+	storageVal := []byte{0x4c, 0x1d}
+	copy(c.Storage[:], storageVal)
+	c.StorageLen = int8(len(storageVal))
+
+	// Root branch is folded at depth=1 (branchKey has 0 nibbles, depth = 0 + 1 = 1)
+	keccak := sha3.NewLegacyKeccak256().(keccakState)
+	depth := int16(1)
+
+	// First hash storage key
+	hashedKeyOffset := int16(0)
+	hashBuf := make([]byte, length.Hash)
+	if err := c.hashStorageKey(keccak, length.Addr, 0, hashedKeyOffset, hashBuf); err != nil {
+		t.Fatal(err)
+	}
+	c.hashedExtension[64-hashedKeyOffset] = terminatorHexByte
+
+	// Compute hash at depth=1
+	hph.memoizationOff = false
+	hash, err := hph.computeCellHash(c, depth, nil)
+	require.NoError(t, err)
+	require.True(t, c.stateHashLen > 0, "stateHash should be set for singleton")
+
+	t.Logf("singleton depth=1 stateHash: %x (len=%d)", c.stateHash[:c.stateHashLen], c.stateHashLen)
+	t.Logf("computed hash: %x", hash)
+
+	// Encode into branch data
+	encoder := NewBranchEncoder(1024)
+	if err := c.hashAccKey(keccak, depth, hashBuf); err != nil {
+		t.Fatal(err)
+	}
+	nibble := int(c.hashedExtension[0])
+	touchMap := uint16(1 << nibble)
+	afterMap := touchMap
+
+	row := [16]*cell{}
+	row[nibble] = c
+	readCell := func(nib int, skip bool) (*cell, error) {
+		return row[nib], nil
+	}
+	branchData, _, err := encoder.EncodeBranch(touchMap, afterMap, touchMap, readCell)
+	require.NoError(t, err)
+
+	// branchKey for root branch: empty path (0 nibbles → depth = 0 + 1 = 1)
+	branchKey := HexNibblesToCompactBytes(nil)
+
+	// Build domain values maps
+	accVal := accounts.SerialiseV3(&acc)
+	accountValues := map[string][]byte{
+		hex.EncodeToString(addr[:]): accVal,
+	}
+	stoKey := hex.EncodeToString(c.storageAddr[:c.storageAddrLen])
+	storageValues := map[string][]byte{
+		stoKey: storageVal,
+	}
+
+	err = VerifyBranchHashes(branchKey, BranchData(branchData), accountValues, storageValues)
+	require.NoError(t, err)
+}
+
+func TestVerifyBranchHashes_Storage(t *testing.T) {
+	t.Parallel()
+
+	hph := NewHexPatriciaHashed(length.Addr, nil)
+
+	// Build a cell with storage data (depth >= 64 = pure storage cell).
+	c := new(cell)
+	addr := common.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	loc := common.HexToHash("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	copy(c.storageAddr[:length.Addr], addr[:])
+	copy(c.storageAddr[length.Addr:], loc[:])
+	c.storageAddrLen = length.Addr + length.Hash
+
+	storageVal := []byte{0x01, 0x02, 0x03}
+	copy(c.Storage[:], storageVal)
+	c.StorageLen = int8(len(storageVal))
+	c.loaded = cellLoadStorage
+
+	// Hash the storage key (depth=65 means non-singleton storage-only cell)
+	keccak := sha3.NewLegacyKeccak256().(keccakState)
+	depth := int16(65)
+	hashedKeyOffset := depth - 64
+	hashBuf := make([]byte, length.Hash)
+	if err := c.hashStorageKey(keccak, length.Addr, 0, hashedKeyOffset, hashBuf); err != nil {
+		t.Fatal(err)
+	}
+	c.hashedExtension[64-hashedKeyOffset] = terminatorHexByte
+
+	hph.memoizationOff = false
+	hash, err := hph.computeCellHash(c, depth, nil)
+	require.NoError(t, err)
+	require.True(t, c.stateHashLen > 0)
+
+	t.Logf("stateHash: %x (len=%d)", c.stateHash[:c.stateHashLen], c.stateHashLen)
+	t.Logf("computed hash: %x", hash)
+
+	// Encode cell into branch data
+	encoder := NewBranchEncoder(1024)
+	nibble := int(c.hashedExtension[0])
+	touchMap := uint16(1 << nibble)
+	afterMap := touchMap
+
+	row := [16]*cell{}
+	row[nibble] = c
+	readCell := func(nib int, skip bool) (*cell, error) {
+		return row[nib], nil
+	}
+	branchData, _, err := encoder.EncodeBranch(touchMap, afterMap, touchMap, readCell)
+	require.NoError(t, err)
+
+	// Build branchKey for depth=65: depth-1 = 64 nibbles (hash of account address).
+	// In production, the storage branch at depth=65 has currentKeyLen=64.
+	keccak.Reset()
+	keccak.Write(addr[:])
+	var hashBuf2 [32]byte
+	keccak.Read(hashBuf2[:])
+	var nibbles [64]byte
+	for i := 0; i < 32; i++ {
+		nibbles[i*2] = hashBuf2[i] >> 4
+		nibbles[i*2+1] = hashBuf2[i] & 0x0f
+	}
+	branchKey := HexNibblesToCompactBytes(nibbles[:])
+
+	// Build domain values map
+	stoKey := hex.EncodeToString(c.storageAddr[:c.storageAddrLen])
+	storageValues := map[string][]byte{
+		stoKey: storageVal,
+	}
+
+	err = VerifyBranchHashes(branchKey, BranchData(branchData), map[string][]byte{}, storageValues)
+	require.NoError(t, err)
+}

--- a/execution/verify/history_verify.go
+++ b/execution/verify/history_verify.go
@@ -1,0 +1,159 @@
+package verify
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/consensuschain"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/services"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/protocol"
+	"github.com/erigontech/erigon/execution/protocol/rules"
+	"github.com/erigontech/erigon/execution/state"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/execution/vm"
+)
+
+// NewHistoryVerifier returns a function that verifies history snapshot files
+// by re-executing blocks using HistoryReaderV3 (which reads state via GetAsOf
+// from history/domain files). ExecuteBlockEphemerally validates receipts, gas,
+// and bloom filters against block headers — if any GetAsOf value is wrong,
+// execution diverges and receipt validation fails.
+//
+// This cross-checks three independent data sources: history files, domain files,
+// and block headers.
+//
+// Workers controls the number of parallel goroutines. Each worker opens its own
+// TemporalTx and processes blocks from a shared counter.
+func NewHistoryVerifier(
+	blockReader services.FullBlockReader,
+	chainConfig *chain.Config,
+	engine rules.Engine,
+	workers int,
+	logger log.Logger,
+) func(ctx context.Context, db kv.TemporalRoDB, fromTxNum, toTxNum uint64) error {
+	return func(ctx context.Context, db kv.TemporalRoDB, fromTxNum, toTxNum uint64) error {
+		txNumsReader := blockReader.TxnumReader()
+
+		// Open a temporary tx to convert txNum range → block range.
+		ttx, err := db.BeginTemporalRo(ctx)
+		if err != nil {
+			return fmt.Errorf("history verify: begin temporal ro: %w", err)
+		}
+		defer ttx.Rollback()
+
+		fromBlock, ok, err := txNumsReader.FindBlockNum(ctx, ttx, fromTxNum)
+		if err != nil {
+			return fmt.Errorf("history verify: find block for txNum %d: %w", fromTxNum, err)
+		}
+		if !ok {
+			return fmt.Errorf("history verify: no block found for txNum %d", fromTxNum)
+		}
+		toBlock, ok, err := txNumsReader.FindBlockNum(ctx, ttx, toTxNum)
+		if err != nil {
+			return fmt.Errorf("history verify: find block for txNum %d: %w", toTxNum, err)
+		}
+		if !ok {
+			toBlock, _, err = txNumsReader.FindBlockNum(ctx, ttx, toTxNum-1)
+			if err != nil {
+				return fmt.Errorf("history verify: find block for txNum %d: %w", toTxNum-1, err)
+			}
+		}
+
+		// Skip range if it only contains genesis.
+		if fromBlock == 0 && toBlock == 0 {
+			return nil
+		}
+
+		logger.Info("[verify-history] re-executing blocks",
+			"fromBlock", fromBlock, "toBlock", toBlock,
+			"fromTxNum", fromTxNum, "toTxNum", toTxNum,
+			"workers", workers)
+
+		var completed atomic.Uint64
+
+		g, gctx := errgroup.WithContext(ctx)
+		g.SetLimit(workers)
+
+		for blockNum := fromBlock; blockNum <= toBlock; blockNum++ {
+			if blockNum == 0 {
+				continue
+			}
+			blockNum := blockNum // capture
+
+			g.Go(func() error {
+				if err := gctx.Err(); err != nil {
+					return fmt.Errorf("history verify: cancelled at block %d: %w", blockNum, err)
+				}
+
+				workerTx, err := db.BeginTemporalRo(gctx)
+				if err != nil {
+					return fmt.Errorf("history verify: begin temporal ro for block %d: %w", blockNum, err)
+				}
+				defer workerTx.Rollback()
+
+				hash, ok, err := blockReader.CanonicalHash(gctx, workerTx, blockNum)
+				if err != nil {
+					return fmt.Errorf("history verify: canonical hash for block %d: %w", blockNum, err)
+				}
+				if !ok {
+					return fmt.Errorf("history verify: no canonical hash for block %d", blockNum)
+				}
+
+				block, _, err := blockReader.BlockWithSenders(gctx, workerTx, hash, blockNum)
+				if err != nil {
+					return fmt.Errorf("history verify: read block %d: %w", blockNum, err)
+				}
+				if block == nil {
+					return fmt.Errorf("history verify: block %d not found", blockNum)
+				}
+
+				blockStartTxNum, err := txNumsReader.Min(gctx, workerTx, blockNum)
+				if err != nil {
+					return fmt.Errorf("history verify: min txNum for block %d: %w", blockNum, err)
+				}
+
+				stateReader := state.NewHistoryReaderV3(workerTx, blockStartTxNum)
+				stateWriter := state.NewNoopWriter()
+				chainReader := consensuschain.NewReader(chainConfig, workerTx, blockReader, logger)
+
+				blockHashFunc := protocol.GetHashFn(block.Header(), func(hash common.Hash, number uint64) (*types.Header, error) {
+					return blockReader.Header(gctx, workerTx, hash, number)
+				})
+
+				vmConfig := vm.Config{}
+				_, err = protocol.ExecuteBlockEphemerally(
+					chainConfig, &vmConfig, blockHashFunc,
+					engine, block,
+					stateReader, stateWriter,
+					chainReader, nil, logger,
+				)
+				if err != nil {
+					return fmt.Errorf("history verify: block %d execution failed: %w", blockNum, err)
+				}
+
+				n := completed.Add(1)
+				if n%1000 == 0 {
+					logger.Info("[verify-history] progress",
+						"completed", n, "total", toBlock-fromBlock)
+				}
+
+				return nil
+			})
+		}
+
+		if err := g.Wait(); err != nil {
+			return err
+		}
+
+		logger.Info("[verify-history] verification complete",
+			"blocks", toBlock-fromBlock+1, "fromTxNum", fromTxNum, "toTxNum", toTxNum)
+		return nil
+	}
+}

--- a/execution/verify/history_verify_test.go
+++ b/execution/verify/history_verify_test.go
@@ -1,0 +1,183 @@
+package verify_test
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/crypto"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv/rawdbv3"
+	"github.com/erigontech/erigon/db/state"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/tests/blockgen"
+	"github.com/erigontech/erigon/execution/tests/mock"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/execution/verify"
+)
+
+// TestHistoryVerification_SimpleBlocks is an integration test that generates blocks
+// with state changes, builds snapshot files, and verifies history via re-execution.
+func TestHistoryVerification_SimpleBlocks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping history verification integration test in short mode")
+	}
+
+	const stepSize = 10
+
+	funds := big.NewInt(1 * common.Ether)
+	key, _ := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	address := crypto.PubkeyToAddress(key.PublicKey)
+	chainConfig := chain.AllProtocolChanges
+	chainConfig.TerminalTotalDifficulty = common.Big0
+	gspec := &types.Genesis{
+		Config: chainConfig,
+		Alloc: types.GenesisAlloc{
+			address: {Balance: funds},
+		},
+	}
+
+	m := mock.MockWithGenesis(t, gspec, key, mock.WithStepSize(stepSize))
+	ctx := context.Background()
+	logger := log.New()
+
+	// Generate blocks — coinbase rewards create account state changes.
+	const numBlocks = 200
+	parent := m.Genesis
+	const batchSize = 100
+	for batchStart := 0; batchStart < numBlocks; batchStart += batchSize {
+		batchEnd := batchStart + batchSize
+		if batchEnd > numBlocks {
+			batchEnd = numBlocks
+		}
+		chainResult, err := blockgen.GenerateChain(m.ChainConfig, parent, m.Engine, m.DB, batchEnd-batchStart, func(i int, b *blockgen.BlockGen) {
+			b.SetCoinbase(common.Address{1})
+		})
+		require.NoError(t, err)
+		require.NoError(t, m.InsertChain(chainResult))
+		parent = chainResult.TopBlock
+	}
+	t.Logf("Inserted %d blocks", numBlocks)
+
+	agg := m.DB.(state.HasAgg).Agg().(*state.Aggregator)
+
+	// Get last txNum.
+	tx, err := m.DB.BeginRo(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+	_, lastTxNum, err := rawdbv3.TxNums.Last(tx)
+	require.NoError(t, err)
+	t.Logf("Last txNum: %d, stepSize: %d, steps: %d", lastTxNum, agg.StepSize(), lastTxNum/agg.StepSize())
+
+	// Build files.
+	err = agg.BuildFiles(lastTxNum)
+	require.NoError(t, err)
+
+	if agg.EndTxNumMinimax() == 0 {
+		t.Skip("No files built (memory backend); skipping history verification integration test")
+	}
+
+	// Now run the history verifier on the built file ranges.
+	historyVerifier := verify.NewHistoryVerifier(m.BlockReader, m.ChainConfig, m.Engine, 2, logger)
+
+	// Get the step size and verify each non-base step.
+	stepSz := agg.StepSize()
+	maxStep := agg.EndTxNumMinimax() / stepSz
+	for step := uint64(1); step < maxStep; step++ {
+		fromTxNum := step * stepSz
+		toTxNum := (step + 1) * stepSz
+		t.Logf("Verifying history step %d [%d, %d)", step, fromTxNum, toTxNum)
+
+		err := historyVerifier(ctx, m.DB, fromTxNum, toTxNum)
+		require.NoError(t, err, "history verification failed for step %d [%d, %d)", step, fromTxNum, toTxNum)
+	}
+
+	t.Logf("History verification passed for %d steps", maxStep-1)
+}
+
+// TestHistoryVerification_WithUserTransactions exercises history verification with
+// blocks containing ETH transfers, which create account balance/nonce changes.
+func TestHistoryVerification_WithUserTransactions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping history verification with user transactions test in short mode")
+	}
+
+	const stepSize = 7
+
+	funds := big.NewInt(1 * common.Ether)
+	key, _ := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	address := crypto.PubkeyToAddress(key.PublicKey)
+	chainConfig := chain.AllProtocolChanges
+	chainConfig.TerminalTotalDifficulty = common.Big0
+	gspec := &types.Genesis{
+		Config: chainConfig,
+		Alloc: types.GenesisAlloc{
+			address: {Balance: funds},
+		},
+	}
+
+	m := mock.MockWithGenesis(t, gspec, key, mock.WithStepSize(stepSize))
+	ctx := context.Background()
+	logger := log.New()
+	signer := types.LatestSignerForChainID(chainConfig.ChainID)
+
+	// Generate blocks with ETH transfers.
+	const numBlocks = 50
+	nonce := uint64(0)
+	recipient := common.Address{0xDE, 0xAD}
+
+	chainResult, err := blockgen.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, numBlocks, func(i int, b *blockgen.BlockGen) {
+		b.SetCoinbase(common.Address{1})
+		// Add 2 ETH transfers per block.
+		for j := 0; j < 2; j++ {
+			tx := types.NewTransaction(nonce, recipient, uint256.NewInt(1), 21000, uint256.NewInt(875000000), nil)
+			signed, signErr := types.SignTx(tx, *signer, key)
+			if signErr != nil {
+				t.Fatal(signErr)
+			}
+			b.AddTx(signed)
+			nonce++
+		}
+	})
+	require.NoError(t, err)
+	require.NoError(t, m.InsertChain(chainResult))
+	t.Logf("Inserted %d blocks with 2 user txs each", numBlocks)
+
+	agg := m.DB.(state.HasAgg).Agg().(*state.Aggregator)
+
+	// Get last txNum.
+	roTx, err := m.DB.BeginRo(ctx)
+	require.NoError(t, err)
+	defer roTx.Rollback()
+	_, lastTxNum, err := rawdbv3.TxNums.Last(roTx)
+	require.NoError(t, err)
+	t.Logf("Last txNum: %d, stepSize: %d, steps: %d", lastTxNum, agg.StepSize(), lastTxNum/agg.StepSize())
+
+	// Build files.
+	err = agg.BuildFiles(lastTxNum)
+	require.NoError(t, err)
+
+	if agg.EndTxNumMinimax() == 0 {
+		t.Skip("No files built (memory backend); skipping history verification integration test")
+	}
+
+	// Run the history verifier.
+	historyVerifier := verify.NewHistoryVerifier(m.BlockReader, m.ChainConfig, m.Engine, 2, logger)
+
+	stepSz := agg.StepSize()
+	maxStep := agg.EndTxNumMinimax() / stepSz
+	for step := uint64(1); step < maxStep; step++ {
+		fromTxNum := step * stepSz
+		toTxNum := (step + 1) * stepSz
+		t.Logf("Verifying history step %d [%d, %d)", step, fromTxNum, toTxNum)
+
+		err := historyVerifier(ctx, m.DB, fromTxNum, toTxNum)
+		require.NoError(t, err, "history verification failed for step %d [%d, %d)", step, fromTxNum, toTxNum)
+	}
+
+	t.Logf("History verification passed for %d steps", maxStep-1)
+}

--- a/execution/verify/snapshot_verify.go
+++ b/execution/verify/snapshot_verify.go
@@ -1,0 +1,122 @@
+package verify
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/consensuschain"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/services"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/protocol"
+	"github.com/erigontech/erigon/execution/protocol/rules"
+	"github.com/erigontech/erigon/execution/state"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/execution/vm"
+)
+
+// NewSnapshotVerifier returns a function that verifies newly built state
+// snapshot files by re-executing all blocks in [fromTxNum, toTxNum) and
+// checking that each block produces the expected receipts, gas usage, and
+// bloom filters. If any block fails, the returned error includes the block
+// number.
+//
+// The db parameter is a temporary TemporalRoDB backed by a fresh aggregator
+// that sees all files on disk (including newly built ones not yet activated).
+func NewSnapshotVerifier(
+	blockReader services.FullBlockReader,
+	chainConfig *chain.Config,
+	engine rules.Engine,
+	logger log.Logger,
+) func(ctx context.Context, db kv.TemporalRoDB, fromTxNum, toTxNum uint64) error {
+	return func(ctx context.Context, db kv.TemporalRoDB, fromTxNum, toTxNum uint64) error {
+		txNumsReader := blockReader.TxnumReader()
+
+		ttx, err := db.BeginTemporalRo(ctx)
+		if err != nil {
+			return fmt.Errorf("snapshot verify: begin temporal ro: %w", err)
+		}
+		defer ttx.Rollback()
+
+		// Convert txNum range to block range.
+		fromBlock, ok, err := txNumsReader.FindBlockNum(ctx, ttx, fromTxNum)
+		if err != nil {
+			return fmt.Errorf("snapshot verify: find block for txNum %d: %w", fromTxNum, err)
+		}
+		if !ok {
+			return fmt.Errorf("snapshot verify: no block found for txNum %d", fromTxNum)
+		}
+		toBlock, ok, err := txNumsReader.FindBlockNum(ctx, ttx, toTxNum)
+		if err != nil {
+			return fmt.Errorf("snapshot verify: find block for txNum %d: %w", toTxNum, err)
+		}
+		if !ok {
+			// toTxNum is exclusive; use the last known block
+			toBlock, _, err = txNumsReader.FindBlockNum(ctx, ttx, toTxNum-1)
+			if err != nil {
+				return fmt.Errorf("snapshot verify: find block for txNum %d: %w", toTxNum-1, err)
+			}
+		}
+
+		chainReader := consensuschain.NewReader(chainConfig, ttx, blockReader, logger)
+
+		logger.Info("[snapshots] verifying blocks", "from", fromBlock, "to", toBlock,
+			"fromTxNum", fromTxNum, "toTxNum", toTxNum)
+
+		for blockNum := fromBlock; blockNum <= toBlock; blockNum++ {
+			if err := ctx.Err(); err != nil {
+				return fmt.Errorf("snapshot verify: cancelled at block %d: %w", blockNum, err)
+			}
+
+			// Skip genesis block — nothing to execute.
+			if blockNum == 0 {
+				continue
+			}
+
+			hash, ok, err := blockReader.CanonicalHash(ctx, ttx, blockNum)
+			if err != nil {
+				return fmt.Errorf("snapshot verify: canonical hash for block %d: %w", blockNum, err)
+			}
+			if !ok {
+				return fmt.Errorf("snapshot verify: no canonical hash for block %d", blockNum)
+			}
+
+			block, _, err := blockReader.BlockWithSenders(ctx, ttx, hash, blockNum)
+			if err != nil {
+				return fmt.Errorf("snapshot verify: read block %d: %w", blockNum, err)
+			}
+			if block == nil {
+				return fmt.Errorf("snapshot verify: block %d not found", blockNum)
+			}
+
+			// Read historical state as of the block's first transaction.
+			blockStartTxNum, err := txNumsReader.Min(ctx, ttx, blockNum)
+			if err != nil {
+				return fmt.Errorf("snapshot verify: min txNum for block %d: %w", blockNum, err)
+			}
+
+			stateReader := state.NewHistoryReaderV3(ttx, blockStartTxNum)
+			stateWriter := state.NewNoopWriter()
+
+			blockHashFunc := protocol.GetHashFn(block.Header(), func(hash common.Hash, number uint64) (*types.Header, error) {
+				return blockReader.Header(ctx, ttx, hash, number)
+			})
+
+			vmConfig := vm.Config{}
+			_, err = protocol.ExecuteBlockEphemerally(
+				chainConfig, &vmConfig, blockHashFunc,
+				engine, block,
+				stateReader, stateWriter,
+				chainReader, nil, logger,
+			)
+			if err != nil {
+				return fmt.Errorf("snapshot verify: block %d execution failed: %w", blockNum, err)
+			}
+		}
+
+		logger.Info("[snapshots] verification complete", "blocks", toBlock-fromBlock+1)
+		return nil
+	}
+}


### PR DESCRIPTION
Add CLI commands and libraries for verifying state and history snapshot correctness by cross-checking commitment branches against domain files and re-executing blocks against history snapshots.

New commands:
  erigon seg verify-state   - verify correspondence between state
                              (accounts, storage) and commitment snapshots

`./build/bin/erigon seg verify-state --datadir ~/ethmain --from-step 2048 --failFast`

  erigon seg verify-history - verify history snapshots by re-executing
                              blocks and comparing state changes

`./build/bin/erigon seg verify-history --datadir ~/ethmain --from-step 2048 --failFast`