### PR TITLE
execution: enforce strict BAL validation (EIP-7928)

### DIFF
--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -139,13 +139,15 @@ jobs:
         # log blob storage purges raw CI logs quickly (BlobNotFound within
         # hours), and the orchestration output alone doesn't tell us what
         # each container was actually doing.
+        #
+        # NB: `kurtosis enclave dump` refuses if the target directory already
+        # exists — do NOT pre-create it.
         if: failure() && !inputs.cache-warming-only
         continue-on-error: true
         run: |
           set -eu
           enclave_name="kurtosis-${{ matrix.suite }}-${{ github.run_id }}"
           dump_dir="${RUNNER_TEMP}/kurtosis-dump-${{ matrix.suite }}"
-          mkdir -p "$dump_dir"
           kurtosis enclave dump "$enclave_name" "$dump_dir" || true
 
       - name: Upload Kurtosis enclave dump

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -27,23 +27,33 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # test_timeout_minutes is a per-suite wall-clock cap for the Kurtosis+assertoor
+        # step. Observed happy-path durations are roughly:
+        #   glamsterdam / caplin-minimal ~12 min, pectra ~30 min, regular ~34 min.
+        # The caps below give ~1.5–2x of the happy path so real regressions still
+        # pass but pathological hangs (e.g. a node that silently stops proposing)
+        # fail in reasonable time instead of burning hours.
         include:
           - suite: regular
             package_args: .github/workflows/kurtosis/regular-assertoor.io
             ethereum_package_branch: "5.0.1"
+            test_timeout_minutes: 50
           - suite: pectra
             package_args: .github/workflows/kurtosis/pectra.io
             ethereum_package_branch: "5.0.1"
+            test_timeout_minutes: 45
           - suite: glamsterdam
             package_args: .github/workflows/kurtosis/glamsterdam.io
             # Pinned to 6.1.0 rather than main: commit 835dd9b on main introduced GpuConfig,
             # a Starlark built-in that requires Kurtosis CLI >=1.18.1, breaking Starlark eval.
             # Unpin to main once CI is upgraded to Kurtosis 1.18.1.
             ethereum_package_branch: "6.1.0"
+            test_timeout_minutes: 20
           - suite: caplin-minimal
             package_args: .github/workflows/kurtosis/caplin-minimal-assertoor.io
             ethereum_package_url: "github.com/erigontech/ethereum-package"
             ethereum_package_branch: "erigontech/fix-caplin-launcher"
+            test_timeout_minutes: 20
 
     steps:
       - name: Fast checkout git repository
@@ -109,6 +119,11 @@ jobs:
         # solely to warm Docker image and BuildKit caches on main for future PRs
         # and merge queue runs. Skip the actual tests to avoid redundant execution.
         if: '!inputs.cache-warming-only'
+        # Per-suite cap — see matrix.test_timeout_minutes. Turns multi-hour
+        # hangs (e.g. a node that silently stops proposing) into prompt
+        # failures so the next investigation or retry can start sooner
+        # instead of burning runner hours on a dead chain.
+        timeout-minutes: ${{ matrix.test_timeout_minutes }}
         uses: ethpandaops/kurtosis-assertoor-github-action@v1
         with:
             enclave_name: "kurtosis-${{ matrix.suite }}-${{ github.run_id }}"
@@ -117,3 +132,28 @@ jobs:
             ethereum_package_branch: "${{ matrix.ethereum_package_branch }}"
             kurtosis_extra_args: --verbosity detailed --cli-log-level trace
             persistent_logs: "true"
+
+      - name: Dump Kurtosis enclave on failure
+        # Capture per-service logs (el-*, cl-*, vc-*, spamoor, assertoor,
+        # snooper-*) so test hangs can be diagnosed after the fact. GitHub's
+        # log blob storage purges raw CI logs quickly (BlobNotFound within
+        # hours), and the orchestration output alone doesn't tell us what
+        # each container was actually doing.
+        if: failure() && !inputs.cache-warming-only
+        continue-on-error: true
+        run: |
+          set -eu
+          enclave_name="kurtosis-${{ matrix.suite }}-${{ github.run_id }}"
+          dump_dir="${RUNNER_TEMP}/kurtosis-dump-${{ matrix.suite }}"
+          mkdir -p "$dump_dir"
+          kurtosis enclave dump "$enclave_name" "$dump_dir" || true
+
+      - name: Upload Kurtosis enclave dump
+        if: failure() && !inputs.cache-warming-only
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: kurtosis-dump-${{ matrix.suite }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/kurtosis-dump-${{ matrix.suite }}
+          retention-days: 7
+          if-no-files-found: warn

--- a/execution/engineapi/engine_api_bal_test.go
+++ b/execution/engineapi/engine_api_bal_test.go
@@ -18,6 +18,7 @@ package engineapi_test
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"math/big"
 	"testing"
 
@@ -27,6 +28,8 @@ import (
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/crypto"
 	"github.com/erigontech/erigon/common/dbg"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/common/testlog"
 	"github.com/erigontech/erigon/execution/abi/bind"
 	"github.com/erigontech/erigon/execution/engineapi/engineapitester"
 	"github.com/erigontech/erigon/execution/protocol/params"
@@ -36,6 +39,70 @@ import (
 	"github.com/erigontech/erigon/rpc"
 	"github.com/erigontech/erigon/rpc/jsonrpc/contracts"
 )
+
+// TestEngineApiBALMultiSenderBlock packs transfers from many independent senders
+// into a single block. Because the senders are independent the parallel executor
+// speculatively executes them concurrently, exercising the coinbase-balance
+// strip→rebase→merge path in finalizeWithIBS. Any divergence between the
+// assembler's BAL (sequential) and the parallel executor's BAL surfaces as a
+// BAL hash mismatch returned by ProcessBAL.
+func TestEngineApiBALMultiSenderBlock(t *testing.T) {
+	if !dbg.Exec3Parallel {
+		t.Skip("requires parallel exec")
+	}
+	const numSenders = 10
+	senderKeys := make([]*ecdsa.PrivateKey, numSenders)
+	for i := range senderKeys {
+		key, err := crypto.GenerateKey()
+		require.NoError(t, err)
+		senderKeys[i] = key
+	}
+
+	genesis, coinbaseKey := engineapitester.DefaultEngineApiTesterGenesis(t)
+	for _, key := range senderKeys {
+		addr := crypto.PubkeyToAddress(key.PublicKey)
+		genesis.Alloc[addr] = types.GenesisAccount{
+			Balance: new(big.Int).Exp(big.NewInt(10), big.NewInt(20), nil), // 100 ETH each
+		}
+	}
+
+	eat := engineapitester.InitialiseEngineApiTester(t, engineapitester.EngineApiTesterInitArgs{
+		Logger:      testlog.Logger(t, log.LvlDebug),
+		DataDir:     t.TempDir(),
+		Genesis:     genesis,
+		CoinbaseKey: coinbaseKey,
+	})
+
+	receiver := common.HexToAddress("0xaaaa")
+
+	eat.Run(t, func(ctx context.Context, t *testing.T, eat engineapitester.EngineApiTester) {
+		// Submit one transfer from each independent sender.
+		txHashes := make([]common.Hash, numSenders)
+		for i, key := range senderKeys {
+			txn, err := eat.Transactor.SubmitSimpleTransfer(key, receiver, big.NewInt(1))
+			require.NoError(t, err)
+			txHashes[i] = txn.Hash()
+		}
+
+		// BuildCanonicalBlock assembles (sequential) then validates via
+		// newPayload (parallel executor). A BAL hash mismatch will surface
+		// as an INVALID payload status, which BuildCanonicalBlock returns
+		// as an error.
+		payload, err := eat.MockCl.BuildCanonicalBlock(ctx)
+		require.NoError(t, err)
+
+		err = eat.TxnInclusionVerifier.VerifyTxnsInclusion(ctx, payload.ExecutionPayload, txHashes...)
+		require.NoError(t, err)
+
+		bal := decodeAndValidateBAL(t, payload)
+
+		blockNumber := rpc.BlockNumber(payload.ExecutionPayload.BlockNumber)
+		block, err := eat.RpcApiClient.GetBlockByNumber(ctx, blockNumber, false)
+		require.NoError(t, err)
+		require.NotNil(t, block.BlockAccessListHash)
+		require.Equal(t, bal.Hash(), *block.BlockAccessListHash)
+	})
+}
 
 func TestEngineApiGeneratedPayloadIncludesBlockAccessList(t *testing.T) {
 	if !dbg.Exec3Parallel {

--- a/execution/stagedsync/bal_create.go
+++ b/execution/stagedsync/bal_create.go
@@ -96,20 +96,10 @@ func ProcessBAL(tx kv.TemporalRwTx, h *types.Header, vio *state.VersionedIO, ams
 			return fmt.Errorf("block %d: invalid block access list, hash mismatch: got %s expected %s", blockNum, dbBAL.Hash(), headerBALHash)
 		}
 	}
-	// Validate computed BAL against header. The parallel executor's speculative
-	// execution can produce slightly different storage reads than sequential
-	// execution (the block assembler), so when the stored BAL (from the proposer's
-	// sequential block assembler) matches the header, trust it even if the
-	// computed BAL differs. The state root check (commitment verification) still
-	// guarantees execution correctness.
+	// Always validate computed BAL against header. The BalancePath cross-check
+	// in VersionMap.validateRead ensures deterministic parallel execution even
+	// without a stored BAL body (HasBAL=false), so the computed BAL is accurate.
 	if headerBALHash != bal.Hash() {
-		if dbBALBytes != nil {
-			if dbBAL2, decErr := types.DecodeBlockAccessListBytes(dbBALBytes); decErr == nil && dbBAL2 != nil && dbBAL2.Hash() == headerBALHash {
-				log.Debug("BAL: computed BAL differs from stored/header, trusting stored BAL",
-					"block", blockNum, "computedHash", bal.Hash(), "headerHash", headerBALHash)
-				return nil
-			}
-		}
 		if dataDir != "" {
 			balDir := filepath.Join(dataDir, "bal")
 			if err := os.MkdirAll(balDir, 0o755); err != nil {

--- a/execution/stagedsync/bal_create.go
+++ b/execution/stagedsync/bal_create.go
@@ -100,6 +100,7 @@ func ProcessBAL(tx kv.TemporalRwTx, h *types.Header, vio *state.VersionedIO, ams
 	// in VersionMap.validateRead ensures deterministic parallel execution even
 	// without a stored BAL body (HasBAL=false), so the computed BAL is accurate.
 	if headerBALHash != bal.Hash() {
+		dumpDir := ""
 		if dataDir != "" {
 			balDir := filepath.Join(dataDir, "bal")
 			if err := os.MkdirAll(balDir, 0o755); err != nil {
@@ -108,6 +109,8 @@ func ProcessBAL(tx kv.TemporalRwTx, h *types.Header, vio *state.VersionedIO, ams
 				computedPath := filepath.Join(balDir, fmt.Sprintf("computed_bal_%d.txt", blockNum))
 				if err := os.WriteFile(computedPath, []byte(bal.DebugString()), 0o644); err != nil {
 					log.Warn("failed to write computed BAL debug file", "path", computedPath, "err", err)
+				} else {
+					dumpDir = balDir
 				}
 				dbBAL2, err := types.DecodeBlockAccessListBytes(dbBALBytes)
 				if err != nil {
@@ -120,7 +123,12 @@ func ProcessBAL(tx kv.TemporalRwTx, h *types.Header, vio *state.VersionedIO, ams
 				}
 			}
 		}
-		return fmt.Errorf("%w, block=%d: block access list mismatch: got %s expected %s", rules.ErrInvalidBlock, blockNum, bal.Hash(), headerBALHash)
+		if dumpDir != "" {
+			return fmt.Errorf("%w, block=%d (hash=%s): block access list mismatch: got %s expected %s; debug dumps in %s",
+				rules.ErrInvalidBlock, blockNum, blockHash, bal.Hash(), headerBALHash, dumpDir)
+		}
+		return fmt.Errorf("%w, block=%d (hash=%s): block access list mismatch: got %s expected %s",
+			rules.ErrInvalidBlock, blockNum, blockHash, bal.Hash(), headerBALHash)
 	}
 	return nil
 }

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -389,8 +389,9 @@ func (pe *parallelExecutor) exec(ctx context.Context, execStage *StageState, u U
 								return err
 							}
 
-							if (pe.cfg.chainConfig.IsAmsterdam(applyResult.BlockTime) || pe.cfg.experimentalBAL) && !applyResult.isPartial {
-								err = ProcessBAL(rwTx, lastHeader, applyResult.TxIO, pe.cfg.chainConfig.IsAmsterdam(applyResult.BlockTime), pe.cfg.experimentalBAL, pe.cfg.dirs.DataDir)
+							amsterdam := pe.cfg.chainConfig.IsAmsterdam(applyResult.BlockTime)
+							if (amsterdam || pe.cfg.experimentalBAL) && !applyResult.isPartial {
+								err = ProcessBAL(rwTx, lastHeader, applyResult.TxIO, amsterdam, pe.cfg.experimentalBAL, pe.cfg.dirs.DataDir)
 								if err != nil {
 									return err
 								}

--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -2288,6 +2288,41 @@ func (sdb *IntraBlockState) MarkReadsInternal(addr accounts.Address) {
 	}
 }
 
+// SnapshotVersionedReadKeys returns the current set of read keys for addr.
+// Used with MarkNewReadsInternal to mark only reads added after the snapshot,
+// preserving pre-existing legitimate reads.
+func (sdb *IntraBlockState) SnapshotVersionedReadKeys(addr accounts.Address) map[AccountKey]struct{} {
+	if sdb.versionedReads == nil {
+		return nil
+	}
+	reads := sdb.versionedReads[addr]
+	if len(reads) == 0 {
+		return nil
+	}
+	snapshot := make(map[AccountKey]struct{}, len(reads))
+	for k := range reads {
+		snapshot[k] = struct{}{}
+	}
+	return snapshot
+}
+
+// MarkNewReadsInternal marks as internal only the reads for addr that were
+// added after the given snapshot. Use this when gas-calculation-only reads
+// were recorded on top of earlier legitimate reads — the legitimate ones
+// must remain non-internal so they appear in the block access list.
+func (sdb *IntraBlockState) MarkNewReadsInternal(addr accounts.Address, before map[AccountKey]struct{}) {
+	if sdb.versionedReads == nil {
+		return
+	}
+	for key, vr := range sdb.versionedReads[addr] {
+		if _, existed := before[key]; existed {
+			continue
+		}
+		vr.internal = true
+		sdb.versionedReads[addr][key] = vr
+	}
+}
+
 // AccessedAddresses returns and resets the set of addresses touched during the current transaction.
 func (sdb *IntraBlockState) AccessedAddresses() AccessSet {
 	if len(sdb.addressAccess) == 0 {

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -1349,13 +1349,21 @@ func (account *accountState) updateWrite(vw *VersionedWrite, accessIndex uint16)
 			return
 		}
 		// If we haven't seen a balance and the first write is zero, treat it
-		// as a touch only — but ONLY when a prior read confirmed the initial
-		// balance was already zero. Without a read we cannot prove the write
-		// is a no-op (e.g. a sender whose balance was depleted to zero by gas
-		// may have no BalancePath read in blockIO due to the parallel
-		// executor's finalize-path read stripping).
+		// as a touch only when the pre-block balance is (or is implicitly) zero:
+		//   - No prior read: the account wasn't accessed before, so its
+		//     pre-block balance is implicitly zero (e.g. a newly CREATE'd
+		//     contract or a receiver observed only via the post-write finalize
+		//     path). Writing zero is a no-op.
+		//   - Prior read showed zero: write matches initial state, no-op.
+		// If a prior read showed a non-zero pre-block balance, the zero write
+		// is a genuine depletion (e.g. a sender whose funds were consumed by
+		// gas) and must be recorded as a real balance change.
 		if account.balanceValue == nil && val.IsZero() &&
-			account.initialBalanceValue != nil && account.initialBalanceValue.IsZero() {
+			(account.initialBalanceValue == nil || account.initialBalanceValue.IsZero()) {
+			if account.initialBalanceValue == nil {
+				v := val
+				account.initialBalanceValue = &v
+			}
 			account.setBalanceValue(val)
 			return
 		}
@@ -1417,12 +1425,8 @@ func (account *accountState) updateRead(vr *VersionedRead) {
 		case BalancePath:
 			if val, ok := vr.Val.(uint256.Int); ok {
 				// Record the initial (pre-block) balance for net-zero detection.
-				// Only set from the first read AND only before any writes have
-				// been recorded. A read that arrives after a write (e.g. the
-				// block-end finalize in the parallel executor reading from a
-				// fresh IBS) reflects post-write state, not the pre-block
-				// balance, and must not be used for net-zero filtering.
-				if account.initialBalanceValue == nil && account.balanceValue == nil {
+				// Only the first read is the original pre-block value.
+				if account.initialBalanceValue == nil {
 					v := val
 					account.initialBalanceValue = &v
 				}

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -1417,8 +1417,12 @@ func (account *accountState) updateRead(vr *VersionedRead) {
 		case BalancePath:
 			if val, ok := vr.Val.(uint256.Int); ok {
 				// Record the initial (pre-block) balance for net-zero detection.
-				// Only the first read is the original pre-block value.
-				if account.initialBalanceValue == nil {
+				// Only set from the first read AND only before any writes have
+				// been recorded. A read that arrives after a write (e.g. the
+				// block-end finalize in the parallel executor reading from a
+				// fresh IBS) reflects post-write state, not the pre-block
+				// balance, and must not be used for net-zero filtering.
+				if account.initialBalanceValue == nil && account.balanceValue == nil {
 					v := val
 					account.initialBalanceValue = &v
 				}

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -1348,12 +1348,14 @@ func (account *accountState) updateWrite(vw *VersionedWrite, accessIndex uint16)
 		if account.selfDestructed && accessIndex == account.selfDestructedAt && !val.IsZero() {
 			return
 		}
-		// If we haven't seen a balance and the first write is zero, treat it as a touch only.
-		if account.balanceValue == nil && val.IsZero() {
-			if account.initialBalanceValue == nil {
-				v := val
-				account.initialBalanceValue = &v
-			}
+		// If we haven't seen a balance and the first write is zero, treat it
+		// as a touch only — but ONLY when a prior read confirmed the initial
+		// balance was already zero. Without a read we cannot prove the write
+		// is a no-op (e.g. a sender whose balance was depleted to zero by gas
+		// may have no BalancePath read in blockIO due to the parallel
+		// executor's finalize-path read stripping).
+		if account.balanceValue == nil && val.IsZero() &&
+			account.initialBalanceValue != nil && account.initialBalanceValue.IsZero() {
 			account.setBalanceValue(val)
 			return
 		}

--- a/execution/tests/eest_devnet/block_test.go
+++ b/execution/tests/eest_devnet/block_test.go
@@ -50,13 +50,6 @@ func TestExecutionSpecBlockchainDevnet(t *testing.T) {
 	bt.Whitelist(`.*for_amsterdam/.*`)
 	// static — tested in state test format by TestState
 	bt.SkipLoad(`^for_amsterdam/static/state_tests/`)
-	// TODO(yperbasis): these two sub-tests exercise a sender whose balance
-	// is depleted to zero during a reverted CREATE containing a nested
-	// SELFDESTRUCT. The parallel executor's finalize path strips the
-	// sender's BalancePath read, leaving VersionedIO unable to distinguish
-	// a real depletion from a touch-only zero write. Skipped until the
-	// missing read is propagated into blockIO.
-	bt.SkipLoad(`create_oog_from_eoa_refunds\.json/.*-selfdestruct-oog_(code_deposit|invalid_opcode)\]$`)
 
 	bt.Walk(t, dir, func(t *testing.T, name string, test *testutil.BlockTest) {
 		// import pre accounts & construct test genesis block & state root

--- a/execution/tests/eest_devnet/block_test.go
+++ b/execution/tests/eest_devnet/block_test.go
@@ -50,6 +50,13 @@ func TestExecutionSpecBlockchainDevnet(t *testing.T) {
 	bt.Whitelist(`.*for_amsterdam/.*`)
 	// static — tested in state test format by TestState
 	bt.SkipLoad(`^for_amsterdam/static/state_tests/`)
+	// TODO(yperbasis): these two sub-tests exercise a sender whose balance
+	// is depleted to zero during a reverted CREATE containing a nested
+	// SELFDESTRUCT. The parallel executor's finalize path strips the
+	// sender's BalancePath read, leaving VersionedIO unable to distinguish
+	// a real depletion from a touch-only zero write. Skipped until the
+	// missing read is propagated into blockIO.
+	bt.SkipLoad(`create_oog_from_eoa_refunds\.json/.*-selfdestruct-oog_(code_deposit|invalid_opcode)\]$`)
 
 	bt.Walk(t, dir, func(t *testing.T, name string, test *testutil.BlockTest) {
 		// import pre accounts & construct test genesis block & state root

--- a/execution/vm/operations_acl.go
+++ b/execution/vm/operations_acl.go
@@ -273,21 +273,22 @@ func makeSelfdestructGasFn(refundsEnabled bool) gasFunc {
 			return mdgas.MdGas{}, err
 		}
 		// Record the beneficiary address access for BAL tracking when the
-		// contract has non-zero balance.  A zero-balance selfdestruct does
+		// contract has non-zero balance. A zero-balance SELFDESTRUCT does
 		// not transfer value, so the beneficiary should not appear in the
-		// block access list.  Skip in read-only context (STATICCALL) where
-		// SELFDESTRUCT will be rejected by ErrWriteProtection.
-		if !evm.readOnly && !balance.IsZero() {
+		// block access list on that basis alone.
+		// (The read-only path is unreachable here — see the early-return
+		// above.)
+		if !balance.IsZero() {
 			evm.IntraBlockState().MarkAddressAccess(address, false)
 		}
-		// When balance is zero OR we're in a read-only (STATICCALL) context,
-		// and the beneficiary differs from self, mark the reads added by the
-		// Empty() gas-calc call as internal.  In both cases those reads
-		// exist purely for gas calculation — no value is actually transferred
-		// (zero balance) or SELFDESTRUCT will be rejected (read-only).
-		// Pre-existing reads are preserved.  Skip when beneficiary == self to
-		// avoid incorrectly marking the contract's own legitimate reads.
-		if (balance.IsZero() || evm.readOnly) && address != callContext.Address() {
+		// When the destructed contract has zero balance, no value is
+		// transferred to the beneficiary. Mark the reads the Empty() gas-calc
+		// call above added for this beneficiary as internal so the
+		// beneficiary does not appear in the BAL purely because of that
+		// gas-calc access. Pre-existing reads are preserved. Skip when
+		// beneficiary == self so the contract's own legitimate reads are
+		// not affected.
+		if balance.IsZero() && address != callContext.Address() {
 			evm.IntraBlockState().MarkNewReadsInternal(address, beneficiaryReadsBefore)
 		}
 		if empty && !balance.IsZero() {

--- a/execution/vm/operations_acl.go
+++ b/execution/vm/operations_acl.go
@@ -257,6 +257,12 @@ func makeSelfdestructGasFn(refundsEnabled bool) gasFunc {
 			evm.IntraBlockState().AddAddressToAccessList(address)
 		}
 
+		// Snapshot the beneficiary's existing reads before Empty() — so we can
+		// later mark only the reads newly recorded by the gas calc as internal,
+		// preserving any pre-existing legitimate reads (e.g. the tx sender's
+		// fee-deduction balance read when the sender is the SELFDESTRUCT
+		// beneficiary).
+		beneficiaryReadsBefore := evm.IntraBlockState().SnapshotVersionedReadKeys(address)
 		// if empty and transfers value
 		empty, err := evm.IntraBlockState().Empty(address)
 		if err != nil {
@@ -275,14 +281,14 @@ func makeSelfdestructGasFn(refundsEnabled bool) gasFunc {
 			evm.IntraBlockState().MarkAddressAccess(address, false)
 		}
 		// When balance is zero OR we're in a read-only (STATICCALL) context,
-		// and the beneficiary differs from self, mark the beneficiary's reads
-		// as internal.  In both cases the Empty() call above recorded versioned
-		// reads for the beneficiary purely for gas calculation — no value is
-		// actually transferred (zero balance) or SELFDESTRUCT will be rejected
-		// (read-only).  Skip when beneficiary == self to avoid incorrectly
-		// marking the contract's own legitimate reads.
+		// and the beneficiary differs from self, mark the reads added by the
+		// Empty() gas-calc call as internal.  In both cases those reads
+		// exist purely for gas calculation — no value is actually transferred
+		// (zero balance) or SELFDESTRUCT will be rejected (read-only).
+		// Pre-existing reads are preserved.  Skip when beneficiary == self to
+		// avoid incorrectly marking the contract's own legitimate reads.
 		if (balance.IsZero() || evm.readOnly) && address != callContext.Address() {
-			evm.IntraBlockState().MarkReadsInternal(address)
+			evm.IntraBlockState().MarkNewReadsInternal(address, beneficiaryReadsBefore)
 		}
 		if empty && !balance.IsZero() {
 			if evm.chainRules.IsAmsterdam {


### PR DESCRIPTION
## Summary

Enforce strict EIP-7928 block-access-list validation end-to-end. Removes a silent-accept fallback that was masking BAL computation bugs, and fixes the two bugs that the unmasking exposed.

## Changes

### Strict BAL validation — `execution/stagedsync/bal_create.go`, `exec3_parallel.go`

`ProcessBAL` now always validates the computed BAL against the header hash. The previous `dbBALBytes` fallback silently accepted a stored BAL from an untrusted payload whenever it matched the header — bypassing EIP-7928 semantic validation. The `isForkValidation` parameter that guarded the fallback is removed.

### Zero-balance write filter — `execution/state/versionedio.go`

`accountState.updateWrite` previously treated ANY first zero-balance write as touch-only, dropping legitimate depletion-to-zero writes (e.g. a sender whose balance was consumed by gas) whenever no prior read was present. The condition now requires either:

- no prior read (implicit pre-block zero — e.g. a newly-CREATE'd contract), or
- a prior read confirming pre-block zero.

If a prior read shows a non-zero pre-block balance, the zero write falls through and is recorded as a real balance change.

### SELFDESTRUCT gas-calc read marking — `execution/vm/operations_acl.go`, `execution/state/intra_block_state.go`

`makeSelfdestructGasFn` previously marked ALL of a beneficiary's versioned reads as internal when the destructed contract had zero balance (or we were in a read-only context). This was too broad: if the beneficiary already had legitimate reads from earlier in the transaction — e.g. the tx sender's fee-deduction BalancePath read when sender == beneficiary — those reads were also stripped from the BAL.

New `SnapshotVersionedReadKeys` / `MarkNewReadsInternal` helpers scope the internal marking to only the reads newly recorded by the gas-calc `Empty()` call; pre-existing legitimate reads are preserved.

### New test — `execution/engineapi/engine_api_bal_test.go`

`TestEngineApiBALMultiSenderBlock` packs transfers from 10 independent senders into a single block, exercising the parallel executor's coinbase-balance strip→rebase→merge path and validating the computed BAL against the assembler's.

## Test plan

- [x] All `create_oog_from_eoa_refunds` subtests pass (24/24, including the previously-failing `selfdestruct-oog_code_deposit` / `selfdestruct-oog_invalid_opcode` variants)
- [x] Amsterdam devnet full fork coverage passes (berlin / byzantium / cancun / constantinople / frontier / homestead / istanbul / london / osaka / paris / prague / shanghai / tangerine_whistle)
- [x] `eest_blockchain` cancun + prague pass
- [x] `execution/state`, `execution/stagedsync`, `execution/engineapi` unit tests pass
- [x] `make lint` clean

## Related

#20620 tracks a pre-existing gap — a zero-balance SELFDESTRUCT to an otherwise-untouched beneficiary should still include the beneficiary as an accessed address per EIP-7928. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)