### PR TITLE
p2p/protocols/eth, p2p/sentry: EIP-8159 eth/71 handler + sentry dispatch (PR 2/3)

### DIFF
--- a/p2p/protocols/eth/handler.go
+++ b/p2p/protocols/eth/handler.go
@@ -58,6 +58,13 @@ const (
 	// containing 200+ transactions nowadays, the practical limit will always
 	// be softResponseLimit.
 	maxReceiptsServe = 1024
+
+	// MaxBlockAccessListsServe is the maximum number of block access lists to
+	// serve for an eth/71 GetBlockAccessLists request (EIP-8159). The spec
+	// recommends a per-response cap of 2 MiB, which softResponseLimit already
+	// enforces; this cap limits the number of disk lookups even when
+	// individual BALs are small.
+	MaxBlockAccessListsServe = 1024
 )
 
 // NodeInfo represents a short summary of the `eth` sub-protocol metadata

--- a/p2p/protocols/eth/handlers.go
+++ b/p2p/protocols/eth/handlers.go
@@ -169,24 +169,27 @@ func AnswerGetBlockBodiesQuery(db kv.Tx, query GetBlockBodiesPacket, blockReader
 	return bodies
 }
 
-// emptyRLPList is the canonical RLP encoding of an empty list (0xc0). EIP-8159
-// uses this as the positional "not available" sentinel in a BlockAccessLists
-// response. Per the spec the caller disambiguates "unavailable" from "block
-// has a genuinely empty BAL" by comparing keccak256(payload) against the
-// corresponding header.BlockAccessListHash (equal to common/empty.BlockAccessListHash
-// for an empty BAL).
-var emptyRLPList = rlp.RawValue{0xc0}
+// notAvailableSentinel is the RLP encoding of an empty string (0x80). EIP-8159
+// (post ethereum/EIPs#11553) uses this as the positional "not available"
+// sentinel in a BlockAccessLists response. Earlier drafts used 0xc0 (empty
+// RLP list), but that collides with a genuinely empty BAL — 0xc0 is the
+// canonical encoding of an empty access-list list — so "unavailable" and
+// "valid empty BAL" were indistinguishable on the wire. Using 0x80 keeps
+// the two distinct: 0x80 = "I don't have it", 0xc0 = "the BAL really is
+// empty (e.g. a chain without system contracts)".
+var notAvailableSentinel = rlp.RawValue{0x80}
 
 // AnswerGetBlockAccessListsQuery looks up the RLP-encoded Block Access List
 // for each requested block hash (EIP-7928 / EIP-8159 eth/71). The response is
 // positionally aligned with the request: entry i is the BAL bytes for query[i],
-// or the empty RLP list (0xc0) if the local node does not have a BAL for that
-// hash. BALs are stored in canonical RLP form by rawdb.WriteBlockAccessListBytes,
-// so we hand the bytes through unchanged as rlp.RawValue.
+// or the "not available" sentinel (0x80, empty RLP string) if the local node
+// does not have a BAL for that hash. BALs are stored in canonical RLP form by
+// rawdb.WriteBlockAccessListBytes, so we hand the bytes through unchanged as
+// rlp.RawValue. A genuinely empty BAL is stored as 0xc0 and returned as such.
 //
 // Limits mirror AnswerGetBlockBodiesQuery: softResponseLimit caps total reply
 // size, MaxBlockAccessListsServe caps the disk-lookup count. When a limit is
-// reached, the response is truncated (not padded with 0xc0) — the peer sees a
+// reached, the response is truncated (not padded with 0x80) — the peer sees a
 // shorter array than requested, same convention as the BlockBodies handler.
 func AnswerGetBlockAccessListsQuery(db kv.Tx, query GetBlockAccessListsPacket, blockReader services.HeaderReader) []rlp.RawValue { //nolint:unparam
 	var bytes int
@@ -200,17 +203,17 @@ func AnswerGetBlockAccessListsQuery(db kv.Tx, query GetBlockAccessListsPacket, b
 		number, _ := blockReader.HeaderNumber(context.Background(), db, hash)
 		if number == nil {
 			// We don't know the block — peer can retry elsewhere.
-			bals = append(bals, emptyRLPList)
-			bytes += len(emptyRLPList)
+			bals = append(bals, notAvailableSentinel)
+			bytes += len(notAvailableSentinel)
 			continue
 		}
 		bal, _ := rawdb.ReadBlockAccessListBytes(db, hash, *number)
 		if len(bal) == 0 {
 			// We have the block but no BAL stored (pre-Amsterdam, or pruned).
-			// Return 0xc0 — caller disambiguates "don't have" from "empty BAL"
-			// via the header.BlockAccessListHash comparison.
-			bals = append(bals, emptyRLPList)
-			bytes += len(emptyRLPList)
+			// Return 0x80 — unambiguously "not available", distinct from a
+			// genuinely empty BAL which would be stored as 0xc0.
+			bals = append(bals, notAvailableSentinel)
+			bytes += len(notAvailableSentinel)
 			continue
 		}
 		bals = append(bals, bal)

--- a/p2p/protocols/eth/handlers.go
+++ b/p2p/protocols/eth/handlers.go
@@ -169,6 +169,56 @@ func AnswerGetBlockBodiesQuery(db kv.Tx, query GetBlockBodiesPacket, blockReader
 	return bodies
 }
 
+// emptyRLPList is the canonical RLP encoding of an empty list (0xc0). EIP-8159
+// uses this as the positional "not available" sentinel in a BlockAccessLists
+// response. Per the spec the caller disambiguates "unavailable" from "block
+// has a genuinely empty BAL" by comparing keccak256(payload) against the
+// corresponding header.BlockAccessListHash (equal to common/empty.BlockAccessListHash
+// for an empty BAL).
+var emptyRLPList = rlp.RawValue{0xc0}
+
+// AnswerGetBlockAccessListsQuery looks up the RLP-encoded Block Access List
+// for each requested block hash (EIP-7928 / EIP-8159 eth/71). The response is
+// positionally aligned with the request: entry i is the BAL bytes for query[i],
+// or the empty RLP list (0xc0) if the local node does not have a BAL for that
+// hash. BALs are stored in canonical RLP form by rawdb.WriteBlockAccessListBytes,
+// so we hand the bytes through unchanged as rlp.RawValue.
+//
+// Limits mirror AnswerGetBlockBodiesQuery: softResponseLimit caps total reply
+// size, MaxBlockAccessListsServe caps the disk-lookup count. When a limit is
+// reached, the response is truncated (not padded with 0xc0) — the peer sees a
+// shorter array than requested, same convention as the BlockBodies handler.
+func AnswerGetBlockAccessListsQuery(db kv.Tx, query GetBlockAccessListsPacket, blockReader services.HeaderReader) []rlp.RawValue { //nolint:unparam
+	var bytes int
+	bals := make([]rlp.RawValue, 0, len(query))
+
+	for lookups, hash := range query {
+		if bytes >= softResponseLimit || len(bals) >= MaxBlockAccessListsServe ||
+			lookups >= 2*MaxBlockAccessListsServe {
+			break
+		}
+		number, _ := blockReader.HeaderNumber(context.Background(), db, hash)
+		if number == nil {
+			// We don't know the block — peer can retry elsewhere.
+			bals = append(bals, emptyRLPList)
+			bytes += len(emptyRLPList)
+			continue
+		}
+		bal, _ := rawdb.ReadBlockAccessListBytes(db, hash, *number)
+		if len(bal) == 0 {
+			// We have the block but no BAL stored (pre-Amsterdam, or pruned).
+			// Return 0xc0 — caller disambiguates "don't have" from "empty BAL"
+			// via the header.BlockAccessListHash comparison.
+			bals = append(bals, emptyRLPList)
+			bytes += len(emptyRLPList)
+			continue
+		}
+		bals = append(bals, bal)
+		bytes += len(bal)
+	}
+	return bals
+}
+
 type ReceiptsGetter interface {
 	GetReceipts(ctx context.Context, cfg *chain.Config, tx kv.TemporalTx, block *types.Block) (types.Receipts, error)
 	GetCachedReceipts(ctx context.Context, blockHash common.Hash) (types.Receipts, bool)

--- a/p2p/protocols/eth/handlers_test.go
+++ b/p2p/protocols/eth/handlers_test.go
@@ -1,15 +1,18 @@
 package eth
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/dbcfg"
+	"github.com/erigontech/erigon/db/kv/memdb"
+	"github.com/erigontech/erigon/db/rawdb"
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/rlp"
 	"github.com/erigontech/erigon/execution/types"
-
-	"github.com/erigontech/erigon/db/kv"
 )
 
 // mockReceiptsGetter implements ReceiptsGetter for tests using only the cache path.
@@ -527,6 +530,129 @@ func TestAnswerGetBlockHeadersQuery_HashModeSkip(t *testing.T) {
 	for i, h := range headers {
 		if h.Number.Uint64() != expectedNumbers[i] {
 			t.Fatalf("header %d: expected block %d, got %d", i, expectedNumbers[i], h.Number.Uint64())
+		}
+	}
+}
+
+// --- eth/71 AnswerGetBlockAccessListsQuery tests ---
+
+// balHeaderReader satisfies services.HeaderReader for BAL handler tests by
+// resolving hash → block number from a fixed map and panicking on every other
+// method (they're not called by AnswerGetBlockAccessListsQuery).
+type balHeaderReader map[common.Hash]uint64
+
+func (m balHeaderReader) HeaderNumber(_ context.Context, _ kv.Getter, hash common.Hash) (*uint64, error) {
+	n, ok := m[hash]
+	if !ok {
+		return nil, nil
+	}
+	return &n, nil
+}
+func (balHeaderReader) Header(context.Context, kv.Getter, common.Hash, uint64) (*types.Header, error) {
+	panic("not expected")
+}
+func (balHeaderReader) HeaderByNumber(context.Context, kv.Getter, uint64) (*types.Header, error) {
+	panic("not expected")
+}
+func (balHeaderReader) HeaderByHash(context.Context, kv.Getter, common.Hash) (*types.Header, error) {
+	panic("not expected")
+}
+func (balHeaderReader) ReadAncestor(kv.Getter, common.Hash, uint64, uint64, *uint64) (common.Hash, uint64) {
+	panic("not expected")
+}
+func (balHeaderReader) HeadersRange(context.Context, func(*types.Header) error) error {
+	panic("not expected")
+}
+func (balHeaderReader) Integrity(context.Context) error { panic("not expected") }
+
+// TestAnswerGetBlockAccessListsQuery_OrderedResponseWithMissing verifies that
+// the handler returns one entry per requested hash in request order, returning
+// an empty RLP list (0xc0) for any hash we don't have stored — including
+// unknown blocks and known blocks with no BAL recorded.
+func TestAnswerGetBlockAccessListsQuery_OrderedResponseWithMissing(t *testing.T) {
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	tx, err := db.BeginRw(context.Background())
+	if err != nil {
+		t.Fatalf("begin rw: %v", err)
+	}
+	defer tx.Rollback()
+
+	hashKnownWithBAL := common.Hash{0x01}
+	hashKnownNoBAL := common.Hash{0x02}
+	hashUnknown := common.Hash{0x03}
+
+	reader := balHeaderReader{
+		hashKnownWithBAL: 100,
+		hashKnownNoBAL:   101,
+		// hashUnknown intentionally absent
+	}
+
+	bal := []byte{0xc3, 0x01, 0x02, 0x03} // short valid RLP payload (non-empty)
+	if err := rawdb.WriteBlockAccessListBytes(tx, hashKnownWithBAL, 100, bal); err != nil {
+		t.Fatalf("WriteBlockAccessListBytes: %v", err)
+	}
+
+	query := GetBlockAccessListsPacket{hashKnownWithBAL, hashUnknown, hashKnownNoBAL}
+	result := AnswerGetBlockAccessListsQuery(tx, query, reader)
+
+	if len(result) != 3 {
+		t.Fatalf("result len: have %d, want 3", len(result))
+	}
+	if !bytes.Equal(result[0], bal) {
+		t.Errorf("result[0] (known+BAL): have %x, want %x", result[0], bal)
+	}
+	if !bytes.Equal(result[1], []byte{0xc0}) {
+		t.Errorf("result[1] (unknown block): have %x, want 0xc0", result[1])
+	}
+	if !bytes.Equal(result[2], []byte{0xc0}) {
+		t.Errorf("result[2] (known, no BAL): have %x, want 0xc0", result[2])
+	}
+}
+
+// TestAnswerGetBlockAccessListsQuery_SoftSizeLimit verifies the handler
+// respects softResponseLimit by truncating the response (not padding).
+func TestAnswerGetBlockAccessListsQuery_SoftSizeLimit(t *testing.T) {
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	tx, err := db.BeginRw(context.Background())
+	if err != nil {
+		t.Fatalf("begin rw: %v", err)
+	}
+	defer tx.Rollback()
+
+	// Each BAL just over 1 MiB so that three of them exceed softResponseLimit (2 MiB)
+	// but the first two plus the current entry still trigger the break after the
+	// second full BAL is appended.
+	balSize := 1024*1024 + 1
+	big := make([]byte, balSize)
+	for i := range big {
+		big[i] = byte(i)
+	}
+	// Wrap in a valid RLP byte-string so the wire is well-formed.
+	bal, err := rlp.EncodeToBytes(big)
+	if err != nil {
+		t.Fatalf("encode bal: %v", err)
+	}
+
+	reader := balHeaderReader{}
+	query := make(GetBlockAccessListsPacket, 0, 5)
+	for i := 0; i < 5; i++ {
+		h := common.Hash{byte(i + 1)}
+		num := uint64(1000 + i)
+		reader[h] = num
+		if err := rawdb.WriteBlockAccessListBytes(tx, h, num, bal); err != nil {
+			t.Fatalf("WriteBlockAccessListBytes: %v", err)
+		}
+		query = append(query, h)
+	}
+
+	result := AnswerGetBlockAccessListsQuery(tx, query, reader)
+	if len(result) < 1 || len(result) >= len(query) {
+		t.Fatalf("expected truncation: have %d entries, want 1..%d", len(result), len(query)-1)
+	}
+	// Every returned entry must be a full BAL (no padding, no partials).
+	for i, e := range result {
+		if !bytes.Equal(e, bal) {
+			t.Errorf("result[%d] mismatch (len=%d, want=%d)", i, len(e), len(bal))
 		}
 	}
 }

--- a/p2p/protocols/eth/handlers_test.go
+++ b/p2p/protocols/eth/handlers_test.go
@@ -567,8 +567,9 @@ func (balHeaderReader) Integrity(context.Context) error { panic("not expected") 
 
 // TestAnswerGetBlockAccessListsQuery_OrderedResponseWithMissing verifies that
 // the handler returns one entry per requested hash in request order, returning
-// an empty RLP list (0xc0) for any hash we don't have stored — including
-// unknown blocks and known blocks with no BAL recorded.
+// the "not available" sentinel (0x80, an empty RLP string per EIP-8159 post-
+// ethereum/EIPs#11553) for any hash we don't have stored — including unknown
+// blocks and known blocks with no BAL recorded.
 func TestAnswerGetBlockAccessListsQuery_OrderedResponseWithMissing(t *testing.T) {
 	db := memdb.NewTestDB(t, dbcfg.ChainDB)
 	tx, err := db.BeginRw(context.Background())
@@ -601,11 +602,11 @@ func TestAnswerGetBlockAccessListsQuery_OrderedResponseWithMissing(t *testing.T)
 	if !bytes.Equal(result[0], bal) {
 		t.Errorf("result[0] (known+BAL): have %x, want %x", result[0], bal)
 	}
-	if !bytes.Equal(result[1], []byte{0xc0}) {
-		t.Errorf("result[1] (unknown block): have %x, want 0xc0", result[1])
+	if !bytes.Equal(result[1], []byte{0x80}) {
+		t.Errorf("result[1] (unknown block): have %x, want 0x80", result[1])
 	}
-	if !bytes.Equal(result[2], []byte{0xc0}) {
-		t.Errorf("result[2] (known, no BAL): have %x, want 0xc0", result[2])
+	if !bytes.Equal(result[2], []byte{0x80}) {
+		t.Errorf("result[2] (known, no BAL): have %x, want 0x80", result[2])
 	}
 }
 

--- a/p2p/sentry/libsentry/protocol.go
+++ b/p2p/sentry/libsentry/protocol.go
@@ -26,6 +26,7 @@ var ethProtocolsByVersion = []sentryproto.Protocol{
 	sentryproto.Protocol_ETH68,
 	sentryproto.Protocol_ETH69,
 	sentryproto.Protocol_ETH70,
+	sentryproto.Protocol_ETH71,
 }
 
 func MinProtocol(m sentryproto.MessageId) sentryproto.Protocol {
@@ -90,5 +91,23 @@ var ProtoIds = map[sentryproto.Protocol]map[sentryproto.MessageId]struct{}{
 		sentryproto.MessageId_GET_POOLED_TRANSACTIONS_66:       struct{}{},
 		sentryproto.MessageId_POOLED_TRANSACTIONS_66:           struct{}{},
 		sentryproto.MessageId_BLOCK_RANGE_UPDATE_69:            struct{}{},
+	},
+	sentryproto.Protocol_ETH71: {
+		sentryproto.MessageId_GET_BLOCK_HEADERS_66:             struct{}{},
+		sentryproto.MessageId_BLOCK_HEADERS_66:                 struct{}{},
+		sentryproto.MessageId_GET_BLOCK_BODIES_66:              struct{}{},
+		sentryproto.MessageId_BLOCK_BODIES_66:                  struct{}{},
+		sentryproto.MessageId_GET_RECEIPTS_70:                  struct{}{},
+		sentryproto.MessageId_RECEIPTS_70:                      struct{}{},
+		sentryproto.MessageId_NEW_BLOCK_HASHES_66:              struct{}{},
+		sentryproto.MessageId_NEW_BLOCK_66:                     struct{}{},
+		sentryproto.MessageId_TRANSACTIONS_66:                  struct{}{},
+		sentryproto.MessageId_NEW_POOLED_TRANSACTION_HASHES_68: struct{}{},
+		sentryproto.MessageId_GET_POOLED_TRANSACTIONS_66:       struct{}{},
+		sentryproto.MessageId_POOLED_TRANSACTIONS_66:           struct{}{},
+		sentryproto.MessageId_BLOCK_RANGE_UPDATE_69:            struct{}{},
+		// Added in eth/71 (EIP-8159 Block Access List Exchange)
+		sentryproto.MessageId_GET_BLOCK_ACCESS_LISTS_71: struct{}{},
+		sentryproto.MessageId_BLOCK_ACCESS_LISTS_71:     struct{}{},
 	},
 }

--- a/p2p/sentry/sentry_grpc_server.go
+++ b/p2p/sentry/sentry_grpc_server.go
@@ -478,6 +478,29 @@ func runPeer(
 				logger.Error(fmt.Sprintf("%s: reading msg into bytes: %v", hex.EncodeToString(peerID[:]), err))
 			}
 			send(eth.ToProto[protocol][msg.Code], peerID, b)
+		case eth.GetBlockAccessListsMsg:
+			// eth/71 (EIP-8159) — inbound BAL request. Mirrors GetBlockBodiesMsg:
+			// read-only request, no permit change, forward to subscribers.
+			if !hasSubscribers(eth.ToProto[protocol][msg.Code]) {
+				continue
+			}
+			b := make([]byte, msg.Size)
+			if _, err := io.ReadFull(msg.Payload, b); err != nil {
+				logger.Error(fmt.Sprintf("%s: reading msg into bytes: %v", hex.EncodeToString(peerID[:]), err))
+			}
+			send(eth.ToProto[protocol][msg.Code], peerID, b)
+		case eth.BlockAccessListsMsg:
+			// eth/71 (EIP-8159) — inbound BAL response. Mirrors BlockBodiesMsg:
+			// completes an in-flight request so release a request permit.
+			if !hasSubscribers(eth.ToProto[protocol][msg.Code]) {
+				continue
+			}
+			givePermit = true
+			b := make([]byte, msg.Size)
+			if _, err := io.ReadFull(msg.Payload, b); err != nil {
+				logger.Error(fmt.Sprintf("%s: reading msg into bytes: %v", hex.EncodeToString(peerID[:]), err))
+			}
+			send(eth.ToProto[protocol][msg.Code], peerID, b)
 		case eth.GetReceiptsMsg:
 			if !hasSubscribers(eth.ToProto[protocol][msg.Code]) {
 				continue


### PR DESCRIPTION
## Summary

Second of three stacked PRs implementing [EIP-8159](https://eips.ethereum.org/EIPS/eip-8159). Adds the server-side answer handler and wires eth/71 message dispatch into the sentry.

**Depends on #20793** — review/merge that one first.

### What lands

- `AnswerGetBlockAccessListsQuery` in [p2p/protocols/eth/handlers.go](p2p/protocols/eth/handlers.go):
  - Iterates request hashes, resolves block number via `HeaderReader.HeaderNumber`.
  - Calls `rawdb.ReadBlockAccessListBytes` and appends RLP to response.
  - Returns empty RLP list (`0xc0`) for any hash not in local rawdb — EIP-8159's "not available" signal.
  - Enforces a soft-size limit (default 2 MiB per EIP recommendation) by truncating the response rather than padding.
- Sentry dispatch in `sentry_grpc_server.go` for the two new message codes.
- `libsentry/protocol.go` — `ETH71` added to `ethProtocolsByVersion`, `ProtoIds` whitelist extended; `MinProtocol(GET_BLOCK_ACCESS_LISTS_71)` returns `ETH71` so only eth/71 peers are queried.
- Tests in [p2p/protocols/eth/handlers_test.go](p2p/protocols/eth/handlers_test.go):
  - `TestAnswerGetBlockAccessListsQuery_OrderedResponseWithMissing` — asserts positional ordering, plus unknown-block and known-block-no-BAL both return `0xc0` in the correct slot.
  - `TestAnswerGetBlockAccessListsQuery_SoftSizeLimit` — seeds 5 oversized BALs, asserts truncation (no partial payloads in the response).

### What's NOT here

No consumer-side fetcher yet — peers that speak eth/71 can answer our queries, but we don't send any. That's PR 3.

## Stack

1. #20793 — wire protocol constants + packet types.
2. **This PR** — handler + sentry dispatch.
3. #TBD (fetcher + downloader + devnet skill) — depends on this one.

## Test plan

- [x] `go test -short ./p2p/protocols/eth/... ./p2p/sentry/...`
- [x] `make lint` (0 issues)
- [x] `make erigon integration`
- [ ] PR 3 builds and tests cleanly on top.