### PR TITLE
db/downloader: preserve writeFile error when cleanup runs

### DIFF
--- a/db/downloader/torrent_files.go
+++ b/db/downloader/torrent_files.go
@@ -82,7 +82,7 @@ func (tf *AtomicTorrentFS) writeFile(name string, r io.Reader) (err error) {
 		}
 		// I wonder if in some circumstances os.Rename can fail but the source file is gone. I doubt
 		// it.
-		err = errors.Join(dir.RemoveFile(f.Name()))
+		err = errors.Join(err, dir.RemoveFile(f.Name()))
 	}()
 	closed := false
 	defer func() {


### PR DESCRIPTION
Preserve the original writeFile failure by joining cleanup removal errors with the existing err, preventing defer-time cleanup from masking earlier write or sync failures.