### PR TITLE
[SharovBot] fix(node): track StartRpcServer goroutine in bgComponentsEg to fix TestShutterBlockBuilding flakiness

### DIFF
--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -1201,11 +1201,14 @@ func (s *Ethereum) Init(stack *node.Node, config *ethconfig.Config, chainConfig 
 		silkwormRPCDaemonService := silkworm.NewRpcDaemonService(s.silkworm, chainKv, settings)
 		s.silkwormRPCDaemonService = &silkwormRPCDaemonService
 	} else {
-		go func() {
+		s.bgComponentsEg.Go(func() error {
+			defer s.logger.Debug("[rpcdaemon] HTTP rpc server goroutine terminated")
 			if err := rpcdaemoncli.StartRpcServer(ctx, &httpRpcCfg, s.apiList, s.logger); err != nil {
 				s.logger.Error("cli.StartRpcServer error", "err", err)
+				return err
 			}
-		}()
+			return nil
+		})
 	}
 
 	if chainConfig.Bor == nil || config.PolygonPosSingleSlotFinality {


### PR DESCRIPTION
**[SharovBot]**

## Problem

`TestShutterBlockBuilding` flakes intermittently on Windows CI with two symptoms (issue #19444):
```
listen tcp 127.0.0.1:46025: bind: Only one usage of each socket address
fcu error: 403 Forbidden: signature is invalid
```

## Root Cause

The `StartRpcServer` goroutine in `node/eth/backend.go` was started with a bare `go func(){}()` — **not tracked** by `bgComponentsEg`:

```go
// Before — untracked:
go func() {
    if err := rpcdaemoncli.StartRpcServer(ctx, &httpRpcCfg, s.apiList, s.logger); err != nil {
        s.logger.Error("cli.StartRpcServer error", "err", err)
    }
}()
```

`Ethereum.Stop()` calls `s.sentryCancel()` (signalling the HTTP server to stop) then calls `s.bgComponentsEg.Wait()` — but since the goroutine was never registered, `Wait()` returns immediately while the HTTP server is still running.

The test restarts `EngineApiTester` (close first → start second with shutter):
1. `Stop()` cancels ctx but returns before HTTP server releases its port
2. `freeport.NextFreePort()` finds the recently-freed ports 'available'
3. Second instance picks the same ports; first server is still bound → **port conflict**
4. Second instance generates a new JWT; engine client (new JWT) hits still-alive first server (old JWT) → **403 Forbidden: signature is invalid**

## Fix

Move `StartRpcServer` into `bgComponentsEg`:

```go
// After — tracked:
s.bgComponentsEg.Go(func() error {
    defer s.logger.Debug("[rpcdaemon] HTTP rpc server goroutine terminated")
    if err := rpcdaemoncli.StartRpcServer(ctx, &httpRpcCfg, s.apiList, s.logger); err != nil {
        s.logger.Error("cli.StartRpcServer error", "err", err)
        return err
    }
    return nil
})
```

`Stop()` → `bgComponentsEg.Wait()` now blocks until the HTTP server has fully exited and released its port, eliminating the race.

The engine server goroutine was already correctly tracked in `bgComponentsEg`; this brings the HTTP RPC server goroutine in line with that pattern.

Fixes #19444