### PR TITLE
exec3_parallel: fix cross-block timing hole in finalizeTx path

### DIFF
--- a/execution/stagedsync/exec3_2cache_test.go
+++ b/execution/stagedsync/exec3_2cache_test.go
@@ -218,3 +218,102 @@ func TestNotifyAccumulatorFromVersionedWrites(t *testing.T) {
 	require.Equal(t, storageVal.Bytes(), changes[0].Changes[0].StorageChanges[0].Data,
 		"ChangeStorage must populate StorageChange.Data")
 }
+
+// TestUpdateBufferedAccountsFromCollectorWrites verifies that
+// UpdateBufferedAccounts correctly populates rs.accounts from VersionedWrites
+// produced by LightCollector. This is the fix for the cross-block timing hole
+// when the direct finalizeTx path bypasses versionedWriteCollector.
+//
+// Without UpdateBufferedAccounts, block N+1 workers reading via bufferedReader
+// would see stale state for accounts modified by block N's regular TXs.
+func TestUpdateBufferedAccountsFromCollectorWrites(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires mdbx")
+	}
+
+	tx, domains := setup2CacheTest(t)
+
+	addr := accounts.InternAddress(common.HexToAddress("0xCAFE"))
+	lgr := log.New()
+
+	rs := state.NewStateV3Buffered(state.NewStateV3(domains, ethconfig.Sync{}, lgr))
+
+	// Simulate the direct finalizeTx path: LightCollector captures writes
+	// but does NOT update rs.accounts.
+	collector := state.NewLightCollector()
+	account := &accounts.Account{Balance: *uint256.NewInt(999), Nonce: 42}
+	original := &accounts.Account{}
+	err := collector.UpdateAccountData(addr, original, account)
+	require.NoError(t, err)
+
+	writes := collector.TakeWrites()
+
+	// Before UpdateBufferedAccounts: bufferedReader should NOT see the account.
+	baseReader := state.NewReaderV3(domains.AsGetter(tx))
+	bufferedRdr := state.NewBufferedReader(rs, baseReader)
+	ibsBefore := state.New(bufferedRdr)
+
+	gotBal, err := ibsBefore.GetBalance(addr)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), gotBal.Uint64(),
+		"before UpdateBufferedAccounts, bufferedReader must NOT see the account")
+
+	// Call UpdateBufferedAccounts — this is what the fix does.
+	rs.UpdateBufferedAccounts(writes)
+
+	// After UpdateBufferedAccounts: bufferedReader MUST see the account.
+	ibsAfter := state.New(state.NewBufferedReader(rs, baseReader))
+
+	gotBal, err = ibsAfter.GetBalance(addr)
+	require.NoError(t, err)
+	require.Equal(t, uint64(999), gotBal.Uint64(),
+		"after UpdateBufferedAccounts, bufferedReader must see the correct balance")
+
+	gotNonce, err := ibsAfter.GetNonce(addr)
+	require.NoError(t, err)
+	require.Equal(t, uint64(42), gotNonce,
+		"after UpdateBufferedAccounts, bufferedReader must see the correct nonce")
+}
+
+// TestUpdateBufferedAccountsDeletedAccount verifies that
+// UpdateBufferedAccounts correctly handles account deletion (SelfDestructPath
+// without account fields).
+func TestUpdateBufferedAccountsDeletedAccount(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires mdbx")
+	}
+
+	tx, domains := setup2CacheTest(t)
+
+	addr := accounts.InternAddress(common.HexToAddress("0xDEAD"))
+	lgr := log.New()
+
+	rs := state.NewStateV3Buffered(state.NewStateV3(domains, ethconfig.Sync{}, lgr))
+
+	// First, populate rs.accounts with a live account (simulating a previous block).
+	liveCollector := state.NewVersionedWriteCollector(rs)
+	liveAccount := &accounts.Account{Balance: *uint256.NewInt(100), Nonce: 1}
+	err := liveCollector.UpdateAccountData(addr, &accounts.Account{}, liveAccount)
+	require.NoError(t, err)
+
+	// Verify the account is visible.
+	baseReader := state.NewReaderV3(domains.AsGetter(tx))
+	ibsLive := state.New(state.NewBufferedReader(rs, baseReader))
+	gotBal, err := ibsLive.GetBalance(addr)
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), gotBal.Uint64())
+
+	// Now simulate a delete via LightCollector + UpdateBufferedAccounts.
+	delCollector := state.NewLightCollector()
+	err = delCollector.DeleteAccount(addr, liveAccount)
+	require.NoError(t, err)
+
+	rs.UpdateBufferedAccounts(delCollector.TakeWrites())
+
+	// After deletion, bufferedReader must return nil for the account.
+	ibsDeleted := state.New(state.NewBufferedReader(rs, baseReader))
+	gotBal, err = ibsDeleted.GetBalance(addr)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), gotBal.Uint64(),
+		"after UpdateBufferedAccounts with delete, account must appear deleted")
+}

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1947,6 +1947,12 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 				// collector populated by FinalizeTx in the IBS path.
 				if txResult.CollectorWrites != nil {
 					txResult.writes = txResult.CollectorWrites
+					// The direct finalizeTx path bypasses versionedWriteCollector,
+					// so rs.accounts is not updated. We must update it here to
+					// maintain the cross-block timing hole bridge: block N+1
+					// workers may read block N state via bufferedReader before
+					// the async applyResults goroutine flushes to SharedDomains.
+					pe.rs.UpdateBufferedAccounts(txResult.CollectorWrites)
 				} else {
 					txResult.writes = collector.Writes()
 				}

--- a/execution/state/rw_v3.go
+++ b/execution/state/rw_v3.go
@@ -586,6 +586,135 @@ func (c *LightCollector) WriteAccountStorage(address accounts.Address, _ uint64,
 
 func (c *LightCollector) CreateContract(_ accounts.Address) error { return nil }
 
+// UpdateBufferedAccounts updates rs.accounts from VersionedWrites to maintain
+// the cross-block timing hole bridge. This must be called during finalize for
+// any path that bypasses versionedWriteCollector (e.g. the direct finalizeTx
+// path which uses LightCollector writes).
+//
+// Without this, block N+1 workers reading via bufferedReader would see stale
+// state for accounts modified by block N's regular TXs, because:
+//   - rs.accounts wouldn't have the latest values (LightCollector doesn't update it)
+//   - SharedDomains may not have been updated yet (async applyResults)
+func (rs *StateV3Buffered) UpdateBufferedAccounts(writes VersionedWrites) {
+	if len(writes) == 0 {
+		return
+	}
+
+	type addrFields struct {
+		balance     *uint256.Int
+		nonce       *uint64
+		incarnation *uint64
+		codeHash    *accounts.CodeHash
+		code        []byte
+		storage     []storageItem
+		deleted     bool
+	}
+
+	perAddr := make(map[accounts.Address]*addrFields, len(writes)/4+1)
+	for _, w := range writes {
+		if w.Val == nil {
+			continue
+		}
+		d := perAddr[w.Address]
+		if d == nil {
+			d = &addrFields{}
+			perAddr[w.Address] = d
+		}
+		switch w.Path {
+		case BalancePath:
+			v := w.Val.(uint256.Int)
+			d.balance = &v
+		case NoncePath:
+			v := w.Val.(uint64)
+			d.nonce = &v
+		case IncarnationPath:
+			v := w.Val.(uint64)
+			d.incarnation = &v
+		case CodeHashPath:
+			v := w.Val.(accounts.CodeHash)
+			d.codeHash = &v
+		case CodePath:
+			d.code = w.Val.([]byte)
+		case SelfDestructPath:
+			// If account fields follow, this is cleanup+recreate.
+			// If no account fields follow, this is a pure delete.
+			d.deleted = true
+		case StoragePath:
+			d.storage = append(d.storage, storageItem{w.Key, w.Val.(uint256.Int)})
+		}
+	}
+
+	rs.accountsMutex.Lock()
+	defer rs.accountsMutex.Unlock()
+
+	for addr, d := range perAddr {
+		// Pure delete: selfDestruct with no account fields.
+		if d.deleted && d.balance == nil && d.nonce == nil && d.incarnation == nil && d.codeHash == nil {
+			obj, ok := rs.accounts[addr]
+			if !ok {
+				obj = &bufferedAccount{data: &deleted}
+				rs.accounts[addr] = obj
+			} else {
+				*obj = bufferedAccount{data: &deleted}
+			}
+			continue
+		}
+
+		// Account update (possibly after selfDestruct cleanup+recreate).
+		if d.balance != nil || d.nonce != nil || d.incarnation != nil || d.codeHash != nil {
+			obj, ok := rs.accounts[addr]
+			if !ok || obj.data == &deleted {
+				obj = &bufferedAccount{}
+				rs.accounts[addr] = obj
+			}
+
+			// Reconstruct account from fields. LightCollector always emits
+			// all 4 fields, so all pointers should be non-nil.
+			acc := accounts.NewAccount()
+			if d.balance != nil {
+				acc.Balance = *d.balance
+			}
+			if d.nonce != nil {
+				acc.Nonce = *d.nonce
+			}
+			if d.incarnation != nil {
+				acc.Incarnation = *d.incarnation
+			}
+			if d.codeHash != nil {
+				acc.CodeHash = *d.codeHash
+			}
+			obj.data = &acc
+		}
+
+		// Code update.
+		if d.code != nil {
+			obj, ok := rs.accounts[addr]
+			if !ok || obj.data == &deleted {
+				obj = &bufferedAccount{}
+				rs.accounts[addr] = obj
+			}
+			obj.code = d.code
+		}
+
+		// Storage updates.
+		if len(d.storage) > 0 {
+			obj, ok := rs.accounts[addr]
+			if !ok || obj.data == &deleted {
+				obj = &bufferedAccount{}
+				rs.accounts[addr] = obj
+			}
+			if obj.storage == nil {
+				obj.storage = btree.NewBTreeGOptions[storageItem](func(a, b storageItem) bool {
+					return a.key.Cmp(b.key) > 0
+				}, btree.Options{NoLocks: true})
+			}
+			for _, item := range d.storage {
+				obj.storage.Set(item)
+			}
+		}
+	}
+}
+
 // NotifyAccumulator drives txpool state-diff notifications from VersionedWrites.
 // It reconstructs account state from the per-field writes and calls
 // ChangeAccount/ChangeCode/ChangeStorage on the accumulator. StartChange must


### PR DESCRIPTION
## Problem

PR #19814's new `finalizeTx` path bypasses `versionedWriteCollector`, which means **`rs.accounts` is never updated** for regular TXs. This breaks the cross-block timing hole bridge.

### What is the timing hole bridge?

`rs.accounts` is a synchronous cache that bridges the gap between when a block's finalize results are computed and when the async `applyResults` goroutine flushes them to SharedDomains. Block N+1 workers read via `bufferedReader`, which checks `rs.accounts` first, then falls through to SharedDomains.

### Why this causes wrong trie roots

1. `finalizeTx` uses `LightCollector` (no `rs.accounts` update) instead of `versionedWriteCollector` (updates `rs.accounts`)
2. Block N+1 workers read stale state from SharedDomains (async apply hasn't caught up)
3. The parallel executor's conflict detection doesn't catch this because the validator also reads from the same stale `bufferedReader`
4. Wrong execution results are committed → wrong trie root

### Reproduction

Wrong trie root at block 1,745,211 on Hoodi (#20012).

## Fix

Add `UpdateBufferedAccounts(writes VersionedWrites)` on `StateV3Buffered` that reconstructs account/code/storage state from `VersionedWrites` and updates `rs.accounts`. Called from the finalize goroutine when using `CollectorWrites` (the direct path).

### Tests

- `TestUpdateBufferedAccountsFromCollectorWrites` — verifies `bufferedReader` sees correct state after `UpdateBufferedAccounts`
- `TestUpdateBufferedAccountsDeletedAccount` — verifies account deletion propagates correctly

Fixes #20012