### PR TITLE
rpc: cancel in-flight op on fatal read error to fix Call hang

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -608,9 +608,12 @@ func (c *Client) dispatch(codec ServerCodec, connCtx context.Context) {
 
 		case err := <-c.readErr:
 			conn.handler.logger.Trace("RPC connection read error", "err", err)
-			// A read error is fatal for the connection, and all pending requests must be cancelled, including any
-			// that might still be considered in-flight.
-			conn.close(err, lastOp)
+			// A read error is fatal for the connection, and all pending requests must be cancelled,
+			// including any that might still be considered in-flight. Once the resp channel is closed
+			// here, a later reconnect must not re-register this op (sending on a closed channel would
+			// panic), so clear lastOp too.
+			conn.close(err, nil)
+			lastOp = nil
 			reading = false
 
 		// Reconnect:
@@ -629,7 +632,10 @@ func (c *Client) dispatch(codec ServerCodec, connCtx context.Context) {
 			reading = true
 			conn = c.newClientConn(newcodec, connCtx)
 			// Re-register the in-flight request on the new handler because that's where it will be sent.
-			conn.handler.addRequestOp(lastOp)
+			// lastOp is nil if a fatal read error already cancelled the op — nothing to transfer then.
+			if lastOp != nil {
+				conn.handler.addRequestOp(lastOp)
+			}
 
 		// Send path:
 		case op := <-reqInitLock:

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -645,9 +645,11 @@ func (c *Client) dispatch(codec ServerCodec, connCtx context.Context) {
 			conn.handler.addRequestOp(op)
 
 		case err := <-c.reqSent:
-			if err != nil {
+			if err != nil && lastOp != nil {
 				// Remove response handlers for the last send. When the read loop
 				// goes down, it will signal all other current operations.
+				// lastOp can be nil if a fatal read error fired first and already
+				// cancelled the in-flight op.
 				conn.handler.removeRequestOp(lastOp)
 			}
 			// Let the next request in.


### PR DESCRIPTION
## Summary

- Fix a long-standing race in `Client.dispatch` (rpc/client.go) where a fatal `readErr` racing against `reqSent` could orphan the in-flight op's `resp` channel, leaving `op.wait` blocked forever on a channel nobody would ever close.
- The readErr handler was passing `lastOp` to `cancelAllRequests`, which deliberately *preserves* the inflight op's resp — directly contradicting the comment immediately above:
  ```
  // A read error is fatal for the connection, and all pending requests
  // must be cancelled, including any that might still be considered in-flight.
  ```
  Pass `nil` instead so the inflight op is cancelled too. Clear `lastOp` so a concurrent reconnect doesn't re-register an op whose resp is already closed (a later `op.resp <- batch` would panic). Nil-guard `addRequestOp` in the reconnect handler accordingly.

## Why

Surfaced as the long-running CI flake [#16875](https://github.com/erigontech/erigon/issues/16875) — `TestWebsocketLargeCall` hanging for ~59 minutes until the test timeout fires. From a recent failing run's goroutine dump:

- the test goroutine sat in `(*requestOp).wait` (rpc/client.go:144) for 58 minutes — i.e., past `c.send`, with the write already returned;
- `Client.dispatch` was idle in `select` (rpc/client.go:597) for the same 58 minutes;
- there were no goroutines inside `coder/websocket` Read or Write — both had returned.

The only way to reach that state is: `readErr` fired, `dispatch` processed it before/instead of `reqSent`'s `lastOp = nil`, `cancelAllRequests` skipped the in-flight op (because `lastOp` was passed as `inflightReq`), and so `op.resp` was never closed. The select between `c.readErr` and `c.reqSent` (which is buffered, size 1) is a coin flip — that's the flake.

## Test plan

- [x] `make lint` — clean
- [x] `make erigon integration` — builds
- [x] `go test -race ./rpc/...` — full suite passes
- [x] `go test -race -count=10 -run '^TestWebsocketLargeCall$' ./rpc/` — 10/10 pass
- [ ] CI race-tests / core-rpc — should be green

🤖 Generated with [Claude Code](https://claude.com/claude-code)