### PR TITLE
cl/clparams: set Gnosis Fulu fork epoch to 1714688

### DIFF
--- a/cl/clparams/config.go
+++ b/cl/clparams/config.go
@@ -1196,7 +1196,7 @@ func gnosisConfig() BeaconChainConfig {
 	cfg.DenebForkVersion = 0x04000064
 	cfg.ElectraForkEpoch = 1337856
 	cfg.ElectraForkVersion = 0x05000064
-	cfg.FuluForkEpoch = math.MaxUint64
+	cfg.FuluForkEpoch = 1714688
 	cfg.FuluForkVersion = 0x06000064
 	cfg.TerminalTotalDifficulty = "8626000000000000000000058750000000000000000000"
 	cfg.DepositContractAddress = "0x0B98057eA310F4d31F2a452B414647007d1645d9"


### PR DESCRIPTION
## Summary
- Set Gnosis mainnet `FULU_FORK_EPOCH` to `1714688` (~2026-04-14 12:06:20 UTC)
- Previously set to `math.MaxUint64` (unscheduled)
- `FULU_FORK_VERSION` (`0x06000064`) was already correct, no change needed

## Reference
- gnosischain/specs#92