### PR TITLE
GenerateWitness: fix stale grid row causing incorrect storage witness after non-existent account proof

### DIFF
--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -2579,6 +2579,16 @@ func (hph *HexPatriciaHashed) GenerateWitness(ctx context.Context, updates *Upda
 				return fmt.Errorf("fold: %w", err)
 			}
 		}
+
+		// Fold back any non-branch rows left by previous extension splits.
+		// These "virtual" rows (branchBefore=false) don't correspond to real DB
+		// branch nodes and carry stale hashedExtension data that confuses
+		// toWitnessTrie() when it traverses the grid top-down.
+		for hph.activeRows > 0 && !hph.branchBefore[hph.activeRows-1] {
+			if err := hph.fold(); err != nil {
+				return fmt.Errorf("fold non-branch: %w", err)
+			}
+		}
 		// Now unfold until we step on an empty cell
 		for unfolding := hph.needUnfolding(hashedKey); unfolding > 0; unfolding = hph.needUnfolding(hashedKey) {
 			if err := hph.unfold(hashedKey, unfolding); err != nil {

--- a/execution/commitment/hex_patricia_hashed_test.go
+++ b/execution/commitment/hex_patricia_hashed_test.go
@@ -2541,4 +2541,55 @@ func Test_WitnessTrie_GenerateWitness(t *testing.T) {
 		keyExists := []bool{true, true, false}
 		buildTrieAndWitness(t, builder, keysToProve, keyExists)
 	})
+
+	t.Run("StorageProofAfterNonExistentAccountUnfoldsExtension", func(t *testing.T) {
+		// a non-existent account whose hash shares the same branch
+		// as an account with storage causes a partial extension unfold (cpl=0).
+		// This creates a stale grid row that isn't folded away because
+		// subsequent keys share the same prefix. When the storage key (128 nibbles)
+		// is then witnessed, toWitnessTrie() traverses past the extension into the
+		// stale row and reads the wrong cell, producing an incorrect witness.
+		//
+		// Hash order: nonExistent(370...) < target(37d...) < storage(37d...+storageHash)
+		// The stale row persists because all keys share prefix [37] → needFolding=false.
+
+		// Target account at hash prefix [3,7,d] — only account at nibble 7 at depth 2,
+		// creating a long extension (62 nibbles) from depth 2 to depth 64.
+		targetAddr, _ := generateKeyWithHashedPrefix([]byte{0x3, 0x7, 0xd}, length.Addr)
+
+		// Other accounts to create branches at depth 1 and depth 2
+		otherAddr35, _ := generateKeyWithHashedPrefix([]byte{0x3, 0x5}, length.Addr)
+		otherAddr5, _ := generateKeyWithHashedPrefix([]byte{0x5}, length.Addr)
+		otherAddr9, _ := generateKeyWithHashedPrefix([]byte{0x9}, length.Addr)
+
+		// Non-existent account at hash prefix [3,7,0] — diverges from target's
+		// extension at cpl=0 (nibble 0 ≠ d), causing unfold(1) which creates a stale
+		// grid row with 61-nibble extension. Hash 370... < 37d... so processed first.
+		nonExistentAddr, _ := generateKeyWithHashedPrefix([]byte{0x3, 0x7, 0x0}, length.Addr)
+
+		// Storage slot for target account
+		storageSlot := make([]byte, length.Hash)
+		storageSlot[31] = 0x01
+
+		builder := NewUpdateBuilder()
+		// builder.Balance(common.Bytes2Hex(nonExistentAddr), 666)
+		builder.Balance(common.Bytes2Hex(targetAddr), 100)
+		builder.Balance(common.Bytes2Hex(otherAddr35), 200)
+		builder.Balance(common.Bytes2Hex(otherAddr5), 300)
+		builder.Balance(common.Bytes2Hex(otherAddr9), 400)
+		builder.Storage(common.Bytes2Hex(targetAddr), common.Bytes2Hex(storageSlot), "0102030405")
+
+		// Full storage key = target address + storage slot (52 bytes)
+		fullStorageKey := common.Copy(targetAddr)
+		fullStorageKey = append(fullStorageKey, storageSlot...)
+		require.Equal(t, len(fullStorageKey), length.Addr+length.Hash)
+
+		// Witness keys (processed in hash order):
+		// 1. nonExistentAddr (370...) — partially unfolds target's extension, stale row left
+		// 2. targetAddr (37d...) — works fine (64-nibble key, loop exits before stale row)
+		// 3. fullStorageKey (37d...+storageHash) — 128-nibble key, affected by stale row of key 1. if it's not folded back
+		buildTrieAndWitness(t, builder,
+			[][]byte{nonExistentAddr, targetAddr, fullStorageKey},
+			[]bool{false, true, true})
+	})
 }


### PR DESCRIPTION
 # Summary         

  - Fixes  a bug in GenerateWitness where proving a non-existent account could corrupt the witness for a subsequent storage key of a different account sharing the same path.
  - Add a test case reproducing the exact conditions that trigger this bug.

#  Problem

  When `GenerateWitness `processes a non-existent account key whose hashed key path diverges from an existing account's extension, `unfold()` partially splits the extension via `fillFromUpperCell`, creating a "virtual" grid row that doesn't correspond to any real DB branch node. It just contains `hashedExtension[1:]` of the cell above. So this row ends up  carrying  stale hashedExtension data.

  If subsequent witness keys share the same hash prefix (e.g. the account that owns the extension, followed by its storage),
  `needFolding` returns false and the stale row persists. When `toWitnessTrie()`later builds the witness for a 128-nibble storage  key, it traverses past the extension into the stale row and reads the wrong cell (grid[2][hashedKey[63]] instead of the account cell), producing `AccountNode.Storage = nil` instead of expanding into the storage subtrie of the account.

  # Fix

 After the regular `needFolding` loop in `GenerateWitness`, fold back any rows where `branchBefore[row] == false`. These are virtual rows created by partial extension splits and not backed by real DB branch data. Folding them ensures the subsequent needUnfolding operates on a real branch-backed cell and unfolds the full extension correctly, placing the account at the right grid position.