### PR TITLE
[r34] [cherry-pick] cmd/utils/app: delete erigondb.toml.torrent during step-rebase

### DIFF
--- a/cmd/utils/app/step_cmd.go
+++ b/cmd/utils/app/step_cmd.go
@@ -111,7 +111,11 @@ func stepRebase(cliCtx *cli.Context) error {
 	dels = append(dels, idxTorrents...)
 
 	// include whole chaindata directory for deletion
-	dels = append(dels, dirs.Chaindata)
+	dels = append(dels, dirs.Chaindata) //nolint:gocritic
+
+	// include erigondb.toml.torrent which is invalidated by the rebase
+	dels = append(dels, filepath.Join(dirs.Snap, "erigondb.toml.torrent"))
+
 	for _, f := range dels {
 		fmt.Printf("D: %s\n", f)
 	}


### PR DESCRIPTION
Cherry-pick of #19723 to `release/3.4`.

## Summary
- `erigon seg step-rebase` renames snapshot data files, invalidating existing torrent metadata
- `.torrent` files in subdirectories (domain/, history/, accessor/, idx/) were already deleted, but `erigondb.toml.torrent` in the snapshots root was missed
- Add it to the deletion list