### PR TITLE
ci: add mcp binary to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ env:
   TARGET_BASE_IMAGE: "debian:12-slim"
   APP_REPO: "erigontech/erigon"
   PACKAGE: "github.com/erigontech/erigon"
-  BINARIES: "erigon downloader evm caplin capcli integration rpcdaemon sentry txpool"
+  BINARIES: "erigon downloader evm caplin capcli integration rpcdaemon sentry txpool mcp"
   DOCKERHUB_REPOSITORY: "erigontech/erigon"
   DOCKERHUB_REPOSITORY_DEV: "erigontech/dev-erigon"
   DOCKERFILE_PATH: "Dockerfile"


### PR DESCRIPTION
## Summary
- Adds `mcp` to the `BINARIES` list in `.github/workflows/release.yml` so it is built and included in release artifacts and Docker images.

## Test plan
- Built Docker image locally with the updated `BINARIES` list — all 10 binaries present including `mcp` at `/usr/local/bin/mcp`.

Generated with Claude.