### PR TITLE
`nextFreePort` got out of port range on win

### DIFF
--- a/common/freeport/free_port.go
+++ b/common/freeport/free_port.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	maxPort    = 49151 // stay below Windows ephemeral port range (49152-65535)
+	maxPort    = 49151 // stay below Windows ephemeral ports 49152-65535 (TCP connections assigned there)
 	minPort    = 1024
 	bucketSize = 2500
 	numBuckets = (maxPort - minPort) / bucketSize


### PR DESCRIPTION
on win:
```
  Error Trace:    D:/a/erigon/erigon/txnprovider/shutter/block_building_integration_test.go:335           
                                                                                                                    
  D:/a/erigon/erigon/txnprovider/shutter/block_building_integration_test.go:63                                        
              Error:          Received unexpected error:                                                          
                              failed to listen on any addresses: [listen tcp4 127.0.0.1:53528: bind: Only one         
  usage of each socket address (protocol/network address/port) is normally permitted.]                            
              Test:           TestShutterBlockBuilding      
```

 Root cause: Port 53528 is in the Windows dynamic/ephemeral port range (49152–65535). Windows uses this range to
  assign outgoing TCP connections. After NextFreePort closes its probe listener, the OS can immediately reassign that 
  port for an outbound connection — then when DialDecryptionKeysSender tries to bind it (much later, after all the    
  contract deployment setup), it's already taken.  


