### PR TITLE
p2p/sentry, node/direct: bound fan-out stream buffers to prevent OOM

### DIFF
--- a/node/direct/sentry_client.go
+++ b/node/direct/sentry_client.go
@@ -246,7 +246,7 @@ func (c *SentryClientDirect) Messages(ctx context.Context, in *sentryproto.Messa
 	in = &sentryproto.MessagesRequest{
 		Ids: filterIds(in.Ids, allProtocols),
 	}
-	ch := make(chan *inboundMessageReply, 16384)
+	ch := make(chan *inboundMessageReply, libsentry.MessagesQueueSize)
 	streamServer := &SentryMessagesStreamS{ch: ch, ctx: ctx}
 	go func() {
 		defer close(ch)
@@ -269,6 +269,7 @@ type SentryMessagesStreamS struct {
 
 func (s *SentryMessagesStreamS) Send(m *sentryproto.InboundMessage) error {
 	s.ch <- &inboundMessageReply{r: m}
+	libsentry.EvictOldestIfHalfFull(s.ch)
 	return nil
 }
 
@@ -311,7 +312,7 @@ func (c *SentryMessagesStreamC) RecvMsg(anyMessage any) error {
 // -- start Peers
 
 func (c *SentryClientDirect) PeerEvents(ctx context.Context, in *sentryproto.PeerEventsRequest, opts ...grpc.CallOption) (sentryproto.Sentry_PeerEventsClient, error) {
-	ch := make(chan *peersReply, 16384)
+	ch := make(chan *peersReply, libsentry.MessagesQueueSize)
 	streamServer := &SentryPeersStreamS{ch: ch, ctx: ctx}
 	go func() {
 		defer close(ch)
@@ -350,6 +351,7 @@ type SentryPeersStreamS struct {
 
 func (s *SentryPeersStreamS) Send(m *sentryproto.PeerEvent) error {
 	s.ch <- &peersReply{r: m}
+	libsentry.EvictOldestIfHalfFull(s.ch)
 	return nil
 }
 

--- a/node/direct/sentry_client_test.go
+++ b/node/direct/sentry_client_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package direct
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/node/gointerfaces/sentryproto"
+	"github.com/erigontech/erigon/p2p/sentry/libsentry"
+)
+
+// Flooding Send() with no consumer must not grow the buffer beyond capacity
+// (the pre-fix 16384 chan would hold ~160 GB of peer-controlled payload at
+// the eth 10 MB limit). Eviction must drop oldest entries, preserving the
+// freshest.
+func TestSentryMessagesStreamS_SendEvictsWhenConsumerSlow(t *testing.T) {
+	ch := make(chan *inboundMessageReply, libsentry.MessagesQueueSize)
+	s := &SentryMessagesStreamS{ch: ch, ctx: t.Context()}
+
+	const flood = libsentry.MessagesQueueSize * 10
+	for i := range flood {
+		data := make([]byte, 4)
+		binary.LittleEndian.PutUint32(data, uint32(i))
+		require.NoError(t, s.Send(&sentryproto.InboundMessage{Data: data}))
+	}
+
+	require.LessOrEqual(t, len(ch), cap(ch), "buffer must not exceed capacity")
+	require.Less(t, len(ch), flood, "eviction must have dropped entries")
+
+	var last uint32
+	for len(ch) > 0 {
+		r := <-ch
+		require.NotNil(t, r)
+		require.NotNil(t, r.r)
+		last = binary.LittleEndian.Uint32(r.r.Data)
+	}
+	assert.Equal(t, uint32(flood-1), last,
+		"eviction drops from the front; the most recent Send must remain queued")
+}
+
+func TestSentryPeersStreamS_SendEvictsWhenConsumerSlow(t *testing.T) {
+	ch := make(chan *peersReply, libsentry.MessagesQueueSize)
+	s := &SentryPeersStreamS{ch: ch, ctx: t.Context()}
+
+	const flood = libsentry.MessagesQueueSize * 10
+	for range flood {
+		require.NoError(t, s.Send(&sentryproto.PeerEvent{}))
+	}
+
+	require.LessOrEqual(t, len(ch), cap(ch))
+	require.Less(t, len(ch), flood)
+}

--- a/p2p/sentry/libsentry/queue.go
+++ b/p2p/sentry/libsentry/queue.go
@@ -1,0 +1,46 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package libsentry
+
+// MessagesQueueSize bounds the per-subscriber channels that fan out inbound
+// P2P messages and peer events from a sentry to its stream consumers. Kept
+// small so that peer-driven traffic cannot push the process toward OOM via
+// the multi-MB ethp2p message size limit; paired with EvictOldestIfHalfFull
+// at fan-out writes so fresh messages are preferred when consumers fall
+// behind.
+const MessagesQueueSize = 1024
+
+// EvictOldestIfHalfFull drops up to cap(ch)/4 oldest items from ch when it
+// is more than half full. Non-blocking: returns as soon as the drain target
+// is reached or ch becomes empty.
+//
+// Intended to be called right after a successful send on fan-out channels,
+// mirroring the eviction policy used by the per-subscriber Messages
+// channels in p2p/sentry.
+func EvictOldestIfHalfFull[T any](ch chan T) {
+	if len(ch) <= cap(ch)/2 {
+		return
+	}
+	drain := cap(ch) / 4
+	for range drain {
+		select {
+		case <-ch:
+		default:
+			return
+		}
+	}
+}

--- a/p2p/sentry/libsentry/queue_test.go
+++ b/p2p/sentry/libsentry/queue_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package libsentry_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/p2p/sentry/libsentry"
+)
+
+func TestEvictOldestIfHalfFull_NoopBelowThreshold(t *testing.T) {
+	ch := make(chan int, 1024)
+	for i := range 512 {
+		ch <- i
+	}
+	libsentry.EvictOldestIfHalfFull(ch)
+	assert.Equal(t, 512, len(ch), "at exactly half capacity eviction must not run")
+}
+
+func TestEvictOldestIfHalfFull_DropsQuarterFromOldest(t *testing.T) {
+	ch := make(chan int, 1024)
+	for i := range 600 {
+		ch <- i
+	}
+	libsentry.EvictOldestIfHalfFull(ch)
+	// cap/4 = 256 drained; 600 - 256 = 344 remain.
+	assert.Equal(t, 344, len(ch))
+	// Drop is from the front of the FIFO, so the oldest (0..255) are gone and
+	// the freshest (599) is still queued.
+	first := <-ch
+	assert.Equal(t, 256, first)
+	var last int
+	for len(ch) > 0 {
+		last = <-ch
+	}
+	assert.Equal(t, 599, last)
+}
+
+func TestEvictOldestIfHalfFull_DrainStopsWhenEmpty(t *testing.T) {
+	// Small cap to make eviction target larger than buffer contents.
+	ch := make(chan int, 4)
+	ch <- 0
+	ch <- 1
+	ch <- 2
+	// len=3, cap=4, cap/2=2, len>cap/2 → eviction runs; cap/4=1 drain target.
+	libsentry.EvictOldestIfHalfFull(ch)
+	require.Equal(t, 2, len(ch))
+	assert.Equal(t, 1, <-ch)
+	assert.Equal(t, 2, <-ch)
+}

--- a/p2p/sentry/libsentry/sentrymultiplexer.go
+++ b/p2p/sentry/libsentry/sentrymultiplexer.go
@@ -453,6 +453,7 @@ type SentryStreamS[T protoreflect.ProtoMessage] struct {
 
 func (s *SentryStreamS[T]) Send(m T) error {
 	s.Ch <- StreamReply[T]{R: m}
+	EvictOldestIfHalfFull(s.Ch)
 	return nil
 }
 
@@ -503,7 +504,7 @@ func (c *SentryStreamC[T]) RecvMsg(anyMessage any) error {
 func (m *sentryMultiplexer) Messages(ctx context.Context, in *sentryproto.MessagesRequest, opts ...grpc.CallOption) (sentryproto.Sentry_MessagesClient, error) {
 	g, gctx := errgroup.WithContext(ctx)
 
-	ch := make(chan StreamReply[*sentryproto.InboundMessage], 16384)
+	ch := make(chan StreamReply[*sentryproto.InboundMessage], MessagesQueueSize)
 	streamServer := &SentryStreamS[*sentryproto.InboundMessage]{Ch: ch, Ctx: ctx}
 
 	go func() {
@@ -682,7 +683,7 @@ func (m *sentryMultiplexer) PeerById(ctx context.Context, in *sentryproto.PeerBy
 func (m *sentryMultiplexer) PeerEvents(ctx context.Context, in *sentryproto.PeerEventsRequest, opts ...grpc.CallOption) (sentryproto.Sentry_PeerEventsClient, error) {
 	g, gctx := errgroup.WithContext(ctx)
 
-	ch := make(chan StreamReply[*sentryproto.PeerEvent], 16384)
+	ch := make(chan StreamReply[*sentryproto.PeerEvent], MessagesQueueSize)
 	streamServer := &SentryStreamS[*sentryproto.PeerEvent]{Ch: ch, Ctx: ctx}
 
 	go func() {

--- a/p2p/sentry/sentry_grpc_server.go
+++ b/p2p/sentry/sentry_grpc_server.go
@@ -57,6 +57,7 @@ import (
 	"github.com/erigontech/erigon/p2p/enode"
 	"github.com/erigontech/erigon/p2p/protocols/eth"
 	"github.com/erigontech/erigon/p2p/protocols/wit"
+	"github.com/erigontech/erigon/p2p/sentry/libsentry"
 
 	_ "github.com/erigontech/erigon/polygon/chain" // Register Polygon chains
 )
@@ -1529,15 +1530,10 @@ func (ss *GrpcServer) send(msgID sentryproto.MessageId, peerID [64]byte, b []byt
 	for i := range ss.messageStreams[msgID] {
 		ch := ss.messageStreams[msgID][i]
 		ch <- req
-		if len(ch) > MessagesQueueSize/2 {
+		before := len(ch)
+		libsentry.EvictOldestIfHalfFull(ch)
+		if before > cap(ch)/2 {
 			ss.logger.Debug("[sentry] consuming is slow, drop 50% of old messages", "msgID", msgID.String())
-			// evict old messages from channel
-			for j := 0; j < MessagesQueueSize/4; j++ {
-				select {
-				case <-ch:
-				default:
-				}
-			}
 		}
 	}
 }
@@ -1576,10 +1572,9 @@ func (ss *GrpcServer) addMessagesStream(ids []sentryproto.MessageId, ch chan *se
 	}
 }
 
-const MessagesQueueSize = 1024 // one such queue per client of .Messages stream
 func (ss *GrpcServer) Messages(req *sentryproto.MessagesRequest, server sentryproto.Sentry_MessagesServer) error {
 	ss.logger.Trace("[Messages] new subscriber", "to", req.Ids)
-	ch := make(chan *sentryproto.InboundMessage, MessagesQueueSize)
+	ch := make(chan *sentryproto.InboundMessage, libsentry.MessagesQueueSize)
 	defer close(ch)
 	clean := ss.addMessagesStream(req.Ids, ch)
 	defer clean()

--- a/p2p/sentry/sentry_grpc_server.go
+++ b/p2p/sentry/sentry_grpc_server.go
@@ -1533,7 +1533,7 @@ func (ss *GrpcServer) send(msgID sentryproto.MessageId, peerID [64]byte, b []byt
 		before := len(ch)
 		libsentry.EvictOldestIfHalfFull(ch)
 		if before > cap(ch)/2 {
-			ss.logger.Debug("[sentry] consuming is slow, drop 50% of old messages", "msgID", msgID.String())
+			ss.logger.Debug("[sentry] consuming is slow, drop oldest 25% of messages", "msgID", msgID.String())
 		}
 	}
 }

--- a/p2p/sentry/sentrymultiplexer_test.go
+++ b/p2p/sentry/sentrymultiplexer_test.go
@@ -238,7 +238,7 @@ func TestMessages(t *testing.T) {
 		client := newClient(ctrl, i, nil)
 		client.EXPECT().Messages(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 			func(ctx context.Context, in *sentryproto.MessagesRequest, opts ...grpc.CallOption) (sentryproto.Sentry_MessagesClient, error) {
-				ch := make(chan libsentry.StreamReply[*sentryproto.InboundMessage], 16384)
+				ch := make(chan libsentry.StreamReply[*sentryproto.InboundMessage], libsentry.MessagesQueueSize)
 				streamServer := &libsentry.SentryStreamS[*sentryproto.InboundMessage]{Ch: ch, Ctx: ctx}
 
 				go func() {
@@ -299,7 +299,7 @@ func TestPeers(t *testing.T) {
 			})
 		client.EXPECT().PeerEvents(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 			func(ctx context.Context, in *sentryproto.PeerEventsRequest, opts ...grpc.CallOption) (sentryproto.Sentry_PeerEventsClient, error) {
-				ch := make(chan libsentry.StreamReply[*sentryproto.PeerEvent], 16384)
+				ch := make(chan libsentry.StreamReply[*sentryproto.PeerEvent], libsentry.MessagesQueueSize)
 				streamServer := &libsentry.SentryStreamS[*sentryproto.PeerEvent]{Ch: ch, Ctx: ctx}
 
 				go func() {


### PR DESCRIPTION
Closes ethereum-bounty/erigon#5

## Summary

Fixes the OOM reported at ethereum-bounty/erigon#5 (private).
`SentryClientDirect` (the in-process sentry client shim) and
`sentryMultiplexer` each allocated a 16384-deep channel per subscriber
to forward inbound P2P messages, with no eviction. Against the eth/68–70
10 MB message cap, a peer using the `ethereum/p2p-tests` stress harness
can saturate those buffers with ~160 GB of in-flight payload per
subscriber and push the process toward OOM.

### Flow (pre-fix)

```
peer → GrpcServer.send()              [chan 1024, evicts oldest cap/4 when >cap/2]
     → GrpcServer.Messages() drains
     → SentryMessagesStreamS.Send()   [chan 16384, no eviction]  ← problem
     → pumpStreamLoop.Recv()          [chan 256]
     → handleInboundMessage
```

### Fix

Apply the existing `GrpcServer.send` eviction policy (cap = 1024, drop
oldest `cap/4` when `len > cap/2`) at every fan-out send site, and
extract the cap constant + helper into `p2p/sentry/libsentry`.

| File | Change |
|---|---|
| `p2p/sentry/libsentry/queue.go` (new) | `MessagesQueueSize = 1024` + generic `EvictOldestIfHalfFull[T](chan T)` helper. |
| `p2p/sentry/sentry_grpc_server.go` | Uses the shared constant + helper; the "consuming is slow" debug log is preserved. |
| `node/direct/sentry_client.go` | `Messages` and `PeerEvents` stream shims: cap 16384 → 1024, eviction after each `Send`. |
| `p2p/sentry/libsentry/sentrymultiplexer.go` | `Messages` and `PeerEvents` fan-out channels: cap 16384 → 1024; eviction in the generic `SentryStreamS[T].Send`. |

### Memory impact

|  | Pre-fix | Post-fix (hard bound) | Post-fix (steady state) |
|---|---|---|---|
| per subscriber, eth (10 MB max) | 16384 × 10 MB ≈ 160 GB | 1024 × 10 MB ≈ 10 GB | ~257–513 buffered entries |

The `wit/0` side protocol allows 16 MB per message but is opt-in
(`--polygon.wit-protocol`, off by default), so the eth 10 MB cap
governs default deployments.

### Follow-up

The bounty reporter also suggested a hard byte budget (drop when the
queue exceeds `N` bytes). That needs a ring-buffer rather than a chan
and is out of scope for this fix; leaving a marker for a follow-up if
the reviewer wants a tighter cap.
