### PR TITLE
cmd/utils: add --exec.serial flag to clamp workers to 1

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1165,6 +1165,11 @@ var (
 		Usage: "Parallel executor worker count (equivalent to EXEC3_WORKERS). Default: half the number of CPU cores, other half reserved for snapshots build/merge/prune.",
 		Value: runtime.NumCPU() / 2,
 	}
+	ExecSerialFlag = cli.BoolFlag{
+		Name:  "exec.serial",
+		Usage: "Force serial execution by clamping the parallel executor to a single worker. Wins over --exec.workers and EXEC3_WORKERS — use to disable parallelism for diagnostics or like-for-like baseline comparisons.",
+		Value: false,
+	}
 	ExecNoMergeFlag = cli.BoolFlag{
 		Name:  "exec.no-merge",
 		Usage: "Disable state-aggregator file merges for Domain / History / Inverted-Index (equivalent to NO_MERGE=true). Diagnostic / perf-comparison use only.",
@@ -2002,6 +2007,11 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 		n := ctx.Int(ExecWorkersFlag.Name)
 		dbg.SetExec3Workers(n)
 		cfg.ExecWorkerCount = n
+	}
+	// --exec.serial wins over --exec.workers / EXEC3_WORKERS: clamp to 1.
+	if ctx.IsSet(ExecSerialFlag.Name) && ctx.Bool(ExecSerialFlag.Name) {
+		dbg.SetExec3Workers(1)
+		cfg.ExecWorkerCount = 1
 	}
 	if ctx.IsSet(ExecNoMergeFlag.Name) {
 		dbg.SetNoMerge(ctx.Bool(ExecNoMergeFlag.Name))

--- a/cmd/utils/flags_test.go
+++ b/cmd/utils/flags_test.go
@@ -132,6 +132,9 @@ func TestExecPerfFlags_OverrideDbg(t *testing.T) {
 		if ctx.IsSet(ExecWorkersFlag.Name) {
 			dbg.SetExec3Workers(ctx.Int(ExecWorkersFlag.Name))
 		}
+		if ctx.IsSet(ExecSerialFlag.Name) && ctx.Bool(ExecSerialFlag.Name) {
+			dbg.SetExec3Workers(1)
+		}
 		if ctx.IsSet(ExecNoMergeFlag.Name) {
 			dbg.SetNoMerge(ctx.Bool(ExecNoMergeFlag.Name))
 		}
@@ -145,7 +148,7 @@ func TestExecPerfFlags_OverrideDbg(t *testing.T) {
 		app := cli.NewApp()
 		app.Flags = []cli.Flag{
 			&ExecBatchedIOFlag, &ExecStateCacheFlag, &ExecWorkersFlag,
-			&ExecNoMergeFlag, &ExecNoPruneFlag,
+			&ExecSerialFlag, &ExecNoMergeFlag, &ExecNoPruneFlag,
 		}
 		app.Action = apply
 		require.NoError(t, app.Run(append([]string{"test"}, args...)))
@@ -193,6 +196,26 @@ func TestExecPerfFlags_OverrideDbg(t *testing.T) {
 		dbg.SetExec3Workers(1)
 		run("--exec.workers=7")
 		require.Equal(t, 7, dbg.Exec3Workers)
+	})
+
+	t.Run("serial=true clamps Exec3Workers to 1", func(t *testing.T) {
+		dbg.SetExec3Workers(8)
+		run("--exec.serial=true")
+		require.Equal(t, 1, dbg.Exec3Workers)
+	})
+
+	t.Run("serial=true wins over --exec.workers", func(t *testing.T) {
+		dbg.SetExec3Workers(1)
+		// flags are applied in declaration order (workers first, then serial),
+		// so serial should override workers regardless of CLI argument order.
+		run("--exec.workers=12", "--exec.serial=true")
+		require.Equal(t, 1, dbg.Exec3Workers)
+	})
+
+	t.Run("serial=false leaves Exec3Workers untouched", func(t *testing.T) {
+		dbg.SetExec3Workers(8)
+		run("--exec.serial=false")
+		require.Equal(t, 8, dbg.Exec3Workers)
 	})
 
 	t.Run("no-merge and no-prune set to true", func(t *testing.T) {

--- a/node/cli/default_flags.go
+++ b/node/cli/default_flags.go
@@ -50,6 +50,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.ExecBatchedIOFlag,
 	&utils.ExecStateCacheFlag,
 	&utils.ExecWorkersFlag,
+	&utils.ExecSerialFlag,
 	&utils.ExecNoMergeFlag,
 	&utils.ExecNoPruneFlag,
 	&BatchSizeFlag,


### PR DESCRIPTION
## Summary

Follow-up to #20797. Adds a single-purpose boolean — \`--exec.serial\` — that forces serial execution by clamping the parallel executor's worker count to 1. Wins over both \`--exec.workers\` and \`EXEC3_WORKERS\`.

## Why a separate flag rather than just \`--exec.workers=1\`

- States intent at the call site (\"force serial\"), so logs / launch scripts / dashboards read clearly.
- Can't be accidentally undone by a stale \`EXEC3_WORKERS\` env var picked up by a test harness or wrapper script.
- Lets operators do like-for-like baseline comparisons against the parallel executor (A/B perf runs on bal-devnet-3, profiling cold paths) without juggling worker numbers.

## Precedence (resolved in \`SetEthConfig\`)

| Flags / env | Result |
|---|---|
| \`--exec.serial=true\` | \`workers=1\` |
| \`--exec.workers=12 --exec.serial=true\` | \`workers=1\` (serial wins) |
| \`--exec.workers=12\` | \`workers=12\` |
| \`--exec.serial=false\` (default) | no override; env var / default applies |

## Test plan

- [x] \`go test -short ./cmd/utils/...\` — \`TestExecPerfFlags_OverrideDbg\` extended with three new subtests: serial=true clamps, serial=true wins over --exec.workers, serial=false leaves Exec3Workers untouched.
- [x] \`make lint\` — 0 issues, twice.
- [x] \`make erigon\` — \`--help\` shows the new flag with the correct usage and default.

## Files touched

- \`cmd/utils/flags.go\` — flag definition + wiring in SetEthConfig (post --exec.workers so it overrides cleanly).
- \`cmd/utils/flags_test.go\` — three new subtests.
- \`node/cli/default_flags.go\` — register flag in DefaultFlags.

~35 LOC including tests.