### PR TITLE
db/state: serialize Aggregator.Set*Workers to fix race with collate (blocks #21039 CI)

### DIFF
--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -86,7 +86,19 @@ type Aggregator struct {
 	disableHistory         bool
 	collateAndBuildWorkers int  // minimize amount of background workers by default
 	mergeWorkers           int  // usually 1
-	lockWorkersEditing     bool // allow changing #workers for merge/collate/build
+	lockWorkersEditing     bool // allow changing #workers for merge/collate/build (read/write under workersMu)
+	// workersMu serializes all Set*Workers writes against each other and
+	// against the LockWorkersEditing/UnlockWorkersEditing toggle. It does
+	// NOT need to be held during long-running operations like buildFiles —
+	// the convention is: long ops set lockWorkersEditing=true (under mu)
+	// before doing concurrent reads of the per-domain CompressorCfg, then
+	// clear it after. Set*Workers acquires mu, checks the flag, and skips
+	// the writes if true. The combination of the mutex (provides
+	// happens-before) and the flag (suppresses writes during reads)
+	// eliminates the data race that the previous implementation tripped
+	// when ExecV3's PresetChainTipConcurrency raced with a background
+	// buildFiles goroutine reading InvertedIndex.CompressorCfg.
+	workersMu sync.Mutex
 
 	// To keep DB small - need move data to small files ASAP.
 	// It means goroutine which creating small files - can't be locked by merge or indexing.
@@ -594,18 +606,24 @@ func (a *Aggregator) closeDirtyFiles() {
 
 func (a *Aggregator) EnableDomain(domain kv.Domain) { a.d[domain].Disable = false }
 func (a *Aggregator) SetCollateAndBuildWorkers(i int) {
+	a.workersMu.Lock()
+	defer a.workersMu.Unlock()
 	if a.lockWorkersEditing {
 		return
 	}
 	a.collateAndBuildWorkers = i
 }
 func (a *Aggregator) SetMergeWorkers(i int) {
+	a.workersMu.Lock()
+	defer a.workersMu.Unlock()
 	if a.lockWorkersEditing {
 		return
 	}
 	a.mergeWorkers = i
 }
 func (a *Aggregator) SetCompressWorkers(i int) {
+	a.workersMu.Lock()
+	defer a.workersMu.Unlock()
 	if a.lockWorkersEditing {
 		return
 	}
@@ -625,6 +643,8 @@ func (a *Aggregator) SetCompressWorkers(i int) {
 }
 
 func (a *Aggregator) SetBuildAccessorsWorkers(i int) {
+	a.workersMu.Lock()
+	defer a.workersMu.Unlock()
 	if a.lockWorkersEditing {
 		return
 	}
@@ -691,8 +711,23 @@ func (a *Aggregator) PresetOfflineExecution() {
 	a.SetMergeWorkers(dbg.MergeWorkers) // compression and accessors: support parallel-building means we don't need multiple `merge_workers` usually
 }
 
-func (a *Aggregator) LockWorkersEditing()   { a.lockWorkersEditing = true }
-func (a *Aggregator) UnlockWorkersEditing() { a.lockWorkersEditing = false }
+// LockWorkersEditing makes subsequent Set*Workers calls a no-op until
+// UnlockWorkersEditing is called. Pair with `defer a.UnlockWorkersEditing()`
+// at the start of any operation that reads per-domain CompressorCfg
+// concurrently with the chain-tip-driven worker reconfiguration in
+// ExecV3 — the toggle prevents Set*Workers from mutating
+// CompressorCfg.Workers under the readers' feet.
+func (a *Aggregator) LockWorkersEditing() {
+	a.workersMu.Lock()
+	defer a.workersMu.Unlock()
+	a.lockWorkersEditing = true
+}
+
+func (a *Aggregator) UnlockWorkersEditing() {
+	a.workersMu.Lock()
+	defer a.workersMu.Unlock()
+	a.lockWorkersEditing = false
+}
 
 func (a *Aggregator) HasBackgroundFilesBuild2() bool {
 	return a.buildingFiles.Load() || a.mergingFiles.Load()
@@ -842,6 +877,14 @@ func (sf AggV3StaticFiles) CleanupOnError() {
 var errStepNotReady = errors.New("step not ready")
 
 func (a *Aggregator) buildFiles(ctx context.Context, step kv.Step) error {
+	// Pin worker counts for the duration of buildFiles. The collate /
+	// build phases below read per-domain/per-II CompressorCfg.Workers
+	// directly (passed by-value into seg.NewCompressor); without this
+	// guard, ExecV3's chain-tip-driven Set*Workers calls would race
+	// with those reads.
+	a.LockWorkersEditing()
+	defer a.UnlockWorkersEditing()
+
 	lastBlockInStep, lastBlockInDB, lastTxInDB, ok, err := a.readyForCollation(ctx, step)
 	if err != nil {
 		return err


### PR DESCRIPTION
> **🚨 Blocks #21039 CI** — the data race this PR fixes is the only reason #21039's `race-tests / execution-other` job fails. #21039 cannot merge until its CI is green, and the only way that happens is for this fix to land first (or be folded in, which would muddy two unrelated PRs). Please prioritise reviewing/merging.

## Summary

Fixes a long-standing data race that the Go race detector flags when a chain-tip `PresetChainTipConcurrency` call from `ExecV3` overlaps with a background `buildFiles` collation. The race is between:

- **Write** in `Aggregator.SetCompressWorkers` ([aggregator.go:623](db/state/aggregator.go#L623)) — `ii.CompressorCfg.Workers = i`
- **Read** in `InvertedIndex.collate` ([inverted_index.go:1003](db/state/inverted_index.go#L1003)) — `seg.NewCompressor(..., ii.CompressorCfg, ...)` reads the cfg by value

Surfaced as a CI failure on PR #21039 (where the race-tests job actually ran):

```
race-tests / tests-linux (ubuntu-latest, execution-other) → TestHistoryVerification_SimpleBlocks
```

## Root cause

`Aggregator.lockWorkersEditing` already existed as a soft-skip flag for `Set*Workers`, but:

1. The bool read/write was unsynchronised — the `if lockWorkersEditing` check could observe a stale `false` while `buildFiles` had just toggled it true, leading to a concurrent `CompressorCfg.Workers = i` write.
2. `LockWorkersEditing` / `UnlockWorkersEditing` were never actually called around `buildFiles` itself.

## Fix

* New `Aggregator.workersMu sync.Mutex`.
* All four `Set*Workers` (Collate/Build, Merge, Compress, BuildAccessors) acquire `workersMu` before the flag-check + write. The combined check+write under the mutex closes the load-then-write race window.
* `LockWorkersEditing` / `UnlockWorkersEditing` acquire `workersMu` around the bool toggle — provides a happens-before edge so any prior `Set*Workers`' write is visible to the `buildFiles` goroutine that subsequently reads `CompressorCfg`, and any concurrent `Set*Workers` blocks briefly until the toggle is observable.
* `Aggregator.buildFiles` wraps its body in `LockWorkersEditing` / `defer UnlockWorkersEditing` so chain-tip-driven `Set*Workers` calls are no-oped for the duration of collation.

## Test plan

- [x] `TestHistoryVerification_SimpleBlocks -race` passes (was the original repro)
- [x] `go test -race -short ./db/state/...` clean (includes the aggregator + state-domain test suites)
- [x] `make lint` clean
- [x] No public-API change beyond making `LockWorkersEditing` / `UnlockWorkersEditing` semantically stronger — they now actually synchronise rather than being a flag with no fence
