### PR TITLE
engineapi, execmodule: support reorg to head's ancestor (execution-apis#770)

### DIFF
--- a/execution/engineapi/engine_api_reorg_test.go
+++ b/execution/engineapi/engine_api_reorg_test.go
@@ -26,6 +26,7 @@ import (
 
 	ethereum "github.com/erigontech/erigon"
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/common/testlog"
 	"github.com/erigontech/erigon/execution/abi/bind"
@@ -33,6 +34,7 @@ import (
 	"github.com/erigontech/erigon/execution/engineapi/engineapitester"
 	"github.com/erigontech/erigon/execution/protocol/params"
 	"github.com/erigontech/erigon/execution/state/contracts"
+	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/node/ethconfig"
 	"github.com/erigontech/erigon/rpc"
 )
@@ -283,5 +285,189 @@ func TestNewPayloadShouldReturnValidWhenSideChainGoingBackIsLtMaxReorgDepth(t *t
 		ps, err := eatCanonical.MockCl.InsertNewPayload(ctx, sideChain)
 		require.NoError(t, err)
 		require.Equal(t, enginetypes.ValidStatus, ps.Status)
+	})
+}
+
+// TestEngineApiFcuToCanonicalAncestorMovesHead verifies that an FCU pointing the
+// head at a canonical ancestor of the current head actually moves the EL head
+// back to that ancestor (spec: ethereum/execution-apis#770 — EL must support
+// reorg to head's ancestor).
+func TestEngineApiFcuToCanonicalAncestorMovesHead(t *testing.T) {
+	eat := engineapitester.DefaultEngineApiTester(t)
+	eat.Run(t, func(ctx context.Context, t *testing.T, eat engineapitester.EngineApiTester) {
+		// Build canonical chain: genesis (0) + empty b1 from DefaultEngineApiTester,
+		// then b2..b5 here. Head is at b5.
+		receiver := common.HexToAddress("0x42")
+		payloads := make([]*engineapitester.MockClPayload, 4)
+		for i := range payloads {
+			txn, err := eat.Transactor.SubmitSimpleTransfer(eat.CoinbaseKey, receiver, big.NewInt(int64(100*(i+1))))
+			require.NoError(t, err)
+			p, err := eat.MockCl.BuildCanonicalBlock(ctx)
+			require.NoError(t, err)
+			err = eat.TxnInclusionVerifier.VerifyTxnsInclusion(ctx, p.ExecutionPayload, txn.Hash())
+			require.NoError(t, err)
+			payloads[i] = p
+		}
+		// Sanity: head is at block 5.
+		latest, err := eat.RpcApiClient.GetBlockByNumber(ctx, rpc.LatestBlockNumber, false)
+		require.NoError(t, err)
+		require.Equal(t, uint64(5), latest.Number.Uint64())
+
+		// Point FCU at block 3 (two blocks behind head), no payload attributes.
+		ancestor := payloads[1]
+		ancestorHash := ancestor.ExecutionPayload.BlockHash
+		require.Equal(t, uint64(3), ancestor.ExecutionPayload.BlockNumber.Uint64())
+
+		fcs := enginetypes.ForkChoiceState{
+			HeadHash:           ancestorHash,
+			SafeBlockHash:      eat.GenesisBlock.Hash(),
+			FinalizedBlockHash: eat.GenesisBlock.Hash(),
+		}
+		resp, err := eat.EngineApiClient.ForkchoiceUpdatedV4(ctx, &fcs, nil)
+		require.NoError(t, err)
+		require.Equal(t, enginetypes.ValidStatus, resp.PayloadStatus.Status)
+		require.NotNil(t, resp.PayloadStatus.LatestValidHash)
+		require.Equal(t, ancestorHash, *resp.PayloadStatus.LatestValidHash)
+		require.Nil(t, resp.PayloadId)
+
+		// EL head must now be the ancestor.
+		latest, err = eat.RpcApiClient.GetBlockByNumber(ctx, rpc.LatestBlockNumber, false)
+		require.NoError(t, err)
+		require.Equal(t, uint64(3), latest.Number.Uint64())
+		require.Equal(t, ancestorHash, latest.Hash)
+	})
+}
+
+// TestEngineApiFcuToCanonicalAncestorWithPayloadAttributes verifies that an FCU
+// with payload attributes whose head is a canonical ancestor triggers a reorg
+// to the ancestor and begins building a payload on top of it (spec:
+// ethereum/execution-apis#770).
+func TestEngineApiFcuToCanonicalAncestorWithPayloadAttributes(t *testing.T) {
+	eat := engineapitester.DefaultEngineApiTester(t)
+	eat.Run(t, func(ctx context.Context, t *testing.T, eat engineapitester.EngineApiTester) {
+		receiver := common.HexToAddress("0x42")
+		payloads := make([]*engineapitester.MockClPayload, 4)
+		for i := range payloads {
+			txn, err := eat.Transactor.SubmitSimpleTransfer(eat.CoinbaseKey, receiver, big.NewInt(int64(100*(i+1))))
+			require.NoError(t, err)
+			p, err := eat.MockCl.BuildCanonicalBlock(ctx)
+			require.NoError(t, err)
+			err = eat.TxnInclusionVerifier.VerifyTxnsInclusion(ctx, p.ExecutionPayload, txn.Hash())
+			require.NoError(t, err)
+			payloads[i] = p
+		}
+		// Head is at block 5. Target ancestor: block 3.
+		ancestor := payloads[1]
+		ancestorHash := ancestor.ExecutionPayload.BlockHash
+		require.Equal(t, uint64(3), ancestor.ExecutionPayload.BlockNumber.Uint64())
+
+		// Build payload attributes for a sibling of block 4, on top of block 3.
+		newTimestamp := uint64(ancestor.ExecutionPayload.Timestamp) + 1
+		parentBeaconBlockRoot := common.HexToHash("0xfeedface")
+		slotNum := eat.MockCl.State().NextSlotNumber()
+		attrs := &enginetypes.PayloadAttributes{
+			Timestamp:             hexutil.Uint64(newTimestamp),
+			PrevRandao:            common.HexToHash("0xdeadbeef"),
+			SuggestedFeeRecipient: eat.GenesisBlock.Coinbase(),
+			Withdrawals:           []*types.Withdrawal{},
+			ParentBeaconBlockRoot: &parentBeaconBlockRoot,
+			SlotNumber:            (*hexutil.Uint64)(&slotNum),
+		}
+		fcs := enginetypes.ForkChoiceState{
+			HeadHash:           ancestorHash,
+			SafeBlockHash:      eat.GenesisBlock.Hash(),
+			FinalizedBlockHash: eat.GenesisBlock.Hash(),
+		}
+		resp, err := eat.EngineApiClient.ForkchoiceUpdatedV4(ctx, &fcs, attrs)
+		require.NoError(t, err)
+		require.Equal(t, enginetypes.ValidStatus, resp.PayloadStatus.Status)
+		require.NotNil(t, resp.PayloadStatus.LatestValidHash)
+		require.Equal(t, ancestorHash, *resp.PayloadStatus.LatestValidHash)
+		require.NotNil(t, resp.PayloadId, "payloadId expected when building on ancestor")
+
+		// Retrieve the newly built payload and verify it is built on top of the ancestor.
+		newPayload, err := eat.EngineApiClient.GetPayloadV6(ctx, *resp.PayloadId)
+		require.NoError(t, err)
+		require.Equal(t, ancestorHash, newPayload.ExecutionPayload.ParentHash)
+		require.Equal(t, uint64(4), uint64(newPayload.ExecutionPayload.BlockNumber))
+		require.Equal(t, newTimestamp, uint64(newPayload.ExecutionPayload.Timestamp))
+
+		// EL head should be the ancestor until the newly built block is promoted.
+		latest, err := eat.RpcApiClient.GetBlockByNumber(ctx, rpc.LatestBlockNumber, false)
+		require.NoError(t, err)
+		require.Equal(t, uint64(3), latest.Number.Uint64())
+		require.Equal(t, ancestorHash, latest.Hash)
+	})
+}
+
+// TestEngineApiFcuToDistantCanonicalAncestorSkipsReorg verifies the MAY-skip branch
+// of ethereum/execution-apis#770: when the requested head is a canonical ancestor
+// more than MaxAncestorReorgDepth (32) blocks behind the current head, the EL may
+// skip the forkchoice update and must return {VALID, latestValidHash: head, payloadId: null}
+// without moving the EL head.
+func TestEngineApiFcuToDistantCanonicalAncestorSkipsReorg(t *testing.T) {
+	eat := engineapitester.DefaultEngineApiTester(t)
+	eat.Run(t, func(ctx context.Context, t *testing.T, eat engineapitester.EngineApiTester) {
+		// DefaultEngineApiTester already built block 1 (empty). Build 35 more so head
+		// is at block 36 and the depth to block 3 is 33 (> 32).
+		const extraBlocks = 35
+		payloads := make([]*engineapitester.MockClPayload, extraBlocks)
+		for i := range payloads {
+			p, err := eat.MockCl.BuildCanonicalBlock(ctx)
+			require.NoError(t, err)
+			payloads[i] = p
+		}
+		latest, err := eat.RpcApiClient.GetBlockByNumber(ctx, rpc.LatestBlockNumber, false)
+		require.NoError(t, err)
+		currentHeadNumber := uint64(extraBlocks) + 1
+		require.Equal(t, currentHeadNumber, latest.Number.Uint64())
+		currentHeadHash := latest.Hash
+
+		// Target: block 3 (33 blocks behind head at block 36).
+		ancestor := payloads[1]
+		ancestorHash := ancestor.ExecutionPayload.BlockHash
+		require.Equal(t, uint64(3), ancestor.ExecutionPayload.BlockNumber.Uint64())
+		require.Greater(t, currentHeadNumber-3, uint64(32), "need depth > MaxAncestorReorgDepth")
+
+		// FCU to the distant ancestor must be skipped: response VALID, payloadId nil, head unmoved.
+		fcs := enginetypes.ForkChoiceState{
+			HeadHash:           ancestorHash,
+			SafeBlockHash:      eat.GenesisBlock.Hash(),
+			FinalizedBlockHash: eat.GenesisBlock.Hash(),
+		}
+		resp, err := eat.EngineApiClient.ForkchoiceUpdatedV4(ctx, &fcs, nil)
+		require.NoError(t, err)
+		require.Equal(t, enginetypes.ValidStatus, resp.PayloadStatus.Status)
+		require.NotNil(t, resp.PayloadStatus.LatestValidHash)
+		require.Equal(t, ancestorHash, *resp.PayloadStatus.LatestValidHash)
+		require.Nil(t, resp.PayloadId)
+
+		latest, err = eat.RpcApiClient.GetBlockByNumber(ctx, rpc.LatestBlockNumber, false)
+		require.NoError(t, err)
+		require.Equal(t, currentHeadNumber, latest.Number.Uint64())
+		require.Equal(t, currentHeadHash, latest.Hash)
+
+		// Even when payload attributes are provided, the skip path must return payloadId=nil
+		// and must not build a payload atop the distant ancestor.
+		newTimestamp := uint64(ancestor.ExecutionPayload.Timestamp) + 1
+		parentBeaconBlockRoot := common.HexToHash("0xcafeface")
+		slotNum := eat.MockCl.State().NextSlotNumber()
+		attrs := &enginetypes.PayloadAttributes{
+			Timestamp:             hexutil.Uint64(newTimestamp),
+			PrevRandao:            common.HexToHash("0xdeadbeef"),
+			SuggestedFeeRecipient: eat.GenesisBlock.Coinbase(),
+			Withdrawals:           []*types.Withdrawal{},
+			ParentBeaconBlockRoot: &parentBeaconBlockRoot,
+			SlotNumber:            (*hexutil.Uint64)(&slotNum),
+		}
+		resp, err = eat.EngineApiClient.ForkchoiceUpdatedV4(ctx, &fcs, attrs)
+		require.NoError(t, err)
+		require.Equal(t, enginetypes.ValidStatus, resp.PayloadStatus.Status)
+		require.Nil(t, resp.PayloadId, "payloadId must be nil when skipping distant ancestor")
+
+		latest, err = eat.RpcApiClient.GetBlockByNumber(ctx, rpc.LatestBlockNumber, false)
+		require.NoError(t, err)
+		require.Equal(t, currentHeadNumber, latest.Number.Uint64())
+		require.Equal(t, currentHeadHash, latest.Hash)
 	})
 }

--- a/execution/engineapi/engine_helpers/constants.go
+++ b/execution/engineapi/engine_helpers/constants.go
@@ -20,6 +20,12 @@ import "github.com/erigontech/erigon/rpc"
 
 const MaxBuilders = 128
 
+// MaxAncestorReorgDepth is the maximum depth behind the current EL head for which
+// a reorg to a canonical ancestor MUST be supported on FCU. See
+// ethereum/execution-apis#770: within this depth we always reorg; beyond it we
+// MAY skip the forkchoice state update and return VALID with payloadId = null.
+const MaxAncestorReorgDepth = 32
+
 var UnknownPayloadErr = rpc.CustomError{Code: -38001, Message: "Unknown payload"}
 var InvalidForkchoiceStateErr = rpc.CustomError{Code: -38002, Message: "Invalid forkchoice state"}
 var InvalidPayloadAttributesErr = rpc.CustomError{Code: -38003, Message: "Invalid payload attributes"}

--- a/execution/engineapi/engine_server.go
+++ b/execution/engineapi/engine_server.go
@@ -548,6 +548,8 @@ func (s *EngineServer) getQuickPayloadStatusIfPossible(ctx context.Context, bloc
 		// For NewPayload: if the block is already canonical and known, return VALID immediately.
 		// For FCU: we must always go through HandleForkChoice so the EL head actually moves,
 		// even if the requested head is a canonical ancestor (e.g. fork choice head regression).
+		// See ethereum/execution-apis#770 — EL must support reorg to the head's ancestor and
+		// allow building a payload on top of it.
 		if newPayload && currentHeader != nil && header != nil && isCanonical {
 			return &engine_types.PayloadStatus{Status: engine_types.ValidStatus, LatestValidHash: &blockHash}, nil
 		}
@@ -669,6 +671,19 @@ func (s *EngineServer) forkchoiceUpdated(ctx context.Context, forkchoiceState *e
 	}
 
 	s.logger.Debug("[ForkChoiceUpdated] processing new request", newReqLogInfoArgs...)
+
+	// PR 770 (ethereum/execution-apis#770): the EL MUST reorg to a canonical ancestor
+	// within MaxAncestorReorgDepth blocks of the current head, but MAY skip the forkchoice
+	// update for deeper canonical ancestors (e.g. a CL that is still catching up). When
+	// we skip, the spec mandates returning {status: VALID, latestValidHash: head, payloadId: null}
+	// without moving the EL head or building a payload. This only applies to ancestor reorgs;
+	// cross-branch reorgs have no depth limit.
+	if skipResp, skipErr := s.maybeSkipDistantAncestorFcu(ctx, forkchoiceState); skipErr != nil {
+		return nil, skipErr
+	} else if skipResp != nil {
+		return skipResp, nil
+	}
+
 	status, err := s.getQuickPayloadStatusIfPossible(ctx, forkchoiceState.HeadHash, 0, common.Hash{}, forkchoiceState, false)
 	if err != nil {
 		return nil, err
@@ -787,6 +802,54 @@ func (s *EngineServer) forkchoiceUpdated(ctx context.Context, forkchoiceState *e
 			LatestValidHash: &forkchoiceState.HeadHash,
 		},
 		PayloadId: engine_types.ConvertPayloadId(assembled.PayloadID),
+	}, nil
+}
+
+// maybeSkipDistantAncestorFcu implements the "skip" branch of ethereum/execution-apis#770:
+// when the requested head is a VALID canonical ancestor more than MaxAncestorReorgDepth
+// blocks behind the current EL head, we return VALID with payloadId=null and leave the
+// EL head in place. Returns (nil, nil) when the FCU should proceed through the normal path
+// (not an ancestor, close ancestor, canonical state unknown, etc.).
+func (s *EngineServer) maybeSkipDistantAncestorFcu(
+	ctx context.Context,
+	forkchoiceState *engine_types.ForkChoiceState,
+) (*engine_types.ForkChoiceUpdatedResponse, error) {
+	currentHeader := s.chainRW.CurrentHeader(ctx)
+	if currentHeader == nil {
+		return nil, nil
+	}
+	requestedHeader := s.chainRW.GetHeaderByHash(ctx, forkchoiceState.HeadHash)
+	if requestedHeader == nil {
+		return nil, nil
+	}
+	currentNumber := currentHeader.Number.Uint64()
+	requestedNumber := requestedHeader.Number.Uint64()
+	if requestedNumber >= currentNumber {
+		return nil, nil // not an ancestor (same height or ahead — handled by the reorg path)
+	}
+	if currentNumber-requestedNumber <= engine_helpers.MaxAncestorReorgDepth {
+		return nil, nil // close ancestor — MUST reorg per spec
+	}
+	isCanonical, err := s.chainRW.IsCanonicalHash(ctx, forkchoiceState.HeadHash)
+	if err != nil {
+		return nil, err
+	}
+	if !isCanonical {
+		return nil, nil // side chain — reorg MUST NOT be limited in depth
+	}
+	s.logger.Info(
+		"[ForkChoiceUpdated] skipping reorg to distant canonical ancestor",
+		"head", forkchoiceState.HeadHash,
+		"headNumber", requestedNumber,
+		"currentNumber", currentNumber,
+		"depth", currentNumber-requestedNumber,
+	)
+	headHash := forkchoiceState.HeadHash
+	return &engine_types.ForkChoiceUpdatedResponse{
+		PayloadStatus: &engine_types.PayloadStatus{
+			Status:          engine_types.ValidStatus,
+			LatestValidHash: &headHash,
+		},
 	}, nil
 }
 

--- a/execution/execmodule/forkchoice.go
+++ b/execution/execmodule/forkchoice.go
@@ -293,6 +293,9 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 	if fcuHeader.Number.Sign() > 0 {
 		if canonicalHash == blockHash && fcuHeader.Number.Uint64() >= finishProgressBefore {
 			// if block hash is part of the canonical chain and execution is not ahead, treat as no-op.
+			// When the requested head is canonical but execution is *ahead* (fcuHeader.Number < finishProgressBefore),
+			// we fall through to the reorg branch below and actually move the head back — required by
+			// ethereum/execution-apis#770 (EL must support reorg to head's ancestor).
 			writeForkChoiceHashes(tx, blockHash, safeHash, finalizedHash)
 			valid, err := e.verifyForkchoiceHashes(ctx, tx, blockHash, finalizedHash, safeHash)
 			if err != nil {


### PR DESCRIPTION
## Summary
- Implements [ethereum/execution-apis#770](https://github.com/ethereum/execution-apis/pull/770): within 32 blocks behind the EL head, FCU to a canonical ancestor triggers a reorg (and payload build if attributes are set); beyond 32 blocks we skip and return `{status: VALID, latestValidHash: head, payloadId: null}` without moving the head. Cross-branch reorgs remain unconstrained.
- `maybeSkipDistantAncestorFcu` in `execution/engineapi/engine_server.go` handles the skip branch; the close-ancestor reorg flows through the existing `updateForkChoice` path in `execution/execmodule/forkchoice.go` (already worked — tests lock it in).
- New constant `engine_helpers.MaxAncestorReorgDepth = 32` documents the spec threshold.

## Test plan
- [x] `go test ./execution/engineapi/... ./execution/execmodule/...` (all green)
- [x] `make lint` (3 runs, 0 issues)
- [x] `make erigon integration`
- [x] New tests in `engine_api_reorg_test.go`:
  - `TestEngineApiFcuToCanonicalAncestorMovesHead` — FCU to close ancestor moves the EL head back.
  - `TestEngineApiFcuToCanonicalAncestorWithPayloadAttributes` — FCU to close ancestor + attrs reorgs and builds a payload on top.
  - `TestEngineApiFcuToDistantCanonicalAncestorSkipsReorg` — FCU to ancestor >32 blocks behind returns VALID + `payloadId=nil` and leaves the head unmoved (even when attrs are provided).

🤖 Generated with [Claude Code](https://claude.com/claude-code)