### PR TITLE
fix(commitment): properly clone CommitmentReplayStateReader with new transaction

### DIFF
--- a/execution/commitment/commitmentdb/reader.go
+++ b/execution/commitment/commitmentdb/reader.go
@@ -181,8 +181,9 @@ func NewCommitmentReplayStateReader(ttx, tx kv.TemporalTx, tsd sd, plainStateAsO
 }
 
 func (crsr *CommitmentReplayStateReader) Clone(tx kv.TemporalTx) StateReader {
-	// do nothing
-	return crsr
+	return &CommitmentReplayStateReader{
+		SplitStateReader: crsr.SplitStateReader.Clone(tx).(*SplitStateReader),
+	}
 }
 
 // A history reader that reads:


### PR DESCRIPTION
## Problem

The `CommitmentReplayStateReader.Clone()` method was returning itself without updating the transaction:

```go
func (crsr *CommitmentReplayStateReader) Clone(tx kv.TemporalTx) StateReader {
    // do nothing
    return crsr
}
```

This caused stale transaction usage when `trieContext()` clones the state reader during `ComputeCommitment()`.

## Impact

This bug affects all usages of `CommitmentReplayStateReader`:
- **Commitment history regeneration** (`RebuildCommitmentFilesWithHistory` in `db/state/squeeze.go`)
- **RPC commitment verification** (`rpc/rpchelper/commitment.go`)
- **Receipts generation** with state root computation (`rpc/jsonrpc/receipts/receipts_generator.go`)

## Fix

Properly delegate to `SplitStateReader.Clone()` which correctly clones both inner readers with the new transaction:

```go
func (crsr *CommitmentReplayStateReader) Clone(tx kv.TemporalTx) StateReader {
    return &CommitmentReplayStateReader{
        SplitStateReader: crsr.SplitStateReader.Clone(tx).(*SplitStateReader),
    }
}
```

## Testing

- `go test ./execution/commitment/...` passes
- Build succeeds