### PR TITLE
[r3.4] etl: munmap temp files in Dispose to prevent disk space leak

### DIFF
--- a/db/etl/collector.go
+++ b/db/etl/collector.go
@@ -173,7 +173,6 @@ func (c *Collector) Load(db kv.RwTx, toBucket string, loadFunc LoadFunc, args Tr
 	if c.buf == nil && c.allocator != nil {
 		c.buf = c.allocator.Get()
 	}
-	defer c.Close()
 	args.BufferType = c.bufType
 
 	if !c.allFlushed {

--- a/db/etl/dataprovider.go
+++ b/db/etl/dataprovider.go
@@ -219,15 +219,17 @@ func (p *fileDataProvider) Dispose() {
 
 	p.Wait()
 
+	if p.mmapData != nil {
+		_ = mmap.Munmap(p.mmapData, p.mmapHandle2)
+		p.mmapData = nil
+		p.mmapHandle2 = nil
+		p.mmapReader = nil
+	}
+
 	filePath := p.file.Name()
 	p.file.Close()
 	p.file = nil
 	_ = dir.RemoveFile(filePath)
-
-	// Note: We intentionally do NOT munmap here. The mmap'd memory remains mapped
-	// and valid for zero-copy slices returned to callers. The OS will unmap when
-	// the process exits or memory pressure requires it. This is safe for the ETL
-	// use case where data is consumed immediately before Close() is called.
 }
 
 func (p *fileDataProvider) String() string {

--- a/db/etl/etl_test.go
+++ b/db/etl/etl_test.go
@@ -485,6 +485,7 @@ func TestReuseCollectorAfterLoad(t *testing.T) {
 	}, TransformArgs{})
 	require.NoError(t, err)
 	require.Equal(t, 1, see)
+	c.Close()
 
 	// buffers are not lost
 	require.Empty(t, buf.data)
@@ -500,6 +501,7 @@ func TestReuseCollectorAfterLoad(t *testing.T) {
 	}, TransformArgs{})
 	require.NoError(t, err)
 	require.Equal(t, 0, see)
+	c.Close()
 
 	// reuse
 	see = 0
@@ -509,6 +511,7 @@ func TestReuseCollectorAfterLoad(t *testing.T) {
 	}, TransformArgs{})
 	require.NoError(t, err)
 	require.Equal(t, 0, see)
+	c.Close()
 
 	err = c.Collect([]byte{3}, []byte{4})
 	require.NoError(t, err)
@@ -708,8 +711,8 @@ func TestSortable(t *testing.T) {
 
 	keys, vals := [][]byte{}, [][]byte{}
 	require.NoError(collector.Load(nil, "", func(k, v []byte, table CurrentTableReader, next LoadNextFunc) error {
-		keys = append(keys, bytes.Clone(k))
-		vals = append(vals, bytes.Clone(v))
+		keys = append(keys, k)
+		vals = append(vals, v)
 		return nil
 	}, TransformArgs{}))
 

--- a/db/etl/etl_test.go
+++ b/db/etl/etl_test.go
@@ -708,8 +708,8 @@ func TestSortable(t *testing.T) {
 
 	keys, vals := [][]byte{}, [][]byte{}
 	require.NoError(collector.Load(nil, "", func(k, v []byte, table CurrentTableReader, next LoadNextFunc) error {
-		keys = append(keys, k)
-		vals = append(vals, v)
+		keys = append(keys, bytes.Clone(k))
+		vals = append(vals, bytes.Clone(v))
 		return nil
 	}, TransformArgs{}))
 

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -613,10 +613,10 @@ func (d *Domain) dumpStepRangeOnDisk(ctx context.Context, stepFrom, stepTo kv.St
 	if err != nil {
 		return err
 	}
-	wal.Close()
 
 	ps := background.NewProgressSet()
 	static, err := d.buildFileRange(ctx, stepFrom, stepTo, coll, ps)
+	wal.Close() // munmap ETL temp files after buildFileRange consumed the zero-copy data
 	if err != nil {
 		return err
 	}

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -669,7 +669,7 @@ func (d *Domain) collateETL(ctx context.Context, stepFrom, stepTo kv.Step, wal *
 		if d.LargeValues {
 			kvs = append(kvs, struct {
 				k, v []byte
-			}{bytes.Clone(k[:len(k)-8]), bytes.Clone(v)})
+			}{k[:len(k)-8], v})
 		} else {
 
 			if vt != nil {

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -669,7 +669,7 @@ func (d *Domain) collateETL(ctx context.Context, stepFrom, stepTo kv.Step, wal *
 		if d.LargeValues {
 			kvs = append(kvs, struct {
 				k, v []byte
-			}{k[:len(k)-8], v})
+			}{bytes.Clone(k[:len(k)-8]), bytes.Clone(v)})
 		} else {
 
 			if vt != nil {


### PR DESCRIPTION
ETL's zero-copy mmap optimization (March 2026) skipped `munmap` in `Dispose()`, keeping disk blocks allocated for deleted temp files until process exit. On long-running `stage_exec`, 111k+ deleted-but-mmap'd sortable-buf files accumulated **2.8TB** of phantom disk space (`df` vs `du` gap), causing ENOSPC.

- Add `mmap.Munmap()` in `Dispose()` before file close/delete
- Remove `defer c.Close()` from `Load()` — callers already have `defer collector.Close()` (enforced by `closeCollector` ruleguard rule in `rules.go`) -- it can help avoid using `bytes.Clone` when some bytes are used temporarily after Load.
  - e.g: Move `wal.Close()` after `buildFileRange` in domain collation so zero-copy mmap slices stay valid during kvs sort/write — no `bytes.Clone` needed
- analyzed the callsites and we should not have any munmapped bytes accessed; but if we do, it'll fail fast and report it.

## Test plan
- [x] `go test -short ./db/etl/` — all pass including `TestSortable` and `TestReuseCollectorAfterLoad`
- [x] `make lint` — 0 issues
- [x] `make erigon integration` — builds clean
- [x] Deploy and verify `grep -c 'sortable-buf.*deleted' /proc/<pid>/maps` stays near 0; no premature "out of disk" errors; no sigfaults due to munmap bytes access