### PR TITLE
[SharovBot] [r3.3] cl/sentinel: fix DISCV5 ENR missing IP and nil IPv6 crash (#19585)

### DIFF
--- a/cl/sentinel/sentinel.go
+++ b/cl/sentinel/sentinel.go
@@ -122,20 +122,45 @@ func (s *Sentinel) createLocalNode(
 	}
 	localNode := enode.NewLocalNode(db, privKey, s.logger)
 
-	ipEntry := enr.IP(ipAddr)
 	udpEntry := enr.UDP(udpPort)
 	tcpEntry := enr.TCP(tcpPort)
 
-	localNode.Set(ipEntry)
 	localNode.Set(udpEntry)
 	localNode.Set(tcpEntry)
-
-	localNode.SetFallbackIP(ipAddr)
 	localNode.SetFallbackUDP(udpPort)
+
+	if ipAddr.IsUnspecified() {
+		if detected := detectOutboundIP(ipAddr); detected != nil {
+			s.logger.Info("[Caplin] Discovery address is unspecified, using detected outbound IP for ENR. Set --caplin.discovery.addr explicitly to override", "detected", detected)
+			ipAddr = detected
+		} else {
+			s.logger.Warn("[Caplin] Discovery address is unspecified and outbound IP detection failed, ENR will have no IP. Set --caplin.discovery.addr to your public IP")
+		}
+	}
+	if !ipAddr.IsUnspecified() {
+		localNode.Set(enr.IP(ipAddr))
+		localNode.SetFallbackIP(ipAddr)
+	}
+
 	s.setupENR(localNode)
 	go s.updateENR(localNode)
 
 	return localNode, nil
+}
+
+// detectOutboundIP determines the preferred outbound IP address by asking the
+// OS routing table (no actual traffic is sent). Returns nil if detection fails.
+func detectOutboundIP(unspecified net.IP) net.IP {
+	network, target := "udp4", "8.8.8.8:80"
+	if unspecified.To4() == nil {
+		network, target = "udp6", "[2001:4860:4860::8888]:80"
+	}
+	conn, err := net.Dial(network, target)
+	if err != nil {
+		return nil
+	}
+	defer conn.Close()
+	return conn.LocalAddr().(*net.UDPAddr).IP
 }
 
 func (s *Sentinel) SetStatus(status *cltypes.Status) {
@@ -557,21 +582,22 @@ func (s *Sentinel) Identity() (pid, enrStr string, p2pAddresses, discoveryAddres
 	}
 	discoveryAddresses = []string{}
 
-	if s.listener.LocalNode().Node().TCP() != 0 {
+	nodeIP := s.listener.LocalNode().Node().IP()
+	if nodeIP == nil {
+		s.logger.Warn("[Sentinel] Discovery node has nil IP address, skipping discovery address advertisement. Check caplin.discovery.addr configuration and host IPv6 setup")
+	} else {
 		protocol := "ip4"
-		if s.listener.LocalNode().Node().IP().To4() == nil {
+		if nodeIP.To4() == nil {
 			protocol = "ip6"
 		}
-		port := s.listener.LocalNode().Node().TCP()
-		discoveryAddresses = append(discoveryAddresses, fmt.Sprintf("/%s/%s/tcp/%d/p2p/%s", protocol, s.listener.LocalNode().Node().IP(), port, pid))
-	}
-	if s.listener.LocalNode().Node().UDP() != 0 {
-		protocol := "ip4"
-		if s.listener.LocalNode().Node().IP().To4() == nil {
-			protocol = "ip6"
+		if s.listener.LocalNode().Node().TCP() != 0 {
+			port := s.listener.LocalNode().Node().TCP()
+			discoveryAddresses = append(discoveryAddresses, fmt.Sprintf("/%s/%s/tcp/%d/p2p/%s", protocol, nodeIP, port, pid))
 		}
-		port := s.listener.LocalNode().Node().UDP()
-		discoveryAddresses = append(discoveryAddresses, fmt.Sprintf("/%s/%s/udp/%d/p2p/%s", protocol, s.listener.LocalNode().Node().IP(), port, pid))
+		if s.listener.LocalNode().Node().UDP() != 0 {
+			port := s.listener.LocalNode().Node().UDP()
+			discoveryAddresses = append(discoveryAddresses, fmt.Sprintf("/%s/%s/udp/%d/p2p/%s", protocol, nodeIP, port, pid))
+		}
 	}
 	subnetField := bitfield.NewBitvector64()
 	syncnetField := bitfield.NewBitvector8()


### PR DESCRIPTION
**[SharovBot]**

Cherry-pick of #19585 to release/3.3.

## Why it doesn't apply cleanly

In `main`, the local node logic lives in `cl/p2p/p2p_localnode.go` (introduced after 3.3 branched off). In release/3.3 the equivalent code is in `cl/sentinel/sentinel.go`'s `createLocalNode()`. All three fixes are ported there.

## Changes

1. **Skip nil IPv6 in discovery addresses** — `Identity()` now nil-checks `LocalNode().Node().IP()` before building discovery address strings. Prevents `/ip6/<nil>/...` malformed addresses and potential panic.

2. **Skip unspecified IP in ENR fallback** — `createLocalNode()` now guards `enr.IP`/`SetFallbackIP` with `IsUnspecified()`. When `caplin.discovery.addr` is `0.0.0.0`/`::`, the unspecified address no longer gets set in the ENR (it was being silently rejected by `updateEndpoints()`, leaving the ENR with no IP).

3. **Auto-detect outbound IP** — When discovery address is unspecified, detect the preferred outbound IP via OS routing table (`net.Dial("udp", ...)` without sending traffic). Populates the ENR immediately, making the node discoverable from startup.

Fixes #19576

## Test
- `go build ./cl/sentinel/...` ✅
- `go test ./cl/sentinel/... -short` ✅ all pass