### PR TITLE
tests: use t.Context() instead of context.Background() in tests

### DIFF
--- a/db/datastruct/btindex/testhelpers_test.go
+++ b/db/datastruct/btindex/testhelpers_test.go
@@ -68,7 +68,7 @@ func generateKV(tb testing.TB, tmp string, keySize, valueSize, keyCount int, log
 	values := make([]byte, valueSize)
 
 	dataPath := filepath.Join(tmp, fmt.Sprintf("%dk.kv", keyCount/1000))
-	comp, err := seg.NewCompressor(context.Background(), "cmp", dataPath, tmp, seg.DefaultCfg, log.LvlDebug, logger)
+	comp, err := seg.NewCompressor(t.Context(), "cmp", dataPath, tmp, seg.DefaultCfg, log.LvlDebug, logger)
 	require.NoError(tb, err)
 
 	bufSize := 8 * datasize.KB

--- a/db/datastruct/btindex/testhelpers_test.go
+++ b/db/datastruct/btindex/testhelpers_test.go
@@ -1,7 +1,6 @@
 package btindex
 
 import (
-	"context"
 	"encoding/binary"
 	"fmt"
 	randOld "math/rand"
@@ -68,7 +67,7 @@ func generateKV(tb testing.TB, tmp string, keySize, valueSize, keyCount int, log
 	values := make([]byte, valueSize)
 
 	dataPath := filepath.Join(tmp, fmt.Sprintf("%dk.kv", keyCount/1000))
-	comp, err := seg.NewCompressor(t.Context(), "cmp", dataPath, tmp, seg.DefaultCfg, log.LvlDebug, logger)
+	comp, err := seg.NewCompressor(tb.Context(), "cmp", dataPath, tmp, seg.DefaultCfg, log.LvlDebug, logger)
 	require.NoError(tb, err)
 
 	bufSize := 8 * datasize.KB

--- a/db/downloader/bt_peer_discovery_test.go
+++ b/db/downloader/bt_peer_discovery_test.go
@@ -25,7 +25,7 @@ import (
 // This is the core mechanism for decentralized snapshot distribution:
 // no DHT, no tracker — just direct peer injection from ENR records.
 func TestBTPeerDiscovery_AddPeersFromENR(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
 	// Create temp dirs for seeder and leecher.

--- a/db/downloader/downloader_test.go
+++ b/db/downloader/downloader_test.go
@@ -89,7 +89,7 @@ func TestChangeInfoHashOfSameFile(t *testing.T) {
 
 func TestNoEscape(t *testing.T) {
 	dirs := datadir.New(t.TempDir())
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tf := NewAtomicTorrentFS(dirs.Snap)
 	// allow adding files only if they are inside snapshots dir
@@ -140,7 +140,7 @@ func TestVerifyDataDownloaderClosed(t *testing.T) {
 func TestAddDel(t *testing.T) {
 	require := require.New(t)
 	test := newDownloaderTest(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// In the following tests we use combinations of f1Abs, f1, f2, and f1BadAbs. Absolute file
 	// paths are allowed to calls to RpcClient if they're local to the SnapDir, it does the required
@@ -229,7 +229,7 @@ func newDownloaderTest(t *testing.T) *downloaderTest {
 
 	dirs := datadir.New(t.TempDir())
 	cfg, err := downloadercfg.New(
-		context.Background(),
+		t.Context(),
 		dirs,
 		"",
 		log.LvlInfo,
@@ -248,7 +248,7 @@ func newDownloaderTest(t *testing.T) *downloaderTest {
 		cfg.ClientConfig.DisableUTP = true
 	}
 
-	d, err := New(context.Background(), cfg, log.New())
+	d, err := New(t.Context(), cfg, log.New())
 	require.NoError(err)
 
 	// Register cleanup in reverse order (downloader closes before config file)

--- a/db/integrity/commitment_state_verify_test.go
+++ b/db/integrity/commitment_state_verify_test.go
@@ -17,7 +17,6 @@
 package integrity_test
 
 import (
-	"context"
 	"math/rand"
 	"testing"
 

--- a/db/integrity/commitment_state_verify_test.go
+++ b/db/integrity/commitment_state_verify_test.go
@@ -45,7 +45,7 @@ func TestCheckStateVerify(t *testing.T) {
 	t.Parallel()
 
 	logger := log.New()
-	ctx := context.Background()
+	ctx := t.Context()
 	stepSize := uint64(100)
 
 	dirs := datadir.New(t.TempDir())
@@ -123,7 +123,7 @@ func TestCheckStateVerify_NoopWrite(t *testing.T) {
 	t.Parallel()
 
 	logger := log.New()
-	ctx := context.Background()
+	ctx := t.Context()
 	stepSize := uint64(100)
 
 	dirs := datadir.New(t.TempDir())
@@ -239,7 +239,7 @@ func TestVerifyBranchHashesFromDB(t *testing.T) {
 	t.Parallel()
 
 	logger := log.New()
-	ctx := context.Background()
+	ctx := t.Context()
 	stepSize := uint64(100)
 
 	dirs := datadir.New(t.TempDir())

--- a/db/kv/kvcache/cache_test.go
+++ b/db/kv/kvcache/cache_test.go
@@ -109,7 +109,7 @@ func TestEvictionInUnexpectedOrder(t *testing.T) {
 }
 
 func TestEviction(t *testing.T) {
-	require, ctx := require.New(t), context.Background()
+	require, ctx := require.New(t), t.Context()
 	cfg := DefaultCoherentConfig
 	cfg.CacheSize = 21
 	cfg.NewBlockWait = 0
@@ -176,7 +176,7 @@ func TestAPI(t *testing.T) {
 	require := require.New(t)
 
 	// Create a context with timeout for the entire test
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
 	c := New(DefaultCoherentConfig)
@@ -444,8 +444,8 @@ func TestAPI(t *testing.T) {
 		fmt.Printf("done4: \n")
 	}()
 	// TODO: Used in other places too cant modify this.
-	// err := db.View(context.Background(), func(tx kv.Tx) error {
-	// 	_, err := AssertCheckValues(context.Background(), tx, c)
+	// err := db.View(t.Context(), func(tx kv.Tx) error {
+	// 	_, err := AssertCheckValues(t.Context(), tx, c)
 	// 	require.NoError(err)
 	// 	return nil
 	// })
@@ -519,7 +519,7 @@ func TestOnNewBlockCodeHashKey(t *testing.T) {
 
 func TestCode(t *testing.T) {
 	t.Skip("TODO: use state reader/writer instead of Put()")
-	require, ctx := require.New(t), context.Background()
+	require, ctx := require.New(t), t.Context()
 	c := New(DefaultCoherentConfig)
 	db := temporaltest.NewTestDB(t, datadir.New(t.TempDir()))
 	k1, k2 := [20]byte{1}, [20]byte{2}

--- a/db/kv/mdbx/kv_abstract_test.go
+++ b/db/kv/mdbx/kv_abstract_test.go
@@ -45,7 +45,7 @@ func TestSequence(t *testing.T) {
 	}
 
 	writeDBs, _ := setupDatabases(t, log.New())
-	ctx := context.Background()
+	ctx := t.Context()
 
 	for _, db := range writeDBs {
 		tx, err := db.BeginRw(ctx)
@@ -97,7 +97,7 @@ func TestManagedTx(t *testing.T) {
 	bucket2 := kv.ChaindataTables[bucketID+1]
 	writeDBs, readDBs := setupDatabases(t, logger)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	for _, db := range writeDBs {
 		tx, err := db.BeginRw(ctx)
@@ -149,7 +149,7 @@ func TestRemoteKvVersion(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("fix me on win please")
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	logger := log.New()
 	dirs := datadir.New(t.TempDir())
 	writeDB := temporaltest.NewTestDB(t, dirs)
@@ -196,7 +196,7 @@ func TestRemoteKvRange(t *testing.T) {
 	logger := log.New()
 	dirs := datadir.New(t.TempDir())
 	writeDB := temporaltest.NewTestDB(t, dirs)
-	ctx := context.Background()
+	ctx := t.Context()
 	grpcServer, conn := grpc.NewServer(), bufconn.Listen(1024*1024)
 	go func() {
 		kvServer := remotedbserver.NewKvServer(ctx, writeDB, nil, nil, nil, logger)
@@ -325,7 +325,7 @@ func TestRemoteKvRange(t *testing.T) {
 
 func setupDatabases(t *testing.T, logger log.Logger) (writeDBs []kv.TemporalRwDB, readDBs []kv.RwDB) {
 	t.Helper()
-	ctx := context.Background()
+	ctx := t.Context()
 	dirs1 := datadir.New(t.TempDir())
 	dirs2 := datadir.New(t.TempDir())
 	writeDBs = []kv.TemporalRwDB{
@@ -377,7 +377,7 @@ func setupDatabases(t *testing.T, logger log.Logger) (writeDBs []kv.TemporalRwDB
 
 func testMultiCursor(t *testing.T, db kv.RwDB, bucket1, bucket2 string) {
 	t.Helper()
-	assert, ctx := assert.New(t), context.Background()
+	assert, ctx := assert.New(t), t.Context()
 	require := require.New(t)
 
 	if err := db.View(ctx, func(tx kv.Tx) error {
@@ -478,7 +478,7 @@ func testMultiCursor(t *testing.T, db kv.RwDB, bucket1, bucket2 string) {
 //	writeDBs, readDBs, closeAll := setupDatabases(ethdb.WithChaindataTables)
 //	defer closeAll()
 //
-//	ctx := context.Background()
+//	ctx := t.Context()
 //
 //	for _, db := range writeDBs {
 //		db := db
@@ -556,7 +556,7 @@ func testMultiCursor(t *testing.T, db kv.RwDB, bucket1, bucket2 string) {
 //	writeDBs, _, closeAll := setupDatabases(ethdb.WithChaindataTables)
 //	defer closeAll()
 //
-//	ctx := context.Background()
+//	ctx := t.Context()
 //
 //	for _, db := range writeDBs {
 //		db := db

--- a/db/kv/mdbx/kv_mdbx_test.go
+++ b/db/kv/mdbx/kv_mdbx_test.go
@@ -72,7 +72,7 @@ func BaseCase(t *testing.T) (kv.RwDB, kv.RwTx, kv.RwCursorDupSort) {
 	db := BaseCaseDB(t)
 	table := "Table"
 
-	tx, err := db.BeginRw(context.Background())
+	tx, err := db.BeginRw(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(tx.Rollback)
 
@@ -271,7 +271,7 @@ func TestRangeRwTxInterleavedWrite(t *testing.T) {
 	}).MapSize(128 * datasize.MB).MustOpen()
 	t.Cleanup(db.Close)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tx, err := db.BeginRw(ctx)
 	require.NoError(t, err)
 	t.Cleanup(tx.Rollback)
@@ -317,7 +317,7 @@ func TestLastDup(t *testing.T) {
 
 	err := tx.Commit()
 	require.NoError(t, err)
-	roTx, err := db.BeginRo(context.Background())
+	roTx, err := db.BeginRo(t.Context())
 	require.NoError(t, err)
 	defer roTx.Rollback()
 
@@ -684,21 +684,21 @@ func TestDupDelete(t *testing.T) {
 func TestBeginRoAfterClose(t *testing.T) {
 	db := New(dbcfg.ChainDB, log.New()).InMem(t, t.TempDir()).MustOpen()
 	db.Close()
-	_, err := db.BeginRo(context.Background())
+	_, err := db.BeginRo(t.Context())
 	require.ErrorContains(t, err, "closed")
 }
 
 func TestBeginRwAfterClose(t *testing.T) {
 	db := New(dbcfg.ChainDB, log.New()).InMem(t, t.TempDir()).MustOpen()
 	db.Close()
-	_, err := db.BeginRw(context.Background())
+	_, err := db.BeginRw(t.Context())
 	require.ErrorContains(t, err, "closed")
 }
 
 func TestBeginRoWithDoneContext(t *testing.T) {
 	db := New(dbcfg.ChainDB, log.New()).InMem(t, t.TempDir()).MustOpen()
 	defer db.Close()
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	_, err := db.BeginRo(ctx)
 	require.ErrorIs(t, err, context.Canceled)
@@ -707,7 +707,7 @@ func TestBeginRoWithDoneContext(t *testing.T) {
 func TestBeginRwWithDoneContext(t *testing.T) {
 	db := New(dbcfg.ChainDB, log.New()).InMem(t, t.TempDir()).MustOpen()
 	defer db.Close()
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	_, err := db.BeginRw(ctx)
 	require.ErrorIs(t, err, context.Canceled)
@@ -751,7 +751,7 @@ func testCloseWaitsAfterTxBegin(
 }
 
 func TestCloseWaitsAfterTxBegin(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	t.Run("BeginRoAndCommit", func(t *testing.T) {
 		testCloseWaitsAfterTxBegin(
 			t,
@@ -834,7 +834,7 @@ func TestDB_Batch(t *testing.T) {
 	}
 
 	// Ensure data is correct.
-	if err := db.View(context.Background(), func(tx kv.Tx) error {
+	if err := db.View(t.Context(), func(tx kv.Tx) error {
 		for i := 0; i < n; i++ {
 			v, err := tx.GetOne(table, u64tob(uint64(i)))
 			if err != nil {
@@ -922,7 +922,7 @@ func TestDB_BatchFull(t *testing.T) {
 	}
 
 	// Ensure data is correct.
-	if err := db.View(context.Background(), func(tx kv.Tx) error {
+	if err := db.View(t.Context(), func(tx kv.Tx) error {
 		for i := 1; i <= size; i++ {
 			v, err := tx.GetOne(table, u64tob(uint64(i)))
 			if err != nil {
@@ -967,7 +967,7 @@ func TestDB_BatchTime(t *testing.T) {
 	}
 
 	// Ensure data is correct.
-	if err := db.View(context.Background(), func(tx kv.Tx) error {
+	if err := db.View(t.Context(), func(tx kv.Tx) error {
 		for i := 1; i <= size; i++ {
 			v, err := tx.GetOne(table, u64tob(uint64(i)))
 			if err != nil {
@@ -988,7 +988,7 @@ func BenchmarkDB_BeginRO(b *testing.B) {
 	db := _db.(*MdbxKV)
 
 	for b.Loop() {
-		tx, _ := db.BeginRo(context.Background())
+		tx, _ := db.BeginRo(t.Context())
 		tx.Rollback()
 	}
 }
@@ -999,7 +999,7 @@ func BenchmarkDB_Get(b *testing.B) {
 	db := _db.(*MdbxKV)
 
 	// buffered so we never leak goroutines
-	err := db.Update(context.Background(), func(tx kv.RwTx) error {
+	err := db.Update(t.Context(), func(tx kv.RwTx) error {
 		return tx.Put(table, u64tob(uint64(1)), u64tob(uint64(1)))
 	})
 	if err != nil {
@@ -1007,7 +1007,7 @@ func BenchmarkDB_Get(b *testing.B) {
 	}
 
 	// Ensure data is correct.
-	if err := db.View(context.Background(), func(tx kv.Tx) error {
+	if err := db.View(t.Context(), func(tx kv.Tx) error {
 		key := u64tob(uint64(1))
 		for b.Loop() {
 			v, err := tx.GetOne(table, key)
@@ -1035,7 +1035,7 @@ func BenchmarkDB_Put(b *testing.B) {
 		keys[i-1] = u64tob(uint64(i))
 	}
 
-	if err := db.Update(context.Background(), func(tx kv.RwTx) error {
+	if err := db.Update(t.Context(), func(tx kv.RwTx) error {
 		var idx int
 		for b.Loop() {
 			err := tx.Put(table, keys[idx%len(keys)], keys[idx%len(keys)])
@@ -1056,7 +1056,7 @@ func BenchmarkDB_PutRandom(b *testing.B) {
 	db := _db.(*MdbxKV)
 
 	// Ensure data is correct.
-	if err := db.Update(context.Background(), func(tx kv.RwTx) error {
+	if err := db.Update(t.Context(), func(tx kv.RwTx) error {
 		keys := make(map[string]struct{}, b.N)
 		for len(keys) < b.N {
 			keys[string(u64tob(uint64(rand.Intn(1e10))))] = struct{}{}
@@ -1085,7 +1085,7 @@ func BenchmarkDB_Delete(b *testing.B) {
 		keys[i-1] = u64tob(uint64(i))
 	}
 
-	if err := db.Update(context.Background(), func(tx kv.RwTx) error {
+	if err := db.Update(t.Context(), func(tx kv.RwTx) error {
 		for i := 0; i < len(keys); i++ {
 			err := tx.Put(table, keys[i], keys[i])
 			if err != nil {
@@ -1097,7 +1097,7 @@ func BenchmarkDB_Delete(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	if err := db.Update(context.Background(), func(tx kv.RwTx) error {
+	if err := db.Update(t.Context(), func(tx kv.RwTx) error {
 		var idx int
 		for b.Loop() {
 			err := tx.Delete(table, keys[idx%len(keys)])
@@ -1165,7 +1165,7 @@ func BenchmarkDB_ResetSequence(b *testing.B) {
 	_db := BaseCaseDBForBenchmark(b)
 	table := "Table"
 	//db := _db.(*MdbxKV)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tx, err := _db.BeginRw(ctx)
 	require.NoError(b, err)
@@ -1189,7 +1189,7 @@ func TestMdbxWithSyncBytes(t *testing.T) {
 		SyncBytes(20_000).
 		DirtySpace(uint64(64 * datasize.MB)).
 		// WithMetrics().
-		Open(context.Background())
+		Open(t.Context())
 	if err != nil {
 		t.Fatalf("failed to open mdbx")
 	}

--- a/db/kv/mdbx/kv_mdbx_test.go
+++ b/db/kv/mdbx/kv_mdbx_test.go
@@ -988,7 +988,7 @@ func BenchmarkDB_BeginRO(b *testing.B) {
 	db := _db.(*MdbxKV)
 
 	for b.Loop() {
-		tx, _ := db.BeginRo(t.Context())
+		tx, _ := db.BeginRo(b.Context())
 		tx.Rollback()
 	}
 }
@@ -999,7 +999,7 @@ func BenchmarkDB_Get(b *testing.B) {
 	db := _db.(*MdbxKV)
 
 	// buffered so we never leak goroutines
-	err := db.Update(t.Context(), func(tx kv.RwTx) error {
+	err := db.Update(b.Context(), func(tx kv.RwTx) error {
 		return tx.Put(table, u64tob(uint64(1)), u64tob(uint64(1)))
 	})
 	if err != nil {
@@ -1007,7 +1007,7 @@ func BenchmarkDB_Get(b *testing.B) {
 	}
 
 	// Ensure data is correct.
-	if err := db.View(t.Context(), func(tx kv.Tx) error {
+	if err := db.View(b.Context(), func(tx kv.Tx) error {
 		key := u64tob(uint64(1))
 		for b.Loop() {
 			v, err := tx.GetOne(table, key)
@@ -1035,7 +1035,7 @@ func BenchmarkDB_Put(b *testing.B) {
 		keys[i-1] = u64tob(uint64(i))
 	}
 
-	if err := db.Update(t.Context(), func(tx kv.RwTx) error {
+	if err := db.Update(b.Context(), func(tx kv.RwTx) error {
 		var idx int
 		for b.Loop() {
 			err := tx.Put(table, keys[idx%len(keys)], keys[idx%len(keys)])
@@ -1056,7 +1056,7 @@ func BenchmarkDB_PutRandom(b *testing.B) {
 	db := _db.(*MdbxKV)
 
 	// Ensure data is correct.
-	if err := db.Update(t.Context(), func(tx kv.RwTx) error {
+	if err := db.Update(b.Context(), func(tx kv.RwTx) error {
 		keys := make(map[string]struct{}, b.N)
 		for len(keys) < b.N {
 			keys[string(u64tob(uint64(rand.Intn(1e10))))] = struct{}{}
@@ -1085,7 +1085,7 @@ func BenchmarkDB_Delete(b *testing.B) {
 		keys[i-1] = u64tob(uint64(i))
 	}
 
-	if err := db.Update(t.Context(), func(tx kv.RwTx) error {
+	if err := db.Update(b.Context(), func(tx kv.RwTx) error {
 		for i := 0; i < len(keys); i++ {
 			err := tx.Put(table, keys[i], keys[i])
 			if err != nil {
@@ -1097,7 +1097,7 @@ func BenchmarkDB_Delete(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	if err := db.Update(t.Context(), func(tx kv.RwTx) error {
+	if err := db.Update(b.Context(), func(tx kv.RwTx) error {
 		var idx int
 		for b.Loop() {
 			err := tx.Delete(table, keys[idx%len(keys)])
@@ -1165,7 +1165,7 @@ func BenchmarkDB_ResetSequence(b *testing.B) {
 	_db := BaseCaseDBForBenchmark(b)
 	table := "Table"
 	//db := _db.(*MdbxKV)
-	ctx := t.Context()
+	ctx := b.Context()
 
 	tx, err := _db.BeginRw(ctx)
 	require.NoError(b, err)

--- a/db/kv/mdbx/kv_migrator_test.go
+++ b/db/kv/mdbx/kv_migrator_test.go
@@ -117,7 +117,7 @@ func TestReadOnlyMode(t *testing.T) {
 	}).MustOpen()
 	defer db2.Close()
 
-	tx, err := db2.BeginRo(context.Background())
+	tx, err := db2.BeginRo(t.Context())
 	require.NoError(t, err)
 	defer tx.Rollback()
 

--- a/db/kv/mdbx/kv_migrator_test.go
+++ b/db/kv/mdbx/kv_migrator_test.go
@@ -19,7 +19,6 @@
 package mdbx_test
 
 import (
-	"context"
 	"testing"
 	"time"
 

--- a/db/kv/membatchwithdb/memory_mutation_test.go
+++ b/db/kv/membatchwithdb/memory_mutation_test.go
@@ -59,7 +59,7 @@ func TestPutAppendHas(t *testing.T) {
 	// Pure Go backend allows out-of-order Append (no MDBX ordering check).
 	require.NoError(t, batch.Append(kv.HeaderNumber, []byte("AAAA"), []byte("value1.3")))
 
-	require.NoError(t, batch.Flush(context.Background(), rwTx))
+	require.NoError(t, batch.Flush(t.Context(), rwTx))
 
 	exist, err := batch.Has(kv.HeaderNumber, []byte("AAAA"))
 	require.NoError(t, err)
@@ -168,7 +168,7 @@ func TestFlush(t *testing.T) {
 	batch.Put(kv.HeaderNumber, []byte("AAAA"), []byte("value5"))
 	batch.Put(kv.HeaderNumber, []byte("FCAA"), []byte("value5"))
 
-	require.NoError(t, batch.Flush(context.Background(), rwTx))
+	require.NoError(t, batch.Flush(t.Context(), rwTx))
 
 	value, err := rwTx.GetOne(kv.HeaderNumber, []byte("BAAA"))
 	require.NoError(t, err)
@@ -188,7 +188,7 @@ func TestForEach(t *testing.T) {
 	require.NoError(t, err)
 	defer batch.Close()
 	batch.Put(kv.HeaderNumber, []byte("FCAA"), []byte("value5"))
-	require.NoError(t, batch.Flush(context.Background(), rwTx))
+	require.NoError(t, batch.Flush(t.Context(), rwTx))
 
 	var keys []string
 	var values []string
@@ -228,7 +228,7 @@ func newTestTx(tb testing.TB) (kv.TemporalRwDB, kv.TemporalRwTx) {
 	dirs := datadir.New(tb.TempDir())
 	stepSize := uint64(16)
 	db := temporaltest.NewTestDBWithStepSize(tb, dirs, stepSize)
-	tx, err := db.BeginTemporalRw(context.Background()) //nolint:gocritic
+	tx, err := db.BeginTemporalRw(t.Context()) //nolint:gocritic
 	if err != nil {
 		tb.Fatal(err)
 	}
@@ -515,7 +515,7 @@ func TestDeleteCurrentDuplicates(t *testing.T) {
 
 	require.NoError(t, cursor.DeleteCurrentDuplicates())
 
-	require.NoError(t, batch.Flush(context.Background(), rwTx))
+	require.NoError(t, batch.Flush(t.Context(), rwTx))
 
 	var keys []string
 	var values []string
@@ -617,7 +617,7 @@ func TestMemoryMutationConcurrentReadWrite(t *testing.T) {
 	require.NoError(t, rwTx.Commit())
 
 	// Open a fresh RO tx as the overlay's backing tx (simulates InsertBlocks).
-	roTx, err := db.BeginRo(context.Background())
+	roTx, err := db.BeginRo(t.Context())
 	require.NoError(t, err)
 	defer roTx.Rollback()
 
@@ -638,7 +638,7 @@ func TestMemoryMutationConcurrentReadWrite(t *testing.T) {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
-			readerTx, err := db.BeginRo(context.Background())
+			readerTx, err := db.BeginRo(t.Context())
 			if err != nil {
 				t.Errorf("reader %d: BeginRo: %v", id, err)
 				return
@@ -713,7 +713,7 @@ func TestMemoryMutationConcurrentDeleteAndRead(t *testing.T) {
 	}
 	require.NoError(t, rwTx.Commit())
 
-	roTx, err := db.BeginRo(context.Background())
+	roTx, err := db.BeginRo(t.Context())
 	require.NoError(t, err)
 	defer roTx.Rollback()
 
@@ -727,7 +727,7 @@ func TestMemoryMutationConcurrentDeleteAndRead(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		readerTx, err := db.BeginRo(context.Background())
+		readerTx, err := db.BeginRo(t.Context())
 		if err != nil {
 			t.Errorf("reader: BeginRo: %v", err)
 			return

--- a/db/kv/membatchwithdb/memory_mutation_test.go
+++ b/db/kv/membatchwithdb/memory_mutation_test.go
@@ -17,7 +17,6 @@
 package membatchwithdb_test
 
 import (
-	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -228,7 +227,7 @@ func newTestTx(tb testing.TB) (kv.TemporalRwDB, kv.TemporalRwTx) {
 	dirs := datadir.New(tb.TempDir())
 	stepSize := uint64(16)
 	db := temporaltest.NewTestDBWithStepSize(tb, dirs, stepSize)
-	tx, err := db.BeginTemporalRw(t.Context()) //nolint:gocritic
+	tx, err := db.BeginTemporalRw(tb.Context()) //nolint:gocritic
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/db/kv/prune/prune_test.go
+++ b/db/kv/prune/prune_test.go
@@ -92,7 +92,7 @@ func TestTableScanningPrune_Basic(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()
 
-	tx, err := db.BeginRw(context.Background())
+	tx, err := db.BeginRw(t.Context())
 	require.NoError(t, err)
 	defer tx.Rollback()
 
@@ -105,7 +105,7 @@ func TestTableScanningPrune_Basic(t *testing.T) {
 	defer cur.Close()
 
 	stat, err := prune.TableScanningPrune(
-		context.Background(), "test", "txlookup",
+		t.Context(), "test", "txlookup",
 		5, 15, 0, 1, logEvery, log.New(),
 		nil, cur, false, &prune.Stat{}, prune.ValueOffset8StorageMode,
 	)
@@ -129,7 +129,7 @@ func TestTableScanningPrune_RollingCursor(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()
 
-	tx, err := db.BeginRw(context.Background())
+	tx, err := db.BeginRw(t.Context())
 	require.NoError(t, err)
 	defer tx.Rollback()
 
@@ -154,7 +154,7 @@ func TestTableScanningPrune_RollingCursor(t *testing.T) {
 
 	cur := openPseudoCursor(t, tx)
 	stat1, err := prune.TableScanningPrune(
-		context.Background(), "test", "txlookup",
+		t.Context(), "test", "txlookup",
 		0, 8, 0, 1, logEvery, log.New(),
 		nil, cur, false, prevStat, prune.ValueOffset8StorageMode,
 	)
@@ -177,7 +177,7 @@ func TestTableScanningPrune_RollingCursor(t *testing.T) {
 	}
 	cur = openPseudoCursor(t, tx)
 	stat2, err := prune.TableScanningPrune(
-		context.Background(), "test", "txlookup",
+		t.Context(), "test", "txlookup",
 		0, 10, 0, 1, logEvery, log.New(),
 		nil, cur, false, newRotStat, prune.ValueOffset8StorageMode,
 	)
@@ -198,7 +198,7 @@ func TestTableScanningPrune_CtxCancelOnOutOfRange(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()
 
-	tx, err := db.BeginRw(context.Background())
+	tx, err := db.BeginRw(t.Context())
 	require.NoError(t, err)
 	defer tx.Rollback()
 
@@ -210,7 +210,7 @@ func TestTableScanningPrune_CtxCancelOnOutOfRange(t *testing.T) {
 	defer logEvery.Stop()
 
 	// Pre-cancel the context so ctx.Done() is immediately readable.
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
 	cur := openPseudoCursor(t, tx)
@@ -240,7 +240,7 @@ func BenchmarkTableScanningPrune(b *testing.B) {
 	defer db.Close()
 
 	const N = 10_000
-	tx, err := db.BeginRw(context.Background())
+	tx, err := db.BeginRw(t.Context())
 	require.NoError(b, err)
 	defer tx.Rollback()
 	insertEntries(b, tx, N, 0) // txNums 0..N-1; prune [0, N/2)
@@ -253,7 +253,7 @@ func BenchmarkTableScanningPrune(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		cur := openPseudoCursor(b, tx)
 		prune.TableScanningPrune( //nolint:errcheck
-			context.Background(), "bench", "txlookup",
+			t.Context(), "bench", "txlookup",
 			0, N/2, 0, 1, logEvery, logger,
 			nil, cur, false, &prune.Stat{}, prune.ValueOffset8StorageMode,
 		)

--- a/db/kv/prune/prune_test.go
+++ b/db/kv/prune/prune_test.go
@@ -240,7 +240,7 @@ func BenchmarkTableScanningPrune(b *testing.B) {
 	defer db.Close()
 
 	const N = 10_000
-	tx, err := db.BeginRw(t.Context())
+	tx, err := db.BeginRw(b.Context())
 	require.NoError(b, err)
 	defer tx.Rollback()
 	insertEntries(b, tx, N, 0) // txNums 0..N-1; prune [0, N/2)
@@ -253,7 +253,7 @@ func BenchmarkTableScanningPrune(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		cur := openPseudoCursor(b, tx)
 		prune.TableScanningPrune( //nolint:errcheck
-			t.Context(), "bench", "txlookup",
+			b.Context(), "bench", "txlookup",
 			0, N/2, 0, 1, logEvery, logger,
 			nil, cur, false, &prune.Stat{}, prune.ValueOffset8StorageMode,
 		)

--- a/db/kv/rawdbv3/txnum_test.go
+++ b/db/kv/rawdbv3/txnum_test.go
@@ -17,7 +17,6 @@
 package rawdbv3
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"

--- a/db/kv/rawdbv3/txnum_test.go
+++ b/db/kv/rawdbv3/txnum_test.go
@@ -35,35 +35,35 @@ func TestTxNum(t *testing.T) {
 	db := mdbx.New(dbcfg.ChainDB, log.New()).InMem(t, dirs.Chaindata).MustOpen()
 	t.Cleanup(db.Close)
 
-	err := db.Update(context.Background(), func(tx kv.RwTx) error {
+	err := db.Update(t.Context(), func(tx kv.RwTx) error {
 		require.NoError(TxNums.Append(tx, 0, 3))
 		require.NoError(TxNums.Append(tx, 1, 99))
 		require.NoError(TxNums.Append(tx, 2, 100))
 
-		n, _, err := TxNums.FindBlockNum(context.Background(), tx, 10)
+		n, _, err := TxNums.FindBlockNum(t.Context(), tx, 10)
 		require.NoError(err)
 		require.Equal(1, int(n))
 
-		n, _, err = TxNums.FindBlockNum(context.Background(), tx, 0)
+		n, _, err = TxNums.FindBlockNum(t.Context(), tx, 0)
 		require.NoError(err)
 		require.Equal(0, int(n))
 
-		n, _, err = TxNums.FindBlockNum(context.Background(), tx, 3)
+		n, _, err = TxNums.FindBlockNum(t.Context(), tx, 3)
 		require.NoError(err)
 		require.Equal(0, int(n))
-		n, _, err = TxNums.FindBlockNum(context.Background(), tx, 4)
+		n, _, err = TxNums.FindBlockNum(t.Context(), tx, 4)
 		require.NoError(err)
 		require.Equal(1, int(n))
 
-		n, _, err = TxNums.FindBlockNum(context.Background(), tx, 99)
+		n, _, err = TxNums.FindBlockNum(t.Context(), tx, 99)
 		require.NoError(err)
 		require.Equal(1, int(n))
 
-		n, _, err = TxNums.FindBlockNum(context.Background(), tx, 100)
+		n, _, err = TxNums.FindBlockNum(t.Context(), tx, 100)
 		require.NoError(err)
 		require.Equal(2, int(n))
 
-		_, ok, err := TxNums.FindBlockNum(context.Background(), tx, 101)
+		_, ok, err := TxNums.FindBlockNum(t.Context(), tx, 101)
 		require.NoError(err)
 		require.False(ok)
 		return nil

--- a/db/kv/remotedbserver/remotedbserver_test.go
+++ b/db/kv/remotedbserver/remotedbserver_test.go
@@ -38,7 +38,7 @@ func TestKvServer_renew(t *testing.T) {
 	}
 
 	dirs := datadir.New(t.TempDir())
-	require, ctx, db := require.New(t), context.Background(), temporaltest.NewTestDB(t, dirs)
+	require, ctx, db := require.New(t), t.Context(), temporaltest.NewTestDB(t, dirs)
 	require.NoError(db.Update(ctx, func(tx kv.RwTx) error {
 		wc, err := tx.RwCursorDupSort(kv.TblAccountVals)
 		require.NoError(err)
@@ -105,7 +105,7 @@ func TestKvServer_renew(t *testing.T) {
 }
 
 func TestKVServerSnapshotsReturnsSnapshots(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctrl := gomock.NewController(t)
 	blockSnapshots := NewMockSnapshots(ctrl)
 	blockSnapshots.EXPECT().Files().Return([]string{"headers.seg", "bodies.seg"}).Times(1)
@@ -120,7 +120,7 @@ func TestKVServerSnapshotsReturnsSnapshots(t *testing.T) {
 }
 
 func TestKVServerSnapshotsReturnsBorSnapshots(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctrl := gomock.NewController(t)
 	blockSnapshots := NewMockSnapshots(ctrl)
 	blockSnapshots.EXPECT().Files().Return([]string{"headers.seg", "bodies.seg"}).Times(1)
@@ -137,7 +137,7 @@ func TestKVServerSnapshotsReturnsBorSnapshots(t *testing.T) {
 }
 
 func TestKVServerSnapshotsReturnsEmptyIfNoBlockSnapshots(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	s := NewKvServer(ctx, nil, nil, nil, nil, log.New())
 	reply, err := s.Snapshots(ctx, nil)
 	require.NoError(t, err)

--- a/db/kv/remotedbserver/remotedbserver_test.go
+++ b/db/kv/remotedbserver/remotedbserver_test.go
@@ -17,7 +17,6 @@
 package remotedbserver
 
 import (
-	"context"
 	"runtime"
 	"testing"
 

--- a/db/kv/stream/stream_test.go
+++ b/db/kv/stream/stream_test.go
@@ -18,7 +18,6 @@ package stream_test
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"testing"
 

--- a/db/kv/stream/stream_test.go
+++ b/db/kv/stream/stream_test.go
@@ -82,7 +82,7 @@ func TestUnion(t *testing.T) {
 }
 func TestUnionPairs(t *testing.T) {
 	db := memdb.NewTestDB(t, dbcfg.ChainDB)
-	ctx := context.Background()
+	ctx := t.Context()
 	t.Run("simple", func(t *testing.T) {
 		require := require.New(t)
 		tx, err := db.BeginRw(ctx)
@@ -152,7 +152,7 @@ func TestUnionPairs(t *testing.T) {
 
 func TestMultisetKV(t *testing.T) {
 	db := memdb.NewTestDB(t, dbcfg.ChainDB)
-	ctx := context.Background()
+	ctx := t.Context()
 	t.Run("preserves duplicates", func(t *testing.T) {
 		require := require.New(t)
 		tx, err := db.BeginRw(ctx)

--- a/db/migrations/migrations_test.go
+++ b/db/migrations/migrations_test.go
@@ -42,7 +42,7 @@ func TestApplyWithInit(t *testing.T) {
 		{
 			"one",
 			func(db kv.RwDB, dirs datadir.Dirs, progress []byte, BeforeCommit Callback, logger log.Logger) (err error) {
-				tx, err := db.BeginRw(context.Background())
+				tx, err := db.BeginRw(t.Context())
 				if err != nil {
 					return err
 				}
@@ -57,7 +57,7 @@ func TestApplyWithInit(t *testing.T) {
 		{
 			"two",
 			func(db kv.RwDB, dirs datadir.Dirs, progress []byte, BeforeCommit Callback, logger log.Logger) (err error) {
-				tx, err := db.BeginRw(context.Background())
+				tx, err := db.BeginRw(t.Context())
 				if err != nil {
 					return err
 				}
@@ -77,7 +77,7 @@ func TestApplyWithInit(t *testing.T) {
 	err := migrator.Apply(db, migrationsDB, "", "", logger)
 	require.NoError(err)
 	var applied map[string][]byte
-	err = migrationsDB.View(context.Background(), func(tx kv.Tx) error {
+	err = migrationsDB.View(t.Context(), func(tx kv.Tx) error {
 		applied, err = AppliedMigrations(tx, false)
 		require.NoError(err)
 
@@ -92,7 +92,7 @@ func TestApplyWithInit(t *testing.T) {
 	// apply again
 	err = migrator.Apply(db, migrationsDB, "", "", logger)
 	require.NoError(err)
-	err = migrationsDB.View(context.Background(), func(tx kv.Tx) error {
+	err = migrationsDB.View(t.Context(), func(tx kv.Tx) error {
 		applied2, err := AppliedMigrations(tx, false)
 		require.NoError(err)
 		require.Equal(applied, applied2)
@@ -115,7 +115,7 @@ func TestApplyWithoutInit(t *testing.T) {
 		{
 			"two",
 			func(db kv.RwDB, dirs datadir.Dirs, progress []byte, BeforeCommit Callback, logger log.Logger) (err error) {
-				tx, err := db.BeginRw(context.Background())
+				tx, err := db.BeginRw(t.Context())
 				if err != nil {
 					return err
 				}
@@ -128,7 +128,7 @@ func TestApplyWithoutInit(t *testing.T) {
 			},
 		},
 	}
-	err := migrationsDB.Update(context.Background(), func(tx kv.RwTx) error {
+	err := migrationsDB.Update(t.Context(), func(tx kv.RwTx) error {
 		return tx.Put(kv.Migrations, []byte(m[0].Name), []byte{1})
 	})
 	require.NoError(err)
@@ -140,7 +140,7 @@ func TestApplyWithoutInit(t *testing.T) {
 	require.NoError(err)
 
 	var applied map[string][]byte
-	err = migrationsDB.View(context.Background(), func(tx kv.Tx) error {
+	err = migrationsDB.View(t.Context(), func(tx kv.Tx) error {
 		applied, err = AppliedMigrations(tx, false)
 		require.NoError(err)
 
@@ -157,7 +157,7 @@ func TestApplyWithoutInit(t *testing.T) {
 	err = migrator.Apply(db, migrationsDB, "", "", logger)
 	require.NoError(err)
 
-	err = migrationsDB.View(context.Background(), func(tx kv.Tx) error {
+	err = migrationsDB.View(t.Context(), func(tx kv.Tx) error {
 		applied2, err := AppliedMigrations(tx, false)
 		require.NoError(err)
 		require.Equal(applied, applied2)
@@ -174,7 +174,7 @@ func TestWhenNonFirstMigrationAlreadyApplied(t *testing.T) {
 		{
 			"one",
 			func(db kv.RwDB, dirs datadir.Dirs, progress []byte, BeforeCommit Callback, logger log.Logger) (err error) {
-				tx, err := db.BeginRw(context.Background())
+				tx, err := db.BeginRw(t.Context())
 				if err != nil {
 					return err
 				}
@@ -194,7 +194,7 @@ func TestWhenNonFirstMigrationAlreadyApplied(t *testing.T) {
 			},
 		},
 	}
-	err := migrationsDB.Update(context.Background(), func(tx kv.RwTx) error {
+	err := migrationsDB.Update(t.Context(), func(tx kv.RwTx) error {
 		return tx.Put(kv.Migrations, []byte(m[1].Name), []byte{1}) // apply non-first migration
 	})
 	require.NoError(err)
@@ -206,7 +206,7 @@ func TestWhenNonFirstMigrationAlreadyApplied(t *testing.T) {
 	require.NoError(err)
 
 	var applied map[string][]byte
-	err = migrationsDB.View(context.Background(), func(tx kv.Tx) error {
+	err = migrationsDB.View(t.Context(), func(tx kv.Tx) error {
 		applied, err = AppliedMigrations(tx, false)
 		require.NoError(err)
 
@@ -222,7 +222,7 @@ func TestWhenNonFirstMigrationAlreadyApplied(t *testing.T) {
 	// apply again
 	err = migrator.Apply(db, migrationsDB, "", "", logger)
 	require.NoError(err)
-	err = migrationsDB.View(context.Background(), func(tx kv.Tx) error {
+	err = migrationsDB.View(t.Context(), func(tx kv.Tx) error {
 		applied2, err := AppliedMigrations(tx, false)
 		require.NoError(err)
 		require.Equal(applied, applied2)
@@ -238,7 +238,7 @@ func TestValidation(t *testing.T) {
 		{
 			Name: "repeated_name",
 			Up: func(db kv.RwDB, dirs datadir.Dirs, progress []byte, BeforeCommit Callback, logger log.Logger) (err error) {
-				tx, err := db.BeginRw(context.Background())
+				tx, err := db.BeginRw(t.Context())
 				if err != nil {
 					return err
 				}
@@ -253,7 +253,7 @@ func TestValidation(t *testing.T) {
 		{
 			Name: "repeated_name",
 			Up: func(db kv.RwDB, dirs datadir.Dirs, progress []byte, BeforeCommit Callback, logger log.Logger) (err error) {
-				tx, err := db.BeginRw(context.Background())
+				tx, err := db.BeginRw(t.Context())
 				if err != nil {
 					return err
 				}
@@ -273,7 +273,7 @@ func TestValidation(t *testing.T) {
 	require.ErrorIs(err, ErrMigrationNonUniqueName)
 
 	var applied map[string][]byte
-	err = migrationsDB.View(context.Background(), func(tx kv.Tx) error {
+	err = migrationsDB.View(t.Context(), func(tx kv.Tx) error {
 		applied, err = AppliedMigrations(tx, false)
 		require.NoError(err)
 		require.Empty(applied)
@@ -301,7 +301,7 @@ func TestCommitCallRequired(t *testing.T) {
 	require.ErrorIs(err, ErrMigrationCommitNotCalled)
 
 	var applied map[string][]byte
-	err = migrationsDB.View(context.Background(), func(tx kv.Tx) error {
+	err = migrationsDB.View(t.Context(), func(tx kv.Tx) error {
 		applied, err = AppliedMigrations(tx, false)
 		require.NoError(err)
 		require.Empty(applied)

--- a/db/migrations/migrations_test.go
+++ b/db/migrations/migrations_test.go
@@ -17,7 +17,6 @@
 package migrations
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"

--- a/db/rawdb/accessors_chain_test.go
+++ b/db/rawdb/accessors_chain_test.go
@@ -481,7 +481,7 @@ func TestBlockStorage(t *testing.T) {
 	} else if entry.Hash() != block.Hash() {
 		t.Fatalf("Retrieved header mismatch: have %v, want %v", entry, block.Header())
 	}
-	if err := rawdb.TruncateBlocks(context.Background(), tx, 2); err != nil {
+	if err := rawdb.TruncateBlocks(t.Context(), tx, 2); err != nil {
 		t.Fatal(err)
 	}
 	if entry, _ := br.BodyWithTransactions(ctx, tx, block.Hash(), block.NumberU64()); entry == nil {
@@ -490,7 +490,7 @@ func TestBlockStorage(t *testing.T) {
 		t.Fatalf("Retrieved body mismatch: have %v, want %v", entry, block.Body())
 	}
 	// Delete the block and verify the execution
-	if err := rawdb.TruncateBlocks(context.Background(), tx, block.NumberU64()); err != nil {
+	if err := rawdb.TruncateBlocks(t.Context(), tx, block.NumberU64()); err != nil {
 		t.Fatal(err)
 	}
 	//if err := DeleteBlock(tx, block.Hash(), block.NumberU64()); err != nil {
@@ -826,10 +826,10 @@ func TestBlockReceiptStorage(t *testing.T) {
 	var txNum uint64
 	{
 		blockNum := header.Number.Uint64()
-		sd, err := execctx.NewSharedDomains(context.Background(), tx, log.New())
+		sd, err := execctx.NewSharedDomains(t.Context(), tx, log.New())
 		require.NoError(err)
 		defer sd.Close()
-		base, err := txNumReader.Min(context.Background(), tx, 1)
+		base, err := txNumReader.Min(t.Context(), tx, 1)
 		require.NoError(err)
 		// Insert the receipt slice into the database and check presence
 		txNum = base
@@ -881,7 +881,7 @@ func TestBlockWithdrawalsStorage(t *testing.T) {
 	require.NoError(err)
 	defer tx.Rollback()
 	br, bw := m.BlocksIO()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// create fake withdrawals
 	w := types.Withdrawal{
@@ -942,7 +942,7 @@ func TestBlockWithdrawalsStorage(t *testing.T) {
 	} else if entry.Hash() != block.Hash() {
 		t.Fatalf("Retrieved header mismatch: have %v, want %v", entry, block.Header())
 	}
-	if err := rawdb.TruncateBlocks(context.Background(), tx, 2); err != nil {
+	if err := rawdb.TruncateBlocks(t.Context(), tx, 2); err != nil {
 		t.Fatal(err)
 	}
 	entry, _ := br.BodyWithTransactions(ctx, tx, block.Hash(), block.NumberU64())
@@ -974,7 +974,7 @@ func TestBlockWithdrawalsStorage(t *testing.T) {
 	require.Equal(uint64(1001), rw2.Amount)
 
 	// Delete the block and verify the execution
-	if err := rawdb.TruncateBlocks(context.Background(), tx, block.NumberU64()); err != nil {
+	if err := rawdb.TruncateBlocks(t.Context(), tx, block.NumberU64()); err != nil {
 		t.Fatal(err)
 	}
 	//if err := DeleteBlock(tx, block.Hash(), block.NumberU64()); err != nil {

--- a/db/rawdb/accessors_chain_test.go
+++ b/db/rawdb/accessors_chain_test.go
@@ -18,7 +18,6 @@ package rawdb_test
 
 import (
 	"bytes"
-	"context"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"

--- a/db/rawdb/accessors_indexes_test.go
+++ b/db/rawdb/accessors_indexes_test.go
@@ -87,7 +87,7 @@ func TestLookupStorage(t *testing.T) {
 			if err := rawdb.WriteSenders(tx, block.Hash(), block.NumberU64(), block.Body().SendersFromTxs()); err != nil {
 				t.Fatal(err)
 			}
-			txNumMin, err := rawdbv3.TxNums.Min(context.Background(), tx, block.NumberU64())
+			txNumMin, err := rawdbv3.TxNums.Min(t.Context(), tx, block.NumberU64())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -137,14 +137,14 @@ func readTransactionByHash(db kv.Tx, hash common.Hash, br services.FullBlockRead
 		return nil, common.Hash{}, 0, 0, 0, nil
 	}
 	txNum = *txNumPtr
-	blockHash, ok, err := br.CanonicalHash(context.Background(), db, blockNumber)
+	blockHash, ok, err := br.CanonicalHash(t.Context(), db, blockNumber)
 	if err != nil {
 		return nil, common.Hash{}, 0, 0, 0, err
 	}
 	if !ok || blockHash == (common.Hash{}) {
 		return nil, common.Hash{}, 0, 0, 0, nil
 	}
-	body, _ := br.BodyWithTransactions(context.Background(), db, blockHash, blockNumber)
+	body, _ := br.BodyWithTransactions(t.Context(), db, blockHash, blockNumber)
 	if body == nil {
 		log.Error("Transaction referenced missing", "number", blockNumber, "hash", blockHash)
 		return nil, common.Hash{}, 0, 0, 0, nil

--- a/db/rawdb/accessors_indexes_test.go
+++ b/db/rawdb/accessors_indexes_test.go
@@ -137,14 +137,14 @@ func readTransactionByHash(db kv.Tx, hash common.Hash, br services.FullBlockRead
 		return nil, common.Hash{}, 0, 0, 0, nil
 	}
 	txNum = *txNumPtr
-	blockHash, ok, err := br.CanonicalHash(t.Context(), db, blockNumber)
+	blockHash, ok, err := br.CanonicalHash(context.Background(), db, blockNumber)
 	if err != nil {
 		return nil, common.Hash{}, 0, 0, 0, err
 	}
 	if !ok || blockHash == (common.Hash{}) {
 		return nil, common.Hash{}, 0, 0, 0, nil
 	}
-	body, _ := br.BodyWithTransactions(t.Context(), db, blockHash, blockNumber)
+	body, _ := br.BodyWithTransactions(context.Background(), db, blockHash, blockNumber)
 	if body == nil {
 		log.Error("Transaction referenced missing", "number", blockNumber, "hash", blockHash)
 		return nil, common.Hash{}, 0, 0, 0, nil

--- a/db/rawdb/rawtemporaldb/accessors_receipt_test.go
+++ b/db/rawdb/rawtemporaldb/accessors_receipt_test.go
@@ -1,7 +1,6 @@
 package rawtemporaldb_test
 
 import (
-	"context"
 	"encoding/binary"
 	"testing"
 
@@ -18,12 +17,12 @@ import (
 func TestAppendReceipt(t *testing.T) {
 	dirs, require := datadir.New(t.TempDir()), require.New(t)
 	db := temporaltest.NewTestDB(t, dirs)
-	tx, err := db.BeginTemporalRw(context.Background())
+	tx, err := db.BeginTemporalRw(t.Context())
 	require.NoError(err)
 	defer tx.Rollback()
 
 	ttx := tx
-	doms, err := execctx.NewSharedDomains(context.Background(), ttx, log.New())
+	doms, err := execctx.NewSharedDomains(t.Context(), ttx, log.New())
 	require.NoError(err)
 	defer doms.Close()
 
@@ -39,7 +38,7 @@ func TestAppendReceipt(t *testing.T) {
 	err = rawtemporaldb.AppendReceipt(doms.AsPutDel(ttx), 4, 14, 0, 4) // 0 log
 	require.NoError(err)
 
-	err = doms.Flush(context.Background(), tx)
+	err = doms.Flush(t.Context(), tx)
 	require.NoError(err)
 
 	v, ok, err := ttx.HistorySeek(kv.ReceiptDomain, rawtemporaldb.LogIndexAfterTxKey, 0)

--- a/db/recsplit/index_test.go
+++ b/db/recsplit/index_test.go
@@ -52,7 +52,7 @@ func TestReWriteIndex(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if err := rs.Build(context.Background()); err != nil {
+	if err := rs.Build(t.Context()); err != nil {
 		t.Fatal(err)
 	}
 	idx := MustOpen(indexFile)

--- a/db/recsplit/index_test.go
+++ b/db/recsplit/index_test.go
@@ -18,7 +18,6 @@ package recsplit
 
 import (
 	"bufio"
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"

--- a/db/recsplit/recsplit_fuzz_test.go
+++ b/db/recsplit/recsplit_fuzz_test.go
@@ -17,7 +17,6 @@
 package recsplit
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 

--- a/db/recsplit/recsplit_fuzz_test.go
+++ b/db/recsplit/recsplit_fuzz_test.go
@@ -75,7 +75,7 @@ func FuzzRecSplit(f *testing.F) {
 		if err := rs.AddKey(in[i:], off); err != nil {
 			t.Fatal(err)
 		}
-		if err = rs.Build(context.Background()); err != nil {
+		if err = rs.Build(t.Context()); err != nil {
 			t.Fatal(err)
 		}
 		// Check that there is a bijection

--- a/db/recsplit/recsplit_test.go
+++ b/db/recsplit/recsplit_test.go
@@ -17,7 +17,6 @@
 package recsplit
 
 import (
-	"context"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -369,7 +368,7 @@ func BenchmarkBuild(b *testing.B) {
 			}
 		}
 		b.StartTimer()
-		if err := rs.Build(t.Context()); err != nil {
+		if err := rs.Build(b.Context()); err != nil {
 			b.Fatal(err)
 		}
 		b.StopTimer()
@@ -417,7 +416,7 @@ func BenchmarkAddKeyAndBuild(b *testing.B) {
 						b.Fatal(err)
 					}
 				}
-				if err := rs.Build(t.Context()); err != nil {
+				if err := rs.Build(b.Context()); err != nil {
 					b.Fatal(err)
 				}
 				b.StopTimer()
@@ -624,7 +623,7 @@ func BenchmarkBuildParallel(b *testing.B) {
 					}
 				}
 				b.StartTimer()
-				if err := rs.Build(t.Context()); err != nil {
+				if err := rs.Build(b.Context()); err != nil {
 					b.Fatal(err)
 				}
 				b.StopTimer()

--- a/db/recsplit/recsplit_test.go
+++ b/db/recsplit/recsplit_test.go
@@ -51,16 +51,16 @@ func TestRecSplit2(t *testing.T) {
 	if err = rs.AddKey([]byte("first_key"), 0); err != nil {
 		t.Error(err)
 	}
-	if err = rs.Build(context.Background()); err == nil {
+	if err = rs.Build(t.Context()); err == nil {
 		t.Errorf("test is expected to fail, too few keys added")
 	}
 	if err = rs.AddKey([]byte("second_key"), 0); err != nil {
 		t.Error(err)
 	}
-	if err = rs.Build(context.Background()); err != nil {
+	if err = rs.Build(t.Context()); err != nil {
 		t.Error(err)
 	}
-	if err = rs.Build(context.Background()); err == nil {
+	if err = rs.Build(t.Context()); err == nil {
 		t.Errorf("test is expected to fail, hash gunction was built already")
 	}
 	if err = rs.AddKey([]byte("key_to_fail"), 0); err == nil {
@@ -90,7 +90,7 @@ func TestRecSplitDuplicate(t *testing.T) {
 	if err := rs.AddKey([]byte("first_key"), 0); err != nil {
 		t.Error(err)
 	}
-	if err := rs.Build(context.Background()); err == nil {
+	if err := rs.Build(t.Context()); err == nil {
 		t.Errorf("test is expected to fail, duplicate key")
 	}
 }
@@ -129,7 +129,7 @@ func TestIndexLookup(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		if err := rs.Build(context.Background()); err != nil {
+		if err := rs.Build(t.Context()); err != nil {
 			t.Fatal(err)
 		}
 		idx := MustOpen(indexFile)
@@ -369,7 +369,7 @@ func BenchmarkBuild(b *testing.B) {
 			}
 		}
 		b.StartTimer()
-		if err := rs.Build(context.Background()); err != nil {
+		if err := rs.Build(t.Context()); err != nil {
 			b.Fatal(err)
 		}
 		b.StopTimer()
@@ -417,7 +417,7 @@ func BenchmarkAddKeyAndBuild(b *testing.B) {
 						b.Fatal(err)
 					}
 				}
-				if err := rs.Build(context.Background()); err != nil {
+				if err := rs.Build(t.Context()); err != nil {
 					b.Fatal(err)
 				}
 				b.StopTimer()
@@ -446,7 +446,7 @@ func TestTwoLayerIndex(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		if err := rs.Build(context.Background()); err != nil {
+		if err := rs.Build(t.Context()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -512,7 +512,7 @@ func TestIndexLookupParallel(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			if err := rs.Build(context.Background()); err != nil {
+			if err := rs.Build(t.Context()); err != nil {
 				t.Fatal(err)
 			}
 			idx := MustOpen(indexFile)
@@ -570,7 +570,7 @@ func TestParallelMatchesSequential(t *testing.T) {
 		for i, k := range keys {
 			require.NoError(t, rs.AddKey(k, uint64(i*17)))
 		}
-		require.NoError(t, rs.Build(context.Background()))
+		require.NoError(t, rs.Build(t.Context()))
 	}
 
 	seqFile := filepath.Join(tmpDir, "seq.idx")
@@ -624,7 +624,7 @@ func BenchmarkBuildParallel(b *testing.B) {
 					}
 				}
 				b.StartTimer()
-				if err := rs.Build(context.Background()); err != nil {
+				if err := rs.Build(t.Context()); err != nil {
 					b.Fatal(err)
 				}
 				b.StopTimer()

--- a/db/seg/compress_fuzz_test.go
+++ b/db/seg/compress_fuzz_test.go
@@ -17,7 +17,6 @@
 package seg
 
 import (
-	"context"
 	"fmt"
 	"math/rand"
 	"path/filepath"

--- a/db/seg/compress_fuzz_test.go
+++ b/db/seg/compress_fuzz_test.go
@@ -47,7 +47,7 @@ func FuzzCompress(f *testing.F) {
 			j = next
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		tmpDir := t.TempDir()
 		file := filepath.Join(tmpDir, fmt.Sprintf("compressed-%d", rand.Int31()))
 		cfg := DefaultCfg

--- a/db/seg/compress_test.go
+++ b/db/seg/compress_test.go
@@ -18,7 +18,6 @@ package seg
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"hash/crc32"
 	"io"

--- a/db/seg/compress_test.go
+++ b/db/seg/compress_test.go
@@ -37,7 +37,7 @@ func TestCompressEmptyDict(t *testing.T) {
 	file := filepath.Join(tmpDir, "compressed")
 	cfg := DefaultCfg
 	cfg.MinPatternScore = 100
-	c, err := NewCompressor(context.Background(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
+	c, err := NewCompressor(t.Context(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,7 +97,7 @@ func prepareDictMetadata(t testing.TB, multiplier int, hasMetadata bool, metadat
 	cfg.MinPatternScore = 1
 	cfg.Workers = 2
 	cfg.ExpectMetadata = hasMetadata
-	c, err := NewCompressor(context.Background(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
+	c, err := NewCompressor(t.Context(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -341,7 +341,7 @@ func TestCompressNoWordPatterns(t *testing.T) {
 	logger := log.New()
 	tmpDir := t.TempDir()
 	file := filepath.Join(tmpDir, "compressed")
-	c, err := NewCompressor(context.Background(), t.Name(), file, tmpDir, DefaultCfg, log.LvlDebug, logger)
+	c, err := NewCompressor(t.Context(), t.Name(), file, tmpDir, DefaultCfg, log.LvlDebug, logger)
 	require.NoError(t, err)
 	defer c.Close()
 

--- a/db/seg/decompress_bench_test.go
+++ b/db/seg/decompress_bench_test.go
@@ -18,7 +18,6 @@ package seg
 
 import (
 	"bytes"
-	"context"
 	"encoding/binary"
 	"fmt"
 	"math/rand"
@@ -103,7 +102,7 @@ func prepareBinaryDict(b testing.TB, keyCount int, keySize int, compressed bool)
 	cfg := DefaultCfg
 	cfg.MinPatternScore = 1
 	cfg.Workers = 2
-	c, err := NewCompressor(t.Context(), b.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
+	c, err := NewCompressor(b.Context(), b.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
 	require.NoError(b, err)
 
 	rng := rand.New(rand.NewSource(42))

--- a/db/seg/decompress_bench_test.go
+++ b/db/seg/decompress_bench_test.go
@@ -103,7 +103,7 @@ func prepareBinaryDict(b testing.TB, keyCount int, keySize int, compressed bool)
 	cfg := DefaultCfg
 	cfg.MinPatternScore = 1
 	cfg.Workers = 2
-	c, err := NewCompressor(context.Background(), b.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
+	c, err := NewCompressor(t.Context(), b.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
 	require.NoError(b, err)
 
 	rng := rand.New(rand.NewSource(42))

--- a/db/seg/decompress_fuzz_test.go
+++ b/db/seg/decompress_fuzz_test.go
@@ -18,7 +18,6 @@ package seg
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"math/rand"
 	"path/filepath"

--- a/db/seg/decompress_fuzz_test.go
+++ b/db/seg/decompress_fuzz_test.go
@@ -48,7 +48,7 @@ func FuzzDecompressMatch(f *testing.F) {
 			j = next
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		tmpDir := t.TempDir()
 		file := filepath.Join(tmpDir, fmt.Sprintf("compressed-%d", rand.Int31()))
 		cfg := DefaultCfg

--- a/db/seg/decompress_test.go
+++ b/db/seg/decompress_test.go
@@ -17,7 +17,6 @@ package seg
 
 import (
 	"bytes"
-	"context"
 	"encoding/binary"
 	"fmt"
 	"math/rand"

--- a/db/seg/decompress_test.go
+++ b/db/seg/decompress_test.go
@@ -44,7 +44,7 @@ func prepareLoremDict(t *testing.T) *Decompressor {
 	cfg := DefaultCfg
 	cfg.MinPatternScore = 1
 	cfg.Workers = 2
-	c, err := NewCompressor(context.Background(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
+	c, err := NewCompressor(t.Context(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,7 +149,7 @@ func prepareStupidDict(t *testing.T, size int) *Decompressor {
 	cfg := DefaultCfg
 	cfg.MinPatternScore = 1
 	cfg.Workers = 2
-	c, err := NewCompressor(context.Background(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
+	c, err := NewCompressor(t.Context(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -268,7 +268,7 @@ func prepareLoremDictUncompressed(t *testing.T) *Decompressor {
 	cfg := DefaultCfg
 	cfg.MinPatternScore = 1
 	cfg.Workers = 2
-	c, err := NewCompressor(context.Background(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
+	c, err := NewCompressor(t.Context(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
 	require.NoError(t, err)
 	defer c.Close()
 	for k, w := range loremStrings {
@@ -360,7 +360,7 @@ func TestDecompressor_OpenCorrupted(t *testing.T) {
 		cfg := DefaultCfg
 		cfg.MinPatternScore = 1
 		cfg.Workers = 2
-		c, err := NewCompressor(context.Background(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
+		c, err := NewCompressor(t.Context(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
 		require.NoError(t, err)
 		defer c.Close()
 		for k, w := range loremStrings {
@@ -382,7 +382,7 @@ func TestDecompressor_OpenCorrupted(t *testing.T) {
 		cfg := DefaultCfg
 		cfg.MinPatternScore = 1
 		cfg.Workers = 2
-		c, err := NewCompressor(context.Background(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
+		c, err := NewCompressor(t.Context(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
 		require.NoError(t, err)
 		defer c.Close()
 		err = c.Compress()
@@ -400,7 +400,7 @@ func TestDecompressor_OpenCorrupted(t *testing.T) {
 		cfg := DefaultCfg
 		cfg.MinPatternScore = 1
 		cfg.Workers = 2
-		c, err := NewCompressor(context.Background(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
+		c, err := NewCompressor(t.Context(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
 		require.NoError(t, err)
 		defer c.Close()
 		for k, w := range loremStrings {
@@ -422,7 +422,7 @@ func TestDecompressor_OpenCorrupted(t *testing.T) {
 		cfg := DefaultCfg
 		cfg.MinPatternScore = 1
 		cfg.Workers = 2
-		c, err := NewCompressor(context.Background(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
+		c, err := NewCompressor(t.Context(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
 		require.NoError(t, err)
 		defer c.Close()
 		err = c.Compress()
@@ -583,7 +583,7 @@ func prepareRandomDict(t *testing.T) (d *Decompressor, WORDS [N][]byte, WORD_FLA
 	cfg := DefaultCfg
 	cfg.MinPatternScore = 1
 	cfg.Workers = 2
-	c, err := NewCompressor(context.Background(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
+	c, err := NewCompressor(t.Context(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -639,7 +639,7 @@ func TestMatchCmpCompressedBinaryKeys(t *testing.T) {
 	cfg := DefaultCfg
 	cfg.MinPatternScore = 1
 	cfg.Workers = 2
-	c, err := NewCompressor(context.Background(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
+	c, err := NewCompressor(t.Context(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
 	require.NoError(t, err)
 
 	// Generate sorted binary keys (20 bytes, like address hashes)
@@ -731,7 +731,7 @@ func TestMatchCmpUncompressedBinaryKeys(t *testing.T) {
 	cfg := DefaultCfg
 	cfg.MinPatternScore = 1
 	cfg.Workers = 2
-	c, err := NewCompressor(context.Background(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
+	c, err := NewCompressor(t.Context(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
 	require.NoError(t, err)
 
 	keys := make([][]byte, 200)
@@ -791,7 +791,7 @@ func TestMatchCmpEmptyAndNil(t *testing.T) {
 	cfg := DefaultCfg
 	cfg.MinPatternScore = 1
 	cfg.Workers = 2
-	c, err := NewCompressor(context.Background(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
+	c, err := NewCompressor(t.Context(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
 	require.NoError(t, err)
 
 	// Write: nil, empty, short, empty, nil
@@ -835,7 +835,7 @@ func TestMatchAllEdgeCases(t *testing.T) {
 		cfg := DefaultCfg
 		cfg.MinPatternScore = 1
 		cfg.Workers = 2
-		c, err := NewCompressor(context.Background(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
+		c, err := NewCompressor(t.Context(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
 		require.NoError(t, err)
 		for _, w := range words {
 			require.NoError(t, c.AddWord(w))
@@ -855,7 +855,7 @@ func TestMatchAllEdgeCases(t *testing.T) {
 		cfg := DefaultCfg
 		cfg.MinPatternScore = 1
 		cfg.Workers = 2
-		c, err := NewCompressor(context.Background(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
+		c, err := NewCompressor(t.Context(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
 		require.NoError(t, err)
 		for _, w := range words {
 			require.NoError(t, c.AddUncompressedWord(w))

--- a/db/seg/seg_paged_rw_test.go
+++ b/db/seg/seg_paged_rw_test.go
@@ -42,7 +42,7 @@ func prepareLoremDictOnPagedWriter(t *testing.T, pageSize int, pageCompression b
 	cfg := DefaultCfg.WithValuesOnCompressedPage(pageSize)
 	cfg.MinPatternScore = 1
 	cfg.Workers = 1
-	c, err := NewCompressor(context.Background(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
+	c, err := NewCompressor(t.Context(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
 	require.NoError(err)
 	defer c.Close()
 
@@ -485,7 +485,7 @@ func prepareKVUncompressedKeysCompressedVals(t *testing.T, keyLen int, numPairs 
 	cfg := DefaultCfg
 	cfg.MinPatternScore = 1
 	cfg.Workers = 2
-	c, err := NewCompressor(context.Background(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
+	c, err := NewCompressor(t.Context(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
 	require.NoError(t, err)
 
 	require.GreaterOrEqual(t, keyLen, 8, "keyLen must be >= 8 for binary.BigEndian.PutUint64")

--- a/db/seg/seg_paged_rw_test.go
+++ b/db/seg/seg_paged_rw_test.go
@@ -18,7 +18,6 @@ package seg
 
 import (
 	"bytes"
-	"context"
 	"encoding/binary"
 	"fmt"
 	"hash/crc32"

--- a/db/snapshotsync/freezeblocks/block_reader_test.go
+++ b/db/snapshotsync/freezeblocks/block_reader_test.go
@@ -17,7 +17,6 @@
 package freezeblocks
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 

--- a/db/snapshotsync/freezeblocks/block_reader_test.go
+++ b/db/snapshotsync/freezeblocks/block_reader_test.go
@@ -43,7 +43,7 @@ import (
 func createTestSegmentFile(t *testing.T, from, to uint64, name snaptype.Enum, dir string, ver snaptype.Version, logger log.Logger) {
 	compressCfg := seg.DefaultCfg
 	compressCfg.MinPatternScore = 100
-	c, err := seg.NewCompressor(context.Background(), "test", filepath.Join(dir, snaptype.SegmentFileName(ver, from, to, name)), dir, compressCfg, log.LvlDebug, logger)
+	c, err := seg.NewCompressor(t.Context(), "test", filepath.Join(dir, snaptype.SegmentFileName(ver, from, to, name)), dir, compressCfg, log.LvlDebug, logger)
 	require.NoError(t, err)
 	defer c.Close()
 	c.DisableFsync()
@@ -63,7 +63,7 @@ func createTestSegmentFile(t *testing.T, from, to uint64, name snaptype.Enum, di
 	idx.DisableFsync()
 	err = idx.AddKey([]byte{1}, 0)
 	require.NoError(t, err)
-	err = idx.Build(context.Background())
+	err = idx.Build(t.Context())
 	require.NoError(t, err)
 	if name == snaptype2.Transactions.Enum() {
 		idx, err := recsplit.NewRecSplit(recsplit.RecSplitArgs{
@@ -76,7 +76,7 @@ func createTestSegmentFile(t *testing.T, from, to uint64, name snaptype.Enum, di
 		require.NoError(t, err)
 		err = idx.AddKey([]byte{1}, 0)
 		require.NoError(t, err)
-		err = idx.Build(context.Background())
+		err = idx.Build(t.Context())
 		require.NoError(t, err)
 		defer idx.Close()
 	}
@@ -88,7 +88,7 @@ func TestBlockReaderGenesisBlockWithSnapshots(t *testing.T) {
 	db := memdb.NewTestDB(t, dbcfg.ChainDB)
 	logger := log.New()
 
-	tx, err := db.BeginRo(context.Background())
+	tx, err := db.BeginRo(t.Context())
 	require.NoError(t, err)
 	defer tx.Rollback()
 
@@ -98,7 +98,7 @@ func TestBlockReaderGenesisBlockWithSnapshots(t *testing.T) {
 
 	// create minimal genesis block for testing
 	tx.Rollback()
-	rwTx, err := db.BeginRw(context.Background())
+	rwTx, err := db.BeginRw(t.Context())
 	require.NoError(t, err)
 	defer rwTx.Rollback()
 
@@ -132,28 +132,28 @@ func TestBlockReaderGenesisBlockWithSnapshots(t *testing.T) {
 	blockReader := NewBlockReader(snapshots, nil)
 
 	// Try to read genesis block (block 0) when snapshots exist.This should read from database not snapshots
-	tx, err = db.BeginRo(context.Background())
+	tx, err = db.BeginRo(t.Context())
 	require.NoError(t, err)
 	defer tx.Rollback()
 
-	hash, ok, err := blockReader.CanonicalHash(context.Background(), tx, 0)
+	hash, ok, err := blockReader.CanonicalHash(t.Context(), tx, 0)
 	assert.NoError(t, err)
 	assert.True(t, ok)
 	assert.Equal(t, genesisHash, hash)
 
-	block, senders, err := blockReader.BlockWithSenders(context.Background(), tx, genesisHash, 0)
+	block, senders, err := blockReader.BlockWithSenders(t.Context(), tx, genesisHash, 0)
 	assert.NoError(t, err)
 	// should be nil because genesis block does not have transactions
 	assert.Nil(t, block)
 	assert.Nil(t, senders)
 
-	header, err := blockReader.Header(context.Background(), tx, genesisHash, 0)
+	header, err := blockReader.Header(t.Context(), tx, genesisHash, 0)
 	require.NoError(t, err)
 	assert.NotNil(t, header)
 	assert.Equal(t, uint64(0), header.Number.Uint64())
 
 	// HasSenders should work for genesis
-	hasSenders, err := blockReader.HasSenders(context.Background(), tx, genesisHash, 0)
+	hasSenders, err := blockReader.HasSenders(t.Context(), tx, genesisHash, 0)
 	assert.NoError(t, err)
 	assert.False(t, hasSenders) // should be false because genesis block does not have senders
 }

--- a/db/snapshotsync/freezeblocks/caplin_snapshots_test.go
+++ b/db/snapshotsync/freezeblocks/caplin_snapshots_test.go
@@ -17,7 +17,6 @@
 package freezeblocks
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"

--- a/db/snapshotsync/freezeblocks/caplin_snapshots_test.go
+++ b/db/snapshotsync/freezeblocks/caplin_snapshots_test.go
@@ -41,6 +41,6 @@ func TestDumpBeaconBlocksNoPanic(t *testing.T) {
 	// so the loop reaches chooseSegmentEnd and dumpBeaconBlocksRange.
 	// Before the fix this panicked; now it returns an error (no snap dir / empty db).
 	require.NotPanics(t, func() {
-		_ = DumpBeaconBlocks(context.Background(), db, 0, snaptype.CaplinMergeLimit, 0, dirs, 1, log.LvlDebug, log.New())
+		_ = DumpBeaconBlocks(t.Context(), db, 0, snaptype.CaplinMergeLimit, 0, dirs, 1, log.LvlDebug, log.New())
 	})
 }

--- a/db/snapshotsync/snapshots_test.go
+++ b/db/snapshotsync/snapshots_test.go
@@ -17,7 +17,6 @@
 package snapshotsync
 
 import (
-	"context"
 	"path/filepath"
 	"slices"
 	"strings"

--- a/db/snapshotsync/snapshots_test.go
+++ b/db/snapshotsync/snapshots_test.go
@@ -44,7 +44,7 @@ import (
 func createTestSegmentFile(t *testing.T, from, to uint64, name snaptype.Enum, dir string, ver snaptype.Version, logger log.Logger) {
 	compressCfg := seg.DefaultCfg
 	compressCfg.MinPatternScore = 100
-	c, err := seg.NewCompressor(context.Background(), "test", filepath.Join(dir, snaptype.SegmentFileName(ver, from, to, name)), dir, compressCfg, log.LvlDebug, logger)
+	c, err := seg.NewCompressor(t.Context(), "test", filepath.Join(dir, snaptype.SegmentFileName(ver, from, to, name)), dir, compressCfg, log.LvlDebug, logger)
 	require.NoError(t, err)
 	defer c.Close()
 	c.DisableFsync()
@@ -64,7 +64,7 @@ func createTestSegmentFile(t *testing.T, from, to uint64, name snaptype.Enum, di
 	idx.DisableFsync()
 	err = idx.AddKey([]byte{1}, 0)
 	require.NoError(t, err)
-	err = idx.Build(context.Background())
+	err = idx.Build(t.Context())
 	require.NoError(t, err)
 	if name == snaptype2.Transactions.Enum() {
 		idx, err := recsplit.NewRecSplit(recsplit.RecSplitArgs{
@@ -77,7 +77,7 @@ func createTestSegmentFile(t *testing.T, from, to uint64, name snaptype.Enum, di
 		require.NoError(t, err)
 		err = idx.AddKey([]byte{1}, 0)
 		require.NoError(t, err)
-		err = idx.Build(context.Background())
+		err = idx.Build(t.Context())
 		require.NoError(t, err)
 		defer idx.Close()
 	}
@@ -213,7 +213,7 @@ func TestMergeSnapshots(t *testing.T) {
 		s.OpenSegments(snaptype2.BlockSnapshotTypes, false, true)
 		Ranges := merger.FindMergeRanges(s.Ranges(false), s.SegmentsMax())
 		require.Len(Ranges, 3)
-		err := merger.Merge(context.Background(), s, snaptype2.BlockSnapshotTypes, Ranges, s.Dir(), false, nil, nil)
+		err := merger.Merge(t.Context(), s, snaptype2.BlockSnapshotTypes, Ranges, s.Dir(), false, nil, nil)
 		require.NoError(err)
 	}
 
@@ -230,7 +230,7 @@ func TestMergeSnapshots(t *testing.T) {
 		s.OpenFolder()
 		Ranges := merger.FindMergeRanges(s.Ranges(false), s.SegmentsMax())
 		require.Empty(Ranges)
-		err := merger.Merge(context.Background(), s, snaptype2.BlockSnapshotTypes, Ranges, s.Dir(), false, nil, nil)
+		err := merger.Merge(t.Context(), s, snaptype2.BlockSnapshotTypes, Ranges, s.Dir(), false, nil, nil)
 		require.NoError(err)
 	}
 
@@ -257,7 +257,7 @@ func TestMergeSnapshots(t *testing.T) {
 	// 	fmt.Println(s.Ranges(), s.SegmentsMax())
 	// 	Ranges := merger.FindMergeRanges(s.Ranges(), s.SegmentsMax())
 	// 	require.True(len(Ranges) > 0)
-	// 	err := merger.Merge(context.Background(), s, snaptype2.BlockSnapshotTypes, Ranges, s.Dir(), false, nil, nil)
+	// 	err := merger.Merge(t.Context(), s, snaptype2.BlockSnapshotTypes, Ranges, s.Dir(), false, nil, nil)
 	// 	require.NoError(err)
 	// }
 
@@ -274,7 +274,7 @@ func TestMergeSnapshots(t *testing.T) {
 	// 	s.OpenSegments(snaptype2.BlockSnapshotTypes, false)
 	// 	Ranges := merger.FindMergeRanges(s.Ranges(), s.SegmentsMax())
 	// 	require.True(len(Ranges) == 0)
-	// 	err := merger.Merge(context.Background(), s, snaptype2.BlockSnapshotTypes, Ranges, s.Dir(), false, nil, nil)
+	// 	err := merger.Merge(t.Context(), s, snaptype2.BlockSnapshotTypes, Ranges, s.Dir(), false, nil, nil)
 	// 	require.NoError(err)
 	// }
 

--- a/db/state/aggregator_bench_test.go
+++ b/db/state/aggregator_bench_test.go
@@ -538,7 +538,7 @@ func BenchmarkDb_BeginFiles_Throughput(b *testing.B) {
 
 	aggStep := uint64(100_00)
 	db, _ := testDbAndAggregatorBench(b, aggStep)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	b.SetParallelism(*parallel) // p * maxprocs
 	b.RunParallel(func(pb *testing.PB) {
@@ -576,7 +576,7 @@ func BenchmarkDb_BeginFiles_Throughput_IO(b *testing.B) {
 
 	aggStep := uint64(100_00)
 	db, _ := testDbAndAggregatorBench(b, aggStep)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	b.SetParallelism(*parallel) // p * maxprocs
 	b.RunParallel(func(pb *testing.PB) {
@@ -626,7 +626,7 @@ func generateKV(tb testing.TB, tmp string, keySize, valueSize, keyCount int, log
 	values := make([]byte, valueSize)
 
 	dataPath := filepath.Join(tmp, fmt.Sprintf("%dk.kv", keyCount/1000))
-	comp, err := seg.NewCompressor(context.Background(), "cmp", dataPath, tmp, seg.DefaultCfg, log.LvlDebug, logger)
+	comp, err := seg.NewCompressor(t.Context(), "cmp", dataPath, tmp, seg.DefaultCfg, log.LvlDebug, logger)
 	require.NoError(tb, err)
 
 	bufSize := 8 * datasize.KB

--- a/db/state/aggregator_bench_test.go
+++ b/db/state/aggregator_bench_test.go
@@ -538,7 +538,7 @@ func BenchmarkDb_BeginFiles_Throughput(b *testing.B) {
 
 	aggStep := uint64(100_00)
 	db, _ := testDbAndAggregatorBench(b, aggStep)
-	ctx := t.Context()
+	ctx := b.Context()
 
 	b.SetParallelism(*parallel) // p * maxprocs
 	b.RunParallel(func(pb *testing.PB) {
@@ -576,7 +576,7 @@ func BenchmarkDb_BeginFiles_Throughput_IO(b *testing.B) {
 
 	aggStep := uint64(100_00)
 	db, _ := testDbAndAggregatorBench(b, aggStep)
-	ctx := t.Context()
+	ctx := b.Context()
 
 	b.SetParallelism(*parallel) // p * maxprocs
 	b.RunParallel(func(pb *testing.PB) {
@@ -626,7 +626,7 @@ func generateKV(tb testing.TB, tmp string, keySize, valueSize, keyCount int, log
 	values := make([]byte, valueSize)
 
 	dataPath := filepath.Join(tmp, fmt.Sprintf("%dk.kv", keyCount/1000))
-	comp, err := seg.NewCompressor(t.Context(), "cmp", dataPath, tmp, seg.DefaultCfg, log.LvlDebug, logger)
+	comp, err := seg.NewCompressor(tb.Context(), "cmp", dataPath, tmp, seg.DefaultCfg, log.LvlDebug, logger)
 	require.NoError(tb, err)
 
 	bufSize := 8 * datasize.KB

--- a/db/state/aggregator_debug_test.go
+++ b/db/state/aggregator_debug_test.go
@@ -25,7 +25,7 @@ func TestDirtyFilesRoTx_CloseCallsCloseAndRemoveWhenRefCntDropsToZero(t *testing
 	fPath := filepath.Join(tmp, "v1-foo.0-1.kv")
 
 	// Create a real compressed segment file so seg.NewDecompressor can open it.
-	comp, err := seg.NewCompressor(context.Background(), t.Name(), fPath, tmp, seg.DefaultCfg, log.LvlDebug, log.New())
+	comp, err := seg.NewCompressor(t.Context(), t.Name(), fPath, tmp, seg.DefaultCfg, log.LvlDebug, log.New())
 	require.NoError(t, err)
 	comp.DisableFsync()
 	require.NoError(t, comp.AddWord([]byte("word")))

--- a/db/state/aggregator_debug_test.go
+++ b/db/state/aggregator_debug_test.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 

--- a/db/state/aggregator_fuzz_test.go
+++ b/db/state/aggregator_fuzz_test.go
@@ -17,7 +17,6 @@
 package state_test
 
 import (
-	"context"
 	"encoding/binary"
 	"testing"
 	"time"
@@ -42,11 +41,11 @@ import (
 func Fuzz_AggregatorV3_Merge(f *testing.F) {
 	db, agg := testFuzzDbAndAggregatorv3(f, 10)
 
-	rwTx, err := db.BeginTemporalRw(t.Context())
+	rwTx, err := db.BeginTemporalRw(f.Context())
 	require.NoError(f, err)
 	defer rwTx.Rollback()
 
-	domains, err := execctx.NewSharedDomains(t.Context(), rwTx, log.New())
+	domains, err := execctx.NewSharedDomains(f.Context(), rwTx, log.New())
 	require.NoError(f, err)
 	defer domains.Close()
 
@@ -158,11 +157,11 @@ func Fuzz_AggregatorV3_MergeValTransform(f *testing.F) {
 	db, agg := testFuzzDbAndAggregatorv3(f, 10)
 	agg.ForTestReplaceKeysInValues(kv.CommitmentDomain, true)
 
-	rwTx, err := db.BeginTemporalRw(t.Context())
+	rwTx, err := db.BeginTemporalRw(f.Context())
 	require.NoError(f, err)
 	defer rwTx.Rollback()
 
-	domains, err := execctx.NewSharedDomains(t.Context(), rwTx, log.New())
+	domains, err := execctx.NewSharedDomains(f.Context(), rwTx, log.New())
 	require.NoError(f, err)
 	defer domains.Close()
 

--- a/db/state/aggregator_fuzz_test.go
+++ b/db/state/aggregator_fuzz_test.go
@@ -42,11 +42,11 @@ import (
 func Fuzz_AggregatorV3_Merge(f *testing.F) {
 	db, agg := testFuzzDbAndAggregatorv3(f, 10)
 
-	rwTx, err := db.BeginTemporalRw(context.Background())
+	rwTx, err := db.BeginTemporalRw(t.Context())
 	require.NoError(f, err)
 	defer rwTx.Rollback()
 
-	domains, err := execctx.NewSharedDomains(context.Background(), rwTx, log.New())
+	domains, err := execctx.NewSharedDomains(t.Context(), rwTx, log.New())
 	require.NoError(f, err)
 	defer domains.Close()
 
@@ -111,7 +111,7 @@ func Fuzz_AggregatorV3_Merge(f *testing.F) {
 
 		}
 
-		err = domains.Flush(context.Background(), rwTx)
+		err = domains.Flush(t.Context(), rwTx)
 		require.NoError(t, err)
 
 		require.NoError(t, err)
@@ -121,21 +121,21 @@ func Fuzz_AggregatorV3_Merge(f *testing.F) {
 		err = agg.BuildFiles(txs)
 		require.NoError(t, err)
 
-		rwTx, err = db.BeginTemporalRw(context.Background())
+		rwTx, err = db.BeginTemporalRw(t.Context())
 		require.NoError(t, err)
 		defer rwTx.Rollback()
 
-		_, err := rwTx.PruneSmallBatches(context.Background(), time.Hour)
+		_, err := rwTx.PruneSmallBatches(t.Context(), time.Hour)
 		require.NoError(t, err)
 
 		err = rwTx.Commit()
 		require.NoError(t, err)
 
-		err = agg.MergeLoop(context.Background())
+		err = agg.MergeLoop(t.Context())
 		require.NoError(t, err)
 
 		// Check the history
-		roTx, err := db.BeginTemporalRo(context.Background())
+		roTx, err := db.BeginTemporalRo(t.Context())
 		require.NoError(t, err)
 		defer roTx.Rollback()
 
@@ -158,11 +158,11 @@ func Fuzz_AggregatorV3_MergeValTransform(f *testing.F) {
 	db, agg := testFuzzDbAndAggregatorv3(f, 10)
 	agg.ForTestReplaceKeysInValues(kv.CommitmentDomain, true)
 
-	rwTx, err := db.BeginTemporalRw(context.Background())
+	rwTx, err := db.BeginTemporalRw(t.Context())
 	require.NoError(f, err)
 	defer rwTx.Rollback()
 
-	domains, err := execctx.NewSharedDomains(context.Background(), rwTx, log.New())
+	domains, err := execctx.NewSharedDomains(t.Context(), rwTx, log.New())
 	require.NoError(f, err)
 	defer domains.Close()
 
@@ -204,7 +204,7 @@ func Fuzz_AggregatorV3_MergeValTransform(f *testing.F) {
 			require.NoError(t, err)
 
 			if (txNum+1)%agg.StepSize() == 0 {
-				_, err := domains.ComputeCommitment(context.Background(), rwTx, true, txNum/10, txNum, "", nil)
+				_, err := domains.ComputeCommitment(t.Context(), rwTx, true, txNum/10, txNum, "", nil)
 				require.NoError(t, err)
 			}
 
@@ -212,7 +212,7 @@ func Fuzz_AggregatorV3_MergeValTransform(f *testing.F) {
 			state[string(addrs[txNum].Bytes())+string(locs[txNum].Bytes())] = []byte{addrs[txNum].Bytes()[0], locs[txNum].Bytes()[0]}
 		}
 
-		err = domains.Flush(context.Background(), rwTx)
+		err = domains.Flush(t.Context(), rwTx)
 		require.NoError(t, err)
 
 		err = rwTx.Commit()
@@ -221,17 +221,17 @@ func Fuzz_AggregatorV3_MergeValTransform(f *testing.F) {
 		err = agg.BuildFiles(txs)
 		require.NoError(t, err)
 
-		rwTx, err = db.BeginTemporalRw(context.Background())
+		rwTx, err = db.BeginTemporalRw(t.Context())
 		require.NoError(t, err)
 		defer rwTx.Rollback()
 
-		_, err := rwTx.PruneSmallBatches(context.Background(), time.Hour)
+		_, err := rwTx.PruneSmallBatches(t.Context(), time.Hour)
 		require.NoError(t, err)
 
 		err = rwTx.Commit()
 		require.NoError(t, err)
 
-		err = agg.MergeLoop(context.Background())
+		err = agg.MergeLoop(t.Context())
 		require.NoError(t, err)
 	})
 }

--- a/db/state/aggregator_test.go
+++ b/db/state/aggregator_test.go
@@ -79,7 +79,7 @@ func generateKV(tb testing.TB, tmp string, keySize, valueSize, keyCount int, log
 	values := make([]byte, valueSize)
 
 	dataPath := filepath.Join(tmp, fmt.Sprintf("%dk.kv", keyCount/1000))
-	comp, err := seg.NewCompressor(context.Background(), "cmp", dataPath, tmp, seg.DefaultCfg, log.LvlDebug, logger)
+	comp, err := seg.NewCompressor(t.Context(), "cmp", dataPath, tmp, seg.DefaultCfg, log.LvlDebug, logger)
 	require.NoError(tb, err)
 
 	bufSize := 8 * datasize.KB

--- a/db/state/aggregator_test.go
+++ b/db/state/aggregator_test.go
@@ -17,7 +17,6 @@
 package state
 
 import (
-	"context"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
@@ -79,7 +78,7 @@ func generateKV(tb testing.TB, tmp string, keySize, valueSize, keyCount int, log
 	values := make([]byte, valueSize)
 
 	dataPath := filepath.Join(tmp, fmt.Sprintf("%dk.kv", keyCount/1000))
-	comp, err := seg.NewCompressor(t.Context(), "cmp", dataPath, tmp, seg.DefaultCfg, log.LvlDebug, logger)
+	comp, err := seg.NewCompressor(tb.Context(), "cmp", dataPath, tmp, seg.DefaultCfg, log.LvlDebug, logger)
 	require.NoError(tb, err)
 
 	bufSize := 8 * datasize.KB

--- a/db/state/archive_test.go
+++ b/db/state/archive_test.go
@@ -43,7 +43,7 @@ func TestArchiveWriter(t *testing.T) {
 		file := filepath.Join(tmp, name)
 		compressCfg := seg.DefaultCfg
 		compressCfg.MinPatternScore = 8
-		comp, err := seg.NewCompressor(context.Background(), "", file, tmp, compressCfg, log.LvlDebug, logger)
+		comp, err := seg.NewCompressor(t.Context(), "", file, tmp, compressCfg, log.LvlDebug, logger)
 		require.NoError(tb, err)
 		w := seg.NewWriter(comp, compFlags)
 		tb.Cleanup(w.Close)

--- a/db/state/archive_test.go
+++ b/db/state/archive_test.go
@@ -18,7 +18,6 @@ package state
 
 import (
 	"bytes"
-	"context"
 	"path/filepath"
 	"sort"
 	"testing"

--- a/db/state/changeset/state_changeset_test.go
+++ b/db/state/changeset/state_changeset_test.go
@@ -17,7 +17,6 @@
 package changeset_test
 
 import (
-	"context"
 	"encoding/binary"
 	"fmt"
 	"testing"
@@ -224,7 +223,7 @@ func BenchmarkWriteDiffSet(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; b.Loop(); i++ {
-		ctx := t.Context()
+		ctx := b.Context()
 		tx, err := db.BeginRw(ctx)
 		if err != nil {
 			b.Fatal(err)
@@ -252,7 +251,7 @@ func BenchmarkWriteDiffSetLarge(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; b.Loop(); i++ {
-		ctx := t.Context()
+		ctx := b.Context()
 		tx, err := db.BeginRw(ctx)
 		if err != nil {
 			b.Fatal(err)

--- a/db/state/changeset/state_changeset_test.go
+++ b/db/state/changeset/state_changeset_test.go
@@ -39,7 +39,7 @@ func TestNoOverflowPages(t *testing.T) {
 	db := mdbx.New(dbcfg.ChainDB, log.Root()).InMem(t, dirs.Chaindata).PageSize(ethconfig.DefaultChainDBPageSize).MustOpen()
 	t.Cleanup(db.Close)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tx, err := db.BeginRw(ctx)
 	require.NoError(t, err)
 	defer tx.Rollback()
@@ -224,7 +224,7 @@ func BenchmarkWriteDiffSet(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; b.Loop(); i++ {
-		ctx := context.Background()
+		ctx := t.Context()
 		tx, err := db.BeginRw(ctx)
 		if err != nil {
 			b.Fatal(err)
@@ -252,7 +252,7 @@ func BenchmarkWriteDiffSetLarge(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; b.Loop(); i++ {
-		ctx := context.Background()
+		ctx := t.Context()
 		tx, err := db.BeginRw(ctx)
 		if err != nil {
 			b.Fatal(err)

--- a/db/state/domain_stream_test.go
+++ b/db/state/domain_stream_test.go
@@ -147,7 +147,7 @@ func TestDomain_IteratePrefix_PrefersFilesOverDB(t *testing.T) {
 	t.Parallel()
 
 	logger := log.New()
-	ctx := context.Background()
+	ctx := t.Context()
 	require := require.New(t)
 
 	stepSize := uint64(16)

--- a/db/state/domain_stream_test.go
+++ b/db/state/domain_stream_test.go
@@ -3,7 +3,6 @@ package state
 import (
 	"bytes"
 	"container/heap"
-	"context"
 	"encoding/binary"
 	"testing"
 

--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -124,7 +124,7 @@ func TestDomain_OpenFolder(t *testing.T) {
 
 	db, d, txs := filledDomain(t, log.New())
 
-	err := db.UpdateNosync(context.Background(), func(tx kv.RwTx) error {
+	err := db.UpdateNosync(t.Context(), func(tx kv.RwTx) error {
 		collateAndMerge(t, tx, d, txs)
 		return nil
 	})
@@ -157,7 +157,7 @@ func testCollationBuild(t *testing.T, compressDomainVals bool) {
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
 	db, d := testDbAndDomainOfStep(t, statecfg.Schema.AccountsDomain, 16, logger)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	if compressDomainVals {
 		d.Compression = seg.CompressKeys | seg.CompressVals
@@ -299,7 +299,7 @@ func TestDomain_AfterPrune(t *testing.T) {
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
 	db, d := testDbAndDomain(t, logger)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tx, err := db.BeginRw(ctx)
 	require.NoError(t, err)
@@ -378,7 +378,7 @@ func TestDomain_AfterPrune(t *testing.T) {
 func fillDomain(t *testing.T, d *Domain, db kv.RwDB, logger log.Logger) uint64 {
 	t.Helper()
 	require := require.New(t)
-	ctx := context.Background()
+	ctx := t.Context()
 	tx, err := db.BeginRw(ctx)
 	require.NoError(err)
 	defer tx.Rollback()
@@ -430,7 +430,7 @@ func checkHistory(t *testing.T, db kv.RwDB, d *Domain, txs uint64) {
 	t.Helper()
 	fmt.Printf("txs: %d\n", txs)
 	require := require.New(t)
-	ctx := context.Background()
+	ctx := t.Context()
 	var err error
 
 	// Check the history
@@ -621,7 +621,7 @@ func TestHistory(t *testing.T) {
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
 	db, d, txs := filledDomain(t, logger)
-	err := db.UpdateNosync(context.Background(), func(tx kv.RwTx) error {
+	err := db.UpdateNosync(t.Context(), func(tx kv.RwTx) error {
 		collateAndMerge(t, tx, d, txs)
 		return nil
 	})
@@ -650,7 +650,7 @@ func collateAndMerge(t *testing.T, tx kv.RwTx, d *Domain, txs uint64) {
 	t.Helper()
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
-	ctx := context.Background()
+	ctx := t.Context()
 	// Leave the last 2 aggregation steps un-collated
 	for step := kv.Step(0); step < kv.Step(txs/d.stepSize)-1; step++ {
 		require.NoError(t, d.collateBuildIntegrate(ctx, step, tx, background.NewProgressSet()))
@@ -690,7 +690,7 @@ func collateAndMergeOnceWithScanPrune(t *testing.T, d *Domain, tx kv.RwTx, step 
 	t.Helper()
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
-	ctx := context.Background()
+	ctx := t.Context()
 	require.NoError(t, d.collateBuildIntegrate(ctx, step, tx, background.NewProgressSet()))
 
 	if prune {
@@ -727,7 +727,7 @@ func collateAndMergeOnce(t *testing.T, d *Domain, tx kv.RwTx, step kv.Step, prun
 	t.Helper()
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	require.NoError(t, d.collateBuildIntegrate(ctx, step, tx, background.NewProgressSet()))
 
@@ -766,7 +766,7 @@ func TestDomain_MergeFiles(t *testing.T) {
 
 	logger := log.New()
 	db, d, txs := filledDomain(t, logger)
-	rwTx, err := db.BeginRw(context.Background())
+	rwTx, err := db.BeginRw(t.Context())
 	require.NoError(t, err)
 	defer rwTx.Rollback()
 
@@ -785,7 +785,7 @@ func TestDomain_ScanFiles(t *testing.T) {
 
 	logger := log.New()
 	db, d, txs := filledDomain(t, logger)
-	err := db.UpdateNosync(context.Background(), func(tx kv.RwTx) error {
+	err := db.UpdateNosync(t.Context(), func(tx kv.RwTx) error {
 		collateAndMerge(t, tx, d, txs)
 		return nil
 	})
@@ -808,7 +808,7 @@ func TestDomainRoTx_CursorParentCheck(t *testing.T) {
 
 	logger := log.New()
 	db, d := testDbAndDomain(t, logger)
-	ctx, require := context.Background(), require.New(t)
+	ctx, require := t.Context(), require.New(t)
 	tx, err := db.BeginRw(ctx)
 	require.NoError(err)
 	defer tx.Rollback()
@@ -870,7 +870,7 @@ func TestDomainRoTx_CursorParentCheck(t *testing.T) {
 func TestDomain_CollationIsolatedFromLaterSteps(t *testing.T) {
 	logger := log.New()
 	db, d := testDbAndDomainOfStep(t, statecfg.Schema.StorageDomain, 16, logger)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	k1 := []byte("key1")
 	k2 := []byte("key2")
@@ -950,7 +950,7 @@ func TestDomain_CollationIsolatedFromLaterSteps(t *testing.T) {
 func TestDomain_UnwindRestoredEntryVisibility(t *testing.T) {
 	logger := log.New()
 	db, d := testDbAndDomainOfStep(t, statecfg.Schema.StorageDomain, 16, logger)
-	ctx := context.Background()
+	ctx := t.Context()
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
 
@@ -1015,7 +1015,7 @@ func TestDomain_Delete(t *testing.T) {
 
 	logger := log.New()
 	db, d := testDbAndDomain(t, logger)
-	ctx, require := context.Background(), require.New(t)
+	ctx, require := t.Context(), require.New(t)
 	tx, err := db.BeginRw(ctx)
 	require.NoError(err)
 	defer tx.Rollback()
@@ -1109,14 +1109,14 @@ func TestDomain_Prune_AfterAllWrites(t *testing.T) {
 	logger := log.New()
 	keyCount, txCount := uint64(4), uint64(64)
 	db, dom, data := filledDomainFixedSize(t, keyCount, txCount, 16, logger)
-	err := db.UpdateNosync(context.Background(), func(tx kv.RwTx) error {
+	err := db.UpdateNosync(t.Context(), func(tx kv.RwTx) error {
 		collateAndMerge(t, tx, dom, txCount)
 		return nil
 	})
 	require.NoError(t, err)
 	maxFrozenFiles := (txCount / dom.stepSize) / config3.DefaultStepsInFrozenFile
 
-	ctx := context.Background()
+	ctx := t.Context()
 	roTx, err := db.BeginRo(ctx)
 	require.NoError(t, err)
 	defer roTx.Rollback()
@@ -1189,7 +1189,7 @@ func TestDomain_PruneOnWrite(t *testing.T) {
 	keysCount, txCount := uint64(16), uint64(64)
 
 	db, d := testDbAndDomainOfStep(t, statecfg.Schema.AccountsDomain, 16, logger)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tx, err := db.BeginRw(ctx)
 	require.NoError(t, err)
@@ -1304,7 +1304,7 @@ func TestDomain_OpenFilesWithDeletions(t *testing.T) {
 
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	err := db.Update(ctx, func(tx kv.RwTx) error {
 		for step := kv.Step(0); step < kv.Step(txCount/dom.stepSize)-1; step++ {
@@ -1448,7 +1448,7 @@ func TestDomain_CollationBuildInMem(t *testing.T) {
 
 	maxTx := uint64(10000)
 	db, d := testDbAndDomainOfStep(t, statecfg.Schema.AccountsDomain, maxTx, log.New())
-	ctx := context.Background()
+	ctx := t.Context()
 	defer d.Close()
 
 	tx, err := db.BeginRw(ctx)
@@ -1542,7 +1542,7 @@ func TestDomainContext_getFromFiles(t *testing.T) {
 	defer db.Close()
 	defer d.Close()
 
-	tx, err := db.BeginRw(context.Background())
+	tx, err := db.BeginRw(t.Context())
 	require.NoError(t, err)
 	defer tx.Rollback()
 
@@ -1579,12 +1579,12 @@ func TestDomainContext_getFromFiles(t *testing.T) {
 			}
 		}
 	}
-	err = writer.Flush(context.Background(), tx)
+	err = writer.Flush(t.Context(), tx)
 	require.NoError(t, err)
 	defer domainRoTx.Close()
 
 	defer func(t time.Time) { fmt.Printf("domain_test.go:1243: %s\n", time.Since(t)) }(time.Now())
-	ctx := context.Background()
+	ctx := t.Context()
 	ps := background.NewProgressSet()
 
 	processStep := func(step kv.Step) {
@@ -1643,7 +1643,7 @@ type upd struct {
 func filledDomainFixedSize(t *testing.T, keysCount, txCount, aggStep uint64, logger log.Logger) (kv.RwDB, *Domain, map[uint64][]bool) {
 	t.Helper()
 	db, d := testDbAndDomainOfStep(t, statecfg.Schema.AccountsDomain, aggStep, logger)
-	ctx := context.Background()
+	ctx := t.Context()
 	tx, err := db.BeginRw(ctx)
 	require.NoError(t, err)
 	defer tx.Rollback()
@@ -1778,7 +1778,7 @@ func TestDomain_GetAfterAggregation(t *testing.T) {
 	db, d := testDbAndDomainOfStep(t, statecfg.Schema.AccountsDomain, 5, log.New())
 	require := require.New(t)
 
-	tx, err := db.BeginRw(context.Background())
+	tx, err := db.BeginRw(t.Context())
 	require.NoError(err)
 	defer tx.Rollback()
 
@@ -1810,14 +1810,14 @@ func TestDomain_GetAfterAggregation(t *testing.T) {
 		}
 	}
 
-	err = writer.Flush(context.Background(), tx)
+	err = writer.Flush(t.Context(), tx)
 	require.NoError(err)
 
 	// aggregate
 	collateAndMerge(t, tx, d, totalTx)
 	require.NoError(tx.Commit())
 
-	tx, err = db.BeginRw(context.Background())
+	tx, err = db.BeginRw(t.Context())
 	require.NoError(err)
 	defer tx.Rollback()
 	domainRoTx.Close()
@@ -1851,7 +1851,7 @@ func TestDomain_GetAfterAggregation(t *testing.T) {
 
 func TestDomainRange(t *testing.T) {
 	db, d := testDbAndDomainOfStep(t, statecfg.Schema.AccountsDomain, 25, log.New())
-	require, ctx := require.New(t), context.Background()
+	require, ctx := require.New(t), t.Context()
 
 	tx, err := db.BeginRw(ctx)
 	require.NoError(err)
@@ -1968,7 +1968,7 @@ func TestDomain_CanScanPruneAfterAggregation(t *testing.T) {
 
 	t.Parallel()
 
-	aggStep, ctx := uint64(5), context.Background()
+	aggStep, ctx := uint64(5), t.Context()
 	db, d := testDbAndDomainOfStep(t, statecfg.Schema.AccountsDomain, aggStep, log.New())
 
 	tx, err := db.BeginRw(ctx)
@@ -2000,11 +2000,11 @@ func TestDomain_CanScanPruneAfterAggregation(t *testing.T) {
 		}
 	}
 
-	err = writer.Flush(context.Background(), tx)
+	err = writer.Flush(t.Context(), tx)
 	require.NoError(t, err)
 	require.NoError(t, tx.Commit())
 
-	tx, err = db.BeginRw(context.Background())
+	tx, err = db.BeginRw(t.Context())
 	require.NoError(t, err)
 	defer tx.Rollback()
 	domainRoTx.Close()
@@ -2069,7 +2069,7 @@ func TestDomain_PruneAfterAggregation(t *testing.T) {
 	defer db.Close()
 	defer d.Close()
 
-	tx, err := db.BeginRw(context.Background())
+	tx, err := db.BeginRw(t.Context())
 	require.NoError(t, err)
 	defer tx.Rollback()
 
@@ -2101,7 +2101,7 @@ func TestDomain_PruneAfterAggregation(t *testing.T) {
 		}
 	}
 
-	err = writer.Flush(context.Background(), tx)
+	err = writer.Flush(t.Context(), tx)
 	require.NoError(t, err)
 
 	// aggregate
@@ -2109,7 +2109,7 @@ func TestDomain_PruneAfterAggregation(t *testing.T) {
 
 	require.NoError(t, tx.Commit())
 
-	tx, err = db.BeginRw(context.Background())
+	tx, err = db.BeginRw(t.Context())
 	require.NoError(t, err)
 	defer tx.Rollback()
 	domainRoTx.Close()
@@ -2151,7 +2151,7 @@ func TestPruneProgress(t *testing.T) {
 	latestKey := []byte("682c02b93b63aeb260eccc33705d584ffb5f0d4c")
 
 	t.Run("reset", func(t *testing.T) {
-		tx, err := db.BeginRw(context.Background())
+		tx, err := db.BeginRw(t.Context())
 		require.NoError(t, err)
 		defer tx.Rollback()
 		err = SaveExecV3PruneProgress(tx, kv.TblAccountVals, latestKey)
@@ -2169,7 +2169,7 @@ func TestPruneProgress(t *testing.T) {
 	})
 
 	t.Run("someKey and reset", func(t *testing.T) {
-		tx, err := db.BeginRw(context.Background())
+		tx, err := db.BeginRw(t.Context())
 		require.NoError(t, err)
 		defer tx.Rollback()
 		err = SaveExecV3PruneProgress(tx, kv.TblAccountVals, latestKey)
@@ -2188,7 +2188,7 @@ func TestPruneProgress(t *testing.T) {
 	})
 
 	t.Run("emptyKey and reset", func(t *testing.T) {
-		tx, err := db.BeginRw(context.Background())
+		tx, err := db.BeginRw(t.Context())
 		require.NoError(t, err)
 		defer tx.Rollback()
 		expected := []byte{}
@@ -2226,7 +2226,7 @@ func TestDomain_PruneProgress(t *testing.T) {
 		stepSize = uint64(1000)
 		keyCount = 200 // enough keys to make the midpoint test meaningful
 	)
-	ctx := context.Background()
+	ctx := t.Context()
 	db, d := testDbAndDomainOfStep(t, statecfg.Schema.AccountsDomain, stepSize, log.New())
 	d.HistoryLargeValues = false
 
@@ -2343,7 +2343,7 @@ func TestDomain_PruneRollingCursorProgress(t *testing.T) {
 		stepSize = uint64(16)
 		keyCount = 40
 	)
-	ctx := context.Background()
+	ctx := t.Context()
 	db, d := testDbAndDomainOfStep(t, statecfg.Schema.AccountsDomain, stepSize, log.New())
 	d.HistoryLargeValues = false
 
@@ -2448,7 +2448,7 @@ func TestDomain_Unwind(t *testing.T) {
 	db, d := testDbAndDomainOfStep(t, statecfg.Schema.AccountsDomain, 16, log.New())
 	defer d.Close()
 	defer db.Close()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	maxTx := d.stepSize - 2
 	currTx := maxTx - 1
@@ -2575,10 +2575,10 @@ func TestDomain_Unwind(t *testing.T) {
 			defer ectx.Close()
 			uc := d.beginForTests()
 			defer uc.Close()
-			et, err := ectx.RangeAsOf(context.Background(), etx, nil, nil, unwindTo, order.Asc, -1)
+			et, err := ectx.RangeAsOf(t.Context(), etx, nil, nil, unwindTo, order.Asc, -1)
 			require.NoError(t, err)
 
-			ut, err := uc.RangeAsOf(context.Background(), etx, nil, nil, unwindTo, order.Asc, -1)
+			ut, err := uc.RangeAsOf(t.Context(), etx, nil, nil, unwindTo, order.Asc, -1)
 			require.NoError(t, err)
 
 			compareIterators(t, et, ut)
@@ -2599,10 +2599,10 @@ func TestDomain_Unwind(t *testing.T) {
 			uc := d.beginForTests()
 			defer uc.Close()
 
-			et, err := ectx.ht.RangeAsOf(context.Background(), unwindTo-1, nil, nil, order.Asc, -1, etx)
+			et, err := ectx.ht.RangeAsOf(t.Context(), unwindTo-1, nil, nil, order.Asc, -1, etx)
 			require.NoError(t, err)
 
-			ut, err := uc.ht.RangeAsOf(context.Background(), unwindTo-1, nil, nil, order.Asc, -1, utx)
+			ut, err := uc.ht.RangeAsOf(t.Context(), unwindTo-1, nil, nil, order.Asc, -1, utx)
 			require.NoError(t, err)
 
 			compareIterators(t, et, ut)
@@ -2692,7 +2692,7 @@ func TestDomain_PruneSimple(t *testing.T) {
 	writeOneKey := func(t *testing.T, d *Domain, db kv.RwDB, maxTx, stepSize uint64) {
 		t.Helper()
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		domainRoTx := d.beginForTests()
 		defer domainRoTx.Close()
@@ -2717,7 +2717,7 @@ func TestDomain_PruneSimple(t *testing.T) {
 	pruneOneKeyHistory := func(t *testing.T, domainRoTx *DomainRoTx, db kv.RwDB, pruneFrom, pruneTo uint64) {
 		t.Helper()
 		// prune history
-		ctx := context.Background()
+		ctx := t.Context()
 		tx, err := db.BeginRw(ctx)
 		require.NoError(t, err)
 		defer tx.Rollback()
@@ -2730,7 +2730,7 @@ func TestDomain_PruneSimple(t *testing.T) {
 	pruneOneKeyDomain := func(t *testing.T, domainRoTx *DomainRoTx, db kv.RwDB, step kv.Step, pruneFrom, pruneTo uint64) {
 		t.Helper()
 		// prune
-		ctx := context.Background()
+		ctx := t.Context()
 		tx, err := db.BeginRw(ctx)
 		require.NoError(t, err)
 		defer tx.Rollback()
@@ -2743,7 +2743,7 @@ func TestDomain_PruneSimple(t *testing.T) {
 	checkKeyPruned := func(t *testing.T, domainRoTx *DomainRoTx, db kv.RwDB, stepSize, pruneFrom, pruneTo uint64) {
 		t.Helper()
 
-		ctx := context.Background()
+		ctx := t.Context()
 		tx, err := db.BeginRw(ctx)
 		require.NoError(t, err)
 		defer tx.Rollback()
@@ -2804,7 +2804,7 @@ func TestDomain_PruneSimple(t *testing.T) {
 		db, d := testDbAndDomainOfStep(t, statecfg.Schema.AccountsDomain, stepSize, log.New())
 		writeOneKey(t, d, db, 3*stepSize, stepSize)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		rotx, err := db.BeginRo(ctx)
 		require.NoError(t, err)
 		t.Cleanup(rotx.Rollback)
@@ -2861,7 +2861,7 @@ func TestDomainContext_findShortenedKey(t *testing.T) {
 	}
 
 	db, d := testDbAndDomainOfStep(t, statecfg.Schema.AccountsDomain, 5, log.New())
-	tx, err := db.BeginRw(context.Background())
+	tx, err := db.BeginRw(t.Context())
 	require.NoError(t, err)
 	defer tx.Rollback()
 
@@ -2887,7 +2887,7 @@ func TestDomainContext_findShortenedKey(t *testing.T) {
 		}
 	}
 
-	err = writer.Flush(context.Background(), tx)
+	err = writer.Flush(t.Context(), tx)
 	require.NoError(t, err)
 
 	// aggregate
@@ -2895,7 +2895,7 @@ func TestDomainContext_findShortenedKey(t *testing.T) {
 
 	require.NoError(t, tx.Commit())
 
-	tx, err = db.BeginRw(context.Background())
+	tx, err = db.BeginRw(t.Context())
 	require.NoError(t, err)
 	defer tx.Rollback()
 	domainRoTx.Close()
@@ -2943,7 +2943,7 @@ func TestDomainContext_findShortenedKey(t *testing.T) {
 
 func TestCanBuild(t *testing.T) {
 	db, d := testDbAndDomain(t, log.New())
-	tx, err := db.BeginRw(context.Background())
+	tx, err := db.BeginRw(t.Context())
 	require.NoError(t, err)
 	defer tx.Rollback()
 
@@ -2959,14 +2959,14 @@ func TestCanBuild(t *testing.T) {
 	k, v := []byte{1}, []byte{1}
 	// db has data which already in files
 	_ = writer.PutWithPrev(k, v, 0, nil)
-	_ = writer.Flush(context.Background(), tx)
+	_ = writer.Flush(t.Context(), tx)
 	canBuild := domainRoTx.canBuild(tx)
 	require.NoError(t, err)
 	require.False(t, canBuild)
 
 	// db has data which already in files and next step. still not enough - we need full step in db.
 	_ = writer.PutWithPrev(k, v, d.stepSize, nil)
-	_ = writer.Flush(context.Background(), tx)
+	_ = writer.Flush(t.Context(), tx)
 	canBuild = domainRoTx.canBuild(tx)
 	require.NoError(t, err)
 	require.False(t, canBuild)
@@ -2974,7 +2974,7 @@ func TestCanBuild(t *testing.T) {
 
 	// db has: 1. data which already in files 2. full next step 3. a bit of next-next step. -> can build
 	_ = writer.PutWithPrev(k, v, d.stepSize*2, nil)
-	_ = writer.Flush(context.Background(), tx)
+	_ = writer.Flush(t.Context(), tx)
 	canBuild = domainRoTx.canBuild(tx)
 	require.NoError(t, err)
 	require.True(t, canBuild)
@@ -2999,7 +2999,7 @@ func testTraceKey(t *testing.T, largeVals bool) {
 	logger := log.New()
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	db, d := testDbAndDomain(t, logger)
 	d.HistoryLargeValues = largeVals
@@ -3072,7 +3072,7 @@ func TestCommitmentDomain_DebugRangeLatest(t *testing.T) {
 	// testDbAndomainRoTxommitmentDomain creates a test domain with CommitmentDomain configuration.
 	// CommitmentDomain uses AccessorHashMap without enums (i.e. elias fano).
 	db, d := testDbAndDomainOfStep(t, statecfg.Schema.CommitmentDomain, 16, logger)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tx, err := db.BeginRw(ctx)
 	require.NoError(t, err)
@@ -3183,7 +3183,7 @@ func TestDomain_DebugRangeLatestFromFiles(t *testing.T) {
 
 	logger := log.New()
 	db, d := testDbAndDomainOfStep(t, statecfg.Schema.AccountsDomain, 16, logger)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tx, err := db.BeginRw(ctx)
 	require.NoError(t, err)
@@ -3337,7 +3337,7 @@ func TestDomain_IntegrateDirtyFilesNilGuard(t *testing.T) {
 
 	logger := log.New()
 	db, d := testDbAndDomain(t, logger) // stepSize=16, accounts domain
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// -- write data spanning steps 0 and 1 (txNums 1..32) --
 	tx, err := db.BeginRw(ctx)
@@ -3469,7 +3469,7 @@ func collateAndMergeWithCollisionRetry(t *testing.T, tx kv.RwTx, d *Domain, txs 
 	t.Helper()
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Collate without collision forcing first
 	for step := kv.Step(0); step < kv.Step(txs/d.stepSize)-1; step++ {
@@ -3508,7 +3508,7 @@ func TestDomain_KeyPosResetOnCollisionRetry(t *testing.T) {
 	logger := log.New()
 	db, d, txs := filledDomainWithHashMapAccessor(t, logger)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tx, err := db.BeginRw(ctx)
 	require.NoError(t, err)
 	defer tx.Rollback()
@@ -3566,7 +3566,7 @@ func TestDomain_DeletedKeyNotResurrectedByFiles(t *testing.T) {
 
 			logger := log.New()
 			db, d := testDbAndDomainOfStep(t, tc.domainCfg, 16, logger)
-			ctx := context.Background()
+			ctx := t.Context()
 			require := require.New(t)
 
 			tx, err := db.BeginRw(ctx)
@@ -3645,7 +3645,7 @@ func TestDomain_UnwindRestoresDeletionMarker(t *testing.T) {
 
 			logger := log.New()
 			db, d := testDbAndDomainOfStep(t, tc.domainCfg, 16, logger)
-			ctx := context.Background()
+			ctx := t.Context()
 			require := require.New(t)
 
 			// Phase 1: Write key1 through three states within step 0 and record diffs.

--- a/db/state/execctx/domain_shared_test.go
+++ b/db/state/execctx/domain_shared_test.go
@@ -82,7 +82,7 @@ func TestSharedDomain_Unwind(t *testing.T) {
 	db := newTestDb(t, stepSize)
 	//db := wrapDbWithCtx(_db, agg)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	rwTx, err := db.BeginTemporalRw(ctx)
 	require.NoError(t, err)
 	defer rwTx.Rollback()
@@ -192,7 +192,7 @@ func TestSharedDomain_UnwindDoesNotRestoreOverlayForNewKey(t *testing.T) {
 
 	stepSize := uint64(100)
 	db := newTestDb(t, stepSize)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	rwTx, err := db.BeginTemporalRw(ctx)
 	require.NoError(t, err)
@@ -266,7 +266,7 @@ func TestNewSharedDomains_StateAheadOfBlocks(t *testing.T) {
 	require := require.New(t)
 	db := newTestDb(t, stepSize)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Phase 1: write some accounts, compute commitment, flush, and append TxNums up to block N.
 	rwTx, err := db.BeginTemporalRw(ctx)
@@ -336,7 +336,7 @@ func TestSharedDomain_StorageIter(t *testing.T) {
 	db := newTestDb(t, stepSize)
 	//db := wrapDbWithCtx(_db, agg)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	rwTx, err := db.BeginTemporalRw(ctx)
 	require.NoError(t, err)
 	defer rwTx.Rollback()
@@ -480,7 +480,7 @@ func TestSharedDomain_IteratePrefix(t *testing.T) {
 	require := require.New(t)
 	db := newTestDb(t, stepSize)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	rwTx, err := db.BeginTemporalRw(ctx)
 	require.NoError(err)
 	defer rwTx.Rollback()
@@ -645,7 +645,7 @@ func TestSharedDomain_HasPrefix_StorageDomain(t *testing.T) {
 	}
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
 
 	stepSize := uint64(1)
@@ -916,7 +916,7 @@ func TestDomainPut_HistoryCorrectness(t *testing.T) {
 	for _, dc := range domainCases {
 		t.Run(dc.domain.String(), func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
+			ctx := t.Context()
 			stepSize := uint64(1000)
 			db := newTestDb(t, stepSize)
 
@@ -1032,7 +1032,7 @@ func TestDomainPut_HistoryCorrectness(t *testing.T) {
 func TestSharedDomain_TouchChangedKeysFromHistory(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
 
 	stepSize := uint64(1)

--- a/db/state/forkable_agg_test.go
+++ b/db/state/forkable_agg_test.go
@@ -30,12 +30,12 @@ func TestOpenFolder(t *testing.T) {
 	headerId, header := setupHeader(t, db, log, dirs)
 	bodyId, bodies := setupBodies(t, db, log, dirs)
 
-	agg := NewForkableAgg(context.Background(), dirs, db, log)
+	agg := NewForkableAgg(t.Context(), dirs, db, log)
 	defer agg.Close()
 	agg.RegisterMarkedForkable(header)
 	agg.RegisterMarkedForkable(bodies)
 
-	rwtx, err := db.BeginRw(context.Background())
+	rwtx, err := db.BeginRw(t.Context())
 	require.NoError(t, err)
 	defer rwtx.Rollback()
 
@@ -78,7 +78,7 @@ func TestOpenFolder(t *testing.T) {
 	aggTx.Close()
 	require.NoError(t, rwtx.Commit())
 
-	rwtx, err = db.BeginRw(context.Background())
+	rwtx, err = db.BeginRw(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(rwtx.Rollback)
 	checkGet(headerTx, bodyTx, rwtx)
@@ -105,7 +105,7 @@ func TestOpenFolder(t *testing.T) {
 		require.Equal(t, uint64(10*(i+1)), bodyItems[i].endTxNum)
 	}
 
-	rwtx, err = db.BeginRw(context.Background())
+	rwtx, err = db.BeginRw(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(rwtx.Rollback)
 
@@ -121,7 +121,7 @@ func TestOpenFolder(t *testing.T) {
 	require.NoError(t, rwtx.Commit())
 
 	agg.Close()
-	agg = NewForkableAgg(context.Background(), dirs, db, log)
+	agg = NewForkableAgg(t.Context(), dirs, db, log)
 	defer agg.Close()
 	agg.RegisterMarkedForkable(header)
 	agg.RegisterMarkedForkable(bodies)
@@ -149,12 +149,12 @@ func TestRecalcVisibleFilesAligned(t *testing.T) {
 	headerId, header := setupHeader(t, db, log, dirs)
 	bodyId, bodies := setupBodies(t, db, log, dirs)
 
-	agg := NewForkableAgg(context.Background(), dirs, db, log)
+	agg := NewForkableAgg(t.Context(), dirs, db, log)
 	defer agg.Close()
 	agg.RegisterMarkedForkable(header)
 	agg.RegisterMarkedForkable(bodies)
 
-	rwtx, err := db.BeginRw(context.Background())
+	rwtx, err := db.BeginRw(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(rwtx.Rollback)
 
@@ -190,7 +190,7 @@ func TestRecalcVisibleFilesAligned(t *testing.T) {
 
 	// now open folder and check visiblefiles
 	agg.Close()
-	agg = NewForkableAgg(context.Background(), dirs, db, log)
+	agg = NewForkableAgg(t.Context(), dirs, db, log)
 	defer agg.Close()
 	agg.RegisterMarkedForkable(header)
 	agg.RegisterMarkedForkable(bodies)
@@ -210,12 +210,12 @@ func TestRecalcVisibleFilesUnaligned(t *testing.T) {
 	bodyId, bodies := setupBodies(t, db, log, dirs)
 	bodies.unaligned = true
 
-	agg := NewForkableAgg(context.Background(), dirs, db, log)
+	agg := NewForkableAgg(t.Context(), dirs, db, log)
 	defer agg.Close()
 	agg.RegisterMarkedForkable(header)
 	agg.RegisterMarkedForkable(bodies)
 
-	rwtx, err := db.BeginRw(context.Background())
+	rwtx, err := db.BeginRw(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(rwtx.Rollback)
 
@@ -252,7 +252,7 @@ func TestRecalcVisibleFilesUnaligned(t *testing.T) {
 
 	// now open folder and check visiblefiles
 	agg.Close()
-	agg = NewForkableAgg(context.Background(), dirs, db, log)
+	agg = NewForkableAgg(t.Context(), dirs, db, log)
 	defer agg.Close()
 	agg.RegisterMarkedForkable(header)
 	agg.RegisterMarkedForkable(bodies)
@@ -270,7 +270,7 @@ func TestRecalcVisibleFilesUnaligned(t *testing.T) {
 	bodies.freezer = bfreezer
 
 	agg.Close()
-	agg = NewForkableAgg(context.Background(), dirs, db, log)
+	agg = NewForkableAgg(t.Context(), dirs, db, log)
 	defer agg.Close()
 	agg.RegisterMarkedForkable(header)
 	agg.RegisterMarkedForkable(bodies)
@@ -297,12 +297,12 @@ func TestClose(t *testing.T) {
 	bodyId, bodies := setupBodies(t, db, log, dirs)
 	bodies.unaligned = true
 
-	agg := NewForkableAgg(context.Background(), dirs, db, log)
+	agg := NewForkableAgg(t.Context(), dirs, db, log)
 	defer agg.Close()
 	agg.RegisterMarkedForkable(header)
 	agg.RegisterMarkedForkable(bodies)
 
-	rwtx, err := db.BeginRw(context.Background())
+	rwtx, err := db.BeginRw(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(rwtx.Rollback)
 
@@ -358,12 +358,12 @@ func TestMergedFileGet(t *testing.T) {
 	headerId, header := setupHeader(t, db, log, dirs)
 	bodyId, bodies := setupBodies(t, db, log, dirs)
 
-	agg := NewForkableAgg(context.Background(), dirs, db, log)
+	agg := NewForkableAgg(t.Context(), dirs, db, log)
 	defer agg.Close()
 	agg.RegisterMarkedForkable(header)
 	agg.RegisterMarkedForkable(bodies)
 
-	rwtx, err := db.BeginRw(context.Background())
+	rwtx, err := db.BeginRw(t.Context())
 	require.NoError(t, err)
 	defer rwtx.Rollback()
 
@@ -407,7 +407,7 @@ func TestMergedFileGet(t *testing.T) {
 	aggTx.Close()
 	require.NoError(t, rwtx.Commit())
 
-	rwtx, err = db.BeginRw(context.Background())
+	rwtx, err = db.BeginRw(t.Context())
 	require.NoError(t, err)
 	defer rwtx.Rollback()
 	checkGet(headerTx, bodyTx, rwtx)
@@ -433,7 +433,7 @@ func TestMergedFileGet(t *testing.T) {
 
 	aggTx = agg.BeginTemporalTx()
 	defer aggTx.Close()
-	rwtx, err = db.BeginRw(context.Background())
+	rwtx, err = db.BeginRw(t.Context())
 	require.NoError(t, err)
 	defer rwtx.Rollback()
 	headerTx, bodyTx = aggTx.Marked(headerId), aggTx.Marked(bodyId)
@@ -630,7 +630,7 @@ func TestUnmarkedForkableUnwindDeletesVals(t *testing.T) {
 	require.NoError(t, err)
 	defer unmarked.Close()
 
-	rwtx, err := db.BeginRw(context.Background())
+	rwtx, err := db.BeginRw(t.Context())
 	require.NoError(t, err)
 	defer rwtx.Rollback()
 
@@ -643,7 +643,7 @@ func TestUnmarkedForkableUnwindDeletesVals(t *testing.T) {
 	}
 
 	from := RootNum(5)
-	fs, err := unmarkedTx.Unwind(context.Background(), from, rwtx)
+	fs, err := unmarkedTx.Unwind(t.Context(), from, rwtx)
 	require.NoError(t, err)
 	require.Greater(t, fs.PruneCount, uint64(0))
 

--- a/db/state/gc_test.go
+++ b/db/state/gc_test.go
@@ -17,7 +17,6 @@
 package state
 
 import (
-	"context"
 	"testing"
 	"time"
 

--- a/db/state/gc_test.go
+++ b/db/state/gc_test.go
@@ -35,7 +35,7 @@ func TestGCReadAfterRemoveFile(t *testing.T) {
 	logger := log.New()
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	test := func(t *testing.T, h *History, db kv.RwDB, txs uint64) {
 		t.Helper()
@@ -129,7 +129,7 @@ func TestDomainGCReadAfterRemoveFile(t *testing.T) {
 
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	test := func(t *testing.T, h *Domain, db kv.RwDB, txs uint64) {
 		t.Helper()

--- a/db/state/history_key_txnum_range_test.go
+++ b/db/state/history_key_txnum_range_test.go
@@ -75,7 +75,7 @@ func TestHistoryKeyTxNumRange(t *testing.T) {
 	t.Parallel()
 
 	logger := log.New()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	test := func(t *testing.T, h *History, db kv.RwDB, txs uint64) {
 		t.Helper()
@@ -126,7 +126,7 @@ func TestHistoryKeyTxNumRange_EdgeCases(t *testing.T) {
 	t.Parallel()
 
 	logger := log.New()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	test := func(t *testing.T, h *History, db kv.RwDB, txs uint64) {
 		t.Helper()
@@ -205,7 +205,7 @@ func TestHistoryKeyTxNumRange_DBOnly(t *testing.T) {
 	t.Parallel()
 
 	logger := log.New()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	test := func(t *testing.T, h *History, db kv.RwDB, txs uint64) {
 		t.Helper()
@@ -248,7 +248,7 @@ func TestHistoryKeyTxNumRange_RandomRanges(t *testing.T) {
 	t.Parallel()
 
 	logger := log.New()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	test := func(t *testing.T, h *History, db kv.RwDB, txs uint64) {
 		t.Helper()

--- a/db/state/history_key_txnum_range_test.go
+++ b/db/state/history_key_txnum_range_test.go
@@ -17,7 +17,6 @@
 package state
 
 import (
-	"context"
 	"encoding/binary"
 	"fmt"
 	"math/rand"

--- a/db/state/history_test.go
+++ b/db/state/history_test.go
@@ -828,7 +828,7 @@ func filledHistoryValues(tb testing.TB, largeValues bool, values map[string][]up
 	tb.Cleanup(db.Close)
 	tb.Cleanup(h.Close)
 
-	ctx := t.Context()
+	ctx := tb.Context()
 	//tx, err := db.BeginRw(ctx)
 	//require.NoError(tb, err)
 	//defer tx.Rollback()
@@ -872,7 +872,7 @@ func filledHistoryValues(tb testing.TB, largeValues bool, values map[string][]up
 func filledHistory(tb testing.TB, largeValues bool, logger log.Logger) (kv.RwDB, *History, uint64) {
 	tb.Helper()
 	db, h := testDbAndHistory(tb, largeValues, logger)
-	ctx := t.Context()
+	ctx := tb.Context()
 	tx, err := db.BeginRw(ctx)
 	require.NoError(tb, err)
 	defer tx.Rollback()
@@ -1179,7 +1179,7 @@ func collateAndMergeHistory(tb testing.TB, db kv.RwDB, h *History, txs uint64, d
 
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
-	ctx := t.Context()
+	ctx := tb.Context()
 	tx, err := db.BeginRwNosync(ctx)
 	require.NoError(err)
 	defer tx.Rollback()
@@ -1230,7 +1230,7 @@ func collateAndMergeHistoryWithCollisionRetry(tb testing.TB, db kv.RwDB, h *Hist
 
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
-	ctx := t.Context()
+	ctx := tb.Context()
 	tx, err := db.BeginRwNosync(ctx)
 	require.NoError(err)
 	defer tx.Rollback()
@@ -1757,7 +1757,7 @@ func TestScanStaticFilesH(t *testing.T) {
 func writeSomeHistory(tb testing.TB, largeValues bool, logger log.Logger) (kv.RwDB, *History, [][]byte, uint64) {
 	tb.Helper()
 	db, h := testDbAndHistory(tb, largeValues, logger)
-	ctx := t.Context()
+	ctx := tb.Context()
 	tx, err := db.BeginRw(ctx)
 	require.NoError(tb, err)
 	defer tx.Rollback()
@@ -2399,7 +2399,7 @@ func TestHistory_IterateChangedRecent_PhantomDBKey(t *testing.T) {
 // across a wide txNum range from segment files (exercises HistoryChangesIterFiles.advance).
 func BenchmarkHistoryRange(b *testing.B) {
 	logger := log.New()
-	ctx := t.Context()
+	ctx := b.Context()
 
 	db, h, txs := filledHistory(b, true, logger)
 	collateAndMergeHistory(b, db, h, txs, true)
@@ -2428,7 +2428,7 @@ func BenchmarkHistoryRange(b *testing.B) {
 // from segment files (exercises HistoryRangeAsOfFiles.advanceInFiles).
 func BenchmarkRangeAsOf(b *testing.B) {
 	logger := log.New()
-	ctx := t.Context()
+	ctx := b.Context()
 
 	db, h, txs := filledHistory(b, true, logger)
 	collateAndMergeHistory(b, db, h, txs, true)
@@ -2459,7 +2459,7 @@ func BenchmarkRangeAsOf(b *testing.B) {
 // This leaves many small files in the heap, exercising heap operations during iteration.
 func collateHistory(b *testing.B, db kv.RwDB, h *History, txs uint64) {
 	b.Helper()
-	ctx := t.Context()
+	ctx := b.Context()
 	tx, err := db.BeginRwNosync(ctx)
 	require.NoError(b, err)
 	defer tx.Rollback()
@@ -2473,7 +2473,7 @@ func collateHistory(b *testing.B, db kv.RwDB, h *History, txs uint64) {
 // step-files unmerged so the heap has ~60 elements, actually exercising heap ops.
 func BenchmarkHistoryRange_MultiFile(b *testing.B) {
 	logger := log.New()
-	ctx := t.Context()
+	ctx := b.Context()
 
 	db, h, txs := filledHistory(b, true, logger)
 	collateHistory(b, db, h, txs)
@@ -2502,7 +2502,7 @@ func BenchmarkHistoryRange_MultiFile(b *testing.B) {
 // step-files unmerged so the heap has ~60 elements, actually exercising heap ops.
 func BenchmarkRangeAsOf_MultiFile(b *testing.B) {
 	logger := log.New()
-	ctx := t.Context()
+	ctx := b.Context()
 
 	db, h, txs := filledHistory(b, true, logger)
 	collateHistory(b, db, h, txs)

--- a/db/state/history_test.go
+++ b/db/state/history_test.go
@@ -92,7 +92,7 @@ func TestHistoryCollationsAndBuilds(t *testing.T) {
 		db, h := filledHistoryValues(t, largeValues, values, log.New())
 		defer db.Close()
 
-		ctx := context.Background()
+		ctx := t.Context()
 		rwtx, err := db.BeginRw(ctx)
 		require.NoError(t, err)
 		defer rwtx.Rollback()
@@ -189,7 +189,7 @@ func TestHistoryCollationBuild(t *testing.T) {
 	logger := log.New()
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	test := func(t *testing.T, h *History, db kv.RwDB) {
 		t.Helper()
@@ -360,7 +360,7 @@ func TestHistoryAfterPrune(t *testing.T) {
 	logger := log.New()
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
-	ctx := context.Background()
+	ctx := t.Context()
 	test := func(t *testing.T, h *History, db kv.RwDB) {
 		t.Helper()
 		require := require.New(t)
@@ -425,7 +425,7 @@ func TestHistoryRangeWithPrune(t *testing.T) {
 	logger := log.New()
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	db, h, _ := filledHistory(t, true, logger)
 	collateAndMergeHistory(t, db, h, 32, true)
@@ -479,7 +479,7 @@ func TestHistoryAsOfWithPrune(t *testing.T) {
 	logger := log.New()
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	db, h, _ := filledHistory(t, true, logger)
 	collateAndMergeHistory(t, db, h, 200, false)
@@ -534,7 +534,7 @@ func TestHistoryCanPrune(t *testing.T) {
 	logger := log.New()
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	stepsTotal := uint64(4)
 	stepKeepInDB := uint64(1)
@@ -587,7 +587,7 @@ func TestHistoryCanPrune(t *testing.T) {
 			defer db.Close()
 			writeKey(t, h, db)
 
-			rwTx, err := db.BeginRw(context.Background())
+			rwTx, err := db.BeginRw(t.Context())
 			require.NoError(t, err)
 			defer rwTx.Rollback()
 
@@ -605,7 +605,7 @@ func TestHistoryCanPrune(t *testing.T) {
 				} else {
 					require.Truef(t, cp, "step %d should be prunable", i)
 				}
-				stat, err := hc.Prune(context.Background(), rwTx, i*h.stepSize, (i+1)*h.stepSize, math.MaxUint64, false, logEvery)
+				stat, err := hc.Prune(t.Context(), rwTx, i*h.stepSize, (i+1)*h.stepSize, math.MaxUint64, false, logEvery)
 				require.NoError(t, err)
 				if i >= stepsTotal-stepKeepInDB {
 					require.Falsef(t, cp, "step %d should be NOT prunable", i)
@@ -626,7 +626,7 @@ func TestHistoryCanPrune(t *testing.T) {
 
 		writeKey(t, h, db)
 
-		rwTx, err := db.BeginRw(context.Background())
+		rwTx, err := db.BeginRw(t.Context())
 		require.NoError(t, err)
 		defer rwTx.Rollback()
 
@@ -643,7 +643,7 @@ func TestHistoryCanPrune(t *testing.T) {
 			} else {
 				require.Truef(t, cp, "step %d should be prunable", i)
 			}
-			stat, err := hc.Prune(context.Background(), rwTx, i*h.stepSize, (i+1)*h.stepSize, math.MaxUint64, false, logEvery)
+			stat, err := hc.Prune(t.Context(), rwTx, i*h.stepSize, (i+1)*h.stepSize, math.MaxUint64, false, logEvery)
 			require.NoError(t, err)
 			if i >= stepsTotal-stepKeepInDB {
 				require.Falsef(t, cp, "step %d should be NOT prunable", i)
@@ -672,7 +672,7 @@ func TestHistoryPruneCorrectnessWithFiles(t *testing.T) {
 		logEvery := time.NewTicker(30 * time.Second)
 		t.Cleanup(logEvery.Stop)
 
-		rwTx, err := db.BeginRw(context.Background())
+		rwTx, err := db.BeginRw(t.Context())
 		require.NoError(t, err)
 		t.Cleanup(rwTx.Rollback)
 
@@ -714,21 +714,21 @@ func TestHistoryPruneCorrectnessWithFiles(t *testing.T) {
 		canHist, txTo := hc.canPruneUntil(rwTx, math.MaxUint64)
 		t.Logf("canPrune=%t [%s] to=%d", canHist, hc.h.KeysTable, txTo)
 
-		stat, err := hc.Prune(context.Background(), rwTx, 0, txTo, 50, false, logEvery)
+		stat, err := hc.Prune(t.Context(), rwTx, 0, txTo, 50, false, logEvery)
 		require.NoError(t, err)
 		require.NotNil(t, stat)
 		t.Logf("stat=%v", stat)
 
-		stat, err = hc.Prune(context.Background(), rwTx, 0, 600, 500, false, logEvery)
+		stat, err = hc.Prune(t.Context(), rwTx, 0, 600, 500, false, logEvery)
 		require.NoError(t, err)
 		require.NotNil(t, stat)
 		t.Logf("stat=%v", stat)
 
-		stat, err = hc.Prune(context.Background(), rwTx, 0, 600, 10, true, logEvery)
+		stat, err = hc.Prune(t.Context(), rwTx, 0, 600, 10, true, logEvery)
 		require.NoError(t, err)
 		t.Logf("stat=%v", stat)
 
-		stat, err = hc.Prune(context.Background(), rwTx, 0, 600, 10, false, logEvery)
+		stat, err = hc.Prune(t.Context(), rwTx, 0, 600, 10, false, logEvery)
 		require.NoError(t, err)
 		t.Logf("stat=%v", stat)
 
@@ -755,7 +755,7 @@ func TestHistoryPruneCorrectness(t *testing.T) {
 		logEvery := time.NewTicker(30 * time.Second)
 		t.Cleanup(logEvery.Stop)
 
-		rwTx, err := db.BeginRw(context.Background())
+		rwTx, err := db.BeginRw(t.Context())
 		require.NoError(t, err)
 		t.Cleanup(rwTx.Rollback)
 
@@ -788,12 +788,12 @@ func TestHistoryPruneCorrectness(t *testing.T) {
 		defer hc.Close()
 
 		// should not prune anything: forced=false but no files built
-		stat, err := hc.Prune(context.Background(), rwTx, 0, 10, pruneLimit, false, logEvery)
+		stat, err := hc.Prune(t.Context(), rwTx, 0, 10, pruneLimit, false, logEvery)
 		require.NoError(t, err)
 		require.Nil(t, stat)
 
 		// should prune tx=0: range [0,1) forced=true
-		stat, err = hc.Prune(context.Background(), rwTx, 0, 1, MaxUint64, true, logEvery)
+		stat, err = hc.Prune(t.Context(), rwTx, 0, 1, MaxUint64, true, logEvery)
 		require.NoError(t, err)
 		require.EqualValues(t, 1, stat.PruneCountValues)
 		require.EqualValues(t, 1, stat.PruneCountTx)
@@ -801,7 +801,7 @@ func TestHistoryPruneCorrectness(t *testing.T) {
 		//TODO: figure out pretty way to deal with it.
 		//// prune exactly pruneLimit*pruneIters transactions
 		//for i := 0; i < pruneIters; i++ {
-		//	stat, err = hc.Prune(context.Background(), rwTx, 0, 1000, pruneLimit, true, logEvery)
+		//	stat, err = hc.Prune(t.Context(), rwTx, 0, 1000, pruneLimit, true, logEvery)
 		//	require.NoError(t, err)
 		//	t.Logf("[%d] stats: %v", i, stat)
 		//}
@@ -828,7 +828,7 @@ func filledHistoryValues(tb testing.TB, largeValues bool, values map[string][]up
 	tb.Cleanup(db.Close)
 	tb.Cleanup(h.Close)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	//tx, err := db.BeginRw(ctx)
 	//require.NoError(tb, err)
 	//defer tx.Rollback()
@@ -872,7 +872,7 @@ func filledHistoryValues(tb testing.TB, largeValues bool, values map[string][]up
 func filledHistory(tb testing.TB, largeValues bool, logger log.Logger) (kv.RwDB, *History, uint64) {
 	tb.Helper()
 	db, h := testDbAndHistory(tb, largeValues, logger)
-	ctx := context.Background()
+	ctx := t.Context()
 	tx, err := db.BeginRw(ctx)
 	require.NoError(tb, err)
 	defer tx.Rollback()
@@ -1179,7 +1179,7 @@ func collateAndMergeHistory(tb testing.TB, db kv.RwDB, h *History, txs uint64, d
 
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
-	ctx := context.Background()
+	ctx := t.Context()
 	tx, err := db.BeginRwNosync(ctx)
 	require.NoError(err)
 	defer tx.Rollback()
@@ -1230,7 +1230,7 @@ func collateAndMergeHistoryWithCollisionRetry(tb testing.TB, db kv.RwDB, h *Hist
 
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
-	ctx := context.Background()
+	ctx := t.Context()
 	tx, err := db.BeginRwNosync(ctx)
 	require.NoError(err)
 	defer tx.Rollback()
@@ -1351,7 +1351,7 @@ func TestHistoryRange1(t *testing.T) {
 	logger := log.New()
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	test := func(t *testing.T, h *History, db kv.RwDB, txs uint64) {
 		t.Helper()
@@ -1512,7 +1512,7 @@ func TestHistoryRange2(t *testing.T) {
 	logger := log.New()
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	test := func(t *testing.T, h *History, db kv.RwDB, txs uint64) {
 		t.Helper()
@@ -1757,7 +1757,7 @@ func TestScanStaticFilesH(t *testing.T) {
 func writeSomeHistory(tb testing.TB, largeValues bool, logger log.Logger) (kv.RwDB, *History, [][]byte, uint64) {
 	tb.Helper()
 	db, h := testDbAndHistory(tb, largeValues, logger)
-	ctx := context.Background()
+	ctx := t.Context()
 	tx, err := db.BeginRw(ctx)
 	require.NoError(tb, err)
 	defer tx.Rollback()
@@ -1829,7 +1829,7 @@ func Test_HistoryIterate_VariousKeysLen(t *testing.T) {
 	logger := log.New()
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	test := func(t *testing.T, h *History, db kv.RwDB, writtenKeys [][]byte, txs uint64) {
 		t.Helper()
@@ -1918,7 +1918,7 @@ func TestHistoryRange_DBOnly(t *testing.T) {
 	t.Parallel()
 
 	logger := log.New()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	test := func(t *testing.T, h *History, db kv.RwDB) {
 		t.Helper()
@@ -2007,7 +2007,7 @@ func TestRangeAsOf_ValuesMatchHistorySeek(t *testing.T) {
 	t.Parallel()
 
 	logger := log.New()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	test := func(t *testing.T, h *History, db kv.RwDB, txs uint64) {
 		t.Helper()
@@ -2101,7 +2101,7 @@ func TestRangeAsOf_DBIteratorSkipsFileRange(t *testing.T) {
 	t.Parallel()
 
 	logger := log.New()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	test := func(t *testing.T, largeValues bool) {
 		t.Helper()
@@ -2172,7 +2172,7 @@ func TestHistoryRange_EmptyRange(t *testing.T) {
 	t.Parallel()
 
 	logger := log.New()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	test := func(t *testing.T, h *History, db kv.RwDB, txs uint64) {
 		t.Helper()
@@ -2231,7 +2231,7 @@ func TestHistory_IterateChangedRecent_SkipsFileRange(t *testing.T) {
 	t.Parallel()
 
 	logger := log.New()
-	ctx := context.Background()
+	ctx := t.Context()
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
 
@@ -2324,7 +2324,7 @@ func TestHistory_IterateChangedRecent_PhantomDBKey(t *testing.T) {
 	t.Parallel()
 
 	logger := log.New()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	test := func(t *testing.T, largeValues bool) {
 		t.Helper()
@@ -2399,7 +2399,7 @@ func TestHistory_IterateChangedRecent_PhantomDBKey(t *testing.T) {
 // across a wide txNum range from segment files (exercises HistoryChangesIterFiles.advance).
 func BenchmarkHistoryRange(b *testing.B) {
 	logger := log.New()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	db, h, txs := filledHistory(b, true, logger)
 	collateAndMergeHistory(b, db, h, txs, true)
@@ -2428,7 +2428,7 @@ func BenchmarkHistoryRange(b *testing.B) {
 // from segment files (exercises HistoryRangeAsOfFiles.advanceInFiles).
 func BenchmarkRangeAsOf(b *testing.B) {
 	logger := log.New()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	db, h, txs := filledHistory(b, true, logger)
 	collateAndMergeHistory(b, db, h, txs, true)
@@ -2459,7 +2459,7 @@ func BenchmarkRangeAsOf(b *testing.B) {
 // This leaves many small files in the heap, exercising heap operations during iteration.
 func collateHistory(b *testing.B, db kv.RwDB, h *History, txs uint64) {
 	b.Helper()
-	ctx := context.Background()
+	ctx := t.Context()
 	tx, err := db.BeginRwNosync(ctx)
 	require.NoError(b, err)
 	defer tx.Rollback()
@@ -2473,7 +2473,7 @@ func collateHistory(b *testing.B, db kv.RwDB, h *History, txs uint64) {
 // step-files unmerged so the heap has ~60 elements, actually exercising heap ops.
 func BenchmarkHistoryRange_MultiFile(b *testing.B) {
 	logger := log.New()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	db, h, txs := filledHistory(b, true, logger)
 	collateHistory(b, db, h, txs)
@@ -2502,7 +2502,7 @@ func BenchmarkHistoryRange_MultiFile(b *testing.B) {
 // step-files unmerged so the heap has ~60 elements, actually exercising heap ops.
 func BenchmarkRangeAsOf_MultiFile(b *testing.B) {
 	logger := log.New()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	db, h, txs := filledHistory(b, true, logger)
 	collateHistory(b, db, h, txs)

--- a/db/state/integrity_checker_test.go
+++ b/db/state/integrity_checker_test.go
@@ -173,7 +173,7 @@ func getPopulatedCommitmentFilesItem(t *testing.T, dirs datadir.Dirs, startTxNum
 	t.Helper()
 
 	base := fmt.Sprintf(dirs.Snap+"/commitment.%d-%d", startTxNum, endTxNum)
-	comp, err := seg.NewCompressor(context.Background(), "", base+"data", dirs.Tmp, seg.DefaultCfg, log.LvlInfo, logger)
+	comp, err := seg.NewCompressor(t.Context(), "", base+"data", dirs.Tmp, seg.DefaultCfg, log.LvlInfo, logger)
 	require.NoError(t, err)
 	require.NotNil(t, comp)
 	defer comp.Close()
@@ -201,7 +201,7 @@ func getPopulatedCommitmentFilesItem(t *testing.T, dirs datadir.Dirs, startTxNum
 		require.NotNil(t, index)
 		defer index.Close()
 
-		require.NoError(t, index.Build(context.Background()))
+		require.NoError(t, index.Build(t.Context()))
 
 		idx0 = recsplit.MustOpen(base + "index")
 		t.Cleanup(idx0.Close)

--- a/db/state/integrity_checker_test.go
+++ b/db/state/integrity_checker_test.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"context"
 	"fmt"
 	"testing"
 

--- a/db/state/inverted_index_test.go
+++ b/db/state/inverted_index_test.go
@@ -724,7 +724,7 @@ func filledInvIndex(tb testing.TB, logger log.Logger) (kv.RwDB, *InvertedIndex, 
 func filledInvIndexOfSize(tb testing.TB, txs, aggStep, module uint64, logger log.Logger) (kv.RwDB, *InvertedIndex, uint64) {
 	tb.Helper()
 	db, ii := testDbAndInvertedIndex(tb, aggStep, logger)
-	ctx, require := t.Context(), require.New(tb)
+	ctx, require := tb.Context(), require.New(tb)
 
 	err := db.Update(ctx, func(tx kv.RwTx) error {
 		ic := ii.beginForTests()
@@ -871,7 +871,7 @@ func mergeInverted(tb testing.TB, db kv.RwDB, ii *InvertedIndex, txs uint64) {
 	tb.Helper()
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
-	ctx := t.Context()
+	ctx := tb.Context()
 	// Leave the last 2 aggregation steps un-collated
 	tx, err := db.BeginRw(ctx)
 	require.NoError(tb, err)

--- a/db/state/inverted_index_test.go
+++ b/db/state/inverted_index_test.go
@@ -98,7 +98,7 @@ func TestInvIndexPruningCorrectness(t *testing.T) {
 		db, ii, _ := filledInvIndexOfSize(t, 1000, 16, 1, log.New())
 		t.Cleanup(func() { ii.Close(); db.Close() })
 
-		tx, err := db.BeginRw(context.Background())
+		tx, err := db.BeginRw(t.Context())
 		require.NoError(t, err)
 		t.Cleanup(tx.Rollback)
 
@@ -135,13 +135,13 @@ func TestInvIndexPruningCorrectness(t *testing.T) {
 			require.Equal(t, count, pruneIters*int(pruneLimit))
 
 			// this one should not prune anything due to forced=false but no files built
-			stat, err := ic.HashSeekingPrune(context.Background(), tx, 0, 10, pruneLimit, logEvery, false, nil, nil, prune.DefaultStorageMode)
+			stat, err := ic.HashSeekingPrune(t.Context(), tx, 0, 10, pruneLimit, logEvery, false, nil, nil, prune.DefaultStorageMode)
 			require.NoError(t, err)
 			require.Zero(t, stat.PruneCountTx)
 			require.Zero(t, stat.PruneCountValues)
 
 			// this one should not prune anything as well due to given range [0,1) even it is forced
-			stat, err = ic.HashSeekingPrune(context.Background(), tx, 0, 1, pruneLimit, logEvery, true, nil, nil, prune.DefaultStorageMode)
+			stat, err = ic.HashSeekingPrune(t.Context(), tx, 0, 1, pruneLimit, logEvery, true, nil, nil, prune.DefaultStorageMode)
 			require.NoError(t, err)
 			require.Zero(t, stat.PruneCountTx)
 			require.Zero(t, stat.PruneCountValues)
@@ -150,9 +150,9 @@ func TestInvIndexPruningCorrectness(t *testing.T) {
 		})
 
 		t.Run("retire_one_step_no_force", func(t *testing.T) {
-			collation, err := ii.collate(context.Background(), 0, tx)
+			collation, err := ii.collate(t.Context(), 0, tx)
 			require.NoError(t, err)
-			sf, _ := ii.buildFiles(context.Background(), 0, collation, background.NewProgressSet())
+			sf, _ := ii.buildFiles(t.Context(), 0, collation, background.NewProgressSet())
 			collation.Close()
 			txFrom, txTo := firstTxNumOfStep(0, ii.stepSize), firstTxNumOfStep(1, ii.stepSize)
 
@@ -161,20 +161,20 @@ func TestInvIndexPruningCorrectness(t *testing.T) {
 			defer ic.Close()
 
 			ii.integrateDirtyFiles(sf, txFrom, txTo)
-			stat, err := ic.HashSeekingPrune(context.Background(), tx, 0, 10, pruneLimit, logEvery, false, nil, nil, prune.DefaultStorageMode)
+			stat, err := ic.HashSeekingPrune(t.Context(), tx, 0, 10, pruneLimit, logEvery, false, nil, nil, prune.DefaultStorageMode)
 			require.NoError(t, err)
 			require.Zero(t, stat.PruneCountTx)
 			require.Zero(t, stat.PruneCountValues)
 
 			ic = ii.beginForTests()
 			defer ic.Close()
-			stat, err = ic.HashSeekingPrune(context.Background(), tx, 0, 10, pruneLimit, logEvery, false, nil, nil, prune.DefaultStorageMode)
+			stat, err = ic.HashSeekingPrune(t.Context(), tx, 0, 10, pruneLimit, logEvery, false, nil, nil, prune.DefaultStorageMode)
 			require.NoError(t, err)
 			require.Equal(t, 9, int(stat.PruneCountTx))
 			require.Equal(t, 9, int(stat.PruneCountValues))
 
 			// prune only what left in step 0. Even if requested more. don't allow print more than what we have in visible files
-			stat, err = ic.HashSeekingPrune(context.Background(), tx, 0, 20, pruneLimit, logEvery, false, nil, nil, prune.DefaultStorageMode)
+			stat, err = ic.HashSeekingPrune(t.Context(), tx, 0, 20, pruneLimit, logEvery, false, nil, nil, prune.DefaultStorageMode)
 			require.NoError(t, err)
 			require.Equal(t, 6, int(stat.PruneCountTx))
 			require.Equal(t, 6, int(stat.PruneCountValues))
@@ -186,7 +186,7 @@ func TestInvIndexPruningCorrectness(t *testing.T) {
 
 			// this should prune exactly pruneLimit*pruneIter transactions
 			for i := 0; i < pruneIters; i++ {
-				stat, err := ic.HashSeekingPrune(context.Background(), tx, 0, 1000, pruneLimit, logEvery, true, nil, nil, prune.DefaultStorageMode)
+				stat, err := ic.HashSeekingPrune(t.Context(), tx, 0, 1000, pruneLimit, logEvery, true, nil, nil, prune.DefaultStorageMode)
 				require.NoError(t, err)
 				t.Logf("[%d] stats: %v", i, stat)
 			}
@@ -235,7 +235,7 @@ func TestInvIndexPruningCorrectness(t *testing.T) {
 		t.Parallel()
 		ii, tx, logEvery, from, to := setup(t)
 		thr := time.Millisecond * 20
-		ctx := context.WithValue(context.Background(), throttle, &thr)
+		ctx := context.WithValue(t.Context(), throttle, &thr)
 
 		t.Run("no_files_no_force", func(t *testing.T) {
 			ic := ii.beginForTests()
@@ -283,10 +283,10 @@ func TestInvIndexPruningCorrectness(t *testing.T) {
 		})
 
 		t.Run("prune was in progress", func(t *testing.T) {
-			collation, err := ii.collate(context.Background(), 0, tx)
+			collation, err := ii.collate(t.Context(), 0, tx)
 			require.NoError(t, err)
 			defer collation.Close()
-			sf, _ := ii.buildFiles(context.Background(), 0, collation, background.NewProgressSet())
+			sf, _ := ii.buildFiles(t.Context(), 0, collation, background.NewProgressSet())
 			defer sf.CleanupOnError()
 			txFrom, txTo := firstTxNumOfStep(0, ii.stepSize), firstTxNumOfStep(1, ii.stepSize)
 
@@ -317,10 +317,10 @@ func TestInvIndexPruningCorrectness(t *testing.T) {
 		t.Run("prune was done", func(t *testing.T) {
 			ii, tx, logEvery, _, _ := setup(t)
 
-			collation, err := ii.collate(context.Background(), 0, tx)
+			collation, err := ii.collate(t.Context(), 0, tx)
 			require.NoError(t, err)
 			defer collation.Close()
-			sf, _ := ii.buildFiles(context.Background(), 0, collation, background.NewProgressSet())
+			sf, _ := ii.buildFiles(t.Context(), 0, collation, background.NewProgressSet())
 			defer sf.CleanupOnError()
 			txFrom, txTo := firstTxNumOfStep(0, ii.stepSize), firstTxNumOfStep(1, ii.stepSize)
 
@@ -347,9 +347,9 @@ func TestInvIndexPruningCorrectness(t *testing.T) {
 
 		t.Run("retire_one_step_no_force", func(t *testing.T) {
 			t.Skip() //TODO: can't deal with this false-positive but it's so theoretical in scanprune, so IDK
-			collation, err := ii.collate(context.Background(), 0, tx)
+			collation, err := ii.collate(t.Context(), 0, tx)
 			require.NoError(t, err)
-			sf, _ := ii.buildFiles(context.Background(), 0, collation, background.NewProgressSet())
+			sf, _ := ii.buildFiles(t.Context(), 0, collation, background.NewProgressSet())
 			collation.Close()
 			txFrom, txTo := firstTxNumOfStep(0, ii.stepSize), firstTxNumOfStep(1, ii.stepSize)
 			ii.integrateDirtyFiles(sf, txFrom, txTo)
@@ -380,7 +380,7 @@ func TestInvIndexPruningCorrectness(t *testing.T) {
 			ic = ii.beginForTests()
 			defer ic.Close()
 			newTHR := 9 * time.Millisecond
-			otherCtx := context.WithValue(context.Background(), throttle, &newTHR)
+			otherCtx := context.WithValue(t.Context(), throttle, &newTHR)
 			stat, err = ic.TableScanningPrune(otherCtx, tx, 0, 10, pruneLimit, logEvery, false, nil, nil, mxPruneSizeIndex, prune.DefaultStorageMode)
 			require.NoError(t, err)
 			require.Equal(t, 9, int(stat.PruneCountTx))
@@ -398,7 +398,7 @@ func TestInvIndexPruningCorrectness(t *testing.T) {
 			ic := ii.beginForTests()
 			defer ic.Close()
 			newTHR := 1 * time.Millisecond
-			ctx := context.WithValue(context.Background(), "throttle", &newTHR)
+			ctx := context.WithValue(t.Context(), "throttle", &newTHR)
 			// this should prune exactly pruneLimit*pruneIter transactions
 			for i := 0; i < pruneIters; i++ {
 				stat, err := ic.TableScanningPrune(ctx, tx, 0, 1000, pruneLimit, logEvery, true, nil, nil, mxPruneSizeIndex, prune.DefaultStorageMode)
@@ -458,7 +458,7 @@ func TestInvIndexCollationBuild(t *testing.T) {
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
 	db, ii := testDbAndInvertedIndex(t, 16, logger)
-	ctx := context.Background()
+	ctx := t.Context()
 	tx, err := db.BeginRw(ctx)
 	require.NoError(t, err)
 	defer tx.Rollback()
@@ -532,7 +532,7 @@ func TestInvIndexAfterPrune(t *testing.T) {
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
 	db, ii := testDbAndInvertedIndex(t, 16, log.New())
-	ctx := context.Background()
+	ctx := t.Context()
 	tx, err := db.BeginRw(ctx) //nolint:gocritic
 	require.NoError(t, err)
 	defer func() {
@@ -618,7 +618,7 @@ func TestInvIndex_PruneRollingCursorProgress(t *testing.T) {
 		aggStep  = uint64(16)
 		keyCount = 40 // unique keys written to the index
 	)
-	ctx := context.Background()
+	ctx := t.Context()
 	db, ii := testDbAndInvertedIndex(t, aggStep, log.New())
 
 	rwTx, err := db.BeginRw(ctx)
@@ -724,7 +724,7 @@ func filledInvIndex(tb testing.TB, logger log.Logger) (kv.RwDB, *InvertedIndex, 
 func filledInvIndexOfSize(tb testing.TB, txs, aggStep, module uint64, logger log.Logger) (kv.RwDB, *InvertedIndex, uint64) {
 	tb.Helper()
 	db, ii := testDbAndInvertedIndex(tb, aggStep, logger)
-	ctx, require := context.Background(), require.New(tb)
+	ctx, require := t.Context(), require.New(tb)
 
 	err := db.Update(ctx, func(tx kv.RwTx) error {
 		ic := ii.beginForTests()
@@ -764,7 +764,7 @@ func filledInvIndexOfSize(tb testing.TB, txs, aggStep, module uint64, logger log
 
 func checkRanges(t *testing.T, db kv.RwDB, ii *InvertedIndex, txs uint64) {
 	t.Helper()
-	ctx := context.Background()
+	ctx := t.Context()
 	ic := ii.beginForTests()
 	defer ic.Close()
 
@@ -871,7 +871,7 @@ func mergeInverted(tb testing.TB, db kv.RwDB, ii *InvertedIndex, txs uint64) {
 	tb.Helper()
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
-	ctx := context.Background()
+	ctx := t.Context()
 	// Leave the last 2 aggregation steps un-collated
 	tx, err := db.BeginRw(ctx)
 	require.NoError(tb, err)
@@ -925,7 +925,7 @@ func TestInvIndexRanges(t *testing.T) {
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
 	db, ii, txs := filledInvIndex(t, logger)
-	ctx := context.Background()
+	ctx := t.Context()
 	tx, err := db.BeginRw(ctx)
 	require.NoError(t, err)
 	defer tx.Rollback()
@@ -1120,7 +1120,7 @@ func TestInvertedIndex_IdxRange_SkipsFileRange(t *testing.T) {
 
 	aggStep := uint64(16)
 	db, ii := testDbAndInvertedIndex(t, aggStep, logger)
-	ctx := context.Background()
+	ctx := t.Context()
 	require := require.New(t)
 
 	// Write entries for a single key across 3 steps (txNums 1..47).
@@ -1208,7 +1208,7 @@ func TestInvertedIndex_IdxRange_IgnoresDBInFileRange(t *testing.T) {
 
 	aggStep := uint64(16)
 	db, ii := testDbAndInvertedIndex(t, aggStep, logger)
-	ctx := context.Background()
+	ctx := t.Context()
 	require := require.New(t)
 
 	var key [8]byte

--- a/db/state/merge_bench_test.go
+++ b/db/state/merge_bench_test.go
@@ -48,7 +48,7 @@ func benchmarkIIMergeFiles(b *testing.B, numFiles int) {
 	const module = 31 // number of distinct keys
 
 	txs := uint64(numFiles) * aggStep
-	ctx := context.Background()
+	ctx := t.Context()
 	logger := log.New()
 
 	db, ii, _ := filledInvIndexOfSize(b, txs, aggStep, module, logger)

--- a/db/state/merge_bench_test.go
+++ b/db/state/merge_bench_test.go
@@ -17,7 +17,6 @@
 package state
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -48,7 +47,7 @@ func benchmarkIIMergeFiles(b *testing.B, numFiles int) {
 	const module = 31 // number of distinct keys
 
 	txs := uint64(numFiles) * aggStep
-	ctx := t.Context()
+	ctx := b.Context()
 	logger := log.New()
 
 	db, ii, _ := filledInvIndexOfSize(b, txs, aggStep, module, logger)

--- a/db/state/merge_test.go
+++ b/db/state/merge_test.go
@@ -17,7 +17,6 @@
 package state
 
 import (
-	"context"
 	"fmt"
 	"slices"
 	"testing"

--- a/db/state/merge_test.go
+++ b/db/state/merge_test.go
@@ -798,7 +798,7 @@ func TestMergeFiles(t *testing.T) {
 	txs := d.stepSize * 8
 	data := generateTestData(t, 20, 52, txs, txs, 100)
 
-	rwTx, err := db.BeginRw(context.Background())
+	rwTx, err := db.BeginRw(t.Context())
 	require.NoError(t, err)
 	defer rwTx.Rollback()
 
@@ -814,18 +814,18 @@ func TestMergeFiles(t *testing.T) {
 		}
 	}
 
-	require.NoError(t, w.Flush(context.Background(), rwTx))
+	require.NoError(t, w.Flush(t.Context(), rwTx))
 	w.Close()
 	err = rwTx.Commit()
 	require.NoError(t, err)
 
-	err = db.UpdateNosync(context.Background(), func(tx kv.RwTx) error {
+	err = db.UpdateNosync(t.Context(), func(tx kv.RwTx) error {
 		collateAndMerge(t, tx, d, txs)
 		return nil
 	})
 	require.NoError(t, err)
 
-	rwTx, err = db.BeginRw(context.Background())
+	rwTx, err = db.BeginRw(t.Context())
 	require.NoError(t, err)
 	defer rwTx.Rollback()
 

--- a/db/state/snap_creation_fragility_test.go
+++ b/db/state/snap_creation_fragility_test.go
@@ -478,7 +478,7 @@ func TestRealFileCreation_DomainDataFile(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create the file using the same compressor used in production
-	comp, err := seg.NewCompressor(context.Background(), t.Name(), dataPath, dirs.Tmp, seg.DefaultCfg, log.LvlDebug, log.New())
+	comp, err := seg.NewCompressor(t.Context(), t.Name(), dataPath, dirs.Tmp, seg.DefaultCfg, log.LvlDebug, log.New())
 	require.NoError(t, err)
 	comp.DisableFsync()
 	require.NoError(t, comp.AddWord([]byte("key1")))
@@ -743,7 +743,7 @@ func TestFindFilesBySearchVersion(t *testing.T) {
 	// Create v1.0 file on disk using a real compressor
 	v10Path, err := schema.DataFile(version.V1_0, from, to)
 	require.NoError(t, err)
-	comp, err := seg.NewCompressor(context.Background(), t.Name(), v10Path, dirs.Tmp, seg.DefaultCfg, log.LvlDebug, log.New())
+	comp, err := seg.NewCompressor(t.Context(), t.Name(), v10Path, dirs.Tmp, seg.DefaultCfg, log.LvlDebug, log.New())
 	require.NoError(t, err)
 	comp.DisableFsync()
 	require.NoError(t, comp.AddWord([]byte("key1")))
@@ -814,7 +814,7 @@ func TestFindFilesBySearchVersion_VersionRangeFiltering(t *testing.T) {
 	makeFile := func(v version.Version) {
 		path, err := schema.DataFile(v, from, to)
 		require.NoError(t, err)
-		comp, err := seg.NewCompressor(context.Background(), t.Name(), path, dirs.Tmp, seg.DefaultCfg, log.LvlDebug, log.New())
+		comp, err := seg.NewCompressor(t.Context(), t.Name(), path, dirs.Tmp, seg.DefaultCfg, log.LvlDebug, log.New())
 		require.NoError(t, err)
 		comp.DisableFsync()
 		require.NoError(t, comp.AddWord([]byte("word")))
@@ -853,7 +853,7 @@ func TestFindFilesByStrictSearchVersion(t *testing.T) {
 	makeFile := func(v version.Version) {
 		path, err := schema.DataFile(v, from, to)
 		require.NoError(t, err)
-		comp, err := seg.NewCompressor(context.Background(), t.Name(), path, dirs.Tmp, seg.DefaultCfg, log.LvlDebug, log.New())
+		comp, err := seg.NewCompressor(t.Context(), t.Name(), path, dirs.Tmp, seg.DefaultCfg, log.LvlDebug, log.New())
 		require.NoError(t, err)
 		comp.DisableFsync()
 		require.NoError(t, comp.AddWord([]byte("word")))
@@ -875,7 +875,7 @@ func TestFindFilesByStrictSearchVersion(t *testing.T) {
 	makeFileFn := func(v version.Version) {
 		path, err := schema2.DataFile(v, from, to)
 		require.NoError(t, err)
-		comp, err := seg.NewCompressor(context.Background(), t.Name(), path, dirs.Tmp, seg.DefaultCfg, log.LvlDebug, log.New())
+		comp, err := seg.NewCompressor(t.Context(), t.Name(), path, dirs.Tmp, seg.DefaultCfg, log.LvlDebug, log.New())
 		require.NoError(t, err)
 		comp.DisableFsync()
 		require.NoError(t, comp.AddWord([]byte("word")))

--- a/db/state/snap_creation_fragility_test.go
+++ b/db/state/snap_creation_fragility_test.go
@@ -5,7 +5,6 @@ package state
 // These tests catch issues as early as possible.
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"

--- a/db/state/snap_repo_test.go
+++ b/db/state/snap_repo_test.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strings"

--- a/db/state/snap_repo_test.go
+++ b/db/state/snap_repo_test.go
@@ -165,7 +165,7 @@ func TestIntegrateDirtyFile(t *testing.T) {
 
 	filesItem := newFilesItemWithSnapConfig(0, 1024, repo.cfg)
 	filename, _ := repo.schema.DataFile(version.V1_0, 0, 1024)
-	comp, err := seg.NewCompressor(context.Background(), t.Name(), filename, dirs.Tmp, seg.DefaultCfg, log.LvlDebug, log.New())
+	comp, err := seg.NewCompressor(t.Context(), t.Name(), filename, dirs.Tmp, seg.DefaultCfg, log.LvlDebug, log.New())
 	require.NoError(t, err)
 	defer comp.Close()
 	comp.DisableFsync()
@@ -681,7 +681,7 @@ func populateFiles(t *testing.T, dirs datadir.Dirs, schema SnapNameSchema, allFi
 	// 1. account domain, history and ii
 	fileGen := func(filename string) {
 		if strings.HasSuffix(filename, ".ef") || strings.HasSuffix(filename, ".v") || strings.HasSuffix(filename, ".kv") {
-			seg, err := seg.NewCompressor(context.Background(), t.Name(), filename, dirs.Tmp, seg.DefaultCfg, log.LvlDebug, log.New())
+			seg, err := seg.NewCompressor(t.Context(), t.Name(), filename, dirs.Tmp, seg.DefaultCfg, log.LvlDebug, log.New())
 			require.NoError(t, err)
 			defer seg.Close()
 			seg.DisableFsync()
@@ -699,7 +699,7 @@ func populateFiles(t *testing.T, dirs datadir.Dirs, schema SnapNameSchema, allFi
 
 		if strings.HasSuffix(filename, ".bt") {
 			sampleFile := filename + ".sample"
-			seg2, err := seg.NewCompressor(context.Background(), t.Name(), sampleFile, dirs.Tmp, seg.DefaultCfg, log.LvlDebug, log.New())
+			seg2, err := seg.NewCompressor(t.Context(), t.Name(), sampleFile, dirs.Tmp, seg.DefaultCfg, log.LvlDebug, log.New())
 			require.NoError(t, err)
 			defer seg2.Close()
 			seg2.DisableFsync()
@@ -762,7 +762,7 @@ func populateFiles(t *testing.T, dirs datadir.Dirs, schema SnapNameSchema, allFi
 			if err = rs.AddKey([]byte("first_key"), 0); err != nil {
 				t.Error(err)
 			}
-			if err = rs.Build(context.Background()); err != nil {
+			if err = rs.Build(t.Context()); err != nil {
 				t.Errorf("test is expected to fail, too few keys added")
 			}
 			rs.Close()

--- a/db/state/squeeze_concurrent_rebuild_test.go
+++ b/db/state/squeeze_concurrent_rebuild_test.go
@@ -229,7 +229,7 @@ func TestConcurrentRebuildCommitment(t *testing.T) {
 	db, agg, dirs := testDbAndAggregatorForLargeData(t, stepSize, persistentDir)
 	agg.ForTestReplaceKeysInValues(kv.CommitmentDomain, false)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// --- Open transaction and shared domains ---
 	rwTx, err := db.BeginTemporalRw(ctx)
@@ -505,7 +505,7 @@ func TestConcurrentRebuildCommitmentNoSqueeze(t *testing.T) {
 	db, agg, dirs := testDbAndAggregatorForLargeData(t, stepSize, "")
 	agg.ForTestReplaceKeysInValues(kv.CommitmentDomain, false)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	rwTx, err := db.BeginTemporalRw(ctx)
 	require.NoError(t, err)
 	defer rwTx.Rollback()

--- a/db/state/squeeze_concurrent_rebuild_test.go
+++ b/db/state/squeeze_concurrent_rebuild_test.go
@@ -2,7 +2,6 @@ package state_test
 
 import (
 	"bytes"
-	"context"
 	"encoding/binary"
 	"os"
 	"path/filepath"

--- a/db/state/squeeze_test.go
+++ b/db/state/squeeze_test.go
@@ -155,16 +155,16 @@ func testDbAggregatorWithNoFiles(tb testing.TB, txCount int, cfg *testAggConfig)
 	db, agg := testDbAndAggregatorv3(tb, cfg.stepSize)
 	agg.ForTestReplaceKeysInValues(kv.CommitmentDomain, !cfg.disableCommitmentBranchTransform)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ac := agg.BeginFilesRo()
 	defer ac.Close()
 
-	rwTx, err := db.BeginTemporalRw(context.Background())
+	rwTx, err := db.BeginTemporalRw(t.Context())
 	require.NoError(tb, err)
 	defer rwTx.Rollback()
 
-	domains, err := execctx.NewSharedDomains(context.Background(), rwTx, log.New())
+	domains, err := execctx.NewSharedDomains(t.Context(), rwTx, log.New())
 	require.NoError(tb, err)
 	defer domains.Close()
 
@@ -196,7 +196,7 @@ func testDbAggregatorWithNoFiles(tb testing.TB, txCount int, cfg *testAggConfig)
 		}
 	}
 
-	err = domains.Flush(context.Background(), rwTx)
+	err = domains.Flush(t.Context(), rwTx)
 	require.NoError(tb, err)
 
 	require.NoError(tb, rwTx.Commit())
@@ -212,35 +212,35 @@ func TestAggregator_SqueezeCommitment(t *testing.T) {
 	cfgd := &testAggConfig{stepSize: 10, disableCommitmentBranchTransform: true}
 	db, agg := testDbAggregatorWithFiles(t, cfgd)
 
-	rwTx, err := db.BeginTemporalRw(context.Background())
+	rwTx, err := db.BeginTemporalRw(t.Context())
 	require.NoError(t, err)
 	defer rwTx.Rollback()
 
-	domains, err := execctx.NewSharedDomains(context.Background(), rwTx, log.New())
+	domains, err := execctx.NewSharedDomains(t.Context(), rwTx, log.New())
 	require.NoError(t, err)
 	defer domains.Close()
 
 	var blockNum uint64
 	// get latest commited root
-	latestRoot, err := domains.ComputeCommitment(context.Background(), rwTx, false, blockNum, 0, "", nil)
+	latestRoot, err := domains.ComputeCommitment(t.Context(), rwTx, false, blockNum, 0, "", nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, latestRoot)
 	domains.Close()
 
 	// now do the squeeze
 	agg.ForTestReplaceKeysInValues(kv.CommitmentDomain, true)
-	err = state.SqueezeCommitmentFiles(context.Background(), state.AggTx(rwTx), log.New())
+	err = state.SqueezeCommitmentFiles(t.Context(), state.AggTx(rwTx), log.New())
 	require.NoError(t, err)
 
 	//agg.recalcVisibleFiles(matgh.MaxUint64)
 	err = rwTx.Commit()
 	require.NoError(t, err)
 
-	rwTx, err = db.BeginTemporalRw(context.Background())
+	rwTx, err = db.BeginTemporalRw(t.Context())
 	require.NoError(t, err)
 	defer rwTx.Rollback()
 
-	domains, err = execctx.NewSharedDomains(context.Background(), rwTx, log.New())
+	domains, err = execctx.NewSharedDomains(t.Context(), rwTx, log.New())
 	require.NoError(t, err)
 
 	// collect account keys to trigger commitment
@@ -257,7 +257,7 @@ func TestAggregator_SqueezeCommitment(t *testing.T) {
 	}
 
 	// check if the commitment is the same
-	root, err := domains.ComputeCommitment(context.Background(), rwTx, false, blockNum, 0, "", nil)
+	root, err := domains.ComputeCommitment(t.Context(), rwTx, false, blockNum, 0, "", nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, root)
 	require.Equal(t, latestRoot, root)
@@ -277,7 +277,7 @@ func TestAggregator_RebuildCommitmentBasedOnFiles(t *testing.T) {
 	var fPaths []string
 
 	{
-		tx, err := db.BeginTemporalRw(context.Background())
+		tx, err := db.BeginTemporalRw(t.Context())
 		require.NoError(t, err)
 		defer tx.Rollback()
 		ac := state.AggTx(tx)
@@ -302,7 +302,7 @@ func TestAggregator_RebuildCommitmentBasedOnFiles(t *testing.T) {
 	defer db.Close()
 
 	// now clean all commitment files along with related db buckets
-	rwTx, err := db.BeginRw(context.Background())
+	rwTx, err := db.BeginRw(t.Context())
 	require.NoError(t, err)
 	defer rwTx.Rollback()
 
@@ -329,7 +329,7 @@ func TestAggregator_RebuildCommitmentBasedOnFiles(t *testing.T) {
 	err = agg.OpenFolder()
 	require.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	finalRoot, err := state.RebuildCommitmentFiles(ctx, db, &rawdbv3.TxNums, log.New(), true)
 	require.NoError(t, err)
 	require.NotEmpty(t, finalRoot)
@@ -432,16 +432,16 @@ type runCfg struct {
 // - new aggregator SeekCommitment must return txNum equal to amount of total txns
 func aggregatorV3_RestartOnDatadir(t *testing.T, rc runCfg) {
 	t.Helper()
-	ctx := context.Background()
+	ctx := t.Context()
 	logger := log.New()
 	aggStep := rc.aggStep
 	db, agg := testDbAndAggregatorv3(t, aggStep)
 
-	tx, err := db.BeginTemporalRw(context.Background())
+	tx, err := db.BeginTemporalRw(t.Context())
 	require.NoError(t, err)
 	defer tx.Rollback()
 
-	domains, err := execctx.NewSharedDomains(context.Background(), tx, log.New())
+	domains, err := execctx.NewSharedDomains(t.Context(), tx, log.New())
 	require.NoError(t, err)
 	defer domains.Close()
 
@@ -489,7 +489,7 @@ func aggregatorV3_RestartOnDatadir(t *testing.T, rc runCfg) {
 	_, err = domains.ComputeCommitment(ctx, tx, true, blockNum, txNum, "", nil)
 	require.NoError(t, err)
 
-	err = domains.Flush(context.Background(), tx)
+	err = domains.Flush(t.Context(), tx)
 	require.NoError(t, err)
 	err = tx.Commit()
 	require.NoError(t, err)
@@ -508,13 +508,13 @@ func aggregatorV3_RestartOnDatadir(t *testing.T, rc runCfg) {
 	require.NoError(t, err)
 	defer db.Close()
 
-	rwTx, err := db.BeginTemporalRw(context.Background())
+	rwTx, err := db.BeginTemporalRw(t.Context())
 	require.NoError(t, err)
 	defer rwTx.Rollback()
 
 	//anotherAgg.SetTx(rwTx)
 	startTx := anotherAgg.EndTxNumMinimax()
-	dom2, err := execctx.NewSharedDomains(context.Background(), rwTx, log.New())
+	dom2, err := execctx.NewSharedDomains(t.Context(), rwTx, log.New())
 	require.NoError(t, err)
 	defer dom2.Close()
 
@@ -527,7 +527,7 @@ func aggregatorV3_RestartOnDatadir(t *testing.T, rc runCfg) {
 	rwTx.Rollback()
 
 	// Check the history
-	roTx, err := db.BeginTemporalRo(context.Background())
+	roTx, err := db.BeginTemporalRo(t.Context())
 	require.NoError(t, err)
 	defer roTx.Rollback()
 
@@ -598,7 +598,7 @@ func TestGenerateCommitmentRebuildData(t *testing.T) {
 	db, agg, dirs := testDbAndAggregatorForLargeData(t, stepSize, persistentDir)
 	agg.ForTestReplaceKeysInValues(kv.CommitmentDomain, false)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	rwTx, err := db.BeginTemporalRw(ctx)
 	require.NoError(t, err)
@@ -729,13 +729,13 @@ func TestGenerateCommitmentRebuildData(t *testing.T) {
 func TestAggregatorV3_SharedDomains(t *testing.T) {
 	t.Parallel()
 	db, _ := testDbAndAggregatorv3(t, 20)
-	ctx := context.Background()
+	ctx := t.Context()
 
-	rwTx, err := db.BeginTemporalRw(context.Background())
+	rwTx, err := db.BeginTemporalRw(t.Context())
 	require.NoError(t, err)
 	defer rwTx.Rollback()
 
-	domains, err := execctx.NewSharedDomains(context.Background(), rwTx, log.New())
+	domains, err := execctx.NewSharedDomains(t.Context(), rwTx, log.New())
 	require.NoError(t, err)
 	defer domains.Close()
 	changesetAt5 := &changeset.StateChangeSet{}
@@ -779,16 +779,16 @@ func TestAggregatorV3_SharedDomains(t *testing.T) {
 		roots = append(roots, rh)
 	}
 
-	err = domains.Flush(context.Background(), rwTx)
+	err = domains.Flush(t.Context(), rwTx)
 	require.NoError(t, err)
 	err = rwTx.Commit()
 	require.NoError(t, err)
 
-	rwTx, err = db.BeginTemporalRw(context.Background())
+	rwTx, err = db.BeginTemporalRw(t.Context())
 	require.NoError(t, err)
 	defer rwTx.Rollback()
 
-	domains, err = execctx.NewSharedDomains(context.Background(), rwTx, log.New())
+	domains, err = execctx.NewSharedDomains(t.Context(), rwTx, log.New())
 	require.NoError(t, err)
 	defer domains.Close()
 	diffs := [kv.DomainLen][]kv.DomainEntryDiff{}
@@ -796,7 +796,7 @@ func TestAggregatorV3_SharedDomains(t *testing.T) {
 		diffs[idx] = changesetAt5.Diffs[idx].GetDiffSet()
 	}
 	err = rwTx.Unwind(ctx, pruneFrom, &diffs)
-	//err = domains.Unwind(context.Background(), rwTx, 0, pruneFrom, &diffs)
+	//err = domains.Unwind(t.Context(), rwTx, 0, pruneFrom, &diffs)
 	require.NoError(t, err)
 
 	domains.SetChangesetAccumulator(changesetAt3)
@@ -826,7 +826,7 @@ func TestAggregatorV3_SharedDomains(t *testing.T) {
 		require.Equal(t, roots[i], rh)
 	}
 
-	err = domains.Flush(context.Background(), rwTx)
+	err = domains.Flush(t.Context(), rwTx)
 	require.NoError(t, err)
 
 	pruneFrom = 3
@@ -834,17 +834,17 @@ func TestAggregatorV3_SharedDomains(t *testing.T) {
 	err = rwTx.Commit()
 	require.NoError(t, err)
 
-	rwTx, err = db.BeginTemporalRw(context.Background())
+	rwTx, err = db.BeginTemporalRw(t.Context())
 	require.NoError(t, err)
 	defer rwTx.Rollback()
 
-	domains, err = execctx.NewSharedDomains(context.Background(), rwTx, log.New())
+	domains, err = execctx.NewSharedDomains(t.Context(), rwTx, log.New())
 	require.NoError(t, err)
 	defer domains.Close()
 	for idx := range changesetAt3.Diffs {
 		diffs[idx] = changesetAt3.Diffs[idx].GetDiffSet()
 	}
-	err = rwTx.Unwind(context.Background(), pruneFrom, &diffs)
+	err = rwTx.Unwind(t.Context(), pruneFrom, &diffs)
 	require.NoError(t, err)
 
 	for i = int(pruneFrom); i < len(vals); i++ {

--- a/db/state/squeeze_test.go
+++ b/db/state/squeeze_test.go
@@ -1,7 +1,6 @@
 package state_test
 
 import (
-	"context"
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
@@ -155,16 +154,16 @@ func testDbAggregatorWithNoFiles(tb testing.TB, txCount int, cfg *testAggConfig)
 	db, agg := testDbAndAggregatorv3(tb, cfg.stepSize)
 	agg.ForTestReplaceKeysInValues(kv.CommitmentDomain, !cfg.disableCommitmentBranchTransform)
 
-	ctx := t.Context()
+	ctx := tb.Context()
 
 	ac := agg.BeginFilesRo()
 	defer ac.Close()
 
-	rwTx, err := db.BeginTemporalRw(t.Context())
+	rwTx, err := db.BeginTemporalRw(tb.Context())
 	require.NoError(tb, err)
 	defer rwTx.Rollback()
 
-	domains, err := execctx.NewSharedDomains(t.Context(), rwTx, log.New())
+	domains, err := execctx.NewSharedDomains(tb.Context(), rwTx, log.New())
 	require.NoError(tb, err)
 	defer domains.Close()
 
@@ -196,7 +195,7 @@ func testDbAggregatorWithNoFiles(tb testing.TB, txCount int, cfg *testAggConfig)
 		}
 	}
 
-	err = domains.Flush(t.Context(), rwTx)
+	err = domains.Flush(tb.Context(), rwTx)
 	require.NoError(tb, err)
 
 	require.NoError(tb, rwTx.Commit())

--- a/db/state/trie_reader_integration_test.go
+++ b/db/state/trie_reader_integration_test.go
@@ -50,7 +50,7 @@ func TestTrieReader_IntegrationWithRealData(t *testing.T) {
 	db, agg := testDbAndAggregatorv3(t, stepSize)
 	agg.ForTestReplaceKeysInValues(kv.CommitmentDomain, false)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	rwTx, err := db.BeginTemporalRw(ctx)
 	require.NoError(t, err)
 	defer rwTx.Rollback()

--- a/db/state/trie_reader_integration_test.go
+++ b/db/state/trie_reader_integration_test.go
@@ -1,7 +1,6 @@
 package state_test
 
 import (
-	"context"
 	"encoding/binary"
 	"testing"
 

--- a/db/test/aggregator_ext_test.go
+++ b/db/test/aggregator_ext_test.go
@@ -61,15 +61,15 @@ func TestAggregatorV3_RestartOnFiles(t *testing.T) {
 
 	logger := log.New()
 	stepSize := uint64(100)
-	ctx := context.Background()
+	ctx := t.Context()
 	db, agg, _ := testDbAndAggregatorv3(t, t.TempDir(), stepSize)
 	dirs := agg.Dirs()
 
-	tx, err := db.BeginTemporalRw(context.Background())
+	tx, err := db.BeginTemporalRw(t.Context())
 	require.NoError(t, err)
 	defer tx.Rollback()
 
-	domains, err := execctx.NewSharedDomains(context.Background(), tx, log.New())
+	domains, err := execctx.NewSharedDomains(t.Context(), tx, log.New())
 	require.NoError(t, err)
 	defer domains.Close()
 
@@ -118,7 +118,7 @@ func TestAggregatorV3_RestartOnFiles(t *testing.T) {
 	}
 
 	// flush and build files
-	err = domains.Flush(context.Background(), tx)
+	err = domains.Flush(t.Context(), tx)
 	require.NoError(t, err)
 
 	progress := tx.Debug().DomainProgress(kv.AccountsDomain)
@@ -146,11 +146,11 @@ func TestAggregatorV3_RestartOnFiles(t *testing.T) {
 
 	db, _ = temporal.New(newDb, newAgg)
 
-	tx, err = db.BeginTemporalRw(context.Background())
+	tx, err = db.BeginTemporalRw(t.Context())
 	require.NoError(t, err)
 	defer tx.Rollback()
 
-	newDoms, err := execctx.NewSharedDomains(context.Background(), tx, log.New())
+	newDoms, err := execctx.NewSharedDomains(t.Context(), tx, log.New())
 	require.NoError(t, err)
 	defer newDoms.Close()
 
@@ -195,16 +195,16 @@ func TestAggregatorV3_ReplaceCommittedKeys(t *testing.T) {
 	}
 
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 	aggStep := uint64(20)
 
 	db, _, _ := testDbAndAggregatorv3(t, t.TempDir(), aggStep)
 
-	tx, err := db.BeginTemporalRw(context.Background())
+	tx, err := db.BeginTemporalRw(t.Context())
 	require.NoError(t, err)
 	defer tx.Rollback()
 
-	domains, err := execctx.NewSharedDomains(context.Background(), tx, log.New())
+	domains, err := execctx.NewSharedDomains(t.Context(), tx, log.New())
 	require.NoError(t, err)
 	defer domains.Close()
 
@@ -218,10 +218,10 @@ func TestAggregatorV3_ReplaceCommittedKeys(t *testing.T) {
 		require.NoError(t, err)
 
 		// TODO: either make the lint rule smarter about closures, or use db.View/db.Update here
-		tx, err = db.BeginTemporalRw(context.Background()) //nolint:gocritic
+		tx, err = db.BeginTemporalRw(t.Context()) //nolint:gocritic
 		require.NoError(t, err)
 
-		domains, err = execctx.NewSharedDomains(context.Background(), tx, log.New())
+		domains, err = execctx.NewSharedDomains(t.Context(), tx, log.New())
 		require.NoError(t, err)
 		atomic.StoreUint64(&latestCommitTxNum, txn)
 		return nil
@@ -278,7 +278,7 @@ func TestAggregatorV3_ReplaceCommittedKeys(t *testing.T) {
 
 	err = tx.Commit()
 
-	tx, err = db.BeginTemporalRw(context.Background())
+	tx, err = db.BeginTemporalRw(t.Context())
 	require.NoError(t, err)
 	defer tx.Rollback()
 
@@ -301,11 +301,11 @@ func TestAggregatorV3_Merge(t *testing.T) {
 	t.Parallel()
 	db, agg, _ := testDbAndAggregatorv3(t, t.TempDir(), 10)
 
-	rwTx, err := db.BeginTemporalRw(context.Background())
+	rwTx, err := db.BeginTemporalRw(t.Context())
 	require.NoError(t, err)
 	defer rwTx.Rollback()
 
-	domains, err := execctx.NewSharedDomains(context.Background(), rwTx, log.New())
+	domains, err := execctx.NewSharedDomains(t.Context(), rwTx, log.New())
 	require.NoError(t, err)
 	defer domains.Close()
 
@@ -365,7 +365,7 @@ func TestAggregatorV3_Merge(t *testing.T) {
 
 	}
 
-	err = domains.Flush(context.Background(), rwTx)
+	err = domains.Flush(t.Context(), rwTx)
 	require.NoError(t, err)
 
 	require.NoError(t, err)
@@ -411,11 +411,11 @@ func TestAggregatorV3_Merge(t *testing.T) {
 	require.Equal(t, 7, onDelCalls)
 
 	{ //prune
-		rwTx, err = db.BeginTemporalRw(context.Background())
+		rwTx, err = db.BeginTemporalRw(t.Context())
 		require.NoError(t, err)
 		defer rwTx.Rollback()
 
-		_, err := state.AggTx(rwTx).PruneSmallBatches(context.Background(), time.Hour, rwTx)
+		_, err := state.AggTx(rwTx).PruneSmallBatches(t.Context(), time.Hour, rwTx)
 		require.NoError(t, err)
 
 		err = rwTx.Commit()
@@ -423,13 +423,13 @@ func TestAggregatorV3_Merge(t *testing.T) {
 	}
 
 	onChangeCalls, onDelCalls = 0, 0
-	err = agg.MergeLoop(context.Background())
+	err = agg.MergeLoop(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, 0, onChangeCalls)
 	require.Equal(t, 0, onDelCalls)
 
 	// Check the history
-	roTx, err := db.BeginTemporalRo(context.Background())
+	roTx, err := db.BeginTemporalRo(t.Context())
 	require.NoError(t, err)
 	defer roTx.Rollback()
 
@@ -451,11 +451,11 @@ func TestAggregatorV3_PruneSmallBatches(t *testing.T) {
 	aggStep := uint64(2)
 	db, agg, _ := testDbAndAggregatorv3(t, t.TempDir(), aggStep)
 
-	tx, err := db.BeginTemporalRw(context.Background())
+	tx, err := db.BeginTemporalRw(t.Context())
 	require.NoError(t, err)
 	defer tx.Rollback()
 
-	domains, err := execctx.NewSharedDomains(context.Background(), tx, log.New())
+	domains, err := execctx.NewSharedDomains(t.Context(), tx, log.New())
 	require.NoError(t, err)
 	defer domains.Close()
 
@@ -467,7 +467,7 @@ func TestAggregatorV3_PruneSmallBatches(t *testing.T) {
 	generateSharedDomainsUpdates(t, domains, tx, maxTx, rnd, length.Addr, 10, aggStep/2)
 
 	// flush and build files
-	err = domains.Flush(context.Background(), tx)
+	err = domains.Flush(t.Context(), tx)
 	require.NoError(t, err)
 
 	var (
@@ -510,18 +510,18 @@ func TestAggregatorV3_PruneSmallBatches(t *testing.T) {
 	err = agg.BuildFiles(maxTx)
 	require.NoError(t, err)
 
-	buildTx, err := db.BeginTemporalRw(context.Background())
+	buildTx, err := db.BeginTemporalRw(t.Context())
 	require.NoError(t, err)
 	defer buildTx.Rollback()
 
 	for i := 0; i < 10; i++ {
-		_, err = buildTx.PruneSmallBatches(context.Background(), time.Second*3)
+		_, err = buildTx.PruneSmallBatches(t.Context(), time.Second*3)
 		require.NoError(t, err)
 	}
 	err = buildTx.Commit()
 	require.NoError(t, err)
 
-	afterTx, err := db.BeginTemporalRw(context.Background())
+	afterTx, err := db.BeginTemporalRw(t.Context())
 	require.NoError(t, err)
 	defer afterTx.Rollback()
 
@@ -580,12 +580,12 @@ func TestSharedDomain_CommitmentKeyReplacement(t *testing.T) {
 	stepSize := uint64(5)
 	db, agg, _ := testDbAndAggregatorv3(t, t.TempDir(), stepSize)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	rwTx, err := db.BeginTemporalRw(ctx)
 	require.NoError(t, err)
 	defer rwTx.Rollback()
 
-	domains, err := execctx.NewSharedDomains(context.Background(), rwTx, log.New())
+	domains, err := execctx.NewSharedDomains(t.Context(), rwTx, log.New())
 	require.NoError(t, err)
 	defer domains.Close()
 
@@ -611,7 +611,7 @@ func TestSharedDomain_CommitmentKeyReplacement(t *testing.T) {
 	}
 
 	// 3. calculate commitment with all data +removed key
-	expectedHash, err := domains.ComputeCommitment(context.Background(), rwTx, false, txNum/stepSize, txNum, "", nil)
+	expectedHash, err := domains.ComputeCommitment(t.Context(), rwTx, false, txNum/stepSize, txNum, "", nil)
 	require.NoError(t, err)
 	domains.Close()
 
@@ -630,7 +630,7 @@ func TestSharedDomain_CommitmentKeyReplacement(t *testing.T) {
 	defer rwTx.Rollback()
 
 	// 4. restart on same (replaced keys) files
-	domains, err = execctx.NewSharedDomains(context.Background(), rwTx, log.New())
+	domains, err = execctx.NewSharedDomains(t.Context(), rwTx, log.New())
 	require.NoError(t, err)
 	defer domains.Close()
 
@@ -639,7 +639,7 @@ func TestSharedDomain_CommitmentKeyReplacement(t *testing.T) {
 	err = domains.DomainDel(kv.AccountsDomain, rwTx, removedKey, txNum, nil)
 	require.NoError(t, err)
 
-	resultHash, err := domains.ComputeCommitment(context.Background(), rwTx, false, txNum/stepSize, txNum, "", nil)
+	resultHash, err := domains.ComputeCommitment(t.Context(), rwTx, false, txNum/stepSize, txNum, "", nil)
 	require.NoError(t, err)
 
 	//t.Logf("result hash: %x", resultHash)
@@ -653,13 +653,13 @@ func TestAggregatorV3_MergeValTransform(t *testing.T) {
 
 	t.Parallel()
 	db, agg, _ := testDbAndAggregatorv3(t, t.TempDir(), 5)
-	rwTx, err := db.BeginTemporalRw(context.Background())
+	rwTx, err := db.BeginTemporalRw(t.Context())
 	require.NoError(t, err)
 	defer rwTx.Rollback()
 
 	agg.ForTestReplaceKeysInValues(kv.CommitmentDomain, true)
 
-	domains, err := execctx.NewSharedDomains(context.Background(), rwTx, log.New())
+	domains, err := execctx.NewSharedDomains(t.Context(), rwTx, log.New())
 	require.NoError(t, err)
 	defer domains.Close()
 
@@ -696,7 +696,7 @@ func TestAggregatorV3_MergeValTransform(t *testing.T) {
 		require.NoError(t, err)
 
 		if (txNum+1)%agg.StepSize() == 0 {
-			_, err := domains.ComputeCommitment(context.Background(), rwTx, true, txNum/10, txNum, "", nil)
+			_, err := domains.ComputeCommitment(t.Context(), rwTx, true, txNum/10, txNum, "", nil)
 			require.NoError(t, err)
 		}
 
@@ -704,7 +704,7 @@ func TestAggregatorV3_MergeValTransform(t *testing.T) {
 		state[string(addr)+string(loc)] = []byte{addr[0], loc[0]}
 	}
 
-	err = domains.Flush(context.Background(), rwTx)
+	err = domains.Flush(t.Context(), rwTx)
 	require.NoError(t, err)
 
 	err = rwTx.Commit()
@@ -713,17 +713,17 @@ func TestAggregatorV3_MergeValTransform(t *testing.T) {
 	err = agg.BuildFiles(txs)
 	require.NoError(t, err)
 
-	rwTx, err = db.BeginTemporalRw(context.Background())
+	rwTx, err = db.BeginTemporalRw(t.Context())
 	require.NoError(t, err)
 	defer rwTx.Rollback()
 
-	_, err = rwTx.PruneSmallBatches(context.Background(), time.Hour)
+	_, err = rwTx.PruneSmallBatches(t.Context(), time.Hour)
 	require.NoError(t, err)
 
 	err = rwTx.Commit()
 	require.NoError(t, err)
 
-	err = agg.MergeLoop(context.Background())
+	err = agg.MergeLoop(t.Context())
 	require.NoError(t, err)
 }
 
@@ -746,7 +746,7 @@ func TestAggregatorV3_BuildFiles_WithReorgDepth(t *testing.T) {
 	tx, err := tdb.BeginTemporalRw(ctx)
 	require.NoError(t, err)
 	t.Cleanup(tx.Rollback)
-	doms, err := execctx.NewSharedDomains(context.Background(), tx, logger)
+	doms, err := execctx.NewSharedDomains(t.Context(), tx, logger)
 	require.NoError(t, err)
 	t.Cleanup(doms.Close)
 	txnNums := uint64(18)
@@ -814,7 +814,7 @@ func generateSharedDomainsUpdates(t *testing.T, domains *execctx.SharedDomains, 
 		}
 		if txNum%commitEvery == 0 {
 			// domains.SetTrace(true)
-			stateRootHash, err := domains.ComputeCommitment(context.Background(), tx, true, txNum/commitEvery, txNum, "", nil)
+			stateRootHash, err := domains.ComputeCommitment(t.Context(), tx, true, txNum/commitEvery, txNum, "", nil)
 			require.NoErrorf(t, err, "txNum=%d", txNum)
 			_ = stateRootHash
 			//t.Logf("commitment %x txn=%d", stateRootHash, txNum)

--- a/db/test/aggregator_ext_test.go
+++ b/db/test/aggregator_ext_test.go
@@ -17,7 +17,6 @@
 package test
 
 import (
-	"context"
 	"encoding/binary"
 	"encoding/hex"
 	"math"

--- a/db/test/domain_shared_bench_test.go
+++ b/db/test/domain_shared_bench_test.go
@@ -68,12 +68,12 @@ func Benchmark_SharedDomains_GetLatest(t *testing.B) {
 	stepSize := uint64(100)
 	db, agg := testDbAndAggregatorBench(t, stepSize)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	rwTx, err := db.BeginTemporalRw(ctx)
 	require.NoError(t, err)
 	defer rwTx.Rollback()
 
-	domains, err := execctx.NewSharedDomains(context.Background(), rwTx, log.New())
+	domains, err := execctx.NewSharedDomains(t.Context(), rwTx, log.New())
 	require.NoError(t, err)
 	defer domains.Close()
 	maxTx := stepSize * 258
@@ -151,12 +151,12 @@ func BenchmarkSharedDomains_ComputeCommitment(b *testing.B) {
 	stepSize := uint64(100)
 	db, _ := testDbAndAggregatorBench(b, stepSize)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	rwTx, err := db.BeginTemporalRw(ctx)
 	require.NoError(b, err)
 	defer rwTx.Rollback()
 
-	domains, err := execctx.NewSharedDomains(context.Background(), rwTx, log.New())
+	domains, err := execctx.NewSharedDomains(t.Context(), rwTx, log.New())
 	require.NoError(b, err)
 	defer domains.Close()
 
@@ -285,7 +285,7 @@ func BenchmarkPruneSmallBatches(b *testing.B) {
 	stepSize := uint64(100)
 	db, agg := testDbAndAggregatorBench(b, stepSize)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	rnd := newRnd(0)
 
 	// Populate data: write enough txs to span several steps

--- a/db/test/domain_shared_bench_test.go
+++ b/db/test/domain_shared_bench_test.go
@@ -17,7 +17,6 @@
 package test
 
 import (
-	"context"
 	"encoding/binary"
 	randOld "math/rand"
 	"math/rand/v2"
@@ -151,12 +150,12 @@ func BenchmarkSharedDomains_ComputeCommitment(b *testing.B) {
 	stepSize := uint64(100)
 	db, _ := testDbAndAggregatorBench(b, stepSize)
 
-	ctx := t.Context()
+	ctx := b.Context()
 	rwTx, err := db.BeginTemporalRw(ctx)
 	require.NoError(b, err)
 	defer rwTx.Rollback()
 
-	domains, err := execctx.NewSharedDomains(t.Context(), rwTx, log.New())
+	domains, err := execctx.NewSharedDomains(b.Context(), rwTx, log.New())
 	require.NoError(b, err)
 	defer domains.Close()
 
@@ -285,7 +284,7 @@ func BenchmarkPruneSmallBatches(b *testing.B) {
 	stepSize := uint64(100)
 	db, agg := testDbAndAggregatorBench(b, stepSize)
 
-	ctx := t.Context()
+	ctx := b.Context()
 	rnd := newRnd(0)
 
 	// Populate data: write enough txs to span several steps

--- a/db/test/domains_restart_test.go
+++ b/db/test/domains_restart_test.go
@@ -74,7 +74,7 @@ func Test_AggregatorV3_RestartOnDatadir_WithoutDB(t *testing.T) {
 
 	aggStep := uint64(100)
 	blockSize := uint64(10) // lets say that each block contains 10 tx, after each block we do commitment
-	ctx := context.Background()
+	ctx := t.Context()
 
 	db, agg, datadir := testDbAndAggregatorv3(t, t.TempDir(), aggStep)
 	tx, err := db.BeginTemporalRw(ctx)
@@ -288,7 +288,7 @@ func Test_AggregatorV3_RestartOnDatadir_WithoutAnything(t *testing.T) {
 		hashes    = make([][]byte, 0)
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	db, agg, datadir := testDbAndAggregatorv3(t, t.TempDir(), aggStep)
 	blockNum, txNum := uint64(0), uint64(0)
@@ -448,7 +448,7 @@ func randomAccount(t *testing.T) (*accounts.Account, accounts.Address) {
 func TestCommit(t *testing.T) {
 	aggStep := uint64(100)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	db, _, _ := testDbAndAggregatorv3(t, t.TempDir(), aggStep)
 	tx, err := db.BeginTemporalRw(ctx)
 	require.NoError(t, err)

--- a/db/test/domains_restart_test.go
+++ b/db/test/domains_restart_test.go
@@ -17,7 +17,6 @@
 package test
 
 import (
-	"context"
 	"encoding/binary"
 	"fmt"
 	"io/fs"

--- a/db/test/lifecycle_bench_test.go
+++ b/db/test/lifecycle_bench_test.go
@@ -167,7 +167,7 @@ func runLifecycle(b *testing.B, cfg lifecycleConfig) (*lifecycleTimings, kv.Temp
 	stepSize := uint64(cfg.txsPerBlock * cfg.blocksPerStep)
 	db, agg := testDbAndAggregatorBench(b, stepSize)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	rwTx, err := db.BeginTemporalRw(ctx)
 	require.NoError(b, err)
 	defer rwTx.Rollback()
@@ -334,7 +334,7 @@ func BenchmarkLifecycle_PhaseIsolation(b *testing.B) {
 
 	b.Run("Execute_Only", func(b *testing.B) {
 		db, _ := testDbAndAggregatorBench(b, stepSize)
-		ctx := context.Background()
+		ctx := t.Context()
 		rwTx, err := db.BeginTemporalRw(ctx)
 		require.NoError(b, err)
 		defer rwTx.Rollback()
@@ -367,7 +367,7 @@ func BenchmarkLifecycle_PhaseIsolation(b *testing.B) {
 
 	b.Run("Commit_Only", func(b *testing.B) {
 		db, _ := testDbAndAggregatorBench(b, stepSize)
-		ctx := context.Background()
+		ctx := t.Context()
 		rwTx, err := db.BeginTemporalRw(ctx)
 		require.NoError(b, err)
 		defer rwTx.Rollback()
@@ -404,7 +404,7 @@ func BenchmarkLifecycle_PhaseIsolation(b *testing.B) {
 
 	b.Run("Flush_Only", func(b *testing.B) {
 		db, _ := testDbAndAggregatorBench(b, stepSize)
-		ctx := context.Background()
+		ctx := t.Context()
 
 		rnd := newRnd(42)
 		keyGen := newKeyGenerator(rnd, cfg.hotAccounts, cfg.coldAccounts)
@@ -442,7 +442,7 @@ func BenchmarkLifecycle_PhaseIsolation(b *testing.B) {
 	b.Run("Collate_Only", func(b *testing.B) {
 		// Build up enough data in MDBX, then benchmark only the BuildFiles call.
 		db, agg := testDbAndAggregatorBench(b, stepSize)
-		ctx := context.Background()
+		ctx := t.Context()
 		rwTx, err := db.BeginTemporalRw(ctx)
 		require.NoError(b, err)
 		defer rwTx.Rollback()
@@ -509,7 +509,7 @@ func BenchmarkReadAfterLifecycle(b *testing.B) {
 
 	_, db, _ := runLifecycle(b, cfg)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	rwTx, err := db.BeginTemporalRw(ctx)
 	require.NoError(b, err)
 	defer rwTx.Rollback()

--- a/db/test/lifecycle_bench_test.go
+++ b/db/test/lifecycle_bench_test.go
@@ -17,7 +17,6 @@
 package test
 
 import (
-	"context"
 	"encoding/binary"
 	"fmt"
 	"testing"
@@ -167,7 +166,7 @@ func runLifecycle(b *testing.B, cfg lifecycleConfig) (*lifecycleTimings, kv.Temp
 	stepSize := uint64(cfg.txsPerBlock * cfg.blocksPerStep)
 	db, agg := testDbAndAggregatorBench(b, stepSize)
 
-	ctx := t.Context()
+	ctx := b.Context()
 	rwTx, err := db.BeginTemporalRw(ctx)
 	require.NoError(b, err)
 	defer rwTx.Rollback()
@@ -334,7 +333,7 @@ func BenchmarkLifecycle_PhaseIsolation(b *testing.B) {
 
 	b.Run("Execute_Only", func(b *testing.B) {
 		db, _ := testDbAndAggregatorBench(b, stepSize)
-		ctx := t.Context()
+		ctx := b.Context()
 		rwTx, err := db.BeginTemporalRw(ctx)
 		require.NoError(b, err)
 		defer rwTx.Rollback()
@@ -367,7 +366,7 @@ func BenchmarkLifecycle_PhaseIsolation(b *testing.B) {
 
 	b.Run("Commit_Only", func(b *testing.B) {
 		db, _ := testDbAndAggregatorBench(b, stepSize)
-		ctx := t.Context()
+		ctx := b.Context()
 		rwTx, err := db.BeginTemporalRw(ctx)
 		require.NoError(b, err)
 		defer rwTx.Rollback()
@@ -404,7 +403,7 @@ func BenchmarkLifecycle_PhaseIsolation(b *testing.B) {
 
 	b.Run("Flush_Only", func(b *testing.B) {
 		db, _ := testDbAndAggregatorBench(b, stepSize)
-		ctx := t.Context()
+		ctx := b.Context()
 
 		rnd := newRnd(42)
 		keyGen := newKeyGenerator(rnd, cfg.hotAccounts, cfg.coldAccounts)
@@ -442,7 +441,7 @@ func BenchmarkLifecycle_PhaseIsolation(b *testing.B) {
 	b.Run("Collate_Only", func(b *testing.B) {
 		// Build up enough data in MDBX, then benchmark only the BuildFiles call.
 		db, agg := testDbAndAggregatorBench(b, stepSize)
-		ctx := t.Context()
+		ctx := b.Context()
 		rwTx, err := db.BeginTemporalRw(ctx)
 		require.NoError(b, err)
 		defer rwTx.Rollback()
@@ -509,7 +508,7 @@ func BenchmarkReadAfterLifecycle(b *testing.B) {
 
 	_, db, _ := runLifecycle(b, cfg)
 
-	ctx := t.Context()
+	ctx := b.Context()
 	rwTx, err := db.BeginTemporalRw(ctx)
 	require.NoError(b, err)
 	defer rwTx.Rollback()

--- a/db/test/marked_forkable_test.go
+++ b/db/test/marked_forkable_test.go
@@ -106,7 +106,7 @@ func TestMarked_PutToDb(t *testing.T) {
 
 	ma_tx := ma.BeginTemporalTx()
 	defer ma_tx.Close()
-	rwtx, err := db.BeginRw(context.Background())
+	rwtx, err := db.BeginRw(t.Context())
 	require.NoError(t, err)
 	defer rwtx.Rollback()
 
@@ -140,7 +140,7 @@ func TestPrune(t *testing.T) {
 			dir, db, log := setup(t)
 			headerId, ma := setupHeader(t, log, dir, db)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			cfg := state.Registry.SnapshotConfig(headerId)
 			extras_count := uint64(5) // in db
 			entries_count = cfg.MinimumSize + cfg.SafetyMargin + extras_count
@@ -231,7 +231,7 @@ func TestBuildFiles_Marked(t *testing.T) {
 	// then unwind and check get
 	dir, db, log := setup(t)
 	headerId, ma := setupHeader(t, log, dir, db)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ma_tx := ma.BeginTemporalTx()
 	defer ma_tx.Close()

--- a/db/test/marked_forkable_test.go
+++ b/db/test/marked_forkable_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"testing"
 

--- a/db/test/unmarked_forkable_test.go
+++ b/db/test/unmarked_forkable_test.go
@@ -70,7 +70,7 @@ func TestUnmarked_PutToDb(t *testing.T) {
 
 	uma_tx := uma.BeginTemporalTx()
 	defer uma_tx.Close()
-	rwtx, err := db.BeginRw(context.Background())
+	rwtx, err := db.BeginRw(t.Context())
 	require.NoError(t, err)
 	defer rwtx.Rollback()
 
@@ -99,7 +99,7 @@ func TestUnmarkedPrune(t *testing.T) {
 			dir, db, log := setup(t)
 			borSpanId, uma := setupBorSpans(t, log, dir, db)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			cfg := state.Registry.SnapshotConfig(borSpanId)
 			extras_count := uint64(5) // db
 			entries_count = cfg.MinimumSize + cfg.SafetyMargin + extras_count
@@ -182,7 +182,7 @@ func CustomSpanIdAt(blockNum uint64) heimdall.SpanId {
 func TestBuildFiles_Unmarked(t *testing.T) {
 	dir, db, log := setup(t)
 	borSpanId, uma := setupBorSpans(t, log, dir, db)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	uma_tx := uma.BeginTemporalTx()
 	defer uma_tx.Close()
@@ -279,7 +279,7 @@ func TestBuildFiles_Unmarked(t *testing.T) {
 func TestBuildFiles_PagedUnmarked(t *testing.T) {
 	dir, db, log := setup(t)
 	pagedDataId, uma := setupPagedEntity(t, log, dir, db)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	uma_tx := uma.BeginTemporalTx()
 	defer uma_tx.Close()
@@ -396,7 +396,7 @@ func setupPagedEntity(t *testing.T, log log.Logger, dirs datadir.Dirs, db kv.RwD
 		state.NewAccessorArgs(false, false, cfg.ValuesOnCompressedPage, stepSize),
 		id, dirs.Tmp, log)
 
-	rwtx, err := db.BeginRw(context.Background())
+	rwtx, err := db.BeginRw(t.Context())
 	require.NoError(t, err)
 	defer rwtx.Rollback()
 

--- a/db/test/unmarked_forkable_test.go
+++ b/db/test/unmarked_forkable_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 

--- a/node/app/component/component_test.go
+++ b/node/app/component/component_test.go
@@ -22,12 +22,13 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+	"go.uber.org/mock/gomock"
+
 	liblog "github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/node/app"
 	"github.com/erigontech/erigon/node/app/component"
-	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v2"
-	gomock "go.uber.org/mock/gomock"
 )
 
 func TestMain(m *testing.M) {
@@ -39,7 +40,7 @@ type provider struct {
 }
 
 func TestCreateComponent(t *testing.T) {
-	c, err := component.NewComponent[provider](context.Background())
+	c, err := component.NewComponent[provider](t.Context())
 	require.Nil(t, err)
 	require.NotNil(t, c)
 	require.Equal(t, "root:provider", c.Id().String())
@@ -48,7 +49,7 @@ func TestCreateComponent(t *testing.T) {
 	var p *provider = c.Provider()
 	require.NotNil(t, p)
 
-	c1, err := component.NewComponent[provider](context.Background(),
+	c1, err := component.NewComponent[provider](t.Context(),
 		component.WithId("my-id"),
 		component.WithName("my name"))
 	require.Nil(t, err)
@@ -56,7 +57,7 @@ func TestCreateComponent(t *testing.T) {
 	require.Equal(t, "root:my-id", c1.Id().String())
 	require.Equal(t, "my name", c1.Name())
 
-	c2, err := component.NewComponent[provider](context.Background(),
+	c2, err := component.NewComponent[provider](t.Context(),
 		component.WithId("my-id-2"),
 		component.WithDependencies(c, c1))
 	require.Nil(t, err)
@@ -71,16 +72,16 @@ func TestCreateComponent(t *testing.T) {
 }
 
 func TestCreateDomain(t *testing.T) {
-	d, err := component.NewComponentDomain(context.Background(), "domain")
+	d, err := component.NewComponentDomain(t.Context(), "domain")
 	require.Nil(t, err)
 	require.NotNil(t, d)
 	require.Equal(t, "root:domain", d.Id().String())
-	d1, err := component.NewComponentDomain(context.Background(), "domain-1",
+	d1, err := component.NewComponentDomain(t.Context(), "domain-1",
 		component.WithDependentDomain(d))
 	require.Nil(t, err)
 	require.NotNil(t, d1)
 	require.Equal(t, "domain:domain-1", d1.Id().String())
-	d2, err := component.NewComponentDomain(context.Background(), "domain-2",
+	d2, err := component.NewComponentDomain(t.Context(), "domain-2",
 		component.WithDependentDomain(d1))
 	require.Nil(t, err)
 	require.NotNil(t, d2)
@@ -88,12 +89,12 @@ func TestCreateDomain(t *testing.T) {
 }
 
 func TestCreateComponentInDomain(t *testing.T) {
-	d, err := component.NewComponentDomain(context.Background(), "domain")
+	d, err := component.NewComponentDomain(t.Context(), "domain")
 	require.Nil(t, err)
 	require.NotNil(t, d)
 	require.Equal(t, "root:domain", d.Id().String())
 
-	c, err := component.NewComponent[provider](context.Background(),
+	c, err := component.NewComponent[provider](t.Context(),
 		component.WithDomain(d))
 	require.Nil(t, err)
 	require.NotNil(t, c)
@@ -102,19 +103,19 @@ func TestCreateComponentInDomain(t *testing.T) {
 	var p *provider = c.Provider()
 	require.NotNil(t, p)
 
-	c1, err := component.NewComponent[provider](context.Background())
+	c1, err := component.NewComponent[provider](t.Context())
 	require.Nil(t, err)
 	require.NotNil(t, c)
 	require.Equal(t, "root:provider", c1.Id().String())
 
-	d1, err := component.NewComponentDomain(context.Background(), "domain-1",
+	d1, err := component.NewComponentDomain(t.Context(), "domain-1",
 		component.WithDependencies(c1))
 	require.Nil(t, err)
 	require.NotNil(t, d1)
 	require.Equal(t, "root:domain-1", d1.Id().String())
 	require.Equal(t, "domain-1:provider", c1.Id().String())
 
-	d2, err := component.NewComponentDomain(context.Background(), "domain-2",
+	d2, err := component.NewComponentDomain(t.Context(), "domain-2",
 		component.WithDependencies(c, c1))
 	require.Nil(t, err)
 	require.NotNil(t, d2)
@@ -159,37 +160,37 @@ func TestComponentLifecycle(t *testing.T) {
 	// instead of gomock.
 	t.Skip("Superseded by hierarchy_test.go — gomock incompatible with shared root domain")
 	ctrl := gomock.NewController(t)
-	testDomain, err := component.NewComponentDomain(context.Background(), "lifecycle")
+	testDomain, err := component.NewComponentDomain(t.Context(), "lifecycle")
 	require.Nil(t, err)
-	c, err := component.NewComponent[component.MockComponentProvider](context.Background(),
+	c, err := component.NewComponent[component.MockComponentProvider](t.Context(),
 		component.WithProvider(mockProvider(ctrl, 1)),
 		component.WithDomain(testDomain))
 	require.Nil(t, err)
 	require.NotNil(t, c)
 	require.Equal(t, "lifecycle:mockcomponentprovider", c.Id().String())
 
-	err = c.Activate(context.Background())
+	err = c.Activate(t.Context())
 	require.Nil(t, err)
 
-	state, err := c.AwaitState(context.Background(), component.Active)
+	state, err := c.AwaitState(t.Context(), component.Active)
 	require.Nil(t, err)
 	require.Equal(t, component.Active, state)
 
-	err = c.Deactivate(context.Background())
+	err = c.Deactivate(t.Context())
 	require.Nil(t, err)
 
-	state, err = c.AwaitState(context.Background(), component.Deactivated)
+	state, err = c.AwaitState(t.Context(), component.Deactivated)
 	require.Nil(t, err)
 	require.Equal(t, component.Deactivated, state)
 
-	d, err := component.NewComponent[component.MockComponentProvider](context.Background(),
+	d, err := component.NewComponent[component.MockComponentProvider](t.Context(),
 		component.WithId("d"), component.WithDomain(testDomain),
 		component.WithProvider(mockProvider(ctrl, 1)))
 	require.Nil(t, err)
 	require.NotNil(t, d)
 	require.Equal(t, "lifecycle:d", d.Id().String())
 
-	c1, err := component.NewComponent[component.MockComponentProvider](context.Background(),
+	c1, err := component.NewComponent[component.MockComponentProvider](t.Context(),
 		component.WithId("c1"), component.WithDomain(testDomain),
 		component.WithProvider(mockProvider(ctrl, 1)),
 		component.WithDependencies(d))
@@ -197,46 +198,46 @@ func TestComponentLifecycle(t *testing.T) {
 	require.NotNil(t, c1)
 	require.Equal(t, "lifecycle:c1", c1.Id().String())
 
-	err = c1.Activate(context.Background())
+	err = c1.Activate(t.Context())
 	require.Nil(t, err)
 
-	state, err = c1.AwaitState(context.Background(), component.Active)
+	state, err = c1.AwaitState(t.Context(), component.Active)
 	require.Nil(t, err)
 	require.Equal(t, component.Active, state)
 	require.Equal(t, component.Active, d.State())
 	require.Equal(t, component.Deactivated, c.State())
 
-	err = c1.Deactivate(context.Background())
+	err = c1.Deactivate(t.Context())
 	require.Nil(t, err)
 
-	state, err = c1.AwaitState(context.Background(), component.Deactivated)
+	state, err = c1.AwaitState(t.Context(), component.Deactivated)
 	require.Nil(t, err)
 	require.Equal(t, component.Deactivated, state)
 	require.Equal(t, component.Deactivated, d.State())
 	require.Equal(t, component.Deactivated, c.State())
 
-	d1, err := component.NewComponent[component.MockComponentProvider](context.Background(),
+	d1, err := component.NewComponent[component.MockComponentProvider](t.Context(),
 		component.WithId("d1"), component.WithDomain(testDomain),
 		component.WithProvider(mockProvider(ctrl, 1)))
 	require.Nil(t, err)
 	require.NotNil(t, d1)
 	require.Equal(t, "lifecycle:d1", d1.Id().String())
 
-	d2, err := component.NewComponent[component.MockComponentProvider](context.Background(),
+	d2, err := component.NewComponent[component.MockComponentProvider](t.Context(),
 		component.WithId("d2"), component.WithDomain(testDomain),
 		component.WithProvider(mockProvider(ctrl, 1)))
 	require.Nil(t, err)
 	require.NotNil(t, d2)
 	require.Equal(t, "lifecycle:d2", d2.Id().String())
 
-	d3, err := component.NewComponent[component.MockComponentProvider](context.Background(),
+	d3, err := component.NewComponent[component.MockComponentProvider](t.Context(),
 		component.WithId("d3"), component.WithDomain(testDomain),
 		component.WithProvider(mockProvider(ctrl, 1)))
 	require.Nil(t, err)
 	require.NotNil(t, d3)
 	require.Equal(t, "lifecycle:d3", d3.Id().String())
 
-	c2, err := component.NewComponent[component.MockComponentProvider](context.Background(),
+	c2, err := component.NewComponent[component.MockComponentProvider](t.Context(),
 		component.WithId("c2"), component.WithDomain(testDomain),
 		component.WithProvider(mockProvider(ctrl, 1)),
 		component.WithDependencies(d1, d2, d3))
@@ -245,10 +246,10 @@ func TestComponentLifecycle(t *testing.T) {
 	require.NotNil(t, c2)
 	require.Equal(t, "lifecycle:c2", c2.Id().String())
 
-	err = c2.Activate(context.Background())
+	err = c2.Activate(t.Context())
 	require.Nil(t, err)
 
-	state, err = c2.AwaitState(context.Background(), component.Active)
+	state, err = c2.AwaitState(t.Context(), component.Active)
 	require.Nil(t, err)
 	require.Equal(t, component.Active, state)
 	require.Equal(t, component.Active, d1.State())
@@ -258,10 +259,10 @@ func TestComponentLifecycle(t *testing.T) {
 	require.Equal(t, component.Deactivated, c1.State())
 	require.Equal(t, component.Deactivated, c.State())
 
-	err = c2.Deactivate(context.Background())
+	err = c2.Deactivate(t.Context())
 	require.Nil(t, err)
 
-	state, err = c2.AwaitState(context.Background(), component.Deactivated)
+	state, err = c2.AwaitState(t.Context(), component.Deactivated)
 	require.Nil(t, err)
 	require.Equal(t, component.Deactivated, state)
 	require.Equal(t, component.Deactivated, d1.State())
@@ -280,28 +281,28 @@ func TestConfigre(t *testing.T) {
 		Return(nil).
 		Times(2)
 
-	c, err := component.NewComponent[component.MockConfigurable](context.Background(),
+	c, err := component.NewComponent[component.MockConfigurable](t.Context(),
 		component.WithProvider(p))
 	require.Nil(t, err)
 	require.NotNil(t, c)
 	require.Equal(t, "root:mockconfigurable", c.Id().String())
 
-	err = c.Activate(context.Background())
+	err = c.Activate(t.Context())
 	require.Nil(t, err)
 
-	state, err := c.AwaitState(context.Background(), component.Active)
+	state, err := c.AwaitState(t.Context(), component.Active)
 	require.Nil(t, err)
 	require.Equal(t, component.Active, state)
 	require.Equal(t, component.Active, c.State())
 
-	err = c.Configure(context.Background())
+	err = c.Configure(t.Context())
 	require.Nil(t, err)
 	require.Equal(t, component.Active, c.State())
 
-	err = c.Deactivate(context.Background())
+	err = c.Deactivate(t.Context())
 	require.Nil(t, err)
 
-	state, err = c.AwaitState(context.Background(), component.Deactivated)
+	state, err = c.AwaitState(t.Context(), component.Deactivated)
 	require.Nil(t, err)
 	require.Equal(t, component.Deactivated, state)
 	require.Equal(t, component.Deactivated, c.State())
@@ -312,20 +313,20 @@ func TestConfigre(t *testing.T) {
 		Return(nil).
 		Times(1)
 
-	c1, err := component.NewComponent[component.MockConfigurable](context.Background(),
+	c1, err := component.NewComponent[component.MockConfigurable](t.Context(),
 		component.WithProvider(p1))
 	require.Nil(t, err)
 	require.NotNil(t, c)
 	require.Equal(t, "root:mockconfigurable", c.Id().String())
 
-	err = c1.Configure(context.Background())
+	err = c1.Configure(t.Context())
 	require.Nil(t, err)
 	require.Equal(t, component.Configured, c1.State())
 
-	err = c1.Activate(context.Background())
+	err = c1.Activate(t.Context())
 	require.Nil(t, err)
 
-	state, err = c1.AwaitState(context.Background(), component.Active)
+	state, err = c1.AwaitState(t.Context(), component.Active)
 	require.Nil(t, err)
 	require.Equal(t, component.Active, state)
 	require.Equal(t, component.Active, c1.State())
@@ -333,13 +334,13 @@ func TestConfigre(t *testing.T) {
 
 func TestDomainLifecycle(t *testing.T) {
 	t.Skip("Superseded by hierarchy_test.go — gomock incompatible with shared root domain")
-	dom, err := component.NewComponentDomain(context.Background(), "domain")
+	dom, err := component.NewComponentDomain(t.Context(), "domain")
 	require.Nil(t, err)
 	require.NotNil(t, dom)
 	require.Equal(t, "root:domain", dom.Id().String())
 
 	ctrl := gomock.NewController(t)
-	c, err := component.NewComponent[component.MockComponentProvider](context.Background(),
+	c, err := component.NewComponent[component.MockComponentProvider](t.Context(),
 		component.WithDependentDomain(dom),
 		component.WithId("c"),
 		component.WithProvider(mockProvider(ctrl, 1)))
@@ -347,14 +348,14 @@ func TestDomainLifecycle(t *testing.T) {
 	require.NotNil(t, c)
 	require.Equal(t, "domain:c", c.Id().String())
 
-	d, err := component.NewComponent[component.MockComponentProvider](context.Background(),
+	d, err := component.NewComponent[component.MockComponentProvider](t.Context(),
 		component.WithId("d"),
 		component.WithProvider(mockProvider(ctrl, 1)))
 	require.Nil(t, err)
 	require.NotNil(t, d)
 	require.Equal(t, "root:d", d.Id().String())
 
-	c1, err := component.NewComponent[component.MockComponentProvider](context.Background(),
+	c1, err := component.NewComponent[component.MockComponentProvider](t.Context(),
 		component.WithDependentDomain(dom),
 		component.WithId("c1"),
 		component.WithProvider(mockProvider(ctrl, 1)),
@@ -364,28 +365,28 @@ func TestDomainLifecycle(t *testing.T) {
 	require.Equal(t, "domain:c1", c1.Id().String())
 	require.Equal(t, "domain:d", d.Id().String())
 
-	d1, err := component.NewComponent[component.MockComponentProvider](context.Background(),
+	d1, err := component.NewComponent[component.MockComponentProvider](t.Context(),
 		component.WithId("d1"),
 		component.WithProvider(mockProvider(ctrl, 1)))
 	require.Nil(t, err)
 	require.NotNil(t, d1)
 	require.Equal(t, "root:d1", d1.Id().String())
 
-	d2, err := component.NewComponent[component.MockComponentProvider](context.Background(),
+	d2, err := component.NewComponent[component.MockComponentProvider](t.Context(),
 		component.WithId("d2"),
 		component.WithProvider(mockProvider(ctrl, 1)))
 	require.Nil(t, err)
 	require.NotNil(t, d2)
 	require.Equal(t, "root:d2", d2.Id().String())
 
-	d3, err := component.NewComponent[component.MockComponentProvider](context.Background(),
+	d3, err := component.NewComponent[component.MockComponentProvider](t.Context(),
 		component.WithId("d3"),
 		component.WithProvider(mockProvider(ctrl, 1)))
 	require.Nil(t, err)
 	require.NotNil(t, d3)
 	require.Equal(t, "root:d3", d3.Id().String())
 
-	c2, err := component.NewComponent[component.MockComponentProvider](context.Background(),
+	c2, err := component.NewComponent[component.MockComponentProvider](t.Context(),
 		component.WithDependentDomain(dom),
 		component.WithId("c2"),
 		component.WithProvider(mockProvider(ctrl, 1)),
@@ -397,10 +398,10 @@ func TestDomainLifecycle(t *testing.T) {
 	require.Equal(t, "domain:d2", d2.Id().String())
 	require.Equal(t, "domain:d3", d3.Id().String())
 
-	err = dom.Activate(context.Background())
+	err = dom.Activate(t.Context())
 	require.Nil(t, err)
 
-	state, err := dom.AwaitState(context.Background(), component.Active)
+	state, err := dom.AwaitState(t.Context(), component.Active)
 	require.Nil(t, err)
 	require.Equal(t, component.Active, state)
 	require.Equal(t, component.Active, dom.State())
@@ -412,10 +413,10 @@ func TestDomainLifecycle(t *testing.T) {
 	require.Equal(t, component.Active, c2.State())
 	require.Equal(t, component.Active, c.State())
 
-	err = dom.Deactivate(context.Background())
+	err = dom.Deactivate(t.Context())
 	require.Nil(t, err)
 
-	state, err = dom.AwaitState(context.Background(), component.Deactivated)
+	state, err = dom.AwaitState(t.Context(), component.Deactivated)
 	require.Nil(t, err)
 	require.Equal(t, component.Deactivated, state)
 	require.Equal(t, component.Deactivated, dom.State())
@@ -437,17 +438,17 @@ func TestLogger(t *testing.T) {
 
 	component.LogLevel(liblog.LvlTrace)
 
-	c, err := component.NewComponent[provider](context.Background())
+	c, err := component.NewComponent[provider](t.Context())
 	require.Nil(t, err)
 	require.NotNil(t, c)
 	require.Equal(t, "root:provider", c.Id().String())
 
-	c.Activate(context.Background())
-	c.AwaitState(context.Background(), component.Active)
+	c.Activate(t.Context())
+	c.AwaitState(t.Context(), component.Active)
 
 	liblog.Root().SetHandler(
 		liblog.DiscardHandler())
-	c, err = component.NewComponent[provider](context.Background(),
+	c, err = component.NewComponent[provider](t.Context(),
 		component.WithLogLabels("label"),
 		component.WithLogCtx("name", "value"),
 		component.WithLogLevel(liblog.LvlDebug))
@@ -456,8 +457,8 @@ func TestLogger(t *testing.T) {
 	require.NotNil(t, c)
 	require.Equal(t, "root:provider", c.Id().String())
 
-	c.Activate(context.Background())
-	c.AwaitState(context.Background(), component.Active)
+	c.Activate(t.Context())
+	c.AwaitState(t.Context(), component.Active)
 
 }
 
@@ -506,7 +507,7 @@ func (p ctxprovider) Activate(ctx context.Context) error {
 }
 
 func TestContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	c, err := component.NewComponent[ctxprovider](ctx,
 		component.WithId("c"),
 		component.WithProvider(&ctxprovider{t: t}))
@@ -516,15 +517,15 @@ func TestContext(t *testing.T) {
 
 	c.Provider().c = c
 
-	c.Configure(context.Background())
+	c.Configure(t.Context())
 
-	c.Activate(context.Background())
-	state, err := c.AwaitState(context.Background(), component.Active)
+	c.Activate(t.Context())
+	state, err := c.AwaitState(t.Context(), component.Active)
 	require.Nil(t, err)
 	require.Equal(t, component.Active, state)
 
 	cancel()
-	state, err = c.AwaitState(context.Background(), component.Deactivated)
+	state, err = c.AwaitState(t.Context(), component.Deactivated)
 	require.Nil(t, err)
 	require.Equal(t, component.Deactivated, state)
 	require.Equal(t, component.Deactivated, c.State())
@@ -543,7 +544,7 @@ func TestFlags(t *testing.T) {
 	var iflag *cli.IntFlag
 	var callcount int
 
-	c, err := component.NewComponent[ctxprovider](context.Background(),
+	c, err := component.NewComponent[ctxprovider](t.Context(),
 		component.WithId("c"),
 		component.WithFlag[*cli.StringFlag, cfgprovider](sflag,
 			func(f *cli.StringFlag, p *cfgprovider) bool {
@@ -562,12 +563,12 @@ func TestFlags(t *testing.T) {
 	require.NotNil(t, c)
 	require.Len(t, c.Flags(), 2)
 	require.Equal(t, 0, callcount)
-	c.Configure(context.Background())
+	c.Configure(t.Context())
 	require.Equal(t, 2, callcount)
 
 	callcount = 0
 
-	d, err := component.NewComponent[component.MockComponentProvider](context.Background(),
+	d, err := component.NewComponent[component.MockComponentProvider](t.Context(),
 		component.WithId("d"),
 		component.WithFlag[*cli.StringFlag, cfgprovider](sflag,
 			func(f *cli.StringFlag, p *cfgprovider) bool {
@@ -580,7 +581,7 @@ func TestFlags(t *testing.T) {
 	require.NotNil(t, d)
 	require.Equal(t, "root:d", d.Id().String())
 
-	c1, err := component.NewComponent[component.MockComponentProvider](context.Background(),
+	c1, err := component.NewComponent[component.MockComponentProvider](t.Context(),
 		component.WithId("c1"),
 		component.WithFlag[*cli.StringFlag, cfgprovider](sflag,
 			func(f *cli.StringFlag, p *cfgprovider) bool {
@@ -601,7 +602,7 @@ func TestFlags(t *testing.T) {
 	require.Equal(t, "root:c1", c1.Id().String())
 	require.Len(t, c1.Flags(), 3)
 	require.Equal(t, 0, callcount)
-	c1.Configure(context.Background())
+	c1.Configure(t.Context())
 	require.Equal(t, 3, callcount)
 }
 
@@ -629,7 +630,7 @@ func (h *handler) H2(s0 string, s1 string) {
 }
 
 func TestEvents(t *testing.T) {
-	c, err := component.NewComponent[eprovider](context.Background(),
+	c, err := component.NewComponent[eprovider](t.Context(),
 		component.WithId("c"),
 		component.WithProvider(&eprovider{}))
 	require.Nil(t, err)
@@ -710,27 +711,27 @@ func TestEvents(t *testing.T) {
 
 func TestMultipleDependents(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	c, err := component.NewComponent[component.MockComponentProvider](context.Background(),
+	c, err := component.NewComponent[component.MockComponentProvider](t.Context(),
 		component.WithProvider(mockProvider(ctrl, 1)))
 	require.Nil(t, err)
 	require.NotNil(t, c)
 	require.Equal(t, "root:mockcomponentprovider", c.Id().String())
 
-	c1, err := component.NewComponent[component.MockComponentProvider](context.Background(),
+	c1, err := component.NewComponent[component.MockComponentProvider](t.Context(),
 		component.WithId("c1"),
 		component.WithProvider(mockProvider(ctrl, 1)))
 	require.Nil(t, err)
 	require.NotNil(t, c1)
 	require.Equal(t, "root:c1", c1.Id().String())
 
-	d, err := component.NewComponent[component.MockComponentProvider](context.Background(),
+	d, err := component.NewComponent[component.MockComponentProvider](t.Context(),
 		component.WithId("d"),
 		component.WithProvider(mockProvider(ctrl, 1)))
 	require.Nil(t, err)
 	require.NotNil(t, d)
 	require.Equal(t, "root:d", d.Id().String())
 
-	d1, err := component.NewComponent[component.MockComponentProvider](context.Background(),
+	d1, err := component.NewComponent[component.MockComponentProvider](t.Context(),
 		component.WithId("d1"),
 		component.WithProvider(mockProvider(ctrl, 1)))
 	require.Nil(t, err)
@@ -742,40 +743,40 @@ func TestMultipleDependents(t *testing.T) {
 	c1.AddDependency(d)
 	c1.AddDependency(d1)
 
-	err = c.Activate(context.Background())
+	err = c.Activate(t.Context())
 	require.Nil(t, err)
 
-	state, err := c.AwaitState(context.Background(), component.Active)
+	state, err := c.AwaitState(t.Context(), component.Active)
 	require.Nil(t, err)
 	require.Equal(t, component.Active, state)
 	require.Equal(t, component.Active, d.State())
 	require.Equal(t, component.Active, d1.State())
 	require.Equal(t, component.Instantiated, c1.State())
 
-	err = c1.Activate(context.Background())
+	err = c1.Activate(t.Context())
 	require.Nil(t, err)
 
-	state, err = c1.AwaitState(context.Background(), component.Active)
+	state, err = c1.AwaitState(t.Context(), component.Active)
 	require.Nil(t, err)
 	require.Equal(t, component.Active, state)
 	require.Equal(t, component.Active, d.State())
 	require.Equal(t, component.Active, d1.State())
 	require.Equal(t, component.Active, c.State())
 
-	err = c.Deactivate(context.Background())
+	err = c.Deactivate(t.Context())
 	require.Nil(t, err)
 
-	state, err = c.AwaitState(context.Background(), component.Deactivated)
+	state, err = c.AwaitState(t.Context(), component.Deactivated)
 	require.Nil(t, err)
 	require.Equal(t, component.Deactivated, state)
 	require.Equal(t, component.Active, d.State())
 	require.Equal(t, component.Active, d1.State())
 	require.Equal(t, component.Active, c1.State())
 
-	err = c1.Deactivate(context.Background())
+	err = c1.Deactivate(t.Context())
 	require.Nil(t, err)
 
-	state, err = c1.AwaitState(context.Background(), component.Deactivated)
+	state, err = c1.AwaitState(t.Context(), component.Deactivated)
 	require.Nil(t, err)
 	require.Equal(t, component.Deactivated, state)
 	require.Equal(t, component.Deactivated, d.State())
@@ -786,20 +787,20 @@ func TestMultipleDependents(t *testing.T) {
 func TestAddRemoveDeps(t *testing.T) {
 	t.Skip("Superseded by hierarchy_test.go — gomock incompatible with shared root domain")
 	ctrl := gomock.NewController(t)
-	c, err := component.NewComponent[component.MockComponentProvider](context.Background(),
+	c, err := component.NewComponent[component.MockComponentProvider](t.Context(),
 		component.WithProvider(mockProvider(ctrl, 1)))
 	require.Nil(t, err)
 	require.NotNil(t, c)
 	require.Equal(t, "root:mockcomponentprovider", c.Id().String())
 
-	d, err := component.NewComponent[component.MockComponentProvider](context.Background(),
+	d, err := component.NewComponent[component.MockComponentProvider](t.Context(),
 		component.WithId("d"),
 		component.WithProvider(mockProvider(ctrl, 1)))
 	require.Nil(t, err)
 	require.NotNil(t, d)
 	require.Equal(t, "root:d", d.Id().String())
 
-	d1, err := component.NewComponent[component.MockComponentProvider](context.Background(),
+	d1, err := component.NewComponent[component.MockComponentProvider](t.Context(),
 		component.WithId("d1"),
 		component.WithProvider(mockProvider(ctrl, 1)))
 	require.Nil(t, err)
@@ -809,10 +810,10 @@ func TestAddRemoveDeps(t *testing.T) {
 	c.AddDependency(d)
 	c.AddDependency(d1)
 
-	err = c.Activate(context.Background())
+	err = c.Activate(t.Context())
 	require.Nil(t, err)
 
-	state, err := c.AwaitState(context.Background(), component.Active)
+	state, err := c.AwaitState(t.Context(), component.Active)
 	require.Nil(t, err)
 	require.Equal(t, component.Active, state)
 	require.Equal(t, component.Active, d.State())
@@ -821,41 +822,41 @@ func TestAddRemoveDeps(t *testing.T) {
 
 	c.RemoveDependency(d1)
 
-	err = c.Deactivate(context.Background())
+	err = c.Deactivate(t.Context())
 	require.Nil(t, err)
 
-	state, err = c.AwaitState(context.Background(), component.Deactivated)
+	state, err = c.AwaitState(t.Context(), component.Deactivated)
 	require.Nil(t, err)
 	require.Equal(t, component.Deactivated, state)
 	require.Equal(t, component.Deactivated, d.State())
 	require.Equal(t, component.Active, d1.State())
 	require.Equal(t, component.Deactivated, c.State())
 
-	err = d1.Deactivate(context.Background())
+	err = d1.Deactivate(t.Context())
 	require.Nil(t, err)
 
-	state, err = d1.AwaitState(context.Background(), component.Deactivated)
+	state, err = d1.AwaitState(t.Context(), component.Deactivated)
 	require.Nil(t, err)
 	require.Equal(t, component.Deactivated, state)
 	require.Equal(t, component.Deactivated, d1.State())
 
-	c, err = component.NewComponent[component.MockComponentProvider](context.Background(),
+	c, err = component.NewComponent[component.MockComponentProvider](t.Context(),
 		component.WithProvider(mockProvider(ctrl, 1)))
 	require.Nil(t, err)
 	require.NotNil(t, c)
 	require.Equal(t, "root:mockcomponentprovider", c.Id().String())
 
-	d, err = component.NewComponent[component.MockComponentProvider](context.Background(),
+	d, err = component.NewComponent[component.MockComponentProvider](t.Context(),
 		component.WithId("d"),
 		component.WithProvider(mockProvider(ctrl, 1)))
 	require.Nil(t, err)
 	require.NotNil(t, d)
 	require.Equal(t, "root:d", d.Id().String())
 
-	err = c.Activate(context.Background())
+	err = c.Activate(t.Context())
 	require.Nil(t, err)
 
-	state, err = c.AwaitState(context.Background(), component.Active)
+	state, err = c.AwaitState(t.Context(), component.Active)
 	require.Nil(t, err)
 	require.Equal(t, component.Active, state)
 	require.Equal(t, component.Instantiated, d.State())
@@ -863,54 +864,54 @@ func TestAddRemoveDeps(t *testing.T) {
 
 	c.AddDependency(d)
 
-	state, err = d.AwaitState(context.Background(), component.Active)
+	state, err = d.AwaitState(t.Context(), component.Active)
 	require.Nil(t, err)
 	require.Equal(t, component.Active, state)
 	require.Equal(t, component.Active, d.State())
 	require.Equal(t, component.Active, c.State())
 
-	err = c.Deactivate(context.Background())
+	err = c.Deactivate(t.Context())
 	require.Nil(t, err)
 
-	state, err = c.AwaitState(context.Background(), component.Deactivated)
+	state, err = c.AwaitState(t.Context(), component.Deactivated)
 	require.Nil(t, err)
 	require.Equal(t, component.Deactivated, state)
 	require.Equal(t, component.Deactivated, d.State())
 	require.Equal(t, component.Deactivated, c.State())
 
-	c1, err := component.NewComponent[provider](context.Background(),
+	c1, err := component.NewComponent[provider](t.Context(),
 		component.WithProvider(&provider{}))
 	require.Nil(t, err)
 	require.NotNil(t, c1)
 	require.Equal(t, "root:provider", c1.Id().String())
 
-	d2, err := component.NewComponent[provider](context.Background(),
+	d2, err := component.NewComponent[provider](t.Context(),
 		component.WithId("d2"),
 		component.WithProvider(&provider{}))
 	require.Nil(t, err)
 	require.NotNil(t, d2)
 	require.Equal(t, "root:d2", d2.Id().String())
 
-	c1.Configure(context.Background())
+	c1.Configure(t.Context())
 	require.Equal(t, component.Configured, c1.State())
 
 	c1.AddDependency(d2)
 	require.Equal(t, component.Configured, c1.State())
 
-	c1, err = component.NewComponent[provider](context.Background(),
+	c1, err = component.NewComponent[provider](t.Context(),
 		component.WithProvider(&provider{}))
 	require.Nil(t, err)
 	require.NotNil(t, c1)
 	require.Equal(t, "root:provider", c1.Id().String())
 
-	d2, err = component.NewComponent[provider](context.Background(),
+	d2, err = component.NewComponent[provider](t.Context(),
 		component.WithId("d2"),
 		component.WithProvider(&provider{}))
 	require.Nil(t, err)
 	require.NotNil(t, d2)
 	require.Equal(t, "root:d2", d2.Id().String())
 
-	c1.Initialize(context.Background())
+	c1.Initialize(t.Context())
 	require.Equal(t, component.Initialised, c1.State())
 
 	c1.AddDependency(d2)
@@ -970,33 +971,33 @@ func (p errprovider) Deactivate(ctx context.Context) error {
 }
 
 func TestFails(t *testing.T) {
-	c, err := component.NewComponent[errprovider](context.Background(),
+	c, err := component.NewComponent[errprovider](t.Context(),
 		component.WithProvider(&errprovider{component.Configured}))
 	require.Nil(t, err)
 	require.NotNil(t, c)
 	require.Equal(t, "root:errprovider", c.Id().String())
 
-	err = c.Activate(context.Background())
+	err = c.Activate(t.Context())
 	require.NotNil(t, err)
 	require.Equal(t, "configure failed", err.Error())
 
-	c, err = component.NewComponent[errprovider](context.Background(),
+	c, err = component.NewComponent[errprovider](t.Context(),
 		component.WithProvider(&errprovider{component.Initialised}))
 	require.Nil(t, err)
 	require.NotNil(t, c)
 	require.Equal(t, "root:errprovider", c.Id().String())
 
-	err = c.Activate(context.Background())
+	err = c.Activate(t.Context())
 	require.NotNil(t, err)
 	require.Equal(t, "initialize failed", err.Error())
 
-	c, err = component.NewComponent[errprovider](context.Background(),
+	c, err = component.NewComponent[errprovider](t.Context(),
 		component.WithProvider(&errprovider{component.Activating}))
 	require.Nil(t, err)
 	require.NotNil(t, c)
 	require.Equal(t, "root:errprovider", c.Id().String())
 
-	err = c.Activate(context.Background(), component.ActivityHandlerFunc[errprovider](
+	err = c.Activate(t.Context(), component.ActivityHandlerFunc[errprovider](
 		func(ctx context.Context, c component.Component[errprovider], state component.State, err error) {
 			switch state {
 			case component.Configured,
@@ -1012,20 +1013,20 @@ func TestFails(t *testing.T) {
 		}))
 	require.Nil(t, err)
 
-	c.AwaitState(context.Background(), component.Failed)
+	c.AwaitState(t.Context(), component.Failed)
 
-	c, err = component.NewComponent[errprovider](context.Background(),
+	c, err = component.NewComponent[errprovider](t.Context(),
 		component.WithProvider(&errprovider{component.Deactivating}))
 	require.Nil(t, err)
 	require.NotNil(t, c)
 	require.Equal(t, "root:errprovider", c.Id().String())
 
-	err = c.Activate(context.Background())
+	err = c.Activate(t.Context())
 	require.Nil(t, err)
 
-	c.AwaitState(context.Background(), component.Active)
+	c.AwaitState(t.Context(), component.Active)
 
-	err = c.Deactivate(context.Background(), component.ActivityHandlerFunc[errprovider](
+	err = c.Deactivate(t.Context(), component.ActivityHandlerFunc[errprovider](
 		func(ctx context.Context, c component.Component[errprovider], state component.State, err error) {
 			switch state {
 			case component.Deactivating:
@@ -1039,5 +1040,5 @@ func TestFails(t *testing.T) {
 		}))
 	require.Nil(t, err)
 
-	c.AwaitState(context.Background(), component.Failed)
+	c.AwaitState(t.Context(), component.Failed)
 }

--- a/node/app/component/event_flow_test.go
+++ b/node/app/component/event_flow_test.go
@@ -23,11 +23,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/erigontech/erigon/node/app"
 	"github.com/erigontech/erigon/node/app/component"
 	"github.com/erigontech/erigon/node/app/event"
 	"github.com/erigontech/erigon/node/app/util"
-	"github.com/stretchr/testify/require"
 )
 
 // --- Test ExecPool (implements util.ExecPool) ---
@@ -290,18 +291,18 @@ func TestSyncHandlerTotalOrdering(t *testing.T) {
 // --- Component Lifecycle + Events Integration ---
 
 func TestComponentLifecycleWithEvents(t *testing.T) {
-	domain, err := component.NewComponentDomain(context.Background(), "evt-lifecycle")
+	domain, err := component.NewComponentDomain(t.Context(), "evt-lifecycle")
 	require.NoError(t, err)
 
 	tracker := &orderTracker{}
 
-	storage, err := component.NewComponent[eventProvider](context.Background(),
+	storage, err := component.NewComponent[eventProvider](t.Context(),
 		component.WithId("storage"),
 		component.WithDomain(domain),
 		component.WithProvider(&eventProvider{name: "storage", tracker: tracker}))
 	require.NoError(t, err)
 
-	dl, err := component.NewComponent[eventProvider](context.Background(),
+	dl, err := component.NewComponent[eventProvider](t.Context(),
 		component.WithId("downloader"),
 		component.WithDomain(domain),
 		component.WithProvider(&eventProvider{name: "downloader", tracker: tracker}),
@@ -309,17 +310,17 @@ func TestComponentLifecycleWithEvents(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start
-	err = dl.Activate(context.Background())
+	err = dl.Activate(t.Context())
 	require.NoError(t, err)
-	_, err = dl.AwaitState(context.Background(), component.Active)
+	_, err = dl.AwaitState(t.Context(), component.Active)
 	require.NoError(t, err)
 	require.Equal(t, component.Active, storage.State())
 
 	// Stop
-	err = dl.Deactivate(context.Background())
+	err = dl.Deactivate(t.Context())
 	require.NoError(t, err)
 
-	waitCtx, waitCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	waitCtx, waitCancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer waitCancel()
 	_, err = dl.AwaitState(waitCtx, component.Deactivated)
 	require.NoError(t, err)

--- a/node/app/component/fuzz_test.go
+++ b/node/app/component/fuzz_test.go
@@ -60,7 +60,7 @@ func TestFuzzLifecycleConcurrent(t *testing.T) {
 	t.Logf("seed=%d (reproduce with rand.NewSource(%d))", seed, seed)
 	rng := rand.New(rand.NewSource(seed))
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Build a fixed tree: 0 is root, each subsequent component depends on
 	// exactly one earlier component (DAG, no cycles).
@@ -167,7 +167,7 @@ func TestFuzzLifecycleSerial(t *testing.T) {
 	t.Logf("seed=%d", seed)
 	rng := rand.New(rand.NewSource(seed))
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	components := make([]component.Component[fuzzProvider], numComponents)
 	for i := 0; i < numComponents; i++ {
@@ -234,7 +234,7 @@ func TestFuzzAddRemoveConcurrent(t *testing.T) {
 	t.Logf("seed=%d", seed)
 	rng := rand.New(rand.NewSource(seed))
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	components := make([]component.Component[fuzzProvider], numComponents)
 	for i := 0; i < numComponents; i++ {

--- a/node/app/component/hierarchy_test.go
+++ b/node/app/component/hierarchy_test.go
@@ -22,9 +22,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/erigontech/erigon/node/app"
 	"github.com/erigontech/erigon/node/app/component"
-	"github.com/stretchr/testify/require"
 )
 
 // --- Test Infrastructure ---
@@ -85,21 +86,21 @@ func (p *trackedProvider) Deactivate(ctx context.Context) error {
 // TestIsolatedDomain verifies that components in an isolated domain
 // don't interfere with the shared root domain.
 func TestIsolatedDomain(t *testing.T) {
-	domain, err := component.NewComponentDomain(context.Background(), "isolated")
+	domain, err := component.NewComponentDomain(t.Context(), "isolated")
 	require.NoError(t, err)
 
 	tracker := &orderTracker{}
-	c, err := component.NewComponent[trackedProvider](context.Background(),
+	c, err := component.NewComponent[trackedProvider](t.Context(),
 		component.WithId("comp"),
 		component.WithDomain(domain),
 		component.WithProvider(&trackedProvider{name: "comp", tracker: tracker}))
 	require.NoError(t, err)
 	require.Equal(t, "isolated:comp", c.Id().String())
 
-	err = c.Activate(context.Background())
+	err = c.Activate(t.Context())
 	require.NoError(t, err)
 
-	state, err := c.AwaitState(context.Background(), component.Active)
+	state, err := c.AwaitState(t.Context(), component.Active)
 	require.NoError(t, err)
 	require.Equal(t, component.Active, state)
 
@@ -108,10 +109,10 @@ func TestIsolatedDomain(t *testing.T) {
 	require.Contains(t, events, "comp:initialize")
 	require.Contains(t, events, "comp:activate")
 
-	err = c.Deactivate(context.Background())
+	err = c.Deactivate(t.Context())
 	require.NoError(t, err)
 
-	state, err = c.AwaitState(context.Background(), component.Deactivated)
+	state, err = c.AwaitState(t.Context(), component.Deactivated)
 	require.NoError(t, err)
 	require.Equal(t, component.Deactivated, state)
 
@@ -123,20 +124,20 @@ func TestIsolatedDomain(t *testing.T) {
 // their dependents — modeling the Storage → Downloader → SnapshotManager
 // hierarchy.
 func TestDependencyActivationOrder(t *testing.T) {
-	domain, err := component.NewComponentDomain(context.Background(), "order-test")
+	domain, err := component.NewComponentDomain(t.Context(), "order-test")
 	require.NoError(t, err)
 
 	tracker := &orderTracker{}
 
 	// Storage — no dependencies (foundation)
-	storage, err := component.NewComponent[trackedProvider](context.Background(),
+	storage, err := component.NewComponent[trackedProvider](t.Context(),
 		component.WithId("storage"),
 		component.WithDomain(domain),
 		component.WithProvider(&trackedProvider{name: "storage", tracker: tracker}))
 	require.NoError(t, err)
 
 	// Downloader — depends on Storage
-	downloader, err := component.NewComponent[trackedProvider](context.Background(),
+	downloader, err := component.NewComponent[trackedProvider](t.Context(),
 		component.WithId("downloader"),
 		component.WithDomain(domain),
 		component.WithProvider(&trackedProvider{name: "downloader", tracker: tracker}),
@@ -144,7 +145,7 @@ func TestDependencyActivationOrder(t *testing.T) {
 	require.NoError(t, err)
 
 	// SnapshotManager — depends on Downloader (and transitively on Storage)
-	snapMgr, err := component.NewComponent[trackedProvider](context.Background(),
+	snapMgr, err := component.NewComponent[trackedProvider](t.Context(),
 		component.WithId("snapshot-manager"),
 		component.WithDomain(domain),
 		component.WithProvider(&trackedProvider{name: "snapshot-manager", tracker: tracker}),
@@ -152,10 +153,10 @@ func TestDependencyActivationOrder(t *testing.T) {
 	require.NoError(t, err)
 
 	// Activate the leaf — should cascade to activate dependencies first
-	err = snapMgr.Activate(context.Background())
+	err = snapMgr.Activate(t.Context())
 	require.NoError(t, err)
 
-	state, err := snapMgr.AwaitState(context.Background(), component.Active)
+	state, err := snapMgr.AwaitState(t.Context(), component.Active)
 	require.NoError(t, err)
 	require.Equal(t, component.Active, state)
 
@@ -188,7 +189,7 @@ func TestDependencyActivationOrder(t *testing.T) {
 // may see stale state because deactivation is async (goroutine at line 1001).
 // This test is skipped until the framework bug is fixed.
 func TestDependencyDeactivationOrder(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	domain, err := component.NewComponentDomain(ctx, "deactivation-test")
 	require.NoError(t, err)
 
@@ -215,10 +216,10 @@ func TestDependencyDeactivationOrder(t *testing.T) {
 	require.Equal(t, component.Active, storage.State())
 
 	// Deactivate the leaf — should cascade to deactivate dependencies
-	err = downloader.Deactivate(context.Background())
+	err = downloader.Deactivate(t.Context())
 	require.NoError(t, err)
 
-	waitCtx, waitCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	waitCtx, waitCancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer waitCancel()
 
 	state, err := downloader.AwaitState(waitCtx, component.Deactivated)
@@ -246,7 +247,7 @@ func TestDependencyDeactivationOrder(t *testing.T) {
 // Storage → Downloader → SnapshotManager, all in an isolated domain.
 // Verifies clean startup, all states correct, clean shutdown.
 func TestThreeLevelHierarchy(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	domain, err := component.NewComponentDomain(ctx, "hierarchy")
 	require.NoError(t, err)
 
@@ -292,10 +293,10 @@ func TestThreeLevelHierarchy(t *testing.T) {
 		"activation order wrong: storage=%d, downloader=%d, snap-mgr=%d", sAct, dAct, smAct)
 
 	// Deactivate from the leaf — should cascade through the full tree
-	err = snapMgr.Deactivate(context.Background())
+	err = snapMgr.Deactivate(t.Context())
 	require.NoError(t, err)
 
-	waitCtx, waitCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	waitCtx, waitCancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer waitCancel()
 
 	_, err = snapMgr.AwaitState(waitCtx, component.Deactivated)
@@ -320,25 +321,25 @@ func TestThreeLevelHierarchy(t *testing.T) {
 // depend on the same base component (e.g., both Downloader and TxPool
 // depend on Storage).
 func TestMultipleDependentsOnSameBase(t *testing.T) {
-	domain, err := component.NewComponentDomain(context.Background(), "multi-dep")
+	domain, err := component.NewComponentDomain(t.Context(), "multi-dep")
 	require.NoError(t, err)
 
 	tracker := &orderTracker{}
 
-	storage, err := component.NewComponent[trackedProvider](context.Background(),
+	storage, err := component.NewComponent[trackedProvider](t.Context(),
 		component.WithId("storage"),
 		component.WithDomain(domain),
 		component.WithProvider(&trackedProvider{name: "storage", tracker: tracker}))
 	require.NoError(t, err)
 
-	downloader, err := component.NewComponent[trackedProvider](context.Background(),
+	downloader, err := component.NewComponent[trackedProvider](t.Context(),
 		component.WithId("downloader"),
 		component.WithDomain(domain),
 		component.WithProvider(&trackedProvider{name: "downloader", tracker: tracker}),
 		component.WithDependencies(storage))
 	require.NoError(t, err)
 
-	txpool, err := component.NewComponent[trackedProvider](context.Background(),
+	txpool, err := component.NewComponent[trackedProvider](t.Context(),
 		component.WithId("txpool"),
 		component.WithDomain(domain),
 		component.WithProvider(&trackedProvider{name: "txpool", tracker: tracker}),
@@ -346,14 +347,14 @@ func TestMultipleDependentsOnSameBase(t *testing.T) {
 	require.NoError(t, err)
 
 	// Activate both leaves
-	err = downloader.Activate(context.Background())
+	err = downloader.Activate(t.Context())
 	require.NoError(t, err)
-	_, err = downloader.AwaitState(context.Background(), component.Active)
+	_, err = downloader.AwaitState(t.Context(), component.Active)
 	require.NoError(t, err)
 
-	err = txpool.Activate(context.Background())
+	err = txpool.Activate(t.Context())
 	require.NoError(t, err)
-	_, err = txpool.AwaitState(context.Background(), component.Active)
+	_, err = txpool.AwaitState(t.Context(), component.Active)
 	require.NoError(t, err)
 
 	// All three active
@@ -362,9 +363,9 @@ func TestMultipleDependentsOnSameBase(t *testing.T) {
 	require.Equal(t, component.Active, txpool.State())
 
 	// Deactivate downloader — storage should stay active (txpool still depends on it)
-	err = downloader.Deactivate(context.Background())
+	err = downloader.Deactivate(t.Context())
 	require.NoError(t, err)
-	_, err = downloader.AwaitState(context.Background(), component.Deactivated)
+	_, err = downloader.AwaitState(t.Context(), component.Deactivated)
 	require.NoError(t, err)
 
 	require.Equal(t, component.Deactivated, downloader.State())

--- a/node/app/workerpool/workerpool_test.go
+++ b/node/app/workerpool/workerpool_test.go
@@ -133,7 +133,7 @@ func TestWorkerTimeout(t *testing.T) {
 	defer wp.Stop()
 
 	// Start workers, and have them all wait on ctx before completing.
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	wp.Pause(ctx)
 
 	if anyReady(wp) {
@@ -170,7 +170,7 @@ func TestStop(t *testing.T) {
 	wp := New(max)
 
 	// Start workers, and have them all wait on ctx before completing.
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	wp.Pause(ctx)
 
 	// Release workers.
@@ -437,7 +437,7 @@ func TestPause(t *testing.T) {
 	wp := New(25)
 	defer wp.Stop()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	ran := make(chan struct{})
 	wp.Submit(func() {
@@ -483,10 +483,10 @@ func TestPause(t *testing.T) {
 
 	// ---- Test pause while paused
 
-	ctx, cancel = context.WithCancel(context.Background())
+	ctx, cancel = context.WithCancel(t.Context())
 	wp.Pause(ctx)
 
-	ctx2, cancel2 := context.WithCancel(context.Background())
+	ctx2, cancel2 := context.WithCancel(t.Context())
 
 	pauseDone := make(chan struct{})
 	go func() {
@@ -516,8 +516,8 @@ func TestPause(t *testing.T) {
 
 	// ---- Test concurrent pauses
 
-	ctx, cancel = context.WithCancel(context.Background())
-	ctx2, cancel2 = context.WithCancel(context.Background())
+	ctx, cancel = context.WithCancel(t.Context())
+	ctx2, cancel2 = context.WithCancel(t.Context())
 	pauseDone = make(chan struct{})
 	pause2Done := make(chan struct{})
 	go func() {
@@ -544,8 +544,8 @@ func TestPause(t *testing.T) {
 
 	// ---- Test stopping paused pool ----
 
-	ctx, cancel = context.WithCancel(context.Background())
-	ctx2, cancel2 = context.WithCancel(context.Background())
+	ctx, cancel = context.WithCancel(t.Context())
+	ctx2, cancel2 = context.WithCancel(t.Context())
 
 	// Stack up two pauses
 	wp.Pause(ctx)
@@ -581,7 +581,7 @@ func TestPause(t *testing.T) {
 
 	// ---- Test pause after stop ----
 
-	ctx, cancel = context.WithCancel(context.Background())
+	ctx, cancel = context.WithCancel(t.Context())
 	pauseDone = make(chan struct{})
 	go func() {
 		wp.Pause(ctx)

--- a/node/components/downloader/provider_test.go
+++ b/node/components/downloader/provider_test.go
@@ -17,13 +17,13 @@
 package downloader
 
 import (
-	"context"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/node/ethconfig"
-	"github.com/stretchr/testify/require"
 )
 
 func TestProviderDisabled(t *testing.T) {
@@ -36,7 +36,7 @@ func TestProviderDisabled(t *testing.T) {
 		nil,
 	)
 
-	err := p.Initialize(context.Background())
+	err := p.Initialize(t.Context())
 	require.NoError(t, err)
 	require.False(t, p.IsEnabled())
 	require.Nil(t, p.Client)
@@ -56,7 +56,7 @@ func TestProviderNoConfig(t *testing.T) {
 		nil,
 	)
 
-	err := p.Initialize(context.Background())
+	err := p.Initialize(t.Context())
 	require.NoError(t, err)
 	// No config → no client, but no error
 	require.Nil(t, p.Client)

--- a/node/components/sentry/provider_test.go
+++ b/node/components/sentry/provider_test.go
@@ -17,7 +17,6 @@
 package sentry
 
 import (
-	"context"
 	"net"
 	"testing"
 
@@ -32,7 +31,7 @@ import (
 func TestConfigureIsPure(t *testing.T) {
 	p := &Provider{}
 	cfg := Config{
-		SentryCtx: context.Background(),
+		SentryCtx: t.Context(),
 		Logger:    log.Root(),
 	}
 	p.Configure(cfg)
@@ -54,7 +53,7 @@ func TestCloseIdempotent(t *testing.T) {
 
 	// Configure, then Close twice.
 	p.Configure(Config{
-		SentryCtx: context.Background(),
+		SentryCtx: t.Context(),
 		Logger:    log.Root(),
 	})
 	p.Close()

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -20,7 +20,6 @@
 package node
 
 import (
-	"context"
 	"errors"
 	"reflect"
 	"runtime"
@@ -55,7 +54,7 @@ func TestNodeCloseMultipleTimes(t *testing.T) {
 		t.Skip("fix me on win please")
 	}
 
-	stack, err := New(context.Background(), testNodeConfig(t), log.New())
+	stack, err := New(t.Context(), testNodeConfig(t), log.New())
 	if err != nil {
 		t.Fatalf("failed to create protocol stack: %v", err)
 	}
@@ -74,7 +73,7 @@ func TestNodeStartMultipleTimes(t *testing.T) {
 		t.Skip("fix me on win please")
 	}
 
-	stack, err := New(context.Background(), testNodeConfig(t), log.New())
+	stack, err := New(t.Context(), testNodeConfig(t), log.New())
 	if err != nil {
 		t.Fatalf("failed to create protocol stack: %v", err)
 	}
@@ -109,7 +108,7 @@ func TestNodeUsedDataDir(t *testing.T) {
 	dir := t.TempDir()
 
 	// Create a new node based on the data directory
-	original, originalErr := New(context.Background(), &nodecfg.Config{Dirs: datadir.New(dir)}, log.New())
+	original, originalErr := New(t.Context(), &nodecfg.Config{Dirs: datadir.New(dir)}, log.New())
 	if originalErr != nil {
 		t.Fatalf("failed to create original protocol stack: %v", originalErr)
 	}
@@ -119,14 +118,14 @@ func TestNodeUsedDataDir(t *testing.T) {
 	}
 
 	// Create a second node based on the same data directory and ensure failure
-	if _, err := New(context.Background(), &nodecfg.Config{Dirs: datadir.New(dir)}, log.New()); !errors.Is(err, datadir.ErrDataDirLocked) {
+	if _, err := New(t.Context(), &nodecfg.Config{Dirs: datadir.New(dir)}, log.New()); !errors.Is(err, datadir.ErrDataDirLocked) {
 		t.Fatalf("duplicate datadir failure mismatch: have %v, want %v", err, datadir.ErrDataDirLocked)
 	}
 }
 
 // Tests whether a Lifecycle can be registered.
 func TestLifecycleRegistry_Successful(t *testing.T) {
-	stack, err := New(context.Background(), testNodeConfig(t), log.New())
+	stack, err := New(t.Context(), testNodeConfig(t), log.New())
 	if err != nil {
 		t.Fatalf("failed to create protocol stack: %v", err)
 	}
@@ -153,21 +152,21 @@ func TestNodeCloseClosesDB(t *testing.T) {
 	}
 
 	logger := log.New()
-	stack, _ := New(context.Background(), testNodeConfig(t), logger)
+	stack, _ := New(t.Context(), testNodeConfig(t), logger)
 	defer stack.Close()
 
-	db, err := OpenDatabase(context.Background(), stack.Config(), dbcfg.SentryDB, "", false, logger)
+	db, err := OpenDatabase(t.Context(), stack.Config(), dbcfg.SentryDB, "", false, logger)
 	if err != nil {
 		t.Fatal("can't open DB:", err)
 	}
-	if err = db.Update(context.Background(), func(tx kv.RwTx) error {
+	if err = db.Update(t.Context(), func(tx kv.RwTx) error {
 		return tx.Put(kv.Inodes, []byte("testK"), []byte{})
 	}); err != nil {
 		t.Fatal("can't Put on open DB:", err)
 	}
 
 	stack.Close()
-	//if err = db.Update(context.Background(), func(tx kv.RwTx) error {
+	//if err = db.Update(t.Context(), func(tx kv.RwTx) error {
 	//	return tx.Put(kv.Inodes, []byte("testK"), []byte{})
 	//}); err == nil {
 	//	t.Fatal("Put succeeded after node is closed")
@@ -181,14 +180,14 @@ func TestNodeOpenDatabaseFromLifecycleStart(t *testing.T) {
 	}
 
 	logger := log.New()
-	stack, err := New(context.Background(), testNodeConfig(t), logger)
+	stack, err := New(t.Context(), testNodeConfig(t), logger)
 	require.NoError(t, err)
 	defer stack.Close()
 
 	var db kv.RwDB
 	stack.RegisterLifecycle(&InstrumentedService{
 		startHook: func() {
-			db, err = OpenDatabase(context.Background(), stack.Config(), dbcfg.SentryDB, "", false, logger)
+			db, err = OpenDatabase(t.Context(), stack.Config(), dbcfg.SentryDB, "", false, logger)
 			if err != nil {
 				t.Fatal("can't open DB:", err)
 			}
@@ -209,12 +208,12 @@ func TestNodeOpenDatabaseFromLifecycleStop(t *testing.T) {
 	}
 
 	logger := log.New()
-	stack, _ := New(context.Background(), testNodeConfig(t), logger)
+	stack, _ := New(t.Context(), testNodeConfig(t), logger)
 	defer stack.Close()
 
 	stack.RegisterLifecycle(&InstrumentedService{
 		stopHook: func() {
-			db, err := OpenDatabase(context.Background(), stack.Config(), dbcfg.ChainDB, "", false, logger)
+			db, err := OpenDatabase(t.Context(), stack.Config(), dbcfg.ChainDB, "", false, logger)
 			if err != nil {
 				t.Fatal("can't open DB:", err)
 			}
@@ -228,7 +227,7 @@ func TestNodeOpenDatabaseFromLifecycleStop(t *testing.T) {
 
 // Tests that registered Lifecycles get started and stopped correctly.
 func TestLifecycleLifeCycle(t *testing.T) {
-	stack, _ := New(context.Background(), testNodeConfig(t), log.New())
+	stack, _ := New(t.Context(), testNodeConfig(t), log.New())
 	defer stack.Close()
 
 	started := make(map[string]bool)
@@ -283,7 +282,7 @@ func TestLifecycleStartupError(t *testing.T) {
 		t.Skip("fix me on win please")
 	}
 
-	stack, err := New(context.Background(), testNodeConfig(t), log.New())
+	stack, err := New(t.Context(), testNodeConfig(t), log.New())
 	if err != nil {
 		t.Fatalf("failed to create protocol stack: %v", err)
 	}
@@ -333,7 +332,7 @@ func TestLifecycleStartupError(t *testing.T) {
 // Tests that even if a registered Lifecycle fails to shut down cleanly, it does
 // not influence the rest of the shutdown invocations.
 func TestLifecycleTerminationGuarantee(t *testing.T) {
-	stack, err := New(context.Background(), testNodeConfig(t), log.New())
+	stack, err := New(t.Context(), testNodeConfig(t), log.New())
 	if err != nil {
 		t.Fatalf("failed to create protocol stack: %v", err)
 	}

--- a/node/nodecfg/config_test.go
+++ b/node/nodecfg/config_test.go
@@ -20,7 +20,6 @@
 package nodecfg_test
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -41,7 +40,7 @@ func TestDataDirCreation(t *testing.T) {
 	}
 	// Create a temporary data dir and check that it can be used by a node
 	dir := t.TempDir()
-	node, err := node2.New(context.Background(), &nodecfg.Config{Dirs: datadir.New(dir)}, log.New())
+	node, err := node2.New(t.Context(), &nodecfg.Config{Dirs: datadir.New(dir)}, log.New())
 	if err != nil {
 		t.Fatalf("failed to create stack with existing datadir: %v", err)
 	}
@@ -50,7 +49,7 @@ func TestDataDirCreation(t *testing.T) {
 	}
 	// Generate a long non-existing datadir path and check that it gets created by a node
 	dir = filepath.Join(dir, "a", "b", "c", "d", "e", "f")
-	node, err = node2.New(context.Background(), &nodecfg.Config{Dirs: datadir.New(dir)}, log.New())
+	node, err = node2.New(t.Context(), &nodecfg.Config{Dirs: datadir.New(dir)}, log.New())
 	if err != nil {
 		t.Fatalf("failed to create stack with creatable datadir: %v", err)
 	}


### PR DESCRIPTION
Replace `context.Background()` with `t.Context()` in test files across `db/` and `node/` packages.

`t.Context()` (added in Go 1.21) returns a context that is cancelled when the test ends, which is more appropriate than `context.Background()` — it ensures resources are cleaned up if a test exits early and makes test cancellation propagate correctly.