### PR TITLE
tracers: fix Stop/GetResult race in native tracers

### DIFF
--- a/execution/tracing/tracers/native/4byte.go
+++ b/execution/tracing/tracers/native/4byte.go
@@ -55,10 +55,10 @@ func init() {
 //	  0xc281d19e-0: 1
 //	}
 type fourByteTracer struct {
-	ids               map[string]int     // ids aggregates the 4byte ids found
-	interrupt         atomic.Bool        // Atomic flag to signal execution interruption
-	reason            error              // Textual reason for the interruption
-	activePrecompiles []accounts.Address // Updated on tx start based on given rules
+	ids               map[string]int        // ids aggregates the 4byte ids found
+	interrupt         atomic.Bool           // Atomic flag to signal execution interruption
+	reason            atomic.Pointer[error] // Reason for the interruption, populated by Stop
+	activePrecompiles []accounts.Address    // Updated on tx start based on given rules
 }
 
 // newFourByteTracer returns a native go tracer which collects
@@ -125,12 +125,15 @@ func (t *fourByteTracer) GetResult() (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	return res, t.reason
+	if p := t.reason.Load(); p != nil {
+		return res, *p
+	}
+	return res, nil
 }
 
 // Stop terminates execution of the tracer at the first opportune moment.
 func (t *fourByteTracer) Stop(err error) {
-	t.reason = err
+	t.reason.Store(&err)
 	t.interrupt.Store(true)
 }
 

--- a/execution/tracing/tracers/native/call.go
+++ b/execution/tracing/tracers/native/call.go
@@ -112,8 +112,8 @@ type callTracer struct {
 	config      callTracerConfig
 	gasLimit    uint64
 	depth       int
-	interrupt   atomic.Bool // Atomic flag to signal execution interruption
-	reason      error       // Textual reason for the interruption
+	interrupt   atomic.Bool           // Atomic flag to signal execution interruption
+	reason      atomic.Pointer[error] // Reason for the interruption, populated by Stop
 	logIndex    uint64
 	logGaps     map[uint64]int
 	precompiles []bool // keep track of whether scopes are for pre-compiles or not
@@ -333,12 +333,15 @@ func (t *callTracer) GetResult() (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	return res, t.reason
+	if p := t.reason.Load(); p != nil {
+		return res, *p
+	}
+	return res, nil
 }
 
 // Stop terminates execution of the tracer at the first opportune moment.
 func (t *callTracer) Stop(err error) {
-	t.reason = err
+	t.reason.Store(&err)
 	t.interrupt.Store(true)
 }
 

--- a/execution/tracing/tracers/native/call_flat.go
+++ b/execution/tracing/tracers/native/call_flat.go
@@ -254,7 +254,10 @@ func (t *flatCallTracer) GetResult() (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	return res, t.tracer.reason
+	if p := t.tracer.reason.Load(); p != nil {
+		return res, *p
+	}
+	return res, nil
 }
 
 // Stop terminates execution of the tracer at the first opportune moment.

--- a/execution/tracing/tracers/native/prestate.go
+++ b/execution/tracing/tracers/native/prestate.go
@@ -74,8 +74,8 @@ type prestateTracer struct {
 	to        accounts.Address
 	gasLimit  uint64 // Amount of gas bought for the whole tx
 	config    prestateTracerConfig
-	interrupt atomic.Bool // Atomic flag to signal execution interruption
-	reason    error       // Textual reason for the interruption
+	interrupt atomic.Bool           // Atomic flag to signal execution interruption
+	reason    atomic.Pointer[error] // Reason for the interruption, populated by Stop
 	created   map[accounts.Address]bool
 	deleted   map[accounts.Address]bool
 }
@@ -365,12 +365,15 @@ func (t *prestateTracer) GetResult() (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	return json.RawMessage(res), t.reason
+	if p := t.reason.Load(); p != nil {
+		return json.RawMessage(res), *p
+	}
+	return json.RawMessage(res), nil
 }
 
 // Stop terminates execution of the tracer at the first opportune moment.
 func (t *prestateTracer) Stop(err error) {
-	t.reason = err
+	t.reason.Store(&err)
 	t.interrupt.Store(true)
 }
 

--- a/execution/tracing/tracers/native/tracer_test.go
+++ b/execution/tracing/tracers/native/tracer_test.go
@@ -36,11 +36,10 @@ import (
 // GetResult. Under -race, writes to the interruption reason field must not
 // race with reads, for every tracer that implements it.
 //
-// callTracer and flatCallTracer's GetResult short-circuits on
-// an empty callstack ("incorrect number of top-level calls") before loading
-// the reason. For those tracers the test pushes a single top-level call frame
-// via OnEnter so GetResult reaches the reason.Load() path where the race can
-// be observed under -race.
+// callTracer and flatCallTracer's GetResult short-circuits when the callstack
+// is empty, before loading the reason. For those tracers the test pushes a
+// single top-level call frame via OnEnter so GetResult reaches the reason.Load()
+// path where the race can be observed under -race.
 func TestTracerStopRace(t *testing.T) {
 	type setup struct {
 		name       string
@@ -54,27 +53,40 @@ func TestTracerStopRace(t *testing.T) {
 	}
 	for _, s := range cases {
 		t.Run(s.name, func(t *testing.T) {
-			tr, err := tracers.New(s.name, &tracers.Context{}, json.RawMessage("{}"))
-			require.NoError(t, err)
-
-			if s.needsFrame && tr.OnEnter != nil {
-				// Push a single top-level call frame so GetResult doesn't
-				// short-circuit before reading the interruption reason.
-				tr.OnEnter(0, byte(vm.CALL), accounts.ZeroAddress, accounts.ZeroAddress, false, nil, 0, uint256.Int{}, nil)
-			}
-
+			const iterations = 1000
 			stopErr := errors.New("execution timeout")
-			var wg sync.WaitGroup
-			wg.Add(2)
-			go func() {
-				defer wg.Done()
-				tr.Stop(stopErr)
-			}()
-			go func() {
-				defer wg.Done()
-				_, _ = tr.GetResult()
-			}()
-			wg.Wait()
+
+			for range iterations {
+				tr, err := tracers.New(s.name, &tracers.Context{}, json.RawMessage("{}"))
+				require.NoError(t, err)
+
+				if s.needsFrame && tr.OnEnter != nil {
+					// Push a single top-level call frame so GetResult doesn't
+					// short-circuit before reading the interruption reason.
+					tr.OnEnter(0, byte(vm.CALL), accounts.ZeroAddress, accounts.ZeroAddress, false, nil, 0, uint256.Int{}, nil)
+				}
+
+				start := make(chan struct{})
+				var ready sync.WaitGroup
+				var wg sync.WaitGroup
+				ready.Add(2)
+				wg.Add(2)
+				go func() {
+					defer wg.Done()
+					ready.Done()
+					<-start
+					tr.Stop(stopErr)
+				}()
+				go func() {
+					defer wg.Done()
+					ready.Done()
+					<-start
+					_, _ = tr.GetResult()
+				}()
+				ready.Wait()
+				close(start)
+				wg.Wait()
+			}
 		})
 	}
 }

--- a/execution/tracing/tracers/native/tracer_test.go
+++ b/execution/tracing/tracers/native/tracer_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package native_test
+
+import (
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/holiman/uint256"
+
+	"github.com/erigontech/erigon/execution/tracing/tracers"
+	"github.com/erigontech/erigon/execution/types/accounts"
+	"github.com/erigontech/erigon/execution/vm"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTracerStopRace exercises the concurrent Stop / GetResult path that the
+// trace RPC handler uses: a timeout watchdog goroutine calls Stop while the
+// main goroutine is still running the trace and will eventually call
+// GetResult. Under -race, writes to the interruption reason field must not
+// race with reads, for every tracer that implements it.
+//
+// callTracer and flatCallTracer's GetResult short-circuits on
+// an empty callstack ("incorrect number of top-level calls") before loading
+// the reason. For those tracers the test pushes a single top-level call frame
+// via OnEnter so GetResult reaches the reason.Load() path where the race can
+// be observed under -race.
+func TestTracerStopRace(t *testing.T) {
+	type setup struct {
+		name       string
+		needsFrame bool // whether GetResult requires a top-level call frame
+	}
+	cases := []setup{
+		{"callTracer", true},
+		{"flatCallTracer", true},
+		{"4byteTracer", false},
+		{"prestateTracer", false},
+	}
+	for _, s := range cases {
+		t.Run(s.name, func(t *testing.T) {
+			tr, err := tracers.New(s.name, &tracers.Context{}, json.RawMessage("{}"))
+			require.NoError(t, err)
+
+			if s.needsFrame && tr.OnEnter != nil {
+				// Push a single top-level call frame so GetResult doesn't
+				// short-circuit before reading the interruption reason.
+				tr.OnEnter(0, byte(vm.CALL), accounts.ZeroAddress, accounts.ZeroAddress, false, nil, 0, uint256.Int{}, nil)
+			}
+
+			stopErr := errors.New("execution timeout")
+			var wg sync.WaitGroup
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				tr.Stop(stopErr)
+			}()
+			go func() {
+				defer wg.Done()
+				_, _ = tr.GetResult()
+			}()
+			wg.Wait()
+		})
+	}
+}


### PR DESCRIPTION
This ports the relevant native tracer race fix to Erigon.

Native tracers that support `Stop` store an interruption reason from the trace timeout path, while `GetResult` can read that reason concurrently from the RPC handler path. The reason was stored as a plain error interface, so concurrent reads and writes were unsynchronized.

Because `error` is an interface value, racing access can observe an inconsistent interface state. This replaces the plain reason field with `atomic.Pointer[error]` in Erigon’s native tracers:
- `execution/tracing/tracers/native/call.go`
- `execution/tracing/tracers/native/4byte.go`
- `execution/tracing/tracers/native/prestate.go`
`flatCallTracer` shares the underlying `callTracer.reason`, so its `GetResult` now reads that pointer atomically as well.

Also adds `TestTracerStopRace`, covering concurrent `Stop` and `GetResult` for:
- `callTracer`
- `flatCallTracer`
- `4byteTracer`
- `prestateTracer`