### PR TITLE
qa-tests: change RPC Integration Latest test trigger

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests-latest.yml
+++ b/.github/workflows/qa-rpc-integration-tests-latest.yml
@@ -9,7 +9,7 @@ on:
         required: false
         default: false
   schedule:
-    - cron: '0 0 * * 0'  # Run on Sunday at 00:00 AM UTC
+    - cron: '0 0 * * *'  # Run nightly at 00:00 AM UTC
   push:
     branches:
       - 'release/3.*'


### PR DESCRIPTION
This test requires that, when starting Erigon from a synced DB, it reach the tip within a few minutes.
This does not seem to be true. So, temporarily, we change the test trigger:
- run nightly in main, 
- run on every push in release