### PR TITLE
execution/stagedsync: gate BAL size check on Amsterdam

### DIFF
--- a/execution/stagedsync/bal_create.go
+++ b/execution/stagedsync/bal_create.go
@@ -61,12 +61,13 @@ func ProcessBAL(tx kv.TemporalRwTx, h *types.Header, vio *state.VersionedIO, ams
 	if err != nil {
 		return fmt.Errorf("block %d: invalid computed block access list: %w", blockNum, err)
 	}
-	if err := bal.ValidateMaxItems(h.GasLimit); err != nil {
-		return fmt.Errorf("%w, block %d: %w", rules.ErrInvalidBlock, blockNum, err)
-	}
 	log.Debug("bal", "blockNum", blockNum, "hash", bal.Hash())
 	if !amsterdam {
 		return nil
+	}
+	// EIP-7928 size bound is only consensus-binding once Amsterdam activates.
+	if err := bal.ValidateMaxItems(h.GasLimit); err != nil {
+		return fmt.Errorf("%w, block %d: %w", rules.ErrInvalidBlock, blockNum, err)
 	}
 	if h.BlockAccessListHash == nil {
 		return fmt.Errorf("block %d: missing block access list hash", blockNum)


### PR DESCRIPTION
- Fixes the `execution-eest-blockchain` race-test failure on #20606 where `test_gas_limit_below_minimum[gas_limit_5000]` on Cancun and Prague forks is incorrectly rejected.
- The EIP-7928 `bal_items <= gasLimit / BAL_ITEM_COST` bound is consensus-binding only once Amsterdam activates. Moves the `bal.ValidateMaxItems` call in `ProcessBAL` below the `if !amsterdam { return nil }` guard so pre-Amsterdam experimental runs don't reject otherwise-valid blocks.
- Concrete breakage: fixture gas_limit = 5000 → maxItems = 2; Cancun block touches 3 items, Prague touches 15. Block is valid (5000 is the minimum, `expectException: None`), but BAL-size check fires.

Failing job before fix: https://github.com/erigontech/erigon/actions/runs/24723349697/job/72317708149
