### PR TITLE
enforce block-snapshots cap inside aggregator collation

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -980,6 +980,9 @@ func allSnapshots(ctx context.Context, db kv.RoDB, logger log.Logger) (*freezebl
 		_aggSingleton = dbstate.New(dirs).Logger(logger).WithErigonDBSettings(erigonDBSettings).MustOpen(ctx, db)
 
 		_aggSingleton.SetProduceMod(snapCfg.ProduceE3)
+		_aggSingleton.SetMaxCollatableTxNumFn(func(ctx context.Context, tx kv.Tx) (uint64, error) {
+			return services.MaxCollatableTxNum(ctx, tx, blockReader)
+		})
 
 		g := &errgroup.Group{}
 		g.Go(func() error {

--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -980,9 +980,7 @@ func allSnapshots(ctx context.Context, db kv.RoDB, logger log.Logger) (*freezebl
 		_aggSingleton = dbstate.New(dirs).Logger(logger).WithErigonDBSettings(erigonDBSettings).MustOpen(ctx, db)
 
 		_aggSingleton.SetProduceMod(snapCfg.ProduceE3)
-		_aggSingleton.SetMaxCollatableTxNumFn(func(ctx context.Context, tx kv.Tx) (uint64, error) {
-			return services.MaxCollatableTxNum(ctx, tx, blockReader)
-		})
+		_aggSingleton.SetFrozenBlocksProvider(blockReader)
 
 		g := &errgroup.Group{}
 		g.Go(func() error {

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -2907,6 +2907,11 @@ func doRetireCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 	blockSnapBuildSema := semaphore.NewWeighted(int64(runtime.NumCPU()))
 	agg.SetSnapshotBuildSema(blockSnapBuildSema)
 
+	blockReader, _ := br.IO()
+	agg.SetMaxCollatableTxNumFn(func(ctx context.Context, tx kv.Tx) (uint64, error) {
+		return services.MaxCollatableTxNum(ctx, tx, blockReader)
+	})
+
 	agg.PresetOfflineMerge()
 	agg.PeriodicalyPrintProcessSet(ctx)
 
@@ -2926,8 +2931,6 @@ func doRetireCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 	}); err != nil {
 		return err
 	}
-
-	blockReader, _ := br.IO()
 
 	blocksInSnapshots := blockReader.FrozenBlocks()
 	if chainConfig.Bor != nil {
@@ -2977,15 +2980,7 @@ func doRetireCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 	if err := db.Update(ctx, func(tx kv.RwTx) error {
 		execProgress, _ := stages.GetStageProgress(tx, stages.Execution)
 		lastTxNum, err = txNumsReader.Max(ctx, tx, execProgress)
-		if err != nil {
-			return err
-		}
-		maxCollatable, err := services.MaxCollatableTxNum(ctx, tx, blockReader)
-		if err != nil {
-			return err
-		}
-		lastTxNum = min(lastTxNum, maxCollatable)
-		return nil
+		return err
 	}); err != nil {
 		return err
 	}

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -67,7 +67,6 @@ import (
 	"github.com/erigontech/erigon/db/rawdb/blockio"
 	"github.com/erigontech/erigon/db/recsplit"
 	"github.com/erigontech/erigon/db/seg"
-	"github.com/erigontech/erigon/db/services"
 	"github.com/erigontech/erigon/db/snapshotsync"
 	"github.com/erigontech/erigon/db/snapshotsync/freezeblocks"
 	"github.com/erigontech/erigon/db/snaptype"
@@ -2908,9 +2907,7 @@ func doRetireCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 	agg.SetSnapshotBuildSema(blockSnapBuildSema)
 
 	blockReader, _ := br.IO()
-	agg.SetMaxCollatableTxNumFn(func(ctx context.Context, tx kv.Tx) (uint64, error) {
-		return services.MaxCollatableTxNum(ctx, tx, blockReader)
-	})
+	agg.SetFrozenBlocksProvider(blockReader)
 
 	agg.PresetOfflineMerge()
 	agg.PeriodicalyPrintProcessSet(ctx)

--- a/db/services/snapshot_progress.go
+++ b/db/services/snapshot_progress.go
@@ -22,11 +22,8 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 )
 
-// MaxCollatableTxNum returns the upper bound txNum that state collation may
-// target without running ahead of block snapshot files. Used by the
-// integrity check at db/integrity/commitment_progress_check.go to detect
-// state-ahead-of-blocks drift. The Aggregator enforces the same cap
-// internally via Aggregator.SetFrozenBlocksProvider.
+// MaxCollatableTxNum: upper bound txNum that state collation may target.
+// Aggregator enforces this internally via SetFrozenBlocksProvider.
 func MaxCollatableTxNum(ctx context.Context, tx kv.Tx, blockReader FullBlockReader) (uint64, error) {
 	return blockReader.TxnumReader().Max(ctx, tx, blockReader.FrozenBlocks())
 }

--- a/db/services/snapshot_progress.go
+++ b/db/services/snapshot_progress.go
@@ -23,9 +23,9 @@ import (
 )
 
 // MaxCollatableTxNum returns the upper bound txNum that state collation may
-// target without running ahead of block snapshot files. Callers of
-// Aggregator.BuildFiles / BuildFilesInBackground must cap their target txNum
-// by this value — otherwise state files may advance past block files, an
+// target without running ahead of block snapshot files. Production wiring
+// installs this as Aggregator.SetMaxCollatableTxNumFn so the aggregator caps its
+// own collation loop — otherwise state files may advance past block files, an
 // unrecoverable state that requires manual `erigon seg rm-state --latest` to
 // release.
 func MaxCollatableTxNum(ctx context.Context, tx kv.Tx, blockReader FullBlockReader) (uint64, error) {

--- a/db/services/snapshot_progress.go
+++ b/db/services/snapshot_progress.go
@@ -23,11 +23,10 @@ import (
 )
 
 // MaxCollatableTxNum returns the upper bound txNum that state collation may
-// target without running ahead of block snapshot files. Production wiring
-// installs this as Aggregator.SetMaxCollatableTxNumFn so the aggregator caps its
-// own collation loop — otherwise state files may advance past block files, an
-// unrecoverable state that requires manual `erigon seg rm-state --latest` to
-// release.
+// target without running ahead of block snapshot files. Used by the
+// integrity check at db/integrity/commitment_progress_check.go to detect
+// state-ahead-of-blocks drift. The Aggregator enforces the same cap
+// internally via Aggregator.SetFrozenBlocksProvider.
 func MaxCollatableTxNum(ctx context.Context, tx kv.Tx, blockReader FullBlockReader) (uint64, error) {
 	return blockReader.TxnumReader().Max(ctx, tx, blockReader.FrozenBlocks())
 }

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -105,6 +105,13 @@ type Aggregator struct {
 	configured   bool
 	savedSalt    *uint32
 	disableFsync bool
+
+	// maxCollatableTxNumFn, if set, returns the upper-bound txNum that state
+	// collation may target — typically the txNum at the end of the last block
+	// snapshot. The buildFilesInBackground loop consults it before each step
+	// and stops if filing the next step would advance state files past block
+	// snapshots (an unrecoverable state). nil = no cap (test default).
+	maxCollatableTxNumFn func(ctx context.Context, tx kv.Tx) (uint64, error)
 }
 
 func newAggregator(ctx context.Context, dirs datadir.Dirs, reorgBlockDepth uint64, db kv.RoDB, logger log.Logger) (*Aggregator, error) {
@@ -1805,6 +1812,15 @@ func (a *Aggregator) SetSnapshotBuildSema(semaphore *semaphore.Weighted) {
 func (a *Aggregator) SetProduceMod(produce bool) {
 	a.produce = produce
 }
+
+// SetMaxCollatableTxNumFn installs a callback used by buildFilesInBackground to
+// cap state collation at the block-snapshots boundary. Production wiring sets
+// this to services.MaxCollatableTxNum(blockReader). Without it, the loop
+// builds every step present in the DB and may advance state files past block
+// files — an unrecoverable state requiring `erigon seg rm-state --latest`.
+func (a *Aggregator) SetMaxCollatableTxNumFn(fn func(ctx context.Context, tx kv.Tx) (uint64, error)) {
+	a.maxCollatableTxNumFn = fn
+}
 func (a *Aggregator) BuildFilesInBackground(txNum uint64) chan struct{} {
 	return a.buildFilesInBackground(txNum, true)
 }
@@ -1872,7 +1888,17 @@ func (a *Aggregator) buildFilesInBackground(txNum uint64, doMerge bool) chan str
 			// the DB before a CommitCycle flushes step S's writes, producing a
 			// file that misses entries. Pruning then removes those entries from
 			// the DB, and the values are lost. See #20169.
+			//
+			// Also enforce the block-snapshots cap (maxCollatableTxNumFn): never
+			// collate a step whose end-txNum would exceed the frozen-block
+			// boundary, otherwise state files race past block files. See
+			// #20701. Read with a plain kv.Tx since TxnumReader.Max doesn't
+			// need temporal access — and a.db is the raw chaindb (production
+			// passes the raw mdbx db to Aggregator before wrapping it with
+			// temporal.New).
 			var committedTxNum uint64
+			var capTxNum uint64
+			capSet := a.maxCollatableTxNumFn != nil
 			if temporalDB, ok := a.db.(kv.TemporalRoDB); ok {
 				if err := temporalDB.ViewTemporal(a.ctx, func(tx kv.TemporalTx) error {
 					v, _, err := tx.GetLatest(kv.CommitmentDomain, commitmentdb.KeyCommitmentState)
@@ -1888,8 +1914,26 @@ func (a *Aggregator) buildFilesInBackground(txNum uint64, doMerge bool) chan str
 					break
 				}
 			}
+			if capSet {
+				if err := a.db.View(a.ctx, func(tx kv.Tx) error {
+					var err error
+					capTxNum, err = a.maxCollatableTxNumFn(a.ctx, tx)
+					return err
+				}); err != nil {
+					a.logger.Warn("[snapshots] buildFilesInBackground: read max collatable txNum", "err", err)
+					break
+				}
+			}
 			if !stepFullyCommitted(committedTxNum, step, a.StepSize()) {
 				break // step not fully committed yet — wait for execution to catch up
+			}
+			if capSet && (uint64(step+1)*a.StepSize()) > capTxNum {
+				a.logger.Info("[snapshots] holding state collation at block snapshot boundary",
+					"step", step,
+					"stepEndTxNum", fmt.Sprintf("%d (step %d)", uint64(step+1)*a.StepSize(), uint64(step+1)),
+					"blockSnapshotsTxNum", fmt.Sprintf("%d (step %d)", capTxNum, capTxNum/a.StepSize()),
+					"lastInDB", lastInDB)
+				break
 			}
 			if err := a.buildFiles(a.ctx, step); err != nil {
 				if errors.Is(err, errStepNotReady) {

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -106,12 +106,17 @@ type Aggregator struct {
 	savedSalt    *uint32
 	disableFsync bool
 
-	// maxCollatableTxNumFn, if set, returns the upper-bound txNum that state
-	// collation may target — typically the txNum at the end of the last block
-	// snapshot. The buildFilesInBackground loop consults it before each step
-	// and stops if filing the next step would advance state files past block
-	// snapshots (an unrecoverable state). nil = no cap (test default).
-	maxCollatableTxNumFn func(ctx context.Context, tx kv.Tx) (uint64, error)
+	// frozenBlocks, if set, supplies the count of blocks already in
+	// block-snapshot files. readyForCollation reads it to compute the
+	// upper-bound txNum that state collation may target — state files past
+	// frozen-block files are an unrecoverable state. nil = no cap (test default).
+	frozenBlocks FrozenBlocksProvider
+}
+
+// FrozenBlocksProvider returns the count of blocks already in block-snapshot
+// files. Any *freezeblocks.BlockReader satisfies this interface.
+type FrozenBlocksProvider interface {
+	FrozenBlocks() uint64
 }
 
 func newAggregator(ctx context.Context, dirs datadir.Dirs, reorgBlockDepth uint64, db kv.RoDB, logger log.Logger) (*Aggregator, error) {
@@ -941,6 +946,30 @@ func (a *Aggregator) buildFiles(ctx context.Context, step kv.Step) error {
 func (a *Aggregator) readyForCollation(ctx context.Context, step kv.Step) (lastBlockInStep, lastBlockInDB, lastTxInDB uint64, ok bool, err error) {
 	if a.reorgBlockDepth == 0 {
 		return 0, 0, 0, true, nil
+	}
+
+	// Block-snapshots cap: refuse to mark a step ready if collating it would
+	// advance state files past frozen-block files. Without this, both
+	// buildFilesInBackground (loops to lastInDB) and BuildFiles2 (loops to
+	// caller-supplied toStep) can race state files past blocks — an
+	// unrecoverable state requiring `erigon seg rm-state --latest`. Production
+	// wiring installs the provider; tests leave it nil (no cap). See #20701, #20852.
+	if a.frozenBlocks != nil {
+		var capTxNum uint64
+		if err = a.db.View(ctx, func(tx kv.Tx) error {
+			var err error
+			capTxNum, err = rawdbv3.TxNums.Max(ctx, tx, a.frozenBlocks.FrozenBlocks())
+			return err
+		}); err != nil {
+			return 0, 0, 0, false, fmt.Errorf("read max collatable txNum: %w", err)
+		}
+		if uint64(step+1)*a.StepSize() > capTxNum {
+			a.logger.Info("[snapshots] holding state collation at block snapshot boundary",
+				"step", step,
+				"stepEndTxNum", fmt.Sprintf("%d (step %d)", uint64(step+1)*a.StepSize(), uint64(step+1)),
+				"blockSnapshotsTxNum", fmt.Sprintf("%d (step %d)", capTxNum, capTxNum/a.StepSize()))
+			return 0, 0, 0, false, nil
+		}
 	}
 	err = a.db.View(ctx, func(tx kv.Tx) error {
 		lastBlockInStep, ok, err = rawdbv3.TxNums.FindBlockNum(ctx, tx, lastTxNumOfStep(step, a.stepSize))
@@ -1813,13 +1842,14 @@ func (a *Aggregator) SetProduceMod(produce bool) {
 	a.produce = produce
 }
 
-// SetMaxCollatableTxNumFn installs a callback used by buildFilesInBackground to
-// cap state collation at the block-snapshots boundary. Production wiring sets
-// this to services.MaxCollatableTxNum(blockReader). Without it, the loop
-// builds every step present in the DB and may advance state files past block
-// files — an unrecoverable state requiring `erigon seg rm-state --latest`.
-func (a *Aggregator) SetMaxCollatableTxNumFn(fn func(ctx context.Context, tx kv.Tx) (uint64, error)) {
-	a.maxCollatableTxNumFn = fn
+// SetFrozenBlocksProvider installs the source of truth for the frozen-block
+// count. readyForCollation uses it to derive the upper-bound txNum and refuses
+// to mark a step ready if collating it would advance state files past block
+// snapshots. Without this, the collation loop may file steps past the
+// block-snapshots boundary — an unrecoverable state requiring `erigon seg
+// rm-state --latest`. Production wiring passes the live *freezeblocks.BlockReader.
+func (a *Aggregator) SetFrozenBlocksProvider(p FrozenBlocksProvider) {
+	a.frozenBlocks = p
 }
 func (a *Aggregator) BuildFilesInBackground(txNum uint64) chan struct{} {
 	return a.buildFilesInBackground(txNum, true)
@@ -1888,17 +1918,7 @@ func (a *Aggregator) buildFilesInBackground(txNum uint64, doMerge bool) chan str
 			// the DB before a CommitCycle flushes step S's writes, producing a
 			// file that misses entries. Pruning then removes those entries from
 			// the DB, and the values are lost. See #20169.
-			//
-			// Also enforce the block-snapshots cap (maxCollatableTxNumFn): never
-			// collate a step whose end-txNum would exceed the frozen-block
-			// boundary, otherwise state files race past block files. See
-			// #20701. Read with a plain kv.Tx since TxnumReader.Max doesn't
-			// need temporal access — and a.db is the raw chaindb (production
-			// passes the raw mdbx db to Aggregator before wrapping it with
-			// temporal.New).
 			var committedTxNum uint64
-			var capTxNum uint64
-			capSet := a.maxCollatableTxNumFn != nil
 			if temporalDB, ok := a.db.(kv.TemporalRoDB); ok {
 				if err := temporalDB.ViewTemporal(a.ctx, func(tx kv.TemporalTx) error {
 					v, _, err := tx.GetLatest(kv.CommitmentDomain, commitmentdb.KeyCommitmentState)
@@ -1914,27 +1934,10 @@ func (a *Aggregator) buildFilesInBackground(txNum uint64, doMerge bool) chan str
 					break
 				}
 			}
-			if capSet {
-				if err := a.db.View(a.ctx, func(tx kv.Tx) error {
-					var err error
-					capTxNum, err = a.maxCollatableTxNumFn(a.ctx, tx)
-					return err
-				}); err != nil {
-					a.logger.Warn("[snapshots] buildFilesInBackground: read max collatable txNum", "err", err)
-					break
-				}
-			}
 			if !stepFullyCommitted(committedTxNum, step, a.StepSize()) {
 				break // step not fully committed yet — wait for execution to catch up
 			}
-			if capSet && (uint64(step+1)*a.StepSize()) > capTxNum {
-				a.logger.Info("[snapshots] holding state collation at block snapshot boundary",
-					"step", step,
-					"stepEndTxNum", fmt.Sprintf("%d (step %d)", uint64(step+1)*a.StepSize(), uint64(step+1)),
-					"blockSnapshotsTxNum", fmt.Sprintf("%d (step %d)", capTxNum, capTxNum/a.StepSize()),
-					"lastInDB", lastInDB)
-				break
-			}
+			// Block-snapshots cap is enforced inside buildFiles (returns errStepNotReady).
 			if err := a.buildFiles(a.ctx, step); err != nil {
 				if errors.Is(err, errStepNotReady) {
 					break

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -106,15 +106,10 @@ type Aggregator struct {
 	savedSalt    *uint32
 	disableFsync bool
 
-	// frozenBlocks, if set, supplies the count of blocks already in
-	// block-snapshot files. readyForCollation reads it to compute the
-	// upper-bound txNum that state collation may target — state files past
-	// frozen-block files are an unrecoverable state. nil = no cap (test default).
+	// nil = no cap. See #20701.
 	frozenBlocks FrozenBlocksProvider
 }
 
-// FrozenBlocksProvider returns the count of blocks already in block-snapshot
-// files. Any *freezeblocks.BlockReader satisfies this interface.
 type FrozenBlocksProvider interface {
 	FrozenBlocks() uint64
 }
@@ -948,12 +943,6 @@ func (a *Aggregator) readyForCollation(ctx context.Context, step kv.Step) (lastB
 		return 0, 0, 0, true, nil
 	}
 
-	// Block-snapshots cap: refuse to mark a step ready if collating it would
-	// advance state files past frozen-block files. Without this, both
-	// buildFilesInBackground (loops to lastInDB) and BuildFiles2 (loops to
-	// caller-supplied toStep) can race state files past blocks — an
-	// unrecoverable state requiring `erigon seg rm-state --latest`. Production
-	// wiring installs the provider; tests leave it nil (no cap). See #20701, #20852.
 	if a.frozenBlocks != nil {
 		var capTxNum uint64
 		if err = a.db.View(ctx, func(tx kv.Tx) error {
@@ -1842,12 +1831,9 @@ func (a *Aggregator) SetProduceMod(produce bool) {
 	a.produce = produce
 }
 
-// SetFrozenBlocksProvider installs the source of truth for the frozen-block
-// count. readyForCollation uses it to derive the upper-bound txNum and refuses
-// to mark a step ready if collating it would advance state files past block
-// snapshots. Without this, the collation loop may file steps past the
-// block-snapshots boundary — an unrecoverable state requiring `erigon seg
-// rm-state --latest`. Production wiring passes the live *freezeblocks.BlockReader.
+// SetFrozenBlocksProvider caps state collation at the block-snapshots boundary.
+// Without it, state files may advance past block files — recovery requires
+// `erigon seg rm-state --latest`. See #20701.
 func (a *Aggregator) SetFrozenBlocksProvider(p FrozenBlocksProvider) {
 	a.frozenBlocks = p
 }
@@ -1937,7 +1923,6 @@ func (a *Aggregator) buildFilesInBackground(txNum uint64, doMerge bool) chan str
 			if !stepFullyCommitted(committedTxNum, step, a.StepSize()) {
 				break // step not fully committed yet — wait for execution to catch up
 			}
-			// Block-snapshots cap is enforced inside buildFiles (returns errStepNotReady).
 			if err := a.buildFiles(a.ctx, step); err != nil {
 				if errors.Is(err, errStepNotReady) {
 					break

--- a/db/test/aggregator_ext_test.go
+++ b/db/test/aggregator_ext_test.go
@@ -769,19 +769,12 @@ func TestAggregatorV3_BuildFiles_WithReorgDepth(t *testing.T) {
 	require.Equal(t, kv.Step(6), kv.Step(agg.EndTxNumMinimax()/agg.StepSize()))
 }
 
-// fakeFrozenBlocks is a stand-in FrozenBlocksProvider for tests. With
-// txnsPerBlock=1 in the rawdbv3.TxNums setup, fakeFrozenBlocks(N) yields
-// capTxNum=N (since TxNums.Max(tx, N) == N).
+// With txnsPerBlock=1, fakeFrozenBlocks(N) yields capTxNum=N.
 type fakeFrozenBlocks uint64
 
 func (f fakeFrozenBlocks) FrozenBlocks() uint64 { return uint64(f) }
 
-// TestAggregatorV3_BuildFiles_RespectsMaxCollatableTxNumCap verifies that when
-// a FrozenBlocksProvider is installed via SetFrozenBlocksProvider, the buildFiles
-// loop stops at the cap regardless of how much data is sitting in the DB.
-// Regression test for the bug behind PR #20701: previously the cap arg was
-// only consulted as an early-return gate; once the loop entered, it built
-// every step in the DB and could blow past block-snapshots progress.
+// Regression for #20701: cap must clamp the loop, not just early-return.
 func TestAggregatorV3_BuildFiles_RespectsMaxCollatableTxNumCap(t *testing.T) {
 	if testing.Short() {
 		t.Skip("slow test")
@@ -795,8 +788,7 @@ func TestAggregatorV3_BuildFiles_RespectsMaxCollatableTxNumCap(t *testing.T) {
 	t.Cleanup(agg.Close)
 	require.NoError(t, agg.OpenFolder())
 
-	// Cap collation at txNum 8 — i.e., 4 steps worth of data may be filed even
-	// though we'll write 9 steps' worth into the DB.
+	// Cap at 4 steps; write 9 steps' worth into the DB.
 	const capTxNum = uint64(8)
 	agg.SetFrozenBlocksProvider(fakeFrozenBlocks(capTxNum))
 
@@ -819,8 +811,6 @@ func TestAggregatorV3_BuildFiles_RespectsMaxCollatableTxNumCap(t *testing.T) {
 	require.NoError(t, doms.Flush(ctx, tx))
 	require.NoError(t, tx.Commit())
 
-	// Pass txnNums (18) as the build target — without the cap the loop would
-	// build all 9 steps. The cap must clamp it to 4 steps.
 	require.NoError(t, agg.BuildFiles(txnNums))
 
 	require.Equal(t, capTxNum, agg.EndTxNumMinimax(),
@@ -828,9 +818,7 @@ func TestAggregatorV3_BuildFiles_RespectsMaxCollatableTxNumCap(t *testing.T) {
 	require.Equal(t, kv.Step(capTxNum/agg.StepSize()), kv.Step(agg.EndTxNumMinimax()/agg.StepSize()))
 }
 
-// TestAggregatorV3_BuildFiles_NoCapHookBuildsAll verifies that without a cap
-// callback installed (nil hook — the default in tests), behavior is unchanged
-// and all DB data outside the reorg depth is filed.
+// nil provider = no cap; behavior unchanged.
 func TestAggregatorV3_BuildFiles_NoCapHookBuildsAll(t *testing.T) {
 	if testing.Short() {
 		t.Skip("slow test")
@@ -843,7 +831,6 @@ func TestAggregatorV3_BuildFiles_NoCapHookBuildsAll(t *testing.T) {
 	agg := state.NewTest(dirs).ReorgBlockDepth(1).StepSize(2).Logger(logger).MustOpen(ctx, db)
 	t.Cleanup(agg.Close)
 	require.NoError(t, agg.OpenFolder())
-	// Note: SetFrozenBlocksProvider is intentionally not called.
 
 	tdb, err := temporal.New(db, agg)
 	require.NoError(t, err)
@@ -866,15 +853,11 @@ func TestAggregatorV3_BuildFiles_NoCapHookBuildsAll(t *testing.T) {
 
 	require.NoError(t, agg.BuildFiles(txnNums))
 
-	// With reorgBlockDepth=1 and txnsPerBlock=1, the last block stays in DB so the
-	// last filed step ends at txNum 16 (step 8). Cap is not set → only the
-	// reorg-depth tail is held back, not the cap.
+	// reorg-depth=1 holds the last block back; cap unset.
 	require.Equal(t, uint64(16), agg.EndTxNumMinimax())
 }
 
-// TestAggregatorV3_BuildFiles2_RespectsMaxCollatableTxNumCap verifies that
-// BuildFiles2 (used by stage_custom_trace and squeeze rebuild paths) honors
-// the same cap as buildFilesInBackground.
+// BuildFiles2 path (stage_custom_trace, squeeze) must honor the cap too.
 func TestAggregatorV3_BuildFiles2_RespectsMaxCollatableTxNumCap(t *testing.T) {
 	if testing.Short() {
 		t.Skip("slow test")
@@ -909,8 +892,6 @@ func TestAggregatorV3_BuildFiles2_RespectsMaxCollatableTxNumCap(t *testing.T) {
 	require.NoError(t, doms.Flush(ctx, tx))
 	require.NoError(t, tx.Commit())
 
-	// Ask for steps [0, 9) — without the cap all 9 steps would be filed.
-	// With cap=8 (txSize=2 → 4 steps fit), only steps 0..3 should land.
 	require.NoError(t, agg.BuildFiles2(ctx, 0, kv.Step(txnNums/agg.StepSize()), false))
 	agg.WaitForFiles()
 
@@ -918,10 +899,7 @@ func TestAggregatorV3_BuildFiles2_RespectsMaxCollatableTxNumCap(t *testing.T) {
 		"BuildFiles2 must clamp to cap (%d), not toStep", capTxNum)
 }
 
-// TestAggregatorV3_BuildFiles_CapBelowVisibleIsNoop verifies that if the cap
-// is already at or below the current visibleFilesMinimaxTxNum (state files
-// already at/past the boundary), the loop produces no new files. The hook is
-// defensive only — it does not roll state files back.
+// Cap below visibleFilesMinimaxTxNum: defensive only — no rollback.
 func TestAggregatorV3_BuildFiles_CapBelowVisibleIsNoop(t *testing.T) {
 	if testing.Short() {
 		t.Skip("slow test")
@@ -954,16 +932,15 @@ func TestAggregatorV3_BuildFiles_CapBelowVisibleIsNoop(t *testing.T) {
 	require.NoError(t, doms.Flush(ctx, tx))
 	require.NoError(t, tx.Commit())
 
-	// First, build files to step 4 (cap=8) so there's existing state at txNum 8.
+	// build state up to txNum 8.
 	agg.SetFrozenBlocksProvider(fakeFrozenBlocks(8))
 	require.NoError(t, agg.BuildFiles(txnNums))
 	require.Equal(t, uint64(8), agg.EndTxNumMinimax())
 
-	// Now lower the cap below current visible — simulates "state already ahead
-	// of blocks". The loop must skip without filing more (and without panicking).
+	// lower cap below current visible — must be a no-op, no rollback.
 	agg.SetFrozenBlocksProvider(fakeFrozenBlocks(4))
 	require.NoError(t, agg.BuildFiles(txnNums))
-	require.Equal(t, uint64(8), agg.EndTxNumMinimax(), "files must not roll back; loop must be a no-op")
+	require.Equal(t, uint64(8), agg.EndTxNumMinimax())
 }
 
 func compareMapsBytes(t *testing.T, m1, m2 map[string][]byte) {

--- a/db/test/aggregator_ext_test.go
+++ b/db/test/aggregator_ext_test.go
@@ -769,12 +769,19 @@ func TestAggregatorV3_BuildFiles_WithReorgDepth(t *testing.T) {
 	require.Equal(t, kv.Step(6), kv.Step(agg.EndTxNumMinimax()/agg.StepSize()))
 }
 
+// fakeFrozenBlocks is a stand-in FrozenBlocksProvider for tests. With
+// txnsPerBlock=1 in the rawdbv3.TxNums setup, fakeFrozenBlocks(N) yields
+// capTxNum=N (since TxNums.Max(tx, N) == N).
+type fakeFrozenBlocks uint64
+
+func (f fakeFrozenBlocks) FrozenBlocks() uint64 { return uint64(f) }
+
 // TestAggregatorV3_BuildFiles_RespectsMaxCollatableTxNumCap verifies that when
-// a cap callback is installed via SetMaxCollatableTxNumFn, the buildFiles loop
-// stops at the cap regardless of how much data is sitting in the DB. Regression
-// test for the bug behind PR #20701: previously the cap arg was only consulted
-// as an early-return gate; once the loop entered, it built every step in the
-// DB and could blow past block-snapshots progress.
+// a FrozenBlocksProvider is installed via SetFrozenBlocksProvider, the buildFiles
+// loop stops at the cap regardless of how much data is sitting in the DB.
+// Regression test for the bug behind PR #20701: previously the cap arg was
+// only consulted as an early-return gate; once the loop entered, it built
+// every step in the DB and could blow past block-snapshots progress.
 func TestAggregatorV3_BuildFiles_RespectsMaxCollatableTxNumCap(t *testing.T) {
 	if testing.Short() {
 		t.Skip("slow test")
@@ -784,16 +791,14 @@ func TestAggregatorV3_BuildFiles_RespectsMaxCollatableTxNumCap(t *testing.T) {
 	dirs := datadir.New(t.TempDir())
 	db := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
 	t.Cleanup(db.Close)
-	agg := state.NewTest(dirs).ReorgBlockDepth(0).StepSize(2).Logger(logger).MustOpen(ctx, db)
+	agg := state.NewTest(dirs).ReorgBlockDepth(1).StepSize(2).Logger(logger).MustOpen(ctx, db)
 	t.Cleanup(agg.Close)
 	require.NoError(t, agg.OpenFolder())
 
 	// Cap collation at txNum 8 — i.e., 4 steps worth of data may be filed even
 	// though we'll write 9 steps' worth into the DB.
 	const capTxNum = uint64(8)
-	agg.SetMaxCollatableTxNumFn(func(_ context.Context, _ kv.Tx) (uint64, error) {
-		return capTxNum, nil
-	})
+	agg.SetFrozenBlocksProvider(fakeFrozenBlocks(capTxNum))
 
 	tdb, err := temporal.New(db, agg)
 	require.NoError(t, err)
@@ -835,10 +840,10 @@ func TestAggregatorV3_BuildFiles_NoCapHookBuildsAll(t *testing.T) {
 	dirs := datadir.New(t.TempDir())
 	db := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
 	t.Cleanup(db.Close)
-	agg := state.NewTest(dirs).ReorgBlockDepth(0).StepSize(2).Logger(logger).MustOpen(ctx, db)
+	agg := state.NewTest(dirs).ReorgBlockDepth(1).StepSize(2).Logger(logger).MustOpen(ctx, db)
 	t.Cleanup(agg.Close)
 	require.NoError(t, agg.OpenFolder())
-	// Note: SetMaxCollatableTxNumFn is intentionally not called.
+	// Note: SetFrozenBlocksProvider is intentionally not called.
 
 	tdb, err := temporal.New(db, agg)
 	require.NoError(t, err)
@@ -861,8 +866,56 @@ func TestAggregatorV3_BuildFiles_NoCapHookBuildsAll(t *testing.T) {
 
 	require.NoError(t, agg.BuildFiles(txnNums))
 
-	// All 9 steps (18 txnums / stepSize 2) should be filed when no cap is set.
-	require.Equal(t, uint64(18), agg.EndTxNumMinimax())
+	// With reorgBlockDepth=1 and txnsPerBlock=1, the last block stays in DB so the
+	// last filed step ends at txNum 16 (step 8). Cap is not set → only the
+	// reorg-depth tail is held back, not the cap.
+	require.Equal(t, uint64(16), agg.EndTxNumMinimax())
+}
+
+// TestAggregatorV3_BuildFiles2_RespectsMaxCollatableTxNumCap verifies that
+// BuildFiles2 (used by stage_custom_trace and squeeze rebuild paths) honors
+// the same cap as buildFilesInBackground.
+func TestAggregatorV3_BuildFiles2_RespectsMaxCollatableTxNumCap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow test")
+	}
+	ctx := t.Context()
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	db := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
+	t.Cleanup(db.Close)
+	agg := state.NewTest(dirs).ReorgBlockDepth(1).StepSize(2).Logger(logger).MustOpen(ctx, db)
+	t.Cleanup(agg.Close)
+	require.NoError(t, agg.OpenFolder())
+
+	const capTxNum = uint64(8)
+	agg.SetFrozenBlocksProvider(fakeFrozenBlocks(capTxNum))
+
+	tdb, err := temporal.New(db, agg)
+	require.NoError(t, err)
+	t.Cleanup(tdb.Close)
+	tx, err := tdb.BeginTemporalRw(ctx)
+	require.NoError(t, err)
+	t.Cleanup(tx.Rollback)
+	doms, err := execctx.NewSharedDomains(context.Background(), tx, logger)
+	require.NoError(t, err)
+	t.Cleanup(doms.Close)
+
+	const txnNums = uint64(18)
+	for i := uint64(0); i < txnNums; i++ {
+		require.NoError(t, rawdbv3.TxNums.Append(tx, i+1, i+1))
+	}
+	generateSharedDomainsUpdates(t, doms, tx, txnNums, newRnd(0), length.Addr, 10, 1)
+	require.NoError(t, doms.Flush(ctx, tx))
+	require.NoError(t, tx.Commit())
+
+	// Ask for steps [0, 9) — without the cap all 9 steps would be filed.
+	// With cap=8 (txSize=2 → 4 steps fit), only steps 0..3 should land.
+	require.NoError(t, agg.BuildFiles2(ctx, 0, kv.Step(txnNums/agg.StepSize()), false))
+	agg.WaitForFiles()
+
+	require.Equal(t, capTxNum, agg.EndTxNumMinimax(),
+		"BuildFiles2 must clamp to cap (%d), not toStep", capTxNum)
 }
 
 // TestAggregatorV3_BuildFiles_CapBelowVisibleIsNoop verifies that if the cap
@@ -878,7 +931,7 @@ func TestAggregatorV3_BuildFiles_CapBelowVisibleIsNoop(t *testing.T) {
 	dirs := datadir.New(t.TempDir())
 	db := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
 	t.Cleanup(db.Close)
-	agg := state.NewTest(dirs).ReorgBlockDepth(0).StepSize(2).Logger(logger).MustOpen(ctx, db)
+	agg := state.NewTest(dirs).ReorgBlockDepth(1).StepSize(2).Logger(logger).MustOpen(ctx, db)
 	t.Cleanup(agg.Close)
 	require.NoError(t, agg.OpenFolder())
 
@@ -902,17 +955,13 @@ func TestAggregatorV3_BuildFiles_CapBelowVisibleIsNoop(t *testing.T) {
 	require.NoError(t, tx.Commit())
 
 	// First, build files to step 4 (cap=8) so there's existing state at txNum 8.
-	agg.SetMaxCollatableTxNumFn(func(_ context.Context, _ kv.Tx) (uint64, error) {
-		return uint64(8), nil
-	})
+	agg.SetFrozenBlocksProvider(fakeFrozenBlocks(8))
 	require.NoError(t, agg.BuildFiles(txnNums))
 	require.Equal(t, uint64(8), agg.EndTxNumMinimax())
 
 	// Now lower the cap below current visible — simulates "state already ahead
 	// of blocks". The loop must skip without filing more (and without panicking).
-	agg.SetMaxCollatableTxNumFn(func(_ context.Context, _ kv.Tx) (uint64, error) {
-		return uint64(4), nil
-	})
+	agg.SetFrozenBlocksProvider(fakeFrozenBlocks(4))
 	require.NoError(t, agg.BuildFiles(txnNums))
 	require.Equal(t, uint64(8), agg.EndTxNumMinimax(), "files must not roll back; loop must be a no-op")
 }

--- a/db/test/aggregator_ext_test.go
+++ b/db/test/aggregator_ext_test.go
@@ -769,6 +769,154 @@ func TestAggregatorV3_BuildFiles_WithReorgDepth(t *testing.T) {
 	require.Equal(t, kv.Step(6), kv.Step(agg.EndTxNumMinimax()/agg.StepSize()))
 }
 
+// TestAggregatorV3_BuildFiles_RespectsMaxCollatableTxNumCap verifies that when
+// a cap callback is installed via SetMaxCollatableTxNumFn, the buildFiles loop
+// stops at the cap regardless of how much data is sitting in the DB. Regression
+// test for the bug behind PR #20701: previously the cap arg was only consulted
+// as an early-return gate; once the loop entered, it built every step in the
+// DB and could blow past block-snapshots progress.
+func TestAggregatorV3_BuildFiles_RespectsMaxCollatableTxNumCap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow test")
+	}
+	ctx := t.Context()
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	db := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
+	t.Cleanup(db.Close)
+	agg := state.NewTest(dirs).ReorgBlockDepth(0).StepSize(2).Logger(logger).MustOpen(ctx, db)
+	t.Cleanup(agg.Close)
+	require.NoError(t, agg.OpenFolder())
+
+	// Cap collation at txNum 8 — i.e., 4 steps worth of data may be filed even
+	// though we'll write 9 steps' worth into the DB.
+	const capTxNum = uint64(8)
+	agg.SetMaxCollatableTxNumFn(func(_ context.Context, _ kv.Tx) (uint64, error) {
+		return capTxNum, nil
+	})
+
+	tdb, err := temporal.New(db, agg)
+	require.NoError(t, err)
+	t.Cleanup(tdb.Close)
+	tx, err := tdb.BeginTemporalRw(ctx)
+	require.NoError(t, err)
+	t.Cleanup(tx.Rollback)
+	doms, err := execctx.NewSharedDomains(context.Background(), tx, logger)
+	require.NoError(t, err)
+	t.Cleanup(doms.Close)
+
+	const txnNums = uint64(18)
+	const txnsPerBlock = uint64(1)
+	for i := uint64(0); i < txnNums/txnsPerBlock; i++ {
+		require.NoError(t, rawdbv3.TxNums.Append(tx, i+1, (i+1)*txnsPerBlock))
+	}
+	generateSharedDomainsUpdates(t, doms, tx, txnNums, newRnd(0), length.Addr, 10, txnsPerBlock)
+	require.NoError(t, doms.Flush(ctx, tx))
+	require.NoError(t, tx.Commit())
+
+	// Pass txnNums (18) as the build target — without the cap the loop would
+	// build all 9 steps. The cap must clamp it to 4 steps.
+	require.NoError(t, agg.BuildFiles(txnNums))
+
+	require.Equal(t, capTxNum, agg.EndTxNumMinimax(),
+		"EndTxNumMinimax must be clamped to cap (%d), not driven by lastInDB", capTxNum)
+	require.Equal(t, kv.Step(capTxNum/agg.StepSize()), kv.Step(agg.EndTxNumMinimax()/agg.StepSize()))
+}
+
+// TestAggregatorV3_BuildFiles_NoCapHookBuildsAll verifies that without a cap
+// callback installed (nil hook — the default in tests), behavior is unchanged
+// and all DB data outside the reorg depth is filed.
+func TestAggregatorV3_BuildFiles_NoCapHookBuildsAll(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow test")
+	}
+	ctx := t.Context()
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	db := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
+	t.Cleanup(db.Close)
+	agg := state.NewTest(dirs).ReorgBlockDepth(0).StepSize(2).Logger(logger).MustOpen(ctx, db)
+	t.Cleanup(agg.Close)
+	require.NoError(t, agg.OpenFolder())
+	// Note: SetMaxCollatableTxNumFn is intentionally not called.
+
+	tdb, err := temporal.New(db, agg)
+	require.NoError(t, err)
+	t.Cleanup(tdb.Close)
+	tx, err := tdb.BeginTemporalRw(ctx)
+	require.NoError(t, err)
+	t.Cleanup(tx.Rollback)
+	doms, err := execctx.NewSharedDomains(context.Background(), tx, logger)
+	require.NoError(t, err)
+	t.Cleanup(doms.Close)
+
+	const txnNums = uint64(18)
+	const txnsPerBlock = uint64(1)
+	for i := uint64(0); i < txnNums/txnsPerBlock; i++ {
+		require.NoError(t, rawdbv3.TxNums.Append(tx, i+1, (i+1)*txnsPerBlock))
+	}
+	generateSharedDomainsUpdates(t, doms, tx, txnNums, newRnd(0), length.Addr, 10, txnsPerBlock)
+	require.NoError(t, doms.Flush(ctx, tx))
+	require.NoError(t, tx.Commit())
+
+	require.NoError(t, agg.BuildFiles(txnNums))
+
+	// All 9 steps (18 txnums / stepSize 2) should be filed when no cap is set.
+	require.Equal(t, uint64(18), agg.EndTxNumMinimax())
+}
+
+// TestAggregatorV3_BuildFiles_CapBelowVisibleIsNoop verifies that if the cap
+// is already at or below the current visibleFilesMinimaxTxNum (state files
+// already at/past the boundary), the loop produces no new files. The hook is
+// defensive only — it does not roll state files back.
+func TestAggregatorV3_BuildFiles_CapBelowVisibleIsNoop(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow test")
+	}
+	ctx := t.Context()
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	db := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
+	t.Cleanup(db.Close)
+	agg := state.NewTest(dirs).ReorgBlockDepth(0).StepSize(2).Logger(logger).MustOpen(ctx, db)
+	t.Cleanup(agg.Close)
+	require.NoError(t, agg.OpenFolder())
+
+	tdb, err := temporal.New(db, agg)
+	require.NoError(t, err)
+	t.Cleanup(tdb.Close)
+	tx, err := tdb.BeginTemporalRw(ctx)
+	require.NoError(t, err)
+	t.Cleanup(tx.Rollback)
+	doms, err := execctx.NewSharedDomains(context.Background(), tx, logger)
+	require.NoError(t, err)
+	t.Cleanup(doms.Close)
+
+	const txnNums = uint64(18)
+	const txnsPerBlock = uint64(1)
+	for i := uint64(0); i < txnNums/txnsPerBlock; i++ {
+		require.NoError(t, rawdbv3.TxNums.Append(tx, i+1, (i+1)*txnsPerBlock))
+	}
+	generateSharedDomainsUpdates(t, doms, tx, txnNums, newRnd(0), length.Addr, 10, txnsPerBlock)
+	require.NoError(t, doms.Flush(ctx, tx))
+	require.NoError(t, tx.Commit())
+
+	// First, build files to step 4 (cap=8) so there's existing state at txNum 8.
+	agg.SetMaxCollatableTxNumFn(func(_ context.Context, _ kv.Tx) (uint64, error) {
+		return uint64(8), nil
+	})
+	require.NoError(t, agg.BuildFiles(txnNums))
+	require.Equal(t, uint64(8), agg.EndTxNumMinimax())
+
+	// Now lower the cap below current visible — simulates "state already ahead
+	// of blocks". The loop must skip without filing more (and without panicking).
+	agg.SetMaxCollatableTxNumFn(func(_ context.Context, _ kv.Tx) (uint64, error) {
+		return uint64(4), nil
+	})
+	require.NoError(t, agg.BuildFiles(txnNums))
+	require.Equal(t, uint64(8), agg.EndTxNumMinimax(), "files must not roll back; loop must be a no-op")
+}
+
 func compareMapsBytes(t *testing.T, m1, m2 map[string][]byte) {
 	t.Helper()
 	for k, v := range m1 {

--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -38,7 +38,6 @@ import (
 	"github.com/erigontech/erigon/db/rawdb"
 	"github.com/erigontech/erigon/db/rawdb/rawdbhelpers"
 	"github.com/erigontech/erigon/db/rawdb/rawtemporaldb"
-	"github.com/erigontech/erigon/db/services"
 	dbstate "github.com/erigontech/erigon/db/state"
 	"github.com/erigontech/erigon/db/state/execctx"
 	"github.com/erigontech/erigon/execution/commitment"
@@ -142,11 +141,7 @@ func ExecV3(ctx context.Context,
 	}
 
 	if execStage.SyncMode() == stages.ModeApplyingBlocks {
-		maxCollatable, err := services.MaxCollatableTxNum(ctx, applyTx, cfg.blockReader)
-		if err != nil {
-			return err
-		}
-		agg.BuildFilesInBackground(min(initialTxNum, maxCollatable))
+		agg.BuildFilesInBackground(initialTxNum)
 	}
 
 	var (

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -1433,9 +1433,7 @@ func SetUpBlockReader(ctx context.Context, db kv.RwDB, dirs datadir.Dirs, snConf
 	}
 	agg.SetSnapshotBuildSema(blockSnapBuildSema)
 	agg.SetProduceMod(snConfig.Snapshot.ProduceE3)
-	agg.SetMaxCollatableTxNumFn(func(ctx context.Context, tx kv.Tx) (uint64, error) {
-		return services.MaxCollatableTxNum(ctx, tx, blockReader)
-	})
+	agg.SetFrozenBlocksProvider(blockReader)
 
 	allSegmentsDownloadComplete, err := rawdb.AllSegmentsDownloadCompleteFromDB(db)
 	if err != nil {

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -1433,6 +1433,9 @@ func SetUpBlockReader(ctx context.Context, db kv.RwDB, dirs datadir.Dirs, snConf
 	}
 	agg.SetSnapshotBuildSema(blockSnapBuildSema)
 	agg.SetProduceMod(snConfig.Snapshot.ProduceE3)
+	agg.SetMaxCollatableTxNumFn(func(ctx context.Context, tx kv.Tx) (uint64, error) {
+		return services.MaxCollatableTxNum(ctx, tx, blockReader)
+	})
 
 	allSegmentsDownloadComplete, err := rawdb.AllSegmentsDownloadCompleteFromDB(db)
 	if err != nil {


### PR DESCRIPTION
- https://github.com/erigontech/erigon/pull/20701/changes was added, wherein the cap was passed to BuildFiles* api
- but BuildFilesInBackground can ignore the passed txnum value (considering `lastTxNumInDb` etc.)
- this PR moves the state collation cap logic inside the aggregator; the aggregator then needs a `SetFrozenBlocksProvider` which is called to find block snapshots progress, and use it to cap the state collation.