### PR TITLE
commitment: add warmup cache hit/miss metrics

### DIFF
--- a/execution/commitment/commitment.go
+++ b/execution/commitment/commitment.go
@@ -564,6 +564,9 @@ func (be *BranchEncoder) CollectUpdate(
 
 	if be.cache != nil {
 		prev, foundInCache = be.cache.GetAndEvictBranch(prefix)
+		if foundInCache && be.metrics != nil {
+			be.metrics.cacheBranch.Add(1)
+		}
 	}
 	if !foundInCache {
 		prev, _, err = ctx.Branch(prefix)
@@ -642,6 +645,9 @@ func (be *BranchEncoder) CollectDeferredUpdate(
 
 	if be.cache != nil {
 		prev, foundInCache = be.cache.GetAndEvictBranch(prefix)
+		if foundInCache && be.metrics != nil {
+			be.metrics.cacheBranch.Add(1)
+		}
 	}
 	if !foundInCache {
 		prev, _, err = ctx.Branch(prefix)

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -2878,6 +2878,9 @@ func (hph *HexPatriciaHashed) ResetContext(ctx PatriciaContext) {
 func (hph *HexPatriciaHashed) branchFromCacheOrDB(key []byte) ([]byte, error) {
 	if hph.cache != nil {
 		if data, found := hph.cache.GetBranch(key); found {
+			if hph.metrics != nil {
+				hph.metrics.cacheBranch.Add(1)
+			}
 			return data, nil
 		}
 	}
@@ -2889,6 +2892,9 @@ func (hph *HexPatriciaHashed) branchFromCacheOrDB(key []byte) ([]byte, error) {
 func (hph *HexPatriciaHashed) accountFromCacheOrDB(plainKey []byte) (*Update, error) {
 	if hph.cache != nil {
 		if update, found := hph.cache.GetAccount(plainKey); found {
+			if hph.metrics != nil {
+				hph.metrics.cacheAccount.Add(1)
+			}
 			return update, nil
 		}
 	}
@@ -2899,6 +2905,9 @@ func (hph *HexPatriciaHashed) accountFromCacheOrDB(plainKey []byte) (*Update, er
 func (hph *HexPatriciaHashed) storageFromCacheOrDB(plainKey []byte) (*Update, error) {
 	if hph.cache != nil {
 		if update, found := hph.cache.GetStorage(plainKey); found {
+			if hph.metrics != nil {
+				hph.metrics.cacheStorage.Add(1)
+			}
 			return update, nil
 		}
 	}

--- a/execution/commitment/metrics.go
+++ b/execution/commitment/metrics.go
@@ -31,6 +31,9 @@ type Metrics struct {
 	loadBranch      atomic.Uint64
 	loadAccount     atomic.Uint64
 	loadStorage     atomic.Uint64
+	cacheBranch     atomic.Uint64
+	cacheAccount    atomic.Uint64
+	cacheStorage    atomic.Uint64
 	updateBranch    atomic.Uint64
 	loadDepths      [10]uint64
 	unfolds         atomic.Uint64
@@ -53,6 +56,9 @@ type MetricValues struct {
 	LoadBranch      uint64
 	LoadAccount     uint64
 	LoadStorage     uint64
+	CacheBranch     uint64
+	CacheAccount    uint64
+	CacheStorage    uint64
 	UpdateBranch    uint64
 	LoadDepths      [10]uint64
 	Unfolds         uint64
@@ -105,6 +111,9 @@ func (m *Metrics) AsValues() MetricValues {
 		LoadBranch:      m.loadBranch.Load(),
 		LoadAccount:     m.loadAccount.Load(),
 		LoadStorage:     m.loadStorage.Load(),
+		CacheBranch:     m.cacheBranch.Load(),
+		CacheAccount:    m.cacheAccount.Load(),
+		CacheStorage:    m.cacheStorage.Load(),
 		UpdateBranch:    m.updateBranch.Load(),
 		LoadDepths:      m.loadDepths,
 		Unfolds:         m.unfolds.Load(),
@@ -134,6 +143,8 @@ func (m *Metrics) logMetrics() []any {
 		"akeys", common.PrettyCounter(m.addressKeys.Load()), "skeys", common.PrettyCounter(m.storageKeys.Load()),
 		"rdb", common.PrettyCounter(m.loadBranch.Load()), "rda", common.PrettyCounter(m.loadAccount.Load()),
 		"rds", common.PrettyCounter(m.loadStorage.Load()), "wrb", common.PrettyCounter(m.updateBranch.Load()),
+		"cb", common.PrettyCounter(m.cacheBranch.Load()), "ca", common.PrettyCounter(m.cacheAccount.Load()),
+		"cs", common.PrettyCounter(m.cacheStorage.Load()),
 		"fld", common.PrettyCounter(m.unfolds.Load()), "pdur", common.Round(m.spentProcessing, 0).String(),
 		"fdur", common.Round(m.spentFolding, 0).String(), "ufdur", common.Round(m.spentUnfolding, 0),
 	}
@@ -148,6 +159,9 @@ func metricsHeaders() []string {
 		"PatriciaContext.Account()",
 		"PatriciaContext.Storage()",
 		"PatriciaContext.PutBranch()",
+		"CacheHit.Branch",
+		"CacheHit.Account",
+		"CacheHit.Storage",
 		"L0 - Load Account/Storage",
 		"L1 - Load Account/Storage",
 		"L2 - Load Account/Storage",
@@ -174,6 +188,9 @@ func (m *Metrics) Values() [][]string {
 			strconv.FormatUint(m.loadAccount.Load(), 10),
 			strconv.FormatUint(m.loadStorage.Load(), 10),
 			strconv.FormatUint(m.updateBranch.Load(), 10),
+			strconv.FormatUint(m.cacheBranch.Load(), 10),
+			strconv.FormatUint(m.cacheAccount.Load(), 10),
+			strconv.FormatUint(m.cacheStorage.Load(), 10),
 			strconv.FormatUint(m.loadDepths[0], 10) + "/" + strconv.FormatUint(m.loadDepths[1], 10),
 			strconv.FormatUint(m.loadDepths[2], 10) + "/" + strconv.FormatUint(m.loadDepths[3], 10),
 			strconv.FormatUint(m.loadDepths[4], 10) + "/" + strconv.FormatUint(m.loadDepths[5], 10),
@@ -210,6 +227,12 @@ func UnmarshallMetricsCsv(filePath string) ([]*Metrics, error) {
 			current.loadStorage.Store(mustParseUintCsvCell(row, col, filePath))
 			col++
 			current.updateBranch.Store(mustParseUintCsvCell(row, col, filePath))
+			col++
+			current.cacheBranch.Store(mustParseUintCsvCell(row, col, filePath))
+			col++
+			current.cacheAccount.Store(mustParseUintCsvCell(row, col, filePath))
+			col++
+			current.cacheStorage.Store(mustParseUintCsvCell(row, col, filePath))
 			col++
 			for k := range 5 {
 				depthsPair := row[col]


### PR DESCRIPTION
## Summary

Add cache hit counters to the commitment `Metrics` struct to measure WarmupCache effectiveness:

- **`cb` (cacheBranch)**: Branch reads served from cache
- **`ca` (cacheAccount)**: Account reads served from cache  
- **`cs` (cacheStorage)**: Storage reads served from cache

These are logged alongside the existing DB read counters (`rdb`/`rda`/`rds`), so you can compute hit rates:
- Branch hit rate = `cb / (cb + rdb)`
- Account hit rate = `ca / (ca + rda)`
- Storage hit rate = `cs / (cs + rds)`

## Context

Chain-head profiling shows commitment is 32.4% of block processing time, and is I/O-bound (14 keys/ms throughput). The WarmupCache exists but has zero instrumentation — we don't know if the 16-worker warmup is actually helping. These metrics answer that question.

## Test plan

- [x] `go build ./execution/commitment/...` clean
- [x] `go test ./execution/commitment/... -short` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)