### PR TITLE
db/state: disable ReplaceKeysInValues during RebuildCommitmentFiles

### DIFF
--- a/db/state/squeeze.go
+++ b/db/state/squeeze.go
@@ -823,6 +823,13 @@ func RebuildCommitmentFiles(ctx context.Context, rwDb kv.TemporalRwDB, txNumsRea
 	// different visibleFiles
 	a.DisableAllDependencies()
 
+	// Disable ReplaceKeysInValues during rebuild. The merge loop after each range would
+	// otherwise shorten keys in commitment branch data, embedding file-range references
+	// (e.g. storage.0-16) that become stale once those files are merged into larger ranges
+	// (storage.0-32). The squeeze pass at the end re-enables this flag and applies the
+	// shortening in one shot when all files are finalized.
+	a.ForTestReplaceKeysInValues(kv.CommitmentDomain, false)
+
 	acRo := a.BeginFilesRo() // this tx is used to read existing domain files and closed in the end
 	defer acRo.Close()
 	defer acRo.MadvNormal().DisableReadAhead()


### PR DESCRIPTION
## Summary

- `RebuildCommitmentFiles` splits large account-domain ranges into shards (e.g. 0-16, 16-32). After each range the merge loop runs and with `ReplaceKeysInValues=true` (the default) it shortens keys in commitment branch data, embedding file-range references like `storage.0-16`
- once those files are merged into larger ranges (`storage.0-32`), subsequent shards fail during unfold because the referenced file no longer exists
- fix: disable `ReplaceKeysInValues` before the rebuild loop, same as `RebuildCommitmentFilesWithHistory` already does. squeeze pass at the end re-enables and applies shortening in one shot

reproduces with `TEST_STEPS=59` on `TestConcurrentRebuildCommitment`

## Test plan

- [x] `TestAggregator_RebuildCommitmentBasedOnFiles` passes (existing test)
- [x] `TestConcurrentRebuildCommitment` with `TEST_STEPS=59` passes (requires test from concurrent-rebuild branch)