### PR TITLE
ci: pin windows selfhosted Go version to 1.25 (latest patch)

### DIFF
--- a/.github/workflows/test-all-erigon.yml
+++ b/.github/workflows/test-all-erigon.yml
@@ -161,7 +161,7 @@ jobs:
         if: needs.source-of-changes.outputs.changed_files != 'true'
         uses: actions/setup-go@v6
         with:
-          go-version: '>=1.25'
+          go-version: '1.25'
           cache: false
 
       # "make" already preinstalled:


### PR DESCRIPTION
## Summary

- Changes `go-version: '>=1.25'` to `go-version: '1.25'` in the `tests-windows` job
- `actions/setup-go` resolves `1.25` to the latest 1.25.x patch release, so this stays up to date within the 1.25 minor version
- `>=1.25` would allow Go 1.26+ to be used once released; `1.25` constrains to the 1.25 line

Alternative to #19640.