### PR TITLE
db/kv/remotedbserver: support PREV_DUP and PREV_NO_DUP

### DIFF
--- a/db/kv/remotedbserver/remotedbserver.go
+++ b/db/kv/remotedbserver/remotedbserver.go
@@ -393,16 +393,10 @@ func handleOp(c kv.Cursor, stream remoteproto.KV_TxServer, in *remoteproto.Curso
 		k, v, err = c.(kv.CursorDupSort).NextNoDup()
 	case remoteproto.Op_PREV:
 		k, v, err = c.Prev()
-	//case remoteproto.Op_PREV_DUP:
-	//	k, v, err = c.(ethdb.CursorDupSort).Prev()
-	//	if err != nil {
-	//		return err
-	//	}
-	//case remoteproto.Op_PREV_NO_DUP:
-	//	k, v, err = c.Prev()
-	//	if err != nil {
-	//		return err
-	//	}
+	case remoteproto.Op_PREV_DUP:
+		k, v, err = c.(kv.CursorDupSort).PrevDup()
+	case remoteproto.Op_PREV_NO_DUP:
+		k, v, err = c.(kv.CursorDupSort).PrevNoDup()
 	case remoteproto.Op_SEEK_EXACT:
 		k, v, err = c.SeekExact(in.K)
 	case remoteproto.Op_SEEK_BOTH_EXACT:


### PR DESCRIPTION
Implement server-side handling for PREV_DUP and PREV_NO_DUP in KV remote cursor ops, aligning runtime behavior with the existing client/proto contract.