### PR TITLE
ci: don't cancel RPC integration test runs on push to main/release

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests-gnosis.yml
+++ b/.github/workflows/qa-rpc-integration-tests-gnosis.yml
@@ -20,12 +20,12 @@ concurrency:
   group: >-
     ${{
       github.event_name == 'pull_request' &&
-      format('{0}-{1}', github.workflow, github.head_ref) ||
+      format('{0}-{1}-{2}', github.workflow, github.event_name, github.head_ref) ||
       github.event_name == 'push' &&
-      format('{0}-{1}', github.workflow, github.ref_name) ||
+      format('{0}-{1}-{2}', github.workflow, github.event_name, github.ref_name) ||
       format('{0}-{1}', github.workflow, github.run_id)
     }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   gnosis-rpc-integ-tests:

--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -20,12 +20,12 @@ concurrency:
   group: >-
     ${{
       github.event_name == 'pull_request' &&
-      format('{0}-{1}', github.workflow, github.head_ref) ||
+      format('{0}-{1}-{2}', github.workflow, github.event_name, github.head_ref) ||
       github.event_name == 'push' &&
-      format('{0}-{1}', github.workflow, github.ref_name) ||
+      format('{0}-{1}-{2}', github.workflow, github.event_name, github.ref_name) ||
       format('{0}-{1}', github.workflow, github.run_id)
     }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   mainnet-rpc-integ-tests:


### PR DESCRIPTION
## Summary

- Include `github.event_name` in the concurrency group key for `qa-rpc-integration-tests` and `qa-rpc-integration-tests-gnosis` to separate PR and push contexts into distinct groups
- Change `cancel-in-progress` from unconditional `true` to `${{ github.event_name == 'pull_request' }}` so cancellation only applies to PR runs (new commits to an open PR cancel the old run), never to push runs on main/release

Fixes the cancellation seen in https://github.com/erigontech/erigon/actions/runs/23741048464 where a push to main was cancelled by a newer push to the same concurrency group.

Addresses Copilot suggestions from #20129.