### PR TITLE
parallel_exec: removing 1 spamming `Background files build` log

### DIFF
--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -353,10 +353,6 @@ func (pe *parallelExecutor) exec(ctx context.Context, execStage *StageState, u U
 									prevCommittedTransactions = committedTransactions
 									prevCommitedGas = committedGas
 								}
-
-								if pe.agg.HasBackgroundFilesBuild() {
-									pe.logger.Info(fmt.Sprintf("[%s] Background files build", pe.logPrefix), "progress", pe.agg.BackgroundProgress())
-								}
 							}
 
 							if time.Since(lastExecutedLog) > logInterval/50 {


### PR DESCRIPTION
`main`, `non-chain-tip`.  `integration stage_exec`. see many log lines per second:
```
[INFO] [04-21|12:37:17.139] [6/8 Execution] Background files build   progress="v2.1-tracesto.0-8.efi=99%"
[INFO] [04-21|12:37:17.140] [6/8 Execution] Background files build   progress="v2.1-tracesto.0-8.efi=99%"
[INFO] [04-21|12:37:17.140] [6/8 Execution] Background files build   progress="v2.1-tracesto.0-8.efi=99%"
[INFO] [04-21|12:37:17.141] [6/8 Execution] Background files build   progress="v2.1-tracesto.0-8.efi=99%"
[INFO] [04-21|12:37:17.141] [6/8 Execution] Background files build   progress="v2.1-tracesto.0-8.efi=99%"
[INFO] [04-21|12:37:17.142] [6/8 Execution] Background files build   progress="v2.1-tracesto.0-8.efi=99%"
```

-- 
we still have one more logging in `case <-logEvery.C:`