### PR TITLE
[SharovBot] rpc: improve prune error message in eth_getLogs

### DIFF
--- a/rpc/jsonrpc/eth_receipts.go
+++ b/rpc/jsonrpc/eth_receipts.go
@@ -225,7 +225,7 @@ func (api *APIImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria) (t
 //   - `--prune.mode=minimal` (and `full`) can serve receipts as much as "state history" available (by re-executing blocks)
 //
 // returns `state.PrunedError` if not available for given `fromTxNum`
-func assertReceiptsAvailable(fromTxNum uint64, tx kv.TemporalTx) error {
+func assertReceiptsAvailable(ctx context.Context, txNumsReader rawdbv3.TxNumsReader, begin uint64, fromTxNum uint64, tx kv.TemporalTx) error {
 	persistReceipts, err := kvcfg.PersistReceipts.Enabled(tx)
 	if err != nil {
 		return err
@@ -234,7 +234,8 @@ func assertReceiptsAvailable(fromTxNum uint64, tx kv.TemporalTx) error {
 		return nil
 	}
 	if minTxNum := state.StateHistoryStartTxNum(tx); fromTxNum < minTxNum {
-		return fmt.Errorf("%w: from tx: %d, min tx: %d", state.PrunedError, fromTxNum, minTxNum)
+		firstAvailBlock, _, _ := txNumsReader.FindBlockNum(ctx, tx, minTxNum)
+		return fmt.Errorf("%w: requested block %d, history is available from block %d", state.PrunedError, begin, firstAvailBlock)
 	}
 	return nil
 }
@@ -247,7 +248,7 @@ func applyFiltersV3(txNumsReader rawdbv3.TxNumsReader, tx kv.TemporalTx, begin, 
 		if err != nil {
 			return out, err
 		}
-		if err := assertReceiptsAvailable(fromTxNum, tx); err != nil {
+		if err := assertReceiptsAvailable(context.Background(), txNumsReader, begin, fromTxNum, tx); err != nil {
 			return out, err
 		}
 	}

--- a/rpc/rpchelper/helper.go
+++ b/rpc/rpchelper/helper.go
@@ -178,8 +178,8 @@ func CreateHistoryStateReader(ctx context.Context, tx kv.TemporalTx, blockNumber
 	}
 	txNum := uint64(int(minTxNum) + txnIndex + /* 1 system txNum in beginning of block */ 1)
 	if minHistoryTxNum := state.StateHistoryStartTxNum(tx); txNum < minHistoryTxNum {
-		bn, _, _ := txNumsReader.FindBlockNum(ctx, tx, minHistoryTxNum)
-		return nil, fmt.Errorf("%w: block tx: %d, min tx: %d last state history bn: %d", state.PrunedError, txNum, minHistoryTxNum, bn)
+		firstAvailBlock, _, _ := txNumsReader.FindBlockNum(ctx, tx, minHistoryTxNum)
+		return nil, fmt.Errorf("%w: requested block %d, history is available from block %d", state.PrunedError, blockNumber, firstAvailBlock)
 	}
 	return state.NewHistoryReaderV3(tx, txNum), nil
 }


### PR DESCRIPTION
**[SharovBot]**

## Problem

When querying `eth_getLogs` on a pruned node, the error message exposed raw internal `txNum` values that are meaningless to Ethereum users:

```json
{"error":{"code":-32000,"message":"old data not available due to pruning: from tx: 1962853355, min tx: 2662500000"}}
```

Issues (as noted in #13198):
1. User never asked for a txNum — they asked for a block range
2. Users don't know what `txNum` is — it's an internal Erigon concept
3. Reason for unavailability not clear (it's because of pruning)
4. No indication of what block range *is* available

## Fix

Convert txNums to block numbers in both error-producing sites:

**`eth_receipts.go` — `assertReceiptsAvailable`:**
- Pass `txNumsReader` and `begin` block through; use `FindBlockNum` to convert `minTxNum` → first available block

**`rpchelper/helper.go` — `CreateHistoryStateReader`:**
- Already had `bn` from `FindBlockNum`; just use it in the message instead of raw txNums

**Before:**
```
old data not available due to pruning: from tx: 1962853355, min tx: 2662500000
```

**After:**
```
old data not available due to pruning: requested block 16999999, history is available from block 22000000
```

## Testing

`go test ./rpc/...` — all pass ✅

Fixes #13198