### PR TITLE
stagedsync: defer E2 block indexing on restart to reduce startup latency

### DIFF
--- a/execution/stagedsync/stage_snapshots.go
+++ b/execution/stagedsync/stage_snapshots.go
@@ -251,29 +251,8 @@ func DownloadAndIndexSnapshotsIfNeed(s *StageState, ctx context.Context, tx kv.R
 		cfg.notifier.Events.OnNewSnapshot()
 	}
 
-	// Check if this is a fresh start or a restart with existing data.
-	// On restart (headersProgress > 0), skip blocking E2 indexing at startup.
-	// Missing E2 indices will be built in the background via RetireBlocksInBackground
-	// (called from SnapshotsPrune on every sync cycle).
-	// Exception: Bor chains always index synchronously because RetireBlocks has an
-	// early-exit guard for Bor data readiness that may skip BuildMissedIndicesIfNeed.
-	// E3 accessors are always built synchronously because there is no background
-	// mechanism to rebuild all missing accessors (MergeLoop only handles merged files).
-	headersProgress, err := stages.GetStageProgress(tx, stages.Headers)
-	if err != nil {
-		return fmt.Errorf("getting headers progress for indexing decision: %w", err)
-	}
-
-	isBor := cfg.chainConfig.Bor != nil
-	canDeferE2 := headersProgress > 0 && !isBor
-
-	diaglib.Send(diaglib.CurrentSyncSubStage{SubStage: "E2 Indexing"})
-	if !canDeferE2 {
-		if err := cfg.blockRetire.BuildMissedIndicesIfNeed(ctx, s.LogPrefix(), cfg.notifier.Events); err != nil {
-			return err
-		}
-	} else {
-		log.Info(fmt.Sprintf("[%s] Deferring E2 indexing to background", s.LogPrefix()), "reason", "restart", "headersProgress", headersProgress)
+	if err := buildOrDeferE2Indices(ctx, tx, s, cfg); err != nil {
+		return err
 	}
 
 	indexWorkers := estimate.IndexSnapshot.Workers()
@@ -330,6 +309,33 @@ func DownloadAndIndexSnapshotsIfNeed(s *StageState, ctx context.Context, tx kv.R
 		})
 	}
 
+	return nil
+}
+
+// buildOrDeferE2Indices decides whether to build E2 block snapshot indices synchronously
+// or defer them to background processing.
+// On restart (headersProgress > 0), E2 indexing is skipped at startup. Missing indices
+// will be built in the background via RetireBlocksInBackground (called from SnapshotsPrune
+// on every sync cycle).
+// Exception: Bor chains always index synchronously because RetireBlocks has an early-exit
+// guard for Bor data readiness that may skip BuildMissedIndicesIfNeed.
+func buildOrDeferE2Indices(ctx context.Context, tx kv.RwTx, s *StageState, cfg SnapshotsCfg) error {
+	headersProgress, err := stages.GetStageProgress(tx, stages.Headers)
+	if err != nil {
+		return fmt.Errorf("getting headers progress for indexing decision: %w", err)
+	}
+
+	isBor := cfg.chainConfig.Bor != nil
+	canDefer := headersProgress > 0 && !isBor
+
+	diaglib.Send(diaglib.CurrentSyncSubStage{SubStage: "E2 Indexing"})
+	if !canDefer {
+		if err := cfg.blockRetire.BuildMissedIndicesIfNeed(ctx, s.LogPrefix(), cfg.notifier.Events); err != nil {
+			return err
+		}
+	} else {
+		log.Info(fmt.Sprintf("[%s] Deferring E2 indexing to background", s.LogPrefix()), "reason", "restart", "headersProgress", headersProgress)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

  On node restart, `BuildMissedIndicesIfNeed` (E2 block snapshot indexing) runs synchronously
  at startup, blocking the entire sync pipeline. When indices already exist this is a fast no-op,
  but after a crash or manual `.idx` deletion it can take a significant amount of time to rebuild
  all indices before sync can proceed.

  This change defers E2 indexing to the background on restart:
  - **Fresh start** (`headersProgress == 0`): E2 indexing remains synchronous (required for
    first-time snapshot usage)
  - **Restart** (`headersProgress > 0`): E2 indexing is skipped at startup; missing `.idx` files
    are rebuilt in the background via the existing `RetireBlocksInBackground` → `RetireBlocks` →
    `BuildMissedIndicesIfNeed` path (called from `SnapshotsPrune` on every sync cycle)
  - **E3 accessors** (`BuildMissedAccessors`): always built synchronously — no background
    mechanism exists to rebuild all missing accessors

  Unindexed segments are safely excluded from visible files by `RecalcVisibleSegments`
  (checks `IsIndexed()`), so `FrozenBlocks()` correctly reflects only indexed data.
  Tip sync continues from DB state while indices rebuild in the background.

  ## Trade-offs

  - Historical block queries (via RPC) for blocks only available in unindexed snapshots will
    temporarily fail until background indexing completes
