### PR TITLE
docs: fix port config flags in migrating-from-geth.md

### DIFF
--- a/docs/gitbook/src/get-started/migrating-from-geth.md
+++ b/docs/gitbook/src/get-started/migrating-from-geth.md
@@ -42,14 +42,14 @@ This path offers the simplest validator configuration by using Erigon's embedded
 **Steps for Minimal Downtime**
 
 1. **Preparation**: [Install](installation/) Erigon.
-2.  **Configuration Check** (No Conflict): Ensure Erigon's standard [ports](../fundamentals/default-ports.md) (JSON-RPC, P2P) are different from Geth's. These ports are configured via command-line options: `--port <port>` and `--p2p.listen-addr <IP:port>`. For example:
+2.  **Configuration Check** (No Conflict): Ensure Erigon's standard [ports](../fundamentals/default-ports.md) (JSON-RPC, P2P) are different from Geth's. These ports are configured via the `--port` and `--p2p.allowed-ports` command-line options. For example:
 
     ```sh
     erigon \
       --datadir=/data/erigon \
       --chain=mainnet \
-      --port: 30304 \
-      --p2p.allowed-ports: 30310, 30311, 30312, 30313, 30314, 30315, 30316
+      --port=30304 \
+      --p2p.allowed-ports=30310,30311,30312,30313,30314,30315,30316
     ```
 3. **Synchronization**: Start syncing Erigon. Monitor the sync status using the `eth_syncing` JSON-[RPC method](../interacting-with-erigon/) or a health check.
 4. **Validator Swap**: Once Erigon is fully synced, shut down Geth and the external CL client.
@@ -65,14 +65,14 @@ Switch to an Erigon Execution Layer (EL) while keeping your current external Con
 **Steps for Minimal Downtime**
 
 1. **Preparation**: [Install](installation/) Erigon.
-2.  **Configuration Check**: run Erigon + Caplin simultaneously with Geth (or any other EL) for fast, parallel syncing and assign unique ports for its P2P networking (check which ports your present EL is using). For example:
+2.  **Configuration Check**: run Erigon + Caplin simultaneously with Geth (or any other EL) for fast, parallel syncing and assign unique ports for its P2P networking via `--port` and `--p2p.allowed-ports` (check which ports your present EL is using). For example:
 
     ```sh
     erigon \
       --datadir=/data/erigon \
       --chain=mainnet \
-      --port: 30304 \
-      --p2p.allowed-ports: 30310, 30311, 30312, 30313, 30314, 30315, 30316
+      --port=30304 \
+      --p2p.allowed-ports=30310,30311,30312,30313,30314,30315,30316
     ```
 3. **Synchronization**: Monitor the sync status using the `eth_syncing` JSON-RPC method or a health check.
 4. **Validator Swap**: Once Erigon is fully synced, **shut down** both Geth and Erigon. **Keep the external CL client running.**
@@ -133,3 +133,4 @@ This path retains your existing **external Consensus Layer (CL)** client (e.g., 
 ***
 
 See [Basic Usage](../fundamentals/basic-usage.md) and [Configuring Erigon](../fundamentals/configuring-erigon/) for more details on available options.
+


### PR DESCRIPTION
## Summary

Fixes two inaccuracies in the "Migrating from Geth" guide's port configuration section:

- **Remove `--p2p.listen-addr`**: This flag does not exist in Erigon. Port binding is controlled via `--port` (and optionally `--p2p.allowed-ports` for extra ports). Replaced the text to reference the correct flags.
- **Fix CLI syntax**: The code examples used `--port: 30304` / `--p2p.allowed-ports: 30310, ...` (colon-space syntax, which is not valid CLI syntax). Corrected to `--port=30304` / `--p2p.allowed-ports=30310,...` (equals-sign, no spaces around commas).

Both fixes appear in two tab variants (standalone Erigon and Erigon + Caplin) in the same file.

## Files changed

- `docs/gitbook/src/get-started/migrating-from-geth.md`