### PR TITLE
Add QA stage_exec smoke test workflow

### DIFF
--- a/.github/workflows/qa-stage-exec.yml
+++ b/.github/workflows/qa-stage-exec.yml
@@ -97,7 +97,7 @@ jobs:
           --repo erigon \
           --commit $(git rev-parse HEAD) \
           --branch ${{ github.ref_name }} \
-          --test_name "stage_exec resume nonchaintip" \
+          --test_name stage_exec_resume_nonchaintip \
           --chain $CHAIN \
           --runner ${{ runner.name }} \
           --db_version $db_version \


### PR DESCRIPTION
## Summary

Adds a manual-dispatch GitHub Actions workflow (`qa-stage-exec.yml`) that smoke-tests Erigon's `stage_exec` (execution stage).

### Workflow steps

1. Build erigon + integration binaries
2. Pause db-producer
3. Mirror reference datadir to testbed
4. Run `stage_exec` smoke test (10-min timeout)
5. Upload `result.json` and erigon logs as artifacts
6. Clean up testbed and resume db-producer

### How it works

The workflow invokes the test script from the `erigon-qa` repo:
`test_system/qa-tests/stage-exec/run_and_check_stage_exec.py`

The script:
- Removes recent state snapshots (`seg rm-state --latest`)
- Resets execution stage (`stage_exec --reset`)
- Runs `stage_exec` with a configurable timeout
- Parses logs for error patterns (panic, SIGSEGV, wrong receipt, etc.)
- Reports pass/fail via exit code and `result.json`

### Companion PR
Test script: erigontech/erigon-qa#390

### Trigger
`workflow_dispatch` only (manual) — run from the Actions tab.