### PR TITLE
db/state: add HistoryKeyTxNumRange API

### DIFF
--- a/db/kv/kv_interface.go
+++ b/db/kv/kv_interface.go
@@ -449,6 +449,9 @@ type TemporalDebugTx interface {
 	// TraceKey returns stream of <txNum->value_after_txnum_change> for a given key
 	TraceKey(domain Domain, k []byte, fromTxNum, toTxNum uint64) (stream.U64V, error)
 
+	// HistoryKeyTxNumRange returns (key, txNum) pairs for every txNum at which a key changed in [fromTs, toTs)
+	HistoryKeyTxNumRange(name Domain, fromTs, toTs int, asc order.By, limit int) (it stream.KU64, err error)
+
 	DomainFiles(domain ...Domain) VisibleFiles
 	CurrentDomainVersion(domain Domain) version.Version
 	TxNumsInFiles(domains ...Domain) (minTxNum uint64)

--- a/db/kv/remotedb/kv_remote.go
+++ b/db/kv/remotedb/kv_remote.go
@@ -261,6 +261,9 @@ func (tx *tx) GetLatestFromFiles(domain kv.Domain, k []byte, maxTxNum uint64) (v
 func (tx *tx) TraceKey(domain kv.Domain, k []byte, fromTxNum, toTxNum uint64) (stream.U64V, error) {
 	panic("not implemented")
 }
+func (tx *tx) HistoryKeyTxNumRange(name kv.Domain, fromTs, toTs int, asc order.By, limit int) (stream.KU64, error) {
+	panic("not implemented")
+}
 func (tx *tx) IIProgress(domain kv.InvertedIdx) uint64 { panic("not implemented") }
 func (tx *tx) RangeLatest(domain kv.Domain, from, to []byte, limit int) (stream.KV, error) {
 	panic("not implemented")

--- a/db/kv/temporal/kv_temporal.go
+++ b/db/kv/temporal/kv_temporal.go
@@ -604,6 +604,23 @@ func (tx *RwTx) HistoryRange(name kv.Domain, fromTs, toTs int, asc order.By, lim
 	return tx.historyRange(name, tx.RwTx, fromTs, toTs, asc, limit)
 }
 
+func (tx *tx) historyKeyTxNumRange(name kv.Domain, dbTx kv.Tx, fromTs, toTs int, asc order.By, limit int) (stream.KU64, error) {
+	it, err := tx.aggtx.HistoryKeyTxNumRange(name, fromTs, toTs, asc, limit, dbTx)
+	if err != nil {
+		return nil, err
+	}
+	tx.resourcesToClose = append(tx.resourcesToClose, it)
+	return it, nil
+}
+
+func (tx *Tx) HistoryKeyTxNumRange(name kv.Domain, fromTs, toTs int, asc order.By, limit int) (stream.KU64, error) {
+	return tx.historyKeyTxNumRange(name, tx.Tx, fromTs, toTs, asc, limit)
+}
+
+func (tx *RwTx) HistoryKeyTxNumRange(name kv.Domain, fromTs, toTs int, asc order.By, limit int) (stream.KU64, error) {
+	return tx.historyKeyTxNumRange(name, tx.RwTx, fromTs, toTs, asc, limit)
+}
+
 // Write methods
 
 func (tx *tx) DomainPut(domain kv.Domain, k, v []byte, txNum uint64, prevVal []byte) error {

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -1896,6 +1896,10 @@ func (at *AggregatorRoTx) HistoryRange(domain kv.Domain, fromTs, toTs int, asc o
 	return at.d[domain].ht.HistoryRange(fromTs, toTs, asc, limit, tx)
 }
 
+func (at *AggregatorRoTx) HistoryKeyTxNumRange(domain kv.Domain, fromTs, toTs int, asc order.By, limit int, tx kv.Tx) (stream.KU64, error) {
+	return at.d[domain].ht.HistoryKeyTxNumRange(fromTs, toTs, asc, limit, tx)
+}
+
 func (at *AggregatorRoTx) KeyCountInFiles(d kv.Domain, start, end uint64) (totalKeys uint64) {
 	if d >= kv.DomainLen {
 		return 0


### PR DESCRIPTION
## Summary
- Adds `HistoryKeyTxNumRange` to `TemporalDebugTx` interface and implements it in `kv_temporal`, `remotedb`, and `AggregatorRoTx`
- Returns `(key, txNum)` pairs for every txNum at which a key changed in a given range
- Prerequisite for the commitment history rebuild PR

## Test plan
- Existing `TestHistoryKeyTxNumRange`, `TestHistoryKeyTxNumRange_EdgeCases`, `TestHistoryKeyTxNumRange_DBOnly`, and `TestHistoryKeyTxNumRange_RandomRanges` tests cover the API