### PR TITLE
stagedsync: use finalizeWithIBS only for Amsterdam blocks

### DIFF
--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1932,7 +1932,13 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 
 				collector := state.NewVersionedWriteCollector(pe.rs)
 
-				balActive := pe.cfg.experimentalBAL || pe.cfg.chainConfig.IsAmsterdam(txTask.BlockTime())
+				// Use finalizeWithIBS only for actual Amsterdam blocks where BAL
+				// is consensus-critical. The experimentalBAL flag generates BAL
+				// data at the block level (ProcessBAL) but must not change the
+				// TX finalization path — finalizeWithIBS has state-computation
+				// bugs during reorgs (wrong trie roots from arithmetic
+				// reconstruction of fee-adjusted balances).
+				balActive := pe.cfg.chainConfig.IsAmsterdam(txTask.BlockTime())
 				_, addReads, addWrites, err := txResult.finalize(prevReceipt, pe.cfg.engine, be.versionMap, stateReader, collector, balActive)
 
 				if err != nil {


### PR DESCRIPTION
## Summary

- Use `finalizeWithIBS` only for actual Amsterdam blocks where BAL is consensus-critical
- The `experimentalBAL` flag still generates BAL data at the block level (`ProcessBAL`) but no longer forces the buggy TX finalization path on pre-Amsterdam blocks
- Fixes deterministic "Wrong trie root" errors during chain reorganizations when `Exec3Parallel=true`

## Details

The parallel executor's `finalizeWithIBS` path reconstructs fee-adjusted balances arithmetically from stripped deltas + VersionMap base values. This produces wrong trie roots when the base values are stale — which happens reliably during reorgs.

Previously, `balActive` was set when either `experimentalBAL` or `IsAmsterdam` was true:
```go
balActive := pe.cfg.experimentalBAL || pe.cfg.chainConfig.IsAmsterdam(txTask.BlockTime())
```

This forced `finalizeWithIBS` on all blocks when `experimentalBAL=true` (the new default), even pre-Amsterdam blocks that don't need BAL for consensus. The fix restricts it to actual Amsterdam blocks:
```go
balActive := pe.cfg.chainConfig.IsAmsterdam(txTask.BlockTime())
```

Failing tests before fix:
- `TestCallTraceUnwind` (wrong root at block 6)
- `TestLongerForkHeaders`, `TestLongerForkBlocks` (wrong root at block 6)
- `TestBlockchainHeaderchainReorgConsistency` ("unfold: empty branch data")
- `TestLowDiffLongChain` (wrong root at block 12)
- `TestEngineApiHighGasContractsFillBlock` (wrong root at block 2)
- `TestTxLookupUnwind`, `TestRecreateAndRewind`

## Test plan

- [x] `make lint` clean
- [x] `make erigon` builds
- [ ] All tests: https://github.com/erigontech/erigon/actions/runs/23365088574
- [ ] Hive: https://github.com/erigontech/erigon/actions/runs/23365089309

🤖 Generated with [Claude Code](https://claude.com/claude-code)