### PR TITLE
[bal-devnet-3] p2p, txpool: fix Hive eth devp2p test failures (#20733)

### DIFF
--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -22,14 +22,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # `sim` is the simulator path passed to `hive --sim`. Most simulators
+        # live under simulators/ethereum/, but a few (e.g. devp2p) are top-level.
         include:
-          - sim: engine
-            sim-limit: exchange-capabilities
+          - sim: ethereum/engine
+            sim-limit: exchange-capabilities|auth
             max-allowed-failures: 0
-          - sim: engine
+          - sim: ethereum/engine
             sim-limit: withdrawals
             max-allowed-failures: 0
-          - sim: engine
+          - sim: ethereum/engine
             sim-limit: cancun
             # 2 failures (not due to us, but due to Hive/Geth secondary client)
             # will remove once resolved by STEEL team (these 2 tests are failing on all clients)
@@ -38,14 +40,19 @@ jobs:
             # known flake under --sim.parallelism=8 due to timing/resource contention; passes
             # cleanly in isolation (--sim.parallelism=1)
             max-allowed-failures: 3
-          - sim: engine
+          - sim: ethereum/engine
             sim-limit: api
             max-allowed-failures: 0
-          - sim: engine
-            sim-limit: auth
-            max-allowed-failures: 0
-          - sim: rpc-compat
+          - sim: ethereum/rpc-compat
             sim-limit: ".*"
+            max-allowed-failures: 0
+          # devp2p/eth: regression guard for eth wire protocol handlers
+          # (GetBlockHeaders skip traversal, BlockRangeUpdate invalid-packet kick,
+          # blob-sidecar commitment check, eth/68 announcement size/type check).
+          # The sibling devp2p suites (snap, discv4, discv5) are intentionally
+          # excluded — they have unrelated pre-existing failures.
+          - sim: devp2p
+            sim-limit: eth
             max-allowed-failures: 0
     steps:
       - name: Checkout Erigon meta
@@ -140,7 +147,7 @@ jobs:
             echo -e "\n\n============================================================"
             echo "Running test: ${1}-${2}"
             echo -e "\n"
-            ./hive -docker.auth --sim ethereum/"${1}" --sim.limit="${2}" --sim.limit.exact=false --sim.parallelism=8 --sim.timelimit 15m --docker.output --client erigon 2>&1 | tee output.log || {
+            ./hive -docker.auth --sim "${1}" --sim.limit="${2}" --sim.limit.exact=false --sim.parallelism=8 --sim.timelimit 15m --docker.output --client erigon 2>&1 | tee output.log || {
               if [ $? -gt 0 ]; then
                 echo "Exitcode gt 0"
               fi
@@ -150,12 +157,12 @@ jobs:
             if [ -z "$suites" ]; then
               status_line=$(tail -1 output.log | sed -r "s/\x1B\[[0-9;]*[a-zA-Z]//g")
               suites=$(echo "$status_line" | sed -n 's/.*suites=\([0-9]*\).*/\1/p')
-            fi 
+            fi
             tests=$(echo "$status_line" | sed -n 's/.*tests=\([0-9]*\).*/\1/p')
             failed=$(echo "$status_line" | sed -n 's/.*failed=\([0-9]*\).*/\1/p')
 
             echo -e "\n"
-            echo "-----------   Results for ${1}-${2}    -----------" 
+            echo "-----------   Results for ${1}-${2}    -----------"
             echo "Tests: $tests, Failed: $failed"
             echo -e "\n\n============================================================"
 

--- a/p2p/protocols/eth/handlers.go
+++ b/p2p/protocols/eth/handlers.go
@@ -106,7 +106,7 @@ func AnswerGetBlockHeadersQuery(db kv.Tx, query *GetBlockHeadersPacket, blockRea
 				log.Warn("[p2p] GetBlockHeaders skip overflow attack", "current", current, "skip", query.Skip, "next", next)
 				unknown = true
 			} else {
-				header, err := blockReader.HeaderByNumber(context.Background(), db, query.Origin.Number)
+				header, err := blockReader.HeaderByNumber(context.Background(), db, next)
 				if err != nil {
 					return nil, err
 				}

--- a/p2p/protocols/eth/handlers_test.go
+++ b/p2p/protocols/eth/handlers_test.go
@@ -441,3 +441,92 @@ func TestAnswerGetReceiptsQueryCacheOnly70_EmptyQuery(t *testing.T) {
 		t.Fatalf("expected 0 block receipt lists, got %d", len(result.EncodedReceipts))
 	}
 }
+
+// mockHeaderReader implements services.HeaderReader for TestAnswerGetBlockHeadersQuery*.
+// It exposes a canonical chain keyed by block number; each block's hash is derived
+// deterministically from its number so the ancestor walk works both ways.
+type mockHeaderReader struct {
+	headers map[uint64]*types.Header // number -> header
+	byHash  map[common.Hash]uint64   // hash -> number
+}
+
+func newMockHeaderReader(chainLen int) *mockHeaderReader {
+	m := &mockHeaderReader{
+		headers: make(map[uint64]*types.Header, chainLen),
+		byHash:  make(map[common.Hash]uint64, chainLen),
+	}
+	var parent common.Hash
+	for i := uint64(0); i < uint64(chainLen); i++ {
+		h := &types.Header{ParentHash: parent}
+		h.Number.SetUint64(i)
+		hash := h.Hash()
+		m.headers[i] = h
+		m.byHash[hash] = i
+		parent = hash
+	}
+	return m
+}
+
+func (m *mockHeaderReader) Header(_ context.Context, _ kv.Getter, hash common.Hash, blockNum uint64) (*types.Header, error) {
+	if h, ok := m.headers[blockNum]; ok && h.Hash() == hash {
+		return h, nil
+	}
+	return nil, nil
+}
+func (m *mockHeaderReader) HeaderByNumber(_ context.Context, _ kv.Getter, blockNum uint64) (*types.Header, error) {
+	return m.headers[blockNum], nil
+}
+func (m *mockHeaderReader) HeaderNumber(_ context.Context, _ kv.Getter, hash common.Hash) (*uint64, error) {
+	if n, ok := m.byHash[hash]; ok {
+		return &n, nil
+	}
+	return nil, nil
+}
+func (m *mockHeaderReader) HeaderByHash(_ context.Context, _ kv.Getter, hash common.Hash) (*types.Header, error) {
+	n, ok := m.byHash[hash]
+	if !ok {
+		return nil, nil
+	}
+	return m.headers[n], nil
+}
+func (m *mockHeaderReader) ReadAncestor(_ kv.Getter, hash common.Hash, number, ancestor uint64, _ *uint64) (common.Hash, uint64) {
+	n, ok := m.byHash[hash]
+	if !ok || n != number || ancestor > number {
+		return common.Hash{}, 0
+	}
+	anc := m.headers[number-ancestor]
+	return anc.Hash(), number - ancestor
+}
+func (m *mockHeaderReader) HeadersRange(_ context.Context, _ func(*types.Header) error) error {
+	return nil
+}
+func (m *mockHeaderReader) Integrity(_ context.Context) error { return nil }
+
+// TestAnswerGetBlockHeadersQuery_HashModeSkip guards against a regression where
+// the non-reverse hash-mode branch read `query.Origin.Number` (the current block)
+// instead of `next`, causing the ancestor check to fail and the handler to
+// return only the origin header when Amount > 1.
+func TestAnswerGetBlockHeadersQuery_HashModeSkip(t *testing.T) {
+	reader := newMockHeaderReader(10)
+	origin := reader.headers[1]
+
+	query := &GetBlockHeadersPacket{
+		Origin:  HashOrNumber{Hash: origin.Hash()},
+		Amount:  3,
+		Skip:    1,
+		Reverse: false,
+	}
+	headers, err := AnswerGetBlockHeadersQuery(nil, query, reader)
+	if err != nil {
+		t.Fatalf("AnswerGetBlockHeadersQuery returned error: %v", err)
+	}
+	if len(headers) != 3 {
+		t.Fatalf("expected 3 headers, got %d", len(headers))
+	}
+	expectedNumbers := []uint64{1, 3, 5}
+	for i, h := range headers {
+		if h.Number.Uint64() != expectedNumbers[i] {
+			t.Fatalf("header %d: expected block %d, got %d", i, expectedNumbers[i], h.Number.Uint64())
+		}
+	}
+}

--- a/p2p/sentry/sentry_grpc_server.go
+++ b/p2p/sentry/sentry_grpc_server.go
@@ -1080,6 +1080,18 @@ func (ss *GrpcServer) deletePeer(peerID [64]byte) {
 
 func (ss *GrpcServer) writePeer(logPrefix string, peerInfo *PeerInfo, msgcode uint64, data []byte, ttl time.Duration) {
 	peerInfo.Async(func() {
+		// Async enqueue can win the race against Remove closing pi.removed, so a
+		// queued task may be scheduled to run on a peer we have already asked
+		// p2p to disconnect. Without this check, one last frame would slip out
+		// after Disconnect — which Hive's devp2p BlobViolations asserts against.
+		// Matches go-ethereum, where Disconnect runs on the same goroutine as
+		// detection so nothing further can be sent.
+		select {
+		case <-peerInfo.removed:
+			return
+		default:
+		}
+
 		msgType, protocolName, protocolVersion := ss.protoMessageID(msgcode)
 		trackPeerStatistics(peerInfo.peer.Fullname(), peerInfo.peer.ID().String(), false, msgType.String(), fmt.Sprintf("%s/%d", protocolName, protocolVersion), len(data))
 

--- a/p2p/sentry/sentry_multi_client/sentry_multi_client.go
+++ b/p2p/sentry/sentry_multi_client/sentry_multi_client.go
@@ -1035,6 +1035,13 @@ func (cs *MultiClient) blockRange69(ctx context.Context, inreq *sentryproto.Inbo
 		return fmt.Errorf("decoding blockRange69: %w, data: %x", err, inreq.Data)
 	}
 	if err := query.Validate(); err != nil {
+		cs.logger.Debug("Kick peer for invalid BlockRangeUpdate", "peer", inreq.PeerId.String(), "err", err)
+		if _, err1 := sentryClient.PenalizePeer(ctx, &sentryproto.PenalizePeerRequest{
+			PeerId:  inreq.PeerId,
+			Penalty: sentryproto.PenaltyKind_Kick,
+		}, &grpc.EmptyCallOption{}); err1 != nil {
+			cs.logger.Error("Could not send penalty", "err", err1)
+		}
 		return err
 	}
 

--- a/p2p/sentry/sentry_multi_client/sentry_multi_client_test.go
+++ b/p2p/sentry/sentry_multi_client/sentry_multi_client_test.go
@@ -148,6 +148,7 @@ type mockSentryClient struct {
 	sendMessageByIdFunc  func(ctx context.Context, req *proto_sentry.SendMessageByIdRequest, opts ...grpc.CallOption) (*proto_sentry.SentPeers, error)
 	sendMessageToAllFunc func(ctx context.Context, req *proto_sentry.OutboundMessageData, opts ...grpc.CallOption) (*proto_sentry.SentPeers, error)
 	handShakeFunc        func(ctx context.Context, req *emptypb.Empty, opts ...grpc.CallOption) (*proto_sentry.HandShakeReply, error)
+	penalizePeerFunc     func(ctx context.Context, req *proto_sentry.PenalizePeerRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
 
 func (m *mockSentryClient) SendMessageById(ctx context.Context, req *proto_sentry.SendMessageByIdRequest, opts ...grpc.CallOption) (*proto_sentry.SentPeers, error) {
@@ -162,8 +163,62 @@ func (m *mockSentryClient) HandShake(ctx context.Context, req *emptypb.Empty, op
 	return m.handShakeFunc(ctx, req, opts...)
 }
 
+func (m *mockSentryClient) PenalizePeer(ctx context.Context, req *proto_sentry.PenalizePeerRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	if m.penalizePeerFunc == nil {
+		return &emptypb.Empty{}, nil
+	}
+	return m.penalizePeerFunc(ctx, req, opts...)
+}
+
 type mockBlockReader struct {
 	services.FullBlockReader
+}
+
+// TestBlockRange69_InvalidPacketKicksPeer verifies that an invalid
+// BlockRangeUpdate (e.g. Earliest > Latest) causes the peer to be penalized.
+// This mirrors the Hive `TestBlockRangeUpdateInvalid` simulator check.
+func TestBlockRange69_InvalidPacketKicksPeer(t *testing.T) {
+	ctx := context.Background()
+
+	peerId := &proto_types.H512{
+		Hi: &proto_types.H256{Hi: &proto_types.H128{}, Lo: &proto_types.H128{}},
+		Lo: &proto_types.H256{Hi: &proto_types.H128{}, Lo: &proto_types.H128{}},
+	}
+
+	// Packet with Earliest > Latest is invalid per BlockRangeUpdatePacket.Validate.
+	invalid := eth.BlockRangeUpdatePacket{
+		Earliest:   10,
+		Latest:     8,
+		LatestHash: common.HexToHash("0xdeadbeef"),
+	}
+	payload, err := rlp.EncodeToBytes(&invalid)
+	if err != nil {
+		t.Fatalf("encode packet: %v", err)
+	}
+
+	var penalized *proto_sentry.PenalizePeerRequest
+	mockSentry := &mockSentryClient{
+		penalizePeerFunc: func(_ context.Context, req *proto_sentry.PenalizePeerRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
+			penalized = req
+			return &emptypb.Empty{}, nil
+		},
+	}
+
+	cs := &MultiClient{logger: log.New()}
+
+	if err := cs.blockRange69(ctx, &proto_sentry.InboundMessage{
+		PeerId: peerId,
+		Data:   payload,
+	}, mockSentry); err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+
+	if penalized == nil {
+		t.Fatal("expected PenalizePeer to be called, got nil")
+	}
+	if penalized.Penalty != proto_sentry.PenaltyKind_Kick {
+		t.Fatalf("expected Kick penalty, got %v", penalized.Penalty)
+	}
 }
 
 type mockReceiptsGenerator struct {

--- a/txnprovider/txpool/fetch.go
+++ b/txnprovider/txpool/fetch.go
@@ -17,7 +17,9 @@
 package txpool
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"sync"
@@ -27,18 +29,32 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	libkzg "github.com/erigontech/erigon/common/crypto/kzg"
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/common/maphash"
 	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/node/gointerfaces"
 	"github.com/erigontech/erigon/node/gointerfaces/grpcutil"
 	"github.com/erigontech/erigon/node/gointerfaces/remoteproto"
 	"github.com/erigontech/erigon/node/gointerfaces/sentryproto"
+	"github.com/erigontech/erigon/node/gointerfaces/typesproto"
 )
 
 // errInternalDB wraps errors that originate from local DB lookups (not from the peer's data).
 // This prevents penalizing peers for our own internal failures.
 var errInternalDB = errors.New("internal db error")
+
+// announceInfo records the (type, size) that a peer promised for a given hash
+// in an eth/68 NewPooledTransactionHashes announcement. We keep the peer id so
+// that a later PooledTransactions reply from a different peer does not clobber
+// the check (two peers can legitimately announce the same hash).
+type announceInfo struct {
+	peerHash uint64 // maphash of the announcing peer's 64-byte id
+	txnType  byte
+	size     uint32
+}
 
 // Fetch connects to sentry and implements eth/66 protocol regarding the transaction
 // messages. It tries to "prime" the sentry with StatusData message containing given
@@ -56,6 +72,7 @@ type Fetch struct {
 	sentryClients            []sentryproto.SentryClient // sentry clients that will be used for accessing the network
 	stateChangesParseCtxLock sync.Mutex
 	pooledTxnsParseCtxLock   sync.Mutex
+	announcements            *maphash.LRU[announceInfo] // announceKey(txHash, peerHash) -> announced (type, size) from that peer
 	logger                   log.Logger
 }
 
@@ -77,6 +94,11 @@ func NewFetch(
 	opts ...Option,
 ) *Fetch {
 	options := applyOpts(opts...)
+	// 64k entries is roughly 1–2 hours of mainnet announcement traffic — more
+	// than the fetcher's own working window (announce → POOLED_TRANSACTIONS
+	// reply is typically seconds, at worst minutes), and bounded so a DoSing
+	// peer spamming unique hashes can't grow this unboundedly.
+	announcements, _ := maphash.NewLRU[announceInfo](64 * 1024)
 	f := &Fetch{
 		ctx:                  ctx,
 		sentryClients:        sentryClients,
@@ -85,6 +107,7 @@ func NewFetch(
 		stateChangesClient:   stateChangesClient,
 		stateChangesParseCtx: NewTxnParseContext(chainID).ChainIDRequired(), //TODO: change ctx if rules changed
 		pooledTxnsParseCtx:   NewTxnParseContext(chainID).ChainIDRequired(),
+		announcements:        announcements,
 		wg:                   options.p2pFetcherWg,
 		logger:               logger,
 	}
@@ -92,6 +115,125 @@ func NewFetch(
 	f.stateChangesParseCtx.ValidateRLP(f.pool.ValidateSerializedTxn)
 
 	return f
+}
+
+// peerHash maps a peer's H512 id to the 64-bit hash we use as part of the
+// announcements LRU key and as a sanity check on lookup. The check is
+// probabilistic (64-bit birthday ~4B peers before a collision is likely) —
+// fine in practice, the worst case is a missed kick for a different peer
+// that hash-collides with the announcer.
+func peerHash(pid *typesproto.H512) uint64 {
+	b := gointerfaces.ConvertH512ToHash(pid)
+	return maphash.Hash(b[:])
+}
+
+// announceKey builds the composite (txHash, peerHash) LRU key used to record
+// and look up announcements. Keying by peer as well as hash prevents a second
+// announcer of the same hash from clobbering the first's entry — without it,
+// a later benign announcement can exonerate an earlier lying peer by making
+// checkPooledTxnAnnouncement bail out on a mismatched peerHash.
+func announceKey(txHash []byte, peerHash uint64) [40]byte {
+	var k [40]byte
+	copy(k[:32], txHash)
+	binary.BigEndian.PutUint64(k[32:], peerHash)
+	return k
+}
+
+// recordAnnouncement remembers the (type, size) a peer promised for each
+// announced hash that also appears in `filter`. Used later to detect peers
+// that lie in their announcements (see checkPooledTxnAnnouncement).
+//
+// `filter` must be a subset of `hashes` preserving order — pass the result of
+// FilterKnownIdHashes so we only record entries for txs we're about to fetch;
+// entries for already-known hashes would otherwise sit unused in the LRU
+// until evicted, displacing announcements we actually care about. Pass nil
+// to record every hash.
+func (f *Fetch) recordAnnouncement(pid *typesproto.H512, txTypes []byte, sizes []uint32, hashes, filter []byte) {
+	if f.announcements == nil || len(txTypes) == 0 {
+		return
+	}
+	ph := peerHash(pid)
+	const hashSize = 32
+	fPos := 0
+	for i := range txTypes {
+		h := hashes[i*hashSize : (i+1)*hashSize]
+		if filter != nil {
+			if fPos >= len(filter) || !bytes.Equal(h, filter[fPos:fPos+hashSize]) {
+				continue
+			}
+			fPos += hashSize
+		}
+		k := announceKey(h, ph)
+		f.announcements.Set(k[:], announceInfo{peerHash: ph, txnType: txTypes[i], size: sizes[i]})
+	}
+}
+
+// announcedSizeSlack is the wiggle-room we allow between the size a peer
+// announces in eth/68 NewPooledTransactionHashes and the size it later
+// delivers. Matches go-ethereum's inline threshold of 8 in
+// eth/fetcher/tx_fetcher.go (|announced-delivered| > 8 drops the peer):
+// typed-tx RLP vs consensus-format size accounting has off-by-a-few-bytes
+// quirks in the wild, so a strict equality check produces false positives.
+// The devp2p BlobViolations hive test probes with a +10 byte mismatch, so
+// raising this above 8 silently disables the size check for that scenario.
+const announcedSizeSlack = 8
+
+// checkPooledTxnAnnouncement returns an error if the peer delivering `slot`
+// announced it earlier with a different type or a grossly different size
+// (see announcedSizeSlack). Unannounced txs (including those announced by a
+// different peer) are skipped — only a self-contradicting announcement is a
+// violation.
+func (f *Fetch) checkPooledTxnAnnouncement(pid *typesproto.H512, slot *TxnSlot) error {
+	if f.announcements == nil {
+		return nil
+	}
+	ph := peerHash(pid)
+	k := announceKey(slot.IDHash[:], ph)
+	info, ok := f.announcements.Get(k[:])
+	if !ok {
+		return nil
+	}
+	// Defence against a maphash collision — peer is part of the key, so on
+	// a clean hit info.peerHash must equal ph.
+	if info.peerHash != ph {
+		return nil
+	}
+	if info.txnType != slot.TxType() {
+		return fmt.Errorf("announced tx type %d != actual %d for hash %x", info.txnType, slot.TxType(), slot.IDHash[:])
+	}
+	sizeDiff := int64(info.size) - int64(slot.Size)
+	if sizeDiff < -announcedSizeSlack || sizeDiff > announcedSizeSlack {
+		return fmt.Errorf("announced tx size %d != actual %d for hash %x", info.size, slot.Size, slot.IDHash[:])
+	}
+	// One-shot: drop the entry so the same announcement can't be replayed.
+	f.announcements.Delete(k[:])
+	return nil
+}
+
+// checkBlobSidecar verifies EIP-4844 per-commitment invariants on a blob tx
+// wrapper that arrived from a peer. Returns an error when the sidecar's
+// commitments don't match the tx's blob_versioned_hashes — the peer that
+// delivered it gets penalized. Non-blob txs pass through unchecked.
+//
+// Callers must parse with wrappedWithBlobs=true (as TRANSACTIONS_66 and
+// POOLED_TRANSACTIONS_66 do), so a blob tx reaching this check is expected
+// to carry a sidecar. A blob tx with an empty sidecar is treated as a
+// protocol violation via the blob_versioned_hashes / BlobBundles count
+// mismatch below (blob txs must declare >=1 blob per EIP-4844).
+func (f *Fetch) checkBlobSidecar(slot *TxnSlot) error {
+	if slot == nil || slot.Txn == nil || slot.Txn.Type() != types.BlobTxType {
+		return nil
+	}
+	blobHashes := slot.Txn.GetBlobHashes()
+	if len(blobHashes) != len(slot.BlobBundles) {
+		return fmt.Errorf("blob_versioned_hashes count %d != blobs count %d", len(blobHashes), len(slot.BlobBundles))
+	}
+	for i := range slot.BlobBundles {
+		if libkzg.KZGToVersionedHash(slot.BlobBundles[i].Commitment) != libkzg.VersionedHash(blobHashes[i]) {
+			return fmt.Errorf("commitment[%d] does not match blob_versioned_hash[%d]", i, i)
+		}
+	}
+	return nil
 }
 
 func (f *Fetch) threadSafeParsePooledTxn(cb func(*TxnParseContext) error) error {
@@ -286,14 +428,28 @@ func (f *Fetch) receiveMessage(ctx context.Context, sentryClient sentryproto.Sen
 			return nil
 		}
 
-		// Skip duplicates using LRU cache with maphash to avoid string allocs
-		if _, seen := seenLRU.Get(req.Data); seen {
-			if f.wg != nil {
-				f.wg.Done()
+		// Skip duplicate tx-body messages (TRANSACTIONS_66, POOLED_TRANSACTIONS_66):
+		// blob-tx verification is the expensive work worth amortizing. We must NOT
+		// dedupe announcements (NEW_POOLED_TRANSACTION_HASHES_66/68) across peers —
+		// when one peer delivers a bad tx for an announced hash and gets kicked,
+		// the tx fetcher falls back to a different peer that announced the same
+		// hash, which only works if each peer's announcement is actually processed.
+		// Same-peer repeated announcements are not deduped here either: the
+		// dominant cost per announcement (a FilterKnownIdHashes call plus one
+		// GET_POOLED_TRANSACTIONS_66 per unknown hash) is self-limiting — once
+		// the pool has ingested the tx, FilterKnownIdHashes returns empty for
+		// all subsequent announcements. Per-peer announcement spam before that
+		// is a peer-reputation concern, not a fetcher dedup one.
+		switch req.Id {
+		case sentryproto.MessageId_TRANSACTIONS_66, sentryproto.MessageId_POOLED_TRANSACTIONS_66:
+			if _, seen := seenLRU.Get(req.Data); seen {
+				if f.wg != nil {
+					f.wg.Done()
+				}
+				continue
 			}
-			continue
+			seenLRU.Set(req.Data, struct{}{})
 		}
-		seenLRU.Set(req.Data, struct{}{})
 
 		batchLock.Lock()
 		batch = append(batch, req)
@@ -363,7 +519,7 @@ func (f *Fetch) handleInboundMessageWithTx(ctx context.Context, tx kv.Tx, req *s
 			sentryClient.PenalizePeer(ctx, &sentryproto.PenalizePeerRequest{PeerId: req.PeerId, Penalty: sentryproto.PenaltyKind_Kick})
 			return nil
 		}
-		_, _, hashes, _, err := parseAnnouncements(req.Data, 0)
+		txTypes, sizes, hashes, _, err := parseAnnouncements(req.Data, 0)
 		if err != nil {
 			f.logger.Debug("[txpool] penalizing peer for malformed NewPooledTransactionHashes68", "peer", req.PeerId, "err", err)
 			sentryClient.PenalizePeer(ctx, &sentryproto.PenalizePeerRequest{PeerId: req.PeerId, Penalty: sentryproto.PenaltyKind_Kick})
@@ -374,6 +530,10 @@ func (f *Fetch) handleInboundMessageWithTx(ctx context.Context, tx kv.Tx, req *s
 		if err != nil {
 			return err
 		}
+		// Record only for unknown hashes — a POOLED_TRANSACTIONS_66 reply
+		// won't come back for already-known txs, so entries for them would
+		// just sit unused in the LRU until evicted.
+		f.recordAnnouncement(req.PeerId, txTypes, sizes, hashes, unknownHashes)
 
 		if len(unknownHashes) > 0 {
 			var encodedRequest []byte
@@ -491,6 +651,25 @@ func (f *Fetch) handleInboundMessageWithTx(ctx context.Context, tx kv.Tx, req *s
 			}
 		default:
 			return fmt.Errorf("unexpected message: %s", req.Id.String())
+		}
+		// Post-parse peer-behaviour checks. checkPooledTxnAnnouncement only
+		// applies to the POOLED_TRANSACTIONS_66 (pull) path since TRANSACTIONS_66
+		// has no prior announcement to compare against; checkBlobSidecar applies
+		// to both because a peer can ship a blob-tx wrapper with mismatched
+		// commitments via either message and must be kicked either way.
+		for i := range txns.Txns {
+			if req.Id == sentryproto.MessageId_POOLED_TRANSACTIONS_66 {
+				if err := f.checkPooledTxnAnnouncement(req.PeerId, txns.Txns[i]); err != nil {
+					f.logger.Debug("[txpool] penalizing peer for mismatched tx announcement", "peer", req.PeerId, "err", err)
+					sentryClient.PenalizePeer(ctx, &sentryproto.PenalizePeerRequest{PeerId: req.PeerId, Penalty: sentryproto.PenaltyKind_Kick})
+					return nil
+				}
+			}
+			if err := f.checkBlobSidecar(txns.Txns[i]); err != nil {
+				f.logger.Debug("[txpool] penalizing peer for bad blob sidecar", "peer", req.PeerId, "err", err)
+				sentryClient.PenalizePeer(ctx, &sentryproto.PenalizePeerRequest{PeerId: req.PeerId, Penalty: sentryproto.PenaltyKind_Kick})
+				return nil
+			}
 		}
 		if len(txns.Txns) == 0 {
 			return nil

--- a/txnprovider/txpool/fetch_test.go
+++ b/txnprovider/txpool/fetch_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/erigontech/erigon/common/u256"
 	"github.com/erigontech/erigon/db/kv/dbcfg"
 	"github.com/erigontech/erigon/db/kv/memdb"
+	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/node/direct"
 	"github.com/erigontech/erigon/node/gointerfaces"
 	"github.com/erigontech/erigon/node/gointerfaces/remoteproto"
@@ -510,6 +511,150 @@ func TestOversizedHashAnnouncement(t *testing.T) {
 			require.NoError(t, err, "oversized announcement should be handled gracefully")
 		})
 	}
+}
+
+// TestCheckPooledTxnAnnouncement verifies that a peer delivering a tx whose
+// type or size does not match what it previously announced is flagged, while
+// mismatches from an unrelated peer or without a prior announcement are not.
+func TestCheckPooledTxnAnnouncement(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	ctrl := gomock.NewController(t)
+	sentryServer := sentryproto.NewMockSentryServer(ctrl)
+	pool := NewMockPool(ctrl)
+
+	m := NewMockSentry(ctx, sentryServer)
+	sentryClient, err := direct.NewSentryClientDirect(direct.ETH68, m, nil)
+	require.NoError(t, err)
+
+	fetch := NewFetch(ctx, []sentryproto.SentryClient{sentryClient}, pool, nil, nil, u256.N1, log.New())
+
+	otherPeer := gointerfaces.ConvertHashToH512([64]byte{0xfe, 0xed})
+
+	hash := [32]byte{0xaa, 0xbb}
+	slot := &TxnSlot{IDHash: hash, Size: 200, Txn: &types.DynamicFeeTransaction{}}
+	// No announcement yet — must be a no-op.
+	require.NoError(t, fetch.checkPooledTxnAnnouncement(peerID, slot))
+
+	// Record an announcement: peer promised (type=DynamicFee, size=200).
+	// Tests pass nil filter to record every announced hash.
+	fetch.recordAnnouncement(peerID, []byte{types.DynamicFeeTxType}, []uint32{200}, hash[:], nil)
+
+	// Same peer, matching (type, size) — ok.
+	require.NoError(t, fetch.checkPooledTxnAnnouncement(peerID, slot))
+
+	// After a successful match the entry is consumed; re-announce for further checks.
+	fetch.recordAnnouncement(peerID, []byte{types.DynamicFeeTxType}, []uint32{200}, hash[:], nil)
+
+	// Same peer, mismatching type (announcement says DynamicFee but we deliver Legacy).
+	badTypeSlot := &TxnSlot{IDHash: hash, Size: 200, Txn: &types.LegacyTx{}}
+	require.Error(t, fetch.checkPooledTxnAnnouncement(peerID, badTypeSlot),
+		"peer delivering wrong type should be flagged")
+
+	// After the mismatch, re-announce and check the size path.
+	fetch.recordAnnouncement(peerID, []byte{types.DynamicFeeTxType}, []uint32{200}, hash[:], nil)
+	badSizeSlot := &TxnSlot{IDHash: hash, Size: 999, Txn: &types.DynamicFeeTransaction{}}
+	require.Error(t, fetch.checkPooledTxnAnnouncement(peerID, badSizeSlot),
+		"peer delivering wrong size should be flagged")
+
+	// Size within the 8-byte slack is not a violation — RLP vs consensus-format
+	// accounting can disagree by a handful of bytes for legacy/typed txs. The
+	// check is symmetric: both announced-larger-than-delivered and
+	// announced-smaller-than-delivered are bounded by the same slack.
+	fetch.recordAnnouncement(peerID, []byte{types.DynamicFeeTxType}, []uint32{208}, hash[:], nil)
+	require.NoError(t, fetch.checkPooledTxnAnnouncement(peerID, slot),
+		"size diff of +8 bytes should be within slack")
+	fetch.recordAnnouncement(peerID, []byte{types.DynamicFeeTxType}, []uint32{209}, hash[:], nil)
+	require.Error(t, fetch.checkPooledTxnAnnouncement(peerID, slot),
+		"size diff of +9 bytes should exceed slack")
+	fetch.recordAnnouncement(peerID, []byte{types.DynamicFeeTxType}, []uint32{192}, hash[:], nil)
+	require.NoError(t, fetch.checkPooledTxnAnnouncement(peerID, slot),
+		"size diff of -8 bytes should be within slack")
+	fetch.recordAnnouncement(peerID, []byte{types.DynamicFeeTxType}, []uint32{191}, hash[:], nil)
+	require.Error(t, fetch.checkPooledTxnAnnouncement(peerID, slot),
+		"size diff of -9 bytes should exceed slack")
+
+	// Different peer delivering the same hash must not be penalized based on
+	// another peer's announcement.
+	fetch.recordAnnouncement(peerID, []byte{types.DynamicFeeTxType}, []uint32{200}, hash[:], nil)
+	require.NoError(t, fetch.checkPooledTxnAnnouncement(otherPeer, badTypeSlot))
+
+	// Filter subset: an announcement for a hash not in the filter is skipped.
+	//
+	//  - hashA is in the filter — its (type, size) should be recorded.
+	//  - hashB is absent from the filter — its entry must NOT be recorded,
+	//    so a subsequent check for hashB from the same peer is a no-op.
+	hashA := [32]byte{0xcc, 0x01}
+	hashB := [32]byte{0xcc, 0x02}
+	both := append(append([]byte{}, hashA[:]...), hashB[:]...)
+	filter := hashA[:] // only hashA survives FilterKnownIdHashes
+	fetch.recordAnnouncement(peerID,
+		[]byte{types.DynamicFeeTxType, types.DynamicFeeTxType},
+		[]uint32{200, 200}, both, filter)
+	require.NoError(t, fetch.checkPooledTxnAnnouncement(peerID,
+		&TxnSlot{IDHash: hashB, Size: 999, Txn: &types.DynamicFeeTransaction{}}),
+		"hashB was filtered out at record time, so no mismatch should fire")
+	require.Error(t, fetch.checkPooledTxnAnnouncement(peerID,
+		&TxnSlot{IDHash: hashA, Size: 999, Txn: &types.DynamicFeeTransaction{}}),
+		"hashA was recorded, so the wrong-size delivery must fire")
+
+	// Multi-peer clobber regression: peer A lies in its announcement, peer B
+	// then announces the same hash with correct metadata. Without a composite
+	// (hash, peer) LRU key, B's entry would overwrite A's and A's lie would
+	// slip through the check. Both announcements must survive so A's delivery
+	// is still matched against A's own record.
+	//
+	// Concretely: A announces (DynamicFee, wrong size), B announces
+	// (DynamicFee, correct size), A then delivers the real 200-byte tx. The
+	// mismatch against A's own announcement must still fire.
+	hashC := [32]byte{0xdd, 0x01}
+	fetch.recordAnnouncement(peerID, []byte{types.DynamicFeeTxType}, []uint32{999}, hashC[:], nil)
+	fetch.recordAnnouncement(otherPeer, []byte{types.DynamicFeeTxType}, []uint32{200}, hashC[:], nil)
+	require.Error(t, fetch.checkPooledTxnAnnouncement(peerID,
+		&TxnSlot{IDHash: hashC, Size: 200, Txn: &types.DynamicFeeTransaction{}}),
+		"peer A's own lying announcement must still match A's delivery after B also announces")
+	// Peer B's delivery against its own (truthful) announcement is clean.
+	require.NoError(t, fetch.checkPooledTxnAnnouncement(otherPeer,
+		&TxnSlot{IDHash: hashC, Size: 200, Txn: &types.DynamicFeeTransaction{}}),
+		"peer B's matching delivery must not fire")
+}
+
+// TestCheckBlobSidecar verifies that a blob tx whose wrapper commitments do not
+// match its blob_versioned_hashes is flagged, while a correctly-formed wrapper
+// and a non-blob tx pass through cleanly.
+func TestCheckBlobSidecar(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	ctrl := gomock.NewController(t)
+	sentryServer := sentryproto.NewMockSentryServer(ctrl)
+	pool := NewMockPool(ctrl)
+	m := NewMockSentry(ctx, sentryServer)
+	sentryClient, err := direct.NewSentryClientDirect(direct.ETH68, m, nil)
+	require.NoError(t, err)
+	fetch := NewFetch(ctx, []sentryproto.SentryClient{sentryClient}, pool, nil, nil, u256.N1, log.New())
+
+	// Non-blob tx — unchecked.
+	require.NoError(t, fetch.checkBlobSidecar(&TxnSlot{Txn: &types.DynamicFeeTransaction{}}))
+
+	// Properly formed blob tx: a slot produced by makeBlobTxn() has both the
+	// inner BlobTx (with BlobVersionedHashes patched to match commitments) and
+	// the populated BlobBundles.
+	good := makeBlobTxn()
+	require.NoError(t, fetch.checkBlobSidecar(&good), "matching sidecar should pass")
+
+	// Corrupt a commitment so it no longer hashes to the versioned-hash.
+	bad := makeBlobTxn()
+	bad.BlobBundles[0].Commitment[0] ^= 0xff
+	require.Error(t, fetch.checkBlobSidecar(&bad), "mismatched commitment should be flagged")
+
+	// Blob tx arriving with no sidecar at all: the inner blob_versioned_hashes
+	// declares blobs but the wrapper delivers none. Treated as a protocol
+	// violation via the count-mismatch check (peer gets kicked).
+	missing := makeBlobTxn()
+	missing.BlobBundles = nil
+	require.Error(t, fetch.checkBlobSidecar(&missing), "blob tx with missing sidecar should be flagged")
 }
 
 // TestNoPenaltyOnInternalDBError verifies that when IdHashKnown returns a DB error


### PR DESCRIPTION
Cherry-pick of #20733 onto bal-devnet-3. Required by the eth/71 cherry-pick stack: PR #20794 includes a regression test (`TestAnswerGetBlockHeadersQuery_HashModeSkip`) that depends on the one-line forward-traversal fix in this PR.