### PR TITLE
[wip] [r3.4]: db/state: add prune consistency assertion (AGG_ASSERT_PRUNE)

### DIFF
--- a/db/kv/prune/prune.go
+++ b/db/kv/prune/prune.go
@@ -375,7 +375,10 @@ func tableScanningPrune(
 			}
 			stat.PruneCountValues += dups
 		} else {
-			// Selective per-dup deletion: reposition to first dup for iteration
+			// Selective per-dup deletion: delete all in-range dups for this key
+			// atomically (no ctx/throttle checks between dups). This prevents
+			// the DB from transiently holding stale data if the prune were
+			// interrupted between deleting a newer and older dup.
 			_, err = valDelCursor.FirstDup()
 			if err != nil {
 				return nil, fmt.Errorf("FirstDup iterate over %s index keys: %w", filenameBase, err)
@@ -391,19 +394,19 @@ func tableScanningPrune(
 				if txNumDup >= txTo {
 					break
 				}
-				if throttling != nil {
-					time.Sleep(*throttling)
-				}
-				if ctx.Err() != nil {
-					return common.Copy(val), nil
-				}
-
 				stat.MinTxNum = min(stat.MinTxNum, txNumDup)
 				stat.MaxTxNum = max(stat.MaxTxNum, txNumDup)
 				if err = valDelCursor.DeleteCurrent(); err != nil {
 					return nil, err
 				}
 				stat.PruneCountValues++
+			}
+			// Check throttle/ctx only AFTER all in-range dups for this key are deleted
+			if throttling != nil {
+				time.Sleep(*throttling)
+			}
+			if ctx.Err() != nil {
+				return common.Copy(val), nil
 			}
 		}
 

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -34,6 +34,7 @@ import (
 	rand2 "golang.org/x/exp/rand"
 
 	"github.com/erigontech/erigon/db/kv/prune"
+	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
 
 	"github.com/tidwall/btree"
 	"golang.org/x/sync/errgroup"
@@ -1814,6 +1815,40 @@ func (a *Aggregator) buildFilesInBackground(txNum uint64, doMerge bool) chan str
 		// - to remove old data from db as early as possible
 		// - during files build, may happen commit of new data. on each loop step getting latest id in db
 		for ; step < lastInDB; step++ { //`step` must be fully-written - means `step+1` records must be visible
+			// Guard against collation/pruning race: only collate step S when the
+			// execution layer has committed ALL data through the end of step S.
+			// Read the latest committed txNum from the commitment domain state
+			// (written by SharedDomains.ComputeCommitment after each flush+commit).
+			// Without this check, the collation's read-transaction may snapshot
+			// the DB before a CommitCycle flushes step S's writes, producing a
+			// file that misses entries. Pruning then removes those entries from
+			// the DB, and the values are lost. See #20169.
+			var committedTxNum uint64
+			if temporalDB, ok := a.db.(kv.TemporalRoDB); ok {
+				if err := temporalDB.ViewTemporal(a.ctx, func(tx kv.TemporalTx) error {
+					v, _, err := tx.GetLatest(kv.CommitmentDomain, commitmentdb.KeyCommitmentState)
+					if err != nil {
+						return err
+					}
+					if len(v) >= 8 {
+						committedTxNum = binary.BigEndian.Uint64(v)
+					}
+					return nil
+				}); err != nil {
+					a.logger.Warn("[snapshots] buildFilesInBackground: read commitment", "err", err)
+					break
+				}
+			}
+			// When committedTxNum > 0, enforce the guard: only collate step S
+			// when all its data has been committed. When committedTxNum == 0
+			// (no ComputeCommitment yet, e.g. in tests), fall through to the
+			// existing lastInDB check which is sufficient without concurrency.
+			if committedTxNum > 0 {
+				stepEndTxNum := a.FirstTxNumOfStep(step + 1)
+				if committedTxNum+1 < stepEndTxNum {
+					break // step not fully committed yet — wait for execution to catch up
+				}
+			}
 			if err := a.buildFiles(a.ctx, step); err != nil {
 				if errors.Is(err, errStepNotReady) {
 					break

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -56,10 +56,11 @@ import (
 )
 
 var (
-	asserts          = dbg.EnvBool("AGG_ASSERTS", false)
-	traceFileLife    = dbg.EnvString("AGG_TRACE_FILE_LIFE", "")
-	traceGetAsOf     = dbg.EnvString("AGG_TRACE_GET_AS_OF", "")
-	tracePutWithPrev = dbg.EnvString("AGG_TRACE_PUT_WITH_PREV", "")
+	asserts                       = dbg.EnvBool("AGG_ASSERTS", false)
+	assertPruneConsistencyEnabled = dbg.EnvBool("AGG_ASSERT_PRUNE", false)
+	traceFileLife                 = dbg.EnvString("AGG_TRACE_FILE_LIFE", "")
+	traceGetAsOf                  = dbg.EnvString("AGG_TRACE_GET_AS_OF", "")
+	tracePutWithPrev              = dbg.EnvString("AGG_TRACE_PUT_WITH_PREV", "")
 )
 var traceGetLatest, _ = kv.String2Domain(dbg.EnvString("AGG_TRACE_GET_LATEST", ""))
 
@@ -1638,9 +1639,6 @@ func (dt *DomainRoTx) getLatestFromDb(key []byte, roTx kv.Tx) ([]byte, kv.Step, 
 	// Deletion entries (empty value) are authoritative regardless of step age:
 	// frozen files have no tombstones, so discarding a deletion marker causes
 	// fallthrough to getLatestFromFiles which returns stale pre-deletion data.
-	// Note: for LargeValues=true, an old-step tombstone may be stale from an
-	// interrupted prune (see cross-check in getLatest). We still return it as
-	// found here; getLatest handles the file cross-check when needed.
 	if len(v) == 0 {
 		return v, foundStep, true, nil
 	}
@@ -1720,6 +1718,21 @@ func (dt *DomainRoTx) getLatest(key []byte, roTx kv.Tx, maxStep kv.Step, metrics
 				}
 			}
 		}
+		// Assert: when DB has a value and files also cover this step,
+		// the file should have the same value (or a newer-step value from merge).
+		// A mismatch where file has an older value indicates lost write.
+		if assertPruneConsistencyEnabled && dt.files.Len() > 0 &&
+			lastTxNumOfStep(foundStep, dt.stepSize) < dt.files.EndTxNum() {
+			fileV, foundInFile, _, fileEndTxNum, fileErr := dt.getLatestFromFiles(key, 0)
+			fileStep := kv.Step(fileEndTxNum / dt.stepSize)
+			if fileErr == nil && foundInFile && fileStep == foundStep && !bytes.Equal(v, fileV) {
+				dt.d.logger.Warn("getLatest: DB/file value mismatch",
+					"domain", dt.name, "key", fmt.Sprintf("%x", key),
+					"dbStep", foundStep, "fileStep", fileStep,
+					"filesEndStep", dt.files.EndTxNum()/dt.stepSize)
+			}
+		}
+
 		if metrics != nil && dbg.KVReadLevelledMetrics {
 			metrics.UpdateDbReads(dt.name, start)
 		}
@@ -1984,6 +1997,16 @@ func (dt *DomainRoTx) prune(ctx context.Context, rwTx kv.RwTx, step kv.Step, txF
 
 	prg.KeyProgress = prune.Done // domains don't have key tables
 
+	// Verify file/DB consistency before pruning. If the DB's highest-step
+	// entry for a key differs from the file value, the collation captured
+	// stale data. Pruning would lose the correct DB value.
+	// Enabled via AGG_ASSERT_PRUNE=true env var.
+	if assertPruneConsistencyEnabled && dt.files.Len() > 0 {
+		if err := dt.assertPruneConsistency(rwTx, txFrom, txTo); err != nil {
+			return stat, err
+		}
+	}
+
 	pruneStat, err := prune.TableScanningPrune(ctx, "domain "+dt.name.String(), dt.d.FilenameBase, txFrom, txTo, limit, dt.stepSize,
 		logEvery, dt.d.logger, nil, valsCursor, asserts, prg, mode)
 	if err != nil {
@@ -2013,6 +2036,120 @@ func (dt *DomainRoTx) prune(ctx context.Context, rwTx kv.RwTx, step kv.Step, txF
 
 func (dt *DomainRoTx) stepsRangeInDB(tx kv.Tx) (from, to float64) {
 	return dt.ht.iit.stepsRangeInDB(tx)
+}
+
+// assertPruneConsistency checks that the file's latest value for each key matches
+// the DB's latest (highest-step) value. Only the highest-step DB entry per key is
+// checked, since older entries are expected to differ from the merged file value.
+// A mismatch at the highest step means the collation captured stale data.
+func (dt *DomainRoTx) assertPruneConsistency(roTx kv.Tx, txFrom, txTo uint64) (retErr error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			dt.d.logger.Warn("assertPruneConsistency recovered from panic", "domain", dt.name, "panic", rec)
+			retErr = nil
+		}
+	}()
+
+	stepFrom := kv.Step(txFrom / dt.stepSize)
+	stepTo := kv.Step(txTo / dt.stepSize)
+
+	if dt.d.LargeValues {
+		// For LargeValues, each row is a separate key with step suffix.
+		// The highest step for a key is the first row found by Seek.
+		cursor, err := roTx.Cursor(dt.d.ValuesTable)
+		if err != nil {
+			return nil
+		}
+		defer cursor.Close()
+
+		var prevKey []byte
+		checked := 0
+		for k, v, err := cursor.First(); k != nil; k, v, err = cursor.Next() {
+			if err != nil {
+				return nil
+			}
+			if len(k) < 8 {
+				continue
+			}
+			dbKey := k[:len(k)-8]
+			dbStep := kv.Step(^binary.BigEndian.Uint64(k[len(k)-8:]))
+
+			// Skip older entries for the same key (only check highest step)
+			if bytes.Equal(dbKey, prevKey) {
+				continue
+			}
+			prevKey = append(prevKey[:0], dbKey...)
+
+			if dbStep < stepFrom || dbStep >= stepTo {
+				continue
+			}
+
+			fileVal, foundInFile, _, fileEndTxNum, ferr := dt.getLatestFromFiles(dbKey, 0)
+			if ferr != nil {
+				continue
+			}
+			fileStep := kv.Step(fileEndTxNum / dt.stepSize)
+			if !foundInFile && len(v) > 0 {
+				return fmt.Errorf("prune assertion failed: domain=%s key=%x dbStep=%d stepRange=[%d,%d) txRange=[%d,%d) filesEndStep=%d — file has no entry",
+					dt.name, dbKey, dbStep, stepFrom, stepTo, txFrom, txTo, dt.files.EndTxNum()/dt.stepSize)
+			}
+			// Only flag mismatch when file step == DB step — same step, different data = stale collation.
+			// When fileStep != dbStep, the values naturally differ across steps.
+			if foundInFile && fileStep == dbStep && !bytes.Equal(fileVal, v) {
+				return fmt.Errorf("prune assertion failed: domain=%s key=%x dbStep=%d fileStep=%d stepRange=[%d,%d) txRange=[%d,%d) — file/DB value mismatch (stale collation)",
+					dt.name, dbKey, dbStep, fileStep, stepFrom, stepTo, txFrom, txTo)
+			}
+			checked++
+		}
+		if checked > 0 {
+			dt.d.logger.Debug("prune consistency check passed", "domain", dt.name, "checked", checked)
+		}
+		return nil
+	}
+
+	// For DupSort: iterate keys via NextNoDup.
+	cursor, err := roTx.CursorDupSort(dt.d.ValuesTable)
+	if err != nil {
+		return nil
+	}
+	defer cursor.Close()
+
+	checked := 0
+	for k, v, err := cursor.First(); k != nil; k, v, err = cursor.NextNoDup() {
+		if err != nil {
+			return nil
+		}
+		if len(v) < 8 {
+			continue
+		}
+		dbStep := kv.Step(^binary.BigEndian.Uint64(v[:8]))
+		dbVal := v[8:]
+
+		if dbStep < stepFrom || dbStep >= stepTo {
+			continue
+		}
+
+		fileVal, foundInFile, _, fileEndTxNum, ferr := dt.getLatestFromFiles(k, 0)
+		if ferr != nil {
+			continue
+		}
+		fileStep := kv.Step(fileEndTxNum / dt.stepSize)
+		if !foundInFile && len(dbVal) > 0 {
+			return fmt.Errorf("prune assertion failed: domain=%s key=%x dbStep=%d stepRange=[%d,%d) txRange=[%d,%d) filesEndStep=%d — file has no entry",
+				dt.name, k, dbStep, stepFrom, stepTo, txFrom, txTo, dt.files.EndTxNum()/dt.stepSize)
+		}
+		// Only flag mismatch when file step == DB step — same step, different data = stale collation.
+		// When fileStep != dbStep, the values naturally differ across steps.
+		if foundInFile && fileStep == dbStep && !bytes.Equal(fileVal, dbVal) {
+			return fmt.Errorf("prune assertion failed: domain=%s key=%x dbStep=%d fileStep=%d stepRange=[%d,%d) txRange=[%d,%d) — file/DB value mismatch (stale collation)",
+				dt.name, k, dbStep, fileStep, stepFrom, stepTo, txFrom, txTo)
+		}
+		checked++
+	}
+	if checked > 0 {
+		dt.d.logger.Debug("prune consistency check passed", "domain", dt.name, "checked", checked)
+	}
+	return nil
 }
 
 func (dt *DomainRoTx) Tables() (res []string) {


### PR DESCRIPTION
## Summary
- Add `AGG_ASSERT_PRUNE=true` env var to enable file/DB consistency checks before pruning
- `assertPruneConsistency`: full-table scan verifying that the DB's highest-step value for each key matches the file value — catches stale collations before prune deletes the correct DB entry
- Inline assert in `getLatest`: warns when a DB value disagrees with the corresponding file value (indicates lost write)
- Both LargeValues and DupSort table layouts are handled