### PR TITLE
ci: trigger CI gate for performance branches

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - 'release/**'
+      - performance
+      - performance-stable
     types:
       - opened
       - reopened


### PR DESCRIPTION
## Summary
- Add `performance` and `performance-stable` to the `ci-gate.yml` `pull_request` branch filter
- Without this, PRs targeting these branches get zero CI checks and are permanently blocked by branch protection

Unblocks #20109.