### PR TITLE
db/state: add optional throttle to MergeLoop to reduce disk I/O pressure

### DIFF
--- a/common/dbg/experiments.go
+++ b/common/dbg/experiments.go
@@ -87,6 +87,8 @@ var (
 
 	AggregationDelayMs = EnvInt("AGGREGATION_DELAY_MS", 0)
 
+	MergeThrottleMs = EnvInt("ERIGON_MERGE_THROTTLE_MS", 0)
+
 	TraceAccounts         = EnvStrings("TRACE_ACCOUNTS", ",", nil)
 	TraceStateKeys        = EnvStrings("TRACE_STATE_KEYS", ",", nil)
 	TraceInstructions     = EnvBool("TRACE_INSTRUCTIONS", false)

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -1027,6 +1027,11 @@ func (a *Aggregator) MergeLoop(ctx context.Context) (err error) {
 	defer a.wg.Done()
 	defer a.mergingFiles.Store(false)
 
+	mergeThrottleMs := dbg.MergeThrottleMs
+	if mergeThrottleMs > 0 {
+		a.logger.Info("[snapshots] MergeLoop throttle enabled", "delay_ms", mergeThrottleMs)
+	}
+
 	for {
 		somethingMerged, err := a.mergeLoopStep(ctx, a.visibleFilesMinimaxTxNum.Load())
 		if err != nil {
@@ -1034,6 +1039,16 @@ func (a *Aggregator) MergeLoop(ctx context.Context) (err error) {
 		}
 		if !somethingMerged {
 			return nil
+		}
+
+		// Throttle between merge steps to reduce disk I/O pressure
+		// and allow block execution to proceed.
+		if mergeThrottleMs > 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(time.Duration(mergeThrottleMs) * time.Millisecond):
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Problem
 
When Erigon is running at chain tip, `MergeLoop` executes merge steps back-to-back with no pause between iterations. Each merge step involves heavy disk I/O (reading, compressing, and writing state files). Running these steps consecutively saturates the disk, starving block execution of I/O bandwidth.
 
The result is periodic block processing stalls: the node's reported block number freezes for minutes at a time while background merges consume all available I/O, then bursts forward when a merge step completes. During these stalls the node falls behind the chain tip and is marked unhealthy by load balancers.
 
### Observed behavior
 
On a production fleet running Erigon v3.3.x on AWS Graviton instances (64GB RAM, EBS gp3 volumes), we observed the following pattern during MergeLoop activity on individual nodes:
 
- Block execution throughput drops from ~20 Mgas/s to 1-5 Mgas/s
- Node block number freezes for 8-16 minutes per merge step
- Page cache eviction of 16GB+ as merge I/O displaces cached state data
- Lag accumulates at ~5 blocks/minute during each stall
- Worst observed: 164 blocks behind over a 188-minute period of continuous merge activity
 
The node always recovers eventually, but the stalls cause the node to be removed from load balancer rotation, reducing fleet capacity.
 
### Solution
 
Add a configurable delay between `MergeLoop` iterations via the `MERGE_THROTTLE_MS` environment variable (default 0, preserving current behavior). The delay is inserted after each successful `mergeLoopStep`, giving block execution a window to access the disk before the next merge step begins.
 
```
Before (current):
  mergeLoopStep()  → heavy I/O
  mergeLoopStep()  → immediately, more heavy I/O
  mergeLoopStep()  → immediately, more heavy I/O
 
After (with ERIGON_MERGE_THROTTLE_MS=2000):
  mergeLoopStep()  → heavy I/O
  sleep(2s)        → block execution catches up
  mergeLoopStep()  → heavy I/O
  sleep(2s)        → block execution catches up
```
 
### Production results
 
We have been running this patch on a 3-node production fleet since December 2025. Results:
 
- Individual node availability during merge-heavy periods improved from ~90% to >99%
- Block execution stalls reduced from 8-16 minutes to under 5 minutes
- Nodes maintain chain tip proximity during merge activity
- No negative impact on merge completion time (merges still finish, just spread over a slightly longer window)
- Fleet-wide availability (via load-balanced proxy) is near 99.99%, with the remaining downtime caused by synchronized stalls that this patch and `AGGREGATION_DELAY_MS` (PR #20391) address together
 
Recommended values based on our testing:
 
| Use case | Value | Effect |
|----------|-------|--------|
| Default (no throttle) | 0 | Current behavior, no change |
| Light throttle | 500 | Slight breathing room between merges |
| Production RPC nodes | 2000 | Good balance of merge progress and block execution |
| Heavy RPC workload | 5000 | Prioritize block execution over merge speed |
 
### Notes
 
- This is complementary to `COMPRESS_WORKERS` (PR #18995) which reduces I/O pressure *within* each merge step by limiting worker parallelism. This PR addresses I/O pressure *between* merge steps.
- This is also complementary to `AGGREGATION_DELAY_MS` (PR #20391, merged) which staggers the *start time* of aggregation across fleet nodes.
- No impact on single-node deployments or initial sync (default delay is 0).