### PR TITLE
[r3.4] db/state: 4x default step, transparent execution log, no key referencing

### DIFF
--- a/cmd/integration/commands/flags.go
+++ b/cmd/integration/commands/flags.go
@@ -117,7 +117,7 @@ func withYes(cmd *cobra.Command) {
 }
 
 func withSqueeze(cmd *cobra.Command) {
-	cmd.Flags().BoolVar(&squeeze, "squeeze", true, "use offset-pointers from commitment.kv to account.kv")
+	cmd.Flags().BoolVar(&squeeze, "squeeze", false, "use offset-pointers from commitment.kv to account.kv")
 }
 
 func withClearCommitment(cmd *cobra.Command) {

--- a/db/state/domain_committed.go
+++ b/db/state/domain_committed.go
@@ -35,7 +35,7 @@ import (
 	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
 )
 
-const minStepsForReferencing = 2
+const minStepsForReferencing = 99999
 
 // ValuesPlainKeyReferencingThresholdReached checks if the range from..to is large enough to use plain key referencing
 // Used for commitment branches - to store references to account and storage keys as shortened keys (file offsets)
@@ -43,6 +43,7 @@ func ValuesPlainKeyReferencingThresholdReached(stepSize, from, to uint64) bool {
 	return ((to-from)/stepSize)%minStepsForReferencing == 0
 }
 
+// Values can use key referencing in this range?
 func MayContainValuesPlainKeyReferencing(stepSize, from, to uint64) bool {
 	return ((to - from) / stepSize) > minStepsForReferencing
 }

--- a/db/state/squeeze.go
+++ b/db/state/squeeze.go
@@ -887,8 +887,7 @@ func RebuildCommitmentFiles(ctx context.Context, rwDb kv.TemporalRwDB, txNumsRea
 		stepsInShard := uint64(shardTo - shardFrom)
 		keysPerStep := totalKeys / stepsInShard // how many keys in just one step?
 
-		// shardStepsSize := kv.Step(2)
-		shardStepsSize := kv.Step(min(uint64(math.Pow(2, math.Log2(float64(stepsInShard)))), 16))
+		shardStepsSize := kv.Step(min(uint64(math.Pow(2, math.Log2(float64(stepsInShard)))), 64))
 		if uint64(shardStepsSize) != stepsInShard { // processing shard in several smaller steps
 			shardTo = shardFrom + shardStepsSize // if shard is quite big, we will process it in several steps
 		}

--- a/db/state/squeeze.go
+++ b/db/state/squeeze.go
@@ -1026,14 +1026,14 @@ func RebuildCommitmentFiles(ctx context.Context, rwDb kv.TemporalRwDB, txNumsRea
 
 	acRo.Close()
 
-	if !squeeze && !statecfg.Schema.CommitmentDomain.ReplaceKeysInValues {
+	if !squeeze {
 		return latestRoot, nil
 	}
 	logger.Info("[squeeze] starting")
 	a.recalcVisibleFiles(a.dirtyFilesEndTxNumMinimax())
 
 	logger.Info(fmt.Sprintf("[squeeze] latest root %x", latestRoot))
-	a.ForTestReplaceKeysInValues(kv.CommitmentDomain, true)
+	a.ForTestReplaceKeysInValues(kv.CommitmentDomain, squeeze)
 
 	actx := a.BeginFilesRo()
 	defer actx.Close()

--- a/db/state/statecfg/state_schema.go
+++ b/db/state/statecfg/state_schema.go
@@ -73,7 +73,7 @@ func Configure(Schema SchemaGen, a AggSetters, dirs datadir.Dirs, salt *uint32, 
 	return nil
 }
 
-const AggregatorSqueezeCommitmentValues = true
+const AggregatorSqueezeCommitmentValues = false
 const MaxNonFuriousDirtySpacePerTx = 64 * datasize.MB
 
 var dbgCommBtIndex = dbg.EnvBool("AGG_COMMITMENT_BT", false)


### PR DESCRIPTION
Cherry-picks 3 commits from `awskii/inc-shard-def-size` onto `release/3.4`:

- `eae5788ad2` 4x bigger default step (`db/state/statecfg/state_schema.go`)
- `90f79e1dc3` disable key referencing (`db/state/domain_committed.go`)
- `12229c3f73` more transparent execution (`db/state/squeeze.go`)

A 4th commit (`56b2c9b3d8 wire step flag`) is intentionally **skipped** — it depends on `ErigondbDomainStepsInFrozenFileFlag` / `LogErigondbDomainStepsInFrozenFileOverride` / aggregator builder method `ErigondbDomainStepsInFrozenFile()`, none of which exist on `release/3.4`. Wiring it would require backporting that whole API surface, which is out of scope here.

`go build ./db/state/... ./execution/commitment/... ./cmd/erigon/...` passes locally.

thats to be able to rebuild and run v3.4.0 without references.