### PR TITLE
cmd, dbg: add --exec.no-background-maintenance flag for focused perf testing

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1182,7 +1182,7 @@ var (
 	}
 	ExecNoBackgroundMaintenanceFlag = cli.BoolFlag{
 		Name:  "exec.no-background-maintenance",
-		Usage: "Suppress background state-aggregator file build, merge, and snapshot retirement goroutines so execution is not perturbed by housekeeping work (equivalent to NO_BACKGROUND_E3_BUILD=true). Diagnostic / focused-performance-testing use only — NOT an operational setting.",
+		Usage: "Suppress background state-aggregator (Domain/Hist/II + forkable) file build/merge and E2 block-snapshot retirement goroutines so execution is not perturbed by housekeeping work (legacy env var: NO_BACKGROUND_E3_BUILD=true). Diagnostic / focused-performance-testing use only — NOT an operational setting.",
 		Value: false,
 	}
 )
@@ -2025,7 +2025,7 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 		dbg.SetNoPrune(ctx.Bool(ExecNoPruneFlag.Name))
 	}
 	if ctx.IsSet(ExecNoBackgroundMaintenanceFlag.Name) {
-		dbg.SetNoBackgroundE3Build(ctx.Bool(ExecNoBackgroundMaintenanceFlag.Name))
+		dbg.SetNoBackgroundMaintenance(ctx.Bool(ExecNoBackgroundMaintenanceFlag.Name))
 	}
 	if ctx.IsSet(RPCGlobalGasCapFlag.Name) {
 		cfg.RPCGasCap = ctx.Uint64(RPCGlobalGasCapFlag.Name)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1180,6 +1180,11 @@ var (
 		Usage: "Disable all DB pruning: state-aggregator (Domain/InvertedIndex/forkable) plus stage-level pruning (Execution: ChangeSets3/BlockAccessList; TxLookup; WitnessProcessing; Snapshots: PruneAncientBlocks/canonical markers/retirement) (equivalent to NO_PRUNE=true). Diagnostic / perf-comparison use only.",
 		Value: false,
 	}
+	ExecNoBackgroundMaintenanceFlag = cli.BoolFlag{
+		Name:  "exec.no-background-maintenance",
+		Usage: "Suppress background state-aggregator file build, merge, and snapshot retirement goroutines so execution is not perturbed by housekeeping work (equivalent to NO_BACKGROUND_E3_BUILD=true). Diagnostic / focused-performance-testing use only — NOT an operational setting.",
+		Value: false,
+	}
 )
 
 var MetricFlags = []cli.Flag{&MetricsEnabledFlag, &MetricsHTTPFlag, &MetricsPortFlag}
@@ -1990,7 +1995,7 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 	// Executor performance toggles. When the user explicitly sets the CLI
 	// flag, it overrides the env-var default that dbg read at package init.
 	// Otherwise env vars (IGNORE_BAL, USE_STATE_CACHE, EXEC3_WORKERS,
-	// NO_MERGE, NO_PRUNE) remain the source of truth.
+	// NO_MERGE, NO_PRUNE, NO_BACKGROUND_E3_BUILD) remain the source of truth.
 	if ctx.IsSet(ExecBatchedIOFlag.Name) {
 		// --exec.batched-io toggles two BAL-driven optimisations together:
 		// read-ahead pre-warming (ReadAhead) and version-map pre-population
@@ -2018,6 +2023,9 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 	}
 	if ctx.IsSet(ExecNoPruneFlag.Name) {
 		dbg.SetNoPrune(ctx.Bool(ExecNoPruneFlag.Name))
+	}
+	if ctx.IsSet(ExecNoBackgroundMaintenanceFlag.Name) {
+		dbg.SetNoBackgroundE3Build(ctx.Bool(ExecNoBackgroundMaintenanceFlag.Name))
 	}
 	if ctx.IsSet(RPCGlobalGasCapFlag.Name) {
 		cfg.RPCGasCap = ctx.Uint64(RPCGlobalGasCapFlag.Name)

--- a/cmd/utils/flags_test.go
+++ b/cmd/utils/flags_test.go
@@ -111,7 +111,7 @@ func TestExecPerfFlags_OverrideDbg(t *testing.T) {
 	origExec3Workers := dbg.Exec3Workers
 	origNoPrune := dbg.NoPrune()
 	origNoMerge := dbg.NoMerge()
-	origNoBackgroundE3Build := dbg.NoBackgroundE3Build()
+	origNoBackgroundMaintenance := dbg.NoBackgroundMaintenance()
 	t.Cleanup(func() {
 		dbg.SetIgnoreBAL(origIgnoreBAL)
 		dbg.SetReadAhead(origReadAhead)
@@ -119,7 +119,7 @@ func TestExecPerfFlags_OverrideDbg(t *testing.T) {
 		dbg.SetExec3Workers(origExec3Workers)
 		dbg.SetNoPrune(origNoPrune)
 		dbg.SetNoMerge(origNoMerge)
-		dbg.SetNoBackgroundE3Build(origNoBackgroundE3Build)
+		dbg.SetNoBackgroundMaintenance(origNoBackgroundMaintenance)
 	})
 
 	apply := func(ctx *cli.Context) error {
@@ -144,7 +144,7 @@ func TestExecPerfFlags_OverrideDbg(t *testing.T) {
 			dbg.SetNoPrune(ctx.Bool(ExecNoPruneFlag.Name))
 		}
 		if ctx.IsSet(ExecNoBackgroundMaintenanceFlag.Name) {
-			dbg.SetNoBackgroundE3Build(ctx.Bool(ExecNoBackgroundMaintenanceFlag.Name))
+			dbg.SetNoBackgroundMaintenance(ctx.Bool(ExecNoBackgroundMaintenanceFlag.Name))
 		}
 		return nil
 	}
@@ -166,7 +166,7 @@ func TestExecPerfFlags_OverrideDbg(t *testing.T) {
 		dbg.SetExec3Workers(42)
 		dbg.SetNoMerge(false)
 		dbg.SetNoPrune(false)
-		dbg.SetNoBackgroundE3Build(false)
+		dbg.SetNoBackgroundMaintenance(false)
 		run()
 		require.Equal(t, false, dbg.IgnoreBAL)
 		require.Equal(t, true, dbg.ReadAhead)
@@ -174,7 +174,7 @@ func TestExecPerfFlags_OverrideDbg(t *testing.T) {
 		require.Equal(t, 42, dbg.Exec3Workers)
 		require.Equal(t, false, dbg.NoMerge())
 		require.Equal(t, false, dbg.NoPrune())
-		require.Equal(t, false, dbg.NoBackgroundE3Build())
+		require.Equal(t, false, dbg.NoBackgroundMaintenance())
 	})
 
 	t.Run("batched-io=false disables read-ahead and sets IgnoreBAL", func(t *testing.T) {
@@ -233,9 +233,9 @@ func TestExecPerfFlags_OverrideDbg(t *testing.T) {
 		require.True(t, dbg.NoPrune())
 	})
 
-	t.Run("no-background-maintenance flips NoBackgroundE3Build", func(t *testing.T) {
-		dbg.SetNoBackgroundE3Build(false)
+	t.Run("no-background-maintenance flips NoBackgroundMaintenance", func(t *testing.T) {
+		dbg.SetNoBackgroundMaintenance(false)
 		run("--exec.no-background-maintenance=true")
-		require.True(t, dbg.NoBackgroundE3Build())
+		require.True(t, dbg.NoBackgroundMaintenance())
 	})
 }

--- a/cmd/utils/flags_test.go
+++ b/cmd/utils/flags_test.go
@@ -111,6 +111,7 @@ func TestExecPerfFlags_OverrideDbg(t *testing.T) {
 	origExec3Workers := dbg.Exec3Workers
 	origNoPrune := dbg.NoPrune()
 	origNoMerge := dbg.NoMerge()
+	origNoBackgroundE3Build := dbg.NoBackgroundE3Build()
 	t.Cleanup(func() {
 		dbg.SetIgnoreBAL(origIgnoreBAL)
 		dbg.SetReadAhead(origReadAhead)
@@ -118,6 +119,7 @@ func TestExecPerfFlags_OverrideDbg(t *testing.T) {
 		dbg.SetExec3Workers(origExec3Workers)
 		dbg.SetNoPrune(origNoPrune)
 		dbg.SetNoMerge(origNoMerge)
+		dbg.SetNoBackgroundE3Build(origNoBackgroundE3Build)
 	})
 
 	apply := func(ctx *cli.Context) error {
@@ -141,6 +143,9 @@ func TestExecPerfFlags_OverrideDbg(t *testing.T) {
 		if ctx.IsSet(ExecNoPruneFlag.Name) {
 			dbg.SetNoPrune(ctx.Bool(ExecNoPruneFlag.Name))
 		}
+		if ctx.IsSet(ExecNoBackgroundMaintenanceFlag.Name) {
+			dbg.SetNoBackgroundE3Build(ctx.Bool(ExecNoBackgroundMaintenanceFlag.Name))
+		}
 		return nil
 	}
 
@@ -148,7 +153,7 @@ func TestExecPerfFlags_OverrideDbg(t *testing.T) {
 		app := cli.NewApp()
 		app.Flags = []cli.Flag{
 			&ExecBatchedIOFlag, &ExecStateCacheFlag, &ExecWorkersFlag,
-			&ExecSerialFlag, &ExecNoMergeFlag, &ExecNoPruneFlag,
+			&ExecSerialFlag, &ExecNoMergeFlag, &ExecNoPruneFlag, &ExecNoBackgroundMaintenanceFlag,
 		}
 		app.Action = apply
 		require.NoError(t, app.Run(append([]string{"test"}, args...)))
@@ -161,6 +166,7 @@ func TestExecPerfFlags_OverrideDbg(t *testing.T) {
 		dbg.SetExec3Workers(42)
 		dbg.SetNoMerge(false)
 		dbg.SetNoPrune(false)
+		dbg.SetNoBackgroundE3Build(false)
 		run()
 		require.Equal(t, false, dbg.IgnoreBAL)
 		require.Equal(t, true, dbg.ReadAhead)
@@ -168,6 +174,7 @@ func TestExecPerfFlags_OverrideDbg(t *testing.T) {
 		require.Equal(t, 42, dbg.Exec3Workers)
 		require.Equal(t, false, dbg.NoMerge())
 		require.Equal(t, false, dbg.NoPrune())
+		require.Equal(t, false, dbg.NoBackgroundE3Build())
 	})
 
 	t.Run("batched-io=false disables read-ahead and sets IgnoreBAL", func(t *testing.T) {
@@ -224,5 +231,11 @@ func TestExecPerfFlags_OverrideDbg(t *testing.T) {
 		run("--exec.no-merge=true", "--exec.no-prune=true")
 		require.True(t, dbg.NoMerge())
 		require.True(t, dbg.NoPrune())
+	})
+
+	t.Run("no-background-maintenance flips NoBackgroundE3Build", func(t *testing.T) {
+		dbg.SetNoBackgroundE3Build(false)
+		run("--exec.no-background-maintenance=true")
+		require.True(t, dbg.NoBackgroundE3Build())
 	})
 }

--- a/common/dbg/experiments.go
+++ b/common/dbg/experiments.go
@@ -56,9 +56,10 @@ var (
 
 	//state v3
 	noPrune              = EnvBool("NO_PRUNE", false)
-	noMerge              = EnvBool("NO_MERGE", false)              // don't merge Domain/Hist/II
-	noMergeHistory       = EnvBool("NO_MERGE_HISTORY", false)      // don't merge Hist/II but still merge Domain
-	noDeepMergeHistory   = EnvBool("NO_DEEP_MERGE_HISTORY", false) // merge Hist/II only up to 2 steps (small+fast), skip larger merges
+	noMerge              = EnvBool("NO_MERGE", false)               // don't merge Domain/Hist/II
+	noBackgroundE3Build  = EnvBool("NO_BACKGROUND_E3_BUILD", false) // suppress background E3 file build / merge / retire goroutines
+	noMergeHistory       = EnvBool("NO_MERGE_HISTORY", false)       // don't merge Hist/II but still merge Domain
+	noDeepMergeHistory   = EnvBool("NO_DEEP_MERGE_HISTORY", false)  // merge Hist/II only up to 2 steps (small+fast), skip larger merges
 	discardCommitment    = EnvBool("DISCARD_COMMITMENT", false)
 	pruneTotalDifficulty = EnvBool("PRUNE_TOTAL_DIFFICULTY", true)
 
@@ -130,6 +131,7 @@ func ReadMemStats(m *runtime.MemStats) {
 func DiscardCommitment() bool    { return discardCommitment }
 func NoPrune() bool              { return noPrune }
 func NoMerge() bool              { return noMerge }
+func NoBackgroundE3Build() bool  { return noBackgroundE3Build }
 func NoMergeHistory() bool       { return noMergeHistory }
 func NoDeepMergeHistory() bool   { return noDeepMergeHistory }
 func PruneTotalDifficulty() bool { return pruneTotalDifficulty }
@@ -137,12 +139,13 @@ func PruneTotalDifficulty() bool { return pruneTotalDifficulty }
 // CLI-override setters for the performance toggles that also have env-var
 // twins. The env var sets the initial value at package init; the CLI layer
 // calls these at node startup only when the user explicitly set the flag.
-func SetIgnoreBAL(b bool)     { IgnoreBAL = b }
-func SetUseStateCache(b bool) { UseStateCache = b }
-func SetReadAhead(b bool)     { ReadAhead = b }
-func SetExec3Workers(n int)   { Exec3Workers = n }
-func SetNoPrune(b bool)       { noPrune = b }
-func SetNoMerge(b bool)       { noMerge = b }
+func SetIgnoreBAL(b bool)           { IgnoreBAL = b }
+func SetUseStateCache(b bool)       { UseStateCache = b }
+func SetReadAhead(b bool)           { ReadAhead = b }
+func SetExec3Workers(n int)         { Exec3Workers = n }
+func SetNoPrune(b bool)             { noPrune = b }
+func SetNoMerge(b bool)             { noMerge = b }
+func SetNoBackgroundE3Build(b bool) { noBackgroundE3Build = b }
 
 var (
 	dirtySace     uint64

--- a/common/dbg/experiments.go
+++ b/common/dbg/experiments.go
@@ -128,24 +128,24 @@ func ReadMemStats(m *runtime.MemStats) {
 	runtime.ReadMemStats(m)
 }
 
-func DiscardCommitment() bool    { return discardCommitment }
-func NoPrune() bool              { return noPrune }
-func NoMerge() bool              { return noMerge }
-func NoBackgroundE3Build() bool  { return noBackgroundE3Build }
-func NoMergeHistory() bool       { return noMergeHistory }
-func NoDeepMergeHistory() bool   { return noDeepMergeHistory }
-func PruneTotalDifficulty() bool { return pruneTotalDifficulty }
+func DiscardCommitment() bool       { return discardCommitment }
+func NoPrune() bool                 { return noPrune }
+func NoMerge() bool                 { return noMerge }
+func NoBackgroundMaintenance() bool { return noBackgroundE3Build }
+func NoMergeHistory() bool          { return noMergeHistory }
+func NoDeepMergeHistory() bool      { return noDeepMergeHistory }
+func PruneTotalDifficulty() bool    { return pruneTotalDifficulty }
 
 // CLI-override setters for the performance toggles that also have env-var
 // twins. The env var sets the initial value at package init; the CLI layer
 // calls these at node startup only when the user explicitly set the flag.
-func SetIgnoreBAL(b bool)           { IgnoreBAL = b }
-func SetUseStateCache(b bool)       { UseStateCache = b }
-func SetReadAhead(b bool)           { ReadAhead = b }
-func SetExec3Workers(n int)         { Exec3Workers = n }
-func SetNoPrune(b bool)             { noPrune = b }
-func SetNoMerge(b bool)             { noMerge = b }
-func SetNoBackgroundE3Build(b bool) { noBackgroundE3Build = b }
+func SetIgnoreBAL(b bool)               { IgnoreBAL = b }
+func SetUseStateCache(b bool)           { UseStateCache = b }
+func SetReadAhead(b bool)               { ReadAhead = b }
+func SetExec3Workers(n int)             { Exec3Workers = n }
+func SetNoPrune(b bool)                 { noPrune = b }
+func SetNoMerge(b bool)                 { noMerge = b }
+func SetNoBackgroundMaintenance(b bool) { noBackgroundE3Build = b }
 
 var (
 	dirtySace     uint64

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -1928,6 +1928,11 @@ func (a *Aggregator) BuildFilesInBackground(txNum uint64) chan struct{} {
 func (a *Aggregator) buildFilesInBackground(txNum uint64, doMerge bool) chan struct{} {
 	fin := make(chan struct{})
 
+	if dbg.NoBackgroundE3Build() {
+		close(fin)
+		return fin
+	}
+
 	if !a.produce {
 		close(fin)
 		return fin

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -1928,7 +1928,7 @@ func (a *Aggregator) BuildFilesInBackground(txNum uint64) chan struct{} {
 func (a *Aggregator) buildFilesInBackground(txNum uint64, doMerge bool) chan struct{} {
 	fin := make(chan struct{})
 
-	if dbg.NoBackgroundE3Build() {
+	if dbg.NoBackgroundMaintenance() {
 		close(fin)
 		return fin
 	}

--- a/db/state/forkable_agg.go
+++ b/db/state/forkable_agg.go
@@ -156,6 +156,15 @@ func (r *ForkableAgg) BuildFilesInBackground(num RootNum) chan struct{} {
 	// build in background
 	fin := make(chan struct{})
 
+	// Mirror the gate in Aggregator.buildFilesInBackground / Eth.startBackgroundMergeLoop
+	// so --exec.no-background-maintenance also suppresses forkable (BlockAccessLists,
+	// receipts, etc.) build+merge — otherwise focused-perf-test runs still see noise
+	// from this goroutine.
+	if dbg.NoBackgroundMaintenance() {
+		close(fin)
+		return fin
+	}
+
 	if ok := r.buildingFiles.CompareAndSwap(false, true); !ok {
 		r.logger.Debug("[fork_agg] BuildFilesInBackground disabled or already in progress. Skipping...")
 		close(fin)

--- a/execution/stagedsync/stage_snapshots.go
+++ b/execution/stagedsync/stage_snapshots.go
@@ -431,7 +431,7 @@ func SnapshotsPrune(s *PruneState, cfg SnapshotsCfg, ctx context.Context, tx kv.
 		return nil
 	}
 	freezingCfg := cfg.blockReader.FreezingCfg()
-	if freezingCfg.ProduceE2 {
+	if freezingCfg.ProduceE2 && !dbg.NoBackgroundE3Build() {
 		//TODO: initialSync maybe save files progress here
 
 		var minBlockNumber uint64

--- a/execution/stagedsync/stage_snapshots.go
+++ b/execution/stagedsync/stage_snapshots.go
@@ -431,7 +431,7 @@ func SnapshotsPrune(s *PruneState, cfg SnapshotsCfg, ctx context.Context, tx kv.
 		return nil
 	}
 	freezingCfg := cfg.blockReader.FreezingCfg()
-	if freezingCfg.ProduceE2 && !dbg.NoBackgroundE3Build() {
+	if freezingCfg.ProduceE2 && !dbg.NoBackgroundMaintenance() {
 		//TODO: initialSync maybe save files progress here
 
 		var minBlockNumber uint64

--- a/node/cli/default_flags.go
+++ b/node/cli/default_flags.go
@@ -53,6 +53,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.ExecSerialFlag,
 	&utils.ExecNoMergeFlag,
 	&utils.ExecNoPruneFlag,
+	&utils.ExecNoBackgroundMaintenanceFlag,
 	&BatchSizeFlag,
 	&BodyCacheLimitFlag,
 	&DatabaseVerbosityFlag,

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -1119,7 +1119,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 		}
 	}
 
-	if !dbg.NoBackgroundE3Build() {
+	if !dbg.NoBackgroundMaintenance() {
 		go func() {
 			if err := temporalDb.Debug().MergeLoop(ctx); err != nil {
 				logger.Error("snapashot merge loop error", "err", err)

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -1119,11 +1119,13 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 		}
 	}
 
-	go func() {
-		if err := temporalDb.Debug().MergeLoop(ctx); err != nil {
-			logger.Error("snapashot merge loop error", "err", err)
-		}
-	}()
+	if !dbg.NoBackgroundE3Build() {
+		go func() {
+			if err := temporalDb.Debug().MergeLoop(ctx); err != nil {
+				logger.Error("snapashot merge loop error", "err", err)
+			}
+		}()
+	}
 
 	return backend, nil
 }


### PR DESCRIPTION
## Summary

Adds a CLI flag (`--exec.no-background-maintenance`) and matching `NO_BACKGROUND_E3_BUILD` env var (kept as legacy name for back-compat with existing benchmarking scripts) that suppresses the four background goroutines performing state-aggregator file build, merge, forkable build, and snapshot retirement:

1. `Aggregator.buildFilesInBackground` — Domain/Hist/II background file build
2. `ForkableAgg.BuildFilesInBackground` — forkable (BlockAccessLists, receipts, etc.) build + merge
3. `SnapshotsPrune` retirement loop in `stage_snapshots.go`
4. `MergeLoop` goroutine launched from `node/eth/backend.go`

Follows the existing `--exec.no-merge` / `--exec.no-prune` precedent: env var is the source of truth at package init; CLI flag overrides at startup if explicitly set.

## Motivation

When running focused performance tests on a specific code path (e.g. commitment calculation, parallel execution, single-block latency), background maintenance goroutines compete for CPU and disk and produce noise that confounds like-for-like comparisons. This flag silences them so the measurement window isolates only the code under test.

This consolidates an env var (`NO_BACKGROUND_E3_BUILD`) that was already in use locally for benchmarking work into a documented, testable CLI flag, with the four call sites routed through a single `dbg.NoBackgroundMaintenance()` accessor.

## Not for operational use

A node running with this flag will accumulate unmerged segment files indefinitely, will not retire ancient blocks, will not build forkable files, and will not build the background E3 file pipeline. **It is only intended for diagnostic / focused-performance-testing use, not as an operational setting.** The flag's `Usage` string makes this explicit.

## Test plan

- [x] `go test ./cmd/utils/... -run TestExecPerfFlags_OverrideDbg` — 11/11 subtests pass including new `no-background-maintenance` subtest
- [x] `make lint` — clean
- [x] Build erigon — clean
- [ ] Verify env var still works as before (`NO_BACKGROUND_E3_BUILD=true ./erigon ...` suppresses background maintenance, no flag set required)
- [ ] Verify flag suppresses background maintenance when set (`./erigon --exec.no-background-maintenance ...`)
- [ ] Verify flag overrides env var when both set (per `--exec.no-merge` precedent)