### PR TITLE
cmd/utils: add --only-history flag to rm-state command

### DIFF
--- a/cmd/integration/Readme.md
+++ b/cmd/integration/Readme.md
@@ -142,6 +142,19 @@ integration stage_custom_trace --domain=receipt,rcache,logtopics,logaddrs,traces
 integration stage_custom_trace --domain=receipt,rcache,logtopics,logaddrs,tracesfrom,tracesto
 ```
 
+## How to remove history snapshots only (keep domain data)
+
+```sh
+# Remove all history files (SnapHistory + SnapIdx + SnapAccessors) without touching domain data (.kv files):
+erigon snapshots rm-state --only-history
+
+# Remove a specific step range of history files only:
+erigon snapshots rm-state --only-history --step=0-900
+
+# Dry-run first to see what would be deleted:
+erigon snapshots rm-state --only-history --step=0-900 --dry-run
+```
+
 ## How to re-gen bor checkpoints
 
 ```sh

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -323,6 +323,7 @@ var snapshotCommand = cli.Command{
 				&cli.BoolFlag{Name: "recentStep", Aliases: []string{"latest", "latestStep", "recent"}, Usage: "remove minimal possible recent/latest files: and Domain and History. Useful when have 1 corrupted recent file"},
 				&cli.BoolFlag{Name: "dry-run"},
 				&cli.StringSliceFlag{Name: "domain"},
+				&cli.BoolFlag{Name: "only-history", Aliases: []string{"history"}, Usage: "remove only history files (SnapHistory+SnapIdx), not domain data"},
 			},
 			),
 		},
@@ -700,6 +701,7 @@ type DeleteStateSnapshotsArgs struct {
 	DryRun                 bool
 	StepRange              string
 	OnlyDomain             bool
+	OnlyHistory            bool
 	DomainNames            []string
 }
 
@@ -729,6 +731,8 @@ func DeleteStateSnapshots(args DeleteStateSnapshotsArgs) error {
 	scanDirs := []string{dirs.SnapIdx, dirs.SnapHistory, dirs.SnapDomain, dirs.SnapAccessors, dirs.SnapForkable}
 	if args.OnlyDomain {
 		scanDirs = []string{dirs.SnapDomain}
+	} else if args.OnlyHistory {
+		scanDirs = []string{dirs.SnapHistory, dirs.SnapIdx}
 	}
 	for _, dirPath := range scanDirs {
 		filePaths, err := dir2.ListFiles(dirPath)
@@ -1035,6 +1039,7 @@ func doRmStateSnapshots(cliCtx *cli.Context) error {
 	stepRange := cliCtx.String("step")
 	domainNames := cliCtx.StringSlice("domain")
 	dryRun := cliCtx.Bool("dry-run")
+	onlyHistory := cliCtx.Bool("only-history")
 	promptUser := true // CLI should always prompt the user
 	return DeleteStateSnapshots(DeleteStateSnapshotsArgs{
 		Dirs:                   dirs,
@@ -1043,6 +1048,7 @@ func doRmStateSnapshots(cliCtx *cli.Context) error {
 		DryRun:                 dryRun,
 		StepRange:              stepRange,
 		DomainNames:            domainNames,
+		OnlyHistory:            onlyHistory,
 	})
 }
 

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -732,7 +732,7 @@ func DeleteStateSnapshots(args DeleteStateSnapshotsArgs) error {
 	if args.OnlyDomain {
 		scanDirs = []string{dirs.SnapDomain}
 	} else if args.OnlyHistory {
-		scanDirs = []string{dirs.SnapHistory, dirs.SnapIdx}
+		scanDirs = []string{dirs.SnapHistory, dirs.SnapIdx, dirs.SnapAccessors}
 	}
 	for _, dirPath := range scanDirs {
 		filePaths, err := dir2.ListFiles(dirPath)


### PR DESCRIPTION
Adds `--only-history` (alias `--history`) to `erigon seg rm-state`.

When set, restricts deletion to history files (`SnapHistory` + `SnapIdx`) only — leaving domain data (`.kv` files in `SnapDomain`, accessor files) untouched.

Useful when combined with `--step from-to` to prune old history without touching domain snapshots.