### PR TITLE
rpc: expose testing_ namespace via --http.api on port 8545

### DIFF
--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -133,7 +134,6 @@ func RootCommand() (*cobra.Command, *httpcfg.HttpCfg) {
 	rootCmd.PersistentFlags().IntVar(&cfg.RpcMaxConcurrentRequests, utils.RpcMaxConcurrentRequestsFlag.Name, utils.RpcMaxConcurrentRequestsFlag.Value, utils.RpcMaxConcurrentRequestsFlag.Usage)
 	rootCmd.PersistentFlags().BoolVar(&cfg.TraceCompatibility, "trace.compat", false, "Bug for bug compatibility with OE for trace_ routines")
 	rootCmd.PersistentFlags().BoolVar(&cfg.GethCompatibility, "rpc.gethcompat", false, "Enables Geth-compatible storage iteration order for debug_storageRangeAt (sorted by keccak256 hash). Disabled by default for performance.")
-	rootCmd.PersistentFlags().BoolVar(&cfg.TestingEnabled, "rpc.testing", false, "Enables the testing_ RPC namespace (testing_buildBlockV1). WARNING: do not enable on production networks.")
 	rootCmd.PersistentFlags().StringVar(&cfg.TxPoolApiAddr, "txpool.api.addr", "", "txpool api network address, for example: 127.0.0.1:9090 (default: use value of --private.api.addr)")
 
 	rootCmd.PersistentFlags().StringVar(&stateCacheStr, "state.cache", "0MB", "Amount of data to store in StateCache (enabled if no --datadir set). Set 0 to disable StateCache. Defaults to 0MB RAM")
@@ -146,7 +146,7 @@ func RootCommand() (*cobra.Command, *httpcfg.HttpCfg) {
 	rootCmd.PersistentFlags().StringVar(&cfg.TLSKeyFile, "tls.key", "", "key file for client side TLS handshake for GRPC")
 	rootCmd.PersistentFlags().StringVar(&cfg.TLSCACert, "tls.cacert", "", "CA certificate for client side TLS handshake for GRPC")
 
-	rootCmd.PersistentFlags().StringSliceVar(&cfg.API, "http.api", []string{"eth", "erigon"}, "API's offered over the RPC interface: eth,erigon,web3,net,debug,trace,txpool,db. Supported methods: https://github.com/erigontech/erigon/tree/main/cmd/rpcdaemon")
+	rootCmd.PersistentFlags().StringSliceVar(&cfg.API, "http.api", []string{"eth", "erigon"}, "API's offered over the RPC interface: eth,erigon,web3,net,debug,trace,txpool,db,testing. Supported methods: https://github.com/erigontech/erigon/tree/main/cmd/rpcdaemon")
 
 	rootCmd.PersistentFlags().BoolVar(&cfg.HttpServerEnabled, "http.enabled", true, "Enable HTTP server")
 	rootCmd.PersistentFlags().StringVar(&cfg.HttpListenAddress, "http.addr", nodecfg.DefaultHTTPHost, "HTTP server listening interface")
@@ -707,9 +707,17 @@ func startRegularRpcServer(ctx context.Context, cfg *httpcfg.HttpCfg, rpcAPI []r
 
 	var apiFlags []string
 	for _, flag := range cfg.API {
-		if flag != "engine" {
-			apiFlags = append(apiFlags, flag)
+		if flag == "engine" || flag == "testing" {
+			continue
 		}
+		apiFlags = append(apiFlags, flag)
+	}
+	// testing_ is only present in defaultAPIList when the caller (embedded mode)
+	// appended an implementation; re-admit it to the whitelist only then.
+	if slices.ContainsFunc(defaultAPIList, func(a rpc.API) bool { return a.Namespace == "testing" }) {
+		apiFlags = append(apiFlags, "testing")
+	} else if slices.Contains(cfg.API, "testing") {
+		logger.Warn("testing_ namespace is not available in standalone rpcdaemon (requires embedded execution service); ignoring")
 	}
 
 	if err := node.RegisterApisFromWhitelist(defaultAPIList, apiFlags, srv, false, logger); err != nil {

--- a/cmd/rpcdaemon/cli/httpcfg/http_cfg.go
+++ b/cmd/rpcdaemon/cli/httpcfg/http_cfg.go
@@ -113,7 +113,4 @@ type HttpCfg struct {
 
 	RpcTxSyncDefaultTimeout time.Duration // Default timeout for eth_sendRawTransactionSync
 	RpcTxSyncMaxTimeout     time.Duration // Maximum timeout for eth_sendRawTransactionSync
-
-	// TestingEnabled enables the testing_ RPC namespace. Should only be used in test/dev environments.
-	TestingEnabled bool
 }

--- a/execution/engineapi/engine_server.go
+++ b/execution/engineapi/engine_server.go
@@ -167,14 +167,9 @@ func (e *EngineServer) Start(
 			Version:   "1.0",
 		}}
 
-	if httpConfig.TestingEnabled {
-		e.logger.Warn("[EngineServer] testing_ RPC namespace is ENABLED — do not use on production networks")
-		apiList = append(apiList, rpc.API{
-			Namespace: "testing",
-			Public:    false,
-			Service:   TestingAPI(NewTestingImpl(e, true)),
-			Version:   "1.0",
-		})
+	if slices.Contains(httpConfig.API, "testing") {
+		e.logger.Warn("[EngineServer] testing_ RPC namespace is ENABLED on engine port — do not use on production networks")
+		apiList = append(apiList, NewTestingRPCEntry(e))
 	}
 
 	eg.Go(func() error {

--- a/execution/engineapi/engine_server.go
+++ b/execution/engineapi/engine_server.go
@@ -167,11 +167,6 @@ func (e *EngineServer) Start(
 			Version:   "1.0",
 		}}
 
-	if slices.Contains(httpConfig.API, "testing") {
-		e.logger.Warn("[EngineServer] testing_ RPC namespace is ENABLED on engine port — do not use on production networks")
-		apiList = append(apiList, NewTestingRPCEntry(e))
-	}
-
 	eg.Go(func() error {
 		defer e.logger.Debug("[EngineServer] engine rpc server goroutine terminated")
 		err := cli.StartRpcServerWithJwtAuthentication(ctx, httpConfig, apiList, e.logger)

--- a/execution/engineapi/testing_api.go
+++ b/execution/engineapi/testing_api.go
@@ -17,7 +17,8 @@
 package engineapi
 
 // testing_api.go implements the testing_ RPC namespace, specifically testing_buildBlockV1.
-// This namespace MUST NOT be enabled on production networks. Gate it with --rpc.testing.
+// Enable via --http.api=...,testing (e.g. --http.api eth,erigon,testing).
+// This namespace MUST NOT be enabled on production networks.
 
 import (
 	"context"
@@ -52,13 +53,22 @@ type TestingAPI interface {
 
 // testingImpl is the concrete implementation of TestingAPI.
 type testingImpl struct {
-	server  *EngineServer
-	enabled bool
+	server *EngineServer
 }
 
 // NewTestingImpl returns a new TestingAPI implementation wrapping the given EngineServer.
-func NewTestingImpl(server *EngineServer, enabled bool) TestingAPI {
-	return &testingImpl{server: server, enabled: enabled}
+func NewTestingImpl(server *EngineServer) TestingAPI {
+	return &testingImpl{server: server}
+}
+
+// NewTestingRPCEntry returns the rpc.API descriptor for the testing_ namespace.
+func NewTestingRPCEntry(server *EngineServer) rpc.API {
+	return rpc.API{
+		Namespace: "testing",
+		Public:    false,
+		Service:   TestingAPI(NewTestingImpl(server)),
+		Version:   "1.0",
+	}
 }
 
 // BuildBlockV1 implements TestingAPI.
@@ -69,10 +79,6 @@ func (t *testingImpl) BuildBlockV1(
 	transactions *[]hexutil.Bytes,
 	extraData *hexutil.Bytes,
 ) (*engine_types.GetPayloadResponse, error) {
-	if !t.enabled {
-		return nil, &rpc.InvalidParamsError{Message: "testing namespace is disabled; start erigon with --rpc.testing (WARNING: not for production use)"}
-	}
-
 	if payloadAttributes == nil {
 		return nil, &rpc.InvalidParamsError{Message: "payloadAttributes must not be null"}
 	}

--- a/execution/engineapi/testing_api_test.go
+++ b/execution/engineapi/testing_api_test.go
@@ -228,7 +228,7 @@ func validPayloadAttrs(parentTimestamp uint64) *engine_types.PayloadAttributes {
 }
 
 // newTestingAPI creates a testingImpl backed by a stub execution module.
-func newTestingAPI(cfg *chain.Config, stub *stubExecutionModule, enabled bool) TestingAPI {
+func newTestingAPI(cfg *chain.Config, stub *stubExecutionModule) TestingAPI {
 	srv := NewEngineServer(
 		log.New(),
 		cfg,
@@ -242,7 +242,7 @@ func newTestingAPI(cfg *chain.Config, stub *stubExecutionModule, enabled bool) T
 		0,     // fcuTimeout
 		0,     // maxReorgDepth
 	)
-	return NewTestingImpl(srv, enabled)
+	return NewTestingImpl(srv)
 }
 
 // makeAssembledBlock builds a minimal BlockWithReceipts for use in stub
@@ -287,22 +287,10 @@ func TestBuildBlockV1(t *testing.T) {
 	parentHdr := makeParentHeader(parentTimestamp)
 	parentHash := parentHdr.Hash()
 
-	t.Run("disabled gate", func(t *testing.T) {
-		t.Parallel()
-		stub := &stubExecutionModule{}
-		api := newTestingAPI(allForksChainConfig(), stub, false)
-		resp, err := api.BuildBlockV1(context.Background(), parentHash, validPayloadAttrs(parentTimestamp), nil, nil)
-		require.Nil(t, resp)
-		require.Error(t, err)
-		var rpcErr *rpc.InvalidParamsError
-		require.ErrorAs(t, err, &rpcErr)
-		assert.Contains(t, rpcErr.Message, "testing namespace is disabled")
-	})
-
 	t.Run("nil payloadAttributes", func(t *testing.T) {
 		t.Parallel()
 		stub := &stubExecutionModule{}
-		api := newTestingAPI(allForksChainConfig(), stub, true)
+		api := newTestingAPI(allForksChainConfig(), stub)
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, nil, nil, nil)
 		require.Nil(t, resp)
 		require.Error(t, err)
@@ -314,7 +302,7 @@ func TestBuildBlockV1(t *testing.T) {
 	t.Run("explicit non-empty transaction list", func(t *testing.T) {
 		t.Parallel()
 		stub := &stubExecutionModule{}
-		api := newTestingAPI(allForksChainConfig(), stub, true)
+		api := newTestingAPI(allForksChainConfig(), stub)
 		txs := []hexutil.Bytes{{0x01, 0x02}}
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, validPayloadAttrs(parentTimestamp), &txs, nil)
 		require.Nil(t, resp)
@@ -334,7 +322,7 @@ func TestBuildBlockV1(t *testing.T) {
 				return nil, nil
 			},
 		}
-		api := newTestingAPI(allForksChainConfig(), stub, true)
+		api := newTestingAPI(allForksChainConfig(), stub)
 		txs := []hexutil.Bytes{} // empty slice, not nil
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, validPayloadAttrs(parentTimestamp), &txs, nil)
 		require.Nil(t, resp)
@@ -352,7 +340,7 @@ func TestBuildBlockV1(t *testing.T) {
 				return nil, nil
 			},
 		}
-		api := newTestingAPI(allForksChainConfig(), stub, true)
+		api := newTestingAPI(allForksChainConfig(), stub)
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, validPayloadAttrs(parentTimestamp), nil, nil)
 		require.Nil(t, resp)
 		require.Error(t, err)
@@ -366,7 +354,7 @@ func TestBuildBlockV1(t *testing.T) {
 		stub := &stubExecutionModule{
 			getHeaderFunc: getHeaderReturning(parentHash, parentHdr),
 		}
-		api := newTestingAPI(allForksChainConfig(), stub, true)
+		api := newTestingAPI(allForksChainConfig(), stub)
 		attrs := validPayloadAttrs(parentTimestamp)
 		attrs.Timestamp = hexutil.Uint64(parentTimestamp) // equal, not greater
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, attrs, nil, nil)
@@ -382,7 +370,7 @@ func TestBuildBlockV1(t *testing.T) {
 		stub := &stubExecutionModule{
 			getHeaderFunc: getHeaderReturning(parentHash, parentHdr),
 		}
-		api := newTestingAPI(allForksChainConfig(), stub, true)
+		api := newTestingAPI(allForksChainConfig(), stub)
 		attrs := validPayloadAttrs(parentTimestamp)
 		attrs.Timestamp = hexutil.Uint64(parentTimestamp - 1) // less than parent
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, attrs, nil, nil)
@@ -398,7 +386,7 @@ func TestBuildBlockV1(t *testing.T) {
 		stub := &stubExecutionModule{
 			getHeaderFunc: getHeaderReturning(parentHash, parentHdr),
 		}
-		api := newTestingAPI(allForksChainConfig(), stub, true)
+		api := newTestingAPI(allForksChainConfig(), stub)
 		attrs := validPayloadAttrs(parentTimestamp)
 		attrs.ParentBeaconBlockRoot = nil // required for Cancun+
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, attrs, nil, nil)
@@ -415,7 +403,7 @@ func TestBuildBlockV1(t *testing.T) {
 			getHeaderFunc: getHeaderReturning(parentHash, parentHdr),
 		}
 		// Use a pre-Cancun config (Shanghai only).
-		api := newTestingAPI(preCancunChainConfig(), stub, true)
+		api := newTestingAPI(preCancunChainConfig(), stub)
 		attrs := validPayloadAttrs(parentTimestamp)
 		// attrs already has ParentBeaconBlockRoot set, which is invalid pre-Cancun.
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, attrs, nil, nil)
@@ -441,7 +429,7 @@ func TestBuildBlockV1(t *testing.T) {
 				return execmodule.AssembleBlockResult{Busy: true}, nil
 			},
 		}
-		api := newTestingAPI(shortSlotCfg, stub, true)
+		api := newTestingAPI(shortSlotCfg, stub)
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, validPayloadAttrs(parentTimestamp), nil, nil)
 		require.Nil(t, resp)
 		require.Error(t, err)
@@ -459,7 +447,7 @@ func TestBuildBlockV1(t *testing.T) {
 				return execmodule.AssembledBlockResult{Busy: true}, nil
 			},
 		}
-		api := newTestingAPI(shortSlotCfg, stub, true)
+		api := newTestingAPI(shortSlotCfg, stub)
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, validPayloadAttrs(parentTimestamp), nil, nil)
 		require.Nil(t, resp)
 		require.Error(t, err)
@@ -477,7 +465,7 @@ func TestBuildBlockV1(t *testing.T) {
 				return execmodule.AssembledBlockResult{Block: nil, Busy: false}, nil
 			},
 		}
-		api := newTestingAPI(allForksChainConfig(), stub, true)
+		api := newTestingAPI(allForksChainConfig(), stub)
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, validPayloadAttrs(parentTimestamp), nil, nil)
 		require.Nil(t, resp)
 		require.Error(t, err)
@@ -505,7 +493,7 @@ func TestBuildBlockV1(t *testing.T) {
 				return execmodule.AssembledBlockResult{Block: blk, BlockValue: blockValue, Busy: false}, nil
 			},
 		}
-		api := newTestingAPI(allForksChainConfig(), stub, true)
+		api := newTestingAPI(allForksChainConfig(), stub)
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, validPayloadAttrs(parentTimestamp), nil, nil)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
@@ -539,7 +527,7 @@ func TestBuildBlockV1(t *testing.T) {
 				}, nil
 			},
 		}
-		api := newTestingAPI(allForksChainConfig(), stub, true)
+		api := newTestingAPI(allForksChainConfig(), stub)
 		overrideData := hexutil.Bytes("overridden-extra")
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, validPayloadAttrs(parentTimestamp), nil, &overrideData)
 		require.NoError(t, err)
@@ -554,7 +542,7 @@ func TestBuildBlockV1(t *testing.T) {
 			getHeaderFunc: getHeaderReturning(parentHash, parentHdr),
 		}
 		// Use pre-Cancun (Shanghai-only) config.
-		api := newTestingAPI(preCancunChainConfig(), stub, true)
+		api := newTestingAPI(preCancunChainConfig(), stub)
 		attrs := &engine_types.PayloadAttributes{
 			Timestamp:             hexutil.Uint64(parentTimestamp + 1),
 			PrevRandao:            common.Hash{0xaa},
@@ -576,7 +564,7 @@ func TestBuildBlockV1(t *testing.T) {
 			getHeaderFunc: getHeaderReturning(parentHash, parentHdr),
 		}
 		// Use pre-Shanghai config.
-		api := newTestingAPI(preShanghaiChainConfig(), stub, true)
+		api := newTestingAPI(preShanghaiChainConfig(), stub)
 		attrs := &engine_types.PayloadAttributes{
 			Timestamp:             hexutil.Uint64(parentTimestamp + 1),
 			PrevRandao:            common.Hash{0xaa},

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -1163,6 +1163,11 @@ func (s *Ethereum) Init(stack *node.Node, config *ethconfig.Config, chainConfig 
 
 	s.apiList = jsonrpc.APIList(chainKv, s.ethRpcClient, s.txPoolRpcClient, s.miningRpcClient, s.rpcFilters, s.rpcDaemonStateCache, blockReader, &httpRpcCfg, s.engine, s.logger, s.polygonBridge, s.heimdallService)
 
+	if slices.Contains(httpRpcCfg.API, "testing") {
+		s.logger.Warn("[HTTP API] testing_ RPC namespace is ENABLED — do not use on production networks")
+		s.apiList = append(s.apiList, engineapi.NewTestingRPCEntry(s.engineBackendRPC))
+	}
+
 	s.bgComponentsEg.Go(func() error {
 		err := rpcdaemoncli.StartRpcServer(ctx, &httpRpcCfg, s.apiList, s.logger)
 		if err != nil && !errors.Is(err, context.Canceled) {


### PR DESCRIPTION
Replace the boolean --rpc.testing flag (engine-port-only, JWT-required) with the standard --http.api mechanism: adding "testing" to the list (e.g. --http.api eth,erigon,testing) registers testing_buildBlockV1 on the plain HTTP port (8545) without JWT, matching Geth's behaviour.

The namespace is disabled by default to prevent accidental production exposure.  In standalone rpcdaemon mode the entry is silently skipped with a Warn log, since block assembly requires direct execution service access unavailable over gRPC.