### PR TITLE
`erigon seg ls`: show dictionary size on disk and in mem

### DIFF
--- a/db/seg/decompress.go
+++ b/db/seg/decompress.go
@@ -513,7 +513,9 @@ func (d *Decompressor) SerializedTotalDictSize() uint64 { return d.serializedDic
 func (d *Decompressor) DictWords() int                  { return d.dictWords }
 func (d *Decompressor) DictLens() int                   { return d.dictLens }
 
-// DictMemSize returns the in-memory size of the decoded Huffman tables (arena allocations).
+// DictMemSize returns the in-memory size of the decoded Huffman table structures
+// (arena-allocated codeword/table/slot slabs). Pattern bytes are subslices of the
+// mmap'd file data and are not included.
 func (d *Decompressor) DictMemSize() uint64 {
 	var total uint64
 	if d.patArena != nil {
@@ -527,6 +529,19 @@ func (d *Decompressor) DictMemSize() uint64 {
 		total += uint64(cap(d.posArena.ptrsArr)) * uint64(unsafe.Sizeof((*posTable)(nil)))
 	}
 	return total
+}
+
+// Stats accumulates snapshot segment stats for summary logging.
+type Stats struct {
+	Words   uint64
+	Dict    uint64
+	DictMem uint64
+}
+
+func (s *Stats) Add(d *Decompressor) {
+	s.Words += uint64(d.Count())
+	s.Dict += d.SerializedTotalDictSize()
+	s.DictMem += d.DictMemSize()
 }
 func (d *Decompressor) CompressedPageValuesCount() int  { return int(d.compPageValuesCount) }
 func (d *Decompressor) CompressionFormatVersion() uint8 { return d.version }

--- a/db/seg/decompress.go
+++ b/db/seg/decompress.go
@@ -509,8 +509,25 @@ func (d *Decompressor) DataHandle() unsafe.Pointer {
 }
 func (d *Decompressor) SerializedDictSize() uint64      { return d.serializedDictSize }
 func (d *Decompressor) SerializedLenSize() uint64       { return d.lenDictSize }
+func (d *Decompressor) SerializedTotalDictSize() uint64 { return d.serializedDictSize + d.lenDictSize }
 func (d *Decompressor) DictWords() int                  { return d.dictWords }
 func (d *Decompressor) DictLens() int                   { return d.dictLens }
+
+// DictMemSize returns the in-memory size of the decoded Huffman tables (arena allocations).
+func (d *Decompressor) DictMemSize() uint64 {
+	var total uint64
+	if d.patArena != nil {
+		total += uint64(cap(d.patArena.codewords)) * uint64(unsafe.Sizeof(codeword{}))
+		total += uint64(cap(d.patArena.tables)) * uint64(unsafe.Sizeof(patternTable{}))
+		total += uint64(cap(d.patArena.slots)) * uint64(unsafe.Sizeof((*codeword)(nil)))
+	}
+	if d.posArena != nil {
+		total += uint64(cap(d.posArena.tables)) * uint64(unsafe.Sizeof(posTable{}))
+		total += uint64(cap(d.posArena.entriesArr)) * uint64(unsafe.Sizeof(posEntry{}))
+		total += uint64(cap(d.posArena.ptrsArr)) * uint64(unsafe.Sizeof((*posTable)(nil)))
+	}
+	return total
+}
 func (d *Decompressor) CompressedPageValuesCount() int  { return int(d.compPageValuesCount) }
 func (d *Decompressor) CompressionFormatVersion() uint8 { return d.version }
 

--- a/db/snapshotsync/caplin_state_snapshots.go
+++ b/db/snapshotsync/caplin_state_snapshots.go
@@ -218,7 +218,7 @@ func (s *CaplinStateSnapshots) LS() {
 	for _, roTx := range view.roTxs {
 		if roTx != nil {
 			for _, seg := range roTx.Segments {
-				s.logger.Info("[agg] ", "f", seg.src.filePath, "words", seg.src.Decompressor.Count())
+				s.logger.Info("[agg] ", "f", seg.src.filePath, "words", seg.src.Decompressor.Count(), "dict", common.ByteCount(seg.src.Decompressor.SerializedDictSize()+seg.src.Decompressor.SerializedLenSize()))
 			}
 		}
 	}

--- a/db/snapshotsync/caplin_state_snapshots.go
+++ b/db/snapshotsync/caplin_state_snapshots.go
@@ -218,7 +218,7 @@ func (s *CaplinStateSnapshots) LS() {
 	for _, roTx := range view.roTxs {
 		if roTx != nil {
 			for _, seg := range roTx.Segments {
-				s.logger.Info("[agg] ", "f", seg.src.filePath, "words", seg.src.Decompressor.Count(), "dict", common.ByteCount(seg.src.Decompressor.SerializedDictSize()+seg.src.Decompressor.SerializedLenSize()))
+				s.logger.Info("[agg] ", "f", seg.src.filePath, "words", seg.src.Decompressor.Count(), "dict", common.ByteCount(seg.src.Decompressor.SerializedTotalDictSize()), "dictMem", common.ByteCount(seg.src.Decompressor.DictMemSize()))
 			}
 		}
 	}

--- a/db/snapshotsync/caplin_state_snapshots.go
+++ b/db/snapshotsync/caplin_state_snapshots.go
@@ -215,18 +215,17 @@ func (s *CaplinStateSnapshots) LS() {
 	view := s.View()
 	defer view.Close()
 
-	var totalWords, totalDict, totalDictMem uint64
+	var stats seg.Stats
 	for _, roTx := range view.roTxs {
 		if roTx != nil {
-			for _, seg := range roTx.Segments {
-				s.logger.Info("[agg] ", "f", seg.src.filePath, "words", seg.src.Decompressor.Count(), "dict", common.ByteCount(seg.src.Decompressor.SerializedTotalDictSize()), "dictMem", common.ByteCount(seg.src.Decompressor.DictMemSize()))
-				totalWords += uint64(seg.src.Decompressor.Count())
-				totalDict += seg.src.Decompressor.SerializedTotalDictSize()
-				totalDictMem += seg.src.Decompressor.DictMemSize()
+			for _, sn := range roTx.Segments {
+				d := sn.src.Decompressor
+				s.logger.Info("[agg] ", "f", d.FileName(), "words", d.Count(), "dictOnDisk", common.ByteCount(d.SerializedTotalDictSize()), "dictMem", common.ByteCount(d.DictMemSize()))
+				stats.Add(d)
 			}
 		}
 	}
-	s.logger.Info("[agg] total", "words", totalWords, "dict", common.ByteCount(totalDict), "dictMem", common.ByteCount(totalDictMem))
+	s.logger.Info("[agg] total", "words", stats.Words, "dictOnDisk", common.ByteCount(stats.Dict), "dictMem", common.ByteCount(stats.DictMem))
 }
 
 func (s *CaplinStateSnapshots) SegFileNames(from, to uint64) []string {

--- a/db/snapshotsync/caplin_state_snapshots.go
+++ b/db/snapshotsync/caplin_state_snapshots.go
@@ -215,13 +215,18 @@ func (s *CaplinStateSnapshots) LS() {
 	view := s.View()
 	defer view.Close()
 
+	var totalWords, totalDict, totalDictMem uint64
 	for _, roTx := range view.roTxs {
 		if roTx != nil {
 			for _, seg := range roTx.Segments {
 				s.logger.Info("[agg] ", "f", seg.src.filePath, "words", seg.src.Decompressor.Count(), "dict", common.ByteCount(seg.src.Decompressor.SerializedTotalDictSize()), "dictMem", common.ByteCount(seg.src.Decompressor.DictMemSize()))
+				totalWords += uint64(seg.src.Decompressor.Count())
+				totalDict += seg.src.Decompressor.SerializedTotalDictSize()
+				totalDictMem += seg.src.Decompressor.DictMemSize()
 			}
 		}
 	}
+	s.logger.Info("[agg] total", "words", totalWords, "dict", common.ByteCount(totalDict), "dictMem", common.ByteCount(totalDictMem))
 }
 
 func (s *CaplinStateSnapshots) SegFileNames(from, to uint64) []string {

--- a/db/snapshotsync/freezeblocks/caplin_snapshots.go
+++ b/db/snapshotsync/freezeblocks/caplin_snapshots.go
@@ -109,24 +109,22 @@ func (s *CaplinSnapshots) LS() {
 	view := s.View()
 	defer view.Close()
 
-	var totalWords, totalDict, totalDictMem uint64
+	var stats seg.Stats
 	lsSeg := func(d *seg.Decompressor) {
-		log.Info("[agg] ", "f", d.FileName(), "words", d.Count(), "dict", common.ByteCount(d.SerializedTotalDictSize()), "dictMem", common.ByteCount(d.DictMemSize()))
-		totalWords += uint64(d.Count())
-		totalDict += d.SerializedTotalDictSize()
-		totalDictMem += d.DictMemSize()
+		log.Info("[agg] ", "f", d.FileName(), "words", d.Count(), "dictOnDisk", common.ByteCount(d.SerializedTotalDictSize()), "dictMem", common.ByteCount(d.DictMemSize()))
+		stats.Add(d)
 	}
 	if view.BeaconBlockRotx != nil {
-		for _, seg := range view.BeaconBlockRotx.Segments {
-			lsSeg(seg.Src().Decompressor)
+		for _, sn := range view.BeaconBlockRotx.Segments {
+			lsSeg(sn.Src().Decompressor)
 		}
 	}
 	if view.BlobSidecarRotx != nil {
-		for _, seg := range view.BlobSidecarRotx.Segments {
-			lsSeg(seg.Src().Decompressor)
+		for _, sn := range view.BlobSidecarRotx.Segments {
+			lsSeg(sn.Src().Decompressor)
 		}
 	}
-	log.Info("[agg] total", "words", totalWords, "dict", common.ByteCount(totalDict), "dictMem", common.ByteCount(totalDictMem))
+	log.Info("[agg] total", "words", stats.Words, "dictOnDisk", common.ByteCount(stats.Dict), "dictMem", common.ByteCount(stats.DictMem))
 }
 
 func (s *CaplinSnapshots) SegFileNames(from, to uint64) []string {

--- a/db/snapshotsync/freezeblocks/caplin_snapshots.go
+++ b/db/snapshotsync/freezeblocks/caplin_snapshots.go
@@ -109,16 +109,24 @@ func (s *CaplinSnapshots) LS() {
 	view := s.View()
 	defer view.Close()
 
+	var totalWords, totalDict, totalDictMem uint64
+	lsSeg := func(d *seg.Decompressor) {
+		log.Info("[agg] ", "f", d.FileName(), "words", d.Count(), "dict", common.ByteCount(d.SerializedTotalDictSize()), "dictMem", common.ByteCount(d.DictMemSize()))
+		totalWords += uint64(d.Count())
+		totalDict += d.SerializedTotalDictSize()
+		totalDictMem += d.DictMemSize()
+	}
 	if view.BeaconBlockRotx != nil {
 		for _, seg := range view.BeaconBlockRotx.Segments {
-			log.Info("[agg] ", "f", seg.Src().Decompressor.FileName(), "words", seg.Src().Decompressor.Count(), "dict", common.ByteCount(seg.Src().Decompressor.SerializedTotalDictSize()), "dictMem", common.ByteCount(seg.Src().Decompressor.DictMemSize()))
+			lsSeg(seg.Src().Decompressor)
 		}
 	}
 	if view.BlobSidecarRotx != nil {
 		for _, seg := range view.BlobSidecarRotx.Segments {
-			log.Info("[agg] ", "f", seg.Src().Decompressor.FileName(), "words", seg.Src().Decompressor.Count(), "dict", common.ByteCount(seg.Src().Decompressor.SerializedTotalDictSize()), "dictMem", common.ByteCount(seg.Src().Decompressor.DictMemSize()))
+			lsSeg(seg.Src().Decompressor)
 		}
 	}
+	log.Info("[agg] total", "words", totalWords, "dict", common.ByteCount(totalDict), "dictMem", common.ByteCount(totalDictMem))
 }
 
 func (s *CaplinSnapshots) SegFileNames(from, to uint64) []string {

--- a/db/snapshotsync/freezeblocks/caplin_snapshots.go
+++ b/db/snapshotsync/freezeblocks/caplin_snapshots.go
@@ -111,12 +111,12 @@ func (s *CaplinSnapshots) LS() {
 
 	if view.BeaconBlockRotx != nil {
 		for _, seg := range view.BeaconBlockRotx.Segments {
-			log.Info("[agg] ", "f", seg.Src().Decompressor.FileName(), "words", seg.Src().Decompressor.Count())
+			log.Info("[agg] ", "f", seg.Src().Decompressor.FileName(), "words", seg.Src().Decompressor.Count(), "dict", common.ByteCount(seg.Src().Decompressor.SerializedDictSize()+seg.Src().Decompressor.SerializedLenSize()))
 		}
 	}
 	if view.BlobSidecarRotx != nil {
 		for _, seg := range view.BlobSidecarRotx.Segments {
-			log.Info("[agg] ", "f", seg.Src().Decompressor.FileName(), "words", seg.Src().Decompressor.Count())
+			log.Info("[agg] ", "f", seg.Src().Decompressor.FileName(), "words", seg.Src().Decompressor.Count(), "dict", common.ByteCount(seg.Src().Decompressor.SerializedDictSize()+seg.Src().Decompressor.SerializedLenSize()))
 		}
 	}
 }

--- a/db/snapshotsync/freezeblocks/caplin_snapshots.go
+++ b/db/snapshotsync/freezeblocks/caplin_snapshots.go
@@ -111,12 +111,12 @@ func (s *CaplinSnapshots) LS() {
 
 	if view.BeaconBlockRotx != nil {
 		for _, seg := range view.BeaconBlockRotx.Segments {
-			log.Info("[agg] ", "f", seg.Src().Decompressor.FileName(), "words", seg.Src().Decompressor.Count(), "dict", common.ByteCount(seg.Src().Decompressor.SerializedDictSize()+seg.Src().Decompressor.SerializedLenSize()))
+			log.Info("[agg] ", "f", seg.Src().Decompressor.FileName(), "words", seg.Src().Decompressor.Count(), "dict", common.ByteCount(seg.Src().Decompressor.SerializedTotalDictSize()), "dictMem", common.ByteCount(seg.Src().Decompressor.DictMemSize()))
 		}
 	}
 	if view.BlobSidecarRotx != nil {
 		for _, seg := range view.BlobSidecarRotx.Segments {
-			log.Info("[agg] ", "f", seg.Src().Decompressor.FileName(), "words", seg.Src().Decompressor.Count(), "dict", common.ByteCount(seg.Src().Decompressor.SerializedDictSize()+seg.Src().Decompressor.SerializedLenSize()))
+			log.Info("[agg] ", "f", seg.Src().Decompressor.FileName(), "words", seg.Src().Decompressor.Count(), "dict", common.ByteCount(seg.Src().Decompressor.SerializedTotalDictSize()), "dictMem", common.ByteCount(seg.Src().Decompressor.DictMemSize()))
 		}
 	}
 }

--- a/db/snapshotsync/snapshots.go
+++ b/db/snapshotsync/snapshots.go
@@ -944,14 +944,19 @@ func (s *RoSnapshots) Ls() {
 	view := s.View()
 	defer view.Close()
 
+	var totalWords, totalDict, totalDictMem uint64
 	for _, t := range s.enums {
 		for _, seg := range view.segments[t].Segments {
 			if seg.src == nil || seg.src.Decompressor == nil {
 				continue
 			}
 			log.Info("[snapshots] ", "f", seg.src.Decompressor.FileName(), "words", seg.src.Decompressor.Count(), "dict", common.ByteCount(seg.src.Decompressor.SerializedTotalDictSize()), "dictMem", common.ByteCount(seg.src.Decompressor.DictMemSize()))
+			totalWords += uint64(seg.src.Decompressor.Count())
+			totalDict += seg.src.Decompressor.SerializedTotalDictSize()
+			totalDictMem += seg.src.Decompressor.DictMemSize()
 		}
 	}
+	log.Info("[snapshots] total", "words", totalWords, "dict", common.ByteCount(totalDict), "dictMem", common.ByteCount(totalDictMem))
 }
 
 func (s *RoSnapshots) Files() (list []string) {

--- a/db/snapshotsync/snapshots.go
+++ b/db/snapshotsync/snapshots.go
@@ -949,7 +949,7 @@ func (s *RoSnapshots) Ls() {
 			if seg.src == nil || seg.src.Decompressor == nil {
 				continue
 			}
-			log.Info("[snapshots] ", "f", seg.src.Decompressor.FileName(), "count", seg.src.Decompressor.Count(), "dict", common.ByteCount(seg.src.Decompressor.SerializedDictSize()+seg.src.Decompressor.SerializedLenSize()))
+			log.Info("[snapshots] ", "f", seg.src.Decompressor.FileName(), "words", seg.src.Decompressor.Count(), "dict", common.ByteCount(seg.src.Decompressor.SerializedTotalDictSize()), "dictMem", common.ByteCount(seg.src.Decompressor.DictMemSize()))
 		}
 	}
 }

--- a/db/snapshotsync/snapshots.go
+++ b/db/snapshotsync/snapshots.go
@@ -949,7 +949,7 @@ func (s *RoSnapshots) Ls() {
 			if seg.src == nil || seg.src.Decompressor == nil {
 				continue
 			}
-			log.Info("[snapshots] ", "f", seg.src.Decompressor.FileName(), "count", seg.src.Decompressor.Count())
+			log.Info("[snapshots] ", "f", seg.src.Decompressor.FileName(), "count", seg.src.Decompressor.Count(), "dict", common.ByteCount(seg.src.Decompressor.SerializedDictSize()+seg.src.Decompressor.SerializedLenSize()))
 		}
 	}
 }

--- a/db/snapshotsync/snapshots.go
+++ b/db/snapshotsync/snapshots.go
@@ -944,19 +944,18 @@ func (s *RoSnapshots) Ls() {
 	view := s.View()
 	defer view.Close()
 
-	var totalWords, totalDict, totalDictMem uint64
+	var stats seg.Stats
 	for _, t := range s.enums {
-		for _, seg := range view.segments[t].Segments {
-			if seg.src == nil || seg.src.Decompressor == nil {
+		for _, sn := range view.segments[t].Segments {
+			if sn.src == nil || sn.src.Decompressor == nil {
 				continue
 			}
-			log.Info("[snapshots] ", "f", seg.src.Decompressor.FileName(), "words", seg.src.Decompressor.Count(), "dict", common.ByteCount(seg.src.Decompressor.SerializedTotalDictSize()), "dictMem", common.ByteCount(seg.src.Decompressor.DictMemSize()))
-			totalWords += uint64(seg.src.Decompressor.Count())
-			totalDict += seg.src.Decompressor.SerializedTotalDictSize()
-			totalDictMem += seg.src.Decompressor.DictMemSize()
+			d := sn.src.Decompressor
+			log.Info("[snapshots] ", "f", d.FileName(), "words", d.Count(), "dictOnDisk", common.ByteCount(d.SerializedTotalDictSize()), "dictMem", common.ByteCount(d.DictMemSize()))
+			stats.Add(d)
 		}
 	}
-	log.Info("[snapshots] total", "words", totalWords, "dict", common.ByteCount(totalDict), "dictMem", common.ByteCount(totalDictMem))
+	log.Info("[snapshots] total", "words", stats.Words, "dictOnDisk", common.ByteCount(stats.Dict), "dictMem", common.ByteCount(stats.DictMem))
 }
 
 func (s *RoSnapshots) Files() (list []string) {

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -691,6 +691,7 @@ func (a *Aggregator) Files() []string {
 	return ac.AllFiles().Fullpaths()
 }
 func (a *Aggregator) LS() {
+	var totalWords, totalDict, totalDictMem uint64
 	doLS := func(dirtyFiles *btree.BTreeG[*FilesItem]) {
 		dirtyFiles.Walk(func(items []*FilesItem) bool {
 			for _, item := range items {
@@ -698,6 +699,9 @@ func (a *Aggregator) LS() {
 					continue
 				}
 				a.logger.Info("[agg] ", "f", item.decompressor.FileName(), "words", item.decompressor.Count(), "dict", common.ByteCount(item.decompressor.SerializedTotalDictSize()), "dictMem", common.ByteCount(item.decompressor.DictMemSize()))
+				totalWords += uint64(item.decompressor.Count())
+				totalDict += item.decompressor.SerializedTotalDictSize()
+				totalDictMem += item.decompressor.DictMemSize()
 			}
 			return true
 		})
@@ -713,6 +717,7 @@ func (a *Aggregator) LS() {
 	for _, d := range a.standaloneIIs() {
 		doLS(d.dirtyFiles)
 	}
+	a.logger.Info("[agg] total", "words", totalWords, "dict", common.ByteCount(totalDict), "dictMem", common.ByteCount(totalDictMem))
 }
 
 func (a *Aggregator) WaitForBuildAndMerge(ctx context.Context) chan struct{} {

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -697,7 +697,7 @@ func (a *Aggregator) LS() {
 				if item.decompressor == nil {
 					continue
 				}
-				a.logger.Info("[agg] ", "f", item.decompressor.FileName(), "words", item.decompressor.Count())
+				a.logger.Info("[agg] ", "f", item.decompressor.FileName(), "words", item.decompressor.Count(), "dict", common.ByteCount(item.decompressor.SerializedDictSize()+item.decompressor.SerializedLenSize()))
 			}
 			return true
 		})

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -50,6 +50,7 @@ import (
 	"github.com/erigontech/erigon/db/kv/order"
 	"github.com/erigontech/erigon/db/kv/rawdbv3"
 	"github.com/erigontech/erigon/db/kv/stream"
+	"github.com/erigontech/erigon/db/seg"
 	"github.com/erigontech/erigon/db/state/changeset"
 	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/db/version"
@@ -691,17 +692,15 @@ func (a *Aggregator) Files() []string {
 	return ac.AllFiles().Fullpaths()
 }
 func (a *Aggregator) LS() {
-	var totalWords, totalDict, totalDictMem uint64
+	var stats seg.Stats
 	doLS := func(dirtyFiles *btree.BTreeG[*FilesItem]) {
 		dirtyFiles.Walk(func(items []*FilesItem) bool {
 			for _, item := range items {
 				if item.decompressor == nil {
 					continue
 				}
-				a.logger.Info("[agg] ", "f", item.decompressor.FileName(), "words", item.decompressor.Count(), "dict", common.ByteCount(item.decompressor.SerializedTotalDictSize()), "dictMem", common.ByteCount(item.decompressor.DictMemSize()))
-				totalWords += uint64(item.decompressor.Count())
-				totalDict += item.decompressor.SerializedTotalDictSize()
-				totalDictMem += item.decompressor.DictMemSize()
+				a.logger.Info("[agg] ", "f", item.decompressor.FileName(), "words", item.decompressor.Count(), "dictOnDisk", common.ByteCount(item.decompressor.SerializedTotalDictSize()), "dictMem", common.ByteCount(item.decompressor.DictMemSize()))
+				stats.Add(item.decompressor)
 			}
 			return true
 		})
@@ -717,7 +716,7 @@ func (a *Aggregator) LS() {
 	for _, d := range a.standaloneIIs() {
 		doLS(d.dirtyFiles)
 	}
-	a.logger.Info("[agg] total", "words", totalWords, "dict", common.ByteCount(totalDict), "dictMem", common.ByteCount(totalDictMem))
+	a.logger.Info("[agg] total", "words", stats.Words, "dictOnDisk", common.ByteCount(stats.Dict), "dictMem", common.ByteCount(stats.DictMem))
 }
 
 func (a *Aggregator) WaitForBuildAndMerge(ctx context.Context) chan struct{} {

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -697,7 +697,7 @@ func (a *Aggregator) LS() {
 				if item.decompressor == nil {
 					continue
 				}
-				a.logger.Info("[agg] ", "f", item.decompressor.FileName(), "words", item.decompressor.Count(), "dict", common.ByteCount(item.decompressor.SerializedDictSize()+item.decompressor.SerializedLenSize()))
+				a.logger.Info("[agg] ", "f", item.decompressor.FileName(), "words", item.decompressor.Count(), "dict", common.ByteCount(item.decompressor.SerializedTotalDictSize()), "dictMem", common.ByteCount(item.decompressor.DictMemSize()))
 			}
 			return true
 		})


### PR DESCRIPTION
## Summary

- Add `dict` (on-disk serialized dict size), `dictMem` (in-memory Huffman table arena size), and `words` fields to all `seg ls` log lines
- Add a `total` summary line at the end of each snapshot group showing aggregate word count, dict size, and dict memory
- Add `SerializedTotalDictSize()` and `DictMemSize()` methods to `seg.Decompressor`
- Normalize `"count"` key to `"words"` in `RoSnapshots.Ls` for consistency across all snapshot types