### PR TITLE
execution/tests: enforce checkNonce/checkTransaction in state harness

### DIFF
--- a/execution/tests/test-corners/state/eip2681-max-sender-nonce.json
+++ b/execution/tests/test-corners/state/eip2681-max-sender-nonce.json
@@ -36,15 +36,6 @@
         "nonce": "0xffffffffffffffff"
       }
     },
-    "config": {
-      "blobSchedule": {
-        "Osaka": {
-          "target": "0x6",
-          "max": "0x9",
-          "baseFeeUpdateFraction": "0x4c6964"
-        }
-      }
-    },
     "transaction": {
       "gasPrice": "0x10",
       "nonce": "0xffffffffffffffff",

--- a/execution/tests/test-corners/state/eip2681-max-sender-nonce.json
+++ b/execution/tests/test-corners/state/eip2681-max-sender-nonce.json
@@ -1,0 +1,80 @@
+{
+  "sender-rules-max-sender-nonce-invalid": {
+    "env": {
+      "currentCoinbase": "b94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+      "currentDifficulty": "0x200000",
+      "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000200000",
+      "currentGasLimit": "0x26e1f476fe1e22",
+      "currentNumber": "0x1",
+      "currentTimestamp": "0x3e8",
+      "previousHash": "0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d",
+      "currentBaseFee": "0x10"
+    },
+    "pre": {
+      "0x3607000000000000000000000000000000000001": {
+        "code": "0x600161ff00553361ff12553061ff13553461ff145560006000f3",
+        "storage": {},
+        "balance": "0x1",
+        "nonce": "0x1"
+      },
+      "0x7702000000000000000000000000000000000001": {
+        "code": "0x00",
+        "storage": {},
+        "balance": "0x1",
+        "nonce": "0x0"
+      },
+      "0x7702000000000000000000000000000000000002": {
+        "code": "0x00",
+        "storage": {},
+        "balance": "0x1",
+        "nonce": "0x0"
+      },
+      "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+        "code": "0x",
+        "storage": {},
+        "balance": "0x5f5e100",
+        "nonce": "0xffffffffffffffff"
+      }
+    },
+    "config": {
+      "blobSchedule": {
+        "Osaka": {
+          "target": "0x6",
+          "max": "0x9",
+          "baseFeeUpdateFraction": "0x4c6964"
+        }
+      }
+    },
+    "transaction": {
+      "gasPrice": "0x10",
+      "nonce": "0xffffffffffffffff",
+      "to": "0x3607000000000000000000000000000000000001",
+      "data": [
+        "0x"
+      ],
+      "gasLimit": [
+        "0xf4240"
+      ],
+      "value": [
+        "0x0"
+      ],
+      "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+      "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+    },
+    "out": "0x",
+    "post": {
+      "Berlin": [
+        {
+          "hash": "0x81198fa92f86e9e2a3020030c99ae87f69c499a5a2bd849b4121ea63f23de715",
+          "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+          "expectException": "transactions with sender nonce 2^64-1 must be rejected",
+          "indexes": {
+            "data": 0,
+            "gas": 0,
+            "value": 0
+          }
+        }
+      ]
+    }
+  }
+}

--- a/execution/tests/test-corners/state/eip7702-prefix-only-delegation-sender.json
+++ b/execution/tests/test-corners/state/eip7702-prefix-only-delegation-sender.json
@@ -36,15 +36,6 @@
         "nonce": "0xfffffffffffffffe"
       }
     },
-    "config": {
-      "blobSchedule": {
-        "Osaka": {
-          "target": "0x6",
-          "max": "0x9",
-          "baseFeeUpdateFraction": "0x4c6964"
-        }
-      }
-    },
     "transaction": {
       "gasPrice": "0x10",
       "nonce": "0xfffffffffffffffe",

--- a/execution/tests/test-corners/state/eip7702-prefix-only-delegation-sender.json
+++ b/execution/tests/test-corners/state/eip7702-prefix-only-delegation-sender.json
@@ -1,0 +1,80 @@
+{
+  "sender-rules-malformed-delegation-sender-rejected": {
+    "env": {
+      "currentCoinbase": "b94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+      "currentDifficulty": "0x200000",
+      "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000200000",
+      "currentGasLimit": "0x26e1f476fe1e22",
+      "currentNumber": "0x1",
+      "currentTimestamp": "0x3e8",
+      "previousHash": "0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d",
+      "currentBaseFee": "0x10"
+    },
+    "pre": {
+      "0x3607000000000000000000000000000000000001": {
+        "code": "0x600161ff00553361ff12553061ff13553461ff145560006000f3",
+        "storage": {},
+        "balance": "0x1",
+        "nonce": "0x1"
+      },
+      "0x7702000000000000000000000000000000000001": {
+        "code": "0x00",
+        "storage": {},
+        "balance": "0x1",
+        "nonce": "0x0"
+      },
+      "0x7702000000000000000000000000000000000002": {
+        "code": "0x00",
+        "storage": {},
+        "balance": "0x1",
+        "nonce": "0x0"
+      },
+      "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+        "code": "0xef0100",
+        "storage": {},
+        "balance": "0x5f5e100",
+        "nonce": "0xfffffffffffffffe"
+      }
+    },
+    "config": {
+      "blobSchedule": {
+        "Osaka": {
+          "target": "0x6",
+          "max": "0x9",
+          "baseFeeUpdateFraction": "0x4c6964"
+        }
+      }
+    },
+    "transaction": {
+      "gasPrice": "0x10",
+      "nonce": "0xfffffffffffffffe",
+      "to": "0x3607000000000000000000000000000000000001",
+      "data": [
+        "0x"
+      ],
+      "gasLimit": [
+        "0xf4240"
+      ],
+      "value": [
+        "0x0"
+      ],
+      "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+      "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+    },
+    "out": "0x",
+    "post": {
+      "Prague": [
+        {
+          "hash": "0xf224752fba8af944766f36c870787d137b78e2a5981123a07ef042b79902bd0f",
+          "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+          "expectException": "malformed delegation-indicator sender code must still be rejected",
+          "indexes": {
+            "data": 0,
+            "gas": 0,
+            "value": 0
+          }
+        }
+      ]
+    }
+  }
+}

--- a/execution/tests/test-corners/state/eip7702-short-target-delegation-sender.json
+++ b/execution/tests/test-corners/state/eip7702-short-target-delegation-sender.json
@@ -30,15 +30,6 @@
         "nonce": "0xfffffffffffffffe"
       }
     },
-    "config": {
-      "blobSchedule": {
-        "Prague": {
-          "target": "0x6",
-          "max": "0x9",
-          "baseFeeUpdateFraction": "0x4c6964"
-        }
-      }
-    },
     "transaction": {
       "gasPrice": "0x10",
       "nonce": "0xfffffffffffffffe",

--- a/execution/tests/test-corners/state/eip7702-short-target-delegation-sender.json
+++ b/execution/tests/test-corners/state/eip7702-short-target-delegation-sender.json
@@ -1,0 +1,74 @@
+{
+  "delegation-sender-malformed-short-target-rejected": {
+    "env": {
+      "currentCoinbase": "b94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+      "currentDifficulty": "0x200000",
+      "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000200000",
+      "currentGasLimit": "0x26e1f476fe1e22",
+      "currentNumber": "0x1",
+      "currentTimestamp": "0x3e8",
+      "previousHash": "0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d",
+      "currentBaseFee": "0x10"
+    },
+    "pre": {
+      "0x77020000000000000000000000000000000000d1": {
+        "code": "0x600161ff00553361ff12553061ff13553461ff145560006000f3",
+        "storage": {},
+        "balance": "0x1",
+        "nonce": "0x1"
+      },
+      "0x77020000000000000000000000000000000000d2": {
+        "code": "0x00",
+        "storage": {},
+        "balance": "0x1",
+        "nonce": "0x0"
+      },
+      "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+        "code": "0xef010077020000000000000000000000000000000000",
+        "storage": {},
+        "balance": "0x5f5e100",
+        "nonce": "0xfffffffffffffffe"
+      }
+    },
+    "config": {
+      "blobSchedule": {
+        "Prague": {
+          "target": "0x6",
+          "max": "0x9",
+          "baseFeeUpdateFraction": "0x4c6964"
+        }
+      }
+    },
+    "transaction": {
+      "gasPrice": "0x10",
+      "nonce": "0xfffffffffffffffe",
+      "to": "0x77020000000000000000000000000000000000d1",
+      "data": [
+        "0x"
+      ],
+      "gasLimit": [
+        "0xf4240"
+      ],
+      "value": [
+        "0x0"
+      ],
+      "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+      "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+    },
+    "out": "0x",
+    "post": {
+      "Prague": [
+        {
+          "hash": "0x032cd98563a58a7df4e12da20942a194037e09bc31c55b5bdc14006d6becb65c",
+          "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+          "expectException": "delegation-indicator sender code must include a 20-byte target",
+          "indexes": {
+            "data": 0,
+            "gas": 0,
+            "value": 0
+          }
+        }
+      ]
+    }
+  }
+}

--- a/execution/tests/test-corners/state/eip7702-trailing-junk-delegation-sender.json
+++ b/execution/tests/test-corners/state/eip7702-trailing-junk-delegation-sender.json
@@ -1,0 +1,74 @@
+{
+  "delegation-sender-malformed-trailing-junk-rejected": {
+    "env": {
+      "currentCoinbase": "b94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+      "currentDifficulty": "0x200000",
+      "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000200000",
+      "currentGasLimit": "0x26e1f476fe1e22",
+      "currentNumber": "0x1",
+      "currentTimestamp": "0x3e8",
+      "previousHash": "0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d",
+      "currentBaseFee": "0x10"
+    },
+    "pre": {
+      "0x77020000000000000000000000000000000000d1": {
+        "code": "0x600161ff00553361ff12553061ff13553461ff145560006000f3",
+        "storage": {},
+        "balance": "0x1",
+        "nonce": "0x1"
+      },
+      "0x77020000000000000000000000000000000000d2": {
+        "code": "0x00",
+        "storage": {},
+        "balance": "0x1",
+        "nonce": "0x0"
+      },
+      "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+        "code": "0xef010077020000000000000000000000000000000000d2ff",
+        "storage": {},
+        "balance": "0x5f5e100",
+        "nonce": "0xfffffffffffffffe"
+      }
+    },
+    "config": {
+      "blobSchedule": {
+        "Prague": {
+          "target": "0x6",
+          "max": "0x9",
+          "baseFeeUpdateFraction": "0x4c6964"
+        }
+      }
+    },
+    "transaction": {
+      "gasPrice": "0x10",
+      "nonce": "0xfffffffffffffffe",
+      "to": "0x77020000000000000000000000000000000000d1",
+      "data": [
+        "0x"
+      ],
+      "gasLimit": [
+        "0xf4240"
+      ],
+      "value": [
+        "0x0"
+      ],
+      "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+      "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+    },
+    "out": "0x",
+    "post": {
+      "Prague": [
+        {
+          "hash": "0xad6d42019639ca66d9cd9a1d7bf459b9268850e09584c50eedffadafd8ed82b8",
+          "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+          "expectException": "delegation-indicator sender code must be exactly 23 bytes long",
+          "indexes": {
+            "data": 0,
+            "gas": 0,
+            "value": 0
+          }
+        }
+      ]
+    }
+  }
+}

--- a/execution/tests/test-corners/state/eip7702-trailing-junk-delegation-sender.json
+++ b/execution/tests/test-corners/state/eip7702-trailing-junk-delegation-sender.json
@@ -30,15 +30,6 @@
         "nonce": "0xfffffffffffffffe"
       }
     },
-    "config": {
-      "blobSchedule": {
-        "Prague": {
-          "target": "0x6",
-          "max": "0x9",
-          "baseFeeUpdateFraction": "0x4c6964"
-        }
-      }
-    },
     "transaction": {
       "gasPrice": "0x10",
       "nonce": "0xfffffffffffffffe",

--- a/execution/tests/testutil/state_test_util.go
+++ b/execution/tests/testutil/state_test_util.go
@@ -475,8 +475,8 @@ func toMessage(tx stTransaction, ps stPostState, baseFee *uint256.Int) (protocol
 		uint256.MustFromBig(&tipCap),
 		data,
 		accessList,
-		false, /* checkNonce */
-		false, /* checkTransaction */
+		true,  /* checkNonce */
+		true,  /* checkTransaction */
 		true,  /* checkGas */
 		false, /* isFree */
 		uint256.MustFromBig(blobFeeCap),


### PR DESCRIPTION
## Summary
- The state-test harness was building `Message`s with `checkNonce=false` and `checkTransaction=false`, bypassing the EIP-2681 saturated-nonce guard and the EIP-3607 / EIP-7702 sender-code check in `preCheck`.
- Without those checks, erigon silently executed transactions from senders with malformed delegation designators (prefix-only, short, or trailing-junk code — anything not matching the strict 23-byte `0xef0100||addr` form) and from senders whose nonce was already `2^64-1`, producing post-state roots that diverged from geth (whose harness runs the equivalents unconditionally).
- Adds the four reproducer fixtures from #20684 under `test-corners/state/` for regression coverage.

Fixes #20684

## Test plan
- [x] `evm statetest` on all four issue fixtures returns the geth-matching reject-state roots (`0xf224752f…`, `0x032cd985…`, `0xad6d4201…`, `0x81198fa9…`)
- [x] `TestStateCornerCases` passes (now picks up the four new fixtures)
- [x] `TestLegacyCancunState` + `TestState` pass (full legacy + EEST static state-test sweep)
- [x] `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)