### PR TITLE
txnprovider/txpool: tolerate invalid EIP-7702 auth tuples

### DIFF
--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -781,7 +781,7 @@ func (p *TxPool) best(ctx context.Context, n int, txns *TxnsRlp, onTopOf uint64,
 		// not an exact science using intrinsic gas but as close as we could hope for at
 		// this stage
 		isAATxn := mt.TxnSlot.TxType() == types.AccountAbstractionTxType
-		authorizationLen := uint64(len(mt.TxnSlot.AuthAndNonces))
+		authorizationLen := uint64(len(mt.TxnSlot.Txn.GetAuthorizations()))
 		intrinsicGasResult, _ := mdgas.CalcIntrinsicGas(mdgas.IntrinsicGasCalcArgs{
 			Data:               make([]byte, mt.TxnSlot.GetDataLen()),
 			DataNonZeroLen:     uint64(mt.TxnSlot.GetDataNonZeroLen()),
@@ -951,7 +951,10 @@ func (p *TxPool) validateTx(txn *TxnSlot, isLocal bool, stateCache kvcache.Cache
 		}
 	}
 
-	authorizationLen := len(txn.AuthAndNonces)
+	// Use the on-tx authorization list length, not len(AuthAndNonces): per
+	// EIP-7702 the sender pays for every auth tuple regardless of validity,
+	// and AuthAndNonces only holds successfully-recovered entries.
+	authorizationLen := len(txn.Txn.GetAuthorizations())
 	if txn.TxType() == SetCodeTxnType {
 		if !isPrague {
 			return txpoolcfg.TypeNotActivated

--- a/txnprovider/txpool/pool_test.go
+++ b/txnprovider/txpool/pool_test.go
@@ -82,6 +82,10 @@ func newTestSetCodeTxnSlot(nonce uint64, senderID uint64, tip, feeCap uint64, ga
 			TipCap: *uint256.NewInt(tip),
 			FeeCap: *uint256.NewInt(feeCap),
 		},
+		// One placeholder auth tuple so Txn.GetAuthorizations() length matches
+		// the AuthAndNonces the test will set: the pool reads the on-tx list
+		// for gas billing and the non-empty check (validateTx).
+		Authorizations: []types.Authorization{{}},
 	}
 	return &TxnSlot{
 		Txn:      txn,

--- a/txnprovider/txpool/pool_txn_packets_test.go
+++ b/txnprovider/txpool/pool_txn_packets_test.go
@@ -17,6 +17,7 @@
 package txpool
 
 import (
+	"bytes"
 	"fmt"
 	"strconv"
 	"testing"
@@ -24,7 +25,10 @@ import (
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/crypto"
 	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/execution/types"
 )
 
 var hashParseTests = []struct {
@@ -193,6 +197,118 @@ var tpEncodeTests = []struct {
 		},
 		encoded: "f8d2f867088504a817c8088302e2489435353535353535353535353535353535353535358202008025a064b1702d9298fee62dfeccc57d322a463ad55ca201256d01f62b45b2e1c21c12a064b1702d9298fee62dfeccc57d322a463ad55ca201256d01f62b45b2e1c21c10f867098504a817c809830334509435353535353535353535353535353535353535358202d98025a052f8f61201b2b11a78d6e866abc9c3db2ae8631fa656bfe5cb53668255367afba052f8f61201b2b11a78d6e866abc9c3db2ae8631fa656bfe5cb53668255367afb", expectedErr: false, chainID: 1,
 	},
+}
+
+// TestEIP7702BatchPoisoning is a regression test for
+// https://github.com/ethereum-bounty/erigon/issues/7. A single EIP-7702
+// SetCode transaction carrying one auth tuple with an unrecoverable signature
+// must not cause sibling transactions in the same Transactions / PooledTransactions
+// devp2p packet to be dropped, nor invalidate the SetCode transaction itself.
+// Per the EIP, "if any step fails for a tuple, processing continues to the
+// next one" — invalid auth tuples are skipped at execution time and the
+// enclosing transaction remains valid (the sender still pays for every tuple).
+func TestEIP7702BatchPoisoning(t *testing.T) {
+	chainID := uint256.NewInt(1)
+	signer := types.LatestSignerForChainID(chainID.ToBig())
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	to := common.Address{0x42}
+
+	mkDynFee := func(nonce uint64) types.Transaction {
+		unsigned := &types.DynamicFeeTransaction{
+			CommonTx: types.CommonTx{
+				Nonce:    nonce,
+				GasLimit: 21000,
+				To:       &to,
+			},
+			ChainID: *chainID,
+			TipCap:  *uint256.NewInt(1_000_000),
+			FeeCap:  *uint256.NewInt(1_000_000),
+		}
+		signed, signErr := types.SignTx(unsigned, *signer, key)
+		require.NoError(t, signErr)
+		return signed
+	}
+
+	// SetCode tx with one auth tuple whose signature is unrecoverable (R=S=0).
+	// The sender's signature on the transaction itself is still valid.
+	setCodeUnsigned := &types.SetCodeTransaction{
+		DynamicFeeTransaction: types.DynamicFeeTransaction{
+			CommonTx: types.CommonTx{
+				Nonce:    1,
+				GasLimit: 100_000,
+				To:       &to,
+			},
+			ChainID: *chainID,
+			TipCap:  *uint256.NewInt(1_000_000),
+			FeeCap:  *uint256.NewInt(1_000_000),
+		},
+		Authorizations: []types.Authorization{{
+			ChainID: *chainID,
+			Address: common.Address{0x99},
+			Nonce:   0,
+			YParity: 0,
+			// R and S left zero — RecoverSigner rejects the tuple.
+		}},
+	}
+	setCode, err := types.SignTx(setCodeUnsigned, *signer, key)
+	require.NoError(t, err)
+
+	// Three-tx batch: sibling, poisoned SetCode, sibling.
+	txns := []types.Transaction{mkDynFee(0), setCode, mkDynFee(2)}
+	txnsRlp := make([][]byte, len(txns))
+	for i, txn := range txns {
+		buf := bytes.NewBuffer(nil)
+		require.NoError(t, txn.MarshalBinary(buf))
+		txnsRlp[i] = buf.Bytes()
+	}
+
+	cases := []struct {
+		name   string
+		encode func() []byte
+		parse  func(payload []byte, slots *TxnSlots) error
+	}{
+		{
+			name:   "Transactions",
+			encode: func() []byte { return EncodeTransactions(txnsRlp, nil) },
+			parse: func(payload []byte, slots *TxnSlots) error {
+				ctx := NewTxnParseContext(*chainID)
+				_, parseErr := ParseTransactions(payload, 0, ctx, slots, nil)
+				return parseErr
+			},
+		},
+		{
+			name:   "PooledTransactions66",
+			encode: func() []byte { return EncodePooledTransactions66(txnsRlp, 1, nil) },
+			parse: func(payload []byte, slots *TxnSlots) error {
+				ctx := NewTxnParseContext(*chainID)
+				_, _, parseErr := ParsePooledTransactions66(payload, 0, ctx, slots, nil)
+				return parseErr
+			},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			r := require.New(t)
+			slots := &TxnSlots{}
+			r.NoError(tt.parse(tt.encode(), slots))
+			// All three txns survive — no batch poisoning.
+			r.Len(slots.Txns, 3)
+
+			// Siblings parsed normally.
+			r.Equal(byte(DynamicFeeTxnType), slots.Txns[0].TxType())
+			r.Equal(byte(DynamicFeeTxnType), slots.Txns[2].TxType())
+
+			// SetCode tx is accepted, but its single auth tuple was skipped.
+			// Gas billing still sees the original auth list (length 1) because
+			// per EIP-7702 the sender pays for every tuple regardless of validity.
+			setCodeSlot := slots.Txns[1]
+			r.Equal(byte(SetCodeTxnType), setCodeSlot.TxType())
+			r.Len(setCodeSlot.Txn.GetAuthorizations(), 1)
+			r.Empty(setCodeSlot.AuthAndNonces)
+		})
+	}
 }
 
 func TestTransactionsPacket(t *testing.T) {

--- a/txnprovider/txpool/pool_txn_parser.go
+++ b/txnprovider/txpool/pool_txn_parser.go
@@ -26,7 +26,6 @@ import (
 	"github.com/holiman/uint256"
 
 	"github.com/erigontech/erigon/common"
-	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/length"
 	"github.com/erigontech/erigon/execution/protocol/mdgas"
 	"github.com/erigontech/erigon/execution/protocol/params"
@@ -394,18 +393,28 @@ func (ctx *TxnParseContext) ParseTransaction(payload []byte, pos int, slot *TxnS
 	slot.Nonce = txn.GetNonce()
 
 	// Authorization signers for SetCode txns (EIP-7702).
+	// Per EIP-7702, invalid auth tuples (unrecoverable signature, out-of-range
+	// chainID, etc.) do not invalidate the enclosing transaction — at execution
+	// time the spec dictates that "if any step fails for a tuple, processing
+	// continues to the next one". We therefore skip bad tuples here instead of
+	// returning a parse error: failing the parse would (a) drop sibling txns
+	// in the same Transactions/PooledTransactions packet and (b) censor txns
+	// that other clients accept. Only successfully-recovered authorities are
+	// indexed in AuthAndNonces (used for pool-replacement bookkeeping); the
+	// original auth-list length is still available via Txn.GetAuthorizations()
+	// for gas accounting (the sender pays for every tuple regardless).
 	if txn.Type() == types.SetCodeTxType {
 		auths := txn.GetAuthorizations()
 		slot.AuthAndNonces = make([]AuthAndNonce, 0, len(auths))
 		for _, auth := range auths {
 			if !auth.ChainID.IsUint64() {
-				return 0, fmt.Errorf("%w: authorization chainId is too big: %s", ErrParseTxn, &auth.ChainID)
+				continue
 			}
 			authCopy := auth
 			ctx.authBuf.Reset()
 			authority, err := authCopy.RecoverSigner(&ctx.authBuf, ctx.authHashBuf[:])
 			if err != nil {
-				return 0, fmt.Errorf("%w: recover authorization signer: %s stack: %s", ErrParseTxn, err, dbg.Stack()) //nolint
+				continue
 			}
 			slot.AuthAndNonces = append(slot.AuthAndNonces, AuthAndNonce{*authority, auth.Nonce})
 		}
@@ -461,7 +470,7 @@ type TxnSlot struct {
 	Size     uint32            // Cached size of the RLP payload (persists after Rlp is set to nil)
 
 	BlobBundles   []PoolBlobBundle // Zero-copy blob data for EIP-4844 wrapped blob txns
-	AuthAndNonces []AuthAndNonce   // Indexed authorization signers + nonces for EIP-7702 txns (type-4)
+	AuthAndNonces []AuthAndNonce   // Recovered authority + nonce for each valid EIP-7702 auth tuple. Tuples with unrecoverable signatures are skipped (per the EIP, they don't invalidate the txn). For total auth-list length (gas billing) use Txn.GetAuthorizations().
 }
 
 // Accessor methods that delegate to the stored Transaction.

--- a/txnprovider/txpool/pool_txn_parser_test.go
+++ b/txnprovider/txpool/pool_txn_parser_test.go
@@ -709,6 +709,11 @@ func TestSetCodeTxnParsingWithLargeAuthorizationValues(t *testing.T) {
 	assert.Equal(t, SetCodeTxnType, txnType)
 
 	_, err = ctx.ParseTransaction(bodyRlx, 0, &txn, nil, false /* hasEnvelope */, false, nil)
+	// Note: the test fixture encodes yParity as a 32-byte field, which is
+	// rejected at RLP decoding (uint overflow) before the parser ever reaches
+	// auth-signer recovery. So this test still validates that grossly malformed
+	// auth tuples are rejected at parse time. Per-tuple recovery failures with
+	// well-formed RLP are exercised separately in TestEIP7702BatchPoisoning.
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
Closes https://github.com/ethereum-bounty/erigon/issues/7

## Summary

Addresses the EIP-7702 batch poisoning / selective tx censorship reported in [ethereum-bounty/erigon#7](https://github.com/ethereum-bounty/erigon/issues/7).

A SetCode (type 0x04) transaction carrying one auth tuple with an unrecoverable signature would propagate `ErrParseTxn` out of `ParseTransaction`, abort the batch loop in `ParseTransactions` / `ParsePooledTransactions66`, and silently drop every sibling transaction in the same `Transactions (0x02)` / `PooledTransactions (0x0a)` devp2p packet (and kick the peer). A malicious peer could weaponize this to selectively censor batches while *appearing* honest.

Per [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702): _"if any step fails for a tuple, processing continues to the next one"_ — invalid auth tuples are skipped at execution time and do not invalidate the enclosing transaction (and the sender still pays for every tuple regardless of validity).

## Changes

- **`pool_txn_parser.go`**: the auth-recovery loop now skips tuples with unrecoverable signatures or out-of-range chainID instead of returning an error. `slot.AuthAndNonces` is populated only with successfully-recovered authorities. Removed the `dbg.Stack()` call from the (now-deleted) error path — it was a DoS amplifier on hostile network input.
- **`pool.go`**: gas billing (`pool.go:786`) and the SetCode non-empty-list check (`pool.go:957`) now use `len(Txn.GetAuthorizations())` instead of `len(AuthAndNonces)`. The on-tx list is the correct source of truth per the EIP. `AuthAndNonces` keeps its narrower role of tracking the recovered subset for the pool-replacement bookkeeping in `p.auths`.
- **`pool_test.go`**: `newTestSetCodeTxnSlot` seeds one placeholder authorization on the underlying `SetCodeTransaction` so existing tests still pass `validateTx`'s non-empty check (those tests bypass the parser and inject `AuthAndNonces` directly).
- **`pool_txn_packets_test.go`**: new `TestEIP7702BatchPoisoning` regression — builds a 3-tx batch `[DynFee, SetCode-with-bad-auth, DynFee]`, exercises both `ParseTransactions` and `ParsePooledTransactions66`, asserts all three survive and the SetCode tx has its auth tuple skipped (`AuthAndNonces` empty) while its on-tx list stays intact (length 1, so gas is still billed).
- **`pool_txn_parser_test.go`**: clarifying comment in `TestSetCodeTxnParsingWithLargeAuthorizationValues` — that fixture's yParity is encoded as 32 bytes, which `decodeAuthorizations` rejects as `uint overflow` at the RLP layer, before signer recovery is ever reached. The test still asserts `Error`, just for the right reason.

## Test plan

- [x] `go test ./txnprovider/txpool/... -count=1 -short` — all tests pass
- [x] `make lint` — clean
- [x] `make erigon integration` — builds
- [ ] CI green

## Out of scope

The same batch-abort pattern exists for the main *sender* signature recovery in `pool_txn_parser.go:436` — a tx with a malformed sender sig also kills the batch via `ErrParseTxn`. Same shape, same censorship vector, but for any tx type. Tracked separately in #20811.

🤖 Generated with [Claude Code](https://claude.com/claude-code)