### PR TITLE
cmd/utils/app: delete erigondb.toml.torrent during step-rebase

### DIFF
--- a/cmd/utils/app/step_cmd.go
+++ b/cmd/utils/app/step_cmd.go
@@ -111,9 +111,11 @@ func stepRebase(cliCtx *cli.Context) error {
 	dels = append(dels, idxTorrents...)
 
 	// include whole chaindata directory for deletion
-	dels = append(dels, dirs.Chaindata)
+	dels = append(dels, dirs.Chaindata) //nolint:gocritic
+
 	// include erigondb.toml.torrent which is invalidated by the rebase
 	dels = append(dels, filepath.Join(dirs.Snap, "erigondb.toml.torrent"))
+
 	for _, f := range dels {
 		fmt.Printf("D: %s\n", f)
 	}


### PR DESCRIPTION
## Summary
- `erigon seg step-rebase` renames snapshot data files, invalidating existing torrent metadata
- `.torrent` files in subdirectories (domain/, history/, accessor/, idx/) were already deleted, but `erigondb.toml.torrent` in the snapshots root was missed
- Add it to the deletion list

## Test evidence (hoodi datadir, step 390625 → 78125)

**BEFORE rebase** — file exists:
```
-rw-r--r--  1 wmitsuda  wheel  293 Feb 18 22:19 .../snapshots/erigondb.toml.torrent
```

**DURING rebase** — listed for deletion and deleted:
```
D: .../snapshots/erigondb.toml.torrent
Deleted: .../snapshots/erigondb.toml.torrent
```

**AFTER rebase** — file is gone:
```
ls: .../snapshots/erigondb.toml.torrent: No such file or directory
```

`erigondb.toml` remains (rewritten with new step size) but `erigondb.toml.torrent` is no longer present.

## Pending
- [x] Cherry-pick the merged commit on main to the branch `release/3.4` after this PR is merged → #19730