### PR TITLE
db/state: add doMerge param to BuildFiles2

### DIFF
--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -966,7 +966,7 @@ Loop:
 }
 
 // [from, to)
-func (a *Aggregator) BuildFiles2(ctx context.Context, fromStep, toStep kv.Step) error {
+func (a *Aggregator) BuildFiles2(ctx context.Context, fromStep, toStep kv.Step, doMerge bool) error {
 	if ok := a.buildingFiles.CompareAndSwap(false, true); !ok {
 		return nil
 	}
@@ -991,11 +991,13 @@ func (a *Aggregator) BuildFiles2(ctx context.Context, fromStep, toStep kv.Step) 
 			a.onFilesChange(nil)
 		}
 
-		go func() {
-			if err := a.MergeLoop(ctx); err != nil {
-				panic(err)
-			}
-		}()
+		if doMerge {
+			go func() {
+				if err := a.MergeLoop(ctx); err != nil {
+					panic(err)
+				}
+			}()
+		}
 	}()
 	return nil
 }

--- a/execution/stagedsync/stage_custom_trace.go
+++ b/execution/stagedsync/stage_custom_trace.go
@@ -269,7 +269,7 @@ func customTraceBatchProduce(ctx context.Context, produce Produce, cfg *exec.Exe
 	}); err != nil {
 		return err
 	}
-	if err := agg.BuildFiles2(ctx, fromStep, toStep); err != nil {
+	if err := agg.BuildFiles2(ctx, fromStep, toStep, true); err != nil {
 		return err
 	}
 	if err := db.Update(ctx, func(tx kv.RwTx) error {


### PR DESCRIPTION
## Summary
- Adds `doMerge bool` parameter to `BuildFiles2` to optionally skip the merge goroutine
- Existing caller in `stage_custom_trace.go` passes `true` to preserve current behavior
- Needed by commitment history rebuild which builds files without merging

## Test plan
- Existing callers updated to pass `true`, preserving current behavior
- No behavioral change for existing code paths

--- 

breaking commitment history rebuild into smaller PRs; this is part of that. 