### PR TITLE
[r3.4] rpc: auto-convert legacy blob sidecar to v1 cell proofs after Osaka

### DIFF
--- a/execution/types/blob_tx_wrapper.go
+++ b/execution/types/blob_tx_wrapper.go
@@ -451,6 +451,43 @@ func (txw *BlobTxWrapper) MarshalBinaryWrapped(w io.Writer) error {
 	}
 	return nil
 }
+
+// ConvertToV1 converts a legacy (wrapper_version=0) blob sidecar into
+// wrapper_version=1 by computing EIP-7594 cell proofs from the blobs.
+// Returns the re-encoded wrapped transaction bytes.
+// TODO: remove once ecosystem tooling fully supports wrapper_version=1.
+func (txw *BlobTxWrapper) ConvertToV1() ([]byte, error) {
+	kzgCtx := libkzg.Ctx()
+
+	cellProofs := make(KZGProofs, 0, len(txw.Blobs)*int(goethkzg.CellsPerExtBlob))
+	for i := range txw.Blobs {
+		_, proofs, err := kzgCtx.ComputeCellsAndKZGProofs((*goethkzg.Blob)(&txw.Blobs[i]), 4)
+		if err != nil {
+			return nil, fmt.Errorf("compute cell proofs for blob %d: %w", i, err)
+		}
+		for _, p := range &proofs {
+			cellProofs = append(cellProofs, KZGProof(p))
+		}
+	}
+
+	// Mutate in-place for marshalling, then restore.
+	origVersion := txw.WrapperVersion
+	origProofs := txw.Proofs
+	txw.WrapperVersion = 1
+	txw.Proofs = cellProofs
+
+	var buf bytes.Buffer
+	err := txw.MarshalBinaryWrapped(&buf)
+
+	txw.WrapperVersion = origVersion
+	txw.Proofs = origProofs
+
+	if err != nil {
+		return nil, fmt.Errorf("marshal converted wrapper: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
 func (txw *BlobTxWrapper) MarshalBinary(w io.Writer) error {
 	return txw.Tx.MarshalBinary(w)
 }

--- a/execution/types/blob_tx_wrapper_test.go
+++ b/execution/types/blob_tx_wrapper_test.go
@@ -1,0 +1,79 @@
+package types
+
+import (
+	"testing"
+
+	goethkzg "github.com/crate-crypto/go-eth-kzg"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	libkzg "github.com/erigontech/erigon/common/crypto/kzg"
+	"github.com/erigontech/erigon/execution/protocol/params"
+)
+
+func TestConvertToV1(t *testing.T) {
+	chainID := uint256.NewInt(5)
+	v0 := MakeWrappedBlobTxn(chainID)
+
+	require.Equal(t, byte(0), v0.WrapperVersion)
+	require.Len(t, v0.Proofs, 2) // 1 proof per blob
+
+	converted, err := v0.ConvertToV1()
+	require.NoError(t, err)
+	require.NotEmpty(t, converted)
+
+	// Decode the converted bytes back.
+	txn, err := DecodeWrappedTransaction(converted)
+	require.NoError(t, err)
+
+	v1, ok := txn.(*BlobTxWrapper)
+	require.True(t, ok)
+
+	assert.Equal(t, byte(1), v1.WrapperVersion)
+	assert.Len(t, v1.Blobs, 2)
+	assert.Len(t, v1.Commitments, 2)
+	assert.Len(t, v1.Proofs, 2*int(params.CellsPerExtBlob)) // 128 cell proofs per blob
+
+	// Blobs and commitments should be identical.
+	assert.Equal(t, v0.Blobs, v1.Blobs)
+	assert.Equal(t, v0.Commitments, v1.Commitments)
+
+	// Transaction body should be identical.
+	assert.Equal(t, v0.Tx.BlobVersionedHashes, v1.Tx.BlobVersionedHashes)
+	assert.Equal(t, v0.Tx.Nonce, v1.Tx.Nonce)
+	assert.Equal(t, v0.Tx.GasLimit, v1.Tx.GasLimit)
+
+	// Verify the cell proofs are cryptographically valid.
+	err = libkzg.VerifyCellProofBatch(v1.blobBytes(), v1.commitmentValues(), v1.proofValues())
+	require.NoError(t, err)
+
+	// Original wrapper should be unchanged.
+	assert.Equal(t, byte(0), v0.WrapperVersion)
+	assert.Len(t, v0.Proofs, 2)
+}
+
+// helpers to convert typed slices into the formats expected by VerifyCellProofBatch
+func (txw *BlobTxWrapper) blobBytes() [][]byte {
+	out := make([][]byte, len(txw.Blobs))
+	for i := range txw.Blobs {
+		out[i] = txw.Blobs[i][:]
+	}
+	return out
+}
+
+func (txw *BlobTxWrapper) commitmentValues() []goethkzg.KZGCommitment {
+	out := make([]goethkzg.KZGCommitment, len(txw.Commitments))
+	for i, c := range txw.Commitments {
+		out[i] = goethkzg.KZGCommitment(c)
+	}
+	return out
+}
+
+func (txw *BlobTxWrapper) proofValues() []goethkzg.KZGProof {
+	out := make([]goethkzg.KZGProof, len(txw.Proofs))
+	for i, p := range txw.Proofs {
+		out[i] = goethkzg.KZGProof(p)
+	}
+	return out
+}

--- a/rpc/jsonrpc/send_transaction.go
+++ b/rpc/jsonrpc/send_transaction.go
@@ -56,8 +56,21 @@ func (api *APIImpl) SendRawTransaction(ctx context.Context, encodedTx hexutil.By
 		}
 	}
 
+	// [EIP-7594] Convert legacy (v0) blob sidecar to v1 cell proofs when Osaka is active.
+	// This allows users with tooling that has not yet been updated for PeerDAS to still
+	// submit blob transactions. The node computes the cell proofs on their behalf.
+	// TODO: remove once ecosystem tooling fully supports wrapper_version=1.
+	txBytes := []byte(encodedTx)
+	if wrapper, ok := txn.(*types.BlobTxWrapper); ok && wrapper.WrapperVersion == 0 && cc.IsOsaka(uint64(time.Now().Unix())) {
+		converted, err := wrapper.ConvertToV1()
+		if err != nil {
+			return common.Hash{}, fmt.Errorf("blob sidecar v0→v1 conversion failed: %w", err)
+		}
+		txBytes = converted
+	}
+
 	hash := txn.Hash()
-	res, err := api.txPool.Add(ctx, &txpoolproto.AddRequest{RlpTxs: [][]byte{encodedTx}})
+	res, err := api.txPool.Add(ctx, &txpoolproto.AddRequest{RlpTxs: [][]byte{txBytes}})
 	if err != nil {
 		return common.Hash{}, err
 	}


### PR DESCRIPTION
## Summary
Cherry-pick of #19950 to `release/3.4`.

After Osaka (EIP-7594/PeerDAS) activation, the txpool requires blob transactions
with `wrapper_version=1` and cell proofs. Ecosystem tooling (`cast`, `alloy`,
`ethers.js`, etc.) still sends Deneb format (`wrapper_version=0`, one KZG proof
per blob), causing `eth_sendRawTransaction` to reject valid blob transactions.

This matches go-ethereum's approach: detect legacy blob sidecars in
`SendRawTransaction`, compute cell proofs from the blobs, re-encode with
`wrapper_version=1`, and forward the converted bytes to the txpool.

Changes:
- Add `BlobTxWrapper.ConvertToV1()` method in `execution/types/blob_tx_wrapper.go`
- Call it from `SendRawTransaction` when Osaka is active and sidecar is v0
- Add `TestConvertToV1` covering round-trip encoding and cryptographic verification

Fixes https://github.com/erigontech/erigon/issues/19709

🤖 Generated with [Claude Code](https://claude.com/claude-code)