### PR TITLE
stagedsync: fix commitmentCalculator asOfReader.txNum=0 lazy-load on snapshot-loaded chains

### DIFF
--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -189,7 +189,21 @@ func (cc *commitmentCalculator) handleMessage(ctx context.Context, msg applyResu
 		// Values are lazy-loaded from domain on first touch, then
 		// overwritten by each TX's writes. At block boundary,
 		// the accumulated final values are flushed to the trie.
+		//
+		// Pin asOfReader at this tx's txNum BEFORE ApplyWrites so any
+		// first-touch lazy-load reads the canonical "pre-tx" state via
+		// GetAsOf(r.txNum). Without this the calculator's initial
+		// asOfReader.txNum=0 leaks into the first lazy-load and crashes
+		// with seekInFiles(txNum=0) on snapshot-loaded datadirs whose
+		// visible history window starts well past genesis (e.g. devnets
+		// loaded from a chunked snapshot). On synced-from-genesis
+		// datadirs txNum=0 is in-window so the bug is invisible.
+		//
+		// computeAndPublish overwrites this back to lastTxNum+1 right
+		// before ComputeCommitment, so the per-tx setting only affects
+		// the lazy-load path and never leaks into the trie fold path.
 		if len(r.writes) > 0 {
+			cc.asOfReader.txNum = r.txNum
 			cc.state.ApplyWrites(r.writes)
 		}
 

--- a/execution/stagedsync/committer_test.go
+++ b/execution/stagedsync/committer_test.go
@@ -17,9 +17,13 @@
 package stagedsync
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/execution/state"
 )
 
 // TestShouldComputeOnRequest_GenesisFirstBatch is the regression test for
@@ -100,4 +104,84 @@ func TestShouldComputeOnRequest_BlockZeroAfterAdvance(t *testing.T) {
 	}
 	assert.False(t, cc.shouldComputeOnRequest(),
 		"stale block 0 result while we've already computed block 5 — skip")
+}
+
+// TestHandleMessage_TxResultPinsAsOfReaderTxNum is the regression test for
+// the snapshot-loaded lazy-load crash: cc.asOfReader is constructed with
+// txNum=0, and only computeAndPublish / computeAndCheck (which run on
+// blockResult) overwrite that field. But cc.state.ApplyWrites runs on
+// every txResult and triggers ensureAccount / ensureStorage lazy-loads
+// through the same reader. txResults arrive before the first blockResult,
+// so the very first lazy-load fires with asOfReader.txNum=0. On a synced-
+// from-genesis chain that's in-window so seekInFiles handles it
+// gracefully; on a snapshot-loaded chain whose visible window starts
+// well past genesis (e.g. perf-devnet-3 starting at txNum~2.9B) it fails
+// hard with `seekInFiles(invIndex=storage,txNum=0) but data before
+// txNum=N not available` and FCU fails on every block.
+//
+// The fix in handleMessage's *txResult branch pins asOfReader.txNum to
+// the current tx's txNum BEFORE ApplyWrites runs. computeAndPublish /
+// computeAndCheck overwrite the field back to lastTxNum+1 right before
+// ComputeCommitment, so this per-tx setting only affects the lazy-load
+// path and never leaks into the trie fold path.
+//
+// We test the post-condition (asOfReader.txNum == r.txNum after each
+// txResult) — the simplest invariant that catches the absence of the
+// fix. The ordering relative to ApplyWrites (set BEFORE) is enforced by
+// inspection: the test cannot observe a successful lazy-load without
+// pulling in real SharedDomains plumbing, but a missing assignment
+// would leave txNum at its prior value and fail this test directly.
+func TestHandleMessage_TxResultPinsAsOfReaderTxNum(t *testing.T) {
+	asOfReader := &asOfStateReader{txNum: 0}
+	cs := newCalcState(asOfReader, nil, "test")
+	// Disable lazy-load — without a real SharedDomains the asOfReader's
+	// Read would NPE on r.sd.GetAsOf. The fix's contract is independent
+	// of whether the read succeeds: txNum must be pinned before the
+	// load is even attempted.
+	cs.domainReader = nil
+	cc := &commitmentCalculator{
+		asOfReader: asOfReader,
+		state:      cs,
+	}
+
+	// A txResult must carry at least one write to enter the fix's
+	// `if len(r.writes) > 0` branch — empty writes have no lazy-loads
+	// to seed and therefore intentionally don't update txNum.
+	someWrites := state.VersionedWrites{
+		// Path/value content irrelevant — domainReader is nil so the
+		// lazy-load path skips the real read. We only need len(writes)>0.
+		&state.VersionedWrite{},
+	}
+
+	// First txResult: txNum jumps from 0 to 12345.
+	cc.handleMessage(context.Background(), &txResult{
+		txNum:  12345,
+		writes: someWrites,
+	})
+	require.Equal(t, uint64(12345), cc.asOfReader.txNum,
+		"asOfReader.txNum must be pinned to the current tx's txNum before "+
+			"ApplyWrites; otherwise lazy-loads triggered by the writes use "+
+			"the stale value (initially 0) and fail on snapshot-loaded chains.")
+
+	// Subsequent txResult: txNum advances to 12346. Verifies the field
+	// is updated on every txResult, not just the first one.
+	cc.handleMessage(context.Background(), &txResult{
+		txNum:  12346,
+		writes: someWrites,
+	})
+	require.Equal(t, uint64(12346), cc.asOfReader.txNum,
+		"asOfReader.txNum must advance on every txResult (each tx's "+
+			"first-touch lazy-loads need the matching pre-tx baseline).")
+
+	// Empty-writes txResult: the fix's len(writes)>0 guard skips the
+	// pin. asOfReader stays where the prior tx left it. This is the
+	// intended behavior — an empty writeset has no lazy-loads to seed,
+	// so updating txNum would be wasted work and could mask real
+	// regressions in producers that drop writes.
+	cc.handleMessage(context.Background(), &txResult{
+		txNum:  12347,
+		writes: nil,
+	})
+	require.Equal(t, uint64(12346), cc.asOfReader.txNum,
+		"empty writes → no lazy-load → don't bump txNum; the prior pin stands.")
 }


### PR DESCRIPTION
## Summary

`commitmentCalculator` lazy-loads from the storage/account domains via a shared `asOfStateReader`. The reader is constructed with `txNum=0` and only updated inside `computeAndPublish` / `computeWithoutCheck` — both of which run on a `blockResult` message. But `cc.state.ApplyWrites` runs on every `txResult` and triggers `ensureAccount` / `ensureStorage` lazy-loads through the same reader.

Since `txResult`s arrive before the first `blockResult`, the very first lazy-load fires with `asOfReader.txNum = 0`. On a synced-from-genesis datadir `txNum=0` is in the visible history window so `seekInFiles` returns gracefully. On a snapshot-loaded datadir the visible window starts well past genesis and `seekInFiles` errors with:

```
ensureStorage(...): seekInFiles(invIndex=storage,txNum=0) but data before txNum=2918750000 not available
```

The calculator publishes the wrapped error and FCU fails on every block.

## Fix

Pin `asOfReader.txNum` to the current tx's `txNum` before `ApplyWrites` runs. Semantically `GetAsOf(r.txNum)` returns the value before tx N modified it = the pre-tx baseline, which is what lazy-load needs (only first-touch slots lazy-load; subsequent same-slot writes hit `cs.storageState` and skip the read path).

`computeAndPublish` overwrites this back to `lastTxNum + 1` right before `ComputeCommitment`, so the per-tx setting only affects the lazy-load path and never leaks into the trie fold path.

## Reproduction

Run the parallel commitment calculator on a snapshot-loaded chain (e.g. perf-devnet-3 starting at txNum~2.9B). Every block fails with the seekInFiles error above. Synced-from-genesis chains don't trip the bug because txNum=0 is in their window.

## Test plan

- [ ] CI green
- [ ] Bench on snapshot-loaded perf-devnet-3 with `EXEC3_PARALLEL=true`: 17 SETUP blocks + 1 TEST block all VALID with 0 lazy-load errors (verified locally)
- [ ] Bench on synced-from-genesis chain: no behavior change (lazy-load already worked at txNum=0 there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)