### PR TITLE
cmd/integration: allow resume of commitment rebuild (no history case)

### DIFF
--- a/cmd/integration/commands/commitment.go
+++ b/cmd/integration/commands/commitment.go
@@ -318,8 +318,9 @@ func commitmentRebuild(db kv.TemporalRwDB, ctx context.Context, logger log.Logge
 		statecfg.EnableHistoricalCommitment()
 	}
 
-	if resume && !noHistory && !commitmentHistoryEnabled {
-		return errors.New("--resume requires commitment history to be enabled (or pass --no-history)")
+	if resume && !commitmentHistoryEnabled && !noHistory {
+		logger.Info("[commitment_rebuild] commitment history not enabled in DB; resuming in --no-history mode")
+		noHistory = true
 	}
 
 	withHistory := false

--- a/cmd/integration/commands/commitment.go
+++ b/cmd/integration/commands/commitment.go
@@ -281,9 +281,6 @@ func commitmentRebuild(db kv.TemporalRwDB, ctx context.Context, logger log.Logge
 	if clearCommitment && resume {
 		return errors.New("--clear-commitment and --resume are mutually exclusive")
 	}
-	if noHistory && resume {
-		return errors.New("--no-history and --resume are mutually exclusive")
-	}
 	if noHistory && clearCommitment {
 		return errors.New("--no-history and --clear-commitment are mutually exclusive")
 	}
@@ -321,8 +318,8 @@ func commitmentRebuild(db kv.TemporalRwDB, ctx context.Context, logger log.Logge
 		statecfg.EnableHistoricalCommitment()
 	}
 
-	if resume && !commitmentHistoryEnabled {
-		return errors.New("--resume requires commitment history to be enabled")
+	if resume && !noHistory && !commitmentHistoryEnabled {
+		return errors.New("--resume requires commitment history to be enabled (or pass --no-history)")
 	}
 
 	withHistory := false

--- a/db/state/squeeze.go
+++ b/db/state/squeeze.go
@@ -865,6 +865,18 @@ func RebuildCommitmentFiles(ctx context.Context, rwDb kv.TemporalRwDB, txNumsRea
 	}
 
 	logger.Info("[commitment_rebuild] collected shards to build", "count", len(sf.d[kv.AccountsDomain]))
+
+	if existing := acRo.TxNumsInFiles(kv.CommitmentDomain); existing > 0 {
+		skipped := 0
+		for _, r := range ranges {
+			if existing >= r.to {
+				skipped++
+			}
+		}
+		logger.Info("[commitment_rebuild] resume: existing commitment files cover up to txNum",
+			"txNum", existing, "rangesToSkip", skipped, "rangesTotal", len(ranges))
+	}
+
 	start := time.Now()
 
 	var totalKeysCommitted uint64


### PR DESCRIPTION
- `--resume` already supported with history commitment rebuild