### PR TITLE
claude: improve test skills with submodule and ramdisk prerequisites

### DIFF
--- a/.claude/skills/erigon-test-all/SKILL.md
+++ b/.claude/skills/erigon-test-all/SKILL.md
@@ -7,6 +7,16 @@ description: Run the full Erigon test suite locally using GOGC=80 make test-all.
 
 Runs the complete test suite with 60-minute timeout and coverage output. Takes ~30 minutes.
 
+## Prerequisite: Update Submodules
+
+Before running `make test-all`, always sync git submodules:
+
+```bash
+git submodule update --init --recursive --force
+```
+
+Most tests in `execution/tests` load test fixtures from a git submodule (`execution/tests/execution-spec-tests`). Without this step the fixture files are missing or stale and tests will fail or skip silently. The CI workflow clones submodules automatically (`submodules: true` in `test-all-erigon.yml`); locally you must do it yourself.
+
 ## Command
 
 ```bash
@@ -54,7 +64,7 @@ Tests skipped via `-short` in `test-short` run fully here. If a test passes in `
 
 - Before marking a PR ready for review
 - After significant logic changes to verify no edge cases break
-- Full gate: `make lint && make erigon integration && GOGC=80 make test-all`
+- Full gate: `git submodule update --init --recursive --force && make lint && make erigon integration && GOGC=80 make test-all`
 
 ## CI Equivalent
 

--- a/.claude/skills/erigon-test-all/SKILL.md
+++ b/.claude/skills/erigon-test-all/SKILL.md
@@ -17,10 +17,22 @@ git submodule update --init --recursive --force
 
 Most tests in `execution/tests` load test fixtures from a git submodule (`execution/tests/execution-spec-tests`). Without this step the fixture files are missing or stale and tests will fail or skip silently. The CI workflow clones submodules automatically (`submodules: true` in `test-all-erigon.yml`); locally you must do it yourself.
 
+## Prerequisite: Create RAM Disk
+
+Before running `make test-all`, create a RAM disk and export its path as `ERIGON_EXECUTION_TESTS_TMPDIR`:
+
+```bash
+path=$(bash tools/create-ramdisk)
+```
+
+Then prepend `ERIGON_EXECUTION_TESTS_TMPDIR=$path` to the test command (see below). The `execution/tests` suite does heavy temp-file I/O; backing that with tmpfs avoids disk bottlenecks and matches how CI runs the same workflow (`ramdisk: true` in `test-all-erigon.yml`, which invokes the same `tools/create-ramdisk` script via `setup-erigon`).
+
+The script is cross-platform (Linux tmpfs, macOS hdiutil, Windows ImDisk). Linux requires `sudo` to mount tmpfs at `/mnt/erigon-ramdisk`. Override size with `RAMDISK_SIZE_MB` (default 2048).
+
 ## Command
 
 ```bash
-GOGC=80 make test-all
+ERIGON_EXECUTION_TESTS_TMPDIR=$path GOGC=80 make test-all
 ```
 
 Equivalent to the **"All tests"** GitHub Actions workflow (`test-all-erigon.yml`).
@@ -64,7 +76,7 @@ Tests skipped via `-short` in `test-short` run fully here. If a test passes in `
 
 - Before marking a PR ready for review
 - After significant logic changes to verify no edge cases break
-- Full gate: `git submodule update --init --recursive --force && make lint && make erigon integration && GOGC=80 make test-all`
+- Full gate: `git submodule update --init --recursive --force && path=$(bash tools/create-ramdisk) && make lint && make erigon integration && ERIGON_EXECUTION_TESTS_TMPDIR=$path GOGC=80 make test-all`
 
 ## CI Equivalent
 

--- a/.claude/skills/erigon-test-race/SKILL.md
+++ b/.claude/skills/erigon-test-race/SKILL.md
@@ -17,10 +17,22 @@ git submodule update --init --recursive --force
 
 Most tests in `execution/tests` load test fixtures from a git submodule (`execution/tests/execution-spec-tests`). Without this step the fixture files are missing or stale and tests will fail or skip silently. The CI workflow clones submodules automatically (`submodules: true` in `test-all-erigon-race.yml`); locally you must do it yourself.
 
+## Prerequisite: Create RAM Disk
+
+Before running `make test-all-race`, create a RAM disk and export its path as `ERIGON_EXECUTION_TESTS_TMPDIR`:
+
+```bash
+path=$(bash tools/create-ramdisk)
+```
+
+Then prepend `ERIGON_EXECUTION_TESTS_TMPDIR=$path` to the test command (see below). The `execution/tests` suite does heavy temp-file I/O; backing that with tmpfs avoids disk bottlenecks and matches how CI runs the same workflow (`ramdisk: true` in `test-all-erigon-race.yml`, which invokes the same `tools/create-ramdisk` script via `setup-erigon`).
+
+The script is cross-platform (Linux tmpfs, macOS hdiutil, Windows ImDisk). Linux requires `sudo` to mount tmpfs at `/mnt/erigon-ramdisk`. Override size with `RAMDISK_SIZE_MB` (default 2048).
+
 ## Command
 
 ```bash
-make test-all-race
+ERIGON_EXECUTION_TESTS_TMPDIR=$path make test-all-race
 ```
 
 ## When Tests Fail — Drill Down
@@ -67,7 +79,7 @@ Areas historically susceptible to races in Erigon:
 
 - After changes to the parallel executor or concurrent code paths
 - For concurrency-sensitive fixes before merging
-- Race check gate: `git submodule update --init --recursive --force && make lint && make test-all-race`
+- Race check gate: `git submodule update --init --recursive --force && path=$(bash tools/create-ramdisk) && make lint && ERIGON_EXECUTION_TESTS_TMPDIR=$path make test-all-race`
 
 ## CI Equivalent
 

--- a/.claude/skills/erigon-test-race/SKILL.md
+++ b/.claude/skills/erigon-test-race/SKILL.md
@@ -7,6 +7,16 @@ description: Run Erigon tests with Go race detector to find data races and concu
 
 Runs the full test suite with Go's `-race` flag. Catches concurrency bugs that normal tests miss. Takes 30–60 minutes.
 
+## Prerequisite: Update Submodules
+
+Before running `make test-all-race`, always sync git submodules:
+
+```bash
+git submodule update --init --recursive --force
+```
+
+Most tests in `execution/tests` load test fixtures from a git submodule (`execution/tests/execution-spec-tests`). Without this step the fixture files are missing or stale and tests will fail or skip silently. The CI workflow clones submodules automatically (`submodules: true` in `test-all-erigon-race.yml`); locally you must do it yourself.
+
 ## Command
 
 ```bash
@@ -57,7 +67,7 @@ Areas historically susceptible to races in Erigon:
 
 - After changes to the parallel executor or concurrent code paths
 - For concurrency-sensitive fixes before merging
-- Race check gate: `make lint && make test-all-race`
+- Race check gate: `git submodule update --init --recursive --force && make lint && make test-all-race`
 
 ## CI Equivalent
 


### PR DESCRIPTION
## Summary

  Documents two prerequisites in the `erigon-test-all` and `erigon-test-race` skills that the CI workflows handle automatically but that local runs must do manually:

  - **Submodule sync** — `git submodule update --init --recursive --force`, needed because most `execution/tests` tests load fixtures from the `execution-spec-tests` git submodule. Without it, fixture
  files are missing or stale and tests fail or skip silently.
  - **RAM disk** — `path=$(bash tools/create-ramdisk)` plus prepending `ERIGON_EXECUTION_TESTS_TMPDIR=$path` to the test command. The `execution/tests` suite does heavy temp-file I/O; backing it with
  tmpfs avoids disk bottlenecks and matches CI (`ramdisk: true` in `test-all-erigon.yml` / `test-all-erigon-race.yml`, which invokes the same `tools/create-ramdisk` script via `setup-erigon`).

  ## Files changed

  - `.claude/skills/erigon-test-all/SKILL.md` — added both prerequisite sections; updated `Command` and "Full gate" one-liner to `ERIGON_EXECUTION_TESTS_TMPDIR=$path GOGC=80 make test-all`.
  - `.claude/skills/erigon-test-race/SKILL.md` — same additions; updated `Command` and "Race check gate" one-liner to `ERIGON_EXECUTION_TESTS_TMPDIR=$path make test-all-race`.

  ## Test plan

  - [ ] Verify the updated skills render correctly when invoked
  - [ ] Run the documented `Full gate` / `Race check gate` one-liners end-to-end on a clean checkout to confirm they work as written
