### PR TITLE
cmd/utils/app: retrofit tests for state snapshot integrity checks

### DIFF
--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -1739,6 +1739,16 @@ func checkIfStateSnapshotsPublishable(dirs datadir.Dirs, chainDB kv.RoDB) error 
 	return checkStateSnapshotFiles(dirs, persistReceiptCache, commitmentHistory)
 }
 
+var (
+	ErrSnapParseFilename   = errors.New("unparseable snapshot filename")
+	ErrSnapNoAccountFiles  = errors.New("no account snapshot files found")
+	ErrSnapGapAtStart      = errors.New("gap at start of snapshot range")
+	ErrSnapOverlap         = errors.New("overlapping snapshot ranges")
+	ErrSnapGap             = errors.New("gap in snapshot ranges")
+	ErrSnapMissingFile     = errors.New("missing snapshot file")
+	ErrSnapMaxStepMismatch = errors.New("max step mismatch across directories")
+)
+
 func checkStateSnapshotFiles(dirs datadir.Dirs, persistReceiptCache, commitmentHistory bool) error {
 	var maxStepDomain uint64 // across all files in SnapDomain
 	var accFiles []snaptype.FileInfo
@@ -1756,7 +1766,7 @@ func checkStateSnapshotFiles(dirs datadir.Dirs, persistReceiptCache, commitmentH
 
 		res, _, ok := snaptype.ParseFileName(dirs.SnapDomain, info.Name())
 		if !ok {
-			return fmt.Errorf("failed to parse filename %s", info.Name())
+			return fmt.Errorf("%w: %s", ErrSnapParseFilename, info.Name())
 		}
 		maxStepDomain = max(maxStepDomain, res.To)
 
@@ -1774,23 +1784,23 @@ func checkStateSnapshotFiles(dirs datadir.Dirs, persistReceiptCache, commitmentH
 		return (accFiles[i].From < accFiles[j].From) || (accFiles[i].From == accFiles[j].From && accFiles[i].To < accFiles[j].To)
 	})
 	if len(accFiles) == 0 {
-		return fmt.Errorf("no account snapshot files (.kv) found in %s", dirs.SnapDomain)
+		return fmt.Errorf("%w (.kv) in %s", ErrSnapNoAccountFiles, dirs.SnapDomain)
 	}
 	if accFiles[0].From != 0 {
-		return fmt.Errorf("gap at start: state snaps start at (%d-%d). snaptype: accounts", accFiles[0].From, accFiles[0].To)
+		return fmt.Errorf("%w: state snaps start at (%d-%d), snaptype: accounts", ErrSnapGapAtStart, accFiles[0].From, accFiles[0].To)
 	}
 
 	prevFrom, prevTo := accFiles[0].From, accFiles[0].To
 	for i := 1; i < len(accFiles); i++ {
 		res := accFiles[i]
 		if prevFrom == res.From {
-			return fmt.Errorf("state file %s is possibly overlapped by previous file %s (maybe run remove_overlaps)", accFiles[i-1].Path, res.Path)
+			return fmt.Errorf("%w: %s possibly overlapped by %s (maybe run remove_overlaps)", ErrSnapOverlap, accFiles[i-1].Path, res.Path)
 		}
 		if res.From < prevTo {
-			return fmt.Errorf("overlap detected between %s and %s", res.Path, accFiles[i-1].Path)
+			return fmt.Errorf("%w: between %s and %s", ErrSnapOverlap, res.Path, accFiles[i-1].Path)
 		}
 		if res.From > prevTo {
-			return fmt.Errorf("gap detected between %s and %s", accFiles[i-1].Path, res.Path)
+			return fmt.Errorf("%w: between %s and %s", ErrSnapGap, accFiles[i-1].Path, res.Path)
 		}
 		prevFrom, prevTo = res.From, res.To
 	}
@@ -1799,7 +1809,7 @@ func checkStateSnapshotFiles(dirs datadir.Dirs, persistReceiptCache, commitmentH
 		// do a range check over all snapshots types (sanitizes domain and history folder)
 		accName, err := version.ReplaceVersionWithMask(res.Name())
 		if err != nil {
-			return fmt.Errorf("failed to replace version file %s: %w", res.Name(), err)
+			return fmt.Errorf("%w: failed to replace version in %s: %v", ErrSnapParseFilename, res.Name(), err)
 		}
 		for snapType := kv.Domain(0); snapType < kv.DomainLen; snapType++ {
 			// skip rcache check if this datadir doesn't produce it
@@ -1810,7 +1820,7 @@ func checkStateSnapshotFiles(dirs datadir.Dirs, persistReceiptCache, commitmentH
 			schemaVersionMinSup := statecfg.Schema.GetDomainCfg(snapType).GetVersions().Domain.DataKV.MinSupported
 			expectedFileName := strings.Replace(accName, "accounts", snapType.String(), 1)
 			if err = version.CheckIsThereFileWithSupportedVersion(filepath.Join(dirs.SnapDomain, expectedFileName), schemaVersionMinSup); err != nil {
-				return fmt.Errorf("missing file %s at path %s with err %w", expectedFileName, filepath.Join(dirs.SnapDomain, expectedFileName), err)
+				return fmt.Errorf("%w: %s at %s: %v", ErrSnapMissingFile, expectedFileName, filepath.Join(dirs.SnapDomain, expectedFileName), err)
 			}
 
 			// check that the index file exist
@@ -1819,7 +1829,7 @@ func checkStateSnapshotFiles(dirs datadir.Dirs, persistReceiptCache, commitmentH
 				fileName := strings.Replace(expectedFileName, ".kv", ".bt", 1)
 				err := version.CheckIsThereFileWithSupportedVersion(filepath.Join(dirs.SnapDomain, fileName), schemaVersionMinSup)
 				if err != nil {
-					return fmt.Errorf("missing file %s at path %s with err %w", expectedFileName, filepath.Join(dirs.SnapDomain, fileName), err)
+					return fmt.Errorf("%w: %s at %s: %v", ErrSnapMissingFile, expectedFileName, filepath.Join(dirs.SnapDomain, fileName), err)
 				}
 			}
 			if statecfg.Schema.GetDomainCfg(snapType).Accessors.Has(statecfg.AccessorExistence) {
@@ -1827,7 +1837,7 @@ func checkStateSnapshotFiles(dirs datadir.Dirs, persistReceiptCache, commitmentH
 				fileName := strings.Replace(expectedFileName, ".kv", ".kvei", 1)
 				err := version.CheckIsThereFileWithSupportedVersion(filepath.Join(dirs.SnapDomain, fileName), schemaVersionMinSup)
 				if err != nil {
-					return fmt.Errorf("missing file %s at path %s with err %w", expectedFileName, filepath.Join(dirs.SnapDomain, fileName), err)
+					return fmt.Errorf("%w: %s at %s: %v", ErrSnapMissingFile, expectedFileName, filepath.Join(dirs.SnapDomain, fileName), err)
 				}
 			}
 			if statecfg.Schema.GetDomainCfg(snapType).Accessors.Has(statecfg.AccessorHashMap) {
@@ -1835,14 +1845,14 @@ func checkStateSnapshotFiles(dirs datadir.Dirs, persistReceiptCache, commitmentH
 				fileName := strings.Replace(expectedFileName, ".kv", ".kvi", 1)
 				err := version.CheckIsThereFileWithSupportedVersion(filepath.Join(dirs.SnapDomain, fileName), schemaVersionMinSup)
 				if err != nil {
-					return fmt.Errorf("missing file %s at path %s with err %w", expectedFileName, filepath.Join(dirs.SnapDomain, fileName), err)
+					return fmt.Errorf("%w: %s at %s: %v", ErrSnapMissingFile, expectedFileName, filepath.Join(dirs.SnapDomain, fileName), err)
 				}
 			}
 		}
 	}
 
 	if maxStepDomain != accFiles[len(accFiles)-1].To {
-		return fmt.Errorf("accounts domain max step (=%d) is different to SnapDomain files max step (=%d)", accFiles[len(accFiles)-1].To, maxStepDomain)
+		return fmt.Errorf("%w: accounts domain max step (=%d) differs from SnapDomain files max step (=%d)", ErrSnapMaxStepMismatch, accFiles[len(accFiles)-1].To, maxStepDomain)
 	}
 
 	var maxStepII uint64 // across all files in SnapIdx
@@ -1861,7 +1871,7 @@ func checkStateSnapshotFiles(dirs datadir.Dirs, persistReceiptCache, commitmentH
 
 		res, _, ok := snaptype.ParseFileName(dirs.SnapIdx, info.Name())
 		if !ok {
-			return fmt.Errorf("failed to parse filename %s: %w", info.Name(), err)
+			return fmt.Errorf("%w: %s", ErrSnapParseFilename, info.Name())
 		}
 
 		maxStepII = max(maxStepII, res.To)
@@ -1881,23 +1891,23 @@ func checkStateSnapshotFiles(dirs datadir.Dirs, persistReceiptCache, commitmentH
 		return (accFiles[i].From < accFiles[j].From) || (accFiles[i].From == accFiles[j].From && accFiles[i].To < accFiles[j].To)
 	})
 	if len(accFiles) == 0 {
-		return fmt.Errorf("no account inverted index files (.ef) found in %s", dirs.SnapIdx)
+		return fmt.Errorf("%w (.ef) in %s", ErrSnapNoAccountFiles, dirs.SnapIdx)
 	}
 	if accFiles[0].From != 0 {
-		return fmt.Errorf("gap at start: state ef snaps start at (%d-%d). snaptype: accounts", accFiles[0].From, accFiles[0].To)
+		return fmt.Errorf("%w: state ef snaps start at (%d-%d), snaptype: accounts", ErrSnapGapAtStart, accFiles[0].From, accFiles[0].To)
 	}
 
 	prevFrom, prevTo = accFiles[0].From, accFiles[0].To
 	for i := 1; i < len(accFiles); i++ {
 		res := accFiles[i]
 		if prevFrom == res.From {
-			return fmt.Errorf("state file %s is possibly overlapped by previous file %s (maybe run remove_overlaps)", accFiles[i-1].Path, res.Path)
+			return fmt.Errorf("%w: %s possibly overlapped by %s (maybe run remove_overlaps)", ErrSnapOverlap, accFiles[i-1].Path, res.Path)
 		}
 		if res.From < prevTo {
-			return fmt.Errorf("overlap detected between %s and %s", res.Path, accFiles[i-1].Path)
+			return fmt.Errorf("%w: between %s and %s", ErrSnapOverlap, res.Path, accFiles[i-1].Path)
 		}
 		if res.From > prevTo {
-			return fmt.Errorf("gap detected between %s and %s", accFiles[i-1].Path, res.Path)
+			return fmt.Errorf("%w: between %s and %s", ErrSnapGap, accFiles[i-1].Path, res.Path)
 		}
 
 		prevFrom, prevTo = res.From, res.To
@@ -1916,7 +1926,7 @@ func checkStateSnapshotFiles(dirs datadir.Dirs, persistReceiptCache, commitmentH
 	for _, res := range accFiles {
 		accName, err := version.ReplaceVersionWithMask(res.Name())
 		if err != nil {
-			return fmt.Errorf("failed to replace version file %s: %w", res.Name(), err)
+			return fmt.Errorf("%w: failed to replace version in %s: %v", ErrSnapParseFilename, res.Name(), err)
 		}
 		// do a range check over all snapshots types (sanitizes domain and history folder)
 		for _, snapType := range iiTypes {
@@ -1928,13 +1938,13 @@ func checkStateSnapshotFiles(dirs datadir.Dirs, persistReceiptCache, commitmentH
 			schemaVersionMinSup := versioned.GetVersions().II.DataEF.MinSupported
 			expectedFileName := strings.Replace(accName, "accounts", snapType, 1)
 			if err = version.CheckIsThereFileWithSupportedVersion(filepath.Join(dirs.SnapIdx, expectedFileName), schemaVersionMinSup); err != nil {
-				return fmt.Errorf("missing file %s at path %s with err %w", expectedFileName, filepath.Join(dirs.SnapIdx, expectedFileName), err)
+				return fmt.Errorf("%w: %s at %s: %v", ErrSnapMissingFile, expectedFileName, filepath.Join(dirs.SnapIdx, expectedFileName), err)
 			}
 			// Check accessors
 			schemaVersionMinSup = versioned.GetVersions().II.AccessorEFI.MinSupported
 			fileName := strings.Replace(expectedFileName, ".ef", ".efi", 1)
 			if err = version.CheckIsThereFileWithSupportedVersion(filepath.Join(dirs.SnapAccessors, fileName), schemaVersionMinSup); err != nil {
-				return fmt.Errorf("missing file %s at path %s with err %w", fileName, filepath.Join(dirs.SnapAccessors, fileName), err)
+				return fmt.Errorf("%w: %s at %s: %v", ErrSnapMissingFile, fileName, filepath.Join(dirs.SnapAccessors, fileName), err)
 			}
 			if !slices.Contains(viTypes, snapType) {
 				continue
@@ -1942,19 +1952,19 @@ func checkStateSnapshotFiles(dirs datadir.Dirs, persistReceiptCache, commitmentH
 			schemaVersionMinSup = versioned.GetVersions().Hist.AccessorVI.MinSupported
 			fileName = strings.Replace(expectedFileName, ".ef", ".vi", 1)
 			if err = version.CheckIsThereFileWithSupportedVersion(filepath.Join(dirs.SnapAccessors, fileName), schemaVersionMinSup); err != nil {
-				return fmt.Errorf("missing file %s at path %s with err %w", fileName, filepath.Join(dirs.SnapAccessors, fileName), err)
+				return fmt.Errorf("%w: %s at %s: %v", ErrSnapMissingFile, fileName, filepath.Join(dirs.SnapAccessors, fileName), err)
 			}
 			schemaVersionMinSup = versioned.GetVersions().Hist.DataV.MinSupported
 			// check that .v
 			fileName = strings.Replace(expectedFileName, ".ef", ".v", 1)
 			if err = version.CheckIsThereFileWithSupportedVersion(filepath.Join(dirs.SnapHistory, fileName), schemaVersionMinSup); err != nil {
-				return fmt.Errorf("missing file %s at path %s with err %w", fileName, filepath.Join(dirs.SnapHistory, fileName), err)
+				return fmt.Errorf("%w: %s at %s: %v", ErrSnapMissingFile, fileName, filepath.Join(dirs.SnapHistory, fileName), err)
 			}
 		}
 	}
 
 	if maxStepDomain != accFiles[len(accFiles)-1].To {
-		return fmt.Errorf("accounts domain max step (=%d) is different to SnapIdx files max step (=%d)", accFiles[len(accFiles)-1].To, maxStepDomain)
+		return fmt.Errorf("%w: accounts domain max step (=%d) differs from SnapIdx files max step (=%d)", ErrSnapMaxStepMismatch, accFiles[len(accFiles)-1].To, maxStepDomain)
 	}
 	return nil
 }

--- a/cmd/utils/app/snapshots_publishable_state_test.go
+++ b/cmd/utils/app/snapshots_publishable_state_test.go
@@ -610,7 +610,7 @@ func Test_CheckStateSnapshotFiles_DomainUnparseableFile(t *testing.T) {
 	dirs := setupWorkingStateMockDatadir(t)
 	createMockFile(t, dirs.SnapDomain, "garbage.txt")
 	err := checkStateSnapshotFiles(dirs, false, false)
-	require.ErrorContains(t, err, "failed to parse filename")
+	require.ErrorIs(t, err, ErrSnapParseFilename)
 }
 
 // When all account .kv files are missing, the check should report that no account snapshots were found.
@@ -622,7 +622,7 @@ func Test_CheckStateSnapshotFiles_DomainNoAccountKV(t *testing.T) {
 	removeMockFile(t, dirs.SnapDomain, "v1.1-accounts.192-200.kv")
 	removeMockFile(t, dirs.SnapDomain, "v1.1-accounts.200-202.kv")
 	err := checkStateSnapshotFiles(dirs, false, false)
-	require.ErrorContains(t, err, "no account snapshot files (.kv) found")
+	require.ErrorIs(t, err, ErrSnapNoAccountFiles)
 }
 
 // If the first account .kv range doesn't start at step 0, a gap-at-start error is expected.
@@ -631,7 +631,7 @@ func Test_CheckStateSnapshotFiles_DomainGapAtStart(t *testing.T) {
 	dirs := setupWorkingStateMockDatadir(t)
 	removeMockFile(t, dirs.SnapDomain, "v1.1-accounts.0-128.kv")
 	err := checkStateSnapshotFiles(dirs, false, false)
-	require.ErrorContains(t, err, "gap at start")
+	require.ErrorIs(t, err, ErrSnapGapAtStart)
 }
 
 // Two account .kv files sharing the same From value should be flagged as a possible overlap.
@@ -640,7 +640,7 @@ func Test_CheckStateSnapshotFiles_DomainOverlapSameFrom(t *testing.T) {
 	dirs := setupWorkingStateMockDatadir(t)
 	createMockFile(t, dirs.SnapDomain, "v1.1-accounts.0-64.kv")
 	err := checkStateSnapshotFiles(dirs, false, false)
-	require.ErrorContains(t, err, "possibly overlapped")
+	require.ErrorIs(t, err, ErrSnapOverlap)
 }
 
 // An account .kv file whose range overlaps with an existing range should be detected.
@@ -649,7 +649,7 @@ func Test_CheckStateSnapshotFiles_DomainOverlap(t *testing.T) {
 	dirs := setupWorkingStateMockDatadir(t)
 	createMockFile(t, dirs.SnapDomain, "v1.1-accounts.64-200.kv")
 	err := checkStateSnapshotFiles(dirs, false, false)
-	require.ErrorContains(t, err, "overlap detected")
+	require.ErrorIs(t, err, ErrSnapOverlap)
 }
 
 // Removing a middle account .kv file creates a gap between consecutive ranges.
@@ -658,7 +658,7 @@ func Test_CheckStateSnapshotFiles_DomainGap(t *testing.T) {
 	dirs := setupWorkingStateMockDatadir(t)
 	removeMockFile(t, dirs.SnapDomain, "v1.1-accounts.128-192.kv")
 	err := checkStateSnapshotFiles(dirs, false, false)
-	require.ErrorContains(t, err, "gap detected")
+	require.ErrorIs(t, err, ErrSnapGap)
 }
 
 // Each account range must have a corresponding .kv file for every domain type; removing one triggers a missing-file error.
@@ -667,7 +667,7 @@ func Test_CheckStateSnapshotFiles_MissingDomainKV(t *testing.T) {
 	dirs := setupWorkingStateMockDatadir(t)
 	removeMockFile(t, dirs.SnapDomain, "v1.1-storage.128-192.kv")
 	err := checkStateSnapshotFiles(dirs, false, false)
-	require.ErrorContains(t, err, "missing file")
+	require.ErrorIs(t, err, ErrSnapMissingFile)
 }
 
 // Domains with AccessorBTree (accounts, storage, code, receipt) require a .bt file for each range.
@@ -676,7 +676,7 @@ func Test_CheckStateSnapshotFiles_MissingDomainBT(t *testing.T) {
 	dirs := setupWorkingStateMockDatadir(t)
 	removeMockFile(t, dirs.SnapDomain, "v1.1-accounts.128-192.bt")
 	err := checkStateSnapshotFiles(dirs, false, false)
-	require.ErrorContains(t, err, "missing file")
+	require.ErrorIs(t, err, ErrSnapMissingFile)
 }
 
 // Domains with AccessorExistence (accounts, storage, code, receipt) require a .kvei file for each range.
@@ -685,7 +685,7 @@ func Test_CheckStateSnapshotFiles_MissingDomainKVEI(t *testing.T) {
 	dirs := setupWorkingStateMockDatadir(t)
 	removeMockFile(t, dirs.SnapDomain, "v1.1-accounts.128-192.kvei")
 	err := checkStateSnapshotFiles(dirs, false, false)
-	require.ErrorContains(t, err, "missing file")
+	require.ErrorIs(t, err, ErrSnapMissingFile)
 }
 
 // The commitment domain uses AccessorHashMap and requires a .kvi file for each range.
@@ -694,7 +694,7 @@ func Test_CheckStateSnapshotFiles_MissingDomainKVI(t *testing.T) {
 	dirs := setupWorkingStateMockDatadir(t)
 	removeMockFile(t, dirs.SnapDomain, "v1.1-commitment.128-192.kvi")
 	err := checkStateSnapshotFiles(dirs, false, false)
-	require.ErrorContains(t, err, "missing file")
+	require.ErrorIs(t, err, ErrSnapMissingFile)
 }
 
 // If a non-account domain file extends beyond the account range, the maxStep check detects the mismatch.
@@ -703,7 +703,7 @@ func Test_CheckStateSnapshotFiles_DomainMaxStepMismatch(t *testing.T) {
 	dirs := setupWorkingStateMockDatadir(t)
 	createMockFile(t, dirs.SnapDomain, "v1.1-storage.202-210.kv")
 	err := checkStateSnapshotFiles(dirs, false, false)
-	require.ErrorContains(t, err, "accounts domain max step")
+	require.ErrorIs(t, err, ErrSnapMaxStepMismatch)
 }
 
 // --- Idx checks ---
@@ -714,7 +714,7 @@ func Test_CheckStateSnapshotFiles_IdxUnparseableFile(t *testing.T) {
 	dirs := setupWorkingStateMockDatadir(t)
 	createMockFile(t, dirs.SnapIdx, "garbage.txt")
 	err := checkStateSnapshotFiles(dirs, false, false)
-	require.ErrorContains(t, err, "failed to parse filename")
+	require.ErrorIs(t, err, ErrSnapParseFilename)
 }
 
 // When all account .ef files are missing, the check should report that no inverted index files were found.
@@ -726,7 +726,7 @@ func Test_CheckStateSnapshotFiles_IdxNoAccountEF(t *testing.T) {
 	removeMockFile(t, dirs.SnapIdx, "v2.0-accounts.192-200.ef")
 	removeMockFile(t, dirs.SnapIdx, "v2.0-accounts.200-202.ef")
 	err := checkStateSnapshotFiles(dirs, false, false)
-	require.ErrorContains(t, err, "no account inverted index files (.ef) found")
+	require.ErrorIs(t, err, ErrSnapNoAccountFiles)
 }
 
 // If the first account .ef range doesn't start at step 0, a gap-at-start error is expected.
@@ -735,7 +735,7 @@ func Test_CheckStateSnapshotFiles_IdxGapAtStart(t *testing.T) {
 	dirs := setupWorkingStateMockDatadir(t)
 	removeMockFile(t, dirs.SnapIdx, "v2.0-accounts.0-128.ef")
 	err := checkStateSnapshotFiles(dirs, false, false)
-	require.ErrorContains(t, err, "gap at start")
+	require.ErrorIs(t, err, ErrSnapGapAtStart)
 }
 
 // Two account .ef files sharing the same From value should be flagged as a possible overlap.
@@ -744,7 +744,7 @@ func Test_CheckStateSnapshotFiles_IdxOverlapSameFrom(t *testing.T) {
 	dirs := setupWorkingStateMockDatadir(t)
 	createMockFile(t, dirs.SnapIdx, "v2.0-accounts.0-64.ef")
 	err := checkStateSnapshotFiles(dirs, false, false)
-	require.ErrorContains(t, err, "possibly overlapped")
+	require.ErrorIs(t, err, ErrSnapOverlap)
 }
 
 // An account .ef file whose range overlaps with an existing range should be detected.
@@ -753,7 +753,7 @@ func Test_CheckStateSnapshotFiles_IdxOverlap(t *testing.T) {
 	dirs := setupWorkingStateMockDatadir(t)
 	createMockFile(t, dirs.SnapIdx, "v2.0-accounts.64-200.ef")
 	err := checkStateSnapshotFiles(dirs, false, false)
-	require.ErrorContains(t, err, "overlap detected")
+	require.ErrorIs(t, err, ErrSnapOverlap)
 }
 
 // Removing a middle account .ef file creates a gap between consecutive ranges.
@@ -762,7 +762,7 @@ func Test_CheckStateSnapshotFiles_IdxGap(t *testing.T) {
 	dirs := setupWorkingStateMockDatadir(t)
 	removeMockFile(t, dirs.SnapIdx, "v2.0-accounts.128-192.ef")
 	err := checkStateSnapshotFiles(dirs, false, false)
-	require.ErrorContains(t, err, "gap detected")
+	require.ErrorIs(t, err, ErrSnapGap)
 }
 
 // Each account range must have a corresponding .ef file for every II type; removing one triggers a missing-file error.
@@ -771,7 +771,7 @@ func Test_CheckStateSnapshotFiles_MissingIdxEF(t *testing.T) {
 	dirs := setupWorkingStateMockDatadir(t)
 	removeMockFile(t, dirs.SnapIdx, "v2.0-logtopics.128-192.ef")
 	err := checkStateSnapshotFiles(dirs, false, false)
-	require.ErrorContains(t, err, "missing file")
+	require.ErrorIs(t, err, ErrSnapMissingFile)
 }
 
 // Every II type requires a corresponding .efi accessor file for each range.
@@ -780,7 +780,7 @@ func Test_CheckStateSnapshotFiles_MissingAccessorEFI(t *testing.T) {
 	dirs := setupWorkingStateMockDatadir(t)
 	removeMockFile(t, dirs.SnapAccessors, "v1.1-accounts.128-192.efi")
 	err := checkStateSnapshotFiles(dirs, false, false)
-	require.ErrorContains(t, err, "missing file")
+	require.ErrorIs(t, err, ErrSnapMissingFile)
 }
 
 // Value-index types (accounts, storage, code, receipt) require a .vi accessor file for each range.
@@ -789,7 +789,7 @@ func Test_CheckStateSnapshotFiles_MissingAccessorVI(t *testing.T) {
 	dirs := setupWorkingStateMockDatadir(t)
 	removeMockFile(t, dirs.SnapAccessors, "v1.1-accounts.128-192.vi")
 	err := checkStateSnapshotFiles(dirs, false, false)
-	require.ErrorContains(t, err, "missing file")
+	require.ErrorIs(t, err, ErrSnapMissingFile)
 }
 
 // Value-index types require a .v history file for each range.
@@ -798,7 +798,7 @@ func Test_CheckStateSnapshotFiles_MissingHistoryV(t *testing.T) {
 	dirs := setupWorkingStateMockDatadir(t)
 	removeMockFile(t, dirs.SnapHistory, "v1.1-accounts.128-192.v")
 	err := checkStateSnapshotFiles(dirs, false, false)
-	require.ErrorContains(t, err, "missing file")
+	require.ErrorIs(t, err, ErrSnapMissingFile)
 }
 
 // If the account idx range is shorter than the domain maxStep, the cross-directory maxStep check fails.
@@ -807,5 +807,5 @@ func Test_CheckStateSnapshotFiles_IdxDomainMaxStepMismatch(t *testing.T) {
 	dirs := setupWorkingStateMockDatadir(t)
 	removeMockFile(t, dirs.SnapIdx, "v2.0-accounts.200-202.ef")
 	err := checkStateSnapshotFiles(dirs, false, false)
-	require.ErrorContains(t, err, "accounts domain max step")
+	require.ErrorIs(t, err, ErrSnapMaxStepMismatch)
 }


### PR DESCRIPTION
## Summary

First in a series of PRs to expand the publishable integrity checks. This PR creates a safety net of tests around the existing `checkIfStateSnapshotsPublishable` logic before adding new checks in follow-up PRs.

- Extract `checkStateSnapshotFiles` from `checkIfStateSnapshotsPublishable` to separate DB reads from filesystem validation — no behavior change, purely mechanical split for testability
- Reverse-engineer the existing checks into 25 tests: 3 success paths (base case + `persistReceiptCache` + `commitmentHistory` feature flags) and 22 failure scenarios covering every validation branch (unparseable filenames, missing account files, range gaps/overlaps, missing companion files, cross-directory max-step mismatches)
- Add 7 exported sentinel errors (`ErrSnapParseFilename`, `ErrSnapNoAccountFiles`, `ErrSnapGapAtStart`, `ErrSnapOverlap`, `ErrSnapGap`, `ErrSnapMissingFile`, `ErrSnapMaxStepMismatch`) for programmatic error matching

## Test plan

- [x] `go test -run Test_CheckStateSnapshotFiles ./cmd/utils/app/...` — all 25 tests pass
- [x] `make lint` — clean
- [x] CI passes
- [x] After merge: cherry-pick squash commit to `release/3.4` → #19878