### PR TITLE
log: less allocs

### DIFF
--- a/common/log/v3/format.go
+++ b/common/log/v3/format.go
@@ -46,6 +46,7 @@ func (f formatFunc) Format(r *Record) []byte {
 //
 //	[May 16 20:58:45] [DBUG] remove route ns=haproxy addr=127.0.0.1:50002
 func TerminalFormat() Format {
+	logNoTimestamps := logEnvBool("ERIGON_LOG_NO_TIMESTAMPS", false)
 	return FormatFunc(func(r *Record) []byte {
 		var color = 0
 		switch r.Lvl {
@@ -62,8 +63,7 @@ func TerminalFormat() Format {
 		}
 
 		b := &bytes.Buffer{}
-		lvl := strings.ToUpper(r.Lvl.String())
-		logNoTimestamps := logEnvBool("ERIGON_LOG_NO_TIMESTAMPS", false)
+		lvl := r.Lvl.UpperString()
 		if logNoTimestamps {
 			if color > 0 {
 				fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m %s ", color, lvl, r.Msg)
@@ -92,7 +92,7 @@ func TerminalFormat() Format {
 func TerminalFormatNoColor() Format {
 	return FormatFunc(func(r *Record) []byte {
 		b := &bytes.Buffer{}
-		lvl := strings.ToUpper(r.Lvl.String())
+		lvl := r.Lvl.UpperString()
 		fmt.Fprintf(b, "[%s] [%s] %s ", lvl, r.Time.Format(termTimeFormat), r.Msg)
 
 		// try to justify the log output for short messages

--- a/common/log/v3/log_test.go
+++ b/common/log/v3/log_test.go
@@ -180,6 +180,29 @@ func TestLogfmt(t *testing.T) {
 	}
 }
 
+func TestTerminalFormatNoColor(t *testing.T) {
+	t.Parallel()
+
+	l, buf := testFormatter(TerminalFormatNoColor())
+	l.Info("some message", "x", 1, "y", "foo")
+
+	// skip the "[INFO] [timestamp] " prefix: "[INFO] " is 7 chars, timestamp
+	// "[01-02|15:04:05.000] " is 21 chars, total 28.
+	const prefixLen = 7 + 21
+	if buf.Len() < prefixLen {
+		t.Fatalf("output too short: %q", buf.String())
+	}
+	if got, want := string(buf.Bytes()[:7]), "[INFO] "; got != want {
+		t.Fatalf("level prefix: got %q, want %q", got, want)
+	}
+	got := buf.Bytes()[prefixLen:]
+	// short messages are right-padded to termMsgJust (40) chars
+	expected := []byte("some message                             x=1 y=foo\n")
+	if !bytes.Equal(got, expected) {
+		t.Fatalf("Got %q, expected %q", got, expected)
+	}
+}
+
 func TestMultiHandler(t *testing.T) {
 	t.Parallel()
 

--- a/common/log/v3/logger.go
+++ b/common/log/v3/logger.go
@@ -47,6 +47,25 @@ func (l Lvl) String() string {
 	}
 }
 
+func (l Lvl) UpperString() string {
+	switch l {
+	case LvlTrace:
+		return "TRACE"
+	case LvlDebug:
+		return "DBUG"
+	case LvlInfo:
+		return "INFO"
+	case LvlWarn:
+		return "WARN"
+	case LvlError:
+		return "EROR"
+	case LvlCrit:
+		return "CRIT"
+	default:
+		panic("bad level")
+	}
+}
+
 // LvlFromString returns the appropriate Lvl from a string name.
 // Useful for parsing command line args and configuration files.
 func LvlFromString(lvlString string) (Lvl, error) {


### PR DESCRIPTION
- no `ToUpper()` call on each format
- no `logEnvBool` call on each format