### PR TITLE
Cherry-pick #18843: Fixed seg_paged_rw to use correct config parameter for page size

### DIFF
--- a/db/seg/seg_paged_rw.go
+++ b/db/seg/seg_paged_rw.go
@@ -244,10 +244,10 @@ func (g *PagedReader) Skip() (uint64, int) {
 
 var workers = dbg.EnvInt("PAGED_WRITER_WORKERS", 1)
 
-func NewPagedWriter(ctx context.Context, parent CompressorI, compressionEnabled bool) *PagedWriter {
+func NewPagedWriter(ctx context.Context, parent CompressorI, pageSize int, compressionEnabled bool) *PagedWriter {
 	pw := &PagedWriter{
 		parent:             parent,
-		pageSize:           parent.GetValuesOnCompressedPage(),
+		pageSize:           pageSize,
 		compressionEnabled: compressionEnabled,
 		ctx:                ctx,
 		numWorkers:         workers, //TODO: accept it as a parameter in next PR

--- a/db/seg/seg_paged_rw_test.go
+++ b/db/seg/seg_paged_rw_test.go
@@ -36,14 +36,14 @@ func prepareLoremDictOnPagedWriter(t *testing.T, pageSize int, pageCompression b
 	logger, require := log.New(), require.New(t)
 	tmpDir := t.TempDir()
 	file := filepath.Join(tmpDir, "compressed1")
-	cfg := DefaultCfg.WithValuesOnCompressedPage(pageSize)
+	cfg := DefaultCfg
 	cfg.MinPatternScore = 1
 	cfg.Workers = 1
 	c, err := NewCompressor(context.Background(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
 	require.NoError(err)
 	defer c.Close()
 
-	p := NewPagedWriter(t.Context(), NewWriter(c, CompressNone), pageCompression)
+	p := NewPagedWriter(t.Context(), NewWriter(c, CompressNone), pageSize, pageCompression)
 	for k, w := range loremStrings {
 		key := fmt.Sprintf("key %d", k)
 		val := fmt.Sprintf("%s %d", w, k)
@@ -118,7 +118,7 @@ func (w *multyBytesWriter) GetValuesOnCompressedPage() int { return w.pageSize }
 func TestPage(t *testing.T) {
 	sampling := 2
 	buf, require := &multyBytesWriter{pageSize: sampling}, require.New(t)
-	w := NewPagedWriter(t.Context(), buf, false)
+	w := NewPagedWriter(t.Context(), buf, sampling, false)
 	for i := 0; i < sampling+1; i++ {
 		k, v := fmt.Sprintf("k %d", i), fmt.Sprintf("v %d", i)
 		require.NoError(w.Add([]byte(k), []byte(v)))
@@ -236,7 +236,7 @@ func TestPagedWriterCRC32Sequential(t *testing.T) {
 
 func BenchmarkName(b *testing.B) {
 	buf := &multyBytesWriter{pageSize: 16}
-	w := NewPagedWriter(b.Context(), buf, false)
+	w := NewPagedWriter(b.Context(), buf, 16, false)
 	for i := 0; i < 16; i++ {
 		w.Add([]byte{byte(i)}, []byte{10 + byte(i)})
 	}

--- a/db/state/history.go
+++ b/db/state/history.go
@@ -871,7 +871,7 @@ func (h *History) dataWriter(ctx context.Context, f *seg.Compressor) *seg.PagedW
 	if !strings.Contains(f.FileName(), ".v") {
 		panic("assert: miss-use " + f.FileName())
 	}
-	return seg.NewPagedWriter(ctx, seg.NewWriter(f, h.Compression), f.GetValuesOnCompressedPage() > 0)
+	return seg.NewPagedWriter(ctx, seg.NewWriter(f, h.Compression), h.HistoryValuesOnCompressedPage, h.HistoryValuesOnCompressedPage > 0)
 }
 func (ht *HistoryRoTx) dataReader(f *seg.Decompressor) *seg.Reader { return ht.h.dataReader(f) }
 func (ht *HistoryRoTx) dataWriter(ctx context.Context, f *seg.Compressor) *seg.PagedWriter {

--- a/db/state/proto_forkable.go
+++ b/db/state/proto_forkable.go
@@ -109,7 +109,8 @@ func (a *ProtoForkable) BuildFile(ctx context.Context, from, to RootNum, db kv.R
 	}
 
 	if !exists {
-		segCfg := seg.DefaultCfg.WithValuesOnCompressedPage(a.cfg.ValuesOnCompressedPage)
+		segCfg := seg.DefaultCfg
+
 		segCfg.Workers = compressionWorkers
 		segCfg.ExpectMetadata = true
 		sn, err := seg.NewCompressor(ctx, "Snapshot "+Registry.Name(a.id), path, a.dirs.Tmp, segCfg, log.LvlTrace, a.logger)
@@ -161,7 +162,7 @@ func (a *ProtoForkable) BuildFile(ctx context.Context, from, to RootNum, db kv.R
 }
 
 func (a *ProtoForkable) DataWriter(ctx context.Context, f *seg.Compressor, compress bool) *seg.PagedWriter {
-	return seg.NewPagedWriter(ctx, seg.NewWriter(f, a.cfg.Compression), compress)
+	return seg.NewPagedWriter(ctx, seg.NewWriter(f, a.cfg.Compression), a.cfg.ValuesOnCompressedPage, compress)
 }
 
 func (a *ProtoForkable) DataReader(f *seg.Decompressor, compress bool) *seg.Reader {


### PR DESCRIPTION
Cherry-pick of #18843 to main.

The original fix was merged to release/3.3 but not to main.

**The Bug:**
- `NewPagedWriter()` was incorrectly getting page size from `parent.GetValuesOnCompressedPage()` (the compressor's config)
- But the compressor's config was being set to `DefaultCfg` without the page size override
- So it was using the wrong (default) page size instead of the domain-specific page size

**The Fix:**
- Changed `NewPagedWriter()` to take `pageSize` as an explicit parameter
- Callers now pass the correct domain-specific page size

**Affected Domains:** rcache and commitment

Original PR: #18843