### PR TITLE
node/cli: fix dotted CLI flags ignored in TOML/YAML config files

### DIFF
--- a/node/cli/config_file.go
+++ b/node/cli/config_file.go
@@ -55,8 +55,14 @@ func SetFlagsFromConfigFile(ctx *cli.Context, filePath string) error {
 	} else {
 		return errors.New("config files only accepted are .yaml and .toml")
 	}
+
+	// Flatten nested maps into dot-separated keys so that TOML nested tables
+	// (e.g. [sentinel] / staticpeers = [...]) and TOML dotted keys
+	// (e.g. sentinel.staticpeers = [...]) map to the correct CLI flag names.
+	flat := flattenConfig(fileConfig, "")
+
 	// sets global flags to value in yaml/toml file
-	for key, value := range fileConfig {
+	for key, value := range flat {
 		if !ctx.IsSet(key) {
 			if reflect.ValueOf(value).Kind() == reflect.Slice {
 				sliceInterface := value.([]any)
@@ -79,4 +85,41 @@ func SetFlagsFromConfigFile(ctx *cli.Context, filePath string) error {
 	}
 
 	return nil
+}
+
+// flattenConfig recursively flattens a nested map[string]any into a flat map
+// using dot-separated keys. This lets TOML nested tables and dotted keys both
+// map naturally to CLI flag names (e.g. sentinel.staticpeers).
+func flattenConfig(m map[string]any, prefix string) map[string]any {
+	result := make(map[string]any)
+	for k, v := range m {
+		key := k
+		if prefix != "" {
+			key = prefix + "." + k
+		}
+		if nested, ok := v.(map[string]any); ok {
+			for fk, fv := range flattenConfig(nested, key) {
+				result[fk] = fv
+			}
+		} else if nested, ok := v.(map[any]any); ok {
+			// gopkg.in/yaml.v2 unmarshals maps as map[interface{}]interface{}
+			converted := convertYAMLMap(nested)
+			for fk, fv := range flattenConfig(converted, key) {
+				result[fk] = fv
+			}
+		} else {
+			result[key] = v
+		}
+	}
+	return result
+}
+
+// convertYAMLMap converts a map[any]any (produced by gopkg.in/yaml.v2) to
+// map[string]any so it can be processed uniformly.
+func convertYAMLMap(m map[any]any) map[string]any {
+	result := make(map[string]any, len(m))
+	for k, v := range m {
+		result[fmt.Sprintf("%v", k)] = v
+	}
+	return result
 }

--- a/node/cli/config_file_test.go
+++ b/node/cli/config_file_test.go
@@ -1,0 +1,94 @@
+// Copyright 2024 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+func TestSetFlagsFromConfigFile_StaticPeers(t *testing.T) {
+	staticPeersFlag := cli.StringFlag{
+		Name:  "staticpeers",
+		Usage: "Comma separated enode URLs to connect to",
+		Value: "",
+	}
+	sentinelStaticPeersFlag := cli.StringSliceFlag{
+		Name:  "sentinel.staticpeers",
+		Usage: "connect to comma-separated Consensus static peers",
+	}
+
+	tests := []struct {
+		name                    string
+		toml                    string
+		wantStaticPeers         string
+		wantSentinelStaticPeers []string
+	}{
+		{
+			name:            "EL staticpeers as TOML array",
+			toml:            "staticpeers = [\"enode://abc@1.2.3.4:30303\", \"enode://def@5.6.7.8:30303\"]\n",
+			wantStaticPeers: "enode://abc@1.2.3.4:30303,enode://def@5.6.7.8:30303",
+		},
+		{
+			name:            "EL staticpeers as TOML string",
+			toml:            "staticpeers = \"enode://abc@1.2.3.4:30303,enode://def@5.6.7.8:30303\"\n",
+			wantStaticPeers: "enode://abc@1.2.3.4:30303,enode://def@5.6.7.8:30303",
+		},
+		{
+			name:                    "CL sentinel.staticpeers as TOML dotted key",
+			toml:                    "sentinel.staticpeers = [\"enode://abc@1.2.3.4:9000\", \"enode://def@5.6.7.8:9000\"]\n",
+			wantSentinelStaticPeers: []string{"enode://abc@1.2.3.4:9000", "enode://def@5.6.7.8:9000"},
+		},
+		{
+			name:                    "CL sentinel.staticpeers as TOML nested table",
+			toml:                    "[sentinel]\nstaticpeers = [\"enode://abc@1.2.3.4:9000\", \"enode://def@5.6.7.8:9000\"]\n",
+			wantSentinelStaticPeers: []string{"enode://abc@1.2.3.4:9000", "enode://def@5.6.7.8:9000"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			cfgFile := filepath.Join(tmpDir, "erigon.toml")
+			require.NoError(t, os.WriteFile(cfgFile, []byte(tt.toml), 0o600))
+
+			app := cli.NewApp()
+			app.Flags = []cli.Flag{&staticPeersFlag, &sentinelStaticPeersFlag}
+			app.Action = func(ctx *cli.Context) error {
+				err := SetFlagsFromConfigFile(ctx, cfgFile)
+				require.NoError(t, err)
+
+				if tt.wantStaticPeers != "" {
+					require.True(t, ctx.IsSet("staticpeers"), "ctx.IsSet(staticpeers) should be true")
+					require.Equal(t, tt.wantStaticPeers, ctx.String("staticpeers"))
+				}
+				if tt.wantSentinelStaticPeers != nil {
+					require.True(t, ctx.IsSet("sentinel.staticpeers"), "ctx.IsSet(sentinel.staticpeers) should be true")
+					require.Equal(t, tt.wantSentinelStaticPeers, ctx.StringSlice("sentinel.staticpeers"))
+				}
+				return nil
+			}
+
+			err := app.Run([]string{"erigon"})
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #17388.

When a TOML config file uses nested tables or dotted keys for flags that contain a `.` in their name (e.g. `sentinel.staticpeers`, `http.addr`), the `pelletier/go-toml` parser produces a nested `map[string]any` rather than a flat key `"sentinel.staticpeers"`. This caused all such flags to be silently ignored.

**Before:** `[sentinel]\nstaticpeers = [...]` → parsed as `{"sentinel": {"staticpeers": [...]}}` → key `"sentinel"` not found as a CLI flag, silently dropped.

**After:** nested maps are recursively flattened into dot-separated keys before applying them to the CLI context, so both of these TOML forms work correctly:

```toml
# Dotted key form
sentinel.staticpeers = ["enode://..."]

# Nested table form
[sentinel]
staticpeers = ["enode://..."]
```

The same fix applies to YAML config files via `gopkg.in/yaml.v2`'s `map[any]any` type.

Note: flat keys without dots (e.g. `staticpeers = [...]`) already worked correctly and continue to do so.