### PR TITLE
Bound domain merge limit; add CLI override

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1145,8 +1145,8 @@ var (
 		Usage: "Port for MCP RPC server",
 		Value: 8553,
 	}
-	OverrideDomainStepsInFrozenFileFlag = cli.StringFlag{
-		Name:  "override.domain.steps-in-frozen-file",
+	ErigondbDomainStepsInFrozenFileFlag = cli.StringFlag{
+		Name:  "erigondb.domain.steps-in-frozen-file",
 		Usage: `Override erigondb.toml "steps_in_frozen_file" for the domain merge cap only (history/inverted-index merges are unaffected). Pass a positive integer to set an explicit cap, or "Inf" to leave the domain merge unbounded. Default: unset, meaning the domain uses the same cap as determined by erigondb.toml.`,
 	}
 )
@@ -2149,22 +2149,22 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 		downloadernat.DoNat(nodeConfig.P2P.NAT, cfg.Downloader.ClientConfig, logger)
 	}
 
-	if ctx.IsSet(OverrideDomainStepsInFrozenFileFlag.Name) {
-		s := ctx.String(OverrideDomainStepsInFrozenFileFlag.Name)
+	if ctx.IsSet(ErigondbDomainStepsInFrozenFileFlag.Name) {
+		s := ctx.String(ErigondbDomainStepsInFrozenFileFlag.Name)
 		var v uint64
 		if strings.EqualFold(s, "inf") {
 			v = config3.UnboundedDomainMerge
 		} else {
 			parsed, err := strconv.ParseUint(s, 10, 64)
 			if err != nil {
-				Fatalf("invalid --%s value %q: must be a positive integer or \"Inf\"", OverrideDomainStepsInFrozenFileFlag.Name, s)
+				Fatalf("invalid --%s value %q: must be a positive integer or \"Inf\"", ErigondbDomainStepsInFrozenFileFlag.Name, s)
 			}
 			if parsed == 0 {
-				Fatalf("invalid --%s value %q: must be a positive integer or \"Inf\"", OverrideDomainStepsInFrozenFileFlag.Name, s)
+				Fatalf("invalid --%s value %q: must be a positive integer or \"Inf\"", ErigondbDomainStepsInFrozenFileFlag.Name, s)
 			}
 			v = parsed
 		}
-		cfg.OverrideDomainStepsInFrozenFile = &v
+		cfg.ErigondbDomainStepsInFrozenFile = &v
 	}
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -47,6 +47,7 @@ import (
 	"github.com/erigontech/erigon/common"
 	libkzg "github.com/erigontech/erigon/common/crypto/kzg"
 	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/config3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/downloader/downloadercfg"
 	"github.com/erigontech/erigon/db/snapcfg"
@@ -1144,6 +1145,10 @@ var (
 		Usage: "Port for MCP RPC server",
 		Value: 8553,
 	}
+	OverrideDomainStepsInFrozenFileFlag = cli.StringFlag{
+		Name:  "override.domain.steps-in-frozen-file",
+		Usage: `Override erigondb.toml "steps_in_frozen_file" for the domain merge cap only (history/inverted-index merges are unaffected). Pass a positive integer to set an explicit cap, or "Inf" to leave the domain merge unbounded. Default: unset, meaning the domain uses the same cap as determined by erigondb.toml.`,
+	}
 )
 
 var MetricFlags = []cli.Flag{&MetricsEnabledFlag, &MetricsHTTPFlag, &MetricsPortFlag}
@@ -2142,6 +2147,24 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 			panic(err)
 		}
 		downloadernat.DoNat(nodeConfig.P2P.NAT, cfg.Downloader.ClientConfig, logger)
+	}
+
+	if ctx.IsSet(OverrideDomainStepsInFrozenFileFlag.Name) {
+		s := ctx.String(OverrideDomainStepsInFrozenFileFlag.Name)
+		var v uint64
+		if strings.EqualFold(s, "inf") {
+			v = config3.UnboundedDomainMerge
+		} else {
+			parsed, err := strconv.ParseUint(s, 10, 64)
+			if err != nil {
+				Fatalf("invalid --%s value %q: must be a positive integer or \"Inf\"", OverrideDomainStepsInFrozenFileFlag.Name, s)
+			}
+			if parsed == 0 {
+				Fatalf("invalid --%s value %q: must be a positive integer or \"Inf\"", OverrideDomainStepsInFrozenFileFlag.Name, s)
+			}
+			v = parsed
+		}
+		cfg.OverrideDomainStepsInFrozenFile = &v
 	}
 }
 

--- a/db/config3/config3.go
+++ b/db/config3/config3.go
@@ -16,6 +16,8 @@
 
 package config3
 
+import "math"
+
 // Step size up to Erigon 3.3
 const LegacyStepSize = 1_562_500
 
@@ -29,8 +31,12 @@ const DefaultStepSize = 1_562_500
 // DefaultStepsInFrozenFile - files of this size are completely frozen/immutable.
 // files of smaller size are also immutable, but can be removed after merge to bigger files.
 // Prefer reading the actual value from erigondb.toml via state.ResolveErigonDBSettings.
-// TODO: there are exceptions to this rule; domains override this limit hardcoded inside domain construction to be unlimited; it could be made more explicit in the schema.
 const DefaultStepsInFrozenFile = 64
+
+// UnboundedDomainMerge is a sentinel "steps in frozen file" value used to signal domain merges
+// are unbounded, i.e., can be merged infinitely. This was the default behavior for Erigon <= 3.4 and
+// this value can be used to restore it.
+const UnboundedDomainMerge uint64 = math.MaxUint64
 
 const EnableHistoryV4InTest = true
 

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -44,6 +44,7 @@ import (
 	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/estimate"
 	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/config3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/order"
@@ -63,7 +64,17 @@ type Aggregator struct {
 	dirs              datadir.Dirs
 	stepSize          atomic.Uint64
 	stepsInFrozenFile atomic.Uint64
-	reorgBlockDepth   uint64
+	// domainStepsInFrozenFileOverride overrides stepsInFrozenFile for the domain merge cap only
+	// (history/II keep using stepsInFrozenFile). Set once at construction via AggOpts. Semantics:
+	//   0                             → no override (default)
+	//   config3.UnboundedDomainMerge  → domain merge is unbounded (no cap)
+	//   other                         → use this value instead of stepsInFrozenFile as the domain cap
+	//
+	// Note: this is a SOFT limit applied during the merge process. If you apply a smaller limit to
+	// an existing datadir, the existing domain files containing more steps will be unaffected.
+	domainStepsInFrozenFileOverride uint64
+
+	reorgBlockDepth uint64
 
 	dirtyFilesLock sync.Mutex
 	// visible is published via atomic.Store under dirtyFilesLock; readers take no lock.
@@ -1588,6 +1599,18 @@ func (v *aggregatorVisible) stateMinimaxTxNum() uint64 {
 
 func (at *AggregatorRoTx) findMergeRange(maxEndTxNum, stepSize, stepsInFrozenFile uint64) *Ranges {
 	maxSpan := stepSize * stepsInFrozenFile
+
+	// --override.domain.steps-in-frozen-file adjusts the domain cap only; history/II keep maxSpan.
+	domainMaxSpan := maxSpan
+	switch override := at.a.domainStepsInFrozenFileOverride; override {
+	case 0:
+		// no override
+	case config3.UnboundedDomainMerge:
+		domainMaxSpan = config3.UnboundedDomainMerge // no cap on domain merge
+	default:
+		domainMaxSpan = stepSize * override
+	}
+
 	r := &Ranges{invertedIndex: make([]*MergeRange, len(at.a.iis))}
 	commitmentUseReferencedBranches := at.a.Cfg(kv.CommitmentDomain).ReplaceKeysInValues
 	if commitmentUseReferencedBranches {
@@ -1606,7 +1629,7 @@ func (at *AggregatorRoTx) findMergeRange(maxEndTxNum, stepSize, stepsInFrozenFil
 		if d.d.Disable {
 			continue
 		}
-		r.domain[id] = d.findMergeRange(maxEndTxNum, maxSpan)
+		r.domain[id] = d.findMergeRange(maxEndTxNum, domainMaxSpan, maxSpan)
 	}
 
 	if commitmentUseReferencedBranches && r.domain[kv.CommitmentDomain].values.needMerge {

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -64,7 +64,7 @@ type Aggregator struct {
 	dirs              datadir.Dirs
 	stepSize          atomic.Uint64
 	stepsInFrozenFile atomic.Uint64
-	// domainStepsInFrozenFileOverride overrides stepsInFrozenFile for the domain merge cap only
+	// erigondbDomainStepsInFrozenFile overrides stepsInFrozenFile for the domain merge cap only
 	// (history/II keep using stepsInFrozenFile). Set once at construction via AggOpts. Semantics:
 	//   0                             → no override (default)
 	//   config3.UnboundedDomainMerge  → domain merge is unbounded (no cap)
@@ -72,7 +72,7 @@ type Aggregator struct {
 	//
 	// Note: this is a SOFT limit applied during the merge process. If you apply a smaller limit to
 	// an existing datadir, the existing domain files containing more steps will be unaffected.
-	domainStepsInFrozenFileOverride uint64
+	erigondbDomainStepsInFrozenFile uint64
 
 	reorgBlockDepth uint64
 
@@ -1600,9 +1600,9 @@ func (v *aggregatorVisible) stateMinimaxTxNum() uint64 {
 func (at *AggregatorRoTx) findMergeRange(maxEndTxNum, stepSize, stepsInFrozenFile uint64) *Ranges {
 	maxSpan := stepSize * stepsInFrozenFile
 
-	// --override.domain.steps-in-frozen-file adjusts the domain cap only; history/II keep maxSpan.
+	// --erigondb.domain.steps-in-frozen-file adjusts the domain cap only; history/II keep maxSpan.
 	domainMaxSpan := maxSpan
-	switch override := at.a.domainStepsInFrozenFileOverride; override {
+	switch override := at.a.erigondbDomainStepsInFrozenFile; override {
 	case 0:
 		// no override
 	case config3.UnboundedDomainMerge:

--- a/db/state/aggregator2.go
+++ b/db/state/aggregator2.go
@@ -20,11 +20,12 @@ import (
 
 // AggOpts is an Aggregator builder and contains only runtime-changeable configs (which may vary between Erigon nodes)
 type AggOpts struct { //nolint:gocritic
-	dirs              datadir.Dirs
-	logger            log.Logger
-	stepSize          uint64 // != 0 mean override erigondb.toml settings
-	stepsInFrozenFile uint64 // != 0 mean override erigondb.toml settings
-	reorgBlockDepth   uint64
+	dirs                            datadir.Dirs
+	logger                          log.Logger
+	stepSize                        uint64 // != 0 mean override erigondb.toml settings
+	stepsInFrozenFile               uint64 // != 0 mean override erigondb.toml settings
+	domainStepsInFrozenFileOverride uint64
+	reorgBlockDepth                 uint64
 
 	genSaltIfNeed   bool
 	sanityOldNaming bool // prevent start directory with old file names
@@ -67,6 +68,7 @@ func (opts AggOpts) Open(ctx context.Context, db kv.RoDB) (*Aggregator, error) {
 
 	a.stepSize.Store(opts.stepSize)
 	a.stepsInFrozenFile.Store(opts.stepsInFrozenFile)
+	a.domainStepsInFrozenFileOverride = opts.domainStepsInFrozenFileOverride
 
 	a.disableHistory = opts.disableHistory
 	a.disableFsync = opts.disableFsync
@@ -93,6 +95,15 @@ func (opts AggOpts) MustOpen(ctx context.Context, db kv.RoDB) *Aggregator { //no
 func (opts AggOpts) StepSize(s uint64) AggOpts { opts.stepSize = s; return opts } //nolint:gocritic
 func (opts AggOpts) StepsInFrozenFile(steps uint64) AggOpts { //nolint:gocritic
 	opts.stepsInFrozenFile = steps
+	return opts
+}
+
+// DomainStepsInFrozenFileOverride sets the domain-only cap override (see
+// Aggregator.domainStepsInFrozenFileOverride). 0 clears the override;
+// config3.UnboundedDomainMerge disables the cap; any other value replaces stepsInFrozenFile
+// for domain merges only.
+func (opts AggOpts) DomainStepsInFrozenFileOverride(steps uint64) AggOpts { //nolint:gocritic
+	opts.domainStepsInFrozenFileOverride = steps
 	return opts
 }
 func (opts AggOpts) ReorgBlockDepth(d uint64) AggOpts { //nolint:gocritic

--- a/db/state/aggregator2.go
+++ b/db/state/aggregator2.go
@@ -24,7 +24,7 @@ type AggOpts struct { //nolint:gocritic
 	logger                          log.Logger
 	stepSize                        uint64 // != 0 mean override erigondb.toml settings
 	stepsInFrozenFile               uint64 // != 0 mean override erigondb.toml settings
-	domainStepsInFrozenFileOverride uint64
+	erigondbDomainStepsInFrozenFile uint64
 	reorgBlockDepth                 uint64
 
 	genSaltIfNeed   bool
@@ -68,7 +68,7 @@ func (opts AggOpts) Open(ctx context.Context, db kv.RoDB) (*Aggregator, error) {
 
 	a.stepSize.Store(opts.stepSize)
 	a.stepsInFrozenFile.Store(opts.stepsInFrozenFile)
-	a.domainStepsInFrozenFileOverride = opts.domainStepsInFrozenFileOverride
+	a.erigondbDomainStepsInFrozenFile = opts.erigondbDomainStepsInFrozenFile
 
 	a.disableHistory = opts.disableHistory
 	a.disableFsync = opts.disableFsync
@@ -98,12 +98,12 @@ func (opts AggOpts) StepsInFrozenFile(steps uint64) AggOpts { //nolint:gocritic
 	return opts
 }
 
-// DomainStepsInFrozenFileOverride sets the domain-only cap override (see
-// Aggregator.domainStepsInFrozenFileOverride). 0 clears the override;
+// ErigondbDomainStepsInFrozenFile sets the domain-only cap override (see
+// Aggregator.erigondbDomainStepsInFrozenFile). 0 clears the override;
 // config3.UnboundedDomainMerge disables the cap; any other value replaces stepsInFrozenFile
 // for domain merges only.
-func (opts AggOpts) DomainStepsInFrozenFileOverride(steps uint64) AggOpts { //nolint:gocritic
-	opts.domainStepsInFrozenFileOverride = steps
+func (opts AggOpts) ErigondbDomainStepsInFrozenFile(steps uint64) AggOpts { //nolint:gocritic
+	opts.erigondbDomainStepsInFrozenFile = steps
 	return opts
 }
 func (opts AggOpts) ReorgBlockDepth(d uint64) AggOpts { //nolint:gocritic

--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -668,7 +668,7 @@ func collateAndMerge(t *testing.T, tx kv.RwTx, d *Domain, txs uint64) {
 		if stop := func() bool {
 			domainRoTx := d.beginForTests()
 			defer domainRoTx.Close()
-			r = domainRoTx.findMergeRange(domainRoTx.files.EndTxNum(), maxSpan)
+			r = domainRoTx.findMergeRange(domainRoTx.files.EndTxNum(), maxSpan, maxSpan)
 			if !r.any() {
 				return true
 			}
@@ -707,7 +707,7 @@ func collateAndMergeOnceWithScanPrune(t *testing.T, d *Domain, tx kv.RwTx, step 
 		if stop := func() bool {
 			domainRoTx := d.beginForTests()
 			defer domainRoTx.Close()
-			r := domainRoTx.findMergeRange(domainRoTx.files.EndTxNum(), maxSpan)
+			r := domainRoTx.findMergeRange(domainRoTx.files.EndTxNum(), maxSpan, maxSpan)
 			if !r.any() {
 				return true
 			}
@@ -743,7 +743,7 @@ func collateAndMergeOnce(t *testing.T, d *Domain, tx kv.RwTx, step kv.Step, prun
 	maxSpan := d.stepSize * config3.DefaultStepsInFrozenFile
 	for {
 		domainRoTx := d.beginForTests()
-		r := domainRoTx.findMergeRange(domainRoTx.files.EndTxNum(), maxSpan)
+		r := domainRoTx.findMergeRange(domainRoTx.files.EndTxNum(), maxSpan, maxSpan)
 		if !r.any() {
 			domainRoTx.Close()
 			break
@@ -1601,7 +1601,7 @@ func TestDomainContext_getFromFiles(t *testing.T) {
 		_, err = domainRoTx.Prune(ctx, tx, step, txFrom, txTo, math.MaxUint64, logEvery)
 		require.NoError(t, err)
 
-		ranges := domainRoTx.findMergeRange(txFrom, txTo)
+		ranges := domainRoTx.findMergeRange(txFrom, txTo, txTo)
 		vl, il, hl := domainRoTx.staticFilesInRange(ranges)
 
 		dv, di, dh, err := domainRoTx.mergeFiles(ctx, vl, il, hl, ranges, nil, ps)
@@ -3485,7 +3485,7 @@ func collateAndMergeWithCollisionRetry(t *testing.T, tx kv.RwTx, d *Domain, txs 
 	defer domainRoTx.Close()
 
 	// Merge with collision retry
-	r := domainRoTx.findMergeRange(d.dirtyFilesEndTxNumMinimax(), d.dirtyFilesEndTxNumMinimax())
+	r := domainRoTx.findMergeRange(d.dirtyFilesEndTxNumMinimax(), d.dirtyFilesEndTxNumMinimax(), d.dirtyFilesEndTxNumMinimax())
 	if r.values.needMerge {
 		valuesOuts, indexOuts, historyOuts := domainRoTx.staticFilesInRange(r)
 		valuesIn, indexIn, historyIn, err := domainRoTx.mergeFiles(ctx, valuesOuts, indexOuts, historyOuts, r, nil, background.NewProgressSet())

--- a/db/state/merge.go
+++ b/db/state/merge.go
@@ -119,7 +119,12 @@ func (iit *InvertedIndexRoTx) FirstStepNotInFiles() kv.Step {
 // findMergeRange
 // make merge determenistic across nodes: even if Node has much small files - do earliest-first merges
 // As any other methods of DomainRoTx - it can't see any files overlaps or garbage
-func (dt *DomainRoTx) findMergeRange(maxEndTxNum, maxSpan uint64) DomainRanges {
+//
+// domainMaxSpan caps the domain values merge range; historyMaxSpan is forwarded to the history
+// (and underlying inverted index) merge. They are passed separately so that the
+// --override.domain.steps-in-frozen-file CLI flag can relax the domain cap without affecting
+// history/II, which keep using the erigondb.toml stepsInFrozenFile value.
+func (dt *DomainRoTx) findMergeRange(maxEndTxNum, domainMaxSpan, maxSpan uint64) DomainRanges {
 	r := DomainRanges{
 		name:    dt.name,
 		aggStep: dt.stepSize,
@@ -130,7 +135,7 @@ func (dt *DomainRoTx) findMergeRange(maxEndTxNum, maxSpan uint64) DomainRanges {
 		}
 		endStep := item.endTxNum / dt.stepSize
 		spanStep := endStep & -endStep // Extract rightmost bit in the binary representation of endStep, this corresponds to size of maximally possible merge ending at endStep
-		span := spanStep * dt.stepSize
+		span := min(spanStep*dt.stepSize, domainMaxSpan)
 		fromTxNum := item.endTxNum - span
 		if fromTxNum >= item.startTxNum {
 			continue

--- a/db/state/merge.go
+++ b/db/state/merge.go
@@ -122,7 +122,7 @@ func (iit *InvertedIndexRoTx) FirstStepNotInFiles() kv.Step {
 //
 // domainMaxSpan caps the domain values merge range; historyMaxSpan is forwarded to the history
 // (and underlying inverted index) merge. They are passed separately so that the
-// --override.domain.steps-in-frozen-file CLI flag can relax the domain cap without affecting
+// --erigondb.domain.steps-in-frozen-file CLI flag can relax the domain cap without affecting
 // history/II, which keep using the erigondb.toml stepsInFrozenFile value.
 func (dt *DomainRoTx) findMergeRange(maxEndTxNum, domainMaxSpan, maxSpan uint64) DomainRanges {
 	r := DomainRanges{

--- a/db/state/merge_test.go
+++ b/db/state/merge_test.go
@@ -60,12 +60,12 @@ func TestDomainRoTx_findMergeRange(t *testing.T) {
 
 	t.Run("empty_and_single_file", func(t *testing.T) {
 		dt := newDomainRoTx(1, []visibleFile{})
-		result := dt.findMergeRange(100, 32)
+		result := dt.findMergeRange(100, 32, 32)
 		assert.False(t, result.values.needMerge)
 		assert.Equal(t, uint64(1), result.aggStep)
 
 		dt = newDomainRoTx(1, []visibleFile{createFile(0, 2)})
-		result = dt.findMergeRange(4, 32)
+		result = dt.findMergeRange(4, 32, 32)
 		assert.False(t, result.values.needMerge)
 	})
 
@@ -77,7 +77,7 @@ func TestDomainRoTx_findMergeRange(t *testing.T) {
 			createFile(5, 6),
 		}
 		dt := newDomainRoTx(1, files)
-		result := dt.findMergeRange(16, 32)
+		result := dt.findMergeRange(16, 32, 32)
 		assert.True(t, result.values.needMerge)
 		assert.Equal(t, uint64(0), result.values.from)
 		assert.Equal(t, uint64(4), result.values.to)
@@ -91,7 +91,7 @@ func TestDomainRoTx_findMergeRange(t *testing.T) {
 			createFile(3, 4),
 		}
 		dt := newDomainRoTx(1, files)
-		result := dt.findMergeRange(4, 32)
+		result := dt.findMergeRange(4, 32, 32)
 		assert.True(t, result.values.needMerge)
 		assert.Equal(t, uint64(0), result.values.from)
 		assert.Equal(t, uint64(4), result.values.to)
@@ -105,7 +105,7 @@ func TestDomainRoTx_findMergeRange(t *testing.T) {
 				createFile(aggStep, aggStep*2),
 			}
 			dt := newDomainRoTx(aggStep, files)
-			result := dt.findMergeRange(endTx, 32)
+			result := dt.findMergeRange(endTx, 32, 32)
 			assert.Equal(t, aggStep, result.aggStep)
 			assert.True(t, result.values.needMerge)
 		}
@@ -537,7 +537,7 @@ func TestFindMergeRange_Optimal(t *testing.T) {
 		files := []visibleFile{
 			f(0, 16), f(16, 24), f(24, 28), f(28, 30), f(30, 31), f(31, 32),
 		}
-		r := newDomainRoTx(1, files).findMergeRange(32, 32)
+		r := newDomainRoTx(1, files).findMergeRange(32, 32, 32)
 		assert.True(t, r.values.needMerge)
 		assert.Equal(t, 0, int(r.values.from))
 		assert.Equal(t, 32, int(r.values.to))
@@ -554,7 +554,7 @@ func TestFindMergeRange_Optimal(t *testing.T) {
 	t.Run("domain/after_partial_merge", func(t *testing.T) {
 		// After a prior merge produced 0-32, the remaining files allow 0-64.
 		files := []visibleFile{f(0, 32), f(32, 48), f(48, 64)}
-		r := newDomainRoTx(16, files).findMergeRange(64, 64)
+		r := newDomainRoTx(16, files).findMergeRange(64, 64, 64)
 		assert.True(t, r.values.needMerge)
 		assert.Equal(t, 0, int(r.values.from))
 		assert.Equal(t, 64, int(r.values.to))
@@ -565,7 +565,7 @@ func TestFindMergeRange_Optimal(t *testing.T) {
 	t.Run("domain/four_equal_steps", func(t *testing.T) {
 		// 4 single-step files → merges 0-64 directly (4-way, single pass).
 		files := []visibleFile{f(0, 16), f(16, 32), f(32, 48), f(48, 64)}
-		r := newDomainRoTx(16, files).findMergeRange(64, 64)
+		r := newDomainRoTx(16, files).findMergeRange(64, 64, 64)
 		assert.True(t, r.values.needMerge)
 		assert.Equal(t, 0, int(r.values.from))
 		assert.Equal(t, 64, int(r.values.to))
@@ -583,7 +583,7 @@ func TestFindMergeRange_Optimal(t *testing.T) {
 			f(0, 1), f(1, 2), f(2, 3), f(3, 4),
 			f(4, 5), f(5, 6), f(6, 7), f(7, 8),
 		}
-		r := newDomainRoTx(1, files).findMergeRange(8, 8)
+		r := newDomainRoTx(1, files).findMergeRange(8, 8, 8)
 		assert.True(t, r.values.needMerge)
 		assert.Equal(t, 0, int(r.values.from))
 		assert.Equal(t, 8, int(r.values.to))
@@ -603,7 +603,7 @@ func TestFindMergeRange_Optimal(t *testing.T) {
 		files := []visibleFile{
 			f(0, 1), f(1, 2), f(2, 3), f(3, 4), f(4, 5), f(5, 6),
 		}
-		r := newDomainRoTx(1, files).findMergeRange(6, 8)
+		r := newDomainRoTx(1, files).findMergeRange(6, 8, 8)
 		assert.True(t, r.values.needMerge)
 		assert.Equal(t, 0, int(r.values.from))
 		assert.Equal(t, 4, int(r.values.to))
@@ -613,7 +613,7 @@ func TestFindMergeRange_Optimal(t *testing.T) {
 		files := []visibleFile{
 			f(0, 1), f(1, 2), f(2, 3), f(3, 4), f(4, 5),
 		}
-		r := newDomainRoTx(1, files).findMergeRange(5, 8)
+		r := newDomainRoTx(1, files).findMergeRange(5, 8, 8)
 		assert.True(t, r.values.needMerge)
 		assert.Equal(t, 0, int(r.values.from))
 		assert.Equal(t, 4, int(r.values.to))

--- a/node/cli/default_flags.go
+++ b/node/cli/default_flags.go
@@ -257,4 +257,6 @@ var DefaultFlags = []cli.Flag{
 	&utils.MCPDisableFlag,
 	&utils.MCPAddrFlag,
 	&utils.MCPPortFlag,
+
+	&utils.OverrideDomainStepsInFrozenFileFlag,
 }

--- a/node/cli/default_flags.go
+++ b/node/cli/default_flags.go
@@ -258,5 +258,5 @@ var DefaultFlags = []cli.Flag{
 	&utils.MCPAddrFlag,
 	&utils.MCPPortFlag,
 
-	&utils.OverrideDomainStepsInFrozenFileFlag,
+	&utils.ErigondbDomainStepsInFrozenFileFlag,
 }

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -1286,14 +1286,14 @@ func SetUpBlockReader(ctx context.Context, db kv.RwDB, dirs datadir.Dirs, snConf
 		return nil, nil, nil, nil, nil, nil, nil, err
 	}
 	aggOpts := state.New(dirs).Logger(logger).SanityOldNaming().GenSaltIfNeed(createNewSaltFileIfNeeded).WithErigonDBSettings(erigonDBSettings)
-	if snConfig.OverrideDomainStepsInFrozenFile != nil {
-		v := *snConfig.OverrideDomainStepsInFrozenFile
+	if snConfig.ErigondbDomainStepsInFrozenFile != nil {
+		v := *snConfig.ErigondbDomainStepsInFrozenFile
 		stepsStr := "Inf"
 		if v != config3.UnboundedDomainMerge {
 			stepsStr = fmt.Sprintf("%d", v)
 		}
 		logger.Info("domain merge cap overridden", "steps_in_frozen_file", stepsStr)
-		aggOpts = aggOpts.DomainStepsInFrozenFileOverride(v)
+		aggOpts = aggOpts.ErigondbDomainStepsInFrozenFile(v)
 	}
 	agg, err := aggOpts.Open(ctx, db)
 	if err != nil {

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -50,6 +50,7 @@ import (
 	"github.com/erigontech/erigon/common/disk"
 	"github.com/erigontech/erigon/common/event"
 	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/config3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/downloader"
 	"github.com/erigontech/erigon/db/kv"
@@ -1284,7 +1285,17 @@ func SetUpBlockReader(ctx context.Context, db kv.RwDB, dirs datadir.Dirs, snConf
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, nil, err
 	}
-	agg, err := state.New(dirs).Logger(logger).SanityOldNaming().GenSaltIfNeed(createNewSaltFileIfNeeded).WithErigonDBSettings(erigonDBSettings).Open(ctx, db)
+	aggOpts := state.New(dirs).Logger(logger).SanityOldNaming().GenSaltIfNeed(createNewSaltFileIfNeeded).WithErigonDBSettings(erigonDBSettings)
+	if snConfig.OverrideDomainStepsInFrozenFile != nil {
+		v := *snConfig.OverrideDomainStepsInFrozenFile
+		stepsStr := "Inf"
+		if v != config3.UnboundedDomainMerge {
+			stepsStr = fmt.Sprintf("%d", v)
+		}
+		logger.Info("domain merge cap overridden", "steps_in_frozen_file", stepsStr)
+		aggOpts = aggOpts.DomainStepsInFrozenFileOverride(v)
+	}
+	agg, err := aggOpts.Open(ctx, db)
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, nil, err
 	}

--- a/node/ethconfig/config.go
+++ b/node/ethconfig/config.go
@@ -268,6 +268,12 @@ type Config struct {
 	FcuBackgroundCommit bool
 
 	MCPAddress string
+
+	// OverrideDomainStepsInFrozenFile overrides erigondb.toml stepsInFrozenFile for the
+	// domain merge cap only (history/II are unaffected). nil = no override;
+	// config3.UnboundedDomainMerge disables the cap; any other positive value is used
+	// directly as the cap in steps.
+	OverrideDomainStepsInFrozenFile *uint64 `toml:",omitempty"`
 }
 
 type Sync struct {

--- a/node/ethconfig/config.go
+++ b/node/ethconfig/config.go
@@ -269,11 +269,11 @@ type Config struct {
 
 	MCPAddress string
 
-	// OverrideDomainStepsInFrozenFile overrides erigondb.toml stepsInFrozenFile for the
+	// ErigondbDomainStepsInFrozenFile overrides erigondb.toml stepsInFrozenFile for the
 	// domain merge cap only (history/II are unaffected). nil = no override;
 	// config3.UnboundedDomainMerge disables the cap; any other positive value is used
 	// directly as the cap in steps.
-	OverrideDomainStepsInFrozenFile *uint64 `toml:",omitempty"`
+	ErigondbDomainStepsInFrozenFile *uint64 `toml:",omitempty"`
 }
 
 type Sync struct {

--- a/node/ethconfig/gen_config.go
+++ b/node/ethconfig/gen_config.go
@@ -59,6 +59,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		FcuBackgroundPrune                  bool
 		FcuBackgroundCommit                 bool
 		MCPAddress                          string
+		OverrideDomainStepsInFrozenFile     *uint64 `toml:",omitempty"`
 	}
 	var enc Config
 	enc.Genesis = c.Genesis
@@ -97,6 +98,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.FcuBackgroundPrune = c.FcuBackgroundPrune
 	enc.FcuBackgroundCommit = c.FcuBackgroundCommit
 	enc.MCPAddress = c.MCPAddress
+	enc.OverrideDomainStepsInFrozenFile = c.OverrideDomainStepsInFrozenFile
 	return &enc, nil
 }
 
@@ -139,6 +141,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		FcuBackgroundPrune                  *bool
 		FcuBackgroundCommit                 *bool
 		MCPAddress                          *string
+		OverrideDomainStepsInFrozenFile     *uint64 `toml:",omitempty"`
 	}
 	var dec Config
 	if err := unmarshal(&dec); err != nil {
@@ -251,6 +254,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.MCPAddress != nil {
 		c.MCPAddress = *dec.MCPAddress
+	}
+	if dec.OverrideDomainStepsInFrozenFile != nil {
+		c.OverrideDomainStepsInFrozenFile = dec.OverrideDomainStepsInFrozenFile
 	}
 	return nil
 }

--- a/node/ethconfig/gen_config.go
+++ b/node/ethconfig/gen_config.go
@@ -59,7 +59,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		FcuBackgroundPrune                  bool
 		FcuBackgroundCommit                 bool
 		MCPAddress                          string
-		OverrideDomainStepsInFrozenFile     *uint64 `toml:",omitempty"`
+		ErigondbDomainStepsInFrozenFile     *uint64 `toml:",omitempty"`
 	}
 	var enc Config
 	enc.Genesis = c.Genesis
@@ -98,7 +98,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.FcuBackgroundPrune = c.FcuBackgroundPrune
 	enc.FcuBackgroundCommit = c.FcuBackgroundCommit
 	enc.MCPAddress = c.MCPAddress
-	enc.OverrideDomainStepsInFrozenFile = c.OverrideDomainStepsInFrozenFile
+	enc.ErigondbDomainStepsInFrozenFile = c.ErigondbDomainStepsInFrozenFile
 	return &enc, nil
 }
 
@@ -141,7 +141,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		FcuBackgroundPrune                  *bool
 		FcuBackgroundCommit                 *bool
 		MCPAddress                          *string
-		OverrideDomainStepsInFrozenFile     *uint64 `toml:",omitempty"`
+		ErigondbDomainStepsInFrozenFile     *uint64 `toml:",omitempty"`
 	}
 	var dec Config
 	if err := unmarshal(&dec); err != nil {
@@ -255,8 +255,8 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	if dec.MCPAddress != nil {
 		c.MCPAddress = *dec.MCPAddress
 	}
-	if dec.OverrideDomainStepsInFrozenFile != nil {
-		c.OverrideDomainStepsInFrozenFile = dec.OverrideDomainStepsInFrozenFile
+	if dec.ErigondbDomainStepsInFrozenFile != nil {
+		c.ErigondbDomainStepsInFrozenFile = dec.ErigondbDomainStepsInFrozenFile
 	}
 	return nil
 }


### PR DESCRIPTION
Currently domain merge is unlimited (ignores steps-in-frozen-files setting, applied only to hsitory/index).

From now on, it follows the same limit by default.

On +3.5 snapshotters we should run erigon with `--override.domain.steps-in-frozen-files="Inf"` to preserve the old behavior and fabricate domains with unlimited merging.