### PR TITLE
[r3.4] execution/cache: fix StateCache dropping deleted storage keys, causing stale reads

### DIFF
--- a/execution/cache/cache_test.go
+++ b/execution/cache/cache_test.go
@@ -603,6 +603,47 @@ func TestStateCache_Delete(t *testing.T) {
 	assert.False(t, ok)
 }
 
+// Regression test for https://github.com/erigontech/erigon/issues/20169
+//
+// SharedDomains.GetLatest caches deleted keys via Put(key, nil).
+// Previously, Put treated nil/empty values as Delete (removing the key from
+// cache), and Get treated empty cached values as "not found". This caused
+// subsequent reads to miss the cache and fall through to the DB, returning
+// stale pre-delete values.
+func TestStateCache_PutEmpty_ThenGet_IsCacheHit(t *testing.T) {
+	c := NewStateCache(100, 100, 100, 100, 100)
+
+	key := make([]byte, 52) // addr(20) + slot(32)
+	key[0] = 0x1d
+	key[51] = 0xa2
+
+	// Simulate the SharedDomains pattern: a DomainDel causes GetLatest
+	// to cache the deletion via Put(key, nil).
+	c.Put(kv.StorageDomain, key, nil)
+
+	// Get must return (_, true) — a cache HIT with empty value.
+	// If it returns (_, false), the caller falls through to DB and
+	// reads the stale pre-delete value.
+	v, ok := c.Get(kv.StorageDomain, key)
+	assert.True(t, ok, "Get after Put(nil) must be a cache hit, not a miss")
+	assert.Empty(t, v, "cached value for a deleted key must be empty")
+}
+
+// Same test for []byte{} (zero-length but non-nil).
+func TestStateCache_PutEmptySlice_ThenGet_IsCacheHit(t *testing.T) {
+	c := NewStateCache(100, 100, 100, 100, 100)
+
+	key := make([]byte, 52)
+	key[0] = 0x1d
+	key[51] = 0xa2
+
+	c.Put(kv.StorageDomain, key, []byte{})
+
+	v, ok := c.Get(kv.StorageDomain, key)
+	assert.True(t, ok, "Get after Put([]byte{}) must be a cache hit")
+	assert.Empty(t, v)
+}
+
 func TestStateCache_Delete_UnsupportedDomain(t *testing.T) {
 	c := NewStateCache(100, 100, 100, 100, 100)
 

--- a/execution/cache/generic_cache.go
+++ b/execution/cache/generic_cache.go
@@ -81,7 +81,7 @@ func (c *DomainCache) Delete(key []byte) {
 // Get retrieves data for the given key.
 func (c *GenericCache[T]) Get(key []byte) (T, bool) {
 	value, ok := c.data.Get(key)
-	if !ok || c.sizeFunc(value) == 0 {
+	if !ok {
 		c.misses.Add(1)
 		var zero T
 		return zero, false

--- a/execution/cache/state_cache.go
+++ b/execution/cache/state_cache.go
@@ -67,16 +67,14 @@ func NewDefaultStateCache() *StateCache {
 }
 
 // Get retrieves data for the given domain and key.
+// Returns (value, true) on cache hit — including (nil, true) for deleted keys —
+// and (nil, false) on cache miss.
 func (c *StateCache) Get(domain kv.Domain, key []byte) ([]byte, bool) {
 	cache := c.caches[domain]
 	if cache == nil {
 		return nil, false
 	}
-	v, ok := cache.Get(key)
-	if len(v) == 0 {
-		return nil, false
-	}
-	return v, ok
+	return cache.Get(key)
 }
 
 // Put stores data for the given domain and key.
@@ -86,10 +84,6 @@ func (c *StateCache) Put(domain kv.Domain, key []byte, value []byte) {
 		return
 	}
 	if domain == kv.CommitmentDomain && bytes.Equal(key, commitmentdb.KeyCommitmentState) {
-		return
-	}
-	if len(value) == 0 {
-		cache.Delete(key)
 		return
 	}
 	cache.Put(key, common.Copy(value))

--- a/execution/tests/blockchain_test.go
+++ b/execution/tests/blockchain_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/prune"
 	"github.com/erigontech/erigon/db/rawdb"
+	"github.com/erigontech/erigon/execution/cache"
 	libchain "github.com/erigontech/erigon/execution/chain"
 	chainspec "github.com/erigontech/erigon/execution/chain/spec"
 	"github.com/erigontech/erigon/execution/execmodule/execmoduletester"
@@ -2354,4 +2355,68 @@ func TestEIP1559Transition(t *testing.T) {
 		return nil
 	})
 	require.NoError(t, err)
+}
+
+// Regression test for https://github.com/erigontech/erigon/issues/20169
+//
+// Tests the SharedDomains StateCache directly, reproducing the exact
+// sequence that caused Hoodi nodes to get stuck:
+//
+//  1. DomainPut writes key=0x42 (populates stateCache with 0x42)
+//  2. Flush + ClearRam (persists to DB, clears mem buffer)
+//  3. DomainDel deletes the key (stateCache.Delete removes entry)
+//  4. Flush + ClearRam (persists deletion to DB, clears mem buffer)
+//  5. GetLatest reads the key — should return nil (deleted)
+//
+// With the bug, step 3's DomainDel calls stateCache.Delete (removing
+// the entry) but step 4's Flush path calls GetLatest which reads nil
+// from mem buffer and does stateCache.Put(nil) → which ALSO deletes
+// from cache. After ClearRam, the mem buffer is empty and the stateCache
+// has no entry. Step 5's GetLatest falls through to the DB, which
+// returns nil (correct, since Flush persisted the deletion).
+//
+// However, if the stateCache was populated between step 2 and step 3
+// by a GetLatest (which caches 0x42 from DB), and the DomainDel's
+// stateCache.Delete removes it, and then stateCache.Put(nil) removes
+// the deletion sentinel, the cache has NO entry for the key. If the
+// DB read in step 5 somehow returns the stale value (e.g. due to
+// transaction isolation), the stale value is returned.
+//
+// This test exercises the StateCache at the cache level to verify
+// that Put(nil) correctly records the deletion as a cache hit.
+func TestStateCacheDeletedStorageSSTOREGas(t *testing.T) {
+	t.Parallel()
+
+	c := cache.NewStateCache(100, 100, 100, 100, 100)
+
+	key := make([]byte, 52) // addr(20) + slot(32)
+	key[0] = 0x1d
+	key[51] = 0xa2
+
+	value := []byte{0x42}
+
+	// Step 1: Put a value (simulates DomainPut caching a storage value)
+	c.Put(kv.StorageDomain, key, value)
+	v, ok := c.Get(kv.StorageDomain, key)
+	require.True(t, ok, "after Put: should be cached")
+	require.Equal(t, value, v)
+
+	// Step 2: Delete the key (simulates DomainDel)
+	c.Delete(kv.StorageDomain, key)
+
+	// Step 3: Put nil (simulates GetLatest caching a deletion from mem buffer)
+	// This is the exact sequence in SharedDomains.GetLatest:
+	//   v, step, ok := sd.mem.GetLatest(domain, k)  // ok=true, v=nil
+	//   sd.stateCache.Put(domain, k, v)              // v=nil
+	c.Put(kv.StorageDomain, key, nil)
+
+	// Step 4: Get must return a cache HIT with empty value.
+	// This is the critical assertion: with the bug, Get returns (nil, false)
+	// meaning "not in cache", so the caller falls through to the DB.
+	v, ok = c.Get(kv.StorageDomain, key)
+	require.True(t, ok,
+		"after Delete+Put(nil): Get must return (nil, true) — cached as deleted. "+
+			"Returning false causes the caller to read stale data from the DB, "+
+			"which is the root cause of the Hoodi gas mismatch (#20169).")
+	require.Empty(t, v, "cached value for a deleted key must be empty")
 }


### PR DESCRIPTION
Cherry-pick of #20265 to `release/3.4`.

## Summary

Fix a bug in `StateCache.Get()`/`Put()` that caused deleted storage keys to be treated as cache misses, allowing stale pre-delete values to be read from the DB.

**Root cause of #20169** (Erigon nodes stuck on Hoodi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)