### PR TITLE
[wip] etl: pre-warm MDBX pages in FlushToDiskAsync goroutine

### DIFF
--- a/db/etl/collector.go
+++ b/db/etl/collector.go
@@ -138,7 +138,7 @@ func (c *Collector) flushBuffer(canStoreInRam bool) error {
 		provider := KeepInRAM(c.buf)
 		c.allFlushed = true
 		c.dataProviders = append(c.dataProviders, provider)
-		if c.warmupDB != nil {
+		if c.warmupDB != nil && c.buf.Len() > 100 {
 			ctx, cancel := context.WithCancel(context.Background())
 			c.warmupCancel = cancel
 			buf := c.buf
@@ -200,13 +200,7 @@ func (c *Collector) Load(db kv.RwTx, toBucket string, loadFunc LoadFunc, args Tr
 		}
 	}
 
-	if c.warmupCancel != nil {
-		defer func() {
-			c.warmupCancel()
-			c.warmupWg.Wait()
-			c.warmupCancel = nil
-		}()
-	}
+	defer c.stopWarmup()
 
 	bucket := toBucket
 
@@ -287,12 +281,16 @@ func (c *Collector) Load(db kv.RwTx, toBucket string, loadFunc LoadFunc, args Tr
 	return nil
 }
 
-func (c *Collector) Close() {
+func (c *Collector) stopWarmup() {
 	if c.warmupCancel != nil {
 		c.warmupCancel()
 		c.warmupWg.Wait()
 		c.warmupCancel = nil
 	}
+}
+
+func (c *Collector) Close() {
+	c.stopWarmup()
 	if c.buf != nil { //idempotency
 		if c.allocator != nil {
 			c.allocator.Put(c.buf)

--- a/db/etl/collector.go
+++ b/db/etl/collector.go
@@ -18,6 +18,7 @@ package etl
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -75,6 +76,17 @@ type Collector struct {
 	sortAndFlushInBackgroundActive atomic.Bool // allow only 1 bg sort per Collector
 
 	allocator *Allocator
+
+	warmupDB     kv.RoDB
+	warmupTbl    string
+	warmupCancel context.CancelFunc
+	warmupWg     sync.WaitGroup
+}
+
+func (c *Collector) WithWarmup(db kv.RoDB, table string) *Collector {
+	c.warmupDB = db
+	c.warmupTbl = table
+	return c
 }
 
 func NewCollectorWithAllocator(logPrefix, tmpdir string, allocator *Allocator, logger log.Logger) *Collector {
@@ -126,6 +138,13 @@ func (c *Collector) flushBuffer(canStoreInRam bool) error {
 		provider := KeepInRAM(c.buf)
 		c.allFlushed = true
 		c.dataProviders = append(c.dataProviders, provider)
+		if c.warmupDB != nil {
+			ctx, cancel := context.WithCancel(context.Background())
+			c.warmupCancel = cancel
+			buf := c.buf
+			c.warmupWg.Add(1)
+			go func() { defer c.warmupWg.Done(); warmupSortedBuffer(ctx, c.warmupDB, c.warmupTbl, buf) }()
+		}
 		return nil
 	}
 
@@ -149,7 +168,7 @@ func (c *Collector) flushBuffer(canStoreInRam bool) error {
 		c.buf = getBufferByType(c.bufType, datasize.ByteSize(fullBuf.SizeLimit()))
 		c.buf.Prealloc(prevLen/8, prevSize/8)
 	}
-	provider, err := FlushToDiskAsync(c.logPrefix, fullBuf, c.tmpdir, c.logLvl, c.allocator, &c.sortAndFlushInBackgroundActive)
+	provider, err := FlushToDiskAsync(c.logPrefix, fullBuf, c.tmpdir, c.logLvl, c.allocator, &c.sortAndFlushInBackgroundActive, c.warmupDB, c.warmupTbl)
 	if err != nil {
 		return err
 	}
@@ -179,6 +198,14 @@ func (c *Collector) Load(db kv.RwTx, toBucket string, loadFunc LoadFunc, args Tr
 		if e := c.flushBuffer(true); e != nil {
 			return e
 		}
+	}
+
+	if c.warmupCancel != nil {
+		defer func() {
+			c.warmupCancel()
+			c.warmupWg.Wait()
+			c.warmupCancel = nil
+		}()
 	}
 
 	bucket := toBucket
@@ -261,6 +288,11 @@ func (c *Collector) Load(db kv.RwTx, toBucket string, loadFunc LoadFunc, args Tr
 }
 
 func (c *Collector) Close() {
+	if c.warmupCancel != nil {
+		c.warmupCancel()
+		c.warmupWg.Wait()
+		c.warmupCancel = nil
+	}
 	if c.buf != nil { //idempotency
 		if c.allocator != nil {
 			c.allocator.Put(c.buf)

--- a/db/etl/dataprovider.go
+++ b/db/etl/dataprovider.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -92,35 +93,49 @@ func FlushToDiskAsync(logPrefix string, b Buffer, tmpdir string, lvl log.Lvl, al
 }
 
 func warmupSortedBuffer(ctx context.Context, db kv.RoDB, table string, b Buffer) {
-	if b.Len() <= 100 {
+	n := b.Len()
+	if n <= 100 {
 		return
 	}
 	t := time.Now()
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	roTx, err := db.BeginRo(ctx)
-	if err != nil {
-		return
-	}
-	defer roTx.Rollback()
-	cursor, err := roTx.Cursor(table)
-	if err != nil {
-		return
-	}
-	defer cursor.Close()
+	const stride = 10
+	workers := min(runtime.NumCPU(), 4)
+	chunkSize := ((n/stride + workers - 1) / workers) * stride
 
-	n := b.Len()
-	seeked := 0
-	for i := 0; i < n; i += 10 {
-		if ctx.Err() != nil {
+	var wg sync.WaitGroup
+	for w := range workers {
+		from := w * chunkSize
+		if from >= n {
 			break
 		}
-		k, _ := b.Get(i)
-		cursor.Seek(k) //nolint:errcheck
-		seeked++
+		to := min(from+chunkSize, n)
+		wg.Add(1)
+		go func(from, to int) {
+			defer wg.Done()
+			roTx, err := db.BeginRo(ctx)
+			if err != nil {
+				return
+			}
+			defer roTx.Rollback()
+			cursor, err := roTx.Cursor(table)
+			if err != nil {
+				return
+			}
+			defer cursor.Close()
+			for i := from; i < to; i += stride {
+				if ctx.Err() != nil {
+					return
+				}
+				k, _ := b.Get(i)
+				cursor.Seek(k) //nolint:errcheck
+			}
+		}(from, to)
 	}
-	log.Debug("[etl] warmup", "table", table, "keys", n, "seeked", seeked, "took", time.Since(t))
+	wg.Wait()
+	log.Debug("[etl] warmup", "table", table, "keys", n, "seeked", n/stride, "took", time.Since(t))
 }
 
 // FlushToDisk - `doFsync` is true only for 'critical' collectors (which should not loose).

--- a/db/etl/dataprovider.go
+++ b/db/etl/dataprovider.go
@@ -18,6 +18,7 @@ package etl
 
 import (
 	"bufio"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -25,6 +26,7 @@ import (
 	"path/filepath"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/c2h5oh/datasize"
 	"golang.org/x/sync/errgroup"
@@ -32,6 +34,7 @@ import (
 	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/common/mmap"
+	"github.com/erigontech/erigon/db/kv"
 )
 
 type dataProvider interface {
@@ -56,7 +59,7 @@ type mmapBytesReader struct {
 }
 
 // FlushToDiskAsync - `doFsync` is true only for 'critical' collectors (which should not loose).
-func FlushToDiskAsync(logPrefix string, b Buffer, tmpdir string, lvl log.Lvl, allocator *Allocator, inProgress *atomic.Bool) (dataProvider, error) {
+func FlushToDiskAsync(logPrefix string, b Buffer, tmpdir string, lvl log.Lvl, allocator *Allocator, inProgress *atomic.Bool, warmupDB kv.RoDB, warmupTbl string) (dataProvider, error) {
 	if b.Len() == 0 {
 		if allocator != nil {
 			allocator.Put(b)
@@ -78,10 +81,46 @@ func FlushToDiskAsync(logPrefix string, b Buffer, tmpdir string, lvl log.Lvl, al
 		}
 		_, fName := filepath.Split(provider.file.Name())
 		log.Log(lvl, fmt.Sprintf("[%s] Flushed buffer file", logPrefix), "name", fName)
+
+		if warmupDB != nil {
+			warmupSortedBuffer(context.Background(), warmupDB, warmupTbl, b)
+		}
 		return nil
 	})
 
 	return provider, nil
+}
+
+func warmupSortedBuffer(ctx context.Context, db kv.RoDB, table string, b Buffer) {
+	if b.Len() <= 100 {
+		return
+	}
+	t := time.Now()
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	roTx, err := db.BeginRo(ctx)
+	if err != nil {
+		return
+	}
+	defer roTx.Rollback()
+	cursor, err := roTx.Cursor(table)
+	if err != nil {
+		return
+	}
+	defer cursor.Close()
+
+	n := b.Len()
+	seeked := 0
+	for i := 0; i < n; i += 10 {
+		if ctx.Err() != nil {
+			break
+		}
+		k, _ := b.Get(i)
+		cursor.Seek(k) //nolint:errcheck
+		seeked++
+	}
+	log.Debug("[etl] warmup", "table", table, "keys", n, "seeked", seeked, "took", time.Since(t))
 }
 
 // FlushToDisk - `doFsync` is true only for 'critical' collectors (which should not loose).

--- a/db/etl/etl_test.go
+++ b/db/etl/etl_test.go
@@ -1531,3 +1531,29 @@ func TestVmtouchMmap(t *testing.T) {
 	}
 	vmtouch("AFTER full scan")
 }
+
+func TestCollectorWithWarmup(t *testing.T) {
+	logger := log.New()
+	db, tx := memdb.NewTestTx(t)
+	bucket := kv.ChaindataTables[0]
+
+	generateTestData(t, tx, bucket, 50)
+
+	collector := NewCollector(t.Name(), t.TempDir(), NewSortableBuffer(datasize.MB), logger)
+	defer collector.Close()
+	collector.WithWarmup(db, bucket)
+
+	for i := 0; i < 50; i++ {
+		k := fmt.Appendf(nil, "%10d-key-%010d", i, i)
+		v := fmt.Appendf(nil, "val-%099d", i)
+		require.NoError(t, collector.Collect(k, v))
+	}
+
+	loaded := 0
+	err := collector.Load(tx, bucket, func(k, v []byte, table CurrentTableReader, next LoadNextFunc) error {
+		loaded++
+		return next(k, k, v)
+	}, TransformArgs{})
+	require.NoError(t, err)
+	require.Equal(t, 50, loaded)
+}

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -209,6 +209,7 @@ func (a *Aggregator) RegisterDomain(cfg statecfg.DomainCfg, salt *uint32, dirs d
 	if err != nil {
 		return err
 	}
+	a.d[cfg.Name].db = a.db
 	a.d[cfg.Name].salt.Store(salt)
 	a.AddDependencyBtwnHistoryII(cfg.Name)
 	return nil

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -72,6 +72,7 @@ var traceGetLatest, _ = kv.String2Domain(dbg.EnvString("AGG_TRACE_GET_LATEST", "
 type Domain struct {
 	statecfg.DomainCfg // keep it above *History to avoid unexpected shadowing
 	*History
+	db kv.RoDB
 
 	// Schema:
 	//  - .kv - key -> value
@@ -380,8 +381,12 @@ func (dt *DomainRoTx) newWriter(tmpdir string, discard bool) *DomainBufferedWrit
 		h:         dt.ht.newWriter(tmpdir, discardHistory),
 	}
 	if !discard {
-		w.values = etl.NewCollectorWithAllocator(dt.d.Name.String()+"domain.flush", tmpdir, etl.SmallSortableBuffers, dt.d.logger).
+		c := etl.NewCollectorWithAllocator(dt.d.Name.String()+"domain.flush", tmpdir, etl.SmallSortableBuffers, dt.d.logger).
 			LogLvl(log.LvlTrace).SortAndFlushInBackground(true)
+		if dt.d.db != nil {
+			c.WithWarmup(dt.d.db, dt.d.ValuesTable)
+		}
+		w.values = c
 	}
 	return w
 }


### PR DESCRIPTION
Pre-warms MDBX pages for domain values tables by seeking keys inside the `FlushToDiskAsync` background goroutine that already exists for sorting and writing the ETL buffer to disk.

## What

- `etl.Collector.WithWarmup(db, table)` — opt-in warmup configuration
- `warmupSortedBuffer` runs after `b.Sort()` inside the async goroutine: opens a short-lived `RoTx`, seeks every 10th key in sorted order (so B-tree traversal is progressive), closes. 5-second timeout. Debug log with key count and duration.
- `DomainRoTx.db kv.RoDB` — threaded from `Aggregator.db` through `beginFilesRo`; not stored on `Domain`
- `DomainRoTx.newWriter` chains `.WithWarmup` when db is present

## Why

Domain `Load` writes keys in sorted order. If those MDBX pages aren't in the OS page cache, each write triggers a page fault. By seeking the same keys in the background goroutine (which runs while the next batch of blocks executes), the pages are warm by the time `Load` runs.

## Properties

- No extra goroutines or channels — reuses the existing `FlushToDiskAsync` goroutine
- No extra key copies — keys are read from the already-sorted buffer via `b.Get(i)`
- Best-effort: timeout and errors are silently ignored