### PR TITLE
revert: prune: use `Put(Current)` mdbx's method instead of `DelCurrent+Put`

### DIFF
--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -440,9 +440,18 @@ func (w *DomainBufferedWriter) Flush(ctx context.Context, tx kv.RwTx) error {
 			return err
 		}
 		if len(foundVal) == 0 || !bytes.Equal(foundVal[:8], v[:8]) {
-			return valuesCursor.Put(k, v)
+			if err := valuesCursor.Put(k, v); err != nil {
+				return err
+			}
+			return nil
 		}
-		return valuesCursor.PutCurrent(k, v) // DeleteCurrent+Put
+		if err := valuesCursor.DeleteCurrent(); err != nil {
+			return err
+		}
+		if err := valuesCursor.Put(k, v); err != nil {
+			return err
+		}
+		return nil
 	}, etl.TransformArgs{Quit: ctx.Done(), EmptyVals: true}); err != nil {
 		return err
 	}


### PR DESCRIPTION
revert changes introduced in https://github.com/erigontech/erigon/pull/19914/changes 

reason: just a moon-shot against "gas missmatch" error