### PR TITLE
[r3.4] caplin: fix BlockCollector crash-loop on gap in collected blocks

### DIFF
--- a/cl/phase1/execution_client/block_collector/persistent_block_collector.go
+++ b/cl/phase1/execution_client/block_collector/persistent_block_collector.go
@@ -163,7 +163,10 @@ func (p *PersistentBlockCollector) Flush(ctx context.Context) error {
 			}
 
 			if prevBlockNum > 0 && block.NumberU64() != prevBlockNum+1 {
-				panic(fmt.Sprintf("assert: BlockCollector inserting gap: %d -> %d. To fix try: `rm datadir/caplin/history datadir/chaindata`", prevBlockNum, block.NumberU64()))
+				p.logger.Warn("[BlockCollector] Gap detected in collected blocks, will re-download missing range",
+					"lastBlock", prevBlockNum, "nextBlock", block.NumberU64(),
+					"gap", block.NumberU64()-prevBlockNum-1)
+				break
 			}
 			prevBlockNum = block.NumberU64()
 			blocksBatch = append(blocksBatch, block)


### PR DESCRIPTION
## Summary

- Replace `panic` with `warn + break` in `PersistentBlockCollector.Flush()` when a gap is detected in collected block numbers
- The persistent MDBX DB can accumulate non-contiguous blocks across process restarts; panicking prevents the DB from ever being cleared, causing a permanent crash-loop
- Now inserts the contiguous prefix of blocks, logs a warning, clears the DB, and lets the next sync cycle re-download the missing range

Fixes https://github.com/erigontech/erigon-qa/issues/383

## Test plan

- [ ] Verify `make lint && make erigon` passes
- [ ] Run Chiado sync and confirm no panic on block gap
- [ ] Confirm gap warning is logged and sync self-heals

🤖 Generated with [Claude Code](https://claude.com/claude-code)