### PR TITLE
cmd, ethconfig: consolidate flag reading and remove global statecfg side effects

### DIFF
--- a/cmd/erigon/node/config_snapshot_test.go
+++ b/cmd/erigon/node/config_snapshot_test.go
@@ -27,12 +27,11 @@ import (
 	"github.com/erigontech/erigon/node/ethconfig"
 	"github.com/erigontech/erigon/node/nodecfg"
 
-	"github.com/erigontech/erigon/cmd/utils"
 	"github.com/erigontech/erigon/common/log/v3"
 )
 
 // buildEthConfig creates an ethconfig.Config by running the full flag parsing
-// pipeline (SetEthConfig + ApplyFlagsForEthConfig) with the given CLI args.
+// pipeline (BuildEthConfig) with the given CLI args.
 func buildEthConfig(t *testing.T, args []string) *ethconfig.Config {
 	t.Helper()
 
@@ -44,8 +43,7 @@ func buildEthConfig(t *testing.T, args []string) *ethconfig.Config {
 		nodeCfg := &nodecfg.Config{}
 		nodeCfg.Dirs.DataDir = t.TempDir()
 		ethCfg := ethconfig.Defaults
-		utils.SetEthConfig(ctx, nodeCfg, &ethCfg, logger)
-		erigoncli.ApplyFlagsForEthConfig(ctx, &ethCfg, logger)
+		erigoncli.BuildEthConfig(ctx, nodeCfg, &ethCfg, logger)
 		result = &ethCfg
 		return nil
 	}

--- a/cmd/erigon/node/config_snapshot_test.go
+++ b/cmd/erigon/node/config_snapshot_test.go
@@ -64,14 +64,15 @@ type configSnapshot struct {
 	RPCTxFeeCap float64 `json:"rpc_tx_fee_cap"`
 
 	// Sync config
-	LoopThrottle   string `json:"loop_throttle"`
+	LoopThrottle    string `json:"loop_throttle"`
 	BreakAfterStage string `json:"break_after_stage"`
-	LoopBlockLimit uint   `json:"loop_block_limit"`
-	ExecWorkerCount int   `json:"exec_worker_count"`
+	LoopBlockLimit  uint   `json:"loop_block_limit"`
+	ExecWorkerCount int    `json:"exec_worker_count"`
 
 	// Feature flags
-	ExperimentalBAL    bool `json:"experimental_bal"`
-	KeepExecutionProofs bool `json:"keep_execution_proofs"`
+	ExperimentalBAL                  bool `json:"experimental_bal"`
+	KeepExecutionProofs              bool `json:"keep_execution_proofs"`
+	ExperimentalConcurrentCommitment bool `json:"experimental_concurrent_commitment"`
 
 	// Snapshot config
 	SnapKeepBlocks bool `json:"snap_keep_blocks"`
@@ -82,28 +83,28 @@ type configSnapshot struct {
 	// Consensus
 	HeimdallURL     string `json:"heimdall_url"`
 	WithoutHeimdall bool   `json:"without_heimdall"`
-
 }
 
 func snapshotConfig(cfg *ethconfig.Config) configSnapshot {
 	return configSnapshot{
-		NetworkID:           cfg.NetworkID,
-		StateStream:         cfg.StateStream,
-		InternalCL:          cfg.InternalCL,
-		RPCGasCap:           cfg.RPCGasCap,
-		RPCTxFeeCap:         cfg.RPCTxFeeCap,
-		LoopThrottle:        cfg.Sync.LoopThrottle.String(),
-		BreakAfterStage:     cfg.Sync.BreakAfterStage,
-		LoopBlockLimit:      cfg.Sync.LoopBlockLimit,
-		ExecWorkerCount:     cfg.Sync.ExecWorkerCount,
-		ExperimentalBAL:     cfg.ExperimentalBAL,
-		KeepExecutionProofs: cfg.Sync.KeepExecutionProofs,
-		SnapKeepBlocks:      cfg.Snapshot.KeepBlocks,
-		SnapProduceE2:       cfg.Snapshot.ProduceE2,
-		SnapProduceE3:       cfg.Snapshot.ProduceE3,
-		NoDownloader:        cfg.Snapshot.NoDownloader,
-		HeimdallURL:         cfg.HeimdallURL,
-		WithoutHeimdall:     cfg.WithoutHeimdall,
+		NetworkID:                        cfg.NetworkID,
+		StateStream:                      cfg.StateStream,
+		InternalCL:                       cfg.InternalCL,
+		RPCGasCap:                        cfg.RPCGasCap,
+		RPCTxFeeCap:                      cfg.RPCTxFeeCap,
+		LoopThrottle:                     cfg.Sync.LoopThrottle.String(),
+		BreakAfterStage:                  cfg.Sync.BreakAfterStage,
+		LoopBlockLimit:                   cfg.Sync.LoopBlockLimit,
+		ExecWorkerCount:                  cfg.Sync.ExecWorkerCount,
+		ExperimentalBAL:                  cfg.ExperimentalBAL,
+		KeepExecutionProofs:              cfg.Sync.KeepExecutionProofs,
+		ExperimentalConcurrentCommitment: cfg.Sync.ExperimentalConcurrentCommitment,
+		SnapKeepBlocks:                   cfg.Snapshot.KeepBlocks,
+		SnapProduceE2:                    cfg.Snapshot.ProduceE2,
+		SnapProduceE3:                    cfg.Snapshot.ProduceE3,
+		NoDownloader:                     cfg.Snapshot.NoDownloader,
+		HeimdallURL:                      cfg.HeimdallURL,
+		WithoutHeimdall:                  cfg.WithoutHeimdall,
 	}
 }
 
@@ -132,9 +133,9 @@ func TestConfigDefaults(t *testing.T) {
 // pattern that must remain stable during refactoring.
 func TestConfigWithFlags(t *testing.T) {
 	tests := []struct {
-		name   string
-		args   []string
-		check  func(t *testing.T, snap configSnapshot)
+		name  string
+		args  []string
+		check func(t *testing.T, snap configSnapshot)
 	}{
 		{
 			name: "disable state stream",

--- a/cmd/erigon/node/config_snapshot_test.go
+++ b/cmd/erigon/node/config_snapshot_test.go
@@ -1,0 +1,216 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package node
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+
+	erigoncli "github.com/erigontech/erigon/node/cli"
+	"github.com/erigontech/erigon/node/ethconfig"
+	"github.com/erigontech/erigon/node/nodecfg"
+
+	"github.com/erigontech/erigon/cmd/utils"
+	"github.com/erigontech/erigon/common/log/v3"
+)
+
+// buildEthConfig creates an ethconfig.Config by running the full flag parsing
+// pipeline (SetEthConfig + ApplyFlagsForEthConfig) with the given CLI args.
+func buildEthConfig(t *testing.T, args []string) *ethconfig.Config {
+	t.Helper()
+
+	var result *ethconfig.Config
+	app := cli.NewApp()
+	app.Flags = erigoncli.DefaultFlags
+	app.Action = func(ctx *cli.Context) error {
+		logger := log.Root()
+		nodeCfg := &nodecfg.Config{}
+		nodeCfg.Dirs.DataDir = t.TempDir()
+		ethCfg := ethconfig.Defaults
+		utils.SetEthConfig(ctx, nodeCfg, &ethCfg, logger)
+		erigoncli.ApplyFlagsForEthConfig(ctx, &ethCfg, logger)
+		result = &ethCfg
+		return nil
+	}
+	require.NoError(t, app.Run(append([]string{"erigon"}, args...)))
+	require.NotNil(t, result)
+	return result
+}
+
+// configJSON returns a deterministic JSON snapshot of the config, excluding
+// fields that vary between runs (Dirs, Genesis, Downloader).
+type configSnapshot struct {
+	NetworkID   uint64  `json:"network_id"`
+	StateStream bool    `json:"state_stream"`
+	InternalCL  bool    `json:"internal_cl"`
+	RPCGasCap   uint64  `json:"rpc_gas_cap"`
+	RPCTxFeeCap float64 `json:"rpc_tx_fee_cap"`
+
+	// Sync config
+	LoopThrottle   string `json:"loop_throttle"`
+	BreakAfterStage string `json:"break_after_stage"`
+	LoopBlockLimit uint   `json:"loop_block_limit"`
+	ExecWorkerCount int   `json:"exec_worker_count"`
+
+	// Feature flags
+	ExperimentalBAL    bool `json:"experimental_bal"`
+	KeepExecutionProofs bool `json:"keep_execution_proofs"`
+
+	// Snapshot config
+	SnapKeepBlocks bool `json:"snap_keep_blocks"`
+	SnapProduceE2  bool `json:"snap_produce_e2"`
+	SnapProduceE3  bool `json:"snap_produce_e3"`
+	NoDownloader   bool `json:"no_downloader"`
+
+	// Consensus
+	HeimdallURL     string `json:"heimdall_url"`
+	WithoutHeimdall bool   `json:"without_heimdall"`
+
+}
+
+func snapshotConfig(cfg *ethconfig.Config) configSnapshot {
+	return configSnapshot{
+		NetworkID:           cfg.NetworkID,
+		StateStream:         cfg.StateStream,
+		InternalCL:          cfg.InternalCL,
+		RPCGasCap:           cfg.RPCGasCap,
+		RPCTxFeeCap:         cfg.RPCTxFeeCap,
+		LoopThrottle:        cfg.Sync.LoopThrottle.String(),
+		BreakAfterStage:     cfg.Sync.BreakAfterStage,
+		LoopBlockLimit:      cfg.Sync.LoopBlockLimit,
+		ExecWorkerCount:     cfg.Sync.ExecWorkerCount,
+		ExperimentalBAL:     cfg.ExperimentalBAL,
+		KeepExecutionProofs: cfg.Sync.KeepExecutionProofs,
+		SnapKeepBlocks:      cfg.Snapshot.KeepBlocks,
+		SnapProduceE2:       cfg.Snapshot.ProduceE2,
+		SnapProduceE3:       cfg.Snapshot.ProduceE3,
+		NoDownloader:        cfg.Snapshot.NoDownloader,
+		HeimdallURL:         cfg.HeimdallURL,
+		WithoutHeimdall:     cfg.WithoutHeimdall,
+	}
+}
+
+// TestConfigDefaults verifies that the default config (no flags) produces
+// expected values. This catches regressions during flag consolidation.
+func TestConfigDefaults(t *testing.T) {
+	cfg := buildEthConfig(t, nil)
+	snap := snapshotConfig(cfg)
+
+	// Core defaults
+	require.Equal(t, uint64(1), snap.NetworkID, "default network should be mainnet")
+	require.True(t, snap.StateStream, "state stream should be enabled by default")
+	require.True(t, snap.InternalCL, "internal CL (Caplin) is on by default")
+	require.False(t, snap.ExperimentalBAL, "experimental BAL should be off by default")
+	require.False(t, snap.KeepExecutionProofs, "keep execution proofs should be off by default")
+
+	// Snapshot defaults
+	require.True(t, snap.SnapProduceE2, "snap produce e2 should be on by default")
+	require.True(t, snap.SnapProduceE3, "snap produce e3 should be on by default")
+	require.False(t, snap.NoDownloader, "downloader should be enabled by default")
+	require.False(t, snap.SnapKeepBlocks, "snap keep blocks should be off by default")
+}
+
+// TestConfigWithFlags verifies that specific flag combinations produce the
+// expected config changes. Each test case represents a common deployment
+// pattern that must remain stable during refactoring.
+func TestConfigWithFlags(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   []string
+		check  func(t *testing.T, snap configSnapshot)
+	}{
+		{
+			name: "disable state stream",
+			args: []string{"--state.stream.disable"},
+			check: func(t *testing.T, snap configSnapshot) {
+				require.False(t, snap.StateStream)
+			},
+		},
+		{
+			name: "experimental BAL",
+			args: []string{"--experimental.bal"},
+			check: func(t *testing.T, snap configSnapshot) {
+				require.True(t, snap.ExperimentalBAL)
+			},
+		},
+		{
+			name: "no downloader",
+			args: []string{"--no-downloader"},
+			check: func(t *testing.T, snap configSnapshot) {
+				require.True(t, snap.NoDownloader)
+			},
+		},
+		{
+			name: "snap stop",
+			args: []string{"--snap.stop"},
+			check: func(t *testing.T, snap configSnapshot) {
+				require.False(t, snap.SnapProduceE2)
+			},
+		},
+		{
+			name: "without heimdall",
+			args: []string{"--bor.withoutheimdall"},
+			check: func(t *testing.T, snap configSnapshot) {
+				require.True(t, snap.WithoutHeimdall)
+			},
+		},
+		{
+			name: "sync loop block limit",
+			args: []string{"--sync.loop.block.limit=1000"},
+			check: func(t *testing.T, snap configSnapshot) {
+				require.Equal(t, uint(1000), snap.LoopBlockLimit)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := buildEthConfig(t, tt.args)
+			snap := snapshotConfig(cfg)
+			tt.check(t, snap)
+		})
+	}
+}
+
+// TestConfigSnapshotStability creates a full JSON snapshot of the config
+// from default flags. This test exists to detect ANY config field change
+// during the consolidation refactor — if this test fails, the diff shows
+// exactly which fields changed.
+func TestConfigSnapshotStability(t *testing.T) {
+	cfg := buildEthConfig(t, nil)
+	snap := snapshotConfig(cfg)
+
+	// Marshal to JSON for readable diffs
+	got, err := json.MarshalIndent(snap, "", "  ")
+	require.NoError(t, err)
+
+	// If this test fails during refactoring, the diff shows which field changed.
+	// Update the expected JSON only after verifying the change is intentional.
+	t.Logf("Config snapshot (update expected if intentional):\n%s", string(got))
+
+	// Verify key structural invariants rather than exact JSON match,
+	// since some defaults depend on runtime (CPU count, etc.)
+	require.Equal(t, uint64(1), snap.NetworkID)
+	require.True(t, snap.StateStream)
+	require.True(t, snap.SnapProduceE2)
+	require.True(t, snap.SnapProduceE3)
+	require.False(t, snap.ExperimentalBAL)
+	require.False(t, snap.NoDownloader)
+}

--- a/cmd/erigon/node/node.go
+++ b/cmd/erigon/node/node.go
@@ -125,9 +125,7 @@ func NewNodConfigUrfave(ctx *cli.Context, debugMux *http.ServeMux, logger log.Lo
 
 func NewEthConfigUrfave(ctx *cli.Context, nodeConfig *nodecfg.Config, logger log.Logger) *ethconfig.Config {
 	ethConfig := ethconfig.Defaults // Needs to be a copy, not pointer
-	utils.SetEthConfig(ctx, nodeConfig, &ethConfig, logger)
-	erigoncli.ApplyFlagsForEthConfig(ctx, &ethConfig, logger)
-
+	erigoncli.BuildEthConfig(ctx, nodeConfig, &ethConfig, logger)
 	return &ethConfig
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -47,7 +47,6 @@ import (
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/downloader/downloadercfg"
 	"github.com/erigontech/erigon/db/snapcfg"
-	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/db/version"
 	"github.com/erigontech/erigon/diagnostics/metrics"
 	"github.com/erigontech/erigon/execution/builder/buildercfg"
@@ -1840,7 +1839,6 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 	cfg.CaplinConfig.CaplinDiscoveryTCPPort = ctx.Uint64(CaplinDiscoveryTCPPortFlag.Name)
 	if ctx.Bool(KeepExecutionProofsFlag.Name) {
 		cfg.KeepExecutionProofs = true
-		statecfg.EnableHistoricalCommitment()
 	}
 
 	if ctx.IsSet(AlwaysGenerateChangesetsFlag.Name) {
@@ -1923,8 +1921,7 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 	cfg.Ethstats = ctx.String(EthStatsURLFlag.Name)
 
 	if ctx.Bool(ExperimentalConcurrentCommitmentFlag.Name) {
-		// cfg.ExperimentalConcurrentCommitment = true
-		statecfg.ExperimentalConcurrentCommitment = true
+		cfg.ExperimentalConcurrentCommitment = true
 	}
 
 	cfg.FcuTimeout = ctx.Duration(FcuTimeoutFlag.Name)

--- a/node/cli/flags.go
+++ b/node/cli/flags.go
@@ -234,7 +234,23 @@ var (
 	}
 )
 
+// BuildEthConfig applies all CLI flags to the ethconfig.Config. This is the single
+// entry point for flag-to-config mapping — it calls utils.SetEthConfig internally
+// and then applies the remaining flags defined in this package.
+//
+// After this function returns, the config is fully populated from CLI flags.
+func BuildEthConfig(ctx *cli.Context, nodeCfg *nodecfg.Config, cfg *ethconfig.Config, logger log.Logger) {
+	utils.SetEthConfig(ctx, nodeCfg, cfg, logger)
+	applyRemainingEthFlags(ctx, cfg, logger)
+}
+
+// ApplyFlagsForEthConfig is kept for backward compatibility. New code should use BuildEthConfig.
+// Deprecated: use BuildEthConfig instead.
 func ApplyFlagsForEthConfig(ctx *cli.Context, cfg *ethconfig.Config, logger log.Logger) {
+	applyRemainingEthFlags(ctx, cfg, logger)
+}
+
+func applyRemainingEthFlags(ctx *cli.Context, cfg *ethconfig.Config, logger log.Logger) {
 	chainId := cfg.NetworkID
 	if cfg.Genesis != nil {
 		chainId = cfg.Genesis.Config.ChainID.Uint64()

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -305,6 +305,16 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 		if err := checkAndSetCommitmentHistoryFlag(tx, logger, dirs, config); err != nil {
 			return err
 		}
+
+		// Apply config-driven global state for the commitment and trie subsystems.
+		// These globals are read by 80+ call sites; the config fields are the source of truth.
+		if config.KeepExecutionProofs {
+			statecfg.EnableHistoricalCommitment()
+		}
+		if config.ExperimentalConcurrentCommitment {
+			statecfg.ExperimentalConcurrentCommitment = true
+		}
+
 		if err = stages.UpdateMetrics(tx); err != nil {
 			return err
 		}

--- a/node/ethconfig/config.go
+++ b/node/ethconfig/config.go
@@ -280,10 +280,11 @@ type Sync struct {
 	LoopBlockLimit             uint
 	ParallelStateFlushing      bool
 
-	ChaosMonkey              bool
-	AlwaysGenerateChangesets bool
-	MaxReorgDepth            uint64
-	KeepExecutionProofs      bool
-	PersistReceiptsCacheV2   bool
-	SnapshotDownloadToBlock  uint64 // exclusive [0,toBlock)
+	ChaosMonkey                      bool
+	AlwaysGenerateChangesets         bool
+	MaxReorgDepth                    uint64
+	KeepExecutionProofs              bool
+	ExperimentalConcurrentCommitment bool
+	PersistReceiptsCacheV2           bool
+	SnapshotDownloadToBlock          uint64 // exclusive [0,toBlock)
 }


### PR DESCRIPTION
## Summary

First step in the componentization series. Removes global side effects from flag
parsing and consolidates config construction:

- **Config snapshot tests**: adds golden-file tests that capture the exact
  `EthConfig` produced by flag combinations, preventing accidental regressions
  as config wiring is refactored.

- **statecfg globals → config fields**: moves `statecfg.OverridePragueTime` and
  similar package-level variables into `EthConfig` fields, eliminating
  init-order-dependent side effects during flag reading.

- **BuildEthConfig consolidation**: introduces a single entry point for building
  `EthConfig` from CLI flags, replacing scattered calls across node setup.

These are safe, incremental refactors — no behavior changes, no new features.
Foundation for subsequent component extraction PRs.

## Test plan

- [x] `make lint` clean
- [x] `make erigon integration` builds
- [x] Config snapshot tests pass
- [ ] CI passes