### PR TITLE
rpc: add eth_getStorageValues endpoint

### DIFF
--- a/docs/readthedocs/source/rpc/index.rst
+++ b/docs/readthedocs/source/rpc/index.rst
@@ -1199,6 +1199,44 @@ Returns the value from a storage position at a given address.
    * - ``DATA``
      - The value at this storage position
 
+--------------------
+
+eth_getStorageValues
+--------------------
+
+Returns the values of multiple storage slots for multiple accounts in a single request.
+
+**Parameters**
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Type
+     - Description
+   * - ``OBJECT``
+     - Map of addresses (``DATA, 20 BYTES``) to arrays of storage slot keys (``DATA, 32 BYTES``)
+   * - ``QUANTITY | TAG``
+     - Integer block number or one of "earliest", "latest" or "pending"
+
+
+**Example**
+
+::
+
+   curl -s --data '{"jsonrpc":"2.0","method":"eth_getStorageValues","params":[{"0xdAC17F958D2ee523a2206206994597C13D831ec7":["0x0000000000000000000000000000000000000000000000000000000000000002","0x0000000000000000000000000000000000000000000000000000000000000006"],"0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48":["0x0000000000000000000000000000000000000000000000000000000000000003"]},"latest"],"id":"1"}' -H "Content-Type: application/json" -X POST http://localhost:8545
+
+**Returns**
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Type
+     - Description
+   * - ``OBJECT``
+     - Map of addresses to arrays of storage values (``DATA, 32 BYTES``) in the same order as the requested keys
+
 --------------
 
 eth_blockNumber

--- a/rpc/jsonrpc/eth_accounts.go
+++ b/rpc/jsonrpc/eth_accounts.go
@@ -160,6 +160,8 @@ func (api *APIImpl) GetCode(ctx context.Context, address common.Address, blockNr
 	return res, nil
 }
 
+// GetStorageValues implements eth_getStorageValues. Returns the values of multiple
+// storage slots for multiple accounts in a single request.
 func (api *APIImpl) GetStorageValues(ctx context.Context, requests map[common.Address][]common.Hash, blockNrOrHash rpc.BlockNumberOrHash) (map[common.Address][]hexutil.Bytes, error) {
 	var totalSlots int
 
@@ -203,8 +205,8 @@ func (api *APIImpl) GetStorageValues(ctx context.Context, requests map[common.Ad
 	result := make(map[common.Address][]hexutil.Bytes, len(requests))
 	for addr, keys := range requests {
 		vals := make([]hexutil.Bytes, len(keys))
+		address := accounts.InternAddress(addr)
 		for i, key := range keys {
-			address := accounts.InternAddress(addr)
 			location := accounts.InternKey(key)
 			res, _, err := reader.ReadAccountStorage(address, location)
 			if err != nil {

--- a/rpc/jsonrpc/eth_accounts.go
+++ b/rpc/jsonrpc/eth_accounts.go
@@ -32,8 +32,8 @@ import (
 	"github.com/erigontech/erigon/rpc/rpchelper"
 )
 
-// maxGetStorageSlots is the maximum total number of storage slots that can
-// be requested in a single eth_getStorageValues call.
+// maxGetStorageSlots caps the total number of storage slots allowed across
+// all addresses in a single eth_getStorageValues request.
 const maxGetStorageSlots = 1024
 
 // GetBalance implements eth_getBalance. Returns the balance of an account for a given address.

--- a/rpc/jsonrpc/eth_accounts.go
+++ b/rpc/jsonrpc/eth_accounts.go
@@ -32,6 +32,10 @@ import (
 	"github.com/erigontech/erigon/rpc/rpchelper"
 )
 
+// maxGetStorageSlots is the maximum total number of storage slots that can
+// be requested in a single eth_getStorageValues call.
+const maxGetStorageSlots = 1024
+
 // GetBalance implements eth_getBalance. Returns the balance of an account for a given address.
 func (api *APIImpl) GetBalance(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (*hexutil.Big, error) {
 	tx, err1 := api.db.BeginTemporalRo(ctx)
@@ -154,6 +158,65 @@ func (api *APIImpl) GetCode(ctx context.Context, address common.Address, blockNr
 		return hexutil.Bytes(""), nil
 	}
 	return res, nil
+}
+
+func (api *APIImpl) GetStorageValues(ctx context.Context, requests map[common.Address][]common.Hash, blockNrOrHash rpc.BlockNumberOrHash) (map[common.Address][]hexutil.Bytes, error) {
+	var totalSlots int
+
+	for _, keys := range requests {
+		totalSlots += len(keys)
+		if totalSlots > maxGetStorageSlots {
+			return nil, clientLimitExceededError(fmt.Sprintf("too many slots (max %d)", maxGetStorageSlots))
+		}
+	}
+	if totalSlots == 0 {
+		return nil, &rpc.InvalidParamsError{Message: "empty request"}
+	}
+
+	tx, err := api.db.BeginTemporalRo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	blockNrOrHash.RequireCanonical = true
+	blockNumber, _, latest, err := rpchelper.GetBlockNumber(ctx, blockNrOrHash, tx, api._blockReader, api.filters)
+	if err != nil {
+		return nil, err
+	}
+
+	err = api.BaseAPI.checkPruneHistory(ctx, tx, blockNumber)
+	if err != nil {
+		return nil, err
+	}
+
+	err = rpchelper.CheckBlockExecuted(tx, blockNumber)
+	if err != nil {
+		return nil, err
+	}
+
+	reader, err := rpchelper.CreateStateReaderFromBlockNumber(ctx, tx, blockNumber, latest, 0, api.stateCache, api._txNumReader)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[common.Address][]hexutil.Bytes, len(requests))
+	for addr, keys := range requests {
+		vals := make([]hexutil.Bytes, len(keys))
+		for i, key := range keys {
+			address := accounts.InternAddress(addr)
+			location := accounts.InternKey(key)
+			res, _, err := reader.ReadAccountStorage(address, location)
+			if err != nil {
+				return nil, err
+			}
+
+			vals[i] = res.PaddedBytes(32)
+		}
+		result[addr] = vals
+	}
+
+	return result, nil
 }
 
 // GetStorageAt implements eth_getStorageAt. Returns the value from a storage position at a given address.

--- a/rpc/jsonrpc/eth_api.go
+++ b/rpc/jsonrpc/eth_api.go
@@ -96,6 +96,7 @@ type EthAPI interface {
 	GetBalance(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (*hexutil.Big, error)
 	GetTransactionCount(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (*hexutil.Uint64, error)
 	GetStorageAt(ctx context.Context, address common.Address, index string, blockNrOrHash rpc.BlockNumberOrHash) (string, error)
+	GetStorageValues(ctx context.Context, requests map[common.Address][]common.Hash, blockNrOrHash rpc.BlockNumberOrHash) (map[common.Address][]hexutil.Bytes, error)
 	GetCode(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (hexutil.Bytes, error)
 
 	// System related (see ./eth_system.go)


### PR DESCRIPTION
Implements `eth_getStorageValues` as per the execution spec, allowing bulk storage slot reads for multiple addresses in a single request instead of multiple `eth_getStorageAt` calls.

Ref: https://github.com/ethereum/execution-apis/issues/752