### PR TITLE
ci: enable hive-eest client pool (~2.7× faster gate)

### DIFF
--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -84,11 +84,12 @@ jobs:
         uses: actions/checkout@v6
         with:
           # EXPERIMENT: pinned to erigontech/hive yperbasis/genesis-pool. This
-          # iteration is the warm-daemon variant — pool keeps client daemons
-          # running across tests and resets state via debug_setHead(0).
+          # iteration adds a global LRU cap to the warm-daemon pool so a
+          # low-reuse shard can no longer accumulate thousands of running
+          # client daemons.
           # Revert to ethereum/hive + steps.hive-version.outputs.ref before merging.
           repository: erigontech/hive
-          ref: c916d4357edcfdb2b23900c2b04157b6b924a84f
+          ref: 08ea28aa57c5a04afa0bc76afd0d5bbef6640607
           path: hive
 
       - name: Conditional Docker Login
@@ -155,7 +156,7 @@ jobs:
             echo -e "\n\n============================================================"
             echo "Running test: ${1}"
             echo -e "\n"
-            ./hive -docker.output -docker.auth --sim ethereum/eels/"${1}" --sim.limit="${2}" --sim.parallelism=12 --client.pool.size=4 --client erigon --docker.nocache=true --sim.limit.exact=false --sim.buildarg fixtures="${fixtures_url}" ${{ matrix.extra-hive-flags }} 2>&1 | tee output.log || {
+            ./hive -docker.output -docker.auth --sim ethereum/eels/"${1}" --sim.limit="${2}" --sim.parallelism=12 --client.pool.size=24 --client erigon --docker.nocache=true --sim.limit.exact=false --sim.buildarg fixtures="${fixtures_url}" ${{ matrix.extra-hive-flags }} 2>&1 | tee output.log || {
               if [ $? -gt 0 ]; then
                 echo "Exitcode gt 0"
               fi

--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -27,10 +27,13 @@ jobs:
           # matches the suite name (eest/consume-engine) while the remainder
           # filters individual pytest test IDs by fork parameter.
           # pool-size: --client.pool.size for hive's warm-daemon client pool.
-          # Set to 24 on shards with high pre-state reuse (cancun/prague/osaka
-          # at ~3× reuse, glamsterdam-devnet); kept at 0 on shards where the
-          # corpus has ~unique pre-state per test (paris+shanghai, consume-rlp)
-          # so we don't pay the per-test reset overhead with no compensating hits.
+          # Tuned per shard from a trace-instrumented dispatch (run 24938677388);
+          # the LRU hit-rate curve plateaus at ~50% past size=4 on the long
+          # consume-engine shards (reuse is essentially depth-2 consecutive),
+          # so 4 captures all available reuse and 24+ buys nothing. paris+shanghai
+          # and consume-rlp have ~unique pre-state per test (0% hit at any size).
+          # glamsterdam-devnet is the exception — its curve keeps climbing past
+          # 24, so it gets a larger pool.
           - sim: consume-engine
             sim-limit: ".*/.*fork_(Paris|Shanghai)"
             shard: paris+shanghai
@@ -38,15 +41,15 @@ jobs:
           - sim: consume-engine
             sim-limit: ".*/.*fork_Cancun"
             shard: cancun
-            pool-size: 24
+            pool-size: 4
           - sim: consume-engine
             sim-limit: ".*/.*fork_Prague"
             shard: prague
-            pool-size: 24
+            pool-size: 4
           - sim: consume-engine
             sim-limit: ".*/.*fork_Osaka"
             shard: osaka
-            pool-size: 24
+            pool-size: 4
           - sim: consume-rlp
             sim-limit: ".*(eip2930_access_list|eip4844_blobs).*" # all tests take too long
             shard: rlp

--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -99,7 +99,7 @@ jobs:
           # pool. Revert to ethereum/hive + steps.hive-version.outputs.ref
           # once that PR lands; until then we ride this fork.
           repository: erigontech/hive
-          ref: 684f7a63
+          ref: 684f7a63f0ba1d18541e265a1e839395a393458e
           path: hive
 
       - name: Conditional Docker Login

--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -84,10 +84,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           # EXPERIMENT: pinned to erigontech/hive yperbasis/genesis-pool to test
-          # the client-pool prototype. Revert to ethereum/hive +
-          # steps.hive-version.outputs.ref before merging.
+          # the client-pool prototype with the snapshot-restore path enabled.
+          # Revert to ethereum/hive + steps.hive-version.outputs.ref before merging.
           repository: erigontech/hive
-          ref: c46813fa410308b4defe849c0518404a6c77505b
+          ref: bc2cfecf24066898d0308f967d1d6d66a2dafc41
           path: hive
 
       - name: Conditional Docker Login

--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -26,25 +26,36 @@ jobs:
           # Pattern format: "<suite-regex>/<test-regex>" — the leading ".*/""
           # matches the suite name (eest/consume-engine) while the remainder
           # filters individual pytest test IDs by fork parameter.
+          # pool-size: --client.pool.size for hive's warm-daemon client pool.
+          # Set to 24 on shards with high pre-state reuse (cancun/prague/osaka
+          # at ~3× reuse, glamsterdam-devnet); kept at 0 on shards where the
+          # corpus has ~unique pre-state per test (paris+shanghai, consume-rlp)
+          # so we don't pay the per-test reset overhead with no compensating hits.
           - sim: consume-engine
             sim-limit: ".*/.*fork_(Paris|Shanghai)"
             shard: paris+shanghai
+            pool-size: 0
           - sim: consume-engine
             sim-limit: ".*/.*fork_Cancun"
             shard: cancun
+            pool-size: 24
           - sim: consume-engine
             sim-limit: ".*/.*fork_Prague"
             shard: prague
+            pool-size: 24
           - sim: consume-engine
             sim-limit: ".*/.*fork_Osaka"
             shard: osaka
+            pool-size: 24
           - sim: consume-rlp
             sim-limit: ".*(eip2930_access_list|eip4844_blobs).*" # all tests take too long
             shard: rlp
+            pool-size: 0
           # Glamsterdam devnet: BAL EIPs against devnet fixtures
           - sim: consume-engine
             sim-limit: ".*(8024|7708|7778|7843|7928|7954|8037).*"
             shard: glamsterdam-devnet
+            pool-size: 24
             fixtures-url: "https://github.com/ethereum/execution-spec-tests/releases/download/bal@v5.7.0/fixtures_bal.tar.gz"
             extra-hive-flags: "--sim.buildarg branch=devnets/bal/4 --sim.loglevel=3 --client.checktimelimit=300s"
             erigon-extra-flags: "--experimental.bal"
@@ -83,13 +94,12 @@ jobs:
       - name: Checkout Hive
         uses: actions/checkout@v6
         with:
-          # EXPERIMENT: pinned to erigontech/hive yperbasis/genesis-pool. This
-          # iteration adds a global LRU cap to the warm-daemon pool so a
-          # low-reuse shard can no longer accumulate thousands of running
-          # client daemons.
-          # Revert to ethereum/hive + steps.hive-version.outputs.ref before merging.
+          # EXPERIMENT: pinned to erigontech/hive yperbasis/client-pool, which
+          # is the upstream-PR-ready (ethereum/hive#1449) warm-daemon client
+          # pool. Revert to ethereum/hive + steps.hive-version.outputs.ref
+          # once that PR lands; until then we ride this fork.
           repository: erigontech/hive
-          ref: 08ea28aa57c5a04afa0bc76afd0d5bbef6640607
+          ref: 684f7a63
           path: hive
 
       - name: Conditional Docker Login
@@ -156,7 +166,7 @@ jobs:
             echo -e "\n\n============================================================"
             echo "Running test: ${1}"
             echo -e "\n"
-            ./hive -docker.output -docker.auth --sim ethereum/eels/"${1}" --sim.limit="${2}" --sim.parallelism=12 --client.pool.size=24 --client erigon --docker.nocache=true --sim.limit.exact=false --sim.buildarg fixtures="${fixtures_url}" ${{ matrix.extra-hive-flags }} 2>&1 | tee output.log || {
+            ./hive -docker.output -docker.auth --sim ethereum/eels/"${1}" --sim.limit="${2}" --sim.parallelism=12 --client.pool.size=${{ matrix.pool-size }} --client erigon --docker.nocache=true --sim.limit.exact=false --sim.buildarg fixtures="${fixtures_url}" ${{ matrix.extra-hive-flags }} 2>&1 | tee output.log || {
               if [ $? -gt 0 ]; then
                 echo "Exitcode gt 0"
               fi

--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -83,8 +83,11 @@ jobs:
       - name: Checkout Hive
         uses: actions/checkout@v6
         with:
-          repository: ethereum/hive
-          ref: ${{ steps.hive-version.outputs.ref }}
+          # EXPERIMENT: pinned to erigontech/hive yperbasis/genesis-pool to test
+          # the client-pool prototype. Revert to ethereum/hive +
+          # steps.hive-version.outputs.ref before merging.
+          repository: erigontech/hive
+          ref: c46813fa410308b4defe849c0518404a6c77505b
           path: hive
 
       - name: Conditional Docker Login
@@ -151,7 +154,7 @@ jobs:
             echo -e "\n\n============================================================"
             echo "Running test: ${1}"
             echo -e "\n"
-            ./hive -docker.output -docker.auth --sim ethereum/eels/"${1}" --sim.limit="${2}" --sim.parallelism=12 --client erigon --docker.nocache=true --sim.limit.exact=false --sim.buildarg fixtures="${fixtures_url}" ${{ matrix.extra-hive-flags }} 2>&1 | tee output.log || {
+            ./hive -docker.output -docker.auth --sim ethereum/eels/"${1}" --sim.limit="${2}" --sim.parallelism=12 --client.pool.size=4 --client erigon --docker.nocache=true --sim.limit.exact=false --sim.buildarg fixtures="${fixtures_url}" ${{ matrix.extra-hive-flags }} 2>&1 | tee output.log || {
               if [ $? -gt 0 ]; then
                 echo "Exitcode gt 0"
               fi

--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -102,7 +102,7 @@ jobs:
           # pool. Revert to ethereum/hive + steps.hive-version.outputs.ref
           # once that PR lands; until then we ride this fork.
           repository: erigontech/hive
-          ref: 06b9774991053bf4952c98750c53fc52bceb3991
+          ref: a3c9afd9ada800efc41c0287d66f7d083684d3cb
           path: hive
 
       - name: Conditional Docker Login

--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -102,7 +102,7 @@ jobs:
           # pool. Revert to ethereum/hive + steps.hive-version.outputs.ref
           # once that PR lands; until then we ride this fork.
           repository: erigontech/hive
-          ref: 684f7a63f0ba1d18541e265a1e839395a393458e
+          ref: 06b9774991053bf4952c98750c53fc52bceb3991
           path: hive
 
       - name: Conditional Docker Login

--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -83,11 +83,12 @@ jobs:
       - name: Checkout Hive
         uses: actions/checkout@v6
         with:
-          # EXPERIMENT: pinned to erigontech/hive yperbasis/genesis-pool to test
-          # the client-pool prototype with the snapshot-restore path enabled.
+          # EXPERIMENT: pinned to erigontech/hive yperbasis/genesis-pool. This
+          # iteration is the warm-daemon variant — pool keeps client daemons
+          # running across tests and resets state via debug_setHead(0).
           # Revert to ethereum/hive + steps.hive-version.outputs.ref before merging.
           repository: erigontech/hive
-          ref: bc2cfecf24066898d0308f967d1d6d66a2dafc41
+          ref: c916d4357edcfdb2b23900c2b04157b6b924a84f
           path: hive
 
       - name: Conditional Docker Login


### PR DESCRIPTION
## Summary

Enables the hive *warm-daemon client pool* on the `test-hive-eest.yml` workflow.

The pool keeps client containers running across tests and resets chain state via JSON-RPC `debug_setHead(0)` between them, instead of creating a fresh container per test. On corpora with high pre-state reuse this skips ~1.9 s of per-test overhead (`docker create` + tar upload + `erigon init` + daemon boot).

**Effect on the hive-eest merge-queue gate:**

| Shard | `pool.size` | Baseline wall | New wall | Δ |
|---|---|---|---|---|
| cancun | 4 | 52.2 min | **18.0 min** | **−65.5%** |
| prague | 4 | 61.0 min | **22.4 min** | **−63.4%** |
| osaka | 4 | 63.0 min | **23.6 min** | **−62.6%** |
| glamsterdam-devnet | 24 | 8.5 min | 6.5 min | −22.9% |
| paris+shanghai | 0 | 13.5 min | 12.3 min | ~baseline |
| consume-rlp | 0 | 32.3 min | 31.1 min | ~baseline |

Pacemaker: **63 min → 24 min** (the gate is now 2.7× faster on every PR / merge group). Baseline run [#24827222279](https://github.com/erigontech/erigon/actions/runs/24827222279); current run [#24941388548](https://github.com/erigontech/erigon/actions/runs/24941388548).

## Per-shard `pool.size`

The pool only helps where tests share pre-state. From a trace-instrumented run + offline LRU simulation, the EEST access pattern is *depth-2 consecutive*: each pre-state is hit twice in a row, then never seen again. So `pool.size = 4` captures all available reuse on the long consume-engine shards; bigger caches buy nothing. The other extreme — paris+shanghai and consume-rlp — has ~unique pre-state per test (~0% hit at any cache size) and gets `pool.size = 0`, which short-circuits every new code path in hive (byte-identical to the pre-pool flow).

| Shard | Reuse | `pool.size` |
|---|---|---|
| cancun, prague, osaka | ~2× | 4 |
| glamsterdam-devnet | curve still climbs at 24 | 24 |
| paris+shanghai, consume-rlp | ~1× | 0 (pool disabled) |

## Files

- `.github/workflows/test-hive-eest.yml`:
  - Pinned hive checkout to `erigontech/hive @ 06b9774991053bf4952c98750c53fc52bceb3991` — see "Pre-merge" below.
  - Added `pool-size` per matrix entry.
  - Added `--client.pool.size=${{ matrix.pool-size }}` to the hive invocation.

No other files touched.

## Pre-merge

The hive-side change is up as a draft at [ethereum/hive#1449](https://github.com/ethereum/hive/pull/1449). This Erigon PR currently pins the hive checkout at the corresponding `erigontech/hive` branch, which is fine for the trial dispatches but **not for merge**.

Before this lands:
1. ethereum/hive#1449 merges.
2. `hive-versions.json` gets a routine bump to the new ethereum/hive ref.
3. The `repository:` / `ref:` override in `test-hive-eest.yml` is reverted to the existing `ethereum/hive` + `steps.hive-version.outputs.ref` pattern.
4. The `pool-size` matrix var and `--client.pool.size` flag stay — they're the actual change this PR ships.

I'll squash the experiment commits down to that final shape once #1449 is in.

## Test plan

- [x] All 6 shards green on the bare-metal `hive` runner group across multiple dispatches.
- [x] Per-shard `pool.size` derived from a trace-instrumented run and an offline LRU simulator (the curve plateaus past 4 on long shards).
- [x] Low-reuse shards (paris+shanghai, consume-rlp) verified at `pool.size=0` — wall time matches the no-pool baseline (no regression from the pool's per-test reset overhead).
- [x] No container-count / disk-pressure issues on the runner (global LRU cap bounds the running daemon count regardless of test corpus).
