### PR TITLE
ci: fix duplicate types key in lint workflow pull_request trigger

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,6 @@ name: Lint
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
     branches:
       - main
       - 'release/**'


### PR DESCRIPTION
## Root cause

The duplicate `types:` key was introduced because PR #19734 was out of sync with https://github.com/erigontech/erigon/commit/2319e0410b209beb6836e3609aff7b8ef242c40f.

That commit had already restored the inline `types: [opened, reopened, synchronize, ready_for_review]` to `lint.yml` on `main`. But PR #19734's branch predated it and hadn't been rebased. One of the PR's commits added a block-style `types:` for the same reason — not knowing `2319e0410b` had already done it. When the PR was squash-merged, GitHub applied the diff on top of `main`'s current state, silently inserting a second `types:` key rather than detecting the conflict.

YAML doesn't prohibit duplicate keys, but GitHub Actions' parser appears to drop the trigger entirely when it encounters them — causing lint to stop firing for all PRs targeting `main`.

## This is exactly the scenario #19673 addresses

If a merge queue had been in place, PR #19734 would have been required to be up to date with `main` before merging. The rebase/update step would have surfaced the conflict with `2319e0410b` and prevented the duplicate from ever landing.