### PR TITLE
p2p/discover: fix expired matcher iteration in discover reply loop

### DIFF
--- a/p2p/discover/common.go
+++ b/p2p/discover/common.go
@@ -20,9 +20,11 @@
 package discover
 
 import (
+	"container/list"
 	"crypto/ecdsa"
 	crand "crypto/rand"
 	"encoding/binary"
+	"iter"
 	"math/rand"
 	"net"
 	"net/netip"
@@ -145,4 +147,17 @@ func (r *reseedingRandom) Shuffle(n int, swap func(i, j int)) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.cur.Shuffle(n, swap)
+}
+
+// iterList iterates over the elements of the given list.
+func iterList[T any](l *list.List) iter.Seq2[T, *list.Element] {
+	return func(yield func(T, *list.Element) bool) {
+		for el := l.Front(); el != nil; {
+			next := el.Next()
+			if !yield(el.Value.(T), el) {
+				return
+			}
+			el = next
+		}
+	}
 }

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -453,6 +453,7 @@ func (t *UDPv4) loop() {
 		// Start the timer so it fires when the next pending reply has expired.
 		now := time.Now()
 		for p, el := range iterList[*replyMatcher](plist) {
+			nextTimeout = p
 			if dist := p.deadline.Sub(now); dist < 2*respTimeout {
 				timeout.Reset(dist)
 				return
@@ -460,7 +461,7 @@ func (t *UDPv4) loop() {
 			// Remove pending replies whose deadline is too far in the
 			// future. These can occur if the system clock jumped
 			// backwards after the deadline was assigned.
-			nextTimeout.errc <- errClockWarp
+			p.errc <- errClockWarp
 			plist.Remove(el)
 		}
 		nextTimeout = nil

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -452,9 +452,8 @@ func (t *UDPv4) loop() {
 		}
 		// Start the timer so it fires when the next pending reply has expired.
 		now := time.Now()
-		for el := plist.Front(); el != nil; el = el.Next() {
-			nextTimeout = el.Value.(*replyMatcher)
-			if dist := nextTimeout.deadline.Sub(now); dist < 2*respTimeout {
+		for p, el := range iterList[*replyMatcher](plist) {
+			if dist := p.deadline.Sub(now); dist < 2*respTimeout {
 				timeout.Reset(dist)
 				return
 			}
@@ -484,8 +483,7 @@ func (t *UDPv4) loop() {
 
 		case r := <-t.gotreply:
 			var matched bool // whether any replyMatcher considered the reply acceptable.
-			for el := plist.Front(); el != nil; el = el.Next() {
-				p := el.Value.(*replyMatcher)
+			for p, el := range iterList[*replyMatcher](plist) {
 				if p.from == r.from && p.ptype == r.data.Kind() && p.ip == r.ip {
 					ok, requestDone := p.callback(r.data)
 					matched = matched || ok
@@ -505,8 +503,7 @@ func (t *UDPv4) loop() {
 			nextTimeout = nil
 
 			// Notify and remove callbacks whose deadline is in the past.
-			for el := plist.Front(); el != nil; el = el.Next() {
-				p := el.Value.(*replyMatcher)
+			for p, el := range iterList[*replyMatcher](plist) {
 				if now.After(p.deadline) || now.Equal(p.deadline) {
 					p.errc <- errTimeout
 					plist.Remove(el)


### PR DESCRIPTION
This update resolves the matcher cleanup loop in the discover reply handling code. When an expired matcher is removed from the list, calling `Remove(el)` invalidates its links, therefore invoking `el.Next()` subsequently may cause the loop to terminate prematurely. To avoid this, the next element is preserved before removal, allowing iteration to proceed appropriately across the entire list. This ensures that all expired matchers in the same tick are processed and that `contTimeouts` are not undercounted when multiple matchers expire simultaneously.