### PR TITLE
cl/checkpoint_sync: suppress cancellation noise

### DIFF
--- a/cl/phase1/core/checkpoint_sync/checkpoint_sync_test.go
+++ b/cl/phase1/core/checkpoint_sync/checkpoint_sync_test.go
@@ -90,6 +90,18 @@ func TestRemoteCheckpointSyncTimeout(t *testing.T) {
 	require.True(t, errors.Is(err, context.DeadlineExceeded))
 }
 
+func TestRemoteCheckpointSyncCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	clparams.ConfigurableCheckpointsURLs = []string{"http://127.0.0.1:1"}
+	syncer := NewRemoteCheckpointSync(&clparams.MainnetBeaconConfig, chainspec.MainnetChainID)
+	currentState, err := syncer.GetLatestBeaconState(ctx)
+
+	require.Nil(t, currentState)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 func TestRemoteCheckpointSyncPossiblyAfterTimeout(t *testing.T) {
 	if testing.Short() {
 		t.Skip()

--- a/cl/phase1/core/checkpoint_sync/remote_checkpoint_sync.go
+++ b/cl/phase1/core/checkpoint_sync/remote_checkpoint_sync.go
@@ -60,12 +60,12 @@ func (r *RemoteCheckpointSync) GetLatestBeaconState(ctx context.Context) (*state
 		}
 		marshaled, err := io.ReadAll(resp.Body)
 		if err != nil {
-			return nil, fmt.Errorf("checkpoint sync read failed %s", err)
+			return nil, fmt.Errorf("checkpoint sync read failed: %w", err)
 		}
 
 		slot, err := utils.ExtractSlotFromSerializedBeaconState(marshaled)
 		if err != nil {
-			return nil, fmt.Errorf("checkpoint sync read failed %s", err)
+			return nil, fmt.Errorf("checkpoint sync read failed: %w", err)
 		}
 
 		epoch := slot / r.beaconConfig.SlotsPerEpoch
@@ -85,6 +85,9 @@ func (r *RemoteCheckpointSync) GetLatestBeaconState(ctx context.Context) (*state
 		beaconState, err = fetchBeaconState(uri)
 		if err == nil {
 			return beaconState, nil
+		}
+		if errors.Is(err, context.Canceled) {
+			return nil, err
 		}
 		log.Warn("[Checkpoint Sync] Failed to fetch beacon state", "uri", uri, "err", err)
 	}

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -1061,7 +1061,9 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 		go func() {
 			eth1Getter := getters.NewExecutionSnapshotReader(ctx, blockReader, backend.chainDB)
 			if err := caplin1.RunCaplinService(ctx, executionEngine, config.CaplinConfig, dirs, eth1Getter, backend.downloaderClient, creds, segmentsBuildLimiter); err != nil {
-				logger.Error("could not start caplin", "err", err)
+				if !errors.Is(err, context.Canceled) {
+					logger.Error("could not start caplin", "err", err)
+				}
 			}
 			ctxCancel()
 		}()


### PR DESCRIPTION
## Summary

Fixes #12434

Preserves `context.Canceled` through checkpoint sync read failures and returns it without logging the fetch warning.

The Caplin startup goroutine now also skips the shutdown-path error log when the service exits because the shared context was canceled.

