### PR TITLE
Replace time.After with time.Sleep in test sleepWithContext

### DIFF
--- a/execution/stagedsync/exec3_parallel_test.go
+++ b/execution/stagedsync/exec3_parallel_test.go
@@ -97,9 +97,10 @@ func sleepWithContext(ctx context.Context, d time.Duration) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-time.After(d):
-		return nil
+	default:
 	}
+	time.Sleep(d)
+	return nil
 }
 
 func (t *testExecTask) Execute(evm *vm.EVM,


### PR DESCRIPTION
time.After allocates a timer + channel per call. In testExecTask.Execute this runs thousands of times for 50µs sleeps, causing 9.4 GB of alloc and 107s of CPU (17%) from timer/select contention. time.Sleep suspends the goroutine directly with zero allocation.