### PR TITLE
d_lru: remove mutex 

### DIFF
--- a/db/state/cache.go
+++ b/db/state/cache.go
@@ -19,7 +19,6 @@ type u128 struct{ hi, lo uint64 }      //nolint
 type u192 struct{ hi, lo, ext uint64 } //nolint
 
 type DomainGetFromFileCache struct {
-	sync.RWMutex
 	*freelru.LRU[uint64, domainGetFromFileCacheItem]
 	enabled, trace bool
 	limit          uint32
@@ -45,25 +44,11 @@ func NewDomainGetFromFileCache(limit uint32) *DomainGetFromFileCache {
 	return &DomainGetFromFileCache{LRU: c, enabled: domainGetFromFileCacheEnabled, trace: domainGetFromFileCacheTrace, limit: limit}
 }
 
-func (c *DomainGetFromFileCache) Add(key uint64, value domainGetFromFileCacheItem) (evicted bool) {
-	c.Lock()
-	defer c.Unlock()
-	return c.LRU.Add(key, value)
-}
-
-func (c *DomainGetFromFileCache) Get(key uint64) (value domainGetFromFileCacheItem, ok bool) {
-	c.Lock() // get upates cache vars
-	defer c.Unlock()
-	return c.LRU.Get(key)
-}
-
 func (c *DomainGetFromFileCache) SetTrace(v bool) { c.trace = v }
 func (c *DomainGetFromFileCache) LogStats(dt kv.Domain) {
 	if c == nil {
 		return
 	}
-	c.RLock()
-	defer c.RUnlock()
 	if !c.enabled || !c.trace {
 		return
 	}


### PR DESCRIPTION
PR #16922 introduced mutex to D_LRU - but i think it's not needed for Parallel exec anymore (because parallel exec doesn't do parallel reads from same `rotx` - current D_LRU is per-rotx)  