### PR TITLE
db/state: unify commitment-branch referencing predicate

### DIFF
--- a/db/integrity/commitment_integrity.go
+++ b/db/integrity/commitment_integrity.go
@@ -504,7 +504,7 @@ func checkCommitmentKvDeref(ctx context.Context, file state.VisibleFile, stepSiz
 	fileName := filepath.Base(file.Fullpath())
 	startTxNum := file.StartRootNum()
 	endTxNum := file.EndRootNum()
-	if !state.MayContainValuesPlainKeyReferencing(stepSize, startTxNum, endTxNum) {
+	if !state.ValuesPlainKeyReferencingThresholdReached(stepSize, startTxNum, endTxNum) {
 		logger.Info(
 			"[integrity] CommitmentKvDeref skipped, file not above min steps",
 			"file", fileName,
@@ -1256,7 +1256,7 @@ func checkStateCorrespondenceBase(ctx context.Context, file state.VisibleFile, s
 	expectedAccounts := uint64(accDecomp.Count()) / 2
 	expectedStorages := uint64(stoDecomp.Count()) / 2
 
-	isReferencing := state.MayContainValuesPlainKeyReferencing(stepSize, startTxNum, endTxNum)
+	isReferencing := state.ValuesPlainKeyReferencingThresholdReached(stepSize, startTxNum, endTxNum)
 
 	// Track unique keys found in commitment branches via ETL collectors (disk-spilling dedup).
 	accCollector := etl.NewCollector("[integrity] StateVerify acc", "", etl.NewOldestEntryBuffer(etl.BufferOptimalSize), logger)
@@ -1854,7 +1854,7 @@ func extractCommitmentRefsToCollectors(ctx context.Context, file state.VisibleFi
 	commReader := seg.NewReader(commDecomp.MakeGetter(), commCompression)
 
 	// Always open domain readers for dereferencing (commitment files may contain
-	// reference keys regardless of MayContainValuesPlainKeyReferencing result)
+	// reference keys regardless of ValuesPlainKeyReferencingThresholdReached result)
 	_, nextAccReader, nextAccClose, err := deriveDecompAndReaderForOtherDomain(file.Fullpath(), kv.CommitmentDomain, kv.AccountsDomain)
 	if err != nil {
 		return err
@@ -1951,7 +1951,7 @@ func checkHashVerification(ctx context.Context, file state.VisibleFile, stepSize
 	startTxNum := file.StartRootNum()
 	endTxNum := file.EndRootNum()
 
-	isReferencing := state.MayContainValuesPlainKeyReferencing(stepSize, startTxNum, endTxNum)
+	isReferencing := state.ValuesPlainKeyReferencingThresholdReached(stepSize, startTxNum, endTxNum)
 
 	logger.Info("[integrity] StateVerify hash verification starting",
 		"kv", fileName, "workers", numWorkers, "referencing", isReferencing)

--- a/db/state/domain_committed.go
+++ b/db/state/domain_committed.go
@@ -40,11 +40,7 @@ const minStepsForReferencing = 2
 // ValuesPlainKeyReferencingThresholdReached checks if the range from..to is large enough to use plain key referencing
 // Used for commitment branches - to store references to account and storage keys as shortened keys (file offsets)
 func ValuesPlainKeyReferencingThresholdReached(stepSize, from, to uint64) bool {
-	return ((to-from)/stepSize)%minStepsForReferencing == 0
-}
-
-func MayContainValuesPlainKeyReferencing(stepSize, from, to uint64) bool {
-	return ((to - from) / stepSize) > minStepsForReferencing
+	return (to-from)/stepSize >= minStepsForReferencing
 }
 
 // replaceShortenedKeysInBranch expands shortened key references (file offsets) in branch data back to full keys


### PR DESCRIPTION
This PR fixes some logic re: handling shortened keys in commitment files:

- `ValuesPlainKeyReferencingThresholdReached` as a general rule, if file contains 1 step, then use plain keys, otherwise references. This works well currently because all merged files contains even number of steps (2, 4, 8, 16, 32, etc.).

The problem is the logic uses %0 implying odd number of steps in range should contain plain keys as well. Because I'm modifying the step-rebase command to allow arbitrary number of steps inside a merged range, if you convert an existing node and it ends up containing an odd number of steps, it'll crash on next merge.

- I noticed a very similar function `MayContainValuesPlainKeyReferencing`, which kind of does the formula correctly, but it misses files with 2 steps. That function is used only by integrity checks, it is currently missing 2-step files and it is IMO incorrect. I'm removing that almost-duplicate function and retrofitting all callers to use `ValuesPlainKeyReferencingThresholdReached`.