### PR TITLE
docs: correct cosmetic formatting in Gitbook documentation

### DIFF
--- a/docs/gitbook/src/fundamentals/basic-usage.md
+++ b/docs/gitbook/src/fundamentals/basic-usage.md
@@ -95,8 +95,7 @@ To run Erigon with RPCDaemon, TxPool, and other components in a single process i
 * `--log.dir.path` dictates where [logs](logs.md) will be output - useful for sending reports to the Erigon team when issues occur.
 * Based on the [sync mode](sync-modes.md) you want to run you can add `--prune.mode=archive` to run a archive node, `--prune.mode=full` for a full node (default value) or `--prune.mode=minimal` for a minimal node.
 * `--http.addr="0.0.0.0" --http.api=eth,web3,net,debug,trace,txpool` to use [RPC Service](../interacting-with-erigon/) and e.g. be able to connect your [wallet](web3-wallet.md).
-* `--torrent.download.rate=512mb` sets the maximum download speed. The default is `512mb`. You can lower this value to
-  limit bandwidth usage, for example `--torrent.download.rate=128mb` to cap downloads at 128 MB/s.
+* `--torrent.download.rate=512mb` sets the maximum download speed. The default is `512mb`. You can lower this value to limit bandwidth usage, for example `--torrent.download.rate=128mb` to cap downloads at 128 MB/s.
 
 To stop the Erigon node you can use the `CTRL+C` command.
 

--- a/docs/gitbook/src/fundamentals/configuring-erigon/README.md
+++ b/docs/gitbook/src/fundamentals/configuring-erigon/README.md
@@ -82,8 +82,7 @@ Flags for managing how old chain data is handled and stored.
   * Default: `0`
 * `--prune.distance.blocks value`: Keeps block history for the latest `N` blocks.
   * Default: `0`
-*
-`--prune.include-commitment-history, --prune.experimental.include-commitment-history, --experimental.commitment-history`: (
+* `--prune.include-commitment-history, --prune.experimental.include-commitment-history, --experimental.commitment-history`: (
 experimental) Enables blazing fast `eth_getProof` for executed blocks by storing commitment history.
   * Default: `false`
 * `--snap.keepblocks`: Keeps ancient blocks in the database for debugging.

--- a/docs/gitbook/src/fundamentals/performance-tricks.md
+++ b/docs/gitbook/src/fundamentals/performance-tricks.md
@@ -18,11 +18,10 @@ These instructions are designed to improve the performance of Erigon 3, particul
 --sync.loop.block.limit=10_000 --batchSize=2g
 ```
 
-* Adjust download speed with flag `--torrent.download.rate=[value]` setting your max speed (default value is `512mb`).
-  For example:
+* Adjust download speed with flag `--torrent.download.rate=[value]` setting your max speed (default value is `512mb`). For example:
 
 ```bash
---torrent.download.rate=512mb
+--torrent.download.rate=1024mb
 ```
 
 ## Optimize for Cloud Drives

--- a/docs/gitbook/src/get-started/migrating-from-geth.md
+++ b/docs/gitbook/src/get-started/migrating-from-geth.md
@@ -42,9 +42,7 @@ This path offers the simplest validator configuration by using Erigon's embedded
 **Steps for Minimal Downtime**
 
 1. **Preparation**: [Install](installation/) Erigon.
-2. **Configuration Check** (No Conflict): Ensure Erigon's standard [ports](../fundamentals/default-ports.md) (JSON-RPC,
-   P2P) are different from Geth's. These ports are configured via the `--port` and `--p2p.allowed-ports` command-line
-   options. For example:
+2. **Configuration Check** (No Conflict): Ensure Erigon's standard [ports](../fundamentals/default-ports.md) (JSON-RPC, P2P) are different from Geth's. These ports are configured via the `--port` and `--p2p.allowed-ports` command-line options. For example:
 
     ```sh
     erigon \
@@ -67,8 +65,7 @@ Switch to an Erigon Execution Layer (EL) while keeping your current external Con
 **Steps for Minimal Downtime**
 
 1. **Preparation**: [Install](installation/) Erigon.
-2. **Configuration Check**: run Erigon + Caplin simultaneously with Geth (or any other EL) for fast, parallel syncing
-   and assign unique ports for its P2P networking via `--port` and `--p2p.allowed-ports` (check which ports your present
+2. **Configuration Check**: run Erigon + Caplin simultaneously with Geth (or any other EL) for fast, parallel syncing and assign unique ports for its P2P networking via `--port` and `--p2p.allowed-ports` (check which ports your present
    EL is using). For example:
 
     ```sh


### PR DESCRIPTION
- docs/gitbook/src/fundamentals/basic-usage.md: fix line wrapping for torrent download rate flag description
- docs/gitbook/src/fundamentals/configuring-erigon/README.md: remove stray newline in prune.include-commitment-history flag description  
- docs/gitbook/src/fundamentals/performance-tricks.md: consolidate torrent.download.rate example formatting and update example value to 1024mb
- docs/gitbook/src/get-started/migrating-from-geth.md: fix line wrapping in port configuration descriptions for Geth migration steps

These changes improve readability and consistency across the Gitbook documentation by removing unnecessary line breaks and consolidating multi-line descriptions into single lines.