### PR TITLE
integration: fix stage_exec performance (1 to 12-15 blk/s)

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -604,6 +604,7 @@ func stageSenders(db kv.TemporalRwDB, ctx context.Context, logger log.Logger) er
 }
 
 func stageExec(db kv.TemporalRwDB, ctx context.Context, logger log.Logger) error {
+	dbg.Exec3Parallel = true
 	if chainTipMode && noCommit {
 		return errors.New("--sync.mode.chaintip cannot work with --no-commit to be false")
 	}

--- a/execution/exec/blocks_read_ahead.go
+++ b/execution/exec/blocks_read_ahead.go
@@ -273,7 +273,7 @@ func ReadBlockWithSendersFromGlobalReadAheader(blockHash common.Hash) (*types.Bl
 }
 
 func BlocksReadAhead(ctx context.Context, workers int, db kv.RoDB, engine rules.Engine, blockReader services.FullBlockReader) (chan uint64, context.CancelFunc) {
-	const readAheadBlocks = 100
+	const readAheadBlocks = 500
 	readAhead := make(chan uint64, readAheadBlocks)
 	g, gCtx := errgroup.WithContext(ctx)
 	for workerNum := 0; workerNum < workers; workerNum++ {

--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -215,7 +215,7 @@ func ExecV3(ctx context.Context,
 	// snapshots are often stored on chaper drives. don't expect low-read-latency and manually read-ahead.
 	// can't use OS-level ReadAhead - because Data >> RAM
 	// it also warmsup state a bit - by touching senders/coninbase accounts and code
-	if !execStage.CurrentSyncCycle.IsInitialCycle && isApplyingBlocks {
+	if isApplyingBlocks {
 		var clean func()
 
 		readAhead, clean = exec.BlocksReadAhead(ctx, 2, cfg.db, cfg.engine, cfg.blockReader)


### PR DESCRIPTION
## Summary

The integration tool's `stage_exec` was running at ~1 blk/s instead of the expected ~16 blk/s. Three small fixes bring it to 12-15 blk/s — matching normal erigon execution at the same block range.

### Changes

- **Enable parallel execution by default** — `cmd/integration/commands/stages.go`: Set `dbg.Exec3Parallel = true` at the start of `stageExec()`. The integration tool was defaulting to serial single-worker execution.
- **Enable readAhead during initial cycle** — `execution/stagedsync/exec3.go`: Remove the `!IsInitialCycle` gate from readAhead activation. The integration tool runs with `IsInitialCycle=true`, which prevented block/state prefetching — the largest single contributor to the slowdown.
- **Increase readAhead prefetch depth** — `execution/exec/blocks_read_ahead.go`: Increase `readAheadBlocks` from 100 to 500. Deeper prefetching keeps the page cache warm ahead of execution when data is local on NVMe.

None of these changes alter read/write behavior or state advancement logic — they only affect execution parallelism and cache warming.

### Performance — hoodi chain at block ~1.25M, bare-metal 12-core

| Metric | Before | After | Reference — normal erigon |
|--------|--------|-------|--------------------------|
| blk/s | 1 | 12-15 | 16-17 |
| bdur | 1s | 65-82ms | 64-73ms |
| tx/s | 28 | 570-648 | 615-667 |

## Test plan

- [x] Verified on hoodi chain at block ~1.25M on bare-metal Linux — 12-core
- [ ] Confirm no regression in normal erigon execution — readAhead change applies to both paths
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
