### PR TITLE
[r3.4] rpc: fix eth_simulateV1 HasStorage RAM batch (#20293)

### DIFF
--- a/db/kv/kv_interface.go
+++ b/db/kv/kv_interface.go
@@ -492,6 +492,7 @@ type TemporalMemBatch interface {
 	IndexAdd(table InvertedIdx, key []byte, txNum uint64) (err error)
 	IteratePrefix(domain Domain, prefix []byte, roTx Tx, it func(k []byte, v []byte) (cont bool, err error)) error
 	HasPrefix(domain Domain, prefix []byte, roTx Tx) ([]byte, []byte, bool, error)
+	HasPrefixInRAM(domain Domain, prefix []byte) bool
 	SizeEstimate() uint64
 	Flush(ctx context.Context, tx RwTx) error
 	Close()

--- a/db/state/temporal_mem_batch.go
+++ b/db/state/temporal_mem_batch.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"maps"
 	"sort"
+	"strings"
 	"sync"
 	"unsafe"
 
@@ -314,6 +315,41 @@ func (sd *TemporalMemBatch) HasPrefix(domain kv.Domain, prefix []byte, roTx kv.T
 		return true, nil
 	})
 	return firstKey, firstVal, hasPrefix, err
+}
+
+// HasPrefixInRAM reports whether the RAM batch contains any non-deleted entry
+// for the given domain whose key starts with prefix.  It never touches disk or
+// segment files — only the in-memory btree (StorageDomain) or the domain map.
+func (sd *TemporalMemBatch) HasPrefixInRAM(domain kv.Domain, prefix []byte) bool {
+	sd.latestStateLock.RLock()
+	defer sd.latestStateLock.RUnlock()
+
+	if domain == kv.StorageDomain {
+		prefixStr := unsafe.String(unsafe.SliceData(prefix), len(prefix))
+		iter := sd.storage.Iter()
+		for ok := iter.Seek(prefixStr); ok; ok = iter.Next() {
+			if !strings.HasPrefix(iter.Key(), prefixStr) {
+				break
+			}
+			vals := iter.Value()
+			if len(vals) > 0 && len(vals[len(vals)-1].data) > 0 {
+				return true
+			}
+		}
+		return false
+	}
+
+	prefixStr := unsafe.String(unsafe.SliceData(prefix), len(prefix))
+	for k, vals := range sd.domains[domain] {
+		if strings.HasPrefix(k, prefixStr) && len(vals) > 0 && len(vals[len(vals)-1].data) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func (sd *TemporalMemBatch) GetChangesetAccumulator() *changeset.StateChangeSet {
+	return sd.currentChangesAccumulator
 }
 
 func (sd *TemporalMemBatch) SetChangesetAccumulator(acc *changeset.StateChangeSet) {

--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -24,6 +24,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"sort"
 	"strings"
@@ -1970,6 +1971,36 @@ func (sdb *IntraBlockState) CommitBlock(chainRules *chain.Rules, stateWriter Sta
 		}
 	}
 	return sdb.MakeWriteSet(chainRules, stateWriter)
+}
+
+// ExtractAndClearDirty snapshots the current stateObjectsDirty set and clears it.
+// Used by eth_simulateV1 to separate accounts dirtied by stateOverrides from those
+// dirtied by actual transaction execution, so CommitBlock does not apply EIP-161 to
+// override-only accounts.
+func (sdb *IntraBlockState) ExtractAndClearDirty() map[accounts.Address]struct{} {
+	dirty := maps.Clone(sdb.stateObjectsDirty)
+	clear(sdb.stateObjectsDirty)
+	return dirty
+}
+
+// CommitOverrideDirtyAccounts writes state-override accounts that were not subsequently
+// touched by any transaction (and therefore not handled by CommitBlock).  EIP-161 is
+// intentionally disabled: override accounts are simulation-only mutations and must not
+// be removed simply because they are "empty" by consensus rules.
+func (sdb *IntraBlockState) CommitOverrideDirtyAccounts(chainRules *chain.Rules, stateWriter StateWriter, overrideDirty map[accounts.Address]struct{}) error {
+	for addr := range overrideDirty {
+		if _, alsoTxDirty := sdb.stateObjectsDirty[addr]; alsoTxDirty {
+			continue // CommitBlock already handled this address
+		}
+		so, exists := sdb.stateObjects[addr]
+		if !exists || so.deleted {
+			continue
+		}
+		if err := updateAccount(false, chainRules.IsAura, stateWriter, addr, so, true, sdb.trace, sdb.tracingHooks, true); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (sdb *IntraBlockState) BalanceIncreaseSet() map[accounts.Address]uint256.Int {

--- a/rpc/ethapi/state_overrides.go
+++ b/rpc/ethapi/state_overrides.go
@@ -116,5 +116,18 @@ func (so *StateOverrides) Override(ibs *state.IntraBlockState, precompiles vm.Pr
 		}
 	}
 
-	return ibs.FinalizeTx(rules, state.NewNoopWriter())
+	// Disable EIP-161 empty-account removal when finalizing state overrides.
+	// FinalizeTx with a NoopWriter commits dirty storage into originStorage
+	// (needed for correct SSTORE gas), but EIP-161 would also mark any account
+	// that becomes empty (nonce=0, code=0x, balance=0) as deleted in the IBS —
+	// even though the deletion is never written to the DB.  That spurious
+	// deleted=true flag causes IntraBlockState.HasStorage to short-circuit to
+	// false before reaching the state reader, breaking EIP-7610 collision
+	// detection in multi-block eth_simulateV1 when a prior simulated block
+	// deployed a contract at the overridden address.
+	// State overrides are simulation-only mutations and must not trigger
+	// consensus rules like EIP-161.
+	noEIP161Rules := *rules
+	noEIP161Rules.IsSpuriousDragon = false
+	return ibs.FinalizeTx(&noEIP161Rules, state.NewNoopWriter())
 }

--- a/rpc/jsonrpc/eth_simulation.go
+++ b/rpc/jsonrpc/eth_simulation.go
@@ -515,10 +515,14 @@ func (s *simulator) simulateBlock(
 
 	// Override the state before block execution.
 	stateOverrides := bsc.StateOverrides
+	var overrideDirtyAccounts map[accounts.Address]struct{}
 	if stateOverrides != nil {
 		if err := stateOverrides.Override(intraBlockState, activePrecompiles, rules); err != nil {
 			return nil, nil, err
 		}
+		// Snapshot and clear dirty set so CommitBlock won't apply EIP-161 to
+		// override-only accounts (they were not "touched" by any transaction).
+		overrideDirtyAccounts = intraBlockState.ExtractAndClearDirty()
 	}
 
 	vmConfig := vm.Config{NoBaseFee: !s.validation}
@@ -582,6 +586,12 @@ func (s *simulator) simulateBlock(
 
 	if err := intraBlockState.CommitBlock(rules, stateWriter); err != nil {
 		return nil, nil, fmt.Errorf("call to CommitBlock to stateWriter: %w", err)
+	}
+	// Write override-only accounts that CommitBlock skipped (EIP-161 disabled for these).
+	if len(overrideDirtyAccounts) > 0 {
+		if err := intraBlockState.CommitOverrideDirtyAccounts(rules, stateWriter, overrideDirtyAccounts); err != nil {
+			return nil, nil, fmt.Errorf("committing override accounts: %w", err)
+		}
 	}
 
 	if err := s.computeSimulatedStateRoot(ctx, tx, sharedDomains, bsc, block, parent, minTxNum, firstMinTxNum, stateWriter.touchedKeys, ancestors, latest); err != nil {
@@ -1031,13 +1041,14 @@ func (r *simulationIntraBlockStateReader) ReadAccountStorage(address accounts.Ad
 }
 
 func (r *simulationIntraBlockStateReader) HasStorage(address accounts.Address) (bool, error) {
-	// The mem batch doesn't support prefix scans, so we check the canonical base-parent state.
-	// TODO: this gives a wrong answer when a prior simulated block deployed a brand-new contract
-	// (i.e. added storage to a previously storage-less account): the mem batch contains that
-	// storage but we never scan it, so HasStorage returns false for the new contract in
-	// subsequent simulation blocks. Fix: iterate r.sd.GetMemBatch() storage keys for the
-	// address as a prefix-scan fallback before (or instead of) the RangeAsOf call.
 	addressValue := address.Value()
+
+	// Check the RAM batch first: storage written by prior simulated blocks lives only in the
+	// in-memory btree and is not yet visible via RangeAsOf(firstMinTxNum).
+	if r.sd.GetMemBatch().HasPrefixInRAM(kv.StorageDomain, addressValue[:]) {
+		return true, nil
+	}
+
 	to, ok := kv.NextSubtree(addressValue[:])
 	if !ok {
 		to = nil

--- a/rpc/jsonrpc/eth_simulation_intrablock_test.go
+++ b/rpc/jsonrpc/eth_simulation_intrablock_test.go
@@ -1,0 +1,99 @@
+package jsonrpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/dbcfg"
+	"github.com/erigontech/erigon/db/kv/mdbx"
+	"github.com/erigontech/erigon/db/kv/temporal"
+	"github.com/erigontech/erigon/db/state"
+	"github.com/erigontech/erigon/db/state/execctx"
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+// TestSimulationIntraBlockHasStorageRAMBatch demonstrates the HasStorage bug in
+// simulationIntraBlockStateReader: storage written to the RAM batch by a prior
+// simulated block is not visible to HasStorage in subsequent blocks because
+// HasStorage only queries RangeAsOf(firstMinTxNum) and never inspects the
+// in-memory batch.
+//
+// With the bug:  HasStorage returns false for a brand-new contract even though
+//
+//	its storage slot lives in sd.GetMemBatch().
+//
+// With the fix:  HasStorage checks the RAM batch first (via HasPrefixInRAM or
+//
+//	IteratePrefix) and returns true.
+func TestSimulationIntraBlockHasStorageRAMBatch(t *testing.T) {
+	ctx := context.Background()
+	logger := log.New()
+
+	// Build an in-memory temporal DB (no files on disk).
+	dirs := datadir.New(t.TempDir())
+	db := mdbx.New(dbcfg.ChainDB, logger).
+		InMem(t, dirs.Chaindata).
+		GrowthStep(32 * datasize.MB).
+		MapSize(2 * datasize.GB).
+		MustOpen()
+	t.Cleanup(db.Close)
+
+	agg := state.NewTest(dirs).Logger(logger).MustOpen(t.Context(), db)
+	t.Cleanup(agg.Close)
+	require.NoError(t, agg.OpenFolder())
+
+	tdb, err := temporal.New(db, agg, nil)
+	require.NoError(t, err)
+	t.Cleanup(tdb.Close)
+
+	rwTx, err := tdb.BeginTemporalRw(ctx)
+	require.NoError(t, err)
+	defer rwTx.Rollback()
+
+	sd, err := execctx.NewSharedDomains(ctx, rwTx, logger)
+	require.NoError(t, err)
+	defer sd.Close()
+
+	// Contract address whose storage we'll write during "block 1" simulation.
+	contractAddr := accounts.InternAddress(common.Address{0xcc, 0x01})
+	addrVal := contractAddr.Value() // [20]byte
+
+	// Storage slot 0: key = address (20 bytes) || slot (32 bytes).
+	slotKey := accounts.InternKey(common.Hash{}) // slot 0x00...00
+	slotVal := slotKey.Value()                   // [32]byte
+
+	storageKey := append(addrVal[:], slotVal[:]...)
+
+	// firstMinTxNum = 0: this is the canonical base state (before any simulated blocks).
+	// The contract does NOT exist in the canonical chain (empty DB), so RangeAsOf(0)
+	// will find no storage for it.
+	const firstMinTxNum = uint64(0)
+
+	// Simulate block 1: write storage[0] = 42 for the contract at txNum=1.
+	// After this, the value lives only in sd.GetMemBatch() (the RAM batch).
+	require.NoError(t, sd.DomainPut(kv.StorageDomain, rwTx, storageKey, []byte{42}, 1, nil))
+
+	// Verify the value is indeed in the RAM batch (sanity check).
+	got, _, ok := sd.GetMemBatch().GetLatest(kv.StorageDomain, storageKey)
+	require.True(t, ok, "storage must be in the RAM batch after DomainPut")
+	require.Equal(t, []byte{42}, got)
+
+	// Create the reader used for block 2 (reads RAM batch + canonical base at firstMinTxNum).
+	reader := newSimulationIntraBlockStateReader(rwTx, sd, firstMinTxNum)
+
+	// HasStorage must return true: the contract has storage in the RAM batch from block 1.
+	// BUG: returns false — only RangeAsOf(firstMinTxNum=0) is checked, which finds nothing
+	//      because the contract had no storage in the canonical chain at txNum 0.
+	// FIX: returns true — RAM batch is checked first and slot 0 = 42 is found.
+	hasStorage, err := reader.HasStorage(contractAddr)
+	require.NoError(t, err)
+	require.True(t, hasStorage,
+		"HasStorage must see storage written to the RAM batch by a prior simulated block")
+}


### PR DESCRIPTION
Cherry-pick of #20293 from main.

Fixes EIP-7610 collision detection in multi-block eth_simulateV1: storage written by prior simulated blocks lives in the RAM batch and was invisible to HasStorage.