### PR TITLE
execution/vm: preserve EIP-4788 no-op-when-not-deployed syscall semantics

### DIFF
--- a/execution/vm/evm.go
+++ b/execution/vm/evm.go
@@ -328,7 +328,12 @@ func (evm *EVM) call(typ OpCode, caller accounts.Address, callerAddress accounts
 			return nil, mdgas.MdGas{}, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
 		}
 		if !exist {
-			if !isPrecompile && evm.chainRules.IsSpuriousDragon && value.IsZero() && !syscall {
+			// EIP-4788/6110/7002/7251 system calls to a non-deployed target
+			// are no-ops (see e.g. EIP-4788: "If the contract code is empty,
+			// the system call is a no-op"). Short-circuit here to preserve
+			// that semantics at the fork-transition block where the target
+			// contract has not been deployed yet.
+			if !isPrecompile && evm.chainRules.IsSpuriousDragon && value.IsZero() {
 				return nil, gas, nil
 			}
 			evm.intraBlockState.CreateAccount(addr, false)

--- a/execution/vm/evm.go
+++ b/execution/vm/evm.go
@@ -328,11 +328,11 @@ func (evm *EVM) call(typ OpCode, caller accounts.Address, callerAddress accounts
 			return nil, mdgas.MdGas{}, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
 		}
 		if !exist {
-			// EIP-4788/6110/7002/7251 system calls to a non-deployed target
-			// are no-ops (see e.g. EIP-4788: "If the contract code is empty,
-			// the system call is a no-op"). Short-circuit here to preserve
-			// that semantics at the fork-transition block where the target
-			// contract has not been deployed yet.
+			// Under Spurious Dragon, a zero-value CALL to a non-existent
+			// non-precompile account short-circuits as a no-op instead of
+			// creating the account. This also preserves the EIP-4788
+			// beacon-root syscall's "no-op when not deployed" semantics at
+			// the fork-transition block, before the contract is deployed.
 			if !isPrecompile && evm.chainRules.IsSpuriousDragon && value.IsZero() {
 				return nil, gas, nil
 			}


### PR DESCRIPTION
## Summary

#19277 added `&& !syscall` to the Spurious Dragon zero-value short-circuit in `evm.call`, causing system calls to a non-deployed target to run `CreateAccount(addr, false)` instead of returning a no-op. That violates EIP-4788's rule that *"if the contract code is empty, the system call is a no-op"*, specifically at the fork-transition block where the beacon-root contract is deployed later in the same block by a CREATE tx.

## Repro

On #20606 (`bal-devnet-4`), which flips `ExperimentalBAL + Exec3Parallel` on by default, the eest_blockchain suite fails:

```
--- FAIL: TestExecutionSpecBlockchain/cancun/eip4788_beacon_root/
          test_beacon_root_contract_deploy.json/.../deploy_on_cancun
block_test.go:62: block #[2 0 0 0] insertion into chain failed:
  BadBlock err: updateForkChoice: [4/6 Execution] invalid block,
  block=2, gas used by execution: 52529, in header: 116552
```

Block 1 is the first Cancun block (timestamp=15000, fork point). The EIP-4788 pre-block syscall fires *before* the beacon-root contract is deployed later in block 1's tx 0. Post-#19277, the syscall calls `CreateAccount(0x000f3df6…, false)` at the beacon-root address, diverting state so block 2's verifier tx underuses gas by ~64k.

Reverting only the `!syscall` clause from the short-circuit — while keeping the rest of #19277 — makes the test green without regressing `TestSystemCallZeroValueSkipsTransferChecks` (its target already exists, so this branch isn't exercised).

## Change

`execution/vm/evm.go`, one hunk:

```diff
 if !exist {
-    if !isPrecompile && evm.chainRules.IsSpuriousDragon && value.IsZero() && !syscall {
+    // EIP-4788/6110/7002/7251 system calls to a non-deployed target are
+    // no-ops ... short-circuit to preserve that at the fork-transition block.
+    if !isPrecompile && evm.chainRules.IsSpuriousDragon && value.IsZero() {
         return nil, gas, nil
     }
     evm.intraBlockState.CreateAccount(addr, false)
 }
```

Everything else from #19277 is preserved: the zero-value `CanTransfer` skip, `TouchAccount(caller)` instead of `Transfer` for syscalls, and the `intra_block_state.go` refactor.

## Validation

Local:
- [x] `cancun/eip4788_beacon_root/*` — all pass (8.5s)
- [x] Full `cancun` eest_blockchain suite — pass (167s)
- [x] Full `prague` eest_blockchain suite — pass (85s)
- [x] `TestSystemCallZeroValueSkipsTransferChecks` — pass (still green)
- [x] `execution/state` + `execution/stagedsync` unit tests — pass
- [x] `make lint` — clean

## Test plan

- [ ] CI Gate green on this branch
- [ ] Rebase #20606 onto this and confirm `race-tests / execution-eest-blockchain` turns green there

## Related

- Introduced by: #19277 (cherry-pick of geth PR 33741)
- Surfaced by: #20606 (bal-devnet-4 defaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)