### PR TITLE
ci: pin Hive version in both hive workflows

### DIFF
--- a/.github/workflows/hive-versions.json
+++ b/.github/workflows/hive-versions.json
@@ -1,0 +1,3 @@
+{
+  "hive_ref": "88786d9744dabb08bdaec8d8b53142cde6e6b79a"
+}

--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -60,18 +60,24 @@ jobs:
           fi
           echo "Pruning docker system..."
           docker system prune -af --volumes
-      - name: Checkout Erigon go.mod
+      - name: Checkout Erigon meta
         uses: actions/checkout@v6
         with:
-          sparse-checkout: go.mod
+          sparse-checkout: |
+            go.mod
+            .github/workflows/hive-versions.json
           sparse-checkout-cone-mode: false
           path: erigon-src
+
+      - name: Read pinned Hive ref
+        id: hive-version
+        run: echo "ref=$(jq -r .hive_ref erigon-src/.github/workflows/hive-versions.json)" >> "$GITHUB_OUTPUT"
 
       - name: Checkout Hive
         uses: actions/checkout@v6
         with:
           repository: ethereum/hive
-          ref: master
+          ref: ${{ steps.hive-version.outputs.ref }}
           path: hive
     
       - name: Conditional Docker Login

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -48,19 +48,25 @@ jobs:
             sim-limit: compat
             max-allowed-failures: 56 # 56 missing eth_simulateV1 MaxGasUsed in Hive tests 
     steps:
-      - name: Checkout Erigon go.mod
+      - name: Checkout Erigon meta
         uses: actions/checkout@v6
         with:
-          sparse-checkout: go.mod
+          sparse-checkout: |
+            go.mod
+            .github/workflows/hive-versions.json
           sparse-checkout-cone-mode: false
           path: erigon-src
+
+      - name: Read pinned Hive ref
+        id: hive-version
+        run: echo "ref=$(jq -r .hive_ref erigon-src/.github/workflows/hive-versions.json)" >> "$GITHUB_OUTPUT"
 
       - name: Checkout Hive
         uses: actions/checkout@v6
         with:
           repository: ethereum/hive
           # version hive and update periodically/on-demand to prevent upstream changes in Hive affecting us with red CI
-          ref: 88786d9744dabb08bdaec8d8b53142cde6e6b79a
+          ref: ${{ steps.hive-version.outputs.ref }}
           path: hive
 
       - name: Setup go env and cache


### PR DESCRIPTION
## Summary
- Upstream hive commit `cac752422d` (2026-03-19) added `--sim.limit.exact` defaulting to `true`, which `QuoteMeta`-escapes `--sim.limit` patterns. This broke all EEST shards (0 tests collected) since `test-hive-eest.yml` was checking out hive `master` (floating).
- Pin both `test-hive.yml` and `test-hive-eest.yml` to the same hive ref via `.github/workflows/hive-versions.json` so there's one place to bump.

## Test plan
- [ ] [Hive EEST tests](https://github.com/erigontech/erigon/actions/runs/23332400669) — verify all 5 shards collect >0 tests again
- [ ] [Test Hive](https://github.com/erigontech/erigon/actions/runs/23332401214) — verify engine/rpc tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)