### PR TITLE
Guard oversized static byte topics

### DIFF
--- a/execution/abi/topics.go
+++ b/execution/abi/topics.go
@@ -89,6 +89,9 @@ func MakeTopics(query ...[]any) ([][]common.Hash, error) {
 				switch {
 				// static byte array
 				case val.Kind() == reflect.Array && reflect.TypeOf(rule).Elem().Kind() == reflect.Uint8:
+					if val.Len() > len(topic) {
+						return nil, fmt.Errorf("indexed byte array too large: [%d]byte", val.Len())
+					}
 					reflect.Copy(reflect.ValueOf(topic[:val.Len()]), val)
 				default:
 					return nil, fmt.Errorf("unsupported indexed type: %T", rule)

--- a/execution/abi/topics_test.go
+++ b/execution/abi/topics_test.go
@@ -45,6 +45,12 @@ func TestMakeTopics(t *testing.T) {
 			false,
 		},
 		{
+			"reject fixed byte types longer than 32 bytes",
+			args{[][]any{{[33]byte{1}}}},
+			nil,
+			true,
+		},
+		{
 			"support common.Hash types in topics",
 			args{[][]any{{common.Hash{1, 2, 3, 4, 5}}}},
 			[][]common.Hash{{common.Hash{1, 2, 3, 4, 5}}},


### PR DESCRIPTION
`MakeTopics` could panic on oversized fixed byte arrays because it sliced `topic[:val.Len()]` without checking that `val.Len() <= 32` (e.g. `[33]byte`).  
  This change adds an explicit bounds check and returns a regular error (`indexed byte array too large`) instead of crashing, aligning this path with the function’s existing error-first behavior. A regression test for `[33]byte` is included to prove the failure mode is now handled safely while preserving behavior for valid fixed-size byte arrays.