### PR TITLE
execution: charge GAS_CREATE state gas before initcode size check

### DIFF
--- a/execution/tests/eest_devnet/block_test.go
+++ b/execution/tests/eest_devnet/block_test.go
@@ -52,7 +52,6 @@ func TestExecutionSpecBlockchainDevnet(t *testing.T) {
 	bt.SkipLoad(`^for_amsterdam/static/state_tests/`)
 	bt.SkipLoad(`^for_amsterdam/amsterdam/eip7928_block_level_access_lists/test_bal_sstore_and_oog.json`)                               // block=1, gas used by execution: 37568, in header: 63573
 	bt.SkipLoad(`^for_amsterdam/amsterdam/eip7954_increase_max_contract_size/test_max_code_size_deposit_gas.json`)                      // block=1, gas used by execution: 38601120, in header: 16777216
-	bt.SkipLoad(`^for_amsterdam/amsterdam/eip7954_increase_max_contract_size/test_max_initcode_size_via_create.json`)                   // block=1, gas used by execution: 16777216, in header: 16645728
 	bt.SkipLoad(`^for_amsterdam/amsterdam/eip8037_state_creation_gas_cost_increase/test_call_oog_reservoir_inflation_detection.json`)   // block=1, gas used by execution: 82640, in header: 214128
 	bt.SkipLoad(`^for_amsterdam/amsterdam/eip8037_state_creation_gas_cost_increase/test_sstore_oog_reservoir_inflation_detection.json`) // block=1, block access list mismatch
 	bt.SkipLoad(`^for_amsterdam/constantinople/eip1052_extcodehash/test_extcodehash_subcall_create2_oog.json`)                          // block=1, receiptHash mismatch: 39c2dfd7f2067a536d977a40ae2f2b3f3614bbef0a4eb26f49b8114d29e9805f != 8e4253c0afb1566ce113e97f42df12955f2712695f33de2b2c6ab30f654f8897, headerNum=1, 4da65b36435c944e6f68e86aa3d5ad3b796d54b0f73f5e096b31e05ae4c8d32d

--- a/execution/vm/eips.go
+++ b/execution/vm/eips.go
@@ -383,5 +383,7 @@ func enable7843(jt *JumpTable) {
 // enable8037 applies EIP-8037 (State Creation Gas Cost Increase)
 func enable8037(jt *JumpTable) {
 	jt[CREATE].constantGas = params.CreateGasEIP8037
+	jt[CREATE].dynamicGas = gasCreateEip8037
 	jt[CREATE2].constantGas = params.Create2GasEIP8037
+	jt[CREATE2].dynamicGas = gasCreate2Eip8037
 }

--- a/execution/vm/gas_table.go
+++ b/execution/vm/gas_table.go
@@ -335,9 +335,6 @@ func gasCreateEip3860(evm *EVM, callContext *CallContext, availableGas mdgas.MdG
 	if overflow {
 		return mdgas.MdGas{}, ErrGasUintOverflow
 	}
-	if evm.chainRules.IsAmsterdam {
-		gas.State += params.StateBytesNewAccount * evm.Context.CostPerStateByte
-	}
 	return gas, nil
 }
 
@@ -360,9 +357,48 @@ func gasCreate2Eip3860(evm *EVM, callContext *CallContext, availableGas mdgas.Md
 	if overflow {
 		return mdgas.MdGas{}, ErrGasUintOverflow
 	}
-	if evm.chainRules.IsAmsterdam {
-		gas.State += params.StateBytesNewAccount * evm.Context.CostPerStateByte
+	return gas, nil
+}
+
+// gasCreateEip8037 is the dynamic gas function for CREATE under EIP-8037.
+// GAS_CREATE is a pre-state cost that must always be charged, so the initcode
+// size is capped (not rejected) here; the actual check happens in opCreate.
+func gasCreateEip8037(evm *EVM, callContext *CallContext, availableGas mdgas.MdGas, memorySize uint64) (gas mdgas.MdGas, err error) {
+	gas.Regular, err = memoryGasCost(callContext, memorySize)
+	if err != nil {
+		return mdgas.MdGas{}, err
 	}
+	size, overflow := callContext.Stack.Back(2).Uint64WithOverflow()
+	if overflow {
+		return mdgas.MdGas{}, ErrGasUintOverflow
+	}
+	wordSize := min(size, params.MaxInitCodeSizeAmsterdam)
+	wordGas := params.InitCodeWordGas * ToWordSize(wordSize)
+	gas.Regular, overflow = math.SafeAdd(gas.Regular, wordGas)
+	if overflow {
+		return mdgas.MdGas{}, ErrGasUintOverflow
+	}
+	gas.State = params.StateBytesNewAccount * evm.Context.CostPerStateByte
+	return gas, nil
+}
+
+// gasCreate2Eip8037 is the dynamic gas function for CREATE2 under EIP-8037.
+func gasCreate2Eip8037(evm *EVM, callContext *CallContext, availableGas mdgas.MdGas, memorySize uint64) (gas mdgas.MdGas, err error) {
+	gas.Regular, err = memoryGasCost(callContext, memorySize)
+	if err != nil {
+		return mdgas.MdGas{}, err
+	}
+	size, overflow := callContext.Stack.Back(2).Uint64WithOverflow()
+	if overflow {
+		return mdgas.MdGas{}, ErrGasUintOverflow
+	}
+	wordSize := min(size, params.MaxInitCodeSizeAmsterdam)
+	wordGas := (params.InitCodeWordGas + params.Keccak256WordGas) * ToWordSize(wordSize)
+	gas.Regular, overflow = math.SafeAdd(gas.Regular, wordGas)
+	if overflow {
+		return mdgas.MdGas{}, ErrGasUintOverflow
+	}
+	gas.State = params.StateBytesNewAccount * evm.Context.CostPerStateByte
 	return gas, nil
 }
 

--- a/execution/vm/instructions.go
+++ b/execution/vm/instructions.go
@@ -988,6 +988,16 @@ func opCreate(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) {
 	if evm.ChainRules().IsTangerineWhistle {
 		gas.Regular -= gas.Regular / 64
 	}
+
+	// EIP-7954: check initcode size after gas is charged (by the dynamic gas
+	// function) but before execution. This ensures GAS_CREATE state gas is
+	// always consumed while oversized initcode aborts the caller's frame.
+	if evm.ChainRules().IsAmsterdam {
+		if err := CheckMaxInitCodeSize(uint64(len(input)), evm.ChainRules().IsShanghai, evm.ChainRules().IsAmsterdam); err != nil {
+			return pc, nil, err
+		}
+	}
+
 	// reuse size int for stackvalue
 	stackvalue := size
 
@@ -1045,6 +1055,16 @@ func opCreate2(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) 
 
 	// Apply EIP150
 	gas.Regular -= gas.Regular / 64
+
+	// EIP-7954: check initcode size after gas is charged (by the dynamic gas
+	// function) but before execution. This ensures GAS_CREATE state gas is
+	// always consumed while oversized initcode aborts the caller's frame.
+	if evm.ChainRules().IsAmsterdam {
+		if err := CheckMaxInitCodeSize(uint64(len(input)), evm.ChainRules().IsShanghai, evm.ChainRules().IsAmsterdam); err != nil {
+			return pc, nil, err
+		}
+	}
+
 	scope.useGas(gas.Regular, evm.Config().Tracer, tracing.GasChangeCallContractCreation2)
 	// reuse size int for stackvalue
 	stackValue := size


### PR DESCRIPTION
## Summary
- EIP-8037 specifies GAS_CREATE as a pre-state cost that must always be charged, even when initcode exceeds max size. Our `gasCreateEip3860` checked `CheckMaxInitCodeSize` before adding state gas (112×cpsb), so oversized initcode OOG'd without state gas ever being charged. Block gas was 16777216 instead of expected 16645728.
- For Amsterdam, cap word gas at `MaxInitCodeSizeAmsterdam` in the dynamic gas functions and always charge state gas. Move the initcode size check into `opCreate`/`opCreate2` after gas is charged, matching go-ethereum's approach.
- Unskip `test_max_initcode_size_via_create` which now passes all 4 subtests.

## Test plan
- [x] `TestExecutionSpecBlockchainDevnet/.../test_max_initcode_size_via_create` — all 4 subtests pass (at_max + over_max for CREATE and CREATE2)
- [x] All EIP-7954 devnet tests pass
- [x] `TestState/stCreateTest` — no regressions
- [x] Verified go-ethereum `bal-devnet-3` passes the same test

🤖 Generated with [Claude Code](https://claude.com/claude-code)