### PR TITLE
[SharovBot] fix: increase kurtosis seconds_per_slot to 8s for assertoor stability

### DIFF
--- a/.github/workflows/kurtosis/fusaka.io
+++ b/.github/workflows/kurtosis/fusaka.io
@@ -29,7 +29,7 @@ network_params:
   bpo_5_target_blobs: 6
   withdrawal_type: "0x01"
   genesis_delay: 30
-  seconds_per_slot: 3
+  seconds_per_slot: 8
 
 snooper_enabled: true
 

--- a/.github/workflows/kurtosis/pectra.io
+++ b/.github/workflows/kurtosis/pectra.io
@@ -14,7 +14,7 @@ network_params:
   min_validator_withdrawability_delay: 1
   shard_committee_period: 1
   churn_limit_quotient: 16
-  seconds_per_slot: 4
+  seconds_per_slot: 8
   genesis_delay: 90
 
 additional_services:

--- a/.github/workflows/kurtosis/regular-assertoor.io
+++ b/.github/workflows/kurtosis/regular-assertoor.io
@@ -11,7 +11,7 @@ network_params:
   #electra_fork_epoch: 1
   min_validator_withdrawability_delay: 1
   shard_committee_period: 1
-  seconds_per_slot: 4
+  seconds_per_slot: 8
 
 additional_services:
   - assertoor


### PR DESCRIPTION
**[SharovBot]**

## Problem

Assertoor kurtosis tests are flaky. The hypothesis is that timing constraints inside assertoor tests are too tight for 4s slots — giving more wall-clock time per slot should improve stability.

## Change

| File | Before | After |
|---|---|---|
| `kurtosis/regular-assertoor.io` | `seconds_per_slot: 4` | `seconds_per_slot: 8` |
| `kurtosis/pectra.io` | `seconds_per_slot: 4` | `seconds_per_slot: 8` |
| `kurtosis/fusaka.io` | `seconds_per_slot: 3` | `seconds_per_slot: 8` |

`fast_lifecycle.io` intentionally left at 1s (speed is the point of that test).