### PR TITLE
warmuper.WaitAndClose: cancel work before wait

### DIFF
--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -2658,7 +2658,7 @@ func (hph *HexPatriciaHashed) Process(ctx context.Context, updates *Updates, log
 		warmup.EnableWarmupCache = hph.enableWarmupCache
 		warmuper = NewWarmuper(ctx, warmup)
 		warmuper.Start()
-		defer warmuper.WaitAndClose()
+		defer warmuper.CloseAndWait()
 		// Set cache on trie if warmup cache is enabled
 		if warmup.EnableWarmupCache {
 			hph.cache = warmuper.Cache()

--- a/execution/commitment/warmuper.go
+++ b/execution/commitment/warmuper.go
@@ -317,8 +317,8 @@ func (w *Warmuper) DrainPending() {
 	}
 }
 
-// WaitAndClose cancel and waits for all warmup work
-func (w *Warmuper) WaitAndClose() {
+// CloseAndWait cancel and waits for all warmup work
+func (w *Warmuper) CloseAndWait() {
 	w.Close()
 	if w.g != nil {
 		_ = w.g.Wait()


### PR DESCRIPTION
before: 
- seems we never close Warmuper - because WaitAndClose switching atomic. 
- seems we wait-first and then cancel/close work channel - it's wrong because `WaitAndClose()` called when warmup not needed anymore (commitment calc finished):
```
warmuper.Start()
defer warmuper.WaitAndClose()
```		


PR: canceling first and then wait gorouines to finish