### PR TITLE
.github: auto-rerun CI Gate leaves that lose runner communication

### DIFF
--- a/.github/workflows/ci-rerun-on-runner-loss.yml
+++ b/.github/workflows/ci-rerun-on-runner-loss.yml
@@ -1,0 +1,89 @@
+name: Rerun on runner loss
+
+# Watchdog that auto-reruns CI Gate leaf jobs whose failure looks like a
+# self-hosted-runner disappearance rather than a real test failure.
+#
+# Failure mode this targets: a self-hosted runner drops its connection
+# mid-job (memory pressure, host crash, network blip, runner-agent restart).
+# GitHub eventually marks the job `failure`, but the runner never got to
+# fire the in-job `gh run cancel` from PR #20789, so the gate aggregator
+# waits for the slowest sibling instead of failing fast.
+#
+# Heuristic: if the failed job has any step still in a non-completed state
+# (status != "completed"), the runner disappeared mid-execution. Real test
+# failures have every step that started reach a definite conclusion.
+#
+# Bound: only retries on the first attempt (run_attempt == 1). If the
+# retried run also dies the same way, we do not chase it further — the
+# gate will fail and a human can investigate the runner pool.
+
+on:
+  workflow_run:
+    workflows:
+      - All tests
+      - All tests (with -race)
+      - Test Hive
+      - Hive EEST tests
+      - Kurtosis Assertoor GitHub Action
+      - Consensus spec
+      - Reproducible build
+    types: [completed]
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  maybe-rerun:
+    if: |
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.run_attempt == 1
+    runs-on: ubuntu-latest
+    steps:
+      - name: Rerun jobs whose runner disappeared mid-execution
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+        run: |
+          set -euo pipefail
+
+          mapfile -t failed_job_ids < <(
+            gh api --paginate "repos/$REPO/actions/runs/$RUN_ID/jobs" \
+              --jq '.jobs[] | select(.conclusion == "failure") | .id'
+          )
+
+          if [ "${#failed_job_ids[@]}" -eq 0 ]; then
+            echo "::notice::$WORKFLOW_NAME run $RUN_ID has no failed jobs; nothing to rerun."
+            exit 0
+          fi
+
+          retried=0
+          for job_id in "${failed_job_ids[@]}"; do
+            # A step that started but never reached `completed` means the
+            # runner went silent before reporting back. Real test failures
+            # leave every started step with status=completed (and a
+            # conclusion of success/failure/skipped/cancelled).
+            orphan_steps=$(
+              gh api "repos/$REPO/actions/jobs/$job_id" \
+                --jq '[.steps[] | select(.status != "completed")] | length'
+            )
+            job_name=$(
+              gh api "repos/$REPO/actions/jobs/$job_id" --jq '.name'
+            )
+
+            if [ "$orphan_steps" -gt 0 ]; then
+              echo "::notice::Job '$job_name' (id $job_id) has $orphan_steps orphan step(s) — runner-loss heuristic, rerunning."
+              gh api -X POST "repos/$REPO/actions/jobs/$job_id/rerun"
+              retried=$((retried + 1))
+            else
+              echo "Job '$job_name' (id $job_id) failed with all steps completed — leaving alone (likely a real test failure)."
+            fi
+          done
+
+          if [ "$retried" -eq 0 ]; then
+            echo "::notice::$WORKFLOW_NAME run $RUN_ID: no runner-loss jobs found."
+          else
+            echo "::notice::$WORKFLOW_NAME run $RUN_ID: reran $retried job(s) flagged as runner-loss."
+          fi


### PR DESCRIPTION
## Summary

Watchdog workflow (`.github/workflows/ci-rerun-on-runner-loss.yml`) that auto-reruns CI Gate leaf jobs whose failure looks like a self-hosted-runner disappearance rather than a real test failure.

Catches the exact failure mode demonstrated on PR #21002's merge-queue run [25433199987](https://github.com/erigontech/erigon/actions/runs/25433199987) — `hive-eest / test-hive-eest (cancun)` lost its runner (`devops-bm-ghrunner-n2`) mid-execution. PR #20789's per-leaf `gh run cancel` couldn't fire (no runner left to fire it) so the gate aggregator waited for the slowest sibling instead of failing fast, costing ~tens of minutes of queue time on what was purely an infra flake.

## How it works

Triggers on `workflow_run` for the seven leaf workflows in CI Gate (the All tests / race / hive / hive-eest / kurtosis / caplin / repro family). On `conclusion == 'failure'` and `run_attempt == 1`:

1. Lists failed jobs in the run via `repos/.../actions/runs/{id}/jobs`.
2. For each, checks `.steps[*].status`. A real test failure leaves every started step with `status == 'completed'` and a definite conclusion. A runner-disappear leaves the in-flight step (and everything after it) in non-completed states because no runner ever reported back.
3. If any failed job has orphan (non-completed) steps, calls `POST /actions/jobs/{job_id}/rerun` for that specific job.

Bounded: `run_attempt == 1` ensures one retry per workflow run. A retry that hits the same runner-disappear failure is left alone, so a sick host doesn't cause an infinite loop — the gate fails and a human investigates the runner pool.

Doesn't relax correctness: real test failures (every step completed, non-zero conclusion) fall through unchanged. Only the specific orphan-step pattern — which uniquely identifies runner-disappear — triggers a retry.

## Tradeoff

`workflow_run` events fire after the failed run completes, which on a runner-disappear means after GitHub's heartbeat timeout (~5–10 min). So this is *fast-ish* rather than instantaneous. PR #20789 still handles the instantaneous case for normally-failing jobs.

## Permissions

- `actions: write` (to POST rerun)
- `contents: read` (default)

## Test plan
- [x] Workflow YAML parses (validated with the listed workflow names matching `name:` lines in each leaf workflow file).
- [ ] Wait for a real runner-loss event after merge and confirm the watchdog observes the failure, identifies orphan steps, and reruns only the affected job.
- [ ] Confirm a *real* test failure does not get retried (orphan-step heuristic returns 0).

## Related

- PR #20789 — adds in-leaf `gh run cancel` for fast-fail; still the primary fail-fast path for normally-failing jobs.
- This PR — covers the runner-disappear edge case PR #20789 can't reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)