### PR TITLE
ci: fail-fast ci-gate in merge queue by cancelling on leaf failure

### DIFF
--- a/.github/workflows/check-large-files.yml
+++ b/.github/workflows/check-large-files.yml
@@ -19,3 +19,12 @@ jobs:
 
       - name: Check for large files in PR
         run: make check-large-files BASE=${{ github.event.pull_request.base.sha }}
+
+      # In the merge queue, cancel the run on first failure so the gate
+      # doesn't stall waiting for still-running siblings. PR runs keep
+      # going so authors see the full failure picture.
+      - name: Cancel workflow run on failure
+        if: failure() && github.event_name == 'merge_group'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run cancel ${{ github.run_id }} || true

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -26,6 +26,13 @@ concurrency:
     }}
   cancel-in-progress: true
 
+# actions: write lets merge-queue runs call `gh run cancel` on a leaf
+# failure so the gate doesn't stall waiting for still-running siblings.
+# Reusable leaves inherit these from the caller.
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   lint:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,3 +42,12 @@ jobs:
         with:
           path: ~/.cache/golangci-lint
           key: golangci-lint|${{ runner.os }}|${{ hashFiles('go.sum') }}|${{ github.run_id }}|${{ github.run_attempt }}
+
+      # In the merge queue, cancel the run on first failure so the gate
+      # doesn't stall waiting for still-running siblings. PR runs keep
+      # going so authors see the full failure picture.
+      - name: Cancel workflow run on failure
+        if: failure() && github.event_name == 'merge_group'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run cancel ${{ github.run_id }} || true

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -40,3 +40,12 @@ jobs:
 
       - uses: ./.github/actions/cleanup-erigon
         if: always()
+
+      # In the merge queue, cancel the run on first failure so the gate
+      # doesn't stall waiting for still-running siblings. PR runs keep
+      # going so authors see the full failure picture.
+      - name: Cancel workflow run on failure
+        if: failure() && github.event_name == 'merge_group'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run cancel ${{ github.run_id }} || true

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -54,3 +54,12 @@ jobs:
 
       - uses: ./.github/actions/cleanup-erigon
         if: always()
+
+      # In the merge queue, cancel the run on first failure so the gate
+      # doesn't stall waiting for still-running siblings. PR runs keep
+      # going so authors see the full failure picture.
+      - name: Cancel workflow run on failure
+        if: failure() && github.event_name == 'merge_group'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run cancel ${{ github.run_id }} || true

--- a/.github/workflows/test-all-erigon-race.yml
+++ b/.github/workflows/test-all-erigon-race.yml
@@ -23,6 +23,15 @@ jobs:
       - id: load
         run: echo "groups=$(./tools/test-groups names)" >> $GITHUB_OUTPUT
 
+      # In the merge queue, cancel the run on first failure so the gate
+      # doesn't stall waiting for still-running siblings. PR runs keep
+      # going so authors see the full failure picture.
+      - name: Cancel workflow run on failure
+        if: failure() && github.event_name == 'merge_group'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run cancel ${{ github.run_id }} || true
+
   tests-linux:
     needs: load-matrix
     timeout-minutes: 90
@@ -62,3 +71,12 @@ jobs:
 
       - uses: ./.github/actions/cleanup-erigon
         if: always()
+
+      # In the merge queue, cancel the run on first failure so the gate
+      # doesn't stall waiting for still-running siblings. PR runs keep
+      # going so authors see the full failure picture.
+      - name: Cancel workflow run on failure
+        if: failure() && github.event_name == 'merge_group'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run cancel ${{ github.run_id }} || true

--- a/.github/workflows/test-all-erigon.yml
+++ b/.github/workflows/test-all-erigon.yml
@@ -66,4 +66,11 @@ jobs:
       - uses: ./.github/actions/cleanup-erigon
         if: always()
 
-
+      # In the merge queue, cancel the run on first failure so the gate
+      # doesn't stall waiting for still-running siblings. PR runs keep
+      # going so authors see the full failure picture.
+      - name: Cancel workflow run on failure
+        if: failure() && github.event_name == 'merge_group'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run cancel ${{ github.run_id }} || true

--- a/.github/workflows/test-bench.yml
+++ b/.github/workflows/test-bench.yml
@@ -42,3 +42,12 @@ jobs:
 
       - uses: ./.github/actions/cleanup-erigon
         if: always()
+
+      # In the merge queue, cancel the run on first failure so the gate
+      # doesn't stall waiting for still-running siblings. PR runs keep
+      # going so authors see the full failure picture.
+      - name: Cancel workflow run on failure
+        if: failure() && github.event_name == 'merge_group'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run cancel ${{ github.run_id }} || true

--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -222,3 +222,12 @@ jobs:
           echo "Pruning docker..."
           docker system prune -af --volumes
         if: always()
+
+      # In the merge queue, cancel the run on first failure so the gate
+      # doesn't stall waiting for still-running siblings. PR runs keep
+      # going so authors see the full failure picture.
+      - name: Cancel workflow run on failure
+        if: failure() && github.event_name == 'merge_group'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run cancel ${{ github.run_id }} || true

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -204,3 +204,12 @@ jobs:
           echo "Pruning docker..."
           docker system prune -af --volumes
         if: always()
+
+      # In the merge queue, cancel the run on first failure so the gate
+      # doesn't stall waiting for still-running siblings. PR runs keep
+      # going so authors see the full failure picture.
+      - name: Cancel workflow run on failure
+        if: failure() && github.event_name == 'merge_group'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run cancel ${{ github.run_id }} || true

--- a/.github/workflows/test-integration-caplin.yml
+++ b/.github/workflows/test-integration-caplin.yml
@@ -36,6 +36,15 @@ jobs:
       - uses: ./.github/actions/cleanup-erigon
         if: always()
 
+      # In the merge queue, cancel the run on first failure so the gate
+      # doesn't stall waiting for still-running siblings. PR runs keep
+      # going so authors see the full failure picture.
+      - name: Cancel workflow run on failure
+        if: failure() && github.event_name == 'merge_group'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run cancel ${{ github.run_id }} || true
+
   tests-windows:
     strategy:
       matrix:
@@ -58,3 +67,12 @@ jobs:
 
       - uses: ./.github/actions/cleanup-erigon
         if: always()
+
+      # In the merge queue, cancel the run on first failure so the gate
+      # doesn't stall waiting for still-running siblings. PR runs keep
+      # going so authors see the full failure picture.
+      - name: Cancel workflow run on failure
+        if: failure() && github.event_name == 'merge_group'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run cancel ${{ github.run_id }} || true

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -159,3 +159,12 @@ jobs:
           path: ${{ runner.temp }}/kurtosis-dump-${{ matrix.suite }}
           retention-days: 7
           if-no-files-found: warn
+
+      # In the merge queue, cancel the run on first failure so the gate
+      # doesn't stall waiting for still-running siblings. PR runs keep
+      # going so authors see the full failure picture.
+      - name: Cancel workflow run on failure
+        if: failure() && github.event_name == 'merge_group'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run cancel ${{ github.run_id }} || true


### PR DESCRIPTION
## Summary
- When any required leaf workflow (lint, tests, race-tests, hive, caplin, etc.) fails in a merge-queue run, the failing leaf now calls `gh run cancel` on the current run. Siblings flip to `cancelled` within seconds, and the `ci-gate` job (still `if: always()` + `needs: [...]`) runs immediately and reports failure — the queue dequeues the broken PR instead of waiting for the slowest sub-workflow to finish.
- Gated on `github.event_name == 'merge_group'` so PR runs still execute every leaf to completion — authors see every failure, not just the first one.
- Workflow-level `permissions: { actions: write, contents: read }` on `ci-gate.yml` so the reusable leaves inherit the permission needed to call the cancel endpoint.

## Why not a polling / needs-less approach
GitHub's `needs:` semantics require every listed need to reach a terminal state before the dependent job can run, so a `needs: [...]` + `if: always()` gate cannot natively fail fast. The only way to make siblings terminate early is to cancel them — so that's what this does, from whichever leaf fails first. The `ci-gate` job itself is unchanged.

## Test plan
- [ ] After merge, observe a real merge-queue failure and confirm ci-gate surfaces `failure` within seconds of the first leaf failing rather than waiting for the slowest sub-workflow.
- [ ] Confirm PR runs still run every leaf to completion (cancel step is gated on `merge_group`).
- [ ] Fork PRs: the gated `if` still fires only in `merge_group`, so fork-PR cancel permissions are a non-issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)