### PR TITLE
[r3.4] cl/caplin: fix nil pointer panics in GetEthV1ValidatorAttestationData

### DIFF
--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -144,6 +144,9 @@ func (a *ApiHandler) GetEthV1ValidatorAttestationData(
 	}
 
 	defer func() {
+		if committeeIndex == nil {
+			return
+		}
 		epoch := *slot / a.beaconChainCfg.SlotsPerEpoch
 		committeesPerSlot := a.syncedData.CommitteeCount(epoch)
 		subnet := subnets.ComputeSubnetForAttestation(

--- a/cl/beacon/synced_data/synced_data.go
+++ b/cl/beacon/synced_data/synced_data.go
@@ -164,6 +164,11 @@ func (s *SyncedDataManager) HeadRoot() common.Hash {
 }
 
 func (s *SyncedDataManager) CommitteeCount(epoch uint64) uint64 {
+	s.accessLock.RLock()
+	defer s.accessLock.RUnlock()
+	if s.headState == nil {
+		return 0
+	}
 	return s.headState.CommitteeCount(epoch)
 }
 


### PR DESCRIPTION
## Summary

Cherry-pick of #19783 from `main` to `release/3.4`.

Fixes a panic observed on `alex/collation_race_fix_34` (and `release/3.4`) when a validator client polls `/eth/v1/validator/attestation_data` before Caplin has synced to head.

- **`SyncedDataManager.CommitteeCount`** (`synced_data.go`): added `accessLock.RLock()` + nil check on `headState`, consistent with every other accessor in the same file.
- **Debug-log defer** (`block_production.go`): guard against nil `committeeIndex` in the deferred log closure.

## Reproduction

Start Erigon on `release/3.4` while a validator client is actively polling. The VC calls `GET /eth/v1/validator/attestation_data` before Caplin reaches head → panic in HTTP handler goroutine:
```
panic: runtime error: invalid memory address or nil pointer dereference
github.com/erigontech/erigon/cl/phase1/core/state.(*CachingBeaconState).CommitteeCount(0x0, ...)
github.com/erigontech/erigon/cl/beacon/synced_data.(*SyncedDataManager).CommitteeCount(...)
github.com/erigontech/erigon/cl/beacon/handler.(*ApiHandler).GetEthV1ValidatorAttestationData.func1()
```

## Test plan

- [x] Clean cherry-pick from `main` (commit `0f3624a17b`)
- [x] `go test ./cl/beacon/synced_data/... ./cl/beacon/handler/... -short` passes on main

Generated with Claude