### PR TITLE
qa-tests: bump lighthouse version

### DIFF
--- a/.github/workflows/qa-sync-with-externalcl.yml
+++ b/.github/workflows/qa-sync-with-externalcl.yml
@@ -31,7 +31,7 @@ jobs:
       TRACKING_TIME_SECONDS: 3600 # 1 hour
       TOTAL_TIME_SECONDS: 28800 # 8 hours
       ERIGON_ASSERT: true
-      LIGHTHOUSE_VERSION: v8.1.0
+      LIGHTHOUSE_VERSION: v8.1.3
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
Needed for Gnosis (Fulu fork) and for security updates