### PR TITLE
ci: skip sonar and claude-review for dependabot PRs

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -79,9 +79,13 @@ jobs:
     secrets: inherit
 
   sonar:
-    # SONAR_TOKEN is a repo secret unavailable to fork PRs, so skip the scan
-    # for external contributions to avoid a guaranteed failure in ci-gate.
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
+    # SONAR_TOKEN is a repo secret unavailable to fork PRs and Dependabot PRs
+    # (GitHub withholds non-GITHUB_TOKEN secrets from Dependabot even for same-repo PRs),
+    # so skip the scan for those to avoid a guaranteed failure in ci-gate.
+    if: |
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       github.actor != 'dependabot[bot]') ||
+      github.event_name != 'pull_request'
     uses: ./.github/workflows/sonar.yml
     secrets: inherit
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,9 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    # Skip Dependabot PRs: the action rejects bot actors and CLAUDE_CODE_OAUTH_TOKEN
+    # is not available to Dependabot workflows anyway.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
GitHub withholds repo secrets (`SONAR_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`) from Dependabot-triggered workflows even for same-repo PRs, causing guaranteed `sonar` and `claude-review` failures in `ci-gate` on every Dependabot PR — see e.g. #20970.

- `ci-gate.yml`: extend the sonar skip condition to also exclude `dependabot[bot]`
- `claude-code-review.yml`: add `if: github.actor != 'dependabot[bot]'` guard