### PR TITLE
prune: replace internal timeout with context-based cancellation

### DIFF
--- a/db/kv/prune/prune.go
+++ b/db/kv/prune/prune.go
@@ -197,6 +197,14 @@ func TableScanningPrune(
 ) (stat *Stat, err error) {
 	stat = &Stat{MinTxNum: math.MaxUint64}
 	start := time.Now()
+	var valLen uint64
+	defer func() {
+		logger.Trace("scan prune res", "name", name, "txFrom", txFrom, "txTo", txTo, "limit", limit, "keys",
+			stat.PruneCountTx, "vals", stat.PruneCountValues, "all vals", valLen, "dups", stat.DupsDeleted,
+			"spent ms", time.Since(start).Milliseconds(),
+			"key prune status", stat.KeyProgress.String(),
+			"val prune status", stat.ValueProgress.String())
+	}()
 
 	if limit == 0 { // limits amount of txn to be pruned
 		limit = math.MaxUint64
@@ -204,11 +212,6 @@ func TableScanningPrune(
 	var throttling *time.Duration
 	if v := ctx.Value("throttle"); v != nil {
 		throttling = v.(*time.Duration)
-	}
-
-	timeOut := 999 * time.Hour
-	if limit < 1000 { //TODO: change after tests
-		timeOut = 200 * time.Millisecond
 	}
 
 	var keyCursorPosition, valCursorPosition = &StartPos{}, &StartPos{}
@@ -233,15 +236,6 @@ func TableScanningPrune(
 		keyCursorPosition.StartKey, _, err = keysCursor.Seek(txKey[:])
 	}
 
-	var pairs, valLen uint64
-
-	//defer func() {
-	//	logger.Debug("scan pruning res", "name", name, "txFrom", txFrom, "txTo", txTo, "limit", limit, "keys",
-	//		stat.PruneCountTx, "vals", stat.PruneCountValues, "all vals", valLen, "dups", stat.DupsDeleted,
-	//		"spent ms", time.Since(start).Milliseconds(),
-	//		"key prune status", stat.KeyProgress.String(),
-	//		"val prune status", stat.ValueProgress.String())
-	//}()
 	if prevStat.KeyProgress != Done {
 		txnb := common.Copy(keyCursorPosition.StartKey)
 		// This deletion iterator goes last to preserve invariant: if some `txNum=N` pruned - it's pruned Fully
@@ -249,21 +243,18 @@ func TableScanningPrune(
 			if err != nil {
 				return nil, fmt.Errorf("iterate over %s index keys: %w", filenameBase, err)
 			}
-			if time.Since(start) > timeOut {
+			select {
+			case <-ctx.Done():
 				stat.LastPrunedKey = common.Copy(txnb)
 				stat.KeyProgress = InProgress
 				return stat, nil
+			default:
 			}
 			txNum := binary.BigEndian.Uint64(txnb)
 			if txNum >= txTo {
 				break
 			}
 			stat.PruneCountTx++
-			dups, err := keysCursor.CountDuplicates()
-			if err != nil {
-				return nil, err
-			}
-			pairs += dups
 			if throttling != nil {
 				time.Sleep(*throttling)
 			}
@@ -307,10 +298,12 @@ func TableScanningPrune(
 			return nil, fmt.Errorf("iterate over %s index keys: %w", filenameBase, err)
 		}
 		valLen += dups
-		if time.Since(start) > timeOut {
+		select {
+		case <-ctx.Done():
 			stat.LastPrunedValue = common.Copy(val)
 			stat.ValueProgress = InProgress
 			return stat, nil
+		default:
 		}
 
 		txNum := txNumGetter(val, txNumBytes)
@@ -364,10 +357,12 @@ func TableScanningPrune(
 				if throttling != nil {
 					time.Sleep(*throttling)
 				}
-				if time.Since(start) > timeOut {
+				select {
+				case <-ctx.Done():
 					stat.LastPrunedValue = common.Copy(val)
 					stat.ValueProgress = InProgress
 					return stat, nil
+				default:
 				}
 				//println("txnum passed checks loop", txNumDup)
 
@@ -392,8 +387,12 @@ func TableScanningPrune(
 		default:
 		}
 
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
+		select {
+		case <-ctx.Done():
+			stat.LastPrunedValue = common.Copy(val)
+			stat.ValueProgress = InProgress
+			return stat, nil
+		default:
 		}
 	}
 

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -1047,9 +1047,6 @@ func (at *AggregatorRoTx) PruneSmallBatches(ctx context.Context, timeout time.Du
 
 	for {
 		iterationStarted := time.Now()
-		// `context.Background()` is important here!
-		//     it allows keep DB consistent - prune all keys-related data or noting
-		//     can't interrupt by ctrl+c and leave dirt in DB
 		stat, err := at.prune(ctxWithTO, tx, pruneLimit /*pruneLimit*/, furiousPrune || aggressivePrune, aggLogEvery)
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {
@@ -1256,7 +1253,7 @@ func (at *AggregatorRoTx) prune(ctx context.Context, tx kv.RwTx, limit uint64, a
 			return aggStat, ctx.Err()
 		default:
 		}
-		aggStat.Domains[at.d[id].d.FilenameBase], err = d.Prune(context.Background(), tx, step, txFrom, txTo, limit, logEvery)
+		aggStat.Domains[at.d[id].d.FilenameBase], err = d.Prune(ctx, tx, step, txFrom, txTo, limit, logEvery)
 		if err != nil {
 			return aggStat, err
 		}
@@ -1278,7 +1275,7 @@ func (at *AggregatorRoTx) prune(ctx context.Context, tx kv.RwTx, limit uint64, a
 		//	invalidateOnce[fmt.Sprintf("ii%s", at.iis[iikey].ii.ValuesTable)] = 1
 		//	at.iis[iikey].ii.logger.Info("invalidated ii prune progress", "name", at.iis[iikey].ii.Name)
 		//}
-		stat, err := at.iis[iikey].TableScanningPrune(context.Background(), tx, txFrom, txTo, limit, logEvery, false, nil,
+		stat, err := at.iis[iikey].TableScanningPrune(ctx, tx, txFrom, txTo, limit, logEvery, false, nil,
 			nil, nil, prune.DefaultStorageMode)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Summary
- TableScanningPrune used an internal timeout (200ms when limit<1000, else 999h) checked via time.Since(). This is an anti-pattern — the caller should control timing via context.WithTimeout
- Replaced all 4 timeout checkpoints with select{case <-ctx.Done()} for clean context-driven cancellation
- Fixed a bug: the bottom-of-loop ctx.Err() check returned nil, ctx.Err() discarding all accumulated stats instead of saving progress like the other 3 checkpoints
- In aggregator.go: replaced context.Background() with ctx in domain/index prune calls so the context deadline actually propagates through the call chain

## Changes

db/kv/prune/prune.go
- Remove internal timeOut variable and all time.Since(start) > timeOut checks
- Replace with non-blocking select{case <-ctx.Done()} at 4 interruption points
- On cancellation: save progress (LastPrunedKey/Value, Progress=InProgress) and return stat, nil for clean resumption
- Remove unused pairs variable and CountDuplicates() call in key deletion phase
- Add deferred trace log that fires on all exit paths (including InProgress)

db/state/aggregator.go
- Replace context.Background() with ctx in d.Prune() and iit.TableScanningPrune() calls inside prune() method
- Without this, ctx.Done() in prune.go would never fire since Background context has no deadline
- Remove outdated comment about context.Background() being "important"

## How it works now
PruneSmallBatches(ctx, timeout) → context.WithTimeout(ctx, timeout) → prune(ctxWithTO) → d.Prune(ctx) → TableScanningPrune(ctx) → select{case <-ctx.Done(): save progress, return}