### PR TITLE
cmd/utils/app: guard step-rebase against zero step size

### DIFF
--- a/cmd/utils/app/step_cmd.go
+++ b/cmd/utils/app/step_cmd.go
@@ -36,6 +36,11 @@ func stepRebase(cliCtx *cli.Context) error {
 	newStepSize := cliCtx.Uint64("new-step-size")
 	logger.Info("Rebasing step size", "current", currentStepSize, "new", newStepSize)
 
+	if newStepSize == 0 {
+		logger.Crit("Invalid step size", "new-step-size", newStepSize)
+		return fmt.Errorf("new step size must be greater than 0")
+	}
+
 	if newStepSize == currentStepSize {
 		logger.Info("Step size is already at the desired value; exiting", "new-step-size", newStepSize)
 		return nil


### PR DESCRIPTION
## Summary

  - add an early `new-step-size == 0` guard in `stepRebase`
  - prevent division-by-zero panic paths in modulo/division checks
  - return a clear validation error before any filesystem operations begin