### PR TITLE
cl, downloader: suppress context-canceled warnings on shutdown

### DIFF
--- a/cl/phase1/core/checkpoint_sync/remote_checkpoint_sync.go
+++ b/cl/phase1/core/checkpoint_sync/remote_checkpoint_sync.go
@@ -86,6 +86,9 @@ func (r *RemoteCheckpointSync) GetLatestBeaconState(ctx context.Context) (*state
 		if err == nil {
 			return beaconState, nil
 		}
+		if errors.Is(err, context.Canceled) {
+			return nil, err
+		}
 		log.Warn("[Checkpoint Sync] Failed to fetch beacon state", "uri", uri, "err", err)
 	}
 	return nil, err

--- a/cl/phase1/core/checkpoint_sync/util.go
+++ b/cl/phase1/core/checkpoint_sync/util.go
@@ -2,6 +2,7 @@ package checkpoint_sync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 
@@ -26,6 +27,9 @@ func ReadOrFetchLatestBeaconState(ctx context.Context, dirs datadir.Dirs, beacon
 		st, err := syncer.GetLatestBeaconState(ctx)
 		if err == nil {
 			return st, nil
+		}
+		if errors.Is(err, context.Canceled) {
+			return nil, err
 		}
 		log.Warn("[Checkpoint Sync] Remote checkpoint sync failed, attempting to read local head state", "err", err)
 

--- a/db/downloader/downloader.go
+++ b/db/downloader/downloader.go
@@ -1129,7 +1129,7 @@ func (d *Downloader) addedFirstDownloader(
 				// Should this error be returned instead?
 				d.log(log.LvlError, "error loading metainfo from disk", "err", err, "name", name)
 			}
-		} else {
+		} else if !errors.Is(err, context.Canceled) {
 			d.log(log.LvlWarn, "error fetching metainfo from webseeds", "err", err, "name", name, "infohash", infoHash)
 		}
 	}


### PR DESCRIPTION
## Summary
- Suppress noisy WARN logs when the user sends Ctrl+C (context canceled is expected, not an error)
- Checkpoint sync: skip the local-state fallback when context is canceled (no point reading disk during shutdown)
- Downloader: skip the webseed fetch warning when context is canceled

## Test plan
- [ ] `make lint` passes
- [ ] Build with `make erigon`
- [ ] Start erigon with checkpoint sync, Ctrl+C during startup → no more `context canceled` WARN lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)