### PR TITLE
commitment: preserve loadStateIfNeeded counters

### DIFF
--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -2293,7 +2293,7 @@ func (hph *HexPatriciaHashed) loadStateIfNeeded(cell *cell, counters skipStat) (
 			hph.metrics.AccountLoad(cell.accountAddr[:cell.accountAddrLen])
 			upd, err := hph.accountFromCacheOrDB(cell.accountAddr[:cell.accountAddrLen])
 			if err != nil {
-				return skipStat{}, err
+				return counters, err
 			}
 			cell.setFromUpdate(upd)
 			// if the update is empty, the loaded flag was not updated so do it manually
@@ -2304,7 +2304,7 @@ func (hph *HexPatriciaHashed) loadStateIfNeeded(cell *cell, counters skipStat) (
 			hph.metrics.StorageLoad(cell.storageAddr[:cell.storageAddrLen])
 			upd, err := hph.storageFromCacheOrDB(cell.storageAddr[:cell.storageAddrLen])
 			if err != nil {
-				return skipStat{}, err
+				return counters, err
 			}
 			cell.setFromUpdate(upd)
 			// if the update is empty, the loaded flag was not updated so do it manually
@@ -2312,7 +2312,7 @@ func (hph *HexPatriciaHashed) loadStateIfNeeded(cell *cell, counters skipStat) (
 			counters.storLoaded++
 		}
 	}
-	return skipStat{}, nil
+	return counters, nil
 }
 
 func (hph *HexPatriciaHashed) deleteCell(hashedKey []byte) {

--- a/execution/commitment/hex_patricia_hashed_test.go
+++ b/execution/commitment/hex_patricia_hashed_test.go
@@ -1157,6 +1157,51 @@ func Test_HexPatriciaHashed_StateRestoreAndContinue(t *testing.T) {
 	require.Equal(t, withoutRestore, afterRestore)
 }
 
+func TestHexPatriciaHashedLoadStateIfNeededReturnsCounters(t *testing.T) {
+	t.Parallel()
+
+	ms := NewMockState(t)
+	addrHex := "00112233445566778899aabbccddeeff00112233"
+	slotHex := "0000000000000000000000000000000000000000000000000000000000000042"
+
+	plainKeys, updates := NewUpdateBuilder().
+		Balance(addrHex, 1).
+		Nonce(addrHex, 2).
+		Storage(addrHex, slotHex, "01").
+		Build()
+	require.NoError(t, ms.applyPlainUpdates(plainKeys, updates))
+
+	hph := NewHexPatriciaHashed(length.Addr, ms)
+
+	t.Run("account", func(t *testing.T) {
+		var accountCell cell
+		addr := common.FromHex("0x" + addrHex)
+		copy(accountCell.accountAddr[:], addr)
+		accountCell.accountAddrLen = int16(len(addr))
+
+		counters := skipStat{accSkipped: 3}
+		got, err := hph.loadStateIfNeeded(&accountCell, counters)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), got.accLoaded)
+		require.Equal(t, counters.accSkipped, got.accSkipped)
+		require.True(t, accountCell.loaded.account())
+	})
+
+	t.Run("storage", func(t *testing.T) {
+		var storageCell cell
+		storageKey := append(common.FromHex("0x"+addrHex), common.FromHex("0x"+slotHex)...)
+		copy(storageCell.storageAddr[:], storageKey)
+		storageCell.storageAddrLen = int16(len(storageKey))
+
+		counters := skipStat{storSkipped: 4}
+		got, err := hph.loadStateIfNeeded(&storageCell, counters)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), got.storLoaded)
+		require.Equal(t, counters.storSkipped, got.storSkipped)
+		require.True(t, storageCell.loaded.storage())
+	})
+}
+
 func Test_HexPatriciaHashed_RestoreAndContinue(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Return the updated `skipStat` from `loadStateIfNeeded` instead of dropping the accumulated counters. Add a focused regression test covering both account and storage loads.

## Problem

`prepareBranchCells` and `foldPropagate` both store the returned `skipStat` back into `hph.hadToLoadL`, but `loadStateIfNeeded` always returned `skipStat{}`. That zeroed `accLoaded` and `storLoaded` after successful loads and polluted the levelled load statistics.

## Solution

Preserve the incoming counters on both success and error returns, and add a unit test that verifies prior skipped counts survive while the new load counts are incremented.