### PR TITLE
ci: bump docs-deploy actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -23,9 +23,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: npm
@@ -42,7 +42,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/site/build
 
@@ -55,4 +55,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

The `docs-deploy.yml` workflow was triggering deprecation warnings on every run because all four actions were pinned to versions that run on Node.js 20, which is being phased out on GitHub Actions runners.

**Timeline:**
- **June 2, 2026** — Node.js 24 becomes the forced default (33 days away)
- **September 16, 2026** — Node.js 20 removed from runners entirely

**Actions bumped:**

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-node` | v4 | v6 |
| `actions/upload-pages-artifact` | v3 | v5 |
| `actions/deploy-pages` | v4 | v5 |

No changes to build logic, Node.js version used for the Docusaurus build, or deployment configuration.

## Test plan
- [ ] Verify `Deploy Docs` workflow runs clean with no Node.js deprecation warnings after merge