### PR TITLE
[wip] domain: store largeValues in own auto-increment-id table

### DIFF
--- a/cmd/utils/app/domain_cmd.go
+++ b/cmd/utils/app/domain_cmd.go
@@ -44,12 +44,12 @@ func domainStat(cliCtx *cli.Context) error {
 	domainCfg := statecfg.Schema.GetDomainCfg(kv.Domain(domain))
 	var cursor kv.Cursor
 	if domainCfg.LargeValues {
-		cursor, err = tx.Cursor(domainCfg.ValuesTable)
+		cursor, err = tx.Cursor(domainCfg.KeysTable)
 		if err != nil {
 			return err
 		}
 	} else {
-		cursor, err = tx.CursorDupSort(domainCfg.ValuesTable)
+		cursor, err = tx.CursorDupSort(domainCfg.KeysTable)
 		if err != nil {
 			return err
 		}

--- a/db/kv/tables.go
+++ b/db/kv/tables.go
@@ -357,6 +357,7 @@ var ChaindataTables = []string{
 	TblCodeHistoryVals,
 	TblCodeIdx,
 
+	TblCommitmentKeys,
 	TblCommitmentVals,
 	TblCommitmentHistoryKeys,
 	TblCommitmentHistoryVals,
@@ -509,11 +510,13 @@ var ChaindataTablesCfg = TableCfg{
 	TblStorageHistoryVals: {Flags: DupSort},
 	TblStorageIdx:         {Flags: DupSort},
 
-	TblCodeValsData:    {},
+	TblCodeVals:        {Flags: DupSort}, // LargeValues: bareKey → ~step(8)+seq_id(8)
+	TblCodeValsData:    {},               // LargeValues: seq_id(8) → code
 	TblCodeHistoryKeys: {Flags: DupSort},
 	TblCodeIdx:         {Flags: DupSort},
 
-	TblCommitmentVals:        {Flags: DupSort},
+	TblCommitmentKeys:        {Flags: DupSort}, // LargeValues: bareKey → ~step(8)+seq_id(8); DupSort required for variable-length trie path keys
+	TblCommitmentVals:        {},               // LargeValues: seq_id(8) → commitment value
 	TblCommitmentHistoryKeys: {Flags: DupSort},
 	TblCommitmentHistoryVals: {Flags: DupSort},
 	TblCommitmentIdx:         {Flags: DupSort},
@@ -523,6 +526,7 @@ var ChaindataTablesCfg = TableCfg{
 	TblReceiptHistoryVals: {Flags: DupSort},
 	TblReceiptIdx:         {Flags: DupSort},
 
+	TblRCacheVals:        {Flags: DupSort}, // LargeValues: bareKey → ~step(8)+seq_id(8)
 	TblRCacheHistoryKeys: {Flags: DupSort},
 	TblRCacheIdx:         {Flags: DupSort},
 

--- a/db/kv/tables.go
+++ b/db/kv/tables.go
@@ -157,8 +157,8 @@ const (
 	TblCodeHistoryVals = "CodeHistoryVals"
 	TblCodeIdx         = "CodeIdx"
 
-	TblCommitmentVals        = "CommitmentVals"
-	TblCommitmentValsData    = "CommitmentValsData" // seq_id -> actual commitment value; TblCommitmentVals stores [~step][seq_id] refs
+	TblCommitmentKeys        = "CommitmentKeys" // DupSort: bareKey → ~step(8)+seq_id(8); required because commitment trie paths are variable-length
+	TblCommitmentVals        = "CommitmentVals" // plain: seq_id(8) → commitment value (referenced by TblCommitmentKeys)
 	TblCommitmentHistoryKeys = "CommitmentHistoryKeys"
 	TblCommitmentHistoryVals = "CommitmentHistoryVals"
 	TblCommitmentIdx         = "CommitmentIdx"
@@ -358,7 +358,6 @@ var ChaindataTables = []string{
 	TblCodeIdx,
 
 	TblCommitmentVals,
-	TblCommitmentValsData,
 	TblCommitmentHistoryKeys,
 	TblCommitmentHistoryVals,
 	TblCommitmentIdx,
@@ -514,8 +513,7 @@ var ChaindataTablesCfg = TableCfg{
 	TblCodeHistoryKeys: {Flags: DupSort},
 	TblCodeIdx:         {Flags: DupSort},
 
-	TblCommitmentVals:        {},
-	TblCommitmentValsData:    {},
+	TblCommitmentVals:        {Flags: DupSort},
 	TblCommitmentHistoryKeys: {Flags: DupSort},
 	TblCommitmentHistoryVals: {Flags: DupSort},
 	TblCommitmentIdx:         {Flags: DupSort},

--- a/db/kv/tables.go
+++ b/db/kv/tables.go
@@ -152,11 +152,13 @@ const (
 	TblStorageIdx         = "StorageIdx"
 
 	TblCodeVals        = "CodeVals"
+	TblCodeValsData    = "CodeValsData"
 	TblCodeHistoryKeys = "CodeHistoryKeys"
 	TblCodeHistoryVals = "CodeHistoryVals"
 	TblCodeIdx         = "CodeIdx"
 
 	TblCommitmentVals        = "CommitmentVals"
+	TblCommitmentValsData    = "CommitmentValsData" // seq_id -> actual commitment value; TblCommitmentVals stores [~step][seq_id] refs
 	TblCommitmentHistoryKeys = "CommitmentHistoryKeys"
 	TblCommitmentHistoryVals = "CommitmentHistoryVals"
 	TblCommitmentIdx         = "CommitmentIdx"
@@ -167,6 +169,7 @@ const (
 	TblReceiptIdx         = "ReceiptIdx"
 
 	TblRCacheVals        = "ReceiptCacheVals"
+	TblRCacheValsData    = "ReceiptCacheValsData"
 	TblRCacheHistoryKeys = "ReceiptCacheHistoryKeys"
 	TblRCacheHistoryVals = "ReceiptCacheHistoryVals"
 	TblRCacheIdx         = "ReceiptCacheIdx"
@@ -349,11 +352,13 @@ var ChaindataTables = []string{
 	TblStorageIdx,
 
 	TblCodeVals,
+	TblCodeValsData,
 	TblCodeHistoryKeys,
 	TblCodeHistoryVals,
 	TblCodeIdx,
 
 	TblCommitmentVals,
+	TblCommitmentValsData,
 	TblCommitmentHistoryKeys,
 	TblCommitmentHistoryVals,
 	TblCommitmentIdx,
@@ -364,6 +369,7 @@ var ChaindataTables = []string{
 	TblReceiptIdx,
 
 	TblRCacheVals,
+	TblRCacheValsData,
 	TblRCacheHistoryKeys,
 	TblRCacheHistoryVals,
 	TblRCacheIdx,
@@ -504,10 +510,12 @@ var ChaindataTablesCfg = TableCfg{
 	TblStorageHistoryVals: {Flags: DupSort},
 	TblStorageIdx:         {Flags: DupSort},
 
+	TblCodeValsData:    {},
 	TblCodeHistoryKeys: {Flags: DupSort},
 	TblCodeIdx:         {Flags: DupSort},
 
-	TblCommitmentVals:        {Flags: DupSort},
+	TblCommitmentVals:        {},
+	TblCommitmentValsData:    {},
 	TblCommitmentHistoryKeys: {Flags: DupSort},
 	TblCommitmentHistoryVals: {Flags: DupSort},
 	TblCommitmentIdx:         {Flags: DupSort},

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1666,29 +1666,7 @@ func (dt *DomainRoTx) getLatestFromDb(key []byte, roTx kv.Tx) ([]byte, kv.Step, 
 		if err != nil {
 			return nil, 0, false, fmt.Errorf("valsCursor.Seek: %w", err)
 		}
-		// For variable-length domain keys (e.g. commitment trie prefixes), Seek(key) may
-		// land on a longer stored key that has 'key' as a byte prefix, because in MDBX
-		// shorter keys sort before longer ones with the same prefix. Scan forward to find
-		// the stored entry whose domain-key part is exactly 'key', stopping when we
-		// overshoot past key+0xff…ff (the max stored key for this domain key).
-		if len(fullkey) > 0 && !(len(fullkey) >= 8 && bytes.Equal(fullkey[:len(fullkey)-8], key)) {
-			// maxKey is key + 8×0xff; allocate only when scan is actually needed.
-			maxKey := append(key[:len(key):len(key)], 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff)
-			for {
-				if bytes.Compare(fullkey, maxKey) > 0 {
-					fullkey = nil
-					break
-				}
-				fullkey, v, err = valsC.Next()
-				if err != nil {
-					return nil, 0, false, fmt.Errorf("valsCursor.Next: %w", err)
-				}
-				if len(fullkey) == 0 || (len(fullkey) >= 8 && bytes.Equal(fullkey[:len(fullkey)-8], key)) {
-					break
-				}
-			}
-		}
-		if len(fullkey) == 0 {
+		if len(fullkey) < 8+len(key) || !bytes.Equal(fullkey[:len(key)], key) {
 			return nil, 0, false, nil
 		}
 		foundInvStep = fullkey[len(fullkey)-8:]

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -441,14 +441,7 @@ func (w *DomainBufferedWriter) Flush(ctx context.Context, tx kv.RwTx) error {
 		defer valsDataCursor.Close()
 
 		var seqIDBuf [8]byte
-		isCommitment := w.keysTable == "CommitmentVals"
-		if isCommitment {
-			fmt.Printf("[DEBUG Flush] domain=%s keysTable=%s valsDataTable=%s\n", w.keysTable, w.keysTable, w.valsDataTable)
-		}
 		if err := w.keys.Load(tx, w.keysTable, func(k, v []byte, table etl.CurrentTableReader, next etl.LoadNextFunc) error {
-			if isCommitment {
-				fmt.Printf("[DEBUG Flush callback] k=%x v_len=%d\n", k, len(v))
-			}
 			// k = domain_key+~step(8B), v = actual_value
 			existingKey, existingSeqID, err := valuesCursor.Seek(k)
 			if err != nil {
@@ -465,9 +458,6 @@ func (w *DomainBufferedWriter) Flush(ctx context.Context, tx kv.RwTx) error {
 				return err
 			}
 			binary.BigEndian.PutUint64(seqIDBuf[:], seqIDNum)
-			if isCommitment {
-				fmt.Printf("[DEBUG Flush write] k=%x seqID=%d v_len=%d\n", k, seqIDNum, len(v))
-			}
 			if err := valsDataCursor.Put(seqIDBuf[:], v); err != nil {
 				return err
 			}
@@ -1661,21 +1651,34 @@ func (dt *DomainRoTx) getLatestFromDb(key []byte, roTx kv.Tx) ([]byte, kv.Step, 
 		if err != nil {
 			return nil, 0, false, fmt.Errorf("valsCursor.Seek: %w", err)
 		}
-		if dt.d.Name == kv.CommitmentDomain {
-			fmt.Printf("[DEBUG getLatestFromDb] domain=%s key=%x fullkey=%x v=%x\n", dt.d.Name, key, fullkey, v)
+		// For variable-length domain keys (e.g. commitment trie prefixes), Seek(key) may
+		// land on a longer stored key that has 'key' as a byte prefix, because in MDBX
+		// shorter keys sort before longer ones with the same prefix. Scan forward until we
+		// find the stored entry whose domain-key part is exactly 'key', or determine it
+		// is absent by overshooting past key+0xff…ff (the max stored key for this domain key).
+		maxKey := make([]byte, len(key)+8)
+		copy(maxKey, key)
+		for i := len(key); i < len(maxKey); i++ {
+			maxKey[i] = 0xff
+		}
+		for len(fullkey) > 0 {
+			if len(fullkey) >= 8 && bytes.Equal(fullkey[:len(fullkey)-8], key) {
+				break
+			}
+			if bytes.Compare(fullkey, maxKey) > 0 {
+				fullkey = nil
+				break
+			}
+			fullkey, v, err = valsC.Next()
+			if err != nil {
+				return nil, 0, false, fmt.Errorf("valsCursor.Next: %w", err)
+			}
 		}
 		if len(fullkey) == 0 {
-			return nil, 0, false, nil // This key is not in DB
-		}
-		if !bytes.Equal(fullkey[:len(fullkey)-8], key) {
-			return nil, 0, false, nil // This key is not in DB
+			return nil, 0, false, nil
 		}
 		foundInvStep = fullkey[len(fullkey)-8:]
-		seqID := v
 		v, err = derefValsData(roTx, dt.d.ValsDataTable, v)
-		if dt.d.Name == kv.CommitmentDomain {
-			fmt.Printf("[DEBUG getLatestFromDb] domain=%s key=%x seqID=%x valsData=%x err=%v\n", dt.d.Name, key, seqID, v, err)
-		}
 		if err != nil {
 			return nil, 0, false, fmt.Errorf("getLatestFromDb: %w", err)
 		}

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1233,7 +1233,7 @@ func buildHashMapAccessor(ctx context.Context, g *seg.Reader, idxPath string, va
 		}
 		if err = rs.Build(ctx); err != nil {
 			if rs.Collision() {
-				logger.Info("Building recsplit. Collision happened. It's ok. Restarting...")
+				logger.Info("Building recsplit. Collision happened. It's ok. Restarting...", "file", fileName, "keys", count)
 				rs.ResetNextSalt()
 			} else {
 				return fmt.Errorf("build idx: %w", err)

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -31,7 +31,6 @@ import (
 	btree2 "github.com/tidwall/btree"
 	"golang.org/x/sync/errgroup"
 
-	mdbx2 "github.com/erigontech/erigon/db/kv/mdbx"
 	"github.com/erigontech/erigon/db/kv/prune"
 
 	"github.com/erigontech/erigon/common"
@@ -182,18 +181,15 @@ func (d *Domain) maxStepInDBNoHistory(tx kv.Tx) (lstInDb kv.Step) {
 	if len(firstKey) == 0 {
 		return 0
 	}
-	if d.LargeValues {
-		stepBytes := firstKey[len(firstKey)-8:]
-		return kv.Step(^binary.BigEndian.Uint64(stepBytes))
-	}
+	// Both LargeValues (DupSort: bareKey → ~step+seq_id) and non-LargeValues (DupSort: bareKey → ~step+value)
+	// store the step in the first 8 bytes of the first dup value for the given key.
 	firstVal, err := tx.GetOne(d.KeysTable, firstKey)
 	if err != nil {
 		d.logger.Warn("[agg] Domain.maxStepInDBNoHistory", "firstKey", firstKey, "err", err)
 		return 0
 	}
 
-	stepBytes := firstVal[:8]
-	return kv.Step(^binary.BigEndian.Uint64(stepBytes))
+	return kv.Step(^binary.BigEndian.Uint64(firstVal[:8]))
 }
 
 func (d *Domain) minStepInDB(tx kv.Tx) (lstInDb uint64) {
@@ -429,11 +425,12 @@ func (w *DomainBufferedWriter) Flush(ctx context.Context, tx kv.RwTx) error {
 	}
 
 	if w.largeVals {
-		valuesCursor, err := tx.RwCursor(w.keysTable)
+		// DupSort KeysTable: bareKey → ~step(8)+seq_id(8); ValsDataTable: seq_id(8) → actualValue
+		keysCursor, err := tx.RwCursorDupSort(w.keysTable)
 		if err != nil {
 			return err
 		}
-		defer valuesCursor.Close()
+		defer keysCursor.Close()
 		valsDataCursor, err := tx.RwCursor(w.valsDataTable)
 		if err != nil {
 			return err
@@ -441,27 +438,33 @@ func (w *DomainBufferedWriter) Flush(ctx context.Context, tx kv.RwTx) error {
 		defer valsDataCursor.Close()
 
 		var seqIDBuf [8]byte
-		if err := w.keys.Load(tx, w.keysTable, func(k, v []byte, table etl.CurrentTableReader, next etl.LoadNextFunc) error {
-			// k = domain_key+~step(8B), v = actual_value
-			existingKey, existingSeqID, err := valuesCursor.Seek(k)
+		var dupValBuf [16]byte
+		if err := w.keys.Load(tx, "", func(k, v []byte, table etl.CurrentTableReader, next etl.LoadNextFunc) error {
+			// k = bareKey+~step(8B), v = actualValue
+			bareKey, invStep := k[:len(k)-8], k[len(k)-8:]
+
+			// Check if (bareKey, ~step) already exists in DupSort table
+			existingDup, err := keysCursor.SeekBothRange(bareKey, invStep)
 			if err != nil {
 				return err
 			}
-			if bytes.Equal(existingKey, k) {
-				// Same (key,step) already exists: reuse seq_id, just update the value.
-				return valsDataCursor.Put(existingSeqID, v)
+			if len(existingDup) >= 8 && bytes.Equal(existingDup[:8], invStep) {
+				// Same (bareKey, step) already exists: reuse seq_id, just update the value.
+				return valsDataCursor.Put(existingDup[8:], v)
 			}
 
-			// New (key,step): allocate a fresh seq_id and write both tables.
+			// New (bareKey, step): allocate a fresh seq_id and write both tables.
 			seqIDNum, err := tx.IncrementSequence(w.valsDataTable, 1)
 			if err != nil {
 				return err
 			}
 			binary.BigEndian.PutUint64(seqIDBuf[:], seqIDNum)
+			copy(dupValBuf[:8], invStep)
+			copy(dupValBuf[8:], seqIDBuf[:])
 			if err := valsDataCursor.Put(seqIDBuf[:], v); err != nil {
 				return err
 			}
-			return valuesCursor.Put(k, seqIDBuf[:])
+			return keysCursor.Put(bareKey, dupValBuf[:])
 		}, etl.TransformArgs{Quit: ctx.Done(), EmptyVals: true}); err != nil {
 			return err
 		}
@@ -552,7 +555,7 @@ type DomainRoTx struct {
 
 	lookupFullKey []byte // scratch buffer for lookupByShortenedKey
 
-	valsC      kv.Cursor
+	valsC      kv.CursorDupSort
 	valCViewID uint64 // to make sure that valsC reading from the same view with given kv.Tx
 
 	getFromFileCache *DomainGetFromFileCache
@@ -799,29 +802,31 @@ func (d *Domain) collate(ctx context.Context, step kv.Step, txFrom, txTo uint64,
 	stepVal := ^uint64(step)
 
 	if d.LargeValues {
-		valsCursor, err := roTx.Cursor(d.KeysTable)
+		// DupSort KeysTable: bareKey → ~step(8)+seq_id(8); iterate all entries, filter by step
+		valsCursor, err := roTx.CursorDupSort(d.KeysTable)
 		if err != nil {
 			return Collation{}, fmt.Errorf("create %s values cursor: %w", d.FilenameBase, err)
 		}
 		defer valsCursor.Close()
-		for k, v, err := valsCursor.First(); k != nil; k, v, err = valsCursor.Next() {
+		for k, dupVal, err := valsCursor.First(); k != nil; {
 			if err != nil {
 				return coll, err
 			}
-			if binary.BigEndian.Uint64(k[len(k)-8:]) != stepVal {
+			if binary.BigEndian.Uint64(dupVal[:8]) != stepVal {
+				k, dupVal, err = valsCursor.Next()
 				continue
 			}
-			bareKey := k[:len(k)-8]
-			if _, err = comp.Write(bareKey); err != nil {
-				return coll, fmt.Errorf("add %s values key [%x]: %w", d.FilenameBase, bareKey, err)
+			if _, err = comp.Write(k); err != nil {
+				return coll, fmt.Errorf("add %s values key [%x]: %w", d.FilenameBase, k, err)
 			}
-			actualVal, err := derefValsData(roTx, d.ValsDataTable, v)
+			actualVal, err := derefValsData(roTx, d.ValsDataTable, dupVal[8:])
 			if err != nil {
 				return coll, fmt.Errorf("collate %s: %w", d.FilenameBase, err)
 			}
 			if _, err = comp.Write(actualVal); err != nil {
-				return coll, fmt.Errorf("add %s values [%x]=>[%x]: %w", d.FilenameBase, bareKey, actualVal, err)
+				return coll, fmt.Errorf("add %s values [%x]=>[%x]: %w", d.FilenameBase, k, actualVal, err)
 			}
+			k, dupVal, err = valsCursor.NextNoDup()
 		}
 	} else {
 		valsCursor, err := roTx.CursorDupSort(d.KeysTable)
@@ -1290,15 +1295,12 @@ func (dt *DomainRoTx) unwind(ctx context.Context, rwTx kv.RwTx, step, txNumUnwin
 	logEvery := time.NewTicker(time.Second * 30)
 	defer logEvery.Stop()
 
-	var valsCursor kv.RwCursorDupSort
-	if !d.LargeValues {
-		var err error
-		valsCursor, err = rwTx.RwCursorDupSort(d.KeysTable)
-		if err != nil {
-			return err
-		}
-		defer valsCursor.Close()
+	valsCursor, err := rwTx.RwCursorDupSort(d.KeysTable)
+	if err != nil {
+		return err
 	}
+	defer valsCursor.Close()
+
 	// Revert keys using diff entries.
 	// Always: delete current entry at the write step, restore prevValue at unwind target step.
 	//
@@ -1321,36 +1323,43 @@ func (dt *DomainRoTx) unwind(ctx context.Context, rwTx kv.RwTx, step, txNumUnwin
 	unwindStepBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(unwindStepBytes, ^uint64(unwindStep))
 	var seqIDBuf [8]byte
+	var dupValBuf [16]byte
 
 	for i := range domainDiffs {
 		keyStr, value := domainDiffs[i].Key, domainDiffs[i].Value
 		key := common.ToBytesZeroCopy(keyStr)
 		if d.LargeValues {
-			// key = domain_key+~step(8B); delete the keysTable entry AND its ValsDataTable row.
-			oldSeqID, err := rwTx.GetOne(d.KeysTable, key)
+			// DupSort KeysTable: bareKey → ~step(8)+seq_id(8)
+			// key = bareKey+~step(8B) from the diff; extract components
+			bareKey, invStep := key[:len(key)-8], key[len(key)-8:]
+
+			// Find and delete the existing DupSort entry for this (bareKey, step)
+			existingDup, err := valsCursor.SeekBothRange(bareKey, invStep)
 			if err != nil {
 				return err
 			}
-			if len(oldSeqID) > 0 {
-				if err := rwTx.Delete(d.ValsDataTable, oldSeqID[:8]); err != nil {
+			if len(existingDup) >= 8 && bytes.Equal(existingDup[:8], invStep) {
+				if err := rwTx.Delete(d.ValsDataTable, existingDup[8:]); err != nil {
+					return err
+				}
+				if err := valsCursor.DeleteCurrent(); err != nil {
 					return err
 				}
 			}
-			if err := rwTx.Delete(d.KeysTable, key); err != nil {
-				return err
-			}
+
 			// nil = different step, skip; []byte{} = absent previously, write empty tombstone
 			if value != nil {
-				fullKey := key[:len(key)-8]
 				seqIDNum, err := rwTx.IncrementSequence(d.ValsDataTable, 1)
 				if err != nil {
 					return err
 				}
 				binary.BigEndian.PutUint64(seqIDBuf[:], seqIDNum)
+				copy(dupValBuf[:8], unwindStepBytes)
+				copy(dupValBuf[8:], seqIDBuf[:])
 				if err := rwTx.Put(d.ValsDataTable, seqIDBuf[:], value); err != nil {
 					return err
 				}
-				if err := rwTx.Put(d.KeysTable, append(fullKey, unwindStepBytes...), seqIDBuf[:]); err != nil {
+				if err := valsCursor.Put(bareKey, dupValBuf[:]); err != nil {
 					return err
 				}
 			}
@@ -1615,24 +1624,15 @@ func (dt *DomainRoTx) closeValsCursor() {
 	}
 }
 
-func (dt *DomainRoTx) valsCursor(tx kv.Tx) (c kv.Cursor, err error) {
+func (dt *DomainRoTx) valsCursor(tx kv.Tx) (c kv.CursorDupSort, err error) {
 	if dt.valsC != nil { // run in assert mode only
 		if asserts {
 			if tx.ViewID() != dt.valCViewID {
 				panic(fmt.Errorf("%w: DomainRoTx=%s cursor ViewID=%d; given tx.ViewID=%d", errSdTxImmutabilityInvariant, dt.d.FilenameBase, dt.valCViewID, tx.ViewID())) // cursor opened by different tx, invariant broken
 			}
 			if mc, ok := dt.valsC.(interface{ IsClosed() bool }); ok && mc.IsClosed() {
-				panic(fmt.Sprintf("domainRoTx=%s cursor lives longer than Cursor (=> than tx opened that cursor)", dt.d.FilenameBase))
+				panic(fmt.Sprintf("domainRoTx=%s cursor lives longer than DupCursor (=> than tx opened that cursor)", dt.d.FilenameBase))
 			}
-			// if dt.d.largeValues {
-			// 	if mc, ok := dt.valsC.(*mdbx.MdbxCursor); ok && mc.IsClosed() {
-			// 		panic(fmt.Sprintf("domainRoTx=%s cursor lives longer than Cursor (=> than tx opened that cursor)", dt.d.filenameBase))
-			// 	}
-			// } else {
-			// 	if mc, ok := dt.valsC.(*mdbx.MdbxDupSortCursor); ok && mc.IsClosed() {
-			// 		panic(fmt.Sprintf("domainRoTx=%s cursor lives longer than DupCursor (=> than tx opened that cursor)", dt.d.filenameBase))
-			// 	}
-			// }
 		}
 		return dt.valsC, nil
 	}
@@ -1640,10 +1640,9 @@ func (dt *DomainRoTx) valsCursor(tx kv.Tx) (c kv.Cursor, err error) {
 	if asserts {
 		dt.valCViewID = tx.ViewID()
 	}
-	if dt.d.LargeValues {
-		dt.valsC, err = tx.Cursor(dt.d.KeysTable)
-		return dt.valsC, err
-	}
+	// All domain KeysTables are DupSort: bareKey → ~step(8)+payload
+	// LargeValues: payload = seq_id(8), value stored in ValsDataTable
+	// non-LargeValues: payload = actualValue (inline)
 	dt.valsC, err = tx.CursorDupSort(dt.d.KeysTable)
 	return dt.valsC, err
 }
@@ -1661,16 +1660,17 @@ func (dt *DomainRoTx) getLatestFromDb(key []byte, roTx kv.Tx) ([]byte, kv.Step, 
 	var v, foundInvStep []byte
 
 	if dt.d.LargeValues {
-		var fullkey []byte
-		fullkey, v, err = valsC.Seek(key)
+		// DupSort KeysTable: bareKey → ~step(8)+seq_id(8); first dup = latest step
+		var dupVal []byte
+		_, dupVal, err = valsC.SeekExact(key)
 		if err != nil {
-			return nil, 0, false, fmt.Errorf("valsCursor.Seek: %w", err)
+			return nil, 0, false, fmt.Errorf("valsCursor.SeekExact: %w", err)
 		}
-		if len(fullkey) < 8+len(key) || !bytes.Equal(fullkey[:len(key)], key) {
+		if len(dupVal) == 0 {
 			return nil, 0, false, nil
 		}
-		foundInvStep = fullkey[len(fullkey)-8:]
-		v, err = derefValsData(roTx, dt.d.ValsDataTable, v)
+		foundInvStep = dupVal[:8]
+		v, err = derefValsData(roTx, dt.d.ValsDataTable, dupVal[8:])
 		if err != nil {
 			return nil, 0, false, fmt.Errorf("getLatestFromDb: %w", err)
 		}
@@ -1967,40 +1967,19 @@ func (dt *DomainRoTx) prune(ctx context.Context, rwTx kv.RwTx, step kv.Step, txF
 	mxPruneInProgress.Inc()
 	defer mxPruneInProgress.Dec()
 	defer mxPruneTookDomain.ObserveDuration(time.Now())
-	var valsCursor kv.PseudoDupSortRwCursor
-	var mode prune.StorageMode
-	if dt.d.LargeValues {
-		mode = prune.StepKeyStorageMode
-		valsRwCursor, err := rwTx.RwCursor(dt.d.KeysTable)
-		if err != nil {
-			return stat, fmt.Errorf("create %s domain values cursor: %w", dt.name.String(), err)
-		}
-		defer valsRwCursor.Close()
-
-		switch c := valsRwCursor.(type) {
-		case *mdbx2.MdbxCursor:
-			valsCursor = &mdbx2.MdbxCursorPseudoDupSort{MdbxCursor: c}
-		case *mdbx2.MdbxDupSortCursor:
-			valsCursor = valsRwCursor.(*mdbx2.MdbxDupSortCursor)
-		default:
-			valsCursor = &kv.RwCursorPseudoDupSort{RwCursor: c}
-		}
-		defer valsCursor.Close()
-	} else {
-		mode = prune.StepValueStorageMode
-		valsCursor, err = rwTx.RwCursorDupSort(dt.d.KeysTable)
-		if err != nil {
-			return stat, fmt.Errorf("create %s domain values cursor: %w", dt.name.String(), err)
-		}
-		defer valsCursor.Close()
+	// All domain KeysTables are DupSort: step is in the first 8 bytes of the dup value
+	valsCursor, err := rwTx.RwCursorDupSort(dt.d.KeysTable)
+	if err != nil {
+		return stat, fmt.Errorf("create %s domain values cursor: %w", dt.name.String(), err)
 	}
+	defer valsCursor.Close()
 
 	prg.KeyProgress = prune.Done // domains don't have key tables
 
 	if dt.d.ValsDataTable != "" {
-		// CommitmentDomain: prune plain keysTable and ValsDataTable together.
-		// keysTable key = domain_key+~step(8B), value = seq_id(8B).
-		// Delete ValsDataTable entry before deleting the keysTable entry.
+		// LargeValues domains (Code, RCache, Commitment): prune DupSort keysTable and ValsDataTable together.
+		// keysTable: bareKey → ~step(8)+seq_id(8) (DupSort); ValsDataTable: seq_id(8) → actualValue.
+		// Delete ValsDataTable entry before deleting the keysTable dup entry.
 		pruneStat, err := dt.pruneWithValsData(ctx, rwTx, valsCursor, txFrom, txTo, limit, logEvery, prg)
 		if err != nil {
 			return stat, err
@@ -2020,8 +1999,9 @@ func (dt *DomainRoTx) prune(ctx context.Context, rwTx kv.RwTx, step kv.Step, txF
 		return stat, err
 	}
 
+	// Step is in the first 8 bytes of the dup value for all domain DupSort tables
 	pruneStat, err := prune.TableScanningPrune(ctx, "domain "+dt.name.String(), dt.d.FilenameBase, txFrom, txTo, limit, dt.stepSize,
-		logEvery, dt.d.logger, nil, valsCursor, asserts, prg, mode)
+		logEvery, dt.d.logger, nil, valsCursor, asserts, prg, prune.StepValueStorageMode)
 	if err != nil {
 		return stat, err
 	}
@@ -2047,13 +2027,13 @@ func (dt *DomainRoTx) prune(ctx context.Context, rwTx kv.RwTx, step kv.Step, txF
 	return stat, err
 }
 
-// pruneWithValsData prunes the plain (non-DupSort) keysTable and companion ValsDataTable together.
-// keysTable key = domain_key+~step(8B), value = seq_id(8B).
-// The seq_id entry in ValsDataTable is deleted before the keysTable entry.
+// pruneWithValsData prunes the DupSort keysTable and companion ValsDataTable together.
+// keysTable (DupSort): bareKey → ~step(8)+seq_id(8); ValsDataTable: seq_id(8) → actualValue.
+// The seq_id entry in ValsDataTable is deleted before the keysTable dup entry.
 func (dt *DomainRoTx) pruneWithValsData(
 	ctx context.Context,
 	rwTx kv.RwTx,
-	keysCursor kv.PseudoDupSortRwCursor,
+	keysCursor kv.RwCursorDupSort,
 	txFrom, txTo, limit uint64,
 	logEvery *time.Ticker,
 	prg *prune.Stat,
@@ -2066,12 +2046,12 @@ func (dt *DomainRoTx) pruneWithValsData(
 	}
 	defer valsDataRw.Close()
 
-	var k, v []byte
+	var k, dupVal []byte
 	switch prg.ValueProgress {
 	case prune.InProgress:
-		k, v, err = keysCursor.Seek(prg.LastPrunedValue)
+		k, dupVal, err = keysCursor.Seek(prg.LastPrunedValue)
 	case prune.First:
-		k, v, err = keysCursor.First()
+		k, dupVal, err = keysCursor.First()
 	default:
 		return stat, nil
 	}
@@ -2087,15 +2067,16 @@ func (dt *DomainRoTx) pruneWithValsData(
 			return stat, nil
 		}
 
-		if len(k) >= 8 {
-			stepNum := kv.Step(^binary.BigEndian.Uint64(k[len(k)-8:]))
+		if len(dupVal) >= 16 {
+			// dupVal = ~step(8) + seq_id(8)
+			stepNum := kv.Step(^binary.BigEndian.Uint64(dupVal[:8]))
 			txNum := uint64(stepNum) * dt.stepSize
 			if txNum >= txFrom && txNum < txTo {
-				if delErr := valsDataRw.Delete(v[:8]); delErr != nil {
+				if delErr := valsDataRw.Delete(dupVal[8:]); delErr != nil {
 					return stat, fmt.Errorf("delete %s ValsDataTable seq_id: %w", dt.name.String(), delErr)
 				}
 				if err = keysCursor.DeleteCurrent(); err != nil {
-					return stat, fmt.Errorf("delete %s keysTable entry: %w", dt.name.String(), err)
+					return stat, fmt.Errorf("delete %s keysTable dup entry: %w", dt.name.String(), err)
 				}
 				stat.MinTxNum = min(stat.MinTxNum, txNum)
 				stat.MaxTxNum = max(stat.MaxTxNum, txNum)
@@ -2109,7 +2090,7 @@ func (dt *DomainRoTx) pruneWithValsData(
 				}
 			}
 		}
-		k, v, err = keysCursor.Next()
+		k, dupVal, err = keysCursor.Next()
 		if err != nil {
 			return stat, fmt.Errorf("next %s cursor: %w", dt.name.String(), err)
 		}

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -441,7 +441,14 @@ func (w *DomainBufferedWriter) Flush(ctx context.Context, tx kv.RwTx) error {
 		defer valsDataCursor.Close()
 
 		var seqIDBuf [8]byte
+		isCommitment := w.keysTable == "CommitmentVals"
+		if isCommitment {
+			fmt.Printf("[DEBUG Flush] domain=%s keysTable=%s valsDataTable=%s\n", w.keysTable, w.keysTable, w.valsDataTable)
+		}
 		if err := w.keys.Load(tx, w.keysTable, func(k, v []byte, table etl.CurrentTableReader, next etl.LoadNextFunc) error {
+			if isCommitment {
+				fmt.Printf("[DEBUG Flush callback] k=%x v_len=%d\n", k, len(v))
+			}
 			// k = domain_key+~step(8B), v = actual_value
 			existingKey, existingSeqID, err := valuesCursor.Seek(k)
 			if err != nil {
@@ -458,6 +465,9 @@ func (w *DomainBufferedWriter) Flush(ctx context.Context, tx kv.RwTx) error {
 				return err
 			}
 			binary.BigEndian.PutUint64(seqIDBuf[:], seqIDNum)
+			if isCommitment {
+				fmt.Printf("[DEBUG Flush write] k=%x seqID=%d v_len=%d\n", k, seqIDNum, len(v))
+			}
 			if err := valsDataCursor.Put(seqIDBuf[:], v); err != nil {
 				return err
 			}
@@ -810,18 +820,12 @@ func (d *Domain) collate(ctx context.Context, step kv.Step, txFrom, txTo uint64,
 			if _, err = comp.Write(bareKey); err != nil {
 				return coll, fmt.Errorf("add %s values key [%x]: %w", d.FilenameBase, bareKey, err)
 			}
-			if d.ValsDataTable != "" {
-				actualVal, err := roTx.GetOne(d.ValsDataTable, v[:8])
-				if err != nil {
-					return coll, fmt.Errorf("collate %s ValsDataTable get [%x]: %w", d.FilenameBase, v[:8], err)
-				}
-				if _, err = comp.Write(actualVal); err != nil {
-					return coll, fmt.Errorf("add %s values [%x]=>[%x]: %w", d.FilenameBase, bareKey, actualVal, err)
-				}
-			} else {
-				if _, err = comp.Write(v); err != nil {
-					return coll, fmt.Errorf("add %s values [%x]=>[%x]: %w", d.FilenameBase, bareKey, v, err)
-				}
+			actualVal, err := derefValsData(roTx, d.ValsDataTable, v)
+			if err != nil {
+				return coll, fmt.Errorf("collate %s: %w", d.FilenameBase, err)
+			}
+			if _, err = comp.Write(actualVal); err != nil {
+				return coll, fmt.Errorf("add %s values [%x]=>[%x]: %w", d.FilenameBase, bareKey, actualVal, err)
 			}
 		}
 	} else {
@@ -1311,36 +1315,38 @@ func (dt *DomainRoTx) unwind(ctx context.Context, rwTx kv.RwTx, step, txNumUnwin
 	}
 	unwindStepBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(unwindStepBytes, ^uint64(unwindStep))
+	var seqIDBuf [8]byte
 
 	for i := range domainDiffs {
 		keyStr, value := domainDiffs[i].Key, domainDiffs[i].Value
 		key := common.ToBytesZeroCopy(keyStr)
 		if d.LargeValues {
-			// key = domain_key+~step(8B); delete at the write step.
+			// key = domain_key+~step(8B); delete the keysTable entry AND its ValsDataTable row.
+			oldSeqID, err := rwTx.GetOne(d.KeysTable, key)
+			if err != nil {
+				return err
+			}
+			if len(oldSeqID) > 0 {
+				if err := rwTx.Delete(d.ValsDataTable, oldSeqID[:8]); err != nil {
+					return err
+				}
+			}
 			if err := rwTx.Delete(d.KeysTable, key); err != nil {
 				return err
 			}
 			// nil = different step, skip; []byte{} = absent previously, write empty tombstone
 			if value != nil {
 				fullKey := key[:len(key)-8]
-				if d.ValsDataTable != "" {
-					// Allocate a new seq_id and write actual value to ValsDataTable.
-					seqIDNum, err := rwTx.IncrementSequence(d.ValsDataTable, 1)
-					if err != nil {
-						return err
-					}
-					var seqIDBuf [8]byte
-					binary.BigEndian.PutUint64(seqIDBuf[:], seqIDNum)
-					if err := rwTx.Put(d.ValsDataTable, seqIDBuf[:], value); err != nil {
-						return err
-					}
-					if err := rwTx.Put(d.KeysTable, append(fullKey, unwindStepBytes...), seqIDBuf[:]); err != nil {
-						return err
-					}
-				} else {
-					if err := rwTx.Put(d.KeysTable, append(fullKey, unwindStepBytes...), value); err != nil {
-						return err
-					}
+				seqIDNum, err := rwTx.IncrementSequence(d.ValsDataTable, 1)
+				if err != nil {
+					return err
+				}
+				binary.BigEndian.PutUint64(seqIDBuf[:], seqIDNum)
+				if err := rwTx.Put(d.ValsDataTable, seqIDBuf[:], value); err != nil {
+					return err
+				}
+				if err := rwTx.Put(d.KeysTable, append(fullKey, unwindStepBytes...), seqIDBuf[:]); err != nil {
+					return err
 				}
 			}
 			continue
@@ -1655,6 +1661,9 @@ func (dt *DomainRoTx) getLatestFromDb(key []byte, roTx kv.Tx) ([]byte, kv.Step, 
 		if err != nil {
 			return nil, 0, false, fmt.Errorf("valsCursor.Seek: %w", err)
 		}
+		if dt.d.Name == kv.CommitmentDomain {
+			fmt.Printf("[DEBUG getLatestFromDb] domain=%s key=%x fullkey=%x v=%x\n", dt.d.Name, key, fullkey, v)
+		}
 		if len(fullkey) == 0 {
 			return nil, 0, false, nil // This key is not in DB
 		}
@@ -1662,11 +1671,13 @@ func (dt *DomainRoTx) getLatestFromDb(key []byte, roTx kv.Tx) ([]byte, kv.Step, 
 			return nil, 0, false, nil // This key is not in DB
 		}
 		foundInvStep = fullkey[len(fullkey)-8:]
-		if dt.d.ValsDataTable != "" {
-			v, err = roTx.GetOne(dt.d.ValsDataTable, v[:8])
-			if err != nil {
-				return nil, 0, false, fmt.Errorf("getLatestFromDb ValsDataTable: %w", err)
-			}
+		seqID := v
+		v, err = derefValsData(roTx, dt.d.ValsDataTable, v)
+		if dt.d.Name == kv.CommitmentDomain {
+			fmt.Printf("[DEBUG getLatestFromDb] domain=%s key=%x seqID=%x valsData=%x err=%v\n", dt.d.Name, key, seqID, v, err)
+		}
+		if err != nil {
+			return nil, 0, false, fmt.Errorf("getLatestFromDb: %w", err)
 		}
 	} else {
 		_, stepWithVal, err := func() (_ []byte, _ []byte, err error) {

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1206,8 +1206,8 @@ func buildHashMapAccessor(ctx context.Context, g *seg.Reader, idxPath string, va
 		testHook(rs)
 	}
 
-	for {
-		// Reset positions at the start of each iteration to handle collision retries correctly
+	var prevKey []byte // for duplicate-key detection
+	for attempt := 0; ; attempt++ {
 		var keyPos, valPos uint64
 		word := make([]byte, 0, 256)
 		if err := ctx.Err(); err != nil {
@@ -1215,9 +1215,16 @@ func buildHashMapAccessor(ctx context.Context, g *seg.Reader, idxPath string, va
 		}
 		g.Reset(0)
 		rs.SetProgress(p)
+		prevKey = prevKey[:0]
 
 		for g.HasNext() {
 			word, valPos = g.Next(word[:0])
+			if asserts {
+				if bytes.Equal(word, prevKey) {
+					return fmt.Errorf("buildHashMapAccessor: duplicate key %x in %s", word, fileName)
+				}
+				prevKey = append(prevKey[:0], word...)
+			}
 			if values {
 				if err = rs.AddKey(word, valPos); err != nil {
 					return fmt.Errorf("add idx key [%x]: %w", word, err)
@@ -1233,6 +1240,9 @@ func buildHashMapAccessor(ctx context.Context, g *seg.Reader, idxPath string, va
 		}
 		if err = rs.Build(ctx); err != nil {
 			if rs.Collision() {
+				if attempt >= 99 {
+					return fmt.Errorf("buildHashMapAccessor: too many recsplit collisions (likely duplicate keys) in %s keys=%d", fileName, count)
+				}
 				logger.Info("Building recsplit. Collision happened. It's ok. Restarting...", "file", fileName, "keys", count)
 				rs.ResetNextSalt()
 			} else {

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -326,7 +326,13 @@ func (d *Domain) calcVisibleFiles(toTxNum uint64) (*domainVisible, visibleFiles,
 	return dv, hv, hiv
 }
 
-func (d *Domain) Tables() []string { return append(d.History.Tables(), d.KeysTable) }
+func (d *Domain) Tables() []string {
+	tables := append(d.History.Tables(), d.KeysTable)
+	if d.ValsDataTable != "" {
+		tables = append(tables, d.ValsDataTable)
+	}
+	return tables
+}
 
 func (d *Domain) Close() {
 	if d == nil {
@@ -373,11 +379,12 @@ func (dt *DomainRoTx) newWriter(tmpdir string, discard bool) *DomainBufferedWrit
 	discardHistory := discard || dt.d.HistoryDisabled
 
 	w := &DomainBufferedWriter{
-		discard:   discard,
-		aux:       make([]byte, 0, 128),
-		keysTable: dt.d.KeysTable,
-		largeVals: dt.d.LargeValues,
-		h:         dt.ht.newWriter(tmpdir, discardHistory),
+		discard:       discard,
+		aux:           make([]byte, 0, 128),
+		keysTable:     dt.d.KeysTable,
+		largeVals:     dt.d.LargeValues,
+		valsDataTable: dt.d.ValsDataTable,
+		h:             dt.ht.newWriter(tmpdir, discardHistory),
 	}
 	if !discard {
 		w.keys = etl.NewCollectorWithAllocator(dt.d.Name.String()+"domain.flush", tmpdir, etl.SmallSortableBuffers, dt.d.logger).
@@ -391,8 +398,9 @@ type DomainBufferedWriter struct {
 
 	discard bool
 
-	keysTable string
-	largeVals bool
+	keysTable     string
+	largeVals     bool
+	valsDataTable string // when non-empty: actual values stored in ValsDataTable; keysTable stores [~step][seq_id] refs
 
 	stepBytes [8]byte // current inverted step representation
 	aux       []byte  // auxilary buffer for key1 + key2
@@ -421,7 +429,40 @@ func (w *DomainBufferedWriter) Flush(ctx context.Context, tx kv.RwTx) error {
 	}
 
 	if w.largeVals {
-		if err := w.keys.Load(tx, w.keysTable, loadFunc, etl.TransformArgs{Quit: ctx.Done(), EmptyVals: true}); err != nil {
+		valuesCursor, err := tx.RwCursor(w.keysTable)
+		if err != nil {
+			return err
+		}
+		defer valuesCursor.Close()
+		valsDataCursor, err := tx.RwCursor(w.valsDataTable)
+		if err != nil {
+			return err
+		}
+		defer valsDataCursor.Close()
+
+		var seqIDBuf [8]byte
+		if err := w.keys.Load(tx, w.keysTable, func(k, v []byte, table etl.CurrentTableReader, next etl.LoadNextFunc) error {
+			// k = domain_key+~step(8B), v = actual_value
+			existingKey, existingSeqID, err := valuesCursor.Seek(k)
+			if err != nil {
+				return err
+			}
+			if bytes.Equal(existingKey, k) {
+				// Same (key,step) already exists: reuse seq_id, just update the value.
+				return valsDataCursor.Put(existingSeqID, v)
+			}
+
+			// New (key,step): allocate a fresh seq_id and write both tables.
+			seqIDNum, err := tx.IncrementSequence(w.valsDataTable, 1)
+			if err != nil {
+				return err
+			}
+			binary.BigEndian.PutUint64(seqIDBuf[:], seqIDNum)
+			if err := valsDataCursor.Put(seqIDBuf[:], v); err != nil {
+				return err
+			}
+			return valuesCursor.Put(k, seqIDBuf[:])
+		}, etl.TransformArgs{Quit: ctx.Done(), EmptyVals: true}); err != nil {
 			return err
 		}
 		w.Close()
@@ -433,6 +474,7 @@ func (w *DomainBufferedWriter) Flush(ctx context.Context, tx kv.RwTx) error {
 		return err
 	}
 	defer valuesCursor.Close()
+
 	if err := w.keys.Load(tx, w.keysTable, func(k, v []byte, table etl.CurrentTableReader, next etl.LoadNextFunc) error {
 		foundVal, err := valuesCursor.SeekBothRange(k, v[:8])
 		if err != nil {
@@ -768,8 +810,18 @@ func (d *Domain) collate(ctx context.Context, step kv.Step, txFrom, txTo uint64,
 			if _, err = comp.Write(bareKey); err != nil {
 				return coll, fmt.Errorf("add %s values key [%x]: %w", d.FilenameBase, bareKey, err)
 			}
-			if _, err = comp.Write(v); err != nil {
-				return coll, fmt.Errorf("add %s values [%x]=>[%x]: %w", d.FilenameBase, bareKey, v, err)
+			if d.ValsDataTable != "" {
+				actualVal, err := roTx.GetOne(d.ValsDataTable, v[:8])
+				if err != nil {
+					return coll, fmt.Errorf("collate %s ValsDataTable get [%x]: %w", d.FilenameBase, v[:8], err)
+				}
+				if _, err = comp.Write(actualVal); err != nil {
+					return coll, fmt.Errorf("add %s values [%x]=>[%x]: %w", d.FilenameBase, bareKey, actualVal, err)
+				}
+			} else {
+				if _, err = comp.Write(v); err != nil {
+					return coll, fmt.Errorf("add %s values [%x]=>[%x]: %w", d.FilenameBase, bareKey, v, err)
+				}
 			}
 		}
 	} else {
@@ -1229,11 +1281,15 @@ func (dt *DomainRoTx) unwind(ctx context.Context, rwTx kv.RwTx, step, txNumUnwin
 	logEvery := time.NewTicker(time.Second * 30)
 	defer logEvery.Stop()
 
-	valsCursor, err := rwTx.RwCursorDupSort(d.KeysTable)
-	if err != nil {
-		return err
+	var valsCursor kv.RwCursorDupSort
+	if !d.LargeValues {
+		var err error
+		valsCursor, err = rwTx.RwCursorDupSort(d.KeysTable)
+		if err != nil {
+			return err
+		}
+		defer valsCursor.Close()
 	}
-	defer valsCursor.Close()
 	// Revert keys using diff entries.
 	// Always: delete current entry at the write step, restore prevValue at unwind target step.
 	//
@@ -1259,16 +1315,32 @@ func (dt *DomainRoTx) unwind(ctx context.Context, rwTx kv.RwTx, step, txNumUnwin
 	for i := range domainDiffs {
 		keyStr, value := domainDiffs[i].Key, domainDiffs[i].Value
 		key := common.ToBytesZeroCopy(keyStr)
-		if dt.d.LargeValues {
-			// Delete the entry at the write step
+		if d.LargeValues {
+			// key = domain_key+~step(8B); delete at the write step.
 			if err := rwTx.Delete(d.KeysTable, key); err != nil {
 				return err
 			}
 			// nil = different step, skip; []byte{} = absent previously, write empty tombstone
 			if value != nil {
 				fullKey := key[:len(key)-8]
-				if err := rwTx.Put(d.KeysTable, append(fullKey, unwindStepBytes...), value); err != nil {
-					return err
+				if d.ValsDataTable != "" {
+					// Allocate a new seq_id and write actual value to ValsDataTable.
+					seqIDNum, err := rwTx.IncrementSequence(d.ValsDataTable, 1)
+					if err != nil {
+						return err
+					}
+					var seqIDBuf [8]byte
+					binary.BigEndian.PutUint64(seqIDBuf[:], seqIDNum)
+					if err := rwTx.Put(d.ValsDataTable, seqIDBuf[:], value); err != nil {
+						return err
+					}
+					if err := rwTx.Put(d.KeysTable, append(fullKey, unwindStepBytes...), seqIDBuf[:]); err != nil {
+						return err
+					}
+				} else {
+					if err := rwTx.Put(d.KeysTable, append(fullKey, unwindStepBytes...), value); err != nil {
+						return err
+					}
 				}
 			}
 			continue
@@ -1590,6 +1662,12 @@ func (dt *DomainRoTx) getLatestFromDb(key []byte, roTx kv.Tx) ([]byte, kv.Step, 
 			return nil, 0, false, nil // This key is not in DB
 		}
 		foundInvStep = fullkey[len(fullkey)-8:]
+		if dt.d.ValsDataTable != "" {
+			v, err = roTx.GetOne(dt.d.ValsDataTable, v[:8])
+			if err != nil {
+				return nil, 0, false, fmt.Errorf("getLatestFromDb ValsDataTable: %w", err)
+			}
+		}
 	} else {
 		_, stepWithVal, err := func() (_ []byte, _ []byte, err error) {
 			defer func() {
@@ -1607,8 +1685,8 @@ func (dt *DomainRoTx) getLatestFromDb(key []byte, roTx kv.Tx) ([]byte, kv.Step, 
 			return nil, 0, false, nil
 		}
 
-		v = stepWithVal[8:]
 		foundInvStep = stepWithVal[:8]
+		v = stepWithVal[8:]
 	}
 
 	foundStep := kv.Step(^binary.BigEndian.Uint64(foundInvStep))
@@ -1684,12 +1762,13 @@ func (dt *DomainRoTx) RangeAsOf(ctx context.Context, tx kv.Tx, fromKey, toKey []
 func (dt *DomainRoTx) DebugRangeLatest(roTx kv.Tx, fromKey, toKey []byte, limit int) (*DomainLatestIterFile, error) {
 	s := &DomainLatestIterFile{
 		from: fromKey, to: toKey, limit: limit,
-		orderAscend: order.Asc,
-		aggStep:     dt.stepSize,
-		roTx:        roTx,
-		valsTable:   dt.d.KeysTable,
-		logger:      dt.d.logger,
-		h:           &CursorHeap{},
+		orderAscend:   order.Asc,
+		aggStep:       dt.stepSize,
+		roTx:          roTx,
+		valsTable:     dt.d.KeysTable,
+		valsDataTable: dt.d.ValsDataTable,
+		logger:        dt.d.logger,
+		h:             &CursorHeap{},
 	}
 	if err := s.init(dt); err != nil {
 		s.Close() //it's responsibility of constructor (our) to close resource on error
@@ -1912,6 +1991,29 @@ func (dt *DomainRoTx) prune(ctx context.Context, rwTx kv.RwTx, step kv.Step, txF
 
 	prg.KeyProgress = prune.Done // domains don't have key tables
 
+	if dt.d.ValsDataTable != "" {
+		// CommitmentDomain: prune plain keysTable and ValsDataTable together.
+		// keysTable key = domain_key+~step(8B), value = seq_id(8B).
+		// Delete ValsDataTable entry before deleting the keysTable entry.
+		pruneStat, err := dt.pruneWithValsData(ctx, rwTx, valsCursor, txFrom, txTo, limit, logEvery, prg)
+		if err != nil {
+			return stat, err
+		}
+		defer func() {
+			pruneStat.TxFrom, pruneStat.TxTo = txFrom, txTo
+			err = SavePruneValProgress(rwTx, dt.d.KeysTable, pruneStat)
+			if err != nil {
+				dt.d.logger.Error("prune val progress", "name", dt.name, "err", err)
+			}
+		}()
+		mxPruneSizeDomain.AddUint64(pruneStat.PruneCountValues)
+		stat.MinStep = kv.Step(pruneStat.MinTxNum / dt.stepSize)
+		stat.MaxStep = kv.Step(pruneStat.MaxTxNum / dt.stepSize)
+		stat.Values = pruneStat.PruneCountValues
+		stat.Progress = pruneStat.ValueProgress
+		return stat, err
+	}
+
 	pruneStat, err := prune.TableScanningPrune(ctx, "domain "+dt.name.String(), dt.d.FilenameBase, txFrom, txTo, limit, dt.stepSize,
 		logEvery, dt.d.logger, nil, valsCursor, asserts, prg, mode)
 	if err != nil {
@@ -1939,12 +2041,93 @@ func (dt *DomainRoTx) prune(ctx context.Context, rwTx kv.RwTx, step kv.Step, txF
 	return stat, err
 }
 
+// pruneWithValsData prunes the plain (non-DupSort) keysTable and companion ValsDataTable together.
+// keysTable key = domain_key+~step(8B), value = seq_id(8B).
+// The seq_id entry in ValsDataTable is deleted before the keysTable entry.
+func (dt *DomainRoTx) pruneWithValsData(
+	ctx context.Context,
+	rwTx kv.RwTx,
+	keysCursor kv.PseudoDupSortRwCursor,
+	txFrom, txTo, limit uint64,
+	logEvery *time.Ticker,
+	prg *prune.Stat,
+) (stat *prune.Stat, err error) {
+	stat = &prune.Stat{MinTxNum: math.MaxUint64}
+
+	valsDataRw, err := rwTx.RwCursor(dt.d.ValsDataTable)
+	if err != nil {
+		return stat, fmt.Errorf("open %s ValsDataTable cursor: %w", dt.name.String(), err)
+	}
+	defer valsDataRw.Close()
+
+	var k, v []byte
+	switch prg.ValueProgress {
+	case prune.InProgress:
+		k, v, err = keysCursor.Seek(prg.LastPrunedValue)
+	case prune.First:
+		k, v, err = keysCursor.First()
+	default:
+		return stat, nil
+	}
+	if err != nil {
+		return stat, fmt.Errorf("seek %s cursor: %w", dt.name.String(), err)
+	}
+
+	var pruned uint64
+	for k != nil && pruned < limit {
+		if ctx.Err() != nil {
+			stat.LastPrunedValue = common.Copy(k)
+			stat.ValueProgress = prune.InProgress
+			return stat, nil
+		}
+
+		if len(k) >= 8 {
+			stepNum := kv.Step(^binary.BigEndian.Uint64(k[len(k)-8:]))
+			txNum := uint64(stepNum) * dt.stepSize
+			if txNum >= txFrom && txNum < txTo {
+				if delErr := valsDataRw.Delete(v[:8]); delErr != nil {
+					return stat, fmt.Errorf("delete %s ValsDataTable seq_id: %w", dt.name.String(), delErr)
+				}
+				if err = keysCursor.DeleteCurrent(); err != nil {
+					return stat, fmt.Errorf("delete %s keysTable entry: %w", dt.name.String(), err)
+				}
+				stat.MinTxNum = min(stat.MinTxNum, txNum)
+				stat.MaxTxNum = max(stat.MaxTxNum, txNum)
+				pruned++
+				stat.PruneCountValues++
+
+				select {
+				case <-logEvery.C:
+					dt.d.logger.Info("[snapshots] prune domain+valsdata", "name", dt.name, "pruned", pruned)
+				default:
+				}
+			}
+		}
+		k, v, err = keysCursor.Next()
+		if err != nil {
+			return stat, fmt.Errorf("next %s cursor: %w", dt.name.String(), err)
+		}
+	}
+
+	if pruned < limit {
+		stat.ValueProgress = prune.Done
+	} else {
+		stat.LastPrunedValue = common.Copy(k)
+		stat.ValueProgress = prune.InProgress
+	}
+	return stat, nil
+}
+
 func (dt *DomainRoTx) stepsRangeInDB(tx kv.Tx) (from, to float64) {
 	return dt.ht.iit.stepsRangeInDB(tx)
 }
 
 func (dt *DomainRoTx) Tables() (res []string) {
-	return []string{dt.d.KeysTable, dt.ht.h.ValuesTable, dt.ht.iit.ii.KeysTable, dt.ht.iit.ii.ValuesTable}
+	tables := []string{dt.d.KeysTable, dt.ht.h.ValuesTable, dt.ht.iit.ii.KeysTable, dt.ht.iit.ii.ValuesTable}
+	if dt.d.ValsDataTable != "" {
+		tables = append(tables, dt.d.ValsDataTable)
+	}
+	return tables
 }
 
 func (dt *DomainRoTx) Files() (res VisibleFiles) {

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -709,9 +709,14 @@ func (d *Domain) collateETL(ctx context.Context, stepFrom, stepTo kv.Step, wal *
 		fromTxNum = uint64(stepFrom-1) * d.stepSize
 	}
 
+	var prevBareKey []byte // for LargeValues: ETL sorts by domainKey+~step; keep only the first (= latest step) per key
 	err = wal.Load(nil, "", func(k, v []byte, table etl.CurrentTableReader, next etl.LoadNextFunc) error {
 		if d.LargeValues {
 			bareKey := k[:len(k)-8]
+			if bytes.Equal(bareKey, prevBareKey) {
+				return nil // same domain key at an older step — skip
+			}
+			prevBareKey = append(prevBareKey[:0], bareKey...)
 			val := v
 			if vt != nil {
 				val, err = vt(v, fromTxNum, endTxNum)

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -174,7 +174,7 @@ func (d *Domain) maxStepInDB(tx kv.Tx) (lstInDb kv.Step) {
 // maxStepInDBNoHistory - return latest available step in db (at-least 1 value in such step)
 // Does not use history table to find the latest step
 func (d *Domain) maxStepInDBNoHistory(tx kv.Tx) (lstInDb kv.Step) {
-	firstKey, err := kv.FirstKey(tx, d.ValuesTable)
+	firstKey, err := kv.FirstKey(tx, d.KeysTable)
 	if err != nil {
 		d.logger.Warn("[agg] Domain.maxStepInDBNoHistory", "firstKey", firstKey, "err", err)
 		return 0
@@ -186,7 +186,7 @@ func (d *Domain) maxStepInDBNoHistory(tx kv.Tx) (lstInDb kv.Step) {
 		stepBytes := firstKey[len(firstKey)-8:]
 		return kv.Step(^binary.BigEndian.Uint64(stepBytes))
 	}
-	firstVal, err := tx.GetOne(d.ValuesTable, firstKey)
+	firstVal, err := tx.GetOne(d.KeysTable, firstKey)
 	if err != nil {
 		d.logger.Warn("[agg] Domain.maxStepInDBNoHistory", "firstKey", firstKey, "err", err)
 		return 0
@@ -326,7 +326,7 @@ func (d *Domain) calcVisibleFiles(toTxNum uint64) (*domainVisible, visibleFiles,
 	return dv, hv, hiv
 }
 
-func (d *Domain) Tables() []string { return append(d.History.Tables(), d.ValuesTable) }
+func (d *Domain) Tables() []string { return append(d.History.Tables(), d.KeysTable) }
 
 func (d *Domain) Close() {
 	if d == nil {
@@ -375,23 +375,23 @@ func (dt *DomainRoTx) newWriter(tmpdir string, discard bool) *DomainBufferedWrit
 	w := &DomainBufferedWriter{
 		discard:   discard,
 		aux:       make([]byte, 0, 128),
-		valsTable: dt.d.ValuesTable,
+		keysTable: dt.d.KeysTable,
 		largeVals: dt.d.LargeValues,
 		h:         dt.ht.newWriter(tmpdir, discardHistory),
 	}
 	if !discard {
-		w.values = etl.NewCollectorWithAllocator(dt.d.Name.String()+"domain.flush", tmpdir, etl.SmallSortableBuffers, dt.d.logger).
+		w.keys = etl.NewCollectorWithAllocator(dt.d.Name.String()+"domain.flush", tmpdir, etl.SmallSortableBuffers, dt.d.logger).
 			LogLvl(log.LvlTrace).SortAndFlushInBackground(true)
 	}
 	return w
 }
 
 type DomainBufferedWriter struct {
-	values *etl.Collector
+	keys *etl.Collector
 
 	discard bool
 
-	valsTable string
+	keysTable string
 	largeVals bool
 
 	stepBytes [8]byte // current inverted step representation
@@ -407,8 +407,8 @@ func (w *DomainBufferedWriter) Close() {
 		return
 	}
 	w.h.close()
-	if w.values != nil {
-		w.values.Close()
+	if w.keys != nil {
+		w.keys.Close()
 	}
 }
 
@@ -421,19 +421,19 @@ func (w *DomainBufferedWriter) Flush(ctx context.Context, tx kv.RwTx) error {
 	}
 
 	if w.largeVals {
-		if err := w.values.Load(tx, w.valsTable, loadFunc, etl.TransformArgs{Quit: ctx.Done(), EmptyVals: true}); err != nil {
+		if err := w.keys.Load(tx, w.keysTable, loadFunc, etl.TransformArgs{Quit: ctx.Done(), EmptyVals: true}); err != nil {
 			return err
 		}
 		w.Close()
 		return nil
 	}
 
-	valuesCursor, err := tx.RwCursorDupSort(w.valsTable)
+	valuesCursor, err := tx.RwCursorDupSort(w.keysTable)
 	if err != nil {
 		return err
 	}
 	defer valuesCursor.Close()
-	if err := w.values.Load(tx, w.valsTable, func(k, v []byte, table etl.CurrentTableReader, next etl.LoadNextFunc) error {
+	if err := w.keys.Load(tx, w.keysTable, func(k, v []byte, table etl.CurrentTableReader, next etl.LoadNextFunc) error {
 		foundVal, err := valuesCursor.SeekBothRange(k, v[:8])
 		if err != nil {
 			return err
@@ -467,7 +467,7 @@ func (w *DomainBufferedWriter) addValue(k, value []byte, step kv.Step) error {
 			}
 		}
 
-		if err := w.values.Collect(fullkey, value); err != nil {
+		if err := w.keys.Collect(fullkey, value); err != nil {
 			return err
 		}
 		return nil
@@ -486,7 +486,7 @@ func (w *DomainBufferedWriter) addValue(k, value []byte, step kv.Step) error {
 	//	fmt.Printf("addValue     [%p;tx=%d] '%x' -> '%x'\n", w, w.h.ii.txNum, fullkey, value)
 	//}()
 
-	if err := w.values.Collect(k, w.aux2); err != nil {
+	if err := w.keys.Collect(k, w.aux2); err != nil {
 		return err
 	}
 	return nil
@@ -614,7 +614,7 @@ func (d *Domain) dumpStepRangeOnDisk(ctx context.Context, stepFrom, stepTo kv.St
 		panic(fmt.Errorf("assert: stepFrom=%d > stepTo=%d", stepFrom, stepTo))
 	}
 
-	coll, err := d.collateETL(ctx, stepFrom, stepTo, wal.values, vt)
+	coll, err := d.collateETL(ctx, stepFrom, stepTo, wal.keys, vt)
 	defer wal.Close()
 	if err != nil {
 		return err
@@ -752,7 +752,7 @@ func (d *Domain) collate(ctx context.Context, step kv.Step, txFrom, txTo uint64,
 	stepVal := ^uint64(step)
 
 	if d.LargeValues {
-		valsCursor, err := roTx.Cursor(d.ValuesTable)
+		valsCursor, err := roTx.Cursor(d.KeysTable)
 		if err != nil {
 			return Collation{}, fmt.Errorf("create %s values cursor: %w", d.FilenameBase, err)
 		}
@@ -773,7 +773,7 @@ func (d *Domain) collate(ctx context.Context, step kv.Step, txFrom, txTo uint64,
 			}
 		}
 	} else {
-		valsCursor, err := roTx.CursorDupSort(d.ValuesTable)
+		valsCursor, err := roTx.CursorDupSort(d.KeysTable)
 		if err != nil {
 			return Collation{}, fmt.Errorf("create %s values cursorDupsort: %w", d.FilenameBase, err)
 		}
@@ -1229,7 +1229,7 @@ func (dt *DomainRoTx) unwind(ctx context.Context, rwTx kv.RwTx, step, txNumUnwin
 	logEvery := time.NewTicker(time.Second * 30)
 	defer logEvery.Stop()
 
-	valsCursor, err := rwTx.RwCursorDupSort(d.ValuesTable)
+	valsCursor, err := rwTx.RwCursorDupSort(d.KeysTable)
 	if err != nil {
 		return err
 	}
@@ -1261,13 +1261,13 @@ func (dt *DomainRoTx) unwind(ctx context.Context, rwTx kv.RwTx, step, txNumUnwin
 		key := common.ToBytesZeroCopy(keyStr)
 		if dt.d.LargeValues {
 			// Delete the entry at the write step
-			if err := rwTx.Delete(d.ValuesTable, key); err != nil {
+			if err := rwTx.Delete(d.KeysTable, key); err != nil {
 				return err
 			}
 			// nil = different step, skip; []byte{} = absent previously, write empty tombstone
 			if value != nil {
 				fullKey := key[:len(key)-8]
-				if err := rwTx.Put(d.ValuesTable, append(fullKey, unwindStepBytes...), value); err != nil {
+				if err := rwTx.Put(d.KeysTable, append(fullKey, unwindStepBytes...), value); err != nil {
 					return err
 				}
 			}
@@ -1558,10 +1558,10 @@ func (dt *DomainRoTx) valsCursor(tx kv.Tx) (c kv.Cursor, err error) {
 		dt.valCViewID = tx.ViewID()
 	}
 	if dt.d.LargeValues {
-		dt.valsC, err = tx.Cursor(dt.d.ValuesTable)
+		dt.valsC, err = tx.Cursor(dt.d.KeysTable)
 		return dt.valsC, err
 	}
-	dt.valsC, err = tx.CursorDupSort(dt.d.ValuesTable)
+	dt.valsC, err = tx.CursorDupSort(dt.d.KeysTable)
 	return dt.valsC, err
 }
 
@@ -1687,7 +1687,7 @@ func (dt *DomainRoTx) DebugRangeLatest(roTx kv.Tx, fromKey, toKey []byte, limit 
 		orderAscend: order.Asc,
 		aggStep:     dt.stepSize,
 		roTx:        roTx,
-		valsTable:   dt.d.ValuesTable,
+		valsTable:   dt.d.KeysTable,
 		logger:      dt.d.logger,
 		h:           &CursorHeap{},
 	}
@@ -1736,7 +1736,7 @@ func (dt *DomainRoTx) canPruneDomainTables(tx kv.Tx, untilTx uint64) (can bool, 
 	if untilTx > 0 {
 		untilStep = kv.Step((untilTx - 1) / dt.stepSize)
 	}
-	sm, err := GetExecV3PrunableProgress(tx, []byte(dt.d.ValuesTable))
+	sm, err := GetExecV3PrunableProgress(tx, []byte(dt.d.KeysTable))
 	if err != nil {
 		dt.d.logger.Error("get domain pruning progress", "name", dt.d.FilenameBase, "error", err)
 		return false, maxStepToPrune
@@ -1765,7 +1765,7 @@ func (dt *DomainRoTx) canScanPruneDomainTables(tx kv.Tx, untilTx uint64) (can bo
 		maxStepToPrune = kv.Step((m - 1) / dt.stepSize)
 	}
 
-	prg, err := GetPruneValProgress(tx, []byte(dt.d.ValuesTable))
+	prg, err := GetPruneValProgress(tx, []byte(dt.d.KeysTable))
 	if err != nil {
 		dt.d.logger.Error("get domain pruning progress", "name", dt.d.FilenameBase, "error", err)
 		return false, maxStepToPrune
@@ -1858,7 +1858,7 @@ func (dt *DomainRoTx) prune(ctx context.Context, rwTx kv.RwTx, step kv.Step, txF
 	if stat.History, err = dt.ht.Prune(ctx, rwTx, txFrom, txTo, limit, false, logEvery); err != nil {
 		return nil, fmt.Errorf("prune history at step %d [%d, %d): %w", step, txFrom, txTo, err)
 	}
-	prg, err := GetPruneValProgress(rwTx, []byte(dt.d.ValuesTable))
+	prg, err := GetPruneValProgress(rwTx, []byte(dt.d.KeysTable))
 	if err != nil {
 		return stat, err
 	}
@@ -1886,7 +1886,7 @@ func (dt *DomainRoTx) prune(ctx context.Context, rwTx kv.RwTx, step kv.Step, txF
 	var mode prune.StorageMode
 	if dt.d.LargeValues {
 		mode = prune.StepKeyStorageMode
-		valsRwCursor, err := rwTx.RwCursor(dt.d.ValuesTable)
+		valsRwCursor, err := rwTx.RwCursor(dt.d.KeysTable)
 		if err != nil {
 			return stat, fmt.Errorf("create %s domain values cursor: %w", dt.name.String(), err)
 		}
@@ -1903,7 +1903,7 @@ func (dt *DomainRoTx) prune(ctx context.Context, rwTx kv.RwTx, step kv.Step, txF
 		defer valsCursor.Close()
 	} else {
 		mode = prune.StepValueStorageMode
-		valsCursor, err = rwTx.RwCursorDupSort(dt.d.ValuesTable)
+		valsCursor, err = rwTx.RwCursorDupSort(dt.d.KeysTable)
 		if err != nil {
 			return stat, fmt.Errorf("create %s domain values cursor: %w", dt.name.String(), err)
 		}
@@ -1919,7 +1919,7 @@ func (dt *DomainRoTx) prune(ctx context.Context, rwTx kv.RwTx, step kv.Step, txF
 	}
 	defer func() {
 		pruneStat.TxFrom, pruneStat.TxTo = txFrom, txTo
-		err = SavePruneValProgress(rwTx, dt.d.ValuesTable, pruneStat)
+		err = SavePruneValProgress(rwTx, dt.d.KeysTable, pruneStat)
 		if err != nil {
 			dt.d.logger.Error("prune val progress", "name", dt.name, "err", err)
 		}
@@ -1944,7 +1944,7 @@ func (dt *DomainRoTx) stepsRangeInDB(tx kv.Tx) (from, to float64) {
 }
 
 func (dt *DomainRoTx) Tables() (res []string) {
-	return []string{dt.d.ValuesTable, dt.ht.h.ValuesTable, dt.ht.iit.ii.KeysTable, dt.ht.iit.ii.ValuesTable}
+	return []string{dt.d.KeysTable, dt.ht.h.ValuesTable, dt.ht.iit.ii.KeysTable, dt.ht.iit.ii.ValuesTable}
 }
 
 func (dt *DomainRoTx) Files() (res VisibleFiles) {

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1653,25 +1653,24 @@ func (dt *DomainRoTx) getLatestFromDb(key []byte, roTx kv.Tx) ([]byte, kv.Step, 
 		}
 		// For variable-length domain keys (e.g. commitment trie prefixes), Seek(key) may
 		// land on a longer stored key that has 'key' as a byte prefix, because in MDBX
-		// shorter keys sort before longer ones with the same prefix. Scan forward until we
-		// find the stored entry whose domain-key part is exactly 'key', or determine it
-		// is absent by overshooting past key+0xff…ff (the max stored key for this domain key).
-		maxKey := make([]byte, len(key)+8)
-		copy(maxKey, key)
-		for i := len(key); i < len(maxKey); i++ {
-			maxKey[i] = 0xff
-		}
-		for len(fullkey) > 0 {
-			if len(fullkey) >= 8 && bytes.Equal(fullkey[:len(fullkey)-8], key) {
-				break
-			}
-			if bytes.Compare(fullkey, maxKey) > 0 {
-				fullkey = nil
-				break
-			}
-			fullkey, v, err = valsC.Next()
-			if err != nil {
-				return nil, 0, false, fmt.Errorf("valsCursor.Next: %w", err)
+		// shorter keys sort before longer ones with the same prefix. Scan forward to find
+		// the stored entry whose domain-key part is exactly 'key', stopping when we
+		// overshoot past key+0xff…ff (the max stored key for this domain key).
+		if len(fullkey) > 0 && !(len(fullkey) >= 8 && bytes.Equal(fullkey[:len(fullkey)-8], key)) {
+			// maxKey is key + 8×0xff; allocate only when scan is actually needed.
+			maxKey := append(key[:len(key):len(key)], 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff)
+			for {
+				if bytes.Compare(fullkey, maxKey) > 0 {
+					fullkey = nil
+					break
+				}
+				fullkey, v, err = valsC.Next()
+				if err != nil {
+					return nil, 0, false, fmt.Errorf("valsCursor.Next: %w", err)
+				}
+				if len(fullkey) == 0 || (len(fullkey) >= 8 && bytes.Equal(fullkey[:len(fullkey)-8], key)) {
+					break
+				}
 			}
 		}
 		if len(fullkey) == 0 {

--- a/db/state/domain_stream.go
+++ b/db/state/domain_stream.go
@@ -221,7 +221,7 @@ func (hi *DomainLatestIterFile) init(domainRoTx *DomainRoTx) error {
 
 func (hi *DomainLatestIterFile) initCursorOnDB(domainRoTx *DomainRoTx) error {
 	if domainRoTx.d.LargeValues {
-		valsCursor, err := hi.roTx.Cursor(domainRoTx.d.ValuesTable) //nolint:gocritic
+		valsCursor, err := hi.roTx.Cursor(domainRoTx.d.KeysTable) //nolint:gocritic
 		if err != nil {
 			return err
 		}
@@ -251,7 +251,7 @@ func (hi *DomainLatestIterFile) initCursorOnDB(domainRoTx *DomainRoTx) error {
 			}
 		}
 	} else {
-		valsCursor, err := hi.roTx.CursorDupSort(domainRoTx.d.ValuesTable) //nolint:gocritic
+		valsCursor, err := hi.roTx.CursorDupSort(domainRoTx.d.KeysTable) //nolint:gocritic
 		if err != nil {
 			return err
 		}
@@ -484,7 +484,7 @@ func (dt *DomainRoTx) debugIteratePrefixLatest(prefix []byte, ramIter btree2.Map
 		}
 	}
 
-	valsCursor, err := roTx.CursorDupSort(dt.d.ValuesTable)
+	valsCursor, err := roTx.CursorDupSort(dt.d.KeysTable)
 	if err != nil {
 		return err
 	}

--- a/db/state/domain_stream.go
+++ b/db/state/domain_stream.go
@@ -108,6 +108,7 @@ type DomainLatestIterFile struct {
 	filesEndTxNum uint64 // files are authoritative for steps below this txNum
 	roTx          kv.Tx
 	valsTable     string
+	valsDataTable string // when set, KeysTable values are seq_id(8B) refs; actual values are in valsDataTable
 
 	limit       int
 	largeVals   bool
@@ -121,6 +122,24 @@ type DomainLatestIterFile struct {
 	k, v, kBackup, vBackup []byte
 
 	logger log.Logger
+}
+
+// derefValsData resolves the actual domain value from a plain-cursor value.
+// When valsDataTable is non-empty, v is a seq_id(8B) reference into valsDataTable;
+// otherwise v IS the actual value.
+func derefValsData(roTx kv.Tx, valsDataTable string, v []byte) ([]byte, error) {
+	if valsDataTable == "" {
+		return v, nil
+	}
+	actual, err := roTx.GetOne(valsDataTable, v[:8])
+	if err != nil {
+		return nil, fmt.Errorf("derefValsData: %w", err)
+	}
+	return actual, nil
+}
+
+func (hi *DomainLatestIterFile) derefLargeVal(v []byte) ([]byte, error) {
+	return derefValsData(hi.roTx, hi.valsDataTable, v)
 }
 
 func (hi *DomainLatestIterFile) Close() {
@@ -241,7 +260,11 @@ func (hi *DomainLatestIterFile) initCursorOnDB(domainRoTx *DomainRoTx) error {
 			step := ^binary.BigEndian.Uint64(stepBytes)
 			endTxNum := step * domainRoTx.d.stepSize
 			if endTxNum >= hi.filesEndTxNum {
-				heap.Push(hi.h, &CursorItem{t: DB_CURSOR, key: common.Copy(k), val: common.Copy(value), cNonDup: valsCursor, endTxNum: endTxNum, reverse: true})
+				val, err := hi.derefLargeVal(value)
+				if err != nil {
+					return err
+				}
+				heap.Push(hi.h, &CursorItem{t: DB_CURSOR, key: common.Copy(k), val: common.Copy(val), cNonDup: valsCursor, endTxNum: endTxNum, reverse: true})
 				pushed = true
 				break
 			}
@@ -267,11 +290,10 @@ func (hi *DomainLatestIterFile) initCursorOnDB(domainRoTx *DomainRoTx) error {
 		}
 		for key != nil && (hi.to == nil || bytes.Compare(key, hi.to) < 0) {
 			stepBytes := value[:8]
-			val := value[8:]
 			step := ^binary.BigEndian.Uint64(stepBytes)
 			endTxNum := step * domainRoTx.d.stepSize
 			if endTxNum >= hi.filesEndTxNum {
-				heap.Push(hi.h, &CursorItem{t: DB_CURSOR, key: common.Copy(key), val: common.Copy(val), cDup: valsCursor, endTxNum: endTxNum, reverse: true})
+				heap.Push(hi.h, &CursorItem{t: DB_CURSOR, key: common.Copy(key), val: common.Copy(value[8:]), cDup: valsCursor, endTxNum: endTxNum, reverse: true})
 				pushed = true
 				break
 			}
@@ -317,9 +339,13 @@ func (hi *DomainLatestIterFile) advanceLargeValsDBCursor(ci1 *CursorItem) error 
 		step := ^binary.BigEndian.Uint64(stepBytes)
 		endTxNum := step * hi.aggStep
 		if endTxNum >= hi.filesEndTxNum {
+			val, err := hi.derefLargeVal(v)
+			if err != nil {
+				return err
+			}
 			ci1.key = common.Copy(k[:len(k)-8])
 			ci1.endTxNum = endTxNum
-			ci1.val = common.Copy(v)
+			ci1.val = common.Copy(val)
 			heap.Push(hi.h, ci1)
 			pushed = true
 			break
@@ -344,13 +370,12 @@ func (hi *DomainLatestIterFile) advanceDupSortDBCursor(ci1 *CursorItem) error {
 			break
 		}
 		stepBytes := stepBytesWithValue[:8]
-		v := stepBytesWithValue[8:]
 		step := ^binary.BigEndian.Uint64(stepBytes)
 		endTxNum := step * hi.aggStep
 		if endTxNum >= hi.filesEndTxNum {
 			ci1.key = common.Copy(k)
 			ci1.endTxNum = endTxNum
-			ci1.val = common.Copy(v)
+			ci1.val = common.Copy(stepBytesWithValue[8:])
 			heap.Push(hi.h, ci1)
 			pushed = true
 			break
@@ -471,7 +496,6 @@ func (dt *DomainRoTx) debugIteratePrefixLatest(prefix []byte, ramIter btree2.Map
 		}
 	}()
 	var k, v []byte
-	var err error
 	filesEndTxNum := dt.files.EndTxNum()
 
 	if ramIter.Seek(string(prefix)) {
@@ -484,24 +508,50 @@ func (dt *DomainRoTx) debugIteratePrefixLatest(prefix []byte, ramIter btree2.Map
 		}
 	}
 
-	valsCursor, err := roTx.CursorDupSort(dt.d.KeysTable)
-	if err != nil {
-		return err
-	}
-	defer valsCursor.Close()
-	if k, v, err = valsCursor.Seek(prefix); err != nil {
-		return err
-	}
-	// Skip DB entries whose step falls within the file range — files are authoritative there.
-	for len(k) > 0 && bytes.HasPrefix(k, prefix) {
-		step := kv.Step(^binary.BigEndian.Uint64(v[:8]))
-		if step.ToTxNum(dt.stepSize) >= filesEndTxNum {
-			val := v[8:]
-			heap.Push(cpPtr, &CursorItem{t: DB_CURSOR, key: common.Copy(k), val: common.Copy(val), cDup: valsCursor, endTxNum: step.ToTxNum(dt.stepSize), reverse: true})
-			break
-		}
-		if k, v, err = valsCursor.NextNoDup(); err != nil {
+	if dt.d.LargeValues {
+		// Plain cursor: key = domain_key+~step(8B), value = actual_value or seq_id(8B).
+		plainCursor, err := roTx.Cursor(dt.d.KeysTable)
+		if err != nil {
 			return err
+		}
+		defer plainCursor.Close()
+		if k, v, err = plainCursor.Seek(prefix); err != nil {
+			return err
+		}
+		for len(k) >= 8 && bytes.HasPrefix(k[:len(k)-8], prefix) {
+			step := kv.Step(^binary.BigEndian.Uint64(k[len(k)-8:]))
+			if step.ToTxNum(dt.stepSize) >= filesEndTxNum {
+				bareKey := k[:len(k)-8]
+				val, err := derefValsData(roTx, dt.d.ValsDataTable, v)
+				if err != nil {
+					return fmt.Errorf("debugIteratePrefixLatest: %w", err)
+				}
+				heap.Push(cpPtr, &CursorItem{t: DB_CURSOR, key: common.Copy(bareKey), val: common.Copy(val), cNonDup: plainCursor, endTxNum: step.ToTxNum(dt.stepSize), reverse: true})
+				break
+			}
+			if k, v, err = plainCursor.Next(); err != nil {
+				return err
+			}
+		}
+	} else {
+		valsCursor, err := roTx.CursorDupSort(dt.d.KeysTable)
+		if err != nil {
+			return err
+		}
+		defer valsCursor.Close()
+		if k, v, err = valsCursor.Seek(prefix); err != nil {
+			return err
+		}
+		// Skip DB entries whose step falls within the file range — files are authoritative there.
+		for len(k) > 0 && bytes.HasPrefix(k, prefix) {
+			step := kv.Step(^binary.BigEndian.Uint64(v[:8]))
+			if step.ToTxNum(dt.stepSize) >= filesEndTxNum {
+				heap.Push(cpPtr, &CursorItem{t: DB_CURSOR, key: common.Copy(k), val: common.Copy(v[8:]), cDup: valsCursor, endTxNum: step.ToTxNum(dt.stepSize), reverse: true})
+				break
+			}
+			if k, v, err = valsCursor.NextNoDup(); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -569,26 +619,55 @@ func (dt *DomainRoTx) debugIteratePrefixLatest(prefix []byte, ramIter btree2.Map
 				}
 			case DB_CURSOR:
 				var pushed bool
-				for {
-					k, v, err := ci1.cDup.NextNoDup()
-					if err != nil {
-						return err
+				if dt.d.LargeValues {
+					for {
+						k, v, err := ci1.cNonDup.Next()
+						if err != nil {
+							return err
+						}
+						if len(k) < 8 || !bytes.HasPrefix(k[:len(k)-8], prefix) {
+							break
+						}
+						step := kv.Step(^binary.BigEndian.Uint64(k[len(k)-8:]))
+						if step.ToTxNum(dt.stepSize) >= filesEndTxNum {
+							bareKey := k[:len(k)-8]
+							val, err := derefValsData(roTx, dt.d.ValsDataTable, v)
+							if err != nil {
+								return fmt.Errorf("debugIteratePrefixLatest: %w", err)
+							}
+							ci1.key = common.Copy(bareKey)
+							ci1.endTxNum = step.ToTxNum(dt.stepSize)
+							ci1.val = common.Copy(val)
+							heap.Push(cpPtr, ci1)
+							pushed = true
+							break
+						}
 					}
-					if len(k) == 0 || !bytes.HasPrefix(k, prefix) {
-						break
+					if !pushed {
+						ci1.cNonDup.Close()
 					}
-					step := kv.Step(^binary.BigEndian.Uint64(v[:8]))
-					if step.ToTxNum(dt.stepSize) >= filesEndTxNum {
-						ci1.key = common.Copy(k)
-						ci1.endTxNum = step.ToTxNum(dt.stepSize)
-						ci1.val = common.Copy(v[8:])
-						heap.Push(cpPtr, ci1)
-						pushed = true
-						break
+				} else {
+					for {
+						k, v, err := ci1.cDup.NextNoDup()
+						if err != nil {
+							return err
+						}
+						if len(k) == 0 || !bytes.HasPrefix(k, prefix) {
+							break
+						}
+						step := kv.Step(^binary.BigEndian.Uint64(v[:8]))
+						if step.ToTxNum(dt.stepSize) >= filesEndTxNum {
+							ci1.key = common.Copy(k)
+							ci1.endTxNum = step.ToTxNum(dt.stepSize)
+							ci1.val = common.Copy(v[8:])
+							heap.Push(cpPtr, ci1)
+							pushed = true
+							break
+						}
 					}
-				}
-				if !pushed {
-					ci1.cDup.Close()
+					if !pushed {
+						ci1.cDup.Close()
+					}
 				}
 			}
 		}

--- a/db/state/domain_stream.go
+++ b/db/state/domain_stream.go
@@ -138,10 +138,6 @@ func derefValsData(roTx kv.Tx, valsDataTable string, v []byte) ([]byte, error) {
 	return actual, nil
 }
 
-func (hi *DomainLatestIterFile) derefLargeVal(v []byte) ([]byte, error) {
-	return derefValsData(hi.roTx, hi.valsDataTable, v)
-}
-
 func (hi *DomainLatestIterFile) Close() {
 	if hi.h == nil {
 		return
@@ -260,7 +256,7 @@ func (hi *DomainLatestIterFile) initCursorOnDB(domainRoTx *DomainRoTx) error {
 			step := ^binary.BigEndian.Uint64(stepBytes)
 			endTxNum := step * domainRoTx.d.stepSize
 			if endTxNum >= hi.filesEndTxNum {
-				val, err := hi.derefLargeVal(value)
+				val, err := derefValsData(hi.roTx, hi.valsDataTable, value)
 				if err != nil {
 					return err
 				}
@@ -339,7 +335,7 @@ func (hi *DomainLatestIterFile) advanceLargeValsDBCursor(ci1 *CursorItem) error 
 		step := ^binary.BigEndian.Uint64(stepBytes)
 		endTxNum := step * hi.aggStep
 		if endTxNum >= hi.filesEndTxNum {
-			val, err := hi.derefLargeVal(v)
+			val, err := derefValsData(hi.roTx, hi.valsDataTable, v)
 			if err != nil {
 				return err
 			}

--- a/db/state/domain_stream_test.go
+++ b/db/state/domain_stream_test.go
@@ -199,7 +199,7 @@ func TestDomain_IteratePrefix_PrefersFilesOverDB(t *testing.T) {
 	tx, err = db.BeginRw(ctx)
 	require.NoError(err)
 	defer tx.Rollback()
-	c, err := tx.RwCursorDupSort(d.ValuesTable)
+	c, err := tx.RwCursorDupSort(d.KeysTable)
 	require.NoError(err)
 	defer c.Close()       //nolint:gocritic
 	var step1Dup [16]byte // [^step1 (8 bytes) | V1 (8 bytes)]
@@ -295,7 +295,7 @@ func TestDomainLatestIterFile_PrefersFilesOverDB(t *testing.T) {
 	tx, err = db.BeginRw(ctx)
 	require.NoError(err)
 	defer tx.Rollback()
-	c, err := tx.RwCursorDupSort(d.ValuesTable)
+	c, err := tx.RwCursorDupSort(d.KeysTable)
 	require.NoError(err)
 	defer c.Close()       //nolint:gocritic
 	var step1Dup [16]byte // [^step1 (8 bytes) | V1 (8 bytes)]
@@ -401,7 +401,7 @@ func TestDomainLatestIterFile_PrefersFilesOverDB_LargeValues(t *testing.T) {
 	var step1Key [16]byte // [userKey (8 bytes) || ^step1 (8 bytes)]
 	copy(step1Key[:8], key[:])
 	binary.BigEndian.PutUint64(step1Key[8:], ^uint64(1))
-	require.NoError(tx.Delete(d.ValuesTable, step1Key[:]))
+	require.NoError(tx.Delete(d.KeysTable, step1Key[:]))
 	require.NoError(tx.Commit())
 
 	// DebugRangeLatest (which uses DomainLatestIterFile) should return V1

--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -2269,7 +2269,7 @@ func TestDomain_PruneProgress(t *testing.T) {
 		TxFrom:          0,
 		TxTo:            stepSize,
 	}
-	err = SavePruneValProgress(rwTx, d.ValuesTable, injected)
+	err = SavePruneValProgress(rwTx, d.KeysTable, injected)
 	require.NoError(t, err)
 
 	stat, err := domainRoTx.prune(ctx, rwTx, 0, 0, stepSize, math.MaxUint64, logEvery)
@@ -2279,13 +2279,13 @@ func TestDomain_PruneProgress(t *testing.T) {
 	require.LessOrEqual(t, stat.Values+stat.Dups, uint64(keyCount/2),
 		"only entries at/after the cursor position should be deleted")
 
-	prg, err := GetPruneValProgress(rwTx, []byte(d.ValuesTable))
+	prg, err := GetPruneValProgress(rwTx, []byte(d.KeysTable))
 	require.NoError(t, err)
 	require.Equal(t, prune.Done, prg.ValueProgress)
 	require.Nil(t, prg.LastPrunedValue, "cursor must be nil after a completed rotation")
 
 	// Verify the first half of keys still exists (before the cursor, not pruned).
-	remaining := countDupSortKeys(t, rwTx, d.ValuesTable)
+	remaining := countDupSortKeys(t, rwTx, d.KeysTable)
 	require.Equal(t, int(keyCount/2), remaining,
 		"keys 0..keyCount/2-1 skipped by rolling cursor must remain")
 
@@ -2296,7 +2296,7 @@ func TestDomain_PruneProgress(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, prune.Done, stat2.Progress)
 	require.Zero(t, stat2.Values+stat2.Dups, "early-exit must do no deletions")
-	require.Equal(t, int(keyCount/2), countDupSortKeys(t, rwTx, d.ValuesTable),
+	require.Equal(t, int(keyCount/2), countDupSortKeys(t, rwTx, d.KeysTable),
 		"early-exit must not change table contents")
 
 	// --- Part 3: new rotation when txTo advances ---------------------------
@@ -2308,9 +2308,9 @@ func TestDomain_PruneProgress(t *testing.T) {
 	require.Equal(t, prune.Done, stat3.Progress)
 	require.EqualValues(t, keyCount/2, stat3.Values+stat3.Dups,
 		"new rotation must clean the first half skipped in rotation 1")
-	require.Zero(t, countDupSortKeys(t, rwTx, d.ValuesTable), "all step-0 entries must be gone")
+	require.Zero(t, countDupSortKeys(t, rwTx, d.KeysTable), "all step-0 entries must be gone")
 
-	prg3, err := GetPruneValProgress(rwTx, []byte(d.ValuesTable))
+	prg3, err := GetPruneValProgress(rwTx, []byte(d.KeysTable))
 	require.NoError(t, err)
 	require.Equal(t, prune.Done, prg3.ValueProgress)
 }
@@ -2379,9 +2379,9 @@ func TestDomain_PruneRollingCursorProgress(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, prune.Done, stat0.Progress)
 	require.NotZero(t, stat0.Values+stat0.Dups, "step-0 entries must have been deleted")
-	require.Zero(t, countDupSortKeys(t, rwTx, d.ValuesTable), "table must be empty after step-0 prune")
+	require.Zero(t, countDupSortKeys(t, rwTx, d.KeysTable), "table must be empty after step-0 prune")
 
-	prg, err := GetPruneValProgress(rwTx, []byte(d.ValuesTable))
+	prg, err := GetPruneValProgress(rwTx, []byte(d.KeysTable))
 	require.NoError(t, err)
 	require.Equal(t, prune.Done, prg.ValueProgress)
 	require.EqualValues(t, stepSize, prg.TxTo)
@@ -2401,9 +2401,9 @@ func TestDomain_PruneRollingCursorProgress(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, prune.Done, stat1.Progress)
 	require.NotZero(t, stat1.Values+stat1.Dups, "step-1 entries must be deleted in new rotation")
-	require.Zero(t, countDupSortKeys(t, rwTx, d.ValuesTable), "table must be empty after both rotations")
+	require.Zero(t, countDupSortKeys(t, rwTx, d.KeysTable), "table must be empty after both rotations")
 
-	prg1, err := GetPruneValProgress(rwTx, []byte(d.ValuesTable))
+	prg1, err := GetPruneValProgress(rwTx, []byte(d.KeysTable))
 	require.NoError(t, err)
 	require.Equal(t, prune.Done, prg1.ValueProgress)
 	require.Nil(t, prg1.LastPrunedValue, "cursor reset after rotation completion")
@@ -2424,7 +2424,7 @@ func TestDomain_PruneRollingCursorProgress(t *testing.T) {
 		TxFrom:          txFrom2,
 		TxTo:            txTo2,
 	}
-	require.NoError(t, SavePruneValProgress(rwTx, d.ValuesTable, injected))
+	require.NoError(t, SavePruneValProgress(rwTx, d.KeysTable, injected))
 
 	// Call with the same txTo2 (InProgress, not Done → no reset).
 	stat2, err := domRoTx.prune(ctx, rwTx, 2, txFrom2, txTo2, math.MaxUint64, logEvery)
@@ -2434,7 +2434,7 @@ func TestDomain_PruneRollingCursorProgress(t *testing.T) {
 	require.LessOrEqual(t, stat2.Values+stat2.Dups, uint64(keyCount/2),
 		"cursor started at midKey so only the second half of keys could be deleted")
 	// First half still in table (cursor skipped them).
-	require.Equal(t, int(keyCount/2), countDupSortKeys(t, rwTx, d.ValuesTable),
+	require.Equal(t, int(keyCount/2), countDupSortKeys(t, rwTx, d.KeysTable),
 		"first half of step-2 keys must remain (before cursor position)")
 }
 

--- a/db/state/execctx/domain_shared_test.go
+++ b/db/state/execctx/domain_shared_test.go
@@ -426,20 +426,20 @@ func TestSharedDomain_RepeatedUnwindAcrossStepBoundary(t *testing.T) {
 	require.LessOrEqualf(postBlock, unwindTarget,
 		"commitment state blockNum=%d must be ≤ unwindTarget=%d after repeated unwinds",
 		postBlock, unwindTarget)
-	// Verify: no commitment values table entries with step > unwindTarget/stepSize.
+	// Verify: no commitment keys table entries with step > unwindTarget/stepSize.
 	maxStep := unwindTarget / stepSize
-	c, err := rwTx.Cursor(kv.TblCommitmentVals)
+	c, err := rwTx.Cursor(kv.TblCommitmentKeys)
 	require.NoError(err)
 	defer c.Close()
 	offending := 0
 	var exampleStep uint64
-	for k, _, err := c.First(); k != nil; k, _, err = c.Next() {
+	for _, v, err := c.First(); v != nil; _, v, err = c.Next() {
 		require.NoError(err)
-		// CommitmentVals is LargeValues: key = domainKey+~step(8B), value = seq_id
-		if len(k) < 8 {
+		// CommitmentKeys is DupSort LargeValues: bareKey → ~step(8)+seq_id(8); step in dup-value first 8 bytes
+		if len(v) < 8 {
 			continue
 		}
-		step := ^binary.BigEndian.Uint64(k[len(k)-8:])
+		step := ^binary.BigEndian.Uint64(v[:8])
 		if step > maxStep {
 			if offending == 0 {
 				exampleStep = step
@@ -448,7 +448,7 @@ func TestSharedDomain_RepeatedUnwindAcrossStepBoundary(t *testing.T) {
 		}
 	}
 	require.Zerof(offending,
-		"%d commitment values entries have step > %d after repeated unwinds (e.g. step %d); "+
+		"%d commitment keys entries have step > %d after repeated unwinds (e.g. step %d); "+
 			"these are the \"orphan\" entries that caused mainnet execution to start at stale commitment state",
 		offending, maxStep, exampleStep)
 }
@@ -582,28 +582,19 @@ func TestSharedDomain_MergeUnwindAcrossStepBoundary(t *testing.T) {
 	// (while corrupting the restored value), so this assertion is mostly
 	// belt-and-braces — still worth guarding against a future regression
 	// that drops entries outright instead of just mis-writing them.
-	// largeVals=true: CommitmentVals stores key=domainKey+~step, value=seq_id (step is in the key).
-	// largeVals=false: AccountVals stores key=domainKey, value=~step+actual (step is in the value).
-	checkTableForOrphans := func(table string, largeVals bool) {
+	// All domain KeysTables are DupSort: bareKey → ~step(8)+payload; step is in first 8 bytes of dup value.
+	checkTableForOrphans := func(table string) {
 		c, err := rwTx.Cursor(table)
 		require.NoError(err)
 		defer c.Close()
 		offending := 0
 		var exampleStep uint64
-		for k, v, err := c.First(); k != nil; k, v, err = c.Next() {
+		for _, v, err := c.First(); v != nil; _, v, err = c.Next() {
 			require.NoError(err)
-			var step uint64
-			if largeVals {
-				if len(k) < 8 {
-					continue
-				}
-				step = ^binary.BigEndian.Uint64(k[len(k)-8:])
-			} else {
-				if len(v) < 8 {
-					continue
-				}
-				step = ^binary.BigEndian.Uint64(v[:8])
+			if len(v) < 8 {
+				continue
 			}
+			step := ^binary.BigEndian.Uint64(v[:8])
 			if step > maxStep {
 				if offending == 0 {
 					exampleStep = step
@@ -615,8 +606,8 @@ func TestSharedDomain_MergeUnwindAcrossStepBoundary(t *testing.T) {
 			"table %s has %d orphan values entries at step > %d after Merge+Flush (e.g. step %d)",
 			table, offending, maxStep, exampleStep)
 	}
-	checkTableForOrphans(kv.TblAccountVals, false)
-	checkTableForOrphans(kv.TblCommitmentVals, true)
+	checkTableForOrphans(kv.TblAccountVals)
+	checkTableForOrphans(kv.TblCommitmentKeys)
 }
 
 // TestSharedDomain_UnwindAcrossStepBoundary reproduces the mainnet corruption
@@ -720,25 +711,25 @@ func TestSharedDomain_UnwindAcrossStepBoundary(t *testing.T) {
 	require.LessOrEqualf(postBlock, unwindTarget,
 		"post-unwind: commitment state blockNum=%d must be ≤ unwindTarget=%d (txNum=%d)",
 		postBlock, unwindTarget, postTxNum)
-	// Fix: also confirm no values table entries exist above the unwind-target step.
+	// Fix: also confirm no keys table entries exist above the unwind-target step.
 	maxStep := unwindTarget / stepSize // step 0 for target 4
-	c, err := rwTx.Cursor(kv.TblCommitmentVals)
+	c, err := rwTx.Cursor(kv.TblCommitmentKeys)
 	require.NoError(err)
 	defer c.Close()
 	offending := 0
-	for k, _, err := c.First(); k != nil; k, _, err = c.Next() {
+	for _, v, err := c.First(); v != nil; _, v, err = c.Next() {
 		require.NoError(err)
-		// CommitmentVals is LargeValues: key = domainKey+~step(8B), value = seq_id
-		if len(k) < 8 {
+		// CommitmentKeys is DupSort LargeValues: bareKey → ~step(8)+seq_id(8); step in dup-value first 8 bytes
+		if len(v) < 8 {
 			continue
 		}
-		step := ^binary.BigEndian.Uint64(k[len(k)-8:])
+		step := ^binary.BigEndian.Uint64(v[:8])
 		if step > maxStep {
 			offending++
 		}
 	}
 	require.Zerof(offending,
-		"post-unwind: %d commitment values entries have step > %d (maxStep for unwindTarget=%d)",
+		"post-unwind: %d commitment keys entries have step > %d (maxStep for unwindTarget=%d)",
 		offending, maxStep, unwindTarget)
 }
 

--- a/db/state/execctx/domain_shared_test.go
+++ b/db/state/execctx/domain_shared_test.go
@@ -433,12 +433,13 @@ func TestSharedDomain_RepeatedUnwindAcrossStepBoundary(t *testing.T) {
 	defer c.Close()
 	offending := 0
 	var exampleStep uint64
-	for k, v, err := c.First(); k != nil; k, v, err = c.Next() {
+	for k, _, err := c.First(); k != nil; k, _, err = c.Next() {
 		require.NoError(err)
-		if len(v) < 8 {
+		// CommitmentVals is LargeValues: key = domainKey+~step(8B), value = seq_id
+		if len(k) < 8 {
 			continue
 		}
-		step := ^binary.BigEndian.Uint64(v[:8])
+		step := ^binary.BigEndian.Uint64(k[len(k)-8:])
 		if step > maxStep {
 			if offending == 0 {
 				exampleStep = step
@@ -581,7 +582,9 @@ func TestSharedDomain_MergeUnwindAcrossStepBoundary(t *testing.T) {
 	// (while corrupting the restored value), so this assertion is mostly
 	// belt-and-braces — still worth guarding against a future regression
 	// that drops entries outright instead of just mis-writing them.
-	checkTableForOrphans := func(table string) {
+	// largeVals=true: CommitmentVals stores key=domainKey+~step, value=seq_id (step is in the key).
+	// largeVals=false: AccountVals stores key=domainKey, value=~step+actual (step is in the value).
+	checkTableForOrphans := func(table string, largeVals bool) {
 		c, err := rwTx.Cursor(table)
 		require.NoError(err)
 		defer c.Close()
@@ -589,10 +592,18 @@ func TestSharedDomain_MergeUnwindAcrossStepBoundary(t *testing.T) {
 		var exampleStep uint64
 		for k, v, err := c.First(); k != nil; k, v, err = c.Next() {
 			require.NoError(err)
-			if len(v) < 8 {
-				continue
+			var step uint64
+			if largeVals {
+				if len(k) < 8 {
+					continue
+				}
+				step = ^binary.BigEndian.Uint64(k[len(k)-8:])
+			} else {
+				if len(v) < 8 {
+					continue
+				}
+				step = ^binary.BigEndian.Uint64(v[:8])
 			}
-			step := ^binary.BigEndian.Uint64(v[:8])
 			if step > maxStep {
 				if offending == 0 {
 					exampleStep = step
@@ -604,8 +615,8 @@ func TestSharedDomain_MergeUnwindAcrossStepBoundary(t *testing.T) {
 			"table %s has %d orphan values entries at step > %d after Merge+Flush (e.g. step %d)",
 			table, offending, maxStep, exampleStep)
 	}
-	checkTableForOrphans(kv.TblAccountVals)
-	checkTableForOrphans(kv.TblCommitmentVals)
+	checkTableForOrphans(kv.TblAccountVals, false)
+	checkTableForOrphans(kv.TblCommitmentVals, true)
 }
 
 // TestSharedDomain_UnwindAcrossStepBoundary reproduces the mainnet corruption
@@ -715,12 +726,13 @@ func TestSharedDomain_UnwindAcrossStepBoundary(t *testing.T) {
 	require.NoError(err)
 	defer c.Close()
 	offending := 0
-	for k, v, err := c.First(); k != nil; k, v, err = c.Next() {
+	for k, _, err := c.First(); k != nil; k, _, err = c.Next() {
 		require.NoError(err)
-		if len(v) < 8 {
+		// CommitmentVals is LargeValues: key = domainKey+~step(8B), value = seq_id
+		if len(k) < 8 {
 			continue
 		}
-		step := ^binary.BigEndian.Uint64(v[:8])
+		step := ^binary.BigEndian.Uint64(k[len(k)-8:])
 		if step > maxStep {
 			offending++
 		}

--- a/db/state/history.go
+++ b/db/state/history.go
@@ -324,7 +324,7 @@ func (h *History) buildVI(ctx context.Context, historyIdxPath string, hist, efHi
 
 		if err = rs.Build(ctx); err != nil {
 			if rs.Collision() {
-				log.Info("Building recsplit. Collision happened. It's ok. Restarting...")
+				log.Info("Building recsplit. Collision happened. It's ok. Restarting...", "file", fName, "keys", cnt)
 				rs.ResetNextSalt()
 			} else {
 				return fmt.Errorf("build idx: %w", err)

--- a/db/state/statecfg/state_schema.go
+++ b/db/state/statecfg/state_schema.go
@@ -191,7 +191,7 @@ var ExperimentalConcurrentCommitment = false // set true to use concurrent commi
 
 var Schema = SchemaGen{
 	AccountsDomain: DomainCfg{
-		Name: kv.AccountsDomain, ValuesTable: kv.TblAccountVals,
+		Name: kv.AccountsDomain, KeysTable: kv.TblAccountVals,
 		CompressCfg: DomainCompressCfg, Compression: seg.CompressNone,
 
 		Accessors: AccessorBTree | AccessorExistence,
@@ -212,7 +212,7 @@ var Schema = SchemaGen{
 		},
 	},
 	StorageDomain: DomainCfg{
-		Name: kv.StorageDomain, ValuesTable: kv.TblStorageVals,
+		Name: kv.StorageDomain, KeysTable: kv.TblStorageVals,
 		CompressCfg: DomainCompressCfg, Compression: seg.CompressKeys,
 
 		Accessors: AccessorBTree | AccessorExistence,
@@ -233,7 +233,7 @@ var Schema = SchemaGen{
 		},
 	},
 	CodeDomain: DomainCfg{
-		Name: kv.CodeDomain, ValuesTable: kv.TblCodeVals,
+		Name: kv.CodeDomain, KeysTable: kv.TblCodeVals,
 		CompressCfg: DomainCompressCfg, Compression: seg.CompressVals, // compressing Code with keys doesn't show any benefits. Compression of values shows 4x ratio on eth-mainnet and 2.5x ratio on bor-mainnet
 
 		Accessors:   AccessorBTree | AccessorExistence,
@@ -255,7 +255,7 @@ var Schema = SchemaGen{
 		},
 	},
 	CommitmentDomain: DomainCfg{
-		Name: kv.CommitmentDomain, ValuesTable: kv.TblCommitmentVals,
+		Name: kv.CommitmentDomain, KeysTable: kv.TblCommitmentVals,
 		CompressCfg: DomainCompressCfg, Compression: seg.CompressKeys,
 
 		Accessors:           AccessorHashMap,
@@ -281,7 +281,7 @@ var Schema = SchemaGen{
 		},
 	},
 	ReceiptDomain: DomainCfg{
-		Name: kv.ReceiptDomain, ValuesTable: kv.TblReceiptVals,
+		Name: kv.ReceiptDomain, KeysTable: kv.TblReceiptVals,
 		CompressCfg: seg.DefaultCfg, Compression: seg.CompressNone,
 		LargeValues: false,
 
@@ -303,7 +303,7 @@ var Schema = SchemaGen{
 		},
 	},
 	RCacheDomain: DomainCfg{
-		Name: kv.RCacheDomain, ValuesTable: kv.TblRCacheVals,
+		Name: kv.RCacheDomain, KeysTable: kv.TblRCacheVals,
 		LargeValues: true,
 
 		Accessors:   AccessorHashMap,

--- a/db/state/statecfg/state_schema.go
+++ b/db/state/statecfg/state_schema.go
@@ -255,11 +255,10 @@ var Schema = SchemaGen{
 		},
 	},
 	CommitmentDomain: DomainCfg{
-		Name: kv.CommitmentDomain, KeysTable: kv.TblCommitmentVals, ValsDataTable: kv.TblCommitmentValsData,
+		Name: kv.CommitmentDomain, KeysTable: kv.TblCommitmentVals,
 		CompressCfg: DomainCompressCfg, Compression: seg.CompressKeys,
 
 		Accessors:           AccessorHashMap,
-		LargeValues:         true,
 		ReplaceKeysInValues: AggregatorSqueezeCommitmentValues, // when true, keys are replaced in values during merge once file range reaches threshold
 
 		Hist: HistCfg{

--- a/db/state/statecfg/state_schema.go
+++ b/db/state/statecfg/state_schema.go
@@ -255,10 +255,11 @@ var Schema = SchemaGen{
 		},
 	},
 	CommitmentDomain: DomainCfg{
-		Name: kv.CommitmentDomain, KeysTable: kv.TblCommitmentVals,
+		Name: kv.CommitmentDomain, KeysTable: kv.TblCommitmentKeys, ValsDataTable: kv.TblCommitmentVals,
 		CompressCfg: DomainCompressCfg, Compression: seg.CompressKeys,
 
 		Accessors:           AccessorHashMap,
+		LargeValues:         true,                              // DupSort KeysTable (bareKey → ~step+seq_id) + plain ValsDataTable (seq_id → value); same layout as Code/RCache; DupSort is required here because commitment trie path keys are variable-length
 		ReplaceKeysInValues: AggregatorSqueezeCommitmentValues, // when true, keys are replaced in values during merge once file range reaches threshold
 
 		Hist: HistCfg{

--- a/db/state/statecfg/state_schema.go
+++ b/db/state/statecfg/state_schema.go
@@ -233,7 +233,7 @@ var Schema = SchemaGen{
 		},
 	},
 	CodeDomain: DomainCfg{
-		Name: kv.CodeDomain, KeysTable: kv.TblCodeVals,
+		Name: kv.CodeDomain, KeysTable: kv.TblCodeVals, ValsDataTable: kv.TblCodeValsData,
 		CompressCfg: DomainCompressCfg, Compression: seg.CompressVals, // compressing Code with keys doesn't show any benefits. Compression of values shows 4x ratio on eth-mainnet and 2.5x ratio on bor-mainnet
 
 		Accessors:   AccessorBTree | AccessorExistence,
@@ -255,10 +255,11 @@ var Schema = SchemaGen{
 		},
 	},
 	CommitmentDomain: DomainCfg{
-		Name: kv.CommitmentDomain, KeysTable: kv.TblCommitmentVals,
+		Name: kv.CommitmentDomain, KeysTable: kv.TblCommitmentVals, ValsDataTable: kv.TblCommitmentValsData,
 		CompressCfg: DomainCompressCfg, Compression: seg.CompressKeys,
 
 		Accessors:           AccessorHashMap,
+		LargeValues:         true,
 		ReplaceKeysInValues: AggregatorSqueezeCommitmentValues, // when true, keys are replaced in values during merge once file range reaches threshold
 
 		Hist: HistCfg{
@@ -303,7 +304,7 @@ var Schema = SchemaGen{
 		},
 	},
 	RCacheDomain: DomainCfg{
-		Name: kv.RCacheDomain, KeysTable: kv.TblRCacheVals,
+		Name: kv.RCacheDomain, KeysTable: kv.TblRCacheVals, ValsDataTable: kv.TblRCacheValsData,
 		LargeValues: true,
 
 		Accessors:   AccessorHashMap,

--- a/db/state/statecfg/statecfg.go
+++ b/db/state/statecfg/statecfg.go
@@ -13,8 +13,13 @@ type DomainCfg struct {
 	Compression seg.FileCompression
 	CompressCfg seg.Cfg
 	Accessors   Accessors // list of indexes for given domain
-	KeysTable   string    // bucket to store domain values; key -> inverted_step + values (Dupsort)
+	KeysTable   string    // bucket to store domain values; key -> inverted_step + values (DupSort, or plain when ValsDataTable is set)
 	LargeValues bool
+
+	// ValsDataTable - when set, KeysTable is plain (non-DupSort): domain_key+~step -> seq_id(8B).
+	// Actual values live in ValsDataTable keyed by auto-increment seq_id.
+	// Used by CommitmentDomain to eliminate DupSort overhead on large branch values.
+	ValsDataTable string
 
 	// replaceKeysInValues allows to replace commitment branch values with shorter keys.
 	// for commitment domain only
@@ -26,7 +31,11 @@ type DomainCfg struct {
 }
 
 func (d DomainCfg) Tables() []string {
-	return []string{d.KeysTable, d.Hist.ValuesTable, d.Hist.IiCfg.KeysTable, d.Hist.IiCfg.ValuesTable}
+	tables := []string{d.KeysTable, d.Hist.ValuesTable, d.Hist.IiCfg.KeysTable, d.Hist.IiCfg.ValuesTable}
+	if d.ValsDataTable != "" {
+		tables = append(tables, d.ValsDataTable)
+	}
+	return tables
 }
 
 func (d DomainCfg) GetVersions() VersionTypes {

--- a/db/state/statecfg/statecfg.go
+++ b/db/state/statecfg/statecfg.go
@@ -16,9 +16,8 @@ type DomainCfg struct {
 	KeysTable   string    // bucket to store domain values; key -> inverted_step + values (DupSort, or plain when ValsDataTable is set)
 	LargeValues bool
 
-	// ValsDataTable - when set, KeysTable is plain (non-DupSort): domain_key+~step -> seq_id(8B).
-	// Actual values live in ValsDataTable keyed by auto-increment seq_id.
-	// Used by CommitmentDomain to eliminate DupSort overhead on large branch values.
+	// ValsDataTable - eliminates DupSort overhead for large values: keysTable stores seq_id refs,
+	// actual values live here keyed by auto-increment seq_id.
 	ValsDataTable string
 
 	// replaceKeysInValues allows to replace commitment branch values with shorter keys.

--- a/db/state/statecfg/statecfg.go
+++ b/db/state/statecfg/statecfg.go
@@ -13,7 +13,7 @@ type DomainCfg struct {
 	Compression seg.FileCompression
 	CompressCfg seg.Cfg
 	Accessors   Accessors // list of indexes for given domain
-	ValuesTable string    // bucket to store domain values; key -> inverted_step + values (Dupsort)
+	KeysTable   string    // bucket to store domain values; key -> inverted_step + values (Dupsort)
 	LargeValues bool
 
 	// replaceKeysInValues allows to replace commitment branch values with shorter keys.
@@ -26,7 +26,7 @@ type DomainCfg struct {
 }
 
 func (d DomainCfg) Tables() []string {
-	return []string{d.ValuesTable, d.Hist.ValuesTable, d.Hist.IiCfg.KeysTable, d.Hist.IiCfg.ValuesTable}
+	return []string{d.KeysTable, d.Hist.ValuesTable, d.Hist.IiCfg.KeysTable, d.Hist.IiCfg.ValuesTable}
 }
 
 func (d DomainCfg) GetVersions() VersionTypes {

--- a/db/state/stream_close_test.go
+++ b/db/state/stream_close_test.go
@@ -50,7 +50,7 @@ func TestDomainLatestIterFileInitCursorMDBXClosesDupCursorOutsideRange(t *testin
 	}
 	domainRoTx := &DomainRoTx{
 		stepSize: 1,
-		d:        &Domain{DomainCfg: statecfg.DomainCfg{ValuesTable: "vals"}},
+		d:        &Domain{DomainCfg: statecfg.DomainCfg{KeysTable: "vals"}},
 	}
 
 	err := hi.initCursorOnDB(domainRoTx)
@@ -70,7 +70,7 @@ func TestDomainLatestIterFileInitCursorMDBXClosesCursorOutsideRangeForLargeValue
 	}
 	domainRoTx := &DomainRoTx{
 		stepSize: 1,
-		d:        &Domain{DomainCfg: statecfg.DomainCfg{LargeValues: true, ValuesTable: "vals"}},
+		d:        &Domain{DomainCfg: statecfg.DomainCfg{LargeValues: true, KeysTable: "vals"}},
 	}
 
 	err := hi.initCursorOnDB(domainRoTx)

--- a/execution/abi/bind/backends/simulated.go
+++ b/execution/abi/bind/backends/simulated.go
@@ -176,7 +176,10 @@ func (b *SimulatedBackend) Rollback() {
 }
 
 func (b *SimulatedBackend) emptyPendingBlock() {
-	blockChain, _ := blockgen.GenerateChain(b.m.ChainConfig, b.prependBlock, b.m.Engine, b.m.DB, 1, func(int, *blockgen.BlockGen) {})
+	blockChain, err := blockgen.GenerateChain(b.m.ChainConfig, b.prependBlock, b.m.Engine, b.m.DB, 1, func(int, *blockgen.BlockGen) {})
+	if err != nil {
+		panic(fmt.Errorf("emptyPendingBlock: %w", err))
+	}
 	b.pendingBlock = blockChain.Blocks[0]
 	b.pendingReceipts = blockChain.Receipts[0]
 	b.pendingHeader = blockChain.Headers[0]

--- a/execution/commitment/commitmentdb/commitment_context.go
+++ b/execution/commitment/commitmentdb/commitment_context.go
@@ -771,10 +771,8 @@ func (sdc *TrieContext) Branch(pref []byte) ([]byte, kv.Step, error) {
 
 func (sdc *TrieContext) PutBranch(prefix []byte, data []byte, prevData []byte) error {
 	if sdc.stateReader.WithHistory() { // do not store branches if explicitly operate on history
-		fmt.Printf("[DEBUG PutBranch] SKIP (WithHistory) prefix=%x\n", prefix)
 		return nil
 	}
-	fmt.Printf("[DEBUG PutBranch] prefix=%x data_len=%d prevData_len=%d\n", prefix, len(data), len(prevData))
 	if sdc.trace {
 		fmt.Printf("[SDC] PutBranch: %x: %x\n", prefix, data)
 	}

--- a/execution/commitment/commitmentdb/commitment_context.go
+++ b/execution/commitment/commitmentdb/commitment_context.go
@@ -771,8 +771,10 @@ func (sdc *TrieContext) Branch(pref []byte) ([]byte, kv.Step, error) {
 
 func (sdc *TrieContext) PutBranch(prefix []byte, data []byte, prevData []byte) error {
 	if sdc.stateReader.WithHistory() { // do not store branches if explicitly operate on history
+		fmt.Printf("[DEBUG PutBranch] SKIP (WithHistory) prefix=%x\n", prefix)
 		return nil
 	}
+	fmt.Printf("[DEBUG PutBranch] prefix=%x data_len=%d prevData_len=%d\n", prefix, len(data), len(prevData))
 	if sdc.trace {
 		fmt.Printf("[SDC] PutBranch: %x: %x\n", prefix, data)
 	}

--- a/execution/commitment/commitmentdb/commitment_context.go
+++ b/execution/commitment/commitmentdb/commitment_context.go
@@ -290,10 +290,10 @@ func (sdc *SharedDomainsCommitmentContext) ComputeCommitment(ctx context.Context
 	defer func() {
 		took := time.Since(start)
 		var keysPerSec uint64
-		if took > 0 {
+		if took > 50*time.Millisecond {
 			keysPerSec = uint64(float64(updateCount) / took.Seconds())
+			log.Debug("[commitment] processed", "block", blockNum, "txNum", txNum, "keys", common.PrettyCounter(updateCount), "keys/s", common.PrettyCounter(keysPerSec), "mode", sdc.updates.Mode(), "spent", took, "rootHash", hex.EncodeToString(rootHash))
 		}
-		log.Debug("[commitment] processed", "block", blockNum, "txNum", txNum, "keys", common.PrettyCounter(updateCount), "keys/s", common.PrettyCounter(keysPerSec), "mode", sdc.updates.Mode(), "spent", took, "rootHash", hex.EncodeToString(rootHash))
 	}()
 	if updateCount == 0 {
 		rootHash, err = sdc.patriciaTrie.RootHash()

--- a/execution/commitment/commitmentdb/commitment_context.go
+++ b/execution/commitment/commitmentdb/commitment_context.go
@@ -288,10 +288,8 @@ func (sdc *SharedDomainsCommitmentContext) ComputeCommitment(ctx context.Context
 	updateCount := sdc.updates.Size()
 	start := time.Now()
 	defer func() {
-		took := time.Since(start)
-		var keysPerSec uint64
-		if took > 50*time.Millisecond {
-			keysPerSec = uint64(float64(updateCount) / took.Seconds())
+		if took := time.Since(start); took > 50*time.Millisecond {
+			keysPerSec := uint64(float64(updateCount) / took.Seconds())
 			log.Debug("[commitment] processed", "block", blockNum, "txNum", txNum, "keys", common.PrettyCounter(updateCount), "keys/s", common.PrettyCounter(keysPerSec), "mode", sdc.updates.Mode(), "spent", took, "rootHash", hex.EncodeToString(rootHash))
 		}
 	}()


### PR DESCRIPTION
add table to commitment domain and store there `auto-increment-id -> largeValue` and main table will refer `key -> auto-increment-id`. Then random-distributed-updates will go to small table (where no large data stored). 
Reason: bloatnet has `domainWriter.flush` and `getLatestFromDB` bottelneck in CommitmentDomain
