### PR TITLE
Makefile: auto-create RAM disk for test-all on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,6 +217,16 @@ else
 endif
 
 test-filtered:
+	@_rd=""; \
+	_cleanup() { [ -n "$$_rd" ] && hdiutil detach -force "$$_rd" >/dev/null 2>&1 || true; }; \
+	trap _cleanup EXIT; \
+	if [ -z "$${ERIGON_EXECUTION_TESTS_TMPDIR:-}" ] && [ "$$(uname -s)" = "Darwin" ]; then \
+		_rd=$$(bash tools/create-ramdisk) || true; \
+		if [ -n "$$_rd" ]; then \
+			export ERIGON_EXECUTION_TESTS_TMPDIR="$$_rd"; \
+			echo "ramdisk: $$_rd"; \
+		fi; \
+	fi; \
 	(set -o pipefail && $(GOTEST) | ./tools/filter-test-output | tee run.log)
 
 test-short: override GO_FLAGS += -short -failfast


### PR DESCRIPTION
## Summary
- `make test-all` was failing locally on macOS because EEST execution tests (eest_devnet, eest_blockchain) exceed the 20m timeout when competing for disk I/O without a RAM disk
- CI avoids this on Linux by creating a RAM disk via `tools/create-ramdisk` — now `test-all` and `test-all-race` do the same on macOS (no sudo required), using the existing `tools/create-ramdisk` script
- The RAM disk is auto-cleaned on exit (including Ctrl-C); users who already set `ERIGON_EXECUTION_TESTS_TMPDIR` are unaffected

Before: `eest_devnet` took 1203s → timeout at 20m
After: `eest_devnet` took 453s → well within 20m

## Test plan
- [x] `make test-all` passes locally on macOS (all packages green, ramdisk auto-cleaned)
- [ ] Verify `make test-all` still works on Linux (no-op — ramdisk creation gated by `uname -s = Darwin`)
- [ ] Verify `ERIGON_EXECUTION_TESTS_TMPDIR=/some/path make test-all` skips ramdisk creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)