### PR TITLE
claude: add CI test skills (unit, all, race, hive, rpc, ci-orchestrator)

### DIFF
--- a/.claude/skills/erigon-ci/SKILL.md
+++ b/.claude/skills/erigon-ci/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: erigon-ci
+description: |
+  Run Erigon CI checks locally and/or trigger them remotely on a branch via GitHub Actions workflow_dispatch.
+  Use this when you need to verify a branch passes all CI before or after pushing — especially for branches
+  like bal-devnet-2 that don't auto-trigger on push/PR events.
+---
+
+# Erigon CI Skill
+
+Orchestrates CI verification: run test groups locally and/or dispatch GitHub Actions on any branch.
+
+Each test group has its own dedicated skill for drill-down on failures. Use those when a specific group fails and you need to re-run individual tests.
+
+---
+
+## Local Test Groups
+
+| Group | Skill | Command | Speed | Use When |
+|-------|-------|---------|-------|----------|
+| lint | *(inline)* | `make lint` | ~1 min | Before every push |
+| unit | `erigon-test-unit` | `make test-short` | ~5 min | Pre-push gate |
+| all | `erigon-test-all` | `GOGC=80 make test-all` | ~30 min | Before PR review |
+| race | `erigon-test-race` | `make test-all-race` | ~60 min | Concurrency changes |
+| hive | `erigon-test-hive` | `make test-hive` | ~20 min | EL/CL interop changes |
+| rpc | `erigon-test-rpc` | *(requires synced DB)* | ~10 min | RPC API changes |
+| assertoor | *(remote only)* | dispatch only | — | Kurtosis network test |
+
+### Lint (run first — non-deterministic, may need multiple runs)
+```bash
+make lint
+```
+
+### Quick gate (before pushing a fix)
+```bash
+make lint && make test-short
+```
+
+### Full gate (before marking PR ready for review)
+```bash
+make lint && make erigon integration && GOGC=80 make test-all
+```
+
+### Race check (for concurrency-sensitive changes)
+```bash
+make lint && make test-all-race
+```
+
+---
+
+## Part 2: Remote Dispatch (trigger CI on any branch)
+
+Use `gh workflow run` to trigger workflows on a branch. Required for branches not targeting main (e.g. `bal-devnet-2`).
+
+### Dispatch all workflows on a branch
+
+```bash
+BRANCH=$(git branch --show-current)  # or set explicitly: BRANCH="bal-devnet-2"
+
+for wf in \
+  "Unit tests" \
+  "All tests" \
+  "Lint" \
+  "Test Hive" \
+  "Kurtosis Assertoor GitHub Action" \
+  "QA - RPC Integration Tests" \
+  "QA - RPC Integration Tests Remote" \
+  "QA - RPC Integration Tests (Gnosis)" \
+  "Windows downloader tests"; do
+  echo "Dispatching: $wf"
+  gh workflow run "$wf" --ref $BRANCH
+done
+```
+
+### Workflow dispatch support
+
+| Workflow name (GitHub)              | dispatch? | Local skill | File |
+|-------------------------------------|-----------|-------------|------|
+| Unit tests                          | yes       | `erigon-test-unit` | `ci.yml` |
+| All tests                           | yes       | `erigon-test-all` | `test-all-erigon.yml` |
+| Lint                                | yes       | *(make lint)* | `lint.yml` |
+| Test Hive                           | yes       | `erigon-test-hive` | `test-hive.yml` |
+| Kurtosis Assertoor GitHub Action    | yes       | *(remote only)* | `test-kurtosis-assertoor.yml` |
+| QA - RPC Integration Tests          | yes       | `erigon-test-rpc` | `qa-rpc-integration-tests.yml` |
+| QA - RPC Integration Tests Remote   | yes       | `erigon-test-rpc` | `qa-rpc-integration-tests-remote.yml` |
+| QA - RPC Integration Tests (Gnosis) | yes       | `erigon-test-rpc` | `qa-rpc-integration-tests-gnosis.yml` |
+| Windows downloader tests            | yes       | *(remote)* | `test-win-downloader.yml` |
+| Consensus spec                      | **no**    | *(PR-only)* | `test-integration-caplin.yml` |
+
+Note: **Consensus spec** has no `workflow_dispatch` — only fires on pull_request events targeting main/release.
+
+### Monitor runs
+
+```bash
+BRANCH=$(git branch --show-current)
+gh run list --branch $BRANCH --limit 15
+```
+
+Check for failures:
+```bash
+gh run list --branch $BRANCH --limit 20 | grep -E "failure|cancelled"
+```
+
+Watch a specific run:
+```bash
+gh run watch <run-id>
+```
+
+---
+
+## Part 3: Full CI Gate (local + remote)
+
+When preparing a devnet/feature branch for review:
+
+1. **Local gate** — fast feedback before pushing:
+   ```bash
+   make lint && make erigon integration && make test-short
+   ```
+
+2. **Push branch**:
+   ```bash
+   git push origin <branch>
+   ```
+
+3. **Dispatch all remote workflows** (use the loop from Part 2).
+
+4. **Monitor** until all pass:
+   ```bash
+   gh run list --branch $(git branch --show-current) --limit 15
+   ```
+
+5. **Race check** (for concurrency-heavy changes):
+   ```bash
+   make test-all-race
+   ```

--- a/.claude/skills/erigon-test-all/SKILL.md
+++ b/.claude/skills/erigon-test-all/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: erigon-test-all
+description: Run the full Erigon test suite locally using GOGC=80 make test-all. Use this before marking a PR ready for review. Equivalent to the "All tests" CI workflow.
+---
+
+# Erigon Full Test Suite
+
+Runs the complete test suite with 60-minute timeout and coverage output. Takes ~30 minutes.
+
+## Command
+
+```bash
+GOGC=80 make test-all
+```
+
+Equivalent to the **"All tests"** GitHub Actions workflow (`test-all-erigon.yml`).
+
+## When Tests Fail — Drill Down
+
+When `make test-all` fails, identify and re-run just the failing package/test:
+
+```bash
+# Re-run just the failing package
+go test --timeout 60m ./execution/stagedsync/...
+
+# Re-run a specific test by name
+go test --timeout 60m -run TestStagedSyncFoo ./execution/stagedsync/...
+
+# Run with verbose output to see what's happening
+go test --timeout 60m -v -run TestName ./path/to/package/...
+
+# Run with GOGC to match CI memory pressure
+GOGC=80 go test --timeout 60m ./path/to/package/...
+```
+
+## Find Which Package Failed
+
+The output shows the failing package path. Look for lines like:
+```
+FAIL    github.com/erigontech/erigon/execution/stagedsync [build failed]
+--- FAIL: TestName (12.34s)
+```
+
+Extract the import path after `github.com/erigontech/erigon/` and convert to a local path:
+```
+github.com/erigontech/erigon/execution/stagedsync → ./execution/stagedsync/
+```
+
+## Common Skips
+
+Tests skipped via `-short` in `test-short` run fully here. If a test passes in `test-short` but fails here, it likely tests a slow path (large dataset, timeout, DB heavy).
+
+## When to Use
+
+- Before marking a PR ready for review
+- After significant logic changes to verify no edge cases break
+- Full gate: `make lint && make erigon integration && GOGC=80 make test-all`
+
+## CI Equivalent
+
+| Local command | CI workflow | File |
+|---------------|-------------|------|
+| `GOGC=80 make test-all` | All tests | `test-all-erigon.yml` |
+
+To dispatch remotely:
+```bash
+gh workflow run "All tests" --ref <branch>
+```

--- a/.claude/skills/erigon-test-hive/SKILL.md
+++ b/.claude/skills/erigon-test-hive/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: erigon-test-hive
+description: Run Erigon Hive simulator tests locally or via GitHub Actions. Tests EL/CL protocol interoperability (engine API, RPC compat, EEST fixtures). Requires Docker and either `act` (for CI simulation) or direct hive invocation.
+---
+
+# Erigon Hive Tests
+
+Runs Hive simulator tests for EL/CL protocol interoperability. Two modes:
+1. **`make test-hive`** — uses `act` (nektos) to simulate the GitHub Actions workflow locally
+2. **`make hive-local`** — builds hive and runs suites directly (no `act` needed)
+3. **`make eest-bal`** — runs the BAL/Amsterdam-specific EEST fixtures
+
+## Prerequisites
+
+- Docker running
+- `GITHUB_TOKEN` environment variable set (for `make test-hive` via `act`)
+- `act` installed (for `make test-hive`): https://nektosact.com/installation/index.html
+
+## Docker Resource Warning
+
+**Hive creates many Docker containers and images per test run.** Without cleanup, these accumulate and exhaust disk space and memory. Always run the cleanup steps below — even after a clean run.
+
+Hive spawns per test:
+- One container per EL client instance (erigon)
+- One container per simulator (e.g., `ethereum/engine`, `eels/consume-engine`)
+- Intermediate build images for each client Dockerfile
+
+The CI workflow always runs `docker system prune -af --volumes` on exit (even on failure). Replicate this locally.
+
+## Commands
+
+### Via act (mirrors CI exactly)
+
+```bash
+export GITHUB_TOKEN=<your-token>
+
+# Run standard hive suite (engine API, RPC compat, EEST)
+make test-hive
+
+# Run EEST-only suite
+SUITE=eest make test-hive
+```
+
+### Direct hive run (no act required)
+
+```bash
+# Build erigon Docker image and run engine/rpc-compat suites
+make hive-local
+```
+
+### BAL/Amsterdam-specific (EIP-7928 fixtures)
+
+```bash
+# Runs eels/consume-engine with amsterdam fixtures
+make eest-bal
+```
+
+## Cleanup (ALWAYS run after hive tests)
+
+Hive leaves behind stopped containers, dangling images, and build caches. Run this after every hive test run, including after failures or ctrl+c:
+
+```bash
+# Stop all running hive-related containers
+docker ps --filter "name=hive" -q | xargs -r docker stop
+
+# Full prune: removes all stopped containers, unused images, build cache, volumes
+docker system prune -af --volumes
+```
+
+### Automated cleanup with trap (recommended for direct hive invocations)
+
+Wrap hive invocations in a script with a trap so cleanup runs on exit/ctrl+c:
+
+```bash
+cleanup() {
+  echo "Cleaning up Docker resources..."
+  docker ps --filter "name=hive" -q | xargs -r docker stop 2>/dev/null || true
+  docker system prune -af --volumes
+  echo "Docker cleanup complete"
+}
+trap cleanup EXIT INT TERM
+
+cd temp/<hive-dir>/hive
+./hive --sim ethereum/engine --sim.limit=".*cancun.*" --client erigon
+```
+
+### Check what's accumulated
+
+```bash
+# Show disk usage by Docker
+docker system df
+
+# List dangling images
+docker images --filter dangling=true
+
+# List stopped containers from hive
+docker ps -a --filter "name=hive" --format "table {{.Names}}\t{{.Status}}\t{{.Size}}"
+```
+
+## When a Suite Fails — Drill Down
+
+Hive outputs test results to `temp/*/hive/workspace/logs/`. View results in the hiveview browser:
+
+```bash
+# hiveview serves results at http://localhost:3000
+cd temp/<hive-dir>/hive
+./hiveview --serve --logdir ./workspace/logs
+```
+
+Re-run a single suite by specifying the simulator and limit:
+```bash
+cd temp/<hive-dir>/hive
+
+# Run only the failing simulator
+./hive --sim ethereum/engine --sim.limit=exchange-capabilities --client erigon
+
+# Run with a specific test pattern
+./hive --sim ethereum/engine --sim.limit=".*cancun.*" --sim.parallelism=4 --client erigon
+
+# Run EEST engine simulator
+./hive --sim ethereum/eels/consume-engine --sim.limit="" --client erigon \
+  --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/v5.3.0/fixtures_develop.tar.gz
+```
+
+## Suites Covered
+
+| Suite | Description |
+|-------|-------------|
+| `engine/exchange-capabilities` | Engine API capability negotiation |
+| `engine/withdrawals` | Withdrawals support |
+| `engine/cancun` | Cancun/EIP-4844 blob txs |
+| `engine/api` | Engine API conformance |
+| `engine/auth` | JWT authentication |
+| `rpc-compat` | RPC compatibility with reference |
+| `eels/consume-engine` | EEST execution spec tests |
+| `eels/consume-engine` (amsterdam) | EIP-7928 BAL Amsterdam fixtures |
+
+## Related Skill
+
+For an **interactive, ephemeral hive workflow** (handles versioned EEST fixtures, Dockerfile setup, BAL workarounds, per-suite parallelism), use the `/hive-test` skill instead:
+```
+/hive-test eest-bal          # run BAL amsterdam tests
+/hive-test engine rpc-compat # run engine + rpc suites
+/hive-test all               # run everything
+```
+The `/hive-test` skill also covers detailed cleanup via `./hive --cleanup` + `docker image prune -f`.
+
+This skill (`erigon-test-hive`) documents the Makefile targets for reference — use `/hive-test` when you need a full guided run.
+
+## CI Equivalent
+
+| Local command | CI workflow | File |
+|---------------|-------------|------|
+| `make test-hive` | Test Hive | `test-hive.yml` |
+
+To dispatch remotely on a branch:
+```bash
+gh workflow run "Test Hive" --ref <branch>
+```
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| `act command not found` | Install from https://nektosact.com/installation/index.html |
+| `GITHUB_TOKEN` not set | `export GITHUB_TOKEN=$(gh auth token)` |
+| Docker build fails | Ensure `make erigon` succeeded first (builds binary used in Docker image) |
+| Hive clone fails | Check network; hive is cloned fresh each run into `temp/` |
+| EEST fixtures 404 | Check `EEST_VERSION` in Makefile; fixtures URL must match a released tag |
+| Disk full / OOM | Run `docker system prune -af --volumes` — previous hive runs left dangling images/containers |
+| Containers stuck running | `docker ps --filter "name=hive" -q \| xargs -r docker stop` |

--- a/.claude/skills/erigon-test-race/SKILL.md
+++ b/.claude/skills/erigon-test-race/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: erigon-test-race
+description: Run Erigon tests with Go race detector to find data races and concurrency bugs. Use this for concurrency-sensitive changes (parallel executor, p2p, txpool). Takes 30-60 minutes.
+---
+
+# Erigon Race Detector Tests
+
+Runs the full test suite with Go's `-race` flag. Catches concurrency bugs that normal tests miss. Takes 30–60 minutes.
+
+## Command
+
+```bash
+make test-all-race
+```
+
+## When Tests Fail — Drill Down
+
+Race detector output includes the goroutine stack traces that caused the race:
+
+```
+==================
+WARNING: DATA RACE
+Read at 0x00c0001a2b40 by goroutine 45:
+  github.com/erigontech/erigon/execution/exec3.(*parallelExecutor).applyLoop()
+      /path/to/exec3_parallel.go:123 +0x4f8
+
+Previous write at 0x00c0001a2b40 by goroutine 23:
+  github.com/erigontech/erigon/execution/exec3.(*parallelExecutor).executeBlocks()
+      /path/to/exec3.go:456 +0x2a0
+==================
+```
+
+Re-run just the failing package with race:
+```bash
+go test -race --timeout 60m ./execution/exec3/...
+go test -race --timeout 60m -run TestName ./path/to/package/...
+```
+
+Run without race first to confirm the test passes normally, then add `-race`:
+```bash
+# 1. Confirm test logic is correct (fast)
+go test -short -run TestName ./path/to/package/...
+
+# 2. Check for races (slower)
+go test -race -run TestName ./path/to/package/...
+```
+
+## Known Race-Prone Areas
+
+Areas historically susceptible to races in Erigon:
+- `execution/exec3/` — parallel executor, `SharedDomains`, `AsyncTx`
+- `p2p/` — sentry, peer manager
+- `txpool/` — concurrent transaction pool
+- `cl/` — caplin consensus layer goroutines
+
+## When to Use
+
+- After changes to the parallel executor or concurrent code paths
+- For concurrency-sensitive fixes before merging
+- Race check gate: `make lint && make test-all-race`
+
+## CI Equivalent
+
+There is no dedicated race CI workflow — the "All tests" workflow does not run with `-race` by default. This is a local-only check.
+
+To run a subset with race via CI, consider running locally or using:
+```bash
+go test -race --timeout 60m ./execution/exec3/... ./execution/stagedsync/...
+```

--- a/.claude/skills/erigon-test-rpc/SKILL.md
+++ b/.claude/skills/erigon-test-rpc/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: erigon-test-rpc
+description: Run QA RPC Integration Tests locally against a synced Erigon datadir, or dispatch them remotely via GitHub Actions. Tests compare rpcdaemon JSON-RPC responses against expected results from erigontech/rpc-tests.
+---
+
+# QA RPC Integration Tests
+
+Tests that run `rpcdaemon` against a pre-synced Erigon datadir and compare JSON-RPC responses against golden expected outputs from the [`erigontech/rpc-tests`](https://github.com/erigontech/rpc-tests) repository.
+
+## Prerequisites
+
+- A **synced Erigon mainnet datadir** (the tests need specific blocks to exist — tests at block ~24.3M require sync to at least that height)
+- Python 3 (for the rpc-tests runner)
+- `rpcdaemon` and `integration` binaries built (`make rpcdaemon integration`)
+
+## How It Works
+
+The CI workflow:
+1. Backs up chaindata from the reference datadir
+2. Runs `integration run_migrations` to apply pending migrations
+3. Starts `rpcdaemon --datadir <reference-datadir>`
+4. Runs `run_rpc_tests.sh` which clones `erigontech/rpc-tests`, sets up a Python venv, and runs `run_tests.py` against port 8545
+5. Restores original chaindata from backup
+
+The backup/restore pattern exists because `run_migrations` writes to the DB.
+
+## Local Setup
+
+### Step 1: Set your reference datadir
+
+```bash
+# Point to your synced mainnet Erigon node
+export ERIGON_REFERENCE_DATA_DIR=/path/to/your/erigon/mainnet-datadir
+
+# Optional: workspace for test output
+export WORKSPACE=/tmp/rpc-test-run
+mkdir -p $WORKSPACE
+```
+
+### Step 2: Back up chaindata (protects your DB from migration writes)
+
+```bash
+cp -r $ERIGON_REFERENCE_DATA_DIR/chaindata /tmp/chaindata-backup
+```
+
+### Step 3: Build binaries
+
+```bash
+make rpcdaemon integration
+```
+
+### Step 4: Run migrations
+
+```bash
+./build/bin/integration run_migrations --datadir $ERIGON_REFERENCE_DATA_DIR --chain mainnet
+```
+
+### Step 5: Start rpcdaemon
+
+```bash
+./build/bin/rpcdaemon --datadir $ERIGON_REFERENCE_DATA_DIR \
+  --http.api admin,debug,eth,parity,erigon,trace,web3,txpool,ots,net \
+  --ws > /tmp/rpcdaemon.log 2>&1 &
+
+RPC_DAEMON_PID=$!
+
+# Wait for port 8545
+for i in {1..30}; do
+  nc -z localhost 8545 && break || sleep 5
+done
+```
+
+### Step 6: Run the tests
+
+```bash
+.github/workflows/scripts/run_rpc_tests_ethereum.sh $WORKSPACE /tmp/rpc-results
+echo "Exit: $?"
+```
+
+### Step 7: Stop and restore
+
+```bash
+kill $RPC_DAEMON_PID
+
+# Restore original chaindata
+rm -rf $ERIGON_REFERENCE_DATA_DIR/chaindata
+mv /tmp/chaindata-backup $ERIGON_REFERENCE_DATA_DIR/chaindata
+```
+
+## Run a Single Test Manually
+
+Clone rpc-tests and run one test directly:
+
+```bash
+git clone --depth 1 --branch v1.121.0 https://github.com/erigontech/rpc-tests /tmp/rpc-tests
+cd /tmp/rpc-tests
+python3 -m venv .venv && source .venv/bin/activate
+pip3 install -r requirements.txt
+
+cd integration
+# Run just one test
+python3 run_tests.py --blockchain mainnet --port 8545 \
+  --include-api-list eth_getBlockByNumber/test_1.json \
+  --display-only-fail --json-diff
+```
+
+## When Tests Fail — Drill Down
+
+The runner outputs diffs for failing tests. Each test is a `.json` file in the `integration/<chain>/` directory of `rpc-tests`. To investigate:
+
+```bash
+# Show which tests failed
+grep "FAILED\|PASS\|SKIP" /tmp/rpc-results/output.log | grep FAIL
+
+# Re-run just the failing API group
+cd /tmp/rpc-tests/integration
+python3 run_tests.py --blockchain mainnet --port 8545 \
+  --include-api-list eth_getBlockByNumber \
+  --display-only-fail --json-diff
+
+# Run with full response dump to see what rpcdaemon returned
+python3 run_tests.py --blockchain mainnet --port 8545 \
+  --include-api-list eth_getBlockByNumber/test_1.json \
+  --dump-response
+```
+
+## Disabled Tests
+
+Some tests are intentionally disabled in the CI run (see `run_rpc_tests_ethereum.sh`). These include:
+- Engine API tests (require active Erigon engine, not just rpcdaemon)
+- Tests requiring specific peer state (`net_peerCount`, `admin_peers`, etc.)
+- Known-broken tests with open issues
+
+## CI Equivalents
+
+| Variant | CI workflow | File |
+|---------|-------------|------|
+| Mainnet | QA - RPC Integration Tests | `qa-rpc-integration-tests.yml` |
+| Latest blocks | QA - RPC Integration Tests Remote | `qa-rpc-integration-tests-remote.yml` |
+| Gnosis | QA - RPC Integration Tests (Gnosis) | `qa-rpc-integration-tests-gnosis.yml` |
+
+Remote dispatch:
+```bash
+gh workflow run "QA - RPC Integration Tests" --ref <branch>
+gh workflow run "QA - RPC Integration Tests Remote" --ref <branch>
+gh workflow run "QA - RPC Integration Tests (Gnosis)" --ref <branch>
+```
+
+## TODO: Reference Datadir Setup
+
+The CI runner maintains a pre-synced mainnet datadir at `/opt/erigon-versions/reference-version/datadir`. To create a local equivalent:
+
+1. Sync Erigon mainnet to at least block ~24.5M (covers all test cases)
+2. Stop the node cleanly
+3. Set `ERIGON_REFERENCE_DATA_DIR` to that datadir
+4. Follow the workflow above
+
+A full mainnet sync takes ~2-4 days on NVMe with `--prune.mode=minimal`. Alternatively, ask the team for a snapshot of the reference datadir.

--- a/.claude/skills/erigon-test-unit/SKILL.md
+++ b/.claude/skills/erigon-test-unit/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: erigon-test-unit
+description: Run Erigon unit tests locally using make test-short. Use this for fast pre-push verification. Equivalent to the "Unit tests" CI workflow.
+---
+
+# Erigon Unit Tests
+
+Runs the full unit test suite with `-short -failfast`. Catches most regressions in ~5 minutes.
+
+## Command
+
+```bash
+make test-short
+```
+
+Equivalent to the **"Unit tests"** GitHub Actions workflow (`ci.yml`).
+
+## Run Specific Package
+
+```bash
+go test -short ./execution/stagedsync/...
+go test -short -run TestName ./path/to/package/...
+```
+
+## Run from Repository Root
+
+Must be run from the repository root (where the Makefile lives):
+
+```bash
+cd /path/to/erigon
+make test-short
+```
+
+## When to Use
+
+- Before every push as a fast gate
+- After fixing a bug to confirm no regressions
+- Part of the quick gate: `make lint && make test-short`
+
+## CI Equivalent
+
+| Local command | CI workflow | Trigger |
+|---------------|-------------|---------|
+| `make test-short` | Unit tests (`ci.yml`) | push/PR to main or dispatch |
+
+To dispatch remotely on a branch without a PR:
+```bash
+gh workflow run "Unit tests" --ref <branch>
+```


### PR DESCRIPTION
## Summary

Adds six new Claude Code agent skills to `.claude/skills/` for running and managing CI checks locally and remotely:

- **`erigon-ci`** — orchestrator skill; dispatches all GitHub Actions workflows on any branch via `gh workflow run` (required for branches like `bal-devnet-2` that don't auto-trigger CI), with a summary table linking to each test skill
- **`erigon-test-unit`** — `make test-short`; fast pre-push gate (~5 min), documents per-package drill-down for failures
- **`erigon-test-all`** — `GOGC=80 make test-all`; full test suite (~30 min), with guidance on extracting failing packages and re-running individually
- **`erigon-test-race`** — `make test-all-race`; race detector for concurrency-sensitive changes (~60 min)
- **`erigon-test-hive`** — Makefile-based hive test reference (`make test-hive`, `hive-local`, `eest-bal`); includes Docker cleanup instructions and a `trap`-based cleanup pattern to prevent resource exhaustion from dangling containers/images; cross-references the existing `/hive-test` skill for interactive runs
- **`erigon-test-rpc`** — QA RPC integration tests; documents local execution against a synced mainnet datadir with chaindata backup/restore around migrations, plus remote `gh workflow run` dispatch; the `erigontech/rpc-tests` framework is cloned automatically by the existing shell script

## Test plan

- [ ] Verify skills load in Claude Code IDE (`/erigon-ci`, `/erigon-test-unit`, etc.)
- [ ] Confirm no IDE warnings in skill frontmatter (no `allowed-tools` attribute)
- [ ] Run `/erigon-test-unit` and verify it executes `make test-short`

🤖 Generated with [Claude Code](https://claude.com/claude-code)