### PR TITLE
tools/create-ramdisk: retry when chocolatey silently fails on Windows

### DIFF
--- a/tools/create-ramdisk
+++ b/tools/create-ramdisk
@@ -31,9 +31,15 @@ case "$(uname -s)" in
     # Install ImDisk (virtual disk driver) via Chocolatey, then create and
     # format the RAM disk. Use cmd to run format so that the /fs flag is not
     # mangled by MSYS path conversion.
+    #
+    # Chocolatey's exit code is unreliable on transient NuGet feed failures
+    # (e.g. community.chocolatey.org 504s): it prints "Chocolatey installed
+    # 0/0 packages" but can still exit 0, so the retry never triggers.
+    # Verify the imdisk binary is actually callable before accepting success.
     installed=false
     for i in 1 2 3; do
-      if choco install imdisk -y --no-progress >&2; then
+      choco install imdisk -y --no-progress >&2 || true
+      if command -v imdisk >/dev/null 2>&1; then
         installed=true
         break
       fi


### PR DESCRIPTION
## Summary

The Windows branch of `tools/create-ramdisk` has a 3-attempt retry loop around `choco install imdisk`, but the retry never actually triggered in practice: when the NuGet feed returned a 504 Gateway Timeout, Chocolatey printed \"Chocolatey installed 0/0 packages\" and still **exited 0**. The `if choco install` short-circuit accepted the success, the script jumped to `imdisk -a -s ...`, and crashed with:

\`\`\`
tools/create-ramdisk: line 47: imdisk: command not found
##[error]Process completed with exit code 127.
\`\`\`

That failure took out the Windows matrix job in `setup-erigon`, which fail-fast-cascaded into cancelling the `tests / tests-mac-linux (ubuntu-24.04)` and `tests / tests-mac-linux (macos-15)` siblings mid-compile.

## Fix

Stop relying on `choco install`'s exit code (it lies on NuGet feed errors). Instead, run the install and then verify the `imdisk` binary is actually callable via `command -v`. If not, the loop retries up to 3×15s; if all three attempts fail, the existing `::warning::` + skip-ramdisk fallback path kicks in.

## Repro / observed failure

Seen on erigontech/erigon#20694's CI run:
- https://github.com/erigontech/erigon/actions/runs/24671843007/job/72144563092 (Windows, root cause)
- Cancelled siblings: ubuntu-24.04 and macos-15 in the same matrix

## Test plan

- [x] `bash -n tools/create-ramdisk` — syntax OK
- [ ] Verify Windows `tests / tests-mac-linux (windows-2025)` passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)