### PR TITLE
execution/abi: add MakeTopics boundary regression tests

### DIFF
--- a/execution/abi/topics_test.go
+++ b/execution/abi/topics_test.go
@@ -75,6 +75,12 @@ func TestMakeTopics(t *testing.T) {
 			false,
 		},
 		{
+			"support negative *big.Int boundary in topics",
+			args{[][]any{{big.NewInt(-2)}}},
+			[][]common.Hash{{common.HexToHash("0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe")}},
+			false,
+		},
+		{
 			"support boolean types in topics",
 			args{[][]any{
 				{true},
@@ -142,6 +148,19 @@ func TestMakeTopics(t *testing.T) {
 				t.Errorf("makeTopics() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestMakeTopicsOversizedStaticBytesReturnsErrorNoPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("MakeTopics() panicked for oversized static bytes: %v", r)
+		}
+	}()
+
+	_, err := MakeTopics([]any{[33]byte{1}})
+	if err == nil {
+		t.Fatal("MakeTopics() expected error for oversized static bytes")
 	}
 }
 

--- a/execution/abi/topics_test.go
+++ b/execution/abi/topics_test.go
@@ -45,6 +45,12 @@ func TestMakeTopics(t *testing.T) {
 			false,
 		},
 		{
+			"support fixed byte boundary type of 32 bytes",
+			args{[][]any{{[32]byte{0: 1, 31: 2}}}},
+			[][]common.Hash{{common.Hash{0: 1, 31: 2}}},
+			false,
+		},
+		{
 			"reject fixed byte types longer than 32 bytes",
 			args{[][]any{{[33]byte{1}}}},
 			nil,
@@ -75,9 +81,21 @@ func TestMakeTopics(t *testing.T) {
 			false,
 		},
 		{
-			"support negative *big.Int boundary in topics",
-			args{[][]any{{big.NewInt(-2)}}},
-			[][]common.Hash{{common.HexToHash("0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe")}},
+			"support minimum int256 boundary in topics",
+			args{[][]any{{new(big.Int).Lsh(big.NewInt(-1), 255)}}},
+			[][]common.Hash{{common.HexToHash("0x8000000000000000000000000000000000000000000000000000000000000000")}},
+			false,
+		},
+		{
+			"support maximum int256 boundary in topics",
+			args{[][]any{{new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 255), big.NewInt(1))}}},
+			[][]common.Hash{{common.HexToHash("0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")}},
+			false,
+		},
+		{
+			"truncate values exceeding 256 bits in topics",
+			args{[][]any{{new(big.Int).Lsh(big.NewInt(1), 256)}}},
+			[][]common.Hash{{common.Hash{}}},
 			false,
 		},
 		{
@@ -148,19 +166,6 @@ func TestMakeTopics(t *testing.T) {
 				t.Errorf("makeTopics() = %v, want %v", got, tt.want)
 			}
 		})
-	}
-}
-
-func TestMakeTopicsOversizedStaticBytesReturnsErrorNoPanic(t *testing.T) {
-	defer func() {
-		if r := recover(); r != nil {
-			t.Fatalf("MakeTopics() panicked for oversized static bytes: %v", r)
-		}
-	}()
-
-	_, err := MakeTopics([]any{[33]byte{1}})
-	if err == nil {
-		t.Fatal("MakeTopics() expected error for oversized static bytes")
 	}
 }
 


### PR DESCRIPTION
Adds regression tests for negative *big.Int boundary encoding and oversized static byte topics, this locks in error-not-panic behavior for MakeTopics.