### PR TITLE
[SharovBot] ci: skip sync wait if node already synced in rpc-integ-tests-latest

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests-latest.yml
+++ b/.github/workflows/qa-rpc-integration-tests-latest.yml
@@ -102,7 +102,8 @@ jobs:
             --total-time=$TOTAL_TIME_SECONDS \
             --chain=$CHAIN \
             --node-type=minimal_node \
-            --stop-erigon=False
+            --stop-erigon=False \
+            --min-block=24400000
           
           # Capture monitoring script exit status
           test_exit_status=$?


### PR DESCRIPTION
**[SharovBot]**

## Problem

`qa-rpc-integration-tests-latest` frequently fails with *"Test not executed, workflow failed for infrastructure reasons"* because the 15-minute sync-wait step times out even when the mirrored datadir is already at tip.

## Solution

Pass `--min-block=24400000` to `run_and_chase_tip.py` in the *Run Erigon and wait for sync* step.

With this flag the script polls `eth_syncing` and `eth_blockNumber` immediately after startup and exits as soon as either:
- `eth_syncing == false`, OR
- `eth_blockNumber >= 24400000`

If the node isn't reachable within 120s, the script falls back to the normal SyncSentinel polling loop.

## Requires

Companion PR in erigon-qa (script change): https://github.com/erigontech/erigon-qa/pull/new/fix/skip-sync-wait-if-already-synced