### PR TITLE
ci: temporarily skip debug_traceBlockByNumber/test_{33,34} after prestateTracer fix

### DIFF
--- a/.github/workflows/scripts/run_rpc_tests_ethereum.sh
+++ b/.github/workflows/scripts/run_rpc_tests_ethereum.sh
@@ -13,6 +13,11 @@ DISABLED_TEST_LIST=(
   net_listening/test_1.json
   # Temporary disable required block 24298763
   debug_traceBlockByNumber/test_51.json
+  # Stale fixtures after #20775 (cherry-picked via #20830) fixed prestateTracer
+  # diff mode to include deleted accounts. rpc-tests fix at erigontech/rpc-tests#554;
+  # re-enable once a new tag (v2.8.2+) is cut and the version is bumped here.
+  debug_traceBlockByNumber/test_33.tar
+  debug_traceBlockByNumber/test_34.tar
   # to investigate
   engine_exchangeCapabilities/test_1.json
   engine_exchangeTransitionConfigurationV1/test_01.json


### PR DESCRIPTION
## Why

#20775 (cherry-picked into main via #20830) fixed \`prestateTracer\` diff mode to include deleted accounts in the \`post\` state — they were silently missing before, which was the actual bug. Two mainnet rpc-tests fixtures hit blocks where this matters:

- \`debug_traceBlockByNumber/test_33.tar\` — block \`0x1048428\`, deleted account \`0xde587bd175be0875fadf15ea5c7bc488b7dd6484\`
- \`debug_traceBlockByNumber/test_34.tar\` — deleted account \`0xf8b9495cc154569f6cc3395d47b03b95a86202d9\`

Their expected JSON in rpc-tests \`v2.8.1\` doesn't include those entries, so \`mainnet-rpc-integ-tests\` is red on every PR — including \`main\` itself since the cherry-pick landed.

## What

Two-line addition to the \`DISABLED_TEST_LIST\` in \`run_rpc_tests_ethereum.sh\`. No production-code change.

## Follow-up

Proper fix in flight: [erigontech/rpc-tests#554](https://github.com/erigontech/rpc-tests/pull/554) refreshes the expected JSON for both blocks. Once that merges and a new tag (\`v2.8.2\`+) is cut, this workaround should be reverted and the version bumped in \`run_rpc_tests_ethereum.sh\` (and the matching cache keys in the qa workflows).

## Test plan

- [x] CI run on this PR shows \`mainnet-rpc-integ-tests\` green again.