### PR TITLE
integrity: fix SnapBlocksRead --to upper bound

### DIFF
--- a/db/integrity/snap_blocks_read.go
+++ b/db/integrity/snap_blocks_read.go
@@ -35,7 +35,7 @@ func SnapBlocksRead(ctx context.Context, db kv.TemporalRoDB, blockReader service
 	maxBlockNum := blockReader.Snapshots().SegmentsMax()
 
 	if to != 0 && maxBlockNum > to {
-		maxBlockNum = 2
+		maxBlockNum = to
 	}
 
 	for i := from; i < maxBlockNum; i += 10_000 {


### PR DESCRIPTION
- Fix `SnapBlocksRead` to cap the iteration upper bound with `to` instead of the hardcoded `2`
- Keep the existing function signature and all other integrity flows unchanged
- Restore the intended bounded `[from, to)` behavior for future or direct bounded checks