### PR TITLE
[bal-devnet-3] --exec.no-prune now disables all DB pruning

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1177,7 +1177,7 @@ var (
 	}
 	ExecNoPruneFlag = cli.BoolFlag{
 		Name:  "exec.no-prune",
-		Usage: "Disable state-aggregator pruning of historical steps (equivalent to NO_PRUNE=true). Diagnostic / perf-comparison use only.",
+		Usage: "Disable all DB pruning: state-aggregator (Domain/InvertedIndex/forkable) plus stage-level pruning (Execution: ChangeSets3/BlockAccessList; TxLookup; WitnessProcessing; Snapshots: PruneAncientBlocks/canonical markers/retirement) (equivalent to NO_PRUNE=true). Diagnostic / perf-comparison use only.",
 		Value: false,
 	}
 )

--- a/execution/stagedsync/no_prune_test.go
+++ b/execution/stagedsync/no_prune_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package stagedsync
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/dbg"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/dbcfg"
+	"github.com/erigontech/erigon/db/kv/memdb"
+	"github.com/erigontech/erigon/execution/stagedsync/stages"
+)
+
+// TestNoPruneSkipsAllPruneStages verifies that when --exec.no-prune is set
+// (dbg.NoPrune() == true), each staged-sync prune entrypoint is a no-op
+// against the MDBX tables it would otherwise delete rows from.
+func TestNoPruneSkipsAllPruneStages(t *testing.T) {
+	orig := dbg.NoPrune()
+	t.Cleanup(func() { dbg.SetNoPrune(orig) })
+	dbg.SetNoPrune(true)
+
+	ctx := context.Background()
+	logger := log.New()
+
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	tx, err := db.BeginRw(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	// Seed rows in every table any of the prune stages would target.
+	type seedRow struct{ table, key, value string }
+	seeds := []seedRow{
+		{kv.ChangeSets3, "k1", "v1"},
+		{kv.ChangeSets3, "k2", "v2"},
+		{kv.BlockAccessList, "b1", "ba1"},
+		{kv.BlockAccessList, "b2", "ba2"},
+		{kv.TxLookup, "t1", "tl1"},
+		{kv.BorWitnesses, "w1", "wit1"},
+	}
+	for _, s := range seeds {
+		require.NoError(t, tx.Put(s.table, []byte(s.key), []byte(s.value)))
+	}
+	countRows := func(t *testing.T, table string) int {
+		c, err := tx.Cursor(table)
+		require.NoError(t, err)
+		defer c.Close()
+		n := 0
+		for k, _, err := c.First(); k != nil; k, _, err = c.Next() {
+			require.NoError(t, err)
+			n++
+		}
+		return n
+	}
+	tracked := []string{kv.ChangeSets3, kv.BlockAccessList, kv.TxLookup, kv.BorWitnesses}
+	pre := map[string]int{}
+	for _, table := range tracked {
+		pre[table] = countRows(t, table)
+		require.Greater(t, pre[table], 0, "expected seeded rows in %s", table)
+	}
+
+	// ForwardProgress is well past MaxReorgDepth so the inner rawdb.PruneTable /
+	// PruneSmallBatches calls would normally fire. Each prune function
+	// early-returns on dbg.NoPrune() before reading any cfg field, so zero-value
+	// cfgs are safe.
+	const forward uint64 = 10_000
+	require.NoError(t, PruneExecutionStage(ctx, &PruneState{ID: stages.Execution, ForwardProgress: forward}, tx, ExecuteBlockCfg{}, 0, logger))
+	require.NoError(t, PruneTxLookup(&PruneState{ID: stages.TxLookup, ForwardProgress: forward}, tx, TxLookupCfg{}, ctx, logger))
+	require.NoError(t, PruneWitnessProcessingStage(&PruneState{ID: stages.WitnessProcessing, ForwardProgress: forward}, tx, WitnessProcessingCfg{}, ctx, logger))
+	require.NoError(t, SnapshotsPrune(&PruneState{ID: stages.Snapshots, ForwardProgress: forward}, SnapshotsCfg{}, ctx, tx, logger))
+
+	for _, table := range tracked {
+		require.Equal(t, pre[table], countRows(t, table), "table %s lost rows under --exec.no-prune", table)
+	}
+}
+
+// TestNoPruneFlagBookkeeping confirms each prune stage still records its
+// PruneProgress when skipping work — otherwise the staged-sync state machine
+// would re-enter the prune step on every cycle.
+func TestNoPruneFlagBookkeeping(t *testing.T) {
+	orig := dbg.NoPrune()
+	t.Cleanup(func() { dbg.SetNoPrune(orig) })
+	dbg.SetNoPrune(true)
+
+	ctx := context.Background()
+	logger := log.New()
+
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	tx, err := db.BeginRw(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	const forward uint64 = 12_345
+	require.NoError(t, PruneExecutionStage(ctx, &PruneState{ID: stages.Execution, ForwardProgress: forward}, tx, ExecuteBlockCfg{}, 0, logger))
+	require.NoError(t, PruneTxLookup(&PruneState{ID: stages.TxLookup, ForwardProgress: forward}, tx, TxLookupCfg{}, ctx, logger))
+	require.NoError(t, PruneWitnessProcessingStage(&PruneState{ID: stages.WitnessProcessing, ForwardProgress: forward}, tx, WitnessProcessingCfg{}, ctx, logger))
+
+	for _, id := range []stages.SyncStage{stages.Execution, stages.TxLookup, stages.WitnessProcessing} {
+		got, err := stages.GetStagePruneProgress(tx, id)
+		require.NoError(t, err)
+		require.Equal(t, forward, got, "stage %s did not record PruneProgress under --exec.no-prune", id)
+	}
+}

--- a/execution/stagedsync/stage_execute.go
+++ b/execution/stagedsync/stage_execute.go
@@ -454,6 +454,9 @@ func UnwindExecutionStage(u *UnwindState, s *StageState, doms *execctx.SharedDom
 }
 
 func PruneExecutionStage(ctx context.Context, s *PruneState, tx kv.RwTx, cfg ExecuteBlockCfg, timeout time.Duration, logger log.Logger) (err error) {
+	if dbg.NoPrune() {
+		return s.Done(tx)
+	}
 	// on chain-tip:
 	//  - can prune only between blocks (without blocking blocks processing)
 	//  - need also leave some time to prune blocks

--- a/execution/stagedsync/stage_snapshots.go
+++ b/execution/stagedsync/stage_snapshots.go
@@ -427,6 +427,9 @@ func pruneCanonicalMarkers(ctx context.Context, tx kv.RwTx, blockReader services
 
 // SnapshotsPrune moving block data from db into snapshots, removing old snapshots (if --prune.* enabled)
 func SnapshotsPrune(s *PruneState, cfg SnapshotsCfg, ctx context.Context, tx kv.RwTx, logger log.Logger) (err error) {
+	if dbg.NoPrune() {
+		return nil
+	}
 	freezingCfg := cfg.blockReader.FreezingCfg()
 	if freezingCfg.ProduceE2 {
 		//TODO: initialSync maybe save files progress here

--- a/execution/stagedsync/stage_txlookup.go
+++ b/execution/stagedsync/stage_txlookup.go
@@ -201,6 +201,9 @@ func UnwindTxLookup(u *UnwindState, s *StageState, tx kv.RwTx, cfg TxLookupCfg, 
 }
 
 func PruneTxLookup(s *PruneState, tx kv.RwTx, cfg TxLookupCfg, ctx context.Context, logger log.Logger) (err error) {
+	if dbg.NoPrune() {
+		return s.Done(tx)
+	}
 	logPrefix := s.LogPrefix()
 	blockFrom := s.PruneProgress
 	if blockFrom == 0 {

--- a/execution/stagedsync/stage_witness_processing.go
+++ b/execution/stagedsync/stage_witness_processing.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
@@ -152,6 +153,9 @@ func UnwindWitnessProcessingStage(u *UnwindState, s *StageState, tx kv.RwTx, ctx
 
 // PruneWitnessProcessingStage handles pruning for witness processing
 func PruneWitnessProcessingStage(p *PruneState, tx kv.RwTx, cfg WitnessProcessingCfg, ctx context.Context, logger log.Logger) error {
+	if dbg.NoPrune() {
+		return p.Done(tx)
+	}
 	// Prune old witness data based on retention policy
 	if err := cleanupOldWitnesses(tx, p.ForwardProgress, logger); err != nil {
 		return err


### PR DESCRIPTION
## Summary

\`--exec.no-prune\` previously only gated the state-aggregator's pruning paths via \`dbg.NoPrune()\` (Domain/InvertedIndex in \`db/state/aggregator.go\`, forkable in \`db/state/forkable_agg.go\`). Stage-level pruning ran regardless:

- \`PruneExecutionStage\` was calling \`rawdb.PruneTable\` on \`kv.ChangeSets3\` and **\`kv.BlockAccessList\`**.
- \`PruneTxLookup\`, \`PruneWitnessProcessingStage\` and \`SnapshotsPrune\` (\`PruneAncientBlocks\`, \`pruneCanonicalMarkers\`, \`RetireBlocksInBackground\`, \`pruneBlockSnapshots\`) had no guard.

The most disruptive case for bal-devnet-3 testing: BAL rows were being deleted every step once \`ForwardProgress > MaxReorgDepth\`, even with the flag set.

## Fix

Add early-return guards on \`dbg.NoPrune()\` at the top of each stage prune entrypoint so the flag genuinely blocks every path that removes rows from MDBX. Each function still calls \`s.Done(tx)\` so the staged-sync state machine doesn't re-enter the prune step on every cycle.

Updated flag usage text to describe the wider semantic.

## Test plan

- [x] \`go test ./execution/stagedsync -run TestNoPrune\` — new \`no_prune_test.go\` seeds rows in \`kv.ChangeSets3\`, \`kv.BlockAccessList\`, \`kv.TxLookup\`, \`kv.BorWitnesses\`; runs all four prune entrypoints with \`NoPrune=true\`; asserts no rows deleted and \`PruneProgress\` is recorded.
- [x] \`make lint\` — clean.
- [x] \`make erigon\` — builds.