### PR TITLE
QA: re-enable debug_accountRange and debug_storageRangeAt RPC integration tests

### DIFF
--- a/.github/workflows/scripts/run_rpc_tests_ethereum.sh
+++ b/.github/workflows/scripts/run_rpc_tests_ethereum.sh
@@ -26,10 +26,6 @@ DISABLED_TEST_LIST=(
   eth_getTransactionByHash/test_02.json
   # Small prune issue that leads to wrong ReceiptDomain data at 16999999 (probably at every million) block: https://github.com/erigontech/erigon/issues/13050
   ots_searchTransactionsBefore/test_04.tar
-  # Temporary disable needs to debug
-  debug_accountRange/test_05.json
-  debug_accountRange/test_25.json
-  debug_storageRangeAt/test_01.json
   # Temporary disable required block 23917742
   debug_traceTransaction/test_149.json
   eth_getWork/test_01.json


### PR DESCRIPTION
## Summary

- Re-enables the 3 RPC integration tests disabled in #20433 to check whether they are still flaky on the CI runner
- Related issue: #20428

## Context

The tests (`debug_accountRange/test_05`, `debug_accountRange/test_25`, `debug_storageRangeAt/test_01`) were disabled because they intermittently failed due to a history gap after snapshot merges on the CI runner's datadir. This PR re-enables them to observe current CI behavior.

Manually dispatched **QA - RPC Integration Tests** workflow on this branch: https://github.com/erigontech/erigon/actions/runs/24403041584

## Test plan

- [ ] Watch the dispatched RPC integration test run for pass/fail on the 3 re-enabled tests


🤖 Generated with [Claude Code](https://claude.com/claude-code)