### PR TITLE
cl/p2p: move logging outside of mutexes. demote several Debug to Trace - to reduce mutex contention

### DIFF
--- a/cl/phase1/network/backward_beacon_downloader.go
+++ b/cl/phase1/network/backward_beacon_downloader.go
@@ -214,7 +214,7 @@ func (b *BackwardBeaconDownloader) processResponses(responses []*cltypes.SignedB
 		}
 
 		if blockRoot != b.expectedRoot {
-			log.Debug("Unexpected root", "got", common.Hash(blockRoot), "expected", b.expectedRoot)
+			log.Trace("Unexpected root", "got", common.Hash(blockRoot), "expected", b.expectedRoot)
 			continue
 		}
 

--- a/cl/phase1/network/gossip/gossip_manager.go
+++ b/cl/phase1/network/gossip/gossip_manager.go
@@ -27,6 +27,9 @@ import (
 	"unicode"
 
 	"github.com/c2h5oh/datasize"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/peer"
+
 	"github.com/erigontech/erigon/cl/beacon/synced_data"
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/gossip"
@@ -37,8 +40,6 @@ import (
 	"github.com/erigontech/erigon/cl/utils/eth_clock"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
-	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 // PeerBanner is an interface for banning misbehaving peers.
@@ -96,7 +97,7 @@ func NewGossipManager(
 
 	go gm.observeBandwidth(cctx, maxInboundTrafficPerPeer, maxOutboundTrafficPerPeer, adaptableTrafficRequirements)
 	go gm.goCheckForkAndResubscribe(cctx)
-	gm.stats.goPrintStats(cctx)
+	//gm.stats.goPrintStats(cctx)
 	return gm
 }
 

--- a/cl/phase1/network/gossip/gossip_message_stats.go
+++ b/cl/phase1/network/gossip/gossip_message_stats.go
@@ -2,6 +2,7 @@ package gossip
 
 import (
 	"context"
+	"maps"
 	"strconv"
 	"strings"
 	"sync"
@@ -78,18 +79,24 @@ func (s *gossipMessageStats) goPrintStats(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
+				// logger has internal mutex
+				// means need make current mutex lock as short as possible
 				s.statsMutex.Lock()
+				accepts := maps.Clone(s.accepts)
+				rejects := maps.Clone(s.rejects)
+				ignores := maps.Clone(s.ignores)
+				s.statsMutex.Unlock()
+
 				totalSeconds := float64(times * int64(duration.Seconds()))
-				for name, count := range s.accepts {
+				for name, count := range accepts {
 					log.Debug("Gossip Message Accepts Stats", "name", name, "count", count, "rate_sec", float64(count)/totalSeconds)
 				}
-				for name, count := range s.rejects {
+				for name, count := range rejects {
 					log.Debug("Gossip Message Rejects Stats", "name", name, "count", count, "rate_sec", float64(count)/totalSeconds)
 				}
-				for name, count := range s.ignores {
+				for name, count := range ignores {
 					log.Debug("Gossip Message Ignores Stats", "name", name, "count", count, "rate_sec", float64(count)/totalSeconds)
 				}
-				s.statsMutex.Unlock()
 				times++
 			}
 		}

--- a/cl/sentinel/discovery.go
+++ b/cl/sentinel/discovery.go
@@ -261,7 +261,7 @@ func (s *Sentinel) proactiveSubnetPeerSearch() {
 			log.Trace("[Sentinel] Subnet coverage after search",
 				"subnetsAtMinPeers", atMin,
 				"minPeersPerSubnet", minimumPeersPerSubnet,
-			)
+				"stillUnderserved", stillUnderserved)
 		}
 	}
 }

--- a/cl/sentinel/discovery.go
+++ b/cl/sentinel/discovery.go
@@ -233,7 +233,7 @@ func (s *Sentinel) proactiveSubnetPeerSearch() {
 				underservedIdxs[i] = info.idx
 			}
 
-			log.Debug("[Sentinel] Proactive subnet search starting",
+			log.Trace("[Sentinel] Proactive subnet search starting",
 				"underservedCount", len(underserved),
 				"threshold", minimumPeersPerSubnet,
 				"subnets", underservedIdxs)
@@ -258,10 +258,10 @@ func (s *Sentinel) proactiveSubnetPeerSearch() {
 					stillUnderserved = append(stillUnderserved, i)
 				}
 			}
-			log.Debug("[Sentinel] Subnet coverage after search",
+			log.Trace("[Sentinel] Subnet coverage after search",
 				"subnetsAtMinPeers", atMin,
 				"minPeersPerSubnet", minimumPeersPerSubnet,
-				"stillUnderserved", stillUnderserved)
+			)
 		}
 	}
 }

--- a/cl/sentinel/handlers/heartbeats.go
+++ b/cl/sentinel/handlers/heartbeats.go
@@ -17,7 +17,6 @@
 package handlers
 
 import (
-	"encoding/hex"
 	"strings"
 
 	"github.com/libp2p/go-libp2p/core/network"
@@ -134,7 +133,7 @@ func (c *ConsensusHandlers) statusV2Handler(s network.Stream) error {
 		return err
 	}
 	copy(status.ForkDigest[:], forkDigest[:])
-	log.Debug("statusV2Handler", "forkDigest", hex.EncodeToString(status.ForkDigest[:]), "finalizedRoot", hex.EncodeToString(status.FinalizedRoot[:]),
-		"finalizedEpoch", status.FinalizedEpoch, "headSlot", status.HeadSlot, "headRoot", hex.EncodeToString(status.HeadRoot[:]), "earliestAvailableSlot", c.peerdasStateReader.GetEarliestAvailableSlot())
+	//log.Debug("statusV2Handler", "forkDigest", hex.EncodeToString(status.ForkDigest[:]), "finalizedRoot", hex.EncodeToString(status.FinalizedRoot[:]),
+	//	"finalizedEpoch", status.FinalizedEpoch, "headSlot", status.HeadSlot, "headRoot", hex.EncodeToString(status.HeadRoot[:]), "earliestAvailableSlot", c.peerdasStateReader.GetEarliestAvailableSlot())
 	return ssz_snappy.EncodeAndWrite(s, status, SuccessfulResponsePrefix)
 }

--- a/p2p/discover/ntp.go
+++ b/p2p/discover/ntp.go
@@ -47,7 +47,7 @@ func checkClockDrift() {
 		log.Warn(fmt.Sprintf("[p2p] System clock seems off by %v, which can prevent network connectivity", drift))
 		log.Warn("[p2p] Please enable network time synchronisation in system settings.")
 	} else {
-		log.Debug("[p2p] NTP sanity check done", "drift", drift)
+		log.Trace("[p2p] NTP sanity check done", "drift", drift)
 	}
 }
 

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -603,7 +603,7 @@ func (tab *Table) deleteInBucket(b *bucket, id enode.ID) *tableNode {
 
 	// Add replacement.
 	if len(b.replacements) == 0 {
-		tab.log.Debug("[p2p] Removed dead node", "b", b.index, "id", n.ID(), "ip", n.IPAddr())
+		tab.log.Trace("[p2p] Removed dead node", "b", b.index, "id", n.ID(), "ip", n.IPAddr())
 		return nil
 	}
 	rindex := tab.rand.Intn(len(b.replacements))
@@ -611,7 +611,7 @@ func (tab *Table) deleteInBucket(b *bucket, id enode.ID) *tableNode {
 	b.replacements = slices.Delete(b.replacements, rindex, rindex+1)
 	b.entries = append(b.entries, rep)
 	tab.nodeAdded(b, rep)
-	tab.log.Debug("[p2p] Replaced dead node", "b", b.index, "id", n.ID(), "ip", n.IPAddr(), "r", rep.ID(), "rip", rep.IPAddr())
+	tab.log.Trace("[p2p] Replaced dead node", "b", b.index, "id", n.ID(), "ip", n.IPAddr(), "r", rep.ID(), "rip", rep.IPAddr())
 	return rep
 }
 

--- a/p2p/discover/table_reval.go
+++ b/p2p/discover/table_reval.go
@@ -124,7 +124,7 @@ func (tab *Table) doRevalidate(resp revalidationResponse, node *enode.Node) {
 	if remoteSeq > node.Seq() {
 		newrec, err := tab.net.RequestENR(node)
 		if err != nil {
-			tab.log.Debug("[p2p] ENR request failed", "id", node.ID(), "err", err)
+			tab.log.Trace("[p2p] ENR request failed", "id", node.ID(), "err", err)
 		} else {
 			resp.newRecord = newrec
 		}
@@ -168,7 +168,7 @@ func (tr *tableRevalidation) handleResponse(tab *Table, resp revalidationRespons
 		if n.livenessChecks <= 0 {
 			tab.deleteInBucket(b, n.ID())
 		} else {
-			tab.log.Debug("[p2p] Node revalidation failed", "b", b.index, "id", n.ID(), "checks", n.livenessChecks, "q", n.revalList.name)
+			tab.log.Trace("[p2p] Node revalidation failed", "b", b.index, "id", n.ID(), "checks", n.livenessChecks, "q", n.revalList.name)
 			tr.moveToList(&tr.fast, n, now, &tab.rand)
 		}
 		return
@@ -177,7 +177,7 @@ func (tr *tableRevalidation) handleResponse(tab *Table, resp revalidationRespons
 	// The node responded.
 	n.livenessChecks++
 	n.isValidatedLive = true
-	tab.log.Debug("[p2p] Node revalidated", "b", b.index, "id", n.ID(), "checks", n.livenessChecks, "q", n.revalList.name)
+	tab.log.Trace("[p2p] Node revalidated", "b", b.index, "id", n.ID(), "checks", n.livenessChecks, "q", n.revalList.name)
 	var endpointChanged bool
 	if resp.newRecord != nil {
 		_, endpointChanged = tab.bumpInBucket(b, resp.newRecord, false)

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -551,17 +551,17 @@ func (t *UDPv4) readLoop(unhandled chan<- ReadPacket) {
 		nbytes, from, err := t.conn.ReadFromUDPAddrPort(buf)
 		if netutil.IsTemporaryError(err) {
 			// Ignore temporary read errors.
-			t.log.Debug("[p2p] Temporary UDP read error", "err", err)
+			t.log.Trace("[p2p] Temporary UDP read error", "err", err)
 			continue
 		} else if err != nil {
 			// Shut down the loop for permanent errors.
 			if !errors.Is(err, io.EOF) {
-				t.log.Debug("[p2p] UDP read error", "err", err)
+				t.log.Trace("[p2p] UDP read error", "err", err)
 			}
 			return
 		}
 		if err := t.handlePacket(from, buf[:nbytes]); err != nil && unhandled == nil {
-			t.log.Debug("[p2p] Bad discv4 packet", "addr", from, "err", err)
+			t.log.Trace("[p2p] Bad discv4 packet", "addr", from, "err", err)
 		} else if err != nil && unhandled != nil {
 			select {
 			case unhandled <- ReadPacket{buf[:nbytes], from}:

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -459,7 +459,7 @@ func (t *UDPv5) waitForNodes(c *callV5, distances []uint) ([]*enode.Node, error)
 			for _, record := range response.Nodes {
 				node, err := t.verifyResponseNode(c, record, distances, seen)
 				if err != nil {
-					t.log.Debug("[p2p] Invalid record in "+response.Name(), "id", c.node.ID(), "err", err)
+					t.log.Trace("[p2p] Invalid record in "+response.Name(), "id", c.node.ID(), "err", err)
 					continue
 				}
 				nodes = append(nodes, node)
@@ -713,12 +713,12 @@ func (t *UDPv5) readLoop() {
 		nbytes, from, err := t.conn.ReadFromUDPAddrPort(buf)
 		if netutil.IsTemporaryError(err) {
 			// Ignore temporary read errors.
-			t.log.Debug("[p2p] Temporary UDP read error", "err", err)
+			t.log.Trace("[p2p] Temporary UDP read error", "err", err)
 			continue
 		} else if err != nil {
 			// Shut down the loop for permanent errors.
 			if !errors.Is(err, io.EOF) {
-				t.log.Debug("[p2p] UDP read error", "err", err)
+				t.log.Trace("[p2p] UDP read error", "err", err)
 			}
 			return
 		}
@@ -774,15 +774,15 @@ func (t *UDPv5) handlePacket(rawpacket []byte, fromAddr netip.AddrPort) error {
 func (t *UDPv5) handleCallResponse(fromID enode.ID, fromAddr netip.AddrPort, p v5wire.Packet) bool {
 	ac := t.activeCallByNode[fromID]
 	if ac == nil || !bytes.Equal(p.RequestID(), ac.reqid) {
-		t.log.Debug(fmt.Sprintf("[p2p] Unsolicited/late %s response", p.Name()), "id", fromID, "addr", fromAddr)
+		t.log.Trace(fmt.Sprintf("[p2p] Unsolicited/late %s response", p.Name()), "id", fromID, "addr", fromAddr)
 		return false
 	}
 	if fromAddr != ac.addr {
-		t.log.Debug(fmt.Sprintf("[p2p] %s from wrong endpoint", p.Name()), "id", fromID, "addr", fromAddr)
+		t.log.Trace(fmt.Sprintf("[p2p] %s from wrong endpoint", p.Name()), "id", fromID, "addr", fromAddr)
 		return false
 	}
 	if p.Kind() != ac.responseType {
-		t.log.Debug(fmt.Sprintf("[p2p] Wrong discv5 response type %s", p.Name()), "id", fromID, "addr", fromAddr)
+		t.log.Trace(fmt.Sprintf("[p2p] Wrong discv5 response type %s", p.Name()), "id", fromID, "addr", fromAddr)
 		return false
 	}
 	t.startResponseTimeout(ac)
@@ -840,7 +840,7 @@ func (t *UDPv5) handleUnknown(p *v5wire.Unknown, fromID enode.ID, fromAddr netip
 		// them which handshake attempt they need to complete. We tell them to use the
 		// existing handshake attempt since the response to that one might still be in
 		// transit.
-		t.log.Debug("[p2p] Repeating discv5 handshake challenge", "id", fromID, "addr", fromAddr)
+		t.log.Trace("[p2p] Repeating discv5 handshake challenge", "id", fromID, "addr", fromAddr)
 		t.sendResponse(fromID, fromAddr, currentChallenge)
 		return
 	}
@@ -870,7 +870,7 @@ func (t *UDPv5) handleWhoareyou(p *v5wire.Whoareyou, fromID enode.ID, fromAddr n
 
 	if c.node == nil {
 		// Can't perform handshake because we don't have the ENR.
-		t.log.Debug("[p2p] Can't handle "+p.Name(), "addr", fromAddr, "err", "call has no ENR")
+		t.log.Trace("[p2p] Can't handle "+p.Name(), "addr", fromAddr, "err", "call has no ENR")
 		c.err <- errors.New("remote wants handshake, but call has no ENR")
 		return
 	}

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -766,8 +766,7 @@ running:
 			}
 		case <-logTimer.C:
 			vals := []any{"protocol", srv.Config.Protocols[0].Version, "peers", len(peers), "trusted", len(trusted), "inbound", inboundCount}
-			vals = append(vals, srv.listErrors()...)
-
+			//vals = append(vals, srv.listErrors()...)
 			srv.logger.Debug("[p2p] Server", vals...)
 		}
 	}


### PR DESCRIPTION
gnosis stuck.

Reasons:
- gossip manager does much debug logs
- p2p pkg moved much logs from trace to debug 


Stuck node goroutines:
```
3256 @ 0x4bf68e 0x49be32 0x49be09 0x4c12e5 0x4d491d 0x1e6ac38 0x1e6ac30 0x1e6abd3 0x1e680aa 0x1e56bd9 0x1e569ca 0x1e56553 0x1e5612f 0x1e55ff8 0x4c7901
#	0x4c12e4	internal/sync.runtime_SemacquireMutex+0x24								runtime/sema.go:95
#	0x4d491c	internal/sync.(*Mutex).lockSlow+0x15c									internal/sync/mutex.go:149
#	0x1e6ac37	internal/sync.(*Mutex).Lock+0xf7									internal/sync/mutex.go:70
#	0x1e6ac2f	sync.(*Mutex).Lock+0xef											sync/mutex.go:46
#	0x1e6abd2	github.com/erigontech/erigon/cl/phase1/network/gossip.(*gossipMessageStats).addIgnore+0x92		github.com/erigontech/erigon/cl/phase1/network/gossip/gossip_message_stats.go:61
#	0x1e680a9	github.com/erigontech/erigon/cl/phase1/network/gossip.(*GossipManager).newPubsubValidator.func1+0xbc9	github.com/erigontech/erigon/cl/phase1/network/gossip/gossip_manager.go:187
#	0x1e56bd8	github.com/libp2p/go-libp2p-pubsub.(*validatorImpl).validateMsg+0x118					github.com/libp2p/go-libp2p-pubsub@v0.11.0/validation.go:485
#	0x1e569c9	github.com/libp2p/go-libp2p-pubsub.(*validation).validateSingleTopic+0x89				github.com/libp2p/go-libp2p-pubsub@v0.11.0/validation.go:463
#	0x1e56552	github.com/libp2p/go-libp2p-pubsub.(*validation).validateTopic+0xd2					github.com/libp2p/go-libp2p-pubsub@v0.11.0/validation.go:412
#	0x1e5612e	github.com/libp2p/go-libp2p-pubsub.(*validation).doValidateTopic+0x4e					github.com/libp2p/go-libp2p-pubsub@v0.11.0/validation.go:383
#	0x1e55ff7	github.com/libp2p/go-libp2p-pubsub.(*validation).validate.func1+0x37					github.com/libp2p/go-libp2p-pubsub@v0.11.0/validation.go:348

208 @ 0x4bf68e 0x49be32 0x49be09 0x4c12e5 0x4d491d 0x8dc585 0x8dc555 0x8dc554 0x8dcee8 0x8df970 0x8dc86e 0x8dd423 0x8ddc76 0x1eda47c 0x1eda3fe 0x1f7dc28 0x1e67d45 0x1e56bd9 0x1e569ca 0x1e56553 0x1e5612f 0x1e55ff8 0x4c7901
#	0x4c12e4	internal/sync.runtime_SemacquireMutex+0x24								runtime/sema.go:95
#	0x4d491c	internal/sync.(*Mutex).lockSlow+0x15c									internal/sync/mutex.go:149
#	0x8dc584	internal/sync.(*Mutex).Lock+0x84									internal/sync/mutex.go:70
#	0x8dc554	sync.(*Mutex).Lock+0x54											sync/mutex.go:46
#	0x8dc553	github.com/erigontech/erigon/common/log/v3.syncHandler.Log+0x53						github.com/erigontech/erigon/common/log/v3/handler.go:74
#	0x8dcee7	github.com/erigontech/erigon/common/log/v3.lazyHandler.Log+0x3e7					github.com/erigontech/erigon/common/log/v3/handler.go:478
#	0x8df96f	github.com/erigontech/erigon/common/log/v3.lvlFilterHandler.Log+0x2f					github.com/erigontech/erigon/common/log/v3/handler.go:293
#	0x8dc86d	github.com/erigontech/erigon/common/log/v3.multiHandler.Log+0xcd					github.com/erigontech/erigon/common/log/v3/handler.go:325
#	0x8dd422	github.com/erigontech/erigon/common/log/v3.(*swapHandler).Log+0x62					github.com/erigontech/erigon/common/log/v3/handler.go:558
#	0x8ddc75	github.com/erigontech/erigon/common/log/v3.(*logger).write+0x175					github.com/erigontech/erigon/common/log/v3/logger.go:145
#	0x1eda47b	github.com/erigontech/erigon/common/log/v3.Debug+0xbb							github.com/erigontech/erigon/common/log/v3/root.go:52
#	0x1eda3fd	github.com/erigontech/erigon/cl/phase1/network/services.(*blockService).ProcessMessage+0x3d		github.com/erigontech/erigon/cl/phase1/network/services/block_service.go:119
#	0x1f7dc27	github.com/erigontech/erigon/cl/phase1/network/gossip.(*serviceWrapper[...]).ProcessMessage+0x47	github.com/erigontech/erigon/cl/phase1/network/gossip/gossip_message_register.go:60
#	0x1e67d44	github.com/erigontech/erigon/cl/phase1/network/gossip.(*GossipManager).newPubsubValidator.func1+0x864	github.com/erigontech/erigon/cl/phase1/network/gossip/gossip_manager.go:183
#	0x1e56bd8	github.com/libp2p/go-libp2p-pubsub.(*validatorImpl).validateMsg+0x118					github.com/libp2p/go-libp2p-pubsub@v0.11.0/validation.go:485
#	0x1e569c9	github.com/libp2p/go-libp2p-pubsub.(*validation).validateSingleTopic+0x89				github.com/libp2p/go-libp2p-pubsub@v0.11.0/validation.go:463
#	0x1e56552	github.com/libp2p/go-libp2p-pubsub.(*validation).validateTopic+0xd2					github.com/libp2p/go-libp2p-pubsub@v0.11.0/validation.go:412
#	0x1e5612e	github.com/libp2p/go-libp2p-pubsub.(*validation).doValidateTopic+0x4e					github.com/libp2p/go-libp2p-pubsub@v0.11.0/validation.go:383
#	0x1e55ff7	github.com/libp2p/go-libp2p-pubsub.(*validation).validate.func1+0x37					github.com/libp2p/go-libp2p-pubsub@v0.11.0/validation.go:348

156 @ 0x4bf68e 0x49afa5 0x192ab1d 0x192a8f6 0x19298b2 0x19297d3 0x191e83e 0x4c7901
#	0x192ab1c	github.com/erigontech/erigon/p2p/discover.(*UDPv5).initCall+0x1dc	github.com/erigontech/erigon/p2p/discover/v5_udp.go:533
#	0x192a8f5	github.com/erigontech/erigon/p2p/discover.(*UDPv5).callToNode+0x135	github.com/erigontech/erigon/p2p/discover/v5_udp.go:512
#	0x19298b1	github.com/erigontech/erigon/p2p/discover.(*UDPv5).Ping+0x91		github.com/erigontech/erigon/p2p/discover/v5_udp.go:417
#	0x19297d2	github.com/erigontech/erigon/p2p/discover.(*UDPv5).ping+0x12		github.com/erigontech/erigon/p2p/discover/v5_udp.go:406
#	0x191e83d	github.com/erigontech/erigon/p2p/discover.(*Table).doRevalidate+0x5d	github.com/erigontech/erigon/p2p/discover/table_reval.go:120

118 @ 0x4bf68e 0x49afa5 0x1949905 0x1949885 0x19492d7 0x1948d8a 0x4c7901
#	0x1949904	github.com/erigontech/erigon/p2p.(*Server).checkpoint+0x5a4		github.com/erigontech/erigon/p2p/server.go:998
#	0x1949884	github.com/erigontech/erigon/p2p.(*Server).setupConn+0x524		github.com/erigontech/erigon/p2p/server.go:958
#	0x19492d6	github.com/erigontech/erigon/p2p.(*Server).SetupConn+0x176		github.com/erigontech/erigon/p2p/server.go:920
#	0x1948d89	github.com/erigontech/erigon/p2p.(*Server).listenLoop.func2+0x69	github.com/erigontech/erigon/p2p/server.go:886

66 @ 0x4bf68e 0x49be32 0x49be09 0x4c12e5 0x4d491d 0x8dc585 0x8dc555 0x8dc554 0x8dcee8 0x8df970 0x8dc86e 0x8dd423 0x8ddc76 0x1fa06af 0x1fa04c9 0x1f9ef5b 0x1d09ce2 0x1d0990d 0x1c04ca5 0x4c7901
#	0x4c12e4	internal/sync.runtime_SemacquireMutex+0x24											runtime/sema.go:95
#	0x4d491c	internal/sync.(*Mutex).lockSlow+0x15c												internal/sync/mutex.go:149
#	0x8dc584	internal/sync.(*Mutex).Lock+0x84												internal/sync/mutex.go:70
#	0x8dc554	sync.(*Mutex).Lock+0x54														sync/mutex.go:46
#	0x8dc553	github.com/erigontech/erigon/common/log/v3.syncHandler.Log+0x53									github.com/erigontech/erigon/common/log/v3/handler.go:74
#	0x8dcee7	github.com/erigontech/erigon/common/log/v3.lazyHandler.Log+0x3e7								github.com/erigontech/erigon/common/log/v3/handler.go:478
#	0x8df96f	github.com/erigontech/erigon/common/log/v3.lvlFilterHandler.Log+0x2f								github.com/erigontech/erigon/common/log/v3/handler.go:293
#	0x8dc86d	github.com/erigontech/erigon/common/log/v3.multiHandler.Log+0xcd								github.com/erigontech/erigon/common/log/v3/handler.go:325
#	0x8dd422	github.com/erigontech/erigon/common/log/v3.(*swapHandler).Log+0x62								github.com/erigontech/erigon/common/log/v3/handler.go:558
#	0x8ddc75	github.com/erigontech/erigon/common/log/v3.(*logger).write+0x175								github.com/erigontech/erigon/common/log/v3/logger.go:145
#	0x1fa06ae	github.com/erigontech/erigon/common/log/v3.Debug+0x44e										github.com/erigontech/erigon/common/log/v3/root.go:52
#	0x1fa04c8	github.com/erigontech/erigon/cl/sentinel/handlers.(*ConsensusHandlers).statusV2Handler+0x268					github.com/erigontech/erigon/cl/sentinel/handlers/heartbeats.go:137
#	0x1f9ef5a	github.com/erigontech/erigon/cl/sentinel/handlers.NewConsensusHandlers.(*ConsensusHandlers).wrapStreamHandler.func1+0x2da	github.com/erigontech/erigon/cl/sentinel/handlers/handlers.go:197
#	0x1d09ce1	github.com/libp2p/go-libp2p/p2p/host/basic.(*BasicHost).SetStreamHandler.func1+0x81						github.com/libp2p/go-libp2p@v0.47.0/p2p/host/basic/basic_host.go:399
#	0x1d0990c	github.com/libp2p/go-libp2p/p2p/host/basic.(*BasicHost).newStreamHandler+0x8cc							github.com/libp2p/go-libp2p@v0.47.0/p2p/host/basic/basic_host.go:358
#	0x1c04ca4	github.com/libp2p/go-libp2p/p2p/net/swarm.(*Conn).start.func1.1+0xa4								github.com/libp2p/go-libp2p@v0.47.0/p2p/net/swarm/swarm_conn.go:159
```