### PR TITLE
ci, execution/tests: skip execution tests on macOS, flip env var polarity

### DIFF
--- a/.github/workflows/test-all-erigon.yml
+++ b/.github/workflows/test-all-erigon.yml
@@ -46,6 +46,9 @@ jobs:
           # marginal timeouts while keeping Linux/macOS at the tighter 20m.
           - os: windows-2025
             test_timeout: 30m
+            skip_execution_tests: 'true'
+          - os: macos-15
+            skip_execution_tests: 'true'
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -71,6 +74,7 @@ jobs:
         env:
           SKIP_FLAKY_TESTS: 'true'
           TEST_TIMEOUT: ${{ matrix.test_timeout || '20m' }}
+          ERIGON_SKIP_EXECUTION_TESTS: ${{ matrix.skip_execution_tests || '' }}
         run: |
           if ! make test-all GO_FLAGS="--timeout $TEST_TIMEOUT"; then
             # Retry after clearing the Go build cache. Low disk space can cause

--- a/execution/tests/testutil/temporal_db.go
+++ b/execution/tests/testutil/temporal_db.go
@@ -19,7 +19,6 @@ package testutil
 import (
 	"context"
 	"os"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -31,10 +30,10 @@ import (
 	"github.com/erigontech/erigon/db/state/execctx"
 )
 
-func SkipOnWindows(t testing.TB) {
+func skipIfRequested(t testing.TB) {
 	t.Helper()
-	if runtime.GOOS == "windows" && os.Getenv("ERIGON_NO_SKIP_EXECUTION_TESTS") == "" {
-		t.Skip("skipped on Windows; set ERIGON_NO_SKIP_EXECUTION_TESTS=1 to run")
+	if os.Getenv("ERIGON_SKIP_EXECUTION_TESTS") != "" {
+		t.Skip("skipped; unset ERIGON_SKIP_EXECUTION_TESTS to run")
 	}
 }
 
@@ -43,13 +42,14 @@ func TemporalDB(t testing.TB) kv.TemporalRwDB {
 }
 
 func TemporalDBWithDirs(t testing.TB, dirs datadir.Dirs) kv.TemporalRwDB {
-	// Skip on Windows: MDBX correctness is thoroughly exercised by the unit and
-	// integration tests in the main repo (execution/state, execution/stagedsync,
-	// db/kv/mdbx, db/state, etc.) which run on all platforms. The spec-test
-	// suites here (ethereum/execution-spec-tests, legacy blockchain tests) verify
-	// EVM and consensus correctness, which is platform-independent; running them
-	// on Linux is sufficient. Set ERIGON_NO_SKIP_EXECUTION_TESTS=1 to force on Windows.
-	SkipOnWindows(t)
+	// Skip when ERIGON_SKIP_EXECUTION_TESTS is set: MDBX correctness is
+	// thoroughly exercised by the unit and integration tests in the main repo
+	// (execution/state, execution/stagedsync, db/kv/mdbx, db/state, etc.) which
+	// run on all platforms. The spec-test suites here
+	// (ethereum/execution-spec-tests, legacy blockchain tests) verify EVM and
+	// consensus correctness, which is platform-independent; running them on
+	// Linux is sufficient. Unset ERIGON_SKIP_EXECUTION_TESTS to force locally.
+	skipIfRequested(t)
 	return temporaltest.NewTestDB(t, dirs)
 }
 


### PR DESCRIPTION
Like #19766 did for Windows, skip the execution spec-test suites (ethereum/execution-spec-tests, legacy blockchain tests) on macOS too. These tests verify EVM and consensus correctness which is platform-independent; running them on Linux is sufficient.

Also flips the env var polarity: `ERIGON_NO_SKIP_EXECUTION_TESTS` (opt-in to run) → `ERIGON_SKIP_EXECUTION_TESTS` (opt-in to skip). The new var is set to `true` for both `windows-2025` and `macos-15` in `test-all-erigon.yml`.