### PR TITLE
`downloader torrent_hashes --diff`

### DIFF
--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -161,8 +161,8 @@ type IntraBlockState struct {
 
 	nilAccounts map[accounts.Address]struct{} // Remember non-existent account to avoid reading them again
 
-	// Per-block intern caches: memoize unique.Make results so the global
-	// concurrent intern table is hit at most once per unique key/address per block.
+	// Per-transaction intern caches: memoize unique.Make results so the global
+	// concurrent intern table is hit at most once per unique key/address per transaction.
 	keyCache  map[common.Hash]accounts.StorageKey
 	addrCache map[common.Address]accounts.Address
 
@@ -2200,10 +2200,10 @@ func (sdb *IntraBlockState) Prepare(rules *chain.Rules, sender, coinbase account
 			al.AddAddress(addr)
 		}
 		for _, el := range list {
-			address := accounts.InternAddress(el.Address)
+			address := sdb.InternAddress(el.Address)
 			al.AddAddress(address)
 			for _, key := range el.StorageKeys {
-				al.AddSlot(address, accounts.InternKey(key))
+				al.AddSlot(address, sdb.InternKey(key))
 			}
 		}
 		if rules.IsShanghai { // EIP-3651: warm coinbase
@@ -2233,7 +2233,7 @@ func (sdb *IntraBlockState) Prepare(rules *chain.Rules, sender, coinbase account
 }
 
 // InternKey returns a cached accounts.StorageKey for k, calling the global intern
-// at most once per unique key per block.
+// at most once per unique key per transaction.
 func (sdb *IntraBlockState) InternKey(k common.Hash) accounts.StorageKey {
 	if h, ok := sdb.keyCache[k]; ok {
 		return h
@@ -2244,7 +2244,7 @@ func (sdb *IntraBlockState) InternKey(k common.Hash) accounts.StorageKey {
 }
 
 // InternAddress returns a cached accounts.Address for a, calling the global intern
-// at most once per unique address per block.
+// at most once per unique address per transaction.
 func (sdb *IntraBlockState) InternAddress(a common.Address) accounts.Address {
 	if h, ok := sdb.addrCache[a]; ok {
 		return h

--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -161,6 +161,11 @@ type IntraBlockState struct {
 
 	nilAccounts map[accounts.Address]struct{} // Remember non-existent account to avoid reading them again
 
+	// Per-block intern caches: memoize unique.Make results so the global
+	// concurrent intern table is hit at most once per unique key/address per block.
+	keyCache  map[common.Hash]accounts.StorageKey
+	addrCache map[common.Address]accounts.Address
+
 	// The refund counter, also used by state transitioning.
 	refund mdgas.MdGas
 
@@ -208,6 +213,8 @@ func New(stateReader StateReader) *IntraBlockState {
 		stateObjects:      map[accounts.Address]*stateObject{},
 		stateObjectsDirty: map[accounts.Address]struct{}{},
 		nilAccounts:       map[accounts.Address]struct{}{},
+		keyCache:          make(map[common.Hash]accounts.StorageKey),
+		addrCache:         make(map[common.Address]accounts.Address),
 		logs:              []types.Logs{},
 		journal:           newJournal(),
 		accessList:        accessList{addresses: make(map[accounts.Address]int)},
@@ -379,6 +386,8 @@ func (sdb *IntraBlockState) Reset() {
 	sdb.codeReadDuration = 0
 	sdb.codeReadCount = 0
 	sdb.dep = UnknownDep
+	clear(sdb.keyCache)
+	clear(sdb.addrCache)
 }
 
 // Release returns pooled resources (like journal, stateObjects) back to their pools.
@@ -2221,6 +2230,28 @@ func (sdb *IntraBlockState) Prepare(rules *chain.Rules, sender, coinbase account
 	sdb.addressAccess = make(map[accounts.Address]*accessOptions)
 	sdb.recordAccess = true
 	return nil
+}
+
+// InternKey returns a cached accounts.StorageKey for k, calling the global intern
+// at most once per unique key per block.
+func (sdb *IntraBlockState) InternKey(k common.Hash) accounts.StorageKey {
+	if h, ok := sdb.keyCache[k]; ok {
+		return h
+	}
+	h := accounts.InternKey(k)
+	sdb.keyCache[k] = h
+	return h
+}
+
+// InternAddress returns a cached accounts.Address for a, calling the global intern
+// at most once per unique address per block.
+func (sdb *IntraBlockState) InternAddress(a common.Address) accounts.Address {
+	if h, ok := sdb.addrCache[a]; ok {
+		return h
+	}
+	h := accounts.InternAddress(a)
+	sdb.addrCache[a] = h
+	return h
 }
 
 // AddAddressToAccessList adds the given address to the access list

--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -2203,7 +2203,7 @@ func (sdb *IntraBlockState) Prepare(rules *chain.Rules, sender, coinbase account
 			address := sdb.InternAddress(el.Address)
 			al.AddAddress(address)
 			for _, key := range el.StorageKeys {
-				al.AddSlot(address, sdb.InternKey(key))
+				al.AddSlot(address, sdb.InternStorage(key))
 			}
 		}
 		if rules.IsShanghai { // EIP-3651: warm coinbase
@@ -2232,9 +2232,9 @@ func (sdb *IntraBlockState) Prepare(rules *chain.Rules, sender, coinbase account
 	return nil
 }
 
-// InternKey returns a cached accounts.StorageKey for k, calling the global intern
+// InternStorage returns a cached accounts.StorageKey for k, calling the global intern
 // at most once per unique key per transaction.
-func (sdb *IntraBlockState) InternKey(k common.Hash) accounts.StorageKey {
+func (sdb *IntraBlockState) InternStorage(k common.Hash) accounts.StorageKey {
 	if h, ok := sdb.keyCache[k]; ok {
 		return h
 	}

--- a/execution/vm/eips.go
+++ b/execution/vm/eips.go
@@ -27,7 +27,6 @@ import (
 	"github.com/holiman/uint256"
 
 	"github.com/erigontech/erigon/execution/protocol/params"
-	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
 var activators = map[int]func(*JumpTable){
@@ -205,7 +204,7 @@ func enable1153(jt *JumpTable) {
 // opTload implements TLOAD opcode
 func opTload(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) {
 	loc := scope.Stack.peek()
-	key := accounts.InternKey(loc.Bytes32())
+	key := evm.IntraBlockState().InternKey(loc.Bytes32())
 	val := evm.IntraBlockState().GetTransientState(scope.Contract.Address(), key)
 	*loc = val
 	return pc, nil, nil
@@ -218,7 +217,7 @@ func opTstore(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) {
 	}
 	loc := scope.Stack.pop()
 	val := scope.Stack.pop()
-	evm.IntraBlockState().SetTransientState(scope.Contract.Address(), accounts.InternKey(loc.Bytes32()), val)
+	evm.IntraBlockState().SetTransientState(scope.Contract.Address(), evm.IntraBlockState().InternKey(loc.Bytes32()), val)
 	return pc, nil, nil
 }
 

--- a/execution/vm/eips.go
+++ b/execution/vm/eips.go
@@ -204,7 +204,7 @@ func enable1153(jt *JumpTable) {
 // opTload implements TLOAD opcode
 func opTload(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) {
 	loc := scope.Stack.peek()
-	key := evm.IntraBlockState().InternKey(loc.Bytes32())
+	key := evm.IntraBlockState().InternStorage(loc.Bytes32())
 	val := evm.IntraBlockState().GetTransientState(scope.Contract.Address(), key)
 	*loc = val
 	return pc, nil, nil
@@ -217,7 +217,7 @@ func opTstore(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) {
 	}
 	loc := scope.Stack.pop()
 	val := scope.Stack.pop()
-	evm.IntraBlockState().SetTransientState(scope.Contract.Address(), evm.IntraBlockState().InternKey(loc.Bytes32()), val)
+	evm.IntraBlockState().SetTransientState(scope.Contract.Address(), evm.IntraBlockState().InternStorage(loc.Bytes32()), val)
 	return pc, nil, nil
 }
 

--- a/execution/vm/evm.go
+++ b/execution/vm/evm.go
@@ -655,14 +655,14 @@ func (evm *EVM) Create(caller accounts.Address, code []byte, gasRemaining mdgas.
 	op := CREATE
 	if salt != nil {
 		op = CREATE2
-		contractAddr = accounts.InternAddress(types.CreateAddress2(caller.Value(), salt.Bytes32(), ch.Hash()))
+		contractAddr = evm.intraBlockState.InternAddress(types.CreateAddress2(caller.Value(), salt.Bytes32(), ch.Hash()))
 	} else {
 		var nonce uint64
 		nonce, err = evm.intraBlockState.GetNonce(caller)
 		if err != nil {
 			return nil, accounts.NilAddress, mdgas.MdGas{}, err
 		}
-		contractAddr = accounts.InternAddress(types.CreateAddress(caller.Value(), nonce))
+		contractAddr = evm.intraBlockState.InternAddress(types.CreateAddress(caller.Value(), nonce))
 	}
 	return evm.create(caller, ch, gasRemaining, endowment, contractAddr, op, true /* incrementNonce */, bailout)
 }

--- a/execution/vm/gas_table.go
+++ b/execution/vm/gas_table.go
@@ -28,7 +28,6 @@ import (
 	"github.com/erigontech/erigon/common/math"
 	"github.com/erigontech/erigon/execution/protocol/mdgas"
 	"github.com/erigontech/erigon/execution/protocol/params"
-	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
 // memoryGasCost calculates the quadratic gas for memory expansion. It does so
@@ -107,7 +106,7 @@ func gasSStore(evm *EVM, callContext *CallContext, availableGas mdgas.MdGas, mem
 		return mdgas.MdGas{}, ErrWriteProtection
 	}
 	value, x := callContext.Stack.Back(1), callContext.Stack.Back(0)
-	key := accounts.InternKey(x.Bytes32())
+	key := evm.IntraBlockState().InternKey(x.Bytes32())
 	current, _ := evm.IntraBlockState().GetState(callContext.Address(), key)
 	// The legacy gas metering only takes into consideration the current state
 	// Legacy rules should be applied if we are in Petersburg (removal of EIP-1283)
@@ -196,7 +195,7 @@ func gasSStoreEIP2200(evm *EVM, callContext *CallContext, availableGas mdgas.MdG
 	}
 	// Gas sentry honoured, do the actual gas calculation based on the stored value
 	value, x := callContext.Stack.Back(1), callContext.Stack.Back(0)
-	key := accounts.InternKey(x.Bytes32())
+	key := evm.IntraBlockState().InternKey(x.Bytes32())
 	current, _ := evm.IntraBlockState().GetState(callContext.Address(), key)
 
 	if current.Eq(value) { // noop (1)
@@ -499,7 +498,7 @@ func statelessGasCall(evm *EVM, callContext *CallContext, availableGas mdgas.MdG
 
 func statefulGasCall(evm *EVM, callContext *CallContext, gas mdgas.MdGas, availableGas mdgas.MdGas, transfersValue bool) (mdgas.MdGas, error) {
 	var accountGas, stateGas uint64
-	var address = accounts.InternAddress(callContext.Stack.Back(1).Bytes20())
+	var address = evm.IntraBlockState().InternAddress(callContext.Stack.Back(1).Bytes20())
 	rules := evm.ChainRules()
 	if rules.IsSpuriousDragon {
 		empty, err := evm.IntraBlockState().Empty(address)
@@ -716,7 +715,7 @@ func gasSelfdestruct(evm *EVM, callContext *CallContext, availableGas mdgas.MdGa
 	// TangerineWhistle (EIP150) gas reprice fork:
 	if evm.ChainRules().IsTangerineWhistle {
 		gas.Regular = params.SelfdestructGasEIP150
-		var address = accounts.InternAddress(callContext.Stack.Back(0).Bytes20())
+		var address = evm.IntraBlockState().InternAddress(callContext.Stack.Back(0).Bytes20())
 
 		if evm.ChainRules().IsSpuriousDragon {
 			// if empty and transfers value

--- a/execution/vm/gas_table.go
+++ b/execution/vm/gas_table.go
@@ -106,7 +106,7 @@ func gasSStore(evm *EVM, callContext *CallContext, availableGas mdgas.MdGas, mem
 		return mdgas.MdGas{}, ErrWriteProtection
 	}
 	value, x := callContext.Stack.Back(1), callContext.Stack.Back(0)
-	key := evm.IntraBlockState().InternKey(x.Bytes32())
+	key := evm.IntraBlockState().InternStorage(x.Bytes32())
 	current, _ := evm.IntraBlockState().GetState(callContext.Address(), key)
 	// The legacy gas metering only takes into consideration the current state
 	// Legacy rules should be applied if we are in Petersburg (removal of EIP-1283)
@@ -195,7 +195,7 @@ func gasSStoreEIP2200(evm *EVM, callContext *CallContext, availableGas mdgas.MdG
 	}
 	// Gas sentry honoured, do the actual gas calculation based on the stored value
 	value, x := callContext.Stack.Back(1), callContext.Stack.Back(0)
-	key := evm.IntraBlockState().InternKey(x.Bytes32())
+	key := evm.IntraBlockState().InternStorage(x.Bytes32())
 	current, _ := evm.IntraBlockState().GetState(callContext.Address(), key)
 
 	if current.Eq(value) { // noop (1)

--- a/execution/vm/instructions.go
+++ b/execution/vm/instructions.go
@@ -383,7 +383,7 @@ func opAddress(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) 
 
 func opBalance(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) {
 	slot := scope.Stack.peek()
-	address := accounts.InternAddress(slot.Bytes20())
+	address := evm.IntraBlockState().InternAddress(slot.Bytes20())
 	// BAL: BALANCE is a real state access per EIP-7928 — mark as non-revertable
 	// so the system address is included when explicitly queried by user txs.
 	evm.IntraBlockState().MarkAddressAccess(address, false)
@@ -544,7 +544,7 @@ func stReturnDataCopy(_ uint64, scope *CallContext) string {
 
 func opExtCodeSize(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) {
 	slot := scope.Stack.peek()
-	addr := accounts.InternAddress(slot.Bytes20())
+	addr := evm.IntraBlockState().InternAddress(slot.Bytes20())
 	// BAL: EXTCODESIZE is a real state access per EIP-7928.
 	evm.IntraBlockState().MarkAddressAccess(addr, false)
 	codeSize, err := evm.IntraBlockState().GetCodeSize(addr)
@@ -584,7 +584,7 @@ func opExtCodeCopy(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, err
 		codeOffset = stack.pop()
 		length     = stack.pop()
 	)
-	addr := accounts.InternAddress(a.Bytes20())
+	addr := evm.IntraBlockState().InternAddress(a.Bytes20())
 	// BAL: EXTCODECOPY is a real state access per EIP-7928.
 	evm.IntraBlockState().MarkAddressAccess(addr, false)
 	len64 := length.Uint64()
@@ -641,7 +641,7 @@ func opExtCodeCopy(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, err
 // equal the result of calling extcodehash on the account directly.
 func opExtCodeHash(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) {
 	slot := scope.Stack.peek()
-	address := accounts.InternAddress(slot.Bytes20())
+	address := evm.IntraBlockState().InternAddress(slot.Bytes20())
 
 	// BAL: EXTCODEHASH is a real state access per EIP-7928 — mark as
 	// non-revertable.  Also ensures non-existent accounts appear in the BAL
@@ -791,7 +791,7 @@ func opMstore8(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) 
 
 func opSload(pc uint64, evm *EVM, scope *CallContext) (_ uint64, _ []byte, err error) {
 	loc := scope.Stack.peek()
-	*loc, err = evm.IntraBlockState().GetState(scope.Contract.Address(), accounts.InternKey(loc.Bytes32()))
+	*loc, err = evm.IntraBlockState().GetState(scope.Contract.Address(), evm.IntraBlockState().InternKey(loc.Bytes32()))
 	return pc, nil, err
 }
 
@@ -806,7 +806,7 @@ func opSstore(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) {
 	}
 	loc := scope.Stack.pop()
 	val := scope.Stack.pop()
-	return pc, nil, evm.IntraBlockState().SetState(scope.Contract.Address(), accounts.InternKey(loc.Bytes32()), val)
+	return pc, nil, evm.IntraBlockState().SetState(scope.Contract.Address(), evm.IntraBlockState().InternKey(loc.Bytes32()), val)
 }
 
 func stSstore(_ uint64, scope *CallContext) string {
@@ -1093,7 +1093,7 @@ func opCall(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) {
 	gas := scope.callGas(evm)
 	// Pop other call parameters.
 	addr, value, inOffset, inSize, retOffset, retSize := stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop()
-	toAddr := accounts.InternAddress(addr.Bytes20())
+	toAddr := evm.IntraBlockState().InternAddress(addr.Bytes20())
 	// Get the arguments from the memory.
 	args := scope.Memory.GetPtr(inOffset.Uint64(), inSize.Uint64())
 
@@ -1155,7 +1155,7 @@ func opCallCode(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error)
 	gas := scope.callGas(evm)
 	// Pop other call parameters.
 	addr, value, inOffset, inSize, retOffset, retSize := stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop()
-	toAddr := accounts.InternAddress(addr.Bytes20())
+	toAddr := evm.IntraBlockState().InternAddress(addr.Bytes20())
 	// Get arguments from the memory.
 	args := scope.Memory.GetPtr(inOffset.Uint64(), inSize.Uint64())
 
@@ -1205,7 +1205,7 @@ func opDelegateCall(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, er
 	gas := scope.callGas(evm)
 	// Pop other call parameters.
 	addr, inOffset, inSize, retOffset, retSize := stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop()
-	toAddr := accounts.InternAddress(addr.Bytes20())
+	toAddr := evm.IntraBlockState().InternAddress(addr.Bytes20())
 	// Get arguments from the memory.
 	args := scope.Memory.GetPtr(inOffset.Uint64(), inSize.Uint64())
 
@@ -1247,7 +1247,7 @@ func opStaticCall(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, erro
 	gas := scope.callGas(evm)
 	// Pop other call parameters.
 	addr, inOffset, inSize, retOffset, retSize := stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop()
-	toAddr := accounts.InternAddress(addr.Bytes20())
+	toAddr := evm.IntraBlockState().InternAddress(addr.Bytes20())
 	// Get arguments from the memory.
 	args := scope.Memory.GetPtr(inOffset.Uint64(), inSize.Uint64())
 
@@ -1307,8 +1307,8 @@ func opSelfdestruct(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, er
 	}
 	beneficiary := scope.Stack.pop()
 	self := scope.Contract.Address()
-	beneficiaryAddr := accounts.InternAddress(beneficiary.Bytes20())
 	ibs := evm.IntraBlockState()
+	beneficiaryAddr := ibs.InternAddress(beneficiary.Bytes20())
 	balance, err := ibs.GetBalance(self)
 	if err != nil {
 		return pc, nil, err
@@ -1332,8 +1332,8 @@ func opSelfdestruct6780(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte
 	}
 	beneficiary := scope.Stack.pop()
 	self := scope.Contract.Address()
-	beneficiaryAddr := accounts.InternAddress(beneficiary.Bytes20())
 	ibs := evm.IntraBlockState()
+	beneficiaryAddr := ibs.InternAddress(beneficiary.Bytes20())
 	balance, err := ibs.GetBalance(self)
 	if err != nil {
 		return pc, nil, err

--- a/execution/vm/instructions.go
+++ b/execution/vm/instructions.go
@@ -791,7 +791,7 @@ func opMstore8(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) 
 
 func opSload(pc uint64, evm *EVM, scope *CallContext) (_ uint64, _ []byte, err error) {
 	loc := scope.Stack.peek()
-	*loc, err = evm.IntraBlockState().GetState(scope.Contract.Address(), evm.IntraBlockState().InternKey(loc.Bytes32()))
+	*loc, err = evm.IntraBlockState().GetState(scope.Contract.Address(), evm.IntraBlockState().InternStorage(loc.Bytes32()))
 	return pc, nil, err
 }
 
@@ -806,7 +806,7 @@ func opSstore(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) {
 	}
 	loc := scope.Stack.pop()
 	val := scope.Stack.pop()
-	return pc, nil, evm.IntraBlockState().SetState(scope.Contract.Address(), evm.IntraBlockState().InternKey(loc.Bytes32()), val)
+	return pc, nil, evm.IntraBlockState().SetState(scope.Contract.Address(), evm.IntraBlockState().InternStorage(loc.Bytes32()), val)
 }
 
 func stSstore(_ uint64, scope *CallContext) string {

--- a/execution/vm/operations_acl.go
+++ b/execution/vm/operations_acl.go
@@ -30,7 +30,6 @@ import (
 	"github.com/erigontech/erigon/execution/protocol/mdgas"
 	"github.com/erigontech/erigon/execution/protocol/params"
 	"github.com/erigontech/erigon/execution/tracing"
-	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
 func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
@@ -46,7 +45,7 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 		// Gas sentry honoured, do the actual gas calculation based on the stored value
 		var (
 			y, x    = callContext.Stack.Back(1), callContext.Stack.peek()
-			slot    = accounts.InternKey(x.Bytes32())
+			slot    = evm.IntraBlockState().InternKey(x.Bytes32())
 			current uint256.Int
 			cost    = uint64(0)
 		)
@@ -70,7 +69,7 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 			return mdgas.MdGas{Regular: cost + params.WarmStorageReadCostEIP2929}, nil // SLOAD_GAS
 		}
 
-		slotCommited := accounts.InternKey(x.Bytes32())
+		slotCommited := evm.IntraBlockState().InternKey(x.Bytes32())
 		var original, _ = evm.IntraBlockState().GetCommittedState(callContext.Address(), slotCommited)
 		if original.Eq(&current) {
 			if original.IsZero() { // create slot (2.1.1)
@@ -128,7 +127,7 @@ func gasSLoadEIP2929(evm *EVM, callContext *CallContext, scopeGas mdgas.MdGas, m
 	loc := callContext.Stack.peek()
 	// If the caller cannot afford the cost, this change will be rolled back
 	// If he does afford it, we can skip checking the same thing later on, during execution
-	if _, slotMod := evm.IntraBlockState().AddSlotToAccessList(callContext.Address(), accounts.InternKey(loc.Bytes32())); slotMod {
+	if _, slotMod := evm.IntraBlockState().AddSlotToAccessList(callContext.Address(), evm.IntraBlockState().InternKey(loc.Bytes32())); slotMod {
 		return mdgas.MdGas{Regular: params.ColdSloadCostEIP2929}, nil
 	}
 	return mdgas.MdGas{Regular: params.WarmStorageReadCostEIP2929}, nil
@@ -145,7 +144,7 @@ func gasExtCodeCopyEIP2929(evm *EVM, callContext *CallContext, scopeGas mdgas.Md
 	if err != nil {
 		return mdgas.MdGas{}, err
 	}
-	addr := accounts.InternAddress(callContext.Stack.peek().Bytes20())
+	addr := evm.IntraBlockState().InternAddress(callContext.Stack.peek().Bytes20())
 	// Check slot presence in the access list
 	if evm.IntraBlockState().AddAddressToAccessList(addr) {
 		var overflow bool
@@ -166,7 +165,7 @@ func gasExtCodeCopyEIP2929(evm *EVM, callContext *CallContext, scopeGas mdgas.Md
 // - extcodesize,
 // - (ext) balance
 func gasEip2929AccountCheck(evm *EVM, callContext *CallContext, scopeGas mdgas.MdGas, memorySize uint64) (mdgas.MdGas, error) {
-	addr := accounts.InternAddress(callContext.Stack.peek().Bytes20())
+	addr := evm.IntraBlockState().InternAddress(callContext.Stack.peek().Bytes20())
 	// If the caller cannot afford the cost, this change will be rolled back
 	if evm.IntraBlockState().AddAddressToAccessList(addr) {
 		// The warm storage read cost is already charged as constantGas
@@ -177,7 +176,7 @@ func gasEip2929AccountCheck(evm *EVM, callContext *CallContext, scopeGas mdgas.M
 
 func makeCallVariantGasCallEIP2929(oldCalculator gasFunc) gasFunc {
 	return func(evm *EVM, callContext *CallContext, scopeGas mdgas.MdGas, memorySize uint64) (mdgas.MdGas, error) {
-		addr := accounts.InternAddress(callContext.Stack.Back(1).Bytes20())
+		addr := evm.IntraBlockState().InternAddress(callContext.Stack.Back(1).Bytes20())
 		// The WarmStorageReadCostEIP2929 (100) is already deducted in the form of a constant cost, so
 		// the cost to charge for cold access, if any, is Cold - Warm
 		coldCost := params.ColdAccountAccessCostEIP2929 - params.WarmStorageReadCostEIP2929
@@ -243,7 +242,7 @@ func makeSelfdestructGasFn(refundsEnabled bool) gasFunc {
 	gasFunc := func(evm *EVM, callContext *CallContext, scopeGas mdgas.MdGas, memorySize uint64) (mdgas.MdGas, error) {
 		var (
 			gas     mdgas.MdGas
-			address = accounts.InternAddress(callContext.Stack.peek().Bytes20())
+			address = evm.IntraBlockState().InternAddress(callContext.Stack.peek().Bytes20())
 		)
 		if evm.readOnly {
 			return mdgas.MdGas{}, ErrWriteProtection
@@ -318,7 +317,7 @@ func makeCallVariantGasCallEIP7702(statelessCalculator statelessGasFunc, statefu
 		if rejectStaticValueTransfer && evm.readOnly && !callContext.Stack.Back(2).IsZero() {
 			return mdgas.MdGas{}, ErrWriteProtection
 		}
-		addr := accounts.InternAddress(callContext.Stack.Back(1).Bytes20())
+		addr := evm.IntraBlockState().InternAddress(callContext.Stack.Back(1).Bytes20())
 		// Check slot presence in the access list
 		var gas mdgas.MdGas
 		var accessGas uint64

--- a/execution/vm/operations_acl.go
+++ b/execution/vm/operations_acl.go
@@ -45,7 +45,7 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 		// Gas sentry honoured, do the actual gas calculation based on the stored value
 		var (
 			y, x    = callContext.Stack.Back(1), callContext.Stack.peek()
-			slot    = evm.IntraBlockState().InternKey(x.Bytes32())
+			slot    = evm.IntraBlockState().InternStorage(x.Bytes32())
 			current uint256.Int
 			cost    = uint64(0)
 		)
@@ -69,7 +69,7 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 			return mdgas.MdGas{Regular: cost + params.WarmStorageReadCostEIP2929}, nil // SLOAD_GAS
 		}
 
-		slotCommited := evm.IntraBlockState().InternKey(x.Bytes32())
+		slotCommited := evm.IntraBlockState().InternStorage(x.Bytes32())
 		var original, _ = evm.IntraBlockState().GetCommittedState(callContext.Address(), slotCommited)
 		if original.Eq(&current) {
 			if original.IsZero() { // create slot (2.1.1)
@@ -127,7 +127,7 @@ func gasSLoadEIP2929(evm *EVM, callContext *CallContext, scopeGas mdgas.MdGas, m
 	loc := callContext.Stack.peek()
 	// If the caller cannot afford the cost, this change will be rolled back
 	// If he does afford it, we can skip checking the same thing later on, during execution
-	if _, slotMod := evm.IntraBlockState().AddSlotToAccessList(callContext.Address(), evm.IntraBlockState().InternKey(loc.Bytes32())); slotMod {
+	if _, slotMod := evm.IntraBlockState().AddSlotToAccessList(callContext.Address(), evm.IntraBlockState().InternStorage(loc.Bytes32())); slotMod {
 		return mdgas.MdGas{Regular: params.ColdSloadCostEIP2929}, nil
 	}
 	return mdgas.MdGas{Regular: params.WarmStorageReadCostEIP2929}, nil


### PR DESCRIPTION
```
go run ./cmd/downloader torrent_hashes --diff --datadir ~/data/chiado34_regen --chain=chiado
# github.com/go-llsqlite/crawshaw/c
warning: unknown warning option '-Wno-stringop-overread' [-Wunknown-warning-option]
WARN[04-15|12:00:21.331] log directory has non-default permissions; group or world access is enabled dir=/Users/alex/data/chiado34_regen/logs mode=0755
INFO[04-15|12:00:21.331] logging to file system                   log dir=/Users/alex/data/chiado34_regen/logs file prefix=downloader log level=dbug json=false
INFO[04-15|12:00:21.332] Build info                               git_branch= git_tag= git_commit=
WARN[04-15|12:00:21.332] log directory has non-default permissions; group or world access is enabled dir=/Users/alex/data/chiado34_regen/logs mode=0755
INFO[04-15|12:00:21.332] logging to file system                   log dir=/Users/alex/data/chiado34_regen/logs file prefix=downloader log level=dbug json=false
released branch: release/3.4  url: https://raw.githubusercontent.com/erigontech/erigon-snapshot/release/3.4/chiado.toml
released: 1533 entries, local: 1421 entries

~~~ hash changed (11):
  domain/v1.1-accounts.0-128.kvei
    released: 38f5271ce69016364f7cfbc920de7951bb53d71f
    local:    f16840149348c4564144e5ba38ca8f614e65466d
  domain/v1.1-accounts.128-160.kvei
    released: ea090ec1efc17865beabd98dc49dfab6b726b661
    local:    a04e051a745e654d3cba1c80d1662e16590331af
  domain/v1.1-code.0-128.kvei
    released: c24bc3512791bd1db43bdf73d17ad612bc886365
    local:    0c2926459c44697749442655a0da9ba6758b7da9
  domain/v1.1-code.128-160.kvei
    released: e0308c44893ba462609193aadafefda52150eeb3
    local:    71c058a8b2d9766cceedae83812e1305860d36ea
  domain/v1.1-storage.0-128.kvei
    released: 391083e7f6faad47033c7a727b3d83b0921266b0
    local:    4cfca6fc0e7c97a569830088d63a04b825c04216
  domain/v1.1-storage.128-160.kvei
    released: 8ae6d46347e404ef706f5384125f7ac295f3112f
    local:    026086c9868cff406e7c1a4318493f9315f54de0
  domain/v1.2-receipt.0-128.kvei
    released: 12f068615c2c0226e3ac9fba9dd357d6fa641a94
    local:    342564d095bff83b5e931fbc95b0902c9592b34e
  domain/v1.2-receipt.128-160.kvei
    released: 8b3334a4b7b8d561e07df628036be89f0cb3f0be
    local:    06afc8d4413484d0015d45de9ed145ca05f74acd
  v1.1-020630-020640-bodies.seg
    released: d46cee158afb12d9c04e6ddde2a88e9127c6ec27
    local:    6a099101310594d79a6025eea1f36d8cc56c9c69
  v1.1-020630-020640-headers.seg
    released: 334ec05c7500782a8f06f0399fe8d174929457d5
    local:    90ce47ce2958cd9bd42f58496aa5e6a344621376
  v1.1-020630-020640-transactions.seg
    released: b5acd2aea633bb577370908adbf5f67b04b89933
    local:    caba6693c75fbe65ddfa0ec92280e3a8c8c64cea

+++ in local, not in released (15):
  + v1.1-020500-020510-bodies.seg = "19e5cc3a16a10fd582e26d6ec1b96a192cb1238d"
  + v1.1-020500-020510-headers.seg = "66cbfeac04b94dc6e7c18550995b48bea8900d34"
  + v1.1-020500-020510-transactions.seg = "8cbe09bdf9e38e49910d12304cc5c1354c7f226d"
  + v1.1-020510-020520-bodies.seg = "979b36a71c3a59918ca32497b4a53fb81efb0e10"
  + v1.1-020510-020520-headers.seg = "6b1661352bdd67a1355e65562cadee2d1793c219"
  + v1.1-020510-020520-transactions.seg = "083478ee70ec540d6ae519c27fa53bbb42d56b23"
  + v1.1-020520-020530-bodies.seg = "1c04595f24d88f3ae50b7654d6deeccef0a25d8c"
  + v1.1-020520-020530-headers.seg = "11a7d18e7f9a746277b72b7647a17888674f42d3"
  + v1.1-020520-020530-transactions.seg = "8559dad9e6d02aff510608efa1760d799d062a4c"
  + v1.1-020530-020540-bodies.seg = "aa159ce2822e4b6b1f838952864371e81a4586b7"
  + v1.1-020530-020540-headers.seg = "629b12165efe2ed3a0982c840b66c46ffc7a6153"
  + v1.1-020530-020540-transactions.seg = "badbedae4ac938ddb597e6ae2367e04c04f267a3"
  + v1.1-020540-020550-bodies.seg = "70f96c0e0a0413b4d0f833e57b1679dac2417f02"
  + v1.1-020540-020550-headers.seg = "fd0982ed6a5e77d94bea23cd70703fdd365e9a52"
  + v1.1-020540-020550-transactions.seg = "7aa1b4e21a5396a84292dc090ba47e6d2cfc2711"

--- in released, not in local (127):
  - accessor/v1.1-code.128-160.vi = "ea1de40175e0417d8d1b2f63d27afc1a6b952147"
  - accessor/v1.1-code.160-161.vi = "5c504fff90599d4b2ae782faf2be2542608329ca"
  - accessor/v1.1-commitment.128-160.vi = "845229019c28069ff3b7f1eb648698995d355748"
```