### PR TITLE
execution/vm: report invalid EIP-8024 stack-op operands in ErrInvalidOpCode

### DIFF
--- a/execution/vm/errors.go
+++ b/execution/vm/errors.go
@@ -80,10 +80,16 @@ func (e *ErrStackOverflow) Error() string {
 
 // ErrInvalidOpCode wraps an evm error when an invalid opcode is encountered.
 type ErrInvalidOpCode struct {
-	opcode OpCode
+	opcode  OpCode
+	operand *byte
 }
 
-func (e *ErrInvalidOpCode) Error() string { return fmt.Sprintf("invalid opcode: %s", e.opcode) }
+func (e *ErrInvalidOpCode) Error() string {
+	if e.operand != nil {
+		return fmt.Sprintf("invalid opcode: %s (operand: 0x%02x)", e.opcode, *e.operand)
+	}
+	return fmt.Sprintf("invalid opcode: %s", e.opcode)
+}
 
 func (m *ErrInvalidOpCode) Is(target error) bool {
 	_, is := target.(*ErrInvalidOpCode)

--- a/execution/vm/instructions.go
+++ b/execution/vm/instructions.go
@@ -1429,7 +1429,8 @@ func opDupN(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) {
 
 	// This range is excluded to preserve compatibility with existing opcodes.
 	if x > 90 && x < 128 {
-		return pc, nil, &ErrInvalidOpCode{opcode: OpCode(x)}
+		operand := x
+		return pc, nil, &ErrInvalidOpCode{opcode: DUPN, operand: &operand}
 	}
 	n := decodeSingle(x)
 
@@ -1453,7 +1454,8 @@ func opSwapN(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) {
 
 	// This range is excluded to preserve compatibility with existing opcodes.
 	if x > 90 && x < 128 {
-		return pc, nil, &ErrInvalidOpCode{opcode: OpCode(x)}
+		operand := x
+		return pc, nil, &ErrInvalidOpCode{opcode: SWAPN, operand: &operand}
 	}
 	n := decodeSingle(x)
 
@@ -1478,7 +1480,8 @@ func opExchange(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error)
 	// This range is excluded both to preserve compatibility with existing opcodes
 	// and to keep decode_pair’s 16-aligned arithmetic mapping valid (0–81, 128–255).
 	if x > 81 && x < 128 {
-		return pc, nil, &ErrInvalidOpCode{opcode: OpCode(x)}
+		operand := x
+		return pc, nil, &ErrInvalidOpCode{opcode: EXCHANGE, operand: &operand}
 	}
 	n, m := decodePair(x)
 	need := max(n, m) + 1

--- a/execution/vm/instructions_test.go
+++ b/execution/vm/instructions_test.go
@@ -948,11 +948,12 @@ func TestEIP8024_Execution(t *testing.T) {
 	evm := NewEVM(evmtypes.BlockContext{}, evmtypes.TxContext{}, nil, chain.AllProtocolChanges, Config{})
 
 	tests := []struct {
-		name       string
-		codeHex    string
-		wantErr    error
-		wantOpcode OpCode
-		wantVals   []uint64
+		name        string
+		codeHex     string
+		wantErr     error
+		wantOperand *byte
+		wantOpcode  OpCode
+		wantVals    []uint64
 	}{
 		{
 			name:    "DUPN",
@@ -1000,10 +1001,18 @@ func TestEIP8024_Execution(t *testing.T) {
 			},
 		},
 		{
-			name:       "INVALID_SWAPN_LOW",
-			codeHex:    "e75b",
-			wantErr:    &ErrInvalidOpCode{},
-			wantOpcode: SWAPN,
+			name:        "INVALID_DUPN_LOW",
+			codeHex:     "e65b",
+			wantErr:     &ErrInvalidOpCode{},
+			wantOpcode:  DUPN,
+			wantOperand: ptrToByte(0x5b),
+		},
+		{
+			name:        "INVALID_SWAPN_LOW",
+			codeHex:     "e75b",
+			wantErr:     &ErrInvalidOpCode{},
+			wantOpcode:  SWAPN,
+			wantOperand: ptrToByte(0x5b),
 		},
 		{
 			name:    "JUMP over INVALID_DUPN",
@@ -1016,36 +1025,40 @@ func TestEIP8024_Execution(t *testing.T) {
 			wantErr:    &ErrStackUnderflow{},
 			wantOpcode: DUPN,
 		},
-		// Additional test cases
 		{
-			name:       "INVALID_DUPN_LOW",
-			codeHex:    "e65b",
-			wantErr:    &ErrInvalidOpCode{},
-			wantOpcode: DUPN,
+			name:        "INVALID_DUPN_LOW",
+			codeHex:     "e65b",
+			wantErr:     &ErrInvalidOpCode{},
+			wantOpcode:  DUPN,
+			wantOperand: ptrToByte(0x5b),
 		},
 		{
-			name:       "INVALID_EXCHANGE_LOW",
-			codeHex:    "e852", // 0x52 = 82, first byte in invalid range (81 < x < 128)
-			wantErr:    &ErrInvalidOpCode{},
-			wantOpcode: EXCHANGE,
+			name:        "INVALID_EXCHANGE_LOW",
+			codeHex:     "e852", // 0x52 = 82, first byte in invalid range (81 < x < 128)
+			wantErr:     &ErrInvalidOpCode{},
+			wantOpcode:  EXCHANGE,
+			wantOperand: ptrToByte(0x52),
 		},
 		{
-			name:       "INVALID_DUPN_HIGH",
-			codeHex:    "e67f",
-			wantErr:    &ErrInvalidOpCode{},
-			wantOpcode: DUPN,
+			name:        "INVALID_DUPN_HIGH",
+			codeHex:     "e67f",
+			wantErr:     &ErrInvalidOpCode{},
+			wantOpcode:  DUPN,
+			wantOperand: ptrToByte(0x7f),
 		},
 		{
-			name:       "INVALID_SWAPN_HIGH",
-			codeHex:    "e77f",
-			wantErr:    &ErrInvalidOpCode{},
-			wantOpcode: SWAPN,
+			name:        "INVALID_SWAPN_HIGH",
+			codeHex:     "e77f",
+			wantErr:     &ErrInvalidOpCode{},
+			wantOpcode:  SWAPN,
+			wantOperand: ptrToByte(0x7f),
 		},
 		{
-			name:       "INVALID_EXCHANGE_HIGH",
-			codeHex:    "e87f",
-			wantErr:    &ErrInvalidOpCode{},
-			wantOpcode: EXCHANGE,
+			name:        "INVALID_EXCHANGE_HIGH",
+			codeHex:     "e87f",
+			wantErr:     &ErrInvalidOpCode{},
+			wantOpcode:  EXCHANGE,
+			wantOperand: ptrToByte(0x7f),
 		},
 		{
 			name:       "UNDERFLOW_DUPN_2",
@@ -1124,9 +1137,20 @@ func TestEIP8024_Execution(t *testing.T) {
 				// Fail if we don't get the error we expect.
 				switch tc.wantErr.(type) {
 				case *ErrInvalidOpCode:
-					var want *ErrInvalidOpCode
-					if !errors.As(err, &want) {
+					var got *ErrInvalidOpCode
+					if !errors.As(err, &got) {
 						t.Fatalf("expected ErrInvalidOpCode, got %v", err)
+					}
+					if got.opcode != tc.wantOpcode {
+						t.Fatalf("ErrInvalidOpCode.opcode=%s; want %s", got.opcode, tc.wantOpcode)
+					}
+					if tc.wantOperand != nil {
+						if got.operand == nil {
+							t.Fatalf("ErrInvalidOpCode.operand=nil; want 0x%02x", *tc.wantOperand)
+						}
+						if *got.operand != *tc.wantOperand {
+							t.Fatalf("ErrInvalidOpCode.operand=0x%02x; want 0x%02x", *got.operand, *tc.wantOperand)
+						}
 					}
 				case *ErrStackUnderflow:
 					var want *ErrStackUnderflow
@@ -1157,4 +1181,9 @@ func TestEIP8024_Execution(t *testing.T) {
 			}
 		})
 	}
+}
+
+func ptrToByte(v byte) *byte {
+	b := v
+	return &b
 }

--- a/execution/vm/instructions_test.go
+++ b/execution/vm/instructions_test.go
@@ -1026,13 +1026,6 @@ func TestEIP8024_Execution(t *testing.T) {
 			wantOpcode: DUPN,
 		},
 		{
-			name:        "INVALID_DUPN_LOW",
-			codeHex:     "e65b",
-			wantErr:     &ErrInvalidOpCode{},
-			wantOpcode:  DUPN,
-			wantOperand: ptrToByte(0x5b),
-		},
-		{
 			name:        "INVALID_EXCHANGE_LOW",
 			codeHex:     "e852", // 0x52 = 82, first byte in invalid range (81 < x < 128)
 			wantErr:     &ErrInvalidOpCode{},


### PR DESCRIPTION
This PR improves invalid opcode reporting for the [EIP-8024](https://eips.ethereum.org/EIPS/eip-8024) stack-manipulation instructions. For `DUPN`, `SWAPN`, and `EXCHANGE`, when the immediate byte falls into an excluded range, `ErrInvalidOpCode` now preserves the parent opcode that triggered the failure and also records the offending operand byte. This makes the error more accurate and easier to diagnose, since the failure is now tied to the actual instruction family instead of the raw immediate value being interpreted as the opcode.

The accompanying tests were updated to match that behavior. They now verify not only that invalid low- and high-range immediates return `ErrInvalidOpCode`, but also that the error contains the correct opcode (DUPN, SWAPN, or EXCHANGE) and the exact invalid operand value.