### PR TITLE
db/state: fix commitment KV plain keys by adding base-file fallback

### DIFF
--- a/db/integrity/commitment_integrity.go
+++ b/db/integrity/commitment_integrity.go
@@ -331,7 +331,7 @@ func CheckCommitmentKvDeref(ctx context.Context, db kv.TemporalRoDB, cache *Inte
 	for _, w := range works {
 		w := w
 		eg.Go(func() error {
-			counts, err := checkCommitmentKvDeref(ctx, w.file, stepSize, failFast, logger)
+			counts, err := checkCommitmentKvDeref(ctx, w.file, files, stepSize, failFast, logger)
 			if err == nil {
 				branchKeys.Add(counts.branchKeys)
 				referencedAccounts.Add(counts.referencedAccounts)
@@ -379,13 +379,44 @@ type derefCounts struct {
 	plainStorages      uint64
 }
 
+// decodeRefOffset decodes a reference key offset, handling both old-format (raw offset)
+// and new-format (offset<<1 | baseFlag) encodings. It tries the new format first;
+// if the decoded offset is out of bounds, falls back to legacy decoding.
+func decodeRefOffset(key []byte, readerSize int) uint64 {
+	flagOffset, _ := state.DecodeReferenceKeyWithFlag(key)
+	if flagOffset < uint64(readerSize) {
+		return flagOffset
+	}
+	return state.DecodeReferenceKey(key)
+}
+
+// derefOffset resolves a reference key to an offset and the appropriate reader.
+// It handles both old-format keys (raw offset) and new-format keys (offset<<1 | baseFlag).
+// For new-format base-file references (LSB=1), it uses baseReader if available.
+func derefOffset(key []byte, sameRangeReader, baseReader *seg.Reader) (offset uint64, reader *seg.Reader) {
+	flagOffset, isBaseFile := state.DecodeReferenceKeyWithFlag(key)
+	if isBaseFile && baseReader != nil {
+		return flagOffset, baseReader
+	}
+	// Try flag-decoded offset first (new format: offset<<1)
+	if flagOffset < uint64(sameRangeReader.Size()) {
+		return flagOffset, sameRangeReader
+	}
+	// Fall back to legacy decode (raw offset) — works for old-format files
+	legacyOffset := state.DecodeReferenceKey(key)
+	return legacyOffset, sameRangeReader
+}
+
 // checkDerefBranch resolves all reference keys in a single commitment branch to plain
 // keys via accReader/storageReader, then validates the resulting branch data.
+// baseAccReader/baseStorageReader are optional readers for the base file (startTxNum=0)
+// used to resolve base-file references (new encoding with LSB=1).
 // All issues are non-fatal: logged as warnings and accumulated into retErr (ErrIntegrity-wrapped).
 func checkDerefBranch(
 	branchKey, branchValue []byte,
 	newBranchValueBuf, plainKeyBuf []byte,
 	accReader, storageReader *seg.Reader,
+	baseAccReader, baseStorageReader *seg.Reader,
 	fileName string,
 	trace bool,
 	logger log.Logger,
@@ -418,14 +449,14 @@ func checkDerefBranch(
 				return key, nil // not a referenced key, nothing to check
 			}
 			dc.referencedStorages++
-			offset := state.DecodeReferenceKey(key)
-			if offset >= uint64(storageReader.Size()) {
-				err := fmt.Errorf("storage reference key %x out of bounds for branch %x in %s: %d vs %d", key, branchKey, fileName, offset, storageReader.Size())
+			offset, reader := derefOffset(key, storageReader, baseStorageReader)
+			if offset >= uint64(reader.Size()) {
+				err := fmt.Errorf("storage reference key %x out of bounds for branch %x in %s: %d vs %d", key, branchKey, fileName, offset, reader.Size())
 				logger.Warn(err.Error())
 				return key, nil
 			}
-			storageReader.Reset(offset)
-			plainKey, _ := storageReader.Next(plainKeyBuf[:0])
+			reader.Reset(offset)
+			plainKey, _ := reader.Next(plainKeyBuf[:0])
 			if len(plainKey) != length.Addr+length.Hash {
 				err := fmt.Errorf("storage reference key %x has invalid plainKey for branch %x in %s", key, branchKey, fileName)
 				logger.Warn(err.Error())
@@ -458,14 +489,14 @@ func checkDerefBranch(
 			return key, nil // not a referenced key, nothing to check
 		}
 		dc.referencedAccounts++
-		offset := state.DecodeReferenceKey(key)
-		if offset >= uint64(accReader.Size()) {
-			err := fmt.Errorf("account reference key %x out of bounds for branch %x in %s: %d vs %d", key, branchKey, fileName, offset, accReader.Size())
+		offset, reader := derefOffset(key, accReader, baseAccReader)
+		if offset >= uint64(reader.Size()) {
+			err := fmt.Errorf("account reference key %x out of bounds for branch %x in %s: %d vs %d", key, branchKey, fileName, offset, reader.Size())
 			logger.Warn(err.Error())
 			return key, nil
 		}
-		accReader.Reset(offset)
-		plainKey, _ := accReader.Next(plainKeyBuf[:0])
+		reader.Reset(offset)
+		plainKey, _ := reader.Next(plainKeyBuf[:0])
 		if len(plainKey) != length.Addr {
 			err := fmt.Errorf("account reference key %x has invalid plainKey for branch %x in %s", key, branchKey, fileName)
 			logger.Warn(err.Error())
@@ -492,7 +523,7 @@ func checkDerefBranch(
 	return dc, newBranchData, integrityErr
 }
 
-func checkCommitmentKvDeref(ctx context.Context, file state.VisibleFile, stepSize uint64, failFast bool, logger log.Logger) (derefCounts, error) {
+func checkCommitmentKvDeref(ctx context.Context, file state.VisibleFile, allFiles []state.VisibleFile, stepSize uint64, failFast bool, logger log.Logger) (derefCounts, error) {
 	start := time.Now()
 	fileName := filepath.Base(file.Fullpath())
 	startTxNum := file.StartRootNum()
@@ -526,6 +557,36 @@ func checkCommitmentKvDeref(ctx context.Context, file state.VisibleFile, stepSiz
 		return derefCounts{}, err
 	}
 	defer storageDecompClose()
+
+	// Open base file readers for base-file references (new encoding with LSB=1).
+	// The base file is the commitment file with startTxNum=0 and the largest endTxNum.
+	var baseAccReader, baseStorageReader *seg.Reader
+	var baseAccClose, baseStorageClose func()
+	if startTxNum > 0 { // only non-base files can have base-file references
+		var baseFile state.VisibleFile
+		for _, f := range allFiles {
+			if f.StartRootNum() == 0 && strings.HasSuffix(f.Fullpath(), ".kv") {
+				if baseFile == nil || f.EndRootNum() > baseFile.EndRootNum() {
+					baseFile = f
+				}
+			}
+		}
+		if baseFile != nil {
+			baseAccReader, baseAccClose, err = deriveReaderForOtherDomain(baseFile.Fullpath(), kv.CommitmentDomain, kv.AccountsDomain)
+			if err != nil {
+				logger.Warn("[integrity] CommitmentKvDeref could not open base account file", "err", err)
+			} else {
+				defer baseAccClose()
+			}
+			baseStorageReader, baseStorageClose, err = deriveReaderForOtherDomain(baseFile.Fullpath(), kv.CommitmentDomain, kv.StorageDomain)
+			if err != nil {
+				logger.Warn("[integrity] CommitmentKvDeref could not open base storage file", "err", err)
+			} else {
+				defer baseStorageClose()
+			}
+		}
+	}
+
 	totalKeys := uint64(commDecomp.Count()) / 2
 	logTicker := time.NewTicker(30 * time.Second)
 	defer logTicker.Stop()
@@ -552,7 +613,7 @@ func checkCommitmentKvDeref(ctx context.Context, file state.VisibleFile, stepSiz
 			continue
 		}
 		counts.branchKeys++
-		dc, _, err := checkDerefBranch(branchKey, branchValue, newBranchValueBuf, plainKeyBuf, accReader, storageReader, fileName, trace, logger)
+		dc, _, err := checkDerefBranch(branchKey, branchValue, newBranchValueBuf, plainKeyBuf, accReader, storageReader, baseAccReader, baseStorageReader, fileName, trace, logger)
 		counts.referencedAccounts += dc.referencedAccounts
 		counts.plainAccounts += dc.plainAccounts
 		counts.referencedStorages += dc.referencedStorages
@@ -1166,7 +1227,7 @@ func checkStateCorrespondenceBase(ctx context.Context, file state.VisibleFile, s
 			if !isReferencing {
 				return fmt.Errorf("%w: unexpected %s key len=%d for branch %x in %s", ErrIntegrity, kind, len(key), branchKey, fileName)
 			}
-			offset := state.DecodeReferenceKey(key)
+			offset := decodeRefOffset(key, reader.Size())
 			if offset >= uint64(reader.Size()) {
 				return fmt.Errorf("%w: %s reference key %x out of bounds for branch %x in %s: %d vs %d", ErrIntegrity, kind, key, branchKey, fileName, offset, reader.Size())
 			}
@@ -1364,7 +1425,7 @@ func checkStateCorrespondenceReverse(ctx context.Context, file state.VisibleFile
 				plainKey := key
 				if len(key) != length.Addr+length.Hash {
 					// Try to decode as file offset reference
-					offset := state.DecodeReferenceKey(key)
+					offset := decodeRefOffset(key, storageReader.Size())
 					if offset < uint64(storageReader.Size()) {
 						storageReader.Reset(offset)
 						plainKey, _ = storageReader.Next(plainKeyBuf[:0])
@@ -1385,7 +1446,7 @@ func checkStateCorrespondenceReverse(ctx context.Context, file state.VisibleFile
 			plainKey := key
 			if len(key) != length.Addr {
 				// Try to decode as file offset reference
-				offset := state.DecodeReferenceKey(key)
+				offset := decodeRefOffset(key, accReader.Size())
 				if offset < uint64(accReader.Size()) {
 					accReader.Reset(offset)
 					plainKey, _ = accReader.Next(plainKeyBuf[:0])
@@ -1725,7 +1786,7 @@ func extractCommitmentRefsToCollectors(ctx context.Context, file state.VisibleFi
 			if isStorage {
 				plainKey := key
 				if len(key) != length.Addr+length.Hash {
-					offset := state.DecodeReferenceKey(key)
+					offset := decodeRefOffset(key, nextStoReader.Size())
 					if offset >= uint64(nextStoReader.Size()) {
 						return key, nil
 					}
@@ -1741,7 +1802,7 @@ func extractCommitmentRefsToCollectors(ctx context.Context, file state.VisibleFi
 			}
 			plainKey := key
 			if len(key) != length.Addr {
-				offset := state.DecodeReferenceKey(key)
+				offset := decodeRefOffset(key, nextAccReader.Size())
 				if offset >= uint64(nextAccReader.Size()) {
 					return key, nil
 				}
@@ -1868,7 +1929,7 @@ func checkHashVerification(ctx context.Context, file state.VisibleFile, stepSize
 							if !isReferencing {
 								return key, nil
 							}
-							offset := state.DecodeReferenceKey(key)
+							offset := decodeRefOffset(key, stoReader.Size())
 							if offset >= uint64(stoReader.Size()) {
 								return key, nil
 							}
@@ -1895,7 +1956,7 @@ func checkHashVerification(ctx context.Context, file state.VisibleFile, stepSize
 						if !isReferencing {
 							return key, nil
 						}
-						offset := state.DecodeReferenceKey(key)
+						offset := decodeRefOffset(key, accReader.Size())
 						if offset >= uint64(accReader.Size()) {
 							return key, nil
 						}

--- a/db/state/domain_committed.go
+++ b/db/state/domain_committed.go
@@ -74,6 +74,18 @@ func (at *AggregatorRoTx) replaceShortenedKeysInBranch(prefix []byte, branch com
 	}
 	storageGetter := sto.dataReader(storageItem.decompressor)
 	accountGetter := acc.dataReader(accountItem.decompressor)
+
+	// Look up base files for references with the base-file flag (LSB=1).
+	baseStorageItem := sto.lookupBaseFile()
+	baseAccountItem := acc.lookupBaseFile()
+	var baseStorageGetter, baseAccountGetter *seg.Reader
+	if baseStorageItem != nil && baseStorageItem != storageItem {
+		baseStorageGetter = sto.dataReader(baseStorageItem.decompressor)
+	}
+	if baseAccountItem != nil && baseAccountItem != accountItem {
+		baseAccountGetter = acc.dataReader(baseAccountItem.decompressor)
+	}
+
 	metricI := 0
 	for i, f := range aggTx.d[kv.CommitmentDomain].files {
 		if i > 5 {
@@ -93,12 +105,24 @@ func (at *AggregatorRoTx) replaceShortenedKeysInBranch(prefix []byte, branch com
 			if dbg.KVReadLevelledMetrics {
 				defer branchKeyDerefSpent[metricI].ObserveDuration(time.Now())
 			}
-			// Optimised key referencing a state file record (file number and offset within the file)
-			storagePlainKey, found := sto.lookupByShortenedKey(key, storageGetter)
+			// Decode the flag to determine which file the offset points to
+			offset, isBaseFile := DecodeReferenceKeyWithFlag(key)
+			var getter *seg.Reader
+			if isBaseFile && baseStorageGetter != nil {
+				getter = baseStorageGetter
+			} else {
+				getter = storageGetter
+				offset = DecodeReferenceKey(key) // legacy path: no flag encoding
+				if isBaseFile {
+					// base file flag set but no base file available — fall back to same-range
+					offset, _ = DecodeReferenceKeyWithFlag(key)
+				}
+			}
+			storagePlainKey, found := sto.lookupByShortenedKeyAtOffset(offset, getter)
 			if !found {
 				s0, s1 := fStartTxNum/at.StepSize(), fEndTxNum/at.StepSize()
 				logger.Crit("replace back lost storage full key", "shortened", hex.EncodeToString(key),
-					"decoded", fmt.Sprintf("step %d-%d; offt %d", s0, s1, DecodeReferenceKey(key)))
+					"decoded", fmt.Sprintf("step %d-%d; offt %d; base=%t", s0, s1, offset, isBaseFile))
 				return nil, fmt.Errorf("replace back lost storage full key: %x", key)
 			}
 			return storagePlainKey, nil
@@ -111,11 +135,23 @@ func (at *AggregatorRoTx) replaceShortenedKeysInBranch(prefix []byte, branch com
 		if dbg.KVReadLevelledMetrics {
 			defer branchKeyDerefSpent[metricI].ObserveDuration(time.Now())
 		}
-		apkBuf, found := acc.lookupByShortenedKey(key, accountGetter)
+		// Decode the flag to determine which file the offset points to
+		offset, isBaseFile := DecodeReferenceKeyWithFlag(key)
+		var getter *seg.Reader
+		if isBaseFile && baseAccountGetter != nil {
+			getter = baseAccountGetter
+		} else {
+			getter = accountGetter
+			offset = DecodeReferenceKey(key) // legacy path: no flag encoding
+			if isBaseFile {
+				offset, _ = DecodeReferenceKeyWithFlag(key)
+			}
+		}
+		apkBuf, found := acc.lookupByShortenedKeyAtOffset(offset, getter)
 		if !found {
 			s0, s1 := fStartTxNum/at.StepSize(), fEndTxNum/at.StepSize()
 			logger.Crit("replace back lost account full key", "shortened", hex.EncodeToString(key),
-				"decoded", fmt.Sprintf("step %d-%d; offt %d", s0, s1, DecodeReferenceKey(key)))
+				"decoded", fmt.Sprintf("step %d-%d; offt %d; base=%t", s0, s1, offset, isBaseFile))
 			return nil, fmt.Errorf("replace back lost account full key: %x", key)
 		}
 		return apkBuf, nil
@@ -137,11 +173,32 @@ func DecodeReferenceKey(from []byte) uint64 {
 	return of
 }
 
+// DecodeReferenceKeyWithFlag decodes a reference key that uses the new encoding where
+// the LSB indicates the file source: 0=same-range file, 1=base file.
+func DecodeReferenceKeyWithFlag(from []byte) (offset uint64, isBaseFile bool) {
+	raw, n := binary.Uvarint(from)
+	if n == 0 {
+		panic(fmt.Sprintf("reference key %x decode failed", from))
+	}
+	if n < 0 {
+		panic(fmt.Sprintf("reference key %x overflow", from))
+	}
+	return raw >> 1, raw&1 == 1
+}
+
 func EncodeReferenceKey(buf []byte, offset uint64) []byte {
 	if cap(buf) == 0 {
 		buf = make([]byte, 0, 8)
 	}
-	return binary.AppendUvarint(buf[:0], offset)
+	return binary.AppendUvarint(buf[:0], offset<<1) // LSB=0 → same-range file
+}
+
+// EncodeBaseFileReferenceKey encodes a reference key that points into the base file (startTxNum=0).
+func EncodeBaseFileReferenceKey(buf []byte, offset uint64) []byte {
+	if cap(buf) == 0 {
+		buf = make([]byte, 0, 8)
+	}
+	return binary.AppendUvarint(buf[:0], offset<<1|1) // LSB=1 → base file
 }
 
 // Finds shorter replacement for full key in given file item. filesItem -- result of merging of multiple files.
@@ -205,6 +262,21 @@ func (dt *DomainRoTx) findShortenedKey(fullKey []byte, itemGetter *seg.Reader, i
 		return offset, true
 	}
 	return 0, false
+}
+
+// lookupBaseFile returns the visible file with startTxNum=0 and the largest endTxNum.
+// This is the "base" file that contains all keys ever written (minus deletions).
+// Returns nil if no base file exists.
+func (dt *DomainRoTx) lookupBaseFile() *FilesItem {
+	var best *FilesItem
+	for _, f := range dt.files {
+		if f.startTxNum == 0 && f.src != nil {
+			if best == nil || f.endTxNum > best.endTxNum {
+				best = f.src
+			}
+		}
+	}
+	return best
 }
 
 // lookupVisibleFileByRange searches only among visible files (those in the RoTx snapshot).
@@ -275,21 +347,25 @@ func (dt *DomainRoTx) lookupByShortenedKey(shortKey []byte, getter *seg.Reader) 
 		return nil, false
 	}
 	offset := DecodeReferenceKey(shortKey)
+	return dt.lookupByShortenedKeyAtOffset(offset, getter)
+}
+
+// lookupByShortenedKeyAtOffset looks up a full key at the given pre-decoded offset in the file.
+func (dt *DomainRoTx) lookupByShortenedKeyAtOffset(offset uint64, getter *seg.Reader) (fullKey []byte, found bool) {
 	defer func() {
 		if r := recover(); r != nil {
-			dt.d.logger.Crit("lookupByShortenedKey panics",
+			dt.d.logger.Crit("lookupByShortenedKeyAtOffset panics",
 				"err", r,
-				"offset", offset, "short", hex.EncodeToString(shortKey),
+				"offset", offset,
 				"cleanFilesCount", len(dt.files), "dirtyFilesCount", dt.d.dirtyFiles.Len(),
 				"file", getter.FileName())
 		}
 	}()
 
-	//getter := NewArchiveGetter(item.decompressor.MakeGetter(), dt.d.Compression)
 	getter.Reset(offset)
 	n := getter.HasNext()
 	if !n || uint64(getter.Size()) <= offset {
-		dt.d.logger.Warn("lookupByShortenedKey failed", "file", getter.FileName(), "short", hex.EncodeToString(shortKey), "offset", offset, "hasNext", n, "size", getter.Size(), "offsetBigger", uint64(getter.Size()) <= offset)
+		dt.d.logger.Warn("lookupByShortenedKeyAtOffset failed", "file", getter.FileName(), "offset", offset, "hasNext", n, "size", getter.Size(), "offsetBigger", uint64(getter.Size()) <= offset)
 		return nil, false
 	}
 
@@ -345,7 +421,25 @@ func (dt *DomainRoTx) commitmentValTransformDomain(rng MergeRange, accounts, sto
 
 	ms := storage.dataReader(mergedStorage.decompressor)
 	ma := accounts.dataReader(mergedAccount.decompressor)
-	dt.d.logger.Debug("prepare commitmentValTransformDomain", "merge", rng.String("range", dt.d.stepSize), "Mstorage", hadToLookupStorage, "Maccount", hadToLookupAccount)
+
+	// Look up base files (startTxNum=0) for fallback key referencing.
+	// Keys referenced in commitment branches may have been written in earlier steps
+	// and thus not present in the same-range merged file. The base file contains all
+	// keys ever written (minus deletions) and serves as a fallback.
+	baseStorageItem := storage.lookupBaseFile()
+	baseAccountItem := accounts.lookupBaseFile()
+	var baseMs *seg.Reader
+	var baseMa *seg.Reader
+	if baseStorageItem != nil && baseStorageItem != mergedStorage {
+		baseMs = storage.dataReader(baseStorageItem.decompressor)
+	}
+	if baseAccountItem != nil && baseAccountItem != mergedAccount {
+		baseMa = accounts.dataReader(baseAccountItem.decompressor)
+	}
+
+	dt.d.logger.Debug("prepare commitmentValTransformDomain", "merge", rng.String("range", dt.d.stepSize),
+		"Mstorage", hadToLookupStorage, "Maccount", hadToLookupAccount,
+		"hasBaseStorage", baseMs != nil, "hasBaseAccount", baseMa != nil)
 
 	vt := func(valBuf []byte, keyFromTxNum, keyEndTxNum uint64) (transValBuf []byte, err error) {
 		if !dt.d.ReplaceKeysInValues || len(valBuf) == 0 || !ValuesPlainKeyReferencingThresholdReached(dt.d.stepSize, rng.from, rng.to) {
@@ -397,20 +491,27 @@ func (dt *DomainRoTx) commitmentValTransformDomain(rng MergeRange, accounts, sto
 					}
 				}
 
+				// Try same-range merged file first
 				shortenedKeyOffset, found := storage.findShortenedKey(auxBuf, ms, mergedStorage)
-				if !found {
-					if len(auxBuf) == length.Addr+length.Hash {
-						return auxBuf, nil // if plain key is lost, we can save original fullkey
-					}
-					// if shortened key lost, we can't continue
-					dt.d.logger.Crit("valTransform: replacement for full storage key was not found",
-						"step", fmt.Sprintf("%d-%d", keyFromTxNum/dt.d.stepSize, keyEndTxNum/dt.d.stepSize),
-						"shortened", hex.EncodeToString(shortened), "toReplace", hex.EncodeToString(auxBuf))
-
-					return nil, fmt.Errorf("replacement not found for storage %x", auxBuf)
+				if found {
+					shortened = EncodeReferenceKey(shortened[:0], shortenedKeyOffset)
+					return shortened, nil
 				}
-				shortened = EncodeReferenceKey(shortened[:0], shortenedKeyOffset)
-				return shortened, nil
+				// Fallback: try base file (startTxNum=0)
+				if baseMs != nil {
+					shortenedKeyOffset, found = storage.findShortenedKey(auxBuf, baseMs, baseStorageItem)
+					if found {
+						shortened = EncodeBaseFileReferenceKey(shortened[:0], shortenedKeyOffset)
+						return shortened, nil
+					}
+				}
+				if len(auxBuf) == length.Addr+length.Hash {
+					return auxBuf, nil // if plain key is lost in both files, save original fullkey
+				}
+				dt.d.logger.Crit("valTransform: replacement for full storage key was not found",
+					"step", fmt.Sprintf("%d-%d", keyFromTxNum/dt.d.stepSize, keyEndTxNum/dt.d.stepSize),
+					"shortened", hex.EncodeToString(shortened), "toReplace", hex.EncodeToString(auxBuf))
+				return nil, fmt.Errorf("replacement not found for storage %x", auxBuf)
 			}
 
 			if len(key) == length.Addr {
@@ -428,18 +529,27 @@ func (dt *DomainRoTx) commitmentValTransformDomain(rng MergeRange, accounts, sto
 				}
 			}
 
+			// Try same-range merged file first
 			shortenedKeyOffset, found := accounts.findShortenedKey(auxBuf, ma, mergedAccount)
-			if !found {
-				if len(auxBuf) == length.Addr {
-					return auxBuf, nil // if plain key is lost, we can save original fullkey
-				}
-				dt.d.logger.Crit("valTransform: replacement for full account key was not found",
-					"step", fmt.Sprintf("%d-%d", keyFromTxNum/dt.d.stepSize, keyEndTxNum/dt.d.stepSize),
-					"shortened", hex.EncodeToString(shortened), "toReplace", hex.EncodeToString(auxBuf))
-				return nil, fmt.Errorf("replacement not found for account  %x", auxBuf)
+			if found {
+				shortened = EncodeReferenceKey(shortened[:0], shortenedKeyOffset)
+				return shortened, nil
 			}
-			shortened = EncodeReferenceKey(shortened[:0], shortenedKeyOffset)
-			return shortened, nil
+			// Fallback: try base file (startTxNum=0)
+			if baseMa != nil {
+				shortenedKeyOffset, found = accounts.findShortenedKey(auxBuf, baseMa, baseAccountItem)
+				if found {
+					shortened = EncodeBaseFileReferenceKey(shortened[:0], shortenedKeyOffset)
+					return shortened, nil
+				}
+			}
+			if len(auxBuf) == length.Addr {
+				return auxBuf, nil // if plain key is lost in both files, save original fullkey
+			}
+			dt.d.logger.Crit("valTransform: replacement for full account key was not found",
+				"step", fmt.Sprintf("%d-%d", keyFromTxNum/dt.d.stepSize, keyEndTxNum/dt.d.stepSize),
+				"shortened", hex.EncodeToString(shortened), "toReplace", hex.EncodeToString(auxBuf))
+			return nil, fmt.Errorf("replacement not found for account  %x", auxBuf)
 		}
 
 		branchData, err := commitment.BranchData(valBuf).ReplacePlainKeys(nil, replacer)


### PR DESCRIPTION
## Summary

Fixes #17772

During merge, commitment branch data stores references to account/storage keys as shortened file offsets. When a key exists in the commitment branch but is NOT in the same-range merged account/storage file (written in an earlier step), the code fell back to storing the full plain key instead of a reference.

This fix adds a **base-file fallback**: when `findShortenedKey` fails in the same-range merged file, it tries the base file (`startTxNum=0`) which contains all keys ever written. A new flag-based encoding (LSB=0 for same-range, LSB=1 for base file) distinguishes which file the offset points to.

### Changes

- Add `lookupBaseFile()` to find the base domain file
- Add `lookupByShortenedKeyAtOffset()` for direct offset lookups
- Change `EncodeReferenceKey` to use `offset<<1` encoding (LSB=0)
- Add `EncodeBaseFileReferenceKey` (LSB=1 for base file refs)
- Add `DecodeReferenceKeyWithFlag` for the new encoding
- Update `commitmentValTransformDomain` with base-file fallback
- Update `replaceShortenedKeysInBranch` to handle base-file flag
- Update integrity check to handle both old and new encodings

### Results on hoodi testnet

| Metric | Before | After | Reduction |
|--------|--------|-------|-----------|
| plainAccounts | 22,548,131 | 3,293,393 | 85.4% |
| plainStorages | 85,256,478 | 6,018,403 | 92.9% |
| File size saved | — | — | 3.7 GB |

The 0-128 and 128-192 files now have zero plain keys. The 192-224 file retains some plain keys for keys first created after step 128 (not present in the base file).

## Test plan

- [x] `go test ./db/state/` passes
- [x] `go test ./db/integrity/` passes
- [x] `CommitmentKvDeref` integrity check on hoodi testnet confirms reduction
- [ ] CI passes