### PR TITLE
rpc: return -32602 when eth_getLogs exceeds block range limit

### DIFF
--- a/rpc/jsonrpc/erigon_receipts_test.go
+++ b/rpc/jsonrpc/erigon_receipts_test.go
@@ -266,6 +266,24 @@ func TestGetLogs_MaxResultsOk(t *testing.T) {
 	assert.NotEmpty(t, logs)
 }
 
+// TestGetLogs_MaxResultsExceeded verifies that eth_getLogs returns invalid params
+// when the matching log count exceeds maxResults.
+func TestGetLogs_MaxResultsExceeded(t *testing.T) {
+	m, _, contractAddr, _ := chainWithDeployedContract(t)
+	ethApi := newEthApiForTest(newBaseApiWithLimits(m, 0, 1), m.DB, nil, nil)
+	_, err := ethApi.GetLogs(context.Background(), filters.FilterCriteria{
+		FromBlock: big.NewInt(0),
+		ToBlock:   big.NewInt(rpc.LatestBlockNumber.Int64()),
+		Addresses: common.Addresses{contractAddr},
+	})
+	require.Error(t, err)
+
+	var rpcErr rpc.Error
+	require.ErrorAs(t, err, &rpcErr)
+	assert.Equal(t, rpc.ErrCodeInvalidParams, rpcErr.ErrorCode())
+	assert.Equal(t, errExceedLogResults+": 1", rpcErr.Error())
+}
+
 // TestGetLatestLogs_LogCountExceedsMaxResults verifies that erigon_getLatestLogs
 // returns an error when the requested logCount exceeds getLogsMaxResults.
 func TestGetLatestLogs_LogCountExceedsMaxResults(t *testing.T) {

--- a/rpc/jsonrpc/erigon_receipts_test.go
+++ b/rpc/jsonrpc/erigon_receipts_test.go
@@ -233,7 +233,11 @@ func TestGetLogs_RangeLimitExceeded(t *testing.T) {
 		ToBlock:   big.NewInt(10),
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), errExceedBlockRange)
+
+	var rpcErr rpc.Error
+	require.ErrorAs(t, err, &rpcErr)
+	assert.Equal(t, rpc.ErrCodeInvalidParams, rpcErr.ErrorCode())
+	assert.Equal(t, errExceedBlockRange+": 5", rpcErr.Error())
 }
 
 // TestGetLogs_RangeLimitOk verifies that eth_getLogs succeeds when the requested block

--- a/rpc/jsonrpc/eth_receipts.go
+++ b/rpc/jsonrpc/eth_receipts.go
@@ -361,7 +361,9 @@ func (api *BaseAPI) getLogsV3(ctx context.Context, tx kv.TemporalTx, begin, end 
 
 				for _, filteredLog := range borLogs {
 					if maxResults != 0 && len(logs) >= maxResults {
-						return nil, fmt.Errorf("%s: %d", errExceedLogResults, maxResults)
+						return nil, &rpc.InvalidParamsError{
+							Message: fmt.Sprintf("%s: %d", errExceedLogResults, maxResults),
+						}
 					}
 					logs = append(logs, &types.ErigonLog{
 						Log:       *filteredLog,
@@ -393,7 +395,9 @@ func (api *BaseAPI) getLogsV3(ctx context.Context, tx kv.TemporalTx, begin, end 
 
 		for _, filteredLog := range filtered {
 			if maxResults != 0 && len(logs) >= maxResults {
-				return nil, fmt.Errorf("%s: %d", errExceedLogResults, maxResults)
+				return nil, &rpc.InvalidParamsError{
+					Message: fmt.Sprintf("%s: %d", errExceedLogResults, maxResults),
+				}
 			}
 			logs = append(logs, &types.ErigonLog{
 				Log:       *filteredLog,

--- a/rpc/jsonrpc/eth_receipts.go
+++ b/rpc/jsonrpc/eth_receipts.go
@@ -286,8 +286,12 @@ func applyFiltersV3(txNumsReader rawdbv3.TxNumsReader, tx kv.TemporalTx, begin, 
 func (api *BaseAPI) getLogsV3(ctx context.Context, tx kv.TemporalTx, begin, end uint64, crit filters.FilterCriteria, rangeLimit int, maxResults int) ([]*types.ErigonLog, error) {
 	logs := []*types.ErigonLog{} //nolint
 
+	// Treat range-limit violations as invalid filter input to match eth_getLogs parameter validation.
 	if rangeLimit != 0 && (end-begin) > uint64(rangeLimit) {
-		return nil, fmt.Errorf("%s: %d", errExceedBlockRange, rangeLimit)
+		return nil, &rpc.CustomError{
+			Message: fmt.Sprintf("%s: %d", errExceedBlockRange, rangeLimit),
+			Code:    rpc.ErrCodeInvalidParams,
+		}
 	}
 
 	addrMap := make(map[common.Address]struct{}, len(crit.Addresses))

--- a/rpc/jsonrpc/eth_receipts.go
+++ b/rpc/jsonrpc/eth_receipts.go
@@ -288,9 +288,8 @@ func (api *BaseAPI) getLogsV3(ctx context.Context, tx kv.TemporalTx, begin, end 
 
 	// Treat range-limit violations as invalid filter input to match eth_getLogs parameter validation.
 	if rangeLimit != 0 && (end-begin) > uint64(rangeLimit) {
-		return nil, &rpc.CustomError{
+		return nil, &rpc.InvalidParamsError{
 			Message: fmt.Sprintf("%s: %d", errExceedBlockRange, rangeLimit),
-			Code:    rpc.ErrCodeInvalidParams,
 		}
 	}
 


### PR DESCRIPTION
This PR updates `eth_getLogs` so that when the requested block range is larger than the configured range limit, Erigon returns `-32602 `(`invalid params`) instead of `-32000` (`server error`). This makes the behavior consistent with the other parameter validation errors already used in the same `eth_getLogs` flow and aligns Erigon with other clients such as Reth.

The change is implemented in `getLogsV3` by returning an RPC invalid-params error for the block range limit check, while keeping the existing error message format unchanged. The related test was also updated to verify the exact RPC behavior, including that the returned error code is `-32602` and that the message remains `query block range exceeds server limit, narrow your filter: 5.`


