### PR TITLE
[r3.4] execmodule, eth: fix roTx leak in updateForkChoice + shutdown ordering (#20220)

### DIFF
--- a/execution/exec/blocks_read_ahead.go
+++ b/execution/exec/blocks_read_ahead.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -28,6 +29,7 @@ type blockReadAheader struct {
 
 	// this is for warming state
 	warming atomic.Bool // only one warmBody can run at a time
+	warmWg  sync.WaitGroup
 }
 
 func newBlockReadAheader() *blockReadAheader {
@@ -61,7 +63,26 @@ func (bra *blockReadAheader) AddHeaderAndBody(ctx context.Context, db kv.RoDB, h
 		if !bra.warming.CompareAndSwap(false, true) {
 			return
 		}
-		go bra.warmBody(ctx, db, header, body, 8) // use 8 workers for warming
+		bra.warmWg.Add(1)
+		go func() {
+			defer bra.warmWg.Done()
+			bra.warmBody(ctx, db, header, body, 8) // use 8 workers for warming
+		}()
+	}
+}
+
+// WaitForWarmup blocks until any in-flight warmBody goroutine finishes or
+// the context is cancelled. Call before closing the database to avoid
+// waitTxsAllDoneOnClose hangs.
+func WaitForWarmup(ctx context.Context) {
+	done := make(chan struct{})
+	go func() {
+		globalReadAheader.warmWg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-ctx.Done():
 	}
 }
 

--- a/execution/execmodule/exec_module.go
+++ b/execution/execmodule/exec_module.go
@@ -261,6 +261,15 @@ func NewExecModule(
 	return em
 }
 
+// WaitIdle blocks until any in-flight updateForkChoice goroutine finishes.
+// Call before closing the database to avoid waitTxsAllDoneOnClose hangs.
+func (e *ExecModule) WaitIdle(ctx context.Context) {
+	if err := e.semaphore.Acquire(ctx, 1); err != nil {
+		return // context cancelled — best effort
+	}
+	e.semaphore.Release(1)
+}
+
 func (e *ExecModule) getHeader(ctx context.Context, tx kv.Tx, blockHash common.Hash, blockNumber uint64) (*types.Header, error) {
 	if e.blockReader == nil {
 		return rawdb.ReadHeader(tx, blockHash, blockNumber), nil

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -85,6 +85,7 @@ import (
 	"github.com/erigontech/erigon/execution/engineapi"
 	"github.com/erigontech/erigon/execution/engineapi/engine_block_downloader"
 	"github.com/erigontech/erigon/execution/engineapi/engine_helpers"
+	"github.com/erigontech/erigon/execution/exec"
 	"github.com/erigontech/erigon/execution/execmodule"
 	"github.com/erigontech/erigon/execution/execmodule/chainreader"
 	execp2p "github.com/erigontech/erigon/execution/p2p"
@@ -1669,6 +1670,29 @@ func (s *Ethereum) Stop() error {
 	for _, sentryServer := range s.sentryServers {
 		sentryServer.Close()
 	}
+
+	// Wait for background goroutines to release DB transactions before closing DB.
+	if err := s.bgComponentsEg.Wait(); err != nil && !errors.Is(err, context.Canceled) {
+		s.logger.Error("background component error", "err", err)
+	}
+
+	// Wait for any in-flight updateForkChoice goroutine to finish. These are
+	// fire-and-forget goroutines that hold DB read transactions; without this
+	// wait, chainDB.Close() can hang in waitTxsAllDoneOnClose.
+	if s.execModule != nil {
+		waitCtx, waitCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		s.execModule.WaitIdle(waitCtx)
+		waitCancel()
+	}
+
+	// Wait for any in-flight read-ahead warmup goroutines that hold DB read
+	// transactions.
+	{
+		warmCtx, warmCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		exec.WaitForWarmup(warmCtx)
+		warmCancel()
+	}
+
 	s.chainDB.Close()
 
 	if s.silkwormRPCDaemonService != nil {
@@ -1685,10 +1709,6 @@ func (s *Ethereum) Stop() error {
 		if err := s.silkworm.Close(); err != nil {
 			s.logger.Error("silkworm.Close error", "err", err)
 		}
-	}
-
-	if err := s.bgComponentsEg.Wait(); err != nil && !errors.Is(err, context.Canceled) {
-		s.logger.Error("background component error", "err", err)
 	}
 
 	if s.config.Downloader != nil {


### PR DESCRIPTION
Manual port of #20220 from main.

Fixes DB hang during shutdown caused by uncommitted read transactions from fire-and-forget goroutines (updateForkChoice and read-ahead warmup). Adds WaitIdle/WaitForWarmup coordination before chainDB.Close().