### PR TITLE
db/integrity: check-commitment-hist-at-blk to consider DB data

### DIFF
--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -1413,9 +1413,8 @@ func doIntegrity(cliCtx *cli.Context) error {
 	return g.Wait()
 }
 
-// stateProgress returns the latest block number covered by state snapshots,
-// derived from the aggregator's EndTxNumMinimax. This may differ from the block
-// files progress — block snapshots and state snapshots advance independently.
+// stateProgress returns the latest block number for which state history is available.
+// It considers both snapshot files (EndTxNumMinimax) and MDBX data (Execution stage progress).
 // Use this as the upper bound for state-history integrity commands.
 func stateProgress(ctx context.Context, db kv.TemporalRoDB, txNumsReader rawdbv3.TxNumsReader) (uint64, error) {
 	agg := db.(state.HasAgg).Agg().(*state.Aggregator)
@@ -1432,15 +1431,16 @@ func stateProgress(ctx context.Context, db kv.TemporalRoDB, txNumsReader rawdbv3
 	if err != nil {
 		return 0, err
 	}
-	// FindBlockNum returns the first block whose maxTxNum >= aggMax, but that
-	// block may not be fully covered by state (maxTxNum+1 > aggMax). Back up
-	// to the last block that is fully covered.
-	maxTxNum, err := txNumsReader.Max(ctx, roTx, blockNum)
-	if err != nil {
-		return 0, err
+	if blockNum > 0 {
+		blockNum-- // FindBlockNum returns the block *containing* aggMax, but the per-block check needs the entire block covered
 	}
-	if maxTxNum+1 > aggMax && blockNum > 0 {
-		blockNum--
+	// Also check execution stage progress — MDBX may have state beyond snapshots
+	execProgress, err := stages.GetStageProgress(roTx, stages.Execution)
+	if err != nil {
+		return blockNum, nil // fall back to snapshot-only progress
+	}
+	if execProgress > blockNum {
+		blockNum = execProgress
 	}
 	return blockNum, nil
 }

--- a/db/integrity/commitment_integrity.go
+++ b/db/integrity/commitment_integrity.go
@@ -850,14 +850,6 @@ func CheckCommitmentHistAtBlk(ctx context.Context, db kv.TemporalRoDB, br servic
 	if err != nil {
 		return err
 	}
-	// Use EndTxNumNoCommitment: this check reconstructs commitment from history
-	// files only (not commitment domain), so commitment domain coverage must not
-	// limit which blocks can be verified.
-	aggTx := state.AggTx(tx)
-	if aggMax := aggTx.EndTxNumNoCommitment(); maxTxNum+1 > aggMax {
-		blockNumOfState, _, _ := txNumsReader.FindBlockNum(ctx, tx, aggMax)
-		return fmt.Errorf("block %d is beyond latest block with state %d", blockNum, blockNumOfState)
-	}
 	toTxNum := maxTxNum + 1
 	sd, err := execctx.NewSharedDomains(ctx, tx, logger)
 	if err != nil {


### PR DESCRIPTION
- `stateProgress` now considers MDBX execution stage progress in addition to snapshot files, so auto-detected `--to` covers blocks beyond what's frozen into snapshots
- `checkCommitmentHistAtBlkWithIdx` no longer gates on `EndTxNumMinimax()`/`EndTxNumNoCommitment()` — temporal reads already resolve from both snapshots and MDBX, so the gate was unnecessarily restrictive