### PR TITLE
cmd/utils, p2p/sentry: honor explicit empty --bootnodes

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1183,7 +1183,7 @@ func setBootstrapNodes(ctx *cli.Context, cfg *p2p.Config) {
 		return
 	}
 
-	nodes, err := GetBootnodesFromFlags(ctx.String(BootnodesFlag.Name), ctx.String(ChainFlag.Name))
+	nodes, err := getBootnodesFromContext(ctx)
 	if err != nil {
 		Fatalf("Option %s: %v", BootnodesFlag.Name, err)
 	}
@@ -1197,12 +1197,22 @@ func setBootstrapNodesV5(ctx *cli.Context, cfg *p2p.Config) {
 		return
 	}
 
-	nodes, err := GetBootnodesFromFlags(ctx.String(BootnodesFlag.Name), ctx.String(ChainFlag.Name))
+	nodes, err := getBootnodesFromContext(ctx)
 	if err != nil {
 		Fatalf("Option %s: %v", BootnodesFlag.Name, err)
 	}
 
 	cfg.BootstrapNodesV5 = nodes
+}
+
+// getBootnodesFromContext resolves bootstrap nodes from the CLI context. An explicitly
+// set --bootnodes flag (even if empty) overrides chain defaults, matching go-ethereum's
+// behavior and allowing callers to run discovery with no bootstrap peers.
+func getBootnodesFromContext(ctx *cli.Context) ([]*enode.Node, error) {
+	if ctx.IsSet(BootnodesFlag.Name) {
+		return enode.ParseNodesFromURLs(common.CliString2Array(ctx.String(BootnodesFlag.Name)))
+	}
+	return GetBootnodesFromFlags("", ctx.String(ChainFlag.Name))
 }
 
 // GetBootnodesFromFlags makes a list of bootnodes from command line flags.

--- a/p2p/sentry/sentry_grpc_server.go
+++ b/p2p/sentry/sentry_grpc_server.go
@@ -369,7 +369,10 @@ func makeP2PServer(
 	bootnodes []string,
 	protocols []p2p.Protocol,
 ) (*p2p.Server, error) {
-	if len(p2pConfig.BootstrapNodes) == 0 && len(bootnodes) > 0 {
+	// Only fall back to chain-default bootnodes when the caller didn't configure
+	// BootstrapNodes at all (nil slice). An empty non-nil slice signals explicit
+	// opt-out (e.g., --bootnodes= on the CLI) and must be preserved.
+	if p2pConfig.BootstrapNodes == nil && len(bootnodes) > 0 {
 		bootstrapNodes, err := enode.ParseNodesFromURLs(bootnodes)
 		if err != nil {
 			return nil, fmt.Errorf("bad bootnodes option: %w", err)


### PR DESCRIPTION
## Summary

- `--bootnodes=` (explicitly empty) now disables bootnodes instead of silently falling back to chain defaults, matching go-ethereum's behavior.
- `p2p/sentry.makeP2PServer` only applies chain-default bootnodes when `BootstrapNodes == nil` (never configured); an empty non-nil slice signals explicit opt-out and is preserved.

## Motivation

hive's devp2p/discv5 simulator pairs with clients that run discovery against an isolated routing table — no public bootnodes, no DNS, no static peers. Geth accepts `--bootnodes=\"\"` for this purpose; erigon silently re-adds chain defaults, which floods the routing table and breaks the `FindnodeResults` test. After this change, `--bootnodes= --discovery.dns= --staticpeers=` produces the isolation the simulator expects.

A companion change to `clients/erigon/erigon.sh` in ethereum/hive is needed to actually pass these flags and to switch `--nat=none` to `--nat=extip:\$ip`. PR: TBD.

## Test plan

- [x] `make lint` — 0 issues
- [x] `make erigon` — builds
- [x] Manual repro of failing hive tests against patched binary: both `FindnodeZeroDistance` and `FindnodeResults` pass (10-11s, was 60s timeout)
- [ ] hive CI green once the hive-side PR lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)