### PR TITLE
[DO-NOT-MERGE] ci: use hive eest stable fixtures instead of develop

### DIFF
--- a/.claude/skills/erigon-test-hive/SKILL.md
+++ b/.claude/skills/erigon-test-hive/SKILL.md
@@ -119,7 +119,7 @@ cd temp/<hive-dir>/hive
 
 # Run EEST engine simulator
 ./hive --sim ethereum/eels/consume-engine --sim.limit="" --client erigon \
-  --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/v5.3.0/fixtures_develop.tar.gz
+  --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/v5.3.0/fixtures_stable.tar.gz
 ```
 
 ## Suites Covered

--- a/.claude/skills/hive-test/SKILL.md
+++ b/.claude/skills/hive-test/SKILL.md
@@ -263,7 +263,7 @@ See https://eest.ethereum.org/main/running_tests/running/#engine-vs-rlp-simulato
 The full RLP test set is too large to run end-to-end in CI — always pass a
 `--sim.limit` regex narrowing the scope. CI mirrors this by running only
 `.*eip2930_access_list.*`. For local debugging, target a single EIP / opcode
-group similarly. Fixtures come from the same `fixtures_develop.tar.gz` archive
+group similarly. Fixtures come from the same `fixtures_stable.tar.gz` archive
 as consume-engine.
 
 ```bash
@@ -273,7 +273,7 @@ as consume-engine.
   --sim ethereum/eels/consume-rlp \
   --sim.limit=".*eip2930_access_list.*" \
   --sim.parallelism=12 --docker.nocache=true \
-  --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/${EEST_VERSION}/fixtures_develop.tar.gz \
+  --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/${EEST_VERSION}/fixtures_stable.tar.gz \
   --sim.timelimit 60m
 ```
 

--- a/.claude/skills/hive-test/SKILL.md
+++ b/.claude/skills/hive-test/SKILL.md
@@ -228,7 +228,7 @@ with `--sim.limit "suite1|suite2|..."`.
 ./hive --client-file erigon-local.yaml \
   --sim ethereum/eels/consume-engine \
   --sim.parallelism=12 --docker.nocache=true \
-  --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/${EEST_VERSION}/fixtures_develop.tar.gz \
+  --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/${EEST_VERSION}/fixtures_stable.tar.gz \
   --sim.timelimit 60m
 ```
 

--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -143,7 +143,7 @@ jobs:
           docker ps
           fixtures_url="${{ matrix.fixtures-url }}"
           if [ -z "$fixtures_url" ]; then
-            fixtures_url="https://github.com/ethereum/execution-spec-tests/releases/download/${{ env.EEST_VERSION }}/fixtures_develop.tar.gz"
+            fixtures_url="https://github.com/ethereum/execution-spec-tests/releases/download/${{ env.EEST_VERSION }}/fixtures_stable.tar.gz"
           fi
           run_suite() {
             echo -e "\n\n============================================================"

--- a/Makefile
+++ b/Makefile
@@ -353,7 +353,7 @@ eest-hive:
 		sed -i'' -e "s/^ARG tag=main-latest$$/ARG tag=$(SHORT_COMMIT)/" clients/erigon/Dockerfile
 	cd "temp/eest-hive-$(SHORT_COMMIT)/hive" && go build . 2>&1 | tee buildlogs.log
 	cd "temp/eest-hive-$(SHORT_COMMIT)/hive" && go build ./cmd/hiveview && ./hiveview --serve --logdir ./workspace/logs &
-	cd "temp/eest-hive-$(SHORT_COMMIT)/hive" && $(call run_suite,eels/consume-engine,"",--sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/${EEST_VERSION}/fixtures_develop.tar.gz)
+	cd "temp/eest-hive-$(SHORT_COMMIT)/hive" && $(call run_suite,eels/consume-engine,"",--sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/${EEST_VERSION}/fixtures_stable.tar.gz)
 
 # define kurtosis assertoor runner
 define run-kurtosis-assertoor


### PR DESCRIPTION
our CI now has a devnet shard (e.g. eest glamsterdam-devnet), so our stable shard should use the "stable" fixtures instead of the "develop" ones, check https://eest.ethereum.org/main/running_tests/releases/#standard-releases