### PR TITLE
shutter: handle transient "block not found" in eon tracker

### DIFF
--- a/txnprovider/shutter/eon_tracker.go
+++ b/txnprovider/shutter/eon_tracker.go
@@ -21,6 +21,7 @@ package shutter
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -174,6 +175,12 @@ func (et *KsmEonTracker) handleBlockEvent(blockEvent BlockEvent) error {
 	blockNum := blockEvent.LatestBlockNum
 	eon, ok, err := et.readEonAtNewBlockEvent(blockNum)
 	if err != nil {
+		// "block not found" is transient: the block event arrives from state changes
+		// before the block is visible to eth_call. Retry on the next block event.
+		if strings.Contains(err.Error(), "block not found") {
+			et.logger.Warn("block not yet available for eon read, will retry on next block event", "blockNum", blockNum)
+			return nil
+		}
 		return fmt.Errorf("read eon at block event (blockNum=%d): %w", blockNum, err)
 	}
 	if !ok {


### PR DESCRIPTION
## Summary
- The shutter pool's eon tracker fatally crashes when a block event arrives before the block is visible to `eth_call`, causing a "block not found" error that propagates through the errgroup and stops the entire pool
- Treat "block not found" as a non-fatal transient error: log a warning and continue, retrying on the next block event
- Fixes flaky `TestShutterBlockBuilding` failure observed on macOS CI ([run](https://github.com/erigontech/erigon/actions/runs/24101141399/job/70312481130))

## Root cause
Caused by #20195, which changed notification dispatch to fire **before** the DB commit (previously notifications arrived after commit). This creates a window where the shutter pool's `BlockListener` receives a block event via state changes, but `eth_call` at that block number fails with `BlockNotFoundErr` because the block isn't committed yet.

The error propagated fatally through the errgroup chain:

`readEonAtNewBlockEvent` → `handleBlockEvent` → `trackCurrentEon` → Pool errgroup cancel → `stopped.Store(true)` → all `ProvideTxns` calls fall back to base txn provider (no shutter txns)

## Test plan
- [x] `TestShutterBlockBuilding` passes consistently (3/3 runs)
- [ ] CI passes on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)