### PR TITLE
execution/vm: skip CanTransfer for zero-value calls (EIP-7928)

### DIFF
--- a/execution/vm/evm.go
+++ b/execution/vm/evm.go
@@ -211,13 +211,17 @@ func (evm *EVM) call(typ OpCode, caller accounts.Address, callerAddress accounts
 		return nil, gas, ErrDepth
 	}
 	if typ == CALL || typ == CALLCODE {
-		// Fail if we're trying to transfer more than the available balance
-		canTransfer, err := evm.Context.CanTransfer(evm.intraBlockState, caller, value)
-		if err != nil {
-			return nil, 0, err
-		}
-		if !value.IsZero() && !canTransfer {
-			if !bailout {
+		// Fail if we're trying to transfer more than the available balance.
+		// Only check when value is non-zero — matching geth's short-circuit
+		// behavior. Calling CanTransfer for zero-value calls (e.g. system
+		// calls) creates spurious balance reads on the caller that pollute
+		// the Block Access List (EIP-7928).
+		if !value.IsZero() {
+			canTransfer, err := evm.Context.CanTransfer(evm.intraBlockState, caller, value)
+			if err != nil {
+				return nil, 0, err
+			}
+			if !canTransfer && !bailout {
 				return nil, gas, ErrInsufficientBalance
 			}
 		}


### PR DESCRIPTION
## Summary

- Skip `CanTransfer` check for zero-value CALL/CALLCODE operations, matching geth's short-circuit behavior
- Zero-value calls (e.g. system calls to EIP-4788, EIP-2935, EIP-7002, EIP-7251 contracts) were creating spurious balance reads on the caller (SystemAddress) that polluted the Block Access List (EIP-7928)
- This caused BAL hash mismatches on bal-devnet-2 at blocks with user transactions doing CALLs to addresses that include the system address

## Details

The old code called `CanTransfer` unconditionally for every CALL/CALLCODE, then checked `!value.IsZero() && !canTransfer`. This means even zero-value system calls would trigger `GetBalance()` on the caller, creating a balance read entry in the BAL for the system address.

The fix moves the `CanTransfer` call inside `if !value.IsZero()`, so it's only invoked when there's actually a value transfer. This matches go-ethereum's behavior.

## Test plan

- [x] `go build ./execution/vm/...` compiles
- [x] `go test -short ./execution/vm/...` passes
- [x] All EIP-7928 BAL spec tests pass (`TestExecutionSpecBlockchainDevnet/amsterdam/eip7928_block_level_access_lists`)
- [x] bal-devnet-2 sync from genesis past 42k+ blocks with zero BAL mismatches (sync ongoing, previously failed at blocks 110807/111692 without this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)