### PR TITLE
db, tests: fix data race in Aggregator.EnableDomain during parallel tests

### DIFF
--- a/db/rawdb/accessors_chain_test.go
+++ b/db/rawdb/accessors_chain_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/memdb"
 	"github.com/erigontech/erigon/db/rawdb"
-	"github.com/erigontech/erigon/db/state"
 	"github.com/erigontech/erigon/db/state/execctx"
 	chainspec "github.com/erigontech/erigon/execution/chain/spec"
 	"github.com/erigontech/erigon/execution/execmodule/execmoduletester"
@@ -737,8 +736,7 @@ func TestHeadStorage(t *testing.T) {
 		t.Skip("slow test")
 	}
 	t.Parallel()
-	m := execmoduletester.New(t)
-	m.DB.(state.HasAgg).Agg().(*state.Aggregator).EnableDomain(kv.RCacheDomain)
+	m := execmoduletester.New(t, execmoduletester.WithEnableDomain(kv.RCacheDomain))
 	tx, err := m.DB.BeginRw(m.Ctx)
 	require.NoError(t, err)
 	defer tx.Rollback()
@@ -765,8 +763,7 @@ func TestBlockReceiptStorage(t *testing.T) {
 		t.Skip("slow test")
 	}
 	t.Parallel()
-	m := execmoduletester.New(t)
-	m.DB.(state.HasAgg).Agg().(*state.Aggregator).EnableDomain(kv.RCacheDomain)
+	m := execmoduletester.New(t, execmoduletester.WithEnableDomain(kv.RCacheDomain))
 	tx, err := m.DB.BeginTemporalRw(m.Ctx)
 	require.NoError(t, err)
 	defer tx.Rollback()

--- a/execution/execmodule/execmoduletester/exec_module_tester.go
+++ b/execution/execmodule/execmoduletester/exec_module_tester.go
@@ -51,6 +51,7 @@ import (
 	"github.com/erigontech/erigon/db/services"
 	"github.com/erigontech/erigon/db/snapshotsync/freezeblocks"
 	"github.com/erigontech/erigon/db/snaptype"
+	dbstate "github.com/erigontech/erigon/db/state"
 	"github.com/erigontech/erigon/execution/builder"
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/execmodule"
@@ -316,6 +317,12 @@ func WithChainConfig(cfg *chain.Config) Option {
 	}
 }
 
+func WithEnableDomain(domains ...kv.Domain) Option {
+	return func(opts *options) {
+		opts.enableDomains = append(opts.enableDomains, domains...)
+	}
+}
+
 type options struct {
 	stepSize        *uint64
 	experimentalBAL bool
@@ -326,6 +333,7 @@ type options struct {
 	pruneMode       *prune.Mode
 	blockBufferSize int
 	withTxPool      bool
+	enableDomains   []kv.Domain
 }
 
 func applyOptions(opts []Option) options {
@@ -693,6 +701,14 @@ func New(tb testing.TB, opts ...Option) *ExecModuleTester {
 	mock.ForkValidator = mock.ExecModule.ForkValidator()
 
 	mock.sentriesClient.Hd.StartPoSDownloader(mock.Ctx, sendHeaderRequest, penalize)
+
+	// Enable optional domains before starting background goroutines to avoid data races.
+	if len(opt.enableDomains) > 0 {
+		agg := mock.DB.(dbstate.HasAgg).Agg().(*dbstate.Aggregator)
+		for _, domain := range opt.enableDomains {
+			agg.EnableDomain(domain)
+		}
+	}
 
 	mock.StreamWg.Add(1)
 	mock.bgComponentsEg.Go(func() error {


### PR DESCRIPTION
## Summary

- Fix data race between `Aggregator.EnableDomain()` and background goroutines started by `ExecModuleTester.New()`
- `TestHeadStorage` and `TestBlockReceiptStorage` called `EnableDomain(kv.RCacheDomain)` after `New()` returned, racing with sentry message loops that read `Domain.Disable`

### Fix

Add `WithEnableDomain(domains...)` option to `ExecModuleTester` that calls `EnableDomain` inside `New()` before starting background goroutines, ensuring no concurrent access.

## Test plan

- [x] `TestHeadStorage` and `TestBlockReceiptStorage` pass with `-race`
- [x] `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)