### PR TITLE
snapcfg: lazy-parse EmbeddedWebseeds, only parse the chain in use

### DIFF
--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -272,7 +272,7 @@ func Downloader(cmd *cobra.Command, logger log.Logger) error {
 	version := "erigon: " + version.VersionWithCommit(version.GitCommit)
 
 	webseedsList := common.CliString2Array(cobraFlagValues.webseeds)
-	if known, ok := snapcfg.GetKnownWebseeds(chain); ok {
+	if known, ok := snapcfg.GetEmbeddedWebseeds(chain); ok {
 		webseedsList = append(webseedsList, known...)
 	}
 	if seedbox {
@@ -540,7 +540,7 @@ var torrentMagnet = &cobra.Command{
 func manifestVerify(ctx context.Context, logger log.Logger) error {
 	webseedsList := common.CliString2Array(cobraFlagValues.webseeds)
 	if len(webseedsList) == 0 { // fallback to default if exact list not passed
-		if known, ok := snapcfg.GetKnownWebseeds(chain); ok {
+		if known, ok := snapcfg.GetEmbeddedWebseeds(chain); ok {
 			for _, s := range known {
 				//TODO: enable validation of this buckets also. skipping to make CI useful.
 				if strings.Contains(s, "erigon2-v2") {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2042,7 +2042,7 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 			// Unfortunately we don't take webseed URL here in the native format.
 			webseedsList = common.CliString2Array(ctx.String(WebSeedsFlag.Name))
 		} else {
-			if known, ok := snapcfg.GetKnownWebseeds(chain); ok {
+			if known, ok := snapcfg.GetEmbeddedWebseeds(chain); ok {
 				webseedsList = append(webseedsList, known...)
 			}
 		}

--- a/db/downloader/webseeds/verify.go
+++ b/db/downloader/webseeds/verify.go
@@ -49,7 +49,7 @@ func Verify(
 		return
 	}
 	allPreverified := snapcfg.GetAllCurrentPreverified()
-	chains := selectChains(targetChain, snapcfg.KnownWebseedsRaw)
+	chains := selectChains(targetChain, snapcfg.EmbeddedWebseedsRaw)
 	if len(chains) == 0 {
 		err = errors.New("no matching chains")
 		return
@@ -78,7 +78,7 @@ func Verify(
 	for _, chain := range chains {
 		// Shift left?
 		//
-		webseeds, _ := snapcfg.GetKnownWebseeds(chain)
+		webseeds, _ := snapcfg.GetEmbeddedWebseeds(chain)
 		var baseUrl string
 		err := errors.New("no valid webseeds")
 		for _, webseed := range webseeds {

--- a/db/snapcfg/util.go
+++ b/db/snapcfg/util.go
@@ -526,8 +526,8 @@ func KnownCfgOrDevnet(networkName string) *Cfg {
 	return cfg
 }
 
-// KnownWebseedsRaw holds the unparsed embedded webseed TOML bytes per chain.
-var KnownWebseedsRaw = map[string][]byte{
+// EmbeddedWebseedsRaw holds the unparsed embedded webseed TOML bytes per chain.
+var EmbeddedWebseedsRaw = map[string][]byte{
 	networkname.Mainnet:    webseed.Mainnet,
 	networkname.Sepolia:    webseed.Sepolia,
 	networkname.Amoy:       webseed.Amoy,
@@ -538,9 +538,9 @@ var KnownWebseedsRaw = map[string][]byte{
 	networkname.Bloatnet:   webseed.Bloatnet,
 }
 
-// GetKnownWebseeds parses and returns the webseed URLs for a single chain.
-func GetKnownWebseeds(chain string) ([]string, bool) {
-	raw, ok := KnownWebseedsRaw[chain]
+// GetEmbeddedWebseeds parses and returns the webseed URLs for a single chain.
+func GetEmbeddedWebseeds(chain string) ([]string, bool) {
+	raw, ok := EmbeddedWebseedsRaw[chain]
 	if !ok {
 		return nil, false
 	}


### PR DESCRIPTION
Follow-up to #19641 — step 2/N towards simplifying TOML reading at startup.

## Summary

- **Lazy-parse webseed TOML**: instead of parsing all 8 chains' webseed TOML at init time, store raw bytes in `EmbeddedWebseedsRaw` and parse on demand via `GetEmbeddedWebseeds(chain)` — only the chain actually in use gets parsed.
- **Remove no-op re-assignment**: `LoadRemotePreverified` was redundantly re-building the same `KnownWebseeds` map; removed.
- **Inline `webseedsParse`**: folded into its sole caller `GetEmbeddedWebseeds`.
- **Rename `KnownWebseeds` → `EmbeddedWebseeds`**: clearer naming — `EmbeddedWebseedsRaw` for the raw bytes map, `GetEmbeddedWebseeds()` for parsed access.

---

~~**TODO**: cherry-pick to `release/3.4` after merge.~~ **Done**: #19727