### PR TITLE
batchSize: more precise estimate

### DIFF
--- a/execution/state/rw_v3.go
+++ b/execution/state/rw_v3.go
@@ -281,7 +281,6 @@ func (rs *StateV3) SizeEstimateBeforeCommitment() uint64 {
 		return 0
 	}
 	sz := rs.domains.Size()
-	sz *= 2 // to cover data-structures overhead: map, btree, etc... and GC overhead (clean happening periodically)
 	sz *= 2 // for Commitment calculation when batch is full
 	return sz
 }
@@ -291,9 +290,7 @@ func (rs *StateV3) SizeEstimateAfterCommitment() uint64 {
 	if rs.domains == nil {
 		return 0
 	}
-	sz := rs.domains.Size()
-	sz *= 2 // to cover data-structures overhead: map, btree, etc... and GC overhead (clean happening periodically)
-	return sz
+	return rs.domains.Size()
 }
 
 type storageItem struct {


### PR DESCRIPTION
no i see:
```
 [INFO] [04-07|03:47:24.324] [4/6 Execution] serial executed          blk=10501877 blks=441 blk/s=22 txs=89.08k tx/s=4.45k gas/s=254.40M tgas/s=0(0) aratio=0.0 tdur=0s        
trdur=0s(0.00%) rd=0 rd/s=0 buf=9.9GB/10.0GB bdur=22ms ucgas=255.45G alloc=35.4GB sys=98.6GB isForkValidation=false isBlockProduction=false isApplyingBlocks=true               
[INFO] [04-07|03:47:33.725] [p2p] GoodPeers                          eth68=74 eth69=120                                                                                         
[INFO] [04-07|03:47:39.246] [mem] memory stats                       Rss=168.1GB Size=0B Pss=168.1GB SharedClean=2.2MB SharedDirty=0B PrivateClean=116.9GB PrivateDirty=51.2GB  
Referenced=110.6GB Anonymous=51.2GB Swap=0B alloc=37.6GB sys=98.6GB                                                                                                             
[INFO] [04-07|03:47:41.683] Caplin P2P                               app=caplin peers_count=296                                                                                 
[INFO] [04-07|03:47:44.357] [4/6 Execution] serial executed          blk=10502328 blks=451 blk/s=22 txs=86.33k tx/s=4.30k gas/s=252.06M tgas/s=0(0) aratio=0.0 tdur=0s          
trdur=0s(0.00%) rd=0 rd/s=0 buf=10.0GB/10.0GB bdur=22ms ucgas=260.50G alloc=38.8GB sys=98.6GB isForkValidation=false isBlockProduction=false isApplyingBlocks=true              
[INFO] [04-07|03:47:44.362] periodic commit check                    block=10502328 txNum=792513438 commitment=4.383236ms    
```

10gb estimate turned into 5gb result membatch. 