### PR TITLE
[r3.4] docs: May 2026 w19 maintenance — stale flags, broken links, accuracy fixes

### DIFF
--- a/docs/site/docs/about/contributing.md
+++ b/docs/site/docs/about/contributing.md
@@ -17,7 +17,7 @@ The Erigon node software is developed in the [erigontech/erigon](https://github.
    git clone https://github.com/<your-username>/erigon.git
    cd erigon
    ```
-2. Build the project (requires Go 1.24+ and a C++ compiler):
+2. Build the project (requires Go 1.25+ and a C++ compiler):
    ```bash
    make erigon
    ```

--- a/docs/site/docs/fundamentals/basic-usage.mdx
+++ b/docs/site/docs/fundamentals/basic-usage.mdx
@@ -94,7 +94,7 @@ To run Erigon with RPCDaemon, TxPool, and other components in a single process i
 * `--log.dir.path` dictates where [logs](logs) will be output - useful for sending reports to the Erigon team when issues occur.
 * Based on the [sync mode](sync-modes) you want to run you can add `--prune.mode=archive` to run an archive node, `--prune.mode=full` for a full node (default value) or `--prune.mode=minimal` for a minimal node.
 * `--http.addr=0.0.0.0 --http.api=eth,web3,net,debug,trace,txpool` to use [RPC Service](../interacting-with-erigon/) and e.g. be able to connect your [wallet](web3-wallet).
-* `--torrent.download.rate=512mb` sets the maximum download speed. The default is `512mb`. You can lower this value to limit bandwidth usage, for example `--torrent.download.rate=128mb` to cap downloads at 128 MB/s.
+* `--torrent.download.rate` sets the torrent download rate cap. The default is `512mb` (megabytes per second). During initial sync Erigon will use the full allowance — on a dedicated machine this is fine, but if you share the machine with other work you may want to lower it (e.g. `--torrent.download.rate=128mb`). Set `--torrent.download.rate=Inf` to remove the limit entirely.
 
 To stop the Erigon node you can use the `CTRL+C` command.
 

--- a/docs/site/docs/fundamentals/basic-usage.mdx
+++ b/docs/site/docs/fundamentals/basic-usage.mdx
@@ -79,7 +79,7 @@ To run Erigon with RPCDaemon, TxPool, and other components in a single process i
  --http \
  --ws \
  --http.api=eth,debug,net,trace,web3,erigon \
- --log.dir.path=/desired/path/to/logs
+ --log.dir.path=/desired/path/to/logs \
  --torrent.download.rate=512mb
 ```
 
@@ -92,7 +92,7 @@ To run Erigon with RPCDaemon, TxPool, and other components in a single process i
     ```
 * The `--chain=mainnet` flag is set by default for Erigon to sync with the Ethereum mainnet. To explore other network options, check the [Supported Networks](supported-networks) section. For quick testing, consider selecting a testnet.
 * `--log.dir.path` dictates where [logs](logs) will be output - useful for sending reports to the Erigon team when issues occur.
-* Based on the [sync mode](sync-modes) you want to run you can add `--prune.mode=archive` to run a archive node, `--prune.mode=full` for a full node (default value) or `--prune.mode=minimal` for a minimal node.
+* Based on the [sync mode](sync-modes) you want to run you can add `--prune.mode=archive` to run an archive node, `--prune.mode=full` for a full node (default value) or `--prune.mode=minimal` for a minimal node.
 * `--http.addr="0.0.0.0" --http.api=eth,web3,net,debug,trace,txpool` to use [RPC Service](../interacting-with-erigon/) and e.g. be able to connect your [wallet](web3-wallet).
 * `--torrent.download.rate=512mb` sets the maximum download speed. The default is `512mb`. You can lower this value to limit bandwidth usage, for example `--torrent.download.rate=128mb` to cap downloads at 128 MB/s.
 

--- a/docs/site/docs/fundamentals/basic-usage.mdx
+++ b/docs/site/docs/fundamentals/basic-usage.mdx
@@ -93,7 +93,7 @@ To run Erigon with RPCDaemon, TxPool, and other components in a single process i
 * The `--chain=mainnet` flag is set by default for Erigon to sync with the Ethereum mainnet. To explore other network options, check the [Supported Networks](supported-networks) section. For quick testing, consider selecting a testnet.
 * `--log.dir.path` dictates where [logs](logs) will be output - useful for sending reports to the Erigon team when issues occur.
 * Based on the [sync mode](sync-modes) you want to run you can add `--prune.mode=archive` to run an archive node, `--prune.mode=full` for a full node (default value) or `--prune.mode=minimal` for a minimal node.
-* `--http.addr="0.0.0.0" --http.api=eth,web3,net,debug,trace,txpool` to use [RPC Service](../interacting-with-erigon/) and e.g. be able to connect your [wallet](web3-wallet).
+* `--http.addr=0.0.0.0 --http.api=eth,web3,net,debug,trace,txpool` to use [RPC Service](../interacting-with-erigon/) and e.g. be able to connect your [wallet](web3-wallet).
 * `--torrent.download.rate=512mb` sets the maximum download speed. The default is `512mb`. You can lower this value to limit bandwidth usage, for example `--torrent.download.rate=128mb` to cap downloads at 128 MB/s.
 
 To stop the Erigon node you can use the `CTRL+C` command.

--- a/docs/site/docs/fundamentals/configuring-erigon/index.mdx
+++ b/docs/site/docs/fundamentals/configuring-erigon/index.mdx
@@ -99,6 +99,9 @@ Flags for managing how old chain data is handled and stored.
   * Default: `false`
 * `--snap.skip-state-snapshot-download`: Skips state download and starts from genesis.
   * Default: `false`
+* `--snap.keepblocks`: Advanced/debug snapshot option to keep block data while working with snapshots. Intended mainly for troubleshooting or workaround scenarios.
+* `--snap.stop value`: Advanced/debug snapshot option to stop snapshot processing at a specified block or stage boundary.
+* `--snap.state.stop value`: Advanced/debug snapshot option to stop state snapshot processing at a specified block or stage boundary.
 
 ### Transaction Pool (TxPool)
 

--- a/docs/site/docs/fundamentals/configuring-erigon/index.mdx
+++ b/docs/site/docs/fundamentals/configuring-erigon/index.mdx
@@ -82,9 +82,6 @@ These flags control database performance and memory usage.
   * Default: `268435456`
 * `--state.cache value`: Sets the amount of data to store in the StateCache.
   * Default: `0MB`
-* `--sync.parallel-state-flushing`: Enables parallel state flushing.
-  * Default: `true`
-
 ### Pruning and Snapshots
 
 Flags for managing how old chain data is handled and stored.
@@ -96,12 +93,6 @@ Flags for managing how old chain data is handled and stored.
 * `--prune.distance.blocks value`: Keeps block history for the latest `N` blocks.
   * Default: `0`
 * `--prune.include-commitment-history, --prune.experimental.include-commitment-history, --experimental.commitment-history`: Enables fast `eth_getProof` for executed blocks by storing commitment history. Requires +32 GB RAM. See [`eth_getProof`](/interacting-with-erigon/eth#eth_getproof).
-  * Default: `false`
-* `--snap.keepblocks`: Keeps ancient blocks in the database for debugging.
-  * Default: `false`
-* `--snap.stop`: Stops generating new snapshots.
-  * Default: `false`
-* `--snap.state.stop`: Stops generating new state files.
   * Default: `false`
 * `--snap.skip-state-snapshot-download`: Skips state download and starts from genesis.
   * Default: `false`

--- a/docs/site/docs/fundamentals/configuring-erigon/index.mdx
+++ b/docs/site/docs/fundamentals/configuring-erigon/index.mdx
@@ -99,9 +99,12 @@ Flags for managing how old chain data is handled and stored.
   * Default: `false`
 * `--snap.skip-state-snapshot-download`: Skips state download and starts from genesis.
   * Default: `false`
-* `--snap.keepblocks`: Advanced/debug snapshot option to keep block data while working with snapshots. Intended mainly for troubleshooting or workaround scenarios.
-* `--snap.stop value`: Advanced/debug snapshot option to stop snapshot processing at a specified block or stage boundary.
-* `--snap.state.stop value`: Advanced/debug snapshot option to stop state snapshot processing at a specified block or stage boundary.
+* `--snap.keepblocks`: Workaround/debug — keeps ancient blocks in the DB instead of moving them into snapshots (useful for debugging).
+  * Default: `false`
+* `--snap.stop`: Workaround for snapshot-related bugs — stops producing new snapshot files (DB will grow as a result).
+  * Default: `false`
+* `--snap.state.stop`: Workaround for state-related bugs — stops producing new state files (DB will grow as a result).
+  * Default: `false`
 
 ### Transaction Pool (TxPool)
 

--- a/docs/site/docs/fundamentals/configuring-erigon/index.mdx
+++ b/docs/site/docs/fundamentals/configuring-erigon/index.mdx
@@ -390,8 +390,7 @@ These flags control the block synchronization and data downloading process, incl
   * Default: `false`
 * `--torrent.upload.rate value`: The upload rate in bytes per second.
   * Default: `16mb`
-* `--torrent.download.rate value`: The download rate in bytes per second.
-  * Default: `512mb`
+* `--torrent.download.rate value`: Sets the torrent download rate cap. Default: `512mb`. Use a lower value on shared machines to avoid saturating the connection; use `Inf` to remove the limit.
 * `--torrent.webseed.download.rate value`: The download rate for webseeds. If not set, rate limit is shared with torrent.
 * `--torrent.verbosity value`: Sets the verbosity level for BitTorrent logs. 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=detail (must set `--verbosity` to equal or higher level)
   * Default: `1`

--- a/docs/site/docs/fundamentals/configuring-erigon/index.mdx
+++ b/docs/site/docs/fundamentals/configuring-erigon/index.mdx
@@ -82,6 +82,9 @@ These flags control database performance and memory usage.
   * Default: `268435456`
 * `--state.cache value`: Sets the amount of data to store in the StateCache.
   * Default: `0MB`
+* `--sync.parallel-state-flushing`: Enables parallel state flushing.
+  * Default: `true`
+
 ### Pruning and Snapshots
 
 Flags for managing how old chain data is handled and stored.

--- a/docs/site/docs/fundamentals/modules/downloader.mdx
+++ b/docs/site/docs/fundamentals/modules/downloader.mdx
@@ -13,7 +13,7 @@ The Downloader is a service responsible for seeding and downloading historical d
 **Info**: While all Erigon components are separable and can be run on different machines, the Downloader must run on the same machine as Erigon to be able to share downloaded and seeded files.
 :::
 
-For a comprehensive understanding of the Downloader's functionality, configuration, and usage, please refer to [./cmd/downloader/README.md](https://github.com/erigontech/erigon/blob/main/cmd/downloader/readme.md) with the following key topics:
+For a comprehensive understanding of the Downloader's functionality, configuration, and usage, please refer to [./cmd/downloader/readme.md](https://github.com/erigontech/erigon/blob/main/cmd/downloader/readme.md) with the following key topics:
 
 1. **Snapshots overview**: An introduction to snapshots, their benefits, and how they are created and used in Erigon.
 2. **Starting Erigon with snapshots support**: Instructions on how to start Erigon with snapshots support, either by default or as a separate process.

--- a/docs/site/docs/fundamentals/sync-modes.md
+++ b/docs/site/docs/fundamentals/sync-modes.md
@@ -1,13 +1,13 @@
 ---
 title: "Sync Modes"
-description: "Full, minimal, and archive sync explained — choose the right mode for your use case."
+description: "Full, minimal, blocks, and archive sync explained — choose the right mode for your use case."
 sidebar_position: 2
 ---
 
 
 # Sync Modes
 
-Erigon 3 supports three prune modes that control how much chain history your node retains. Choose based on your use case — most users should run a Full Node.
+Erigon 3 supports four prune modes that control how much chain history your node retains. Choose based on your use case — most users should run a Full Node.
 
 | **Prune Mode**                                                        | **Flag**               | **Data Retained**                                                                                   | **Primary Use Case**                                                                     |
 | --------------------------------------------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |

--- a/docs/site/docs/get-started/easy-nodes/how-to-run-a-gnosis-chain-node/gnosis-with-an-external-cl.md
+++ b/docs/site/docs/get-started/easy-nodes/how-to-run-a-gnosis-chain-node/gnosis-with-an-external-cl.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 # Gnosis Chain with an external CL
 
-Alternatively, you can also run an Ethereum node as an Execution Layer (EL) and couple it with an external Consensus Layer (CL). Here is an example of configuration with **Lighthouse**.
+Alternatively, you can also run a Gnosis Chain node as an Execution Layer (EL) and couple it with an external Consensus Layer (CL). Here is an example of configuration with **Lighthouse**.
 
 ### 1. Start Erigon:
 

--- a/docs/site/docs/get-started/easy-nodes/how-to-run-a-gnosis-chain-node/gnosis-with-an-external-cl.md
+++ b/docs/site/docs/get-started/easy-nodes/how-to-run-a-gnosis-chain-node/gnosis-with-an-external-cl.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 # Gnosis Chain with an external CL
 
-Alternatively, you can also run a Ethereum node as an Execution Layer (EL) and couple it with an external Consensus Layer (CL). Here is an example of configuration with **Lighthouse**.
+Alternatively, you can also run an Ethereum node as an Execution Layer (EL) and couple it with an external Consensus Layer (CL). Here is an example of configuration with **Lighthouse**.
 
 ### 1. Start Erigon:
 
@@ -70,4 +70,4 @@ To communicate with Erigon, the execution endpoint must be specified as `<erigon
      --checkpoint-sync-url "https://checkpoint.chiadochain.net"
     ```
 
-Check the Erigon and Lightouse logs to make sure that the EL and CL are communicating and that your is syncing correctly.
+Check the Erigon and Lighthouse logs to make sure that the EL and CL are communicating and that your node is syncing correctly.

--- a/docs/site/docs/get-started/easy-nodes/how-to-run-an-ethereum-node/index.md
+++ b/docs/site/docs/get-started/easy-nodes/how-to-run-an-ethereum-node/index.md
@@ -66,7 +66,7 @@ docker compose up
 * `--chain=mainnet` specifies to run on Ethereum mainnet
 * Add `--prune.mode=minimal` to run minimal [Sync Mode](/fundamentals/sync-modes) or `--prune.mode=archive` to run an archive node
 * `--http.addr=0.0.0.0 --http.api=eth,web3,net,debug,trace,txpool` to use RPC and e.g. be able to connect your [web3 wallet](/fundamentals/web3-wallet)
-* `--torrent.download.rate=512mb` sets the download rate cap. The default is `512mb` (megabytes per second). You can lower this to limit bandwidth usage, for example `--torrent.download.rate=128mb`, or set `--torrent.download.rate=Inf` to remove the limit.
+* `--torrent.download.rate` sets the torrent download rate cap. The default is `512mb` (megabytes per second). During initial sync Erigon will use the full allowance — on a dedicated machine this is fine, but if you share the machine with other work you may want to lower it (e.g. `--torrent.download.rate=128mb`). Set `--torrent.download.rate=Inf` to remove the limit entirely.
 
 When you get familiar with running Erigon from CLI you may also consider [staking](/staking/caplin) and/or running an Ethereum node with an [external Consensus Layer](/get-started/easy-nodes/how-to-run-an-ethereum-node/ethereum-with-an-external-cl).
 

--- a/docs/site/docs/get-started/easy-nodes/how-to-run-an-ethereum-node/index.md
+++ b/docs/site/docs/get-started/easy-nodes/how-to-run-an-ethereum-node/index.md
@@ -66,7 +66,7 @@ docker compose up
 * `--chain=mainnet` specifies to run on Ethereum mainnet
 * Add `--prune.mode=minimal` to run minimal [Sync Mode](/fundamentals/sync-modes) or `--prune.mode=archive` to run an archive node
 * `--http.addr=0.0.0.0 --http.api=eth,web3,net,debug,trace,txpool` to use RPC and e.g. be able to connect your [web3 wallet](/fundamentals/web3-wallet)
-* `--torrent.download.rate=512mb` to increase download speed. While the default downloading speed is 128mb, with this flag Erigon will use as much download speed as it can, up to a maximum of 512 megabytes per second. This means it will try to download data as quickly as possible, but it won't exceed the 512 MB/s limit you've set
+* `--torrent.download.rate=512mb` sets the download rate cap. The default is `512mb` (megabytes per second). You can lower this to limit bandwidth usage, for example `--torrent.download.rate=128mb`, or set `--torrent.download.rate=Inf` to remove the limit.
 
 When you get familiar with running Erigon from CLI you may also consider [staking](/staking/caplin) and/or running an Ethereum node with an [external Consensus Layer](/get-started/easy-nodes/how-to-run-an-ethereum-node/ethereum-with-an-external-cl).
 

--- a/docs/site/docs/get-started/easy-nodes/how-to-run-an-ethereum-node/index.md
+++ b/docs/site/docs/get-started/easy-nodes/how-to-run-an-ethereum-node/index.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 ---
 
 
-# How to run a Ethereum node
+# How to run an Ethereum node
 
 ## 1. Prerequisites Check
 
@@ -31,7 +31,7 @@ services:
     command:
       # --- Basic Configuration ---
       - --chain=mainnet
-      - --http.addr="0.0.0.0"
+      - --http.addr=0.0.0.0
       - --http.api=eth,web3,net,debug,trace,txpool
       # --- Performance Tweaks ---
       - --torrent.download.rate=512mb
@@ -63,12 +63,12 @@ docker compose up
 
 ## Flag explanation
 
-* `--chain=gnosis` specifies to run on Gnosis Chain, use `--chain=chiado` for Chiado testnet
+* `--chain=mainnet` specifies to run on Ethereum mainnet
 * Add `--prune.mode=minimal` to run minimal [Sync Mode](/fundamentals/sync-modes) or `--prune.mode=archive` to run an archive node
-* `--http.addr="0.0.0.0" --http.api=eth,web3,net,debug,trace,txpool` to use RPC and e.g. be able to connect your [web3 wallet](/fundamentals/web3-wallet)
+* `--http.addr=0.0.0.0 --http.api=eth,web3,net,debug,trace,txpool` to use RPC and e.g. be able to connect your [web3 wallet](/fundamentals/web3-wallet)
 * `--torrent.download.rate=512mb` to increase download speed. While the default downloading speed is 128mb, with this flag Erigon will use as much download speed as it can, up to a maximum of 512 megabytes per second. This means it will try to download data as quickly as possible, but it won't exceed the 512 MB/s limit you've set
 
-When you get familiar with running Erigon from CLI you may also consider [staking](/staking/caplin) and/or run a Gnosis node with an [external Consensus Layer](/get-started/easy-nodes/how-to-run-an-ethereum-node/ethereum-with-an-external-cl).
+When you get familiar with running Erigon from CLI you may also consider [staking](/staking/caplin) and/or running an Ethereum node with an [external Consensus Layer](/get-started/easy-nodes/how-to-run-an-ethereum-node/ethereum-with-an-external-cl).
 
 :::tip
 Press `Ctrl+C` in your terminal to stop Erigon.

--- a/docs/site/docs/staking/external-consensus-client-as-validator.md
+++ b/docs/site/docs/staking/external-consensus-client-as-validator.md
@@ -7,7 +7,7 @@ sidebar_position: 2
 
 # Using an external consensus client as validator
 
-To use an external Consensus Layer (CL) it is necessary to add to Erigon the flag `--externalcl`. Here are a couple of examples on how to configure Lighhouse and Prysm to run along with Erigon:
+To use an external Consensus Layer (CL) it is necessary to add to Erigon the flag `--externalcl`. Here are a couple of examples on how to configure Lighthouse and Prysm to run along with Erigon:
 
 * [Ethereum](../get-started/easy-nodes/how-to-run-an-ethereum-node/ethereum-with-an-external-cl)
 * [Gnosis Chain](../get-started/easy-nodes/how-to-run-a-gnosis-chain-node/gnosis-with-an-external-cl)
@@ -37,7 +37,7 @@ erigon \
   --externalcl \
   --datadir=/data/erigon \
   --chain=sepolia \
-  --authrpc.jwtsecret=/jwt
+  --authrpc.jwtsecret=/jwt \
   --authrpc.addr=0.0.0.0 \
   --http \
   --http.addr=0.0.0.0 \

--- a/docs/site/versioned_docs/version-v3.3/about/contributing.md
+++ b/docs/site/versioned_docs/version-v3.3/about/contributing.md
@@ -9,7 +9,7 @@ This documentation is powered by [MdBook](https://rust-lang.github.io/mdBook).
 To contribute to the Erigon Docs, you can either:
 
 1. Create an Issue: Open a new issue in the main branch to suggest changes or report problems.
-2. Open a Branch and Submit a PR: Create a new branch, make your changes, and submit a pull request (PR) on Github.
+2. Open a Branch and Submit a PR: Create a new branch, make your changes, and submit a pull request (PR) on GitHub.
 
 [https://github.com/erigontech/erigon](https://github.com/erigontech/erigon)
 

--- a/docs/site/versioned_docs/version-v3.3/fundamentals/basic-usage.md
+++ b/docs/site/versioned_docs/version-v3.3/fundamentals/basic-usage.md
@@ -44,7 +44,7 @@ To run Erigon with RPCDaemon, TxPool, and other components in a single process i
  --http \
  --ws \
  --http.api=eth,debug,net,trace,web3,erigon \
- --log.dir.path=/desired/path/to/logs
+ --log.dir.path=/desired/path/to/logs \
  --torrent.download.rate=512mb
 ```
 
@@ -57,7 +57,7 @@ To run Erigon with RPCDaemon, TxPool, and other components in a single process i
     ```
 * The `--chain=mainnet` flag is set by default for Erigon to sync with the Ethereum mainnet. To explore other network options, check the [Supported Networks](supported-networks) section. For quick testing, consider selecting a testnet.
 * `--log.dir.path` dictates where [logs](logs) will be output - useful for sending reports to the Erigon team when issues occur.
-* Based on the [sync mode](sync-modes) you want to run you can add `--prune.mode=archive` to run a archive node, `--prune.mode=full` for a full node (default value) or `--prune.mode=minimal` for a minimal node.
+* Based on the [sync mode](sync-modes) you want to run you can add `--prune.mode=archive` to run an archive node, `--prune.mode=full` for a full node (default value) or `--prune.mode=minimal` for a minimal node.
 * `--http.addr="0.0.0.0" --http.api=eth,web3,net,debug,trace,txpool` to use [RPC Service](../interacting-with-erigon/) and e.g. be able to connect your [wallet](web3-wallet).
 * `--torrent.download.rate=512mb` to increase download speed. While the default downloading speed is 128mb, with this flag Erigon will use as much download speed as it can, up to a maximum of 512 megabytes per second. This means it will try to download data as quickly as possible, but it won't exceed the 512 MB/s limit you've set.
 

--- a/docs/site/versioned_docs/version-v3.3/fundamentals/basic-usage.md
+++ b/docs/site/versioned_docs/version-v3.3/fundamentals/basic-usage.md
@@ -58,8 +58,8 @@ To run Erigon with RPCDaemon, TxPool, and other components in a single process i
 * The `--chain=mainnet` flag is set by default for Erigon to sync with the Ethereum mainnet. To explore other network options, check the [Supported Networks](supported-networks) section. For quick testing, consider selecting a testnet.
 * `--log.dir.path` dictates where [logs](logs) will be output - useful for sending reports to the Erigon team when issues occur.
 * Based on the [sync mode](sync-modes) you want to run you can add `--prune.mode=archive` to run an archive node, `--prune.mode=full` for a full node (default value) or `--prune.mode=minimal` for a minimal node.
-* `--http.addr="0.0.0.0" --http.api=eth,web3,net,debug,trace,txpool` to use [RPC Service](../interacting-with-erigon/) and e.g. be able to connect your [wallet](web3-wallet).
-* `--torrent.download.rate=512mb` to increase download speed. While the default downloading speed is 128mb, with this flag Erigon will use as much download speed as it can, up to a maximum of 512 megabytes per second. This means it will try to download data as quickly as possible, but it won't exceed the 512 MB/s limit you've set.
+* `--http.addr=0.0.0.0 --http.api=eth,web3,net,debug,trace,txpool` to use [RPC Service](../interacting-with-erigon/) and e.g. be able to connect your [wallet](web3-wallet).
+* `--torrent.download.rate=512mb` sets the download rate cap. The default is `512mb` (megabytes per second). You can lower this to limit bandwidth usage, for example `--torrent.download.rate=128mb`, or set `--torrent.download.rate=Inf` to remove the limit.
 
 To stop the Erigon node you can use the `CTRL+C` command.
 

--- a/docs/site/versioned_docs/version-v3.3/fundamentals/basic-usage.md
+++ b/docs/site/versioned_docs/version-v3.3/fundamentals/basic-usage.md
@@ -59,7 +59,7 @@ To run Erigon with RPCDaemon, TxPool, and other components in a single process i
 * `--log.dir.path` dictates where [logs](logs) will be output - useful for sending reports to the Erigon team when issues occur.
 * Based on the [sync mode](sync-modes) you want to run you can add `--prune.mode=archive` to run an archive node, `--prune.mode=full` for a full node (default value) or `--prune.mode=minimal` for a minimal node.
 * `--http.addr=0.0.0.0 --http.api=eth,web3,net,debug,trace,txpool` to use [RPC Service](../interacting-with-erigon/) and e.g. be able to connect your [wallet](web3-wallet).
-* `--torrent.download.rate=512mb` sets the download rate cap. The default is `512mb` (megabytes per second). You can lower this to limit bandwidth usage, for example `--torrent.download.rate=128mb`, or set `--torrent.download.rate=Inf` to remove the limit.
+* `--torrent.download.rate` sets the torrent download rate cap. The default is `512mb` (megabytes per second). During initial sync Erigon will use the full allowance — on a dedicated machine this is fine, but if you share the machine with other work you may want to lower it (e.g. `--torrent.download.rate=128mb`). Set `--torrent.download.rate=Inf` to remove the limit entirely.
 
 To stop the Erigon node you can use the `CTRL+C` command.
 

--- a/docs/site/versioned_docs/version-v3.3/fundamentals/configuring-erigon/index.md
+++ b/docs/site/versioned_docs/version-v3.3/fundamentals/configuring-erigon/index.md
@@ -363,7 +363,7 @@ These flags control the block synchronization and data downloading process, incl
   * Default: `false`
 * `--torrent.upload.rate value`: The upload rate in bytes per second.
   * Default: `32mb`
-* `--torrent.download.rate value`: The download rate in bytes per second.
+* `--torrent.download.rate value`: Sets the torrent download rate cap. Default: `512mb`. Use a lower value on shared machines to avoid saturating the connection; use `Inf` to remove the limit.
 * `--torrent.webseed.download.rate value`: The download rate for webseeds.
 * `--torrent.verbosity value`: Sets the verbosity level for BitTorrent logs.
   * Default: `1`

--- a/docs/site/versioned_docs/version-v3.3/fundamentals/modules/downloader.md
+++ b/docs/site/versioned_docs/version-v3.3/fundamentals/modules/downloader.md
@@ -10,7 +10,7 @@ The Downloader is a service responsible for seeding and downloading historical d
 **Info**: While all Erigon components are separable and can be run on different machines, the Downloader must run on the same machine as Erigon to be able to share downloaded and seeded files.
 :::
 
-For a comprehensive understanding of the Downloader's functionality, configuration, and usage, please refer to [./cmd/downloader/README.md](https://github.com/erigontech/erigon/blob/main/cmd/downloader/readme) with the following key topics:
+For a comprehensive understanding of the Downloader's functionality, configuration, and usage, please refer to [./cmd/downloader/README.md](https://github.com/erigontech/erigon/blob/main/cmd/downloader/readme.md) with the following key topics:
 
 1. **Snapshots overview**: An introduction to snapshots, their benefits, and how they are created and used in Erigon.
 2. **Starting Erigon with snapshots support**: Instructions on how to start Erigon with snapshots support, either by default or as a separate process.
@@ -70,7 +70,7 @@ Flags:
       --diagnostics.endpoint.port uint     Diagnostics HTTP server listening port (default 6062)
       --diagnostics.speedtest              Enable speed test
       --downloader.api.addr string         external downloader api network address, for example: 127.0.0.1:9093 serves remote downloader interface (default "127.0.0.1:9093")
-      --downloader.disable.ipv4            Turns off ipv6 for the downloader
+      --downloader.disable.ipv4            Turns off ipv4 for the downloader
       --downloader.disable.ipv6            Turns off ipv6 for the downloader
   -h, --help                               help for this command
       --log.console.json                   Format console logs with JSON

--- a/docs/site/versioned_docs/version-v3.3/fundamentals/modules/downloader.md
+++ b/docs/site/versioned_docs/version-v3.3/fundamentals/modules/downloader.md
@@ -10,7 +10,7 @@ The Downloader is a service responsible for seeding and downloading historical d
 **Info**: While all Erigon components are separable and can be run on different machines, the Downloader must run on the same machine as Erigon to be able to share downloaded and seeded files.
 :::
 
-For a comprehensive understanding of the Downloader's functionality, configuration, and usage, please refer to [./cmd/downloader/README.md](https://github.com/erigontech/erigon/blob/main/cmd/downloader/readme.md) with the following key topics:
+For a comprehensive understanding of the Downloader's functionality, configuration, and usage, please refer to [cmd/downloader/readme.md](https://github.com/erigontech/erigon/blob/main/cmd/downloader/readme.md) with the following key topics:
 
 1. **Snapshots overview**: An introduction to snapshots, their benefits, and how they are created and used in Erigon.
 2. **Starting Erigon with snapshots support**: Instructions on how to start Erigon with snapshots support, either by default or as a separate process.

--- a/docs/site/versioned_docs/version-v3.3/fundamentals/modules/rpc-daemon.md
+++ b/docs/site/versioned_docs/version-v3.3/fundamentals/modules/rpc-daemon.md
@@ -18,9 +18,9 @@ The Erigon RPC service offers three distinct deployment modes when it comes to t
 
 For a comprehensive understanding and the latest instructions, the official documentation is essential:
 
-* **Detailed Functionality and Configuration**: The primary documentation for the `rpcdaemon` is located at [https://github.com/erigontech/erigon/blob/main/cmd/rpcdaemon/README.md](https://github.com/erigontech/erigon/blob/main/cmd/rpcdaemon/).
+* **Detailed Functionality and Configuration**: The primary documentation for the `rpcdaemon` is located at [https://github.com/erigontech/erigon/blob/main/cmd/rpcdaemon/README.md](https://github.com/erigontech/erigon/blob/main/cmd/rpcdaemon/README.md).
 * **Local Access**: This documentation is also contained in your locally compiled Erigon folder at `/cmd/rpcdaemon`.
-* **Remote Running Instructions**: For detailed instructions on running RPC in Remote mode, refer to the documentation [here](https://github.com/erigontech/erigon/blob/main/cmd/rpcdaemon/README#running-remotely).
+* **Remote Running Instructions**: For detailed instructions on running RPC in Remote mode, refer to the documentation [here](https://github.com/erigontech/erigon/blob/main/cmd/rpcdaemon/README.md#running-remotely).
 
 :::tip
 To interact with the **RPC Service** visit the dedicated page [Interacting with Erigon](../../interacting-with-erigon/).

--- a/docs/site/versioned_docs/version-v3.3/fundamentals/multiple-instances.md
+++ b/docs/site/versioned_docs/version-v3.3/fundamentals/multiple-instances.md
@@ -77,7 +77,7 @@ For multiple instances, consider adjusting database parameters to reduce resourc
 
 ```bash
 # Reduce memory-mapped database growth to minimize disk churn
---db.growth.step=32MB
+--db.growth.step=32MB \
 --db.size.limit=512MB
 ```
 

--- a/docs/site/versioned_docs/version-v3.3/fundamentals/sync-modes.md
+++ b/docs/site/versioned_docs/version-v3.3/fundamentals/sync-modes.md
@@ -1,12 +1,12 @@
 ---
 title: "Sync Modes"
-description: "Full, minimal, and archive sync explained — choose the right mode for your use case."
+description: "Full, minimal, blocks, and archive sync explained — choose the right mode for your use case."
 sidebar_position: 2
 ---
 
 # Sync Modes
 
-Erigon 3 supports three prune modes that control how much chain history your node retains. Choose based on your use case — most users should run a Full Node.
+Erigon 3 supports four prune modes that control how much chain history your node retains. Choose based on your use case — most users should run a Full Node.
 
 | **Prune Mode**                                                        | **Flag**               | **Data Retained**                                                                                    | **Primary Use Case**                                                                     |
 | --------------------------------------------------------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |

--- a/docs/site/versioned_docs/version-v3.3/get-started/easy-nodes/how-to-run-a-gnosis-chain-node/gnosis-with-an-external-cl.md
+++ b/docs/site/versioned_docs/version-v3.3/get-started/easy-nodes/how-to-run-a-gnosis-chain-node/gnosis-with-an-external-cl.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 # Gnosis Chain with an external CL
 
-Alternatively, you can also run a Ethereum node as an Execution Layer (EL) and couple it with an external Consensus Layer (CL). Here is an example of configuration with **Lighthouse**.
+Alternatively, you can also run an Ethereum node as an Execution Layer (EL) and couple it with an external Consensus Layer (CL). Here is an example of configuration with **Lighthouse**.
 
 ### 1. Start Erigon:
 
@@ -69,4 +69,4 @@ To communicate with Erigon, the execution endpoint must be specified as `<erigon
      --checkpoint-sync-url "https://checkpoint.chiadochain.net"
     ```
 
-Check the Erigon and Lightouse logs to make sure that the EL and CL are communicating and that your is syncing correctly.
+Check the Erigon and Lighthouse logs to make sure that the EL and CL are communicating and that your node is syncing correctly.

--- a/docs/site/versioned_docs/version-v3.3/get-started/easy-nodes/how-to-run-a-gnosis-chain-node/gnosis-with-an-external-cl.md
+++ b/docs/site/versioned_docs/version-v3.3/get-started/easy-nodes/how-to-run-a-gnosis-chain-node/gnosis-with-an-external-cl.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 # Gnosis Chain with an external CL
 
-Alternatively, you can also run an Ethereum node as an Execution Layer (EL) and couple it with an external Consensus Layer (CL). Here is an example of configuration with **Lighthouse**.
+Alternatively, you can also run a Gnosis Chain node as an Execution Layer (EL) and couple it with an external Consensus Layer (CL). Here is an example of configuration with **Lighthouse**.
 
 ### 1. Start Erigon:
 

--- a/docs/site/versioned_docs/version-v3.3/get-started/easy-nodes/how-to-run-an-ethereum-node/index.md
+++ b/docs/site/versioned_docs/version-v3.3/get-started/easy-nodes/how-to-run-an-ethereum-node/index.md
@@ -64,7 +64,7 @@ docker compose up
 * `--chain=mainnet` specifies to run on Ethereum mainnet, see also other [Supported Networks](../../fundamentals/supported-networks)
 * Add `--prune.mode=minimal` to run minimal [Sync Mode](../../fundamentals/sync-modes) or `--prune.mode=archive` to run an archive node
 * `--http.addr=0.0.0.0 --http.api=eth,web3,net,debug,trace,txpool` to use RPC and e.g. be able to connect your [web3 wallet](../../fundamentals/web3-wallet)
-* `--torrent.download.rate=512mb` sets the download rate cap. The default is `512mb` (megabytes per second). You can lower this to limit bandwidth usage, for example `--torrent.download.rate=128mb`, or set `--torrent.download.rate=Inf` to remove the limit.
+* `--torrent.download.rate` sets the torrent download rate cap. The default is `512mb` (megabytes per second). During initial sync Erigon will use the full allowance — on a dedicated machine this is fine, but if you share the machine with other work you may want to lower it (e.g. `--torrent.download.rate=128mb`). Set `--torrent.download.rate=Inf` to remove the limit entirely.
 
 When you get familiar with running Erigon from CLI you may also consider [staking](../../../staking/caplin) and/or run an Ethereum node with an [external Consensus Layer](ethereum-with-an-external-cl.md).
 

--- a/docs/site/versioned_docs/version-v3.3/get-started/easy-nodes/how-to-run-an-ethereum-node/index.md
+++ b/docs/site/versioned_docs/version-v3.3/get-started/easy-nodes/how-to-run-an-ethereum-node/index.md
@@ -29,7 +29,7 @@ services:
     command:
       # --- Basic Configuration ---
       - --chain=mainnet
-      - --http.addr="0.0.0.0"
+      - --http.addr=0.0.0.0
       - --http.api=eth,web3,net,debug,trace,txpool
       # --- Performance Tweaks ---
       - --torrent.download.rate=512mb
@@ -63,8 +63,8 @@ docker compose up
 
 * `--chain=mainnet` specifies to run on Ethereum mainnet, see also other [Supported Networks](../../fundamentals/supported-networks)
 * Add `--prune.mode=minimal` to run minimal [Sync Mode](../../fundamentals/sync-modes) or `--prune.mode=archive` to run an archive node
-* `--http.addr="0.0.0.0" --http.api=eth,web3,net,debug,trace,txpool` to use RPC and e.g. be able to connect your [web3 wallet](../../fundamentals/web3-wallet)
-* `--torrent.download.rate=512mb` to increase download speed. While the default downloading speed is 128mb, with this flag Erigon will use as much download speed as it can, up to a maximum of 512 megabytes per second. This means it will try to download data as quickly as possible, but it won't exceed the 512 MB/s limit you've set
+* `--http.addr=0.0.0.0 --http.api=eth,web3,net,debug,trace,txpool` to use RPC and e.g. be able to connect your [web3 wallet](../../fundamentals/web3-wallet)
+* `--torrent.download.rate=512mb` sets the download rate cap. The default is `512mb` (megabytes per second). You can lower this to limit bandwidth usage, for example `--torrent.download.rate=128mb`, or set `--torrent.download.rate=Inf` to remove the limit.
 
 When you get familiar with running Erigon from CLI you may also consider [staking](../../../staking/caplin) and/or run an Ethereum node with an [external Consensus Layer](ethereum-with-an-external-cl.md).
 

--- a/docs/site/versioned_docs/version-v3.3/get-started/easy-nodes/how-to-run-an-ethereum-node/index.md
+++ b/docs/site/versioned_docs/version-v3.3/get-started/easy-nodes/how-to-run-an-ethereum-node/index.md
@@ -66,7 +66,7 @@ docker compose up
 * `--http.addr="0.0.0.0" --http.api=eth,web3,net,debug,trace,txpool` to use RPC and e.g. be able to connect your [web3 wallet](../../fundamentals/web3-wallet)
 * `--torrent.download.rate=512mb` to increase download speed. While the default downloading speed is 128mb, with this flag Erigon will use as much download speed as it can, up to a maximum of 512 megabytes per second. This means it will try to download data as quickly as possible, but it won't exceed the 512 MB/s limit you've set
 
-When you get familiar with running Erigon from CLI you may also consider [staking](../../../staking/caplin) and/or run a Ethereum node with an [external Consensus Layer](ethereum-with-an-external-cl.md).
+When you get familiar with running Erigon from CLI you may also consider [staking](../../../staking/caplin) and/or run an Ethereum node with an [external Consensus Layer](ethereum-with-an-external-cl.md).
 
 :::tip
 Press `Ctrl+C` in your terminal to stop Erigon.

--- a/docs/site/versioned_docs/version-v3.3/interacting-with-erigon/erigon.md
+++ b/docs/site/versioned_docs/version-v3.3/interacting-with-erigon/erigon.md
@@ -24,7 +24,7 @@ These methods must be explicitly enabled using the `--http.api` flag when starti
 * `erigon_getLogs` returns enhanced ErigonLog objects with additional metadata like timestamps
 * `erigon_getBlockByTimestamp` uses binary search for efficient timestamp-based block lookup
 
-See more details [here](https://github.com/erigontech/erigon/blob/main/cmd/rpcdaemon/README#rpc-implementation-status) about implementation status.
+See more details [here](https://github.com/erigontech/erigon/blob/main/cmd/rpcdaemon/README.md#rpc-implementation-status) about implementation status.
 
 ***
 

--- a/docs/site/versioned_docs/version-v3.3/staking/external-consensus-client-as-validator.md
+++ b/docs/site/versioned_docs/version-v3.3/staking/external-consensus-client-as-validator.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Using an external consensus client as validator
 
-To use an external Consensus Layer (CL) it is necessary to add to Erigon the flag `--externalcl`. Here are a couple of examples on how to configure Lighhouse and Prysm to run along with Erigon:
+To use an external Consensus Layer (CL) it is necessary to add to Erigon the flag `--externalcl`. Here are a couple of examples on how to configure Lighthouse and Prysm to run along with Erigon:
 
 * [Ethereum](../get-started/easy-nodes/how-to-run-an-ethereum-node/ethereum-with-an-external-cl)
 * [Gnosis Chain](../get-started/easy-nodes/how-to-run-a-gnosis-chain-node/gnosis-with-an-external-cl)
@@ -34,7 +34,7 @@ erigon \
   --externalcl \
   --datadir=/data/erigon \
   --chain=sepolia \
-  --authrpc.jwtsecret=/jwt
+  --authrpc.jwtsecret=/jwt \
   --authrpc.addr=0.0.0.0 \
   --http \
   --http.addr=0.0.0.0 \


### PR DESCRIPTION
## Summary

Addresses findings from the w19 weekly docs full check against `release/3.4`.

## Changes

### Broken GitHub blob links fixed — `versioned_docs/version-v3.3/`

| File | Fix |
|------|-----|
| `interacting-with-erigon/erigon.md` | `README` → `README.md` |
| `fundamentals/modules/rpc-daemon.md` | `README` → `README.md` (×2) |
| `fundamentals/modules/downloader.md` | `readme` → `readme.md` |

### Content & language fixes

| Category | File | Fix |
|----------|------|-----|
| Semantic | `docs/fundamentals/sync-modes.md` | "three prune modes" → "four" (full / minimal / blocks / archive); frontmatter updated |
| Semantic | `versioned_docs/version-v3.3/fundamentals/sync-modes.md` | same |
| Semantic | `docs/about/contributing.md` | "Go 1.24+" → "Go 1.25+" (matches `go.mod`) |
| Syntax | `docs/get-started/easy-nodes/how-to-run-an-ethereum-node/index.md` | "a Ethereum" → "an Ethereum"; flag explanation corrected from Gnosis/Chiado to Ethereum mainnet; `--http.addr="0.0.0.0"` → `--http.addr=0.0.0.0` |
| Syntax | `docs/.../gnosis-with-an-external-cl.md` (v3.4 + v3.3) | "a Ethereum" → "an Ethereum" |
| Syntax | `versioned_docs/version-v3.3/.../how-to-run-an-ethereum-node/index.md` | "a Ethereum" → "an Ethereum" |
| Syntax | `docs/fundamentals/basic-usage.mdx` (v3.4 + v3.3) | "a archive" → "an archive"; missing `\` line continuation added |
| Syntax | `docs/staking/external-consensus-client-as-validator.md` (v3.4 + v3.3) | missing `\` line continuation added |
| Syntax | `versioned_docs/version-v3.3/fundamentals/multiple-instances.md` | missing `\` line continuation added |
| Syntax | `versioned_docs/version-v3.3/fundamentals/modules/downloader.md` | `--downloader.disable.ipv4` described as "Turns off ipv6" — corrected to ipv4 |
| Spell | `docs/staking/external-consensus-client-as-validator.md` (v3.4 + v3.3) | "Lighhouse" → "Lighthouse" |
| Spell | `docs/.../gnosis-with-an-external-cl.md` (v3.4 + v3.3) | "Lightouse" → "Lighthouse"; "your is syncing" → "your node is syncing" |
| Branding | `versioned_docs/version-v3.3/about/contributing.md` | "Github" → "GitHub" |
| Accuracy | `docs/fundamentals/basic-usage.mdx` + v3.3, `docs/get-started/easy-nodes/.../index.md` + v3.3, `docs/fundamentals/configuring-erigon/index.mdx` + v3.3 | `--torrent.download.rate` description unified across all 6 files: correct default (512mb), shared-machine note, and `Inf` option |

After this merges, a follow-up PR will cherry-pick to `main` on top of #21013.

🤖 Generated with [Claude Code](https://claude.com/claude-code)