### PR TITLE
[r3.4] fix fork choice block validation and error propagation

### DIFF
--- a/cl/phase1/forkchoice/on_block.go
+++ b/cl/phase1/forkchoice/on_block.go
@@ -46,6 +46,7 @@ const foreseenProposers = 16
 var (
 	ErrEIP4844DataNotAvailable       = errors.New("EIP-4844 blob data is not available")
 	ErrEIP7594ColumnDataNotAvailable = errors.New("EIP-7594 column data is not available")
+	ErrNewPayloadNoStatus            = errors.New("newPayload returned no status")
 )
 
 func verifyKzgCommitmentsAgainstTransactions(cfg *clparams.BeaconChainConfig, block *cltypes.BeaconBlock) error {
@@ -97,9 +98,14 @@ func (f *ForkChoiceStore) OnBlock(ctx context.Context, block *cltypes.SignedBeac
 	}
 
 	// Check that block is later than the finalized epoch slot (optimization to reduce calls to get_ancestor)
-	finalizedSlot := f.computeStartSlotAtEpoch(f.finalizedCheckpoint.Load().(solid.Checkpoint).Epoch)
+	finalizedCheckpoint := f.finalizedCheckpoint.Load().(solid.Checkpoint)
+	finalizedSlot := f.computeStartSlotAtEpoch(finalizedCheckpoint.Epoch)
 	if block.Block.Slot <= finalizedSlot {
 		return nil
+	}
+	// Check block is a descendant of the finalized block at the checkpoint finalized slot
+	if ancestorRoot := f.Ancestor(block.Block.ParentRoot, finalizedSlot); ancestorRoot != finalizedCheckpoint.Root {
+		return fmt.Errorf("block is not a descendant of the finalized checkpoint")
 	}
 	// Now we find the versioned hashes
 	var versionedHashes []common.Hash
@@ -169,6 +175,9 @@ func (f *ForkChoiceStore) OnBlock(ctx context.Context, block *cltypes.SignedBeac
 		monitor.ObserveNewPayloadTime(timeStartExec)
 		log.Debug("[OnBlock] NewPayload", "status", payloadStatus, "blockSlot", block.Block.Slot)
 		switch payloadStatus {
+		case execution_client.PayloadStatusNone:
+			log.Debug("OnBlock: EL failed to process block", "block", common.Hash(blockRoot), "err", err)
+			return fmt.Errorf("%w: %v", ErrNewPayloadNoStatus, err)
 		case execution_client.PayloadStatusNotValidated:
 			log.Debug("OnBlock: block is not validated yet", "block", common.Hash(blockRoot))
 			// optimistic block candidate
@@ -272,7 +281,7 @@ func (f *ForkChoiceStore) OnBlock(ctx context.Context, block *cltypes.SignedBeac
 	var (
 		previousJustifiedCheckpoint = lastProcessedState.PreviousJustifiedCheckpoint()
 		currentJustifiedCheckpoint  = lastProcessedState.CurrentJustifiedCheckpoint()
-		finalizedCheckpoint         = lastProcessedState.FinalizedCheckpoint()
+		stateFinalized              = lastProcessedState.FinalizedCheckpoint()
 		justificationBits           = lastProcessedState.JustificationBits().Copy()
 	)
 	f.operationsPool.NotifyBlock(block.Block)
@@ -285,7 +294,7 @@ func (f *ForkChoiceStore) OnBlock(ctx context.Context, block *cltypes.SignedBeac
 	// Set the changed value pre-simulation
 	lastProcessedState.SetPreviousJustifiedCheckpoint(previousJustifiedCheckpoint)
 	lastProcessedState.SetCurrentJustifiedCheckpoint(currentJustifiedCheckpoint)
-	lastProcessedState.SetFinalizedCheckpoint(finalizedCheckpoint)
+	lastProcessedState.SetFinalizedCheckpoint(stateFinalized)
 	lastProcessedState.SetJustificationBits(justificationBits)
 
 	// If the block is from a prior epoch, apply the realized values

--- a/cl/phase1/stages/chain_tip_sync.go
+++ b/cl/phase1/stages/chain_tip_sync.go
@@ -173,6 +173,7 @@ MainLoop:
 				// Process the block - DA can be downloaded later if we are behind (see blobHistoryDownloader)
 				if err := processBlock(ctx, cfg, cfg.indiciesDB, block, true, true, false); err != nil {
 					log.Debug("bad blocks segment received", "err", err, "blockSlot", block.Block.Slot)
+					seenBlockRoots[blockRoot] = struct{}{}
 					continue
 				}
 


### PR DESCRIPTION
## Summary
Cherry-pick of #19923 to `release/3.4`.

- Add finalized checkpoint ancestry check in `OnBlock` to reject blocks not descending from the finalized checkpoint
- Handle `PayloadStatusNone` from EL in fork choice, returning an error instead of silently ignoring
- Mark bad blocks as seen in chain tip sync to prevent repeated reprocessing

## Context
Nodes on `release/3.4` are reporting continuous `[GossipManager] reject message` warnings with `"attester is not a member of the committee"` errors across multiple committees and validators. Root cause analysis indicates the node's beacon state has diverged from the canonical chain — without the finalized checkpoint ancestry check, the node may have accepted blocks from a non-canonical fork, causing RANDAO mix divergence and thus incorrect committee compositions.

## Test plan
- [ ] CI passes (`make lint && make erigon integration`)
- [ ] Verify on a node experiencing the issue: restart with this fix and confirm attestation rejections stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)