### PR TITLE
cmd/evm: fix false panic in benchmark error comparison

### DIFF
--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -111,8 +111,14 @@ func timedExec(bench bool, execFunc func() ([]byte, uint64, error)) (output []by
 				if haveGasUsed != gasUsed {
 					panic(fmt.Sprintf("gas differs, have %v want %v", haveGasUsed, gasUsed))
 				}
-				if haveErr != err {
-					panic(fmt.Sprintf("err differs, have %v want %v", haveErr, err))
+				// Compare errors by their string representation because struct-based
+				// errors (e.g. &ErrStackUnderflow{stackLen: n, required: m}) are
+				// distinct pointer allocations on each call, so direct == fails.
+				if (haveErr == nil) != (err == nil) {
+					panic(fmt.Sprintf("err differs in nil-ness, have %v want %v", haveErr, err))
+				}
+				if haveErr != nil && err != nil && haveErr.Error() != err.Error() {
+					panic(fmt.Sprintf("err differs, have %q want %q", haveErr.Error(), err.Error()))
 				}
 			}
 		})


### PR DESCRIPTION
`timedExec` uses direct interface inequality (`haveErr != err`) to compare errors across benchmark iterations. When `execFunc` returns newly allocated struct-based errors, such as `&ErrStackUnderflow{stackLen: n, required: m}`, this panics because each call generates a unique reference, even if the error indicates the same failure.

A two-step comparison should be used in favor of the straight `==` check: first, confirm that nil-ness matches, and then compare using the output of the `Error()` string. This accurately identifies divergent behavior without producing false positives due to mismatched pointer identities.