### PR TITLE
db/state: clip merge windows that straddle existing files

### DIFF
--- a/cmd/utils/app/step_cmd.go
+++ b/cmd/utils/app/step_cmd.go
@@ -210,13 +210,16 @@ func collectRenameList(domainPath string, re *regexp.Regexp, decr bool, factor u
 	})
 
 	if walkErr != nil {
-		return nil, walkErr
+		return nil, fmt.Errorf("scanning %s: %w", domainPath, walkErr)
 	}
 	return renList, nil
 }
 
 // collectTorrentFiles walks given root and returns absolute paths to files ending with .torrent
 func collectTorrentFiles(root string) ([]string, error) {
+	if _, err := os.Stat(root); os.IsNotExist(err) {
+		return nil, nil
+	}
 	list := make([]string, 0, 100)
 	walkErr := fs.WalkDir(os.DirFS(root), ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -231,7 +234,7 @@ func collectTorrentFiles(root string) ([]string, error) {
 		return nil
 	})
 	if walkErr != nil {
-		return nil, walkErr
+		return nil, fmt.Errorf("scanning %s: %w", root, walkErr)
 	}
 	return list, nil
 }

--- a/db/state/merge.go
+++ b/db/state/merge.go
@@ -136,7 +136,7 @@ func (dt *DomainRoTx) findMergeRange(maxEndTxNum, domainMaxSpan, maxSpan uint64)
 		endStep := item.endTxNum / dt.stepSize
 		spanStep := endStep & -endStep // Extract rightmost bit in the binary representation of endStep, this corresponds to size of maximally possible merge ending at endStep
 		span := min(spanStep*dt.stepSize, domainMaxSpan)
-		fromTxNum := item.endTxNum - span
+		fromTxNum := clipMergeStartToFileBoundary(dt.files, item.endTxNum-span)
 		if fromTxNum >= item.startTxNum {
 			continue
 		}
@@ -175,7 +175,7 @@ func (ht *HistoryRoTx) findMergeRange(maxEndTxNum, maxSpan uint64) HistoryRanges
 		endStep := item.endTxNum / ht.stepSize
 		spanStep := endStep & -endStep // Extract rightmost bit in the binary representation of endStep, this corresponds to size of maximally possible merge ending at endStep
 		span := min(spanStep*ht.stepSize, maxSpan)
-		startTxNum := item.endTxNum - span
+		startTxNum := clipMergeStartToFileBoundary(ht.files, item.endTxNum-span)
 
 		foundSuperSet := r.history.from == item.startTxNum && item.endTxNum >= r.history.to
 		if foundSuperSet {
@@ -228,7 +228,7 @@ func (iit *InvertedIndexRoTx) findMergeRange(maxEndTxNum, maxSpan uint64) *Merge
 		endStep := item.endTxNum / iit.stepSize
 		spanStep := endStep & -endStep // Extract rightmost bit in the binary representation of endStep, this corresponds to size of maximally possible merge ending at endStep
 		span := min(spanStep*iit.stepSize, maxSpan)
-		start := item.endTxNum - span
+		start := clipMergeStartToFileBoundary(iit.files, item.endTxNum-span)
 		foundSuperSet := startTxNum == item.startTxNum && item.endTxNum >= endTxNum
 		if foundSuperSet {
 			minFound = false
@@ -250,6 +250,24 @@ func (iit *InvertedIndexRoTx) findMergeRange(maxEndTxNum, maxSpan uint64) *Merge
 		panic(fmt.Sprintf("assert: startTxNum(%d) == endTxNum(%d)", startTxNum, endTxNum))
 	}
 	return &MergeRange{iit.name.String(), minFound, startTxNum, endTxNum}
+}
+
+// clipMergeStartToFileBoundary bumps start up to the endTxNum of any visible
+// file that straddles it (startTxNum < start < endTxNum). visibleFiles are
+// non-overlapping, so at most one straddling file can exist; the loop returns
+// as soon as it is found. Files are sorted by endTxNum ascending, so the first
+// file with endTxNum > start is the only straddler candidate.
+func clipMergeStartToFileBoundary(files visibleFiles, start uint64) uint64 {
+	for _, f := range files {
+		if f.endTxNum <= start {
+			continue
+		}
+		if f.startTxNum < start {
+			return f.endTxNum
+		}
+		return start
+	}
+	return start
 }
 
 type HistoryRanges struct {


### PR DESCRIPTION
Cherry-pick of #20909 (by @wmitsuda), adapted for this branch.

Fixes #20878.

When the natural merge start (endTxNum minus the largest power-of-two step span) falls strictly inside an existing visible file, `clipMergeStartToFileBoundary` bumps it up to that file's endTxNum. Without this clip, non-power-of-2 step layouts (e.g. after a step-size rebase) let the algorithm propose windows whose `from` lies inside a pre-existing file — `staticFilesInRange` then silently drops that file and emits a merged segment that lies about its coverage.

Applied to `DomainRoTx`, `HistoryRoTx`, and `InvertedIndexRoTx` `findMergeRange` (this branch has inline merge logic vs. the extracted `findMergeRangeInFiles` helper on main).

Also: wrap walk errors with path context; guard `collectTorrentFiles` against a missing torrent dir.