### PR TITLE
optimize slice allocation in shutter crypto

### DIFF
--- a/txnprovider/shutter/internal/crypto/hash.go
+++ b/txnprovider/shutter/internal/crypto/hash.go
@@ -35,11 +35,16 @@ func keccak256(ds ...[]byte) []byte {
 }
 
 func hashWithPrefix(p byte, b []byte) []byte {
-	return keccak256(append([]byte{p}, b...))
+	buf := make([]byte, 1+len(b))
+	buf[0] = p
+	copy(buf[1:], b)
+	return keccak256(buf)
 }
 
 func Hash1(b []byte) *blst.P1Affine {
-	bWithPrefix := append([]byte{1}, b...)
+	bWithPrefix := make([]byte, 1+len(b))
+	bWithPrefix[0] = 1
+	copy(bWithPrefix[1:], b)
 	p := blst.HashToG1(bWithPrefix, []byte(HashToG1DST))
 	return p.ToAffine()
 }

--- a/txnprovider/shutter/internal/crypto/helpers_test.go
+++ b/txnprovider/shutter/internal/crypto/helpers_test.go
@@ -34,3 +34,26 @@ func EnsureGobable(t *testing.T, src, dst any) {
 	require.NoError(t, err)
 	assert.Equal(t, src, dst)
 }
+
+var globalBuf []byte
+
+func BenchmarkAppend(b *testing.B) {
+	data := make([]byte, 32)
+	p := byte(1)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		globalBuf = append([]byte{p}, data...)
+	}
+}
+
+func BenchmarkMakeCopy(b *testing.B) {
+	data := make([]byte, 32)
+	p := byte(1)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf := make([]byte, 1+len(data))
+		buf[0] = p
+		copy(buf[1:], data)
+		globalBuf = buf
+	}
+}


### PR DESCRIPTION
Replace append with make and copy for slice initialization, reducing memory allocations in the cryptographic hot path.
