### PR TITLE
[SharovBot] fix(txpool): reduce P2P message batch flush interval from 1s to 250ms

### DIFF
--- a/txnprovider/txpool/fetch.go
+++ b/txnprovider/txpool/fetch.go
@@ -229,8 +229,12 @@ func (f *Fetch) receiveMessage(ctx context.Context, sentryClient sentryproto.Sen
 		}
 	}
 
-	// Start ticker goroutine to flush batch every second
-	ticker := time.NewTicker(1 * time.Second)
+	// Start ticker goroutine to flush batch.
+	// Reduced from 1s to 250ms to lower worst-case latency between receiving
+	// a POOLED_TRANSACTIONS_66 response and the transaction entering the pool.
+	// This matters for block builders that need freshly-gossiped transactions
+	// (e.g. multi-client blob tx ordering tests with a 2s payload window).
+	ticker := time.NewTicker(250 * time.Millisecond)
 	defer ticker.Stop()
 	go func() {
 		for {


### PR DESCRIPTION
**[SharovBot]**

> **Draft** — running hive `engine/cancun` test 100× before marking ready for review

## Problem

The hive test **"Blob Transaction Ordering, Multiple Clients (Cancun)"** intermittently fails with:
```
FAIL: Error verifying blob bundle (payload 1/5): expected 6 blob, got 5
```

Root cause: `fetch.go`'s `receiveMessage` batches ALL inbound P2P messages and flushes them via a ticker set to **1 second**. Combined with `processRemoteTxnsEvery = 100ms`, worst-case latency from P2P receipt to pool inclusion is **~1.1 seconds**.

The hive test sends 1-blob transactions to Client B which must gossip to Client A before Client A builds the payload (`GetPayloadDelay: 2s` window). With 1.1s worst-case latency the margin is only 0.9s — sometimes not enough in the docker test environment.

## Fix

Reduce the batch flush ticker from **1s → 250ms**. Worst-case latency drops to **~350ms**, giving ~1.65s margin within the 2-second payload window.

```diff
-ticker := time.NewTicker(1 * time.Second)
+ticker := time.NewTicker(250 * time.Millisecond)
```

## Testing

Running hive `engine/cancun` test 100 times on this branch. Will mark ready for review once all pass.

Fixes: https://github.com/erigontech/erigon/actions/runs/22242447860/job/64349011577