### PR TITLE
execution: fix simulated call defaults under Osaka

### DIFF
--- a/execution/abi/bind/backends/simulated.go
+++ b/execution/abi/bind/backends/simulated.go
@@ -738,6 +738,12 @@ func (b *SimulatedBackend) callContract(_ context.Context, call ethereum.CallMsg
 	}
 	if call.Gas == 0 {
 		call.Gas = 50000000
+		if call.Gas > params.MaxTxnGasLimit && b.m.ChainConfig.IsOsaka(block.Time()) {
+			call.Gas = params.MaxTxnGasLimit
+		}
+	}
+	if call.MaxFeePerBlobGas == nil {
+		call.MaxFeePerBlobGas = new(uint256.Int)
 	}
 	if call.Value == nil {
 		call.Value = new(uint256.Int)

--- a/execution/abi/bind/backends/simulated_test.go
+++ b/execution/abi/bind/backends/simulated_test.go
@@ -1020,6 +1020,42 @@ func TestSimulatedBackend_PendingAndCallContract(t *testing.T) {
 	}
 }
 
+func TestSimulatedBackend_CallContractDefaultGasRespectsOsakaCap(t *testing.T) {
+	testAddr := crypto.PubkeyToAddress(testKey.PublicKey)
+	contractAddr := common.HexToAddress("0x1000000000000000000000000000000000000001")
+	sim := NewSimulatedBackendWithConfig(t, types.GenesisAlloc{
+		testAddr:     {Balance: big.NewInt(common.Ether)},
+		contractAddr: {Balance: big.NewInt(0), Code: common.FromHex(deployedCode)},
+	}, chain.AllProtocolChanges, params.MaxTxnGasLimit+1_000_000)
+	bgCtx := context.Background()
+
+	require.True(t, sim.m.ChainConfig.IsOsaka(sim.pendingBlock.Time()))
+
+	parsed, err := abi.JSON(strings.NewReader(abiJSON))
+	require.NoError(t, err)
+
+	input, err := parsed.Pack("receive", []byte("X"))
+	require.NoError(t, err)
+
+	res, err := sim.PendingCallContract(bgCtx, ethereum.CallMsg{
+		From: testAddr,
+		To:   &contractAddr,
+		Data: input,
+	})
+	require.NoError(t, err)
+	require.Equal(t, expectedReturn, res)
+
+	sim.Commit()
+
+	res, err = sim.CallContract(bgCtx, ethereum.CallMsg{
+		From: testAddr,
+		To:   &contractAddr,
+		Data: input,
+	}, nil)
+	require.NoError(t, err)
+	require.Equal(t, expectedReturn, res)
+}
+
 // This test is based on the following contract:
 /*
 contract Reverter {


### PR DESCRIPTION
Cap SimulatedBackend default call gas under Osaka, and initialize blob fee defaults so default calls no longer panic.