### PR TITLE
db/downloader: raise TestBTPeerDiscovery_AddPeersFromENR timeout to 2m

### DIFF
--- a/db/downloader/bt_peer_discovery_test.go
+++ b/db/downloader/bt_peer_discovery_test.go
@@ -25,7 +25,7 @@ import (
 // This is the core mechanism for decentralized snapshot distribution:
 // no DHT, no tracker — just direct peer injection from ENR records.
 func TestBTPeerDiscovery_AddPeersFromENR(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	defer cancel()
 
 	// Create temp dirs for seeder and leecher.


### PR DESCRIPTION
## Summary
- Bump the test's hard deadline from 30s to 2m so the race-detector CI job has enough headroom for the BT choke/unchoke + piece-transfer cycle.

## Context
[race-tests / tests-linux (ubuntu-latest, core-rpc)](https://github.com/erigontech/erigon/actions/runs/24881553099/job/72850999273) failed on the merge queue with:

```
--- FAIL: TestBTPeerDiscovery_AddPeersFromENR (30.00s)
    bt_peer_discovery_test.go:102: timed out downloading from seeder
```

The failure is exactly at the `context.WithTimeout(t.Context(), 30*time.Second)` deadline set at the top of the test. The first wait (`<-leecherTorrent.GotInfo()`) succeeded — so TCP connect, BT handshake, and metainfo exchange all completed. Only the piece-transfer step ran out of time.

With `NoDHT=true` + `DisableTrackers=true` and a single trusted peer injected via `AddPeers`, the download is gated on the anacrolix/torrent internal choke/unchoke cycle. Under `-race` on a shared GitHub runner that cycle routinely pushes past 30s. All three non-race siblings (`tests / tests-mac-linux` on ubuntu/windows/macos) passed on the same commit.

Bumping to 2m leaves headroom for `-race` + CI contention without changing the passing-case wall-clock (the test is O(milliseconds) when it's not starved).

## Test plan
- [ ] Existing unit tests pass under `-race` in CI