### PR TITLE
ci: add cleanup-space to race tests workflow to fix disk-full failures

### DIFF
--- a/.github/workflows/test-all-erigon-race.yml
+++ b/.github/workflows/test-all-erigon-race.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           submodules: true
           lfs: tests
+          cleanup-space: true
           build-cache-extra-key: ${{ matrix.test-group }}
           ramdisk: true
 


### PR DESCRIPTION
## Summary

The `race-tests / tests-linux (ubuntu-latest, execution-other)` job was failing with `No space left on device` (see run [#23548021331](https://github.com/erigontech/erigon/actions/runs/23548021331)).

Root cause: `test-all-erigon-race.yml` called `setup-erigon` without `cleanup-space: true`, so the large pre-installed packages (`/usr/local/lib/android`, `/opt/az`, `/opt/microsoft`, `/usr/share/dotnet`, etc.) were never removed before tests ran. The `test-all-erigon.yml` already had `cleanup-space: true` — this was simply missing from the race variant.

## Fix

Add `cleanup-space: true` to the `setup-erigon` call in `test-all-erigon-race.yml`, matching what `test-all-erigon.yml` already does. This frees 20–30 GB on the runner before the race tests start.

## Test plan

- [ ] Verify `race-tests / tests-linux (ubuntu-latest, execution-other)` passes without disk-full error