### PR TITLE
ci: run Kurtosis Docker volumes on a RAM disk

### DIFF
--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -63,13 +63,6 @@ jobs:
           username: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_USERNAME }}
           password: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_TOKEN }}
 
-      - name: Move Docker volumes to RAM disk
-        run: |
-          sudo systemctl stop docker
-          sudo mkdir -p /var/lib/docker/volumes
-          sudo mount -t tmpfs -o size=4096m tmpfs /var/lib/docker/volumes
-          sudo systemctl start docker
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -106,6 +99,13 @@ jobs:
           tags: test/erigon:current
           cache-from: type=gha,scope=kurtosis-erigon-build
           cache-to: type=gha,mode=max,scope=kurtosis-erigon-build
+
+      - name: Move Docker volumes to RAM disk
+        run: |
+          sudo systemctl stop docker
+          sudo mkdir -p /var/lib/docker/volumes
+          sudo mount -t tmpfs -o size=4096m tmpfs /var/lib/docker/volumes
+          sudo systemctl start docker
 
       - name: Run ${{ matrix.suite }} Kurtosis + assertoor tests
         uses: ethpandaops/kurtosis-assertoor-github-action@v1


### PR DESCRIPTION
## Summary

Attempted to speed up Kurtosis assertoor tests by mounting a 4 GB tmpfs
on `/var/lib/docker/volumes` just before the kurtosis run, so that all
Kurtosis-created node volumes (Erigon MDBX datadir, CL state) land in
RAM rather than on the SSD.

## Findings

Pectra and regular test times with and without the ramdisk:

| | pectra | regular |
|---|---|---|
| baseline (main) | 28m 59s | 33m 38s |
| with ramdisk | 29m 42s | 32m 56s |

No meaningful difference. Historical range on main across 17 runs:
min=33m, typical=34m, occasional=35–37m. Our run lands squarely in that
range.

## Why ramdisks won't help here

Kurtosis test duration is dominated by **consensus protocol timing**:
- Each slot is 12 seconds
- Each epoch is 32 slots = 6.4 minutes
- Assertoor waits for real on-chain events (finality, deposits, etc.)

Erigon on a fresh devnet processes only a few hundred blocks total —
even on a spinning disk that would be negligible. Unlike the MDBX
execution tests (which got ~12x faster from a ramdisk because they
write millions of state entries as fast as possible), kurtosis tests are
waiting for a clock, not for disk.

Mounting tmpfs inside the containers (`--tmpfs /data`) would be
technically cleaner but Kurtosis's `ServiceConfig` Starlark API doesn't
expose a `tmpfs` parameter, and the bottleneck still wouldn't be disk.