### PR TITLE
cp: skip commitment history integrity checks when disabled

### DIFF
--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -1269,6 +1269,15 @@ func doIntegrity(cliCtx *cli.Context) error {
 	blockReader, _ := blockRetire.IO()
 	heimdallStore, _ := blockRetire.BorStore()
 
+	var commitmentHistoryEnabled bool
+	if err := chainDB.View(ctx, func(tx kv.Tx) error {
+		var err error
+		commitmentHistoryEnabled, _, err = rawdb.ReadDBCommitmentHistoryEnabled(tx)
+		return err
+	}); err != nil {
+		return fmt.Errorf("failed to read CommitmentHistory config: %w", err)
+	}
+
 	runCheck := func(ctx context.Context, chk integrity.Check) error {
 		switch chk {
 		case integrity.BlocksTxnID:
@@ -1317,10 +1326,18 @@ func doIntegrity(cliCtx *cli.Context) error {
 		case integrity.CommitmentKvDeref:
 			return integrity.CheckCommitmentKvDeref(ctx, db, cache, failFast, logger)
 		case integrity.CommitmentHistVal:
+			if !commitmentHistoryEnabled {
+				logger.Info("[integrity] CommitmentHistVal skipped because commitment history is not enabled on this datadir")
+				return nil
+			}
 			scCopy := sc
 			scCopy.SampleRatio /= 100 // it's very slow check
 			return integrity.CheckCommitmentHistVal(ctx, scCopy, db, blockReader, failFast, logger)
 		case integrity.StateRootVerifyByHistory:
+			if !commitmentHistoryEnabled {
+				logger.Info("[integrity] StateRootVerifyByHistory skipped because commitment history is not enabled on this datadir")
+				return nil
+			}
 			to, err := stateProgress(ctx, db, blockReader.TxnumReader())
 			if err != nil {
 				return err


### PR DESCRIPTION
Cherry-pick of #20835 to `release/3.4`.