### PR TITLE
cmd/utils/app, db/integrity: add check-rcache-root-at-blk[-range] commands

### DIFF
--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -468,6 +468,47 @@ var snapshotCommand = cli.Command{
 			}),
 		},
 		{
+			Name: "check-rcache-root-at-blk",
+			Action: func(cliCtx *cli.Context) error {
+				logger := log.Root()
+				err := doCheckRCacheRootAtBlk(cliCtx, logger)
+				if err != nil {
+					log.Error("[check-rcache-root-at-blk] failure", "err", err)
+					return err
+				}
+				log.Info("[check-rcache-root-at-blk] success")
+				return nil
+			},
+			Description: "verify the receipt root at a given block by reconstructing receipts from RCache and comparing against the block header",
+			Flags: joinFlags([]cli.Flag{
+				&utils.DataDirFlag,
+				&cli.Uint64Flag{Name: "block", Usage: "block number to verify", Required: true},
+				&cli.BoolFlag{Name: "failFast", Value: true, Usage: "stop on first mismatch (otherwise log and continue)"},
+			}),
+		},
+		{
+			Name: "check-rcache-root-at-blk-range",
+			Action: func(cliCtx *cli.Context) error {
+				logger := log.Root()
+				err := doCheckRCacheRootAtBlkRange(cliCtx, logger)
+				if err != nil {
+					log.Error("[check-rcache-root-at-blk-range] failure", "err", err)
+					return err
+				}
+				log.Info("[check-rcache-root-at-blk-range] success")
+				return nil
+			},
+			Description: "verify receipt roots against RCache for a given [from,to) block range with optional sampling",
+			Flags: joinFlags([]cli.Flag{
+				&utils.DataDirFlag,
+				&cli.Uint64Flag{Name: "from", Usage: "block number from which to start verifying (default: 0)"},
+				&cli.Uint64Flag{Name: "to", Usage: "block number up to which to verify (exclusive); defaults to RCache domain tip"},
+				&cli.Int64Flag{Name: "seed", Usage: "random seed for block sampling (auto-generated if not set)"},
+				&cli.Float64Flag{Name: "sample", Usage: "fraction of blocks to check via pseudo-random sampling (0.0-1.0)", Value: 1.0},
+				&cli.BoolFlag{Name: "failFast", Value: true, Usage: "stop on first mismatch (otherwise log and continue)"},
+			}),
+		},
+		{
 			Name:        "verify-state",
 			Description: "verify correspondence between state snapshots (accounts, storage) and commitment snapshots",
 			Action: func(cliCtx *cli.Context) error {
@@ -1600,7 +1641,7 @@ func doIntegrity(cliCtx *cli.Context) error {
 		case integrity.RCacheNoDups:
 			return integrity.CheckRCacheNoDups(ctx, sc, db, blockReader, failFast)
 		case integrity.ReceiptRootIntegrity:
-			return integrity.CheckReceiptRootIntegrity(ctx, sc, db, blockReader, chainConfig, failFast)
+			return integrity.CheckReceiptRootIntegrity(ctx, sc, db, blockReader, chainConfig, failFast, logger)
 		case integrity.CommitmentRoot:
 			return integrity.CheckCommitmentRoot(ctx, db, blockReader, failFast, logger)
 		case integrity.CommitmentKvi:
@@ -1787,6 +1828,89 @@ func doCheckStateRootByHistory(cliCtx *cli.Context, logger log.Logger) error {
 	}
 	logger.Info("[check-commitment-hist-at-blk-range] sampling config", "seed", sc.Seed, "sampleRatio", sc.SampleRatio)
 	return integrity.CheckCommitmentHistAtBlkRange(ctx, sc, db, blockReader, from, to, logger)
+}
+
+func doCheckRCacheRootAtBlk(cliCtx *cli.Context, logger log.Logger) error {
+	ctx := cliCtx.Context
+	dirs := datadir.New(cliCtx.String(utils.DataDirFlag.Name))
+	chainDB := dbCfg(dbcfg.ChainDB, dirs.Chaindata).MustOpen()
+	defer chainDB.Close()
+	chainConfig := fromdb.ChainConfig(chainDB)
+	cfg := ethconfig.NewSnapCfg(false /*keepBlocks*/, true /*produceE2*/, true /*produceE3*/, chainConfig.ChainName)
+	res, clean, err := openSnaps(ctx, cfg, dirs, chainDB, logger)
+	if err != nil {
+		return err
+	}
+	defer clean()
+	blockRetire, agg := res.BlockRetire, res.Aggregator
+	defer blockRetire.MadvNormal().DisableReadAhead()
+	defer agg.MadvNormal().DisableReadAhead()
+	db, err := temporal.New(chainDB, agg)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	blockReader, _ := blockRetire.IO()
+	blockNum := cliCtx.Uint64("block")
+	failFast := cliCtx.Bool("failFast")
+	if err := integrity.CheckRCacheRootAtBlk(ctx, db, blockReader, chainConfig, blockNum, failFast, logger); err != nil {
+		return fmt.Errorf("checkRCacheRootAtBlk: %d, %w", blockNum, err)
+	}
+	return nil
+}
+
+func doCheckRCacheRootAtBlkRange(cliCtx *cli.Context, logger log.Logger) error {
+	ctx := cliCtx.Context
+	dirs := datadir.New(cliCtx.String(utils.DataDirFlag.Name))
+	chainDB := dbCfg(dbcfg.ChainDB, dirs.Chaindata).MustOpen()
+	defer chainDB.Close()
+	chainConfig := fromdb.ChainConfig(chainDB)
+	cfg := ethconfig.NewSnapCfg(false /*keepBlocks*/, true /*produceE2*/, true /*produceE3*/, chainConfig.ChainName)
+	res, clean, err := openSnaps(ctx, cfg, dirs, chainDB, logger)
+	if err != nil {
+		return err
+	}
+	defer clean()
+	blockRetire, agg := res.BlockRetire, res.Aggregator
+	defer blockRetire.MadvNormal().DisableReadAhead()
+	defer agg.MadvNormal().DisableReadAhead()
+	db, err := temporal.New(chainDB, agg)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	blockReader, _ := blockRetire.IO()
+
+	from := cliCtx.Uint64("from")
+	to := cliCtx.Uint64("to")
+	if !cliCtx.IsSet("to") {
+		tx, err := db.BeginTemporalRo(ctx)
+		if err != nil {
+			return err
+		}
+		defer tx.Rollback()
+		rcacheTip, _, err := blockReader.TxnumReader().FindBlockNum(ctx, tx, tx.Debug().DomainProgress(kv.RCacheDomain))
+		tx.Rollback()
+		if err != nil {
+			return err
+		}
+		to = rcacheTip + 1 // exclusive upper bound
+		logger.Info("[check-rcache-root-at-blk-range] auto-detected --to", "to", to)
+	}
+	var seed int64
+	if cliCtx.IsSet("seed") {
+		seed = cliCtx.Int64("seed")
+	} else {
+		seed = time.Now().UnixNano()
+	}
+	sampleRatio := cliCtx.Float64("sample")
+	sc, err := integrity.NewSamplerCfg(seed, sampleRatio)
+	if err != nil {
+		return err
+	}
+	failFast := cliCtx.Bool("failFast")
+	logger.Info("[check-rcache-root-at-blk-range] sampling config", "seed", sc.Seed, "sampleRatio", sc.SampleRatio)
+	return integrity.CheckRCacheRootAtBlkRange(ctx, sc, db, blockReader, chainConfig, from, to, failFast, logger)
 }
 
 func doVerifyState(cliCtx *cli.Context, logger log.Logger) error {

--- a/db/integrity/rcache_receipt_root.go
+++ b/db/integrity/rcache_receipt_root.go
@@ -29,15 +29,16 @@ import (
 )
 
 // CheckReceiptRootIntegrity verifies that receipts from RCache domain produce
-// receipt roots matching block headers for a range of blocks with sampling.
+// receipt roots matching block headers. It auto-detects the range
+// [Byzantium, rcacheTip] and delegates to CheckRCacheRootAtBlkRange.
 //
 // Pre-Byzantium blocks are skipped: their consensus receipt encoding includes
 // the 32-byte intermediate state root (PostState), which Erigon does not
 // compute or persist at execution time, so RCache cannot reconstruct the
 // canonical receipt root for those blocks.
-func CheckReceiptRootIntegrity(ctx context.Context, sc SamplerCfg, db kv.TemporalRoDB, blockReader services.FullBlockReader, cc *chain.Config, failFast bool) (err error) {
+func CheckReceiptRootIntegrity(ctx context.Context, sc SamplerCfg, db kv.TemporalRoDB, blockReader services.FullBlockReader, cc *chain.Config, failFast bool, logger log.Logger) (err error) {
 	defer func() {
-		log.Info("[integrity] ReceiptRootIntegrity: done", "err", err)
+		logger.Info("[integrity] ReceiptRootIntegrity: done", "err", err)
 	}()
 
 	txNumsReader := blockReader.TxnumReader()
@@ -49,30 +50,56 @@ func CheckReceiptRootIntegrity(ctx context.Context, sc SamplerCfg, db kv.Tempora
 	defer tx.Rollback()
 
 	rcacheDomainProgress := tx.Debug().DomainProgress(kv.RCacheDomain)
-	fromBlock := uint64(1)
-	if cc.ByzantiumBlock != nil && *cc.ByzantiumBlock > fromBlock {
-		fromBlock = *cc.ByzantiumBlock
-	}
-	toBlock, _, _ := txNumsReader.FindBlockNum(ctx, tx, rcacheDomainProgress)
+	rcacheTip, _, _ := txNumsReader.FindBlockNum(ctx, tx, rcacheDomainProgress)
 
 	if err := ValidateDomainProgress(ctx, db, kv.RCacheDomain, txNumsReader); err != nil {
 		return err
 	}
+	tx.Rollback()
 
-	if fromBlock > toBlock {
-		log.Info("[integrity] ReceiptRootIntegrity skipped (no post-Byzantium blocks in RCache)", "byzantium", fromBlock, "rcacheTip", toBlock)
-		return nil
-	}
-	log.Info("[integrity] ReceiptRootIntegrity starting", "fromBlock", fromBlock, "toBlock", toBlock)
-
-	return parallelChunkCheck(ctx, sc.NewSampler(), fromBlock, toBlock, db, blockReader, failFast, string(ReceiptRootIntegrity), ReceiptRootIntegrityRange)
+	return CheckRCacheRootAtBlkRange(ctx, sc, db, blockReader, cc, 1, rcacheTip+1, failFast, logger)
 }
 
-// ReceiptRootIntegrityRange verifies receipt roots for a range of blocks.
-// It opens a single ReceiptCacheV2Stream covering [fromBlock, toBlock] and
-// walks blocks in lockstep with the stream's txNum cursor, so we avoid one
+// CheckRCacheRootAtBlk verifies the receipt root for a single block by
+// reconstructing receipts from RCache and comparing against the block header.
+// Pre-Byzantium blocks cannot be verified (see CheckReceiptRootIntegrity); for
+// such a block this logs a warning and returns nil.
+func CheckRCacheRootAtBlk(ctx context.Context, db kv.TemporalRoDB, blockReader services.FullBlockReader, cc *chain.Config, blockNum uint64, failFast bool, logger log.Logger) error {
+	if cc.ByzantiumBlock != nil && blockNum < *cc.ByzantiumBlock {
+		logger.Warn("[integrity] check-rcache-root-at-blk: skipping pre-Byzantium block (no PostState in RCache)",
+			"block", blockNum, "byzantium", *cc.ByzantiumBlock)
+		return nil
+	}
+	return checkRCacheRootAtBlkChunk(ctx, blockNum, blockNum, db, blockReader, failFast)
+}
+
+// CheckRCacheRootAtBlkRange verifies receipt roots over [from, to) using
+// sampling. Pre-Byzantium blocks are skipped; if `from` falls below Byzantium
+// it is clamped up with a warning.
+func CheckRCacheRootAtBlkRange(ctx context.Context, sc SamplerCfg, db kv.TemporalRoDB, blockReader services.FullBlockReader, cc *chain.Config, from, to uint64, failFast bool, logger log.Logger) error {
+	if from >= to {
+		logger.Info("[integrity] check-rcache-root-at-blk-range: empty range, skipping", "from", from, "to", to)
+		return nil
+	}
+	if cc.ByzantiumBlock != nil && from < *cc.ByzantiumBlock {
+		byzantium := *cc.ByzantiumBlock
+		logger.Warn("[integrity] check-rcache-root-at-blk-range: clamping from to Byzantium (pre-Byzantium blocks have no PostState in RCache)",
+			"from", from, "byzantium", byzantium)
+		from = byzantium
+		if from >= to {
+			logger.Info("[integrity] check-rcache-root-at-blk-range: range entirely pre-Byzantium, skipping", "to", to, "byzantium", byzantium)
+			return nil
+		}
+	}
+	logger.Info("[integrity] check-rcache-root-at-blk-range starting", "from", from, "to", to)
+	return parallelChunkCheck(ctx, sc.NewSampler(), from, to-1, db, blockReader, failFast, string(ReceiptRootIntegrity), checkRCacheRootAtBlkChunk)
+}
+
+// checkRCacheRootAtBlkChunk verifies receipt roots for an inclusive range of
+// blocks. It opens a single ReceiptCacheV2Stream covering [fromBlock, toBlock]
+// and walks blocks in lockstep with the stream's txNum cursor, so we avoid one
 // stream + one Min query per block.
-func ReceiptRootIntegrityRange(ctx context.Context, fromBlock, toBlock uint64, db kv.TemporalRoDB, blockReader services.FullBlockReader, failFast bool) (err error) {
+func checkRCacheRootAtBlkChunk(ctx context.Context, fromBlock, toBlock uint64, db kv.TemporalRoDB, blockReader services.FullBlockReader, failFast bool) (err error) {
 	if fromBlock > toBlock {
 		panic(fmt.Sprintf("fromBlock(%d) > toBlock(%d)", fromBlock, toBlock))
 	}
@@ -87,16 +114,16 @@ func ReceiptRootIntegrityRange(ctx context.Context, fromBlock, toBlock uint64, d
 
 	fromTxNum, err := txNumsReader.Min(ctx, tx, fromBlock)
 	if err != nil {
-		return fmt.Errorf("ReceiptRootIntegrity: failed to get minTxNum for block %d: %w", fromBlock, err)
+		return fmt.Errorf("check-rcache-root-at-blk: failed to get minTxNum for block %d: %w", fromBlock, err)
 	}
 	toTxNum, err := txNumsReader.Max(ctx, tx, toBlock)
 	if err != nil {
-		return fmt.Errorf("ReceiptRootIntegrity: failed to get maxTxNum for block %d: %w", toBlock, err)
+		return fmt.Errorf("check-rcache-root-at-blk: failed to get maxTxNum for block %d: %w", toBlock, err)
 	}
 
 	it, err := rawdb.ReceiptCacheV2Stream(tx, fromTxNum, toTxNum)
 	if err != nil {
-		return fmt.Errorf("ReceiptRootIntegrity: failed to stream receipts for blocks [%d,%d]: %w", fromBlock, toBlock, err)
+		return fmt.Errorf("check-rcache-root-at-blk: failed to stream receipts for blocks [%d,%d]: %w", fromBlock, toBlock, err)
 	}
 	defer it.Close()
 
@@ -107,17 +134,17 @@ func ReceiptRootIntegrityRange(ctx context.Context, fromBlock, toBlock uint64, d
 	}
 	header, err := blockReader.HeaderByNumber(ctx, tx, blockNum)
 	if err != nil {
-		return fmt.Errorf("ReceiptRootIntegrity: failed to get header for block %d: %w", blockNum, err)
+		return fmt.Errorf("check-rcache-root-at-blk: failed to get header for block %d: %w", blockNum, err)
 	}
 	if header == nil {
-		return fmt.Errorf("ReceiptRootIntegrity: missing header for block %d", blockNum)
+		return fmt.Errorf("check-rcache-root-at-blk: missing header for block %d", blockNum)
 	}
 	var receipts types.Receipts
 
 	verifyAndAdvance := func() error {
 		computedRoot := types.DeriveSha(receipts)
 		if computedRoot != header.ReceiptHash {
-			mismatch := fmt.Errorf("%w: ReceiptRootIntegrity: receipt root mismatch at block %d: computed=%s, header=%s",
+			mismatch := fmt.Errorf("%w: check-rcache-root-at-blk: receipt root mismatch at block %d: computed=%s, header=%s",
 				ErrIntegrity, blockNum, computedRoot, header.ReceiptHash)
 			if failFast {
 				return mismatch
@@ -135,10 +162,10 @@ func ReceiptRootIntegrityRange(ctx context.Context, fromBlock, toBlock uint64, d
 		}
 		header, err = blockReader.HeaderByNumber(ctx, tx, blockNum)
 		if err != nil {
-			return fmt.Errorf("ReceiptRootIntegrity: failed to get header for block %d: %w", blockNum, err)
+			return fmt.Errorf("check-rcache-root-at-blk: failed to get header for block %d: %w", blockNum, err)
 		}
 		if header == nil {
-			return fmt.Errorf("ReceiptRootIntegrity: missing header for block %d", blockNum)
+			return fmt.Errorf("check-rcache-root-at-blk: missing header for block %d", blockNum)
 		}
 		return nil
 	}
@@ -146,7 +173,7 @@ func ReceiptRootIntegrityRange(ctx context.Context, fromBlock, toBlock uint64, d
 	for it.HasNext() {
 		txNum, r, err := it.Next()
 		if err != nil {
-			return fmt.Errorf("ReceiptRootIntegrity: failed to read receipt: %w", err)
+			return fmt.Errorf("check-rcache-root-at-blk: failed to read receipt: %w", err)
 		}
 
 		for txNum > curMax && blockNum <= toBlock {


### PR DESCRIPTION
- Add `erigon snapshots check-rcache-root-at-blk --block <N>` to verify the receipt root for a single block by reconstructing receipts from the RCache domain and comparing against the block header.
- Add `erigon snapshots check-rcache-root-at-blk-range [--from --to --seed --sample --failFast]` for sampled verification over a `[from, to)` range; `--to` auto-detects from RCache domain tip when unset.
- Refactor `db/integrity/rcache_receipt_root.go`: split into `CheckRCacheRootAtBlk` (single block) and `CheckRCacheRootAtBlkRange` (sampled range), with `checkRCacheRootAtBlkChunk` as the internal per-chunk worker. The umbrella `CheckReceiptRootIntegrity` (action key `ReceiptRootIntegrity`) now auto-detects the range and delegates to `CheckRCacheRootAtBlkRange`.
- Pre-Byzantium blocks have no PostState in RCache; the single-block command logs a warning and returns nil, the range form clamps `from` up to Byzantium with a warning.

## Test plan
- [x] `make erigon integration` builds
- [x] `make lint` clean
- [x] `--help` shows both new commands and flags
- [x] Run `check-rcache-root-at-blk --block N` against a synced datadir
- [x] Run `check-rcache-root-at-blk-range --sample 0.01` against a synced datadir
- [x] Confirm `erigon snapshots integrity --check ReceiptRootIntegrity` still works (umbrella wrapper)