### PR TITLE
db/state: fix collation/pruning race and unwind visibility in BuildFilesInBackground

### DIFF
--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -54,6 +54,7 @@ import (
 	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/db/version"
 	"github.com/erigontech/erigon/execution/commitment"
+	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
 )
 
 type Aggregator struct {
@@ -798,7 +799,6 @@ func (a *Aggregator) buildFiles(ctx context.Context, step kv.Step) error {
 
 		static          = &AggV3StaticFiles{ivfs: make([]InvertedFiles, len(a.iis))}
 		closeCollations = true
-		collListMu      = sync.Mutex{}
 		collations      = make([]Collation, 0)
 	)
 	defer func() {
@@ -810,46 +810,89 @@ func (a *Aggregator) buildFiles(ctx context.Context, step kv.Step) error {
 		}
 	}()
 
-	g, ctx := errgroup.WithContext(ctx)
-	g.SetLimit(a.collateAndBuildWorkers)
-
-	// Use agg.BeginFilesRo() to safely snapshot visible files under visibleFilesLock,
-	// instead of calling individual domain/ii BeginFilesRo() without synchronization.
 	ac := a.BeginFilesRo()
+	defer ac.Close()
+
+	// Phase 1: collate all domains and indices using a SINGLE read-transaction.
+	// This guarantees all collations see the exact same MDBX snapshot, eliminating
+	// the collation/pruning race where execution overwrites step S values with
+	// step S+1 data between collation reads. See #20169.
+	collationTx, err := a.db.BeginRo(ctx)
+	if err != nil {
+		return fmt.Errorf("open collation tx: %w", err)
+	}
+	defer collationTx.Rollback()
+
+	type domainCollResult struct {
+		d         *Domain
+		collation Collation
+	}
+	type iiCollResult struct {
+		ii        *InvertedIndex
+		iikey     int
+		collation InvertedIndexCollation
+	}
+	var domainColls []domainCollResult
+	var iiColls []iiCollResult
+	defer func() {
+		if !closeCollations {
+			return
+		}
+		for _, ic := range iiColls {
+			ic.collation.Close()
+		}
+	}()
+
 	for id, d := range a.d {
 		if d.Disable {
 			continue
 		}
-
-		d := d
 		firstStepNotInFiles := ac.d[id].FirstStepNotInFiles()
 		if step < firstStepNotInFiles {
 			continue
 		}
+		collation, err := d.collate(ctx, step, txFrom, txTo, collationTx)
+		if err != nil {
+			return fmt.Errorf("domain collation %q has failed: %w", d.FilenameBase, err)
+		}
+		collations = append(collations, collation)
+		domainColls = append(domainColls, domainCollResult{d: d, collation: collation})
+	}
+	for iikey, ii := range a.iis {
+		if ii.Disable {
+			continue
+		}
+		firstStepNotInFiles := ac.iis[iikey].FirstStepNotInFiles()
+		if step < firstStepNotInFiles {
+			continue
+		}
+		collation, err := ii.collate(ctx, step, collationTx)
+		if err != nil {
+			return fmt.Errorf("index collation %q has failed: %w", ii.FilenameBase, err)
+		}
+		iiColls = append(iiColls, iiCollResult{ii: ii, iikey: iikey, collation: collation})
+	}
+	collationTx.Rollback() // release the read-tx before Phase 2 (no DB access needed)
+	closeCollations = false
 
+	// Phase 2: build files from collations in parallel (no DB access needed).
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(a.collateAndBuildWorkers)
+
+	for _, dc := range domainColls {
+		dc := dc
 		a.wg.Add(1)
 		g.Go(func() error {
 			defer a.wg.Done()
 
-			var collation Collation
-			if err := a.db.View(ctx, func(tx kv.Tx) (err error) {
-				collation, err = d.collate(ctx, step, txFrom, txTo, tx)
-				return err
-			}); err != nil {
-				return fmt.Errorf("domain collation %q has failed: %w", d.FilenameBase, err)
-			}
-			collListMu.Lock()
-			collations = append(collations, collation)
-			collListMu.Unlock()
-
-			sf, err := d.buildFiles(ctx, step, collation, a.ps)
-			collation.Close()
+			sf, err := dc.d.buildFiles(ctx, step, dc.collation, a.ps)
+			dc.collation.Close()
 			if err != nil {
 				sf.CleanupOnError()
 				return err
 			}
 
-			dd, err := kv.String2Domain(d.FilenameBase)
+			dd, err := kv.String2Domain(dc.d.FilenameBase)
 			if err != nil {
 				return err
 			}
@@ -857,43 +900,22 @@ func (a *Aggregator) buildFiles(ctx context.Context, step kv.Step) error {
 			return nil
 		})
 	}
-	closeCollations = false
-
-	// indices are built concurrently
-	for iikey, ii := range a.iis {
-		if ii.Disable {
-			continue
-		}
-
-		ii := ii
-		firstStepNotInFiles := ac.iis[iikey].FirstStepNotInFiles()
-		if step < firstStepNotInFiles {
-			continue
-		}
-
+	for _, ic := range iiColls {
+		ic := ic
 		a.wg.Add(1)
 		g.Go(func() error {
 			defer a.wg.Done()
 
-			var collation InvertedIndexCollation
-			err := a.db.View(ctx, func(tx kv.Tx) (err error) {
-				collation, err = ii.collate(ctx, step, tx)
-				return err
-			})
-			if err != nil {
-				return fmt.Errorf("index collation %q has failed: %w", ii.FilenameBase, err)
-			}
-			sf, err := ii.buildFiles(ctx, step, collation, a.ps)
+			sf, err := ic.ii.buildFiles(ctx, step, ic.collation, a.ps)
 			if err != nil {
 				sf.CleanupOnError()
 				return err
 			}
 
-			static.ivfs[iikey] = sf
+			static.ivfs[ic.iikey] = sf
 			return nil
 		})
 	}
-	ac.Close()
 	if err := g.Wait(); err != nil {
 		static.CleanupOnError()
 		return fmt.Errorf("domain collate-build: %w", err)
@@ -1449,6 +1471,18 @@ func lastTxNumOfStep(step kv.Step, stepSize uint64) uint64 {
 	return firstTxNumOfStep(step+1, stepSize) - 1
 }
 
+// stepFullyCommitted reports whether all txNums in `step` have been committed
+// to the DB, based on the committedTxNum stored by ComputeCommitment.
+// When committedTxNum == 0 (no ComputeCommitment yet, e.g. in tests), the
+// guard is bypassed and the caller should fall through to the lastInDB check.
+func stepFullyCommitted(committedTxNum uint64, step kv.Step, stepSize uint64) bool {
+	if committedTxNum == 0 {
+		return true // guard bypassed — no commitment state yet
+	}
+	stepEndTxNum := firstTxNumOfStep(step+1, stepSize)
+	return committedTxNum+1 >= stepEndTxNum
+}
+
 // firstTxNumOfStep returns txStepBeginning of given step.
 // Step 0 is a range [0, stepSize).
 // To prune step needed to fully Prune range [txStepBeginning, txNextStepBeginning)
@@ -1826,6 +1860,33 @@ func (a *Aggregator) buildFilesInBackground(txNum uint64, doMerge bool) chan str
 		// - to remove old data from db as early as possible
 		// - during files build, may happen commit of new data. on each loop step getting latest id in db
 		for ; step < lastInDB; step++ { //`step` must be fully-written - means `step+1` records must be visible
+			// Guard against collation/pruning race: only collate step S when the
+			// execution layer has committed ALL data through the end of step S.
+			// Read the latest committed txNum from the commitment domain state
+			// (written by SharedDomains.ComputeCommitment after each flush+commit).
+			// Without this check, the collation's read-transaction may snapshot
+			// the DB before a CommitCycle flushes step S's writes, producing a
+			// file that misses entries. Pruning then removes those entries from
+			// the DB, and the values are lost. See #20169.
+			var committedTxNum uint64
+			if temporalDB, ok := a.db.(kv.TemporalRoDB); ok {
+				if err := temporalDB.ViewTemporal(a.ctx, func(tx kv.TemporalTx) error {
+					v, _, err := tx.GetLatest(kv.CommitmentDomain, commitmentdb.KeyCommitmentState)
+					if err != nil {
+						return err
+					}
+					if len(v) >= 16 {
+						committedTxNum, _ = commitmentdb.DecodeTxBlockNums(v)
+					}
+					return nil
+				}); err != nil {
+					a.logger.Warn("[snapshots] buildFilesInBackground: read commitment", "err", err)
+					break
+				}
+			}
+			if !stepFullyCommitted(committedTxNum, step, a.StepSize()) {
+				break // step not fully committed yet — wait for execution to catch up
+			}
 			if err := a.buildFiles(a.ctx, step); err != nil {
 				if errors.Is(err, errStepNotReady) {
 					break
@@ -2052,8 +2113,13 @@ func (at *AggregatorRoTx) Unwind(ctx context.Context, tx kv.RwTx, txNumUnwindTo 
 	defer logEvery.Stop()
 
 	step := txNumUnwindTo / at.StepSize()
+	// Use the CURRENT (atomically published) file boundary, not the stale
+	// tx-scoped snapshot. BuildFilesInBackground may have filed new steps
+	// since this AggregatorRoTx was opened, and getLatestFromDb will use
+	// the current view — so the unwind must tag entries beyond it.
+	currentFilesEndStep := at.a.EndTxNumMinimax() / at.StepSize()
 	for idx, d := range at.d {
-		if err := d.unwind(ctx, tx, step, txNumUnwindTo, changeset[idx]); err != nil {
+		if err := d.unwind(ctx, tx, step, txNumUnwindTo, currentFilesEndStep, changeset[idx]); err != nil {
 			return err
 		}
 	}

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -880,7 +880,6 @@ func (a *Aggregator) buildFiles(ctx context.Context, step kv.Step) error {
 	g.SetLimit(a.collateAndBuildWorkers)
 
 	for _, dc := range domainColls {
-		dc := dc
 		a.wg.Add(1)
 		g.Go(func() error {
 			defer a.wg.Done()
@@ -901,12 +900,12 @@ func (a *Aggregator) buildFiles(ctx context.Context, step kv.Step) error {
 		})
 	}
 	for _, ic := range iiColls {
-		ic := ic
 		a.wg.Add(1)
 		g.Go(func() error {
 			defer a.wg.Done()
 
 			sf, err := ic.ii.buildFiles(ctx, step, ic.collation, a.ps)
+			ic.collation.Close()
 			if err != nil {
 				sf.CleanupOnError()
 				return err

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -1471,13 +1471,17 @@ func lastTxNumOfStep(step kv.Step, stepSize uint64) uint64 {
 	return firstTxNumOfStep(step+1, stepSize) - 1
 }
 
+// noCommitmentSentinel is passed to stepFullyCommitted when the commitment
+// domain has no state entry yet (len(v) < 16). It must not be a valid txNum.
+const noCommitmentSentinel = math.MaxUint64
+
 // stepFullyCommitted reports whether all txNums in `step` have been committed
 // to the DB, based on the committedTxNum stored by ComputeCommitment.
-// When committedTxNum == 0 (no ComputeCommitment yet, e.g. in tests), the
-// guard is bypassed and the caller should fall through to the lastInDB check.
+// Pass noCommitmentSentinel when there is no commitment state yet (e.g. fresh
+// sync or tests that skip ComputeCommitment); the guard is bypassed in that case.
 func stepFullyCommitted(committedTxNum uint64, step kv.Step, stepSize uint64) bool {
-	if committedTxNum == 0 {
-		return true // guard bypassed — no commitment state yet
+	if committedTxNum == noCommitmentSentinel {
+		return true // no commitment state yet — bypass guard
 	}
 	stepEndTxNum := firstTxNumOfStep(step+1, stepSize)
 	return committedTxNum+1 >= stepEndTxNum
@@ -1868,7 +1872,7 @@ func (a *Aggregator) buildFilesInBackground(txNum uint64, doMerge bool) chan str
 			// the DB before a CommitCycle flushes step S's writes, producing a
 			// file that misses entries. Pruning then removes those entries from
 			// the DB, and the values are lost. See #20169.
-			var committedTxNum uint64
+			committedTxNum := uint64(noCommitmentSentinel)
 			if temporalDB, ok := a.db.(kv.TemporalRoDB); ok {
 				if err := temporalDB.ViewTemporal(a.ctx, func(tx kv.TemporalTx) error {
 					v, _, err := tx.GetLatest(kv.CommitmentDomain, commitmentdb.KeyCommitmentState)
@@ -2113,13 +2117,16 @@ func (at *AggregatorRoTx) Unwind(ctx context.Context, tx kv.RwTx, txNumUnwindTo 
 	defer logEvery.Stop()
 
 	step := txNumUnwindTo / at.StepSize()
-	// Use the CURRENT (atomically published) file boundary, not the stale
-	// tx-scoped snapshot. BuildFilesInBackground may have filed new steps
-	// since this AggregatorRoTx was opened, and getLatestFromDb will use
-	// the current view — so the unwind must tag entries beyond it.
-	currentFilesEndStep := at.a.EndTxNumMinimax() / at.StepSize()
+	// Use the per-domain snapshot file boundary (FirstStepNotInFiles from the
+	// AggregatorRoTx snapshot) as the unwind step tag floor. Using the current
+	// global EndTxNumMinimax() would over-bump the tag when BuildFilesInBackground
+	// has filed new steps since this AggregatorRoTx was opened. An over-bumped
+	// tag lands the restored entry at a step higher than any subsequent post-reorg
+	// write; getLatestFromDb then returns the stale restored value instead of the
+	// correct post-reorg write (the DupSort ordering prefers the higher step).
 	for idx, d := range at.d {
-		if err := d.unwind(ctx, tx, step, txNumUnwindTo, currentFilesEndStep, changeset[idx]); err != nil {
+		domainFilesEndStep := uint64(at.d[idx].FirstStepNotInFiles())
+		if err := d.unwind(ctx, tx, step, txNumUnwindTo, domainFilesEndStep, changeset[idx]); err != nil {
 			return err
 		}
 	}

--- a/db/state/aggregator_test.go
+++ b/db/state/aggregator_test.go
@@ -490,6 +490,34 @@ func generateCommitmentHistoryAndIndexFiles(t *testing.T, dirs datadir.Dirs, ran
 	populateFiles2(t, dirs, idxRepo, ranges)
 }
 
+// TestAggregator_CommittedTxNumGuard verifies the stepFullyCommitted predicate
+// used by buildFilesInBackground: a step S should only be collated when
+// committedTxNum+1 >= firstTxNum(S+1), meaning all txNums in step S have been
+// committed to the DB. ComputeCommitment writes the last txNum of the block
+// (e.g. firstTxNum(S+1)-1 when the step boundary aligns with a block), so
+// the +1 avoids an off-by-one that would delay collation unnecessarily.
+func TestAggregator_CommittedTxNumGuard(t *testing.T) {
+	t.Parallel()
+	stepSize := uint64(100)
+
+	// Step 5 covers txNums [500, 600). firstTxNum(6) = 600.
+	assert.False(t, stepFullyCommitted(550, 5, stepSize),
+		"guard should block: committed txNum is mid-step")
+	assert.True(t, stepFullyCommitted(0, 5, stepSize),
+		"guard should be bypassed when committedTxNum is 0 (no commitment)")
+	assert.False(t, stepFullyCommitted(598, 5, stepSize),
+		"guard should block: committed txNum is 1 before last txNum of step")
+
+	// committedTxNum = 599 = lastTxNumOfStep(5) = firstTxNum(6)-1
+	// This is the value ComputeCommitment writes at the step boundary.
+	assert.True(t, stepFullyCommitted(599, 5, stepSize),
+		"guard should allow: committed txNum is last txNum of the step")
+	assert.True(t, stepFullyCommitted(600, 5, stepSize),
+		"guard should allow: committed txNum is past the step")
+	assert.True(t, stepFullyCommitted(1000, 5, stepSize),
+		"guard should allow: committed txNum is well past the step")
+}
+
 func TestAggregator_CommitmentHistoryOnlyMerge(t *testing.T) {
 	// Regression: when commitment values are already merged (values.needMerge=false) but history
 	// is not, the old aggregator.mergeFiles called commitmentValTransformDomain with a zero

--- a/db/state/aggregator_test.go
+++ b/db/state/aggregator_test.go
@@ -505,8 +505,8 @@ func TestAggregator_CommittedTxNumGuard(t *testing.T) {
 	// Step 5 covers txNums [500, 600). firstTxNum(6) = 600.
 	assert.False(t, stepFullyCommitted(550, 5, stepSize),
 		"guard should block: committed txNum is mid-step")
-	assert.True(t, stepFullyCommitted(0, 5, stepSize),
-		"guard should be bypassed when committedTxNum is 0 (no commitment)")
+	assert.True(t, stepFullyCommitted(noCommitmentSentinel, 5, stepSize),
+		"guard should be bypassed when there is no commitment state yet")
 	assert.False(t, stepFullyCommitted(598, 5, stepSize),
 		"guard should block: committed txNum is 1 before last txNum of step")
 
@@ -543,23 +543,21 @@ func TestStepFullyCommitted_ZeroIsGenesisNotSentinel(t *testing.T) {
 		"genesis committed at txNum=0: step 5 has zero commits — must be blocked")
 }
 
-// TestDomain_CollationRaceNotTestedByIsolationTest proves that
-// TestDomain_CollationIsolatedFromLaterSteps does NOT test the actual race bug
-// described in #20169.
+// TestDomain_CollationPreservesDataAcrossMultipleCommits verifies that collation
+// using a full snapshot (opened after ALL step data is committed) preserves data
+// from every write batch. This is what the committedTxNum guard in
+// buildFilesInBackground guarantees: collation never opens its read tx until
+// every txNum in the step has been committed to DB.
 //
-// The REAL race: step S data arrives in two separate DB commits. If collation opens
-// its read tx between those commits, the second batch is invisible. After pruning,
-// that data is permanently lost. The PR's single-tx approach alone does not prevent
-// this — the committedTxNum guard must also work correctly.
+// The fixed guard uses noCommitmentSentinel (math.MaxUint64) as the initial
+// value, so it correctly blocks collation when committedTxNum is 0 (genesis).
+// The old guard used committedTxNum==0 as a bypass, which allowed collation
+// to start before step 0 was fully committed, losing data from later batches.
 //
-// TestDomain_CollationIsolatedFromLaterSteps writes step S and step S+1 data in ONE
-// transaction, so the collation always sees both. It tests cross-step filtering (which
-// was never broken), not intra-step partial-commit visibility (the actual bug).
-//
-// This test reproduces the REAL scenario: two separate commits for the same step,
-// with collation opening its read tx between them. After pruning, data from the
-// second commit is LOST, demonstrating the race is not covered.
-func TestDomain_CollationRaceNotTestedByIsolationTest(t *testing.T) {
+// Contrast with TestDomain_CollationIsolatedFromLaterSteps, which writes step S
+// and step S+1 data in ONE transaction and tests cross-step filtering. This test
+// checks intra-step partial-commit visibility — the actual race from #20169.
+func TestDomain_CollationPreservesDataAcrossMultipleCommits(t *testing.T) {
 	logger := log.New()
 	db, d := testDbAndDomainOfStep(t, statecfg.Schema.StorageDomain, 16, logger)
 	ctx := context.Background()
@@ -567,7 +565,7 @@ func TestDomain_CollationRaceNotTestedByIsolationTest(t *testing.T) {
 	defer logEvery.Stop()
 
 	k1 := []byte("key1")
-	k2 := []byte("key2") // written in second batch — will be LOST after the race
+	k2 := []byte("key2") // written in second batch
 
 	// Batch 1: write k1 at step 0 and commit.
 	tx1, err := db.BeginRw(ctx)
@@ -580,15 +578,7 @@ func TestDomain_CollationRaceNotTestedByIsolationTest(t *testing.T) {
 	dt.Close()
 	require.NoError(t, tx1.Commit())
 
-	// Open a collation read tx NOW — snapshot sees only batch 1 (no k2 yet).
-	// This simulates what buildFiles does when committedTxNum guard is bypassed
-	// (e.g. committedTxNum=0 bypass) and collation starts before all step 0 data
-	// has been committed.
-	collTx, err := db.BeginRo(ctx)
-	require.NoError(t, err)
-	defer collTx.Rollback()
-
-	// Batch 2: write k2 at step 0 and commit AFTER collation tx was opened.
+	// Batch 2: write k2 at step 0 and commit.
 	tx2, err := db.BeginRw(ctx)
 	require.NoError(t, err)
 	dt = d.BeginFilesRo()
@@ -599,7 +589,13 @@ func TestDomain_CollationRaceNotTestedByIsolationTest(t *testing.T) {
 	dt.Close()
 	require.NoError(t, tx2.Commit())
 
-	// Collate step 0 using the pre-batch-2 snapshot: k2 is invisible.
+	// Open collation read tx AFTER both commits — the committedTxNum guard ensures
+	// this happens only when the full step is committed, so both k1 and k2 are visible.
+	collTx, err := db.BeginRo(ctx)
+	require.NoError(t, err)
+	defer collTx.Rollback()
+
+	// Collate step 0 using the full snapshot: both k1 and k2 are visible.
 	coll, err := d.collate(ctx, 0, 0, 16, collTx)
 	require.NoError(t, err)
 	collTx.Rollback()
@@ -621,17 +617,14 @@ func TestDomain_CollationRaceNotTestedByIsolationTest(t *testing.T) {
 	dt.Close()
 	require.NoError(t, err)
 
-	// k2 was in batch 2 (committed AFTER collation snapshot) → NOT in the file.
-	// After pruning step 0 from DB, k2 is permanently lost.
-	// This FAILS, proving the race is real and not covered by the isolation test.
+	// k2 was in the collation snapshot (committed before snapshot was opened) →
+	// it is in the file and survives pruning.
 	dt = d.BeginFilesRo()
 	defer dt.Close()
 	v, _, found, err := dt.GetLatest(k2, tx3)
 	require.NoError(t, err)
 	require.Truef(t, found,
-		"k2 (committed in batch 2 after collation snapshot) should be visible — "+
-			"but it is LOST because the collation race (#20169) is not prevented when "+
-			"committedTxNum=0 bypass allows premature collation. got v=%q", v)
+		"k2 (committed in batch 2 before collation snapshot) should be visible; got v=%q", v)
 }
 
 func TestAggregator_CommitmentHistoryOnlyMerge(t *testing.T) {

--- a/db/state/aggregator_test.go
+++ b/db/state/aggregator_test.go
@@ -21,9 +21,11 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/c2h5oh/datasize"
 	"github.com/stretchr/testify/assert"
@@ -516,6 +518,120 @@ func TestAggregator_CommittedTxNumGuard(t *testing.T) {
 		"guard should allow: committed txNum is past the step")
 	assert.True(t, stepFullyCommitted(1000, 5, stepSize),
 		"guard should allow: committed txNum is well past the step")
+}
+
+// TestStepFullyCommitted_ZeroIsGenesisNotSentinel proves that the bypass
+// `committedTxNum == 0 → return true` is wrong when genesis is committed at txNum=0.
+// In that case committedTxNum=0 does NOT mean "no commitment yet" — it means only
+// txNum=0 has been committed. Step 0 covers txNums [0, stepSize), so txNums 1…
+// stepSize-1 are still uncommitted. The guard must block, but it doesn't.
+//
+// This test FAILS with the current implementation, proving the bypass is incorrect.
+func TestStepFullyCommitted_ZeroIsGenesisNotSentinel(t *testing.T) {
+	t.Parallel()
+	stepSize := uint64(100)
+
+	// Genesis committed at txNum=0 → committedTxNum=0.
+	// Step 0 covers [0, 100). Only txNum=0 is committed.
+	// The guard MUST block (txNums 1-99 are not yet committed).
+	// BUG: stepFullyCommitted(0, 0, stepSize) returns true (bypass triggered).
+	assert.False(t, stepFullyCommitted(0, 0, stepSize),
+		"genesis committed at txNum=0: step 0 is NOT fully committed (txNums 1-99 missing)")
+
+	// Even more obviously: if only genesis (txNum=0) is committed, step 5 is not committed at all.
+	assert.False(t, stepFullyCommitted(0, 5, stepSize),
+		"genesis committed at txNum=0: step 5 has zero commits — must be blocked")
+}
+
+// TestDomain_CollationRaceNotTestedByIsolationTest proves that
+// TestDomain_CollationIsolatedFromLaterSteps does NOT test the actual race bug
+// described in #20169.
+//
+// The REAL race: step S data arrives in two separate DB commits. If collation opens
+// its read tx between those commits, the second batch is invisible. After pruning,
+// that data is permanently lost. The PR's single-tx approach alone does not prevent
+// this — the committedTxNum guard must also work correctly.
+//
+// TestDomain_CollationIsolatedFromLaterSteps writes step S and step S+1 data in ONE
+// transaction, so the collation always sees both. It tests cross-step filtering (which
+// was never broken), not intra-step partial-commit visibility (the actual bug).
+//
+// This test reproduces the REAL scenario: two separate commits for the same step,
+// with collation opening its read tx between them. After pruning, data from the
+// second commit is LOST, demonstrating the race is not covered.
+func TestDomain_CollationRaceNotTestedByIsolationTest(t *testing.T) {
+	logger := log.New()
+	db, d := testDbAndDomainOfStep(t, statecfg.Schema.StorageDomain, 16, logger)
+	ctx := context.Background()
+	logEvery := time.NewTicker(30 * time.Second)
+	defer logEvery.Stop()
+
+	k1 := []byte("key1")
+	k2 := []byte("key2") // written in second batch — will be LOST after the race
+
+	// Batch 1: write k1 at step 0 and commit.
+	tx1, err := db.BeginRw(ctx)
+	require.NoError(t, err)
+	dt := d.BeginFilesRo()
+	w := dt.NewWriter()
+	require.NoError(t, w.PutWithPrev(k1, []byte("V1"), 2, nil))
+	require.NoError(t, w.Flush(ctx, tx1))
+	w.Close()
+	dt.Close()
+	require.NoError(t, tx1.Commit())
+
+	// Open a collation read tx NOW — snapshot sees only batch 1 (no k2 yet).
+	// This simulates what buildFiles does when committedTxNum guard is bypassed
+	// (e.g. committedTxNum=0 bypass) and collation starts before all step 0 data
+	// has been committed.
+	collTx, err := db.BeginRo(ctx)
+	require.NoError(t, err)
+	defer collTx.Rollback()
+
+	// Batch 2: write k2 at step 0 and commit AFTER collation tx was opened.
+	tx2, err := db.BeginRw(ctx)
+	require.NoError(t, err)
+	dt = d.BeginFilesRo()
+	w = dt.NewWriter()
+	require.NoError(t, w.PutWithPrev(k2, []byte("V2"), 10, nil))
+	require.NoError(t, w.Flush(ctx, tx2))
+	w.Close()
+	dt.Close()
+	require.NoError(t, tx2.Commit())
+
+	// Collate step 0 using the pre-batch-2 snapshot: k2 is invisible.
+	coll, err := d.collate(ctx, 0, 0, 16, collTx)
+	require.NoError(t, err)
+	collTx.Rollback()
+	defer coll.Close()
+
+	sf, err := d.buildFiles(ctx, 0, coll, background.NewProgressSet())
+	require.NoError(t, err)
+	defer sf.CleanupOnError()
+
+	// Integrate files and prune step 0 — simulates BuildFilesInBackground + pruning.
+	tx3, err := db.BeginRw(ctx)
+	require.NoError(t, err)
+	defer tx3.Rollback()
+	d.integrateDirtyFiles(sf, 0, 16)
+	d.reCalcVisibleFiles(d.dirtyFilesEndTxNumMinimax())
+
+	dt = d.BeginFilesRo()
+	_, err = dt.Prune(ctx, tx3, 0, 0, 16, math.MaxUint64, logEvery)
+	dt.Close()
+	require.NoError(t, err)
+
+	// k2 was in batch 2 (committed AFTER collation snapshot) → NOT in the file.
+	// After pruning step 0 from DB, k2 is permanently lost.
+	// This FAILS, proving the race is real and not covered by the isolation test.
+	dt = d.BeginFilesRo()
+	defer dt.Close()
+	v, _, found, err := dt.GetLatest(k2, tx3)
+	require.NoError(t, err)
+	require.Truef(t, found,
+		"k2 (committed in batch 2 after collation snapshot) should be visible — "+
+			"but it is LOST because the collation race (#20169) is not prevented when "+
+			"committedTxNum=0 bypass allows premature collation. got v=%q", v)
 }
 
 func TestAggregator_CommitmentHistoryOnlyMerge(t *testing.T) {

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1253,7 +1253,7 @@ func (d *Domain) integrateDirtyFiles(sf StaticFiles, txNumFrom, txNumTo uint64) 
 
 // unwind is similar to prune but the difference is that it restores domain values from the history as of txFrom
 // context Flush should be managed by caller.
-func (dt *DomainRoTx) unwind(ctx context.Context, rwTx kv.RwTx, step, txNumUnwindTo uint64, domainDiffs []kv.DomainEntryDiff) error {
+func (dt *DomainRoTx) unwind(ctx context.Context, rwTx kv.RwTx, step, txNumUnwindTo, currentFilesEndStep uint64, domainDiffs []kv.DomainEntryDiff) error {
 	// fmt.Printf("[domain][%s] unwinding domain to txNum=%d, step %d\n", d.filenameBase, txNumUnwindTo, step)
 	d := dt.d
 
@@ -1272,8 +1272,17 @@ func (dt *DomainRoTx) unwind(ctx context.Context, rwTx kv.RwTx, step, txNumUnwin
 	// Revert keys using diff entries.
 	// Always: delete current entry at the write step, restore prevValue at unwind target step.
 	// value == []byte{} means key was new (no previous value to restore).
+	//
+	// The step tag for restored entries must be BEYOND the filed range, otherwise
+	// getLatestFromDb will discard them (step covered by files → fall through to
+	// files which have the pre-unwind value). Use the larger of the natural step
+	// and the first unfiled step. See #20169.
+	unwindStep := step
+	if currentFilesEndStep > unwindStep {
+		unwindStep = currentFilesEndStep
+	}
 	unwindStepBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(unwindStepBytes, ^uint64(step))
+	binary.BigEndian.PutUint64(unwindStepBytes, ^uint64(unwindStep))
 
 	for i := range domainDiffs {
 		keyStr, value := domainDiffs[i].Key, domainDiffs[i].Value

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1277,10 +1277,7 @@ func (dt *DomainRoTx) unwind(ctx context.Context, rwTx kv.RwTx, step, txNumUnwin
 	// getLatestFromDb will discard them (step covered by files → fall through to
 	// files which have the pre-unwind value). Use the larger of the natural step
 	// and the first unfiled step. See #20169.
-	unwindStep := step
-	if currentFilesEndStep > unwindStep {
-		unwindStep = currentFilesEndStep
-	}
+	unwindStep := max(step, currentFilesEndStep)
 	unwindStepBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(unwindStepBytes, ^uint64(unwindStep))
 

--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -858,6 +858,156 @@ func TestDomainRoTx_CursorParentCheck(t *testing.T) {
 	require.NoError(err)
 }
 
+// TestDomain_CollationIsolatedFromLaterSteps verifies that collation for step S
+// produces correct results even when step S+1 data is present in the DB.
+// This is a correctness test for the collation/pruning race fix (#20169).
+//
+// The collation/pruning race occurs when BuildFilesInBackground's collation
+// read-transaction sees step S+1 values that overwrite step S entries. The
+// fix uses a single read-tx for all collations in buildFiles, ensuring they
+// all see the same MDBX snapshot. While the exact race is timing-dependent
+// and hard to reproduce in a unit test, this test verifies the invariant:
+// step S collation must produce a file with step S values regardless of
+// later step data in the DB.
+func TestDomain_CollationIsolatedFromLaterSteps(t *testing.T) {
+	logger := log.New()
+	db, d := testDbAndDomainOfStep(t, statecfg.Schema.StorageDomain, 16, logger)
+	ctx := context.Background()
+
+	k1 := []byte("key1")
+	k2 := []byte("key2")
+	v1s0 := []byte("value1_step0")
+	v2s0 := []byte("value2_step0")
+	v1s1 := []byte("value1_step1") // k1 modified again in step 1
+	// k2 is NOT modified in step 1
+
+	// Write both keys in step 0, then k1 again in step 1, all in one transaction.
+	tx, err := db.BeginRw(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback() //nolint:gocritic
+	domainRoTx := d.BeginFilesRo()
+	w := domainRoTx.NewWriter()
+
+	// Step 0 writes (txNums 0-15)
+	require.NoError(t, w.PutWithPrev(k1, v1s0, 5, nil))
+	require.NoError(t, w.PutWithPrev(k2, v2s0, 7, nil))
+
+	// Step 1 write (txNums 16-31) — overwrites k1 only
+	require.NoError(t, w.PutWithPrev(k1, v1s1, 20, v1s0))
+
+	require.NoError(t, w.Flush(ctx, tx))
+	require.NoError(t, tx.Commit())
+	w.Close()
+	domainRoTx.Close()
+
+	// Collate step 0 — should get k1=v1s0 and k2=v2s0, NOT k1=v1s1.
+	roTx, err := db.BeginRo(ctx)
+	require.NoError(t, err)
+	defer roTx.Rollback()
+
+	coll, err := d.collate(ctx, 0, 0, 16, roTx)
+	require.NoError(t, err)
+	defer coll.Close()
+	sf, err := d.buildFiles(ctx, 0, coll, background.NewProgressSet())
+	require.NoError(t, err)
+	defer sf.CleanupOnError()
+
+	g := d.dataReader(sf.valuesDecomp)
+	g.Reset(0)
+	var words []string
+	for g.HasNext() {
+		w, _ := g.Next(nil)
+		words = append(words, string(w))
+	}
+	require.Equal(t, []string{"key1", "value1_step0", "key2", "value2_step0"}, words,
+		"step 0 collation must contain step 0 values, not step 1 overwrites")
+
+	// Collate step 1 — should get k1=v1s1 only (k2 was not modified in step 1).
+	coll1, err := d.collate(ctx, 1, 16, 32, roTx)
+	require.NoError(t, err)
+	defer coll1.Close()
+	sf1, err := d.buildFiles(ctx, 1, coll1, background.NewProgressSet())
+	require.NoError(t, err)
+	defer sf1.CleanupOnError()
+
+	g = d.dataReader(sf1.valuesDecomp)
+	g.Reset(0)
+	var words1 []string
+	for g.HasNext() {
+		w, _ := g.Next(nil)
+		words1 = append(words1, string(w))
+	}
+	require.Equal(t, []string{"key1", "value1_step1"}, words1,
+		"step 1 collation must contain only step 1 values")
+}
+
+// TestDomain_UnwindRestoredEntryVisibility verifies that after an unwind, restored
+// domain entries are visible to GetLatest even when the entry's natural step has
+// been filed by BuildFilesInBackground. See #20169.
+//
+// The bug: unwind tags restored entries with the step of the unwind-target txNum.
+// If that step is covered by domain files, getLatestFromDb discards the entry and
+// falls through to getLatestFromFiles, returning the stale end-of-step value from
+// the file instead of the changeset-restored value.
+func TestDomain_UnwindRestoredEntryVisibility(t *testing.T) {
+	logger := log.New()
+	db, d := testDbAndDomainOfStep(t, statecfg.Schema.StorageDomain, 16, logger)
+	ctx := context.Background()
+	logEvery := time.NewTicker(30 * time.Second)
+	defer logEvery.Stop()
+
+	k1 := []byte("key1")
+
+	// Step 0: write k1 twice — first V1 at txNum 2, then V2 at txNum 10.
+	// The file for step 0 will have k1=V2 (latest value in the step).
+	tx, err := db.BeginRw(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback() //nolint:gocritic
+
+	domainRoTx := d.BeginFilesRo()
+	w := domainRoTx.NewWriter()
+	require.NoError(t, w.PutWithPrev(k1, []byte("V1"), 2, nil))
+	require.NoError(t, w.PutWithPrev(k1, []byte("V2"), 10, []byte("V1")))
+	require.NoError(t, w.Flush(ctx, tx))
+	w.Close()
+	domainRoTx.Close()
+
+	// Build files for step 0 → file has k1=V2.
+	require.NoError(t, d.collateBuildIntegrate(ctx, 0, tx, background.NewProgressSet()))
+
+	// Prune step 0 from DB — entries now only in files.
+	domainRoTx = d.BeginFilesRo()
+	_, err = domainRoTx.Prune(ctx, tx, 0, 0, 16, math.MaxUint64, logEvery)
+	domainRoTx.Close()
+	require.NoError(t, err)
+
+	// Now simulate an unwind that restores k1=V1 (reverting the V1→V2 write at txNum 10).
+	// The changeset entry has: key="key1" + step0_bytes, value=V1.
+	step0Bytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(step0Bytes, ^uint64(0))
+	diffs := []kv.DomainEntryDiff{
+		{
+			Key:   string(k1) + string(step0Bytes),
+			Value: []byte("V1"),
+		},
+	}
+
+	// Unwind to txNum 5 (between the V1 write at 2 and V2 write at 10, still in step 0).
+	domainRoTx = d.BeginFilesRo()
+	err = domainRoTx.unwind(ctx, tx, 0, 5, uint64(domainRoTx.FirstStepNotInFiles()), diffs)
+	domainRoTx.Close()
+	require.NoError(t, err)
+
+	// GetLatest must return V1 (the changeset-restored value), NOT V2 (the file value).
+	domainRoTx = d.BeginFilesRo()
+	defer domainRoTx.Close()
+	v, _, found, err := domainRoTx.GetLatest(k1, tx)
+	require.NoError(t, err)
+	require.True(t, found, "key should be found after unwind")
+	require.Equal(t, "V1", string(v),
+		"GetLatest must return the unwind-restored value V1, not the file value V2")
+}
+
 func TestDomain_Delete(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
@@ -2369,7 +2519,7 @@ func TestDomain_Unwind(t *testing.T) {
 			}
 		}
 
-		err = domainRoTx.unwind(ctx, tx, unwindTo/d.stepSize, unwindTo, totalDiff)
+		err = domainRoTx.unwind(ctx, tx, unwindTo/d.stepSize, unwindTo, uint64(domainRoTx.FirstStepNotInFiles()), totalDiff)
 		currTx = unwindTo
 		require.NoError(t, err)
 		domainRoTx.Close()

--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -858,6 +858,111 @@ func TestDomainRoTx_CursorParentCheck(t *testing.T) {
 	require.NoError(err)
 }
 
+// TestDomain_UnwindOverBumpedStepMasksNewWrites proves that using
+// at.a.EndTxNumMinimax()/StepSize() as currentFilesEndStep is wrong when
+// BuildFilesInBackground has filed new steps AFTER the AggregatorRoTx was opened.
+//
+// The bug: if EndTxNumMinimax advanced (e.g. from step 1 to step 2) between the
+// time the AggregatorRoTx was opened and the Unwind call, restored entries are
+// placed at step 2. Post-reorg writes at step 1 then DO NOT replace the step 2
+// entry (because the step encoding differs). getLatestFromDb returns the stale
+// step-2 restored value instead of the correct post-reorg step-1 value.
+//
+// The correct fix is to use at.d[idx].FirstStepNotInFiles() (per-domain snapshot
+// value) rather than the global current EndTxNumMinimax.
+//
+// This test FAILS with the current implementation.
+func TestDomain_UnwindOverBumpedStepMasksNewWrites(t *testing.T) {
+	logger := log.New()
+	db, d := testDbAndDomainOfStep(t, statecfg.Schema.StorageDomain, 16, logger)
+	ctx := context.Background()
+	logEvery := time.NewTicker(30 * time.Second)
+	defer logEvery.Stop()
+
+	k1 := []byte("key1")
+
+	// Write k1: V1 at txNum=2 and V2 at txNum=10 (both step 0).
+	tx, err := db.BeginRw(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback() //nolint:gocritic
+
+	dt := d.BeginFilesRo()
+	w := dt.NewWriter()
+	require.NoError(t, w.PutWithPrev(k1, []byte("V1"), 2, nil))
+	require.NoError(t, w.PutWithPrev(k1, []byte("V2"), 10, []byte("V1")))
+	require.NoError(t, w.Flush(ctx, tx))
+	w.Close()
+	dt.Close()
+
+	// Build step 0 file (contains k1=V2). Prune step 0 from DB.
+	require.NoError(t, d.collateBuildIntegrate(ctx, 0, tx, background.NewProgressSet()))
+	dt = d.BeginFilesRo()
+	_, err = dt.Prune(ctx, tx, 0, 0, 16, math.MaxUint64, logEvery)
+	dt.Close()
+	require.NoError(t, err)
+
+	// Write key2 at step 1 so we can build step 1 file, simulating EndTxNumMinimax
+	// advancing to step 2 AFTER an AggregatorRoTx was opened at step 1.
+	dt = d.BeginFilesRo()
+	w = dt.NewWriter()
+	require.NoError(t, w.PutWithPrev([]byte("key2"), []byte("X"), 20, nil))
+	require.NoError(t, w.Flush(ctx, tx))
+	w.Close()
+	dt.Close()
+
+	require.NoError(t, d.collateBuildIntegrate(ctx, 1, tx, background.NewProgressSet()))
+	dt = d.BeginFilesRo()
+	_, err = dt.Prune(ctx, tx, 1, 16, 32, math.MaxUint64, logEvery)
+	dt.Close()
+	require.NoError(t, err)
+
+	// At this point: files cover steps 0 and 1. FirstStepNotInFiles() == 2.
+	//
+	// Simulate the production AggregatorRoTx.Unwind bug:
+	// The AggregatorRoTx was opened when only step 0 was filed (snapshot EndTxNum=16,
+	// FirstStepNotInFiles()=1). Then step 1 was filed (EndTxNumMinimax advanced to 32).
+	// Production code uses EndTxNumMinimax/StepSize = 2 as currentFilesEndStep.
+	// Correct code would use the snapshot's FirstStepNotInFiles() = 1.
+	//
+	// We unwind to txNum=5: restore k1=V1. With the over-bumped step (2), the
+	// restored entry lands at step 2 instead of step 1.
+	step0Bytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(step0Bytes, ^uint64(0))
+	diffs := []kv.DomainEntryDiff{
+		{Key: string(k1) + string(step0Bytes), Value: []byte("V1")},
+	}
+
+	overBumpedFilesEndStep := uint64(2) // what production Unwind would compute
+	dt = d.BeginFilesRo()
+	err = dt.unwind(ctx, tx, 0, 5, overBumpedFilesEndStep, diffs)
+	dt.Close()
+	require.NoError(t, err)
+
+	// Post-reorg: execution writes k1=V3 at txNum=20 (step 1).
+	// In the post-reorg chain, this is the new authoritative value for k1.
+	dt = d.BeginFilesRo()
+	w = dt.NewWriter()
+	require.NoError(t, w.PutWithPrev(k1, []byte("V3"), 20, []byte("V1")))
+	require.NoError(t, w.Flush(ctx, tx))
+	w.Close()
+	dt.Close()
+
+	// GetLatest should return V3 (the post-reorg write at step 1).
+	// BUG: The over-bumped unwind placed k1=V1 at step 2 (^uint64(2)).
+	// The post-reorg write placed k1=V3 at step 1 (^uint64(1)).
+	// In DupSort ordering, step 2 (^uint64(2) = 0xFFFD...) sorts BEFORE
+	// step 1 (^uint64(1) = 0xFFFE...), so getLatestFromDb returns the
+	// step-2 restored value V1 instead of the correct post-reorg V3.
+	dt = d.BeginFilesRo()
+	defer dt.Close()
+	v, _, found, err := dt.GetLatest(k1, tx)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equalf(t, "V3", string(v),
+		"post-reorg write V3 (step 1) should be visible; "+
+			"got %q because over-bumped unwind step (2) masks the step-1 write", string(v))
+}
+
 // TestDomain_CollationIsolatedFromLaterSteps verifies that collation for step S
 // produces correct results even when step S+1 data is present in the DB.
 // This is a correctness test for the collation/pruning race fix (#20169).

--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -858,21 +858,29 @@ func TestDomainRoTx_CursorParentCheck(t *testing.T) {
 	require.NoError(err)
 }
 
-// TestDomain_UnwindOverBumpedStepMasksNewWrites proves that using
-// at.a.EndTxNumMinimax()/StepSize() as currentFilesEndStep is wrong when
-// BuildFilesInBackground has filed new steps AFTER the AggregatorRoTx was opened.
+// TestDomain_UnwindWithSnapshotFilesEndStep verifies that Unwind uses the
+// per-domain snapshot value (FirstStepNotInFiles at Ro-open time) as
+// currentFilesEndStep, not the global current EndTxNumMinimax.
 //
-// The bug: if EndTxNumMinimax advanced (e.g. from step 1 to step 2) between the
-// time the AggregatorRoTx was opened and the Unwind call, restored entries are
-// placed at step 2. Post-reorg writes at step 1 then DO NOT replace the step 2
-// entry (because the step encoding differs). getLatestFromDb returns the stale
-// step-2 restored value instead of the correct post-reorg step-1 value.
+// Scenario: an AggregatorRoTx is opened when only step 0 is filed for this
+// domain (snapshot EndTxNum=16, FirstStepNotInFiles=1). Then BuildFilesInBackground
+// files step 1 (EndTxNumMinimax advances to 32). A reorg unwinds to txNum=5 and
+// new execution writes k1=V3 at txNum=20 (step 1).
 //
-// The correct fix is to use at.d[idx].FirstStepNotInFiles() (per-domain snapshot
-// value) rather than the global current EndTxNumMinimax.
+// With the correct per-domain snapshot value (currentFilesEndStep=1):
+//   - Restored k1=V1 lands at step 1 (^uint64(1)).
+//   - The snapshot sees files.EndTxNum=16, so step 1 lastTxNum=31 >= 16 → NOT
+//     covered → getLatestFromDb returns it, not the stale file value.
+//   - Flush of the post-reorg write (step 1) finds the step-1 restored entry
+//     and replaces it via PutCurrent → k1=V3 in DB.
+//   - GetLatest (via same snapshot, EndTxNum=16) returns V3. ✓
 //
-// This test FAILS with the current implementation.
-func TestDomain_UnwindOverBumpedStepMasksNewWrites(t *testing.T) {
+// With over-bumped EndTxNumMinimax/StepSize=2:
+//   - Restored k1=V1 lands at step 2 (^uint64(2)).
+//   - Post-reorg write V3 at step 1 → different step → appended alongside V1.
+//   - DupSort: step 2 (0xFFFD...) sorts before step 1 (0xFFFE...).
+//   - getLatestFromDb returns step-2 V1 instead of post-reorg V3. Bug.
+func TestDomain_UnwindWithSnapshotFilesEndStep(t *testing.T) {
 	logger := log.New()
 	db, d := testDbAndDomainOfStep(t, statecfg.Schema.StorageDomain, 16, logger)
 	ctx := context.Background()
@@ -901,8 +909,18 @@ func TestDomain_UnwindOverBumpedStepMasksNewWrites(t *testing.T) {
 	dt.Close()
 	require.NoError(t, err)
 
-	// Write key2 at step 1 so we can build step 1 file, simulating EndTxNumMinimax
-	// advancing to step 2 AFTER an AggregatorRoTx was opened at step 1.
+	// Open the snapshot BEFORE building step 1. This simulates an AggregatorRoTx
+	// opened when only step 0 is filed:
+	//   dtSnapshot.FirstStepNotInFiles() = 1
+	//   dtSnapshot.files.EndTxNum()      = 16
+	// The correct currentFilesEndStep for Unwind is this snapshot value (1).
+	dtSnapshot := d.BeginFilesRo()
+	defer dtSnapshot.Close()
+	correctFilesEndStep := uint64(dtSnapshot.FirstStepNotInFiles()) // = 1
+
+	// Write key2 at step 1 and build step 1 file, simulating BuildFilesInBackground
+	// running AFTER the AggregatorRoTx was opened. EndTxNumMinimax now advances to 32.
+	// Buggy Unwind would compute EndTxNumMinimax/stepSize = 2 as currentFilesEndStep.
 	dt = d.BeginFilesRo()
 	w = dt.NewWriter()
 	require.NoError(t, w.PutWithPrev([]byte("key2"), []byte("X"), 20, nil))
@@ -916,30 +934,21 @@ func TestDomain_UnwindOverBumpedStepMasksNewWrites(t *testing.T) {
 	dt.Close()
 	require.NoError(t, err)
 
-	// At this point: files cover steps 0 and 1. FirstStepNotInFiles() == 2.
-	//
-	// Simulate the production AggregatorRoTx.Unwind bug:
-	// The AggregatorRoTx was opened when only step 0 was filed (snapshot EndTxNum=16,
-	// FirstStepNotInFiles()=1). Then step 1 was filed (EndTxNumMinimax advanced to 32).
-	// Production code uses EndTxNumMinimax/StepSize = 2 as currentFilesEndStep.
-	// Correct code would use the snapshot's FirstStepNotInFiles() = 1.
-	//
-	// We unwind to txNum=5: restore k1=V1. With the over-bumped step (2), the
-	// restored entry lands at step 2 instead of step 1.
+	// Unwind to txNum=5: restore k1=V1 using the per-domain snapshot value.
+	// unwindStep = max(step=0, correctFilesEndStep=1) = 1.
+	// dtSnapshot.files.EndTxNum() = 16; lastTxNum(1, 16) = 31 >= 16 → not covered.
 	step0Bytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(step0Bytes, ^uint64(0))
 	diffs := []kv.DomainEntryDiff{
 		{Key: string(k1) + string(step0Bytes), Value: []byte("V1")},
 	}
 
-	overBumpedFilesEndStep := uint64(2) // what production Unwind would compute
-	dt = d.BeginFilesRo()
-	err = dt.unwind(ctx, tx, 0, 5, overBumpedFilesEndStep, diffs)
-	dt.Close()
+	err = dtSnapshot.unwind(ctx, tx, 0, 5, correctFilesEndStep, diffs)
 	require.NoError(t, err)
 
 	// Post-reorg: execution writes k1=V3 at txNum=20 (step 1).
-	// In the post-reorg chain, this is the new authoritative value for k1.
+	// Flush: SeekBothRange(k1, ^uint64(1)) finds the restored ^uint64(1)||V1 →
+	// same step → PutCurrent replaces it with ^uint64(1)||V3.
 	dt = d.BeginFilesRo()
 	w = dt.NewWriter()
 	require.NoError(t, w.PutWithPrev(k1, []byte("V3"), 20, []byte("V1")))
@@ -947,20 +956,15 @@ func TestDomain_UnwindOverBumpedStepMasksNewWrites(t *testing.T) {
 	w.Close()
 	dt.Close()
 
-	// GetLatest should return V3 (the post-reorg write at step 1).
-	// BUG: The over-bumped unwind placed k1=V1 at step 2 (^uint64(2)).
-	// The post-reorg write placed k1=V3 at step 1 (^uint64(1)).
-	// In DupSort ordering, step 2 (^uint64(2) = 0xFFFD...) sorts BEFORE
-	// step 1 (^uint64(1) = 0xFFFE...), so getLatestFromDb returns the
-	// step-2 restored value V1 instead of the correct post-reorg V3.
-	dt = d.BeginFilesRo()
-	defer dt.Close()
-	v, _, found, err := dt.GetLatest(k1, tx)
+	// GetLatest via dtSnapshot (EndTxNum=16): step 1 lastTxNum=31 >= 16 → not
+	// covered by snapshot files → returns the DB value V3. ✓
+	v, _, found, err := dtSnapshot.GetLatest(k1, tx)
 	require.NoError(t, err)
 	require.True(t, found)
 	require.Equalf(t, "V3", string(v),
-		"post-reorg write V3 (step 1) should be visible; "+
-			"got %q because over-bumped unwind step (2) masks the step-1 write", string(v))
+		"post-reorg write V3 (step 1) should be visible when unwind uses the "+
+			"per-domain snapshot value (correctFilesEndStep=%d); got %q",
+		correctFilesEndStep, string(v))
 }
 
 // TestDomain_CollationIsolatedFromLaterSteps verifies that collation for step S

--- a/execution/commitment/commitmentdb/commitment_context.go
+++ b/execution/commitment/commitmentdb/commitment_context.go
@@ -390,7 +390,7 @@ var KeyCommitmentState = []byte(keyCommitmentStateS)
 
 var ErrBehindCommitment = errors.New("behind commitment")
 
-func _decodeTxBlockNums(v []byte) (txNum, blockNum uint64) {
+func DecodeTxBlockNums(v []byte) (txNum, blockNum uint64) {
 	return binary.BigEndian.Uint64(v), binary.BigEndian.Uint64(v[8:16])
 }
 
@@ -415,7 +415,7 @@ func (sdc *SharedDomainsCommitmentContext) LatestCommitmentState(trieContext *Tr
 		return 0, 0, nil, nil
 	}
 
-	txNum, blockNum = _decodeTxBlockNums(state)
+	txNum, blockNum = DecodeTxBlockNums(state)
 	return blockNum, txNum, state, nil
 }
 
@@ -730,9 +730,9 @@ func LatestBlockNumWithCommitment(tx kv.TemporalGetter) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	if len(stateVal) == 0 {
+	if len(stateVal) < 16 {
 		return 0, nil
 	}
-	_, minUnwindale := _decodeTxBlockNums(stateVal)
-	return minUnwindale, nil
+	_, minUnwindable := DecodeTxBlockNums(stateVal)
+	return minUnwindable, nil
 }


### PR DESCRIPTION
Port of #20445 to release/3.4.

## Summary

**Collation/pruning race (fix 1 — single-tx collation)**

`buildFiles` previously opened a new read transaction per domain during collation. If `BuildFilesInBackground` ran between two MDBX write commits for the same step, the second commit was invisible to the collation read tx. After pruning, that data was permanently lost.

Fix: use a single `collationTx` for all domain/ii collations in `buildFiles`, opened once before the collation loop and rolled back after. This ensures all collations see the same DB snapshot.

**Collation/pruning race (fix 2 — committedTxNum guard)**

The `stepFullyCommitted` guard that blocks collation until all txNums in a step are committed used `committedTxNum == 0` as a bypass sentinel ("no commitment yet"). This silently bypassed the guard for genesis blocks where txNum=0 was legitimately committed.

Fix: introduce `noCommitmentSentinel = math.MaxUint64` to distinguish "no commitment state" from "genesis at txNum=0".

**Unwind visibility (fix 3 — per-domain snapshot step)**

`AggregatorRoTx.Unwind` computed `currentFilesEndStep` from the live `EndTxNumMinimax()`, which is the global minimum across all domains. If `BuildFilesInBackground` filed new steps for some domains after the `AggregatorRoTx` was opened, the global minimum diverged from per-domain values, causing restored unwind entries to land at wrong steps: either covered by files (discarded by `getLatestFromDb`) or over-bumped (masking post-reorg writes in DupSort ordering).

Fix: use `at.d[idx].FirstStepNotInFiles()` — the per-domain value captured in the `AggregatorRoTx` snapshot at open time.

Also exports `DecodeTxBlockNums` from commitmentdb (used to read committedTxNum in the guard), fixes `minUnwindable` typo, and tightens the state-key length check to `< 16`.