### PR TITLE
types: deduplicate types across packages

### DIFF
--- a/cl/sentinel/config.go
+++ b/cl/sentinel/config.go
@@ -19,31 +19,17 @@ package sentinel
 import (
 	"github.com/c2h5oh/datasize"
 
-	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/p2p"
 )
 
 type SentinelConfig struct {
-	NetworkConfig *clparams.NetworkConfig
-	BeaconConfig  *clparams.BeaconChainConfig
-	IpAddr        string
-	Port          int
-	TCPPort       uint
+	p2p.P2PConfig
 
 	MaxInboundTrafficPerPeer     datasize.ByteSize
 	MaxOutboundTrafficPerPeer    datasize.ByteSize
 	AdaptableTrafficRequirements bool
-	// Optional
-	LocalIP        string
-	EnableUPnP     bool
-	RelayNodeAddr  string
-	HostAddress    string
-	HostDNS        string
-	NoDiscovery    bool
-	TmpDir         string
-	LocalDiscovery bool
 
 	EnableBlocks       bool
 	SubscribeAllTopics bool // Capture all topics
 	ActiveIndicies     uint64
-	MaxPeerCount       uint64
 }

--- a/cl/sentinel/sentinel_requests_test.go
+++ b/cl/sentinel/sentinel_requests_test.go
@@ -138,10 +138,12 @@ func newTestSentinel(t *testing.T, ethClock eth_clock.EthereumClock, reader free
 	networkConfig, beaconConfig := clparams.GetConfigsByNetwork(chainspec.MainnetChainID)
 	pm := newTestP2PManager(t, ethClock)
 	sent, err := New(t.Context(), &SentinelConfig{
-		NetworkConfig: networkConfig,
-		BeaconConfig:  beaconConfig,
-		EnableBlocks:  true,
-		MaxPeerCount:  100,
+		P2PConfig: p2p.P2PConfig{
+			NetworkConfig: networkConfig,
+			BeaconConfig:  beaconConfig,
+			MaxPeerCount:  100,
+		},
+		EnableBlocks: true,
 	}, ethClock, reader, nil, db, log.New(), &mock_services.ForkChoiceStorageMock{}, nil, mockPeerDasStateReader, pm)
 	noErr(err)
 	t.Cleanup(func() { sent.Stop() })

--- a/cmd/caplin/caplin1/run.go
+++ b/cmd/caplin/caplin1/run.go
@@ -40,7 +40,7 @@ import (
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/das"
 	peerdasstate "github.com/erigontech/erigon/cl/das/state"
-	"github.com/erigontech/erigon/cl/p2p"
+	clp2p "github.com/erigontech/erigon/cl/p2p"
 	"github.com/erigontech/erigon/cl/persistence/beacon_indicies"
 	"github.com/erigontech/erigon/cl/persistence/blob_storage"
 	"github.com/erigontech/erigon/cl/persistence/format/snapshot_format"
@@ -294,7 +294,7 @@ func RunCaplinService(ctx context.Context, engine execution_client.ExecutionEngi
 		return err
 	}
 	activeIndicies := state.GetActiveValidatorsIndices(state.Slot() / beaconConfig.SlotsPerEpoch)
-	p2p, err := p2p.NewP2Pmanager(ctx, &p2p.P2PConfig{
+	p2p, err := clp2p.NewP2Pmanager(ctx, &clp2p.P2PConfig{
 		IpAddr:     config.CaplinDiscoveryAddr,
 		Port:       int(config.CaplinDiscoveryPort),
 		TCPPort:    uint(config.CaplinDiscoveryTCPPort),
@@ -315,20 +315,22 @@ func RunCaplinService(ctx context.Context, engine execution_client.ExecutionEngi
 	peerDasState := peerdasstate.NewPeerDasState(beaconConfig, networkConfig)
 	columnStorage := blob_storage.NewDataColumnStore(afero.NewBasePathFs(afero.NewOsFs(), dirs.CaplinColumnData), pruneBlobDistance, beaconConfig, ethClock, emitters)
 	sentinel, localNode, err := service.StartSentinelService(&sentinel.SentinelConfig{
-		IpAddr:                       config.CaplinDiscoveryAddr,
-		Port:                         int(config.CaplinDiscoveryPort),
-		TCPPort:                      uint(config.CaplinDiscoveryTCPPort),
-		EnableUPnP:                   config.EnableUPnP,
+		P2PConfig: clp2p.P2PConfig{
+			IpAddr:        config.CaplinDiscoveryAddr,
+			Port:          int(config.CaplinDiscoveryPort),
+			TCPPort:       uint(config.CaplinDiscoveryTCPPort),
+			EnableUPnP:    config.EnableUPnP,
+			NetworkConfig: networkConfig,
+			BeaconConfig:  beaconConfig,
+			TmpDir:        dirs.Tmp,
+			MaxPeerCount:  config.MaxPeerCount,
+		},
 		MaxInboundTrafficPerPeer:     config.MaxInboundTrafficPerPeer,
 		MaxOutboundTrafficPerPeer:    config.MaxOutboundTrafficPerPeer,
 		AdaptableTrafficRequirements: config.AdptableTrafficRequirements,
 		SubscribeAllTopics:           config.SubscribeAllTopics,
-		NetworkConfig:                networkConfig,
-		BeaconConfig:                 beaconConfig,
-		TmpDir:                       dirs.Tmp,
 		EnableBlocks:                 true,
 		ActiveIndicies:               uint64(len(activeIndicies)),
-		MaxPeerCount:                 config.MaxPeerCount,
 	}, rcsn, blobStorage, indexDB, &service.ServerConfig{
 		Network: "tcp",
 		Addr:    fmt.Sprintf("%s:%d", config.SentinelAddr, config.SentinelPort),

--- a/db/services/interfaces.go
+++ b/db/services/interfaces.go
@@ -133,10 +133,6 @@ type DBEventNotifier interface {
 	OnNewSnapshot()
 }
 
-type Range struct {
-	From, To uint64
-}
-
 type BlockSnapshots interface {
 	LogStat(label string)
 	OpenFolder() error

--- a/execution/types/log.go
+++ b/execution/types/log.go
@@ -64,16 +64,8 @@ type Log struct {
 type Logs []*Log
 
 type ErigonLog struct {
-	Address     common.Address `json:"address" gencodec:"required" codec:"1"`
-	Topics      []common.Hash  `json:"topics" gencodec:"required" codec:"2"`
-	Data        []byte         `json:"data" gencodec:"required" codec:"3"`
-	BlockNumber uint64         `json:"blockNumber" codec:"-"`
-	TxHash      common.Hash    `json:"transactionHash" gencodec:"required" codec:"-"`
-	TxIndex     uint           `json:"transactionIndex" codec:"-"`
-	BlockHash   common.Hash    `json:"blockHash" codec:"-"`
-	Index       uint           `json:"logIndex" codec:"-"`
-	Removed     bool           `json:"removed" codec:"-"`
-	Timestamp   uint64         `json:"timestamp" codec:"-"`
+	Log
+	Timestamp uint64 `json:"timestamp" codec:"-"`
 }
 
 type ErigonLogs []*ErigonLog
@@ -83,16 +75,8 @@ func (logs Logs) ToErigonLogs(timestamp uint64) ErigonLogs {
 	result := make(ErigonLogs, len(logs))
 	for i, l := range logs {
 		result[i] = &ErigonLog{
-			Address:     l.Address,
-			Topics:      l.Topics,
-			Data:        l.Data,
-			BlockNumber: l.BlockNumber,
-			TxHash:      l.TxHash,
-			TxIndex:     l.TxIndex,
-			BlockHash:   l.BlockHash,
-			Index:       l.Index,
-			Removed:     l.Removed,
-			Timestamp:   timestamp,
+			Log:       *l,
+			Timestamp: timestamp,
 		}
 	}
 	return result

--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -619,7 +619,7 @@ func (c *Bor) VerifyUncles(_ rules.ChainReader, _ *types.Header, uncles []*types
 
 // VerifySeal implements rules.Engine, checking whether the signature contained
 // in the header satisfies the consensus protocol requirements.
-func (c *Bor) VerifySeal(chain ChainHeaderReader, header *types.Header) error {
+func (c *Bor) VerifySeal(chain rules.ChainHeaderReader, header *types.Header) error {
 	v, err := c.spanReader.Producers(context.Background(), header.Number.Uint64())
 	if err != nil {
 		return err
@@ -632,7 +632,7 @@ func (c *Bor) VerifySeal(chain ChainHeaderReader, header *types.Header) error {
 // consensus protocol requirements. The method accepts an optional list of parent
 // headers that aren't yet part of the local blockchain to generate the snapshots
 // from.
-func (c *Bor) verifySeal(chain ChainHeaderReader, header *types.Header, parents []*types.Header, validatorSet *heimdall.ValidatorSet) error {
+func (c *Bor) verifySeal(chain rules.ChainHeaderReader, header *types.Header, parents []*types.Header, validatorSet *heimdall.ValidatorSet) error {
 	// Verifying the genesis block is not supported
 	number := header.Number.Uint64()
 	if number == 0 {

--- a/polygon/bor/spanner.go
+++ b/polygon/bor/spanner.go
@@ -25,7 +25,6 @@ import (
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/protocol/rules"
 	"github.com/erigontech/erigon/execution/rlp"
-	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/execution/types/accounts"
 	"github.com/erigontech/erigon/polygon/bor/borcfg"
 	"github.com/erigontech/erigon/polygon/heimdall"
@@ -96,12 +95,6 @@ func (c *ChainSpanner) GetCurrentSpan(syscall rules.SystemCall) (*heimdall.Span,
 	}
 
 	return &span, nil
-}
-
-type ChainHeaderReader interface {
-	GetHeaderByNumber(number uint64) *types.Header
-	GetHeader(hash common.Hash, number uint64) *types.Header
-	FrozenBlocks() uint64
 }
 
 func (c *ChainSpanner) CommitSpan(heimdallSpan heimdall.Span, syscall rules.SystemCall) error {

--- a/rpc/jsonrpc/erigon_receipts_test.go
+++ b/rpc/jsonrpc/erigon_receipts_test.go
@@ -83,16 +83,8 @@ func TestErigonGetLatestLogs(t *testing.T) {
 	expectedErigonLogs := make(types.ErigonLogs, 0)
 	for i := len(expectedLogs) - 1; i >= 0; i-- {
 		expectedErigonLogs = append(expectedErigonLogs, &types.ErigonLog{
-			Address:     expectedLogs[i].Address,
-			Topics:      expectedLogs[i].Topics,
-			Data:        expectedLogs[i].Data,
-			BlockNumber: expectedLogs[i].BlockNumber,
-			TxHash:      expectedLogs[i].TxHash,
-			TxIndex:     expectedLogs[i].TxIndex,
-			BlockHash:   expectedLogs[i].BlockHash,
-			Index:       expectedLogs[i].Index,
-			Removed:     expectedLogs[i].Removed,
-			Timestamp:   expectedLogs[i].Timestamp,
+			Log:       expectedLogs[i].Log,
+			Timestamp: expectedLogs[i].Timestamp,
 		})
 	}
 	actual, err := api.GetLatestLogs(m.Ctx, filters.FilterCriteria{FromBlock: big.NewInt(0), ToBlock: big.NewInt(rpc.LatestBlockNumber.Int64())}, filters.LogFilterOptions{
@@ -105,16 +97,18 @@ func TestErigonGetLatestLogs(t *testing.T) {
 	assert.Equal(expectedErigonLogs, actual)
 
 	expectedLog := &types.ErigonLog{
-		Address:     common.HexToAddress("0x3CB5b6E26e0f37F2514D45641F15Bd6fEC2E0c4c"),
-		Topics:      []common.Hash{common.HexToHash("0x68f6a0f063c25c6678c443b9a484086f15ba8f91f60218695d32a5251f2050eb")},
-		Data:        []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 151, 160, 176, 241, 203, 220, 75, 75, 222, 127, 170, 33, 171, 34, 107, 143, 20, 185, 234, 201},
-		BlockNumber: 10,
-		TxHash:      common.HexToHash("0xb6449d8e167a8826d050afe4c9f07095236ff769a985f02649b1023c2ded2059"),
-		TxIndex:     0,
-		BlockHash:   common.HexToHash("0x6804117de2f3e6ee32953e78ced1db7b20214e0d8c745a03b8fecf7cc8ee76ef"),
-		Index:       0,
-		Removed:     false,
-		Timestamp:   100,
+		Log: types.Log{
+			Address:     common.HexToAddress("0x3CB5b6E26e0f37F2514D45641F15Bd6fEC2E0c4c"),
+			Topics:      []common.Hash{common.HexToHash("0x68f6a0f063c25c6678c443b9a484086f15ba8f91f60218695d32a5251f2050eb")},
+			Data:        []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 151, 160, 176, 241, 203, 220, 75, 75, 222, 127, 170, 33, 171, 34, 107, 143, 20, 185, 234, 201},
+			BlockNumber: 10,
+			TxHash:      common.HexToHash("0xb6449d8e167a8826d050afe4c9f07095236ff769a985f02649b1023c2ded2059"),
+			TxIndex:     0,
+			BlockHash:   common.HexToHash("0x6804117de2f3e6ee32953e78ced1db7b20214e0d8c745a03b8fecf7cc8ee76ef"),
+			Index:       0,
+			Removed:     false,
+		},
+		Timestamp: 100,
 	}
 	assert.Equal(expectedLog, actual[0])
 }
@@ -129,16 +123,8 @@ func TestErigonGetLatestLogsIgnoreTopics(t *testing.T) {
 	expectedErigonLogs := make([]*types.ErigonLog, 0)
 	for i := len(expectedLogs) - 1; i >= 0; i-- {
 		expectedErigonLogs = append(expectedErigonLogs, &types.ErigonLog{
-			Address:     expectedLogs[i].Address,
-			Topics:      expectedLogs[i].Topics,
-			Data:        expectedLogs[i].Data,
-			BlockNumber: expectedLogs[i].BlockNumber,
-			TxHash:      expectedLogs[i].TxHash,
-			TxIndex:     expectedLogs[i].TxIndex,
-			BlockHash:   expectedLogs[i].BlockHash,
-			Index:       expectedLogs[i].Index,
-			Removed:     expectedLogs[i].Removed,
-			Timestamp:   expectedLogs[i].Timestamp,
+			Log:       expectedLogs[i].Log,
+			Timestamp: expectedLogs[i].Timestamp,
 		})
 	}
 

--- a/rpc/jsonrpc/eth_receipts.go
+++ b/rpc/jsonrpc/eth_receipts.go
@@ -361,16 +361,8 @@ func (api *BaseAPI) getLogsV3(ctx context.Context, tx kv.TemporalTx, begin, end 
 						return nil, fmt.Errorf("%s: %d", errExceedLogResults, maxResults)
 					}
 					logs = append(logs, &types.ErigonLog{
-						Address:     filteredLog.Address,
-						Topics:      filteredLog.Topics,
-						Data:        filteredLog.Data,
-						BlockNumber: filteredLog.BlockNumber,
-						TxHash:      filteredLog.TxHash,
-						TxIndex:     filteredLog.TxIndex,
-						BlockHash:   filteredLog.BlockHash,
-						Index:       filteredLog.Index,
-						Removed:     filteredLog.Removed,
-						Timestamp:   header.Time,
+						Log:       *filteredLog,
+						Timestamp: header.Time,
 					})
 				}
 			}
@@ -401,16 +393,8 @@ func (api *BaseAPI) getLogsV3(ctx context.Context, tx kv.TemporalTx, begin, end 
 				return nil, fmt.Errorf("%s: %d", errExceedLogResults, maxResults)
 			}
 			logs = append(logs, &types.ErigonLog{
-				Address:     filteredLog.Address,
-				Topics:      filteredLog.Topics,
-				Data:        filteredLog.Data,
-				BlockNumber: filteredLog.BlockNumber,
-				TxHash:      filteredLog.TxHash,
-				TxIndex:     filteredLog.TxIndex,
-				BlockHash:   filteredLog.BlockHash,
-				Index:       filteredLog.Index,
-				Removed:     filteredLog.Removed,
-				Timestamp:   header.Time,
+				Log:       *filteredLog,
+				Timestamp: header.Time,
 			})
 		}
 	}


### PR DESCRIPTION
## Summary

- **ErigonLog**: embed `Log` instead of duplicating all 9 fields (like `RPCLog` already does)
- **SentinelConfig**: embed `P2PConfig` instead of repeating 14 shared fields
- **bor.ChainHeaderReader**: remove local 3-method interface, use `rules.ChainHeaderReader` (already imported)
- **services.Range**: remove unused type (zero references in codebase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)