### PR TITLE
execmodule, stageloop: apply ERIGON_IN_MEM_HISTORY flag to ExecV3 path

### DIFF
--- a/execution/execmodule/exec_module.go
+++ b/execution/execmodule/exec_module.go
@@ -450,6 +450,7 @@ func (e *ExecModule) ValidateChain(ctx context.Context, req *executionproto.Vali
 	if err != nil {
 		return nil, err
 	}
+	doms.SetInMemHistoryReads(inMemHistoryReads)
 
 	// Set state cache in SharedDomains for use during state reading
 	if e.stateCache != nil && dbg.UseStateCache {

--- a/execution/execmodule/forkchoice.go
+++ b/execution/execmodule/forkchoice.go
@@ -236,6 +236,9 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 			return sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, err, false)
 		}
 	}
+	if currentContext != nil {
+		currentContext.SetInMemHistoryReads(inMemHistoryReads)
+	}
 
 	defer func() {
 		if closeOnReturn && currentContext != nil {

--- a/execution/stagedsync/stageloop/stageloop.go
+++ b/execution/stagedsync/stageloop/stageloop.go
@@ -247,6 +247,7 @@ func StageLoopIteration(ctx context.Context, db kv.TemporalRwDB, sync *stagedsyn
 				return err
 			}
 			defer sd.Close()
+			sd.SetInMemHistoryReads(inMemHistoryReads)
 			hasMore, err = stageLoopIteration(ctx, sd, tx, sync, initialCycle, firstCycle, logger, blockReader, hook)
 			if err != nil {
 				return err


### PR DESCRIPTION
Follow-up to #20245.

`ProcessFrozenBlocks` already respected the `ERIGON_IN_MEM_HISTORY` env flag, but the remaining `SharedDomains` creation sites did not. This applies the flag to:

- `StageLoopIteration` — ExecV3 live execution path
- `ValidateChain` — fork validation path  
- `updateForkChoice` — FCU path

Setting `ERIGON_IN_MEM_HISTORY=false` now disables in-memory history reads across all execution paths, not just frozen block processing.