### PR TITLE
rpc: fix flaky TestReceiptRootValidationAfterReorg on Windows

### DIFF
--- a/rpc/jsonrpc/receipt_root_validation_test.go
+++ b/rpc/jsonrpc/receipt_root_validation_test.go
@@ -103,6 +103,7 @@ func TestReceiptRootValidationAfterReorg(t *testing.T) {
 		require.NoError(t, err)
 		chainA[1] = block3A
 	})
+	eatA.Close(t) // free MDBX resources before creating the next tester
 
 	// ==============================================================================================================
 	// Chain B: Deploy Changer + ETH transfer in block 2 (no Change() call), ETH transfer in block 3
@@ -145,6 +146,7 @@ func TestReceiptRootValidationAfterReorg(t *testing.T) {
 		require.NoError(t, err)
 		chainB[1] = block3B
 	})
+	eatB.Close(t) // free MDBX resources before creating the next tester
 
 	// ==============================================================================================================
 	// Sync tester: process chain A, then re-org to chain B, then query receipts for orphaned block 3(A)


### PR DESCRIPTION
## Summary
- Close EngineApiTester nodes explicitly after extracting payloads, before creating the next one

The test creates 3 full EngineApiTester nodes (chainA, chainB, sync). Since `t.Cleanup` only runs at test end, all 3 MDBX databases stay open simultaneously, exhausting the Windows CI paging file (`mdbx_env_open: The paging file is too small`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)