### PR TITLE
rpc: compression with libdeflate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,9 @@ go 1.25.7
 
 replace github.com/holiman/bloomfilter/v2 => github.com/AskAlexSharov/bloomfilter/v2 v2.0.9
 
-replace github.com/erigontech/go-libdeflate => /home/simon/silkworm/go-libdeflate
-
 require (
 	github.com/erigontech/erigon-snapshot v1.3.1-0.20260402120223-7bb412bc89cd
-	github.com/erigontech/go-libdeflate v0.0.0
+	github.com/erigontech/go-libdeflate v0.1.0
 	github.com/erigontech/mdbx-go v0.39.17
 	github.com/erigontech/secp256k1 v1.2.1-0.20260218182123-377cc1bd6410
 )

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,11 @@ go 1.25.7
 
 replace github.com/holiman/bloomfilter/v2 => github.com/AskAlexSharov/bloomfilter/v2 v2.0.9
 
+replace github.com/erigontech/go-libdeflate => /home/simon/silkworm/go-libdeflate
+
 require (
 	github.com/erigontech/erigon-snapshot v1.3.1-0.20260402120223-7bb412bc89cd
+	github.com/erigontech/go-libdeflate v0.0.0
 	github.com/erigontech/mdbx-go v0.39.17
 	github.com/erigontech/secp256k1 v1.2.1-0.20260218182123-377cc1bd6410
 )

--- a/go.sum
+++ b/go.sum
@@ -344,6 +344,8 @@ github.com/erigontech/fastkeccak v0.1.1-0.20260408010752-08e7b6602268 h1:NHl4+Dj
 github.com/erigontech/fastkeccak v0.1.1-0.20260408010752-08e7b6602268/go.mod h1:CwJFJVKFVWpQyKSfRrQyY56IqV16sR5xnQoFThGHiZA=
 github.com/erigontech/go-eth-kzg v0.0.0-20260401161010-070339460d07 h1:0VpFIthaJzGs3iwyrKCj67wptrNq7KKiLhilDCRPqwk=
 github.com/erigontech/go-eth-kzg v0.0.0-20260401161010-070339460d07/go.mod h1:J9/u5sWfznSObptgfa92Jq8rTswn6ahQWEuiLHOjCUI=
+github.com/erigontech/go-libdeflate v0.1.0 h1:WtKiuNpuAP/Qyq3mbPwFB0DoQikabtOeZFUgo9VGRsY=
+github.com/erigontech/go-libdeflate v0.1.0/go.mod h1:OCQBWlynNqNCYb1ckqNjY69H1LAhg2TyyfYZalO03BM=
 github.com/erigontech/mdbx-go v0.39.17 h1:+FQMaCuH/IB+t9HEXVDxTJaV5jvZTwC/6YgDHHKDDMo=
 github.com/erigontech/mdbx-go v0.39.17/go.mod h1:VTGwYzepS9Wg38jVfreOsSVlh73OBGPZluu7kHo6X6g=
 github.com/erigontech/secp256k1 v1.2.1-0.20260218182123-377cc1bd6410 h1:5YD7JJ5PaqOdjKA84lTDtQby9nbI4podqrkUhyIyFDw=

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -608,10 +608,10 @@ func newGzipHandler(next http.Handler) http.Handler {
 			*dstPtr = (*dstPtr)[:needed]
 		}
 		n, err := c.CompressGzip(*dstPtr, src)
-		if cap(*dstPtr) <= 1<<20 {
-			gzDstPool.Put(dstPtr)
-		}
 		if err != nil {
+			if cap(*dstPtr) <= 1<<20 {
+				gzDstPool.Put(dstPtr)
+			}
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -622,6 +622,9 @@ func newGzipHandler(next http.Handler) http.Handler {
 			w.WriteHeader(grw.status)
 		}
 		w.Write((*dstPtr)[:n]) //nolint:errcheck
+		if cap(*dstPtr) <= 1<<20 {
+			gzDstPool.Put(dstPtr)
+		}
 	})
 }
 

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -20,17 +20,18 @@
 package node
 
 import (
-	"compress/gzip"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
+
+	libdeflate "github.com/erigontech/go-libdeflate"
 
 	"github.com/rs/cors"
 
@@ -508,25 +509,25 @@ func (h *virtualHostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	http.Error(w, "invalid host specified", http.StatusForbidden)
 }
 
-var gzPool = sync.Pool{
+var gzCompressorPool = sync.Pool{
 	New: func() any {
-		w := gzip.NewWriter(io.Discard)
-		return w
+		c, _ := libdeflate.NewCompressor(libdeflate.DefaultCompression)
+		return c
 	},
 }
 
 type gzipResponseWriter struct {
-	io.Writer
+	buf bytes.Buffer
 	http.ResponseWriter
+	status int
 }
 
 func (w *gzipResponseWriter) WriteHeader(status int) {
-	w.Header().Del("Content-Length")
-	w.ResponseWriter.WriteHeader(status)
+	w.status = status
 }
 
 func (w *gzipResponseWriter) Write(b []byte) (int, error) {
-	return w.Writer.Write(b)
+	return w.buf.Write(b)
 }
 
 func newGzipHandler(next http.Handler) http.Handler {
@@ -536,15 +537,26 @@ func newGzipHandler(next http.Handler) http.Handler {
 			return
 		}
 
+		grw := &gzipResponseWriter{ResponseWriter: w}
+		next.ServeHTTP(grw, r)
+
+		c := gzCompressorPool.Get().(*libdeflate.Compressor)
+		defer gzCompressorPool.Put(c)
+
+		src := grw.buf.Bytes()
+		dst := make([]byte, c.GzipCompressBound(len(src)))
+		n, err := c.CompressGzip(dst, src)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
 		w.Header().Set("Content-Encoding", "gzip")
-
-		gz := gzPool.Get().(*gzip.Writer)
-		defer gzPool.Put(gz)
-
-		gz.Reset(w)
-		defer gz.Close()
-
-		next.ServeHTTP(&gzipResponseWriter{ResponseWriter: w, Writer: gz}, r)
+		w.Header().Del("Content-Length")
+		if grw.status != 0 {
+			w.WriteHeader(grw.status)
+		}
+		w.Write(dst[:n]) //nolint:errcheck
 	})
 }
 

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -525,11 +525,13 @@ var gzPool = sync.Pool{
 
 var libdeflateWarnOnce sync.Once
 var libdeflateCompressWarnOnce sync.Once
+var libdeflateDisabled atomic.Bool
 
 var gzCompressorPool = sync.Pool{
 	New: func() any {
 		c, err := libdeflate.NewCompressor(libdeflate.DefaultCompression)
 		if err != nil {
+			libdeflateDisabled.Store(true)
 			libdeflateWarnOnce.Do(func() {
 				log.Warn("libdeflate unavailable, falling back to stdlib gzip", "err", err)
 			})
@@ -544,7 +546,32 @@ var gzBufPool = sync.Pool{
 }
 
 var gzDstPool = sync.Pool{
-	New: func() any { b := make([]byte, 0, 64*1024); return &b },
+	New: func() any { return make([]byte, 0, 64*1024) },
+}
+
+func getBuf() *bytes.Buffer {
+	buf := gzBufPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	return buf
+}
+
+func putBuf(buf *bytes.Buffer) {
+	if buf.Cap() <= gzPoolBufCap {
+		gzBufPool.Put(buf)
+	}
+}
+
+func putDst(dst []byte) {
+	if cap(dst) <= gzPoolBufCap {
+		gzDstPool.Put(dst)
+	}
+}
+
+func gzDstGrow(b []byte, wantLen int) []byte {
+	if cap(b) >= wantLen {
+		return b[:wantLen]
+	}
+	return make([]byte, wantLen, max(wantLen, 2*cap(b)))
 }
 
 type gzipResponseWriter struct {
@@ -590,9 +617,7 @@ func (w *gzipResponseWriter) Flush() {
 	}
 }
 
-// writeStdlibGzip compresses src with stdlib gzip and writes the response to w.
-// buf is returned to gzBufPool if its capacity is within gzPoolBufCap.
-func writeStdlibGzip(w http.ResponseWriter, src []byte, status int, buf *bytes.Buffer) {
+func writeStdlibGzip(w http.ResponseWriter, src []byte, status int) {
 	gz := gzPool.Get().(*gzip.Writer)
 	defer gzPool.Put(gz)
 	gz.Reset(w)
@@ -602,10 +627,66 @@ func writeStdlibGzip(w http.ResponseWriter, src []byte, status int, buf *bytes.B
 		w.WriteHeader(status)
 	}
 	_, _ = gz.Write(src)
-	if buf.Cap() <= gzPoolBufCap {
-		gzBufPool.Put(buf)
-	}
 	_ = gz.Close()
+}
+
+// compressLibdeflate tries to compress src with libdeflate and write the response.
+// Returns false if libdeflate is unavailable or compression fails; the caller
+// should then fall back to writeStdlibGzip.
+func compressLibdeflate(w http.ResponseWriter, src []byte, status int) bool {
+	if libdeflateDisabled.Load() {
+		return false
+	}
+	raw := gzCompressorPool.Get()
+	if raw == nil {
+		return false
+	}
+	c := raw.(*libdeflate.Compressor)
+	defer gzCompressorPool.Put(c)
+
+	dst := gzDstPool.Get().([]byte)
+	dst = gzDstGrow(dst, c.GzipCompressBound(len(src)))
+	defer putDst(dst)
+
+	n, err := c.CompressGzip(dst, src)
+	if err != nil {
+		libdeflateCompressWarnOnce.Do(func() {
+			log.Warn("libdeflate compression failed, falling back to stdlib gzip", "err", err)
+		})
+		return false
+	}
+
+	w.Header().Set("Content-Encoding", "gzip")
+	w.Header().Set("Content-Length", strconv.Itoa(n))
+	if status != 0 {
+		w.WriteHeader(status)
+	}
+	w.Write(dst[:n]) //nolint:errcheck
+	return true
+}
+
+func sendGzipResponse(w http.ResponseWriter, grw *gzipResponseWriter) {
+	defer putBuf(grw.buf)
+
+	if grw.gzw != nil {
+		defer gzPool.Put(grw.gzw)
+		defer grw.gzw.Close() //nolint:errcheck
+		return
+	}
+
+	src := grw.buf.Bytes()
+	if len(src) < minGzipBodySize {
+		w.Header().Set("Content-Length", strconv.Itoa(len(src)))
+		if grw.status != 0 {
+			w.WriteHeader(grw.status)
+		}
+		w.Write(src) //nolint:errcheck
+		return
+	}
+
+	if !compressLibdeflate(w, src, grw.status) {
+		writeStdlibGzip(w, src, grw.status)
+	}
 }
 
 func newGzipHandler(next http.Handler) http.Handler {
@@ -615,77 +696,12 @@ func newGzipHandler(next http.Handler) http.Handler {
 			return
 		}
 
-		buf := gzBufPool.Get().(*bytes.Buffer)
-		buf.Reset()
-		grw := &gzipResponseWriter{buf: buf, ResponseWriter: w}
+		grw := &gzipResponseWriter{buf: getBuf(), ResponseWriter: w}
 		// The hook activates streaming mode before the first write; absent when gzip
 		// is off so it cannot prematurely commit HTTP headers (e.g. 200 before 503).
 		r = r.WithContext(rpc.WithGzipStreamingHook(r.Context(), grw.Flush))
 		next.ServeHTTP(grw, r)
-
-		if grw.gzw != nil {
-			if buf.Cap() <= gzPoolBufCap {
-				gzBufPool.Put(buf)
-			}
-			defer gzPool.Put(grw.gzw)
-			_ = grw.gzw.Close()
-			return
-		}
-
-		// Non-streaming: skip compression for small responses where gzip overhead
-		// would exceed the savings (header ~18 B + deflate framing).
-		src := grw.buf.Bytes()
-		if len(src) < minGzipBodySize {
-			w.Header().Set("Content-Length", strconv.Itoa(len(src)))
-			if grw.status != 0 {
-				w.WriteHeader(grw.status)
-			}
-			w.Write(src) //nolint:errcheck
-			if buf.Cap() <= gzPoolBufCap {
-				gzBufPool.Put(buf)
-			}
-			return
-		}
-
-		// Non-streaming: prefer libdeflate for faster one-shot compression.
-		if raw := gzCompressorPool.Get(); raw != nil {
-			c := raw.(*libdeflate.Compressor)
-			defer gzCompressorPool.Put(c)
-
-			dstPtr := gzDstPool.Get().(*[]byte)
-			needed := c.GzipCompressBound(len(src))
-			if cap(*dstPtr) < needed {
-				*dstPtr = make([]byte, needed)
-			} else {
-				*dstPtr = (*dstPtr)[:needed]
-			}
-			n, err := c.CompressGzip(*dstPtr, src)
-			if err != nil {
-				libdeflateCompressWarnOnce.Do(func() {
-					log.Warn("libdeflate compression failed, falling back to stdlib gzip", "err", err)
-				})
-				if cap(*dstPtr) <= gzPoolBufCap {
-					gzDstPool.Put(dstPtr)
-				}
-				writeStdlibGzip(w, src, grw.status, buf)
-				return
-			}
-			if buf.Cap() <= gzPoolBufCap {
-				gzBufPool.Put(buf)
-			}
-			w.Header().Set("Content-Encoding", "gzip")
-			w.Header().Set("Content-Length", strconv.Itoa(n))
-			if grw.status != 0 {
-				w.WriteHeader(grw.status)
-			}
-			w.Write((*dstPtr)[:n]) //nolint:errcheck
-			if cap(*dstPtr) <= gzPoolBufCap {
-				gzDstPool.Put(dstPtr)
-			}
-			return
-		}
-
-		writeStdlibGzip(w, src, grw.status, buf)
+		sendGzipResponse(w, grw)
 	})
 }
 

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -20,18 +20,17 @@
 package node
 
 import (
-	"bytes"
+	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
-
-	libdeflate "github.com/erigontech/go-libdeflate"
 
 	"github.com/rs/cors"
 
@@ -509,25 +508,25 @@ func (h *virtualHostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	http.Error(w, "invalid host specified", http.StatusForbidden)
 }
 
-var gzCompressorPool = sync.Pool{
+var gzPool = sync.Pool{
 	New: func() any {
-		c, _ := libdeflate.NewCompressor(libdeflate.DefaultCompression)
-		return c
+		w := gzip.NewWriter(io.Discard)
+		return w
 	},
 }
 
 type gzipResponseWriter struct {
-	buf bytes.Buffer
+	io.Writer
 	http.ResponseWriter
-	status int
 }
 
 func (w *gzipResponseWriter) WriteHeader(status int) {
-	w.status = status
+	w.Header().Del("Content-Length")
+	w.ResponseWriter.WriteHeader(status)
 }
 
 func (w *gzipResponseWriter) Write(b []byte) (int, error) {
-	return w.buf.Write(b)
+	return w.Writer.Write(b)
 }
 
 func newGzipHandler(next http.Handler) http.Handler {
@@ -537,26 +536,15 @@ func newGzipHandler(next http.Handler) http.Handler {
 			return
 		}
 
-		grw := &gzipResponseWriter{ResponseWriter: w}
-		next.ServeHTTP(grw, r)
-
-		c := gzCompressorPool.Get().(*libdeflate.Compressor)
-		defer gzCompressorPool.Put(c)
-
-		src := grw.buf.Bytes()
-		dst := make([]byte, c.GzipCompressBound(len(src)))
-		n, err := c.CompressGzip(dst, src)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
 		w.Header().Set("Content-Encoding", "gzip")
-		w.Header().Del("Content-Length")
-		if grw.status != 0 {
-			w.WriteHeader(grw.status)
-		}
-		w.Write(dst[:n]) //nolint:errcheck
+
+		gz := gzPool.Get().(*gzip.Writer)
+		defer gzPool.Put(gz)
+
+		gz.Reset(w)
+		defer gz.Close()
+
+		next.ServeHTTP(&gzipResponseWriter{ResponseWriter: w, Writer: gz}, r)
 	})
 }
 

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -29,6 +29,7 @@ import (
 	"net"
 	"net/http"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -514,6 +515,10 @@ func (h *virtualHostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // gzPoolBufCap is the maximum buffer capacity retained in pools to bound RSS growth.
 const gzPoolBufCap = 1 << 20
 
+// minGzipBodySize is the minimum response body size to compress. Responses
+// smaller than this are sent as-is: gzip framing overhead would exceed savings.
+const minGzipBodySize = 1024
+
 var gzPool = sync.Pool{
 	New: func() any { w, _ := gzip.NewWriterLevel(io.Discard, gzip.BestSpeed); return w },
 }
@@ -627,12 +632,26 @@ func newGzipHandler(next http.Handler) http.Handler {
 			return
 		}
 
+		// Non-streaming: skip compression for small responses where gzip overhead
+		// would exceed the savings (header ~18 B + deflate framing).
+		src := grw.buf.Bytes()
+		if len(src) < minGzipBodySize {
+			w.Header().Set("Content-Length", strconv.Itoa(len(src)))
+			if grw.status != 0 {
+				w.WriteHeader(grw.status)
+			}
+			w.Write(src) //nolint:errcheck
+			if buf.Cap() <= gzPoolBufCap {
+				gzBufPool.Put(buf)
+			}
+			return
+		}
+
 		// Non-streaming: prefer libdeflate for faster one-shot compression.
 		if raw := gzCompressorPool.Get(); raw != nil {
 			c := raw.(*libdeflate.Compressor)
 			defer gzCompressorPool.Put(c)
 
-			src := grw.buf.Bytes()
 			dstPtr := gzDstPool.Get().(*[]byte)
 			needed := c.GzipCompressBound(len(src))
 			if cap(*dstPtr) < needed {
@@ -655,7 +674,7 @@ func newGzipHandler(next http.Handler) http.Handler {
 				gzBufPool.Put(buf)
 			}
 			w.Header().Set("Content-Encoding", "gzip")
-			w.Header().Del("Content-Length")
+			w.Header().Set("Content-Length", strconv.Itoa(n))
 			if grw.status != 0 {
 				w.WriteHeader(grw.status)
 			}
@@ -666,7 +685,7 @@ func newGzipHandler(next http.Handler) http.Handler {
 			return
 		}
 
-		writeStdlibGzip(w, grw.buf.Bytes(), grw.status, buf)
+		writeStdlibGzip(w, src, grw.status, buf)
 	})
 }
 

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -511,15 +511,24 @@ func (h *virtualHostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	http.Error(w, "invalid host specified", http.StatusForbidden)
 }
 
+// gzPoolBufCap is the maximum buffer capacity retained in pools to bound RSS growth.
+const gzPoolBufCap = 1 << 20
+
 var gzPool = sync.Pool{
-	New: func() any { return gzip.NewWriter(io.Discard) },
+	New: func() any { w, _ := gzip.NewWriterLevel(io.Discard, gzip.BestSpeed); return w },
 }
+
+var libdeflateWarnOnce sync.Once
+var libdeflateCompressWarnOnce sync.Once
 
 var gzCompressorPool = sync.Pool{
 	New: func() any {
 		c, err := libdeflate.NewCompressor(libdeflate.DefaultCompression)
 		if err != nil {
-			panic(fmt.Sprintf("libdeflate: failed to create compressor: %v", err))
+			libdeflateWarnOnce.Do(func() {
+				log.Warn("libdeflate unavailable, falling back to stdlib gzip", "err", err)
+			})
+			return nil
 		}
 		return c
 	},
@@ -529,8 +538,6 @@ var gzBufPool = sync.Pool{
 	New: func() any { return new(bytes.Buffer) },
 }
 
-// gzDstPool pools the destination slice for libdeflate one-shot compression,
-// avoiding a large per-request allocation. The slice is grown as needed.
 var gzDstPool = sync.Pool{
 	New: func() any { b := make([]byte, 0, 64*1024); return &b },
 }
@@ -557,23 +564,43 @@ func (w *gzipResponseWriter) Write(b []byte) (int, error) {
 	return w.buf.Write(b)
 }
 
-// Flush implements http.Flusher. Switches from buffering to stdlib gzip streaming
-// so that libdeflate is used only for non-streaming responses.
+// Flush switches to streaming gzip on first call; subsequent calls flush incrementally.
 func (w *gzipResponseWriter) Flush() {
-	if w.gzw != nil {
-		return
+	if w.gzw == nil {
+		w.ResponseWriter.Header().Set("Content-Encoding", "gzip")
+		w.ResponseWriter.Header().Del("Content-Length")
+		if w.status != 0 {
+			w.ResponseWriter.WriteHeader(w.status)
+		}
+		w.gzw = gzPool.Get().(*gzip.Writer)
+		w.gzw.Reset(w.ResponseWriter)
+		if w.buf.Len() > 0 {
+			_, _ = w.gzw.Write(w.buf.Bytes())
+			w.buf.Reset()
+		}
 	}
-	w.ResponseWriter.Header().Set("Content-Encoding", "gzip")
-	w.ResponseWriter.Header().Del("Content-Length")
-	if w.status != 0 {
-		w.ResponseWriter.WriteHeader(w.status)
+	_ = w.gzw.Flush()
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
 	}
-	w.gzw = gzPool.Get().(*gzip.Writer)
-	w.gzw.Reset(w.ResponseWriter)
-	if w.buf.Len() > 0 {
-		_, _ = w.gzw.Write(w.buf.Bytes())
-		w.buf.Reset()
+}
+
+// writeStdlibGzip compresses src with stdlib gzip and writes the response to w.
+// buf is returned to gzBufPool if its capacity is within gzPoolBufCap.
+func writeStdlibGzip(w http.ResponseWriter, src []byte, status int, buf *bytes.Buffer) {
+	gz := gzPool.Get().(*gzip.Writer)
+	defer gzPool.Put(gz)
+	gz.Reset(w)
+	w.Header().Set("Content-Encoding", "gzip")
+	w.Header().Del("Content-Length")
+	if status != 0 {
+		w.WriteHeader(status)
 	}
+	_, _ = gz.Write(src)
+	if buf.Cap() <= gzPoolBufCap {
+		gzBufPool.Put(buf)
+	}
+	_ = gz.Close()
 }
 
 func newGzipHandler(next http.Handler) http.Handler {
@@ -585,46 +612,61 @@ func newGzipHandler(next http.Handler) http.Handler {
 
 		buf := gzBufPool.Get().(*bytes.Buffer)
 		buf.Reset()
-		defer gzBufPool.Put(buf)
 		grw := &gzipResponseWriter{buf: buf, ResponseWriter: w}
+		// The hook activates streaming mode before the first write; absent when gzip
+		// is off so it cannot prematurely commit HTTP headers (e.g. 200 before 503).
+		r = r.WithContext(rpc.WithGzipStreamingHook(r.Context(), grw.Flush))
 		next.ServeHTTP(grw, r)
 
 		if grw.gzw != nil {
+			if buf.Cap() <= gzPoolBufCap {
+				gzBufPool.Put(buf)
+			}
 			defer gzPool.Put(grw.gzw)
 			_ = grw.gzw.Close()
 			return
 		}
 
-		// Non-streaming: use libdeflate for faster one-shot compression.
-		c := gzCompressorPool.Get().(*libdeflate.Compressor)
-		defer gzCompressorPool.Put(c)
+		// Non-streaming: prefer libdeflate for faster one-shot compression.
+		if raw := gzCompressorPool.Get(); raw != nil {
+			c := raw.(*libdeflate.Compressor)
+			defer gzCompressorPool.Put(c)
 
-		src := grw.buf.Bytes()
-		dstPtr := gzDstPool.Get().(*[]byte)
-		needed := c.GzipCompressBound(len(src))
-		if cap(*dstPtr) < needed {
-			*dstPtr = make([]byte, needed)
-		} else {
-			*dstPtr = (*dstPtr)[:needed]
-		}
-		n, err := c.CompressGzip(*dstPtr, src)
-		if err != nil {
-			if cap(*dstPtr) <= 1<<20 {
+			src := grw.buf.Bytes()
+			dstPtr := gzDstPool.Get().(*[]byte)
+			needed := c.GzipCompressBound(len(src))
+			if cap(*dstPtr) < needed {
+				*dstPtr = make([]byte, needed)
+			} else {
+				*dstPtr = (*dstPtr)[:needed]
+			}
+			n, err := c.CompressGzip(*dstPtr, src)
+			if err != nil {
+				libdeflateCompressWarnOnce.Do(func() {
+					log.Warn("libdeflate compression failed, falling back to stdlib gzip", "err", err)
+				})
+				if cap(*dstPtr) <= gzPoolBufCap {
+					gzDstPool.Put(dstPtr)
+				}
+				writeStdlibGzip(w, src, grw.status, buf)
+				return
+			}
+			if buf.Cap() <= gzPoolBufCap {
+				gzBufPool.Put(buf)
+			}
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Del("Content-Length")
+			if grw.status != 0 {
+				w.WriteHeader(grw.status)
+			}
+			w.Write((*dstPtr)[:n]) //nolint:errcheck
+			if cap(*dstPtr) <= gzPoolBufCap {
 				gzDstPool.Put(dstPtr)
 			}
-			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
-		w.Header().Set("Content-Encoding", "gzip")
-		w.Header().Del("Content-Length")
-		if grw.status != 0 {
-			w.WriteHeader(grw.status)
-		}
-		w.Write((*dstPtr)[:n]) //nolint:errcheck
-		if cap(*dstPtr) <= 1<<20 {
-			gzDstPool.Put(dstPtr)
-		}
+		writeStdlibGzip(w, grw.buf.Bytes(), grw.status, buf)
 	})
 }
 

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -601,7 +601,6 @@ func newGzipHandler(next http.Handler) http.Handler {
 
 		src := grw.buf.Bytes()
 		dstPtr := gzDstPool.Get().(*[]byte)
-		defer gzDstPool.Put(dstPtr)
 		needed := c.GzipCompressBound(len(src))
 		if cap(*dstPtr) < needed {
 			*dstPtr = make([]byte, needed)
@@ -609,6 +608,9 @@ func newGzipHandler(next http.Handler) http.Handler {
 			*dstPtr = (*dstPtr)[:needed]
 		}
 		n, err := c.CompressGzip(*dstPtr, src)
+		if cap(*dstPtr) <= 1<<20 {
+			gzDstPool.Put(dstPtr)
+		}
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -20,6 +20,7 @@
 package node
 
 import (
+	"bytes"
 	"compress/gzip"
 	"context"
 	"errors"
@@ -31,6 +32,8 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+
+	libdeflate "github.com/erigontech/go-libdeflate"
 
 	"github.com/rs/cors"
 
@@ -509,24 +512,68 @@ func (h *virtualHostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 var gzPool = sync.Pool{
+	New: func() any { return gzip.NewWriter(io.Discard) },
+}
+
+var gzCompressorPool = sync.Pool{
 	New: func() any {
-		w := gzip.NewWriter(io.Discard)
-		return w
+		c, err := libdeflate.NewCompressor(libdeflate.DefaultCompression)
+		if err != nil {
+			panic(fmt.Sprintf("libdeflate: failed to create compressor: %v", err))
+		}
+		return c
 	},
 }
 
+var gzBufPool = sync.Pool{
+	New: func() any { return new(bytes.Buffer) },
+}
+
+// gzDstPool pools the destination slice for libdeflate one-shot compression,
+// avoiding a large per-request allocation. The slice is grown as needed.
+var gzDstPool = sync.Pool{
+	New: func() any { b := make([]byte, 0, 64*1024); return &b },
+}
+
 type gzipResponseWriter struct {
-	io.Writer
+	buf    *bytes.Buffer
+	gzw    *gzip.Writer
+	status int
 	http.ResponseWriter
 }
 
 func (w *gzipResponseWriter) WriteHeader(status int) {
-	w.Header().Del("Content-Length")
-	w.ResponseWriter.WriteHeader(status)
+	if w.gzw != nil {
+		w.ResponseWriter.WriteHeader(status)
+	} else {
+		w.status = status
+	}
 }
 
 func (w *gzipResponseWriter) Write(b []byte) (int, error) {
-	return w.Writer.Write(b)
+	if w.gzw != nil {
+		return w.gzw.Write(b)
+	}
+	return w.buf.Write(b)
+}
+
+// Flush implements http.Flusher. Switches from buffering to stdlib gzip streaming
+// so that libdeflate is used only for non-streaming responses.
+func (w *gzipResponseWriter) Flush() {
+	if w.gzw != nil {
+		return
+	}
+	w.ResponseWriter.Header().Set("Content-Encoding", "gzip")
+	w.ResponseWriter.Header().Del("Content-Length")
+	if w.status != 0 {
+		w.ResponseWriter.WriteHeader(w.status)
+	}
+	w.gzw = gzPool.Get().(*gzip.Writer)
+	w.gzw.Reset(w.ResponseWriter)
+	if w.buf.Len() > 0 {
+		_, _ = w.gzw.Write(w.buf.Bytes())
+		w.buf.Reset()
+	}
 }
 
 func newGzipHandler(next http.Handler) http.Handler {
@@ -536,15 +583,43 @@ func newGzipHandler(next http.Handler) http.Handler {
 			return
 		}
 
+		buf := gzBufPool.Get().(*bytes.Buffer)
+		buf.Reset()
+		defer gzBufPool.Put(buf)
+		grw := &gzipResponseWriter{buf: buf, ResponseWriter: w}
+		next.ServeHTTP(grw, r)
+
+		if grw.gzw != nil {
+			defer gzPool.Put(grw.gzw)
+			_ = grw.gzw.Close()
+			return
+		}
+
+		// Non-streaming: use libdeflate for faster one-shot compression.
+		c := gzCompressorPool.Get().(*libdeflate.Compressor)
+		defer gzCompressorPool.Put(c)
+
+		src := grw.buf.Bytes()
+		dstPtr := gzDstPool.Get().(*[]byte)
+		defer gzDstPool.Put(dstPtr)
+		needed := c.GzipCompressBound(len(src))
+		if cap(*dstPtr) < needed {
+			*dstPtr = make([]byte, needed)
+		} else {
+			*dstPtr = (*dstPtr)[:needed]
+		}
+		n, err := c.CompressGzip(*dstPtr, src)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
 		w.Header().Set("Content-Encoding", "gzip")
-
-		gz := gzPool.Get().(*gzip.Writer)
-		defer gzPool.Put(gz)
-
-		gz.Reset(w)
-		defer gz.Close()
-
-		next.ServeHTTP(&gzipResponseWriter{ResponseWriter: w, Writer: gz}, r)
+		w.Header().Del("Content-Length")
+		if grw.status != 0 {
+			w.WriteHeader(grw.status)
+		}
+		w.Write((*dstPtr)[:n]) //nolint:errcheck
 	})
 }
 

--- a/node/rpcstack_gzip_handler_test.go
+++ b/node/rpcstack_gzip_handler_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -50,9 +51,10 @@ func gzipRequest(t *testing.T, handler http.Handler) *httptest.ResponseRecorder 
 }
 
 // TestGzipHandlerNonStreaming verifies that a normal (non-streaming) response
-// is gzip-compressed and the decompressed body matches the original.
+// above minGzipBodySize is gzip-compressed and the decompressed body matches
+// the original. Content-Length must equal the compressed size (no chunked).
 func TestGzipHandlerNonStreaming(t *testing.T) {
-	body := []byte(`{"jsonrpc":"2.0","result":"hello"}`)
+	body := bytes.Repeat([]byte(`{"jsonrpc":"2.0","result":"hello"}`), 64) // > minGzipBodySize
 	handler := newGzipHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write(body)
 	}))
@@ -60,7 +62,25 @@ func TestGzipHandlerNonStreaming(t *testing.T) {
 	rec := gzipRequest(t, handler)
 
 	assert.Equal(t, "gzip", rec.Header().Get("Content-Encoding"))
+	assert.Equal(t, strconv.Itoa(rec.Body.Len()), rec.Header().Get("Content-Length"))
 	assert.Equal(t, body, decompressGzip(t, rec.Body))
+}
+
+// TestGzipHandlerSmallBody verifies that responses below minGzipBodySize are
+// sent as-is: no Content-Encoding, correct Content-Length, verbatim body.
+func TestGzipHandlerSmallBody(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","result":"ok"}`)
+	require.Less(t, len(body), minGzipBodySize)
+
+	handler := newGzipHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(body)
+	}))
+
+	rec := gzipRequest(t, handler)
+
+	assert.Empty(t, rec.Header().Get("Content-Encoding"))
+	assert.Equal(t, strconv.Itoa(len(body)), rec.Header().Get("Content-Length"))
+	assert.Equal(t, body, rec.Body.Bytes())
 }
 
 // TestGzipHandlerNoAcceptEncoding verifies that the response is not compressed
@@ -102,17 +122,20 @@ func TestGzipHandlerStreaming(t *testing.T) {
 }
 
 // TestGzipHandlerStatusBuffered verifies that a custom HTTP status set before
-// any write is correctly forwarded in the non-streaming (buffered) path.
+// any write is correctly forwarded in the non-streaming (buffered) path, for
+// a body large enough to trigger gzip compression.
 func TestGzipHandlerStatusBuffered(t *testing.T) {
+	body := bytes.Repeat([]byte("x"), minGzipBodySize)
 	handler := newGzipHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusCreated)
-		_, _ = w.Write([]byte(`ok`))
+		_, _ = w.Write(body)
 	}))
 
 	rec := gzipRequest(t, handler)
 
 	assert.Equal(t, http.StatusCreated, rec.Code)
 	assert.Equal(t, "gzip", rec.Header().Get("Content-Encoding"))
+	assert.Equal(t, body, decompressGzip(t, rec.Body))
 }
 
 // TestGzipHandlerStatusStreaming verifies that a custom HTTP status set before

--- a/node/rpcstack_gzip_handler_test.go
+++ b/node/rpcstack_gzip_handler_test.go
@@ -1,0 +1,191 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package node
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// decompressGzip reads a gzip-compressed body and returns the raw bytes.
+func decompressGzip(t *testing.T, r io.Reader) []byte {
+	t.Helper()
+	gz, err := gzip.NewReader(r)
+	require.NoError(t, err)
+	defer gz.Close()
+	data, err := io.ReadAll(gz)
+	require.NoError(t, err)
+	return data
+}
+
+// gzipRequest issues a POST to handler with Accept-Encoding: gzip and returns the recorder.
+func gzipRequest(t *testing.T, handler http.Handler) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestGzipHandlerNonStreaming verifies that a normal (non-streaming) response
+// is gzip-compressed and the decompressed body matches the original.
+func TestGzipHandlerNonStreaming(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","result":"hello"}`)
+	handler := newGzipHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(body)
+	}))
+
+	rec := gzipRequest(t, handler)
+
+	assert.Equal(t, "gzip", rec.Header().Get("Content-Encoding"))
+	assert.Equal(t, body, decompressGzip(t, rec.Body))
+}
+
+// TestGzipHandlerNoAcceptEncoding verifies that the response is not compressed
+// when the client does not advertise gzip support.
+func TestGzipHandlerNoAcceptEncoding(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","result":"hello"}`)
+	handler := newGzipHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(body)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Empty(t, rec.Header().Get("Content-Encoding"))
+	assert.Equal(t, body, rec.Body.Bytes())
+}
+
+// TestGzipHandlerStreaming verifies that a handler that calls Flush() activates
+// stdlib gzip streaming and the full response decompresses correctly.
+func TestGzipHandlerStreaming(t *testing.T) {
+	parts := [][]byte{
+		[]byte(`{"jsonrpc":"2.0","result":`),
+		[]byte(`"hello"`),
+		[]byte(`}`),
+	}
+	handler := newGzipHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.(http.Flusher).Flush() // activates streaming mode
+		for _, p := range parts {
+			_, _ = w.Write(p)
+		}
+	}))
+
+	rec := gzipRequest(t, handler)
+
+	assert.Equal(t, "gzip", rec.Header().Get("Content-Encoding"))
+	want := []byte(`{"jsonrpc":"2.0","result":"hello"}`)
+	assert.Equal(t, want, decompressGzip(t, rec.Body))
+}
+
+// TestGzipHandlerStatusBuffered verifies that a custom HTTP status set before
+// any write is correctly forwarded in the non-streaming (buffered) path.
+func TestGzipHandlerStatusBuffered(t *testing.T) {
+	handler := newGzipHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`ok`))
+	}))
+
+	rec := gzipRequest(t, handler)
+
+	assert.Equal(t, http.StatusCreated, rec.Code)
+	assert.Equal(t, "gzip", rec.Header().Get("Content-Encoding"))
+}
+
+// TestGzipHandlerStatusStreaming verifies that a custom HTTP status set before
+// Flush() is correctly forwarded when switching to streaming mode.
+func TestGzipHandlerStatusStreaming(t *testing.T) {
+	handler := newGzipHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+		w.(http.Flusher).Flush()
+		_, _ = w.Write([]byte(`ok`))
+	}))
+
+	rec := gzipRequest(t, handler)
+
+	assert.Equal(t, http.StatusAccepted, rec.Code)
+	assert.Equal(t, "gzip", rec.Header().Get("Content-Encoding"))
+}
+
+// TestGzipHandlerLargeBody verifies that a response body larger than
+// gzPoolBufCap (1 MiB) is compressed correctly. This exercises the pool-cap
+// path: the oversized buffer must not be returned to gzBufPool.
+func TestGzipHandlerLargeBody(t *testing.T) {
+	body := bytes.Repeat([]byte("x"), gzPoolBufCap+1)
+	handler := newGzipHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(body)
+	}))
+
+	rec := gzipRequest(t, handler)
+
+	assert.Equal(t, "gzip", rec.Header().Get("Content-Encoding"))
+	assert.Equal(t, body, decompressGzip(t, rec.Body))
+}
+
+// TestGzipResponseWriterFlushActivatesStreaming is a unit test on
+// gzipResponseWriter.Flush(): verifies it switches from buffered to streaming
+// mode and that buffered bytes are drained into the gzip writer.
+func TestGzipResponseWriterFlushActivatesStreaming(t *testing.T) {
+	rec := httptest.NewRecorder()
+	buf := gzBufPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	grw := &gzipResponseWriter{buf: buf, ResponseWriter: rec}
+
+	// Write into the buffer before activating streaming.
+	_, _ = grw.Write([]byte("pre-flush"))
+	require.Nil(t, grw.gzw, "gzw must be nil before first Flush")
+
+	grw.Flush()
+	require.NotNil(t, grw.gzw, "Flush must activate the gzip writer")
+	assert.Equal(t, 0, buf.Len(), "buf must be drained into gzw after Flush")
+
+	// Write more data in streaming mode, then close.
+	_, _ = grw.Write([]byte(" post-flush"))
+	require.NoError(t, grw.gzw.Close())
+	gzPool.Put(grw.gzw)
+
+	got := decompressGzip(t, rec.Body)
+	assert.Equal(t, []byte("pre-flush post-flush"), got)
+}
+
+// TestGzipBufPoolCapThreshold verifies that the cap guard does not return
+// an oversized buffer to gzBufPool.
+func TestGzipBufPoolCapThreshold(t *testing.T) {
+	buf := gzBufPool.Get().(*bytes.Buffer)
+	buf.Grow(gzPoolBufCap + 1)
+	require.Greater(t, buf.Cap(), gzPoolBufCap)
+
+	// Simulate the handler's cap check: large buffer is NOT returned.
+	if buf.Cap() <= gzPoolBufCap {
+		gzBufPool.Put(buf)
+	}
+
+	// Any buffer obtained from the pool now must be within the cap limit.
+	fresh := gzBufPool.Get().(*bytes.Buffer)
+	defer gzBufPool.Put(fresh)
+	assert.LessOrEqual(t, fresh.Cap(), gzPoolBufCap,
+		"pool must not contain a buffer larger than gzPoolBufCap")
+}

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -677,9 +677,7 @@ func (h *handler) runMethod(ctx context.Context, msg *jsonrpcMessage, callb *cal
 		return msg.response(result)
 	}
 
-	// Activate streaming compression in the gzip middleware before writing any data.
-	// This switches gzipResponseWriter from buffer mode to live gzip streaming,
-	// so trace data is compressed and sent to the client as it is produced.
+	// Switch gzip middleware to streaming mode before writing any response data.
 	if flush, ok := ctx.Value(httpFlusherContextKey{}).(func()); ok {
 		flush()
 	}

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -677,6 +677,13 @@ func (h *handler) runMethod(ctx context.Context, msg *jsonrpcMessage, callb *cal
 		return msg.response(result)
 	}
 
+	// Activate streaming compression in the gzip middleware before writing any data.
+	// This switches gzipResponseWriter from buffer mode to live gzip streaming,
+	// so trace data is compressed and sent to the client as it is produced.
+	if flush, ok := ctx.Value(httpFlusherContextKey{}).(func()); ok {
+		flush()
+	}
+
 	stream.WriteObjectStart()
 	stream.WriteObjectField("jsonrpc")
 	stream.WriteString("2.0")

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -340,10 +340,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Retry-After", "1")
 			w.WriteHeader(http.StatusServiceUnavailable)
 		}
-		// Flush any remaining buffered bytes to the underlying writer.
-		// For streaming methods, grw.Flush() was already called from runMethod
-		// before writing started, so data went directly to the gzip writer.
-		// For non-streaming methods, this is a no-op (stream.buf is empty).
 		stream.Flush()
 	}
 }

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -242,9 +242,17 @@ func (t *httpServerConn) SetWriteDeadline(time.Time) error { return nil }
 // ServeHTTP injects the *bool; runMethod sets it so the correct HTTP 503 status is written before flush.
 type httpOverloadedKey struct{}
 
-// httpFlusherContextKey carries the http.Flusher (as a func()) for the current request.
-// runMethod calls it for streamable methods to activate gzip streaming mode before writing.
+// httpFlusherContextKey carries a gzip-activation hook for the current request.
+// It must only be set by the gzip middleware (not by a generic http.Flusher check),
+// so that it is absent when gzip is disabled and cannot prematurely commit HTTP headers.
 type httpFlusherContextKey struct{}
+
+// WithGzipStreamingHook stores hook in ctx so that runMethod will call it before
+// writing the first byte of a streamable response, switching the gzip middleware from
+// one-shot buffering to incremental streaming. Must only be called by the gzip middleware.
+func WithGzipStreamingHook(ctx context.Context, hook func()) context.Context {
+	return context.WithValue(ctx, httpFlusherContextKey{}, hook)
+}
 
 func withOverloadedFlag(ctx context.Context) (context.Context, *bool) {
 	flag := new(bool)
@@ -296,9 +304,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	ctx = context.WithValue(ctx, peerInfoContextKey{}, connInfo)
 	ctx, overloaded := withOverloadedFlag(ctx)
-	if f, ok := w.(http.Flusher); ok {
-		ctx = context.WithValue(ctx, httpFlusherContextKey{}, f.Flush)
-	}
+	// Note: the gzip-streaming hook (httpFlusherContextKey) is injected by the gzip
+	// middleware via WithGzipStreamingHook, not here, to avoid prematurely committing
+	// HTTP headers when gzip is disabled.
 
 	// All checks passed, create a codec that reads directly from the request body
 	// until EOF, writes the response to w, and orders the server to process a

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -242,6 +242,10 @@ func (t *httpServerConn) SetWriteDeadline(time.Time) error { return nil }
 // ServeHTTP injects the *bool; runMethod sets it so the correct HTTP 503 status is written before flush.
 type httpOverloadedKey struct{}
 
+// httpFlusherContextKey carries the http.Flusher (as a func()) for the current request.
+// runMethod calls it for streamable methods to activate gzip streaming mode before writing.
+type httpFlusherContextKey struct{}
+
 func withOverloadedFlag(ctx context.Context) (context.Context, *bool) {
 	flag := new(bool)
 	return context.WithValue(ctx, httpOverloadedKey{}, flag), flag
@@ -292,6 +296,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	ctx = context.WithValue(ctx, peerInfoContextKey{}, connInfo)
 	ctx, overloaded := withOverloadedFlag(ctx)
+	if f, ok := w.(http.Flusher); ok {
+		ctx = context.WithValue(ctx, httpFlusherContextKey{}, f.Flush)
+	}
 
 	// All checks passed, create a codec that reads directly from the request body
 	// until EOF, writes the response to w, and orders the server to process a
@@ -333,6 +340,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Retry-After", "1")
 			w.WriteHeader(http.StatusServiceUnavailable)
 		}
+		// Flush any remaining buffered bytes to the underlying writer.
+		// For streaming methods, grw.Flush() was already called from runMethod
+		// before writing started, so data went directly to the gzip writer.
+		// For non-streaming methods, this is a no-op (stream.buf is empty).
 		stream.Flush()
 	}
 }


### PR DESCRIPTION
close #17112 
                                                                                                                                                                                                                                                                                                                                                                                              
    This PR replaces the existing single-path compress/gzip middleware in node/rpcstack.go with a dual-path implementation that distinguishes between streaming and non-streaming responses.
                                                                                                                                                                                                                                                                                                                                                                                              
 a) Non-streaming responses (standard JSON-RPC calls such as eth_getBlockByNumber):
 -  are now compressed in one shot using go-libdeflate, a lightweight CGo wrapper around ebiggers/libdeflate. Benchmarks show ~1.75x speedup vs stdlib gzip on ~30 KB JSON payloads (4.6 ms vs 8.0 ms, 122 MB/s vs 70 MB/s); under high concurrency the advantage is larger due to lower CPU usage per request.
 - Since the compressed size is known before writing, Content-Length is now set to the exact compressed size, avoiding unnecessary Transfer-Encoding: chunked. 
 - Responses smaller than 1 KB are sent uncompressed: at that size the CPU overhead of initialising the compressor outweighs the benefit, and for very small payloads the compressed output can exceed the input size due to gzip  framing overhead.    
                                                                                                                                                                                                                                                                                                                                                                                              
  b) Streaming responses (e.g. debug_traceTransaction, trace_filter) are detected via http.Flusher: when the RPC handler calls Flush() before writing, the middleware switches to stdlib compress/gzip in streaming mode, compressing trace data incrementally without buffering the full response.                                                                                              
   
                                                                               
                                                                                                                                                                                                                                                                                                                                                                                              
  Changes:                                                  
  - node/rpcstack.go: new gzipResponseWriter with buffer/stream dual mode; 4 sync.Pool instances for zero-allocation hot path                                                                                                                                                                                                                                                                 
  - rpc/http.go: injects http.Flusher into request context via httpFlusherContextKey                                                                                                                                                                                                                                                                                                          
  - rpc/handler.go: streaming methods call flush before writing to activate streaming mode
  - go.mod: adds github.com/erigontech/go-libdeflate v0.1.0 
  
# 🚀 Performance Benchmarks: Gzip Optimization
---
<details>
<summary><b>1. Isolated Compression Benchmarks (libdeflate vs stdlib)</b></summary>

Diff

  Benchmark (Gzip isolation)    Latency      Throughput   Mem Alloc
- BenchmarkStdlibGzip           8.0ms/req    70 MB/s      66KB
+ BenchmarkLibdeflateGzip       4.6ms/req    122 MB/s     63KB  (2x faster)
Note: We observed a ~1.75x speedup on a single thread. Under high concurrency, the advantage is even greater due to reduced CPU overhead.

</details>

<details>
<summary><b>2. eth_getBlockByNumber with txs  (Old SW vs Main SW)</b></summary>

Old SW - Results with instability and errors:

Diff

- [2. 1] qps: 2000 -> [R=97.74% max=9.103s error=503 Service Unavailable]
- [3. 3] qps: 2300 -> [R=98.50% max=5.841s error=503 Service Unavailable]
- [3. 4] qps: 2300 -> [R=99.80% max=5.634s error=503 Service Unavailable]
- [3. 5] qps: 2300 -> [R=98.25% max=5.877s error=503 Service Unavailable]


Main SW - Stable results with 100% success rate:
Diff

+ [2. 1] qps: 2000 -> [R=100.00% max=141.22ms]
+ [2. 5] qps: 2000 -> [R=100.00% max=157.7ms]
+ [3. 1] qps: 2300 -> [R=100.00% max=217.23ms]
+ [3. 5] qps: 2300 -> [R=100.00% max=224.174ms]
</details>

<details>
<summary><b>3. trace_block </b></summary>

| Metric | Old SW | Main SW | Speedup |
| :--- | :--- | :--- | :--- |
| **Throughput** | 375.9 r/s | **455.0 r/s** | **+21%** |
| **p50 Latency** | 114.4 ms | **96.9 ms** | **1.18x** |
| **p90 Latency** | 232.0 ms | **181.2 ms** | **1.28x** |
| **Mean Latency** | 132.4 ms | **109.5 ms** | **1.21x** |

</details>

<details>
<summary><b>4. Executes all RPC using http, http-compressed and websockets</b></summary>

./run_all.sh -T http,http_comp,websocket 
Run tests in parallel on localhost:8545/localhost:8551
Result directory: /home/simon/silkworm/tests/rpc-tests3/integration/results
                                                                                                                  
Time:                         2026-04-19 08:58:05.257624
Total round_trip time:        3:40:01.359044
Total marshalling time:       0:00:00.063308
Total unmarshalling time:     0:01:40.509521
No of json Diffs:             0
Test time-elapsed:            0:08:37.467460
Available tests:              1436
Available tested api:         112
Number of loop:               1
Number of executed tests:     4152
Number of NOT executed tests: 156
Number of success tests:      4152
Number of failed tests:       0
</details>
