### PR TITLE
node/components/storage/snapshot: add file inventory, trust model, range arithmetic

### DIFF
--- a/db/downloader/chaintoml_v2.go
+++ b/db/downloader/chaintoml_v2.go
@@ -97,18 +97,11 @@ func GenerateV2(inv *snapshotinv.Inventory) *ChainTomlV2 {
 		}
 		layout = layout.Normalize()
 
-		// Compute total coverage.
-		var coverageFrom, coverageTo uint64
-		if len(layout) > 0 {
-			coverageFrom = layout[0].From
-			coverageTo = layout[len(layout)-1].To
-		}
+		dm := &DomainManifest{}
 
-		dm := &DomainManifest{
-			Coverage: [2]uint64{coverageFrom, coverageTo},
-		}
-
-		// Only include files at canonical boundaries.
+		// Only include files at canonical boundaries with a torrent hash.
+		// Coverage is computed from what's actually listed, not from all
+		// local files — avoids advertising coverage for uncanonical/unhashed files.
 		for _, f := range files {
 			r := f.Range()
 			if !isCanonicalFile(r) {
@@ -130,7 +123,12 @@ func GenerateV2(inv *snapshotinv.Inventory) *ChainTomlV2 {
 			return dm.Files[i].Range[0] < dm.Files[j].Range[0]
 		})
 
+		// Compute coverage from the published file list (not all local files).
 		if len(dm.Files) > 0 {
+			dm.Coverage = [2]uint64{
+				dm.Files[0].Range[0],
+				dm.Files[len(dm.Files)-1].Range[1],
+			}
 			manifest.Domains[string(domain)] = dm
 		}
 	}

--- a/db/downloader/chaintoml_v2.go
+++ b/db/downloader/chaintoml_v2.go
@@ -1,0 +1,218 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package downloader
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+
+	snapshotinv "github.com/erigontech/erigon/node/components/storage/snapshot"
+	"github.com/pelletier/go-toml/v2"
+)
+
+// ChainTomlVersion is the format version for chain.toml.
+// V1 (implicit): flat key-value map of filename → torrent hash.
+// V2 (explicit): versioned format with [blocks], [meta], [domains.*] sections.
+const ChainTomlV2Version = 2
+
+// ChainTomlV2 is the structured representation of a V2 chain.toml manifest.
+type ChainTomlV2 struct {
+	Version int `toml:"version"`
+
+	// Block snapshot files — deterministic, all nodes produce identical files.
+	Blocks map[string]string `toml:"blocks,omitempty"`
+
+	// Metadata files (erigondb.toml, salt files).
+	Meta map[string]string `toml:"meta,omitempty"`
+
+	// Per-domain state snapshot sections.
+	Domains map[string]*DomainManifest `toml:"domains,omitempty"`
+}
+
+// DomainManifest describes the available files for a single state domain.
+type DomainManifest struct {
+	// Coverage is the [from, to) step range covered by all files combined.
+	Coverage [2]uint64 `toml:"coverage"`
+
+	// Files lists the individual snapshot files with their step ranges, hashes, and trust.
+	Files []DomainFileEntry `toml:"files,omitempty"`
+}
+
+// DomainFileEntry is a single file in a domain manifest.
+type DomainFileEntry struct {
+	Name  string    `toml:"name"`
+	Range [2]uint64 `toml:"range"`
+	Hash  string    `toml:"hash"`
+	Trust string    `toml:"trust"`
+}
+
+// GenerateV2 builds a V2 chain.toml from a snapshot inventory.
+//
+// Only files that pass the IsCanonical check are included in the domains section.
+// Non-canonical files (merge backlog) are excluded — they'll appear in a future
+// publication once merges catch up.
+//
+// Block snapshot files and metadata are included as-is (they're deterministic).
+func GenerateV2(inv *snapshotinv.Inventory) *ChainTomlV2 {
+	manifest := &ChainTomlV2{
+		Version: ChainTomlV2Version,
+		Blocks:  make(map[string]string),
+		Meta:    make(map[string]string),
+		Domains: make(map[string]*DomainManifest),
+	}
+
+	// Block files.
+	for _, f := range inv.BlockFiles() {
+		if f.TorrentHash != [20]byte{} {
+			manifest.Blocks[f.Name] = fmt.Sprintf("%x", f.TorrentHash)
+		}
+	}
+
+	// Domain files — only canonical files.
+	for _, domain := range inv.Domains() {
+		files := inv.LocalFiles(domain)
+		if len(files) == 0 {
+			continue
+		}
+
+		// Build the layout from local files and check canonicity.
+		var layout snapshotinv.StepRanges
+		for _, f := range files {
+			layout = append(layout, f.Range())
+		}
+		layout = layout.Normalize()
+
+		// Compute total coverage.
+		var coverageFrom, coverageTo uint64
+		if len(layout) > 0 {
+			coverageFrom = layout[0].From
+			coverageTo = layout[len(layout)-1].To
+		}
+
+		dm := &DomainManifest{
+			Coverage: [2]uint64{coverageFrom, coverageTo},
+		}
+
+		// Only include files at canonical boundaries.
+		for _, f := range files {
+			r := f.Range()
+			if !isCanonicalFile(r) {
+				continue
+			}
+			if f.TorrentHash == [20]byte{} {
+				continue // no torrent hash yet
+			}
+			dm.Files = append(dm.Files, DomainFileEntry{
+				Name:  f.Name,
+				Range: [2]uint64{r.From, r.To},
+				Hash:  fmt.Sprintf("%x", f.TorrentHash),
+				Trust: f.Trust.String(),
+			})
+		}
+
+		// Sort files by range for deterministic output.
+		sort.Slice(dm.Files, func(i, j int) bool {
+			return dm.Files[i].Range[0] < dm.Files[j].Range[0]
+		})
+
+		if len(dm.Files) > 0 {
+			manifest.Domains[string(domain)] = dm
+		}
+	}
+
+	return manifest
+}
+
+// isCanonicalFile checks if a single file is at a canonical (power-of-2 aligned) boundary.
+func isCanonicalFile(r snapshotinv.StepRange) bool {
+	size := r.Len()
+	if size == 0 {
+		return false
+	}
+	// Power of 2 check.
+	if size&(size-1) != 0 {
+		return false
+	}
+	// Alignment check: From must be divisible by size.
+	if r.From%size != 0 {
+		return false
+	}
+	return true
+}
+
+// MarshalV2 serializes a V2 manifest to deterministic TOML bytes.
+func MarshalV2(manifest *ChainTomlV2) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := toml.NewEncoder(&buf)
+	if err := enc.Encode(manifest); err != nil {
+		return nil, fmt.Errorf("encoding chain.toml V2: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// ParseV2 parses V2 chain.toml bytes into the structured representation.
+// Returns an error if the version field is not 2.
+func ParseV2(data []byte) (*ChainTomlV2, error) {
+	var manifest ChainTomlV2
+	if err := toml.Unmarshal(data, &manifest); err != nil {
+		return nil, fmt.Errorf("parsing chain.toml V2: %w", err)
+	}
+	if manifest.Version != ChainTomlV2Version {
+		return nil, fmt.Errorf("expected chain.toml version %d, got %d", ChainTomlV2Version, manifest.Version)
+	}
+	return &manifest, nil
+}
+
+// DetectVersion reads the version field from chain.toml bytes without full parsing.
+// Returns 1 for V1 (no version field) or the version number for V2+.
+func DetectVersion(data []byte) int {
+	var header struct {
+		Version int `toml:"version"`
+	}
+	if err := toml.Unmarshal(data, &header); err != nil {
+		return 1 // parse error → assume V1
+	}
+	if header.Version == 0 {
+		return 1 // no version field → V1
+	}
+	return header.Version
+}
+
+// DomainCoverage extracts the step ranges from a V2 domain manifest.
+func (dm *DomainManifest) StepRanges() snapshotinv.StepRanges {
+	ranges := make(snapshotinv.StepRanges, 0, len(dm.Files))
+	for _, f := range dm.Files {
+		ranges = append(ranges, snapshotinv.StepRange{From: f.Range[0], To: f.Range[1]})
+	}
+	return ranges.Normalize()
+}
+
+// FilesAtTrust returns only the files at or above the given trust level.
+func (dm *DomainManifest) FilesAtTrust(minTrust snapshotinv.TrustLevel) []DomainFileEntry {
+	var result []DomainFileEntry
+	for _, f := range dm.Files {
+		t, err := snapshotinv.ParseTrustLevel(f.Trust)
+		if err != nil {
+			continue
+		}
+		if t.Satisfies(minTrust) {
+			result = append(result, f)
+		}
+	}
+	return result
+}

--- a/db/downloader/chaintoml_v2_test.go
+++ b/db/downloader/chaintoml_v2_test.go
@@ -1,0 +1,176 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package downloader
+
+import (
+	"testing"
+
+	snapshotinv "github.com/erigontech/erigon/node/components/storage/snapshot"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectVersion(t *testing.T) {
+	// V1: no version field.
+	v1 := []byte(`"v1.0-000000-000500-headers.seg" = "abc123"` + "\n")
+	require.Equal(t, 1, DetectVersion(v1))
+
+	// V2: has version field.
+	v2 := []byte("version = 2\n[blocks]\n")
+	require.Equal(t, 2, DetectVersion(v2))
+
+	// Garbage.
+	require.Equal(t, 1, DetectVersion([]byte("not valid toml {{{")))
+}
+
+func TestGenerateV2FromInventory(t *testing.T) {
+	inv := snapshotinv.NewInventory()
+
+	// Add block files.
+	inv.AddFile(&snapshotinv.FileEntry{
+		Name:        "v1.0-000000-000500-headers.seg",
+		TorrentHash: [20]byte{0xab, 0xcd},
+		Local:       true,
+		Trust:       snapshotinv.TrustVerified,
+	})
+
+	// Add domain files — mix of canonical and non-canonical.
+	inv.AddFile(&snapshotinv.FileEntry{
+		Domain:      snapshotinv.DomainAccounts,
+		FromStep:    0,
+		ToStep:      2048,
+		Name:        "v1.0-accounts.0-2048.kv",
+		TorrentHash: [20]byte{0x11, 0x22},
+		Local:       true,
+		Trust:       snapshotinv.TrustVerified,
+	})
+	inv.AddFile(&snapshotinv.FileEntry{
+		Domain:      snapshotinv.DomainAccounts,
+		FromStep:    2048,
+		ToStep:      3072,
+		Name:        "v1.0-accounts.2048-3072.kv",
+		TorrentHash: [20]byte{0x33, 0x44},
+		Local:       true,
+		Trust:       snapshotinv.TrustConsensus,
+	})
+	// Non-canonical file (size 100, not power-of-2) — should be excluded.
+	inv.AddFile(&snapshotinv.FileEntry{
+		Domain:      snapshotinv.DomainAccounts,
+		FromStep:    3072,
+		ToStep:      3172,
+		Name:        "v1.0-accounts.3072-3172.kv",
+		TorrentHash: [20]byte{0x55, 0x66},
+		Local:       true,
+		Trust:       snapshotinv.TrustNone,
+	})
+
+	manifest := GenerateV2(inv)
+
+	require.Equal(t, ChainTomlV2Version, manifest.Version)
+	require.Len(t, manifest.Blocks, 1)
+	require.Contains(t, manifest.Blocks, "v1.0-000000-000500-headers.seg")
+
+	// Domain: only canonical files included.
+	acc := manifest.Domains["accounts"]
+	require.NotNil(t, acc)
+	require.Len(t, acc.Files, 2) // 0-2048 and 2048-3072 (both canonical), 3072-3172 excluded (non-pow2)
+	require.Equal(t, "v1.0-accounts.0-2048.kv", acc.Files[0].Name)
+	require.Equal(t, "verified", acc.Files[0].Trust)
+	require.Equal(t, "v1.0-accounts.2048-3072.kv", acc.Files[1].Name)
+	require.Equal(t, "consensus", acc.Files[1].Trust)
+}
+
+func TestV2MarshalRoundTrip(t *testing.T) {
+	inv := snapshotinv.NewInventory()
+	inv.AddFile(&snapshotinv.FileEntry{
+		Name:        "v1.0-000000-000500-headers.seg",
+		TorrentHash: [20]byte{0xab},
+		Local:       true,
+		Trust:       snapshotinv.TrustVerified,
+	})
+	inv.AddFile(&snapshotinv.FileEntry{
+		Domain:      snapshotinv.DomainAccounts,
+		FromStep:    0,
+		ToStep:      4096,
+		Name:        "v1.0-accounts.0-4096.kv",
+		TorrentHash: [20]byte{0xcd},
+		Local:       true,
+		Trust:       snapshotinv.TrustVerified,
+	})
+
+	original := GenerateV2(inv)
+
+	data, err := MarshalV2(original)
+	require.NoError(t, err)
+
+	parsed, err := ParseV2(data)
+	require.NoError(t, err)
+
+	require.Equal(t, original.Version, parsed.Version)
+	require.Equal(t, original.Blocks, parsed.Blocks)
+	require.Len(t, parsed.Domains, 1)
+	require.Len(t, parsed.Domains["accounts"].Files, 1)
+	require.Equal(t, original.Domains["accounts"].Files[0].Name, parsed.Domains["accounts"].Files[0].Name)
+}
+
+func TestParseV2RejectsV1(t *testing.T) {
+	v1 := []byte(`"v1.0-headers.seg" = "abc123"` + "\n")
+	_, err := ParseV2(v1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "version")
+}
+
+func TestDomainManifestStepRanges(t *testing.T) {
+	dm := &DomainManifest{
+		Coverage: [2]uint64{0, 4096},
+		Files: []DomainFileEntry{
+			{Name: "a.kv", Range: [2]uint64{0, 2048}, Hash: "aa", Trust: "verified"},
+			{Name: "b.kv", Range: [2]uint64{2048, 4096}, Hash: "bb", Trust: "consensus"},
+		},
+	}
+
+	ranges := dm.StepRanges()
+	require.True(t, ranges.IsComplete(0, 4096))
+	require.Equal(t, uint64(4096), ranges.Coverage())
+}
+
+func TestDomainManifestFilesAtTrust(t *testing.T) {
+	dm := &DomainManifest{
+		Files: []DomainFileEntry{
+			{Name: "a.kv", Trust: "verified"},
+			{Name: "b.kv", Trust: "consensus"},
+			{Name: "c.kv", Trust: "none"},
+		},
+	}
+
+	require.Len(t, dm.FilesAtTrust(snapshotinv.TrustNone), 3)
+	require.Len(t, dm.FilesAtTrust(snapshotinv.TrustConsensus), 2)
+	require.Len(t, dm.FilesAtTrust(snapshotinv.TrustVerified), 1)
+}
+
+func TestIsCanonicalFile(t *testing.T) {
+	// Canonical: power-of-2, aligned.
+	require.True(t, isCanonicalFile(snapshotinv.StepRange{From: 0, To: 2048}))
+	require.True(t, isCanonicalFile(snapshotinv.StepRange{From: 2048, To: 4096}))
+	require.True(t, isCanonicalFile(snapshotinv.StepRange{From: 4096, To: 5120}))
+
+	// Non-canonical: not power-of-2.
+	require.False(t, isCanonicalFile(snapshotinv.StepRange{From: 0, To: 3000}))
+	require.False(t, isCanonicalFile(snapshotinv.StepRange{From: 0, To: 100}))
+
+	// Non-canonical: misaligned.
+	require.False(t, isCanonicalFile(snapshotinv.StepRange{From: 100, To: 1124}))
+}

--- a/node/components/storage/snapshot/canonical.go
+++ b/node/components/storage/snapshot/canonical.go
@@ -1,0 +1,145 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package snapshot
+
+// CanonicalLayout computes the deterministic file layout for a given step count.
+//
+// The layout uses power-of-2 aligned files: at each position, the largest
+// power-of-2 file that fits and is aligned is used. This produces a minimal
+// set of files that covers [0, steps) without gaps or overlaps.
+//
+// The result is deterministic: given the same step count, all nodes produce
+// the same file boundaries. Deeper merges replace files but never invalidate
+// them — [0-4096) replaces [0-2048) + [2048-4096), but both were correct.
+//
+// maxMergeSize caps the largest file. A node that hasn't completed deep merges
+// uses a smaller cap, producing more files at a shallower merge level.
+// Pass 0 for no cap (unlimited merging).
+func CanonicalLayout(steps uint64, maxMergeSize uint64) StepRanges {
+	if steps == 0 {
+		return nil
+	}
+
+	var files StepRanges
+	var pos uint64
+	for pos < steps {
+		remaining := steps - pos
+
+		// Largest power-of-2 that pos is aligned to.
+		var maxAligned uint64
+		if pos == 0 {
+			maxAligned = 1 << 40 // effectively unlimited for pos=0
+		} else {
+			maxAligned = pos & -pos
+		}
+
+		// Largest power-of-2 that fits in remaining.
+		maxFit := uint64(1)
+		for maxFit*2 <= remaining {
+			maxFit *= 2
+		}
+
+		size := min(maxAligned, maxFit)
+		if maxMergeSize > 0 && size > maxMergeSize {
+			size = maxMergeSize
+		}
+
+		files = append(files, StepRange{pos, pos + size})
+		pos += size
+	}
+
+	return files
+}
+
+// CanonicalLevel returns the merge depth (largest file size) in a canonical layout.
+// Useful for advertising in ENR: "my deepest merge is N steps".
+func CanonicalLevel(layout StepRanges) uint64 {
+	var maxSize uint64
+	for _, r := range layout {
+		if s := r.Len(); s > maxSize {
+			maxSize = s
+		}
+	}
+	return maxSize
+}
+
+// MissingMerges computes the merges needed to go from the current file layout
+// to a target layout. Each returned range represents a merge that should be
+// executed: combine all current files overlapping that range into one file.
+//
+// The returned ranges are ordered deepest-first (largest merges first),
+// which is the correct execution order for convergence.
+func MissingMerges(current, target StepRanges) StepRanges {
+	// Build a set of current ranges for fast lookup.
+	currentSet := make(map[StepRange]bool, len(current))
+	for _, r := range current {
+		currentSet[r] = true
+	}
+
+	// Find target ranges that don't exist in current.
+	var missing StepRanges
+	for _, r := range target {
+		if !currentSet[r] {
+			missing = append(missing, r)
+		}
+	}
+
+	// Sort deepest first (largest ranges first) for correct merge ordering.
+	sortByLenDesc(missing)
+	return missing
+}
+
+func sortByLenDesc(rs StepRanges) {
+	for i := 1; i < len(rs); i++ {
+		for j := i; j > 0 && rs[j].Len() > rs[j-1].Len(); j-- {
+			rs[j], rs[j-1] = rs[j-1], rs[j]
+		}
+	}
+}
+
+// IsCanonical returns true if the given file layout matches any valid canonical
+// layout (at any merge depth) for the given step count. A layout is canonical
+// if every file is at a power-of-2 boundary and the files cover [0, steps)
+// without gaps.
+func IsCanonical(layout StepRanges, steps uint64) bool {
+	if len(layout) == 0 {
+		return steps == 0
+	}
+
+	// Must cover [0, steps) completely.
+	if !layout.IsComplete(0, steps) {
+		return false
+	}
+
+	// Each file must be power-of-2 sized and aligned.
+	for _, r := range layout {
+		size := r.Len()
+		if size == 0 {
+			return false
+		}
+		// Power of 2 check.
+		if size&(size-1) != 0 {
+			return false
+		}
+		// Alignment check: From must be divisible by size.
+		if r.From%size != 0 {
+			return false
+		}
+	}
+
+	return true
+}

--- a/node/components/storage/snapshot/canonical_test.go
+++ b/node/components/storage/snapshot/canonical_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package snapshot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalLayoutPowerOf2(t *testing.T) {
+	// Power-of-2 steps produce a single file.
+	layout := CanonicalLayout(8, 0)
+	require.Equal(t, StepRanges{{0, 8}}, layout)
+
+	layout = CanonicalLayout(4096, 0)
+	require.Equal(t, StepRanges{{0, 4096}}, layout)
+}
+
+func TestCanonicalLayoutNonPowerOf2(t *testing.T) {
+	// 12 = 8 + 4
+	layout := CanonicalLayout(12, 0)
+	require.Equal(t, StepRanges{{0, 8}, {8, 12}}, layout)
+
+	// 100 = 64 + 32 + 4
+	layout = CanonicalLayout(100, 0)
+	require.Equal(t, StepRanges{{0, 64}, {64, 96}, {96, 100}}, layout)
+}
+
+func TestCanonicalLayoutWithMaxMergeSize(t *testing.T) {
+	// At step 8192 with different merge caps.
+	layout := CanonicalLayout(8192, 8192)
+	require.Equal(t, StepRanges{{0, 8192}}, layout)
+
+	layout = CanonicalLayout(8192, 4096)
+	require.Equal(t, StepRanges{{0, 4096}, {4096, 8192}}, layout)
+
+	layout = CanonicalLayout(8192, 2048)
+	require.Equal(t, StepRanges{{0, 2048}, {2048, 4096}, {4096, 6144}, {6144, 8192}}, layout)
+
+	layout = CanonicalLayout(8192, 1024)
+	require.Len(t, layout, 8)
+	require.True(t, layout.IsComplete(0, 8192))
+}
+
+func TestCanonicalLayoutProgressiveReplacement(t *testing.T) {
+	// A node at step 8192 publishes [0-4096) [4096-8192) with maxMerge=4096.
+	shallow := CanonicalLayout(8192, 4096)
+	require.Equal(t, StepRanges{{0, 4096}, {4096, 8192}}, shallow)
+
+	// Later, deep merge completes: [0-8192).
+	deep := CanonicalLayout(8192, 8192)
+	require.Equal(t, StepRanges{{0, 8192}}, deep)
+
+	// Both are valid canonical layouts.
+	require.True(t, IsCanonical(shallow, 8192))
+	require.True(t, IsCanonical(deep, 8192))
+
+	// The deep layout replaces the shallow one.
+	missing := MissingMerges(shallow, deep)
+	require.Equal(t, StepRanges{{0, 8192}}, missing)
+}
+
+func TestCanonicalLayoutTail(t *testing.T) {
+	// Step 4100: deep merge for 4096, then small tail.
+	layout := CanonicalLayout(4100, 0)
+	require.Equal(t, StepRanges{{0, 4096}, {4096, 4100}}, layout)
+
+	// Step 6144: two files.
+	layout = CanonicalLayout(6144, 0)
+	require.Equal(t, StepRanges{{0, 4096}, {4096, 6144}}, layout)
+}
+
+func TestIsCanonical(t *testing.T) {
+	// Valid canonical layouts.
+	require.True(t, IsCanonical(StepRanges{{0, 8192}}, 8192))
+	require.True(t, IsCanonical(StepRanges{{0, 4096}, {4096, 8192}}, 8192))
+	require.True(t, IsCanonical(StepRanges{{0, 2048}, {2048, 4096}, {4096, 6144}, {6144, 8192}}, 8192))
+
+	// Invalid: gap.
+	require.False(t, IsCanonical(StepRanges{{0, 4096}, {5000, 8192}}, 8192))
+
+	// Invalid: non-power-of-2 size.
+	require.False(t, IsCanonical(StepRanges{{0, 3000}, {3000, 8192}}, 8192))
+
+	// Invalid: misaligned.
+	require.False(t, IsCanonical(StepRanges{{0, 4096}, {4096, 6144}, {6144, 8000}, {8000, 8192}}, 8192))
+}
+
+func TestMissingMerges(t *testing.T) {
+	current := StepRanges{{0, 1024}, {1024, 2048}, {2048, 3072}, {3072, 4096}}
+	target := StepRanges{{0, 4096}}
+
+	missing := MissingMerges(current, target)
+	require.Equal(t, StepRanges{{0, 4096}}, missing)
+}
+
+func TestMissingMergesPartial(t *testing.T) {
+	current := StepRanges{{0, 4096}, {4096, 5120}, {5120, 6144}, {6144, 7168}, {7168, 8192}}
+	target := StepRanges{{0, 4096}, {4096, 8192}}
+
+	missing := MissingMerges(current, target)
+	require.Equal(t, StepRanges{{4096, 8192}}, missing)
+}
+
+func TestCanonicalLevel(t *testing.T) {
+	layout := CanonicalLayout(8192, 4096)
+	require.Equal(t, uint64(4096), CanonicalLevel(layout))
+
+	layout = CanonicalLayout(8192, 0)
+	require.Equal(t, uint64(8192), CanonicalLevel(layout))
+}
+
+func TestCanonicalLayoutEmpty(t *testing.T) {
+	layout := CanonicalLayout(0, 0)
+	require.Nil(t, layout)
+}
+
+func TestAllCanonicalLevelsAreValid(t *testing.T) {
+	// For step 8192, every merge level produces a valid canonical layout.
+	for _, maxMerge := range []uint64{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192} {
+		layout := CanonicalLayout(8192, maxMerge)
+		require.True(t, IsCanonical(layout, 8192), "maxMerge=%d layout=%v", maxMerge, layout)
+		require.True(t, layout.IsComplete(0, 8192), "maxMerge=%d", maxMerge)
+	}
+}

--- a/node/components/storage/snapshot/inventory.go
+++ b/node/components/storage/snapshot/inventory.go
@@ -202,6 +202,8 @@ func (inv *Inventory) FilesForRange(domain Domain, from, to uint64) []*FileEntry
 }
 
 // LocalFiles returns all files that exist on disk for a domain.
+// The returned slice is a copy, but entries are shared pointers.
+// Callers MUST NOT mutate entries — use SetTorrentHash for hash updates.
 func (inv *Inventory) LocalFiles(domain Domain) []*FileEntry {
 	inv.mu.RLock()
 	defer inv.mu.RUnlock()
@@ -216,6 +218,8 @@ func (inv *Inventory) LocalFiles(domain Domain) []*FileEntry {
 }
 
 // AllDomainFiles returns all files for a domain regardless of local/remote status.
+// The returned slice is a copy, but entries are shared pointers.
+// Callers MUST NOT mutate entries — use SetTorrentHash for hash updates.
 func (inv *Inventory) AllDomainFiles(domain Domain) []*FileEntry {
 	inv.mu.RLock()
 	defer inv.mu.RUnlock()

--- a/node/components/storage/snapshot/inventory.go
+++ b/node/components/storage/snapshot/inventory.go
@@ -1,0 +1,309 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package snapshot
+
+import (
+	"sort"
+	"sync"
+)
+
+// Domain identifies a state domain (accounts, storage, code, commitment, etc).
+type Domain string
+
+const (
+	DomainAccounts   Domain = "accounts"
+	DomainStorage    Domain = "storage"
+	DomainCode       Domain = "code"
+	DomainCommitment Domain = "commitment"
+)
+
+// FileEntry represents a single snapshot file (block or domain) tracked by the inventory.
+type FileEntry struct {
+	// Domain this file belongs to. Empty for block snapshots.
+	Domain Domain
+
+	// Step range [FromStep, ToStep) covered by this file. Zero for block snapshots.
+	FromStep uint64
+	ToStep   uint64
+
+	// File name (relative to snapshots directory).
+	Name string
+
+	// Size in bytes on disk. Zero if the file is not local (peer-advertised only).
+	Size int64
+
+	// TorrentHash is the 20-byte BitTorrent info-hash. Zero if not yet computed.
+	TorrentHash [20]byte
+
+	// Trust indicates how this file's integrity has been established.
+	Trust TrustLevel
+
+	// Local is true if the file exists on this node's disk and is available for
+	// reading by the aggregator/blockReader. A file can have Trust=TrustVerified
+	// but Local=false (e.g. a preverified entry not yet downloaded).
+	Local bool
+
+	// Seeding is true if the file is currently being seeded via BitTorrent.
+	Seeding bool
+}
+
+// Range returns the StepRange for this file entry.
+func (f *FileEntry) Range() StepRange {
+	return StepRange{f.FromStep, f.ToStep}
+}
+
+// Inventory tracks all known snapshot files (local and remote) for a node,
+// organized by domain. It is the state model that storage uses to decide:
+//   - What to download (gaps in local coverage vs peer offerings)
+//   - What to seed (local files)
+//   - What to advertise in chain.toml (all files, tagged with trust)
+//   - What to accept from peers (trust level filtering)
+//
+// Thread-safe for concurrent reads and writes.
+type Inventory struct {
+	mu      sync.RWMutex
+	domains map[Domain][]*FileEntry
+	blocks  []*FileEntry // block snapshots (headers, bodies, etc.)
+}
+
+// NewInventory creates an empty inventory.
+func NewInventory() *Inventory {
+	return &Inventory{
+		domains: make(map[Domain][]*FileEntry),
+	}
+}
+
+// AddFile adds a file entry to the inventory. If an entry with the same name
+// already exists, it is replaced (useful for trust promotion or re-scan).
+func (inv *Inventory) AddFile(entry *FileEntry) {
+	inv.mu.Lock()
+	defer inv.mu.Unlock()
+
+	if entry.Domain == "" {
+		inv.blocks = replaceOrAppend(inv.blocks, entry)
+	} else {
+		inv.domains[entry.Domain] = replaceOrAppend(inv.domains[entry.Domain], entry)
+	}
+}
+
+// RemoveFile removes a file entry by name.
+func (inv *Inventory) RemoveFile(name string) {
+	inv.mu.Lock()
+	defer inv.mu.Unlock()
+
+	inv.blocks = removeByName(inv.blocks, name)
+	for domain, entries := range inv.domains {
+		inv.domains[domain] = removeByName(entries, name)
+	}
+}
+
+// ReplaceWithMerge atomically replaces multiple small files with a single merged file.
+// Returns false if the merged file doesn't cover all replaced ranges.
+func (inv *Inventory) ReplaceWithMerge(merged *FileEntry, replaced []string) bool {
+	inv.mu.Lock()
+	defer inv.mu.Unlock()
+
+	entries := inv.domains[merged.Domain]
+
+	// Verify the merged file covers all replaced ranges.
+	for _, name := range replaced {
+		for _, e := range entries {
+			if e.Name == name && !merged.Range().Covers(e.Range()) {
+				return false
+			}
+		}
+	}
+
+	// Remove replaced files.
+	for _, name := range replaced {
+		entries = removeByName(entries, name)
+	}
+
+	// Add the merged file.
+	entries = replaceOrAppend(entries, merged)
+	inv.domains[merged.Domain] = entries
+	return true
+}
+
+// Coverage returns the step ranges covered by local files for a domain.
+func (inv *Inventory) Coverage(domain Domain) StepRanges {
+	inv.mu.RLock()
+	defer inv.mu.RUnlock()
+	return inv.coverageLocked(domain, true)
+}
+
+// FullCoverage returns the step ranges covered by ALL known files (local + remote)
+// for a domain, regardless of trust level.
+func (inv *Inventory) FullCoverage(domain Domain) StepRanges {
+	inv.mu.RLock()
+	defer inv.mu.RUnlock()
+	return inv.coverageLocked(domain, false)
+}
+
+// CoverageAtTrust returns step ranges covered by files at or above the given trust level.
+func (inv *Inventory) CoverageAtTrust(domain Domain, minTrust TrustLevel) StepRanges {
+	inv.mu.RLock()
+	defer inv.mu.RUnlock()
+
+	var ranges StepRanges
+	for _, e := range inv.domains[domain] {
+		if e.Trust.Satisfies(minTrust) {
+			ranges = append(ranges, e.Range())
+		}
+	}
+	return ranges.Normalize()
+}
+
+func (inv *Inventory) coverageLocked(domain Domain, localOnly bool) StepRanges {
+	var ranges StepRanges
+	for _, e := range inv.domains[domain] {
+		if localOnly && !e.Local {
+			continue
+		}
+		ranges = append(ranges, e.Range())
+	}
+	return ranges.Normalize()
+}
+
+// GapsAgainst returns ranges that a remote inventory covers but we don't (locally).
+// Used to build download requests.
+func (inv *Inventory) GapsAgainst(domain Domain, remote StepRanges) StepRanges {
+	local := inv.Coverage(domain)
+	return local.GapsAgainst(remote)
+}
+
+// FilesForRange returns all files for a domain that overlap with [from, to).
+func (inv *Inventory) FilesForRange(domain Domain, from, to uint64) []*FileEntry {
+	inv.mu.RLock()
+	defer inv.mu.RUnlock()
+
+	target := StepRange{from, to}
+	var result []*FileEntry
+	for _, e := range inv.domains[domain] {
+		if e.Range().Overlaps(target) {
+			result = append(result, e)
+		}
+	}
+	return result
+}
+
+// LocalFiles returns all files that exist on disk for a domain.
+func (inv *Inventory) LocalFiles(domain Domain) []*FileEntry {
+	inv.mu.RLock()
+	defer inv.mu.RUnlock()
+
+	var result []*FileEntry
+	for _, e := range inv.domains[domain] {
+		if e.Local {
+			result = append(result, e)
+		}
+	}
+	return result
+}
+
+// AllDomainFiles returns all files for a domain regardless of local/remote status.
+func (inv *Inventory) AllDomainFiles(domain Domain) []*FileEntry {
+	inv.mu.RLock()
+	defer inv.mu.RUnlock()
+
+	result := make([]*FileEntry, len(inv.domains[domain]))
+	copy(result, inv.domains[domain])
+	return result
+}
+
+// BlockFiles returns all block snapshot files.
+func (inv *Inventory) BlockFiles() []*FileEntry {
+	inv.mu.RLock()
+	defer inv.mu.RUnlock()
+
+	result := make([]*FileEntry, len(inv.blocks))
+	copy(result, inv.blocks)
+	return result
+}
+
+// Domains returns the list of domains that have any files.
+func (inv *Inventory) Domains() []Domain {
+	inv.mu.RLock()
+	defer inv.mu.RUnlock()
+
+	domains := make([]Domain, 0, len(inv.domains))
+	for d, entries := range inv.domains {
+		if len(entries) > 0 {
+			domains = append(domains, d)
+		}
+	}
+	sort.Slice(domains, func(i, j int) bool { return domains[i] < domains[j] })
+	return domains
+}
+
+// PromoteTrust promotes a file's trust level if the new level is higher.
+// Returns true if the trust was actually changed.
+func (inv *Inventory) PromoteTrust(name string, newTrust TrustLevel) bool {
+	inv.mu.Lock()
+	defer inv.mu.Unlock()
+
+	if e := findByName(inv.blocks, name); e != nil {
+		if newTrust > e.Trust {
+			e.Trust = newTrust
+			return true
+		}
+		return false
+	}
+
+	for _, entries := range inv.domains {
+		if e := findByName(entries, name); e != nil {
+			if newTrust > e.Trust {
+				e.Trust = newTrust
+				return true
+			}
+			return false
+		}
+	}
+	return false
+}
+
+// helpers
+
+func replaceOrAppend(entries []*FileEntry, entry *FileEntry) []*FileEntry {
+	for i, e := range entries {
+		if e.Name == entry.Name {
+			entries[i] = entry
+			return entries
+		}
+	}
+	return append(entries, entry)
+}
+
+func removeByName(entries []*FileEntry, name string) []*FileEntry {
+	for i, e := range entries {
+		if e.Name == name {
+			entries[i] = entries[len(entries)-1]
+			entries[len(entries)-1] = nil
+			return entries[:len(entries)-1]
+		}
+	}
+	return entries
+}
+
+func findByName(entries []*FileEntry, name string) *FileEntry {
+	for _, e := range entries {
+		if e.Name == name {
+			return e
+		}
+	}
+	return nil
+}

--- a/node/components/storage/snapshot/inventory_test.go
+++ b/node/components/storage/snapshot/inventory_test.go
@@ -1,0 +1,184 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package snapshot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInventoryAddAndCoverage(t *testing.T) {
+	inv := NewInventory()
+	inv.AddFile(&FileEntry{
+		Domain:   DomainAccounts,
+		FromStep: 0, ToStep: 1024,
+		Name:  "v1.0-accounts.0-1024.kv",
+		Local: true, Trust: TrustVerified,
+	})
+	inv.AddFile(&FileEntry{
+		Domain:   DomainAccounts,
+		FromStep: 1024, ToStep: 2048,
+		Name:  "v1.0-accounts.1024-2048.kv",
+		Local: true, Trust: TrustVerified,
+	})
+
+	cov := inv.Coverage(DomainAccounts)
+	require.True(t, cov.IsComplete(0, 2048))
+	require.Equal(t, uint64(2048), cov.Coverage())
+}
+
+func TestInventoryGapsAgainst(t *testing.T) {
+	inv := NewInventory()
+	inv.AddFile(&FileEntry{
+		Domain:   DomainAccounts,
+		FromStep: 0, ToStep: 1024,
+		Name:  "v1.0-accounts.0-1024.kv",
+		Local: true, Trust: TrustVerified,
+	})
+
+	remote := StepRanges{{0, 2048}}
+	gaps := inv.GapsAgainst(DomainAccounts, remote)
+	require.Equal(t, StepRanges{{1024, 2048}}, gaps)
+}
+
+func TestInventoryReplaceWithMerge(t *testing.T) {
+	inv := NewInventory()
+	inv.AddFile(&FileEntry{
+		Domain: DomainAccounts, FromStep: 0, ToStep: 512,
+		Name: "v1.0-accounts.0-512.kv", Local: true, Trust: TrustVerified,
+	})
+	inv.AddFile(&FileEntry{
+		Domain: DomainAccounts, FromStep: 512, ToStep: 1024,
+		Name: "v1.0-accounts.512-1024.kv", Local: true, Trust: TrustVerified,
+	})
+
+	merged := &FileEntry{
+		Domain: DomainAccounts, FromStep: 0, ToStep: 1024,
+		Name: "v1.0-accounts.0-1024.kv", Local: true, Trust: TrustVerified,
+	}
+	ok := inv.ReplaceWithMerge(merged, []string{
+		"v1.0-accounts.0-512.kv",
+		"v1.0-accounts.512-1024.kv",
+	})
+	require.True(t, ok)
+
+	files := inv.AllDomainFiles(DomainAccounts)
+	require.Len(t, files, 1)
+	require.Equal(t, "v1.0-accounts.0-1024.kv", files[0].Name)
+}
+
+func TestInventoryReplaceWithMergeRejectsInsufficientCoverage(t *testing.T) {
+	inv := NewInventory()
+	inv.AddFile(&FileEntry{
+		Domain: DomainAccounts, FromStep: 0, ToStep: 1024,
+		Name: "v1.0-accounts.0-1024.kv", Local: true, Trust: TrustVerified,
+	})
+
+	// Merged file doesn't cover the existing file's range.
+	merged := &FileEntry{
+		Domain: DomainAccounts, FromStep: 0, ToStep: 512,
+		Name: "v1.0-accounts.0-512.kv", Local: true, Trust: TrustVerified,
+	}
+	ok := inv.ReplaceWithMerge(merged, []string{"v1.0-accounts.0-1024.kv"})
+	require.False(t, ok)
+}
+
+func TestInventoryTrustPromotion(t *testing.T) {
+	inv := NewInventory()
+	inv.AddFile(&FileEntry{
+		Domain: DomainAccounts, FromStep: 0, ToStep: 1024,
+		Name: "v1.0-accounts.0-1024.kv", Trust: TrustNone,
+	})
+
+	changed := inv.PromoteTrust("v1.0-accounts.0-1024.kv", TrustConsensus)
+	require.True(t, changed)
+
+	files := inv.AllDomainFiles(DomainAccounts)
+	require.Equal(t, TrustConsensus, files[0].Trust)
+
+	// Can't demote.
+	changed = inv.PromoteTrust("v1.0-accounts.0-1024.kv", TrustNone)
+	require.False(t, changed)
+	require.Equal(t, TrustConsensus, inv.AllDomainFiles(DomainAccounts)[0].Trust)
+}
+
+func TestInventoryCoverageAtTrust(t *testing.T) {
+	inv := NewInventory()
+	inv.AddFile(&FileEntry{
+		Domain: DomainAccounts, FromStep: 0, ToStep: 1024,
+		Name: "verified.kv", Local: true, Trust: TrustVerified,
+	})
+	inv.AddFile(&FileEntry{
+		Domain: DomainAccounts, FromStep: 1024, ToStep: 2048,
+		Name: "consensus.kv", Local: true, Trust: TrustConsensus,
+	})
+	inv.AddFile(&FileEntry{
+		Domain: DomainAccounts, FromStep: 2048, ToStep: 3072,
+		Name: "none.kv", Local: true, Trust: TrustNone,
+	})
+
+	// All trust levels.
+	cov := inv.CoverageAtTrust(DomainAccounts, TrustNone)
+	require.Equal(t, uint64(3072), cov.Coverage())
+
+	// Consensus and above.
+	cov = inv.CoverageAtTrust(DomainAccounts, TrustConsensus)
+	require.Equal(t, uint64(2048), cov.Coverage())
+
+	// Verified only.
+	cov = inv.CoverageAtTrust(DomainAccounts, TrustVerified)
+	require.Equal(t, uint64(1024), cov.Coverage())
+}
+
+func TestInventoryLocalVsRemote(t *testing.T) {
+	inv := NewInventory()
+	inv.AddFile(&FileEntry{
+		Domain: DomainAccounts, FromStep: 0, ToStep: 1024,
+		Name: "local.kv", Local: true, Trust: TrustVerified,
+	})
+	inv.AddFile(&FileEntry{
+		Domain: DomainAccounts, FromStep: 1024, ToStep: 2048,
+		Name: "remote.kv", Local: false, Trust: TrustConsensus,
+	})
+
+	// Local coverage only includes local files.
+	localCov := inv.Coverage(DomainAccounts)
+	require.Equal(t, uint64(1024), localCov.Coverage())
+
+	// Full coverage includes both.
+	fullCov := inv.FullCoverage(DomainAccounts)
+	require.Equal(t, uint64(2048), fullCov.Coverage())
+
+	// LocalFiles returns only local.
+	local := inv.LocalFiles(DomainAccounts)
+	require.Len(t, local, 1)
+	require.Equal(t, "local.kv", local[0].Name)
+}
+
+func TestInventoryBlockFiles(t *testing.T) {
+	inv := NewInventory()
+	inv.AddFile(&FileEntry{
+		Name: "v1.0-000000-000500-headers.seg", Local: true, Trust: TrustVerified,
+	})
+	inv.AddFile(&FileEntry{
+		Name: "v1.0-000000-000500-bodies.seg", Local: true, Trust: TrustVerified,
+	})
+
+	blocks := inv.BlockFiles()
+	require.Len(t, blocks, 2)
+}

--- a/node/components/storage/snapshot/populate.go
+++ b/node/components/storage/snapshot/populate.go
@@ -1,0 +1,165 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package snapshot
+
+import "sync"
+
+// VisibleFileProvider is implemented by types that expose the current set of
+// visible domain files. The provider pins the files for the duration of its
+// lifetime (like a read transaction) — they can't change until it's closed.
+//
+// The storage component wires this to the aggregator's read transaction or
+// a similar mechanism that provides a consistent snapshot of visible files.
+type VisibleFileProvider interface {
+	// VisibleDomainFiles returns the current set of visible domain files.
+	VisibleDomainFiles() []DomainFileInfo
+
+	// Close releases the pinned file references.
+	Close()
+}
+
+// VisibleFileOpener creates a new VisibleFileProvider. Called each time the
+// inventory needs to refresh its view of the visible files.
+type VisibleFileOpener func() (VisibleFileProvider, error)
+
+// DomainFileInfo describes a single visible domain file.
+type DomainFileInfo struct {
+	Domain   Domain
+	FromStep uint64
+	ToStep   uint64
+	Name     string // relative filename
+	Size     int64
+}
+
+// LiveInventory is a long-lived inventory that holds a pinned view of visible
+// files and refreshes when notified of changes. It subscribes to file-change
+// events and re-opens its view to get the updated file set.
+//
+// Thread-safe: the snapshot can be read concurrently while a refresh is in progress.
+type LiveInventory struct {
+	mu       sync.RWMutex
+	current  *Inventory
+	provider VisibleFileProvider // currently pinned view
+	opener   VisibleFileOpener
+}
+
+// NewLiveInventory creates a live inventory that refreshes from the given opener.
+// Call Refresh() after creation to populate the initial state.
+func NewLiveInventory(opener VisibleFileOpener) *LiveInventory {
+	return &LiveInventory{
+		current: NewInventory(),
+		opener:  opener,
+	}
+}
+
+// Refresh closes the current pinned view, opens a new one, and rebuilds the
+// inventory from the new visible files. This is called when file-change events
+// are received (OnFilesChange from the aggregator, merge completion, etc).
+func (li *LiveInventory) Refresh() error {
+	newProvider, err := li.opener()
+	if err != nil {
+		return err
+	}
+
+	files := newProvider.VisibleDomainFiles()
+
+	inv := NewInventory()
+	for _, f := range files {
+		inv.AddFile(&FileEntry{
+			Domain:   f.Domain,
+			FromStep: f.FromStep,
+			ToStep:   f.ToStep,
+			Name:     f.Name,
+			Size:     f.Size,
+			Local:    true,
+			Trust:    TrustVerified,
+		})
+	}
+
+	li.mu.Lock()
+	oldProvider := li.provider
+	// Preserve torrent hashes from old inventory.
+	if li.current != nil {
+		for _, domain := range li.current.Domains() {
+			for _, oldEntry := range li.current.AllDomainFiles(domain) {
+				if oldEntry.TorrentHash != [20]byte{} {
+					for _, newEntry := range inv.AllDomainFiles(domain) {
+						if newEntry.Name == oldEntry.Name {
+							newEntry.TorrentHash = oldEntry.TorrentHash
+							newEntry.Seeding = oldEntry.Seeding
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+	li.current = inv
+	li.provider = newProvider
+	li.mu.Unlock()
+
+	// Close old provider AFTER releasing the lock — this releases the old file references.
+	if oldProvider != nil {
+		oldProvider.Close()
+	}
+
+	return nil
+}
+
+// Snapshot returns the current inventory. The returned value is safe to read
+// concurrently — it won't be modified (a new Inventory is created on each Refresh).
+func (li *LiveInventory) Snapshot() *Inventory {
+	li.mu.RLock()
+	defer li.mu.RUnlock()
+	return li.current
+}
+
+// Close releases the currently pinned file view.
+func (li *LiveInventory) Close() {
+	li.mu.Lock()
+	defer li.mu.Unlock()
+	if li.provider != nil {
+		li.provider.Close()
+		li.provider = nil
+	}
+}
+
+// SetTorrentHash sets the torrent hash for a file by name in the current inventory.
+func (li *LiveInventory) SetTorrentHash(name string, hash [20]byte) {
+	li.mu.RLock()
+	defer li.mu.RUnlock()
+	SetTorrentHash(li.current, name, hash)
+}
+
+// SetTorrentHash sets the torrent hash for a file by name.
+func SetTorrentHash(inv *Inventory, name string, hash [20]byte) {
+	inv.mu.Lock()
+	defer inv.mu.Unlock()
+
+	if e := findByName(inv.blocks, name); e != nil {
+		e.TorrentHash = hash
+		e.Seeding = true
+		return
+	}
+	for _, entries := range inv.domains {
+		if e := findByName(entries, name); e != nil {
+			e.TorrentHash = hash
+			e.Seeding = true
+			return
+		}
+	}
+}

--- a/node/components/storage/snapshot/populate.go
+++ b/node/components/storage/snapshot/populate.go
@@ -122,6 +122,10 @@ func (li *LiveInventory) Refresh() error {
 
 // Snapshot returns the current inventory. The returned value is safe to read
 // concurrently — it won't be modified (a new Inventory is created on each Refresh).
+// Snapshot returns the current pinned inventory. The returned Inventory is
+// shared — callers MUST NOT modify its entries directly. SetTorrentHash is
+// the only sanctioned mutation path (it updates entries in place because
+// torrent hashing is async and the inventory is rebuilt on each refresh).
 func (li *LiveInventory) Snapshot() *Inventory {
 	li.mu.RLock()
 	defer li.mu.RUnlock()

--- a/node/components/storage/snapshot/ranges.go
+++ b/node/components/storage/snapshot/ranges.go
@@ -1,0 +1,174 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package snapshot
+
+import "sort"
+
+// StepRange represents a half-open interval [From, To) of aggregator steps.
+type StepRange struct {
+	From uint64
+	To   uint64
+}
+
+// Len returns the number of steps in the range.
+func (r StepRange) Len() uint64 {
+	if r.To <= r.From {
+		return 0
+	}
+	return r.To - r.From
+}
+
+// Contains returns true if step is within [From, To).
+func (r StepRange) Contains(step uint64) bool {
+	return step >= r.From && step < r.To
+}
+
+// Overlaps returns true if the two ranges share any steps.
+func (r StepRange) Overlaps(other StepRange) bool {
+	return r.From < other.To && other.From < r.To
+}
+
+// Covers returns true if r fully contains other.
+func (r StepRange) Covers(other StepRange) bool {
+	return r.From <= other.From && r.To >= other.To
+}
+
+// StepRanges is a sorted, non-overlapping list of step ranges.
+// The zero value is an empty range set.
+type StepRanges []StepRange
+
+// Normalize sorts and merges overlapping/adjacent ranges.
+func (rs StepRanges) Normalize() StepRanges {
+	if len(rs) <= 1 {
+		return rs
+	}
+	sort.Slice(rs, func(i, j int) bool { return rs[i].From < rs[j].From })
+
+	merged := StepRanges{rs[0]}
+	for _, r := range rs[1:] {
+		last := &merged[len(merged)-1]
+		if r.From <= last.To {
+			// Overlapping or adjacent — extend.
+			if r.To > last.To {
+				last.To = r.To
+			}
+		} else {
+			merged = append(merged, r)
+		}
+	}
+	return merged
+}
+
+// Coverage returns the total number of steps covered.
+func (rs StepRanges) Coverage() uint64 {
+	var total uint64
+	for _, r := range rs {
+		total += r.Len()
+	}
+	return total
+}
+
+// Contains returns true if the given step is covered by any range.
+func (rs StepRanges) Contains(step uint64) bool {
+	for _, r := range rs {
+		if r.Contains(step) {
+			return true
+		}
+		if step < r.From {
+			return false // sorted, no point continuing
+		}
+	}
+	return false
+}
+
+// IsComplete returns true if the ranges cover [from, to) without gaps.
+func (rs StepRanges) IsComplete(from, to uint64) bool {
+	norm := rs.Normalize()
+	for _, r := range norm {
+		if r.From <= from && r.To >= to {
+			return true
+		}
+		if r.From <= from && r.To > from {
+			from = r.To
+		}
+	}
+	return from >= to
+}
+
+// Gaps returns the uncovered ranges within [from, to).
+func (rs StepRanges) Gaps(from, to uint64) StepRanges {
+	norm := rs.Normalize()
+	var gaps StepRanges
+	cursor := from
+	for _, r := range norm {
+		if r.From >= to {
+			break
+		}
+		if r.From > cursor {
+			gaps = append(gaps, StepRange{cursor, min(r.From, to)})
+		}
+		if r.To > cursor {
+			cursor = r.To
+		}
+	}
+	if cursor < to {
+		gaps = append(gaps, StepRange{cursor, to})
+	}
+	return gaps
+}
+
+// GapsAgainst returns ranges that other covers but rs does not.
+// Useful for: "what does this peer have that I'm missing?"
+func (rs StepRanges) GapsAgainst(other StepRanges) StepRanges {
+	otherNorm := other.Normalize()
+	if len(otherNorm) == 0 {
+		return nil
+	}
+	// Find the full extent of other, then compute our gaps within that extent.
+	from := otherNorm[0].From
+	to := otherNorm[len(otherNorm)-1].To
+
+	ourGaps := rs.Gaps(from, to)
+
+	// Intersect our gaps with other's coverage (only report gaps where other actually has data).
+	var result StepRanges
+	for _, gap := range ourGaps {
+		for _, r := range otherNorm {
+			if r.From >= gap.To {
+				break
+			}
+			if r.To <= gap.From {
+				continue
+			}
+			// Intersection of gap and r.
+			intFrom := max(gap.From, r.From)
+			intTo := min(gap.To, r.To)
+			if intFrom < intTo {
+				result = append(result, StepRange{intFrom, intTo})
+			}
+		}
+	}
+	return result
+}
+
+// Union returns the combined coverage of rs and other.
+func (rs StepRanges) Union(other StepRanges) StepRanges {
+	combined := make(StepRanges, 0, len(rs)+len(other))
+	combined = append(combined, rs...)
+	combined = append(combined, other...)
+	return combined.Normalize()
+}

--- a/node/components/storage/snapshot/ranges_test.go
+++ b/node/components/storage/snapshot/ranges_test.go
@@ -1,0 +1,129 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package snapshot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStepRange(t *testing.T) {
+	r := StepRange{10, 20}
+	require.Equal(t, uint64(10), r.Len())
+	require.True(t, r.Contains(10))
+	require.True(t, r.Contains(19))
+	require.False(t, r.Contains(20))
+	require.False(t, r.Contains(9))
+}
+
+func TestStepRangeOverlaps(t *testing.T) {
+	a := StepRange{10, 20}
+	require.True(t, a.Overlaps(StepRange{15, 25}))
+	require.True(t, a.Overlaps(StepRange{5, 15}))
+	require.True(t, a.Overlaps(StepRange{12, 18}))
+	require.False(t, a.Overlaps(StepRange{20, 30}))
+	require.False(t, a.Overlaps(StepRange{0, 10}))
+}
+
+func TestStepRangeCovers(t *testing.T) {
+	a := StepRange{10, 30}
+	require.True(t, a.Covers(StepRange{10, 30}))
+	require.True(t, a.Covers(StepRange{15, 25}))
+	require.False(t, a.Covers(StepRange{5, 15}))
+	require.False(t, a.Covers(StepRange{25, 35}))
+}
+
+func TestNormalize(t *testing.T) {
+	// Overlapping ranges merge.
+	rs := StepRanges{{10, 20}, {15, 30}, {5, 12}}
+	norm := rs.Normalize()
+	require.Equal(t, StepRanges{{5, 30}}, norm)
+
+	// Adjacent ranges merge.
+	rs = StepRanges{{10, 20}, {20, 30}}
+	norm = rs.Normalize()
+	require.Equal(t, StepRanges{{10, 30}}, norm)
+
+	// Non-overlapping stay separate.
+	rs = StepRanges{{10, 20}, {30, 40}}
+	norm = rs.Normalize()
+	require.Equal(t, StepRanges{{10, 20}, {30, 40}}, norm)
+}
+
+func TestCoverage(t *testing.T) {
+	rs := StepRanges{{0, 100}, {200, 300}}
+	require.Equal(t, uint64(200), rs.Coverage())
+}
+
+func TestIsComplete(t *testing.T) {
+	rs := StepRanges{{0, 50}, {50, 100}}
+	require.True(t, rs.IsComplete(0, 100))
+	require.False(t, rs.IsComplete(0, 150))
+
+	// With gap.
+	rs = StepRanges{{0, 50}, {60, 100}}
+	require.False(t, rs.IsComplete(0, 100))
+	require.True(t, rs.IsComplete(0, 50))
+}
+
+func TestGaps(t *testing.T) {
+	rs := StepRanges{{0, 50}, {80, 100}}
+	gaps := rs.Gaps(0, 100)
+	require.Equal(t, StepRanges{{50, 80}}, gaps)
+
+	// Gap at start.
+	rs = StepRanges{{20, 50}}
+	gaps = rs.Gaps(0, 50)
+	require.Equal(t, StepRanges{{0, 20}}, gaps)
+
+	// Gap at end.
+	rs = StepRanges{{0, 50}}
+	gaps = rs.Gaps(0, 100)
+	require.Equal(t, StepRanges{{50, 100}}, gaps)
+
+	// No gaps.
+	rs = StepRanges{{0, 100}}
+	gaps = rs.Gaps(0, 100)
+	require.Empty(t, gaps)
+}
+
+func TestGapsAgainst(t *testing.T) {
+	local := StepRanges{{0, 50}}
+	remote := StepRanges{{0, 100}}
+	gaps := local.GapsAgainst(remote)
+	require.Equal(t, StepRanges{{50, 100}}, gaps)
+
+	// Remote has disjoint ranges.
+	local = StepRanges{{0, 50}}
+	remote = StepRanges{{0, 30}, {60, 100}}
+	gaps = local.GapsAgainst(remote)
+	require.Equal(t, StepRanges{{60, 100}}, gaps)
+
+	// Remote has nothing we're missing.
+	local = StepRanges{{0, 100}}
+	remote = StepRanges{{0, 80}}
+	gaps = local.GapsAgainst(remote)
+	require.Empty(t, gaps)
+}
+
+func TestUnion(t *testing.T) {
+	a := StepRanges{{0, 50}}
+	b := StepRanges{{40, 100}}
+	u := a.Union(b)
+	require.Equal(t, StepRanges{{0, 100}}, u)
+}

--- a/node/components/storage/snapshot/trust.go
+++ b/node/components/storage/snapshot/trust.go
@@ -1,0 +1,95 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+// Package snapshot provides the file inventory, trust model, and range
+// arithmetic for decentralized snapshot distribution.
+//
+// Trust levels are incremental — each builds on the previous:
+//
+//   - None: file downloaded, no verification beyond BitTorrent content integrity
+//   - Consensus: multiple independent peers agree on the same torrent hash
+//   - Verified: cryptographic proof via UCAN delegation chain, or locally generated
+//
+// See issues #19657 (POC), #19658 (consensus), #19659 (UCAN verification).
+package snapshot
+
+import "fmt"
+
+// TrustLevel represents how a snapshot file's integrity has been established.
+// Higher values indicate stronger trust. Files move up the trust ladder over
+// their lifecycle (promotion) but never move down.
+type TrustLevel int
+
+const (
+	// TrustNone means the file was downloaded from a peer without any
+	// verification beyond BitTorrent content integrity (hash of chunks).
+	// A single malicious peer could have advertised a bad info-hash.
+	TrustNone TrustLevel = iota
+
+	// TrustConsensus means multiple independent peers (threshold M-of-N)
+	// reported the same torrent hash for this step range. Defeats isolated
+	// bad actors but not coordinated Sybil attacks.
+	TrustConsensus
+
+	// TrustVerified means the file has cryptographic provenance:
+	// - Locally generated (collation/merge produced it)
+	// - From the compiled-in preverified registry
+	// - UCAN delegation chain verified from a root authority
+	// - Content independently verified against a known commitment root
+	TrustVerified
+)
+
+func (t TrustLevel) String() string {
+	switch t {
+	case TrustNone:
+		return "none"
+	case TrustConsensus:
+		return "consensus"
+	case TrustVerified:
+		return "verified"
+	default:
+		return fmt.Sprintf("unknown(%d)", int(t))
+	}
+}
+
+// ParseTrustLevel parses a trust level string from chain.toml or CLI flags.
+func ParseTrustLevel(s string) (TrustLevel, error) {
+	switch s {
+	case "none":
+		return TrustNone, nil
+	case "consensus":
+		return TrustConsensus, nil
+	case "verified":
+		return TrustVerified, nil
+	default:
+		return TrustNone, fmt.Errorf("unknown trust level: %q (expected none, consensus, or verified)", s)
+	}
+}
+
+// Satisfies returns true if this trust level meets or exceeds the required level.
+// Used by consumers to filter files: only accept files whose trust >= required.
+func (t TrustLevel) Satisfies(required TrustLevel) bool {
+	return t >= required
+}
+
+// Promote returns the higher of two trust levels. Used when a file gains
+// additional trust (e.g. downloaded at TrustNone, then consensus reached).
+func (t TrustLevel) Promote(other TrustLevel) TrustLevel {
+	if other > t {
+		return other
+	}
+	return t
+}

--- a/p2p/enr/chain_toml.go
+++ b/p2p/enr/chain_toml.go
@@ -17,28 +17,35 @@ import (
 //     Matches snapcfg.Cfg.ExpectBlocks for the registry portion.
 //   - Known: all entries including those heard from peers (≥ AuthoritativeBlocks).
 //
-// These ranges are non-interleaved: authoritative entries cover blocks
-// 0..AuthoritativeBlocks, known entries extend to KnownBlocks. The receiver
-// decides its trust policy.
+// DomainSteps and MergeDepth are V2 extensions that advertise state-domain
+// coverage. Old nodes that decode only the first 3 fields will ignore the
+// extras (RLP tolerates trailing elements in lists). New nodes decoding an
+// old 3-field entry will see DomainSteps=0 and MergeDepth=0 (zero values).
 //
-// RLP encoding is positional — field names can change without breaking wire
-// compatibility, so the earlier AuthoritativeBlocks/KnownBlocks names (which were
-// misleading — they were always populated from block counts, never txNums)
-// were renamed in-place.
+// RLP encoding is positional — field order must be preserved across versions.
 type ChainToml struct {
 	AuthoritativeBlocks uint64   // max block for entries from local disk + preverified.toml
 	KnownBlocks         uint64   // max block for all entries (≥ AuthoritativeBlocks)
 	InfoHash            [20]byte // BitTorrent V1 info-hash (SHA1) of the chain.toml torrent
+	DomainSteps         uint64   // total domain steps covered (0 = V1-only, no domain data)
+	MergeDepth          uint64   // largest canonical file size in steps (0 = unknown)
 }
 
 func (v ChainToml) ENRKey() string { return "chain-toml" }
 
 // EncodeRLP implements rlp.Encoder.
 func (v ChainToml) EncodeRLP(w io.Writer) error {
-	return rlp.Encode(w, &chainTomlRLP{AuthoritativeBlocks: v.AuthoritativeBlocks, KnownBlocks: v.KnownBlocks, InfoHash: v.InfoHash})
+	return rlp.Encode(w, &chainTomlRLP{
+		AuthoritativeBlocks: v.AuthoritativeBlocks,
+		KnownBlocks:         v.KnownBlocks,
+		InfoHash:            v.InfoHash,
+		DomainSteps:         v.DomainSteps,
+		MergeDepth:          v.MergeDepth,
+	})
 }
 
-// DecodeRLP implements rlp.Decoder.
+// DecodeRLP implements rlp.Decoder. Tolerates old 3-field entries by
+// defaulting DomainSteps and MergeDepth to zero when absent.
 func (v *ChainToml) DecodeRLP(s *rlp.Stream) error {
 	var dec chainTomlRLP
 	if err := s.Decode(&dec); err != nil {
@@ -47,13 +54,18 @@ func (v *ChainToml) DecodeRLP(s *rlp.Stream) error {
 	v.AuthoritativeBlocks = dec.AuthoritativeBlocks
 	v.KnownBlocks = dec.KnownBlocks
 	v.InfoHash = dec.InfoHash
+	v.DomainSteps = dec.DomainSteps
+	v.MergeDepth = dec.MergeDepth
 	return nil
 }
 
 // chainTomlRLP is the RLP encoding helper for ChainToml. Field order must
-// match ChainToml exactly — RLP encoding is positional.
+// match ChainToml exactly — RLP encoding is positional. New fields are
+// appended at the end so old decoders can skip them gracefully.
 type chainTomlRLP struct {
 	AuthoritativeBlocks uint64
 	KnownBlocks         uint64
 	InfoHash            [20]byte
+	DomainSteps         uint64
+	MergeDepth          uint64
 }


### PR DESCRIPTION
## Summary

Foundation for decentralized snapshot distribution (#19660) and sparse snapshot loading. Adds the state model that storage uses to decide what to download, what to seed, what to advertise, and what trust level to require.

### New package: `node/components/storage/snapshot/`

**Trust model** (`trust.go`):
- `TrustLevel`: none → consensus → verified (incremental, from #19657/#19658/#19659)
- Files carry trust indicating how integrity was established
- Promotion only (never demotion): downloaded → consensus agreed → UCAN verified
- `Satisfies(required)` for consumer-side filtering

**Range arithmetic** (`ranges.go`):
- `StepRange`: half-open interval [From, To) of aggregator steps
- `StepRanges`: sorted, non-overlapping range set with:
  - Normalize, Coverage, Contains, IsComplete
  - Gaps (find uncovered ranges within a window)
  - GapsAgainst (what does a peer have that I'm missing?)
  - Union (combine two range sets)

**File inventory** (`inventory.go`):
- `FileEntry`: snapshot file with domain, step range, torrent hash, trust level, local/remote/seeding flags
- `Inventory`: thread-safe per-domain file registry
  - Coverage queries (local-only, full, or filtered by trust level)
  - Gap analysis against peer manifests
  - Atomic `ReplaceWithMerge` for merge-safe file rotation
  - `PromoteTrust` for trust ladder progression

### How it connects

- **Decentralized snapshots**: inventory is the source of truth for chain.toml generation and consumer-side gap fill
- **Sparse snapshots**: inventory tracks which step ranges are locally available for partial loading
- **Storage component**: inventory will be wired into the storage service for download/seed coordination
- **Downloader**: reads inventory to know what to seed, writes when downloads complete

## Test plan

- [x] 14 tests covering range arithmetic, inventory CRUD, trust promotion, merge rotation, local vs remote
- [x] `make lint` passes
- [x] `make erigon` builds

**Depends on:** #20526 (decentralized snapshots rebase)