### PR TITLE
integration: guard unwind boundaries

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -604,6 +604,10 @@ func stageSenders(db kv.TemporalRwDB, ctx context.Context, logger log.Logger) er
 
 	cfg := stagedsync.StageSendersCfg(chainConfig, sync.Cfg(), false /* badBlockHalt */, tmpdir, pm, br, nil /* hd */)
 	if unwind > 0 {
+		if unwind > s.BlockNumber {
+			return errors.New("cannot unwind past 0")
+		}
+
 		u := sync.NewUnwindState(stages.Senders, s.BlockNumber-unwind, s.BlockNumber, true, false)
 		if err = stagedsync.UnwindSendersStage(u, tx, cfg, ctx); err != nil {
 			return err
@@ -977,6 +981,10 @@ func stageTxLookup(db kv.TemporalRwDB, ctx context.Context, logger log.Logger) e
 	br, _ := blocksIO(db, logger)
 	cfg := stagedsync.StageTxLookupCfg(pm, dirs.Tmp, br)
 	if unwind > 0 {
+		if unwind > s.BlockNumber {
+			return errors.New("cannot unwind past 0")
+		}
+
 		u := sync.NewUnwindState(stages.TxLookup, s.BlockNumber-unwind, s.BlockNumber, true, false)
 		err = stagedsync.UnwindTxLookup(u, s, tx, cfg, ctx, logger)
 		if err != nil {

--- a/cmd/integration/commands/state_stages.go
+++ b/cmd/integration/commands/state_stages.go
@@ -200,6 +200,9 @@ func syncBySmallSteps(db kv.TemporalRwDB, builderConfig buildercfg.BuilderConfig
 	onlyOneUnwind := block == 0 && unwindEvery == 0 && unwind > 0
 	backward := unwindEvery < unwind
 	if onlyOneUnwind {
+		if unwind > execAtBlock {
+			return errors.New("cannot unwind past 0")
+		}
 		stopAt = progress(tx, stages.Execution) - unwind
 	} else if block > 0 && block < senderAtBlock {
 		stopAt = block
@@ -305,6 +308,9 @@ func syncBySmallSteps(db kv.TemporalRwDB, builderConfig buildercfg.BuilderConfig
 		if unwind == 0 {
 			continue
 		}
+		if unwind > execAtBlock {
+			return errors.New("cannot unwind past 0")
+		}
 
 		to := execAtBlock - unwind
 		if err := stateStages.UnwindTo(to, stagedsync.StagedUnwind, tx); err != nil {
@@ -322,7 +328,11 @@ func syncBySmallSteps(db kv.TemporalRwDB, builderConfig buildercfg.BuilderConfig
 
 		// allow backward loop
 		if unwind > 0 && unwindEvery > 0 {
-			stopAt -= unwind
+			if unwind > stopAt {
+				stopAt = 1
+			} else {
+				stopAt -= unwind
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Add `cannot unwind past 0` checks before sender and tx lookup stage unwind arithmetic.
- Guard `state_stages` one-shot and loop unwind paths before subtracting from unsigned block numbers.
- Clamp the backward-loop stop boundary at genesis to avoid uint64 underflow while preserving the existing integration command flow.