### PR TITLE
execution: fix BAL header/blockIO mismatch in parallel executor

### DIFF
--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -389,7 +389,23 @@ func (pe *parallelExecutor) exec(ctx context.Context, execStage *StageState, u U
 							}
 
 							if pe.cfg.chainConfig.IsAmsterdam(applyResult.BlockTime) || pe.cfg.experimentalBAL {
-								err = ProcessBAL(rwTx, lastHeader, applyResult.TxIO, pe.cfg.chainConfig.IsAmsterdam(applyResult.BlockTime), pe.cfg.experimentalBAL, pe.cfg.dirs.DataDir)
+								// Use the blockResult's own header, not lastHeader, to
+								// ensure the BAL is validated against the correct block.
+								// lastHeader is only updated for non-partial results and
+								// may still point to the previous block's header when a
+								// partial result for the current block triggers a commit.
+								balHeader := applyResult.Header
+								if balHeader == nil {
+									balHeader = lastHeader
+								}
+								if balHeader != nil && balHeader.Number.Uint64() != applyResult.BlockNum {
+									pe.logger.Warn("BAL header/blockNum mismatch",
+										"headerNum", balHeader.Number.Uint64(),
+										"applyBlockNum", applyResult.BlockNum,
+										"isPartial", applyResult.isPartial,
+										"applyBlockHash", applyResult.BlockHash)
+								}
+								err = ProcessBAL(rwTx, balHeader, applyResult.TxIO, pe.cfg.chainConfig.IsAmsterdam(applyResult.BlockTime), pe.cfg.experimentalBAL, pe.cfg.dirs.DataDir)
 								if err != nil {
 									return err
 								}


### PR DESCRIPTION
## Summary

- Fix BAL (Block Access List) validation using the wrong block's header during parallel execution
- When a partial `blockResult` triggers a commit, `lastHeader` still points to the **previous block's** header while `applyResult.TxIO` contains the **current block's** data. This causes `ProcessBAL` to validate the BAL against the wrong block, producing a hash mismatch.
- Use the `blockResult`'s own `Header` field instead of the shared `lastHeader` variable, with a debug warning when a mismatch is detected.

### Root cause

In `exec3_parallel.go`, `lastHeader` is only updated for non-partial block results (line 264: `!applyResult.isPartial`). However, `ProcessBAL` is called at commit boundaries which can be triggered by partial results. This means:

1. Block N completes → `lastHeader` = block N header
2. Block N+1 partial result arrives → `lastHeader` unchanged (still block N)
3. Commit triggered → `ProcessBAL(lastHeader[N], applyResult.TxIO[N+1])` → **mismatch**

Evidence from Kurtosis assertoor CI: the computed BAL for block 9 contained block 8's EIP-2935 system call data (slot 7 instead of slot 8), confirming the header/TxIO came from different blocks.

## Test plan

- [ ] Kurtosis Glamsterdam assertoor suite passes (dispatched on `yperbasis/glamsterdam-assertoor`: https://github.com/erigontech/erigon/actions/runs/24103243533)
- [ ] `make test-short` passes
- [ ] Verify debug warning does not fire under normal operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)