### PR TITLE
execution/types/stateless: reject empty witness headers during decode

### DIFF
--- a/execution/types/stateless/encoding.go
+++ b/execution/types/stateless/encoding.go
@@ -17,6 +17,7 @@
 package stateless
 
 import (
+	"errors"
 	"io"
 
 	"github.com/erigontech/erigon/execution/rlp"
@@ -41,6 +42,9 @@ func (w *Witness) toExtWitness() *extWitness {
 
 // fromExtWitness converts the consensus witness format into our internal one.
 func (w *Witness) fromExtWitness(ext *extWitness) error {
+	if len(ext.Headers) == 0 {
+		return errors.New("witness must contain at least one header")
+	}
 	w.context = ext.Context
 	w.Headers = ext.Headers
 	w.State = make(map[string]struct{}, len(ext.State))

--- a/execution/types/stateless/witness.go
+++ b/execution/types/stateless/witness.go
@@ -84,16 +84,17 @@ type Witness struct {
 
 // NewWitness creates an empty witness ready for population.
 func NewWitness(context *types.Header, chain HeaderReader) (*Witness, error) {
+	if chain == nil {
+		return nil, errors.New("header reader is required")
+	}
 	// When building witnesses, retrieve the parent header, which will *always*
 	// be included to act as a trustless pre-root hash container
 	var headers []*types.Header
-	if chain != nil {
-		parent := chain.GetHeader(context.ParentHash, context.Number.Uint64()-1)
-		if parent == nil {
-			return nil, errors.New("failed to retrieve parent header")
-		}
-		headers = append(headers, parent)
+	parent := chain.GetHeader(context.ParentHash, context.Number.Uint64()-1)
+	if parent == nil {
+		return nil, errors.New("failed to retrieve parent header")
 	}
+	headers = append(headers, parent)
 	// Create the wtness with a reconstructed gutted out block
 	return &Witness{
 		context: context,

--- a/execution/types/stateless/witness.go
+++ b/execution/types/stateless/witness.go
@@ -89,7 +89,7 @@ func NewWitness(context *types.Header, chain HeaderReader) (*Witness, error) {
 	}
 	// When building witnesses, retrieve the parent header, which will *always*
 	// be included to act as a trustless pre-root hash container
-	var headers []*types.Header
+	headers := make([]*types.Header, 0, 1)
 	parent := chain.GetHeader(context.ParentHash, context.Number.Uint64()-1)
 	if parent == nil {
 		return nil, errors.New("failed to retrieve parent header")

--- a/execution/types/stateless/witness_test.go
+++ b/execution/types/stateless/witness_test.go
@@ -259,6 +259,13 @@ func TestValidateWitnessPreState_MultipleHeaders(t *testing.T) {
 	}
 }
 
+func TestNewWitnessRequiresHeaderReader(t *testing.T) {
+	_, err := NewWitness(&types.Header{Number: *uint256.NewInt(1)}, nil)
+	if err == nil || err.Error() != "header reader is required" {
+		t.Fatalf("expected missing header reader error, got %v", err)
+	}
+}
+
 func TestWitnessDecodeRLPRequiresHeader(t *testing.T) {
 	var witness Witness
 	payload, err := rlp.EncodeToBytes(&extWitness{

--- a/execution/types/stateless/witness_test.go
+++ b/execution/types/stateless/witness_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/holiman/uint256"
 
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/rlp"
 	"github.com/erigontech/erigon/execution/types"
 )
 
@@ -255,5 +256,22 @@ func TestValidateWitnessPreState_MultipleHeaders(t *testing.T) {
 	err := ValidateWitnessPreState(witness, mockReader)
 	if err != nil {
 		t.Errorf("Expected validation to succeed with multiple headers, but got error: %v", err)
+	}
+}
+
+func TestWitnessDecodeRLPRequiresHeader(t *testing.T) {
+	var witness Witness
+	payload, err := rlp.EncodeToBytes(&extWitness{
+		Context: &types.Header{},
+		Headers: []*types.Header{},
+		State:   [][]byte{},
+	})
+	if err != nil {
+		t.Fatalf("EncodeToBytes: %v", err)
+	}
+
+	err = rlp.DecodeBytes(payload, &witness)
+	if err == nil || err.Error() != "witness must contain at least one header" {
+		t.Fatalf("expected missing-header error, got %v", err)
 	}
 }

--- a/p2p/sentry/sentry_multi_client/witness_test.go
+++ b/p2p/sentry/sentry_multi_client/witness_test.go
@@ -27,6 +27,24 @@ import (
 	"github.com/erigontech/erigon/p2p/protocols/wit"
 )
 
+type mockHeaderReader struct {
+	headers map[common.Hash]*types.Header
+}
+
+func newMockHeaderReader() *mockHeaderReader {
+	return &mockHeaderReader{
+		headers: make(map[common.Hash]*types.Header),
+	}
+}
+
+func (m *mockHeaderReader) GetHeader(hash common.Hash, number uint64) *types.Header {
+	return m.headers[hash]
+}
+
+func (m *mockHeaderReader) addHeader(header *types.Header) {
+	m.headers[header.Hash()] = header
+}
+
 func addTestWitnessData(db kv.TemporalRwDB, hash common.Hash, witnessData []byte, blockNumber uint64) error {
 	tx, err := db.BeginRw(context.Background())
 	if err != nil {
@@ -72,7 +90,16 @@ func addTestWitnessData(db kv.TemporalRwDB, hash common.Hash, witnessData []byte
 func createTestWitness(t *testing.T, header *types.Header) *stateless.Witness {
 	t.Helper()
 
-	witness, err := stateless.NewWitness(header, nil)
+	parentHeader := &types.Header{
+		Number: *uint256.NewInt(header.Number.Uint64() - 1),
+		Root:   common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"),
+	}
+	header.ParentHash = parentHeader.Hash()
+
+	headerReader := newMockHeaderReader()
+	headerReader.addHeader(parentHeader)
+
+	witness, err := stateless.NewWitness(header, headerReader)
 	require.NoError(t, err)
 
 	testState := map[string]struct{}{


### PR DESCRIPTION
This fixes a crash path when decoding an empty stateless witness. Some downstream witness logic assumes at least one header is present and may access `Headers[0]`, so accepting an empty witness can lead to a panic later. The change adds a small validation in `fromExtWitness` to reject witnesses with no headers during decode, and includes a regression test for the RLP decode path. 