### PR TITLE
Makefile: use gotestsum for test output formatting

### DIFF
--- a/.github/actions/setup-erigon/action.yml
+++ b/.github/actions/setup-erigon/action.yml
@@ -241,6 +241,10 @@ runs:
         # We have our own caching because we smrt.
         cache: false
 
+    - name: Install gotestsum
+      shell: bash
+      run: go install gotest.tools/gotestsum@latest
+
     # TODO: Make this optional, it's possibly not needed for lints and a few other quick things.
     - name: Install dependencies on Linux
       if: ${{ runner.os == 'Linux' }}

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ default_test_timeout      := 20m
 default_test_race_timeout := 60m
 
 GOTEST_PACKAGES = ./...
-GOTEST = $(GO_BUILD_ENV) GODEBUG=$(GODEBUG) GOTRACEBACK=1 $(GO) test $(GO_FLAGS) $(GOTEST_PACKAGES)
+GOTEST = $(GO_BUILD_ENV) GODEBUG=$(GODEBUG) GOTRACEBACK=1 gotestsum --raw-command --no-color=false --format-hide-empty-pkg --hide-summary=skipped -- $(GO) test -json $(GO_FLAGS) $(GOTEST_PACKAGES)
 
 GOINSTALL = go install -trimpath
 
@@ -217,7 +217,7 @@ else
 endif
 
 test-filtered:
-	(set -o pipefail && $(GOTEST) | ./tools/filter-test-output | tee run.log)
+	(set -o pipefail && $(GOTEST) | tee run.log)
 
 test-short: override GO_FLAGS += -short -failfast
 test-short: test-filtered


### PR DESCRIPTION
Replace the custom `filter-test-output` pipe with `gotestsum --raw-command` for cleaner, coloured test output with empty package hiding and skipped summary suppression.