### PR TITLE
execution: fix BAL recording when coinbase == transaction target

### DIFF
--- a/execution/stagedsync/exec3_finalize_test.go
+++ b/execution/stagedsync/exec3_finalize_test.go
@@ -183,8 +183,8 @@ func (s *testFinalizeScenario) runFinalizeTx(t *testing.T) (state.ReadSet, state
 	result.TxOut = txOut
 	txOut, burntDelta, burntDeltaIncrease, hasBurntDelta := result.TxOut.StripBalanceWrite(result.ExecutionResult.BurntContractAddress, result.TxIn)
 	result.TxOut = txOut
-	delete(result.TxIn, result.Coinbase)
-	delete(result.TxIn, result.ExecutionResult.BurntContractAddress)
+	result.TxIn.Delete(result.Coinbase, state.AccountKey{Path: state.BalancePath})
+	result.TxIn.Delete(result.ExecutionResult.BurntContractAddress, state.AccountKey{Path: state.BalancePath})
 
 	task := result.Task.(*taskVersion)
 	txTask := task.Task.(*exec.TxTask)

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1088,10 +1088,14 @@ func (result *execResult) finalize(prevReceipt *types.Receipt, engine rules.Engi
 	txOut, burntDelta, burntDeltaIncrease, hasBurntDelta := result.TxOut.StripBalanceWrite(result.ExecutionResult.BurntContractAddress, result.TxIn)
 	result.TxOut = txOut
 
-	// Force a re-read of the coinbase & burnt contract address
+	// Force a re-read of the coinbase & burnt contract balance
 	// so the VersionedStateReader provides the correct base values.
-	delete(result.TxIn, result.Coinbase)
-	delete(result.TxIn, result.ExecutionResult.BurntContractAddress)
+	// Only remove the BalancePath read — not the entire address —
+	// because result.TxIn is shared with blockIO and deleting the
+	// full address also drops storage/code/nonce reads needed for
+	// the BAL (e.g. when coinbase == transaction target).
+	result.TxIn.Delete(result.Coinbase, state.AccountKey{Path: state.BalancePath})
+	result.TxIn.Delete(result.ExecutionResult.BurntContractAddress, state.AccountKey{Path: state.BalancePath})
 
 	txTask, ok := task.Task.(*exec.TxTask)
 

--- a/execution/tests/eest_devnet/block_test.go
+++ b/execution/tests/eest_devnet/block_test.go
@@ -50,8 +50,6 @@ func TestExecutionSpecBlockchainDevnet(t *testing.T) {
 	bt.Whitelist(`.*for_amsterdam/.*`)
 	// static — tested in state test format by TestState
 	bt.SkipLoad(`^for_amsterdam/static/state_tests/`)
-	// TODO(yperbasis, mh0lt) BAL recording bug: coinbase==target causes TxIn reads to be dropped
-	bt.SkipLoad(`stBugs/random_statetest_default_minus_tue_07_58_41_minus_15153_minus_575192`)
 
 	bt.Walk(t, dir, func(t *testing.T, name string, test *testutil.BlockTest) {
 		// import pre accounts & construct test genesis block & state root


### PR DESCRIPTION
## Summary
- Fix BAL (Block Access List) recording bug where `coinbase == transaction target` caused storage/code/nonce reads to be dropped from the BAL
- `finalizeTx` used `delete(result.TxIn, result.Coinbase)` which removed the entire address from the shared read-set map, destroying execution reads needed by `AsBlockAccessList`
- Replace with `result.TxIn.Delete(addr, AccountKey{Path: BalancePath})` to surgically remove only the stale balance read, preserving all other reads

## Test plan
- [x] Unskipped `stBugs/random_statetest_default_minus_tue_07_58_41_minus_15153_minus_575192` in `TestExecutionSpecBlockchainDevnet`
- [x] Both amsterdam variants pass (base + london)
- [x] `make lint` clean
- [x] `make erigon integration` builds
- [ ] Full `TestExecutionSpecBlockchainDevnet` suite on Linux CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)