### PR TITLE
hive: update max-allowed-failures 57 for rpc-compat

### DIFF
--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -60,7 +60,7 @@ jobs:
             max-allowed-failures: 0
           - sim: rpc
             sim-limit: compat
-            max-allowed-failures: 1 # https://github.com/erigontech/erigon/issues/19758
+            max-allowed-failures: 57 # 56 missing eth_simulateV1 MaxGasUsed in Hive tests + 1 https://github.com/erigontech/erigon/issues/19758
     steps:
       - name: Checkout Erigon go.mod
         uses: actions/checkout@v6


### PR DESCRIPTION
Increase max allowed failures in Hive `rpc-compat` to accommodate missing `eth_simulateV1` MaxGasUsed field in Hive test vectors