### PR TITLE
rpc:  fix three testing_buildBlockV1 hive test failures

### DIFF
--- a/execution/engineapi/engine_types/jsonrpc.go
+++ b/execution/engineapi/engine_types/jsonrpc.go
@@ -49,7 +49,7 @@ type ExecutionPayload struct {
 	Withdrawals     []*types.Withdrawal `json:"withdrawals"`
 	BlobGasUsed     *hexutil.Uint64     `json:"blobGasUsed"`
 	ExcessBlobGas   *hexutil.Uint64     `json:"excessBlobGas"`
-	SlotNumber      *hexutil.Uint64     `json:"slotNumber"`
+	SlotNumber      *hexutil.Uint64     `json:"slotNumber,omitempty"`
 	BlockAccessList hexutil.Bytes       `json:"blockAccessList,omitempty"`
 }
 

--- a/execution/engineapi/testing_api.go
+++ b/execution/engineapi/testing_api.go
@@ -120,10 +120,10 @@ func (t *testingImpl) decodeTxnProvider(ctx context.Context, transactions *[]hex
 		want := expectedNonce[sender]
 		got := tx.GetNonce()
 		if got > want {
-			return nil, &rpc.InvalidParamsError{Message: fmt.Sprintf("nonce too high: address %v, tx: %d state: %d", sender.Value(), got, want)}
+			return nil, &rpc.CustomError{Code: rpc.ErrCodeDefault, Message: fmt.Sprintf("nonce too high: address %v, tx: %d state: %d", sender.Value(), got, want)}
 		}
 		if got < want {
-			return nil, &rpc.InvalidParamsError{Message: fmt.Sprintf("nonce too low: address %v, tx: %d state: %d", sender.Value(), got, want)}
+			return nil, &rpc.CustomError{Code: rpc.ErrCodeDefault, Message: fmt.Sprintf("nonce too low: address %v, tx: %d state: %d", sender.Value(), got, want)}
 		}
 		expectedNonce[sender]++
 		decoded = append(decoded, tx)
@@ -279,8 +279,6 @@ func (t *testingImpl) BuildBlockV1(
 		return nil, err
 	}
 	response.ShouldOverrideBuilder = false
-	// Return blockValue=0, matching Geth's BuildTestingPayload behaviour.
-	response.BlockValue = new(hexutil.Big)
 	if extraData != nil {
 		h := types.CopyHeader(assembled.Block.Block.Header())
 		h.Extra = *extraData

--- a/execution/engineapi/testing_api_test.go
+++ b/execution/engineapi/testing_api_test.go
@@ -532,9 +532,8 @@ func TestBuildBlockV1(t *testing.T) {
 		assert.Equal(t, hexutil.Bytes("test"), resp.ExecutionPayload.ExtraData)
 		assert.Equal(t, false, resp.ShouldOverrideBuilder)
 
-		// blockValue is always 0 (matching Geth's BuildTestingPayload behaviour).
 		require.NotNil(t, resp.BlockValue)
-		assert.Equal(t, "0", resp.BlockValue.ToInt().String())
+		assert.Equal(t, "12345", resp.BlockValue.ToInt().String())
 	})
 
 	t.Run("happy path with extraData override", func(t *testing.T) {
@@ -620,8 +619,9 @@ func TestBuildBlockV1(t *testing.T) {
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, validPayloadAttrs(parentTimestamp), &txs, nil)
 		require.Nil(t, resp)
 		require.Error(t, err)
-		var rpcErr *rpc.InvalidParamsError
+		var rpcErr *rpc.CustomError
 		require.ErrorAs(t, err, &rpcErr)
+		assert.Equal(t, rpc.ErrCodeDefault, rpcErr.Code)
 		assert.Contains(t, rpcErr.Message, "nonce too high")
 	})
 
@@ -642,8 +642,9 @@ func TestBuildBlockV1(t *testing.T) {
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, validPayloadAttrs(parentTimestamp), &txs, nil)
 		require.Nil(t, resp)
 		require.Error(t, err)
-		var rpcErr *rpc.InvalidParamsError
+		var rpcErr *rpc.CustomError
 		require.ErrorAs(t, err, &rpcErr)
+		assert.Equal(t, rpc.ErrCodeDefault, rpcErr.Code)
 		assert.Contains(t, rpcErr.Message, "nonce too low")
 	})
 
@@ -877,8 +878,9 @@ func TestBuildBlockV1MultipleSendersNonce(t *testing.T) {
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, validPayloadAttrs(parentTimestamp), &txs, nil)
 		require.Nil(t, resp)
 		require.Error(t, err)
-		var rpcErr *rpc.InvalidParamsError
+		var rpcErr *rpc.CustomError
 		require.ErrorAs(t, err, &rpcErr)
+		assert.Equal(t, rpc.ErrCodeDefault, rpcErr.Code)
 		assert.Contains(t, rpcErr.Message, "nonce too high")
 	})
 }


### PR DESCRIPTION
This PR fixes 3 testing_ api  after merge(today) of PR 783 execution_apis:

- engine_types/jsonrpc.go: add omitempty to SlotNumber JSON tag so nil slot number is omitted from ExecutionPayloadV3 responses (Prague chain does not include slotNumber, only Amsterdam/V4+) 
- testing_api.go: return real blockValue from assembler instead of hardcoding zero; 
- nonce validation errors now use -32000 (execution error) instead of -32602 (invalid params) to match execution-apis spec
