### PR TITLE
execution/abi: fix regex submatch for parsing variable size in types

### DIFF
--- a/execution/abi/type.go
+++ b/execution/abi/type.go
@@ -128,7 +128,7 @@ func NewType(t string, internalType string, components []ArgumentMarshaling) (ty
 	var varSize int
 	if len(parsedType[3]) > 0 {
 		var err error
-		varSize, err = strconv.Atoi(parsedType[2])
+		varSize, err = strconv.Atoi(parsedType[3])
 		if err != nil {
 			return Type{}, fmt.Errorf("abi: error parsing variable size: %w", err)
 		}

--- a/execution/abi/type_test.go
+++ b/execution/abi/type_test.go
@@ -412,8 +412,8 @@ func TestNewTypeFixedPointWrongSizeSubmatch(t *testing.T) {
 		if err == nil {
 			t.Fatalf("type %q: expected error for unsupported fixed-point type", s)
 		}
-		if strings.Contains(err.Error(), "error parsing variable size") {
-			t.Fatalf("type %q: got size parse error (wrong regexp submatch); want unsupported: %v", s, err)
+		if !strings.Contains(err.Error(), "unsupported arg type") {
+			t.Fatalf("type %q: got %v; want error containing %q", s, err, "unsupported arg type")
 		}
 	}
 }

--- a/execution/abi/type_test.go
+++ b/execution/abi/type_test.go
@@ -417,4 +417,3 @@ func TestNewTypeFixedPointWrongSizeSubmatch(t *testing.T) {
 		}
 	}
 }
-

--- a/execution/abi/type_test.go
+++ b/execution/abi/type_test.go
@@ -398,3 +398,23 @@ func TestGetTypeSize(t *testing.T) {
 		}
 	}
 }
+
+// TestNewTypeFixedPointWrongSizeSubmatch is a regression test for a bug in NewType
+// that used the wrong regexp submatch (parsedType[2]) for the first numeric size.
+// For types like fixed128x18, the overall second group is "128x18", not an integer
+// string; the first integer is parsedType[3] ("128"). The bug caused strconv.Atoi
+// to fail with "error parsing variable size" instead of the intended "unsupported
+// arg type" outcome for unimplemented fixed-point encodings.
+func TestNewTypeFixedPointWrongSizeSubmatch(t *testing.T) {
+	t.Parallel()
+	for _, s := range []string{"fixed128x18", "ufixed256x10"} {
+		_, err := NewType(s, "", nil)
+		if err == nil {
+			t.Fatalf("type %q: expected error for unsupported fixed-point type", s)
+		}
+		if strings.Contains(err.Error(), "error parsing variable size") {
+			t.Fatalf("type %q: got size parse error (wrong regexp submatch); want unsupported: %v", s, err)
+		}
+	}
+}
+


### PR DESCRIPTION
This request fixes a parsing issue in the ABI package that occurs when evaluating types with multi-dimensional sizes. Previously, the regular expression used the wrong capture group when parsing the type string. For types such as `fixed128x18`, the code incorrectly captured the entire suffix "128x18" instead of just the leading number "128". This caused an invalid syntax error when the application attempted to parse that combined string as an integer.

By updating the regex submatch index, the parser now correctly isolates the first numeric value so it can be evaluated properly. Along with this fix, a regression test has been added to ensure that unsupported fixed-point types correctly return an "unsupported arg type" error rather than failing unexpectedly during the size calculation process.