### PR TITLE
Test optimisation: pool resources allocated in the HexPatriciaHashed

### DIFF
--- a/execution/commitment/commitmentdb/commitment_context.go
+++ b/execution/commitment/commitmentdb/commitment_context.go
@@ -308,6 +308,7 @@ func (sdc *SharedDomainsCommitmentContext) trieContext(tx kv.TemporalTx, txNum u
 
 func (sdc *SharedDomainsCommitmentContext) Close() {
 	sdc.updates.Close()
+	sdc.patriciaTrie.Release()
 }
 
 func (sdc *SharedDomainsCommitmentContext) Reset() {

--- a/execution/commitment/hex_concurrent_patricia_hashed.go
+++ b/execution/commitment/hex_concurrent_patricia_hashed.go
@@ -345,6 +345,10 @@ func (p *ConcurrentPatriciaHashed) Reset() {
 	}
 }
 
+func (p *ConcurrentPatriciaHashed) Release() {
+	p.root.Release()
+}
+
 // Set context for state IO
 func (p *ConcurrentPatriciaHashed) ResetContext(ctx PatriciaContext) {
 	p.root.ctx = ctx


### PR DESCRIPTION
During the work on testlab, profiler identified two major sources of allocation in the tests, putting pressure on the GC. Pooling these resources avoids reallocation and reduces GC pressure during the tests