### PR TITLE
Fix backwards check for Linux IPv6 module

### DIFF
--- a/db/downloader/downloadercfg/downloadercfg.go
+++ b/db/downloader/downloadercfg/downloadercfg.go
@@ -359,7 +359,7 @@ func getIpv6Enabled() bool {
 			return false
 		}
 		fileContent := strings.TrimSpace(string(file))
-		return fileContent != "0"
+		return fileContent == "0"
 	}
 
 	// TODO hotfix: for platforms other than linux disable ipv6


### PR DESCRIPTION
I noticed a log saying ipv6-enabled=false. This is why: disabled=="0" actually means enabled.
Affects the sync torrent downloader, or something.
I have no idea if this is a good change, but it's a really obviously dumb bug so...