### PR TITLE
execution/tracers: emit empty code in diff mode for EIP-7702 deauthorization

### DIFF
--- a/execution/tracing/tracers/internal/tracetest/testdata/prestate_tracer_with_diff_mode/eip7702_deauth.json
+++ b/execution/tracing/tracers/internal/tracetest/testdata/prestate_tracer_with_diff_mode/eip7702_deauth.json
@@ -1,0 +1,98 @@
+{
+  "genesis": {
+    "blobGasUsed": "0",
+    "difficulty": "0",
+    "excessBlobGas": "0",
+    "extraData": "0x",
+    "gasLimit": "11511229",
+    "hash": "0x455b93a512baa4ed5e117508b184a6bb03904b94d665ce38931728eca9cdd8fe",
+    "miner": "0x71562b71999873db5b286df957af199ec94617f7",
+    "mixHash": "0x042877c4fab9f022d29590ae83bad89d6181afb1d6e107619911ea52e5901364",
+    "nonce": "0x0000000000000000",
+    "number": "1",
+    "parentBeaconBlockRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "stateRoot": "0xc8688ad6433e6b9f4edeb82360d2b99c8e919f493a01cacbe7c4a97184f5d043",
+    "timestamp": "1775654796",
+    "alloc": {
+      "0x71562b71999873db5b286df957af199ec94617f7": {
+        "balance": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffdb64910c3bf7",
+        "nonce": "1"
+      },
+      "0xe85a1c0e9d5b1c9b417c6c1b34c22cd77f623f50": {
+        "balance": "0x0",
+        "code": "0xef0100d313d93607c016a85e63e557a11ca5ab0b53ad83",
+        "codeHash": "0x9eea9f41ed2b35e6234d1e1c14e88c1136f85d56ed1f32a7efc0096d998dad3d",
+        "nonce": "1"
+      }
+    },
+    "config": {
+      "chainId": 1337,
+      "homesteadBlock": 0,
+      "eip150Block": 0,
+      "eip155Block": 0,
+      "eip158Block": 0,
+      "byzantiumBlock": 0,
+      "constantinopleBlock": 0,
+      "petersburgBlock": 0,
+      "istanbulBlock": 0,
+      "muirGlacierBlock": 0,
+      "berlinBlock": 0,
+      "londonBlock": 0,
+      "arrowGlacierBlock": 0,
+      "grayGlacierBlock": 0,
+      "shanghaiTime": 0,
+      "cancunTime": 0,
+      "pragueTime": 0,
+      "terminalTotalDifficulty": 0,
+      "blobSchedule": {
+        "cancun": {
+          "target": 3,
+          "max": 6,
+          "baseFeeUpdateFraction": 3338477
+        },
+        "prague": {
+          "target": 6,
+          "max": 9,
+          "baseFeeUpdateFraction": 5007716
+        }
+      }
+    }
+  },
+  "context": {
+    "number": "2",
+    "difficulty": "0",
+    "timestamp": "1775654797",
+    "gasLimit": "11522469",
+    "miner": "0x71562b71999873db5b286df957af199ec94617f7",
+    "baseFeePerGas": "766499147"
+  },
+  "input": "0x04f8cd82053901843b9aca008477359400830186a09471562b71999873db5b286df957af199ec94617f78080c0f85ef85c8205399400000000000000000000000000000000000000000101a011fc0271f2566e7ebe5ddbff6d48ea97a19afa248452a392781096b7e3b89177a0020107ecefe99c90429b416fe4d1eead5a7fa253761e85cd7cdc7df6e5032d7f80a098495fb16c904f0b67b49afe868b28b0159c8df07522bed99ef6ff2cc2ac2935a048857a9c385d91735a9fdccabc66de7a5ea1897f523a5b9a352e281642a76e6b",
+  "tracerConfig": {
+    "diffMode": true
+  },
+  "result": {
+    "post": {
+      "0x71562b71999873db5b286df957af199ec94617f7": {
+        "balance": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffc1bd12c85eb7",
+        "nonce": 2
+      },
+      "0xe85a1c0e9d5b1c9b417c6c1b34c22cd77f623f50": {
+        "code": "0x",
+        "codeHash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 2
+      }
+    },
+    "pre": {
+      "0x71562b71999873db5b286df957af199ec94617f7": {
+        "balance": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffdb64910c3bf7",
+        "nonce": 1
+      },
+      "0xe85a1c0e9d5b1c9b417c6c1b34c22cd77f623f50": {
+        "balance": "0x0",
+        "code": "0xef0100d313d93607c016a85e63e557a11ca5ab0b53ad83",
+        "codeHash": "0x9eea9f41ed2b35e6234d1e1c14e88c1136f85d56ed1f32a7efc0096d998dad3d",
+        "nonce": 1
+      }
+    }
+  }
+}

--- a/execution/tracing/tracers/native/gen_account_json.go
+++ b/execution/tracing/tracers/native/gen_account_json.go
@@ -16,14 +16,14 @@ var _ = (*accountMarshaling)(nil)
 func (a account) MarshalJSON() ([]byte, error) {
 	type account struct {
 		Balance  *hexutil.Big                `json:"balance,omitempty"`
-		Code     hexutil.Bytes               `json:"code,omitempty"`
+		Code     *hexutil.Bytes              `json:"code,omitempty"`
 		CodeHash *common.Hash                `json:"codeHash,omitempty"`
 		Nonce    uint64                      `json:"nonce,omitempty"`
 		Storage  map[common.Hash]common.Hash `json:"storage,omitempty"`
 	}
 	var enc account
 	enc.Balance = (*hexutil.Big)(a.Balance)
-	enc.Code = a.Code
+	enc.Code = (*hexutil.Bytes)(a.Code)
 	enc.CodeHash = a.CodeHash
 	enc.Nonce = a.Nonce
 	enc.Storage = a.Storage
@@ -47,7 +47,7 @@ func (a *account) UnmarshalJSON(input []byte) error {
 		a.Balance = (*big.Int)(dec.Balance)
 	}
 	if dec.Code != nil {
-		a.Code = *dec.Code
+		a.Code = (*[]byte)(dec.Code)
 	}
 	if dec.CodeHash != nil {
 		a.CodeHash = dec.CodeHash

--- a/execution/tracing/tracers/native/prestate.go
+++ b/execution/tracing/tracers/native/prestate.go
@@ -278,7 +278,10 @@ func (t *prestateTracer) processDiffState() {
 			continue
 		}
 		modified := false
-		postAccount := &account{Storage: make(map[common.Hash]common.Hash)}
+		postAccount := &account{
+			Storage: make(map[common.Hash]common.Hash),
+		}
+
 		newBalance, _ := t.env.IntraBlockState.GetBalance(addr)
 		newNonce, _ := t.env.IntraBlockState.GetNonce(addr)
 		newCode, _ := t.env.IntraBlockState.GetCode(addr)
@@ -296,8 +299,6 @@ func (t *prestateTracer) processDiffState() {
 			postAccount.Nonce = newNonce
 		}
 
-		// Empty code hashes are excluded from the prestate, so default
-		// to EmptyCodeHash to match what GetCodeHash returns for codeless accounts.
 		prevCodeHash := empty.CodeHash
 		if t.pre[addr].CodeHash != nil {
 			prevCodeHash = *t.pre[addr].CodeHash
@@ -309,7 +310,6 @@ func (t *prestateTracer) processDiffState() {
 		}
 
 		if !t.config.DisableCode {
-			newCode, _ := t.env.IntraBlockState.GetCode(addr)
 			var prevCode []byte
 			if t.pre[addr].Code != nil {
 				prevCode = *t.pre[addr].Code
@@ -330,7 +330,7 @@ func (t *prestateTracer) processDiffState() {
 					delete(t.pre[addr].Storage, key)
 				}
 
-				var newVal, _ = t.env.IntraBlockState.GetState(addr, accounts.InternKey(key))
+				newVal, _ := t.env.IntraBlockState.GetState(addr, accounts.InternKey(key))
 				if new(uint256.Int).SetBytes(val[:]).Eq(&newVal) {
 					// Omit unchanged slots
 					delete(t.pre[addr].Storage, key)
@@ -388,23 +388,31 @@ func (t *prestateTracer) lookupAccount(addr accounts.Address) {
 	nonce, _ := t.env.IntraBlockState.GetNonce(addr)
 	code, _ := t.env.IntraBlockState.GetCode(addr)
 
-	t.pre[addr] = &account{
+	acc := &account{
 		Balance: balance.ToBig(),
 		Nonce:   nonce,
 	}
+
 	if len(code) > 0 {
+		acc.Code = &code
 		codeHash := crypto.HashData(code)
-		t.pre[addr].CodeHash = &codeHash
-	} else {
-		t.pre[addr].CodeHash = nil
+		acc.CodeHash = &codeHash
 	}
 
-	if !t.config.DisableCode && (!t.config.DiffMode || len(code) > 0) {
-		t.pre[addr].Code = &code
+	if !acc.exists() {
+		acc.empty = true
 	}
+
+	// code fetched before emptiness check, then stripped if disabled
+	if t.config.DisableCode {
+		acc.Code = nil
+	}
+
 	if !t.config.DisableStorage {
-		t.pre[addr].Storage = make(map[common.Hash]common.Hash)
+		acc.Storage = make(map[common.Hash]common.Hash)
 	}
+
+	t.pre[addr] = acc
 }
 
 // lookupStorage fetches the requested storage slot and adds

--- a/execution/tracing/tracers/native/prestate.go
+++ b/execution/tracing/tracers/native/prestate.go
@@ -55,7 +55,6 @@ type account struct {
 	CodeHash *common.Hash                `json:"codeHash,omitempty"`
 	Nonce    uint64                      `json:"nonce,omitempty"`
 	Storage  map[common.Hash]common.Hash `json:"storage,omitempty"`
-	empty    bool
 }
 
 func (a *account) exists() bool {
@@ -299,6 +298,8 @@ func (t *prestateTracer) processDiffState() {
 			postAccount.Nonce = newNonce
 		}
 
+		// Empty code hashes are excluded from the prestate, so default
+		// to EmptyCodeHash to match what GetCodeHash returns for codeless accounts.
 		prevCodeHash := empty.CodeHash
 		if t.pre[addr].CodeHash != nil {
 			prevCodeHash = *t.pre[addr].CodeHash
@@ -399,11 +400,8 @@ func (t *prestateTracer) lookupAccount(addr accounts.Address) {
 		acc.CodeHash = &codeHash
 	}
 
-	if !acc.exists() {
-		acc.empty = true
-	}
-
-	// code fetched before emptiness check, then stripped if disabled
+	// Fetch and use code for the emptiness check before honoring DisableCode.
+	// Account emptiness should not depend on the config flag.
 	if t.config.DisableCode {
 		acc.Code = nil
 	}

--- a/execution/tracing/tracers/native/prestate.go
+++ b/execution/tracing/tracers/native/prestate.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/crypto"
+	"github.com/erigontech/erigon/common/empty"
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/execution/tracing"
 	"github.com/erigontech/erigon/execution/tracing/tracers"
@@ -47,20 +48,23 @@ func init() {
 type state = map[accounts.Address]*account
 
 type account struct {
-	Balance  *big.Int                    `json:"balance,omitempty"`
-	Code     []byte                      `json:"code,omitempty"`
+	Balance *big.Int `json:"balance,omitempty"`
+	// Code is a pointer so omitempty can omit unchanged code (nil) while
+	// still emitting "0x" when code is cleared (e.g. EIP-7702 deauth).
+	Code     *[]byte                     `json:"code,omitempty"`
 	CodeHash *common.Hash                `json:"codeHash,omitempty"`
 	Nonce    uint64                      `json:"nonce,omitempty"`
 	Storage  map[common.Hash]common.Hash `json:"storage,omitempty"`
+	empty    bool
 }
 
 func (a *account) exists() bool {
-	return a.Nonce > 0 || len(a.Code) > 0 || len(a.Storage) > 0 || (a.Balance != nil && a.Balance.Sign() != 0)
+	return a.Nonce > 0 || (a.Code != nil && len(*a.Code) > 0) || len(a.Storage) > 0 || (a.Balance != nil && a.Balance.Sign() != 0)
 }
 
 type accountMarshaling struct {
 	Balance *hexutil.Big
-	Code    hexutil.Bytes
+	Code    *hexutil.Bytes
 }
 
 type prestateTracer struct {
@@ -278,7 +282,7 @@ func (t *prestateTracer) processDiffState() {
 		newBalance, _ := t.env.IntraBlockState.GetBalance(addr)
 		newNonce, _ := t.env.IntraBlockState.GetNonce(addr)
 		newCode, _ := t.env.IntraBlockState.GetCode(addr)
-		newCodeHash := common.Hash{}
+		newCodeHash := empty.CodeHash
 		if len(newCode) > 0 {
 			newCodeHash = crypto.HashData(newCode)
 		}
@@ -292,7 +296,9 @@ func (t *prestateTracer) processDiffState() {
 			postAccount.Nonce = newNonce
 		}
 
-		prevCodeHash := common.Hash{}
+		// Empty code hashes are excluded from the prestate, so default
+		// to EmptyCodeHash to match what GetCodeHash returns for codeless accounts.
+		prevCodeHash := empty.CodeHash
 		if t.pre[addr].CodeHash != nil {
 			prevCodeHash = *t.pre[addr].CodeHash
 		}
@@ -304,9 +310,16 @@ func (t *prestateTracer) processDiffState() {
 
 		if !t.config.DisableCode {
 			newCode, _ := t.env.IntraBlockState.GetCode(addr)
-			if !bytes.Equal(newCode, t.pre[addr].Code) {
+			var prevCode []byte
+			if t.pre[addr].Code != nil {
+				prevCode = *t.pre[addr].Code
+			}
+			if !bytes.Equal(newCode, prevCode) {
 				modified = true
-				postAccount.Code = newCode
+				if newCode == nil {
+					newCode = []byte{}
+				}
+				postAccount.Code = &newCode
 			}
 		}
 
@@ -386,8 +399,8 @@ func (t *prestateTracer) lookupAccount(addr accounts.Address) {
 		t.pre[addr].CodeHash = nil
 	}
 
-	if !t.config.DisableCode {
-		t.pre[addr].Code = code
+	if !t.config.DisableCode && (!t.config.DiffMode || len(code) > 0) {
+		t.pre[addr].Code = &code
 	}
 	if !t.config.DisableStorage {
 		t.pre[addr].Storage = make(map[common.Hash]common.Hash)

--- a/execution/tracing/tracers/native/prestate.go
+++ b/execution/tracing/tracers/native/prestate.go
@@ -58,7 +58,7 @@ type account struct {
 }
 
 func (a *account) exists() bool {
-	return a.Nonce > 0 || (a.Code != nil && len(*a.Code) > 0) || len(a.Storage) > 0 || (a.Balance != nil && a.Balance.Sign() != 0)
+	return a.Nonce > 0 || a.CodeHash != nil || len(a.Storage) > 0 || (a.Balance != nil && a.Balance.Sign() != 0)
 }
 
 type accountMarshaling struct {
@@ -317,9 +317,6 @@ func (t *prestateTracer) processDiffState() {
 			}
 			if !bytes.Equal(newCode, prevCode) {
 				modified = true
-				if newCode == nil {
-					newCode = []byte{}
-				}
 				postAccount.Code = &newCode
 			}
 		}
@@ -399,9 +396,7 @@ func (t *prestateTracer) lookupAccount(addr accounts.Address) {
 		codeHash := crypto.HashData(code)
 		acc.CodeHash = &codeHash
 	}
-
-	// Fetch and use code for the emptiness check before honoring DisableCode.
-	// Account emptiness should not depend on the config flag.
+	// The code must be fetched first for the emptiness check.
 	if t.config.DisableCode {
 		acc.Code = nil
 	}


### PR DESCRIPTION
This PR fixes prestate tracer diff-mode output for EIP-7702 deauthorization in Erigon.

Previously, when a transaction deauthorized an EIP-7702 delegated account (authorization to address(0)), the tracer omitted the `code` field from the `post` object after the delegation code was cleared. That treated the change as if the field had been deleted entirely.

In reality, the account still exists and its code is simply updated from delegated code (`0xef0100 || delegate`) to empty code (`0x`). Since this is a normal state transition - not an account deletion - the `post` object should include the updated empty code value.

This makes code handling consistent with how other account fields like balance are represented when they transition to zero, and keeps diff-mode semantics clearer: omitted fields should represent actual deletions, while modified fields should appear in `post` even if their new value is empty.

After this change, EIP-7702 deauthorization traces correctly return `"code": "0x"` in the `post` state.
