### PR TITLE
[r3.4] db/state: return DomainRoTx IndexReaders to sync.Pool on Close

### DIFF
--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1479,6 +1479,10 @@ func (dt *DomainRoTx) Close() {
 			src.closeFilesAndRemove()
 		}
 	}
+	for _, r := range dt.mapReaders {
+		r.Close()
+	}
+	dt.mapReaders = nil
 	dt.ht.Close()
 
 	dt.visible.returnGetFromFileCache(dt.getFromFileCache)


### PR DESCRIPTION
DomainRoTx.Close was not returning readers acquired via `statelessIdxReader` back to the `recsplit.Index` readers pool, so every new DomainRoTx allocated fresh IndexReaders via `NewIndexReader`. Under the commitment warmuper path this dominated `alloc_objects` (~21.8%).

`HistoryRoTx.Close` and `InvertedIndexRoTx.Close` already do this correctly.