### PR TITLE
qa-tests: restore the execution of RPC tests on the main and release branches

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests-gnosis.yml
+++ b/.github/workflows/qa-rpc-integration-tests-gnosis.yml
@@ -1,6 +1,10 @@
 name: QA - RPC Integration Tests (Gnosis)
 
 on:
+  push:
+    branches:
+      - main
+      - 'release/**'
   pull_request:
     branches:
       - main
@@ -17,6 +21,8 @@ concurrency:
     ${{
       github.event_name == 'pull_request' &&
       format('{0}-{1}', github.workflow, github.head_ref) ||
+      github.event_name == 'push' &&
+      format('{0}-{1}', github.workflow, github.ref_name) ||
       format('{0}-{1}', github.workflow, github.run_id)
     }}
   cancel-in-progress: true

--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -1,6 +1,10 @@
 name: QA - RPC Integration Tests
 
 on:
+  push:
+    branches:
+      - main
+      - 'release/**'
   pull_request:
     branches:
       - main
@@ -17,6 +21,8 @@ concurrency:
     ${{
       github.event_name == 'pull_request' &&
       format('{0}-{1}', github.workflow, github.head_ref) ||
+      github.event_name == 'push' &&
+      format('{0}-{1}', github.workflow, github.ref_name) ||
       format('{0}-{1}', github.workflow, github.run_id)
     }}
   cancel-in-progress: true


### PR DESCRIPTION
Restore the execution of RPC tests on the main and release branches.