### PR TITLE
log: demote from Debug to Trace. move logging out of external mutexes. optimize log formatter

### DIFF
--- a/cl/p2p/p2p_discovery.go
+++ b/cl/p2p/p2p_discovery.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"time"
 
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"golang.org/x/sync/semaphore"
+
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/p2p/discover"
 	"github.com/erigontech/erigon/p2p/enr"
-	"github.com/libp2p/go-libp2p/core/network"
-	"github.com/libp2p/go-libp2p/core/peer"
-	"golang.org/x/sync/semaphore"
 )
 
 func (p *p2pManager) connectToBootnodes(ctx context.Context, discoverConfig discover.Config) error {
@@ -99,7 +100,7 @@ func (p *p2pManager) peerMonitor(ctx context.Context) {
 					closed++
 				}
 			}
-			log.Debug("[caplin p2p] reporting connected peers", "connected", connected, "closed", closed, "emptyAddrs", emptyAddrs)
+			log.Trace("[caplin p2p] reporting connected peers", "connected", connected, "closed", closed, "emptyAddrs", emptyAddrs)
 		case <-ctx.Done():
 			return
 		}

--- a/cl/phase1/network/services/block_service.go
+++ b/cl/phase1/network/services/block_service.go
@@ -23,6 +23,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/libp2p/go-libp2p/core/peer"
+
 	"github.com/erigontech/erigon/cl/beacon/beaconevents"
 	"github.com/erigontech/erigon/cl/beacon/synced_data"
 	"github.com/erigontech/erigon/cl/clparams"
@@ -38,7 +40,6 @@ import (
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
-	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 var (
@@ -116,7 +117,7 @@ func (b *blockService) DecodeGossipMessage(_ peer.ID, data []byte, version clpar
 
 // ProcessMessage processes a block message according to https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#beacon_block
 func (b *blockService) ProcessMessage(ctx context.Context, _ *uint64, msg *cltypes.SignedBeaconBlock) error {
-	log.Debug("Received block via gossip", "slot", msg.Block.Slot)
+	log.Trace("Received block via gossip", "slot", msg.Block.Slot)
 	blockEpoch := msg.Block.Slot / b.beaconCfg.SlotsPerEpoch
 
 	if b.syncedData.Syncing() {
@@ -213,7 +214,7 @@ func (b *blockService) publishBlockGossipEvent(block *cltypes.SignedBeaconBlock)
 
 // scheduleBlockForLaterProcessing schedules a block for later processing
 func (b *blockService) scheduleBlockForLaterProcessing(block *cltypes.SignedBeaconBlock) {
-	log.Debug("Block scheduled for later processing", "slot", block.Block.Slot, "block", block.Block.Body.ExecutionPayload.BlockNumber)
+	log.Trace("Block scheduled for later processing", "slot", block.Block.Slot, "block", block.Block.Body.ExecutionPayload.BlockNumber)
 	blockRoot, err := block.Block.HashSSZ()
 	if err != nil {
 		log.Debug("Failed to hash block", "block", block, "error", err)
@@ -277,7 +278,7 @@ func (b *blockService) importBlockOperations(block *cltypes.SignedBeaconBlock) {
 		}
 		return true
 	})
-	log.Debug("import operations", "time", time.Since(start))
+	log.Trace("import operations", "time", time.Since(start))
 }
 
 // loop is the main loop of the block service

--- a/cl/rpc/peer_selection.go
+++ b/cl/rpc/peer_selection.go
@@ -129,7 +129,7 @@ func (c *columnDataPeers) refreshPeers(ctx context.Context) {
 			data := &peerData{pid: pid, mask: custodyIndices}
 			c.peerMetaCache.Add(peerKey, data)
 			newPeers = append(newPeers, *data)
-			log.Debug("[peerSelector] added peer", "peer", pid, "custodies", len(custodyIndices))
+			log.Trace("[peerSelector] added peer", "peer", pid, "custodies", len(custodyIndices))
 		}
 		c.peersMutex.Lock()
 		c.peersQueue = newPeers

--- a/cl/sentinel/handlers/handlers.go
+++ b/cl/sentinel/handlers/handlers.go
@@ -201,7 +201,7 @@ func (c *ConsensusHandlers) wrapStreamHandler(name string, fn func(s network.Str
 					log.Debug("failed to write resource unavailable prefix", "err", err)
 				}
 			}
-			log.Debug("[pubsubhandler] stream handler returned error", "protocol", name, "peer", s.Conn().RemotePeer().String(), "err", err)
+			log.Trace("[pubsubhandler] stream handler returned error", "protocol", name, "peer", s.Conn().RemotePeer().String(), "err", err)
 			_ = s.Reset()
 			_ = s.Close()
 			return

--- a/common/log/v3/format.go
+++ b/common/log/v3/format.go
@@ -112,9 +112,11 @@ func TerminalFormatNoColor() Format {
 // For more details see: http://godoc.org/github.com/kr/logfmt
 func LogfmtFormat() Format {
 	return FormatFunc(func(r *Record) []byte {
-		common := []any{r.KeyNames.Time, r.Time, r.KeyNames.Lvl, r.Lvl, r.KeyNames.Msg, r.Msg}
+		common := make([]any, 0, 6+len(r.Ctx))
+		common = append(common, r.KeyNames.Time, r.Time, r.KeyNames.Lvl, r.Lvl, r.KeyNames.Msg, r.Msg)
+		common = append(common, r.Ctx...)
 		buf := &bytes.Buffer{}
-		logfmt(buf, append(common, r.Ctx...), 0)
+		logfmt(buf, common, 0)
 		return buf.Bytes()
 	})
 }

--- a/common/log/v3/format.go
+++ b/common/log/v3/format.go
@@ -8,8 +8,8 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
+	"unicode/utf8"
 )
 
 const (
@@ -120,25 +120,29 @@ func LogfmtFormat() Format {
 }
 
 func logfmt(buf *bytes.Buffer, ctx []any, color int) {
+	// Stack-allocated scratch for encoding numeric values; avoids
+	// allocating an intermediate string in the value path.
+	var scratch [64]byte
 	for i := 0; i < len(ctx); i += 2 {
 		if i != 0 {
 			buf.WriteByte(' ')
 		}
 
 		k, ok := ctx[i].(string)
-		v := formatLogfmtValue(ctx[i+1])
+		v := ctx[i+1]
 		if !ok {
-			k, v = errorKey, formatLogfmtValue(k)
+			// key is not a string: log errorKey and describe the bad key as value
+			k, v = errorKey, ctx[i]
 		}
 
 		// XXX: we should probably check that all of your key bytes aren't invalid
 		if color > 0 {
-			fmt.Fprintf(buf, "\x1b[%dm%s\x1b[0m=%s", color, k, v)
+			fmt.Fprintf(buf, "\x1b[%dm%s\x1b[0m=", color, k)
 		} else {
 			buf.WriteString(k)
 			buf.WriteByte('=')
-			buf.WriteString(v)
 		}
+		buf.Write(appendLogfmtValue(scratch[:0], v))
 	}
 
 	buf.WriteByte('\n')
@@ -231,80 +235,93 @@ func formatJSONValue(value any) any {
 	}
 }
 
-// formatValue formats a value for serialization
-func formatLogfmtValue(value any) string {
+// appendLogfmtValue appends a value in logfmt format to dst and returns the
+// extended slice. This is the append-style equivalent of the previous
+// formatLogfmtValue+escapeString path: it writes directly into the caller's
+// buffer, avoiding an intermediate string allocation and a sync.Pool round-trip.
+func appendLogfmtValue(dst []byte, value any) []byte {
 	if value == nil {
-		return "nil"
+		return append(dst, "nil"...)
 	}
-
 	if t, ok := value.(time.Time); ok {
-		// Performance optimization: No need for escaping since the provided
-		// timeFormat doesn't have any escape characters, and escaping is
-		// expensive.
-		return t.Format(timeFormat)
+		// Performance optimization: timeFormat has no escape characters, so
+		// we can skip escaping entirely.
+		return t.AppendFormat(dst, timeFormat)
 	}
 	value = formatShared(value)
 	switch v := value.(type) {
 	case bool:
-		return strconv.FormatBool(v)
+		return strconv.AppendBool(dst, v)
 	case float32:
-		return strconv.FormatFloat(float64(v), floatFormat, 3, 64)
+		return strconv.AppendFloat(dst, float64(v), floatFormat, 3, 64)
 	case float64:
-		return strconv.FormatFloat(v, floatFormat, 3, 64)
-	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-		return fmt.Sprintf("%d", value)
+		return strconv.AppendFloat(dst, v, floatFormat, 3, 64)
+	case int:
+		return strconv.AppendInt(dst, int64(v), 10)
+	case int8:
+		return strconv.AppendInt(dst, int64(v), 10)
+	case int16:
+		return strconv.AppendInt(dst, int64(v), 10)
+	case int32:
+		return strconv.AppendInt(dst, int64(v), 10)
+	case int64:
+		return strconv.AppendInt(dst, v, 10)
+	case uint:
+		return strconv.AppendUint(dst, uint64(v), 10)
+	case uint8:
+		return strconv.AppendUint(dst, uint64(v), 10)
+	case uint16:
+		return strconv.AppendUint(dst, uint64(v), 10)
+	case uint32:
+		return strconv.AppendUint(dst, uint64(v), 10)
+	case uint64:
+		return strconv.AppendUint(dst, v, 10)
 	case string:
-		return escapeString(v)
+		return appendEscaped(dst, v)
 	default:
-		return escapeString(fmt.Sprintf("%+v", value))
+		return appendEscaped(dst, fmt.Sprintf("%+v", value))
 	}
 }
 
-var stringBufPool = sync.Pool{
-	New: func() any { return new(bytes.Buffer) },
-}
-
-func escapeString(s string) string {
+// appendEscaped appends s to dst, quoting and escaping if s contains any
+// character that would require it in logfmt. Zero-alloc in the fast path
+// (s appended verbatim) and one-pass in the slow path.
+func appendEscaped(dst []byte, s string) []byte {
 	needsQuotes := false
 	needsEscape := false
-	for _, r := range s {
-		if r <= ' ' || r == '=' || r == '"' {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c <= ' ' || c == '=' || c == '"' {
 			needsQuotes = true
 		}
-		if r == '\\' || r == '"' || r == '\n' || r == '\r' || r == '\t' {
+		if c == '\\' || c == '"' || c == '\n' || c == '\r' || c == '\t' {
 			needsEscape = true
 		}
 	}
-	if needsEscape == false && needsQuotes == false {
-		return s
+	if !needsEscape && !needsQuotes {
+		return append(dst, s...)
 	}
-	e := stringBufPool.Get().(*bytes.Buffer)
-	e.WriteByte('"')
+	if needsQuotes {
+		dst = append(dst, '"')
+	}
 	for _, r := range s {
 		switch r {
 		case '\\', '"':
-			e.WriteByte('\\')
-			e.WriteByte(byte(r))
+			dst = append(dst, '\\', byte(r))
 		case '\n':
-			e.WriteString("\\n")
+			dst = append(dst, '\\', 'n')
 		case '\r':
-			e.WriteString("\\r")
+			dst = append(dst, '\\', 'r')
 		case '\t':
-			e.WriteString("\\t")
+			dst = append(dst, '\\', 't')
 		default:
-			e.WriteRune(r)
+			dst = utf8.AppendRune(dst, r)
 		}
 	}
-	e.WriteByte('"')
-	var ret string
 	if needsQuotes {
-		ret = e.String()
-	} else {
-		ret = string(e.Bytes()[1 : e.Len()-1])
+		dst = append(dst, '"')
 	}
-	e.Reset()
-	stringBufPool.Put(e)
-	return ret
+	return dst
 }
 
 // EnvBool from dbg uses log many times so don't want to make a cycle.

--- a/db/kv/table_sizes.go
+++ b/db/kv/table_sizes.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/c2h5oh/datasize"
+
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/log/v3"
@@ -95,6 +97,9 @@ func CollectTableSizesPeriodically(ctx context.Context, db TemporalRoDB, label L
 
 			var sb strings.Builder
 			for _, t := range tableSizes {
+				if t.Size < (1 * datasize.MB).Bytes() {
+					continue
+				}
 				dbTableSizeBytes.WithLabelValues(string(label), t.Name).Set(float64(t.Size))
 				if t.Size == 0 || !debugLogging {
 					continue

--- a/execution/p2p/peer_tracker.go
+++ b/execution/p2p/peer_tracker.go
@@ -138,10 +138,11 @@ func (pt *PeerTracker) BlockHashPresent(peerId *PeerId, blockHash common.Hash) {
 }
 
 func (pt *PeerTracker) PeerDisconnected(peerId *PeerId) {
+	pt.logger.Trace(peerTrackerLogPrefix("peer disconnected"), "peerId", peerId.String())
+
 	pt.mu.Lock()
 	defer pt.mu.Unlock()
 
-	pt.logger.Debug(peerTrackerLogPrefix("peer disconnected"), "peerId", peerId.String())
 	delete(pt.peerSyncProgresses, *peerId)
 	delete(pt.peerKnownBlockAnnounces, *peerId)
 }
@@ -154,7 +155,7 @@ func (pt *PeerTracker) PeerConnected(peerId *PeerId) {
 }
 
 func (pt *PeerTracker) peerConnected(peerId *PeerId) {
-	pt.logger.Debug(peerTrackerLogPrefix("peer connected"), "peerId", peerId.String())
+	pt.logger.Trace(peerTrackerLogPrefix("peer connected"), "peerId", peerId.String())
 
 	peerIdVal := *peerId
 	if _, ok := pt.peerSyncProgresses[peerIdVal]; !ok {

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -165,8 +165,7 @@ func (se *serialExecutor) exec(ctx context.Context, execStage *StageState, u Unw
 		start := time.Now()
 		continueLoop, err := se.executeBlock(ctx, txTasks, execStage.CurrentSyncCycle.IsInitialCycle, false)
 
-		took := time.Since(start)
-		if took > 20*time.Millisecond { // prevent logs spamming
+		if took := time.Since(start); took > 20*time.Millisecond { // prevent logs spamming
 			log.Debug(fmt.Sprintf("[%s] executed block %d in %s", se.logPrefix, blockNum, took))
 		}
 		if err != nil {

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -166,7 +166,7 @@ func (se *serialExecutor) exec(ctx context.Context, execStage *StageState, u Unw
 		continueLoop, err := se.executeBlock(ctx, txTasks, execStage.CurrentSyncCycle.IsInitialCycle, false)
 
 		took := time.Since(start)
-		if took > 20*time.Millisecond {
+		if took > 20*time.Millisecond { // prevent logs spamming
 			log.Debug(fmt.Sprintf("[%s] executed block %d in %s", se.logPrefix, blockNum, took))
 		}
 		if err != nil {

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -165,7 +165,7 @@ func (se *serialExecutor) exec(ctx context.Context, execStage *StageState, u Unw
 		start := time.Now()
 		continueLoop, err := se.executeBlock(ctx, txTasks, execStage.CurrentSyncCycle.IsInitialCycle, false)
 
-		if took := time.Since(start); took > 20*time.Millisecond { // prevent logs spamming
+		if took := time.Since(start); took > 30*time.Millisecond { // prevent logs spamming
 			log.Debug(fmt.Sprintf("[%s] executed block %d in %s", se.logPrefix, blockNum, took))
 		}
 		if err != nil {

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -165,7 +165,7 @@ func (se *serialExecutor) exec(ctx context.Context, execStage *StageState, u Unw
 		start := time.Now()
 		continueLoop, err := se.executeBlock(ctx, txTasks, execStage.CurrentSyncCycle.IsInitialCycle, false)
 
-		if took := time.Since(start); took > 30*time.Millisecond { // prevent logs spamming
+		if took := time.Since(start); took > 50*time.Millisecond { // prevent logs spamming
 			log.Debug(fmt.Sprintf("[%s] executed block %d in %s", se.logPrefix, blockNum, took))
 		}
 		if err != nil {

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -165,7 +165,10 @@ func (se *serialExecutor) exec(ctx context.Context, execStage *StageState, u Unw
 		start := time.Now()
 		continueLoop, err := se.executeBlock(ctx, txTasks, execStage.CurrentSyncCycle.IsInitialCycle, false)
 
-		log.Debug(fmt.Sprintf("[%s] executed block %d in %s", se.logPrefix, blockNum, time.Since(start)))
+		took := time.Since(start)
+		if took > 20*time.Millisecond {
+			log.Debug(fmt.Sprintf("[%s] executed block %d in %s", se.logPrefix, blockNum, took))
+		}
 		if err != nil {
 			return nil, rwTx, err
 		}

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -487,11 +487,11 @@ func (tab *Table) addIP(b *bucket, ip netip.Addr) bool {
 		return true
 	}
 	if !tab.ips.AddAddr(ip) {
-		tab.log.Debug("[p2p] IP exceeds table limit", "ip", ip)
+		tab.log.Trace("[p2p] IP exceeds table limit", "ip", ip)
 		return false
 	}
 	if !b.ips.AddAddr(ip) {
-		tab.log.Debug("[p2p] IP exceeds bucket limit", "ip", ip)
+		tab.log.Trace("[p2p] IP exceeds bucket limit", "ip", ip)
 		tab.ips.RemoveAddr(ip)
 		return false
 	}


### PR DESCRIPTION
for https://github.com/erigontech/erigon/issues/20661

- demote some logs from Debug to Trace
- move some logs out of external mutexes
- optimize log formatter (to reduce time spent inside logger's mutex)
- `[kv] table sizes` sending too much data to logger. filter-out tables