### PR TITLE
cmd/utils: gate chain defaults by --networkid for P2P discovery

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1205,6 +1205,27 @@ func setBootstrapNodesV5(ctx *cli.Context, cfg *p2p.Config) {
 	cfg.BootstrapNodesV5 = nodes
 }
 
+// resolveChainName returns the chain name to use for looking up network
+// defaults (bootnodes, DNS discovery URLs, static peers). It mirrors
+// go-ethereum's behavior: when --networkid is explicitly set to a non-mainnet
+// value and --chain is not, the "mainnet" default on --chain should not bleed
+// into network defaults. If the networkid maps to a known chain, that name is
+// returned; otherwise an empty string is returned, yielding no defaults.
+func resolveChainName(ctx *cli.Context) string {
+	chain := ctx.String(ChainFlag.Name)
+	if !ctx.IsSet(NetworkIdFlag.Name) || ctx.IsSet(ChainFlag.Name) {
+		return chain
+	}
+	networkID := ctx.Uint64(NetworkIdFlag.Name)
+	if networkID == 1 {
+		return chain
+	}
+	if chainName, ok := chainspec.NetworkNameByID[networkID]; ok {
+		return chainName
+	}
+	return ""
+}
+
 // getBootnodesFromContext resolves bootstrap nodes from the CLI context. An explicitly
 // set --bootnodes flag (even if empty) overrides chain defaults, matching go-ethereum's
 // behavior and allowing callers to run discovery with no bootstrap peers.
@@ -1212,7 +1233,7 @@ func getBootnodesFromContext(ctx *cli.Context) ([]*enode.Node, error) {
 	if ctx.IsSet(BootnodesFlag.Name) {
 		return enode.ParseNodesFromURLs(common.CliString2Array(ctx.String(BootnodesFlag.Name)))
 	}
-	return GetBootnodesFromFlags("", ctx.String(ChainFlag.Name))
+	return GetBootnodesFromFlags("", resolveChainName(ctx))
 }
 
 // GetBootnodesFromFlags makes a list of bootnodes from command line flags.
@@ -1236,8 +1257,7 @@ func setStaticPeers(ctx *cli.Context, cfg *p2p.Config) {
 	if ctx.IsSet(StaticPeersFlag.Name) {
 		urls = common.CliString2Array(ctx.String(StaticPeersFlag.Name))
 	} else {
-		chain := ctx.String(ChainFlag.Name)
-		urls = chainspec.StaticPeerURLsOfChain(chain)
+		urls = chainspec.StaticPeerURLsOfChain(resolveChainName(ctx))
 	}
 
 	nodes, err := enode.ParseNodesFromURLs(urls)
@@ -1873,18 +1893,9 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 	cfg.CaplinConfig.BootstrapNodes = ctx.StringSlice(SentinelBootnodes.Name)
 	cfg.CaplinConfig.StaticPeers = ctx.StringSlice(SentinelStaticPeers.Name)
 
-	chain := ctx.String(ChainFlag.Name) // mainnet by default
+	chain := resolveChainName(ctx)
 	if ctx.IsSet(NetworkIdFlag.Name) {
 		cfg.NetworkID = ctx.Uint64(NetworkIdFlag.Name)
-		if cfg.NetworkID != 1 && !ctx.IsSet(ChainFlag.Name) {
-			chainName, ok := chainspec.NetworkNameByID[cfg.NetworkID]
-			if !ok {
-				chain = "" // don't default to mainnet if NetworkID != 1 and it's devchain or smth
-			} else {
-				chain = chainName // fetch network name from id if name wasn't provided
-			}
-
-		}
 	} else if chain != networkname.Dev && chain != networkname.BorDevnet {
 		spec, err := chainspec.ChainSpecByName(chain)
 		if err != nil {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1205,12 +1205,16 @@ func setBootstrapNodesV5(ctx *cli.Context, cfg *p2p.Config) {
 	cfg.BootstrapNodesV5 = nodes
 }
 
-// resolveChainName returns the chain name to use for looking up network
-// defaults (bootnodes, DNS discovery URLs, static peers). It mirrors
-// go-ethereum's behavior: when --networkid is explicitly set to a non-mainnet
-// value and --chain is not, the "mainnet" default on --chain should not bleed
-// into network defaults. If the networkid maps to a known chain, that name is
-// returned; otherwise an empty string is returned, yielding no defaults.
+// resolveChainName returns the effective chain name from --chain and --networkid.
+// It is used for bootnodes, DNS discovery URLs, static peers, and the
+// chain-derived configuration in SetEthConfig (snapshot chain name,
+// chain-specific branches, etc.).
+//
+// It mirrors go-ethereum's behavior: when --networkid is explicitly set to a
+// non-mainnet value and --chain is not, the "mainnet" default on --chain
+// should not bleed into chain-derived config. If the networkid maps to a known
+// chain, that name is returned; otherwise an empty string is returned,
+// yielding no defaults.
 func resolveChainName(ctx *cli.Context) string {
 	chain := ctx.String(ChainFlag.Name)
 	if !ctx.IsSet(NetworkIdFlag.Name) || ctx.IsSet(ChainFlag.Name) {

--- a/cmd/utils/flags_test.go
+++ b/cmd/utils/flags_test.go
@@ -23,6 +23,9 @@ package utils
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
 )
 
 func Test_SplitTagsFlag(t *testing.T) {
@@ -62,6 +65,34 @@ func Test_SplitTagsFlag(t *testing.T) {
 			if got := SplitTagsFlag(tt.args); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("splitTagsFlag() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestResolveChainName(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"default (no flags) → mainnet", nil, "mainnet"},
+		{"--chain=sepolia", []string{"--chain=sepolia"}, "sepolia"},
+		{"--networkid=1 only → mainnet", []string{"--networkid=1"}, "mainnet"},
+		{"--networkid=11155111 only → sepolia (known id)", []string{"--networkid=11155111"}, "sepolia"},
+		{"--networkid=99999 only → empty (unknown id)", []string{"--networkid=99999"}, ""},
+		{"--networkid=1337 only → bor-devnet (registered id)", []string{"--networkid=1337"}, "bor-devnet"},
+		{"--networkid=99999 --chain=mainnet → mainnet (explicit chain wins)", []string{"--networkid=99999", "--chain=mainnet"}, "mainnet"},
+		{"--networkid=99999 --chain=sepolia → sepolia (explicit chain wins)", []string{"--networkid=99999", "--chain=sepolia"}, "sepolia"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := cli.NewApp()
+			app.Flags = []cli.Flag{&ChainFlag, &NetworkIdFlag}
+			app.Action = func(ctx *cli.Context) error {
+				require.Equal(t, tt.want, resolveChainName(ctx))
+				return nil
+			}
+			require.NoError(t, app.Run(append([]string{"test"}, tt.args...)))
 		})
 	}
 }

--- a/cmd/utils/flags_test.go
+++ b/cmd/utils/flags_test.go
@@ -83,6 +83,7 @@ func TestResolveChainName(t *testing.T) {
 		{"--networkid=1337 only → bor-devnet (registered id)", []string{"--networkid=1337"}, "bor-devnet"},
 		{"--networkid=99999 --chain=mainnet → mainnet (explicit chain wins)", []string{"--networkid=99999", "--chain=mainnet"}, "mainnet"},
 		{"--networkid=99999 --chain=sepolia → sepolia (explicit chain wins)", []string{"--networkid=99999", "--chain=sepolia"}, "sepolia"},
+		{"--networkid=1 --chain=sepolia → sepolia (explicit chain wins over mainnet id)", []string{"--networkid=1", "--chain=sepolia"}, "sepolia"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Previously, `setBootstrapNodes` and `setStaticPeers` read `--chain` directly and picked up the `"mainnet"` default even when the user explicitly set `--networkid` to a non-mainnet value. This leaked mainnet bootnodes onto non-mainnet networks — a parallel issue to the one #20630 fixed on the explicit `--bootnodes=` path.

Extract a `resolveChainName` helper mirroring the existing DNS detour in `SetEthConfig`, and apply it to bootnodes and static-peer resolution so all three paths consistently derive defaults from the networkid-implied chain (or empty, when the networkid is unrecognized). This brings erigon closer to go-ethereum's behavior, where mainnet defaults only apply when `--networkid == 1`.

## Behavior matrix

| Flags | Old bootnodes source | New bootnodes source |
|---|---|---|
| (none) | mainnet | mainnet (unchanged) |
| `--chain=sepolia` | sepolia | sepolia (unchanged) |
| `--networkid=1` | mainnet | mainnet (unchanged) |
| `--networkid=11155111` | **mainnet** (bug) | sepolia |
| `--networkid=1337` | **mainnet** (bug) | bor-devnet (empty) |
| `--networkid=99999` | **mainnet** (bug) | none |
| `--networkid=1337 --chain=mainnet` | mainnet | mainnet (explicit wins) |

## Motivation

The hive devp2p/discv5 simulator runs `erigon --networkid=1337` without `--chain`. Before #20630, this leaked mainnet bootnodes into the simulator's isolated routing table, breaking `FindnodeResults`. #20630 solved it by honoring `--bootnodes=""`. This PR removes the need for that workaround entirely by making the implicit path correct.

DNS-discovery defaults were already gated in `SetEthConfig`'s inline detour; this PR just hoists that detour into a helper so bootnodes and static peers get the same treatment.

## Test plan

- [x] `make lint` — 0 issues (ran twice)
- [x] `make erigon` — builds
- [x] New `TestResolveChainName` covers all conditions; `go test ./cmd/utils/...` green
- [x] `go test -short ./cmd/utils/... ./cmd/erigon/node/... ./node/... ./p2p/...` green

## Follow-up

Other `ctx.String(ChainFlag.Name)` uses in `cmd/utils/flags.go` exhibit the same latent mainnet-leak pattern but are out of scope for this PR (which targets P2P discovery):

- `setEtherbase` — Dev/BorDevnet etherbase default wouldn't apply under `--networkid=1337` alone.
- `setDataDir` — datadir defaults to the mainnet path when `--networkid=<non-mainnet>` is set alone. User-visible; worth a dedicated PR to avoid surprising anyone currently relying on this behavior.
- `setBorConfig` — Bor-chain `MaxPeers=100` default wouldn't trigger under `--networkid=137` alone.

The dev-mode discovery-disable in `SetP2PConfig` is unaffected: `networkname.Dev` is not registered in `NetworkNameByID`, so `resolveChainName` can never produce `"dev"` from a networkid alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)