### PR TITLE
[performance] fix issue #20169: StateCache + collation/pruning race fixes

### DIFF
--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -252,7 +252,7 @@ func runDatadirMode(ctx context.Context, logger log.Logger, dataDir, privAPI, lo
 	}
 
 	// Create the typed JSON-RPC APIs — same path as rpcdaemon.
-	apiList := jsonrpc.APIList(db, backend, txPool, mining, ff, stateCache, blockReader, cfg, engine, logger, bridgeReader, heimdallReader)
+	apiList := jsonrpc.APIList(db, backend, txPool, mining, ff, stateCache, blockReader, cfg, engine, logger, bridgeReader, heimdallReader, nil)
 
 	// Extract the EthAPI, ErigonAPI, OtterscanAPI from the API list.
 	var (

--- a/cmd/rpcdaemon/main.go
+++ b/cmd/rpcdaemon/main.go
@@ -56,7 +56,7 @@ func main() {
 			defer heimdallReader.Close()
 		}
 
-		apiList := jsonrpc.APIList(db, backend, txPool, mining, ff, stateCache, blockReader, cfg, engine, logger, bridgeReader, heimdallReader)
+		apiList := jsonrpc.APIList(db, backend, txPool, mining, ff, stateCache, blockReader, cfg, engine, logger, bridgeReader, heimdallReader, nil)
 		rpc.PreAllocateRPCMetricLabels(apiList)
 		if err := cli.StartRpcServer(ctx, cfg, apiList, logger); err != nil {
 			logger.Error(err.Error())

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -54,6 +54,7 @@ import (
 	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/db/version"
 	"github.com/erigontech/erigon/execution/commitment"
+	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
 )
 
 type Aggregator struct {
@@ -821,7 +822,6 @@ func (a *Aggregator) buildFiles(ctx context.Context, step kv.Step) error {
 
 		static          = &AggV3StaticFiles{ivfs: make([]InvertedFiles, len(a.iis))}
 		closeCollations = true
-		collListMu      = sync.Mutex{}
 		collations      = make([]Collation, 0)
 	)
 	defer func() {
@@ -833,46 +833,89 @@ func (a *Aggregator) buildFiles(ctx context.Context, step kv.Step) error {
 		}
 	}()
 
-	g, ctx := errgroup.WithContext(ctx)
-	g.SetLimit(a.collateAndBuildWorkers)
-
-	// Use agg.BeginFilesRo() to safely snapshot visible files under visibleFilesLock,
-	// instead of calling individual domain/ii BeginFilesRo() without synchronization.
 	ac := a.BeginFilesRo()
+	defer ac.Close()
+
+	// Phase 1: collate all domains and indices using a SINGLE read-transaction.
+	// This guarantees all collations see the exact same MDBX snapshot, eliminating
+	// the collation/pruning race where execution overwrites step S values with
+	// step S+1 data between collation reads. See #20169.
+	collationTx, err := a.db.BeginRo(ctx)
+	if err != nil {
+		return fmt.Errorf("open collation tx: %w", err)
+	}
+	defer collationTx.Rollback()
+
+	type domainCollResult struct {
+		d         *Domain
+		collation Collation
+	}
+	type iiCollResult struct {
+		ii        *InvertedIndex
+		iikey     int
+		collation InvertedIndexCollation
+	}
+	var domainColls []domainCollResult
+	var iiColls []iiCollResult
+	defer func() {
+		if !closeCollations {
+			return
+		}
+		for _, ic := range iiColls {
+			ic.collation.Close()
+		}
+	}()
+
 	for id, d := range a.d {
 		if d.Disable {
 			continue
 		}
-
-		d := d
 		firstStepNotInFiles := ac.d[id].FirstStepNotInFiles()
 		if step < firstStepNotInFiles {
 			continue
 		}
+		collation, err := d.collate(ctx, step, txFrom, txTo, collationTx)
+		if err != nil {
+			return fmt.Errorf("domain collation %q has failed: %w", d.FilenameBase, err)
+		}
+		collations = append(collations, collation)
+		domainColls = append(domainColls, domainCollResult{d: d, collation: collation})
+	}
+	for iikey, ii := range a.iis {
+		if ii.Disable {
+			continue
+		}
+		firstStepNotInFiles := ac.iis[iikey].FirstStepNotInFiles()
+		if step < firstStepNotInFiles {
+			continue
+		}
+		collation, err := ii.collate(ctx, step, collationTx)
+		if err != nil {
+			return fmt.Errorf("index collation %q has failed: %w", ii.FilenameBase, err)
+		}
+		iiColls = append(iiColls, iiCollResult{ii: ii, iikey: iikey, collation: collation})
+	}
+	collationTx.Rollback() // release the read-tx before Phase 2 (no DB access needed)
+	closeCollations = false
 
+	// Phase 2: build files from collations in parallel (no DB access needed).
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(a.collateAndBuildWorkers)
+
+	for _, dc := range domainColls {
+		dc := dc
 		a.wg.Add(1)
 		g.Go(func() error {
 			defer a.wg.Done()
 
-			var collation Collation
-			if err := a.db.View(ctx, func(tx kv.Tx) (err error) {
-				collation, err = d.collate(ctx, step, txFrom, txTo, tx)
-				return err
-			}); err != nil {
-				return fmt.Errorf("domain collation %q has failed: %w", d.FilenameBase, err)
-			}
-			collListMu.Lock()
-			collations = append(collations, collation)
-			collListMu.Unlock()
-
-			sf, err := d.buildFiles(ctx, step, collation, a.ps)
-			collation.Close()
+			sf, err := dc.d.buildFiles(ctx, step, dc.collation, a.ps)
+			dc.collation.Close()
 			if err != nil {
 				sf.CleanupOnError()
 				return err
 			}
 
-			dd, err := kv.String2Domain(d.FilenameBase)
+			dd, err := kv.String2Domain(dc.d.FilenameBase)
 			if err != nil {
 				return err
 			}
@@ -880,39 +923,19 @@ func (a *Aggregator) buildFiles(ctx context.Context, step kv.Step) error {
 			return nil
 		})
 	}
-	closeCollations = false
-
-	// indices are built concurrently
-	for iikey, ii := range a.iis {
-		if ii.Disable {
-			continue
-		}
-
-		ii := ii
-		firstStepNotInFiles := ac.iis[iikey].FirstStepNotInFiles()
-		if step < firstStepNotInFiles {
-			continue
-		}
-
+	for _, ic := range iiColls {
+		ic := ic
 		a.wg.Add(1)
 		g.Go(func() error {
 			defer a.wg.Done()
 
-			var collation InvertedIndexCollation
-			err := a.db.View(ctx, func(tx kv.Tx) (err error) {
-				collation, err = ii.collate(ctx, step, tx)
-				return err
-			})
-			if err != nil {
-				return fmt.Errorf("index collation %q has failed: %w", ii.FilenameBase, err)
-			}
-			sf, err := ii.buildFiles(ctx, step, collation, a.ps)
+			sf, err := ic.ii.buildFiles(ctx, step, ic.collation, a.ps)
 			if err != nil {
 				sf.CleanupOnError()
 				return err
 			}
 
-			static.ivfs[iikey] = sf
+			static.ivfs[ic.iikey] = sf
 			return nil
 		})
 	}
@@ -1475,6 +1498,18 @@ func lastTxNumOfStep(step kv.Step, stepSize uint64) uint64 {
 	return firstTxNumOfStep(step+1, stepSize) - 1
 }
 
+// stepFullyCommitted reports whether all txNums in `step` have been committed
+// to the DB, based on the committedTxNum stored by ComputeCommitment.
+// When committedTxNum == 0 (no ComputeCommitment yet, e.g. in tests), the
+// guard is bypassed and the caller should fall through to the lastInDB check.
+func stepFullyCommitted(committedTxNum uint64, step kv.Step, stepSize uint64) bool {
+	if committedTxNum == 0 {
+		return true // guard bypassed — no commitment state yet
+	}
+	stepEndTxNum := firstTxNumOfStep(step+1, stepSize)
+	return committedTxNum+1 >= stepEndTxNum
+}
+
 // firstTxNumOfStep returns txStepBeginning of given step.
 // Step 0 is a range [0, stepSize).
 // To prune step needed to fully Prune range [txStepBeginning, txNextStepBeginning)
@@ -1788,6 +1823,7 @@ func (a *Aggregator) SetSnapshotBuildSema(semaphore *semaphore.Weighted) {
 func (a *Aggregator) SetProduceMod(produce bool) {
 	a.produce = produce
 }
+
 func (a *Aggregator) BuildFilesInBackground(txNum uint64) chan struct{} {
 	return a.buildFilesInBackground(txNum, true)
 }
@@ -1847,6 +1883,33 @@ func (a *Aggregator) buildFilesInBackground(txNum uint64, doMerge bool) chan str
 		// - to remove old data from db as early as possible
 		// - during files build, may happen commit of new data. on each loop step getting latest id in db
 		for ; step < lastInDB; step++ { //`step` must be fully-written - means `step+1` records must be visible
+			// Guard against collation/pruning race: only collate step S when the
+			// execution layer has committed ALL data through the end of step S.
+			// Read the latest committed txNum from the commitment domain state
+			// (written by SharedDomains.ComputeCommitment after each flush+commit).
+			// Without this check, the collation's read-transaction may snapshot
+			// the DB before a CommitCycle flushes step S's writes, producing a
+			// file that misses entries. Pruning then removes those entries from
+			// the DB, and the values are lost. See #20169.
+			var committedTxNum uint64
+			if temporalDB, ok := a.db.(kv.TemporalRoDB); ok {
+				if err := temporalDB.ViewTemporal(a.ctx, func(tx kv.TemporalTx) error {
+					v, _, err := tx.GetLatest(kv.CommitmentDomain, commitmentdb.KeyCommitmentState)
+					if err != nil {
+						return err
+					}
+					if len(v) >= 16 {
+						committedTxNum, _ = commitmentdb.DecodeTxBlockNums(v)
+					}
+					return nil
+				}); err != nil {
+					a.logger.Warn("[snapshots] buildFilesInBackground: read commitment", "err", err)
+					break
+				}
+			}
+			if !stepFullyCommitted(committedTxNum, step, a.StepSize()) {
+				break // step not fully committed yet — wait for execution to catch up
+			}
 			if err := a.buildFiles(a.ctx, step); err != nil {
 				if errors.Is(err, errStepNotReady) {
 					break
@@ -2073,8 +2136,13 @@ func (at *AggregatorRoTx) Unwind(ctx context.Context, tx kv.RwTx, txNumUnwindTo 
 	defer logEvery.Stop()
 
 	step := txNumUnwindTo / at.StepSize()
+	// Use the CURRENT (atomically published) file boundary, not the stale
+	// tx-scoped snapshot. BuildFilesInBackground may have filed new steps
+	// since this AggregatorRoTx was opened, and getLatestFromDb will use
+	// the current view — so the unwind must tag entries beyond it.
+	currentFilesEndStep := at.a.EndTxNumMinimax() / at.StepSize()
 	for idx, d := range at.d {
-		if err := d.unwind(ctx, tx, step, txNumUnwindTo, changeset[idx]); err != nil {
+		if err := d.unwind(ctx, tx, step, txNumUnwindTo, currentFilesEndStep, changeset[idx]); err != nil {
 			return err
 		}
 	}

--- a/db/state/aggregator_test.go
+++ b/db/state/aggregator_test.go
@@ -490,6 +490,34 @@ func generateCommitmentHistoryAndIndexFiles(t *testing.T, dirs datadir.Dirs, ran
 	populateFiles2(t, dirs, idxRepo, ranges)
 }
 
+// TestAggregator_CommittedTxNumGuard verifies the stepFullyCommitted predicate
+// used by buildFilesInBackground: a step S should only be collated when
+// committedTxNum+1 >= firstTxNum(S+1), meaning all txNums in step S have been
+// committed to the DB. ComputeCommitment writes the last txNum of the block
+// (e.g. firstTxNum(S+1)-1 when the step boundary aligns with a block), so
+// the +1 avoids an off-by-one that would delay collation unnecessarily.
+func TestAggregator_CommittedTxNumGuard(t *testing.T) {
+	t.Parallel()
+	stepSize := uint64(100)
+
+	// Step 5 covers txNums [500, 600). firstTxNum(6) = 600.
+	assert.False(t, stepFullyCommitted(550, 5, stepSize),
+		"guard should block: committed txNum is mid-step")
+	assert.True(t, stepFullyCommitted(0, 5, stepSize),
+		"guard should be bypassed when committedTxNum is 0 (no commitment)")
+	assert.False(t, stepFullyCommitted(598, 5, stepSize),
+		"guard should block: committed txNum is 1 before last txNum of step")
+
+	// committedTxNum = 599 = lastTxNumOfStep(5) = firstTxNum(6)-1
+	// This is the value ComputeCommitment writes at the step boundary.
+	assert.True(t, stepFullyCommitted(599, 5, stepSize),
+		"guard should allow: committed txNum is last txNum of the step")
+	assert.True(t, stepFullyCommitted(600, 5, stepSize),
+		"guard should allow: committed txNum is past the step")
+	assert.True(t, stepFullyCommitted(1000, 5, stepSize),
+		"guard should allow: committed txNum is well past the step")
+}
+
 func TestAggregator_CommitmentHistoryOnlyMerge(t *testing.T) {
 	// Regression: when commitment values are already merged (values.needMerge=false) but history
 	// is not, the old aggregator.mergeFiles called commitmentValTransformDomain with a zero

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1284,7 +1284,7 @@ func (d *Domain) integrateDirtyFiles(sf StaticFiles, txNumFrom, txNumTo uint64) 
 
 // unwind is similar to prune but the difference is that it restores domain values from the history as of txFrom
 // context Flush should be managed by caller.
-func (dt *DomainRoTx) unwind(ctx context.Context, rwTx kv.RwTx, step, txNumUnwindTo uint64, domainDiffs []kv.DomainEntryDiff) error {
+func (dt *DomainRoTx) unwind(ctx context.Context, rwTx kv.RwTx, step, txNumUnwindTo, currentFilesEndStep uint64, domainDiffs []kv.DomainEntryDiff) error {
 	// fmt.Printf("[domain][%s] unwinding domain to txNum=%d, step %d\n", d.filenameBase, txNumUnwindTo, step)
 	d := dt.d
 
@@ -1303,8 +1303,17 @@ func (dt *DomainRoTx) unwind(ctx context.Context, rwTx kv.RwTx, step, txNumUnwin
 	// Revert keys using diff entries.
 	// Always: delete current entry at the write step, restore prevValue at unwind target step.
 	// value == []byte{} means key was new (no previous value to restore).
+	//
+	// The step tag for restored entries must be BEYOND the filed range, otherwise
+	// getLatestFromDb will discard them (step covered by files → fall through to
+	// files which have the pre-unwind value). Use the larger of the natural step
+	// and the first unfiled step. See #20169.
+	unwindStep := step
+	if currentFilesEndStep > unwindStep {
+		unwindStep = currentFilesEndStep
+	}
 	unwindStepBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(unwindStepBytes, ^uint64(step))
+	binary.BigEndian.PutUint64(unwindStepBytes, ^uint64(unwindStep))
 
 	for i := range domainDiffs {
 		keyStr, value := domainDiffs[i].Key, domainDiffs[i].Value

--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -885,7 +885,7 @@ func TestDomain_CollationIsolatedFromLaterSteps(t *testing.T) {
 	tx, err := db.BeginRw(ctx)
 	require.NoError(t, err)
 	defer tx.Rollback() //nolint:gocritic
-	dt := d.beginForTests()
+	dt := d.BeginFilesRo()
 	w := dt.NewWriter()
 
 	// Step 0 writes (txNums 0-15)
@@ -964,7 +964,7 @@ func TestDomain_UnwindRestoredEntryVisibility(t *testing.T) {
 	require.NoError(t, err)
 	defer tx.Rollback() //nolint:gocritic
 
-	dt := d.beginForTests()
+	dt := d.BeginFilesRo()
 	w := dt.NewWriter()
 	require.NoError(t, w.PutWithPrev(k1, []byte("V1"), 2, nil))
 	require.NoError(t, w.PutWithPrev(k1, []byte("V2"), 10, []byte("V1")))
@@ -976,7 +976,7 @@ func TestDomain_UnwindRestoredEntryVisibility(t *testing.T) {
 	require.NoError(t, d.collateBuildIntegrate(ctx, 0, tx, background.NewProgressSet()))
 
 	// Prune step 0 from DB — entries now only in files.
-	dt = d.beginForTests()
+	dt = d.BeginFilesRo()
 	_, err = dt.Prune(ctx, tx, 0, 0, 16, math.MaxUint64, logEvery)
 	dt.Close()
 	require.NoError(t, err)
@@ -993,13 +993,13 @@ func TestDomain_UnwindRestoredEntryVisibility(t *testing.T) {
 	}
 
 	// Unwind to txNum 5 (between the V1 write at 2 and V2 write at 10, still in step 0).
-	dt = d.beginForTests()
+	dt = d.BeginFilesRo()
 	err = dt.unwind(ctx, tx, 0, 5, uint64(dt.FirstStepNotInFiles()), diffs)
 	dt.Close()
 	require.NoError(t, err)
 
 	// GetLatest must return V1 (the changeset-restored value), NOT V2 (the file value).
-	dt = d.beginForTests()
+	dt = d.BeginFilesRo()
 	defer dt.Close()
 	v, _, found, err := dt.GetLatest(k1, tx)
 	require.NoError(t, err)

--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -858,6 +858,156 @@ func TestDomainRoTx_CursorParentCheck(t *testing.T) {
 	require.NoError(err)
 }
 
+// TestDomain_CollationIsolatedFromLaterSteps verifies that collation for step S
+// produces correct results even when step S+1 data is present in the DB.
+// This is a correctness test for the collation/pruning race fix (#20169).
+//
+// The collation/pruning race occurs when BuildFilesInBackground's collation
+// read-transaction sees step S+1 values that overwrite step S entries. The
+// fix uses a single read-tx for all collations in buildFiles, ensuring they
+// all see the same MDBX snapshot. While the exact race is timing-dependent
+// and hard to reproduce in a unit test, this test verifies the invariant:
+// step S collation must produce a file with step S values regardless of
+// later step data in the DB.
+func TestDomain_CollationIsolatedFromLaterSteps(t *testing.T) {
+	logger := log.New()
+	db, d := testDbAndDomainOfStep(t, statecfg.Schema.StorageDomain, 16, logger)
+	ctx := context.Background()
+
+	k1 := []byte("key1")
+	k2 := []byte("key2")
+	v1s0 := []byte("value1_step0")
+	v2s0 := []byte("value2_step0")
+	v1s1 := []byte("value1_step1") // k1 modified again in step 1
+	// k2 is NOT modified in step 1
+
+	// Write both keys in step 0, then k1 again in step 1, all in one transaction.
+	tx, err := db.BeginRw(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback() //nolint:gocritic
+	dt := d.beginForTests()
+	w := dt.NewWriter()
+
+	// Step 0 writes (txNums 0-15)
+	require.NoError(t, w.PutWithPrev(k1, v1s0, 5, nil))
+	require.NoError(t, w.PutWithPrev(k2, v2s0, 7, nil))
+
+	// Step 1 write (txNums 16-31) — overwrites k1 only
+	require.NoError(t, w.PutWithPrev(k1, v1s1, 20, v1s0))
+
+	require.NoError(t, w.Flush(ctx, tx))
+	require.NoError(t, tx.Commit())
+	w.Close()
+	dt.Close()
+
+	// Collate step 0 — should get k1=v1s0 and k2=v2s0, NOT k1=v1s1.
+	roTx, err := db.BeginRo(ctx)
+	require.NoError(t, err)
+	defer roTx.Rollback()
+
+	coll, err := d.collate(ctx, 0, 0, 16, roTx)
+	require.NoError(t, err)
+	defer coll.Close()
+	sf, err := d.buildFiles(ctx, 0, coll, background.NewProgressSet())
+	require.NoError(t, err)
+	defer sf.CleanupOnError()
+
+	g := d.dataReader(sf.valuesDecomp)
+	g.Reset(0)
+	var words []string
+	for g.HasNext() {
+		w, _ := g.Next(nil)
+		words = append(words, string(w))
+	}
+	require.Equal(t, []string{"key1", "value1_step0", "key2", "value2_step0"}, words,
+		"step 0 collation must contain step 0 values, not step 1 overwrites")
+
+	// Collate step 1 — should get k1=v1s1 only (k2 was not modified in step 1).
+	coll1, err := d.collate(ctx, 1, 16, 32, roTx)
+	require.NoError(t, err)
+	defer coll1.Close()
+	sf1, err := d.buildFiles(ctx, 1, coll1, background.NewProgressSet())
+	require.NoError(t, err)
+	defer sf1.CleanupOnError()
+
+	g = d.dataReader(sf1.valuesDecomp)
+	g.Reset(0)
+	var words1 []string
+	for g.HasNext() {
+		w, _ := g.Next(nil)
+		words1 = append(words1, string(w))
+	}
+	require.Equal(t, []string{"key1", "value1_step1"}, words1,
+		"step 1 collation must contain only step 1 values")
+}
+
+// TestDomain_UnwindRestoredEntryVisibility verifies that after an unwind, restored
+// domain entries are visible to GetLatest even when the entry's natural step has
+// been filed by BuildFilesInBackground. See #20169.
+//
+// The bug: unwind tags restored entries with the step of the unwind-target txNum.
+// If that step is covered by domain files, getLatestFromDb discards the entry and
+// falls through to getLatestFromFiles, returning the stale end-of-step value from
+// the file instead of the changeset-restored value.
+func TestDomain_UnwindRestoredEntryVisibility(t *testing.T) {
+	logger := log.New()
+	db, d := testDbAndDomainOfStep(t, statecfg.Schema.StorageDomain, 16, logger)
+	ctx := context.Background()
+	logEvery := time.NewTicker(30 * time.Second)
+	defer logEvery.Stop()
+
+	k1 := []byte("key1")
+
+	// Step 0: write k1 twice — first V1 at txNum 2, then V2 at txNum 10.
+	// The file for step 0 will have k1=V2 (latest value in the step).
+	tx, err := db.BeginRw(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback() //nolint:gocritic
+
+	dt := d.beginForTests()
+	w := dt.NewWriter()
+	require.NoError(t, w.PutWithPrev(k1, []byte("V1"), 2, nil))
+	require.NoError(t, w.PutWithPrev(k1, []byte("V2"), 10, []byte("V1")))
+	require.NoError(t, w.Flush(ctx, tx))
+	w.Close()
+	dt.Close()
+
+	// Build files for step 0 → file has k1=V2.
+	require.NoError(t, d.collateBuildIntegrate(ctx, 0, tx, background.NewProgressSet()))
+
+	// Prune step 0 from DB — entries now only in files.
+	dt = d.beginForTests()
+	_, err = dt.Prune(ctx, tx, 0, 0, 16, math.MaxUint64, logEvery)
+	dt.Close()
+	require.NoError(t, err)
+
+	// Now simulate an unwind that restores k1=V1 (reverting the V1→V2 write at txNum 10).
+	// The changeset entry has: key="key1" + step0_bytes, value=V1.
+	step0Bytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(step0Bytes, ^uint64(0))
+	diffs := []kv.DomainEntryDiff{
+		{
+			Key:   string(k1) + string(step0Bytes),
+			Value: []byte("V1"),
+		},
+	}
+
+	// Unwind to txNum 5 (between the V1 write at 2 and V2 write at 10, still in step 0).
+	dt = d.beginForTests()
+	err = dt.unwind(ctx, tx, 0, 5, uint64(dt.FirstStepNotInFiles()), diffs)
+	dt.Close()
+	require.NoError(t, err)
+
+	// GetLatest must return V1 (the changeset-restored value), NOT V2 (the file value).
+	dt = d.beginForTests()
+	defer dt.Close()
+	v, _, found, err := dt.GetLatest(k1, tx)
+	require.NoError(t, err)
+	require.True(t, found, "key should be found after unwind")
+	require.Equal(t, "V1", string(v),
+		"GetLatest must return the unwind-restored value V1, not the file value V2")
+}
+
 func TestDomain_Delete(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
@@ -2346,7 +2496,7 @@ func TestDomain_Unwind(t *testing.T) {
 			}
 		}
 
-		err = domainRoTx.unwind(ctx, tx, unwindTo/d.stepSize, unwindTo, totalDiff)
+		err = domainRoTx.unwind(ctx, tx, unwindTo/d.stepSize, unwindTo, uint64(domainRoTx.FirstStepNotInFiles()), totalDiff)
 		currTx = unwindTo
 		require.NoError(t, err)
 		domainRoTx.Close()

--- a/execution/builder/builder.go
+++ b/execution/builder/builder.go
@@ -133,7 +133,11 @@ func (b *Builder) Build(param *Parameters, interrupt *atomic.Bool) (result *type
 		return nil, err
 	}
 	createCfg := StageBuilderCreateBlockCfg(state, b.chainConfig, b.engine, param, b.blockReader)
-	execCfg := StageBuilderExecCfg(state, b.notifier, b.chainConfig, b.engine, b.vmConfig, b.tmpdir, interrupt, param.PayloadId, b.txnProvider, b.blockReader)
+	txnProvider := b.txnProvider
+	if param.CustomTxnProvider != nil {
+		txnProvider = param.CustomTxnProvider
+	}
+	execCfg := StageBuilderExecCfg(state, b.notifier, b.chainConfig, b.engine, b.vmConfig, b.tmpdir, interrupt, param.PayloadId, txnProvider, b.blockReader)
 	finishCfg := StageBuilderFinishCfg(b.chainConfig, b.engine, state, b.sealCancel, b.blockReader, b.latestBlockBuiltStore)
 
 	if err := createBlock(b.ctx, sd, tx, executionAt, createCfg, b.logger); err != nil {

--- a/execution/builder/parameters.go
+++ b/execution/builder/parameters.go
@@ -19,6 +19,7 @@ package builder
 import (
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/txnprovider"
 )
 
 // Parameters for PoS block building
@@ -32,4 +33,7 @@ type Parameters struct {
 	Withdrawals           []*types.Withdrawal // added in Shapella (EIP-4895)
 	ParentBeaconBlockRoot *common.Hash        // added in Dencun (EIP-4788)
 	SlotNumber            *uint64             // added in Amsterdam (EIP-7843)
+	// CustomTxnProvider overrides the block's transaction source when non-nil.
+	// nil → use the injected TxnProvider (normal mempool path)
+	CustomTxnProvider txnprovider.TxnProvider
 }

--- a/execution/cache/cache_test.go
+++ b/execution/cache/cache_test.go
@@ -603,13 +603,9 @@ func TestStateCache_Delete(t *testing.T) {
 	assert.False(t, ok)
 }
 
-// Regression test for https://github.com/erigontech/erigon/issues/20169
-//
-// SharedDomains.GetLatest caches deleted keys via Put(key, nil).
-// Previously, Put treated nil/empty values as Delete (removing the key from
-// cache), and Get treated empty cached values as "not found". This caused
-// subsequent reads to miss the cache and fall through to the DB, returning
-// stale pre-delete values.
+// Put(key, nil) must be a cache hit, not a miss. SharedDomains.GetLatest
+// caches deleted keys via Put(key, nil); if Get treats that as "not found",
+// the caller unnecessarily falls through to the DB on every read.
 func TestStateCache_PutEmpty_ThenGet_IsCacheHit(t *testing.T) {
 	c := NewStateCache(100, 100, 100, 100, 100)
 
@@ -617,13 +613,8 @@ func TestStateCache_PutEmpty_ThenGet_IsCacheHit(t *testing.T) {
 	key[0] = 0x1d
 	key[51] = 0xa2
 
-	// Simulate the SharedDomains pattern: a DomainDel causes GetLatest
-	// to cache the deletion via Put(key, nil).
 	c.Put(kv.StorageDomain, key, nil)
 
-	// Get must return (_, true) — a cache HIT with empty value.
-	// If it returns (_, false), the caller falls through to DB and
-	// reads the stale pre-delete value.
 	v, ok := c.Get(kv.StorageDomain, key)
 	assert.True(t, ok, "Get after Put(nil) must be a cache hit, not a miss")
 	assert.Empty(t, v, "cached value for a deleted key must be empty")

--- a/execution/cache/cache_test.go
+++ b/execution/cache/cache_test.go
@@ -603,6 +603,47 @@ func TestStateCache_Delete(t *testing.T) {
 	assert.False(t, ok)
 }
 
+// Regression test for https://github.com/erigontech/erigon/issues/20169
+//
+// SharedDomains.GetLatest caches deleted keys via Put(key, nil).
+// Previously, Put treated nil/empty values as Delete (removing the key from
+// cache), and Get treated empty cached values as "not found". This caused
+// subsequent reads to miss the cache and fall through to the DB, returning
+// stale pre-delete values.
+func TestStateCache_PutEmpty_ThenGet_IsCacheHit(t *testing.T) {
+	c := NewStateCache(100, 100, 100, 100, 100)
+
+	key := make([]byte, 52) // addr(20) + slot(32)
+	key[0] = 0x1d
+	key[51] = 0xa2
+
+	// Simulate the SharedDomains pattern: a DomainDel causes GetLatest
+	// to cache the deletion via Put(key, nil).
+	c.Put(kv.StorageDomain, key, nil)
+
+	// Get must return (_, true) — a cache HIT with empty value.
+	// If it returns (_, false), the caller falls through to DB and
+	// reads the stale pre-delete value.
+	v, ok := c.Get(kv.StorageDomain, key)
+	assert.True(t, ok, "Get after Put(nil) must be a cache hit, not a miss")
+	assert.Empty(t, v, "cached value for a deleted key must be empty")
+}
+
+// Same test for []byte{} (zero-length but non-nil).
+func TestStateCache_PutEmptySlice_ThenGet_IsCacheHit(t *testing.T) {
+	c := NewStateCache(100, 100, 100, 100, 100)
+
+	key := make([]byte, 52)
+	key[0] = 0x1d
+	key[51] = 0xa2
+
+	c.Put(kv.StorageDomain, key, []byte{})
+
+	v, ok := c.Get(kv.StorageDomain, key)
+	assert.True(t, ok, "Get after Put([]byte{}) must be a cache hit")
+	assert.Empty(t, v)
+}
+
 func TestStateCache_Delete_UnsupportedDomain(t *testing.T) {
 	c := NewStateCache(100, 100, 100, 100, 100)
 

--- a/execution/cache/generic_cache.go
+++ b/execution/cache/generic_cache.go
@@ -81,7 +81,7 @@ func (c *DomainCache) Delete(key []byte) {
 // Get retrieves data for the given key.
 func (c *GenericCache[T]) Get(key []byte) (T, bool) {
 	value, ok := c.data.Get(key)
-	if !ok || c.sizeFunc(value) == 0 {
+	if !ok {
 		c.misses.Add(1)
 		var zero T
 		return zero, false

--- a/execution/cache/state_cache.go
+++ b/execution/cache/state_cache.go
@@ -67,16 +67,14 @@ func NewDefaultStateCache() *StateCache {
 }
 
 // Get retrieves data for the given domain and key.
+// Returns (value, true) on cache hit — including (nil, true) for deleted keys —
+// and (nil, false) on cache miss.
 func (c *StateCache) Get(domain kv.Domain, key []byte) ([]byte, bool) {
 	cache := c.caches[domain]
 	if cache == nil {
 		return nil, false
 	}
-	v, ok := cache.Get(key)
-	if len(v) == 0 {
-		return nil, false
-	}
-	return v, ok
+	return cache.Get(key)
 }
 
 // Put stores data for the given domain and key.
@@ -86,10 +84,6 @@ func (c *StateCache) Put(domain kv.Domain, key []byte, value []byte) {
 		return
 	}
 	if domain == kv.CommitmentDomain && bytes.Equal(key, commitmentdb.KeyCommitmentState) {
-		return
-	}
-	if len(value) == 0 {
-		cache.Delete(key)
 		return
 	}
 	cache.Put(key, common.Copy(value))

--- a/execution/commitment/commitmentdb/commitment_context.go
+++ b/execution/commitment/commitmentdb/commitment_context.go
@@ -460,7 +460,7 @@ var KeyCommitmentState = []byte(keyCommitmentStateS)
 
 var ErrBehindCommitment = errors.New("behind commitment")
 
-func _decodeTxBlockNums(v []byte) (txNum, blockNum uint64) {
+func DecodeTxBlockNums(v []byte) (txNum, blockNum uint64) {
 	return binary.BigEndian.Uint64(v), binary.BigEndian.Uint64(v[8:16])
 }
 
@@ -485,7 +485,7 @@ func (sdc *SharedDomainsCommitmentContext) LatestCommitmentState(trieContext *Tr
 		return 0, 0, nil, nil
 	}
 
-	txNum, blockNum = _decodeTxBlockNums(state)
+	txNum, blockNum = DecodeTxBlockNums(state)
 	return blockNum, txNum, state, nil
 }
 
@@ -809,9 +809,9 @@ func LatestBlockNumWithCommitment(tx kv.TemporalGetter) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	if len(stateVal) == 0 {
+	if len(stateVal) < 16 {
 		return 0, nil
 	}
-	_, minUnwindale := _decodeTxBlockNums(stateVal)
-	return minUnwindale, nil
+	_, minUnwindable := DecodeTxBlockNums(stateVal)
+	return minUnwindable, nil
 }

--- a/execution/engineapi/engine_server.go
+++ b/execution/engineapi/engine_server.go
@@ -156,16 +156,6 @@ func (e *EngineServer) Start(
 			Version:   "1.0",
 		}}
 
-	if httpConfig.TestingEnabled {
-		e.logger.Warn("[EngineServer] testing_ RPC namespace is ENABLED — do not use on production networks")
-		apiList = append(apiList, rpc.API{
-			Namespace: "testing",
-			Public:    false,
-			Service:   TestingAPI(NewTestingImpl(e, true)),
-			Version:   "1.0",
-		})
-	}
-
 	eg.Go(func() error {
 		defer e.logger.Debug("[EngineServer] engine rpc server goroutine terminated")
 		err := cli.StartRpcServerWithJwtAuthentication(ctx, httpConfig, apiList, e.logger)

--- a/execution/engineapi/engine_types/jsonrpc.go
+++ b/execution/engineapi/engine_types/jsonrpc.go
@@ -67,7 +67,7 @@ type PayloadAttributes struct {
 	SuggestedFeeRecipient common.Address      `json:"suggestedFeeRecipient" gencodec:"required"`
 	Withdrawals           []*types.Withdrawal `json:"withdrawals"`
 	ParentBeaconBlockRoot *common.Hash        `json:"parentBeaconBlockRoot"`
-	SlotNumber            *hexutil.Uint64     `json:"slotNumber,omitempty"`
+	SlotNumber            *hexutil.Uint64     `json:"slotNumber"`
 }
 
 // TransitionConfiguration represents the correct configurations of the CL and the EL
@@ -84,6 +84,41 @@ type BlobsBundle struct {
 	Commitments []hexutil.Bytes `json:"commitments" gencodec:"required"`
 	Proofs      []hexutil.Bytes `json:"proofs"      gencodec:"required"`
 	Blobs       []hexutil.Bytes `json:"blobs"       gencodec:"required"`
+}
+
+// BlobsBundleFromTransactions builds a BlobsBundle by extracting blobs,
+// commitments, and proofs from blob transactions in the given list.
+func BlobsBundleFromTransactions(txs types.Transactions) (*BlobsBundle, error) {
+	bundle := &BlobsBundle{
+		Commitments: make([]hexutil.Bytes, 0),
+		Proofs:      make([]hexutil.Bytes, 0),
+		Blobs:       make([]hexutil.Bytes, 0),
+	}
+	for i, txn := range txs {
+		if txn.Type() != types.BlobTxType {
+			continue
+		}
+		blobTx, ok := txn.(*types.BlobTxWrapper)
+		if !ok {
+			return nil, fmt.Errorf("expected BlobTxWrapper for tx %d, got %T", i, txn)
+		}
+		for _, c := range blobTx.Commitments {
+			cp := make([]byte, len(c))
+			copy(cp, c[:])
+			bundle.Commitments = append(bundle.Commitments, cp)
+		}
+		for _, p := range blobTx.Proofs {
+			pp := make([]byte, len(p))
+			copy(pp, p[:])
+			bundle.Proofs = append(bundle.Proofs, pp)
+		}
+		for _, b := range blobTx.Blobs {
+			bp := make([]byte, len(b))
+			copy(bp, b[:])
+			bundle.Blobs = append(bundle.Blobs, bp)
+		}
+	}
+	return bundle, nil
 }
 
 // BlobAndProofV1 holds one item for engine_getBlobsV1

--- a/execution/engineapi/engine_types/jsonrpc.go
+++ b/execution/engineapi/engine_types/jsonrpc.go
@@ -49,8 +49,8 @@ type ExecutionPayload struct {
 	Withdrawals     []*types.Withdrawal `json:"withdrawals"`
 	BlobGasUsed     *hexutil.Uint64     `json:"blobGasUsed"`
 	ExcessBlobGas   *hexutil.Uint64     `json:"excessBlobGas"`
-	SlotNumber      *hexutil.Uint64     `json:"slotNumber"`
-	BlockAccessList hexutil.Bytes       `json:"blockAccessList"`
+	SlotNumber      *hexutil.Uint64     `json:"slotNumber,omitempty"`
+	BlockAccessList hexutil.Bytes       `json:"blockAccessList,omitempty"`
 }
 
 // PayloadAttributes represent the attributes required to start assembling a payload
@@ -67,7 +67,7 @@ type PayloadAttributes struct {
 	SuggestedFeeRecipient common.Address      `json:"suggestedFeeRecipient" gencodec:"required"`
 	Withdrawals           []*types.Withdrawal `json:"withdrawals"`
 	ParentBeaconBlockRoot *common.Hash        `json:"parentBeaconBlockRoot"`
-	SlotNumber            *hexutil.Uint64     `json:"slotNumber"`
+	SlotNumber            *hexutil.Uint64     `json:"slotNumber,omitempty"`
 }
 
 // TransitionConfiguration represents the correct configurations of the CL and the EL
@@ -106,7 +106,7 @@ type ExecutionPayloadBody struct {
 type ExecutionPayloadBodyV2 struct {
 	Transactions    []hexutil.Bytes     `json:"transactions" gencodec:"required"`
 	Withdrawals     []*types.Withdrawal `json:"withdrawals"  gencodec:"required"`
-	BlockAccessList hexutil.Bytes       `json:"blockAccessList"`
+	BlockAccessList hexutil.Bytes       `json:"blockAccessList,omitempty"`
 }
 
 type PayloadStatus struct {

--- a/execution/engineapi/testing_api.go
+++ b/execution/engineapi/testing_api.go
@@ -17,21 +17,39 @@
 package engineapi
 
 // testing_api.go implements the testing_ RPC namespace, specifically testing_buildBlockV1.
-// This namespace MUST NOT be enabled on production networks. Gate it with --rpc.testing.
+// Enable via --http.api=...,testing (e.g. --http.api eth,erigon,testing).
+// This namespace MUST NOT be enabled on production networks.
 
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
+	execctx "github.com/erigontech/erigon/db/state/execctx"
+	"github.com/erigontech/erigon/execution/builder"
 	"github.com/erigontech/erigon/execution/engineapi/engine_types"
+	"github.com/erigontech/erigon/execution/state"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/execution/types/accounts"
 	"github.com/erigontech/erigon/node/gointerfaces"
 	"github.com/erigontech/erigon/node/gointerfaces/executionproto"
 	"github.com/erigontech/erigon/rpc"
+	"github.com/erigontech/erigon/txnprovider"
 )
+
+// directServerAccessor is implemented by direct.ExecutionClientDirect, which wraps the real
+// ExecModule.  We use a two-step assertion (client → server → concrete method) to avoid
+// importing execution/builder inside node/direct (which would introduce an import cycle).
+type directServerAccessor interface {
+	Server() executionproto.ExecutionServer
+}
 
 // TestingAPI is the interface for the testing_ RPC namespace.
 type TestingAPI interface {
@@ -42,23 +60,110 @@ type TestingAPI interface {
 	//
 	// transactions: nil  → draw from mempool (normal builder behaviour)
 	//               []   → build an empty block (mempool bypassed, no txs)
-	//               [...] → TODO: explicit tx list not yet supported; returns error
-	//
-	// NOTE: overriding extraData post-assembly means the BlockHash in the returned payload
-	// will NOT match a block header that includes that extraData. Callers should treat the
-	// result as a template when extraData is overridden.
+	//               [...] → build a block containing exactly these transactions (strict nonce check)
 	BuildBlockV1(ctx context.Context, parentHash common.Hash, payloadAttributes *engine_types.PayloadAttributes, transactions *[]hexutil.Bytes, extraData *hexutil.Bytes) (*engine_types.GetPayloadResponse, error)
+}
+
+// blockParamAssembler is implemented by execmodule.ExecModule.  We reach it via the two-step
+// assertion executionService → directServerAccessor.Server() → blockParamAssembler.
+type blockParamAssembler interface {
+	AssembleBlockWithParams(ctx context.Context, params *builder.Parameters) (payloadID uint64, busy bool, err error)
+}
+
+// resolveBlockParamAssembler extracts a blockParamAssembler from the execution service,
+// using the directServerAccessor indirection to avoid circular imports.
+func resolveBlockParamAssembler(svc executionproto.ExecutionClient) (blockParamAssembler, bool) {
+	dsa, ok := svc.(directServerAccessor)
+	if !ok {
+		return nil, false
+	}
+	bpa, ok := dsa.Server().(blockParamAssembler)
+	return bpa, ok
 }
 
 // testingImpl is the concrete implementation of TestingAPI.
 type testingImpl struct {
-	server  *EngineServer
-	enabled bool
+	server *EngineServer
+	logger log.Logger
+	db     kv.TemporalRoDB
 }
 
 // NewTestingImpl returns a new TestingAPI implementation wrapping the given EngineServer.
-func NewTestingImpl(server *EngineServer, enabled bool) TestingAPI {
-	return &testingImpl{server: server, enabled: enabled}
+func NewTestingImpl(server *EngineServer, logger log.Logger, db kv.TemporalRoDB) TestingAPI {
+	return &testingImpl{server: server, logger: logger, db: db}
+}
+
+// NewTestingRPCEntry returns the rpc.API descriptor for the testing_ namespace.
+func NewTestingRPCEntry(server *EngineServer, logger log.Logger, db kv.TemporalRoDB) rpc.API {
+	return rpc.API{
+		Namespace: "testing",
+		Public:    false,
+		Service:   TestingAPI(NewTestingImpl(server, logger, db)),
+		Version:   "1.0",
+	}
+}
+
+// decodeTxnProvider decodes raw transactions into a TxnProvider.
+// Returns nil if transactions is nil (mempool path).
+// Opens a single temporal DB transaction for all nonce lookups to avoid per-sender overhead.
+func (t *testingImpl) decodeTxnProvider(ctx context.Context, transactions *[]hexutil.Bytes, blockNumber, timestamp uint64) (txnprovider.TxnProvider, error) {
+	if transactions == nil {
+		return nil, nil
+	}
+
+	var reader *state.ReaderV3
+	if t.db != nil {
+		dbTx, err := t.db.BeginTemporalRo(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("testing_buildBlockV1: could not begin temporal transaction: %w", err)
+		}
+		defer dbTx.Rollback()
+		sd, err := execctx.NewSharedDomains(ctx, dbTx, t.logger)
+		if err != nil {
+			return nil, fmt.Errorf("testing_buildBlockV1: NewSharedDomains error: %w", err)
+		}
+		defer sd.Close()
+		reader = state.NewReaderV3(sd.AsGetter(dbTx))
+	}
+
+	decoded := make([]types.Transaction, 0, len(*transactions))
+	signer := types.MakeSigner(t.server.config, blockNumber, timestamp)
+	expectedNonce := make(map[accounts.Address]uint64, len(*transactions))
+	for i, rawTx := range *transactions {
+		tx, err := types.DecodeTransaction(rawTx)
+		if err != nil {
+			return nil, &rpc.InvalidParamsError{Message: fmt.Sprintf("transaction %d: decode error: %v", i, err)}
+		}
+		sender, err := signer.Sender(tx)
+		if err != nil {
+			return nil, &rpc.InvalidParamsError{Message: fmt.Sprintf("transaction %d: cannot recover sender: %v", i, err)}
+		}
+		tx.SetSender(sender)
+		if _, seen := expectedNonce[sender]; !seen {
+			var stateNonce uint64
+			if reader != nil {
+				acc, err := reader.ReadAccountData(accounts.InternAddress(sender.Value()))
+				if err != nil {
+					return nil, fmt.Errorf("testing_buildBlockV1: ReadAccountData error: %w", err)
+				}
+				if acc != nil {
+					stateNonce = acc.Nonce
+				}
+			}
+			expectedNonce[sender] = stateNonce
+		}
+		want := expectedNonce[sender]
+		got := tx.GetNonce()
+		if got > want {
+			return nil, &rpc.CustomError{Code: rpc.ErrCodeDefault, Message: fmt.Sprintf("nonce too high: address %v, tx: %d state: %d", sender.Value(), got, want)}
+		}
+		if got < want {
+			return nil, &rpc.CustomError{Code: rpc.ErrCodeDefault, Message: fmt.Sprintf("nonce too low: address %v, tx: %d state: %d", sender.Value(), got, want)}
+		}
+		expectedNonce[sender]++
+		decoded = append(decoded, tx)
+	}
+	return &staticTxnProvider{txns: decoded}, nil
 }
 
 // BuildBlockV1 implements TestingAPI.
@@ -69,18 +174,8 @@ func (t *testingImpl) BuildBlockV1(
 	transactions *[]hexutil.Bytes,
 	extraData *hexutil.Bytes,
 ) (*engine_types.GetPayloadResponse, error) {
-	if !t.enabled {
-		return nil, &rpc.InvalidParamsError{Message: "testing namespace is disabled; start erigon with --rpc.testing (WARNING: not for production use)"}
-	}
-
 	if payloadAttributes == nil {
 		return nil, &rpc.InvalidParamsError{Message: "payloadAttributes must not be null"}
-	}
-
-	// Explicit transaction list is not yet supported (requires proto extension).
-	// TODO: implement forced_transactions via AssembleBlockRequest proto extension.
-	if transactions != nil && len(*transactions) > 0 {
-		return nil, &rpc.InvalidParamsError{Message: "explicit transaction list not yet supported in testing_buildBlockV1; use null for mempool or [] for empty block"}
 	}
 
 	// Validate parent block exists.
@@ -124,19 +219,9 @@ func (t *testingImpl) BuildBlockV1(
 		return nil, &rpc.InvalidParamsError{Message: "parentBeaconBlockRoot not supported before Cancun"}
 	}
 
-	// Build the AssembleBlock request (mirrors forkchoiceUpdated logic).
-	req := &executionproto.AssembleBlockRequest{
-		ParentHash:            gointerfaces.ConvertHashToH256(parentHash),
-		Timestamp:             timestamp,
-		PrevRandao:            gointerfaces.ConvertHashToH256(payloadAttributes.PrevRandao),
-		SuggestedFeeRecipient: gointerfaces.ConvertAddressToH160(payloadAttributes.SuggestedFeeRecipient),
-		SlotNumber:            (*uint64)(payloadAttributes.SlotNumber),
-	}
-	if version >= clparams.CapellaVersion {
-		req.Withdrawals = engine_types.ConvertWithdrawalsToRpc(payloadAttributes.Withdrawals)
-	}
-	if version >= clparams.DenebVersion {
-		req.ParentBeaconBlockRoot = gointerfaces.ConvertHashToH256(*payloadAttributes.ParentBeaconBlockRoot)
+	customProvider, err := t.decodeTxnProvider(ctx, transactions, parentHeader.Number.Uint64()+1, timestamp)
+	if err != nil {
+		return nil, err
 	}
 
 	// Both steps share a single slot-duration budget so the total wall-clock
@@ -144,14 +229,62 @@ func (t *testingImpl) BuildBlockV1(
 	// Each step acquires the lock independently, matching production behaviour
 	// where ForkChoiceUpdated and GetPayload are separate RPC calls.
 	deadline := time.Now().Add(time.Duration(t.server.config.SecondsPerSlot()) * time.Second)
+	if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(deadline) {
+		deadline = ctxDeadline
+	}
 
-	// Step 1: AssembleBlock (locked scope).
-	assembleResp, execBusy, err := func() (*executionproto.AssembleBlockResponse, bool, error) {
+	// Step 1: AssembleBlock.
+	var payloadID uint64
+	execBusy, err := func() (bool, error) {
 		t.server.lock.Lock()
 		defer t.server.lock.Unlock()
 
+		if customProvider != nil {
+			// Explicit tx list path: use AssembleBlockWithParams to pass CustomTxnProvider.
+			bpa, ok := resolveBlockParamAssembler(t.server.executionService)
+			if !ok {
+				return false, errors.New("execution service does not support explicit transaction list")
+			}
+			params := &builder.Parameters{
+				ParentHash:            parentHash,
+				Timestamp:             timestamp,
+				PrevRandao:            payloadAttributes.PrevRandao,
+				SuggestedFeeRecipient: payloadAttributes.SuggestedFeeRecipient,
+				SlotNumber:            (*uint64)(payloadAttributes.SlotNumber),
+				CustomTxnProvider:     customProvider,
+			}
+			if version >= clparams.CapellaVersion {
+				params.Withdrawals = payloadAttributes.Withdrawals
+			}
+			if version >= clparams.DenebVersion {
+				params.ParentBeaconBlockRoot = payloadAttributes.ParentBeaconBlockRoot
+			}
+			var id uint64
+			var busy bool
+			var err error
+			busy, err = waitForResponse(time.Until(deadline), func() (bool, error) {
+				id, busy, err = bpa.AssembleBlockWithParams(ctx, params)
+				return busy, err
+			})
+			payloadID = id
+			return busy, err
+		}
+
+		// Mempool / empty tx path: use the proto-based AssembleBlock.
+		req := &executionproto.AssembleBlockRequest{
+			ParentHash:            gointerfaces.ConvertHashToH256(parentHash),
+			Timestamp:             timestamp,
+			PrevRandao:            gointerfaces.ConvertHashToH256(payloadAttributes.PrevRandao),
+			SuggestedFeeRecipient: gointerfaces.ConvertAddressToH160(payloadAttributes.SuggestedFeeRecipient),
+			SlotNumber:            (*uint64)(payloadAttributes.SlotNumber),
+		}
+		if version >= clparams.CapellaVersion {
+			req.Withdrawals = engine_types.ConvertWithdrawalsToRpc(payloadAttributes.Withdrawals)
+		}
+		if version >= clparams.DenebVersion {
+			req.ParentBeaconBlockRoot = gointerfaces.ConvertHashToH256(*payloadAttributes.ParentBeaconBlockRoot)
+		}
 		var resp *executionproto.AssembleBlockResponse
-		var err error
 		busy, err := waitForResponse(time.Until(deadline), func() (bool, error) {
 			resp, err = t.server.executionService.AssembleBlock(ctx, req)
 			if err != nil {
@@ -159,7 +292,10 @@ func (t *testingImpl) BuildBlockV1(
 			}
 			return resp.Busy, nil
 		})
-		return resp, busy, err
+		if resp != nil {
+			payloadID = resp.Id
+		}
+		return busy, err
 	}()
 	if err != nil {
 		return nil, err
@@ -168,15 +304,12 @@ func (t *testingImpl) BuildBlockV1(
 		return nil, errors.New("execution service is busy, cannot build block")
 	}
 
-	payloadID := assembleResp.Id
-
-	// Step 2: GetAssembledBlock (separate locked scope).
+	// Step 2: GetAssembledBlock (proto-based).
 	getResp, execBusy, err := func() (*executionproto.GetAssembledBlockResponse, bool, error) {
 		t.server.lock.Lock()
 		defer t.server.lock.Unlock()
 
 		var resp *executionproto.GetAssembledBlockResponse
-		var err error
 		busy, err := waitForResponse(time.Until(deadline), func() (bool, error) {
 			resp, err = t.server.executionService.GetAssembledBlock(ctx, &executionproto.GetAssembledBlockRequest{
 				Id: payloadID,
@@ -212,19 +345,32 @@ func (t *testingImpl) BuildBlockV1(
 	}
 
 	response := &engine_types.GetPayloadResponse{
-		ExecutionPayload:  engine_types.ConvertPayloadFromRpc(data.ExecutionPayload),
-		BlockValue:        (*hexutil.Big)(gointerfaces.ConvertH256ToUint256Int(data.BlockValue).ToBig()),
-		BlobsBundle:       engine_types.ConvertBlobsFromRpc(data.BlobsBundle),
-		ExecutionRequests: executionRequests,
-		// ShouldOverrideBuilder is always false for the testing namespace (no MEV-boost context).
+		ExecutionPayload:      engine_types.ConvertPayloadFromRpc(data.ExecutionPayload),
+		BlockValue:            (*hexutil.Big)(gointerfaces.ConvertH256ToUint256Int(data.BlockValue).ToBig()),
+		BlobsBundle:           engine_types.ConvertBlobsFromRpc(data.BlobsBundle),
+		ExecutionRequests:     executionRequests,
 		ShouldOverrideBuilder: false,
 	}
 
-	// Override extra data if provided. Note: the BlockHash in ExecutionPayload reflects the
-	// originally built block; overriding ExtraData here means BlockHash will NOT match.
 	if extraData != nil {
 		response.ExecutionPayload.ExtraData = *extraData
 	}
 
 	return response, nil
+}
+
+// staticTxnProvider is a TxnProvider that yields a fixed transaction list exactly once,
+// then returns nil on every subsequent call. Used only by the testing_ namespace.
+type staticTxnProvider struct {
+	txns []types.Transaction
+	done atomic.Bool
+}
+
+func (s *staticTxnProvider) ProvideTxns(_ context.Context, _ ...txnprovider.ProvideOption) ([]types.Transaction, error) {
+	if !s.done.CompareAndSwap(false, true) {
+		return nil, nil
+	}
+	txns := s.txns
+	s.txns = nil // release for GC after handing off
+	return txns, nil
 }

--- a/execution/engineapi/testing_api_test.go
+++ b/execution/engineapi/testing_api_test.go
@@ -187,7 +187,7 @@ func makeParentHeader(timestamp uint64) (*types.Header, *executionproto.Header) 
 
 // newTestingAPI creates a testingImpl backed by a stub execution server
 // wrapped with direct.NewExecutionClientDirect.
-func newTestingAPI(cfg *chain.Config, stub *stubExecutionServer, enabled bool) TestingAPI {
+func newTestingAPI(cfg *chain.Config, stub *stubExecutionServer) TestingAPI {
 	srv := NewEngineServer(
 		log.New(),
 		cfg,
@@ -200,7 +200,7 @@ func newTestingAPI(cfg *chain.Config, stub *stubExecutionServer, enabled bool) T
 		0,     // fcuTimeout
 		0,     // maxReorgDepth
 	)
-	return NewTestingImpl(srv, enabled)
+	return NewTestingImpl(srv, log.New(), nil)
 }
 
 // validPayloadAttrs returns payload attributes valid for a post-Cancun chain
@@ -244,22 +244,10 @@ func TestBuildBlockV1(t *testing.T) {
 	parentHdr, parentRPC := makeParentHeader(parentTimestamp)
 	parentHash := parentHdr.Hash()
 
-	t.Run("disabled gate", func(t *testing.T) {
-		t.Parallel()
-		stub := &stubExecutionServer{}
-		api := newTestingAPI(allForksChainConfig(), stub, false)
-		resp, err := api.BuildBlockV1(context.Background(), parentHash, validPayloadAttrs(parentTimestamp), nil, nil)
-		require.Nil(t, resp)
-		require.Error(t, err)
-		var rpcErr *rpc.InvalidParamsError
-		require.ErrorAs(t, err, &rpcErr)
-		assert.Contains(t, rpcErr.Message, "testing namespace is disabled")
-	})
-
 	t.Run("nil payloadAttributes", func(t *testing.T) {
 		t.Parallel()
 		stub := &stubExecutionServer{}
-		api := newTestingAPI(allForksChainConfig(), stub, true)
+		api := newTestingAPI(allForksChainConfig(), stub)
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, nil, nil, nil)
 		require.Nil(t, resp)
 		require.Error(t, err)
@@ -268,17 +256,20 @@ func TestBuildBlockV1(t *testing.T) {
 		assert.Contains(t, rpcErr.Message, "payloadAttributes must not be null")
 	})
 
-	t.Run("explicit non-empty transaction list", func(t *testing.T) {
+	t.Run("explicit non-empty transaction list with invalid tx", func(t *testing.T) {
 		t.Parallel()
-		stub := &stubExecutionServer{}
-		api := newTestingAPI(allForksChainConfig(), stub, true)
-		txs := []hexutil.Bytes{{0x01, 0x02}}
+		_, rpcHeader := makeParentHeader(parentTimestamp)
+		stub := &stubExecutionServer{
+			getHeaderFunc: getHeaderReturning(parentHash, rpcHeader),
+		}
+		api := newTestingAPI(allForksChainConfig(), stub)
+		txs := []hexutil.Bytes{{0x01, 0x02}} // invalid RLP/tx encoding
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, validPayloadAttrs(parentTimestamp), &txs, nil)
 		require.Nil(t, resp)
 		require.Error(t, err)
 		var rpcErr *rpc.InvalidParamsError
 		require.ErrorAs(t, err, &rpcErr)
-		assert.Contains(t, rpcErr.Message, "explicit transaction list not yet supported")
+		assert.Contains(t, rpcErr.Message, "decode error")
 	})
 
 	t.Run("empty transaction list is allowed", func(t *testing.T) {
@@ -291,7 +282,7 @@ func TestBuildBlockV1(t *testing.T) {
 				return &executionproto.GetHeaderResponse{Header: nil}, nil
 			},
 		}
-		api := newTestingAPI(allForksChainConfig(), stub, true)
+		api := newTestingAPI(allForksChainConfig(), stub)
 		txs := []hexutil.Bytes{} // empty slice, not nil
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, validPayloadAttrs(parentTimestamp), &txs, nil)
 		require.Nil(t, resp)
@@ -309,7 +300,7 @@ func TestBuildBlockV1(t *testing.T) {
 				return &executionproto.GetHeaderResponse{Header: nil}, nil
 			},
 		}
-		api := newTestingAPI(allForksChainConfig(), stub, true)
+		api := newTestingAPI(allForksChainConfig(), stub)
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, validPayloadAttrs(parentTimestamp), nil, nil)
 		require.Nil(t, resp)
 		require.Error(t, err)
@@ -323,7 +314,7 @@ func TestBuildBlockV1(t *testing.T) {
 		stub := &stubExecutionServer{
 			getHeaderFunc: getHeaderReturning(parentHash, parentRPC),
 		}
-		api := newTestingAPI(allForksChainConfig(), stub, true)
+		api := newTestingAPI(allForksChainConfig(), stub)
 		attrs := validPayloadAttrs(parentTimestamp)
 		attrs.Timestamp = hexutil.Uint64(parentTimestamp) // equal, not greater
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, attrs, nil, nil)
@@ -339,7 +330,7 @@ func TestBuildBlockV1(t *testing.T) {
 		stub := &stubExecutionServer{
 			getHeaderFunc: getHeaderReturning(parentHash, parentRPC),
 		}
-		api := newTestingAPI(allForksChainConfig(), stub, true)
+		api := newTestingAPI(allForksChainConfig(), stub)
 		attrs := validPayloadAttrs(parentTimestamp)
 		attrs.Timestamp = hexutil.Uint64(parentTimestamp - 1) // less than parent
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, attrs, nil, nil)
@@ -355,7 +346,7 @@ func TestBuildBlockV1(t *testing.T) {
 		stub := &stubExecutionServer{
 			getHeaderFunc: getHeaderReturning(parentHash, parentRPC),
 		}
-		api := newTestingAPI(allForksChainConfig(), stub, true)
+		api := newTestingAPI(allForksChainConfig(), stub)
 		attrs := validPayloadAttrs(parentTimestamp)
 		attrs.ParentBeaconBlockRoot = nil // required for Cancun+
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, attrs, nil, nil)
@@ -372,7 +363,7 @@ func TestBuildBlockV1(t *testing.T) {
 			getHeaderFunc: getHeaderReturning(parentHash, parentRPC),
 		}
 		// Use a pre-Cancun config (Shanghai only).
-		api := newTestingAPI(preCancunChainConfig(), stub, true)
+		api := newTestingAPI(preCancunChainConfig(), stub)
 		attrs := validPayloadAttrs(parentTimestamp)
 		// attrs already has ParentBeaconBlockRoot set, which is invalid pre-Cancun.
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, attrs, nil, nil)
@@ -401,7 +392,7 @@ func TestBuildBlockV1(t *testing.T) {
 				}, nil
 			},
 		}
-		api := newTestingAPI(shortSlotCfg, stub, true)
+		api := newTestingAPI(shortSlotCfg, stub)
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, validPayloadAttrs(parentTimestamp), nil, nil)
 		require.Nil(t, resp)
 		require.Error(t, err)
@@ -424,7 +415,7 @@ func TestBuildBlockV1(t *testing.T) {
 				}, nil
 			},
 		}
-		api := newTestingAPI(shortSlotCfg, stub, true)
+		api := newTestingAPI(shortSlotCfg, stub)
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, validPayloadAttrs(parentTimestamp), nil, nil)
 		require.Nil(t, resp)
 		require.Error(t, err)
@@ -445,7 +436,7 @@ func TestBuildBlockV1(t *testing.T) {
 				}, nil
 			},
 		}
-		api := newTestingAPI(allForksChainConfig(), stub, true)
+		api := newTestingAPI(allForksChainConfig(), stub)
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, validPayloadAttrs(parentTimestamp), nil, nil)
 		require.Nil(t, resp)
 		require.Error(t, err)
@@ -500,7 +491,7 @@ func TestBuildBlockV1(t *testing.T) {
 				}, nil
 			},
 		}
-		api := newTestingAPI(allForksChainConfig(), stub, true)
+		api := newTestingAPI(allForksChainConfig(), stub)
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, validPayloadAttrs(parentTimestamp), nil, nil)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
@@ -551,7 +542,7 @@ func TestBuildBlockV1(t *testing.T) {
 				}, nil
 			},
 		}
-		api := newTestingAPI(allForksChainConfig(), stub, true)
+		api := newTestingAPI(allForksChainConfig(), stub)
 		overrideData := hexutil.Bytes("overridden-extra")
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, validPayloadAttrs(parentTimestamp), nil, &overrideData)
 		require.NoError(t, err)
@@ -566,7 +557,7 @@ func TestBuildBlockV1(t *testing.T) {
 			getHeaderFunc: getHeaderReturning(parentHash, parentRPC),
 		}
 		// Use pre-Cancun (Shanghai-only) config.
-		api := newTestingAPI(preCancunChainConfig(), stub, true)
+		api := newTestingAPI(preCancunChainConfig(), stub)
 		attrs := &engine_types.PayloadAttributes{
 			Timestamp:             hexutil.Uint64(parentTimestamp + 1),
 			PrevRandao:            common.Hash{0xaa},
@@ -588,7 +579,7 @@ func TestBuildBlockV1(t *testing.T) {
 			getHeaderFunc: getHeaderReturning(parentHash, parentRPC),
 		}
 		// Use pre-Shanghai config.
-		api := newTestingAPI(preShanghaiChainConfig(), stub, true)
+		api := newTestingAPI(preShanghaiChainConfig(), stub)
 		attrs := &engine_types.PayloadAttributes{
 			Timestamp:             hexutil.Uint64(parentTimestamp + 1),
 			PrevRandao:            common.Hash{0xaa},

--- a/execution/execmodule/block_building.go
+++ b/execution/execmodule/block_building.go
@@ -108,6 +108,31 @@ func (e *ExecModule) AssembleBlock(ctx context.Context, req *executionproto.Asse
 	}, nil
 }
 
+// AssembleBlockWithParams starts building a block with the given parameters directly (no proto
+// conversion). Unlike AssembleBlock, it skips the dedup check so that a caller can inject a
+// CustomTxnProvider even when the other parameters match a previous request.
+func (e *ExecModule) AssembleBlockWithParams(ctx context.Context, params *builder.Parameters) (payloadID uint64, busy bool, err error) {
+	if !e.semaphore.TryAcquire(1) {
+		return 0, true, nil
+	}
+	defer e.semaphore.Release(1)
+
+	if err := e.checkWithdrawalsPresence(params.Timestamp, params.Withdrawals); err != nil {
+		return 0, false, err
+	}
+
+	e.evictOldBuilders()
+
+	e.nextPayloadId++
+	params.PayloadId = e.nextPayloadId
+	e.lastParameters = params
+
+	e.builders[e.nextPayloadId] = builder.NewBlockBuilder(e.builderFunc, params, e.config.SecondsPerSlot()/4)
+	e.logger.Info("[ForkChoiceUpdated] BlockBuilder added", "payload", e.nextPayloadId)
+
+	return e.nextPayloadId, false, nil
+}
+
 // The expected value to be received by the feeRecipient in wei
 func blockValue(br *types.BlockWithReceipts, baseFee *uint256.Int) *uint256.Int {
 	blockValue := uint256.NewInt(0)

--- a/execution/tests/blockchain_test.go
+++ b/execution/tests/blockchain_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/prune"
 	"github.com/erigontech/erigon/db/rawdb"
-	"github.com/erigontech/erigon/execution/cache"
 	libchain "github.com/erigontech/erigon/execution/chain"
 	chainspec "github.com/erigontech/erigon/execution/chain/spec"
 	"github.com/erigontech/erigon/execution/execmodule/execmoduletester"
@@ -2355,68 +2354,4 @@ func TestEIP1559Transition(t *testing.T) {
 		return nil
 	})
 	require.NoError(t, err)
-}
-
-// Regression test for https://github.com/erigontech/erigon/issues/20169
-//
-// Tests the SharedDomains StateCache directly, reproducing the exact
-// sequence that caused Hoodi nodes to get stuck:
-//
-//  1. DomainPut writes key=0x42 (populates stateCache with 0x42)
-//  2. Flush + ClearRam (persists to DB, clears mem buffer)
-//  3. DomainDel deletes the key (stateCache.Delete removes entry)
-//  4. Flush + ClearRam (persists deletion to DB, clears mem buffer)
-//  5. GetLatest reads the key — should return nil (deleted)
-//
-// With the bug, step 3's DomainDel calls stateCache.Delete (removing
-// the entry) but step 4's Flush path calls GetLatest which reads nil
-// from mem buffer and does stateCache.Put(nil) → which ALSO deletes
-// from cache. After ClearRam, the mem buffer is empty and the stateCache
-// has no entry. Step 5's GetLatest falls through to the DB, which
-// returns nil (correct, since Flush persisted the deletion).
-//
-// However, if the stateCache was populated between step 2 and step 3
-// by a GetLatest (which caches 0x42 from DB), and the DomainDel's
-// stateCache.Delete removes it, and then stateCache.Put(nil) removes
-// the deletion sentinel, the cache has NO entry for the key. If the
-// DB read in step 5 somehow returns the stale value (e.g. due to
-// transaction isolation), the stale value is returned.
-//
-// This test exercises the StateCache at the cache level to verify
-// that Put(nil) correctly records the deletion as a cache hit.
-func TestStateCacheDeletedStorageSSTOREGas(t *testing.T) {
-	t.Parallel()
-
-	c := cache.NewStateCache(100, 100, 100, 100, 100)
-
-	key := make([]byte, 52) // addr(20) + slot(32)
-	key[0] = 0x1d
-	key[51] = 0xa2
-
-	value := []byte{0x42}
-
-	// Step 1: Put a value (simulates DomainPut caching a storage value)
-	c.Put(kv.StorageDomain, key, value)
-	v, ok := c.Get(kv.StorageDomain, key)
-	require.True(t, ok, "after Put: should be cached")
-	require.Equal(t, value, v)
-
-	// Step 2: Delete the key (simulates DomainDel)
-	c.Delete(kv.StorageDomain, key)
-
-	// Step 3: Put nil (simulates GetLatest caching a deletion from mem buffer)
-	// This is the exact sequence in SharedDomains.GetLatest:
-	//   v, step, ok := sd.mem.GetLatest(domain, k)  // ok=true, v=nil
-	//   sd.stateCache.Put(domain, k, v)              // v=nil
-	c.Put(kv.StorageDomain, key, nil)
-
-	// Step 4: Get must return a cache HIT with empty value.
-	// This is the critical assertion: with the bug, Get returns (nil, false)
-	// meaning "not in cache", so the caller falls through to the DB.
-	v, ok = c.Get(kv.StorageDomain, key)
-	require.True(t, ok,
-		"after Delete+Put(nil): Get must return (nil, true) — cached as deleted. "+
-			"Returning false causes the caller to read stale data from the DB, "+
-			"which is the root cause of the Hoodi gas mismatch (#20169).")
-	require.Empty(t, v, "cached value for a deleted key must be empty")
 }

--- a/execution/tests/blockchain_test.go
+++ b/execution/tests/blockchain_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/prune"
 	"github.com/erigontech/erigon/db/rawdb"
+	"github.com/erigontech/erigon/execution/cache"
 	libchain "github.com/erigontech/erigon/execution/chain"
 	chainspec "github.com/erigontech/erigon/execution/chain/spec"
 	"github.com/erigontech/erigon/execution/execmodule/execmoduletester"
@@ -2354,4 +2355,68 @@ func TestEIP1559Transition(t *testing.T) {
 		return nil
 	})
 	require.NoError(t, err)
+}
+
+// Regression test for https://github.com/erigontech/erigon/issues/20169
+//
+// Tests the SharedDomains StateCache directly, reproducing the exact
+// sequence that caused Hoodi nodes to get stuck:
+//
+//  1. DomainPut writes key=0x42 (populates stateCache with 0x42)
+//  2. Flush + ClearRam (persists to DB, clears mem buffer)
+//  3. DomainDel deletes the key (stateCache.Delete removes entry)
+//  4. Flush + ClearRam (persists deletion to DB, clears mem buffer)
+//  5. GetLatest reads the key — should return nil (deleted)
+//
+// With the bug, step 3's DomainDel calls stateCache.Delete (removing
+// the entry) but step 4's Flush path calls GetLatest which reads nil
+// from mem buffer and does stateCache.Put(nil) → which ALSO deletes
+// from cache. After ClearRam, the mem buffer is empty and the stateCache
+// has no entry. Step 5's GetLatest falls through to the DB, which
+// returns nil (correct, since Flush persisted the deletion).
+//
+// However, if the stateCache was populated between step 2 and step 3
+// by a GetLatest (which caches 0x42 from DB), and the DomainDel's
+// stateCache.Delete removes it, and then stateCache.Put(nil) removes
+// the deletion sentinel, the cache has NO entry for the key. If the
+// DB read in step 5 somehow returns the stale value (e.g. due to
+// transaction isolation), the stale value is returned.
+//
+// This test exercises the StateCache at the cache level to verify
+// that Put(nil) correctly records the deletion as a cache hit.
+func TestStateCacheDeletedStorageSSTOREGas(t *testing.T) {
+	t.Parallel()
+
+	c := cache.NewStateCache(100, 100, 100, 100, 100)
+
+	key := make([]byte, 52) // addr(20) + slot(32)
+	key[0] = 0x1d
+	key[51] = 0xa2
+
+	value := []byte{0x42}
+
+	// Step 1: Put a value (simulates DomainPut caching a storage value)
+	c.Put(kv.StorageDomain, key, value)
+	v, ok := c.Get(kv.StorageDomain, key)
+	require.True(t, ok, "after Put: should be cached")
+	require.Equal(t, value, v)
+
+	// Step 2: Delete the key (simulates DomainDel)
+	c.Delete(kv.StorageDomain, key)
+
+	// Step 3: Put nil (simulates GetLatest caching a deletion from mem buffer)
+	// This is the exact sequence in SharedDomains.GetLatest:
+	//   v, step, ok := sd.mem.GetLatest(domain, k)  // ok=true, v=nil
+	//   sd.stateCache.Put(domain, k, v)              // v=nil
+	c.Put(kv.StorageDomain, key, nil)
+
+	// Step 4: Get must return a cache HIT with empty value.
+	// This is the critical assertion: with the bug, Get returns (nil, false)
+	// meaning "not in cache", so the caller falls through to the DB.
+	v, ok = c.Get(kv.StorageDomain, key)
+	require.True(t, ok,
+		"after Delete+Put(nil): Get must return (nil, true) — cached as deleted. "+
+			"Returning false causes the caller to read stale data from the DB, "+
+			"which is the root cause of the Hoodi gas mismatch (#20169).")
+	require.Empty(t, v, "cached value for a deleted key must be empty")
 }

--- a/node/direct/execution_client.go
+++ b/node/direct/execution_client.go
@@ -38,6 +38,12 @@ func (s *ExecutionClientDirect) AssembleBlock(ctx context.Context, in *execution
 	return s.server.AssembleBlock(ctx, in)
 }
 
+// Server returns the underlying ExecutionServer, allowing callers to type-assert it to
+// concrete types that provide methods beyond the proto interface (e.g. AssembleBlockWithParams).
+func (s *ExecutionClientDirect) Server() executionproto.ExecutionServer {
+	return s.server
+}
+
 func (s *ExecutionClientDirect) GetBodiesByHashes(ctx context.Context, in *executionproto.GetBodiesByHashesRequest, opts ...grpc.CallOption) (*executionproto.GetBodiesBatchResponse, error) {
 	return s.server.GetBodiesByHashes(ctx, in)
 }

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -1117,7 +1117,12 @@ func (s *Ethereum) Init(stack *node.Node, config *ethconfig.Config, chainConfig 
 		}
 	}
 
-	s.apiList = jsonrpc.APIList(chainKv, s.ethRpcClient, s.txPoolRpcClient, s.miningRpcClient, s.rpcFilters, s.rpcDaemonStateCache, blockReader, &httpRpcCfg, s.engine, s.logger, s.polygonBridge, s.heimdallService)
+	var testingEntry *rpc.API
+	if slices.Contains(httpRpcCfg.API, "testing") {
+		entry := engineapi.NewTestingRPCEntry(s.engineBackendRPC, s.logger, s.chainDB)
+		testingEntry = &entry
+	}
+	s.apiList = jsonrpc.APIList(chainKv, s.ethRpcClient, s.txPoolRpcClient, s.miningRpcClient, s.rpcFilters, s.rpcDaemonStateCache, blockReader, &httpRpcCfg, s.engine, s.logger, s.polygonBridge, s.heimdallService, testingEntry)
 
 	s.bgComponentsEg.Go(func() error {
 		err := rpcdaemoncli.StartRpcServer(ctx, &httpRpcCfg, s.apiList, s.logger)

--- a/rpc/ethapi/api.go
+++ b/rpc/ethapi/api.go
@@ -647,8 +647,8 @@ func NewRPCTransaction(txn types.Transaction, blockHash common.Hash, blockTime u
 	return result
 }
 
-func computeGasPrice(txn types.Transaction, blockHash common.Hash, baseFee *uint256.Int) *hexutil.Big {
-	if baseFee != nil && blockHash != (common.Hash{}) {
+func computeGasPrice(txn types.Transaction, _ common.Hash, baseFee *uint256.Int) *hexutil.Big {
+	if baseFee != nil {
 		// price = min(tip + baseFee, gasFeeCap)
 		price := u256.Min(u256.Add(*txn.GetTipCap(), *baseFee), *txn.GetFeeCap())
 		return (*hexutil.Big)(price.ToBig())

--- a/rpc/jsonrpc/daemon.go
+++ b/rpc/jsonrpc/daemon.go
@@ -48,6 +48,7 @@ func APIList(db kv.TemporalRoDB, eth rpchelper.ApiBackend, txPool txpoolproto.Tx
 	filters *rpchelper.Filters, stateCache kvcache.Cache,
 	blockReader services.FullBlockReader, cfg *httpcfg.HttpCfg, engine rules.EngineReader,
 	logger log.Logger, bridgeReader bridgeReader, spanProducersReader spanProducersReader,
+	testingEntry *rpc.API,
 ) (list []rpc.API) {
 	base := NewBaseApi(filters, stateCache, blockReader, cfg.WithDatadir, cfg.EvmCallTimeout, engine, cfg.Dirs, bridgeReader, cfg.BlockRangeLimit, cfg.GetLogsMaxResults)
 	ethImpl := NewEthAPI(base, db, eth, txPool, mining, NewEthApiConfig(cfg), logger)
@@ -195,6 +196,11 @@ func APIList(db kv.TemporalRoDB, eth rpchelper.ApiBackend, txPool txpoolproto.Tx
 				Service:   OverlayAPI(overlayImpl),
 				Version:   "1.0",
 			})
+		case "testing":
+			if testingEntry != nil {
+				logger.Warn("[HTTP API] testing_ RPC namespace is ENABLED — do not use on production networks")
+				list = append(list, *testingEntry)
+			}
 		}
 	}
 

--- a/rpc/jsonrpc/txpool_api.go
+++ b/rpc/jsonrpc/txpool_api.go
@@ -80,6 +80,11 @@ func (api *TxPoolAPIImpl) Content(ctx context.Context) (map[string]map[string]ma
 		if err != nil {
 			return nil, fmt.Errorf("decoding transaction from: %x: %w", reply.Txs[i].RlpTx, err)
 		}
+		// Blob transactions (type 3) are excluded from txpool_content, matching Geth and Nethermind behaviour.
+		// Geth's BlobPool.Content() returns empty maps; Nethermind queries only the standard pool.
+		if txn.Type() == types.BlobTxType {
+			continue
+		}
 		addr := gointerfaces.ConvertH160toAddress(reply.Txs[i].Sender)
 		switch reply.Txs[i].TxnType {
 		case txpoolproto.AllReply_PENDING:
@@ -138,6 +143,11 @@ func (api *TxPoolAPIImpl) ContentFrom(ctx context.Context, addr common.Address) 
 		}
 		sender := gointerfaces.ConvertH160toAddress(reply.Txs[i].Sender)
 		if sender != addr {
+			continue
+		}
+		// Blob transactions (type 3) are excluded from txpool_content, matching Geth and Nethermind behaviour.
+		// Geth's BlobPool.Content() returns empty maps; Nethermind queries only the standard pool.
+		if txn.Type() == types.BlobTxType {
 			continue
 		}
 

--- a/rpc/jsonrpc/txpool_api.go
+++ b/rpc/jsonrpc/txpool_api.go
@@ -70,12 +70,10 @@ func (api *TxPoolAPIImpl) Content(ctx context.Context) (map[string]map[string]ma
 
 	content := map[string]map[string]map[string]*ethapi.RPCTransaction{
 		"pending": make(map[string]map[string]*ethapi.RPCTransaction),
-		"baseFee": make(map[string]map[string]*ethapi.RPCTransaction),
 		"queued":  make(map[string]map[string]*ethapi.RPCTransaction),
 	}
 
 	pending := make(map[common.Address][]types.Transaction, 8)
-	baseFee := make(map[common.Address][]types.Transaction, 8)
 	queued := make(map[common.Address][]types.Transaction, 8)
 	for i := range reply.Txs {
 		txn, err := types.DecodeWrappedTransaction(reply.Txs[i].RlpTx)
@@ -89,11 +87,6 @@ func (api *TxPoolAPIImpl) Content(ctx context.Context) (map[string]map[string]ma
 				pending[addr] = make([]types.Transaction, 0, 4)
 			}
 			pending[addr] = append(pending[addr], txn)
-		case txpoolproto.AllReply_BASE_FEE:
-			if _, ok := baseFee[addr]; !ok {
-				baseFee[addr] = make([]types.Transaction, 0, 4)
-			}
-			baseFee[addr] = append(baseFee[addr], txn)
 		case txpoolproto.AllReply_QUEUED:
 			if _, ok := queued[addr]; !ok {
 				queued[addr] = make([]types.Transaction, 0, 4)
@@ -116,15 +109,9 @@ func (api *TxPoolAPIImpl) Content(ctx context.Context) (map[string]map[string]ma
 	if curHeader == nil {
 		return nil, nil
 	}
-	// Flatten the pending transactions
 	for account, txs := range pending {
 		content["pending"][account.Hex()] = flattenTxs(txs, curHeader, cc)
 	}
-	// Flatten the baseFee transactions
-	for account, txs := range baseFee {
-		content["baseFee"][account.Hex()] = flattenTxs(txs, curHeader, cc)
-	}
-	// Flatten the queued transactions
 	for account, txs := range queued {
 		content["queued"][account.Hex()] = flattenTxs(txs, curHeader, cc)
 	}
@@ -139,12 +126,10 @@ func (api *TxPoolAPIImpl) ContentFrom(ctx context.Context, addr common.Address) 
 
 	content := map[string]map[string]*ethapi.RPCTransaction{
 		"pending": make(map[string]*ethapi.RPCTransaction),
-		"baseFee": make(map[string]*ethapi.RPCTransaction),
 		"queued":  make(map[string]*ethapi.RPCTransaction),
 	}
 
 	pending := make([]types.Transaction, 0, 4)
-	baseFee := make([]types.Transaction, 0, 4)
 	queued := make([]types.Transaction, 0, 4)
 	for i := range reply.Txs {
 		txn, err := types.DecodeWrappedTransaction(reply.Txs[i].RlpTx)
@@ -159,8 +144,6 @@ func (api *TxPoolAPIImpl) ContentFrom(ctx context.Context, addr common.Address) 
 		switch reply.Txs[i].TxnType {
 		case txpoolproto.AllReply_PENDING:
 			pending = append(pending, txn)
-		case txpoolproto.AllReply_BASE_FEE:
-			baseFee = append(baseFee, txn)
 		case txpoolproto.AllReply_QUEUED:
 			queued = append(queued, txn)
 		}
@@ -180,11 +163,7 @@ func (api *TxPoolAPIImpl) ContentFrom(ctx context.Context, addr common.Address) 
 	if curHeader == nil {
 		return nil, nil
 	}
-	// Flatten the pending transactions
 	content["pending"] = flattenTxs(pending, curHeader, cc)
-	// Flatten the baseFee transactions
-	content["baseFee"] = flattenTxs(baseFee, curHeader, cc)
-	// Flatten the queued transactions
 	content["queued"] = flattenTxs(queued, curHeader, cc)
 	return content, nil
 }
@@ -197,7 +176,6 @@ func (api *TxPoolAPIImpl) Status(ctx context.Context) (map[string]hexutil.Uint, 
 	}
 	return map[string]hexutil.Uint{
 		"pending": hexutil.Uint(reply.PendingCount),
-		"baseFee": hexutil.Uint(reply.BaseFeeCount),
 		"queued":  hexutil.Uint(reply.QueuedCount),
 	}, nil
 }

--- a/rpc/jsonrpc/txpool_api_test.go
+++ b/rpc/jsonrpc/txpool_api_test.go
@@ -74,7 +74,7 @@ func TestTxPoolContent(t *testing.T) {
 
 	status, err := api.Status(ctx)
 	require.NoError(err)
-	require.Len(status, 3)
+	require.Len(status, 2)
 	require.Equal(status["pending"], hexutil.Uint(1))
 	require.Equal(status["queued"], hexutil.Uint(0))
 }


### PR DESCRIPTION
Cherry-picks to `performance` branch for issue #20169 (gas mismatches / stale reads):

- #20265 — execution/cache: fix StateCache dropping deleted storage keys, causing stale reads
- #20498 — clean up PR 20265: remove misleading #20169 attribution from StateCache tests
- #20445 — db/state: fix collation/pruning race and unwind visibility in BuildFilesInBackground

Hive rpc-compat fixes:

- #20698 — fix testing_buildBlockV1 hive test failures (`SlotNumber` omitempty)
- #20699 — fix txpool_content/contentFrom/status hive test failures (remove baseFee bucket)
- #20719 — txpool_content*() filter BlobTx as nethermind and Geth