### PR TITLE
execution/abi: don't unset Amsterdam in NewSimulatedBackendWithConfig

### DIFF
--- a/execution/abi/bind/backends/simulated.go
+++ b/execution/abi/bind/backends/simulated.go
@@ -29,11 +29,9 @@ import (
 	"time"
 
 	"github.com/holiman/uint256"
-	"github.com/jinzhu/copier"
 
 	ethereum "github.com/erigontech/erigon"
 	"github.com/erigontech/erigon/common"
-	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/common/math"
@@ -97,14 +95,6 @@ type SimulatedBackend struct {
 }
 
 func NewSimulatedBackendWithConfig(t *testing.T, alloc types.GenesisAlloc, config *chain.Config, gasLimit uint64) *SimulatedBackend {
-	if !dbg.Exec3Parallel && config.AmsterdamTime != nil {
-		// Amsterdam required parallel processing
-		// - remove this once all tests pass with parallel as default
-		var copy chain.Config
-		copier.Copy(&copy, config)
-		config.AmsterdamTime = nil
-		config = &copy
-	}
 	genesis := types.Genesis{Config: config, GasLimit: gasLimit, Alloc: alloc}
 	var engine rules.Engine
 	switch {


### PR DESCRIPTION
All tests should pass with parallel as default