### PR TITLE
ci: pin glamsterdam kurtosis to last-known-good ethereum-package commit

### DIFF
--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -36,7 +36,14 @@ jobs:
             ethereum_package_branch: "5.0.1"
           - suite: glamsterdam
             package_args: .github/workflows/kurtosis/glamsterdam.io
-            ethereum_package_branch: "main"
+            # Pinned to the last-known-good commit before upstream
+            # ethpandaops/ethereum-package@main introduced an undefined
+            # GpuConfig reference in zkboost_launcher.star (commit 835dd9b,
+            # 2026-04-15). Unpinned "main" tracking was causing every Erigon
+            # PR to fail glamsterdam regardless of what the PR changed.
+            # Revisit once upstream stabilises (or a newer tag supports
+            # gloas_fork_epoch / fulu_fork_epoch used by our config).
+            ethereum_package_branch: "e07503d16b292a4a0d0dde267b461c22eb394852"
           - suite: caplin-minimal
             package_args: .github/workflows/kurtosis/caplin-minimal-assertoor.io
             ethereum_package_url: "github.com/erigontech/ethereum-package"


### PR DESCRIPTION
## Summary

Every open Erigon PR that triggers the kurtosis assertoor suite is failing `assertoor_glamsterdam_test` with an upstream Starlark error:

```
Evaluation error: Multiple errors caught interpreting the Starlark script.
  at [github.com/ethpandaops/ethereum-package/src/zkboost/zkboost_launcher.star:272:17]:
      undefined: GpuConfig (did you mean get_config?)
```

## Root cause

`.github/workflows/test-kurtosis-assertoor.yml` pins the `regular` and `pectra` suites to `ethereum_package_branch: "5.0.1"`, but leaves **glamsterdam** tracking the floating `"main"` branch of `ethpandaops/ethereum-package`.

Upstream commit [ethpandaops/ethereum-package@835dd9b](https://github.com/ethpandaops/ethereum-package/commit/835dd9b) ("feat: support gpu ere prover in zkboost", 2026-04-15) introduced an undefined `GpuConfig` reference in `zkboost_launcher.star:272`. Since then, every Erigon PR that runs glamsterdam has failed — regardless of what the PR changed.

Confirmed failures across six unrelated PRs on 2026-04-15:
- #20471 (downloader extraction)
- #20472 (plugins/auth — standalone library, no runtime change)
- #20526 (decentralized snapshots POC)
- #20583, #20584, #20585 (component framework follow-ups)

Main's last passing glamsterdam was at the previous upstream commit [e07503d16b](https://github.com/ethpandaops/ethereum-package/commit/e07503d16b) (2026-04-13).

## Fix

Pin glamsterdam to `e07503d16b292a4a0d0dde267b461c22eb394852` — the last-known-good upstream commit. Stops the bleeding across every open PR. Revisit once upstream stabilises, or switch to a tagged release that supports `gloas_fork_epoch` / `fulu_fork_epoch` used by `glamsterdam.io`.

## Test plan

- [ ] CI passes on this PR
- [ ] Confirm glamsterdam turns green on a rebased PR after this merges