### PR TITLE
[r3.4] ci: add mcp binary to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ env:
   TARGET_BASE_IMAGE: "debian:12-slim"
   APP_REPO: "erigontech/erigon"
   PACKAGE: "github.com/erigontech/erigon"
-  BINARIES: "erigon downloader evm caplin capcli integration rpcdaemon sentry txpool"
+  BINARIES: "erigon downloader evm caplin capcli integration rpcdaemon sentry txpool mcp"
   DOCKERHUB_REPOSITORY: "erigontech/erigon"
   DOCKERHUB_REPOSITORY_DEV: "erigontech/dev-erigon"
   DOCKERFILE_PATH: "Dockerfile"


### PR DESCRIPTION
Cherry-pick of #19819 to `release/3.4`.

## Summary
- Adds `mcp` to the `BINARIES` list in `.github/workflows/release.yml` so it is built and included in release artifacts and Docker images.

Generated with Claude.