### PR TITLE
state: add VersionedIO net-zero detection and selfdestruct write filtering tests

### DIFF
--- a/execution/state/versionedio_test.go
+++ b/execution/state/versionedio_test.go
@@ -24,8 +24,34 @@ import (
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/execution/protocol/params"
+	"github.com/erigontech/erigon/execution/tracing"
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
+
+// minimalStateReader is a no-op StateReader for tests that create fresh accounts.
+// All methods return zero/nil — the IBS will create new empty state objects.
+type minimalStateReader struct{}
+
+func (r *minimalStateReader) ReadAccountData(addr accounts.Address) (*accounts.Account, error) {
+	return nil, nil
+}
+func (r *minimalStateReader) ReadAccountDataForDebug(addr accounts.Address) (*accounts.Account, error) {
+	return nil, nil
+}
+func (r *minimalStateReader) ReadAccountStorage(addr accounts.Address, key accounts.StorageKey) (uint256.Int, bool, error) {
+	return uint256.Int{}, false, nil
+}
+func (r *minimalStateReader) HasStorage(addr accounts.Address) (bool, error) { return false, nil }
+func (r *minimalStateReader) ReadAccountCode(addr accounts.Address) ([]byte, error) {
+	return nil, nil
+}
+func (r *minimalStateReader) ReadAccountCodeSize(addr accounts.Address) (int, error) { return 0, nil }
+func (r *minimalStateReader) ReadAccountIncarnation(addr accounts.Address) (uint64, error) {
+	return 0, nil
+}
+func (r *minimalStateReader) SetTrace(trace bool, tracePrefix string) {}
+func (r *minimalStateReader) Trace() bool                             { return false }
+func (r *minimalStateReader) TracePrefix() string                     { return "" }
 
 // TestAsBlockAccessList_SystemAddressExcludedWithoutChanges verifies that the
 // system address (0xff...fe) is excluded from the BAL when it has no actual
@@ -237,4 +263,161 @@ func TestAsBlockAccessList_NonRevertableOverridesRevertable(t *testing.T) {
 	}
 	require.True(t, found,
 		"system address should be included: non-revertable user access overrides earlier revertable access")
+}
+
+// TestVersionedIO_BalanceNetZeroWriteOmittedFromBAL verifies that a balance
+// write that restores the exact pre-block value (with no intermediate writes)
+// is treated as a net-zero change and omitted from the BAL.
+func TestVersionedIO_BalanceNetZeroWriteOmittedFromBAL(t *testing.T) {
+	t.Parallel()
+
+	addr := accounts.InternAddress(common.HexToAddress("0xaaaa"))
+	initial := *uint256.NewInt(100)
+
+	io := NewVersionedIO(1)
+
+	// System tx reads the pre-block balance (establishes initialBalanceValue).
+	reads := ReadSet{}
+	reads.Set(VersionedRead{Address: addr, Path: BalancePath, Val: initial})
+	io.RecordReads(Version{TxIndex: -1}, reads)
+
+	// User tx writes the exact same balance back — net-zero, should be omitted.
+	io.RecordWrites(Version{TxIndex: 0}, VersionedWrites{
+		&VersionedWrite{Address: addr, Path: BalancePath, Version: Version{TxIndex: 0}, Val: initial},
+	})
+
+	bal := io.AsBlockAccessList()
+	for _, ac := range bal {
+		if ac.Address == addr {
+			require.Empty(t, ac.BalanceChanges,
+				"net-zero balance write (matches pre-block balance, no intermediates) must not appear in BAL")
+		}
+	}
+}
+
+// TestVersionedIO_BalanceRestoreAfterIntermediateIsRecorded verifies that
+// restoring a balance to the pre-block (initial) value IS recorded in the BAL
+// when intermediate balance changes exist. The restore write is needed so that
+// parallel executors observing the tx see the correct value.
+func TestVersionedIO_BalanceRestoreAfterIntermediateIsRecorded(t *testing.T) {
+	t.Parallel()
+
+	addr := accounts.InternAddress(common.HexToAddress("0xbbbb"))
+	initial := *uint256.NewInt(100)
+	intermediate := *uint256.NewInt(200)
+
+	io := NewVersionedIO(2)
+
+	// System tx establishes pre-block balance.
+	reads := ReadSet{}
+	reads.Set(VersionedRead{Address: addr, Path: BalancePath, Val: initial})
+	io.RecordReads(Version{TxIndex: -1}, reads)
+
+	// tx0: intermediate write (changes balance away from initial).
+	io.RecordWrites(Version{TxIndex: 0}, VersionedWrites{
+		&VersionedWrite{Address: addr, Path: BalancePath, Version: Version{TxIndex: 0}, Val: intermediate},
+	})
+
+	// tx1: restores initial balance — must be recorded because an intermediate exists.
+	io.RecordWrites(Version{TxIndex: 1}, VersionedWrites{
+		&VersionedWrite{Address: addr, Path: BalancePath, Version: Version{TxIndex: 1}, Val: initial},
+	})
+
+	bal := io.AsBlockAccessList()
+
+	found := false
+	for _, ac := range bal {
+		if ac.Address == addr {
+			found = true
+			require.Len(t, ac.BalanceChanges, 2,
+				"both the intermediate write and the restore-to-initial write must appear in BAL")
+		}
+	}
+	require.True(t, found, "address must appear in BAL")
+}
+
+// TestVersionedIO_StaleBalanceReadAfterWriteDoesNotCorruptNoOpCheck verifies
+// that a stale BalancePath read arriving after a write (e.g. from a cached DB
+// value that pre-dates the write) does not override balanceValue and cause a
+// subsequent identical write to be incorrectly recorded as a new change.
+func TestVersionedIO_StaleBalanceReadAfterWriteDoesNotCorruptNoOpCheck(t *testing.T) {
+	t.Parallel()
+
+	addr := accounts.InternAddress(common.HexToAddress("0xcccc"))
+	io := NewVersionedIO(2)
+
+	// tx0: writes balance=200.
+	io.RecordWrites(Version{TxIndex: 0}, VersionedWrites{
+		&VersionedWrite{Address: addr, Path: BalancePath, Version: Version{TxIndex: 0}, Val: *uint256.NewInt(200)},
+	})
+
+	// tx1: stale DB read of balance=100 (DB value predates tx0's write).
+	reads := ReadSet{}
+	reads.Set(VersionedRead{Address: addr, Path: BalancePath, Val: *uint256.NewInt(100)})
+	io.RecordReads(Version{TxIndex: 1}, reads)
+
+	// tx1: writes balance=200 again — same as tx0, a true no-op.
+	io.RecordWrites(Version{TxIndex: 1}, VersionedWrites{
+		&VersionedWrite{Address: addr, Path: BalancePath, Version: Version{TxIndex: 1}, Val: *uint256.NewInt(200)},
+	})
+
+	bal := io.AsBlockAccessList()
+
+	found := false
+	for _, ac := range bal {
+		if ac.Address == addr {
+			found = true
+			require.Len(t, ac.BalanceChanges, 1,
+				"tx1's write of 200 is a no-op (same as tx0's 200); stale read must not cause a spurious second entry")
+			// blockAccessIndex = TxIndex+1, so tx0 (TxIndex=0) → Index=1.
+			require.Equal(t, uint16(1), ac.BalanceChanges[0].Index,
+				"the single balance change must be from tx0 (blockAccessIndex=1)")
+		}
+	}
+	require.True(t, found, "address must appear in BAL (tx0's write is a real change)")
+}
+
+// TestIBSVersionedWrites_SelfdestructRetainsBalanceDropsOtherPaths verifies
+// that IntraBlockState.VersionedWrites retains SelfDestructPath, BalancePath
+// (including non-zero residual balances — EIP-7708 case 2), and IncarnationPath
+// after selfdestruct, and drops NoncePath/CodePath which selfdestruct resets.
+func TestIBSVersionedWrites_SelfdestructRetainsBalanceDropsOtherPaths(t *testing.T) {
+	t.Parallel()
+
+	addr := accounts.InternAddress(common.HexToAddress("0xdead"))
+	ibs := NewWithVersionMap(&minimalStateReader{}, NewVersionMap(nil))
+	ibs.SetTxContext(1, 0)
+
+	// Establish nonce and code before selfdestruct — these should be dropped.
+	require.NoError(t, ibs.SetNonce(addr, 5))
+	require.NoError(t, ibs.SetCode(addr, []byte{0x60, 0x00}))
+	require.NoError(t, ibs.SetBalance(addr, *uint256.NewInt(0), tracing.BalanceChangeUnspecified))
+
+	// Selfdestruct: records SelfDestructPath=true, IncarnationPath, BalancePath=0.
+	destructed, err := ibs.Selfdestruct(addr)
+	require.NoError(t, err)
+	require.True(t, destructed)
+
+	// Simulate a non-zero post-selfdestruct balance write (EIP-7708 case 2:
+	// value sent to a selfdestructed address in the same block). This overwrites
+	// the zero-balance from Selfdestruct with a non-zero value that must be kept.
+	require.NoError(t, ibs.SetBalance(addr, *uint256.NewInt(500), tracing.BalanceChangeUnspecified))
+
+	writes := ibs.VersionedWrites(false)
+
+	pathSet := map[AccountPath]bool{}
+	for _, vw := range writes {
+		if vw.Address == addr {
+			pathSet[vw.Path] = true
+		}
+	}
+
+	// Retained paths.
+	require.True(t, pathSet[SelfDestructPath], "SelfDestructPath must be retained")
+	require.True(t, pathSet[IncarnationPath], "IncarnationPath must be retained")
+	require.True(t, pathSet[BalancePath], "BalancePath (non-zero residual) must be retained")
+
+	// Dropped paths — selfdestruct resets nonce and code, so they must not appear.
+	require.False(t, pathSet[NoncePath], "NoncePath must be dropped after selfdestruct")
+	require.False(t, pathSet[CodePath], "CodePath must be dropped after selfdestruct")
 }


### PR DESCRIPTION
## Summary

Tests requested in the [PR #19668](https://github.com/erigontech/erigon/pull/19668) review, covering the two BAL fixes: net-zero balance detection and selfdestruct write filtering.

**New tests:**
- `TestVersionedIO_BalanceNetZeroWriteOmittedFromBAL` — balance write that restores the exact pre-block value with no intermediate writes is omitted from the BAL (net-zero detection via `initialBalanceValue`)
- `TestVersionedIO_BalanceRestoreAfterIntermediateIsRecorded` — restore-to-initial write IS recorded when an intermediate balance change exists (correct: parallel executors need to observe the value)
- `TestVersionedIO_StaleBalanceReadAfterWriteDoesNotCorruptNoOpCheck` — stale DB read arriving after a write does not override `balanceValue` and produce a spurious second BAL entry
- `TestIBSVersionedWrites_SelfdestructRetainsBalanceDropsOtherPaths` — after selfdestruct, `BalancePath`/`SelfDestructPath`/`IncarnationPath` are retained and `NoncePath`/`CodePath` are dropped; covers EIP-7708 case 2 (non-zero residual balance)

Also adds `minimalStateReader` helper (no-op `StateReader`) for IBS tests that create fresh accounts from zero state.

## Test plan

- [x] All 9 tests in `execution/state` pass: `go test ./execution/state/... -run "TestVersionedIO_|TestIBSVersionedWrites_|TestAsBlockAccessList_"`
- [x] Only `execution/state/versionedio_test.go` is modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)