### PR TITLE
[r3.4] exec: fix partial block receipt reconstruction (#20452)

### DIFF
--- a/execution/receipts/derive.go
+++ b/execution/receipts/derive.go
@@ -1,0 +1,142 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+// Package receipts provides shared receipt derivation by replaying transactions.
+// Used by both the RPC layer (rpc/jsonrpc/receipts) and the execution pipeline
+// (execution/stagedsync) to avoid duplicating transaction replay logic.
+package receipts
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/protocol"
+	"github.com/erigontech/erigon/execution/protocol/rules"
+	"github.com/erigontech/erigon/execution/state"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/execution/types/accounts"
+	"github.com/erigontech/erigon/execution/vm"
+)
+
+// GetHeaderFunc returns a header by hash+number. Used for BLOCKHASH opcode.
+type GetHeaderFunc = func(hash common.Hash, number uint64) (*types.Header, error)
+
+// DeriveForRange replays transactions fromIdx..toIdx-1 (0-based within the block)
+// against the provided IntraBlockState and returns receipts for each.
+//
+// The caller is responsible for:
+//   - Creating the IntraBlockState with the correct state reader (history or live)
+//   - Providing a GasPool with the block's gas limit
+//   - Providing the GetHeader function for BLOCKHASH resolution
+//
+// No caching — callers wrap this with their own caching layer.
+func DeriveForRange(
+	ctx context.Context,
+	cfg *chain.Config,
+	engine rules.EngineReader,
+	header *types.Header,
+	txns types.Transactions,
+	fromIdx int,
+	toIdx int,
+	ibs *state.IntraBlockState,
+	gp *protocol.GasPool,
+	getHeader GetHeaderFunc,
+) (types.Receipts, error) {
+	if fromIdx < 0 {
+		fromIdx = 0
+	}
+	if toIdx > len(txns) {
+		toIdx = len(txns)
+	}
+	if fromIdx >= toIdx {
+		return nil, nil
+	}
+
+	blockNum := header.Number.Uint64()
+	gasUsed := new(protocol.GasUsed)
+	noopWriter := state.NewNoopWriter()
+	hashFn := protocol.GetHashFn(header, getHeader)
+	vmCfg := vm.Config{}
+
+	// If starting mid-block, we need to replay 0..fromIdx-1 first to get
+	// cumulative gas and state to the right point. We discard those receipts.
+	for i := 0; i < fromIdx; i++ {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+		ibs.SetTxContext(blockNum, i)
+		evm := protocol.CreateEVM(cfg, hashFn, engine, accounts.NilAddress, ibs, header, vmCfg)
+		_, err := protocol.ApplyTransactionWithEVM(cfg, engine, gp, ibs, noopWriter, header, txns[i], gasUsed, vmCfg, evm)
+		if err != nil {
+			return nil, fmt.Errorf("receipts.DeriveForRange: replay tx %d (warmup): %w", i, err)
+		}
+	}
+
+	// Now execute the target range and collect receipts.
+	receipts := make(types.Receipts, 0, toIdx-fromIdx)
+	for i := fromIdx; i < toIdx; i++ {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+		ibs.SetTxContext(blockNum, i)
+		evm := protocol.CreateEVM(cfg, hashFn, engine, accounts.NilAddress, ibs, header, vmCfg)
+		receipt, err := protocol.ApplyTransactionWithEVM(cfg, engine, gp, ibs, noopWriter, header, txns[i], gasUsed, vmCfg, evm)
+		if err != nil {
+			return nil, fmt.Errorf("receipts.DeriveForRange: replay tx %d: %w", i, err)
+		}
+		receipts = append(receipts, receipt)
+	}
+
+	return receipts, nil
+}
+
+// DeriveBlockReceipts replays all transactions in a block and returns their receipts.
+// Convenience wrapper around DeriveForRange(ctx, cfg, engine, header, txns, 0, len(txns), ...).
+func DeriveBlockReceipts(
+	ctx context.Context,
+	cfg *chain.Config,
+	engine rules.EngineReader,
+	header *types.Header,
+	txns types.Transactions,
+	ibs *state.IntraBlockState,
+	gp *protocol.GasPool,
+	getHeader GetHeaderFunc,
+) (types.Receipts, error) {
+	return DeriveForRange(ctx, cfg, engine, header, txns, 0, len(txns), ibs, gp, getHeader)
+}
+
+// DerivePriorReceipts replays transactions 0..startTxIndex-1 and returns their
+// receipts. Used when execution resumes mid-block from a snapshot boundary and
+// Finalize needs the full receipt set for requests hash computation.
+func DerivePriorReceipts(
+	ctx context.Context,
+	cfg *chain.Config,
+	engine rules.EngineReader,
+	header *types.Header,
+	txns types.Transactions,
+	startTxIndex int,
+	ibs *state.IntraBlockState,
+	gp *protocol.GasPool,
+	getHeader GetHeaderFunc,
+) (types.Receipts, error) {
+	return DeriveForRange(ctx, cfg, engine, header, txns, 0, startTxIndex, ibs, gp, getHeader)
+}

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -29,6 +29,7 @@ import (
 	"github.com/erigontech/erigon/execution/exec"
 	"github.com/erigontech/erigon/execution/protocol"
 	"github.com/erigontech/erigon/execution/protocol/rules"
+	"github.com/erigontech/erigon/execution/receipts"
 	"github.com/erigontech/erigon/execution/state"
 	"github.com/erigontech/erigon/execution/tests/chaos_monkey"
 	"github.com/erigontech/erigon/execution/tracing"
@@ -610,14 +611,23 @@ func (pe *parallelExecutor) execLoop(ctx context.Context) (err error) {
 							reader = state.NewReaderV3(pe.rs.Domains().AsGetter(applyTx))
 						}
 						ibs := state.New(state.NewBufferedReader(pe.rs, reader))
+						defer ibs.Release(true)
 						ibs.SetVersion(finalVersion.Incarnation)
 						localVersionMap := state.NewVersionMap(nil)
 						ibs.SetVersionMap(localVersionMap)
 						ibs.SetTxContext(finalVersion.BlockNum, finalVersion.TxIndex)
 
-						txTask, ok := result.Task.(*taskVersion).Task.(*exec.TxTask)
+						var txTask *exec.TxTask
+						switch t := result.Task.(type) {
+						case *taskVersion:
+							if tt, ok := t.Task.(*exec.TxTask); ok {
+								txTask = tt
+							}
+						case *exec.TxTask:
+							txTask = t
+						}
 
-						if !ok {
+						if txTask == nil {
 							return state.StateUpdates{}, nil
 						}
 
@@ -631,15 +641,39 @@ func (pe *parallelExecutor) execLoop(ctx context.Context) (err error) {
 						}
 
 						chainReader := consensuschain.NewReader(pe.cfg.chainConfig, applyTx, pe.cfg.blockReader, pe.logger)
+
+						// For partial blocks, reconstruct prior receipts. See #20452.
+						finalizeReceipts := blockReceipts
+						if blockResult.isPartial && len(txTask.Txs) > 0 {
+							firstTxIndex := blockExecutor.tasks[0].Version().TxIndex
+							if firstTxIndex > 0 {
+								blockStartTxNum := txTask.TxNum - uint64(txTask.TxIndex)
+								priorReader := state.NewHistoryReaderV3(applyTx, blockStartTxNum)
+								priorIbs := state.New(priorReader)
+								defer priorIbs.Release(true)
+								priorGp := protocol.NewGasPool(txTask.Header.GasLimit, pe.cfg.chainConfig.GetMaxBlobGasPerBlock(txTask.Header.Time))
+								getHeader := func(hash common.Hash, number uint64) (*types.Header, error) {
+									return pe.cfg.blockReader.Header(ctx, applyTx, hash, number)
+								}
+								priorReceipts, priorErr := receipts.DerivePriorReceipts(ctx, pe.cfg.chainConfig, pe.cfg.engine, txTask.Header, txTask.Txs, firstTxIndex, priorIbs, priorGp, getHeader)
+								if priorErr != nil {
+									pe.logger.Warn("[parallel] failed to reconstruct prior receipts for partial block",
+										"block", blockResult.BlockNum, "startTxIndex", firstTxIndex, "err", priorErr)
+								} else {
+									finalizeReceipts = append(priorReceipts, blockReceipts...)
+								}
+							}
+						}
+
 						if pe.isBlockProduction {
 							_, _, err =
 								pe.cfg.engine.FinalizeAndAssemble(
-									pe.cfg.chainConfig, types.CopyHeader(txTask.Header), ibs, txTask.Txs, txTask.Uncles, blockReceipts,
+									pe.cfg.chainConfig, types.CopyHeader(txTask.Header), ibs, txTask.Txs, txTask.Uncles, finalizeReceipts,
 									txTask.Withdrawals, chainReader, syscall, nil, pe.logger)
 						} else {
 							_, err =
 								pe.cfg.engine.Finalize(
-									pe.cfg.chainConfig, types.CopyHeader(txTask.Header), ibs, txTask.Uncles, blockReceipts,
+									pe.cfg.chainConfig, types.CopyHeader(txTask.Header), ibs, txTask.Uncles, finalizeReceipts,
 									txTask.Withdrawals, chainReader, syscall, false, pe.logger)
 						}
 

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -20,6 +20,7 @@ import (
 	"github.com/erigontech/erigon/execution/exec"
 	"github.com/erigontech/erigon/execution/protocol"
 	"github.com/erigontech/erigon/execution/protocol/rules"
+	"github.com/erigontech/erigon/execution/receipts"
 	"github.com/erigontech/erigon/execution/state"
 	"github.com/erigontech/erigon/execution/tests/chaos_monkey"
 	"github.com/erigontech/erigon/execution/types"
@@ -378,14 +379,40 @@ func (se *serialExecutor) executeBlock(ctx context.Context, tasks []exec.Task, i
 
 				chainReader := consensuschain.NewReader(se.cfg.chainConfig, se.applyTx, se.cfg.blockReader, se.logger)
 
+				// For partial blocks (resuming from snapshot boundary), reconstruct
+				// prior receipts so Finalize receives the full receipt set for requests
+				// hash computation (deposit extraction from logs). See #20452.
+				finalizeReceipts := blockReceipts
+				if startTxIndex > 0 && len(txTask.Txs) > 0 {
+					// Use the first executed user tx task (not the block-end task) to
+					// derive blockStartTxNum, since the block-end task's TxIndex is
+					// len(txs) which would compute the wrong range.
+					firstTask := tasks[0].(*exec.TxTask)
+					blockStartTxNum := firstTask.TxNum - uint64(firstTask.TxIndex)
+					reader := state.NewHistoryReaderV3(se.applyTx, blockStartTxNum)
+					priorIbs := state.New(reader)
+					defer priorIbs.Release(true)
+					priorGp := protocol.NewGasPool(txTask.Header.GasLimit, se.cfg.chainConfig.GetMaxBlobGasPerBlock(txTask.Header.Time))
+					getHeader := func(hash common.Hash, number uint64) (*types.Header, error) {
+						return se.cfg.blockReader.Header(ctx, se.applyTx, hash, number)
+					}
+					priorReceipts, priorErr := receipts.DerivePriorReceipts(ctx, se.cfg.chainConfig, se.cfg.engine, txTask.Header, txTask.Txs, startTxIndex, priorIbs, priorGp, getHeader)
+					if priorErr != nil {
+						se.logger.Warn(fmt.Sprintf("[%s] failed to reconstruct prior receipts for partial block", se.logPrefix),
+							"block", txTask.BlockNumber(), "startTxIndex", startTxIndex, "err", priorErr)
+					} else {
+						finalizeReceipts = append(priorReceipts, blockReceipts...)
+					}
+				}
+
 				if se.isBlockProduction {
 					_, _, err = se.cfg.engine.FinalizeAndAssemble(
 						se.cfg.chainConfig, types.CopyHeader(txTask.Header), ibs, txTask.Txs, txTask.Uncles,
-						blockReceipts, txTask.Withdrawals, chainReader, syscall, nil, se.logger)
+						finalizeReceipts, txTask.Withdrawals, chainReader, syscall, nil, se.logger)
 				} else {
 					_, err = se.cfg.engine.Finalize(
 						se.cfg.chainConfig, types.CopyHeader(txTask.Header), ibs, txTask.Uncles,
-						blockReceipts, txTask.Withdrawals, chainReader, syscall, false, se.logger)
+						finalizeReceipts, txTask.Withdrawals, chainReader, syscall, false, se.logger)
 				}
 
 				if err != nil {


### PR DESCRIPTION
Cherry-pick of #20467 to release/3.4.

When execution resumes from a snapshot boundary mid-block (`initialBlockTxOffset > 0`), the receipts passed to `engine.Finalize()` only contained receipts from the re-executed portion. This causes Pectra requests hash validation to fail because deposit request extraction needs ALL receipt logs.

Reproduces as: `invalid requests root hash in header` at block 24966723 on mainnet re-sync.