### PR TITLE
[wip] db/state, stagedsync: add agg.WarmupDB() to pre-warm OS page cache

### DIFF
--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -798,6 +798,7 @@ func (a *Aggregator) BuildMissedAccessors(ctx context.Context, workers int) erro
 }
 
 func (a *Aggregator) WarmupDB() {
+	started := time.Now()
 	for name, cfg := range a.db.AllTables() {
 		if cfg.IsDeprecated {
 			continue
@@ -805,6 +806,7 @@ func (a *Aggregator) WarmupDB() {
 		a.wg.Add(1)
 		go func() {
 			defer a.wg.Done()
+			t := time.Now()
 			tx, err := a.db.BeginRo(a.ctx)
 			if err != nil {
 				return
@@ -828,8 +830,17 @@ func (a *Aggregator) WarmupDB() {
 				default:
 				}
 			}
+			if took := time.Since(t); took > 1*time.Millisecond {
+				a.logger.Debug("[agg] WarmupDB table", "table", name, "took", took)
+			}
 		}()
 	}
+	go func() {
+		a.wg.Wait()
+		if took := time.Since(started); took > 1*time.Millisecond {
+			a.logger.Debug("[agg] WarmupDB done", "took", took)
+		}
+	}()
 }
 
 type AggV3StaticFiles struct {

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -817,13 +817,14 @@ func (a *Aggregator) WarmupDB() {
 			defer c.Close()
 			// .Next() does return zero-copy pointers to mmap without touching leaf pages of db's btree
 			// so basically it's branch-nodes of btree warmup
-			for k, _, err := c.First(); k != nil && err == nil; k, _, err = c.Next() {
+			for k, _, err := c.First(); k != nil; k, _, err = c.Next() {
+				if err != nil {
+					a.logger.Warn("[agg] WarmupDB scan error", "table", name, "err", err)
+					return
+				}
 				if a.ctx.Err() != nil {
 					return
 				}
-			}
-			if err != nil {
-				a.logger.Warn("[agg] WarmupDB scan error", "table", name, "err", err)
 			}
 		}()
 	}

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -830,7 +830,7 @@ func (a *Aggregator) WarmupDB() {
 				default:
 				}
 			}
-			if took := time.Since(t); took > 1*time.Millisecond {
+			if took := time.Since(t); took > 50*time.Millisecond {
 				a.logger.Debug("[agg] WarmupDB table", "table", name, "took", took)
 			}
 		}()

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -797,6 +797,38 @@ func (a *Aggregator) BuildMissedAccessors(ctx context.Context, workers int) erro
 	return nil
 }
 
+func (a *Aggregator) WarmupDB() {
+	for name, cfg := range a.db.AllTables() {
+		if cfg.IsDeprecated {
+			continue
+		}
+		a.wg.Add(1)
+		go func() {
+			defer a.wg.Done()
+			tx, err := a.db.BeginRo(a.ctx)
+			if err != nil {
+				return
+			}
+			defer tx.Rollback()
+			c, err := tx.Cursor(name)
+			if err != nil {
+				return
+			}
+			defer c.Close()
+			// .Next() does return zero-copy pointers to mmap without touching leaf pages of db's btree
+			// so basically it's branch-nodes of btree warmup
+			for k, _, err := c.First(); k != nil && err == nil; k, _, err = c.Next() {
+				if a.ctx.Err() != nil {
+					return
+				}
+			}
+			if err != nil {
+				a.logger.Warn("[agg] WarmupDB scan error", "table", name, "err", err)
+			}
+		}()
+	}
+}
+
 type AggV3StaticFiles struct {
 	d    [kv.DomainLen]StaticFiles
 	ivfs [kv.StandaloneIdxLen]InvertedFiles

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -822,8 +822,10 @@ func (a *Aggregator) WarmupDB() {
 					a.logger.Warn("[agg] WarmupDB scan error", "table", name, "err", err)
 					return
 				}
-				if a.ctx.Err() != nil {
+				select {
+				case <-a.ctx.Done():
 					return
+				default:
 				}
 			}
 		}()

--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -128,6 +128,7 @@ func ExecV3(ctx context.Context,
 	}
 
 	agg := cfg.db.(dbstate.HasAgg).Agg().(*dbstate.Aggregator)
+	agg.WarmupDB()
 	if isApplyingBlocks {
 		if initialCycle {
 			agg.PresetNonChainTipConcurrency()


### PR DESCRIPTION
ExecV3 calls `agg.WarmupDB()` at startup.

`WarmupDB` spawns one goroutine per MDBX table. Each goroutine opens its own read-only transaction and does a full sequential scan via `cursor.Next()` to pull pages into the OS page cache. The method is non-blocking — it returns immediately, with goroutines tracked via `agg.wg`.