### PR TITLE
[SharovBot] fix(shutter): wait for pending nonce after block build to prevent flaky TestShutterBlockBuilding

### DIFF
--- a/txnprovider/shutter/internal/testhelpers/contracts_deployer.go
+++ b/txnprovider/shutter/internal/testhelpers/contracts_deployer.go
@@ -21,6 +21,9 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"math/big"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/crypto"
@@ -56,12 +59,38 @@ func NewContractsDeployer(
 	}
 }
 
+// waitForPendingNonce polls PendingNonceAt until it reaches expectedNonce. This is
+// necessary because ForkChoiceUpdated persistence is asynchronous: after a block is
+// built and receipts become available, the txpool may not yet have updated its view
+// of the account nonce. Submitting the next transaction before the nonce is committed
+// can result in a stale nonce being used, causing the transaction to revert.
+func (d ContractsDeployer) waitForPendingNonce(ctx context.Context, expectedNonce uint64) error {
+	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	return backoff.Retry(func() error {
+		nonce, err := d.contractBackend.PendingNonceAt(waitCtx, d.address)
+		if err != nil {
+			return backoff.Permanent(err)
+		}
+		if nonce < expectedNonce {
+			return fmt.Errorf("pending nonce %d not yet at expected %d, retrying", nonce, expectedNonce)
+		}
+		return nil
+	}, backoff.WithContext(backoff.NewConstantBackOff(50*time.Millisecond), waitCtx))
+}
+
 func (d ContractsDeployer) DeployCore(ctx context.Context) (_ ContractsDeployment, err error) {
 	defer func() {
 		if err != nil {
 			fmt.Println("DEPLOY ERR", err, dbg.Stack())
 		}
 	}()
+
+	startNonce, err := d.contractBackend.PendingNonceAt(ctx, d.address)
+	if err != nil {
+		return ContractsDeployment{}, err
+	}
+
 	transactOpts, err := bind.NewKeyedTransactorWithChainID(d.key, d.chainId)
 	if err != nil {
 		return ContractsDeployment{}, err
@@ -103,6 +132,14 @@ func (d ContractsDeployer) DeployCore(ctx context.Context) (_ ContractsDeploymen
 		return ContractsDeployment{}, err
 	}
 
+	// Wait for the 3 deploy txns to be reflected in the pending nonce before
+	// submitting the next transaction. The txpool may briefly return a stale
+	// nonce after ForkChoiceUpdated persistence, causing the Initialize call
+	// to use nonce 0 instead of 3, which would revert.
+	if err = d.waitForPendingNonce(ctx, startNonce+3); err != nil {
+		return ContractsDeployment{}, err
+	}
+
 	ksmInitTxn, err := ksm.Initialize(transactOpts, d.address, d.address)
 	if err != nil {
 		return ContractsDeployment{}, err
@@ -132,6 +169,11 @@ func (d ContractsDeployer) DeployKeyperSet(
 	dep ContractsDeployment,
 	ekg EonKeyGeneration,
 ) (common.Address, *shuttercontracts.KeyperSet, error) {
+	startNonce, err := d.contractBackend.PendingNonceAt(ctx, d.address)
+	if err != nil {
+		return common.Address{}, nil, err
+	}
+
 	transactOpts, err := bind.NewKeyedTransactorWithChainID(d.key, d.chainId)
 	if err != nil {
 		return common.Address{}, nil, err
@@ -149,6 +191,10 @@ func (d ContractsDeployer) DeployKeyperSet(
 
 	err = d.txnInclusionVerifier.VerifyTxnsInclusion(ctx, block, keyperSetDeployTxn.Hash())
 	if err != nil {
+		return common.Address{}, nil, err
+	}
+
+	if err = d.waitForPendingNonce(ctx, startNonce+1); err != nil {
 		return common.Address{}, nil, err
 	}
 
@@ -182,6 +228,10 @@ func (d ContractsDeployer) DeployKeyperSet(
 		return common.Address{}, nil, err
 	}
 
+	if err = d.waitForPendingNonce(ctx, startNonce+5); err != nil {
+		return common.Address{}, nil, err
+	}
+
 	ksm, err := shuttercontracts.NewKeyperSetManager(dep.KsmAddr, d.contractBackend)
 	if err != nil {
 		return common.Address{}, nil, err
@@ -199,6 +249,10 @@ func (d ContractsDeployer) DeployKeyperSet(
 
 	err = d.txnInclusionVerifier.VerifyTxnsInclusion(ctx, block, addKeyperSetTxn.Hash())
 	if err != nil {
+		return common.Address{}, nil, err
+	}
+
+	if err = d.waitForPendingNonce(ctx, startNonce+6); err != nil {
 		return common.Address{}, nil, err
 	}
 


### PR DESCRIPTION
**[SharovBot]**

## Problem

`TestShutterBlockBuilding` was intermittently failing in CI with:

```
DEPLOY ERR txn 0 in block 5 not successful [contracts_deployer.go:62 contracts_deployer.go:118 block_building_integration_test.go:320 block_building_integration_test.go:63]
--- FAIL: TestShutterBlockBuilding (5.35s)
```

The `ksmInitTxn` (`ksm.Initialize`) was being included in block 5 but the transaction was reverting.

## Root Cause

ForkChoiceUpdated persistence in Erigon is asynchronous (as noted by the existing comment in `txn_inclusion_verifier.go`). After `BuildBlock()` is called and `VerifyTxnsInclusion()` confirms receipts are available, there is a brief window where:

1. The txpool has removed confirmed transactions from its pending pool (after processing the new canonical head)
2. But the committed state nonce is **not yet visible** to `PendingNonceAt()`

During this window, `PendingNonceAt()` returns a stale value (e.g., 0 instead of 3), because the txpool sees no pending transactions and the EVM state nonce has not been committed yet.

When `ksm.Initialize(transactOpts, ...)` is called in this window, the `bind.ContractBackend` calls `PendingNonceAt()` to get the nonce for the transaction. It gets nonce 0 (stale), signs and submits a transaction with nonce 0. When block 5 is built with this transaction, the EVM sees the deployer's committed nonce is 3, so the transaction with nonce 0 fails with `receipt.Status = 0`.

## Fix

Add `waitForPendingNonce()` calls in `ContractsDeployer` after each `VerifyTxnsInclusion()`. The helper polls `PendingNonceAt()` with 50ms backoff (up to 10s) until it returns at least the expected nonce value. This ensures the txpool and committed state are consistent before the next transaction is submitted.

The same fix is applied in both `DeployCore` and `DeployKeyperSet` to cover all block boundaries in the deployment sequence.

## Verification

Ran `TestShutterBlockBuilding` 4 consecutive times locally — all passed (~25s each). The test previously failed ~25% of the time on the sonar job.
