### PR TITLE
cl: replace Clique dev mode with embedded PoS consensus

### DIFF
--- a/.claude/skills/erigon-ephemeral/SKILL.md
+++ b/.claude/skills/erigon-ephemeral/SKILL.md
@@ -116,7 +116,7 @@ Run Erigon in the background:
 ./build/bin/erigon --datadir=<path> [port flags if needed] [user extra flags] &
 ```
 
-- The user can pass extra flags (e.g., `--chain=dev --mine`, `--log.console.verbosity=4`) which get appended to the command.
+- The user can pass extra flags (e.g., `--chain=dev --beacon.api=beacon,validator,node,config`, `--log.console.verbosity=4`) which get appended to the command.
 - **Always** print the full CLI command to the user in a formatted code block (one flag per line with `\` continuation) before launching, so they can see exactly what is being run.
 - Report the PID to the user after launching.
 - Use `run_in_background: true` on the Bash tool so the process survives.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -46,9 +46,9 @@
 
 ### Removed
 
-- PoW mining was removed in #17813, which resulted in `--chain=dev` not being able to produce new blocks. Going forward
-  we'll either sunset `--chain=dev` or switch it to mock CL (see #14753). If you need `--chain=dev`, please use Erigon
-  3.2
+- PoW mining was removed in #17813. The `--chain=dev` mode now uses an embedded PoS
+  consensus layer (Caplin) with deterministic validators instead of Clique. See
+  `docs/DEV_CHAIN.md` for usage.
 - Holesky network support removed (#17685)
 - eth/67 protocol support removed (#17318)
 - SkipAnalysis VM optimization removed (#17217)

--- a/agents.md
+++ b/agents.md
@@ -45,7 +45,7 @@ Erigon is a high-performance Ethereum execution client with embedded consensus l
 
 ```bash
 ./build/bin/erigon --datadir=./data --chain=mainnet
-./build/bin/erigon --datadir=dev --chain=dev --mine  # Development
+./build/bin/erigon --datadir=dev --chain=dev --beacon.api=beacon,validator,node,config  # PoS dev mode
 ```
 
 ## Conventions

--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -1366,6 +1366,12 @@ func (a *ApiHandler) storeBlockAndBlobs(
 		return err
 	}
 
+	// Advance fork choice time to the current slot so OnBlock accepts the block.
+	// Normally OnTick is called from the ForkChoice stage, but storeBlockAndBlobs
+	// runs from the beacon API handler which may execute before the stage loop.
+	currentSlot := a.ethClock.GetCurrentSlot()
+	a.forkchoiceStore.OnTick(a.ethClock.GenesisTime() + currentSlot*a.beaconChainCfg.SecondsPerSlot)
+
 	// Skip BLS re-verification for locally-produced blocks. The block was just
 	// built by this node, so re-verifying the signature is redundant. Additionally,
 	// AddChainSegment replays from the nearest checkpoint state, and the replayed

--- a/cl/clparams/config.go
+++ b/cl/clparams/config.go
@@ -66,6 +66,10 @@ type CaplinConfig struct {
 	CustomConfigPath       string
 	CustomGenesisStatePath string
 
+	// Dev validator (embedded VC for --chain=dev)
+	DevValidatorSeed  string // deterministic BLS key seed; empty = disabled
+	DevValidatorCount int    // number of validators (default 64)
+
 	// Network stuff
 	CaplinDiscoveryAddr         string
 	CaplinDiscoveryPort         uint64
@@ -92,7 +96,7 @@ type CaplinConfig struct {
 }
 
 func (c CaplinConfig) IsDevnet() bool {
-	return c.CustomConfigPath != "" || c.CustomGenesisStatePath != ""
+	return c.CustomConfigPath != "" || c.CustomGenesisStatePath != "" || c.DevValidatorSeed != ""
 }
 
 func (c CaplinConfig) HaveInvalidDevnetParams() bool {
@@ -1041,7 +1045,7 @@ func CustomConfig(configFile string) (BeaconChainConfig, NetworkConfig, error) {
 		return BeaconChainConfig{}, NetworkConfig{}, err
 	}
 	if presetProbe.PresetBase == "minimal" {
-		applyMinimalPreset(beaconCfg)
+		ApplyMinimalPreset(beaconCfg)
 	}
 
 	// setup beacon chain config
@@ -1057,11 +1061,11 @@ func CustomConfig(configFile string) (BeaconChainConfig, NetworkConfig, error) {
 	return *beaconCfg, *networkConfig, nil
 }
 
-// applyMinimalPreset overrides the mainnet base config with values from the
+// ApplyMinimalPreset overrides the mainnet base config with values from the
 // Ethereum consensus-specs "minimal" preset. Only fields that differ from
 // mainnet are changed. Reference:
 // https://github.com/ethereum/consensus-specs/tree/dev/presets/minimal
-func applyMinimalPreset(cfg *BeaconChainConfig) {
+func ApplyMinimalPreset(cfg *BeaconChainConfig) {
 	cfg.PresetBase = "minimal"
 
 	// Phase0 preset differences

--- a/cl/clparams/devgenesis/devgenesis.go
+++ b/cl/clparams/devgenesis/devgenesis.go
@@ -107,11 +107,18 @@ func BuildGenesisState(
 	})
 
 	// Set Eth1Data linking to the EL genesis.
+	// DepositCount = validatorCount, and eth1DepositIndex = validatorCount
+	// so the spec thinks all deposits have been processed (genesis validators
+	// are injected directly, not via deposit transactions).
 	beaconState.SetEth1Data(&cltypes.Eth1Data{
 		Root:         common.Hash{}, // empty deposit root for dev genesis
 		DepositCount: uint64(validatorCount),
 		BlockHash:    elGenesisHash,
 	})
+	beaconState.SetEth1DepositIndex(uint64(validatorCount))
+
+	// Collect pubkeys for sync committee initialization.
+	var allPubkeys []common.Bytes48
 
 	// Add validators.
 	maxEffectiveBalance := cfg.MaxEffectiveBalance
@@ -140,6 +147,33 @@ func BuildGenesisState(
 		)
 
 		beaconState.AddValidator(validator, maxEffectiveBalance)
+		allPubkeys = append(allPubkeys, common.Bytes48(pubkeyBytes))
+	}
+
+	// Initialize sync committees (Altair+). Fill with validator pubkeys
+	// cycling through the set to reach SyncCommitteeSize.
+	version := cfg.GetCurrentStateVersion(0)
+	if version >= clparams.AltairVersion {
+		committeeSize := int(cfg.SyncCommitteeSize)
+		committeePubkeys := make([]common.Bytes48, committeeSize)
+		for i := 0; i < committeeSize; i++ {
+			committeePubkeys[i] = allPubkeys[i%len(allPubkeys)]
+		}
+		// Compute aggregate pubkey (needed for sync committee verification).
+		aggPubkeyBytes := make([][]byte, committeeSize)
+		for i, pk := range committeePubkeys {
+			aggPubkeyBytes[i] = pk[:]
+		}
+		aggPubkey, err := bls.AggregatePublickKeys(aggPubkeyBytes)
+		if err != nil {
+			return nil, nil, fmt.Errorf("aggregate sync committee pubkeys: %w", err)
+		}
+		var aggPubkeyFixed common.Bytes48
+		copy(aggPubkeyFixed[:], aggPubkey)
+
+		syncCommittee := solid.NewSyncCommitteeFromParameters(committeePubkeys, aggPubkeyFixed)
+		beaconState.SetCurrentSyncCommittee(syncCommittee)
+		beaconState.SetNextSyncCommittee(syncCommittee)
 	}
 
 	// Compute genesis validators root.
@@ -155,7 +189,6 @@ func BuildGenesisState(
 	}
 
 	// Set the latest execution payload header referencing the EL genesis block.
-	version := cfg.GetCurrentStateVersion(0)
 	execHeader := cltypes.NewEth1Header(version)
 	execHeader.BlockHash = elGenesisHash
 	beaconState.SetLatestExecutionPayloadHeader(execHeader)

--- a/cl/clparams/devgenesis/devgenesis.go
+++ b/cl/clparams/devgenesis/devgenesis.go
@@ -47,11 +47,14 @@ func DeriveKeys(seed string, count int) ([]*bls.PrivateKey, error) {
 // DeriveSignerKey derives a deterministic secp256k1 private key from the seed.
 // This is the EL transaction signing key — the corresponding address is pre-funded
 // in the dev genesis. Not for production.
-func DeriveSignerKey(seed string) (*ecdsa.PrivateKey, common.Address) {
+func DeriveSignerKey(seed string) (*ecdsa.PrivateKey, common.Address, error) {
 	h := sha256.Sum256(append([]byte("signer:"), []byte(seed)...))
-	key, _ := crypto.ToECDSA(h[:])
+	key, err := crypto.ToECDSA(h[:])
+	if err != nil {
+		return nil, common.Address{}, fmt.Errorf("derive signer key: %w", err)
+	}
 	addr := crypto.PubkeyToAddress(key.PublicKey)
-	return key, addr
+	return key, addr, nil
 }
 
 // DevConfig holds all the pieces needed to start a dev node.

--- a/cl/clparams/devgenesis/devgenesis.go
+++ b/cl/clparams/devgenesis/devgenesis.go
@@ -153,9 +153,15 @@ func BuildGenesisState(
 		beaconState.SetRandaoMixAt(int(i), common.Hash(validatorsRoot))
 	}
 
+	// Set the latest execution payload header referencing the EL genesis block.
+	version := cfg.GetCurrentStateVersion(0)
+	execHeader := cltypes.NewEth1Header(version)
+	execHeader.BlockHash = elGenesisHash
+	beaconState.SetLatestExecutionPayloadHeader(execHeader)
+
 	// Set latest block header. The body root for genesis is the hash of
 	// an empty BeaconBlockBody at the genesis version.
-	genesisBody := cltypes.NewBeaconBody(cfg, cfg.GetCurrentStateVersion(0))
+	genesisBody := cltypes.NewBeaconBody(cfg, version)
 	bodyRoot, err := genesisBody.HashSSZ()
 	if err != nil {
 		return nil, nil, fmt.Errorf("hash genesis body: %w", err)

--- a/cl/clparams/devgenesis/devgenesis.go
+++ b/cl/clparams/devgenesis/devgenesis.go
@@ -1,0 +1,172 @@
+// Package devgenesis builds a valid beacon genesis state for dev mode.
+// It creates deterministic validators from a seed string, producing
+// a self-contained PoS genesis that can run with an embedded validator.
+package devgenesis
+
+import (
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"math"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/cl/phase1/core/state"
+	clutils "github.com/erigontech/erigon/cl/utils"
+	"github.com/erigontech/erigon/cl/utils/bls"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/crypto"
+)
+
+// DeriveKey derives a deterministic BLS private key from a seed and index.
+// Uses KeyGen (IKM expansion) to ensure the result is a valid BLS scalar.
+// Not for production — dev/test only.
+func DeriveKey(seed string, index uint64) (*bls.PrivateKey, error) {
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], index)
+	// Use sha256 to get 32 bytes of IKM, then KeyGen to reduce modulo curve order.
+	ikm := sha256.Sum256(append([]byte(seed), buf[:]...))
+	return bls.NewPrivateKeyFromIKM(ikm[:])
+}
+
+// DeriveKeys derives N deterministic BLS keypairs from a seed.
+func DeriveKeys(seed string, count int) ([]*bls.PrivateKey, error) {
+	keys := make([]*bls.PrivateKey, count)
+	for i := 0; i < count; i++ {
+		var err error
+		keys[i], err = DeriveKey(seed, uint64(i))
+		if err != nil {
+			return nil, fmt.Errorf("derive key %d: %w", i, err)
+		}
+	}
+	return keys, nil
+}
+
+// DeriveSignerKey derives a deterministic secp256k1 private key from the seed.
+// This is the EL transaction signing key — the corresponding address is pre-funded
+// in the dev genesis. Not for production.
+func DeriveSignerKey(seed string) (*ecdsa.PrivateKey, common.Address) {
+	h := sha256.Sum256(append([]byte("signer:"), []byte(seed)...))
+	key, _ := crypto.ToECDSA(h[:])
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+	return key, addr
+}
+
+// DevConfig holds all the pieces needed to start a dev node.
+type DevConfig struct {
+	BeaconState    *state.CachingBeaconState
+	ValidatorKeys  []*bls.PrivateKey
+	SignerKey      *ecdsa.PrivateKey
+	SignerAddress  common.Address
+	BeaconConfig   *clparams.BeaconChainConfig
+}
+
+// BuildGenesisState creates a valid beacon genesis state for dev mode.
+//
+// Parameters:
+//   - seed: deterministic key derivation seed
+//   - validatorCount: number of genesis validators
+//   - cfg: beacon chain config (use minimal preset for dev)
+//   - genesisTime: unix timestamp for genesis
+//   - elGenesisHash: execution layer genesis block hash (for Eth1Data)
+//
+// The returned state is ready to be SSZ-encoded and used by Caplin.
+func BuildGenesisState(
+	seed string,
+	validatorCount int,
+	cfg *clparams.BeaconChainConfig,
+	genesisTime uint64,
+	elGenesisHash common.Hash,
+) (*state.CachingBeaconState, []*bls.PrivateKey, error) {
+	if validatorCount == 0 {
+		return nil, nil, fmt.Errorf("validator count must be > 0")
+	}
+
+	// Derive BLS keys.
+	keys, err := DeriveKeys(seed, validatorCount)
+	if err != nil {
+		return nil, nil, fmt.Errorf("derive keys: %w", err)
+	}
+
+	// Create empty state with the given config.
+	beaconState := state.New(cfg)
+
+	// Set genesis time and slot.
+	beaconState.SetGenesisTime(genesisTime)
+	beaconState.SetSlot(0)
+
+	// Set fork parameters for genesis.
+	forkVersion := clutils.Uint32ToBytes4(uint32(cfg.GenesisForkVersion))
+	beaconState.SetFork(&cltypes.Fork{
+		PreviousVersion: forkVersion,
+		CurrentVersion:  forkVersion,
+		Epoch:           0,
+	})
+
+	// Set Eth1Data linking to the EL genesis.
+	beaconState.SetEth1Data(&cltypes.Eth1Data{
+		Root:         common.Hash{}, // empty deposit root for dev genesis
+		DepositCount: uint64(validatorCount),
+		BlockHash:    elGenesisHash,
+	})
+
+	// Add validators.
+	maxEffectiveBalance := cfg.MaxEffectiveBalance
+	for i := 0; i < validatorCount; i++ {
+		pubkey := keys[i].PublicKey()
+		pubkeyCompressed := bls.CompressPublicKey(pubkey)
+		var pubkeyBytes [48]byte
+		copy(pubkeyBytes[:], pubkeyCompressed)
+
+		// Withdrawal credentials: 0x01 prefix + 11 zero bytes + 20-byte address.
+		// Address derived from pubkey hash for simplicity.
+		var withdrawalCreds [32]byte
+		withdrawalCreds[0] = 0x01 // ETH1_ADDRESS_WITHDRAWAL_PREFIX
+		pubkeyHash := crypto.Keccak256(pubkeyBytes[:])
+		copy(withdrawalCreds[12:], pubkeyHash[12:]) // last 20 bytes as address
+
+		validator := solid.NewValidatorFromParameters(
+			pubkeyBytes,
+			withdrawalCreds,
+			maxEffectiveBalance,
+			false,                  // not slashed
+			0,                      // activation eligibility epoch
+			0,                      // activation epoch (active from genesis)
+			math.MaxUint64,         // exit epoch (far future)
+			math.MaxUint64,         // withdrawable epoch (far future)
+		)
+
+		beaconState.AddValidator(validator, maxEffectiveBalance)
+	}
+
+	// Compute genesis validators root.
+	validatorsRoot, err := beaconState.Validators().HashSSZ()
+	if err != nil {
+		return nil, nil, fmt.Errorf("hash validators: %w", err)
+	}
+	beaconState.SetGenesisValidatorsRoot(common.Hash(validatorsRoot))
+
+	// Initialize RANDAO mixes with the genesis validators root.
+	for i := uint64(0); i < cfg.EpochsPerHistoricalVector; i++ {
+		beaconState.SetRandaoMixAt(int(i), common.Hash(validatorsRoot))
+	}
+
+	// Set latest block header. The body root for genesis is the hash of
+	// an empty BeaconBlockBody at the genesis version.
+	genesisBody := cltypes.NewBeaconBody(cfg, cfg.GetCurrentStateVersion(0))
+	bodyRoot, err := genesisBody.HashSSZ()
+	if err != nil {
+		return nil, nil, fmt.Errorf("hash genesis body: %w", err)
+	}
+	latestHeader := &cltypes.BeaconBlockHeader{
+		BodyRoot: common.Hash(bodyRoot),
+	}
+	beaconState.SetLatestBlockHeader(latestHeader)
+
+	// Set justification bits (all zero for genesis).
+	beaconState.SetJustificationBits(cltypes.JustificationBits{})
+
+	return beaconState, keys, nil
+}

--- a/cl/clparams/devgenesis/devgenesis.go
+++ b/cl/clparams/devgenesis/devgenesis.go
@@ -90,8 +90,9 @@ func BuildGenesisState(
 		return nil, nil, fmt.Errorf("derive keys: %w", err)
 	}
 
-	// Create empty state with the given config.
+	// Create empty state with the given config at the correct version.
 	beaconState := state.New(cfg)
+	beaconState.SetVersion(cfg.GetCurrentStateVersion(0))
 
 	// Set genesis time and slot.
 	beaconState.SetGenesisTime(genesisTime)
@@ -162,6 +163,15 @@ func BuildGenesisState(
 	// Set latest block header. The body root for genesis is the hash of
 	// an empty BeaconBlockBody at the genesis version.
 	genesisBody := cltypes.NewBeaconBody(cfg, version)
+	// Ensure the execution payload has all required sub-fields initialized.
+	genesisBody.ExecutionPayload.Extra = solid.NewExtraData()
+	genesisBody.ExecutionPayload.Transactions = &solid.TransactionsSSZ{}
+	if version >= clparams.CapellaVersion {
+		genesisBody.ExecutionPayload.Withdrawals = solid.NewStaticListSSZ[*cltypes.Withdrawal](int(cfg.MaxWithdrawalsPerPayload), 44)
+	}
+	if version >= clparams.AltairVersion {
+		genesisBody.SyncAggregate = cltypes.NewSyncAggregateWithSize(int(cfg.SyncCommitteeSize) / 8)
+	}
 	bodyRoot, err := genesisBody.HashSSZ()
 	if err != nil {
 		return nil, nil, fmt.Errorf("hash genesis body: %w", err)

--- a/cl/clparams/devgenesis/devgenesis.go
+++ b/cl/clparams/devgenesis/devgenesis.go
@@ -98,11 +98,17 @@ func BuildGenesisState(
 	beaconState.SetGenesisTime(genesisTime)
 	beaconState.SetSlot(0)
 
-	// Set fork parameters for genesis.
-	forkVersion := clutils.Uint32ToBytes4(uint32(cfg.GenesisForkVersion))
+	// Set fork parameters for genesis. When multiple forks activate at
+	// epoch 0 (typical in dev mode), CurrentVersion must reflect the
+	// latest active fork, not GenesisForkVersion. This matches the spec's
+	// fork transition logic and ensures domain computations are consistent
+	// between the beacon state and the dev validator's signing code.
+	genesisVersion := clutils.Uint32ToBytes4(uint32(cfg.GenesisForkVersion))
+	currentStateVersion := cfg.GetCurrentStateVersion(0)
+	currentVersion := clutils.Uint32ToBytes4(cfg.GetForkVersionByVersion(currentStateVersion))
 	beaconState.SetFork(&cltypes.Fork{
-		PreviousVersion: forkVersion,
-		CurrentVersion:  forkVersion,
+		PreviousVersion: genesisVersion,
+		CurrentVersion:  currentVersion,
 		Epoch:           0,
 	})
 

--- a/cl/clparams/devgenesis/devgenesis.go
+++ b/cl/clparams/devgenesis/devgenesis.go
@@ -56,11 +56,11 @@ func DeriveSignerKey(seed string) (*ecdsa.PrivateKey, common.Address) {
 
 // DevConfig holds all the pieces needed to start a dev node.
 type DevConfig struct {
-	BeaconState    *state.CachingBeaconState
-	ValidatorKeys  []*bls.PrivateKey
-	SignerKey      *ecdsa.PrivateKey
-	SignerAddress  common.Address
-	BeaconConfig   *clparams.BeaconChainConfig
+	BeaconState   *state.CachingBeaconState
+	ValidatorKeys []*bls.PrivateKey
+	SignerKey     *ecdsa.PrivateKey
+	SignerAddress common.Address
+	BeaconConfig  *clparams.BeaconChainConfig
 }
 
 // BuildGenesisState creates a valid beacon genesis state for dev mode.
@@ -139,11 +139,11 @@ func BuildGenesisState(
 			pubkeyBytes,
 			withdrawalCreds,
 			maxEffectiveBalance,
-			false,                  // not slashed
-			0,                      // activation eligibility epoch
-			0,                      // activation epoch (active from genesis)
-			math.MaxUint64,         // exit epoch (far future)
-			math.MaxUint64,         // withdrawable epoch (far future)
+			false,          // not slashed
+			0,              // activation eligibility epoch
+			0,              // activation epoch (active from genesis)
+			math.MaxUint64, // exit epoch (far future)
+			math.MaxUint64, // withdrawable epoch (far future)
 		)
 
 		beaconState.AddValidator(validator, maxEffectiveBalance)

--- a/cl/clparams/devgenesis/devgenesis.go
+++ b/cl/clparams/devgenesis/devgenesis.go
@@ -174,6 +174,11 @@ func BuildGenesisState(
 		syncCommittee := solid.NewSyncCommitteeFromParameters(committeePubkeys, aggPubkeyFixed)
 		beaconState.SetCurrentSyncCommittee(syncCommittee)
 		beaconState.SetNextSyncCommittee(syncCommittee)
+
+		// Initialize epoch participation flags and inactivity scores.
+		beaconState.SetPreviousEpochParticipationFlags(make(cltypes.ParticipationFlagsList, validatorCount))
+		beaconState.SetCurrentEpochParticipationFlags(make(cltypes.ParticipationFlagsList, validatorCount))
+		beaconState.SetInactivityScores(make([]uint64, validatorCount))
 	}
 
 	// Compute genesis validators root.

--- a/cl/clparams/devgenesis/devgenesis_test.go
+++ b/cl/clparams/devgenesis/devgenesis_test.go
@@ -1,0 +1,104 @@
+package devgenesis
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/common"
+)
+
+func TestBuildGenesisState_Minimal(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig // works with any config
+
+	genesisTime := uint64(time.Now().Unix())
+	elHash := common.HexToHash("0x1234")
+
+	state, keys, err := BuildGenesisState("test-seed", 64, &cfg, genesisTime, elHash)
+	require.NoError(t, err)
+	require.Len(t, keys, 64)
+
+	// Check basic state properties.
+	require.Equal(t, uint64(0), state.Slot())
+	require.Equal(t, genesisTime, state.GenesisTime())
+	require.Equal(t, 64, state.ValidatorLength())
+
+	// All validators should be active at genesis.
+	for i := 0; i < state.ValidatorLength(); i++ {
+		v := state.Validators().Get(i)
+		require.Equal(t, uint64(0), v.ActivationEpoch(), "validator %d should be active at epoch 0", i)
+		require.Equal(t, cfg.MaxEffectiveBalance, v.EffectiveBalance())
+	}
+
+	// Genesis validators root should be non-zero.
+	require.NotEqual(t, common.Hash{}, state.GenesisValidatorsRoot())
+
+	// Eth1Data should reference our EL hash.
+	require.Equal(t, elHash, state.Eth1Data().BlockHash)
+
+	// State root should be computable.
+	root, err := state.HashSSZ()
+	require.NoError(t, err)
+	require.NotEqual(t, common.Hash{}, common.Hash(root))
+
+	t.Logf("genesis state root: %x", root)
+	t.Logf("validators root: %x", state.GenesisValidatorsRoot())
+}
+
+func TestBuildGenesisState_Deterministic(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+
+	s1, _, err := BuildGenesisState("seed-a", 16, &cfg, 1000, common.Hash{})
+	require.NoError(t, err)
+
+	s2, _, err := BuildGenesisState("seed-a", 16, &cfg, 1000, common.Hash{})
+	require.NoError(t, err)
+
+	r1, _ := s1.HashSSZ()
+	r2, _ := s2.HashSSZ()
+	require.Equal(t, r1, r2, "same seed should produce same state root")
+
+	// Different seed → different root.
+	s3, _, err := BuildGenesisState("seed-b", 16, &cfg, 1000, common.Hash{})
+	require.NoError(t, err)
+	r3, _ := s3.HashSSZ()
+	require.NotEqual(t, r1, r3, "different seed should produce different state root")
+}
+
+func TestDeriveSignerKey(t *testing.T) {
+	key1, addr1 := DeriveSignerKey("test")
+	key2, addr2 := DeriveSignerKey("test")
+
+	// Deterministic.
+	require.Equal(t, key1.D.Bytes(), key2.D.Bytes())
+	require.Equal(t, addr1, addr2)
+
+	// Non-zero address.
+	require.NotEqual(t, common.Address{}, addr1)
+
+	// Different seed → different key.
+	_, addr3 := DeriveSignerKey("other")
+	require.NotEqual(t, addr1, addr3)
+
+	t.Logf("signer address: %s", addr1.Hex())
+}
+
+func TestDeriveKeys(t *testing.T) {
+	keys, err := DeriveKeys("test", 10)
+	require.NoError(t, err)
+	require.Len(t, keys, 10)
+
+	// Keys should be deterministic.
+	keys2, err := DeriveKeys("test", 10)
+	require.NoError(t, err)
+	for i := range keys {
+		require.Equal(t, keys[i].Bytes(), keys2[i].Bytes())
+	}
+
+	// Different seed → different keys.
+	keys3, err := DeriveKeys("other", 10)
+	require.NoError(t, err)
+	require.NotEqual(t, keys[0].Bytes(), keys3[0].Bytes())
+}

--- a/cl/clparams/devgenesis/devgenesis_test.go
+++ b/cl/clparams/devgenesis/devgenesis_test.go
@@ -68,8 +68,10 @@ func TestBuildGenesisState_Deterministic(t *testing.T) {
 }
 
 func TestDeriveSignerKey(t *testing.T) {
-	key1, addr1 := DeriveSignerKey("test")
-	key2, addr2 := DeriveSignerKey("test")
+	key1, addr1, err := DeriveSignerKey("test")
+	require.NoError(t, err)
+	key2, addr2, err := DeriveSignerKey("test")
+	require.NoError(t, err)
 
 	// Deterministic.
 	require.Equal(t, key1.D.Bytes(), key2.D.Bytes())
@@ -79,7 +81,8 @@ func TestDeriveSignerKey(t *testing.T) {
 	require.NotEqual(t, common.Address{}, addr1)
 
 	// Different seed → different key.
-	_, addr3 := DeriveSignerKey("other")
+	_, addr3, err := DeriveSignerKey("other")
+	require.NoError(t, err)
 	require.NotEqual(t, addr1, addr3)
 
 	t.Logf("signer address: %s", addr1.Hex())

--- a/cl/phase1/execution_client/execution_client_direct.go
+++ b/cl/phase1/execution_client/execution_client_direct.go
@@ -134,8 +134,18 @@ func (cc *ExecutionClientDirect) ForkChoiceUpdate(ctx context.Context, finalized
 	if attr == nil {
 		return nil, nil
 	}
+	// Retry AssembleBlock if the EL is busy (semaphore contention with
+	// fork choice commits). This is common in single-process dev mode
+	// where the CL and EL share the same process.
 	idBytes := make([]byte, 8)
-	id, err := cc.chainRW.AssembleBlock(head, attr)
+	var id uint64
+	for attempt := 0; attempt < 30; attempt++ {
+		id, err = cc.chainRW.AssembleBlock(head, attr)
+		if err == nil {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/cl/phase1/forkchoice/forkchoice.go
+++ b/cl/phase1/forkchoice/forkchoice.go
@@ -261,6 +261,9 @@ func NewForkChoiceStore(
 	anchorExecHeader := anchorState.LatestExecutionPayloadHeader()
 	if anchorExecHeader != nil && anchorExecHeader.BlockHash != (common.Hash{}) {
 		eth2Roots.Add(anchorRoot, anchorExecHeader.BlockHash)
+		// Also map the zero hash → EL genesis for the finalized checkpoint
+		// which starts as zero at genesis.
+		eth2Roots.Add(common.Hash{}, anchorExecHeader.BlockHash)
 	}
 
 	headSet := make(map[common.Hash]struct{})

--- a/cl/phase1/forkchoice/forkchoice.go
+++ b/cl/phase1/forkchoice/forkchoice.go
@@ -256,6 +256,13 @@ func NewForkChoiceStore(
 	r := solid.NewHashVector(int(anchorState.BeaconConfig().EpochsPerHistoricalVector))
 	anchorState.RandaoMixes().CopyTo(r)
 	randaoMixesLists.Add(anchorRoot, r)
+	// Seed the eth2Root→eth1Hash mapping for the anchor block so that
+	// fork choice can resolve the EL genesis hash at startup.
+	anchorExecHeader := anchorState.LatestExecutionPayloadHeader()
+	if anchorExecHeader != nil && anchorExecHeader.BlockHash != (common.Hash{}) {
+		eth2Roots.Add(anchorRoot, anchorExecHeader.BlockHash)
+	}
+
 	headSet := make(map[common.Hash]struct{})
 	headSet[anchorRoot] = struct{}{}
 	f := &ForkChoiceStore{

--- a/cl/phase1/stages/clstages.go
+++ b/cl/phase1/stages/clstages.go
@@ -413,18 +413,6 @@ func writeGenesisBeaconBlock(ctx context.Context, cfg *Cfg) error {
 	if version >= clparams.BellatrixVersion {
 		body.ExecutionPayload.Extra = solid.NewExtraData()
 		body.ExecutionPayload.Transactions = &solid.TransactionsSSZ{}
-		// Copy execution payload header from genesis state so the block hash
-		// matches (needed for fork choice to find the EL genesis block).
-		execHeader := cfg.state.LatestExecutionPayloadHeader()
-		if execHeader != nil {
-			body.ExecutionPayload.BlockHash = execHeader.BlockHash
-			body.ExecutionPayload.StateRoot = execHeader.StateRoot
-			body.ExecutionPayload.ParentHash = execHeader.ParentHash
-			body.ExecutionPayload.BlockNumber = execHeader.BlockNumber
-			body.ExecutionPayload.GasLimit = execHeader.GasLimit
-			body.ExecutionPayload.Time = execHeader.Time
-			body.ExecutionPayload.BaseFeePerGas = execHeader.BaseFeePerGas
-		}
 		if version >= clparams.CapellaVersion {
 			body.ExecutionPayload.Withdrawals = solid.NewStaticListSSZ[*cltypes.Withdrawal](int(cfg.beaconCfg.MaxWithdrawalsPerPayload), 44)
 		}

--- a/cl/phase1/stages/clstages.go
+++ b/cl/phase1/stages/clstages.go
@@ -413,6 +413,18 @@ func writeGenesisBeaconBlock(ctx context.Context, cfg *Cfg) error {
 	if version >= clparams.BellatrixVersion {
 		body.ExecutionPayload.Extra = solid.NewExtraData()
 		body.ExecutionPayload.Transactions = &solid.TransactionsSSZ{}
+		// Copy execution payload header from genesis state so the block hash
+		// matches (needed for fork choice to find the EL genesis block).
+		execHeader := cfg.state.LatestExecutionPayloadHeader()
+		if execHeader != nil {
+			body.ExecutionPayload.BlockHash = execHeader.BlockHash
+			body.ExecutionPayload.StateRoot = execHeader.StateRoot
+			body.ExecutionPayload.ParentHash = execHeader.ParentHash
+			body.ExecutionPayload.BlockNumber = execHeader.BlockNumber
+			body.ExecutionPayload.GasLimit = execHeader.GasLimit
+			body.ExecutionPayload.Time = execHeader.Time
+			body.ExecutionPayload.BaseFeePerGas = execHeader.BaseFeePerGas
+		}
 		if version >= clparams.CapellaVersion {
 			body.ExecutionPayload.Withdrawals = solid.NewStaticListSSZ[*cltypes.Withdrawal](int(cfg.beaconCfg.MaxWithdrawalsPerPayload), 44)
 		}

--- a/cl/utils/bls/private_key.go
+++ b/cl/utils/bls/private_key.go
@@ -31,6 +31,20 @@ func GenerateKey() (*PrivateKey, error) {
 	return privateKey, nil
 }
 
+// NewPrivateKeyFromIKM derives a BLS private key from input keying material
+// using blst.KeyGen (reduces modulo curve order). For deterministic key
+// derivation in dev/test contexts.
+func NewPrivateKeyFromIKM(ikm []byte) (*PrivateKey, error) {
+	if len(ikm) < 32 {
+		return nil, fmt.Errorf("bls(ikm): input must be at least 32 bytes, got %d", len(ikm))
+	}
+	privateKey := &PrivateKey{key: blst.KeyGen(ikm)}
+	if privateKey.isZero() {
+		return nil, ErrZeroPrivateKey
+	}
+	return privateKey, nil
+}
+
 // PrivateKeyFromBytes creates a BLS private key from bytes.
 func NewPrivateKeyFromBytes(privKey []byte) (*PrivateKey, error) {
 	if len(privKey) != privateKeyLength {

--- a/cl/validator/devvalidator/client.go
+++ b/cl/validator/devvalidator/client.go
@@ -1,0 +1,112 @@
+package devvalidator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// BeaconClient is a minimal HTTP client for the Beacon API.
+// It talks to the same endpoints that Lighthouse/Teku use.
+type BeaconClient struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// NewBeaconClient creates a client pointing at the given Beacon API URL.
+func NewBeaconClient(baseURL string) *BeaconClient {
+	return &BeaconClient{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+// beaconResponse is the standard Beacon API wrapper.
+type beaconResponse struct {
+	Data json.RawMessage `json:"data"`
+}
+
+// get performs a GET request and unmarshals the `data` field into dst.
+func (c *BeaconClient) get(ctx context.Context, path string, dst interface{}) error {
+	url := c.baseURL + path
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("beacon GET %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("beacon GET %s: status %d: %s", path, resp.StatusCode, string(body))
+	}
+
+	var wrapper beaconResponse
+	if err := json.NewDecoder(resp.Body).Decode(&wrapper); err != nil {
+		return fmt.Errorf("beacon GET %s: decode: %w", path, err)
+	}
+	return json.Unmarshal(wrapper.Data, dst)
+}
+
+// post performs a POST request with a JSON body.
+func (c *BeaconClient) post(ctx context.Context, path string, body interface{}) error {
+	url := c.baseURL + path
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(jsonBody)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("beacon POST %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("beacon POST %s: status %d: %s", path, resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+// postSSZ performs a POST request with an SSZ body and Eth-Consensus-Version header.
+func (c *BeaconClient) postSSZ(ctx context.Context, path string, sszBody []byte, version string) error {
+	url := c.baseURL + path
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(sszBody)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+	if version != "" {
+		req.Header.Set("Eth-Consensus-Version", version)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("beacon POST SSZ %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("beacon POST SSZ %s: status %d: %s", path, resp.StatusCode, string(body))
+	}
+	return nil
+}

--- a/cl/validator/devvalidator/client.go
+++ b/cl/validator/devvalidator/client.go
@@ -86,6 +86,36 @@ func (c *BeaconClient) post(ctx context.Context, path string, body interface{}) 
 	return nil
 }
 
+// postJSON performs a POST request with a JSON body and Eth-Consensus-Version header.
+func (c *BeaconClient) postJSON(ctx context.Context, path string, body interface{}, version string) error {
+	url := c.baseURL + path
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(jsonBody)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if version != "" {
+		req.Header.Set("Eth-Consensus-Version", version)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("beacon POST %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("beacon POST %s: status %d: %s", path, resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
 // postSSZ performs a POST request with an SSZ body and Eth-Consensus-Version header.
 func (c *BeaconClient) postSSZ(ctx context.Context, path string, sszBody []byte, version string) error {
 	url := c.baseURL + path

--- a/cl/validator/devvalidator/client.go
+++ b/cl/validator/devvalidator/client.go
@@ -86,6 +86,41 @@ func (c *BeaconClient) post(ctx context.Context, path string, body interface{}) 
 	return nil
 }
 
+// postAndDecode performs a POST request with a JSON body and unmarshals the
+// response `data` field into dst. This is needed for endpoints like
+// /eth/v1/validator/duties/attester/{epoch} which are POST-only per spec.
+func (c *BeaconClient) postAndDecode(ctx context.Context, path string, body interface{}, dst interface{}) error {
+	url := c.baseURL + path
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(jsonBody)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("beacon POST %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("beacon POST %s: status %d: %s", path, resp.StatusCode, string(respBody))
+	}
+
+	var wrapper beaconResponse
+	if err := json.NewDecoder(resp.Body).Decode(&wrapper); err != nil {
+		return fmt.Errorf("beacon POST %s: decode: %w", path, err)
+	}
+	return json.Unmarshal(wrapper.Data, dst)
+}
+
 // postJSON performs a POST request with a JSON body and Eth-Consensus-Version header.
 func (c *BeaconClient) postJSON(ctx context.Context, path string, body interface{}, version string) error {
 	url := c.baseURL + path

--- a/cl/validator/devvalidator/client_test.go
+++ b/cl/validator/devvalidator/client_test.go
@@ -1,0 +1,88 @@
+package devvalidator
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPostAndDecode_AttesterDuties verifies that postAndDecode correctly
+// sends a POST with a JSON body and decodes the response's "data" field.
+// This is a regression test for the bug where maybeAttest used post()
+// (which discards the response) followed by get() (which hits a
+// non-existent GET endpoint → 405).
+func TestPostAndDecode_AttesterDuties(t *testing.T) {
+	type duty struct {
+		ValidatorIndex string `json:"validator_index"`
+		Slot           string `json:"slot"`
+	}
+
+	expectedDuties := []duty{
+		{ValidatorIndex: "0", Slot: "5"},
+		{ValidatorIndex: "1", Slot: "5"},
+	}
+
+	// Mock beacon server: POST-only attester duties endpoint.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/eth/v1/validator/duties/attester/0", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		// Verify we received valid JSON indices in the body.
+		var indices []string
+		if err := json.NewDecoder(r.Body).Decode(&indices); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		require.NotEmpty(t, indices)
+
+		// Return duties wrapped in standard Beacon API response.
+		resp := map[string]interface{}{"data": expectedDuties}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client := NewBeaconClient(srv.URL)
+	ctx := context.Background()
+
+	// postAndDecode should succeed and parse the duties.
+	var duties []duty
+	err := client.postAndDecode(ctx, "/eth/v1/validator/duties/attester/0", []string{"0", "1"}, &duties)
+	require.NoError(t, err)
+	require.Len(t, duties, 2)
+	require.Equal(t, "0", duties[0].ValidatorIndex)
+	require.Equal(t, "5", duties[0].Slot)
+}
+
+// TestGet_AttesterDuties_Fails confirms that a GET request to a POST-only
+// endpoint returns an error. This documents the original bug.
+func TestGet_AttesterDuties_Fails(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/eth/v1/validator/duties/attester/0", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		resp := map[string]interface{}{"data": []interface{}{}}
+		json.NewEncoder(w).Encode(resp)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client := NewBeaconClient(srv.URL)
+	ctx := context.Background()
+
+	// GET must fail with 405 — this is the bug that postAndDecode fixes.
+	var duties []interface{}
+	err := client.get(ctx, "/eth/v1/validator/duties/attester/0", &duties)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "405")
+}

--- a/cl/validator/devvalidator/keys.go
+++ b/cl/validator/devvalidator/keys.go
@@ -1,0 +1,48 @@
+package devvalidator
+
+import (
+	"github.com/erigontech/erigon/cl/clparams/devgenesis"
+	"github.com/erigontech/erigon/cl/utils/bls"
+	"github.com/erigontech/erigon/common"
+)
+
+// ValidatorKey holds a BLS keypair and its on-chain validator index.
+type ValidatorKey struct {
+	PrivKey        *bls.PrivateKey
+	PubKey         bls.PublicKey
+	PubKeyBytes    [48]byte
+	ValidatorIndex uint64 // set after resolving against beacon state
+}
+
+// LoadKeys derives deterministic BLS keys from a seed and prepares them
+// for signing. Validator indices are resolved later via the Beacon API.
+func LoadKeys(seed string, count int) ([]*ValidatorKey, error) {
+	privKeys, err := devgenesis.DeriveKeys(seed, count)
+	if err != nil {
+		return nil, err
+	}
+
+	keys := make([]*ValidatorKey, count)
+	for i, priv := range privKeys {
+		pub := priv.PublicKey()
+		compressed := bls.CompressPublicKey(pub)
+		var pubBytes [48]byte
+		copy(pubBytes[:], compressed)
+
+		keys[i] = &ValidatorKey{
+			PrivKey:     priv,
+			PubKey:      pub,
+			PubKeyBytes: pubBytes,
+		}
+	}
+	return keys, nil
+}
+
+// PubKeyToKey returns a map from compressed pubkey to ValidatorKey for fast lookup.
+func PubKeyToKey(keys []*ValidatorKey) map[common.Bytes48]*ValidatorKey {
+	m := make(map[common.Bytes48]*ValidatorKey, len(keys))
+	for _, k := range keys {
+		m[common.Bytes48(k.PubKeyBytes)] = k
+	}
+	return m
+}

--- a/cl/validator/devvalidator/service.go
+++ b/cl/validator/devvalidator/service.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/erigontech/erigon/cl/clparams"
@@ -97,7 +98,13 @@ func (s *Service) waitForReady(ctx context.Context) {
 			GenesisValidatorsRoot string `json:"genesis_validators_root"`
 		}
 		if err := s.client.get(ctx, "/eth/v1/beacon/genesis", &genesis); err == nil {
-			fmt.Sscanf(genesis.GenesisTime, "%d", &s.genesisTime)
+			gt, parseErr := strconv.ParseUint(genesis.GenesisTime, 10, 64)
+			if parseErr != nil {
+				s.logger.Warn("[dev-validator] invalid genesis_time", "value", genesis.GenesisTime, "err", parseErr)
+				time.Sleep(time.Second)
+				continue
+			}
+			s.genesisTime = gt
 			root, err := hexutil.Decode(genesis.GenesisValidatorsRoot)
 			if err == nil && len(root) == 32 {
 				copy(s.genesisValidatorsRoot[:], root)
@@ -135,8 +142,10 @@ func (s *Service) resolveIndices(ctx context.Context) error {
 		var pub common.Bytes48
 		copy(pub[:], pubBytes)
 		if key, ok := s.keysByPub[pub]; ok {
-			idx := uint64(0)
-			fmt.Sscanf(v.Index, "%d", &idx)
+			idx, parseErr := strconv.ParseUint(v.Index, 10, 64)
+			if parseErr != nil {
+				continue
+			}
 			key.ValidatorIndex = idx
 			resolved++
 		}
@@ -213,8 +222,10 @@ func (s *Service) maybePropose(ctx context.Context, slot uint64) {
 	}
 
 	for _, duty := range duties {
-		dutySlot := uint64(0)
-		fmt.Sscanf(duty.Slot, "%d", &dutySlot)
+		dutySlot, parseErr := strconv.ParseUint(duty.Slot, 10, 64)
+		if parseErr != nil {
+			continue
+		}
 		if dutySlot != slot || slot == 0 {
 			continue // skip genesis slot
 		}
@@ -358,8 +369,10 @@ func (s *Service) maybeAttest(ctx context.Context, slot uint64) {
 
 	attested := 0
 	for _, duty := range duties {
-		dutySlot := uint64(0)
-		fmt.Sscanf(duty.Slot, "%d", &dutySlot)
+		dutySlot, parseErr := strconv.ParseUint(duty.Slot, 10, 64)
+		if parseErr != nil {
+			continue
+		}
 		if dutySlot != slot {
 			continue
 		}
@@ -375,8 +388,10 @@ func (s *Service) maybeAttest(ctx context.Context, slot uint64) {
 			continue
 		}
 
-		committeeIndex := uint64(0)
-		fmt.Sscanf(duty.CommitteeIndex, "%d", &committeeIndex)
+		committeeIndex, parseErr := strconv.ParseUint(duty.CommitteeIndex, 10, 64)
+		if parseErr != nil {
+			continue
+		}
 
 		// Get attestation data for this slot + committee.
 		attPath := fmt.Sprintf("/eth/v1/validator/attestation_data?slot=%d&committee_index=%d",
@@ -395,10 +410,14 @@ func (s *Service) maybeAttest(ctx context.Context, slot uint64) {
 		}
 
 		// Build aggregation bits — set our bit position.
-		committeeLength := uint64(0)
-		validatorPosition := uint64(0)
-		fmt.Sscanf(duty.CommitteeLength, "%d", &committeeLength)
-		fmt.Sscanf(duty.ValidatorCommitteeIndex, "%d", &validatorPosition)
+		committeeLength, parseErr := strconv.ParseUint(duty.CommitteeLength, 10, 64)
+		if parseErr != nil {
+			continue
+		}
+		validatorPosition, parseErr := strconv.ParseUint(duty.ValidatorCommitteeIndex, 10, 64)
+		if parseErr != nil {
+			continue
+		}
 
 		aggBitsLen := (committeeLength + 7) / 8
 		aggBits := make([]byte, aggBitsLen)

--- a/cl/validator/devvalidator/service.go
+++ b/cl/validator/devvalidator/service.go
@@ -265,10 +265,25 @@ func (s *Service) proposeBlock(ctx context.Context, slot uint64, key *ValidatorK
 		return fmt.Errorf("get block template: %w", getErr)
 	}
 
-	// Parse the block into a SignedBeaconBlock (signature is zero initially).
+	// Parse the block template. The v3 response is a DenebBeaconBlock
+	// ({"block": {...}, "kzg_proofs": [...], "blobs": [...]}).
 	version := s.cfg.GetCurrentStateVersion(epoch)
+	var denebBlock struct {
+		Block     json.RawMessage `json:"block"`
+		KZGProofs json.RawMessage `json:"kzg_proofs"`
+		Blobs     json.RawMessage `json:"blobs"`
+	}
+	if err := json.Unmarshal(blockResponse, &denebBlock); err != nil {
+		return fmt.Errorf("parse deneb block wrapper: %w", err)
+	}
+	// The inner "block" is a BeaconBlock.
+	blockJSON := denebBlock.Block
+	if len(blockJSON) == 0 {
+		// Pre-Deneb or non-wrapped response: use the raw response directly.
+		blockJSON = blockResponse
+	}
 	block := cltypes.NewSignedBeaconBlock(s.cfg, version)
-	if err := json.Unmarshal(blockResponse, block.Block); err != nil {
+	if err := json.Unmarshal(blockJSON, block.Block); err != nil {
 		return fmt.Errorf("parse block template: %w", err)
 	}
 

--- a/cl/validator/devvalidator/service.go
+++ b/cl/validator/devvalidator/service.go
@@ -1,0 +1,288 @@
+// Package devvalidator implements an embedded validator client for dev mode.
+// It uses the standard Beacon API (same endpoints as Lighthouse/Teku) to
+// propose blocks and submit attestations. Intended for development and
+// integration testing only — not for production use.
+package devvalidator
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/common/log/v3"
+)
+
+// Service is the embedded dev validator. It runs as a goroutine inside
+// Caplin, producing blocks and attestations for all configured validators.
+type Service struct {
+	client    *BeaconClient
+	keys      []*ValidatorKey
+	keysByPub map[common.Bytes48]*ValidatorKey
+	cfg       *clparams.BeaconChainConfig
+	logger    log.Logger
+	cancel    context.CancelFunc
+}
+
+// NewService creates a dev validator service.
+func NewService(beaconAPIURL string, seed string, validatorCount int,
+	cfg *clparams.BeaconChainConfig, logger log.Logger) (*Service, error) {
+
+	keys, err := LoadKeys(seed, validatorCount)
+	if err != nil {
+		return nil, fmt.Errorf("load dev validator keys: %w", err)
+	}
+
+	return &Service{
+		client:    NewBeaconClient(beaconAPIURL),
+		keys:      keys,
+		keysByPub: PubKeyToKey(keys),
+		cfg:       cfg,
+		logger:    logger,
+	}, nil
+}
+
+// Start begins the validator duty loop. It blocks until the context is cancelled.
+func (s *Service) Start(ctx context.Context) {
+	ctx, s.cancel = context.WithCancel(ctx)
+
+	// Wait for the beacon node to be ready.
+	s.waitForReady(ctx)
+	if ctx.Err() != nil {
+		return
+	}
+
+	// Resolve validator indices from the beacon state.
+	if err := s.resolveIndices(ctx); err != nil {
+		s.logger.Error("[dev-validator] failed to resolve indices", "err", err)
+		return
+	}
+
+	s.logger.Info("[dev-validator] started",
+		"validators", len(s.keys),
+		"slotsPerEpoch", s.cfg.SlotsPerEpoch,
+		"secondsPerSlot", s.cfg.SecondsPerSlot,
+	)
+
+	// Main slot loop.
+	s.slotLoop(ctx)
+}
+
+// Stop cancels the validator service.
+func (s *Service) Stop() {
+	if s.cancel != nil {
+		s.cancel()
+	}
+}
+
+// waitForReady polls the beacon node until it responds.
+func (s *Service) waitForReady(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		var genesis struct {
+			GenesisTime string `json:"genesis_time"`
+		}
+		if err := s.client.get(ctx, "/eth/v1/beacon/genesis", &genesis); err == nil {
+			s.logger.Info("[dev-validator] beacon node ready", "genesisTime", genesis.GenesisTime)
+			return
+		}
+		time.Sleep(time.Second)
+	}
+}
+
+// resolveIndices maps pubkeys to on-chain validator indices.
+func (s *Service) resolveIndices(ctx context.Context) error {
+	type validatorEntry struct {
+		Index     string `json:"index"`
+		Validator struct {
+			Pubkey string `json:"pubkey"`
+		} `json:"validator"`
+	}
+
+	var validators []validatorEntry
+	if err := s.client.get(ctx, "/eth/v1/beacon/states/head/validators", &validators); err != nil {
+		return fmt.Errorf("get validators: %w", err)
+	}
+
+	resolved := 0
+	for _, v := range validators {
+		pubBytes, err := hexutil.Decode(v.Validator.Pubkey)
+		if err != nil || len(pubBytes) != 48 {
+			continue
+		}
+		var pub common.Bytes48
+		copy(pub[:], pubBytes)
+		if key, ok := s.keysByPub[pub]; ok {
+			idx := uint64(0)
+			fmt.Sscanf(v.Index, "%d", &idx)
+			key.ValidatorIndex = idx
+			resolved++
+		}
+	}
+
+	s.logger.Info("[dev-validator] resolved validator indices", "resolved", resolved, "total", len(s.keys))
+	if resolved == 0 {
+		return fmt.Errorf("no validators found in beacon state matching our keys")
+	}
+	return nil
+}
+
+// slotLoop runs once per slot, checking duties and performing them.
+func (s *Service) slotLoop(ctx context.Context) {
+	// Get genesis time to compute slot boundaries.
+	var genesis struct {
+		GenesisTime string `json:"genesis_time"`
+	}
+	if err := s.client.get(ctx, "/eth/v1/beacon/genesis", &genesis); err != nil {
+		s.logger.Error("[dev-validator] failed to get genesis", "err", err)
+		return
+	}
+	genesisTime := uint64(0)
+	fmt.Sscanf(genesis.GenesisTime, "%d", &genesisTime)
+
+	secPerSlot := s.cfg.SecondsPerSlot
+	slotDuration := time.Duration(secPerSlot) * time.Second
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		now := uint64(time.Now().Unix())
+		if now < genesisTime {
+			time.Sleep(time.Until(time.Unix(int64(genesisTime), 0)))
+			continue
+		}
+
+		currentSlot := (now - genesisTime) / secPerSlot
+		slotStart := time.Unix(int64(genesisTime+currentSlot*secPerSlot), 0)
+		nextSlotStart := slotStart.Add(slotDuration)
+
+		// Wait until 1/3 into the slot for proposals, then attest.
+		proposalTime := slotStart.Add(slotDuration / 3)
+		if time.Now().Before(proposalTime) {
+			time.Sleep(time.Until(proposalTime))
+		}
+
+		if ctx.Err() != nil {
+			return
+		}
+
+		// Propose if we have a duty for this slot.
+		s.maybePropose(ctx, currentSlot)
+
+		// Attest for all validators with duties at this slot.
+		s.maybeAttest(ctx, currentSlot)
+
+		// Wait for next slot.
+		if time.Now().Before(nextSlotStart) {
+			time.Sleep(time.Until(nextSlotStart))
+		}
+	}
+}
+
+// maybePropose checks if any of our validators should propose at this slot
+// and produces a block if so.
+func (s *Service) maybePropose(ctx context.Context, slot uint64) {
+	epoch := slot / s.cfg.SlotsPerEpoch
+
+	// Get proposer duties for this epoch.
+	type proposerDuty struct {
+		Pubkey         string `json:"pubkey"`
+		ValidatorIndex string `json:"validator_index"`
+		Slot           string `json:"slot"`
+	}
+	var duties []proposerDuty
+	path := fmt.Sprintf("/eth/v1/validator/duties/proposer/%d", epoch)
+	if err := s.client.get(ctx, path, &duties); err != nil {
+		return // silently skip — node may not be ready
+	}
+
+	for _, duty := range duties {
+		dutySlot := uint64(0)
+		fmt.Sscanf(duty.Slot, "%d", &dutySlot)
+		if dutySlot != slot {
+			continue
+		}
+
+		pubBytes, err := hexutil.Decode(duty.Pubkey)
+		if err != nil || len(pubBytes) != 48 {
+			continue
+		}
+		var pub common.Bytes48
+		copy(pub[:], pubBytes)
+		key, ok := s.keysByPub[pub]
+		if !ok {
+			continue
+		}
+
+		s.logger.Info("[dev-validator] proposing block", "slot", slot, "validator", key.ValidatorIndex)
+		if err := s.proposeBlock(ctx, slot, key); err != nil {
+			s.logger.Warn("[dev-validator] proposal failed", "slot", slot, "err", err)
+		}
+	}
+}
+
+// proposeBlock fetches a block template, signs it, and submits it.
+func (s *Service) proposeBlock(ctx context.Context, slot uint64, key *ValidatorKey) error {
+	// Compute RANDAO reveal: sign(epoch, DOMAIN_RANDAO).
+	epoch := slot / s.cfg.SlotsPerEpoch
+	randaoReveal, err := s.signEpoch(epoch, key)
+	if err != nil {
+		return fmt.Errorf("randao reveal: %w", err)
+	}
+
+	// Get block template.
+	path := fmt.Sprintf("/eth/v3/validator/blocks/%d?randao_reveal=%s&graffiti=0x%064x",
+		slot, hexutil.Encode(randaoReveal[:]), 0)
+
+	var blockResponse json.RawMessage
+	if err := s.client.get(ctx, path, &blockResponse); err != nil {
+		return fmt.Errorf("get block: %w", err)
+	}
+
+	// The block template needs to be signed and submitted.
+	// For now, submit the unsigned block — the beacon node will handle it.
+	// TODO: parse block, compute signing root, sign with BLS, submit signed block.
+	s.logger.Info("[dev-validator] got block template", "slot", slot, "size", len(blockResponse))
+
+	return nil
+}
+
+// signEpoch computes the RANDAO reveal: BLS signature of the epoch.
+func (s *Service) signEpoch(epoch uint64, key *ValidatorKey) ([96]byte, error) {
+	var epochBytes [32]byte
+	binary.LittleEndian.PutUint64(epochBytes[:8], epoch)
+	// TODO: compute proper signing root with domain separation
+	sig := key.PrivKey.Sign(epochBytes[:])
+	sigBytes := sig.Bytes()
+	var result [96]byte
+	copy(result[:], sigBytes)
+	return result, nil
+}
+
+// maybeAttest submits attestations for validators with duties at this slot.
+func (s *Service) maybeAttest(ctx context.Context, slot uint64) {
+	// Get attestation data for this slot.
+	path := fmt.Sprintf("/eth/v1/validator/attestation_data?slot=%d&committee_index=0", slot)
+
+	var attData json.RawMessage
+	if err := s.client.get(ctx, path, &attData); err != nil {
+		return // silently skip
+	}
+
+	s.logger.Debug("[dev-validator] got attestation data", "slot", slot)
+	// TODO: for each validator with attester duty at this slot,
+	// sign the attestation data and submit via POST /eth/v1/beacon/pool/attestations
+}

--- a/cl/validator/devvalidator/service.go
+++ b/cl/validator/devvalidator/service.go
@@ -315,8 +315,8 @@ func (s *Service) proposeBlock(ctx context.Context, slot uint64, key *ValidatorK
 	if version >= clparams.DenebVersion {
 		submitBody = &cltypes.DenebSignedBeaconBlock{
 			SignedBlock: block,
-			KZGProofs:  solid.NewStaticListSSZ[*cltypes.KZGProof](cltypes.MaxBlobsCommittmentsPerBlock*int(s.cfg.NumberOfColumns), cltypes.BYTES_KZG_PROOF),
-			Blobs:      solid.NewStaticListSSZ[*cltypes.Blob](cltypes.MaxBlobsCommittmentsPerBlock, int(cltypes.BYTES_PER_BLOB)),
+			KZGProofs:   solid.NewStaticListSSZ[*cltypes.KZGProof](cltypes.MaxBlobsCommittmentsPerBlock*int(s.cfg.NumberOfColumns), cltypes.BYTES_KZG_PROOF),
+			Blobs:       solid.NewStaticListSSZ[*cltypes.Blob](cltypes.MaxBlobsCommittmentsPerBlock, int(cltypes.BYTES_PER_BLOB)),
 		}
 	}
 	if err := s.client.postJSON(ctx, "/eth/v2/beacon/blocks", submitBody, versionStr); err != nil {

--- a/cl/validator/devvalidator/service.go
+++ b/cl/validator/devvalidator/service.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/common/log/v3"
@@ -237,46 +239,140 @@ func (s *Service) maybePropose(ctx context.Context, slot uint64) {
 
 // proposeBlock fetches a block template, signs it, and submits it.
 func (s *Service) proposeBlock(ctx context.Context, slot uint64, key *ValidatorKey) error {
-	// Compute RANDAO reveal: sign(epoch, DOMAIN_RANDAO).
 	epoch := slot / s.cfg.SlotsPerEpoch
-	randaoReveal, err := s.signEpoch(epoch, key)
+
+	// Compute RANDAO reveal.
+	randaoReveal, err := signRandaoReveal(key, epoch, s.cfg, s.genesisValidatorsRoot)
 	if err != nil {
 		return fmt.Errorf("randao reveal: %w", err)
 	}
 
-	// Get block template.
-	path := fmt.Sprintf("/eth/v3/validator/blocks/%d?randao_reveal=%s&graffiti=0x%064x",
-		slot, hexutil.Encode(randaoReveal[:]), 0)
+	// Get block template (unsigned BeaconBlock).
+	path := fmt.Sprintf("/eth/v3/validator/blocks/%d?randao_reveal=%s",
+		slot, hexutil.Encode(randaoReveal[:]))
 
 	var blockResponse json.RawMessage
 	if err := s.client.get(ctx, path, &blockResponse); err != nil {
-		return fmt.Errorf("get block: %w", err)
+		return fmt.Errorf("get block template: %w", err)
 	}
 
-	// The block template needs to be signed and submitted.
-	// For now, submit the unsigned block — the beacon node will handle it.
-	// TODO: parse block, compute signing root, sign with BLS, submit signed block.
-	s.logger.Info("[dev-validator] got block template", "slot", slot, "size", len(blockResponse))
+	// Parse the block into a SignedBeaconBlock (signature is zero initially).
+	version := s.cfg.GetCurrentStateVersion(epoch)
+	block := cltypes.NewSignedBeaconBlock(s.cfg, version)
+	if err := json.Unmarshal(blockResponse, block.Block); err != nil {
+		return fmt.Errorf("parse block template: %w", err)
+	}
 
+	// Sign the block.
+	sig, err := signBlock(key, block.Block, slot, s.cfg, s.genesisValidatorsRoot)
+	if err != nil {
+		return fmt.Errorf("sign block: %w", err)
+	}
+	block.Signature = sig
+
+	// Submit the signed block.
+	versionStr := version.String()
+	if err := s.client.postJSON(ctx, "/eth/v2/beacon/blocks", block, versionStr); err != nil {
+		return fmt.Errorf("submit block: %w", err)
+	}
+
+	s.logger.Info("[dev-validator] proposed block", "slot", slot, "validator", key.ValidatorIndex)
 	return nil
-}
-
-// signEpoch computes the RANDAO reveal using proper domain separation.
-func (s *Service) signEpoch(epoch uint64, key *ValidatorKey) (common.Bytes96, error) {
-	return signRandaoReveal(key, epoch, s.cfg, s.genesisValidatorsRoot)
 }
 
 // maybeAttest submits attestations for validators with duties at this slot.
 func (s *Service) maybeAttest(ctx context.Context, slot uint64) {
-	// Get attestation data for this slot.
-	path := fmt.Sprintf("/eth/v1/validator/attestation_data?slot=%d&committee_index=0", slot)
+	epoch := slot / s.cfg.SlotsPerEpoch
 
-	var attData json.RawMessage
-	if err := s.client.get(ctx, path, &attData); err != nil {
-		return // silently skip
+	// Get attester duties for this epoch.
+	type attesterDuty struct {
+		Pubkey                  string `json:"pubkey"`
+		ValidatorIndex          string `json:"validator_index"`
+		Slot                    string `json:"slot"`
+		CommitteeIndex          string `json:"committee_index"`
+		CommitteeLength         string `json:"committee_length"`
+		ValidatorCommitteeIndex string `json:"validator_committee_index"`
 	}
 
-	s.logger.Debug("[dev-validator] got attestation data", "slot", slot)
-	// TODO: for each validator with attester duty at this slot,
-	// sign the attestation data and submit via POST /eth/v1/beacon/pool/attestations
+	// POST attester duties with our validator indices.
+	indices := make([]string, 0, len(s.keys))
+	for _, k := range s.keys {
+		indices = append(indices, fmt.Sprintf("%d", k.ValidatorIndex))
+	}
+
+	var duties []attesterDuty
+	path := fmt.Sprintf("/eth/v1/validator/duties/attester/%d", epoch)
+	if err := s.client.post(ctx, path, indices); err != nil {
+		// Fall back to getting attestation data without duties.
+		return
+	}
+	// Re-fetch as GET with response.
+	if err := s.client.get(ctx, path, &duties); err != nil {
+		return
+	}
+
+	attested := 0
+	for _, duty := range duties {
+		dutySlot := uint64(0)
+		fmt.Sscanf(duty.Slot, "%d", &dutySlot)
+		if dutySlot != slot {
+			continue
+		}
+
+		pubBytes, err := hexutil.Decode(duty.Pubkey)
+		if err != nil || len(pubBytes) != 48 {
+			continue
+		}
+		var pub common.Bytes48
+		copy(pub[:], pubBytes)
+		key, ok := s.keysByPub[pub]
+		if !ok {
+			continue
+		}
+
+		committeeIndex := uint64(0)
+		fmt.Sscanf(duty.CommitteeIndex, "%d", &committeeIndex)
+
+		// Get attestation data for this slot + committee.
+		attPath := fmt.Sprintf("/eth/v1/validator/attestation_data?slot=%d&committee_index=%d",
+			slot, committeeIndex)
+
+		var attData solid.AttestationData
+		if err := s.client.get(ctx, attPath, &attData); err != nil {
+			continue
+		}
+
+		// Sign the attestation data.
+		sig, err := signAttestation(key, &attData, slot, s.cfg, s.genesisValidatorsRoot)
+		if err != nil {
+			s.logger.Warn("[dev-validator] attestation sign failed", "err", err)
+			continue
+		}
+
+		// Build aggregation bits — set our bit position.
+		committeeLength := uint64(0)
+		validatorPosition := uint64(0)
+		fmt.Sscanf(duty.CommitteeLength, "%d", &committeeLength)
+		fmt.Sscanf(duty.ValidatorCommitteeIndex, "%d", &validatorPosition)
+
+		aggBitsLen := (committeeLength + 7) / 8
+		aggBits := make([]byte, aggBitsLen)
+		aggBits[validatorPosition/8] |= 1 << (validatorPosition % 8)
+
+		// Submit attestation.
+		attestation := map[string]interface{}{
+			"aggregation_bits": hexutil.Encode(aggBits),
+			"data":             &attData,
+			"signature":        hexutil.Encode(sig[:]),
+		}
+		if err := s.client.post(ctx, "/eth/v1/beacon/pool/attestations", []interface{}{attestation}); err != nil {
+			s.logger.Debug("[dev-validator] attestation submit failed", "slot", slot, "err", err)
+			continue
+		}
+		attested++
+	}
+
+	if attested > 0 {
+		s.logger.Debug("[dev-validator] attested", "slot", slot, "count", attested)
+	}
 }

--- a/cl/validator/devvalidator/service.go
+++ b/cl/validator/devvalidator/service.go
@@ -6,7 +6,6 @@ package devvalidator
 
 import (
 	"context"
-	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -20,12 +19,14 @@ import (
 // Service is the embedded dev validator. It runs as a goroutine inside
 // Caplin, producing blocks and attestations for all configured validators.
 type Service struct {
-	client    *BeaconClient
-	keys      []*ValidatorKey
-	keysByPub map[common.Bytes48]*ValidatorKey
-	cfg       *clparams.BeaconChainConfig
-	logger    log.Logger
-	cancel    context.CancelFunc
+	client                *BeaconClient
+	keys                  []*ValidatorKey
+	keysByPub             map[common.Bytes48]*ValidatorKey
+	cfg                   *clparams.BeaconChainConfig
+	genesisValidatorsRoot common.Hash
+	genesisTime           uint64
+	logger                log.Logger
+	cancel                context.CancelFunc
 }
 
 // NewService creates a dev validator service.
@@ -79,7 +80,8 @@ func (s *Service) Stop() {
 	}
 }
 
-// waitForReady polls the beacon node until it responds.
+// waitForReady polls the beacon node until it responds, then fetches
+// genesis time and validators root needed for signing.
 func (s *Service) waitForReady(ctx context.Context) {
 	for {
 		select {
@@ -89,10 +91,19 @@ func (s *Service) waitForReady(ctx context.Context) {
 		}
 
 		var genesis struct {
-			GenesisTime string `json:"genesis_time"`
+			GenesisTime           string `json:"genesis_time"`
+			GenesisValidatorsRoot string `json:"genesis_validators_root"`
 		}
 		if err := s.client.get(ctx, "/eth/v1/beacon/genesis", &genesis); err == nil {
-			s.logger.Info("[dev-validator] beacon node ready", "genesisTime", genesis.GenesisTime)
+			fmt.Sscanf(genesis.GenesisTime, "%d", &s.genesisTime)
+			root, err := hexutil.Decode(genesis.GenesisValidatorsRoot)
+			if err == nil && len(root) == 32 {
+				copy(s.genesisValidatorsRoot[:], root)
+			}
+			s.logger.Info("[dev-validator] beacon node ready",
+				"genesisTime", s.genesisTime,
+				"validatorsRoot", s.genesisValidatorsRoot.Hex(),
+			)
 			return
 		}
 		time.Sleep(time.Second)
@@ -138,18 +149,8 @@ func (s *Service) resolveIndices(ctx context.Context) error {
 
 // slotLoop runs once per slot, checking duties and performing them.
 func (s *Service) slotLoop(ctx context.Context) {
-	// Get genesis time to compute slot boundaries.
-	var genesis struct {
-		GenesisTime string `json:"genesis_time"`
-	}
-	if err := s.client.get(ctx, "/eth/v1/beacon/genesis", &genesis); err != nil {
-		s.logger.Error("[dev-validator] failed to get genesis", "err", err)
-		return
-	}
-	genesisTime := uint64(0)
-	fmt.Sscanf(genesis.GenesisTime, "%d", &genesisTime)
-
 	secPerSlot := s.cfg.SecondsPerSlot
+	genesisTime := s.genesisTime
 	slotDuration := time.Duration(secPerSlot) * time.Second
 
 	for {
@@ -260,16 +261,9 @@ func (s *Service) proposeBlock(ctx context.Context, slot uint64, key *ValidatorK
 	return nil
 }
 
-// signEpoch computes the RANDAO reveal: BLS signature of the epoch.
-func (s *Service) signEpoch(epoch uint64, key *ValidatorKey) ([96]byte, error) {
-	var epochBytes [32]byte
-	binary.LittleEndian.PutUint64(epochBytes[:8], epoch)
-	// TODO: compute proper signing root with domain separation
-	sig := key.PrivKey.Sign(epochBytes[:])
-	sigBytes := sig.Bytes()
-	var result [96]byte
-	copy(result[:], sigBytes)
-	return result, nil
+// signEpoch computes the RANDAO reveal using proper domain separation.
+func (s *Service) signEpoch(epoch uint64, key *ValidatorKey) (common.Bytes96, error) {
+	return signRandaoReveal(key, epoch, s.cfg, s.genesisValidatorsRoot)
 }
 
 // maybeAttest submits attestations for validators with duties at this slot.

--- a/cl/validator/devvalidator/service.go
+++ b/cl/validator/devvalidator/service.go
@@ -349,12 +349,10 @@ func (s *Service) maybeAttest(ctx context.Context, slot uint64) {
 
 	var duties []attesterDuty
 	path := fmt.Sprintf("/eth/v1/validator/duties/attester/%d", epoch)
-	if err := s.client.post(ctx, path, indices); err != nil {
-		// Fall back to getting attestation data without duties.
-		return
-	}
-	// Re-fetch as GET with response.
-	if err := s.client.get(ctx, path, &duties); err != nil {
+	// Attester duties is POST-only per the Beacon API spec (the request body
+	// carries the validator index list). Use postAndDecode to send the indices
+	// and parse the response in a single round-trip.
+	if err := s.client.postAndDecode(ctx, path, indices, &duties); err != nil {
 		return
 	}
 

--- a/cl/validator/devvalidator/service.go
+++ b/cl/validator/devvalidator/service.go
@@ -272,6 +272,20 @@ func (s *Service) proposeBlock(ctx context.Context, slot uint64, key *ValidatorK
 		return fmt.Errorf("parse block template: %w", err)
 	}
 
+	// Ensure execution payload sub-fields are initialized (the JSON response
+	// may leave some nil which causes HashSSZ to panic).
+	if block.Block.Body.ExecutionPayload != nil {
+		if block.Block.Body.ExecutionPayload.Extra == nil {
+			block.Block.Body.ExecutionPayload.Extra = solid.NewExtraData()
+		}
+		if block.Block.Body.ExecutionPayload.Transactions == nil {
+			block.Block.Body.ExecutionPayload.Transactions = &solid.TransactionsSSZ{}
+		}
+		if version >= clparams.CapellaVersion && block.Block.Body.ExecutionPayload.Withdrawals == nil {
+			block.Block.Body.ExecutionPayload.Withdrawals = solid.NewStaticListSSZ[*cltypes.Withdrawal](int(s.cfg.MaxWithdrawalsPerPayload), 44)
+		}
+	}
+
 	// Sign the block.
 	sig, err := signBlock(key, block.Block, slot, s.cfg, s.genesisValidatorsRoot)
 	if err != nil {
@@ -279,9 +293,18 @@ func (s *Service) proposeBlock(ctx context.Context, slot uint64, key *ValidatorK
 	}
 	block.Signature = sig
 
-	// Submit the signed block.
+	// Submit the signed block. For Deneb+, wrap in DenebSignedBeaconBlock
+	// with empty blob sidecars.
 	versionStr := version.String()
-	if err := s.client.postJSON(ctx, "/eth/v2/beacon/blocks", block, versionStr); err != nil {
+	var submitBody interface{} = block
+	if version >= clparams.DenebVersion {
+		submitBody = &cltypes.DenebSignedBeaconBlock{
+			SignedBlock: block,
+			KZGProofs:  solid.NewStaticListSSZ[*cltypes.KZGProof](cltypes.MaxBlobsCommittmentsPerBlock*int(s.cfg.NumberOfColumns), cltypes.BYTES_KZG_PROOF),
+			Blobs:      solid.NewStaticListSSZ[*cltypes.Blob](cltypes.MaxBlobsCommittmentsPerBlock, int(cltypes.BYTES_PER_BLOB)),
+		}
+	}
+	if err := s.client.postJSON(ctx, "/eth/v2/beacon/blocks", submitBody, versionStr); err != nil {
 		return fmt.Errorf("submit block: %w", err)
 	}
 

--- a/cl/validator/devvalidator/service.go
+++ b/cl/validator/devvalidator/service.go
@@ -215,8 +215,8 @@ func (s *Service) maybePropose(ctx context.Context, slot uint64) {
 	for _, duty := range duties {
 		dutySlot := uint64(0)
 		fmt.Sscanf(duty.Slot, "%d", &dutySlot)
-		if dutySlot != slot {
-			continue
+		if dutySlot != slot || slot == 0 {
+			continue // skip genesis slot
 		}
 
 		pubBytes, err := hexutil.Decode(duty.Pubkey)
@@ -247,13 +247,22 @@ func (s *Service) proposeBlock(ctx context.Context, slot uint64, key *ValidatorK
 		return fmt.Errorf("randao reveal: %w", err)
 	}
 
-	// Get block template (unsigned BeaconBlock).
+	// Get block template (unsigned BeaconBlock). Retry a few times if the EL
+	// is busy with fork choice (semaphore contention in AssembleBlock).
 	path := fmt.Sprintf("/eth/v3/validator/blocks/%d?randao_reveal=%s",
 		slot, hexutil.Encode(randaoReveal[:]))
 
 	var blockResponse json.RawMessage
-	if err := s.client.get(ctx, path, &blockResponse); err != nil {
-		return fmt.Errorf("get block template: %w", err)
+	var getErr error
+	for attempt := 0; attempt < 5; attempt++ {
+		getErr = s.client.get(ctx, path, &blockResponse)
+		if getErr == nil {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	if getErr != nil {
+		return fmt.Errorf("get block template: %w", getErr)
 	}
 
 	// Parse the block into a SignedBeaconBlock (signature is zero initially).

--- a/cl/validator/devvalidator/signing.go
+++ b/cl/validator/devvalidator/signing.go
@@ -13,6 +13,14 @@ import (
 // signing provides BLS signing helpers using the correct domain separation
 // as defined by the Ethereum consensus spec.
 
+// forkVersionForEpoch returns the fork version active at the given epoch,
+// per the beacon chain config's fork schedule. This mirrors the spec's
+// get_domain logic: find the latest fork whose epoch <= the target epoch.
+func forkVersionForEpoch(epoch uint64, cfg *clparams.BeaconChainConfig) common.Bytes4 {
+	stateVersion := cfg.GetCurrentStateVersion(epoch)
+	return utils.Uint32ToBytes4(cfg.GetForkVersionByVersion(stateVersion))
+}
+
 // signObject signs an SSZ-hashable object with the given domain type.
 func signObject(
 	key *ValidatorKey,
@@ -22,7 +30,7 @@ func signObject(
 	cfg *clparams.BeaconChainConfig,
 	genesisValidatorsRoot common.Hash,
 ) (common.Bytes96, error) {
-	forkVersion := utils.Uint32ToBytes4(uint32(cfg.GenesisForkVersion))
+	forkVersion := forkVersionForEpoch(epoch, cfg)
 	domain, err := fork.ComputeDomain(domainType[:], forkVersion, genesisValidatorsRoot)
 	if err != nil {
 		return common.Bytes96{}, err

--- a/cl/validator/devvalidator/signing.go
+++ b/cl/validator/devvalidator/signing.go
@@ -1,0 +1,86 @@
+package devvalidator
+
+import (
+	"encoding/binary"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/fork"
+	"github.com/erigontech/erigon/cl/utils"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/ssz"
+)
+
+// signing provides BLS signing helpers using the correct domain separation
+// as defined by the Ethereum consensus spec.
+
+// signObject signs an SSZ-hashable object with the given domain type.
+func signObject(
+	key *ValidatorKey,
+	obj ssz.HashableSSZ,
+	domainType common.Bytes4,
+	epoch uint64,
+	cfg *clparams.BeaconChainConfig,
+	genesisValidatorsRoot common.Hash,
+) (common.Bytes96, error) {
+	forkVersion := utils.Uint32ToBytes4(uint32(cfg.GenesisForkVersion))
+	domain, err := fork.ComputeDomain(domainType[:], forkVersion, genesisValidatorsRoot)
+	if err != nil {
+		return common.Bytes96{}, err
+	}
+
+	signingRoot, err := fork.ComputeSigningRoot(obj, domain)
+	if err != nil {
+		return common.Bytes96{}, err
+	}
+
+	sig := key.PrivKey.Sign(signingRoot[:])
+	var result common.Bytes96
+	copy(result[:], sig.Bytes())
+	return result, nil
+}
+
+// epochSSZ is a minimal SSZ type wrapping a uint64 for RANDAO signing.
+type epochSSZ uint64
+
+func (e epochSSZ) HashSSZ() ([32]byte, error) {
+	var buf [32]byte
+	binary.LittleEndian.PutUint64(buf[:8], uint64(e))
+	return buf, nil
+}
+
+func (e epochSSZ) EncodingSizeSSZ() int { return 8 }
+
+// signRandaoReveal computes the RANDAO reveal for the given epoch:
+// BLS_sign(compute_signing_root(epoch, get_domain(DOMAIN_RANDAO, epoch)))
+func signRandaoReveal(
+	key *ValidatorKey,
+	epoch uint64,
+	cfg *clparams.BeaconChainConfig,
+	genesisValidatorsRoot common.Hash,
+) (common.Bytes96, error) {
+	return signObject(key, epochSSZ(epoch), cfg.DomainRandao, epoch, cfg, genesisValidatorsRoot)
+}
+
+// signBlock signs a beacon block with DOMAIN_BEACON_PROPOSER.
+func signBlock(
+	key *ValidatorKey,
+	block ssz.HashableSSZ,
+	slot uint64,
+	cfg *clparams.BeaconChainConfig,
+	genesisValidatorsRoot common.Hash,
+) (common.Bytes96, error) {
+	epoch := slot / cfg.SlotsPerEpoch
+	return signObject(key, block, cfg.DomainBeaconProposer, epoch, cfg, genesisValidatorsRoot)
+}
+
+// signAttestation signs attestation data with DOMAIN_BEACON_ATTESTER.
+func signAttestation(
+	key *ValidatorKey,
+	attData ssz.HashableSSZ,
+	slot uint64,
+	cfg *clparams.BeaconChainConfig,
+	genesisValidatorsRoot common.Hash,
+) (common.Bytes96, error) {
+	epoch := slot / cfg.SlotsPerEpoch
+	return signObject(key, attData, cfg.DomainBeaconAttester, epoch, cfg, genesisValidatorsRoot)
+}

--- a/cl/validator/devvalidator/signing_test.go
+++ b/cl/validator/devvalidator/signing_test.go
@@ -1,0 +1,95 @@
+package devvalidator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/clparams/devgenesis"
+	"github.com/erigontech/erigon/cl/fork"
+	"github.com/erigontech/erigon/cl/utils"
+	"github.com/erigontech/erigon/common"
+)
+
+// TestForkVersionForEpoch_DevMode verifies that forkVersionForEpoch returns
+// the correct (latest active) fork version, not GenesisForkVersion, when
+// all forks are activated at epoch 0.
+func TestForkVersionForEpoch_DevMode(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	// Simulate dev mode: all forks at epoch 0.
+	cfg.AltairForkEpoch = 0
+	cfg.BellatrixForkEpoch = 0
+	cfg.CapellaForkEpoch = 0
+	cfg.DenebForkEpoch = 0
+	cfg.ElectraForkEpoch = 0
+	cfg.FuluForkEpoch = 0
+
+	fv := forkVersionForEpoch(0, &cfg)
+
+	// Must NOT be GenesisForkVersion.
+	genesisVersion := common.Bytes4(utils.Uint32ToBytes4(uint32(cfg.GenesisForkVersion)))
+	require.NotEqual(t, genesisVersion, fv,
+		"dev mode epoch 0 should use the latest fork version, not GenesisForkVersion")
+
+	// Must be FuluForkVersion (the latest fork with epoch <= 0).
+	expected := common.Bytes4(utils.Uint32ToBytes4(uint32(cfg.FuluForkVersion)))
+	require.Equal(t, expected, fv)
+}
+
+// TestForkVersionForEpoch_MainnetProgression verifies that on mainnet config
+// (where forks activate at different epochs), the version progresses correctly.
+func TestForkVersionForEpoch_MainnetProgression(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+
+	// Before Altair → GenesisForkVersion.
+	fv := forkVersionForEpoch(0, &cfg)
+	require.Equal(t, common.Bytes4(utils.Uint32ToBytes4(uint32(cfg.GenesisForkVersion))), fv)
+
+	// At Altair epoch → AltairForkVersion.
+	fv = forkVersionForEpoch(cfg.AltairForkEpoch, &cfg)
+	require.Equal(t, common.Bytes4(utils.Uint32ToBytes4(uint32(cfg.AltairForkVersion))), fv)
+
+	// At Deneb epoch → DenebForkVersion.
+	fv = forkVersionForEpoch(cfg.DenebForkEpoch, &cfg)
+	require.Equal(t, common.Bytes4(utils.Uint32ToBytes4(uint32(cfg.DenebForkVersion))), fv)
+}
+
+// TestSigningDomainMatchesGenesis verifies that the domain computed by
+// signObject at epoch 0 matches the domain derived from the genesis state's
+// Fork.CurrentVersion. This is the core invariant: if these two diverge,
+// every block proposal and attestation in dev mode will be rejected.
+func TestSigningDomainMatchesGenesis(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.AltairForkEpoch = 0
+	cfg.BellatrixForkEpoch = 0
+	cfg.CapellaForkEpoch = 0
+	cfg.DenebForkEpoch = 0
+	cfg.ElectraForkEpoch = 0
+	cfg.FuluForkEpoch = 0
+
+	genesisTime := uint64(1000)
+	elHash := common.Hash{}
+
+	state, _, err := devgenesis.BuildGenesisState("test", 4, &cfg, genesisTime, elHash)
+	require.NoError(t, err)
+
+	gvr := state.GenesisValidatorsRoot()
+
+	// Domain from genesis state's Fork.CurrentVersion.
+	stateForkVersion := state.Fork().CurrentVersion
+	stateDomain, err := fork.ComputeDomain(
+		cfg.DomainBeaconProposer[:], stateForkVersion, gvr,
+	)
+	require.NoError(t, err)
+
+	// Domain from signing code's forkVersionForEpoch.
+	signingForkVersion := forkVersionForEpoch(0, &cfg)
+	signingDomain, err := fork.ComputeDomain(
+		cfg.DomainBeaconProposer[:], signingForkVersion, gvr,
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, stateDomain, signingDomain,
+		"signing domain must match genesis state domain at epoch 0")
+}

--- a/cmd/caplin/caplin1/dev_genesis.go
+++ b/cmd/caplin/caplin1/dev_genesis.go
@@ -1,0 +1,78 @@
+package caplin1
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/cl/persistence/beacon_indicies"
+	"github.com/erigontech/erigon/cl/phase1/core/state"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
+)
+
+// writeDevGenesisBeaconBlock constructs and writes the genesis beacon block to
+// the index DB. This is the minimal equivalent of clstages.writeGenesisBeaconBlock
+// but runs during startup before the fork choice is created.
+func writeDevGenesisBeaconBlock(ctx context.Context, genesisState *state.CachingBeaconState, cfg *clparams.BeaconChainConfig, db kv.RwDB) error {
+	version := genesisState.Version()
+	block := cltypes.NewSignedBeaconBlock(cfg, version)
+	blk := block.Block
+
+	header := genesisState.LatestBlockHeader()
+	blk.Slot = header.Slot
+	blk.ProposerIndex = header.ProposerIndex
+	blk.ParentRoot = header.ParentRoot
+
+	// Fill in the state root (zeroed in LatestBlockHeader per spec).
+	stateRoot, err := genesisState.HashSSZ()
+	if err != nil {
+		return fmt.Errorf("compute genesis state root: %w", err)
+	}
+	blk.StateRoot = stateRoot
+
+	// Initialize the body with preset-aware defaults.
+	body := blk.Body
+	if version >= clparams.AltairVersion {
+		body.SyncAggregate = cltypes.NewSyncAggregateWithSize(int(cfg.SyncCommitteeSize) / 8)
+	}
+	if version >= clparams.BellatrixVersion {
+		body.ExecutionPayload.Extra = solid.NewExtraData()
+		body.ExecutionPayload.Transactions = &solid.TransactionsSSZ{}
+
+		// Copy execution payload header from genesis state so the block hash
+		// matches the EL genesis (needed for fork choice to find the EL block).
+		execHeader := genesisState.LatestExecutionPayloadHeader()
+		if execHeader != nil {
+			body.ExecutionPayload.BlockHash = execHeader.BlockHash
+			body.ExecutionPayload.StateRoot = execHeader.StateRoot
+			body.ExecutionPayload.ParentHash = execHeader.ParentHash
+			body.ExecutionPayload.BlockNumber = execHeader.BlockNumber
+			body.ExecutionPayload.GasLimit = execHeader.GasLimit
+			body.ExecutionPayload.Time = execHeader.Time
+			body.ExecutionPayload.BaseFeePerGas = execHeader.BaseFeePerGas
+		}
+
+		if version >= clparams.CapellaVersion {
+			body.ExecutionPayload.Withdrawals = solid.NewStaticListSSZ[*cltypes.Withdrawal](int(cfg.MaxWithdrawalsPerPayload), 44)
+		}
+	}
+
+	blockRoot, err := blk.HashSSZ()
+	if err != nil {
+		return fmt.Errorf("compute genesis block root: %w", err)
+	}
+
+	log.Info("[dev-genesis] writing genesis beacon block",
+		"blockRoot", common.Hash(blockRoot).Hex(),
+		"stateRoot", common.Hash(stateRoot).Hex(),
+		"execBlockHash", body.ExecutionPayload.BlockHash.Hex(),
+	)
+
+	return db.Update(ctx, func(tx kv.RwTx) error {
+		return beacon_indicies.WriteBeaconBlockAndIndicies(ctx, tx, block, true)
+	})
+}

--- a/cmd/caplin/caplin1/run.go
+++ b/cmd/caplin/caplin1/run.go
@@ -230,6 +230,15 @@ func RunCaplinService(ctx context.Context, engine execution_client.ExecutionEngi
 		return err
 	}
 
+	// For dev mode (PoS from genesis), write the genesis beacon block to the
+	// index DB before the fork choice is created. This ensures the anchor
+	// block exists and the fork choice can resolve the EL genesis hash.
+	if config.DevValidatorSeed != "" && state != nil {
+		if err := writeDevGenesisBeaconBlock(ctx, state, beaconConfig, indexDB); err != nil {
+			return fmt.Errorf("write dev genesis beacon block: %w", err)
+		}
+	}
+
 	caplinOptions := []CaplinOption{}
 	if config.BeaconAPIRouter.Builder {
 		if config.RelayUrlExist() {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2011,10 +2011,21 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 		cfg.InternalCL = true
 		cfg.CaplinConfig.DevValidatorSeed = seed
 		cfg.CaplinConfig.DevValidatorCount = validatorCount
+		// Enable Beacon API endpoints needed by the dev validator.
+		cfg.CaplinConfig.BeaconAPIRouter.Active = true
+		if cfg.CaplinConfig.BeaconAPIRouter.Address == "" {
+			cfg.CaplinConfig.BeaconAPIRouter.Address = "127.0.0.1:5555"
+		}
 
 		// Build beacon genesis state and write to temp file for Caplin.
 		beaconCfg := clparams.MainnetBeaconConfig
 		clparams.ApplyMinimalPreset(&beaconCfg)
+		// Enable all forks from genesis (PoS from block 0).
+		beaconCfg.AltairForkEpoch = 0
+		beaconCfg.BellatrixForkEpoch = 0
+		beaconCfg.CapellaForkEpoch = 0
+		beaconCfg.DenebForkEpoch = 0
+		beaconCfg.InitializeForkSchedule()
 		genesisTime := uint64(time.Now().Unix())
 		// Compute the EL genesis block hash so the beacon state's Eth1Data
 		// matches the actual chain genesis.
@@ -2034,9 +2045,17 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 		genesisStatePath := filepath.Join(tmpDir, "genesis.ssz")
 		os.WriteFile(genesisStatePath, stateSSZ, 0644)
 
-		// Write minimal beacon config YAML.
+		// Write beacon config YAML with all forks enabled from genesis.
 		configPath := filepath.Join(tmpDir, "config.yaml")
-		configYAML := fmt.Sprintf("PRESET_BASE: minimal\nMIN_GENESIS_TIME: %d\n", genesisTime)
+		configYAML := fmt.Sprintf(
+			"PRESET_BASE: minimal\n"+
+				"MIN_GENESIS_TIME: %d\n"+
+				"ALTAIR_FORK_EPOCH: 0\n"+
+				"BELLATRIX_FORK_EPOCH: 0\n"+
+				"CAPELLA_FORK_EPOCH: 0\n"+
+				"DENEB_FORK_EPOCH: 0\n"+
+				"TERMINAL_TOTAL_DIFFICULTY: 0\n",
+			genesisTime)
 		os.WriteFile(configPath, []byte(configYAML), 0644)
 
 		cfg.CaplinConfig.CustomConfigPath = configPath

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2054,10 +2054,17 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 		}
 		// Write beacon config and genesis state to temp files.
 		tmpDir := filepath.Join(cfg.Dirs.DataDir, "dev-beacon")
-		os.MkdirAll(tmpDir, 0755)
-		stateSSZ, _ := beaconState.EncodeSSZ(nil)
+		if err := os.MkdirAll(tmpDir, 0755); err != nil {
+			Fatalf("Failed to create dev beacon dir: %v", err)
+		}
+		stateSSZ, err := beaconState.EncodeSSZ(nil)
+		if err != nil {
+			Fatalf("Failed to encode dev genesis state: %v", err)
+		}
 		genesisStatePath := filepath.Join(tmpDir, "genesis.ssz")
-		os.WriteFile(genesisStatePath, stateSSZ, 0644)
+		if err := os.WriteFile(genesisStatePath, stateSSZ, 0644); err != nil {
+			Fatalf("Failed to write dev genesis state: %v", err)
+		}
 
 		// Write beacon config YAML with all forks enabled from genesis.
 		configPath := filepath.Join(tmpDir, "config.yaml")
@@ -2071,7 +2078,9 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 				"DENEB_FORK_EPOCH: 0\n"+
 				"TERMINAL_TOTAL_DIFFICULTY: 0\n",
 			genesisTime, beaconCfg.SecondsPerSlot)
-		os.WriteFile(configPath, []byte(configYAML), 0644)
+		if err := os.WriteFile(configPath, []byte(configYAML), 0644); err != nil {
+			Fatalf("Failed to write dev beacon config: %v", err)
+		}
 
 		cfg.CaplinConfig.CustomConfigPath = configPath
 		cfg.CaplinConfig.CustomGenesisStatePath = genesisStatePath

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -116,6 +116,11 @@ var (
 		Usage: "Number of validators for PoS dev mode",
 		Value: 64,
 	}
+	DevSlotTimeFlag = cli.IntFlag{
+		Name:  "dev.slot-time",
+		Usage: "Slot duration in seconds for PoS dev mode (default: 6)",
+		Value: 6,
+	}
 	ChainFlag = cli.StringFlag{
 		Name:  "chain",
 		Usage: "name of the network to join",
@@ -2001,17 +2006,21 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 
 		// Build PoS EL genesis (TTD=0, post-merge from genesis).
 		cfg.Genesis = chainspec.DeveloperGenesisBlock(0, signerAddr)
-		// Override: remove Clique, set TTD=0 for PoS.
+		// Override: remove Clique, set TTD=0, enable all forks from genesis.
 		cfg.Genesis.Config.Clique = nil
 		cfg.Genesis.Config.TerminalTotalDifficulty = big.NewInt(0)
 		cfg.Genesis.Config.TerminalTotalDifficultyPassed = true
 		cfg.Genesis.ExtraData = make([]byte, 32) // no Clique signer in extra data
+		zero := uint64(0)
+		cfg.Genesis.Config.ShanghaiTime = &zero
+		cfg.Genesis.Config.CancunTime = &zero
+		cfg.Genesis.Config.PragueTime = nil // Prague may need more config; leave disabled
 
 		// Configure embedded Caplin + dev validator.
 		cfg.InternalCL = true
 		cfg.CaplinConfig.DevValidatorSeed = seed
 		cfg.CaplinConfig.DevValidatorCount = validatorCount
-		// Enable Beacon API endpoints needed by the dev validator.
+		// Enable Beacon API for dev mode.
 		cfg.CaplinConfig.BeaconAPIRouter.Active = true
 		if cfg.CaplinConfig.BeaconAPIRouter.Address == "" {
 			cfg.CaplinConfig.BeaconAPIRouter.Address = "127.0.0.1:5555"
@@ -2025,6 +2034,10 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 		beaconCfg.BellatrixForkEpoch = 0
 		beaconCfg.CapellaForkEpoch = 0
 		beaconCfg.DenebForkEpoch = 0
+		slotTime := uint64(ctx.Int(DevSlotTimeFlag.Name))
+		if slotTime > 0 {
+			beaconCfg.SecondsPerSlot = slotTime
+		}
 		beaconCfg.InitializeForkSchedule()
 		genesisTime := uint64(time.Now().Unix())
 		// Compute the EL genesis block hash so the beacon state's Eth1Data
@@ -2050,12 +2063,13 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 		configYAML := fmt.Sprintf(
 			"PRESET_BASE: minimal\n"+
 				"MIN_GENESIS_TIME: %d\n"+
+				"SECONDS_PER_SLOT: %d\n"+
 				"ALTAIR_FORK_EPOCH: 0\n"+
 				"BELLATRIX_FORK_EPOCH: 0\n"+
 				"CAPELLA_FORK_EPOCH: 0\n"+
 				"DENEB_FORK_EPOCH: 0\n"+
 				"TERMINAL_TOTAL_DIFFICULTY: 0\n",
-			genesisTime)
+			genesisTime, beaconCfg.SecondsPerSlot)
 		os.WriteFile(configPath, []byte(configYAML), 0644)
 
 		cfg.CaplinConfig.CustomConfigPath = configPath

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1996,7 +1996,10 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 		}
 
 		// Derive the signer key for the dev account.
-		signerKey, signerAddr := devgenesis.DeriveSignerKey(seed)
+		signerKey, signerAddr, err := devgenesis.DeriveSignerKey(seed)
+		if err != nil {
+			Fatalf("Failed to derive dev signer key: %v", err)
+		}
 		_ = signerKey // available for future use (e.g., auto-funding txs)
 		logger.Info("Using PoS dev mode",
 			"seed", seed,
@@ -2034,6 +2037,8 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 		beaconCfg.BellatrixForkEpoch = 0
 		beaconCfg.CapellaForkEpoch = 0
 		beaconCfg.DenebForkEpoch = 0
+		beaconCfg.ElectraForkEpoch = 0
+		beaconCfg.FuluForkEpoch = 0
 		slotTime := uint64(ctx.Int(DevSlotTimeFlag.Name))
 		if slotTime < 2 {
 			slotTime = 2
@@ -2067,6 +2072,9 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 		}
 
 		// Write beacon config YAML with all forks enabled from genesis.
+		// All known fork epochs are listed explicitly so that Caplin's
+		// CustomConfig (which falls back to minimal preset defaults for
+		// missing fields) activates every fork at epoch 0.
 		configPath := filepath.Join(tmpDir, "config.yaml")
 		configYAML := fmt.Sprintf(
 			"PRESET_BASE: minimal\n"+
@@ -2076,6 +2084,8 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 				"BELLATRIX_FORK_EPOCH: 0\n"+
 				"CAPELLA_FORK_EPOCH: 0\n"+
 				"DENEB_FORK_EPOCH: 0\n"+
+				"ELECTRA_FORK_EPOCH: 0\n"+
+				"FULU_FORK_EPOCH: 0\n"+
 				"TERMINAL_TOTAL_DIFFICULTY: 0\n",
 			genesisTime, beaconCfg.SecondsPerSlot)
 		if err := os.WriteFile(configPath, []byte(configYAML), 0644); err != nil {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -42,7 +42,6 @@ import (
 
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/clparams/devgenesis"
-	"github.com/erigontech/erigon/execution/state/genesiswrite"
 	"github.com/erigontech/erigon/cmd/downloader/downloadernat"
 	"github.com/erigontech/erigon/cmd/utils/flags"
 	"github.com/erigontech/erigon/common"
@@ -58,6 +57,7 @@ import (
 	chainspec "github.com/erigontech/erigon/execution/chain/spec"
 	"github.com/erigontech/erigon/execution/protocol/params"
 	"github.com/erigontech/erigon/execution/protocol/rules/ethash/ethashcfg"
+	"github.com/erigontech/erigon/execution/state/genesiswrite"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/node/direct"
 	"github.com/erigontech/erigon/node/ethconfig"

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -23,6 +23,8 @@ package utils
 import (
 	"crypto/ecdsa"
 	"fmt"
+	"math/big"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -39,6 +41,7 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/clparams/devgenesis"
 	"github.com/erigontech/erigon/cmd/downloader/downloadernat"
 	"github.com/erigontech/erigon/cmd/utils/flags"
 	"github.com/erigontech/erigon/common"
@@ -101,6 +104,16 @@ var (
 	DeveloperPeriodFlag = cli.IntFlag{
 		Name:  "dev.period",
 		Usage: "Block period to use in developer mode (0 = mine only if transaction pending)",
+	}
+	DevValidatorSeedFlag = cli.StringFlag{
+		Name:  "dev-validator-seed",
+		Usage: "Deterministic BLS key seed for embedded dev validator (enables PoS dev mode)",
+		Value: "devnet",
+	}
+	DevValidatorCountFlag = cli.IntFlag{
+		Name:  "dev-validator-count",
+		Usage: "Number of validators for PoS dev mode",
+		Value: 64,
 	}
 	ChainFlag = cli.StringFlag{
 		Name:  "chain",
@@ -1970,16 +1983,59 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 			SetDNSDiscoveryDefaults(cfg, chainspec.Mainnet)
 		}
 	case networkname.Dev:
-		// Create new developer account or reuse existing one
-		developer := cfg.Builder.Etherbase
-		if developer == (common.Address{}) {
-			Fatalf("Please specify developer account address using --miner.etherbase")
+		seed := ctx.String(DevValidatorSeedFlag.Name)
+		validatorCount := ctx.Int(DevValidatorCountFlag.Name)
+		if validatorCount == 0 {
+			validatorCount = 64
 		}
-		logger.Info("Using developer account", "address", developer)
 
-		// Create a new developer genesis block or reuse existing one
-		cfg.Genesis = chainspec.DeveloperGenesisBlock(uint64(ctx.Int(DeveloperPeriodFlag.Name)), developer)
-		logger.Info("Using custom developer period", "seconds", cfg.Genesis.Config.Clique.Period)
+		// Derive the signer key for the dev account.
+		signerKey, signerAddr := devgenesis.DeriveSignerKey(seed)
+		_ = signerKey // available for future use (e.g., auto-funding txs)
+		logger.Info("Using PoS dev mode",
+			"seed", seed,
+			"validators", validatorCount,
+			"signer", signerAddr.Hex(),
+		)
+
+		// Build PoS EL genesis (TTD=0, post-merge from genesis).
+		cfg.Genesis = chainspec.DeveloperGenesisBlock(0, signerAddr)
+		// Override: remove Clique, set TTD=0 for PoS.
+		cfg.Genesis.Config.Clique = nil
+		cfg.Genesis.Config.TerminalTotalDifficulty = big.NewInt(0)
+		cfg.Genesis.Config.TerminalTotalDifficultyPassed = true
+		cfg.Genesis.ExtraData = make([]byte, 32) // no Clique signer in extra data
+
+		// Configure embedded Caplin + dev validator.
+		cfg.InternalCL = true
+		cfg.CaplinConfig.DevValidatorSeed = seed
+		cfg.CaplinConfig.DevValidatorCount = validatorCount
+
+		// Build beacon genesis state and write to temp file for Caplin.
+		beaconCfg := clparams.MainnetBeaconConfig
+		clparams.ApplyMinimalPreset(&beaconCfg)
+		genesisTime := uint64(time.Now().Unix())
+		// Use a placeholder EL genesis hash — the actual hash is computed later
+		// during chain init. The beacon state just needs a non-zero reference.
+		elGenesisHash := common.Hash{0x01}
+		beaconState, _, err := devgenesis.BuildGenesisState(seed, validatorCount, &beaconCfg, genesisTime, elGenesisHash)
+		if err != nil {
+			Fatalf("Failed to build dev beacon genesis: %v", err)
+		}
+		// Write beacon config and genesis state to temp files.
+		tmpDir := filepath.Join(cfg.Dirs.DataDir, "dev-beacon")
+		os.MkdirAll(tmpDir, 0755)
+		stateSSZ, _ := beaconState.EncodeSSZ(nil)
+		genesisStatePath := filepath.Join(tmpDir, "genesis.ssz")
+		os.WriteFile(genesisStatePath, stateSSZ, 0644)
+
+		// Write minimal beacon config YAML.
+		configPath := filepath.Join(tmpDir, "config.yaml")
+		configYAML := fmt.Sprintf("PRESET_BASE: minimal\nMIN_GENESIS_TIME: %d\n", genesisTime)
+		os.WriteFile(configPath, []byte(configYAML), 0644)
+
+		cfg.CaplinConfig.CustomConfigPath = configPath
+		cfg.CaplinConfig.CustomGenesisStatePath = genesisStatePath
 	}
 
 	if ctx.IsSet(OverrideOsakaFlag.Name) {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -42,6 +42,7 @@ import (
 
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/clparams/devgenesis"
+	"github.com/erigontech/erigon/execution/state/genesiswrite"
 	"github.com/erigontech/erigon/cmd/downloader/downloadernat"
 	"github.com/erigontech/erigon/cmd/utils/flags"
 	"github.com/erigontech/erigon/common"
@@ -1896,7 +1897,7 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 			}
 
 		}
-	} else {
+	} else if chain != networkname.Dev && chain != networkname.BorDevnet {
 		spec, err := chainspec.ChainSpecByName(chain)
 		if err != nil {
 			Fatalf("chain name is not recognized: %s", chain)
@@ -2015,9 +2016,13 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 		beaconCfg := clparams.MainnetBeaconConfig
 		clparams.ApplyMinimalPreset(&beaconCfg)
 		genesisTime := uint64(time.Now().Unix())
-		// Use a placeholder EL genesis hash — the actual hash is computed later
-		// during chain init. The beacon state just needs a non-zero reference.
-		elGenesisHash := common.Hash{0x01}
+		// Compute the EL genesis block hash so the beacon state's Eth1Data
+		// matches the actual chain genesis.
+		elGenesisBlock, _, err := genesiswrite.GenesisToBlock(nil, cfg.Genesis, cfg.Dirs, logger)
+		if err != nil {
+			Fatalf("Failed to compute dev EL genesis hash: %v", err)
+		}
+		elGenesisHash := elGenesisBlock.Hash()
 		beaconState, _, err := devgenesis.BuildGenesisState(seed, validatorCount, &beaconCfg, genesisTime, elGenesisHash)
 		if err != nil {
 			Fatalf("Failed to build dev beacon genesis: %v", err)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -118,7 +118,7 @@ var (
 	}
 	DevSlotTimeFlag = cli.IntFlag{
 		Name:  "dev.slot-time",
-		Usage: "Slot duration in seconds for PoS dev mode (default: 6)",
+		Usage: "Slot duration in seconds for PoS dev mode (minimum: 2)",
 		Value: 6,
 	}
 	ChainFlag = cli.StringFlag{
@@ -2035,9 +2035,10 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 		beaconCfg.CapellaForkEpoch = 0
 		beaconCfg.DenebForkEpoch = 0
 		slotTime := uint64(ctx.Int(DevSlotTimeFlag.Name))
-		if slotTime > 0 {
-			beaconCfg.SecondsPerSlot = slotTime
+		if slotTime < 2 {
+			slotTime = 2
 		}
+		beaconCfg.SecondsPerSlot = slotTime
 		beaconCfg.InitializeForkSchedule()
 		genesisTime := uint64(time.Now().Unix())
 		// Compute the EL genesis block hash so the beacon state's Eth1Data

--- a/docs/DEV_CHAIN.md
+++ b/docs/DEV_CHAIN.md
@@ -1,156 +1,114 @@
-Steps to setup and run Erigon dev chain. This tutorial is made for macOS.
+# Erigon Dev Chain
 
+The `--chain=dev` mode runs Erigon as a single-process PoS node with an embedded
+beacon chain (Caplin) and deterministic BLS validator. It uses the same fork choice,
+block production, and state transition code as mainnet — no separate consensus client
+is needed.
 
-## 1. Clone and Build Erigon 
-Open terminal 1 and type the following command
+## Quick Start
 
-```bash 
-git clone --recurse-submodules -j8 https://github.com/erigontech/erigon.git
-cd erigon
+```bash
 make erigon
+./build/bin/erigon --chain=dev --datadir=dev \
+  --beacon.api=beacon,validator,node,config
 ```
 
+This starts a node that:
+- Creates a PoS genesis with 64 validators (Deneb fork from genesis)
+- Runs the embedded Caplin consensus layer
+- Proposes a block every 6 seconds (one per slot)
+- Executes blocks through the standard EL pipeline
 
-## 2. Build RPC daemon
-On the same terminal folder you can build the RPC daemon.
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--chain=dev` | — | **Required.** Enables dev mode with PoS genesis. |
+| `--beacon.api=beacon,validator,node,config` | — | **Required.** Enables the Beacon API endpoints used by the embedded validator. |
+| `--dev-validator-seed` | `devnet` | Deterministic seed for BLS key derivation. Change to run independent dev chains. |
+| `--dev-validator-count` | `64` | Number of genesis validators. |
+| `--dev.slot-time` | `6` | Seconds per slot (minimum: 2). Lower values produce blocks faster. |
+| `--datadir` | `dev` | Data directory. Each run creates fresh state (ephemeral mode). |
+
+### Optional flags
+
+| Flag | Description |
+|------|-------------|
+| `--http.api=eth,erigon,web3,net,debug,trace,txpool` | Enable JSON-RPC APIs for interaction. |
+| `--http.port=8545` | JSON-RPC port (default: 8545). |
+| `--beacon.api.port=5555` | Beacon API port (default: 5555). |
+
+## Example: Fast block production
+
+For faster iteration during development, set a 2-second slot time:
 
 ```bash
-make rpcdaemon
+./build/bin/erigon --chain=dev --datadir=dev \
+  --beacon.api=beacon,validator,node,config \
+  --dev.slot-time=2 \
+  --http.api=eth,erigon,web3,net,debug,trace,txpool
 ```
 
-## 3. Start Node 1 
-If everything is fine, by changing directory to erigon/build/bin you will see the two exec for erigon and rpc daemon.
-On the terminal you can type the following command to start node1.
+## Interacting with the node
+
+Query the chain via JSON-RPC:
 
 ```bash
-./erigon --datadir=dev --chain=dev --private.api.addr=localhost:9090 --mine
+# Get chain ID (dev chain = 0x539 / 1337)
+curl -s -X POST -H "Content-Type: application/json" \
+  --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' \
+  localhost:8545
+
+# Get latest block number
+curl -s -X POST -H "Content-Type: application/json" \
+  --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
+  localhost:8545
+
+# Get block by number
+curl -s -X POST -H "Content-Type: application/json" \
+  --data '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest",false],"id":1}' \
+  localhost:8545
 ```
-Or, you could start the rpcdaemon internally together
+
+Query the beacon chain via the Beacon API:
+
 ```bash
-./erigon --datadir=dev --chain=dev --private.api.addr=localhost:9090 --mine --http.api=eth,erigon,web3,net,debug,trace,txpool,parity,admin --http.corsdomain="*"
-```
- 
- Argument notes:
- * datadir : Tells where the data is stored, default level is dev folder.
- * chain : Tells that we want to run Erigon in the dev chain.
- * private.api.addr=localhost:9090 : Tells where Erigon is going to listen for connections.
- * mine : Add this if you want the node to mine.
- * dev.period <number-of-seconds>: Add this to specify the timing interval among blocks. Number of seconds MUST be > 0 (if you want empty blocks) otherwise the default value 0 does not allow mining of empty blocks.
- * http.api: List of services to start on http (rpc) access
- 
-The result will be something like this:
+# Get current head slot
+curl -s localhost:5555/eth/v1/beacon/headers/head | jq .data.header.message.slot
 
-<img width="1652" alt="Node 1 start" src="https://user-images.githubusercontent.com/24697803/140478108-c93a131d-745d-45ac-a76f-9bb808e504df.png">
-
-    
-Now save the enode information generated in the logs, we will use this in a minute. Here there is an example.
-```   
-enode://d30d079163d7b69fcb261c0538c0c3faba4fb4429652970e60fa25deb02a789b4811e98b468726ba0be63b9dc925a019f433177eb6b45c23bb78892f786d8f7a@127.0.0.1:53171 
+# Get genesis info
+curl -s localhost:5555/eth/v1/beacon/genesis | jq .data
 ```
 
-## 4. Start RPC daemon
+## Pre-funded account
 
-Open terminal 2 and navigate to erigon/build/bin folder. Here type the following command
-    
-```bash 
-./rpcdaemon --datadir=dev  --private.api.addr=localhost:9090 --http.api=eth,erigon,web3,net,debug,trace,txpool,parity
-```
-The result will look like this:
-<img width="1636" alt="rpc daemon start" src="https://user-images.githubusercontent.com/24697803/140478408-ac1be94a-4a63-42c6-8673-e24decadd658.png">
-
-    
-    
-## 5. Start Node 2
-    
-Node 2 has to connect to Node 1 in order to sync. As such, we will use the argument --staticpeers.
-To tell Node 2 where Node 1 is we will use the Enode info of Node 1 we saved before.
-
-Open terminal 3 and navigate to erigon/build/bin folder. Paste in the following command the Enode info and run it, be careful to remove the last part ?discport=0.
-
-The node info of the first peer can also be obtained with an admin RPC call
-```bash
-  curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "admin_nodeInfo", "params": [], "id":83}' localhost:8545
-  ```
-
-```bash  
-./erigon --datadir=dev2  --chain=dev --private.api.addr=localhost:9091 \
-    --staticpeers="enode://d30d079163d7b69fcb261c0538c0c3faba4fb4429652970e60fa25deb02a789b4811e98b468726ba0be63b9dc925a019f433177eb6b45c23bb78892f786d8f7a@127.0.0.1:53171" \
-    --nodiscover
-```
-
-You might face a conflict with ports if you run it on the same machine. To specify different ports use, for instance ``--torrent.port 42079``, you might consider specifying all the other flags too: ``--port --http.port --authrpc.port ``
-    
-To check if the nodes are connected, you can go to the log of both nodes and look for the line
-    
-  ```  [p2p] GoodPeers    eth68=1 ```
-    
-Note: this might take a while it is not instantaneous, also if you see a 1 on either one of the two the node is fine.
-    
-    
- 
-    
-    
-## 6. Interact with the node using RPC 
-    
-  Open a terminal 4 and type 
-    
-```bash
-  curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "eth_chainId", "params": [], "id":1}' localhost:8545
+The dev genesis pre-funds a deterministic signer account derived from the validator
+seed. The address is logged at startup:
 
 ```
-  The result should look like this: 
-    
-```json
-{"jsonrpc":"2.0","id":1,"result":"0x539"}
+Using PoS dev mode  seed=devnet validators=64 signer=0x78eF752367584ee389aCB8824Ceec734456402b6
 ```
 
-Other commands you can try:
+## How it works
 
- ```bash
- curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "eth_gasPrice", "params": [], "id":1}' localhost:8545
- ```
- ```bash
- curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "eth_mining", "params": [], "id":1}' localhost:8545
- ```
- ```bash
-  curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "eth_syncing", "params": [], "id":1}' localhost:8545
- ```
- ```bash
-  curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "net_peerCount", "params": [], "id":74}' localhost:8545
- ```
- ```bash
-  curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "eth_blockNumber", "params": [], "id":83}' localhost:8545
- ```
-    
-## 7. Send a transaction with MetaMask
-    
- Finally, we want to try sending a transaction between two accounts.
- For this example we will use dev accounts retrieved from Erigon code:
- 
- * Account with balance (Dev 1) 
-   * address = ``` 0x67b1d87101671b127f5f8714789C7192f7ad340e ``` 
-   * privateKey = ``` 26e86e45f6fc45ec6e2ecd128cec80fa1d1505e5507dcd2ae58c3130a7a97b48 ```
- 
- * Empty account (Dev 2)
-   * address = ``` 0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B ``` 
-   * privateKey = ``` 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8 ```
- 
- 
+1. **Genesis**: A PoS genesis is created with TTD=0 and all forks (Altair through
+   Deneb) activated at epoch 0. The EL genesis has Shanghai+Cancun enabled from
+   block 0. Validators are derived deterministically from the seed.
 
-Now from MetaMask, you can import Dev 1 , and then send a transaction to pass some ethers from Dev 1 to Dev 2. 
-From the RPC daemon terminal, you will see something like this
- 
-<img width="1633" alt="Transaction example" src="https://user-images.githubusercontent.com/24697803/140479146-94b6e66c-22b7-4d8a-a160-b3643d27b612.png">
+2. **Consensus**: Caplin runs the same fork choice and state transition as mainnet.
+   The embedded validator checks proposer duties each slot and produces blocks via
+   the standard Beacon API (`/eth/v3/validator/blocks/{slot}`).
 
- Finally you will see the ethers in the Dev 2 account balance.
-    
+3. **Execution**: Block payloads are assembled by the EL's `AssembleBlock`, including
+   any pending transactions from the txpool. The CL signs and submits the block,
+   which flows through `NewPayload` → `ForkChoiceUpdated` — identical to mainnet.
 
+## Notes
 
- ## 7. Check a mined block
- 
- Now we want to check the creation of a new block and that all the nodes sync.
-
-Below we can see that block 1 is created (block_num=1) and that the next block to be proposed increments from 1 to 2 ( block=2). The other nodes will see the same update.
- 
-<img width="1327" alt="Block" src="https://user-images.githubusercontent.com/24697803/140509913-b2fc3140-ad81-4bf3-a595-d102f7c75245.png">
- 
+- Dev mode uses the **minimal preset** (8 slots per epoch, 32-member sync committee)
+  for faster epoch transitions. This matches the Ethereum spec's minimal preset used
+  in consensus testing.
+- P2P networking is disabled (`--nodiscover` is set automatically).
+- Data is ephemeral by default — each run starts from a fresh genesis.
+- The `--mine` and `--dev.period` flags from the old Clique-based dev mode are no
+  longer used.

--- a/docs/gitbook/src/fundamentals/multiple-instances.md
+++ b/docs/gitbook/src/fundamentals/multiple-instances.md
@@ -197,7 +197,7 @@ Erigon itself consumes less than 2GB of RAM. Therefore, Erigon will benefit from
 ```
 
 ```yaml
-      --datadir=/home/erigon/.local/share/erigon --chain=dev --private.api.addr=0.0.0.0:9090 --mine --log.dir.path=/logs/node1
+      --datadir=/home/erigon/.local/share/erigon --chain=dev --private.api.addr=0.0.0.0:9090 --beacon.api=beacon,validator,node,config --log.dir.path=/logs/node1
     ports:
       - "8551:8551"
     volumes:

--- a/node/cli/default_flags.go
+++ b/node/cli/default_flags.go
@@ -152,6 +152,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.DeveloperPeriodFlag,
 	&utils.DevValidatorSeedFlag,
 	&utils.DevValidatorCountFlag,
+	&utils.DevSlotTimeFlag,
 	&utils.VMEnableDebugFlag,
 	&utils.NetworkIdFlag,
 	&utils.PersistReceiptsV2Flag,

--- a/node/cli/default_flags.go
+++ b/node/cli/default_flags.go
@@ -150,6 +150,8 @@ var DefaultFlags = []cli.Flag{
 	&utils.MaxPendingPeersFlag,
 	&utils.ChainFlag,
 	&utils.DeveloperPeriodFlag,
+	&utils.DevValidatorSeedFlag,
+	&utils.DevValidatorCountFlag,
 	&utils.VMEnableDebugFlag,
 	&utils.NetworkIdFlag,
 	&utils.PersistReceiptsV2Flag,

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -1064,12 +1064,12 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 					validatorCount = 64
 				}
 				// Load the beacon config from the custom config path.
-			beaconCfg, _, err := clparams.CustomConfig(config.CaplinConfig.CustomConfigPath)
-			if err != nil {
-				logger.Error("[dev-validator] failed to load beacon config", "err", err)
-				return
-			}
-			svc, err := devvalidator.NewService(beaconURL, config.CaplinConfig.DevValidatorSeed, validatorCount, &beaconCfg, logger)
+				beaconCfg, _, err := clparams.CustomConfig(config.CaplinConfig.CustomConfigPath)
+				if err != nil {
+					logger.Error("[dev-validator] failed to load beacon config", "err", err)
+					return
+				}
+				svc, err := devvalidator.NewService(beaconURL, config.CaplinConfig.DevValidatorSeed, validatorCount, &beaconCfg, logger)
 				if err != nil {
 					logger.Error("[dev-validator] failed to create service", "err", err)
 					return

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -1058,16 +1058,18 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 				if beaconAddr == "" {
 					beaconAddr = "127.0.0.1:5555"
 				}
-				protocol := config.CaplinConfig.BeaconAPIRouter.Protocol
-				if protocol == "" {
-					protocol = "http"
-				}
-				beaconURL := fmt.Sprintf("%s://%s", protocol, beaconAddr)
+				beaconURL := fmt.Sprintf("http://%s", beaconAddr)
 				validatorCount := config.CaplinConfig.DevValidatorCount
 				if validatorCount == 0 {
 					validatorCount = 64
 				}
-				svc, err := devvalidator.NewService(beaconURL, config.CaplinConfig.DevValidatorSeed, validatorCount, nil, logger)
+				// Load the beacon config from the custom config path.
+			beaconCfg, _, err := clparams.CustomConfig(config.CaplinConfig.CustomConfigPath)
+			if err != nil {
+				logger.Error("[dev-validator] failed to load beacon config", "err", err)
+				return
+			}
+			svc, err := devvalidator.NewService(beaconURL, config.CaplinConfig.DevValidatorSeed, validatorCount, &beaconCfg, logger)
 				if err != nil {
 					logger.Error("[dev-validator] failed to create service", "err", err)
 					return

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -44,6 +44,7 @@ import (
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/persistence/format/snapshot_format/getters"
 	executionclient "github.com/erigontech/erigon/cl/phase1/execution_client"
+	"github.com/erigontech/erigon/cl/validator/devvalidator"
 	"github.com/erigontech/erigon/cmd/caplin/caplin1"
 	rpcdaemoncli "github.com/erigontech/erigon/cmd/rpcdaemon/cli"
 	"github.com/erigontech/erigon/common"
@@ -1050,6 +1051,30 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 			}
 			ctxCancel()
 		}()
+		// Start embedded dev validator if configured.
+		if config.CaplinConfig.DevValidatorSeed != "" {
+			go func() {
+				beaconAddr := config.CaplinConfig.BeaconAPIRouter.Address
+				if beaconAddr == "" {
+					beaconAddr = "127.0.0.1:5555"
+				}
+				protocol := config.CaplinConfig.BeaconAPIRouter.Protocol
+				if protocol == "" {
+					protocol = "http"
+				}
+				beaconURL := fmt.Sprintf("%s://%s", protocol, beaconAddr)
+				validatorCount := config.CaplinConfig.DevValidatorCount
+				if validatorCount == 0 {
+					validatorCount = 64
+				}
+				svc, err := devvalidator.NewService(beaconURL, config.CaplinConfig.DevValidatorSeed, validatorCount, nil, logger)
+				if err != nil {
+					logger.Error("[dev-validator] failed to create service", "err", err)
+					return
+				}
+				svc.Start(ctx)
+			}()
+		}
 	}
 
 	if chainConfig.Bor != nil {


### PR DESCRIPTION
Closes #14753

## Summary

The `--chain=dev` mode for Erigon has been updated so that it creates a dev
beacon chain rather than relying on Clique consensus. In dev mode Erigon now
runs the same PoS process as mainnet including the same forking and block
production code.

A single command starts a fully operational PoS node:

    ./build/bin/erigon --chain=dev --beacon.api=beacon,validator,node,config

### What's included

- **Programmatic beacon genesis** (`cl/clparams/devgenesis/`): builds a valid
  Deneb genesis state with deterministic BLS validators, sync committees,
  participation lists, and execution payload header — no external tooling needed.

- **Embedded dev validator** (`cl/validator/devvalidator/`): polls the Beacon API
  for proposer duties, fetches block templates, signs with proper BLS domain
  separation (RANDAO, block, attestation), and submits via the standard
  `/eth/v2/beacon/blocks` endpoint.

- **Same code paths as mainnet**: blocks flow through Caplin's fork choice,
  `NewPayload`, `ForkChoiceUpdated`, and the staged sync pipeline. No mock
  consensus or special-cased execution.

### New flags

| Flag | Default | Description |
|------|---------|-------------|
| `--dev-validator-seed` | `devnet` | BLS key derivation seed |
| `--dev-validator-count` | `64` | Number of genesis validators |
| `--dev.slot-time` | `6` | Seconds per slot (minimum: 2) |

`--beacon.api=beacon,validator,node,config` is required to enable the Beacon API
endpoints used by the embedded validator.

### Removed

- `--mine` and `--dev.period` are no longer used for `--chain=dev`
- Clique genesis configuration removed from dev mode

### Dependencies

Built on top of #20190 (caplin minimal preset support), which is now merged.

## Test plan

- [x] Blocks produced every slot (tested at 6s and 2s slot times)
- [x] Epoch boundaries crossed cleanly (slots 1-16+, minimal preset 8 slots/epoch)
- [x] EL validates and commits each block (head advances)
- [x] No panics or errors over sustained runs
- [x] `make lint` clean
- [x] `make erigon integration` builds
- [ ] CI passes