### PR TITLE
[r3.4] caplin: fix peerdas gossip init order to eliminate false warning

### DIFF
--- a/cmd/caplin/caplin1/run.go
+++ b/cmd/caplin/caplin1/run.go
@@ -367,8 +367,6 @@ func RunCaplinService(ctx context.Context, engine execution_client.ExecutionEngi
 	peerDasState.SetLocalNodeID(localNode)
 	beaconRpc := rpc.NewBeaconRpcP2P(ctx, sentinel, beaconConfig, ethClock, state)
 	gossipManager.SetPeerBanner(beaconRpc)
-	peerDas := das.NewPeerDas(ctx, beaconRpc, beaconConfig, &config, columnStorage, blobStorage, sentinel, localNode.ID(), ethClock, peerDasState, gossipManager)
-	forkChoice.InitPeerDas(peerDas) // hack init
 	committeeSub := committee_subscription.NewCommitteeSubscribeManagement(ctx, beaconConfig, networkConfig, ethClock, aggregationPool, syncedDataManager, gossipManager)
 	batchSignatureVerifier := services.NewBatchSignatureVerifier(ctx, sentinel)
 	// Define gossip services
@@ -399,6 +397,10 @@ func RunCaplinService(ctx context.Context, engine execution_client.ExecutionEngi
 		blsToExecutionChangeService,
 		proposerSlashingService,
 	)
+
+	// Create PeerDas after gossip topics are registered so that resubscribeGossip() finds them.
+	peerDas := das.NewPeerDas(ctx, beaconRpc, beaconConfig, &config, columnStorage, blobStorage, sentinel, localNode.ID(), ethClock, peerDasState, gossipManager)
+	forkChoice.InitPeerDas(peerDas) // hack init
 
 	{
 		go batchSignatureVerifier.Start()


### PR DESCRIPTION
Cherry-pick of https://github.com/erigontech/erigon/pull/20538