### PR TITLE
cmd/utils/app: fix seg reset not removing chaindata

### DIFF
--- a/cmd/utils/app/reset-datadir.go
+++ b/cmd/utils/app/reset-datadir.go
@@ -121,6 +121,7 @@ func resetCliAction(cliCtx *cli.Context) (err error) {
 	r := reset.Reset{
 		Dirs:                 &dirs,
 		RemoveUnknown:        removeLocal,
+		RemoveLocal:          removeLocal,
 		Logger:               logger,
 		PreverifiedSnapshots: cfg.Preverified.Items,
 		RemoveFunc: func(osName reset.OsFilePath) error {


### PR DESCRIPTION
- \`seg reset\` regressed in #18273: \`removeLocal\` from the CLI is wired into \`reset.Reset.RemoveUnknown\` but not \`RemoveLocal\`, which gates chaindata + Heimdall/PolygonBridge DB removal in \`db/datadir/reset/reset.go\`. Result: \`seg reset\` no longer touches chaindata at all.
- Library-level \`TestResetChaindata\` exists but sets \`RemoveLocal: true\` directly, so the CLI plumbing was uncovered.

closes https://github.com/erigontech/erigon/issues/20260