### PR TITLE
execution/vm, test-fixtures: bump eest_benchmark to v0.0.9 + small EVM dispatch wins

### DIFF
--- a/execution/tests/benchmark_engine_x_test.go
+++ b/execution/tests/benchmark_engine_x_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -54,8 +55,19 @@ func benchmarkEngineX(b *testing.B, category string) {
 	ctx := b.Context()
 	logger := testlog.Logger(b, log.LvlDebug)
 	engineXDir := filepath.Join("..", "..", "test-fixtures-cache", "eest_benchmark", "fixtures", "blockchain_tests_engine_x")
-	testsDir := filepath.Join(engineXDir, "benchmark", "compute", category)
 	preAllocDir := filepath.Join(engineXDir, "pre_alloc")
+
+	// Layout: blockchain_tests_engine_x/for_osaka_at_<NNNN>M/compute/<category>/<subcat>/<file>.json
+	gasEntries, err := os.ReadDir(engineXDir)
+	require.NoError(b, err)
+	var gasLimits []string
+	for _, e := range gasEntries {
+		if e.IsDir() && strings.HasPrefix(e.Name(), "for_") {
+			gasLimits = append(gasLimits, e.Name())
+		}
+	}
+	sort.Strings(gasLimits)
+	require.NotEmpty(b, gasLimits, "no for_*_at_<gas>M dirs under %s", engineXDir)
 
 	runner, err := engineapitester.NewEngineXTestRunner(ctx, logger, preAllocDir)
 	require.NoError(b, err)
@@ -64,53 +76,77 @@ func benchmarkEngineX(b *testing.B, category string) {
 		require.NoError(b, err)
 	})
 
-	// Parse all test files, group by subcategory.
 	type testEntry struct {
 		name string
 		def  engineapitester.EngineXTestDefinition
 	}
-	subcategories := make(map[string][]testEntry)
-	err = filepath.WalkDir(testsDir, func(path string, d os.DirEntry, err error) error {
-		if err != nil || d.IsDir() || filepath.Ext(path) != ".json" {
+	type subcatEntries struct {
+		name    string
+		entries []testEntry
+	}
+	allTests := make(map[string][]subcatEntries)
+	for _, gas := range gasLimits {
+		testsDir := filepath.Join(engineXDir, gas, "compute", category)
+		bySubcat := make(map[string][]testEntry)
+		err = filepath.WalkDir(testsDir, func(path string, d os.DirEntry, err error) error {
+			if err != nil || d.IsDir() || filepath.Ext(path) != ".json" {
+				return nil
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			var tests map[string]engineapitester.EngineXTestDefinition
+			if err := json.Unmarshal(data, &tests); err != nil {
+				return nil
+			}
+			rel := filepath.ToSlash(strings.TrimPrefix(path, testsDir+string(filepath.Separator)))
+			subcat := strings.SplitN(rel, "/", 2)[0]
+			for name, def := range tests {
+				bySubcat[subcat] = append(bySubcat[subcat], testEntry{name: name, def: def})
+			}
 			return nil
+		})
+		require.NoError(b, err)
+		subcatNames := make([]string, 0, len(bySubcat))
+		for k := range bySubcat {
+			subcatNames = append(subcatNames, k)
 		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
+		sort.Strings(subcatNames)
+		ordered := make([]subcatEntries, 0, len(subcatNames))
+		for _, k := range subcatNames {
+			ordered = append(ordered, subcatEntries{name: k, entries: bySubcat[k]})
 		}
-		var tests map[string]engineapitester.EngineXTestDefinition
-		if err := json.Unmarshal(data, &tests); err != nil {
-			return nil
-		}
-		rel := filepath.ToSlash(strings.TrimPrefix(path, testsDir+string(filepath.Separator)))
-		subcat := strings.SplitN(rel, "/", 2)[0]
-		for name, def := range tests {
-			subcategories[subcat] = append(subcategories[subcat], testEntry{name: name, def: def})
-		}
-		return nil
-	})
-	require.NoError(b, err)
+		allTests[gas] = ordered
+	}
 
 	// Pre-create all testers (not timed).
 	seen := make(map[[2]string]bool)
-	for _, entries := range subcategories {
-		for _, e := range entries {
-			k := [2]string{string(e.def.Fork), string(e.def.PreAllocHash)}
-			if !seen[k] {
-				seen[k] = true
-				require.NoError(b, runner.EnsureTester(e.def))
+	for _, ordered := range allTests {
+		for _, sc := range ordered {
+			for _, e := range sc.entries {
+				k := [2]string{string(e.def.Fork), string(e.def.PreAllocHash)}
+				if !seen[k] {
+					seen[k] = true
+					require.NoError(b, runner.EnsureTester(e.def))
+				}
 			}
 		}
 	}
 
 	b.ResetTimer()
-	for subcat, entries := range subcategories {
-		entries := entries
-		b.Run(subcat, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				for _, e := range entries {
-					require.NoError(b, runner.Execute(ctx, e.def), "%s/%s", subcat, e.name)
-				}
+	for _, gas := range gasLimits {
+		ordered := allTests[gas]
+		b.Run(gas, func(b *testing.B) {
+			for _, sc := range ordered {
+				sc := sc
+				b.Run(sc.name, func(b *testing.B) {
+					for i := 0; i < b.N; i++ {
+						for _, e := range sc.entries {
+							require.NoError(b, runner.Execute(ctx, e.def), "%s/%s/%s", gas, sc.name, e.name)
+						}
+					}
+				})
 			}
 		})
 	}

--- a/execution/tests/benchmark_engine_x_test.go
+++ b/execution/tests/benchmark_engine_x_test.go
@@ -18,6 +18,7 @@ package executiontests
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -98,7 +99,7 @@ func benchmarkEngineX(b *testing.B, category string) {
 			}
 			var tests map[string]engineapitester.EngineXTestDefinition
 			if err := json.Unmarshal(data, &tests); err != nil {
-				return nil
+				return fmt.Errorf("unmarshal %s: %w", path, err)
 			}
 			rel := filepath.ToSlash(strings.TrimPrefix(path, testsDir+string(filepath.Separator)))
 			subcat := strings.SplitN(rel, "/", 2)[0]

--- a/execution/vm/instructions.go
+++ b/execution/vm/instructions.go
@@ -1550,7 +1550,7 @@ func makePush(size uint64, pushByteSize int) executionFunc {
 		integer.SetBytes(scope.Contract.Code[startMin:endMin])
 		// Missing bytes: pushByteSize - len(pushData)
 		if missing := pushByteSize - (endMin - startMin); missing > 0 {
-			integer.Lsh(&integer, uint(8*missing))
+			integer.ILsh(uint(8 * missing))
 		}
 		scope.Stack.push(integer)
 

--- a/execution/vm/instructions.go
+++ b/execution/vm/instructions.go
@@ -1501,13 +1501,10 @@ func makeLog(size int) executionFunc {
 
 // opPush1 is a specialized version of pushN
 func opPush1(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) {
-	var (
-		codeLen = uint64(len(scope.Contract.Code))
-		integer = new(uint256.Int)
-	)
+	codeLen := uint64(len(scope.Contract.Code))
 	pc++
 	if pc < codeLen {
-		scope.Stack.push(*integer.SetUint64(uint64(scope.Contract.Code[pc])))
+		scope.Stack.push(uint256.Int{uint64(scope.Contract.Code[pc])})
 	} else {
 		scope.Stack.push(uint256.Int{})
 	}
@@ -1529,17 +1526,14 @@ func stPush1(pc uint64, scope *CallContext) string {
 
 // opPush2 is a specialized version of pushN
 func opPush2(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) {
-	var (
-		codeLen = uint64(len(scope.Contract.Code))
-		integer = new(uint256.Int)
-	)
-
+	codeLen := uint64(len(scope.Contract.Code))
+	var integer uint256.Int
 	if pc+2 < codeLen {
 		integer.SetBytes2(scope.Contract.Code[pc+1 : pc+3])
 	} else if pc+1 < codeLen {
 		integer.SetUint64(uint64(scope.Contract.Code[pc+1]) << 8)
 	}
-	scope.Stack.push(*integer)
+	scope.Stack.push(integer)
 	pc += 2
 	return pc, nil, nil
 }
@@ -1552,12 +1546,13 @@ func makePush(size uint64, pushByteSize int) executionFunc {
 		startMin := min(int(pc+1), codeLen)
 		endMin := min(startMin+pushByteSize, codeLen)
 
-		integer := new(uint256.Int).SetBytes(scope.Contract.Code[startMin:endMin])
+		var integer uint256.Int
+		integer.SetBytes(scope.Contract.Code[startMin:endMin])
 		// Missing bytes: pushByteSize - len(pushData)
 		if missing := pushByteSize - (endMin - startMin); missing > 0 {
-			integer.Lsh(integer, uint(8*missing))
+			integer.Lsh(&integer, uint(8*missing))
 		}
-		scope.Stack.push(*integer)
+		scope.Stack.push(integer)
 
 		pc += size
 		return pc, nil, nil

--- a/execution/vm/interpreter.go
+++ b/execution/vm/interpreter.go
@@ -485,10 +485,12 @@ func (evm *EVM) Run(contract Contract, gas mdgas.MdGas, input []byte, readOnly b
 				}
 				return nil, callContext.Gas(), err
 			}
-			cost += dynamicCost.Regular // for tracing
-			callGas = operation.constantGas + dynamicCost.Regular - evm.CallGasTemp()
-			if dbg.TraceDynamicGas && dynamicCost.Regular > 0 {
-				fmt.Printf("%d (%d.%d) Dynamic Gas: %d (%s)\n", blockNum, txIndex, txIncarnation, traceGas(op, callGas, cost), op)
+			if anyTrace {
+				cost += dynamicCost.Regular
+				callGas = operation.constantGas + dynamicCost.Regular - evm.CallGasTemp()
+				if dbg.TraceDynamicGas && dynamicCost.Regular > 0 {
+					fmt.Printf("%d (%d.%d) Dynamic Gas: %d (%s)\n", blockNum, txIndex, txIncarnation, traceGas(op, callGas, cost), op)
+				}
 			}
 			// EIP-8037: "Regular gas charge MUST be applied first. If the regular
 			// gas charge triggers an out-of-gas error, the state gas charge is

--- a/test-fixtures.json
+++ b/test-fixtures.json
@@ -1,8 +1,8 @@
 {
   "eest_benchmark": {
-    "url": "https://github.com/ethereum/execution-spec-tests/releases/download/benchmark%40v0.0.7/fixtures_benchmark.tar.gz",
-    "sha256": "efa7cbec58bedab28870e260eca1f5271b1c3d81c952f221ba6432bff88fee5d",
-    "size": 428679253
+    "url": "https://github.com/ethereum/execution-specs/releases/download/tests-benchmark%40v0.0.9/fixtures_benchmark.tar.gz",
+    "sha256": "5aee5d1bf7430d5b6ca5b48269dd2a1fb0f9df39ac1e980bac9fc56ad403b8c7",
+    "size": 1025048557
   },
   "eest_devnet": {
     "url": "https://github.com/ethereum/execution-spec-tests/releases/download/bal%40v5.7.0/fixtures_bal.tar.gz",


### PR DESCRIPTION
## Summary
- **test-fixtures**: bump \`eest_benchmark\` to [tests-benchmark@v0.0.9](https://github.com/ethereum/execution-specs/releases/tag/tests-benchmark%40v0.0.9). The new fixture suite reorganizes \`blockchain_tests_engine_x\` to nest tests under per-gas-limit dirs (\`for_osaka_at_<NNNN>M/compute/<category>/<subcat>\`) instead of a flat \`benchmark/compute/<category>\`. Updated \`benchmarkEngineX\` to walk every \`for_*M\` dir and emit sub-benchmarks as \`<gas>/<subcat>\`; \`(Fork, PreAllocHash)\` tester cache still deduplicates across gas levels.
- **execution/vm/instructions.go**: drop unnecessary \`new(uint256.Int)\` in \`opPush1\`/\`opPush2\`/\`makePush\`. The compiler was already proving these non-escaping, but the deref+method-call indirection pushed \`opPush1\` over the inliner budget. Now \`opPush1\` inlines (cost 58 vs 80). On the eest engine-x instruction benchmark suite \`opPush1\` flat CPU drops ~8% (5.60s → 5.16s of 489s); allocation counts unchanged.
- **execution/vm/interpreter.go**: gate tracing-only \`cost +=\` / \`callGas =\` / \`TraceDynamicGas\` printf in the dynamic-gas branch of \`EVM.Run\` behind \`if anyTrace\`. Both values are read only by tracer hooks (\`OnGasChange\`/\`OnOpcode\`) and the trace-print at line 545; \`anyTrace\` already covers all readers. CPU attributed to those lines drops from ~2.73s to ~0.86s on the same benchmark.