### PR TITLE
[kimiko] eth/69: fix typed receipt encoding to use flat RLP list

### DIFF
--- a/execution/types/receipt.go
+++ b/execution/types/receipt.go
@@ -98,7 +98,11 @@ type receiptRLP struct {
 }
 
 // receiptRLP69 is the post-eth/69 consensus encoding of a receipt.
+// ETH69 changed receipt encoding so all receipts (including typed) use the same
+// flat list format: [tx-type, post-state-or-status, cumulative-gas, logs].
+// This removes the type-byte envelope used in ETH68 and drops the bloom filter.
 type receiptRLP69 struct {
+	Type              uint8
 	PostStateOrStatus []byte
 	CumulativeGasUsed uint64
 	Logs              []*Log
@@ -152,28 +156,16 @@ func (r Receipt) EncodeRLP(w io.Writer) error {
 
 // EncodeRLP69 implements rlp.Encoder for post-eth/69 messages, and flattens the consensus fields of a receipt
 // into an RLP stream. If no post state is present, byzantium fork is assumed.
+// ETH69 uses a uniform list encoding for all receipt types:
+//
+//	receiptₙ = [tx-type, post-state-or-status, cumulative-gas, logs]
 func (r Receipt) EncodeRLP69(w io.Writer) error {
-	data := &receiptRLP69{r.statusEncoding(), r.CumulativeGasUsed, r.Logs}
-	if r.Type == LegacyTxType {
-		return rlp.Encode(w, data)
-	}
-	buf := encodeBufferPool.Get().(*bytes.Buffer)
-	defer encodeBufferPool.Put(buf)
-	buf.Reset()
-	if err := r.encodeTyped69(data, buf); err != nil {
-		return err
-	}
-	return rlp.Encode(w, buf.Bytes())
+	data := &receiptRLP69{r.Type, r.statusEncoding(), r.CumulativeGasUsed, r.Logs}
+	return rlp.Encode(w, data)
 }
 
 // encodeTyped writes the canonical encoding of a typed receipt to w.
 func (r *Receipt) encodeTyped(data *receiptRLP, w *bytes.Buffer) error {
-	w.WriteByte(r.Type)
-	return rlp.Encode(w, data)
-}
-
-// encodeTyped writes the post-eth/69 canonical encoding of a typed receipt to w.
-func (r *Receipt) encodeTyped69(data *receiptRLP69, w *bytes.Buffer) error {
 	w.WriteByte(r.Type)
 	return rlp.Encode(w, data)
 }

--- a/execution/types/receipt_test.go
+++ b/execution/types/receipt_test.go
@@ -352,6 +352,184 @@ func TestReceiptUnmarshalBinary(t *testing.T) {
 	})
 }
 
+// TestReceiptEncodeRLP69_AllTypesAreList verifies that EncodeRLP69 produces a flat RLP
+// list [tx-type, post-state-or-status, cumulative-gas, logs] for every transaction type,
+// conforming to the ETH69 spec. In particular, typed receipts must NOT use the old
+// type_byte || rlp(data) byte-string envelope from ETH68.
+func TestReceiptEncodeRLP69_AllTypesAreList(t *testing.T) {
+	t.Parallel()
+
+	logs := []*Log{
+		{
+			Address: common.BytesToAddress([]byte{0x11}),
+			Topics:  []common.Hash{common.HexToHash("dead"), common.HexToHash("beef")},
+			Data:    []byte{0x01, 0x00, 0xff},
+		},
+	}
+
+	txTypes := []struct {
+		name   string
+		txType uint8
+	}{
+		{"Legacy", LegacyTxType},
+		{"AccessList", AccessListTxType},
+		{"DynamicFee", DynamicFeeTxType},
+		{"Blob", BlobTxType},
+		{"SetCode", SetCodeTxType},
+	}
+
+	for _, tt := range txTypes {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			receipt := &Receipt{
+				Type:              tt.txType,
+				Status:            ReceiptStatusSuccessful,
+				CumulativeGasUsed: 50000,
+				Logs:              logs,
+			}
+
+			var buf bytes.Buffer
+			err := receipt.EncodeRLP69(&buf)
+			require.NoError(t, err)
+			encoded := buf.Bytes()
+			require.NotEmpty(t, encoded)
+
+			// The first byte must indicate an RLP list (0xc0..0xf7 for short lists,
+			// 0xf8..0xff for long lists), NOT a byte string (0x80..0xbf).
+			firstByte := encoded[0]
+			assert.True(t, firstByte >= 0xc0,
+				"expected RLP list prefix (>= 0xc0), got 0x%02x — typed receipt was likely wrapped as byte string", firstByte)
+
+			// Decode back using the receiptRLP69 struct to verify all 4 fields.
+			var decoded receiptRLP69
+			err = rlp.DecodeBytes(encoded, &decoded)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.txType, decoded.Type, "Type mismatch")
+			assert.Equal(t, receiptStatusSuccessfulRLP, decoded.PostStateOrStatus, "PostStateOrStatus mismatch")
+			assert.Equal(t, uint64(50000), decoded.CumulativeGasUsed, "CumulativeGasUsed mismatch")
+			require.Len(t, decoded.Logs, 1)
+			assert.Equal(t, logs[0].Address, decoded.Logs[0].Address)
+		})
+	}
+}
+
+// TestReceiptEncodeRLP69_NoBloom confirms that the ETH69 encoding omits the bloom filter.
+func TestReceiptEncodeRLP69_NoBloom(t *testing.T) {
+	t.Parallel()
+
+	receipt := &Receipt{
+		Type:              DynamicFeeTxType,
+		Status:            ReceiptStatusSuccessful,
+		CumulativeGasUsed: 21000,
+		Bloom:             CreateBloom(Receipts{{Status: ReceiptStatusSuccessful, Logs: []*Log{{Address: common.BytesToAddress([]byte{0x11})}}}}),
+		Logs:              []*Log{},
+	}
+
+	var buf bytes.Buffer
+	err := receipt.EncodeRLP69(&buf)
+	require.NoError(t, err)
+
+	// Decode using the 4-field struct; if a bloom was incorrectly included,
+	// the RLP decoder would either fail or produce wrong field values.
+	var decoded receiptRLP69
+	err = rlp.DecodeBytes(buf.Bytes(), &decoded)
+	require.NoError(t, err)
+	assert.Equal(t, uint8(DynamicFeeTxType), decoded.Type)
+	assert.Equal(t, uint64(21000), decoded.CumulativeGasUsed)
+}
+
+// TestReceiptsEncodeRLP69_MixedTypes verifies that Receipts.EncodeRLP69 correctly
+// encodes a batch of mixed-type receipts.
+func TestReceiptsEncodeRLP69_MixedTypes(t *testing.T) {
+	t.Parallel()
+
+	receipts := Receipts{
+		{
+			Type:              LegacyTxType,
+			Status:            ReceiptStatusSuccessful,
+			CumulativeGasUsed: 21000,
+			Logs:              []*Log{},
+		},
+		{
+			Type:              AccessListTxType,
+			Status:            ReceiptStatusFailed,
+			CumulativeGasUsed: 42000,
+			Logs:              []*Log{},
+		},
+		{
+			Type:              DynamicFeeTxType,
+			Status:            ReceiptStatusSuccessful,
+			CumulativeGasUsed: 63000,
+			Logs:              []*Log{},
+		},
+		{
+			Type:              BlobTxType,
+			Status:            ReceiptStatusSuccessful,
+			CumulativeGasUsed: 84000,
+			Logs:              []*Log{},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := receipts.EncodeRLP69(&buf)
+	require.NoError(t, err)
+
+	// Decode the outer list of receipt lists.
+	var decodedList []receiptRLP69
+	err = rlp.DecodeBytes(buf.Bytes(), &decodedList)
+	require.NoError(t, err)
+	require.Len(t, decodedList, 4)
+
+	assert.Equal(t, uint8(LegacyTxType), decodedList[0].Type)
+	assert.Equal(t, uint64(21000), decodedList[0].CumulativeGasUsed)
+
+	assert.Equal(t, uint8(AccessListTxType), decodedList[1].Type)
+	assert.Equal(t, receiptStatusFailedRLP, decodedList[1].PostStateOrStatus)
+
+	assert.Equal(t, uint8(DynamicFeeTxType), decodedList[2].Type)
+	assert.Equal(t, uint64(63000), decodedList[2].CumulativeGasUsed)
+
+	assert.Equal(t, uint8(BlobTxType), decodedList[3].Type)
+	assert.Equal(t, uint64(84000), decodedList[3].CumulativeGasUsed)
+}
+
+// TestReceiptEncodeRLP69_DiffersFromETH68 ensures that the ETH69 encoding
+// is structurally different from the ETH68 encoding for typed receipts.
+func TestReceiptEncodeRLP69_DiffersFromETH68(t *testing.T) {
+	t.Parallel()
+
+	receipt := &Receipt{
+		Type:              DynamicFeeTxType,
+		Status:            ReceiptStatusSuccessful,
+		CumulativeGasUsed: 21000,
+		Bloom:             CreateBloom(Receipts{{Status: ReceiptStatusSuccessful, Logs: []*Log{}}}),
+		Logs:              []*Log{},
+	}
+
+	// ETH68 encoding
+	var buf68 bytes.Buffer
+	err := receipt.EncodeRLP(&buf68)
+	require.NoError(t, err)
+
+	// ETH69 encoding
+	var buf69 bytes.Buffer
+	err = receipt.EncodeRLP69(&buf69)
+	require.NoError(t, err)
+
+	// They must differ: ETH68 wraps typed receipts as byte strings; ETH69 uses flat lists.
+	assert.False(t, bytes.Equal(buf68.Bytes(), buf69.Bytes()),
+		"ETH68 and ETH69 typed receipt encodings should differ")
+
+	// ETH69 result must be a list (first byte >= 0xc0).
+	assert.True(t, buf69.Bytes()[0] >= 0xc0,
+		"ETH69 encoding should be an RLP list, got first byte 0x%02x", buf69.Bytes()[0])
+
+	// ETH68 result for typed receipt is a byte string (first byte < 0xc0).
+	assert.True(t, buf68.Bytes()[0] < 0xc0,
+		"ETH68 typed receipt encoding should be an RLP byte string, got first byte 0x%02x", buf68.Bytes()[0])
+}
+
 func TestReceiptEncode(t *testing.T) {
 	t.Run("Enc.FirstLogIndexWithinBlock", func(t *testing.T) {
 		r1 := &ReceiptForStorage{FirstLogIndexWithinBlock: 1}

--- a/p2p/sentry/sentry_multi_client/sentry_multi_client_test.go
+++ b/p2p/sentry/sentry_multi_client/sentry_multi_client_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 type receiptRLP69 struct {
+	Type              uint8
 	PostStateOrStatus []byte
 	CumulativeGasUsed uint64
 	Logs              []*types.Log
@@ -30,6 +31,7 @@ func TestMultiClient_GetReceipts69(t *testing.T) {
 	testHash := common.HexToHash("0x123")
 	testReceipts := types.Receipts{
 		{
+			Type:              types.LegacyTxType,
 			Status:            types.ReceiptStatusSuccessful,
 			CumulativeGasUsed: 21000,
 			Logs:              []*types.Log{},
@@ -37,6 +39,7 @@ func TestMultiClient_GetReceipts69(t *testing.T) {
 			GasUsed:           21000,
 		},
 		{
+			Type:              types.DynamicFeeTxType,
 			Status:            types.ReceiptStatusSuccessful,
 			CumulativeGasUsed: 42000,
 			Logs:              []*types.Log{},
@@ -116,14 +119,27 @@ func TestMultiClient_GetReceipts69(t *testing.T) {
 	}
 
 	if len(receiptsList) != 2 {
-		t.Fatalf("Expected 2 receipt in list, got %d", len(receiptsList))
+		t.Fatalf("Expected 2 receipts in list, got %d", len(receiptsList))
 	}
 
-	receipt := receiptsList[0]
+	// Verify legacy receipt (type 0)
+	receipt0 := receiptsList[0]
+	if receipt0.Type != types.LegacyTxType {
+		t.Errorf("Expected receipt[0] Type %d (legacy), got %d", types.LegacyTxType, receipt0.Type)
+	}
+	if receipt0.CumulativeGasUsed != 21000 {
+		t.Errorf("Expected receipt[0] CumulativeGasUsed 21000, got %d", receipt0.CumulativeGasUsed)
+	}
 
-	// Verify the receipt was decoded correctly
-	if receipt.CumulativeGasUsed != 21000 {
-		t.Errorf("Expected CumulativeGasUsed 21000, got %d", receipt.CumulativeGasUsed)
+	// Verify typed receipt (DynamicFee, type 2) — this is the critical case:
+	// ETH69 requires typed receipts to be list-encoded [type, status, gas, logs],
+	// NOT the old byte-string envelope (type_byte || rlp(data)) used in ETH68.
+	receipt1 := receiptsList[1]
+	if receipt1.Type != types.DynamicFeeTxType {
+		t.Errorf("Expected receipt[1] Type %d (DynamicFee), got %d", types.DynamicFeeTxType, receipt1.Type)
+	}
+	if receipt1.CumulativeGasUsed != 42000 {
+		t.Errorf("Expected receipt[1] CumulativeGasUsed 42000, got %d", receipt1.CumulativeGasUsed)
 	}
 }
 


### PR DESCRIPTION
ETH69 changed receipt encoding so all receipts (including typed) use the same flat list format: [tx-type, post-state-or-status, cumulative-gas, logs]. This removes the type-byte envelope used in ETH68 and drops the bloom filter.

- Add Type field to receiptRLP69 struct
- Simplify EncodeRLP69 to always produce a flat list (no envelope)
- Remove now-unused encodeTyped69 method
- Update sentry_multi_client_test to verify both legacy and typed receipts
- Add comprehensive tests for ETH69 encoding (all types, no bloom, mixed batch, diff from ETH68)

Closes #19520