### PR TITLE
cmd/evm: fix gasUsed reporting in --create path

### DIFF
--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -315,7 +315,7 @@ func runCmd(ctx *cli.Context) error {
 		input = append(code, input...)
 		execFunc = func() ([]byte, uint64, error) {
 			output, _, gasLeft, err := runtime.Create(input, &runtimeConfig, 0)
-			return output, gasLeft.Total(), err
+			return output, initialGas - gasLeft.Total(), err
 		}
 	} else {
 		if len(code) > 0 {


### PR DESCRIPTION
## Summary

Fix gas accounting in `cmd/evm` for the `--create` execution path.

Previously, the `--create` branch returned `gasLeft` from `execFunc`, while the rest of the code treated the second return value as `gasUsed`. This made gas reporting incorrect and could cause `timedExec` benchmark consistency checks to fail.

## Change

Update the `--create` path in `cmd/evm/runner.go` to return:

`initialGas - gasLeft.Total()`

instead of returning remaining gas directly.

## Result

This makes gas accounting consistent between create and call execution paths, fixes the reported `gasUsed` value, and keeps benchmark validation in `timedExec` aligned with the actual meaning of the returned value.
