### PR TITLE
ci: remove flaky eoa-transactions-test from caplin-minimal suite

### DIFF
--- a/.github/workflows/kurtosis/caplin-minimal-assertoor.io
+++ b/.github/workflows/kurtosis/caplin-minimal-assertoor.io
@@ -20,5 +20,10 @@ assertoor_params:
   tests:
     - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/synchronized-check.yaml
     - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/block-proposal-check.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/eoa-transactions-test.yaml
+    # eoa-transactions-test omitted: the upstream test uses 100 child wallets
+    # per phase, which is too aggressive for a single-node minimal-preset
+    # environment. The legacy phase drains child wallet balances, causing the
+    # subsequent dynfee phase to fail with "insufficient funds" (maxFeePerGas *
+    # gasLimit exceeds remaining balance). EOA transactions are already covered
+    # by the regular assertoor suite.
     - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/stability-check.yaml


### PR DESCRIPTION
## Summary
- Remove the upstream `eoa-transactions-test` from the caplin-minimal kurtosis suite to fix intermittent CI failures
- The test uses 100 child wallets per phase, which is too aggressive for a single-node minimal-preset environment: the legacy phase drains child wallet balances, and the dynfee phase then fails with `insufficient funds` (every block has 0 transactions for 30 minutes until timeout)
- EOA transaction coverage is already provided by the `regular` assertoor suite

## Root cause
The `eoa-transactions-test.yaml` runs legacy then dynfee EOA phases reusing the same child wallets. In caplin-minimal (one node, minimal preset):
1. Legacy phase foreground check passes almost instantly, canceling the background generator mid-funding
2. Child wallets end up with ~0.998 ETH
3. Dynfee phase immediately gets `INTERNAL_ERROR: insufficient funds` because EIP-1559 validation (`maxFeePerGas * gasLimit + value`) exceeds remaining balance
4. Zero transactions are included in blocks 22–310 for 30 minutes until the test times out

Confirmed flaky: a retry on the same commit passes.

## Test plan
- [ ] CI `kurtosis / assertoor_caplin-minimal_test` passes without the problematic test
- [ ] `regular` suite still includes `eoa-transactions-test` for EOA coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)