### PR TITLE
logging: flexible log directory permissions with secure defaults

### DIFF
--- a/db/datadir/dirs.go
+++ b/db/datadir/dirs.go
@@ -86,7 +86,6 @@ func New(datadir string) Dirs {
 		dirs.CaplinColumnData,
 		dirs.CaplinHistory,
 		dirs.Migrations,
-		filepath.Join(datadir, "logs"),
 	)
 
 	return dirs
@@ -131,6 +130,7 @@ func Open(datadir string) Dirs {
 		CaplinGenesis:    filepath.Join(datadir, "caplin", "genesis-state"),
 		CaplinHistory:    filepath.Join(datadir, "caplin", "history"),
 		Migrations:       filepath.Join(datadir, "migrations"),
+		Log:              filepath.Join(datadir, "logs"),
 	}
 	return dirs
 }

--- a/node/logging/logging.go
+++ b/node/logging/logging.go
@@ -18,6 +18,7 @@ package logging
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -234,10 +235,33 @@ func initSeparatedLogging(
 		return
 	}
 
-	err := os.MkdirAll(dirPath, 0755)
-	if err != nil {
-		logger.Warn("failed to create log dir, console logging only")
-		return
+	// Create the log directory with owner-only permissions (0700) so that
+	// by default only the erigon user can read logs. Group or world access
+	// must be explicitly granted by the operator (e.g. chmod 750 <logs-dir>).
+	// If the directory already exists we inspect its permissions: any group
+	// or world access bits are reported as a warning but we proceed running.
+	if info, err := os.Stat(dirPath); err != nil {
+		if !os.IsNotExist(err) {
+			logger.Warn("failed to stat log dir, console logging only", "err", err)
+			return
+		}
+		if err := os.MkdirAll(dirPath, 0700); err != nil {
+			logger.Warn("failed to create log dir, console logging only", "err", err)
+			return
+		}
+	} else {
+		if mode := info.Mode().Perm(); mode&0o077 != 0 {
+			logger.Warn("log directory has non-default permissions; group or world access is enabled",
+				"dir", dirPath, "mode", fmt.Sprintf("%04o", mode))
+		}
+	}
+
+	// Pre-create the log file with group-readable permissions (0640).
+	// lumberjack.v2 copies the mode of the existing file when rotating, so
+	// all subsequent rotated files will also be created with 0640.
+	logFilePath := filepath.Join(dirPath, filePrefix+".log")
+	if f, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0640); err == nil {
+		_ = f.Close()
 	}
 
 	dirFormat := log.TerminalFormatNoColor()
@@ -246,7 +270,7 @@ func initSeparatedLogging(
 	}
 
 	lumberjack := &lumberjack.Logger{
-		Filename:   filepath.Join(dirPath, filePrefix+".log"),
+		Filename:   logFilePath,
 		MaxSize:    100, // megabytes
 		MaxBackups: 3,
 		MaxAge:     28, //days


### PR DESCRIPTION
changes in logging: restrict log directory to owner-only by default and warn on wider access

By default the logs/ directory is now created with 0700 (owner-only). Group or world access must be explicitly granted by the operator (e.g. chmod 750 <datadir>/logs). On startup with an existing datadir erigon checks the directory mode: if group or world bits are set it logs a warning and proceeds.

Log files are pre-created with 0640 (group-readable) before lumberjack opens them. lumberjack.v2 copies the mode of the existing file when rotating, so all rotated files inherit 0640 as well. This means that once the operator widens directory access the files are immediately readable by group members without a restart.

dirs.go: populate the Dirs.Log field in Open() and remove the logs/ directory from the MustExist call in New() — the logging subsystem now owns the lifecycle of this directory.