### PR TITLE
commitment, execctx: fix InsertBlocks failure during block catch-up

### DIFF
--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -33,6 +33,7 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/membatchwithdb"
 	"github.com/erigontech/erigon/db/kv/order"
+	"github.com/erigontech/erigon/db/kv/rawdbv3"
 	"github.com/erigontech/erigon/db/state/changeset"
 	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/diagnostics/metrics"
@@ -76,11 +77,13 @@ type accHolder interface {
 
 func IsDomainAheadOfBlocks(ctx context.Context, tx kv.TemporalRwTx, logger log.Logger) bool {
 	doms, err := NewSharedDomains(ctx, tx, logger)
+	if doms != nil {
+		defer doms.Close()
+	}
 	if err != nil {
 		logger.Debug("domain ahead of blocks", "err", err, "stack", dbg.Stack())
 		return errors.Is(err, commitmentdb.ErrBehindCommitment)
 	}
-	defer doms.Close()
 	return false
 }
 
@@ -138,8 +141,20 @@ func NewSharedDomainsWithTrieVariant(ctx context.Context, tx kv.TemporalTx, logg
 	sd.mem = tx.Debug().NewMemBatch(&sd.metrics)
 	sd.sdCtx = commitmentdb.NewSharedDomainsCommitmentContext(sd, commitment.ModeDirect, tv, tx.Debug().Dirs().Tmp)
 
-	if _, _, err := sd.SeekCommitment(ctx, tx); err != nil {
+	_, blockNum, err := sd.SeekCommitment(ctx, tx)
+	if err != nil {
 		return sd, err
+	}
+
+	// ErrBehindCommitment is an environmental signal; sd is fully initialized.
+	if blockNum > 0 {
+		lastBn, _, err := rawdbv3.TxNums.Last(tx)
+		if err != nil {
+			return sd, err
+		}
+		if lastBn < blockNum {
+			return sd, fmt.Errorf("%w: TxNums index is at block %d and behind commitment %d", commitmentdb.ErrBehindCommitment, lastBn, blockNum)
+		}
 	}
 
 	return sd, nil

--- a/db/state/execctx/domain_shared_test.go
+++ b/db/state/execctx/domain_shared_test.go
@@ -170,6 +170,79 @@ Loop:
 	goto Loop
 }
 
+// TestNewSharedDomains_StateAheadOfBlocks verifies that when the persisted
+// commitment state is ahead of the TxNums index (catch-up scenario),
+// NewSharedDomains returns ErrBehindCommitment but the SharedDomains itself
+// is fully initialized (txNum set, patricia trie restored). Catch-up handlers
+// like ExecModule.InsertBlocks and forkchoice rely on receiving a usable SD
+// alongside the signal error.
+func TestNewSharedDomains_StateAheadOfBlocks(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
+	stepSize := uint64(8)
+	require := require.New(t)
+	db := newTestDb(t, stepSize)
+
+	ctx := context.Background()
+
+	// Phase 1: write some accounts, compute commitment, flush, and append TxNums up to block N.
+	rwTx, err := db.BeginTemporalRw(ctx)
+	require.NoError(err)
+	defer rwTx.Rollback()
+
+	const lastBlock = uint64(10)
+	for blockNum := uint64(0); blockNum <= lastBlock; blockNum++ {
+		maxTxNum := blockNum*2 + 1
+		require.NoError(rawdbv3.TxNums.Append(rwTx, blockNum, maxTxNum))
+	}
+
+	doms, err := execctx.NewSharedDomains(ctx, rwTx, log.New())
+	require.NoError(err)
+
+	addr := make([]byte, length.Addr)
+	for i := uint64(0); i < 4; i++ {
+		addr[0] = byte(i)
+		acc := accounts.Account{
+			Nonce:   i,
+			Balance: *uint256.NewInt(i + 1),
+		}
+		require.NoError(doms.DomainPut(kv.AccountsDomain, rwTx, addr, accounts3.SerialiseV3(&acc), uint64(i), nil))
+	}
+	commitTxNum := lastBlock*2 + 1
+	_, err = doms.ComputeCommitment(ctx, rwTx, true, lastBlock, commitTxNum, "", nil)
+	require.NoError(err)
+	require.NoError(doms.Flush(ctx, rwTx))
+	doms.Close()
+	require.NoError(rwTx.Commit())
+
+	// Phase 2: truncate TxNums so that lastBn < commitment block — this is the
+	// "state ahead of blocks" condition.
+	rwTx, err = db.BeginTemporalRw(ctx)
+	require.NoError(err)
+	defer rwTx.Rollback()
+	require.NoError(rawdbv3.TxNums.Truncate(rwTx, lastBlock-3))
+	lastBn, _, err := rawdbv3.TxNums.Last(rwTx)
+	require.NoError(err)
+	require.Less(lastBn, lastBlock, "TxNums must be behind commitment block for the test to be meaningful")
+
+	// Phase 3: NewSharedDomains must return ErrBehindCommitment AND a fully-initialized SD.
+	doms, err = execctx.NewSharedDomains(ctx, rwTx, log.New())
+	require.ErrorIs(err, commitmentdb.ErrBehindCommitment, "expected ErrBehindCommitment signal")
+	require.NotNil(doms, "SD must be returned alongside the signal error")
+	defer doms.Close()
+
+	// SD is fully initialized: txNum set to commitment-state's txNum.
+	require.Equal(commitTxNum, doms.TxNum(), "SD txNum must be set to the commitment state's txNum (full restore)")
+
+	// Basic domain reads work — no panic, no nil deref.
+	addr[0] = 0
+	_, _, err = doms.GetLatest(kv.AccountsDomain, rwTx, addr)
+	require.NoError(err)
+}
+
 func TestSharedDomain_StorageIter(t *testing.T) {
 	if testing.Short() {
 		t.Skip()

--- a/execution/commitment/commitmentdb/commitment_context.go
+++ b/execution/commitment/commitmentdb/commitment_context.go
@@ -611,15 +611,6 @@ func (sdc *SharedDomainsCommitmentContext) SeekCommitment(ctx context.Context, t
 		if err != nil {
 			return 0, 0, err
 		}
-		if blockNum > 0 {
-			lastBn, _, err := rawdbv3.TxNums.Last(tx)
-			if err != nil {
-				return 0, 0, err
-			}
-			if lastBn < blockNum {
-				return 0, 0, fmt.Errorf("%w: TxNums index is at block %d and behind commitment %d", ErrBehindCommitment, lastBn, blockNum)
-			}
-		}
 		if err = sdc.enableConcurrentCommitmentIfPossible(); err != nil {
 			return 0, 0, err
 		}

--- a/execution/execmodule/inserters.go
+++ b/execution/execmodule/inserters.go
@@ -18,11 +18,13 @@ package execmodule
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 
 	"github.com/erigontech/erigon/db/rawdb"
 	"github.com/erigontech/erigon/db/state/execctx"
+	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
 	"github.com/erigontech/erigon/execution/metrics"
 	"github.com/erigontech/erigon/execution/types"
 )
@@ -48,8 +50,12 @@ func (e *ExecModule) InsertBlocks(ctx context.Context, blocks []*types.RawBlock)
 	sd := e.currentContext
 	if sd == nil {
 		sd, err = execctx.NewSharedDomains(ctx, roTx, e.logger)
+		// ErrBehindCommitment is tolerated: sd is usable, catch-up drives txNums forward.
 		if err != nil {
-			return 0, fmt.Errorf("ethereumExecutionModule.InsertBlocks: could not create shared domains: %s", err)
+			if !errors.Is(err, commitmentdb.ErrBehindCommitment) {
+				return 0, fmt.Errorf("ethereumExecutionModule.InsertBlocks: could not create shared domains: %s", err)
+			}
+			e.logger.Info("ethereumExecutionModule.InsertBlocks: state ahead of blocks, proceeding with catch-up", "err", err)
 		}
 		e.lock.Lock()
 		e.currentContext = sd


### PR DESCRIPTION
## Summary

Fixes a chicken-and-egg failure where `ExecModule.InsertBlocks` refuses to run during block catch-up, because `NewSharedDomains` returned `ErrBehindCommitment` when the persisted commitment state was ahead of the `TxNums` index:

```
ethereumExecutionModule.InsertBlocks: could not create shared domains:
behind commitment: TxNums index is at block 2579999 and behind commitment 2584312
```

The node is precisely in this state because it needs to download the missing blocks via `InsertBlocks` — but the call bails out before any block can be written. `InsertBlocks` didn't handle `ErrBehindCommitment` separately, so catch-up couldn't make progress.

## Framing

`ErrBehindCommitment` is a statement about **the environment** (TxNums index is behind commitment), not about SharedDomains itself. `SharedDomains` has no trouble initialising in the state-ahead-of-blocks scenario — the patricia trie, `txNum`, and concurrent-commitment setup can all be restored from the persisted commitment state normally. Arguably, `NewSharedDomains` returning an error at all for an environmental condition is itself anti-pattern; callers could just probe the environment directly. **This PR keeps the error to minimise the change surface** — the error stays as a signal for the handful of callers that already use it — but reworks where the check lives so the SD is fully initialised before the error fires.

## What changed

- `SeekCommitment` no longer performs the state-ahead check — it just restores and returns. The check is an environmental probe, not a restoration concern, so it doesn't belong in that method.
- `NewSharedDomainsWithTrieVariant` probes `TxNums.Last` against the restored commitment block after `SeekCommitment` and returns `(sd, ErrBehindCommitment)` when state is ahead. The SD is reliably fully-initialised in that case.
- `InsertBlocks` treats `ErrBehindCommitment` as a non-fatal signal — block metadata writes into the overlay proceed with the fully-initialised SD, letting catch-up drive forward. `AppendCanonicalTxNums` (in the FCU path) advances `TxNums` each cycle until it catches up to commitment, after which the signal stops firing.

## What didn't change

- All ~45 non-handler callers of `NewSharedDomains` (RPC paths, block builder, receipts generator, stage tools, integration commands) still fail-fast on `ErrBehindCommitment` — we do **not** silently switch them to operate against a state-ahead SD (would be unsafe: `eth_call` returning state from beyond canonical head, builder building on advanced state, receipts re-executed against wrong state).
- The 5 other handler callers (`forkchoice.go:209`, `IsDomainAheadOfBlocks`, `executor.go:207`, `stageloop.go:150`, `sync.go:143`) keep the same `errors.Is(err, ErrBehindCommitment)` idiom. No behaviour change at those sites.

## Test plan

- [x] `make lint` — 0 issues
- [x] `go test -count=1 ./execution/commitment/... ./db/state/execctx/... ./execution/execmodule/...` — all pass
- [x] New unit test `TestNewSharedDomains_StateAheadOfBlocks`: asserts `NewSharedDomains` returns `(sd, ErrBehindCommitment)` with `sd != nil` and `sd.TxNum() == commitTxNum` (fully restored) when commitment block > `TxNums.Last()`
- [x] End-to-end on `/erigon-data/hoodi_arch_1_1_1`: ~35K blocks past the previously-stuck point, 0 `behind commitment` warnings, no panics
- [x] End-to-end on `/erigon-data/hoodi_arch_1_2`: ~19K blocks crossing the same 2580000+ boundary where the bug manifests, 0 warnings
- [ ] `make test-all` (CI)