### PR TITLE
ci: improve disk space management on self-hosted Windows runner

### DIFF
--- a/.github/workflows/test-all-erigon.yml
+++ b/.github/workflows/test-all-erigon.yml
@@ -142,14 +142,6 @@ jobs:
       #    minimum-size: 8GB
       #    disk-root: "C:"
 
-      # Clears stale test-result cache so tests always run fresh.
-      # Runs before checkout so it also fires on runs cancelled mid-job,
-      # preventing a dirty build cache from carrying over to the next run.
-      - name: Pre-run Go cache cleanup
-        if: always()
-        shell: bash
-        run: go clean -testcache
-
       - name: "Checkout code with submodules and large files (lfs) on ${{ matrix.os }}"
         if: needs.source-of-changes.outputs.changed_files != 'true'
         uses: actions/checkout@v6


### PR DESCRIPTION
## Changes

- Move `GOMODCACHE`/`GOCACHE` env vars to job level so all steps share the same cache paths
- Add **pre-run** `go clean -testcache` (`if: always()`) — ensures tests run fresh and catches leftovers from cancelled runs
- Add **LFS prune** step after checkout — removes blobs no longer referenced by the current branch
- Replace old `Cleanup` with **post-run** `go clean -cache` — clears compiled artifacts after each run to prevent unbounded growth on the persistent runner
- Post-run cleanup also removes `coverage-test-all.out` and `$env:RUNNER_TEMP` (previously only `$env:TEMP` was cleaned)