### PR TITLE
ci: fix hashFiles() in composite action outputs

### DIFF
--- a/.github/actions/restore-mod-cache/action.yml
+++ b/.github/actions/restore-mod-cache/action.yml
@@ -19,19 +19,27 @@ outputs:
     value: ${{ steps.restore.outputs.cache-matched-key }}
   primary-key:
     description: "The primary cache key (for use by save-mod-cache)"
-    value: gomodcache|${{ inputs.workflow-id }}|${{ github.job }}|${{ inputs.matrix-key }}|${{ runner.os }}|${{ hashFiles('go.sum') }}|${{ github.run_id }}|${{ github.run_attempt }}
+    value: ${{ steps.compute-key.outputs.primary-key }}
 
 runs:
   using: composite
   steps:
+    - id: compute-key
+      shell: bash
+      run: |
+        gosum_hash=$(sha256sum go.sum | cut -d' ' -f1)
+        primary_key="gomodcache|${{ inputs.workflow-id }}|${{ github.job }}|${{ inputs.matrix-key }}|${{ runner.os }}|${gosum_hash}|${{ github.run_id }}|${{ github.run_attempt }}"
+        echo "primary-key=${primary_key}" >> "$GITHUB_OUTPUT"
+        echo "gosum-hash=${gosum_hash}" >> "$GITHUB_OUTPUT"
+
     - id: restore
       uses: actions/cache/restore@v4
       with:
         path: ${{ inputs.modcache-path }}/cache/download
-        key: gomodcache|${{ inputs.workflow-id }}|${{ github.job }}|${{ inputs.matrix-key }}|${{ runner.os }}|${{ hashFiles('go.sum') }}|${{ github.run_id }}|${{ github.run_attempt }}
+        key: ${{ steps.compute-key.outputs.primary-key }}
         restore-keys: |
-          gomodcache|${{ inputs.workflow-id }}|${{ github.job }}|${{ inputs.matrix-key }}|${{ runner.os }}|${{ hashFiles('go.sum') }}|${{ github.run_id }}|
-          gomodcache|${{ inputs.workflow-id }}|${{ github.job }}|${{ inputs.matrix-key }}|${{ runner.os }}|${{ hashFiles('go.sum') }}|
+          gomodcache|${{ inputs.workflow-id }}|${{ github.job }}|${{ inputs.matrix-key }}|${{ runner.os }}|${{ steps.compute-key.outputs.gosum-hash }}|${{ github.run_id }}|
+          gomodcache|${{ inputs.workflow-id }}|${{ github.job }}|${{ inputs.matrix-key }}|${{ runner.os }}|${{ steps.compute-key.outputs.gosum-hash }}|
 
     - name: Warn on module cache miss
       if: ${{ steps.restore.outputs.cache-matched-key == '' }}


### PR DESCRIPTION
Fixes CI failures across all branches:
```
Unrecognized function: hashFiles. Located at position 1
within expression: hashFiles('go.sum')
```

`hashFiles()` is not available in composite action `outputs` section — only in workflow-level and step-level expressions.

## Fix
Compute `go.sum` hash in a dedicated step via `sha256sum`, store in step output, reference from cache key and action outputs.

**Before**: `${{ hashFiles('go.sum') }}` in outputs (broken)
**After**: `${{ steps.compute-key.outputs.gosum-hash }}` in cache key

Co-Authored-By: Shuo <shuo@erigon.dev>