### PR TITLE
vm: fix CREATE/CREATE2 collision with EIP-7702 delegated accounts

### DIFF
--- a/execution/vm/evm.go
+++ b/execution/vm/evm.go
@@ -422,8 +422,12 @@ func (evm *EVM) create(caller accounts.Address, codeAndHash *codeAndHash, gasRem
 	// BAL: record target address even on failed CREATE/CREATE2 calls
 	evm.intraBlockState.MarkAddressAccess(address, false)
 
-	// Ensure there's no existing contract already at the designated address
-	contractHash, err := evm.intraBlockState.ResolveCodeHash(address)
+	// Ensure there's no existing contract already at the designated address.
+	// Use GetCodeHash (not ResolveCodeHash) so that an EIP-7702 delegation
+	// designator (0xef0100...) is seen as non-empty code, triggering a collision.
+	// This matches geth's behavior: CREATE/CREATE2 must not overwrite a
+	// delegated account even if the delegation target is empty.
+	contractHash, err := evm.intraBlockState.GetCodeHash(address)
 	if err != nil {
 		return nil, accounts.NilAddress, 0, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
 	}

--- a/execution/vm/runtime/runtime_test.go
+++ b/execution/vm/runtime/runtime_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/crypto"
 	"github.com/erigontech/erigon/db/kv/rawdbv3"
 	"github.com/erigontech/erigon/execution/abi"
 	"github.com/erigontech/erigon/execution/chain"
@@ -39,6 +40,7 @@ import (
 	"github.com/erigontech/erigon/execution/protocol/rules"
 	"github.com/erigontech/erigon/execution/state"
 	"github.com/erigontech/erigon/execution/tests/testutil"
+	"github.com/erigontech/erigon/execution/tracing"
 	"github.com/erigontech/erigon/execution/tracing/tracers/logger"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/execution/types/accounts"
@@ -696,4 +698,130 @@ func BenchmarkEVM_SWAP1(b *testing.B) {
 			}
 		}
 	})
+}
+
+// TestCreate2CollisionWithEIP7702Delegation verifies that CREATE2 to an address
+// with an EIP-7702 delegation designator triggers ErrContractAddressCollision,
+// matching geth's behavior. The delegation designator (0xef0100 ++ address) is
+// non-empty code and must be treated as an occupied account.
+// See https://github.com/ethereum-bounty/erigon/issues/2
+func TestCreate2CollisionWithEIP7702Delegation(t *testing.T) {
+	t.Parallel()
+
+	db := testutil.TemporalDB(t)
+	tx, domains := testutil.TemporalTxSD(t, db)
+	statedb := state.New(state.NewReaderV3(domains.AsGetter(tx)))
+
+	sender := accounts.InternAddress(common.HexToAddress("0x1234"))
+	statedb.CreateAccount(sender, true)
+	statedb.AddBalance(sender, *uint256.NewInt(1e18), tracing.BalanceChangeUnspecified)
+
+	// Initcode that just returns empty runtime code (PUSH1 0, PUSH1 0, RETURN).
+	initcode := []byte{byte(vm.PUSH1), 0, byte(vm.PUSH1), 0, byte(vm.RETURN)}
+
+	// Compute the CREATE2 target address: keccak256(0xff ++ factory ++ salt ++ keccak256(initcode))[12:]
+	salt := uint256.NewInt(0)
+	factoryAddr := common.HexToAddress("0xfac0")
+	create2Addr := types.CreateAddress2(factoryAddr, salt.Bytes32(), accounts.InternCodeHash(crypto.Keccak256Hash(initcode)))
+	delegatedAddr := accounts.InternAddress(create2Addr)
+
+	// Set an EIP-7702 delegation on the target address (points to some arbitrary empty account).
+	delegationTarget := common.HexToAddress("0xdead")
+	delegationCode := types.AddressToDelegation(accounts.InternAddress(delegationTarget))
+	statedb.CreateAccount(delegatedAddr, true)
+	statedb.SetCode(delegatedAddr, delegationCode)
+
+	// Build a factory contract that executes CREATE2 with the initcode and salt=0.
+	// The factory is placed at factoryAddr.
+	factory := program.New()
+	factory.Create2(initcode, salt)
+	// Push the result to storage slot 0 for inspection.
+	factory.Push(0).Op(vm.SSTORE)
+
+	statedb.CreateAccount(accounts.InternAddress(factoryAddr), true)
+	statedb.SetCode(accounts.InternAddress(factoryAddr), factory.Bytes())
+
+	cfg := &Config{
+		State:  statedb,
+		Origin: sender,
+	}
+
+	_, _, err := Call(accounts.InternAddress(factoryAddr), nil, cfg)
+	require.NoError(t, err) // the CALL itself succeeds; CREATE2 failure is internal
+
+	// The CREATE2 should have failed (collision), so the factory's SSTORE
+	// should have stored the zero address (CREATE2 returns 0 on failure).
+	val, err := statedb.GetState(accounts.InternAddress(factoryAddr), accounts.StorageKey{})
+	require.NoError(t, err)
+	require.True(t, val.IsZero(), "CREATE2 should have returned 0 (collision), but got %x", val)
+
+	// Also verify that the delegation code on the target address is still intact.
+	code, err := statedb.GetCode(delegatedAddr)
+	require.NoError(t, err)
+	require.Equal(t, delegationCode, code, "delegation code should be unchanged")
+}
+
+// TestCreateCollisionWithEIP7702Delegation verifies that CREATE (not just CREATE2)
+// also collides with an EIP-7702 delegated account.
+func TestCreateCollisionWithEIP7702Delegation(t *testing.T) {
+	t.Parallel()
+
+	db := testutil.TemporalDB(t)
+	tx, domains := testutil.TemporalTxSD(t, db)
+	statedb := state.New(state.NewReaderV3(domains.AsGetter(tx)))
+
+	sender := accounts.InternAddress(common.HexToAddress("0x1234"))
+	statedb.CreateAccount(sender, true)
+	statedb.AddBalance(sender, *uint256.NewInt(1e18), tracing.BalanceChangeUnspecified)
+
+	// Initcode that returns empty runtime code.
+	initcode := []byte{byte(vm.PUSH1), 0, byte(vm.PUSH1), 0, byte(vm.RETURN)}
+
+	// Compute the CREATE target address: keccak256(rlp([factory, nonce]))[12:]
+	// Factory nonce starts at 1 (after SpuriousDragon sets it during create).
+	// But for the factory contract already deployed, its nonce is 0 initially;
+	// CREATE uses current nonce then increments. So target = CreateAddress(factory, 1)
+	// because the factory itself has nonce=1 set by SpuriousDragon during deployment.
+	// We'll use a simpler approach: just precompute and set delegation on the target.
+	factoryAddr := common.HexToAddress("0xfac1")
+	factoryAcct := accounts.InternAddress(factoryAddr)
+
+	// Factory nonce will be 1 (set by SpuriousDragon on CreateAccount).
+	// CREATE uses nonce of the calling contract. The factory already exists with nonce=0.
+	// EVM increments nonce before CREATE, but here the factory's nonce is 0.
+	// Actually in the EVM, CREATE does: target = CreateAddress(caller, callerNonce), then increments.
+	// Since our factory is pre-deployed with nonce 0, CREATE target = CreateAddress(factoryAddr, 0).
+	createAddr := types.CreateAddress(factoryAddr, 0)
+	delegatedAddr := accounts.InternAddress(createAddr)
+
+	// Set an EIP-7702 delegation on the target address.
+	delegationTarget := common.HexToAddress("0xdead")
+	delegationCode := types.AddressToDelegation(accounts.InternAddress(delegationTarget))
+	statedb.CreateAccount(delegatedAddr, true)
+	statedb.SetCode(delegatedAddr, delegationCode)
+
+	// Build a factory that executes CREATE with the initcode.
+	factory := program.New()
+	factory.MstoreSmall(initcode, 0)
+	factory.Push(len(initcode)). // size
+					Push(32 - len(initcode)). // offset (right-aligned in the 32-byte word)
+					Push(0).                  // value
+					Op(vm.CREATE)
+	factory.Push(0).Op(vm.SSTORE) // store result in slot 0
+
+	statedb.CreateAccount(factoryAcct, true)
+	statedb.SetCode(factoryAcct, factory.Bytes())
+
+	cfg := &Config{
+		State:  statedb,
+		Origin: sender,
+	}
+
+	_, _, err := Call(factoryAcct, nil, cfg)
+	require.NoError(t, err)
+
+	// CREATE should have failed (collision), returning 0.
+	val, err := statedb.GetState(factoryAcct, accounts.StorageKey{})
+	require.NoError(t, err)
+	require.True(t, val.IsZero(), "CREATE should have returned 0 (collision), but got %x", val)
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/ethereum-bounty/erigon/issues/2

## Test plan
- [x] `TestCreate2CollisionWithEIP7702Delegation` — CREATE2 targeting a delegated address returns 0 (collision)
- [x] `TestCreateCollisionWithEIP7702Delegation` — CREATE targeting a delegated address returns 0 (collision)
- [x] Existing VM tests pass (`go test -short ./execution/vm/...`)
- [x] `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)