### PR TITLE
p2p: skip chain-specific bootnodes when genesis hash doesn't match

### DIFF
--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -439,10 +439,12 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 
 		p2pConfig.DiscoveryDNS = backend.config.EthDiscoveryURLs
 
-		// Resolve chain-specific bootnodes and DNS for sentry servers
+		// Resolve chain-specific bootnodes and DNS for sentry servers.
+		// Only use them when the actual genesis hash matches the chain spec to avoid
+		// connecting to mainnet bootnodes when running with a custom genesis (e.g. Hive tests).
 		var chainBootnodes []string
 		var chainDNSNetwork string
-		if spec, err := chainspec.ChainSpecByName(config.Snapshot.ChainName); err == nil {
+		if spec, err := chainspec.ChainSpecByName(config.Snapshot.ChainName); err == nil && spec.GenesisHash == backend.genesisHash {
 			chainBootnodes = spec.Bootnodes
 			chainDNSNetwork = spec.DNSNetwork
 		}


### PR DESCRIPTION
## Summary

- After #19751 changed bootnode resolution from genesis-hash-based to name-based, Hive EEST tests (`consume-engine`, `consume-rlp`) started timing out
- The `--chain` flag defaults to `"mainnet"`, so `ChainSpecByName("mainnet")` succeeds and passes mainnet bootnodes to the sentry even when the actual genesis is a custom Hive test genesis
- The p2p server then starts inside the isolated Docker container trying to connect to real mainnet bootnodes, consuming resources and pushing test runtime past the CI timeout
- Fix: gate bootnode/DNS resolution on the actual genesis hash matching the chain spec's expected genesis hash

## Test plan

- [ ] Hive EEST `consume-engine` passes without timeout
- [ ] Hive EEST `consume-rlp` (`.*eip2930_access_list.*`) passes without timeout
- [ ] Normal mainnet sync still discovers peers (genesis hash matches → bootnodes used as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)