### PR TITLE
ci: skip sonar scan for fork PRs

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -75,6 +75,9 @@ jobs:
     secrets: inherit
 
   sonar:
+    # SONAR_TOKEN is a repo secret unavailable to fork PRs, so skip the scan
+    # for external contributions to avoid a guaranteed failure in ci-gate.
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
     uses: ./.github/workflows/sonar.yml
     secrets: inherit
 


### PR DESCRIPTION
## Summary
- SONAR_TOKEN is a repo secret not exposed to fork PR workflows, causing a guaranteed SonarCloud failure that blocks ci-gate for every external contribution (e.g. #20022)
- Skip the sonar job when the PR originates from a fork; the ci-gate job already treats skipped jobs as passing
- Internal PRs, push events, merge-group, and workflow_dispatch continue to run sonar as before

## Test plan
- [ ] Verify ci-gate passes on this PR (sonar runs since it's an internal PR)
- [ ] Verify sonar is skipped on a fork PR (observable on any future external contribution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)