### PR TITLE
rpc: Fix regression on eth_createAccessList and add mgt ctx.err in loop

### DIFF
--- a/.github/workflows/scripts/run_rpc_tests_ethereum.sh
+++ b/.github/workflows/scripts/run_rpc_tests_ethereum.sh
@@ -45,6 +45,9 @@ DISABLED_TEST_LIST=(
   net_version/test_1.json
   txpool_status/test_1.json
   web3_clientVersion/test_1.json
+  # Temporarily disabled: the following tests hang (possible regression in Erigon).
+  # For debug_traceTransaction, the issue is under analysis.
+  debug_traceTransaction/test_12.json
 )
 
 # Transform the array into a comma-separated string

--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -913,9 +913,10 @@ func (api *APIImpl) CreateAccessList(ctx context.Context, args ethapi2.CallArgs,
 	blockCtx := transactions.NewEVMBlockContext(engine, header, bNrOrHash.RequireCanonical, tx, api._blockReader, chainConfig)
 	precompiles := vm.ActivePrecompiles(blockCtx.Rules(chainConfig))
 	excl := make(map[common.Address]struct{})
-	// Add 'from', 'to', precompiles to the exclusion list
+	// Exclude 'from' and precompiles — they are pre-warmed by EIP-2929.
+	// 'to' is intentionally not excluded: its storage slots must appear in the
+	// access list so they are warmed (EIP-2929 warms the address, not its slots).
 	excl[*args.From] = struct{}{}
-	excl[to] = struct{}{}
 	for _, pc := range precompiles {
 		excl[pc.Value()] = struct{}{}
 	}

--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -956,6 +956,9 @@ func (api *APIImpl) CreateAccessList(ctx context.Context, args ethapi2.CallArgs,
 	}
 
 	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		ibs := state.New(stateReader)
 		// Override the fields of specified contracts before execution.
 		if stateOverrides != nil {

--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -1003,9 +1003,10 @@ func (api *APIImpl) CreateAccessList(ctx context.Context, args ethapi2.CallArgs,
 				errString = res.Err.Error()
 			}
 			accessList := &accessListResult{Accesslist: &accessList, Error: errString, GasUsed: hexutil.Uint64(res.ReceiptGasUsed)}
+			if args.To != nil {
+				optimizeWarmAddrAndAdjustGas(accessList, to)
+			}
 			if optimizeGas != nil && *optimizeGas {
-				optimizeWarmAddrInAccessList(accessList, *args.From)
-				optimizeWarmAddrInAccessList(accessList, to)
 				optimizeWarmAddrInAccessList(accessList, header.Coinbase)
 				for addr := range tracer.CreatedContracts() {
 					if !tracer.UsedBeforeCreation(addr) {
@@ -1047,4 +1048,23 @@ func optimizeWarmAddrInAccessList(accessList *accessListResult, addr common.Addr
 
 func removeIndex(s types.AccessList, index int) types.AccessList {
 	return append(s[:index], s[index+1:]...)
+}
+
+// optimizeWarmAddrAndAdjustGas removes a zero-slot entry for addr from the access list
+// and subtracts TxAccessListAddressGas from GasUsed. Use for the recipient address:
+// EIP-2929 pre-warms it for free, so an address-only entry is pure intrinsic-gas overhead
+// with no EVM benefit. Entries with storage keys are left untouched.
+func optimizeWarmAddrAndAdjustGas(accessList *accessListResult, addr common.Address) {
+	for i, entry := range *accessList.Accesslist {
+		if entry.Address != addr {
+			continue
+		}
+		if len(entry.StorageKeys) == 0 {
+			if uint64(accessList.GasUsed) >= params.TxAccessListAddressGas {
+				accessList.GasUsed -= hexutil.Uint64(params.TxAccessListAddressGas)
+			}
+			*accessList.Accesslist = removeIndex(*accessList.Accesslist, i)
+		}
+		return
+	}
 }

--- a/rpc/jsonrpc/eth_call_test.go
+++ b/rpc/jsonrpc/eth_call_test.go
@@ -822,3 +822,42 @@ func doPrune(t *testing.T, db kv.RwDB, pruneTo uint64) {
 	err = tx.Commit()
 	require.NoError(t, err)
 }
+
+func TestOptimizeWarmAddrAndAdjustGas(t *testing.T) {
+	addr := common.HexToAddress("0xbeefbabeea323f07c59926295205d3b7a17e8638")
+	other := common.HexToAddress("0x0000000000000000000000000000000000000001")
+	slot := common.HexToHash("0x01")
+	const baseGas = hexutil.Uint64(50000)
+
+	t.Run("zero_slots_removed_gas_adjusted", func(t *testing.T) {
+		al := types.AccessList{{Address: addr, StorageKeys: []common.Hash{}}}
+		res := &accessListResult{Accesslist: &al, GasUsed: baseGas}
+		optimizeWarmAddrAndAdjustGas(res, addr)
+		require.Empty(t, *res.Accesslist)
+		require.Equal(t, baseGas-hexutil.Uint64(params.TxAccessListAddressGas), res.GasUsed)
+	})
+
+	t.Run("with_slots_not_removed", func(t *testing.T) {
+		al := types.AccessList{{Address: addr, StorageKeys: []common.Hash{slot}}}
+		res := &accessListResult{Accesslist: &al, GasUsed: baseGas}
+		optimizeWarmAddrAndAdjustGas(res, addr)
+		require.Len(t, *res.Accesslist, 1)
+		require.Equal(t, baseGas, res.GasUsed)
+	})
+
+	t.Run("addr_not_in_list_noop", func(t *testing.T) {
+		al := types.AccessList{{Address: other, StorageKeys: []common.Hash{}}}
+		res := &accessListResult{Accesslist: &al, GasUsed: baseGas}
+		optimizeWarmAddrAndAdjustGas(res, addr)
+		require.Len(t, *res.Accesslist, 1)
+		require.Equal(t, baseGas, res.GasUsed)
+	})
+
+	t.Run("gas_no_underflow", func(t *testing.T) {
+		al := types.AccessList{{Address: addr, StorageKeys: []common.Hash{}}}
+		res := &accessListResult{Accesslist: &al, GasUsed: hexutil.Uint64(100)}
+		optimizeWarmAddrAndAdjustGas(res, addr)
+		require.Empty(t, *res.Accesslist)
+		require.Equal(t, hexutil.Uint64(100), res.GasUsed) // 100 < 2400, no underflow
+	})
+}


### PR DESCRIPTION
This PR contains 2 fixes:
  1. rpc/jsonrpc/eth_call.go — removed excl[to] = struct{}{} → fixes the convergence regression (PR #21036) 
  2. rpc/jsonrpc/eth_call.go — add ctx.Err() check as a protection

Erigon and Geth (historically) share the same behavior. Before the changes in this PR:
* test_15: Entered an infinite loop.
* test_17: Returned OK.

After removing excl[to] = struct{}{}:
* test_15: Is now OK (fixed).
* test_17: Fails.


With the logic implemented in this PR, both tests are now passing.