### PR TITLE
integration: propagate stage errors to non-zero exit code

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -93,17 +93,17 @@ import (
 // Set debugVerbosity=true to force log verbosity to "debug" before SetupCobra.
 func makeStageCmd(use string, stageFn func(kv.TemporalRwDB, context.Context, log.Logger) error, applyMigrations, timeit, debugVerbosity bool) *cobra.Command {
 	return &cobra.Command{
-		Use:   use,
-		Short: "",
-		Run: func(cmd *cobra.Command, args []string) {
+		Use:          use,
+		Short:        "",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if debugVerbosity {
 				cmd.Flags().Set(logging.LogConsoleVerbosityFlag.Name, "debug")
 			}
 			logger := debug.SetupCobra(cmd, "integration")
 			db, err := openDB(dbCfg(dbcfg.ChainDB, chaindata), applyMigrations, chain, logger)
 			if err != nil {
-				logger.Error("Opening DB", "error", err)
-				return
+				return fmt.Errorf("opening DB: %w", err)
 			}
 			defer db.Close()
 			if timeit {
@@ -112,10 +112,12 @@ func makeStageCmd(use string, stageFn func(kv.TemporalRwDB, context.Context, log
 			ctx, cancel := context.WithCancel(cmd.Context())
 			defer cancel()
 			if err := stageFn(db, ctx, logger); err != nil {
-				if !errors.Is(err, context.Canceled) {
-					logger.Error(err.Error())
+				if errors.Is(err, context.Canceled) {
+					return nil // graceful shutdown
 				}
+				return err
 			}
+			return nil
 		},
 	}
 }


### PR DESCRIPTION
## Problem

`makeStageCmd` used cobra's `Run` (void return) instead of `RunE`, so errors from stage functions were logged but silently swallowed — the process always exited 0.

This means:
- A gas mismatch error exits 0
- A "wrong receipt" error exits 0
- Any validation failure exits 0
- Only panics and signals produce non-zero exits

Scripts, CI pipelines, and `set -e` cannot detect execution errors.

## Fix

Switch `Run` to `RunE` so errors propagate through cobra to a non-zero exit code. `context.Canceled` (graceful shutdown via Ctrl+C) still exits 0.

## Verification

Tested all three scenarios on a real hoodi datadir:

| Scenario | Before (exit code) | After (exit code) |
|---|---|---|
| `return fmt.Errorf("gas mismatch...")` | **0** ❌ | **1** ✅ |
| `panic("...")` | **2** | **2** (unchanged) |
| Non-existing datadir (`MustOpen` panic) | **2** | **2** (unchanged) |

## Affected commands

All commands created via `makeStageCmd`: `stage_snapshots`, `stage_headers`, `stage_bodies`, `stage_senders`, `stage_exec`, `stage_exec_replay`, `stage_custom_trace`, `stage_tx_lookup`, `print_stages`.
