### PR TITLE
stagedsync: enforce strict BAL validation during fork validation (EIP-7928)

### DIFF
--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -36,7 +36,7 @@ jobs:
             ethereum_package_branch: "5.0.1"
           - suite: glamsterdam
             package_args: .github/workflows/kurtosis/glamsterdam.io
-            ethereum_package_branch: "main"
+            ethereum_package_branch: "e07503d16b29"
           - suite: caplin-minimal
             package_args: .github/workflows/kurtosis/caplin-minimal-assertoor.io
             ethereum_package_url: "github.com/erigontech/ethereum-package"

--- a/execution/stagedsync/bal_create.go
+++ b/execution/stagedsync/bal_create.go
@@ -47,7 +47,7 @@ func writeBALToFile(bal types.BlockAccessList, blockNum uint64, dataDir string) 
 	bal.DebugPrint(file)
 }
 
-func ProcessBAL(tx kv.TemporalRwTx, h *types.Header, vio *state.VersionedIO, amsterdam bool, experimental bool, dataDir string) error {
+func ProcessBAL(tx kv.TemporalRwTx, h *types.Header, vio *state.VersionedIO, amsterdam bool, experimental bool, isForkValidation bool, dataDir string) error {
 	if !amsterdam && !experimental {
 		return nil
 	}
@@ -96,14 +96,13 @@ func ProcessBAL(tx kv.TemporalRwTx, h *types.Header, vio *state.VersionedIO, ams
 			return fmt.Errorf("block %d: invalid block access list, hash mismatch: got %s expected %s", blockNum, dbBAL.Hash(), headerBALHash)
 		}
 	}
-	// Validate computed BAL against header. The parallel executor's speculative
-	// execution can produce slightly different storage reads than sequential
-	// execution (the block assembler), so when the stored BAL (from the proposer's
-	// sequential block assembler) matches the header, trust it even if the
-	// computed BAL differs. The state root check (commitment verification) still
-	// guarantees execution correctness.
+	// Validate computed BAL against header. During fork validation (engine API
+	// newPayload) the stored BAL comes from the untrusted payload and trivially
+	// matches the header hash. Trusting it would bypass semantic validation
+	// (EIP-7928). For re-execution of already-validated blocks, the parallel
+	// executor can still diverge in edge cases, so fall back to the stored BAL.
 	if headerBALHash != bal.Hash() {
-		if dbBALBytes != nil {
+		if dbBALBytes != nil && !isForkValidation {
 			if dbBAL2, decErr := types.DecodeBlockAccessListBytes(dbBALBytes); decErr == nil && dbBAL2 != nil && dbBAL2.Hash() == headerBALHash {
 				log.Debug("BAL: computed BAL differs from stored/header, trusting stored BAL",
 					"block", blockNum, "computedHash", bal.Hash(), "headerHash", headerBALHash)

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -390,7 +390,7 @@ func (pe *parallelExecutor) exec(ctx context.Context, execStage *StageState, u U
 							}
 
 							if (pe.cfg.chainConfig.IsAmsterdam(applyResult.BlockTime) || pe.cfg.experimentalBAL) && !applyResult.isPartial {
-								err = ProcessBAL(rwTx, lastHeader, applyResult.TxIO, pe.cfg.chainConfig.IsAmsterdam(applyResult.BlockTime), pe.cfg.experimentalBAL, pe.cfg.dirs.DataDir)
+								err = ProcessBAL(rwTx, lastHeader, applyResult.TxIO, pe.cfg.chainConfig.IsAmsterdam(applyResult.BlockTime), pe.cfg.experimentalBAL, pe.isForkValidation, pe.cfg.dirs.DataDir)
 								if err != nil {
 									return err
 								}


### PR DESCRIPTION
- **Gate the trust-stored-BAL fallback on `!isForkValidation`** in `ProcessBAL`. During engine API `newPayload`, the stored BAL comes from the untrusted payload and trivially matches the header hash (both derived from the same bytes), so the fallback was bypassing all semantic BAL validation — blocks with extraneous entries, wrong values, or missing accounts were accepted as `VALID`.

The fallback remains active for re-execution of already-validated blocks where the parallel executor can still diverge.

Fixes 26 Hive `bal-quick` test failures in `test_block_access_lists_invalid.py` ([results](https://hive.ethpandaops.io/#/test/bal-quick/1776173850-3128d86b4fd4acf36ea019fab1e185fa)).