### PR TITLE
db/kv/mdbx: comment on 9K roTxsLimiter target

### DIFF
--- a/db/kv/mdbx/kv_mdbx.go
+++ b/db/kv/mdbx/kv_mdbx.go
@@ -355,6 +355,9 @@ func (opts MdbxOpts) Open(ctx context.Context) (kv.RwDB, error) {
 	}
 
 	if opts.roTxsLimiter == nil {
+		// Golang panics over 10K threads.
+		// RoTx doesn't create thread, but if user's goroutine facing PageFault in RoTx - such goroutine gets out of CPU-bounded-threads-pool (to unlimited-IO-bounded-threads-pool).
+		// So, 9K goroutines can produce 0 new threads (if no PageFaults) - or 9K io-threads (if read only cold data).
 		targetSemCount := int64(9_000)
 		opts.roTxsLimiter = semaphore.NewWeighted(targetSemCount) // 1 less than max to allow unlocking to happen
 	}


### PR DESCRIPTION
Explain why the read-only tx semaphore is sized at 9000:

- Go panics above ~10K OS threads.
- An `RoTx` itself does not spawn a thread, but a goroutine that hits a page fault inside the RoTx moves from the CPU-bounded thread pool to the (unlimited) IO-bounded pool.
- 9K concurrent RoTx goroutines can therefore produce 0 new threads (no faults) or up to 9K IO threads (cold reads).

Comment-only change.