### PR TITLE
[r3.4] db/version: bump version to 3.4.1

### DIFF
--- a/db/version/app.go
+++ b/db/version/app.go
@@ -31,7 +31,7 @@ var (
 const (
 	Major                    = 3             // Major version component of the current release
 	Minor                    = 4             // Minor version component of the current release
-	Micro                    = 0             // Patch version component of the current release
+	Micro                    = 1             // Patch version component of the current release
 	Modifier                 = ""            // Modifier component of the current release
 	DefaultSnapshotGitBranch = "release/3.4" // Branch of erigontech/erigon-snapshot to use in OtterSync.
 	VersionKeyCreated        = "ErigonVersionCreated"


### PR DESCRIPTION
## Summary
- Bumps `Micro` version from 0 → 1, making the release version `3.4.1`