### PR TITLE
node/eth, db/downloader: gate chain.toml v2 publish paths behind --snap.p2p-manifest

### DIFF
--- a/db/downloader/downloader.go
+++ b/db/downloader/downloader.go
@@ -807,8 +807,12 @@ func (d *Downloader) DownloadSnapshots(ctx context.Context, items []preverifiedS
 	}
 
 	// After downloads complete, regenerate chain.toml with all available torrents.
-	if pubErr := d.PublishLocalChainToml(); pubErr != nil {
-		d.logger.Warn("[Downloader] failed to publish chain.toml after download", "err", pubErr)
+	// Only republish when P2P manifest mode is opt-in (matches the gate in backend.go);
+	// manifestReady is non-nil iff EnableP2PManifest was called by the backend.
+	if d.manifestReady != nil {
+		if pubErr := d.PublishLocalChainToml(); pubErr != nil {
+			d.logger.Warn("[Downloader] failed to publish chain.toml after download", "err", pubErr)
+		}
 	}
 	return
 }

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -538,7 +538,11 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 	}
 
 	// Wire chain.toml ENR updater and P2P discovery after sentry servers are created.
-	if backend.downloader != nil && len(backend.sentryServers) > 0 {
+	// The entire chain.toml v2 publishing / discovery / torrent-peer-manager stack is
+	// gated behind --snap.p2p-manifest so opt-in users get the new flow while default
+	// syncs keep the pre-v2 behaviour (avoids a torrent-name collision between the
+	// locally-seeded chain.toml and the downloaded chain.toml.torrent).
+	if backend.downloader != nil && len(backend.sentryServers) > 0 && backend.config.Snapshot.P2PManifest {
 		backend.downloader.SetENRUpdater(func(ct enr.ChainToml) {
 			// Resolve the torrent port at update time rather than capture-time:
 			// the torrent client may not be listening yet when the updater
@@ -1458,8 +1462,13 @@ func (s *Ethereum) initDownloader(
 	// Generate chain.toml from existing torrents on disk. The ENR updater is wired
 	// later (after this function returns), so the ENR update will be a no-op here.
 	// The background loop will re-publish with the correct frozenTx once P2P is up.
-	if pubErr := s.downloader.PublishLocalChainToml(); pubErr != nil {
-		s.logger.Warn("Failed to publish initial chain.toml", "err", pubErr)
+	// Only publish when P2P manifest mode is opt-in; otherwise a locally-seeded
+	// chain.toml collides with a subsequently-downloaded chain.toml.torrent in
+	// AddTorrentsFromDisk (see getExistingSnapshotTorrent).
+	if s.config.Snapshot.P2PManifest {
+		if pubErr := s.downloader.PublishLocalChainToml(); pubErr != nil {
+			s.logger.Warn("Failed to publish initial chain.toml", "err", pubErr)
+		}
 	}
 
 	bittorrentServer, err := downloader.NewGrpcServer(s.downloader)


### PR DESCRIPTION
## Summary

- Fix fresh-mainnet-sync regression introduced with the chain.toml v2 merge: the publish/seed stack was running unconditionally and collided with the downloaded `chain.toml.torrent` during post-OtterSync `AddTorrentsFromDisk`, aborting the execution service with `snapshot exists with a different name: "chain.toml"`.
- Gate the three unconditional v2 call sites on the existing `--snap.p2p-manifest` flag (default `false`) so default syncs stay on the pre-v2 path while opt-in users get the full v2 flow.

## Reproduction (before this change)

```
USE_STATE_CACHE=false ./build/bin/erigon \
  --datadir=<fresh> --chain=mainnet --prune.mode=minimal
```

Fails during stage `[1/6 OtterSync]` immediately after `Downloader completed remaining snapshots`:

```
[EROR] Could not start execution service
  err="[1/6 OtterSync] after snapshot download: adding torrents from disk:
       adding torrent for chain.toml.torrent:
       snapshot exists with a different name: \"chain.toml\""
```

Collision originates in `getExistingSnapshotTorrent` ([db/downloader/downloader.go:1683](https://github.com/erigontech/erigon/blob/main/db/downloader/downloader.go#L1683)) — the locally-seeded `chain.toml` torrent is already registered under that info-hash when the disk-scanned `chain.toml.torrent` tries to add.

## Change

Three gated sites, all tied to the pre-existing `--snap.p2p-manifest` flag (usage: *"Discover snapshot manifest (chain.toml) from P2P peers via ENR instead of using centralized preverified.toml"* — default `false`):

1. [node/eth/backend.go:541](https://github.com/erigontech/erigon/blob/main/node/eth/backend.go#L541) — wrap the whole ENR updater / `SetNodeSourceFn` / delayed `PublishLocalChainToml` / `StartChainTomlDiscovery` / `StartTorrentPeerManager` block in `&& backend.config.Snapshot.P2PManifest`.
2. [node/eth/backend.go:1461](https://github.com/erigontech/erigon/blob/main/node/eth/backend.go#L1461) — gate the initial publish in `initDownloader()`.
3. [db/downloader/downloader.go:810](https://github.com/erigontech/erigon/blob/main/db/downloader/downloader.go#L810) — gate the post-download republish using `d.manifestReady != nil`, which is the internal signal that `EnableP2PManifest()` was invoked by the backend. This also covers the loop-internal publish in `chainTomlDiscoveryLoop` (only runs under P2P manifest mode).

Default `--snap.p2p-manifest=false` ⇒ **zero v2 behaviour** ⇒ collision avoided.
Opt-in `--snap.p2p-manifest=true` ⇒ full v2 publish + discover + peer-manager flow preserved.

## Test plan

- [x] `make lint` — 0 issues
- [x] `make erigon` — builds clean
- [x] `go test -short ./db/downloader/...` — passes (`chaintoml_test.go`, `chaintoml_v2_test.go` call `PublishChainToml` directly, unaffected)
- [x] `go vet ./node/eth/... ./db/downloader/...` — clean
- [ ] Manual: fresh `--chain=mainnet` sync with default flags completes OtterSync and enters Headers stage without the collision error (reviewer to confirm on their setup — original reproducer took ~13 min to hit the crash point)
- [ ] Manual: fresh sync with `--snap.p2p-manifest=true` still performs chain.toml discovery / publishing as before (v2 behaviour preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)