### PR TITLE
cp: integrity check PRs to performance (#20435, #20680, #20714, #20835)

### DIFF
--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -1291,6 +1291,15 @@ func doIntegrity(cliCtx *cli.Context) error {
 	blockReader, _ := blockRetire.IO()
 	heimdallStore, _ := blockRetire.BorStore()
 
+	var commitmentHistoryEnabled bool
+	if err := chainDB.View(ctx, func(tx kv.Tx) error {
+		var err error
+		commitmentHistoryEnabled, _, err = rawdb.ReadDBCommitmentHistoryEnabled(tx)
+		return err
+	}); err != nil {
+		return fmt.Errorf("failed to read CommitmentHistory config: %w", err)
+	}
+
 	runCheck := func(ctx context.Context, chk integrity.Check) error {
 		switch chk {
 		case integrity.BlocksTxnID:
@@ -1343,6 +1352,10 @@ func doIntegrity(cliCtx *cli.Context) error {
 			}
 			return integrity.CheckCommitmentKvDeref(ctx, db, cache, failFast, logger)
 		case integrity.CommitmentHistVal:
+			if !commitmentHistoryEnabled {
+				logger.Info("[integrity] CommitmentHistVal skipped because commitment history is not enabled on this datadir")
+				return nil
+			}
 			scCopy := sc
 			scCopy.SampleRatio /= 100 // it's very slow check
 			if chainConfig.ChainName == networkname.Bloatnet {
@@ -1350,6 +1363,10 @@ func doIntegrity(cliCtx *cli.Context) error {
 			}
 			return integrity.CheckCommitmentHistVal(ctx, scCopy, db, blockReader, failFast, logger)
 		case integrity.StateRootVerifyByHistory:
+			if !commitmentHistoryEnabled {
+				logger.Info("[integrity] StateRootVerifyByHistory skipped because commitment history is not enabled on this datadir")
+				return nil
+			}
 			to, err := stateProgress(ctx, db, blockReader.TxnumReader())
 			if err != nil {
 				return err

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -38,7 +38,6 @@ import (
 	g "github.com/anacrolix/generics"
 	"github.com/c2h5oh/datasize"
 	"github.com/urfave/cli/v2"
-	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 
 	"github.com/erigontech/erigon/cl/clparams"
@@ -417,6 +416,7 @@ var snapshotCommand = cli.Command{
 				&cli.BoolFlag{Name: "skip-torrent-verify", Usage: "skip torrent piece verification when using file-integrity-cache"},
 				&cli.Int64Flag{Name: "seed", Usage: "random seed for sampling (auto-generated if not set)"},
 				&cli.Float64Flag{Name: "sample", Usage: "fraction of items to check via pseudo-random sampling (0.0-1.0)", Value: 0.01},
+				&cli.DurationFlag{Name: "integrity.budget", Value: 0, Usage: "total wall-clock budget for the run; each check gets (remaining / remaining_checks). 0 (default) means no limit"},
 			}),
 		},
 		{
@@ -500,7 +500,8 @@ var snapshotCommand = cli.Command{
 		{
 			Name: "publishable",
 			Action: func(cliCtx *cli.Context) error {
-				if err := doPublishable(cliCtx, nil); err != nil {
+				dirs := datadir.New(cliCtx.String(utils.DataDirFlag.Name))
+				if err := doPublishable(dirs, nil); err != nil {
 					log.Error("[publishable]", "err", err)
 					return err
 				}
@@ -1216,6 +1217,11 @@ func doIntegrity(cliCtx *cli.Context) error {
 		requestedChecks = finalChecks
 	}
 
+	if len(requestedChecks) == 0 {
+		logger.Warn("[integrity] no checks to run (all filtered out)")
+		return nil
+	}
+
 	failFast := cliCtx.Bool("failFast")
 	fromStep := cliCtx.Uint64("fromStep")
 
@@ -1285,134 +1291,129 @@ func doIntegrity(cliCtx *cli.Context) error {
 	blockReader, _ := blockRetire.IO()
 	heimdallStore, _ := blockRetire.BorStore()
 
-	g, ctx := errgroup.WithContext(ctx)
-	g.SetLimit(1)
-	for _, chk := range requestedChecks {
-		chk := chk
-		g.Go(func() error {
-			logger.Info("[integrity] starting", "check", chk)
-			if err := func() error {
-				switch chk {
-				case integrity.BlocksTxnID:
-					if err := blockReader.(*freezeblocks.BlockReader).IntegrityTxnID(failFast); err != nil {
-						return err
-					}
-				case integrity.HeaderNoGaps:
-					if err := integrity.NoGapsInCanonicalHeaders(ctx, db, blockReader, failFast); err != nil {
-						return err
-					}
-				case integrity.Blocks:
-					if err := integrity.SnapBlocksRead(ctx, db, blockReader, 0, 0, failFast); err != nil {
-						return err
-					}
-				case integrity.InvertedIndex:
-					if err := integrity.E3EfFiles(ctx, db, failFast, fromStep); err != nil {
-						return err
-					}
-				case integrity.HistoryNoSystemTxs:
-					if err := integrity.HistoryCheckNoSystemTxs(ctx, db, blockReader); err != nil {
-						return err
-					}
-				case integrity.BorEvents:
-					if !CheckBorChain(chainConfig.ChainName) {
-						logger.Info("BorEvents skipped because not bor chain")
-						return nil
-					}
-					snapshots := blockReader.BorSnapshots().(*heimdall.RoSnapshots)
-					if err := bridge.ValidateBorEvents(ctx, db, blockReader, snapshots, 0, 0, failFast); err != nil {
-						return err
-					}
-				case integrity.BorSpans:
-					if !CheckBorChain(chainConfig.ChainName) {
-						logger.Info("BorSpans skipped because not bor chain")
-						return nil
-					}
-					if err := heimdall.ValidateBorSpans(ctx, logger, dirs, heimdallStore, borSnaps, failFast); err != nil {
-						return err
-					}
-				case integrity.BorCheckpoints:
-					if !CheckBorChain(chainConfig.ChainName) {
-						logger.Info("BorCheckpoints skipped because not bor chain")
-						return nil
-					}
-					if err := heimdall.ValidateBorCheckpoints(ctx, logger, dirs, heimdallStore, borSnaps, failFast); err != nil {
-						return err
-					}
-				case integrity.ReceiptsNoDups:
-					if err := integrity.CheckReceiptsNoDups(ctx, sc, db, blockReader, failFast); err != nil {
-						return err
-					}
-				case integrity.RCacheNoDups:
-					if err := integrity.CheckRCacheNoDups(ctx, sc, db, blockReader, failFast); err != nil {
-						return err
-					}
-				case integrity.StateProgress:
-					if err := integrity.CheckStateProgress(ctx, db, blockReader, failFast); err != nil {
-						return err
-					}
-				case integrity.Publishable:
-					if err := doPublishable(cliCtx, chainDB); err != nil {
-						return err
-					}
-				case integrity.CommitmentRoot:
-					if err := integrity.CheckCommitmentRoot(ctx, db, blockReader, failFast, logger); err != nil {
-						return err
-					}
-				case integrity.CommitmentKvi:
-					scCopy := sc
-					scCopy.SampleRatio = 0 // Sudeep will try to speedup it different way: by use `cache`
-					if err := integrity.CheckCommitmentKvi(ctx, scCopy, db, cache, failFast, logger); err != nil {
-						return err
-					}
-				case integrity.CommitmentKvDeref:
-					if chainConfig.ChainName == networkname.Bloatnet {
-						log.Warn("[todo] CommitmentKvDeref disabled on bloatnet. see https://github.com/erigontech/erigon/issues/20814")
-						return nil // TODO: taking too long on bloatnet
-					}
-					if err := integrity.CheckCommitmentKvDeref(ctx, db, cache, failFast, logger); err != nil {
-						return err
-					}
-				case integrity.CommitmentHistVal:
-					scCopy := sc
-					scCopy.SampleRatio /= 100 // it's very slow check
-					if chainConfig.ChainName == networkname.Bloatnet {
-						scCopy.SampleRatio /= 10
-					}
-					if err := integrity.CheckCommitmentHistVal(ctx, scCopy, db, blockReader, failFast, logger); err != nil {
-						return err
-					}
-				case integrity.StateRootVerifyByHistory:
-					to, err := stateProgress(ctx, db, blockReader.TxnumReader())
-					if err != nil {
-						return err
-					}
-					scCopy := sc
-					scCopy.SampleRatio /= 100 // it's very slow check
-					if chainConfig.ChainName == networkname.Bloatnet {
-						scCopy.SampleRatio /= 10
-					}
-					if err := integrity.CheckCommitmentHistAtBlkRange(ctx, scCopy, db, blockReader, 1, to+1, failFast, logger); err != nil {
-						return err
-					}
-				case integrity.StateVerify:
-					if err := integrity.CheckStateVerify(ctx, db, failFast, fromStep, logger); err != nil {
-						return err
-					}
-				default:
-					err := fmt.Errorf("unknown check: %s", chk)
-					if err != nil {
-						log.Warn(err.Error())
-					}
-				}
+	runCheck := func(ctx context.Context, chk integrity.Check) error {
+		switch chk {
+		case integrity.BlocksTxnID:
+			return blockReader.(*freezeblocks.BlockReader).IntegrityTxnID(ctx, failFast)
+		case integrity.HeaderNoGaps:
+			return integrity.NoGapsInCanonicalHeaders(ctx, db, blockReader, failFast)
+		case integrity.Blocks:
+			return integrity.SnapBlocksRead(ctx, db, blockReader, 0, 0, failFast)
+		case integrity.InvertedIndex:
+			return integrity.E3EfFiles(ctx, db, failFast, fromStep)
+		case integrity.HistoryNoSystemTxs:
+			return integrity.HistoryCheckNoSystemTxs(ctx, db, blockReader)
+		case integrity.StateProgress:
+			return integrity.CheckStateProgress(ctx, db, blockReader, failFast)
+		case integrity.Publishable:
+			return doPublishable(dirs, chainDB)
+		case integrity.BorEvents:
+			if !CheckBorChain(chainConfig.ChainName) {
+				logger.Info("BorEvents skipped because not bor chain")
 				return nil
-			}(); err != nil {
-				return fmt.Errorf("%s: %w", chk, err)
 			}
-			return nil
-		})
+			snapshots := blockReader.BorSnapshots().(*heimdall.RoSnapshots)
+			return bridge.ValidateBorEvents(ctx, db, blockReader, snapshots, 0, 0, failFast)
+		case integrity.BorSpans:
+			if !CheckBorChain(chainConfig.ChainName) {
+				logger.Info("BorSpans skipped because not bor chain")
+				return nil
+			}
+			return heimdall.ValidateBorSpans(ctx, logger, dirs, heimdallStore, borSnaps, failFast)
+		case integrity.BorCheckpoints:
+			if !CheckBorChain(chainConfig.ChainName) {
+				logger.Info("BorCheckpoints skipped because not bor chain")
+				return nil
+			}
+			return heimdall.ValidateBorCheckpoints(ctx, logger, dirs, heimdallStore, borSnaps, failFast)
+		case integrity.ReceiptsNoDups:
+			return integrity.CheckReceiptsNoDups(ctx, sc, db, blockReader, failFast)
+		case integrity.RCacheNoDups:
+			return integrity.CheckRCacheNoDups(ctx, sc, db, blockReader, failFast)
+		case integrity.CommitmentRoot:
+			return integrity.CheckCommitmentRoot(ctx, db, blockReader, failFast, logger)
+		case integrity.CommitmentKvi:
+			scCopy := sc
+			scCopy.SampleRatio = 0 // Sudeep will try to speedup it different way: by use `cache`
+			return integrity.CheckCommitmentKvi(ctx, scCopy, db, cache, failFast, logger)
+		case integrity.CommitmentKvDeref:
+			if chainConfig.ChainName == networkname.Bloatnet {
+				log.Warn("[todo] CommitmentKvDeref disabled on bloatnet. see https://github.com/erigontech/erigon/issues/20814")
+				return nil // TODO: taking too long on bloatnet
+			}
+			return integrity.CheckCommitmentKvDeref(ctx, db, cache, failFast, logger)
+		case integrity.CommitmentHistVal:
+			scCopy := sc
+			scCopy.SampleRatio /= 100 // it's very slow check
+			if chainConfig.ChainName == networkname.Bloatnet {
+				scCopy.SampleRatio /= 10
+			}
+			return integrity.CheckCommitmentHistVal(ctx, scCopy, db, blockReader, failFast, logger)
+		case integrity.StateRootVerifyByHistory:
+			to, err := stateProgress(ctx, db, blockReader.TxnumReader())
+			if err != nil {
+				return err
+			}
+			scCopy := sc
+			scCopy.SampleRatio /= 100 // it's very slow check
+			if chainConfig.ChainName == networkname.Bloatnet {
+				scCopy.SampleRatio /= 10
+			}
+			return integrity.CheckCommitmentHistAtBlkRange(ctx, scCopy, db, blockReader, 1, to+1, failFast, logger)
+		case integrity.StateVerify:
+			return integrity.CheckStateVerify(ctx, db, failFast, fromStep, logger)
+		default:
+			return fmt.Errorf("unknown check: %s", chk)
+		}
 	}
 
-	return g.Wait()
+	var deadline time.Time
+	if budget := cliCtx.Duration("integrity.budget"); budget > 0 {
+		requestedChecks = integrity.SortChecksByCost(requestedChecks)
+		deadline = time.Now().Add(budget)
+		logger.Info("[integrity] budget", "total", budget, "perCheck", budget/time.Duration(len(requestedChecks)))
+	}
+
+	for i, chk := range requestedChecks {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		checkCtx := ctx
+		var cancel context.CancelFunc
+		if !deadline.IsZero() {
+			remaining := time.Until(deadline)
+			if remaining <= 0 {
+				logger.Info("[integrity] budget exhausted, skipping remaining", "skipped", len(requestedChecks)-i)
+				break
+			}
+			slice := remaining / time.Duration(len(requestedChecks)-i)
+			checkCtx, cancel = context.WithTimeout(ctx, slice)
+		}
+
+		logger.Info("[integrity] starting", "check", chk)
+		start := time.Now()
+		err := runCheck(checkCtx, chk)
+		elapsed := time.Since(start)
+		if cancel != nil {
+			cancel()
+		}
+
+		if err == nil {
+			logger.Info("[integrity] done", "check", chk, "elapsed", elapsed)
+			continue
+		}
+		if parentErr := ctx.Err(); parentErr != nil {
+			return parentErr
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			logger.Info("[integrity] budget exhausted, moving on", "check", chk, "elapsed", elapsed)
+			continue
+		}
+		return fmt.Errorf("%s: %w", chk, err)
+	}
+
+	return nil
 }
 
 // stateProgress returns the latest block number covered by state snapshots,
@@ -2115,8 +2116,7 @@ func doBlockSnapshotsRangeCheck(snapDir string, suffix string, snapType string) 
 
 }
 
-func doPublishable(cliCtx *cli.Context, chainDB kv.RoDB) error {
-	dat := datadir.New(cliCtx.String(utils.DataDirFlag.Name))
+func doPublishable(dat datadir.Dirs, chainDB kv.RoDB) error {
 	// Check block snapshots sanity
 	if err := checkIfBlockSnapshotsPublishable(dat.Snap); err != nil {
 		return err

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -1346,10 +1346,6 @@ func doIntegrity(cliCtx *cli.Context) error {
 			scCopy.SampleRatio = 0 // Sudeep will try to speedup it different way: by use `cache`
 			return integrity.CheckCommitmentKvi(ctx, scCopy, db, cache, failFast, logger)
 		case integrity.CommitmentKvDeref:
-			if chainConfig.ChainName == networkname.Bloatnet {
-				log.Warn("[todo] CommitmentKvDeref disabled on bloatnet. see https://github.com/erigontech/erigon/issues/20814")
-				return nil // TODO: taking too long on bloatnet
-			}
 			return integrity.CheckCommitmentKvDeref(ctx, db, cache, failFast, logger)
 		case integrity.CommitmentHistVal:
 			if !commitmentHistoryEnabled {

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -1345,6 +1345,10 @@ func doIntegrity(cliCtx *cli.Context) error {
 					if err := integrity.CheckRCacheNoDups(ctx, sc, db, blockReader, failFast); err != nil {
 						return err
 					}
+				case integrity.StateProgress:
+					if err := integrity.CheckStateProgress(ctx, db, blockReader, failFast); err != nil {
+						return err
+					}
 				case integrity.Publishable:
 					if err := doPublishable(cliCtx, chainDB); err != nil {
 						return err

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -69,6 +69,7 @@ import (
 	"github.com/erigontech/erigon/db/rawdb/blockio"
 	"github.com/erigontech/erigon/db/recsplit"
 	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/services"
 	"github.com/erigontech/erigon/db/snapshotsync"
 	"github.com/erigontech/erigon/db/snapshotsync/freezeblocks"
 	"github.com/erigontech/erigon/db/snaptype"
@@ -2981,6 +2982,11 @@ func doRetireCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 		if err != nil {
 			return err
 		}
+		maxCollatable, err := services.MaxCollatableTxNum(ctx, tx, blockReader)
+		if err != nil {
+			return err
+		}
+		lastTxNum = min(lastTxNum, maxCollatable)
 		return nil
 	}); err != nil {
 		return err

--- a/db/integrity/commitment_progress_check.go
+++ b/db/integrity/commitment_progress_check.go
@@ -1,0 +1,32 @@
+package integrity
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/services"
+)
+
+func CheckStateProgress(ctx context.Context, db kv.TemporalRoDB, blockReader services.FullBlockReader, failFast bool) (err error) {
+	// state files should not be ahead of blocks files
+	tx, err := db.BeginTemporalRo(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	stateFileProgress := tx.Debug().DomainFiles(kv.CommitmentDomain).EndRootNum()
+
+	txnumReader := blockReader.TxnumReader()
+	blockFileProgress, err := txnumReader.Max(ctx, tx, blockReader.FrozenBlocks())
+	if err != nil {
+		return err
+	}
+
+	if stateFileProgress > blockFileProgress {
+		return fmt.Errorf("state files progress (%d) is ahead of blocks files progress (%d). To recover: erigon seg rm-state --latest --datadir=<datadir>, then run integration stage_exec --reset --datadir=<datadir>", stateFileProgress, blockFileProgress)
+	}
+
+	return nil
+}

--- a/db/integrity/integrity_action_type.go
+++ b/db/integrity/integrity_action_type.go
@@ -105,6 +105,11 @@ const (
 	// bidirectional correspondence rather than just reference validity.
 	StateVerify Check = "StateVerify"
 
+	// StateProgress verifies state files aren't ahead of block files. Checks that the
+	// commitment domain progress doesn't exceed the frozen block files progress.
+	// Prevents inconsistent states where state snapshots are more recent than block snapshots.
+	StateProgress Check = "StateProgress"
+
 	// Publishable validates snapshot publication readiness. Checks that all required snapshot
 	// files exist and are properly structured: block snapshots, state snapshots, beacon/caplin
 	// snapshots, and required metadata files (salt files). This is the final check before
@@ -113,7 +118,7 @@ const (
 )
 
 var FastChecks = []Check{
-	Blocks, HeaderNoGaps, BlocksTxnID, InvertedIndex, HistoryNoSystemTxs,
+	Blocks, HeaderNoGaps, BlocksTxnID, InvertedIndex, StateProgress, HistoryNoSystemTxs,
 	CommitmentKvi, ReceiptsNoDups, RCacheNoDups, CommitmentRoot,
 	CommitmentHistVal, StateRootVerifyByHistory, Publishable,
 }

--- a/db/integrity/integrity_action_type.go
+++ b/db/integrity/integrity_action_type.go
@@ -16,6 +16,10 @@
 
 package integrity
 
+import (
+	"sort"
+)
+
 type Check string
 
 const (
@@ -117,10 +121,12 @@ const (
 	Publishable Check = "Publishable"
 )
 
+// FastChecks is ordered cheapest → heaviest so time-budgeted runs give unused
+// budget to the heavier checks at the tail.
 var FastChecks = []Check{
-	Blocks, HeaderNoGaps, BlocksTxnID, InvertedIndex, StateProgress, HistoryNoSystemTxs,
-	CommitmentKvi, ReceiptsNoDups, RCacheNoDups, CommitmentRoot,
-	CommitmentHistVal, StateRootVerifyByHistory, Publishable,
+	StateProgress, Publishable, HeaderNoGaps, BlocksTxnID, Blocks,
+	ReceiptsNoDups, RCacheNoDups, InvertedIndex, CommitmentRoot, CommitmentKvi,
+	HistoryNoSystemTxs, CommitmentHistVal, StateRootVerifyByHistory,
 }
 
 var SlowChecks = []Check{StateVerify}
@@ -129,3 +135,28 @@ var DeprecatedChecks = []Check{
 	CommitmentKvDeref, //StateVerify - will overcome
 }
 var AllChecks = append(append(append([]Check{}, FastChecks...), SlowChecks...), DeprecatedChecks...)
+
+// SortChecksByCost returns a copy of checks ordered by their position in FastChecks
+// (cheapest → heaviest). Checks not in FastChecks keep their original relative order at the end.
+func SortChecksByCost(checks []Check) []Check {
+	rank := make(map[Check]int, len(FastChecks))
+	for i, c := range FastChecks {
+		rank[c] = i
+	}
+	out := append([]Check{}, checks...)
+	sort.SliceStable(out, func(i, j int) bool {
+		ri, oki := rank[out[i]]
+		rj, okj := rank[out[j]]
+		switch {
+		case oki && okj:
+			return ri < rj
+		case oki:
+			return true
+		case okj:
+			return false
+		default:
+			return false
+		}
+	})
+	return out
+}

--- a/db/integrity/integrity_kvi.go
+++ b/db/integrity/integrity_kvi.go
@@ -217,6 +217,12 @@ func CheckKvi(ctx context.Context, kviPath string, kvPath string, kvCompression 
 		var keyBuf []byte
 		var keyOffset uint64 // byte offset of the current key in the bitstream
 		for kvReader.HasNext() {
+			// Skip path is hot (full-skip mode loops over every key); amortize the ctx check.
+			if keyCount%100000 == 0 {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+			}
 			if sampler.CanSkip() {
 				kvReader.Skip()                // skip key (no decompression of bytes)
 				keyOffset, _ = kvReader.Skip() // skip value, advance to next key
@@ -227,7 +233,7 @@ func CheckKvi(ctx context.Context, kviPath string, kvPath string, kvCompression 
 			nextOffset, _ := kvReader.Skip()      // skip value
 			select {
 			case <-ctx.Done():
-				return nil
+				return ctx.Err()
 			case workCh <- kviWorkItem{key: bytes.Clone(keyBuf), offset: keyOffset}:
 			}
 			keyOffset = nextOffset

--- a/db/services/snapshot_progress.go
+++ b/db/services/snapshot_progress.go
@@ -1,0 +1,33 @@
+// Copyright 2024 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package services
+
+import (
+	"context"
+
+	"github.com/erigontech/erigon/db/kv"
+)
+
+// MaxCollatableTxNum returns the upper bound txNum that state collation may
+// target without running ahead of block snapshot files. Callers of
+// Aggregator.BuildFiles / BuildFilesInBackground must cap their target txNum
+// by this value — otherwise state files may advance past block files, an
+// unrecoverable state that requires manual `erigon seg rm-state --latest` to
+// release.
+func MaxCollatableTxNum(ctx context.Context, tx kv.Tx, blockReader FullBlockReader) (uint64, error) {
+	return blockReader.TxnumReader().Max(ctx, tx, blockReader.FrozenBlocks())
+}

--- a/db/snapshotsync/freezeblocks/block_reader.go
+++ b/db/snapshotsync/freezeblocks/block_reader.go
@@ -1320,13 +1320,18 @@ func (r *BlockReader) IterateFrozenBodies(f func(blockNum, baseTxNum, txCount ui
 	return nil
 }
 
-func (r *BlockReader) IntegrityTxnID(failFast bool) error {
+func (r *BlockReader) IntegrityTxnID(ctx context.Context, failFast bool) error {
 	defer log.Info("[integrity] BlocksTxnID done")
 	view := r.sn.View()
 	defer view.Close()
 
 	var expectedFirstTxnID uint64
-	for _, snb := range view.Bodies() {
+	for i, snb := range view.Bodies() {
+		if i%1000 == 0 {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+		}
 		if snb.Src() == nil {
 			continue
 		}

--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -38,6 +38,7 @@ import (
 	"github.com/erigontech/erigon/db/rawdb"
 	"github.com/erigontech/erigon/db/rawdb/rawdbhelpers"
 	"github.com/erigontech/erigon/db/rawdb/rawtemporaldb"
+	"github.com/erigontech/erigon/db/services"
 	dbstate "github.com/erigontech/erigon/db/state"
 	"github.com/erigontech/erigon/db/state/execctx"
 	"github.com/erigontech/erigon/execution/commitment"
@@ -141,7 +142,11 @@ func ExecV3(ctx context.Context,
 	}
 
 	if execStage.SyncMode() == stages.ModeApplyingBlocks {
-		agg.BuildFilesInBackground(initialTxNum)
+		maxCollatable, err := services.MaxCollatableTxNum(ctx, applyTx, cfg.blockReader)
+		if err != nil {
+			return err
+		}
+		agg.BuildFilesInBackground(min(initialTxNum, maxCollatable))
 	}
 
 	var (


### PR DESCRIPTION
Cherry-picks the integrity-area chain from `main` onto `performance`, in order:

1. #20435 — `integrity: restore StateProgress check`
2. #20680 — `integrity, stagedsync: cap state collation at block snapshots progress`
3. #20714 — `add time budget for integrity checks`
4. #20835 — `cmd/utils/app: skip commitment history integrity checks when disabled`

#20714 is the structural refactor of `doIntegrity` (`errgroup.Go(switch{...})` → `runCheck := func{}` + budget loop). Conflicted with performance-only Bloatnet customizations on the same function (#20806, #20810, #20813); resolved by adopting #20714's shape and re-applying the Bloatnet handling for `CommitmentKvDeref`, `CommitmentHistVal`, and `StateRootVerifyByHistory`. `failFast` arg on `CheckCommitmentHistAtBlkRange` preserved (matches performance's signature).

Submodule pointer for `execution/tests/execution-spec-tests` left unchanged.

`make erigon` + `make lint` clean.