### PR TITLE
p2p/protocols/eth: EIP-8159 eth/71 wire protocol (PR 1/3)

### DIFF
--- a/docs/plans/eip-8159-eth71-bal-exchange.md
+++ b/docs/plans/eip-8159-eth71-bal-exchange.md
@@ -119,6 +119,22 @@ This is the substantial, net-new piece. The goal: during sync, fill the `kv.Bloc
 
 Decision point: whether to make BAL fetching a first-class blocking stage or an opportunistic background fetch. Recommend **background**: stage_exec already validates BAL locally via `ProcessBAL`, so missing-peer BALs are self-healing via local regeneration. p2p BAL is an optimisation for nodes that want to skip the recompute cost.
 
+**Validation lives in the p2p layer (not a higher layer callback).** Follow the existing pattern where BlockBodies / Receipts validation runs inside the fetcher against header data it already has in scope. The fetcher pre-loads `header.BlockAccessListHash` for each pending request hash, and on each inbound `BlockAccessLists` response validates `keccak256(payload) == expected_hash` inline — **before** dispatching to the rawdb writer. Non-matching payloads never cross the p2p boundary.
+
+**Empty-RLP ambiguity** (`0xc0` has two meanings on the wire):
+
+- `0xc0` means *"peer does not have this BAL"* when `expected_hash != empty.BlockAccessListHash`.
+- `0xc0` means *"block genuinely has an empty BAL"* when `expected_hash == empty.BlockAccessListHash` (the keccak256 of the empty RLP list, `0x1dcc4de8...`; already exported at [common/empty/empty_hashes.go:49](common/empty/empty_hashes.go#L49)).
+
+The fetcher always disambiguates against the expected hash, never by inspecting the payload alone. Accept `0xc0` only when the hashes match.
+
+**Bad-peer management** — two distinct penalty tracks layered on top of the per-peer request-rate limits:
+
+1. **Garbage / wrong hash.** Any non-`0xc0` payload whose `keccak256` does not equal the expected hash → immediate disconnect via `Sentry.PenalizePeer`. No ambiguity: the peer is corrupt or malicious.
+2. **Silent withholding.** A peer that consistently returns `0xc0` for BAL hashes we know to be non-empty is DoS-ing the stream without sending garbage. Maintain a per-peer score that decrements on each confirmed-withholding reply (expected ≠ empty-list hash but peer returned `0xc0`) and increments on each valid answer; drop and temporarily ban below a threshold (N withholdings in a rolling window, or an absolute ratio — tune against the existing body-fetcher thresholds for parity). Same `Sentry.PenalizePeer` path so the usual peer telemetry and reconnection logic applies.
+
+Unit tests in the fetcher cover: valid full BAL accepted, valid empty BAL accepted (expected hash = empty-list hash), mismatched-hash → disconnect, and repeated-`0xc0`-for-non-empty-expected → ban. Fetcher should emit metrics for each case so the behaviour is observable in production.
+
 ### Phase 6 — Hive / integration tests
 
 - Hive EEST: verify eth/71 handshake negotiation.

--- a/docs/plans/eip-8159-eth71-bal-exchange.md
+++ b/docs/plans/eip-8159-eth71-bal-exchange.md
@@ -1,0 +1,160 @@
+# EIP-8159 — eth/71 Block Access List Exchange
+
+**Status:** Plan. No code changes yet on this branch.
+**Branch:** `feat/eip-8159-eth71-bal-exchange` off `main`.
+**Spec:** https://eips.ethereum.org/EIPS/eip-8159 (Draft, Networking / Standards Track).
+**Depends on:** EIP-7928 (BAL generation — already partially in-tree).
+**Fork gate:** Amsterdam (`chain.Config.AmsterdamTime`).
+
+## What the EIP adds
+
+1. **Block header field** (already present in the code): `BlockAccessListHash` — `keccak256(rlp.encode(bal))`, sits after `RequestsHash`.
+2. **eth wire protocol bump**: `eth/70 → eth/71`.
+3. **Two new wire messages**:
+   - `GetBlockAccessLists (0x12)`  — request BALs by block hash list
+   - `BlockAccessLists    (0x13)`  — response, BAL bytes per requested hash (empty RLP list `0xc0` for unavailable)
+4. **Validation**: peers verify received BAL by `keccak256(rlp.encode(bal)) == header.BlockAccessListHash`.
+
+No execution-layer / opcode / gas / consensus changes. Purely p2p distribution.
+
+## What's already in the tree (credit to EIP-7928 prep)
+
+Minimising surprise, these pieces are reusable as-is:
+
+| Piece | Location | Notes |
+|---|---|---|
+| Header field `BlockAccessListHash *common.Hash` | [execution/types/block.go:110](execution/types/block.go#L110) | Already RLP-encoded conditionally after `RequestsHash` ([:164–170, :316–321](execution/types/block.go#L164)) |
+| BAL type + `Hash()` method computing `keccak256(rlp.encode(bal))` | [execution/types/block_access_list.go:827](execution/types/block_access_list.go#L827) | Matches EIP-8159 hash definition exactly |
+| BAL rawdb sidecar storage | [db/rawdb/accessors_chain.go:597–612](db/rawdb/accessors_chain.go#L597) — `ReadBlockAccessListBytes` / `WriteBlockAccessListBytes`, table `kv.BlockAccessList` | Already RLP bytes on disk — exactly what we send on the wire |
+| Amsterdam fork gate | [execution/chain/chain_config.go:401–403](execution/chain/chain_config.go#L401) — `IsAmsterdam(time)` | No new fork constant needed |
+| Known-empty BAL hash constant | [common/empty/empty_hashes.go:49–50](common/empty/empty_hashes.go#L49) | Reusable for validation of empty-list BALs |
+| BAL creation on execute | [execution/stagedsync/bal_create.go](execution/stagedsync/bal_create.go) — `CreateBAL`, `ProcessBAL` | Attaches hash validation against `header.BlockAccessListHash` post-Amsterdam |
+| Protocol plumbing precedent | `eth/68 → eth/69 → eth/70` upgrades (see below) | Same pattern to replicate |
+
+The networking additions are the only new code.
+
+## Implementation plan — 5 phases, each a landable commit
+
+### Phase 1 — Wire protocol constants + protobuf enum
+
+- [p2p/protocols/eth/protocol.go:37](p2p/protocols/eth/protocol.go#L37): add `ETH71` to `ProtocolToString`, set `ProtocolLengths[ETH71] = 20` (17 → 18 → 18 → 20 to accommodate the 2 new codes).
+- [node/direct/sentry_client.go:35–37](node/direct/sentry_client.go#L35): add `ETH71 = 71`.
+- [p2p/protocols/eth/protocol.go:53–71](p2p/protocols/eth/protocol.go#L53): add message-code constants:
+  ```go
+  GetBlockAccessListsMsg = 0x12
+  BlockAccessListsMsg    = 0x13
+  ```
+- [node/interfaces/p2psentry/sentry.proto:73](node/interfaces/p2psentry/sentry.proto#L73): add `GET_BLOCK_ACCESS_LISTS_71 = 42; BLOCK_ACCESS_LISTS_71 = 43;`. Regenerate bindings (`make gen`).
+- Unit: lint + build. No functional change yet.
+
+### Phase 2 — Packet types + RLP
+
+Add in `p2p/protocols/eth/protocol.go` alongside `GetBlockBodiesPacket` / `BlockBodiesPacket` (the closest-shaped pair — list of hashes in, list of RLP payloads out):
+
+```go
+// GetBlockAccessListsPacket66 requests BALs for the given block hashes.
+type GetBlockAccessListsPacket66 struct {
+    RequestId uint64
+    BlockHashes []common.Hash
+}
+
+// BlockAccessListsPacket66 replies with RLP-encoded BALs, positionally aligned
+// with the request. An empty RLP list (0xc0) indicates the peer does not have
+// that BAL.
+type BlockAccessListsPacket66 struct {
+    RequestId uint64
+    BALs      []rlp.RawValue
+}
+```
+
+Matches the eth/66 request-id-wrapped envelope used for BlockBodies. We don't wrap the inner BAL bytes again — the on-disk `ReadBlockAccessListBytes` output is already RLP, we hand it through as `RawValue`.
+
+Add `ToProto` / `FromProto` entries for `ETH71` in the same file (big switch tables at :73 and :122) covering all existing eth/70 codes plus the two new ones.
+
+Round-trip serialization test in [p2p/protocols/eth/protocol_test.go](p2p/protocols/eth/protocol_test.go) following the `TestGetBlockHeadersDataEncodeDecode` pattern.
+
+### Phase 3 — Answer handler (server side)
+
+In `p2p/protocols/eth/handlers.go` add:
+
+```go
+// AnswerGetBlockAccessListsQuery looks up BAL RLP bytes for each requested
+// hash from rawdb. Returns empty RLP list for any hash not in the local store.
+// Caller enforces the 2 MiB response-size cap recommended by EIP-8159.
+func AnswerGetBlockAccessListsQuery(
+    db kv.Getter,
+    blockReader services.FullBlockReader,
+    query GetBlockAccessListsPacket66,
+    softResponseLimit int,
+) []rlp.RawValue { … }
+```
+
+- Iterate `query.BlockHashes`, resolve block number via `blockReader.HeaderNumber(hash)`.
+- Call `rawdb.ReadBlockAccessListBytes(db, hash, num)`.
+- If nil → append empty RLP list `[]byte{0xc0}`.
+- If size would exceed `softResponseLimit` (default 2 MiB), truncate and stop.
+
+Unit tests in `handlers_test.go`: seed rawdb with a BAL for one hash, leave another unseeded; assert response ordering + empty for the missing one.
+
+### Phase 4 — Sentry dispatch + subscriber plumbing
+
+- [p2p/sentry/sentry_grpc_server.go:450–540](p2p/sentry/sentry_grpc_server.go#L450): extend the inbound switch with:
+  ```go
+  case eth.GetBlockAccessListsMsg:
+      send(eth.ToProto[protocolVersion][msg.Code], peerID, msgBytes)
+  case eth.BlockAccessListsMsg:
+      send(eth.ToProto[protocolVersion][msg.Code], peerID, msgBytes)
+  ```
+  Same fan-out pattern as `GetBlockBodiesMsg` / `BlockBodiesMsg`.
+- [p2p/sentry/libsentry/protocol.go:25–94](p2p/sentry/libsentry/protocol.go#L25): add `ETH71` to `ethProtocolsByVersion`, extend the per-protocol `ProtoIds` whitelist with the two new MessageIds.
+- Negotiation: `MinProtocol(GET_BLOCK_ACCESS_LISTS_71)` must return `ETH71` so only eth/71 peers are queried.
+
+### Phase 5 — Consumer side: BAL fetcher for sync
+
+This is the substantial, net-new piece. The goal: during sync, fill the `kv.BlockAccessList` table for blocks whose `header.BlockAccessListHash != nil` and that we don't already have a BAL for.
+
+- New `p2p/download/bal_fetcher.go` (mirroring the bodies fetcher). Consumes from the sentry Messages stream subscribed to `BLOCK_ACCESS_LISTS_71`, validates `keccak256(rlp.encode(payload)) == header.BlockAccessListHash`, writes via `rawdb.WriteBlockAccessListBytes`.
+- Stage hook: post-headers, post-bodies, a `[N/M DownloadBALs]` stage (or attach to the existing bodies stage) that queues missing BAL hashes and waits on the fetcher.
+- Eviction: deferred — EIP-7928 defines BAL pruning separately; out of scope here.
+
+Decision point: whether to make BAL fetching a first-class blocking stage or an opportunistic background fetch. Recommend **background**: stage_exec already validates BAL locally via `ProcessBAL`, so missing-peer BALs are self-healing via local regeneration. p2p BAL is an optimisation for nodes that want to skip the recompute cost.
+
+### Phase 6 — Hive / integration tests
+
+- Hive EEST: verify eth/71 handshake negotiation.
+- Add a fixture block with a non-trivial BAL, exercise round-trip: peer A writes BAL, peer B sends `GetBlockAccessLists`, validates hash match.
+- CI entry under `.github/workflows/test-hive.yml` if the hive fixtures for eth/71 are added upstream; otherwise defer until they land.
+
+## Test plan per phase
+
+Before merging each phase:
+- `make lint`
+- `make erigon`
+- `go test -short ./p2p/... ./execution/types/... ./db/rawdb/...`
+- For phase 4+: run `mainnet-rpc-integ-tests` and `race-tests / tests-linux` on the PR.
+- Final: bal-devnet-2 integration (the existing skill `launch-bal-devnet-2`) with eth/71 enabled on both endpoints — verify BALs propagate over the wire rather than being generated locally only.
+
+## Risks & open questions
+
+1. **Amsterdam timing**: the Amsterdam activation timestamp on mainnet is not yet set (field is `*uint64`, nil on mainnet today). eth/71 must negotiate regardless of fork activation (peers can request BALs for historic blocks after the fork activates). No fork-gate on the wire protocol version itself — only on the header field's required-ness.
+2. **Empty-list semantics**: EIP spec says empty RLP list = "not available". Our implementation also produces `0xc0` when `ReadBlockAccessListBytes` returns nil. Need to distinguish "peer genuinely has no BAL for this hash" from "BAL is empty because the block had zero state accesses" — the latter is a valid hash (`empty.BlockAccessListHash`). Callers must compare against the header's expected hash.
+3. **Ordering**: spec says response array aligns positionally with request. Handler must preserve request order even when some entries are missing. Phase 3 enforces this.
+4. **Response limit**: EIP recommends 2 MiB per message. If a single BAL exceeds 2 MiB we return empty for it (peer will fall back to regenerate). Phase 3 handles this.
+5. **DoS**: large `GetBlockAccessLists` requests. Enforce per-peer request-rate and max-hashes-per-message limits (follow `BlockBodiesMsg` precedent — check its rate limit code path).
+6. **Pectra / Fusaka coexistence**: eth/71 must be backwards-compatible with older peers. Protocol negotiation already supports this in `libsentry/protocol.go` — new code paths must be gated on negotiated protocol version, not on header presence.
+
+## Out of scope for this feature branch
+
+- EIP-7928 improvements (BAL generation changes) — already tracked elsewhere.
+- BAL pruning / retention policy — separate EIP/work.
+- Consensus-layer changes in Caplin — EIP-8159 is EL-only.
+- RPC-level `debug_getBlockAccessList` (if wanted, separate endpoint addition).
+
+## Suggested PR stacking
+
+1. **PR 1** — Phases 1 + 2 (constants, packet types, serialization tests). Small, easily reviewed.
+2. **PR 2** — Phases 3 + 4 (handler + sentry wiring + libsentry negotiation). Mid-sized.
+3. **PR 3** — Phase 5 (consumer-side fetcher + stage integration). Largest, most review-worthy; depends on PR 2.
+4. **PR 4** — Phase 6 (hive tests, devnet verification). Independent; can land any time after PR 3.
+
+Each PR independently revertible. Total estimated diff ~500 LOC code + ~300 LOC tests.

--- a/node/direct/sentry_client.go
+++ b/node/direct/sentry_client.go
@@ -35,6 +35,7 @@ const (
 	ETH68 = 68
 	ETH69 = 69
 	ETH70 = 70
+	ETH71 = 71
 
 	WIT0 = 1
 )
@@ -44,11 +45,13 @@ var (
 		sentryproto.Protocol_ETH68: ETH68,
 		sentryproto.Protocol_ETH69: ETH69,
 		sentryproto.Protocol_ETH70: ETH70,
+		sentryproto.Protocol_ETH71: ETH71,
 	}
 	UintToProtocolMap = map[uint]sentryproto.Protocol{
 		ETH68: sentryproto.Protocol_ETH68,
 		ETH69: sentryproto.Protocol_ETH69,
 		ETH70: sentryproto.Protocol_ETH70,
+		ETH71: sentryproto.Protocol_ETH71,
 	}
 	SupportedSideProtocols = map[sentryproto.Protocol]struct{}{
 		sentryproto.Protocol_WIT0: {},

--- a/node/gointerfaces/sentryproto/sentry.pb.go
+++ b/node/gointerfaces/sentryproto/sentry.pb.go
@@ -74,6 +74,9 @@ const (
 	// ======= eth 70 protocol ===========
 	MessageId_GET_RECEIPTS_70 MessageId = 40
 	MessageId_RECEIPTS_70     MessageId = 41
+	// ======= eth 71 protocol (EIP-8159) ===========
+	MessageId_GET_BLOCK_ACCESS_LISTS_71 MessageId = 42
+	MessageId_BLOCK_ACCESS_LISTS_71     MessageId = 43
 )
 
 // Enum value maps for MessageId.
@@ -120,6 +123,8 @@ var (
 		39: "BLOCK_RANGE_UPDATE_69",
 		40: "GET_RECEIPTS_70",
 		41: "RECEIPTS_70",
+		42: "GET_BLOCK_ACCESS_LISTS_71",
+		43: "BLOCK_ACCESS_LISTS_71",
 	}
 	MessageId_value = map[string]int32{
 		"STATUS_65":                        0,
@@ -163,6 +168,8 @@ var (
 		"BLOCK_RANGE_UPDATE_69":            39,
 		"GET_RECEIPTS_70":                  40,
 		"RECEIPTS_70":                      41,
+		"GET_BLOCK_ACCESS_LISTS_71":        42,
+		"BLOCK_ACCESS_LISTS_71":            43,
 	}
 )
 
@@ -245,6 +252,7 @@ const (
 	Protocol_ETH68 Protocol = 3
 	Protocol_ETH69 Protocol = 4
 	Protocol_ETH70 Protocol = 6
+	Protocol_ETH71 Protocol = 7
 	Protocol_WIT0  Protocol = 5
 )
 
@@ -256,8 +264,9 @@ var (
 		2: "ETH67",
 		3: "ETH68",
 		4: "ETH69",
-		5: "WIT0",
 		6: "ETH70",
+		7: "ETH71",
+		5: "WIT0",
 	}
 	Protocol_value = map[string]int32{
 		"ETH65": 0,
@@ -266,6 +275,7 @@ var (
 		"ETH68": 3,
 		"ETH69": 4,
 		"ETH70": 6,
+		"ETH71": 7,
 		"WIT0":  5,
 	}
 )
@@ -1788,7 +1798,7 @@ const file_p2psentry_sentry_proto_rawDesc = "" +
 	"\fAddPeerReply\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\"+\n" +
 	"\x0fRemovePeerReply\x12\x18\n" +
-	"\asuccess\x18\x01 \x01(\bR\asuccess*\x9e\a\n" +
+	"\asuccess\x18\x01 \x01(\bR\asuccess*\xfe\a\n" +
 	"\tMessageId\x12\r\n" +
 	"\tSTATUS_65\x10\x00\x12\x18\n" +
 	"\x14GET_BLOCK_HEADERS_65\x10\x01\x12\x14\n" +
@@ -1829,15 +1839,21 @@ const file_p2psentry_sentry_proto_rawDesc = "" +
 	"\x15NEW_WITNESS_HASHES_W0\x10$\x12\r\n" +
 	"\tSTATUS_69\x10%\x12\x13\n" +
 	"\x0fGET_RECEIPTS_69\x10&\x12\x19\n" +
-	"\x15BLOCK_RANGE_UPDATE_69\x10'*\x17\n" +
+	"\x15BLOCK_RANGE_UPDATE_69\x10'\x12\x13\n" +
+	"\x0fGET_RECEIPTS_70\x10(\x12\x0f\n" +
+	"\vRECEIPTS_70\x10)\x12\x1d\n" +
+	"\x19GET_BLOCK_ACCESS_LISTS_71\x10*\x12\x19\n" +
+	"\x15BLOCK_ACCESS_LISTS_71\x10+*\x17\n" +
 	"\vPenaltyKind\x12\b\n" +
-	"\x04Kick\x10\x00*K\n" +
+	"\x04Kick\x10\x00*a\n" +
 	"\bProtocol\x12\t\n" +
 	"\x05ETH65\x10\x00\x12\t\n" +
 	"\x05ETH66\x10\x01\x12\t\n" +
 	"\x05ETH67\x10\x02\x12\t\n" +
 	"\x05ETH68\x10\x03\x12\t\n" +
-	"\x05ETH69\x10\x04\x12\b\n" +
+	"\x05ETH69\x10\x04\x12\t\n" +
+	"\x05ETH70\x10\x06\x12\t\n" +
+	"\x05ETH71\x10\a\x12\b\n" +
 	"\x04WIT0\x10\x052\xd5\n" +
 	"\n" +
 	"\x06Sentry\x127\n" +

--- a/node/interfaces/p2psentry/sentry.proto
+++ b/node/interfaces/p2psentry/sentry.proto
@@ -71,6 +71,10 @@ enum MessageId {
   // ======= eth 70 protocol ===========
   GET_RECEIPTS_70 = 40;
   RECEIPTS_70 = 41;
+
+  // ======= eth 71 protocol (EIP-8159) ===========
+  GET_BLOCK_ACCESS_LISTS_71 = 42;
+  BLOCK_ACCESS_LISTS_71 = 43;
 }
 
 message OutboundMessageData {
@@ -156,6 +160,7 @@ enum Protocol {
   ETH68 = 3;
   ETH69 = 4;
   ETH70 = 6;
+  ETH71 = 7;
   WIT0 = 5;
 }
 

--- a/p2p/protocols/eth/protocol.go
+++ b/p2p/protocols/eth/protocol.go
@@ -38,6 +38,7 @@ var ProtocolToString = map[uint]string{
 	direct.ETH68: "eth68",
 	direct.ETH69: "eth69",
 	direct.ETH70: "eth70",
+	direct.ETH71: "eth71",
 }
 
 // ProtocolName is the official short name of the `eth` protocol used during
@@ -48,7 +49,7 @@ const ProtocolName = "eth"
 const maxMessageSize = 10 * 1024 * 1024
 const ProtocolMaxMsgSize = maxMessageSize
 
-var ProtocolLengths = map[uint]uint64{direct.ETH68: 17, direct.ETH69: 18, direct.ETH70: 18}
+var ProtocolLengths = map[uint]uint64{direct.ETH68: 17, direct.ETH69: 18, direct.ETH70: 18, direct.ETH71: 20}
 
 const (
 	// Protocol messages in eth/64
@@ -68,6 +69,10 @@ const (
 	GetPooledTransactionsMsg      = 0x09
 	PooledTransactionsMsg         = 0x0a
 	BlockRangeUpdateMsg           = 0x11
+
+	// Protocol messages added in eth/71 (EIP-8159 Block Access List Exchange)
+	GetBlockAccessListsMsg = 0x12
+	BlockAccessListsMsg    = 0x13
 )
 
 var ToProto = map[uint]map[uint64]sentryproto.MessageId{
@@ -117,6 +122,25 @@ var ToProto = map[uint]map[uint64]sentryproto.MessageId{
 		PooledTransactionsMsg:         sentryproto.MessageId_POOLED_TRANSACTIONS_66,
 		BlockRangeUpdateMsg:           sentryproto.MessageId_BLOCK_RANGE_UPDATE_69,
 	},
+	direct.ETH71: {
+		StatusMsg:                     sentryproto.MessageId_STATUS_69,
+		GetBlockHeadersMsg:            sentryproto.MessageId_GET_BLOCK_HEADERS_66,
+		BlockHeadersMsg:               sentryproto.MessageId_BLOCK_HEADERS_66,
+		GetBlockBodiesMsg:             sentryproto.MessageId_GET_BLOCK_BODIES_66,
+		BlockBodiesMsg:                sentryproto.MessageId_BLOCK_BODIES_66,
+		GetReceiptsMsg:                sentryproto.MessageId_GET_RECEIPTS_70,
+		ReceiptsMsg:                   sentryproto.MessageId_RECEIPTS_70,
+		NewBlockHashesMsg:             sentryproto.MessageId_NEW_BLOCK_HASHES_66,
+		NewBlockMsg:                   sentryproto.MessageId_NEW_BLOCK_66,
+		TransactionsMsg:               sentryproto.MessageId_TRANSACTIONS_66,
+		NewPooledTransactionHashesMsg: sentryproto.MessageId_NEW_POOLED_TRANSACTION_HASHES_68,
+		GetPooledTransactionsMsg:      sentryproto.MessageId_GET_POOLED_TRANSACTIONS_66,
+		PooledTransactionsMsg:         sentryproto.MessageId_POOLED_TRANSACTIONS_66,
+		BlockRangeUpdateMsg:           sentryproto.MessageId_BLOCK_RANGE_UPDATE_69,
+		// Added in eth/71 (EIP-8159 Block Access List Exchange)
+		GetBlockAccessListsMsg: sentryproto.MessageId_GET_BLOCK_ACCESS_LISTS_71,
+		BlockAccessListsMsg:    sentryproto.MessageId_BLOCK_ACCESS_LISTS_71,
+	},
 }
 
 var FromProto = map[uint]map[sentryproto.MessageId]uint64{
@@ -163,6 +187,24 @@ var FromProto = map[uint]map[sentryproto.MessageId]uint64{
 		sentryproto.MessageId_GET_POOLED_TRANSACTIONS_66:       GetPooledTransactionsMsg,
 		sentryproto.MessageId_POOLED_TRANSACTIONS_66:           PooledTransactionsMsg,
 		sentryproto.MessageId_BLOCK_RANGE_UPDATE_69:            BlockRangeUpdateMsg,
+	},
+	direct.ETH71: {
+		sentryproto.MessageId_GET_BLOCK_HEADERS_66:             GetBlockHeadersMsg,
+		sentryproto.MessageId_BLOCK_HEADERS_66:                 BlockHeadersMsg,
+		sentryproto.MessageId_GET_BLOCK_BODIES_66:              GetBlockBodiesMsg,
+		sentryproto.MessageId_BLOCK_BODIES_66:                  BlockBodiesMsg,
+		sentryproto.MessageId_GET_RECEIPTS_70:                  GetReceiptsMsg,
+		sentryproto.MessageId_RECEIPTS_70:                      ReceiptsMsg,
+		sentryproto.MessageId_NEW_BLOCK_HASHES_66:              NewBlockHashesMsg,
+		sentryproto.MessageId_NEW_BLOCK_66:                     NewBlockMsg,
+		sentryproto.MessageId_TRANSACTIONS_66:                  TransactionsMsg,
+		sentryproto.MessageId_NEW_POOLED_TRANSACTION_HASHES_68: NewPooledTransactionHashesMsg,
+		sentryproto.MessageId_GET_POOLED_TRANSACTIONS_66:       GetPooledTransactionsMsg,
+		sentryproto.MessageId_POOLED_TRANSACTIONS_66:           PooledTransactionsMsg,
+		sentryproto.MessageId_BLOCK_RANGE_UPDATE_69:            BlockRangeUpdateMsg,
+		// Added in eth/71 (EIP-8159 Block Access List Exchange)
+		sentryproto.MessageId_GET_BLOCK_ACCESS_LISTS_71: GetBlockAccessListsMsg,
+		sentryproto.MessageId_BLOCK_ACCESS_LISTS_71:     BlockAccessListsMsg,
 	},
 }
 
@@ -350,6 +392,44 @@ type BlockBodiesRLPPacket66 struct {
 	RequestId uint64
 	BlockBodiesRLPPacket
 }
+
+// GetBlockAccessListsPacket is the eth/71 request to retrieve Block Access
+// Lists (EIP-7928) for a list of block hashes (EIP-8159).
+type GetBlockAccessListsPacket []common.Hash
+
+// GetBlockAccessListsPacket66 wraps GetBlockAccessListsPacket in the eth/66
+// request-id envelope. Reused unchanged for eth/71.
+type GetBlockAccessListsPacket66 struct {
+	RequestId uint64
+	GetBlockAccessListsPacket
+}
+
+// BlockAccessListsPacket is the eth/71 response to a GetBlockAccessLists
+// request. Entries are positionally aligned with the request: element i is
+// the BAL for request hash i. The BAL payload is the canonical RLP encoding
+// of a types.BlockAccessList per EIP-7928, passed through as RawValue since
+// rawdb stores it in that exact form.
+//
+// An empty RLP list (0xc0) in slot i has two possible meanings and MUST be
+// disambiguated by the caller via the corresponding header's
+// BlockAccessListHash:
+//   - "peer does not have this BAL" — hash will not match the header
+//   - "block has a genuinely empty BAL" — hash will equal the empty-list hash
+//     (see common/empty.BlockAccessListHash)
+type BlockAccessListsPacket []rlp.RawValue
+
+// BlockAccessListsPacket66 wraps BlockAccessListsPacket in the eth/66
+// request-id envelope. Reused unchanged for eth/71.
+type BlockAccessListsPacket66 struct {
+	RequestId uint64
+	BlockAccessListsPacket
+}
+
+func (p *GetBlockAccessListsPacket66) Name() string { return "GetBlockAccessLists" }
+func (p *GetBlockAccessListsPacket66) Kind() byte   { return GetBlockAccessListsMsg }
+
+func (p *BlockAccessListsPacket66) Name() string { return "BlockAccessLists" }
+func (p *BlockAccessListsPacket66) Kind() byte   { return BlockAccessListsMsg }
 
 // Unpack retrieves the transactions, uncles, withdrawals from the range packet and returns
 // them in a split flat format that's more consistent with the internal data structures.

--- a/p2p/protocols/eth/protocol_test.go
+++ b/p2p/protocols/eth/protocol_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/execution/rlp"
 	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/node/direct"
+	"github.com/erigontech/erigon/node/gointerfaces/sentryproto"
 )
 
 // Tests that the custom union field encoder and decoder works correctly.
@@ -90,6 +92,9 @@ func TestEth66EmptyMessages(t *testing.T) {
 		// Receipts
 		GetReceiptsPacket66{1111, nil},
 		ReceiptsPacket66{1111, nil},
+		// Block Access Lists (eth/71, EIP-8159)
+		GetBlockAccessListsPacket66{1111, nil},
+		BlockAccessListsPacket66{1111, nil},
 
 		// Headers
 		BlockHeadersPacket66{1111, BlockHeadersPacket([]*types.Header{})},
@@ -100,6 +105,9 @@ func TestEth66EmptyMessages(t *testing.T) {
 		// Receipts
 		GetReceiptsPacket66{1111, GetReceiptsPacket([]common.Hash{})},
 		ReceiptsPacket66{1111, ReceiptsPacket([][]*types.Receipt{})},
+		// Block Access Lists (eth/71, EIP-8159)
+		GetBlockAccessListsPacket66{1111, GetBlockAccessListsPacket([]common.Hash{})},
+		BlockAccessListsPacket66{1111, BlockAccessListsPacket([]rlp.RawValue{})},
 	} {
 		if have, _ := rlp.EncodeToBytes(msg); !bytes.Equal(have, want) {
 			t.Errorf("test %d, type %T, have\n\t%x\nwant\n\t%x", i, msg, have, want)
@@ -229,5 +237,125 @@ func TestEth66Messages(t *testing.T) {
 		if have, _ := rlp.EncodeToBytes(tc.message); !bytes.Equal(have, tc.want) {
 			t.Errorf("test %d, type %T, have\n\t%x\nwant\n\t%x", i, tc.message, have, tc.want)
 		}
+	}
+}
+
+// TestBlockAccessListsPacket66RoundTrip verifies the eth/71 (EIP-8159) BAL
+// exchange packet types encode and decode losslessly at every cardinality that
+// matters in production: nil, empty list, single RLP-empty-list ("not available"
+// or "genuinely empty BAL"), and a multi-entry response with heterogeneous
+// payloads.
+func TestBlockAccessListsPacket66RoundTrip(t *testing.T) {
+	const reqID uint64 = 0x12345678
+
+	hashA := common.Hash{0xaa, 0xbb, 0xcc}
+	hashB := common.Hash{0x11, 0x22, 0x33}
+	hashC := common.Hash{0x42}
+
+	// Non-trivial BAL payload stand-in: a valid RLP list of two byte-strings.
+	// We don't construct a full types.BlockAccessList here — wire layer treats
+	// the payload as opaque RLP bytes; content validation happens at the
+	// callsite via keccak256 comparison against header.BlockAccessListHash.
+	bal, err := rlp.EncodeToBytes([]any{[]byte{0x01, 0x02}, []byte{0x03}})
+	if err != nil {
+		t.Fatalf("encode stub BAL: %v", err)
+	}
+	emptyRLPList := common.FromHex("c0") // EIP-8159: empty list = "not available" OR "genuinely empty"
+
+	t.Run("GetBlockAccessLists", func(t *testing.T) {
+		cases := [][]common.Hash{
+			nil,
+			{},
+			{hashA},
+			{hashA, hashB, hashC},
+		}
+		for i, hashes := range cases {
+			msg := GetBlockAccessListsPacket66{RequestId: reqID, GetBlockAccessListsPacket: hashes}
+			enc, err := rlp.EncodeToBytes(&msg)
+			if err != nil {
+				t.Fatalf("case %d: encode: %v", i, err)
+			}
+			var dec GetBlockAccessListsPacket66
+			if err := rlp.DecodeBytes(enc, &dec); err != nil {
+				t.Fatalf("case %d: decode: %v", i, err)
+			}
+			if dec.RequestId != reqID {
+				t.Fatalf("case %d: request id: have %d want %d", i, dec.RequestId, reqID)
+			}
+			if len(dec.GetBlockAccessListsPacket) != len(hashes) {
+				t.Fatalf("case %d: hash count: have %d want %d", i, len(dec.GetBlockAccessListsPacket), len(hashes))
+			}
+			for j := range hashes {
+				if dec.GetBlockAccessListsPacket[j] != hashes[j] {
+					t.Fatalf("case %d idx %d: hash mismatch: have %x want %x", i, j, dec.GetBlockAccessListsPacket[j], hashes[j])
+				}
+			}
+		}
+	})
+
+	t.Run("BlockAccessLists", func(t *testing.T) {
+		cases := [][]rlp.RawValue{
+			nil,
+			{},
+			{emptyRLPList},           // single "not available / empty" entry
+			{bal},                    // single populated BAL
+			{bal, emptyRLPList, bal}, // mixed — some available, one not
+		}
+		for i, bals := range cases {
+			msg := BlockAccessListsPacket66{RequestId: reqID, BlockAccessListsPacket: bals}
+			enc, err := rlp.EncodeToBytes(&msg)
+			if err != nil {
+				t.Fatalf("case %d: encode: %v", i, err)
+			}
+			var dec BlockAccessListsPacket66
+			if err := rlp.DecodeBytes(enc, &dec); err != nil {
+				t.Fatalf("case %d: decode: %v", i, err)
+			}
+			if dec.RequestId != reqID {
+				t.Fatalf("case %d: request id: have %d want %d", i, dec.RequestId, reqID)
+			}
+			if len(dec.BlockAccessListsPacket) != len(bals) {
+				t.Fatalf("case %d: bal count: have %d want %d", i, len(dec.BlockAccessListsPacket), len(bals))
+			}
+			for j := range bals {
+				if !bytes.Equal(dec.BlockAccessListsPacket[j], bals[j]) {
+					t.Fatalf("case %d idx %d: payload mismatch: have %x want %x", i, j, dec.BlockAccessListsPacket[j], bals[j])
+				}
+			}
+		}
+	})
+}
+
+// TestEth71ProtocolRegistration verifies the eth/71 version is registered in
+// the protocol name/length tables and that the two new message codes route to
+// their sentry MessageId counterparts via ToProto/FromProto.
+func TestEth71ProtocolRegistration(t *testing.T) {
+	if name, ok := ProtocolToString[direct.ETH71]; !ok || name != "eth71" {
+		t.Fatalf("ProtocolToString[ETH71] = (%q, %v), want (eth71, true)", name, ok)
+	}
+	if length, ok := ProtocolLengths[direct.ETH71]; !ok || length != 20 {
+		t.Fatalf("ProtocolLengths[ETH71] = (%d, %v), want (20, true)", length, ok)
+	}
+
+	fwd := ToProto[direct.ETH71]
+	if fwd == nil {
+		t.Fatal("ToProto has no ETH71 entry")
+	}
+	if got := fwd[GetBlockAccessListsMsg]; got != sentryproto.MessageId_GET_BLOCK_ACCESS_LISTS_71 {
+		t.Errorf("ToProto[ETH71][GetBlockAccessListsMsg] = %v, want GET_BLOCK_ACCESS_LISTS_71", got)
+	}
+	if got := fwd[BlockAccessListsMsg]; got != sentryproto.MessageId_BLOCK_ACCESS_LISTS_71 {
+		t.Errorf("ToProto[ETH71][BlockAccessListsMsg] = %v, want BLOCK_ACCESS_LISTS_71", got)
+	}
+
+	rev := FromProto[direct.ETH71]
+	if rev == nil {
+		t.Fatal("FromProto has no ETH71 entry")
+	}
+	if got := rev[sentryproto.MessageId_GET_BLOCK_ACCESS_LISTS_71]; got != GetBlockAccessListsMsg {
+		t.Errorf("FromProto[ETH71][GET_BLOCK_ACCESS_LISTS_71] = %v, want GetBlockAccessListsMsg", got)
+	}
+	if got := rev[sentryproto.MessageId_BLOCK_ACCESS_LISTS_71]; got != BlockAccessListsMsg {
+		t.Errorf("FromProto[ETH71][BLOCK_ACCESS_LISTS_71] = %v, want BlockAccessListsMsg", got)
 	}
 }


### PR DESCRIPTION
## Summary

First of three stacked PRs implementing [EIP-8159](https://eips.ethereum.org/EIPS/eip-8159) — the eth/71 Block Access List exchange protocol. This PR lays the wire-protocol substrate: constants, message-code numbering, packet types, protobuf enum, and a round-trip encode/decode test. No peer-level logic yet.

Follows the implementation plan at [docs/plans/eip-8159-eth71-bal-exchange.md](docs/plans/eip-8159-eth71-bal-exchange.md) (added in the first commit).

### What lands

- `eth/71` added to `ProtocolToString` and `ProtocolLengths` with length 20.
- Message codes `GetBlockAccessListsMsg = 0x12`, `BlockAccessListsMsg = 0x13`.
- Request-id-wrapped packet types `GetBlockAccessListsPacket66` and `BlockAccessListsPacket66` (`[]common.Hash` in, `[]rlp.RawValue` out — the on-disk BAL bytes are already RLP).
- `ToProto` / `FromProto` entries for `ETH71` covering all existing eth/70 codes plus the two new ones.
- `sentry.proto` gains `GET_BLOCK_ACCESS_LISTS_71 = 42` and `BLOCK_ACCESS_LISTS_71 = 43`, with regenerated gRPC bindings.
- `TestBlockAccessListsPacket66RoundTrip` — RLP round-trip for nil / empty / populated / oversized hash lists.

### What's NOT here

No handler (PR 2), no sentry dispatch (PR 2), no fetcher (PR 3). Sending a `GetBlockAccessLists` message against this branch alone produces a protocol-level NACK.

## Stack

1. **This PR** — wire protocol constants + packet types.
2. #TBD (handler + sentry) — depends on this one.
3. #TBD (fetcher + downloader + devnet skill) — depends on 2.

## Test plan

- [x] `go test -short ./p2p/protocols/eth/...`
- [x] `make lint` (0 issues)
- [x] `make erigon integration`
- [ ] Downstream stacks (PR 2, PR 3) build and test cleanly on top.