### PR TITLE
db/version: default snapshot git branch to performance

### DIFF
--- a/db/version/app.go
+++ b/db/version/app.go
@@ -33,7 +33,7 @@ const (
 	Minor                    = 5             // Minor version component of the current release
 	Micro                    = 0             // Patch version component of the current release
 	Modifier                 = "dev"         // Modifier component of the current release
-	DefaultSnapshotGitBranch = "release/3.4" // Branch of erigontech/erigon-snapshot to use in OtterSync.
+	DefaultSnapshotGitBranch = "performance" // Branch of erigontech/erigon-snapshot to use in OtterSync.
 	VersionKeyCreated        = "ErigonVersionCreated"
 	VersionKeyFinished       = "ErigonVersionFinished"
 	ClientName               = "erigon"


### PR DESCRIPTION
## Summary
- Point `DefaultSnapshotGitBranch` at the `performance` branch of `erigontech/erigon-snapshot` so `chain.toml` fetches (R2 first, GitHub fallback) hit the performance-track manifests by default on this branch.