### PR TITLE
cherry-picks from release/3.4 to main

### DIFF
--- a/cl/phase1/stages/clstages.go
+++ b/cl/phase1/stages/clstages.go
@@ -289,7 +289,7 @@ func ConsensusClStages(ctx context.Context,
 					startingSlot := cfg.state.LatestBlockHeader().Slot
 					downloader := network2.NewBackwardBeaconDownloader(ctx, cfg.rpc, cfg.sn, cfg.executionClient, cfg.indiciesDB)
 
-					if err := SpawnStageHistoryDownload(StageHistoryReconstruction(downloader, cfg.antiquary, cfg.sn, cfg.indiciesDB, cfg.executionClient, cfg.beaconCfg, cfg.caplinConfig, false, startingRoot, startingSlot, cfg.dirs.Tmp, 600*time.Millisecond, cfg.blockCollector, cfg.blockReader, cfg.blobStore, logger, cfg.forkChoice, cfg.blobDownloader), context.Background(), logger); err != nil {
+					if err := SpawnStageHistoryDownload(StageHistoryReconstruction(downloader, cfg.antiquary, cfg.sn, cfg.indiciesDB, cfg.executionClient, cfg.beaconCfg, cfg.caplinConfig, false, startingRoot, startingSlot, cfg.dirs.Tmp, 600*time.Millisecond, cfg.blockCollector, cfg.blockReader, cfg.blobStore, logger, cfg.forkChoice, cfg.blobDownloader), ctx, logger); err != nil {
 						cfg.hasDownloaded = false
 						return err
 					}

--- a/execution/tracing/hooks.go
+++ b/execution/tracing/hooks.go
@@ -49,6 +49,7 @@ type IntraBlockState interface {
 	GetBalance(accounts.Address) (uint256.Int, error)
 	GetNonce(accounts.Address) (uint64, error)
 	GetCode(accounts.Address) ([]byte, error)
+	GetCodeHash(accounts.Address) (accounts.CodeHash, error)
 	GetState(addr accounts.Address, key accounts.StorageKey) (uint256.Int, error)
 	Exist(accounts.Address) (bool, error)
 	GetRefund() mdgas.MdGas

--- a/execution/tracing/tracers/logger/json_stream_test.go
+++ b/execution/tracing/tracers/logger/json_stream_test.go
@@ -56,6 +56,9 @@ type mockIBS struct{}
 func (m *mockIBS) GetBalance(accounts.Address) (uint256.Int, error) { return uint256.Int{}, nil }
 func (m *mockIBS) GetNonce(accounts.Address) (uint64, error)        { return 0, nil }
 func (m *mockIBS) GetCode(accounts.Address) ([]byte, error)         { return nil, nil }
+func (m *mockIBS) GetCodeHash(accounts.Address) (accounts.CodeHash, error) {
+	return accounts.NilCodeHash, nil
+}
 func (m *mockIBS) GetState(accounts.Address, accounts.StorageKey) (uint256.Int, error) {
 	return uint256.Int{}, nil
 }

--- a/execution/tracing/tracers/native/prestate.go
+++ b/execution/tracing/tracers/native/prestate.go
@@ -283,23 +283,21 @@ func (t *prestateTracer) processDiffState() {
 
 		newBalance, _ := t.env.IntraBlockState.GetBalance(addr)
 		newNonce, _ := t.env.IntraBlockState.GetNonce(addr)
-		newCode, _ := t.env.IntraBlockState.GetCode(addr)
-		newCodeHash := empty.CodeHash
-		if len(newCode) > 0 {
-			newCodeHash = crypto.HashData(newCode)
-		}
+		// GetCodeHash returns common.Hash{} for deleted accounts; GetCode cannot make
+		// that distinction (empty bytes for both deleted and codeless accounts).
+		codeHash, _ := t.env.IntraBlockState.GetCodeHash(addr)
+		newCodeHash := codeHash.Value()
 
-		if newBalance.ToBig().Cmp(t.pre[addr].Balance) != 0 {
+		newBalanceBig := newBalance.ToBig()
+		if newBalanceBig.Cmp(t.pre[addr].Balance) != 0 {
 			modified = true
-			postAccount.Balance = newBalance.ToBig()
+			postAccount.Balance = newBalanceBig
 		}
 		if newNonce != t.pre[addr].Nonce {
 			modified = true
 			postAccount.Nonce = newNonce
 		}
 
-		// Empty code hashes are excluded from the prestate, so default
-		// to EmptyCodeHash to match what GetCodeHash returns for codeless accounts.
 		prevCodeHash := empty.CodeHash
 		if t.pre[addr].CodeHash != nil {
 			prevCodeHash = *t.pre[addr].CodeHash
@@ -311,6 +309,7 @@ func (t *prestateTracer) processDiffState() {
 		}
 
 		if !t.config.DisableCode {
+			newCode, _ := t.env.IntraBlockState.GetCode(addr)
 			var prevCode []byte
 			if t.pre[addr].Code != nil {
 				prevCode = *t.pre[addr].Code

--- a/execution/tracing/tracers/native/prestate_deleted_test.go
+++ b/execution/tracing/tracers/native/prestate_deleted_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package native
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/tracing"
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+// postTxIBS simulates the IntraBlockState *after* a transaction where deletedAddr
+// no longer exists (GetCodeHash returns NilCodeHash) and all other accounts are
+// codeless-but-existent (EmptyCodeHash).
+type postTxIBS struct {
+	deletedAddr accounts.Address
+}
+
+func (m *postTxIBS) GetBalance(accounts.Address) (uint256.Int, error) { return uint256.Int{}, nil }
+func (m *postTxIBS) GetNonce(accounts.Address) (uint64, error)        { return 0, nil }
+func (m *postTxIBS) GetCode(accounts.Address) ([]byte, error)         { return nil, nil }
+func (m *postTxIBS) GetState(accounts.Address, accounts.StorageKey) (uint256.Int, error) {
+	return uint256.Int{}, nil
+}
+func (m *postTxIBS) Exist(accounts.Address) (bool, error) { return false, nil }
+func (m *postTxIBS) GetRefund() uint64                    { return 0 }
+func (m *postTxIBS) GetCodeHash(addr accounts.Address) (accounts.CodeHash, error) {
+	if addr == m.deletedAddr {
+		return accounts.NilCodeHash, nil
+	}
+	return accounts.EmptyCodeHash, nil
+}
+
+// TestPrestateTracerDiffModeDeletedAccount verifies that an account deleted during
+// a tx appears in the diff-mode post state with codeHash == 0x000...000.
+func TestPrestateTracerDiffModeDeletedAccount(t *testing.T) {
+	deletedAddr := accounts.InternAddress(common.HexToAddress("0x0000000000000000000000000000000000001234"))
+
+	tr := &prestateTracer{
+		pre:     state{},
+		post:    state{},
+		config:  prestateTracerConfig{DiffMode: true, DisableCode: true, DisableStorage: true},
+		created: make(map[accounts.Address]bool),
+		deleted: make(map[accounts.Address]bool),
+	}
+
+	// Pre-tx: codeless account — no CodeHash set, balance = 0.
+	tr.pre[deletedAddr] = &account{Balance: big.NewInt(0)}
+
+	tr.env = &tracing.VMContext{
+		IntraBlockState: &postTxIBS{deletedAddr: deletedAddr},
+	}
+
+	tr.processDiffState()
+
+	post, ok := tr.post[deletedAddr]
+	require.True(t, ok, "deleted account must appear in post state")
+	require.NotNil(t, post.CodeHash, "deleted account must carry codeHash in post state")
+	require.Equal(t, common.Hash{}, *post.CodeHash, "deleted account must have zero codeHash")
+}
+
+// TestPrestateTracerDiffModeCodelessUnchanged verifies that a codeless account
+// with no state changes does NOT appear in the post state (no false positive).
+func TestPrestateTracerDiffModeCodelessUnchanged(t *testing.T) {
+	addr := accounts.InternAddress(common.HexToAddress("0x0000000000000000000000000000000000005678"))
+	// Use a different deleted addr so that `addr` is treated as still-existent.
+	otherAddr := accounts.InternAddress(common.HexToAddress("0x0000000000000000000000000000000000009999"))
+
+	tr := &prestateTracer{
+		pre:     state{},
+		post:    state{},
+		config:  prestateTracerConfig{DiffMode: true, DisableCode: true, DisableStorage: true},
+		created: make(map[accounts.Address]bool),
+		deleted: make(map[accounts.Address]bool),
+	}
+
+	tr.pre[addr] = &account{Balance: big.NewInt(0)}
+
+	tr.env = &tracing.VMContext{
+		IntraBlockState: &postTxIBS{deletedAddr: otherAddr}, // addr returns EmptyCodeHash
+	}
+
+	tr.processDiffState()
+
+	_, ok := tr.post[addr]
+	require.False(t, ok, "unchanged codeless account must NOT appear in post state")
+}

--- a/execution/tracing/tracers/native/prestate_deleted_test.go
+++ b/execution/tracing/tracers/native/prestate_deleted_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/protocol/mdgas"
 	"github.com/erigontech/erigon/execution/tracing"
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
@@ -42,7 +43,7 @@ func (m *postTxIBS) GetState(accounts.Address, accounts.StorageKey) (uint256.Int
 	return uint256.Int{}, nil
 }
 func (m *postTxIBS) Exist(accounts.Address) (bool, error) { return false, nil }
-func (m *postTxIBS) GetRefund() uint64                    { return 0 }
+func (m *postTxIBS) GetRefund() mdgas.MdGas               { return mdgas.MdGas{} }
 func (m *postTxIBS) GetCodeHash(addr accounts.Address) (accounts.CodeHash, error) {
 	if addr == m.deletedAddr {
 		return accounts.NilCodeHash, nil

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -777,7 +777,6 @@ running:
 		case <-logTimer.C:
 			vals := []any{"protocol", srv.Config.Protocols[0].Version, "peers", len(peers), "trusted", len(trusted), "inbound", inboundCount}
 			vals = append(vals, srv.listAndResetErrors()...)
-
 			srv.logger.Debug("[p2p] Server", vals...)
 		}
 	}

--- a/rpc/mcp/mcp.go
+++ b/rpc/mcp/mcp.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"net/http"
 	"os"
 	"strings"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
 	chainspec "github.com/erigontech/erigon/execution/chain/spec"
 	"github.com/erigontech/erigon/rpc"
 	"github.com/erigontech/erigon/rpc/ethapi"
@@ -1194,13 +1196,26 @@ func (e *ErigonMCPServer) Serve() error {
 // ServeContext starts MCP server in stdio mode using the provided context
 // for lifecycle management, avoiding duplicate signal handlers.
 func (e *ErigonMCPServer) ServeContext(ctx context.Context) error {
+	// Apply NonBlockingAcquire so BeginRo fails fast (ErrServerOverloaded)
+	// instead of blocking the entire sequential stdio session indefinitely.
 	s := server.NewStdioServer(e.mcpServer)
+	s.SetContextFunc(func(ctx context.Context) context.Context {
+		return kv.WithNonBlockingAcquire(ctx)
+	})
 	return s.Listen(ctx, os.Stdin, os.Stdout)
 }
 
 // ServeSSE starts MCP server with SSE transport
 func (e *ErigonMCPServer) ServeSSE(addr string) (err error) {
-	sse := server.NewSSEServer(e.mcpServer)
+	// Apply NonBlockingAcquire so BeginRo fails fast (ErrServerOverloaded)
+	// instead of blocking the SSE handler goroutine indefinitely when all DB
+	// read slots are held by a concurrent write/ETL transaction. The HTTP RPC
+	// layer sets the same flag in node/rpcstack.go.
+	sse := server.NewSSEServer(e.mcpServer,
+		server.WithSSEContextFunc(func(ctx context.Context, _ *http.Request) context.Context {
+			return kv.WithNonBlockingAcquire(ctx)
+		}),
+	)
 
 	defer func() {
 		if r := recover(); r != nil {


### PR DESCRIPTION
Cherry-picks of PRs from release/3.4 that were missing from main.

- #20778 rpc/mcp: fix tools/call hanging indefinitely under DB load
- #20775 tracing: fix prestateTracer diff mode missing deleted accounts (flaky)
- #20766 SpawnStageHistoryDownload: didn't support graceful restart
- #20659 cl: move stats logging outside of mutex