### PR TITLE
execution/abi: fix encoding of negative *big.Int in MakeTopics

### DIFF
--- a/execution/abi/topics.go
+++ b/execution/abi/topics.go
@@ -29,6 +29,7 @@ import (
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/crypto"
 	"github.com/erigontech/erigon/common/length"
+	"github.com/erigontech/erigon/common/math"
 )
 
 // MakeTopics converts a filter query argument list into a filter topic set.
@@ -45,8 +46,7 @@ func MakeTopics(query ...[]any) ([][]common.Hash, error) {
 			case common.Address:
 				copy(topic[length.Hash-length.Addr:], rule[:])
 			case *big.Int:
-				blob := rule.Bytes()
-				copy(topic[length.Hash-len(blob):], blob)
+				copy(topic[:], math.U256Bytes(new(big.Int).Set(rule)))
 			case bool:
 				if rule {
 					topic[length.Hash-1] = 1

--- a/execution/abi/topics_test.go
+++ b/execution/abi/topics_test.go
@@ -63,6 +63,12 @@ func TestMakeTopics(t *testing.T) {
 			false,
 		},
 		{
+			"support negative *big.Int types in topics",
+			args{[][]any{{big.NewInt(-1)}}},
+			[][]common.Hash{{common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")}},
+			false,
+		},
+		{
 			"support boolean types in topics",
 			args{[][]any{
 				{true},


### PR DESCRIPTION
## Summary
- Fix `MakeTopics` to correctly encode negative `*big.Int` values using two's complement (`math.U256Bytes`) instead of `big.Int.Bytes()` which returns the absolute value and drops the sign
- Add test case for `big.NewInt(-1)` → `0xFFFF...FFFF`

Fixes erigontech/security#6

## Test plan
- [x] `go test ./execution/abi/...` passes, including new negative `*big.Int` test case
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)