### PR TITLE
merge: prioritize `Domain` merge over `StandeloneInvIdx`

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -56,6 +56,10 @@ Cherry-pick PRs: when opening a PR that cherry-picks a commit to a `release/X.Y`
 
 **Important**: Always run `make lint` after making code changes and before committing. Fix any linter errors before proceeding. PRs must pass `make lint` before being opened or updated.
 
+## Pre-push
+
+Before running `git push`, always run `make lint` first and fix all issues. Run lint multiple times if needed — it is non-deterministic.
+
 ## Lint Notes
 
 The linter (`make lint`) is non-deterministic in which files it scans — new issues may appear on subsequent runs. Run lint repeatedly until clean.

--- a/db/state/aggregator_bench_test.go
+++ b/db/state/aggregator_bench_test.go
@@ -451,7 +451,8 @@ func BenchmarkAggregator_BeginFilesRo_Latency(b *testing.B) {
 }
 
 var parallel = flag.Int("bench.parallel", 1, "parallelism value") // runs 1 *maxprocs
-var loopv = flag.Int("bench.loopv", 100000, "loop value")
+var cpuIters = flag.Int("bench.cpu-iters", 1000, "CPU work iterations between BeginFilesRo and Close")
+var sleepMs = flag.Int("bench.sleep-ms", 5, "sleep duration in milliseconds between BeginRo and Rollback")
 
 func BenchmarkAggregator_BeginFilesRo_Throughput(b *testing.B) {
 	// RESULT: deteriorates after 2^21 goroutines
@@ -461,7 +462,7 @@ func BenchmarkAggregator_BeginFilesRo_Throughput(b *testing.B) {
 		cpus=$((1 << $cpu))  # Same as 2^cpu
 		echo -n "($cpus, "
 		echo -n $(go test -benchmem -run=^$ -bench ^BenchmarkAggregator_BeginFilesRo_Throughput$ github.com/erigontech/erigon/db/state  \
-		-bench.parallel=$cpus -bench.loopv=1000 | grep 'BenchmarkAggregator_BeginFilesRo_Throughput' | cut -f3 | xargs|cut -d' ' -f1)
+		-bench.parallel=$cpus -bench.cpu-iters=1000 | grep 'BenchmarkAggregator_BeginFilesRo_Throughput' | cut -f3 | xargs|cut -d' ' -f1)
 		echo -n "), "
 	done
 	**/
@@ -469,7 +470,7 @@ func BenchmarkAggregator_BeginFilesRo_Throughput(b *testing.B) {
 	if !flag.Parsed() {
 		flag.Parse()
 	}
-	//b.Logf("Running with parallel=%d work=%d, #goroutines:%d", *parallel, *loopv, *parallel*runtime.GOMAXPROCS(0))
+	//b.Logf("Running with parallel=%d work=%d, #goroutines:%d", *parallel, *cpuIters, *parallel*runtime.GOMAXPROCS(0))
 
 	aggStep := uint64(100_00)
 	_, agg := testDbAndAggregatorBench(b, aggStep)
@@ -479,7 +480,7 @@ func BenchmarkAggregator_BeginFilesRo_Throughput(b *testing.B) {
 		foo := 0
 		for b.Next() {
 			tx := agg.BeginFilesRo()
-			for i := 0; i < *loopv; i++ {
+			for i := 0; i < *cpuIters; i++ {
 				foo *= 2
 				foo /= 2
 			}
@@ -496,7 +497,7 @@ func BenchmarkDb_BeginFiles_Throughput(b *testing.B) {
 	    cpus=$((1 << $cpu))  # Same as 2^cpu
 	    echo -n "($cpus, "
 	    echo -n $(go test -benchmem -run=^$ -bench ^BenchmarkDb_BeginFiles_Throughput$ github.com/erigontech/erigon/db/state  \
-		-bench.parallel=$cpus -bench.loopv=1000 | grep 'BenchmarkDb_BeginFiles_Throughput' | cut -f3 | xargs|cut -d' ' -f1)
+		-bench.parallel=$cpus -bench.sleep-ms=1000 | grep 'BenchmarkDb_BeginFiles_Throughput' | cut -f3 | xargs|cut -d' ' -f1)
 	    echo -n "), "
 	done
 	**/
@@ -505,7 +506,7 @@ func BenchmarkDb_BeginFiles_Throughput(b *testing.B) {
 	if !flag.Parsed() {
 		flag.Parse()
 	}
-	//b.Logf("Running with parallel=%d work=%d, #goroutines:%d", *parallel, *loopv, *parallel*runtime.GOMAXPROCS(0))
+	//b.Logf("Running with parallel=%d work=%d, #goroutines:%d", *parallel, *sleepMs, *parallel*runtime.GOMAXPROCS(0))
 
 	aggStep := uint64(100_00)
 	db, _ := testDbAndAggregatorBench(b, aggStep)
@@ -519,13 +520,7 @@ func BenchmarkDb_BeginFiles_Throughput(b *testing.B) {
 			if err != nil {
 				b.Fatalf("%v", err)
 			}
-			millis := *loopv * 1000000
-			time.Sleep(time.Duration(int64(millis)))
-
-			// for i := 0; i < *loopv; i++ {
-			// 	foo *= 2
-			// 	foo /= 2
-			// }
+			time.Sleep(time.Duration(*sleepMs) * time.Millisecond)
 			tx.Rollback()
 		}
 	})

--- a/execution/tests/testutil/temporal_db.go
+++ b/execution/tests/testutil/temporal_db.go
@@ -18,6 +18,8 @@ package testutil
 
 import (
 	"context"
+	"os"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -29,11 +31,25 @@ import (
 	"github.com/erigontech/erigon/db/state/execctx"
 )
 
+func SkipOnWindows(t testing.TB) {
+	t.Helper()
+	if runtime.GOOS == "windows" && os.Getenv("ERIGON_NO_SKIP_EXECUTION_TESTS") == "" {
+		t.Skip("skipped on Windows; set ERIGON_NO_SKIP_EXECUTION_TESTS=1 to run")
+	}
+}
+
 func TemporalDB(t testing.TB) kv.TemporalRwDB {
 	return TemporalDBWithDirs(t, datadir.New(t.TempDir()))
 }
 
 func TemporalDBWithDirs(t testing.TB, dirs datadir.Dirs) kv.TemporalRwDB {
+	// Skip on Windows: MDBX correctness is thoroughly exercised by the unit and
+	// integration tests in the main repo (execution/state, execution/stagedsync,
+	// db/kv/mdbx, db/state, etc.) which run on all platforms. The spec-test
+	// suites here (ethereum/execution-spec-tests, legacy blockchain tests) verify
+	// EVM and consensus correctness, which is platform-independent; running them
+	// on Linux is sufficient. Set ERIGON_NO_SKIP_EXECUTION_TESTS=1 to force on Windows.
+	SkipOnWindows(t)
 	return temporaltest.NewTestDB(t, dirs)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -22,12 +22,12 @@ require (
 	github.com/RoaringBitmap/roaring/v2 v2.14.4
 	github.com/alecthomas/kong v0.8.1
 	github.com/anacrolix/envpprof v1.5.0
-	github.com/anacrolix/generics v0.1.1-0.20251125230353-15d98d46693b
+	github.com/anacrolix/generics v0.2.0
 	github.com/anacrolix/go-libutp v1.3.3-0.20251121015447-f294e5ed5b4d
 	github.com/anacrolix/log v0.17.1-0.20251118025802-918f1157b7bb
 	github.com/anacrolix/missinggo/v2 v2.10.0
 	github.com/anacrolix/sync v0.5.5-0.20251119100342-d78dd1f686f1
-	github.com/anacrolix/torrent v1.61.1-0.20260205044246-b4fcea2871e5
+	github.com/anacrolix/torrent v1.61.1-0.20260306043331-7dea980541ac
 	github.com/benesch/cgosymbolizer v0.0.0-20190515212042-bec6fe6e597b
 	github.com/c2h5oh/datasize v0.0.0-20231215233829-aa82cc1e6500
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,8 @@ github.com/anacrolix/envpprof v1.1.0/go.mod h1:My7T5oSqVfEn4MD4Meczkw/f5lSIndGAK
 github.com/anacrolix/envpprof v1.5.0 h1:eMI07YWjk86b+8N9A4k0OtLSS472/1Z0qraAW2oPZb4=
 github.com/anacrolix/envpprof v1.5.0/go.mod h1:OQPV3SNK6uVAlXL4slcZVXv+xLcE0ybWgVKcUfr5fE8=
 github.com/anacrolix/generics v0.0.0-20230113004304-d6428d516633/go.mod h1:ff2rHB/joTV03aMSSn/AZNnaIpUw0h3njetGsaXcMy8=
-github.com/anacrolix/generics v0.1.1-0.20251125230353-15d98d46693b h1:Kuvx/A/TTJuT9x8mn7DeGx2KW9tWn1LI8bira67xdT0=
-github.com/anacrolix/generics v0.1.1-0.20251125230353-15d98d46693b/go.mod h1:NGehhfeXJPBujPx0s6cstSj8B+TERsTY32Xckfx5ftc=
+github.com/anacrolix/generics v0.2.0 h1:gPwGOs14irokFN9kUP1i1A0Bn0FPT7/hWWD3hHKSKNw=
+github.com/anacrolix/generics v0.2.0/go.mod h1:NGehhfeXJPBujPx0s6cstSj8B+TERsTY32Xckfx5ftc=
 github.com/anacrolix/go-libutp v1.3.3-0.20251121015447-f294e5ed5b4d h1:HzCiW9zyO7fv4sKZU5k+pGn/m/FhxTOKwKiVIO3Uhig=
 github.com/anacrolix/go-libutp v1.3.3-0.20251121015447-f294e5ed5b4d/go.mod h1:2XL3ViU/7+l/kB6poGICETXdEVRdTALyqQrKFBCkBc4=
 github.com/anacrolix/log v0.3.0/go.mod h1:lWvLTqzAnCWPJA08T2HCstZi0L1y2Wyvm3FJgwU9jwU=
@@ -145,8 +145,8 @@ github.com/anacrolix/sync v0.5.5-0.20251119100342-d78dd1f686f1/go.mod h1:21cUWer
 github.com/anacrolix/tagflag v0.0.0-20180109131632-2146c8d41bf0/go.mod h1:1m2U/K6ZT+JZG0+bdMK6qauP49QT4wE5pmhJXOKKCHw=
 github.com/anacrolix/tagflag v1.0.0/go.mod h1:1m2U/K6ZT+JZG0+bdMK6qauP49QT4wE5pmhJXOKKCHw=
 github.com/anacrolix/tagflag v1.1.0/go.mod h1:Scxs9CV10NQatSmbyjqmqmeQNwGzlNe0CMUMIxqHIG8=
-github.com/anacrolix/torrent v1.61.1-0.20260205044246-b4fcea2871e5 h1:RjSwlTCefJzsX1fSWAjtFbrREVmFCznQSh4BowIb+nE=
-github.com/anacrolix/torrent v1.61.1-0.20260205044246-b4fcea2871e5/go.mod h1:99HuZswKVFJaolion++ekIiF52WDiEtQJqqib4IPdZc=
+github.com/anacrolix/torrent v1.61.1-0.20260306043331-7dea980541ac h1:gpzbmV0sooJvesid+HTgoG/bR8IS38k6jbD1hyHI04M=
+github.com/anacrolix/torrent v1.61.1-0.20260306043331-7dea980541ac/go.mod h1:CJaFHVYZv9k3btNExGGHIXjI6vvGb10QoCRWOKpUd10=
 github.com/anacrolix/upnp v0.1.4 h1:+2t2KA6QOhm/49zeNyeVwDu1ZYS9dB9wfxyVvh/wk7U=
 github.com/anacrolix/upnp v0.1.4/go.mod h1:Qyhbqo69gwNWvEk1xNTXsS5j7hMHef9hdr984+9fIic=
 github.com/anacrolix/utp v0.1.0 h1:FOpQOmIwYsnENnz7tAGohA+r6iXpRjrq8ssKSre2Cp4=

--- a/node/cli/config_file.go
+++ b/node/cli/config_file.go
@@ -55,8 +55,14 @@ func SetFlagsFromConfigFile(ctx *cli.Context, filePath string) error {
 	} else {
 		return errors.New("config files only accepted are .yaml and .toml")
 	}
+
+	// Flatten nested maps into dot-separated keys so that TOML nested tables
+	// (e.g. [sentinel] / staticpeers = [...]) and TOML dotted keys
+	// (e.g. sentinel.staticpeers = [...]) map to the correct CLI flag names.
+	flat := flattenConfig(fileConfig, "")
+
 	// sets global flags to value in yaml/toml file
-	for key, value := range fileConfig {
+	for key, value := range flat {
 		if !ctx.IsSet(key) {
 			if reflect.ValueOf(value).Kind() == reflect.Slice {
 				sliceInterface := value.([]any)
@@ -79,4 +85,41 @@ func SetFlagsFromConfigFile(ctx *cli.Context, filePath string) error {
 	}
 
 	return nil
+}
+
+// flattenConfig recursively flattens a nested map[string]any into a flat map
+// using dot-separated keys. This lets TOML nested tables and dotted keys both
+// map naturally to CLI flag names (e.g. sentinel.staticpeers).
+func flattenConfig(m map[string]any, prefix string) map[string]any {
+	result := make(map[string]any)
+	for k, v := range m {
+		key := k
+		if prefix != "" {
+			key = prefix + "." + k
+		}
+		if nested, ok := v.(map[string]any); ok {
+			for fk, fv := range flattenConfig(nested, key) {
+				result[fk] = fv
+			}
+		} else if nested, ok := v.(map[any]any); ok {
+			// gopkg.in/yaml.v2 unmarshals maps as map[interface{}]interface{}
+			converted := convertYAMLMap(nested)
+			for fk, fv := range flattenConfig(converted, key) {
+				result[fk] = fv
+			}
+		} else {
+			result[key] = v
+		}
+	}
+	return result
+}
+
+// convertYAMLMap converts a map[any]any (produced by gopkg.in/yaml.v2) to
+// map[string]any so it can be processed uniformly.
+func convertYAMLMap(m map[any]any) map[string]any {
+	result := make(map[string]any, len(m))
+	for k, v := range m {
+		result[fmt.Sprintf("%v", k)] = v
+	}
+	return result
 }

--- a/node/cli/config_file_test.go
+++ b/node/cli/config_file_test.go
@@ -1,0 +1,94 @@
+// Copyright 2024 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+func TestSetFlagsFromConfigFile_StaticPeers(t *testing.T) {
+	staticPeersFlag := cli.StringFlag{
+		Name:  "staticpeers",
+		Usage: "Comma separated enode URLs to connect to",
+		Value: "",
+	}
+	sentinelStaticPeersFlag := cli.StringSliceFlag{
+		Name:  "sentinel.staticpeers",
+		Usage: "connect to comma-separated Consensus static peers",
+	}
+
+	tests := []struct {
+		name                    string
+		toml                    string
+		wantStaticPeers         string
+		wantSentinelStaticPeers []string
+	}{
+		{
+			name:            "EL staticpeers as TOML array",
+			toml:            "staticpeers = [\"enode://abc@1.2.3.4:30303\", \"enode://def@5.6.7.8:30303\"]\n",
+			wantStaticPeers: "enode://abc@1.2.3.4:30303,enode://def@5.6.7.8:30303",
+		},
+		{
+			name:            "EL staticpeers as TOML string",
+			toml:            "staticpeers = \"enode://abc@1.2.3.4:30303,enode://def@5.6.7.8:30303\"\n",
+			wantStaticPeers: "enode://abc@1.2.3.4:30303,enode://def@5.6.7.8:30303",
+		},
+		{
+			name:                    "CL sentinel.staticpeers as TOML dotted key",
+			toml:                    "sentinel.staticpeers = [\"enode://abc@1.2.3.4:9000\", \"enode://def@5.6.7.8:9000\"]\n",
+			wantSentinelStaticPeers: []string{"enode://abc@1.2.3.4:9000", "enode://def@5.6.7.8:9000"},
+		},
+		{
+			name:                    "CL sentinel.staticpeers as TOML nested table",
+			toml:                    "[sentinel]\nstaticpeers = [\"enode://abc@1.2.3.4:9000\", \"enode://def@5.6.7.8:9000\"]\n",
+			wantSentinelStaticPeers: []string{"enode://abc@1.2.3.4:9000", "enode://def@5.6.7.8:9000"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			cfgFile := filepath.Join(tmpDir, "erigon.toml")
+			require.NoError(t, os.WriteFile(cfgFile, []byte(tt.toml), 0o600))
+
+			app := cli.NewApp()
+			app.Flags = []cli.Flag{&staticPeersFlag, &sentinelStaticPeersFlag}
+			app.Action = func(ctx *cli.Context) error {
+				err := SetFlagsFromConfigFile(ctx, cfgFile)
+				require.NoError(t, err)
+
+				if tt.wantStaticPeers != "" {
+					require.True(t, ctx.IsSet("staticpeers"), "ctx.IsSet(staticpeers) should be true")
+					require.Equal(t, tt.wantStaticPeers, ctx.String("staticpeers"))
+				}
+				if tt.wantSentinelStaticPeers != nil {
+					require.True(t, ctx.IsSet("sentinel.staticpeers"), "ctx.IsSet(sentinel.staticpeers) should be true")
+					require.Equal(t, tt.wantSentinelStaticPeers, ctx.StringSlice("sentinel.staticpeers"))
+				}
+				return nil
+			}
+
+			err := app.Run([]string{"erigon"})
+			require.NoError(t, err)
+		})
+	}
+}

--- a/txnprovider/txpool/pool_test.go
+++ b/txnprovider/txpool/pool_test.go
@@ -1803,7 +1803,7 @@ func BenchmarkProcessRemoteTxns(b *testing.B) {
 
 	// Run the benchmark: process transactions one by one
 	// This measures the performance of adding and processing remote transactions
-	for i := 0; b.Loop(); i++ {
+	for i := 0; i < b.N; i++ {
 		pool.AddRemoteTxns(ctx, TxnSlots{testTxns.Txns[i : i+1], testTxns.Senders[i : i+1], testTxns.IsLocal[i : i+1]})
 		err := pool.processRemoteTxns(ctx)
 		require.NoError(err)


### PR DESCRIPTION
todo: if any domain has pending merges, skip II merges this round.

before: can see things like
```
INFO[03-22|14:06:53.367] [snapshots] merge state accounts(val=0-1024), storage(val=0-1024), code(val=1024-1088), commitment(val=0-1024), receipt(val=1088-1104), rcache(val=1088-1104), logaddrs(768-1024), logtopics(768-1024), tracesfrom(768-1024), tracesto(768-1024)
```