### PR TITLE
ci: shard hive EEST consume-engine by fork (~2.8x speedup)

### DIFF
--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -24,19 +24,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # consume-engine: split by fork for parallelism (61k+ tests total)
+          # consume-engine: split by fork for parallelism (61k+ tests total).
           # Engine API tests only exist from Paris (The Merge) onwards.
+          # Pattern format: "<suite-regex>/<test-regex>" — the leading ".*/""
+          # matches the suite name (eest/consume-engine) while the remainder
+          # filters individual pytest test IDs by fork parameter.
           - sim: consume-engine
-            sim-limit: "fork_Paris|fork_Shanghai"
+            sim-limit: ".*/.*fork_(Paris|Shanghai)"
             shard: paris+shanghai
           - sim: consume-engine
-            sim-limit: "fork_Cancun"
+            sim-limit: ".*/.*fork_Cancun"
             shard: cancun
           - sim: consume-engine
-            sim-limit: "fork_Prague"
+            sim-limit: ".*/.*fork_Prague"
             shard: prague
           - sim: consume-engine
-            sim-limit: "fork_Osaka"
+            sim-limit: ".*/.*fork_Osaka"
             shard: osaka
           - sim: consume-rlp
             sim-limit: ".*eip2930_access_list.*" # all tests take too long


### PR DESCRIPTION
## Summary

- Split the single `consume-engine` job (61k+ tests, ~200 min) into **4 parallel shards** by target fork
- Each shard runs on a separate `hive` runner
- Fix unquoted `run_suite` arguments (`|` was interpreted as bash pipe)

## Sharding

| Shard | sim-limit | ~Tests | Time |
|-------|-----------|--------|------|
| paris+shanghai | `.*/.*fork_(Paris\|Shanghai)` | ~2,600 | 12 min |
| cancun | `.*/.*fork_Cancun` | ~17,250 | 59 min |
| prague | `.*/.*fork_Prague` | ~20,500 | 71 min |
| osaka | `.*/.*fork_Osaka` | ~21,000 | 74 min |
| rlp *(unchanged)* | `.*eip2930_access_list.*` | — | 19 min |

**Wall clock: 74 min** (down from ~200 min).

The `sim-limit` patterns use hive's `<suite-regex>/<test-regex>` format: the `.*` before `/` matches the suite name (`eest/consume-engine`), while the remainder filters individual pytest test IDs by `fork_<Name>` parameter.

## Test plan

- [x] CI run passed all 5 shards: https://github.com/erigontech/erigon/actions/runs/23113701478

🤖 Generated with [Claude Code](https://claude.com/claude-code)