### PR TITLE
deps: update fastkeccak

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/dop251/goja v0.0.0-20230605162241-28ee0ee714f3
 	github.com/edsrzf/mmap-go v1.2.0
 	github.com/elastic/go-freelru v0.16.0
-	github.com/erigontech/fastkeccak v0.1.1-0.20260314092403-84387234991f
+	github.com/erigontech/fastkeccak v0.1.1-0.20260314101201-2b20530d819d
 	github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab
 	github.com/felixge/fgprof v0.9.5
 	github.com/go-chi/chi/v5 v5.2.3

--- a/go.sum
+++ b/go.sum
@@ -325,8 +325,8 @@ github.com/erigontech/erigon-snapshot v1.3.1-0.20260210221902-e495954c7e78 h1:z3
 github.com/erigontech/erigon-snapshot v1.3.1-0.20260210221902-e495954c7e78/go.mod h1:ooHlCl+eEYzebiPu+FP6Q6SpPUeMADn8Jxabv3IKb9M=
 github.com/erigontech/erigonwatch v0.0.0-20240718131902-b6576bde1116 h1:KCFa2uXEfZoBjV4buzjWmCmoqVLXiGCq0ZmQ2OjeRvQ=
 github.com/erigontech/erigonwatch v0.0.0-20240718131902-b6576bde1116/go.mod h1:8vQ+VjvLu2gkPs8EwdPrOTAAo++WuLuBi54N7NuAF0I=
-github.com/erigontech/fastkeccak v0.1.1-0.20260314092403-84387234991f h1:0xBDhewgMjVGqRp+ghKtH51pdyKkZoqefECz4gt3cpE=
-github.com/erigontech/fastkeccak v0.1.1-0.20260314092403-84387234991f/go.mod h1:CwJFJVKFVWpQyKSfRrQyY56IqV16sR5xnQoFThGHiZA=
+github.com/erigontech/fastkeccak v0.1.1-0.20260314101201-2b20530d819d h1:uOWUcvi6Lzji2kxOfhBmeOpAsaWVgX1pWJHMyA56Ox0=
+github.com/erigontech/fastkeccak v0.1.1-0.20260314101201-2b20530d819d/go.mod h1:CwJFJVKFVWpQyKSfRrQyY56IqV16sR5xnQoFThGHiZA=
 github.com/erigontech/mdbx-go v0.39.12 h1:WjvPzloxXOYfRamIxt8NOB7i3/M8cSCSfWQHvMNANrE=
 github.com/erigontech/mdbx-go v0.39.12/go.mod h1:tHUS492F5YZvccRqatNdpTDQAaN+Vv4HRARYq89KqeY=
 github.com/erigontech/secp256k1 v1.2.1-0.20260218182123-377cc1bd6410 h1:5YD7JJ5PaqOdjKA84lTDtQby9nbI4podqrkUhyIyFDw=


### PR DESCRIPTION
Pick up https://github.com/erigontech/fastkeccak/pull/6. **Prerequisite: https://github.com/erigontech/fastkeccak/pull/7.**

## Summary
- Update `github.com/erigontech/fastkeccak` from `95925bf94241` to `0f8e619ea178`
- ~15% speedup on `BenchmarkOpKeccak256` (246→209 ns/op, p=0.002), no change in allocations

```
               │    old        │            new                     │
               │    sec/op     │   sec/op     vs base               │
OpKeccak256-32    246.1n ± 5%    209.2n ± 2%  -14.99% (p=0.002 n=6)
```
(on 13th Gen Intel Core i9-13900KS)

## Test plan
- [x] Ran `BenchmarkOpKeccak256` with 6 iterations on both old and new versions
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)