### PR TITLE
[r3.4] ci: filter release BINARIES by Makefile targets to fix mcp build failure on release branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,26 @@ jobs:
           echo "short_commit_id=$(git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
           echo "parsed_version=$(echo ${RELEASE_VERSION} | sed -e 's/^v//g')" >> $GITHUB_OUTPUT
 
+      - name: Filter BINARIES to those available in the checked-out branch's Makefile
+        run: |
+          cd erigon
+          # Collect all targets available via COMMANDS in the Makefile, plus 'erigon' which is always present
+          AVAILABLE_TARGETS=$(grep '^COMMANDS +=' Makefile | awk '{print $3}' | tr '\n' ' ')
+          AVAILABLE_TARGETS="erigon $AVAILABLE_TARGETS"
+          echo "Makefile targets available: $AVAILABLE_TARGETS"
+
+          FILTERED=""
+          for bin in $BINARIES; do
+            if echo " $AVAILABLE_TARGETS " | grep -qw "$bin"; then
+              FILTERED="$FILTERED $bin"
+            else
+              echo "Skipping '$bin': no Makefile target in this branch"
+            fi
+          done
+          FILTERED="${FILTERED# }"
+          echo "Filtered BINARIES: $FILTERED"
+          echo "BINARIES=$FILTERED" >> $GITHUB_ENV
+
       - name: Validate release version against db/version/app.go
         if: ${{ ! inputs.disable_version_check }}
         env:


### PR DESCRIPTION
Cherry-pick of #20167 to release/3.4.