### PR TITLE
execmodule, eth: fix roTx leak in updateForkChoice + improve shutdown ordering

### DIFF
--- a/execution/exec/blocks_read_ahead.go
+++ b/execution/exec/blocks_read_ahead.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -28,6 +29,7 @@ type blockReadAheader struct {
 
 	// this is for warming state
 	warming atomic.Bool // only one warmBody can run at a time
+	warmWg  sync.WaitGroup
 }
 
 func newBlockReadAheader() *blockReadAheader {
@@ -61,7 +63,26 @@ func (bra *blockReadAheader) AddHeaderAndBody(ctx context.Context, db kv.RoDB, h
 		if !bra.warming.CompareAndSwap(false, true) {
 			return
 		}
-		go bra.warmBody(ctx, db, header, body, 8) // use 8 workers for warming
+		bra.warmWg.Add(1)
+		go func() {
+			defer bra.warmWg.Done()
+			bra.warmBody(ctx, db, header, body, 8) // use 8 workers for warming
+		}()
+	}
+}
+
+// WaitForWarmup blocks until any in-flight warmBody goroutine finishes or
+// the context is cancelled. Call before closing the database to avoid
+// waitTxsAllDoneOnClose hangs.
+func WaitForWarmup(ctx context.Context) {
+	done := make(chan struct{})
+	go func() {
+		globalReadAheader.warmWg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-ctx.Done():
 	}
 }
 

--- a/execution/execmodule/exec_module.go
+++ b/execution/execmodule/exec_module.go
@@ -264,6 +264,15 @@ func NewExecModule(
 	return em
 }
 
+// WaitIdle blocks until any in-flight updateForkChoice goroutine finishes.
+// Call before closing the database to avoid waitTxsAllDoneOnClose hangs.
+func (e *ExecModule) WaitIdle(ctx context.Context) {
+	if err := e.semaphore.Acquire(ctx, 1); err != nil {
+		return // context cancelled — best effort
+	}
+	e.semaphore.Release(1)
+}
+
 // ForkValidator returns the fork validator owned by this module.
 func (e *ExecModule) ForkValidator() *ForkValidator { return e.forkValidator }
 

--- a/execution/execmodule/forkchoice.go
+++ b/execution/execmodule/forkchoice.go
@@ -214,7 +214,7 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 	if err != nil {
 		return sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, err, false)
 	}
-	defer roTx.Rollback()
+	defer func() { roTx.Rollback() }() // closure: CommitCycle may reassign roTx
 
 	closeOnReturn := true
 

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -78,6 +78,7 @@ import (
 	chainspec "github.com/erigontech/erigon/execution/chain/spec"
 	"github.com/erigontech/erigon/execution/engineapi"
 	"github.com/erigontech/erigon/execution/engineapi/engine_block_downloader"
+	"github.com/erigontech/erigon/execution/exec"
 	"github.com/erigontech/erigon/execution/execmodule"
 	"github.com/erigontech/erigon/execution/execmodule/chainreader"
 	execp2p "github.com/erigontech/erigon/execution/p2p"
@@ -1555,11 +1556,33 @@ func (s *Ethereum) Stop() error {
 	for _, sentryServer := range s.sentryServers {
 		sentryServer.Close()
 	}
-	s.chainDB.Close()
 
+	// Wait for background goroutines to release DB transactions before closing DB.
+	// Background components (txpool, sentry loops, p2p) hold read transactions that
+	// must be rolled back before chainDB.Close() can complete.
 	if err := s.bgComponentsEg.Wait(); err != nil && !errors.Is(err, context.Canceled) {
 		s.logger.Error("background component error", "err", err)
 	}
+
+	// Wait for any in-flight updateForkChoice goroutine to finish. These are
+	// fire-and-forget goroutines that hold DB read transactions; without this
+	// wait, chainDB.Close() can hang in waitTxsAllDoneOnClose.
+	if s.execModule != nil {
+		waitCtx, waitCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		s.execModule.WaitIdle(waitCtx)
+		waitCancel()
+	}
+
+	// Wait for any in-flight read-ahead warmup goroutines that hold DB read
+	// transactions. The global read-aheader spawns fire-and-forget goroutines
+	// via AddHeaderAndBodyToGlobalReadAheader during ValidateChain.
+	{
+		warmCtx, warmCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		exec.WaitForWarmup(warmCtx)
+		warmCancel()
+	}
+
+	s.chainDB.Close()
 
 	if s.config.Downloader != nil {
 		_ = s.config.Downloader.CloseTorrentLogFile()


### PR DESCRIPTION
## Summary
- Cherry-pick of `0ba474ae66` from `bal-devnet-3`
- Fixes DB hang during shutdown caused by uncommitted read transactions from fire-and-forget goroutines (updateForkChoice and read-ahead warmup)
- Adds `WaitIdle()` method to exec module and `WaitForWarmup()` to blocks_read_ahead for proper shutdown coordination
- The OverlayTemporalReadView dispatch fix (`a78015edb6`) was already on main

## Test plan
- [ ] `make lint` passes
- [ ] `make erigon` builds
- [ ] Verify clean shutdown without DB hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)