### PR TITLE
execution/execmodule: test EIP-7708 burn log when coinbase self-destructs

### DIFF
--- a/execution/execmodule/exec_module_test.go
+++ b/execution/execmodule/exec_module_test.go
@@ -1221,15 +1221,21 @@ func TestEIP7708BurnLogWhenCoinbaseSelfDestructs(t *testing.T) {
 	require.Greater(t, receipt.GasUsed, uint64(0))
 
 	var burnLog *types.Log
+	var burnCount, transferCount int
 	for _, log := range receipt.Logs {
-		if log.Address == params.SystemAddress.Value() &&
-			len(log.Topics) >= 2 &&
-			log.Topics[0] == misc.EthBurnLogEvent {
+		if log.Address != params.SystemAddress.Value() || len(log.Topics) < 2 {
+			continue
+		}
+		switch log.Topics[0] {
+		case misc.EthBurnLogEvent:
 			burnLog = log
-			break
+			burnCount++
+		case misc.EthTransferLogEvent:
+			transferCount++
 		}
 	}
-	require.NotNil(t, burnLog, "expected EIP-7708 Burn log for selfdestructed coinbase")
+	require.Equal(t, 1, burnCount, "expected exactly one EIP-7708 Burn log")
+	require.Equal(t, 0, transferCount, "no Transfer log expected for zero-value CREATE")
 	require.Equal(t, coinbaseAddr.Hash(), burnLog.Topics[1],
 		"burn log should reference the coinbase address")
 


### PR DESCRIPTION
## Summary
- Adds a regression test for #19951: verifies EIP-7708 burn logs are emitted when the coinbase is a contract that self-destructs during execution
- The test pre-computes the CREATE address, sets it as coinbase, deploys a 2-byte contract (`CALLER SELFDESTRUCT`), then asserts the receipt contains the correct Burn log and the state root validates
- Establishes a baseline that the parallel executor's `finalizeTx` direct path must also match when enabled

## N.B.
Should be already covered by https://github.com/ethereum/execution-specs/pull/2106, but adding a block builder test for completness.