### PR TITLE
execution/execmodule: use last known finalised hash for fcu finalisedBlockNum

### DIFF
--- a/execution/execmodule/forkchoice.go
+++ b/execution/execmodule/forkchoice.go
@@ -297,11 +297,9 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 
 	if fcuHeader.Number.Sign() > 0 {
 		var finalisedBlockNum uint64
-		if finalizedHash == (common.Hash{}) {
-			// The CL has not finalised anything yet (e.g. fresh devnet before finality kicks in).
-			finalisedBlockNum = finishProgressBefore
-		} else {
-			bn, err := e.blockReader.HeaderNumber(ctx, tx, finalizedHash)
+		lastKnownFinalisedHash := rawdb.ReadForkchoiceFinalized(tx)
+		if lastKnownFinalisedHash != (common.Hash{}) {
+			bn, err := e.blockReader.HeaderNumber(ctx, tx, lastKnownFinalisedHash)
 			if err != nil {
 				return sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, err, false)
 			}


### PR DESCRIPTION
follow up to https://github.com/erigontech/erigon/pull/20825
best to use the last known finalised hash from the db and not from the request, otherwise the logic can be circumvented by a bad request
also if there is no known finalised hash the finalisedBlockNum should be 0