### PR TITLE
TotalMemory: calc once

### DIFF
--- a/common/estimate/total_memory.go
+++ b/common/estimate/total_memory.go
@@ -18,20 +18,29 @@ package estimate
 
 import (
 	"runtime/debug"
+	"sync"
 
 	"github.com/pbnjay/memory"
 )
 
+var (
+	totalMemoryOnce   sync.Once
+	totalMemoryCached uint64
+)
+
 func TotalMemory() uint64 {
-	mem := memory.TotalMemory()
+	totalMemoryOnce.Do(func() {
+		mem := memory.TotalMemory()
 
-	if cgroupsMemLimit, err := cgroupsMemoryLimit(); (err == nil) && (cgroupsMemLimit > 0) {
-		mem = min(mem, cgroupsMemLimit)
-	}
+		if cgroupsMemLimit, err := cgroupsMemoryLimit(); (err == nil) && (cgroupsMemLimit > 0) {
+			mem = min(mem, cgroupsMemLimit)
+		}
 
-	if goMemLimit := debug.SetMemoryLimit(-1); goMemLimit > 0 {
-		mem = min(mem, uint64(goMemLimit))
-	}
+		if goMemLimit := debug.SetMemoryLimit(-1); goMemLimit > 0 {
+			mem = min(mem, uint64(goMemLimit))
+		}
 
-	return mem
+		totalMemoryCached = mem
+	})
+	return totalMemoryCached
 }


### PR DESCRIPTION
Physical RAM, cgroup limits, and `GOMEMLIMIT` are all fixed at process startup — there is no reason to re-read them on every `Workers()` call. Cache the result with `sync.Once`.


<img width="2554" height="654" alt="Screenshot 2026-05-03 at 17 18 06" src="https://github.com/user-attachments/assets/68d7dd4b-9fb7-484a-8df0-4fa50cf6d61f" />
