### PR TITLE
docs: document backport PR conventions for release branches

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -54,6 +54,15 @@ Run `make lint` before every push. The linter is non-deterministic — run it re
 
 When manually dispatching a workflow that is not part of the PR's automatic check list, add a comment on the PR explaining which workflow was dispatched, why it was chosen, and include a direct link to the workflow run.
 
+### Backport PRs to release branches
+
+When opening a PR against `release/3.4` (or another release branch):
+
+- **Title**: prefix with `[r3.4]` — e.g. `[r3.4] db/version: enforce upper-bound file version check`. Variants `[r34]` and `[3.4]` also appear but `[r3.4]` is the dominant form.
+- **Body**: keep it short. For a straight cherry-pick: `Cherry-pick of #<N> to release/3.4.` When release-branch adjustments were needed (different APIs, skipped tests, etc.), add a `## r3.4-specific adaptations` section listing the deltas. When the change is not a cherry-pick of a merged PR (e.g. a dependency bump pulling a fix), describe what's being pulled in and why it's needed on the release branch.
+- **Branch name**: keep a `3.4` marker. Common forms: `cherry-pick-<PR#>-to-release-3.4`, `cherry-pick-<PR#>-r34`, `cp/<PR#>-to-3.4`, or `<user>/<short>_34`.
+- **Base branch**: `release/3.4`.
+
 ## Pre-push
 
 Before running `git push`, always run `make lint` first and fix all issues. Run lint multiple times if needed — it is non-deterministic.


### PR DESCRIPTION
## Summary

Adds a "Backport PRs to release branches" subsection under "Pull Requests & Workflows" in `agents.md`, capturing the conventions used in actual `release/3.4` backport PRs:

- Title prefix forms (`[r3.4]` is dominant; `[r34]` and `[3.4]` also seen)
- Body shape (short cherry-pick line, optional `## r3.4-specific adaptations` section, or a description for non-cherry-pick pulls)
- Branch name forms in use
- Base branch

These are conventions for the human-facing PR (title/body/branch), and are complementary to — not duplicated by — the existing `.claude/skills/github-pr-cleanup` and `.claude/skills/erigon-cherry-pick` skills, which describe the automated cherry-pick *mechanics* (fetching, branching, opening the PR via `gh`) rather than the conventions a contributor should follow when opening one manually.