### PR TITLE
commitment: extract canonical DecodeBranchInto (refactor toward representation reduction)

### DIFF
--- a/execution/commitment/branch_decode.go
+++ b/execution/commitment/branch_decode.go
@@ -1,0 +1,95 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package commitment
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math/bits"
+)
+
+// BranchMaps captures the three branch-level bitmasks decoded alongside the
+// per-cell payload. Held separately from the cells slice so callers can apply
+// them into trie state without struct-assigning the whole [16]cell array.
+type BranchMaps struct {
+	Bitmap   uint16 // present-children bitmap (the canonical map encoded in the branch)
+	TouchMap uint16 // children that were touched in this branch (set by caller per deleted flag)
+	AfterMap uint16 // children present after this commitment step
+}
+
+// DecodeBranchInto parses the on-disk encoded form of a branch (as returned
+// by ctx.Branch / readBranchAndCheckForFlushing with the leading 2-byte
+// touch-map stripped) and populates the supplied cells array.
+//
+// branchData must already have the leading touch-map prefix stripped — the
+// raw bytes returned from Branch() include it; callers strip it before
+// invoking this function (matching the unfoldBranchNode call pattern).
+//
+// deleted controls the touchMap/afterMap convention:
+//   - deleted=true  → all decoded cells are touched-but-not-present-after
+//     (touchMap = bitmap, afterMap = 0)
+//   - deleted=false → all decoded cells are present-after (touchMap = 0,
+//     afterMap = bitmap)
+//
+// Returns the three branch-level maps for the caller to apply into their
+// own state machine. The cells array is mutated in place.
+//
+// This is a PURE decode — it does NOT call deriveHashedKeys on the cells.
+// Trie callers (HexPatriciaHashed.unfoldBranchNode) follow this with their
+// own loop calling deriveHashedKeys per cell, since they have the keccak
+// scratch buffer. Cache callers can skip deriveHashedKeys entirely until
+// the cell is consumed by the trie.
+//
+// This function is the canonical decoder for branch data. Both
+// unfoldBranchNode (which feeds the in-memory grid for fold/unfold) and
+// future cache populators consume branches via this same path so the
+// encoded→cells transformation lives in one place.
+func DecodeBranchInto(
+	branchData []byte,
+	deleted bool,
+	cells *[16]cell,
+) (BranchMaps, error) {
+	if len(branchData) < 2 {
+		return BranchMaps{}, fmt.Errorf("branch data too short for bitmap: %d bytes", len(branchData))
+	}
+	bitmap := binary.BigEndian.Uint16(branchData[0:])
+	maps := BranchMaps{Bitmap: bitmap}
+	if deleted {
+		maps.TouchMap, maps.AfterMap = bitmap, 0
+	} else {
+		maps.TouchMap, maps.AfterMap = 0, bitmap
+	}
+
+	pos := 2
+	for bitset := bitmap; bitset != 0; {
+		bit := bitset & -bitset
+		nibble := bits.TrailingZeros16(bit)
+		c := &cells[nibble]
+		if pos >= len(branchData) {
+			return BranchMaps{}, fmt.Errorf("branch data truncated before cell at nibble %d", nibble)
+		}
+		fieldBits := branchData[pos]
+		pos++
+		newPos, err := c.fillFromFields(branchData, pos, cellFields(fieldBits))
+		if err != nil {
+			return BranchMaps{}, fmt.Errorf("fillFromFields nibble %d: %w", nibble, err)
+		}
+		pos = newPos
+		bitset ^= bit
+	}
+	return maps, nil
+}

--- a/execution/commitment/branch_decode_test.go
+++ b/execution/commitment/branch_decode_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package commitment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDecodeBranchInto_RoundTrip asserts that DecodeBranchInto recovers
+// the cells encoded by BranchEncoder.EncodeBranch — the property test that
+// keeps the canonical decoder consistent with the canonical encoder.
+func TestDecodeBranchInto_RoundTrip(t *testing.T) {
+	t.Parallel()
+	row, bm := generateCellRow(t, 16)
+
+	be := NewBranchEncoder(1024)
+	cellData := generateCellEncodeDataRow(t, row, bm)
+	enc, err := be.EncodeBranch(bm, bm, bm, &cellData)
+	require.NoError(t, err)
+	require.NotEmpty(t, enc)
+
+	// EncodeBranch produces bytes WITH the 2-byte touch-map prefix; the
+	// decoder consumes the bytes WITHOUT it (matching the unfoldBranchNode
+	// call pattern, which strips the touch-map prefix before decoding).
+	branchData := []byte(enc)[2:]
+
+	var cells [16]cell
+	maps, err := DecodeBranchInto(branchData, false /* not deleted */, &cells)
+	require.NoError(t, err)
+
+	// Bitmap should match what was encoded
+	require.Equal(t, bm, maps.Bitmap, "decoded bitmap mismatch")
+	require.Equal(t, uint16(0), maps.TouchMap, "expected empty touchMap when deleted=false")
+	require.Equal(t, bm, maps.AfterMap, "afterMap should equal bitmap when deleted=false")
+
+	// Each present cell should match the original on the fields that
+	// survive encode→decode (extension, account/storage addr, hash).
+	// hashedExtension etc. are set by deriveHashedKeys (separate step) and
+	// are not part of the decoder's responsibility.
+	for i, orig := range row {
+		decoded := &cells[i]
+		require.Equal(t, orig.extLen, decoded.extLen, "cell %d extLen", i)
+		require.Equal(t, orig.extension[:orig.extLen], decoded.extension[:decoded.extLen], "cell %d extension", i)
+		require.Equal(t, orig.accountAddrLen, decoded.accountAddrLen, "cell %d accountAddrLen", i)
+		require.Equal(t, orig.accountAddr[:orig.accountAddrLen], decoded.accountAddr[:decoded.accountAddrLen], "cell %d accountAddr", i)
+		require.Equal(t, orig.storageAddrLen, decoded.storageAddrLen, "cell %d storageAddrLen", i)
+		require.Equal(t, orig.storageAddr[:orig.storageAddrLen], decoded.storageAddr[:decoded.storageAddrLen], "cell %d storageAddr", i)
+		require.Equal(t, orig.hashLen, decoded.hashLen, "cell %d hashLen", i)
+		require.Equal(t, orig.hash[:orig.hashLen], decoded.hash[:decoded.hashLen], "cell %d hash", i)
+	}
+}
+
+// TestDecodeBranchInto_DeletedFlag verifies the touchMap/afterMap convention
+// flips correctly with the deleted parameter.
+func TestDecodeBranchInto_DeletedFlag(t *testing.T) {
+	t.Parallel()
+	row, bm := generateCellRow(t, 16)
+
+	be := NewBranchEncoder(1024)
+	cellData := generateCellEncodeDataRow(t, row, bm)
+	enc, err := be.EncodeBranch(bm, bm, bm, &cellData)
+	require.NoError(t, err)
+	branchData := []byte(enc)[2:]
+
+	var cells [16]cell
+	maps, err := DecodeBranchInto(branchData, true, &cells)
+	require.NoError(t, err)
+	require.Equal(t, bm, maps.Bitmap)
+	require.Equal(t, bm, maps.TouchMap, "deleted=true → touchMap = bitmap")
+	require.Equal(t, uint16(0), maps.AfterMap, "deleted=true → afterMap = 0")
+}
+
+// TestDecodeBranchInto_TruncatedInput asserts the decoder fails cleanly on
+// truncated branch data instead of panicking.
+func TestDecodeBranchInto_TruncatedInput(t *testing.T) {
+	t.Parallel()
+	var cells [16]cell
+
+	// Empty data — should fail at bitmap read.
+	_, err := DecodeBranchInto(nil, false, &cells)
+	require.Error(t, err)
+
+	// Just bitmap, no cells — should be fine if bitmap is 0.
+	_, err = DecodeBranchInto([]byte{0x00, 0x00}, false, &cells)
+	require.NoError(t, err, "bitmap=0 with no cell data should decode cleanly")
+
+	// Bitmap claims one cell but data missing — should fail.
+	_, err = DecodeBranchInto([]byte{0x00, 0x01}, false, &cells)
+	require.Error(t, err, "bitmap with set bit but no cell data should error")
+}

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -1750,28 +1750,19 @@ func (hph *HexPatriciaHashed) unfoldBranchNode(row int, depth int16, deleted boo
 		return fmt.Errorf("empty branch data read during unfold, compact prefix %x nibbles %x", key, hph.currentKey[:hph.currentKeyLen])
 	}
 	hph.branchBefore[row] = true
-	bitmap := binary.BigEndian.Uint16(branchData[0:])
-	pos := 2
-	if deleted { // All cells come as deleted (touched but not present after)
-		hph.touchMap[row], hph.afterMap[row] = bitmap, 0
-	} else {
-		hph.touchMap[row], hph.afterMap[row] = 0, bitmap
+	maps, err := DecodeBranchInto(branchData, deleted, &hph.grid[row])
+	if err != nil {
+		return fmt.Errorf("prefix [%x] branchData[%x]: %w", hph.currentKey[:hph.currentKeyLen], branchData, err)
 	}
-	//fmt.Printf("unfoldBranchNode prefix '%x' [%x], afterMap = [%016b], touchMap = [%016b]\n", key, branchData, hph.afterMap[row], hph.touchMap[row])
-	// Loop iterating over the set bits of modMask
-	for bitset, j := bitmap, 0; bitset != 0; j++ {
+	hph.touchMap[row] = maps.TouchMap
+	hph.afterMap[row] = maps.AfterMap
+	for bitset := maps.Bitmap; bitset != 0; {
 		bit := bitset & -bitset
 		nibble := bits.TrailingZeros16(bit)
 		cell := &hph.grid[row][nibble]
-		fieldBits := branchData[pos]
-		pos++
-		if pos, err = cell.fillFromFields(branchData, pos, cellFields(fieldBits)); err != nil {
-			return fmt.Errorf("prefix [%x] branchData[%x]: %w", hph.currentKey[:hph.currentKeyLen], branchData, err)
-		}
 		if hph.trace {
 			fmt.Printf("cell (%d, %x, depth=%d) %s\n", row, nibble, depth, cell.FullString())
 		}
-
 		// relies on plain account/storage key so need to be dereferenced before hashing
 		if err = cell.deriveHashedKeys(depth, hph.keccak, hph.accountKeyLen, hph.cellHashBuf[:]); err != nil {
 			return err


### PR DESCRIPTION
## Summary

Pure refactor — behavior preserved. Splits the encoded-branch→cells decode logic out of `HexPatriciaHashed.unfoldBranchNode` into a free function `DecodeBranchInto` so the same code is consumed by:

- `unfoldBranchNode` (existing trie unfold path)
- Future cache populators (decoded-payload BranchCache work)
- Future parallel pre-unfold orchestrator (Stage E in the long-term roadmap)

Today these would each have to re-derive the encoded-branch parsing logic. Centralising it ensures one decoder, one set of edge cases, one place to fix any bug in the on-disk format handling.

## Why this matters

This is the foundation step of the representation-reduction work tracked in `agentspecs/trie-data-pipeline-complexity-tax.md`. The cache prototype investigation (#20920 follow-up) showed that meaningful cross-block cache benefit requires reducing the number of branch representations the codebase juggles. This PR centralises one of those representation transitions — encoded-bytes → cells — into a single pure function. Subsequent PRs in the sequence will:

1. Add a decoded-payload cache that reads through this same decoder.
2. Lift `unfoldKeyPath` as a per-key traversal primitive consumed by the warmer + future Stage E.
3. Drop the `extractBranchCellAddresses` partial-decode (now redundant once the decoded cache holds the structure).

This PR is independent and merge-able on its own — purely a refactor consolidating one duplicated representation transition.

## Design notes

- `DecodeBranchInto` is intentionally **pure** — it does not call `deriveHashedKeys`. Trie callers (which need hashed keys for the fold state machine) follow the decode with their own keccak loop. Cache callers can skip the derive step entirely until the cell is consumed by the trie.
- `branchData` must already have the leading 2-byte touch-map prefix stripped — matches the `unfoldBranchNode` call pattern. Documented in the function comment.
- `BranchMaps` struct returns the three branch-level bitmasks (Bitmap, TouchMap, AfterMap) — kept separate from the cells slice so callers can apply them into trie state without struct-copying the whole `[16]cell` array.

## Test plan

- [x] `TestDecodeBranchInto_RoundTrip`: `BranchEncoder.EncodeBranch` produces bytes that `DecodeBranchInto` recovers cell-for-cell. Property test that keeps the canonical decoder consistent with the canonical encoder.
- [x] `TestDecodeBranchInto_DeletedFlag`: `touchMap`/`afterMap` convention with the `deleted` parameter.
- [x] `TestDecodeBranchInto_TruncatedInput`: clean errors on truncated input (no panic).
- [x] Existing commitment test suite (incl. `TestBranchData_*` trie-mismatch tests) — all pass without modification, confirming the refactor preserves `unfoldBranchNode`'s behavior.
- [x] `make lint` clean
- [x] `make erigon` builds

Stacked against `exec3/remove-rwtx-threading-merge-main` (PR #20805). Independent of #20982 (Stage A removal) and #20983 (WarmupCache observability) — different files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
