### PR TITLE
rpc: WebSocket overload protection

### DIFF
--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -132,6 +132,7 @@ func RootCommand() (*cobra.Command, *httpcfg.HttpCfg) {
 	rootCmd.PersistentFlags().BoolVar(&cfg.DebugSingleRequest, utils.HTTPDebugSingleFlag.Name, false, utils.HTTPDebugSingleFlag.Usage)
 	rootCmd.PersistentFlags().IntVar(&cfg.DBReadConcurrency, utils.DBReadConcurrencyFlag.Name, utils.DBReadConcurrencyFlag.Value, utils.DBReadConcurrencyFlag.Usage)
 	rootCmd.PersistentFlags().IntVar(&cfg.RpcMaxConcurrentRequests, utils.RpcMaxConcurrentRequestsFlag.Name, utils.RpcMaxConcurrentRequestsFlag.Value, utils.RpcMaxConcurrentRequestsFlag.Usage)
+	rootCmd.PersistentFlags().IntVar(&cfg.WsMaxConnections, utils.WsMaxConnectionsFlag.Name, utils.WsMaxConnectionsFlag.Value, utils.WsMaxConnectionsFlag.Usage)
 	rootCmd.PersistentFlags().BoolVar(&cfg.TraceCompatibility, "trace.compat", false, "Bug for bug compatibility with OE for trace_ routines")
 	rootCmd.PersistentFlags().BoolVar(&cfg.GethCompatibility, "rpc.gethcompat", false, "Enables Geth-compatible storage iteration order for debug_storageRangeAt (sorted by keccak256 hash). Disabled by default for performance.")
 	rootCmd.PersistentFlags().StringVar(&cfg.TxPoolApiAddr, "txpool.api.addr", "", "txpool api network address, for example: 127.0.0.1:9090 (default: use value of --private.api.addr)")
@@ -772,7 +773,8 @@ func startRegularRpcServer(ctx context.Context, cfg *httpcfg.HttpCfg, rpcAPI []r
 	httpHandler := node.NewHTTPHandlerStack(srv, cfg.HttpCORSDomain, cfg.HttpVirtualHost, cfg.HttpCompression, rpcConcurrencyLimit, true)
 	var wsHandler http.Handler
 	if cfg.WebsocketEnabled {
-		wsHandler = srv.WebsocketHandler([]string{"*"}, nil, cfg.WebsocketCompression, logger)
+		wsHandler = node.NewWSConnectionLimiter(int64(cfg.WsMaxConnections),
+			srv.WebsocketHandler([]string{"*"}, nil, cfg.WebsocketCompression, logger))
 	}
 	graphQLHandler := graphql.CreateHandler(defaultAPIList)
 	apiHandler, err := createHandler(cfg, defaultAPIList, httpHandler, wsHandler, graphQLHandler, nil)

--- a/cmd/rpcdaemon/cli/httpcfg/http_cfg.go
+++ b/cmd/rpcdaemon/cli/httpcfg/http_cfg.go
@@ -73,6 +73,7 @@ type HttpCfg struct {
 	RpcFiltersConfig                  rpchelper.FiltersConfig
 	DBReadConcurrency                 int
 	RpcMaxConcurrentRequests          int  // HTTP admission control limit; -1 = unlimited
+	WsMaxConnections                  int  // WebSocket connection limit; 0 = unlimited
 	TraceCompatibility                bool // Bug for bug compatibility for trace_ routines with OpenEthereum
 	GethCompatibility                 bool // Geth-compatible storage iteration order for debug_storageRangeAt
 	TxPoolApiAddr                     string

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -413,6 +413,11 @@ var (
 		Usage: "Maximum number of concurrent HTTP RPC requests (HTTP admission control). 0 = use db.read.concurrency, -1 = unlimited (no admission control)",
 		Value: 0,
 	}
+	WsMaxConnectionsFlag = cli.IntFlag{
+		Name:  "ws.max.connections",
+		Usage: "Maximum number of concurrent WebSocket connections. 0 = unlimited",
+		Value: 0,
+	}
 	RpcAccessListFlag = cli.StringFlag{
 		Name:  "rpc.accessList",
 		Usage: "Specify granular (method-by-method) API allowlist",

--- a/node/cli/default_flags.go
+++ b/node/cli/default_flags.go
@@ -85,6 +85,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.RpcStreamingDisableFlag,
 	&utils.DBReadConcurrencyFlag,
 	&utils.RpcMaxConcurrentRequestsFlag,
+	&utils.WsMaxConnectionsFlag,
 	&utils.RpcAccessListFlag,
 	&utils.RpcTraceCompatFlag,
 	&utils.RpcGethCompatFlag,

--- a/node/cli/flags.go
+++ b/node/cli/flags.go
@@ -464,6 +464,7 @@ func setEmbeddedRpcDaemon(ctx *cli.Context, cfg *nodecfg.Config, logger log.Logg
 		RpcStreamingDisable:       ctx.Bool(utils.RpcStreamingDisableFlag.Name),
 		DBReadConcurrency:         ctx.Int(utils.DBReadConcurrencyFlag.Name),
 		RpcMaxConcurrentRequests:  ctx.Int(utils.RpcMaxConcurrentRequestsFlag.Name),
+		WsMaxConnections:          ctx.Int(utils.WsMaxConnectionsFlag.Name),
 		RpcAllowListFilePath:      ctx.String(utils.RpcAccessListFlag.Name),
 		RpcFiltersConfig: rpchelper.FiltersConfig{
 			RpcSubscriptionFiltersMaxLogs:      ctx.Int(RpcSubscriptionFiltersMaxLogsFlag.Name),

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -85,9 +85,9 @@ type httpServer struct {
 	httpHandler atomic.Value // *rpcHandler
 
 	// WebSocket handler things.
-	wsConfig    wsConfig
-	wsHandler   atomic.Value // *rpcHandler
-	wsConnCount atomic.Int64 // live WebSocket connections
+	wsConfig  wsConfig
+	wsHandler atomic.Value         // *rpcHandler
+	wsLimiter *wsConnectionLimiter // non-nil when WsConnectionLimit > 0
 
 	// These are set by setListenAddr.
 	endpoint string
@@ -207,19 +207,11 @@ func (h *httpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Note: WebSocket connections bypass rpcAdmissionHandler intentionally.
 	// HTTP admission control limits inflight requests, but WebSocket is a
 	// persistent long-lived connection where the relevant limit is the number
-	// of concurrent open connections. WsConnectionLimit enforces that here.
+	// of concurrent open connections. Connection limiting is enforced by the
+	// wsConnectionLimiter that wraps the handler when WsConnectionLimit > 0.
 	ws := h.wsHandler.Load().(*rpcHandler)
 	if ws != nil && isWebsocket(r) {
 		if checkPath(r, h.wsConfig.prefix) {
-			if h.wsConfig.WsConnectionLimit > 0 {
-				if h.wsConnCount.Add(1) > h.wsConfig.WsConnectionLimit {
-					h.wsConnCount.Add(-1)
-					wsConnectionRejected.Inc()
-					rpc.WriteOverloadedResponse(w)
-					return
-				}
-				defer h.wsConnCount.Add(-1)
-			}
 			ws.ServeHTTP(w, r)
 		}
 		return
@@ -336,8 +328,14 @@ func (h *httpServer) enableWS(apis []rpc.API, config wsConfig, allowList rpc.All
 		return err
 	}
 	h.wsConfig = config
+	var wsHandler http.Handler = srv.WebsocketHandler(config.Origins, nil, false, h.logger)
+	if config.WsConnectionLimit > 0 {
+		lim := &wsConnectionLimiter{limit: config.WsConnectionLimit, next: wsHandler}
+		h.wsLimiter = lim
+		wsHandler = lim
+	}
 	h.wsHandler.Store(&rpcHandler{
-		Handler: srv.WebsocketHandler(config.Origins, nil, false, h.logger),
+		Handler: wsHandler,
 		server:  srv,
 	})
 	return nil
@@ -349,6 +347,7 @@ func (h *httpServer) disableWS() bool {
 	if ws != nil {
 		h.wsHandler.Store((*rpcHandler)(nil))
 		ws.server.Stop()
+		h.wsLimiter = nil
 	}
 	return ws != nil
 }

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -59,6 +59,10 @@ type wsConfig struct {
 	Origins []string
 	Modules []string
 	prefix  string // path prefix on which to mount ws handler
+	// WsConnectionLimit is the maximum number of concurrent WebSocket connections.
+	// New connections beyond this limit receive an immediate 503 before the upgrade.
+	// 0 means unlimited.
+	WsConnectionLimit int64
 }
 
 type rpcHandler struct {
@@ -81,8 +85,9 @@ type httpServer struct {
 	httpHandler atomic.Value // *rpcHandler
 
 	// WebSocket handler things.
-	wsConfig  wsConfig
-	wsHandler atomic.Value // *rpcHandler
+	wsConfig    wsConfig
+	wsHandler   atomic.Value // *rpcHandler
+	wsConnCount atomic.Int64 // live WebSocket connections
 
 	// These are set by setListenAddr.
 	endpoint string
@@ -200,13 +205,21 @@ func (h *httpServer) start() error {
 func (h *httpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// check if ws request and serve if ws enabled
 	// Note: WebSocket connections bypass rpcAdmissionHandler intentionally.
-	// HTTP admission control limits inflight requests per connection, but WebSocket
-	// is a persistent long-lived connection where the relevant limit is the number
-	// of concurrent connections, not inflight requests. A dedicated WebSocket
-	// connection limiter will be addressed in a separate PR.
+	// HTTP admission control limits inflight requests, but WebSocket is a
+	// persistent long-lived connection where the relevant limit is the number
+	// of concurrent open connections. WsConnectionLimit enforces that here.
 	ws := h.wsHandler.Load().(*rpcHandler)
 	if ws != nil && isWebsocket(r) {
 		if checkPath(r, h.wsConfig.prefix) {
+			if h.wsConfig.WsConnectionLimit > 0 {
+				if h.wsConnCount.Add(1) > h.wsConfig.WsConnectionLimit {
+					h.wsConnCount.Add(-1)
+					wsConnectionRejected.Inc()
+					rpc.WriteOverloadedResponse(w)
+					return
+				}
+				defer h.wsConnCount.Add(-1)
+			}
 			ws.ServeHTTP(w, r)
 		}
 		return
@@ -381,6 +394,7 @@ type rpcAdmissionHandler struct {
 }
 
 var rpcAdmissionRejected = metrics.GetOrCreateCounter(`rpc_admission_rejected_total`)
+var wsConnectionRejected = metrics.GetOrCreateCounter(`ws_connection_rejected_total`)
 
 func newRPCAdmissionHandler(limit int64, next http.Handler) http.Handler {
 	return &rpcAdmissionHandler{limit: limit, next: next}
@@ -401,6 +415,33 @@ func (h *rpcAdmissionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		ctx = kv.WithNonBlockingAcquire(ctx)
 	}
 	h.next.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// NewWSConnectionLimiter wraps next so that at most limit concurrent WebSocket
+// connections are served. Connections beyond the limit receive HTTP 503. If
+// limit is 0, next is returned unwrapped.
+func NewWSConnectionLimiter(limit int64, next http.Handler) http.Handler {
+	if limit <= 0 {
+		return next
+	}
+	return &wsConnectionLimiter{limit: limit, next: next}
+}
+
+type wsConnectionLimiter struct {
+	count atomic.Int64
+	limit int64
+	next  http.Handler
+}
+
+func (h *wsConnectionLimiter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if h.count.Add(1) > h.limit {
+		h.count.Add(-1)
+		wsConnectionRejected.Inc()
+		rpc.WriteOverloadedResponse(w)
+		return
+	}
+	defer h.count.Add(-1)
+	h.next.ServeHTTP(w, r)
 }
 
 func newCorsHandler(srv http.Handler, allowedOrigins []string) http.Handler {

--- a/node/rpcstack_test.go
+++ b/node/rpcstack_test.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
@@ -441,4 +442,91 @@ func TestRPCAdmissionHandler(t *testing.T) {
 		close(gate)
 		wg.Wait()
 	})
+}
+
+// TestWsConnectionLimit verifies that WsConnectionLimit rejects excess WebSocket
+// connections with HTTP 503 and allows new ones once a slot is freed.
+func TestWsConnectionLimit(t *testing.T) {
+	const limit = 1
+	srv := createAndStartServer(t, &httpConfig{}, true, &wsConfig{
+		Origins:           []string{"*"},
+		WsConnectionLimit: limit,
+	})
+	defer srv.stop()
+	url := fmt.Sprintf("ws://%v", srv.listenAddr())
+
+	// First connection should succeed.
+	conn1, resp1, err := websocket.DefaultDialer.Dial(url, nil)
+	if resp1 != nil {
+		resp1.Body.Close()
+	}
+	require.NoError(t, err, "first connection should succeed")
+
+	// Wait until the server increments its counter.
+	require.Eventually(t, func() bool { return srv.wsConnCount.Load() == 1 },
+		5*time.Second, time.Millisecond)
+
+	// While first connection is open the second must be rejected.
+	_, resp, err2 := websocket.DefaultDialer.Dial(url, nil)
+	require.Error(t, err2, "second connection should be rejected")
+	if resp != nil {
+		assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+		resp.Body.Close()
+	}
+
+	// Close first connection and wait for the counter to drop.
+	conn1.Close()
+	require.Eventually(t, func() bool { return srv.wsConnCount.Load() == 0 },
+		5*time.Second, time.Millisecond)
+
+	// A new connection should now succeed.
+	conn3, resp3, err := websocket.DefaultDialer.Dial(url, nil)
+	if resp3 != nil {
+		resp3.Body.Close()
+	}
+	require.NoError(t, err, "connection after limit released should succeed")
+	conn3.Close()
+}
+
+// TestNewWSConnectionLimiter tests the standalone NewWSConnectionLimiter handler.
+func TestNewWSConnectionLimiter(t *testing.T) {
+	// limit=0: handler passes through without restriction.
+	passthrough := NewWSConnectionLimiter(0, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	rr0 := httptest.NewRecorder()
+	passthrough.ServeHTTP(rr0, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.Equal(t, http.StatusOK, rr0.Code)
+
+	// Build a limiter with limit=1.
+	// Use a channel to keep "connections" open until the test releases them.
+	hold := make(chan struct{})
+	slow := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-hold
+		w.WriteHeader(http.StatusOK)
+	})
+	limiter := NewWSConnectionLimiter(1, slow)
+
+	// First request: should be accepted (blocks on hold).
+	go func() {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		limiter.ServeHTTP(httptest.NewRecorder(), req)
+	}()
+
+	// Give the goroutine time to increment the counter.
+	require.Eventually(t, func() bool {
+		return limiter.(*wsConnectionLimiter).count.Load() == 1
+	}, 2*time.Second, time.Millisecond)
+
+	// Second request: should be rejected with 503.
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	limiter.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
+
+	// Release the first "connection".
+	close(hold)
+	require.Eventually(t, func() bool {
+		return limiter.(*wsConnectionLimiter).count.Load() == 0
+	}, 2*time.Second, time.Millisecond)
 }

--- a/node/rpcstack_test.go
+++ b/node/rpcstack_test.go
@@ -463,8 +463,8 @@ func TestWsConnectionLimit(t *testing.T) {
 	require.NoError(t, err, "first connection should succeed")
 
 	// Wait until the server increments its counter.
-	require.Eventually(t, func() bool { return srv.wsConnCount.Load() == 1 },
-		5*time.Second, time.Millisecond)
+	require.Eventually(t, func() bool { return srv.wsLimiter.count.Load() == 1 },
+		5*time.Second, 5*time.Millisecond)
 
 	// While first connection is open the second must be rejected.
 	_, resp, err2 := websocket.DefaultDialer.Dial(url, nil)
@@ -476,8 +476,8 @@ func TestWsConnectionLimit(t *testing.T) {
 
 	// Close first connection and wait for the counter to drop.
 	conn1.Close()
-	require.Eventually(t, func() bool { return srv.wsConnCount.Load() == 0 },
-		5*time.Second, time.Millisecond)
+	require.Eventually(t, func() bool { return srv.wsLimiter.count.Load() == 0 },
+		5*time.Second, 5*time.Millisecond)
 
 	// A new connection should now succeed.
 	conn3, resp3, err := websocket.DefaultDialer.Dial(url, nil)

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -115,8 +115,8 @@ type clientConn struct {
 	handler *handler
 }
 
-func (c *Client) newClientConn(conn ServerCodec) *clientConn {
-	ctx := context.WithValue(context.Background(), clientContextKey{}, c)
+func (c *Client) newClientConn(conn ServerCodec, connCtx context.Context) *clientConn {
+	ctx := context.WithValue(connCtx, clientContextKey{}, c)
 	ctx = context.WithValue(ctx, peerInfoContextKey{}, conn.peerInfo())
 	handler := newHandler(ctx, conn, c.idgen, c.services, c.batchLimit, c.methodAllowList, 50, false /* traceRequests */, c.logger, 0)
 	return &clientConn{conn, handler}
@@ -212,6 +212,10 @@ func newClient(initctx context.Context, connect reconnectFunc, logger log.Logger
 }
 
 func initClient(conn ServerCodec, idgen func() ID, services *serviceRegistry, batchLimit int, logger log.Logger) *Client {
+	return initClientWithBaseCtx(context.Background(), conn, idgen, services, batchLimit, logger)
+}
+
+func initClientWithBaseCtx(baseCtx context.Context, conn ServerCodec, idgen func() ID, services *serviceRegistry, batchLimit int, logger log.Logger) *Client {
 	_, isHTTP := conn.(*httpConn)
 	c := &Client{
 		idgen:       idgen,
@@ -231,7 +235,7 @@ func initClient(conn ServerCodec, idgen func() ID, services *serviceRegistry, ba
 		logger:      logger,
 	}
 	if !isHTTP {
-		go c.dispatch(conn)
+		go c.dispatch(conn, baseCtx)
 	}
 	return c
 }
@@ -570,11 +574,11 @@ func (c *Client) reconnect(ctx context.Context) error {
 // dispatch is the main loop of the client.
 // It sends read messages to waiting calls to Call and BatchCall
 // and subscription notifications to registered subscriptions.
-func (c *Client) dispatch(codec ServerCodec) {
+func (c *Client) dispatch(codec ServerCodec, connCtx context.Context) {
 	var (
 		lastOp      *requestOp  // tracks last send operation
 		reqInitLock = c.reqInit // nil while the send lock is held
-		conn        = c.newClientConn(codec)
+		conn        = c.newClientConn(codec, connCtx)
 		reading     = true
 	)
 	defer func() {
@@ -623,7 +627,7 @@ func (c *Client) dispatch(codec ServerCodec) {
 			}
 			go c.read(newcodec)
 			reading = true
-			conn = c.newClientConn(newcodec)
+			conn = c.newClientConn(newcodec, connCtx)
 			// Re-register the in-flight request on the new handler because that's where it will be sent.
 			conn.handler.addRequestOp(lastOp)
 

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -99,6 +99,13 @@ func (s *Server) RegisterName(name string, receiver any) error {
 //
 // Note that codec options are no longer supported.
 func (s *Server) ServeCodec(codec ServerCodec, options CodecOption) {
+	s.ServeCodecWithContext(context.Background(), codec, options)
+}
+
+// ServeCodecWithContext is like ServeCodec but uses connCtx as the base context for all
+// handler goroutines spawned for this connection. Values set on connCtx (e.g.
+// kv.WithNonBlockingAcquire) propagate to every method call on the connection.
+func (s *Server) ServeCodecWithContext(connCtx context.Context, codec ServerCodec, options CodecOption) {
 	defer codec.Close()
 
 	// Don't serve if server is stopped.
@@ -110,7 +117,7 @@ func (s *Server) ServeCodec(codec ServerCodec, options CodecOption) {
 	s.codecs.Add(codec)
 	defer s.codecs.Remove(codec)
 
-	c := initClient(codec, s.idgen, &s.services, s.batchLimit, s.logger)
+	c := initClientWithBaseCtx(connCtx, codec, s.idgen, &s.services, s.batchLimit, s.logger)
 	<-codec.closed()
 	c.Close()
 }

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gorilla/websocket"
 
 	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
 )
 
 const (
@@ -68,7 +69,10 @@ func (s *Server) WebsocketHandler(allowedOrigins []string, jwtSecret []byte, com
 			return
 		}
 		codec := NewWebsocketCodec(conn, r.Host, r.Header)
-		s.ServeCodec(codec, 0)
+		// Tag the connection context so BeginRo fails fast (ErrReadTxLimitExceeded)
+		// instead of blocking indefinitely when the DB semaphore is full.
+		ctx := kv.WithNonBlockingAcquire(r.Context())
+		s.ServeCodecWithContext(ctx, codec, 0)
 	})
 }
 

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -71,6 +71,9 @@ func (s *Server) WebsocketHandler(allowedOrigins []string, jwtSecret []byte, com
 		codec := NewWebsocketCodec(conn, r.Host, r.Header)
 		// Tag the connection context so BeginRo fails fast (ErrReadTxLimitExceeded)
 		// instead of blocking indefinitely when the DB semaphore is full.
+		// r.Context() remains valid for the lifetime of the WebSocket session because
+		// the HTTP handler goroutine blocks inside ServeCodecWithContext until the
+		// connection closes.
 		ctx := kv.WithNonBlockingAcquire(r.Context())
 		s.ServeCodecWithContext(ctx, codec, 0)
 	})

--- a/rpc/websocket_test.go
+++ b/rpc/websocket_test.go
@@ -26,12 +26,14 @@ import (
 	"net/http/httptest"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/gorilla/websocket"
 
 	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
 )
 
 func TestWebsocketClientHeaders(t *testing.T) {
@@ -310,5 +312,63 @@ func wsPingTestHandler(t *testing.T, conn *websocket.Conn, shutdown, sendPing <-
 			conn.Close()
 			return
 		}
+	}
+}
+
+// dbOverloadSvc simulates a service whose method returns ErrReadTxLimitExceeded.
+// It also records whether the handler context had kv.NonBlockingAcquire set.
+type dbOverloadSvc struct {
+	sawNonBlocking atomic.Bool
+}
+
+func (s *dbOverloadSvc) Overload(ctx context.Context) error {
+	s.sawNonBlocking.Store(kv.IsNonBlockingAcquire(ctx))
+	return kv.ErrReadTxLimitExceeded
+}
+
+// TestWebsocketNonBlockingAcquire verifies two things about the WS handler:
+//  1. The context passed to method handlers has kv.WithNonBlockingAcquire tagged,
+//     so a real BeginRo would use TryAcquire instead of blocking.
+//  2. When a handler returns kv.ErrReadTxLimitExceeded, remapDBOverload converts it
+//     to JSON-RPC -32005 and the client receives that error code (no HTTP 503 is
+//     possible on an already-upgraded WebSocket connection).
+func TestWebsocketNonBlockingAcquire(t *testing.T) {
+	t.Parallel()
+	logger := log.New()
+
+	svc := &dbOverloadSvc{}
+	srv := NewServer(50, false, false, true, logger, 100)
+	if err := srv.RegisterName("db", svc); err != nil {
+		t.Fatal(err)
+	}
+	httpsrv := httptest.NewServer(srv.WebsocketHandler([]string{"*"}, nil, false, logger))
+	defer srv.Stop()
+	defer httpsrv.Close()
+
+	wsURL := "ws:" + strings.TrimPrefix(httpsrv.URL, "http:")
+	client, err := DialWebsocket(context.Background(), wsURL, "", logger)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer client.Close()
+
+	var result any
+	callErr := client.Call(&result, "db_overload")
+
+	// The handler context must have NonBlockingAcquire set.
+	if !svc.sawNonBlocking.Load() {
+		t.Error("handler context did not have kv.NonBlockingAcquire tagged")
+	}
+
+	// The client must receive a JSON-RPC -32005 (not a nil error, not a generic error).
+	if callErr == nil {
+		t.Fatal("expected -32005 error but Call succeeded")
+	}
+	rpcErr, ok := callErr.(Error)
+	if !ok {
+		t.Fatalf("expected rpc.Error, got %T: %v", callErr, callErr)
+	}
+	if rpcErr.ErrorCode() != ErrCodeServerOverloaded {
+		t.Errorf("expected error code %d (server overloaded), got %d", ErrCodeServerOverloaded, rpcErr.ErrorCode())
 	}
 }


### PR DESCRIPTION
Two defences against WebSocket overload:

1. Fail-fast on DB semaphore full: WebsocketHandler now tags the connection context with kv.WithNonBlockingAcquire so every method call uses TryAcquire instead of blocking indefinitely. When the read-tx semaphore is exhausted, BeginRo returns ErrReadTxLimitExceeded immediately; remapDBOverload converts it to JSON-RPC -32005. ServeCodecWithContext is added to thread the context through the dispatch/handler goroutines without storing it in the Client struct.

2. Connection limiter: WsConnectionLimit on wsConfig / httpServer rejects new WebSocket connections with HTTP 503 once the limit is exceeded. NewWSConnectionLimiter exports the same logic as a standalone http.Handler wrapper, used by startRegularRpcServer in rpcdaemon. Exposed as --ws.max.connections CLI flag for both erigon and rpcdaemon (0 = unlimited).