### PR TITLE
rpc: fix txpool_content/contentFrom/status hive test failures

### DIFF
--- a/rpc/ethapi/api.go
+++ b/rpc/ethapi/api.go
@@ -604,8 +604,8 @@ func NewRPCTransaction(txn types.Transaction, blockHash common.Hash, blockTime u
 	return result
 }
 
-func computeGasPrice(txn types.Transaction, blockHash common.Hash, baseFee *uint256.Int) *hexutil.Big {
-	if baseFee != nil && blockHash != (common.Hash{}) {
+func computeGasPrice(txn types.Transaction, _ common.Hash, baseFee *uint256.Int) *hexutil.Big {
+	if baseFee != nil {
 		// price = min(tip + baseFee, gasFeeCap)
 		price := u256.Min(u256.Add(*txn.GetTipCap(), *baseFee), *txn.GetFeeCap())
 		return (*hexutil.Big)(price.ToBig())

--- a/rpc/jsonrpc/txpool_api.go
+++ b/rpc/jsonrpc/txpool_api.go
@@ -70,12 +70,10 @@ func (api *TxPoolAPIImpl) Content(ctx context.Context) (map[string]map[string]ma
 
 	content := map[string]map[string]map[string]*ethapi.RPCTransaction{
 		"pending": make(map[string]map[string]*ethapi.RPCTransaction),
-		"baseFee": make(map[string]map[string]*ethapi.RPCTransaction),
 		"queued":  make(map[string]map[string]*ethapi.RPCTransaction),
 	}
 
 	pending := make(map[common.Address][]types.Transaction, 8)
-	baseFee := make(map[common.Address][]types.Transaction, 8)
 	queued := make(map[common.Address][]types.Transaction, 8)
 	for i := range reply.Txs {
 		txn, err := types.DecodeWrappedTransaction(reply.Txs[i].RlpTx)
@@ -89,11 +87,6 @@ func (api *TxPoolAPIImpl) Content(ctx context.Context) (map[string]map[string]ma
 				pending[addr] = make([]types.Transaction, 0, 4)
 			}
 			pending[addr] = append(pending[addr], txn)
-		case txpoolproto.AllReply_BASE_FEE:
-			if _, ok := baseFee[addr]; !ok {
-				baseFee[addr] = make([]types.Transaction, 0, 4)
-			}
-			baseFee[addr] = append(baseFee[addr], txn)
 		case txpoolproto.AllReply_QUEUED:
 			if _, ok := queued[addr]; !ok {
 				queued[addr] = make([]types.Transaction, 0, 4)
@@ -116,15 +109,9 @@ func (api *TxPoolAPIImpl) Content(ctx context.Context) (map[string]map[string]ma
 	if curHeader == nil {
 		return nil, nil
 	}
-	// Flatten the pending transactions
 	for account, txs := range pending {
 		content["pending"][account.Hex()] = flattenTxs(txs, curHeader, cc)
 	}
-	// Flatten the baseFee transactions
-	for account, txs := range baseFee {
-		content["baseFee"][account.Hex()] = flattenTxs(txs, curHeader, cc)
-	}
-	// Flatten the queued transactions
 	for account, txs := range queued {
 		content["queued"][account.Hex()] = flattenTxs(txs, curHeader, cc)
 	}
@@ -139,12 +126,10 @@ func (api *TxPoolAPIImpl) ContentFrom(ctx context.Context, addr common.Address) 
 
 	content := map[string]map[string]*ethapi.RPCTransaction{
 		"pending": make(map[string]*ethapi.RPCTransaction),
-		"baseFee": make(map[string]*ethapi.RPCTransaction),
 		"queued":  make(map[string]*ethapi.RPCTransaction),
 	}
 
 	pending := make([]types.Transaction, 0, 4)
-	baseFee := make([]types.Transaction, 0, 4)
 	queued := make([]types.Transaction, 0, 4)
 	for i := range reply.Txs {
 		txn, err := types.DecodeWrappedTransaction(reply.Txs[i].RlpTx)
@@ -159,8 +144,6 @@ func (api *TxPoolAPIImpl) ContentFrom(ctx context.Context, addr common.Address) 
 		switch reply.Txs[i].TxnType {
 		case txpoolproto.AllReply_PENDING:
 			pending = append(pending, txn)
-		case txpoolproto.AllReply_BASE_FEE:
-			baseFee = append(baseFee, txn)
 		case txpoolproto.AllReply_QUEUED:
 			queued = append(queued, txn)
 		}
@@ -180,11 +163,7 @@ func (api *TxPoolAPIImpl) ContentFrom(ctx context.Context, addr common.Address) 
 	if curHeader == nil {
 		return nil, nil
 	}
-	// Flatten the pending transactions
 	content["pending"] = flattenTxs(pending, curHeader, cc)
-	// Flatten the baseFee transactions
-	content["baseFee"] = flattenTxs(baseFee, curHeader, cc)
-	// Flatten the queued transactions
 	content["queued"] = flattenTxs(queued, curHeader, cc)
 	return content, nil
 }
@@ -197,7 +176,6 @@ func (api *TxPoolAPIImpl) Status(ctx context.Context) (map[string]hexutil.Uint, 
 	}
 	return map[string]hexutil.Uint{
 		"pending": hexutil.Uint(reply.PendingCount),
-		"baseFee": hexutil.Uint(reply.BaseFeeCount),
 		"queued":  hexutil.Uint(reply.QueuedCount),
 	}, nil
 }

--- a/rpc/jsonrpc/txpool_api_test.go
+++ b/rpc/jsonrpc/txpool_api_test.go
@@ -74,7 +74,7 @@ func TestTxPoolContent(t *testing.T) {
 
 	status, err := api.Status(ctx)
 	require.NoError(err)
-	require.Len(status, 3)
+	require.Len(status, 2)
 	require.Equal(status["pending"], hexutil.Uint(1))
 	require.Equal(status["queued"], hexutil.Uint(0))
 }


### PR DESCRIPTION
This PR fixes hive after merge (today) PR 783 on execution-apis:
- Remove baseFee bucket from txpool_content, txpool_contentFrom and txpool_status responses: the field is not in the execution-apis spec and causes hive rpc-compat failures

- computeGasPrice: compute effective gasPrice for EIP-1559 pending transactions using current header baseFee, instead of returning nil when blockHash is zero