### PR TITLE
wire --erigondb.domain.steps-in-frozen-file for stage_exec and seg retire

### DIFF
--- a/cmd/integration/commands/flags.go
+++ b/cmd/integration/commands/flags.go
@@ -48,11 +48,12 @@ var (
 
 	dbWriteMap bool
 
-	chainTipMode    bool
-	clearCommitment bool
-	resume          bool
-	noHistory       bool
-	syncCfg         = ethconfig.Defaults.Sync
+	chainTipMode                    bool
+	clearCommitment                 bool
+	resume                          bool
+	noHistory                       bool
+	erigondbDomainStepsInFrozenFile string
+	syncCfg                         = ethconfig.Defaults.Sync
 )
 
 func must(err error) {
@@ -201,6 +202,12 @@ func withOutputCsvFile(cmd *cobra.Command) {
 
 func withChaosMonkey(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&syncCfg.ChaosMonkey, utils.ChaosMonkeyFlag.Name, utils.ChaosMonkeyFlag.Value, utils.ChaosMonkeyFlag.Usage)
+}
+
+func withErigondbDomainStepsInFrozenFile(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&erigondbDomainStepsInFrozenFile,
+		utils.ErigondbDomainStepsInFrozenFileFlag.Name, "",
+		utils.ErigondbDomainStepsInFrozenFileFlag.Usage)
 }
 
 // withStageBase applies flags common to most stage commands: config, datadir, chain, chaos monkey, heimdall, unwind.

--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -36,11 +37,13 @@ import (
 	"golang.org/x/sync/semaphore"
 
 	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cmd/utils"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/estimate"
 	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/config3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/fromdb"
 	"github.com/erigontech/erigon/db/integrity"
@@ -322,6 +325,7 @@ func init() {
 	withPruneTo(cmdStageExec)
 	withTraceFlags(cmdStageExec)
 	withChainTipMode(cmdStageExec)
+	withErigondbDomainStepsInFrozenFile(cmdStageExec)
 	rootCmd.AddCommand(cmdStageExec)
 
 	withStageBase(cmdStageExecReplay)
@@ -1073,7 +1077,28 @@ func allSnapshots(ctx context.Context, db kv.RoDB, logger log.Logger) (*freezebl
 		if erigonDBSettings, err = dbstate.ResolveErigonDBSettings(dirs, logger, false); err != nil {
 			return
 		}
-		_aggSingleton = dbstate.New(dirs).Logger(logger).WithErigonDBSettings(erigonDBSettings).MustOpen(ctx, db)
+		aggOpts := dbstate.New(dirs).Logger(logger).WithErigonDBSettings(erigonDBSettings)
+		if erigondbDomainStepsInFrozenFile != "" {
+			var v uint64
+			if strings.EqualFold(erigondbDomainStepsInFrozenFile, "inf") {
+				v = config3.UnboundedDomainMerge
+			} else {
+				parsed, perr := strconv.ParseUint(erigondbDomainStepsInFrozenFile, 10, 64)
+				if perr != nil || parsed == 0 {
+					err = fmt.Errorf("invalid --%s value %q: must be a positive integer or \"Inf\"",
+						utils.ErigondbDomainStepsInFrozenFileFlag.Name, erigondbDomainStepsInFrozenFile)
+					return
+				}
+				v = parsed
+			}
+			stepsStr := "Inf"
+			if v != config3.UnboundedDomainMerge {
+				stepsStr = fmt.Sprintf("%d", v)
+			}
+			logger.Info("domain merge cap overridden", "steps_in_frozen_file", stepsStr)
+			aggOpts = aggOpts.ErigondbDomainStepsInFrozenFile(v)
+		}
+		_aggSingleton = aggOpts.MustOpen(ctx, db)
 
 		_aggSingleton.SetProduceMod(snapCfg.ProduceE3)
 		_aggSingleton.SetFrozenBlocksProvider(blockReader)

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -189,6 +189,7 @@ var snapshotCommand = cli.Command{
 			Usage: "create snapshots from the specified block number",
 			Flags: joinFlags([]cli.Flag{
 				&utils.DataDirFlag,
+				&utils.ErigondbDomainStepsInFrozenFileFlag,
 			}),
 		},
 		{
@@ -3191,6 +3192,27 @@ func doRetireCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 
 	defer br.MadvNormal().DisableReadAhead()
 	defer agg.MadvNormal().DisableReadAhead()
+
+	if cliCtx.IsSet(utils.ErigondbDomainStepsInFrozenFileFlag.Name) {
+		s := cliCtx.String(utils.ErigondbDomainStepsInFrozenFileFlag.Name)
+		var v uint64
+		if strings.EqualFold(s, "inf") {
+			v = config3.UnboundedDomainMerge
+		} else {
+			parsed, perr := strconv.ParseUint(s, 10, 64)
+			if perr != nil || parsed == 0 {
+				return fmt.Errorf("invalid --%s value %q: must be a positive integer or \"Inf\"",
+					utils.ErigondbDomainStepsInFrozenFileFlag.Name, s)
+			}
+			v = parsed
+		}
+		stepsStr := "Inf"
+		if v != config3.UnboundedDomainMerge {
+			stepsStr = fmt.Sprintf("%d", v)
+		}
+		logger.Info("domain merge cap overridden", "steps_in_frozen_file", stepsStr)
+		agg.SetErigondbDomainStepsInFrozenFile(v)
+	}
 
 	blockSnapBuildSema := semaphore.NewWeighted(int64(runtime.NumCPU()))
 	agg.SetSnapshotBuildSema(blockSnapBuildSema)

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -273,6 +273,14 @@ func (a *Aggregator) Dirs() datadir.Dirs        { return a.dirs }
 func (a *Aggregator) StepsInFrozenFile() uint64 { return a.stepsInFrozenFile.Load() }
 func (a *Aggregator) Logger() log.Logger        { return a.logger }
 
+// SetErigondbDomainStepsInFrozenFile applies a domain-only merge cap override at runtime.
+// Intended for one-shot tools (e.g. `erigon seg retire`) that construct the aggregator
+// via openAgg and need to override the cap after construction. Must be called before any
+// merge work begins.
+func (a *Aggregator) SetErigondbDomainStepsInFrozenFile(steps uint64) {
+	a.erigondbDomainStepsInFrozenFile = steps
+}
+
 func (a *Aggregator) ForTestReplaceKeysInValues(domain kv.Domain, v bool) {
 	a.d[domain].ReplaceKeysInValues = v
 }


### PR DESCRIPTION
## Summary

Wire the existing `--erigondb.domain.steps-in-frozen-file` flag into two more entry points so the domain-only merge cap can be overridden when running these tools directly:

- **`integration stage_exec`** — registers the flag and applies it via `AggOpts.ErigondbDomainStepsInFrozenFile` when constructing the aggregator singleton.
- **`erigon seg retire`** — registers the flag on the `seg retire` subcommand and applies it via a new `Aggregator.SetErigondbDomainStepsInFrozenFile` runtime setter (the aggregator is constructed via `openAgg` here, so the override is applied post-construction, before any merge work begins).

History/inverted-index merges are unaffected — the flag still only adjusts the domain merge cap, matching the main `erigon` binary's behavior.

Both commits cherry-picked from the `explores_3` exploration branch.

## Test plan
- [x] `make erigon integration` builds clean
- [x] `make lint` reports 0 issues
- [ ] Manual smoke: run `integration stage_exec --erigondb.domain.steps-in-frozen-file=Inf` and `erigon seg retire --erigondb.domain.steps-in-frozen-file=64` against a test datadir, confirm the override-log line fires and merges respect the new cap