### PR TITLE
[SharovBot] ci: add continue-on-error to Conditional Docker Login steps

### DIFF
--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -61,10 +61,13 @@ jobs:
         # Only login if we can. Workflow works without it but we want to avoid
         # rate limiting by Docker Hub when possible. External repos don't
         # have access to our Docker secrets.
+        # continue-on-error: transient Docker Hub network timeouts should not
+        # abort the entire workflow — the run proceeds without login (unlogged pull).
         if: |
           github.repository == 'erigontech/erigon' && 
           github.actor != 'dependabot[bot]' &&
           (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
+        continue-on-error: true
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_USERNAME }}

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -83,10 +83,13 @@ jobs:
         # Only login if we can. Workflow works without it but we want to avoid
         # rate limiting by Docker Hub when possible. External repos don't
         # have access to our Docker secrets.
+        # continue-on-error: transient Docker Hub network timeouts should not
+        # abort the entire workflow — the run proceeds without login (unlogged pull).
         if: |
           github.repository == 'erigontech/erigon' && 
           github.actor != 'dependabot[bot]' &&
           (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
+        continue-on-error: true
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_USERNAME }}

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -35,10 +35,13 @@ jobs:
         # Only login if we can. Workflow works without it but we want to avoid
         # rate limiting by Docker Hub when possible. External repos don't
         # have access to our Docker secrets.
+        # continue-on-error: transient Docker Hub network timeouts should not
+        # abort the entire workflow — the run proceeds without login (unlogged pull).
         if: |
           github.repository == 'erigontech/erigon' &&
           github.actor != 'dependabot[bot]' &&
           (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
+        continue-on-error: true
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_USERNAME }}
@@ -76,10 +79,13 @@ jobs:
         # Only login if we can. Workflow works without it but we want to avoid
         # rate limiting by Docker Hub when possible. External repos don't
         # have access to our Docker secrets.
+        # continue-on-error: transient Docker Hub network timeouts should not
+        # abort the entire workflow — the run proceeds without login (unlogged pull).
         if: |
           github.repository == 'erigontech/erigon' &&
           github.actor != 'dependabot[bot]' &&
           (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
+        continue-on-error: true
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_USERNAME }}


### PR DESCRIPTION
**[SharovBot]**

## Problem

`Conditional Docker Login` intermittently fails entire CI workflows with:
```
Error response from daemon: Get "https://registry-1.docker.io/v2/": Get
"https://auth.docker.io/token?...": net/http: request canceled
(Client.Timeout exceeded while awaiting headers)
```

This aborts the **entire** Kurtosis/Hive run before any test executes — ~32s into a job that should run for 30+ minutes.

## Root Cause

The Docker Hub auth endpoint occasionally times out on GitHub Actions runners (transient network issue). Since there's no retry or `continue-on-error`, a single timeout kills the whole workflow.

## Fix

The workflow comment *already says* **"Workflow works without it but we want to avoid rate limiting"** — the login is best-effort. Adding `continue-on-error: true` makes that intent explicit in the workflow config.

On timeout: job continues without Docker Hub login → Docker pulls are unlogged (anonymous) → risk of rate limiting but tests still run.  
On success: exactly as before.

## Files changed

- `.github/workflows/test-kurtosis-assertoor.yml` — both jobs
- `.github/workflows/test-hive.yml`
- `.github/workflows/test-hive-eest.yml`

Fixes: https://github.com/erigontech/erigon/actions/runs/22406724281/job/64868531740