### PR TITLE
ci: use App token in In-case-of-failure rollback job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -699,6 +699,14 @@ jobs:
     env:
       RELEASE_VERSION: ${{ inputs.release_version }}
     steps:
+      - name: Generate GitHub App token for git operations
+        id: generate_token_rollback
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf  ## v2.2.1
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
+          repositories: "erigon"
+
       - name: Checkout git repository ${{ env.APP_REPO }} reference ${{ inputs.checkout_ref }}
         uses: actions/checkout@v6
         with:
@@ -706,6 +714,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.checkout_ref }}
           path: 'erigon'
+          token: ${{ steps.generate_token_rollback.outputs.token }}
 
       - name: Rollback - remove git tag ${{ inputs.release_version }}
         if: ${{ (inputs.perform_release) && (inputs.release_version != '') }}


### PR DESCRIPTION
## Summary

- The `In-case-of-failure` rollback job deletes the release git tag when the pipeline fails mid-way (after the tag was pushed but before the release completed)
- It previously used the implicit `GITHUB_TOKEN`, which lacks the `workflows` scope — tag deletion would fail with "workflows scope may be required" if the tag pointed to a workflow-touching commit
- Apply the same App token pattern as `build-release`: generate a token via `RELEASE_BOT` before checkout so `git push -d` uses the App's credentials (which carry `Workflows: Write`)

## Test plan

- [ ] Verify `In-case-of-failure` job picks up the App token on next release run
- [ ] No change to happy-path behavior (job only runs on failure)

🤖 Generated with Claude