### PR TITLE
chore: rename Selfdestruct log topic to Burn EIP-7708

### DIFF
--- a/execution/protocol/misc/eip7708.go
+++ b/execution/protocol/misc/eip7708.go
@@ -37,8 +37,8 @@ var (
 	// keccak256('Transfer(address,address,uint256)')
 	EthTransferLogEvent = common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef")
 
-	// keccak256('Selfdestruct(address,uint256)')
-	EthSelfDestructLogEvent = common.HexToHash("0x4bfaba3443c1a1836cd362418edc679fc96cae8449cbefccb6457cdf2c943083")
+	// keccak256('Burn(address,uint256)')
+	EthBurnLogEvent = common.HexToHash("0xcc16f5dbb4873280815c1ee09dbd06736cffcc184412cf7a71a0fdb75d397ca5")
 )
 
 // EthTransferLog creates and ETH transfer log according to EIP-7708.
@@ -56,14 +56,14 @@ func EthTransferLog(from, to common.Address, amount uint256.Int) *types.Log {
 	}
 }
 
-// EthSelfDestructLog creates and ETH self-destruct burn log according to EIP-7708.
+// EthBurnLog creates an ETH burn log according to EIP-7708.
 // Specification: https://eips.ethereum.org/EIPS/eip-7708
-func EthSelfDestructLog(from common.Address, amount uint256.Int) *types.Log {
+func EthBurnLog(from common.Address, amount uint256.Int) *types.Log {
 	amount32 := amount.Bytes32()
 	return &types.Log{
 		Address: params.SystemAddress.Value(),
 		Topics: []common.Hash{
-			EthSelfDestructLogEvent,
+			EthBurnLogEvent,
 			from.Hash(),
 		},
 		Data: amount32[:],
@@ -135,6 +135,6 @@ func LogSelfDestructedAccounts(ibs evmtypes.IntraBlockState, sender accounts.Add
 	})
 	for _, addr := range addrs {
 		bal := combined[addr]
-		ibs.AddLog(EthSelfDestructLog(addr, bal))
+		ibs.AddLog(EthBurnLog(addr, bal))
 	}
 }

--- a/execution/vm/instructions.go
+++ b/execution/vm/instructions.go
@@ -1336,7 +1336,7 @@ func opSelfdestruct6780(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte
 		if self != beneficiaryAddr {
 			ibs.AddLog(misc.EthTransferLog(self.Value(), beneficiaryAddr.Value(), balance))
 		} else if newContract {
-			ibs.AddLog(misc.EthSelfDestructLog(self.Value(), balance))
+			ibs.AddLog(misc.EthBurnLog(self.Value(), balance))
 		}
 	}
 	tracer := evm.Config().Tracer


### PR DESCRIPTION
This PR renames the log topic from Selfdestruct to Burn as defined in the EIP-7708 specification. The new name Burn clearly describes what happens - ETH is permanently removed - instead of referring to the internal opcode used. This makes the API more clear and focused on the result.

Refrence: https://github.com/ethereum/EIPs/pull/11311