### PR TITLE
blk-range: wrong logs 

### DIFF
--- a/db/integrity/commitment_integrity.go
+++ b/db/integrity/commitment_integrity.go
@@ -663,8 +663,7 @@ func CheckCommitmentHistVal(ctx context.Context, sc SamplerCfg, db kv.TemporalRo
 			continue
 		}
 		filesChecked++
-		// XOR file index into seed so bucket selection is reproducible per file.
-		sampler := NewSampler(sc.Seed^int64(i), sc.SampleRatio)
+		sampler := sc.NewWindowSampler(uint64(i))
 		for bucket := range sampler.Buckets(0, numBuckets) {
 			totalBuckets++
 			eg.Go(func() error {
@@ -1009,8 +1008,8 @@ func CheckCommitmentHistAtBlkRange(ctx context.Context, sc SamplerCfg, db kv.Tem
 			if err != nil {
 				return fmt.Errorf("CheckCommitmentHistAtBlkRange: build index window=[%d,%d): %w", windowStart, windowEnd, err)
 			}
-			// Each goroutine needs its own Sampler — the RNG is not goroutine-safe.
-			sampler := sc.NewSampler()
+			// Each goroutine needs its own Sampler
+			sampler := sc.NewWindowSampler(windowStart)
 			for blockNum := range sampler.BlockNums(windowStart, windowEnd) {
 				if err := checkCommitmentHistAtBlkWithIdx(wCtx, tx, sd, db, br, blockNum, idx, log.LvlTrace, logger); err != nil {
 					return fmt.Errorf("checkCommitmentHistAtBlk: %d, %w", blockNum, err)

--- a/db/integrity/sampler.go
+++ b/db/integrity/sampler.go
@@ -59,6 +59,13 @@ func (c SamplerCfg) NewSampler() *Sampler {
 	}
 }
 
+// NewWindowSampler returns a Sampler whose seed is derived by XORing offset into
+// c.Seed.  Use this when spawning one sampler per window/shard so that each shard
+// samples different relative positions rather than all selecting identical offsets.
+func (c SamplerCfg) NewWindowSampler(offset uint64) *Sampler {
+	return SamplerCfg{Seed: c.Seed ^ int64(offset), SampleRatio: c.SampleRatio}.NewSampler()
+}
+
 // validateSampleRatio returns an error if sampleRatio is outside the valid range (0, 1].
 func validateSampleRatio(sampleRatio float64) error {
 	if sampleRatio <= 0 || sampleRatio > 1 {


### PR DESCRIPTION
```
 [INFO] [04-15|05:15:50.145] [integrity] StateRootVerifyByHistory     blks/s=0.5 checked=3.72k/2.48k windows=1860/2488                 
  blkRange=1-24.87M                                                                                                                     

  ```  
`checked` overflow 