### PR TITLE
gossip, forkchoice: fix mutex leak in topic subscription and nil peerDas guards

### DIFF
--- a/cl/phase1/forkchoice/on_block.go
+++ b/cl/phase1/forkchoice/on_block.go
@@ -111,14 +111,16 @@ func (f *ForkChoiceStore) OnBlock(ctx context.Context, block *cltypes.SignedBeac
 	var versionedHashes []common.Hash
 	if newPayload && f.engine != nil && block.Version() >= clparams.DenebVersion {
 		versionedHashes = []common.Hash{}
-		solid.RangeErr[*cltypes.KZGCommitment](block.Block.Body.BlobKzgCommitments, func(i1 int, k *cltypes.KZGCommitment, i2 int) error {
+		if err := solid.RangeErr[*cltypes.KZGCommitment](block.Block.Body.BlobKzgCommitments, func(i1 int, k *cltypes.KZGCommitment, i2 int) error {
 			versionedHash, err := utils.KzgCommitmentToVersionedHash(common.Bytes48(*k))
 			if err != nil {
 				return err
 			}
 			versionedHashes = append(versionedHashes, versionedHash)
 			return nil
-		})
+		}); err != nil {
+			return err
+		}
 	}
 
 	elHasBlobs := false

--- a/cl/phase1/forkchoice/on_block.go
+++ b/cl/phase1/forkchoice/on_block.go
@@ -122,7 +122,7 @@ func (f *ForkChoiceStore) OnBlock(ctx context.Context, block *cltypes.SignedBeac
 	}
 
 	elHasBlobs := false
-	if f.engine != nil && checkDataAvaiability && block.Block.Body.BlobKzgCommitments.Len() > 0 && !f.peerDas.IsArchivedMode() {
+	if f.engine != nil && f.peerDas != nil && checkDataAvaiability && block.Block.Body.BlobKzgCommitments.Len() > 0 && !f.peerDas.IsArchivedMode() {
 		blobsWithProof, proofs, err := f.engine.GetBlobs(ctx, versionedHashes, block.Version())
 		if err != nil {
 			log.Warn("OnBlock: GetBlobs failed", "blockRoot", common.Hash(blockRoot), "err", err)
@@ -133,7 +133,7 @@ func (f *ForkChoiceStore) OnBlock(ctx context.Context, block *cltypes.SignedBeac
 
 	// Check if blob data is available (skip if blobs are in txpool)
 	if checkDataAvaiability && block.Block.Body.BlobKzgCommitments.Len() > 0 && !elHasBlobs {
-		if block.Version() >= clparams.FuluVersion {
+		if block.Version() >= clparams.FuluVersion && f.peerDas != nil {
 			available, err := f.peerDas.IsDataAvailable(block.Block.Slot, blockRoot)
 			if err != nil {
 				return err
@@ -330,10 +330,12 @@ func (f *ForkChoiceStore) OnBlock(ctx context.Context, block *cltypes.SignedBeac
 		log.Debug("OnBlock", "elapsed", time.Since(start), "slot", block.Block.Slot)
 	}
 
-	if connectedValidators := f.localValidators.GetValidators(); len(connectedValidators) > 0 {
-		// update the custody requirement whenever we see a new block
-		custodyRequirement := state.GetValidatorsCustodyRequirement(lastProcessedState, connectedValidators)
-		f.peerDas.UpdateValidatorsCustody(custodyRequirement)
+	if f.peerDas != nil {
+		if connectedValidators := f.localValidators.GetValidators(); len(connectedValidators) > 0 {
+			// update the custody requirement whenever we see a new block
+			custodyRequirement := state.GetValidatorsCustodyRequirement(lastProcessedState, connectedValidators)
+			f.peerDas.UpdateValidatorsCustody(custodyRequirement)
+		}
 	}
 	return nil
 }

--- a/cl/phase1/network/gossip/gossip_subscription.go
+++ b/cl/phase1/network/gossip/gossip_subscription.go
@@ -59,7 +59,7 @@ func (t *TopicSubscriptions) Get(topic string) *TopicSubscription {
 }
 
 func (t *TopicSubscriptions) Add(topic string, topicHandle *pubsub.Topic, validator pubsub.ValidatorEx) error {
-	deferredExpiry, ok, err := t.addLocked(topic, topicHandle, validator)
+	deferredExpiry, ok, err := t.addInternal(topic, topicHandle, validator)
 	if err != nil {
 		return err
 	}
@@ -69,7 +69,7 @@ func (t *TopicSubscriptions) Add(topic string, topicHandle *pubsub.Topic, valida
 	return nil
 }
 
-func (t *TopicSubscriptions) addLocked(topic string, topicHandle *pubsub.Topic, validator pubsub.ValidatorEx) (deferredExpiry time.Time, hasDeferredExpiry bool, err error) {
+func (t *TopicSubscriptions) addInternal(topic string, topicHandle *pubsub.Topic, validator pubsub.ValidatorEx) (deferredExpiry time.Time, hasDeferredExpiry bool, err error) {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 

--- a/cl/phase1/network/gossip/gossip_subscription.go
+++ b/cl/phase1/network/gossip/gossip_subscription.go
@@ -6,10 +6,11 @@ import (
 	"sync"
 	"time"
 
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+
 	"github.com/erigontech/erigon/cl/gossip"
 	"github.com/erigontech/erigon/cl/p2p"
 	"github.com/erigontech/erigon/common/log/v3"
-	pubsub "github.com/libp2p/go-libp2p-pubsub"
 )
 
 var (
@@ -58,9 +59,22 @@ func (t *TopicSubscriptions) Get(topic string) *TopicSubscription {
 }
 
 func (t *TopicSubscriptions) Add(topic string, topicHandle *pubsub.Topic, validator pubsub.ValidatorEx) error {
+	deferredExpiry, ok, err := t.addLocked(topic, topicHandle, validator)
+	if err != nil {
+		return err
+	}
+	if ok {
+		return t.SubscribeWithExpiry(topic, deferredExpiry)
+	}
+	return nil
+}
+
+func (t *TopicSubscriptions) addLocked(topic string, topicHandle *pubsub.Topic, validator pubsub.ValidatorEx) (deferredExpiry time.Time, hasDeferredExpiry bool, err error) {
 	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
 	if _, ok := t.subs[topic]; ok {
-		return errors.New("topic already exists")
+		return time.Time{}, false, errors.New("topic already exists")
 	}
 	t.subs[topic] = &TopicSubscription{
 		topic:     topicHandle,
@@ -70,11 +84,9 @@ func (t *TopicSubscriptions) Add(topic string, topicHandle *pubsub.Topic, valida
 	}
 	if expiry, ok := t.toSubscribes[topic]; ok {
 		delete(t.toSubscribes, topic)
-		t.mutex.Unlock()
-		return t.SubscribeWithExpiry(topic, expiry)
+		return expiry, true, nil
 	}
-	t.mutex.Unlock()
-	return nil
+	return time.Time{}, false, nil
 }
 
 func (t *TopicSubscriptions) Remove(topic string) error {


### PR DESCRIPTION
## Summary
- Fix mutex leak in `TopicSubscriptions.Add()` — when a duplicate topic was added, the function returned an error without unlocking the mutex, deadlocking the entire gossip system. Extract `addInternal()` helper that uses `defer` to guarantee unlock on all paths.
- Add nil guards for `f.peerDas` in `OnBlock` to prevent nil-pointer panics if `OnBlock` runs before the hack-init `InitPeerDas()` call.
- Fix discarded `solid.RangeErr` return value when computing versioned hashes — error was silently ignored.