### PR TITLE
cmd/utils/app: fix pprof port collision in seg subcommands

### DIFF
--- a/cmd/utils/app/domain_cmd.go
+++ b/cmd/utils/app/domain_cmd.go
@@ -13,16 +13,10 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/dbcfg"
 	"github.com/erigontech/erigon/db/state/statecfg"
-	"github.com/erigontech/erigon/node/debug"
 	"github.com/urfave/cli/v2"
 )
 
 func domainStat(cliCtx *cli.Context) error {
-	_, err := debug.SetupSimple(cliCtx, true /* root logger */)
-	if err != nil {
-		return err
-	}
-
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
 

--- a/cmd/utils/app/seg_info_cmd.go
+++ b/cmd/utils/app/seg_info_cmd.go
@@ -6,19 +6,16 @@ import (
 	"slices"
 	"time"
 
+	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/seg"
-	"github.com/erigontech/erigon/node/debug"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
 )
 
 func segInfo(cliCtx *cli.Context) error {
-	logger, err := debug.SetupSimple(cliCtx, true /* root logger */)
-	if err != nil {
-		return err
-	}
+	logger := log.Root()
 
 	// Compression settings
 	compress := cliCtx.String("compress")

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -314,14 +314,11 @@ var snapshotCommand = cli.Command{
 				"It is useful for shadowforks, recovering broken nodes or chains, and/or for doing experiments that " +
 				"involve replaying certain blocks.",
 			Action: func(cliCtx *cli.Context) error {
-				logger, err := debug.SetupSimple(cliCtx, true /* root logger */)
-				if err != nil {
-					panic(fmt.Errorf("rollback snapshots to block: could not setup logger: %w", err))
-				}
+				logger := log.Root()
 				block := cliCtx.Uint64("block")
 				prompt := cliCtx.Bool("prompt")
 				dataDir := cliCtx.String(utils.DataDirFlag.Name)
-				err = doRollbackSnapshotsToBlock(cliCtx.Context, block, prompt, dataDir, logger)
+				err := doRollbackSnapshotsToBlock(cliCtx.Context, block, prompt, dataDir, logger)
 				if err != nil {
 					logger.Error(err.Error())
 					return err
@@ -400,11 +397,8 @@ var snapshotCommand = cli.Command{
 		{
 			Name: "check-commitment-hist-at-blk",
 			Action: func(cliCtx *cli.Context) error {
-				logger, err := debug.SetupSimple(cliCtx, true /* root logger */)
-				if err != nil {
-					panic(fmt.Errorf("check commitment history at block: could not setup logger: %w", err))
-				}
-				err = doCheckCommitmentHistAtBlk(cliCtx, logger)
+				logger := log.Root()
+				err := doCheckCommitmentHistAtBlk(cliCtx, logger)
 				if err != nil {
 					log.Error("[check-commitment-hist-at-blk] failure", "err", err)
 					return err
@@ -421,11 +415,8 @@ var snapshotCommand = cli.Command{
 		{
 			Name: "check-commitment-hist-at-blk-range",
 			Action: func(cliCtx *cli.Context) error {
-				logger, err := debug.SetupSimple(cliCtx, true /* root logger */)
-				if err != nil {
-					panic(fmt.Errorf("check commitment history at block range: could not setup logger: %w", err))
-				}
-				err = doCheckCommitmentHistAtBlkRange(cliCtx, logger)
+				logger := log.Root()
+				err := doCheckCommitmentHistAtBlkRange(cliCtx, logger)
 				if err != nil {
 					log.Error("[check-commitment-hist-at-blk-range] failure", "err", err)
 					return err
@@ -444,11 +435,8 @@ var snapshotCommand = cli.Command{
 			Name:        "verify-state",
 			Description: "verify correspondence between state snapshots (accounts, storage) and commitment snapshots",
 			Action: func(cliCtx *cli.Context) error {
-				logger, err := debug.SetupSimple(cliCtx, true /* root logger */)
-				if err != nil {
-					panic(fmt.Errorf("verify-state: could not setup logger: %w", err))
-				}
-				err = doVerifyState(cliCtx, logger)
+				logger := log.Root()
+				err := doVerifyState(cliCtx, logger)
 				if err != nil {
 					log.Error("[verify-state] failure", "err", err)
 					return err
@@ -466,11 +454,8 @@ var snapshotCommand = cli.Command{
 			Name:        "verify-history",
 			Description: "verify history snapshots by re-executing blocks and comparing state changes",
 			Action: func(cliCtx *cli.Context) error {
-				logger, err := debug.SetupSimple(cliCtx, true /* root logger */)
-				if err != nil {
-					panic(fmt.Errorf("verify-history: could not setup logger: %w", err))
-				}
-				err = doVerifyHistory(cliCtx, logger)
+				logger := log.Root()
+				err := doVerifyHistory(cliCtx, logger)
 				if err != nil {
 					log.Error("[verify-history] failure", "err", err)
 					return err
@@ -987,10 +972,7 @@ func doBtSearch(cliCtx *cli.Context) error {
 		return err
 	}
 	defer l.Unlock()
-	logger, err := debug.SetupSimple(cliCtx, true /* root logger */)
-	if err != nil {
-		return err
-	}
+	logger := log.Root()
 
 	srcF := cliCtx.String("src")
 	dataFilePath := strings.TrimRight(srcF, ".bt") + ".kv"
@@ -1032,10 +1014,7 @@ func doBtSearch(cliCtx *cli.Context) error {
 }
 
 func doDebugKey(cliCtx *cli.Context) error {
-	logger, err := debug.SetupSimple(cliCtx, true /* root logger */)
-	if err != nil {
-		return err
-	}
+	logger := log.Root()
 	key := common.FromHex(cliCtx.String("key"))
 	var domain kv.Domain
 	var idx kv.InvertedIdx
@@ -1085,10 +1064,7 @@ func doDebugKey(cliCtx *cli.Context) error {
 }
 
 func doIntegrity(cliCtx *cli.Context) error {
-	logger, err := debug.SetupSimple(cliCtx, true /* root logger */)
-	if err != nil {
-		return err
-	}
+	logger := log.Root()
 
 	ctx := cliCtx.Context
 	checkStr := cliCtx.String("check")
@@ -1991,10 +1967,7 @@ func deleteFilesWithExtensions(dir string, extensions []string) error {
 }
 
 func doBlkTxNum(cliCtx *cli.Context) error {
-	logger, err := debug.SetupSimple(cliCtx, true /* rootLogger */)
-	if err != nil {
-		return err
-	}
+	logger := log.Root()
 	defer logger.Info("Done")
 
 	dirs := datadir.New(cliCtx.String(utils.DataDirFlag.Name))
@@ -2163,10 +2136,7 @@ func doMeta(cliCtx *cli.Context) error {
 }
 
 func doDecompressSpeed(cliCtx *cli.Context) error {
-	logger, err := debug.SetupSimple(cliCtx, true /* rootLogger */)
-	if err != nil {
-		return err
-	}
+	logger := log.Root()
 	args := cliCtx.Args()
 	if args.Len() < 1 {
 		return errors.New("expecting file path as a first argument")
@@ -2203,10 +2173,7 @@ func doDecompressSpeed(cliCtx *cli.Context) error {
 }
 
 func doIndicesCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
-	logger, err := debug.SetupSimple(cliCtx, true /* rootLogger */)
-	if err != nil {
-		return err
-	}
+	logger := log.Root()
 	defer logger.Info("Done")
 	ctx := cliCtx.Context
 
@@ -2255,10 +2222,7 @@ func doIndicesCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 	return nil
 }
 func doLS(cliCtx *cli.Context, dirs datadir.Dirs) error {
-	logger, err := debug.SetupSimple(cliCtx, true /* rootLogger */)
-	if err != nil {
-		return err
-	}
+	logger := log.Root()
 	defer logger.Info("Done")
 	ctx := cliCtx.Context
 
@@ -2387,10 +2351,6 @@ func doUncompress(cliCtx *cli.Context) error {
 		return err
 	}
 	defer l.Unlock()
-	if _, err = debug.SetupSimple(cliCtx, true /* rootLogger */); err != nil {
-		return err
-	}
-
 	args := cliCtx.Args()
 	if args.Len() < 1 {
 		return errors.New("expecting file path as a first argument")
@@ -2425,10 +2385,7 @@ func doCompress(cliCtx *cli.Context) error {
 	}
 	defer lck.Unlock()
 
-	logger, err := debug.SetupSimple(cliCtx, true /* rootLogger */)
-	if err != nil {
-		return err
-	}
+	logger := log.Root()
 	ctx := cliCtx.Context
 
 	args := cliCtx.Args()
@@ -2526,10 +2483,7 @@ func doCompress(cliCtx *cli.Context) error {
 }
 
 func doRemoveOverlap(cliCtx *cli.Context, dirs datadir.Dirs) error {
-	logger, err := debug.SetupSimple(cliCtx, true /* rootLogger */)
-	if err != nil {
-		return err
-	}
+	logger := log.Root()
 	defer logger.Info("Done")
 
 	db := dbCfg(dbcfg.ChainDB, dirs.Chaindata).MustOpen()
@@ -2549,10 +2503,7 @@ func doRemoveOverlap(cliCtx *cli.Context, dirs datadir.Dirs) error {
 }
 
 func doUnmerge(cliCtx *cli.Context, dirs datadir.Dirs) error {
-	logger, err := debug.SetupSimple(cliCtx, true /* rootLogger */)
-	if err != nil {
-		return err
-	}
+	logger := log.Root()
 	defer logger.Info("Done")
 
 	ctx := cliCtx.Context
@@ -2684,10 +2635,7 @@ func doUnmerge(cliCtx *cli.Context, dirs datadir.Dirs) error {
 }
 
 func doRetireCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
-	logger, err := debug.SetupSimple(cliCtx, true /* rootLogger */)
-	if err != nil {
-		return err
-	}
+	logger := log.Root()
 	defer logger.Info("Done")
 	ctx := cliCtx.Context
 
@@ -2818,10 +2766,7 @@ func doRetireCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 func doCompareIdx(cliCtx *cli.Context) error {
 	// doesn't compare exact hashes offset,
 	// only sizes, counts, offsets, and ordinal lookups.
-	logger, err := debug.SetupSimple(cliCtx, true /* root logger */)
-	if err != nil {
-		return err
-	}
+	logger := log.Root()
 
 	cmpFn := func(f, s uint64, msg string) {
 		if f != s {

--- a/cmd/utils/app/squeeze_cmd.go
+++ b/cmd/utils/app/squeeze_cmd.go
@@ -37,7 +37,6 @@ import (
 	"github.com/erigontech/erigon/db/snaptype"
 	"github.com/erigontech/erigon/db/snaptype2"
 	"github.com/erigontech/erigon/db/state"
-	"github.com/erigontech/erigon/node/debug"
 	"github.com/erigontech/erigon/node/ethconfig"
 )
 
@@ -56,10 +55,7 @@ func doSqueeze(cliCtx *cli.Context) error {
 		return err
 	}
 	defer l.Unlock()
-	logger, err := debug.SetupSimple(cliCtx, true /* rootLogger */)
-	if err != nil {
-		return err
-	}
+	logger := log.Root()
 	ctx := cliCtx.Context
 	logEvery := time.NewTicker(10 * time.Second)
 	defer logEvery.Stop()

--- a/cmd/utils/app/step_cmd.go
+++ b/cmd/utils/app/step_cmd.go
@@ -15,16 +15,13 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/erigontech/erigon/common/dir"
+	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/state"
-	"github.com/erigontech/erigon/node/debug"
 )
 
 func stepRebase(cliCtx *cli.Context) error {
-	logger, err := debug.SetupSimple(cliCtx, true /* root logger */)
-	if err != nil {
-		return err
-	}
+	logger := log.Root()
 
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()


### PR DESCRIPTION
 Fixes #18778

when --pprof is passed in seg subcommands:
- `commonBeforeSnapshotCommand` is injected as a Before hook into every seg/snapshots subcommand via `init()`. It calls `debug.SetupSimple`, which starts the pprof server on :6060. Each subcommand's do* function was also calling `debug.SetupSimple`, causing a second bind attempt on the same port → "listen tcp 127.0.0.1:6060: bind: address already in use".
- Remove the redundant `debug.SetupSimple` calls from all affected `do*` functions and inline actions in snapshots_cmd.go, squeeze_cmd.go, step_cmd.go, seg_info_cmd.go, and domain_cmd.go
- Use `log.Root()` instead, which returns the already-configured root logger set up by `commonBeforeSnapshotCommand` (same pattern already used in resetCliAction)
