### PR TITLE
commitment: extract unfoldKeyPath as per-key traversal primitive

### DIFF
--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -2499,6 +2499,40 @@ func (hph *HexPatriciaHashed) RootHash() ([]byte, error) {
 	return rootHash[1:], nil // first byte is 128+hash_len=160
 }
 
+// unfoldKeyPath drives hph.unfold in a loop until the trie is unfolded
+// far enough that the cell at hashedKey can be updated — i.e. until
+// needUnfolding returns 0. This is the per-key traversal primitive
+// that follows the fold step in followAndUpdate.
+//
+// Extracted as a primitive so future orchestrators can drive
+// unfold-only traversals (e.g. cache populators that walk a touched-key
+// path to fill cell state without doing a fold/update). HashSort's
+// per-key followAndUpdate is the sequential orchestrator over this
+// primitive today; future concurrent / parallel orchestrators (each
+// with their own HexPatriciaHashed instance) can reuse it.
+//
+// plainKey is used only for per-key metrics labelling (StartUnfolding).
+// Pass an empty/nil slice if no metric attribution is needed.
+func (hph *HexPatriciaHashed) unfoldKeyPath(hashedKey, plainKey []byte) error {
+	for unfolding := hph.needUnfolding(hashedKey); unfolding > 0; unfolding = hph.needUnfolding(hashedKey) {
+		printLater := hph.currentKeyLen == 0 && hph.mounted && hph.trace
+		var unfoldDone func()
+		if dbg.KVReadLevelledMetrics {
+			unfoldDone = hph.metrics.StartUnfolding(plainKey)
+		}
+		if err := hph.unfold(hashedKey, unfolding); err != nil {
+			return fmt.Errorf("unfold: %w", err)
+		}
+		if unfoldDone != nil {
+			unfoldDone()
+		}
+		if printLater {
+			fmt.Printf("[%x] subtrie pref '%x' d=%d\n", hph.mountedNib, hph.currentKey[:hph.currentKeyLen], hph.depths[max(0, hph.activeRows-1)])
+		}
+	}
+	return nil
+}
+
 func (hph *HexPatriciaHashed) followAndUpdate(hashedKey, plainKey []byte, stateUpdate *Update) (err error) {
 	//if hph.trace {
 	// fmt.Printf("mnt: %0x current: %x path %x\n", hph.mountedNib, hph.currentKey[:hph.currentKeyLen], hashedKey)
@@ -2516,23 +2550,9 @@ func (hph *HexPatriciaHashed) followAndUpdate(hashedKey, plainKey []byte, stateU
 			foldDone()
 		}
 	}
-	// Now unfold until we step on an empty cell
-	for unfolding := hph.needUnfolding(hashedKey); unfolding > 0; unfolding = hph.needUnfolding(hashedKey) {
-		printLater := hph.currentKeyLen == 0 && hph.mounted && hph.trace
-		var unfoldDone func()
-		if dbg.KVReadLevelledMetrics {
-			unfoldDone = hph.metrics.StartUnfolding(plainKey)
-		}
-		if err := hph.unfold(hashedKey, unfolding); err != nil {
-			return fmt.Errorf("unfold: %w", err)
-		}
-		if unfoldDone != nil {
-			unfoldDone()
-		}
-		if printLater {
-			fmt.Printf("[%x] subtrie pref '%x' d=%d\n", hph.mountedNib, hph.currentKey[:hph.currentKeyLen], hph.depths[max(0, hph.activeRows-1)])
-		}
-		// fmt.Printf("mnt: %0x current: %x path %x\n", hph.mountedNib, hph.currentKey[:hph.currentKeyLen], hashedKey)
+	// Now unfold the path so the cell at hashedKey is reachable.
+	if err := hph.unfoldKeyPath(hashedKey, plainKey); err != nil {
+		return err
 	}
 
 	if stateUpdate == nil {


### PR DESCRIPTION
## Summary

Pure refactor — behavior preserved. Lifts the unfold-loop from `HexPatriciaHashed.followAndUpdate` into its own method, parameterized over `(hashedKey, plainKey)` and intended as the per-key traversal primitive that future orchestrators consume.

Today only `followAndUpdate` calls it, replacing the inline loop with a one-line call. The extracted method preserves the existing metric attribution (`StartUnfolding`) and trace-print behavior verbatim.

## Why now

This is the second step in the representation-reduction sequence (see `agentspecs/trie-data-pipeline-complexity-tax.md`). Future PRs will introduce orchestrators that drive unfold-only walks of touched-key paths to fill cell state without going through the full fold/update cycle:

- **Cache populator** (decoded-payload BranchCache) needs to walk a touched-key path and capture the cells encountered, without triggering fold or modifying the trie's update buffer.
- **Stage E parallel pre-unfold orchestrator** drives `unfoldKeyPath` across multiple `HexPatriciaHashed` instances concurrently to pre-warm trie state before commit.

Both consume the same primitive. Centralising it now means each future orchestrator is a thin wrapper rather than a duplicate of the unfold-loop logic.

## Design notes

- Method on `HexPatriciaHashed` (not free function) because the unfold operation is fundamentally state-coupled to the trie instance (`hph.currentKey`, `hph.activeRows`, `hph.grid[row]`). Future orchestrators that want concurrent traversal will use multiple `HexPatriciaHashed` instances, each running its own `unfoldKeyPath` calls — not multiple goroutines on a shared instance.
- `plainKey` parameter retained for `StartUnfolding` metric labelling. Pass nil/empty if no metric attribution needed.
- Trace-print behavior (`printLater` block) preserved verbatim — same conditions, same format.

## Test plan

- [x] Full commitment test suite passes without modification (all test files under `execution/commitment/...` — `TestBranchData_*`, `TestCommitment_*`, `TestCalculator_*`, etc.) confirming the refactor preserves `followAndUpdate`'s behavior.
- [x] `make lint` clean
- [x] `make erigon` builds

Stacked against `exec3/remove-rwtx-threading-merge-main` (PR #20805). Independent of #20982 (Stage A removal), #20983 (WarmupCache observability), and #20984 (DecodeBranchInto) — different files / different sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
