### PR TITLE
refactor: omit unnecessary reassignment

### DIFF
--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -1211,7 +1211,6 @@ func doIntegrity(cliCtx *cli.Context) error {
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(1)
 	for _, chk := range requestedChecks {
-		chk := chk
 		g.Go(func() error {
 			logger.Info("[integrity] starting", "check", chk)
 			if err := func() error {

--- a/db/integrity/commitment_integrity.go
+++ b/db/integrity/commitment_integrity.go
@@ -329,7 +329,6 @@ func CheckCommitmentKvDeref(ctx context.Context, db kv.TemporalRoDB, cache *Inte
 	var successFps [][]fileFingerprint
 	var branchKeys, referencedAccounts, plainAccounts, referencedStorages, plainStorages atomic.Uint64
 	for _, w := range works {
-		w := w
 		eg.Go(func() error {
 			counts, err := checkCommitmentKvDeref(ctx, w.file, stepSize, failFast, logger)
 			if err == nil {

--- a/db/integrity/integrity_kvi.go
+++ b/db/integrity/integrity_kvi.go
@@ -105,7 +105,6 @@ func CheckKvis(ctx context.Context, tx kv.TemporalTx, domain kv.Domain, checkTyp
 	var successFps [][]fileFingerprint
 	var keyCount atomic.Uint64
 	for _, w := range works {
-		w := w
 		eg.Go(func() error {
 			keys, err := CheckKvi(ctx, w.kviPath, w.kvPath, kvCompression, sc, failFast, logger)
 			if err == nil {

--- a/db/integrity/torrent_verify.go
+++ b/db/integrity/torrent_verify.go
@@ -93,7 +93,6 @@ func VerifyTorrentFiles(ctx context.Context, dir string, failFast bool, logger l
 	}()
 
 	for _, torrentFile := range toVerify {
-		torrentFile := torrentFile
 		g.Go(func() error {
 			defer completedFiles.Add(1)
 			err := verifyFileFromTorrent(ctx, torrentFile, &completedBytes)

--- a/db/recsplit/eliasfano32/elias_fano_seek_bench_test.go
+++ b/db/recsplit/eliasfano32/elias_fano_seek_bench_test.go
@@ -50,7 +50,6 @@ func BenchmarkGet(b *testing.B) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		ef := buildEF(count, tc.stride)
 
 		// precompute random permutation of indices so the access pattern is random
@@ -95,7 +94,6 @@ func BenchmarkSeek(b *testing.B) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		ef := buildEF(count, tc.stride)
 		maxOffset := (count - 1) * tc.stride
 
@@ -129,7 +127,6 @@ func BenchmarkAddOffset(b *testing.B) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		b.Run(tc.name, func(b *testing.B) {
 			b.ReportAllocs()
 			maxOffset := (count - 1) * tc.stride

--- a/db/recsplit/recsplit_test.go
+++ b/db/recsplit/recsplit_test.go
@@ -578,7 +578,6 @@ func TestParallelMatchesSequential(t *testing.T) {
 	seqSum := fileChecksum(seqFile)
 
 	for _, workers := range []int{2, 4, 8} {
-		workers := workers
 		t.Run(fmt.Sprintf("workers=%d", workers), func(t *testing.T) {
 			parFile := filepath.Join(tmpDir, fmt.Sprintf("par_w%d.idx", workers))
 			build(workers, parFile)

--- a/db/seg/sais/sais_test.go
+++ b/db/seg/sais/sais_test.go
@@ -134,7 +134,6 @@ func TestExpand8_32BStrictlyDecreasing(t *testing.T) {
 	}
 
 	for _, tc := range inputs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			text := tc.data
 			n := len(text)


### PR DESCRIPTION
Inspired by PR https://github.com/erigontech/erigon/pull/17147, and replaced additional cases as well.


The new version of Go has been optimized, and variables do not need to be reassigned.

For more info: https://tip.golang.org/wiki/LoopvarExperiment#does-this-mean-i-dont-have-to-write-x--x-in-my-loops-anymore