### PR TITLE
hive: add job name to test-hive workflow

### DIFF
--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -26,6 +26,7 @@ concurrency:
 
 jobs:
   test-hive:
+    name: (${{ matrix.sim }}, ${{ matrix.sim-limit }})
     if: >-
       ${{ github.event_name == 'push'
       || (!github.event.pull_request.draft


### PR DESCRIPTION
This avoids stuck CI jobs when changing `max-allowed-failures` values