### PR TITLE
Schedule Osaka for Gnosis

### DIFF
--- a/execution/chain/spec/chainspecs/gnosis.json
+++ b/execution/chain/spec/chainspecs/gnosis.json
@@ -17,6 +17,7 @@
   "shanghaiTime": 1690889660,
   "cancunTime": 1710181820,
   "pragueTime": 1746021820,
+  "osakaTime": 1776168380,
   "minBlobGasPrice": 1000000000,
   "blobSchedule": {
     "cancun": {
@@ -25,6 +26,11 @@
       "baseFeeUpdateFraction": 1112826
     },
     "prague": {
+      "target": 1,
+      "max": 2,
+      "baseFeeUpdateFraction": 1112826
+    },
+    "osaka": {
       "target": 1,
       "max": 2,
       "baseFeeUpdateFraction": 1112826

--- a/p2p/forkid/forkid_test.go
+++ b/p2p/forkid/forkid_test.go
@@ -138,7 +138,8 @@ func TestCreation(t *testing.T) {
 				{32880680, 1710181820, ID{Hash: ChecksumToBytes(0x1384dfc1), Activation: 1710181820, Next: 1746021820}}, // First Cancun block
 				{39827052, 1746021815, ID{Hash: ChecksumToBytes(0x1384dfc1), Activation: 1710181820, Next: 1746021820}}, // Last Cancun block
 				{39827053, 1746021825, ID{Hash: ChecksumToBytes(0x2f095d4a), Activation: 1746021820, Next: 1766419900}}, // First Prague block
-				{43785599, 1766419900, ID{Hash: ChecksumToBytes(0xd00284ad), Activation: 1766419900, Next: 0}},          // Future Balancer block (approx)
+				{43785599, 1766419900, ID{Hash: ChecksumToBytes(0xd00284ad), Activation: 1766419900, Next: 1776168380}}, // First Balancer block (approx)
+				{45735295, 1776168380, ID{Hash: ChecksumToBytes(0xcfca387c), Activation: 1776168380, Next: 0}},          // First Osaka block (approx)
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
- Schedule the Osaka (Fusaka) hard fork on Gnosis Chain mainnet
- Timestamp `1776168380` — Apr 14, 2026, 12:06:20 UTC
- CL Fulu fork epoch `1714688` was already merged via #20081

Values from https://github.com/gnosischain/specs/pull/92.

## Changes
- `execution/chain/spec/chainspecs/gnosis.json`: add `osakaTime` and `osaka` blob schedule
- `p2p/forkid/forkid_test.go`: update Gnosis fork ID test vectors

🤖 Generated with [Claude Code](https://claude.com/claude-code)