### PR TITLE
cmd/utils: fix flag deduplication in appFlags

### DIFF
--- a/cmd/utils/app/make_app.go
+++ b/cmd/utils/app/make_app.go
@@ -112,6 +112,7 @@ func appFlags(cliFlags []cli.Flag) []cli.Flag {
 			continue
 		}
 		newFlags = append(newFlags, v)
+		seen[v.String()] = struct{}{}
 	}
 
 	return newFlags


### PR DESCRIPTION
Fix appFlags to actually populate the seen map, so duplicate flags are removed as intended.    