### PR TITLE
rpc: use library Close helper for websocket disconnect

### DIFF
--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -257,28 +257,7 @@ type wsConnAdapter struct {
 }
 
 func (a *wsConnAdapter) Close() error {
-	// Attempt a graceful WebSocket close handshake first, so the peer sees a clean
-	// 1000 (normal closure) instead of 1006 (abnormal). Keep the handshake fully async
-	// so server shutdown doesn't block per connection, and force-close after a bounded
-	// grace period if the peer doesn't complete the close promptly.
-	closeDone := make(chan struct{})
-	go func() {
-		defer close(closeDone)
-		_ = a.conn.Close(websocket.StatusNormalClosure, "")
-	}()
-
-	go func() {
-		timer := time.NewTimer(time.Second)
-		defer timer.Stop()
-
-		select {
-		case <-closeDone:
-		case <-timer.C:
-			_ = a.conn.CloseNow()
-		}
-	}()
-
-	return nil
+	return a.conn.Close(websocket.StatusNormalClosure, "")
 }
 
 func (a *wsConnAdapter) SetWriteDeadline(t time.Time) error {


### PR DESCRIPTION
## Summary

Follow-up to #20788. Address review feedback from @anacrolix:

> I thought there was a helper in the websocket library for this so you don't need to spin up a bunch of timers and goroutines?

The `coder/websocket` `Conn.Close(code, reason)` method already performs the close handshake with bounded internal timeouts (5s write, 5s read), so the manual goroutine + timer plumbing in `wsConnAdapter.Close` is redundant. Replace it with a direct call.

The existing `TestWebsocketServerGracefulClose` test still passes — clients see a clean `StatusNormalClosure` (1000) instead of `StatusAbnormalClosure` (1006).

## Test plan

- [x] `go test ./rpc/ -run Websocket` — all pass
- [x] `make lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)