### PR TITLE
ci: update docker actions to v4.0.0 (Node.js 24)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,16 +134,16 @@ jobs:
           echo "OK: release_version matches db/version/app.go."
 
       - name: Login to Docker Hub
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567  ## v3.3.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  ## v4.0.0
         with:
           username: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_USERNAME }}
           password: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  ## v4.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  ## v4.0.0
 
       - name: Build and push temporary multiplatform image, store outputs locally for further processing
         env:
@@ -371,7 +371,7 @@ jobs:
         name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_amd64v2.tar
 
     - name: Login to Docker Hub
-      uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567  ## v3.3.0
+      uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  ## v4.0.0
       with:
         username: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_USERNAME }}
         password: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_TOKEN }}


### PR DESCRIPTION
## Summary

- Update `docker/login-action`, `docker/setup-qemu-action`, and `docker/setup-buildx-action` from v3.x (Node.js 20) to v4.0.0 (Node.js 24) in `release.yml`
- Pin actions to specific commit SHAs for supply chain security
- Addresses GitHub Actions deprecation warning: Node.js 20 actions will stop working on June 2, 2026

## Actions updated

| Action | Old | New |
|--------|-----|-----|
| `docker/login-action` | `v3.3.0` | `v4.0.0` (pinned SHA) |
| `docker/setup-qemu-action` | `v3` | `v4.0.0` (pinned SHA) |
| `docker/setup-buildx-action` | `v3` | `v4.0.0` (pinned SHA) |

Generated with Claude.