### PR TITLE
execution/commitmentdb: copy branch slice returned by `TrieContext.Branch` before sending via channel

### DIFF
--- a/execution/commitment/commitmentdb/commitment_context.go
+++ b/execution/commitment/commitmentdb/commitment_context.go
@@ -793,7 +793,16 @@ func NewTrieContextRo(reader StateReader, stepSize uint64) *TrieContext {
 }
 
 func (sdc *TrieContext) Branch(pref []byte) ([]byte, kv.Step, error) {
-	return sdc.readDomain(kv.CommitmentDomain, pref)
+	enc, step, err := sdc.readDomain(kv.CommitmentDomain, pref)
+	if err != nil {
+		return nil, 0, err
+	}
+	// Branch reads feed Merge(prev,update), branchEncoder/merger internal buffers,
+	// deferred-update queues, and unfoldBranchNode reads. The slice returned by the
+	// underlying state cache / getter aliases shared storage that another goroutine
+	// (concurrent commitment workers) can recycle. Own the bytes at the trie-context
+	// boundary so all downstream consumers are safe.
+	return common.Copy(enc), step, nil
 }
 
 func (sdc *TrieContext) PutBranch(prefix []byte, data []byte, prevData []byte) error {


### PR DESCRIPTION
Closes https://github.com/erigontech/erigon/issues/20945
## Summary

`TrieContext.Branch(prefix)` returns the slice handed back by the underlying `LatestStateReader.Read` / `getter.GetLatest` chain. Inside `db/state/execctx/SharedDomains.GetLatest` that slice can come from `sd.stateCache.Get(domain, k)` — the cache returns a slice into shared storage that another goroutine can recycle. With `--experimental.concurrent-commitment=true`, multiple worker goroutines call into the trie context concurrently; the per-worker `roTx`/`stateReader` chain isolates the *transaction* but not the cache's slice backing.

Branch reads feed:
- `Merge(prev, update)` inside `CollectUpdate`
- `branchEncoder.buf` / `merger.buf` internal buffer reuse
- `DeferredBranchUpdate.prev` queues that survive across many `ctx.Branch` calls
- `unfoldBranchNode` dereferencing the bytes inline

Any of these reaching the recycled slice triggers `SIGSEGV SEGV_MAPERR`. We saw it crash in `binary.bigEndian.Uint16(branch1[0:])` inside `Merge`, in `unfoldBranchNode` at the same `Uint16` site, and even mid-`bytes.Clone` of a caller-side `common.Copy(prev)` (the source page got unmapped/recycled during the copy).

This patch copies once at the trie-context boundary so every downstream consumer owns the bytes. Caller-side copies become unnecessary and the `USE_STATE_CACHE=false` workaround stops being required.

## Repro and validation

Bench: `--experimental.concurrent-commitment=true` on mainnet (snap-arb1).

| config | result |
|---|---|
| baseline (`v3.4.0` and `main`) | SIGSEGV in `Merge` ~3 min after exec start, around block 24,883,672 |
| `+ common.Copy(prev)` in `CollectUpdate` | SIGSEGV moved to `unfoldBranchNode` (read path) |
| `+ common.Copy(data)` in `branchFromCacheOrDB` | SIGSEGV inside the `bytes.Clone` itself (mid-`memmove`) |
| deferred branch updates disabled | SIGSEGV unchanged — same `unfoldBranchNode` site |
| `USE_STATE_CACHE=false` env | clean run; concurrent-commitment leads serial by +25-30 % keys/s |
| **this patch** (`USE_STATE_CACHE=default=true`) | clean run; 110+ batches over 13 + hours past the prior crash boundary, +8-9 % gas/s vs serial-trie B in steady state |

## Test plan

- [x] `make lint` clean
- [x] `make erigon` clean
- [x] `go test ./execution/commitment/...` clean
- [x] `make test-short` clean (222 packages OK, 0 fail)
- [x] mainnet bench on snap-arb1 with `--experimental.concurrent-commitment=true` for 13+ hours past the prior crash boundary