### PR TITLE
qa-tests: rename Constrained Tip-Tracking in Tip-Tracking with contraints

### DIFF
--- a/.github/workflows/qa-constrained-tip-tracking.yml
+++ b/.github/workflows/qa-constrained-tip-tracking.yml
@@ -1,4 +1,4 @@
-name: QA - Constrained Tip tracking
+name: QA - Tip tracking with constraints
 
 on:
   schedule:


### PR DESCRIPTION
Rename the test to improve its position in the test report, in which tests are listed alphabetically.