### PR TITLE
[r3.4] db/state, txpool: benchmark fixes and bench flag improvements

### DIFF
--- a/db/state/aggregator_bench_test.go
+++ b/db/state/aggregator_bench_test.go
@@ -451,7 +451,8 @@ func BenchmarkAggregator_BeginFilesRo_Latency(b *testing.B) {
 }
 
 var parallel = flag.Int("bench.parallel", 1, "parallelism value") // runs 1 *maxprocs
-var loopv = flag.Int("bench.loopv", 100000, "loop value")
+var cpuIters = flag.Int("bench.cpu-iters", 1000, "CPU work iterations between BeginFilesRo and Close")
+var sleepMs = flag.Int("bench.sleep-ms", 5, "sleep duration in milliseconds between BeginRo and Rollback")
 
 func BenchmarkAggregator_BeginFilesRo_Throughput(b *testing.B) {
 	// RESULT: deteriorates after 2^21 goroutines
@@ -461,7 +462,7 @@ func BenchmarkAggregator_BeginFilesRo_Throughput(b *testing.B) {
 		cpus=$((1 << $cpu))  # Same as 2^cpu
 		echo -n "($cpus, "
 		echo -n $(go test -benchmem -run=^$ -bench ^BenchmarkAggregator_BeginFilesRo_Throughput$ github.com/erigontech/erigon/db/state  \
-		-bench.parallel=$cpus -bench.loopv=1000 | grep 'BenchmarkAggregator_BeginFilesRo_Throughput' | cut -f3 | xargs|cut -d' ' -f1)
+		-bench.parallel=$cpus -bench.cpu-iters=1000 | grep 'BenchmarkAggregator_BeginFilesRo_Throughput' | cut -f3 | xargs|cut -d' ' -f1)
 		echo -n "), "
 	done
 	**/
@@ -469,7 +470,7 @@ func BenchmarkAggregator_BeginFilesRo_Throughput(b *testing.B) {
 	if !flag.Parsed() {
 		flag.Parse()
 	}
-	//b.Logf("Running with parallel=%d work=%d, #goroutines:%d", *parallel, *loopv, *parallel*runtime.GOMAXPROCS(0))
+	//b.Logf("Running with parallel=%d work=%d, #goroutines:%d", *parallel, *cpuIters, *parallel*runtime.GOMAXPROCS(0))
 
 	aggStep := uint64(100_00)
 	_, agg := testDbAndAggregatorBench(b, aggStep)
@@ -479,7 +480,7 @@ func BenchmarkAggregator_BeginFilesRo_Throughput(b *testing.B) {
 		foo := 0
 		for b.Next() {
 			tx := agg.BeginFilesRo()
-			for i := 0; i < *loopv; i++ {
+			for i := 0; i < *cpuIters; i++ {
 				foo *= 2
 				foo /= 2
 			}
@@ -496,7 +497,7 @@ func BenchmarkDb_BeginFiles_Throughput(b *testing.B) {
 	    cpus=$((1 << $cpu))  # Same as 2^cpu
 	    echo -n "($cpus, "
 	    echo -n $(go test -benchmem -run=^$ -bench ^BenchmarkDb_BeginFiles_Throughput$ github.com/erigontech/erigon/db/state  \
-		-bench.parallel=$cpus -bench.loopv=1000 | grep 'BenchmarkDb_BeginFiles_Throughput' | cut -f3 | xargs|cut -d' ' -f1)
+		-bench.parallel=$cpus -bench.sleep-ms=1000 | grep 'BenchmarkDb_BeginFiles_Throughput' | cut -f3 | xargs|cut -d' ' -f1)
 	    echo -n "), "
 	done
 	**/
@@ -505,7 +506,7 @@ func BenchmarkDb_BeginFiles_Throughput(b *testing.B) {
 	if !flag.Parsed() {
 		flag.Parse()
 	}
-	//b.Logf("Running with parallel=%d work=%d, #goroutines:%d", *parallel, *loopv, *parallel*runtime.GOMAXPROCS(0))
+	//b.Logf("Running with parallel=%d work=%d, #goroutines:%d", *parallel, *sleepMs, *parallel*runtime.GOMAXPROCS(0))
 
 	aggStep := uint64(100_00)
 	db, _ := testDbAndAggregatorBench(b, aggStep)
@@ -519,13 +520,7 @@ func BenchmarkDb_BeginFiles_Throughput(b *testing.B) {
 			if err != nil {
 				b.Fatalf("%v", err)
 			}
-			millis := *loopv * 1000000
-			time.Sleep(time.Duration(int64(millis)))
-
-			// for i := 0; i < *loopv; i++ {
-			// 	foo *= 2
-			// 	foo /= 2
-			// }
+			time.Sleep(time.Duration(*sleepMs) * time.Millisecond)
 			tx.Rollback()
 		}
 	})

--- a/txnprovider/txpool/pool_test.go
+++ b/txnprovider/txpool/pool_test.go
@@ -1803,7 +1803,7 @@ func BenchmarkProcessRemoteTxns(b *testing.B) {
 
 	// Run the benchmark: process transactions one by one
 	// This measures the performance of adding and processing remote transactions
-	for i := 0; b.Loop(); i++ {
+	for i := 0; i < b.N; i++ {
 		pool.AddRemoteTxns(ctx, TxnSlots{testTxns.Txns[i : i+1], testTxns.Senders[i : i+1], testTxns.IsLocal[i : i+1]})
 		err := pool.processRemoteTxns(ctx)
 		require.NoError(err)


### PR DESCRIPTION
Backport of #19971 to release/3.4.

Includes benchmark fixes and bench flag improvements for `db/state` and `txpool`.