### PR TITLE
[r3.4] execution/state: revert CodeSizePath in codeChange journal entry

### DIFF
--- a/execution/state/journal.go
+++ b/execution/state/journal.go
@@ -416,6 +416,7 @@ func (ch codeChange) revert(s *IntraBlockState) error {
 			}
 			s.versionedWrites.Delete(ch.account, AccountKey{Path: CodeHashPath})
 			s.versionedWrites.Delete(ch.account, AccountKey{Path: CodePath})
+			s.versionedWrites.Delete(ch.account, AccountKey{Path: CodeSizePath})
 		} else {
 			if v, ok := s.versionedWrites[ch.account][AccountKey{Path: CodePath}]; ok {
 				if trace {
@@ -430,6 +431,9 @@ func (ch codeChange) revert(s *IntraBlockState) error {
 					fmt.Printf("%s WRT Revert %x: %x -> %x\n", tracePrefix, ch.account, v.Val, ch.prevhash)
 				}
 				v.Val = ch.prevhash
+			}
+			if v, ok := s.versionedWrites[ch.account][AccountKey{Path: CodeSizePath}]; ok {
+				v.Val = len(ch.prevcode)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Backport of main commit `94a02c2bbb` to `release/3.4`, adapted for r3.4's `*VersionedWrite` pointer map.

### The bug

`SetCode` writes three versioned entries (`CodePath`, `CodeHashPath`, `CodeSizePath`) to `versionedWrites`, but `codeChange.revert()` only cleaned up `CodePath` and `CodeHashPath`. The stale `CodeSizePath` caused `GetCodeSize` to return the pre-revert value after a parent frame reverted a child `CREATE`/`CREATE2`, making `EXTCODESIZE` report wrong results.

**Concrete impact**: contracts checking `extcodesize(addr) > 0` after a failed deployment see a non-zero size instead of 0, taking a different code path and computing different gas. This produces arbitrary gas under-counts that fail block validation with `"gas used by execution: X, in header: Y"`.

**Observed in production**:
- Mainnet node (r3.4, build `cd4cc8e1`) stuck at block 24741565 with `-61,560` gas diff
- Hoodi node previously exhibited similar pattern at block 2486302

### The fix

Add `CodeSizePath` cleanup to both branches of `codeChange.revert()`:
- `wasCommited == true`: `Delete(CodeSizePath)` alongside the existing `Delete` calls
- `wasCommited == false`: restore `v.Val = len(ch.prevcode)` (r3.4 uses `*VersionedWrite` pointers, not `UpdateVal`)

### Adaptation from main

Main uses `WriteSet.UpdateVal()` (added in the IBS 2-cache refactor which is main-only). r3.4's `WriteSet` stores `*VersionedWrite` pointers, so direct `v.Val = ...` assignment modifies the map entry in place — consistent with all other `wasCommited == false` revert handlers in r3.4's `journal.go`.

## Test plan
- [x] `make erigon` builds cleanly
- [x] `make lint` clean (0 issues)
- [ ] Mainnet node at block 24741565 unblocked after deploying this fix