### PR TITLE
Revert "[r3.4] db/state: 4x default step, transparent execution log, no key referencing"

### DIFF
--- a/cmd/integration/commands/flags.go
+++ b/cmd/integration/commands/flags.go
@@ -117,7 +117,7 @@ func withYes(cmd *cobra.Command) {
 }
 
 func withSqueeze(cmd *cobra.Command) {
-	cmd.Flags().BoolVar(&squeeze, "squeeze", false, "use offset-pointers from commitment.kv to account.kv")
+	cmd.Flags().BoolVar(&squeeze, "squeeze", true, "use offset-pointers from commitment.kv to account.kv")
 }
 
 func withClearCommitment(cmd *cobra.Command) {

--- a/db/state/domain_committed.go
+++ b/db/state/domain_committed.go
@@ -35,7 +35,7 @@ import (
 	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
 )
 
-const minStepsForReferencing = 99999
+const minStepsForReferencing = 2
 
 // ValuesPlainKeyReferencingThresholdReached checks if the range from..to is large enough to use plain key referencing
 // Used for commitment branches - to store references to account and storage keys as shortened keys (file offsets)
@@ -43,7 +43,6 @@ func ValuesPlainKeyReferencingThresholdReached(stepSize, from, to uint64) bool {
 	return ((to-from)/stepSize)%minStepsForReferencing == 0
 }
 
-// Values can use key referencing in this range?
 func MayContainValuesPlainKeyReferencing(stepSize, from, to uint64) bool {
 	return ((to - from) / stepSize) > minStepsForReferencing
 }

--- a/db/state/squeeze.go
+++ b/db/state/squeeze.go
@@ -887,7 +887,8 @@ func RebuildCommitmentFiles(ctx context.Context, rwDb kv.TemporalRwDB, txNumsRea
 		stepsInShard := uint64(shardTo - shardFrom)
 		keysPerStep := totalKeys / stepsInShard // how many keys in just one step?
 
-		shardStepsSize := kv.Step(min(uint64(math.Pow(2, math.Log2(float64(stepsInShard)))), 64))
+		// shardStepsSize := kv.Step(2)
+		shardStepsSize := kv.Step(min(uint64(math.Pow(2, math.Log2(float64(stepsInShard)))), 16))
 		if uint64(shardStepsSize) != stepsInShard { // processing shard in several smaller steps
 			shardTo = shardFrom + shardStepsSize // if shard is quite big, we will process it in several steps
 		}
@@ -1026,14 +1027,14 @@ func RebuildCommitmentFiles(ctx context.Context, rwDb kv.TemporalRwDB, txNumsRea
 
 	acRo.Close()
 
-	if !squeeze {
+	if !squeeze && !statecfg.Schema.CommitmentDomain.ReplaceKeysInValues {
 		return latestRoot, nil
 	}
 	logger.Info("[squeeze] starting")
 	a.recalcVisibleFiles(a.dirtyFilesEndTxNumMinimax())
 
 	logger.Info(fmt.Sprintf("[squeeze] latest root %x", latestRoot))
-	a.ForTestReplaceKeysInValues(kv.CommitmentDomain, squeeze)
+	a.ForTestReplaceKeysInValues(kv.CommitmentDomain, true)
 
 	actx := a.BeginFilesRo()
 	defer actx.Close()

--- a/db/state/statecfg/state_schema.go
+++ b/db/state/statecfg/state_schema.go
@@ -73,7 +73,7 @@ func Configure(Schema SchemaGen, a AggSetters, dirs datadir.Dirs, salt *uint32, 
 	return nil
 }
 
-const AggregatorSqueezeCommitmentValues = false
+const AggregatorSqueezeCommitmentValues = true
 const MaxNonFuriousDirtySpacePerTx = 64 * datasize.MB
 
 var dbgCommBtIndex = dbg.EnvBool("AGG_COMMITMENT_BT", false)


### PR DESCRIPTION
Reverts erigontech/erigon#20930
```
go run ./cmd/erigon --datadir ~/data/chiado35_minimal/ --chain=chiado --prune.mode=minimal
panic: runtime error: slice bounds out of range [20:3]

goroutine 126 [running]:
github.com/erigontech/erigon/execution/commitment.(*cell).hashStorageKey(...)
    /home/alex/projects/erigon/execution/commitment/hex_patricia_hashed.go:283
github.com/erigontech/erigon/execution/commitment.(*cell).deriveHashedKeys(0x4251ff67980, 0x44, {0x381ac40, 0x42506b53080}, 0x14, {0x4252003a6a8, 0x20, 0x20})
    /home/alex/projects/erigon/execution/commitment/hex_patricia_hashed.go:481 +0x336
github.com/erigontech/erigon/execution/commitment.(*HexPatriciaHashed).unfoldBranchNode(0x4251ff56000, 0x9, 0x44, 0x0)
    /home/alex/projects/erigon/execution/commitment/hex_patricia_hashed.go:1827 +0x629
```