### PR TITLE
p2p/discover: copy buffer before sending read errors to unhandled

### DIFF
--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -561,8 +561,9 @@ func (t *UDPv4) readLoop(unhandled chan<- ReadPacket) {
 		if err := t.handlePacket(from, buf[:nbytes]); err != nil && unhandled == nil {
 			t.log.Trace("[p2p] Bad discv4 packet", "addr", from, "err", err)
 		} else if err != nil && unhandled != nil {
+			p := ReadPacket{bytes.Clone(buf[:nbytes]), from}
 			select {
-			case unhandled <- ReadPacket{buf[:nbytes], from}:
+			case unhandled <- p:
 			default:
 			}
 		}


### PR DESCRIPTION
This fixes an issue where packets send to the Unhandled channel configured on discv4 could be corrupted when the packet buffer gets reused.