### PR TITLE
[r3.4] ci: use App token for build-release and In-case-of-failure rollback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -690,6 +690,14 @@ jobs:
     env:
       RELEASE_VERSION: ${{ inputs.release_version }}
     steps:
+      - name: Generate GitHub App token for git operations
+        id: generate_token_rollback
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf  ## v2.2.1
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
+          repositories: "erigon"
+
       - name: Checkout git repository ${{ env.APP_REPO }} reference ${{ inputs.checkout_ref }}
         uses: actions/checkout@v6
         with:
@@ -697,6 +705,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.checkout_ref }}
           path: 'erigon'
+          token: ${{ steps.generate_token_rollback.outputs.token }}
 
       - name: Rollback - remove git tag ${{ inputs.release_version }}
         if: ${{ (inputs.perform_release) && (inputs.release_version != '') }}


### PR DESCRIPTION
Cherry-pick of #20157 and #20162 to `release/3.4`.

## Summary

- `build-release`: use GitHub App token for checkout so `git push` of the release tag has `workflows` scope (#20157)
- `In-case-of-failure`: same App token treatment for the rollback `git push -d` that deletes the tag on failure (#20162)

Both fixes require `RELEASE_BOT` App to have `Workflows: Write` permission (already granted).

Co-Authored-By: Claude