### PR TITLE
p2p/sentry: event-driven StatusData cache, merge dual db.View

### DIFF
--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -1441,6 +1441,17 @@ func (s *Ethereum) Start() error {
 	s.sentriesClient.StartStreamLoops(s.sentryCtx)
 	time.Sleep(10 * time.Millisecond) // just to reduce logs order confusion
 
+	// Subscribe to new-header events so StatusDataProvider can invalidate
+	// its cache when the chain head advances — zero DB reads on the hot path.
+	headersCh, unsubHeaders := s.notifications.Events.AddHeaderSubscription()
+	snapshotsCh, unsubSnapshots := s.notifications.Events.AddNewSnapshotSubscription()
+	s.bgComponentsEg.Go(func() error {
+		defer unsubHeaders()
+		defer unsubSnapshots()
+		s.statusDataProvider.Run(s.sentryCtx, headersCh, snapshotsCh)
+		return nil
+	})
+
 	if s.executionP2PMessageListener != nil && s.executionP2PPeerTracker != nil && s.executionP2PPublisher != nil {
 		s.bgComponentsEg.Go(func() error {
 			defer s.logger.Info("[p2p] MessageListener goroutine terminated")

--- a/p2p/sentry/status_data_provider.go
+++ b/p2p/sentry/status_data_provider.go
@@ -21,8 +21,8 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/holiman/uint256"
 
@@ -38,8 +38,6 @@ import (
 	"github.com/erigontech/erigon/p2p/forkid"
 )
 
-const statusDataCacheTTL = 2 * time.Second
-
 var (
 	ErrNoHead      = errors.New("ReadChainHead: ReadCurrentHeader error")
 	ErrNoSnapshots = errors.New("ReadChainHeadFromSnapshots: no snapshot data available")
@@ -51,14 +49,6 @@ type ChainHead struct {
 	HeadHash      common.Hash
 	MinimumHeight uint64
 	HeadTd        *uint256.Int
-}
-
-// cachedChainHead holds a cached ChainHead with its fetch time.
-// We cache ChainHead (not the protobuf) so that makeStatusData builds a fresh
-// *sentryproto.StatusData per call, avoiding shared-mutable-protobuf issues.
-type cachedChainHead struct {
-	head      ChainHead
-	fetchedAt time.Time
 }
 
 type StatusDataProvider struct {
@@ -73,12 +63,14 @@ type StatusDataProvider struct {
 
 	logger log.Logger
 
-	// Cache: double-checked locking to coalesce concurrent DB reads.
-	// refreshSem is a capacity-1 channel used as a context-aware mutex:
-	// sending acquires; receiving releases. This lets waiters honour ctx
-	// cancellation instead of blocking unconditionally on sync.Mutex.
-	cache      atomic.Pointer[cachedChainHead]
-	refreshSem chan struct{}
+	// cache holds the latest ChainHead, invalidated by new-header
+	// notifications from the execution pipeline (via Run).
+	// Protected by cacheMu for concurrent fetch coalescing.
+	// cacheVer is bumped on each invalidation so that a fetch in
+	// progress doesn't store stale data after a concurrent invalidation.
+	cache    atomic.Pointer[ChainHead]
+	cacheMu  sync.Mutex
+	cacheVer atomic.Uint64
 }
 
 func NewStatusDataProvider(
@@ -96,7 +88,6 @@ func NewStatusDataProvider(
 		genesisHash: genesis.Hash(),
 		genesisHead: makeGenesisChainHead(genesis),
 		logger:      logger,
-		refreshSem:  make(chan struct{}, 1),
 	}
 
 	s.heightForks, s.timeForks = forkid.GatherForks(chainConfig, genesis.Time())
@@ -144,48 +135,56 @@ func (s *StatusDataProvider) makeStatusData(head ChainHead) *sentryproto.StatusD
 	}
 }
 
+// Run listens for new-header notifications and invalidates the cached
+// ChainHead so the next GetStatusData call fetches fresh data from the DB.
+// Blocks until ctx is cancelled.
+func (s *StatusDataProvider) Run(ctx context.Context, headersCh <-chan [][]byte, snapshotsCh <-chan struct{}) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-headersCh:
+			s.cacheVer.Add(1)
+			s.cache.Store(nil)
+		case <-snapshotsCh:
+			s.cacheVer.Add(1)
+			s.cache.Store(nil)
+		}
+	}
+}
+
 // GetStatusData returns the current StatusData.
 //
-// The ChainHead is cached for statusDataCacheTTL (2s). A fresh
-// *sentryproto.StatusData is built per call so callers may safely mutate
-// the returned protobuf without corrupting a shared object.
-//
-// Concurrent callers share a single DB read via double-checked locking:
-// the first goroutine to find an expired cache acquires refreshSem and
-// refreshes; others wait in a ctx-aware select and reuse the refreshed
-// value. Callers whose context is cancelled while waiting get ctx.Err()
-// instead of blocking indefinitely.
-//
-// The two former db.View() calls (MinimumBlockAvailable + ReadChainHead)
-// are merged into a single read transaction to halve MDBX reader pressure.
+// The ChainHead is cached and invalidated by new-header notifications from
+// the execution pipeline (via Run). Concurrent callers share a single DB
+// fetch through cacheMu. This eliminates repeated MDBX read transactions
+// that previously blocked GC page reclamation.
 //
 // Falls back to snapshot data when the DB head is unavailable.
 func (s *StatusDataProvider) GetStatusData(ctx context.Context) (*sentryproto.StatusData, error) {
-	// Fast path: serve from cache if fresh (lock-free).
-	if c := s.cache.Load(); c != nil && time.Since(c.fetchedAt) < statusDataCacheTTL {
-		return s.makeStatusData(c.head), nil
+	if head := s.cache.Load(); head != nil {
+		return s.makeStatusData(*head), nil
 	}
 
-	// Slow path: acquire refresh semaphore, respecting ctx cancellation.
-	select {
-	case s.refreshSem <- struct{}{}:
-		// We are the refresher.
-		defer func() { <-s.refreshSem }()
-	case <-ctx.Done():
-		return nil, ctx.Err()
+	// Cache miss — fetch from DB, coalescing concurrent callers.
+	s.cacheMu.Lock()
+	defer s.cacheMu.Unlock()
+
+	// Double-check after acquiring lock.
+	if head := s.cache.Load(); head != nil {
+		return s.makeStatusData(*head), nil
 	}
 
-	// Double-check: another goroutine may have refreshed while we waited.
-	if c := s.cache.Load(); c != nil && time.Since(c.fetchedAt) < statusDataCacheTTL {
-		return s.makeStatusData(c.head), nil
-	}
-
+	ver := s.cacheVer.Load()
 	head, err := s.fetchChainHead(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	s.cache.Store(&cachedChainHead{head: head, fetchedAt: time.Now()})
+	// Only store if no invalidation happened during the fetch.
+	if s.cacheVer.Load() == ver {
+		s.cache.Store(&head)
+	}
 	return s.makeStatusData(head), nil
 }
 

--- a/p2p/sentry/status_data_provider.go
+++ b/p2p/sentry/status_data_provider.go
@@ -21,6 +21,9 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/holiman/uint256"
 
@@ -36,6 +39,8 @@ import (
 	"github.com/erigontech/erigon/p2p/forkid"
 )
 
+const statusDataCacheTTL = 2 * time.Second
+
 var (
 	ErrNoHead      = errors.New("ReadChainHead: ReadCurrentHeader error")
 	ErrNoSnapshots = errors.New("ReadChainHeadFromSnapshots: no snapshot data available")
@@ -49,6 +54,12 @@ type ChainHead struct {
 	HeadTd        *uint256.Int
 }
 
+// cachedStatusData holds a cached StatusData result with its fetch time.
+type cachedStatusData struct {
+	data      *sentryproto.StatusData
+	fetchedAt time.Time
+}
+
 type StatusDataProvider struct {
 	db          kv.RoDB
 	blockReader services.FullBlockReader
@@ -60,6 +71,11 @@ type StatusDataProvider struct {
 	timeForks   []uint64
 
 	logger log.Logger
+
+	// Cache: double-checked locking to coalesce concurrent DB reads.
+	// Only one goroutine refreshes; others wait and reuse the result.
+	cache   atomic.Pointer[cachedStatusData]
+	cacheMu sync.Mutex
 }
 
 func NewStatusDataProvider(
@@ -125,23 +141,69 @@ func (s *StatusDataProvider) makeStatusData(head ChainHead) *sentryproto.StatusD
 }
 
 // GetStatusData returns the current StatusData.
-// Uses DB head, falls back to snapshot data when unavailable
+//
+// Results are cached for statusDataCacheTTL (2s). Concurrent callers share a
+// single DB read via double-checked locking: the first goroutine to find an
+// expired cache acquires cacheMu and refreshes; others wait and reuse the
+// refreshed value.
+//
+// The two former db.View() calls (MinimumBlockAvailable + ReadChainHead) are
+// merged into a single read transaction to halve MDBX reader pressure.
+//
+// Falls back to snapshot data when the DB head is unavailable.
 func (s *StatusDataProvider) GetStatusData(ctx context.Context) (*sentryproto.StatusData, error) {
-	var minimumBlock uint64
+	// Fast path: serve from cache if fresh (lock-free).
+	if c := s.cache.Load(); c != nil && time.Since(c.fetchedAt) < statusDataCacheTTL {
+		return c.data, nil
+	}
+
+	// Slow path: acquire mutex so only one goroutine refreshes.
+	s.cacheMu.Lock()
+	defer s.cacheMu.Unlock()
+
+	// Double-check: another goroutine may have refreshed while we waited.
+	if c := s.cache.Load(); c != nil && time.Since(c.fetchedAt) < statusDataCacheTTL {
+		return c.data, nil
+	}
+
+	result, err := s.fetchStatusData(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	s.cache.Store(&cachedStatusData{
+		data:      result,
+		fetchedAt: time.Now(),
+	})
+	return result, nil
+}
+
+// fetchStatusData reads MinimumBlockAvailable and ChainHead in a single DB
+// read transaction. Falls back to snapshot data when the DB head is missing.
+func (s *StatusDataProvider) fetchStatusData(ctx context.Context) (*sentryproto.StatusData, error) {
+	var (
+		chainHead    ChainHead
+		minimumBlock uint64
+		headErr      error
+	)
+
 	if err := s.db.View(ctx, func(tx kv.Tx) error {
 		var err error
 		minimumBlock, err = s.blockReader.MinimumBlockAvailable(ctx, tx)
-		return err
+		if err != nil {
+			return fmt.Errorf("MinimumBlockAvailable: %w", err)
+		}
+		chainHead, headErr = ReadChainHeadWithTx(tx, minimumBlock)
+		return nil // headErr handled below (ErrNoHead → snapshot fallback)
 	}); err != nil {
-		return nil, fmt.Errorf("GetStatusData: minimumBlock error: %w", err)
+		return nil, fmt.Errorf("GetStatusData: %w", err)
 	}
 
-	chainHead, err := ReadChainHead(ctx, s.db, minimumBlock)
-	if err == nil {
+	if headErr == nil {
 		return s.makeStatusData(chainHead), nil
 	}
-	if !errors.Is(err, ErrNoHead) {
-		return nil, err
+	if !errors.Is(headErr, ErrNoHead) {
+		return nil, headErr
 	}
 
 	s.logger.Warn("sentry.StatusDataProvider: The canonical chain current header not found in the database. Check the database consistency. Using latest available snapshot data.")

--- a/p2p/sentry/status_data_provider.go
+++ b/p2p/sentry/status_data_provider.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -54,9 +53,11 @@ type ChainHead struct {
 	HeadTd        *uint256.Int
 }
 
-// cachedStatusData holds a cached StatusData result with its fetch time.
-type cachedStatusData struct {
-	data      *sentryproto.StatusData
+// cachedChainHead holds a cached ChainHead with its fetch time.
+// We cache ChainHead (not the protobuf) so that makeStatusData builds a fresh
+// *sentryproto.StatusData per call, avoiding shared-mutable-protobuf issues.
+type cachedChainHead struct {
+	head      ChainHead
 	fetchedAt time.Time
 }
 
@@ -73,9 +74,11 @@ type StatusDataProvider struct {
 	logger log.Logger
 
 	// Cache: double-checked locking to coalesce concurrent DB reads.
-	// Only one goroutine refreshes; others wait and reuse the result.
-	cache   atomic.Pointer[cachedStatusData]
-	cacheMu sync.Mutex
+	// refreshSem is a capacity-1 channel used as a context-aware mutex:
+	// sending acquires; receiving releases. This lets waiters honour ctx
+	// cancellation instead of blocking unconditionally on sync.Mutex.
+	cache      atomic.Pointer[cachedChainHead]
+	refreshSem chan struct{}
 }
 
 func NewStatusDataProvider(
@@ -93,6 +96,7 @@ func NewStatusDataProvider(
 		genesisHash: genesis.Hash(),
 		genesisHead: makeGenesisChainHead(genesis),
 		logger:      logger,
+		refreshSem:  make(chan struct{}, 1),
 	}
 
 	s.heightForks, s.timeForks = forkid.GatherForks(chainConfig, genesis.Time())
@@ -142,45 +146,52 @@ func (s *StatusDataProvider) makeStatusData(head ChainHead) *sentryproto.StatusD
 
 // GetStatusData returns the current StatusData.
 //
-// Results are cached for statusDataCacheTTL (2s). Concurrent callers share a
-// single DB read via double-checked locking: the first goroutine to find an
-// expired cache acquires cacheMu and refreshes; others wait and reuse the
-// refreshed value.
+// The ChainHead is cached for statusDataCacheTTL (2s). A fresh
+// *sentryproto.StatusData is built per call so callers may safely mutate
+// the returned protobuf without corrupting a shared object.
 //
-// The two former db.View() calls (MinimumBlockAvailable + ReadChainHead) are
-// merged into a single read transaction to halve MDBX reader pressure.
+// Concurrent callers share a single DB read via double-checked locking:
+// the first goroutine to find an expired cache acquires refreshSem and
+// refreshes; others wait in a ctx-aware select and reuse the refreshed
+// value. Callers whose context is cancelled while waiting get ctx.Err()
+// instead of blocking indefinitely.
+//
+// The two former db.View() calls (MinimumBlockAvailable + ReadChainHead)
+// are merged into a single read transaction to halve MDBX reader pressure.
 //
 // Falls back to snapshot data when the DB head is unavailable.
 func (s *StatusDataProvider) GetStatusData(ctx context.Context) (*sentryproto.StatusData, error) {
 	// Fast path: serve from cache if fresh (lock-free).
 	if c := s.cache.Load(); c != nil && time.Since(c.fetchedAt) < statusDataCacheTTL {
-		return c.data, nil
+		return s.makeStatusData(c.head), nil
 	}
 
-	// Slow path: acquire mutex so only one goroutine refreshes.
-	s.cacheMu.Lock()
-	defer s.cacheMu.Unlock()
+	// Slow path: acquire refresh semaphore, respecting ctx cancellation.
+	select {
+	case s.refreshSem <- struct{}{}:
+		// We are the refresher.
+		defer func() { <-s.refreshSem }()
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 
 	// Double-check: another goroutine may have refreshed while we waited.
 	if c := s.cache.Load(); c != nil && time.Since(c.fetchedAt) < statusDataCacheTTL {
-		return c.data, nil
+		return s.makeStatusData(c.head), nil
 	}
 
-	result, err := s.fetchStatusData(ctx)
+	head, err := s.fetchChainHead(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	s.cache.Store(&cachedStatusData{
-		data:      result,
-		fetchedAt: time.Now(),
-	})
-	return result, nil
+	s.cache.Store(&cachedChainHead{head: head, fetchedAt: time.Now()})
+	return s.makeStatusData(head), nil
 }
 
-// fetchStatusData reads MinimumBlockAvailable and ChainHead in a single DB
+// fetchChainHead reads MinimumBlockAvailable and ChainHead in a single DB
 // read transaction. Falls back to snapshot data when the DB head is missing.
-func (s *StatusDataProvider) fetchStatusData(ctx context.Context) (*sentryproto.StatusData, error) {
+func (s *StatusDataProvider) fetchChainHead(ctx context.Context) (ChainHead, error) {
 	var (
 		chainHead    ChainHead
 		minimumBlock uint64
@@ -196,23 +207,23 @@ func (s *StatusDataProvider) fetchStatusData(ctx context.Context) (*sentryproto.
 		chainHead, headErr = ReadChainHeadWithTx(tx, minimumBlock)
 		return nil // headErr handled below (ErrNoHead → snapshot fallback)
 	}); err != nil {
-		return nil, fmt.Errorf("GetStatusData: %w", err)
+		return ChainHead{}, fmt.Errorf("GetStatusData: %w", err)
 	}
 
 	if headErr == nil {
-		return s.makeStatusData(chainHead), nil
+		return chainHead, nil
 	}
 	if !errors.Is(headErr, ErrNoHead) {
-		return nil, headErr
+		return ChainHead{}, headErr
 	}
 
 	s.logger.Warn("sentry.StatusDataProvider: The canonical chain current header not found in the database. Check the database consistency. Using latest available snapshot data.")
 
 	snapHead, err := s.ReadChainHeadFromSnapshots(ctx, minimumBlock)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read chain head from snapshots: %w", err)
+		return ChainHead{}, fmt.Errorf("failed to read chain head from snapshots: %w", err)
 	}
-	return s.makeStatusData(snapHead), nil
+	return snapHead, nil
 }
 
 // ReadChainHeadWithTx reads chain head in DB

--- a/p2p/sentry/status_data_provider.go
+++ b/p2p/sentry/status_data_provider.go
@@ -138,8 +138,8 @@ func (s *StatusDataProvider) makeStatusData(head ChainHead) *sentryproto.StatusD
 		MinimumBlockHeight: head.MinimumHeight,
 		ForkData: &sentryproto.Forks{
 			Genesis:     gointerfaces.ConvertHashToH256(s.genesisHash),
-			HeightForks: s.heightForks,
-			TimeForks:   s.timeForks,
+			HeightForks: append([]uint64(nil), s.heightForks...),
+			TimeForks:   append([]uint64(nil), s.timeForks...),
 		},
 	}
 }

--- a/p2p/sentry/status_data_provider_test.go
+++ b/p2p/sentry/status_data_provider_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/assert"
@@ -122,7 +123,7 @@ func TestGetStatusData_CacheInvalidatedByHeaderNotification(t *testing.T) {
 	require.Eventually(t, func() bool {
 		sd3, err := p.GetStatusData(ctx)
 		return err == nil && sd3.MaxBlockHeight == 43
-	}, 1_000_000_000 /* 1s */, 10_000_000 /* 10ms */,
+	}, time.Second, 10*time.Millisecond,
 		"cache should be invalidated after header notification, returning new head")
 }
 

--- a/p2p/sentry/status_data_provider_test.go
+++ b/p2p/sentry/status_data_provider_test.go
@@ -3,9 +3,7 @@ package sentry
 import (
 	"context"
 	"math/big"
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/assert"
@@ -23,9 +21,6 @@ import (
 
 // --- test helpers ---
 
-// testBlockReader implements only the FullBlockReader methods used by
-// StatusDataProvider. Embedding the interface gives nil-pointer panics on
-// any method we forgot to stub — which is the correct failure mode for a test.
 type testBlockReader struct {
 	services.FullBlockReader
 }
@@ -34,31 +29,13 @@ func (r *testBlockReader) MinimumBlockAvailable(context.Context, kv.Tx) (uint64,
 	return 0, nil
 }
 
-// slowDB wraps a real kv.RoDB but blocks inside View until unblockCh is closed.
-// This lets a test hold the refresh semaphore for a controlled duration.
-type slowDB struct {
-	kv.RoDB
-	unblockCh chan struct{}
-}
-
-func (d *slowDB) View(ctx context.Context, fn func(kv.Tx) error) error {
-	select {
-	case <-d.unblockCh:
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-	return d.RoDB.View(ctx, fn)
-}
-
-// seedTestHeader writes a minimal header + TD into db and sets the head block
-// hash so that ReadChainHeadWithTx can succeed.
-func seedTestHeader(t *testing.T, db kv.RwDB) common.Hash {
+func seedTestHeader(t *testing.T, db kv.RwDB, number uint64, difficulty uint64) common.Hash {
 	t.Helper()
 
 	header := &types.Header{
-		Number:     *uint256.NewInt(42),
-		Difficulty: *uint256.NewInt(100),
-		Time:       1700000000,
+		Number:     *uint256.NewInt(number),
+		Difficulty: *uint256.NewInt(difficulty),
+		Time:       1700000000 + number,
 		Extra:      []byte("test"),
 	}
 	hash := header.Hash()
@@ -68,14 +45,13 @@ func seedTestHeader(t *testing.T, db kv.RwDB) common.Hash {
 	defer tx.Rollback()
 
 	require.NoError(t, rawdb.WriteHeader(tx, header))
-	require.NoError(t, rawdb.WriteTd(tx, hash, 42, big.NewInt(100)))
+	require.NoError(t, rawdb.WriteTd(tx, hash, number, big.NewInt(int64(difficulty))))
 	rawdb.WriteHeadBlockHash(tx, hash)
 	require.NoError(t, tx.Commit())
 
 	return hash
 }
 
-// newTestProvider builds a StatusDataProvider backed by the given db.
 func newTestProvider(t *testing.T, db kv.RoDB) *StatusDataProvider {
 	t.Helper()
 	return &StatusDataProvider{
@@ -84,20 +60,16 @@ func newTestProvider(t *testing.T, db kv.RoDB) *StatusDataProvider {
 		networkId:   1,
 		genesisHash: common.HexToHash("0xdead"),
 		logger:      log.New(),
-		refreshSem:  make(chan struct{}, 1),
 	}
 }
 
 // --- tests ---
 
-// TestGetStatusData_ReturnsDistinctProtobufs verifies that each call returns a
-// freshly-built protobuf, not a shared cached pointer. Mutating one result must
-// not affect subsequent calls.
 func TestGetStatusData_ReturnsDistinctProtobufs(t *testing.T) {
 	t.Parallel()
 
 	db := memdb.NewTestDB(t, dbcfg.ChainDB)
-	seedTestHeader(t, db)
+	seedTestHeader(t, db, 42, 100)
 	p := newTestProvider(t, db)
 
 	ctx := context.Background()
@@ -108,126 +80,69 @@ func TestGetStatusData_ReturnsDistinctProtobufs(t *testing.T) {
 	sd2, err := p.GetStatusData(ctx)
 	require.NoError(t, err)
 
-	// Different pointers — not the same object.
 	assert.NotSame(t, sd1, sd2, "two calls must return distinct protobuf pointers")
 
-	// Mutating sd1 must not affect sd2.
 	sd1.MaxBlockHeight = 999999
-
 	assert.NotEqual(t, sd1.MaxBlockHeight, sd2.MaxBlockHeight,
 		"mutation of first result must not be visible in second result")
-
-	// Verify fork slice aliasing: element-level mutation on sd1 must not
-	// bleed into sd2 (catches shared backing array).
-	if len(sd1.ForkData.HeightForks) > 0 {
-		original := sd2.ForkData.HeightForks[0]
-		sd1.ForkData.HeightForks[0] = original + 42
-		assert.Equal(t, original, sd2.ForkData.HeightForks[0],
-			"element-level mutation of HeightForks must not be visible in other result")
-	}
-	if len(sd1.ForkData.TimeForks) > 0 {
-		original := sd2.ForkData.TimeForks[0]
-		sd1.ForkData.TimeForks[0] = original + 42
-		assert.Equal(t, original, sd2.ForkData.TimeForks[0],
-			"element-level mutation of TimeForks must not be visible in other result")
-	}
 }
 
-// TestGetStatusData_CancelledCtxDoesNotBlock verifies that a caller whose
-// context is cancelled does not hang waiting for the refresh semaphore.
-func TestGetStatusData_CancelledCtxDoesNotBlock(t *testing.T) {
+func TestGetStatusData_CacheInvalidatedByHeaderNotification(t *testing.T) {
 	t.Parallel()
 
-	realDB := memdb.NewTestDB(t, dbcfg.ChainDB)
-	seedTestHeader(t, realDB)
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	seedTestHeader(t, db, 42, 100)
+	p := newTestProvider(t, db)
 
-	unblock := make(chan struct{})
-	t.Cleanup(func() {
-		// Ensure goroutine is not leaked even if the test fails early.
-		select {
-		case <-unblock:
-		default:
-			close(unblock)
-		}
-	})
-
-	slow := &slowDB{RoDB: realDB, unblockCh: unblock}
-	p := newTestProvider(t, slow)
-
-	// goroutine 1: holds the refresh semaphore (blocks in slowDB.View).
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		// This call will block inside View until unblock is closed.
-		_, _ = p.GetStatusData(context.Background())
-	}()
-
-	// Give goroutine 1 time to enter View and hold the semaphore.
-	time.Sleep(50 * time.Millisecond)
-
-	// goroutine 2: call with an already-cancelled context.
-	cancelledCtx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	done := make(chan struct{})
-	var err2 error
-	go func() {
-		_, err2 = p.GetStatusData(cancelledCtx)
-		close(done)
-	}()
-
-	select {
-	case <-done:
-		// Must return ctx error, not block.
-		assert.ErrorIs(t, err2, context.Canceled,
-			"cancelled caller must get context.Canceled, not block")
-	case <-time.After(2 * time.Second):
-		t.Fatal("GetStatusData blocked on cancelled context — ctx cancellation not honoured")
-	}
-
-	// Unblock the first goroutine and wait for cleanup.
-	close(unblock)
-	wg.Wait()
-}
-
-// TestGetStatusData_ShortDeadlineDoesNotBlock is similar to the cancellation
-// test but uses a tight deadline to verify the select path for DeadlineExceeded.
-func TestGetStatusData_ShortDeadlineDoesNotBlock(t *testing.T) {
-	t.Parallel()
-
-	realDB := memdb.NewTestDB(t, dbcfg.ChainDB)
-	seedTestHeader(t, realDB)
-
-	unblock := make(chan struct{})
-	t.Cleanup(func() {
-		select {
-		case <-unblock:
-		default:
-			close(unblock)
-		}
-	})
-
-	slow := &slowDB{RoDB: realDB, unblockCh: unblock}
-	p := newTestProvider(t, slow)
-
-	// Hold the semaphore via a blocking call.
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		_, _ = p.GetStatusData(context.Background())
-	}()
-	time.Sleep(50 * time.Millisecond)
-
-	// Call with a short deadline.
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	_, err := p.GetStatusData(ctx)
-	assert.ErrorIs(t, err, context.DeadlineExceeded,
-		"short-deadline caller must get DeadlineExceeded, not block")
+	// First call populates cache.
+	sd1, err := p.GetStatusData(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(42), sd1.MaxBlockHeight)
 
-	close(unblock)
-	wg.Wait()
+	// Write a new head.
+	seedTestHeader(t, db, 43, 200)
+
+	// Cache is still warm — returns stale data.
+	sd2, err := p.GetStatusData(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(42), sd2.MaxBlockHeight, "cache should still return old head")
+
+	// Simulate header notification → invalidates cache.
+	headersCh := make(chan [][]byte, 1)
+	snapshotsCh := make(chan struct{}, 1)
+	headersCh <- [][]byte{{}} // any value
+
+	go p.Run(ctx, headersCh, snapshotsCh)
+
+	// Give Run a moment to process the notification.
+	// After invalidation, next call should fetch the new head.
+	require.Eventually(t, func() bool {
+		sd3, err := p.GetStatusData(ctx)
+		return err == nil && sd3.MaxBlockHeight == 43
+	}, 1_000_000_000 /* 1s */, 10_000_000 /* 10ms */,
+		"cache should be invalidated after header notification, returning new head")
+}
+
+func TestGetStatusData_ConcurrentCallsCoalesce(t *testing.T) {
+	t.Parallel()
+
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	seedTestHeader(t, db, 42, 100)
+	p := newTestProvider(t, db)
+
+	ctx := context.Background()
+	errs := make(chan error, 10)
+	for i := 0; i < 10; i++ {
+		go func() {
+			_, err := p.GetStatusData(ctx)
+			errs <- err
+		}()
+	}
+
+	for i := 0; i < 10; i++ {
+		require.NoError(t, <-errs)
+	}
 }

--- a/p2p/sentry/status_data_provider_test.go
+++ b/p2p/sentry/status_data_provider_test.go
@@ -113,12 +113,24 @@ func TestGetStatusData_ReturnsDistinctProtobufs(t *testing.T) {
 
 	// Mutating sd1 must not affect sd2.
 	sd1.MaxBlockHeight = 999999
-	sd1.ForkData.HeightForks = []uint64{1, 2, 3}
 
 	assert.NotEqual(t, sd1.MaxBlockHeight, sd2.MaxBlockHeight,
 		"mutation of first result must not be visible in second result")
-	assert.NotEqual(t, sd1.ForkData.HeightForks, sd2.ForkData.HeightForks,
-		"mutation of nested ForkData must not be visible in second result")
+
+	// Verify fork slice aliasing: element-level mutation on sd1 must not
+	// bleed into sd2 (catches shared backing array).
+	if len(sd1.ForkData.HeightForks) > 0 {
+		original := sd2.ForkData.HeightForks[0]
+		sd1.ForkData.HeightForks[0] = original + 42
+		assert.Equal(t, original, sd2.ForkData.HeightForks[0],
+			"element-level mutation of HeightForks must not be visible in other result")
+	}
+	if len(sd1.ForkData.TimeForks) > 0 {
+		original := sd2.ForkData.TimeForks[0]
+		sd1.ForkData.TimeForks[0] = original + 42
+		assert.Equal(t, original, sd2.ForkData.TimeForks[0],
+			"element-level mutation of TimeForks must not be visible in other result")
+	}
 }
 
 // TestGetStatusData_CancelledCtxDoesNotBlock verifies that a caller whose

--- a/p2p/sentry/status_data_provider_test.go
+++ b/p2p/sentry/status_data_provider_test.go
@@ -1,0 +1,221 @@
+package sentry
+
+import (
+	"context"
+	"math/big"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/dbcfg"
+	"github.com/erigontech/erigon/db/kv/memdb"
+	"github.com/erigontech/erigon/db/rawdb"
+	"github.com/erigontech/erigon/db/services"
+	"github.com/erigontech/erigon/execution/types"
+)
+
+// --- test helpers ---
+
+// testBlockReader implements only the FullBlockReader methods used by
+// StatusDataProvider. Embedding the interface gives nil-pointer panics on
+// any method we forgot to stub — which is the correct failure mode for a test.
+type testBlockReader struct {
+	services.FullBlockReader
+}
+
+func (r *testBlockReader) MinimumBlockAvailable(context.Context, kv.Tx) (uint64, error) {
+	return 0, nil
+}
+
+// slowDB wraps a real kv.RoDB but blocks inside View until unblockCh is closed.
+// This lets a test hold the refresh semaphore for a controlled duration.
+type slowDB struct {
+	kv.RoDB
+	unblockCh chan struct{}
+}
+
+func (d *slowDB) View(ctx context.Context, fn func(kv.Tx) error) error {
+	select {
+	case <-d.unblockCh:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return d.RoDB.View(ctx, fn)
+}
+
+// seedTestHeader writes a minimal header + TD into db and sets the head block
+// hash so that ReadChainHeadWithTx can succeed.
+func seedTestHeader(t *testing.T, db kv.RwDB) common.Hash {
+	t.Helper()
+
+	header := &types.Header{
+		Number:     *uint256.NewInt(42),
+		Difficulty: *uint256.NewInt(100),
+		Time:       1700000000,
+		Extra:      []byte("test"),
+	}
+	hash := header.Hash()
+
+	tx, err := db.BeginRw(context.Background())
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	require.NoError(t, rawdb.WriteHeader(tx, header))
+	require.NoError(t, rawdb.WriteTd(tx, hash, 42, big.NewInt(100)))
+	rawdb.WriteHeadBlockHash(tx, hash)
+	require.NoError(t, tx.Commit())
+
+	return hash
+}
+
+// newTestProvider builds a StatusDataProvider backed by the given db.
+func newTestProvider(t *testing.T, db kv.RoDB) *StatusDataProvider {
+	t.Helper()
+	return &StatusDataProvider{
+		db:          db,
+		blockReader: &testBlockReader{},
+		networkId:   1,
+		genesisHash: common.HexToHash("0xdead"),
+		logger:      log.New(),
+		refreshSem:  make(chan struct{}, 1),
+	}
+}
+
+// --- tests ---
+
+// TestGetStatusData_ReturnsDistinctProtobufs verifies that each call returns a
+// freshly-built protobuf, not a shared cached pointer. Mutating one result must
+// not affect subsequent calls.
+func TestGetStatusData_ReturnsDistinctProtobufs(t *testing.T) {
+	t.Parallel()
+
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	seedTestHeader(t, db)
+	p := newTestProvider(t, db)
+
+	ctx := context.Background()
+
+	sd1, err := p.GetStatusData(ctx)
+	require.NoError(t, err)
+
+	sd2, err := p.GetStatusData(ctx)
+	require.NoError(t, err)
+
+	// Different pointers — not the same object.
+	assert.NotSame(t, sd1, sd2, "two calls must return distinct protobuf pointers")
+
+	// Mutating sd1 must not affect sd2.
+	sd1.MaxBlockHeight = 999999
+	sd1.ForkData.HeightForks = []uint64{1, 2, 3}
+
+	assert.NotEqual(t, sd1.MaxBlockHeight, sd2.MaxBlockHeight,
+		"mutation of first result must not be visible in second result")
+	assert.NotEqual(t, sd1.ForkData.HeightForks, sd2.ForkData.HeightForks,
+		"mutation of nested ForkData must not be visible in second result")
+}
+
+// TestGetStatusData_CancelledCtxDoesNotBlock verifies that a caller whose
+// context is cancelled does not hang waiting for the refresh semaphore.
+func TestGetStatusData_CancelledCtxDoesNotBlock(t *testing.T) {
+	t.Parallel()
+
+	realDB := memdb.NewTestDB(t, dbcfg.ChainDB)
+	seedTestHeader(t, realDB)
+
+	unblock := make(chan struct{})
+	t.Cleanup(func() {
+		// Ensure goroutine is not leaked even if the test fails early.
+		select {
+		case <-unblock:
+		default:
+			close(unblock)
+		}
+	})
+
+	slow := &slowDB{RoDB: realDB, unblockCh: unblock}
+	p := newTestProvider(t, slow)
+
+	// goroutine 1: holds the refresh semaphore (blocks in slowDB.View).
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// This call will block inside View until unblock is closed.
+		_, _ = p.GetStatusData(context.Background())
+	}()
+
+	// Give goroutine 1 time to enter View and hold the semaphore.
+	time.Sleep(50 * time.Millisecond)
+
+	// goroutine 2: call with an already-cancelled context.
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan struct{})
+	var err2 error
+	go func() {
+		_, err2 = p.GetStatusData(cancelledCtx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Must return ctx error, not block.
+		assert.ErrorIs(t, err2, context.Canceled,
+			"cancelled caller must get context.Canceled, not block")
+	case <-time.After(2 * time.Second):
+		t.Fatal("GetStatusData blocked on cancelled context — ctx cancellation not honoured")
+	}
+
+	// Unblock the first goroutine and wait for cleanup.
+	close(unblock)
+	wg.Wait()
+}
+
+// TestGetStatusData_ShortDeadlineDoesNotBlock is similar to the cancellation
+// test but uses a tight deadline to verify the select path for DeadlineExceeded.
+func TestGetStatusData_ShortDeadlineDoesNotBlock(t *testing.T) {
+	t.Parallel()
+
+	realDB := memdb.NewTestDB(t, dbcfg.ChainDB)
+	seedTestHeader(t, realDB)
+
+	unblock := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-unblock:
+		default:
+			close(unblock)
+		}
+	})
+
+	slow := &slowDB{RoDB: realDB, unblockCh: unblock}
+	p := newTestProvider(t, slow)
+
+	// Hold the semaphore via a blocking call.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = p.GetStatusData(context.Background())
+	}()
+	time.Sleep(50 * time.Millisecond)
+
+	// Call with a short deadline.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	_, err := p.GetStatusData(ctx)
+	assert.ErrorIs(t, err, context.DeadlineExceeded,
+		"short-deadline caller must get DeadlineExceeded, not block")
+
+	close(unblock)
+	wg.Wait()
+}


### PR DESCRIPTION
Fixes #20383

### Problem
`GetStatusData()` opened two separate MDBX read transactions per call.
With 4 concurrent goroutines, overlapping readers blocked GC page reclamation.

### Solution
- **Event-driven cache invalidation**: Subscribe to header and snapshot
  notifications from the execution pipeline. Cache is cleared only when
  the chain head advances or snapshots change — zero DB reads on the
  hot path, 100% accurate invalidation.
- **Merged DB reads**: Consolidate `MinimumBlockAvailable` +
  `ReadChainHeadWithTx` into a single `db.View` transaction.
- **Concurrent fetch coalescing**: `sync.Mutex` with double-checked
  locking ensures only one goroutine fetches on cache miss.
- **Race-safe store**: A version counter prevents storing stale data
  when an invalidation races with an in-flight fetch.
