### PR TITLE
[SharovBot] ci: increase test timeout to 30m on windows-2025 to fix eest_blockchain marginal failure

### DIFF
--- a/.github/workflows/test-all-erigon.yml
+++ b/.github/workflows/test-all-erigon.yml
@@ -40,6 +40,12 @@ jobs:
           - ubuntu-24.04
           - macos-15
           - windows-2025
+        include:
+          # eest_blockchain tests take ~1190s on the GitHub-hosted windows-2025
+          # runner (right at the 20m limit). Give Windows extra headroom to avoid
+          # marginal timeouts while keeping Linux/macOS at the tighter 20m.
+          - os: windows-2025
+            test_timeout: 30m
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -63,8 +69,9 @@ jobs:
       - name: Run all tests on ${{ matrix.os }}
         env:
           SKIP_FLAKY_TESTS: 'true'
+          TEST_TIMEOUT: ${{ matrix.test_timeout || '20m' }}
         run: |
-          if ! make test-all GO_FLAGS='--timeout 20m'; then
+          if ! make test-all GO_FLAGS="--timeout $TEST_TIMEOUT"; then
             # Retry after clearing the Go build cache. Low disk space can cause
             # severe, non-obvious build/test failures that don't surface a clear
             # "no space left" message. Tuning a cache size limit is too fragile;
@@ -72,7 +79,7 @@ jobs:
             # handles the rest.
             echo "::notice::make test-all failed; clearing Go build cache and retrying"
             time go clean -cache
-            make test-all GO_FLAGS='--timeout 20m'
+            make test-all GO_FLAGS="--timeout $TEST_TIMEOUT"
           fi
 
       - uses: ./.github/actions/cleanup-erigon


### PR DESCRIPTION
**[SharovBot]**

## Problem

The `tests-mac-linux (windows-2025)` CI job has been consistently failing since commit `495b946f` (Remove unused 'isBlockProduction' from ExecV3) on commits `495b946f` and `2d94e91a`.

Root cause: the `execution/tests/eest_blockchain` test suite takes **~1190 seconds** (~19.8 minutes) on the GitHub-hosted `windows-2025` runner — right at the 20-minute (1200s) test timeout introduced by commit `cac5e91b` ('ci: port Windows tests to setup-erigon, drop self-hosted runner').

Evidence from CI logs:
- `cac5e91b` (passing): `ok  github.com/erigontech/erigon/execution/tests/eest_blockchain  1190.918s`
- `495b946f` (failing): `panic: test timed out after 20m0s` / `FAIL github.com/erigontech/erigon/execution/tests/eest_blockchain  1200.471s`
- `2d94e91a` (failing): same timeout on both first attempt and retry

The `495b946f` commit is a correct dead-code cleanup; the failure is due to the extremely tight margin between actual test duration (~1190s) and the timeout limit (1200s). Runner load variability and minor overhead are enough to push it over the limit.

## Fix

Add a `matrix.include` entry for `windows-2025` that sets `test_timeout: 30m`. Linux (`ubuntu-24.04`) and macOS (`macos-15`) keep the existing 20m timeout. The 30m limit gives ~10 minutes of headroom without masking real hangs (all other packages complete in well under a minute).

## Verification

- CI-only change (YAML only), no Go code modified
- No `*_test.go` files modified
- YAML syntax validated