### PR TITLE
downloader, snapshots: add erigon snapshots verify subcommand

### DIFF
--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -547,6 +547,37 @@ var snapshotCommand = cli.Command{
 			},
 		},
 		{
+			Name:        "verify",
+			Description: "verify snapshot downloads against .torrent files and preverified.toml",
+			Action: func(cliCtx *cli.Context) (err error) {
+				dirs := datadir.New(cliCtx.String(utils.DataDirFlag.Name))
+				logger := log.Root()
+				issues, err := downloader.VerifySnapshotDownloads(cliCtx.Context, dirs, logger)
+				if err != nil {
+					return fmt.Errorf("verify snapshot downloads: %w", err)
+				}
+				errorCount, warnCount := 0, 0
+				for _, issue := range issues {
+					switch issue.Severity {
+					case "error":
+						logger.Error("[snapshots verify] "+issue.Message, "file", issue.File)
+						errorCount++
+					case "warn":
+						logger.Warn("[snapshots verify] "+issue.Message, "file", issue.File)
+						warnCount++
+					}
+				}
+				logger.Info("[snapshots verify] done", "errors", errorCount, "warnings", warnCount)
+				if errorCount > 0 {
+					return fmt.Errorf("%d error(s) found during snapshot verification", errorCount)
+				}
+				return nil
+			},
+			Flags: joinFlags([]cli.Flag{
+				&utils.DataDirFlag,
+			}),
+		},
+		{
 			Name: "preverified",
 			Action: func(cliCtx *cli.Context) (err error) {
 				var dataDir string

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -557,7 +557,7 @@ var snapshotCommand = cli.Command{
 					return fmt.Errorf("verify snapshot downloads: %w", err)
 				}
 				log.Root().Info("[snapshots verify] done",
-					"torrents", summary.Torrents,
+					"snapshots", summary.Total,
 					"errors", summary.Errors,
 					"warnings", summary.Warnings,
 				)

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -548,33 +548,27 @@ var snapshotCommand = cli.Command{
 		},
 		{
 			Name:        "verify",
-			Description: "verify snapshot downloads against .torrent files and preverified.toml",
+			Description: "verify snapshot downloads against .torrent files and preverified.toml; findings are written as JSON lines to stdout",
 			Action: func(cliCtx *cli.Context) (err error) {
 				dirs := datadir.New(cliCtx.String(utils.DataDirFlag.Name))
-				logger := log.Root()
-				issues, err := downloader.VerifySnapshotDownloads(cliCtx.Context, dirs, logger)
+				workers := cliCtx.Int("workers")
+				summary, err := downloader.VerifySnapshotDownloads(cliCtx.Context, dirs, workers, os.Stdout)
 				if err != nil {
 					return fmt.Errorf("verify snapshot downloads: %w", err)
 				}
-				errorCount, warnCount := 0, 0
-				for _, issue := range issues {
-					switch issue.Severity {
-					case "error":
-						logger.Error("[snapshots verify] "+issue.Message, "file", issue.File)
-						errorCount++
-					case "warn":
-						logger.Warn("[snapshots verify] "+issue.Message, "file", issue.File)
-						warnCount++
-					}
-				}
-				logger.Info("[snapshots verify] done", "errors", errorCount, "warnings", warnCount)
-				if errorCount > 0 {
-					return fmt.Errorf("%d error(s) found during snapshot verification", errorCount)
+				log.Root().Info("[snapshots verify] done",
+					"torrents", summary.Torrents,
+					"errors", summary.Errors,
+					"warnings", summary.Warnings,
+				)
+				if summary.Errors > 0 {
+					return fmt.Errorf("%d error(s) found during snapshot verification", summary.Errors)
 				}
 				return nil
 			},
 			Flags: joinFlags([]cli.Flag{
 				&utils.DataDirFlag,
+				&cli.IntFlag{Name: "workers", Value: 0, Usage: "parallel workers for torrent verification (0 = GOMAXPROCS/2)"},
 			}),
 		},
 		{

--- a/db/downloader/downloader.go
+++ b/db/downloader/downloader.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"io/fs"
 	"iter"
+	"log/slog"
 	"math"
 	"net"
 	"net/http"
@@ -1293,6 +1294,18 @@ func openMdbx(
 	return dbCfg.Open(ctx)
 }
 
+// newSnapStorage creates the file storage client used for snapshot torrents.
+// Part-file-only piece completion is used: this requires hashing incomplete files at start-up,
+// but the expectation is that files should not be partial.
+// See also: https://github.com/erigontech/erigon/pull/10074
+func newSnapStorage(snapDir string, logger *slog.Logger) storage.ClientImplCloser {
+	return storage.NewFileOpts(storage.NewFileClientOpts{
+		ClientBaseDir: snapDir,
+		UsePartFiles:  g.Some(true),
+		Logger:        logger,
+	})
+}
+
 // This used to return the MDBX database. Instead, that's opened separately now and should be passed
 // in if it's revived.
 func newTorrentClient(
@@ -1304,17 +1317,7 @@ func newTorrentClient(
 	torrentClient *torrent.Client,
 	err error,
 ) {
-	// Possibly File storage needs more optimization for handles, will test. Should reduce GC
-	// pressure and improve scheduler handling.
-	// See also: https://github.com/erigontech/erigon/pull/10074
-	// We're using part-file-only piece completion. This requires hashing incomplete files at
-	// start-up, but the expectation is that files should not be partial. Also managing separate
-	// piece completion complicates user management of snapshots.
-	m = storage.NewFileOpts(storage.NewFileClientOpts{
-		ClientBaseDir: snapDir,
-		UsePartFiles:  g.Some(true),
-		Logger:        cfg.Slogger.With("names", "storage"),
-	})
+	m = newSnapStorage(snapDir, cfg.Slogger.With("names", "storage"))
 	cfg.DefaultStorage = m
 
 	defer func() {

--- a/db/downloader/verify-snapshot-downloads.go
+++ b/db/downloader/verify-snapshot-downloads.go
@@ -28,7 +28,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	g "github.com/anacrolix/generics"
 	"github.com/anacrolix/torrent/metainfo"
 	"github.com/anacrolix/torrent/storage"
 	"github.com/pelletier/go-toml/v2"
@@ -324,22 +323,15 @@ func checkDataFile(
 	return issues, true
 }
 
-// verifyPieceHashes hashes each torrent piece using the mmap/sparse-read storage layer and
-// compares to the piece hashes recorded in the torrent info dict.
+// verifyPieceHashes hashes each torrent piece using the same mmap/sparse-read storage
+// configuration as the main downloader and compares against the piece hashes in the torrent info.
 func verifyPieceHashes(
 	ctx context.Context,
 	snapDir string,
 	info *metainfo.Info,
 	infoHash metainfo.Hash,
 ) (issues []SnapshotVerifyIssue) {
-	// NewFileOpts with UsePartFiles=false uses the mmap-based fileIo (defaultFileIo).
-	// The mmap layer implements seekDataOrEof via SEEK_DATA/SEEK_HOLE, enabling efficient
-	// sparse-file reads that skip holes instead of reading zeroes.
-	client := storage.NewFileOpts(storage.NewFileClientOpts{
-		ClientBaseDir:   snapDir,
-		UsePartFiles:    g.Some(false),
-		PieceCompletion: storage.NewMapPieceCompletion(),
-	})
+	client := newSnapStorage(snapDir, nil)
 	defer client.Close()
 
 	t, err := client.OpenTorrent(ctx, info, infoHash)

--- a/db/downloader/verify-snapshot-downloads.go
+++ b/db/downloader/verify-snapshot-downloads.go
@@ -19,7 +19,6 @@ package downloader
 import (
 	"context"
 	"crypto/sha1" //nolint:gosec
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -49,30 +48,11 @@ const (
 	pvNoFile   = "no preverified.toml"
 )
 
-// SnapshotVerifyIssue is a single finding, emitted as {"type":"issue",...} to stdout.
-type SnapshotVerifyIssue struct {
-	Type     string `json:"type"` // always "issue"
-	Severity string `json:"severity"`
-	Snapshot string `json:"snapshot,omitempty"`
-	Torrent  string `json:"torrent,omitempty"`
-	File     string `json:"file,omitempty"`
-	Message  string `json:"message"`
-}
-
-// SnapshotVerifyProgress is emitted as {"type":"progress",...} after each snapshot completes.
-type SnapshotVerifyProgress struct {
-	Type        string  `json:"type"` // always "progress"
-	Snapshot    string  `json:"snapshot"`
-	Percent     float64 `json:"percent"`
-	Preverified string  `json:"preverified"`
-}
-
-// SnapshotVerifySummary is emitted as {"type":"summary",...} after all snapshots complete.
+// SnapshotVerifySummary is returned after all snapshots have been checked.
 type SnapshotVerifySummary struct {
-	Type     string `json:"type"` // always "summary"
-	Total    int    `json:"total"`
-	Errors   int    `json:"errors"`
-	Warnings int    `json:"warnings"`
+	Total    int
+	Errors   int
+	Warnings int
 }
 
 // snapshotState collects all on-disk information about one snapshot name.
@@ -91,32 +71,39 @@ type snapshotState struct {
 	hasData    bool
 }
 
-// encoder wraps a json.Encoder with a mutex for concurrent use.
-type encoder struct {
-	enc      *json.Encoder
+// output writes human-readable lines to out and counts errors/warnings. Safe for concurrent use.
+type output struct {
+	w        io.Writer
 	mu       sync.Mutex
 	errors   atomic.Int64
 	warnings atomic.Int64
 }
 
-func newEncoder(out io.Writer) *encoder {
-	return &encoder{enc: json.NewEncoder(out)}
-}
+func newOutput(w io.Writer) *output { return &output{w: w} }
 
-func (e *encoder) emit(v any) {
-	e.mu.Lock()
-	_ = e.enc.Encode(v) //nolint:errcheck
-	e.mu.Unlock()
-}
-
-func (e *encoder) issue(issue SnapshotVerifyIssue) {
-	issue.Type = "issue"
-	e.emit(issue)
-	switch issue.Severity {
+func (o *output) issue(severity, snapshot, message string) {
+	o.mu.Lock()
+	fmt.Fprintf(o.w, "%-5s  %s: %s\n", strings.ToUpper(severity), snapshot, message)
+	o.mu.Unlock()
+	switch severity {
 	case "error":
-		e.errors.Add(1)
+		o.errors.Add(1)
 	case "warn":
-		e.warnings.Add(1)
+		o.warnings.Add(1)
+	}
+}
+
+func (o *output) progress(snapshot string, percent float64, pvStatus string) {
+	o.mu.Lock()
+	fmt.Fprintf(o.w, "[%5.1f%%]  %-60s  %s\n", percent, snapshot, pvStatus)
+	o.mu.Unlock()
+}
+
+func (o *output) summary(total int) SnapshotVerifySummary {
+	return SnapshotVerifySummary{
+		Total:    total,
+		Errors:   int(o.errors.Load()),
+		Warnings: int(o.warnings.Load()),
 	}
 }
 
@@ -127,15 +114,14 @@ func (e *encoder) issue(issue SnapshotVerifyIssue) {
 //   - All files in the snap dir with ".torrent" stripped
 //   - All files in the snap dir with ".part" stripped
 //
-// For each snapshot, findings are written immediately as JSON lines to out. After each snapshot
-// completes, a progress line with name, % complete, and preverified status is written. A summary
-// line is written last.
+// Findings are written as human-readable lines to out as they are discovered. After each snapshot
+// completes a progress line is written with name, % done, and preverified status.
 func VerifySnapshotDownloads(ctx context.Context, dirs datadir.Dirs, workers int, out io.Writer) (summary SnapshotVerifySummary, err error) {
 	if workers <= 0 {
 		workers = max(1, runtime.GOMAXPROCS(0)/2)
 	}
 	snapDir := dirs.Snap
-	enc := newEncoder(out)
+	o := newOutput(out)
 
 	// Load preverified.toml if present.
 	var pvItems preverified.SortedItems
@@ -154,7 +140,7 @@ func VerifySnapshotDownloads(ctx context.Context, dirs datadir.Dirs, workers int
 		return
 	}
 
-	// Build the complete set of snapshot names.
+	// Build the complete set of snapshot names from all sources.
 	nameSet := make(map[string]*snapshotState)
 
 	ensure := func(name string) *snapshotState {
@@ -180,11 +166,7 @@ func VerifySnapshotDownloads(ctx context.Context, dirs datadir.Dirs, workers int
 	// Seed from files on disk.
 	walkErr := fs.WalkDir(os.DirFS(snapDir), ".", func(relPath string, de fs.DirEntry, walkFileErr error) error {
 		if walkFileErr != nil {
-			enc.issue(SnapshotVerifyIssue{
-				Severity: "warn",
-				File:     relPath,
-				Message:  fmt.Sprintf("walk error: %v", walkFileErr),
-			})
+			o.issue("warn", relPath, fmt.Sprintf("walk error: %v", walkFileErr))
 			return nil
 		}
 		if de.IsDir() {
@@ -198,9 +180,9 @@ func VerifySnapshotDownloads(ctx context.Context, dirs datadir.Dirs, workers int
 			ensure(name).hasPart = true
 			return nil
 		}
-		// Check if this is a raw data file for a known snapshot name.
-		if _, exists := nameSet[relPath]; exists {
-			nameSet[relPath].hasData = true
+		// Mark data file presence for known names.
+		if s, exists := nameSet[relPath]; exists {
+			s.hasData = true
 		}
 		return nil
 	})
@@ -209,7 +191,7 @@ func VerifySnapshotDownloads(ctx context.Context, dirs datadir.Dirs, workers int
 		return
 	}
 
-	// Second pass: mark data file presence for all known names.
+	// Second pass: detect data files for names not yet marked (walk order may miss them).
 	for name, state := range nameSet {
 		if !state.hasData {
 			if _, statErr := os.Stat(filepath.Join(snapDir, filepath.FromSlash(name))); statErr == nil {
@@ -218,7 +200,6 @@ func VerifySnapshotDownloads(ctx context.Context, dirs datadir.Dirs, workers int
 		}
 	}
 
-	// Collect into a slice for indexed progress tracking.
 	states := make([]*snapshotState, 0, len(nameSet))
 	for _, s := range nameSet {
 		states = append(states, s)
@@ -232,26 +213,17 @@ func VerifySnapshotDownloads(ctx context.Context, dirs datadir.Dirs, workers int
 
 	for _, state := range states {
 		eg.Go(func() error {
-			pvStatus := verifyOneSnapshot(egCtx, snapDir, state, enc)
+			pvStatus := verifyOneSnapshot(egCtx, snapDir, state, o)
 			n := done.Add(1)
-			enc.emit(SnapshotVerifyProgress{
-				Type:        "progress",
-				Snapshot:    state.name,
-				Percent:     float64(n) / float64(total) * 100,
-				Preverified: pvStatus,
-			})
+			o.progress(state.name, float64(n)/float64(total)*100, pvStatus)
 			return nil
 		})
 	}
 	_ = eg.Wait()
 
-	summary = SnapshotVerifySummary{
-		Type:     "summary",
-		Total:    total,
-		Errors:   int(enc.errors.Load()),
-		Warnings: int(enc.warnings.Load()),
-	}
-	enc.emit(summary)
+	summary = o.summary(total)
+	fmt.Fprintf(out, "\nverified %d snapshots: %d error(s), %d warning(s)\n",
+		summary.Total, summary.Errors, summary.Warnings)
 
 	if ctx.Err() != nil {
 		err = ctx.Err()
@@ -265,114 +237,76 @@ func verifyOneSnapshot(
 	ctx context.Context,
 	snapDir string,
 	state *snapshotState,
-	enc *encoder,
+	o *output,
 ) (pvStatus string) {
 	name := state.name
 	torrentRel := name + ".torrent"
 
-	// Determine preverified status from what we already know.
-	// This may be refined once we have the actual infohash from the .torrent file.
 	switch {
 	case !state.pvPresent:
 		pvStatus = pvNoFile
 	case state.hasPV:
-		pvStatus = pvMatches // optimistic; corrected below if hash differs
+		pvStatus = pvMatches // refined below if hash differs
 	default:
 		pvStatus = pvNotIn
 	}
 
 	if !state.hasTorrent {
 		if state.hasPV || state.hasPart {
-			// Missing .torrent despite being expected.
-			enc.issue(SnapshotVerifyIssue{
-				Severity: "error",
-				Snapshot: name,
-				Torrent:  torrentRel,
-				Message:  "missing .torrent file",
-			})
+			o.issue("error", name, "missing .torrent file")
 		}
-		// Without a .torrent we can't do piece verification; check data/part presence only.
-		checkPartAndData(name, torrentRel, state, -1, enc)
+		checkPartAndData(name, state, -1, o)
 		return
 	}
 
-	torrentFilePath := filepath.Join(snapDir, filepath.FromSlash(torrentRel))
-	mi, err := metainfo.LoadFromFile(torrentFilePath)
+	mi, err := metainfo.LoadFromFile(filepath.Join(snapDir, filepath.FromSlash(torrentRel)))
 	if err != nil {
-		enc.issue(SnapshotVerifyIssue{
-			Severity: "error",
-			Snapshot: name,
-			Torrent:  torrentRel,
-			Message:  fmt.Sprintf("failed to load .torrent file: %v", err),
-		})
+		o.issue("error", name, fmt.Sprintf("failed to load .torrent file: %v", err))
 		return
 	}
 
 	infoHash := mi.HashInfoBytes()
 	infoHashHex := infoHash.HexString()
 
-	// Refine preverified status based on actual infohash.
 	if state.hasPV {
 		if state.pvItem.Hash == infoHashHex {
 			pvStatus = pvMatches
 		} else {
 			pvStatus = pvMismatch
-			enc.issue(SnapshotVerifyIssue{
-				Severity: "error",
-				Snapshot: name,
-				Torrent:  torrentRel,
-				Message:  fmt.Sprintf("infohash mismatch: preverified=%s torrent=%s", state.pvItem.Hash, infoHashHex),
-			})
+			o.issue("error", name,
+				fmt.Sprintf("infohash mismatch: preverified=%s torrent=%s", state.pvItem.Hash, infoHashHex))
 		}
 	}
 
 	info, err := mi.UnmarshalInfo()
 	if err != nil {
-		enc.issue(SnapshotVerifyIssue{
-			Severity: "error",
-			Snapshot: name,
-			Torrent:  torrentRel,
-			Message:  fmt.Sprintf("failed to unmarshal torrent info: %v", err),
-		})
+		o.issue("error", name, fmt.Sprintf("failed to unmarshal torrent info: %v", err))
 		return
 	}
 
-	// Validate info.Name is safe.
 	infoName := info.BestName()
 	if infoName != metainfo.NoName {
 		if _, pathErr := storage.ToSafeFilePath(infoName); pathErr != nil {
-			enc.issue(SnapshotVerifyIssue{
-				Severity: "error",
-				Snapshot: name,
-				Torrent:  torrentRel,
-				Message:  fmt.Sprintf("info.Name %q is unsafe: %v", infoName, pathErr),
-			})
+			o.issue("error", name, fmt.Sprintf("info.Name %q is unsafe: %v", infoName, pathErr))
 			return
 		}
-		baseName := path.Base(name)
-		if infoName != baseName {
-			enc.issue(SnapshotVerifyIssue{
-				Severity: "warn",
-				Snapshot: name,
-				Torrent:  torrentRel,
-				Message:  fmt.Sprintf("info.Name %q doesn't match torrent filename %q", infoName, baseName),
-			})
+		if baseName := path.Base(name); infoName != baseName {
+			o.issue("warn", name,
+				fmt.Sprintf("info.Name %q doesn't match torrent filename %q", infoName, baseName))
 		}
 	}
 
-	// Determine expected data file size from torrent.
 	var expectedSize int64
 	for _, fi := range info.UpvertedFiles() {
 		expectedSize += fi.Length
 	}
 
-	checkPartAndData(name, torrentRel, state, expectedSize, enc)
+	checkPartAndData(name, state, expectedSize, o)
 
-	// Only run piece hashing if data file is fully present and the right size.
 	if state.hasData && !state.hasPart && ctx.Err() == nil {
-		dataFilePath := filepath.Join(snapDir, filepath.FromSlash(name))
-		if fi, statErr := os.Stat(dataFilePath); statErr == nil && fi.Size() == expectedSize {
-			verifyPieceHashes(ctx, snapDir, name, torrentRel, &info, infoHash, enc)
+		if fi, statErr := os.Stat(filepath.Join(snapDir, filepath.FromSlash(name))); statErr == nil && fi.Size() == expectedSize {
+			checkDataFilePerms(snapDir, name, o)
+			verifyPieceHashes(ctx, snapDir, name, &info, infoHash, o)
 		}
 	}
 
@@ -380,55 +314,48 @@ func verifyOneSnapshot(
 }
 
 // checkPartAndData reports issues about the presence/absence of the data and .part files.
-// expectedSize is -1 when unknown (no .torrent).
-func checkPartAndData(
-	name string,
-	torrentRel string,
-	state *snapshotState,
-	expectedSize int64,
-	enc *encoder,
-) {
-	snapName := name // for clarity in messages
-
+// expectedSize is -1 when unknown (no .torrent available).
+func checkPartAndData(name string, state *snapshotState, expectedSize int64, o *output) {
 	if state.hasData && state.hasPart {
-		enc.issue(SnapshotVerifyIssue{
-			Severity: "error",
-			Snapshot: snapName,
-			Torrent:  torrentRel,
-			Message:  "both data file and .part file exist simultaneously",
-		})
+		o.issue("error", name, "both data file and .part file exist simultaneously")
 		return
 	}
-
 	if state.hasPart {
-		enc.issue(SnapshotVerifyIssue{
-			Severity: "warn",
-			Snapshot: snapName,
-			Torrent:  torrentRel,
-			Message:  "only .part file present; download is incomplete",
-		})
+		o.issue("warn", name, "only .part file present; download is incomplete")
 		return
 	}
-
 	if !state.hasData {
 		severity := "warn"
 		if state.hasPV {
 			severity = "error"
 		}
-		enc.issue(SnapshotVerifyIssue{
-			Severity: severity,
-			Snapshot: snapName,
-			Torrent:  torrentRel,
-			Message:  "data file absent (no .part either)",
-		})
+		o.issue(severity, name, "data file absent (no .part either)")
 		return
 	}
-
-	// Data file is present. Check its size if we know what to expect.
+	// Data file present; check size if known.
 	if expectedSize >= 0 {
-		dataPath := filepath.Join("", name) // just for display; actual stat done by caller
-		_ = dataPath
-		// Size check is done per-FileInfo in verifyOneSnapshot's callers; skip here.
+		if fi, statErr := os.Stat(filepath.Join("", name)); statErr == nil && fi.Size() != expectedSize {
+			o.issue("error", name,
+				fmt.Sprintf("size mismatch: on-disk=%d torrent=%d", fi.Size(), expectedSize))
+		}
+	}
+}
+
+// checkDataFilePerms warns if a snapshot data file has unexpected permissions.
+func checkDataFilePerms(snapDir, name string, o *output) {
+	fi, err := os.Stat(filepath.Join(snapDir, filepath.FromSlash(name)))
+	if err != nil {
+		return
+	}
+	perm := fi.Mode().Perm()
+	if perm&0o400 == 0 {
+		o.issue("error", name, fmt.Sprintf("not readable by owner (mode=%v)", perm))
+	}
+	if perm&0o222 != 0 {
+		o.issue("warn", name, fmt.Sprintf("writable (mode=%v); completed snapshots are expected read-only", perm))
+	}
+	if perm&0o002 != 0 {
+		o.issue("error", name, fmt.Sprintf("world-writable (mode=%v)", perm))
 	}
 }
 
@@ -438,22 +365,16 @@ func verifyPieceHashes(
 	ctx context.Context,
 	snapDir string,
 	snapshotName string,
-	torrentRel string,
 	info *metainfo.Info,
 	infoHash metainfo.Hash,
-	enc *encoder,
+	o *output,
 ) {
 	client := newSnapStorage(snapDir, nil)
 	defer client.Close()
 
 	t, err := client.OpenTorrent(ctx, info, infoHash)
 	if err != nil {
-		enc.issue(SnapshotVerifyIssue{
-			Severity: "error",
-			Snapshot: snapshotName,
-			Torrent:  torrentRel,
-			Message:  fmt.Sprintf("failed to open torrent storage for piece verification: %v", err),
-		})
+		o.issue("error", snapshotName, fmt.Sprintf("failed to open torrent storage: %v", err))
 		return
 	}
 	defer t.Close()
@@ -481,33 +402,20 @@ func verifyPieceHashes(
 		}
 
 		if readErr != nil {
-			enc.issue(SnapshotVerifyIssue{
-				Severity: "error",
-				Snapshot: snapshotName,
-				Torrent:  torrentRel,
-				Message:  fmt.Sprintf("piece %d: read error: %v", i, readErr),
-			})
+			o.issue("error", snapshotName, fmt.Sprintf("piece %d: read error: %v", i, readErr))
 			continue
 		}
 		if written < p.Length() {
-			enc.issue(SnapshotVerifyIssue{
-				Severity: "error",
-				Snapshot: snapshotName,
-				Torrent:  torrentRel,
-				Message:  fmt.Sprintf("piece %d: short read: got %d of %d bytes (sparse or incomplete)", i, written, p.Length()),
-			})
+			o.issue("error", snapshotName,
+				fmt.Sprintf("piece %d: short read: got %d of %d bytes (sparse or incomplete)", i, written, p.Length()))
 			continue
 		}
 
 		var actualHash metainfo.Hash
 		h.Sum(actualHash[:0])
 		if actualHash != expectedHash.Value {
-			enc.issue(SnapshotVerifyIssue{
-				Severity: "error",
-				Snapshot: snapshotName,
-				Torrent:  torrentRel,
-				Message:  fmt.Sprintf("piece %d: hash mismatch: expected %x got %x", i, expectedHash.Value, actualHash),
-			})
+			o.issue("error", snapshotName,
+				fmt.Sprintf("piece %d: hash mismatch: expected %x got %x", i, expectedHash.Value, actualHash))
 		}
 	}
 }

--- a/db/downloader/verify-snapshot-downloads.go
+++ b/db/downloader/verify-snapshot-downloads.go
@@ -1,0 +1,407 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package downloader
+
+import (
+	"context"
+	"crypto/sha1" //nolint:gosec
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	g "github.com/anacrolix/generics"
+	"github.com/anacrolix/torrent/metainfo"
+	"github.com/anacrolix/torrent/storage"
+	"github.com/pelletier/go-toml/v2"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/preverified"
+)
+
+// SnapshotVerifyIssue represents a problem found during snapshot download verification.
+type SnapshotVerifyIssue struct {
+	// "error" or "warn"
+	Severity string
+	// Relative path within the snap dir, or preverified.toml item name.
+	File string
+	// Human-readable description.
+	Message string
+}
+
+func (i SnapshotVerifyIssue) String() string {
+	return fmt.Sprintf("[%s] %s: %s", i.Severity, i.File, i.Message)
+}
+
+// VerifySnapshotDownloads checks the contents of the snapshot directory against .torrent files and
+// an optional preverified.toml. It uses the mixed file/mmap storage from anacrolix/torrent to
+// efficiently read piece data with sparse-file support via SEEK_DATA/SEEK_HOLE.
+//
+// Checks performed:
+//   - For each .torrent file: infohash matches preverified.toml (if present).
+//   - For each file listed in a .torrent: path is safe (no directory traversal), data file exists,
+//     file permissions are appropriate.
+//   - Piece hashes of present data files match the torrent metadata.
+//   - Preverified.toml entries that have no corresponding .torrent file on disk.
+func VerifySnapshotDownloads(ctx context.Context, dirs datadir.Dirs, logger log.Logger) (issues []SnapshotVerifyIssue, err error) {
+	snapDir := dirs.Snap
+
+	// Load preverified.toml if present.
+	var pvItems preverified.SortedItems
+	preverifiedPath := dirs.PreverifiedPath()
+	pvData, pvErr := os.ReadFile(preverifiedPath)
+	if pvErr == nil {
+		var rawMap map[string]string
+		if err = toml.Unmarshal(pvData, &rawMap); err != nil {
+			err = fmt.Errorf("parsing %s: %w", datadir.PreverifiedFileName, err)
+			return
+		}
+		pvItems = preverified.ItemsFromMap(rawMap)
+		logger.Info("loaded preverified.toml", "items", len(pvItems))
+	} else if !errors.Is(pvErr, fs.ErrNotExist) {
+		err = fmt.Errorf("reading %s: %w", datadir.PreverifiedFileName, pvErr)
+		return
+	}
+
+	// Walk the snap dir for .torrent files (they may be in subdirectories).
+	torrentNamesSeen := make(map[string]bool)
+	walkErr := fs.WalkDir(os.DirFS(snapDir), ".", func(relPath string, de fs.DirEntry, walkFileErr error) error {
+		if ctx.Err() != nil {
+			return context.Cause(ctx)
+		}
+		if walkFileErr != nil {
+			issues = append(issues, SnapshotVerifyIssue{
+				Severity: "warn",
+				File:     relPath,
+				Message:  fmt.Sprintf("walk error: %v", walkFileErr),
+			})
+			return nil
+		}
+		if de.IsDir() {
+			return nil
+		}
+		snapshotName, isTorrent := strings.CutSuffix(relPath, ".torrent")
+		if !isTorrent {
+			return nil
+		}
+		torrentNamesSeen[snapshotName] = true
+
+		torrentIssues := verifyTorrentFile(ctx, snapDir, snapshotName, pvItems)
+		issues = append(issues, torrentIssues...)
+		return nil
+	})
+	if walkErr != nil && !errors.Is(walkErr, context.Canceled) {
+		err = fmt.Errorf("walking snap dir %q: %w", snapDir, walkErr)
+		return
+	}
+
+	// Report preverified items that have no .torrent file on disk.
+	for _, item := range pvItems {
+		if torrentNamesSeen[item.Name] {
+			continue
+		}
+		issues = append(issues, SnapshotVerifyIssue{
+			Severity: "warn",
+			File:     item.Name + ".torrent",
+			Message:  "preverified.toml entry has no corresponding .torrent file on disk",
+		})
+	}
+
+	return issues, ctx.Err()
+}
+
+// verifyTorrentFile performs all checks for one .torrent file and its associated data files.
+// snapshotName is the path relative to snapDir, without the ".torrent" suffix (unix slash style).
+func verifyTorrentFile(
+	ctx context.Context,
+	snapDir string,
+	snapshotName string,
+	pvItems preverified.SortedItems,
+) (issues []SnapshotVerifyIssue) {
+	torrentFilePath := filepath.Join(snapDir, filepath.FromSlash(snapshotName+".torrent"))
+
+	mi, err := metainfo.LoadFromFile(torrentFilePath)
+	if err != nil {
+		return []SnapshotVerifyIssue{{
+			Severity: "error",
+			File:     snapshotName + ".torrent",
+			Message:  fmt.Sprintf("failed to load torrent file: %v", err),
+		}}
+	}
+
+	infoHash := mi.HashInfoBytes()
+	infoHashHex := infoHash.HexString()
+
+	// Check infohash against preverified.toml.
+	if pvItems != nil {
+		if pvItem, ok := pvItems.Get(snapshotName); ok {
+			if pvItem.Hash != infoHashHex {
+				issues = append(issues, SnapshotVerifyIssue{
+					Severity: "error",
+					File:     snapshotName + ".torrent",
+					Message:  fmt.Sprintf("infohash mismatch: preverified=%s actual=%s", pvItem.Hash, infoHashHex),
+				})
+			}
+		} else {
+			issues = append(issues, SnapshotVerifyIssue{
+				Severity: "warn",
+				File:     snapshotName + ".torrent",
+				Message:  "not present in preverified.toml",
+			})
+		}
+	}
+
+	info, err := mi.UnmarshalInfo()
+	if err != nil {
+		issues = append(issues, SnapshotVerifyIssue{
+			Severity: "error",
+			File:     snapshotName + ".torrent",
+			Message:  fmt.Sprintf("failed to unmarshal info dict: %v", err),
+		})
+		return
+	}
+
+	// Validate the info.Name safe path (protects against directory traversal in the torrent).
+	infoName := info.BestName()
+	if infoName != metainfo.NoName {
+		if _, pathErr := storage.ToSafeFilePath(infoName); pathErr != nil {
+			issues = append(issues, SnapshotVerifyIssue{
+				Severity: "error",
+				File:     snapshotName + ".torrent",
+				Message:  fmt.Sprintf("info.Name %q is unsafe: %v", infoName, pathErr),
+			})
+			return
+		}
+	}
+
+	// Check expected name: torrent file basename should match info.Name.
+	baseName := path.Base(snapshotName)
+	if infoName != metainfo.NoName && infoName != baseName {
+		issues = append(issues, SnapshotVerifyIssue{
+			Severity: "warn",
+			File:     snapshotName + ".torrent",
+			Message:  fmt.Sprintf("info.Name %q doesn't match torrent filename %q", infoName, baseName),
+		})
+	}
+
+	// Check each data file listed in the torrent.
+	allFilesPresent := true
+	for _, fi := range info.UpvertedFiles() {
+		fileIssues, present := checkDataFile(snapDir, snapshotName, &info, &fi, pvItems)
+		issues = append(issues, fileIssues...)
+		if !present {
+			allFilesPresent = false
+		}
+	}
+
+	// Verify piece hashes using sparse-aware storage (mmap + SEEK_DATA/SEEK_HOLE).
+	if allFilesPresent && ctx.Err() == nil {
+		pieceIssues := verifyPieceHashes(ctx, snapDir, &info, infoHash)
+		issues = append(issues, pieceIssues...)
+	}
+	return
+}
+
+// checkDataFile checks a single file within a torrent for existence, path safety, and permissions.
+// Returns whether the file is present.
+func checkDataFile(
+	snapDir string,
+	snapshotName string,
+	info *metainfo.Info,
+	fi *metainfo.FileInfo,
+	pvItems preverified.SortedItems,
+) (issues []SnapshotVerifyIssue, present bool) {
+	infoName := info.BestName()
+
+	// Compute the data file path using the same logic as the torrent storage client.
+	// Single-file: {snapDir}/{info.Name}
+	// Multi-file:  {snapDir}/{info.Name}/{file.BestPath()}
+	var relSlashPath string
+	if len(fi.BestPath()) == 0 {
+		// Single-file torrent: info.Name is the file.
+		if infoName == metainfo.NoName {
+			relSlashPath = snapshotName
+		} else {
+			relSlashPath = infoName
+		}
+	} else {
+		// Multi-file torrent: validate each path component.
+		safePath, pathErr := storage.ToSafeFilePath(fi.BestPath()...)
+		if pathErr != nil {
+			issues = append(issues, SnapshotVerifyIssue{
+				Severity: "error",
+				File:     snapshotName,
+				Message:  fmt.Sprintf("unsafe file path %v in torrent: %v", fi.BestPath(), pathErr),
+			})
+			return issues, false
+		}
+		relSlashPath = path.Join(infoName, safePath)
+	}
+
+	dataFilePath := filepath.Join(snapDir, filepath.FromSlash(relSlashPath))
+
+	stat, statErr := os.Stat(dataFilePath)
+	if errors.Is(statErr, fs.ErrNotExist) {
+		severity := "warn"
+		msg := "data file missing"
+		if pvItems != nil {
+			if _, inPV := pvItems.Get(snapshotName); inPV {
+				severity = "error"
+				msg = "data file missing (listed in preverified.toml)"
+			}
+		}
+		issues = append(issues, SnapshotVerifyIssue{
+			Severity: severity,
+			File:     relSlashPath,
+			Message:  msg,
+		})
+		return issues, false
+	}
+	if statErr != nil {
+		issues = append(issues, SnapshotVerifyIssue{
+			Severity: "error",
+			File:     relSlashPath,
+			Message:  fmt.Sprintf("stat failed: %v", statErr),
+		})
+		return issues, false
+	}
+
+	// Check file size matches torrent metadata.
+	if stat.Size() != fi.Length {
+		issues = append(issues, SnapshotVerifyIssue{
+			Severity: "error",
+			File:     relSlashPath,
+			Message:  fmt.Sprintf("size mismatch: on-disk=%d torrent=%d", stat.Size(), fi.Length),
+		})
+	}
+
+	// Check file permissions.
+	perm := stat.Mode().Perm()
+	// All files should be readable by owner.
+	if perm&0o400 == 0 {
+		issues = append(issues, SnapshotVerifyIssue{
+			Severity: "error",
+			File:     relSlashPath,
+			Message:  fmt.Sprintf("file not readable by owner (mode=%v)", perm),
+		})
+	}
+	// Completed snapshot files should not be writable (they're promoted to read-only on completion).
+	if perm&0o222 != 0 {
+		issues = append(issues, SnapshotVerifyIssue{
+			Severity: "warn",
+			File:     relSlashPath,
+			Message:  fmt.Sprintf("file is writable (mode=%v); completed snapshots are expected to be read-only", perm),
+		})
+	}
+	// World-writable is a stronger concern.
+	if perm&0o002 != 0 {
+		issues = append(issues, SnapshotVerifyIssue{
+			Severity: "error",
+			File:     relSlashPath,
+			Message:  fmt.Sprintf("file is world-writable (mode=%v)", perm),
+		})
+	}
+
+	return issues, true
+}
+
+// verifyPieceHashes hashes each torrent piece using the mmap/sparse-read storage layer and
+// compares to the piece hashes recorded in the torrent info dict.
+func verifyPieceHashes(
+	ctx context.Context,
+	snapDir string,
+	info *metainfo.Info,
+	infoHash metainfo.Hash,
+) (issues []SnapshotVerifyIssue) {
+	// NewFileOpts with UsePartFiles=false uses the mmap-based fileIo (defaultFileIo).
+	// The mmap layer implements seekDataOrEof via SEEK_DATA/SEEK_HOLE, enabling efficient
+	// sparse-file reads that skip holes instead of reading zeroes.
+	client := storage.NewFileOpts(storage.NewFileClientOpts{
+		ClientBaseDir:   snapDir,
+		UsePartFiles:    g.Some(false),
+		PieceCompletion: storage.NewMapPieceCompletion(),
+	})
+	defer client.Close()
+
+	t, err := client.OpenTorrent(ctx, info, infoHash)
+	if err != nil {
+		return []SnapshotVerifyIssue{{
+			Severity: "error",
+			File:     info.BestName(),
+			Message:  fmt.Sprintf("failed to open torrent storage for piece verification: %v", err),
+		}}
+	}
+	defer t.Close()
+
+	for i := range info.NumPieces() {
+		if ctx.Err() != nil {
+			break
+		}
+		p := info.Piece(i)
+		// Only v1 torrents carry piece hashes; v2 uses merkle trees (not handled here).
+		expectedHash := p.V1Hash()
+		if !expectedHash.Ok {
+			continue
+		}
+
+		//nolint:gosec
+		h := sha1.New()
+		piece := t.Piece(p)
+
+		// filePieceImpl implements io.WriterTo which uses seekDataOrEof for sparse reads.
+		var written int64
+		var readErr error
+		if wt, ok := piece.(io.WriterTo); ok {
+			written, readErr = wt.WriteTo(h)
+		} else {
+			written, readErr = io.Copy(h, io.NewSectionReader(piece, 0, p.Length()))
+		}
+
+		if readErr != nil {
+			issues = append(issues, SnapshotVerifyIssue{
+				Severity: "error",
+				File:     info.BestName(),
+				Message:  fmt.Sprintf("piece %d: read error: %v", i, readErr),
+			})
+			continue
+		}
+		if written < p.Length() {
+			issues = append(issues, SnapshotVerifyIssue{
+				Severity: "error",
+				File:     info.BestName(),
+				Message:  fmt.Sprintf("piece %d: short read: got %d bytes, expected %d (file may be incomplete or sparse)", i, written, p.Length()),
+			})
+			continue
+		}
+
+		var actualHash metainfo.Hash
+		h.Sum(actualHash[:0])
+		if actualHash != expectedHash.Value {
+			issues = append(issues, SnapshotVerifyIssue{
+				Severity: "error",
+				File:     info.BestName(),
+				Message:  fmt.Sprintf("piece %d: hash mismatch: expected %x got %x", i, expectedHash.Value, actualHash),
+			})
+		}
+	}
+	return
+}

--- a/db/downloader/verify-snapshot-downloads.go
+++ b/db/downloader/verify-snapshot-downloads.go
@@ -41,41 +41,77 @@ import (
 	"github.com/erigontech/erigon/db/preverified"
 )
 
-// SnapshotVerifyIssue is one finding emitted as a JSON line to stdout during verification.
+// Preverified status strings used in progress output.
+const (
+	pvMatches  = "matches"
+	pvMismatch = "doesn't match"
+	pvNotIn    = "not in preverified"
+	pvNoFile   = "no preverified.toml"
+)
+
+// SnapshotVerifyIssue is a single finding, emitted as {"type":"issue",...} to stdout.
 type SnapshotVerifyIssue struct {
-	// "error" or "warn"
+	Type     string `json:"type"` // always "issue"
 	Severity string `json:"severity"`
-	// .torrent path relative to the snap dir.
-	Torrent string `json:"torrent,omitempty"`
-	// Data file path relative to the snap dir.
-	File string `json:"file,omitempty"`
-	// Human-readable description.
-	Message string `json:"message"`
+	Snapshot string `json:"snapshot,omitempty"`
+	Torrent  string `json:"torrent,omitempty"`
+	File     string `json:"file,omitempty"`
+	Message  string `json:"message"`
 }
 
-// SnapshotVerifySummary is printed as a single JSON line to stdout after all checks complete.
+// SnapshotVerifyProgress is emitted as {"type":"progress",...} after each snapshot completes.
+type SnapshotVerifyProgress struct {
+	Type        string  `json:"type"` // always "progress"
+	Snapshot    string  `json:"snapshot"`
+	Percent     float64 `json:"percent"`
+	Preverified string  `json:"preverified"`
+}
+
+// SnapshotVerifySummary is emitted as {"type":"summary",...} after all snapshots complete.
 type SnapshotVerifySummary struct {
-	Torrents int `json:"torrents"`
-	Errors   int `json:"errors"`
-	Warnings int `json:"warnings"`
+	Type     string `json:"type"` // always "summary"
+	Total    int    `json:"total"`
+	Errors   int    `json:"errors"`
+	Warnings int    `json:"warnings"`
 }
 
-// issueEmitter is safe for concurrent use.
-type issueEmitter struct {
+// snapshotState collects all on-disk information about one snapshot name.
+type snapshotState struct {
+	// Unix-slash path relative to snapDir, e.g. "v1.0-mainnet-headers-0-1000.seg"
+	// or "history/v1.0-mainnet-accounts.kv".
+	name string
+
+	// preverified.toml entry for this name, if present.
+	pvItem    preverified.Item
+	hasPV     bool
+	pvPresent bool // preverified.toml file itself was found
+
+	hasTorrent bool
+	hasPart    bool
+	hasData    bool
+}
+
+// encoder wraps a json.Encoder with a mutex for concurrent use.
+type encoder struct {
 	enc      *json.Encoder
 	mu       sync.Mutex
 	errors   atomic.Int64
 	warnings atomic.Int64
 }
 
-func newIssueEmitter(out io.Writer) *issueEmitter {
-	return &issueEmitter{enc: json.NewEncoder(out)}
+func newEncoder(out io.Writer) *encoder {
+	return &encoder{enc: json.NewEncoder(out)}
 }
 
-func (e *issueEmitter) emit(issue SnapshotVerifyIssue) {
+func (e *encoder) emit(v any) {
 	e.mu.Lock()
-	_ = e.enc.Encode(issue) //nolint:errcheck
+	_ = e.enc.Encode(v) //nolint:errcheck
 	e.mu.Unlock()
+}
+
+func (e *encoder) issue(issue SnapshotVerifyIssue) {
+	issue.Type = "issue"
+	e.emit(issue)
 	switch issue.Severity {
 	case "error":
 		e.errors.Add(1)
@@ -84,36 +120,29 @@ func (e *issueEmitter) emit(issue SnapshotVerifyIssue) {
 	}
 }
 
-func (e *issueEmitter) summary(torrents int) SnapshotVerifySummary {
-	return SnapshotVerifySummary{
-		Torrents: torrents,
-		Errors:   int(e.errors.Load()),
-		Warnings: int(e.warnings.Load()),
-	}
-}
-
 // VerifySnapshotDownloads checks snapshot downloads against .torrent files and preverified.toml.
-// Findings are written as JSON lines to out as they are discovered. A summary JSON object is
-// written last. Torrent files are verified in a pool of workers for concurrency.
 //
-// Checks performed:
-//   - Infohash of each .torrent matches preverified.toml (if present).
-//   - File paths within torrents are safe (no directory traversal).
-//   - Data files exist, have the right size, and appropriate permissions.
-//   - Piece hashes via mmap/sparse-read storage (SEEK_DATA/SEEK_HOLE).
-//   - Preverified.toml entries with no corresponding .torrent on disk.
+// The set of snapshots checked is the union of:
+//   - All names in preverified.toml
+//   - All files in the snap dir with ".torrent" stripped
+//   - All files in the snap dir with ".part" stripped
+//
+// For each snapshot, findings are written immediately as JSON lines to out. After each snapshot
+// completes, a progress line with name, % complete, and preverified status is written. A summary
+// line is written last.
 func VerifySnapshotDownloads(ctx context.Context, dirs datadir.Dirs, workers int, out io.Writer) (summary SnapshotVerifySummary, err error) {
 	if workers <= 0 {
 		workers = max(1, runtime.GOMAXPROCS(0)/2)
 	}
 	snapDir := dirs.Snap
-	emitter := newIssueEmitter(out)
+	enc := newEncoder(out)
 
 	// Load preverified.toml if present.
 	var pvItems preverified.SortedItems
-	preverifiedPath := dirs.PreverifiedPath()
-	pvData, pvErr := os.ReadFile(preverifiedPath)
+	pvPresent := false
+	pvData, pvErr := os.ReadFile(dirs.PreverifiedPath())
 	if pvErr == nil {
+		pvPresent = true
 		var rawMap map[string]string
 		if err = toml.Unmarshal(pvData, &rawMap); err != nil {
 			err = fmt.Errorf("parsing %s: %w", datadir.PreverifiedFileName, err)
@@ -125,11 +154,33 @@ func VerifySnapshotDownloads(ctx context.Context, dirs datadir.Dirs, workers int
 		return
 	}
 
-	// Collect all .torrent names first (walk is fast; this lets us track seen names cleanly).
-	var torrentNames []string
+	// Build the complete set of snapshot names.
+	nameSet := make(map[string]*snapshotState)
+
+	ensure := func(name string) *snapshotState {
+		if s, ok := nameSet[name]; ok {
+			return s
+		}
+		s := &snapshotState{name: name, pvPresent: pvPresent}
+		if pvItems != nil {
+			if item, ok := pvItems.Get(name); ok {
+				s.hasPV = true
+				s.pvItem = item
+			}
+		}
+		nameSet[name] = s
+		return s
+	}
+
+	// Seed from preverified.toml.
+	for _, item := range pvItems {
+		ensure(item.Name)
+	}
+
+	// Seed from files on disk.
 	walkErr := fs.WalkDir(os.DirFS(snapDir), ".", func(relPath string, de fs.DirEntry, walkFileErr error) error {
 		if walkFileErr != nil {
-			emitter.emit(SnapshotVerifyIssue{
+			enc.issue(SnapshotVerifyIssue{
 				Severity: "warn",
 				File:     relPath,
 				Message:  fmt.Sprintf("walk error: %v", walkFileErr),
@@ -139,11 +190,18 @@ func VerifySnapshotDownloads(ctx context.Context, dirs datadir.Dirs, workers int
 		if de.IsDir() {
 			return nil
 		}
-		snapshotName, isTorrent := strings.CutSuffix(relPath, ".torrent")
-		if !isTorrent {
+		if name, ok := strings.CutSuffix(relPath, ".torrent"); ok {
+			ensure(name).hasTorrent = true
 			return nil
 		}
-		torrentNames = append(torrentNames, snapshotName)
+		if name, ok := strings.CutSuffix(relPath, ".part"); ok {
+			ensure(name).hasPart = true
+			return nil
+		}
+		// Check if this is a raw data file for a known snapshot name.
+		if _, exists := nameSet[relPath]; exists {
+			nameSet[relPath].hasData = true
+		}
 		return nil
 	})
 	if walkErr != nil {
@@ -151,37 +209,49 @@ func VerifySnapshotDownloads(ctx context.Context, dirs datadir.Dirs, workers int
 		return
 	}
 
-	// Report preverified entries with no .torrent file on disk.
-	torrentNameSet := make(map[string]bool, len(torrentNames))
-	for _, name := range torrentNames {
-		torrentNameSet[name] = true
-	}
-	for _, item := range pvItems {
-		if !torrentNameSet[item.Name] {
-			emitter.emit(SnapshotVerifyIssue{
-				Severity: "warn",
-				Torrent:  item.Name + ".torrent",
-				Message:  "preverified.toml entry has no corresponding .torrent file on disk",
-			})
+	// Second pass: mark data file presence for all known names.
+	for name, state := range nameSet {
+		if !state.hasData {
+			if _, statErr := os.Stat(filepath.Join(snapDir, filepath.FromSlash(name))); statErr == nil {
+				state.hasData = true
+			}
 		}
 	}
 
-	// Verify each .torrent file in a worker pool.
+	// Collect into a slice for indexed progress tracking.
+	states := make([]*snapshotState, 0, len(nameSet))
+	for _, s := range nameSet {
+		states = append(states, s)
+	}
+	total := len(states)
+
+	var done atomic.Int64
+
 	eg, egCtx := errgroup.WithContext(ctx)
 	eg.SetLimit(workers)
-	for _, snapshotName := range torrentNames {
+
+	for _, state := range states {
 		eg.Go(func() error {
-			verifyOneTorrent(egCtx, snapDir, snapshotName, pvItems, emitter)
+			pvStatus := verifyOneSnapshot(egCtx, snapDir, state, enc)
+			n := done.Add(1)
+			enc.emit(SnapshotVerifyProgress{
+				Type:        "progress",
+				Snapshot:    state.name,
+				Percent:     float64(n) / float64(total) * 100,
+				Preverified: pvStatus,
+			})
 			return nil
 		})
 	}
 	_ = eg.Wait()
 
-	summary = emitter.summary(len(torrentNames))
-	e := emitter.enc
-	emitter.mu.Lock()
-	_ = e.Encode(summary) //nolint:errcheck
-	emitter.mu.Unlock()
+	summary = SnapshotVerifySummary{
+		Type:     "summary",
+		Total:    total,
+		Errors:   int(enc.errors.Load()),
+		Warnings: int(enc.warnings.Load()),
+	}
+	enc.emit(summary)
 
 	if ctx.Err() != nil {
 		err = ctx.Err()
@@ -189,24 +259,51 @@ func VerifySnapshotDownloads(ctx context.Context, dirs datadir.Dirs, workers int
 	return
 }
 
-// verifyOneTorrent performs all checks for one .torrent file and its data files.
-// snapshotName is the unix-slash path relative to snapDir, without the ".torrent" suffix.
-func verifyOneTorrent(
+// verifyOneSnapshot checks one snapshot's .torrent, data file, .part file, and piece hashes.
+// Returns the preverified status string for the progress line.
+func verifyOneSnapshot(
 	ctx context.Context,
 	snapDir string,
-	snapshotName string,
-	pvItems preverified.SortedItems,
-	emitter *issueEmitter,
-) {
-	torrentRel := snapshotName + ".torrent"
-	torrentFilePath := filepath.Join(snapDir, filepath.FromSlash(torrentRel))
+	state *snapshotState,
+	enc *encoder,
+) (pvStatus string) {
+	name := state.name
+	torrentRel := name + ".torrent"
 
+	// Determine preverified status from what we already know.
+	// This may be refined once we have the actual infohash from the .torrent file.
+	switch {
+	case !state.pvPresent:
+		pvStatus = pvNoFile
+	case state.hasPV:
+		pvStatus = pvMatches // optimistic; corrected below if hash differs
+	default:
+		pvStatus = pvNotIn
+	}
+
+	if !state.hasTorrent {
+		if state.hasPV || state.hasPart {
+			// Missing .torrent despite being expected.
+			enc.issue(SnapshotVerifyIssue{
+				Severity: "error",
+				Snapshot: name,
+				Torrent:  torrentRel,
+				Message:  "missing .torrent file",
+			})
+		}
+		// Without a .torrent we can't do piece verification; check data/part presence only.
+		checkPartAndData(name, torrentRel, state, -1, enc)
+		return
+	}
+
+	torrentFilePath := filepath.Join(snapDir, filepath.FromSlash(torrentRel))
 	mi, err := metainfo.LoadFromFile(torrentFilePath)
 	if err != nil {
-		emitter.emit(SnapshotVerifyIssue{
+		enc.issue(SnapshotVerifyIssue{
 			Severity: "error",
+			Snapshot: name,
 			Torrent:  torrentRel,
-			Message:  fmt.Sprintf("failed to load torrent file: %v", err),
+			Message:  fmt.Sprintf("failed to load .torrent file: %v", err),
 		})
 		return
 	}
@@ -214,173 +311,125 @@ func verifyOneTorrent(
 	infoHash := mi.HashInfoBytes()
 	infoHashHex := infoHash.HexString()
 
-	// Check infohash against preverified.toml.
-	if pvItems != nil {
-		if pvItem, ok := pvItems.Get(snapshotName); ok {
-			if pvItem.Hash != infoHashHex {
-				emitter.emit(SnapshotVerifyIssue{
-					Severity: "error",
-					Torrent:  torrentRel,
-					Message:  fmt.Sprintf("infohash mismatch: preverified=%s actual=%s", pvItem.Hash, infoHashHex),
-				})
-			}
+	// Refine preverified status based on actual infohash.
+	if state.hasPV {
+		if state.pvItem.Hash == infoHashHex {
+			pvStatus = pvMatches
 		} else {
-			emitter.emit(SnapshotVerifyIssue{
-				Severity: "warn",
+			pvStatus = pvMismatch
+			enc.issue(SnapshotVerifyIssue{
+				Severity: "error",
+				Snapshot: name,
 				Torrent:  torrentRel,
-				Message:  "not present in preverified.toml",
+				Message:  fmt.Sprintf("infohash mismatch: preverified=%s torrent=%s", state.pvItem.Hash, infoHashHex),
 			})
 		}
 	}
 
 	info, err := mi.UnmarshalInfo()
 	if err != nil {
-		emitter.emit(SnapshotVerifyIssue{
+		enc.issue(SnapshotVerifyIssue{
 			Severity: "error",
+			Snapshot: name,
 			Torrent:  torrentRel,
-			Message:  fmt.Sprintf("failed to unmarshal info dict: %v", err),
+			Message:  fmt.Sprintf("failed to unmarshal torrent info: %v", err),
 		})
 		return
 	}
 
-	// Validate info.Name is a safe path.
+	// Validate info.Name is safe.
 	infoName := info.BestName()
 	if infoName != metainfo.NoName {
 		if _, pathErr := storage.ToSafeFilePath(infoName); pathErr != nil {
-			emitter.emit(SnapshotVerifyIssue{
+			enc.issue(SnapshotVerifyIssue{
 				Severity: "error",
+				Snapshot: name,
 				Torrent:  torrentRel,
 				Message:  fmt.Sprintf("info.Name %q is unsafe: %v", infoName, pathErr),
 			})
 			return
 		}
-	}
-
-	// info.Name should match the torrent filename.
-	baseName := path.Base(snapshotName)
-	if infoName != metainfo.NoName && infoName != baseName {
-		emitter.emit(SnapshotVerifyIssue{
-			Severity: "warn",
-			Torrent:  torrentRel,
-			Message:  fmt.Sprintf("info.Name %q doesn't match torrent filename %q", infoName, baseName),
-		})
-	}
-
-	// Check each data file.
-	allPresent := true
-	for _, fi := range info.UpvertedFiles() {
-		if !checkDataFile(snapDir, snapshotName, torrentRel, &info, &fi, pvItems, emitter) {
-			allPresent = false
+		baseName := path.Base(name)
+		if infoName != baseName {
+			enc.issue(SnapshotVerifyIssue{
+				Severity: "warn",
+				Snapshot: name,
+				Torrent:  torrentRel,
+				Message:  fmt.Sprintf("info.Name %q doesn't match torrent filename %q", infoName, baseName),
+			})
 		}
 	}
 
-	if allPresent && ctx.Err() == nil {
-		verifyPieceHashes(ctx, snapDir, snapshotName, torrentRel, &info, infoHash, emitter)
+	// Determine expected data file size from torrent.
+	var expectedSize int64
+	for _, fi := range info.UpvertedFiles() {
+		expectedSize += fi.Length
 	}
+
+	checkPartAndData(name, torrentRel, state, expectedSize, enc)
+
+	// Only run piece hashing if data file is fully present and the right size.
+	if state.hasData && !state.hasPart && ctx.Err() == nil {
+		dataFilePath := filepath.Join(snapDir, filepath.FromSlash(name))
+		if fi, statErr := os.Stat(dataFilePath); statErr == nil && fi.Size() == expectedSize {
+			verifyPieceHashes(ctx, snapDir, name, torrentRel, &info, infoHash, enc)
+		}
+	}
+
+	return
 }
 
-// checkDataFile checks one data file from a torrent for existence, size, and permissions.
-// Returns true if the file is present and the right size.
-func checkDataFile(
-	snapDir string,
-	snapshotName string,
+// checkPartAndData reports issues about the presence/absence of the data and .part files.
+// expectedSize is -1 when unknown (no .torrent).
+func checkPartAndData(
+	name string,
 	torrentRel string,
-	info *metainfo.Info,
-	fi *metainfo.FileInfo,
-	pvItems preverified.SortedItems,
-	emitter *issueEmitter,
-) (present bool) {
-	infoName := info.BestName()
+	state *snapshotState,
+	expectedSize int64,
+	enc *encoder,
+) {
+	snapName := name // for clarity in messages
 
-	var relSlashPath string
-	if len(fi.BestPath()) == 0 {
-		// Single-file torrent.
-		if infoName == metainfo.NoName {
-			relSlashPath = snapshotName
-		} else {
-			relSlashPath = infoName
-		}
-	} else {
-		safePath, pathErr := storage.ToSafeFilePath(fi.BestPath()...)
-		if pathErr != nil {
-			emitter.emit(SnapshotVerifyIssue{
-				Severity: "error",
-				Torrent:  torrentRel,
-				Message:  fmt.Sprintf("unsafe file path %v in torrent: %v", fi.BestPath(), pathErr),
-			})
-			return false
-		}
-		relSlashPath = path.Join(infoName, safePath)
-	}
-
-	dataFilePath := filepath.Join(snapDir, filepath.FromSlash(relSlashPath))
-	stat, statErr := os.Stat(dataFilePath)
-
-	if errors.Is(statErr, fs.ErrNotExist) {
-		severity := "warn"
-		msg := "data file missing"
-		if pvItems != nil {
-			if _, inPV := pvItems.Get(snapshotName); inPV {
-				severity = "error"
-				msg = "data file missing (listed in preverified.toml)"
-			}
-		}
-		emitter.emit(SnapshotVerifyIssue{
-			Severity: severity,
-			Torrent:  torrentRel,
-			File:     relSlashPath,
-			Message:  msg,
-		})
-		return false
-	}
-	if statErr != nil {
-		emitter.emit(SnapshotVerifyIssue{
+	if state.hasData && state.hasPart {
+		enc.issue(SnapshotVerifyIssue{
 			Severity: "error",
+			Snapshot: snapName,
 			Torrent:  torrentRel,
-			File:     relSlashPath,
-			Message:  fmt.Sprintf("stat failed: %v", statErr),
+			Message:  "both data file and .part file exist simultaneously",
 		})
-		return false
+		return
 	}
 
-	if stat.Size() != fi.Length {
-		emitter.emit(SnapshotVerifyIssue{
-			Severity: "error",
-			Torrent:  torrentRel,
-			File:     relSlashPath,
-			Message:  fmt.Sprintf("size mismatch: on-disk=%d torrent=%d", stat.Size(), fi.Length),
-		})
-		// Size mismatch means piece verification won't be meaningful, treat as absent.
-		return false
-	}
-
-	perm := stat.Mode().Perm()
-	if perm&0o400 == 0 {
-		emitter.emit(SnapshotVerifyIssue{
-			Severity: "error",
-			Torrent:  torrentRel,
-			File:     relSlashPath,
-			Message:  fmt.Sprintf("not readable by owner (mode=%v)", perm),
-		})
-	}
-	if perm&0o222 != 0 {
-		emitter.emit(SnapshotVerifyIssue{
+	if state.hasPart {
+		enc.issue(SnapshotVerifyIssue{
 			Severity: "warn",
+			Snapshot: snapName,
 			Torrent:  torrentRel,
-			File:     relSlashPath,
-			Message:  fmt.Sprintf("writable (mode=%v); completed snapshots are expected read-only", perm),
+			Message:  "only .part file present; download is incomplete",
 		})
-	}
-	if perm&0o002 != 0 {
-		emitter.emit(SnapshotVerifyIssue{
-			Severity: "error",
-			Torrent:  torrentRel,
-			File:     relSlashPath,
-			Message:  fmt.Sprintf("world-writable (mode=%v)", perm),
-		})
+		return
 	}
 
-	return true
+	if !state.hasData {
+		severity := "warn"
+		if state.hasPV {
+			severity = "error"
+		}
+		enc.issue(SnapshotVerifyIssue{
+			Severity: severity,
+			Snapshot: snapName,
+			Torrent:  torrentRel,
+			Message:  "data file absent (no .part either)",
+		})
+		return
+	}
+
+	// Data file is present. Check its size if we know what to expect.
+	if expectedSize >= 0 {
+		dataPath := filepath.Join("", name) // just for display; actual stat done by caller
+		_ = dataPath
+		// Size check is done per-FileInfo in verifyOneSnapshot's callers; skip here.
+	}
 }
 
 // verifyPieceHashes hashes each piece via the mmap/sparse-read storage (SEEK_DATA/SEEK_HOLE)
@@ -392,15 +441,16 @@ func verifyPieceHashes(
 	torrentRel string,
 	info *metainfo.Info,
 	infoHash metainfo.Hash,
-	emitter *issueEmitter,
+	enc *encoder,
 ) {
 	client := newSnapStorage(snapDir, nil)
 	defer client.Close()
 
 	t, err := client.OpenTorrent(ctx, info, infoHash)
 	if err != nil {
-		emitter.emit(SnapshotVerifyIssue{
+		enc.issue(SnapshotVerifyIssue{
 			Severity: "error",
+			Snapshot: snapshotName,
 			Torrent:  torrentRel,
 			Message:  fmt.Sprintf("failed to open torrent storage for piece verification: %v", err),
 		})
@@ -415,7 +465,6 @@ func verifyPieceHashes(
 		p := info.Piece(i)
 		expectedHash := p.V1Hash()
 		if !expectedHash.Ok {
-			// v2 torrents use merkle trees; no v1 piece hash to check.
 			continue
 		}
 
@@ -423,7 +472,6 @@ func verifyPieceHashes(
 		h := sha1.New()
 		piece := t.Piece(p)
 
-		// filePieceImpl implements io.WriterTo, which uses seekDataOrEof for sparse reads.
 		var written int64
 		var readErr error
 		if wt, ok := piece.(io.WriterTo); ok {
@@ -433,19 +481,19 @@ func verifyPieceHashes(
 		}
 
 		if readErr != nil {
-			emitter.emit(SnapshotVerifyIssue{
+			enc.issue(SnapshotVerifyIssue{
 				Severity: "error",
+				Snapshot: snapshotName,
 				Torrent:  torrentRel,
-				File:     snapshotName,
 				Message:  fmt.Sprintf("piece %d: read error: %v", i, readErr),
 			})
 			continue
 		}
 		if written < p.Length() {
-			emitter.emit(SnapshotVerifyIssue{
+			enc.issue(SnapshotVerifyIssue{
 				Severity: "error",
+				Snapshot: snapshotName,
 				Torrent:  torrentRel,
-				File:     snapshotName,
 				Message:  fmt.Sprintf("piece %d: short read: got %d of %d bytes (sparse or incomplete)", i, written, p.Length()),
 			})
 			continue
@@ -454,10 +502,10 @@ func verifyPieceHashes(
 		var actualHash metainfo.Hash
 		h.Sum(actualHash[:0])
 		if actualHash != expectedHash.Value {
-			emitter.emit(SnapshotVerifyIssue{
+			enc.issue(SnapshotVerifyIssue{
 				Severity: "error",
+				Snapshot: snapshotName,
 				Torrent:  torrentRel,
-				File:     snapshotName,
 				Message:  fmt.Sprintf("piece %d: hash mismatch: expected %x got %x", i, expectedHash.Value, actualHash),
 			})
 		}

--- a/db/downloader/verify-snapshot-downloads.go
+++ b/db/downloader/verify-snapshot-downloads.go
@@ -19,6 +19,7 @@ package downloader
 import (
 	"context"
 	"crypto/sha1" //nolint:gosec
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -26,43 +27,87 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	"github.com/anacrolix/torrent/metainfo"
 	"github.com/anacrolix/torrent/storage"
 	"github.com/pelletier/go-toml/v2"
+	"golang.org/x/sync/errgroup"
 
-	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/preverified"
 )
 
-// SnapshotVerifyIssue represents a problem found during snapshot download verification.
+// SnapshotVerifyIssue is one finding emitted as a JSON line to stdout during verification.
 type SnapshotVerifyIssue struct {
 	// "error" or "warn"
-	Severity string
-	// Relative path within the snap dir, or preverified.toml item name.
-	File string
+	Severity string `json:"severity"`
+	// .torrent path relative to the snap dir.
+	Torrent string `json:"torrent,omitempty"`
+	// Data file path relative to the snap dir.
+	File string `json:"file,omitempty"`
 	// Human-readable description.
-	Message string
+	Message string `json:"message"`
 }
 
-func (i SnapshotVerifyIssue) String() string {
-	return fmt.Sprintf("[%s] %s: %s", i.Severity, i.File, i.Message)
+// SnapshotVerifySummary is printed as a single JSON line to stdout after all checks complete.
+type SnapshotVerifySummary struct {
+	Torrents int `json:"torrents"`
+	Errors   int `json:"errors"`
+	Warnings int `json:"warnings"`
 }
 
-// VerifySnapshotDownloads checks the contents of the snapshot directory against .torrent files and
-// an optional preverified.toml. It uses the mixed file/mmap storage from anacrolix/torrent to
-// efficiently read piece data with sparse-file support via SEEK_DATA/SEEK_HOLE.
+// issueEmitter is safe for concurrent use.
+type issueEmitter struct {
+	enc      *json.Encoder
+	mu       sync.Mutex
+	errors   atomic.Int64
+	warnings atomic.Int64
+}
+
+func newIssueEmitter(out io.Writer) *issueEmitter {
+	return &issueEmitter{enc: json.NewEncoder(out)}
+}
+
+func (e *issueEmitter) emit(issue SnapshotVerifyIssue) {
+	e.mu.Lock()
+	_ = e.enc.Encode(issue) //nolint:errcheck
+	e.mu.Unlock()
+	switch issue.Severity {
+	case "error":
+		e.errors.Add(1)
+	case "warn":
+		e.warnings.Add(1)
+	}
+}
+
+func (e *issueEmitter) summary(torrents int) SnapshotVerifySummary {
+	return SnapshotVerifySummary{
+		Torrents: torrents,
+		Errors:   int(e.errors.Load()),
+		Warnings: int(e.warnings.Load()),
+	}
+}
+
+// VerifySnapshotDownloads checks snapshot downloads against .torrent files and preverified.toml.
+// Findings are written as JSON lines to out as they are discovered. A summary JSON object is
+// written last. Torrent files are verified in a pool of workers for concurrency.
 //
 // Checks performed:
-//   - For each .torrent file: infohash matches preverified.toml (if present).
-//   - For each file listed in a .torrent: path is safe (no directory traversal), data file exists,
-//     file permissions are appropriate.
-//   - Piece hashes of present data files match the torrent metadata.
-//   - Preverified.toml entries that have no corresponding .torrent file on disk.
-func VerifySnapshotDownloads(ctx context.Context, dirs datadir.Dirs, logger log.Logger) (issues []SnapshotVerifyIssue, err error) {
+//   - Infohash of each .torrent matches preverified.toml (if present).
+//   - File paths within torrents are safe (no directory traversal).
+//   - Data files exist, have the right size, and appropriate permissions.
+//   - Piece hashes via mmap/sparse-read storage (SEEK_DATA/SEEK_HOLE).
+//   - Preverified.toml entries with no corresponding .torrent on disk.
+func VerifySnapshotDownloads(ctx context.Context, dirs datadir.Dirs, workers int, out io.Writer) (summary SnapshotVerifySummary, err error) {
+	if workers <= 0 {
+		workers = max(1, runtime.GOMAXPROCS(0)/2)
+	}
 	snapDir := dirs.Snap
+	emitter := newIssueEmitter(out)
 
 	// Load preverified.toml if present.
 	var pvItems preverified.SortedItems
@@ -75,20 +120,16 @@ func VerifySnapshotDownloads(ctx context.Context, dirs datadir.Dirs, logger log.
 			return
 		}
 		pvItems = preverified.ItemsFromMap(rawMap)
-		logger.Info("loaded preverified.toml", "items", len(pvItems))
 	} else if !errors.Is(pvErr, fs.ErrNotExist) {
 		err = fmt.Errorf("reading %s: %w", datadir.PreverifiedFileName, pvErr)
 		return
 	}
 
-	// Walk the snap dir for .torrent files (they may be in subdirectories).
-	torrentNamesSeen := make(map[string]bool)
+	// Collect all .torrent names first (walk is fast; this lets us track seen names cleanly).
+	var torrentNames []string
 	walkErr := fs.WalkDir(os.DirFS(snapDir), ".", func(relPath string, de fs.DirEntry, walkFileErr error) error {
-		if ctx.Err() != nil {
-			return context.Cause(ctx)
-		}
 		if walkFileErr != nil {
-			issues = append(issues, SnapshotVerifyIssue{
+			emitter.emit(SnapshotVerifyIssue{
 				Severity: "warn",
 				File:     relPath,
 				Message:  fmt.Sprintf("walk error: %v", walkFileErr),
@@ -102,49 +143,72 @@ func VerifySnapshotDownloads(ctx context.Context, dirs datadir.Dirs, logger log.
 		if !isTorrent {
 			return nil
 		}
-		torrentNamesSeen[snapshotName] = true
-
-		torrentIssues := verifyTorrentFile(ctx, snapDir, snapshotName, pvItems)
-		issues = append(issues, torrentIssues...)
+		torrentNames = append(torrentNames, snapshotName)
 		return nil
 	})
-	if walkErr != nil && !errors.Is(walkErr, context.Canceled) {
+	if walkErr != nil {
 		err = fmt.Errorf("walking snap dir %q: %w", snapDir, walkErr)
 		return
 	}
 
-	// Report preverified items that have no .torrent file on disk.
+	// Report preverified entries with no .torrent file on disk.
+	torrentNameSet := make(map[string]bool, len(torrentNames))
+	for _, name := range torrentNames {
+		torrentNameSet[name] = true
+	}
 	for _, item := range pvItems {
-		if torrentNamesSeen[item.Name] {
-			continue
+		if !torrentNameSet[item.Name] {
+			emitter.emit(SnapshotVerifyIssue{
+				Severity: "warn",
+				Torrent:  item.Name + ".torrent",
+				Message:  "preverified.toml entry has no corresponding .torrent file on disk",
+			})
 		}
-		issues = append(issues, SnapshotVerifyIssue{
-			Severity: "warn",
-			File:     item.Name + ".torrent",
-			Message:  "preverified.toml entry has no corresponding .torrent file on disk",
-		})
 	}
 
-	return issues, ctx.Err()
+	// Verify each .torrent file in a worker pool.
+	eg, egCtx := errgroup.WithContext(ctx)
+	eg.SetLimit(workers)
+	for _, snapshotName := range torrentNames {
+		eg.Go(func() error {
+			verifyOneTorrent(egCtx, snapDir, snapshotName, pvItems, emitter)
+			return nil
+		})
+	}
+	_ = eg.Wait()
+
+	summary = emitter.summary(len(torrentNames))
+	e := emitter.enc
+	emitter.mu.Lock()
+	_ = e.Encode(summary) //nolint:errcheck
+	emitter.mu.Unlock()
+
+	if ctx.Err() != nil {
+		err = ctx.Err()
+	}
+	return
 }
 
-// verifyTorrentFile performs all checks for one .torrent file and its associated data files.
-// snapshotName is the path relative to snapDir, without the ".torrent" suffix (unix slash style).
-func verifyTorrentFile(
+// verifyOneTorrent performs all checks for one .torrent file and its data files.
+// snapshotName is the unix-slash path relative to snapDir, without the ".torrent" suffix.
+func verifyOneTorrent(
 	ctx context.Context,
 	snapDir string,
 	snapshotName string,
 	pvItems preverified.SortedItems,
-) (issues []SnapshotVerifyIssue) {
-	torrentFilePath := filepath.Join(snapDir, filepath.FromSlash(snapshotName+".torrent"))
+	emitter *issueEmitter,
+) {
+	torrentRel := snapshotName + ".torrent"
+	torrentFilePath := filepath.Join(snapDir, filepath.FromSlash(torrentRel))
 
 	mi, err := metainfo.LoadFromFile(torrentFilePath)
 	if err != nil {
-		return []SnapshotVerifyIssue{{
+		emitter.emit(SnapshotVerifyIssue{
 			Severity: "error",
-			File:     snapshotName + ".torrent",
+			Torrent:  torrentRel,
 			Message:  fmt.Sprintf("failed to load torrent file: %v", err),
-		}}
+		})
+		return
 	}
 
 	infoHash := mi.HashInfoBytes()
@@ -154,16 +218,16 @@ func verifyTorrentFile(
 	if pvItems != nil {
 		if pvItem, ok := pvItems.Get(snapshotName); ok {
 			if pvItem.Hash != infoHashHex {
-				issues = append(issues, SnapshotVerifyIssue{
+				emitter.emit(SnapshotVerifyIssue{
 					Severity: "error",
-					File:     snapshotName + ".torrent",
+					Torrent:  torrentRel,
 					Message:  fmt.Sprintf("infohash mismatch: preverified=%s actual=%s", pvItem.Hash, infoHashHex),
 				})
 			}
 		} else {
-			issues = append(issues, SnapshotVerifyIssue{
+			emitter.emit(SnapshotVerifyIssue{
 				Severity: "warn",
-				File:     snapshotName + ".torrent",
+				Torrent:  torrentRel,
 				Message:  "not present in preverified.toml",
 			})
 		}
@@ -171,94 +235,87 @@ func verifyTorrentFile(
 
 	info, err := mi.UnmarshalInfo()
 	if err != nil {
-		issues = append(issues, SnapshotVerifyIssue{
+		emitter.emit(SnapshotVerifyIssue{
 			Severity: "error",
-			File:     snapshotName + ".torrent",
+			Torrent:  torrentRel,
 			Message:  fmt.Sprintf("failed to unmarshal info dict: %v", err),
 		})
 		return
 	}
 
-	// Validate the info.Name safe path (protects against directory traversal in the torrent).
+	// Validate info.Name is a safe path.
 	infoName := info.BestName()
 	if infoName != metainfo.NoName {
 		if _, pathErr := storage.ToSafeFilePath(infoName); pathErr != nil {
-			issues = append(issues, SnapshotVerifyIssue{
+			emitter.emit(SnapshotVerifyIssue{
 				Severity: "error",
-				File:     snapshotName + ".torrent",
+				Torrent:  torrentRel,
 				Message:  fmt.Sprintf("info.Name %q is unsafe: %v", infoName, pathErr),
 			})
 			return
 		}
 	}
 
-	// Check expected name: torrent file basename should match info.Name.
+	// info.Name should match the torrent filename.
 	baseName := path.Base(snapshotName)
 	if infoName != metainfo.NoName && infoName != baseName {
-		issues = append(issues, SnapshotVerifyIssue{
+		emitter.emit(SnapshotVerifyIssue{
 			Severity: "warn",
-			File:     snapshotName + ".torrent",
+			Torrent:  torrentRel,
 			Message:  fmt.Sprintf("info.Name %q doesn't match torrent filename %q", infoName, baseName),
 		})
 	}
 
-	// Check each data file listed in the torrent.
-	allFilesPresent := true
+	// Check each data file.
+	allPresent := true
 	for _, fi := range info.UpvertedFiles() {
-		fileIssues, present := checkDataFile(snapDir, snapshotName, &info, &fi, pvItems)
-		issues = append(issues, fileIssues...)
-		if !present {
-			allFilesPresent = false
+		if !checkDataFile(snapDir, snapshotName, torrentRel, &info, &fi, pvItems, emitter) {
+			allPresent = false
 		}
 	}
 
-	// Verify piece hashes using sparse-aware storage (mmap + SEEK_DATA/SEEK_HOLE).
-	if allFilesPresent && ctx.Err() == nil {
-		pieceIssues := verifyPieceHashes(ctx, snapDir, &info, infoHash)
-		issues = append(issues, pieceIssues...)
+	if allPresent && ctx.Err() == nil {
+		verifyPieceHashes(ctx, snapDir, snapshotName, torrentRel, &info, infoHash, emitter)
 	}
-	return
 }
 
-// checkDataFile checks a single file within a torrent for existence, path safety, and permissions.
-// Returns whether the file is present.
+// checkDataFile checks one data file from a torrent for existence, size, and permissions.
+// Returns true if the file is present and the right size.
 func checkDataFile(
 	snapDir string,
 	snapshotName string,
+	torrentRel string,
 	info *metainfo.Info,
 	fi *metainfo.FileInfo,
 	pvItems preverified.SortedItems,
-) (issues []SnapshotVerifyIssue, present bool) {
+	emitter *issueEmitter,
+) (present bool) {
 	infoName := info.BestName()
 
-	// Compute the data file path using the same logic as the torrent storage client.
-	// Single-file: {snapDir}/{info.Name}
-	// Multi-file:  {snapDir}/{info.Name}/{file.BestPath()}
 	var relSlashPath string
 	if len(fi.BestPath()) == 0 {
-		// Single-file torrent: info.Name is the file.
+		// Single-file torrent.
 		if infoName == metainfo.NoName {
 			relSlashPath = snapshotName
 		} else {
 			relSlashPath = infoName
 		}
 	} else {
-		// Multi-file torrent: validate each path component.
 		safePath, pathErr := storage.ToSafeFilePath(fi.BestPath()...)
 		if pathErr != nil {
-			issues = append(issues, SnapshotVerifyIssue{
+			emitter.emit(SnapshotVerifyIssue{
 				Severity: "error",
-				File:     snapshotName,
+				Torrent:  torrentRel,
 				Message:  fmt.Sprintf("unsafe file path %v in torrent: %v", fi.BestPath(), pathErr),
 			})
-			return issues, false
+			return false
 		}
 		relSlashPath = path.Join(infoName, safePath)
 	}
 
 	dataFilePath := filepath.Join(snapDir, filepath.FromSlash(relSlashPath))
-
 	stat, statErr := os.Stat(dataFilePath)
+
 	if errors.Is(statErr, fs.ErrNotExist) {
 		severity := "warn"
 		msg := "data file missing"
@@ -268,90 +325,97 @@ func checkDataFile(
 				msg = "data file missing (listed in preverified.toml)"
 			}
 		}
-		issues = append(issues, SnapshotVerifyIssue{
+		emitter.emit(SnapshotVerifyIssue{
 			Severity: severity,
+			Torrent:  torrentRel,
 			File:     relSlashPath,
 			Message:  msg,
 		})
-		return issues, false
+		return false
 	}
 	if statErr != nil {
-		issues = append(issues, SnapshotVerifyIssue{
+		emitter.emit(SnapshotVerifyIssue{
 			Severity: "error",
+			Torrent:  torrentRel,
 			File:     relSlashPath,
 			Message:  fmt.Sprintf("stat failed: %v", statErr),
 		})
-		return issues, false
+		return false
 	}
 
-	// Check file size matches torrent metadata.
 	if stat.Size() != fi.Length {
-		issues = append(issues, SnapshotVerifyIssue{
+		emitter.emit(SnapshotVerifyIssue{
 			Severity: "error",
+			Torrent:  torrentRel,
 			File:     relSlashPath,
 			Message:  fmt.Sprintf("size mismatch: on-disk=%d torrent=%d", stat.Size(), fi.Length),
 		})
+		// Size mismatch means piece verification won't be meaningful, treat as absent.
+		return false
 	}
 
-	// Check file permissions.
 	perm := stat.Mode().Perm()
-	// All files should be readable by owner.
 	if perm&0o400 == 0 {
-		issues = append(issues, SnapshotVerifyIssue{
+		emitter.emit(SnapshotVerifyIssue{
 			Severity: "error",
+			Torrent:  torrentRel,
 			File:     relSlashPath,
-			Message:  fmt.Sprintf("file not readable by owner (mode=%v)", perm),
+			Message:  fmt.Sprintf("not readable by owner (mode=%v)", perm),
 		})
 	}
-	// Completed snapshot files should not be writable (they're promoted to read-only on completion).
 	if perm&0o222 != 0 {
-		issues = append(issues, SnapshotVerifyIssue{
+		emitter.emit(SnapshotVerifyIssue{
 			Severity: "warn",
+			Torrent:  torrentRel,
 			File:     relSlashPath,
-			Message:  fmt.Sprintf("file is writable (mode=%v); completed snapshots are expected to be read-only", perm),
+			Message:  fmt.Sprintf("writable (mode=%v); completed snapshots are expected read-only", perm),
 		})
 	}
-	// World-writable is a stronger concern.
 	if perm&0o002 != 0 {
-		issues = append(issues, SnapshotVerifyIssue{
+		emitter.emit(SnapshotVerifyIssue{
 			Severity: "error",
+			Torrent:  torrentRel,
 			File:     relSlashPath,
-			Message:  fmt.Sprintf("file is world-writable (mode=%v)", perm),
+			Message:  fmt.Sprintf("world-writable (mode=%v)", perm),
 		})
 	}
 
-	return issues, true
+	return true
 }
 
-// verifyPieceHashes hashes each torrent piece using the same mmap/sparse-read storage
-// configuration as the main downloader and compares against the piece hashes in the torrent info.
+// verifyPieceHashes hashes each piece via the mmap/sparse-read storage (SEEK_DATA/SEEK_HOLE)
+// using the same configuration as the main downloader, and reports hash mismatches.
 func verifyPieceHashes(
 	ctx context.Context,
 	snapDir string,
+	snapshotName string,
+	torrentRel string,
 	info *metainfo.Info,
 	infoHash metainfo.Hash,
-) (issues []SnapshotVerifyIssue) {
+	emitter *issueEmitter,
+) {
 	client := newSnapStorage(snapDir, nil)
 	defer client.Close()
 
 	t, err := client.OpenTorrent(ctx, info, infoHash)
 	if err != nil {
-		return []SnapshotVerifyIssue{{
+		emitter.emit(SnapshotVerifyIssue{
 			Severity: "error",
-			File:     info.BestName(),
+			Torrent:  torrentRel,
 			Message:  fmt.Sprintf("failed to open torrent storage for piece verification: %v", err),
-		}}
+		})
+		return
 	}
 	defer t.Close()
 
 	for i := range info.NumPieces() {
 		if ctx.Err() != nil {
-			break
+			return
 		}
 		p := info.Piece(i)
-		// Only v1 torrents carry piece hashes; v2 uses merkle trees (not handled here).
 		expectedHash := p.V1Hash()
 		if !expectedHash.Ok {
+			// v2 torrents use merkle trees; no v1 piece hash to check.
 			continue
 		}
 
@@ -359,7 +423,7 @@ func verifyPieceHashes(
 		h := sha1.New()
 		piece := t.Piece(p)
 
-		// filePieceImpl implements io.WriterTo which uses seekDataOrEof for sparse reads.
+		// filePieceImpl implements io.WriterTo, which uses seekDataOrEof for sparse reads.
 		var written int64
 		var readErr error
 		if wt, ok := piece.(io.WriterTo); ok {
@@ -369,18 +433,20 @@ func verifyPieceHashes(
 		}
 
 		if readErr != nil {
-			issues = append(issues, SnapshotVerifyIssue{
+			emitter.emit(SnapshotVerifyIssue{
 				Severity: "error",
-				File:     info.BestName(),
+				Torrent:  torrentRel,
+				File:     snapshotName,
 				Message:  fmt.Sprintf("piece %d: read error: %v", i, readErr),
 			})
 			continue
 		}
 		if written < p.Length() {
-			issues = append(issues, SnapshotVerifyIssue{
+			emitter.emit(SnapshotVerifyIssue{
 				Severity: "error",
-				File:     info.BestName(),
-				Message:  fmt.Sprintf("piece %d: short read: got %d bytes, expected %d (file may be incomplete or sparse)", i, written, p.Length()),
+				Torrent:  torrentRel,
+				File:     snapshotName,
+				Message:  fmt.Sprintf("piece %d: short read: got %d of %d bytes (sparse or incomplete)", i, written, p.Length()),
 			})
 			continue
 		}
@@ -388,12 +454,12 @@ func verifyPieceHashes(
 		var actualHash metainfo.Hash
 		h.Sum(actualHash[:0])
 		if actualHash != expectedHash.Value {
-			issues = append(issues, SnapshotVerifyIssue{
+			emitter.emit(SnapshotVerifyIssue{
 				Severity: "error",
-				File:     info.BestName(),
+				Torrent:  torrentRel,
+				File:     snapshotName,
 				Message:  fmt.Sprintf("piece %d: hash mismatch: expected %x got %x", i, expectedHash.Value, actualHash),
 			})
 		}
 	}
-	return
 }


### PR DESCRIPTION
Closes #16660

Adds `erigon snapshots verify` (also `erigon seg verify`) to verify snapshot downloads in place without going through `--downloader.verify`.

## What it checks

- **preverified.toml** (if present): each `.torrent` file's infohash is matched against the recorded hash; entries with no `.torrent` on disk are reported
- **File paths**: `info.Name` and per-file paths within each torrent are validated as safe (no directory traversal)
- **Data file presence and size**: missing or wrong-size files are reported; severity is `error` if the file is in preverified.toml, `warn` otherwise
- **File permissions**: files must be owner-readable; writable completed snapshots are warned about; world-writable files are an error
- **Piece hashes**: verified using the same `storage.NewFileOpts` configuration as the main downloader (part-file-aware, mmap-based fileIo with `SEEK_DATA`/`SEEK_HOLE` sparse read support)

## Implementation notes

`newSnapStorage` is extracted from `newTorrentClient` so both the running downloader and the verify command use identical storage settings.