### PR TITLE
ci: handle git-restore-mtime download failure gracefully

### DIFF
--- a/.github/actions/setup-erigon/action.yml
+++ b/.github/actions/setup-erigon/action.yml
@@ -163,11 +163,16 @@ runs:
     - name: Install git-restore-mtime
       shell: bash
       run: |
-        curl -sL https://raw.githubusercontent.com/MestreLion/git-tools/main/git-restore-mtime -o "$RUNNER_TEMP/git-restore-mtime"
-        chmod +x "$RUNNER_TEMP/git-restore-mtime"
+        if ! curl -sfL https://raw.githubusercontent.com/MestreLion/git-tools/main/git-restore-mtime -o "$RUNNER_TEMP/git-restore-mtime"; then
+          echo "::warning::Failed to download git-restore-mtime (rate-limited?), skipping mtime restore"
+          echo "SKIP_MTIME=true" >> "$GITHUB_ENV"
+        else
+          chmod +x "$RUNNER_TEMP/git-restore-mtime"
+        fi
         echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
 
     - name: Restore fixture mtimes for Go test caching
+      if: ${{ env.SKIP_MTIME != 'true' }}
       shell: bash
       run: |
         # Go's test cache keys include stat metadata (mtime+size) for every


### PR DESCRIPTION
Fixes #20172

## Problem
`curl -sL` silently saves HTTP 429 rate-limit HTML as the `git-restore-mtime` script. Bash then tries to execute HTML:
```
/home/runner/work/_temp/git-restore-mtime: 1: 429:: not found
/home/runner/work/_temp/git-restore-mtime: 2: Syntax error: "(" unexpected
```

## Fix
- Add `-f` flag to curl (fail on HTTP errors instead of saving error page)
- If download fails, set `SKIP_MTIME=true` and warn instead of failing the entire job
- Guard the "Restore fixture mtimes" step with `if: env.SKIP_MTIME != 'true'`

Test caching may be less effective when mtime restore is skipped, but CI will not break.

Co-Authored-By: Shuo <shuo@erigon.dev>