### PR TITLE
rpc: send clean close frame on websocket disconnect

### DIFF
--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -330,6 +330,9 @@ func NewWebsocketCodec(conn *websocket.Conn, host string, req http.Header, remot
 }
 
 func (wc *websocketCodec) Close() {
+	// Send a WebSocket Close frame before closing the underlying connection,
+	// so the server sees a clean 1000 (normal closure) instead of 1006 (abnormal).
+	wc.conn.Close(websocket.StatusNormalClosure, "")
 	wc.jsonCodec.Close()
 	wc.wg.Wait()
 }

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -266,7 +266,7 @@ func (a *wsConnAdapter) Close() error {
 		defer close(closeDone)
 		_ = a.conn.Close(websocket.StatusNormalClosure, "")
 	}()
-	
+
 	timer := time.NewTimer(time.Second)
 	defer timer.Stop()
 	select {

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -258,23 +258,27 @@ type wsConnAdapter struct {
 
 func (a *wsConnAdapter) Close() error {
 	// Attempt a graceful WebSocket close handshake first, so the peer sees a clean
-	// 1000 (normal closure) instead of 1006 (abnormal). The underlying codec close path
-	// may hard-close the transport, so give the handshake a bounded chance to complete
-	// before falling back to CloseNow().
+	// 1000 (normal closure) instead of 1006 (abnormal). Keep the handshake fully async
+	// so server shutdown doesn't block per connection, and force-close after a bounded
+	// grace period if the peer doesn't complete the close promptly.
 	closeDone := make(chan struct{})
 	go func() {
 		defer close(closeDone)
 		_ = a.conn.Close(websocket.StatusNormalClosure, "")
 	}()
 
-	timer := time.NewTimer(time.Second)
-	defer timer.Stop()
-	select {
-	case <-closeDone:
-	case <-timer.C:
-	}
+	go func() {
+		timer := time.NewTimer(time.Second)
+		defer timer.Stop()
 
-	return a.conn.CloseNow()
+		select {
+		case <-closeDone:
+		case <-timer.C:
+			_ = a.conn.CloseNow()
+		}
+	}()
+
+	return nil
 }
 
 func (a *wsConnAdapter) SetWriteDeadline(t time.Time) error {

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -257,6 +257,23 @@ type wsConnAdapter struct {
 }
 
 func (a *wsConnAdapter) Close() error {
+	// Attempt a graceful WebSocket close handshake first, so the peer sees a clean
+	// 1000 (normal closure) instead of 1006 (abnormal). The underlying codec close path
+	// may hard-close the transport, so give the handshake a bounded chance to complete
+	// before falling back to CloseNow().
+	closeDone := make(chan struct{})
+	go func() {
+		defer close(closeDone)
+		_ = a.conn.Close(websocket.StatusNormalClosure, "")
+	}()
+	
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case <-closeDone:
+	case <-timer.C:
+	}
+
 	return a.conn.CloseNow()
 }
 
@@ -330,9 +347,6 @@ func NewWebsocketCodec(conn *websocket.Conn, host string, req http.Header, remot
 }
 
 func (wc *websocketCodec) Close() {
-	// Send a WebSocket Close frame before closing the underlying connection,
-	// so the server sees a clean 1000 (normal closure) instead of 1006 (abnormal).
-	wc.conn.Close(websocket.StatusNormalClosure, "")
 	wc.jsonCodec.Close()
 	wc.wg.Wait()
 }

--- a/rpc/websocket_test.go
+++ b/rpc/websocket_test.go
@@ -384,7 +384,10 @@ func TestWebsocketServerGracefulClose(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	conn, resp, err := websocket.Dial(ctx, wsURL, nil)
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)
 	}

--- a/rpc/websocket_test.go
+++ b/rpc/websocket_test.go
@@ -388,6 +388,7 @@ func TestWebsocketServerGracefulClose(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)
 	}
+	defer conn.CloseNow()
 
 	if err := conn.Write(ctx, websocket.MessageText, []byte("invalid json")); err != nil {
 		t.Fatalf("failed to write: %v", err)

--- a/rpc/websocket_test.go
+++ b/rpc/websocket_test.go
@@ -385,10 +385,10 @@ func TestWebsocketServerGracefulClose(t *testing.T) {
 	defer cancel()
 
 	conn, resp, err := websocket.Dial(ctx, wsURL, nil)
-	if resp != nil && resp.Body != nil {
-		defer resp.Body.Close()
-	}
 	if err != nil {
+		if resp != nil && resp.Body != nil {
+			resp.Body.Close()
+		}
 		t.Fatalf("failed to dial: %v", err)
 	}
 	defer conn.CloseNow()

--- a/rpc/websocket_test.go
+++ b/rpc/websocket_test.go
@@ -367,3 +367,40 @@ func TestWebsocketNonBlockingAcquire(t *testing.T) {
 		t.Errorf("expected error code %d (server overloaded), got %d", ErrCodeServerOverloaded, rpcErr.ErrorCode())
 	}
 }
+
+// TestWebsocketServerGracefulClose verifies that when the server initiates a
+// websocket closure, it explicitly sends a clean StatusNormalClosure (1000)
+// rather than an abnormal closure.
+func TestWebsocketServerGracefulClose(t *testing.T) {
+	t.Parallel()
+	logger := log.New()
+
+	srv := newTestServer(logger)
+	httpsrv := httptest.NewServer(srv.WebsocketHandler([]string{"*"}, nil, false, logger))
+	wsURL := "ws:" + strings.TrimPrefix(httpsrv.URL, "http:")
+	defer srv.Stop()
+	defer httpsrv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+
+	if err := conn.Write(ctx, websocket.MessageText, []byte("invalid json")); err != nil {
+		t.Fatalf("failed to write: %v", err)
+	}
+
+	for {
+		_, _, err := conn.Read(ctx)
+		if err != nil {
+			status := websocket.CloseStatus(err)
+			if status != websocket.StatusNormalClosure {
+				t.Errorf("expected close status %v, got %v (err: %v)", websocket.StatusNormalClosure, status, err)
+			}
+			break
+		}
+	}
+}


### PR DESCRIPTION
Currently, when a WebSocket connection is closed by the RPC server, the underlying TCP connection gets torn down immediately without sending a final WebSocket Close frame. Because of this abrupt teardown, clients connected to the node experience an abnormal closure (error code 1006) instead of a clean, normal disconnect (error code 1000).

This PR fixes that behavior by explicitly sending a clean 1000 normal closure frame right before terminating the connection. It uses the `Close()` method from the `coder/websocket` library to safely transmit this control frame.