### PR TITLE
p2p/discover: queue copied datagrams in v4 UDP test pipe

### DIFF
--- a/p2p/discover/v4_udp_test.go
+++ b/p2p/discover/v4_udp_test.go
@@ -684,7 +684,7 @@ func (c *dgramPipe) WriteToUDPAddrPort(b []byte, to netip.AddrPort) (n int, err 
 	if c.closed {
 		return 0, errors.New("closed")
 	}
-	c.queue = append(c.queue, dgram{to, b})
+	c.queue = append(c.queue, dgram{to, msg})
 	c.cond.Signal()
 	return len(b), nil
 }


### PR DESCRIPTION
## Summary
- update `dgramPipe.WriteToUDPAddrPort` to enqueue `msg` (copied bytes) instead of the caller-owned slice `b`
- remove potential aliasing between queued packets and reused write buffers in discv4 UDP tests
- keep behavior unchanged except for stronger test isolation against buffer reuse races

## Test plan
- [x] `gofmt -w p2p/discover/v4_udp_test.go`
- [x] `GOPROXY=https://goproxy.cn,direct GOCACHE=/tmp/go-build GOTMPDIR=/tmp/go-tmp go test ./p2p/discover -run TestDoesNotExist -count=1`