### PR TITLE
[SharovBot] fix(txpool): reduce P2P message batch flush interval from 1s to 100ms

### DIFF
--- a/.github/workflows/test-hive-cancun-stress.yml
+++ b/.github/workflows/test-hive-cancun-stress.yml
@@ -1,0 +1,116 @@
+name: Hive Cancun Stress Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      repetitions:
+        description: 'Number of parallel repetitions (max 50 per dispatch)'
+        required: false
+        default: '50'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  test-hive-cancun:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on:
+      group: hive
+    strategy:
+      fail-fast: false
+      matrix:
+        run_id: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50]
+
+    steps:
+      - name: Checkout Erigon go.mod
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: go.mod
+          sparse-checkout-cone-mode: false
+          path: erigon-src
+
+      - name: Checkout Hive
+        uses: actions/checkout@v6
+        with:
+          repository: ethereum/hive
+          ref: 0ee187ce394720a5902c135324ac7de4240cbb37
+          path: hive
+
+      - name: Setup go env and cache
+        uses: actions/setup-go@v6
+        with:
+          go-version: '>=1.24'
+          go-version-file: 'hive/go.mod'
+
+      - name: Conditional Docker Login
+        if: |
+          github.repository == 'erigontech/erigon' &&
+          github.actor != 'dependabot[bot]' &&
+          (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_USERNAME }}
+          password: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_TOKEN }}
+
+      - name: Get dependencies and build hive
+        env:
+          SOURCE_REPO: ${{ github.repository }}
+        run: |
+          cd hive
+          go get . >> buildlogs.log
+          rm clients/erigon/Dockerfile
+          mv clients/erigon/Dockerfile.git clients/erigon/Dockerfile
+          branch_name=$(echo ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}} | sed 's/[&/\]/\\&/g')
+          echo Building Hive with Erigon repo - ${SOURCE_REPO}, branch - $branch_name
+          sed -i "s|^ARG github=erigontech/erigon$|ARG github=${SOURCE_REPO}|" clients/erigon/Dockerfile
+          sed -i "s/^ARG tag=main$/ARG tag=${branch_name}/" clients/erigon/Dockerfile
+          go_version=$(go mod edit -json ../erigon-src/go.mod | jq -r .Go)
+          echo "Patching builder Go version to ${go_version}"
+          sed -i "s|golang:[0-9.]*-alpine|golang:${go_version}-alpine|" clients/erigon/Dockerfile
+          go build . >> buildlogs.log
+
+      - name: Run hive engine/cancun (run ${{ matrix.run_id }}/50)
+        run: |
+          cd hive
+          run_suite() {
+            echo "Running engine/cancun - attempt ${{ matrix.run_id }}"
+            ./hive -docker.auth --sim ethereum/engine --sim.limit=cancun --sim.parallelism=8 --client erigon 2>&1 | tee output.log || true
+            status_line=$(tail -2 output.log | head -1 | sed -r "s/\x1B\[[0-9;]*[a-zA-Z]//g")
+            suites=$(echo "$status_line" | sed -n 's/.*suites=\([0-9]*\).*/\1/p')
+            if [ -z "$suites" ]; then
+              status_line=$(tail -1 output.log | sed -r "s/\x1B\[[0-9;]*[a-zA-Z]//g")
+              suites=$(echo "$status_line" | sed -n 's/.*suites=\([0-9]*\).*/\1/p')
+            fi
+            tests=$(echo "$status_line" | sed -n 's/.*tests=\([0-9]*\).*/\1/p')
+            failed=$(echo "$status_line" | sed -n 's/.*failed=\([0-9]*\).*/\1/p')
+            echo "Run ${{ matrix.run_id }}: Tests=$tests Failed=$failed"
+            if (( tests < 4 )); then
+              echo "Too few tests run: ${tests}"
+              exit 1
+            fi
+            max_allowed_failures=2
+            if (( failed > max_allowed_failures )); then
+              echo "Too many failures: ${failed} failed out of ${tests} (max allowed: ${max_allowed_failures})"
+              exit 1
+            fi
+            echo "PASS: ${failed} failures (within max=${max_allowed_failures})"
+          }
+          run_suite
+        continue-on-error: false
+
+      - name: Upload output log
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: hive-cancun-run-${{ matrix.run_id }}
+          path: hive/workspace/logs
+        continue-on-error: true
+
+      - name: Remove Hive directory
+        if: always()
+        run: rm -rf hive
+
+      - name: Prune docker
+        if: always()
+        run: docker system prune -af --volumes

--- a/txnprovider/txpool/fetch.go
+++ b/txnprovider/txpool/fetch.go
@@ -229,8 +229,11 @@ func (f *Fetch) receiveMessage(ctx context.Context, sentryClient sentryproto.Sen
 		}
 	}
 
-	// Start ticker goroutine to flush batch every second
-	ticker := time.NewTicker(1 * time.Second)
+	// Start ticker goroutine to flush batch every 100ms.
+	// Keeping this tight reduces the worst-case latency between receiving a
+	// POOLED_TRANSACTIONS_66 response and the transaction entering the pool,
+	// which matters for block builders picking up freshly-gossiped transactions.
+	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 	go func() {
 		for {


### PR DESCRIPTION
**[SharovBot]**

> **Draft** — running hive `engine/cancun` test 100× before marking ready

## Problem

The hive test **"Blob Transaction Ordering, Multiple Clients (Cancun)"** intermittently fails with:
```
FAIL: Error verifying blob bundle (payload 1/5): expected 6 blob, got 5
```

Root cause: `fetch.go`'s `receiveMessage` batches ALL inbound P2P messages and flushes them via a ticker set to **1 second**. Combined with `processRemoteTxnsEvery = 100ms`, worst-case latency from P2P receipt to pool inclusion is **~1.1 seconds**.

The hive test sends 1-blob transactions to Client B which must gossip to Client A before Client A builds the payload (`GetPayloadDelay: 2s` window). With 1.1s worst-case latency the margin is only 0.9s — sometimes insufficient in the docker test environment.

## Fix

Reduce the batch flush ticker from **1 second → 100ms**. Worst-case latency drops to **~200ms**, giving a comfortable 1.8s margin within the 2-second payload window.

```diff
-ticker := time.NewTicker(1 * time.Second)
+ticker := time.NewTicker(100 * time.Millisecond)
```

## Testing

Running hive `engine/cancun` test 100 times. Will mark ready for review once all pass.

Fixes: https://github.com/erigontech/erigon/actions/runs/22242447860/job/64349011577