### PR TITLE
execution/stagedsync: extract helpers so robustness tests drive production

### DIFF
--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -672,10 +672,8 @@ func (te *txExecutor) executeBlocks(ctx context.Context, startBlockNum uint64, m
 			// if we're in the initialCycle before we consider the blockLimit we need to make sure we keep executing
 			// until we reach a transaction whose commitment which is writable to the db, otherwise the update will get lost
 			var exhausted *ErrLoopExhausted
-			if !initialCycle || lastExecutedStep > 0 && lastExecutedStep > lastFrozenStep && !dbg.DiscardCommitment() {
-				if blockLimit > 0 && blockNum-startBlockNum+1 >= blockLimit && blockNum != maxBlockNum {
-					exhausted = &ErrLoopExhausted{From: startBlockNum, To: blockNum, Reason: "block limit reached"}
-				}
+			if shouldMarkExhaustedAtBlock(initialCycle, lastExecutedStep, lastFrozenStep, dbg.DiscardCommitment(), blockLimit, blockNum, startBlockNum, maxBlockNum) {
+				exhausted = &ErrLoopExhausted{From: startBlockNum, To: blockNum, Reason: "block limit reached"}
 			}
 			var commitCh chan applyResult
 			if len(commitResults) > 0 {
@@ -797,6 +795,45 @@ func computeAndCheckCommitmentV3(ctx context.Context, header *types.Header, appl
 	}
 	return true, times, nil
 
+}
+
+// shouldMarkExhaustedAtBlock decides whether the per-cycle block-limit
+// has been crossed at the current block — which causes executeBlocks to
+// stamp the dispatched blockResult with `Exhausted` and break out of
+// its loop. The exec loop sees the Exhausted flag, fires its
+// partial-batch flush, and the apply loop returns ErrLoopExhausted so
+// the stage loop resumes from the next block.
+//
+// Two gates protect the initial cycle:
+//  1. !initialCycle — later cycles enforce blockLimit unconditionally.
+//  2. On initialCycle, only enforce when we have at least one frozen
+//     step worth of work AND we're not in DiscardCommitment debug mode
+//     (otherwise the partial-batch flush would lose the commitment
+//     that's still pending in sd.mem). See exec3.go's call site for
+//     the historical reasoning.
+//
+// blockNum != maxBlockNum guards against marking the goal block as
+// exhausted — the goal block already triggers a clean reachedMaxBlock
+// exit and shouldn't be relabeled as "more work pending".
+//
+// Pure function so the precedence is unit-testable. See
+// TestShouldMarkExhaustedAtBlock.
+func shouldMarkExhaustedAtBlock(initialCycle bool, lastExecutedStep, lastFrozenStep kv.Step, discardCommitment bool, blockLimit, blockNum, startBlockNum, maxBlockNum uint64) bool {
+	if initialCycle {
+		if !(lastExecutedStep > 0 && lastExecutedStep > lastFrozenStep && !discardCommitment) {
+			return false
+		}
+	}
+	if blockLimit == 0 {
+		return false
+	}
+	if blockNum-startBlockNum+1 < blockLimit {
+		return false
+	}
+	if blockNum == maxBlockNum {
+		return false
+	}
+	return true
 }
 
 func shouldGenerateChangeSets(cfg ExecuteBlockCfg, blockNum, maxBlockNum uint64) bool {

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -676,35 +676,7 @@ func (pe *parallelExecutor) execLoop(ctx context.Context) (err error) {
 	// Note: pe.applyTx is the stageloop's rwTx (externally supplied).
 	// Do NOT rollback it here — the stageloop owns its lifecycle.
 
-	defer func() {
-		// Close channels AFTER the exec loop finishes processing all
-		// blocks. This ensures all blockResults reach the apply loop
-		// and calculator before channels close. executeBlocks does NOT
-		// close channels — it returns from the errgroup after loading
-		// blocks, but the exec loop keeps processing.
-		safeClose := func(ch chan applyResult) {
-			defer func() {
-				// "close of closed channel" panics here are benign — it just means the
-				// channel was already closed by another shutdown path. Recover only that
-				// specific panic and re-raise anything else so real bugs still surface.
-				if rec := recover(); rec != nil {
-					if e, ok := rec.(runtime.Error); ok && strings.Contains(e.Error(), "close of closed channel") {
-						return
-					}
-					panic(rec)
-				}
-			}()
-			close(ch)
-		}
-		if pe.commitResultsCh != nil {
-			safeClose(pe.commitResultsCh)
-			pe.commitResultsCh = nil
-		}
-		if pe.applyResultsCh != nil {
-			safeClose(pe.applyResultsCh)
-			pe.applyResultsCh = nil
-		}
-	}()
+	defer pe.closeApplyChannels()
 	defer func() {
 		// Close the exec loop's own RO tx — prevents leak across batches.
 		if pe.applyTx != nil {
@@ -889,35 +861,12 @@ func (pe *parallelExecutor) execLoop(ctx context.Context) (err error) {
 				// We are inside the `blockResult != nil` branch, so at least one
 				// complete (non-partial) block has been applied in this batch.
 				// That is enough to safely trigger a batch commit on size.
-				if sizeEst > batchLimit {
-					pe.triggerBatchCommitment(ctx)
-					return nil
-				}
-
-				if blockResult.BlockNum >= pe.maxBlockNum {
+				switch execLoopShouldExit(blockResult, sizeEst, batchLimit, pe.maxBlockNum, dbg.StopAfterBlock) {
+				case execLoopExitMaxReached:
 					pe.reachedMaxBlock.Store(true)
 					pe.triggerBatchCommitment(ctx)
 					return nil
-				}
-
-				// executeBlocks marks the final dispatched block with Exhausted
-				// when the per-cycle block limit is reached (on the initial cycle
-				// the limit only kicks in after crossing a step boundary AND when
-				// commitments aren't being discarded — see exec3.go:675; later
-				// cycles enforce it unconditionally). Once that block's result
-				// has been applied,
-				// no further execRequests will arrive — executeBlocks's loop
-				// exited via `break`. Without honoring this signal here, the
-				// exec loop parks forever on its main select waiting for work
-				// the dispatcher will never produce. Closing channels via the
-				// deferred close lets the apply loop return ErrLoopExhausted
-				// so the stage loop resumes from blockResult.BlockNum+1.
-				if blockResult.Exhausted != nil {
-					pe.triggerBatchCommitment(ctx)
-					return nil
-				}
-
-				if dbg.StopAfterBlock > 0 && blockResult.BlockNum >= dbg.StopAfterBlock {
+				case execLoopExitSizeLimit, execLoopExitExhausted, execLoopExitStopAfter:
 					pe.triggerBatchCommitment(ctx)
 					return nil
 				}
@@ -1071,6 +1020,104 @@ func applyLoopMissingBlocks(txResultBlocks, appliedBlocks map[uint64]struct{}) [
 		}
 	}
 	return missing
+}
+
+// execLoopExitDecision is the result of evaluating the exec-loop's
+// per-blockResult exit conditions. Values are ordered by precedence:
+// later conditions only matter if no earlier one fired.
+type execLoopExitDecision int
+
+const (
+	// execLoopContinue: keep processing — no exit condition met.
+	execLoopContinue execLoopExitDecision = iota
+	// execLoopExitSizeLimit: rs.SizeEstimate*Commitment crossed the
+	// configured batch budget; the partial-batch flush path runs.
+	execLoopExitSizeLimit
+	// execLoopExitMaxReached: blockResult.BlockNum >= maxBlockNum;
+	// the caller flips reachedMaxBlock so the apply loop returns
+	// nil (clean batch end) rather than ErrLoopExhausted.
+	execLoopExitMaxReached
+	// execLoopExitExhausted: executeBlocks dispatched its final
+	// blockResult with .Exhausted set (per-cycle block limit hit).
+	// Without honoring this the exec loop parks forever waiting
+	// for work the dispatcher will never produce.
+	execLoopExitExhausted
+	// execLoopExitStopAfter: dbg.StopAfterBlock crossed (debug only).
+	execLoopExitStopAfter
+)
+
+// execLoopShouldExit evaluates the exec-loop's per-blockResult exit
+// decision in priority order. Pure function so the precedence is
+// unit-testable; the production code at exec3_parallel.go around line
+// 864 calls this and dispatches based on the returned decision.
+//
+// Priority order (matches production):
+//  1. sizeEst > batchLimit         (size-limit batch flush — most urgent)
+//  2. blockResult.BlockNum >= max  (clean end — flip reachedMaxBlock)
+//  3. blockResult.Exhausted != nil (per-cycle dispatch limit hit)
+//  4. dbg.StopAfterBlock crossed   (debug-only halt)
+//  5. otherwise execLoopContinue   (schedule next block)
+//
+// Reordering any of these silently changes which exit branch wins when
+// two conditions overlap (e.g. final block of a cycle that also crosses
+// the size limit), which is why the test pins the exact precedence.
+// See TestExecLoopShouldExitPriority.
+func execLoopShouldExit(blockResult *blockResult, sizeEst, batchLimit, maxBlockNum, stopAfterBlock uint64) execLoopExitDecision {
+	if sizeEst > batchLimit {
+		return execLoopExitSizeLimit
+	}
+	if blockResult.BlockNum >= maxBlockNum {
+		return execLoopExitMaxReached
+	}
+	if blockResult.Exhausted != nil {
+		return execLoopExitExhausted
+	}
+	if stopAfterBlock > 0 && blockResult.BlockNum >= stopAfterBlock {
+		return execLoopExitStopAfter
+	}
+	return execLoopContinue
+}
+
+// closeApplyChannels closes the apply-loop-bound channels in the order
+// the calculator and apply loop require: commitResults FIRST so the
+// calculator drains and closes rootResults, then applyResults so the
+// apply loop sees its channel close after the calculator is done. The
+// inverse order would let the apply loop exit while the calculator is
+// still publishing — the trailing commitment write would land on a
+// closed channel and panic.
+//
+// "close of closed channel" panics inside safeClose are benign — it
+// just means the channel was already closed by another shutdown path.
+// Recover only that specific panic and re-raise anything else so real
+// bugs still surface.
+//
+// Returns the names of the channels closed in the order they were
+// closed. The production call site discards this (deferred-call
+// return values are ignored); tests use it to deterministically
+// verify the close order without racing on observer-goroutine
+// wakeups. See TestApplyLoopChannelCloseOrder.
+func (pe *parallelExecutor) closeApplyChannels() (closedOrder []string) {
+	safeClose := func(ch chan applyResult, name string) {
+		defer func() {
+			if rec := recover(); rec != nil {
+				if e, ok := rec.(runtime.Error); ok && strings.Contains(e.Error(), "close of closed channel") {
+					return
+				}
+				panic(rec)
+			}
+		}()
+		close(ch)
+		closedOrder = append(closedOrder, name)
+	}
+	if pe.commitResultsCh != nil {
+		safeClose(pe.commitResultsCh, "commitResults")
+		pe.commitResultsCh = nil
+	}
+	if pe.applyResultsCh != nil {
+		safeClose(pe.applyResultsCh, "applyResults")
+		pe.applyResultsCh = nil
+	}
+	return
 }
 
 // execLoopExitCheck enforces the completeness invariant for the exec

--- a/execution/stagedsync/exec3_parallel_robustness_test.go
+++ b/execution/stagedsync/exec3_parallel_robustness_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/execution/protocol/rules"
 )
 
@@ -440,296 +441,322 @@ func TestApplyLoopPartialBatchReturnsErrLoopExhausted(t *testing.T) {
 	})
 }
 
-// TestApplyLoopChannelCloseOrder exercises the documented invariant
-// that the exec loop closes commitResults BEFORE applyResults on
-// shutdown. The calculator drains commitResults and signals the apply
-// loop via rootResults; if applyResults closes first, the apply loop
-// can race with the calculator's final commitment write.
+// TestApplyLoopChannelCloseOrder exercises the production
+// closeApplyChannels helper to pin the documented close-order
+// invariant: commitResults BEFORE applyResults. The calculator drains
+// commitResults and signals the apply loop via rootResults; if
+// applyResults closes first, the apply loop can race with the
+// calculator's final commitment write.
 //
-// The exec loop's deferred close in execLoop() does the right thing
-// (commitResults first), but the close ordering is load-bearing —
-// changing it silently corrupts the shutdown sequence. This test
-// captures the shape of the deferred close to pin the order down.
+// The test creates a parallelExecutor with mock channels, calls the
+// production helper, and asserts the order via close-detection on each
+// channel. Reordering the closes inside closeApplyChannels — or
+// dropping the helper and inlining a wrong order back into execLoop —
+// surfaces here.
 func TestApplyLoopChannelCloseOrder(t *testing.T) {
-	commitResults := make(chan struct{})
-	applyResults := make(chan struct{})
-
-	closeOrder := make(chan string, 2)
-
-	// Mimic execLoop's deferred close: commitResults first, then
-	// applyResults.
-	closeBoth := func() {
-		close(commitResults)
-		closeOrder <- "commitResults"
-		close(applyResults)
-		closeOrder <- "applyResults"
+	commit := make(chan applyResult)
+	apply := make(chan applyResult)
+	pe := &parallelExecutor{
+		commitResultsCh: commit,
+		applyResultsCh:  apply,
 	}
 
-	go closeBoth()
-
-	first := <-closeOrder
-	second := <-closeOrder
-
-	if first != "commitResults" {
-		t.Fatalf("commitResults must close first; got close order [%s, %s]", first, second)
+	// closeApplyChannels' return value records the close sequence
+	// inline as each close() succeeds — no goroutine wakeup races.
+	order := pe.closeApplyChannels()
+	if len(order) != 2 {
+		t.Fatalf("closeApplyChannels must close 2 channels, got order=%v", order)
 	}
-	if second != "applyResults" {
-		t.Fatalf("applyResults must close second; got close order [%s, %s]", first, second)
+	if order[0] != "commitResults" || order[1] != "applyResults" {
+		t.Fatalf("close order must be [commitResults, applyResults]; got %v", order)
 	}
 
-	// Sanity: both channels actually closed.
-	if _, ok := <-commitResults; ok {
-		t.Fatal("commitResults not actually closed")
+	// Sanity: both channels are actually closed (read returns ok=false).
+	if _, ok := <-commit; ok {
+		t.Error("commit channel not actually closed")
 	}
-	if _, ok := <-applyResults; ok {
-		t.Fatal("applyResults not actually closed")
+	if _, ok := <-apply; ok {
+		t.Error("apply channel not actually closed")
+	}
+
+	// pe.commitResultsCh and pe.applyResultsCh must be nil-ed by the
+	// helper so subsequent calls are no-ops rather than double-closes.
+	if pe.commitResultsCh != nil {
+		t.Error("closeApplyChannels must nil commitResultsCh after closing")
+	}
+	if pe.applyResultsCh != nil {
+		t.Error("closeApplyChannels must nil applyResultsCh after closing")
+	}
+
+	// Calling the helper again with already-nil fields must be a no-op,
+	// not a panic, and the returned order must be empty.
+	if order := pe.closeApplyChannels(); len(order) != 0 {
+		t.Errorf("closeApplyChannels on already-nil channels must return empty order, got %v", order)
 	}
 }
 
-// TestExecLoopHonorsBlockResultExhausted is the orchestration counterpart
-// to TestApplyLoopPartialBatchReturnsErrLoopExhausted: the apply-loop
-// side gets the "exhausted" surface right (return ErrLoopExhausted, no
-// false-positive missing-block flag), but only if the exec-loop actually
-// closes the apply channels in the partial-batch case. executeBlocks
-// signals partial-batch completion by setting blockResult.Exhausted on
-// the final dispatched block then exiting its goroutine — without
-// closing pe.execRequests, without cancelling ctx. If the exec loop
-// doesn't react to that signal, it parks on its main select forever
-// (no more dispatched requests, no more rws.ResultCh activity, no
-// ctx.Done) and the apply loop never gets the channel-close signal it
-// needs to return ErrLoopExhausted. Symptom in production: chiado
+// TestCloseApplyChannelsDoubleCloseRecovers ensures the safety-net
+// recover in closeApplyChannels actually catches the
+// "close of closed channel" panic when, e.g., a parallel shutdown path
+// closes the channels before the deferred close fires. After the
+// recover, the closed-order slice should NOT include the channel name
+// (since the close() didn't succeed) but the field should still be
+// nilled so subsequent calls are clean no-ops.
+func TestCloseApplyChannelsDoubleCloseRecovers(t *testing.T) {
+	pe := &parallelExecutor{
+		commitResultsCh: make(chan applyResult),
+		applyResultsCh:  make(chan applyResult),
+	}
+	close(pe.commitResultsCh) // pre-closed by the racing path
+	close(pe.applyResultsCh)
+
+	// Must not panic — the helper's recover catches "close of closed channel".
+	order := pe.closeApplyChannels()
+	if len(order) != 0 {
+		t.Errorf("closeApplyChannels on already-closed channels must NOT count them as freshly closed; got order=%v", order)
+	}
+	if pe.commitResultsCh != nil || pe.applyResultsCh != nil {
+		t.Fatal("closeApplyChannels must nil the fields even on double-close")
+	}
+}
+
+// TestExecLoopShouldExitPriority exercises the production
+// execLoopShouldExit helper directly. Each case pins one branch's
+// precedence; reordering the production helper or dropping a branch
+// makes the corresponding case fail. This replaces the earlier
+// model-based decision-tree test that could drift from production.
+//
+// Production background: executeBlocks marks the final dispatched
+// block with Exhausted when the per-cycle block limit is reached, then
+// exits — without closing pe.execRequests, without cancelling ctx. If
+// execLoopShouldExit doesn't honor that signal the exec loop parks on
+// its main select forever waiting for work the dispatcher will never
+// produce. Symptom in production: chiado
 // `EXEC3_PARALLEL=true ... --sync.loop.block.limit=10_000` parallel
 // exec from block 0 silently hangs at the first step boundary
-// (block 150662 in chiado's case) — a hang masking a wrong-trie-root
-// failure that issue erigon#20711 originally reported as the visible
-// symptom.
-//
-// We can't reach into the real execLoop without spinning up the full
-// parallel executor + workers + calculator (the same constraint
-// TestApplyLoopPartialBatchReturnsErrLoopExhausted documents). Instead
-// the test runs TWO models of the exec loop's blockResult-handling
-// decision tree against an identical channel-orchestration setup:
-//   - "with fix" (post-fix): mirrors the production precedence
-//     including the Exhausted check — must return cleanly.
-//   - "without fix" (pre-fix): same precedence WITHOUT the Exhausted
-//     check — must hang past the timeout, proving the orchestration
-//     scaffolding genuinely surfaces the bug rather than passing
-//     vacuously.
-//
-// This also locks in the precedence ordering: the Exhausted check
-// must fire after maxBlockNum (otherwise the final-block-of-cycle
-// case where both flags happen to be set would mis-flag as "more
-// work pending") and before StopAfterBlock (which is debug-only).
-func TestExecLoopHonorsBlockResultExhausted(t *testing.T) {
+// (block 150662 in chiado's case) — a hang masking the wrong-trie-root
+// failure that issue erigon#20711 reported as the visible symptom.
+func TestExecLoopShouldExitPriority(t *testing.T) {
 	const (
-		dispatched   = 5  // dispatcher emits this many blockResults
-		maxBlockNum  = 99 // far above dispatched — partial batch
 		batchLimit   = uint64(1 << 30)
-		fakeSizeEst  = uint64(1024) // < batchLimit, so sizeEst path doesn't fire
-		stopAfterBlk = uint64(0)    // disabled
+		smallSizeEst = uint64(1024) // < batchLimit
+		bigSizeEst   = uint64(1<<30) + 1
 	)
 
-	type result struct {
-		exitErr      error
-		triggerCount int
-		hung         bool
+	exhaustedSignal := &ErrLoopExhausted{From: 1, To: 5, Reason: "test"}
+
+	cases := []struct {
+		name           string
+		blockNum       uint64
+		exhausted      *ErrLoopExhausted
+		sizeEst        uint64
+		maxBlockNum    uint64
+		stopAfterBlock uint64
+		want           execLoopExitDecision
+	}{
+		{
+			// No exit condition met — keep processing.
+			name: "continue", blockNum: 5, sizeEst: smallSizeEst, maxBlockNum: 99,
+			want: execLoopContinue,
+		},
+		{
+			// Size limit alone — fires regardless of other state.
+			name:     "size limit fires before maxBlockNum",
+			blockNum: 5, sizeEst: bigSizeEst, maxBlockNum: 99,
+			want: execLoopExitSizeLimit,
+		},
+		{
+			// maxBlockNum alone — flag for clean batch end.
+			name:     "maxBlockNum reached",
+			blockNum: 99, sizeEst: smallSizeEst, maxBlockNum: 99,
+			want: execLoopExitMaxReached,
+		},
+		{
+			// Final dispatched block carries Exhausted — partial batch.
+			name:     "Exhausted on partial batch",
+			blockNum: 5, exhausted: exhaustedSignal, sizeEst: smallSizeEst, maxBlockNum: 99,
+			want: execLoopExitExhausted,
+		},
+		{
+			// dbg.StopAfterBlock crossed — debug halt.
+			name:     "stopAfterBlock crossed",
+			blockNum: 7, sizeEst: smallSizeEst, maxBlockNum: 99, stopAfterBlock: 5,
+			want: execLoopExitStopAfter,
+		},
+		{
+			// stopAfterBlock=0 means disabled — must NOT fire.
+			name:     "stopAfterBlock=0 disabled",
+			blockNum: 7, sizeEst: smallSizeEst, maxBlockNum: 99, stopAfterBlock: 0,
+			want: execLoopContinue,
+		},
+		// Precedence: when MULTIPLE conditions overlap, only the
+		// highest-priority one wins. Reordering the helper would flip
+		// these cases.
+		{
+			// Final block of a cycle that ALSO reaches maxBlockNum.
+			// maxBlockNum must win (clean nil return) — Exhausted
+			// would mis-flag the batch as "more work pending".
+			name:     "precedence: maxBlockNum beats Exhausted",
+			blockNum: 99, exhausted: exhaustedSignal, sizeEst: smallSizeEst, maxBlockNum: 99,
+			want: execLoopExitMaxReached,
+		},
+		{
+			// Size limit at the same block that also reached max.
+			// Size limit wins — most urgent (sd.mem is over budget).
+			name:     "precedence: sizeLimit beats maxBlockNum",
+			blockNum: 99, sizeEst: bigSizeEst, maxBlockNum: 99,
+			want: execLoopExitSizeLimit,
+		},
+		{
+			// Exhausted set together with stopAfterBlock crossed.
+			// Exhausted wins — production stops the partial batch
+			// rather than masking it with the debug halt.
+			name:     "precedence: Exhausted beats stopAfterBlock",
+			blockNum: 7, exhausted: exhaustedSignal, sizeEst: smallSizeEst,
+			maxBlockNum: 99, stopAfterBlock: 5,
+			want: execLoopExitExhausted,
+		},
 	}
 
-	// runModel runs `dispatched` blockResults through `model`, with the
-	// last carrying Exhausted. Returns whether `model` exited cleanly,
-	// and how many times the trigger-equivalent fired.
-	runModel := func(model func(br *blockResult, trigger func()) (done bool)) result {
-		br := make(chan *blockResult, dispatched)
-
-		// Dispatcher mirrors executeBlocks's partial-batch exit: send,
-		// return — do NOT close the channel (the production exec loop
-		// owns close ordering).
-		go func() {
-			for i := uint64(1); i <= dispatched; i++ {
-				r := &blockResult{BlockNum: i}
-				if i == dispatched {
-					r.Exhausted = &ErrLoopExhausted{From: 1, To: i, Reason: "block limit reached"}
-				}
-				br <- r
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			br := &blockResult{BlockNum: tc.blockNum, Exhausted: tc.exhausted}
+			got := execLoopShouldExit(br, tc.sizeEst, batchLimit, tc.maxBlockNum, tc.stopAfterBlock)
+			if got != tc.want {
+				t.Fatalf("execLoopShouldExit got %v, want %v", got, tc.want)
 			}
-		}()
-
-		var triggerCount int
-		trigger := func() { triggerCount++ }
-		exited := make(chan error, 1)
-		// Inner ctx lets the goroutine cooperate with the outer timeout
-		// without leaking when the model hangs on <-br. We translate
-		// "exited via ctx" to result.hung — that is the hang signal.
-		// 300ms is plenty for the in-memory channel + closure dispatch
-		// loop to either complete or genuinely block; the outer 500ms
-		// safety net catches the case where the model doesn't even
-		// respect ctx (which would itself be a different bug).
-		ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
-		defer cancel()
-
-		go func() {
-			for {
-				select {
-				case <-ctx.Done():
-					exited <- ctx.Err()
-					return
-				case b := <-br:
-					if model(b, trigger) {
-						exited <- nil
-						return
-					}
-				}
-			}
-		}()
-
-		select {
-		case err := <-exited:
-			if errors.Is(err, context.DeadlineExceeded) {
-				// Model couldn't make progress — only escape was the
-				// inner ctx timeout. That's the hang signal.
-				return result{hung: true, triggerCount: triggerCount}
-			}
-			return result{exitErr: err, triggerCount: triggerCount}
-		case <-time.After(500 * time.Millisecond):
-			// Outer safety net — model didn't even respect ctx. Still a
-			// hang, just a different shape.
-			return result{hung: true, triggerCount: triggerCount}
-		}
+		})
 	}
-
-	// Production decision tree, mirroring exec3_parallel.go's
-	//   if blockResult != nil { ... } block:
-	//     1. sizeEst > batchLimit → trigger + return
-	//     2. blockResult.BlockNum >= maxBlockNum → reachedMaxBlock + trigger + return
-	//     3. blockResult.Exhausted != nil → trigger + return
-	//     4. dbg.StopAfterBlock → trigger + return
-	//     5. fall through to next-block scheduling.
-	withFix := func(b *blockResult, trigger func()) (done bool) {
-		if fakeSizeEst > batchLimit {
-			trigger()
-			return true
-		}
-		if b.BlockNum >= maxBlockNum {
-			trigger()
-			return true
-		}
-		if b.Exhausted != nil {
-			trigger()
-			return true
-		}
-		if stopAfterBlk > 0 && b.BlockNum >= stopAfterBlk {
-			trigger()
-			return true
-		}
-		return false
-	}
-
-	// Pre-fix decision tree: same as withFix but missing the Exhausted
-	// branch — i.e. the production code as it stood when issue #20711
-	// was first reported.
-	withoutFix := func(b *blockResult, trigger func()) (done bool) {
-		if fakeSizeEst > batchLimit {
-			trigger()
-			return true
-		}
-		if b.BlockNum >= maxBlockNum {
-			trigger()
-			return true
-		}
-		if stopAfterBlk > 0 && b.BlockNum >= stopAfterBlk {
-			trigger()
-			return true
-		}
-		return false
-	}
-
-	t.Run("with fix — exec loop returns cleanly on Exhausted", func(t *testing.T) {
-		r := runModel(withFix)
-		if r.hung {
-			t.Fatal("post-fix model hung past timeout — fix is not effective")
-		}
-		if r.exitErr != nil {
-			t.Fatalf("post-fix model exited with %v, want nil", r.exitErr)
-		}
-		if r.triggerCount != 1 {
-			t.Fatalf("post-fix model: triggerBatchCommitment-equivalent must fire exactly once on Exhausted, got %d", r.triggerCount)
-		}
-	})
-
-	t.Run("without fix — exec loop hangs (regression guard)", func(t *testing.T) {
-		r := runModel(withoutFix)
-		if !r.hung {
-			t.Fatalf("pre-fix model did not hang as expected — orchestration scaffolding is wrong; result=%+v", r)
-		}
-		if r.triggerCount != 0 {
-			t.Fatalf("pre-fix model fired trigger %d times — should be 0 because no exit branch matches", r.triggerCount)
-		}
-	})
 }
 
-// TestExecLoopExhaustedOnlySetOnFinalBlock is a guard against future
-// regressions in the dispatcher: blockResult.Exhausted being set on a
-// non-final block would cause the exec loop to drop later blocks that
-// have already been queued. Locks down the precedence: among blocks in
-// flight, only the trailing dispatched block's Exhausted is honored —
-// any earlier Exhausted signal would short-circuit the batch and lose
-// already-scheduled work. This test pins the convention to exec3.go's
-// `if exhausted != nil { break }` after dispatch: the break ensures
-// no later blockResult is produced once Exhausted is set on a
-// dispatched request.
-func TestExecLoopExhaustedOnlySetOnFinalBlock(t *testing.T) {
-	// Simulate executeBlocks' loop: it sets exhausted, dispatches the
-	// blockResult containing it, and breaks out — no further blocks.
-	// Verify the convention: count(Exhausted != nil) == 1 always, and
-	// it's always the last blockResult.
-	type dispatched struct {
-		num       uint64
-		exhausted bool
+// TestShouldMarkExhaustedAtBlock exercises the production
+// shouldMarkExhaustedAtBlock helper directly. The helper is the gate
+// that decides whether executeBlocks stamps a dispatched block with
+// Exhausted; misjudging this either causes the exec loop to park
+// forever (Exhausted not set when it should be) or trims a batch
+// short (set when it shouldn't be).
+//
+// The "only-set-on-final-block" structural property — that
+// executeBlocks runs `if exhausted != nil { break }` immediately
+// after stamping, so no later block is dispatched in the same cycle —
+// is enforced by the explicit `break` at exec3.go's call site rather
+// than by the helper itself; that's a single line of code that can be
+// reasoned about by inspection. This test focuses on the helper's
+// own decision matrix.
+func TestShouldMarkExhaustedAtBlock(t *testing.T) {
+	cases := []struct {
+		name                                             string
+		initialCycle                                     bool
+		lastExecutedStep, lastFrozenStep                 kv.Step
+		discardCommitment                                bool
+		blockLimit, blockNum, startBlockNum, maxBlockNum uint64
+		want                                             bool
+	}{
+		{
+			// Later cycle, blockLimit reached mid-batch — must mark.
+			name:          "later cycle, limit reached",
+			blockLimit:    10,
+			blockNum:      100,
+			startBlockNum: 91, // span = 10 == limit
+			maxBlockNum:   200,
+			want:          true,
+		},
+		{
+			// Later cycle, but landed exactly on maxBlockNum — must NOT
+			// mark (the goal block triggers reachedMaxBlock instead).
+			name:          "later cycle, hit maxBlockNum exactly",
+			blockLimit:    10,
+			blockNum:      100,
+			startBlockNum: 91,
+			maxBlockNum:   100,
+			want:          false,
+		},
+		{
+			// blockLimit == 0 means "no per-cycle limit" — must NOT mark
+			// regardless of how far we've progressed.
+			name:          "blockLimit=0 disabled",
+			blockLimit:    0,
+			blockNum:      100,
+			startBlockNum: 1,
+			maxBlockNum:   200,
+			want:          false,
+		},
+		{
+			// Later cycle, span < limit — keep going.
+			name:          "later cycle, span below limit",
+			blockLimit:    10,
+			blockNum:      95,
+			startBlockNum: 91, // span = 5 < 10
+			maxBlockNum:   200,
+			want:          false,
+		},
+		{
+			// Initial cycle, no frozen progress yet — gate closed.
+			name:             "initial cycle, no step progress",
+			initialCycle:     true,
+			lastExecutedStep: 0,
+			lastFrozenStep:   0,
+			blockLimit:       10,
+			blockNum:         100,
+			startBlockNum:    91,
+			maxBlockNum:      200,
+			want:             false,
+		},
+		{
+			// Initial cycle, lastExecutedStep > lastFrozenStep AND not
+			// DiscardCommitment — gate open, limit reached.
+			name:             "initial cycle, step progressed, limit reached",
+			initialCycle:     true,
+			lastExecutedStep: 5,
+			lastFrozenStep:   3,
+			blockLimit:       10,
+			blockNum:         100,
+			startBlockNum:    91,
+			maxBlockNum:      200,
+			want:             true,
+		},
+		{
+			// Initial cycle, step progressed but DiscardCommitment is
+			// on — gate stays closed (a partial-batch flush would lose
+			// the in-memory commitment).
+			name:              "initial cycle, DiscardCommitment masks step progress",
+			initialCycle:      true,
+			lastExecutedStep:  5,
+			lastFrozenStep:    3,
+			discardCommitment: true,
+			blockLimit:        10,
+			blockNum:          100,
+			startBlockNum:     91,
+			maxBlockNum:       200,
+			want:              false,
+		},
+		{
+			// Initial cycle, lastExecutedStep == lastFrozenStep — no
+			// new committable step yet, gate closed.
+			name:             "initial cycle, step not advanced past frozen",
+			initialCycle:     true,
+			lastExecutedStep: 3,
+			lastFrozenStep:   3,
+			blockLimit:       10,
+			blockNum:         100,
+			startBlockNum:    91,
+			maxBlockNum:      200,
+			want:             false,
+		},
 	}
-	dispatch := func(blocks []dispatched) error {
-		var prevExhausted bool
-		for _, b := range blocks {
-			if prevExhausted {
-				return errors.New("dispatched a block after Exhausted was set — exec loop would drop it")
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldMarkExhaustedAtBlock(
+				tc.initialCycle, tc.lastExecutedStep, tc.lastFrozenStep,
+				tc.discardCommitment,
+				tc.blockLimit, tc.blockNum, tc.startBlockNum, tc.maxBlockNum,
+			)
+			if got != tc.want {
+				t.Fatalf("shouldMarkExhaustedAtBlock got %v, want %v", got, tc.want)
 			}
-			if b.exhausted {
-				prevExhausted = true
-			}
-		}
-		return nil
+		})
 	}
-
-	t.Run("Exhausted only on last block — valid", func(t *testing.T) {
-		err := dispatch([]dispatched{
-			{num: 1, exhausted: false},
-			{num: 2, exhausted: false},
-			{num: 3, exhausted: true},
-		})
-		if err != nil {
-			t.Fatalf("valid case rejected: %v", err)
-		}
-	})
-
-	t.Run("no Exhausted — valid (full-batch path)", func(t *testing.T) {
-		err := dispatch([]dispatched{
-			{num: 1, exhausted: false},
-			{num: 2, exhausted: false},
-		})
-		if err != nil {
-			t.Fatalf("valid case rejected: %v", err)
-		}
-	})
-
-	t.Run("Exhausted mid-stream — invalid (regression guard)", func(t *testing.T) {
-		err := dispatch([]dispatched{
-			{num: 1, exhausted: false},
-			{num: 2, exhausted: true},
-			{num: 3, exhausted: false},
-		})
-		if err == nil {
-			t.Fatal("dispatch convention violated: blockResult emitted after Exhausted")
-		}
-	})
 }
 
 // sameSet compares two slices ignoring order. Used because


### PR DESCRIPTION
Follow-up to #21039 addressing Copilot's review feedback that the new robustness tests were modelling the exec-loop and apply-loop decision trees in local closures — which would let the model drift from production silently.

This PR extracts three pure helpers from the production code and rewires the tests to drive them directly. **No production behaviour change** — the helpers wrap the exact same logic that was inline before.

## Helpers extracted

| Helper | Production call site | What it pins |
|---|---|---|
| `closeApplyChannels` (pe method) | `execLoop` deferred close | commitResults-then-applyResults order |
| `execLoopShouldExit` (pure) | `execLoop` per-blockResult branch | sizeLimit > maxBlockNum > Exhausted > StopAfterBlock precedence |
| `shouldMarkExhaustedAtBlock` (pure) | `executeBlocks` per-cycle limit gate | initial-cycle gates + blockLimit + maxBlockNum guard |

`closeApplyChannels` returns the actual close-order as a string slice — the previous test was racy because observer goroutines could wake up out of order even when the helper closed the channels in the right order; the slice removes that race entirely.

## Tests rewired

* **`TestApplyLoopChannelCloseOrder`** — now calls `pe.closeApplyChannels()` on a real `parallelExecutor` with mock channels and asserts on the returned close-order slice. Also covers double-close recovery and the post-close nil-out.
* **`TestCloseApplyChannelsDoubleCloseRecovers`** — verifies the recover-on-double-close path doesn't count pre-closed channels as freshly closed.
* **`TestExecLoopShouldExitPriority`** — table-driven coverage of each branch, including cross-condition cases (e.g. maxBlockNum AND Exhausted both set on the final block — maxBlockNum must win for the clean reachedMaxBlock path).
* **`TestShouldMarkExhaustedAtBlock`** — table-driven coverage of the initial-cycle gates (\`lastExecutedStep\`/\`lastFrozenStep\`/\`DiscardCommitment\`), the \`blockLimit==0\` disabled case, the span < limit case, and the \`maxBlockNum\` exact-hit no-mark case.

The previous \`TestExecLoopHonorsBlockResultExhausted\` and \`TestExecLoopExhaustedOnlySetOnFinalBlock\` tests are removed — both are subsumed by the new \`TestExecLoopShouldExitPriority\` and \`TestShouldMarkExhaustedAtBlock\` cases that drive production code.

## Test plan

- [x] All four new tests pass: \`TestApplyLoopChannelCloseOrder\`, \`TestCloseApplyChannelsDoubleCloseRecovers\`, \`TestExecLoopShouldExitPriority\`, \`TestShouldMarkExhaustedAtBlock\`
- [x] Existing tests in the same file (\`TestApplyLoopMissingBlocks\`, \`TestExecLoopExitCheck\`, \`TestApplyLoopRootResultsCloseDoesNotRace\`, etc.) still pass
- [x] \`make lint\` clean
- [x] No production behaviour change (\`go build ./...\` clean)

## Stack

Stacked on #21039 (the apply-loop fix). Both should land together — this PR alone doesn't make sense without #21039's helper-using tests as context.