### PR TITLE
[performance] sync claude-code-review and ci-gate workflows with main

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -79,9 +79,13 @@ jobs:
     secrets: inherit
 
   sonar:
-    # SONAR_TOKEN is a repo secret unavailable to fork PRs, so skip the scan
-    # for external contributions to avoid a guaranteed failure in ci-gate.
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
+    # SONAR_TOKEN is a repo secret unavailable to fork PRs and Dependabot PRs
+    # (GitHub withholds non-GITHUB_TOKEN secrets from Dependabot even for same-repo PRs),
+    # so skip the scan for those to avoid a guaranteed failure in ci-gate.
+    if: |
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       github.actor != 'dependabot[bot]') ||
+      github.event_name != 'pull_request'
     uses: ./.github/workflows/sonar.yml
     secrets: inherit
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,9 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    # Skip Dependabot PRs: the action rejects bot actors and CLAUDE_CODE_OAUTH_TOKEN
+    # is not available to Dependabot workflows anyway.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
Cherry-picks #20832 and #20972 from `main` to `performance`.

Required because `anthropics/claude-code-action` validates that the workflow file content on the PR matches the version on the repository's default branch. The `performance` branch lagged on these two updates, so every PR targeting `performance` was failing `claude-review` (and consequently `ci-gate`) — see e.g. failure on #21037: https://github.com/erigontech/erigon/actions/runs/25501768729/job/74836354066

- b3a00272bd build(deps): bump actions/checkout from 4 to 6 (#20832)
- 0d361416d6 ci: skip sonar and claude-review for dependabot PRs (#20972)