### PR TITLE
Reduce impact of synchronized aggregation across fleet nodes

### DIFF
--- a/common/dbg/experiments.go
+++ b/common/dbg/experiments.go
@@ -85,6 +85,8 @@ var (
 	MergeWorkers         = EnvInt("MERGE_WORKERS", 1)
 	CollateWorkers       = EnvInt("COLLATE_WORKERS", 2)
 
+	AggregationDelayMs = EnvInt("AGGREGATION_DELAY_MS", 0)
+
 	TraceAccounts         = EnvStrings("TRACE_ACCOUNTS", ",", nil)
 	TraceStateKeys        = EnvStrings("TRACE_STATE_KEYS", ",", nil)
 	TraceInstructions     = EnvBool("TRACE_INSTRUCTIONS", false)

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -1796,6 +1796,26 @@ func (a *Aggregator) buildFilesInBackground(txNum uint64, doMerge bool) chan str
 			lastIdInDB(a.db, a.d[kv.CommitmentDomain]))
 		a.logger.Info("BuildFilesInBackground", "step", step, "lastInDB", lastInDB)
 
+		// Stagger aggregation across fleet nodes to prevent synchronized I/O stalls.
+		// Set different values per node via AGGREGATION_DELAY_MS env var.
+		if dbg.AggregationDelayMs > 0 {
+			a.logger.Info("[snapshots] aggregation delay before build", "delay_ms", dbg.AggregationDelayMs)
+			timer := time.NewTimer(time.Duration(dbg.AggregationDelayMs) * time.Millisecond)
+			defer func() {
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+			}()
+			select {
+			case <-a.ctx.Done():
+				close(fin)
+				return
+			case <-timer.C:
+}
+
 		// check if db has enough data (maybe we didn't commit them yet or all keys are unique so history is empty)
 		hasData := lastInDB > step // `step` must be fully-written - means `step+1` records must be visible
 		if !hasData {

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -30,8 +31,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-
-	"math/rand"
 
 	"github.com/erigontech/erigon/db/kv/prune"
 
@@ -1814,7 +1813,8 @@ func (a *Aggregator) buildFilesInBackground(txNum uint64, doMerge bool) chan str
 				close(fin)
 				return
 			case <-timer.C:
-}
+			}
+		}
 
 		// check if db has enough data (maybe we didn't commit them yet or all keys are unique so history is empty)
 		hasData := lastInDB > step // `step` must be fully-written - means `step+1` records must be visible


### PR DESCRIPTION
## Reduce impact of synchronized aggregation across fleet nodes
 
### Problem
 
When running multiple Erigon nodes syncing the same chain, all nodes cross snapshot step boundaries at nearly the same time (within seconds of each other). This triggers `BuildFilesInBackground` simultaneously on every node, and the resulting aggregation I/O stalls block execution on all nodes at once.
 
In a load-balanced fleet this causes a total service outage — every backend falls behind the chain tip simultaneously, and the proxy has zero healthy backends to route traffic to.
 
### Real-world incident (April 7 2026)
 
We operate a 3-node fleet. After ~2 months of stable operation, all nodes hit aggregation step 2193 within 20 seconds of each other:
 
| Node | `BuildFilesInBackground step=2193` | Aggregation duration |
|------|-------------------------------------|---------------------|
| node-1 | 09:59:34 | 2m30s |
| node-2 | 09:59:28 | 2m29s |
| node-3 | 09:59:48 | still aggregating, was restarted |
 
During the aggregation, block execution throughput dropped from ~20 Mgas/s to ~1-5 Mgas/s. All nodes fell behind the chain tip. At 10:07:33 the fleet had **0 out of 3 healthy backends** for 60 seconds.
 
The aggregation step itself evicted ~16GB of page cache (RSS dropped from 48GB to 32GB on one node), starving block execution of I/O bandwidth.
 
Each node recovered on its own within 10-15 minutes, but the synchronized nature of the stall meant there was no healthy node to absorb traffic during the event.
 
### Root cause
 
`BuildFilesInBackground` is triggered when `txNum` crosses a step boundary. Since all nodes process the same chain in real time, they all cross the boundary on the same block. The trigger is deterministic — there is no jitter or per-node offset.
 
### Solution
 
Add a configurable delay (`ERIGON_AGGREGATION_DELAY_MS`, default 0) at the start of `BuildFilesInBackground`, before the build loop begins. This follows the same pattern as the existing `COMPRESS_WORKERS` env var in `common/dbg/experiments.go`.
 
Operators running multi-node fleets can set different values per node to desynchronize aggregation:
 
```
node-1: ERIGON_AGGREGATION_DELAY_MS=0
node-2: ERIGON_AGGREGATION_DELAY_MS=60000
node-3: ERIGON_AGGREGATION_DELAY_MS=120000
```
 
This guarantees at least 60 seconds between each node starting its aggregation, which would have completely prevented the 0/3 healthy window in the incident above. Single-node operators are unaffected (default is 0).
 

### Notes
 
- This is complementary to `COMPRESS_WORKERS` (PR #18995) which reduces I/O pressure *within* each aggregation step. This PR addresses the *timing* of when aggregation starts across nodes.
- No impact on single-node deployments or initial sync (default delay is 0).