### PR TITLE
exec: separate tickers of logging and membatch-size-check 

### DIFF
--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -59,8 +59,8 @@ func (se *serialExecutor) exec(ctx context.Context, execStage *StageState, u Unw
 
 	se.resetWorkers(ctx, se.rs, se.applyTx)
 
-	commitEvery := time.NewTicker(5 * time.Second)
-	defer commitEvery.Stop()
+	checkIsBatchFullEvery := time.NewTicker(5 * time.Second)
+	defer checkIsBatchFullEvery.Stop()
 
 	havePartialBlock := false
 	blockNum := startBlockNum
@@ -234,7 +234,7 @@ func (se *serialExecutor) exec(ctx context.Context, execStage *StageState, u Unw
 			if se.isApplyingBlocks {
 				se.LogExecution()
 			}
-		case <-commitEvery.C:
+		case <-checkIsBatchFullEvery.C:
 			if !se.isApplyingBlocks {
 				break
 			}

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -59,6 +59,9 @@ func (se *serialExecutor) exec(ctx context.Context, execStage *StageState, u Unw
 
 	se.resetWorkers(ctx, se.rs, se.applyTx)
 
+	commitEvery := time.NewTicker(5 * time.Second)
+	defer commitEvery.Stop()
+
 	havePartialBlock := false
 	blockNum := startBlockNum
 
@@ -228,10 +231,13 @@ func (se *serialExecutor) exec(ctx context.Context, execStage *StageState, u Unw
 
 		select {
 		case <-logEvery.C:
+			if se.isApplyingBlocks {
+				se.LogExecution()
+			}
+		case <-commitEvery.C:
 			if !se.isApplyingBlocks {
 				break
 			}
-			se.LogExecution()
 			isBatchFull := se.readState().SizeEstimateBeforeCommitment() >= se.cfg.batchSize.Bytes()
 			needCalcRoot := isBatchFull || havePartialBlock
 			// If we have a partial first block it may not be validated, then we should compute root hash ASAP for fail-fast


### PR DESCRIPTION
## Summary

- `LogInterval` (20 s) was controlling both progress-log emission and membatch size checks in the serial executor
- Split into two tickers: `logEvery` (20 s) for `LogExecution()` only, and `checkIsBatchFullEvery` (5 s) for the batch-full check
- A full membatch now triggers a commit within 5 s instead of up to 20 s
- The parallel executor is unaffected — it already checks batch size inline after every block result (event-driven, no ticker needed)