### PR TITLE
db/state: fix btree cursor leak in debugIteratePrefixLatest

### DIFF
--- a/db/state/domain_stream.go
+++ b/db/state/domain_stream.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
-	"github.com/erigontech/erigon/db/datastruct/btindex"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/order"
 	"github.com/erigontech/erigon/db/kv/stream"
@@ -44,6 +43,14 @@ const (
 	RAM_CURSOR
 )
 
+// fileCursor abstracts btindex.Cursor for testability.
+type fileCursor interface {
+	Next() bool
+	Key() []byte
+	Value() []byte
+	Close()
+}
+
 // CursorItem is the item in the priority queue used to do merge interation
 // over storage of a given account
 type CursorItem struct {
@@ -53,7 +60,7 @@ type CursorItem struct {
 	iter         btree2.MapIter[string, []dataWithTxNum]
 	kvReader     *seg.Reader
 	hist         *seg.PagedReader
-	btCursor     *btindex.Cursor
+	btCursor     fileCursor
 	key          []byte
 	val          []byte
 	startTxNum   uint64
@@ -444,6 +451,8 @@ func (dt *DomainRoTx) debugIteratePrefixLatest(prefix []byte, ramIter btree2.Map
 						if ci1.key != nil && bytes.HasPrefix(ci1.key, prefix) {
 							ci1.val = ci1.btCursor.Value()
 							heap.Push(cpPtr, ci1)
+						} else {
+							ci1.btCursor.Close()
 						}
 					} else {
 						ci1.btCursor.Close()

--- a/db/state/domain_stream.go
+++ b/db/state/domain_stream.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/datastruct/btindex"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/order"
 	"github.com/erigontech/erigon/db/kv/stream"
@@ -43,14 +44,6 @@ const (
 	RAM_CURSOR
 )
 
-// fileCursor abstracts btindex.Cursor for testability.
-type fileCursor interface {
-	Next() bool
-	Key() []byte
-	Value() []byte
-	Close()
-}
-
 // CursorItem is the item in the priority queue used to do merge interation
 // over storage of a given account
 type CursorItem struct {
@@ -60,7 +53,7 @@ type CursorItem struct {
 	iter         btree2.MapIter[string, []dataWithTxNum]
 	kvReader     *seg.Reader
 	hist         *seg.PagedReader
-	btCursor     fileCursor
+	btCursor     *btindex.Cursor
 	key          []byte
 	val          []byte
 	startTxNum   uint64
@@ -384,6 +377,14 @@ func (dt *DomainRoTx) debugIteratePrefixLatest(prefix []byte, ramIter btree2.Map
 	var cp CursorHeap
 	cpPtr := &cp
 	heap.Init(cpPtr)
+	defer func() {
+		for cp.Len() > 0 {
+			ci := heap.Pop(cpPtr).(*CursorItem)
+			if ci.btCursor != nil {
+				ci.btCursor.Close()
+			}
+		}
+	}()
 	var k, v []byte
 	var err error
 

--- a/db/state/domain_stream_test.go
+++ b/db/state/domain_stream_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCursorHeapPriority_RAMOverDBOverFILE(t *testing.T) {
@@ -118,4 +119,66 @@ func TestCursorHeapMergeLoop_RAMOverridesDB(t *testing.T) {
 	// key2: RAM value 0xAA must win over DB value 0xBB
 	assert.Equal(t, key2, results[1].key)
 	assert.Equal(t, []byte{0xAA}, results[1].val, "RAM value must override DB for key2")
+}
+
+// mockBtCursor is a fake fileCursor that iterates through a fixed list of keys
+// and tracks whether Close was called.
+type mockBtCursor struct {
+	keys   [][]byte
+	vals   [][]byte
+	pos    int
+	closed bool
+}
+
+func (m *mockBtCursor) Next() bool {
+	m.pos++
+	return m.pos < len(m.keys)
+}
+func (m *mockBtCursor) Key() []byte   { return m.keys[m.pos] }
+func (m *mockBtCursor) Value() []byte { return m.vals[m.pos] }
+func (m *mockBtCursor) Close()        { m.closed = true }
+
+// TestFileCursorClosedWhenKeyLeavesPrefix verifies that a FILE_CURSOR's
+// btCursor is closed when Next() advances past the prefix boundary.
+// Before the fix, the cursor was dropped without Close(), leaking it.
+func TestFileCursorClosedWhenKeyLeavesPrefix(t *testing.T) {
+	prefix := []byte("aa")
+
+	// Cursor has one in-prefix key, then advances to an out-of-prefix key.
+	cursor := &mockBtCursor{
+		keys: [][]byte{[]byte("aa01"), []byte("bb01")},
+		vals: [][]byte{[]byte("v1"), []byte("v2")},
+	}
+
+	var h CursorHeap
+	heap.Init(&h)
+	heap.Push(&h, &CursorItem{
+		t: FILE_CURSOR, key: cursor.Key(), val: cursor.Value(),
+		btCursor: cursor, endTxNum: 100, reverse: true,
+	})
+
+	// Run the same merge loop as debugIteratePrefixLatest
+	for h.Len() > 0 {
+		lastKey := make([]byte, len(h[0].key))
+		copy(lastKey, h[0].key)
+
+		for h.Len() > 0 && bytes.Equal(h[0].key, lastKey) {
+			ci := heap.Pop(&h).(*CursorItem)
+			if ci.btCursor != nil {
+				if ci.btCursor.Next() {
+					ci.key = ci.btCursor.Key()
+					if ci.key != nil && bytes.HasPrefix(ci.key, prefix) {
+						ci.val = ci.btCursor.Value()
+						heap.Push(&h, ci)
+					} else {
+						ci.btCursor.Close()
+					}
+				} else {
+					ci.btCursor.Close()
+				}
+			}
+		}
+	}
+
+	require.True(t, cursor.closed, "btCursor must be closed when key leaves prefix")
 }

--- a/db/state/domain_stream_test.go
+++ b/db/state/domain_stream_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCursorHeapPriority_RAMOverDBOverFILE(t *testing.T) {
@@ -119,66 +118,4 @@ func TestCursorHeapMergeLoop_RAMOverridesDB(t *testing.T) {
 	// key2: RAM value 0xAA must win over DB value 0xBB
 	assert.Equal(t, key2, results[1].key)
 	assert.Equal(t, []byte{0xAA}, results[1].val, "RAM value must override DB for key2")
-}
-
-// mockBtCursor is a fake fileCursor that iterates through a fixed list of keys
-// and tracks whether Close was called.
-type mockBtCursor struct {
-	keys   [][]byte
-	vals   [][]byte
-	pos    int
-	closed bool
-}
-
-func (m *mockBtCursor) Next() bool {
-	m.pos++
-	return m.pos < len(m.keys)
-}
-func (m *mockBtCursor) Key() []byte   { return m.keys[m.pos] }
-func (m *mockBtCursor) Value() []byte { return m.vals[m.pos] }
-func (m *mockBtCursor) Close()        { m.closed = true }
-
-// TestFileCursorClosedWhenKeyLeavesPrefix verifies that a FILE_CURSOR's
-// btCursor is closed when Next() advances past the prefix boundary.
-// Before the fix, the cursor was dropped without Close(), leaking it.
-func TestFileCursorClosedWhenKeyLeavesPrefix(t *testing.T) {
-	prefix := []byte("aa")
-
-	// Cursor has one in-prefix key, then advances to an out-of-prefix key.
-	cursor := &mockBtCursor{
-		keys: [][]byte{[]byte("aa01"), []byte("bb01")},
-		vals: [][]byte{[]byte("v1"), []byte("v2")},
-	}
-
-	var h CursorHeap
-	heap.Init(&h)
-	heap.Push(&h, &CursorItem{
-		t: FILE_CURSOR, key: cursor.Key(), val: cursor.Value(),
-		btCursor: cursor, endTxNum: 100, reverse: true,
-	})
-
-	// Run the same merge loop as debugIteratePrefixLatest
-	for h.Len() > 0 {
-		lastKey := make([]byte, len(h[0].key))
-		copy(lastKey, h[0].key)
-
-		for h.Len() > 0 && bytes.Equal(h[0].key, lastKey) {
-			ci := heap.Pop(&h).(*CursorItem)
-			if ci.btCursor != nil {
-				if ci.btCursor.Next() {
-					ci.key = ci.btCursor.Key()
-					if ci.key != nil && bytes.HasPrefix(ci.key, prefix) {
-						ci.val = ci.btCursor.Value()
-						heap.Push(&h, ci)
-					} else {
-						ci.btCursor.Close()
-					}
-				} else {
-					ci.btCursor.Close()
-				}
-			}
-		}
-	}
-
-	require.True(t, cursor.closed, "btCursor must be closed when key leaves prefix")
 }


### PR DESCRIPTION
- Close btree cursor when `Next()` advances past the prefix boundary in the FILE_CURSOR merge loop
- Drain heap on function return, closing any remaining btree cursors