### PR TITLE
warmuper: worker to be cancellable

### DIFF
--- a/execution/commitment/warmuper.go
+++ b/execution/commitment/warmuper.go
@@ -175,17 +175,18 @@ func (w *Warmuper) Start() {
 				defer cleanup()
 			}
 
-			for item := range w.work {
+			for {
 				select {
 				case <-w.ctx.Done():
 					return w.ctx.Err()
-				default:
+				case item, ok := <-w.work:
+					if !ok {
+						return nil
+					}
+					w.warmupKey(trieCtx, item.hashedKey, item.startDepth)
+					w.keysProcessed.Add(1)
 				}
-
-				w.warmupKey(trieCtx, item.hashedKey, item.startDepth)
-				w.keysProcessed.Add(1)
 			}
-			return nil
 		})
 	}
 }
@@ -289,8 +290,7 @@ func (w *Warmuper) Wait() error {
 		return nil
 	}
 	w.Close()
-	w.g.Wait()
-	return nil
+	return w.g.Wait()
 }
 
 // Stats returns statistics about the warmup.


### PR DESCRIPTION
Replace `for item := range w.work` + non-blocking select with a single select on both `ctx.Done` and the work channel. Workers now unblock immediately on cancellation even when no items are queued.

Also return the errgroup error from `Wait()` instead of discarding it.