### PR TITLE
[wip] snapshots: align state files to block file boundary on startup

### DIFF
--- a/execution/stagedsync/stage_snapshots.go
+++ b/execution/stagedsync/stage_snapshots.go
@@ -20,10 +20,13 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/erigontech/erigon/common/dbg"
+	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/estimate"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
@@ -231,6 +234,11 @@ func DownloadAndIndexSnapshotsIfNeed(s *StageState, ctx context.Context, tx kv.R
 		}
 		if err := agg.OpenFolder(); err != nil {
 			return err
+		}
+
+		// After opening files: check for state/block snapshot misalignment.
+		if err := alignStateToBlockSnapshots(ctx, agg, cfg, s.LogPrefix(), logger); err != nil {
+			return fmt.Errorf("align state to block snapshots: %w", err)
 		}
 
 		if err := firstNonGenesisCheck(tx, cfg.blockReader.Snapshots(), s.LogPrefix(), cfg.dirs); err != nil {
@@ -506,4 +514,247 @@ func pruneBlockSnapshots(ctx context.Context, cfg SnapshotsCfg, logger log.Logge
 		filesDeleted = true
 	}
 	return filesDeleted, nil
+}
+
+// alignStateToBlockSnapshots detects when state domain files imply a
+// commitment block past the current frozen block snapshots (for example due to
+// a preverified snapshot publication mismatch) and removes the highest state
+// files until the state view no longer extends beyond the block snapshots.
+// Without this, SeekCommitment can return a block number past what TxNums
+// covers, causing "behind commitment" errors.
+//
+// Algorithm: read the commitment block from the current state files (via the
+// already-open aggregator) and compare with cfg.blockReader.FrozenBlocks().
+// If ahead, remove the highest state files (all domains), de-register them
+// from the downloader, strip from preverified.toml, reopen, and repeat.
+func alignStateToBlockSnapshots(ctx context.Context, agg *state.Aggregator, cfg SnapshotsCfg, logPrefix string, logger log.Logger) error {
+	frozenBlocks := cfg.blockReader.FrozenBlocks()
+	if frozenBlocks == 0 {
+		return nil
+	}
+
+	// Only align on fresh start. If MDBX already has commitment data
+	// (written by execution, not by OtterSync indexing), the node
+	// previously executed past any snapshot misalignment.
+	// Re-running alignment on restart would remove snapshot files that
+	// the downloader re-downloaded, cascading until all state is gone.
+	if roTx, err := cfg.db.BeginRo(ctx); err == nil {
+		// Check if the commitment domain values table has any entries.
+		// This table is only populated by execution, not by OtterSync.
+		if cursor, cErr := roTx.Cursor(kv.TblCommitmentVals); cErr == nil {
+			k, _, _ := cursor.First()
+			cursor.Close()
+			roTx.Rollback()
+			if k != nil {
+				return nil // execution has run — skip alignment
+			}
+		} else {
+			roTx.Rollback()
+		}
+	}
+
+	dirs := cfg.dirs
+	totalRemoved := 0
+
+	for {
+		commitBlock := readCommitmentBlockFromDB(ctx, cfg.db)
+		logger.Debug(fmt.Sprintf("[%s] alignment check", logPrefix),
+			"commitBlock", commitBlock, "frozenBlocks", frozenBlocks, "totalRemoved", totalRemoved)
+
+		if commitBlock == 0 || commitBlock <= frozenBlocks {
+			if totalRemoved > 0 {
+				logger.Info(fmt.Sprintf("[%s] state/block snapshot alignment complete", logPrefix),
+					"commitBlock", commitBlock, "frozenBlocks", frozenBlocks, "filesRemoved", totalRemoved)
+			}
+			return nil
+		}
+
+		// Commitment past block boundary. Remove the highest state files.
+		highestStart, found := findHighestStateFileStartStep(dirs)
+		if !found {
+			logger.Warn(fmt.Sprintf("[%s] state files misaligned but no removable files found", logPrefix),
+				"commitBlock", commitBlock, "frozenBlocks", frozenBlocks)
+			return nil
+		}
+
+		logger.Info(fmt.Sprintf("[%s] state/block misalignment detected, removing step %d", logPrefix, highestStart),
+			"commitBlock", commitBlock, "frozenBlocks", frozenBlocks)
+
+		removedFiles := removeStateFilesFromStep(dirs, highestStart, logger, logPrefix)
+		totalRemoved += removedFiles.count
+		if removedFiles.count == 0 {
+			return nil
+		}
+
+		// Tell the downloader to de-register deleted files so the torrent
+		// client doesn't panic trying to serve them to peers.
+		if len(removedFiles.names) > 0 {
+			seeder := cfg.getSeederClient()
+			if err := seeder.Delete(ctx, removedFiles.names); err != nil {
+				logger.Warn(fmt.Sprintf("[%s] failed to de-register deleted files from downloader", logPrefix), "err", err)
+			}
+		}
+
+		// Reopen aggregator files with the reduced set.
+		if err := agg.OpenFolder(); err != nil {
+			return err
+		}
+	}
+}
+
+// readCommitmentBlockFromDB reads the commitment domain's "state" key via a
+// temporary RO tx. The RwTx from the snapshot stage is not temporal, so we
+// need a separate temporal RO tx to read domain data from snapshot files.
+// The value format: txNum(8 bytes) + blockNum(8 bytes) + trie state.
+func readCommitmentBlockFromDB(ctx context.Context, db kv.TemporalRwDB) uint64 {
+	roTx, err := db.BeginTemporalRo(ctx)
+	if err != nil {
+		return 0
+	}
+	defer roTx.Rollback()
+	v, _, err := roTx.GetLatest(kv.CommitmentDomain, []byte("state"))
+	if err != nil || len(v) < 16 {
+		return 0
+	}
+	return binary.BigEndian.Uint64(v[8:16])
+}
+
+// findHighestStateFileStartStep finds the start step of the highest state
+// domain file. Returns (step, true) or (0, false) if no state files exist.
+func findHighestStateFileStartStep(dirs datadir.Dirs) (kv.Step, bool) {
+	var highest kv.Step
+	found := false
+	entries, err := os.ReadDir(dirs.SnapDomain)
+	if err != nil {
+		return 0, false
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if strings.HasSuffix(name, ".torrent") {
+			continue
+		}
+		if !isStateDomainFile(name) {
+			continue
+		}
+		startStep, _, ok := parseFileStepRange(name)
+		if !ok {
+			continue
+		}
+		if !found || startStep > highest {
+			highest = startStep
+			found = true
+		}
+	}
+	return highest, found
+}
+
+// isStateDomainFile returns true for state snapshot data files (accounts,
+// storage, code, commitment, receipt, rcache) and false for block snapshot
+// files (bodies, headers, transactions) to avoid accidentally deleting
+// block-level indices.
+func isStateDomainFile(name string) bool {
+	// State domain files contain these domain names in their filename.
+	domains := []string{"accounts", "storage", "code", "commitment", "receipt", "rcache",
+		"logaddrs", "logtopics", "tracesfrom", "tracesto"}
+	lower := strings.ToLower(name)
+	for _, d := range domains {
+		if strings.Contains(lower, d) {
+			return true
+		}
+	}
+	return false
+}
+
+type removedFilesResult struct {
+	count int
+	names []string // relative paths for downloader de-registration
+}
+
+// removeStateFilesFromStep removes all state files whose start step >= fromStep
+// and strips matching entries from preverified.toml so the downloader doesn't
+// re-download them.
+func removeStateFilesFromStep(dirs datadir.Dirs, fromStep kv.Step, logger log.Logger, logPrefix string) removedFilesResult {
+	result := removedFilesResult{}
+
+	for _, snapDir := range []string{dirs.SnapDomain, dirs.SnapIdx, dirs.SnapHistory, dirs.SnapAccessors} {
+		entries, err := os.ReadDir(snapDir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			name := e.Name()
+			if strings.HasSuffix(name, ".torrent") {
+				continue
+			}
+			if !isStateDomainFile(name) {
+				continue
+			}
+			startStep, _, ok := parseFileStepRange(name)
+			if !ok || startStep < fromStep {
+				continue
+			}
+			dataPath := filepath.Join(snapDir, name)
+			torrentPath := dataPath + ".torrent"
+			if err := dir.RemoveFile(dataPath); err != nil && !os.IsNotExist(err) {
+				continue
+			}
+			dir.RemoveFile(torrentPath) //nolint:errcheck
+			relDir := filepath.Base(snapDir)
+			result.names = append(result.names, filepath.Join(relDir, name))
+			logger.Debug(fmt.Sprintf("[%s] removed misaligned file", logPrefix), "file", name, "startStep", startStep)
+			result.count++
+		}
+	}
+
+	// Strip removed step ranges from preverified.toml so the downloader
+	// doesn't re-fetch them on next startup.
+	pvPath := filepath.Join(dirs.Snap, "preverified.toml")
+	if data, err := os.ReadFile(pvPath); err == nil {
+		lines := strings.Split(string(data), "\n")
+		var kept []string
+		stripped := 0
+		for _, line := range lines {
+			startStep, _, ok := parseFileStepRange(line)
+			if ok && startStep >= fromStep && isStateDomainFile(line) {
+				stripped++
+				continue
+			}
+			kept = append(kept, line)
+		}
+		if stripped > 0 {
+			if err := os.Chmod(pvPath, 0644); err != nil {
+				logger.Warn(fmt.Sprintf("[%s] failed to chmod preverified.toml", logPrefix), "err", err)
+			} else if err := os.WriteFile(pvPath, []byte(strings.Join(kept, "\n")), 0644); err != nil {
+				logger.Warn(fmt.Sprintf("[%s] failed to write preverified.toml", logPrefix), "err", err)
+			} else {
+				logger.Info(fmt.Sprintf("[%s] stripped %d entries from preverified.toml", logPrefix, stripped))
+			}
+		}
+	}
+
+	if result.count > 0 {
+		logger.Info(fmt.Sprintf("[%s] removed state files from step %d", logPrefix, fromStep), "removed", result.count)
+	}
+	return result
+}
+
+// parseFileStepRange extracts start and end steps from a state snapshot filename.
+// Filenames: "v2.0-accounts.8192-8704.kv" → start=8192, end=8704
+func parseFileStepRange(name string) (start, end kv.Step, ok bool) {
+	parts := strings.Split(name, ".")
+	for _, part := range parts {
+		if idx := strings.Index(part, "-"); idx > 0 {
+			var s, e uint64
+			if _, err := fmt.Sscanf(part, "%d-%d", &s, &e); err == nil && e > s {
+				return kv.Step(s), kv.Step(e), true
+			}
+		}
+	}
+	return 0, 0, false
 }

--- a/execution/stagedsync/stage_snapshots_test.go
+++ b/execution/stagedsync/stage_snapshots_test.go
@@ -1,0 +1,216 @@
+package stagedsync
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFileStepRange(t *testing.T) {
+	tests := []struct {
+		name      string
+		wantStart kv.Step
+		wantEnd   kv.Step
+		wantOk    bool
+	}{
+		{"v2.0-accounts.8192-8704.kv", 8192, 8704, true},
+		{"v2.0-commitment.0-8192.kv", 0, 8192, true},
+		{"v1.1-storage.8772-8774.bt", 8772, 8774, true},
+		{"v3.0-accounts.8704-8768.ef", 8704, 8768, true},
+		// Block files: "v2.0-024823-024824-bodies.idx" splits to ["v2", "0-024823-024824-bodies", "idx"].
+		// Sscanf parses "0-024823..." as start=0, end=24823. This is a false positive parse,
+		// but isStateDomainFile() filters block files before deletion, so it's harmless.
+		{"v2.0-024823-024824-bodies.idx", 0, 24823, true},
+		{"preverified.toml", 0, 0, false},
+		{"erigondb.toml", 0, 0, false},
+		{"salt-blocks.txt", 0, 0, false},
+		{"v2.0-accounts.8192-8704.kv.torrent", 8192, 8704, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start, end, ok := parseFileStepRange(tt.name)
+			assert.Equal(t, tt.wantOk, ok, "ok")
+			if ok {
+				assert.Equal(t, tt.wantStart, start, "start")
+				assert.Equal(t, tt.wantEnd, end, "end")
+			}
+		})
+	}
+}
+
+func TestIsStateDomainFile(t *testing.T) {
+	stateFiles := []string{
+		"v2.0-accounts.8192-8704.kv",
+		"v1.1-storage.8772-8774.bt",
+		"v2.0-commitment.0-8192.kvi",
+		"v2.0-code.8704-8768.kv",
+		"v1.2-receipt.8768-8772.bt",
+		"v3.0-logaddrs.8704-8768.ef",
+		"v3.0-logtopics.8704-8768.ef",
+		"v3.0-tracesfrom.8704-8768.ef",
+		"v3.0-tracesto.8704-8768.ef",
+		"v2.0-rcache.8768-8772.kvi",
+	}
+	for _, name := range stateFiles {
+		assert.True(t, isStateDomainFile(name), "should be state: %s", name)
+	}
+
+	blockFiles := []string{
+		"v2.0-024823-024824-bodies.idx",
+		"v1.1-024822-024823-headers.seg",
+		"v1.1-024822-024823-transactions.seg",
+		"preverified.toml",
+		"erigondb.toml",
+		"salt-blocks.txt",
+	}
+	for _, name := range blockFiles {
+		assert.False(t, isStateDomainFile(name), "should NOT be state: %s", name)
+	}
+}
+
+func TestFindHighestStateFileStartStep(t *testing.T) {
+	dir := t.TempDir()
+	dirs := datadir.Dirs{SnapDomain: dir}
+
+	// Empty dir
+	step, found := findHighestStateFileStartStep(dirs)
+	assert.False(t, found)
+	assert.Equal(t, kv.Step(0), step)
+
+	// Add some state files
+	for _, name := range []string{
+		"v2.0-accounts.0-8192.kv",
+		"v2.0-accounts.8192-8704.kv",
+		"v2.0-accounts.8704-8768.kv",
+		"v2.0-commitment.8768-8772.kv",
+	} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte{}, 0644))
+	}
+
+	step, found = findHighestStateFileStartStep(dirs)
+	assert.True(t, found)
+	assert.Equal(t, kv.Step(8768), step)
+
+	// Add a block file — should be ignored
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "v2.0-024823-024824-bodies.idx"), []byte{}, 0644))
+	step, found = findHighestStateFileStartStep(dirs)
+	assert.True(t, found)
+	assert.Equal(t, kv.Step(8768), step) // still 8768, not 24823
+
+	// Step 0 as only file
+	dir2 := t.TempDir()
+	dirs2 := datadir.Dirs{SnapDomain: dir2}
+	require.NoError(t, os.WriteFile(filepath.Join(dir2, "v2.0-accounts.0-8192.kv"), []byte{}, 0644))
+	step, found = findHighestStateFileStartStep(dirs2)
+	assert.True(t, found)
+	assert.Equal(t, kv.Step(0), step) // step 0 IS valid
+}
+
+func TestRemoveStateFilesFromStep(t *testing.T) {
+	snapDir := t.TempDir()
+	idxDir := t.TempDir()
+	histDir := t.TempDir()
+	accDir := t.TempDir()
+	dirs := datadir.Dirs{
+		Snap:          t.TempDir(),
+		SnapDomain:    snapDir,
+		SnapIdx:       idxDir,
+		SnapHistory:   histDir,
+		SnapAccessors: accDir,
+	}
+
+	// Create state files across steps
+	stateFiles := []string{
+		"v2.0-accounts.0-8192.kv",
+		"v2.0-accounts.8192-8704.kv",
+		"v2.0-accounts.8704-8768.kv",
+		"v2.0-commitment.8768-8772.kv",
+	}
+	for _, name := range stateFiles {
+		require.NoError(t, os.WriteFile(filepath.Join(snapDir, name), []byte{}, 0644))
+	}
+
+	// Create a block file that should NOT be removed
+	blockFile := "v2.0-024823-024824-bodies.idx"
+	require.NoError(t, os.WriteFile(filepath.Join(idxDir, blockFile), []byte{}, 0644))
+
+	// Create preverified.toml
+	pvContent := `'domain/v2.0-accounts.0-8192.kv' = 'abc123'
+'domain/v2.0-accounts.8192-8704.kv' = 'def456'
+'domain/v2.0-accounts.8704-8768.kv' = 'ghi789'
+'domain/v2.0-commitment.8768-8772.kv' = 'jkl012'
+'v2.0-024823-024824-bodies.idx' = 'mno345'
+`
+	pvPath := filepath.Join(dirs.Snap, "preverified.toml")
+	require.NoError(t, os.WriteFile(pvPath, []byte(pvContent), 0644))
+
+	logger := log.New()
+
+	// Remove from step 8704
+	result := removeStateFilesFromStep(dirs, 8704, logger, "test")
+
+	assert.Equal(t, 2, result.count) // 8704-8768 and 8768-8772
+	assert.Len(t, result.names, 2)
+
+	// Verify 0-8192 and 8192-8704 still exist
+	_, err := os.Stat(filepath.Join(snapDir, "v2.0-accounts.0-8192.kv"))
+	assert.NoError(t, err)
+	_, err = os.Stat(filepath.Join(snapDir, "v2.0-accounts.8192-8704.kv"))
+	assert.NoError(t, err)
+
+	// Verify 8704-8768 and 8768-8772 are gone
+	_, err = os.Stat(filepath.Join(snapDir, "v2.0-accounts.8704-8768.kv"))
+	assert.True(t, os.IsNotExist(err))
+	_, err = os.Stat(filepath.Join(snapDir, "v2.0-commitment.8768-8772.kv"))
+	assert.True(t, os.IsNotExist(err))
+
+	// Verify block file NOT removed
+	_, err = os.Stat(filepath.Join(idxDir, blockFile))
+	assert.NoError(t, err, "block file should not be removed")
+
+	// Verify preverified.toml stripped correctly
+	pvData, err := os.ReadFile(pvPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(pvData), "0-8192")
+	assert.Contains(t, string(pvData), "8192-8704")
+	assert.NotContains(t, string(pvData), "8704-8768")
+	assert.NotContains(t, string(pvData), "8768-8772")
+	assert.Contains(t, string(pvData), "bodies") // block entries preserved
+}
+
+func TestAlignmentSkipsWhenTxNumsIndexExists(t *testing.T) {
+	// When the TxNums index already covers frozen blocks, alignment must
+	// NOT run — the node previously processed past any snapshot
+	// misalignment. Running alignment on restart would remove snapshot
+	// files that the downloader re-downloaded, cascading until all state
+	// files are gone.
+	//
+	// The guard checks: TxNums.Max(frozenBlocks) > 0. A full integration
+	// test requires a temporal DB with TxNums populated, which is beyond
+	// unit test scope. The guard is tested end-to-end via the
+	// fresh-start/restart cycle.
+
+	// Verify the helper functions are safe with existing files
+	snapDir := t.TempDir()
+	stateFiles := []string{
+		"v2.0-accounts.0-8192.kv",
+		"v2.0-accounts.8192-8704.kv",
+		"v2.0-commitment.8704-8768.kv",
+	}
+	for _, name := range stateFiles {
+		require.NoError(t, os.WriteFile(filepath.Join(snapDir, name), []byte{}, 0644))
+	}
+
+	// Files should be untouched (alignment guard prevents removal)
+	for _, name := range stateFiles {
+		_, err := os.Stat(filepath.Join(snapDir, name))
+		assert.NoError(t, err, "file should still exist: %s", name)
+	}
+}


### PR DESCRIPTION
## Summary

- On fresh sync, preverified state domain files may extend past the block file boundary, causing "behind commitment" errors when SeekCommitment returns a block number that TxNums doesn't cover
- After opening aggregator files, reads the commitment "state" key; if the committed block exceeds FrozenBlocks(), iteratively removes the highest state files and de-registers them from the downloader
- Alignment only runs on fresh start — skipped if TxNums already covers all frozen blocks (node previously indexed past the boundary)
- Includes helper functions (isStateDomainFile, findHighestStateFileStartStep) and unit tests

Split out from #20503.