### PR TITLE
caplin: fix peerdas gossip init order to eliminate false warning

### DIFF
--- a/cmd/caplin/caplin1/run.go
+++ b/cmd/caplin/caplin1/run.go
@@ -370,8 +370,6 @@ func RunCaplinService(ctx context.Context, engine execution_client.ExecutionEngi
 	peerDasState.SetLocalNodeID(localNode)
 	beaconRpc := rpc.NewBeaconRpcP2P(ctx, sentinel, beaconConfig, ethClock, state)
 	gossipManager.SetPeerBanner(beaconRpc)
-	peerDas := das.NewPeerDas(ctx, beaconRpc, beaconConfig, &config, columnStorage, blobStorage, sentinel, localNode.ID(), ethClock, peerDasState, gossipManager)
-	forkChoice.InitPeerDas(peerDas) // hack init
 	committeeSub := committee_subscription.NewCommitteeSubscribeManagement(ctx, beaconConfig, networkConfig, ethClock, aggregationPool, syncedDataManager, gossipManager)
 	batchSignatureVerifier := services.NewBatchSignatureVerifier(ctx, sentinel)
 	// Define gossip services
@@ -402,6 +400,10 @@ func RunCaplinService(ctx context.Context, engine execution_client.ExecutionEngi
 		blsToExecutionChangeService,
 		proposerSlashingService,
 	)
+
+	// Create PeerDas after gossip topics are registered so that resubscribeGossip() finds them.
+	peerDas := das.NewPeerDas(ctx, beaconRpc, beaconConfig, &config, columnStorage, blobStorage, sentinel, localNode.ID(), ethClock, peerDasState, gossipManager)
+	forkChoice.InitPeerDas(peerDas) // hack init
 
 	{
 		go batchSignatureVerifier.Start()


### PR DESCRIPTION
## Summary
- Move `NewPeerDas()` after `RegisterGossipServices()` so gossip topics are already registered when `resubscribeGossip()` runs
- Eliminates the spurious `[peerdas] failed to subscribe to column sidecar subnet err="topic not found"` warnings on every startup
- No API changes — pure init reorder; the existing `toSubscribes` recovery mechanism remains as a safety net

## Test plan
- [x] `make erigon` builds successfully
- [ ] Start node and verify no more `[peerdas] failed to subscribe to column sidecar subnet` warnings at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)