### PR TITLE
txpool: enforce 4096 hash limit on eth/68 NewPooledTransactionHashes

### DIFF
--- a/txnprovider/txpool/fetch.go
+++ b/txnprovider/txpool/fetch.go
@@ -362,6 +362,15 @@ func (f *Fetch) handleInboundMessageWithTx(ctx context.Context, tx kv.Tx, req *s
 			sentryClient.PenalizePeer(ctx, &sentryproto.PenalizePeerRequest{PeerId: req.PeerId, Penalty: sentryproto.PenaltyKind_Kick})
 			return nil
 		}
+
+		const maxHashesPerMsg = 4096 // See https://github.com/ethereum/devp2p/blob/master/caps/eth.md#newpooledtransactionhashes-0x08
+		if hashCount := len(hashes) / 32; hashCount > maxHashesPerMsg {
+			f.logger.Warn("Oversized hash announcement",
+				"peer", req.PeerId, "count", hashCount)
+			sentryClient.PenalizePeer(ctx, &sentryproto.PenalizePeerRequest{PeerId: req.PeerId, Penalty: sentryproto.PenaltyKind_Kick})
+			return nil
+		}
+
 		unknownHashes, err := f.pool.FilterKnownIdHashes(tx, hashes)
 		if err != nil {
 			return err

--- a/txnprovider/txpool/fetch.go
+++ b/txnprovider/txpool/fetch.go
@@ -357,16 +357,15 @@ func (f *Fetch) handleInboundMessageWithTx(ctx context.Context, tx kv.Tx, req *s
 			}
 		}
 	case sentryproto.MessageId_NEW_POOLED_TRANSACTION_HASHES_68:
-		_, _, hashes, _, err := parseAnnouncements(req.Data, 0)
-		if err != nil {
-			f.logger.Debug("[txpool] penalizing peer for malformed NewPooledTransactionHashes68", "peer", req.PeerId, "err", err)
+		if count, err := peekAnnouncementCount(req.Data); err == nil && count > maxHashesPerMsg {
+			f.logger.Warn("Oversized hash announcement",
+				"peer", req.PeerId, "count", count)
 			sentryClient.PenalizePeer(ctx, &sentryproto.PenalizePeerRequest{PeerId: req.PeerId, Penalty: sentryproto.PenaltyKind_Kick})
 			return nil
 		}
-
-		if hashCount := len(hashes) / 32; hashCount > maxHashesPerMsg {
-			f.logger.Warn("Oversized hash announcement",
-				"peer", req.PeerId, "count", hashCount)
+		_, _, hashes, _, err := parseAnnouncements(req.Data, 0)
+		if err != nil {
+			f.logger.Debug("[txpool] penalizing peer for malformed NewPooledTransactionHashes68", "peer", req.PeerId, "err", err)
 			sentryClient.PenalizePeer(ctx, &sentryproto.PenalizePeerRequest{PeerId: req.PeerId, Penalty: sentryproto.PenaltyKind_Kick})
 			return nil
 		}

--- a/txnprovider/txpool/fetch.go
+++ b/txnprovider/txpool/fetch.go
@@ -312,6 +312,8 @@ func (f *Fetch) handleInboundMessageWithTx(ctx context.Context, tx kv.Tx, req *s
 		return nil
 	}
 
+	const maxHashesPerMsg = 4096 // See https://github.com/ethereum/devp2p/blob/master/caps/eth.md#newpooledtransactionhashes-0x08
+
 	switch req.Id {
 	case sentryproto.MessageId_NEW_POOLED_TRANSACTION_HASHES_66:
 		hashCount, pos, err := ParseHashesCount(req.Data, 0)
@@ -321,7 +323,6 @@ func (f *Fetch) handleInboundMessageWithTx(ctx context.Context, tx kv.Tx, req *s
 			return nil
 		}
 
-		const maxHashesPerMsg = 4096 // See https://github.com/ethereum/devp2p/blob/master/caps/eth.md#newpooledtransactionhashes-0x08
 		if hashCount > maxHashesPerMsg {
 			f.logger.Warn("Oversized hash announcement",
 				"peer", req.PeerId, "count", hashCount)
@@ -363,7 +364,6 @@ func (f *Fetch) handleInboundMessageWithTx(ctx context.Context, tx kv.Tx, req *s
 			return nil
 		}
 
-		const maxHashesPerMsg = 4096 // See https://github.com/ethereum/devp2p/blob/master/caps/eth.md#newpooledtransactionhashes-0x08
 		if hashCount := len(hashes) / 32; hashCount > maxHashesPerMsg {
 			f.logger.Warn("Oversized hash announcement",
 				"peer", req.PeerId, "count", hashCount)

--- a/txnprovider/txpool/fetch_test.go
+++ b/txnprovider/txpool/fetch_test.go
@@ -441,6 +441,77 @@ func TestPenalizePeerForMalformedMessages(t *testing.T) {
 	}
 }
 
+// TestOversizedHashAnnouncement verifies that both eth/66 and eth/68 handlers
+// penalize peers that send more than 4096 hashes per NewPooledTransactionHashes
+// message (the devp2p soft limit) and do not issue a GetPooledTransactions request.
+func TestOversizedHashAnnouncement(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	const oversizedCount = 4097
+
+	// Build oversized eth/66 payload: an RLP list of 4097 hashes.
+	hashes := make([]byte, 32*oversizedCount)
+	for i := range oversizedCount {
+		hashes[i*32] = byte(i)
+		hashes[i*32+1] = byte(i >> 8)
+	}
+	payload66 := EncodeHashes(hashes, nil)
+
+	// Build oversized eth/68 payload: announcement with 4097 entries.
+	types68 := make([]byte, oversizedCount)
+	sizes68 := make([]uint32, oversizedCount)
+	for i := range oversizedCount {
+		types68[i] = 2  // EIP-1559
+		sizes68[i] = 100 // arbitrary size
+	}
+	encodeBuf := make([]byte, 150_000)
+	n := encodeAnnouncements(types68, sizes68, hashes, encodeBuf)
+	payload68 := make([]byte, n)
+	copy(payload68, encodeBuf[:n])
+
+	tests := []struct {
+		name string
+		id   sentryproto.MessageId
+		data []byte
+	}{
+		{"eth/66", sentryproto.MessageId_NEW_POOLED_TRANSACTION_HASHES_66, payload66},
+		{"eth/68", sentryproto.MessageId_NEW_POOLED_TRANSACTION_HASHES_68, payload68},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			sentryServer := sentryproto.NewMockSentryServer(ctrl)
+			pool := NewMockPool(ctrl)
+			pool.EXPECT().Started().Return(true)
+
+			// Expect peer to be penalized.
+			sentryServer.EXPECT().
+				PenalizePeer(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, req *sentryproto.PenalizePeerRequest) (*emptypb.Empty, error) {
+					assert.Equal(t, sentryproto.PenaltyKind_Kick, req.Penalty)
+					return &emptypb.Empty{}, nil
+				}).
+				Times(1)
+
+			m := NewMockSentry(ctx, sentryServer)
+			sentryClient, err := direct.NewSentryClientDirect(direct.ETH68, m, nil)
+			require.NoError(t, err)
+
+			fetch := NewFetch(ctx, []sentryproto.SentryClient{sentryClient}, pool, nil, nil, u256.N1, log.New())
+
+			err = fetch.handleInboundMessageWithTx(ctx, nil, &sentryproto.InboundMessage{
+				Id:     tt.id,
+				Data:   tt.data,
+				PeerId: peerID,
+			}, sentryClient)
+			require.NoError(t, err, "oversized announcement should be handled gracefully")
+		})
+	}
+}
+
 // TestNoPenaltyOnInternalDBError verifies that when IdHashKnown returns a DB error
 // during transaction parsing, the peer is NOT penalized (since it's our internal failure,
 // not the peer's fault).

--- a/txnprovider/txpool/fetch_test.go
+++ b/txnprovider/txpool/fetch_test.go
@@ -462,7 +462,7 @@ func TestOversizedHashAnnouncement(t *testing.T) {
 	types68 := make([]byte, oversizedCount)
 	sizes68 := make([]uint32, oversizedCount)
 	for i := range oversizedCount {
-		types68[i] = 2  // EIP-1559
+		types68[i] = 2   // EIP-1559
 		sizes68[i] = 100 // arbitrary size
 	}
 	encodeBuf := make([]byte, announcementsLen(types68, sizes68, hashes))

--- a/txnprovider/txpool/fetch_test.go
+++ b/txnprovider/txpool/fetch_test.go
@@ -465,7 +465,7 @@ func TestOversizedHashAnnouncement(t *testing.T) {
 		types68[i] = 2  // EIP-1559
 		sizes68[i] = 100 // arbitrary size
 	}
-	encodeBuf := make([]byte, 150_000)
+	encodeBuf := make([]byte, announcementsLen(types68, sizes68, hashes))
 	n := encodeAnnouncements(types68, sizes68, hashes, encodeBuf)
 	payload68 := make([]byte, n)
 	copy(payload68, encodeBuf[:n])

--- a/txnprovider/txpool/rlp_eth.go
+++ b/txnprovider/txpool/rlp_eth.go
@@ -153,7 +153,11 @@ func parseAnnouncements(payload []byte, pos int) ([]byte, []uint32, []byte, int,
 	if pos+hashesLen > len(payload) {
 		return nil, nil, nil, pos, fmt.Errorf("parse announcement payload: hashesLen %d is beyond the end of payload", hashesLen)
 	}
-	hashes := make([]byte, 32*(hashesLen/33))
+	hashCount := hashesLen / 33
+	if hashCount != typesLen {
+		return nil, nil, nil, pos, fmt.Errorf("parse announcement payload: hash count %d does not match types count %d", hashCount, typesLen)
+	}
+	hashes := make([]byte, 32*hashCount)
 	for i := 0; i < len(hashes); i += 32 {
 		if pos, err = parseRLPHash(payload, pos, hashes[i:]); err != nil {
 			return nil, nil, nil, pos, err

--- a/txnprovider/txpool/rlp_eth.go
+++ b/txnprovider/txpool/rlp_eth.go
@@ -153,11 +153,10 @@ func parseAnnouncements(payload []byte, pos int) ([]byte, []uint32, []byte, int,
 	if pos+hashesLen > len(payload) {
 		return nil, nil, nil, pos, fmt.Errorf("parse announcement payload: hashesLen %d is beyond the end of payload", hashesLen)
 	}
-	hashCount := hashesLen / 33
-	if hashCount != typesLen {
-		return nil, nil, nil, pos, fmt.Errorf("parse announcement payload: hash count %d does not match types count %d", hashCount, typesLen)
+	if hashesLen != 33*typesLen {
+		return nil, nil, nil, pos, fmt.Errorf("parse announcement payload: hashesLen %d does not match types count %d (expected %d)", hashesLen, typesLen, 33*typesLen)
 	}
-	hashes := make([]byte, 32*hashCount)
+	hashes := make([]byte, 32*typesLen)
 	for i := 0; i < len(hashes); i += 32 {
 		if pos, err = parseRLPHash(payload, pos, hashes[i:]); err != nil {
 			return nil, nil, nil, pos, err

--- a/txnprovider/txpool/rlp_eth.go
+++ b/txnprovider/txpool/rlp_eth.go
@@ -100,6 +100,21 @@ func encodeAnnouncements(types []byte, sizes []uint32, hashes []byte, encodeBuf 
 	return pos
 }
 
+// peekAnnouncementCount returns the number of items in an ETH/68 announcement
+// by reading only the types-string length, without allocating or decoding the
+// full payload.
+func peekAnnouncementCount(payload []byte) (int, error) {
+	pos, _, err := rlp.ParseList(payload, 0)
+	if err != nil {
+		return 0, err
+	}
+	_, typesLen, err := rlp.ParseString(payload, pos)
+	if err != nil {
+		return 0, err
+	}
+	return typesLen, nil
+}
+
 // parseAnnouncements decodes an ETH/68 (EIP-5793) transaction announcement.
 func parseAnnouncements(payload []byte, pos int) ([]byte, []uint32, []byte, int, error) {
 	pos, totalLen, err := rlp.ParseList(payload, pos)


### PR DESCRIPTION
## Summary
- The eth/66 `NewPooledTransactionHashes` handler enforced the devp2p soft limit of 4096 hashes, but the eth/68 handler did not
- A peer could announce an arbitrary number of hashes via eth/68, causing Erigon to request them all unconditionally
- Apply the same limit and peer penalty to eth/68 announcements

Closes #20385

## Test plan
- [x] `make lint` passes
- [x] `make erigon` builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)