### PR TITLE
rpc: fix race between overlay publish and state change consumers

### DIFF
--- a/rpc/rpchelper/filters.go
+++ b/rpc/rpchelper/filters.go
@@ -71,10 +71,11 @@ type Filters struct {
 	pendingTxsStores   *concurrent.SyncMap[PendingTxsSubID, [][]types.Transaction]
 	logger             log.Logger
 
-	// latestSD holds the most recent SharedDomains published via Events.
-	// Used by in-process RPC handlers to read uncommitted block/state data.
+	// latestSD is the local fallback for the most recent SharedDomains.
 	// When events is non-nil (embedded mode), LatestSD() reads directly from
 	// Events.LatestSD() which is updated synchronously in PublishOverlay.
+	// When events is nil (remote mode), latestSD is not populated and
+	// LatestSD() returns nil — remote rpcdaemons do not use the overlay.
 	latestSD atomic.Pointer[execctx.SharedDomains]
 	events   *shards.Events
 


### PR DESCRIPTION
## Summary
- Fix a race condition introduced by #20195 where `Filters.LatestSD()` could return nil even though the overlay had already been published
- In embedded mode, `Filters.LatestSD()` now reads directly from the synchronous `Events.LatestSD()` atomic, eliminating the channel delay
- Root cause of the flaky `TestShutterBlockBuilding` on macOS CI ([run](https://github.com/erigontech/erigon/actions/runs/24101141399/job/70312481130))

## Root cause
`Events.PublishOverlay(sd)` does two things:
1. `e.latestSD.Store(sd)` — **synchronous** atomic store
2. Sends `sd` to subscription channels — **asynchronous** non-blocking sends

`Filters` had a goroutine reading from one of these subscription channels to update its own `ff.latestSD` copy. State change consumers (e.g. shutter's eon tracker) received notifications through a *different* channel from `Dispatch()`. There was **no ordering guarantee** between the two goroutine consumers — the eon tracker could receive a block event and call `eth_call` before the Filters goroutine had processed the overlay, resulting in "block not found" for a block that only existed in the uncommitted overlay.

## Fix
- Store a reference to `Events` in `Filters`
- `LatestSD()` delegates to `Events.LatestSD()` in embedded mode (direct atomic read, no channel)
- Remove the overlay subscription goroutine (no longer needed)
- `WithOverlay()` / `WithTemporalOverlay()` now go through `LatestSD()` for consistency

Since `PublishOverlay` updates `Events.latestSD` **before** `Dispatch` sends notifications, the overlay is guaranteed to be visible to any `eth_call` triggered by a state change consumer.

Companion to #20398 which adds a safety-net for `BlockNotFoundErr` in the shutter eon tracker.

## Test plan
- [x] `TestShutterBlockBuilding` passes (3/3 runs)
- [x] Full build passes
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)