### PR TITLE
Fix BAL validation: make BalancePath cross-check unconditional

### DIFF
--- a/execution/stagedsync/bal_create.go
+++ b/execution/stagedsync/bal_create.go
@@ -154,11 +154,10 @@ func ProcessBAL(tx kv.TemporalRwTx, h *types.Header, vio *state.VersionedIO, blo
 			return fmt.Errorf("block %d: invalid block access list, hash mismatch: got %s expected %s", blockNum, dbBAL.Hash(), headerBALHash)
 		}
 	}
-	// Only validate computed BAL against header when we have the stored BAL
-	// body. Without it, HasBAL=false on the VersionMap, so the computed BAL
-	// may be inaccurate due to VersionMap mutations during execution.
-	// This limitation goes away once eth/71 delivers BAL bodies via p2p sync.
-	if dbBALBytes != nil && headerBALHash != bal.Hash() {
+	// Always validate computed BAL against header. The BalancePath cross-check
+	// in VersionMap.validateRead ensures deterministic parallel execution even
+	// without a stored BAL body (HasBAL=false), so the computed BAL is accurate.
+	if headerBALHash != bal.Hash() {
 		if dataDir != "" {
 			balDir := filepath.Join(dataDir, "bal")
 			if err := os.MkdirAll(balDir, 0o755); err != nil {

--- a/execution/state/versionmap.go
+++ b/execution/state/versionmap.go
@@ -381,11 +381,11 @@ func (vm *VersionMap) validateRead(txIndex int, addr accounts.Address, path Acco
 					valid = vm.validateRead(txIndex, addr, SelfDestructPath, accounts.StorageKey{}, source,
 						version, checkVersion, traceInvalid, tracePrefix)
 
-					// When BAL is present, AddressPath is NOT pre-populated
-					// but BalancePath IS. If a prior tx created this account,
-					// the BAL will have a BalancePath entry at a lower txIndex.
-					// A nil AddressPath read from storage is then stale.
-					if valid == VersionValid && vm.HasBAL {
+					// If a prior tx created this account, BalancePath will
+					// have an entry at a lower txIndex (from BAL pre-population
+					// or worker flush). A nil AddressPath read from storage
+					// is then stale and must be invalidated.
+					if valid == VersionValid {
 						balRR := vm.Read(addr, BalancePath, accounts.NilKey, txIndex)
 						if balRR.Status() == MVReadResultDone {
 							valid = VersionInvalid

--- a/execution/state/versionmap_test.go
+++ b/execution/state/versionmap_test.go
@@ -373,9 +373,9 @@ func TestValidateRead_NoHasBAL_InvalidatesAllPaths(t *testing.T) {
 // TestValidateRead_HasBAL_AddressPathCrossCheckWithBalancePath verifies that
 // when HasBAL is true and an AddressPath read returns MVReadResultNone (no
 // entry in the version map), but BalancePath has a MVReadResultDone entry
-// (from BAL pre-population at a lower txIndex), the AddressPath read is
-// invalidated. This catches the case where a prior tx created the account,
-// reflected in the BAL as a BalancePath entry.
+// (from BAL pre-population), the AddressPath read is invalidated.
+// See also TestValidateRead_NoHasBAL_AddressPathCrossCheckWithBalancePath
+// for the same check without HasBAL (worker flush case).
 func TestValidateRead_HasBAL_AddressPathCrossCheckWithBalancePath(t *testing.T) {
 	t.Parallel()
 
@@ -409,6 +409,46 @@ func TestValidateRead_HasBAL_AddressPathCrossCheckWithBalancePath(t *testing.T) 
 	valid := vm.ValidateVersion(2, io, checkVersionEqual, false, "")
 	require.Equal(t, VersionInvalid, valid,
 		"AddressPath read should be invalidated when BAL has a BalancePath entry from a prior tx (account may have been created)")
+}
+
+// TestValidateRead_NoHasBAL_AddressPathCrossCheckWithBalancePath verifies that
+// even without HasBAL (no stored BAL body, e.g. p2p blocks), the BalancePath
+// cross-check still catches stale AddressPath reads. This is the key fix:
+// worker flushes create BalancePath entries that must be checked regardless
+// of whether BAL pre-population was used.
+func TestValidateRead_NoHasBAL_AddressPathCrossCheckWithBalancePath(t *testing.T) {
+	t.Parallel()
+
+	addr := getAddress(42)
+	checkVersionEqual := func(readVersion, writeVersion Version) VersionValidity {
+		if readVersion == writeVersion {
+			return VersionValid
+		}
+		return VersionInvalid
+	}
+
+	vm := NewVersionMap(nil) // HasBAL = false
+	require.False(t, vm.HasBAL)
+
+	// A concurrent worker flushed a BalancePath entry at txIndex 0
+	// (simulating account creation by a prior tx).
+	vm.Write(addr, BalancePath, accounts.NilKey, Version{TxIndex: 0, Incarnation: 1}, valueFor(0, 1), true)
+
+	// No AddressPath entry exists.
+	// Tx 2 read AddressPath from storage during execution (got "account doesn't exist").
+	io := NewVersionedIO(2)
+	rs := ReadSet{}
+	rs.Set(VersionedRead{
+		Address: addr,
+		Path:    AddressPath,
+		Source:  StorageRead,
+		Version: Version{TxIndex: 2, Incarnation: 1},
+	})
+	io.RecordReads(Version{TxIndex: 2, Incarnation: 1}, rs)
+
+	valid := vm.ValidateVersion(2, io, checkVersionEqual, false, "")
+	require.Equal(t, VersionInvalid, valid,
+		"without HasBAL, AddressPath read should still be invalidated when BalancePath has an entry from a worker flush")
 }
 
 func BenchmarkWriteTimeSameLocationDifferentTxIdx(b *testing.B) {


### PR DESCRIPTION
## Summary

Follow-up to #19628. Two fixes for deterministic BAL computation without a stored BAL body (p2p blocks before eth/71):

- **Remove `vm.HasBAL` guard from BalancePath cross-check** (`versionmap.go`): The cross-check was only running when a stored BAL body was available for pre-population. Without it, stale "account doesn't exist" reads passed validation when a concurrent worker had already created the account via a BalancePath flush. This caused phantom accounts in the computed BAL, producing hash mismatches.

- **Always validate computed BAL against header** (`bal_create.go`): Remove the `dbBALBytes != nil` guard so the computed BAL hash is validated even for p2p blocks. With the cross-check fix above, parallel execution is deterministic regardless of whether BAL pre-population was used.

## Root Cause

When TX N creates an account and TX M (M > N) reads the account as non-existent, the stale read must be invalidated. The BalancePath cross-check catches this: if BalancePath has an entry at a lower txIndex (from BAL pre-population **or worker flush**), the AddressPath read is stale.

The bug was that the cross-check was gated behind `vm.HasBAL`, so it only worked with BAL pre-population — not with worker flushes (the `HasBAL=false` case).

## Test plan

- [x] New unit test: `TestValidateRead_NoHasBAL_AddressPathCrossCheckWithBalancePath`
- [x] All existing `TestValidateRead_*` tests pass
- [x] `make lint` clean
- [x] Verified on bal-devnet-2: 40K+ p2p blocks with zero BAL mismatches (previously failed at block 8997)

🤖 Generated with [Claude Code](https://claude.com/claude-code)