### PR TITLE
ci: add discv5 to devp2p Hive shard, bump hive pins

### DIFF
--- a/.github/workflows/hive-versions.json
+++ b/.github/workflows/hive-versions.json
@@ -1,4 +1,4 @@
 {
   "hive_ref": "15750c964cf8dec6f793447ee830f4a483eafcd5",
-  "execution_apis_ref": "8deedf1556015a54404fbfe735a74844715f4011"
+  "execution_apis_ref": "8d6b784cc57047ef10e4044ec2efc1c60950dd7f"
 }

--- a/.github/workflows/hive-versions.json
+++ b/.github/workflows/hive-versions.json
@@ -1,4 +1,4 @@
 {
-  "hive_ref": "02075f473fcf91df834d09b6f3b05b59a530ea61",
+  "hive_ref": "15750c964cf8dec6f793447ee830f4a483eafcd5",
   "execution_apis_ref": "8deedf1556015a54404fbfe735a74844715f4011"
 }

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -40,13 +40,8 @@ jobs:
           - sim: ethereum/rpc-compat
             sim-limit: ".*"
             max-allowed-failures: 0
-          # devp2p/eth: regression guard for eth wire protocol handlers
-          # (GetBlockHeaders skip traversal, BlockRangeUpdate invalid-packet kick,
-          # blob-sidecar commitment check, eth/68 announcement size/type check).
-          # The sibling devp2p suites (snap, discv4, discv5) are intentionally
-          # excluded — they have unrelated pre-existing failures.
           - sim: devp2p
-            sim-limit: eth
+            sim-limit: eth|discv5
             max-allowed-failures: 0
     steps:
       - name: Checkout Erigon meta


### PR DESCRIPTION
Closes #17354

## Summary
- Add `discv5` to the `devp2p` Hive matrix shard (`sim-limit: eth|discv5`)
- Bump `hive_ref` to `ethereum/hive@15750c9`
- Bump `execution_apis_ref` to `ethereum/execution-apis@8d6b784`

## Test plan
- [x] Test Hive workflow dispatched on this branch — https://github.com/erigontech/erigon/actions/runs/25552211034

🤖 Generated with [Claude Code](https://claude.com/claude-code)