### PR TITLE
stagedsync: replace TxLookup prune full-table scan with block-based deletion

### DIFF
--- a/execution/stagedsync/stage_txlookup.go
+++ b/execution/stagedsync/stage_txlookup.go
@@ -224,6 +224,16 @@ func PruneTxLookup(s *PruneState, tx kv.RwTx, cfg TxLookupCfg, ctx context.Conte
 		blockTo = cfg.blockReader.CanPruneTo(s.ForwardProgress)
 	}
 
+	// At chain tip, cap the number of blocks pruned per cycle to bound the
+	// time spent inside a single DB transaction. Each block adds ~150 random
+	// key deletions to TxLookup, so 100 blocks ≈ 15 000 deletes — a few
+	// tens of milliseconds. During initial sync there is no slot budget
+	// pressure, so we let it run unrestricted.
+	if !s.CurrentSyncCycle.IsInitialCycle {
+		const maxBlocksPerCycle = 100
+		blockTo = min(blockTo, blockFrom+maxBlocksPerCycle)
+	}
+
 	if blockFrom >= blockTo {
 		return nil
 	}


### PR DESCRIPTION
## Summary

https://github.com/erigontech/erigon/issues/19890
- PruneTxLookup previously used `TableScanningPrune` which scans the entire
  TxLookup table (keyed by random tx hashes) to find entries within a txNum
  range — O(table_size). At chain tip this burned a constant ~2s per block
  even when there was nothing to prune, wasting ~17% of the 12s slot budget.
- Replace with `deleteTxLookupRange` which iterates HeaderCanonical for the
  block range, looks up each block's transactions, and deletes their TxLookup
  entries directly — O(txs_to_delete). This is the same approach already used
  by UnwindTxLookup.
- At chain tip, cap pruning to 100 blocks per cycle to bound DB transaction size.

## Background

PR #19179 ("prune unification") moved TxLookup to the generic `TableScanningPrune`
framework. That framework works well for tables whose keys contain txNum/step
(domain, history, inverted_index), but TxLookup keys are random tx hashes with
txNum buried in the value — forcing a full table scan even when 0 entries need
deleting.

## Test plan

- [ ] `make lint`
- [ ] `make test-short`
- [ ] Verify on a synced mainnet node that TxLookup prune completes in
      milliseconds instead of ~2s at chain tip