### PR TITLE
[SharovBot] fix eth_simulateV1 rejecting block number -1

### DIFF
--- a/rpc/jsonrpc/eth_simulation.go
+++ b/rpc/jsonrpc/eth_simulation.go
@@ -122,6 +122,15 @@ func (api *APIImpl) SimulateV1(ctx context.Context, req SimulationRequest, block
 	if err != nil {
 		return nil, err
 	}
+	// Block number -1 in JSON-RPC means "latest". GetBlockNumber converts it
+	// to math.MaxUint64 (uint64 underflow), so clamp it to the latest block.
+	if blockNumber == math.MaxUint64 {
+		blockNumber = latestBlockNumber
+		blockHash, err = rawdb.ReadCanonicalHash(tx, blockNumber)
+		if err != nil {
+			return nil, err
+		}
+	}
 	if latestBlockNumber < blockNumber {
 		return nil, fmt.Errorf("block number is in the future latest=%d requested=%d", latestBlockNumber, blockNumber)
 	}


### PR DESCRIPTION
**[SharovBot]**

## Summary
- Fix `eth_simulateV1` returning "block number is in the future" when called with block number `-1`
- When `-1` is passed as a JSON integer, `rpchelper.GetBlockNumber` converts it to `math.MaxUint64` (uint64 underflow), causing the future-block check added in PR #19364 to reject it
- Before the future-block check, detect `math.MaxUint64` and clamp to the latest block number

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./rpc/jsonrpc/... -count=3` passes (no failures)
- [x] No `*_test.go` files modified

Fixes https://github.com/erigontech/erigon/issues/19758

🤖 Generated with [Claude Code](https://claude.com/claude-code)