### PR TITLE
[SharovBot] chain: add default Osaka blob config and fix Amsterdam blob schedule key

### DIFF
--- a/execution/chain/chain_config.go
+++ b/execution/chain/chain_config.go
@@ -410,6 +410,9 @@ func (c *Config) GetBlobConfig(time uint64) *params.BlobConfig {
 		if c.PragueTime != nil {
 			c.parsedBlobSchedule[c.PragueTime.Uint64()] = &params.DefaultPragueBlobConfig
 		}
+		if c.OsakaTime != nil {
+			c.parsedBlobSchedule[c.OsakaTime.Uint64()] = &params.DefaultOsakaBlobConfig
+		}
 
 		// Override with supplied values
 		val, ok := c.BlobSchedule["cancun"]
@@ -424,7 +427,7 @@ func (c *Config) GetBlobConfig(time uint64) *params.BlobConfig {
 		if ok && c.OsakaTime != nil {
 			c.parsedBlobSchedule[c.OsakaTime.Uint64()] = val
 		}
-		val, ok = c.BlobSchedule["gloas"]
+		val, ok = c.BlobSchedule["amsterdam"]
 		if ok && c.AmsterdamTime != nil {
 			c.parsedBlobSchedule[c.AmsterdamTime.Uint64()] = val
 		}

--- a/execution/protocol/params/protocol.go
+++ b/execution/protocol/params/protocol.go
@@ -258,3 +258,9 @@ var DefaultPragueBlobConfig = BlobConfig{
 	Max:                   9,
 	BaseFeeUpdateFraction: 5007716,
 }
+
+var DefaultOsakaBlobConfig = BlobConfig{
+	Target:                6,
+	Max:                   9,
+	BaseFeeUpdateFraction: 5007716,
+}


### PR DESCRIPTION
## Summary

- Add `DefaultOsakaBlobConfig` (target=6, max=9, fraction=5007716) to protocol params, matching Prague defaults per the Osaka fork specification
- Include Osaka in `GetBlobConfig()` default schedule so that Osaka-fork chains without an explicit `blobSchedule` in genesis get correct blob parameters
- Fix blob schedule map key typo: `"gloas"` → `"amsterdam"` so that Amsterdam blob configuration from genesis JSON is actually loaded

## Context

The hive EEST consume-engine CI job (run 22960760252, commit 5abb053) showed 7015 failures across three categories:

1. **Category 1** (`blockchain_test_engine_from_state_test`): Fixed by PR #19827 (genesis config mismatch — custom genesis config was silently overwritten with mainnet's when `--chain` defaulted to `"mainnet"`). Already merged to main.

2. **Category 2** (Osaka-specific EIP failures): EIP-7883 (modexp gas increase) and EIP-7918 (blob reserve price) are already implemented, but Osaka blob config defaults were missing — this PR adds them.

3. **Category 3** (eip4844 blob_txs): The `"gloas"` typo prevented Amsterdam blob schedule from being loaded from genesis JSON. This PR fixes the key to `"amsterdam"`.

Without `DefaultOsakaBlobConfig`, any Osaka-fork chain that omits an explicit blob schedule (e.g. non-hive usage) would get `nil` from `GetBlobConfig()`, causing `GetMaxBlobsPerBlock()` to return 0, which triggers a division-by-zero panic in `CalcExcessBlobGas()` (EIP-7918 path).

## Test plan

- [x] `go build ./...` passes
- [x] `TestSetupGenesis` passes (8 subtests including the hive EEST regression test)
- [x] All chain config tests pass (`TestConfigValueLookup`, `TestNilBlobSchedule`, `TestBlobParameter*`)
- [x] All EIP-4844 tests pass (`TestFakeExponential`, etc.)
- [x] `make lint` clean (0 issues)
- [x] `make erigon` builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)