### PR TITLE
feat: finalized/safe block tags for Arbitrum

### DIFF
--- a/arb/l1sync/config.go
+++ b/arb/l1sync/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	StartL1Block       uint64
 	L1BlocksPerRequest uint64
 	ChainID            *big.Int
+	GenesisBlockNumber uint64
 	SequencerInboxAddr common.Address
 	BridgeAddr         common.Address
 }

--- a/arb/l1sync/finality.go
+++ b/arb/l1sync/finality.go
@@ -1,0 +1,131 @@
+package l1sync
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/rawdb"
+	"github.com/erigontech/erigon/rpc"
+	"github.com/erigontech/nitro-erigon/arbutil"
+)
+
+func (s *L1SyncService) addRecentBatch(info batchInfo) {
+	s.recentBatches = append(s.recentBatches, info)
+	if len(s.recentBatches) > maxRecentBatches {
+		s.recentBatches = s.recentBatches[len(s.recentBatches)-maxRecentBatches:]
+	}
+}
+
+// loadRecentBatches loads the last N batches from DB into the in-memory buffer on startup.
+func (s *L1SyncService) loadRecentBatches(ctx context.Context, lastBatchSeqNum uint64) {
+	start := uint64(0)
+	if lastBatchSeqNum >= maxRecentBatches {
+		start = lastBatchSeqNum - maxRecentBatches + 1
+	}
+
+	_ = s.db.View(ctx, func(tx kv.Tx) error {
+		for seq := start; seq <= lastBatchSeqNum; seq++ {
+			_, l1Block, cumMsgCount, _, err := readBatch(tx, seq)
+			if err != nil {
+				continue
+			}
+			s.recentBatches = append(s.recentBatches, batchInfo{
+				seqNum:             seq,
+				l1Block:            l1Block,
+				cumulativeMsgCount: cumMsgCount,
+			})
+		}
+		// Set cumulative msg count from latest batch
+		if len(s.recentBatches) > 0 {
+			s.cumulativeMsgCount = s.recentBatches[len(s.recentBatches)-1].cumulativeMsgCount
+		}
+		return nil
+	})
+
+	s.logger.Info("loaded recent batches for finality", "count", len(s.recentBatches))
+}
+
+// updateFinality queries L1 for finalized and safe block numbers, maps them to L2 blocks
+// via the in-memory batch buffer, and writes the forkchoice entries so that
+// eth_getBlockByNumber("finalized") and ("safe") work.
+func (s *L1SyncService) updateFinality(ctx context.Context) error {
+	if len(s.recentBatches) == 0 {
+		return nil
+	}
+
+	// Query L1 finalized and safe block numbers
+	finalizedHeader, err := s.l1Client.HeaderByNumber(ctx, big.NewInt(int64(rpc.FinalizedBlockNumber)))
+	if err != nil {
+		return fmt.Errorf("failed to get L1 finalized block: %w", err)
+	}
+	safeHeader, err := s.l1Client.HeaderByNumber(ctx, big.NewInt(int64(rpc.SafeBlockNumber)))
+	if err != nil {
+		return fmt.Errorf("failed to get L1 safe block: %w", err)
+	}
+
+	l1Finalized := finalizedHeader.Number.Uint64()
+	l1Safe := safeHeader.Number.Uint64()
+
+	tx, err := s.db.BeginRw(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin DB transaction for finality: %w", err)
+	}
+	defer tx.Rollback()
+
+	updated := false
+
+	if hash, ok := s.resolveL2BlockForL1Block(tx, l1Finalized); ok {
+		rawdb.WriteForkchoiceFinalized(tx, hash)
+		updated = true
+		s.logger.Debug("updated finalized block", "l1Finalized", l1Finalized, "l2Hash", hash)
+	}
+
+	if hash, ok := s.resolveL2BlockForL1Block(tx, l1Safe); ok {
+		rawdb.WriteForkchoiceSafe(tx, hash)
+		updated = true
+		s.logger.Debug("updated safe block", "l1Safe", l1Safe, "l2Hash", hash)
+	}
+
+	if updated {
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("failed to commit finality update: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// resolveL2BlockForL1Block finds the last batch posted at or before the given L1 block,
+// converts its cumulative message count to an L2 block number, and returns the L2 block hash.
+func (s *L1SyncService) resolveL2BlockForL1Block(tx kv.Tx, l1Block uint64) (common.Hash, bool) {
+	msgCount := s.getMsgCountAtL1Block(l1Block)
+	if msgCount == 0 {
+		return common.Hash{}, false
+	}
+
+	l2BlockNum := arbutil.MessageCountToBlockNumber(arbutil.MessageIndex(msgCount), s.config.GenesisBlockNumber)
+	if l2BlockNum < 0 {
+		return common.Hash{}, false
+	}
+
+	hash, err := rawdb.ReadCanonicalHash(tx, uint64(l2BlockNum))
+	if err != nil || hash == (common.Hash{}) {
+		return common.Hash{}, false
+	}
+
+	return hash, true
+}
+
+// getMsgCountAtL1Block walks the in-memory batch buffer backward to find
+// the last batch with l1Block <= the given L1 block number.
+func (s *L1SyncService) getMsgCountAtL1Block(l1Block uint64) uint64 {
+	for i := len(s.recentBatches) - 1; i >= 0; i-- {
+		if s.recentBatches[i].l1Block <= l1Block {
+			return s.recentBatches[i].cumulativeMsgCount
+		}
+	}
+	return 0
+}

--- a/arb/l1sync/l1_sync.go
+++ b/arb/l1sync/l1_sync.go
@@ -16,6 +16,18 @@ import (
 	"github.com/erigontech/nitro-erigon/util/headerreader"
 )
 
+// batchInfo holds metadata about a processed batch for in-memory finality lookups.
+type batchInfo struct {
+	seqNum             uint64
+	l1Block            uint64
+	cumulativeMsgCount uint64
+}
+
+// maxRecentBatches is the number of recent batches kept in memory for finality lookups.
+// L1 finality is ~64 blocks (~13min), batches are posted every few minutes,
+// so 128 batches is more than enough.
+const maxRecentBatches = 128
+
 type L1SyncService struct {
 	config         *Config
 	sequencerInbox *arbnode.SequencerInbox
@@ -27,7 +39,11 @@ type L1SyncService struct {
 	logger         log.Logger
 
 	delayedMessagesRead uint64
+	cumulativeMsgCount  uint64
 	chunkSize           uint64
+
+	// recentBatches holds recent batch metadata for finality lookups (sorted by seqNum ascending)
+	recentBatches []batchInfo
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -111,13 +127,15 @@ func (s *L1SyncService) fetchDelayedMessagesInRange(ctx context.Context, fromL1B
 func (s *L1SyncService) Start(ctx context.Context) {
 	s.ctx, s.cancel = context.WithCancel(ctx)
 
-	// Load delayedMessagesRead from DB (from the last message of the last processed batch)
+	// Load state from DB
 	lastBatch, _, err := s.GetProgress(ctx)
 	if err == nil && lastBatch > 0 {
 		dmr, err := s.getLastDelayedMessagesRead(ctx, lastBatch)
 		if err == nil {
 			s.delayedMessagesRead = dmr
 		}
+		// Load recent batches into memory for finality lookups
+		s.loadRecentBatches(ctx, lastBatch)
 	}
 
 	s.wg.Add(1)
@@ -145,6 +163,11 @@ func (s *L1SyncService) pollLoop() {
 		pollMore, err := s.pollOnce(s.ctx)
 		if err != nil {
 			s.logger.Warn("L1 sync poll error", "err", err)
+		}
+
+		// Update finalized/safe block tags after each poll (best-effort)
+		if err := s.updateFinality(s.ctx); err != nil {
+			s.logger.Warn("failed to update finality", "err", err)
 		}
 
 		if pollMore {
@@ -256,7 +279,7 @@ func (s *L1SyncService) pollOnce(ctx context.Context) (pollMore bool, err error)
 
 		fromL1Block = toL1Block + 1
 
-		// Log progress every 10 seconds
+		// Log progress and update finality every 10 seconds
 		if time.Since(lastLogTime) > 10*time.Second {
 			elapsed := time.Since(pollStart)
 			l1Blocks := fromL1Block - startL1Block
@@ -271,8 +294,14 @@ func (s *L1SyncService) pollOnce(ctx context.Context) (pollMore bool, err error)
 				"chunkSize", s.chunkSize,
 			)
 			lastLogTime = time.Now()
+
+			// Update finalized/safe block tags (best-effort)
+			if err := s.updateFinality(ctx); err != nil {
+				s.logger.Warn("failed to update finality", "err", err)
+			}
 		}
 	}
+
 	return false, nil
 }
 

--- a/arb/l1sync/processor.go
+++ b/arb/l1sync/processor.go
@@ -110,11 +110,10 @@ func (s *L1SyncService) ProcessBatch(ctx context.Context, seqNum uint64, data []
 	}
 	defer tx.Rollback()
 
-	// Store raw batch data with msg count: value = uint64(msgCount) + rawData
-	batchVal := make([]byte, 8+len(data))
-	binary.BigEndian.PutUint64(batchVal[:8], uint64(len(messages)))
-	copy(batchVal[8:], data)
-	if err := tx.Put(kv.ArbL1SyncBatch, uint64Key(seqNum), batchVal); err != nil {
+	// Compute cumulative message count
+	cumulativeMsgCount := s.cumulativeMsgCount + uint64(len(messages))
+
+	if err := storeBatch(tx, seqNum, l1BlockNumber, cumulativeMsgCount, data, uint64(len(messages))); err != nil {
 		return fmt.Errorf("failed to store batch %d: %w", seqNum, err)
 	}
 
@@ -154,10 +153,18 @@ func (s *L1SyncService) ProcessBatch(ctx context.Context, seqNum uint64, data []
 		return fmt.Errorf("failed to commit batch %d: %w", seqNum, err)
 	}
 
-	// Update in-memory delayedMessagesRead from the last message of this batch
+	// Update in-memory state
+	s.cumulativeMsgCount = cumulativeMsgCount
 	if len(messages) > 0 {
 		s.delayedMessagesRead = messages[len(messages)-1].DelayedMessagesRead
 	}
+
+	// Track batch in memory for finality lookups
+	s.addRecentBatch(batchInfo{
+		seqNum:             seqNum,
+		l1Block:            l1BlockNumber,
+		cumulativeMsgCount: cumulativeMsgCount,
+	})
 
 	s.logger.Info("batch processed and stored", "batchSeqNum", seqNum, "messages", len(messages), "l1Block", l1BlockNumber)
 	return nil
@@ -168,15 +175,10 @@ func (s *L1SyncService) ProcessBatch(ctx context.Context, seqNum uint64, data []
 func (s *L1SyncService) getLastDelayedMessagesRead(ctx context.Context, batchSeqNum uint64) (uint64, error) {
 	var result uint64
 	err := s.db.View(ctx, func(tx kv.Tx) error {
-		// Get msg count from the batch entry
-		val, e := tx.GetOne(kv.ArbL1SyncBatch, uint64Key(batchSeqNum))
+		msgCount, _, _, _, e := readBatch(tx, batchSeqNum)
 		if e != nil {
 			return e
 		}
-		if val == nil || len(val) < 8 {
-			return nil
-		}
-		msgCount := binary.BigEndian.Uint64(val[:8])
 		if msgCount == 0 {
 			return nil
 		}
@@ -214,16 +216,9 @@ func (s *L1SyncService) GetProgress(ctx context.Context) (lastBatchSeqNum uint64
 
 func (s *L1SyncService) GetStoredBatch(ctx context.Context, seqNum uint64) (data []byte, msgCount uint64, err error) {
 	err = s.db.View(ctx, func(tx kv.Tx) error {
-		val, e := tx.GetOne(kv.ArbL1SyncBatch, uint64Key(seqNum))
-		if e != nil {
-			return e
-		}
-		if val == nil || len(val) < 8 {
-			return fmt.Errorf("batch %d not found", seqNum)
-		}
-		msgCount = binary.BigEndian.Uint64(val[:8])
-		data = val[8:]
-		return nil
+		var e error
+		msgCount, _, _, data, e = readBatch(tx, seqNum)
+		return e
 	})
 	return
 }
@@ -330,6 +325,36 @@ func createNewHeader(prevHeader *types.Header, l1info *L1Info) *types.Header {
 		Nonce:       [8]byte{}, // Filled in later; post-merge Ethereum will require this to be zero
 	}
 	return header
+}
+
+// --- batch storage helpers ---
+
+// storeBatch writes batch data to DB.
+// Value format: uint64(msgCount) + uint64(l1BlockNumber) + uint64(cumulativeMsgCount) + rawData
+func storeBatch(tx kv.RwTx, seqNum, l1BlockNumber, cumulativeMsgCount uint64, data []byte, msgCount uint64) error {
+	batchVal := make([]byte, 24+len(data))
+	binary.BigEndian.PutUint64(batchVal[:8], msgCount)
+	binary.BigEndian.PutUint64(batchVal[8:16], l1BlockNumber)
+	binary.BigEndian.PutUint64(batchVal[16:24], cumulativeMsgCount)
+	copy(batchVal[24:], data)
+	return tx.Put(kv.ArbL1SyncBatch, uint64Key(seqNum), batchVal)
+}
+
+// readBatch reads batch data from DB. Returns all metadata and raw data.
+func readBatch(tx kv.Tx, seqNum uint64) (msgCount, l1Block, cumulativeMsgCount uint64, data []byte, err error) {
+	val, err := tx.GetOne(kv.ArbL1SyncBatch, uint64Key(seqNum))
+	if err != nil {
+		return 0, 0, 0, nil, err
+	}
+	if val == nil || len(val) < 24 {
+		return 0, 0, 0, nil, fmt.Errorf("batch %d not found", seqNum)
+	}
+	msgCount = binary.BigEndian.Uint64(val[:8])
+	l1Block = binary.BigEndian.Uint64(val[8:16])
+	cumulativeMsgCount = binary.BigEndian.Uint64(val[16:24])
+	data = make([]byte, len(val)-24)
+	copy(data, val[24:])
+	return
 }
 
 // --- delayed message helpers ---


### PR DESCRIPTION
## Summary
- Extend `ArbL1SyncBatch` value format to include L1 block number and cumulative message count
- Add in-memory ring buffer of recent batches for efficient finality lookups
- Query L1 finalized/safe block numbers, map back to L2 blocks via batch metadata, write forkchoice entries
- `eth_getBlockByNumber("finalized")` and `("safe")` now return valid blocks

Depends on #19359 and #19689

issue https://github.com/erigontech/erigon/issues/19184