### PR TITLE
integrity: skip remaining checks when ctx is cancelled due to error

### DIFF
--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -1302,6 +1302,9 @@ func doIntegrity(cliCtx *cli.Context) error {
 	for _, chk := range requestedChecks {
 		chk := chk
 		g.Go(func() error {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 			logger.Info("[integrity] starting", "check", chk)
 			if err := func() error {
 				switch chk {


### PR DESCRIPTION
- `StateRootVerifyByHistory` (and other checks) return a non-nil error, which causes `errgroup.WithContext` to cancel the derived context
- subsequent goroutines blocked by `SetLimit(1)` were starting and running to completion despite the cancelled context — e.g. `Publishable` ran even after `StateRootVerifyByHistory` failed
- add `ctx.Err()` guard at the top of each check goroutine to bail immediately