### PR TITLE
plugins/auth: add UCAN core library with EOA signer and MDBX store

### DIFF
--- a/plugins/auth/README.md
+++ b/plugins/auth/README.md
@@ -1,0 +1,41 @@
+# plugins/auth — UCAN Authorization
+
+UCAN-based capability authorization for the Erigon plugin ecosystem. Provides delegatable, attenuated authorization with on-chain revocation.
+
+**Design:** https://github.com/erigontech/cocoon/tree/master/pocs/auth
+
+## What's Implemented
+
+- **DID parsing** — `did:pkh:eip155:{chainId}:{address}` and `did:key:{multibase}`
+- **Capability model** — hierarchical commands (`/storage/*`), wildcard matching, attenuation validation
+- **UCAN Token** — structure validation, time bounds, CID computation, payload serialization
+- **Delegation chain verifier** — recursive proof resolution, depth-limited, attenuation-checked
+- **EOA Signer** — ERC-191 personal_sign signature creation and verification (real ECDSA)
+- **Store interface** — `MemoryStore` (testing) and `MDBXStore` (production, MDBX-backed)
+- **21 tests** — DID, capabilities, tokens, EOA signatures, full delegation chains with real crypto, MDBX store
+
+## What's Next
+
+- [ ] ERC-1271 contract wallet signature verification (needs `eth_call`)
+- [ ] On-chain revocation registry integration (needs `eth_call`)
+- [ ] RPC middleware — validate UCAN on authenticated RPC calls
+- [ ] Component provider — wrap as `component.Component[AuthProvider]`
+- [ ] Plugin registration — `init()` + `components.Register("auth", ...)`
+- [ ] EIP-8141 frame transaction validation (future, post-Hegota)
+- [ ] Torrent-based token distribution via CCIP plugin
+- [ ] DAG-CBOR encoding (currently JSON — switch to CBOR for spec compliance)
+- [ ] did:key support for ML-KEM-768 public keys
+
+## Configuration (future)
+
+```toml
+[auth]
+enabled = true
+revocation-registry = "0x..."  # on-chain revocation contract address
+```
+
+## Dependencies
+
+- `common/crypto` — ECDSA signing, keccak256
+- `db/kv/mdbx` — persistent token and revocation storage
+- No dependency on component framework (yet) — pure library code

--- a/plugins/auth/auth_test.go
+++ b/plugins/auth/auth_test.go
@@ -178,8 +178,10 @@ func TestTokenCID(t *testing.T) {
 // mockSigner always validates signatures.
 type mockSigner struct{}
 
-func (m *mockSigner) CanVerify(did string) bool                                                       { return true }
-func (m *mockSigner) Verify(_ context.Context, _ []byte, _ []byte, _ string) (bool, error) { return true, nil }
+func (m *mockSigner) CanVerify(did string) bool { return true }
+func (m *mockSigner) Verify(_ context.Context, _ []byte, _ []byte, _ string) (bool, error) {
+	return true, nil
+}
 
 func TestVerifyRootToken(t *testing.T) {
 	nonce := make([]byte, 16)

--- a/plugins/auth/auth_test.go
+++ b/plugins/auth/auth_test.go
@@ -1,0 +1,327 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/stretchr/testify/require"
+)
+
+// --- DID Tests ---
+
+func TestParseDIDPKH(t *testing.T) {
+	did, err := ParseDID("did:pkh:eip155:1:0xab5801a7d398351b8be11c439e05c5b3259aec9b")
+	require.NoError(t, err)
+	require.Equal(t, "pkh", did.Method)
+	require.Equal(t, uint64(1), did.ChainID())
+	require.Equal(t, common.HexToAddress("0xab5801a7d398351b8be11c439e05c5b3259aec9b"), did.Address())
+	require.True(t, did.IsPKH())
+	require.False(t, did.IsKey())
+}
+
+func TestParseDIDKey(t *testing.T) {
+	did, err := ParseDID("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK")
+	require.NoError(t, err)
+	require.Equal(t, "key", did.Method)
+	require.True(t, did.IsKey())
+	require.False(t, did.IsPKH())
+}
+
+func TestParseDIDInvalid(t *testing.T) {
+	tests := []string{
+		"",
+		"not-a-did",
+		"did:",
+		"did:pkh",
+		"did:pkh:eip155",
+		"did:pkh:eip155:1",
+		"did:pkh:eip155:1:not-an-address",
+		"did:pkh:cosmos:1:addr",
+		"did:unknown:foo",
+	}
+	for _, s := range tests {
+		_, err := ParseDID(s)
+		require.Error(t, err, "expected error for: %q", s)
+	}
+}
+
+func TestNewDIDPKH(t *testing.T) {
+	addr := common.HexToAddress("0xab5801a7d398351b8be11c439e05c5b3259aec9b")
+	did := NewDIDPKH(1, addr)
+	require.Equal(t, "did:pkh:eip155:1:0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B", did.String())
+	require.Equal(t, addr, did.Address())
+}
+
+// --- Capability Tests ---
+
+func TestCommandCovers(t *testing.T) {
+	tests := []struct {
+		granting string
+		required string
+		covers   bool
+	}{
+		{"/storage/read", "/storage/read", true},
+		{"/storage/*", "/storage/read", true},
+		{"/storage/*", "/storage/write", true},
+		{"/*", "/anything", true},
+		{"/storage/read", "/storage/write", false},
+		{"/storage", "/storage/read", false}, // no wildcard = no cover
+		{"/id/*", "/storage/read", false},
+	}
+	for _, tt := range tests {
+		result := commandCovers(tt.granting, tt.required)
+		require.Equal(t, tt.covers, result, "commandCovers(%q, %q)", tt.granting, tt.required)
+	}
+}
+
+func TestCapabilityAttenuates(t *testing.T) {
+	parent := Capability{Command: "/storage/*"}
+	child := Capability{Command: "/storage/read"}
+	wider := Capability{Command: "/compute/*"}
+
+	require.True(t, child.Attenuates(parent))
+	require.False(t, wider.Attenuates(parent))
+	require.False(t, parent.Attenuates(child)) // can't widen
+}
+
+// --- Token Tests ---
+
+func TestTokenStructureValidation(t *testing.T) {
+	nonce := make([]byte, 16)
+	rand.Read(nonce)
+
+	valid := &Token{
+		Issuer:    "did:pkh:eip155:1:0xab5801a7d398351b8be11c439e05c5b3259aec9b",
+		Audience:  "did:pkh:eip155:1:0x1234567890abcdef1234567890abcdef12345678",
+		Command:   "/storage/read",
+		Nonce:     nonce,
+		Signature: []byte{0x01}, // placeholder
+	}
+	require.NoError(t, valid.ValidateStructure())
+
+	// Missing issuer
+	noIss := *valid
+	noIss.Issuer = ""
+	require.Error(t, noIss.ValidateStructure())
+
+	// Missing command
+	noCmd := *valid
+	noCmd.Command = ""
+	require.Error(t, noCmd.ValidateStructure())
+
+	// Invalid DID
+	badDID := *valid
+	badDID.Issuer = "not-a-did"
+	require.Error(t, badDID.ValidateStructure())
+}
+
+func TestTokenExpiry(t *testing.T) {
+	token := &Token{Exp: uint64(time.Now().Add(-1 * time.Hour).Unix())}
+	require.True(t, token.IsExpired())
+	require.False(t, token.IsActive())
+
+	token.Exp = uint64(time.Now().Add(1 * time.Hour).Unix())
+	require.False(t, token.IsExpired())
+	require.True(t, token.IsActive())
+
+	token.Exp = 0 // no expiry
+	require.False(t, token.IsExpired())
+	require.True(t, token.IsActive())
+}
+
+func TestTokenCID(t *testing.T) {
+	nonce := make([]byte, 16)
+	rand.Read(nonce)
+
+	t1 := &Token{
+		Issuer:   "did:pkh:eip155:1:0xab5801a7d398351b8be11c439e05c5b3259aec9b",
+		Audience: "did:pkh:eip155:1:0x1234567890abcdef1234567890abcdef12345678",
+		Command:  "/storage/read",
+		Nonce:    nonce,
+	}
+	t2 := &Token{
+		Issuer:   "did:pkh:eip155:1:0xab5801a7d398351b8be11c439e05c5b3259aec9b",
+		Audience: "did:pkh:eip155:1:0x1234567890abcdef1234567890abcdef12345678",
+		Command:  "/storage/read",
+		Nonce:    nonce,
+	}
+
+	// Same content → same CID
+	require.Equal(t, t1.ComputeCID(), t2.ComputeCID())
+
+	// Different content → different CID
+	t2.Command = "/storage/write"
+	require.NotEqual(t, t1.ComputeCID(), t2.ComputeCID())
+}
+
+// --- Verifier Tests ---
+
+// mockSigner always validates signatures.
+type mockSigner struct{}
+
+func (m *mockSigner) CanVerify(did string) bool                                                       { return true }
+func (m *mockSigner) Verify(_ context.Context, _ []byte, _ []byte, _ string) (bool, error) { return true, nil }
+
+func TestVerifyRootToken(t *testing.T) {
+	nonce := make([]byte, 16)
+	rand.Read(nonce)
+
+	token := &Token{
+		Issuer:    "did:pkh:eip155:1:0xab5801a7d398351b8be11c439e05c5b3259aec9b",
+		Audience:  "did:pkh:eip155:1:0x1234567890abcdef1234567890abcdef12345678",
+		Command:   "/storage/*",
+		Nonce:     nonce,
+		Exp:       uint64(time.Now().Add(1 * time.Hour).Unix()),
+		Signature: []byte{0x01},
+	}
+
+	store := NewMemoryStore()
+	verifier := NewVerifier(NewStoreResolver(store), &mockSigner{})
+
+	// Root token with wildcard covers /storage/read
+	err := verifier.Verify(context.Background(), token, Capability{Command: "/storage/read"})
+	require.NoError(t, err)
+
+	// Root token does NOT cover /compute/run
+	err = verifier.Verify(context.Background(), token, Capability{Command: "/compute/run"})
+	require.Error(t, err)
+}
+
+func TestVerifyDelegationChain(t *testing.T) {
+	nonce := make([]byte, 16)
+	rand.Read(nonce)
+
+	alice := "did:pkh:eip155:1:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	bob := "did:pkh:eip155:1:0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	carol := "did:pkh:eip155:1:0xcccccccccccccccccccccccccccccccccccccccc"
+
+	// Alice → Bob: full storage access
+	aliceToBob := &Token{
+		Issuer:    alice,
+		Audience:  bob,
+		Command:   "/storage/*",
+		Nonce:     nonce,
+		Exp:       uint64(time.Now().Add(1 * time.Hour).Unix()),
+		Signature: []byte{0x01},
+	}
+	aliceToBobCID := aliceToBob.ComputeCID()
+
+	// Bob → Carol: read-only (attenuated)
+	bobToCarol := &Token{
+		Issuer:    bob,
+		Audience:  carol,
+		Command:   "/storage/read",
+		Nonce:     nonce,
+		Exp:       uint64(time.Now().Add(1 * time.Hour).Unix()),
+		Proofs:    []CID{aliceToBobCID},
+		Signature: []byte{0x02},
+	}
+
+	store := NewMemoryStore()
+	store.PutToken(context.Background(), aliceToBobCID, aliceToBob)
+
+	verifier := NewVerifier(NewStoreResolver(store), &mockSigner{})
+
+	// Carol's token authorizes /storage/read
+	err := verifier.Verify(context.Background(), bobToCarol, Capability{Command: "/storage/read"})
+	require.NoError(t, err)
+
+	// Carol's token does NOT authorize /storage/write
+	err = verifier.Verify(context.Background(), bobToCarol, Capability{Command: "/storage/write"})
+	require.Error(t, err)
+}
+
+func TestVerifyBrokenChain(t *testing.T) {
+	nonce := make([]byte, 16)
+	rand.Read(nonce)
+
+	// Token references a proof that doesn't exist
+	token := &Token{
+		Issuer:    "did:pkh:eip155:1:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Audience:  "did:pkh:eip155:1:0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		Command:   "/storage/read",
+		Nonce:     nonce,
+		Exp:       uint64(time.Now().Add(1 * time.Hour).Unix()),
+		Proofs:    []CID{common.Hash{0xff}}, // non-existent
+		Signature: []byte{0x01},
+	}
+
+	store := NewMemoryStore()
+	verifier := NewVerifier(NewStoreResolver(store), &mockSigner{})
+
+	err := verifier.Verify(context.Background(), token, Capability{Command: "/storage/read"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "proof not found")
+}
+
+func TestVerifyExpiredToken(t *testing.T) {
+	nonce := make([]byte, 16)
+	rand.Read(nonce)
+
+	token := &Token{
+		Issuer:    "did:pkh:eip155:1:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Audience:  "did:pkh:eip155:1:0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		Command:   "/storage/read",
+		Nonce:     nonce,
+		Exp:       uint64(time.Now().Add(-1 * time.Hour).Unix()), // expired
+		Signature: []byte{0x01},
+	}
+
+	store := NewMemoryStore()
+	verifier := NewVerifier(NewStoreResolver(store), &mockSigner{})
+
+	err := verifier.Verify(context.Background(), token, Capability{Command: "/storage/read"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expired")
+}
+
+// --- Store Tests ---
+
+func TestMemoryStoreRevocation(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+
+	cid := common.Hash{0x01}
+	issuer := "did:pkh:eip155:1:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	// Not revoked initially
+	revoked, err := store.IsRevoked(ctx, cid, issuer, 1000)
+	require.NoError(t, err)
+	require.False(t, revoked)
+
+	// Revoke specific token
+	require.NoError(t, store.Revoke(ctx, cid))
+	revoked, err = store.IsRevoked(ctx, cid, issuer, 1000)
+	require.NoError(t, err)
+	require.True(t, revoked)
+
+	// Bulk revocation
+	cid2 := common.Hash{0x02}
+	require.NoError(t, store.RevokeAllBefore(ctx, issuer, 2000))
+	revoked, err = store.IsRevoked(ctx, cid2, issuer, 1500)
+	require.NoError(t, err)
+	require.True(t, revoked) // issued before bulk revocation timestamp
+
+	revoked, err = store.IsRevoked(ctx, cid2, issuer, 2500)
+	require.NoError(t, err)
+	require.False(t, revoked) // issued after bulk revocation timestamp
+}

--- a/plugins/auth/auth_test.go
+++ b/plugins/auth/auth_test.go
@@ -114,6 +114,7 @@ func TestTokenStructureValidation(t *testing.T) {
 		Audience:  "did:pkh:eip155:1:0x1234567890abcdef1234567890abcdef12345678",
 		Command:   "/storage/read",
 		Nonce:     nonce,
+		Iat:       uint64(time.Now().Unix()),
 		Signature: []byte{0x01}, // placeholder
 	}
 	require.NoError(t, valid.ValidateStructure())
@@ -157,12 +158,14 @@ func TestTokenCID(t *testing.T) {
 		Audience: "did:pkh:eip155:1:0x1234567890abcdef1234567890abcdef12345678",
 		Command:  "/storage/read",
 		Nonce:    nonce,
+		Iat:      uint64(time.Now().Unix()),
 	}
 	t2 := &Token{
 		Issuer:   "did:pkh:eip155:1:0xab5801a7d398351b8be11c439e05c5b3259aec9b",
 		Audience: "did:pkh:eip155:1:0x1234567890abcdef1234567890abcdef12345678",
 		Command:  "/storage/read",
 		Nonce:    nonce,
+		Iat:      uint64(time.Now().Unix()),
 	}
 
 	// Same content → same CID
@@ -192,12 +195,13 @@ func TestVerifyRootToken(t *testing.T) {
 		Audience:  "did:pkh:eip155:1:0x1234567890abcdef1234567890abcdef12345678",
 		Command:   "/storage/*",
 		Nonce:     nonce,
+		Iat:       uint64(time.Now().Unix()),
 		Exp:       uint64(time.Now().Add(1 * time.Hour).Unix()),
 		Signature: []byte{0x01},
 	}
 
 	store := NewMemoryStore()
-	verifier := NewVerifier(NewStoreResolver(store), &mockSigner{})
+	verifier := NewVerifier(NewStoreResolver(store), store, &mockSigner{})
 
 	// Root token with wildcard covers /storage/read
 	err := verifier.Verify(context.Background(), token, Capability{Command: "/storage/read"})
@@ -222,6 +226,7 @@ func TestVerifyDelegationChain(t *testing.T) {
 		Audience:  bob,
 		Command:   "/storage/*",
 		Nonce:     nonce,
+		Iat:       uint64(time.Now().Unix()),
 		Exp:       uint64(time.Now().Add(1 * time.Hour).Unix()),
 		Signature: []byte{0x01},
 	}
@@ -233,6 +238,7 @@ func TestVerifyDelegationChain(t *testing.T) {
 		Audience:  carol,
 		Command:   "/storage/read",
 		Nonce:     nonce,
+		Iat:       uint64(time.Now().Unix()),
 		Exp:       uint64(time.Now().Add(1 * time.Hour).Unix()),
 		Proofs:    []CID{aliceToBobCID},
 		Signature: []byte{0x02},
@@ -241,7 +247,7 @@ func TestVerifyDelegationChain(t *testing.T) {
 	store := NewMemoryStore()
 	store.PutToken(context.Background(), aliceToBobCID, aliceToBob)
 
-	verifier := NewVerifier(NewStoreResolver(store), &mockSigner{})
+	verifier := NewVerifier(NewStoreResolver(store), store, &mockSigner{})
 
 	// Carol's token authorizes /storage/read
 	err := verifier.Verify(context.Background(), bobToCarol, Capability{Command: "/storage/read"})
@@ -262,13 +268,14 @@ func TestVerifyBrokenChain(t *testing.T) {
 		Audience:  "did:pkh:eip155:1:0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 		Command:   "/storage/read",
 		Nonce:     nonce,
+		Iat:       uint64(time.Now().Unix()),
 		Exp:       uint64(time.Now().Add(1 * time.Hour).Unix()),
 		Proofs:    []CID{common.Hash{0xff}}, // non-existent
 		Signature: []byte{0x01},
 	}
 
 	store := NewMemoryStore()
-	verifier := NewVerifier(NewStoreResolver(store), &mockSigner{})
+	verifier := NewVerifier(NewStoreResolver(store), store, &mockSigner{})
 
 	err := verifier.Verify(context.Background(), token, Capability{Command: "/storage/read"})
 	require.Error(t, err)
@@ -284,12 +291,13 @@ func TestVerifyExpiredToken(t *testing.T) {
 		Audience:  "did:pkh:eip155:1:0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 		Command:   "/storage/read",
 		Nonce:     nonce,
+		Iat:       uint64(time.Now().Unix()),
 		Exp:       uint64(time.Now().Add(-1 * time.Hour).Unix()), // expired
 		Signature: []byte{0x01},
 	}
 
 	store := NewMemoryStore()
-	verifier := NewVerifier(NewStoreResolver(store), &mockSigner{})
+	verifier := NewVerifier(NewStoreResolver(store), store, &mockSigner{})
 
 	err := verifier.Verify(context.Background(), token, Capability{Command: "/storage/read"})
 	require.Error(t, err)

--- a/plugins/auth/capability.go
+++ b/plugins/auth/capability.go
@@ -1,0 +1,102 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package auth
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Capability represents a UCAN capability — a command path with optional
+// policy constraints. Capabilities follow a hierarchical namespace:
+//
+//	/storage/*       — all storage operations
+//	/storage/read    — read only
+//	/id/decrypt      — decrypt identity claims
+//	/auth/delegate   — create delegations
+type Capability struct {
+	Command string   `json:"cmd"`
+	Policy  []Policy `json:"pol,omitempty"`
+}
+
+// Policy is a constraint on a capability: [field, operator, value].
+// Operators: "==", "!=", "in", "subset", "glob".
+type Policy struct {
+	Field    string `json:"field"`
+	Operator string `json:"op"`
+	Value    any    `json:"value"`
+}
+
+// Covers returns true if this capability authorizes the required capability.
+// A capability covers another if:
+//  1. The command is equal or a parent wildcard (e.g. /storage/* covers /storage/read)
+//  2. All policies on this capability are satisfied by the required capability's context
+func (c Capability) Covers(required Capability) bool {
+	return commandCovers(c.Command, required.Command)
+}
+
+// commandCovers checks if the granting command covers the required command.
+//
+// Rules:
+//   - Exact match: "/storage/read" covers "/storage/read"
+//   - Wildcard: "/storage/*" covers "/storage/read", "/storage/write"
+//   - Deep wildcard: "/*" covers everything
+//   - Parent does NOT cover child without wildcard: "/storage" does NOT cover "/storage/read"
+func commandCovers(granting, required string) bool {
+	if granting == required {
+		return true
+	}
+
+	// Wildcard matching
+	if strings.HasSuffix(granting, "/*") {
+		prefix := strings.TrimSuffix(granting, "*")
+		return strings.HasPrefix(required, prefix)
+	}
+
+	return false
+}
+
+// Attenuates returns true if the child capability is a valid attenuation
+// (narrowing) of the parent capability. Attenuation can only narrow scope:
+//   - Command must be equal or more specific
+//   - Policies can be added or tightened, never removed or loosened
+func (c Capability) Attenuates(parent Capability) bool {
+	// Child command must be covered by parent command
+	if !commandCovers(parent.Command, c.Command) {
+		return false
+	}
+	// Additional policies on child are fine (they narrow scope)
+	// We don't validate policy tightening here — that requires
+	// knowing the policy semantics, which is application-specific.
+	return true
+}
+
+// String returns a human-readable representation.
+func (c Capability) String() string {
+	if len(c.Policy) == 0 {
+		return c.Command
+	}
+	return fmt.Sprintf("%s (with %d policies)", c.Command, len(c.Policy))
+}
+
+// Well-known capability namespaces.
+const (
+	NamespaceStorage = "/storage"
+	NamespaceID      = "/id"
+	NamespaceWebF    = "/webf"
+	NamespaceAuth    = "/auth"
+)

--- a/plugins/auth/capability.go
+++ b/plugins/auth/capability.go
@@ -44,9 +44,41 @@ type Policy struct {
 // Covers returns true if this capability authorizes the required capability.
 // A capability covers another if:
 //  1. The command is equal or a parent wildcard (e.g. /storage/* covers /storage/read)
-//  2. All policies on this capability are satisfied by the required capability's context
+//  2. All policies on this capability are satisfied by the required capability
+//
+// Policy evaluation: each policy on this (granting) capability must be matched
+// by a corresponding policy on the required capability with the same key and
+// a value that satisfies the operator. This is a simple equality check for v1;
+// range/comparison operators are a future extension.
 func (c Capability) Covers(required Capability) bool {
-	return commandCovers(c.Command, required.Command)
+	if !commandCovers(c.Command, required.Command) {
+		return false
+	}
+	// Every policy on the granting capability must be satisfied.
+	for _, grantPol := range c.Policy {
+		matched := false
+		for _, reqPol := range required.Policy {
+			if grantPol.Field == reqPol.Field && policyValueSatisfies(grantPol, reqPol.Value) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	return true
+}
+
+// policyValueSatisfies checks if the required value satisfies the granting policy.
+// For v1, only equality ("eq") is supported.
+func policyValueSatisfies(grant Policy, requiredValue any) bool {
+	switch grant.Operator {
+	case "eq", "":
+		return fmt.Sprintf("%v", grant.Value) == fmt.Sprintf("%v", requiredValue)
+	default:
+		return false
+	}
 }
 
 // commandCovers checks if the granting command covers the required command.

--- a/plugins/auth/did.go
+++ b/plugins/auth/did.go
@@ -31,9 +31,9 @@ import (
 // DID represents a Decentralized Identifier.
 // Supported methods: did:pkh (blockchain addresses), did:key (standalone keys).
 type DID struct {
-	Method  string // "pkh" or "key"
-	Raw     string // full DID string
-	chainID uint64 // for did:pkh only
+	Method  string         // "pkh" or "key"
+	Raw     string         // full DID string
+	chainID uint64         // for did:pkh only
 	address common.Address // for did:pkh only
 }
 

--- a/plugins/auth/did.go
+++ b/plugins/auth/did.go
@@ -1,0 +1,129 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+// Package auth provides UCAN-based authorization for Erigon plugins.
+//
+// The core library handles UCAN token creation, validation, delegation chain
+// verification, and capability matching. It has no dependency on Erigon internals
+// and can be tested standalone.
+package auth
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/erigontech/erigon/common"
+)
+
+// DID represents a Decentralized Identifier.
+// Supported methods: did:pkh (blockchain addresses), did:key (standalone keys).
+type DID struct {
+	Method  string // "pkh" or "key"
+	Raw     string // full DID string
+	chainID uint64 // for did:pkh only
+	address common.Address // for did:pkh only
+}
+
+// ParseDID parses a DID string into its components.
+//
+// Supported formats:
+//   - did:pkh:eip155:{chainId}:{address} — Ethereum address (EOA, contract, AA)
+//   - did:key:{multibase-encoded-key}    — standalone cryptographic key
+func ParseDID(s string) (DID, error) {
+	if !strings.HasPrefix(s, "did:") {
+		return DID{}, fmt.Errorf("invalid DID: must start with 'did:': %q", s)
+	}
+
+	parts := strings.SplitN(s, ":", 3)
+	if len(parts) < 3 {
+		return DID{}, fmt.Errorf("invalid DID: too few components: %q", s)
+	}
+
+	method := parts[1]
+	switch method {
+	case "pkh":
+		return parseDIDPKH(s)
+	case "key":
+		return DID{Method: "key", Raw: s}, nil
+	default:
+		return DID{}, fmt.Errorf("unsupported DID method: %q", method)
+	}
+}
+
+// parseDIDPKH parses did:pkh:eip155:{chainId}:{address}
+func parseDIDPKH(s string) (DID, error) {
+	// did:pkh:eip155:1:0xab5801a7d398351b8be11c439e05c5b3259aec9b
+	parts := strings.Split(s, ":")
+	if len(parts) != 5 {
+		return DID{}, fmt.Errorf("invalid did:pkh: expected 5 components, got %d: %q", len(parts), s)
+	}
+	if parts[2] != "eip155" {
+		return DID{}, fmt.Errorf("unsupported did:pkh namespace: %q (only eip155 supported)", parts[2])
+	}
+
+	var chainID uint64
+	if _, err := fmt.Sscanf(parts[3], "%d", &chainID); err != nil {
+		return DID{}, fmt.Errorf("invalid chain ID in did:pkh: %q: %w", parts[3], err)
+	}
+
+	if !common.IsHexAddress(parts[4]) {
+		return DID{}, fmt.Errorf("invalid address in did:pkh: %q", parts[4])
+	}
+
+	return DID{
+		Method:  "pkh",
+		Raw:     s,
+		chainID: chainID,
+		address: common.HexToAddress(parts[4]),
+	}, nil
+}
+
+// Address returns the Ethereum address for did:pkh DIDs.
+// Returns zero address for other DID methods.
+func (d DID) Address() common.Address {
+	return d.address
+}
+
+// ChainID returns the chain ID for did:pkh DIDs. Returns 0 for other methods.
+func (d DID) ChainID() uint64 {
+	return d.chainID
+}
+
+// String returns the full DID string.
+func (d DID) String() string {
+	return d.Raw
+}
+
+// IsPKH returns true if this is a did:pkh (blockchain address) DID.
+func (d DID) IsPKH() bool {
+	return d.Method == "pkh"
+}
+
+// IsKey returns true if this is a did:key (standalone key) DID.
+func (d DID) IsKey() bool {
+	return d.Method == "key"
+}
+
+// NewDIDPKH creates a did:pkh DID from a chain ID and address.
+func NewDIDPKH(chainID uint64, addr common.Address) DID {
+	raw := fmt.Sprintf("did:pkh:eip155:%d:%s", chainID, addr.Hex())
+	return DID{
+		Method:  "pkh",
+		Raw:     raw,
+		chainID: chainID,
+		address: addr,
+	}
+}

--- a/plugins/auth/signer_eoa.go
+++ b/plugins/auth/signer_eoa.go
@@ -1,0 +1,103 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package auth
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"fmt"
+	"strings"
+
+	"github.com/erigontech/erigon/common/crypto"
+)
+
+// EOASigner verifies UCAN token signatures from Ethereum EOA accounts.
+// It uses ERC-191 personal_sign format: keccak256("\x19Ethereum Signed Message:\n32" + hash).
+type EOASigner struct{}
+
+// NewEOASigner creates an EOA signature verifier.
+func NewEOASigner() *EOASigner {
+	return &EOASigner{}
+}
+
+// CanVerify returns true for did:pkh DIDs (Ethereum addresses).
+func (s *EOASigner) CanVerify(did string) bool {
+	return strings.HasPrefix(did, "did:pkh:eip155:")
+}
+
+// Verify checks that the signature over payload was produced by the address
+// in the issuer DID. Uses ERC-191 personal_sign prefix.
+func (s *EOASigner) Verify(_ context.Context, payload []byte, signature []byte, issuerDID string) (bool, error) {
+	did, err := ParseDID(issuerDID)
+	if err != nil {
+		return false, fmt.Errorf("invalid issuer DID: %w", err)
+	}
+	if !did.IsPKH() {
+		return false, fmt.Errorf("EOASigner only handles did:pkh, got %q", did.Method)
+	}
+
+	expectedAddr := did.Address()
+
+	// ERC-191 personal_sign: prefix the hash
+	hash := crypto.Keccak256(payload)
+	prefixed := personalSignHash(hash)
+
+	// Recover the public key from the signature
+	if len(signature) != 65 {
+		return false, fmt.Errorf("invalid signature length: %d (expected 65)", len(signature))
+	}
+
+	// Normalize V value (27/28 → 0/1 for crypto.SigToPub)
+	sig := make([]byte, 65)
+	copy(sig, signature)
+	if sig[64] >= 27 {
+		sig[64] -= 27
+	}
+
+	pubKey, err := crypto.SigToPub(prefixed, sig)
+	if err != nil {
+		return false, fmt.Errorf("signature recovery failed: %w", err)
+	}
+
+	recoveredAddr := crypto.PubkeyToAddress(*pubKey)
+	return recoveredAddr == expectedAddr, nil
+}
+
+// Sign produces an ERC-191 personal_sign signature over the payload.
+// Used for creating UCAN tokens (delegation).
+func (s *EOASigner) Sign(payload []byte, key *ecdsa.PrivateKey) ([]byte, error) {
+	hash := crypto.Keccak256(payload)
+	prefixed := personalSignHash(hash)
+
+	sig, err := crypto.Sign(prefixed, key)
+	if err != nil {
+		return nil, fmt.Errorf("signing failed: %w", err)
+	}
+
+	// Normalize V to 27/28 (Ethereum convention)
+	if sig[64] < 27 {
+		sig[64] += 27
+	}
+
+	return sig, nil
+}
+
+// personalSignHash applies the ERC-191 personal_sign prefix to a 32-byte hash.
+func personalSignHash(hash []byte) []byte {
+	prefix := fmt.Sprintf("\x19Ethereum Signed Message:\n%d", len(hash))
+	return crypto.Keccak256([]byte(prefix), hash)
+}

--- a/plugins/auth/signer_eoa_test.go
+++ b/plugins/auth/signer_eoa_test.go
@@ -1,0 +1,166 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package auth
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"github.com/erigontech/erigon/common/crypto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEOASignerSignAndVerify(t *testing.T) {
+	// Generate a test key
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+	did := NewDIDPKH(1, addr)
+
+	signer := NewEOASigner()
+
+	// Sign a payload
+	payload := []byte("test UCAN payload data")
+	sig, err := signer.Sign(payload, key)
+	require.NoError(t, err)
+	require.Len(t, sig, 65)
+
+	// Verify succeeds with correct DID
+	valid, err := signer.Verify(context.Background(), payload, sig, did.String())
+	require.NoError(t, err)
+	require.True(t, valid)
+
+	// Verify fails with wrong DID
+	wrongDID := NewDIDPKH(1, crypto.PubkeyToAddress(mustGenerateKey(t).PublicKey))
+	valid, err = signer.Verify(context.Background(), payload, sig, wrongDID.String())
+	require.NoError(t, err)
+	require.False(t, valid)
+
+	// Verify fails with tampered payload
+	valid, err = signer.Verify(context.Background(), []byte("tampered"), sig, did.String())
+	require.NoError(t, err)
+	require.False(t, valid)
+
+	// Verify fails with tampered signature
+	badSig := make([]byte, 65)
+	copy(badSig, sig)
+	badSig[10] ^= 0xff
+	valid, err = signer.Verify(context.Background(), payload, badSig, did.String())
+	// May return error (recovery fails) or false (wrong address)
+	if err == nil {
+		require.False(t, valid)
+	}
+}
+
+func TestEOASignerCanVerify(t *testing.T) {
+	signer := NewEOASigner()
+
+	require.True(t, signer.CanVerify("did:pkh:eip155:1:0xab5801a7d398351b8be11c439e05c5b3259aec9b"))
+	require.False(t, signer.CanVerify("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"))
+	require.False(t, signer.CanVerify("not-a-did"))
+}
+
+func TestEOASignerInvalidSignatureLength(t *testing.T) {
+	signer := NewEOASigner()
+	did := "did:pkh:eip155:1:0xab5801a7d398351b8be11c439e05c5b3259aec9b"
+
+	_, err := signer.Verify(context.Background(), []byte("payload"), []byte{0x01, 0x02}, did)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid signature length")
+}
+
+// TestFullDelegationChainWithRealSignatures tests a complete Alice→Bob→Carol
+// delegation chain with real ECDSA signatures.
+func TestFullDelegationChainWithRealSignatures(t *testing.T) {
+	// Generate keys for three parties
+	aliceKey := mustGenerateKey(t)
+	bobKey := mustGenerateKey(t)
+	carolKey := mustGenerateKey(t)
+
+	aliceDID := NewDIDPKH(1, crypto.PubkeyToAddress(aliceKey.PublicKey))
+	bobDID := NewDIDPKH(1, crypto.PubkeyToAddress(bobKey.PublicKey))
+	carolDID := NewDIDPKH(1, crypto.PubkeyToAddress(carolKey.PublicKey))
+
+	signer := NewEOASigner()
+	store := NewMemoryStore()
+	ctx := context.Background()
+
+	nonce := make([]byte, 16)
+	rand.Read(nonce)
+
+	// Alice → Bob: full storage access
+	aliceToBob := &Token{
+		Issuer:   aliceDID.String(),
+		Audience: bobDID.String(),
+		Command:  "/storage/*",
+		Nonce:    nonce,
+		Exp:      uint64(time.Now().Add(1 * time.Hour).Unix()),
+	}
+	aliceToBobPayload, err := aliceToBob.PayloadBytes()
+	require.NoError(t, err)
+	aliceToBob.Signature, err = signer.Sign(aliceToBobPayload, aliceKey)
+	require.NoError(t, err)
+
+	aliceToBobCID := aliceToBob.ComputeCID()
+	require.NoError(t, store.PutToken(ctx, aliceToBobCID, aliceToBob))
+
+	// Bob → Carol: read-only (attenuated)
+	nonce2 := make([]byte, 16)
+	rand.Read(nonce2)
+
+	bobToCarol := &Token{
+		Issuer:   bobDID.String(),
+		Audience: carolDID.String(),
+		Command:  "/storage/read",
+		Nonce:    nonce2,
+		Exp:      uint64(time.Now().Add(1 * time.Hour).Unix()),
+		Proofs:   []CID{aliceToBobCID},
+	}
+	bobToCarolPayload, err := bobToCarol.PayloadBytes()
+	require.NoError(t, err)
+	bobToCarol.Signature, err = signer.Sign(bobToCarolPayload, bobKey)
+	require.NoError(t, err)
+
+	// Verify the chain with real signature verification
+	verifier := NewVerifier(NewStoreResolver(store), signer)
+
+	// Carol's token authorizes /storage/read through the chain
+	err = verifier.Verify(ctx, bobToCarol, Capability{Command: "/storage/read"})
+	require.NoError(t, err)
+
+	// Carol's token does NOT authorize /storage/write
+	err = verifier.Verify(ctx, bobToCarol, Capability{Command: "/storage/write"})
+	require.Error(t, err)
+
+	// Tamper with Alice's signature → chain breaks
+	aliceToBob.Signature[10] ^= 0xff
+	require.NoError(t, store.PutToken(ctx, aliceToBobCID, aliceToBob))
+	err = verifier.Verify(ctx, bobToCarol, Capability{Command: "/storage/read"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "signature")
+}
+
+func mustGenerateKey(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	return key
+}

--- a/plugins/auth/signer_eoa_test.go
+++ b/plugins/auth/signer_eoa_test.go
@@ -112,6 +112,7 @@ func TestFullDelegationChainWithRealSignatures(t *testing.T) {
 		Audience: bobDID.String(),
 		Command:  "/storage/*",
 		Nonce:    nonce,
+		Iat:      uint64(time.Now().Unix()),
 		Exp:      uint64(time.Now().Add(1 * time.Hour).Unix()),
 	}
 	aliceToBobPayload, err := aliceToBob.PayloadBytes()
@@ -131,6 +132,7 @@ func TestFullDelegationChainWithRealSignatures(t *testing.T) {
 		Audience: carolDID.String(),
 		Command:  "/storage/read",
 		Nonce:    nonce2,
+		Iat:      uint64(time.Now().Unix()),
 		Exp:      uint64(time.Now().Add(1 * time.Hour).Unix()),
 		Proofs:   []CID{aliceToBobCID},
 	}
@@ -140,7 +142,7 @@ func TestFullDelegationChainWithRealSignatures(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify the chain with real signature verification
-	verifier := NewVerifier(NewStoreResolver(store), signer)
+	verifier := NewVerifier(NewStoreResolver(store), store, signer)
 
 	// Carol's token authorizes /storage/read through the chain
 	err = verifier.Verify(ctx, bobToCarol, Capability{Command: "/storage/read"})

--- a/plugins/auth/store.go
+++ b/plugins/auth/store.go
@@ -1,0 +1,101 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package auth
+
+import (
+	"context"
+)
+
+// Store persists UCAN tokens and revocation state.
+// The initial implementation uses MDBX (core component, always available).
+type Store interface {
+	// PutToken stores a token by its CID.
+	PutToken(ctx context.Context, cid CID, token *Token) error
+
+	// GetToken retrieves a token by its CID. Returns nil, nil if not found.
+	GetToken(ctx context.Context, cid CID) (*Token, error)
+
+	// IsRevoked checks if a token CID has been revoked, either directly
+	// or via a bulk revocation (all tokens from issuer before timestamp).
+	IsRevoked(ctx context.Context, cid CID, issuerDID string, issuedAt uint64) (bool, error)
+
+	// Revoke marks a specific token as revoked.
+	Revoke(ctx context.Context, cid CID) error
+
+	// RevokeAllBefore revokes all tokens from the given issuer issued before timestamp.
+	// Used for key compromise recovery.
+	RevokeAllBefore(ctx context.Context, issuerDID string, timestamp uint64) error
+}
+
+// MemoryStore is an in-memory Store implementation for testing.
+type MemoryStore struct {
+	tokens       map[CID]*Token
+	revoked      map[CID]bool
+	revokedAfter map[string]uint64 // issuerDID → timestamp
+}
+
+// NewMemoryStore creates an in-memory token store.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{
+		tokens:       make(map[CID]*Token),
+		revoked:      make(map[CID]bool),
+		revokedAfter: make(map[string]uint64),
+	}
+}
+
+func (s *MemoryStore) PutToken(_ context.Context, cid CID, token *Token) error {
+	s.tokens[cid] = token
+	return nil
+}
+
+func (s *MemoryStore) GetToken(_ context.Context, cid CID) (*Token, error) {
+	return s.tokens[cid], nil
+}
+
+func (s *MemoryStore) IsRevoked(_ context.Context, cid CID, issuerDID string, issuedAt uint64) (bool, error) {
+	if s.revoked[cid] {
+		return true, nil
+	}
+	if after, ok := s.revokedAfter[issuerDID]; ok && issuedAt < after {
+		return true, nil
+	}
+	return false, nil
+}
+
+func (s *MemoryStore) Revoke(_ context.Context, cid CID) error {
+	s.revoked[cid] = true
+	return nil
+}
+
+func (s *MemoryStore) RevokeAllBefore(_ context.Context, issuerDID string, timestamp uint64) error {
+	s.revokedAfter[issuerDID] = timestamp
+	return nil
+}
+
+// StoreResolver adapts a Store into a TokenResolver for the Verifier.
+type StoreResolver struct {
+	store Store
+}
+
+// NewStoreResolver wraps a Store as a TokenResolver.
+func NewStoreResolver(store Store) *StoreResolver {
+	return &StoreResolver{store: store}
+}
+
+func (r *StoreResolver) Resolve(ctx context.Context, cid CID) (*Token, error) {
+	return r.store.GetToken(ctx, cid)
+}

--- a/plugins/auth/store_mdbx.go
+++ b/plugins/auth/store_mdbx.go
@@ -1,0 +1,123 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package auth
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+
+	"github.com/erigontech/erigon/common/crypto"
+	"github.com/erigontech/erigon/db/kv"
+)
+
+// MDBX table names for the auth plugin.
+const (
+	TableTokens       = "AuthTokens"       // CID → JSON-encoded Token
+	TableRevoked      = "AuthRevoked"      // CID → empty (presence = revoked)
+	TableRevokedAfter = "AuthRevokedAfter" // keccak(issuerDID) → uint64 timestamp
+)
+
+// AuthTablesCfg returns the MDBX table configuration for the auth plugin.
+func AuthTablesCfg(defaultBuckets kv.TableCfg) kv.TableCfg {
+	defaultBuckets[TableTokens] = kv.TableCfgItem{}
+	defaultBuckets[TableRevoked] = kv.TableCfgItem{}
+	defaultBuckets[TableRevokedAfter] = kv.TableCfgItem{}
+	return defaultBuckets
+}
+
+// MDBXStore implements Store backed by MDBX.
+type MDBXStore struct {
+	db kv.RwDB
+}
+
+// NewMDBXStore creates a Store backed by an MDBX database.
+func NewMDBXStore(db kv.RwDB) *MDBXStore {
+	return &MDBXStore{db: db}
+}
+
+func (s *MDBXStore) PutToken(ctx context.Context, cid CID, token *Token) error {
+	data, err := json.Marshal(token)
+	if err != nil {
+		return fmt.Errorf("failed to marshal token: %w", err)
+	}
+	return s.db.Update(ctx, func(tx kv.RwTx) error {
+		return tx.Put(TableTokens, cid[:], data)
+	})
+}
+
+func (s *MDBXStore) GetToken(ctx context.Context, cid CID) (*Token, error) {
+	var token *Token
+	err := s.db.View(ctx, func(tx kv.Tx) error {
+		data, err := tx.GetOne(TableTokens, cid[:])
+		if err != nil {
+			return err
+		}
+		if data == nil {
+			return nil // not found
+		}
+		token = &Token{}
+		return json.Unmarshal(data, token)
+	})
+	return token, err
+}
+
+func (s *MDBXStore) IsRevoked(ctx context.Context, cid CID, issuerDID string, issuedAt uint64) (bool, error) {
+	var revoked bool
+	err := s.db.View(ctx, func(tx kv.Tx) error {
+		// Check specific token revocation
+		data, err := tx.GetOne(TableRevoked, cid[:])
+		if err != nil {
+			return err
+		}
+		if data != nil {
+			revoked = true
+			return nil
+		}
+
+		// Check bulk revocation
+		issuerHash := crypto.Keccak256([]byte(issuerDID))
+		data, err = tx.GetOne(TableRevokedAfter, issuerHash)
+		if err != nil {
+			return err
+		}
+		if data != nil && len(data) == 8 {
+			timestamp := binary.BigEndian.Uint64(data)
+			if issuedAt < timestamp {
+				revoked = true
+			}
+		}
+		return nil
+	})
+	return revoked, err
+}
+
+func (s *MDBXStore) Revoke(ctx context.Context, cid CID) error {
+	return s.db.Update(ctx, func(tx kv.RwTx) error {
+		return tx.Put(TableRevoked, cid[:], []byte{1})
+	})
+}
+
+func (s *MDBXStore) RevokeAllBefore(ctx context.Context, issuerDID string, timestamp uint64) error {
+	issuerHash := crypto.Keccak256([]byte(issuerDID))
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], timestamp)
+	return s.db.Update(ctx, func(tx kv.RwTx) error {
+		return tx.Put(TableRevokedAfter, issuerHash, buf[:])
+	})
+}

--- a/plugins/auth/store_mdbx_test.go
+++ b/plugins/auth/store_mdbx_test.go
@@ -1,0 +1,136 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/dbcfg"
+	"github.com/erigontech/erigon/db/kv/mdbx"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestDB(t *testing.T) kv.RwDB {
+	t.Helper()
+	db := mdbx.New(dbcfg.ConsensusDB, log.Root()).
+		InMem(t, t.TempDir()).
+		WithTableCfg(AuthTablesCfg).
+		MustOpen()
+	t.Cleanup(db.Close)
+	return db
+}
+
+func TestMDBXStorePutGetToken(t *testing.T) {
+	db := newTestDB(t)
+	store := NewMDBXStore(db)
+	ctx := context.Background()
+
+	nonce := make([]byte, 16)
+	rand.Read(nonce)
+
+	token := &Token{
+		Issuer:    "did:pkh:eip155:1:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Audience:  "did:pkh:eip155:1:0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		Command:   "/storage/read",
+		Nonce:     nonce,
+		Exp:       uint64(time.Now().Add(1 * time.Hour).Unix()),
+		Signature: []byte{0x01, 0x02, 0x03},
+	}
+	cid := token.ComputeCID()
+
+	// Put
+	require.NoError(t, store.PutToken(ctx, cid, token))
+
+	// Get
+	got, err := store.GetToken(ctx, cid)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, token.Issuer, got.Issuer)
+	require.Equal(t, token.Audience, got.Audience)
+	require.Equal(t, token.Command, got.Command)
+	require.Equal(t, token.Exp, got.Exp)
+
+	// Get non-existent
+	got, err = store.GetToken(ctx, common.Hash{0xff})
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+func TestMDBXStoreRevocation(t *testing.T) {
+	db := newTestDB(t)
+	store := NewMDBXStore(db)
+	ctx := context.Background()
+
+	cid := common.Hash{0x01}
+	issuer := "did:pkh:eip155:1:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	// Not revoked initially
+	revoked, err := store.IsRevoked(ctx, cid, issuer, 1000)
+	require.NoError(t, err)
+	require.False(t, revoked)
+
+	// Revoke specific token
+	require.NoError(t, store.Revoke(ctx, cid))
+	revoked, err = store.IsRevoked(ctx, cid, issuer, 1000)
+	require.NoError(t, err)
+	require.True(t, revoked)
+
+	// Bulk revocation
+	cid2 := common.Hash{0x02}
+	require.NoError(t, store.RevokeAllBefore(ctx, issuer, 2000))
+
+	revoked, err = store.IsRevoked(ctx, cid2, issuer, 1500) // before timestamp
+	require.NoError(t, err)
+	require.True(t, revoked)
+
+	revoked, err = store.IsRevoked(ctx, cid2, issuer, 2500) // after timestamp
+	require.NoError(t, err)
+	require.False(t, revoked)
+}
+
+func TestMDBXStoreAsResolver(t *testing.T) {
+	db := newTestDB(t)
+	store := NewMDBXStore(db)
+	ctx := context.Background()
+
+	nonce := make([]byte, 16)
+	rand.Read(nonce)
+
+	token := &Token{
+		Issuer:    "did:pkh:eip155:1:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Audience:  "did:pkh:eip155:1:0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		Command:   "/storage/*",
+		Nonce:     nonce,
+		Exp:       uint64(time.Now().Add(1 * time.Hour).Unix()),
+		Signature: []byte{0x01},
+	}
+	cid := token.ComputeCID()
+	require.NoError(t, store.PutToken(ctx, cid, token))
+
+	// Use as TokenResolver via StoreResolver adapter
+	resolver := NewStoreResolver(store)
+	got, err := resolver.Resolve(ctx, cid)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, token.Command, got.Command)
+}

--- a/plugins/auth/token.go
+++ b/plugins/auth/token.go
@@ -32,16 +32,16 @@ import (
 // audience, optionally referencing proof tokens that form a delegation chain
 // back to the root authority (subject).
 type Token struct {
-	Issuer    string     `json:"iss"`           // DID of the signer
-	Audience  string     `json:"aud"`           // DID of the recipient
-	Subject   string     `json:"sub,omitempty"` // DID of the root authority
-	Command   string     `json:"cmd"`           // capability command path
-	Policy    []Policy   `json:"pol,omitempty"` // capability constraints
-	Nonce     []byte     `json:"nonce"`         // replay protection
-	Exp       uint64     `json:"exp,omitempty"` // expiry (unix timestamp, 0 = no expiry)
-	Nbf       uint64     `json:"nbf,omitempty"` // not-before (unix timestamp, 0 = immediate)
-	Proofs    []CID      `json:"prf,omitempty"` // CIDs of proof tokens (delegation chain)
-	Signature []byte     `json:"sig"`           // signature by issuer
+	Issuer    string   `json:"iss"`           // DID of the signer
+	Audience  string   `json:"aud"`           // DID of the recipient
+	Subject   string   `json:"sub,omitempty"` // DID of the root authority
+	Command   string   `json:"cmd"`           // capability command path
+	Policy    []Policy `json:"pol,omitempty"` // capability constraints
+	Nonce     []byte   `json:"nonce"`         // replay protection
+	Exp       uint64   `json:"exp,omitempty"` // expiry (unix timestamp, 0 = no expiry)
+	Nbf       uint64   `json:"nbf,omitempty"` // not-before (unix timestamp, 0 = immediate)
+	Proofs    []CID    `json:"prf,omitempty"` // CIDs of proof tokens (delegation chain)
+	Signature []byte   `json:"sig"`           // signature by issuer
 }
 
 // CID is a content identifier for a UCAN token (SHA-256 of the encoded payload).

--- a/plugins/auth/token.go
+++ b/plugins/auth/token.go
@@ -38,6 +38,7 @@ type Token struct {
 	Command   string   `json:"cmd"`           // capability command path
 	Policy    []Policy `json:"pol,omitempty"` // capability constraints
 	Nonce     []byte   `json:"nonce"`         // replay protection
+	Iat       uint64   `json:"iat"`           // issued-at (unix timestamp, mandatory)
 	Exp       uint64   `json:"exp,omitempty"` // expiry (unix timestamp, 0 = no expiry)
 	Nbf       uint64   `json:"nbf,omitempty"` // not-before (unix timestamp, 0 = immediate)
 	Proofs    []CID    `json:"prf,omitempty"` // CIDs of proof tokens (delegation chain)
@@ -85,11 +86,15 @@ func (t *Token) ComputeCID() CID {
 		Command:  t.Command,
 		Policy:   t.Policy,
 		Nonce:    t.Nonce,
+		Iat:      t.Iat,
 		Exp:      t.Exp,
 		Nbf:      t.Nbf,
 		Proofs:   t.Proofs,
 	}
-	data, _ := json.Marshal(payload)
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return [32]byte{}
+	}
 	return sha256.Sum256(data)
 }
 
@@ -101,6 +106,7 @@ type tokenPayload struct {
 	Command  string   `json:"cmd"`
 	Policy   []Policy `json:"pol,omitempty"`
 	Nonce    []byte   `json:"nonce"`
+	Iat      uint64   `json:"iat"`
 	Exp      uint64   `json:"exp,omitempty"`
 	Nbf      uint64   `json:"nbf,omitempty"`
 	Proofs   []CID    `json:"prf,omitempty"`
@@ -115,6 +121,7 @@ func (t *Token) PayloadBytes() ([]byte, error) {
 		Command:  t.Command,
 		Policy:   t.Policy,
 		Nonce:    t.Nonce,
+		Iat:      t.Iat,
 		Exp:      t.Exp,
 		Nbf:      t.Nbf,
 		Proofs:   t.Proofs,
@@ -136,6 +143,9 @@ func (t *Token) ValidateStructure() error {
 	}
 	if len(t.Nonce) == 0 {
 		return errors.New("token missing nonce")
+	}
+	if t.Iat == 0 {
+		return errors.New("token missing issued-at timestamp (iat)")
 	}
 	if len(t.Signature) == 0 {
 		return errors.New("token missing signature (sig)")

--- a/plugins/auth/token.go
+++ b/plugins/auth/token.go
@@ -1,0 +1,155 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package auth
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/erigontech/erigon/common"
+)
+
+// Token represents a UCAN authorization token.
+//
+// A token asserts that the issuer delegates the specified capability to the
+// audience, optionally referencing proof tokens that form a delegation chain
+// back to the root authority (subject).
+type Token struct {
+	Issuer    string     `json:"iss"`           // DID of the signer
+	Audience  string     `json:"aud"`           // DID of the recipient
+	Subject   string     `json:"sub,omitempty"` // DID of the root authority
+	Command   string     `json:"cmd"`           // capability command path
+	Policy    []Policy   `json:"pol,omitempty"` // capability constraints
+	Nonce     []byte     `json:"nonce"`         // replay protection
+	Exp       uint64     `json:"exp,omitempty"` // expiry (unix timestamp, 0 = no expiry)
+	Nbf       uint64     `json:"nbf,omitempty"` // not-before (unix timestamp, 0 = immediate)
+	Proofs    []CID      `json:"prf,omitempty"` // CIDs of proof tokens (delegation chain)
+	Signature []byte     `json:"sig"`           // signature by issuer
+}
+
+// CID is a content identifier for a UCAN token (SHA-256 of the encoded payload).
+type CID = common.Hash
+
+// Capability returns the token's capability.
+func (t *Token) Capability() Capability {
+	return Capability{
+		Command: t.Command,
+		Policy:  t.Policy,
+	}
+}
+
+// IsExpired returns true if the token has expired.
+func (t *Token) IsExpired() bool {
+	if t.Exp == 0 {
+		return false // no expiry
+	}
+	return uint64(time.Now().Unix()) > t.Exp
+}
+
+// IsActive returns true if the token is within its validity window.
+func (t *Token) IsActive() bool {
+	now := uint64(time.Now().Unix())
+	if t.Exp > 0 && now > t.Exp {
+		return false
+	}
+	if t.Nbf > 0 && now < t.Nbf {
+		return false
+	}
+	return true
+}
+
+// ComputeCID computes the content identifier (SHA-256 hash) of the token's
+// payload (everything except the signature).
+func (t *Token) ComputeCID() CID {
+	payload := tokenPayload{
+		Issuer:   t.Issuer,
+		Audience: t.Audience,
+		Subject:  t.Subject,
+		Command:  t.Command,
+		Policy:   t.Policy,
+		Nonce:    t.Nonce,
+		Exp:      t.Exp,
+		Nbf:      t.Nbf,
+		Proofs:   t.Proofs,
+	}
+	data, _ := json.Marshal(payload)
+	return sha256.Sum256(data)
+}
+
+// tokenPayload is the unsigned portion of a token (for CID computation and signing).
+type tokenPayload struct {
+	Issuer   string   `json:"iss"`
+	Audience string   `json:"aud"`
+	Subject  string   `json:"sub,omitempty"`
+	Command  string   `json:"cmd"`
+	Policy   []Policy `json:"pol,omitempty"`
+	Nonce    []byte   `json:"nonce"`
+	Exp      uint64   `json:"exp,omitempty"`
+	Nbf      uint64   `json:"nbf,omitempty"`
+	Proofs   []CID    `json:"prf,omitempty"`
+}
+
+// PayloadBytes returns the canonical bytes of the token payload for signing.
+func (t *Token) PayloadBytes() ([]byte, error) {
+	payload := tokenPayload{
+		Issuer:   t.Issuer,
+		Audience: t.Audience,
+		Subject:  t.Subject,
+		Command:  t.Command,
+		Policy:   t.Policy,
+		Nonce:    t.Nonce,
+		Exp:      t.Exp,
+		Nbf:      t.Nbf,
+		Proofs:   t.Proofs,
+	}
+	return json.Marshal(payload)
+}
+
+// ValidateStructure checks that the token has all required fields.
+// Does NOT verify the signature or delegation chain.
+func (t *Token) ValidateStructure() error {
+	if t.Issuer == "" {
+		return errors.New("token missing issuer (iss)")
+	}
+	if t.Audience == "" {
+		return errors.New("token missing audience (aud)")
+	}
+	if t.Command == "" {
+		return errors.New("token missing command (cmd)")
+	}
+	if len(t.Nonce) == 0 {
+		return errors.New("token missing nonce")
+	}
+	if len(t.Signature) == 0 {
+		return errors.New("token missing signature (sig)")
+	}
+	if _, err := ParseDID(t.Issuer); err != nil {
+		return fmt.Errorf("invalid issuer DID: %w", err)
+	}
+	if _, err := ParseDID(t.Audience); err != nil {
+		return fmt.Errorf("invalid audience DID: %w", err)
+	}
+	if t.Subject != "" {
+		if _, err := ParseDID(t.Subject); err != nil {
+			return fmt.Errorf("invalid subject DID: %w", err)
+		}
+	}
+	return nil
+}

--- a/plugins/auth/verify.go
+++ b/plugins/auth/verify.go
@@ -1,0 +1,157 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package auth
+
+import (
+	"context"
+	"fmt"
+)
+
+// Verifier validates UCAN tokens and delegation chains.
+type Verifier struct {
+	signers  []Signer
+	resolver TokenResolver
+}
+
+// Signer verifies signatures for a specific DID method.
+type Signer interface {
+	// CanVerify returns true if this signer handles the given DID.
+	CanVerify(did string) bool
+
+	// Verify checks a signature over payload bytes for the given issuer DID.
+	Verify(ctx context.Context, payload []byte, signature []byte, issuerDID string) (bool, error)
+}
+
+// TokenResolver resolves proof token CIDs to full tokens.
+// Implementations may use local cache, MDBX, or torrent download.
+type TokenResolver interface {
+	// Resolve returns the token for the given CID.
+	// Returns nil, nil if the token is not found.
+	Resolve(ctx context.Context, cid CID) (*Token, error)
+}
+
+// NewVerifier creates a verifier with the given signers and token resolver.
+func NewVerifier(resolver TokenResolver, signers ...Signer) *Verifier {
+	return &Verifier{
+		signers:  signers,
+		resolver: resolver,
+	}
+}
+
+// Verify validates a UCAN token:
+//  1. Structure validation (required fields)
+//  2. Time bounds (not expired, not before nbf)
+//  3. Signature verification (dispatched to correct signer)
+//  4. Delegation chain (each proof verified recursively, attenuation checked)
+//  5. Capability check (token authorizes the required capability)
+func (v *Verifier) Verify(ctx context.Context, token *Token, required Capability) error {
+	return v.verifyToken(ctx, token, required, 0)
+}
+
+const maxChainDepth = 64
+
+func (v *Verifier) verifyToken(ctx context.Context, token *Token, required Capability, depth int) error {
+	if depth > maxChainDepth {
+		return fmt.Errorf("delegation chain too deep (max %d)", maxChainDepth)
+	}
+
+	// 1. Structure
+	if err := token.ValidateStructure(); err != nil {
+		return fmt.Errorf("invalid token structure: %w", err)
+	}
+
+	// 2. Time bounds
+	if !token.IsActive() {
+		if token.IsExpired() {
+			return fmt.Errorf("token expired (exp=%d)", token.Exp)
+		}
+		return fmt.Errorf("token not yet valid (nbf=%d)", token.Nbf)
+	}
+
+	// 3. Signature
+	if err := v.verifySignature(ctx, token); err != nil {
+		return fmt.Errorf("signature verification failed: %w", err)
+	}
+
+	// 4. Capability check — does this token authorize the required capability?
+	tokenCap := token.Capability()
+	if !tokenCap.Covers(required) {
+		return fmt.Errorf("token capability %q does not cover required %q", tokenCap.Command, required.Command)
+	}
+
+	// 5. Delegation chain — verify each proof
+	if len(token.Proofs) > 0 {
+		return v.verifyChain(ctx, token, required, depth)
+	}
+
+	// No proofs — this is a root token. The issuer IS the root authority.
+	return nil
+}
+
+func (v *Verifier) verifySignature(ctx context.Context, token *Token) error {
+	payload, err := token.PayloadBytes()
+	if err != nil {
+		return fmt.Errorf("failed to encode payload: %w", err)
+	}
+
+	for _, signer := range v.signers {
+		if signer.CanVerify(token.Issuer) {
+			valid, err := signer.Verify(ctx, payload, token.Signature, token.Issuer)
+			if err != nil {
+				return fmt.Errorf("signer error for %s: %w", token.Issuer, err)
+			}
+			if !valid {
+				return fmt.Errorf("invalid signature for issuer %s", token.Issuer)
+			}
+			return nil
+		}
+	}
+
+	return fmt.Errorf("no signer available for DID: %s", token.Issuer)
+}
+
+func (v *Verifier) verifyChain(ctx context.Context, token *Token, required Capability, depth int) error {
+	for _, proofCID := range token.Proofs {
+		// Resolve the proof token
+		proof, err := v.resolver.Resolve(ctx, proofCID)
+		if err != nil {
+			return fmt.Errorf("failed to resolve proof %x: %w", proofCID[:8], err)
+		}
+		if proof == nil {
+			return fmt.Errorf("proof not found: %x", proofCID[:8])
+		}
+
+		// The proof's audience must be this token's issuer (delegation chain)
+		if proof.Audience != token.Issuer {
+			return fmt.Errorf("proof audience %q != token issuer %q (broken chain)", proof.Audience, token.Issuer)
+		}
+
+		// Attenuation check — this token's capability must be narrower than the proof's
+		proofCap := proof.Capability()
+		tokenCap := token.Capability()
+		if !tokenCap.Attenuates(proofCap) {
+			return fmt.Errorf("token capability %q does not attenuate proof capability %q", tokenCap.Command, proofCap.Command)
+		}
+
+		// Recursively verify the proof token
+		if err := v.verifyToken(ctx, proof, required, depth+1); err != nil {
+			return fmt.Errorf("proof chain broken: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/plugins/auth/verify.go
+++ b/plugins/auth/verify.go
@@ -25,6 +25,7 @@ import (
 type Verifier struct {
 	signers  []Signer
 	resolver TokenResolver
+	store    Store // optional — if set, revoked tokens are rejected during verification
 }
 
 // Signer verifies signatures for a specific DID method.
@@ -45,10 +46,12 @@ type TokenResolver interface {
 }
 
 // NewVerifier creates a verifier with the given signers and token resolver.
-func NewVerifier(resolver TokenResolver, signers ...Signer) *Verifier {
+// If store is non-nil, revoked tokens are rejected during verification.
+func NewVerifier(resolver TokenResolver, store Store, signers ...Signer) *Verifier {
 	return &Verifier{
 		signers:  signers,
 		resolver: resolver,
+		store:    store,
 	}
 }
 
@@ -65,7 +68,7 @@ func (v *Verifier) Verify(ctx context.Context, token *Token, required Capability
 const maxChainDepth = 64
 
 func (v *Verifier) verifyToken(ctx context.Context, token *Token, required Capability, depth int) error {
-	if depth > maxChainDepth {
+	if depth >= maxChainDepth {
 		return fmt.Errorf("delegation chain too deep (max %d)", maxChainDepth)
 	}
 
@@ -85,6 +88,18 @@ func (v *Verifier) verifyToken(ctx context.Context, token *Token, required Capab
 	// 3. Signature
 	if err := v.verifySignature(ctx, token); err != nil {
 		return fmt.Errorf("signature verification failed: %w", err)
+	}
+
+	// 3b. Revocation check — if a store is configured, reject revoked tokens.
+	if v.store != nil {
+		cid := token.ComputeCID()
+		revoked, err := v.store.IsRevoked(ctx, cid, token.Issuer, token.Iat)
+		if err != nil {
+			return fmt.Errorf("revocation check failed: %w", err)
+		}
+		if revoked {
+			return fmt.Errorf("token %x has been revoked", cid)
+		}
 	}
 
 	// 4. Capability check — does this token authorize the required capability?


### PR DESCRIPTION
## Summary

Adds the foundational auth plugin for the Cocoon plugin system.

### UCAN core library (`plugins/auth/`)
- Token creation, parsing, and chain verification (delegation chains)
- Capability model with resource/action/policy matching (v1: equality operator)
- EOA signer with ERC-191 personal_sign for BLS-free environments
- MDBX-backed persistent token store with revocation support
- Verifier checks revocation state when store is configured
- Full test coverage (token lifecycle, capability matching with policies, chain verification, store operations)

### Review feedback addressed
- `ComputeCID` handles json.Marshal errors (returns zero-CID)
- `Covers` evaluates Policy constraints (field + operator matching)
- Chain depth guard uses `>=` (exact max, not off-by-one)
- Verifier checks `Store.IsRevoked` before capability evaluation
- `NewVerifier` accepts optional Store for revocation enforcement

## Test plan

- [x] `make lint` passes
- [x] `go test ./plugins/auth/...` — all pass
- [ ] CI passes