### PR TITLE
engineapi: preallocate NewPayload transactions

### DIFF
--- a/execution/engineapi/engine_server.go
+++ b/execution/engineapi/engine_server.go
@@ -267,7 +267,7 @@ func (s *EngineServer) newPayload(ctx context.Context, req *engine_types.Executi
 	var bloom types.Bloom
 	copy(bloom[:], req.LogsBloom)
 
-	txs := [][]byte{}
+	txs := make([][]byte, 0, len(req.Transactions))
 	for _, transaction := range req.Transactions {
 		txs = append(txs, transaction)
 	}


### PR DESCRIPTION
## Summary

- Preallocate the transaction byte slice in `EngineServer.newPayload`.
- Keep the existing copy loop and payload construction semantics unchanged.