### PR TITLE
db/integrity: enable CommitmentRoot check on all .kv files

### DIFF
--- a/db/integrity/commitment_integrity.go
+++ b/db/integrity/commitment_integrity.go
@@ -60,19 +60,27 @@ func CheckCommitmentRoot(ctx context.Context, db kv.TemporalRoDB, br services.Fu
 	defer tx.Rollback()
 	aggTx := state.AggTx(tx)
 	defer aggTx.Close()
-	files := aggTx.Files(kv.CommitmentDomain)
+	allFiles := aggTx.Files(kv.CommitmentDomain)
 	// atm our older files are missing the root due to purification, so this flag can be used to only check the last file
-	onlyCheckLastFile := dbg.EnvBool("CHECK_COMMITMENT_ROOT_ONLY_LAST_FILE", true)
+	onlyCheckLastFile := dbg.EnvBool("CHECK_COMMITMENT_ROOT_ONLY_LAST_FILE", false)
 	// may want to check all files for root key presence, but only recompute for the last file (due to purification)
-	onlyRecomputeLastFile := dbg.EnvBool("CHECK_COMMITMENT_ROOT_ONLY_LAST_FILE_RECOMPUTE", true)
-	if onlyCheckLastFile && len(files) > 0 {
+	onlyRecomputeLastFile := dbg.EnvBool("CHECK_COMMITMENT_ROOT_ONLY_LAST_FILE_RECOMPUTE", false)
+	files := make([]state.VisibleFile, 0, len(allFiles))
+	for _, f := range allFiles {
+		if strings.HasSuffix(f.Fullpath(), ".kv") {
+			files = append(files, f)
+		}
+	}
+	logger.Info("[integrity] CommitmentRoot files discovered", "total", len(allFiles), "kvFiles", len(files), "onlyCheckLastFile", onlyCheckLastFile, "onlyRecomputeLastFile", onlyRecomputeLastFile)
+	if len(files) == 0 {
+		logger.Warn("[integrity] CommitmentRoot: no commitment .kv files found, nothing to check")
+		return nil
+	}
+	if onlyCheckLastFile {
 		files = files[len(files)-1:]
 	}
 	var integrityErr error
 	for i, file := range files {
-		if !strings.HasSuffix(file.Fullpath(), ".kv") {
-			continue
-		}
 		recompute := !onlyRecomputeLastFile || i == len(files)-1
 		err = checkCommitmentRootInFile(ctx, db, br, file, recompute, logger)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Filter `.kv` files before slicing in `CheckCommitmentRoot`, so `onlyCheckLastFile` picks the latest `.kv` instead of whatever `aggTx.Files` returned last (which was often the `.ef`).
- Default `CHECK_COMMITMENT_ROOT_ONLY_LAST_FILE` and `CHECK_COMMITMENT_ROOT_ONLY_LAST_FILE_RECOMPUTE` to `false` so the check now covers all `.kv` files by default.
- Add a discovery log line and a clearer warning when no `.kv` files are present.
- with https://github.com/erigontech/erigon/pull/21026 -- recompute check works fine now; and it is fast enough to do for all kv files

## Test plan
- [ ] `make lint`
- [ ] `make erigon integration`
- [ ] Run `erigon seg integrity --check=CommitmentRoot` against a datadir and confirm all `.kv` files get checked.