### PR TITLE
[SharovBot] ci: disable QA - RPC Integration Tests Latest from push/PR triggers

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests-latest.yml
+++ b/.github/workflows/qa-rpc-integration-tests-latest.yml
@@ -1,24 +1,13 @@
 name: QA - RPC Integration Tests Latest
 
 on:
-  workflow_dispatch:     # Run manually
+  workflow_dispatch:     # Run manually only (disabled from CI until infra is updated to support separate dbs for main vs branches)
     inputs:
       force_dump_response:
         description: 'Force dump results even if they match (by default only if actual != expected)'
         type: boolean
         required: false
         default: false
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
 
 
 jobs:


### PR DESCRIPTION
**[SharovBot]**

## Summary

Temporarily disables the `QA - RPC Integration Tests Latest` workflow from running on push and pull_request events.

## Root Cause

The `pre_test_step` consistently fails when erigon (built from a PR/branch commit) is started against the existing 3.3.7 mainnet datadir on the runner. The erigon under test is unable to reach the chain tip, producing `snapshot metainfo missing` errors. This is a known infra issue: the single datadir is maintained by erigon 3.3.7 (onboard version) and is incompatible with builds from newer commits.

## Change

- Removed `push` and `pull_request` triggers from `.github/workflows/qa-rpc-integration-tests-latest.yml`
- Kept `workflow_dispatch` so the test can still be triggered manually

## Next Steps

rimichelangelo will add a second datadir (one for main, one for branches) to properly support this test. The workflow triggers will be re-enabled once that infra is in place.

Discussed in #qa on 2026-02-27.