### PR TITLE
txpool: penalize peers sending malformed p2p messages

### DIFF
--- a/txnprovider/txpool/fetch.go
+++ b/txnprovider/txpool/fetch.go
@@ -37,6 +37,10 @@ import (
 	"github.com/erigontech/erigon/node/gointerfaces/sentryproto"
 )
 
+// errInternalDB wraps errors that originate from local DB lookups (not from the peer's data).
+// This prevents penalizing peers for our own internal failures.
+var errInternalDB = errors.New("internal db error")
+
 // Fetch connects to sentry and implements eth/66 protocol regarding the transaction
 // messages. It tries to "prime" the sentry with StatusData message containing given
 // genesis hash and list of forks, but with zero max block and total difficulty
@@ -292,7 +296,9 @@ func (f *Fetch) handleInboundMessageWithTx(ctx context.Context, tx kv.Tx, req *s
 	case sentryproto.MessageId_NEW_POOLED_TRANSACTION_HASHES_66:
 		hashCount, pos, err := ParseHashesCount(req.Data, 0)
 		if err != nil {
-			return fmt.Errorf("parsing NewPooledTransactionHashes: %w", err)
+			f.logger.Debug("[txpool] penalizing peer for malformed NewPooledTransactionHashes66", "peer", req.PeerId, "err", err)
+			sentryClient.PenalizePeer(ctx, &sentryproto.PenalizePeerRequest{PeerId: req.PeerId, Penalty: sentryproto.PenaltyKind_Kick})
+			return nil
 		}
 
 		const maxHashesPerMsg = 4096 // See https://github.com/ethereum/devp2p/blob/master/caps/eth.md#newpooledtransactionhashes-0x08
@@ -306,7 +312,9 @@ func (f *Fetch) handleInboundMessageWithTx(ctx context.Context, tx kv.Tx, req *s
 		hashes := make([]byte, 32*hashCount)
 		for i := 0; i < len(hashes); i += 32 {
 			if _, pos, err = ParseHash(req.Data, pos, hashes[i:]); err != nil {
-				return err
+				f.logger.Debug("[txpool] penalizing peer for malformed NewPooledTransactionHashes66", "peer", req.PeerId, "err", err)
+				sentryClient.PenalizePeer(ctx, &sentryproto.PenalizePeerRequest{PeerId: req.PeerId, Penalty: sentryproto.PenaltyKind_Kick})
+				return nil
 			}
 		}
 		unknownHashes, err := f.pool.FilterKnownIdHashes(tx, hashes)
@@ -330,7 +338,9 @@ func (f *Fetch) handleInboundMessageWithTx(ctx context.Context, tx kv.Tx, req *s
 	case sentryproto.MessageId_NEW_POOLED_TRANSACTION_HASHES_68:
 		_, _, hashes, _, err := rlp.ParseAnnouncements(req.Data, 0)
 		if err != nil {
-			return fmt.Errorf("parsing NewPooledTransactionHashes88: %w", err)
+			f.logger.Debug("[txpool] penalizing peer for malformed NewPooledTransactionHashes68", "peer", req.PeerId, "err", err)
+			sentryClient.PenalizePeer(ctx, &sentryproto.PenalizePeerRequest{PeerId: req.PeerId, Penalty: sentryproto.PenaltyKind_Kick})
+			return nil
 		}
 		unknownHashes, err := f.pool.FilterKnownIdHashes(tx, hashes)
 		if err != nil {
@@ -358,7 +368,9 @@ func (f *Fetch) handleInboundMessageWithTx(ctx context.Context, tx kv.Tx, req *s
 		messageID = sentryproto.MessageId_POOLED_TRANSACTIONS_66
 		requestID, hashes, _, err := ParseGetPooledTransactions66(req.Data, 0, nil)
 		if err != nil {
-			return err
+			f.logger.Debug("[txpool] penalizing peer for malformed GetPooledTransactions66", "peer", req.PeerId, "err", err)
+			sentryClient.PenalizePeer(ctx, &sentryproto.PenalizePeerRequest{PeerId: req.PeerId, Penalty: sentryproto.PenaltyKind_Kick})
+			return nil
 		}
 
 		// limit to max 256 transactions in a reply
@@ -408,7 +420,7 @@ func (f *Fetch) handleInboundMessageWithTx(ctx context.Context, tx kv.Tx, req *s
 				if _, err := ParseTransactions(req.Data, 0, parseContext, &txns, func(hash []byte) error {
 					known, err := f.pool.IdHashKnown(tx, hash)
 					if err != nil {
-						return err
+						return fmt.Errorf("%w: %w", errInternalDB, err)
 					}
 					if known {
 						return ErrRejected
@@ -419,14 +431,19 @@ func (f *Fetch) handleInboundMessageWithTx(ctx context.Context, tx kv.Tx, req *s
 				}
 				return nil
 			}); err != nil {
-				return err
+				if errors.Is(err, errInternalDB) {
+					return err
+				}
+				f.logger.Debug("[txpool] penalizing peer for malformed Transactions66", "peer", req.PeerId, "err", err)
+				sentryClient.PenalizePeer(ctx, &sentryproto.PenalizePeerRequest{PeerId: req.PeerId, Penalty: sentryproto.PenaltyKind_Kick})
+				return nil
 			}
 		case sentryproto.MessageId_POOLED_TRANSACTIONS_66:
 			if err := f.threadSafeParsePooledTxn(func(parseContext *TxnParseContext) error {
 				if _, _, err := ParsePooledTransactions66(req.Data, 0, parseContext, &txns, func(hash []byte) error {
 					known, err := f.pool.IdHashKnown(tx, hash)
 					if err != nil {
-						return err
+						return fmt.Errorf("%w: %w", errInternalDB, err)
 					}
 					if known {
 						return ErrRejected
@@ -437,7 +454,12 @@ func (f *Fetch) handleInboundMessageWithTx(ctx context.Context, tx kv.Tx, req *s
 				}
 				return nil
 			}); err != nil {
-				return err
+				if errors.Is(err, errInternalDB) {
+					return err
+				}
+				f.logger.Debug("[txpool] penalizing peer for malformed PooledTransactions66", "peer", req.PeerId, "err", err)
+				sentryClient.PenalizePeer(ctx, &sentryproto.PenalizePeerRequest{PeerId: req.PeerId, Penalty: sentryproto.PenaltyKind_Kick})
+				return nil
 			}
 		default:
 			return fmt.Errorf("unexpected message: %s", req.Id.String())

--- a/txnprovider/txpool/fetch_test.go
+++ b/txnprovider/txpool/fetch_test.go
@@ -368,6 +368,115 @@ func (ms *MockSentry) PeerEvents(_ *sentryproto.PeerEventsRequest, stream sentry
 	}
 }
 
+func TestPenalizePeerForMalformedMessages(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	// Each sub-test sends a malformed message of a given type and asserts that PenalizePeer is called.
+	tests := []struct {
+		name string
+		id   sentryproto.MessageId
+		data []byte // deliberately malformed payload
+	}{
+		{
+			name: "malformed Transactions66",
+			id:   sentryproto.MessageId_TRANSACTIONS_66,
+			data: []byte{0xff, 0xfe}, // invalid RLP
+		},
+		{
+			name: "malformed PooledTransactions66",
+			id:   sentryproto.MessageId_POOLED_TRANSACTIONS_66,
+			data: []byte{0xff, 0xfe},
+		},
+		{
+			name: "malformed NewPooledTransactionHashes66",
+			id:   sentryproto.MessageId_NEW_POOLED_TRANSACTION_HASHES_66,
+			data: []byte{0xff, 0xfe},
+		},
+		{
+			name: "malformed NewPooledTransactionHashes68",
+			id:   sentryproto.MessageId_NEW_POOLED_TRANSACTION_HASHES_68,
+			data: []byte{0xff, 0xfe},
+		},
+		{
+			name: "malformed GetPooledTransactions66",
+			id:   sentryproto.MessageId_GET_POOLED_TRANSACTIONS_66,
+			data: []byte{0xff, 0xfe},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+
+			sentryServer := sentryproto.NewMockSentryServer(ctrl)
+			pool := NewMockPool(ctrl)
+			pool.EXPECT().Started().Return(true)
+
+			// Expect PenalizePeer to be called exactly once with a Kick penalty.
+			sentryServer.EXPECT().
+				PenalizePeer(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, req *sentryproto.PenalizePeerRequest) (*emptypb.Empty, error) {
+					assert.Equal(t, sentryproto.PenaltyKind_Kick, req.Penalty)
+					assert.Equal(t, peerID, PeerID(req.PeerId))
+					return &emptypb.Empty{}, nil
+				}).
+				Times(1)
+
+			m := NewMockSentry(ctx, sentryServer)
+			sentryClient, err := direct.NewSentryClientDirect(direct.ETH68, m, nil)
+			require.NoError(t, err)
+
+			fetch := NewFetch(ctx, []sentryproto.SentryClient{sentryClient}, pool, nil, nil, u256.N1, log.New())
+
+			err = fetch.handleInboundMessageWithTx(ctx, nil, &sentryproto.InboundMessage{
+				Id:     tt.id,
+				Data:   tt.data,
+				PeerId: peerID,
+			}, sentryClient)
+			require.NoError(t, err, "malformed message should be handled gracefully (penalize + return nil)")
+		})
+	}
+}
+
+// TestNoPenaltyOnInternalDBError verifies that when IdHashKnown returns a DB error
+// during transaction parsing, the peer is NOT penalized (since it's our internal failure,
+// not the peer's fault).
+func TestNoPenaltyOnInternalDBError(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	// Build a valid Transactions66 RLP payload from a known good transaction.
+	txnRlp := decodeHex("f867088504a817c8088302e2489435353535353535353535353535353535353535358202008025a064b1702d9298fee62dfeccc57d322a463ad55ca201256d01f62b45b2e1c21c12a064b1702d9298fee62dfeccc57d322a463ad55ca201256d01f62b45b2e1c21c10")
+	validPayload := EncodeTransactions([][]byte{txnRlp}, nil)
+
+	ctrl := gomock.NewController(t)
+	sentryServer := sentryproto.NewMockSentryServer(ctrl)
+	pool := NewMockPool(ctrl)
+	pool.EXPECT().Started().Return(true)
+	pool.EXPECT().ValidateSerializedTxn(gomock.Any()).Return(nil).AnyTimes()
+
+	dbErr := fmt.Errorf("mdbx read error")
+	pool.EXPECT().IdHashKnown(gomock.Any(), gomock.Any()).Return(false, dbErr).AnyTimes()
+
+	// PenalizePeer must NOT be called.
+	sentryServer.EXPECT().PenalizePeer(gomock.Any(), gomock.Any()).Times(0)
+
+	m := NewMockSentry(ctx, sentryServer)
+	sentryClient, err := direct.NewSentryClientDirect(direct.ETH68, m, nil)
+	require.NoError(t, err)
+
+	fetch := NewFetch(ctx, []sentryproto.SentryClient{sentryClient}, pool, nil, nil, u256.N1, log.New())
+
+	err = fetch.handleInboundMessageWithTx(ctx, nil, &sentryproto.InboundMessage{
+		Id:     sentryproto.MessageId_TRANSACTIONS_66,
+		Data:   validPayload,
+		PeerId: peerID,
+	}, sentryClient)
+	require.Error(t, err, "internal DB error should be propagated, not swallowed")
+}
+
 func testRlps(num int) [][]byte {
 	rlps := make([][]byte, num)
 	for i := 0; i < num; i++ {


### PR DESCRIPTION
## Summary
- Penalize (kick/disconnect) peers that send malformed transaction-related P2P messages instead of just logging the error at Trace level
- Covers all message types in `handleInboundMessageWithTx`: `TRANSACTIONS_66`, `POOLED_TRANSACTIONS_66`, `NEW_POOLED_TRANSACTION_HASHES_66/68`, and `GET_POOLED_TRANSACTIONS_66`
- Introduces `errInternalDB` sentinel to distinguish local DB errors (from `IdHashKnown`) from parse errors, so innocent peers are not penalized for our internal failures

Closes erigontech/security#67

## Test plan
- [x] `TestPenalizePeerForMalformedMessages` — table-driven test covering all 5 message types with invalid RLP, asserts `PenalizePeer` called with `PenaltyKind_Kick`
- [x] `TestNoPenaltyOnInternalDBError` — sends valid transaction but mocks `IdHashKnown` to return DB error, asserts peer is NOT penalized and error is propagated
- [x] Existing tests pass (`go test -short ./txnprovider/txpool/...`)
- [x] `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)