### PR TITLE
[SharovBot] ci: pin assertoor to v0.0.17 in kurtosis config (release/3.3)

### DIFF
--- a/.github/workflows/kurtosis/regular-assertoor.io
+++ b/.github/workflows/kurtosis/regular-assertoor.io
@@ -18,6 +18,7 @@ additional_services:
 assertoor_params:
   run_stability_check: false
   run_block_proposal_check: true
+  image: ethpandaops/assertoor:v0.0.17
   tests:
     - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/all-opcodes-test.yaml
     - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/blob-transactions-test.yaml


### PR DESCRIPTION
**[SharovBot]**

Fixes kurtosis `assertoor_regular_test` blob-transactions-test failure introduced when `ethpandaops/assertoor:latest` became v0.0.18.

## Root Cause

- **Main branch** explicitly pins `image: ethpandaops/assertoor:v0.0.17` in `.github/workflows/kurtosis/regular-assertoor.io`
- **Release/3.3** had no `image:` field → uses `ethpandaops/assertoor:latest` (the kurtosis ethereum-package default)
- assertoor v0.0.18 was released 2026-02-20 and is now the `latest` tag
- v0.0.18 appears to generate blob transactions in a format incompatible with erigon release/3.3's txpool validation (likely EIP-7594 cell-proof format requiring Osaka activation)
- Result: every blob tx is rejected with `INVALID: blob_versioned_hashes, blobs, commitments and proofs must have equal number`

## Fix

Pin assertoor to `v0.0.17` to match main branch behavior.

## Evidence

- Failing run (release/3.3): https://github.com/erigontech/erigon/actions/runs/22714379326/job/65860223954
- Passing run (main): https://github.com/erigontech/erigon/actions/runs/22714266657/job/65859835774
- Main explicitly uses `ethpandaops/assertoor:v0.0.17`, release/3.3 did not pin it