### PR TITLE
[wip] Revert "Revert "[r3.4] logger: avoid mutex contention""

### DIFF
--- a/common/log/v3/bench_test.go
+++ b/common/log/v3/bench_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -128,6 +130,150 @@ func BenchmarkDescendant8(b *testing.B) {
 	for b.Loop() {
 		lg.Info("test message")
 	}
+}
+
+// slowWriter simulates a slow I/O destination (e.g. network, overloaded disk).
+// With SyncHandler all goroutines serialize on the mutex and total time ≈ N × delay.
+// Without it goroutines write in parallel and total time ≈ delay.
+type slowWriter struct {
+	delay time.Duration
+	lines atomic.Int64
+}
+
+func (w *slowWriter) Write(p []byte) (int, error) {
+	time.Sleep(w.delay)
+	w.lines.Add(int64(bytes.Count(p, []byte{'\n'})))
+	return len(p), nil
+}
+
+func TestStreamHandlerNoContention(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping wall-clock contention test in short mode")
+	}
+
+	const (
+		goroutines = 100
+		writeDelay = 2 * time.Millisecond
+	)
+
+	run := func(handler Handler, wr *slowWriter) (time.Duration, int64) {
+		lg := New()
+		lg.SetHandler(handler)
+
+		start := time.Now()
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+		for i := 0; i < goroutines; i++ {
+			go func() {
+				defer wg.Done()
+				lg.Info("msg")
+			}()
+		}
+		wg.Wait()
+
+		return time.Since(start), wr.lines.Load()
+	}
+
+	parallelWr := &slowWriter{delay: writeDelay}
+	parallelElapsed, parallelLines := run(
+		StreamHandler(parallelWr, TerminalFormatNoColor()),
+		parallelWr,
+	)
+	if parallelLines != goroutines {
+		t.Fatalf("parallel StreamHandler run: expected %d log lines, got %d", goroutines, parallelLines)
+	}
+
+	serialWr := &slowWriter{delay: writeDelay}
+	serialElapsed, serialLines := run(
+		SyncHandler(StreamHandler(serialWr, TerminalFormatNoColor())),
+		serialWr,
+	)
+	if serialLines != goroutines {
+		t.Fatalf("sync-wrapped StreamHandler run: expected %d log lines, got %d", goroutines, serialLines)
+	}
+
+	// Compare relative behavior within the same test run instead of asserting a
+	// fixed wall-clock threshold. The sync-wrapped handler should be
+	// meaningfully slower because it serializes all writes through one mutex.
+	if serialElapsed <= parallelElapsed {
+		t.Fatalf("expected SyncHandler(StreamHandler(...)) to be slower than StreamHandler(...): parallel=%v serial=%v", parallelElapsed, serialElapsed)
+	}
+	if serialElapsed < 2*parallelElapsed {
+		t.Fatalf("expected SyncHandler(StreamHandler(...)) to be at least 2x slower: parallel=%v serial=%v", parallelElapsed, serialElapsed)
+	}
+
+	t.Logf("parallel=%v serial=%v lines=%d", parallelElapsed, serialElapsed, parallelLines)
+}
+
+func TestStreamHandlerAllocsUpperBound(t *testing.T) {
+	lg := New()
+	lg.SetHandler(StreamHandler(io.Discard, TerminalFormatNoColor()))
+
+	allocs := testing.AllocsPerRun(100, func() {
+		lg.Info("test message", "key", "value")
+	})
+	// Formatting allocates (bytes.Buffer, fmt.Fprintf, etc.), so this
+	// is not expected to be literally zero. Keep a generous upper bound
+	// so the test remains stable across Go versions while still catching
+	// meaningful regressions in per-call allocation behavior.
+	const maxAllocsPerOp = 16
+	if allocs > maxAllocsPerOp {
+		t.Fatalf("StreamHandler allocs/op too high: got %.0f, want <= %d", allocs, maxAllocsPerOp)
+	}
+	t.Logf("StreamHandler allocs/op: %.0f", allocs)
+}
+
+func TestStreamHandlerNoConcurrencyOverhead(t *testing.T) {
+	lg := New()
+	lg.SetHandler(StreamHandler(io.Discard, TerminalFormatNoColor()))
+
+	// Measure single-goroutine allocs as baseline.
+	baseline := testing.AllocsPerRun(100, func() {
+		lg.Info("msg", "k", "v")
+	})
+
+	// Pre-spawn workers so AllocsPerRun measures logging under concurrency
+	// rather than goroutine creation/teardown or per-run WaitGroup setup.
+	const goroutines = 64
+	start := make(chan struct{})
+	done := make(chan struct{}, goroutines)
+
+	var workers sync.WaitGroup
+	workers.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer workers.Done()
+			for range start {
+				lg.Info("msg", "k", "v")
+				done <- struct{}{}
+			}
+		}()
+	}
+
+	concurrent := testing.AllocsPerRun(100, func() {
+		for i := 0; i < goroutines; i++ {
+			start <- struct{}{}
+		}
+		for i := 0; i < goroutines; i++ {
+			<-done
+		}
+	})
+
+	close(start)
+	workers.Wait()
+
+	perCall := concurrent / goroutines
+
+	// Concurrent allocs per call should stay close to baseline. Allow a
+	// small slack for channel/scheduler overhead in the fan-out harness
+	// itself (amortized across `goroutines` calls) — the purpose of the
+	// test is to catch a mutex/sync.Pool regression that would add O(1)
+	// extra allocs per call, not sub-alloc harness noise.
+	const slack = 2.0
+	if perCall > baseline+slack {
+		t.Fatalf("concurrent allocs/op (%.1f) exceed baseline+slack (%.1f) — likely mutex or sync overhead", perCall, baseline+slack)
+	}
+	t.Logf("baseline=%.0f  concurrent_per_call=%.1f", baseline, perCall)
 }
 
 // Copied from https://github.com/uber-go/zap/blob/master/benchmarks/log15_bench_test.go

--- a/common/log/v3/handler.go
+++ b/common/log/v3/handler.go
@@ -36,10 +36,13 @@ type Handler interface {
 // to easily begin writing log records to other
 // outputs.
 //
-// StreamHandler wraps itself with LazyHandler and SyncHandler
-// to evaluate Lazy objects and perform safe concurrent writes.
+// StreamHandler wraps itself with LazyHandler to evaluate Lazy objects.
+// StreamHandler does not add any synchronization of its own, so
+// concurrent use is only safe when the provided Format allocates
+// per-call buffers (all built-in formats do) and the underlying
+// io.Writer supports concurrent Write calls (e.g. *os.File).
 func StreamHandler(wr io.Writer, fmtr Format) Handler {
-	return LazyHandler(SyncHandler(streamHandler{wr: wr, fmtr: fmtr}))
+	return LazyHandler(streamHandler{wr: wr, fmtr: fmtr})
 }
 
 type streamHandler struct {
@@ -98,13 +101,17 @@ func FileHandler(path string, fmtr Format, maxFileSize uint64) (Handler, error) 
 }
 
 type rotatingWriter struct {
+	mu         sync.Mutex
 	file       *os.File
 	logMaxSize uint64
 }
 
 // Write checks if current log size + expected write size is larger than limit.
 // If limit outreached, file is truncated then write is called.
+// Mutex is required because the operation is multi-step (stat+truncate+write+sync).
 func (r *rotatingWriter) Write(p []byte) (n int, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	info, err := r.file.Stat()
 	if err != nil {
 		return 0, fmt.Errorf("rotating log %q stat: %w", r.file.Name(), err)
@@ -125,6 +132,8 @@ func (r *rotatingWriter) Write(p []byte) (n int, err error) {
 }
 
 func (r *rotatingWriter) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.file.Close()
 }
 


### PR DESCRIPTION
Reverts erigontech/erigon#20652

Because I did miss-interpreted stacktrace as deadlock/race inside logger https://github.com/erigontech/erigon/issues/20661 - but it had another Root-Cause