### PR TITLE
cleanup(exec3): remove unreachable debug branch in ExecV3

### DIFF
--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -346,10 +346,6 @@ func ExecV3(ctx context.Context,
 		lastCommittedTxNum = se.lastCommittedTxNum.Load()
 	}
 
-	if false && !isForkValidation {
-		dumpPlainStateDebug(applyTx, doms)
-	}
-
 	lastCommitedStep := kv.Step((lastCommittedTxNum) / doms.StepSize())
 	lastFrozenStep := applyTx.StepsInFiles(kv.CommitmentDomain)
 


### PR DESCRIPTION
Summary
- Remove an unreachable debug-only branch from `ExecV3` in `execution/stagedsync/exec3.go`.
- The removed block was guarded by `if false`, so it could never execute.
- This is a no-behavior-change cleanup that reduces noise and improves maintainability.
