### PR TITLE
node: introduce nodebuilder component registry

### DIFF
--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -90,7 +90,6 @@ import (
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/execution/vm"
 	"github.com/erigontech/erigon/node"
-	downloadercomp "github.com/erigontech/erigon/node/components/downloader"
 	"github.com/erigontech/erigon/node/direct"
 	"github.com/erigontech/erigon/node/ethconfig"
 	"github.com/erigontech/erigon/node/ethstats"
@@ -100,6 +99,7 @@ import (
 	"github.com/erigontech/erigon/node/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon/node/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon/node/gointerfaces/typesproto"
+	"github.com/erigontech/erigon/node/nodebuilder"
 	privateapi2 "github.com/erigontech/erigon/node/privateapi"
 	"github.com/erigontech/erigon/node/rulesconfig"
 	"github.com/erigontech/erigon/node/shards"
@@ -198,7 +198,7 @@ type Ethereum struct {
 	txPoolRpcClient           txpoolproto.TxpoolClient
 	shutterPool               *shutter.Pool
 	blockBuilderNotifyNewTxns chan struct{}
-	downloaderProvider        *downloadercomp.Provider
+	components                *nodebuilder.Builder
 
 	blockSnapshots *freezeblocks.RoSnapshots
 	blockReader    services.FullBlockReader
@@ -406,13 +406,12 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 	backend.blockSnapshots, backend.blockReader, backend.blockWriter = allSnapshots, blockReader, blockWriter
 	backend.chainDB = temporalDb
 
-	// Initialize the downloader component (local in-process or remote via gRPC).
-	backend.downloaderProvider = &downloadercomp.Provider{}
-	backend.downloaderProvider.Configure(config.Downloader, config.Snapshot, config.Dirs, logger, stack.Config().DebugMux)
-	if err := backend.downloaderProvider.Initialize(ctx); err != nil {
+	// Initialize extracted components.
+	backend.components = nodebuilder.New()
+	if err := backend.components.BuildDownloader(ctx, config.Downloader, config.Snapshot, config.Dirs, logger, stack.Config().DebugMux); err != nil {
 		return nil, err
 	}
-	backend.downloaderClient = backend.downloaderProvider.Client
+	backend.downloaderClient = backend.components.Downloader.Client
 
 	// Register file-change callbacks so completed snapshots are seeded and
 	// deleted snapshots are removed from the swarm. These stay here because
@@ -964,9 +963,9 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 	// snapshots not in that set could cause issues. That's an unsolved issue and probably requires
 	// always resetting before resuming/starting a sync.
 	var afterSnapshotDownload func(ctx context.Context) error
-	if backend.downloaderProvider != nil && backend.downloaderProvider.Downloader != nil {
+	if backend.components.Downloader != nil && backend.components.Downloader.Downloader != nil {
 		afterSnapshotDownload = func(ctx context.Context) (err error) {
-			incomplete, err := backend.downloaderProvider.Downloader.AddTorrentsFromDisk(ctx)
+			incomplete, err := backend.components.Downloader.Downloader.AddTorrentsFromDisk(ctx)
 			if err != nil {
 				err = fmt.Errorf("adding torrents from disk: %w", err)
 				return
@@ -1496,8 +1495,8 @@ func (s *Ethereum) Stop() error {
 	if s.unsubscribeEthstat != nil {
 		s.unsubscribeEthstat()
 	}
-	if s.downloaderProvider != nil {
-		s.downloaderProvider.Close()
+	if s.components.Downloader != nil {
+		s.components.Downloader.Close()
 	}
 	if s.privateAPI != nil {
 		shutdownDone := make(chan bool)

--- a/node/nodebuilder/builder.go
+++ b/node/nodebuilder/builder.go
@@ -1,0 +1,62 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+// Package nodebuilder is the central component registry for an Erigon node.
+//
+// Components are extracted from backend.go incrementally and registered here.
+// The builder provides:
+//   - A single field in the Ethereum struct instead of N individual provider fields
+//   - A clear inventory of what has been componentized vs what remains in backend.go
+//
+// Build ordering:
+//  1. BuildDownloader — torrent client, gRPC proxy
+//  2. (future) BuildStorage — DB, snapshots, blockReader, notifications
+//
+// Components are configured and initialized in backend.go (deps differ per component),
+// but the builder owns allocation and provides a single access point.
+package nodebuilder
+
+import (
+	"context"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	downloadercomp "github.com/erigontech/erigon/node/components/downloader"
+	"github.com/erigontech/erigon/node/ethconfig"
+
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/downloader/downloadercfg"
+
+	"net/http"
+)
+
+// Builder holds all extracted node component providers.
+// Fields are added here as components graduate from backend.go.
+type Builder struct {
+	Downloader *downloadercomp.Provider
+}
+
+// New allocates a Builder with all providers pre-initialized.
+func New() *Builder {
+	return &Builder{
+		Downloader: &downloadercomp.Provider{},
+	}
+}
+
+// BuildDownloader configures and initializes the downloader component.
+func (b *Builder) BuildDownloader(ctx context.Context, dlCfg *downloadercfg.Cfg, snapCfg ethconfig.BlocksFreezing, dirs datadir.Dirs, logger log.Logger, debugMux *http.ServeMux) error {
+	b.Downloader.Configure(dlCfg, snapCfg, dirs, logger, debugMux)
+	return b.Downloader.Initialize(ctx)
+}


### PR DESCRIPTION
## Summary

Introduces `node/nodebuilder/Builder` as the central registry for extracted components. Replaces the inline `downloaderProvider` field on the Ethereum struct with `backend.components` — a single access point for all componentized subsystems.

Currently holds only Downloader; Storage will be added in the next PR.

### Changes
- **New:** `node/nodebuilder/builder.go` — Builder struct with `BuildDownloader` method
- **Modified:** `node/eth/backend.go` — replace `downloaderProvider` field with `components *nodebuilder.Builder`, update all references

This is minimal scaffolding that grows as components graduate from backend.go.

## Test plan

- [x] `make lint` passes
- [x] `make erigon` builds
- [ ] CI passes

**Depends on:** #20472 (auth plugin)