### PR TITLE
cl/forkchoice: key optimistic store by blockRoot

### DIFF
--- a/cl/phase1/forkchoice/on_block.go
+++ b/cl/phase1/forkchoice/on_block.go
@@ -189,21 +189,21 @@ func (f *ForkChoiceStore) OnBlock(ctx context.Context, block *cltypes.SignedBeac
 		case execution_client.PayloadStatusNotValidated:
 			log.Debug("OnBlock: block is not validated yet", "block", common.Hash(blockRoot))
 			// optimistic block candidate
-			if err := f.optimisticStore.AddOptimisticCandidate(block.Block); err != nil {
+			if err := f.optimisticStore.AddOptimisticCandidate(blockRoot, block.Block); err != nil {
 				return fmt.Errorf("failed to add block to optimistic store: %v", err)
 			}
 		case execution_client.PayloadStatusInvalidated:
 			log.Warn("OnBlock: block is invalid", "block", common.Hash(blockRoot), "err", err)
 			f.forkGraph.MarkHeaderAsInvalid(blockRoot)
 			// remove from optimistic candidate
-			if err := f.optimisticStore.InvalidateBlock(block.Block); err != nil {
+			if err := f.optimisticStore.InvalidateBlock(blockRoot, block.Block); err != nil {
 				return fmt.Errorf("failed to remove block from optimistic store: %v", err)
 			}
 			return errors.New("block is invalid")
 		case execution_client.PayloadStatusValidated:
 			log.Trace("OnBlock: block is validated", "block", common.Hash(blockRoot))
 			// remove from optimistic candidate
-			if err := f.optimisticStore.ValidateBlock(block.Block); err != nil {
+			if err := f.optimisticStore.ValidateBlock(blockRoot, block.Block); err != nil {
 				return fmt.Errorf("failed to validate block in optimistic store: %v", err)
 			}
 			f.verifiedExecutionPayload.Add(blockRoot, struct{}{})

--- a/cl/phase1/forkchoice/optimistic/optimistic.go
+++ b/cl/phase1/forkchoice/optimistic/optimistic.go
@@ -22,8 +22,8 @@ import (
 )
 
 type OptimisticStore interface {
-	AddOptimisticCandidate(block *cltypes.BeaconBlock) error
-	ValidateBlock(block *cltypes.BeaconBlock) error
-	InvalidateBlock(block *cltypes.BeaconBlock) error
+	AddOptimisticCandidate(blockRoot common.Hash, block *cltypes.BeaconBlock) error
+	ValidateBlock(blockRoot common.Hash, block *cltypes.BeaconBlock) error
+	InvalidateBlock(blockRoot common.Hash, block *cltypes.BeaconBlock) error
 	IsOptimistic(root common.Hash) bool
 }

--- a/cl/phase1/forkchoice/optimistic/optimistic_impl.go
+++ b/cl/phase1/forkchoice/optimistic/optimistic_impl.go
@@ -38,12 +38,12 @@ type opNode struct {
 	children     []common.Hash
 }
 
-func (impl *optimisticStoreImpl) AddOptimisticCandidate(block *cltypes.BeaconBlock) error {
+func (impl *optimisticStoreImpl) AddOptimisticCandidate(blockRoot common.Hash, block *cltypes.BeaconBlock) error {
 	if block.Body.ExecutionPayload == nil || *block.Body.ExecutionPayload == (cltypes.Eth1Block{}) {
 		return nil
 	}
 
-	root := block.StateRoot
+	root := blockRoot
 	parentRoot := block.ParentRoot
 	impl.opMutex.Lock()
 	defer impl.opMutex.Unlock()
@@ -70,7 +70,7 @@ func (impl *optimisticStoreImpl) AddOptimisticCandidate(block *cltypes.BeaconBlo
 	return nil
 }
 
-func (impl *optimisticStoreImpl) ValidateBlock(block *cltypes.BeaconBlock) error {
+func (impl *optimisticStoreImpl) ValidateBlock(blockRoot common.Hash, block *cltypes.BeaconBlock) error {
 	// When a block transitions from NOT_VALIDATED -> VALID, all ancestors of the block MUST also transition
 	// from NOT_VALIDATED -> VALID. Such a block and any previously NOT_VALIDATED ancestors are no longer considered "optimistically imported".
 	if block.Body.ExecutionPayload == nil || *block.Body.ExecutionPayload == (cltypes.Eth1Block{}) {
@@ -79,7 +79,7 @@ func (impl *optimisticStoreImpl) ValidateBlock(block *cltypes.BeaconBlock) error
 	blockNum := block.Body.ExecutionPayload.BlockNumber
 	impl.opMutex.Lock()
 	defer impl.opMutex.Unlock()
-	curRoot := block.StateRoot
+	curRoot := blockRoot
 	for {
 		if node, ok := impl.optimisticRoots.Load(curRoot); ok {
 			// validate the block
@@ -112,7 +112,7 @@ func (impl *optimisticStoreImpl) ValidateBlock(block *cltypes.BeaconBlock) error
 	return nil
 }
 
-func (impl *optimisticStoreImpl) InvalidateBlock(block *cltypes.BeaconBlock) error {
+func (impl *optimisticStoreImpl) InvalidateBlock(blockRoot common.Hash, block *cltypes.BeaconBlock) error {
 	// When a block transitions from NOT_VALIDATED -> INVALIDATED, all descendants of the block MUST also transition
 	// from NOT_VALIDATED -> INVALIDATED.
 	if block.Body.ExecutionPayload == nil || *block.Body.ExecutionPayload == (cltypes.Eth1Block{}) {
@@ -121,7 +121,7 @@ func (impl *optimisticStoreImpl) InvalidateBlock(block *cltypes.BeaconBlock) err
 	impl.opMutex.Lock()
 	defer impl.opMutex.Unlock()
 	// start from the block to be invalidated, and remove all its descendants
-	toRemoves := []common.Hash{block.StateRoot}
+	toRemoves := []common.Hash{blockRoot}
 	for len(toRemoves) > 0 {
 		curRoot := toRemoves[0]
 		toRemoves = toRemoves[1:]

--- a/cl/phase1/forkchoice/optimistic/optimistic_test.go
+++ b/cl/phase1/forkchoice/optimistic/optimistic_test.go
@@ -26,6 +26,11 @@ import (
 )
 
 var (
+	mockBlock1Root = common.Hash{11}
+	mockBlock2Root = common.Hash{12}
+	mockBlock3Root = common.Hash{13}
+	mockBlock4Root = common.Hash{14}
+
 	// Mock blocks for testing
 	// mock1 -> mock2 -> mock3_1
 	// 	 			  -> mock3_2
@@ -40,7 +45,7 @@ var (
 	}
 	mockBlock2 = &cltypes.BeaconBlock{
 		StateRoot:  common.Hash{2},
-		ParentRoot: common.Hash{1},
+		ParentRoot: mockBlock1Root,
 		Body: &cltypes.BeaconBody{
 			ExecutionPayload: &cltypes.Eth1Block{
 				BlockNumber: 2,
@@ -49,7 +54,7 @@ var (
 	}
 	mockBlock3_1 = &cltypes.BeaconBlock{
 		StateRoot:  common.Hash{3},
-		ParentRoot: common.Hash{2},
+		ParentRoot: mockBlock2Root,
 		Body: &cltypes.BeaconBody{
 			ExecutionPayload: &cltypes.Eth1Block{
 				BlockNumber: 3,
@@ -58,7 +63,7 @@ var (
 	}
 	mockBlock3_2 = &cltypes.BeaconBlock{
 		StateRoot:  common.Hash{4},
-		ParentRoot: common.Hash{2},
+		ParentRoot: mockBlock2Root,
 		Body: &cltypes.BeaconBody{
 			ExecutionPayload: &cltypes.Eth1Block{
 				BlockNumber: 3,
@@ -91,14 +96,14 @@ func checkSyncMapLength(m *sync.Map, length int) bool {
 func (t *optimisticTestSuite) TestAddOptimisticCandidate() {
 
 	// Add an optimistic candidate
-	err := t.opStore.AddOptimisticCandidate(mockBlock1)
+	err := t.opStore.AddOptimisticCandidate(mockBlock1Root, mockBlock1)
 	t.Require().NoError(err)
 	// Add the same optimistic candidate again, expect nothing to happen
-	err = t.opStore.AddOptimisticCandidate(mockBlock1)
+	err = t.opStore.AddOptimisticCandidate(mockBlock1Root, mockBlock1)
 	t.Require().NoError(err)
 	// Check optimisticRoots table
 	t.Require().True(checkSyncMapLength(&t.opStore.optimisticRoots, 1))
-	node, ok := t.opStore.optimisticRoots.Load(mockBlock1.StateRoot)
+	node, ok := t.opStore.optimisticRoots.Load(mockBlock1Root)
 	t.Require().True(ok)
 	t.Require().Equal(&opNode{
 		execBlockNum: mockBlock1.Body.ExecutionPayload.BlockNumber,
@@ -107,18 +112,18 @@ func (t *optimisticTestSuite) TestAddOptimisticCandidate() {
 	}, node)
 
 	// Add a child block
-	err = t.opStore.AddOptimisticCandidate(mockBlock2)
+	err = t.opStore.AddOptimisticCandidate(mockBlock2Root, mockBlock2)
 	t.Require().NoError(err)
 	// check connection between parent and child
 	t.Require().True(checkSyncMapLength(&t.opStore.optimisticRoots, 2))
-	node, ok = t.opStore.optimisticRoots.Load(mockBlock1.StateRoot)
+	node, ok = t.opStore.optimisticRoots.Load(mockBlock1Root)
 	t.Require().True(ok)
 	t.Require().Equal(&opNode{
 		execBlockNum: 1,
 		parent:       common.Hash{0},
-		children:     []common.Hash{{2}},
+		children:     []common.Hash{mockBlock2Root},
 	}, node)
-	node, ok = t.opStore.optimisticRoots.Load(mockBlock2.StateRoot)
+	node, ok = t.opStore.optimisticRoots.Load(mockBlock2Root)
 	t.Require().True(ok)
 	t.Require().Equal(&opNode{
 		execBlockNum: mockBlock2.Body.ExecutionPayload.BlockNumber,
@@ -128,22 +133,25 @@ func (t *optimisticTestSuite) TestAddOptimisticCandidate() {
 }
 
 func (t *optimisticTestSuite) TestValidateBlock() {
-	for _, block := range []*cltypes.BeaconBlock{
-		mockBlock1,
-		mockBlock2,
-		mockBlock3_1,
-		mockBlock3_2,
+	for _, blockWithRoot := range []struct {
+		root  common.Hash
+		block *cltypes.BeaconBlock
+	}{
+		{root: mockBlock1Root, block: mockBlock1},
+		{root: mockBlock2Root, block: mockBlock2},
+		{root: mockBlock3Root, block: mockBlock3_1},
+		{root: mockBlock4Root, block: mockBlock3_2},
 	} {
-		err := t.opStore.AddOptimisticCandidate(block)
+		err := t.opStore.AddOptimisticCandidate(blockWithRoot.root, blockWithRoot.block)
 		t.Require().NoError(err)
 	}
 
 	// Validate the last block
-	err := t.opStore.ValidateBlock(mockBlock3_2)
+	err := t.opStore.ValidateBlock(mockBlock4Root, mockBlock3_2)
 	t.Require().NoError(err)
 	// Check optimisticRoots table
 	t.Require().True(checkSyncMapLength(&t.opStore.optimisticRoots, 1))
-	node, ok := t.opStore.optimisticRoots.Load(mockBlock3_1.StateRoot)
+	node, ok := t.opStore.optimisticRoots.Load(mockBlock3Root)
 	t.Require().True(ok)
 	t.Require().Equal(&opNode{
 		execBlockNum: mockBlock3_1.Body.ExecutionPayload.BlockNumber,
@@ -153,18 +161,21 @@ func (t *optimisticTestSuite) TestValidateBlock() {
 }
 
 func (t *optimisticTestSuite) TestInvalidateBlock() {
-	for _, block := range []*cltypes.BeaconBlock{
-		mockBlock1,
-		mockBlock2,
-		mockBlock3_1,
-		mockBlock3_2,
+	for _, blockWithRoot := range []struct {
+		root  common.Hash
+		block *cltypes.BeaconBlock
+	}{
+		{root: mockBlock1Root, block: mockBlock1},
+		{root: mockBlock2Root, block: mockBlock2},
+		{root: mockBlock3Root, block: mockBlock3_1},
+		{root: mockBlock4Root, block: mockBlock3_2},
 	} {
-		err := t.opStore.AddOptimisticCandidate(block)
+		err := t.opStore.AddOptimisticCandidate(blockWithRoot.root, blockWithRoot.block)
 		t.Require().NoError(err)
 	}
 
 	// Invalidate the first block
-	err := t.opStore.InvalidateBlock(mockBlock1)
+	err := t.opStore.InvalidateBlock(mockBlock1Root, mockBlock1)
 	t.Require().NoError(err)
 	// Check optimisticRoots table
 	t.Require().True(checkSyncMapLength(&t.opStore.optimisticRoots, 0))


### PR DESCRIPTION
This change keys optimistic candidates by blockRoot across add/validate/invalidate, ensuring execution_optimistic checks and parent-child linking use consistent roots.