### PR TITLE
db/state: simplify DomainLatestIterFile

### DIFF
--- a/db/state/domain_stream.go
+++ b/db/state/domain_stream.go
@@ -19,7 +19,6 @@ package state
 import (
 	"bytes"
 	"container/heap"
-	"context"
 	"encoding/binary"
 	"fmt"
 	"math"
@@ -170,7 +169,7 @@ func (hi *DomainLatestIterFile) init(domainRoTx *DomainRoTx) error {
 
 	// Initialize DB cursors (skip if filesOnly mode)
 	if !hi.filesOnly {
-		if err := hi.initCursorMDBX(domainRoTx); err != nil {
+		if err := hi.initCursorOnDB(domainRoTx); err != nil {
 			return err
 		}
 	}
@@ -220,73 +219,142 @@ func (hi *DomainLatestIterFile) init(domainRoTx *DomainRoTx) error {
 	return hi.advanceInFiles()
 }
 
-// initCursorMDBX initializes DB cursors for iterating over MDBX values table.
-func (hi *DomainLatestIterFile) initCursorMDBX(domainRoTx *DomainRoTx) error {
-	return hi.roTx.Apply(context.Background(), func(tx kv.Tx) error {
-		if domainRoTx.d.LargeValues {
-			valsCursor, err := hi.roTx.Cursor(domainRoTx.d.ValuesTable) //nolint:gocritic
-			if err != nil {
-				return err
-			}
-			key, value, err := valsCursor.Seek(hi.from)
-			if err != nil {
-				valsCursor.Close()
-				return err
-			}
-			// Skip DB entries within file range — files are authoritative there.
-			var pushed bool
-			for key != nil && len(key) > 8 && (hi.to == nil || bytes.Compare(key[:len(key)-8], hi.to) < 0) {
-				k := key[:len(key)-8]
-				stepBytes := key[len(key)-8:]
-				step := ^binary.BigEndian.Uint64(stepBytes)
-				endTxNum := step * domainRoTx.d.stepSize
-				if endTxNum >= hi.filesEndTxNum {
-					heap.Push(hi.h, &CursorItem{t: DB_CURSOR, key: common.Copy(k), val: common.Copy(value), cNonDup: valsCursor, endTxNum: endTxNum, reverse: true})
-					pushed = true
-					break
-				}
-				key, value, err = valsCursor.Next()
-				if err != nil {
-					return err
-				}
-			}
+func (hi *DomainLatestIterFile) initCursorOnDB(domainRoTx *DomainRoTx) error {
+	if domainRoTx.d.LargeValues {
+		valsCursor, err := hi.roTx.Cursor(domainRoTx.d.ValuesTable) //nolint:gocritic
+		if err != nil {
+			return err
+		}
+		var pushed bool
+		defer func() {
 			if !pushed {
 				valsCursor.Close()
 			}
-		} else {
-			valsCursor, err := hi.roTx.CursorDupSort(domainRoTx.d.ValuesTable) //nolint:gocritic
+		}()
+		key, value, err := valsCursor.Seek(hi.from)
+		if err != nil {
+			return err
+		}
+		for key != nil && len(key) > 8 && (hi.to == nil || bytes.Compare(key[:len(key)-8], hi.to) < 0) {
+			k := key[:len(key)-8]
+			stepBytes := key[len(key)-8:]
+			step := ^binary.BigEndian.Uint64(stepBytes)
+			endTxNum := step * domainRoTx.d.stepSize
+			if endTxNum >= hi.filesEndTxNum {
+				heap.Push(hi.h, &CursorItem{t: DB_CURSOR, key: common.Copy(k), val: common.Copy(value), cNonDup: valsCursor, endTxNum: endTxNum, reverse: true})
+				pushed = true
+				break
+			}
+			key, value, err = valsCursor.Next()
 			if err != nil {
 				return err
-			}
-
-			var pushed bool
-			key, value, err := valsCursor.Seek(hi.from)
-			if err != nil {
-				valsCursor.Close()
-				return err
-			}
-			// Skip DB entries within file range — files are authoritative there.
-			for key != nil && (hi.to == nil || bytes.Compare(key, hi.to) < 0) {
-				stepBytes := value[:8]
-				val := value[8:]
-				step := ^binary.BigEndian.Uint64(stepBytes)
-				endTxNum := step * domainRoTx.d.stepSize
-				if endTxNum >= hi.filesEndTxNum {
-					heap.Push(hi.h, &CursorItem{t: DB_CURSOR, key: common.Copy(key), val: common.Copy(val), cDup: valsCursor, endTxNum: endTxNum, reverse: true})
-					pushed = true
-					break
-				}
-				key, value, err = valsCursor.NextNoDup()
-				if err != nil {
-					return err
-				}
-			}
-			if !pushed {
-				valsCursor.Close()
 			}
 		}
-		return nil
-	})
+	} else {
+		valsCursor, err := hi.roTx.CursorDupSort(domainRoTx.d.ValuesTable) //nolint:gocritic
+		if err != nil {
+			return err
+		}
+		var pushed bool
+		defer func() {
+			if !pushed {
+				valsCursor.Close()
+			}
+		}()
+		key, value, err := valsCursor.Seek(hi.from)
+		if err != nil {
+			return err
+		}
+		for key != nil && (hi.to == nil || bytes.Compare(key, hi.to) < 0) {
+			stepBytes := value[:8]
+			val := value[8:]
+			step := ^binary.BigEndian.Uint64(stepBytes)
+			endTxNum := step * domainRoTx.d.stepSize
+			if endTxNum >= hi.filesEndTxNum {
+				heap.Push(hi.h, &CursorItem{t: DB_CURSOR, key: common.Copy(key), val: common.Copy(val), cDup: valsCursor, endTxNum: endTxNum, reverse: true})
+				pushed = true
+				break
+			}
+			key, value, err = valsCursor.NextNoDup()
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// advanceLargeValsDBCursor owns ci1: it either re-pushes it onto the heap or closes it.
+func (hi *DomainLatestIterFile) advanceLargeValsDBCursor(ci1 *CursorItem) error {
+	var pushed bool
+	defer func() {
+		if !pushed {
+			hi.closeCursorItem(ci1)
+		}
+	}()
+	for {
+		initial, v, err := ci1.cNonDup.Current()
+		if err != nil {
+			return err
+		}
+		var k []byte
+		for initial != nil && len(initial) > 8 && (k == nil || (len(k) > 8 && bytes.Equal(initial[:len(initial)-8], k[:len(k)-8]))) {
+			k, v, err = ci1.cNonDup.Next()
+			if err != nil {
+				return err
+			}
+			if k == nil {
+				break
+			}
+		}
+		if len(k) <= 8 || !(hi.to == nil || bytes.Compare(k[:len(k)-8], hi.to) < 0) {
+			break
+		}
+		stepBytes := k[len(k)-8:]
+		step := ^binary.BigEndian.Uint64(stepBytes)
+		endTxNum := step * hi.aggStep
+		if endTxNum >= hi.filesEndTxNum {
+			ci1.key = common.Copy(k[:len(k)-8])
+			ci1.endTxNum = endTxNum
+			ci1.val = common.Copy(v)
+			heap.Push(hi.h, ci1)
+			pushed = true
+			break
+		}
+	}
+	return nil
+}
+
+// advanceDupSortDBCursor owns ci1: it either re-pushes it onto the heap or closes it.
+func (hi *DomainLatestIterFile) advanceDupSortDBCursor(ci1 *CursorItem) error {
+	var pushed bool
+	defer func() {
+		if !pushed {
+			hi.closeCursorItem(ci1)
+		}
+	}()
+	for {
+		k, stepBytesWithValue, err := ci1.cDup.NextNoDup()
+		if err != nil {
+			return err
+		}
+		if len(k) == 0 || !(hi.to == nil || bytes.Compare(k, hi.to) < 0) {
+			break
+		}
+		stepBytes := stepBytesWithValue[:8]
+		v := stepBytesWithValue[8:]
+		step := ^binary.BigEndian.Uint64(stepBytes)
+		endTxNum := step * hi.aggStep
+		if endTxNum >= hi.filesEndTxNum {
+			ci1.key = common.Copy(k)
+			ci1.endTxNum = endTxNum
+			ci1.val = common.Copy(v)
+			heap.Push(hi.h, ci1)
+			pushed = true
+			break
+		}
+	}
+	return nil
 }
 
 func (hi *DomainLatestIterFile) advanceInFiles() error {
@@ -325,75 +393,12 @@ func (hi *DomainLatestIterFile) advanceInFiles() error {
 				}
 			case DB_CURSOR:
 				if hi.largeVals {
-					// Skip DB entries within file range — files are authoritative there.
-					var pushed bool
-					for {
-						// start from current go to next
-						initial, v, err := ci1.cNonDup.Current()
-						if err != nil {
-							hi.closeCursorItem(ci1)
-							return err
-						}
-						var k []byte
-						for initial != nil && len(initial) > 8 && (k == nil || (len(k) > 8 && bytes.Equal(initial[:len(initial)-8], k[:len(k)-8]))) {
-							k, v, err = ci1.cNonDup.Next()
-							if err != nil {
-								return err
-							}
-							if k == nil {
-								break
-							}
-						}
-
-						if len(k) <= 8 || !(hi.to == nil || bytes.Compare(k[:len(k)-8], hi.to) < 0) {
-							break
-						}
-						stepBytes := k[len(k)-8:]
-						step := ^binary.BigEndian.Uint64(stepBytes)
-						endTxNum := step * hi.aggStep
-						if endTxNum >= hi.filesEndTxNum {
-							ci1.key = common.Copy(k[:len(k)-8])
-							ci1.endTxNum = endTxNum
-							ci1.val = common.Copy(v)
-							heap.Push(hi.h, ci1)
-							pushed = true
-							break
-						}
-						// Skip this DB entry, continue to next key
-					}
-					if !pushed {
-						ci1.cNonDup.Close()
+					if err := hi.advanceLargeValsDBCursor(ci1); err != nil {
+						return err
 					}
 				} else {
-					// Skip DB entries within file range — files are authoritative there.
-					var pushed bool
-					for {
-						// start from current go to next
-						k, stepBytesWithValue, err := ci1.cDup.NextNoDup()
-						if err != nil {
-							hi.closeCursorItem(ci1)
-							return err
-						}
-
-						if len(k) == 0 || !(hi.to == nil || bytes.Compare(k, hi.to) < 0) {
-							break
-						}
-						stepBytes := stepBytesWithValue[:8]
-						v := stepBytesWithValue[8:]
-						step := ^binary.BigEndian.Uint64(stepBytes)
-						endTxNum := step * hi.aggStep
-						if endTxNum >= hi.filesEndTxNum {
-							ci1.key = common.Copy(k)
-							ci1.endTxNum = endTxNum
-							ci1.val = common.Copy(v)
-							heap.Push(hi.h, ci1)
-							pushed = true
-							break
-						}
-						// Skip this DB entry, continue to next key
-					}
-					if !pushed {
-						ci1.cDup.Close()
+					if err := hi.advanceDupSortDBCursor(ci1); err != nil {
+						return err
 					}
 				}
 

--- a/db/state/domain_stream.go
+++ b/db/state/domain_stream.go
@@ -284,7 +284,6 @@ func (hi *DomainLatestIterFile) initCursorOnDB(domainRoTx *DomainRoTx) error {
 	return nil
 }
 
-// advanceLargeValsDBCursor owns ci1: it either re-pushes it onto the heap or closes it.
 func (hi *DomainLatestIterFile) advanceLargeValsDBCursor(ci1 *CursorItem) error {
 	var pushed bool
 	defer func() {
@@ -293,21 +292,25 @@ func (hi *DomainLatestIterFile) advanceLargeValsDBCursor(ci1 *CursorItem) error 
 		}
 	}()
 	for {
-		initial, v, err := ci1.cNonDup.Current()
+		initial, _, err := ci1.cNonDup.Current()
 		if err != nil {
 			return err
 		}
-		var k []byte
-		for initial != nil && len(initial) > 8 && (k == nil || (len(k) > 8 && bytes.Equal(initial[:len(initial)-8], k[:len(k)-8]))) {
+		if initial == nil || len(initial) <= 8 {
+			break
+		}
+		baseKey := initial[:len(initial)-8]
+		var k, v []byte
+		for {
 			k, v, err = ci1.cNonDup.Next()
 			if err != nil {
 				return err
 			}
-			if k == nil {
+			if k == nil || len(k) <= 8 || !bytes.Equal(k[:len(k)-8], baseKey) {
 				break
 			}
 		}
-		if len(k) <= 8 || !(hi.to == nil || bytes.Compare(k[:len(k)-8], hi.to) < 0) {
+		if k == nil || len(k) <= 8 || !(hi.to == nil || bytes.Compare(k[:len(k)-8], hi.to) < 0) {
 			break
 		}
 		stepBytes := k[len(k)-8:]
@@ -325,7 +328,6 @@ func (hi *DomainLatestIterFile) advanceLargeValsDBCursor(ci1 *CursorItem) error 
 	return nil
 }
 
-// advanceDupSortDBCursor owns ci1: it either re-pushes it onto the heap or closes it.
 func (hi *DomainLatestIterFile) advanceDupSortDBCursor(ci1 *CursorItem) error {
 	var pushed bool
 	defer func() {

--- a/db/state/domain_stream_test.go
+++ b/db/state/domain_stream_test.go
@@ -332,7 +332,7 @@ func TestDomainLatestIterFile_PrefersFilesOverDB(t *testing.T) {
 
 // TestDomainLatestIterFile_PrefersFilesOverDB_LargeValues is the LargeValues
 // counterpart to TestDomainLatestIterFile_PrefersFilesOverDB.  It uses
-// CodeDomain (LargeValues: true) so that both initCursorMDBX branches and both
+// CodeDomain (LargeValues: true) so that both initCursorOnDB branches and both
 // advanceInFiles DB_CURSOR branches are exercised.
 //
 // For LargeValues domains the DB key layout is:

--- a/db/state/stream_close_test.go
+++ b/db/state/stream_close_test.go
@@ -53,7 +53,7 @@ func TestDomainLatestIterFileInitCursorMDBXClosesDupCursorOutsideRange(t *testin
 		d:        &Domain{DomainCfg: statecfg.DomainCfg{ValuesTable: "vals"}},
 	}
 
-	err := hi.initCursorMDBX(domainRoTx)
+	err := hi.initCursorOnDB(domainRoTx)
 
 	require.NoError(t, err)
 	require.Equal(t, 1, c.closed)
@@ -73,7 +73,7 @@ func TestDomainLatestIterFileInitCursorMDBXClosesCursorOutsideRangeForLargeValue
 		d:        &Domain{DomainCfg: statecfg.DomainCfg{LargeValues: true, ValuesTable: "vals"}},
 	}
 
-	err := hi.initCursorMDBX(domainRoTx)
+	err := hi.initCursorOnDB(domainRoTx)
 
 	require.NoError(t, err)
 	require.Equal(t, 1, c.closed)


### PR DESCRIPTION
## Summary

- Rename `initCursorMDBX` → `initCursorOnDB` (name was MDBX-specific; the method initializes DB cursors generically)
- Remove `roTx.Apply(context.Background(), ...)` wrapper — it was a no-op: all concrete tx types used here return `f(tx)` directly, and the closure ignored the `tx` parameter, calling `hi.roTx` directly anyway
- Replace fragile per-error-path `cursor.Close()` calls with `defer func() { if !pushed { cursor.Close() } }()` in both branches of `initCursorOnDB`
- Extract `advanceLargeValsDBCursor` and `advanceDupSortDBCursor` helpers from `advanceInFiles` so the same defer-based ownership pattern applies there — each helper owns its `ci1`: either re-pushes it onto the heap or closes it via defer