### PR TITLE
[cherry-pick] [r34] snapcfg: lazy-parse EmbeddedWebseeds, only parse the chain in use

### DIFF
--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -272,7 +272,7 @@ func Downloader(cmd *cobra.Command, logger log.Logger) error {
 	version := "erigon: " + version.VersionWithCommit(version.GitCommit)
 
 	webseedsList := common.CliString2Array(cobraFlagValues.webseeds)
-	if known, ok := snapcfg.KnownWebseeds[chain]; ok {
+	if known, ok := snapcfg.GetEmbeddedWebseeds(chain); ok {
 		webseedsList = append(webseedsList, known...)
 	}
 	if seedbox {
@@ -540,7 +540,7 @@ var torrentMagnet = &cobra.Command{
 func manifestVerify(ctx context.Context, logger log.Logger) error {
 	webseedsList := common.CliString2Array(cobraFlagValues.webseeds)
 	if len(webseedsList) == 0 { // fallback to default if exact list not passed
-		if known, ok := snapcfg.KnownWebseeds[chain]; ok {
+		if known, ok := snapcfg.GetEmbeddedWebseeds(chain); ok {
 			for _, s := range known {
 				//TODO: enable validation of this buckets also. skipping to make CI useful.
 				if strings.Contains(s, "erigon2-v2") {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2042,7 +2042,7 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 			// Unfortunately we don't take webseed URL here in the native format.
 			webseedsList = common.CliString2Array(ctx.String(WebSeedsFlag.Name))
 		} else {
-			if known, ok := snapcfg.KnownWebseeds[chain]; ok {
+			if known, ok := snapcfg.GetEmbeddedWebseeds(chain); ok {
 				webseedsList = append(webseedsList, known...)
 			}
 		}

--- a/db/downloader/webseeds/verify.go
+++ b/db/downloader/webseeds/verify.go
@@ -49,7 +49,7 @@ func Verify(
 		return
 	}
 	allPreverified := snapcfg.GetAllCurrentPreverified()
-	chains := selectChains(targetChain, snapcfg.KnownWebseeds)
+	chains := selectChains(targetChain, snapcfg.EmbeddedWebseedsRaw)
 	if len(chains) == 0 {
 		err = errors.New("no matching chains")
 		return
@@ -78,7 +78,7 @@ func Verify(
 	for _, chain := range chains {
 		// Shift left?
 		//
-		webseeds := g.MapMustGet(snapcfg.KnownWebseeds, chain)
+		webseeds, _ := snapcfg.GetEmbeddedWebseeds(chain)
 		var baseUrl string
 		err := errors.New("no valid webseeds")
 		for _, webseed := range webseeds {

--- a/db/snapcfg/util.go
+++ b/db/snapcfg/util.go
@@ -526,27 +526,34 @@ func KnownCfgOrDevnet(networkName string) *Cfg {
 	return cfg
 }
 
-var KnownWebseeds = map[string][]string{
-	networkname.Mainnet:    webseedsParse(webseed.Mainnet),
-	networkname.Sepolia:    webseedsParse(webseed.Sepolia),
-	networkname.Amoy:       webseedsParse(webseed.Amoy),
-	networkname.BorMainnet: webseedsParse(webseed.BorMainnet),
-	networkname.Gnosis:     webseedsParse(webseed.Gnosis),
-	networkname.Chiado:     webseedsParse(webseed.Chiado),
-	networkname.Hoodi:      webseedsParse(webseed.Hoodi),
-	networkname.Bloatnet:   webseedsParse(webseed.Bloatnet),
+// EmbeddedWebseedsRaw holds the unparsed embedded webseed TOML bytes per chain.
+var EmbeddedWebseedsRaw = map[string][]byte{
+	networkname.Mainnet:    webseed.Mainnet,
+	networkname.Sepolia:    webseed.Sepolia,
+	networkname.Amoy:       webseed.Amoy,
+	networkname.BorMainnet: webseed.BorMainnet,
+	networkname.Gnosis:     webseed.Gnosis,
+	networkname.Chiado:     webseed.Chiado,
+	networkname.Hoodi:      webseed.Hoodi,
+	networkname.Bloatnet:   webseed.Bloatnet,
 }
 
-func webseedsParse(in []byte) (res []string) {
+// GetEmbeddedWebseeds parses and returns the webseed URLs for a single chain.
+func GetEmbeddedWebseeds(chain string) ([]string, bool) {
+	raw, ok := EmbeddedWebseedsRaw[chain]
+	if !ok {
+		return nil, false
+	}
 	a := map[string]string{}
-	if err := toml.Unmarshal(in, &a); err != nil {
+	if err := toml.Unmarshal(raw, &a); err != nil {
 		panic(err)
 	}
+	res := make([]string, 0, len(a))
 	for _, l := range a {
 		res = append(res, l)
 	}
 	slices.Sort(res)
-	return res
+	return res, true
 }
 
 const RemotePreverifiedEnvKey = "ERIGON_REMOTE_PREVERIFIED"
@@ -647,17 +654,6 @@ func LoadRemotePreverified(ctx context.Context) (err error) {
 				return err
 			}
 		}
-	}
-
-	KnownWebseeds = map[string][]string{
-		networkname.Mainnet:    webseedsParse(webseed.Mainnet),
-		networkname.Sepolia:    webseedsParse(webseed.Sepolia),
-		networkname.Amoy:       webseedsParse(webseed.Amoy),
-		networkname.BorMainnet: webseedsParse(webseed.BorMainnet),
-		networkname.Gnosis:     webseedsParse(webseed.Gnosis),
-		networkname.Chiado:     webseedsParse(webseed.Chiado),
-		networkname.Hoodi:      webseedsParse(webseed.Hoodi),
-		networkname.Bloatnet:   webseedsParse(webseed.Bloatnet),
 	}
 
 	// Re-load the preverified hashes


### PR DESCRIPTION
Cherry-pick of #19722 (merged to main as a18eb9baab) to `release/3.4`.

## Summary

- **Lazy-parse webseed TOML**: instead of parsing all 8 chains' webseed TOML at init time, store raw bytes in `EmbeddedWebseedsRaw` and parse on demand via `GetEmbeddedWebseeds(chain)` — only the chain actually in use gets parsed.
- **Remove no-op re-assignment**: `LoadRemotePreverified` was redundantly re-building the same `KnownWebseeds` map; removed.
- **Inline `webseedsParse`**: folded into its sole caller `GetEmbeddedWebseeds`.
- **Rename `KnownWebseeds` → `EmbeddedWebseeds`**: clearer naming — `EmbeddedWebseedsRaw` for the raw bytes map, `GetEmbeddedWebseeds()` for parsed access.