### PR TITLE
cmd/utils: guard zero current step size

### DIFF
--- a/cmd/utils/app/step_cmd.go
+++ b/cmd/utils/app/step_cmd.go
@@ -40,6 +40,10 @@ func stepRebase(cliCtx *cli.Context) error {
 		logger.Crit("Invalid step size", "new-step-size", newStepSize)
 		return fmt.Errorf("new step size must be greater than 0")
 	}
+	if currentStepSize == 0 {
+		logger.Crit("Invalid current step size", "current-step-size", currentStepSize)
+		return fmt.Errorf("current step size must be greater than 0")
+	}
 
 	if newStepSize == currentStepSize {
 		logger.Info("Step size is already at the desired value; exiting", "new-step-size", newStepSize)


### PR DESCRIPTION
Reject a zero current DB step size before `stepRebase` performs modulo or division.
Keep the existing `new-step-size=0` validation and add a diagnostic error for corrupt or invalid current settings.
Prevent the step rebase command from panicking on invalid persisted step-size metadata.