### PR TITLE
rpc: clamp zero batch concurrency

### DIFF
--- a/rpc/server.go
+++ b/rpc/server.go
@@ -33,6 +33,8 @@ import (
 
 const MetadataApi = "rpc"
 
+const minBatchConcurrency uint = 1
+
 // CodecOption specifies which type of messages a codec supports.
 //
 // Deprecated: this option is no longer honored by Server.
@@ -65,6 +67,9 @@ type Server struct {
 
 // NewServer creates a new server instance with no registered handlers.
 func NewServer(batchConcurrency uint, traceRequests, debugSingleRequest, disableStreaming bool, logger log.Logger, rpcSlowLogThreshold time.Duration) *Server {
+	if batchConcurrency == 0 {
+		batchConcurrency = minBatchConcurrency
+	}
 	server := &Server{services: serviceRegistry{logger: logger}, idgen: randomIDGenerator(), codecs: mapset.NewSet[ServerCodec](), batchConcurrency: batchConcurrency,
 		disableStreaming: disableStreaming, traceRequests: traceRequests, debugSingleRequest: debugSingleRequest, logger: logger, rpcSlowLogThreshold: rpcSlowLogThreshold}
 	server.run.Store(true)

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -60,6 +60,13 @@ func TestServerRegisterName(t *testing.T) {
 	}
 }
 
+func TestNewServerClampsZeroBatchConcurrency(t *testing.T) {
+	server := NewServer(0, false /* traceRequests */, false /* debugSingleRequests */, true, log.New(), 100)
+	if server.batchConcurrency != minBatchConcurrency {
+		t.Fatalf("expected batch concurrency %d, got %d", minBatchConcurrency, server.batchConcurrency)
+	}
+}
+
 func TestServer(t *testing.T) {
 	logger := log.New()
 	files, err := dir.ReadDir("testdata")


### PR DESCRIPTION
## Summary

- Clamp RPC batch concurrency to at least one worker when constructing the server.
- Prevent `rpc.batch.concurrency=0` from creating an unbuffered admission channel that blocks batch processing before any request goroutine can start.
- Add a direct server constructor regression test for the zero-value case.