### PR TITLE
bloatnet: disable `CheckCommitmentKvDeref` 

### DIFF
--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -1360,6 +1360,7 @@ func doIntegrity(cliCtx *cli.Context) error {
 						return err
 					}
 				case integrity.CommitmentKvDeref:
+					log.Warn("[todo] CommitmentKvDeref disabled on bloatnet. see https://github.com/erigontech/erigon/issues/20814")
 					return nil // TODO: taking too long on bloatnet
 					if err := integrity.CheckCommitmentKvDeref(ctx, db, cache, failFast, logger); err != nil {
 						return err

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -1360,6 +1360,7 @@ func doIntegrity(cliCtx *cli.Context) error {
 						return err
 					}
 				case integrity.CommitmentKvDeref:
+					return nil // TODO: taking too long on bloatnet
 					if err := integrity.CheckCommitmentKvDeref(ctx, db, cache, failFast, logger); err != nil {
 						return err
 					}

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -1365,7 +1365,7 @@ func doIntegrity(cliCtx *cli.Context) error {
 					}
 				case integrity.CommitmentHistVal:
 					scCopy := sc
-					scCopy.SampleRatio /= 100 // it's very slow check
+					scCopy.SampleRatio /= 1000 // it's very slow check
 					if err := integrity.CheckCommitmentHistVal(ctx, scCopy, db, blockReader, failFast, logger); err != nil {
 						return err
 					}
@@ -1375,7 +1375,7 @@ func doIntegrity(cliCtx *cli.Context) error {
 						return err
 					}
 					scCopy := sc
-					scCopy.SampleRatio /= 100 // it's very slow check
+					scCopy.SampleRatio /= 1000 // it's very slow check
 					if err := integrity.CheckCommitmentHistAtBlkRange(ctx, scCopy, db, blockReader, 1, to+1, failFast, logger); err != nil {
 						return err
 					}

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -1360,8 +1360,10 @@ func doIntegrity(cliCtx *cli.Context) error {
 						return err
 					}
 				case integrity.CommitmentKvDeref:
-					log.Warn("[todo] CommitmentKvDeref disabled on bloatnet. see https://github.com/erigontech/erigon/issues/20814")
-					return nil // TODO: taking too long on bloatnet
+					if chainConfig.ChainName == networkname.Bloatnet {
+						log.Warn("[todo] CommitmentKvDeref disabled on bloatnet. see https://github.com/erigontech/erigon/issues/20814")
+						return nil // TODO: taking too long on bloatnet
+					}
 					if err := integrity.CheckCommitmentKvDeref(ctx, db, cache, failFast, logger); err != nil {
 						return err
 					}

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -1369,7 +1369,10 @@ func doIntegrity(cliCtx *cli.Context) error {
 					}
 				case integrity.CommitmentHistVal:
 					scCopy := sc
-					scCopy.SampleRatio /= 1000 // it's very slow check
+					scCopy.SampleRatio /= 100 // it's very slow check
+					if chainConfig.ChainName == networkname.Bloatnet {
+						scCopy.SampleRatio /= 10
+					}
 					if err := integrity.CheckCommitmentHistVal(ctx, scCopy, db, blockReader, failFast, logger); err != nil {
 						return err
 					}
@@ -1379,7 +1382,10 @@ func doIntegrity(cliCtx *cli.Context) error {
 						return err
 					}
 					scCopy := sc
-					scCopy.SampleRatio /= 1000 // it's very slow check
+					scCopy.SampleRatio /= 100 // it's very slow check
+					if chainConfig.ChainName == networkname.Bloatnet {
+						scCopy.SampleRatio /= 10
+					}
 					if err := integrity.CheckCommitmentHistAtBlkRange(ctx, scCopy, db, blockReader, 1, to+1, failFast, logger); err != nil {
 						return err
 					}


### PR DESCRIPTION
- because it can't finish
