### PR TITLE
protocol: deduplicate Amsterdam gas accounting in TxnExecutor.Execute

### DIFF
--- a/execution/protocol/txn_executor.go
+++ b/execution/protocol/txn_executor.go
@@ -600,48 +600,46 @@ func (st *TxnExecutor) Execute(refunds bool, gasBailout bool) (result *evmtypes.
 		ret, st.gasRemaining, vmerr = st.evm.Call(sender, st.to(), st.data, st.gasRemaining, st.value, bailout)
 	}
 
+	// Step 1: Compute raw gas consumption and block-level accounting.
+	mdGasUsed := st.mdGasUsed()
+	if rules.IsAmsterdam {
+		// EIP-8037 + EIP-7778: Block gas accounting uses two dimensions.
+		// stateGasConsumed tracks ALL state gas charges (including spill to regular gas).
+		// regularGasConsumed tracks only regular-dimension opcode gas.
+		blockState := imdGas.State + st.evm.StateGasConsumed()
+		blockRegular := imdGas.Regular + st.evm.RegularGasConsumed()
+		st.blockRegularGasUsed = max(blockRegular, intrinsicGasResult.FloorGasCost)
+		st.blockStateGasUsed = blockState
+		// Receipt gasUsed: total gas pool depletion + spill restored on depth-0 REVERT.
+		st.txnGasUsedB4Refunds = mdGasUsed.Total() + st.evm.RevertedSpillGas()
+	} else {
+		st.txnGasUsedB4Refunds = mdGasUsed.Regular
+	}
+
+	// Step 2: Apply refunds or record raw gas usage.
 	if refunds && !gasBailout {
 		refundQuotient := params.RefundQuotient
 		if rules.IsLondon {
 			refundQuotient = params.RefundQuotientEIP3529
 		}
-		mdGasUsed := st.mdGasUsed()
 		if rules.IsAmsterdam {
-			// EIP-8037 + EIP-7778: Block gas accounting uses two dimensions.
-			// stateGasConsumed tracks ALL state gas charges (including spill to regular gas).
-			// regularGasConsumed tracks only regular-dimension opcode gas.
-			blockState := imdGas.State + st.evm.StateGasConsumed()
-			blockRegular := imdGas.Regular + st.evm.RegularGasConsumed()
-			st.blockRegularGasUsed = max(blockRegular, intrinsicGasResult.FloorGasCost)
-			st.blockStateGasUsed = blockState
-			// Receipt gasUsed: total gas pool depletion + spill restored on depth-0 REVERT.
-			st.txnGasUsedB4Refunds = mdGasUsed.Total() + st.evm.RevertedSpillGas()
 			refund := min(st.txnGasUsedB4Refunds/refundQuotient, st.state.GetRefund().Total())
 			st.txnGasUsed = max(intrinsicGasResult.FloorGasCost, st.txnGasUsedB4Refunds-refund)
-		} else if rules.IsPrague {
-			st.txnGasUsedB4Refunds = mdGasUsed.Regular
-			refund := min(st.txnGasUsedB4Refunds/refundQuotient, st.state.GetRefund().Regular)
-			st.txnGasUsed = max(intrinsicGasResult.FloorGasCost, st.txnGasUsedB4Refunds-refund)
-			st.blockRegularGasUsed = st.txnGasUsed
 		} else {
-			st.txnGasUsedB4Refunds = mdGasUsed.Regular
 			refund := min(st.txnGasUsedB4Refunds/refundQuotient, st.state.GetRefund().Regular)
-			st.txnGasUsed = st.txnGasUsedB4Refunds - refund
+			if rules.IsPrague {
+				st.txnGasUsed = max(intrinsicGasResult.FloorGasCost, st.txnGasUsedB4Refunds-refund)
+			} else {
+				st.txnGasUsed = st.txnGasUsedB4Refunds - refund
+			}
 			st.blockRegularGasUsed = st.txnGasUsed
 		}
 		st.refundGas()
 	} else if rules.IsAmsterdam {
-		mdGasUsed := st.mdGasUsed()
-		blockState := imdGas.State + st.evm.StateGasConsumed()
-		blockRegular := imdGas.Regular + st.evm.RegularGasConsumed()
-		st.blockRegularGasUsed = max(blockRegular, intrinsicGasResult.FloorGasCost)
-		st.blockStateGasUsed = blockState
-		st.txnGasUsedB4Refunds = mdGasUsed.Total() + st.evm.RevertedSpillGas()
 		st.txnGasUsed = max(st.txnGasUsedB4Refunds, intrinsicGasResult.FloorGasCost)
 	} else {
 		// No-refund path: gasBailout (trace_call) or !refunds.
 		// Don't apply Prague floor or refunds — just record raw gas used.
-		st.txnGasUsedB4Refunds = st.mdGasUsed().Regular
 		st.txnGasUsed = st.txnGasUsedB4Refunds
 		st.blockRegularGasUsed = st.msg.Gas() // match pre-refactor: consume full gas limit from pool
 	}


### PR DESCRIPTION
- Restructure gas accounting in `Execute()` into two phases: (1) compute raw gas consumption and block-level accounting, (2) apply refunds or record raw gas usage
- Eliminates duplicated Amsterdam block accounting that appeared in both refund and no-refund paths (5 identical lines)
- Reduces `txnGasUsedB4Refunds` assignment sites from 5 to 2, removes a redundant `mdGasUsed()` call
- No behavioral change — all fork paths produce identical results
