### PR TITLE
[r3.4] cl/services: wrap attestation propagation range error with ErrIgnore

### DIFF
--- a/cl/phase1/network/services/attestation_service.go
+++ b/cl/phase1/network/services/attestation_service.go
@@ -182,7 +182,7 @@ func (s *attestationService) ProcessMessage(ctx context.Context, subnet *uint64,
 	// i.e. attestation.data.slot + ATTESTATION_PROPAGATION_SLOT_RANGE >= current_slot >= attestation.data.slot (a client MAY queue future attestations for processing at the appropriate slot).
 	currentSlot := s.ethClock.GetCurrentSlot()
 	if currentSlot < slot || currentSlot > slot+s.netCfg.AttestationPropagationSlotRange {
-		return fmt.Errorf("not in propagation range")
+		return fmt.Errorf("not in propagation range: %w", ErrIgnore)
 	}
 	// [REJECT] The attestation's epoch matches its target -- i.e. attestation.data.target.epoch == compute_epoch_at_slot(attestation.data.slot)
 	if targetEpoch != slot/s.beaconCfg.SlotsPerEpoch {


### PR DESCRIPTION
## Summary
- Wrap "not in propagation range" error with `ErrIgnore` in attestation service, aligning with main branch behavior
- Without this fix, GossipManager incorrectly rejects (and potentially bans) peers for out-of-range attestations, instead of ignoring them as the spec requires (`[IGNORE]`)

## Test plan
- [ ] Verify `make lint` passes
- [ ] Verify node no longer logs `[WARN] reject message` for out-of-propagation-range attestations — should silently ignore instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)