### PR TITLE
types, vm, dbg: remove unique handles for account keys

### DIFF
--- a/common/dbg/experiments.go
+++ b/common/dbg/experiments.go
@@ -28,7 +28,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"unique"
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/estimate"
@@ -348,7 +347,7 @@ func SaveHeapProfileNearOOMPeriodically(ctx context.Context, opts ...SaveHeapOpt
 var tracedBlocks map[uint64]struct{}
 var traceAllBlocks bool
 var tracedTxIndexes map[int64]struct{}
-var tracedAccounts map[unique.Handle[common.Address]]struct{}
+var tracedAccounts map[common.Address]struct{}
 var traceAllDomains bool
 var tracedDomains map[uint16]struct{}
 
@@ -366,10 +365,10 @@ func initTraceMaps() {
 	for _, index := range TraceTxIndexes {
 		tracedTxIndexes[index] = struct{}{}
 	}
-	tracedAccounts = map[unique.Handle[common.Address]]struct{}{}
+	tracedAccounts = map[common.Address]struct{}{}
 	for _, account := range TraceAccounts {
 		account, _ = strings.CutPrefix(strings.ToLower(account), "Ox")
-		tracedAccounts[unique.Make(common.HexToAddress(account))] = struct{}{}
+		tracedAccounts[common.HexToAddress(account)] = struct{}{}
 	}
 	if len(traceDomains) == 1 &&
 		(strings.EqualFold(traceDomains[0], "all") || strings.EqualFold(traceDomains[0], "any") ||
@@ -438,7 +437,7 @@ func TraceTx(blockNum uint64, txIndex int) bool {
 	return true
 }
 
-func TraceAccount(addr unique.Handle[common.Address]) bool {
+func TraceAccount(addr common.Address) bool {
 	traceInit.Do(initTraceMaps)
 	if len(tracedAccounts) != 0 {
 		_, ok := tracedAccounts[addr]

--- a/execution/abi/bind/backends/simulated.go
+++ b/execution/abi/bind/backends/simulated.go
@@ -879,7 +879,7 @@ func (m callMsg) CheckNonce() bool       { return false }
 func (m callMsg) CheckTransaction() bool { return false }
 func (m callMsg) To() accounts.Address {
 	if m.CallMsg.To == nil {
-		return accounts.NilAddress
+		return accounts.ZeroAddress
 	}
 	return accounts.InternAddress(*m.CallMsg.To)
 }

--- a/execution/exec/txtask.go
+++ b/execution/exec/txtask.go
@@ -191,7 +191,7 @@ func (r *TxResult) CreateReceipt(txIndex int, cumulativeGasUsed uint64, firstLog
 		return nil, err
 	}
 
-	if txMessage != nil && txMessage.To().IsNil() {
+	if txMessage != nil && txMessage.To().IsZero() {
 		txSender, err := r.TxSender()
 		if err != nil {
 			return nil, err

--- a/execution/protocol/block_exec.go
+++ b/execution/protocol/block_exec.go
@@ -293,7 +293,7 @@ func SysCallContractWithBlockContext(contract accounts.Address, data []byte, cha
 func SysCreate(contract accounts.Address, data []byte, chainConfig *chain.Config, ibs *state.IntraBlockState, header *types.Header) (result []byte, err error) {
 	msg := types.NewMessage(
 		contract,
-		accounts.NilAddress, // to
+		accounts.ZeroAddress, // to
 		0, &u256.Num0,
 		SysCallGasLimit,
 		&u256.Num0,

--- a/execution/protocol/state_processor.go
+++ b/execution/protocol/state_processor.go
@@ -173,7 +173,7 @@ func MakeReceipt(
 		receipt.BlobGasUsed = txn.GetBlobGas()
 	}
 	// If the transaction created a contract, store the creation address in the receipt.
-	if msg.To().IsNil() {
+	if msg.To().IsZero() {
 		receipt.ContractAddress = types.CreateAddress(evm.Origin.Value(), txn.GetNonce())
 	}
 	// Set the receipt logs and create a bloom for filtering

--- a/execution/protocol/txn_executor.go
+++ b/execution/protocol/txn_executor.go
@@ -178,7 +178,7 @@ func ApplyFrame(evm *vm.EVM, msg Message, gp *GasPool) (*evmtypes.ExecutionResul
 
 // to returns the recipient of the message.
 func (st *TxnExecutor) to() accounts.Address {
-	if st.msg == nil || st.msg.To().IsNil() /* contract creation */ {
+	if st.msg == nil || st.msg.To().IsZero() {
 		return accounts.ZeroAddress
 	}
 	return st.msg.To()
@@ -369,7 +369,7 @@ func (st *TxnExecutor) ApplyFrame() (*evmtypes.ExecutionResult, error) {
 
 	msg := st.msg
 	sender := msg.From()
-	contractCreation := msg.To().IsNil()
+	contractCreation := msg.To().IsZero()
 	rules := st.evm.ChainRules()
 	vmConfig := st.evm.Config()
 	isEIP3860 := vmConfig.HasEip3860(rules)
@@ -503,7 +503,7 @@ func (st *TxnExecutor) Execute(refunds bool, gasBailout bool) (result *evmtypes.
 
 	msg := st.msg
 	sender := msg.From()
-	contractCreation := msg.To().IsNil()
+	contractCreation := msg.To().IsZero()
 	accessTuples := slices.Clone[types.AccessList](msg.AccessList())
 	auths := msg.Authorizations()
 

--- a/execution/protocol/txn_executor_test.go
+++ b/execution/protocol/txn_executor_test.go
@@ -167,7 +167,7 @@ func TestEIP8037_GasPoolTracksOnlyRegularGas(t *testing.T) {
 	// Initcode = STOP (0x00): creates account, deploys no code.
 	evm1 := newAmsterdamEVM(ibs, blockGasLimit)
 	msg1 := types.NewMessage(
-		sender, accounts.NilAddress, 0, uint256.NewInt(0), 200_000,
+		sender, accounts.ZeroAddress, 0, uint256.NewInt(0), 200_000,
 		uint256.NewInt(0), uint256.NewInt(0), uint256.NewInt(0),
 		[]byte{0x00}, nil,
 		false, // checkNonce

--- a/execution/tests/testutil/transaction_test_util.go
+++ b/execution/tests/testutil/transaction_test_util.go
@@ -85,7 +85,7 @@ func (tt *TransactionTest) Run(chainID *big.Int) error {
 			AuthorizationsLen:  authorizationsLen,
 			AccessListLen:      uint64(len(msg.AccessList())),
 			StorageKeysLen:     uint64(msg.AccessList().StorageKeys()),
-			IsContractCreation: msg.To().IsNil(),
+			IsContractCreation: msg.To().IsZero(),
 			IsEIP2:             rules.IsHomestead,
 			IsEIP2028:          rules.IsIstanbul,
 			IsEIP3860:          rules.IsShanghai,

--- a/execution/types/aa_transaction.go
+++ b/execution/types/aa_transaction.go
@@ -209,7 +209,7 @@ func (tx *AccountAbstractionTransaction) payloadSize() (payloadSize, accessListL
 	payloadSize += rlp.U64Len(tx.Nonce)
 
 	payloadSize++
-	if !tx.SenderAddress.IsNil() {
+	if !tx.SenderAddress.IsZero() {
 		payloadSize += 20
 	}
 
@@ -293,7 +293,7 @@ func (tx *AccountAbstractionTransaction) encodePayload(w io.Writer, b []byte, pa
 	}
 
 	var senderAddress *common.Address
-	if !tx.SenderAddress.IsNil() {
+	if !tx.SenderAddress.IsZero() {
 		senderValue := tx.SenderAddress.Value()
 		senderAddress = &senderValue
 

--- a/execution/types/access_list_tx.go
+++ b/execution/types/access_list_tx.go
@@ -362,7 +362,7 @@ func (tx *AccessListTx) DecodeRLP(s *rlp.Stream) error {
 func (tx *AccessListTx) AsMessage(s Signer, _ *uint256.Int, rules *chain.Rules) (*Message, error) {
 	var txTo accounts.Address
 	if tx.To == nil {
-		txTo = accounts.NilAddress
+		txTo = accounts.ZeroAddress
 	} else {
 		txTo = accounts.InternAddress(*tx.To)
 	}
@@ -462,17 +462,16 @@ func (tx *AccessListTx) GetChainID() *uint256.Int {
 
 func (tx *AccessListTx) cachedSender() (sender accounts.Address, ok bool) {
 	s := tx.from
-	if s.IsNil() {
+	if s.IsZero() {
 		return sender, false
 	}
 	return s, true
 }
 
 func (tx *AccessListTx) Sender(signer Signer) (accounts.Address, error) {
-	if from := tx.from; !from.IsNil() {
-		if !from.IsZero() { // Sender address can never be zero in a transaction with a valid signer
-			return from, nil
-		}
+	if from := tx.from; !from.IsZero() {
+		// Sender address can never be zero in a transaction with a valid signer
+		return from, nil
 	}
 
 	addr, err := signer.Sender(tx)

--- a/execution/types/accounts/key_types.go
+++ b/execution/types/accounts/key_types.go
@@ -18,60 +18,46 @@ package accounts
 
 import (
 	"fmt"
-	"unique"
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/empty"
 )
 
-type Address unique.Handle[common.Address]
+type Address common.Address
 
 var ZeroAddress = InternAddress(common.Address{})
 var NilAddress = Address{}
 
 func InternAddress(a common.Address) Address {
-	return Address(unique.Make(a))
+	return Address(a)
 }
 
 func (a Address) IsNil() bool {
-	return a == NilAddress
+	return false
 }
 
 func (a Address) IsZero() bool {
-	return a == NilAddress || a == ZeroAddress
+	return common.Address(a) == (common.Address{})
 }
 
 func (a Address) Value() common.Address {
-	if a == NilAddress {
-		return common.Address{}
-	}
-	return unique.Handle[common.Address](a).Value()
+	return common.Address(a)
 }
 
-func (a Address) Handle() unique.Handle[common.Address] {
-	return unique.Handle[common.Address](a)
+func (a Address) Handle() common.Address {
+	return a.Value()
 }
 
 func (a Address) String() string {
-	if a == NilAddress {
-		return "<nil>"
-	}
 	return a.Value().String()
 }
 
 func (a Address) Format(s fmt.State, c rune) {
-	if a == NilAddress {
-		s.Write([]byte("<nil>"))
-		return
-	}
 	a.Value().Format(s, c)
 }
 
 // MarshalText returns the hex representation of a.
 func (a Address) MarshalText() ([]byte, error) {
-	if a.IsNil() {
-		return nil, nil
-	}
 	return a.Value().MarshalText()
 }
 
@@ -96,128 +82,73 @@ func (a *Address) UnmarshalJSON(input []byte) error {
 }
 
 func (a Address) Cmp(o Address) int {
-	switch {
-	case a == NilAddress:
-		switch {
-		case o == NilAddress:
-			return 0
-		default:
-			return -1
-		}
-	case o == NilAddress:
-		return +1
-	}
-
 	return a.Value().Cmp(o.Value())
 }
 
-type StorageKey unique.Handle[common.Hash]
+type StorageKey common.Hash
 
 var ZeroKey = InternKey(common.Hash{})
 var NilKey = StorageKey{}
 
 func InternKey(k common.Hash) StorageKey {
-	return StorageKey(unique.Make(k))
+	return StorageKey(k)
 }
 
 func (k StorageKey) IsNil() bool {
-	return k == NilKey
+	return false
 }
 
 func (k StorageKey) Value() common.Hash {
-	if k == NilKey {
-		return common.Hash{}
-	}
-	return unique.Handle[common.Hash](k).Value()
+	return common.Hash(k)
 }
 
 func (k StorageKey) String() string {
-	if k == NilKey {
-		return "<nil>"
-	}
 	return k.Value().String()
 }
 
 func (k StorageKey) Format(s fmt.State, c rune) {
-	if k == NilKey {
-		s.Write([]byte("<nil>"))
-		return
-	}
 	k.Value().Format(s, c)
 }
 
 func (k StorageKey) Cmp(o StorageKey) int {
-	switch {
-	case k == NilKey:
-		switch {
-		case o == NilKey:
-			return 0
-		default:
-			return -1
-		}
-	case o == NilKey:
-		return +1
-	}
-
 	return k.Value().Cmp(o.Value())
 }
 
-type CodeHash unique.Handle[common.Hash]
+type CodeHash common.Hash
 
 var ZeroCodeHash = InternCodeHash(common.Hash{})
 var NilCodeHash = CodeHash{}
 var EmptyCodeHash = InternCodeHash(empty.CodeHash)
 
 func InternCodeHash(k common.Hash) CodeHash {
-	return CodeHash(unique.Make(k))
+	return CodeHash(k)
 }
 
 func (h CodeHash) IsNil() bool {
-	return h == NilCodeHash
+	return false
 }
 
 func (h CodeHash) IsEmpty() bool {
-	return h == EmptyCodeHash || h == ZeroCodeHash || h == NilCodeHash
+	value := common.Hash(h)
+	return value == empty.CodeHash || value == (common.Hash{})
 }
 
 func (h CodeHash) IsZero() bool {
-	return h == NilCodeHash || h == ZeroCodeHash
+	return common.Hash(h) == (common.Hash{})
 }
 
 func (h CodeHash) Value() common.Hash {
-	if h == NilCodeHash {
-		return common.Hash{}
-	}
-	return unique.Handle[common.Hash](h).Value()
+	return common.Hash(h)
 }
 
 func (h CodeHash) String() string {
-	if h == NilCodeHash {
-		return "<nil>"
-	}
 	return h.Value().String()
 }
 
 func (h CodeHash) Format(s fmt.State, c rune) {
-	if h == NilCodeHash {
-		s.Write([]byte("<nil>"))
-		return
-	}
 	h.Value().Format(s, c)
 }
 
 func (h CodeHash) Cmp(o CodeHash) int {
-	switch {
-	case h == NilCodeHash:
-		switch {
-		case o == NilCodeHash:
-			return 0
-		default:
-			return -1
-		}
-	case o == NilCodeHash:
-		return +1
-	}
-
 	return h.Value().Cmp(o.Value())
 }

--- a/execution/types/blob_tx.go
+++ b/execution/types/blob_tx.go
@@ -69,7 +69,7 @@ func (stx *BlobTx) GetBlobGas() uint64 {
 func (stx *BlobTx) AsMessage(s Signer, baseFee *uint256.Int, rules *chain.Rules) (*Message, error) {
 	var stxTo accounts.Address
 	if stx.To == nil {
-		stxTo = accounts.NilAddress
+		stxTo = accounts.ZeroAddress
 	} else {
 		stxTo = accounts.InternAddress(*stx.To)
 	}
@@ -108,14 +108,14 @@ func (stx *BlobTx) AsMessage(s Signer, baseFee *uint256.Int, rules *chain.Rules)
 
 func (stx *BlobTx) cachedSender() (sender accounts.Address, ok bool) {
 	s := stx.from
-	if s.IsNil() {
+	if s.IsZero() {
 		return sender, false
 	}
 	return s, true
 }
 
 func (stx *BlobTx) Sender(signer Signer) (accounts.Address, error) {
-	if from := stx.from; !from.IsNil() && !from.IsZero() {
+	if from := stx.from; !from.IsZero() {
 		// Sender address can never be zero in a transaction with a valid signer
 		return from, nil
 	}

--- a/execution/types/dynamic_fee_tx.go
+++ b/execution/types/dynamic_fee_tx.go
@@ -276,7 +276,7 @@ func (tx *DynamicFeeTransaction) DecodeRLP(s *rlp.Stream) error {
 func (tx *DynamicFeeTransaction) AsMessage(s Signer, baseFee *uint256.Int, rules *chain.Rules) (*Message, error) {
 	var to accounts.Address
 	if tx.To == nil {
-		to = accounts.NilAddress
+		to = accounts.ZeroAddress
 	} else {
 		to = accounts.InternAddress(*tx.To)
 	}
@@ -374,13 +374,13 @@ func (tx *DynamicFeeTransaction) GetChainID() *uint256.Int {
 
 func (tx *DynamicFeeTransaction) cachedSender() (sender accounts.Address, ok bool) {
 	s := tx.from
-	if s.IsNil() {
+	if s.IsZero() {
 		return sender, false
 	}
 	return s, true
 }
 func (tx *DynamicFeeTransaction) Sender(signer Signer) (accounts.Address, error) {
-	if from := tx.from; !from.IsNil() && !from.IsZero() {
+	if from := tx.from; !from.IsZero() {
 		// Sender address can never be zero in a transaction with a valid signer
 		return from, nil
 	}

--- a/execution/types/legacy_tx.go
+++ b/execution/types/legacy_tx.go
@@ -85,7 +85,7 @@ func (ct *CommonTx) GetData() []byte {
 }
 
 func (ct *CommonTx) GetSender() (accounts.Address, bool) {
-	if sc := ct.from; !sc.IsNil() {
+	if sc := ct.from; !sc.IsZero() {
 		return sc, true
 	}
 	return accounts.NilAddress, false
@@ -313,7 +313,7 @@ func (tx *LegacyTx) DecodeRLP(s *rlp.Stream) error {
 func (tx *LegacyTx) AsMessage(s Signer, _ *uint256.Int, _ *chain.Rules) (*Message, error) {
 	var to accounts.Address
 	if tx.To == nil {
-		to = accounts.NilAddress
+		to = accounts.ZeroAddress
 	} else {
 		to = accounts.InternAddress(*tx.To)
 	}
@@ -415,13 +415,13 @@ func (tx *LegacyTx) GetChainID() *uint256.Int {
 
 func (tx *LegacyTx) cachedSender() (sender accounts.Address, ok bool) {
 	s := tx.from
-	if s.IsNil() {
+	if s.IsZero() {
 		return sender, false
 	}
 	return s, true
 }
 func (tx *LegacyTx) Sender(signer Signer) (accounts.Address, error) {
-	if from := tx.from; !from.IsNil() && !from.IsZero() {
+	if from := tx.from; !from.IsZero() {
 		// Sender address can never be zero in a transaction with a valid signer
 		return from, nil
 	}

--- a/execution/types/set_code_tx.go
+++ b/execution/types/set_code_tx.go
@@ -118,7 +118,7 @@ func (tx *SetCodeTransaction) MarshalBinary(w io.Writer) error {
 func (tx *SetCodeTransaction) AsMessage(s Signer, baseFee *uint256.Int, rules *chain.Rules) (*Message, error) {
 	var to accounts.Address
 	if tx.To == nil {
-		to = accounts.NilAddress
+		to = accounts.ZeroAddress
 	} else {
 		to = accounts.InternAddress(*tx.To)
 	}
@@ -160,7 +160,7 @@ func (tx *SetCodeTransaction) AsMessage(s Signer, baseFee *uint256.Int, rules *c
 }
 
 func (tx *SetCodeTransaction) Sender(signer Signer) (accounts.Address, error) {
-	if from := tx.from; !from.IsNil() && !from.IsZero() {
+	if from := tx.from; !from.IsZero() {
 		// Sender address can never be zero in a transaction with a valid signer
 		return from, nil
 	}

--- a/execution/vm/interpreter.go
+++ b/execution/vm/interpreter.go
@@ -62,47 +62,18 @@ type CallContext struct {
 	input    []byte
 	Memory   Memory
 
-	// Opcode-scoped key/address intern cache. cacheGen is incremented once per
-	// opcode dispatch in the interpreter loop; cachedKeyGen/cachedAddrGen hold
-	// the generation at which the entry was populated. An entry is valid only
-	// when its gen equals cacheGen, giving the gas phase and execute phase of
-	// the same opcode a shared interned value without a second unique.Make call.
-	// Placed before Stack so these fields stay in L1D rather than being pushed
-	// out by Stack.data (32 KB).
-	cacheGen      uint64
-	cachedKeyGen  uint64
-	cachedAddrGen uint64
-	cachedKey     accounts.StorageKey
-	cachedAddr    accounts.Address
-
 	Stack    Stack
 	Contract Contract
 }
 
 // peekStorageKey returns the top-of-stack value as an interned StorageKey.
-// The result is cached for the lifetime of one opcode dispatch (gas phase +
-// execute phase share the same cacheGen), so unique.Make is called at most
-// once per opcode. Callers must invoke this before any stack mutation
-// (pop/push/swap) within the same dispatch — the cache is keyed by generation
-// only and will not detect a changed stack top within the same opcode.
 func (ctx *CallContext) peekStorageKey() accounts.StorageKey {
-	if ctx.cachedKeyGen == ctx.cacheGen {
-		return ctx.cachedKey
-	}
-	ctx.cachedKey = accounts.InternKey(ctx.Stack.peek().Bytes32())
-	ctx.cachedKeyGen = ctx.cacheGen
-	return ctx.cachedKey
+	return accounts.InternKey(ctx.Stack.peek().Bytes32())
 }
 
 // peekAddress returns the top-of-stack value as an interned Address.
-// Cached like peekStorageKey; same constraint: call before any stack mutation.
 func (ctx *CallContext) peekAddress() accounts.Address {
-	if ctx.cachedAddrGen == ctx.cacheGen {
-		return ctx.cachedAddr
-	}
-	ctx.cachedAddr = accounts.InternAddress(ctx.Stack.peek().Bytes20())
-	ctx.cachedAddrGen = ctx.cacheGen
-	return ctx.cachedAddr
+	return accounts.InternAddress(ctx.Stack.peek().Bytes20())
 }
 
 var contextPool = sync.Pool{
@@ -127,15 +98,6 @@ func getCallContext(contract Contract, input []byte, gas mdgas.MdGas) *CallConte
 func (c *CallContext) put() {
 	c.Memory.reset()
 	c.Stack.Reset()
-	c.cacheGen = 0
-	// Use sentinel values so that a peek call before the first cacheGen++ is
-	// always a miss rather than returning a stale handle from a prior use.
-	c.cachedKeyGen = ^uint64(0)
-	c.cachedAddrGen = ^uint64(0)
-	// Zero the handles to release their canonMap pins while the context is
-	// idle in the pool; unique.Handle values keep interned entries alive.
-	c.cachedKey = accounts.NilKey
-	c.cachedAddr = accounts.NilAddress
 	contextPool.Put(c)
 }
 
@@ -427,7 +389,6 @@ func (evm *EVM) Run(contract Contract, gas mdgas.MdGas, input []byte, readOnly b
 	anyTrace := dbg.TraceDynamicGas || debug || trace
 
 	for {
-		callContext.cacheGen++
 		if anyTrace {
 			// Capture pre-execution values for tracing.
 			logged, pcCopy, gasCopy = false, pc, callContext.gas

--- a/rpc/jsonrpc/overlay_api.go
+++ b/rpc/jsonrpc/overlay_api.go
@@ -520,7 +520,7 @@ func (api *OverlayAPIImpl) replayBlock(ctx context.Context, blockNum uint64, sta
 		if receipt.Status == types.ReceiptStatusFailed {
 			log.Debug("[replayBlock] skipping transaction because it has status=failed", "transactionHash", txn.Hash())
 
-			contractCreation := msg.To().IsNil()
+			contractCreation := msg.To().IsZero()
 			if !contractCreation {
 				// bump the nonce of the sender
 				sender := vm.AccountRef(msg.From())


### PR DESCRIPTION
## Summary
- replace `unique.Handle` storage for account addresses, storage keys, and code hashes with plain value wrappers
- update debug account tracing to match on raw `common.Address` values
- remove the VM opcode-scoped intern cache that was only avoiding repeated `unique.Make` calls

## Testing
- `go test ./execution/types/accounts ./common/dbg ./execution/vm`
- `go test ./execution/types ./execution/state ./execution/protocol ./execution/stagedsync ./execution/builder ./execution/exec`
- `make lint`