### PR TITLE
ci: pin create-github-app-token to v2.2.1 SHA (Node.js 24)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -549,7 +549,7 @@ jobs:
     - name: Generate GitHub App token for release publishing
       id: generate_token
       if: ${{ inputs.perform_release }}
-      uses: actions/create-github-app-token@v2
+      uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf  ## v2.2.1
       with:
         app-id: ${{ vars.RELEASE_BOT_APP_ID }}
         private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}


### PR DESCRIPTION
## Summary

- Pin `actions/create-github-app-token` from `@v2` to SHA of `v2.2.1`
- Fixes Node.js 20 deprecation warning in the "Publish release notes" step
- Consistent with the SHA-pinning approach used for other actions in this workflow