### PR TITLE
cl/caplin: fix intermittent 0-peer sync failures on Gnosis 

### DIFF
--- a/cl/phase1/network/backward_beacon_downloader.go
+++ b/cl/phase1/network/backward_beacon_downloader.go
@@ -18,6 +18,7 @@ package network
 
 import (
 	"context"
+	"errors"
 	"math"
 	"sync"
 	"sync/atomic"
@@ -28,6 +29,7 @@ import (
 	"github.com/erigontech/erigon/cl/persistence/beacon_indicies"
 	"github.com/erigontech/erigon/cl/phase1/execution_client"
 	"github.com/erigontech/erigon/cl/rpc"
+	"github.com/erigontech/erigon/cl/sentinel/peers"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
@@ -186,7 +188,17 @@ func (b *BackwardBeaconDownloader) sendBlockRequest(
 	requestSent *atomic.Bool,
 ) {
 	blocks, peerId, err := b.rpc.SendBeaconBlocksByRangeReq(ctx, start, count)
-	if err != nil || blocks == nil || len(blocks) == 0 {
+	if err != nil {
+		// Don't ban when the error is due to no peers being available.
+		if !errors.Is(err, peers.ErrNoPeers) {
+			b.rpc.BanPeer(peerId)
+		} else {
+			log.Debug("[Caplin] no peers available for backward beacon block request", "start", start, "count", count)
+		}
+		requestSent.Store(false)
+		return
+	}
+	if blocks == nil || len(blocks) == 0 {
 		b.rpc.BanPeer(peerId)
 		requestSent.Store(false)
 		return

--- a/cl/phase1/network/beacon_downloader.go
+++ b/cl/phase1/network/beacon_downloader.go
@@ -113,7 +113,7 @@ Loop:
 				responses, peerId, err := f.rpc.SendBeaconBlocksByRangeReq(ctx, reqSlot, reqCount)
 				if err != nil {
 					if errors.Is(err, peers.ErrNoPeers) {
-						log.Trace("No peers available for beacon blocks by range request", "err", err, "peer", peerId, "slot", reqSlot, "reqCount", reqCount)
+						log.Debug("[Caplin] no peers available for beacon blocks by range request", "slot", reqSlot, "reqCount", reqCount)
 					} else {
 						log.Debug("Failed to send beacon blocks by range request", "err", err, "peer", peerId, "slot", reqSlot, "reqCount", reqCount)
 					}

--- a/cl/phase1/stages/chain_tip_sync.go
+++ b/cl/phase1/stages/chain_tip_sync.go
@@ -2,6 +2,7 @@ package stages
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"time"
 
@@ -57,9 +58,23 @@ func waitForExecutionEngineToBeFinished(ctx context.Context, cfg *Cfg) (ready bo
 // It sends a request to fetch the blocks, verifies the associated blobs, and inserts them into the blob store.
 // It returns a PeeredObject containing the blocks and the peer ID, or an error if something goes wrong.
 func fetchBlocksFromReqResp(ctx context.Context, cfg *Cfg, from uint64, count uint64) (*peers.PeeredObject[[]*cltypes.SignedBeaconBlock], error) {
-	// spam requests to fetch blocks by range from the execution client
 	blocks, pid, err := cfg.rpc.SendBeaconBlocksByRangeReq(ctx, from, count)
 	for err != nil {
+		// Respect context cancellation to avoid infinite loops.
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+		if errors.Is(err, peers.ErrNoPeers) {
+			// Back off when no peers are available to avoid CPU-burning tight loops.
+			log.Debug("[Caplin] no peers available, backing off before retrying block request", "from", from, "count", count)
+			select {
+			case <-time.After(2 * time.Second):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
 		blocks, pid, err = cfg.rpc.SendBeaconBlocksByRangeReq(ctx, from, count)
 	}
 

--- a/cl/phase1/stages/clstages.go
+++ b/cl/phase1/stages/clstages.go
@@ -142,12 +142,20 @@ const (
 	ForkChoice               StageName = "ForkChoice"
 	CleanupAndPruning        StageName = "CleanupAndPruning"
 	SleepForSlot             StageName = "SleepForSlot"
+	WaitForPeers             StageName = "WaitForPeers"
 	DownloadHistoricalBlocks StageName = "DownloadHistoricalBlocks"
 )
 
 func MetaCatchingUp(args Args) StageName {
 	if !args.hasDownloaded {
 		return DownloadHistoricalBlocks
+	}
+	// If we have no peers, sleep until the next slot rather than entering sync
+	// stages that will fail. This avoids CPU-burning retry loops when peer
+	// discovery has not completed yet (common on Gnosis with 5-second slots).
+	if args.peers == 0 {
+		log.Debug("[Caplin] no peers available, waiting for peer discovery before syncing")
+		return WaitForPeers
 	}
 	if args.seenEpoch < args.targetEpoch {
 		return ForwardSync
@@ -313,6 +321,24 @@ func ConsensusClStages(ctx context.Context,
 					return SleepForSlot
 				},
 				ActionFunc: cleanupAndPruning,
+			},
+			WaitForPeers: {
+				Description: `brief wait for peer discovery when no peers are available`,
+				TransitionFunc: func(cfg *Cfg, args Args, err error) string {
+					if x := MetaCatchingUp(args); x != "" {
+						return x
+					}
+					return ChainTipSync
+				},
+				ActionFunc: func(ctx context.Context, logger log.Logger, cfg *Cfg, args Args) error {
+					// Wait 1 second before re-checking peers. Short enough to react
+					// quickly once peers appear, long enough to avoid busy-looping.
+					select {
+					case <-time.After(1 * time.Second):
+					case <-ctx.Done():
+					}
+					return nil
+				},
 			},
 			SleepForSlot: {
 				Description: `sleep until the next slot`,


### PR DESCRIPTION
## Summary
Fixes #19858

The Gnosis tip-tracking test intermittently fails because the stage pipeline
enters sync stages before peer discovery completes (Gnosis has 5s slots vs
mainnet 12s, narrowing the race window).

- **Add `WaitForPeers` stage**: 1s retry loop when peers=0, avoids entering
  ForwardSync/ChainTipSync prematurely without sleeping a full slot
- **Fix tight retry loop**: `fetchBlocksFromReqResp` now checks context
  cancellation and backs off 2s on `ErrNoPeers`
- **Don't ban empty peerId**: `BackwardBeaconDownloader.sendBlockRequest`
  no longer calls `BanPeer("")` on `ErrNoPeers`
- **Improve observability**: `ErrNoPeers` log level raised from Trace to Debug

## Test plan
- [x] `go build ./cl/phase1/stages/ ./cl/phase1/network/` — compiles clean
- [x] Dispatch `qa-tip-tracking-gnosis` workflow on this branch to verify fix
https://github.com/erigontech/erigon/actions/runs/23181300043
- [ ] Monitor that Debug logs appear when peers are temporarily unavailable