### PR TITLE
claude: add rules from release/3.4 (branch-naming, lint-fixes)

### DIFF
--- a/.claude/rules/branch-naming.md
+++ b/.claude/rules/branch-naming.md
@@ -1,0 +1,23 @@
+# Branch Naming Conventions
+
+## Release branches
+
+- `release/3.3` — Stable 3.3.x
+- `release/3.4` — Stable 3.4.x (current)
+- `main` — Next feature release (3.5)
+
+## Developer branches (alex's convention)
+
+Format: `alex/<short_desc>_<release_num>[_suffix]`
+
+Release number is two digits without the dot: `34` = release/3.4, `35` = main, `33` = release/3.3.
+
+Examples: `alex/seg_header_meta2_34`, `alex/integ_trie_root_35`, `alex/all7_34_dbg`
+
+Suffixes: `_dbg` (debug), `_auto` (automated), `_<n>` (revision). Short descs use underscores.
+
+## Choosing a base branch
+
+- Bug for current stable release → base on `release/3.4`
+- New feature → base on `main`
+- Backport / cherry-pick → branch off target release branch, prefix PR title with `[rX.Y]`

--- a/.claude/rules/lint-fixes.md
+++ b/.claude/rules/lint-fixes.md
@@ -1,0 +1,12 @@
+# Lint Fix Reference
+
+Common `make lint` categories and fixes:
+
+- **ruleguard (defer tx.Rollback/cursor.Close):** Error check must come *before* `defer tx.Rollback()`. Never remove an explicit `.Close()` or `.Rollback()` — add `defer` as a safety net alongside it.
+- **prealloc:** Pre-allocate slices when length is known from a range.
+- **unslice:** Remove redundant `[:]` on variables already slices.
+- **newDeref:** Replace `*new(T)` with `T{}`.
+- **appendCombine:** Combine consecutive `append` calls into one.
+- **rangeExprCopy:** Use `&x` in `range` to avoid copying large arrays.
+- **dupArg:** For intentional `x.Equal(x)` self-equality tests, suppress with `//nolint:gocritic`.
+- **Loop ruleguard in benchmarks:** For `BeginRw`/`BeginRo` inside loops where `defer` doesn't apply, suppress with `//nolint:gocritic`.


### PR DESCRIPTION
Add `.claude/rules/` files from `release/3.4` that were missing in `main`:

- `branch-naming.md` — documents release branch naming, developer branch format, and when to target which base
- `lint-fixes.md` — quick reference for common `make lint` error categories and their fixes