### PR TITLE
Disable Go cache in workflow on win-server

### DIFF
--- a/.github/workflows/test-all-erigon.yml
+++ b/.github/workflows/test-all-erigon.yml
@@ -152,7 +152,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: '>=1.25'
-          cache: true
+          cache: false
 
       # "make" already preinstalled:
       #- name: Install make
@@ -161,6 +161,9 @@ jobs:
       - name: Run all tests on ${{ matrix.os }}
         if: needs.source-of-changes.outputs.changed_files != 'true'
         shell: bash
+        env:
+          GOMODCACHE: C:\go-cache\mod
+          GOCACHE: C:\go-cache\build
         run: make test-all
 
       - name: Cleanup


### PR DESCRIPTION
Disable caching for Go setup and set cache environment variables (locally) for tests.