### PR TITLE
[SharovBot] fix: hive EEST workflow false failures due to missing workspace/logs (#17506)

### DIFF
--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -135,11 +135,14 @@ jobs:
           run_suite ${{ matrix.sim }} ${{ matrix.sim-limit }}
         continue-on-error: true
       - name: Upload output log
+        if: always()
         uses: actions/upload-artifact@v6
         with:
           name: hive-workspace-log-${{ matrix.sim }}
           path: hive/workspace/logs
+          if-no-files-found: ignore
       - name: Test Results
+        if: always()
         run: |
           cat hive/result.log
           if grep -q "failed" hive/failed.log; then


### PR DESCRIPTION
**[SharovBot]**

## Problem

The `test-hive-eest` workflow was producing false CI failures. The failure pattern:

1. **Step 8** "Run hive tests and parse output" — has `continue-on-error: true`, so it always shows success regardless of what happened
2. **Step 9** "Upload output log" — tries to upload `hive/workspace/logs`, but **hive only creates this directory when tests fail**. When all tests pass, the path doesn't exist, and the upload step errors out
3. **Step 10** "Test Results" — the real pass/fail check (reads `failed.log`) — gets **skipped** because step 9 failed and it had no `if: always()`
4. Job concludes as **failure** even though tests actually passed

Confirmed in [run 22123438284](https://github.com/erigontech/erigon/actions/runs/22123438284/job/63948376737): `consume-rlp` failed at "Upload output log", "Test Results" was skipped, yet "Run hive tests" succeeded.

## Fix

- Add `if: always()` to "Upload output log" so it runs even after prior step errors
- Add `if-no-files-found: ignore` so missing `workspace/logs` doesn't fail the upload
- Add `if: always()` to "Test Results" so it always checks `failed.log` and correctly fails only when tests actually failed

