### PR TITLE
db/state: reset reader on recsplit collision retry in SimpleAccessorBuilder

### DIFF
--- a/db/state/simple_accessor_builder.go
+++ b/db/state/simple_accessor_builder.go
@@ -192,6 +192,7 @@ func (s *SimpleAccessorBuilder) Build(ctx context.Context, decomp *seg.Decompres
 
 	defer iidq.reader.MadvNormal().DisableReadAhead()
 	for {
+		iidq.reader.Reset(0)
 		rs.SetProgress(p)
 		stream := iidq.GetStream(ctx)
 		defer stream.Close()

--- a/db/state/simple_accessor_builder.go
+++ b/db/state/simple_accessor_builder.go
@@ -24,6 +24,7 @@ type IndexInputDataQuery interface {
 	GetStream(ctx context.Context) stream.Trio[[]byte, uint64, uint64] // (word/value, index, offset)
 	GetBaseDataId() uint64
 	GetCount() uint64
+	Reset()
 	Close()
 }
 
@@ -192,7 +193,7 @@ func (s *SimpleAccessorBuilder) Build(ctx context.Context, decomp *seg.Decompres
 
 	defer iidq.reader.MadvNormal().DisableReadAhead()
 	for {
-		iidq.reader.Reset(0)
+		iidq.Reset()
 		rs.SetProgress(p)
 		stream := iidq.GetStream(ctx)
 		defer stream.Close()
@@ -263,6 +264,10 @@ func (d *DecompressorIndexInputDataQuery) Count() uint64 {
 
 func (d *DecompressorIndexInputDataQuery) Metadata() NumMetadata {
 	return d.m
+}
+
+func (d *DecompressorIndexInputDataQuery) Reset() {
+	d.reader.Reset(0)
 }
 
 func (d *DecompressorIndexInputDataQuery) Close() {


### PR DESCRIPTION
Adds `iidq.reader.Reset(0)` at the top of the retry loop in `SimpleAccessorBuilder.Build`, matching `buildVI` (5c7fe1b) and `buildHashMapAccessor`. Without it, retry iterations start with an exhausted `PagedReader` and feed zero keys to recsplit, producing a corrupt accessor index for forkable snapshots (headers/bodies).