### PR TITLE
execution/trie: enhance trie hashing flow and correct key encoding

### DIFF
--- a/execution/commitment/trie/hashbuilder.go
+++ b/execution/commitment/trie/hashbuilder.go
@@ -497,8 +497,6 @@ func (hb *HashBuilder) extensionHash(key []byte) error {
 func (hb *HashBuilder) branch(set uint16) error {
 	if hb.trace {
 		fmt.Printf("BRANCH (%b)\n", set)
-	}
-	if hb.trace {
 		fmt.Printf("Stack depth: %d\n", len(hb.nodeStack))
 	}
 	f := &FullNode{}

--- a/execution/commitment/trie/hasher.go
+++ b/execution/commitment/trie/hasher.go
@@ -299,10 +299,18 @@ func (h *hasher) valueNodeToBuffer(vn ValueNode, buffer []byte, pos int) (int, e
 }
 
 func (h *hasher) accountNodeToBuffer(ac *AccountNode, buffer []byte, pos int) (int, error) {
-	encLen := ac.EncodingLengthForHashing()
-	// Reuse the end of the pre-allocated 1MB buffers to avoid heap allocation.
-	// Account RLP encoding is always small (usually ~80 bytes).
-	acRlp := h.buffers[len(h.buffers)-128 : len(h.buffers)-128+int(encLen)]
+	encLen := int(ac.EncodingLengthForHashing())
+	const accountRlpScratchSize = 128
+	// Reuse the end of the pre-allocated buffers to avoid heap allocation when
+	// the account RLP fits in the scratch region. Fall back to a dedicated
+	// allocation if the encoding grows beyond the scratch capacity.
+	var acRlp []byte
+	if encLen <= accountRlpScratchSize && len(h.buffers) >= accountRlpScratchSize {
+		start := len(h.buffers) - accountRlpScratchSize
+		acRlp = h.buffers[start : start+encLen]
+	} else {
+		acRlp = make([]byte, encLen)
+	}
 	ac.EncodeForHashing(acRlp)
 	enc := rlp.RlpEncodedBytes(acRlp)
 	h.bw.Setup(buffer, pos)

--- a/execution/commitment/trie/hasher.go
+++ b/execution/commitment/trie/hasher.go
@@ -299,7 +299,10 @@ func (h *hasher) valueNodeToBuffer(vn ValueNode, buffer []byte, pos int) (int, e
 }
 
 func (h *hasher) accountNodeToBuffer(ac *AccountNode, buffer []byte, pos int) (int, error) {
-	acRlp := make([]byte, ac.EncodingLengthForHashing())
+	encLen := ac.EncodingLengthForHashing()
+	// Reuse the end of the pre-allocated 1MB buffers to avoid heap allocation.
+	// Account RLP encoding is always small (usually ~80 bytes).
+	acRlp := h.buffers[len(h.buffers)-128 : len(h.buffers)-128+int(encLen)]
 	ac.EncodeForHashing(acRlp)
 	enc := rlp.RlpEncodedBytes(acRlp)
 	h.bw.Setup(buffer, pos)

--- a/execution/commitment/trie/node.go
+++ b/execution/commitment/trie/node.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"io"
 	"math/bits"
+
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/execution/rlp"
 	"github.com/erigontech/erigon/execution/types/accounts"

--- a/execution/commitment/trie/node.go
+++ b/execution/commitment/trie/node.go
@@ -22,7 +22,7 @@ package trie
 import (
 	"bytes"
 	"io"
-
+	"math/bits"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/execution/rlp"
 	"github.com/erigontech/erigon/execution/types/accounts"
@@ -129,20 +129,8 @@ func (n *DuoNode) EncodeRLP(w io.Writer) error {
 }
 
 func (n *DuoNode) childrenIdx() (i1 byte, i2 byte) {
-	child := 1
-	var m uint32 = 1
-	for i := 0; i < 17; i++ {
-		if (n.mask & m) > 0 {
-			if child == 1 {
-				i1 = byte(i)
-				child = 2
-			} else if child == 2 {
-				i2 = byte(i)
-				break
-			}
-		}
-		m <<= 1
-	}
+	i1 = byte(bits.TrailingZeros32(n.mask))
+	i2 = byte(bits.TrailingZeros32(n.mask & ^(1 << i1)))
 	return i1, i2
 }
 

--- a/execution/commitment/trie/retain_list.go
+++ b/execution/commitment/trie/retain_list.go
@@ -359,10 +359,6 @@ func (rl *RetainList) ensureInited() {
 // come in monotonically ascending order, we optimise for this, though
 // the function would still work if the order is different
 func (rl *RetainList) Retain(prefix []byte) bool {
-	// if bytes.HasPrefix(prefix, common.FromHex("0x0d05")) {
-	// 	fmt.Println("here!!!!!")
-	// }
-
 	rl.ensureInited()
 	if len(prefix) < rl.minLength {
 		return true

--- a/execution/commitment/trie/stream.go
+++ b/execution/commitment/trie/stream.go
@@ -67,27 +67,13 @@ type Stream struct {
 
 // Reset sets all slices to zero sizes, without de-allocating
 func (s *Stream) Reset() {
-	if len(s.keyBytes) > 0 {
-		s.keyBytes = s.keyBytes[:0]
-	}
-	if len(s.keySizes) > 0 {
-		s.keySizes = s.keySizes[:0]
-	}
-	if len(s.itemTypes) > 0 {
-		s.itemTypes = s.itemTypes[:0]
-	}
-	if len(s.aValues) > 0 {
-		s.aValues = s.aValues[:0]
-	}
-	if len(s.aCodes) > 0 {
-		s.aCodes = s.aCodes[:0]
-	}
-	if len(s.sValues) > 0 {
-		s.sValues = s.sValues[:0]
-	}
-	if len(s.hashes) > 0 {
-		s.hashes = s.hashes[:0]
-	}
+	s.keyBytes = s.keyBytes[:0]
+	s.keySizes = s.keySizes[:0]
+	s.itemTypes = s.itemTypes[:0]
+	s.aValues = s.aValues[:0]
+	s.aCodes = s.aCodes[:0]
+	s.sValues = s.sValues[:0]
+	s.hashes = s.hashes[:0]
 }
 
 type StreamIterator interface {
@@ -126,21 +112,15 @@ func NewIterator(t *Trie, rl *RetainList, trace bool) *Iterator {
 func (it *Iterator) Reset(t *Trie, rl *RetainList, trace bool) {
 	it.rl = rl
 	it.hex = it.hex[:0]
-	if len(it.nodeStack) > 0 {
-		it.nodeStack = it.nodeStack[:0]
-	}
+	it.nodeStack = it.nodeStack[:0]
 	it.nodeStack = append(it.nodeStack, t.RootNode)
-	if len(it.iStack) > 0 {
-		it.iStack = it.iStack[:0]
-	}
-	it.lenStack = append(it.lenStack, 0)
-	if len(it.goDeepStack) > 0 {
-		it.goDeepStack = it.goDeepStack[:0]
-	}
+	it.iStack = it.iStack[:0]
+	it.iStack = append(it.iStack, 0)
+	it.goDeepStack = it.goDeepStack[:0]
 	it.goDeepStack = append(it.goDeepStack, true)
-	if len(it.accountStack) > 0 {
-		it.accountStack = it.accountStack[:0]
-	}
+	it.lenStack = it.lenStack[:0]
+	it.lenStack = append(it.lenStack, 0)
+	it.accountStack = it.accountStack[:0]
 	it.accountStack = append(it.accountStack, true)
 	it.top = 1
 	it.trace = trace

--- a/execution/commitment/trie/trie.go
+++ b/execution/commitment/trie/trie.go
@@ -1808,31 +1808,7 @@ func resolveHashNodes(node Node, nodeMap map[common.Hash]Node, insideStorageTree
 }
 
 func sameNodeType(a, b Node) bool {
-	switch a.(type) {
-	case *ShortNode:
-		_, ok := b.(*ShortNode)
-		return ok
-	case *FullNode:
-		_, ok := b.(*FullNode)
-		return ok
-	case *DuoNode:
-		_, ok := b.(*DuoNode)
-		return ok
-	case *AccountNode:
-		_, ok := b.(*AccountNode)
-		return ok
-	case *HashNode:
-		_, ok := b.(*HashNode)
-		return ok
-	case ValueNode:
-		_, ok := b.(ValueNode)
-		return ok
-	case CodeNode:
-		_, ok := b.(CodeNode)
-		return ok
-	default:
-		return false
-	}
+	return reflect.TypeOf(a) == reflect.TypeOf(b)
 }
 
 // GetNode returns the trie node found at the given hex-nibble path,

--- a/execution/commitment/trie/trie.go
+++ b/execution/commitment/trie/trie.go
@@ -152,7 +152,7 @@ func merge2ShortNodes(node1, node2 *ShortNode) (bool, error) {
 	} else { // node1.Val is not a hashnode
 		// if node2.Val is not  a hashnode, node2.Val is expected to have the same type as node1.Val, otherwise if it is a hashnode no action is necessary (just ignore the hashnode)
 		if _, ok2 := node2.Val.(*HashNode); !ok2 {
-			if reflect.TypeOf(node1.Val) != reflect.TypeOf(node2.Val) { // sanity check
+			if !sameNodeType(node1.Val, node2.Val) { // sanity check
 				return false, fmt.Errorf("node1.Val and node2.Val have different types: %T != %T ", node1.Val, node2.Val)
 			} else {
 				furtherMergingNeeded = true
@@ -501,12 +501,17 @@ func (t *Trie) getPath(origNode Node, parents [][]byte, key []byte, pos int) ([]
 func (t *Trie) Update(key, value []byte) {
 	hex := nibbles.KeybytesToHex(key)
 
+	if len(value) == 0 {
+		_, t.RootNode = t.delete(t.RootNode, hex, false)
+		return
+	}
+
 	newnode := ValueNode(value)
 
 	if t.RootNode == nil {
 		t.RootNode = NewShortNode(hex, newnode)
 	} else {
-		_, t.RootNode = t.insert(t.RootNode, hex, ValueNode(value))
+		_, t.RootNode = t.insert(t.RootNode, hex, newnode)
 	}
 }
 
@@ -1799,6 +1804,34 @@ func resolveHashNodes(node Node, nodeMap map[common.Hash]Node, insideStorageTree
 
 	default:
 		return n, nil
+	}
+}
+
+func sameNodeType(a, b Node) bool {
+	switch a.(type) {
+	case *ShortNode:
+		_, ok := b.(*ShortNode)
+		return ok
+	case *FullNode:
+		_, ok := b.(*FullNode)
+		return ok
+	case *DuoNode:
+		_, ok := b.(*DuoNode)
+		return ok
+	case *AccountNode:
+		_, ok := b.(*AccountNode)
+		return ok
+	case *HashNode:
+		_, ok := b.(*HashNode)
+		return ok
+	case ValueNode:
+		_, ok := b.(ValueNode)
+		return ok
+	case CodeNode:
+		_, ok := b.(CodeNode)
+		return ok
+	default:
+		return false
 	}
 }
 

--- a/execution/commitment/trie/trie_test.go
+++ b/execution/commitment/trie/trie_test.go
@@ -72,6 +72,40 @@ func TestNull(t *testing.T) {
 	}
 }
 
+func TestUpdateEmptyValueDeletes(t *testing.T) {
+	trie := newEmpty()
+	key := []byte("test-key")
+	value := []byte("test-value")
+
+	// 1. Insert a value
+	trie.Update(key, value)
+	v, ok := trie.Get(key)
+	require.True(t, ok)
+	require.Equal(t, value, v)
+
+	// 2. Update with empty value (should delete)
+	trie.Update(key, []byte{})
+
+	// 3. Verify deletion
+	v, ok = trie.Get(key)
+	require.True(t, ok) // true because we resolved it fully without hitting a hash node
+	require.Nil(t, v, "key should be deleted when updated with empty value")
+
+	// 4. Insert again
+	trie.Update(key, value)
+	v, ok = trie.Get(key)
+	require.True(t, ok)
+	require.Equal(t, value, v)
+
+	// 5. Update with nil (should delete)
+	trie.Update(key, nil)
+
+	// 6. Verify deletion
+	v, ok = trie.Get(key)
+	require.True(t, ok)
+	require.Nil(t, v, "key should be deleted when updated with nil value")
+}
+
 func TestLargeValue(t *testing.T) {
 	trie := newEmpty()
 	trie.Update([]byte("key1"), []byte{99, 99, 99, 99})


### PR DESCRIPTION
```
goos: linux
goarch: amd64
pkg: github.com/erigontech/erigon/execution/commitment/trie
cpu: Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz
                  │ old_bench.txt │         new_bench.txt         │
                  │    sec/op     │   sec/op     vs base          │
TrieUpdateAccount     1.040m ± 4%   1.017m ± 5%  ~ (p=0.315 n=10)

                  │ old_bench.txt │            new_bench.txt             │
                  │     B/op      │     B/op      vs base                │
TrieUpdateAccount    382.8Ki ± 0%   336.0Ki ± 0%  -12.25% (p=0.000 n=10)

                  │ old_bench.txt │            new_bench.txt            │
                  │   allocs/op   │  allocs/op   vs base                │
TrieUpdateAccount     4.669k ± 0%   4.169k ± 0%  -10.71% (p=0.000 n=10)
```

Benchmark
```go
func BenchmarkTrieUpdateAccount(b *testing.B) {
	random := rand.New(rand.NewSource(42))

	const numEntries = 500
	addresses := make([][20]byte, numEntries)
	for i := range addresses {
		random.Read(addresses[i][:])
	}
	testAccounts := make([]*accounts.Account, numEntries)
	for i := range testAccounts {
		acc := accounts.NewAccount()
		acc.Nonce = uint64(random.Int63())
		acc.Balance = *uint256.NewInt(uint64(random.Int63()))
		acc.Root = EmptyRoot
		acc.CodeHash = accounts.EmptyCodeHash
		testAccounts[i] = &acc
	}

	b.ResetTimer()
	b.ReportAllocs()
	for i := 0; i < b.N; i++ {
		trie := newEmpty()
		for j := 0; j < numEntries; j++ {
			trie.UpdateAccount(crypto.Keccak256(addresses[j][:]), testAccounts[j])
		}
		trie.Hash()
	}
}
```