### PR TITLE
engineapi: defer V3 payloadAttributes checks until head is VALID

### DIFF
--- a/.github/workflows/hive-versions.json
+++ b/.github/workflows/hive-versions.json
@@ -1,4 +1,4 @@
 {
-  "hive_ref": "684d4add6e5a3fd77c043e8b482c39a19f47cacf",
+  "hive_ref": "02075f473fcf91df834d09b6f3b05b59a530ea61",
   "execution_apis_ref": "8deedf1556015a54404fbfe735a74844715f4011"
 }

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -33,13 +33,7 @@ jobs:
             max-allowed-failures: 0
           - sim: ethereum/engine
             sim-limit: cancun
-            # 2 failures (not due to us, but due to Hive/Geth secondary client)
-            # will remove once resolved by STEEL team (these 2 tests are failing on all clients)
-            # see https://discord.com/channels/1359927674746835211/1410592782258540565/1462699469824065560
-            # 3rd allowed failure: "Blob Transaction Ordering, Multiple Clients (Cancun)" is a
-            # known flake under --sim.parallelism=8 due to timing/resource contention; passes
-            # cleanly in isolation (--sim.parallelism=1)
-            max-allowed-failures: 3
+            max-allowed-failures: 0
           - sim: ethereum/engine
             sim-limit: api
             max-allowed-failures: 0

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -33,7 +33,13 @@ jobs:
             max-allowed-failures: 0
           - sim: ethereum/engine
             sim-limit: cancun
-            max-allowed-failures: 0
+            # 2 failures (not due to us, but due to Hive/Geth secondary client)
+            # will remove once resolved by STEEL team (these 2 tests are failing on all clients)
+            # see https://discord.com/channels/1359927674746835211/1410592782258540565/1462699469824065560
+            # 3rd allowed failure: "Blob Transaction Ordering, Multiple Clients (Cancun)" is a
+            # known flake under --sim.parallelism=8 due to timing/resource contention; passes
+            # cleanly in isolation (--sim.parallelism=1)
+            max-allowed-failures: 3
           - sim: ethereum/engine
             sim-limit: api
             max-allowed-failures: 0

--- a/execution/engineapi/engine_server.go
+++ b/execution/engineapi/engine_server.go
@@ -195,23 +195,38 @@ func (s *EngineServer) isWithdrawalsPresenceValid(time uint64, withdrawals types
 	return withdrawals != nil
 }
 
-func (s *EngineServer) validatePayloadAttributes(version clparams.StateVersion, payloadAttributes *engine_types.PayloadAttributes) error {
-	if version < clparams.DenebVersion && payloadAttributes.ParentBeaconBlockRoot != nil {
-		return &engine_helpers.InvalidPayloadAttributesErr // Unexpected Beacon Root
-	}
-	if version >= clparams.DenebVersion && payloadAttributes.ParentBeaconBlockRoot == nil {
-		return &engine_helpers.InvalidPayloadAttributesErr // Beacon Root missing
-	}
-
+// validatePayloadAttributesPreFCU runs the request-level "wrong version of the
+// structure" checks defined by engine_forkchoiceUpdatedV2's Request section.
+// These are independent of fork-choice sync state and so MUST run before the
+// SYNCING short-circuit, otherwise a CL that sends mismatched-version attrs
+// would never see the spec-mandated -38003/-38005.
+func (s *EngineServer) validatePayloadAttributesPreFCU(version clparams.StateVersion, payloadAttributes *engine_types.PayloadAttributes) error {
 	timestamp := uint64(payloadAttributes.Timestamp)
-	if !s.config.IsCancun(timestamp) && version >= clparams.DenebVersion { // V3 before cancun
-		return &rpc.UnsupportedForkError{Message: "Unsupported fork"}
+	if version < clparams.DenebVersion && payloadAttributes.ParentBeaconBlockRoot != nil {
+		return &engine_helpers.InvalidPayloadAttributesErr // V1/V2 attrs MUST NOT carry parentBeaconBlockRoot
 	}
-	if s.config.IsCancun(timestamp) && version < clparams.DenebVersion { // Not V3 after cancun
+	if s.config.IsCancun(timestamp) && version < clparams.DenebVersion { // V1/V2 fcu at a Cancun timestamp
 		return &rpc.UnsupportedForkError{Message: "Unsupported fork"}
 	}
 	if version >= clparams.CapellaVersion && !s.isWithdrawalsPresenceValid(timestamp, payloadAttributes.Withdrawals) {
-		return &engine_helpers.InvalidPayloadAttributesErr
+		return &engine_helpers.InvalidPayloadAttributesErr // wrong V1/V2 withdrawals presence vs Shanghai
+	}
+	return nil
+}
+
+// validatePayloadAttributesPostFCU runs the checks the engine API spec defines
+// under "Extend point (8)" of engine_forkchoiceUpdatedV1, which the spec gates
+// on the head being VALID. They MUST run only after the SYNCING short-circuit,
+// so that an unknown head is reported as SYNCING (no -38003/-38005). See the
+// hive engine-cancun "Invalid PayloadAttributes, Missing BeaconRoot,
+// Syncing=True" tests for the canonical scenario.
+func (s *EngineServer) validatePayloadAttributesPostFCU(version clparams.StateVersion, payloadAttributes *engine_types.PayloadAttributes) error {
+	timestamp := uint64(payloadAttributes.Timestamp)
+	if version >= clparams.DenebVersion && payloadAttributes.ParentBeaconBlockRoot == nil {
+		return &engine_helpers.InvalidPayloadAttributesErr // V3 attrs require parentBeaconBlockRoot (cancun.md point 8.1)
+	}
+	if !s.config.IsCancun(timestamp) && version >= clparams.DenebVersion { // V3 outside Cancun window (cancun.md point 8.2)
+		return &rpc.UnsupportedForkError{Message: "Unsupported fork"}
 	}
 	if version >= clparams.GloasVersion && payloadAttributes.SlotNumber == nil {
 		return &engine_helpers.InvalidPayloadAttributesErr // SlotNumber required for Glamsterdam (EIP-7843)
@@ -725,13 +740,14 @@ func (s *EngineServer) forkchoiceUpdated(ctx context.Context, forkchoiceState *e
 		s.logger.Debug("[ForkChoiceUpdated] got quick payload status", "status", status.Status)
 	}
 
-	// Per the engine API spec, payloadAttributes must be validated against the
-	// fork schedule regardless of the fork-choice sync state. Doing this before
-	// the SYNCING short-circuit below lets the CL detect misconfigured attributes
-	// (e.g. fcuV2 with nil withdrawals at a Shanghai timestamp) even when the
-	// head is still syncing.
+	// engine_forkchoiceUpdatedV2's Request section makes the "wrong version of
+	// structure" rule independent of fork-choice sync state, so run those
+	// checks before the SYNCING short-circuit below. The remaining attribute
+	// checks live under "Extend point (8)" of engine_forkchoiceUpdatedV1,
+	// which the spec gates on the head being VALID — those run after the
+	// short-circuit so a SYNCING head is not turned into -38003/-38005.
 	if payloadAttributes != nil {
-		if err := s.validatePayloadAttributes(version, payloadAttributes); err != nil {
+		if err := s.validatePayloadAttributesPreFCU(version, payloadAttributes); err != nil {
 			return nil, err
 		}
 	}
@@ -739,6 +755,10 @@ func (s *EngineServer) forkchoiceUpdated(ctx context.Context, forkchoiceState *e
 	// No need for payload building
 	if payloadAttributes == nil || status.Status != engine_types.ValidStatus {
 		return &engine_types.ForkChoiceUpdatedResponse{PayloadStatus: status}, nil
+	}
+
+	if err := s.validatePayloadAttributesPostFCU(version, payloadAttributes); err != nil {
+		return nil, err
 	}
 
 	timestamp := uint64(payloadAttributes.Timestamp)

--- a/execution/engineapi/testing_api_test.go
+++ b/execution/engineapi/testing_api_test.go
@@ -1014,6 +1014,99 @@ func TestForkchoiceUpdatedV2ValidatesAttributesWhenSyncing(t *testing.T) {
 	require.Equal(t, -38003, err.(rpc.Error).ErrorCode())
 }
 
+// TestForkchoiceUpdatedV3DefersAttributesValidationWhenSyncing pins the
+// engine API spec rule that the "Extend point (8)" checks added by
+// engine_forkchoiceUpdatedV3 (cancun.md) — including the
+// `parentBeaconBlockRoot != null` requirement — only run when the head is
+// VALID. The hive `engine-cancun / Invalid PayloadAttributes, Missing
+// BeaconRoot, Syncing=True` test exercises exactly this: CLMocker sends
+// fcuV3 with nil parentBeaconBlockRoot to a head the EL hasn't seen, and
+// expects {payloadStatus: SYNCING} with no JSON-RPC error.
+func TestForkchoiceUpdatedV3DefersAttributesValidationWhenSyncing(t *testing.T) {
+	t.Parallel()
+
+	forkchoiceState := &engine_types.ForkChoiceState{
+		HeadHash:           common.Hash{0x1},
+		SafeBlockHash:      common.Hash{0x2},
+		FinalizedBlockHash: common.Hash{0x3},
+	}
+	stub := &stubExecutionModule{} // GetForkChoice/GetHeaderByHash stubs -> SYNCING
+	cfg := allForksChainConfig()
+	srv := NewEngineServer(
+		log.New(),
+		cfg,
+		stub,
+		engine_block_downloader.NewEngineBlockDownloader(
+			context.Background(), log.New(), stub, nil, nil, cfg, ethconfig.Sync{}, nil,
+		),
+		false,
+		false,
+		false,
+		true,
+		nil,
+		0,
+		0,
+	)
+	srv.test = true // avoid invoking downloader.StartDownloading on the SYNCING path
+
+	resp, err := srv.forkchoiceUpdated(context.Background(), forkchoiceState, &engine_types.PayloadAttributes{
+		Timestamp:             hexutil.Uint64(1001),
+		PrevRandao:            common.Hash{0xaa},
+		SuggestedFeeRecipient: common.HexToAddress("0x1111111111111111111111111111111111111111"),
+		Withdrawals:           make([]*types.Withdrawal, 0),
+		ParentBeaconBlockRoot: nil, // V3 attrs MUST carry it, but head is unknown -> SYNCING wins
+	}, clparams.DenebVersion)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, engine_types.SyncingStatus, resp.PayloadStatus.Status)
+	require.Nil(t, resp.PayloadId)
+}
+
+// TestForkchoiceUpdatedV3RejectsMissingBeaconRootWhenValid pins the other
+// half of the spec rule: when the head IS VALID, fcuV3 with a nil
+// parentBeaconBlockRoot MUST return -38003 (cancun.md point 8.1).
+func TestForkchoiceUpdatedV3RejectsMissingBeaconRootWhenValid(t *testing.T) {
+	t.Parallel()
+
+	forkchoiceState := &engine_types.ForkChoiceState{
+		HeadHash:           common.Hash{0x1},
+		SafeBlockHash:      common.Hash{0x2},
+		FinalizedBlockHash: common.Hash{0x3},
+	}
+	srv := NewEngineServer(
+		log.New(),
+		allForksChainConfig(),
+		&stubExecutionModule{
+			getForkChoiceFunc: func(_ context.Context) (execmodule.ForkChoiceState, error) {
+				return execmodule.ForkChoiceState{
+					HeadHash:      forkchoiceState.HeadHash,
+					SafeHash:      forkchoiceState.SafeBlockHash,
+					FinalizedHash: forkchoiceState.FinalizedBlockHash,
+				}, nil
+			},
+		},
+		nil,
+		false,
+		false,
+		false,
+		true,
+		nil,
+		0,
+		0,
+	)
+
+	resp, err := srv.forkchoiceUpdated(context.Background(), forkchoiceState, &engine_types.PayloadAttributes{
+		Timestamp:             hexutil.Uint64(1001),
+		PrevRandao:            common.Hash{0xaa},
+		SuggestedFeeRecipient: common.HexToAddress("0x1111111111111111111111111111111111111111"),
+		Withdrawals:           make([]*types.Withdrawal, 0),
+		ParentBeaconBlockRoot: nil,
+	}, clparams.DenebVersion)
+	require.Nil(t, resp)
+	require.Error(t, err)
+	require.Equal(t, -38003, err.(rpc.Error).ErrorCode())
+}
+
 func ptrUint64(v uint64) *uint64 {
 	return &v
 }


### PR DESCRIPTION
## Summary

- Hive `engine-cancun / Invalid PayloadAttributes, Missing BeaconRoot, Syncing=True (Cancun)` (test 376 of [this run](https://hive.ethpandaops.io/#/test/generic/1777279481-85063528cea3c966b05ec4fef21a48ad?testnumber=376)) was failing because Erigon validated `parentBeaconBlockRoot` before the SYNCING short-circuit and returned `-38003` when the head was unknown.
- Split `validatePayloadAttributes` into request-level (pre-FCU) and point-(8)-extension (post-FCU) halves so the spec-mandated ordering is preserved on both the SYNCING and VALID paths.
- The fix that motivated #20728 (hive `engine-withdrawals / Empty Withdrawals (Paris)`) still passes — its check (V2 wrong withdrawals presence) is in the pre-FCU group.

## Why

[`cancun.md`](https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md#engine_forkchoiceupdatedv3) says fcuV3 _extends_ point (8) of `engine_forkchoiceUpdatedV1`:

> 2. **Extend point (8)** of the `engine_forkchoiceUpdatedV1` specification by defining the following sequence of checks that **MUST** be run over `payloadAttributes`:
>     1. `payloadAttributes` matches the `PayloadAttributesV3` structure, return `-38003: Invalid payload attributes` on failure.
>     2. `payloadAttributes.timestamp` does not fall within the time frame of the Cancun fork, return `-38005: Unsupported fork` on failure.
>     3. `payloadAttributes.timestamp` is greater than `timestamp` of a block referenced by `forkchoiceState.headBlockHash`, return `-38003: Invalid payload attributes` on failure.

…and point (8) of V1 (paris.md) gates the entire processing flow on the head being `VALID`:

> 8. Client software **MUST** process provided `payloadAttributes` **after successfully applying the `forkchoiceState`** and **only if the payload referenced by `forkchoiceState.headBlockHash` is `VALID`**.

So with an unknown head, point (8) doesn't fire and the response is the SYNCING one in point (9). The `Syncing=True` family of hive cancun tests pin exactly this.

The pre-FCU "wrong version of structure" rule is different — it lives in the V2 [Request section](https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#engine_forkchoiceupdatedv2) and has no precondition on head state, which is why #20728 correctly moved it before the short-circuit.

## What changed

- `validatePayloadAttributesPreFCU` keeps the request-level checks: `parentBeaconBlockRoot` on V1/V2, V1/V2 fcu at a Cancun timestamp, withdrawals presence vs Shanghai. Runs before the SYNCING short-circuit.
- `validatePayloadAttributesPostFCU` runs the V3 point-(8) extensions: `parentBeaconBlockRoot != null` for V3+, Cancun-window for V3+, `SlotNumber != null` for V4+. Runs only when `status.Status == ValidStatus`.
- Two regression tests in `testing_api_test.go`:
  - `TestForkchoiceUpdatedV3DefersAttributesValidationWhenSyncing` — pins the hive `Syncing=True` scenario (no error, status=SYNCING).
  - `TestForkchoiceUpdatedV3RejectsMissingBeaconRootWhenValid` — pins the spec-mandated `-38003` when the head is VALID so the deferral can't regress into a permanent swallow.
