### PR TITLE
[r3.4] rpc: fix null result unmarshalling in CallContext (#20393)

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -331,7 +331,10 @@ func (c *Client) CallContext(ctx context.Context, result any, method string, arg
 	case len(resp.Result) == 0:
 		return ErrNoResult
 	default:
-		return json.Unmarshal(resp.Result, &result)
+		if result == nil {
+			return nil
+		}
+		return json.Unmarshal(resp.Result, result)
 	}
 }
 

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -55,6 +55,22 @@ func TestClientRequest(t *testing.T) {
 	}
 }
 
+func TestNullResponse(t *testing.T) {
+	logger := log.New()
+	server := newTestServer(logger)
+	defer server.Stop()
+	client := DialInProc(server, logger)
+	defer client.Close()
+
+	var result json.RawMessage
+	if err := client.Call(&result, "test_returnNull"); err != nil {
+		t.Fatal(err)
+	}
+	if string(result) != "null" {
+		t.Errorf("expected null, got %s", result)
+	}
+}
+
 func TestClientResponseType(t *testing.T) {
 	logger := log.New()
 	server := newTestServer(logger)

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -21,6 +21,7 @@ package rpc
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"net"

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -54,7 +54,7 @@ func TestServerRegisterName(t *testing.T) {
 		t.Fatalf("Expected service calc to be registered")
 	}
 
-	wantCallbacks := 10
+	wantCallbacks := 11
 	if len(svc.callbacks) != wantCallbacks {
 		t.Errorf("Expected %d callbacks for service 'service', got %d", wantCallbacks, len(svc.callbacks))
 	}

--- a/rpc/testservice_test.go
+++ b/rpc/testservice_test.go
@@ -119,6 +119,10 @@ func (s *testService) ReturnError() error {
 	return testError{}
 }
 
+func (s *testService) ReturnNull() any {
+	return nil
+}
+
 func (s *testService) CallMeBack(ctx context.Context, method string, args []any) (any, error) {
 	c, ok := ClientFromContext(ctx, log.New())
 	if !ok {


### PR DESCRIPTION
Cherry-pick of #20393 from main.

Fixes double indirection on interface{} preventing correct unmarshalling of JSON null responses. Mirrors go-ethereum PR #26723.