### PR TITLE
refactor: use WaitGroup.Go to simplify code

### DIFF
--- a/p2p/discover/v4_lookup_test.go
+++ b/p2p/discover/v4_lookup_test.go
@@ -89,11 +89,9 @@ func TestUDPv4_LookupIterator(t *testing.T) {
 		bootnodes[i] = lookupTestnet.node(256, i)
 	}
 	fillTable(test.table, bootnodes, true)
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		serveTestnet(test, lookupTestnet)
-		wg.Done()
-	}()
+	})
 
 	// Create the iterator and collect the nodes it yields.
 	iter := test.udp.RandomNodes()
@@ -133,11 +131,9 @@ func TestUDPv4_LookupIteratorClose(t *testing.T) {
 	}
 	fillTable(test.table, bootnodes, true)
 
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		serveTestnet(test, lookupTestnet)
-		wg.Done()
-	}()
+	})
 
 	it := test.udp.RandomNodes()
 	if ok := it.Next(); !ok || it.Node() == nil {

--- a/p2p/event/example_scope_test.go
+++ b/p2p/event/example_scope_test.go
@@ -96,9 +96,7 @@ func ExampleSubscriptionScope() {
 	// Run a subscriber in the background.
 	divsub := app.SubscribeResults('/', divs)
 	mulsub := app.SubscribeResults('*', muls)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		defer fmt.Println("subscriber exited")
 		defer divsub.Unsubscribe()
 		defer mulsub.Unsubscribe()
@@ -114,7 +112,7 @@ func ExampleSubscriptionScope() {
 				return
 			}
 		}
-	}()
+	})
 
 	// Interact with the app.
 	app.Calc('/', 22, 11)

--- a/p2p/event/feed_test.go
+++ b/p2p/event/feed_test.go
@@ -253,11 +253,9 @@ func TestFeedUnsubscribeSentChan(t *testing.T) {
 	)
 	defer sub2.Unsubscribe()
 
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		feed.Send(0)
-		wg.Done()
-	}()
+	})
 
 	// Wait for the value on ch1.
 	<-ch1
@@ -270,11 +268,9 @@ func TestFeedUnsubscribeSentChan(t *testing.T) {
 
 	// Send again. This should send to ch2 only, so the wait group will unblock
 	// as soon as a value is received on ch2.
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		feed.Send(0)
-		wg.Done()
-	}()
+	})
 	<-ch2
 	wg.Wait()
 }

--- a/p2p/event/feedof_test.go
+++ b/p2p/event/feedof_test.go
@@ -194,11 +194,9 @@ func TestFeedOfUnsubscribeSentChan(t *testing.T) {
 	)
 	defer sub2.Unsubscribe()
 
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		feed.Send(0)
-		wg.Done()
-	}()
+	})
 
 	// Wait for the value on ch1.
 	<-ch1
@@ -211,11 +209,9 @@ func TestFeedOfUnsubscribeSentChan(t *testing.T) {
 
 	// Send again. This should send to ch2 only, so the wait group will unblock
 	// as soon as a value is received on ch2.
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		feed.Send(0)
-		wg.Done()
-	}()
+	})
 	<-ch2
 	wg.Wait()
 }

--- a/p2p/sentry/sentry_grpc_server_test.go
+++ b/p2p/sentry/sentry_grpc_server_test.go
@@ -237,20 +237,16 @@ func TestHandShake69_ETH69ToETH69(t *testing.T) {
 	var reply69_1 *eth.StatusPacket69
 	var peerErr1 *p2p.PeerError
 	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		reply69_1, peerErr1 = handShake[eth.StatusPacket69](ctx, sentry1Status, sentry1RW, direct.ETH69, direct.ETH69, encodeStatusPacket69, compatStatusPacket69, handshakeTimeout)
-	}()
+	})
 
 	// Run ETH69 handshake for Sentry 2 in a goroutine
 	var reply69_2 *eth.StatusPacket69
 	var peerErr2 *p2p.PeerError
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		reply69_2, peerErr2 = handShake[eth.StatusPacket69](ctx, sentry2Status, sentry2RW, direct.ETH69, direct.ETH69, encodeStatusPacket69, compatStatusPacket69, handshakeTimeout)
-	}()
+	})
 
 	wg.Wait()
 


### PR DESCRIPTION

use WaitGroup.Go to simplify code. More info: https://github.com/golang/go/issues/63796