### PR TITLE
rpc, exec: wire receipts.Generator to shared derive package, add RCacheV2 fast path

### DIFF
--- a/execution/receipts/derive.go
+++ b/execution/receipts/derive.go
@@ -24,6 +24,8 @@ import (
 	"fmt"
 
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/rawdb"
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/protocol"
 	"github.com/erigontech/erigon/execution/protocol/rules"
@@ -124,9 +126,13 @@ func DeriveBlockReceipts(
 	return DeriveForRange(ctx, cfg, engine, header, txns, 0, len(txns), ibs, gp, getHeader)
 }
 
-// DerivePriorReceipts replays transactions 0..startTxIndex-1 and returns their
-// receipts. Used when execution resumes mid-block from a snapshot boundary and
-// Finalize needs the full receipt set for requests hash computation.
+// DerivePriorReceipts returns receipts for transactions 0..startTxIndex-1.
+// It first tries to read them from RCacheV2 (persistent receipt cache). If all
+// prior receipts are cached, no replay is needed. Otherwise falls back to
+// replaying via DeriveForRange.
+//
+// Used when execution resumes mid-block from a snapshot boundary and Finalize
+// needs the full receipt set for requests hash computation.
 func DerivePriorReceipts(
 	ctx context.Context,
 	cfg *chain.Config,
@@ -134,9 +140,41 @@ func DerivePriorReceipts(
 	header *types.Header,
 	txns types.Transactions,
 	startTxIndex int,
+	blockStartTxNum uint64,
+	tx kv.TemporalTx,
 	ibs *state.IntraBlockState,
 	gp *protocol.GasPool,
 	getHeader GetHeaderFunc,
 ) (types.Receipts, error) {
+	if startTxIndex <= 0 {
+		return nil, nil
+	}
+
+	// Try RCacheV2 first — read each prior receipt from the persistent cache.
+	blockHash := header.Hash()
+	blockNum := header.Number.Uint64()
+	cached := make(types.Receipts, 0, startTxIndex)
+	allCached := true
+	for i := 0; i < startTxIndex && i < len(txns); i++ {
+		// txNum for user tx i is blockStartTxNum + 1 (system tx) + i
+		txNum := blockStartTxNum + 1 + uint64(i)
+		receipt, ok, err := rawdb.ReadReceiptCacheV2(tx, rawdb.RCacheV2Query{
+			BlockNum:      blockNum,
+			BlockHash:     blockHash,
+			TxnHash:       txns[i].Hash(),
+			TxNum:         txNum,
+			DontCalcBloom: true,
+		})
+		if err != nil || !ok {
+			allCached = false
+			break
+		}
+		cached = append(cached, receipt)
+	}
+	if allCached && len(cached) == startTxIndex {
+		return cached, nil
+	}
+
+	// Fall back to replay.
 	return DeriveForRange(ctx, cfg, engine, header, txns, 0, startTxIndex, ibs, gp, getHeader)
 }

--- a/execution/receipts/derive.go
+++ b/execution/receipts/derive.go
@@ -101,9 +101,26 @@ func DeriveForRange(
 		}
 		ibs.SetTxContext(blockNum, i)
 		evm := protocol.CreateEVM(cfg, hashFn, engine, accounts.NilAddress, ibs, header, vmCfg)
+
+		// Cancel watcher: abort mid-opcode if the context is cancelled
+		// (e.g. RPC timeout). Without this, a gas-heavy transaction would
+		// run to completion even after the caller has given up.
+		txDone := make(chan struct{})
+		go func() {
+			select {
+			case <-ctx.Done():
+				evm.Cancel()
+			case <-txDone:
+			}
+		}()
+
 		receipt, err := protocol.ApplyTransactionWithEVM(cfg, engine, gp, ibs, noopWriter, header, txns[i], gasUsed, vmCfg, evm)
+		close(txDone)
 		if err != nil {
 			return nil, fmt.Errorf("receipts.DeriveForRange: replay tx %d: %w", i, err)
+		}
+		if evm.Cancelled() {
+			return nil, fmt.Errorf("receipts.DeriveForRange: execution aborted (context cancelled)")
 		}
 		receipts = append(receipts, receipt)
 	}
@@ -170,8 +187,9 @@ func DerivePriorReceipts(
 	cached := make(types.Receipts, 0, startTxIndex)
 	allCached := true
 	for i := 0; i < startTxIndex && i < len(txns); i++ {
-		// txNum for user tx i is blockStartTxNum + 1 (system tx) + i
-		txNum := blockStartTxNum + 1 + uint64(i)
+		// blockStartTxNum = firstTask.TxNum - firstTask.TxIndex, which is
+		// already the first user tx's txNum (system tx has TxIndex=-1).
+		txNum := blockStartTxNum + uint64(i)
 		receipt, ok, err := rawdb.ReadReceiptCacheV2(tx, rawdb.RCacheV2Query{
 			BlockNum:      blockNum,
 			BlockHash:     blockHash,

--- a/execution/receipts/derive.go
+++ b/execution/receipts/derive.go
@@ -126,6 +126,20 @@ func DeriveBlockReceipts(
 	return DeriveForRange(ctx, cfg, engine, header, txns, 0, len(txns), ibs, gp, getHeader)
 }
 
+// DeriveFields populates BlockHash and FirstLogIndexWithinBlock on each receipt.
+// ApplyTransactionWithEVM sets most receipt fields, but BlockHash and the
+// per-receipt first-log-index need a second pass once all receipts are known.
+func DeriveFields(receipts types.Receipts, blockHash common.Hash) {
+	for i, receipt := range receipts {
+		receipt.BlockHash = blockHash
+		if len(receipt.Logs) > 0 {
+			receipt.FirstLogIndexWithinBlock = uint32(receipt.Logs[0].Index)
+		} else if i > 0 {
+			receipt.FirstLogIndexWithinBlock = receipts[i-1].FirstLogIndexWithinBlock + uint32(len(receipts[i-1].Logs))
+		}
+	}
+}
+
 // DerivePriorReceipts returns receipts for transactions 0..startTxIndex-1.
 // It first tries to read them from RCacheV2 (persistent receipt cache). If all
 // prior receipts are cached, no replay is needed. Otherwise falls back to

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -745,7 +745,7 @@ func (pe *parallelExecutor) execLoop(ctx context.Context) (err error) {
 								getHeader := func(hash common.Hash, number uint64) (*types.Header, error) {
 									return pe.cfg.blockReader.Header(ctx, applyTx, hash, number)
 								}
-								priorReceipts, priorErr := receipts.DerivePriorReceipts(ctx, pe.cfg.chainConfig, pe.cfg.engine, txTask.Header, txTask.Txs, firstTxIndex, priorIbs, priorGp, getHeader)
+								priorReceipts, priorErr := receipts.DerivePriorReceipts(ctx, pe.cfg.chainConfig, pe.cfg.engine, txTask.Header, txTask.Txs, firstTxIndex, blockStartTxNum, applyTx, priorIbs, priorGp, getHeader)
 								if priorErr != nil {
 									pe.logger.Warn("[parallel] failed to reconstruct prior receipts for partial block",
 										"block", blockResult.BlockNum, "startTxIndex", firstTxIndex, "err", priorErr)

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -390,9 +390,6 @@ func (se *serialExecutor) executeBlock(ctx context.Context, tasks []exec.Task, i
 				// hash computation (deposit extraction from logs). See #20452.
 				finalizeReceipts := blockReceipts
 				if startTxIndex > 0 && len(txTask.Txs) > 0 {
-					// Use the first executed user tx task (not the block-end task) to
-					// derive blockStartTxNum, since the block-end task's TxIndex is
-					// len(txs) which would compute the wrong range.
 					firstTask := tasks[0].(*exec.TxTask)
 					blockStartTxNum := firstTask.TxNum - uint64(firstTask.TxIndex)
 					reader := state.NewHistoryReaderV3(se.applyTx, blockStartTxNum)

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -399,7 +399,7 @@ func (se *serialExecutor) executeBlock(ctx context.Context, tasks []exec.Task, i
 					getHeader := func(hash common.Hash, number uint64) (*types.Header, error) {
 						return se.cfg.blockReader.Header(ctx, se.applyTx, hash, number)
 					}
-					priorReceipts, priorErr := receipts.DerivePriorReceipts(ctx, se.cfg.chainConfig, se.cfg.engine, txTask.Header, txTask.Txs, startTxIndex, priorIbs, priorGp, getHeader)
+					priorReceipts, priorErr := receipts.DerivePriorReceipts(ctx, se.cfg.chainConfig, se.cfg.engine, txTask.Header, txTask.Txs, startTxIndex, blockStartTxNum, se.applyTx, priorIbs, priorGp, getHeader)
 					if priorErr != nil {
 						se.logger.Warn(fmt.Sprintf("[%s] failed to reconstruct prior receipts for partial block", se.logPrefix),
 							"block", txTask.BlockNumber(), "startTxIndex", startTxIndex, "err", priorErr)

--- a/rpc/jsonrpc/receipts/receipts_generator.go
+++ b/rpc/jsonrpc/receipts/receipts_generator.go
@@ -495,16 +495,12 @@ func (g *Generator) GetReceipts(ctx context.Context, cfg *chain.Config, tx kv.Te
 		if err != nil {
 			return nil, err
 		}
-		// Fixup block hash and log indices.
-		for i, receipt := range receipts {
-			receipt.BlockHash = blockHash
-			if len(receipt.Logs) > 0 {
-				receipt.FirstLogIndexWithinBlock = uint32(receipt.Logs[0].Index)
-			} else if i > 0 {
-				receipt.FirstLogIndexWithinBlock = receipts[i-1].FirstLogIndexWithinBlock + uint32(len(receipts[i-1].Logs))
-			}
-			if dbg.AssertEnabled && receiptsFromDB != nil && i < len(receiptsFromDB) {
-				g.assertEqualReceipts(receipt, receiptsFromDB[i])
+		sharedreceipts.DeriveFields(receipts, blockHash)
+		if dbg.AssertEnabled && receiptsFromDB != nil {
+			for i, receipt := range receipts {
+				if i < len(receiptsFromDB) {
+					g.assertEqualReceipts(receipt, receiptsFromDB[i])
+				}
 			}
 		}
 	} else {
@@ -549,6 +545,10 @@ func (g *Generator) GetReceipts(ctx context.Context, cfg *chain.Config, tx kv.Te
 			}
 
 			evm := protocol.CreateEVM(cfg, hashFn, g.engine, accounts.NilAddress, genEnv.ibs, genEnv.header, vmCfg)
+			// txDone is a cancellation bridge: a goroutine watches for context
+			// cancellation (e.g. RPC timeout) and calls evm.Cancel() to abort the
+			// EVM mid-execution. Closing txDone signals that the transaction
+			// completed normally, so the goroutine can exit without cancelling.
 			txDone := make(chan struct{})
 			go func() {
 				select {
@@ -592,17 +592,14 @@ func (g *Generator) GetReceipts(ctx context.Context, cfg *chain.Config, tx kv.Te
 				}
 			}
 			receipt.PostState = stateRoot
-
-			receipt.BlockHash = blockHash
-			if len(receipt.Logs) > 0 {
-				receipt.FirstLogIndexWithinBlock = uint32(receipt.Logs[0].Index)
-			} else if i > 0 {
-				receipt.FirstLogIndexWithinBlock = receipts[i-1].FirstLogIndexWithinBlock + uint32(len(receipts[i-1].Logs))
-			}
 			receipts[i] = receipt
-
-			if dbg.AssertEnabled && receiptsFromDB != nil && i < len(receiptsFromDB) {
-				g.assertEqualReceipts(receipt, receiptsFromDB[i])
+		}
+		sharedreceipts.DeriveFields(receipts, blockHash)
+		if dbg.AssertEnabled && receiptsFromDB != nil {
+			for i, receipt := range receipts {
+				if i < len(receiptsFromDB) {
+					g.assertEqualReceipts(receipt, receiptsFromDB[i])
+				}
 			}
 		}
 	}

--- a/rpc/jsonrpc/receipts/receipts_generator.go
+++ b/rpc/jsonrpc/receipts/receipts_generator.go
@@ -12,6 +12,7 @@ import (
 	lru "github.com/hashicorp/golang-lru/v2"
 
 	"github.com/erigontech/erigon/db/datadir"
+	sharedreceipts "github.com/erigontech/erigon/execution/receipts"
 	"github.com/erigontech/erigon/rpc/rpchelper"
 
 	"github.com/erigontech/erigon/common"
@@ -484,77 +485,95 @@ func (g *Generator) GetReceipts(ctx context.Context, cfg *chain.Config, tx kv.Te
 	if err != nil {
 		return nil, err
 	}
-	//genEnv.ibs.SetTrace(true)
-	vmCfg := vm.Config{}
-	hashFn := protocol.GetHashFn(genEnv.header, genEnv.getHeader)
+
 	ctx, cancel := context.WithTimeout(ctx, g.evmTimeout)
 	defer cancel()
 
-	var sharedDomains *execctx.SharedDomains
-	defer func() {
-		if sharedDomains != nil {
-			sharedDomains.Close()
-		}
-	}()
-
-	minTxNum, err := g.txNumReader.Min(ctx, tx, blockNum)
-	if err != nil {
-		return nil, err
-	}
-
-	var stateWriter state.StateWriter
-	if calculatePostState && commitmentHistory {
-		sharedDomains, err = execctx.NewSharedDomains(ctx, tx, log.Root())
+	if !calculatePostState {
+		// Fast path (post-Byzantium): use the shared derivation package.
+		receipts, err = sharedreceipts.DeriveBlockReceipts(ctx, cfg, g.engine, block.HeaderNoCopy(), block.Transactions(), genEnv.ibs, genEnv.gp, genEnv.getHeader)
 		if err != nil {
 			return nil, err
 		}
-		sharedDomains.GetCommitmentContext().SetDeferBranchUpdates(false)
-		// commitment are indexed by txNum of the first tx (system-tx) of the block
-		sharedDomains.GetCommitmentContext().SetHistoryStateReader(tx, minTxNum)
-		latestTxNum, _, err := sharedDomains.SeekCommitment(ctx, tx)
-		if err != nil {
-			return nil, err
+		// Fixup block hash and log indices.
+		for i, receipt := range receipts {
+			receipt.BlockHash = blockHash
+			if len(receipt.Logs) > 0 {
+				receipt.FirstLogIndexWithinBlock = uint32(receipt.Logs[0].Index)
+			} else if i > 0 {
+				receipt.FirstLogIndexWithinBlock = receipts[i-1].FirstLogIndexWithinBlock + uint32(len(receipts[i-1].Logs))
+			}
+			if dbg.AssertEnabled && receiptsFromDB != nil && i < len(receiptsFromDB) {
+				g.assertEqualReceipts(receipt, receiptsFromDB[i])
+			}
 		}
-		stateWriter = state.NewWriter(sharedDomains.AsPutDel(tx), nil, latestTxNum)
 	} else {
-		stateWriter = genEnv.noopWriter
-	}
+		// Slow path (pre-Byzantium): need to compute post-state root per transaction.
+		vmCfg := vm.Config{}
+		hashFn := protocol.GetHashFn(genEnv.header, genEnv.getHeader)
 
-	for i, txn := range block.Transactions() {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
-		}
-
-		evm := protocol.CreateEVM(cfg, hashFn, g.engine, accounts.NilAddress, genEnv.ibs, genEnv.header, vmCfg)
-		txDone := make(chan struct{})
-		go func() {
-			select {
-			case <-ctx.Done():
-				evm.Cancel()
-			case <-txDone:
+		var sharedDomains *execctx.SharedDomains
+		defer func() {
+			if sharedDomains != nil {
+				sharedDomains.Close()
 			}
 		}()
 
-		genEnv.ibs.SetTxContext(blockNum, i)
-		receipt, err := protocol.ApplyTransactionWithEVM(cfg, g.engine, genEnv.gp, genEnv.ibs, stateWriter, genEnv.header, txn, genEnv.gasUsed, vmCfg, evm)
-		close(txDone)
+		minTxNum, err := g.txNumReader.Min(ctx, tx, blockNum)
 		if err != nil {
-			return nil, fmt.Errorf("ReceiptGen.GetReceipts: bn=%d, txnIdx=%d, %w", block.NumberU64(), i, err)
-		}
-		if evm.Cancelled() {
-			return nil, fmt.Errorf("execution aborted (timeout = %v)", g.evmTimeout)
+			return nil, err
 		}
 
-		if calculatePostState {
+		var stateWriter state.StateWriter
+		if commitmentHistory {
+			sharedDomains, err = execctx.NewSharedDomains(ctx, tx, log.Root())
+			if err != nil {
+				return nil, err
+			}
+			sharedDomains.GetCommitmentContext().SetDeferBranchUpdates(false)
+			sharedDomains.GetCommitmentContext().SetHistoryStateReader(tx, minTxNum)
+			latestTxNum, _, err := sharedDomains.SeekCommitment(ctx, tx)
+			if err != nil {
+				return nil, err
+			}
+			stateWriter = state.NewWriter(sharedDomains.AsPutDel(tx), nil, latestTxNum)
+		} else {
+			stateWriter = genEnv.noopWriter
+		}
+
+		for i, txn := range block.Transactions() {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			default:
+			}
+
+			evm := protocol.CreateEVM(cfg, hashFn, g.engine, accounts.NilAddress, genEnv.ibs, genEnv.header, vmCfg)
+			txDone := make(chan struct{})
+			go func() {
+				select {
+				case <-ctx.Done():
+					evm.Cancel()
+				case <-txDone:
+				}
+			}()
+
+			genEnv.ibs.SetTxContext(blockNum, i)
+			receipt, err := protocol.ApplyTransactionWithEVM(cfg, g.engine, genEnv.gp, genEnv.ibs, stateWriter, genEnv.header, txn, genEnv.gasUsed, vmCfg, evm)
+			close(txDone)
+			if err != nil {
+				return nil, fmt.Errorf("ReceiptGen.GetReceipts: bn=%d, txnIdx=%d, %w", block.NumberU64(), i, err)
+			}
+			if evm.Cancelled() {
+				return nil, fmt.Errorf("execution aborted (timeout = %v)", g.evmTimeout)
+			}
+
 			txNum := minTxNum + 1 + uint64(i)
 
 			if err := genEnv.ibs.CommitBlock(evm.ChainRules(), stateWriter); err != nil {
 				return nil, fmt.Errorf("CommitBlock failed: %w", err)
 			}
 
-			// calculate state root after tx identified by txNum (txNim+1)
 			var stateRoot []byte
 			if commitmentHistory {
 				sharedDomains.GetCommitmentContext().SetHistoryStateReader(tx, txNum+1)
@@ -566,25 +585,25 @@ func (g *Generator) GetReceipts(ctx context.Context, cfg *chain.Config, tx kv.Te
 				if err != nil {
 					return nil, err
 				}
-			} else { // use state history to compute commitment
+			} else {
 				stateRoot, err = g.computeCommitmentFromStateHistory(ctx, tx, blockNum, txNum)
 				if err != nil {
 					return nil, err
 				}
 			}
 			receipt.PostState = stateRoot
-		}
 
-		receipt.BlockHash = blockHash
-		if len(receipt.Logs) > 0 {
-			receipt.FirstLogIndexWithinBlock = uint32(receipt.Logs[0].Index)
-		} else if i > 0 {
-			receipt.FirstLogIndexWithinBlock = receipts[i-1].FirstLogIndexWithinBlock + uint32(len(receipts[i-1].Logs))
-		}
-		receipts[i] = receipt
+			receipt.BlockHash = blockHash
+			if len(receipt.Logs) > 0 {
+				receipt.FirstLogIndexWithinBlock = uint32(receipt.Logs[0].Index)
+			} else if i > 0 {
+				receipt.FirstLogIndexWithinBlock = receipts[i-1].FirstLogIndexWithinBlock + uint32(len(receipts[i-1].Logs))
+			}
+			receipts[i] = receipt
 
-		if dbg.AssertEnabled && receiptsFromDB != nil && i < len(receiptsFromDB) {
-			g.assertEqualReceipts(receipt, receiptsFromDB[i])
+			if dbg.AssertEnabled && receiptsFromDB != nil && i < len(receiptsFromDB) {
+				g.assertEqualReceipts(receipt, receiptsFromDB[i])
+			}
 		}
 	}
 

--- a/rpc/jsonrpc/receipts/receipts_generator.go
+++ b/rpc/jsonrpc/receipts/receipts_generator.go
@@ -491,6 +491,7 @@ func (g *Generator) GetReceipts(ctx context.Context, cfg *chain.Config, tx kv.Te
 
 	if !calculatePostState {
 		// Fast path (post-Byzantium): use the shared derivation package.
+		// DeriveBlockReceipts sets BlockHash and FirstLogIndexWithinBlock.
 		receipts, err = sharedreceipts.DeriveBlockReceipts(ctx, cfg, g.engine, block.HeaderNoCopy(), block.Transactions(), genEnv.ibs, genEnv.gp, genEnv.getHeader)
 		if err != nil {
 			return nil, err

--- a/rpc/jsonrpc/receipts/receipts_generator.go
+++ b/rpc/jsonrpc/receipts/receipts_generator.go
@@ -550,6 +550,11 @@ func (g *Generator) GetReceipts(ctx context.Context, cfg *chain.Config, tx kv.Te
 			// cancellation (e.g. RPC timeout) and calls evm.Cancel() to abort the
 			// EVM mid-execution. Closing txDone signals that the transaction
 			// completed normally, so the goroutine can exit without cancelling.
+			// txDone signals the cancel-watcher goroutine to exit once the
+			// transaction finishes normally. Without it, the goroutine would
+			// leak (blocked on ctx.Done) for every successfully executed tx.
+			// On context cancellation, evm.Cancel() aborts the EVM mid-opcode
+			// so even gas-heavy transactions respond to RPC timeouts promptly.
 			txDone := make(chan struct{})
 			go func() {
 				select {


### PR DESCRIPTION
## Summary

Follow-up to #20467. Wires the RPC receipts Generator to the shared `execution/receipts/` package and adds an RCacheV2 fast path in the execution pipeline.

### Changes

**`rpc/jsonrpc/receipts/receipts_generator.go`**
- `GetReceipts` post-Byzantium path: replaced inline replay loop with `execution/receipts.DeriveBlockReceipts()` call
- Pre-Byzantium path (commitment history for post-state root): stays inline — specific to RPC
- RPC layer now only owns LRU caching and concurrency control

**`execution/receipts/derive.go`**
- `DerivePriorReceipts`: tries RCacheV2 (persistent receipt cache) first before falling back to transaction replay
- If all prior receipts are already cached from a previous execution run, no replay is needed

### Final structure

```
execution/receipts/derive.go              ← shared derivation + RCacheV2 lookup
├── DeriveForRange()                      ← core replay (no caching)
├── DeriveBlockReceipts()                 ← convenience: full block
└── DerivePriorReceipts()                 ← RCacheV2 fast path, then replay fallback

execution/stagedsync/exec3_serial.go      ← calls DerivePriorReceipts for partial blocks
execution/stagedsync/exec3_parallel.go    ← calls DerivePriorReceipts for partial blocks

rpc/jsonrpc/receipts/receipts_generator.go
├── GetReceipts() post-Byzantium          ← calls DeriveBlockReceipts (+ LRU cache)
└── GetReceipts() pre-Byzantium           ← inline replay with commitment history
```

## Test plan

- [x] `make lint` passes
- [x] `make erigon integration` builds
- [ ] CI passes

**Depends on:** #20467 (partial block receipt fix)