### PR TITLE
rpc: add call limits for eth_simulateV1

### DIFF
--- a/rpc/jsonrpc/eth_simulation.go
+++ b/rpc/jsonrpc/eth_simulation.go
@@ -187,6 +187,10 @@ func (api *APIImpl) SimulateV1(ctx context.Context, req SimulationRequest, block
 }
 
 func validateSimulationRequest(blocks []SimulatedBlock) error {
+	// Reject requests that exceed the maximum number of simulated blocks.
+	if len(blocks) > maxSimulateBlocks {
+		return clientLimitExceededError(fmt.Sprintf("too many blocks in request: %d > %d", len(blocks), maxSimulateBlocks))
+	}
 	var totalCalls int
 	for _, block := range blocks {
 		if len(block.Calls) > maxSimulateCallsPerBlock {

--- a/rpc/jsonrpc/eth_simulation.go
+++ b/rpc/jsonrpc/eth_simulation.go
@@ -59,6 +59,12 @@ const (
 	// maxSimulateBlocks is the maximum number of blocks that can be simulated in a single request.
 	maxSimulateBlocks = 256
 
+	// maxSimulateCallsPerBlock is the maximum number of calls allowed in a single simulated block.
+	maxSimulateCallsPerBlock = 5000
+
+	// maxSimulateTotalCalls is the maximum total number of calls allowed across all simulated blocks in a single request.
+	maxSimulateTotalCalls = 10000
+
 	// timestampIncrement is the default increment between block timestamps.
 	timestampIncrement = 12
 )
@@ -98,6 +104,9 @@ type SimulationResult []SimulatedBlockResult
 func (api *APIImpl) SimulateV1(ctx context.Context, req SimulationRequest, blockParameter rpc.BlockNumberOrHash) (SimulationResult, error) {
 	if len(req.BlockStateCalls) == 0 {
 		return nil, errors.New("empty input")
+	}
+	if err := validateSimulationRequest(req.BlockStateCalls); err != nil {
+		return nil, err
 	}
 	// Default to the latest block if no block parameter is given.
 	if blockParameter.BlockHash == nil && blockParameter.BlockNumber == nil {
@@ -175,6 +184,20 @@ func (api *APIImpl) SimulateV1(ctx context.Context, req SimulationRequest, block
 	}
 
 	return simulatedBlockResults, nil
+}
+
+func validateSimulationRequest(blocks []SimulatedBlock) error {
+	var totalCalls int
+	for _, block := range blocks {
+		if len(block.Calls) > maxSimulateCallsPerBlock {
+			return clientLimitExceededError(fmt.Sprintf("too many calls in block: %d > %d", len(block.Calls), maxSimulateCallsPerBlock))
+		}
+		totalCalls += len(block.Calls)
+		if totalCalls > maxSimulateTotalCalls {
+			return clientLimitExceededError(fmt.Sprintf("too many calls: %d > %d", totalCalls, maxSimulateTotalCalls))
+		}
+	}
+	return nil
 }
 
 type simulator struct {

--- a/rpc/jsonrpc/eth_simulation_test.go
+++ b/rpc/jsonrpc/eth_simulation_test.go
@@ -2,6 +2,8 @@ package jsonrpc
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"math"
 	"math/big"
 	"testing"
@@ -492,6 +494,58 @@ func TestSimulatedCanonicalReaderBadHeaderNumber(t *testing.T) {
 	blockHeight, err := reader.BadHeaderNumber(context.TODO(), nil, common.Hash{})
 	assert.Nil(t, blockHeight)
 	require.Error(t, err)
+}
+
+func TestValidateSimulationRequest(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		blocks    []SimulatedBlock
+		wantCode  int
+		wantError string
+	}{
+		{
+			name:      "too many blocks in request",
+			blocks:    make([]SimulatedBlock, maxSimulateBlocks+1),
+			wantCode:  rpc.ErrCodeClientLimitExceeded,
+			wantError: fmt.Sprintf("too many blocks in request: %d > %d", maxSimulateBlocks+1, maxSimulateBlocks),
+		},
+		{
+			name: "too many calls in block",
+			blocks: []SimulatedBlock{
+				{Calls: make([]ethapi.CallArgs, maxSimulateCallsPerBlock+1)},
+			},
+			wantCode:  rpc.ErrCodeClientLimitExceeded,
+			wantError: fmt.Sprintf("too many calls in block: %d > %d", maxSimulateCallsPerBlock+1, maxSimulateCallsPerBlock),
+		},
+		{
+			name: "too many calls in request",
+			blocks: []SimulatedBlock{
+				{Calls: make([]ethapi.CallArgs, maxSimulateCallsPerBlock)},
+				{Calls: make([]ethapi.CallArgs, maxSimulateCallsPerBlock)},
+				{Calls: make([]ethapi.CallArgs, 1)},
+			},
+			wantCode:  rpc.ErrCodeClientLimitExceeded,
+			wantError: fmt.Sprintf("too many calls: %d > %d", maxSimulateTotalCalls+1, maxSimulateTotalCalls),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateSimulationRequest(tc.blocks)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+
+			var customErr *rpc.CustomError
+			if !errors.As(err, &customErr) {
+				t.Fatalf("expected rpc.CustomError, got %T", err)
+			}
+			if customErr.Code != tc.wantCode {
+				t.Fatalf("unexpected error code: want %d, got %d", tc.wantCode, customErr.Code)
+			}
+			if customErr.Message != tc.wantError {
+				t.Fatalf("unexpected error message: want %q, got %q", tc.wantError, customErr.Message)
+			}
+		})
+	}
 }
 
 // ─── helpers ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
This change adds request limits to `eth_simulateV1`. It now rejects requests with more than 5000 calls in one simulated block, and more than 10000 total calls across the full request. The validation is done early before simulation work starts, so very large requests are rejected quickly.

