### PR TITLE
snapshotsync: make snapshot deletion idempotent

### DIFF
--- a/db/snapshotsync/snapshots.go
+++ b/db/snapshotsync/snapshots.go
@@ -1395,13 +1395,12 @@ func (s *RoSnapshots) delete(fileName string) error {
 	s.dirtyLock.Lock()
 	defer s.dirtyLock.Unlock()
 
-	var err error
 	var delSeg *DirtySegment
 	var dirtySegments *btree.BTreeG[*DirtySegment]
 
 	_, fName := filepath.Split(fileName)
 	for _, t := range s.enums {
-		findDelSeg := false
+		found := false
 		s.dirty[t].Walk(func(segs []*DirtySegment) bool {
 			for _, sn := range segs {
 				if sn.Decompressor == nil {
@@ -1413,17 +1412,22 @@ func (s *RoSnapshots) delete(fileName string) error {
 				sn.canDelete.Store(true)
 				delSeg = sn
 				dirtySegments = s.dirty[t]
-				findDelSeg = false
-				return true
+				found = true
+				return false
 			}
 			return true
 		})
-		if findDelSeg {
+		if found {
 			break
 		}
 	}
+	if delSeg == nil || dirtySegments == nil {
+		// Deletion is intentionally idempotent because a snapshot may already
+		// have been removed from the in-memory set by another pruning path.
+		return nil
+	}
 	dirtySegments.Delete(delSeg)
-	return err
+	return nil
 }
 
 // prune visible segments

--- a/db/snapshotsync/snapshots_test.go
+++ b/db/snapshotsync/snapshots_test.go
@@ -318,6 +318,32 @@ func TestDeleteSnapshots(t *testing.T) {
 	}
 }
 
+func TestDeleteSnapshotsIsIdempotent(t *testing.T) {
+	logger := testlog.Logger(t, log.LvlCrit)
+	dir := t.TempDir()
+	require := require.New(t)
+
+	for _, snT := range snaptype2.BlockSnapshotTypes {
+		createTestSegmentFile(t, 0, 10_000, snT.Enum(), dir, version.V1_0, logger)
+	}
+
+	s := NewRoSnapshots(ethconfig.BlocksFreezing{ChainName: networkname.Mainnet}, dir, snaptype2.BlockSnapshotTypes, true, logger)
+	defer s.Close()
+	require.NoError(s.OpenFolder())
+
+	fileName := snaptype.SegmentFileName(version.V1_0, 0, 10_000, snaptype2.Bodies.Enum())
+
+	require.NoError(s.Delete(fileName))
+	require.False(slices.Contains(s.Files(), fileName))
+
+	require.NotPanics(func() {
+		require.NoError(s.Delete(fileName))
+	})
+	require.NotPanics(func() {
+		require.NoError(s.Delete("v1.0-999999-1000000-bodies.seg"))
+	})
+}
+
 func TestRemoveOverlaps(t *testing.T) {
 	mustSeeFile := func(files []string, fileNameWithoutVersion string) bool { //file-version agnostic
 		for _, f := range files {


### PR DESCRIPTION
  `RoSnapshots.delete` could call `dirtySegments.Delete(delSeg)` even when the target segment was no longer present. That makes repeated  deletes or overlapping cleanup paths turn a harmless "already gone" case into a nil-pointer failure in snapshot pruning.
                                                                                                                                          
  This change makes deletion explicitly idempotent: once no matching segment is found, we return `nil` instead of touching an empty tree. It also stops the tree walk as soon as the target is found.                                                                             

  The regression test covers both cases that matter here: deleting the same snapshot twice and deleting a snapshot that does not exist. That gives a direct proof that the new behavior is safe and matches the intended delete semantics.