### PR TITLE
txpool: recover queued txs misclassified by stale senders.info race

### DIFF
--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -1567,9 +1567,35 @@ func (p *TxPool) addTxnsOnNewBlock(blockNum uint64, cacheView kvcache.CacheView,
 		}
 	}
 
+	// Senders with queued txns that didn't appear in stateChanges still need
+	// re-evaluation: a tx misclassified into queued at AddLocalTxns time —
+	// e.g. because senders.info returned a stale sender nonce due to the
+	// pre-commit dispatch race introduced in #20195 — would otherwise stay
+	// queued forever, since the only re-evaluation trigger is the sender
+	// appearing in a block's stateChanges, which doesn't happen if the
+	// queued tx is the sender's only outstanding tx.
+	queuedSenders := map[uint64]struct{}{}
+	for _, mt := range p.queued.best.ms {
+		senderID := mt.TxnSlot.SenderID
+		if _, alreadyCovered := sendersWithChangedState[senderID]; alreadyCovered {
+			continue
+		}
+		queuedSenders[senderID] = struct{}{}
+	}
+
 	for senderID := range sendersWithChangedState {
 		// Reset the dormancy timer: this sender had a real on-chain state change.
 		p.senderLastActivity[senderID] = blockNum
+		nonce, balance, err := senders.info(cacheView, senderID)
+		if err != nil {
+			return announcements, err
+		}
+		p.onSenderStateChange(senderID, nonce, balance, blockGasLimit, logger)
+	}
+
+	// Don't touch senderLastActivity for queuedSenders — these senders did not
+	// change state on-chain, so the dormancy timer should not be reset.
+	for senderID := range queuedSenders {
 		nonce, balance, err := senders.info(cacheView, senderID)
 		if err != nil {
 			return announcements, err

--- a/txnprovider/txpool/pool_test.go
+++ b/txnprovider/txpool/pool_test.go
@@ -2228,3 +2228,115 @@ func TestStalePendingEvictionViaMineNonce(t *testing.T) {
 	asrt.Equal(0, pending, "T2 must be evicted: on-chain nonce=2 > T2.nonce=1")
 	asrt.Equal(0, queued, "no queued txns expected")
 }
+
+// TestQueuedTxnPromotedAfterStaleAddLocal reproduces the failure mode observed
+// on the kurtosis assertoor_regular_test in CI run 25366656375: a transaction
+// added via AddLocalTxns gets misclassified into queued because senders.info
+// returned the previous block's sender nonce, and then stays queued forever
+// because no subsequent block touches that sender on-chain.
+//
+// Background: PR #20195 (pre-commit dispatch + overlay-aware RPC) lets an RPC
+// client see a receipt — and submit the next-nonce tx — before the txpool has
+// processed the dispatched StateChangeBatch. PR #20515 narrowed but did not
+// close the resulting race: AddLocalTxns can still capture a cacheView whose
+// SimpleCache lookups return the pre-block sender nonce. With NoNonceGaps
+// unset, the new tx lands in queued. The only mechanism that re-evaluates a
+// queued sender's bits is `addTxnsOnNewBlock`'s sendersWithChangedState loop,
+// which depends on the sender appearing in stateChanges. If the sender's only
+// outstanding tx is the misclassified one, its on-chain state never changes
+// again and the tx is stuck (until the dormancy sweep evicts it).
+//
+// Scenario:
+//  1. addr1 starts at on-chain nonce=0; OnNewBlock seeds the SimpleCache.
+//  2. The chain advances addr1 to nonce=1 but the pool has not yet received
+//     the corresponding StateChangeBatch. Modeled directly: write the new
+//     on-chain state to the DB while the SimpleCache still holds nonce=0
+//     from the seed batch — same observable conditions as the production
+//     race when AddLocalTxns reads the cache before cache.OnNewBlock fires.
+//  3. AddLocalTxns adds a nonce=1 tx. The cache hit returns nonce=0,
+//     NoNonceGaps stays unset, the tx lands in queued.
+//  4. A subsequent block arrives whose stateChanges does NOT touch addr1.
+//  5. Assert: the queued tx has been re-evaluated against current state
+//     (DB returns nonce=1) and promoted to pending.
+//
+// Today step 5 fails: addr1 is not in sendersWithChangedState for the new
+// block, no onSenderStateChange call fires, and the tx stays queued.
+func TestQueuedTxnPromotedAfterStaleAddLocal(t *testing.T) {
+	asrt := assert.New(t)
+	req := require.New(t)
+	logger := log.New()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	ch := make(chan Announcements, 100)
+	coreDB := temporaltest.NewTestDB(t, datadir.New(t.TempDir()))
+	cfg := txpoolcfg.DefaultConfig
+
+	// SimpleCache matches the in-process embedded RPC daemon configuration in
+	// node/eth/backend.go and the cache the production failure was observed on.
+	pool, err := New(ctx, ch, nil, coreDB, cfg, kvcache.NewSimple(), chain.AllProtocolChanges, nil, nil, func() {}, nil, nil, logger, WithFeeCalculator(nil))
+	req.NoError(err)
+	req.NotNil(pool)
+
+	var addr1 [20]byte
+	addr1[0] = 1
+	h0 := gointerfaces.ConvertHashToH256([32]byte{})
+
+	serialiseAcc := func(nonce uint64) []byte {
+		a := accounts3.Account{
+			Nonce: nonce, Balance: *uint256.NewInt(1 * common.Ether),
+			CodeHash: accounts.EmptyCodeHash, Incarnation: 1,
+		}
+		return accounts3.SerialiseV3(&a)
+	}
+
+	// 1) Bootstrap addr1 at nonce=0 in both DB and SimpleCache.
+	writeTestSenderState(t, ctx, coreDB, logger, addr1, serialiseAcc(0), 0)
+	initChange := &remoteproto.StateChangeBatch{
+		StateVersionId: 0, PendingBlockBaseFee: 200_000, BlockGasLimit: 1_000_000,
+		ChangeBatch: []*remoteproto.StateChange{{BlockHeight: 0, BlockHash: h0}},
+	}
+	initChange.ChangeBatch[0].Changes = append(initChange.ChangeBatch[0].Changes, &remoteproto.AccountChange{
+		Action:  remoteproto.Action_UPSERT,
+		Address: gointerfaces.ConvertAddressToH160(addr1),
+		Data:    serialiseAcc(0),
+	})
+	req.NoError(pool.OnNewBlock(ctx, initChange, TxnSlots{}, TxnSlots{}, TxnSlots{}))
+
+	// 2) Chain advances addr1 to nonce=1 (a tx from addr1 mined) but the pool
+	// has not yet processed the StateChangeBatch for that block. The DB now
+	// reflects the new on-chain state; the SimpleCache still holds nonce=0.
+	writeTestSenderState(t, ctx, coreDB, logger, addr1, serialiseAcc(1), 1)
+
+	// 3) AddLocalTxns runs in this race window. The SimpleCache hit returns
+	// the stale nonce=0, so the nonce=1 tx is misclassified into queued.
+	txn := newTestTxnSlot(1, 0, 300_000, 300_000, 100_000)
+	txn.IDHash[0] = 1
+	var slots TxnSlots
+	slots.Append(txn, addr1[:], true)
+	reasons, err := pool.AddLocalTxns(ctx, slots)
+	req.NoError(err)
+	for _, r := range reasons {
+		asrt.Equal(txpoolcfg.Success, r, r.String())
+	}
+	pending, _, queued := pool.CountContent()
+	asrt.Equal(0, pending, "race outcome: tx misclassified into queued, not pending")
+	asrt.Equal(1, queued, "race outcome: tx misclassified into queued")
+
+	// 4) Next block: stateChanges does NOT contain addr1. The sender's only
+	// outstanding tx is the stuck queued one, so its on-chain state hasn't
+	// changed since the block in step 2.
+	h2 := gointerfaces.ConvertHashToH256([32]byte{2})
+	block2Change := &remoteproto.StateChangeBatch{
+		StateVersionId: 2, PendingBlockBaseFee: 200_000, BlockGasLimit: 1_000_000,
+		ChangeBatch: []*remoteproto.StateChange{{BlockHeight: 2, BlockHash: h2}},
+	}
+	req.NoError(pool.OnNewBlock(ctx, block2Change, TxnSlots{}, TxnSlots{}, TxnSlots{}))
+
+	// 5) The queued tx must have been re-evaluated against current state
+	// (DB returns nonce=1) and promoted to pending.
+	pending, _, queued = pool.CountContent()
+	asrt.Equal(1, pending, "queued tx must be promoted after re-evaluation")
+	asrt.Equal(0, queued, "queued must be empty after promotion")
+}


### PR DESCRIPTION
## Summary

A transaction submitted via `AddLocalTxns` can get stuck in the queued sub-pool indefinitely under a narrow race introduced by the pre-commit dispatch path in #20195: `senders.info` returns the previous block's sender nonce, `NoNonceGaps` stays unset, and the only existing re-evaluation trigger (the sender appearing in a block's stateChanges UPSERTs) never fires when the queued tx is the sender's only outstanding tx.

Observed in [CI run 25366656375](https://github.com/erigontech/erigon/actions/runs/25366656375/job/74379132776) (kurtosis `assertoor_regular_test`): assertoor's `all-opcodes-test` got stuck on task 11 (`Call precompiles test contract: test3()`). Erigon's enclave dump shows both EL nodes reporting `pending=0 queued=1` for ~46 minutes after the misclassification, until the GitHub Actions step timeout fired.

## Root cause

`addTxnsOnNewBlock` only calls `onSenderStateChange` for senders that appear in this block's stateChanges as `UPSERT`/`UPSERT_CODE`. If a tx was misclassified into queued at add time (because `senders.info` saw stale state) and the sender's state doesn't change on-chain again, the bits never get refreshed. PR #20515 (`SimpleCache`) narrowed the race window but did not eliminate it: there's still a moment where `AddLocalTxns` can read the cache before `cache.OnNewBlock` for the latest block has fired.

## Fix

Extend `addTxnsOnNewBlock` to collect senders that have queued txns and aren't already in `sendersWithChangedState`, and run `onSenderStateChange` for each. With this, a queued tx misclassified at add time gets re-evaluated against the current cacheView on the next block and `promote()` lifts it to pending.

`senderLastActivity` is deliberately not touched on the new pass — a legitimately queued (future-nonce, gapped) sender did not change state on-chain and should keep aging toward dormancy eviction.

Cost: O(|queued|) per block. The queued sub-pool is small in practice.

## Test plan

- [x] New `TestQueuedTxnPromotedAfterStaleAddLocal` reproduces the failure mode (race-induced misclassification + sender not in subsequent stateChanges) and asserts the queued tx is promoted to pending. Fails on baseline, passes with the fix.
- [x] Full `./txnprovider/txpool/...` suite passes.
- [x] `make lint` clean.
- [ ] Re-run kurtosis `assertoor_regular_test` to confirm the assertoor flow no longer stalls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)