### PR TITLE
docs: backport v3.4 documentation updates to main

### DIFF
--- a/docs/gitbook/src/fundamentals/caplin.md
+++ b/docs/gitbook/src/fundamentals/caplin.md
@@ -27,6 +27,12 @@ In addition, Caplin can backfill recent blobs for an op-node or other uses with 
 
 * `--caplin.blobs-immediate-backfill`: Backfills the last 18 days' worth of blobs to quickly populate historical blob data for operational needs or analytics.
 
+### PeerDAS Data Column Retention
+
+For nodes participating in PeerDAS (EIP-7594), Caplin retains data column sidecars for a configurable window:
+
+* `--caplin.columns-keep-slots` (default: `131072`, ~18 days): Number of slots to retain PeerDAS data column sidecars. The default matches `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS × SLOTS_PER_EPOCH`. Increase this value for DA oracle or rollup nodes that require a longer column history.
+
 Caplin can also be used for [block production](../staking/caplin.md), aka **staking**.
 
 ## Beacon API Configuration

--- a/docs/gitbook/src/fundamentals/configuring-erigon/README.md
+++ b/docs/gitbook/src/fundamentals/configuring-erigon/README.md
@@ -82,7 +82,7 @@ Flags for managing how old chain data is handled and stored.
   * Default: `0`
 * `--prune.distance.blocks value`: Keeps block history for the latest `N` blocks.
   * Default: `0`
-* `--prune.include-commitment-history, --prune.experimental.include-commitment-history, --experimental.commitment-history`: Enables blazing fast `eth_getProof` for executed blocks by storing commitment history.
+* `--prune.include-commitment-history, --prune.experimental.include-commitment-history, --experimental.commitment-history`: Enables blazing fast `eth_getProof` for executed blocks by storing commitment history. Requires +32 GB RAM. See [`eth_getProof`](../../interacting-with-erigon/eth.md#eth_getproof).
   * Default: `false`
 * `--snap.keepblocks`: Keeps ancient blocks in the database for debugging.
   * Default: `false`
@@ -139,9 +139,9 @@ These flags manage network connectivity, peer discovery, and traffic control.
 * `--nodiscover`: Disables peer discovery.
   * Default: `false`
 * `--discovery.v4`, `--discv4`: Enables the Node Discovery Protocol v4 (Discv4) for managed ENRs and topic discovery.
-  * Default: `false`
+  * Default: `false` (disabled by default since v3.4; discv5 is now the default discovery protocol)
 * `--discovery.v5`, `--discv5`, `--v5disc`: Enables the Node Discovery Protocol v5 (Discv5) for managed ENRs and topic discovery.
-  * Default: `true`
+  * Default: `true` (enabled by default since v3.4)
 * `--netrestrict value`: Restricts network communication to specific IP networks.
 * `--nodekey value`: The P2P node key file.
 * `--nodekeyhex value`: The P2P node key as a hexadecimal string.
@@ -208,8 +208,10 @@ Flags for configuring various RPC servers and their behavior.
   * Default: `50000000`
 * `--rpc.batch.limit value`: Sets the maximum number of requests in a batch.
   * Default: `100`
-* `--rpc.blockrange.limit value`: Sets a hardware cap on the number of blocks scanned per RPC request. Protects the rpcdaemon from resource exhaustion (CPU/Memory) and hangs caused by "heavy" queries. A value of `0` means unlimited.
-  * Default: `0`
+* `--rpc.blockrange.limit value`: Sets a cap on the number of blocks scanned per RPC request for `eth_getLogs` and similar range queries. Protects the node from resource exhaustion. A value of `0` means unlimited.
+  * Default: `1000` (changed from `0` in v3.4)
+* `--rpc.logs.maxresults value`: Sets the maximum number of log results returned per query.
+  * Default: `20000`
 * `--rpc.returndata.limit value`: Sets the maximum return data size for `eth_call`.
   * Default: `100000`
 * `--rpc.allow-unprotected-txs`: Allows unprotected transactions via RPC.

--- a/docs/gitbook/src/interacting-with-erigon/admin.md
+++ b/docs/gitbook/src/interacting-with-erigon/admin.md
@@ -137,3 +137,55 @@ curl -s --data '{"jsonrpc":"2.0","method":"admin_removePeer","params":["enode://
 | Boolean | True if the peer was successfully removed, false otherwise |
 
 ***
+
+## **admin\_addTrustedPeer**
+
+Adds a peer to the trusted peers list. Trusted peers are exempt from the maximum peer count limit and will always be connected, even when the node has reached its peer limit.
+
+**Parameters**
+
+| Parameter | Type   | Description                                                              |
+| --------- | ------ | ------------------------------------------------------------------------ |
+| enode     | STRING | The enode URL of the trusted peer to add (format: enode://pubkey@ip:port) |
+
+**Example**
+
+{% code overflow="wrap" %}
+```bash
+curl -s --data '{"jsonrpc":"2.0","method":"admin_addTrustedPeer","params":["enode://a979fb575495b8d6db44f750317d0f4622bf4c2aa3365d6af7c284339968eef29b69ad0dce72a4d8db5ebb4968de0e3bec910127f134779fbcb0cb6d3331163c@52.16.188.185:30303"],"id":"1"}' -H "Content-Type: application/json" -X POST http://localhost:8545
+```
+{% endcode %}
+
+**Returns**
+
+| Type    | Description                                                       |
+| ------- | ----------------------------------------------------------------- |
+| Boolean | True if the trusted peer was successfully added, false otherwise  |
+
+***
+
+## **admin\_removeTrustedPeer**
+
+Removes a peer from the trusted peers list. The peer may still remain connected if slots are available, but will no longer bypass the peer limit.
+
+**Parameters**
+
+| Parameter | Type   | Description                                                                 |
+| --------- | ------ | --------------------------------------------------------------------------- |
+| enode     | STRING | The enode URL of the trusted peer to remove (format: enode://pubkey@ip:port) |
+
+**Example**
+
+{% code overflow="wrap" %}
+```bash
+curl -s --data '{"jsonrpc":"2.0","method":"admin_removeTrustedPeer","params":["enode://a979fb575495b8d6db44f750317d0f4622bf4c2aa3365d6af7c284339968eef29b69ad0dce72a4d8db5ebb4968de0e3bec910127f134779fbcb0cb6d3331163c@52.16.188.185:30303"],"id":"1"}' -H "Content-Type: application/json" -X POST http://localhost:8545
+```
+{% endcode %}
+
+**Returns**
+
+| Type    | Description                                                          |
+| ------- | -------------------------------------------------------------------- |
+| Boolean | True if the trusted peer was successfully removed, false otherwise   |
+
+***

--- a/docs/gitbook/src/interacting-with-erigon/engine.md
+++ b/docs/gitbook/src/interacting-with-erigon/engine.md
@@ -32,6 +32,7 @@ When in use (with external CL clients), the Engine API provides essential method
 * Fork Choice Updates: `engine_forkchoiceUpdatedV1/V2/V3` updates the chain head and triggers block building.
 * Payload Retrieval: `engine_getPayloadV1/V2/V3/V4` retrieves built blocks for the CL to propose.
 * Payload Bodies: `engine_getPayloadBodiesByHashV1` and `engine_getPayloadBodiesByRangeV1` fetch historical data.
+* Blob Retrieval: `engine_getBlobsV1/V2/V3` retrieves blobs by versioned hash, with V3 adding support for PeerDAS data columns.
 
 #### Configuration and Security
 

--- a/docs/gitbook/src/interacting-with-erigon/eth.md
+++ b/docs/gitbook/src/interacting-with-erigon/eth.md
@@ -22,10 +22,40 @@ For API usage refer to the below official resources:
 
 ### eth\_getProof
 
-To enable the `eth_getProof` JSON-RPC method, you must explicitly activate the storage of commitment history. Add the following option to your Erigon instance:
+`eth_getProof` returns Merkle proofs for account state and storage slots, as defined in [EIP-1186](https://eips.ethereum.org/EIPS/eip-1186). It is stable and production-ready as of Erigon v3.4.
+
+To enable historical proof support, activate commitment history storage at startup:
 
 ```
 --prune.include-commitment-history=true
 ```
 
-This will allows for blazing fast retrieval of Merkle proofs for executed blocks.
+{% hint style="warning" %}
+**RAM requirement:** Historical `eth_getProof` requires at least **+32 GB RAM** to operate efficiently. Running without sufficient memory will severely degrade node performance.
+{% endhint %}
+
+This enables blazing fast retrieval of Merkle proofs for any executed block.
+
+### eth\_getStorageValues
+
+`eth_getStorageValues` is an Erigon extension that retrieves multiple storage slots for a given account in a single call, reducing round-trips compared to multiple `eth_getStorageAt` calls.
+
+**Parameters**
+
+| Parameter    | Type             | Description                                          |
+| ------------ | ---------------- | ---------------------------------------------------- |
+| address      | STRING           | The account address to query storage for             |
+| storageKeys  | ARRAY of STRING  | List of 32-byte storage slot keys (hex-encoded)      |
+| blockNumber  | STRING or NUMBER | Block number or tag (`"latest"`, `"earliest"`, etc.) |
+
+**Example**
+
+{% code overflow="wrap" %}
+```bash
+curl --data '{"jsonrpc":"2.0","method":"eth_getStorageValues","params":["0xAddress","["0x0000000000000000000000000000000000000000000000000000000000000001"],"latest"],"id":1}' -H "Content-Type: application/json" -X POST http://localhost:8545
+```
+{% endcode %}
+
+**Returns**
+
+An object mapping each requested storage key to its 32-byte value.

--- a/docs/gitbook/src/interacting-with-erigon/trace.md
+++ b/docs/gitbook/src/interacting-with-erigon/trace.md
@@ -28,6 +28,10 @@ The diagnostics are requested by providing a configuration object that specifies
 * `vmTrace`: Provides a Virtual Machine Execution Trace, delivering a full step-by-step trace of the EVM's state throughout the transaction, including all opcodes and gas usage.
 * `stateDiff`: Provides a State Difference, detailing all altered portions of the Ethereum state (e.g., storage, balances, nonces) resulting from the transaction's execution.
 
+#### Flat Tracers
+
+As of v3.4, Erigon supports **flat tracers**, which produce OpenEthereum-compatible call traces in a flat (non-nested) list format. Each call frame is emitted as a separate object with an explicit `subtraces` count, matching the standard output format of `trace_transaction` and `trace_block`. Flat tracers are available for all ad-hoc tracing methods by including `"trace"` in the trace type array.
+
 #### Providing a Transaction to Trace
 
 There are three primary ways to specify the transaction to be traced:


### PR DESCRIPTION
## Summary

Backports all v3.4 documentation changes to `main`, combining:

- **PR #20729** — `--caplin.columns-keep-slots` (PeerDAS column retention)
- **PR #20736** — v3.4 release feature coverage

### Changes included

**configuring-erigon/README.md**
- `--caplin.columns-keep-slots` flag (PeerDAS data column retention, default 131072 slots ~18 days)
- `--rpc.blockrange.limit` default updated to `1000` (was `0`/unlimited — breaking change in v3.4)
- `--rpc.logs.maxresults` new flag (default `20000`)
- discv4/discv5 default change noted (discv5 default since v3.4)
- `--prune.include-commitment-history` — stable, +32 GB RAM requirement, link to eth_getProof

**admin.md** — `admin_addTrustedPeer` / `admin_removeTrustedPeer`

**engine.md** — `engine_getBlobsV3`

**eth.md** — `eth_getStorageValues`; `eth_getProof` stable + +32 GB RAM requirement

**trace.md** — flat tracers documentation (v3.4)

**caplin.md** — PeerDAS Data Column Retention section

## Related PRs

- #20729 (release/3.4)
- #20736 (release/3.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)