### PR TITLE
cl/beacon_indicies: fix BeaconBlocks prune cursor

### DIFF
--- a/cl/persistence/beacon_indicies/indicies.go
+++ b/cl/persistence/beacon_indicies/indicies.go
@@ -381,7 +381,7 @@ func PruneBlocks(ctx context.Context, tx kv.RwTx, to uint64) error {
 		return err
 	}
 	defer cursor.Close()
-	for k, _, err := cursor.First(); err == nil && k != nil; k, _, err = cursor.Prev() {
+	for k, _, err := cursor.First(); err == nil && k != nil; k, _, err = cursor.Next() {
 		if len(k) != 40 {
 			continue
 		}

--- a/cl/persistence/beacon_indicies/indicies_test.go
+++ b/cl/persistence/beacon_indicies/indicies_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/dbcfg"
+	"github.com/erigontech/erigon/db/kv/dbutils"
 	"github.com/erigontech/erigon/db/kv/memdb"
 )
 
@@ -195,4 +196,43 @@ func TestWriteExecutionBlockHash(t *testing.T) {
 	tHash3, err := ReadExecutionBlockHash(tx, tHash)
 	require.NoError(t, err)
 	require.Equal(t, tHash2, tHash3)
+}
+
+func TestPruneBlocksRemovesAllBlocksBeforeSlot(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	tx, err := db.BeginRw(context.Background())
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	type storedBlock struct {
+		slot uint64
+		root common.Hash
+	}
+
+	var blocks []storedBlock
+	for _, slot := range []uint64{1, 2, 3, 4} {
+		block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.Phase0Version)
+		block.Block.Slot = slot
+		block.EncodingSizeSSZ()
+
+		root, err := block.Block.HashSSZ()
+		require.NoError(t, err)
+		require.NoError(t, WriteBeaconBlockAndIndicies(context.Background(), tx, block, false))
+
+		blocks = append(blocks, storedBlock{slot: slot, root: root})
+	}
+
+	require.NoError(t, PruneBlocks(context.Background(), tx, 3))
+
+	for _, block := range blocks {
+		body, err := tx.GetOne(kv.BeaconBlocks, dbutils.BlockBodyKey(block.slot, block.root))
+		require.NoError(t, err)
+		if block.slot < 3 {
+			require.Empty(t, body)
+			continue
+		}
+		require.NotEmpty(t, body)
+	}
 }


### PR DESCRIPTION
- Fix `PruneBlocks` to iterate the `BeaconBlocks` cursor with `Next()` after `First()` instead of walking backward with `Prev()`
- Keep the prune logic and slot cutoff unchanged, but restore the intended forward scan so all entries with `slot < to` can be deleted
- Add `TestPruneBlocksRemovesAllBlocksBeforeSlot` to cover the prune range and verify older entries are removed while newer ones remain