### PR TITLE
caplin: remove noisy voluntary exit gossip error log

### DIFF
--- a/cl/beacon/handler/pool.go
+++ b/cl/beacon/handler/pool.go
@@ -269,10 +269,7 @@ func (a *ApiHandler) PostEthV1BeaconPoolVoluntaryExits(w http.ResponseWriter, r 
 		return
 	}
 	a.operationsPool.VoluntaryExitsPool.Insert(req.VoluntaryExit.ValidatorIndex, &req)
-	if err := a.gossipManager.Publish(r.Context(), gossip.TopicNameVoluntaryExit, encodedSSZ); err != nil {
-		a.logger.Debug("[Beacon REST] failed to publish voluntary exit to gossip", "err", err)
-	}
-	// Only write 200
+	a.gossipManager.Publish(r.Context(), gossip.TopicNameVoluntaryExit, encodedSSZ)
 	w.WriteHeader(http.StatusOK)
 }
 


### PR DESCRIPTION
Fixes #19643

The `PostEthV1BeaconPoolVoluntaryExits` handler logs a debug error when gossip publish fails:

```
failed to publish voluntary exit to gossip app=caplin err="unknown topic voluntary_exit"
```

This is harmless — the voluntary exit is already inserted into the operations pool before the publish call. The "unknown topic" error occurs when the node is not subscribed to the topic (e.g. not yet synced or topic not active), but it does not affect functionality.

This PR removes the error check and debug log, letting the publish call fire-and-forget. Also removes a stale `// Only write 200` comment.