### PR TITLE
[release/3.4] fix(history): reset page counter on recsplit collision retry in buildVI

### DIFF
--- a/db/state/history.go
+++ b/db/state/history.go
@@ -280,11 +280,12 @@ func (h *History) buildVI(ctx context.Context, historyIdxPath string, hist, efHi
 	seq := &multiencseq.SequenceReader{}
 	it := &multiencseq.SequenceIterator{}
 
-	i := 0
 	for {
 		histReader.Reset(0)
 		iiReader.Reset(0)
 		rs.SetProgress(p)
+
+		i := 0
 
 		valOffset = 0
 		for iiReader.HasNext() {


### PR DESCRIPTION
Cherry-pick of #19695 to release/3.4

---

The counter 'i' used to track page offsets in paged history files was declared outside the retry loop. When a recsplit collision occurred and the loop retried, 'i' retained its value from the previous iteration, causing incorrect page offset tracking in the .vi index.

Fix: Move `i := 0` inside the retry loop so it's reset on each attempt.