### PR TITLE
migrations: support of whole-datadir migrations. don't store progress in `chaindata`

### DIFF
--- a/db/datadir/dirs.go
+++ b/db/datadir/dirs.go
@@ -59,6 +59,7 @@ type Dirs struct {
 	CaplinLatest     string
 	CaplinGenesis    string
 	CaplinHistory    string
+	Migrations       string // persistent DB tracking which migrations have been applied
 
 	Log string
 }
@@ -84,6 +85,7 @@ func New(datadir string) Dirs {
 		dirs.CaplinGenesis,
 		dirs.CaplinColumnData,
 		dirs.CaplinHistory,
+		dirs.Migrations,
 		filepath.Join(datadir, "logs"),
 	)
 
@@ -128,6 +130,7 @@ func Open(datadir string) Dirs {
 		CaplinLatest:     filepath.Join(datadir, "caplin", "latest"),
 		CaplinGenesis:    filepath.Join(datadir, "caplin", "genesis-state"),
 		CaplinHistory:    filepath.Join(datadir, "caplin", "history"),
+		Migrations:       filepath.Join(datadir, "migrations"),
 	}
 	return dirs
 }

--- a/db/kv/dbcfg/db_constants.go
+++ b/db/kv/dbcfg/db_constants.go
@@ -11,4 +11,5 @@ const (
 	PolygonBridgeDB = "polygon-bridge"
 	CaplinDB        = "caplin"
 	TemporaryDB     = "temporary"
+	MigrationsDB    = "migrations"
 )

--- a/db/kv/tables.go
+++ b/db/kv/tables.go
@@ -588,11 +588,14 @@ var DownloaderTablesCfg = TableCfg{}
 var DiagnosticsTablesCfg = TableCfg{}
 var HeimdallTablesCfg = TableCfg{}
 var PolygonBridgeTablesCfg = TableCfg{}
+var MigrationsTablesCfg = TableCfg{Migrations: {}}
 
 func TablesCfgByLabel(label Label) TableCfg {
 	switch label {
 	case dbcfg.ChainDB, dbcfg.TemporaryDB, dbcfg.CaplinDB: //TODO: move caplindb tables to own table config
 		return ChaindataTablesCfg
+	case dbcfg.MigrationsDB:
+		return MigrationsTablesCfg
 	case dbcfg.TxPoolDB:
 		return TxpoolTablesCfg
 	case dbcfg.SentryDB:

--- a/db/migrations/migrations.go
+++ b/db/migrations/migrations.go
@@ -30,6 +30,7 @@ import (
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/dbcfg"
+	kv2 "github.com/erigontech/erigon/db/kv/mdbx"
 	"github.com/erigontech/erigon/db/rawdb"
 )
 
@@ -71,6 +72,17 @@ var (
 	)
 )
 
+// OpenMigrationsDB opens (or creates) the dedicated migrations-tracking database at the given
+// directory. Only the kv.Migrations table is opened; all other tables are excluded. The DB
+// survives deletion of any other sub-database (e.g. chaindata) so migration state persists
+// across datadir clean-ups.
+func OpenMigrationsDB(migrationsDir string, logger log.Logger) (kv.RwDB, error) {
+	dir.MustExist(migrationsDir)
+	return kv2.New(dbcfg.MigrationsDB, logger).
+		Path(migrationsDir).
+		Open(context.Background())
+}
+
 func NewMigrator(label kv.Label) *Migrator {
 	return &Migrator{
 		Migrations: migrations[label],
@@ -81,6 +93,9 @@ type Migrator struct {
 	Migrations []Migration
 }
 
+// AppliedMigrations returns the set of migration names that have already been recorded as
+// complete. tx must be a read transaction on the migrations-tracking DB (opened via
+// OpenMigrationsDB), NOT on the target database.
 func AppliedMigrations(tx kv.Tx, withPayload bool) (map[string][]byte, error) {
 	applied := map[string][]byte{}
 	err := tx.ForEach(kv.Migrations, nil, func(k []byte, v []byte) error {
@@ -97,9 +112,11 @@ func AppliedMigrations(tx kv.Tx, withPayload bool) (map[string][]byte, error) {
 	return applied, err
 }
 
-func (m *Migrator) HasPendingMigrations(db kv.RwDB) (bool, error) {
+// HasPendingMigrations reports whether any registered migrations have not yet been applied.
+// migrationsDB must be the database returned by OpenMigrationsDB.
+func (m *Migrator) HasPendingMigrations(migrationsDB kv.RwDB) (bool, error) {
 	var has bool
-	if err := db.View(context.Background(), func(tx kv.Tx) error {
+	if err := migrationsDB.View(context.Background(), func(tx kv.Tx) error {
 		pending, err := m.PendingMigrations(tx)
 		if err != nil {
 			return err
@@ -112,6 +129,8 @@ func (m *Migrator) HasPendingMigrations(db kv.RwDB) (bool, error) {
 	return has, nil
 }
 
+// PendingMigrations returns the subset of registered migrations that have not yet been applied.
+// tx must be a read transaction on the migrations-tracking DB.
 func (m *Migrator) PendingMigrations(tx kv.Tx) ([]Migration, error) {
 	applied, err := AppliedMigrations(tx, false)
 	if err != nil {
@@ -167,14 +186,21 @@ func (m *Migrator) VerifyVersion(db kv.RwDB, chaindata string) error {
 	return nil
 }
 
-func (m *Migrator) Apply(db kv.RwDB, dataDir, chaindata string, logger log.Logger) error {
+// Apply runs all pending migrations in order.
+//
+//   - db is the target database being migrated (e.g. chaindata).
+//   - migrationsDB is the dedicated migrations-tracking database (opened via OpenMigrationsDB).
+//     Applied-migration records are written here, so they survive deletion of the target DB.
+//   - dataDir is the root data directory (used to set up per-migration temp dirs).
+//   - chaindata is the path to the target DB directory (used only in error messages).
+func (m *Migrator) Apply(db kv.RwDB, migrationsDB kv.RwDB, dataDir, chaindata string, logger log.Logger) error {
 	if len(m.Migrations) == 0 {
 		return nil
 	}
 	dirs := datadir.New(dataDir)
 
 	var applied map[string][]byte
-	if err := db.View(context.Background(), func(tx kv.Tx) error {
+	if err := migrationsDB.View(context.Background(), func(tx kv.Tx) error {
 		var err error
 		applied, err = AppliedMigrations(tx, false)
 		if err != nil {
@@ -208,19 +234,23 @@ func (m *Migrator) Apply(db kv.RwDB, dataDir, chaindata string, logger log.Logge
 
 		logger.Info("Apply migration", "name", v.Name)
 		var progress []byte
-		if err := db.View(context.Background(), func(tx kv.Tx) (err error) {
+		if err := migrationsDB.View(context.Background(), func(tx kv.Tx) (err error) {
 			progress, err = tx.GetOne(kv.Migrations, []byte("_progress_"+v.Name))
 			return err
 		}); err != nil {
 			return fmt.Errorf("migrator.Apply: %w", err)
 		}
 
-		dirs.Tmp = filepath.Join(dirs.DataDir, "migrations", v.Name)
+		// Each migration gets its own sub-directory inside dirs.Migrations for ETL temp files.
+		dirs.Tmp = filepath.Join(dirs.Migrations, v.Name)
 		dir.MustExist(dirs.Tmp)
 		if err := v.Up(db, dirs, progress, func(tx kv.RwTx, key []byte, isDone bool) error {
 			if !isDone {
 				if key != nil {
-					if err := tx.Put(kv.Migrations, []byte("_progress_"+v.Name), key); err != nil {
+					// Persist resumable progress in the migrations DB.
+					if err := migrationsDB.Update(context.Background(), func(migTx kv.RwTx) error {
+						return migTx.Put(kv.Migrations, []byte("_progress_"+v.Name), key)
+					}); err != nil {
 						return err
 					}
 				}
@@ -228,21 +258,18 @@ func (m *Migrator) Apply(db kv.RwDB, dataDir, chaindata string, logger log.Logge
 			}
 			callbackCalled = true
 
+			// Capture the target DB's stage state for bug-report context, then record
+			// the migration as complete in the migrations-tracking DB.
 			stagesProgress, err := json.Marshal(tx)
 			if err != nil {
 				return err
 			}
-			err = tx.Put(kv.Migrations, []byte(v.Name), stagesProgress)
-			if err != nil {
-				return err
-			}
-
-			err = tx.Delete(kv.Migrations, []byte("_progress_"+v.Name))
-			if err != nil {
-				return err
-			}
-
-			return nil
+			return migrationsDB.Update(context.Background(), func(migTx kv.RwTx) error {
+				if err := migTx.Put(kv.Migrations, []byte(v.Name), stagesProgress); err != nil {
+					return err
+				}
+				return migTx.Delete(kv.Migrations, []byte("_progress_"+v.Name))
+			})
 		}, logger); err != nil {
 			return fmt.Errorf("migrator.Apply.Up: %s, %w", v.Name, err)
 		}


### PR DESCRIPTION
- we ofthen `rm datadir/chaindata` now - means can't store there migrations state
- we sometime need release files migrations (not chaindata)

so, moving migrations into own db 
