### PR TITLE
db/version: enforce upper-bound file version check

### DIFF
--- a/db/snaptype2/block_types.go
+++ b/db/snaptype2/block_types.go
@@ -199,13 +199,7 @@ var (
 				if !ok {
 					return fmt.Errorf("can't find files with vers by pattern %s for indexing in bodies", bodiesPathPattern)
 				}
-				if bVer.Less(statecfg.Schema.BodiesBlock.FileVersion.DataSeg.MinSupported) {
-					verToPanic := version.Versions{
-						Current:      bVer,
-						MinSupported: statecfg.Schema.BodiesBlock.FileVersion.DataSeg.MinSupported,
-					}
-					version.VersionTooLowPanic(filepath.Base(bodiesPath), verToPanic)
-				}
+				statecfg.Schema.BodiesBlock.FileVersion.DataSeg.MustSupport(bVer, filepath.Base(bodiesPath))
 				bodiesSegment, err := seg.NewDecompressor(bodiesPath)
 				if err != nil {
 					return fmt.Errorf("can't open %s for indexing in bodies: %w", sn.As(Bodies).Path, err)
@@ -228,13 +222,7 @@ var (
 				if !ok {
 					return fmt.Errorf("can't find files with vers by pattern %s for indexing in txs", txPathPattern)
 				}
-				if tVer.Less(statecfg.Schema.TransactionsBlock.FileVersion.DataSeg.MinSupported) {
-					verToPanic := version.Versions{
-						Current:      tVer,
-						MinSupported: statecfg.Schema.TransactionsBlock.FileVersion.DataSeg.MinSupported,
-					}
-					version.VersionTooLowPanic(filepath.Base(txPath), verToPanic)
-				}
+				statecfg.Schema.TransactionsBlock.FileVersion.DataSeg.MustSupport(tVer, filepath.Base(txPath))
 				d, err := seg.NewDecompressor(txPath)
 				if err != nil {
 					return fmt.Errorf("can't open %s for indexing in transactions: %w", sn.Path, err)

--- a/db/state/dirty_files.go
+++ b/db/state/dirty_files.go
@@ -335,7 +335,7 @@ func (d *Domain) openDirtyFiles(dirEntries []string) (err error) {
 				fNameMask := d.kvFileNameMask(fromStep, toStep)
 				fPath, fileVer, ok, err := version.MatchVersionedFile(fNameMask, dirEntries, d.dirs.SnapDomain)
 				if err != nil {
-					_, fName := filepath.Split(fPath)
+					fName := filepath.Base(fPath)
 					d.logger.Debug("[agg] Domain.openDirtyFiles: FileExist err", "f", fName, "err", err)
 					invalidFileItemsLock.Lock()
 					invalidFileItems = append(invalidFileItems, item)
@@ -351,7 +351,7 @@ func (d *Domain) openDirtyFiles(dirEntries []string) (err error) {
 					continue
 				}
 
-				_, fName := filepath.Split(fPath)
+				fName := filepath.Base(fPath)
 				d.FileVersion.DataKV.MustSupport(fileVer, fName)
 
 				if item.decompressor, err = seg.NewDecompressor(fPath); err != nil {
@@ -372,11 +372,11 @@ func (d *Domain) openDirtyFiles(dirEntries []string) (err error) {
 				fNameMask := d.kviAccessorFileNameMask(fromStep, toStep)
 				fPath, fileVer, ok, err := version.MatchVersionedFile(fNameMask, dirEntries, d.dirs.SnapDomain)
 				if err != nil {
-					_, fName := filepath.Split(fPath)
+					fName := filepath.Base(fPath)
 					d.logger.Warn("[agg] Domain.openDirtyFiles", "err", err, "f", fName)
 				}
 				if ok {
-					_, fName := filepath.Split(fPath)
+					fName := filepath.Base(fPath)
 					d.FileVersion.AccessorKVI.MustSupport(fileVer, fName)
 					if item.index, err = recsplit.OpenIndex(fPath); err != nil {
 						d.logger.Warn("[agg] Domain.openDirtyFiles", "err", err, "f", fName)
@@ -388,11 +388,11 @@ func (d *Domain) openDirtyFiles(dirEntries []string) (err error) {
 				fNameMask := d.kvBtAccessorFileNameMask(fromStep, toStep)
 				fPath, fileVer, ok, err := version.MatchVersionedFile(fNameMask, dirEntries, d.dirs.SnapDomain)
 				if err != nil {
-					_, fName := filepath.Split(fPath)
+					fName := filepath.Base(fPath)
 					d.logger.Warn("[agg] Domain.openDirtyFiles", "err", err, "f", fName)
 				}
 				if ok {
-					_, fName := filepath.Split(fPath)
+					fName := filepath.Base(fPath)
 					d.FileVersion.AccessorBT.MustSupport(fileVer, fName)
 					if item.bindex, err = btindex.OpenBtreeIndexWithDecompressor(fPath, btindex.DefaultBtreeM, d.dataReader(item.decompressor)); err != nil {
 						d.logger.Warn("[agg] Domain.openDirtyFiles", "err", err, "f", fName)
@@ -404,11 +404,11 @@ func (d *Domain) openDirtyFiles(dirEntries []string) (err error) {
 				fNameMask := d.kvExistenceIdxFileNameMask(fromStep, toStep)
 				fPath, fileVer, ok, err := version.MatchVersionedFile(fNameMask, dirEntries, d.dirs.SnapDomain)
 				if err != nil {
-					_, fName := filepath.Split(fPath)
+					fName := filepath.Base(fPath)
 					d.logger.Warn("[agg] Domain.openDirtyFiles", "err", err, "f", fName)
 				}
 				if ok {
-					_, fName := filepath.Split(fPath)
+					fName := filepath.Base(fPath)
 					d.FileVersion.AccessorKVEI.MustSupport(fileVer, fName)
 					if item.existence, err = existence.OpenFilter(fPath, false); err != nil {
 						d.logger.Warn("[agg] Domain.openDirtyFiles", "err", err, "f", fName)
@@ -438,7 +438,7 @@ func (h *History) openDirtyFiles(dataEntries, accessorEntries []string) error {
 				fNameMask := h.vFileNameMask(fromStep, toStep)
 				fPath, fileVer, ok, err := version.MatchVersionedFile(fNameMask, dataEntries, h.dirs.SnapHistory)
 				if err != nil {
-					_, fName := filepath.Split(fPath)
+					fName := filepath.Base(fPath)
 					h.logger.Debug("[agg] History.openDirtyFiles: FileExist", "f", fName, "err", err)
 					invalidFilesMu.Lock()
 					invalidFileItems = append(invalidFileItems, item)
@@ -453,7 +453,7 @@ func (h *History) openDirtyFiles(dataEntries, accessorEntries []string) error {
 					invalidFilesMu.Unlock()
 					continue
 				}
-				_, fName := filepath.Split(fPath)
+				fName := filepath.Base(fPath)
 				h.FileVersion.DataV.MustSupport(fileVer, fName)
 
 				if item.decompressor, err = seg.NewDecompressor(fPath); err != nil {
@@ -487,11 +487,11 @@ func (h *History) openDirtyFiles(dataEntries, accessorEntries []string) error {
 				fNameMask := h.vAccessorFileNameMask(fromStep, toStep)
 				fPath, fileVer, ok, err := version.MatchVersionedFile(fNameMask, accessorEntries, h.dirs.SnapAccessors)
 				if err != nil {
-					_, fName := filepath.Split(fPath)
+					fName := filepath.Base(fPath)
 					h.logger.Warn("[agg] History.openDirtyFiles", "err", err, "f", fName)
 				}
 				if ok {
-					_, fName := filepath.Split(fPath)
+					fName := filepath.Base(fPath)
 					h.FileVersion.AccessorVI.MustSupport(fileVer, fName)
 					if item.index, err = recsplit.OpenIndex(fPath); err != nil {
 						h.logger.Warn("[agg] History.openDirtyFiles", "err", err, "f", fName)
@@ -520,7 +520,7 @@ func (ii *InvertedIndex) openDirtyFiles(dataEntries, accessorEntries []string) e
 				fNameMask := ii.efFileNameMask(fromStep, toStep)
 				fPath, fileVer, ok, err := version.MatchVersionedFile(fNameMask, dataEntries, ii.dirs.SnapIdx)
 				if err != nil {
-					_, fName := filepath.Split(fPath)
+					fName := filepath.Base(fPath)
 					ii.logger.Debug("[agg] InvertedIndex.openDirtyFiles: MatchVersionedFile error", "f", fName, "err", err)
 					invalidFileItemsLock.Lock()
 					invalidFileItems = append(invalidFileItems, item)
@@ -537,7 +537,7 @@ func (ii *InvertedIndex) openDirtyFiles(dataEntries, accessorEntries []string) e
 					continue
 				}
 
-				_, fName := filepath.Split(fPath)
+				fName := filepath.Base(fPath)
 				ii.FileVersion.DataEF.MustSupport(fileVer, fName)
 
 				if item.decompressor, err = seg.NewDecompressor(fPath); err != nil {
@@ -558,12 +558,12 @@ func (ii *InvertedIndex) openDirtyFiles(dataEntries, accessorEntries []string) e
 				fNameMask := ii.efAccessorFileNameMask(fromStep, toStep)
 				fPath, fileVer, ok, err := version.MatchVersionedFile(fNameMask, accessorEntries, ii.dirs.SnapAccessors)
 				if err != nil {
-					_, fName := filepath.Split(fPath)
+					fName := filepath.Base(fPath)
 					ii.logger.Warn("[agg] InvertedIndex.openDirtyFiles", "err", err, "f", fName)
 					// don't interrupt on error. other files may be good
 				}
 				if ok {
-					_, fName := filepath.Split(fPath)
+					fName := filepath.Base(fPath)
 					ii.FileVersion.AccessorEFI.MustSupport(fileVer, fName)
 					if item.index, err = recsplit.OpenIndex(fPath); err != nil {
 						ii.logger.Warn("[agg] InvertedIndex.openDirtyFiles", "err", err, "f", fName)

--- a/db/state/dirty_files.go
+++ b/db/state/dirty_files.go
@@ -351,13 +351,10 @@ func (d *Domain) openDirtyFiles(dirEntries []string) (err error) {
 					continue
 				}
 
-				if fileVer.Less(d.FileVersion.DataKV.MinSupported) {
-					_, fName := filepath.Split(fPath)
-					versionTooLowPanic(fName, d.FileVersion.DataKV)
-				}
+				_, fName := filepath.Split(fPath)
+				d.FileVersion.DataKV.MustSupport(fileVer, fName)
 
 				if item.decompressor, err = seg.NewDecompressor(fPath); err != nil {
-					_, fName := filepath.Split(fPath)
 					if errors.Is(err, &seg.ErrCompressedFileCorrupted{}) {
 						d.logger.Debug("[agg] Domain.openDirtyFiles", "err", err, "f", fName)
 					} else {
@@ -379,12 +376,9 @@ func (d *Domain) openDirtyFiles(dirEntries []string) (err error) {
 					d.logger.Warn("[agg] Domain.openDirtyFiles", "err", err, "f", fName)
 				}
 				if ok {
-					if fileVer.Less(d.FileVersion.AccessorKVI.MinSupported) {
-						_, fName := filepath.Split(fPath)
-						versionTooLowPanic(fName, d.FileVersion.AccessorKVI)
-					}
+					_, fName := filepath.Split(fPath)
+					d.FileVersion.AccessorKVI.MustSupport(fileVer, fName)
 					if item.index, err = recsplit.OpenIndex(fPath); err != nil {
-						_, fName := filepath.Split(fPath)
 						d.logger.Warn("[agg] Domain.openDirtyFiles", "err", err, "f", fName)
 						// don't interrupt on error. other files may be good
 					}
@@ -398,12 +392,9 @@ func (d *Domain) openDirtyFiles(dirEntries []string) (err error) {
 					d.logger.Warn("[agg] Domain.openDirtyFiles", "err", err, "f", fName)
 				}
 				if ok {
-					if fileVer.Less(d.FileVersion.AccessorBT.MinSupported) {
-						_, fName := filepath.Split(fPath)
-						versionTooLowPanic(fName, d.FileVersion.AccessorBT)
-					}
+					_, fName := filepath.Split(fPath)
+					d.FileVersion.AccessorBT.MustSupport(fileVer, fName)
 					if item.bindex, err = btindex.OpenBtreeIndexWithDecompressor(fPath, btindex.DefaultBtreeM, d.dataReader(item.decompressor)); err != nil {
-						_, fName := filepath.Split(fPath)
 						d.logger.Warn("[agg] Domain.openDirtyFiles", "err", err, "f", fName)
 						// don't interrupt on error. other files may be good
 					}
@@ -417,12 +408,9 @@ func (d *Domain) openDirtyFiles(dirEntries []string) (err error) {
 					d.logger.Warn("[agg] Domain.openDirtyFiles", "err", err, "f", fName)
 				}
 				if ok {
-					if fileVer.Less(d.FileVersion.AccessorKVEI.MinSupported) {
-						_, fName := filepath.Split(fPath)
-						versionTooLowPanic(fName, d.FileVersion.AccessorKVEI)
-					}
+					_, fName := filepath.Split(fPath)
+					d.FileVersion.AccessorKVEI.MustSupport(fileVer, fName)
 					if item.existence, err = existence.OpenFilter(fPath, false); err != nil {
-						_, fName := filepath.Split(fPath)
 						d.logger.Warn("[agg] Domain.openDirtyFiles", "err", err, "f", fName)
 						// don't interrupt on error. other files may be good
 					}
@@ -465,13 +453,10 @@ func (h *History) openDirtyFiles(dataEntries, accessorEntries []string) error {
 					invalidFilesMu.Unlock()
 					continue
 				}
-				if fileVer.Less(h.FileVersion.DataV.MinSupported) {
-					_, fName := filepath.Split(fPath)
-					versionTooLowPanic(fName, h.FileVersion.DataV)
-				}
+				_, fName := filepath.Split(fPath)
+				h.FileVersion.DataV.MustSupport(fileVer, fName)
 
 				if item.decompressor, err = seg.NewDecompressor(fPath); err != nil {
-					_, fName := filepath.Split(fPath)
 					if errors.Is(err, &seg.ErrCompressedFileCorrupted{}) {
 						h.logger.Debug("[agg] History.openDirtyFiles", "err", err, "f", fName)
 						// TODO we do not restore those files so we could just remove them along with indices. Same for domains/indices.
@@ -506,12 +491,9 @@ func (h *History) openDirtyFiles(dataEntries, accessorEntries []string) error {
 					h.logger.Warn("[agg] History.openDirtyFiles", "err", err, "f", fName)
 				}
 				if ok {
-					if fileVer.Less(h.FileVersion.AccessorVI.MinSupported) {
-						_, fName := filepath.Split(fPath)
-						versionTooLowPanic(fName, h.FileVersion.AccessorVI)
-					}
+					_, fName := filepath.Split(fPath)
+					h.FileVersion.AccessorVI.MustSupport(fileVer, fName)
 					if item.index, err = recsplit.OpenIndex(fPath); err != nil {
-						_, fName := filepath.Split(fPath)
 						h.logger.Warn("[agg] History.openDirtyFiles", "err", err, "f", fName)
 						// don't interrupt on error. other files may be good
 					}
@@ -555,13 +537,10 @@ func (ii *InvertedIndex) openDirtyFiles(dataEntries, accessorEntries []string) e
 					continue
 				}
 
-				if fileVer.Less(ii.FileVersion.DataEF.MinSupported) {
-					_, fName := filepath.Split(fPath)
-					versionTooLowPanic(fName, ii.FileVersion.DataEF)
-				}
+				_, fName := filepath.Split(fPath)
+				ii.FileVersion.DataEF.MustSupport(fileVer, fName)
 
 				if item.decompressor, err = seg.NewDecompressor(fPath); err != nil {
-					_, fName := filepath.Split(fPath)
 					if errors.Is(err, &seg.ErrCompressedFileCorrupted{}) {
 						ii.logger.Debug("[agg] InvertedIndex.openDirtyFiles", "err", err, "f", fName)
 					} else {
@@ -584,12 +563,9 @@ func (ii *InvertedIndex) openDirtyFiles(dataEntries, accessorEntries []string) e
 					// don't interrupt on error. other files may be good
 				}
 				if ok {
-					if fileVer.Less(ii.FileVersion.AccessorEFI.MinSupported) {
-						_, fName := filepath.Split(fPath)
-						versionTooLowPanic(fName, ii.FileVersion.AccessorEFI)
-					}
+					_, fName := filepath.Split(fPath)
+					ii.FileVersion.AccessorEFI.MustSupport(fileVer, fName)
 					if item.index, err = recsplit.OpenIndex(fPath); err != nil {
-						_, fName := filepath.Split(fPath)
 						ii.logger.Warn("[agg] InvertedIndex.openDirtyFiles", "err", err, "f", fName)
 						// don't interrupt on error. other files may be good
 					}

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -2013,23 +2013,6 @@ func (dt *DomainRoTx) Files() (res VisibleFiles) {
 }
 func (dt *DomainRoTx) Name() kv.Domain { return dt.name }
 
-func versionTooLowPanic(filename string, version version.Versions) {
-	panic(fmt.Sprintf(
-		"FileVersion is too low, try to run snapshot reset: `erigon --datadir $DATADIR --chain $CHAIN snapshots reset`. file=%s, min_supported=%s, current=%s",
-		filename,
-		version.MinSupported,
-		version.Current,
-	))
-}
-
-func versionTooHighPanic(filename string, version version.Versions) {
-	panic(fmt.Sprintf(
-		"FileVersion is too high (binary is older than snapshot files), please upgrade erigon. file=%s, current=%s",
-		filename,
-		version.Current,
-	))
-}
-
 // [startTxNum, endTxNum)
 func (dt *DomainRoTx) TraceKey(ctx context.Context, key []byte, startTxNum, endTxNum uint64, roTx kv.Tx) (stream.U64V, error) {
 	// need to do this first as TraceKey doesn't work if internal seg readers are seeked into different locations

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -2022,6 +2022,14 @@ func versionTooLowPanic(filename string, version version.Versions) {
 	))
 }
 
+func versionTooHighPanic(filename string, version version.Versions) {
+	panic(fmt.Sprintf(
+		"FileVersion is too high (binary is older than snapshot files), please upgrade erigon. file=%s, current=%s",
+		filename,
+		version.Current,
+	))
+}
+
 // [startTxNum, endTxNum)
 func (dt *DomainRoTx) TraceKey(ctx context.Context, key []byte, startTxNum, endTxNum uint64, roTx kv.Tx) (stream.U64V, error) {
 	// need to do this first as TraceKey doesn't work if internal seg readers are seeked into different locations

--- a/db/version/file_version.go
+++ b/db/version/file_version.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/erigontech/erigon/common/log/v3"
 )
 
 /*

--- a/db/version/file_version.go
+++ b/db/version/file_version.go
@@ -204,7 +204,7 @@ func (v Versions) MustSupport(ver Version, filename string) {
 		)
 	} else {
 		msg = fmt.Sprintf(
-			"Snapshot file is newer than this Erigon build supports: file=%s, highest_supported=<%s. To fix, either upgrade Erigon to a newer release, or reset snapshots: `erigon snapshots reset --datadir $DATADIR --chain $CHAIN`",
+			"Snapshot file is newer than this Erigon build supports: file=%s, highest_supported=<%s. To fix, either upgrade Erigon to a newer release, or align snapshots by command: `erigon snapshots reset --datadir $DATADIR --chain $CHAIN`",
 			filename, ver,
 		)
 	}

--- a/db/version/file_version.go
+++ b/db/version/file_version.go
@@ -196,21 +196,12 @@ func (v Versions) MustSupport(ver Version, filename string) {
 	var msg string
 	if ver.Less(v.MinSupported) {
 		msg = fmt.Sprintf(
-			"Snapshot file is too old for this Erigon build.\n"+
-				"  file:             %s\n"+
-				"  file version:     %s\n"+
-				"  minimum required: %s\n"+
-				"To fix, reset snapshots: `erigon snapshots reset --datadir $DATADIR --chain $CHAIN`",
+			"Snapshot file is too old for this Erigon build: file=%s, file_version=%s, minimum_required=%s. To fix, reset snapshots: `erigon snapshots reset --datadir $DATADIR --chain $CHAIN`",
 			filename, ver, v.MinSupported,
 		)
 	} else {
 		msg = fmt.Sprintf(
-			"Snapshot file is newer than this Erigon build supports.\n"+
-				"  file:              %s\n"+
-				"  file version:      %s\n"+
-				"  highest supported: < %s\n"+
-				"To fix, either upgrade Erigon to a newer release,\n"+
-				"or reset snapshots: `erigon snapshots reset --datadir $DATADIR --chain $CHAIN`",
+			"Snapshot file is newer than this Erigon build supports: file=%s, file_version=%s, highest_supported=<%s. To fix, either upgrade Erigon to a newer release, or reset snapshots: `erigon snapshots reset --datadir $DATADIR --chain $CHAIN`",
 			filename, ver, ver,
 		)
 	}

--- a/db/version/file_version.go
+++ b/db/version/file_version.go
@@ -185,6 +185,24 @@ func (v Versions) Supports(ver Version) bool {
 	return ver.GreaterOrEqual(v.MinSupported) && ver.LessOrEqual(v.Current)
 }
 
+// MustSupport panics if ver is outside [MinSupported, Current].
+// Too-low means snapshots are stale; too-high means the binary is older than the files.
+func (v Versions) MustSupport(ver Version, filename string) {
+	if v.Supports(ver) {
+		return
+	}
+	if ver.Less(v.MinSupported) {
+		panic(fmt.Sprintf(
+			"FileVersion is too low, try to run snapshot reset: `erigon --datadir $DATADIR --chain $CHAIN snapshots reset`. file=%s, min_supported=%s, current=%s",
+			filename, v.MinSupported, v.Current,
+		))
+	}
+	panic(fmt.Sprintf(
+		"FileVersion is too high (binary is older than snapshot files), please upgrade erigon. file=%s, file_version=%s, current=%s",
+		filename, ver, v.Current,
+	))
+}
+
 // FindFilesWithVersionsByPattern return an filepath by pattern
 func FindFilesWithVersionsByPattern(pattern string) (string, Version, bool, error) {
 	matches, err := filepath.Glob(pattern)
@@ -310,13 +328,4 @@ func (v *Version) UnmarshalYAML(node *yaml.Node) error {
 	}
 	*v = ver
 	return nil
-}
-
-func VersionTooLowPanic(filename string, version Versions) {
-	panic(fmt.Sprintf(
-		"FileVersion is too low, try to run snapshot reset: `erigon --datadir $DATADIR --chain $CHAIN snapshots reset`. file=%s, min_supported=%s, current=%s",
-		filename,
-		version.MinSupported,
-		version.Current,
-	))
 }

--- a/db/version/file_version.go
+++ b/db/version/file_version.go
@@ -193,25 +193,29 @@ func (v Versions) MustSupport(ver Version, filename string) {
 	if v.Supports(ver) {
 		return
 	}
+	var msg string
 	if ver.Less(v.MinSupported) {
-		panic(fmt.Sprintf(
+		msg = fmt.Sprintf(
 			"Snapshot file is too old for this Erigon build.\n"+
 				"  file:             %s\n"+
 				"  file version:     %s\n"+
 				"  minimum required: %s\n"+
 				"To fix, reset snapshots: `erigon snapshots reset --datadir $DATADIR --chain $CHAIN`",
 			filename, ver, v.MinSupported,
-		))
+		)
+	} else {
+		msg = fmt.Sprintf(
+			"Snapshot file is newer than this Erigon build supports.\n"+
+				"  file:              %s\n"+
+				"  file version:      %s\n"+
+				"  highest supported: < %s\n"+
+				"To fix, either upgrade Erigon to a newer release,\n"+
+				"or reset snapshots: `erigon snapshots reset --datadir $DATADIR --chain $CHAIN`",
+			filename, ver, ver,
+		)
 	}
-	panic(fmt.Sprintf(
-		"Snapshot file is newer than this Erigon build supports.\n"+
-			"  file:              %s\n"+
-			"  file version:      %s\n"+
-			"  highest supported: < %s\n"+
-			"To fix, either upgrade Erigon to a newer release,\n"+
-			"or reset snapshots: `erigon snapshots reset --datadir $DATADIR --chain $CHAIN`",
-		filename, ver, ver,
-	))
+	log.Error(msg)
+	panic(msg)
 }
 
 // FindFilesWithVersionsByPattern return an filepath by pattern

--- a/db/version/file_version.go
+++ b/db/version/file_version.go
@@ -191,7 +191,6 @@ func (v Versions) Supports(ver Version) bool {
 var mustSupportLogOnce sync.Once
 
 // MustSupport panics if ver is outside [MinSupported, Current].
-// Too-low means snapshots are stale; too-high means the binary is older than the files.
 func (v Versions) MustSupport(ver Version, filename string) {
 	if v.Supports(ver) {
 		return

--- a/db/version/file_version.go
+++ b/db/version/file_version.go
@@ -188,6 +188,8 @@ func (v Versions) Supports(ver Version) bool {
 	return ver.GreaterOrEqual(v.MinSupported) && ver.LessOrEqual(v.Current)
 }
 
+var mustSupportLogOnce sync.Once
+
 // MustSupport panics if ver is outside [MinSupported, Current].
 // Too-low means snapshots are stale; too-high means the binary is older than the files.
 func (v Versions) MustSupport(ver Version, filename string) {
@@ -197,16 +199,16 @@ func (v Versions) MustSupport(ver Version, filename string) {
 	var msg string
 	if ver.Less(v.MinSupported) {
 		msg = fmt.Sprintf(
-			"Snapshot file is too old for this Erigon build: file=%s, file_version=%s, minimum_required=%s. To fix, reset snapshots: `erigon snapshots reset --datadir $DATADIR --chain $CHAIN`",
-			filename, ver, v.MinSupported,
+			"Snapshot file is too old for this Erigon build: file=%s, minimum_required=%s. To fix, reset snapshots: `erigon snapshots reset --datadir $DATADIR --chain $CHAIN`",
+			filename, v.MinSupported,
 		)
 	} else {
 		msg = fmt.Sprintf(
-			"Snapshot file is newer than this Erigon build supports: file=%s, file_version=%s, highest_supported=<%s. To fix, either upgrade Erigon to a newer release, or reset snapshots: `erigon snapshots reset --datadir $DATADIR --chain $CHAIN`",
-			filename, ver, ver,
+			"Snapshot file is newer than this Erigon build supports: file=%s, highest_supported=<%s. To fix, either upgrade Erigon to a newer release, or reset snapshots: `erigon snapshots reset --datadir $DATADIR --chain $CHAIN`",
+			filename, ver,
 		)
 	}
-	log.Error(msg)
+	mustSupportLogOnce.Do(func() { log.Error(msg) })
 	panic(msg)
 }
 

--- a/db/version/file_version.go
+++ b/db/version/file_version.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	"gopkg.in/yaml.v3"
 

--- a/db/version/file_version.go
+++ b/db/version/file_version.go
@@ -193,13 +193,22 @@ func (v Versions) MustSupport(ver Version, filename string) {
 	}
 	if ver.Less(v.MinSupported) {
 		panic(fmt.Sprintf(
-			"FileVersion is too low, try to run snapshot reset: `erigon --datadir $DATADIR --chain $CHAIN snapshots reset`. file=%s, min_supported=%s, current=%s",
-			filename, v.MinSupported, v.Current,
+			"Snapshot file is too old for this Erigon build.\n"+
+				"  file:             %s\n"+
+				"  file version:     %s\n"+
+				"  minimum required: %s\n"+
+				"To fix, reset snapshots: `erigon snapshots reset --datadir $DATADIR --chain $CHAIN`",
+			filename, ver, v.MinSupported,
 		))
 	}
 	panic(fmt.Sprintf(
-		"FileVersion is too high (binary is older than snapshot files), please upgrade erigon. file=%s, file_version=%s, current=%s",
-		filename, ver, v.Current,
+		"Snapshot file is newer than this Erigon build supports.\n"+
+			"  file:              %s\n"+
+			"  file version:      %s\n"+
+			"  highest supported: < %s\n"+
+			"To fix, either upgrade Erigon to a newer release,\n"+
+			"or reset snapshots: `erigon snapshots reset --datadir $DATADIR --chain $CHAIN`",
+		filename, ver, ver,
 	))
 }
 

--- a/db/version/file_version_test.go
+++ b/db/version/file_version_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -412,6 +413,63 @@ func TestMatchVersionedFile_DifferentSegAndIdxNames(t *testing.T) {
 	if ok {
 		t.Fatal("expected ok == false for non-existent file type")
 	}
+}
+
+func TestMustSupport(t *testing.T) {
+	supported := Versions{Current: V1_2, MinSupported: V1_1}
+
+	t.Run("in-range does not panic", func(t *testing.T) {
+		for _, ver := range []Version{V1_1, V1_2} {
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						t.Errorf("unexpected panic for ver=%s: %v", ver, r)
+					}
+				}()
+				supported.MustSupport(ver, "test.kv")
+			}()
+		}
+	})
+
+	t.Run("too low panics with reset instructions", func(t *testing.T) {
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatal("expected panic for too-low version")
+			}
+			msg, ok := r.(string)
+			if !ok {
+				t.Fatalf("expected string panic, got %T", r)
+			}
+			if !strings.Contains(msg, "too old") || !strings.Contains(msg, "snapshots reset") {
+				t.Errorf("panic message missing remediation hint: %q", msg)
+			}
+			if !strings.Contains(msg, "test.kv") {
+				t.Errorf("panic message missing filename: %q", msg)
+			}
+		}()
+		supported.MustSupport(V1_0, "test.kv")
+	})
+
+	t.Run("too high panics with upgrade instructions", func(t *testing.T) {
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatal("expected panic for too-high version")
+			}
+			msg, ok := r.(string)
+			if !ok {
+				t.Fatalf("expected string panic, got %T", r)
+			}
+			if !strings.Contains(msg, "newer than") || !strings.Contains(msg, "upgrade Erigon") || !strings.Contains(msg, "snapshots reset") {
+				t.Errorf("panic message missing remediation hint: %q", msg)
+			}
+			if !strings.Contains(msg, "test.kv") {
+				t.Errorf("panic message missing filename: %q", msg)
+			}
+		}()
+		supported.MustSupport(V2_0, "test.kv")
+	})
 }
 
 func BenchmarkMatchVersionedFile(b *testing.B) {


### PR DESCRIPTION
## Problem

Snapshot file-version checks only rejected files that were **too old**. Files that were **too new** passed the check and got read with the wrong parser.

Example: binary supports up to `v2.1`, directory contains `v3.0-storage.0-32.efi` — opened silently, no error.

## Solution

Check both bounds in `Versions.MustSupport` and fail fast:

- **Too old** → suggests `erigon snapshots reset`.
- **Too new** → suggests upgrading Erigon, or `erigon snapshots reset` to align.

Logged once via `sync.Once` (parallel goroutines don't duplicate the banner), then panics. Callsites in `dirty_files.go` and `block_types.go` migrated; `VersionTooLowPanic` and its local twin deleted. Unit tests cover in-range, too-low, and too-high.