### PR TITLE
[pick from 3.4] evm: accesList.Reset()

### DIFF
--- a/execution/state/access_list.go
+++ b/execution/state/access_list.go
@@ -20,11 +20,36 @@
 package state
 
 import (
+	"maps"
+
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
+// accessList tracks addresses and storage slots accessed during a transaction.
+// addresses maps each address to its index in slots (-1 if address-only, no slots).
+// This layout matches go-ethereum's design: the slots slice backing array is
+// reused across transactions via Reset, eliminating per-tx slot-map allocations.
 type accessList struct {
-	addresses map[accounts.Address]map[accounts.StorageKey]struct{}
+	addresses map[accounts.Address]int
+	slots     []map[accounts.StorageKey]struct{}
+}
+
+// newAccessList creates a new accessList.
+func newAccessList() *accessList {
+	return &accessList{
+		addresses: make(map[accounts.Address]int),
+	}
+}
+
+// Reset clears the access list for reuse, keeping allocated memory.
+// The slots backing array is retained; cleared inner maps are reused by
+// subsequent AddSlot calls without new allocations.
+func (al *accessList) Reset() {
+	for _, s := range al.slots {
+		clear(s)
+	}
+	al.slots = al.slots[:0]
+	clear(al.addresses)
 }
 
 // ContainsAddress returns true if the address is in the access list.
@@ -33,56 +58,29 @@ func (al *accessList) ContainsAddress(address accounts.Address) bool {
 	return ok
 }
 
-// Reset
-//func (al *accessList) Reset() {
-//	clear(al.addresses)
-//	clear(al.slots)
-//	al.slots = al.slots[:0]
-//}
-
 // Contains checks if a slot within an account is present in the access list, returning
 // separate flags for the presence of the account and the slot respectively.
 func (al *accessList) Contains(address accounts.Address, slot accounts.StorageKey) (addressPresent bool, slotPresent bool) {
-	slots, ok := al.addresses[address]
+	idx, ok := al.addresses[address]
 	if !ok {
-		// no such address (and hence zero slots)
 		return false, false
 	}
-	if slots == nil {
-		// address yes, but no slots
+	if idx == -1 {
 		return true, false
 	}
-	_, slotPresent = slots[slot]
+	_, slotPresent = al.slots[idx][slot]
 	return true, slotPresent
 }
 
-// newAccessList creates a new accessList.
-func newAccessList() *accessList {
-	return &accessList{
-		addresses: map[accounts.Address]map[accounts.StorageKey]struct{}{},
-	}
-}
-
-//func (al *accessList) Reset() {
-//	clear(al.addresses)
-//	clear(al.slots)
-//}
-
 // Copy creates an independent copy of an accessList.
 func (al *accessList) Copy() *accessList {
-	cp := newAccessList()
-	for k, v := range al.addresses {
-		if v == nil {
-			cp.addresses[k] = v
-		} else {
-			slots := map[accounts.StorageKey]struct{}{}
-			for k := range v {
-				slots[k] = struct{}{}
-			}
-			cp.addresses[k] = slots
-		}
+	cp := &accessList{
+		addresses: maps.Clone(al.addresses),
+		slots:     make([]map[accounts.StorageKey]struct{}, len(al.slots)),
 	}
-
+	for i, slotMap := range al.slots {
+		cp.slots[i] = maps.Clone(slotMap)
+	}
 	return cp
 }
 
@@ -92,7 +90,7 @@ func (al *accessList) AddAddress(address accounts.Address) bool {
 	if _, present := al.addresses[address]; present {
 		return false
 	}
-	al.addresses[address] = nil
+	al.addresses[address] = -1
 	return true
 }
 
@@ -102,51 +100,54 @@ func (al *accessList) AddAddress(address accounts.Address) bool {
 // - slot added
 // For any 'true' value returned, a corresponding journal entry must be made.
 func (al *accessList) AddSlot(address accounts.Address, slot accounts.StorageKey) (addrChange bool, slotChange bool) {
-	slots, addrPresent := al.addresses[address]
-	if !addrPresent || slots == nil {
-		// Address not present, or addr present but no slots there
-		al.addresses[address] = map[accounts.StorageKey]struct{}{slot: {}}
+	idx, addrPresent := al.addresses[address]
+	if !addrPresent || idx == -1 {
+		// Address not present, or addr present but no slots yet.
+		// Reuse a cleared slot map from the backing array if available.
+		newIdx := len(al.slots)
+		al.addresses[address] = newIdx
+		var slotmap map[accounts.StorageKey]struct{}
+		if newIdx < cap(al.slots) {
+			slotmap = al.slots[:cap(al.slots)][newIdx]
+		}
+		if slotmap == nil {
+			slotmap = make(map[accounts.StorageKey]struct{})
+		}
+		slotmap[slot] = struct{}{}
+		al.slots = append(al.slots, slotmap)
 		return !addrPresent, true
 	}
-	if _, ok := slots[slot]; !ok {
-		slots[slot] = struct{}{}
-		// Journal add slot change
+	slotmap := al.slots[idx]
+	if _, ok := slotmap[slot]; !ok {
+		slotmap[slot] = struct{}{}
 		return false, true
 	}
-	// No changes required
 	return false, false
 }
 
 // DeleteSlot removes an (address, slot)-tuple from the access list.
 // This operation needs to be performed in the same order as the addition happened.
-// This method is meant to be used  by the journal, which maintains ordering of
+// This method is meant to be used by the journal, which maintains ordering of
 // operations.
 func (al *accessList) DeleteSlot(address accounts.Address, slot accounts.StorageKey) {
-	slots, addrOk := al.addresses[address]
-	// There are two ways this can fail
+	idx, addrOk := al.addresses[address]
 	if !addrOk {
 		panic("reverting slot change, address not present in list")
 	}
-	delete(slots, slot)
-	// If that was the last (first) slot, remove it
-	// Since additions and rollbacks are always performed in order,
-	// we can delete the item without worrying about screwing up later indices
-	if len(slots) == 0 {
-		al.addresses[address] = nil
+	slotmap := al.slots[idx]
+	delete(slotmap, slot)
+	// Since additions and rollbacks are always in LIFO order, when a slot map
+	// becomes empty it must be the last one appended — truncate the slice.
+	if len(slotmap) == 0 {
+		al.slots = al.slots[:idx]
+		al.addresses[address] = -1
 	}
 }
 
 // DeleteAddress removes an address from the access list. This operation
 // needs to be performed in the same order as the addition happened.
-// This method is meant to be used  by the journal, which maintains ordering of
+// This method is meant to be used by the journal, which maintains ordering of
 // operations.
 func (al *accessList) DeleteAddress(address accounts.Address) {
-	slots, addrOk := al.addresses[address]
-	if !addrOk {
-		panic("reverting address change, address not present in list")
-	}
-	if len(slots) > 0 {
-		panic("reverting address change, address has slots")
-	}
 	delete(al.addresses, address)
 }

--- a/execution/state/access_list_test.go
+++ b/execution/state/access_list_test.go
@@ -70,10 +70,12 @@ func verifySlots(t *testing.T, s *IntraBlockState, addrString string, slotString
 		}
 	}
 	// Check that no extra elements are in the access list
-	stateSlots := s.accessList.addresses[address]
-	for s := range stateSlots {
-		if _, slotPresent := slotMap[s]; !slotPresent {
-			t.Fatalf("scope has extra slot %v (address %v)", s, addrString)
+	idx := s.accessList.addresses[address]
+	if idx >= 0 {
+		for s := range s.accessList.slots[idx] {
+			if _, slotPresent := slotMap[s]; !slotPresent {
+				t.Fatalf("scope has extra slot %v (address %v)", s, addrString)
+			}
 		}
 	}
 }
@@ -91,7 +93,7 @@ func TestAccessList(t *testing.T) {
 
 	state := New(NewReaderV3(domains.AsGetter(tx)))
 
-	state.accessList = newAccessList()
+	state.accessList.Reset()
 
 	state.AddAddressToAccessList(addr("aa"))          // 1
 	state.AddSlotToAccessList(addr("bb"), slot("01")) // 2,3
@@ -187,4 +189,53 @@ func TestAccessList(t *testing.T) {
 	if got, exp := len(state.accessList.addresses), 0; got != exp {
 		t.Fatalf("expected empty, got %d", got)
 	}
+}
+
+func BenchmarkAccessListReset(b *testing.B) {
+	sender := accounts.InternAddress(common.HexToAddress("0x1111"))
+	dst := accounts.InternAddress(common.HexToAddress("0x2222"))
+	precompiles := []accounts.Address{
+		accounts.InternAddress(common.HexToAddress("0x0001")),
+		accounts.InternAddress(common.HexToAddress("0x0002")),
+		accounts.InternAddress(common.HexToAddress("0x0003")),
+		accounts.InternAddress(common.HexToAddress("0x0004")),
+		accounts.InternAddress(common.HexToAddress("0x0005")),
+		accounts.InternAddress(common.HexToAddress("0x0006")),
+		accounts.InternAddress(common.HexToAddress("0x0007")),
+		accounts.InternAddress(common.HexToAddress("0x0008")),
+		accounts.InternAddress(common.HexToAddress("0x0009")),
+	}
+	slots := []accounts.StorageKey{
+		accounts.InternKey(common.HexToHash("0xabc1")),
+		accounts.InternKey(common.HexToHash("0xabc2")),
+		accounts.InternKey(common.HexToHash("0xabc3")),
+	}
+
+	populate := func(al *accessList) {
+		al.AddAddress(sender)
+		al.AddAddress(dst)
+		for _, p := range precompiles {
+			al.AddAddress(p)
+		}
+		for _, s := range slots {
+			al.AddSlot(dst, s)
+		}
+	}
+
+	b.Run("new", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			al := newAccessList()
+			populate(al)
+		}
+	})
+
+	b.Run("reset", func(b *testing.B) {
+		b.ReportAllocs()
+		al := newAccessList()
+		for i := 0; i < b.N; i++ {
+			al.Reset()
+			populate(al)
+		}
+	})
 }

--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -169,7 +169,7 @@ type IntraBlockState struct {
 	logSize  uint
 
 	// Per-transaction access list
-	accessList *accessList
+	accessList accessList
 
 	// Transient storage
 	transientStorage transientStorage
@@ -209,7 +209,7 @@ func New(stateReader StateReader) *IntraBlockState {
 		nilAccounts:       map[accounts.Address]struct{}{},
 		logs:              []types.Logs{},
 		journal:           newJournal(),
-		accessList:        newAccessList(),
+		accessList:        accessList{addresses: make(map[accounts.Address]int)},
 		transientStorage:  newTransientStorage(),
 		balanceInc:        map[accounts.Address]*BalanceIncrease{},
 		addressAccess:     nil,
@@ -2119,10 +2119,8 @@ func (sdb *IntraBlockState) Prepare(rules *chain.Rules, sender, coinbase account
 	}
 	if rules.IsBerlin {
 		// Clear out any leftover from previous executions
-		al := newAccessList()
-		sdb.accessList = al
-		//sdb.accessList.Reset()
-		//al := sdb.accessList
+		sdb.accessList.Reset()
+		al := &sdb.accessList
 
 		al.AddAddress(sender)
 		if !dst.IsNil() {


### PR DESCRIPTION
Port of release/3.4 PR #19983 to main.

Changes IntraBlockState.accessList from pointer to value type; Prepare() now calls Reset() instead of allocating a new accessList each transaction.

Note: temporal_db.go additions and vm/benchmark files from the original PR were already present on main independently.