### PR TITLE
makefile: `solc` depend on `OPENZEPPELIN` 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -454,7 +454,7 @@ mocks:
 	PATH="$(GOBIN):$(PATH)" go generate -run "mockgen" ./...
 
 ## solc:                              generate all solidity contracts
-solc:
+solc: $(OPENZEPPELIN)
 	PATH="$(GOBIN):$(PATH)" go generate -run "solc" -skip "txnprovider/shutter" ./...
 	@cd txnprovider/shutter && $(MAKE) solc
 


### PR DESCRIPTION
to fix errors like:
```
Error: Source "openzeppelin/contracts/access/Ownable.sol" not found: File not found. Searched the following locations: "/Users/alex/projects/erigon_a2/txnprovider/shutter/internal/contracts/.", "/Users/alex/projects/erigon_a2/txnprovider/shutter/build".
 --> KeyperSet.sol:4:1:
  |
4 | import "openzeppelin/contracts/access/Ownable.sol";
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```