### PR TITLE
rpc: use synctest for TestClientCancelHTTP to fix CI flakiness

### DIFF
--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
@@ -166,51 +167,35 @@ func TestClientNotify(t *testing.T) {
 func TestClientCancelWebsocket(t *testing.T) { testClientCancel("ws", t, log.New()) }
 func TestClientCancelHTTP(t *testing.T)      { testClientCancel("http", t, log.New()) }
 
-// This test checks that requests made through CallContext can be canceled by canceling
-// the context.
+// testClientCancel checks that requests made through CallContext can be canceled
+// by canceling the context at various stages of request processing:
+//   - cancel during dial
+//   - cancel while performing an HTTP request
+//   - cancel while waiting for a response
+//
+// The HTTP transport uses synctest with in-memory connections for deterministic timing.
+// The WebSocket transport uses real TCP because its long-lived server goroutines
+// (pingLoop, ServeCodec, dispatch) have complex shutdown dependencies incompatible
+// with synctest's requirement that all bubble goroutines exit.
 func testClientCancel(transport string, t *testing.T, logger log.Logger) {
 	if testing.Short() {
 		t.Skip()
 	}
 
-	// These tests take a lot of time, run them all at once.
-	// You probably want to run with -parallel 1 or comment out
-	// the call to t.Parallel if you enable the logging.
-	t.Parallel()
-
-	server := newTestServer(logger)
-	defer server.Stop()
-
-	// What we want to achieve is that the context gets canceled
-	// at various stages of request processing. The interesting cases
-	// are:
-	//  - cancel during dial
-	//  - cancel while performing a HTTP request
-	//  - cancel while waiting for a response
-	//
-	// To trigger those, the times are chosen such that connections
-	// are killed within the deadline for every other call (maxKillTimeout
-	// is 2x maxCancelTimeout).
-	//
-	// Once a connection is dead, there is a fair chance it won't connect
-	// successfully because the accept is delayed by 1s.
-	maxContextCancelTimeout := 300 * time.Millisecond
-	fl := &flakeyListener{
-		maxAcceptDelay: 1 * time.Second,
-		maxKillTimeout: 600 * time.Millisecond,
-	}
-
-	var client *Client
 	switch transport {
-	case "ws", "http":
-		c, hs := httpTestClient(server, transport, fl)
-		defer hs.Close()
-		client = c
+	case "http":
+		testClientCancelSynctest(t, logger)
+	case "ws":
+		testClientCancelTCP(t, logger)
 	default:
 		panic("unknown transport: " + transport)
 	}
+}
 
-	// The actual test starts here.
+// runCancelCallers spawns ncallers goroutines, each making nreqs calls to test_block
+// with random context cancellation. No call should ever succeed because test_block
+// blocks until the context is canceled.
+func runCancelCallers(t *testing.T, client *Client, maxContextCancelTimeout time.Duration) {
 	var (
 		wg       sync.WaitGroup
 		nreqs    = 10
@@ -225,25 +210,18 @@ func testClientCancel(transport string, t *testing.T, logger log.Logger) {
 				timeout = time.Duration(rand.Int63n(int64(maxContextCancelTimeout)))
 			)
 			if index < ncallers/2 {
-				// For half of the callers, create a context without deadline
-				// and cancel it later.
+				// Half the callers cancel via explicit cancel func.
 				ctx, cancel = context.WithCancel(context.Background())
 				time.AfterFunc(timeout, cancel)
 			} else {
-				// For the other half, create a context with a deadline instead. This is
-				// different because the context deadline is used to set the socket write
-				// deadline.
+				// Other half use context deadline, which also sets the
+				// socket write deadline — a different cancellation path.
 				ctx, cancel = context.WithTimeout(context.Background(), timeout)
 			}
-
-			// Now perform a call with the context.
-			// The key thing here is that no call will ever complete successfully.
 			err := client.CallContext(ctx, nil, "test_block")
 			if err == nil {
 				_, hasDeadline := ctx.Deadline()
 				t.Errorf("no error for call with %v wait time (deadline: %v)", timeout, hasDeadline)
-				// default:
-				// 	t.Logf("got expected error with %v wait time: %v", timeout, err)
 			}
 			cancel()
 		}
@@ -253,6 +231,55 @@ func testClientCancel(transport string, t *testing.T, logger log.Logger) {
 		go caller(i)
 	}
 	wg.Wait()
+}
+
+// testClientCancelSynctest runs the cancel test using synctest with in-memory
+// connections. All time.Sleep/time.AfterFunc use fake time, so it runs instantly
+// regardless of CI machine speed.
+func testClientCancelSynctest(t *testing.T, logger log.Logger) {
+	synctest.Test(t, func(t *testing.T) {
+		server := newTestServer(logger)
+
+		// To trigger cancels at various stages, the times are chosen such that
+		// connections are killed within the deadline for every other call
+		// (maxKillTimeout is 2x maxCancelTimeout).
+		// Once a connection is dead, there is a fair chance it won't connect
+		// successfully because the accept is delayed by 1s.
+		fl := &flakeyListener{
+			maxAcceptDelay: 1 * time.Second,
+			maxKillTimeout: 600 * time.Millisecond,
+		}
+
+		client, hs := memHTTPTestClient(server, fl)
+		defer hs.Close()
+		defer server.Stop()
+
+		runCancelCallers(t, client, 300*time.Millisecond)
+	})
+}
+
+// testClientCancelTCP runs the cancel test over real TCP connections.
+func testClientCancelTCP(t *testing.T, logger log.Logger) {
+	t.Parallel()
+
+	server := newTestServer(logger)
+	defer server.Stop()
+
+	// To trigger cancels at various stages, the times are chosen such that
+	// connections are killed within the deadline for every other call
+	// (maxKillTimeout is 2x maxCancelTimeout).
+	// Once a connection is dead, there is a fair chance it won't connect
+	// successfully because the accept is delayed by 1s.
+	fl := &flakeyListener{
+		maxAcceptDelay: 1 * time.Second,
+		maxKillTimeout: 600 * time.Millisecond,
+	}
+
+	client, hs := httpTestClient(server, "ws", fl)
+	defer hs.Close()
+	defer client.Close()
+
+	runCancelCallers(t, client, 300*time.Millisecond)
 }
 
 func TestClientSubscribeInvalidArg(t *testing.T) {
@@ -641,4 +668,87 @@ func (l *flakeyListener) Accept() (net.Conn, error) {
 		})
 	}
 	return c, err
+}
+
+// memListener is an in-memory net.Listener backed by net.Pipe.
+// It is compatible with synctest because it uses no real I/O.
+type memListener struct {
+	connCh chan net.Conn
+	done   chan struct{}
+	once   sync.Once
+}
+
+func newMemListener() *memListener {
+	return &memListener{
+		connCh: make(chan net.Conn),
+		done:   make(chan struct{}),
+	}
+}
+
+func (l *memListener) Accept() (net.Conn, error) {
+	select {
+	case c := <-l.connCh:
+		return c, nil
+	case <-l.done:
+		return nil, net.ErrClosed
+	}
+}
+
+func (l *memListener) Close() error {
+	l.once.Do(func() { close(l.done) })
+	return nil
+}
+
+func (l *memListener) Addr() net.Addr {
+	return memAddr{}
+}
+
+// Dial creates a new in-memory connection to this listener.
+func (l *memListener) Dial(ctx context.Context, _, _ string) (net.Conn, error) {
+	server, client := net.Pipe()
+	select {
+	case l.connCh <- server:
+		return client, nil
+	case <-l.done:
+		server.Close()
+		client.Close()
+		return nil, net.ErrClosed
+	case <-ctx.Done():
+		server.Close()
+		client.Close()
+		return nil, ctx.Err()
+	}
+}
+
+type memAddr struct{}
+
+func (memAddr) Network() string { return "mem" }
+func (memAddr) String() string  { return "mem" }
+
+// memHTTPTestClient creates an HTTP test client using in-memory connections
+// (no real TCP). Compatible with synctest.
+func memHTTPTestClient(srv *Server, fl *flakeyListener) (*Client, *http.Server) {
+	logger := log.New()
+	ml := newMemListener()
+
+	var listener net.Listener = ml
+	if fl != nil {
+		fl.Listener = ml
+		listener = fl
+	}
+
+	hs := &http.Server{Handler: srv}
+	go hs.Serve(listener)
+
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			DialContext: ml.Dial,
+		},
+	}
+
+	client, err := DialHTTPWithClient("http://mem", httpClient, logger)
+	if err != nil {
+		panic(err)
+	}
+	return client, hs
 }


### PR DESCRIPTION
Replace real TCP connections with in-memory net.Pipe-based listener for the HTTP cancel test, wrapped in synctest.Test for deterministic fake-time execution. The test now runs in ~0s instead of timing out on slow CI runners.

WebSocket cancel test keeps real TCP due to complex goroutine shutdown dependencies incompatible with synctest's bubble requirements.

err: 
```
[WARN] [04-07|01:51:47.496] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:51:47.496] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:51:47.497] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:51:47.507] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:51:47.507] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:51:47.507] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:51:47.510] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:51:47.510] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:51:47.510] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:51:47.512] [rpc] served                             method=test_returnError reqid=1 err=testError errdata="testError data"
[WARN] [04-07|01:51:47.513] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:51:47.513] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:51:47.513] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:51:47.515] [rpc] served                             method=no_such_method reqid=3 err="the method no_such_method does not exist/is not available"
[WARN] [04-07|01:51:47.516] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:51:47.516] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:51:47.516] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:51:47.517] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:51:47.517] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:51:47.518] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:51:47.519] [rpc] served                             method=eth_subscribe reqid=1 err="no \"foo_bar\" subscription in eth namespace"
[WARN] [04-07|01:51:47.519] [rpc] served                             method=eth_subscribe reqid=2 err="no \"foo_bar\" subscription in eth namespace"
[WARN] [04-07|01:51:47.520] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:51:47.520] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:51:47.520] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:51:47.523] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:51:47.523] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:51:47.524] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:51:47.527] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:51:47.527] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:51:47.527] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:51:47.563] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:51:47.563] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:51:47.563] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:51:56.015] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:51:56.015] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:51:56.015] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:51:56.019] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:51:56.019] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:51:56.019] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:51:56.103] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:51:56.103] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:51:56.103] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:51:58.107] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:51:58.107] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:51:58.107] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:52:32.735] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:52:32.735] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:52:32.735] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:52:32.737] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:52:32.737] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:52:32.737] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:52:32.737] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:52:32.737] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:52:32.737] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:52:32.738] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:52:32.738] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:52:32.738] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:52:32.740] [rpc] served                             method=unknown_method reqid=2 err="the method unknown_method does not exist/is not available"
[WARN] [04-07|01:52:32.741] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:52:32.741] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:52:32.741] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:52:32.743] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:52:32.743] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:52:32.743] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:52:32.744] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:52:32.744] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:52:32.744] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:52:32.745] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:52:32.745] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:52:32.745] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:52:32.746] [rpc] served                             method=test_echo reqid=2 err="missing value for required argument 0"
[WARN] [04-07|01:52:32.746] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:52:32.747] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:52:32.747] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:52:32.748] [rpc] served                             method=test_echo reqid=2 err="missing value for required argument 0"
[WARN] [04-07|01:52:32.748] [rpc] served                             method=test_echo reqid=2 err="missing value for required argument 1"
[WARN] [04-07|01:52:32.750] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:52:32.750] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:52:32.750] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:52:32.751] [rpc] served                             method=test_echo reqid=3 err="non-array args"
[WARN] [04-07|01:52:32.751] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:52:32.751] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:52:32.751] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:52:32.752] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:52:32.752] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:52:32.752] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:52:32.753] [rpc] served                             method=invalid_method reqid=2 err="the method invalid_method does not exist/is not available"
[WARN] [04-07|01:52:32.754] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:52:32.754] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:52:32.754] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:52:32.754] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:52:32.754] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:52:32.755] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:52:32.755] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:52:32.755] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:52:32.755] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:52:32.757] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:52:32.757] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:52:32.757] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:52:32.758] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:52:32.758] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:52:32.758] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:52:32.760] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:52:32.760] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:52:32.760] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:52:32.771] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:52:32.771] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:52:32.771] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:52:44.363] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:52:44.363] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:52:44.363] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:52:44.363] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:52:44.363] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:52:44.363] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
[WARN] [04-07|01:52:44.363] Cannot register RPC callback [invalidRets1] - error must the last return value 
[WARN] [04-07|01:52:44.363] Cannot register RPC callback [invalidRets2] - error must the last return value 
[WARN] [04-07|01:52:44.363] Cannot register RPC callback [invalidRets3] - maximum 2 return values are allowed, got 3 
--- FAIL: TestClientCancelWebsocket (1.00s)
panic: read tcp 127.0.0.1:59236->127.0.0.1:33899: read: connection reset by peer [recovered, repanicked]

goroutine 66 [running]:
testing.tRunner.func1.2({0x117cd40, 0xc000059720})
	/opt/hostedtoolcache/go/1.25.8/x64/src/testing/testing.go:1872 +0x419
testing.tRunner.func1()
	/opt/hostedtoolcache/go/1.25.8/x64/src/testing/testing.go:1875 +0x683
panic({0x117cd40?, 0xc000059720?})
	/opt/hostedtoolcache/go/1.25.8/x64/src/runtime/panic.go:783 +0x132
github.com/erigontech/erigon/rpc.httpTestClient(0xc000324180, {0x11fcef1, 0x2}, 0xc000059120)
	/home/runner/work/erigon/erigon/rpc/client_test.go:619 +0x6b9
github.com/erigontech/erigon/rpc.testClientCancel({0x11fcef1, 0x2}, 0xc000102e00, {0x136dd10, 0xc000300c60})
	/home/runner/work/erigon/erigon/rpc/client_test.go:206 +0x256
github.com/erigontech/erigon/rpc.TestClientCancelWebsocket(0xc000102e00)
	/home/runner/work/erigon/erigon/rpc/client_test.go:166 +0x58
testing.tRunner(0xc000102e00, 0x1241000)
	/opt/hostedtoolcache/go/1.25.8/x64/src/testing/testing.go:1934 +0x21d
created by testing.(*T).Run in goroutine 1
	/opt/hostedtoolcache/go/1.25.8/x64/src/testing/testing.go:1997 +0x9d3

goroutine 1 [chan receive]:
testing.tRunner.func1()
	/opt/hostedtoolcache/go/1.25.8/x64/src/testing/testing.go:1891 +0x9ad
testing.tRunner(0xc00037e1c0, 0xc000053ae0)
	/opt/hostedtoolcache/go/1.25.8/x64/src/testing/testing.go:1940 +0x256
testing.runTests(0xc00035c3c0, {0x198f6a0, 0x28, 0x28}, {0x0?, 0x4bba45?, 0x1999960?})
	/opt/hostedtoolcache/go/1.25.8/x64/src/testing/testing.go:2475 +0x96d
testing.(*M).Run(0xc00037a140)
	/opt/hostedtoolcache/go/1.25.8/x64/src/testing/testing.go:2337 +0xed5
main.main()
	_testmain.go:129 +0x165

goroutine 37 [chan receive]:
```