### PR TITLE
execution/stagedsync: call accumulator.StartChange with txs in parallel executor

### DIFF
--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -235,6 +235,14 @@ func (pe *parallelExecutor) exec(ctx context.Context, execStage *StageState, u U
 						if !pe.isBlockProduction && !applyResult.isPartial && !execStage.CurrentSyncCycle.IsInitialCycle {
 							pe.cfg.notifications.RecentReceipts.Add(applyResult.Receipts, b.Transactions(), lastHeader)
 						}
+
+						if accumulator != nil && !pe.isBlockProduction {
+							txsRaw, rawErr := pe.cfg.blockReader.RawTransactions(ctx, rwTx, applyResult.BlockNum, applyResult.BlockNum)
+							if rawErr != nil {
+								return fmt.Errorf("RawTransactions for accumulator: %w", rawErr)
+							}
+							accumulator.StartChange(lastHeader, txsRaw, false)
+						}
 					}
 
 					if applyResult.BlockNum > lastBlockResult.BlockNum {


### PR DESCRIPTION
## Summary

- The parallel executor was missing `accumulator.StartChange(header, txs, false)`, which the serial executor has always called before executing each block
- Without this, `change.Txs` in the `StateChangeBatch` is nil when parallel execution runs, so `handleStateChangesRequest` in the txpool cannot populate `minedTxns`, `removeMined` does nothing, and mined transactions linger in the pending pool
- On the next block assembly, `filterBadTransactions` filters them all as nonce-too-low, producing an empty block

## Root cause

The bug exists in the parallel executor on both `main` and `bal-devnet-2`. On `main` it is masked because `Exec3Parallel` defaults to `false` and `ExperimentalBAL` is `false`, so the serial executor runs. When either flag is enabled (e.g. `EXEC3_PARALLEL=true` or `experimentalBAL: true`), the parallel executor is used and this bug is hit.

## Test plan
- [x] `TestAssembleBlockGasOverflow` passes (was failing)
- [x] `TestEngineApiBlockGasOverflowSpillsToNextBlock` passes (was failing)
- [x] `make test-short` — clean
- [x] Cherry-picked from `fix/bal-selfdestruct-netzero` where the same fix resolves CI failures on PR #19228

🤖 Generated with [Claude Code](https://claude.com/claude-code)