### PR TITLE
[wip] db/state, stagedsync: add agg.WarmupDB() to pre-warm OS page cache

### DIFF
--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -797,6 +797,37 @@ func (a *Aggregator) BuildMissedAccessorsInBackground(workers int) bool {
 	return true
 }
 
+// WarmupDB spawns one goroutine per MDBX table; each goroutine opens its own
+// read transaction and does a full sequential scan to pull pages into the OS
+// page cache. Returns immediately; use agg.wg to wait for completion.
+func (a *Aggregator) WarmupDB() {
+	for name, cfg := range a.db.AllTables() {
+		if cfg.IsDeprecated {
+			continue
+		}
+		name := name
+		a.wg.Add(1)
+		go func() {
+			defer a.wg.Done()
+			tx, err := a.db.BeginRo(a.ctx)
+			if err != nil {
+				return
+			}
+			defer tx.Rollback()
+			c, err := tx.Cursor(name)
+			if err != nil {
+				return
+			}
+			defer c.Close()
+			for k, _, err := c.First(); k != nil && err == nil; k, _, err = c.Next() {
+				if a.ctx.Err() != nil {
+					return
+				}
+			}
+		}()
+	}
+}
+
 type AggV3StaticFiles struct {
 	d    [kv.DomainLen]StaticFiles
 	ivfs []InvertedFiles

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -797,15 +797,11 @@ func (a *Aggregator) BuildMissedAccessorsInBackground(workers int) bool {
 	return true
 }
 
-// WarmupDB spawns one goroutine per MDBX table; each goroutine opens its own
-// read transaction and does a full sequential scan to pull pages into the OS
-// page cache. Returns immediately; use agg.wg to wait for completion.
 func (a *Aggregator) WarmupDB() {
 	for name, cfg := range a.db.AllTables() {
 		if cfg.IsDeprecated {
 			continue
 		}
-		name := name
 		a.wg.Add(1)
 		go func() {
 			defer a.wg.Done()
@@ -823,6 +819,9 @@ func (a *Aggregator) WarmupDB() {
 				if a.ctx.Err() != nil {
 					return
 				}
+			}
+			if err != nil {
+				a.logger.Warn("[agg] WarmupDB scan error", "table", name, "err", err)
 			}
 		}()
 	}

--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -129,7 +129,9 @@ func ExecV3(ctx context.Context,
 	}
 
 	agg := cfg.db.(dbstate.HasAgg).Agg().(*dbstate.Aggregator)
-	agg.WarmupDB()
+	if initialCycle {
+		agg.WarmupDB()
+	}
 	if isApplyingBlocks {
 		if initialCycle {
 			agg.PresetNonChainTipConcurrency()

--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -129,9 +129,7 @@ func ExecV3(ctx context.Context,
 	}
 
 	agg := cfg.db.(dbstate.HasAgg).Agg().(*dbstate.Aggregator)
-	if initialCycle {
-		agg.WarmupDB()
-	}
+	agg.WarmupDB()
 	if isApplyingBlocks {
 		if initialCycle {
 			agg.PresetNonChainTipConcurrency()

--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -129,6 +129,7 @@ func ExecV3(ctx context.Context,
 	}
 
 	agg := cfg.db.(dbstate.HasAgg).Agg().(*dbstate.Aggregator)
+	agg.WarmupDB()
 	if isApplyingBlocks {
 		if initialCycle {
 			agg.PresetNonChainTipConcurrency()


### PR DESCRIPTION
ExecV3 calls `agg.WarmupDB()` at startup.

`WarmupDB` spawns one goroutine per MDBX table. Each goroutine opens its own read-only transaction and does a full sequential scan via `cursor.Next()` to pull pages into the OS page cache. The method is non-blocking — it returns immediately, with goroutines tracked via `agg.wg`.