### PR TITLE
db/snapcfg: vendor erigon-snapshot/webseed inline

### DIFF
--- a/db/downloader/webseeds/verify.go
+++ b/db/downloader/webseeds/verify.go
@@ -44,7 +44,7 @@ func Verify(
 	if dataDir != "" {
 		dirs = datadir.Open(dataDir)
 	}
-	chains := selectChains(targetChain, snapcfg.EmbeddedWebseedsRaw)
+	chains := selectChains(targetChain, snapcfg.EmbeddedWebseeds)
 	if len(chains) == 0 {
 		err = errors.New("no matching chains")
 		return

--- a/db/snapcfg/util.go
+++ b/db/snapcfg/util.go
@@ -32,7 +32,6 @@ import (
 	"sync"
 
 	snapshothashes "github.com/erigontech/erigon-snapshot"
-	"github.com/erigontech/erigon-snapshot/webseed"
 	"github.com/pelletier/go-toml/v2"
 	"github.com/tidwall/btree"
 
@@ -498,32 +497,22 @@ func KnownCfgOrDevnet(networkName string) *Cfg {
 	return cfg
 }
 
-// EmbeddedWebseedsRaw holds the unparsed embedded webseed TOML bytes per chain.
-var EmbeddedWebseedsRaw = map[string][]byte{
-	networkname.Mainnet:  webseed.Mainnet,
-	networkname.Sepolia:  webseed.Sepolia,
-	networkname.Gnosis:   webseed.Gnosis,
-	networkname.Chiado:   webseed.Chiado,
-	networkname.Hoodi:    webseed.Hoodi,
-	networkname.Bloatnet: webseed.Bloatnet,
+// EmbeddedWebseeds holds the public HTTP webseed URLs for each chain. Vendored
+// from erigon-snapshot/webseed, which used to ship one one-key TOML file per
+// chain; the only consumers want the URL list, so the TOML wrapper was dropped.
+var EmbeddedWebseeds = map[string][]string{
+	networkname.Mainnet:  {"v1:https://erigon34-v1-snapshots-mainnet.erigon.network"},
+	networkname.Sepolia:  {"v1:https://erigon34-v1-snapshots-sepolia.erigon.network"},
+	networkname.Gnosis:   {"v1:https://erigon34-v1-snapshots-gnosis.erigon.network"},
+	networkname.Chiado:   {"v1:https://erigon34-v1-snapshots-chiado.erigon.network"},
+	networkname.Hoodi:    {"v1:https://erigon34-v1-snapshots-hoodi.erigon.network"},
+	networkname.Bloatnet: {"v1:https://erigon34-v1-snapshots-bloatnet.erigon.network"},
 }
 
-// GetEmbeddedWebseeds parses and returns the webseed URLs for a single chain.
+// GetEmbeddedWebseeds returns the webseed URLs for a single chain.
 func GetEmbeddedWebseeds(chain string) ([]string, bool) {
-	raw, ok := EmbeddedWebseedsRaw[chain]
-	if !ok {
-		return nil, false
-	}
-	a := map[string]string{}
-	if err := toml.Unmarshal(raw, &a); err != nil {
-		panic(err)
-	}
-	res := make([]string, 0, len(a))
-	for _, l := range a {
-		res = append(res, l)
-	}
-	slices.Sort(res)
-	return res, true
+	s, ok := EmbeddedWebseeds[chain]
+	return s, ok
 }
 
 const RemotePreverifiedEnvKey = "ERIGON_REMOTE_PREVERIFIED"


### PR DESCRIPTION
The erigon binary is the only place that uses erigon-snapshot/webseed, hence updating webseeds require updating the erigon-snapshot repo and updating the go.mod on the erigon side.

This PR internalizes those settings simplifying the process of updating it.

This is one more small step towards removing the dependency of erigon to erigon-snapshot module.

note: E35 still depends on erigon-snapshot/release/3.4, don't remove the webseed stuff there. once this PR gets merged we can remove the webseed stuff on erigon-snapshot on main branch only.