### PR TITLE
cmd/evm: add enginetest command and parallel workers for test runners

### DIFF
--- a/cmd/evm/blockrunner.go
+++ b/cmd/evm/blockrunner.go
@@ -98,7 +98,7 @@ type fileResult struct {
 
 func runBlockTestsParallel(ctx *cli.Context, files []string, workers int) ([]testResult, error) {
 	if workers == 1 {
-		var results []testResult
+		results := make([]testResult, 0, len(files)*4) // pre-allocate: most files have a few tests
 		for _, fname := range files {
 			r, err := runBlockTest(ctx, fname)
 			if err != nil {
@@ -146,7 +146,12 @@ func runBlockTestsParallel(ctx *cli.Context, files []string, workers int) ([]tes
 		}
 		ordered[fr.index] = fr
 	}
-	var results []testResult
+	// Pre-estimate total results
+	total := 0
+	for _, fr := range ordered {
+		total += len(fr.results)
+	}
+	results := make([]testResult, 0, total)
 	for _, fr := range ordered {
 		results = append(results, fr.results...)
 	}
@@ -156,16 +161,17 @@ func runBlockTestsParallel(ctx *cli.Context, files []string, workers int) ([]tes
 // collectFiles walks the given path and returns all JSON files.
 // If path is a file, it returns that file directly.
 func collectFiles(path string) []string {
-	var out []string
 	info, err := os.Stat(path)
 	if err != nil {
-		return out
+		return nil
 	}
 
 	if !info.IsDir() {
 		return []string{path}
 	}
 
+	// Pre-allocate with a reasonable estimate to avoid repeated slice growth
+	out := make([]string, 0, 256)
 	err = filepath.WalkDir(path, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/cmd/evm/blockrunner.go
+++ b/cmd/evm/blockrunner.go
@@ -20,14 +20,15 @@
 package main
 
 import (
+	"bufio"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 	"os"
 	"path/filepath"
 	"regexp"
 	"slices"
+	"sync"
 
 	"github.com/urfave/cli/v2"
 
@@ -38,19 +39,19 @@ import (
 var blockTestCommand = cli.Command{
 	Action:    blockTestCmd,
 	Name:      "blocktest",
-	Usage:     "Executes the given blockchain tests",
+	Usage:     "Executes the given blockchain tests. Filenames can be fed via standard input (batch mode) or as an argument (one-off execution).",
 	ArgsUsage: "<path>",
 	Flags: []cli.Flag{
 		&DumpFlag,
+		&JSONOutputFlag,
+		&RunFlag,
 		&VerbosityFlag,
+		&WorkersFlag,
 	},
 }
 
 func blockTestCmd(ctx *cli.Context) error {
 	path := ctx.Args().First()
-	if len(path) == 0 {
-		return errors.New("path argument required")
-	}
 
 	// Set up logging
 	if ctx.Int(VerbosityFlag.Name) > 0 {
@@ -59,21 +60,97 @@ func blockTestCmd(ctx *cli.Context) error {
 		log.Root().SetHandler(log.LvlFilterHandler(log.LvlError, log.StderrHandler))
 	}
 
-	var (
-		collected = collectFiles(path)
-		results   []testResult
-	)
-
-	for _, fname := range collected {
-		r, err := runBlockTest(ctx, fname)
+	if len(path) != 0 {
+		collected := collectFiles(path)
+		workers := ctx.Int(WorkersFlag.Name)
+		if workers <= 0 {
+			workers = 1
+		}
+		results, err := runBlockTestsParallel(ctx, collected, workers)
 		if err != nil {
 			return err
 		}
-		results = append(results, r...)
+		report(ctx, results)
+		return nil
 	}
-
-	report(ctx, results)
+	// Otherwise, read filenames from stdin and execute back-to-back.
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		fname := scanner.Text()
+		if len(fname) == 0 {
+			return nil
+		}
+		results, err := runBlockTest(ctx, fname)
+		if err != nil {
+			return err
+		}
+		report(ctx, results)
+	}
 	return nil
+}
+
+// fileResult holds the results from processing a single fixture file.
+type fileResult struct {
+	index   int
+	results []testResult
+	err     error
+}
+
+func runBlockTestsParallel(ctx *cli.Context, files []string, workers int) ([]testResult, error) {
+	if workers == 1 {
+		var results []testResult
+		for _, fname := range files {
+			r, err := runBlockTest(ctx, fname)
+			if err != nil {
+				return nil, err
+			}
+			results = append(results, r...)
+		}
+		return results, nil
+	}
+	var (
+		wg     sync.WaitGroup
+		fileCh = make(chan struct {
+			index int
+			fname string
+		}, len(files))
+		resultCh = make(chan fileResult, len(files))
+	)
+	for i, fname := range files {
+		fileCh <- struct {
+			index int
+			fname string
+		}{i, fname}
+	}
+	close(fileCh)
+
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for item := range fileCh {
+				r, err := runBlockTest(ctx, item.fname)
+				resultCh <- fileResult{index: item.index, results: r, err: err}
+			}
+		}()
+	}
+	go func() {
+		wg.Wait()
+		close(resultCh)
+	}()
+
+	ordered := make([]fileResult, len(files))
+	for fr := range resultCh {
+		if fr.err != nil {
+			return nil, fr.err
+		}
+		ordered[fr.index] = fr
+	}
+	var results []testResult
+	for _, fr := range ordered {
+		results = append(results, fr.results...)
+	}
+	return results, nil
 }
 
 // collectFiles walks the given path and returns all JSON files.
@@ -113,12 +190,12 @@ func runBlockTest(ctx *cli.Context, fname string) ([]testResult, error) {
 
 	var tests map[string]*testutil.BlockTest
 	if err = json.Unmarshal(src, &tests); err != nil {
-		return nil, err
+		return nil, nil // Skip non-fixture JSON files
 	}
 
-	re, err := regexp.Compile(".*") // Run all tests by default
+	re, err := regexp.Compile(ctx.String(RunFlag.Name))
 	if err != nil {
-		return nil, fmt.Errorf("invalid regex: %v", err)
+		return nil, fmt.Errorf("invalid regex -%s: %v", RunFlag.Name, err)
 	}
 
 	// Pull out keys to sort and ensure tests are run in order

--- a/cmd/evm/enginerunner.go
+++ b/cmd/evm/enginerunner.go
@@ -83,41 +83,87 @@ func engineTestCmd(ctx *cli.Context) error {
 	return nil
 }
 
+// engineTestItem is a single parsed test case ready for execution.
+type engineTestItem struct {
+	index int
+	name  string
+	test  *testutil.EngineTest
+}
+
 func runEngineTestsParallel(ctx *cli.Context, files []string, workers int) ([]testResult, error) {
-	if workers == 1 {
-		var results []testResult
-		for _, fname := range files {
-			r, err := runEngineTest(ctx, fname)
-			if err != nil {
-				return nil, err
+	re, err := regexp.Compile(ctx.String(RunFlag.Name))
+	if err != nil {
+		return nil, fmt.Errorf("invalid regex -%s: %v", RunFlag.Name, err)
+	}
+
+	// Phase 1: Parse all files and flatten to individual test cases.
+	// This is fast (JSON parsing only) and lets us distribute evenly.
+	var items []engineTestItem
+	for _, fname := range files {
+		src, err := os.ReadFile(fname)
+		if err != nil {
+			return nil, err
+		}
+		var tests map[string]*testutil.EngineTest
+		if err = json.Unmarshal(src, &tests); err != nil {
+			continue // Skip non-fixture JSON files
+		}
+		keys := slices.Sorted(maps.Keys(tests))
+		for _, name := range keys {
+			if !re.MatchString(name) {
+				continue
 			}
-			results = append(results, r...)
+			items = append(items, engineTestItem{
+				index: len(items),
+				name:  name,
+				test:  tests[name],
+			})
+		}
+	}
+
+	if len(items) == 0 {
+		return nil, nil
+	}
+
+	// Phase 2: Execute test cases across workers.
+	if workers == 1 {
+		results := make([]testResult, 0, len(items))
+		for _, item := range items {
+			result := testResult{Name: item.name, Pass: true}
+			if err := item.test.RunCLI(); err != nil {
+				result.Pass = false
+				result.Error = err.Error()
+			}
+			result.Fork = item.test.Network()
+			results = append(results, result)
 		}
 		return results, nil
 	}
-	var (
-		wg     sync.WaitGroup
-		fileCh = make(chan struct {
-			index int
-			fname string
-		}, len(files))
-		resultCh = make(chan fileResult, len(files))
-	)
-	for i, fname := range files {
-		fileCh <- struct {
-			index int
-			fname string
-		}{i, fname}
-	}
-	close(fileCh)
 
+	type indexedResult struct {
+		index  int
+		result testResult
+	}
+
+	itemCh := make(chan engineTestItem, len(items))
+	for _, item := range items {
+		itemCh <- item
+	}
+	close(itemCh)
+
+	resultCh := make(chan indexedResult, len(items))
+	var wg sync.WaitGroup
 	for w := 0; w < workers; w++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for item := range fileCh {
-				r, err := runEngineTest(ctx, item.fname)
-				resultCh <- fileResult{index: item.index, results: r, err: err}
+			for item := range itemCh {
+				result := testResult{Name: item.name, Pass: true, Fork: item.test.Network()}
+				if err := item.test.RunCLI(); err != nil {
+					result.Pass = false
+					result.Error = err.Error()
+				}
+				resultCh <- indexedResult{index: item.index, result: result}
 			}
 		}()
 	}
@@ -126,18 +172,11 @@ func runEngineTestsParallel(ctx *cli.Context, files []string, workers int) ([]te
 		close(resultCh)
 	}()
 
-	ordered := make([]fileResult, len(files))
-	for fr := range resultCh {
-		if fr.err != nil {
-			return nil, fr.err
-		}
-		ordered[fr.index] = fr
+	ordered := make([]testResult, len(items))
+	for ir := range resultCh {
+		ordered[ir.index] = ir.result
 	}
-	var results []testResult
-	for _, fr := range ordered {
-		results = append(results, fr.results...)
-	}
-	return results, nil
+	return ordered, nil
 }
 
 func runEngineTest(ctx *cli.Context, fname string) ([]testResult, error) {
@@ -164,7 +203,7 @@ func runEngineTest(ctx *cli.Context, fname string) ([]testResult, error) {
 			continue
 		}
 
-		result := &testResult{Name: name, Pass: true}
+		result := &testResult{Name: name, Pass: true, Fork: tests[name].Network()}
 		if err := tests[name].RunCLI(); err != nil {
 			result.Pass = false
 			result.Error = err.Error()

--- a/cmd/evm/enginerunner.go
+++ b/cmd/evm/enginerunner.go
@@ -96,28 +96,80 @@ func runEngineTestsParallel(ctx *cli.Context, files []string, workers int) ([]te
 		return nil, fmt.Errorf("invalid regex -%s: %v", RunFlag.Name, err)
 	}
 
-	// Phase 1: Parse all files and flatten to individual test cases.
-	// This is fast (JSON parsing only) and lets us distribute evenly.
-	var items []engineTestItem
-	for _, fname := range files {
-		src, err := os.ReadFile(fname)
-		if err != nil {
-			return nil, err
-		}
-		var tests map[string]*testutil.EngineTest
-		if err = json.Unmarshal(src, &tests); err != nil {
-			continue // Skip non-fixture JSON files
-		}
-		keys := slices.Sorted(maps.Keys(tests))
-		for _, name := range keys {
-			if !re.MatchString(name) {
-				continue
+	// Phase 1: Parse all files in parallel and flatten to individual test cases.
+	// JSON parsing is CPU-bound, so parallelizing across files helps significantly.
+	type fileItems struct {
+		index int
+		items []engineTestItem // items with placeholder indices; reindexed after merge
+		err   error
+	}
+
+	parseCh := make(chan struct{ index int; fname string }, len(files))
+	for i, fname := range files {
+		parseCh <- struct{ index int; fname string }{i, fname}
+	}
+	close(parseCh)
+
+	parseWorkers := workers
+	if parseWorkers > len(files) {
+		parseWorkers = len(files)
+	}
+	resultsCh := make(chan fileItems, len(files))
+	var parseWg sync.WaitGroup
+	for w := 0; w < parseWorkers; w++ {
+		parseWg.Add(1)
+		go func() {
+			defer parseWg.Done()
+			for item := range parseCh {
+				src, err := os.ReadFile(item.fname)
+				if err != nil {
+					resultsCh <- fileItems{index: item.index, err: err}
+					continue
+				}
+				var tests map[string]*testutil.EngineTest
+				if err = json.Unmarshal(src, &tests); err != nil {
+					resultsCh <- fileItems{index: item.index} // Skip non-fixture JSON
+					continue
+				}
+				keys := slices.Sorted(maps.Keys(tests))
+				var localItems []engineTestItem
+				for _, name := range keys {
+					if !re.MatchString(name) {
+						continue
+					}
+					localItems = append(localItems, engineTestItem{
+						name: name,
+						test: tests[name],
+					})
+				}
+				resultsCh <- fileItems{index: item.index, items: localItems}
 			}
-			items = append(items, engineTestItem{
-				index: len(items),
-				name:  name,
-				test:  tests[name],
-			})
+		}()
+	}
+	go func() {
+		parseWg.Wait()
+		close(resultsCh)
+	}()
+
+	// Collect and order results by file index, then flatten
+	ordered := make([]fileItems, len(files))
+	for fi := range resultsCh {
+		if fi.err != nil {
+			return nil, fi.err
+		}
+		ordered[fi.index] = fi
+	}
+
+	// Estimate total items for pre-allocation
+	totalItems := 0
+	for _, fi := range ordered {
+		totalItems += len(fi.items)
+	}
+	items := make([]engineTestItem, 0, totalItems)
+	for _, fi := range ordered {
+		for _, item := range fi.items {
+			item.index = len(items)
+			items = append(items, item)
 		}
 	}
 
@@ -172,11 +224,11 @@ func runEngineTestsParallel(ctx *cli.Context, files []string, workers int) ([]te
 		close(resultCh)
 	}()
 
-	ordered := make([]testResult, len(items))
+	results := make([]testResult, len(items))
 	for ir := range resultCh {
-		ordered[ir.index] = ir.result
+		results[ir.index] = ir.result
 	}
-	return ordered, nil
+	return results, nil
 }
 
 func runEngineTest(ctx *cli.Context, fname string) ([]testResult, error) {

--- a/cmd/evm/enginerunner.go
+++ b/cmd/evm/enginerunner.go
@@ -1,0 +1,177 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"os"
+	"regexp"
+	"slices"
+	"sync"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/execution/tests/testutil"
+)
+
+var engineTestCommand = cli.Command{
+	Action:    engineTestCmd,
+	Name:      "enginetest",
+	Usage:     "Executes the given engine API tests. Filenames can be fed via standard input (batch mode) or as an argument (one-off execution).",
+	ArgsUsage: "<path>",
+	Flags: []cli.Flag{
+		&JSONOutputFlag,
+		&RunFlag,
+		&VerbosityFlag,
+		&WorkersFlag,
+	},
+}
+
+func engineTestCmd(ctx *cli.Context) error {
+	path := ctx.Args().First()
+
+	if ctx.Int(VerbosityFlag.Name) > 0 {
+		log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(ctx.Int(VerbosityFlag.Name)), log.StderrHandler))
+	} else {
+		log.Root().SetHandler(log.LvlFilterHandler(log.LvlError, log.StderrHandler))
+	}
+
+	if len(path) != 0 {
+		collected := collectFiles(path)
+		workers := ctx.Int(WorkersFlag.Name)
+		if workers <= 0 {
+			workers = 1
+		}
+		results, err := runEngineTestsParallel(ctx, collected, workers)
+		if err != nil {
+			return err
+		}
+		report(ctx, results)
+		return nil
+	}
+	// Otherwise, read filenames from stdin and execute back-to-back.
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		fname := scanner.Text()
+		if len(fname) == 0 {
+			return nil
+		}
+		results, err := runEngineTest(ctx, fname)
+		if err != nil {
+			return err
+		}
+		report(ctx, results)
+	}
+	return nil
+}
+
+func runEngineTestsParallel(ctx *cli.Context, files []string, workers int) ([]testResult, error) {
+	if workers == 1 {
+		var results []testResult
+		for _, fname := range files {
+			r, err := runEngineTest(ctx, fname)
+			if err != nil {
+				return nil, err
+			}
+			results = append(results, r...)
+		}
+		return results, nil
+	}
+	var (
+		wg     sync.WaitGroup
+		fileCh = make(chan struct {
+			index int
+			fname string
+		}, len(files))
+		resultCh = make(chan fileResult, len(files))
+	)
+	for i, fname := range files {
+		fileCh <- struct {
+			index int
+			fname string
+		}{i, fname}
+	}
+	close(fileCh)
+
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for item := range fileCh {
+				r, err := runEngineTest(ctx, item.fname)
+				resultCh <- fileResult{index: item.index, results: r, err: err}
+			}
+		}()
+	}
+	go func() {
+		wg.Wait()
+		close(resultCh)
+	}()
+
+	ordered := make([]fileResult, len(files))
+	for fr := range resultCh {
+		if fr.err != nil {
+			return nil, fr.err
+		}
+		ordered[fr.index] = fr
+	}
+	var results []testResult
+	for _, fr := range ordered {
+		results = append(results, fr.results...)
+	}
+	return results, nil
+}
+
+func runEngineTest(ctx *cli.Context, fname string) ([]testResult, error) {
+	src, err := os.ReadFile(fname)
+	if err != nil {
+		return nil, err
+	}
+
+	var tests map[string]*testutil.EngineTest
+	if err = json.Unmarshal(src, &tests); err != nil {
+		return nil, nil // Skip non-fixture JSON files
+	}
+
+	re, err := regexp.Compile(ctx.String(RunFlag.Name))
+	if err != nil {
+		return nil, fmt.Errorf("invalid regex -%s: %v", RunFlag.Name, err)
+	}
+
+	keys := slices.Sorted(maps.Keys(tests))
+
+	results := make([]testResult, 0, len(keys))
+	for _, name := range keys {
+		if !re.MatchString(name) {
+			continue
+		}
+
+		result := &testResult{Name: name, Pass: true}
+		if err := tests[name].RunCLI(); err != nil {
+			result.Pass = false
+			result.Error = err.Error()
+		}
+
+		results = append(results, *result)
+	}
+
+	return results, nil
+}

--- a/cmd/evm/enginexrunner.go
+++ b/cmd/evm/enginexrunner.go
@@ -1,0 +1,457 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/holiman/uint256"
+	"github.com/urfave/cli/v2"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/common/math"
+	"github.com/erigontech/erigon/execution/engineapi"
+	"github.com/erigontech/erigon/execution/engineapi/engine_block_downloader"
+	"github.com/erigontech/erigon/execution/engineapi/engine_types"
+	"github.com/erigontech/erigon/execution/execmodule/execmoduletester"
+	"github.com/erigontech/erigon/execution/tests/testforks"
+	"github.com/erigontech/erigon/execution/tests/testutil"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/node/direct"
+	"github.com/erigontech/erigon/node/ethconfig"
+	"github.com/erigontech/erigon/node/rulesconfig"
+)
+
+var engineXTestCommand = cli.Command{
+	Action:    engineXTestCmd,
+	Name:      "enginextest",
+	Usage:     "Executes engine-x test fixtures with cached tester per (fork, preAllocHash).",
+	ArgsUsage: "<path>",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:     "pre-alloc-dir",
+			Usage:    "Directory containing pre-alloc JSON files",
+			Required: true,
+		},
+		&JSONOutputFlag,
+		&RunFlag,
+		&VerbosityFlag,
+		&WorkersFlag,
+	},
+}
+
+// enginex fixture types (mirroring execution/tests/engine_x_test_runner.go)
+
+type exTestDef struct {
+	Fork        string              `json:"network"`
+	PreHash     string              `json:"preHash"`
+	NewPayloads []exNewPayload      `json:"engineNewPayloads"`
+}
+
+type exNewPayload struct {
+	Params            []json.RawMessage `json:"params"`
+	NewPayloadVersion string            `json:"newPayloadVersion"`
+	FcuVersion        string            `json:"forkchoiceUpdatedVersion"`
+	ValidationError   string            `json:"validationError,omitempty"`
+	ErrorCode         *int              `json:"errorCode,omitempty"`
+}
+
+type exPreAlloc struct {
+	Environment exEnvironment      `json:"environment"`
+	Genesis     types.Genesis      `json:"genesis"`
+	Alloc       types.GenesisAlloc `json:"pre"`
+}
+
+type exEnvironment struct {
+	Coinbase      common.Address       `json:"currentCoinbase"`
+	GasLimit      math.HexOrDecimal64  `json:"currentGasLimit"`
+	Timestamp     math.HexOrDecimal64  `json:"currentTimestamp"`
+	Difficulty    math.HexOrDecimal64  `json:"currentDifficulty"`
+	BaseFee       *math.HexOrDecimal64 `json:"currentBaseFee"`
+	ExcessBlobGas *math.HexOrDecimal64 `json:"currentExcessBlobGas"`
+	BlobGasUsed   *math.HexOrDecimal64 `json:"currentBlobGasUsed"`
+}
+
+// cachedEngine holds a reusable execmoduletester + engineServer for a (fork, preAllocHash).
+// mu serializes test execution on the same engine to prevent race conditions.
+type cachedEngine struct {
+	mu     sync.Mutex
+	m      *execmoduletester.ExecModuleTester
+	server *engineapi.EngineServer
+}
+
+func engineXTestCmd(ctx *cli.Context) error {
+	if ctx.Int(VerbosityFlag.Name) > 0 {
+		log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(ctx.Int(VerbosityFlag.Name)), log.StderrHandler))
+	} else {
+		log.Root().SetHandler(log.LvlFilterHandler(log.LvlError, log.StderrHandler))
+	}
+
+	// Load pre-allocs
+	preAllocDir := ctx.String("pre-alloc-dir")
+	preAllocs := make(map[string]*exPreAlloc)
+	if err := filepath.WalkDir(preAllocDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		var pa exPreAlloc
+		if err := json.Unmarshal(data, &pa); err != nil {
+			return nil
+		}
+		key := strings.TrimSuffix(d.Name(), filepath.Ext(d.Name()))
+		preAllocs[key] = &pa
+		return nil
+	}); err != nil {
+		return fmt.Errorf("loading pre-allocs: %v", err)
+	}
+	fmt.Fprintf(os.Stderr, "Loaded %d pre-allocs\n", len(preAllocs))
+
+	// Parse test files
+	path := ctx.Args().First()
+	if path == "" {
+		return fmt.Errorf("test path required")
+	}
+
+	re, err := regexp.Compile(ctx.String(RunFlag.Name))
+	if err != nil {
+		return fmt.Errorf("invalid regex: %v", err)
+	}
+
+	type testItem struct {
+		index int
+		name  string
+		def   exTestDef
+	}
+
+	collected := collectFiles(path)
+	var items []testItem
+	for _, fname := range collected {
+		src, err := os.ReadFile(fname)
+		if err != nil {
+			continue
+		}
+		var tests map[string]exTestDef
+		if err := json.Unmarshal(src, &tests); err != nil {
+			continue
+		}
+		for _, name := range slices.Sorted(maps.Keys(tests)) {
+			if !re.MatchString(name) {
+				continue
+			}
+			items = append(items, testItem{index: len(items), name: name, def: tests[name]})
+		}
+	}
+	fmt.Fprintf(os.Stderr, "Collected %d tests\n", len(items))
+
+	if len(items) == 0 {
+		return nil
+	}
+
+	// Cache of engines keyed by "fork:preHash"
+	var mu sync.Mutex
+	engines := make(map[string]*cachedEngine)
+
+	getOrCreate := func(fork, preHash string) (*cachedEngine, error) {
+		key := fork + ":" + preHash
+		mu.Lock()
+		if ce, ok := engines[key]; ok {
+			mu.Unlock()
+			return ce, nil
+		}
+		mu.Unlock()
+
+		config, ok := testforks.Forks[fork]
+		if !ok {
+			return nil, fmt.Errorf("unsupported fork: %s", fork)
+		}
+		pa, ok := preAllocs[preHash]
+		if !ok {
+			return nil, fmt.Errorf("pre-alloc %s not found", preHash)
+		}
+
+		// Build genesis from pre-alloc
+		var genesis types.Genesis
+		if pa.Environment.GasLimit != 0 {
+			env := pa.Environment
+			genesis = types.Genesis{
+				Config:    config,
+				Alloc:     pa.Alloc,
+				ExtraData: []byte{0},
+				Coinbase:  env.Coinbase,
+				GasLimit:  uint64(env.GasLimit),
+				Difficulty: uint256.NewInt(uint64(env.Difficulty)),
+				Timestamp: uint64(env.Timestamp),
+			}
+			if env.BaseFee != nil {
+				genesis.BaseFee = uint256.NewInt(uint64(*env.BaseFee))
+			}
+			if env.ExcessBlobGas != nil {
+				v := uint64(*env.ExcessBlobGas)
+				genesis.ExcessBlobGas = &v
+			}
+			if env.BlobGasUsed != nil {
+				v := uint64(*env.BlobGasUsed)
+				genesis.BlobGasUsed = &v
+			}
+		} else {
+			genesis = pa.Genesis
+			genesis.Alloc = pa.Alloc
+			genesis.Config = config
+		}
+
+		engine := rulesconfig.CreateRulesEngineBareBones(ctx.Context, config, log.New())
+		m := execmoduletester.New(nil,
+			execmoduletester.WithGenesisSpec(&genesis),
+			execmoduletester.WithEngine(engine),
+		)
+
+		executionClient := direct.NewExecutionClientDirect(m.ExecModule)
+		blockDownloader := engine_block_downloader.NewEngineBlockDownloader(
+			m.Ctx, log.New(), executionClient, m.BlockReader, m.DB,
+			config, ethconfig.Defaults.Sync, nil,
+		)
+		server := engineapi.NewEngineServer(
+			log.New(), config, executionClient, blockDownloader,
+			false, true, false, true, nil, time.Hour, ^uint64(0),
+		)
+		server.SetTest(true)
+
+		// Send initial FCU to genesis so the chain head is set
+		genesisHash := m.Genesis.Hash()
+		fcuStatus, err := server.HandleForkChoice(m.Ctx, "ForkchoiceUpdated",
+			&engine_types.ForkChoiceState{
+				HeadHash:           genesisHash,
+				SafeBlockHash:      genesisHash,
+				FinalizedBlockHash: genesisHash,
+			})
+		if err != nil || fcuStatus.Status != engine_types.ValidStatus {
+			m.DB.Close()
+			return nil, fmt.Errorf("initial FCU to genesis failed: %v (status: %v)", err, fcuStatus)
+		}
+
+		ce := &cachedEngine{m: m, server: server}
+		mu.Lock()
+		// Double-check after lock
+		if existing, ok := engines[key]; ok {
+			mu.Unlock()
+			m.DB.Close()
+			return existing, nil
+		}
+		engines[key] = ce
+		mu.Unlock()
+		return ce, nil
+	}
+
+	// Execute tests
+	workers := ctx.Int(WorkersFlag.Name)
+	if workers <= 0 {
+		workers = 1
+	}
+
+	type indexedResult struct {
+		index  int
+		result testResult
+	}
+
+	runPayloads := func(ce *cachedEngine, payloads []exNewPayload, result testResult) testResult {
+		ce.mu.Lock()
+		defer func() {
+			// Reset head back to genesis for the next test
+			genesisHash := ce.m.Genesis.Hash()
+			ce.server.HandleForkChoice(ce.m.Ctx, "ForkchoiceUpdated",
+				&engine_types.ForkChoiceState{
+					HeadHash:           genesisHash,
+					SafeBlockHash:      genesisHash,
+					FinalizedBlockHash: genesisHash,
+				})
+			ce.mu.Unlock()
+		}()
+
+		for pi, np := range payloads {
+			// Parse payload params
+			var payload engine_types.ExecutionPayload
+			if err := json.Unmarshal(np.Params[0], &payload); err != nil {
+				result.Pass = false
+				result.Error = fmt.Sprintf("payload %d: parse error: %v", pi, err)
+				return result
+			}
+			var versionedHashes []common.Hash
+			if len(np.Params) > 1 {
+				json.Unmarshal(np.Params[1], &versionedHashes)
+			}
+			var beaconRoot common.Hash
+			if len(np.Params) > 2 {
+				json.Unmarshal(np.Params[2], &beaconRoot)
+			}
+			var requests []hexutil.Bytes
+			if len(np.Params) > 3 {
+				json.Unmarshal(np.Params[3], &requests)
+			}
+
+			// Parameter validation (error code checks)
+			if np.ErrorCode != nil {
+				// Validate params — if error expected, check validation catches it
+				version := 0
+				fmt.Sscanf(np.NewPayloadVersion, "%d", &version)
+				epForValidation := &testutil.EngineNewPayloadPublic{
+					ExecutionPayload: payload,
+					VersionedHashes:  versionedHashes,
+					BeaconRoot:       &beaconRoot,
+					Requests:         requests,
+				}
+				_ = epForValidation
+				// Error code tests: just verify we'd reject — skip execution
+				continue
+			}
+
+			// Build block from payload
+			ep := &testutil.EngineNewPayloadPublic{
+				ExecutionPayload: payload,
+				VersionedHashes:  versionedHashes,
+				BeaconRoot:       &beaconRoot,
+				Requests:         requests,
+			}
+			block, bal, err := testutil.PayloadToBlock(ep)
+			if err != nil {
+				if np.ValidationError != "" {
+					continue // Expected invalid
+				}
+				result.Pass = false
+				result.Error = fmt.Sprintf("payload %d: block build error: %v", pi, err)
+				return result
+			}
+
+			// HandleNewPayload + FCU to advance head
+			status, err := ce.server.HandleNewPayload(ce.m.Ctx, "NewPayload", block, versionedHashes, bal)
+			if err != nil {
+				if np.ValidationError != "" {
+					continue
+				}
+				result.Pass = false
+				result.Error = fmt.Sprintf("payload %d: %v", pi, err)
+				return result
+			}
+
+			if np.ValidationError != "" {
+				if status.Status != engine_types.InvalidStatus {
+					result.Pass = false
+					result.Error = fmt.Sprintf("payload %d: expected INVALID for %q, got %s", pi, np.ValidationError, status.Status)
+					return result
+				}
+				continue
+			}
+
+			if status.Status != engine_types.ValidStatus {
+				result.Pass = false
+				errMsg := ""
+				if status.ValidationError != nil {
+					errMsg = status.ValidationError.Error().Error()
+				}
+				result.Error = fmt.Sprintf("payload %d: got %s (err: %s)", pi, status.Status, errMsg)
+				return result
+			}
+
+			// FCU to advance head between payloads within the same test
+			fcuStatus, err := ce.server.HandleForkChoice(ce.m.Ctx, "ForkchoiceUpdated",
+				&engine_types.ForkChoiceState{
+					HeadHash:           payload.BlockHash,
+					SafeBlockHash:      payload.BlockHash,
+					FinalizedBlockHash: payload.BlockHash,
+				})
+			if err != nil {
+				result.Pass = false
+				result.Error = fmt.Sprintf("payload %d: FCU error: %v", pi, err)
+				return result
+			}
+			if fcuStatus.Status != engine_types.ValidStatus {
+				result.Pass = false
+				result.Error = fmt.Sprintf("payload %d: FCU %s", pi, fcuStatus.Status)
+				return result
+			}
+		}
+
+		return result
+	}
+
+	runOne := func(item testItem) testResult {
+		result := testResult{Name: item.name, Pass: true, Fork: item.def.Fork}
+		ce, err := getOrCreate(item.def.Fork, item.def.PreHash)
+		if err != nil {
+			result.Pass = false
+			result.Error = err.Error()
+			return result
+		}
+		return runPayloads(ce, item.def.NewPayloads, result)
+	}
+
+	if workers == 1 {
+		results := make([]testResult, 0, len(items))
+		for _, item := range items {
+			results = append(results, runOne(item))
+		}
+		report(ctx, results)
+	} else {
+		itemCh := make(chan testItem, len(items))
+		for _, item := range items {
+			itemCh <- item
+		}
+		close(itemCh)
+
+		resultCh := make(chan indexedResult, len(items))
+		var wg sync.WaitGroup
+		for w := 0; w < workers; w++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for item := range itemCh {
+					resultCh <- indexedResult{index: item.index, result: runOne(item)}
+				}
+			}()
+		}
+		go func() {
+			wg.Wait()
+			close(resultCh)
+		}()
+
+		ordered := make([]testResult, len(items))
+		for ir := range resultCh {
+			ordered[ir.index] = ir.result
+		}
+		report(ctx, ordered)
+	}
+
+	// Cleanup
+	for _, ce := range engines {
+		ce.m.DB.Close()
+	}
+	return nil
+}

--- a/cmd/evm/enginexrunner.go
+++ b/cmd/evm/enginexrunner.go
@@ -112,26 +112,70 @@ func engineXTestCmd(ctx *cli.Context) error {
 		log.Root().SetHandler(log.LvlFilterHandler(log.LvlError, log.StderrHandler))
 	}
 
-	// Load pre-allocs
+	// Load pre-allocs in parallel. The directory can contain 24k+ files,
+	// so we first collect the file paths, then parse them concurrently.
 	preAllocDir := ctx.String("pre-alloc-dir")
-	preAllocs := make(map[string]*exPreAlloc)
+	type preAllocFile struct {
+		path string
+		key  string
+	}
+	var paFiles []preAllocFile
 	if err := filepath.WalkDir(preAllocDir, func(path string, d os.DirEntry, err error) error {
 		if err != nil || d.IsDir() {
 			return nil
 		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return nil
-		}
-		var pa exPreAlloc
-		if err := json.Unmarshal(data, &pa); err != nil {
-			return nil
-		}
 		key := strings.TrimSuffix(d.Name(), filepath.Ext(d.Name()))
-		preAllocs[key] = &pa
+		paFiles = append(paFiles, preAllocFile{path: path, key: key})
 		return nil
 	}); err != nil {
-		return fmt.Errorf("loading pre-allocs: %v", err)
+		return fmt.Errorf("scanning pre-alloc dir: %v", err)
+	}
+
+	preAllocs := make(map[string]*exPreAlloc, len(paFiles))
+	{
+		type paResult struct {
+			key string
+			pa  *exPreAlloc
+		}
+		paWorkers := ctx.Int(WorkersFlag.Name)
+		if paWorkers <= 0 {
+			paWorkers = 1
+		}
+		if paWorkers > 32 {
+			paWorkers = 32
+		}
+		paCh := make(chan preAllocFile, len(paFiles))
+		for _, f := range paFiles {
+			paCh <- f
+		}
+		close(paCh)
+
+		paResultCh := make(chan paResult, 256)
+		var paWg sync.WaitGroup
+		for w := 0; w < paWorkers; w++ {
+			paWg.Add(1)
+			go func() {
+				defer paWg.Done()
+				for f := range paCh {
+					data, err := os.ReadFile(f.path)
+					if err != nil {
+						continue
+					}
+					var pa exPreAlloc
+					if err := json.Unmarshal(data, &pa); err != nil {
+						continue
+					}
+					paResultCh <- paResult{key: f.key, pa: &pa}
+				}
+			}()
+		}
+		go func() {
+			paWg.Wait()
+			close(paResultCh)
+		}()
+		for r := range paResultCh {
+			preAllocs[r.key] = r.pa
+		}
 	}
 	fmt.Fprintf(os.Stderr, "Loaded %d pre-allocs\n", len(preAllocs))
 
@@ -153,21 +197,71 @@ func engineXTestCmd(ctx *cli.Context) error {
 	}
 
 	collected := collectFiles(path)
-	var items []testItem
-	for _, fname := range collected {
-		src, err := os.ReadFile(fname)
-		if err != nil {
-			continue
-		}
-		var tests map[string]exTestDef
-		if err := json.Unmarshal(src, &tests); err != nil {
-			continue
-		}
-		for _, name := range slices.Sorted(maps.Keys(tests)) {
-			if !re.MatchString(name) {
-				continue
+
+	// Parse test files in parallel
+	type fileTestItems struct {
+		index int
+		items []testItem
+	}
+	testParseCh := make(chan struct{ index int; fname string }, len(collected))
+	for i, fname := range collected {
+		testParseCh <- struct{ index int; fname string }{i, fname}
+	}
+	close(testParseCh)
+
+	testParseWorkers := ctx.Int(WorkersFlag.Name)
+	if testParseWorkers <= 0 {
+		testParseWorkers = 1
+	}
+	if testParseWorkers > len(collected) {
+		testParseWorkers = len(collected)
+	}
+	testResultsCh := make(chan fileTestItems, len(collected))
+	var testParseWg sync.WaitGroup
+	for w := 0; w < testParseWorkers; w++ {
+		testParseWg.Add(1)
+		go func() {
+			defer testParseWg.Done()
+			for item := range testParseCh {
+				src, err := os.ReadFile(item.fname)
+				if err != nil {
+					testResultsCh <- fileTestItems{index: item.index}
+					continue
+				}
+				var tests map[string]exTestDef
+				if err := json.Unmarshal(src, &tests); err != nil {
+					testResultsCh <- fileTestItems{index: item.index}
+					continue
+				}
+				var localItems []testItem
+				for _, name := range slices.Sorted(maps.Keys(tests)) {
+					if !re.MatchString(name) {
+						continue
+					}
+					localItems = append(localItems, testItem{name: name, def: tests[name]})
+				}
+				testResultsCh <- fileTestItems{index: item.index, items: localItems}
 			}
-			items = append(items, testItem{index: len(items), name: name, def: tests[name]})
+		}()
+	}
+	go func() {
+		testParseWg.Wait()
+		close(testResultsCh)
+	}()
+
+	orderedFiles := make([]fileTestItems, len(collected))
+	for fi := range testResultsCh {
+		orderedFiles[fi.index] = fi
+	}
+	totalItems := 0
+	for _, fi := range orderedFiles {
+		totalItems += len(fi.items)
+	}
+	items := make([]testItem, 0, totalItems)
+	for _, fi := range orderedFiles {
+		for _, item := range fi.items {
+			item.index = len(items)
+			items = append(items, item)
 		}
 	}
 	fmt.Fprintf(os.Stderr, "Collected %d tests\n", len(items))
@@ -176,99 +270,137 @@ func engineXTestCmd(ctx *cli.Context) error {
 		return nil
 	}
 
-	// Cache of engines keyed by "fork:preHash"
+	// Cache of engines keyed by "fork:preHash".
+	// Use per-key sync.Once to avoid duplicate creation and reduce contention.
 	var mu sync.Mutex
 	engines := make(map[string]*cachedEngine)
+	creating := make(map[string]*sync.Once)
 
 	getOrCreate := func(fork, preHash string) (*cachedEngine, error) {
 		key := fork + ":" + preHash
+
+		// Fast path: engine already exists
 		mu.Lock()
 		if ce, ok := engines[key]; ok {
 			mu.Unlock()
 			return ce, nil
 		}
+		// Get or create a sync.Once for this key
+		once, exists := creating[key]
+		if !exists {
+			once = &sync.Once{}
+			creating[key] = once
+		}
 		mu.Unlock()
 
-		config, ok := testforks.Forks[fork]
-		if !ok {
-			return nil, fmt.Errorf("unsupported fork: %s", fork)
-		}
-		pa, ok := preAllocs[preHash]
-		if !ok {
-			return nil, fmt.Errorf("pre-alloc %s not found", preHash)
-		}
-
-		// Build genesis from pre-alloc
-		var genesis types.Genesis
-		if pa.Environment.GasLimit != 0 {
-			env := pa.Environment
-			genesis = types.Genesis{
-				Config:    config,
-				Alloc:     pa.Alloc,
-				ExtraData: []byte{0},
-				Coinbase:  env.Coinbase,
-				GasLimit:  uint64(env.GasLimit),
-				Difficulty: uint256.NewInt(uint64(env.Difficulty)),
-				Timestamp: uint64(env.Timestamp),
+		var ce *cachedEngine
+		var createErr error
+		once.Do(func() {
+			config, ok := testforks.Forks[fork]
+			if !ok {
+				createErr = fmt.Errorf("unsupported fork: %s", fork)
+				return
 			}
-			if env.BaseFee != nil {
-				genesis.BaseFee = uint256.NewInt(uint64(*env.BaseFee))
+			pa, ok := preAllocs[preHash]
+			if !ok {
+				createErr = fmt.Errorf("pre-alloc %s not found", preHash)
+				return
 			}
-			if env.ExcessBlobGas != nil {
-				v := uint64(*env.ExcessBlobGas)
-				genesis.ExcessBlobGas = &v
+
+			// Build genesis from pre-alloc
+			var genesis types.Genesis
+			if pa.Environment.GasLimit != 0 {
+				env := pa.Environment
+				genesis = types.Genesis{
+					Config:     config,
+					Alloc:      pa.Alloc,
+					ExtraData:  []byte{0},
+					Coinbase:   env.Coinbase,
+					GasLimit:   uint64(env.GasLimit),
+					Difficulty: uint256.NewInt(uint64(env.Difficulty)),
+					Timestamp:  uint64(env.Timestamp),
+				}
+				if env.BaseFee != nil {
+					genesis.BaseFee = uint256.NewInt(uint64(*env.BaseFee))
+				}
+				if env.ExcessBlobGas != nil {
+					v := uint64(*env.ExcessBlobGas)
+					genesis.ExcessBlobGas = &v
+				}
+				if env.BlobGasUsed != nil {
+					v := uint64(*env.BlobGasUsed)
+					genesis.BlobGasUsed = &v
+				}
+			} else {
+				genesis = pa.Genesis
+				genesis.Alloc = pa.Alloc
+				genesis.Config = config
 			}
-			if env.BlobGasUsed != nil {
-				v := uint64(*env.BlobGasUsed)
-				genesis.BlobGasUsed = &v
+
+			engine := rulesconfig.CreateRulesEngineBareBones(ctx.Context, config, log.New())
+			m := execmoduletester.New(nil,
+				execmoduletester.WithGenesisSpec(&genesis),
+				execmoduletester.WithEngine(engine),
+			)
+
+			executionClient := direct.NewExecutionClientDirect(m.ExecModule)
+			blockDownloader := engine_block_downloader.NewEngineBlockDownloader(
+				m.Ctx, log.New(), executionClient, m.BlockReader, m.DB,
+				config, ethconfig.Defaults.Sync, nil,
+			)
+			server := engineapi.NewEngineServer(
+				log.New(), config, executionClient, blockDownloader,
+				false, true, false, true, nil, time.Hour, ^uint64(0),
+			)
+			server.SetTest(true)
+
+			// Send initial FCU to genesis so the chain head is set
+			genesisHash := m.Genesis.Hash()
+			fcuStatus, err := server.HandleForkChoice(m.Ctx, "ForkchoiceUpdated",
+				&engine_types.ForkChoiceState{
+					HeadHash:           genesisHash,
+					SafeBlockHash:      genesisHash,
+					FinalizedBlockHash: genesisHash,
+				})
+			if err != nil || fcuStatus.Status != engine_types.ValidStatus {
+				m.DB.Close()
+				createErr = fmt.Errorf("initial FCU to genesis failed: %v (status: %v)", err, fcuStatus)
+				return
 			}
-		} else {
-			genesis = pa.Genesis
-			genesis.Alloc = pa.Alloc
-			genesis.Config = config
-		}
 
-		engine := rulesconfig.CreateRulesEngineBareBones(ctx.Context, config, log.New())
-		m := execmoduletester.New(nil,
-			execmoduletester.WithGenesisSpec(&genesis),
-			execmoduletester.WithEngine(engine),
-		)
-
-		executionClient := direct.NewExecutionClientDirect(m.ExecModule)
-		blockDownloader := engine_block_downloader.NewEngineBlockDownloader(
-			m.Ctx, log.New(), executionClient, m.BlockReader, m.DB,
-			config, ethconfig.Defaults.Sync, nil,
-		)
-		server := engineapi.NewEngineServer(
-			log.New(), config, executionClient, blockDownloader,
-			false, true, false, true, nil, time.Hour, ^uint64(0),
-		)
-		server.SetTest(true)
-
-		// Send initial FCU to genesis so the chain head is set
-		genesisHash := m.Genesis.Hash()
-		fcuStatus, err := server.HandleForkChoice(m.Ctx, "ForkchoiceUpdated",
-			&engine_types.ForkChoiceState{
-				HeadHash:           genesisHash,
-				SafeBlockHash:      genesisHash,
-				FinalizedBlockHash: genesisHash,
-			})
-		if err != nil || fcuStatus.Status != engine_types.ValidStatus {
-			m.DB.Close()
-			return nil, fmt.Errorf("initial FCU to genesis failed: %v (status: %v)", err, fcuStatus)
-		}
-
-		ce := &cachedEngine{m: m, server: server}
-		mu.Lock()
-		// Double-check after lock
-		if existing, ok := engines[key]; ok {
+			ce = &cachedEngine{m: m, server: server}
+			mu.Lock()
+			engines[key] = ce
 			mu.Unlock()
-			m.DB.Close()
-			return existing, nil
+		})
+
+		if createErr != nil {
+			return nil, createErr
 		}
-		engines[key] = ce
+
+		// After once.Do, the engine must be in the map
+		mu.Lock()
+		ce = engines[key]
 		mu.Unlock()
 		return ce, nil
+	}
+
+	// Pre-create all needed engines before parallel execution.
+	// This avoids lazy creation during the test phase, where it would
+	// add latency to the first test hitting each (fork, preHash) pair.
+	{
+		uniqueKeys := make(map[string]struct{})
+		for _, item := range items {
+			key := item.def.Fork + ":" + item.def.PreHash
+			uniqueKeys[key] = struct{}{}
+		}
+		fmt.Fprintf(os.Stderr, "Pre-creating %d engines\n", len(uniqueKeys))
+		for key := range uniqueKeys {
+			parts := strings.SplitN(key, ":", 2)
+			if _, err := getOrCreate(parts[0], parts[1]); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: failed to pre-create engine for %s: %v\n", key, err)
+			}
+		}
 	}
 
 	// Execute tests

--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -202,6 +202,7 @@ func init() {
 		&runCommand,
 		&blockTestCommand,
 		&engineTestCommand,
+		&engineXTestCommand,
 		&stateTestCommand,
 		&stateTransitionCommand,
 	}

--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -201,6 +201,7 @@ func init() {
 		&disasmCommand,
 		&runCommand,
 		&blockTestCommand,
+		&engineTestCommand,
 		&stateTestCommand,
 		&stateTransitionCommand,
 	}

--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -131,6 +131,20 @@ var (
 		Name:  "noreturndata",
 		Usage: "disable return data output",
 	}
+	RunFlag = cli.StringFlag{
+		Name:  "run",
+		Value: ".*",
+		Usage: "Run only those tests matching the regular expression.",
+	}
+	WorkersFlag = cli.IntFlag{
+		Name:  "workers",
+		Usage: "Number of parallel workers for processing fixture files",
+		Value: 1,
+	}
+	JSONOutputFlag = cli.BoolFlag{
+		Name:  "jsonout",
+		Usage: "Output results as JSON array instead of human-readable format",
+	}
 )
 
 var stateTransitionCommand = cli.Command{

--- a/cmd/evm/reporter.go
+++ b/cmd/evm/reporter.go
@@ -40,8 +40,10 @@ type testResult struct {
 	Name  string       `json:"name"`
 	Pass  bool         `json:"pass"`
 	Root  *common.Hash `json:"stateRoot,omitempty"`
+	Fork  string       `json:"fork,omitempty"`
 	Error string       `json:"error,omitempty"`
 	State *state.Dump  `json:"state,omitempty"`
+	Stats *execStats   `json:"benchStats,omitempty"`
 }
 
 func (r testResult) String() string {
@@ -55,6 +57,9 @@ func (r testResult) String() string {
 	var extra string
 	if !r.Pass {
 		extra = fmt.Sprintf(", err=%v", r.Error)
+		if r.Fork != "" {
+			extra += fmt.Sprintf(", fork=%s", r.Fork)
+		}
 	}
 
 	out := fmt.Sprintf("%s %s%s", status, r.Name, extra)
@@ -67,6 +72,11 @@ func (r testResult) String() string {
 
 // report prints the after-test summary.
 func report(ctx *cli.Context, results []testResult) {
+	if ctx.Bool(JSONOutputFlag.Name) {
+		out, _ := json.MarshalIndent(results, "", "  ")
+		fmt.Println(string(out))
+		return
+	}
 	pass := 0
 	for _, r := range results {
 		if r.Pass {

--- a/cmd/evm/reporter.go
+++ b/cmd/evm/reporter.go
@@ -43,7 +43,7 @@ type testResult struct {
 	Pass  bool         `json:"pass"`
 	Root  *common.Hash `json:"stateRoot,omitempty"`
 	Fork  string       `json:"fork,omitempty"`
-	Error string       `json:"error,omitempty"`
+	Error string       `json:"error"`
 	State *state.Dump  `json:"state,omitempty"`
 	Stats *execStats   `json:"benchStats,omitempty"`
 }

--- a/cmd/evm/reporter.go
+++ b/cmd/evm/reporter.go
@@ -20,8 +20,10 @@
 package main
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/urfave/cli/v2"
 
@@ -73,8 +75,11 @@ func (r testResult) String() string {
 // report prints the after-test summary.
 func report(ctx *cli.Context, results []testResult) {
 	if ctx.Bool(JSONOutputFlag.Name) {
-		out, _ := json.MarshalIndent(results, "", "  ")
-		fmt.Println(string(out))
+		// Write directly to stdout via encoder to avoid the intermediate
+		// MarshalIndent -> string -> Println allocation chain.
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		enc.Encode(results) //nolint:errcheck
 		return
 	}
 	pass := 0
@@ -84,10 +89,12 @@ func report(ctx *cli.Context, results []testResult) {
 		}
 	}
 
+	// Use buffered writer to reduce syscalls when printing many results
+	w := bufio.NewWriter(os.Stdout)
 	for _, r := range results {
-		fmt.Println(r)
+		fmt.Fprintln(w, r)
 	}
-
-	fmt.Println("--")
-	fmt.Printf("%d tests passed, %d tests failed.\n", pass, len(results)-pass)
+	fmt.Fprintln(w, "--")
+	fmt.Fprintf(w, "%d tests passed, %d tests failed.\n", pass, len(results)-pass)
+	w.Flush()
 }

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -25,6 +25,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
+	"sync"
 
 	"github.com/urfave/cli/v2"
 
@@ -33,7 +35,6 @@ import (
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv/temporal/temporaltest"
-	"github.com/erigontech/erigon/execution/state"
 	"github.com/erigontech/erigon/execution/tests/testutil"
 	"github.com/erigontech/erigon/execution/tracing/tracers/logger"
 	"github.com/erigontech/erigon/execution/vm"
@@ -42,20 +43,21 @@ import (
 var stateTestCommand = cli.Command{
 	Action:    stateTestCmd,
 	Name:      "statetest",
-	Usage:     "executes the given state tests",
+	Usage:     "Executes the given state tests. Filenames can be fed via standard input (batch mode) or as an argument (one-off execution).",
 	ArgsUsage: "<file>",
-}
-
-// StatetestResult contains the execution status after running a state test, any
-// error that might have occurred and a dump of the final state if requested.
-type StatetestResult struct {
-	Name  string       `json:"name"`
-	Pass  bool         `json:"pass"`
-	Root  *common.Hash `json:"stateRoot,omitempty"`
-	Fork  string       `json:"fork"`
-	Error string       `json:"error,omitempty"`
-	State *state.Dump  `json:"state,omitempty"`
-	Stats *execStats   `json:"benchStats,omitempty"`
+	Flags: []cli.Flag{
+		&BenchFlag,
+		&DebugFlag,
+		&DumpFlag,
+		&JSONOutputFlag,
+		&MachineFlag,
+		&RunFlag,
+		&WorkersFlag,
+		&DisableMemoryFlag,
+		&DisableStackFlag,
+		&DisableStorageFlag,
+		&DisableReturnDataFlag,
+	},
 }
 
 func stateTestCmd(ctx *cli.Context) error {
@@ -80,48 +82,109 @@ func stateTestCmd(ctx *cli.Context) error {
 		cfg.Tracer = logger.NewStructLogger(config).Tracer().Hooks
 	}
 
-	if len(ctx.Args().First()) != 0 {
-		return runStateTest(ctx.Args().First(), cfg, ctx.Bool(MachineFlag.Name), ctx.Bool(BenchFlag.Name))
+	path := ctx.Args().First()
+	if len(path) != 0 {
+		collected := collectFiles(path)
+		workers := ctx.Int(WorkersFlag.Name)
+		if workers <= 0 {
+			workers = 1
+		}
+		results, err := runStateTestsParallel(ctx, cfg, collected, workers)
+		if err != nil {
+			return err
+		}
+		report(ctx, results)
+		return nil
 	}
+	// Otherwise, read filenames from stdin and execute back-to-back.
 	scanner := bufio.NewScanner(os.Stdin)
 	for scanner.Scan() {
 		fname := scanner.Text()
 		if len(fname) == 0 {
 			return nil
 		}
-		if err := runStateTest(fname, cfg, ctx.Bool(MachineFlag.Name), ctx.Bool(BenchFlag.Name)); err != nil {
+		results, err := runStateTest(ctx, cfg, fname)
+		if err != nil {
 			return err
 		}
+		report(ctx, results)
 	}
 	return nil
+}
+
+func runStateTestsParallel(ctx *cli.Context, cfg vm.Config, files []string, workers int) ([]testResult, error) {
+	if workers == 1 {
+		var results []testResult
+		for _, fname := range files {
+			r, err := runStateTest(ctx, cfg, fname)
+			if err != nil {
+				return nil, err
+			}
+			results = append(results, r...)
+		}
+		return results, nil
+	}
+	var (
+		wg     sync.WaitGroup
+		fileCh = make(chan struct {
+			index int
+			fname string
+		}, len(files))
+		resultCh = make(chan fileResult, len(files))
+	)
+	for i, fname := range files {
+		fileCh <- struct {
+			index int
+			fname string
+		}{i, fname}
+	}
+	close(fileCh)
+
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for item := range fileCh {
+				r, err := runStateTest(ctx, cfg, item.fname)
+				resultCh <- fileResult{index: item.index, results: r, err: err}
+			}
+		}()
+	}
+	go func() {
+		wg.Wait()
+		close(resultCh)
+	}()
+
+	ordered := make([]fileResult, len(files))
+	for fr := range resultCh {
+		if fr.err != nil {
+			return nil, fr.err
+		}
+		ordered[fr.index] = fr
+	}
+	var results []testResult
+	for _, fr := range ordered {
+		results = append(results, fr.results...)
+	}
+	return results, nil
 }
 
 // runStateTest loads the state-test given by fname, and executes the test.
-func runStateTest(fname string, cfg vm.Config, jsonOut bool, bench bool) error {
-	// Load the test content from the input file
+func runStateTest(ctx *cli.Context, cfg vm.Config, fname string) ([]testResult, error) {
 	src, err := os.ReadFile(fname)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	var stateTests map[string]testutil.StateTest
 	if err = json.Unmarshal(src, &stateTests); err != nil {
-		return err
+		return nil, nil // Skip non-fixture JSON files
 	}
 
-	// Iterate over all the stateTests, run them and aggregate the results
-	results, err := aggregateResultsFromStateTests(stateTests, cfg, jsonOut, bench)
+	re, err := regexp.Compile(ctx.String(RunFlag.Name))
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("invalid regex -%s: %v", RunFlag.Name, err)
 	}
 
-	out, _ := json.MarshalIndent(results, "", "  ")
-	fmt.Println(string(out))
-	return nil
-}
-
-func aggregateResultsFromStateTests(
-	stateTests map[string]testutil.StateTest, cfg vm.Config,
-	jsonOut bool, bench bool) ([]StatetestResult, error) {
 	tmpDir, err := os.MkdirTemp("", "erigon-statetest-*")
 	if err != nil {
 		return nil, err
@@ -137,37 +200,32 @@ func aggregateResultsFromStateTests(
 		return nil, txErr
 	}
 	defer tx.Rollback()
-	results := make([]StatetestResult, 0, len(stateTests))
+
+	bench := ctx.Bool(BenchFlag.Name)
+	results := make([]testResult, 0, len(stateTests))
 
 	for key, test := range stateTests {
+		if !re.MatchString(key) {
+			continue
+		}
 		for _, st := range test.Subtests() {
-			// Run the test and aggregate the result
-			result := &StatetestResult{Name: key, Fork: st.Fork, Pass: true}
+			result := &testResult{Name: key, Fork: st.Fork, Pass: true}
 
 			statedb, root, err := test.Run(nil, tx, st, cfg, dirs)
 			if err != nil {
-				// Test failed, mark as so and dump any state to aid debugging
 				result.Pass, result.Error = false, err.Error()
 			}
 
-			// print state root for evmlab tracing
 			if statedb != nil {
-				result.Root = &root
-				if jsonOut {
-					_, printErr := fmt.Fprintf(os.Stderr, "{\"stateRoot\": \"%#x\"}\n", root.Bytes())
-					if printErr != nil {
-						log.Warn("Failed to write to stderr", "err", printErr)
-					}
-				}
+				h := common.Hash(root)
+				result.Root = &h
 			}
 
-			// if benchmark requested rerun test w/o verification and collect stats
 			if bench {
 				_, stats, _ := timedExec(true, func() ([]byte, uint64, error) {
 					_, _, gasUsed, _ := test.RunNoVerify(nil, tx, st, cfg, dirs)
 					return nil, gasUsed, nil
 				})
-
 				result.Stats = &stats
 			}
 

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -114,7 +114,7 @@ func stateTestCmd(ctx *cli.Context) error {
 
 func runStateTestsParallel(ctx *cli.Context, cfg vm.Config, files []string, workers int) ([]testResult, error) {
 	if workers == 1 {
-		var results []testResult
+		results := make([]testResult, 0, len(files)*4) // pre-allocate
 		for _, fname := range files {
 			r, err := runStateTest(ctx, cfg, fname)
 			if err != nil {
@@ -162,7 +162,12 @@ func runStateTestsParallel(ctx *cli.Context, cfg vm.Config, files []string, work
 		}
 		ordered[fr.index] = fr
 	}
-	var results []testResult
+	// Pre-estimate total results
+	total := 0
+	for _, fr := range ordered {
+		total += len(fr.results)
+	}
+	results := make([]testResult, 0, total)
 	for _, fr := range ordered {
 		results = append(results, fr.results...)
 	}

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -185,22 +185,6 @@ func runStateTest(ctx *cli.Context, cfg vm.Config, fname string) ([]testResult, 
 		return nil, fmt.Errorf("invalid regex -%s: %v", RunFlag.Name, err)
 	}
 
-	tmpDir, err := os.MkdirTemp("", "erigon-statetest-*")
-	if err != nil {
-		return nil, err
-	}
-	defer dir.RemoveAll(tmpDir)
-	dirs := datadir.New(tmpDir)
-
-	db := temporaltest.NewTestDB(nil, dirs)
-	defer db.Close()
-
-	tx, txErr := db.BeginTemporalRw(context.Background())
-	if txErr != nil {
-		return nil, txErr
-	}
-	defer tx.Rollback()
-
 	bench := ctx.Bool(BenchFlag.Name)
 	results := make([]testResult, 0, len(stateTests))
 
@@ -210,6 +194,24 @@ func runStateTest(ctx *cli.Context, cfg vm.Config, fname string) ([]testResult, 
 		}
 		for _, st := range test.Subtests() {
 			result := &testResult{Name: key, Fork: st.Fork, Pass: true}
+
+			// Create fresh DB per subtest to avoid state pollution
+			tmpDir, err := os.MkdirTemp("", "erigon-statetest-*")
+			if err != nil {
+				result.Pass, result.Error = false, err.Error()
+				results = append(results, *result)
+				continue
+			}
+			dirs := datadir.New(tmpDir)
+			db := temporaltest.NewTestDB(nil, dirs)
+			tx, txErr := db.BeginTemporalRw(context.Background())
+			if txErr != nil {
+				db.Close()
+				dir.RemoveAll(tmpDir)
+				result.Pass, result.Error = false, txErr.Error()
+				results = append(results, *result)
+				continue
+			}
 
 			statedb, root, err := test.Run(nil, tx, st, cfg, dirs)
 			if err != nil {
@@ -228,6 +230,10 @@ func runStateTest(ctx *cli.Context, cfg vm.Config, fname string) ([]testResult, 
 				})
 				result.Stats = &stats
 			}
+
+			tx.Rollback()
+			db.Close()
+			dir.RemoveAll(tmpDir)
 
 			results = append(results, *result)
 		}

--- a/execution/engineapi/engine_server.go
+++ b/execution/engineapi/engine_server.go
@@ -124,6 +124,10 @@ func NewEngineServer(
 	return srv
 }
 
+// SetTest enables test mode which skips block downloading attempts
+// and returns SYNCING status immediately when parent blocks aren't found.
+func (e *EngineServer) SetTest(t bool) { e.test = t }
+
 func (e *EngineServer) Start(
 	ctx context.Context,
 	httpConfig *httpcfg.HttpCfg,
@@ -198,14 +202,28 @@ func (s *EngineServer) isWithdrawalsPresenceValid(time uint64, withdrawals types
 }
 
 func (s *EngineServer) checkRequestsPresence(version clparams.StateVersion, executionRequests []hexutil.Bytes) error {
+	return ValidateExecutionRequests(version, executionRequests)
+}
+
+// ValidateExecutionRequests checks execution request parameters per the Engine API spec:
+// presence/absence by version, minimum item length, and strictly increasing type ordering.
+func ValidateExecutionRequests(version clparams.StateVersion, executionRequests []hexutil.Bytes) error {
 	if version < clparams.ElectraVersion {
 		if executionRequests != nil {
 			return &rpc.InvalidParamsError{Message: "requests in EngineAPI not supported before Prague"}
 		}
-	} else if executionRequests == nil {
+		return nil
+	}
+	if executionRequests == nil {
 		return &rpc.InvalidParamsError{Message: "missing requests list"}
 	}
-
+	lastReqType := -1
+	for i, r := range executionRequests {
+		if len(r) <= 1 || (lastReqType >= 0 && int(r[0]) <= lastReqType) {
+			return &rpc.InvalidParamsError{Message: fmt.Sprintf("Invalid Request at index %d", i)}
+		}
+		lastReqType = int(r[0])
+	}
 	return nil
 }
 

--- a/execution/execmodule/execmoduletester/exec_module_tester.go
+++ b/execution/execmodule/execmoduletester/exec_module_tester.go
@@ -160,6 +160,29 @@ func (emt *ExecModuleTester) Close() {
 	}
 }
 
+// CloseCLI is like Close but safe for CLI mode (tb==nil). It cancels the
+// background context, waits for goroutines to drain, and closes resources.
+// This prevents goroutine leaks when ExecModuleTester is used outside of
+// testing.T contexts (e.g. the evm enginetest command).
+func (emt *ExecModuleTester) CloseCLI() {
+	emt.cancel()
+	_ = emt.bgComponentsEg.Wait() // expect context.Canceled
+	if emt.Engine != nil {
+		emt.Engine.Close()
+	}
+	if emt.BlockSnapshots != nil {
+		emt.BlockSnapshots.Close()
+	}
+	if emt.DB != nil {
+		emt.DB.Close()
+	}
+	// In CLI mode (tb==nil), the temp dir is never cleaned up via tb.Cleanup.
+	// Remove it here to prevent disk space leaks.
+	if emt.tb == nil && emt.Dirs.DataDir != "" {
+		dir.RemoveAll(emt.Dirs.DataDir)
+	}
+}
+
 // Stream returns stream, waiting if necessary
 func (emt *ExecModuleTester) Send(req *sentryproto.InboundMessage) (errs []error) {
 	emt.StreamWg.Wait()

--- a/execution/protocol/txn_executor.go
+++ b/execution/protocol/txn_executor.go
@@ -724,9 +724,15 @@ func (st *TxnExecutor) verifyAuthorities(auths []types.Authorization, contractCr
 		stateIgasRefundInc = params.StateBytesNewAccount * st.evm.Context.CostPerStateByte
 	}
 	verifiedAuthorities := make([]accounts.Address, 0)
-	if len(auths) > 0 {
+	if auths != nil {
+		if !st.evm.ChainRules().IsPrague {
+			return nil, stateIgasRefund, errors.New("SetCode transaction not allowed before Prague fork")
+		}
 		if contractCreation {
 			return nil, stateIgasRefund, errors.New("contract creation not allowed with type4 txs")
+		}
+		if len(auths) == 0 {
+			return nil, stateIgasRefund, errors.New("SetCode transaction must have at least one authorization")
 		}
 		var b [32]byte
 		data := bytes.NewBuffer(nil)

--- a/execution/tests/testutil/engine_test_util.go
+++ b/execution/tests/testutil/engine_test_util.go
@@ -237,6 +237,10 @@ func payloadToBlock(p *etNewPayload) (*types.Block, []byte, error) {
 	return block, blockAccessListBytes, nil
 }
 
+// Shared logger for engine test CLI mode. Using a single logger avoids
+// repeated allocations of loggers that all write to stderr at the same level.
+var cliLogger = log.New()
+
 // RunCLI executes the engine test through the real Engine API path:
 // HandleNewPayload (block insertion + chain validation) and
 // HandleForkChoice (canonical head advancement).
@@ -253,9 +257,9 @@ func (t *EngineTest) RunCLI() error {
 	if !ok {
 		return testforks.UnsupportedForkError{Name: t.json.Network}
 	}
-	engine := rulesconfig.CreateRulesEngineBareBones(context.Background(), config, log.New())
+	engine := rulesconfig.CreateRulesEngineBareBones(context.Background(), config, cliLogger)
 	m := execmoduletester.New(nil, execmoduletester.WithGenesisSpec(t.genesis(config)), execmoduletester.WithEngine(engine))
-	defer m.DB.Close()
+	defer m.CloseCLI()
 
 	if m.Genesis.Hash() != t.json.Genesis.Hash {
 		return fmt.Errorf("genesis block hash doesn't match test: computed=%x, test=%x", m.Genesis.Hash().Bytes()[:6], t.json.Genesis.Hash[:6])
@@ -267,11 +271,11 @@ func (t *EngineTest) RunCLI() error {
 	// Create EngineServer for HandleNewPayload + HandleForkChoice
 	executionClient := direct.NewExecutionClientDirect(m.ExecModule)
 	blockDownloader := engine_block_downloader.NewEngineBlockDownloader(
-		m.Ctx, log.New(), executionClient, m.BlockReader, m.DB,
+		m.Ctx, cliLogger, executionClient, m.BlockReader, m.DB,
 		config, ethconfig.Defaults.Sync, nil,
 	)
 	engineServer := engineapi.NewEngineServer(
-		log.New(), config, executionClient, blockDownloader,
+		cliLogger, config, executionClient, blockDownloader,
 		false, true, false, true, nil, time.Hour, ^uint64(0),
 	)
 	engineServer.SetTest(true)

--- a/execution/tests/testutil/engine_test_util.go
+++ b/execution/tests/testutil/engine_test_util.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/holiman/uint256"
 
+	"time"
+
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/common/log/v3"
@@ -33,14 +35,15 @@ import (
 	"github.com/erigontech/erigon/common/empty"
 	"github.com/erigontech/erigon/db/rawdb"
 	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/engineapi"
 	"github.com/erigontech/erigon/execution/engineapi/engine_types"
 	"github.com/erigontech/erigon/execution/execmodule/execmoduletester"
 	"github.com/erigontech/erigon/execution/protocol/rules/merge"
 	"github.com/erigontech/erigon/execution/state"
-	"github.com/erigontech/erigon/execution/tests/blockgen"
 	"github.com/erigontech/erigon/execution/tests/testforks"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/execution/types/accounts"
+	"github.com/erigontech/erigon/node/direct"
 	"github.com/erigontech/erigon/node/rulesconfig"
 	"github.com/erigontech/erigon/rpc"
 )
@@ -136,8 +139,13 @@ func (p *etNewPayload) UnmarshalJSON(data []byte) error {
 	}
 	// V4/V5+: params[3] = executionRequests
 	if len(raw.Params) >= 4 {
-		if err := json.Unmarshal(raw.Params[3], &p.Requests); err != nil {
+		var hexRequests []hexutil.Bytes
+		if err := json.Unmarshal(raw.Params[3], &hexRequests); err != nil {
 			return fmt.Errorf("failed to unmarshal executionRequests: %v", err)
+		}
+		p.Requests = make([][]byte, len(hexRequests))
+		for i, r := range hexRequests {
+			p.Requests[i] = r
 		}
 	}
 	return nil
@@ -249,64 +257,117 @@ func (t *EngineTest) RunCLI() error {
 		return fmt.Errorf("genesis block state root does not match test: computed=%x, test=%x", m.Genesis.Root().Bytes()[:6], t.json.Genesis.StateRoot[:6])
 	}
 
-	// Send initial forkchoiceUpdated to genesis (matching consume engine behavior)
-	// InsertChain internally calls InsertBlocksAndWait + UpdateForkChoice,
-	// which is the same path as the real engine API.
+	// Create EngineServer to route through the real engine API path
+	executionClient := direct.NewExecutionClientDirect(m.ExecModule)
+	engineServer := engineapi.NewEngineServer(
+		log.New(),
+		config,
+		executionClient,
+		nil,   // blockDownloader — not needed for payload execution
+		false, // caplin
+		true,  // internalCL
+		false, // proposing
+		true,  // consuming
+		nil,   // txPool
+		time.Hour, // fcuTimeout
+		0,     // maxReorgDepth
+	)
+
+	// Send initial forkchoiceUpdated to genesis
+	genesisHash := m.Genesis.Hash()
+	fcuStatus, err := engineServer.HandleForkChoice(m.Ctx, "ForkchoiceUpdated",
+		&engine_types.ForkChoiceState{
+			HeadHash:           genesisHash,
+			SafeBlockHash:      genesisHash,
+			FinalizedBlockHash: genesisHash,
+		})
+	if err != nil || fcuStatus.Status != engine_types.ValidStatus {
+		return fmt.Errorf("initial FCU to genesis failed: %v (status: %v)", err, fcuStatus)
+	}
 
 	for i, payload := range t.json.Payloads {
-		// Version validation
-		if err := validatePayloadVersion(&payload, config); err != nil {
-			if payload.ErrorCode != nil {
-				var rpcErr *rpc.InvalidParamsError
-				var unsupportedErr *rpc.UnsupportedForkError
-				if errors.As(err, &rpcErr) || errors.As(err, &unsupportedErr) {
-					// Check error code matches
-					if rpcErr != nil {
-						// InvalidParamsError maps to -32602
-						expectedCode := *payload.ErrorCode
-						if expectedCode != -32602 {
-							return fmt.Errorf("payload %d: expected error code %d, got -32602", i, expectedCode)
-						}
-					}
-					continue // Expected error
-				}
+		// Call the real engine newPayload via EngineServer
+		version := payload.Version
+		req := &payload.ExecutionPayload
+
+		var versionedHashes []common.Hash
+		var beaconRoot *common.Hash
+		var executionRequests []hexutil.Bytes
+
+		if payload.VersionedHashes != nil {
+			versionedHashes = payload.VersionedHashes
+		}
+		if payload.BeaconRoot != nil {
+			beaconRoot = payload.BeaconRoot
+		}
+		if payload.Requests != nil {
+			executionRequests = make([]hexutil.Bytes, len(payload.Requests))
+			for j, r := range payload.Requests {
+				executionRequests[j] = r
 			}
-			if payload.ValidationError != "" {
-				continue // Expected to be invalid
-			}
-			return fmt.Errorf("payload %d: %v", i, err)
 		}
 
-		// Check error code was expected but not triggered
+		var status *engine_types.PayloadStatus
+		switch version {
+		case 1:
+			status, err = engineServer.NewPayloadV1(m.Ctx, req)
+		case 2:
+			status, err = engineServer.NewPayloadV2(m.Ctx, req)
+		case 3:
+			status, err = engineServer.NewPayloadV3(m.Ctx, req, versionedHashes, beaconRoot)
+		case 4:
+			status, err = engineServer.NewPayloadV4(m.Ctx, req, versionedHashes, beaconRoot, executionRequests)
+		case 5:
+			status, err = engineServer.NewPayloadV5(m.Ctx, req, versionedHashes, beaconRoot, executionRequests)
+		default:
+			return fmt.Errorf("payload %d: unsupported version %d", i, version)
+		}
+
+		// Check error code expectation
 		if payload.ErrorCode != nil {
-			return fmt.Errorf("payload %d: expected error code %d but no error occurred", i, *payload.ErrorCode)
+			if err == nil {
+				return fmt.Errorf("payload %d: expected error code %d but no error occurred", i, *payload.ErrorCode)
+			}
+			// Error occurred — check if it's the right type
+			continue
 		}
-
-		// Convert payload to block
-		block, balBytes, err := payloadToBlock(&payload)
 		if err != nil {
 			if payload.ValidationError != "" {
 				continue // Expected to be invalid
 			}
-			return fmt.Errorf("payload %d: failed to convert payload to block: %v", i, err)
+			return fmt.Errorf("payload %d: unexpected error: %v", i, err)
 		}
 
-		// Insert block
-		chain := &blockgen.ChainPack{
-			Blocks:           []*types.Block{block},
-			Headers:          []*types.Header{block.HeaderNoCopy()},
-			TopBlock:         block,
-			BlockAccessLists: [][]byte{balBytes},
-		}
-		if err := m.InsertChain(chain); err != nil {
-			if payload.ValidationError != "" {
-				continue // Expected to be invalid
-			}
-			return fmt.Errorf("payload %d: block insertion failed: %v", i, err)
-		}
-		// If we expected this payload to be invalid but it succeeded
+		// Check validation error expectation
 		if payload.ValidationError != "" {
-			return fmt.Errorf("payload %d: expected validation error %q but block was accepted", i, payload.ValidationError)
+			if status.Status != engine_types.InvalidStatus {
+				return fmt.Errorf("payload %d: expected INVALID for %q, got %s", i, payload.ValidationError, status.Status)
+			}
+			continue
+		}
+
+		// Expect valid
+		if status.Status != engine_types.ValidStatus {
+			errMsg := ""
+			if status.ValidationError != nil {
+				errMsg = status.ValidationError.Error()
+			}
+			return fmt.Errorf("payload %d: expected VALID, got %s (err: %s)", i, status.Status, errMsg)
+		}
+
+		// Send forkchoiceUpdated to advance head
+		blockHash := payload.ExecutionPayload.BlockHash
+		fcuStatus, err := engineServer.HandleForkChoice(m.Ctx, "ForkchoiceUpdated",
+			&engine_types.ForkChoiceState{
+				HeadHash:           blockHash,
+				SafeBlockHash:      blockHash,
+				FinalizedBlockHash: blockHash,
+			})
+		if err != nil {
+			return fmt.Errorf("payload %d: FCU error: %v", i, err)
+		}
+		if fcuStatus.Status != engine_types.ValidStatus {
+			return fmt.Errorf("payload %d: FCU returned %s", i, fcuStatus.Status)
 		}
 	}
 

--- a/execution/tests/testutil/engine_test_util.go
+++ b/execution/tests/testutil/engine_test_util.go
@@ -249,6 +249,10 @@ func (t *EngineTest) RunCLI() error {
 		return fmt.Errorf("genesis block state root does not match test: computed=%x, test=%x", m.Genesis.Root().Bytes()[:6], t.json.Genesis.StateRoot[:6])
 	}
 
+	// Send initial forkchoiceUpdated to genesis (matching consume engine behavior)
+	// InsertChain internally calls InsertBlocksAndWait + UpdateForkChoice,
+	// which is the same path as the real engine API.
+
 	for i, payload := range t.json.Payloads {
 		// Version validation
 		if err := validatePayloadVersion(&payload, config); err != nil {
@@ -256,6 +260,14 @@ func (t *EngineTest) RunCLI() error {
 				var rpcErr *rpc.InvalidParamsError
 				var unsupportedErr *rpc.UnsupportedForkError
 				if errors.As(err, &rpcErr) || errors.As(err, &unsupportedErr) {
+					// Check error code matches
+					if rpcErr != nil {
+						// InvalidParamsError maps to -32602
+						expectedCode := *payload.ErrorCode
+						if expectedCode != -32602 {
+							return fmt.Errorf("payload %d: expected error code %d, got -32602", i, expectedCode)
+						}
+					}
 					continue // Expected error
 				}
 			}
@@ -263,6 +275,11 @@ func (t *EngineTest) RunCLI() error {
 				continue // Expected to be invalid
 			}
 			return fmt.Errorf("payload %d: %v", i, err)
+		}
+
+		// Check error code was expected but not triggered
+		if payload.ErrorCode != nil {
+			return fmt.Errorf("payload %d: expected error code %d but no error occurred", i, *payload.ErrorCode)
 		}
 
 		// Convert payload to block

--- a/execution/tests/testutil/engine_test_util.go
+++ b/execution/tests/testutil/engine_test_util.go
@@ -1,0 +1,445 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package testutil
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/holiman/uint256"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/common/crypto"
+	"github.com/erigontech/erigon/common/empty"
+	"github.com/erigontech/erigon/db/rawdb"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/engineapi/engine_types"
+	"github.com/erigontech/erigon/execution/execmodule/execmoduletester"
+	"github.com/erigontech/erigon/execution/protocol/rules/merge"
+	"github.com/erigontech/erigon/execution/state"
+	"github.com/erigontech/erigon/execution/tests/blockgen"
+	"github.com/erigontech/erigon/execution/tests/testforks"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/execution/types/accounts"
+	"github.com/erigontech/erigon/node/rulesconfig"
+	"github.com/erigontech/erigon/rpc"
+)
+
+// EngineTest checks processing of engine API payloads.
+type EngineTest struct {
+	json etJSON
+}
+
+func (t *EngineTest) UnmarshalJSON(in []byte) error {
+	return json.Unmarshal(in, &t.json)
+}
+
+// Network returns the network/fork name for this test.
+func (t *EngineTest) Network() string {
+	return t.json.Network
+}
+
+type etJSON struct {
+	Genesis   btHeader               `json:"genesisBlockHeader"`
+	Pre       types.GenesisAlloc     `json:"pre"`
+	Post      types.GenesisAlloc     `json:"postState"`
+	PostHash  *common.UnprefixedHash `json:"postStateHash"`
+	BestBlock common.UnprefixedHash  `json:"lastblockhash"`
+	Network   string                 `json:"network"`
+	Payloads  []etNewPayload         `json:"engineNewPayloads"`
+}
+
+// etNewPayload represents a single engine API new payload call from the fixture.
+type etNewPayload struct {
+	ExecutionPayload engine_types.ExecutionPayload
+	VersionedHashes  []common.Hash
+	BeaconRoot       *common.Hash
+	Requests         []hexutil.Bytes
+
+	Version         int    // newPayloadVersion
+	FcuVersion      int    // forkchoiceUpdatedVersion
+	ValidationError string // expected validation error (empty = expect VALID)
+	ErrorCode       *int   // expected JSON-RPC error code
+}
+
+func (p *etNewPayload) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Params                   []json.RawMessage `json:"params"`
+		NewPayloadVersion        string            `json:"newPayloadVersion"`
+		ForkchoiceUpdatedVersion string            `json:"forkchoiceUpdatedVersion"`
+		ValidationError          string            `json:"validationError,omitempty"`
+		ErrorCode                json.RawMessage    `json:"errorCode,omitempty"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	p.ValidationError = raw.ValidationError
+	// errorCode can be a string ("-32602") or int (-32602) in fixtures
+	if len(raw.ErrorCode) > 0 && string(raw.ErrorCode) != "null" {
+		s := string(raw.ErrorCode)
+		if len(s) >= 2 && s[0] == '"' {
+			s = s[1 : len(s)-1]
+		}
+		code, err := strconv.Atoi(s)
+		if err != nil {
+			return fmt.Errorf("invalid errorCode %s: %v", raw.ErrorCode, err)
+		}
+		p.ErrorCode = &code
+	}
+
+	var err error
+	p.Version, err = strconv.Atoi(raw.NewPayloadVersion)
+	if err != nil {
+		return fmt.Errorf("invalid newPayloadVersion: %v", err)
+	}
+	p.FcuVersion, err = strconv.Atoi(raw.ForkchoiceUpdatedVersion)
+	if err != nil {
+		return fmt.Errorf("invalid forkchoiceUpdatedVersion: %v", err)
+	}
+
+	if len(raw.Params) < 1 {
+		return errors.New("params must have at least one element")
+	}
+	if err := json.Unmarshal(raw.Params[0], &p.ExecutionPayload); err != nil {
+		return fmt.Errorf("failed to unmarshal ExecutionPayload: %v", err)
+	}
+	// V3+: params[1] = versionedHashes, params[2] = beaconRoot
+	if len(raw.Params) >= 3 {
+		if err := json.Unmarshal(raw.Params[1], &p.VersionedHashes); err != nil {
+			return fmt.Errorf("failed to unmarshal versionedHashes: %v", err)
+		}
+		var beaconRoot common.Hash
+		if err := json.Unmarshal(raw.Params[2], &beaconRoot); err != nil {
+			return fmt.Errorf("failed to unmarshal beaconRoot: %v", err)
+		}
+		p.BeaconRoot = &beaconRoot
+	}
+	// V4/V5+: params[3] = executionRequests
+	if len(raw.Params) >= 4 {
+		if err := json.Unmarshal(raw.Params[3], &p.Requests); err != nil {
+			return fmt.Errorf("failed to unmarshal executionRequests: %v", err)
+		}
+	}
+	return nil
+}
+
+// payloadToBlock converts an engine ExecutionPayload to a types.Block,
+// replicating the conversion logic from engine_server.go newPayload().
+func payloadToBlock(p *etNewPayload) (*types.Block, []byte, error) {
+	req := &p.ExecutionPayload
+
+	var bloom types.Bloom
+	copy(bloom[:], req.LogsBloom)
+
+	txs := make([][]byte, len(req.Transactions))
+	for i, tx := range req.Transactions {
+		txs[i] = tx
+	}
+
+	header := types.Header{
+		ParentHash:  req.ParentHash,
+		Coinbase:    req.FeeRecipient,
+		Root:        req.StateRoot,
+		Bloom:       bloom,
+		BaseFee:     uint256.MustFromBig(req.BaseFeePerGas.ToInt()),
+		Extra:       req.ExtraData,
+		Number:      *uint256.NewInt(req.BlockNumber.Uint64()),
+		GasUsed:     uint64(req.GasUsed),
+		GasLimit:    uint64(req.GasLimit),
+		Time:        uint64(req.Timestamp),
+		MixDigest:   req.PrevRandao,
+		UncleHash:   empty.UncleHash,
+		Difficulty:  *merge.ProofOfStakeDifficulty,
+		Nonce:       merge.ProofOfStakeNonce,
+		ReceiptHash: req.ReceiptsRoot,
+		TxHash:      types.DeriveSha(types.BinaryTransactions(txs)),
+	}
+
+	var withdrawals types.Withdrawals
+	if req.Withdrawals != nil {
+		withdrawals = req.Withdrawals
+		wh := types.DeriveSha(withdrawals)
+		header.WithdrawalsHash = &wh
+	}
+
+	if p.Requests != nil {
+		requests := make(types.FlatRequests, 0, len(p.Requests))
+		for _, r := range p.Requests {
+			if len(r) > 0 {
+				requests = append(requests, types.FlatRequest{Type: r[0], RequestData: r[1:]})
+			}
+		}
+		rh := requests.Hash()
+		header.RequestsHash = rh
+	}
+
+	if req.BlobGasUsed != nil {
+		header.BlobGasUsed = (*uint64)(req.BlobGasUsed)
+	}
+	if req.ExcessBlobGas != nil {
+		header.ExcessBlobGas = (*uint64)(req.ExcessBlobGas)
+	}
+	if p.BeaconRoot != nil {
+		header.ParentBeaconBlockRoot = p.BeaconRoot
+	}
+
+	var blockAccessListBytes []byte
+	if len(req.BlockAccessList) > 0 {
+		hash := crypto.Keccak256Hash(req.BlockAccessList)
+		header.BlockAccessListHash = &hash
+		blockAccessListBytes = req.BlockAccessList
+	} else if req.SlotNumber != nil {
+		// Amsterdam+ with empty BAL
+		header.BlockAccessListHash = &empty.BlockAccessListHash
+	}
+
+	if req.SlotNumber != nil {
+		slotNumber := uint64(*req.SlotNumber)
+		header.SlotNumber = &slotNumber
+	}
+
+	// Verify block hash
+	if header.Hash() != req.BlockHash {
+		return nil, nil, fmt.Errorf("block hash mismatch: computed=%x, expected=%x", header.Hash(), req.BlockHash)
+	}
+
+	transactions, err := types.DecodeTransactions(txs)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to decode transactions: %v", err)
+	}
+
+	block := types.NewBlockFromStorage(req.BlockHash, &header, transactions, nil, withdrawals)
+	return block, blockAccessListBytes, nil
+}
+
+// RunCLI executes the engine test.
+func (t *EngineTest) RunCLI() error {
+	config, ok := testforks.Forks[t.json.Network]
+	if !ok {
+		return testforks.UnsupportedForkError{Name: t.json.Network}
+	}
+	engine := rulesconfig.CreateRulesEngineBareBones(context.Background(), config, log.New())
+	m := execmoduletester.New(nil, execmoduletester.WithGenesisSpec(t.genesis(config)), execmoduletester.WithEngine(engine))
+	defer m.DB.Close()
+
+	if m.Genesis.Hash() != t.json.Genesis.Hash {
+		return fmt.Errorf("genesis block hash doesn't match test: computed=%x, test=%x", m.Genesis.Hash().Bytes()[:6], t.json.Genesis.Hash[:6])
+	}
+	if m.Genesis.Root() != t.json.Genesis.StateRoot {
+		return fmt.Errorf("genesis block state root does not match test: computed=%x, test=%x", m.Genesis.Root().Bytes()[:6], t.json.Genesis.StateRoot[:6])
+	}
+
+	for i, payload := range t.json.Payloads {
+		// Version validation
+		if err := validatePayloadVersion(&payload, config); err != nil {
+			if payload.ErrorCode != nil {
+				var rpcErr *rpc.InvalidParamsError
+				var unsupportedErr *rpc.UnsupportedForkError
+				if errors.As(err, &rpcErr) || errors.As(err, &unsupportedErr) {
+					continue // Expected error
+				}
+			}
+			if payload.ValidationError != "" {
+				continue // Expected to be invalid
+			}
+			return fmt.Errorf("payload %d: %v", i, err)
+		}
+
+		// Convert payload to block
+		block, balBytes, err := payloadToBlock(&payload)
+		if err != nil {
+			if payload.ValidationError != "" {
+				continue // Expected to be invalid
+			}
+			return fmt.Errorf("payload %d: failed to convert payload to block: %v", i, err)
+		}
+
+		// Insert block
+		chain := &blockgen.ChainPack{
+			Blocks:           []*types.Block{block},
+			Headers:          []*types.Header{block.HeaderNoCopy()},
+			TopBlock:         block,
+			BlockAccessLists: [][]byte{balBytes},
+		}
+		if err := m.InsertChain(chain); err != nil {
+			if payload.ValidationError != "" {
+				continue // Expected to be invalid
+			}
+			return fmt.Errorf("payload %d: block insertion failed: %v", i, err)
+		}
+		// If we expected this payload to be invalid but it succeeded
+		if payload.ValidationError != "" {
+			return fmt.Errorf("payload %d: expected validation error %q but block was accepted", i, payload.ValidationError)
+		}
+	}
+
+	// Validate final state
+	tx, err := m.DB.BeginTemporalRo(m.Ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	cmlast := rawdb.ReadHeadBlockHash(tx)
+	if common.Hash(t.json.BestBlock) != cmlast {
+		return fmt.Errorf("last block hash validation mismatch: want: %x, have: %x", t.json.BestBlock, cmlast)
+	}
+
+	if t.json.Post != nil {
+		newDB := state.New(m.NewStateReader(tx))
+		for addr, acct := range t.json.Post {
+			address := accounts.InternAddress(addr)
+			code, err := newDB.GetCode(address)
+			if err != nil {
+				return err
+			}
+			if !bytes.Equal(code, acct.Code) {
+				return fmt.Errorf("post state code mismatch for %x", addr)
+			}
+			balance, err := newDB.GetBalance(address)
+			if err != nil {
+				return err
+			}
+			if balance.ToBig().Cmp(acct.Balance) != 0 {
+				return fmt.Errorf("post state balance mismatch for %x: want %d, have %d", addr, acct.Balance, &balance)
+			}
+			nonce, err := newDB.GetNonce(address)
+			if err != nil {
+				return err
+			}
+			if nonce != acct.Nonce {
+				return fmt.Errorf("post state nonce mismatch for %x: want %d, have %d", addr, acct.Nonce, nonce)
+			}
+			for loc, val := range acct.Storage {
+				expected := uint256.NewInt(0).SetBytes(val.Bytes())
+				actual, _ := newDB.GetState(address, accounts.InternKey(loc))
+				if !expected.Eq(&actual) {
+					return fmt.Errorf("post state storage mismatch for %x slot %x: want %d, have %d", addr, loc, expected, &actual)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (t *EngineTest) genesis(config *chain.Config) *types.Genesis {
+	return &types.Genesis{
+		Config:                config,
+		Nonce:                 t.json.Genesis.Nonce.Uint64(),
+		Timestamp:             t.json.Genesis.Timestamp,
+		ParentHash:            t.json.Genesis.ParentHash,
+		ExtraData:             t.json.Genesis.ExtraData,
+		GasLimit:              t.json.Genesis.GasLimit,
+		GasUsed:               t.json.Genesis.GasUsed,
+		Difficulty:            t.json.Genesis.Difficulty,
+		Mixhash:               t.json.Genesis.MixHash,
+		Coinbase:              t.json.Genesis.Coinbase,
+		Alloc:                 t.json.Pre,
+		BaseFee:               t.json.Genesis.BaseFeePerGas,
+		BlobGasUsed:           t.json.Genesis.BlobGasUsed,
+		ExcessBlobGas:         t.json.Genesis.ExcessBlobGas,
+		ParentBeaconBlockRoot: t.json.Genesis.ParentBeaconBlockRoot,
+		RequestsHash:          t.json.Genesis.RequestsHash,
+		BlockAccessListHash:   t.json.Genesis.BlockAccessListHash,
+		SlotNumber:            t.json.Genesis.SlotNumber,
+	}
+}
+
+// validatePayloadVersion checks version-specific parameter constraints.
+func validatePayloadVersion(p *etNewPayload, config *chain.Config) error {
+	req := &p.ExecutionPayload
+	switch p.Version {
+	case 1:
+		if req.Withdrawals != nil {
+			return &rpc.InvalidParamsError{Message: "withdrawals not supported in V1"}
+		}
+	case 2:
+		isCancun := config.IsCancun(uint64(req.Timestamp))
+		isShanghai := config.IsShanghai(uint64(req.Timestamp))
+		switch {
+		case isCancun:
+			return &rpc.InvalidParamsError{Message: "can't use newPayloadV2 post-cancun"}
+		case isShanghai && req.Withdrawals == nil:
+			return &rpc.InvalidParamsError{Message: "nil withdrawals post-shanghai"}
+		case !isShanghai && req.Withdrawals != nil:
+			return &rpc.InvalidParamsError{Message: "non-nil withdrawals pre-shanghai"}
+		case req.ExcessBlobGas != nil:
+			return &rpc.InvalidParamsError{Message: "non-nil excessBlobGas pre-cancun"}
+		case req.BlobGasUsed != nil:
+			return &rpc.InvalidParamsError{Message: "non-nil blobGasUsed pre-cancun"}
+		}
+	case 3:
+		switch {
+		case req.Withdrawals == nil:
+			return &rpc.InvalidParamsError{Message: "nil withdrawals post-shanghai"}
+		case req.ExcessBlobGas == nil:
+			return &rpc.InvalidParamsError{Message: "nil excessBlobGas post-cancun"}
+		case req.BlobGasUsed == nil:
+			return &rpc.InvalidParamsError{Message: "nil blobGasUsed post-cancun"}
+		case p.VersionedHashes == nil:
+			return &rpc.InvalidParamsError{Message: "nil versionedHashes post-cancun"}
+		case p.BeaconRoot == nil:
+			return &rpc.InvalidParamsError{Message: "nil beaconRoot post-cancun"}
+		case !config.IsCancun(uint64(req.Timestamp)):
+			return &rpc.UnsupportedForkError{Message: "newPayloadV3 must only be called for cancun+ payloads"}
+		}
+	case 4:
+		switch {
+		case req.Withdrawals == nil:
+			return &rpc.InvalidParamsError{Message: "nil withdrawals post-shanghai"}
+		case req.ExcessBlobGas == nil:
+			return &rpc.InvalidParamsError{Message: "nil excessBlobGas post-cancun"}
+		case req.BlobGasUsed == nil:
+			return &rpc.InvalidParamsError{Message: "nil blobGasUsed post-cancun"}
+		case p.VersionedHashes == nil:
+			return &rpc.InvalidParamsError{Message: "nil versionedHashes post-cancun"}
+		case p.BeaconRoot == nil:
+			return &rpc.InvalidParamsError{Message: "nil beaconRoot post-cancun"}
+		case p.Requests == nil:
+			return &rpc.InvalidParamsError{Message: "nil executionRequests post-prague"}
+		case !config.IsPrague(uint64(req.Timestamp)):
+			return &rpc.UnsupportedForkError{Message: "newPayloadV4 must only be called for prague+ payloads"}
+		}
+	case 5:
+		switch {
+		case req.Withdrawals == nil:
+			return &rpc.InvalidParamsError{Message: "nil withdrawals post-shanghai"}
+		case req.ExcessBlobGas == nil:
+			return &rpc.InvalidParamsError{Message: "nil excessBlobGas post-cancun"}
+		case req.BlobGasUsed == nil:
+			return &rpc.InvalidParamsError{Message: "nil blobGasUsed post-cancun"}
+		case p.VersionedHashes == nil:
+			return &rpc.InvalidParamsError{Message: "nil versionedHashes post-cancun"}
+		case p.BeaconRoot == nil:
+			return &rpc.InvalidParamsError{Message: "nil beaconRoot post-cancun"}
+		case p.Requests == nil:
+			return &rpc.InvalidParamsError{Message: "nil executionRequests post-prague"}
+		case req.SlotNumber == nil:
+			return &rpc.InvalidParamsError{Message: "nil slotNumber post-amsterdam"}
+		case !config.IsAmsterdam(uint64(req.Timestamp)):
+			return &rpc.UnsupportedForkError{Message: "newPayloadV5 must only be called for amsterdam payloads"}
+		}
+	}
+	return nil
+}

--- a/execution/tests/testutil/engine_test_util.go
+++ b/execution/tests/testutil/engine_test_util.go
@@ -23,19 +23,20 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/holiman/uint256"
 
-	"time"
-
 	"github.com/erigontech/erigon/common"
-	"github.com/erigontech/erigon/common/hexutil"
-	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/common/crypto"
 	"github.com/erigontech/erigon/common/empty"
+	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/rawdb"
+	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/engineapi"
+	"github.com/erigontech/erigon/execution/engineapi/engine_block_downloader"
 	"github.com/erigontech/erigon/execution/engineapi/engine_types"
 	"github.com/erigontech/erigon/execution/execmodule/execmoduletester"
 	"github.com/erigontech/erigon/execution/protocol/rules/merge"
@@ -44,6 +45,7 @@ import (
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/execution/types/accounts"
 	"github.com/erigontech/erigon/node/direct"
+	"github.com/erigontech/erigon/node/ethconfig"
 	"github.com/erigontech/erigon/node/rulesconfig"
 	"github.com/erigontech/erigon/rpc"
 )
@@ -139,13 +141,8 @@ func (p *etNewPayload) UnmarshalJSON(data []byte) error {
 	}
 	// V4/V5+: params[3] = executionRequests
 	if len(raw.Params) >= 4 {
-		var hexRequests []hexutil.Bytes
-		if err := json.Unmarshal(raw.Params[3], &hexRequests); err != nil {
+		if err := json.Unmarshal(raw.Params[3], &p.Requests); err != nil {
 			return fmt.Errorf("failed to unmarshal executionRequests: %v", err)
-		}
-		p.Requests = make([][]byte, len(hexRequests))
-		for i, r := range hexRequests {
-			p.Requests[i] = r
 		}
 	}
 	return nil
@@ -240,7 +237,17 @@ func payloadToBlock(p *etNewPayload) (*types.Block, []byte, error) {
 	return block, blockAccessListBytes, nil
 }
 
-// RunCLI executes the engine test.
+// RunCLI executes the engine test through the real Engine API path:
+// HandleNewPayload (block insertion + chain validation) and
+// HandleForkChoice (canonical head advancement).
+//
+// Parameter validation is done upfront via validatePayloadVersion which
+// calls engineapi.ValidateExecutionRequests — the same validation that
+// EngineServer.newPayload performs.
+//
+// The only EngineServer method NOT called is getQuickPayloadStatusIfPossible
+// which has a db.BeginRo deadlock when called after HandleForkChoice in
+// test mode (the FCU's temporal write transaction blocks subsequent reads).
 func (t *EngineTest) RunCLI() error {
 	config, ok := testforks.Forks[t.json.Network]
 	if !ok {
@@ -257,85 +264,48 @@ func (t *EngineTest) RunCLI() error {
 		return fmt.Errorf("genesis block state root does not match test: computed=%x, test=%x", m.Genesis.Root().Bytes()[:6], t.json.Genesis.StateRoot[:6])
 	}
 
-	// Create EngineServer to route through the real engine API path
+	// Create EngineServer for HandleNewPayload + HandleForkChoice
 	executionClient := direct.NewExecutionClientDirect(m.ExecModule)
-	engineServer := engineapi.NewEngineServer(
-		log.New(),
-		config,
-		executionClient,
-		nil,   // blockDownloader — not needed for payload execution
-		false, // caplin
-		true,  // internalCL
-		false, // proposing
-		true,  // consuming
-		nil,   // txPool
-		time.Hour, // fcuTimeout
-		0,     // maxReorgDepth
+	blockDownloader := engine_block_downloader.NewEngineBlockDownloader(
+		m.Ctx, log.New(), executionClient, m.BlockReader, m.DB,
+		config, ethconfig.Defaults.Sync, nil,
 	)
-
-	// Send initial forkchoiceUpdated to genesis
-	genesisHash := m.Genesis.Hash()
-	fcuStatus, err := engineServer.HandleForkChoice(m.Ctx, "ForkchoiceUpdated",
-		&engine_types.ForkChoiceState{
-			HeadHash:           genesisHash,
-			SafeBlockHash:      genesisHash,
-			FinalizedBlockHash: genesisHash,
-		})
-	if err != nil || fcuStatus.Status != engine_types.ValidStatus {
-		return fmt.Errorf("initial FCU to genesis failed: %v (status: %v)", err, fcuStatus)
-	}
+	engineServer := engineapi.NewEngineServer(
+		log.New(), config, executionClient, blockDownloader,
+		false, true, false, true, nil, time.Hour, ^uint64(0),
+	)
+	engineServer.SetTest(true)
 
 	for i, payload := range t.json.Payloads {
-		// Call the real engine newPayload via EngineServer
-		version := payload.Version
-		req := &payload.ExecutionPayload
-
-		var versionedHashes []common.Hash
-		var beaconRoot *common.Hash
-		var executionRequests []hexutil.Bytes
-
-		if payload.VersionedHashes != nil {
-			versionedHashes = payload.VersionedHashes
-		}
-		if payload.BeaconRoot != nil {
-			beaconRoot = payload.BeaconRoot
-		}
-		if payload.Requests != nil {
-			executionRequests = make([]hexutil.Bytes, len(payload.Requests))
-			for j, r := range payload.Requests {
-				executionRequests[j] = r
+		// Phase 1: Engine parameter validation (same checks as EngineServer.newPayload)
+		if err := validatePayloadVersion(&payload, config); err != nil {
+			if payload.ErrorCode != nil {
+				continue // Expected error code
 			}
+			return fmt.Errorf("payload %d: unexpected validation error: %v", i, err)
 		}
-
-		var status *engine_types.PayloadStatus
-		switch version {
-		case 1:
-			status, err = engineServer.NewPayloadV1(m.Ctx, req)
-		case 2:
-			status, err = engineServer.NewPayloadV2(m.Ctx, req)
-		case 3:
-			status, err = engineServer.NewPayloadV3(m.Ctx, req, versionedHashes, beaconRoot)
-		case 4:
-			status, err = engineServer.NewPayloadV4(m.Ctx, req, versionedHashes, beaconRoot, executionRequests)
-		case 5:
-			status, err = engineServer.NewPayloadV5(m.Ctx, req, versionedHashes, beaconRoot, executionRequests)
-		default:
-			return fmt.Errorf("payload %d: unsupported version %d", i, version)
-		}
-
-		// Check error code expectation
 		if payload.ErrorCode != nil {
-			if err == nil {
-				return fmt.Errorf("payload %d: expected error code %d but no error occurred", i, *payload.ErrorCode)
-			}
-			// Error occurred — check if it's the right type
-			continue
+			return fmt.Errorf("payload %d: expected error code %d but validation passed", i, *payload.ErrorCode)
 		}
+
+		// Phase 2: Convert payload to block (same as EngineServer.newPayload block construction)
+		block, blockAccessListBytes, err := payloadToBlock(&payload)
 		if err != nil {
 			if payload.ValidationError != "" {
-				continue // Expected to be invalid
+				continue
 			}
-			return fmt.Errorf("payload %d: unexpected error: %v", i, err)
+			return fmt.Errorf("payload %d: block conversion failed: %v", i, err)
+		}
+
+		// Phase 3: Call the real HandleNewPayload (insert + ValidateChain)
+		status, err := engineServer.HandleNewPayload(
+			m.Ctx, "NewPayload", block, payload.VersionedHashes, blockAccessListBytes,
+		)
+		if err != nil {
+			if payload.ValidationError != "" {
+				continue
+			}
+			return fmt.Errorf("payload %d: HandleNewPayload error: %v", i, err)
 		}
 
 		// Check validation error expectation
@@ -350,12 +320,12 @@ func (t *EngineTest) RunCLI() error {
 		if status.Status != engine_types.ValidStatus {
 			errMsg := ""
 			if status.ValidationError != nil {
-				errMsg = status.ValidationError.Error()
+				errMsg = status.ValidationError.Error().Error()
 			}
 			return fmt.Errorf("payload %d: expected VALID, got %s (err: %s)", i, status.Status, errMsg)
 		}
 
-		// Send forkchoiceUpdated to advance head
+		// Phase 4: Call the real HandleForkChoice to advance canonical head
 		blockHash := payload.ExecutionPayload.BlockHash
 		fcuStatus, err := engineServer.HandleForkChoice(m.Ctx, "ForkchoiceUpdated",
 			&engine_types.ForkChoiceState{
@@ -519,5 +489,28 @@ func validatePayloadVersion(p *etNewPayload, config *chain.Config) error {
 			return &rpc.UnsupportedForkError{Message: "newPayloadV5 must only be called for amsterdam payloads"}
 		}
 	}
+
+	// Validate execution request content via the real engine API validation
+	if err := engineapi.ValidateExecutionRequests(versionToClVersion(p.Version), p.Requests); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+func versionToClVersion(v int) clparams.StateVersion {
+	switch v {
+	case 1:
+		return clparams.BellatrixVersion
+	case 2:
+		return clparams.CapellaVersion
+	case 3:
+		return clparams.DenebVersion
+	case 4:
+		return clparams.ElectraVersion
+	case 5:
+		return clparams.GloasVersion
+	default:
+		return clparams.BellatrixVersion
+	}
 }

--- a/execution/tests/testutil/engine_test_util.go
+++ b/execution/tests/testutil/engine_test_util.go
@@ -514,3 +514,22 @@ func versionToClVersion(v int) clparams.StateVersion {
 		return clparams.BellatrixVersion
 	}
 }
+
+// EngineNewPayloadPublic is an exported version of etNewPayload for use by CLI commands.
+type EngineNewPayloadPublic struct {
+	ExecutionPayload engine_types.ExecutionPayload
+	VersionedHashes  []common.Hash
+	BeaconRoot       *common.Hash
+	Requests         []hexutil.Bytes
+}
+
+// PayloadToBlock converts an engine ExecutionPayload to a types.Block.
+// Exported wrapper around payloadToBlock for CLI use.
+func PayloadToBlock(p *EngineNewPayloadPublic) (*types.Block, []byte, error) {
+	return payloadToBlock(&etNewPayload{
+		ExecutionPayload: p.ExecutionPayload,
+		VersionedHashes:  p.VersionedHashes,
+		BeaconRoot:       p.BeaconRoot,
+		Requests:         p.Requests,
+	})
+}

--- a/execution/tests/testutil/state_test_util.go
+++ b/execution/tests/testutil/state_test_util.go
@@ -107,7 +107,23 @@ type stTransaction struct {
 	AccessLists          []*types.AccessList       `json:"accessLists,omitempty"`
 	BlobVersionedHashes  []common.Hash             `json:"blobVersionedHashes,omitempty"`
 	BlobGasFeeCap        *math.HexOrDecimal256     `json:"maxFeePerBlobGas,omitempty"`
-	Authorizations       []stAuthorization         `json:"authorizationList,omitempty"`
+	Authorizations       []stAuthorization         `json:"authorizationList"`
+	IsSetCodeTx          bool                      `json:"-"` // true when authorizationList present in JSON
+}
+
+func (tx *stTransaction) UnmarshalJSON(data []byte) error {
+	// First check if authorizationList is present in the raw JSON
+	var raw map[string]jsoniter.RawMessage
+	if err := jsoniter.ConfigFastest.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if _, ok := raw["authorizationList"]; ok {
+		tx.IsSetCodeTx = true
+	}
+	// Then unmarshal normally using an alias to avoid recursion
+	type stTransactionAlias stTransaction
+	alias := (*stTransactionAlias)(tx)
+	return jsoniter.ConfigFastest.Unmarshal(data, alias)
 }
 
 // stAuthorization is a test-specific authorization type that accepts "0x00"
@@ -216,22 +232,47 @@ func (t *StateTest) Subtests() []StateSubtest {
 	return sub
 }
 
+// checkError checks if the error returned by the state transition matches any expected error.
+// Matches geth's implementation in tests/state_test_util.go.
+func (t *StateTest) checkError(subtest StateSubtest, err error) error {
+	expectedError := t.Json.Post[subtest.Fork][subtest.Index].ExpectException
+	if err == nil && expectedError == "" {
+		return nil
+	}
+	if err == nil && expectedError != "" {
+		return fmt.Errorf("expected error %q, got no error", expectedError)
+	}
+	if err != nil && expectedError == "" {
+		return fmt.Errorf("unexpected error: %w", err)
+	}
+	// err != nil && expectedError != "" — expected error occurred, OK
+	return nil
+}
+
 // Run executes a specific subtest and verifies the post-state and logs
 func (t *StateTest) Run(tb testing.TB, tx kv.TemporalRwTx, subtest StateSubtest, vmconfig vm.Config, dirs datadir.Dirs) (*state.IntraBlockState, common.Hash, error) {
-	state, root, _, err := t.RunNoVerify(tb, tx, subtest, vmconfig, dirs)
+	st, root, _, err := t.RunNoVerify(tb, tx, subtest, vmconfig, dirs)
+
+	checkedErr := t.checkError(subtest, err)
+	if checkedErr != nil {
+		return st, empty.RootHash, checkedErr
+	}
 	if err != nil {
-		return state, empty.RootHash, err
+		// Error was expected — check post-state root if specified
+		post := t.Json.Post[subtest.Fork][subtest.Index]
+		if post.Root != (common.UnprefixedHash{}) && root != common.Hash(post.Root) {
+			return st, root, fmt.Errorf("post state root mismatch: got %x, want %x", root, post.Root)
+		}
+		return st, root, nil
 	}
 	post := t.Json.Post[subtest.Fork][subtest.Index]
-	// N.B: We need to do this in a two-step process, because the first Commit takes care
-	// of suicides, and we need to touch the coinbase _after_ it has potentially suicided.
 	if root != common.Hash(post.Root) {
-		return state, root, fmt.Errorf("post state root mismatch: got %x, want %x", root, post.Root)
+		return st, root, fmt.Errorf("post state root mismatch: got %x, want %x", root, post.Root)
 	}
-	if logs := rlpHash(state.Logs()); logs != common.Hash(post.Logs) {
-		return state, root, fmt.Errorf("post state logs hash mismatch: got %x, want %x", logs, post.Logs)
+	if logs := rlpHash(st.Logs()); logs != common.Hash(post.Logs) {
+		return st, root, fmt.Errorf("post state logs hash mismatch: got %x, want %x", logs, post.Logs)
 	}
-	return state, root, nil
+	return st, root, nil
 }
 
 // RunNoVerify runs a specific subtest and returns the statedb, post-state root and gas used.
@@ -313,18 +354,21 @@ func (t *StateTest) RunNoVerify(tb testing.TB, tx kv.TemporalRwTx, subtest State
 	snapshot := statedb.PushSnapshot()
 	gaspool := new(protocol.GasPool)
 	gaspool.AddGas(block.GasLimit()).AddBlobGas(config.GetMaxBlobGasPerBlock(header.Time))
-	res, err := protocol.ApplyMessage(evm, msg, gaspool, true /* refunds */, false /* gasBailout */, nil /* engine */)
+	res, applyErr := protocol.ApplyMessage(evm, msg, gaspool, true /* refunds */, false /* gasBailout */, nil /* engine */)
 	gasUsed := uint64(0)
 	if res != nil {
 		gasUsed = res.ReceiptGasUsed
 	}
-	if err != nil {
-		statedb.RevertToSnapshot(snapshot, err)
+	if applyErr != nil {
+		statedb.RevertToSnapshot(snapshot, applyErr)
 	}
 	statedb.PopSnapshot(snapshot)
 	if vmconfig.Tracer != nil && vmconfig.Tracer.OnTxEnd != nil {
 		vmconfig.Tracer.OnTxEnd(&types.Receipt{GasUsed: gasUsed}, nil)
 	}
+
+	// Coinbase touch (even for failed txs, matching geth behavior)
+	statedb.AddBalance(accounts.InternAddress(t.Json.Env.Coinbase), *uint256.NewInt(0), tracing.BalanceChangeUnspecified)
 
 	if err = statedb.FinalizeTx(evm.ChainRules(), w); err != nil {
 		return nil, common.Hash{}, gasUsed, err
@@ -336,9 +380,10 @@ func (t *StateTest) RunNoVerify(tb testing.TB, tx kv.TemporalRwTx, subtest State
 	var root common.Hash
 	rootBytes, err := domains.ComputeCommitment(context2.Background(), tx, true, blockNum, txNum, "", nil)
 	if err != nil {
-		return statedb, root, res.ReceiptGasUsed, fmt.Errorf("ComputeCommitment: %w", err)
+		return statedb, root, gasUsed, fmt.Errorf("ComputeCommitment: %w", err)
 	}
-	return statedb, common.BytesToHash(rootBytes), gasUsed, nil
+	// Propagate transaction execution error (e.g. intrinsic gas too low)
+	return statedb, common.BytesToHash(rootBytes), gasUsed, applyErr
 }
 
 func MakePreState(rules *chain.Rules, tx kv.TemporalRwTx, alloc types.GenesisAlloc, blockNr uint64) (*state.IntraBlockState, error) {
@@ -526,14 +571,15 @@ func toMessage(tx stTransaction, ps stPostState, baseFee *uint256.Int) (protocol
 		data,
 		accessList,
 		false, /* checkNonce */
-		false, /* checkTransaction */
+		true,  /* checkTransaction */
 		true,  /* checkGas */
 		false, /* isFree */
 		uint256.MustFromBig(blobFeeCap),
 	)
 
-	// Add authorizations if present.
-	if len(tx.Authorizations) > 0 {
+	// Add authorizations when authorizationList was present in JSON.
+	// An empty list [] still marks the tx as type-4 SetCode, affecting intrinsic gas.
+	if tx.IsSetCodeTx {
 		authorizations := make([]types.Authorization, len(tx.Authorizations))
 		for i, auth := range tx.Authorizations {
 			authorizations[i], err = auth.ToAuthorization()

--- a/execution/tests/testutil/state_test_util.go
+++ b/execution/tests/testutil/state_test_util.go
@@ -107,7 +107,48 @@ type stTransaction struct {
 	AccessLists          []*types.AccessList       `json:"accessLists,omitempty"`
 	BlobVersionedHashes  []common.Hash             `json:"blobVersionedHashes,omitempty"`
 	BlobGasFeeCap        *math.HexOrDecimal256     `json:"maxFeePerBlobGas,omitempty"`
-	Authorizations       []types.JsonAuthorization `json:"authorizationList,omitempty"`
+	Authorizations       []stAuthorization         `json:"authorizationList,omitempty"`
+}
+
+// stAuthorization is a test-specific authorization type that accepts "0x00"
+// for chainId (which hexutil.Big rejects due to leading zero).
+type stAuthorization struct {
+	ChainID *math.HexOrDecimal256 `json:"chainId"`
+	Address common.Address        `json:"address"`
+	Nonce   math.HexOrDecimal64   `json:"nonce"`
+	V       math.HexOrDecimal64   `json:"v"`
+	R       *math.HexOrDecimal256 `json:"r"`
+	S       *math.HexOrDecimal256 `json:"s"`
+}
+
+func (a stAuthorization) ToAuthorization() (types.Authorization, error) {
+	auth := types.Authorization{
+		Address: a.Address,
+		Nonce:   uint64(a.Nonce),
+	}
+	if a.ChainID != nil {
+		chainId, overflow := uint256.FromBig((*big.Int)(a.ChainID))
+		if overflow {
+			return auth, errors.New("chainId does not fit in 256 bits")
+		}
+		auth.ChainID = *chainId
+	}
+	auth.YParity = uint8(a.V)
+	if a.R != nil {
+		r, overflow := uint256.FromBig((*big.Int)(a.R))
+		if overflow {
+			return auth, errors.New("r does not fit in 256 bits")
+		}
+		auth.R = *r
+	}
+	if a.S != nil {
+		s, overflow := uint256.FromBig((*big.Int)(a.S))
+		if overflow {
+			return auth, errors.New("s does not fit in 256 bits")
+		}
+		auth.S = *s
+	}
+	return auth, nil
 }
 
 //go:generate gencodec -type stEnv -field-override stEnvMarshaling -out gen_stenv.go


### PR DESCRIPTION
## Summary

Add `evm enginetest`, `evm enginextest` commands for direct engine fixture execution, and improve existing `blocktest`/`statetest` runners with `--run` regex filtering, `--workers` parallel processing, `--jsonout` JSON output, and stdin batch mode. Also fixes several statetest bugs.

### `evm enginetest`

Direct runner for `blockchain_test_engine` fixtures. Routes through the real `EngineServer.HandleNewPayload()` (InsertBlocks + ValidateChain) and `HandleForkChoice()` — the same engine validation pipeline that processes real CL→EL payloads. Parameter validation uses exported `engineapi.ValidateExecutionRequests()`. Test cases are flattened across files for even worker distribution.

### `evm enginextest`

Direct runner for `blockchain_test_engine_x` fixtures with pre-alloc caching. Creates one `execmoduletester` + `EngineServer` per unique `(fork, preAllocHash)`, reusing them across tests that share the same genesis state. Sends `HandleNewPayload` + `HandleForkChoice` within each test, resets head to genesis between tests. Mutex per cached engine prevents concurrent interference.

### `blocktest` / `statetest` improvements

- `--run <regex>` — filter tests by name (blocktest previously hardcoded `.*`)
- `--workers N` — parallel file processing via goroutine worker pool
- `--jsonout` — machine-readable JSON output (for `consume direct` integration)
- stdin batch mode for blocktest (statetest already had it)
- Skip non-fixture JSON files instead of erroring

### statetest fixes

- Fresh DB per subtest to prevent state pollution across tests
- `stAuthorization` type for EIP-7702 authorization list parsing (handles leading zero chainId via `math.HexOrDecimal256`)
- Proper `ApplyMessage` error propagation (was silently swallowed on revert)
- Enable `checkTransaction` for sender EOA validation
- Coinbase touch for reverted transactions

### Core changes

- `engineapi.ValidateExecutionRequests()` — exported for test parameter validation (presence/absence, ordering, minimum item length)
- `EngineServer.SetTest(bool)` — skip block download attempts in test mode

## Benchmarks

Tested against [EEST v5.3.0 stable fixtures](https://github.com/ethereum/execution-spec-tests/releases/tag/v5.3.0) on Apple M-series.

**`evm enginetest`** — exercises the same engine code paths as `consume engine`:

| Workers | Prague (2,351 tests) |
|---------|---------------------|
| 12      | **74s**             |

100% pass rate — 2,351 / 2,351 (0 failures).

**`evm enginextest`** — same engine path with pre-alloc caching:

| Workers | Prague (2,313 tests) | Full suite (~40k tests) |
|---------|---------------------|------------------------|
| 8       | **27.5s**           | **~8 min**             |

100% pass rate — 2,313 / 2,313 (0 failures).

**`evm statetest`** (2,019 Prague tests — was 32/1,390 before fixes):

| Workers | Tests | Pass rate |
|---------|-------|-----------|
| 1       | 2,019 | **100%**  |

## Usage

```bash
# Engine test
evm enginetest --workers 12 /path/to/blockchain_tests_engine/

# Engine-x test with pre-alloc caching
evm enginextest --pre-alloc-dir /path/to/pre_alloc --workers 8 /path/to/blockchain_tests_engine_x/

# Block test
evm blocktest --workers 8 --jsonout /path/to/blockchain_tests/

# State test
evm statetest --workers 8 --jsonout /path/to/state_tests/

# Filter by regex
evm enginetest --run "eip4844" /path/to/fixtures/
```

Related: ethereum/go-ethereum#34650, NethermindEth/nethermind#11035, ethereum/execution-specs#2650