### PR TITLE
[r3.4] txpool: use poolDB tx for getCachedBlobTxnLocked

### DIFF
--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -338,6 +338,12 @@ func (p *TxPool) OnNewBlock(ctx context.Context, stateChanges *remoteproto.State
 
 	defer coreTx.Rollback()
 
+	poolTx, err := p.poolDB.BeginRo(ctx)
+	if err != nil {
+		return err
+	}
+	defer poolTx.Rollback()
+
 	block := stateChanges.ChangeBatch[len(stateChanges.ChangeBatch)-1].BlockHeight
 	baseFee := stateChanges.PendingBlockBaseFee
 
@@ -425,7 +431,7 @@ func (p *TxPool) OnNewBlock(ctx context.Context, stateChanges *remoteproto.State
 
 	for i, txn := range unwindBlobTxns.Txns {
 		if txn.Type == BlobTxnType {
-			knownBlobTxn, err := p.getCachedBlobTxnLocked(coreTx, txn.IDHash[:])
+			knownBlobTxn, err := p.getCachedBlobTxnLocked(poolTx, txn.IDHash[:])
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Summary

`OnNewBlock` was passing the chaindata `coreTx` into `getCachedBlobTxnLocked`, but that function reads `kv.PoolTransaction` — a table that lives in the txpool DB, not chaindata. MDBX therefore can't find the table and the call fails on every blob-txn unwind path, producing warnings like:

```
[fetch] onNewBlock err="TxPool.getCachedBlobTxnLocked: Get: 32, label: chaindata, ...
```

Fix: open a RO tx on `poolDB` and pass that into `getCachedBlobTxnLocked`. The tx is opened before `p.lock` is acquired, which preserves the existing RoTx→p.lock ordering documented in `pool.go` to avoid deadlocks.