### PR TITLE
caplin: re-enable voluntary_exit gossip topic subscription

### DIFF
--- a/cl/sentinel/service/start.go
+++ b/cl/sentinel/service/start.go
@@ -112,7 +112,7 @@ func createSentinel(
 	}
 	gossipTopics := []sentinel.GossipTopic{
 		sentinel.BeaconBlockSsz,
-		//sentinel.VoluntaryExitSsz,
+		sentinel.VoluntaryExitSsz,
 		sentinel.ProposerSlashingSsz,
 		sentinel.AttesterSlashingSsz,
 		sentinel.BlsToExecutionChangeSsz,


### PR DESCRIPTION
Fixes #19643

The `voluntary_exit` gossip topic was accidentally commented out in `cl/sentinel/service/start.go`, causing `POST /eth/v1/beacon/pool/voluntary_exits` to fail with:

```
[Beacon REST] failed to publish voluntary exit to gossip app=caplin err="unknown topic voluntary_exit"
```

Voluntary exits were being inserted into the operations pool but never propagated via gossip.

Fix: uncomment `sentinel.VoluntaryExitSsz` in the gossip topic list.

Note: this is already fixed on `main` where the gossip subscription architecture was refactored — the voluntary exit service is properly registered via `RegisterGossipServices` in `register.go`.