### PR TITLE
execution/execmodule: wire stateCache into canonical UpdateForkChoice

### DIFF
--- a/execution/execmodule/forkchoice.go
+++ b/execution/execmodule/forkchoice.go
@@ -218,6 +218,11 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 	}
 	if currentContext != nil {
 		currentContext.SetInMemHistoryReads(inMemHistoryReads)
+		// Wire the state cache so canonical execution reads benefit from
+		// the per-execution Account/Storage/Code cache. Previously only
+		// ValidateChain (fork validation, exec_module.go) set this, leaving
+		// the canonical execution path running uncached against the aggTx.
+		currentContext.SetStateCache(e.stateCache)
 	}
 
 	defer func() {


### PR DESCRIPTION
## Summary

`SharedDomains.SetStateCache` was only invoked from `ValidateChain` (fork-validation path, [exec_module.go:523](https://github.com/erigontech/erigon/blob/main/execution/execmodule/exec_module.go#L523)). The canonical execution path in `updateForkChoice` constructs its own `SharedDomains` ([forkchoice.go:211](https://github.com/erigontech/erigon/blob/main/execution/execmodule/forkchoice.go#L211)) and runs the staged sync pipeline through it without ever wiring the cache, so every Account/Storage/Code read on the canonical path went straight to `aggTx` (MDBX → snapshot files) uncached.

## Why it was invisible

Hit/miss counters for the `stateCache` layer aren't surfaced in metrics — `sd.metrics.CacheReadCount` only tracks `sd.mem` hits, and `CacheGetCount` is a defined-but-never-incremented field. So a quick glance at `[domain reads]` log lines (`cache=2 puts=8 ... gets=0`) gave no signal that the cache layer wasn't being consulted at all on the canonical path.

A diagnostic log added inside `SetStateCache` confirmed it fired zero times across 611 canonical `engine_newPayloadV4 → engine_forkchoiceUpdatedV3` calls on a perf-devnet-3 cold bench under `EXEC3_PARALLEL=true`.

## Fix

One-line addition in `updateForkChoice` after the existing `SetInMemHistoryReads` call:

```go
currentContext.SetStateCache(e.stateCache)
```

Mirrors what `ValidateChain` does. `SetStateCache` is already gated on `dbg.UseStateCache` and a non-nil cache, so behavior is unchanged when either is false.

## Effect

After the fix, the same cold bench on perf-devnet-3 shows the cache absorbing ~23% of reads on the SSTORE-bloat TEST block, with MDBX read count dropping from 68 to 19 per block. File-read count is essentially unchanged because cache misses still fall through to the snapshot-file path — but the cache is now actually doing its job on the canonical path, which was its design intent.

Correctness preserved: 0 trie-root divergences across the canonical SETUP+TEST sequence.

## Test plan

- [ ] CI green (`make lint`, unit tests)
- [x] perf-devnet-3 cold bench under `EXEC3_PARALLEL=true`: SETUP 610 blocks + TEST block all VALID, 0 divergences
- [x] `[state-cache] SetStateCache enabled on SD` (diagnostic log added during investigation, not part of this PR) confirmed firing 613 times across the bench

🤖 Generated with [Claude Code](https://claude.com/claude-code)