### PR TITLE
[throwaway] Instrument EVM to log SELFDESTRUCT burn events

### DIFF
--- a/execution/exec/historical_trace_worker.go
+++ b/execution/exec/historical_trace_worker.go
@@ -226,9 +226,7 @@ func (rw *HistoricalTraceWorker) RunTxTask(txTask *TxTask) *TxResult {
 				return err
 			}
 			txContext := protocol.NewEVMTxContext(msg)
-			if rw.vmCfg.TraceJumpDest {
-				txContext.TxHash = txn.Hash()
-			}
+			txContext.TxHash = txn.Hash()
 			rw.evm.ResetBetweenBlocks(txTask.EvmBlockContext, txContext, ibs, *rw.vmCfg, rules)
 			if hooks != nil && hooks.OnTxStart != nil {
 				hooks.OnTxStart(rw.evm.GetVMContext(), txn, msg.From())

--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -1894,8 +1894,12 @@ func updateAccount(EIP161Enabled bool, isAura bool, stateWriter StateWriter, add
 	emptyRemoval := EIP161Enabled && stateObject.data.Empty() && (!isAura || addr != params.SystemAddress)
 	if stateObject.selfdestructed || (isDirty && emptyRemoval) {
 		balance := stateObject.Balance()
-		if tracingHooks != nil && tracingHooks.OnBalanceChange != nil && !(&balance).IsZero() && stateObject.selfdestructed {
-			tracingHooks.OnBalanceChange(stateObject.address, balance, uint256.Int{}, tracing.BalanceDecreaseSelfdestructBurn)
+		if !(&balance).IsZero() && stateObject.selfdestructed {
+			if tracingHooks != nil && tracingHooks.OnBalanceChange != nil {
+				tracingHooks.OnBalanceChange(stateObject.address, balance, uint256.Int{}, tracing.BalanceDecreaseSelfdestructBurn)
+			}
+			sdBurnLogf("SD-FINAL block=%d tx=%d addr=%x balance=%s newly_created=%v",
+				stateObject.db.blockNum, stateObject.db.txIndex, stateObject.address, balance.String(), stateObject.newlyCreated)
 		}
 		if dbg.TraceDomainIO || (dbg.TraceTransactionIO && (trace || dbg.TraceAccount(addr.Handle()))) {
 			if _, ok := stateWriter.(*NoopWriter); !ok || dbg.TraceNoopIO {

--- a/execution/state/sd_burn_log.go
+++ b/execution/state/sd_burn_log.go
@@ -1,0 +1,37 @@
+// Instrumentation: SD-FINAL event emitted when an account destroyed at tx end
+// still has a non-zero balance. Mirrors the vm package's SDBurnLog setup but
+// kept separate to avoid an import cycle.
+package state
+
+import (
+	"io"
+	"log"
+	"os"
+	"sync"
+)
+
+var (
+	sdBurnOnce sync.Once
+	sdBurnLog  *log.Logger
+)
+
+const sdBurnDefaultPath = "/tmp/sd_burns.log"
+
+func sdBurnInit() {
+	path := os.Getenv("SD_BURN_LOG")
+	if path == "" {
+		path = sdBurnDefaultPath
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		sdBurnLog = log.New(io.Discard, "", 0)
+		return
+	}
+	sdBurnLog = log.New(f, "", 0)
+}
+
+// sdBurnLogf writes one line to the SD-FINAL log.
+func sdBurnLogf(format string, args ...any) {
+	sdBurnOnce.Do(sdBurnInit)
+	sdBurnLog.Printf(format, args...)
+}

--- a/execution/vm/instructions.go
+++ b/execution/vm/instructions.go
@@ -1316,6 +1316,10 @@ func opSelfdestruct(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, er
 
 	ibs.AddBalance(beneficiaryAddr, balance, tracing.BalanceIncreaseSelfdestruct)
 	ibs.Selfdestruct(self)
+	if kind := ClassifySDBurn(false, false, self == beneficiaryAddr, balance.IsZero()); kind == SDBurnSelf {
+		SDBurnLog("SD-SELF block=%d tx=%x addr=%x ben=%x balance=%s just_created=pre6780",
+			evm.Context.BlockNumber, evm.TxHash, self, beneficiaryAddr, balance.String())
+	}
 	tracer := evm.Config().Tracer
 	if tracer != nil && tracer.OnEnter != nil {
 		tracer.OnEnter(evm.depth, byte(SELFDESTRUCT), scope.Contract.Address(), beneficiaryAddr, false, []byte{}, 0, balance, nil)
@@ -1361,6 +1365,14 @@ func opSelfdestruct6780(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte
 		} else if newContract {
 			ibs.AddLog(misc.EthBurnLog(self.Value(), balance))
 		}
+	}
+	switch ClassifySDBurn(true, newContract, self == beneficiaryAddr, balance.IsZero()) {
+	case SDBurnSelf:
+		SDBurnLog("SD-SELF block=%d tx=%x addr=%x ben=%x balance=%s just_created=true",
+			evm.Context.BlockNumber, evm.TxHash, self, beneficiaryAddr, balance.String())
+	case SDBurnFake:
+		SDBurnLog("FAKE-BURN block=%d tx=%x addr=%x ben=%x balance=%s",
+			evm.Context.BlockNumber, evm.TxHash, self, beneficiaryAddr, balance.String())
 	}
 	tracer := evm.Config().Tracer
 	if tracer != nil && tracer.OnEnter != nil {

--- a/execution/vm/sd_burn_log.go
+++ b/execution/vm/sd_burn_log.go
@@ -1,0 +1,79 @@
+// Instrumentation: log SELFDESTRUCT-related burn events.
+// Detects three scenarios:
+//   - SD-SELF:   real burn at SELFDESTRUCT time (self == beneficiary, balance > 0,
+//                and the account is actually destroyed — pre-Cancun always, post-Cancun
+//                only if just_created).
+//   - FAKE-BURN: post-Cancun "would-have-been" burn that EIP-6780 turned into a no-op
+//                (self == beneficiary on an existing contract, balance > 0).
+//   - SD-FINAL:  emitted by the state package when an account is destroyed at tx end
+//                with a non-zero balance (e.g. ETH arrived after SELFDESTRUCT).
+package vm
+
+import (
+	"io"
+	"log"
+	"os"
+	"sync"
+)
+
+// SDBurnKind classifies a SELFDESTRUCT-time event. It is independent of the
+// balance > 0 check so tests can exercise every condition separately.
+type SDBurnKind int
+
+const (
+	SDBurnNone SDBurnKind = iota
+	SDBurnSelf            // real burn (pre-6780 or post-6780 newContract) with self == beneficiary
+	SDBurnFake            // post-6780 would-be burn blocked by EIP-6780 (!newContract)
+)
+
+// ClassifySDBurn returns the kind of burn event for an opcode-time SELFDESTRUCT.
+// Pure function — all inputs are already extracted from the EVM state.
+//
+//	post6780:    chain is at or past Cancun.
+//	newContract: account was created in the current tx (EIP-6780 trigger).
+//	selfEqBen:   beneficiary address equals the contract's own address.
+//	balanceZero: contract's balance is zero.
+func ClassifySDBurn(post6780, newContract, selfEqBen, balanceZero bool) SDBurnKind {
+	if balanceZero || !selfEqBen {
+		return SDBurnNone
+	}
+	if !post6780 || newContract {
+		return SDBurnSelf
+	}
+	return SDBurnFake
+}
+
+var (
+	sdBurnOnce sync.Once
+	sdBurnLog  *log.Logger
+)
+
+// sdBurnPath is the default log file; overridable via env SD_BURN_LOG.
+const sdBurnDefaultPath = "/tmp/sd_burns.log"
+
+func sdBurnInit() {
+	path := os.Getenv("SD_BURN_LOG")
+	if path == "" {
+		path = sdBurnDefaultPath
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		sdBurnLog = log.New(io.Discard, "", 0)
+		return
+	}
+	sdBurnLog = log.New(f, "", 0)
+}
+
+// SDBurnLog writes one line to the burn log. Safe for concurrent use
+// (log.Logger uses an internal mutex and O_APPEND makes small writes atomic).
+func SDBurnLog(format string, args ...any) {
+	sdBurnOnce.Do(sdBurnInit)
+	sdBurnLog.Printf(format, args...)
+}
+
+// SetSDBurnLogWriter redirects output for testing. Not concurrency-safe with
+// ongoing SDBurnLog calls — intended for test setup only.
+func SetSDBurnLogWriter(w io.Writer) {
+	sdBurnOnce.Do(func() {}) // mark init done so sdBurnInit doesn't overwrite
+	sdBurnLog = log.New(w, "", 0)
+}

--- a/execution/vm/sd_burn_log_test.go
+++ b/execution/vm/sd_burn_log_test.go
@@ -1,0 +1,60 @@
+package vm
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestClassifySDBurn(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name                                         string
+		post6780, newContract, selfEqBen, balanceZero bool
+		want                                         SDBurnKind
+	}{
+		// Pre-Cancun: any self-beneficiary with positive balance is a real burn.
+		{"pre6780/self/nz", false, false, true, false, SDBurnSelf},
+		{"pre6780/self/zero", false, false, true, true, SDBurnNone},
+		{"pre6780/other/nz", false, false, false, false, SDBurnNone},
+
+		// Post-Cancun, newContract (contract actually destroyed): same as pre-6780
+		// for the self-beneficiary path — balance stays at self and is wiped.
+		{"post6780/new/self/nz", true, true, true, false, SDBurnSelf},
+		{"post6780/new/self/zero", true, true, true, true, SDBurnNone},
+		{"post6780/new/other/nz", true, true, false, false, SDBurnNone},
+
+		// Post-Cancun, !newContract: EIP-6780 blocks destruction. Self-beneficiary
+		// with positive balance is the canonical "fake burn" / "burn broken by Cancun".
+		{"post6780/exist/self/nz", true, false, true, false, SDBurnFake},
+		{"post6780/exist/self/zero", true, false, true, true, SDBurnNone},
+		{"post6780/exist/other/nz", true, false, false, false, SDBurnNone},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ClassifySDBurn(c.post6780, c.newContract, c.selfEqBen, c.balanceZero)
+			if got != c.want {
+				t.Errorf("ClassifySDBurn(post6780=%v,new=%v,selfEqBen=%v,bZero=%v) = %d, want %d",
+					c.post6780, c.newContract, c.selfEqBen, c.balanceZero, got, c.want)
+			}
+		})
+	}
+}
+
+func TestSDBurnLogWriter(t *testing.T) {
+	var buf bytes.Buffer
+	SetSDBurnLogWriter(&buf)
+
+	SDBurnLog("SD-SELF block=%d balance=%s", uint64(19_500_000), "42")
+	SDBurnLog("FAKE-BURN block=%d balance=%s", uint64(19_500_001), "0x1")
+
+	out := buf.String()
+	for _, want := range []string{
+		"SD-SELF block=19500000 balance=42",
+		"FAKE-BURN block=19500001 balance=0x1",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing log line %q in output:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
Throwaway research patch — not for upstream. Adds opcode-level logging of three SELFDESTRUCT scenarios for a one-shot mainnet replay study:

  - SD-SELF:   pre-Cancun, or post-Cancun with newContract — real burn at SD time
  - FAKE-BURN: post-Cancun, !newContract, self == beneficiary — would-have-been
               burn that EIP-6780 turned into a no-op
  - SD-FINAL:  account destroyed at tx-end with non-zero balance (deferred burn)

Output is line-appended to $SD_BURN_LOG (default /tmp/sd_burns.log). log.Logger's mutex + O_APPEND atomic writes make concurrent worker writes safe.

Touches:
  execution/vm/sd_burn_log.go              new — pure ClassifySDBurn + logger
  execution/vm/sd_burn_log_test.go         new — truth-table test for classifier
  execution/state/sd_burn_log.go           new — separate logger to avoid import cycle
  execution/vm/instructions.go             call sites in opSelfdestruct{,6780}
  execution/state/intra_block_state.go     SD-FINAL emit in updateAccount
  execution/exec/historical_trace_worker.go  unconditionally set TxContext.TxHash
                                             so the log records the real tx hash
                                             during stage_exec_replay (otherwise
                                             only set under TraceJumpDest)

Caveat: events are logged at opcode time, before tx outcome is known — reverted txs still emit a line. Filter with eth_getTransactionReceipt for burn-only views. SD-FINAL emits during finalization, after revert handling, so it's revert-safe by construction.