### PR TITLE
cmd/utils: clarify --snap.skip-state-snapshot-download vs --prune.mode=blocks

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -706,7 +706,7 @@ var (
 	}
 	SnapSkipStateSnapshotDownloadFlag = cli.BoolFlag{
 		Name:  "snap.skip-state-snapshot-download",
-		Usage: "Skip state download and start from genesis block",
+		Usage: "Skip state snapshot download and re-execute from genesis to build state. Unlike --prune.mode=blocks which downloads state snapshots then prunes history, this flag skips the download entirely.",
 		Value: false,
 	}
 	SnapP2PManifestFlag = cli.BoolFlag{


### PR DESCRIPTION
Improves the `--snap.skip-state-snapshot-download` flag description to distinguish it from `--prune.mode=blocks`: both result in a node without downloaded state snapshots, but `--prune.mode=blocks` downloads them then prunes history, while this flag skips the download entirely.