### PR TITLE
golangci: allow parallel runners

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  allow-parallel-runners: true
 linters:
   enable:
     - asasalint


### PR DESCRIPTION
- Set `allow-parallel-runners: true` in `.golangci.yml` so multiple golangci-lint instances can run concurrently without file lock contention
- Needed because different worktrees each execing linter would otherwise serialize or fail with a 5s lock timeout (https://golangci-lint.run/docs/configuration/file/#run-configuration)