### PR TITLE
docs: document --erigondb.domain.steps-in-frozen-file flag

### DIFF
--- a/docs/gitbook/src/fundamentals/configuring-erigon/README.md
+++ b/docs/gitbook/src/fundamentals/configuring-erigon/README.md
@@ -71,6 +71,9 @@ These flags control database performance and memory usage.
   * Default: `0MB`
 * `--sync.parallel-state-flushing`: Enables parallel state flushing.
   * Default: `true`
+* `--erigondb.domain.steps-in-frozen-file value`: Overrides the `steps_in_frozen_file` setting from `erigondb.toml` for the domain merge cap only (history and inverted-index merges are unaffected). Pass a positive integer to set an explicit cap, or `Inf` to leave the domain merge unbounded.
+  * Default: unset (uses the value from `erigondb.toml`)
+  * Use with care — an incorrect value may affect database structure.
 
 ### Pruning and Snapshots
 


### PR DESCRIPTION
## Summary

Documents the `--erigondb.domain.steps-in-frozen-file` flag introduced in #20705.

- Adds entry to the **Database and Caching** section of `configuring-erigon/README.md`
- Flag overrides `erigondb.toml` `steps_in_frozen_file` for the domain merge cap only
- Accepts a positive integer or `Inf` (unbounded); default is unset (uses `erigondb.toml`)
- History and inverted-index merges are unaffected

## Test plan
- [ ] Verify flag appears in `erigon --help` on `main`
- [ ] Verify `Inf` is accepted as value

🤖 Generated with [Claude Code](https://claude.com/claude-code)