### PR TITLE
[SharovBot] fix(p2p): fix anacrolix/torrent UDP tracker race (issue #18901)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ replace github.com/holiman/bloomfilter/v2 => github.com/AskAlexSharov/bloomfilte
 
 replace github.com/holiman/uint256 => github.com/erigontech/uint256 v0.0.0-20260128213548-c9ef4c05bfe3
 
+replace github.com/anacrolix/torrent => github.com/erigontech/torrent v1.61.1-0.20260220162608-6a4c394c09a3
+
 require (
 	github.com/erigontech/erigon-snapshot v1.3.1-0.20260210221902-e495954c7e78
 	github.com/erigontech/erigonwatch v0.0.0-20240718131902-b6576bde1116

--- a/go.sum
+++ b/go.sum
@@ -352,6 +352,8 @@ github.com/erigontech/secp256k1 v1.2.1-0.20260218182123-377cc1bd6410 h1:5YD7JJ5P
 github.com/erigontech/secp256k1 v1.2.1-0.20260218182123-377cc1bd6410/go.mod h1:CnigLRUsfobnTYoUzwdT/De67fw9OhTA0KTkxa+svik=
 github.com/erigontech/silkworm-go v0.24.0 h1:fFe74CjQM5LI7ouMYjmqfFaqIFzQTpMrt+ls+a5PxpE=
 github.com/erigontech/silkworm-go v0.24.0/go.mod h1:O50ux0apICEVEGyRWiE488K8qz8lc3PA/SXbQQAc8SU=
+github.com/erigontech/torrent v1.61.1-0.20260220162608-6a4c394c09a3 h1:lTsYoSP3RpXJnivn4OU4kNWRRtgC0D4/lSLTGEpulHM=
+github.com/erigontech/torrent v1.61.1-0.20260220162608-6a4c394c09a3/go.mod h1:99HuZswKVFJaolion++ekIiF52WDiEtQJqqib4IPdZc=
 github.com/erigontech/uint256 v0.0.0-20260128213548-c9ef4c05bfe3 h1:E5PV7YXmws6zaTwp/Rf4tWoaTgBNuvrS4rMCeL61dY4=
 github.com/erigontech/uint256 v0.0.0-20260128213548-c9ef4c05bfe3/go.mod h1:EOMSn4q6Nyt9P6efbI3bueV4e1b3dGlUCXeiRV4ng7E=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=


### PR DESCRIPTION
**[SharovBot]**

## Problem

Data race in `anacrolix/torrent/tracker/udp.(*Client).request()` — two goroutines concurrently writing `cl.connIdIssued` without mutex protection.

Stack trace from issue #18901:
```
Write at 0x00c0f5193528 by goroutine 60999585:
  github.com/anacrolix/torrent/tracker/udp.(*Client).request()
      tracker/udp/client.go:235 +0x834

Previous write at 0x00c0f5193528 by goroutine 60999531:
  github.com/anacrolix/torrent/tracker/udp.(*Client).request()
      tracker/udp/client.go:235 +0x834
```

Line 235 is: `cl.connIdIssued = time.Time{}`

This reset happens without holding any lock. The `mu` lock is only held inside `writeRequest()`, which runs in a goroutine and returns before `request()` selects on its response channel. Two concurrent callers of `request()` can both write `connIdIssued` simultaneously.

## Fix

Patched the `erigontech/torrent` fork (branch [`fix/udp-race-18901`](https://github.com/erigontech/torrent/tree/fix/udp-race-18901), commit `6a4c394c09a3`):

- Added a dedicated `connIdMu sync.Mutex` to the `Client` struct
- Protected all reads/writes of `connIdIssued` with `connIdMu`:
  - `shouldReconnectDefault()`: read protected
  - `doConnectRoundTrip()`: write protected
  - `request()` error path (line 235): write protected

Lock ordering: always `mu → connIdMu`.

Updated `go.mod` to redirect `github.com/anacrolix/torrent` to the patched fork via a `replace` directive.

## Verification

- `go build github.com/anacrolix/torrent/tracker/udp` ✅
- `go build ./cmd/downloader/... ./db/downloader/...` ✅

Closes #18901