### PR TITLE
execution/protocol: validate logs bloom on pre-Byzantium blocks

### DIFF
--- a/execution/protocol/block_exec.go
+++ b/execution/protocol/block_exec.go
@@ -376,7 +376,7 @@ func InitializeBlockExecution(engine rules.Engine, chain rules.ChainHeaderReader
 
 var alwaysSkipReceiptCheck = dbg.EnvBool("EXEC_SKIP_RECEIPT_CHECK", false)
 
-func BlockPostValidation(blockGasUsed, blobGasUsed uint64, checkReceipts bool, receipts types.Receipts, h *types.Header, txns types.Transactions, chainConfig *chain.Config, logger log.Logger) error {
+func BlockPostValidation(blockGasUsed, blobGasUsed uint64, checkReceipts, checkBloom bool, receipts types.Receipts, h *types.Header, txns types.Transactions, chainConfig *chain.Config, logger log.Logger) error {
 	if blockGasUsed != h.GasUsed {
 		logger.Warn("gas used mismatch", "block", h.Number.Uint64(), "header", h.GasUsed, "execution", blockGasUsed,
 			"diff", int64(blockGasUsed)-int64(h.GasUsed), "txCount", len(txns), "receiptCount", len(receipts))
@@ -413,7 +413,15 @@ func BlockPostValidation(blockGasUsed, blobGasUsed uint64, checkReceipts bool, r
 			return fmt.Errorf("receiptHash mismatch: %x != %x, headerNum=%d, %x",
 				receiptHash, h.ReceiptHash, h.Number.Uint64(), h.Hash())
 		}
+	}
 
+	// The logs bloom is part of every block header from Frontier on, so it must
+	// be validated independently of the receipt-root check (which is gated on
+	// Byzantium because pre-Byzantium receipts encode an intermediate state
+	// root that Erigon doesn't materialise). Without this, an invalid bloom on
+	// a pre-Byzantium block (e.g. hive bcInvalidHeaderTest/log1_wrongBloom)
+	// is silently accepted.
+	if checkBloom && !alwaysSkipReceiptCheck {
 		lbloom := types.CreateBloom(receipts)
 		if lbloom != h.Bloom {
 			return fmt.Errorf("invalid bloom (remote: %x  local: %x)", h.Bloom, lbloom)

--- a/execution/protocol/block_post_validation_test.go
+++ b/execution/protocol/block_post_validation_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package protocol
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/holiman/uint256"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/types"
+)
+
+// TestBlockPostValidation_PreByzantiumBloomMismatch covers the regression
+// where a pre-Byzantium block with an invalid logs bloom was silently
+// accepted because the bloom check was gated on the same Byzantium flag as
+// the receipt-root check (hive bcInvalidHeaderTest/log1_wrongBloom_Frontier
+// and friends).
+func TestBlockPostValidation_PreByzantiumBloomMismatch(t *testing.T) {
+	t.Parallel()
+
+	// Frontier rules — pre-Byzantium, so the receipt-root path is not exercised.
+	cfg := &chain.Config{ChainID: big.NewInt(1)}
+
+	logAddr := common.HexToAddress("0x095e7baea6a6c7c4c2dfeb977efac326af552d87")
+	receipt := &types.Receipt{
+		CumulativeGasUsed: 21912,
+		Logs: []*types.Log{{
+			Address: logAddr,
+			Topics:  []common.Hash{},
+			Data:    []byte{},
+		}},
+	}
+	receipts := types.Receipts{receipt}
+	correctBloom := types.CreateBloom(receipts)
+	if correctBloom == (types.Bloom{}) {
+		t.Fatal("test setup: a non-empty log should produce a non-zero bloom")
+	}
+
+	header := &types.Header{
+		Number:  *uint256.NewInt(1),
+		GasUsed: 21912,
+		// Bloom intentionally left zero — header disagrees with logs.
+	}
+
+	const checkReceipts = false // pre-Byzantium gate
+	const checkBloom = true
+
+	err := BlockPostValidation(21912, 0, checkReceipts, checkBloom, receipts, header, nil, cfg, log.New())
+	if err == nil {
+		t.Fatal("expected bloom-mismatch error on pre-Byzantium block, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid bloom") {
+		t.Fatalf("expected \"invalid bloom\" error, got: %v", err)
+	}
+
+	// Set the correct bloom — validation must pass.
+	header.Bloom = correctBloom
+	if err := BlockPostValidation(21912, 0, checkReceipts, checkBloom, receipts, header, nil, cfg, log.New()); err != nil {
+		t.Fatalf("expected success when bloom matches, got: %v", err)
+	}
+
+	// With checkBloom disabled the mismatch must not trigger an error
+	// (sanity check that the new flag does gate the new path).
+	header.Bloom = types.Bloom{}
+	if err := BlockPostValidation(21912, 0, checkReceipts, false, receipts, header, nil, cfg, log.New()); err != nil {
+		t.Fatalf("checkBloom=false should skip bloom validation, got: %v", err)
+	}
+}

--- a/execution/stagedsync/block_post_validator.go
+++ b/execution/stagedsync/block_post_validator.go
@@ -26,12 +26,12 @@ type blockValidator struct {
 
 // newBlockValidator starts validation in a goroutine. The caller must
 // eventually call Wait() to surface the result and to drain the goroutine.
-func newBlockValidator(blockGasUsed, blobGasUsed uint64, checkReceipts bool, receipts types.Receipts,
+func newBlockValidator(blockGasUsed, blobGasUsed uint64, checkReceipts, checkBloom bool, receipts types.Receipts,
 	header *types.Header, txns types.Transactions,
 	chainConfig *chain.Config, logger log.Logger) *blockValidator {
 	bv := &blockValidator{done: make(chan error, 1)}
 	go func() {
-		bv.done <- protocol.BlockPostValidation(blockGasUsed, blobGasUsed, checkReceipts, receipts, header, txns, chainConfig, logger)
+		bv.done <- protocol.BlockPostValidation(blockGasUsed, blobGasUsed, checkReceipts, checkBloom, receipts, header, txns, chainConfig, logger)
 	}()
 	return bv
 }

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -402,9 +402,8 @@ func (pe *parallelExecutor) exec(ctx context.Context, execStage *StageState, u U
 
 					var blockValidatorWaiter *blockValidator
 					if applyResult.BlockNum > 0 && !applyResult.isPartial { //Disable check for genesis. Maybe need somehow improve it in future - to satisfy TestExecutionSpec
-						checkReceipts := !pe.cfg.vmConfig.StatelessExec &&
-							pe.cfg.chainConfig.IsByzantium(applyResult.BlockNum) &&
-							!pe.cfg.vmConfig.NoReceipts
+						checkBloom := !pe.cfg.vmConfig.StatelessExec && !pe.cfg.vmConfig.NoReceipts
+						checkReceipts := checkBloom && pe.cfg.chainConfig.IsByzantium(applyResult.BlockNum)
 
 						b, err := pe.cfg.blockReader.BlockByHash(ctx, rwTx, applyResult.BlockHash)
 
@@ -428,7 +427,7 @@ func (pe *parallelExecutor) exec(ctx context.Context, execStage *StageState, u U
 						// Spawn per-block validation in a goroutine — the result is
 						// joined via Wait() below, after the other per-result work
 						// has had a chance to run in parallel with validation.
-						blockValidatorWaiter = newBlockValidator(applyResult.BlockGasUsed, applyResult.BlobGasUsed, checkReceipts, applyResult.Receipts,
+						blockValidatorWaiter = newBlockValidator(applyResult.BlockGasUsed, applyResult.BlobGasUsed, checkReceipts, checkBloom, applyResult.Receipts,
 							lastHeader, b.Transactions(), pe.cfg.chainConfig, pe.logger)
 
 						if !applyResult.isPartial && !execStage.CurrentSyncCycle.IsInitialCycle {

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -429,13 +429,14 @@ func (se *serialExecutor) executeBlock(ctx context.Context, tasks []exec.Task, i
 				if startTxIndex == 0 && !isInitialCycle {
 					se.cfg.notifications.RecentReceipts.Add(blockReceipts, txTask.Txs, txTask.Header)
 				}
-				checkReceipts := !se.cfg.vmConfig.StatelessExec && se.cfg.chainConfig.IsByzantium(txTask.BlockNumber()) && !se.cfg.vmConfig.NoReceipts
+				checkBloom := !se.cfg.vmConfig.StatelessExec && !se.cfg.vmConfig.NoReceipts
+				checkReceipts := checkBloom && se.cfg.chainConfig.IsByzantium(txTask.BlockNumber())
 
 				if txTask.BlockNumber() > 0 && startTxIndex == 0 {
 					//Disable check for genesis. Maybe need somehow improve it in future - to satisfy TestExecutionSpec
 					// Block gas = max(regular, state). Pre-Amsterdam: blockStateGasUsed is 0.
 					blockGasUsed := max(se.blockGasUsed, se.blockStateGasUsed)
-					if err := protocol.BlockPostValidation(blockGasUsed, se.blobGasUsed, checkReceipts, blockReceipts, txTask.Header, txTask.Txs, se.cfg.chainConfig, se.logger); err != nil {
+					if err := protocol.BlockPostValidation(blockGasUsed, se.blobGasUsed, checkReceipts, checkBloom, blockReceipts, txTask.Header, txTask.Txs, se.cfg.chainConfig, se.logger); err != nil {
 						return fmt.Errorf("%w, txnIdx=%d, %w", rules.ErrInvalidBlock, txTask.TxIndex, err) //same as in stage_exec.go
 					}
 				}


### PR DESCRIPTION
## Summary

- The bloom check in `BlockPostValidation` was nested inside the `checkReceipts` block, which gates on Byzantium. The receipt-root gate is correct (pre-Byzantium receipts encode an intermediate state root that Erigon does not materialise), but the logs bloom is part of the header from Frontier onward and must be validated regardless of fork.
- As a result, hive `bcInvalidHeaderTest/log1_wrongBloom_{Frontier,Homestead,EIP150,EIP158}` was silently accepting a block whose header carried an all-zero bloom while the executed transaction emitted a log.
- Fix: split the bloom validation behind a new `checkBloom` flag (`!StatelessExec && !NoReceipts`, no Byzantium gate) and thread it through `exec3_serial`, `exec3_parallel` and the `newBlockValidator` wrapper.

Repro from the failed run: https://hive.ethpandaops.io/#/test/generic/1777648476-0a0bd8ed62bf8169d9a95089c1262e74

```
last block hash mismatch:
  want 0x66104b0a4a5286d1eb5fdae40606edf36cc2d15f9e046d55eebe9a8fdf217386  // genesis (block was supposed to be rejected)
   got 0xaa8f488137d4148151f6c7d5bd6608054093c088634704e026b41971a0b771f7
```

The other 4 failures in that run (`walletReorganizeOwners_*`) are an intermittent infrastructure flake — Hive's generic "container did not start: timed out waiting for container startup" before any Erigon code runs, with all 4 forks failing or passing together across recent runs (e.g. 2026-04-09 4/4 fail, 04-22 0/4, 04-25 0/4, 05-01 4/4). Not addressed here.

## Test plan

- [x] `go test ./execution/protocol/ -run TestBlockPostValidation_PreByzantiumBloomMismatch` — added; pins the pre-Byzantium bloom-mismatch path so this can't regress.
- [x] `make lint` clean
- [x] `make erigon integration` clean
- [x] `go test ./execution/protocol/ ./execution/stagedsync/ -short` clean
- [ ] Hive `legacy` simulator on this branch — `log1_wrongBloom_*` should turn green on all forks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)