### PR TITLE
ci: make assertoor_glamsterdam_test non-gating

### DIFF
--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -24,6 +24,10 @@ jobs:
     name: assertoor_${{ matrix.suite }}_test
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-uncaching') }}
     runs-on: ubuntu-latest
+    # Per-suite gating: matrix entries with continue_on_error: true still execute
+    # and report status in the UI, but their failure does not fail the job —
+    # so they don't block ci-gate or PR merges.
+    continue-on-error: ${{ matrix.continue_on_error || false }}
     strategy:
       fail-fast: false
       matrix:
@@ -49,6 +53,9 @@ jobs:
             # Unpin to main once CI is upgraded to Kurtosis 1.18.1.
             ethereum_package_branch: "6.1.0"
             test_timeout_minutes: 20
+            # Glamsterdam (EIP-7928 / Block Access Lists devnet) is still stabilizing
+            # upstream. Run it for visibility but don't let failures block PR merges.
+            continue_on_error: true
           - suite: caplin-minimal
             package_args: .github/workflows/kurtosis/caplin-minimal-assertoor.io
             ethereum_package_url: "github.com/erigontech/ethereum-package"


### PR DESCRIPTION
## Summary
- The Glamsterdam (EIP-7928 Block Access Lists) devnet is still stabilizing upstream. Keep running the `assertoor_glamsterdam_test` suite for visibility, but stop blocking PR merges on its result.
- Implemented as a per-matrix-entry `continue_on_error` opt-in in `test-kurtosis-assertoor.yml` — the other suites (`regular`, `pectra`, `caplin-minimal`) remain gating and require no changes.
- The job still runs every PR/merge_group, the UI still shows pass/fail, and enclave dumps are still uploaded on failure.

## Test plan
- [ ] CI Gate triggers normally on this PR
- [ ] `assertoor_glamsterdam_test` still appears in the checks list and runs to completion
- [ ] If `assertoor_glamsterdam_test` fails, the parent `kurtosis` job result is still success and `ci-gate` does not block the PR
- [ ] `assertoor_regular_test`, `assertoor_pectra_test`, and `assertoor_caplin-minimal_test` still gate as before (verified by inspecting the workflow run if any of them legitimately fails)

> Note: if `assertoor_glamsterdam_test` is also listed as a required check in branch-protection settings independently of `ci-gate`, that entry needs to be removed in repo settings — `continue-on-error` only controls the workflow result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)