### PR TITLE
ci: fix Hive Go version patching for non-alpine base images

### DIFF
--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -92,7 +92,7 @@ jobs:
           sed -i "s/^ARG tag=main$/ARG tag=${branch_name}/" clients/erigon/Dockerfile
           go_version=$(go mod edit -json ../erigon-src/go.mod | jq -r .Go)
           echo "Patching builder Go version to ${go_version}"
-          sed -i "s|golang:[0-9.]*-alpine|golang:${go_version}-alpine|" clients/erigon/Dockerfile
+          sed -i "s|golang:[0-9.]*-|golang:${go_version}-|" clients/erigon/Dockerfile
           go build . >> buildlogs.log
       # Depends on the last line of hive output that prints the number of suites, tests and failed
       # Currently, we fail even if suites and tests are too few, indicating the tests did not run

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -115,7 +115,7 @@ jobs:
           sed -i "s/^ARG tag=main$/ARG tag=${branch_name}/" clients/erigon/Dockerfile
           go_version=$(go mod edit -json ../erigon-src/go.mod | jq -r .Go)
           echo "Patching builder Go version to ${go_version}"
-          sed -i "s|golang:[0-9.]*-alpine|golang:${go_version}-alpine|" clients/erigon/Dockerfile
+          sed -i "s|golang:[0-9.]*-|golang:${go_version}-|" clients/erigon/Dockerfile
           go build . >> buildlogs.log
       # Depends on the last line of hive output that prints the number of suites, tests and failed
       # Currently, we fail even if suites and tests are too few, indicating the tests did not run


### PR DESCRIPTION
## Summary
- The Hive workflow sed pattern only matched `golang:X.Y.Z-alpine`, but the upstream Hive `Dockerfile.git` uses `golang:X.Y.Z-trixie`
- This caused the Go version to never be patched, so when #19808 bumped `go.mod` from `go 1.25.0` to `go 1.25.7`, the Hive container still had Go 1.25.0 and the build failed with `go: ../../go.mod requires go >= 1.25.7`
- Fix: match any distro suffix (`s|golang:[0-9.]*-|golang:${go_version}-|`) instead of hardcoding `-alpine`

Fixes the Hive EEST failure from #19808. Once merged, the gnark-crypto v0.20.0 upgrade can be re-landed.

## Test plan
- [ ] Verify Hive tests pass on this branch (the workflow fix itself is exercised when the Hive job runs)
- [ ] After merge, re-land gnark-crypto v0.20.0 upgrade and confirm Hive EEST passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)