### PR TITLE
rpc: guard eth_createAccessList when from is omitted

### DIFF
--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -839,6 +839,10 @@ func (api *APIImpl) CreateAccessList(ctx context.Context, args ethapi2.CallArgs,
 	// lists and we'll need to reestimate every time
 	nogas := args.Gas == nil
 
+	if args.From == nil {
+		args.From = &common.Address{}
+	}
+
 	var to common.Address
 	if args.To != nil {
 		to = *args.To
@@ -868,10 +872,6 @@ func (api *APIImpl) CreateAccessList(ctx context.Context, args ethapi2.CallArgs,
 			args.Nonce = (*hexutil.Uint64)(&nonce)
 		}
 		to = types.CreateAddress(*args.From, uint64(*args.Nonce))
-	}
-
-	if args.From == nil {
-		args.From = &common.Address{}
 	}
 
 	// Retrieve the precompiles since they don't need to be added to the access list

--- a/rpc/jsonrpc/eth_call_test.go
+++ b/rpc/jsonrpc/eth_call_test.go
@@ -27,6 +27,8 @@ import (
 	"testing"
 	"time"
 
+	"google.golang.org/grpc"
+
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -73,6 +75,27 @@ func TestEstimateGas(t *testing.T) {
 	}, nil, nil, nil); err != nil {
 		t.Errorf("calling EstimateGas: %v", err)
 	}
+}
+
+type stubTxPoolClient struct{ txpoolproto.TxpoolClient }
+
+func (stubTxPoolClient) Nonce(context.Context, *txpoolproto.NonceRequest, ...grpc.CallOption) (*txpoolproto.NonceReply, error) {
+	return &txpoolproto.NonceReply{}, nil
+}
+
+func TestCreateAccessListContractCreationWithoutFromDoesNotPanic(t *testing.T) {
+	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
+	api := newEthApiForTest(newBaseApiForTest(m), m.DB, stubTxPoolClient{}, nil)
+
+	var (
+		res *accessListResult
+		err error
+	)
+	require.NotPanics(t, func() {
+		res, err = api.CreateAccessList(context.Background(), ethapi.CallArgs{}, nil, nil, nil)
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
 }
 
 func TestEthCallNonCanonical(t *testing.T) {


### PR DESCRIPTION
Initialize the default sender before contract-creation nonce and address derivation, and add a regression test for eth_createAccessList requests without `from`.