### PR TITLE
cl: wrap ErrIgnore in attestation propagation range check

### DIFF
--- a/cl/phase1/network/services/attestation_service.go
+++ b/cl/phase1/network/services/attestation_service.go
@@ -182,7 +182,7 @@ func (s *attestationService) ProcessMessage(ctx context.Context, subnet *uint64,
 	// i.e. attestation.data.slot + ATTESTATION_PROPAGATION_SLOT_RANGE >= current_slot >= attestation.data.slot (a client MAY queue future attestations for processing at the appropriate slot).
 	currentSlot := s.ethClock.GetCurrentSlot()
 	if currentSlot < slot || currentSlot > slot+s.netCfg.AttestationPropagationSlotRange {
-		return fmt.Errorf("not in propagation range")
+		return fmt.Errorf("not in propagation range: %w", ErrIgnore)
 	}
 	// [REJECT] The attestation's epoch matches its target -- i.e. attestation.data.target.epoch == compute_epoch_at_slot(attestation.data.slot)
 	if targetEpoch != slot/s.beaconCfg.SlotsPerEpoch {


### PR DESCRIPTION
## Summary
- The "not in propagation range" error in `attestation_service.go` was not wrapping `ErrIgnore`, so the Beacon REST handler in `pool.go` logged it at WARN level instead of ignoring it
- This is especially noisy for validators with many keys (~5000 on Hoodi), where minor clock skew between the VC and Caplin produces thousands of spurious `[Beacon REST] failed to process attestation in attestation service err="not in propagation range"` warnings per minute
- The spec comment already marks this as an `[IGNORE]` condition, and all other ignorable checks in the same file correctly wrap `ErrIgnore`

## Test plan
- [ ] Verify `make lint` passes
- [ ] Run a validator with many keys and confirm the WARN spam is gone (now logged at Debug level by the handler)

🤖 Generated with [Claude Code](https://claude.com/claude-code)