### PR TITLE
execution/stagedsync: use read-only tx in MiningStep

### DIFF
--- a/execution/stagedsync/stageloop/stageloop.go
+++ b/execution/stagedsync/stageloop/stageloop.go
@@ -527,7 +527,9 @@ func MiningStep(ctx context.Context, db kv.TemporalRwDB, mining *stagedsync.Sync
 			err = fmt.Errorf("%+v, trace: %s", rec, dbg.Stack())
 		}
 	}() // avoid crash because Erigon's core does many things
-	tx, err := db.BeginTemporalRw(ctx)
+	// Use a read-only tx: all writes go to the MemoryBatch overlay and are
+	// never committed, so there is no need to hold the MDBX exclusive write lock.
+	tx, err := db.BeginTemporalRo(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

`MiningStep` wraps the base transaction in a `MemoryBatch` overlay and unconditionally rolls it back — no writes ever reach the underlying MDBX transaction. Despite this, it was opening a `BeginTemporalRw` (exclusive write lock) for the entire block-build duration.

This unnecessarily holds the MDBX exclusive write lock while the block builder runs (which can take most of a 12-second slot). Other operations serialised via `e.semaphore` — FCU, prune, `ValidateChain` — need to open their own write transactions. Even though they already hold the semaphore, they block waiting for the MDBX write lock held by the builder, causing "wrong head block" errors and, in tight single-node environments, a permanent SYNCING loop.

This causes failures in kurtosis depending on load and may explain some of the flakey test results we've seen with the assertor.

Switch to `BeginTemporalRo`: reads go straight to MDBX, writes still go to `MemoryBatch` in-memory, and the MDBX exclusive write lock is never acquired.

## Test plan
- [x] `make erigon` builds cleanly
- [x] `make lint` passes
- [x] Kurtosis single-node devnet (`cl_type: caplin`): `synchronized-check` and `block-proposal-check` assertoor tests both pass