### PR TITLE
[wip] db/state: History.collate - reduce seeks and copies

### DIFF
--- a/db/state/history.go
+++ b/db/state/history.go
@@ -635,18 +635,20 @@ func (h *History) collate(ctx context.Context, step kv.Step, txFrom, txTo uint64
 				vTxNum := baseTxNum + uint64(off)
 				seqBuilder.AddOffset(vTxNum)
 
-				var (
-					val      []byte
-					fetchErr error
-				)
+				var val []byte
 				if i == 0 {
 					binary.BigEndian.PutUint64(numBuf, vTxNum)
-					val, fetchErr = cd.SeekBothRange(prevKey, numBuf)
+					var err error
+					val, err = cd.SeekBothRange(prevKey, numBuf)
+					if err != nil {
+						return fmt.Errorf("seekBothRange %s history val [%x]: %w", h.FilenameBase, prevKey, err)
+					}
 				} else {
-					_, val, fetchErr = cd.NextDup()
-				}
-				if fetchErr != nil {
-					return fmt.Errorf("seek %s history val [%x]: %w", h.FilenameBase, prevKey, fetchErr)
+					var err error
+					_, val, err = cd.NextDup()
+					if err != nil {
+						return fmt.Errorf("nextDup %s history val [%x]: %w", h.FilenameBase, prevKey, err)
+					}
 				}
 				if val != nil && binary.BigEndian.Uint64(val) == vTxNum {
 					val = val[8:]
@@ -665,23 +667,23 @@ func (h *History) collate(ctx context.Context, step kv.Step, txFrom, txTo uint64
 				vTxNum := baseTxNum + uint64(off)
 				seqBuilder.AddOffset(vTxNum)
 
-				var (
-					val      []byte
-					fetchErr error
-				)
+				var val []byte
 				if i == 0 {
 					binary.BigEndian.PutUint64(numBuf, vTxNum)
 					keyBuf = append(append(keyBuf[:0], prevKey...), numBuf...)
-					_, val, fetchErr = c.SeekExact(keyBuf)
-				} else {
-					var nextKey []byte
-					nextKey, val, fetchErr = c.Next()
-					if len(nextKey) != len(prevKey)+8 || !bytes.Equal(nextKey[:len(prevKey)], prevKey) {
-						val = nil
+					var err error
+					_, val, err = c.SeekExact(keyBuf)
+					if err != nil {
+						return fmt.Errorf("seekExact %s history val [%x]: %w", h.FilenameBase, prevKey, err)
 					}
-				}
-				if fetchErr != nil {
-					return fmt.Errorf("seek %s history val [%x]: %w", h.FilenameBase, prevKey, fetchErr)
+				} else {
+					nextKey, nextVal, err := c.Next()
+					if err != nil {
+						return fmt.Errorf("next %s history val [%x]: %w", h.FilenameBase, prevKey, err)
+					}
+					if len(nextKey) == len(prevKey)+8 && bytes.Equal(nextKey[:len(prevKey)], prevKey) {
+						val = nextVal
+					}
 				}
 				if len(val) == 0 {
 					val = nil

--- a/db/state/history.go
+++ b/db/state/history.go
@@ -613,9 +613,7 @@ func (h *History) collate(ctx context.Context, step kv.Step, txFrom, txTo uint64
 		initialized bool
 	)
 
-	cnt := 0
 	var histKeyBuf []byte
-	//log.Warn("[dbg] collate", "name", h.filenameBase, "sampling", h.historyValuesOnCompressedPage)
 
 	loadBitmapsFunc := func(k, v []byte, table etl.CurrentTableReader, next etl.LoadNextFunc) error {
 		txNum := binary.BigEndian.Uint64(v)
@@ -630,41 +628,68 @@ func (h *History) collate(ctx context.Context, step kv.Step, txFrom, txTo uint64
 		}
 		seqBuilder.Reset(baseTxNum, uint64(len(offsets)), baseTxNum+uint64(offsets[len(offsets)-1]))
 
-		for _, off := range offsets {
-			cnt++
-			vTxNum := baseTxNum + uint64(off)
-			seqBuilder.AddOffset(vTxNum)
+		if !h.HistoryLargeValues {
+			// Offsets are sorted ascending; DupSort dups are sorted ascending by txNum.
+			// Seek only for the first txNum per key group; step sequentially for the rest.
+			for i, off := range offsets {
+				vTxNum := baseTxNum + uint64(off)
+				seqBuilder.AddOffset(vTxNum)
+				binary.BigEndian.PutUint64(numBuf, vTxNum)
 
-			binary.BigEndian.PutUint64(numBuf, vTxNum)
-			if !h.HistoryLargeValues {
-				val, err := cd.SeekBothRange(prevKey, numBuf)
-				if err != nil {
-					return fmt.Errorf("seekBothRange %s history val [%x]: %w", h.FilenameBase, prevKey, err)
+				var (
+					val      []byte
+					fetchErr error
+				)
+				if i == 0 {
+					val, fetchErr = cd.SeekBothRange(prevKey, numBuf)
+				} else {
+					_, val, fetchErr = cd.NextDup()
+				}
+				if fetchErr != nil {
+					return fmt.Errorf("seek %s history val [%x]: %w", h.FilenameBase, prevKey, fetchErr)
 				}
 				if val != nil && binary.BigEndian.Uint64(val) == vTxNum {
 					val = val[8:]
 				} else {
 					val = nil
 				}
-
 				histKeyBuf = historyKey(vTxNum, prevKey, histKeyBuf)
 				if err := historyWriter.Add(histKeyBuf, val); err != nil {
 					return fmt.Errorf("add %s history val [%x]: %w", h.FilenameBase, prevKey, err)
 				}
-				continue
 			}
-			keyBuf = append(append(keyBuf[:0], prevKey...), numBuf...)
-			key, val, err := c.SeekExact(keyBuf)
-			if err != nil {
-				return fmt.Errorf("seekExact %s history val [%x]: %w", h.FilenameBase, key, err)
-			}
-			if len(val) == 0 {
-				val = nil
-			}
+		} else {
+			// LargeValues keys are prevKey+txNum, sorted lexicographically.
+			// Seek only for the first txNum per key group; step sequentially for the rest.
+			for i, off := range offsets {
+				vTxNum := baseTxNum + uint64(off)
+				seqBuilder.AddOffset(vTxNum)
+				binary.BigEndian.PutUint64(numBuf, vTxNum)
 
-			histKeyBuf = historyKey(vTxNum, prevKey, histKeyBuf)
-			if err := historyWriter.Add(histKeyBuf, val); err != nil {
-				return fmt.Errorf("add %s history val [%x]: %w", h.FilenameBase, key, err)
+				var (
+					val      []byte
+					fetchErr error
+				)
+				if i == 0 {
+					keyBuf = append(append(keyBuf[:0], prevKey...), numBuf...)
+					_, val, fetchErr = c.SeekExact(keyBuf)
+				} else {
+					var nextKey []byte
+					nextKey, val, fetchErr = c.Next()
+					if len(nextKey) != len(prevKey)+8 || !bytes.Equal(nextKey[:len(prevKey)], prevKey) {
+						val = nil
+					}
+				}
+				if fetchErr != nil {
+					return fmt.Errorf("seek %s history val [%x]: %w", h.FilenameBase, prevKey, fetchErr)
+				}
+				if len(val) == 0 {
+					val = nil
+				}
+				histKeyBuf = historyKey(vTxNum, prevKey, histKeyBuf)
+				if err := historyWriter.Add(histKeyBuf, val); err != nil {
+					return fmt.Errorf("add %s history val [%x]: %w", h.FilenameBase, prevKey, err)
+				}
 			}
 		}
 		offsets = offsets[:0]

--- a/db/state/history.go
+++ b/db/state/history.go
@@ -634,13 +634,13 @@ func (h *History) collate(ctx context.Context, step kv.Step, txFrom, txTo uint64
 			for i, off := range offsets {
 				vTxNum := baseTxNum + uint64(off)
 				seqBuilder.AddOffset(vTxNum)
-				binary.BigEndian.PutUint64(numBuf, vTxNum)
 
 				var (
 					val      []byte
 					fetchErr error
 				)
 				if i == 0 {
+					binary.BigEndian.PutUint64(numBuf, vTxNum)
 					val, fetchErr = cd.SeekBothRange(prevKey, numBuf)
 				} else {
 					_, val, fetchErr = cd.NextDup()
@@ -664,13 +664,13 @@ func (h *History) collate(ctx context.Context, step kv.Step, txFrom, txTo uint64
 			for i, off := range offsets {
 				vTxNum := baseTxNum + uint64(off)
 				seqBuilder.AddOffset(vTxNum)
-				binary.BigEndian.PutUint64(numBuf, vTxNum)
 
 				var (
 					val      []byte
 					fetchErr error
 				)
 				if i == 0 {
+					binary.BigEndian.PutUint64(numBuf, vTxNum)
 					keyBuf = append(append(keyBuf[:0], prevKey...), numBuf...)
 					_, val, fetchErr = c.SeekExact(keyBuf)
 				} else {

--- a/db/state/history.go
+++ b/db/state/history.go
@@ -601,7 +601,6 @@ func (h *History) collate(ctx context.Context, step kv.Step, txFrom, txTo uint64
 	baseTxNum := uint64(step) * h.stepSize
 	var (
 		keyBuf = make([]byte, 0, 256)
-		numBuf = make([]byte, 8)
 		// offsets: stores (txNum-baseTxNum) values; ETL delivers txNums sorted per key
 		// so no dedup/sort needed. Safe: collate covers exactly one step so values < stepSize < math.MaxUint32.
 		// Worst case: one key touched every txNum in the step → stepSize uint32 entries.
@@ -628,18 +627,27 @@ func (h *History) collate(ctx context.Context, step kv.Step, txFrom, txTo uint64
 		}
 		seqBuilder.Reset(baseTxNum, uint64(len(offsets)), baseTxNum+uint64(offsets[len(offsets)-1]))
 
+		// prevKey is fixed for the whole group. Set up histKeyBuf[8:] = prevKey once;
+		// only the txNum prefix (first 8 bytes) is overwritten per iteration.
+		if cap(histKeyBuf) < 8+len(prevKey) {
+			histKeyBuf = make([]byte, 8+len(prevKey))
+		} else {
+			histKeyBuf = histKeyBuf[:8+len(prevKey)]
+		}
+		copy(histKeyBuf[8:], prevKey)
+
 		if !h.HistoryLargeValues {
 			// Offsets are sorted ascending; DupSort dups are sorted ascending by txNum.
 			// Seek only for the first txNum per key group; step sequentially for the rest.
 			for i, off := range offsets {
 				vTxNum := baseTxNum + uint64(off)
 				seqBuilder.AddOffset(vTxNum)
+				binary.BigEndian.PutUint64(histKeyBuf, vTxNum)
 
 				var val []byte
 				if i == 0 {
-					binary.BigEndian.PutUint64(numBuf, vTxNum)
 					var err error
-					val, err = cd.SeekBothRange(prevKey, numBuf)
+					val, err = cd.SeekBothRange(prevKey, histKeyBuf[:8])
 					if err != nil {
 						return fmt.Errorf("seekBothRange %s history val [%x]: %w", h.FilenameBase, prevKey, err)
 					}
@@ -655,7 +663,6 @@ func (h *History) collate(ctx context.Context, step kv.Step, txFrom, txTo uint64
 				} else {
 					val = nil
 				}
-				histKeyBuf = historyKey(vTxNum, prevKey, histKeyBuf)
 				if err := historyWriter.Add(histKeyBuf, val); err != nil {
 					return fmt.Errorf("add %s history val [%x]: %w", h.FilenameBase, prevKey, err)
 				}
@@ -663,14 +670,21 @@ func (h *History) collate(ctx context.Context, step kv.Step, txFrom, txTo uint64
 		} else {
 			// LargeValues keys are prevKey+txNum, sorted lexicographically.
 			// Seek only for the first txNum per key group; step sequentially for the rest.
+			// Set up keyBuf prefix (prevKey) once; only the 8-byte txNum suffix changes per seek.
+			if cap(keyBuf) < len(prevKey)+8 {
+				keyBuf = make([]byte, len(prevKey)+8)
+			} else {
+				keyBuf = keyBuf[:len(prevKey)+8]
+			}
+			copy(keyBuf, prevKey)
 			for i, off := range offsets {
 				vTxNum := baseTxNum + uint64(off)
 				seqBuilder.AddOffset(vTxNum)
+				binary.BigEndian.PutUint64(histKeyBuf, vTxNum)
 
 				var val []byte
 				if i == 0 {
-					binary.BigEndian.PutUint64(numBuf, vTxNum)
-					keyBuf = append(append(keyBuf[:0], prevKey...), numBuf...)
+					binary.BigEndian.PutUint64(keyBuf[len(prevKey):], vTxNum)
 					var err error
 					_, val, err = c.SeekExact(keyBuf)
 					if err != nil {
@@ -688,7 +702,6 @@ func (h *History) collate(ctx context.Context, step kv.Step, txFrom, txTo uint64
 				if len(val) == 0 {
 					val = nil
 				}
-				histKeyBuf = historyKey(vTxNum, prevKey, histKeyBuf)
 				if err := historyWriter.Add(histKeyBuf, val); err != nil {
 					return fmt.Errorf("add %s history val [%x]: %w", h.FilenameBase, prevKey, err)
 				}


### PR DESCRIPTION
## Summary

Optimizes `History.collate()` in the hot collation path:

- **Seek → sequential step**: for each key group, MDBX seeks (`SeekBothRange` / `SeekExact`) are now issued only for the first txNum; subsequent txNums in the same group use `NextDup()` / `Next()`. This is safe because ETL delivers offsets sorted ascending and DupSort dups / LargeValues keys are also sorted ascending by txNum. For accounts touched many times per step (fee recipients, busy ERC-20 contracts), converts N random B-tree seeks into 1 seek + (N-1) sequential cursor steps.

- **Hoist `h.HistoryLargeValues` branch**: moved outside the inner loop (was checked once per txNum per key).

- **`historyKey` copy elimination**: `histKeyBuf` (layout: `txNum[8] + key`) is set up once per key group by copying `prevKey` into `histKeyBuf[8:]`. The per-iteration cost drops from a full `8+len(key)` byte copy to a single 8-byte `PutUint64` write.

- **`keyBuf` copy elimination (LargeValues)**: `keyBuf` (layout: `key + txNum[8]`) prefix (`prevKey`) is copied once per key group; only the 8-byte txNum suffix is updated per seek.

- **`numBuf` eliminated**: was a separate 8-byte heap slice used as a staging buffer for txNum encoding. Removed — SmallValues now reads directly from `histKeyBuf[:8]`; LargeValues writes directly into `keyBuf[len(prevKey):]`.

- **Dead code removed**: unused `cnt` variable and commented-out debug log line.