### PR TITLE
p2p/protocols/wit, p2p/sentry: validate WitnessPageResponse fields

### DIFF
--- a/p2p/protocols/wit/protocol.go
+++ b/p2p/protocols/wit/protocol.go
@@ -39,6 +39,12 @@ const (
 	MaximumCachedWitnessOnARequest = 200 * 1024 * 1024 // 200 MB, the maximum amount of memory a request can demand while getting witness
 	MaximumResponseSize            = 16 * 1024 * 1024  // 16 MB, helps to fast fail check
 
+	// MaxWitnessPages caps the TotalPages a peer may advertise in a response. A
+	// legitimate witness fits in MaximumCachedWitnessOnARequest bytes split into
+	// PageSize chunks; anything larger is attacker-inflated and would drive
+	// unbounded allocation in the response handler.
+	MaxWitnessPages = (MaximumCachedWitnessOnARequest + PageSize - 1) / PageSize
+
 	// RetentionBlocks defines how many recent blocks to keep witness data for
 	RetentionBlocks = 10_000
 )

--- a/p2p/sentry/sentry_multi_client/sentry_multi_client.go
+++ b/p2p/sentry/sentry_multi_client/sentry_multi_client.go
@@ -901,8 +901,8 @@ func (cs *MultiClient) addBlockWitnesses(ctx context.Context, inreq *sentryproto
 		if pageResponse.TotalPages > wit.MaxWitnessPages {
 			return fmt.Errorf("witness response advertises TotalPages %d > max %d for hash %x", pageResponse.TotalPages, wit.MaxWitnessPages, pageResponse.Hash)
 		}
-		// Per protocol, Page >= TotalPages signals that the peer has no data for this
-		// witness (e.g. TotalPages == 0). Skip rather than allocate or reject.
+		// Page >= TotalPages is the empty-response sentinel documented on
+		// wit.WitnessPageResponse.Page; skip without allocating.
 		if pageResponse.Page >= pageResponse.TotalPages {
 			continue
 		}

--- a/p2p/sentry/sentry_multi_client/sentry_multi_client.go
+++ b/p2p/sentry/sentry_multi_client/sentry_multi_client.go
@@ -898,6 +898,17 @@ func (cs *MultiClient) addBlockWitnesses(ctx context.Context, inreq *sentryproto
 	witnessTotalPages := make(map[common.Hash]uint64)
 
 	for _, pageResponse := range query.WitnessPacketResponse {
+		if pageResponse.TotalPages > wit.MaxWitnessPages {
+			return fmt.Errorf("witness response advertises TotalPages %d > max %d for hash %x", pageResponse.TotalPages, wit.MaxWitnessPages, pageResponse.Hash)
+		}
+		// Per protocol, Page >= TotalPages signals that the peer has no data for this
+		// witness (e.g. TotalPages == 0). Skip rather than allocate or reject.
+		if pageResponse.Page >= pageResponse.TotalPages {
+			continue
+		}
+		if prev, ok := witnessTotalPages[pageResponse.Hash]; ok && prev != pageResponse.TotalPages {
+			return fmt.Errorf("witness response has inconsistent TotalPages for hash %x: %d vs %d", pageResponse.Hash, prev, pageResponse.TotalPages)
+		}
 		if witnessPages[pageResponse.Hash] == nil {
 			witnessPages[pageResponse.Hash] = make(map[uint64][]byte)
 		}

--- a/p2p/sentry/sentry_multi_client/witness_test.go
+++ b/p2p/sentry/sentry_multi_client/witness_test.go
@@ -647,3 +647,106 @@ func TestWitnessExactPageSize(t *testing.T) {
 	err = multiClient.getBlockWitnesses(ctx, inboundMsg, mockSentryClient)
 	require.NoError(t, err)
 }
+
+// Regression for a single-packet DoS: an inflated TotalPages claim used to
+// drive the missing-pages loop into allocating gigabytes.
+func TestAddBlockWitnessesRejectsInflatedTotalPages(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ctx := context.Background()
+	mockSentryClient := direct.NewMockSentryClient(ctrl)
+	multiClient, _ := createTestMultiClient(t)
+
+	t.Run("TotalPages above cap is rejected", func(t *testing.T) {
+		payload, err := rlp.EncodeToBytes(&wit.WitnessPacketRLPPacket{
+			RequestId: 1,
+			WitnessPacketResponse: wit.WitnessPacketResponse{{
+				Data:       []byte{0xDE, 0xAD},
+				Hash:       common.Hash{0x42},
+				Page:       0,
+				TotalPages: 100_000_000,
+			}},
+		})
+		require.NoError(t, err)
+
+		inbound := &sentryproto.InboundMessage{
+			Id:     sentryproto.MessageId_BLOCK_WITNESS_W0,
+			Data:   payload,
+			PeerId: gointerfaces.ConvertHashToH512([64]byte{0x01}),
+		}
+
+		err = multiClient.handleInboundMessage(ctx, inbound, mockSentryClient)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "TotalPages")
+	})
+
+	t.Run("inconsistent TotalPages across pages for same hash is rejected", func(t *testing.T) {
+		hash := common.Hash{0x99}
+		payload, err := rlp.EncodeToBytes(&wit.WitnessPacketRLPPacket{
+			RequestId: 2,
+			WitnessPacketResponse: wit.WitnessPacketResponse{
+				{Data: []byte{0x01}, Hash: hash, Page: 0, TotalPages: 2},
+				{Data: []byte{0x02}, Hash: hash, Page: 1, TotalPages: 3},
+			},
+		})
+		require.NoError(t, err)
+
+		inbound := &sentryproto.InboundMessage{
+			Id:     sentryproto.MessageId_BLOCK_WITNESS_W0,
+			Data:   payload,
+			PeerId: gointerfaces.ConvertHashToH512([64]byte{0x02}),
+		}
+
+		err = multiClient.handleInboundMessage(ctx, inbound, mockSentryClient)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "inconsistent TotalPages")
+	})
+
+	t.Run("Page >= TotalPages is skipped (peer-has-no-witness sentinel)", func(t *testing.T) {
+		payload, err := rlp.EncodeToBytes(&wit.WitnessPacketRLPPacket{
+			RequestId: 3,
+			WitnessPacketResponse: wit.WitnessPacketResponse{{
+				Data:       nil,
+				Hash:       common.Hash{0x33},
+				Page:       0,
+				TotalPages: 0,
+			}},
+		})
+		require.NoError(t, err)
+
+		inbound := &sentryproto.InboundMessage{
+			Id:     sentryproto.MessageId_BLOCK_WITNESS_W0,
+			Data:   payload,
+			PeerId: gointerfaces.ConvertHashToH512([64]byte{0x03}),
+		}
+
+		err = multiClient.handleInboundMessage(ctx, inbound, mockSentryClient)
+		require.NoError(t, err)
+	})
+
+	t.Run("TotalPages at cap is accepted", func(t *testing.T) {
+		payload, err := rlp.EncodeToBytes(&wit.WitnessPacketRLPPacket{
+			RequestId: 4,
+			WitnessPacketResponse: wit.WitnessPacketResponse{{
+				Data:       []byte{0xAB},
+				Hash:       common.Hash{0x44},
+				Page:       0,
+				TotalPages: wit.MaxWitnessPages,
+			}},
+		})
+		require.NoError(t, err)
+
+		inbound := &sentryproto.InboundMessage{
+			Id:     sentryproto.MessageId_BLOCK_WITNESS_W0,
+			Data:   payload,
+			PeerId: gointerfaces.ConvertHashToH512([64]byte{0x04}),
+		}
+
+		mockSentryClient.EXPECT().
+			SendMessageById(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&sentryproto.SentPeers{}, nil).
+			Times(1)
+
+		err = multiClient.handleInboundMessage(ctx, inbound, mockSentryClient)
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
Closes https://github.com/ethereum-bounty/erigon/issues/6

## Summary
- Cap `WitnessPageResponse.TotalPages` at `MaxWitnessPages` (= `ceil(MaximumCachedWitnessOnARequest / PageSize)` = 14). Reject anything larger.
- Reject responses that advertise different `TotalPages` across pages of the same witness.
- Keep `Page >= TotalPages` as the "peer has no witness for this hash" sentinel documented on `WitnessPageResponse.Page` and skip without allocating.

Without the cap, `addBlockWitnesses` used the peer-controlled `TotalPages` as a loop bound when enumerating missing pages. A single `WitnessMsg` with an inflated `TotalPages` (e.g. `1e8`) drove O(TotalPages) slice growth and could OOM a node. Reachable only for nodes running the WIT protocol (Polygon/Bor with `--polygon.wit-protocol`).

A legitimate server already caps witnesses at `MaximumCachedWitnessOnARequest` (200 MB) served in `PageSize` (15 MB) chunks, so honest peers never advertise more than 14 pages per witness.

## Test plan
- [x] New `TestAddBlockWitnessesRejectsInflatedTotalPages` with four subcases: over-cap rejected, inconsistent-across-pages rejected, `TotalPages == 0` sentinel skipped, cap-boundary (`TotalPages == MaxWitnessPages`) accepted.
- [x] Existing witness tests unaffected (`TestWitnessPagination`, `TestWitnessFunctionsThroughMessageHandler`, `TestGetBlockWitnessesFunction`, `TestNewWitnessFunction`, `TestWitnessExactPageSize`).
- [x] `make lint` clean.
- [x] `make erigon integration` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)