### PR TITLE
stagedsync: guard BAL debug file writes and unify serialization format

### DIFF
--- a/execution/stagedsync/bal_create.go
+++ b/execution/stagedsync/bal_create.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/rawdb"
@@ -15,7 +16,9 @@ import (
 
 func CreateBAL(blockNum uint64, txIO *state.VersionedIO, dataDir string) types.BlockAccessList {
 	bal := txIO.AsBlockAccessList()
-	writeBALToFile(bal, blockNum, dataDir)
+	if dbg.TraceBlockAccessLists {
+		writeBALToFile(bal, blockNum, dataDir)
+	}
 	return bal
 }
 
@@ -40,73 +43,8 @@ func writeBALToFile(bal types.BlockAccessList, blockNum uint64, dataDir string) 
 	}
 	defer file.Close()
 
-	// Write header information
 	fmt.Fprintf(file, "Block Access List for Block %d\n", blockNum)
-	fmt.Fprintf(file, "Total Accounts: %d\n\n", len(bal))
-
-	// Write each account's changes
-	for _, account := range bal {
-		fmt.Fprintf(file, "Account: %s\n", account.Address.Value().Hex())
-
-		// Storage changes
-		if len(account.StorageChanges) > 0 {
-			fmt.Fprintf(file, "  Storage Changes (%d):\n", len(account.StorageChanges))
-			for _, slotChange := range account.StorageChanges {
-				fmt.Fprintf(file, "    Slot: %s\n", slotChange.Slot.Value().Hex())
-				for _, change := range slotChange.Changes {
-					fmt.Fprintf(file, "      [%d] -> %s\n", change.Index, change.Value.Hex())
-				}
-			}
-		}
-
-		// Storage reads
-		if len(account.StorageReads) > 0 {
-			fmt.Fprintf(file, "  Storage Reads (%d):\n", len(account.StorageReads))
-			for _, read := range account.StorageReads {
-				fmt.Fprintf(file, "    %s\n", read.Value().Hex())
-			}
-		}
-
-		// Balance changes
-		if len(account.BalanceChanges) > 0 {
-			fmt.Fprintf(file, "  Balance Changes (%d):\n", len(account.BalanceChanges))
-			for _, change := range account.BalanceChanges {
-				fmt.Fprintf(file, "    [%d] -> %s\n", change.Index, change.Value.String())
-			}
-		}
-
-		// Nonce changes
-		if len(account.NonceChanges) > 0 {
-			fmt.Fprintf(file, "  Nonce Changes (%d):\n", len(account.NonceChanges))
-			for _, change := range account.NonceChanges {
-				fmt.Fprintf(file, "    [%d] -> %d\n", change.Index, change.Value)
-			}
-		}
-
-		// Code changes
-		if len(account.CodeChanges) > 0 {
-			fmt.Fprintf(file, "  Code Changes (%d):\n", len(account.CodeChanges))
-			for _, change := range account.CodeChanges {
-				fmt.Fprintf(file, "    [%d] -> %d bytes\n", change.Index, len(change.Bytecode))
-				if len(change.Bytecode) <= 64 {
-					fmt.Fprintf(file, "      Bytecode: %x\n", change.Bytecode)
-				} else {
-					fmt.Fprintf(file, "      Bytecode: %x... (truncated)\n", change.Bytecode[:64])
-				}
-			}
-		}
-
-		// If no changes, indicate that
-		if len(account.StorageChanges) == 0 && len(account.StorageReads) == 0 &&
-			len(account.BalanceChanges) == 0 && len(account.NonceChanges) == 0 &&
-			len(account.CodeChanges) == 0 {
-			fmt.Fprintf(file, "  No changes (accessed only)\n")
-		}
-
-		fmt.Fprintf(file, "\n")
-	}
-
-	//log.Info("BAL written to file", "blockNum", blockNum, "filename", filename, "accounts", len(bal))
+	bal.DebugPrint(file)
 }
 
 func ProcessBAL(tx kv.TemporalRwTx, h *types.Header, vio *state.VersionedIO, amsterdam bool, experimental bool, dataDir string) error {


### PR DESCRIPTION
## Summary
- Guard `writeBALToFile` behind `dbg.TraceBlockAccessLists` (`TRACE_BLOCK_ACCESS_LISTS` env var) so BAL debug files are **not written by default**, preventing unbounded disk growth
- Replace ~65 lines of custom printf-based serialization in `writeBALToFile` with a single call to `bal.DebugPrint(file)`, unifying the output format with the mismatch-dump path (`DebugString`)

Related: #20214, #20216

## Test plan
- [x] `make erigon` compiles successfully
- [ ] Run with `TRACE_BLOCK_ACCESS_LISTS=true` and verify BAL files are written with the unified format
- [ ] Run without the env var and verify no BAL files are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)