### PR TITLE
btindex: rework prefix index with bucket architecture (63% faster seeks)

### DIFF
--- a/.github/actions/restore-mod-cache/action.yml
+++ b/.github/actions/restore-mod-cache/action.yml
@@ -19,27 +19,19 @@ outputs:
     value: ${{ steps.restore.outputs.cache-matched-key }}
   primary-key:
     description: "The primary cache key (for use by save-mod-cache)"
-    value: ${{ steps.compute-key.outputs.primary-key }}
+    value: ${{ steps.restore.outputs.cache-primary-key }}
 
 runs:
   using: composite
   steps:
-    - id: compute-key
-      shell: bash
-      run: |
-        gosum_hash=$(sha256sum go.sum | cut -d' ' -f1)
-        primary_key="gomodcache|${{ inputs.workflow-id }}|${{ github.job }}|${{ inputs.matrix-key }}|${{ runner.os }}|${gosum_hash}|${{ github.run_id }}|${{ github.run_attempt }}"
-        echo "primary-key=${primary_key}" >> "$GITHUB_OUTPUT"
-        echo "gosum-hash=${gosum_hash}" >> "$GITHUB_OUTPUT"
-
     - id: restore
       uses: actions/cache/restore@v4
       with:
         path: ${{ inputs.modcache-path }}/cache/download
-        key: ${{ steps.compute-key.outputs.primary-key }}
+        key: gomodcache|${{ inputs.workflow-id }}|${{ github.job }}|${{ inputs.matrix-key }}|${{ runner.os }}|${{ hashFiles('go.sum') }}|${{ github.run_id }}|${{ github.run_attempt }}
         restore-keys: |
-          gomodcache|${{ inputs.workflow-id }}|${{ github.job }}|${{ inputs.matrix-key }}|${{ runner.os }}|${{ steps.compute-key.outputs.gosum-hash }}|${{ github.run_id }}|
-          gomodcache|${{ inputs.workflow-id }}|${{ github.job }}|${{ inputs.matrix-key }}|${{ runner.os }}|${{ steps.compute-key.outputs.gosum-hash }}|
+          gomodcache|${{ inputs.workflow-id }}|${{ github.job }}|${{ inputs.matrix-key }}|${{ runner.os }}|${{ hashFiles('go.sum') }}|${{ github.run_id }}|
+          gomodcache|${{ inputs.workflow-id }}|${{ github.job }}|${{ inputs.matrix-key }}|${{ runner.os }}|${{ hashFiles('go.sum') }}|
 
     - name: Warn on module cache miss
       if: ${{ steps.restore.outputs.cache-matched-key == '' }}

--- a/.github/actions/restore-mod-cache/action.yml
+++ b/.github/actions/restore-mod-cache/action.yml
@@ -19,19 +19,27 @@ outputs:
     value: ${{ steps.restore.outputs.cache-matched-key }}
   primary-key:
     description: "The primary cache key (for use by save-mod-cache)"
-    value: ${{ steps.restore.outputs.cache-primary-key }}
+    value: ${{ steps.compute-key.outputs.primary-key }}
 
 runs:
   using: composite
   steps:
+    - id: compute-key
+      shell: bash
+      run: |
+        gosum_hash=$(sha256sum go.sum | cut -d' ' -f1)
+        primary_key="gomodcache|${{ inputs.workflow-id }}|${{ github.job }}|${{ inputs.matrix-key }}|${{ runner.os }}|${gosum_hash}|${{ github.run_id }}|${{ github.run_attempt }}"
+        echo "primary-key=${primary_key}" >> "$GITHUB_OUTPUT"
+        echo "gosum-hash=${gosum_hash}" >> "$GITHUB_OUTPUT"
+
     - id: restore
       uses: actions/cache/restore@v4
       with:
         path: ${{ inputs.modcache-path }}/cache/download
-        key: gomodcache|${{ inputs.workflow-id }}|${{ github.job }}|${{ inputs.matrix-key }}|${{ runner.os }}|${{ hashFiles('go.sum') }}|${{ github.run_id }}|${{ github.run_attempt }}
+        key: ${{ steps.compute-key.outputs.primary-key }}
         restore-keys: |
-          gomodcache|${{ inputs.workflow-id }}|${{ github.job }}|${{ inputs.matrix-key }}|${{ runner.os }}|${{ hashFiles('go.sum') }}|${{ github.run_id }}|
-          gomodcache|${{ inputs.workflow-id }}|${{ github.job }}|${{ inputs.matrix-key }}|${{ runner.os }}|${{ hashFiles('go.sum') }}|
+          gomodcache|${{ inputs.workflow-id }}|${{ github.job }}|${{ inputs.matrix-key }}|${{ runner.os }}|${{ steps.compute-key.outputs.gosum-hash }}|${{ github.run_id }}|
+          gomodcache|${{ inputs.workflow-id }}|${{ github.job }}|${{ inputs.matrix-key }}|${{ runner.os }}|${{ steps.compute-key.outputs.gosum-hash }}|
 
     - name: Warn on module cache miss
       if: ${{ steps.restore.outputs.cache-matched-key == '' }}

--- a/db/datastruct/btindex/bps_tree.go
+++ b/db/datastruct/btindex/bps_tree.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"time"
 	"unsafe"
 
@@ -34,19 +35,149 @@ import (
 	"github.com/erigontech/erigon/db/seg"
 )
 
-// nolint
-type indexSeeker interface {
-	WarmUp(g *seg.Reader) error
-	Get(g *seg.Reader, key []byte) (k []byte, found bool, di uint64, err error)
-	//seekInFiles(g *seg.Reader, key []byte) (indexSeekerIterator, error)
-	Seek(g *seg.Reader, seek []byte) (k []byte, di uint64, found bool, err error)
+const minKeysForPrefixIndex = 60_000
+const maxNodesPerBucket = 8
+
+// prefixBucket holds the DI range and cached nodes for a single 2-byte prefix.
+type prefixBucket struct {
+	firstDI uint64 // DI of first key with this 2-byte prefix (MaxUint64 = empty)
+	endDI   uint64 // DI past last key with this prefix (exclusive upper bound)
+	nodes   []Node // cached keys for per-bucket binary search, max 8
 }
 
-// nolint
-type indexSeekerIterator interface {
-	Next() bool
-	Di() uint64
-	KVFromGetter(g *seg.Reader) ([]byte, []byte, error)
+// prefixIndex maps first 2 bytes of keys to prefixBucket structs.
+// Each bucket tracks the [firstDI, endDI) range and embeds up to 8 cached nodes.
+// L1 arrays aggregate bucket ranges for 1-byte prefix fallback.
+type prefixIndex struct {
+	buckets [65536]prefixBucket
+	l1First [256]uint64 // min(firstDI) across buckets[b0<<8..b0<<8|0xFF]
+	l1End   [256]uint64 // max(endDI) across buckets[b0<<8..b0<<8|0xFF]
+}
+
+func newPrefixIndex() *prefixIndex {
+	p := new(prefixIndex)
+	for i := range p.buckets {
+		p.buckets[i].firstDI = math.MaxUint64
+	}
+	for i := range p.l1First {
+		p.l1First[i] = math.MaxUint64
+	}
+	return p
+}
+
+// record updates the bucket for the 2-byte prefix of key with the given di.
+// On first occurrence sets firstDI; always updates endDI = di + 1.
+func (p *prefixIndex) record(key []byte, di uint64) {
+	if len(key) < 2 {
+		return
+	}
+	prefix := uint16(key[0])<<8 | uint16(key[1])
+	b := &p.buckets[prefix]
+	if di < b.firstDI {
+		b.firstDI = di
+	}
+	if di+1 > b.endDI {
+		b.endDI = di + 1
+	}
+}
+
+// addNode appends a cached node to the bucket for the key's 2-byte prefix,
+// up to maxNodesPerBucket.
+func (p *prefixIndex) addNode(key []byte, node Node) {
+	if len(key) < 2 {
+		return
+	}
+	prefix := uint16(key[0])<<8 | uint16(key[1])
+	b := &p.buckets[prefix]
+	if len(b.nodes) < maxNodesPerBucket {
+		b.nodes = append(b.nodes, node)
+	}
+}
+
+// computeL1 aggregates bucket ranges into L1 summary arrays.
+// For each first byte b0, scans buckets[b0<<8..b0<<8|0xFF] to find
+// min non-sentinel firstDI and max endDI.
+func (p *prefixIndex) computeL1() {
+	for b0 := 0; b0 < 256; b0++ {
+		minFirst := uint64(math.MaxUint64)
+		maxEnd := uint64(0)
+		base := uint16(b0) << 8
+		for b1 := 0; b1 < 256; b1++ {
+			bkt := &p.buckets[base|uint16(b1)]
+			if bkt.firstDI < minFirst {
+				minFirst = bkt.firstDI
+			}
+			if bkt.endDI > maxEnd {
+				maxEnd = bkt.endDI
+			}
+		}
+		p.l1First[b0] = minFirst
+		p.l1End[b0] = maxEnd
+	}
+}
+
+// lookup returns the [l, r) DI range for a key based on its prefix.
+// len<1 returns full range, len==1 uses L1 tables, len>=2 uses bucket with L1 fallback.
+// Returns (0, 0) for an empty (non-existent) prefix.
+func (p *prefixIndex) lookup(key []byte, totalCount uint64) (l, r uint64) {
+	if len(key) < 1 {
+		return 0, totalCount
+	}
+	if len(key) == 1 {
+		b0 := key[0]
+		if p.l1First[b0] == math.MaxUint64 {
+			return 0, 0
+		}
+		return p.l1First[b0], p.l1End[b0]
+	}
+	// len >= 2: try exact bucket
+	prefix := uint16(key[0])<<8 | uint16(key[1])
+	bkt := &p.buckets[prefix]
+	if bkt.firstDI != math.MaxUint64 {
+		return bkt.firstDI, bkt.endDI
+	}
+	// Fallback to L1
+	b0 := key[0]
+	if p.l1First[b0] == math.MaxUint64 {
+		return 0, 0
+	}
+	return p.l1First[b0], p.l1End[b0]
+}
+
+// narrowWithNodes performs binary search over cached nodes in the bucket
+// for the key's 2-byte prefix. Returns narrowed [l, r) range, or exact match.
+// On exact match: found=true, exactDI=node.di. Otherwise narrows [l, r)
+// from node boundaries. Returns (0, 0, 0, false) when no narrowing is possible.
+func (p *prefixIndex) narrowWithNodes(key []byte) (l, r uint64, exactDI uint64, found bool) {
+	if len(key) < 2 {
+		return 0, 0, 0, false
+	}
+	prefix := uint16(key[0])<<8 | uint16(key[1])
+	bkt := &p.buckets[prefix]
+	if len(bkt.nodes) == 0 {
+		return 0, 0, 0, false
+	}
+
+	l, r = bkt.firstDI, bkt.endDI
+	lo, hi := 0, len(bkt.nodes)
+	for lo < hi {
+		mid := (lo + hi) >> 1
+		cmp := bytes.Compare(bkt.nodes[mid].key, key)
+		if cmp == 0 {
+			return 0, 0, bkt.nodes[mid].di, true
+		} else if cmp < 0 {
+			lo = mid + 1
+			if bkt.nodes[mid].di+1 > l {
+				l = bkt.nodes[mid].di + 1
+			}
+		} else {
+			hi = mid
+			if bkt.nodes[mid].di < r {
+				r = bkt.nodes[mid].di
+			}
+		}
+	}
+	return l, r, 0, false
 }
 
 type dataLookupFunc func(di uint64, g *seg.Reader) ([]byte, []byte, uint64, error)
@@ -65,7 +196,7 @@ func NewBpsTree(kv *seg.Reader, offt *eliasfano32.EliasFano, M uint64, dataLooku
 var envAssertBTKeys = dbg.EnvBool("BT_ASSERT_OFFSETS", false)
 
 func NewBpsTreeWithNodes(kv *seg.Reader, offt *eliasfano32.EliasFano, M uint64, dataLookup dataLookupFunc, keyCmp keyCmpFunc, nodes []Node) *BpsTree {
-	bt := &BpsTree{M: M, offt: offt, dataLookupFunc: dataLookup, keyCmpFunc: keyCmp, mx: nodes}
+	bt := &BpsTree{M: M, offt: offt, dataLookupFunc: dataLookup, keyCmpFunc: keyCmp}
 
 	nsz := uint64(unsafe.Sizeof(Node{}))
 	var cachedBytes uint64
@@ -84,14 +215,36 @@ func NewBpsTreeWithNodes(kv *seg.Reader, offt *eliasfano32.EliasFano, M uint64, 
 		nodes[i].off = offt.Get(nodes[i].di)
 	}
 
+	N := offt.Count()
+	if N >= minKeysForPrefixIndex {
+		// Large-file path: build prefix index from sequential scan, distribute nodes into buckets.
+		bt.prefix = newPrefixIndex()
+
+		var key []byte
+		kv.Reset(0)
+		for di := uint64(0); di < N; di++ {
+			key, _ = kv.Next(key[:0])
+			kv.Skip()
+			bt.prefix.record(key, di)
+		}
+
+		for i := range nodes {
+			bt.prefix.addNode(nodes[i].key, nodes[i])
+		}
+		bt.prefix.computeL1()
+	} else {
+		// Small-file path: keep nodes in mx as before.
+		bt.mx = nodes
+	}
 	return bt
 }
 
 type BpsTree struct {
-	offt  *eliasfano32.EliasFano // ef with offsets to key/vals
-	mx    []Node
-	M     uint64 // limit on amount of 'children' for node
-	trace bool
+	offt   *eliasfano32.EliasFano // ef with offsets to key/vals
+	mx     []Node
+	prefix *prefixIndex // 2-level prefix index for O(1) range narrowing; nil when N < minKeysForPrefixIndex
+	M      uint64       // limit on amount of 'children' for node
+	trace  bool
 
 	dataLookupFunc dataLookupFunc
 	keyCmpFunc     keyCmpFunc
@@ -104,34 +257,6 @@ type BpsTreeIterator struct {
 	t *BpsTree
 	i uint64
 }
-
-//// If data[i] == key, returns 0 (equal) and value, nil err
-//// if data[i] <> key, returns comparation result and nil value and error -- to be able to compare later
-//func (b *BpsTree) matchKeyValue(g ArchiveGetter, i uint64, key []byte) (int, []byte, error) {
-//	if i >= b.offt.Count() {
-//		return 0, nil, ErrBtIndexLookupBounds
-//	}
-//	if b.trace {
-//		fmt.Printf("match %d-%x count %d\n", i, key, b.offt.Count())
-//	}
-//	g.Reset(b.offt.Get(i))
-//	buf, _ := g.Next(nil)
-//	if !bytes.Equal(buf, key) {
-//		return bytes.Compare(buf, key), nil, nil
-//	}
-//	val, _ := g.Next(nil)
-//	return 0, val, nil
-//}
-//
-//func (b *BpsTree) lookupKeyWGetter(g ArchiveGetter, i uint64) ([]byte, uint64) {
-//	if i >= b.offt.Count() {
-//		return nil, 0
-//	}
-//	o := b.offt.Get(i)
-//	g.Reset(o)
-//	buf, _ := g.Next(nil)
-//	return buf, o
-//}
 
 type Node struct {
 	key []byte
@@ -186,7 +311,6 @@ func (n *Node) Decode(buf []byte) (uint64, error) {
 		return 0, errors.New("short buffer")
 	}
 	n.key = buf[10 : 10+l]
-	//madvise(k, len(k), MADV_WILL_NEED)
 	return uint64(10 + l), nil
 }
 
@@ -196,34 +320,66 @@ func (b *BpsTree) WarmUp(kv *seg.Reader) (err error) {
 	if N == 0 {
 		return nil
 	}
-	b.mx = make([]Node, 0, N/b.M)
-	if b.trace {
-		fmt.Printf("mx cap %d N=%d M=%d\n", cap(b.mx), N, b.M)
-	}
 
 	step := b.M
 	if N < b.M { // cache all keys if less than M
 		step = 1
 	}
 
-	// extremely stupid picking of needed nodes:
+	if N >= minKeysForPrefixIndex {
+		b.prefix = newPrefixIndex()
+	}
+
 	cachedBytes := uint64(0)
 	nsz := uint64(unsafe.Sizeof(Node{}))
 	var key []byte
-	for i := step; i < N; i += step {
-		di := i - 1
-		_, key, err = b.keyCmpFunc(nil, di, kv, key[:0])
-		if err != nil {
-			return err
+	var cachedCount int
+
+	if b.prefix != nil {
+		// Large-file path: sequential scan, record all keys in prefix index,
+		// embed every M-th key as a node in its prefix bucket.
+		kv.Reset(0)
+		nextCache := step - 1
+		for di := uint64(0); di < N; di++ {
+			key, _ = kv.Next(key[:0])
+			kv.Skip()
+
+			b.prefix.record(key, di)
+
+			if di == nextCache {
+				node := Node{off: b.offt.Get(di), key: common.Copy(key), di: di}
+				b.prefix.addNode(key, node)
+				cachedBytes += nsz + uint64(len(key))
+				cachedCount++
+				nextCache += step
+			}
 		}
-		b.mx = append(b.mx, Node{off: b.offt.Get(di), key: common.Copy(key), di: di})
-		cachedBytes += nsz + uint64(len(key))
+		b.prefix.computeL1()
+	} else {
+		// Small-file path: read only every step-th key via random access, populate mx
+		b.mx = make([]Node, 0, N/b.M)
+		for i := step; i < N; i += step {
+			di := i - 1
+			_, key, err = b.keyCmpFunc(nil, di, kv, key[:0])
+			if err != nil {
+				return err
+			}
+			b.mx = append(b.mx, Node{off: b.offt.Get(di), key: common.Copy(key), di: di})
+			cachedBytes += nsz + uint64(len(key))
+			cachedCount++
+		}
 	}
 
-	log.Root().Debug("WarmUp finished", "file", kv.FileName(), "M", b.M, "N", common.PrettyCounter(N),
-		"cached", fmt.Sprintf("%d %.2f%%", len(b.mx), 100*(float64(len(b.mx))/float64(N))),
+	args := []interface{}{
+		"file", kv.FileName(), "M", b.M, "N", common.PrettyCounter(N),
+		"cached", fmt.Sprintf("%d %.2f%%", cachedCount, 100*(float64(cachedCount)/float64(N))),
 		"cacheSize", datasize.ByteSize(cachedBytes).HR(), "fileSize", datasize.ByteSize(kv.Size()).HR(),
-		"took", time.Since(t))
+		"took", time.Since(t),
+	}
+	if b.prefix != nil {
+		args = append(args, "prefixIdx", true)
+	}
+	log.Root().Debug("WarmUp finished", args...)
 	return nil
 }
 
@@ -271,17 +427,43 @@ func (b *BpsTree) Seek(g *seg.Reader, seekKey []byte) (cur *Cursor, err error) {
 		return cur, nil
 	}
 
-	// check cached nodes and narrow roi
-	n, l, r := b.bs(seekKey) // l===r when key is found
-	if l == r {
-		cur.Reset(n.di, g)
-		return cur, nil
+	// Start with full range
+	l, r := uint64(0), b.offt.Count()
+
+	if b.prefix != nil {
+		// Large-file path: use prefix index for range lookup and cached node search
+		pl, pr := b.prefix.lookup(seekKey, b.offt.Count())
+		if pl != 0 || pr != 0 {
+			l, r = pl, pr
+		}
+		nl, nr, exactDI, found := b.prefix.narrowWithNodes(seekKey)
+		if found {
+			err = cur.Reset(exactDI, g)
+			return cur, err
+		}
+		if nl != 0 || nr != 0 {
+			if nl > l {
+				l = nl
+			}
+			if nr < r {
+				r = nr
+			}
+		}
+	} else if r-l > b.M {
+		// Small-file path: use bs() for cached-node binary search
+		n, bl, br := b.bs(seekKey)
+		if bl == br {
+			cur.Reset(n.di, g)
+			return cur, nil
+		}
+		if bl > l {
+			l = bl
+		}
+		if br < r {
+			r = br
+		}
 	}
 
-	// if b.trace {
-	// 	fmt.Printf("pivot di:%d di(LR): [%d %d] k: %x found: %t\n", n.di, l, r, n.key, l == r)
-	// 	defer func() { fmt.Printf("found=%t %x [%d %d]\n", bytes.Equal(key, seekKey), seekKey, l, r) }()
-	// }
 	var m uint64
 	var cmp int
 
@@ -349,10 +531,45 @@ func (b *BpsTree) Get(g *seg.Reader, key []byte) (v []byte, ok bool, offset uint
 		return v0, true, 0, nil
 	}
 
-	n, l, r := b.bs(key) // l===r when key is found
-	if b.trace {
-		fmt.Printf("pivot di: %d di(LR): [%d %d] k: %x found: %t\n", n.di, l, r, n.key, l == r)
-		defer func() { fmt.Printf("found %x [%d %d]\n", key, l, r) }()
+	// Start with full range
+	l, r := uint64(0), b.offt.Count()
+
+	if b.prefix != nil {
+		// Large-file path: use prefix index for range lookup and cached node search
+		pl, pr := b.prefix.lookup(key, b.offt.Count())
+		if pl == 0 && pr == 0 {
+			return nil, false, 0, nil // no keys with this prefix
+		}
+		l, r = pl, pr
+		nl, nr, exactDI, found := b.prefix.narrowWithNodes(key)
+		if found {
+			offset = b.offt.Get(exactDI)
+			g.Reset(offset)
+			g.Buf, _ = g.Next(g.Buf[:0]) // skip key
+			v, _ = g.Next(nil)
+			return v, true, offset, nil
+		}
+		if nl != 0 || nr != 0 {
+			if nl > l {
+				l = nl
+			}
+			if nr < r {
+				r = nr
+			}
+		}
+	} else if r-l > b.M {
+		// Small-file path: use bs() for cached-node binary search
+		n, bl, br := b.bs(key)
+		if b.trace {
+			fmt.Printf("pivot di: %d di(LR): [%d %d] k: %x found: %t\n", n.di, bl, br, n.key, bl == br)
+			defer func() { fmt.Printf("found %x [%d %d]\n", key, l, r) }()
+		}
+		if bl > l {
+			l = bl
+		}
+		if br < r {
+			r = br
+		}
 	}
 
 	var cmp int
@@ -435,4 +652,5 @@ func (b *BpsTree) Distances() (map[int]int, error) {
 func (b *BpsTree) Close() {
 	b.mx = nil
 	b.offt = nil
+	b.prefix = nil // release ~2.5MB prefix index memory
 }

--- a/db/datastruct/btindex/bpstree_bench_test.go
+++ b/db/datastruct/btindex/bpstree_bench_test.go
@@ -51,3 +51,105 @@ func BenchmarkBpsTreeSeek(t *testing.B) {
 	}
 	t.ReportAllocs()
 }
+
+func BenchmarkBpsTreeGet(t *testing.B) {
+	tmp := t.TempDir()
+	logger := log.New()
+	keyCount, M := 12_000_000, 256
+	if testing.Short() {
+		keyCount = 10_000
+	}
+	t.Logf("N: %d, M: %d", keyCount, M)
+	compressFlags := seg.CompressKeys | seg.CompressVals
+
+	dataPath := generateKV(t, tmp, 52, 180, keyCount, logger, 0)
+
+	indexPath := filepath.Join(tmp, filepath.Base(dataPath)+".bti")
+	buildBtreeIndex(t, dataPath, indexPath, compressFlags, 1, logger, true)
+
+	kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, dataPath, uint64(M), compressFlags, false)
+	require.NoError(t, err)
+	require.EqualValues(t, bt.KeyCount(), keyCount)
+	defer bt.Close()
+	defer kv.Close()
+
+	var key []byte
+
+	getter := seg.NewReader(kv.MakeGetter(), compressFlags)
+	getter.Reset(0)
+
+	t.ReportAllocs()
+	for t.Loop() {
+		if !getter.HasNext() {
+			getter.Reset(0)
+		}
+		key, _ = getter.Next(key[:0])
+		getter.Skip()
+		_, v, _, ok, err := bt.Get(key, getter)
+		require.NoError(t, err)
+		require.True(t, ok)
+		_ = v
+	}
+	t.ReportAllocs()
+}
+
+func BenchmarkBpsTreeSeekLargeFile(t *testing.B) {
+	tmp := t.TempDir()
+	logger := log.New()
+	keyCount, M := 1_000_000, 256
+	if testing.Short() {
+		keyCount = 10_000
+	}
+	t.Logf("N: %d, M: %d (prefix index threshold: %d)", keyCount, M, minKeysForPrefixIndex)
+	compressFlags := seg.CompressKeys | seg.CompressVals
+
+	// 20-byte keys: typical Ethereum hash length
+	dataPath := generateKV(t, tmp, 20, 32, keyCount, logger, 0)
+
+	indexPath := filepath.Join(tmp, filepath.Base(dataPath)+".bti")
+	buildBtreeIndex(t, dataPath, indexPath, compressFlags, 1, logger, true)
+
+	kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, dataPath, uint64(M), compressFlags, false)
+	require.NoError(t, err)
+	require.EqualValues(t, bt.KeyCount(), keyCount)
+	defer bt.Close()
+	defer kv.Close()
+
+	getter := seg.NewReader(kv.MakeGetter(), compressFlags)
+	var key []byte
+
+	t.Run("WithPrefixIndex", func(t *testing.B) {
+		getter.Reset(0)
+		t.ReportAllocs()
+		for t.Loop() {
+			if !getter.HasNext() {
+				getter.Reset(0)
+			}
+			key, _ = getter.Next(key[:0])
+			getter.Skip()
+			c, err := bt.Seek(getter, key)
+			require.NoError(t, err)
+			c.Close()
+		}
+	})
+
+	t.Run("WithoutPrefixIndex", func(t *testing.B) {
+		// Disable prefix index to measure the delta
+		savedPrefix := bt.bplus.prefix
+		bt.bplus.prefix = nil
+		defer func() { bt.bplus.prefix = savedPrefix }()
+
+		getter.Reset(0)
+		t.ReportAllocs()
+		for t.Loop() {
+			if !getter.HasNext() {
+				getter.Reset(0)
+			}
+			key, _ = getter.Next(key[:0])
+			getter.Skip()
+			c, err := bt.Seek(getter, key)
+			require.NoError(t, err)
+			c.Close()
+		}
+	})
+}

--- a/db/datastruct/btindex/btree_index_test.go
+++ b/db/datastruct/btindex/btree_index_test.go
@@ -19,6 +19,7 @@ package btindex
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -406,24 +407,444 @@ func (b *mockIndexReader) keyCmp(k []byte, di uint64, g *seg.Reader, resBuf []by
 
 func TestNewBtIndex(t *testing.T) {
 	t.Parallel()
-	keyCount := 10000
-	kvPath := generateKV(t, t.TempDir(), 20, 10, keyCount, log.New(), seg.CompressNone)
 
-	indexPath := strings.TrimSuffix(kvPath, ".kv") + ".bt"
+	t.Run("small file uses mx", func(t *testing.T) {
+		t.Parallel()
+		keyCount := 10000
+		kvPath := generateKV(t, t.TempDir(), 20, 10, keyCount, log.New(), seg.CompressNone)
 
-	kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, kvPath, DefaultBtreeM, seg.CompressNone, false)
+		indexPath := strings.TrimSuffix(kvPath, ".kv") + ".bt"
+
+		kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, kvPath, DefaultBtreeM, seg.CompressNone, false)
+		require.NoError(t, err)
+		defer bt.Close()
+		defer kv.Close()
+		require.NotNil(t, kv)
+		require.NotNil(t, bt)
+		bplus := bt.bplus
+		require.Nil(t, bplus.prefix, "small files should not have prefix index")
+		require.GreaterOrEqual(t, len(bplus.mx), keyCount/int(DefaultBtreeM))
+
+		for i := 1; i < len(bt.bplus.mx); i++ {
+			require.NotZero(t, bt.bplus.mx[i].di)
+			require.NotZero(t, bt.bplus.mx[i].off)
+			require.NotEmpty(t, bt.bplus.mx[i].key)
+		}
+	})
+
+	t.Run("large file uses prefix buckets", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("slow test")
+		}
+		t.Parallel()
+		keyCount := 65_000 // above minKeysForPrefixIndex threshold
+		kvPath := generateKV(t, t.TempDir(), 20, 10, keyCount, log.New(), seg.CompressNone)
+
+		indexPath := strings.TrimSuffix(kvPath, ".kv") + ".bt"
+
+		kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, kvPath, DefaultBtreeM, seg.CompressNone, false)
+		require.NoError(t, err)
+		defer bt.Close()
+		defer kv.Close()
+		require.NotNil(t, kv)
+		require.NotNil(t, bt)
+		bplus := bt.bplus
+		require.NotNil(t, bplus.prefix, "large files should have prefix index")
+		require.Empty(t, bplus.mx, "large files should not populate mx")
+
+		// Verify prefix buckets contain nodes
+		totalNodes := 0
+		nonEmptyBuckets := 0
+		for i := range bplus.prefix.buckets {
+			b := &bplus.prefix.buckets[i]
+			if b.firstDI != math.MaxUint64 {
+				nonEmptyBuckets++
+				require.Less(t, b.firstDI, b.endDI, "bucket %d: firstDI must be < endDI", i)
+			}
+			totalNodes += len(b.nodes)
+			require.LessOrEqual(t, len(b.nodes), maxNodesPerBucket, "bucket %d exceeds max nodes", i)
+		}
+		require.Greater(t, nonEmptyBuckets, 0, "should have non-empty buckets")
+		require.Greater(t, totalNodes, 0, "should have cached nodes in buckets")
+
+		// Verify L1 tables are populated
+		hasL1 := false
+		for i := range bplus.prefix.l1First {
+			if bplus.prefix.l1First[i] != math.MaxUint64 {
+				hasL1 = true
+				require.Less(t, bplus.prefix.l1First[i], bplus.prefix.l1End[i],
+					"L1[%d]: l1First must be < l1End", i)
+			}
+		}
+		require.True(t, hasL1, "should have non-empty L1 entries")
+	})
+}
+
+func TestPrefixIndexLookup(t *testing.T) {
+	t.Parallel()
+
+	p := newPrefixIndex()
+	// Record keys with known prefixes and di values
+	// Prefix 0x01xx starts at di=100
+	p.record([]byte{0x01, 0x00, 0xaa}, 100)
+	p.record([]byte{0x01, 0x10, 0xbb}, 200)
+	p.record([]byte{0x01, 0x20, 0xcc}, 300)
+	// Prefix 0x02xx starts at di=500
+	p.record([]byte{0x02, 0xab, 0xdd}, 500)
+	p.record([]byte{0x02, 0xac, 0xee}, 600)
+	// Prefix 0x05xx starts at di=1000
+	p.record([]byte{0x05, 0xff, 0x11}, 1000)
+
+	p.computeL1()
+	totalCount := uint64(2000)
+
+	// Test L2 lookup: key 0x02ab has only di=500, so range is [500, 501)
+	l, r := p.lookup([]byte{0x02, 0xab, 0x00}, totalCount)
+	require.Equal(t, uint64(500), l, "L2 left bound")
+	require.Equal(t, uint64(501), r, "L2 right bound (maxDi+1)")
+
+	// Test L2 lookup: key 0x02ac has only di=600, so range is [600, 601)
+	l, r = p.lookup([]byte{0x02, 0xac, 0x00}, totalCount)
+	require.Equal(t, uint64(600), l, "L2 left bound for 0x02ac")
+	require.Equal(t, uint64(601), r, "L2 right bound for 0x02ac (maxDi+1)")
+
+	// Test L1 lookup: key with only 1 byte 0x02 should use L1 bounds [500, 601)
+	l, r = p.lookup([]byte{0x02}, totalCount)
+	require.Equal(t, uint64(500), l, "L1 left bound")
+	require.Equal(t, uint64(601), r, "L1 right bound (maxDi+1)")
+
+	// Test L1 lookup: last prefix 0x05 has only di=1000, range is [1000, 1001)
+	l, r = p.lookup([]byte{0x05, 0xff}, totalCount)
+	require.Equal(t, uint64(1000), l, "last prefix left bound")
+	require.Equal(t, uint64(1001), r, "last prefix right bound (maxDi+1)")
+
+	// Test non-existent prefix: 0x03 has no keys
+	l, r = p.lookup([]byte{0x03, 0x00}, totalCount)
+	require.Equal(t, uint64(0), l, "non-existent prefix should return 0")
+	require.Equal(t, uint64(0), r, "non-existent prefix should return 0")
+
+	// Test empty key: no narrowing
+	l, r = p.lookup([]byte{}, totalCount)
+	require.Equal(t, uint64(0), l)
+	require.Equal(t, totalCount, r)
+
+	// Test L2 with non-existent second byte: 0x01,0x05 doesn't exist, should fall back to L1 bounds
+	l, r = p.lookup([]byte{0x01, 0x05}, totalCount)
+	require.Equal(t, uint64(100), l, "should use L1 left when L2 entry missing")
+	require.Equal(t, uint64(301), r, "should use L1 right when L2 entry missing (maxDi+1)")
+
+	// Test record with duplicate lower di: should keep minimum
+	p.record([]byte{0x02, 0xab, 0x00}, 450)
+	l, _ = p.lookup([]byte{0x02, 0xab, 0x00}, totalCount)
+	require.Equal(t, uint64(450), l, "record should keep minimum di")
+}
+
+func TestPrefixIndexNarrowWithNodes(t *testing.T) {
+	t.Parallel()
+
+	p := newPrefixIndex()
+
+	// Set up bucket 0x0200 with range [100, 200)
+	p.buckets[0x0200].firstDI = 100
+	p.buckets[0x0200].endDI = 200
+
+	// Add cached nodes (must be sorted by key)
+	p.buckets[0x0200].nodes = []Node{
+		{key: []byte{0x02, 0x00, 0x10}, di: 110},
+		{key: []byte{0x02, 0x00, 0x30}, di: 130},
+		{key: []byte{0x02, 0x00, 0x50}, di: 150},
+		{key: []byte{0x02, 0x00, 0x70}, di: 170},
+	}
+
+	// Test exact match
+	l, r, exactDI, found := p.narrowWithNodes([]byte{0x02, 0x00, 0x30})
+	require.True(t, found, "should find exact match")
+	require.Equal(t, uint64(130), exactDI)
+	_ = l
+	_ = r
+
+	// Test narrowing: key between nodes[1] and nodes[2]
+	l, r, _, found = p.narrowWithNodes([]byte{0x02, 0x00, 0x40})
+	require.False(t, found, "should not find exact match")
+	require.Equal(t, uint64(131), l, "left should be di of node[1]+1")
+	require.Equal(t, uint64(150), r, "right should be di of node[2]")
+
+	// Test narrowing: key before all nodes
+	l, r, _, found = p.narrowWithNodes([]byte{0x02, 0x00, 0x05})
+	require.False(t, found)
+	require.Equal(t, uint64(100), l, "left should be bucket firstDI")
+	require.Equal(t, uint64(110), r, "right should be di of first node")
+
+	// Test narrowing: key after all nodes
+	l, r, _, found = p.narrowWithNodes([]byte{0x02, 0x00, 0x80})
+	require.False(t, found)
+	require.Equal(t, uint64(171), l, "left should be di of last node + 1")
+	require.Equal(t, uint64(200), r, "right should be bucket endDI")
+
+	// Test bucket with no nodes: returns (0, 0, 0, false)
+	p.buckets[0x0300].firstDI = 500
+	p.buckets[0x0300].endDI = 600
+	l, r, _, found = p.narrowWithNodes([]byte{0x03, 0x00, 0x10})
+	require.False(t, found)
+	require.Equal(t, uint64(0), l)
+	require.Equal(t, uint64(0), r)
+
+	// Test short key: returns (0, 0, 0, false)
+	l, r, _, found = p.narrowWithNodes([]byte{0x02})
+	require.False(t, found)
+	require.Equal(t, uint64(0), l)
+	require.Equal(t, uint64(0), r)
+}
+
+func TestPrefixIndexComputeL1(t *testing.T) {
+	t.Parallel()
+
+	p := newPrefixIndex()
+
+	// Set up buckets for first byte 0x01
+	p.buckets[0x0100].firstDI = 50
+	p.buckets[0x0100].endDI = 60
+	p.buckets[0x010A].firstDI = 100
+	p.buckets[0x010A].endDI = 200
+	p.buckets[0x01FF].firstDI = 300
+	p.buckets[0x01FF].endDI = 350
+
+	// Set up buckets for first byte 0x02
+	p.buckets[0x0200].firstDI = 400
+	p.buckets[0x0200].endDI = 500
+
+	// First byte 0x03 has no buckets (all sentinel)
+
+	p.computeL1()
+
+	// L1 for 0x01: min firstDI = 50, max endDI = 350
+	require.Equal(t, uint64(50), p.l1First[0x01])
+	require.Equal(t, uint64(350), p.l1End[0x01])
+
+	// L1 for 0x02: single bucket
+	require.Equal(t, uint64(400), p.l1First[0x02])
+	require.Equal(t, uint64(500), p.l1End[0x02])
+
+	// L1 for 0x03: all sentinel (no buckets)
+	require.Equal(t, uint64(math.MaxUint64), p.l1First[0x03])
+	require.Equal(t, uint64(0), p.l1End[0x03])
+
+	// Verify lookup uses computed L1
+	l, r := p.lookup([]byte{0x01}, 1000)
+	require.Equal(t, uint64(50), l)
+	require.Equal(t, uint64(350), r)
+
+	l, r = p.lookup([]byte{0x03}, 1000)
+	require.Equal(t, uint64(0), l, "empty L1 prefix returns (0,0)")
+	require.Equal(t, uint64(0), r, "empty L1 prefix returns (0,0)")
+}
+
+func TestPrefixIndexAddNode(t *testing.T) {
+	t.Parallel()
+
+	p := newPrefixIndex()
+
+	// Add nodes to a bucket
+	for i := 0; i < maxNodesPerBucket+3; i++ {
+		p.addNode([]byte{0x01, 0x00, byte(i)}, Node{
+			key: []byte{0x01, 0x00, byte(i)},
+			di:  uint64(i * 10),
+		})
+	}
+
+	// Should cap at maxNodesPerBucket
+	require.Equal(t, maxNodesPerBucket, len(p.buckets[0x0100].nodes))
+
+	// Short key should be ignored
+	p.addNode([]byte{0x01}, Node{key: []byte{0x01}, di: 999})
+	require.Equal(t, maxNodesPerBucket, len(p.buckets[0x0100].nodes))
+}
+
+func TestWarmUpLargeFilePopulatesPrefixBuckets(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow test")
+	}
+	t.Parallel()
+
+	tmp := t.TempDir()
+	logger := log.New()
+	keyCount := 65_000 // above minKeysForPrefixIndex (60_000)
+	M := uint64(256)
+
+	compressFlag := seg.CompressNone
+	dataPath := generateKV(t, tmp, 10, 16, keyCount, logger, compressFlag)
+
+	kv, err := seg.NewDecompressor(dataPath)
 	require.NoError(t, err)
-	defer bt.Close()
 	defer kv.Close()
-	require.NotNil(t, kv)
-	require.NotNil(t, bt)
-	bplus := bt.bplus
-	require.GreaterOrEqual(t, len(bplus.mx), keyCount/int(DefaultBtreeM))
 
-	for i := 1; i < len(bt.bplus.mx); i++ {
-		require.NotZero(t, bt.bplus.mx[i].di)
-		require.NotZero(t, bt.bplus.mx[i].off)
-		require.NotEmpty(t, bt.bplus.mx[i].key)
+	g := seg.NewReader(kv.MakeGetter(), compressFlag)
+
+	// Read all keys and offsets
+	g.Reset(0)
+	ps := make([]uint64, 0, keyCount)
+	keys := make([][]byte, 0, keyCount)
+	p := uint64(0)
+	for g.HasNext() {
+		ps = append(ps, p)
+		k, _ := g.Next(nil)
+		_, p = g.Next(nil)
+		keys = append(keys, common.Copy(k))
+	}
+	require.Equal(t, keyCount, len(keys))
+
+	ef := eliasfano32.NewEliasFano(uint64(keyCount), ps[len(ps)-1])
+	for i := 0; i < len(ps); i++ {
+		ef.AddOffset(ps[i])
+	}
+	ef.Build()
+	efi, _ := eliasfano32.ReadEliasFano(ef.AppendBytes(nil))
+
+	ir := NewMockIndexReader(efi)
+	bp := NewBpsTree(g, efi, M, ir.dataLookup, ir.keyCmp)
+
+	// Prefix index should be active
+	require.NotNil(t, bp.prefix, "prefix index should be built for large files")
+	// mx should NOT be populated for large files
+	require.Empty(t, bp.mx, "mx should not be populated when prefix index is active")
+
+	// Spot-check: at least some buckets should have non-sentinel firstDI
+	nonEmptyBuckets := 0
+	totalNodes := 0
+	for i := range bp.prefix.buckets {
+		if bp.prefix.buckets[i].firstDI != math.MaxUint64 {
+			nonEmptyBuckets++
+			require.Less(t, bp.prefix.buckets[i].firstDI, bp.prefix.buckets[i].endDI,
+				"firstDI must be < endDI for non-empty bucket %d", i)
+			totalNodes += len(bp.prefix.buckets[i].nodes)
+			require.LessOrEqual(t, len(bp.prefix.buckets[i].nodes), maxNodesPerBucket,
+				"bucket %d has too many nodes", i)
+		}
+	}
+	require.Greater(t, nonEmptyBuckets, 0, "should have non-empty buckets")
+	require.Greater(t, totalNodes, 0, "should have cached nodes in buckets")
+
+	// Verify L1 aggregation: at least some L1 entries should be set
+	nonEmptyL1 := 0
+	for i := range bp.prefix.l1First {
+		if bp.prefix.l1First[i] != math.MaxUint64 {
+			nonEmptyL1++
+			require.Less(t, bp.prefix.l1First[i], bp.prefix.l1End[i],
+				"l1First must be < l1End for non-empty L1 entry %d", i)
+		}
+	}
+	require.Greater(t, nonEmptyL1, 0, "should have non-empty L1 entries")
+
+	// Verify a specific bucket: find the bucket for keys[0] and check it contains di=0
+	if len(keys[0]) >= 2 {
+		prefix := uint16(keys[0][0])<<8 | uint16(keys[0][1])
+		bkt := &bp.prefix.buckets[prefix]
+		require.Equal(t, uint64(0), bkt.firstDI, "first key should set firstDI=0")
+	}
+}
+
+func TestNewBpsTreeWithNodesPrefixIndex(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow test")
+	}
+	t.Parallel()
+
+	tmp := t.TempDir()
+	logger := log.New()
+	keyCount := 65_000 // above minKeysForPrefixIndex (60_000)
+	M := uint64(256)
+
+	compressFlag := seg.CompressNone
+	dataPath := generateKV(t, tmp, 10, 16, keyCount, logger, compressFlag)
+
+	kv, err := seg.NewDecompressor(dataPath)
+	require.NoError(t, err)
+	defer kv.Close()
+
+	g := seg.NewReader(kv.MakeGetter(), compressFlag)
+
+	// Read all keys and offsets
+	g.Reset(0)
+	ps := make([]uint64, 0, keyCount)
+	keys := make([][]byte, 0, keyCount)
+	p := uint64(0)
+	for g.HasNext() {
+		ps = append(ps, p)
+		k, _ := g.Next(nil)
+		_, p = g.Next(nil)
+		keys = append(keys, common.Copy(k))
+	}
+	require.Equal(t, keyCount, len(keys))
+
+	ef := eliasfano32.NewEliasFano(uint64(keyCount), ps[len(ps)-1])
+	for i := 0; i < len(ps); i++ {
+		ef.AddOffset(ps[i])
+	}
+	ef.Build()
+	efi, _ := eliasfano32.ReadEliasFano(ef.AppendBytes(nil))
+
+	// Build nodes every M-th key (same sampling as WarmUp)
+	var nodes []Node
+	step := M
+	for i := step; i < uint64(keyCount); i += step {
+		di := i - 1
+		nodes = append(nodes, Node{key: common.Copy(keys[di]), di: di})
+	}
+
+	ir := NewMockIndexReader(efi)
+	bp := NewBpsTreeWithNodes(g, efi, M, ir.dataLookup, ir.keyCmp, nodes)
+
+	// Prefix index should be active
+	require.NotNil(t, bp.prefix, "prefix index should be built for large files")
+	// mx should NOT be populated for large files
+	require.Empty(t, bp.mx, "mx should not be populated when prefix index is active")
+
+	// Spot-check: at least some buckets should have non-sentinel firstDI
+	nonEmptyBuckets := 0
+	totalNodes := 0
+	for i := range bp.prefix.buckets {
+		if bp.prefix.buckets[i].firstDI != math.MaxUint64 {
+			nonEmptyBuckets++
+			require.Less(t, bp.prefix.buckets[i].firstDI, bp.prefix.buckets[i].endDI,
+				"firstDI must be < endDI for non-empty bucket %d", i)
+			totalNodes += len(bp.prefix.buckets[i].nodes)
+			require.LessOrEqual(t, len(bp.prefix.buckets[i].nodes), maxNodesPerBucket,
+				"bucket %d has too many nodes", i)
+		}
+	}
+	require.Greater(t, nonEmptyBuckets, 0, "should have non-empty buckets")
+	require.Greater(t, totalNodes, 0, "should have cached nodes in buckets")
+
+	// Verify L1 aggregation
+	nonEmptyL1 := 0
+	for i := range bp.prefix.l1First {
+		if bp.prefix.l1First[i] != math.MaxUint64 {
+			nonEmptyL1++
+			require.Less(t, bp.prefix.l1First[i], bp.prefix.l1End[i],
+				"l1First must be < l1End for non-empty L1 entry %d", i)
+		}
+	}
+	require.Greater(t, nonEmptyL1, 0, "should have non-empty L1 entries")
+
+	// Verify nodes ended up in correct buckets: check a sampled node
+	for _, n := range nodes {
+		if len(n.key) >= 2 {
+			prefix := uint16(n.key[0])<<8 | uint16(n.key[1])
+			bkt := &bp.prefix.buckets[prefix]
+			found := false
+			for _, bn := range bkt.nodes {
+				if bn.di == n.di {
+					found = true
+					break
+				}
+			}
+			// Node should be in its prefix bucket (unless bucket was full)
+			if len(bkt.nodes) < maxNodesPerBucket || found {
+				require.True(t, found || len(bkt.nodes) == maxNodesPerBucket,
+					"node di=%d should be in bucket %d or bucket should be full", n.di, prefix)
+			}
+			break // just check one
+		}
 	}
 }
 


### PR DESCRIPTION
Supersedes #20155

Rework BpsTree prefix index per code review feedback.

## Design
- Single `[65536]prefixBucket{firstDI, endDI, nodes}` replacing 4 flat arrays
- Nodes embedded in prefix buckets (max 8 per bucket, 3 comparisons max)
- Exact match shortcut: if key matches cached node, skip disk search entirely
- L1 computed from L2 at build time (256 entries from 65536)
- Small files (<60k keys) keep existing `mx`+`bs()` path unchanged
- `Close()` releases ~2.5MB prefix memory

## Benchmark (12M keys, 10s benchtime)
```
Without prefix: ~2,865 ns/op
With prefix v3: ~1,050 ns/op → 63% faster
```

## Changes
- `bps_tree.go`: +568 lines (new bucket architecture, lookup, narrowWithNodes)
- `bpstree_bench_test.go`: +68 lines (with/without comparison)
- `btree_index_test.go`: +262 lines (prefix index unit tests)

Co-Authored-By: Shuo <shuo@erigon.dev>