### PR TITLE
[performance] enforce block-snapshots cap inside aggregator collation

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -1066,6 +1066,7 @@ func allSnapshots(ctx context.Context, db kv.RoDB, logger log.Logger) (*freezebl
 		_aggSingleton = dbstate.New(dirs).Logger(logger).WithErigonDBSettings(erigonDBSettings).MustOpen(ctx, db)
 
 		_aggSingleton.SetProduceMod(snapCfg.ProduceE3)
+		_aggSingleton.SetFrozenBlocksProvider(blockReader)
 
 		g := &errgroup.Group{}
 		g.Go(func() error {

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -68,7 +68,6 @@ import (
 	"github.com/erigontech/erigon/db/rawdb/blockio"
 	"github.com/erigontech/erigon/db/recsplit"
 	"github.com/erigontech/erigon/db/seg"
-	"github.com/erigontech/erigon/db/services"
 	"github.com/erigontech/erigon/db/snapshotsync"
 	"github.com/erigontech/erigon/db/snapshotsync/freezeblocks"
 	"github.com/erigontech/erigon/db/snaptype"
@@ -3202,6 +3201,9 @@ func doRetireCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 	blockSnapBuildSema := semaphore.NewWeighted(int64(runtime.NumCPU()))
 	agg.SetSnapshotBuildSema(blockSnapBuildSema)
 
+	blockReader, _ := br.IO()
+	agg.SetFrozenBlocksProvider(blockReader)
+
 	agg.PresetOfflineMerge()
 	agg.PeriodicalyPrintProcessSet(ctx)
 
@@ -3221,8 +3223,6 @@ func doRetireCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 	}); err != nil {
 		return err
 	}
-
-	blockReader, _ := br.IO()
 
 	blocksInSnapshots := blockReader.FrozenBlocks()
 	if chainConfig.Bor != nil {
@@ -3272,15 +3272,7 @@ func doRetireCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 	if err := db.Update(ctx, func(tx kv.RwTx) error {
 		execProgress, _ := stages.GetStageProgress(tx, stages.Execution)
 		lastTxNum, err = txNumsReader.Max(ctx, tx, execProgress)
-		if err != nil {
-			return err
-		}
-		maxCollatable, err := services.MaxCollatableTxNum(ctx, tx, blockReader)
-		if err != nil {
-			return err
-		}
-		lastTxNum = min(lastTxNum, maxCollatable)
-		return nil
+		return err
 	}); err != nil {
 		return err
 	}

--- a/db/services/snapshot_progress.go
+++ b/db/services/snapshot_progress.go
@@ -22,12 +22,8 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 )
 
-// MaxCollatableTxNum returns the upper bound txNum that state collation may
-// target without running ahead of block snapshot files. Callers of
-// Aggregator.BuildFiles / BuildFilesInBackground must cap their target txNum
-// by this value — otherwise state files may advance past block files, an
-// unrecoverable state that requires manual `erigon seg rm-state --latest` to
-// release.
+// MaxCollatableTxNum: upper bound txNum that state collation may target.
+// Aggregator enforces this internally via SetFrozenBlocksProvider.
 func MaxCollatableTxNum(ctx context.Context, tx kv.Tx, blockReader FullBlockReader) (uint64, error) {
 	return blockReader.TxnumReader().Max(ctx, tx, blockReader.FrozenBlocks())
 }

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -116,6 +116,13 @@ type Aggregator struct {
 	configured   bool
 	savedSalt    *uint32
 	disableFsync bool
+
+	// nil = no cap. See #20701.
+	frozenBlocks FrozenBlocksProvider
+}
+
+type FrozenBlocksProvider interface {
+	FrozenBlocks() uint64
 }
 
 func newAggregator(ctx context.Context, dirs datadir.Dirs, reorgBlockDepth uint64, db kv.RoDB, logger log.Logger) (*Aggregator, error) {
@@ -957,6 +964,24 @@ func (a *Aggregator) buildFiles(ctx context.Context, step kv.Step) error {
 func (a *Aggregator) readyForCollation(ctx context.Context, step kv.Step) (lastBlockInStep, lastBlockInDB, lastTxInDB uint64, ok bool, err error) {
 	if a.reorgBlockDepth == 0 {
 		return 0, 0, 0, true, nil
+	}
+
+	if a.frozenBlocks != nil {
+		var capTxNum uint64
+		if err = a.db.View(ctx, func(tx kv.Tx) error {
+			var err error
+			capTxNum, err = rawdbv3.TxNums.Max(ctx, tx, a.frozenBlocks.FrozenBlocks())
+			return err
+		}); err != nil {
+			return 0, 0, 0, false, fmt.Errorf("read max collatable txNum: %w", err)
+		}
+		if uint64(step+1)*a.StepSize() > capTxNum {
+			a.logger.Info("[snapshots] holding state collation at block snapshot boundary",
+				"step", step,
+				"stepEndTxNum", fmt.Sprintf("%d (step %d)", uint64(step+1)*a.StepSize(), uint64(step+1)),
+				"blockSnapshotsTxNum", fmt.Sprintf("%d (step %d)", capTxNum, capTxNum/a.StepSize()))
+			return 0, 0, 0, false, nil
+		}
 	}
 	err = a.db.View(ctx, func(tx kv.Tx) error {
 		lastBlockInStep, ok, err = rawdbv3.TxNums.FindBlockNum(ctx, tx, lastTxNumOfStep(step, a.stepSize.Load()))
@@ -1884,6 +1909,13 @@ func (a *Aggregator) SetSnapshotBuildSema(semaphore *semaphore.Weighted) {
 // SetProduceMod allows setting produce to false in order to stop making state files (default value is true)
 func (a *Aggregator) SetProduceMod(produce bool) {
 	a.produce = produce
+}
+
+// SetFrozenBlocksProvider caps state collation at the block-snapshots boundary.
+// Without it, state files may advance past block files — recovery requires
+// `erigon seg rm-state --latest`. See #20701.
+func (a *Aggregator) SetFrozenBlocksProvider(p FrozenBlocksProvider) {
+	a.frozenBlocks = p
 }
 
 func (a *Aggregator) BuildFilesInBackground(txNum uint64) chan struct{} {

--- a/db/test/aggregator_ext_test.go
+++ b/db/test/aggregator_ext_test.go
@@ -768,6 +768,180 @@ func TestAggregatorV3_BuildFiles_WithReorgDepth(t *testing.T) {
 	require.Equal(t, kv.Step(6), kv.Step(agg.EndTxNumMinimax()/agg.StepSize()))
 }
 
+// With txnsPerBlock=1, fakeFrozenBlocks(N) yields capTxNum=N.
+type fakeFrozenBlocks uint64
+
+func (f fakeFrozenBlocks) FrozenBlocks() uint64 { return uint64(f) }
+
+// Regression for #20701: cap must clamp the loop, not just early-return.
+func TestAggregatorV3_BuildFiles_RespectsMaxCollatableTxNumCap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow test")
+	}
+	ctx := t.Context()
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	db := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
+	t.Cleanup(db.Close)
+	agg := state.NewTest(dirs).ReorgBlockDepth(1).StepSize(2).Logger(logger).MustOpen(ctx, db)
+	t.Cleanup(agg.Close)
+	require.NoError(t, agg.OpenFolder())
+
+	// Cap at 4 steps; write 9 steps' worth into the DB.
+	const capTxNum = uint64(8)
+	agg.SetFrozenBlocksProvider(fakeFrozenBlocks(capTxNum))
+
+	tdb, err := temporal.New(db, agg)
+	require.NoError(t, err)
+	t.Cleanup(tdb.Close)
+	tx, err := tdb.BeginTemporalRw(ctx)
+	require.NoError(t, err)
+	t.Cleanup(tx.Rollback)
+	doms, err := execctx.NewSharedDomains(context.Background(), tx, logger)
+	require.NoError(t, err)
+	t.Cleanup(doms.Close)
+
+	const txnNums = uint64(18)
+	const txnsPerBlock = uint64(1)
+	for i := uint64(0); i < txnNums/txnsPerBlock; i++ {
+		require.NoError(t, rawdbv3.TxNums.Append(tx, i+1, (i+1)*txnsPerBlock))
+	}
+	generateSharedDomainsUpdates(t, doms, tx, txnNums, newRnd(0), length.Addr, 10, txnsPerBlock)
+	require.NoError(t, doms.Flush(ctx, tx))
+	require.NoError(t, tx.Commit())
+
+	require.NoError(t, agg.BuildFiles(txnNums))
+
+	require.Equal(t, capTxNum, agg.EndTxNumMinimax(),
+		"EndTxNumMinimax must be clamped to cap (%d), not driven by lastInDB", capTxNum)
+	require.Equal(t, kv.Step(capTxNum/agg.StepSize()), kv.Step(agg.EndTxNumMinimax()/agg.StepSize()))
+}
+
+// nil provider = no cap; behavior unchanged.
+func TestAggregatorV3_BuildFiles_NoCapHookBuildsAll(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow test")
+	}
+	ctx := t.Context()
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	db := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
+	t.Cleanup(db.Close)
+	agg := state.NewTest(dirs).ReorgBlockDepth(1).StepSize(2).Logger(logger).MustOpen(ctx, db)
+	t.Cleanup(agg.Close)
+	require.NoError(t, agg.OpenFolder())
+
+	tdb, err := temporal.New(db, agg)
+	require.NoError(t, err)
+	t.Cleanup(tdb.Close)
+	tx, err := tdb.BeginTemporalRw(ctx)
+	require.NoError(t, err)
+	t.Cleanup(tx.Rollback)
+	doms, err := execctx.NewSharedDomains(context.Background(), tx, logger)
+	require.NoError(t, err)
+	t.Cleanup(doms.Close)
+
+	const txnNums = uint64(18)
+	const txnsPerBlock = uint64(1)
+	for i := uint64(0); i < txnNums/txnsPerBlock; i++ {
+		require.NoError(t, rawdbv3.TxNums.Append(tx, i+1, (i+1)*txnsPerBlock))
+	}
+	generateSharedDomainsUpdates(t, doms, tx, txnNums, newRnd(0), length.Addr, 10, txnsPerBlock)
+	require.NoError(t, doms.Flush(ctx, tx))
+	require.NoError(t, tx.Commit())
+
+	require.NoError(t, agg.BuildFiles(txnNums))
+
+	// reorg-depth=1 holds the last block back; cap unset.
+	require.Equal(t, uint64(16), agg.EndTxNumMinimax())
+}
+
+// BuildFiles2 path (stage_custom_trace, squeeze) must honor the cap too.
+func TestAggregatorV3_BuildFiles2_RespectsMaxCollatableTxNumCap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow test")
+	}
+	ctx := t.Context()
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	db := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
+	t.Cleanup(db.Close)
+	agg := state.NewTest(dirs).ReorgBlockDepth(1).StepSize(2).Logger(logger).MustOpen(ctx, db)
+	t.Cleanup(agg.Close)
+	require.NoError(t, agg.OpenFolder())
+
+	const capTxNum = uint64(8)
+	agg.SetFrozenBlocksProvider(fakeFrozenBlocks(capTxNum))
+
+	tdb, err := temporal.New(db, agg)
+	require.NoError(t, err)
+	t.Cleanup(tdb.Close)
+	tx, err := tdb.BeginTemporalRw(ctx)
+	require.NoError(t, err)
+	t.Cleanup(tx.Rollback)
+	doms, err := execctx.NewSharedDomains(context.Background(), tx, logger)
+	require.NoError(t, err)
+	t.Cleanup(doms.Close)
+
+	const txnNums = uint64(18)
+	for i := uint64(0); i < txnNums; i++ {
+		require.NoError(t, rawdbv3.TxNums.Append(tx, i+1, i+1))
+	}
+	generateSharedDomainsUpdates(t, doms, tx, txnNums, newRnd(0), length.Addr, 10, 1)
+	require.NoError(t, doms.Flush(ctx, tx))
+	require.NoError(t, tx.Commit())
+
+	require.NoError(t, agg.BuildFiles2(ctx, 0, kv.Step(txnNums/agg.StepSize()), false))
+	agg.WaitForFiles()
+
+	require.Equal(t, capTxNum, agg.EndTxNumMinimax(),
+		"BuildFiles2 must clamp to cap (%d), not toStep", capTxNum)
+}
+
+// Cap below visibleFilesMinimaxTxNum: defensive only — no rollback.
+func TestAggregatorV3_BuildFiles_CapBelowVisibleIsNoop(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow test")
+	}
+	ctx := t.Context()
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	db := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
+	t.Cleanup(db.Close)
+	agg := state.NewTest(dirs).ReorgBlockDepth(1).StepSize(2).Logger(logger).MustOpen(ctx, db)
+	t.Cleanup(agg.Close)
+	require.NoError(t, agg.OpenFolder())
+
+	tdb, err := temporal.New(db, agg)
+	require.NoError(t, err)
+	t.Cleanup(tdb.Close)
+	tx, err := tdb.BeginTemporalRw(ctx)
+	require.NoError(t, err)
+	t.Cleanup(tx.Rollback)
+	doms, err := execctx.NewSharedDomains(context.Background(), tx, logger)
+	require.NoError(t, err)
+	t.Cleanup(doms.Close)
+
+	const txnNums = uint64(18)
+	const txnsPerBlock = uint64(1)
+	for i := uint64(0); i < txnNums/txnsPerBlock; i++ {
+		require.NoError(t, rawdbv3.TxNums.Append(tx, i+1, (i+1)*txnsPerBlock))
+	}
+	generateSharedDomainsUpdates(t, doms, tx, txnNums, newRnd(0), length.Addr, 10, txnsPerBlock)
+	require.NoError(t, doms.Flush(ctx, tx))
+	require.NoError(t, tx.Commit())
+
+	// build state up to txNum 8.
+	agg.SetFrozenBlocksProvider(fakeFrozenBlocks(8))
+	require.NoError(t, agg.BuildFiles(txnNums))
+	require.Equal(t, uint64(8), agg.EndTxNumMinimax())
+
+	// lower cap below current visible — must be a no-op, no rollback.
+	agg.SetFrozenBlocksProvider(fakeFrozenBlocks(4))
+	require.NoError(t, agg.BuildFiles(txnNums))
+	require.Equal(t, uint64(8), agg.EndTxNumMinimax())
+}
+
 func compareMapsBytes(t *testing.T, m1, m2 map[string][]byte) {
 	t.Helper()
 	for k, v := range m1 {

--- a/db/test/aggregator_ext_test.go
+++ b/db/test/aggregator_ext_test.go
@@ -17,6 +17,7 @@
 package test
 
 import (
+	"context"
 	"encoding/binary"
 	"encoding/hex"
 	"math"

--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -38,7 +38,6 @@ import (
 	"github.com/erigontech/erigon/db/rawdb"
 	"github.com/erigontech/erigon/db/rawdb/rawdbhelpers"
 	"github.com/erigontech/erigon/db/rawdb/rawtemporaldb"
-	"github.com/erigontech/erigon/db/services"
 	dbstate "github.com/erigontech/erigon/db/state"
 	"github.com/erigontech/erigon/db/state/execctx"
 	"github.com/erigontech/erigon/execution/commitment"
@@ -142,11 +141,7 @@ func ExecV3(ctx context.Context,
 	}
 
 	if execStage.SyncMode() == stages.ModeApplyingBlocks {
-		maxCollatable, err := services.MaxCollatableTxNum(ctx, applyTx, cfg.blockReader)
-		if err != nil {
-			return err
-		}
-		agg.BuildFilesInBackground(min(initialTxNum, maxCollatable))
+		agg.BuildFilesInBackground(initialTxNum)
 	}
 
 	var (

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -1299,6 +1299,7 @@ func SetUpBlockReader(ctx context.Context, db kv.RwDB, dirs datadir.Dirs, snConf
 	}
 	agg.SetSnapshotBuildSema(blockSnapBuildSema)
 	agg.SetProduceMod(snConfig.Snapshot.ProduceE3)
+	agg.SetFrozenBlocksProvider(blockReader)
 
 	allSegmentsDownloadComplete, err := rawdb.AllSegmentsDownloadCompleteFromDB(db)
 	if err != nil {


### PR DESCRIPTION
Cherry-pick of #20852 to performance.

## performance-specific adaptations
Resolved trivial conflict in `db/state/aggregator.go` (added `SetFrozenBlocksProvider` method).