### PR TITLE
cmd/utils/app: skip commitment history integrity checks when disabled

### DIFF
--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -1552,6 +1552,15 @@ func doIntegrity(cliCtx *cli.Context) error {
 	blockReader, _ := blockRetire.IO()
 	heimdallStore, _ := blockRetire.BorStore()
 
+	var commitmentHistoryEnabled bool
+	if err := chainDB.View(ctx, func(tx kv.Tx) error {
+		var err error
+		commitmentHistoryEnabled, _, err = rawdb.ReadDBCommitmentHistoryEnabled(tx)
+		return err
+	}); err != nil {
+		return fmt.Errorf("failed to read CommitmentHistory config: %w", err)
+	}
+
 	runCheck := func(ctx context.Context, chk integrity.Check) error {
 		switch chk {
 		case integrity.BlocksTxnID:
@@ -1600,10 +1609,18 @@ func doIntegrity(cliCtx *cli.Context) error {
 		case integrity.CommitmentKvDeref:
 			return integrity.CheckCommitmentKvDeref(ctx, db, cache, failFast, logger)
 		case integrity.CommitmentHistVal:
+			if !commitmentHistoryEnabled {
+				logger.Info("[integrity] CommitmentHistVal skipped because commitment history is not enabled on this datadir")
+				return nil
+			}
 			scCopy := sc
 			scCopy.SampleRatio /= 100 // it's very slow check
 			return integrity.CheckCommitmentHistVal(ctx, scCopy, db, blockReader, failFast, logger)
 		case integrity.StateRootVerifyByHistory:
+			if !commitmentHistoryEnabled {
+				logger.Info("[integrity] StateRootVerifyByHistory skipped because commitment history is not enabled on this datadir")
+				return nil
+			}
 			to, err := stateProgress(ctx, db, blockReader.TxnumReader())
 			if err != nil {
 				return err


### PR DESCRIPTION
## Summary

`seg integrity` runs `CommitmentHistVal` and `StateRootVerifyByHistory` regardless of whether commitment history is persisted on the datadir. Both depend on commitment history `.v` files:

- `CheckCommitmentHistVal` iterates `.v` files; when none exist it returns nil after logging `files=0`, which silently masks misconfiguration as a passing check.
- `CheckCommitmentHistAtBlkRange` would fail confusingly when trying to read history that isn't there.

This PR reads `rawdb.ReadDBCommitmentHistoryEnabled` once at the start of `doIntegrity` and skips both checks with an informative log line when the flag is off. Mirrors the existing `BorEvents` / `BorSpans` chain-guard pattern in the same dispatch switch.

The other commitment checks (`CommitmentRoot`, `CommitmentKvi`, `CommitmentKvDeref`, `StateVerify`) operate on the domain `.kv` files and don't depend on history, so they remain unconditional.

## Test plan

- [x] `make lint` clean
- [x] `go build ./cmd/utils/app/...` succeeds
- [x] On a no-history datadir, run `seg integrity --check CommitmentHistVal` and confirm the skip log appears and the command exits 0 instead of "passing" with files=0
- [x] On a history-enabled datadir, confirm `CommitmentHistVal` and `StateRootVerifyByHistory` still execute as before