### PR TITLE
mark `commitment history` feature as non-experimental

### DIFF
--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -276,9 +276,6 @@ func checkAndSetCommitmentHistoryFlag(tx kv.RwTx, logger log.Logger, dirs datadi
 	if err := rawdb.WriteDBCommitmentHistoryEnabled(tx, cfg.KeepExecutionProofs); err != nil {
 		return err
 	}
-	if cfg.KeepExecutionProofs {
-		logger.Warn("[experiment] enabling commitment history. this is an experimental flag so run at your own risk!", "enabled", cfg.KeepExecutionProofs)
-	}
 	return nil
 }
 


### PR DESCRIPTION
remove alert: `[experiment] enabling commitment history. this is an experimental flag so run at your own risk!`
