### PR TITLE
db/kv/membatchwithdb: delegate HistorySeek / HistoryRange to backing tx

### DIFF
--- a/db/kv/membatchwithdb/memory_mutation.go
+++ b/db/kv/membatchwithdb/memory_mutation.go
@@ -869,8 +869,10 @@ func (m *MemoryMutation) RangeAsOf(name kv.Domain, fromKey, toKey []byte, ts uin
 }
 
 func (m *MemoryMutation) HistorySeek(name kv.Domain, k []byte, ts uint64) (v []byte, ok bool, err error) {
-	panic("not supported")
-	// return m.db.HistorySeek(name, k, ts)
+	if m.db == nil {
+		return nil, false, fmt.Errorf("MemoryMutation: history read requires backing tx (detached overlay)")
+	}
+	return m.db.HistorySeek(name, k, ts)
 }
 
 func (m *MemoryMutation) IndexRange(name kv.InvertedIdx, k []byte, fromTs, toTs int, asc order.By, limit int) (timestamps stream.U64, err error) {
@@ -881,8 +883,10 @@ func (m *MemoryMutation) IndexRange(name kv.InvertedIdx, k []byte, fromTs, toTs 
 }
 
 func (m *MemoryMutation) HistoryRange(name kv.Domain, fromTs, toTs int, asc order.By, limit int) (it stream.KV, err error) {
-	panic("not supported")
-	// return m.db.HistoryRange(name, fromTs, toTs, asc, limit)
+	if m.db == nil {
+		return nil, fmt.Errorf("MemoryMutation: history read requires backing tx (detached overlay)")
+	}
+	return m.db.HistoryRange(name, fromTs, toTs, asc, limit)
 }
 
 func (m *MemoryMutation) HistoryStartFrom(name kv.Domain) uint64 {


### PR DESCRIPTION
## Summary

- Fix a `panic(\"not supported\")` that aborts post-Fusaka mainnet sync resumed from snapshots-only (chaindata wiped, snapshots kept).
- `MemoryMutation.HistorySeek` and `HistoryRange` were placeholders; the correct delegation was already commented out. This PR just flips them to delegate to the backing tx, matching every sibling temporal-read method.

## Repro

On a post-Fusaka mainnet datadir, keep `snapshots/`, wipe `chaindata/`, and start `erigon`. The first forkchoice-triggered execution resumes mid-block (`startTxIndex > 0`) and takes the partial-block receipt reconstruction path added in #20452. That calls `receipts.DerivePriorReceipts`, which on top of the RCacheV2 fast path (#20485) issues `tx.HistorySeek(kv.RCacheDomain, …)`. When the containing executor runs through `ExecModule.updateForkChoice`, the tx is the block overlay (`MemoryMutation`), and `HistorySeek` panics:

```
panic: not supported

goroutine … [running]:
…/db/kv/membatchwithdb.(*MemoryMutation).HistorySeek
  .../db/kv/membatchwithdb/memory_mutation.go:872
…/db/rawdb.ReadReceiptCacheV2
  .../db/rawdb/accessors_chain.go:1276
…/execution/receipts.DerivePriorReceipts
  .../execution/receipts/derive.go:193
…/execution/stagedsync.(*serialExecutor).executeBlock.func2
  .../execution/stagedsync/exec3_serial.go:402
…
…/execution/execmodule.(*ExecModule).updateForkChoice
  .../execution/execmodule/forkchoice.go:473
```

## Why delegation is correct (not a workaround)

- Every other temporal-read method on `MemoryMutation` already delegates to the backing tx: `GetLatest`, `GetAsOf`, `RangeAsOf`, `IndexRange`, `HistoryStartFrom`. The two outliers just hadn't been wired.
- The block overlay never writes to history / domain tables — its scope is block-level metadata (headers, TDs, bodies, canonical hashes, BAL bytes, see `execution/execmodule/inserters.go`). History writes flow through `DomainBufferedWriter` / `SharedDomains`, not through the overlay. `grep -rnE \"indexKeys|historyKey|InvertedIndexWriter|DomainBufferedWriter\" db/kv/membatchwithdb/` is empty.
- Any `HistorySeek` routed through the overlay is therefore asking for data that lives exclusively in committed DB state or frozen snapshot files. The base tx is authoritative; the overlay has nothing to add.
- The original author even left the correct call commented out on the same line.

## Test plan

- [x] `make lint` — 0 issues
- [x] `make erigon` — builds clean
- [x] `go test -short ./db/kv/membatchwithdb/...` — passes
- [ ] Manual: post-Fusaka mainnet, wipe `chaindata/` / keep `snapshots/`, restart — sync now progresses past the first forkchoice-triggered execution instead of panicking (next hit in our testing was the unrelated stale-read bug tracked in follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)