### PR TITLE
kurtosis: use a fixed version of assertoor for our current tests

### DIFF
--- a/.github/workflows/kurtosis/pectra.io
+++ b/.github/workflows/kurtosis/pectra.io
@@ -24,6 +24,7 @@ snooper_enabled: false
 assertoor_params:
   run_stability_check: true
   run_block_proposal_check: true
+  image: ethpandaops/assertoor:v0.0.17
   tests:
     - file: https://raw.githubusercontent.com/erigontech/erigon/refs/heads/main/.github/workflows/kurtosis/deposit-request.io
     - file: https://raw.githubusercontent.com/erigontech/erigon/refs/heads/main/.github/workflows/kurtosis/el-triggered-consolidations-test.io

--- a/.github/workflows/kurtosis/regular-assertoor.io
+++ b/.github/workflows/kurtosis/regular-assertoor.io
@@ -19,6 +19,7 @@ additional_services:
 assertoor_params:
   run_stability_check: false
   run_block_proposal_check: true
+  image: ethpandaops/assertoor:v0.0.17
   tests:
     - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/all-opcodes-test.yaml
     - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/blob-transactions-test.yaml

--- a/Makefile
+++ b/Makefile
@@ -320,7 +320,7 @@ eest-hive:
 define run-kurtosis-assertoor
 	docker build -t test/erigon:current . ; \
 	kurtosis enclave rm -f makefile-kurtosis-testnet ; \
-	kurtosis run --enclave makefile-kurtosis-testnet github.com/ethpandaops/ethereum-package --args-file $(1) ; \
+	kurtosis run --enclave makefile-kurtosis-testnet github.com/ethpandaops/ethereum-package@5.0.1 --args-file $(1) ; \
 	printf "\nTo view logs: \nkurtosis service logs makefile-kurtosis-testnet el-1-erigon-lighthouse\n"
 endef
 


### PR DESCRIPTION
`ethpandaops/assertoor:v0.0.18` has been released and it caused our current kurtosis tests to go red, pinning assertor to previous version for now

the reason why the tests were failing is related to Blobs, was seeing 
```
[WARN] [02-20|10:40:01.306] [rpc] served                             conn=172.16.0.16:54438 method=eth_sendRawTransaction reqid=77 err="INVALID: blob_versioned_hashes, blobs, commitments and proofs must have equal number"
[WARN] [02-20|10:40:01.884] [rpc] served                             conn=172.16.0.16:54438 method=eth_sendRawTransaction reqid=78 err="INVALID: blob_versioned_hashes, blobs, commitments and proofs must have equal number"
```

and then the assertoor checker for `"build a block with at least >= 1 blobs"` was failing

this is likely due to assertoor v0.0.18 changing the blob format (possibly for fusaka format) - can see notes at https://github.com/ethpandaops/assertoor/releases/tag/v0.0.18

will need to dig deeper into this to see where the error came from so that we can update to newer versions (it is likely related to the kurtosis config which we are using to run this test - I noticed Erigon was run with Pectra only config, no Fusaka enabled - so there will be a discrepancy in blob formats) 

but for now short fix is just to use the previous version of assertoor