### PR TITLE
[wip] db/state: restore domain infinity merge default broken by #20705

### DIFF
--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -1638,14 +1638,10 @@ func (v *aggregatorVisible) stateMinimaxTxNum() uint64 {
 func (at *AggregatorRoTx) findMergeRange(maxEndTxNum, stepSize, stepsInFrozenFile uint64) *Ranges {
 	maxSpan := stepSize * stepsInFrozenFile
 
-	// --erigondb.domain.steps-in-frozen-file adjusts the domain cap only; history/II keep maxSpan.
-	domainMaxSpan := maxSpan
-	switch override := at.a.erigondbDomainStepsInFrozenFile; override {
-	case 0:
-		// no override
-	case config3.UnboundedDomainMerge:
-		domainMaxSpan = config3.UnboundedDomainMerge // no cap on domain merge
-	default:
+	// Domain .kv files use infinity merge by default (no cap), matching pre-#20705 behaviour.
+	// history/II keep maxSpan. --erigondb.domain.steps-in-frozen-file can impose an explicit cap.
+	domainMaxSpan := config3.UnboundedDomainMerge
+	if override := at.a.erigondbDomainStepsInFrozenFile; override != 0 && override != config3.UnboundedDomainMerge {
 		domainMaxSpan = stepSize * override
 	}
 

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -1636,10 +1636,10 @@ func (v *aggregatorVisible) stateMinimaxTxNum() uint64 {
 }
 
 func (at *AggregatorRoTx) findMergeRange(maxEndTxNum, stepSize, stepsInFrozenFile uint64) *Ranges {
-	maxSpan := stepSize * stepsInFrozenFile
+	historyMaxSpan := stepSize * stepsInFrozenFile
 
 	// Domain .kv files use infinity merge by default (no cap), matching pre-#20705 behaviour.
-	// history/II keep maxSpan. --erigondb.domain.steps-in-frozen-file can impose an explicit cap.
+	// history/II keep historyMaxSpan. --erigondb.domain.steps-in-frozen-file can impose an explicit cap.
 	domainMaxSpan := config3.UnboundedDomainMerge
 	if override := at.a.erigondbDomainStepsInFrozenFile; override != 0 && override != config3.UnboundedDomainMerge {
 		domainMaxSpan = stepSize * override
@@ -1663,7 +1663,7 @@ func (at *AggregatorRoTx) findMergeRange(maxEndTxNum, stepSize, stepsInFrozenFil
 		if d.d.Disable {
 			continue
 		}
-		r.domain[id] = d.findMergeRange(maxEndTxNum, domainMaxSpan, maxSpan)
+		r.domain[id] = d.findMergeRange(maxEndTxNum, domainMaxSpan, historyMaxSpan)
 	}
 
 	if commitmentUseReferencedBranches && r.domain[kv.CommitmentDomain].values.needMerge {
@@ -1709,10 +1709,10 @@ func (at *AggregatorRoTx) findMergeRange(maxEndTxNum, stepSize, stepsInFrozenFil
 		if ii.ii.Disable {
 			continue
 		}
-		r.invertedIndex[id] = ii.findMergeRange(maxEndTxNum, maxSpan)
+		r.invertedIndex[id] = ii.findMergeRange(maxEndTxNum, historyMaxSpan)
 	}
 
-	//log.Info(fmt.Sprintf("findMergeRange(%d, %d)=%s\n", maxEndTxNum/at.a.stepSize, maxSpan/at.a.stepSize, r))
+	//log.Info(fmt.Sprintf("findMergeRange(%d, %d)=%s\n", maxEndTxNum/at.a.stepSize, historyMaxSpan/at.a.stepSize, r))
 	return r
 }
 

--- a/db/state/merge.go
+++ b/db/state/merge.go
@@ -174,7 +174,7 @@ func findMergeRangeInFiles(files visibleFiles, stepSize, maxEndTxNum, maxSpan ui
 // (and underlying inverted index) merge. They are passed separately so that the
 // --erigondb.domain.steps-in-frozen-file CLI flag can relax the domain cap without affecting
 // history/II, which keep using the erigondb.toml stepsInFrozenFile value.
-func (dt *DomainRoTx) findMergeRange(maxEndTxNum, domainMaxSpan, maxSpan uint64) DomainRanges {
+func (dt *DomainRoTx) findMergeRange(maxEndTxNum, domainMaxSpan, historyMaxSpan uint64) DomainRanges {
 	r := DomainRanges{
 		name:    dt.name,
 		aggStep: dt.stepSize,
@@ -184,7 +184,7 @@ func (dt *DomainRoTx) findMergeRange(maxEndTxNum, domainMaxSpan, maxSpan uint64)
 	// merge History only if nothing to merge in Domain. to minimize amount of Domain files:
 	//  - to prioritize blocks execution perf (which needs only LatestState - Domains)
 	if !r.any() {
-		r.history = dt.ht.findMergeRange(maxEndTxNum, maxSpan)
+		r.history = dt.ht.findMergeRange(maxEndTxNum, historyMaxSpan)
 	}
 
 	return r

--- a/db/state/merge_test.go
+++ b/db/state/merge_test.go
@@ -788,25 +788,25 @@ func TestFindMergeRangeInFiles(t *testing.T) {
 	}
 
 	const stepSize = uint64(1)
-	const noCapSpan = config3.UnboundedDomainMerge // pass as maxSpan to disable clamping
+	const maxSpan = config3.UnboundedDomainMerge
 
 	t.Run("empty", func(t *testing.T) {
 		// (none) -> (no merge)
-		mr := findMergeRangeInFiles(nil, stepSize, 1024, noCapSpan, false)
+		mr := findMergeRangeInFiles(nil, stepSize, 1024, maxSpan, false)
 		assert.False(t, mr.needMerge)
 	})
 
 	t.Run("single_aligned_file_skips", func(t *testing.T) {
 		// [0, 1024) ->
 		// [0, 1024)   (no merge — already at max-aligned span)
-		mr := findMergeRangeInFiles(visibleFiles{f(0, 1024)}, stepSize, 1024, noCapSpan, false)
+		mr := findMergeRangeInFiles(visibleFiles{f(0, 1024)}, stepSize, 1024, maxSpan, false)
 		assert.False(t, mr.needMerge)
 	})
 
 	t.Run("two_singletons_merge_to_2", func(t *testing.T) {
 		// [0, 1), [1, 2) ->
 		// [0, 2)
-		mr := findMergeRangeInFiles(visibleFiles{f(0, 1), f(1, 2)}, stepSize, 2, noCapSpan, false)
+		mr := findMergeRangeInFiles(visibleFiles{f(0, 1), f(1, 2)}, stepSize, 2, maxSpan, false)
 		assert.True(t, mr.needMerge)
 		assert.Equal(t, uint64(0), mr.from)
 		assert.Equal(t, uint64(2), mr.to)
@@ -816,7 +816,7 @@ func TestFindMergeRangeInFiles(t *testing.T) {
 		// [0, 1), [1, 2), [2, 3) -> with maxEndTxNum=2
 		// [0, 2), [2, 3)   ([2, 3) is past the frontier and ignored)
 		files := visibleFiles{f(0, 1), f(1, 2), f(2, 3)}
-		mr := findMergeRangeInFiles(files, stepSize, 2, noCapSpan, false)
+		mr := findMergeRangeInFiles(files, stepSize, 2, maxSpan, false)
 		assert.True(t, mr.needMerge)
 		assert.Equal(t, uint64(0), mr.from)
 		assert.Equal(t, uint64(2), mr.to)
@@ -826,7 +826,7 @@ func TestFindMergeRangeInFiles(t *testing.T) {
 		// [0, 1), [1, 2), [2, 3), [3, 4) ->
 		// [0, 4)   ([1, 2) initially proposes {0,2}; [3, 4) widens it to {0,4} which absorbs everything)
 		files := visibleFiles{f(0, 1), f(1, 2), f(2, 3), f(3, 4)}
-		mr := findMergeRangeInFiles(files, stepSize, 4, noCapSpan, false)
+		mr := findMergeRangeInFiles(files, stepSize, 4, maxSpan, false)
 		assert.True(t, mr.needMerge)
 		assert.Equal(t, uint64(0), mr.from)
 		assert.Equal(t, uint64(4), mr.to)
@@ -856,7 +856,7 @@ func TestFindMergeRangeInFiles(t *testing.T) {
 			f(1600, 1610),
 			f(1610, 1620),
 		}
-		mr := findMergeRangeInFiles(files, stepSize, 1620, noCapSpan, false)
+		mr := findMergeRangeInFiles(files, stepSize, 1620, maxSpan, false)
 		assert.False(t, mr.needMerge)
 	})
 
@@ -873,7 +873,7 @@ func TestFindMergeRangeInFiles(t *testing.T) {
 			f(1620, 1621),
 			f(1621, 1622),
 		}
-		mr := findMergeRangeInFiles(files, stepSize, 1622, noCapSpan, false)
+		mr := findMergeRangeInFiles(files, stepSize, 1622, maxSpan, false)
 		assert.True(t, mr.needMerge)
 		assert.Equal(t, uint64(1620), mr.from)
 		assert.Equal(t, uint64(1622), mr.to)
@@ -902,7 +902,7 @@ func TestFindMergeRangeInFiles(t *testing.T) {
 			f(1620, 1621),
 			f(1621, 1622),
 		}
-		mr := findMergeRangeInFiles(files, stepSize, 1622, noCapSpan, false)
+		mr := findMergeRangeInFiles(files, stepSize, 1622, maxSpan, false)
 		assert.True(t, mr.needMerge)
 		assert.Equal(t, uint64(1620), mr.from,
 			"window must not straddle [1600, 1618); the safe candidate is the trailing pair")
@@ -917,7 +917,7 @@ func TestFindMergeRangeInFiles(t *testing.T) {
 		// [1, 2) initially proposes {0, 2}; [0, 4) has same startTxNum 0 and endTxNum 4 >= 2,
 		// so superSetCheck widens the candidate and clears needMerge. [4, 5) is self-aligned.
 		files := visibleFiles{f(0, 1), f(1, 2), f(0, 4), f(4, 5)}
-		mr := findMergeRangeInFiles(files, stepSize, 5, noCapSpan, true)
+		mr := findMergeRangeInFiles(files, stepSize, 5, maxSpan, true)
 		assert.False(t, mr.needMerge)
 	})
 
@@ -927,7 +927,7 @@ func TestFindMergeRangeInFiles(t *testing.T) {
 		// [0, 4) clears the {0, 2} candidate via superSetCheck; then [5, 6) has start 4 < 5
 		// and re-arms needMerge with {4, 6}.
 		files := visibleFiles{f(0, 1), f(1, 2), f(0, 4), f(4, 5), f(5, 6)}
-		mr := findMergeRangeInFiles(files, stepSize, 6, noCapSpan, true)
+		mr := findMergeRangeInFiles(files, stepSize, 6, maxSpan, true)
 		assert.True(t, mr.needMerge)
 		assert.Equal(t, uint64(4), mr.from)
 		assert.Equal(t, uint64(6), mr.to)

--- a/db/state/merge_test.go
+++ b/db/state/merge_test.go
@@ -534,8 +534,8 @@ func TestFindMergeRange_Optimal(t *testing.T) {
 
 	// -- Cases where the current algorithm is already optimal --
 
-	t.Run("domain/natural_decreasing_already_optimal", func(t *testing.T) {
-		// Files in the "natural shape" from prior merges: sizes match binary representation.
+	t.Run("domain/binary_decreasing_already_optimal", func(t *testing.T) {
+		// Files whose sizes are the binary digits of the total step count (endStep & -endStep).
 		// 32 = 100000₂ → single merge 0-32 in one pass.
 		files := []visibleFile{
 			f(0, 16), f(16, 24), f(24, 28), f(28, 30), f(30, 31), f(31, 32),
@@ -545,7 +545,7 @@ func TestFindMergeRange_Optimal(t *testing.T) {
 		assert.Equal(t, 0, int(r.values.from))
 		assert.Equal(t, 32, int(r.values.to))
 	})
-	t.Run("ii/natural_decreasing_already_optimal", func(t *testing.T) {
+	t.Run("ii/binary_decreasing_already_optimal", func(t *testing.T) {
 		files := []visibleFile{
 			f(0, 16), f(16, 24), f(24, 28), f(28, 30), f(30, 31), f(31, 32),
 		}
@@ -593,8 +593,8 @@ func TestFindMergeRange_Optimal(t *testing.T) {
 	})
 	t.Run("domain/infinity_merge_beyond_frozen_step_cap", func(t *testing.T) {
 		// Regression for #20705: when domainMaxSpan is unbounded, 8 files of 8 steps each
-		// must still merge further — endStep=64 has spanStep=64, natural window is 0-64.
-		// Capping domainMaxSpan at 8 would skip every file and return needMerge=false.
+		// must still merge further — endStep=64 has spanStep=64, so the merge candidate is
+		// [0, 64). Capping domainMaxSpan at 8 would skip every file and return needMerge=false.
 		files := []visibleFile{
 			f(0, 8), f(8, 16), f(16, 24), f(24, 32),
 			f(32, 40), f(40, 48), f(48, 56), f(56, 64),
@@ -745,7 +745,7 @@ func TestCalculateMergeStartTxNum(t *testing.T) {
 		{13, 12}, // [0, 8), [8, 12), [12, 13)
 		{14, 12}, // [0, 8), [8, 12), [12, 13), [13, 14) -> [0, 8), [8, 12), [12, 14)
 		{15, 14}, // [0, 8), [8, 12), [12, 14), [14, 15)
-		{16, 8},  // [0, 8), [8, 12), [12, 14), [14, 15), [15, 16) -> [0, 8), [8, 16) (capped by maxSpan; natural span 16 > 8)
+		{16, 8},  // [0, 8), [8, 12), [12, 14), [14, 15), [15, 16) -> [0, 8), [8, 16) (capped by maxSpan; spanStep*stepSize=16 > maxSpan=8)
 		{17, 16}, // [0, 8), [8, 16), [16, 17)
 		{18, 16}, // [0, 8), [8, 16), [16, 17), [17, 18) -> [0, 8), [8, 16), [16, 18)
 		{19, 18}, // [0, 8), [8, 16), [16, 18), [18, 19)
@@ -761,7 +761,7 @@ func TestCalculateMergeStartTxNum(t *testing.T) {
 		{29, 28}, // [0, 8), [8, 16), [16, 24), [24, 28), [28, 29)
 		{30, 28}, // [0, 8), [8, 16), [16, 24), [24, 28), [28, 29), [29, 30) -> [0, 8), [8, 16), [16, 24), [24, 28), [28, 30)
 		{31, 30}, // [0, 8), [8, 16), [16, 24), [24, 28), [28, 30), [30, 31)
-		{32, 24}, // [0, 8), [8, 16), [16, 24), [24, 28), [28, 30), [30, 31), [31, 32) -> [0, 8), [8, 16), [16, 24), [24, 32) (capped by maxSpan; natural span 32 > 8)
+		{32, 24}, // [0, 8), [8, 16), [16, 24), [24, 28), [28, 30), [30, 31), [31, 32) -> [0, 8), [8, 16), [16, 24), [24, 32) (capped by maxSpan; spanStep*stepSize=32 > maxSpan=8)
 		{33, 32}, // [0, 8), [8, 16), [16, 24), [24, 32), [32, 33)
 		{34, 32}, // [0, 8), [8, 16), [16, 24), [24, 32), [32, 33), [33, 34) -> [0, 8), [8, 16), [16, 24), [24, 32), [32, 34)
 		{35, 34}, // [0, 8), [8, 16), [16, 24), [24, 32), [32, 34), [34, 35)
@@ -788,25 +788,25 @@ func TestFindMergeRangeInFiles(t *testing.T) {
 	}
 
 	const stepSize = uint64(1)
-	const bigSpan = uint64(4096) // large enough not to clamp anything in these scenarios
+	const noCapSpan = config3.UnboundedDomainMerge // pass as maxSpan to disable clamping
 
 	t.Run("empty", func(t *testing.T) {
 		// (none) -> (no merge)
-		mr := findMergeRangeInFiles(nil, stepSize, 1024, bigSpan, false)
+		mr := findMergeRangeInFiles(nil, stepSize, 1024, noCapSpan, false)
 		assert.False(t, mr.needMerge)
 	})
 
 	t.Run("single_aligned_file_skips", func(t *testing.T) {
 		// [0, 1024) ->
 		// [0, 1024)   (no merge — already at max-aligned span)
-		mr := findMergeRangeInFiles(visibleFiles{f(0, 1024)}, stepSize, 1024, bigSpan, false)
+		mr := findMergeRangeInFiles(visibleFiles{f(0, 1024)}, stepSize, 1024, noCapSpan, false)
 		assert.False(t, mr.needMerge)
 	})
 
 	t.Run("two_singletons_merge_to_2", func(t *testing.T) {
 		// [0, 1), [1, 2) ->
 		// [0, 2)
-		mr := findMergeRangeInFiles(visibleFiles{f(0, 1), f(1, 2)}, stepSize, 2, bigSpan, false)
+		mr := findMergeRangeInFiles(visibleFiles{f(0, 1), f(1, 2)}, stepSize, 2, noCapSpan, false)
 		assert.True(t, mr.needMerge)
 		assert.Equal(t, uint64(0), mr.from)
 		assert.Equal(t, uint64(2), mr.to)
@@ -816,7 +816,7 @@ func TestFindMergeRangeInFiles(t *testing.T) {
 		// [0, 1), [1, 2), [2, 3) -> with maxEndTxNum=2
 		// [0, 2), [2, 3)   ([2, 3) is past the frontier and ignored)
 		files := visibleFiles{f(0, 1), f(1, 2), f(2, 3)}
-		mr := findMergeRangeInFiles(files, stepSize, 2, bigSpan, false)
+		mr := findMergeRangeInFiles(files, stepSize, 2, noCapSpan, false)
 		assert.True(t, mr.needMerge)
 		assert.Equal(t, uint64(0), mr.from)
 		assert.Equal(t, uint64(2), mr.to)
@@ -826,7 +826,7 @@ func TestFindMergeRangeInFiles(t *testing.T) {
 		// [0, 1), [1, 2), [2, 3), [3, 4) ->
 		// [0, 4)   ([1, 2) initially proposes {0,2}; [3, 4) widens it to {0,4} which absorbs everything)
 		files := visibleFiles{f(0, 1), f(1, 2), f(2, 3), f(3, 4)}
-		mr := findMergeRangeInFiles(files, stepSize, 4, bigSpan, false)
+		mr := findMergeRangeInFiles(files, stepSize, 4, noCapSpan, false)
 		assert.True(t, mr.needMerge)
 		assert.Equal(t, uint64(0), mr.from)
 		assert.Equal(t, uint64(4), mr.to)
@@ -844,7 +844,7 @@ func TestFindMergeRangeInFiles(t *testing.T) {
 
 	// --- Hand-traced scenarios ---
 
-	t.Run("non_canonical_all_self_aligned_no_merge", func(t *testing.T) {
+	t.Run("all_self_aligned_no_merge", func(t *testing.T) {
 		// [0, 1024), [1024, 1536), [1536, 1600), [1600, 1610), [1610, 1620) ->
 		// [0, 1024), [1024, 1536), [1536, 1600), [1600, 1610), [1610, 1620)   (no merge)
 		// Every file's startTxNum already covers the largest aligned span ending at its
@@ -856,7 +856,7 @@ func TestFindMergeRangeInFiles(t *testing.T) {
 			f(1600, 1610),
 			f(1610, 1620),
 		}
-		mr := findMergeRangeInFiles(files, stepSize, 1620, bigSpan, false)
+		mr := findMergeRangeInFiles(files, stepSize, 1620, noCapSpan, false)
 		assert.False(t, mr.needMerge)
 	})
 
@@ -873,7 +873,7 @@ func TestFindMergeRangeInFiles(t *testing.T) {
 			f(1620, 1621),
 			f(1621, 1622),
 		}
-		mr := findMergeRangeInFiles(files, stepSize, 1622, bigSpan, false)
+		mr := findMergeRangeInFiles(files, stepSize, 1622, noCapSpan, false)
 		assert.True(t, mr.needMerge)
 		assert.Equal(t, uint64(1620), mr.from)
 		assert.Equal(t, uint64(1622), mr.to)
@@ -889,10 +889,8 @@ func TestFindMergeRangeInFiles(t *testing.T) {
 		// window and instead pick the trailing pair's safe window {1620, 1622}.
 		//
 		// TODO(#20878): findMergeRangeInFiles currently picks {1616, 1620} regardless.
-		// The "Flexible merge ranges" proposal in https://github.com/erigontech/erigon/issues/20878
-		// fixes this by clipping the candidate window's `from` to the smallest visible
-		// startTxNum >= the natural from, so a window can never straddle an existing file.
-		// Once that lands, unskip this test.
+		// The fix clips the candidate `from` to the nearest existing file boundary so the
+		// proposed range cannot straddle a pre-existing file. Unskip once #20878 lands.
 		t.Skip("known pathology: findMergeRangeInFiles selects a window straddling an existing file; see #20878")
 
 		files := visibleFiles{
@@ -904,7 +902,7 @@ func TestFindMergeRangeInFiles(t *testing.T) {
 			f(1620, 1621),
 			f(1621, 1622),
 		}
-		mr := findMergeRangeInFiles(files, stepSize, 1622, bigSpan, false)
+		mr := findMergeRangeInFiles(files, stepSize, 1622, noCapSpan, false)
 		assert.True(t, mr.needMerge)
 		assert.Equal(t, uint64(1620), mr.from,
 			"window must not straddle [1600, 1618); the safe candidate is the trailing pair")
@@ -919,7 +917,7 @@ func TestFindMergeRangeInFiles(t *testing.T) {
 		// [1, 2) initially proposes {0, 2}; [0, 4) has same startTxNum 0 and endTxNum 4 >= 2,
 		// so superSetCheck widens the candidate and clears needMerge. [4, 5) is self-aligned.
 		files := visibleFiles{f(0, 1), f(1, 2), f(0, 4), f(4, 5)}
-		mr := findMergeRangeInFiles(files, stepSize, 5, bigSpan, true)
+		mr := findMergeRangeInFiles(files, stepSize, 5, noCapSpan, true)
 		assert.False(t, mr.needMerge)
 	})
 
@@ -929,7 +927,7 @@ func TestFindMergeRangeInFiles(t *testing.T) {
 		// [0, 4) clears the {0, 2} candidate via superSetCheck; then [5, 6) has start 4 < 5
 		// and re-arms needMerge with {4, 6}.
 		files := visibleFiles{f(0, 1), f(1, 2), f(0, 4), f(4, 5), f(5, 6)}
-		mr := findMergeRangeInFiles(files, stepSize, 6, bigSpan, true)
+		mr := findMergeRangeInFiles(files, stepSize, 6, noCapSpan, true)
 		assert.True(t, mr.needMerge)
 		assert.Equal(t, uint64(4), mr.from)
 		assert.Equal(t, uint64(6), mr.to)

--- a/db/state/merge_test.go
+++ b/db/state/merge_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"math"
 	"slices"
 	"testing"
 
@@ -593,15 +592,14 @@ func TestFindMergeRange_Optimal(t *testing.T) {
 		assert.Equal(t, 8, int(r.values.to))
 	})
 	t.Run("domain/infinity_merge_beyond_frozen_step_cap", func(t *testing.T) {
-		// Regression for #20705 regression: when domainMaxSpan is unbounded (math.MaxUint64),
-		// 8 files of 8 steps each must still merge further — endStep=64 has spanStep=64, so
-		// the natural window is 0-64. Capping domainMaxSpan at 8 would skip every file and
-		// incorrectly return needMerge=false.
+		// Regression for #20705: when domainMaxSpan is unbounded, 8 files of 8 steps each
+		// must still merge further — endStep=64 has spanStep=64, natural window is 0-64.
+		// Capping domainMaxSpan at 8 would skip every file and return needMerge=false.
 		files := []visibleFile{
 			f(0, 8), f(8, 16), f(16, 24), f(24, 32),
 			f(32, 40), f(40, 48), f(48, 56), f(56, 64),
 		}
-		r := newDomainRoTx(1, files).findMergeRange(64, math.MaxUint64, 8)
+		r := newDomainRoTx(1, files).findMergeRange(64, config3.UnboundedDomainMerge, 8)
 		assert.True(t, r.values.needMerge)
 		assert.Equal(t, 0, int(r.values.from))
 		assert.Equal(t, 64, int(r.values.to))

--- a/db/state/merge_test.go
+++ b/db/state/merge_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"math"
 	"slices"
 	"testing"
 
@@ -590,6 +591,20 @@ func TestFindMergeRange_Optimal(t *testing.T) {
 		assert.True(t, r.values.needMerge)
 		assert.Equal(t, 0, int(r.values.from))
 		assert.Equal(t, 8, int(r.values.to))
+	})
+	t.Run("domain/infinity_merge_beyond_frozen_step_cap", func(t *testing.T) {
+		// Regression for #20705 regression: when domainMaxSpan is unbounded (math.MaxUint64),
+		// 8 files of 8 steps each must still merge further — endStep=64 has spanStep=64, so
+		// the natural window is 0-64. Capping domainMaxSpan at 8 would skip every file and
+		// incorrectly return needMerge=false.
+		files := []visibleFile{
+			f(0, 8), f(8, 16), f(16, 24), f(24, 32),
+			f(32, 40), f(40, 48), f(48, 56), f(56, 64),
+		}
+		r := newDomainRoTx(1, files).findMergeRange(64, math.MaxUint64, 8)
+		assert.True(t, r.values.needMerge)
+		assert.Equal(t, 0, int(r.values.from))
+		assert.Equal(t, 64, int(r.values.to))
 	})
 	t.Run("ii/eight_equal_steps", func(t *testing.T) {
 		files := []visibleFile{

--- a/db/state/merge_test.go
+++ b/db/state/merge_test.go
@@ -534,9 +534,9 @@ func TestFindMergeRange_Optimal(t *testing.T) {
 
 	// -- Cases where the current algorithm is already optimal --
 
-	t.Run("domain/binary_decreasing_already_optimal", func(t *testing.T) {
-		// Files whose sizes are the binary digits of the total step count (endStep & -endStep).
-		// 32 = 100000₂ → single merge 0-32 in one pass.
+	t.Run("domain/rightmost_bit_already_optimal", func(t *testing.T) {
+		// Each file's span already equals its endStep's rightmost bit (endStep & -endStep).
+		// endStep=32, rightmost bit=32 → single merge 0-32 in one pass.
 		files := []visibleFile{
 			f(0, 16), f(16, 24), f(24, 28), f(28, 30), f(30, 31), f(31, 32),
 		}
@@ -545,7 +545,7 @@ func TestFindMergeRange_Optimal(t *testing.T) {
 		assert.Equal(t, 0, int(r.values.from))
 		assert.Equal(t, 32, int(r.values.to))
 	})
-	t.Run("ii/binary_decreasing_already_optimal", func(t *testing.T) {
+	t.Run("ii/rightmost_bit_already_optimal", func(t *testing.T) {
 		files := []visibleFile{
 			f(0, 16), f(16, 24), f(24, 28), f(28, 30), f(30, 31), f(31, 32),
 		}
@@ -676,7 +676,7 @@ func TestFindMergeRange_Optimal(t *testing.T) {
 		assert.Equal(t, 0, int(r.history.from))
 		assert.Equal(t, 4, int(r.history.to))
 	})
-	t.Run("history/natural_decreasing_already_optimal", func(t *testing.T) {
+	t.Run("history/rightmost_bit_already_optimal", func(t *testing.T) {
 		files := []visibleFile{
 			f(0, 16), f(16, 24), f(24, 28), f(28, 30), f(30, 31), f(31, 32),
 		}


### PR DESCRIPTION
## Summary

- #20705 changed `domainMaxSpan` default from unbounded to `stepsInFrozenFile*stepSize`, so domain `.kv` files stopped merging beyond a single frozen-file window (e.g. 8 steps with chiado `stepsInFrozenFile=8`). Instead of the expected 0-64 merged file you'd get individual 0-8, 8-16, … files with no further merging.
- Restore the pre-#20705 default: `domainMaxSpan=UnboundedDomainMerge` when no `--erigondb.domain.steps-in-frozen-file` CLI override is given. The CLI flag still works as before.
- Add a regression test: 8 files of 8 steps each with `domainMaxSpan=MaxUint64` must propose the 0-64 merge.