### PR TITLE
ci: use golang:1.26-trixie for snapshot docker images

### DIFF
--- a/.github/workflows/ci-cd-main-branch-docker-images.yml
+++ b/.github/workflows/ci-cd-main-branch-docker-images.yml
@@ -5,6 +5,7 @@ env:
   APPLICATION: "erigon"
   APP_REPO: "erigontech/erigon"
   DOCKERHUB_REPOSITORY: "erigontech/erigon"
+  BUILDER_IMAGE: "golang:1.26-trixie"
   LABEL_DESCRIPTION: "[docker image built on a last commit id from the main branch] Erigon is an implementation of Ethereum (execution layer with embeddable consensus layer), on the efficiency frontier. Archive Node by default."
 
 on:
@@ -116,6 +117,7 @@ jobs:
           docker buildx build \
           --file ${{ env.DOCKERFILE_PATH }} \
           --build-arg BINARIES='${{ steps.def_docker_vars.outputs.binaries }}' \
+          --build-arg BUILDER_IMAGE='${{ env.BUILDER_IMAGE }}' \
           --attest type=provenance,mode=max \
           --no-cache \
           --sbom=true \


### PR DESCRIPTION
## Summary
- Adds `BUILDER_IMAGE: "golang:1.26-trixie"` to the workflow env in `ci-cd-main-branch-docker-images.yml`
- Passes it as `--build-arg BUILDER_IMAGE` to `docker buildx build`, matching the pattern already used in `release.yml`
- The Dockerfile default (`golang:1.25-trixie`) and the release workflow (`golang:1.25-bookworm`) are unchanged

## Test plan
- Built Docker image locally using the same `BINARIES="erigon integration rpcdaemon"` and `BUILDER_IMAGE="golang:1.26-trixie"` — succeeded, all 3 binaries present.

Generated with Claude.