### PR TITLE
execution/vm: switch modExp precompile to evmone + math/big hybrid

### DIFF
--- a/execution/vm/contracts.go
+++ b/execution/vm/contracts.go
@@ -629,9 +629,7 @@ func (c *bigModExp) Run(input []byte) ([]byte, error) {
 		baseBig := new(big.Int).SetBytes(base)
 		expBig := new(big.Int).SetBytes(exp)
 		modBig := new(big.Int).SetBytes(mod)
-		if modBig.Sign() > 0 {
-			baseBig.Exp(baseBig, expBig, modBig).FillBytes(result)
-		}
+		baseBig.Exp(baseBig, expBig, modBig).FillBytes(result)
 	default:
 		evmone.ModExp(result, base, exp, mod)
 	}

--- a/execution/vm/contracts.go
+++ b/execution/vm/contracts.go
@@ -32,7 +32,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fp"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"github.com/consensys/gnark-crypto/ecc/bn254"
-	patched_big "github.com/ethereum/go-bigmodexpfix/src/math/big"
+	"github.com/erigontech/evmone_precompiles"
 	"github.com/holiman/uint256"
 
 	"github.com/erigontech/erigon/common"
@@ -568,7 +568,6 @@ var (
 	errModExpBaseLengthTooLarge     = errors.New("base length is too large")
 	errModExpExponentLengthTooLarge = errors.New("exponent length is too large")
 	errModExpModulusLengthTooLarge  = errors.New("modulus length is too large")
-	patchedBig1                     = patched_big.NewInt(1)
 )
 
 func (c *bigModExp) Run(input []byte) ([]byte, error) {
@@ -611,24 +610,33 @@ func (c *bigModExp) Run(input []byte) ([]byte, error) {
 	} else {
 		input = input[:0]
 	}
-	// Retrieve the operands and execute the exponentiation
-	var (
-		base = new(patched_big.Int).SetBytes(getData(input, 0, baseLen))
-		exp  = new(patched_big.Int).SetBytes(getData(input, baseLen, expLen))
-		mod  = new(patched_big.Int).SetBytes(getData(input, baseLen+expLen, modLen))
-	)
 
-	// Allocate the result buffer once, zero-filled.
+	base := getData(input, 0, baseLen)
+	exp := getData(input, baseLen, expLen)
+	mod := getData(input, baseLen+expLen, modLen)
+
 	result := make([]byte, modLen)
-	switch {
-	case mod.Cmp(patchedBig1) <= 0:
-		// Leave the result as zero for mod 0 (undefined) and 1
-	case base.Cmp(patchedBig1) == 0:
-		// If base == 1 (and mod > 1), then the result is 1
-		result[modLen-1] = 1
-	default:
-		base.Exp(base, exp, mod).FillBytes(result)
+	// 1^exp % mod = 1 (for mod > 1) or 0 (for mod <= 1).
+	// Short-circuit to avoid expensive Montgomery setup.
+	if len(base) > 0 && !bitutil.TestBytes(base[:len(base)-1]) && base[len(base)-1] == 1 {
+		if bitutil.TestBytes(mod[:len(mod)-1]) || mod[len(mod)-1] > 1 {
+			result[modLen-1] = 1
+		}
+		return result, nil
 	}
+	// For small exponents (≤255) with large moduli (>256 bits), use Go's math/big
+	// directly. evmone uses Montgomery multiplication whose O(n²) setup (converting
+	// to Montgomery form) doesn't pay off when the exponent only needs a few squarings.
+	if modLen > 32 && len(exp) > 0 && !bitutil.TestBytes(exp[:len(exp)-1]) {
+		baseBig := new(big.Int).SetBytes(base)
+		expBig := new(big.Int).SetBytes(exp)
+		modBig := new(big.Int).SetBytes(mod)
+		if modBig.Sign() > 0 {
+			baseBig.Exp(baseBig, expBig, modBig).FillBytes(result)
+		}
+		return result, nil
+	}
+	evmone.ModExp(result, base, exp, mod)
 	return result, nil
 }
 

--- a/execution/vm/contracts.go
+++ b/execution/vm/contracts.go
@@ -616,27 +616,25 @@ func (c *bigModExp) Run(input []byte) ([]byte, error) {
 	mod := getData(input, baseLen+expLen, modLen)
 
 	result := make([]byte, modLen)
-	// 1^exp % mod = 1 (for mod > 1) or 0 (for mod <= 1).
-	// Short-circuit to avoid expensive Montgomery setup.
-	if len(base) > 0 && !bitutil.TestBytes(base[:len(base)-1]) && base[len(base)-1] == 1 {
+	switch {
+	case len(base) > 0 && !bitutil.TestBytes(base[:len(base)-1]) && base[len(base)-1] == 1:
+		// If base == 1 (and mod > 1), then the result is 1
 		if bitutil.TestBytes(mod[:len(mod)-1]) || mod[len(mod)-1] > 1 {
 			result[modLen-1] = 1
 		}
-		return result, nil
-	}
-	// For small exponents (≤255) with large moduli (>256 bits), use Go's math/big
-	// directly. evmone uses Montgomery multiplication whose O(n²) setup (converting
-	// to Montgomery form) doesn't pay off when the exponent only needs a few squarings.
-	if modLen > 32 && len(exp) > 0 && !bitutil.TestBytes(exp[:len(exp)-1]) {
+	case modLen > 32 && len(exp) > 0 && !bitutil.TestBytes(exp[:len(exp)-1]):
+		// For small exponents (≤255) with large moduli (>256 bits), use Go's math/big
+		// directly. evmone uses Montgomery multiplication whose O(n²) setup (converting
+		// to Montgomery form) doesn't pay off when the exponent only needs a few squarings.
 		baseBig := new(big.Int).SetBytes(base)
 		expBig := new(big.Int).SetBytes(exp)
 		modBig := new(big.Int).SetBytes(mod)
 		if modBig.Sign() > 0 {
 			baseBig.Exp(baseBig, expBig, modBig).FillBytes(result)
 		}
-		return result, nil
+	default:
+		evmone.ModExp(result, base, exp, mod)
 	}
-	evmone.ModExp(result, base, exp, mod)
 	return result, nil
 }
 

--- a/execution/vm/contracts.go
+++ b/execution/vm/contracts.go
@@ -32,7 +32,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fp"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"github.com/consensys/gnark-crypto/ecc/bn254"
-	"github.com/erigontech/evmone_precompiles"
+	evmone "github.com/erigontech/evmone_precompiles"
 	"github.com/holiman/uint256"
 
 	"github.com/erigontech/erigon/common"
@@ -615,6 +615,7 @@ func (c *bigModExp) Run(input []byte) ([]byte, error) {
 	exp := getData(input, baseLen, expLen)
 	mod := getData(input, baseLen+expLen, modLen)
 
+	// Allocate the result buffer once, zero-filled.
 	result := make([]byte, modLen)
 	switch {
 	case !bitutil.TestBytes(mod[:len(mod)-1]) && mod[len(mod)-1] <= 1:

--- a/execution/vm/contracts.go
+++ b/execution/vm/contracts.go
@@ -610,7 +610,7 @@ func (c *bigModExp) Run(input []byte) ([]byte, error) {
 	} else {
 		input = input[:0]
 	}
-
+	// Retrieve the operands and execute the exponentiation
 	base := getData(input, 0, baseLen)
 	exp := getData(input, baseLen, expLen)
 	mod := getData(input, baseLen+expLen, modLen)

--- a/execution/vm/contracts.go
+++ b/execution/vm/contracts.go
@@ -617,11 +617,11 @@ func (c *bigModExp) Run(input []byte) ([]byte, error) {
 
 	result := make([]byte, modLen)
 	switch {
+	case !bitutil.TestBytes(mod[:len(mod)-1]) && mod[len(mod)-1] <= 1:
+		// Leave the result as zero for mod 0 (undefined) and 1
 	case len(base) > 0 && !bitutil.TestBytes(base[:len(base)-1]) && base[len(base)-1] == 1:
 		// If base == 1 (and mod > 1), then the result is 1
-		if bitutil.TestBytes(mod[:len(mod)-1]) || mod[len(mod)-1] > 1 {
-			result[modLen-1] = 1
-		}
+		result[modLen-1] = 1
 	case modLen > 32 && len(exp) > 0 && !bitutil.TestBytes(exp[:len(exp)-1]):
 		// For small exponents (≤255) with large moduli (>256 bits), use Go's math/big
 		// directly. evmone uses Montgomery multiplication whose O(n²) setup (converting

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/dop251/goja v0.0.0-20230605162241-28ee0ee714f3
 	github.com/edsrzf/mmap-go v1.2.0
 	github.com/elastic/go-freelru v0.16.0
-	github.com/erigontech/evmone_precompiles v0.0.0-20260413152657-6802dc727f8d
+	github.com/erigontech/evmone_precompiles v0.0.0-20260414072133-b8b2bdc99de2
 	github.com/erigontech/fastkeccak v0.1.1-0.20260408010752-08e7b6602268
 	github.com/felixge/fgprof v0.9.5
 	github.com/go-chi/chi/v5 v5.2.3

--- a/go.mod
+++ b/go.mod
@@ -39,8 +39,8 @@ require (
 	github.com/dop251/goja v0.0.0-20230605162241-28ee0ee714f3
 	github.com/edsrzf/mmap-go v1.2.0
 	github.com/elastic/go-freelru v0.16.0
+	github.com/erigontech/evmone_precompiles v0.0.0-20260413152657-6802dc727f8d
 	github.com/erigontech/fastkeccak v0.1.1-0.20260408010752-08e7b6602268
-	github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab
 	github.com/felixge/fgprof v0.9.5
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/go-chi/cors v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -339,8 +339,8 @@ github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/erigontech/erigon-snapshot v1.3.1-0.20260402120223-7bb412bc89cd h1:wSSc83NNfqBlDArQ1ph/rFAFp6E27N2Z8WO5VIBdbC4=
 github.com/erigontech/erigon-snapshot v1.3.1-0.20260402120223-7bb412bc89cd/go.mod h1:ooHlCl+eEYzebiPu+FP6Q6SpPUeMADn8Jxabv3IKb9M=
-github.com/erigontech/evmone_precompiles v0.0.0-20260413152657-6802dc727f8d h1:d4YaLIKjpfzQeN82D52QUGh/GvtzBDapgaYJv3LBp80=
-github.com/erigontech/evmone_precompiles v0.0.0-20260413152657-6802dc727f8d/go.mod h1:WQvAqmoairhdM5RFNFDKK9oT6dzuZEbWMJH+ZdRTjP0=
+github.com/erigontech/evmone_precompiles v0.0.0-20260414072133-b8b2bdc99de2 h1:BoHriVEyPxNCO/gY+e0ZrGz0GSnAbXlXNQ7Skn907g8=
+github.com/erigontech/evmone_precompiles v0.0.0-20260414072133-b8b2bdc99de2/go.mod h1:WQvAqmoairhdM5RFNFDKK9oT6dzuZEbWMJH+ZdRTjP0=
 github.com/erigontech/fastkeccak v0.1.1-0.20260408010752-08e7b6602268 h1:NHl4+DjblLuHBJradIg9KriKmtByjRvLqLhkVODibac=
 github.com/erigontech/fastkeccak v0.1.1-0.20260408010752-08e7b6602268/go.mod h1:CwJFJVKFVWpQyKSfRrQyY56IqV16sR5xnQoFThGHiZA=
 github.com/erigontech/go-eth-kzg v0.0.0-20260401161010-070339460d07 h1:0VpFIthaJzGs3iwyrKCj67wptrNq7KKiLhilDCRPqwk=

--- a/go.sum
+++ b/go.sum
@@ -339,6 +339,8 @@ github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/erigontech/erigon-snapshot v1.3.1-0.20260402120223-7bb412bc89cd h1:wSSc83NNfqBlDArQ1ph/rFAFp6E27N2Z8WO5VIBdbC4=
 github.com/erigontech/erigon-snapshot v1.3.1-0.20260402120223-7bb412bc89cd/go.mod h1:ooHlCl+eEYzebiPu+FP6Q6SpPUeMADn8Jxabv3IKb9M=
+github.com/erigontech/evmone_precompiles v0.0.0-20260413152657-6802dc727f8d h1:d4YaLIKjpfzQeN82D52QUGh/GvtzBDapgaYJv3LBp80=
+github.com/erigontech/evmone_precompiles v0.0.0-20260413152657-6802dc727f8d/go.mod h1:WQvAqmoairhdM5RFNFDKK9oT6dzuZEbWMJH+ZdRTjP0=
 github.com/erigontech/fastkeccak v0.1.1-0.20260408010752-08e7b6602268 h1:NHl4+DjblLuHBJradIg9KriKmtByjRvLqLhkVODibac=
 github.com/erigontech/fastkeccak v0.1.1-0.20260408010752-08e7b6602268/go.mod h1:CwJFJVKFVWpQyKSfRrQyY56IqV16sR5xnQoFThGHiZA=
 github.com/erigontech/go-eth-kzg v0.0.0-20260401161010-070339460d07 h1:0VpFIthaJzGs3iwyrKCj67wptrNq7KKiLhilDCRPqwk=
@@ -347,8 +349,6 @@ github.com/erigontech/mdbx-go v0.39.12 h1:WjvPzloxXOYfRamIxt8NOB7i3/M8cSCSfWQHvM
 github.com/erigontech/mdbx-go v0.39.12/go.mod h1:tHUS492F5YZvccRqatNdpTDQAaN+Vv4HRARYq89KqeY=
 github.com/erigontech/secp256k1 v1.2.1-0.20260218182123-377cc1bd6410 h1:5YD7JJ5PaqOdjKA84lTDtQby9nbI4podqrkUhyIyFDw=
 github.com/erigontech/secp256k1 v1.2.1-0.20260218182123-377cc1bd6410/go.mod h1:CnigLRUsfobnTYoUzwdT/De67fw9OhTA0KTkxa+svik=
-github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab h1:rvv6MJhy07IMfEKuARQ9TKojGqLVNxQajaXEp/BoqSk=
-github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab/go.mod h1:IuLm4IsPipXKF7CW5Lzf68PIbZ5yl7FFd74l/E0o9A8=
 github.com/ettle/strcase v0.2.0 h1:fGNiVF21fHXpX1niBgk0aROov1LagYsOwV/xqKDKR/Q=
 github.com/ettle/strcase v0.2.0/go.mod h1:DajmHElDSaX76ITe3/VHVyMin4LWSJN5Z909Wp+ED1A=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=


### PR DESCRIPTION
## Summary
- Use evmone's C++ Montgomery multiplication for large exponents
- Use Go's `math/big` for small exponents (≤255) with large moduli (>256 bits), where Montgomery setup cost dominates
- Short-circuit `base == 1`
- Drop `go-bigmodexpfix` dependency
- Depends on erigontech/evmone_precompiles#4

## Benchmarks

Apple M2 Max, `go test -bench -count=5`, back-to-back (main first, then feature branch).

### All results (mgas/s, higher is better) — no regressions

```
                              main mgas/s   evmone mgas/s
Large exponents (→ evmone Montgomery):
  nagydani-1-pow0x10001            975          1513       +55%
  nagydani-2-pow0x10001           1134          1730       +53%
  nagydani-3-pow0x10001           1034          1433       +39%
  nagydani-4-pow0x10001            774          1051       +36%
  nagydani-5-pow0x10001            623           777       +25%
  eip_example1                     559           793       +42%

Small exponents (→ math/big fast path):
  nagydani-2-square                715           734        +3%
  nagydani-3-square                924           928         ~
  nagydani-4-square               1023          1050        +3%
  nagydani-5-square               1117          1139        +2%
  mod-1024-exp-2                   207           208         ~

256-bit (→ evmone specialized mul_amm_256):
  nagydani-1-square                379           406        +7%
  nagydani-1-qube                  263           266        +1%

base == 1 short-circuit:
  guido-4-even                    6285         15631      +149%
```

### BenchmarkEngineXPrecompile/modexp (representative workload mix)

```
main:    81.46s
evmone:  70.83s    -13%
```

## Test plan
- [x] `TestPrecompiledModExp` — all passing
- [x] `TestPrecompiledModExpEIP2565` — all passing
- [x] `TestPrecompiledModExpOOG` — all passing
- [ ] Full CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)