### PR TITLE
db/state: skip redundant state cache put for in-memory batch values

### DIFF
--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -427,13 +427,12 @@ func (sd *SharedDomains) GetLatest(domain kv.Domain, tx kv.TemporalTx, k []byte)
 	}
 	maxStep := kv.Step(math.MaxUint64)
 
-	// Check mem batch first - it has the current transaction's uncommitted state
+	// Check mem batch first - it has the current transaction's uncommitted state.
+	// No need to populate stateCache here — mem is checked first on every read,
+	// so the value is already accessible without caching it again.
 	if v, step, ok := sd.mem.GetLatest(domain, k); ok {
 		if dbg.KVReadLevelledMetrics {
 			sd.metrics.UpdateCacheReads(domain, start)
-		}
-		if sd.stateCache != nil {
-			sd.stateCache.Put(domain, k, v)
 		}
 		return v, step, nil
 	} else {


### PR DESCRIPTION
## Summary
- When `SharedDomains.GetLatest` finds a value in the mem batch, skip copying it into the state cache. The mem batch is always checked first on reads, so the duplicate cache entry just wastes memory via `bytes.Clone`.

## Benchmark results (BenchmarkEngineXScenario)
- `bytes.Clone` allocations: **30.2 GB → 0.8 GB** (37x reduction)
- Total allocations: **144 GB → 18 GB** (8x reduction)

## Test plan
- [x] `go test -short ./db/state/execctx/...`
- [x] `BenchmarkEngineXScenario` passes with improved allocation profile
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)