### PR TITLE
ci: skip TestExecutionSpecBlockchainDevnet on macOS (too slow)

### DIFF
--- a/execution/tests/eest_devnet/block_test.go
+++ b/execution/tests/eest_devnet/block_test.go
@@ -33,9 +33,9 @@ func TestExecutionSpecBlockchainDevnet(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
 		// TODO(yperbasis, mh0lt)
-		t.Skip("fix me on windows please")
+		t.Skip("fix me on windows/macOS please")
 	}
 
 	t.Parallel()


### PR DESCRIPTION
`TestExecutionSpecBlockchainDevnet` became [too slow](https://github.com/erigontech/erigon/actions/runs/24136363754/job/70425455944) on macOS after PR #20290, blocking the [merge queue](https://github.com/erigontech/erigon/queue/main).