### PR TITLE
commitment: WarmupCache hit/miss/evict observability counters

### DIFF
--- a/execution/commitment/warmup_cache.go
+++ b/execution/commitment/warmup_cache.go
@@ -17,6 +17,7 @@
 package commitment
 
 import (
+	"fmt"
 	"sync/atomic"
 
 	"github.com/erigontech/erigon/common/maphash"
@@ -46,6 +47,13 @@ type WarmupCache struct {
 	storage  *maphash.Map[*storageEntry]
 
 	enabled atomic.Bool
+
+	// Observability counters. Updated by Get/Put paths; read by Stats().
+	// Atomic so warmup-worker reads and main-trie reads don't race.
+	branchHits, branchMisses, branchEvicted atomic.Uint64
+	branchBytesServed                       atomic.Uint64
+	accountHits, accountMisses              atomic.Uint64
+	storageHits, storageMisses              atomic.Uint64
 }
 
 // NewWarmupCache creates a new warmup cache instance.
@@ -87,9 +95,16 @@ func (c *WarmupCache) GetBranch(prefix []byte) ([]byte, bool) {
 		return nil, false
 	}
 	entry, found := c.branches.Get(prefix)
-	if !found || entry.isEvicted.Load() {
+	if !found {
+		c.branchMisses.Add(1)
 		return nil, false
 	}
+	if entry.isEvicted.Load() {
+		c.branchEvicted.Add(1)
+		return nil, false
+	}
+	c.branchHits.Add(1)
+	c.branchBytesServed.Add(uint64(len(entry.data)))
 	return entry.data, true
 }
 
@@ -99,10 +114,17 @@ func (c *WarmupCache) GetAndEvictBranch(prefix []byte) ([]byte, bool) {
 		return nil, false
 	}
 	entry, found := c.branches.Get(prefix)
-	if !found || entry.isEvicted.Load() {
+	if !found {
+		c.branchMisses.Add(1)
+		return nil, false
+	}
+	if entry.isEvicted.Load() {
+		c.branchEvicted.Add(1)
 		return nil, false
 	}
 	entry.isEvicted.Store(true)
+	c.branchHits.Add(1)
+	c.branchBytesServed.Add(uint64(len(entry.data)))
 	return entry.data, true
 }
 
@@ -137,8 +159,10 @@ func (c *WarmupCache) GetAccount(plainKey []byte) (*Update, bool) {
 	}
 	entry, found := c.accounts.Get(plainKey)
 	if !found || entry.isEvicted.Load() {
+		c.accountMisses.Add(1)
 		return nil, false
 	}
+	c.accountHits.Add(1)
 	return entry.update, true
 }
 
@@ -187,8 +211,10 @@ func (c *WarmupCache) GetStorage(plainKey []byte) (*Update, bool) {
 	}
 	entry, found := c.storage.Get(plainKey)
 	if !found || entry.isEvicted.Load() {
+		c.storageMisses.Add(1)
 		return nil, false
 	}
+	c.storageHits.Add(1)
 	return entry.update, true
 }
 
@@ -231,9 +257,46 @@ func (c *WarmupCache) EvictPlainKey(plainKey []byte) {
 	}
 }
 
-// Clear clears all cached data.
+// Clear clears all cached data and resets stats counters.
 func (c *WarmupCache) Clear() {
 	c.branches = maphash.NewMap[*branchEntry]()
 	c.accounts = maphash.NewMap[*accountEntry]()
 	c.storage = maphash.NewMap[*storageEntry]()
+	c.ResetStats()
+}
+
+// Stats returns a one-line summary of cache hit/miss counters.
+// Format matches the per-block log line: branch, account, storage with
+// hit-percentages and bytes served. Useful in commitment debug logs and
+// for the per-Process LogCommitments line.
+func (c *WarmupCache) Stats() string {
+	bh, bm, be := c.branchHits.Load(), c.branchMisses.Load(), c.branchEvicted.Load()
+	bb := c.branchBytesServed.Load()
+	ah, am := c.accountHits.Load(), c.accountMisses.Load()
+	sh, sm := c.storageHits.Load(), c.storageMisses.Load()
+	pct := func(hit, miss uint64) float64 {
+		total := hit + miss
+		if total == 0 {
+			return 0
+		}
+		return 100.0 * float64(hit) / float64(total)
+	}
+	return fmt.Sprintf(
+		"branch hit=%d miss=%d evict=%d (%.1f%%, %.1f MiB) | acct hit=%d miss=%d (%.1f%%) | stor hit=%d miss=%d (%.1f%%)",
+		bh, bm, be, pct(bh, bm), float64(bb)/1024/1024,
+		ah, am, pct(ah, am),
+		sh, sm, pct(sh, sm),
+	)
+}
+
+// ResetStats zeros out all hit/miss/byte counters without touching cached data.
+func (c *WarmupCache) ResetStats() {
+	c.branchHits.Store(0)
+	c.branchMisses.Store(0)
+	c.branchEvicted.Store(0)
+	c.branchBytesServed.Store(0)
+	c.accountHits.Store(0)
+	c.accountMisses.Store(0)
+	c.storageHits.Store(0)
+	c.storageMisses.Store(0)
 }

--- a/execution/commitment/warmup_cache_test.go
+++ b/execution/commitment/warmup_cache_test.go
@@ -333,3 +333,94 @@ func BenchmarkComparison_Map_100k(b *testing.B) {
 		cache.GetStorage(keys[i%len(keys)])
 	}
 }
+
+// TestWarmupCache_Stats verifies that hit/miss/evict counters are updated
+// correctly across the Get/Put/Evict paths and that Stats() returns a
+// deterministic format.
+func TestWarmupCache_Stats(t *testing.T) {
+	cache := NewWarmupCache()
+
+	// Branch hits + misses + bytes-served
+	bk := []byte("k-branch")
+	bd := []byte("branch-data-12345")
+	cache.PutBranch(bk, bd)
+	if _, ok := cache.GetBranch(bk); !ok {
+		t.Fatal("expected branch hit")
+	}
+	if _, ok := cache.GetBranch([]byte("missing-branch")); ok {
+		t.Fatal("expected branch miss")
+	}
+
+	// Branch eviction
+	cache.EvictBranch(bk)
+	if _, ok := cache.GetBranch(bk); ok {
+		t.Fatal("expected branch evicted miss")
+	}
+
+	// Account hits + misses
+	ak := []byte("k-acct")
+	cache.PutAccount(ak, &Update{})
+	if _, ok := cache.GetAccount(ak); !ok {
+		t.Fatal("expected account hit")
+	}
+	if _, ok := cache.GetAccount([]byte("missing-acct")); ok {
+		t.Fatal("expected account miss")
+	}
+
+	// Storage hits + misses
+	sk := []byte("k-stor")
+	cache.PutStorage(sk, &Update{})
+	if _, ok := cache.GetStorage(sk); !ok {
+		t.Fatal("expected storage hit")
+	}
+	if _, ok := cache.GetStorage([]byte("missing-stor")); ok {
+		t.Fatal("expected storage miss")
+	}
+
+	// Counters: branch hit=1 miss=1 evict=1 bytes=17, acct hit=1 miss=1, stor hit=1 miss=1
+	if got := cache.branchHits.Load(); got != 1 {
+		t.Fatalf("branchHits: got %d, want 1", got)
+	}
+	if got := cache.branchMisses.Load(); got != 1 {
+		t.Fatalf("branchMisses: got %d, want 1", got)
+	}
+	if got := cache.branchEvicted.Load(); got != 1 {
+		t.Fatalf("branchEvicted: got %d, want 1", got)
+	}
+	if got := cache.branchBytesServed.Load(); got != uint64(len(bd)) {
+		t.Fatalf("branchBytesServed: got %d, want %d", got, len(bd))
+	}
+	if got := cache.accountHits.Load(); got != 1 {
+		t.Fatalf("accountHits: got %d, want 1", got)
+	}
+	if got := cache.accountMisses.Load(); got != 1 {
+		t.Fatalf("accountMisses: got %d, want 1", got)
+	}
+	if got := cache.storageHits.Load(); got != 1 {
+		t.Fatalf("storageHits: got %d, want 1", got)
+	}
+	if got := cache.storageMisses.Load(); got != 1 {
+		t.Fatalf("storageMisses: got %d, want 1", got)
+	}
+
+	// Stats() format
+	stats := cache.Stats()
+	for _, want := range []string{
+		"branch hit=1 miss=1 evict=1",
+		"acct hit=1 miss=1",
+		"stor hit=1 miss=1",
+	} {
+		if !bytes.Contains([]byte(stats), []byte(want)) {
+			t.Errorf("Stats() missing %q\nfull: %s", want, stats)
+		}
+	}
+
+	// ResetStats zeros counters but leaves data intact
+	cache.ResetStats()
+	if got := cache.branchHits.Load(); got != 0 {
+		t.Fatalf("branchHits after Reset: got %d, want 0", got)
+	}
+	if _, ok := cache.GetAccount(ak); !ok {
+		t.Fatal("account data should survive ResetStats")
+	}
+}


### PR DESCRIPTION
## Summary

Adds hit/miss/evict observability counters to `WarmupCache` plus a `Stats()` string formatter and `ResetStats()` helper. No behavior change beyond the counter updates themselves.

## What's added

- Per-cache atomic counters: `branchHits`, `branchMisses`, `branchEvicted`, `branchBytesServed`, `accountHits`, `accountMisses`, `storageHits`, `storageMisses`
- `Stats() string` — one-line summary suitable for embedding in `LogCommitments` or per-Process debug output. Format:
  ```
  branch hit=N miss=N evict=N (X.X%, Y.Y MiB) | acct hit=N miss=N (X.X%) | stor hit=N miss=N (X.X%)
  ```
- `ResetStats()` — zeros counters without touching cached data. Useful for per-Process windowed measurement.
- `Clear()` now also resets counters (since data and counters were accumulated together).

## Why

Confirming warmup effectiveness in production was previously blind — the warmer would run, but operators couldn't see per-block hit rates without changing log levels or wiring up `KV_READ_METRICS`. These counters are always-on (atomic ops are negligible) and provide:

- Per-block diagnostics when investigating commitment perf (e.g. for #20920 follow-up work)
- Future per-pool dashboards once a coordinator/observability layer lands (tracked separately)
- Validation signal when changes touch the warmup path

## Test plan

- [x] `TestWarmupCache_Stats` covers hit/miss/evict accounting across branch/account/storage paths, verifies `Stats()` format, and confirms `ResetStats()` preserves data.
- [x] `make lint` clean
- [x] `make erigon` builds

Stacked against `exec3/remove-rwtx-threading-merge-main` (PR #20805). Independent of #20982 (Stage A removal) — different files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
