### PR TITLE
QA: fix/update gnosis/ethereum yml

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests-gnosis.yml
+++ b/.github/workflows/qa-rpc-integration-tests-gnosis.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ runner.workspace }}/rpc-tests
-          key: rpc-tests-${{ runner.os }}-${{ runner.arch }}-v1.121.0
+          key: rpc-tests-${{ runner.os }}-${{ runner.arch }}-v2.4.0
 
       - name: Run RPC Integration Tests
         id: test_step
@@ -151,7 +151,16 @@ jobs:
             db_version="no-version"
           fi
           
-          python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py --repo erigon --commit $(git rev-parse HEAD) --branch ${{ github.ref_name }} --test_name rpc-integration-tests --chain $CHAIN --runner ${{ runner.name }} --db_version $db_version --outcome $TEST_RESULT #--result_file ${{ github.workspace }}/result-$CHAIN.json
+          python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py \
+            --repo erigon \
+            --commit $(git rev-parse HEAD) \
+            --branch ${{ github.ref_name }} \
+            --test_name rpc-integration-tests \
+            --chain $CHAIN \
+            --runner ${{ runner.name }} \
+            --db_version $db_version \
+            --outcome $TEST_RESULT \
+            --result_file $TEST_RESULT_DIR/results/test_report.json
 
       - name: Action to check failure condition
         if: failure()

--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ runner.workspace }}/rpc-tests
-          key: rpc-tests-${{ runner.os }}-${{ runner.arch }}-v1.121.0
+          key: rpc-tests-${{ runner.os }}-${{ runner.arch }}-v2.4.0
 
       - name: Run RPC Integration Tests
         id: test_step

--- a/.github/workflows/scripts/run_rpc_tests_local.sh
+++ b/.github/workflows/scripts/run_rpc_tests_local.sh
@@ -88,10 +88,13 @@ cleanup() {
     mv "$BACKUP_DIR/chaindata" "$DATADIR/chaindata"
   fi
   if $OWN_BACKUP_DIR && [ -n "$BACKUP_DIR" ]; then
-    rmdir "$BACKUP_DIR" 2>/dev/null || true
+    rm -rf "$BACKUP_DIR"
   fi
   if $OWN_WORKSPACE && [ -n "$WORKSPACE" ]; then
     rm -rf "$WORKSPACE"
+  fi
+  if $OWN_RESULT_DIR && [ -n "$RESULT_DIR" ]; then
+    rm -rf "$RESULT_DIR"
   fi
 }
 trap cleanup EXIT


### PR DESCRIPTION
The following changes are made:

 qa-rpc-integration-tests-gnosis.yml                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
  1. Cache key updated — from v1.121.0 to v2.4.0 (aligned with the rpc-tests version in use).                                                                                                                                                                                                                                                                                           
  2. --result_file uncommented and path fixed — it was commented out (#--result_file ...) with a wrong path (${{ github.workspace }}/result-$CHAIN.json). Now uses the correct path $TEST_RESULT_DIR/results/test_report.json, consistent with the mainnet workflow. Also reformatted to multiline for readability.                                                                     
                                                                                                                                                                                                                                                                                                                                                                                        
  ---                                                                                                                                                                                                                                                                                                                                                                                   
  qa-rpc-integration-tests.yml (mainnet)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
  1. Cache key updated — from v1.121.0 to v2.4.0, same alignment.
                                                                                                                                                                                                                                                                                                                                                                                        
  ---                                                       
  scripts/run_rpc_tests_local.sh
                                
  1. rmdir → rm -rf for OWN_BACKUP_DIR — rmdir fails silently if the directory is not empty (e.g. if the chaindata restore did not complete). rm -rf handles all cases correctly.
  2. Added cleanup of OWN_RESULT_DIR in cleanup() — the temp directory created via mktemp -d was never removed. It is now deleted on exit, except on test failure where OWN_RESULT_DIR is set to false to allow log inspection.                                                                                                                                                         
       