### PR TITLE
engineapi: validate payloadAttributes before SYNCING short-circuit

### DIFF
--- a/execution/engineapi/engine_server.go
+++ b/execution/engineapi/engine_server.go
@@ -195,6 +195,30 @@ func (s *EngineServer) isWithdrawalsPresenceValid(time uint64, withdrawals types
 	return withdrawals != nil
 }
 
+func (s *EngineServer) validatePayloadAttributes(version clparams.StateVersion, payloadAttributes *engine_types.PayloadAttributes) error {
+	if version < clparams.DenebVersion && payloadAttributes.ParentBeaconBlockRoot != nil {
+		return &engine_helpers.InvalidPayloadAttributesErr // Unexpected Beacon Root
+	}
+	if version >= clparams.DenebVersion && payloadAttributes.ParentBeaconBlockRoot == nil {
+		return &engine_helpers.InvalidPayloadAttributesErr // Beacon Root missing
+	}
+
+	timestamp := uint64(payloadAttributes.Timestamp)
+	if !s.config.IsCancun(timestamp) && version >= clparams.DenebVersion { // V3 before cancun
+		return &rpc.UnsupportedForkError{Message: "Unsupported fork"}
+	}
+	if s.config.IsCancun(timestamp) && version < clparams.DenebVersion { // Not V3 after cancun
+		return &rpc.UnsupportedForkError{Message: "Unsupported fork"}
+	}
+	if version >= clparams.CapellaVersion && !s.isWithdrawalsPresenceValid(timestamp, payloadAttributes.Withdrawals) {
+		return &engine_helpers.InvalidPayloadAttributesErr
+	}
+	if version >= clparams.GloasVersion && payloadAttributes.SlotNumber == nil {
+		return &engine_helpers.InvalidPayloadAttributesErr // SlotNumber required for Glamsterdam (EIP-7843)
+	}
+	return nil
+}
+
 func (s *EngineServer) checkRequestsPresence(version clparams.StateVersion, executionRequests []hexutil.Bytes) error {
 	if version < clparams.ElectraVersion {
 		if executionRequests != nil {
@@ -701,31 +725,23 @@ func (s *EngineServer) forkchoiceUpdated(ctx context.Context, forkchoiceState *e
 		s.logger.Debug("[ForkChoiceUpdated] got quick payload status", "status", status.Status)
 	}
 
+	// Per the engine API spec, payloadAttributes must be validated against the
+	// fork schedule regardless of the fork-choice sync state. Doing this before
+	// the SYNCING short-circuit below lets the CL detect misconfigured attributes
+	// (e.g. fcuV2 with nil withdrawals at a Shanghai timestamp) even when the
+	// head is still syncing.
+	if payloadAttributes != nil {
+		if err := s.validatePayloadAttributes(version, payloadAttributes); err != nil {
+			return nil, err
+		}
+	}
+
 	// No need for payload building
 	if payloadAttributes == nil || status.Status != engine_types.ValidStatus {
 		return &engine_types.ForkChoiceUpdatedResponse{PayloadStatus: status}, nil
 	}
 
-	if version < clparams.DenebVersion && payloadAttributes.ParentBeaconBlockRoot != nil {
-		return nil, &engine_helpers.InvalidPayloadAttributesErr // Unexpected Beacon Root
-	}
-	if version >= clparams.DenebVersion && payloadAttributes.ParentBeaconBlockRoot == nil {
-		return nil, &engine_helpers.InvalidPayloadAttributesErr // Beacon Root missing
-	}
-
 	timestamp := uint64(payloadAttributes.Timestamp)
-	if !s.config.IsCancun(timestamp) && version >= clparams.DenebVersion { // V3 before cancun
-		return nil, &rpc.UnsupportedForkError{Message: "Unsupported fork"}
-	}
-	if s.config.IsCancun(timestamp) && version < clparams.DenebVersion { // Not V3 after cancun
-		return nil, &rpc.UnsupportedForkError{Message: "Unsupported fork"}
-	}
-	if version >= clparams.CapellaVersion && !s.isWithdrawalsPresenceValid(timestamp, payloadAttributes.Withdrawals) {
-		return nil, &engine_helpers.InvalidPayloadAttributesErr
-	}
-	if version >= clparams.GloasVersion && payloadAttributes.SlotNumber == nil {
-		return nil, &engine_helpers.InvalidPayloadAttributesErr // SlotNumber required for Glamsterdam (EIP-7843)
-	}
 
 	if !s.proposing {
 		return nil, errors.New("execution layer not running as a proposer. enable proposer by taking out the --proposer.disable flag on startup")

--- a/execution/engineapi/testing_api_test.go
+++ b/execution/engineapi/testing_api_test.go
@@ -35,9 +35,11 @@ import (
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/execution/builder"
 	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/engineapi/engine_block_downloader"
 	"github.com/erigontech/erigon/execution/engineapi/engine_types"
 	"github.com/erigontech/erigon/execution/execmodule"
 	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/node/ethconfig"
 	"github.com/erigontech/erigon/rpc"
 )
 
@@ -965,6 +967,51 @@ func TestForkchoiceUpdatedV2PayloadAttributesWithdrawalsValidation(t *testing.T)
 		require.Error(t, err)
 		require.Equal(t, -38003, err.(rpc.Error).ErrorCode())
 	})
+}
+
+// TestForkchoiceUpdatedV2ValidatesAttributesWhenSyncing pins the engine-api spec
+// requirement that payloadAttributes validation runs regardless of fork-choice
+// sync state. The hive `engine-withdrawals / Empty Withdrawals (Paris)` test
+// exercises exactly this: CLMocker sends fcuV2 with nil withdrawals at a
+// Shanghai timestamp while the EL reports SYNCING, and expects -38003.
+func TestForkchoiceUpdatedV2ValidatesAttributesWhenSyncing(t *testing.T) {
+	t.Parallel()
+
+	forkchoiceState := &engine_types.ForkChoiceState{
+		HeadHash:           common.Hash{0x1},
+		SafeBlockHash:      common.Hash{0x2},
+		FinalizedBlockHash: common.Hash{0x3},
+	}
+	stub := &stubExecutionModule{} // GetHeaderHashNumber returns nil -> HandleForkChoice -> SYNCING
+	srv := NewEngineServer(
+		log.New(),
+		preCancunChainConfig(),
+		stub,
+		// minimal downloader just provides the badHeaders LRU used by
+		// getQuickPayloadStatusIfPossible; other deps are not touched because
+		// srv.test = true guards StartDownloading below.
+		engine_block_downloader.NewEngineBlockDownloader(
+			context.Background(), log.New(), stub, nil, nil, preCancunChainConfig(), ethconfig.Sync{}, nil,
+		),
+		false,
+		false,
+		false,
+		true,
+		nil,
+		0,
+		0,
+	)
+	srv.test = true // avoid invoking downloader.StartDownloading on the SYNCING path
+
+	resp, err := srv.forkchoiceUpdated(context.Background(), forkchoiceState, &engine_types.PayloadAttributes{
+		Timestamp:             hexutil.Uint64(1001),
+		PrevRandao:            common.Hash{0xaa},
+		SuggestedFeeRecipient: common.HexToAddress("0x1111111111111111111111111111111111111111"),
+		Withdrawals:           nil, // invalid: Shanghai timestamp requires non-nil withdrawals
+	}, clparams.CapellaVersion)
+	require.Nil(t, resp)
+	require.Error(t, err)
+	require.Equal(t, -38003, err.(rpc.Error).ErrorCode())
 }
 
 func ptrUint64(v uint64) *uint64 {


### PR DESCRIPTION
## Summary

- Move payloadAttributes validation (withdrawals presence, beacon-root, fork-version) to run before the SYNCING short-circuit in `forkchoiceUpdated`, so a CL that sends invalid attributes gets `-38003`/`-38005` even when the EL is still syncing.
- Extract the checks into a new `validatePayloadAttributes` helper (no behavior change for VALID-status FCUs).
- Add a regression test covering the SYNCING path.

## Why

The engine API spec requires `payloadAttributes` to be validated against the fork schedule independently of the fork-choice sync state. The previous code returned `{status: SYNCING}` up front whenever `HandleForkChoice` couldn't produce `VALID` (e.g. unknown head, busy executor), so the CL never saw the spec-mandated error.

Noticed while looking at [hive run `1776846836-81a466ccd994e017e6ff298c773d9ab6`](https://hive.ethpandaops.io/#/test/generic/1776846836-81a466ccd994e017e6ff298c773d9ab6) — the single failure in `engine-withdrawals` was `Empty Withdrawals (Paris)`, where CLMocker sent fcuV2 with `withdrawals: null` at a Shanghai timestamp:

```
>> engine_forkchoiceUpdatedV2({ timestamp: 0x1235, withdrawals: null, parentBeaconBlockRoot: null })
<< { status: SYNCING, validationError: null, latestValidHash: null }

DEBUG (Empty Withdrawals): Sent shanghai fcu using PayloadAttributesV1, error is expected
FAIL  (Empty Withdrawals): Expected error on EngineForkchoiceUpdatedV2
```

Geth validates attributes at the top of its fcuV2 handler (before the shared forkchoice update path) for the same reason. This PR brings erigon in line.

## Test plan

- [x] `go test ./execution/engineapi/... -count=1` (new + existing tests pass)
- [x] `make lint` (clean)
- [x] `make erigon` (builds)
- [ ] Rerun hive `engine-withdrawals` to confirm `Empty Withdrawals (Paris)` now passes