### PR TITLE
db/kv, db/state: use PutCurrent instead of DeleteCurrent+Put in domain flush

### DIFF
--- a/db/kv/kv_interface.go
+++ b/db/kv/kv_interface.go
@@ -293,6 +293,7 @@ type RwCursorDupSort interface {
 	RwCursor
 
 	PutNoDupData(key, value []byte) error // PutNoDupData - inserts key without dupsort
+	PutCurrent(key, value []byte) error   // PutCurrent - replaces the current dup entry in-place (cursor must be positioned); saves Del+Put round-trip
 	DeleteCurrentDuplicates() error       // DeleteCurrentDuplicates - deletes all values of the current key
 	DeleteExact(k1, k2 []byte) error      // DeleteExact - delete 1 value from given key
 	AppendDup(key, value []byte) error    // AppendDup - same as Append, but for sorted dup data

--- a/db/kv/mdbx/kv_mdbx.go
+++ b/db/kv/mdbx/kv_mdbx.go
@@ -1610,7 +1610,16 @@ func (c *MdbxDupSortCursor) PutNoDupData(k, v []byte) error {
 	if err := c.c.Put(k, v, mdbx.NoDupData); err != nil {
 		return fmt.Errorf("label: %s, in PutNoDupData: %w", c.label, err)
 	}
+	return nil
+}
 
+// PutCurrent replaces the current dup entry in-place. The cursor must be
+// positioned (e.g. via SeekBothRange) on the entry to replace.
+// Saves one CGo call vs DeleteCurrent()+Put() for the update path.
+func (c *MdbxDupSortCursor) PutCurrent(k, v []byte) error {
+	if err := c.c.PutCurrent(k, v); err != nil {
+		return fmt.Errorf("label: %s, in PutCurrent: %w", c.label, err)
+	}
 	return nil
 }
 

--- a/db/kv/membatchwithdb/memory_mutation_cursor.go
+++ b/db/kv/membatchwithdb/memory_mutation_cursor.go
@@ -297,6 +297,10 @@ func (m *memoryMutationCursor) PutNoDupData(key, value []byte) error {
 	panic("Not implemented")
 }
 
+func (m *memoryMutationCursor) PutCurrent(key, value []byte) error {
+	panic("Not implemented")
+}
+
 func (m *memoryMutationCursor) Delete(k []byte) error {
 	return m.mutation.Delete(m.table, k)
 }

--- a/db/kv/membatchwithdb/memory_store.go
+++ b/db/kv/membatchwithdb/memory_store.go
@@ -755,6 +755,7 @@ func (c *memStoreCursor) DeleteCurrentDuplicates() error {
 }
 
 func (c *memStoreCursor) PutNoDupData(key, value []byte) error { panic("PutNoDupData not implemented") }
+func (c *memStoreCursor) PutCurrent(key, value []byte) error   { panic("PutCurrent not implemented") }
 
 func (c *memStoreCursor) Close() {}
 

--- a/db/kv/remotedb/kv_remote.go
+++ b/db/kv/remotedb/kv_remote.go
@@ -677,6 +677,7 @@ func (c *remoteCursorDupSort) SeekBothRange(k, v []byte) ([]byte, error) {
 func (c *remoteCursorDupSort) DeleteExact(k1, k2 []byte) error    { panic("not supported") }
 func (c *remoteCursorDupSort) AppendDup(k []byte, v []byte) error { panic("not supported") }
 func (c *remoteCursorDupSort) PutNoDupData(k, v []byte) error     { panic("not supported") }
+func (c *remoteCursorDupSort) PutCurrent(k, v []byte) error       { panic("not supported") }
 func (c *remoteCursorDupSort) DeleteCurrentDuplicates() error     { panic("not supported") }
 func (c *remoteCursorDupSort) CountDuplicates() (uint64, error)   { panic("not supported") }
 

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -440,18 +440,9 @@ func (w *DomainBufferedWriter) Flush(ctx context.Context, tx kv.RwTx) error {
 			return err
 		}
 		if len(foundVal) == 0 || !bytes.Equal(foundVal[:8], v[:8]) {
-			if err := valuesCursor.Put(k, v); err != nil {
-				return err
-			}
-			return nil
+			return valuesCursor.Put(k, v)
 		}
-		if err := valuesCursor.DeleteCurrent(); err != nil {
-			return err
-		}
-		if err := valuesCursor.Put(k, v); err != nil {
-			return err
-		}
-		return nil
+		return valuesCursor.PutCurrent(k, v) // DeleteCurrent+Put
 	}, etl.TransformArgs{Quit: ctx.Done(), EmptyVals: true}); err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ replace github.com/holiman/bloomfilter/v2 => github.com/AskAlexSharov/bloomfilte
 
 require (
 	github.com/erigontech/erigon-snapshot v1.3.1-0.20260402120223-7bb412bc89cd
-	github.com/erigontech/mdbx-go v0.39.12
+	github.com/erigontech/mdbx-go v0.39.17
 	github.com/erigontech/secp256k1 v1.2.1-0.20260218182123-377cc1bd6410
 )
 

--- a/go.sum
+++ b/go.sum
@@ -344,8 +344,8 @@ github.com/erigontech/fastkeccak v0.1.1-0.20260408010752-08e7b6602268 h1:NHl4+Dj
 github.com/erigontech/fastkeccak v0.1.1-0.20260408010752-08e7b6602268/go.mod h1:CwJFJVKFVWpQyKSfRrQyY56IqV16sR5xnQoFThGHiZA=
 github.com/erigontech/go-eth-kzg v0.0.0-20260401161010-070339460d07 h1:0VpFIthaJzGs3iwyrKCj67wptrNq7KKiLhilDCRPqwk=
 github.com/erigontech/go-eth-kzg v0.0.0-20260401161010-070339460d07/go.mod h1:J9/u5sWfznSObptgfa92Jq8rTswn6ahQWEuiLHOjCUI=
-github.com/erigontech/mdbx-go v0.39.12 h1:WjvPzloxXOYfRamIxt8NOB7i3/M8cSCSfWQHvMNANrE=
-github.com/erigontech/mdbx-go v0.39.12/go.mod h1:tHUS492F5YZvccRqatNdpTDQAaN+Vv4HRARYq89KqeY=
+github.com/erigontech/mdbx-go v0.39.17 h1:+FQMaCuH/IB+t9HEXVDxTJaV5jvZTwC/6YgDHHKDDMo=
+github.com/erigontech/mdbx-go v0.39.17/go.mod h1:VTGwYzepS9Wg38jVfreOsSVlh73OBGPZluu7kHo6X6g=
 github.com/erigontech/secp256k1 v1.2.1-0.20260218182123-377cc1bd6410 h1:5YD7JJ5PaqOdjKA84lTDtQby9nbI4podqrkUhyIyFDw=
 github.com/erigontech/secp256k1 v1.2.1-0.20260218182123-377cc1bd6410/go.mod h1:CnigLRUsfobnTYoUzwdT/De67fw9OhTA0KTkxa+svik=
 github.com/ettle/strcase v0.2.0 h1:fGNiVF21fHXpX1niBgk0aROov1LagYsOwV/xqKDKR/Q=


### PR DESCRIPTION
Adds `PutCurrent` to the `RwCursorDupSort` interface and implements it via mdbx's native cursor-replace operation. Changes `DomainBufferedWriter.Flush` to use `PutCurrent` on the update path instead of `DeleteCurrent`+`Put`, saving one CGo round-trip per flush entry.

Bumps `mdbx-go` to v0.39.17 which exposes the `PutCurrent` method.

Revives https://github.com/erigontech/erigon/pull/19914 for main.