### PR TITLE
rpc: return null storageKeys in eth_createAccessList when no storage

### DIFF
--- a/execution/tracing/tracers/logger/access_list_tracer.go
+++ b/execution/tracing/tracers/logger/access_list_tracer.go
@@ -114,11 +114,14 @@ func (al accessList) Equal(other accessList) bool {
 func (al accessList) accessList() types.AccessList {
 	acl := make(types.AccessList, len(al))
 	for addr, storage := range al {
-		tuple := types.AccessTuple{Address: addr, StorageKeys: make([]common.Hash, len(storage.slots))}
-		for slot, pos := range storage.slots {
-			tuple.StorageKeys[pos] = slot
+		var storageKeys []common.Hash
+		if len(storage.slots) > 0 {
+			storageKeys = make([]common.Hash, len(storage.slots))
+			for slot, pos := range storage.slots {
+				storageKeys[pos] = slot
+			}
 		}
-		acl[storage.order] = tuple
+		acl[storage.order] = types.AccessTuple{Address: addr, StorageKeys: storageKeys}
 	}
 	return acl
 }
@@ -127,13 +130,16 @@ func (al accessList) accessList() types.AccessList {
 func (al accessList) accessListSorted() types.AccessList {
 	acl := make(types.AccessList, 0, len(al))
 	for addr, storage := range al {
-		storageKeys := make([]common.Hash, len(storage.slots))
-		for slot, pos := range storage.slots {
-			storageKeys[pos] = slot
+		var storageKeys []common.Hash
+		if len(storage.slots) > 0 {
+			storageKeys = make([]common.Hash, len(storage.slots))
+			for slot, pos := range storage.slots {
+				storageKeys[pos] = slot
+			}
+			slices.SortFunc(storageKeys, func(a, b common.Hash) int {
+				return a.Cmp(b)
+			})
 		}
-		slices.SortFunc(storageKeys, func(a, b common.Hash) int {
-			return a.Cmp(b)
-		})
 		acl = append(acl, types.AccessTuple{
 			Address:     addr,
 			StorageKeys: storageKeys,

--- a/execution/tracing/tracers/logger/access_list_tracer_test.go
+++ b/execution/tracing/tracers/logger/access_list_tracer_test.go
@@ -55,3 +55,19 @@ func TestTracer_AccessList_Order(t *testing.T) {
 	require.Equal(t, ordered, al.accessListSorted())
 	require.True(t, al.Equal(al)) //nolint:gocritic
 }
+
+// TestTracer_AccessList_EmptyStorageKeys verifies that addresses with no storage
+// accesses produce nil storageKeys (serializes as JSON null), matching Geth behaviour.
+// See: https://github.com/ethereum/go-ethereum/issues/23233
+func TestTracer_AccessList_EmptyStorageKeys(t *testing.T) {
+	al := newAccessList()
+	al.addAddress(addr)
+
+	acl := al.accessList()
+	require.Len(t, acl, 1)
+	require.Nil(t, acl[0].StorageKeys)
+
+	aclSorted := al.accessListSorted()
+	require.Len(t, aclSorted, 1)
+	require.Nil(t, aclSorted[0].StorageKeys)
+}


### PR DESCRIPTION

When an address is accessed but has no storage slot reads/writes, eth_createAccessList was returning "storageKeys": [] (empty array) instead of "storageKeys": null. This aligns Erigon with Geth's actual behaviour, as confirmed by comparing responses from both clients against the same transaction.