### PR TITLE
caplin: ban peers that fail gossip verification

### DIFF
--- a/cl/phase1/network/gossip/gossip_manager.go
+++ b/cl/phase1/network/gossip/gossip_manager.go
@@ -41,6 +41,11 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
+// PeerBanner is an interface for banning misbehaving peers.
+type PeerBanner interface {
+	BanPeer(pid string)
+}
+
 // GossipManager is responsible for managing the gossip subscriptions and publications
 // making sure that this module is simple and don't depend on network services pkg
 type GossipManager struct {
@@ -52,6 +57,7 @@ type GossipManager struct {
 	registeredServices []GossipService
 	stats              *gossipMessageStats
 	p2p                p2p.P2PManager
+	peerBanner         PeerBanner
 
 	activeIndicies uint64
 	subscriptions  *TopicSubscriptions
@@ -92,6 +98,11 @@ func NewGossipManager(
 	go gm.goCheckForkAndResubscribe(cctx)
 	gm.stats.goPrintStats(cctx)
 	return gm
+}
+
+// SetPeerBanner sets the peer banner used to ban peers that fail message verification.
+func (g *GossipManager) SetPeerBanner(pb PeerBanner) {
+	g.peerBanner = pb
 }
 
 // Close gracefully shuts down the GossipManager and all its goroutines
@@ -176,8 +187,11 @@ func (g *GossipManager) newPubsubValidator(service serviceintf.Service[any], con
 			g.stats.addIgnore(name)
 			return pubsub.ValidationIgnore
 		} else if err != nil {
-			log.Warn("[GossipManager] reject message", "topic", name, "err", err)
+			log.Warn("[GossipManager] reject message", "topic", name, "err", err, "peer", pid)
 			g.stats.addReject(name)
+			if g.peerBanner != nil {
+				g.peerBanner.BanPeer(string(pid))
+			}
 			return pubsub.ValidationReject
 		}
 

--- a/cmd/caplin/caplin1/run.go
+++ b/cmd/caplin/caplin1/run.go
@@ -366,6 +366,7 @@ func RunCaplinService(ctx context.Context, engine execution_client.ExecutionEngi
 
 	peerDasState.SetLocalNodeID(localNode)
 	beaconRpc := rpc.NewBeaconRpcP2P(ctx, sentinel, beaconConfig, ethClock, state)
+	gossipManager.SetPeerBanner(beaconRpc)
 	peerDas := das.NewPeerDas(ctx, beaconRpc, beaconConfig, &config, columnStorage, blobStorage, sentinel, localNode.ID(), ethClock, peerDasState, gossipManager)
 	forkChoice.InitPeerDas(peerDas) // hack init
 	committeeSub := committee_subscription.NewCommitteeSubscribeManagement(ctx, beaconConfig, networkConfig, ethClock, aggregationPool, syncedDataManager, gossipManager)


### PR DESCRIPTION
Backport of #20336 to release/3.4.

Cherry-picked from d9510c0834bfeefbb671560adc34152a97e6d425.

This wires the gossip manager peer banner into caplin and bans peers that fail gossip message verification.