### PR TITLE
p2p: preserve full enode for inbound connections from static peers

### DIFF
--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -127,6 +127,15 @@ type dialScheduler struct {
 	static     map[enode.ID]*dialTask
 	staticPool []*dialTask
 
+	// staticByID is a concurrency-safe view of the static-peer enodes,
+	// indexed by enode.ID. Populated by addStatic / removeStatic so
+	// setupConn can resolve an inbound peer's full enode (with its ENR
+	// record) by pubkey, instead of falling back to a stub enode that
+	// strips custom ENR entries. Held outside the loop's exclusive
+	// state because setupConn runs on a different goroutine.
+	staticByIDMu sync.RWMutex
+	staticByID   map[enode.ID]*enode.Node
+
 	// The dial history keeps recently dialed nodes. Members of history are not dialed.
 	history          expHeap
 	historyTimer     mclock.Timer
@@ -204,6 +213,12 @@ func (d *dialScheduler) stop() {
 
 // addStatic adds a static dial candidate.
 func (d *dialScheduler) addStatic(n *enode.Node) {
+	d.staticByIDMu.Lock()
+	if d.staticByID == nil {
+		d.staticByID = make(map[enode.ID]*enode.Node)
+	}
+	d.staticByID[n.ID()] = n
+	d.staticByIDMu.Unlock()
 	select {
 	case d.addStaticCh <- n:
 	case <-d.ctx.Done():
@@ -212,10 +227,23 @@ func (d *dialScheduler) addStatic(n *enode.Node) {
 
 // removeStatic removes a static dial candidate.
 func (d *dialScheduler) removeStatic(n *enode.Node) {
+	d.staticByIDMu.Lock()
+	delete(d.staticByID, n.ID())
+	d.staticByIDMu.Unlock()
 	select {
 	case d.remStaticCh <- n:
 	case <-d.ctx.Done():
 	}
+}
+
+// lookupStatic returns the enode for a configured static peer by ID, or
+// nil if no static entry exists. Used by Server.setupConn to resolve
+// inbound connections from known static peers to their full enode (with
+// custom ENR entries) instead of the stub created from pubkey + addr.
+func (d *dialScheduler) lookupStatic(id enode.ID) *enode.Node {
+	d.staticByIDMu.RLock()
+	defer d.staticByIDMu.RUnlock()
+	return d.staticByID[id]
 }
 
 // peerAdded updates the peer set.

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -965,7 +965,24 @@ func (srv *Server) setupConn(c *conn, flags connFlag, dialDest *enode.Node) erro
 	if dialDest != nil {
 		c.node = dialDest
 	} else {
-		c.node = nodeFromConn(remotePubkey, c.fd)
+		// Inbound connection: there's no dial-time enode, so by default
+		// nodeFromConn fabricates a stub from pubkey + remote addr. That
+		// stub is missing any ENR entries the remote advertises. If the
+		// remote is a configured static peer we already hold its full
+		// enode, so prefer that — keeps custom ENR entries intact across
+		// inbound handshakes without requiring discv5 / discovery v5
+		// ENR resolution. Pure-discovery deployments (no static peers)
+		// keep the stub fallback.
+		c.node = nil
+		if srv.dialsched != nil {
+			id := enode.PubkeyToIDV4(remotePubkey)
+			if static := srv.dialsched.lookupStatic(id); static != nil {
+				c.node = static
+			}
+		}
+		if c.node == nil {
+			c.node = nodeFromConn(remotePubkey, c.fd)
+		}
 	}
 	clog := srv.logger.New("id", c.node.ID(), "addr", c.fd.RemoteAddr(), "conn", c.flags)
 	err = srv.checkpoint(c, srv.checkpointPostHandshake)

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -32,6 +32,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/erigontech/erigon/common/crypto"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/p2p/enode"
@@ -537,6 +539,65 @@ func randomID() (id enode.ID) {
 		id[i] = byte(rand.Intn(255))
 	}
 	return id
+}
+
+// TestServerInboundUsesStaticEnode covers the inbound-stub-enode bug:
+// a peer that's been registered as a static peer should keep its full
+// ENR record after an inbound connection completes, not be silently
+// downgraded to a stub enode containing only pubkey + remote addr.
+//
+// Without the fix at server.setupConn, the acceptor side of an inbound
+// handshake constructs a fresh enode via nodeFromConn, dropping every
+// custom ENR entry the dialer originally advertised. With the fix the
+// acceptor consults the static-peer table and reuses the registered
+// enode, preserving entries needed by downstream consumers (e.g.
+// chain.toml.v2 InfoHash, BT torrent port).
+func TestServerInboundUsesStaticEnode(t *testing.T) {
+	logger := log.New()
+
+	// The remote peer's key. The static-peer enode advertises a custom
+	// "ct" (chain-toml v2 stand-in) entry that should survive the
+	// inbound handshake.
+	remoteKey := newkey()
+	remoteCustom := enr.WithEntry("ct", uint64(0xabcdef))
+
+	var rec enr.Record
+	rec.Set(enode.Secp256k1(remoteKey.PublicKey))
+	rec.Set(enr.IP(net.IP{127, 0, 0, 1}))
+	rec.Set(enr.TCP(0))
+	rec.Set(remoteCustom)
+	rec.SetSeq(1)
+	require.NoError(t, enode.SignV4(&rec, remoteKey))
+	staticEnode, err := enode.New(enode.ValidSchemes, &rec)
+	require.NoError(t, err)
+
+	connected := make(chan *Peer, 1)
+	srv := startTestServer(t, &remoteKey.PublicKey, func(p *Peer) {
+		connected <- p
+	}, logger)
+	defer srv.Stop()
+
+	// Register the remote as a static peer with its full enode (custom
+	// ENR entry intact). The acceptor's setupConn is expected to look
+	// this up by pubkey when the inbound handshake produces no
+	// dialDest.
+	srv.AddPeer(staticEnode)
+
+	// Drive an inbound connection.
+	conn, err := net.DialTimeout("tcp", srv.ListenAddr, 5*time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	select {
+	case peer := <-connected:
+		var got uint64
+		err := peer.Node().Record().Load(enr.WithEntry("ct", &got))
+		if err != nil || got != 0xabcdef {
+			t.Fatalf("inbound peer enode lost custom ENR entry: err=%v got=%x", err, got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not accept within two seconds")
+	}
 }
 
 // This test checks that inbound connections are throttled by IP.


### PR DESCRIPTION
## Summary

`Server.setupConn` previously fell back to a stub enode (just pubkey + remote IP/port) for every inbound connection, dropping any custom ENR entries the remote advertises. With `NoDiscovery=true` and no discv5 fallback, that stub permanently masks the real ENR, so consumers reading `peer.Node().Record()` silently miss every entry on the acceptor side of every handshake.

This PR teaches `setupConn` to consult the static-peer table when an inbound connection has no `dialDest`. If the remote's pubkey matches an `AddPeer`'d entry, we reuse that entry's full enode (with its complete ENR record) instead of `nodeFromConn`'s stub.

`dialScheduler` now keeps a small concurrency-safe `staticByID` map alongside its loop-only `static` map so `setupConn` can read off the loop goroutine.

## Motivation

Surfaced by a swarm-replication integration test where every peer needs to read every other peer's `chain.toml.v2` info-hash off the connection ENR. With three peers in a mesh, only the dialer side of each pair saw the real ENR — the acceptor side received a stub, and `manifest_exchange.onPeerConnected` silently early-returned (`ct.InfoHash == 0`). Result: one peer in three never received any peer manifest, leaving 1/3 of the swarm starved.

## Scope

- Pure-discovery deployments (no static peers) keep the existing stub fallback. Behaviour change is opt-in: only nodes that explicitly registered a static peer benefit.
- Devp2p RLPx 0x04/0x05 (`ENR_Request` / `ENR_Response`) is the spec-level fix for non-static deployments. Erigon's p2p package doesn't currently implement those messages; that's a larger follow-up. This PR is the focused, backwards-compatible step that unblocks integration test scenarios and any deployment using static peers.

## Test plan

- [x] New unit test `TestServerInboundUsesStaticEnode` in `p2p/server_test.go` exercises the path: register a static peer with a custom ENR entry, drive an inbound TCP dial, assert the resulting `Peer.Node().Record()` carries the entry. Fails on `main`, passes with this change.
- [x] Full `go test ./p2p/...` sweep stays green.
- [ ] CI on this branch

## Follow-ups

- Implement RLPx `ENR_Request`/`ENR_Response` (0x04/0x05) at the base-protocol level for full ENR exchange in pure-discovery deployments.