### PR TITLE
[DO-NOT-MERGE] enable ExperimentalBAL and Exec3Parallel by default

### DIFF
--- a/cmd/erigon/node/config_snapshot_test.go
+++ b/cmd/erigon/node/config_snapshot_test.go
@@ -116,7 +116,7 @@ func TestConfigDefaults(t *testing.T) {
 	require.Equal(t, uint64(1), snap.NetworkID, "default network should be mainnet")
 	require.True(t, snap.StateStream, "state stream should be enabled by default")
 	require.True(t, snap.InternalCL, "internal CL (Caplin) is on by default")
-	require.False(t, snap.ExperimentalBAL, "experimental BAL should be off by default")
+	require.True(t, snap.ExperimentalBAL, "experimental BAL should be on by default on bal-devnet branches")
 	require.False(t, snap.KeepExecutionProofs, "keep execution proofs should be off by default")
 
 	// Snapshot defaults
@@ -210,6 +210,6 @@ func TestConfigSnapshotStability(t *testing.T) {
 	require.True(t, snap.StateStream)
 	require.True(t, snap.SnapProduceE2)
 	require.True(t, snap.SnapProduceE3)
-	require.False(t, snap.ExperimentalBAL)
+	require.True(t, snap.ExperimentalBAL)
 	require.False(t, snap.NoDownloader)
 }

--- a/common/dbg/experiments.go
+++ b/common/dbg/experiments.go
@@ -77,7 +77,7 @@ var (
 
 	CaplinSyncedDataMangerDeadlockDetection = EnvBool("CAPLIN_SYNCED_DATA_MANAGER_DEADLOCK_DETECTION", false)
 
-	Exec3Parallel        = EnvBool("EXEC3_PARALLEL", false)
+	Exec3Parallel        = EnvBool("EXEC3_PARALLEL", true)
 	numWorkers           = runtime.NumCPU() / 2
 	Exec3Workers         = EnvInt("EXEC3_WORKERS", numWorkers)
 	ExecTerseLoggerLevel = EnvInt("EXEC_TERSE_LOGGER_LEVEL", int(log.LvlWarn))

--- a/execution/engineapi/engine_api_bal_test.go
+++ b/execution/engineapi/engine_api_bal_test.go
@@ -18,6 +18,7 @@ package engineapi_test
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"math/big"
 	"testing"
 
@@ -27,6 +28,8 @@ import (
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/crypto"
 	"github.com/erigontech/erigon/common/dbg"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/common/testlog"
 	"github.com/erigontech/erigon/execution/abi/bind"
 	"github.com/erigontech/erigon/execution/engineapi/engineapitester"
 	"github.com/erigontech/erigon/execution/protocol/params"
@@ -36,6 +39,70 @@ import (
 	"github.com/erigontech/erigon/rpc"
 	"github.com/erigontech/erigon/rpc/jsonrpc/contracts"
 )
+
+// TestEngineApiBALMultiSenderBlock packs transfers from many independent senders
+// into a single block. Because the senders are independent the parallel executor
+// speculatively executes them concurrently, exercising the coinbase-balance
+// strip→rebase→merge path in finalizeWithIBS. Any divergence between the
+// assembler's BAL (sequential) and the parallel executor's BAL surfaces as a
+// BAL hash mismatch returned by ProcessBAL.
+func TestEngineApiBALMultiSenderBlock(t *testing.T) {
+	if !dbg.Exec3Parallel {
+		t.Skip("requires parallel exec")
+	}
+	const numSenders = 10
+	senderKeys := make([]*ecdsa.PrivateKey, numSenders)
+	for i := range senderKeys {
+		key, err := crypto.GenerateKey()
+		require.NoError(t, err)
+		senderKeys[i] = key
+	}
+
+	genesis, coinbaseKey := engineapitester.DefaultEngineApiTesterGenesis(t)
+	for _, key := range senderKeys {
+		addr := crypto.PubkeyToAddress(key.PublicKey)
+		genesis.Alloc[addr] = types.GenesisAccount{
+			Balance: new(big.Int).Exp(big.NewInt(10), big.NewInt(20), nil), // 100 ETH each
+		}
+	}
+
+	eat := engineapitester.InitialiseEngineApiTester(t, engineapitester.EngineApiTesterInitArgs{
+		Logger:      testlog.Logger(t, log.LvlDebug),
+		DataDir:     t.TempDir(),
+		Genesis:     genesis,
+		CoinbaseKey: coinbaseKey,
+	})
+
+	receiver := common.HexToAddress("0xaaaa")
+
+	eat.Run(t, func(ctx context.Context, t *testing.T, eat engineapitester.EngineApiTester) {
+		// Submit one transfer from each independent sender.
+		txHashes := make([]common.Hash, numSenders)
+		for i, key := range senderKeys {
+			txn, err := eat.Transactor.SubmitSimpleTransfer(key, receiver, big.NewInt(1))
+			require.NoError(t, err)
+			txHashes[i] = txn.Hash()
+		}
+
+		// BuildCanonicalBlock assembles (sequential) then validates via
+		// newPayload (parallel executor). A BAL hash mismatch will surface
+		// as an INVALID payload status, which BuildCanonicalBlock returns
+		// as an error.
+		payload, err := eat.MockCl.BuildCanonicalBlock(ctx)
+		require.NoError(t, err)
+
+		err = eat.TxnInclusionVerifier.VerifyTxnsInclusion(ctx, payload.ExecutionPayload, txHashes...)
+		require.NoError(t, err)
+
+		bal := decodeAndValidateBAL(t, payload)
+
+		blockNumber := rpc.BlockNumber(payload.ExecutionPayload.BlockNumber)
+		block, err := eat.RpcApiClient.GetBlockByNumber(ctx, blockNumber, false)
+		require.NoError(t, err)
+		require.NotNil(t, block.BlockAccessListHash)
+		require.Equal(t, bal.Hash(), *block.BlockAccessListHash)
+	})
+}
 
 func TestEngineApiGeneratedPayloadIncludesBlockAccessList(t *testing.T) {
 	if !dbg.Exec3Parallel {

--- a/execution/execmodule/execmoduletester/exec_module_tester.go
+++ b/execution/execmodule/execmoduletester/exec_module_tester.go
@@ -366,7 +366,7 @@ func applyOptions(opts []Option) options {
 		pruneMode:       &defaultPruneMode,
 		blockBufferSize: 128,
 		chainConfig:     chain.TestChainBerlinConfig,
-		experimentalBAL: false,
+		experimentalBAL: true,
 	}
 	for _, o := range opts {
 		o(&opt)

--- a/execution/stagedsync/bal_create.go
+++ b/execution/stagedsync/bal_create.go
@@ -96,20 +96,10 @@ func ProcessBAL(tx kv.TemporalRwTx, h *types.Header, vio *state.VersionedIO, ams
 			return fmt.Errorf("block %d: invalid block access list, hash mismatch: got %s expected %s", blockNum, dbBAL.Hash(), headerBALHash)
 		}
 	}
-	// Validate computed BAL against header. The parallel executor's speculative
-	// execution can produce slightly different storage reads than sequential
-	// execution (the block assembler), so when the stored BAL (from the proposer's
-	// sequential block assembler) matches the header, trust it even if the
-	// computed BAL differs. The state root check (commitment verification) still
-	// guarantees execution correctness.
+	// Always validate computed BAL against header. The BalancePath cross-check
+	// in VersionMap.validateRead ensures deterministic parallel execution even
+	// without a stored BAL body (HasBAL=false), so the computed BAL is accurate.
 	if headerBALHash != bal.Hash() {
-		if dbBALBytes != nil {
-			if dbBAL2, decErr := types.DecodeBlockAccessListBytes(dbBALBytes); decErr == nil && dbBAL2 != nil && dbBAL2.Hash() == headerBALHash {
-				log.Debug("BAL: computed BAL differs from stored/header, trusting stored BAL",
-					"block", blockNum, "computedHash", bal.Hash(), "headerHash", headerBALHash)
-				return nil
-			}
-		}
 		if dataDir != "" {
 			balDir := filepath.Join(dataDir, "bal")
 			if err := os.MkdirAll(balDir, 0o755); err != nil {

--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -2288,6 +2288,41 @@ func (sdb *IntraBlockState) MarkReadsInternal(addr accounts.Address) {
 	}
 }
 
+// SnapshotVersionedReadKeys returns the current set of read keys for addr.
+// Used with MarkNewReadsInternal to mark only reads added after the snapshot,
+// preserving pre-existing legitimate reads.
+func (sdb *IntraBlockState) SnapshotVersionedReadKeys(addr accounts.Address) map[AccountKey]struct{} {
+	if sdb.versionedReads == nil {
+		return nil
+	}
+	reads := sdb.versionedReads[addr]
+	if len(reads) == 0 {
+		return nil
+	}
+	snapshot := make(map[AccountKey]struct{}, len(reads))
+	for k := range reads {
+		snapshot[k] = struct{}{}
+	}
+	return snapshot
+}
+
+// MarkNewReadsInternal marks as internal only the reads for addr that were
+// added after the given snapshot. Use this when gas-calculation-only reads
+// were recorded on top of earlier legitimate reads — the legitimate ones
+// must remain non-internal so they appear in the block access list.
+func (sdb *IntraBlockState) MarkNewReadsInternal(addr accounts.Address, before map[AccountKey]struct{}) {
+	if sdb.versionedReads == nil {
+		return
+	}
+	for key, vr := range sdb.versionedReads[addr] {
+		if _, existed := before[key]; existed {
+			continue
+		}
+		vr.internal = true
+		sdb.versionedReads[addr][key] = vr
+	}
+}
+
 // AccessedAddresses returns and resets the set of addresses touched during the current transaction.
 func (sdb *IntraBlockState) AccessedAddresses() AccessSet {
 	if len(sdb.addressAccess) == 0 {

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -1349,13 +1349,21 @@ func (account *accountState) updateWrite(vw *VersionedWrite, accessIndex uint16)
 			return
 		}
 		// If we haven't seen a balance and the first write is zero, treat it
-		// as a touch only — but ONLY when a prior read confirmed the initial
-		// balance was already zero. Without a read we cannot prove the write
-		// is a no-op (e.g. a sender whose balance was depleted to zero by gas
-		// may have no BalancePath read in blockIO due to the parallel
-		// executor's finalize-path read stripping).
+		// as a touch only when the pre-block balance is (or is implicitly) zero:
+		//   - No prior read: the account wasn't accessed before, so its
+		//     pre-block balance is implicitly zero (e.g. a newly CREATE'd
+		//     contract or a receiver observed only via the post-write finalize
+		//     path). Writing zero is a no-op.
+		//   - Prior read showed zero: write matches initial state, no-op.
+		// If a prior read showed a non-zero pre-block balance, the zero write
+		// is a genuine depletion (e.g. a sender whose funds were consumed by
+		// gas) and must be recorded as a real balance change.
 		if account.balanceValue == nil && val.IsZero() &&
-			account.initialBalanceValue != nil && account.initialBalanceValue.IsZero() {
+			(account.initialBalanceValue == nil || account.initialBalanceValue.IsZero()) {
+			if account.initialBalanceValue == nil {
+				v := val
+				account.initialBalanceValue = &v
+			}
 			account.setBalanceValue(val)
 			return
 		}
@@ -1417,12 +1425,8 @@ func (account *accountState) updateRead(vr *VersionedRead) {
 		case BalancePath:
 			if val, ok := vr.Val.(uint256.Int); ok {
 				// Record the initial (pre-block) balance for net-zero detection.
-				// Only set from the first read AND only before any writes have
-				// been recorded. A read that arrives after a write (e.g. the
-				// block-end finalize in the parallel executor reading from a
-				// fresh IBS) reflects post-write state, not the pre-block
-				// balance, and must not be used for net-zero filtering.
-				if account.initialBalanceValue == nil && account.balanceValue == nil {
+				// Only the first read is the original pre-block value.
+				if account.initialBalanceValue == nil {
 					v := val
 					account.initialBalanceValue = &v
 				}

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -1417,8 +1417,12 @@ func (account *accountState) updateRead(vr *VersionedRead) {
 		case BalancePath:
 			if val, ok := vr.Val.(uint256.Int); ok {
 				// Record the initial (pre-block) balance for net-zero detection.
-				// Only the first read is the original pre-block value.
-				if account.initialBalanceValue == nil {
+				// Only set from the first read AND only before any writes have
+				// been recorded. A read that arrives after a write (e.g. the
+				// block-end finalize in the parallel executor reading from a
+				// fresh IBS) reflects post-write state, not the pre-block
+				// balance, and must not be used for net-zero filtering.
+				if account.initialBalanceValue == nil && account.balanceValue == nil {
 					v := val
 					account.initialBalanceValue = &v
 				}

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -1348,12 +1348,14 @@ func (account *accountState) updateWrite(vw *VersionedWrite, accessIndex uint16)
 		if account.selfDestructed && accessIndex == account.selfDestructedAt && !val.IsZero() {
 			return
 		}
-		// If we haven't seen a balance and the first write is zero, treat it as a touch only.
-		if account.balanceValue == nil && val.IsZero() {
-			if account.initialBalanceValue == nil {
-				v := val
-				account.initialBalanceValue = &v
-			}
+		// If we haven't seen a balance and the first write is zero, treat it
+		// as a touch only — but ONLY when a prior read confirmed the initial
+		// balance was already zero. Without a read we cannot prove the write
+		// is a no-op (e.g. a sender whose balance was depleted to zero by gas
+		// may have no BalancePath read in blockIO due to the parallel
+		// executor's finalize-path read stripping).
+		if account.balanceValue == nil && val.IsZero() &&
+			account.initialBalanceValue != nil && account.initialBalanceValue.IsZero() {
 			account.setBalanceValue(val)
 			return
 		}

--- a/execution/tests/eest_devnet/block_test.go
+++ b/execution/tests/eest_devnet/block_test.go
@@ -50,13 +50,6 @@ func TestExecutionSpecBlockchainDevnet(t *testing.T) {
 	bt.Whitelist(`.*for_amsterdam/.*`)
 	// static — tested in state test format by TestState
 	bt.SkipLoad(`^for_amsterdam/static/state_tests/`)
-	// TODO(yperbasis): these two sub-tests exercise a sender whose balance
-	// is depleted to zero during a reverted CREATE containing a nested
-	// SELFDESTRUCT. The parallel executor's finalize path strips the
-	// sender's BalancePath read, leaving VersionedIO unable to distinguish
-	// a real depletion from a touch-only zero write. Skipped until the
-	// missing read is propagated into blockIO.
-	bt.SkipLoad(`create_oog_from_eoa_refunds\.json/.*-selfdestruct-oog_(code_deposit|invalid_opcode)\]$`)
 
 	bt.Walk(t, dir, func(t *testing.T, name string, test *testutil.BlockTest) {
 		// import pre accounts & construct test genesis block & state root

--- a/execution/tests/eest_devnet/block_test.go
+++ b/execution/tests/eest_devnet/block_test.go
@@ -50,6 +50,13 @@ func TestExecutionSpecBlockchainDevnet(t *testing.T) {
 	bt.Whitelist(`.*for_amsterdam/.*`)
 	// static — tested in state test format by TestState
 	bt.SkipLoad(`^for_amsterdam/static/state_tests/`)
+	// TODO(yperbasis): these two sub-tests exercise a sender whose balance
+	// is depleted to zero during a reverted CREATE containing a nested
+	// SELFDESTRUCT. The parallel executor's finalize path strips the
+	// sender's BalancePath read, leaving VersionedIO unable to distinguish
+	// a real depletion from a touch-only zero write. Skipped until the
+	// missing read is propagated into blockIO.
+	bt.SkipLoad(`create_oog_from_eoa_refunds\.json/.*-selfdestruct-oog_(code_deposit|invalid_opcode)\]$`)
 
 	bt.Walk(t, dir, func(t *testing.T, name string, test *testutil.BlockTest) {
 		// import pre accounts & construct test genesis block & state root

--- a/execution/vm/operations_acl.go
+++ b/execution/vm/operations_acl.go
@@ -257,6 +257,12 @@ func makeSelfdestructGasFn(refundsEnabled bool) gasFunc {
 			evm.IntraBlockState().AddAddressToAccessList(address)
 		}
 
+		// Snapshot the beneficiary's existing reads before Empty() — so we can
+		// later mark only the reads newly recorded by the gas calc as internal,
+		// preserving any pre-existing legitimate reads (e.g. the tx sender's
+		// fee-deduction balance read when the sender is the SELFDESTRUCT
+		// beneficiary).
+		beneficiaryReadsBefore := evm.IntraBlockState().SnapshotVersionedReadKeys(address)
 		// if empty and transfers value
 		empty, err := evm.IntraBlockState().Empty(address)
 		if err != nil {
@@ -275,14 +281,14 @@ func makeSelfdestructGasFn(refundsEnabled bool) gasFunc {
 			evm.IntraBlockState().MarkAddressAccess(address, false)
 		}
 		// When balance is zero OR we're in a read-only (STATICCALL) context,
-		// and the beneficiary differs from self, mark the beneficiary's reads
-		// as internal.  In both cases the Empty() call above recorded versioned
-		// reads for the beneficiary purely for gas calculation — no value is
-		// actually transferred (zero balance) or SELFDESTRUCT will be rejected
-		// (read-only).  Skip when beneficiary == self to avoid incorrectly
-		// marking the contract's own legitimate reads.
+		// and the beneficiary differs from self, mark the reads added by the
+		// Empty() gas-calc call as internal.  In both cases those reads
+		// exist purely for gas calculation — no value is actually transferred
+		// (zero balance) or SELFDESTRUCT will be rejected (read-only).
+		// Pre-existing reads are preserved.  Skip when beneficiary == self to
+		// avoid incorrectly marking the contract's own legitimate reads.
 		if (balance.IsZero() || evm.readOnly) && address != callContext.Address() {
-			evm.IntraBlockState().MarkReadsInternal(address)
+			evm.IntraBlockState().MarkNewReadsInternal(address, beneficiaryReadsBefore)
 		}
 		if empty && !balance.IsZero() {
 			if evm.chainRules.IsAmsterdam {

--- a/node/cli/flags.go
+++ b/node/cli/flags.go
@@ -118,7 +118,7 @@ var (
 	ExperimentalBALFlag = cli.BoolFlag{
 		Name:  "experimental.bal",
 		Usage: "generate block access list",
-		Value: false,
+		Value: true,
 	}
 
 	// Throttling Flags

--- a/node/ethconfig/config.go
+++ b/node/ethconfig/config.go
@@ -114,7 +114,7 @@ var Defaults = Config{
 	FcuTimeout:          1 * time.Second,
 	FcuBackgroundPrune:  true,
 	FcuBackgroundCommit: false, // to enable, we need to 1) have rawdb API go via execctx and 2) revive Coherent cache for rpcdaemon
-	ExperimentalBAL:     false,
+	ExperimentalBAL:     true,
 }
 
 const DefaultChainDBPageSize = 16 * datasize.KB


### PR DESCRIPTION
Flip the defaults to on for the parallel executor and block access list generation, matching the devnet-branch pattern from #19581.

## Changes

- \`common/dbg/experiments.go\`: \`EXEC3_PARALLEL\` env default → \`true\`
- \`node/cli/flags.go\`: \`--experimental.bal\` CLI default → \`true\`
- \`node/ethconfig/config.go\`: \`Defaults.ExperimentalBAL\` → \`true\`
- \`execution/execmodule/execmoduletester\`: tester default → \`true\`
- \`cmd/erigon/node/config_snapshot_test.go\`: update matching assertions

## Notes

- Draft / do-not-merge: intended as a devnet-exercise branch (parallel EIP-7928 BAL pipeline on by default) while the underlying machinery stabilises.
- Stacked on top of #20602 (BAL validation fixes). When viewed against \`main\` the diff includes those commits too until #20602 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)