### PR TITLE
Bug 1: Fix integrity check at domain <-> history boundary (cherry-pick to 3.4)

### DIFF
--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -1385,6 +1385,9 @@ func doIntegrity(cliCtx *cli.Context) error {
 func stateProgress(ctx context.Context, db kv.TemporalRoDB, txNumsReader rawdbv3.TxNumsReader) (uint64, error) {
 	agg := db.(state.HasAgg).Agg().(*state.Aggregator)
 	aggMax := agg.EndTxNumMinimax()
+	if aggMax == 0 {
+		return 0, nil
+	}
 	roTx, err := db.BeginRo(ctx)
 	if err != nil {
 		return 0, err
@@ -1393,6 +1396,16 @@ func stateProgress(ctx context.Context, db kv.TemporalRoDB, txNumsReader rawdbv3
 	blockNum, _, err := txNumsReader.FindBlockNum(ctx, roTx, aggMax)
 	if err != nil {
 		return 0, err
+	}
+	// FindBlockNum returns the first block whose maxTxNum >= aggMax, but that
+	// block may not be fully covered by state (maxTxNum+1 > aggMax). Back up
+	// to the last block that is fully covered.
+	maxTxNum, err := txNumsReader.Max(ctx, roTx, blockNum)
+	if err != nil {
+		return 0, err
+	}
+	if maxTxNum+1 > aggMax && blockNum > 0 {
+		blockNum--
 	}
 	return blockNum, nil
 }

--- a/db/integrity/commitment_integrity.go
+++ b/db/integrity/commitment_integrity.go
@@ -848,7 +848,11 @@ func checkCommitmentHistAtBlkWithIdx(ctx context.Context, tx kv.TemporalTx, sd *
 	if err != nil {
 		return err
 	}
-	if aggMax := db.(state.HasAgg).Agg().(*state.Aggregator).EndTxNumMinimax(); maxTxNum+1 > aggMax { // don't use seek-commitment to check "state progress" - because we are in method which checking "files validity" (can't rely on them here)
+	// Use EndTxNumNoCommitment: this check reconstructs commitment from history
+	// files only (not commitment domain), so commitment domain coverage must not
+	// limit which blocks can be verified.
+	aggTx := state.AggTx(tx)
+	if aggMax := aggTx.EndTxNumNoCommitment(); maxTxNum+1 > aggMax {
 		blockNumOfState, _, _ := txNumsReader.FindBlockNum(ctx, tx, aggMax)
 		return fmt.Errorf("block %d is beyond latest block with state %d", blockNum, blockNumOfState)
 	}


### PR DESCRIPTION
Cherry-pick of #20311 to `release/3.4`.

Just use correct function for integrity check at domain <-> history boundary.