### PR TITLE
txpool: add GetBlobs to GrpcDisabled stub

### DIFF
--- a/cl/phase1/execution_client/execution_client_direct.go
+++ b/cl/phase1/execution_client/execution_client_direct.go
@@ -36,6 +36,7 @@ import (
 	"github.com/erigontech/erigon/node/gointerfaces"
 	"github.com/erigontech/erigon/node/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon/node/gointerfaces/typesproto"
+	"github.com/erigontech/erigon/txnprovider/txpool"
 )
 
 const reorgTooDeepDepth = 3
@@ -219,6 +220,9 @@ func (cc *ExecutionClientDirect) GetBlobs(ctx context.Context, versionedHashes [
 	}
 	resp, err := cc.txpool.GetBlobs(ctx, req)
 	if err != nil {
+		if errors.Is(err, txpool.ErrPoolDisabled) {
+			return nil, nil, nil
+		}
 		return nil, nil, fmt.Errorf("txpool GetBlobs: %w", err)
 	}
 	blobsWithProof := resp.BlobsWithProofs

--- a/cl/phase1/execution_client/execution_client_engine.go
+++ b/cl/phase1/execution_client/execution_client_engine.go
@@ -40,6 +40,7 @@ import (
 	"github.com/erigontech/erigon/node/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon/node/gointerfaces/typesproto"
 	"github.com/erigontech/erigon/rpc"
+	"github.com/erigontech/erigon/txnprovider/txpool"
 )
 
 var ErrNotSupported = errors.New("operation not supported in engine API mode")
@@ -525,6 +526,9 @@ func (cc *ExecutionClientEngine) GetBlobs(ctx context.Context, versionedHashes [
 		}
 		resp, err := cc.txpool.GetBlobs(ctx, req)
 		if err != nil {
+			if errors.Is(err, txpool.ErrPoolDisabled) {
+				return nil, nil, nil
+			}
 			return nil, nil, fmt.Errorf("txpool GetBlobs: %w", err)
 		}
 		blobsWithProof := resp.BlobsWithProofs

--- a/txnprovider/txpool/txpool_grpc_server.go
+++ b/txnprovider/txpool/txpool_grpc_server.go
@@ -96,6 +96,9 @@ func (*GrpcDisabled) Status(ctx context.Context, request *txpoolproto.StatusRequ
 func (*GrpcDisabled) Nonce(ctx context.Context, request *txpoolproto.NonceRequest) (*txpoolproto.NonceReply, error) {
 	return nil, ErrPoolDisabled
 }
+func (*GrpcDisabled) GetBlobs(ctx context.Context, request *txpoolproto.GetBlobsRequest) (*txpoolproto.GetBlobsReply, error) {
+	return nil, ErrPoolDisabled
+}
 
 type GrpcServer struct {
 	txpoolproto.UnimplementedTxpoolServer


### PR DESCRIPTION
## Summary
- `GrpcDisabled` (used when `--txpool.disable` is set) was missing a `GetBlobs` method, causing the embedded `UnimplementedTxpoolServer` to return a gRPC "Unimplemented" error on every block with blob commitments
- Added `GetBlobs` to `GrpcDisabled` returning `ErrPoolDisabled` (consistent with all other 9 methods on the stub)
- Handle `ErrPoolDisabled` gracefully in `ExecutionClientDirect` and `ExecutionClientEngine` so it silently falls through to the PeerDAS/network fallback path without WARN log spam

Fixes #20709

## Test plan
- [ ] `make lint` passes (verified locally, ran twice)
- [ ] `make erigon` builds successfully (verified locally)
- [ ] Run with `--txpool.disable` on mainnet and confirm no `OnBlock: GetBlobs failed` WARN logs
- [ ] Verify blocks with blob commitments still sync correctly via PeerDAS fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)