### PR TITLE
NewStreamFromPool: zero-alloc

### DIFF
--- a/execution/rlp/decode.go
+++ b/execution/rlp/decode.go
@@ -119,7 +119,7 @@ func Decode(r io.Reader, val interface{}) error {
 // DecodeBytes parses RLP data from b into val. Please see package-level documentation for
 // the decoding rules. The input must contain exactly one value and no trailing data.
 func DecodeBytes(b []byte, val interface{}) error {
-	stream := NewStreamFromPool(b, uint64(len(b)))
+	stream := NewStreamFromPool(b)
 	defer stream.Release()
 	if err := stream.Decode(val); err != nil {
 		return err
@@ -183,7 +183,7 @@ func addErrorContext(err error, ctx string) error {
 // DecodeBytesPartial parses RLP data from b into val.
 // Unlike DecodeBytes, it does not require that all bytes are consumed.
 func DecodeBytesPartial(b []byte, val any) error {
-	stream := NewStreamFromPool(b, uint64(len(b)))
+	stream := NewStreamFromPool(b)
 	defer stream.Release()
 	return stream.Decode(val)
 }
@@ -695,10 +695,10 @@ func NewListStream(r io.Reader, len uint64) *Stream {
 // NewStreamFromPool returns a Stream from the pool. Call Release() when done.
 // sr is stored as a field on Stream (not a local var) so &stream.sr does not
 // escape to the heap, making this call allocation-free.
-func NewStreamFromPool(b []byte, inputLimit uint64) (stream *Stream) {
+func NewStreamFromPool(b []byte) (stream *Stream) {
 	stream = streamPool.Get().(*Stream)
 	stream.sr = b // typed field: to avoid heap-escaping of reader interface
-	stream.Reset(&stream.sr, inputLimit)
+	stream.Reset(&stream.sr, uint64(len(b)))
 	return stream
 }
 

--- a/execution/rlp/decode_test.go
+++ b/execution/rlp/decode_test.go
@@ -1144,7 +1144,7 @@ func unhex(str string) []byte {
 func TestNewStreamFromPoolAllocs(t *testing.T) {
 	data := []byte{0xc1, 0x80} // minimal RLP list
 	allocs := testing.AllocsPerRun(100, func() {
-		s := NewStreamFromPool(data, uint64(len(data)))
+		s := NewStreamFromPool(data)
 		s.Release()
 	})
 	if allocs != 0 {

--- a/execution/tests/testutil/rlp_test_util.go
+++ b/execution/tests/testutil/rlp_test_util.go
@@ -80,7 +80,7 @@ func (t *RLPTest) Run() error {
 		return fmt.Errorf("encode produced %x, want %x", b, outb)
 	}
 	// Test stream decoding.
-	s := rlp.NewStreamFromPool(outb, uint64(len(outb)))
+	s := rlp.NewStreamFromPool(outb)
 	defer s.Release()
 	return checkDecodeFromJSON(s, in)
 }

--- a/execution/types/block_access_list.go
+++ b/execution/types/block_access_list.go
@@ -564,7 +564,7 @@ func decodeBlockAccessList(out *BlockAccessList, s *rlp.Stream) error {
 
 // DecodeBlockAccessListBytes decodes an RLP-encoded block access list and returns it.
 func DecodeBlockAccessListBytes(data []byte) (BlockAccessList, error) {
-	stream := rlp.NewStreamFromPool(data, uint64(len(data)))
+	stream := rlp.NewStreamFromPool(data)
 	defer stream.Release()
 	var bal BlockAccessList
 	if err := decodeBlockAccessList(&bal, stream); err != nil {

--- a/execution/types/receipt.go
+++ b/execution/types/receipt.go
@@ -315,7 +315,7 @@ func (r *Receipt) DecodeRLP(s *rlp.Stream) error {
 		r.Type = b[0]
 		switch r.Type {
 		case AccessListTxType, DynamicFeeTxType, BlobTxType, SetCodeTxType:
-			inner := rlp.NewStreamFromPool(b[1:], uint64(len(b)-1))
+			inner := rlp.NewStreamFromPool(b[1:])
 			defer inner.Release()
 			if err := r.decodePayload(inner); err != nil {
 				return err

--- a/execution/types/transaction.go
+++ b/execution/types/transaction.go
@@ -172,7 +172,7 @@ func DecodeWrappedTransaction(data []byte) (Transaction, error) {
 	if data[0] < 0x80 { // the encoding is canonical, not RLP
 		return UnmarshalTransactionFromBinary(data, blobTxnsAreWrappedWithBlobs)
 	}
-	s := rlp.NewStreamFromPool(data, uint64(len(data)))
+	s := rlp.NewStreamFromPool(data)
 	defer s.Release()
 	return DecodeRLPTransaction(s, blobTxnsAreWrappedWithBlobs)
 }
@@ -187,7 +187,7 @@ func DecodeTransaction(data []byte) (Transaction, error) {
 		return UnmarshalTransactionFromBinary(data, blobTxnsAreWrappedWithBlobs)
 	}
 
-	s := rlp.NewStreamFromPool(data, uint64(len(data)))
+	s := rlp.NewStreamFromPool(data)
 	defer s.Release()
 	tx, err := DecodeRLPTransaction(s, blobTxnsAreWrappedWithBlobs)
 	if err != nil {
@@ -201,7 +201,7 @@ func UnmarshalTransactionFromBinary(data []byte, blobTxnsAreWrappedWithBlobs boo
 	if len(data) <= 1 {
 		return nil, fmt.Errorf("short input: %v", len(data))
 	}
-	s := rlp.NewStreamFromPool(data[1:], uint64(len(data)-1))
+	s := rlp.NewStreamFromPool(data[1:])
 	defer s.Release()
 
 	var t Transaction

--- a/p2p/sentry/sentry_multi_client/sentry_multi_client.go
+++ b/p2p/sentry/sentry_multi_client/sentry_multi_client.go
@@ -354,7 +354,7 @@ func (cs *MultiClient) blockHeaders66(ctx context.Context, in *sentryproto.Inbou
 	}
 
 	// Prepare to extract raw headers from the block
-	rlpStream := rlp.NewStreamFromPool(in.Data, uint64(len(in.Data)))
+	rlpStream := rlp.NewStreamFromPool(in.Data)
 	defer rlpStream.Release()
 	if _, err := rlpStream.List(); err != nil { // Now stream is at the beginning of 66 object
 		return fmt.Errorf("decode 1 BlockHeadersPacket66: %w", err)
@@ -453,7 +453,7 @@ func (cs *MultiClient) newBlock66(ctx context.Context, inreq *sentryproto.Inboun
 	}
 
 	// Extract header from the block
-	rlpStream := rlp.NewStreamFromPool(inreq.Data, uint64(len(inreq.Data)))
+	rlpStream := rlp.NewStreamFromPool(inreq.Data)
 	defer rlpStream.Release()
 	_, err := rlpStream.List() // Now stream is at the beginning of the block record
 	if err != nil {


### PR DESCRIPTION
<img width="1002" height="1260" alt="Screenshot 2026-03-23 at 16 17 51" src="https://github.com/user-attachments/assets/b9fa7603-84ff-4b0b-8013-a1f62126e98c" />

PR:
- doesn't create closure anymore
- `io.Reader` parameter doesn't escape to heap anymore (by using `sliceReader` and embedding it as field to `Stream`)

`NewStreamFromPool` allocs `2 -> 0`