### PR TITLE
cl/gossip,p2p: guard negative subnet index in ENR updates

### DIFF
--- a/cl/gossip/gossip.go
+++ b/cl/gossip/gossip.go
@@ -70,16 +70,16 @@ func TopicNameDataColumnSidecar(d uint64) string {
 }
 
 func IsTopicBlobSidecar(d string) bool {
-	return strings.Contains(d, "blob_sidecar_")
+	return strings.HasPrefix(d, "blob_sidecar_")
 }
 
 func IsTopicDataColumnSidecar(d string) bool {
-	return strings.Contains(d, "data_column_sidecar_")
+	return strings.HasPrefix(d, "data_column_sidecar_")
 }
 
 func IsTopicSyncCommittee(d string) bool {
-	return strings.Contains(d, "sync_committee_") && !strings.Contains(d, TopicNameSyncCommitteeContributionAndProof)
+	return strings.HasPrefix(d, "sync_committee_") && !strings.Contains(d, TopicNameSyncCommitteeContributionAndProof)
 }
 func IsTopicBeaconAttestation(d string) bool {
-	return strings.Contains(d, "beacon_attestation_")
+	return strings.HasPrefix(d, "beacon_attestation_")
 }

--- a/cl/p2p/p2p.go
+++ b/cl/p2p/p2p.go
@@ -223,6 +223,10 @@ func (s *p2pManager) updateSubnetENR(subnetKey string, subnetIndex int, on bool)
 		return
 	}
 	subnetField = common.Copy(subnetField)
+	if subnetIndex < 0 {
+		log.Error("[Sentinel] Subnet index out of range", "subnetIndex", subnetIndex, "len", len(subnetField))
+		return
+	}
 	if len(subnetField) <= subnetIndex/8 {
 		log.Error("[Sentinel] Subnet index out of range", "subnetIndex", subnetIndex, "len", len(subnetField))
 		return

--- a/cl/phase1/network/gossip/gossip_manager.go
+++ b/cl/phase1/network/gossip/gossip_manager.go
@@ -393,6 +393,9 @@ func extractTopicName(topic string) string {
 
 func extractSubnetIndexByGossipTopic(name string) int {
 	// e.g blob_sidecar_3, we want to extract 3
+	if name == "" {
+		return -1
+	}
 	// reject if last character is not a number
 	if !unicode.IsNumber(rune(name[len(name)-1])) {
 		return -1


### PR DESCRIPTION
Guard negative subnet indexes before ENR bit operations, and tighten gossip subnet-topic matching to reduce malformed-input exposure.