### PR TITLE
commitment: preserve map  capacity in Updates.Reset

### DIFF
--- a/execution/commitment/commitment.go
+++ b/execution/commitment/commitment.go
@@ -1936,8 +1936,11 @@ func (t *Updates) HashSort(ctx context.Context, warmuper *Warmuper, fn func(hk, 
 func (t *Updates) Reset() {
 	switch t.mode {
 	case ModeDirect:
-		t.keys = nil
-		t.keys = make(map[string]struct{})
+		if t.keys == nil {
+			t.keys = make(map[string]struct{})
+		} else {
+			clear(t.keys)
+		}
 		t.initCollector()
 	case ModeUpdate:
 		t.tree.Clear(true)


### PR DESCRIPTION
Preserve `t.keys` capacity in `Updates.Reset` for `ModeDirect` to avoid repeated map allocations, reducing allocator churn in frequent commitment reset cycles.