### PR TITLE
execution/stagedsync: enable deferred commitment updates for parallel fork validation

### DIFF
--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -210,10 +210,10 @@ func ExecV3(ctx context.Context,
 	if !isApplyingBlocks {
 		postValidator = newParallelBlockPostExecutionValidator()
 	}
-	// Enable deferred commitment updates only for serial execution (fork validation).
-	// The parallel executor has a subtle interaction with deferred updates that causes
-	// intermittent trie root mismatches during re-org validation.
-	if !parallel && isForkValidation {
+	// Enable deferred commitment updates for fork validation (both serial and parallel).
+	// Deferred updates batch commitment calculations to block boundaries rather than
+	// per-transaction, significantly reducing re-org validation overhead.
+	if isForkValidation {
 		doms.SetDeferCommitmentUpdates(true)
 	}
 	defer doms.SetDeferCommitmentUpdates(false)


### PR DESCRIPTION
## Problem

`SetDeferCommitmentUpdates` was restricted to serial mode (`!parallel`) during fork (re-org) validation. The restriction existed because the parallel executor produced intermittent trie root mismatches when deferred updates were enabled.

Root cause of those mismatches: `applyStorageChanges` used `blockOriginStorage[key]` (block-start value) as the skip criterion for `WriteAccountStorage`. This caused MDBX to hold stale intermediate values after certain intra-block storage patterns, which propagated into trie root calculations, producing non-deterministic mismatches depending on execution order.

That underlying bug is fixed in #19748.

## Fix

Remove the `!parallel` guard so both serial and parallel fork validation benefit from deferred commitment updates. Deferred updates batch trie root calculations to block boundaries rather than recomputing after every transaction, significantly reducing re-org validation overhead in parallel mode.

## Test plan

- [ ] Verify `make erigon` builds cleanly  
- [ ] Run `go test ./execution/stagedsync/...`
- [ ] Parallel fork validation no longer produces trie root mismatches
- [ ] Re-org handling is faster under parallel execution
🤖 Generated with [Claude Code](https://claude.com/claude-code)