### PR TITLE
p2p/sentry: defensive copy of fork slices in StatusData

### DIFF
--- a/p2p/sentry/status_data_provider.go
+++ b/p2p/sentry/status_data_provider.go
@@ -118,8 +118,8 @@ func (s *StatusDataProvider) makeStatusData(head ChainHead) *sentryproto.StatusD
 		MinimumBlockHeight: head.MinimumHeight,
 		ForkData: &sentryproto.Forks{
 			Genesis:     gointerfaces.ConvertHashToH256(s.genesisHash),
-			HeightForks: s.heightForks,
-			TimeForks:   s.timeForks,
+			HeightForks: append([]uint64(nil), s.heightForks...),
+			TimeForks:   append([]uint64(nil), s.timeForks...),
 		},
 	}
 }


### PR DESCRIPTION
## Summary
- `makeStatusData()` previously assigned `s.heightForks` and `s.timeForks` directly into the returned `StatusData`, sharing the backing array with `StatusDataProvider` internal state.
- Replace with `append([]uint64(nil), ...)` to return an independent copy on each call, preventing unintended mutation and potential data races.

## Test plan
- [x] `make lint` passes
- [ ] Existing `p2p/sentry` and `p2p/forkid` tests pass (`go test ./p2p/sentry/... ./p2p/forkid/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)