### PR TITLE
cl/beacon: fix nil pointer panics in GetEthV1ValidatorAttestationData

### DIFF
--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -144,6 +144,9 @@ func (a *ApiHandler) GetEthV1ValidatorAttestationData(
 	}
 
 	defer func() {
+		if committeeIndex == nil {
+			return
+		}
 		epoch := *slot / a.beaconChainCfg.SlotsPerEpoch
 		committeesPerSlot := a.syncedData.CommitteeCount(epoch)
 		subnet := subnets.ComputeSubnetForAttestation(

--- a/cl/beacon/synced_data/synced_data.go
+++ b/cl/beacon/synced_data/synced_data.go
@@ -162,6 +162,11 @@ func (s *SyncedDataManager) HeadRoot() common.Hash {
 }
 
 func (s *SyncedDataManager) CommitteeCount(epoch uint64) uint64 {
+	s.accessLock.RLock()
+	defer s.accessLock.RUnlock()
+	if s.headState == nil {
+		return 0
+	}
 	return s.headState.CommitteeCount(epoch)
 }
 


### PR DESCRIPTION
## Summary

- **`SyncedDataManager.CommitteeCount`** (`synced_data.go`): added `accessLock.RLock()` + nil check on `headState`, consistent with every other accessor in the same file. Fixes a panic when a validator client polls `/eth/v1/validator/attestation_data` before Caplin has synced to head. Also closes a check-then-act race in `pool.go` and `committee_subscription.go` where `Syncing()` is checked before `CommitteeCount` is called.
- **Debug-log defer** (`block_production.go`): guard against nil `committeeIndex` in the deferred log closure, which is nil on two early-return paths — pre-Electra requests missing the `committee_index` query param, and Electra cache-hit returns (the `committeeIndex = &zero` assignment is bypassed by the cache-hit early return at line 158).

## Reproduction

Start Erigon with a fresh `caplin/` directory (or right after node restart) while a Lighthouse VC is actively polling. The VC calls `GET /eth/v1/validator/attestation_data` before Caplin reaches head → panic in HTTP handler goroutine with `runtime error: invalid memory address or nil pointer dereference` at `CachingBeaconState.CommitteeCount(0x0, ...)`.

## Test plan

- [x] `go test ./cl/beacon/synced_data/... ./cl/beacon/handler/... -short` passes
- [x] `make lint` clean
- [x] Observed panic no longer reproducible after fix

Generated with Claude.