### PR TITLE
parallel: reduce execRequests/in/applyResults buffers from 100k to prevent OOM

### DIFF
--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -561,8 +561,23 @@ func (pe *parallelExecutor) execLoop(ctx context.Context) (err error) {
 			return err
 		}
 
+		// Limit how many blocks can be pending in pe.blockExecutors simultaneously.
+		// processRequest is non-blocking (it just stores blocks in the map), so
+		// without this check execRequests drains instantly and pe.blockExecutors
+		// grows unbounded — holding all decoded TxTask objects in RAM.
+		// Setting pendingCh to nil causes the select to skip that case entirely,
+		// applying backpressure that propagates to executeBlocks.func1.
+		const maxPendingBlocks = 32
+		pe.RLock()
+		pendingBlocks := len(pe.blockExecutors)
+		pe.RUnlock()
+		var pendingCh chan *execRequest
+		if pendingBlocks < maxPendingBlocks {
+			pendingCh = pe.execRequests
+		}
+
 		select {
-		case exec := <-pe.execRequests:
+		case exec := <-pendingCh:
 			if err := pe.processRequest(ctx, exec); err != nil {
 				return err
 			}


### PR DESCRIPTION
## Summary

Fixes unbounded memory growth in the parallel executor, observed when running `integration stage_exec` with `EXEC3_PARALLEL=true` (or during normal erigon sync with the parallel executor enabled).

### Root cause

Two separate issues compound:

**1. Unbounded `pe.blockExecutors` map** (the real problem)

`processRequest` is non-blocking — it stores decoded blocks in `pe.blockExecutors` without any capacity check. The `execLoop` select drains `execRequests` as fast as possible, creating a blockExecutor for every decoded block. Entries are only removed when a block is *fully committed*, so the map accumulates decoded TxTask objects for every block between the current execution position and the commit boundary.

**2. Oversized channel buffers** (contributing factor)

`execRequests`, `pe.in`, and `applyResults` were all buffered at 100,000 entries, allowing the block-loader goroutine to race far ahead decoding transactions.

### Heap profile (before fix, 90 seconds into run)

| Allocator | In-use |
|---|---|
| `executeBlocks.func1` (decoded TxTask objects) | 10.9 GB |
| `rlp.(*Stream).Bytes` | 7.5 GB |
| `UnmarshalTransactionFromBinary` | 4.9 GB |
| `processRequest` (blockExecutor objects) | 4.6 GB |

Total: ~30 GB live heap after 90 seconds. Process OOM-killed.

### Fix

**Backpressure via blockExecutors depth limit** (primary fix):

In the `execLoop` select, use the nil-channel trick: when `len(pe.blockExecutors) >= 32`, set `pendingCh = nil` so the select skips the `execRequests` case entirely and processes results instead. This drains completed blocks before accepting more, propagating backpressure all the way to `executeBlocks.func1`.

**Reduced channel buffers** (secondary):
- `execRequests`: 100,000 → 128 (block-level)
- `in` (QueueWithRetry): 100,000 → 2,048
- `applyResults`: 100,000 → 2,048

### Results (verified on bare-metal n4, hoodi blocks ~89k-92k)

| Metric | Before | After |
|---|---|---|
| RSS at t=90s | ~30 GB | ~1 GB |
| Heap alloc (steady state) | unbounded | 400-660 MB (GC cycling) |
| OOM-killed | yes (~90s) | no |
| blk/s | n/a (OOM'd) | ~19 blk/s |

## Test plan

- [x] Build passes (`make erigon`, `make integration`)
- [x] `EXEC3_PARALLEL=true integration stage_exec` on hoodi: RSS stays bounded (~1 GB vs 30 GB before fix)
- [ ] Verify normal erigon sync blk/s throughput not regressed

Generated with [Claude Code](https://claude.com/claude-code)
