### PR TITLE
Revert "db/version: enforce upper-bound file version check (#20722)"

### DIFF
--- a/db/snaptype2/block_types.go
+++ b/db/snaptype2/block_types.go
@@ -199,7 +199,13 @@ var (
 				if !ok {
 					return fmt.Errorf("can't find files with vers by pattern %s for indexing in bodies", bodiesPathPattern)
 				}
-				statecfg.Schema.BodiesBlock.FileVersion.DataSeg.MustSupport(bVer, filepath.Base(bodiesPath))
+				if bVer.Less(statecfg.Schema.BodiesBlock.FileVersion.DataSeg.MinSupported) {
+					verToPanic := version.Versions{
+						Current:      bVer,
+						MinSupported: statecfg.Schema.BodiesBlock.FileVersion.DataSeg.MinSupported,
+					}
+					version.VersionTooLowPanic(filepath.Base(bodiesPath), verToPanic)
+				}
 				bodiesSegment, err := seg.NewDecompressor(bodiesPath)
 				if err != nil {
 					return fmt.Errorf("can't open %s for indexing in bodies: %w", sn.As(Bodies).Path, err)
@@ -222,7 +228,13 @@ var (
 				if !ok {
 					return fmt.Errorf("can't find files with vers by pattern %s for indexing in txs", txPathPattern)
 				}
-				statecfg.Schema.TransactionsBlock.FileVersion.DataSeg.MustSupport(tVer, filepath.Base(txPath))
+				if tVer.Less(statecfg.Schema.TransactionsBlock.FileVersion.DataSeg.MinSupported) {
+					verToPanic := version.Versions{
+						Current:      tVer,
+						MinSupported: statecfg.Schema.TransactionsBlock.FileVersion.DataSeg.MinSupported,
+					}
+					version.VersionTooLowPanic(filepath.Base(txPath), verToPanic)
+				}
 				d, err := seg.NewDecompressor(txPath)
 				if err != nil {
 					return fmt.Errorf("can't open %s for indexing in transactions: %w", sn.Path, err)

--- a/db/state/dirty_files.go
+++ b/db/state/dirty_files.go
@@ -335,7 +335,7 @@ func (d *Domain) openDirtyFiles(dirEntries []string) (err error) {
 				fNameMask := d.kvFileNameMask(fromStep, toStep)
 				fPath, fileVer, ok, err := version.MatchVersionedFile(fNameMask, dirEntries, d.dirs.SnapDomain)
 				if err != nil {
-					fName := filepath.Base(fPath)
+					_, fName := filepath.Split(fPath)
 					d.logger.Debug("[agg] Domain.openDirtyFiles: FileExist err", "f", fName, "err", err)
 					invalidFileItemsLock.Lock()
 					invalidFileItems = append(invalidFileItems, item)
@@ -351,10 +351,13 @@ func (d *Domain) openDirtyFiles(dirEntries []string) (err error) {
 					continue
 				}
 
-				fName := filepath.Base(fPath)
-				d.FileVersion.DataKV.MustSupport(fileVer, fName)
+				if fileVer.Less(d.FileVersion.DataKV.MinSupported) {
+					_, fName := filepath.Split(fPath)
+					versionTooLowPanic(fName, d.FileVersion.DataKV)
+				}
 
 				if item.decompressor, err = seg.NewDecompressor(fPath); err != nil {
+					_, fName := filepath.Split(fPath)
 					if errors.Is(err, &seg.ErrCompressedFileCorrupted{}) {
 						d.logger.Debug("[agg] Domain.openDirtyFiles", "err", err, "f", fName)
 					} else {
@@ -372,13 +375,16 @@ func (d *Domain) openDirtyFiles(dirEntries []string) (err error) {
 				fNameMask := d.kviAccessorFileNameMask(fromStep, toStep)
 				fPath, fileVer, ok, err := version.MatchVersionedFile(fNameMask, dirEntries, d.dirs.SnapDomain)
 				if err != nil {
-					fName := filepath.Base(fPath)
+					_, fName := filepath.Split(fPath)
 					d.logger.Warn("[agg] Domain.openDirtyFiles", "err", err, "f", fName)
 				}
 				if ok {
-					fName := filepath.Base(fPath)
-					d.FileVersion.AccessorKVI.MustSupport(fileVer, fName)
-					if item.index, err = d.openHashMapAccessor(fPath); err != nil {
+					if fileVer.Less(d.FileVersion.AccessorKVI.MinSupported) {
+						_, fName := filepath.Split(fPath)
+						versionTooLowPanic(fName, d.FileVersion.AccessorKVI)
+					}
+					if item.index, err = recsplit.OpenIndex(fPath); err != nil {
+						_, fName := filepath.Split(fPath)
 						d.logger.Warn("[agg] Domain.openDirtyFiles", "err", err, "f", fName)
 						// don't interrupt on error. other files may be good
 					}
@@ -388,13 +394,16 @@ func (d *Domain) openDirtyFiles(dirEntries []string) (err error) {
 				fNameMask := d.kvBtAccessorFileNameMask(fromStep, toStep)
 				fPath, fileVer, ok, err := version.MatchVersionedFile(fNameMask, dirEntries, d.dirs.SnapDomain)
 				if err != nil {
-					fName := filepath.Base(fPath)
+					_, fName := filepath.Split(fPath)
 					d.logger.Warn("[agg] Domain.openDirtyFiles", "err", err, "f", fName)
 				}
 				if ok {
-					fName := filepath.Base(fPath)
-					d.FileVersion.AccessorBT.MustSupport(fileVer, fName)
+					if fileVer.Less(d.FileVersion.AccessorBT.MinSupported) {
+						_, fName := filepath.Split(fPath)
+						versionTooLowPanic(fName, d.FileVersion.AccessorBT)
+					}
 					if item.bindex, err = btindex.OpenBtreeIndexWithDecompressor(fPath, btindex.DefaultBtreeM, d.dataReader(item.decompressor)); err != nil {
+						_, fName := filepath.Split(fPath)
 						d.logger.Warn("[agg] Domain.openDirtyFiles", "err", err, "f", fName)
 						// don't interrupt on error. other files may be good
 					}
@@ -404,13 +413,16 @@ func (d *Domain) openDirtyFiles(dirEntries []string) (err error) {
 				fNameMask := d.kvExistenceIdxFileNameMask(fromStep, toStep)
 				fPath, fileVer, ok, err := version.MatchVersionedFile(fNameMask, dirEntries, d.dirs.SnapDomain)
 				if err != nil {
-					fName := filepath.Base(fPath)
+					_, fName := filepath.Split(fPath)
 					d.logger.Warn("[agg] Domain.openDirtyFiles", "err", err, "f", fName)
 				}
 				if ok {
-					fName := filepath.Base(fPath)
-					d.FileVersion.AccessorKVEI.MustSupport(fileVer, fName)
+					if fileVer.Less(d.FileVersion.AccessorKVEI.MinSupported) {
+						_, fName := filepath.Split(fPath)
+						versionTooLowPanic(fName, d.FileVersion.AccessorKVEI)
+					}
 					if item.existence, err = existence.OpenFilter(fPath, false); err != nil {
+						_, fName := filepath.Split(fPath)
 						d.logger.Warn("[agg] Domain.openDirtyFiles", "err", err, "f", fName)
 						// don't interrupt on error. other files may be good
 					}
@@ -438,7 +450,7 @@ func (h *History) openDirtyFiles(dataEntries, accessorEntries []string) error {
 				fNameMask := h.vFileNameMask(fromStep, toStep)
 				fPath, fileVer, ok, err := version.MatchVersionedFile(fNameMask, dataEntries, h.dirs.SnapHistory)
 				if err != nil {
-					fName := filepath.Base(fPath)
+					_, fName := filepath.Split(fPath)
 					h.logger.Debug("[agg] History.openDirtyFiles: FileExist", "f", fName, "err", err)
 					invalidFilesMu.Lock()
 					invalidFileItems = append(invalidFileItems, item)
@@ -453,10 +465,13 @@ func (h *History) openDirtyFiles(dataEntries, accessorEntries []string) error {
 					invalidFilesMu.Unlock()
 					continue
 				}
-				fName := filepath.Base(fPath)
-				h.FileVersion.DataV.MustSupport(fileVer, fName)
+				if fileVer.Less(h.FileVersion.DataV.MinSupported) {
+					_, fName := filepath.Split(fPath)
+					versionTooLowPanic(fName, h.FileVersion.DataV)
+				}
 
 				if item.decompressor, err = seg.NewDecompressor(fPath); err != nil {
+					_, fName := filepath.Split(fPath)
 					if errors.Is(err, &seg.ErrCompressedFileCorrupted{}) {
 						h.logger.Debug("[agg] History.openDirtyFiles", "err", err, "f", fName)
 						// TODO we do not restore those files so we could just remove them along with indices. Same for domains/indices.
@@ -487,13 +502,16 @@ func (h *History) openDirtyFiles(dataEntries, accessorEntries []string) error {
 				fNameMask := h.vAccessorFileNameMask(fromStep, toStep)
 				fPath, fileVer, ok, err := version.MatchVersionedFile(fNameMask, accessorEntries, h.dirs.SnapAccessors)
 				if err != nil {
-					fName := filepath.Base(fPath)
+					_, fName := filepath.Split(fPath)
 					h.logger.Warn("[agg] History.openDirtyFiles", "err", err, "f", fName)
 				}
 				if ok {
-					fName := filepath.Base(fPath)
-					h.FileVersion.AccessorVI.MustSupport(fileVer, fName)
+					if fileVer.Less(h.FileVersion.AccessorVI.MinSupported) {
+						_, fName := filepath.Split(fPath)
+						versionTooLowPanic(fName, h.FileVersion.AccessorVI)
+					}
 					if item.index, err = recsplit.OpenIndex(fPath); err != nil {
+						_, fName := filepath.Split(fPath)
 						h.logger.Warn("[agg] History.openDirtyFiles", "err", err, "f", fName)
 						// don't interrupt on error. other files may be good
 					}
@@ -520,7 +538,7 @@ func (ii *InvertedIndex) openDirtyFiles(dataEntries, accessorEntries []string) e
 				fNameMask := ii.efFileNameMask(fromStep, toStep)
 				fPath, fileVer, ok, err := version.MatchVersionedFile(fNameMask, dataEntries, ii.dirs.SnapIdx)
 				if err != nil {
-					fName := filepath.Base(fPath)
+					_, fName := filepath.Split(fPath)
 					ii.logger.Debug("[agg] InvertedIndex.openDirtyFiles: MatchVersionedFile error", "f", fName, "err", err)
 					invalidFileItemsLock.Lock()
 					invalidFileItems = append(invalidFileItems, item)
@@ -537,10 +555,13 @@ func (ii *InvertedIndex) openDirtyFiles(dataEntries, accessorEntries []string) e
 					continue
 				}
 
-				fName := filepath.Base(fPath)
-				ii.FileVersion.DataEF.MustSupport(fileVer, fName)
+				if fileVer.Less(ii.FileVersion.DataEF.MinSupported) {
+					_, fName := filepath.Split(fPath)
+					versionTooLowPanic(fName, ii.FileVersion.DataEF)
+				}
 
 				if item.decompressor, err = seg.NewDecompressor(fPath); err != nil {
+					_, fName := filepath.Split(fPath)
 					if errors.Is(err, &seg.ErrCompressedFileCorrupted{}) {
 						ii.logger.Debug("[agg] InvertedIndex.openDirtyFiles", "err", err, "f", fName)
 					} else {
@@ -558,14 +579,17 @@ func (ii *InvertedIndex) openDirtyFiles(dataEntries, accessorEntries []string) e
 				fNameMask := ii.efAccessorFileNameMask(fromStep, toStep)
 				fPath, fileVer, ok, err := version.MatchVersionedFile(fNameMask, accessorEntries, ii.dirs.SnapAccessors)
 				if err != nil {
-					fName := filepath.Base(fPath)
+					_, fName := filepath.Split(fPath)
 					ii.logger.Warn("[agg] InvertedIndex.openDirtyFiles", "err", err, "f", fName)
 					// don't interrupt on error. other files may be good
 				}
 				if ok {
-					fName := filepath.Base(fPath)
-					ii.FileVersion.AccessorEFI.MustSupport(fileVer, fName)
+					if fileVer.Less(ii.FileVersion.AccessorEFI.MinSupported) {
+						_, fName := filepath.Split(fPath)
+						versionTooLowPanic(fName, ii.FileVersion.AccessorEFI)
+					}
 					if item.index, err = recsplit.OpenIndex(fPath); err != nil {
+						_, fName := filepath.Split(fPath)
 						ii.logger.Warn("[agg] InvertedIndex.openDirtyFiles", "err", err, "f", fName)
 						// don't interrupt on error. other files may be good
 					}

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1979,6 +1979,15 @@ func (dt *DomainRoTx) Files() (res VisibleFiles) {
 }
 func (dt *DomainRoTx) Name() kv.Domain { return dt.name }
 
+func versionTooLowPanic(filename string, version version.Versions) {
+	panic(fmt.Sprintf(
+		"FileVersion is too low, try to run snapshot reset: `erigon --datadir $DATADIR --chain $CHAIN snapshots reset`. file=%s, min_supported=%s, current=%s",
+		filename,
+		version.MinSupported,
+		version.Current,
+	))
+}
+
 // [startTxNum, endTxNum)
 func (dt *DomainRoTx) TraceKey(ctx context.Context, key []byte, startTxNum, endTxNum uint64, roTx kv.Tx) (stream.U64V, error) {
 	// need to do this first as TraceKey doesn't work if internal seg readers are seeked into different locations

--- a/db/version/file_version.go
+++ b/db/version/file_version.go
@@ -8,11 +8,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 
 	"gopkg.in/yaml.v3"
-
-	"github.com/erigontech/erigon/common/log/v3"
 )
 
 /*
@@ -188,29 +185,6 @@ func (v Versions) Supports(ver Version) bool {
 	return ver.GreaterOrEqual(v.MinSupported) && ver.LessOrEqual(v.Current)
 }
 
-var mustSupportLogOnce sync.Once
-
-// MustSupport panics if ver is outside [MinSupported, Current].
-func (v Versions) MustSupport(ver Version, filename string) {
-	if v.Supports(ver) {
-		return
-	}
-	var msg string
-	if ver.Less(v.MinSupported) {
-		msg = fmt.Sprintf(
-			"Snapshot file is too old for this Erigon build: file=%s, minimum_required=%s. To fix, reset snapshots: `erigon snapshots reset --datadir $DATADIR --chain $CHAIN`",
-			filename, v.MinSupported,
-		)
-	} else {
-		msg = fmt.Sprintf(
-			"Snapshot file is newer than this Erigon build supports: file=%s, highest_supported=<%s. To fix, either upgrade Erigon to a newer release, or align snapshots by command: `erigon snapshots reset --datadir $DATADIR --chain $CHAIN`",
-			filename, ver,
-		)
-	}
-	mustSupportLogOnce.Do(func() { log.Error(msg) })
-	panic(msg)
-}
-
 // FindFilesWithVersionsByPattern return an filepath by pattern
 func FindFilesWithVersionsByPattern(pattern string) (string, Version, bool, error) {
 	matches, err := filepath.Glob(pattern)
@@ -336,4 +310,13 @@ func (v *Version) UnmarshalYAML(node *yaml.Node) error {
 	}
 	*v = ver
 	return nil
+}
+
+func VersionTooLowPanic(filename string, version Versions) {
+	panic(fmt.Sprintf(
+		"FileVersion is too low, try to run snapshot reset: `erigon --datadir $DATADIR --chain $CHAIN snapshots reset`. file=%s, min_supported=%s, current=%s",
+		filename,
+		version.MinSupported,
+		version.Current,
+	))
 }

--- a/db/version/file_version_test.go
+++ b/db/version/file_version_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"strings"
 	"testing"
 )
 
@@ -413,63 +412,6 @@ func TestMatchVersionedFile_DifferentSegAndIdxNames(t *testing.T) {
 	if ok {
 		t.Fatal("expected ok == false for non-existent file type")
 	}
-}
-
-func TestMustSupport(t *testing.T) {
-	supported := Versions{Current: V1_2, MinSupported: V1_1}
-
-	t.Run("in-range does not panic", func(t *testing.T) {
-		for _, ver := range []Version{V1_1, V1_2} {
-			func() {
-				defer func() {
-					if r := recover(); r != nil {
-						t.Errorf("unexpected panic for ver=%s: %v", ver, r)
-					}
-				}()
-				supported.MustSupport(ver, "test.kv")
-			}()
-		}
-	})
-
-	t.Run("too low panics with reset instructions", func(t *testing.T) {
-		defer func() {
-			r := recover()
-			if r == nil {
-				t.Fatal("expected panic for too-low version")
-			}
-			msg, ok := r.(string)
-			if !ok {
-				t.Fatalf("expected string panic, got %T", r)
-			}
-			if !strings.Contains(msg, "too old") || !strings.Contains(msg, "snapshots reset") {
-				t.Errorf("panic message missing remediation hint: %q", msg)
-			}
-			if !strings.Contains(msg, "test.kv") {
-				t.Errorf("panic message missing filename: %q", msg)
-			}
-		}()
-		supported.MustSupport(V1_0, "test.kv")
-	})
-
-	t.Run("too high panics with upgrade instructions", func(t *testing.T) {
-		defer func() {
-			r := recover()
-			if r == nil {
-				t.Fatal("expected panic for too-high version")
-			}
-			msg, ok := r.(string)
-			if !ok {
-				t.Fatalf("expected string panic, got %T", r)
-			}
-			if !strings.Contains(msg, "newer than") || !strings.Contains(msg, "upgrade Erigon") || !strings.Contains(msg, "snapshots reset") {
-				t.Errorf("panic message missing remediation hint: %q", msg)
-			}
-			if !strings.Contains(msg, "test.kv") {
-				t.Errorf("panic message missing filename: %q", msg)
-			}
-		}()
-		supported.MustSupport(V2_0, "test.kv")
-	})
 }
 
 func BenchmarkMatchVersionedFile(b *testing.B) {


### PR DESCRIPTION
- This reverts commit 91088e6edc5d003bbcc307e7469b95196d0a36e5.
- we need to regenerate receipts before re-adding this check back.
- should fix:

```
INFO[05-08|23:29:49.236] adjusting receipt current version to v1.1
EROR[05-08|23:29:49.476] Snapshot file is newer than this Erigon build supports: file=v3.0-receipt.187416-187420.v, highest_supported=<v3.0. To fix, either upgrade Erigon to a newer release, or align snapshots by command: `erigon snapshots reset --datadir $DATADIR --chain $CHAIN`
panic: Snapshot file is newer than this Erigon build supports: file=v3.0-receipt.187416-187420.v, highest_supported=<v3.0. To fix, either upgrade Erigon to a newer release, or align snapshots by command: `erigon snapshots reset --datadir $DATADIR --chain $CHAIN`

goroutine 136 [running]:
github.com/erigontech/erigon/db/version.Versions.MustSupport({{0x1, 0x1}, {0x1, 0x0}}, {0x3, 0x0}, {0xc001c91edf, 0x1c})
        
```

- added issue for adding this check back - https://github.com/erigontech/erigon/issues/21104

