### PR TITLE
stagedsync/bal: validate max items on stored block access list

### DIFF
--- a/execution/stagedsync/bal_create.go
+++ b/execution/stagedsync/bal_create.go
@@ -149,6 +149,9 @@ func ProcessBAL(tx kv.TemporalRwTx, h *types.Header, vio *state.VersionedIO, ams
 		if err = dbBAL.Validate(); err != nil {
 			return fmt.Errorf("block %d: db block access list is invalid: %w", blockNum, err)
 		}
+		if err = dbBAL.ValidateMaxItems(h.GasLimit); err != nil {
+			return fmt.Errorf("block %d: stored block access list exceeds max items: %w", blockNum, err)
+		}
 
 		if headerBALHash != dbBAL.Hash() {
 			log.Info(fmt.Sprintf("bal from block: %s", dbBAL.DebugString()))


### PR DESCRIPTION
## Summary
- Apply `ValidateMaxItems` check to BAL decoded from the database (downloaded via p2p), matching the validation already enforced on locally computed BAL

Related: #20217

## Test plan
- [x] `go build ./execution/stagedsync/...`
- [x] `go test -short ./execution/stagedsync/...`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)