### PR TITLE
state, stagedsync: enable deferred branch updates for parallel executor

### DIFF
--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -396,6 +396,13 @@ func (sd *SharedDomains) Close() {
 
 func (sd *SharedDomains) Flush(ctx context.Context, tx kv.RwTx) error {
 	defer mxFlushTook.ObserveDuration(time.Now())
+	if sd.sdCtx.HasPendingUpdate() {
+		if ttx, ok := tx.(kv.TemporalTx); ok {
+			if err := sd.FlushPendingUpdates(ctx, ttx); err != nil {
+				return err
+			}
+		}
+	}
 	if sd.blockOverlay != nil {
 		if err := sd.blockOverlay.Flush(ctx, tx); err != nil {
 			return err

--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -205,10 +205,12 @@ func ExecV3(ctx context.Context,
 	if !isApplyingBlocks {
 		postValidator = newParallelBlockPostExecutionValidator()
 	}
-	// Enable deferred commitment updates for fork validation (both serial and parallel).
+	// Enable deferred commitment updates for fork validation and parallel initial sync.
 	// Deferred updates batch commitment calculations to block boundaries rather than
 	// per-transaction, significantly reducing re-org validation overhead.
-	if isForkValidation {
+	// For the parallel path during initial sync, Flush() now includes pending updates,
+	// so they are no longer silently discarded between StageLoopIteration cycles.
+	if isForkValidation || (parallel && isApplyingBlocks) {
 		doms.SetDeferCommitmentUpdates(true)
 	}
 	defer doms.SetDeferCommitmentUpdates(false)


### PR DESCRIPTION
## Summary

- **Fix `SharedDomains.Flush()` to include pending commitment branch updates** — previously, deferred branch updates (`pendingUpdate`) were silently discarded when `doms` was closed between `StageLoopIteration` cycles, because `Flush()` only flushed the mem batch.

- **Enable `SetDeferCommitmentUpdates(true)` for the parallel executor** during initial sync (`isApplyingBlocks`). This gives the parallel path the same parallel branch encoding that serial fork validation already uses — branch writes are batched and encoded concurrently with `runtime.NumCPU()` workers via `ApplyDeferredBranchUpdates`.

## Context

Commitment profiling at chain head (Stage 0 measurement) shows:
- Commitment = 32.4% of per-block processing time (95ms avg, 14 keys/ms throughput)
- I/O-bound: branch node reads from MDBX/snapshots dominate, not hash computation
- Deferred writes parallelize the encoding phase, reducing the single-threaded bottleneck

See also: `parallel-commitment-optimization.md` for the full root cause analysis of why this was previously disabled.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./db/state/execctx/... ./execution/stagedsync/... -short` passes
- [ ] CI passes
- [ ] Run parallel node at chain head, verify commitment times decrease (expected: branch encoding phase parallelized across 12 cores)

🤖 Generated with [Claude Code](https://claude.com/claude-code)