### PR TITLE
cmd/utils/app: wait for background build/merge before MergeLoop in seg retire

### DIFF
--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -3286,9 +3286,6 @@ func doRetireCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 		}
 	}
 
-	// Wait for any background build/merge work kicked off by BuildFiles to drain
-	// before MergeLoop — otherwise MergeLoop's mergingFiles CAS would lose to the
-	// background merge and return immediately without doing anything.
 	logger.Info("waiting for background build/merge to drain")
 	agg.WaitForFiles()
 

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -3286,6 +3286,12 @@ func doRetireCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 		}
 	}
 
+	// Wait for any background build/merge work kicked off by BuildFiles to drain
+	// before MergeLoop — otherwise MergeLoop's mergingFiles CAS would lose to the
+	// background merge and return immediately without doing anything.
+	logger.Info("waiting for background build/merge to drain")
+	agg.WaitForFiles()
+
 	if err = agg.MergeLoop(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- In `seg retire`, `BuildFiles` can leave background build/merge goroutines running. If `MergeLoop` runs while one of those is still in flight, its `mergingFiles` CAS loses to the background merge and `MergeLoop` returns immediately without doing anything.
- The next MergeLoop is typically skipped because an earlier one is running. And so the whole merge logic was being skipped.
- Drain background work via `agg.WaitForFiles()` between `BuildFiles`/prune and `MergeLoop` so the merge step actually runs.

## Test plan
- [ ] `make lint` passes
- [ ] `make erigon` builds
- [ ] Run `erigon seg retire` on a datadir where background build/merge is active and confirm `MergeLoop` performs merges (previously a no-op)