### PR TITLE
recsplit: keyPos reset on retry

### DIFF
--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1214,8 +1214,8 @@ func buildHashMapAccessor(ctx context.Context, g *seg.Reader, idxPath string, va
 		}
 	}()
 
-	var keyPos, valPos uint64
 	for {
+		var keyPos, valPos uint64
 		word := make([]byte, 0, 256)
 		if err := ctx.Err(); err != nil {
 			return err


### PR DESCRIPTION
- db/state/domain.go: Move keyPos and valPos declarations inside the retry loop