### PR TITLE
commitment: replace cell type heuristics with CellType enum (#13234)

### DIFF
--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -1801,23 +1801,10 @@ func (hph *HexPatriciaHashed) unfold(hashedKey []byte, unfolding int16) error {
 	}
 
 	// CellTypeHash, CellTypeAccount, CellTypeStorage, CellTypeEmpty
-	var nibble uint8
-	var copyLen int16
-
 	lowest := min(unfolding, upCell.hashedExtLen)
 	depth = upDepth + lowest
-	copyLen = lowest - 1
-	nibble = upCell.hashedExtension[copyLen]
-
-	//if upCell.hashedExtLen >= unfolding {
-	//	depth = upDepth + unfolding
-	//	nibble = upCell.hashedExtension[unfolding-1]
-	//	copyLen = unfolding - 1
-	//} else {
-	//	depth = upDepth + upCell.hashedExtLen
-	//	nibble = upCell.hashedExtension[upCell.hashedExtLen-1]
-	//	copyLen = upCell.hashedExtLen - 1
-	//}
+	copyLen := int16(lowest - 1)
+	nibble := uint8(upCell.hashedExtension[copyLen])
 
 	if touched {
 		hph.touchMap[row] = uint16(1) << nibble

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -1795,48 +1795,54 @@ func (hph *HexPatriciaHashed) unfold(hashedKey []byte, unfolding int16) error {
 	}
 	hph.touchMap[row], hph.afterMap[row], hph.branchBefore[row] = 0, 0, false
 
-	switch upCell.Type() {
-	case CellTypeExtension:
-		var nibble uint8
-		var copyLen int16
-		if upCell.hashedExtLen >= unfolding {
-			depth = upDepth + unfolding
-			nibble = upCell.hashedExtension[unfolding-1]
-			copyLen = unfolding - 1
-		} else {
-			depth = upDepth + upCell.hashedExtLen
-			nibble = upCell.hashedExtension[upCell.hashedExtLen-1]
-			copyLen = upCell.hashedExtLen - 1
-		}
-
-		if touched {
-			hph.touchMap[row] = uint16(1) << nibble
-		}
-		if present {
-			hph.afterMap[row] = uint16(1) << nibble
-		}
-
-		cell := &hph.grid[row][nibble]
-		cell.fillFromUpperCell(upCell, depth, min(unfolding, upCell.hashedExtLen))
-		if hph.trace {
-			fmt.Printf("unfolded cell (%d, %x, depth=%d) %s\n", row, nibble, depth, cell.FullString())
-		}
-		if row >= 64 {
-			cell.accountAddrLen = 0
-		}
-
-		if copyLen > 0 {
-			copy(hph.currentKey[hph.currentKeyLen:], upCell.hashedExtension[:copyLen])
-			hph.currentKeyLen += copyLen
-		}
-
-		hph.depths[hph.activeRows] = depth
-		hph.activeRows++
-		return nil
-	default: // CellTypeHash, CellTypeAccount, CellTypeStorage, CellTypeEmpty
+	if upCell.Type() == CellTypeHash {
 		depth = upDepth + 1
 		return hph.unfoldBranchNode(row, depth, touched && !present)
 	}
+
+	// CellTypeHash, CellTypeAccount, CellTypeStorage, CellTypeEmpty
+	var nibble uint8
+	var copyLen int16
+
+	lowest := min(unfolding, upCell.hashedExtLen)
+	depth = upDepth + lowest
+	copyLen = lowest - 1
+	nibble = upCell.hashedExtension[copyLen]
+
+	//if upCell.hashedExtLen >= unfolding {
+	//	depth = upDepth + unfolding
+	//	nibble = upCell.hashedExtension[unfolding-1]
+	//	copyLen = unfolding - 1
+	//} else {
+	//	depth = upDepth + upCell.hashedExtLen
+	//	nibble = upCell.hashedExtension[upCell.hashedExtLen-1]
+	//	copyLen = upCell.hashedExtLen - 1
+	//}
+
+	if touched {
+		hph.touchMap[row] = uint16(1) << nibble
+	}
+	if present {
+		hph.afterMap[row] = uint16(1) << nibble
+	}
+
+	cell := &hph.grid[row][nibble]
+	cell.fillFromUpperCell(upCell, depth, min(unfolding, upCell.hashedExtLen))
+	if hph.trace {
+		fmt.Printf("unfolded cell (%d, %x, depth=%d) %s\n", row, nibble, depth, cell.FullString())
+	}
+	if row >= 64 {
+		cell.accountAddrLen = 0
+	}
+
+	if copyLen > 0 {
+		copy(hph.currentKey[hph.currentKeyLen:], upCell.hashedExtension[:copyLen])
+		hph.currentKeyLen += copyLen
+	}
+
+	hph.depths[hph.activeRows] = depth
+	hph.activeRows++
+	return nil
 }
 
 func (hph *HexPatriciaHashed) needFolding(hashedKey []byte) bool {

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -268,6 +268,52 @@ func (f loadFlags) addFlag(loadFlags loadFlags) loadFlags {
 	return f | loadFlags
 }
 
+// CellType classifies a cell by its role in the trie, derived from which length
+// fields are set. The precedence is: Extension > Storage > Account > Hash > Empty.
+type CellType uint8
+
+const (
+	CellTypeEmpty     CellType = iota // all lengths == 0
+	CellTypeHash                      // hashLen > 0, unloaded/pruned node
+	CellTypeExtension                 // hashedExtLen > 0 (may also have accountAddrLen or storageAddrLen)
+	CellTypeStorage                   // storageAddrLen > 0 (and hashedExtLen == 0)
+	CellTypeAccount                   // accountAddrLen > 0 (and hashedExtLen == 0, storageAddrLen == 0)
+)
+
+// Type derives the CellType from the cell's length fields without storing it.
+func (c *cell) Type() CellType {
+	if c.hashedExtLen > 0 {
+		return CellTypeExtension
+	}
+	if c.storageAddrLen > 0 {
+		return CellTypeStorage
+	}
+	if c.accountAddrLen > 0 {
+		return CellTypeAccount
+	}
+	if c.hashLen > 0 {
+		return CellTypeHash
+	}
+	return CellTypeEmpty
+}
+
+func (ct CellType) String() string {
+	switch ct {
+	case CellTypeEmpty:
+		return "Empty"
+	case CellTypeHash:
+		return "Hash"
+	case CellTypeExtension:
+		return "Extension"
+	case CellTypeAccount:
+		return "Account"
+	case CellTypeStorage:
+		return "Storage"
+	default:
+		return fmt.Sprintf("CellType(%d)", ct)
+	}
+}
+
 var (
 	emptyRootHashBytes = empty.RootHash.Bytes()
 )
@@ -1720,7 +1766,7 @@ func (hph *HexPatriciaHashed) unfold(hashedKey []byte, unfolding int16) error {
 	var touched, present bool
 	var upDepth, depth int16
 	if hph.activeRows == 0 {
-		if hph.rootChecked && hph.root.hashLen == 0 && hph.root.hashedExtLen == 0 {
+		if hph.rootChecked && hph.root.Type() == CellTypeEmpty {
 			return nil // No unfolding for empty root
 		}
 		upCell = &hph.root
@@ -1749,47 +1795,48 @@ func (hph *HexPatriciaHashed) unfold(hashedKey []byte, unfolding int16) error {
 	}
 	hph.touchMap[row], hph.afterMap[row], hph.branchBefore[row] = 0, 0, false
 
-	if upCell.hashedExtLen == 0 {
+	switch upCell.Type() {
+	case CellTypeExtension:
+		var nibble uint8
+		var copyLen int16
+		if upCell.hashedExtLen >= unfolding {
+			depth = upDepth + unfolding
+			nibble = upCell.hashedExtension[unfolding-1]
+			copyLen = unfolding - 1
+		} else {
+			depth = upDepth + upCell.hashedExtLen
+			nibble = upCell.hashedExtension[upCell.hashedExtLen-1]
+			copyLen = upCell.hashedExtLen - 1
+		}
+
+		if touched {
+			hph.touchMap[row] = uint16(1) << nibble
+		}
+		if present {
+			hph.afterMap[row] = uint16(1) << nibble
+		}
+
+		cell := &hph.grid[row][nibble]
+		cell.fillFromUpperCell(upCell, depth, min(unfolding, upCell.hashedExtLen))
+		if hph.trace {
+			fmt.Printf("unfolded cell (%d, %x, depth=%d) %s\n", row, nibble, depth, cell.FullString())
+		}
+		if row >= 64 {
+			cell.accountAddrLen = 0
+		}
+
+		if copyLen > 0 {
+			copy(hph.currentKey[hph.currentKeyLen:], upCell.hashedExtension[:copyLen])
+			hph.currentKeyLen += copyLen
+		}
+
+		hph.depths[hph.activeRows] = depth
+		hph.activeRows++
+		return nil
+	default: // CellTypeHash, CellTypeAccount, CellTypeStorage, CellTypeEmpty
 		depth = upDepth + 1
 		return hph.unfoldBranchNode(row, depth, touched && !present)
 	}
-
-	var nibble uint8
-	var copyLen int16
-	if upCell.hashedExtLen >= unfolding {
-		depth = upDepth + unfolding
-		nibble = upCell.hashedExtension[unfolding-1]
-		copyLen = unfolding - 1
-	} else {
-		depth = upDepth + upCell.hashedExtLen
-		nibble = upCell.hashedExtension[upCell.hashedExtLen-1]
-		copyLen = upCell.hashedExtLen - 1
-	}
-
-	if touched {
-		hph.touchMap[row] = uint16(1) << nibble
-	}
-	if present {
-		hph.afterMap[row] = uint16(1) << nibble
-	}
-
-	cell := &hph.grid[row][nibble]
-	cell.fillFromUpperCell(upCell, depth, min(unfolding, upCell.hashedExtLen))
-	if hph.trace {
-		fmt.Printf("unfolded cell (%d, %x, depth=%d) %s\n", row, nibble, depth, cell.FullString())
-	}
-	if row >= 64 {
-		cell.accountAddrLen = 0
-	}
-
-	if copyLen > 0 {
-		copy(hph.currentKey[hph.currentKeyLen:], upCell.hashedExtension[:copyLen])
-		hph.currentKeyLen += copyLen
-	}
-
-	hph.depths[hph.activeRows] = depth
-	hph.activeRows++
-	return nil
 }
 
 func (hph *HexPatriciaHashed) needFolding(hashedKey []byte) bool {

--- a/execution/commitment/hex_patricia_hashed_test.go
+++ b/execution/commitment/hex_patricia_hashed_test.go
@@ -2983,3 +2983,87 @@ func Test_WitnessTrie_GenerateWitness(t *testing.T) {
 		buildTrieAndWitness(t, builder, [][]byte{fullStorageKeyToProve}, []bool{true})
 	})
 }
+
+func TestCellType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		cell     cell
+		expected CellType
+	}{
+		{
+			name:     "empty cell",
+			cell:     cell{},
+			expected: CellTypeEmpty,
+		},
+		{
+			name:     "hash only",
+			cell:     cell{hashLen: 32},
+			expected: CellTypeHash,
+		},
+		{
+			name:     "extension only",
+			cell:     cell{hashedExtLen: 5},
+			expected: CellTypeExtension,
+		},
+		{
+			name:     "account only",
+			cell:     cell{accountAddrLen: length.Addr},
+			expected: CellTypeAccount,
+		},
+		{
+			name:     "storage only",
+			cell:     cell{storageAddrLen: length.Addr + length.Hash},
+			expected: CellTypeStorage,
+		},
+		{
+			name:     "extension with account (extension takes precedence)",
+			cell:     cell{hashedExtLen: 10, accountAddrLen: length.Addr},
+			expected: CellTypeExtension,
+		},
+		{
+			name:     "extension with storage (extension takes precedence)",
+			cell:     cell{hashedExtLen: 10, storageAddrLen: length.Addr + length.Hash},
+			expected: CellTypeExtension,
+		},
+		{
+			name:     "extension with account and storage",
+			cell:     cell{hashedExtLen: 64, accountAddrLen: length.Addr, storageAddrLen: length.Addr + length.Hash},
+			expected: CellTypeExtension,
+		},
+		{
+			name:     "account with hash (account takes precedence)",
+			cell:     cell{accountAddrLen: length.Addr, hashLen: 32},
+			expected: CellTypeAccount,
+		},
+		{
+			name:     "storage with account (storage takes precedence)",
+			cell:     cell{accountAddrLen: length.Addr, storageAddrLen: length.Addr + length.Hash},
+			expected: CellTypeStorage,
+		},
+		{
+			name:     "storage with hash (storage takes precedence)",
+			cell:     cell{storageAddrLen: length.Addr + length.Hash, hashLen: 32},
+			expected: CellTypeStorage,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cell.Type()
+			require.Equal(t, tt.expected, got, "Type() = %s, want %s", got, tt.expected)
+		})
+	}
+}
+
+func TestCellType_String(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "Empty", CellTypeEmpty.String())
+	require.Equal(t, "Hash", CellTypeHash.String())
+	require.Equal(t, "Extension", CellTypeExtension.String())
+	require.Equal(t, "Account", CellTypeAccount.String())
+	require.Equal(t, "Storage", CellTypeStorage.String())
+	require.Equal(t, "CellType(255)", CellType(255).String())
+}


### PR DESCRIPTION
Fixes #13234.

## Summary

Introduces a `CellType` enum and `Type()` method on the `cell` struct to replace raw length-field heuristics used as type discriminators throughout `hex_patricia_hashed.go`.

### Before
```go
} else if cell.hashLen > 0 { // hash cell means we will expand using a full node
```

### After
```go
switch cell.Type() {
case CellTypeHash:      // unloaded/pruned node referenced by hash
case CellTypeExtension: // extension node
case CellTypeAccount:   // account leaf
case CellTypeStorage:   // storage leaf
case CellTypeEmpty:     // empty cell
}
```

## Changes

- Add `CellType` enum (`CellTypeEmpty`, `CellTypeHash`, `CellTypeExtension`, `CellTypeAccount`, `CellTypeStorage`) with `String()` method
- Add `(c *cell) Type() CellType` — pure derived property, no new struct field, preserves original field precedence (storage before account, extension first)
- Replace all type-discriminator conditionals in `hex_patricia_hashed.go` with `Type()` checks
- Add unit tests for `Type()` covering all variants and edge cases

Co-authored-by: shuo <shuo@erigon.dev>