### PR TITLE
Replace time.After with time.Sleep in test sleepWithContext

### DIFF
--- a/execution/stagedsync/exec3_parallel_test.go
+++ b/execution/stagedsync/exec3_parallel_test.go
@@ -94,10 +94,12 @@ func NewTestExecTask(txIdx int, ops []Op, sender accounts.Address, nonce int) *t
 }
 
 func sleepWithContext(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-time.After(d):
+	case <-timer.C:
 		return nil
 	}
 }


### PR DESCRIPTION
 time.After creates a timer and then leaks it until it fires (even if ctx.Done() wins the select). time.NewTimer + defer Stop() cleans it up immediately