### PR TITLE
commitment: remove WarmupCache.enabled atomic.Bool

### DIFF
--- a/execution/commitment/warmup_cache.go
+++ b/execution/commitment/warmup_cache.go
@@ -44,36 +44,19 @@ type WarmupCache struct {
 	branches *maphash.Map[*branchEntry]
 	accounts *maphash.Map[*accountEntry]
 	storage  *maphash.Map[*storageEntry]
-
-	enabled atomic.Bool
 }
 
 // NewWarmupCache creates a new warmup cache instance.
 func NewWarmupCache() *WarmupCache {
-	c := &WarmupCache{
+	return &WarmupCache{
 		branches: maphash.NewMap[*branchEntry](),
 		accounts: maphash.NewMap[*accountEntry](),
 		storage:  maphash.NewMap[*storageEntry](),
 	}
-	c.enabled.Store(true)
-	return c
-}
-
-// Enable enables or disables the cache.
-func (c *WarmupCache) Enable(enabled bool) {
-	c.enabled.Store(enabled)
-}
-
-// IsEnabled returns whether the cache is enabled.
-func (c *WarmupCache) IsEnabled() bool {
-	return c.enabled.Load()
 }
 
 // PutBranch stores branch data in the cache.
 func (c *WarmupCache) PutBranch(prefix []byte, data []byte) {
-	if !c.enabled.Load() {
-		return
-	}
 	// Make a copy of the data to avoid issues with buffer reuse
 	dataCopy := make([]byte, len(data))
 	copy(dataCopy, data)
@@ -83,9 +66,6 @@ func (c *WarmupCache) PutBranch(prefix []byte, data []byte) {
 
 // GetBranch retrieves branch data from the cache.
 func (c *WarmupCache) GetBranch(prefix []byte) ([]byte, bool) {
-	if !c.enabled.Load() {
-		return nil, false
-	}
 	entry, found := c.branches.Get(prefix)
 	if !found || entry.isEvicted.Load() {
 		return nil, false
@@ -95,9 +75,6 @@ func (c *WarmupCache) GetBranch(prefix []byte) ([]byte, bool) {
 
 // GetAndEvictBranch retrieves branch data and marks the entry as evicted in one operation.
 func (c *WarmupCache) GetAndEvictBranch(prefix []byte) ([]byte, bool) {
-	if !c.enabled.Load() {
-		return nil, false
-	}
 	entry, found := c.branches.Get(prefix)
 	if !found || entry.isEvicted.Load() {
 		return nil, false
@@ -108,9 +85,6 @@ func (c *WarmupCache) GetAndEvictBranch(prefix []byte) ([]byte, bool) {
 
 // EvictBranch marks a branch entry as evicted without retrieving it.
 func (c *WarmupCache) EvictBranch(prefix []byte) {
-	if !c.enabled.Load() {
-		return
-	}
 	entry, found := c.branches.Get(prefix)
 	if found {
 		entry.isEvicted.Store(true)
@@ -119,9 +93,6 @@ func (c *WarmupCache) EvictBranch(prefix []byte) {
 
 // PutAccount stores account data in the cache.
 func (c *WarmupCache) PutAccount(plainKey []byte, update *Update) {
-	if !c.enabled.Load() {
-		return
-	}
 	var updateCopy *Update
 	if update != nil {
 		updateCopy = update.Copy()
@@ -132,9 +103,6 @@ func (c *WarmupCache) PutAccount(plainKey []byte, update *Update) {
 
 // GetAccount retrieves account data from the cache.
 func (c *WarmupCache) GetAccount(plainKey []byte) (*Update, bool) {
-	if !c.enabled.Load() {
-		return nil, false
-	}
 	entry, found := c.accounts.Get(plainKey)
 	if !found || entry.isEvicted.Load() {
 		return nil, false
@@ -145,9 +113,6 @@ func (c *WarmupCache) GetAccount(plainKey []byte) (*Update, bool) {
 // GetAndEvictAccount retrieves account data and marks the entry as evicted in one operation.
 // Returns the entry pointer allowing the caller to read the data before it's considered evicted.
 func (c *WarmupCache) GetAndEvictAccount(plainKey []byte) *accountEntry {
-	if !c.enabled.Load() {
-		return nil
-	}
 	entry, found := c.accounts.Get(plainKey)
 	if !found || entry.isEvicted.Load() {
 		return nil
@@ -158,9 +123,6 @@ func (c *WarmupCache) GetAndEvictAccount(plainKey []byte) *accountEntry {
 
 // EvictAccount marks an account entry as evicted without retrieving it.
 func (c *WarmupCache) EvictAccount(plainKey []byte) {
-	if !c.enabled.Load() {
-		return
-	}
 	entry, found := c.accounts.Get(plainKey)
 	if found {
 		entry.isEvicted.Store(true)
@@ -169,9 +131,6 @@ func (c *WarmupCache) EvictAccount(plainKey []byte) {
 
 // PutStorage stores storage data in the cache.
 func (c *WarmupCache) PutStorage(plainKey []byte, update *Update) {
-	if !c.enabled.Load() {
-		return
-	}
 	var updateCopy *Update
 	if update != nil {
 		updateCopy = update.Copy()
@@ -182,9 +141,6 @@ func (c *WarmupCache) PutStorage(plainKey []byte, update *Update) {
 
 // GetStorage retrieves storage data from the cache.
 func (c *WarmupCache) GetStorage(plainKey []byte) (*Update, bool) {
-	if !c.enabled.Load() {
-		return nil, false
-	}
 	entry, found := c.storage.Get(plainKey)
 	if !found || entry.isEvicted.Load() {
 		return nil, false
@@ -195,9 +151,6 @@ func (c *WarmupCache) GetStorage(plainKey []byte) (*Update, bool) {
 // GetAndEvictStorage retrieves storage data and marks the entry as evicted in one operation.
 // Returns the entry pointer allowing the caller to read the data before it's considered evicted.
 func (c *WarmupCache) GetAndEvictStorage(plainKey []byte) *storageEntry {
-	if !c.enabled.Load() {
-		return nil
-	}
 	entry, found := c.storage.Get(plainKey)
 	if !found || entry.isEvicted.Load() {
 		return nil
@@ -208,9 +161,6 @@ func (c *WarmupCache) GetAndEvictStorage(plainKey []byte) *storageEntry {
 
 // EvictStorage marks a storage entry as evicted without retrieving it.
 func (c *WarmupCache) EvictStorage(plainKey []byte) {
-	if !c.enabled.Load() {
-		return
-	}
 	entry, found := c.storage.Get(plainKey)
 	if found {
 		entry.isEvicted.Store(true)
@@ -220,9 +170,6 @@ func (c *WarmupCache) EvictStorage(plainKey []byte) {
 // EvictPlainKey evicts a key from both accounts and storage caches.
 // Use this when you don't know if the key is an account or storage key.
 func (c *WarmupCache) EvictPlainKey(plainKey []byte) {
-	if !c.enabled.Load() {
-		return
-	}
 	if entry, found := c.accounts.Get(plainKey); found {
 		entry.isEvicted.Store(true)
 	}

--- a/execution/commitment/warmup_cache_test.go
+++ b/execution/commitment/warmup_cache_test.go
@@ -114,38 +114,6 @@ func TestWarmupCache_Eviction(t *testing.T) {
 	}
 }
 
-// TestWarmupCache_Enable tests enable/disable
-func TestWarmupCache_Enable(t *testing.T) {
-	cache := NewWarmupCache()
-
-	key := []byte("12345678901234567890")
-	cache.PutAccount(key, &Update{Flags: BalanceUpdate})
-
-	// Should find when enabled
-	_, found := cache.GetAccount(key)
-	if !found {
-		t.Fatal("expected to find account when enabled")
-	}
-
-	// Disable cache
-	cache.Enable(false)
-
-	// Should not find when disabled
-	_, found = cache.GetAccount(key)
-	if found {
-		t.Error("expected not to find account when disabled")
-	}
-
-	// Re-enable
-	cache.Enable(true)
-
-	// Should find again
-	_, found = cache.GetAccount(key)
-	if !found {
-		t.Error("expected to find account after re-enabling")
-	}
-}
-
 // TestWarmupCache_Clear tests clearing the cache
 func TestWarmupCache_Clear(t *testing.T) {
 	cache := NewWarmupCache()


### PR DESCRIPTION
`WarmupCache.enabled` was always `true` — `Enable()`/`IsEnabled()` were never called in production code. Every hot-path method was paying an atomic load for nothing; all call sites already guard with `if cache != nil`.

- Remove `enabled atomic.Bool` field and `Enable`/`IsEnabled` methods
- Remove the `c.enabled.Load()` guard from every `Put*`/`Get*`/`Evict*` method
- Remove the corresponding test (`TestWarmupCache_Enable`)