### PR TITLE
execution/state/genesiswrite: fix hive EEST consume-rlp timeout

### DIFF
--- a/execution/state/genesiswrite/genesis_test.go
+++ b/execution/state/genesiswrite/genesis_test.go
@@ -257,6 +257,19 @@ func TestSetupGenesis(t *testing.T) {
 			wantConfig: customg.Config,
 		},
 		{
+			// Reproduces the hive EEST consume-rlp scenario:
+			// 1. `erigon init genesis.json` writes a custom genesis + config
+			// 2. `erigon --import` reopens the DB with genesis=nil, chainName="mainnet" (default)
+			// The custom config must be preserved, not overwritten with mainnet's.
+			name: "custom block in DB, genesis == nil, chainName mainnet",
+			fn: func(t *testing.T, db kv.RwDB, tmpdir string) (*chain.Config, *types.Block, error) {
+				genesiswrite.MustCommitGenesis(&customg, db, datadir.New(tmpdir), logger)
+				return genesiswrite.CommitGenesisBlock(db, nil, networkname.Mainnet, datadir.New(tmpdir), logger)
+			},
+			wantHash:   customghash,
+			wantConfig: customg.Config,
+		},
+		{
 			name: "custom block in DB, genesis == sepolia",
 			fn: func(t *testing.T, db kv.RwDB, tmpdir string) (*chain.Config, *types.Block, error) {
 				genesiswrite.MustCommitGenesis(&customg, db, datadir.New(tmpdir), logger)

--- a/execution/state/genesiswrite/genesis_write.go
+++ b/execution/state/genesiswrite/genesis_write.go
@@ -111,13 +111,13 @@ func CommitGenesisBlockWithOverride(db kv.RwDB, genesis *types.Genesis, chainNam
 	return c, b, nil
 }
 
-func configOrDefault(g *types.Genesis, chainName string) *chain.Config {
+func configOrDefault(g *types.Genesis, chainName string, genesisHash common.Hash) *chain.Config {
 	if g != nil {
 		return g.Config
 	}
 	if chainName != "" {
 		spec, err := chainspec.ChainSpecByName(chainName)
-		if err == nil {
+		if err == nil && spec.GenesisHash == genesisHash {
 			return spec.Config
 		}
 	}
@@ -186,7 +186,7 @@ func WriteGenesisBlock(tx kv.RwTx, genesis *types.Genesis, chainName string, ove
 		}
 	}
 	// Get the existing chain configuration.
-	newCfg := configOrDefault(genesis, chainName)
+	newCfg := configOrDefault(genesis, chainName, storedHash)
 	applyOverrides(newCfg)
 	if err := newCfg.CheckConfigForkOrder(); err != nil {
 		return newCfg, nil, err
@@ -208,8 +208,8 @@ func WriteGenesisBlock(tx kv.RwTx, genesis *types.Genesis, chainName string, ove
 	// In that case, only apply the overrides.
 	if genesis == nil {
 		if !keepStoredChainConfig {
-			_, err := chainspec.ChainSpecByName(chainName)
-			keepStoredChainConfig = err != nil
+			spec, err := chainspec.ChainSpecByName(chainName)
+			keepStoredChainConfig = err != nil || spec.GenesisHash != storedHash
 		}
 		if keepStoredChainConfig {
 			newCfg = storedCfg


### PR DESCRIPTION
## Summary

- Fix `configOrDefault` and `keepStoredChainConfig` in `WriteGenesisBlock` to verify the stored genesis hash matches the named chain before using its config
- Add regression test reproducing the hive EEST consume-rlp scenario

PR #19751 changed `configOrDefault` to look up chain config by name instead of genesis hash. This broke hive EEST consume-rlp tests: when `erigon --import` opens a DB with a custom genesis (written by `erigon init`), `--chain` defaults to `"mainnet"`, so `configOrDefault(nil, "mainnet")` returned mainnet's fork schedule instead of `AllProtocolChanges`. The `keepStoredChainConfig` logic was similarly broken — `ChainSpecByName("mainnet")` succeeded, causing the custom config to be overwritten with mainnet's.

Fix: pass the stored genesis hash into `configOrDefault` and the `keepStoredChainConfig` check, so they only use a named chain's config when its genesis hash actually matches.

## Test plan

- [x] New test `TestSetupGenesis/custom block in DB, genesis == nil, chainName mainnet` — fails without fix, passes with fix
- [x] All existing `TestSetupGenesis` cases pass
- [x] `make erigon integration` builds
- [x] `make lint` clean (pre-existing issues only)
- [ ] Hive EEST CI: https://github.com/erigontech/erigon/actions/runs/22975864240

🤖 Generated with [Claude Code](https://claude.com/claude-code)