### PR TITLE
[r3.4] fix TestAggregatorV3_Merge: correct onDelCalls expectation

### DIFF
--- a/db/test/aggregator_ext_test.go
+++ b/db/test/aggregator_ext_test.go
@@ -408,7 +408,7 @@ func TestAggregatorV3_Merge(t *testing.T) {
 	err = agg.BuildFiles(txs)
 	require.NoError(t, err)
 	require.Equal(t, 6, onChangeCalls)
-	require.Equal(t, 9, onDelCalls)
+	require.Equal(t, 7, onDelCalls)
 
 	{ //prune
 		rwTx, err = db.BeginTemporalRw(context.Background())


### PR DESCRIPTION
The merge prioritization changes (ee312d2, 0887f41c) correctly increased `onChangeCalls` from 3 to 6 (more merge rounds due to domain-value priority), but `onDelCalls` was incorrectly bumped from 7 to 9 in b9658302e9. The number of deleted files doesn't change with merge ordering — it stays at 7.

Fixes CI failure: https://github.com/erigontech/erigon/actions/runs/23438287562/job/68181996129