### PR TITLE
db/state: fix unsafe dirtyFiles access in merge file lookups

### DIFF
--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -1554,7 +1554,7 @@ func (at *AggregatorRoTx) findMergeRange(maxEndTxNum, stepSize, stepsInFrozenFil
 			}
 			// commitment waits until storage and account are merged so it may be a bit behind (if merge was interrupted before)
 			if !dr.values.needMerge || cr.values.to < dr.values.from {
-				if mf := at.d[kd].lookupDirtyFileByItsRange(cr.values.from, cr.values.to); mf != nil {
+				if _, err := at.d[kd].lookupVisibleFileByRange(cr.values.from, cr.values.to); err == nil {
 					// file for required range exists, hold this domain from merge but allow to merge comitemnt
 					r.domain[k].values = MergeRange{}
 					at.a.logger.Debug("findMergeRange: commitment range is different but file exists in domain, hold further merge",

--- a/db/state/domain_committed.go
+++ b/db/state/domain_committed.go
@@ -207,6 +207,18 @@ func (dt *DomainRoTx) findShortenedKey(fullKey []byte, itemGetter *seg.Reader, i
 	return 0, false
 }
 
+// lookupVisibleFileByRange searches only among visible files (those in the RoTx snapshot).
+// Use this during merge operations where constituent files are guaranteed to be visible.
+func (dt *DomainRoTx) lookupVisibleFileByRange(txFrom, txTo uint64) (*FilesItem, error) {
+	for _, f := range dt.files {
+		if f.startTxNum == txFrom && f.endTxNum == txTo && f.src != nil {
+			return f.src, nil
+		}
+	}
+	return nil, fmt.Errorf("file %s-%s.%d-%d.kv not found in visible files",
+		dt.d.FileVersion.DataKV.String(), dt.d.FilenameBase, txFrom/dt.d.stepSize, txTo/dt.d.stepSize)
+}
+
 // rawLookupFileByRange searches for a file that contains the given range of tx numbers.
 // Given range should exactly match the range of some file, so expected to be multiple of stepSize.
 // At first it checks range among visible files, then among dirty files.
@@ -344,11 +356,11 @@ func (dt *DomainRoTx) commitmentValTransformDomain(rng MergeRange, accounts, sto
 		}
 		sig, ok := storageFileMap[keyFromTxNum][keyEndTxNum]
 		if !ok {
-			dirty := storage.lookupDirtyFileByItsRange(keyFromTxNum, keyEndTxNum)
-			if dirty == nil {
-				return nil, fmt.Errorf("dirty storage file not found %d-%d", keyFromTxNum/dt.d.stepSize, keyEndTxNum/dt.d.stepSize)
+			f, err := storage.lookupVisibleFileByRange(keyFromTxNum, keyEndTxNum)
+			if err != nil {
+				return nil, fmt.Errorf("storage file not found in visible files: %w", err)
 			}
-			sig = storage.dataReader(dirty.decompressor)
+			sig = storage.dataReader(f.decompressor)
 			storageFileMap[keyFromTxNum][keyEndTxNum] = sig
 		}
 
@@ -357,11 +369,11 @@ func (dt *DomainRoTx) commitmentValTransformDomain(rng MergeRange, accounts, sto
 		}
 		aig, ok := accountFileMap[keyFromTxNum][keyEndTxNum]
 		if !ok {
-			dirty := accounts.lookupDirtyFileByItsRange(keyFromTxNum, keyEndTxNum)
-			if dirty == nil {
-				return nil, fmt.Errorf("dirty account file not found %d-%d", keyFromTxNum/dt.d.stepSize, keyEndTxNum/dt.d.stepSize)
+			f, err := accounts.lookupVisibleFileByRange(keyFromTxNum, keyEndTxNum)
+			if err != nil {
+				return nil, fmt.Errorf("account file not found in visible files: %w", err)
 			}
-			aig = accounts.dataReader(dirty.decompressor)
+			aig = accounts.dataReader(f.decompressor)
 			accountFileMap[keyFromTxNum][keyEndTxNum] = aig
 		}
 


### PR DESCRIPTION
`dirtyFiles` is mutable shared state — accessing it from a RoTx context is unsafe: no mutex, no refcount, and `aggRoTx.Close()` can `closeAndRemove` a file mid-lookup. `commitmentValTransformDomain` and `findMergeRange` both did this via `lookupDirtyFileByItsRange`.

Since the introduction of the dependency checker, dependent files are guaranteed to move together — so any file needed during merge is already visible in the RoTx, making `lookupVisibleFileByRange` safe to use.

- Add `lookupVisibleFileByRange` on `DomainRoTx` searching only the visible-file snapshot
- Replace `lookupDirtyFileByItsRange` in `commitmentValTransformDomain` and `findMergeRange`

Part of #15482.