### PR TITLE
db/snapcfg: internalize SnapshotSource enum, drop stale TODOs

### DIFF
--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -34,7 +34,6 @@ import (
 	g "github.com/anacrolix/generics"
 	"github.com/anacrolix/missinggo/v2/panicif"
 	"github.com/anacrolix/torrent/metainfo"
-	snapshothashes "github.com/erigontech/erigon-snapshot"
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"
 	"github.com/pelletier/go-toml/v2"
@@ -712,7 +711,7 @@ type hashChange struct{ name, released, local string }
 func doDiffTorrentHashes(ctx context.Context, local map[string]string) error {
 	branch := version.DefaultSnapshotGitBranch
 	url := snapcfg.ChainTomlGitHubURL(branch, chain)
-	body, err := snapcfg.FetchChainToml(ctx, snapshothashes.Github, branch, chain)
+	body, err := snapcfg.FetchChainToml(ctx, snapcfg.Github, branch, chain)
 	if err != nil {
 		return fmt.Errorf("diff: %w", err)
 	}

--- a/db/snapcfg/cdn.go
+++ b/db/snapcfg/cdn.go
@@ -15,8 +15,6 @@ const (
 )
 
 // cloudflareHeaders are required for R2 CDN access.
-// TODO: Copied from github.com/erigontech/erigon-snapshot/embed.go (cloudflareHeaders).
-// Remove the copy in erigon-snapshot once this is the canonical location.
 var cloudflareHeaders = http.Header{
 	"lsjdjwcush6jbnjj3jnjscoscisoc5s": []string{"I%OSJDNFKE783DDHHJD873EFSIVNI7384R78SSJBJBCCJBC32JABBJCBJK45"},
 }

--- a/db/snapcfg/cdn.go
+++ b/db/snapcfg/cdn.go
@@ -6,6 +6,14 @@ import (
 	"net/http"
 )
 
+// SnapshotSource selects which CDN to fetch preverified snapshot TOMLs from.
+type SnapshotSource int
+
+const (
+	Github SnapshotSource = 0
+	R2     SnapshotSource = 1
+)
+
 // cloudflareHeaders are required for R2 CDN access.
 // TODO: Copied from github.com/erigontech/erigon-snapshot/embed.go (cloudflareHeaders).
 // Remove the copy in erigon-snapshot once this is the canonical location.

--- a/db/snapcfg/util.go
+++ b/db/snapcfg/util.go
@@ -529,8 +529,6 @@ func GetEmbeddedWebseeds(chain string) ([]string, bool) {
 const RemotePreverifiedEnvKey = "ERIGON_REMOTE_PREVERIFIED"
 
 // FetchChainToml fetches a single chain's TOML file from the snapshot CDN.
-// TODO: Copied from github.com/erigontech/erigon-snapshot/embed.go (getURLByChain + fetchSnapshotHashes).
-// Remove the copies in erigon-snapshot once this is the canonical location.
 func FetchChainToml(ctx context.Context, source SnapshotSource, branch, chain string) ([]byte, error) {
 	var url string
 	if source == R2 {

--- a/db/snapcfg/util.go
+++ b/db/snapcfg/util.go
@@ -531,9 +531,9 @@ const RemotePreverifiedEnvKey = "ERIGON_REMOTE_PREVERIFIED"
 // FetchChainToml fetches a single chain's TOML file from the snapshot CDN.
 // TODO: Copied from github.com/erigontech/erigon-snapshot/embed.go (getURLByChain + fetchSnapshotHashes).
 // Remove the copies in erigon-snapshot once this is the canonical location.
-func FetchChainToml(ctx context.Context, source snapshothashes.SnapshotSource, branch, chain string) ([]byte, error) {
+func FetchChainToml(ctx context.Context, source SnapshotSource, branch, chain string) ([]byte, error) {
 	var url string
-	if source == snapshothashes.R2 {
+	if source == R2 {
 		url = ChainTomlR2URL(branch, chain)
 	} else {
 		url = ChainTomlGitHubURL(branch, chain)
@@ -542,7 +542,7 @@ func FetchChainToml(ctx context.Context, source snapshothashes.SnapshotSource, b
 	if err != nil {
 		return nil, err
 	}
-	if source == snapshothashes.R2 {
+	if source == R2 {
 		InsertCloudflareHeaders(req)
 	}
 	resp, err := http.DefaultClient.Do(req)
@@ -578,11 +578,11 @@ func LoadRemotePreverified(ctx context.Context, chainName string) error {
 	} else {
 		log.Info("Loading remote snapshot hashes", "chain", chainName)
 
-		hashes, err := FetchChainToml(ctx, snapshothashes.R2, snapshotGitBranch, chainName)
+		hashes, err := FetchChainToml(ctx, R2, snapshotGitBranch, chainName)
 		if err != nil {
 			log.Root().Warn("Failed to load snapshot hashes from R2; falling back to GitHub", "chain", chainName, "err", err)
 
-			hashes, err = FetchChainToml(ctx, snapshothashes.Github, snapshotGitBranch, chainName)
+			hashes, err = FetchChainToml(ctx, Github, snapshotGitBranch, chainName)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Summary
- Define `SnapshotSource` (`Github` / `R2`) locally in `db/snapcfg/cdn.go` alongside the other helpers already mirrored from `erigon-snapshot/embed.go`, and switch `FetchChainToml` + its callers to the local type. `cmd/downloader/main.go` no longer imports `erigontech/erigon-snapshot` at all; `db/snapcfg/util.go` still does for the embedded chain TOMLs and the `webseed` sub-package.
- Drop the two `TODO: Copied from erigon-snapshot/embed.go` markers in `db/snapcfg/cdn.go` and `db/snapcfg/util.go`. The duplicated upstream helpers (`getURLByChain`, `fetchSnapshotHashes`, `cloudflareHeaders`, `insertCloudflareHeaders`) were removed in erigontech/erigon-snapshot#1266 (merged to `release/3.4`); cherry-picks to `main` (erigontech/erigon-snapshot#1267) and `performance` (erigontech/erigon-snapshot#1268) are open.

## Test plan
- [x] `go build ./db/snapcfg/... ./cmd/downloader/...` clean
- [x] `make lint` clean
- [ ] CI green