### PR TITLE
execution/stagedsync: use BlockOverlay read view for BLOCKHASH lookups

### DIFF
--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -627,9 +627,22 @@ func (te *txExecutor) executeBlocks(ctx context.Context, tx kv.TemporalTx, start
 			txs := b.Transactions()
 			header := b.HeaderNoCopy()
 
-			// BLOCKHASH looks back at most 256 blocks. Use a short-lived read
-			// tx (not the apply-tx) to avoid races with fcuOverlay lifecycle.
+			// BLOCKHASH looks back at most 256 blocks. During initial sync the
+			// headers for recently-inserted blocks live in the in-memory block
+			// overlay (see execmodule/inserters.go) and are not yet in the main
+			// DB; read them via an OverlayReadView so that the walk-back used by
+			// GetHashFn can find every header between (blockNum-256) and
+			// (blockNum-1).
 			blockContext := protocol.NewEVMBlockContext(header, protocol.GetHashFn(header, func(hash common.Hash, number uint64) (*types.Header, error) {
+				if overlay := te.doms.BlockOverlay(); overlay != nil {
+					roTx, err := te.cfg.db.BeginRo(ctx) //nolint:gocritic
+					if err != nil {
+						return nil, err
+					}
+					defer roTx.Rollback()
+					view := overlay.NewReadView(roTx)
+					return te.cfg.blockReader.Header(ctx, view, hash, number)
+				}
 				var h *types.Header
 				if err := te.cfg.db.View(ctx, func(roTx kv.Tx) error {
 					var err error


### PR DESCRIPTION
During initial sync, the parallel executor's BLOCKHASH walk-back opens a fresh `db.View()` RO tx to look up ancestor headers. Recently-inserted headers are still in the in-memory `BlockOverlay` (populated by `execmodule/inserters.go`) and haven't been committed to the main DB, so the fresh RO tx returns nil on the first walk-back step and `GetHashFn` short-circuits to the zero hash.

When `BlockOverlay` is active, wrap a RO tx with `overlay.NewReadView(...)` before consulting the block reader so the walk-back sees every header between `blockNum-256` and `blockNum-1`.

## Reproduction (bal-devnet-3)

Erigon failed to sync past block 624 with `gas used by execution: 5563565, in header: 5565882, diff=-2317`. Side-by-side opcode traces with geth showed:

- `BLOCKHASH(512)` → `0` on erigon, `0x2186f41f…944744` on geth.
- A contract derives a `LOG4` data length via `AND(literal, last_2_bytes_of_blockhash)`; with the wrong blockhash the length computed to `0` instead of `18244`, skipping the 148,301-gas data+memory portion of LOG4's cost.
- The 63/64 forwarding rule amplified the divergence through a subsequent precompile (`0x0a`) call that burned its entire gas stipend, leaving the net -2,317 gas mismatch at the receipt / header level.

With this fix applied, erigon sync proceeds past block 624.