### PR TITLE
rpc: fix estimateGas returning -32000 instead of error code 3 on revert

### DIFF
--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -299,7 +299,7 @@ func (api *APIImpl) EstimateGas(ctx context.Context, argsOrNil *ethapi2.CallArgs
 	}
 	if failed {
 		if result != nil && !errors.Is(result.Err, vm.ErrOutOfGas) {
-			if len(result.Revert()) > 0 {
+			if errors.Is(result.Err, vm.ErrExecutionReverted) {
 				return 0, ethapi2.NewRevertError(result)
 			}
 			return 0, result.Err


### PR DESCRIPTION


When EstimateGas fails with ErrExecutionReverted but no revert data, Erigon was returning the raw error (code -32000) instead of a RevertError (code 3). 
Align with Geth/erigon in Call() by checking errors.Is(result.Err, vm.ErrExecutionReverted) rather than len(result.Revert()) > 0, so code 3 is always returned on revert.