### PR TITLE
cmd/integration: enable historical commitment config during rebuild

### DIFF
--- a/cmd/integration/commands/commitment.go
+++ b/cmd/integration/commands/commitment.go
@@ -301,6 +301,9 @@ func commitmentRebuild(db kv.TemporalRwDB, ctx context.Context, logger log.Logge
 	if err != nil {
 		return err
 	}
+	if commitmentHistoryEnabled {
+		statecfg.EnableHistoricalCommitment()
+	}
 
 	if resume && !commitmentHistoryEnabled {
 		return errors.New("--resume requires commitment history to be enabled")


### PR DESCRIPTION
- this will allow rebuild commitment to prune commitment history 