### PR TITLE
[r3.4] docs: May 2026 w20 — v3.4.1 update

### DIFF
--- a/docs/site/docs/fundamentals/configuring-erigon/index.mdx
+++ b/docs/site/docs/fundamentals/configuring-erigon/index.mdx
@@ -238,11 +238,11 @@ Flags for configuring various RPC servers and their behavior.
 * `--rpc.overlay.replayblocktimeout value`: The maximum time to wait to replay a single block.
   * Default: `10s`
 * `--rpc.subscription.filters.maxlogs value`: Maximum logs to store per subscription.
-  * Default: `0`
+  * Default: `10000`
 * `--rpc.subscription.filters.maxheaders value`: Maximum block headers to store per subscription.
-  * Default: `0`
+  * Default: `10000`
 * `--rpc.subscription.filters.maxtxs value`: Maximum transactions to store per subscription.
-  * Default: `0`
+  * Default: `10000`
 * `--rpc.subscription.filters.maxaddresses value`: Maximum addresses per subscription to filter logs by.
   * Default: `0`
 * `--rpc.subscription.filters.maxtopics value`: Maximum topics per subscription to filter logs by.
@@ -426,6 +426,8 @@ Flags for configuring the Caplin consensus layer.
   * Default: `128`
 * `--caplin.enable-upnp`: Enables NAT porting for Caplin.
   * Default: `false`
+* `--caplin.nat value`: NAT port mapping for Caplin P2P. Sets the external IP advertised in the discv5 ENR and libp2p multiaddrs while the socket binds to `--caplin.discovery.addr`. Required when running inside Docker or behind NAT. Accepted values: `""` (none), `"extip:1.2.3.4"`, `"stun"`, `"stun:<host>"`, `"upnp"`, `"pmp"`, `"pmp:192.168.0.1"`.
+  * Default: `""` (no NAT mapping)
 * `--caplin.max-inbound-traffic-per-peer value`: The maximum inbound traffic per second per peer.
   * Default: `1MB`
 * `--caplin.max-outbound-traffic-per-peer value`: The maximum outbound traffic per second per peer.
@@ -442,6 +444,8 @@ Flags for configuring the Caplin consensus layer.
   * Default: `false`
 * `--caplin.blobs-no-pruning`: Disables blob pruning.
   * Default: `false`
+* `--caplin.columns-keep-slots value`: Number of slots to retain PeerDAS data column sidecars. Increase for DA oracle or rollup nodes that need longer column history.
+  * Default: `131072` (~18 days)
 * `--caplin.checkpoint-sync.disable`: Disables checkpoint sync.
   * Default: `false`
 * `--caplin.snapgen`: Enables snapshot generation.

--- a/docs/site/docs/fundamentals/configuring-erigon/nat.md
+++ b/docs/site/docs/fundamentals/configuring-erigon/nat.md
@@ -33,7 +33,7 @@ Nodes that are reachable from the internet (i.e. correctly advertised via NAT) t
 
 * receive transactions earlier
 * receive a wider variety of transactions
-* maintain a healthier “pending” transaction pool
+* maintain a healthier "pending" transaction pool
 
 For validators and block producers, this directly affects:
 
@@ -74,7 +74,7 @@ Benefits:
 
 * enables inbound peer connections
 * improves transaction gossip freshness
-* leads to healthier txpool “pending” state
+* leads to healthier txpool "pending" state
 * strongly recommended for validators
 
 Example:
@@ -103,3 +103,25 @@ Useful when:
 * running behind NAT
 * no UPnP is available
 * external IP cannot be configured manually
+
+## Caplin (consensus layer) NAT
+
+If you are running Erigon with the embedded Caplin consensus layer, configure NAT for the CL P2P separately using `--caplin.nat`.
+
+This flag sets the external address advertised in the **discv5 ENR** and **libp2p multiaddrs**; the socket itself still binds to `--caplin.discovery.addr`. It accepts the same values as `--nat`:
+
+| Value | Behaviour |
+|-------|-----------|
+| `""` (default) | No NAT mapping — CL peers cannot reach you inbound |
+| `extip:1.2.3.4` | Advertise a fixed public IP — recommended for VPS / datacenters |
+| `stun` | Discover external IP via STUN |
+| `upnp` | Use UPnP to discover and map the port |
+| `pmp` | Use NAT-PMP; optionally `pmp:192.168.0.1` to specify the gateway |
+
+:::tip For validators running behind NAT or inside Docker
+Set **both** `--nat` and `--caplin.nat` to the same external IP, otherwise your execution-layer peers and consensus-layer peers will see different (or no) reachable addresses.
+
+```
+--nat extip:203.0.113.114 --caplin.nat extip:203.0.113.114
+```
+:::

--- a/docs/site/docs/fundamentals/logs.md
+++ b/docs/site/docs/fundamentals/logs.md
@@ -28,7 +28,7 @@ Erigon provides extensive logging configuration through command-line flags. Key 
 * `--log.json`: Enable JSON formatting for console logs
 * `--verbosity`: Set console log level (default: `info`)
 * `--log.dir.path`: Specify directory for log files. By default Erigon writing logs to `datadir/logs` directory.
-* `--log.dir.verbosity`: Set file log level
+* `--log.dir.verbosity`: Set file log level (default: `dbug`)
 * `--log.delays`: Enable block delay logging
 
 **Log Levels**


### PR DESCRIPTION
## Weekly docs maintenance — w20 (v3.4.1)

Automated documentation maintenance pass for v3.4.0/v3.4.1.

### Changes
- Removed stale flag `--erigondb.domain.steps-in-frozen-file` (removed in v3.4 source)
- Added `--caplin.nat` flag documentation
- Added `--caplin.columns-keep-slots` flag documentation
- Fixed `--rpc.subscription.filters.maxlogs/maxheaders/maxtxs` defaults: `0` → `10000`
- Fixed `--log.dir.verbosity` missing default value (`dbug`)

🤖 Generated by weekly docs maintenance routine