### PR TITLE
cherry-pick 14 commits from release/3.4 to main

### DIFF
--- a/.claude/skills/erigon-exec-from-0/SKILL.md
+++ b/.claude/skills/erigon-exec-from-0/SKILL.md
@@ -1,27 +1,70 @@
 ---
 name: erigon-exec-from-0
-description: Re exec all blocks from 0 to reproduce bugs
+description: >
+  Re-execute all Ethereum blocks from block 0 to reproduce bugs, validate state, or test
+  correctness after code changes. Use this skill whenever the user wants to re-run execution
+  from scratch, reset execution stage, reproduce a state mismatch, validate a fix by re-exec,
+  or run blocks from the beginning on a specific chain/datadir.
 ---
 
+# Re-execute all blocks from 0
+
+Use this workflow to wipe execution state and re-run all blocks from block 0.
+Common reasons: reproducing a state root mismatch, validating a bug fix, testing
+new execution logic end-to-end.
+
+## Prerequisites
+
+You need:
+- `--datadir` — path to the Erigon data directory (block snapshots must be present)
+- `--chain` — chain name (e.g. `chiado`, `mainnet`, `gnosis`, `sepolia`)
+
+## Step 1: Remove state snapshots (keep block snapshots)
+
+```bash
+go run ./cmd/erigon snapshots rm-all-state-snapshots --datadir <datadir>
 ```
-# remove all State files (not Block files)
-go run ./cmd/erigon snapshots rm-all-state-snapshots --datadir ~/data/chiado34_regen
 
-# clean database tables related to stage_exec
-go run ./cmd/integration stage_exec --datadir ~/data/chiado34_regen --chain=chiado --reset
+This removes `.kv` state snapshot files but leaves `.seg` block snapshot files intact,
+so you don't need to re-download block data.
 
-# exec blocks
-go run ./cmd/integration stage_exec --datadir ~/data/chiado34_regen --chain=chiado --batchSize=8m
+## Step 2: Reset the execution stage
 
-# flags for profiler
+```bash
+go run ./cmd/integration stage_exec --datadir <datadir> --chain=<chain> --reset
+```
+
+This clears the execution-stage progress in the database so the next run starts from block 0.
+
+## Step 3: Run execution
+
+```bash
+go run ./cmd/integration stage_exec --datadir <datadir> --chain=<chain> --batchSize=8m
+```
+
+Adjust `--batchSize` to control how frequently state is flushed to disk. Larger = faster
+but more RAM; `8m` is a reasonable default.
+
+## Useful optional flags
+
+**Profiling** (add when you want pprof):
+```
 --pprof --pprof.port=6160
-
-# flags for correctness
-`ERIGON_ASSERT=true`
 ```
 
-### tools for files correctness check
-
+**Correctness assertions** (add when hunting state bugs — slows execution):
 ```
-go run ./cmd/erigon seg integrity --datadir ~/data/chiado34_archive --sample=0.001 
+ERIGON_ASSERT=true
+```
+
+**Stop at a specific block** (useful to reproduce a bug at block N):
+```
+--block=<N>
+```
+
+## Verifying snapshot integrity
+
+If you suspect corrupted snapshot files before running:
+```bash
+go run ./cmd/erigon seg integrity --datadir <datadir> --sample=0.001
 ```

--- a/cl/antiquary/beacon_states_collector.go
+++ b/cl/antiquary/beacon_states_collector.go
@@ -356,75 +356,79 @@ func (i *beaconStatesCollector) collectInactivityScores(slot uint64, inactivityS
 }
 
 func (i *beaconStatesCollector) flush(ctx context.Context, tx kv.RwTx) error {
-	if err := i.effectiveBalanceCollector.Load(tx, kv.ValidatorEffectiveBalance, etl.IdentityLoadFunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
+	loadfunc := func(k, v []byte, table etl.CurrentTableReader, next etl.LoadNextFunc) error {
+		return next(k, k, v)
+	}
+
+	if err := i.effectiveBalanceCollector.Load(tx, kv.ValidatorEffectiveBalance, loadfunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
 		return err
 	}
-	if err := i.randaoMixesCollector.Load(tx, kv.RandaoMixes, etl.IdentityLoadFunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
+	if err := i.randaoMixesCollector.Load(tx, kv.RandaoMixes, loadfunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
 		return err
 	}
-	if err := i.balancesCollector.Load(tx, kv.ValidatorBalance, etl.IdentityLoadFunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
+	if err := i.balancesCollector.Load(tx, kv.ValidatorBalance, loadfunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
 		return err
 	}
 
-	if err := i.slashingsCollector.Load(tx, kv.ValidatorSlashings, etl.IdentityLoadFunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
+	if err := i.slashingsCollector.Load(tx, kv.ValidatorSlashings, loadfunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
 		return err
 	}
-	if err := i.blockRootsCollector.Load(tx, kv.BlockRoot, etl.IdentityLoadFunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
+	if err := i.blockRootsCollector.Load(tx, kv.BlockRoot, loadfunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
 		return err
 	}
-	if err := i.stateRootsCollector.Load(tx, kv.StateRoot, etl.IdentityLoadFunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
+	if err := i.stateRootsCollector.Load(tx, kv.StateRoot, loadfunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
 		return err
 	}
-	if err := i.activeValidatorIndiciesCollector.Load(tx, kv.ActiveValidatorIndicies, etl.IdentityLoadFunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
+	if err := i.activeValidatorIndiciesCollector.Load(tx, kv.ActiveValidatorIndicies, loadfunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
 		return err
 	}
-	if err := i.slotDataCollector.Load(tx, kv.SlotData, etl.IdentityLoadFunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
+	if err := i.slotDataCollector.Load(tx, kv.SlotData, loadfunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
 		return err
 	}
-	if err := i.inactivityScoresCollector.Load(tx, kv.InactivityScores, etl.IdentityLoadFunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
+	if err := i.inactivityScoresCollector.Load(tx, kv.InactivityScores, loadfunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
 		return err
 	}
-	if err := i.intraRandaoMixesCollector.Load(tx, kv.IntraRandaoMixes, etl.IdentityLoadFunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
+	if err := i.intraRandaoMixesCollector.Load(tx, kv.IntraRandaoMixes, loadfunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
 		return err
 	}
-	if err := i.epochDataCollector.Load(tx, kv.EpochData, etl.IdentityLoadFunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
+	if err := i.epochDataCollector.Load(tx, kv.EpochData, loadfunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
 		return err
 	}
-	if err := i.nextSyncCommitteeCollector.Load(tx, kv.NextSyncCommittee, etl.IdentityLoadFunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
+	if err := i.nextSyncCommitteeCollector.Load(tx, kv.NextSyncCommittee, loadfunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
 		return err
 	}
-	if err := i.currentSyncCommitteeCollector.Load(tx, kv.CurrentSyncCommittee, etl.IdentityLoadFunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
+	if err := i.currentSyncCommitteeCollector.Load(tx, kv.CurrentSyncCommittee, loadfunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
 		return err
 	}
-	if err := i.eth1DataVotesCollector.Load(tx, kv.Eth1DataVotes, etl.IdentityLoadFunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
+	if err := i.eth1DataVotesCollector.Load(tx, kv.Eth1DataVotes, loadfunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
 		return err
 	}
-	if err := i.stateEventsCollector.Load(tx, kv.StateEvents, etl.IdentityLoadFunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
+	if err := i.stateEventsCollector.Load(tx, kv.StateEvents, loadfunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
 		return err
 	}
-	if err := i.effectiveBalancesDumpCollector.Load(tx, kv.EffectiveBalancesDump, etl.IdentityLoadFunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
+	if err := i.effectiveBalancesDumpCollector.Load(tx, kv.EffectiveBalancesDump, loadfunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
 		return err
 	}
-	if err := i.pendingDepositsCollector.Load(tx, kv.PendingDeposits, etl.IdentityLoadFunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
+	if err := i.pendingDepositsCollector.Load(tx, kv.PendingDeposits, loadfunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
 		return err
 	}
-	if err := i.pendingConsolidationsCollector.Load(tx, kv.PendingConsolidations, etl.IdentityLoadFunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
+	if err := i.pendingConsolidationsCollector.Load(tx, kv.PendingConsolidations, loadfunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
 		return err
 	}
-	if err := i.pendingWithdrawalsCollector.Load(tx, kv.PendingPartialWithdrawals, etl.IdentityLoadFunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
+	if err := i.pendingWithdrawalsCollector.Load(tx, kv.PendingPartialWithdrawals, loadfunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
 		return err
 	}
-	if err := i.pendingDepositsCollectorDump.Load(tx, kv.PendingDepositsDump, etl.IdentityLoadFunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
+	if err := i.pendingDepositsCollectorDump.Load(tx, kv.PendingDepositsDump, loadfunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
 		return err
 	}
-	if err := i.pendingConsolidationsCollectorDump.Load(tx, kv.PendingConsolidationsDump, etl.IdentityLoadFunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
+	if err := i.pendingConsolidationsCollectorDump.Load(tx, kv.PendingConsolidationsDump, loadfunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
 		return err
 	}
-	if err := i.pendingWithdrawalsCollectorDump.Load(tx, kv.PendingPartialWithdrawalsDump, etl.IdentityLoadFunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
+	if err := i.pendingWithdrawalsCollectorDump.Load(tx, kv.PendingPartialWithdrawalsDump, loadfunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
 		return err
 	}
 
-	return i.balancesDumpsCollector.Load(tx, kv.BalancesDump, etl.IdentityLoadFunc, etl.TransformArgs{Quit: ctx.Done()})
+	return i.balancesDumpsCollector.Load(tx, kv.BalancesDump, loadfunc, etl.TransformArgs{Quit: ctx.Done()})
 }
 
 func (i *beaconStatesCollector) close() {

--- a/cl/antiquary/beacon_states_collector.go
+++ b/cl/antiquary/beacon_states_collector.go
@@ -356,9 +356,7 @@ func (i *beaconStatesCollector) collectInactivityScores(slot uint64, inactivityS
 }
 
 func (i *beaconStatesCollector) flush(ctx context.Context, tx kv.RwTx) error {
-	loadfunc := func(k, v []byte, table etl.CurrentTableReader, next etl.LoadNextFunc) error {
-		return next(k, k, v)
-	}
+	loadfunc := etl.IdentityLoadFunc
 
 	if err := i.effectiveBalanceCollector.Load(tx, kv.ValidatorEffectiveBalance, loadfunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
 		return err

--- a/cl/phase1/execution_client/block_collector/persistent_block_collector.go
+++ b/cl/phase1/execution_client/block_collector/persistent_block_collector.go
@@ -205,7 +205,7 @@ func (p *PersistentBlockCollector) Flush(ctx context.Context) error {
 	}
 	p.db = db
 
-	p.logger.Info("[BlockCollector] Flush complete", "blocksInserted", inserted)
+	//p.logger.Info("[BlockCollector] Flush complete", "blocksInserted", inserted)
 
 	return nil
 }

--- a/cl/phase1/execution_client/block_collector/persistent_block_collector.go
+++ b/cl/phase1/execution_client/block_collector/persistent_block_collector.go
@@ -205,8 +205,6 @@ func (p *PersistentBlockCollector) Flush(ctx context.Context) error {
 	}
 	p.db = db
 
-	//p.logger.Info("[BlockCollector] Flush complete", "blocksInserted", inserted)
-
 	return nil
 }
 

--- a/db/etl/collector.go
+++ b/db/etl/collector.go
@@ -173,7 +173,6 @@ func (c *Collector) Load(db kv.RwTx, toBucket string, loadFunc LoadFunc, args Tr
 	if c.buf == nil && c.allocator != nil {
 		c.buf = c.allocator.Get()
 	}
-	defer c.Close()
 	args.BufferType = c.bufType
 
 	if !c.allFlushed {

--- a/db/etl/dataprovider.go
+++ b/db/etl/dataprovider.go
@@ -219,15 +219,17 @@ func (p *fileDataProvider) Dispose() {
 
 	p.Wait()
 
+	if p.mmapData != nil {
+		_ = mmap.Munmap(p.mmapData, p.mmapHandle2)
+		p.mmapData = nil
+		p.mmapHandle2 = nil
+		p.mmapReader = nil
+	}
+
 	filePath := p.file.Name()
 	p.file.Close()
 	p.file = nil
 	_ = dir.RemoveFile(filePath)
-
-	// Note: We intentionally do NOT munmap here. The mmap'd memory remains mapped
-	// and valid for zero-copy slices returned to callers. The OS will unmap when
-	// the process exits or memory pressure requires it. This is safe for the ETL
-	// use case where data is consumed immediately before Close() is called.
 }
 
 func (p *fileDataProvider) String() string {

--- a/db/etl/dataprovider.go
+++ b/db/etl/dataprovider.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/c2h5oh/datasize"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/erigontech/erigon/common/dir"
@@ -100,7 +101,7 @@ func FlushToDisk(logPrefix string, b Buffer, tmpdir string, lvl log.Lvl) (dataPr
 	return provider, nil
 }
 
-var bufioWriterPool = sync.Pool{New: func() any { return bufio.NewWriterSize(nil, BufIOSize) }}
+var bufioWriterPool = sync.Pool{New: func() any { return bufio.NewWriterSize(nil, int(512*datasize.KB)) }}
 
 func getBufioWriter(w io.Writer) *bufio.Writer {
 	bw := bufioWriterPool.Get().(*bufio.Writer)

--- a/db/etl/dataprovider.go
+++ b/db/etl/dataprovider.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 
 	"golang.org/x/sync/errgroup"
@@ -99,6 +100,19 @@ func FlushToDisk(logPrefix string, b Buffer, tmpdir string, lvl log.Lvl) (dataPr
 	return provider, nil
 }
 
+var bufioWriterPool = sync.Pool{New: func() any { return bufio.NewWriterSize(nil, BufIOSize) }}
+
+func getBufioWriter(w io.Writer) *bufio.Writer {
+	bw := bufioWriterPool.Get().(*bufio.Writer)
+	bw.Reset(w)
+	return bw
+}
+
+// Reset(nil) before Put is required: without it the pool entry retains a
+// reference to the underlying io.Writer/io.Reader, keeping it alive until the
+// next GC cycle or until the entry is reused — whichever comes first.
+func putBufioWriter(w *bufio.Writer) { w.Reset(nil); bufioWriterPool.Put(w) }
+
 func sortAndFlush(b Buffer, tmpdir string) (*os.File, error) {
 	b.Sort()
 
@@ -115,11 +129,14 @@ func sortAndFlush(b Buffer, tmpdir string) (*os.File, error) {
 		return nil, err
 	}
 
-	w := bufio.NewWriterSize(bufferFile, BufIOSize)
-	defer w.Flush() //nolint:errcheck
+	w := getBufioWriter(bufferFile)
+	defer putBufioWriter(w)
 
 	if err = b.Write(w); err != nil {
 		return bufferFile, fmt.Errorf("error writing entries to disk: %w", err)
+	}
+	if err = w.Flush(); err != nil {
+		return bufferFile, fmt.Errorf("error flushing buffer to disk: %w", err)
 	}
 	return bufferFile, nil
 }

--- a/db/etl/etl_test.go
+++ b/db/etl/etl_test.go
@@ -485,6 +485,7 @@ func TestReuseCollectorAfterLoad(t *testing.T) {
 	}, TransformArgs{})
 	require.NoError(t, err)
 	require.Equal(t, 1, see)
+	c.Close()
 
 	// buffers are not lost
 	require.Empty(t, buf.data)
@@ -500,6 +501,7 @@ func TestReuseCollectorAfterLoad(t *testing.T) {
 	}, TransformArgs{})
 	require.NoError(t, err)
 	require.Equal(t, 0, see)
+	c.Close()
 
 	// reuse
 	see = 0
@@ -509,6 +511,7 @@ func TestReuseCollectorAfterLoad(t *testing.T) {
 	}, TransformArgs{})
 	require.NoError(t, err)
 	require.Equal(t, 0, see)
+	c.Close()
 
 	err = c.Collect([]byte{3}, []byte{4})
 	require.NoError(t, err)

--- a/db/kv/bitmapdb/bitmapdb.go
+++ b/db/kv/bitmapdb/bitmapdb.go
@@ -19,6 +19,7 @@ package bitmapdb
 import (
 	"sync"
 
+	"github.com/RoaringBitmap/roaring/v2"
 	"github.com/RoaringBitmap/roaring/v2/roaring64"
 )
 
@@ -38,4 +39,25 @@ func ReturnToPool64(a *roaring64.Bitmap) {
 		return
 	}
 	roaring64Pool.Put(a)
+}
+
+var roaring32Pool = sync.Pool{
+	New: func() any {
+		return roaring.New()
+	},
+}
+
+// NewBitmap32 returns a pooled 32-bit roaring bitmap.
+// Use when values fit in uint32 (e.g. txNum offsets within a collate step).
+func NewBitmap32() *roaring.Bitmap {
+	a := roaring32Pool.Get().(*roaring.Bitmap)
+	a.Clear()
+	return a
+}
+
+func ReturnToPool32(a *roaring.Bitmap) {
+	if a == nil {
+		return
+	}
+	roaring32Pool.Put(a)
 }

--- a/db/recsplit/recsplit.go
+++ b/db/recsplit/recsplit.go
@@ -260,7 +260,7 @@ func NewRecSplit(args RecSplitArgs, logger log.Logger) (*RecSplit, error) {
 	} else {
 		rs.salt = *args.Salt
 	}
-	rs.bucketCollector = etl.NewCollectorWithAllocator(RecSplitLogPrefix+" "+fname, rs.tmpDir, etl.SmallSortableBuffers, logger)
+	rs.bucketCollector = etl.NewCollectorWithAllocator(RecSplitLogPrefix+" "+fname, rs.tmpDir, etl.LargeSortableBuffers, logger)
 	rs.bucketCollector.SortAndFlushInBackground(rs.workers > 1)
 	rs.bucketCollector.LogLvl(log.LvlDebug)
 	var err error

--- a/db/seg/compress.go
+++ b/db/seg/compress.go
@@ -222,8 +222,8 @@ func (c *Compressor) Count() int { return int(c.wordsCount) }
 // parallel small unit-tests which each create many small files and bufio
 // readers/writers — pooling avoids the allocation pressure in that scenario.
 var (
-	bufioWriterPool = sync.Pool{New: func() any { return bufio.NewWriterSize(nil, int(128*datasize.KB)) }}
-	bufioReaderPool = sync.Pool{New: func() any { return bufio.NewReaderSize(nil, int(128*datasize.KB)) }}
+	bufioWriterPool = sync.Pool{New: func() any { return bufio.NewWriterSize(nil, int(256*datasize.KB)) }}
+	bufioReaderPool = sync.Pool{New: func() any { return bufio.NewReaderSize(nil, int(256*datasize.KB)) }}
 )
 
 func getBufioWriter(w io.Writer) *bufio.Writer {

--- a/db/seg/compress.go
+++ b/db/seg/compress.go
@@ -34,10 +34,8 @@ import (
 	"time"
 
 	"github.com/c2h5oh/datasize"
-	"golang.org/x/sync/semaphore"
 
 	"github.com/erigontech/erigon/common"
-	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/dir"
 	dir2 "github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/log/v3"
@@ -88,11 +86,6 @@ func (c Cfg) WithValuesOnCompressedPage(n int) Cfg {
 	c.ValuesOnCompressedPage = n
 	return c
 }
-
-// WorkersLimiter is a caps global active compression workers
-// across all compressor instances in the app. Each worker goroutine acquires 1 from
-// this semaphore before doing CPU-heavy work.
-var WorkersLimiter = semaphore.NewWeighted(int64(dbg.CompressWorkers))
 
 var DefaultCfg = Cfg{
 	MinPatternScore: 1024,
@@ -309,11 +302,6 @@ func (c *Compressor) AddUncompressedWord(word []byte) error {
 }
 
 func (c *Compressor) Compress() error {
-	if err := WorkersLimiter.Acquire(c.ctx, 1); err != nil {
-		return err
-	}
-	defer WorkersLimiter.Release(1)
-
 	if err := c.uncompressedFile.Flush(); err != nil {
 		return err
 	}

--- a/db/seg/parallel_compress.go
+++ b/db/seg/parallel_compress.go
@@ -1063,7 +1063,8 @@ func PersistDictionary(fileName string, db *DictionaryBuilder) error {
 	if err != nil {
 		return err
 	}
-	w := bufio.NewWriterSize(df, 2*etl.BufIOSize)
+	w := getBufioWriter(df)
+	defer putBufioWriter(w)
 	db.ForEach(func(score uint64, word []byte) { fmt.Fprintf(w, "%d %x\n", score, word) })
 	if err = w.Flush(); err != nil {
 		return err
@@ -1082,7 +1083,8 @@ func ReadSimpleFile(fileName string, walker func(v []byte) error) error {
 		return err
 	}
 	defer f.Close()
-	r := bufio.NewReaderSize(f, etl.BufIOSize)
+	r := getBufioReader(f)
+	defer putBufioReader(r)
 	buf := make([]byte, 4096)
 	for l, e := binary.ReadUvarint(r); ; l, e = binary.ReadUvarint(r) {
 		if e != nil {

--- a/db/snapshotsync/freezeblocks/caplin_snapshots.go
+++ b/db/snapshotsync/freezeblocks/caplin_snapshots.go
@@ -638,6 +638,17 @@ func (s *CaplinSnapshots) BuildMissingIndices(ctx context.Context, logger log.Lo
 	if err != nil {
 		return err
 	}
+
+	//TODO: to walk over dirtyFiles and to use `.IsIndexed()` method - like in Block-Snapshots
+	des, err := os.ReadDir(s.dir)
+	if err != nil {
+		return err
+	}
+	dirEntries := make([]string, len(des))
+	for i, de := range des {
+		dirEntries[i] = de.Name()
+	}
+
 	noneDone := true
 	for index := range segments {
 		segment := segments[index]
@@ -645,7 +656,7 @@ func (s *CaplinSnapshots) BuildMissingIndices(ctx context.Context, logger log.Lo
 		if segment.Type.Enum() != snaptype.CaplinEnums.BeaconBlocks && segment.Type.Enum() != snaptype.CaplinEnums.BlobSidecars {
 			continue
 		}
-		if segment.Type.HasIndexFiles(segment, logger) {
+		if segment.Type.HasIndexFiles(segment, dirEntries, logger) {
 			continue
 		}
 		p := &background.Progress{}

--- a/db/snaptype/type.go
+++ b/db/snaptype/type.go
@@ -157,7 +157,7 @@ var CaplinIndexes = struct {
 	BlobSidecarSlot: Index{Name: "blocksidecars", Version: version.V1_1_standart},
 }
 
-func (i Index) HasFile(info FileInfo, logger log.Logger) bool {
+func (i Index) HasFile(info FileInfo, dirEntries []string, logger log.Logger) bool {
 	dir := info.Dir()
 	// segment, err := seg.NewDecompressor(info.Path)
 
@@ -167,14 +167,13 @@ func (i Index) HasFile(info FileInfo, logger log.Logger) bool {
 
 	// defer segment.Close()
 
-	// Let's actually
-	if _, err := os.Stat(info.Path); err != nil {
-		logger.Debug("[ind] HasFile: seg file didn't found", "path", info.Path, "dir", dir, "err", err)
+	if !slices.Contains(dirEntries, filepath.Base(info.Path)) {
+		logger.Debug("[ind] HasFile: seg file didn't found", "path", info.Path, "dir", dir)
 		return false
 	}
 
 	fNameMask := IdxFileMask(info.From, info.To, i.Name)
-	fPath, fileVer, ok, err := version.FindFilesWithVersionsByPattern(filepath.Join(dir, fNameMask))
+	fPath, fileVer, ok, err := version.MatchVersionedFile(fNameMask, dirEntries, dir)
 	if err != nil {
 		logger.Debug("[ind] HasFile: files by pattern didn't found", "f", fNameMask, "dir", dir, "err", err)
 		return false
@@ -217,7 +216,7 @@ type Type interface {
 	IdxFileName(version Version, from uint64, to uint64, index ...Index) string
 	IdxFileNames(from uint64, to uint64) []string
 	Indexes() []Index
-	HasIndexFiles(info FileInfo, logger log.Logger) bool
+	HasIndexFiles(info FileInfo, dirEntries []string, logger log.Logger) bool
 	BuildIndexes(ctx context.Context, info FileInfo, indexBuilder IndexBuilder, chainConfig *chain.Config, tmpDir string, p *background.Progress, lvl log.Lvl, logger log.Logger) error
 	ExtractRange(ctx context.Context, info FileInfo, rangeExtractor RangeExtractor, indexBuilder IndexBuilder, firstKeyGetter FirstKeyGetter, db kv.RoDB, chainConfig *chain.Config, tmpDir string, workers int, lvl log.Lvl, logger log.Logger, hashResolver BlockHashResolver) (uint64, error)
 
@@ -332,9 +331,9 @@ func (s SnapType) BuildIndexes(ctx context.Context, info FileInfo, indexBuilder 
 	return indexBuilder.Build(ctx, info, salt, chainConfig, tmpDir, p, lvl, logger)
 }
 
-func (s SnapType) HasIndexFiles(info FileInfo, logger log.Logger) bool {
+func (s SnapType) HasIndexFiles(info FileInfo, dirEntries []string, logger log.Logger) bool {
 	for _, index := range s.indexes {
-		if !index.HasFile(info, logger) {
+		if !index.HasFile(info, dirEntries, logger) {
 			return false
 		}
 	}
@@ -439,8 +438,8 @@ func (e Enum) FileInfo(dir string, from uint64, to uint64) FileInfo {
 	return f
 }
 
-func (e Enum) HasIndexFiles(info FileInfo, logger log.Logger) bool {
-	return e.Type().HasIndexFiles(info, logger)
+func (e Enum) HasIndexFiles(info FileInfo, dirEntries []string, logger log.Logger) bool {
+	return e.Type().HasIndexFiles(info, dirEntries, logger)
 }
 
 func (e Enum) BuildIndexes(ctx context.Context, info FileInfo, indexBuilder IndexBuilder, chainConfig *chain.Config, tmpDir string, p *background.Progress, lvl log.Lvl, logger log.Logger) error {

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -625,10 +625,10 @@ func (d *Domain) dumpStepRangeOnDisk(ctx context.Context, stepFrom, stepTo kv.St
 	if err != nil {
 		return err
 	}
-	wal.Close()
 
 	ps := background.NewProgressSet()
 	static, err := d.buildFileRange(ctx, stepFrom, stepTo, coll, ps)
+	wal.Close() // munmap ETL temp files after buildFileRange consumed the zero-copy data
 	if err != nil {
 		return err
 	}

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1354,8 +1354,7 @@ func (dt *DomainRoTx) getLatestFromFiles(k []byte, maxTxNum uint64) (v []byte, f
 		maxTxNum = math.MaxUint64
 	}
 	useExistenceFilter := dt.d.Accessors.Has(statecfg.AccessorExistence)
-	//useCache := dt.name != kv.CommitmentDomain && maxTxNum == math.MaxUint64
-	useCache := maxTxNum == math.MaxUint64
+	useCache := dt.name != kv.CommitmentDomain && maxTxNum == math.MaxUint64
 
 	hi, lo := dt.ht.iit.hashKey(k)
 

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1354,7 +1354,8 @@ func (dt *DomainRoTx) getLatestFromFiles(k []byte, maxTxNum uint64) (v []byte, f
 		maxTxNum = math.MaxUint64
 	}
 	useExistenceFilter := dt.d.Accessors.Has(statecfg.AccessorExistence)
-	useCache := dt.name != kv.CommitmentDomain && maxTxNum == math.MaxUint64
+	//useCache := dt.name != kv.CommitmentDomain && maxTxNum == math.MaxUint64
+	useCache := maxTxNum == math.MaxUint64
 
 	hi, lo := dt.ht.iit.hashKey(k)
 

--- a/db/state/history.go
+++ b/db/state/history.go
@@ -37,7 +37,6 @@ import (
 	"github.com/erigontech/erigon/db/datastruct/existence"
 	"github.com/erigontech/erigon/db/etl"
 	"github.com/erigontech/erigon/db/kv"
-	"github.com/erigontech/erigon/db/kv/bitmapdb"
 	mdbx2 "github.com/erigontech/erigon/db/kv/mdbx"
 	"github.com/erigontech/erigon/db/kv/order"
 	"github.com/erigontech/erigon/db/kv/prune"
@@ -606,18 +605,21 @@ func (h *History) collate(ctx context.Context, step kv.Step, txFrom, txTo uint64
 		defer cd.Close()
 	}
 
+	baseTxNum := uint64(step) * h.stepSize
 	var (
-		keyBuf  = make([]byte, 0, 256)
-		numBuf  = make([]byte, 8)
-		bitmap  = bitmapdb.NewBitmap64()
-		prevEf  []byte
-		prevKey []byte
+		keyBuf = make([]byte, 0, 256)
+		numBuf = make([]byte, 8)
+		// offsets: stores (txNum-baseTxNum) values; ETL delivers txNums sorted per key
+		// so no dedup/sort needed. Safe: collate covers exactly one step so values < stepSize < math.MaxUint32.
+		// Worst case: one key touched every txNum in the step → stepSize entries (390_625 × 4B ≈ 1.56 MB).
+		offsets    = make([]uint32, 0, 64)
+		prevEf     []byte
+		prevKey    []byte
+		seqBuilder multiencseq.SequenceBuilder
 
 		initialized bool
 	)
-	defer bitmapdb.ReturnToPool64(bitmap)
 
-	baseTxNum := uint64(step) * h.stepSize
 	cnt := 0
 	var histKeyBuf []byte
 	//log.Warn("[dbg] collate", "name", h.filenameBase, "sampling", h.historyValuesOnCompressedPage)
@@ -630,17 +632,14 @@ func (h *History) collate(ctx context.Context, step kv.Step, txFrom, txTo uint64
 		}
 
 		if bytes.Equal(prevKey, k) {
-			bitmap.Add(txNum)
-			prevKey = append(prevKey[:0], k...)
+			offsets = append(offsets, uint32(txNum-baseTxNum))
 			return nil
 		}
+		seqBuilder.Reset(baseTxNum, uint64(len(offsets)), baseTxNum+uint64(offsets[len(offsets)-1]))
 
-		seqBuilder := multiencseq.NewBuilder(baseTxNum, bitmap.GetCardinality(), bitmap.Maximum())
-		it := bitmap.Iterator()
-
-		for it.HasNext() {
+		for _, off := range offsets {
 			cnt++
-			vTxNum := it.Next()
+			vTxNum := baseTxNum + uint64(off)
 			seqBuilder.AddOffset(vTxNum)
 
 			binary.BigEndian.PutUint64(numBuf, vTxNum)
@@ -675,7 +674,7 @@ func (h *History) collate(ctx context.Context, step kv.Step, txFrom, txTo uint64
 				return fmt.Errorf("add %s history val [%x]: %w", h.FilenameBase, key, err)
 			}
 		}
-		bitmap.Clear()
+		offsets = offsets[:0]
 		seqBuilder.Build()
 
 		prevEf = seqBuilder.AppendBytes(prevEf[:0])
@@ -689,7 +688,7 @@ func (h *History) collate(ctx context.Context, step kv.Step, txFrom, txTo uint64
 
 		prevKey = append(prevKey[:0], k...)
 		txNum = binary.BigEndian.Uint64(v)
-		bitmap.Add(txNum)
+		offsets = append(offsets[:0], uint32(txNum-baseTxNum))
 
 		return nil
 	}
@@ -698,7 +697,7 @@ func (h *History) collate(ctx context.Context, step kv.Step, txFrom, txTo uint64
 	if err != nil {
 		return HistoryCollation{}, err
 	}
-	if !bitmap.IsEmpty() {
+	if len(offsets) > 0 {
 		if err = loadBitmapsFunc(nil, make([]byte, 8), nil, nil); err != nil {
 			return HistoryCollation{}, err
 		}

--- a/db/state/history.go
+++ b/db/state/history.go
@@ -611,7 +611,7 @@ func (h *History) collate(ctx context.Context, step kv.Step, txFrom, txTo uint64
 		numBuf = make([]byte, 8)
 		// offsets: stores (txNum-baseTxNum) values; ETL delivers txNums sorted per key
 		// so no dedup/sort needed. Safe: collate covers exactly one step so values < stepSize < math.MaxUint32.
-		// Worst case: one key touched every txNum in the step → stepSize entries (390_625 × 4B ≈ 1.56 MB).
+		// Worst case: one key touched every txNum in the step → stepSize uint32 entries.
 		offsets    = make([]uint32, 0, 64)
 		prevEf     []byte
 		prevKey    []byte

--- a/db/state/history.go
+++ b/db/state/history.go
@@ -686,6 +686,10 @@ func (h *History) collate(ctx context.Context, step kv.Step, txFrom, txTo uint64
 			return fmt.Errorf("add %s ef history val: %w", h.FilenameBase, err)
 		}
 
+		if k == nil { // sentinel flush: no next group to start
+			return nil
+		}
+
 		prevKey = append(prevKey[:0], k...)
 		txNum = binary.BigEndian.Uint64(v)
 		offsets = append(offsets[:0], uint32(txNum-baseTxNum))

--- a/db/state/inverted_index.go
+++ b/db/state/inverted_index.go
@@ -1054,6 +1054,10 @@ func (ii *InvertedIndex) collate(ctx context.Context, step kv.Step, roTx kv.Tx) 
 			return fmt.Errorf("add %s efi index val: %w", ii.FilenameBase, err)
 		}
 
+		if k == nil { // sentinel flush: no next group to start
+			return nil
+		}
+
 		prevKey = append(prevKey[:0], k...)
 		txNum = binary.BigEndian.Uint64(v)
 		offsets = append(offsets[:0], uint32(txNum-baseTxNum))

--- a/db/state/inverted_index.go
+++ b/db/state/inverted_index.go
@@ -44,7 +44,6 @@ import (
 	"github.com/erigontech/erigon/db/datastruct/existence"
 	"github.com/erigontech/erigon/db/etl"
 	"github.com/erigontech/erigon/db/kv"
-	"github.com/erigontech/erigon/db/kv/bitmapdb"
 	"github.com/erigontech/erigon/db/kv/order"
 	"github.com/erigontech/erigon/db/kv/prune"
 	"github.com/erigontech/erigon/db/kv/stream"
@@ -1011,13 +1010,17 @@ func (ii *InvertedIndex) collate(ctx context.Context, step kv.Step, roTx kv.Tx) 
 	}
 	coll.writer = seg.NewWriter(comp, ii.Compression)
 
+	baseTxNum := uint64(step) * ii.stepSize
 	var (
 		prevEf      []byte
 		prevKey     []byte
 		initialized bool
-		bitmap      = bitmapdb.NewBitmap64()
+		// offsets: stores (txNum-baseTxNum) values; ETL delivers txNums sorted per key
+		// so no dedup/sort needed. Safe: collate covers exactly one step so values < stepSize < math.MaxUint32.
+		// Worst case: one key touched every txNum in the step → stepSize entries (390_625 × 4B ≈ 1.56 MB).
+		offsets = make([]uint32, 0, 64)
+		ef      multiencseq.SequenceBuilder
 	)
-	defer bitmapdb.ReturnToPool64(bitmap)
 
 	loadBitmapsFunc := func(k, v []byte, table etl.CurrentTableReader, next etl.LoadNextFunc) error {
 		txNum := binary.BigEndian.Uint64(v)
@@ -1027,22 +1030,19 @@ func (ii *InvertedIndex) collate(ctx context.Context, step kv.Step, roTx kv.Tx) 
 		}
 
 		if bytes.Equal(prevKey, k) {
-			bitmap.Add(txNum)
-			prevKey = append(prevKey[:0], k...)
+			offsets = append(offsets, uint32(txNum-baseTxNum))
 			return nil
 		}
-
-		baseTxNum := uint64(step) * ii.stepSize
-		if bitmap.Minimum() < txFrom || bitmap.Maximum() >= txTo {
+		absMin, absMax := baseTxNum+uint64(offsets[0]), baseTxNum+uint64(offsets[len(offsets)-1])
+		if absMin < txFrom || absMax >= txTo {
 			return fmt.Errorf("[inverted_index] collate %s: txNums out of range [%d, %d) for step %d: min=%d, max=%d, key=%x",
-				ii.FilenameBase, txFrom, txTo, step, bitmap.Minimum(), bitmap.Maximum(), prevKey)
+				ii.FilenameBase, txFrom, txTo, step, absMin, absMax, prevKey)
 		}
-		ef := multiencseq.NewBuilder(baseTxNum, bitmap.GetCardinality(), bitmap.Maximum())
-		it := bitmap.Iterator()
-		for it.HasNext() {
-			ef.AddOffset(it.Next())
+		ef.Reset(baseTxNum, uint64(len(offsets)), absMax)
+		for _, off := range offsets {
+			ef.AddOffset(baseTxNum + uint64(off))
 		}
-		bitmap.Clear()
+		offsets = offsets[:0]
 		ef.Build()
 
 		prevEf = ef.AppendBytes(prevEf[:0])
@@ -1056,7 +1056,7 @@ func (ii *InvertedIndex) collate(ctx context.Context, step kv.Step, roTx kv.Tx) 
 
 		prevKey = append(prevKey[:0], k...)
 		txNum = binary.BigEndian.Uint64(v)
-		bitmap.Add(txNum)
+		offsets = append(offsets[:0], uint32(txNum-baseTxNum))
 
 		return nil
 	}
@@ -1065,7 +1065,7 @@ func (ii *InvertedIndex) collate(ctx context.Context, step kv.Step, roTx kv.Tx) 
 	if err != nil {
 		return InvertedIndexCollation{}, err
 	}
-	if !bitmap.IsEmpty() {
+	if len(offsets) > 0 {
 		if err = loadBitmapsFunc(nil, make([]byte, 8), nil, nil); err != nil {
 			return InvertedIndexCollation{}, err
 		}

--- a/db/state/inverted_index.go
+++ b/db/state/inverted_index.go
@@ -1017,7 +1017,7 @@ func (ii *InvertedIndex) collate(ctx context.Context, step kv.Step, roTx kv.Tx) 
 		initialized bool
 		// offsets: stores (txNum-baseTxNum) values; ETL delivers txNums sorted per key
 		// so no dedup/sort needed. Safe: collate covers exactly one step so values < stepSize < math.MaxUint32.
-		// Worst case: one key touched every txNum in the step → stepSize entries (390_625 × 4B ≈ 1.56 MB).
+		// Worst case: one key touched every txNum in the step → stepSize uint32 entries.
 		offsets = make([]uint32, 0, 64)
 		ef      multiencseq.SequenceBuilder
 	)

--- a/db/state/merge.go
+++ b/db/state/merge.go
@@ -660,7 +660,7 @@ func (iit *InvertedIndexRoTx) mergeFiles(ctx context.Context, files []*FilesItem
 	var keyBuf, valBuf []byte
 	var lastKey, lastVal []byte
 	var seqReader multiencseq.SequenceReader
-	builder := &multiencseq.SequenceBuilder{}
+	var builder multiencseq.SequenceBuilder
 	// sameKeyItems collects all heap items sharing the current key; reused across iterations.
 	var sameKeyItems []*CursorItem
 	// mergeBaseNums and mergeSeqs hold the per-item inputs for MergeSorted in ascending txNum order.

--- a/db/state/temporal_mem_batch.go
+++ b/db/state/temporal_mem_batch.go
@@ -162,7 +162,8 @@ func (sd *TemporalMemBatch) putLatest(domain kv.Domain, key string, val []byte, 
 				putValueSize += len(val)
 			} else {
 				putValueSize += len(val) - len(old[len(old)-1].data)
-				sd.storage.Set(key, []dataWithTxNum{valWithStep})
+				old[0] = valWithStep
+				sd.storage.Set(key, old[:1])
 			}
 		} else {
 			sd.storage.Set(key, []dataWithTxNum{valWithStep})
@@ -180,7 +181,8 @@ func (sd *TemporalMemBatch) putLatest(domain kv.Domain, key string, val []byte, 
 			putValueSize += len(val)
 		} else {
 			putValueSize += len(val) - len(old[len(old)-1].data)
-			sd.domains[domain][key] = []dataWithTxNum{valWithStep}
+			old[0] = valWithStep
+			sd.domains[domain][key] = old[:1]
 		}
 	} else {
 		sd.domains[domain][key] = []dataWithTxNum{valWithStep}

--- a/execution/state/journal.go
+++ b/execution/state/journal.go
@@ -436,9 +436,6 @@ func (ch codeChange) revert(s *IntraBlockState) error {
 			if _, ok := s.versionedWrites[ch.account][AccountKey{Path: CodeSizePath}]; ok {
 				s.versionedWrites.UpdateVal(ch.account, AccountKey{Path: CodeSizePath}, len(ch.prevcode))
 			}
-			if v, ok := s.versionedWrites[ch.account][AccountKey{Path: CodeSizePath}]; ok {
-				v.Val = len(ch.prevcode)
-			}
 		}
 	}
 	return nil

--- a/execution/state/journal.go
+++ b/execution/state/journal.go
@@ -436,6 +436,9 @@ func (ch codeChange) revert(s *IntraBlockState) error {
 			if _, ok := s.versionedWrites[ch.account][AccountKey{Path: CodeSizePath}]; ok {
 				s.versionedWrites.UpdateVal(ch.account, AccountKey{Path: CodeSizePath}, len(ch.prevcode))
 			}
+			if v, ok := s.versionedWrites[ch.account][AccountKey{Path: CodeSizePath}]; ok {
+				v.Val = len(ch.prevcode)
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Cherry-pick from `release/3.4` to `main`:

- #19677 agg: workers presets. ressplit workers
- #19919 Revert "flush: use etl.IdentityLoadFunc instead custom. part2"
- #19780 etl: zero-copy memDataProvider
- #19941 d_lru: disable for commitment
- #19942 TemporalMemBatch: re-use vals-slice when can
- #19996 etl: pool of bufwriter
- #19995 collate: replace bitmap by array
- #20002 skill creator review results
- #20033 seg: revert global limiter
- #20046 Caplin: prevent calling `glob` per file in `BuildMissingIndices`
- #20113 seg: more usage of bufio
- #20194 execution/state: revert CodeSizePath in codeChange journal entry
- #20431 remove `flush complete` log line
- #20440 etl: munmap temp files in Dispose to prevent disk space leak

93 commits skipped due to conflicts (branches diverged significantly).