### PR TITLE
add `NO_DEEP_MERGE_HISTORY` env - to allow only history-merges up to `2-steps`

### DIFF
--- a/common/dbg/experiments.go
+++ b/common/dbg/experiments.go
@@ -56,8 +56,9 @@ var (
 
 	//state v3
 	noPrune              = EnvBool("NO_PRUNE", false)
-	noMerge              = EnvBool("NO_MERGE", false)         // don't merge Domain/Hist/II
-	noMergeHistory       = EnvBool("NO_MERGE_HISTORY", false) // don't merge Hist/II but still merge Domain
+	noMerge              = EnvBool("NO_MERGE", false)              // don't merge Domain/Hist/II
+	noMergeHistory       = EnvBool("NO_MERGE_HISTORY", false)      // don't merge Hist/II but still merge Domain
+	noDeepMergeHistory   = EnvBool("NO_DEEP_MERGE_HISTORY", false) // merge Hist/II only up to 2 steps (small+fast), skip larger merges
 	discardCommitment    = EnvBool("DISCARD_COMMITMENT", false)
 	pruneTotalDifficulty = EnvBool("PRUNE_TOTAL_DIFFICULTY", true)
 
@@ -122,6 +123,7 @@ func DiscardCommitment() bool    { return discardCommitment }
 func NoPrune() bool              { return noPrune }
 func NoMerge() bool              { return noMerge }
 func NoMergeHistory() bool       { return noMergeHistory }
+func NoDeepMergeHistory() bool   { return noDeepMergeHistory }
 func PruneTotalDifficulty() bool { return pruneTotalDifficulty }
 
 var (

--- a/db/state/merge.go
+++ b/db/state/merge.go
@@ -155,6 +155,9 @@ func (ht *HistoryRoTx) findMergeRange(maxEndTxNum, maxSpan uint64) HistoryRanges
 	if dbg.NoMergeHistory() {
 		return r
 	}
+	if dbg.NoDeepMergeHistory() {
+		maxSpan = min(maxSpan, 2*ht.stepSize)
+	}
 
 	mr := ht.iit.findMergeRange(maxEndTxNum, maxSpan)
 	r.index = *mr


### PR DESCRIPTION
fast merges, less impact on exec, less disk space (10x for comm history)