### PR TITLE
recsplit: sharded FuseFilter (cherry-pick #20644)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,7 @@ agentspecs/
 
 # ralphex progress logs
 .ralphex/progress/
+
+.gomodcache
+_artifacts
+gocache

--- a/db/datastruct/fusefilter/fusefilter_bench_test.go
+++ b/db/datastruct/fusefilter/fusefilter_bench_test.go
@@ -1,0 +1,323 @@
+package fusefilter
+
+import (
+	"math/rand/v2"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// peakSampler polls runtime.MemStats.HeapAlloc in a tight loop and tracks the maximum
+// observed value. It exists so the benchmark can attribute the well-known OOM in
+// xorfilter.NewBinaryFuse (t2hash + reverseOrder buffers, ~10x bytes-per-key at peak)
+// to a specific Build call rather than relying on b.AllocedBytesPerOp which only
+// reflects total allocs, not concurrent peak residency.
+type peakSampler struct {
+	stop chan struct{}
+	done chan struct{}
+	max  atomic.Uint64
+}
+
+func startPeakSampler(every time.Duration) *peakSampler {
+	p := &peakSampler{stop: make(chan struct{}), done: make(chan struct{})}
+	go func() {
+		defer close(p.done)
+		var ms runtime.MemStats
+		t := time.NewTicker(every)
+		defer t.Stop()
+		for {
+			select {
+			case <-p.stop:
+				runtime.ReadMemStats(&ms)
+				if ms.HeapAlloc > p.max.Load() {
+					p.max.Store(ms.HeapAlloc)
+				}
+				return
+			case <-t.C:
+				runtime.ReadMemStats(&ms)
+				if ms.HeapAlloc > p.max.Load() {
+					p.max.Store(ms.HeapAlloc)
+				}
+			}
+		}
+	}()
+	return p
+}
+
+func (p *peakSampler) Stop() uint64 {
+	close(p.stop)
+	<-p.done
+	return p.max.Load()
+}
+
+// benchBuild streams n random uint64 hashes through the writer's AddHash
+// (matching the production recsplit path: hashes flow one-at-a-time into the
+// off-heap mmap temp file), then drops the rng + AddHash state, runs a GC,
+// and only THEN starts the peak sampler and the bench timer for Build().
+//
+// Why no pre-allocated []uint64 slice: if the bench keeps a slice of all keys
+// alive, that slice (8 MB at 1M keys, 80 MB at 10M) becomes a fixed floor
+// shared by both paths and masks the real Build-internal heap delta. After
+// `keys = nil; runtime.GC()` the compiler may still keep the backing array
+// reachable from a stack slot until the surrounding function returns, which
+// is exactly what made earlier readings show ~78 MB peak at n=10M sharded
+// (a number the real-file tooltest at 339M keys then disproved by reporting
+// 32 MB — i.e. ~1/256 of plain). Streaming kills the floor entirely.
+func benchBuild(b *testing.B, sharded bool, n int) {
+	b.Helper()
+
+	var totalFileBytes uint64
+	var totalPeakHeap uint64
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		dir := b.TempDir()
+		fp := filepath.Join(dir, "f")
+
+		var (
+			plainW *Writer
+			shardW *WriterSharded
+		)
+		if sharded {
+			w, err := NewWriterSharded(fp)
+			if err != nil {
+				b.Fatal(err)
+			}
+			w.DisableFsync()
+			rng := rand.New(rand.NewPCG(1, 2))
+			for j := 0; j < n; j++ {
+				if err := w.AddHash(rng.Uint64()); err != nil {
+					b.Fatal(err)
+				}
+			}
+			shardW = w
+		} else {
+			w, err := NewWriter(fp)
+			if err != nil {
+				b.Fatal(err)
+			}
+			w.DisableFsync()
+			rng := rand.New(rand.NewPCG(1, 2))
+			for j := 0; j < n; j++ {
+				if err := w.AddHash(rng.Uint64()); err != nil {
+					b.Fatal(err)
+				}
+			}
+			plainW = w
+		}
+
+		runtime.GC()
+		sampler := startPeakSampler(500 * time.Microsecond)
+		b.StartTimer()
+
+		if sharded {
+			if err := shardW.Build(); err != nil {
+				b.Fatal(err)
+			}
+			shardW.Close()
+		} else {
+			if err := plainW.Build(); err != nil {
+				b.Fatal(err)
+			}
+			plainW.Close()
+		}
+
+		b.StopTimer()
+		peak := sampler.Stop()
+		totalPeakHeap += peak
+
+		st, err := os.Stat(fp)
+		if err != nil {
+			b.Fatal(err)
+		}
+		totalFileBytes += uint64(st.Size())
+		b.StartTimer()
+	}
+	b.StopTimer()
+
+	if b.N > 0 {
+		b.ReportMetric(float64(totalPeakHeap)/float64(b.N)/(1<<20), "peak_heap_mb")
+		b.ReportMetric(float64(totalFileBytes)/float64(b.N)/(1<<20), "file_size_mb")
+		b.ReportMetric(float64(n), "keys")
+	}
+}
+
+// BenchmarkBuild isolates the Build phase: input is streamed into the writer
+// (off-heap mmap), then dropped before the sampler starts. peak_heap_mb is
+// the heap residency of Build itself — exactly what causes the OOM in
+// production.
+//
+// Compare paths with `go test -bench=BenchmarkBuild -run=^$ -benchtime=3x -count=5`
+// and pipe through benchstat. Sizes deliberately cap at 10M so it runs on a
+// dev box; absolute numbers extrapolate ~linearly to 3B (the bloatnet OOM
+// scenario).
+func BenchmarkBuild(b *testing.B) {
+	for _, n := range []int{100_000, 1_000_000} {
+		for _, sharded := range []bool{false, true} {
+			label := "writer"
+			if sharded {
+				label = "sharded"
+			}
+			b.Run(label+"/n="+itoaUnderscored(n), func(b *testing.B) {
+				benchBuild(b, sharded, n)
+			})
+		}
+	}
+}
+
+// BenchmarkBuildLarge runs the 10M-key variant. Gated by -short so the regular
+// test-short suite skips it. Run with `go test -bench=BenchmarkBuildLarge
+// -run=^$ -benchtime=1x ./db/datastruct/fusefilter/`.
+func BenchmarkBuildLarge(b *testing.B) {
+	if testing.Short() {
+		b.Skip("skipping large build benchmark in -short mode")
+	}
+	const n = 10_000_000
+	for _, sharded := range []bool{false, true} {
+		label := "writer"
+		if sharded {
+			label = "sharded"
+		}
+		b.Run(label+"/n="+itoaUnderscored(n), func(b *testing.B) {
+			benchBuild(b, sharded, n)
+		})
+	}
+}
+
+// benchLookup measures the cost of N random ContainsHash probes (mix of present and
+// absent keys) on a prebuilt filter. Hot-cache only — the cold path is dominated by
+// IO, not by Reader vs ReaderSharded code.
+func benchLookup(b *testing.B, sharded bool, n int) {
+	b.Helper()
+	dir := b.TempDir()
+	fp := filepath.Join(dir, "f")
+
+	// Build the filter by streaming hashes (no materialised []uint64).
+	if sharded {
+		w, err := NewWriterSharded(fp)
+		if err != nil {
+			b.Fatal(err)
+		}
+		w.DisableFsync()
+		rng := rand.New(rand.NewPCG(1, 2))
+		for j := 0; j < n; j++ {
+			if err := w.AddHash(rng.Uint64()); err != nil {
+				b.Fatal(err)
+			}
+		}
+		if err := w.Build(); err != nil {
+			b.Fatal(err)
+		}
+		w.Close()
+	} else {
+		w, err := NewWriter(fp)
+		if err != nil {
+			b.Fatal(err)
+		}
+		w.DisableFsync()
+		rng := rand.New(rand.NewPCG(1, 2))
+		for j := 0; j < n; j++ {
+			if err := w.AddHash(rng.Uint64()); err != nil {
+				b.Fatal(err)
+			}
+		}
+		if err := w.Build(); err != nil {
+			b.Fatal(err)
+		}
+		w.Close()
+	}
+
+	// Small fixed-size probe buffer (16k uint64 = 128 KB) is enough to defeat
+	// branch-predictor caching of the inner ContainsHash and re-used cyclically
+	// via `i%len(probes)`. Keeping it bounded means lookup bench heap stays tiny
+	// regardless of n.
+	const probesN = 16 * 1024
+	probes := make([]uint64, probesN)
+	{
+		rng := rand.New(rand.NewPCG(7, 11))
+		for i := range probes {
+			probes[i] = rng.Uint64()
+		}
+	}
+
+	type containsReader interface {
+		ContainsHash(uint64) bool
+	}
+	var r containsReader
+	if sharded {
+		rs, err := NewReaderSharded(fp)
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer rs.Close()
+		r = rs
+	} else {
+		rr, err := NewReader(fp)
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer rr.Close()
+		r = rr
+	}
+
+	// Warm pages.
+	for _, k := range probes[:min(len(probes), 1024)] {
+		_ = r.ContainsHash(k)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	var hits int
+	for i := 0; i < b.N; i++ {
+		if r.ContainsHash(probes[i%len(probes)]) {
+			hits++
+		}
+	}
+	b.StopTimer()
+	_ = hits
+}
+
+func BenchmarkLookup(b *testing.B) {
+	for _, n := range []int{100_000, 1_000_000} {
+		for _, sharded := range []bool{false, true} {
+			label := "writer"
+			if sharded {
+				label = "sharded"
+			}
+			b.Run(label+"/n="+itoaUnderscored(n), func(b *testing.B) {
+				benchLookup(b, sharded, n)
+			})
+		}
+	}
+}
+
+// itoaUnderscored renders 1000000 as "1_000_000" for readable bench names.
+func itoaUnderscored(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	buf := make([]byte, 0, 16)
+	for i := 0; n > 0; i++ {
+		if i > 0 && i%3 == 0 {
+			buf = append(buf, '_')
+		}
+		buf = append(buf, byte('0'+n%10))
+		n /= 10
+	}
+	if neg {
+		buf = append(buf, '-')
+	}
+	for i, j := 0, len(buf)-1; i < j; i, j = i+1, j-1 {
+		buf[i], buf[j] = buf[j], buf[i]
+	}
+	return string(buf)
+}

--- a/db/datastruct/fusefilter/fusefilter_corruption_test.go
+++ b/db/datastruct/fusefilter/fusefilter_corruption_test.go
@@ -1,0 +1,222 @@
+package fusefilter
+
+import (
+	"bytes"
+	"encoding/binary"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// validBlob builds a real, valid filter blob over `n` keys and returns its bytes.
+func validBlob(t *testing.T, n int) []byte {
+	t.Helper()
+	w, err := NewWriterOffHeap(filepath.Join(t.TempDir(), "v"))
+	require.NoError(t, err)
+	defer w.Close()
+	for i := 0; i < n; i++ {
+		require.NoError(t, w.AddHash(uint64(i)))
+	}
+	var buf bytes.Buffer
+	_, err = w.BuildTo(&buf)
+	require.NoError(t, err)
+	return buf.Bytes()
+}
+
+// validShardedBlob builds a real, valid sharded blob over `n` keys.
+func validShardedBlob(t *testing.T, n int) []byte {
+	t.Helper()
+	w, err := NewWriterSharded(filepath.Join(t.TempDir(), "v"))
+	require.NoError(t, err)
+	defer w.Close()
+	for i := 0; i < n; i++ {
+		require.NoError(t, w.AddHash(uint64(i)))
+	}
+	var buf bytes.Buffer
+	_, err = w.BuildTo(&buf)
+	require.NoError(t, err)
+	return buf.Bytes()
+}
+
+// header field offsets inside a per-shard fusefilter blob (see writeFilter):
+//
+//	0..4    version+features
+//	4..8    SegmentCount
+//	8..12   SegmentCountLength
+//	12..20  Seed
+//	20..24  SegmentLength
+//	24..28  SegmentLengthMask
+//	28..36  fingerprints length
+const (
+	hdrSegmentCount       = 4
+	hdrSegmentCountLength = 8
+	hdrSegmentLength      = 20
+	hdrSegmentLengthMask  = 24
+	hdrFingerprintsLen    = 28
+)
+
+func mutateU32(b []byte, off int, v uint32) []byte {
+	out := append([]byte(nil), b...)
+	binary.BigEndian.PutUint32(out[off:], v)
+	return out
+}
+func mutateU64(b []byte, off int, v uint64) []byte {
+	out := append([]byte(nil), b...)
+	binary.BigEndian.PutUint64(out[off:], v)
+	return out
+}
+
+func TestNewReaderOnBytes_RejectsCorrupt(t *testing.T) {
+	require := require.New(t)
+	good := validBlob(t, 1000)
+
+	t.Run("too_short_for_header", func(t *testing.T) {
+		_, _, err := NewReaderOnBytes(good[:headerSize-1], "x")
+		require.Error(err)
+	})
+
+	t.Run("fingerprints_length_overflows", func(t *testing.T) {
+		// fingerprintsLen == len(data)+1 → runs past the available bytes.
+		bad := append([]byte(nil), good...)
+		// Set fingerprints length to a value larger than what's actually present.
+		dataLen := uint64(len(bad)-headerSize) + 1
+		binary.BigEndian.PutUint64(bad[hdrFingerprintsLen:], dataLen)
+		_, _, err := NewReaderOnBytes(bad, "x")
+		require.Error(err)
+	})
+
+	t.Run("zero_SegmentLength", func(t *testing.T) {
+		bad := mutateU32(good, hdrSegmentLength, 0)
+		_, _, err := NewReaderOnBytes(bad, "x")
+		require.Error(err)
+	})
+
+	t.Run("zero_SegmentCount", func(t *testing.T) {
+		bad := mutateU32(good, hdrSegmentCount, 0)
+		_, _, err := NewReaderOnBytes(bad, "x")
+		require.Error(err)
+	})
+
+	t.Run("non_power_of_two_SegmentLength", func(t *testing.T) {
+		bad := mutateU32(good, hdrSegmentLength, 1024+1)
+		bad = mutateU32(bad, hdrSegmentLengthMask, 1024)
+		_, _, err := NewReaderOnBytes(bad, "x")
+		require.Error(err)
+	})
+
+	t.Run("inconsistent_mask", func(t *testing.T) {
+		// SegmentLength is a power of two but mask doesn't match — would let
+		// h1, h2 indices escape the per-segment range.
+		r, _, err := NewReaderOnBytes(good, "x")
+		require.NoError(err)
+		segLen := r.inner.SegmentLength
+		bad := mutateU32(good, hdrSegmentLengthMask, segLen) // should be segLen-1
+		_, _, err = NewReaderOnBytes(bad, "x")
+		require.Error(err)
+	})
+
+	t.Run("inconsistent_SegmentCountLength", func(t *testing.T) {
+		r, _, err := NewReaderOnBytes(good, "x")
+		require.NoError(err)
+		// Lie: claim SegmentCountLength is one larger than SegmentCount*SegmentLength.
+		bad := mutateU32(good, hdrSegmentCountLength, r.inner.SegmentCountLength+1)
+		_, _, err = NewReaderOnBytes(bad, "x")
+		require.Error(err)
+	})
+
+	t.Run("fingerprints_too_short_for_geometry", func(t *testing.T) {
+		// Truncate fingerprints to a value that fits in the byte stream but is
+		// smaller than (SegmentCount+2)*SegmentLength — the OOB-read condition.
+		// We do this by claiming the data section is smaller than required.
+		r, _, err := NewReaderOnBytes(good, "x")
+		require.NoError(err)
+		required := (uint64(r.inner.SegmentCount) + 2) * uint64(r.inner.SegmentLength)
+		require.Greater(required, uint64(0))
+		smaller := required - 1
+		// Build a payload with fingerprintsLen=smaller, but we need at least that
+		// many bytes after the header. The original blob is bigger so this is fine.
+		bad := append([]byte(nil), good[:headerSize+int(smaller)]...)
+		binary.BigEndian.PutUint64(bad[hdrFingerprintsLen:], smaller)
+		_, _, err = NewReaderOnBytes(bad, "x")
+		require.Error(err)
+	})
+
+	t.Run("SegmentCount_times_SegmentLength_overflows", func(t *testing.T) {
+		// Force SegmentCount * SegmentLength to overflow uint32. Pair both fields
+		// with a SegmentLengthMask consistent with SegmentLength so we hit the
+		// overflow check, not the mask check.
+		bad := mutateU32(good, hdrSegmentCount, 1<<20)
+		bad = mutateU32(bad, hdrSegmentLength, 1<<13) // 8K, power of two
+		bad = mutateU32(bad, hdrSegmentLengthMask, (1<<13)-1)
+		// 1<<20 * 1<<13 = 1<<33 > MaxUint32
+		_, _, err := NewReaderOnBytes(bad, "x")
+		require.Error(err)
+	})
+}
+
+func TestNewReaderShardedOnBytes_RejectsCorrupt(t *testing.T) {
+	require := require.New(t)
+	good := validShardedBlob(t, 1000)
+
+	t.Run("too_short_for_outer_header", func(t *testing.T) {
+		_, _, err := NewReaderShardedOnBytes(good[:3], "x")
+		require.Error(err)
+	})
+
+	t.Run("unsupported_outer_version", func(t *testing.T) {
+		bad := append([]byte(nil), good...)
+		bad[0] = 99
+		_, _, err := NewReaderShardedOnBytes(bad, "x")
+		require.Error(err)
+	})
+
+	t.Run("truncated_shard_table", func(t *testing.T) {
+		// Outer header (4 bytes) ok, but cut off mid-shard-table.
+		_, _, err := NewReaderShardedOnBytes(good[:5], "x")
+		require.Error(err)
+	})
+
+	t.Run("shard_size_overflows_remainder", func(t *testing.T) {
+		// First 8-byte size in the shard table claims a blob bigger than what's
+		// left in the buffer.
+		bad := append([]byte(nil), good...)
+		binary.BigEndian.PutUint64(bad[4:], 1<<40)
+		_, _, err := NewReaderShardedOnBytes(bad, "x")
+		require.Error(err)
+	})
+
+	t.Run("shard_size_smaller_than_header", func(t *testing.T) {
+		// Find first non-empty shard slot and shrink it to less than headerSize.
+		bad := append([]byte(nil), good...)
+		offset := 4
+		for i := 0; i < 256; i++ {
+			sz := binary.BigEndian.Uint64(bad[offset:])
+			if sz != 0 {
+				binary.BigEndian.PutUint64(bad[offset:], 4) // < filterBlobHeaderSize
+				break
+			}
+			offset += 8
+		}
+		_, _, err := NewReaderShardedOnBytes(bad, "x")
+		require.Error(err)
+	})
+
+	t.Run("corrupt_inner_shard_geometry", func(t *testing.T) {
+		// Find first non-empty shard, zero out its SegmentLength → inner
+		// validation should reject without ever looking at fingerprints.
+		bad := append([]byte(nil), good...)
+		offset := 4
+		for i := 0; i < 256; i++ {
+			sz := binary.BigEndian.Uint64(bad[offset:])
+			offset += 8
+			if sz != 0 {
+				// Zero the SegmentLength field of the inner shard header.
+				binary.BigEndian.PutUint32(bad[offset+hdrSegmentLength:], 0)
+				break
+			}
+		}
+		_, _, err := NewReaderShardedOnBytes(bad, "x")
+		require.Error(err)
+	})
+}

--- a/db/datastruct/fusefilter/fusefilter_fuzz_test.go
+++ b/db/datastruct/fusefilter/fusefilter_fuzz_test.go
@@ -1,0 +1,176 @@
+package fusefilter
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+)
+
+// FuzzReaderOnBytes asserts NewReaderOnBytes never panics on any byte input
+// and that, when it succeeds, calling ContainsHash on the resulting filter
+// also never panics on a sweep of probe values. This closes the OOB-read
+// concern Copilot raised on the per-shard blob parser: a truncated or
+// adversarially-crafted blob must surface as an error, not a runtime panic
+// in xorfilter.Contains.
+//
+// Seed corpus: a known-good 1000-key blob plus a few obviously-bad inputs.
+// Run with:
+//
+//	go test -run=^$ -fuzz=FuzzReaderOnBytes -fuzztime=30s ./db/datastruct/fusefilter/
+func FuzzReaderOnBytes(f *testing.F) {
+	good := buildValidBlob(f, 1000)
+	f.Add(good)
+	f.Add([]byte{})
+	f.Add(make([]byte, headerSize-1))
+	f.Add(make([]byte, headerSize))
+	// Truncate at every header byte boundary.
+	for i := 0; i < headerSize; i++ {
+		if i < len(good) {
+			f.Add(good[:i])
+		}
+	}
+
+	probes := []uint64{0, 1, ^uint64(0), 0xdeadbeefcafebabe, 0x42, 1 << 56}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		r, _, err := NewReaderOnBytes(data, "fuzz")
+		if err != nil {
+			return
+		}
+		// Successful parse: every probe must complete without panicking.
+		for _, p := range probes {
+			_ = r.ContainsHash(p)
+		}
+	})
+}
+
+// FuzzReaderShardedOnBytes is the same property for the sharded outer format.
+// It exercises the [4-byte header | 256 × (8-byte size, blob)] layout, which
+// has more dimensions of possible corruption (shard table truncation, oversize
+// shard size fields, recursively-corrupt inner blobs).
+//
+// Run with:
+//
+//	go test -run=^$ -fuzz=FuzzReaderShardedOnBytes -fuzztime=30s ./db/datastruct/fusefilter/
+func FuzzReaderShardedOnBytes(f *testing.F) {
+	good := buildValidShardedBlob(f, 1000)
+	f.Add(good)
+	f.Add([]byte{})
+	f.Add(make([]byte, 3))                  // shorter than outer header
+	f.Add(make([]byte, 4))                  // outer header only, no shard table
+	f.Add(good[:5])                         // mid-shard-table truncation
+	f.Add(append([]byte(nil), 99, 0, 0, 0)) // unsupported version
+
+	probes := []uint64{0, 1, ^uint64(0), 0xdeadbeefcafebabe, 0x42, 1 << 56}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		r, _, err := NewReaderShardedOnBytes(data, "fuzz")
+		if err != nil {
+			return
+		}
+		for _, p := range probes {
+			_ = r.ContainsHash(p)
+		}
+	})
+}
+
+// FuzzWriterRoundTrip asserts a build → read round-trip property: every key
+// fed into the writer is reported present by the reader (xorfilter has 0%
+// false-negative rate, by construction). Keys are derived deterministically
+// from the fuzz inputs so the seed corpus shrinks naturally.
+//
+// Run with:
+//
+//	go test -run=^$ -fuzz=FuzzWriterRoundTrip -fuzztime=30s ./db/datastruct/fusefilter/
+func FuzzWriterRoundTrip(f *testing.F) {
+	f.Add(uint64(1), uint16(64))
+	f.Add(uint64(0), uint16(1))
+	f.Add(uint64(^uint64(0)), uint16(8192))
+
+	f.Fuzz(func(t *testing.T, seed uint64, n uint16) {
+		// Cap n so each fuzz iteration stays under a few ms.
+		if n == 0 {
+			return
+		}
+		if n > 8192 {
+			n = 8192
+		}
+
+		dir := t.TempDir()
+		fp := filepath.Join(dir, "f")
+		w, err := NewWriterSharded(fp)
+		if err != nil {
+			t.Fatal(err)
+		}
+		w.DisableFsync()
+
+		// Cheap deterministic key stream: splitmix64.
+		x := seed
+		keys := make([]uint64, 0, n)
+		for i := uint16(0); i < n; i++ {
+			x += 0x9E3779B97F4A7C15
+			z := x
+			z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9
+			z = (z ^ (z >> 27)) * 0x94D049BB133111EB
+			z = z ^ (z >> 31)
+			keys = append(keys, z)
+			if err := w.AddHash(z); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := w.Build(); err != nil {
+			t.Fatal(err)
+		}
+		w.Close()
+
+		r, err := NewReaderSharded(fp)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer r.Close()
+		for _, k := range keys {
+			if !r.ContainsHash(k) {
+				t.Fatalf("seed=%d n=%d: ContainsHash(%d) = false (xorfilter must have 0%% FN rate)", seed, n, k)
+			}
+		}
+	})
+}
+
+// buildValidBlob is a fuzz-friendly twin of validBlob() that takes *testing.F.
+func buildValidBlob(f *testing.F, n int) []byte {
+	f.Helper()
+	w, err := NewWriterOffHeap(filepath.Join(f.TempDir(), "v"))
+	if err != nil {
+		f.Fatal(err)
+	}
+	defer w.Close()
+	for i := 0; i < n; i++ {
+		if err := w.AddHash(uint64(i)); err != nil {
+			f.Fatal(err)
+		}
+	}
+	var buf bytes.Buffer
+	if _, err := w.BuildTo(&buf); err != nil {
+		f.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func buildValidShardedBlob(f *testing.F, n int) []byte {
+	f.Helper()
+	w, err := NewWriterSharded(filepath.Join(f.TempDir(), "v"))
+	if err != nil {
+		f.Fatal(err)
+	}
+	defer w.Close()
+	for i := 0; i < n; i++ {
+		if err := w.AddHash(uint64(i)); err != nil {
+			f.Fatal(err)
+		}
+	}
+	var buf bytes.Buffer
+	if _, err := w.BuildTo(&buf); err != nil {
+		f.Fatal(err)
+	}
+	return buf.Bytes()
+}

--- a/db/datastruct/fusefilter/fusefilter_reader.go
+++ b/db/datastruct/fusefilter/fusefilter_reader.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"unsafe"
@@ -75,19 +76,26 @@ func NewReader(filePath string) (*Reader, error) {
 	return r, nil
 }
 
+func parseHeaderFeatures(header []byte, fName string) (version uint8, features Features, err error) {
+	version = header[0]
+	features = Features(binary.BigEndian.Uint32(header[:4]) & 0x00FFFFFF)
+	if (features&IsLittleEndianFeature != 0) != IsLittleEndian {
+		return 0, 0, fmt.Errorf("file %s is not compatible with your machine (different Endianness), but you can run `erigon snapshots index`", fName)
+	}
+	return version, features, nil
+}
+
 func NewReaderOnBytes(m []byte, fName string) (*Reader, int, error) {
+	if len(m) < headerSize {
+		return nil, 0, fmt.Errorf("fusefilter %s: too small for header (%d < %d)", fName, len(m), headerSize)
+	}
 	filter := &xorfilter.BinaryFuse[uint8]{}
 
 	header, data := m[:headerSize], m[headerSize:]
-	v := header[0]
 
-	// 1 byte - version, 3 bytes - `Features`
-	featuresBytes := bytes.Clone(header[:4])
-	featuresBytes[0] = 0 // mask version byte
-	features := Features(binary.BigEndian.Uint32(featuresBytes))
-	fileIsLittleEndian := features&IsLittleEndianFeature != 0
-	if fileIsLittleEndian != IsLittleEndian {
-		return nil, 0, fmt.Errorf("file %s is not compatible with your machine (different Endianness), but you can run `erigon snapshots index`", fName)
+	v, features, err := parseHeaderFeatures(header, fName)
+	if err != nil {
+		return nil, 0, err
 	}
 
 	filter.SegmentCount = binary.BigEndian.Uint32(header[4:])
@@ -95,10 +103,55 @@ func NewReaderOnBytes(m []byte, fName string) (*Reader, int, error) {
 	filter.Seed = binary.BigEndian.Uint64(header[4+4+4:])
 	filter.SegmentLength = binary.BigEndian.Uint32(header[4+4+4+8:])
 	filter.SegmentLengthMask = binary.BigEndian.Uint32(header[4+4+4+8+4:])
-	fingerprintsLen := int(binary.BigEndian.Uint64(header[4+4+4+8+4+4:]))
+	fingerprintsLen64 := binary.BigEndian.Uint64(header[4+4+4+8+4+4:])
+	if fingerprintsLen64 > math.MaxInt || uint64(len(data)) < fingerprintsLen64 {
+		return nil, 0, fmt.Errorf("fusefilter %s: fingerprints length %d exceeds available bytes %d", fName, fingerprintsLen64, len(data))
+	}
+	fingerprintsLen := int(fingerprintsLen64)
+
+	if err := validateFilterGeometry(filter, fingerprintsLen, fName); err != nil {
+		return nil, 0, err
+	}
 
 	filter.Fingerprints = data[:fingerprintsLen]
-	return &Reader{inner: filter, version: v, features: features, m: m}, headerSize + fingerprintsLen, nil
+	total := headerSize + fingerprintsLen
+	return &Reader{inner: filter, version: v, features: features, m: m[:total]}, total, nil
+}
+
+// validateFilterGeometry rejects on-disk header values that would let
+// xorfilter.Contains panic with an out-of-bounds Fingerprints index. The fuse
+// filter encodes h_i = uint32(Mul64(hash, SegmentCountLength).hi) + i*SegmentLength
+// for i in {0,1,2}; the largest index it can produce is SegmentCountLength-1 +
+// 2*SegmentLength, so we need len(Fingerprints) >= (SegmentCount+2)*SegmentLength.
+func validateFilterGeometry(filter *xorfilter.BinaryFuse[uint8], fingerprintsLen int, fName string) error {
+	if filter.SegmentLength == 0 || filter.SegmentCount == 0 {
+		return fmt.Errorf("fusefilter %s: zero SegmentLength=%d SegmentCount=%d", fName, filter.SegmentLength, filter.SegmentCount)
+	}
+	// SegmentLength is a power of two by construction (calculateSegmentLength
+	// returns 1<<k). The mask must equal SegmentLength-1; otherwise hi-bit
+	// shifts in getHashFromHash compute indices beyond SegmentLengthMask+1,
+	// breaking the implicit bound used below.
+	if filter.SegmentLength&(filter.SegmentLength-1) != 0 {
+		return fmt.Errorf("fusefilter %s: SegmentLength=%d is not a power of two", fName, filter.SegmentLength)
+	}
+	if filter.SegmentLengthMask != filter.SegmentLength-1 {
+		return fmt.Errorf("fusefilter %s: SegmentLengthMask=%d != SegmentLength-1=%d", fName, filter.SegmentLengthMask, filter.SegmentLength-1)
+	}
+	wantSCL := uint64(filter.SegmentCount) * uint64(filter.SegmentLength)
+	if wantSCL > math.MaxUint32 {
+		return fmt.Errorf("fusefilter %s: SegmentCount*SegmentLength=%d overflows uint32", fName, wantSCL)
+	}
+	if uint64(filter.SegmentCountLength) != wantSCL {
+		return fmt.Errorf("fusefilter %s: SegmentCountLength=%d != SegmentCount*SegmentLength=%d", fName, filter.SegmentCountLength, wantSCL)
+	}
+	wantFP := (uint64(filter.SegmentCount) + 2) * uint64(filter.SegmentLength)
+	if wantFP > math.MaxInt {
+		return fmt.Errorf("fusefilter %s: required fingerprints length %d overflows int", fName, wantFP)
+	}
+	if uint64(fingerprintsLen) < wantFP {
+		return fmt.Errorf("fusefilter %s: fingerprints length %d < required %d for SegmentCount=%d SegmentLength=%d", fName, fingerprintsLen, wantFP, filter.SegmentCount, filter.SegmentLength)
+	}
+	return nil
 }
 
 func (r *Reader) ForceInMem() datasize.ByteSize {
@@ -134,6 +187,157 @@ func (r *Reader) Close() {
 	_ = r.m.Unmap() //nolint
 	_ = r.f.Close() //nolint
 	r.f = nil
+}
+
+// ReaderSharded reads a sharded fusefilter (outer header version=1).
+// Only the shard matching keyHash >> 56 is checked on lookup.
+// shards is a value array (not pointer array) so ContainsHash needs only one pointer dereference.
+type ReaderSharded struct {
+	m         mmap.MMap // outer slice spanning header + all shard blobs, used for madvise
+	f         *os.File  // non-nil only when opened via NewReaderSharded(filePath)
+	fileName  string
+	keepInMem bool // ForceInMem replaced m with an anonymous heap copy; skip madvise/munmap
+	shards    [256]Reader
+}
+
+func NewReaderSharded(filePath string) (*ReaderSharded, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	st, err := f.Stat()
+	if err != nil {
+		_ = f.Close() //nolint
+		return nil, err
+	}
+	sz := int(st.Size())
+	m, err := mmap.MapRegion(f, sz, mmap.RDONLY, 0, 0)
+	if err != nil {
+		_ = f.Close() //nolint
+		return nil, err
+	}
+	_, fileName := filepath.Split(filePath)
+	r, _, err := NewReaderShardedOnBytes(m, fileName)
+	if err != nil {
+		_ = m.Unmap() //nolint
+		_ = f.Close() //nolint
+		return nil, err
+	}
+	r.f = f
+	r.m = m
+	r.fileName = fileName
+	return r, nil
+}
+
+func (r *ReaderSharded) FileName() string { return r.fileName }
+
+func (r *ReaderSharded) Close() {
+	if r == nil || r.f == nil {
+		return
+	}
+	if !r.keepInMem {
+		_ = r.m.Unmap() //nolint
+	}
+	_ = r.f.Close() //nolint
+	r.f = nil
+}
+
+func NewReaderShardedOnBytes(m []byte, fName string) (*ReaderSharded, int, error) {
+	const headerSize = 4
+	if len(m) < headerSize {
+		return nil, 0, fmt.Errorf("fusefilter sharded %s: too small (%d bytes)", fName, len(m))
+	}
+	v, _, err := parseHeaderFeatures(m[:4], fName)
+	if err != nil {
+		return nil, 0, err
+	}
+	if v != 1 {
+		return nil, 0, fmt.Errorf("fusefilter sharded %s: unsupported version %d", fName, v)
+	}
+
+	r := &ReaderSharded{}
+	offset := headerSize
+	for i := range 256 {
+		if offset+8 > len(m) {
+			return nil, 0, fmt.Errorf("fusefilter sharded %s: truncated at shard %d", fName, i)
+		}
+		sz64 := binary.BigEndian.Uint64(m[offset:])
+		offset += 8
+		if sz64 == 0 {
+			continue
+		}
+		if sz64 > math.MaxInt || sz64 > uint64(len(m)-offset) {
+			return nil, 0, fmt.Errorf("fusefilter sharded %s: shard %d blob overflows (offset=%d sz=%d total=%d)", fName, i, offset, sz64, len(m))
+		}
+		sz := int(sz64)
+		if sz < filterBlobHeaderSize {
+			return nil, 0, fmt.Errorf("fusefilter sharded %s: shard %d size %d < header %d", fName, i, sz, filterBlobHeaderSize)
+		}
+		shard, consumed, err := NewReaderOnBytes(m[offset:offset+sz], fName)
+		if err != nil {
+			return nil, 0, fmt.Errorf("shard %d of %s: %w", i, fName, err)
+		}
+		if consumed != sz {
+			return nil, 0, fmt.Errorf("fusefilter sharded %s: shard %d consumed %d != declared size %d", fName, i, consumed, sz)
+		}
+		r.shards[i] = *shard
+		offset += sz
+	}
+	r.m = m[:offset]
+	return r, offset, nil
+}
+
+func (r *ReaderSharded) ContainsHash(v uint64) bool {
+	s := &r.shards[v>>56]
+	if s.inner == nil {
+		return false
+	}
+	return s.ContainsHash(v)
+}
+
+// ForceInMem clones the entire mmap region into anonymous heap memory in a
+// single allocation, then re-points each shard's Fingerprints slice into the
+// clone at the same byte offset. Avoids 256 separate allocations.
+func (r *ReaderSharded) ForceInMem() datasize.ByteSize {
+	if len(r.m) == 0 {
+		return 0
+	}
+	base := unsafe.Pointer(&r.m[0])
+	clone := bytes.Clone(r.m)
+	for i := range r.shards {
+		s := &r.shards[i]
+		if s.inner == nil || len(s.inner.Fingerprints) == 0 {
+			continue
+		}
+		off := uintptr(unsafe.Pointer(&s.inner.Fingerprints[0])) - uintptr(base)
+		ln := len(s.inner.Fingerprints)
+		s.inner.Fingerprints = clone[off : off+uintptr(ln)]
+		s.keepInMem = true
+	}
+	r.m = clone
+	r.keepInMem = true
+	return datasize.ByteSize(len(clone))
+}
+
+// MadvWillNeed hints to the OS that all shard blobs will be accessed.
+// One madvise on the outer mmap slice covers all shards in a single syscall,
+// instead of 256 madvise calls on adjacent sub-slices of the same VMA.
+func (r *ReaderSharded) MadvWillNeed() {
+	if r == nil || len(r.m) == 0 || r.keepInMem {
+		return
+	}
+	if err := mm.MadviseWillNeed(r.m); err != nil {
+		panic(err)
+	}
+}
+
+func (r *ReaderSharded) MadvNormal() {
+	if r == nil || len(r.m) == 0 || r.keepInMem {
+		return
+	}
+	if err := mm.MadviseNormal(r.m); err != nil {
+		panic(err)
+	}
 }
 
 var IsLittleEndian = isLittleEndian()

--- a/db/datastruct/fusefilter/fusefilter_realfile_test.go
+++ b/db/datastruct/fusefilter/fusefilter_realfile_test.go
@@ -1,0 +1,365 @@
+package fusefilter
+
+import (
+	"bufio"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spaolacci/murmur3"
+
+	"github.com/erigontech/erigon/db/seg"
+)
+
+// TestIndexFromFile is a "tooltest": it indexes the same key stream through
+// both Writer (legacy) and WriterSharded paths, then prints a side-by-side
+// comparison of peak heap / wall time / file size and verifies every input
+// key is present in both readers.
+//
+// Hashes are streamed, never materialised into a Go slice — the same shape
+// recsplit uses in production (one key at a time → AddHash → off-heap mmap
+// temp file). This is the only way the tool can run on the 85 GB .kv that
+// originally caused issue #20560: a 3 B-key uint64 slice would itself need
+// 24 GB of heap and OOM the harness before Build even starts.
+//
+// Modes (auto-detected by file extension, override with FUSEFILTER_INPUT_MODE):
+//
+//   - kv  : seg-compressed file with alternating key/value words (.kv, .v, .seg).
+//     Keys are murmur3-128-hashed (top 64 bits) before AddHash, mirroring
+//     how recsplit.AddKey feeds the existence filter in production.
+//   - raw : flat stream of uint64 hashes (8 bytes each, little-endian).
+//     Useful when you've already extracted hashes from somewhere and
+//     want to skip the key-iteration cost.
+//
+// Skips when FUSEFILTER_INPUT is empty, so it never runs in CI.
+//
+// Set FUSEFILTER_SKIP_PARITY=1 to skip the third (parity) stream pass on huge
+// files where the extra disk read is expensive.
+//
+// Example:
+//
+//	FUSEFILTER_INPUT=/snapshots/v2.0-storage.7488-7496.kv \
+//	    go test -run=TestIndexFromFile -v -count=1 -timeout=8h \
+//	    ./db/datastruct/fusefilter/
+func TestIndexFromFile(t *testing.T) {
+	path := os.Getenv("FUSEFILTER_INPUT")
+	if path == "" {
+		t.Skip("set FUSEFILTER_INPUT=/path/to/file (.kv, .v, .seg, or raw uint64 stream) to run")
+	}
+	mode := os.Getenv("FUSEFILTER_INPUT_MODE")
+	if mode == "" {
+		switch strings.ToLower(filepath.Ext(path)) {
+		case ".kv", ".v", ".seg":
+			mode = "kv"
+		default:
+			mode = "raw"
+		}
+	}
+
+	stream, err := streamerFor(path, mode)
+	if err != nil {
+		t.Fatalf("streamerFor: %v", err)
+	}
+
+	outDir := t.TempDir()
+	plainPath := filepath.Join(outDir, "plain.efi")
+	shardPath := filepath.Join(outDir, "sharded.efi")
+
+	plain := runBuild(t, "plain", stream, plainPath, false)
+	shard := runBuild(t, "sharded", stream, shardPath, true)
+
+	if plain.keyCount != shard.keyCount {
+		t.Fatalf("stream key count drift: plain=%d sharded=%d", plain.keyCount, shard.keyCount)
+	}
+
+	t.Logf("")
+	t.Logf("=== summary (n=%d) ===", plain.keyCount)
+	t.Logf("                 plain          sharded        delta")
+	t.Logf("peak_heap   %12.1f MB %12.1f MB  %+6.1f%%", mb(plain.peakHeap), mb(shard.peakHeap), pct(plain.peakHeap, shard.peakHeap))
+	t.Logf("file_size   %12.1f MB %12.1f MB  %+6.1f%%", mb(plain.fileSize), mb(shard.fileSize), pct(plain.fileSize, shard.fileSize))
+	t.Logf("build_time  %12s    %12s     %+6.1f%%", plain.buildWall, shard.buildWall, pctDur(plain.buildWall, shard.buildWall))
+	t.Logf("ingest_time %12s    %12s", plain.ingestWall, shard.ingestWall)
+	t.Logf("ratios      peak %.2fx (plain/sharded)  size %.2fx (sharded/plain)  build_time %.2fx",
+		float64(plain.peakHeap)/float64(shard.peakHeap),
+		float64(shard.fileSize)/float64(plain.fileSize),
+		float64(shard.buildWall)/float64(plain.buildWall))
+
+	if os.Getenv("FUSEFILTER_SKIP_PARITY") != "" {
+		t.Logf("parity check skipped (FUSEFILTER_SKIP_PARITY set)")
+	} else {
+		verifyParity(t, stream, plainPath, shardPath)
+	}
+	measureFP(t, shardPath)
+}
+
+type buildResult struct {
+	keyCount   int
+	peakHeap   uint64
+	fileSize   uint64
+	ingestWall time.Duration
+	buildWall  time.Duration
+}
+
+// runBuild streams the input through AddHash, then drops the streamer, runs a
+// GC to clear any source-side state, and only THEN starts the peak sampler
+// and the wall-clock timer for Build(). This isolates the Go-heap pressure
+// inside Build (the actual OOM site) from key-iteration overhead.
+func runBuild(t *testing.T, label string, stream streamer, outPath string, sharded bool) buildResult {
+	t.Helper()
+
+	type writerLike interface {
+		AddHash(uint64) error
+		DisableFsync()
+	}
+	var (
+		w     writerLike
+		build func() error
+		close func()
+	)
+	if sharded {
+		ww, err := NewWriterSharded(outPath)
+		if err != nil {
+			t.Fatalf("%s: NewWriterSharded: %v", label, err)
+		}
+		w = ww
+		build = ww.Build
+		close = ww.Close
+	} else {
+		ww, err := NewWriter(outPath)
+		if err != nil {
+			t.Fatalf("%s: NewWriter: %v", label, err)
+		}
+		w = ww
+		build = ww.Build
+		close = ww.Close
+	}
+	w.DisableFsync()
+
+	ingestStart := time.Now()
+	count, err := stream.each(func(h uint64) error { return w.AddHash(h) })
+	ingestWall := time.Since(ingestStart)
+	if err != nil {
+		t.Fatalf("%s: ingest: %v", label, err)
+	}
+
+	// Drop any per-stream buffers and let the GC run BEFORE we start measuring
+	// Build. Anything still on the heap at this point is part of the writer's
+	// own state — exactly what the OOM-prone path holds onto.
+	runtime.GC()
+	sampler := startPeakSampler(500 * time.Microsecond)
+	buildStart := time.Now()
+	if err := build(); err != nil {
+		sampler.Stop()
+		t.Fatalf("%s: Build: %v", label, err)
+	}
+	buildWall := time.Since(buildStart)
+	peak := sampler.Stop()
+	close()
+
+	st, err := os.Stat(outPath)
+	if err != nil {
+		t.Fatalf("%s: stat: %v", label, err)
+	}
+	t.Logf("%-7s  ingest=%s  build=%s  peak=%.1f MB  size=%.1f MB  keys=%d",
+		label, ingestWall, buildWall, mb(peak), mb(uint64(st.Size())), count)
+	return buildResult{
+		keyCount:   count,
+		peakHeap:   peak,
+		fileSize:   uint64(st.Size()),
+		ingestWall: ingestWall,
+		buildWall:  buildWall,
+	}
+}
+
+func verifyParity(t *testing.T, stream streamer, plainPath, shardPath string) {
+	t.Helper()
+	plain, err := NewReader(plainPath)
+	if err != nil {
+		t.Fatalf("open plain: %v", err)
+	}
+	defer plain.Close()
+	shard, err := NewReaderSharded(shardPath)
+	if err != nil {
+		t.Fatalf("open sharded: %v", err)
+	}
+	defer shard.Close()
+
+	missingPlain, missingShard := 0, 0
+	count, err := stream.each(func(h uint64) error {
+		if !plain.ContainsHash(h) {
+			missingPlain++
+		}
+		if !shard.ContainsHash(h) {
+			missingShard++
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("parity stream: %v", err)
+	}
+	if missingPlain != 0 || missingShard != 0 {
+		t.Fatalf("missing keys: plain=%d sharded=%d (must be 0 — fuse filter has 0%% false-negative rate)", missingPlain, missingShard)
+	}
+	t.Logf("parity ok: all %d input hashes present in both readers", count)
+}
+
+// measureFP samples the false-positive rate of the sharded reader by probing
+// random uint64s. We deliberately do NOT build a presence map of input keys
+// (that would defeat the streaming design at scale): on any realistic input
+// size N, the chance a random uint64 collides with a known key is N/2^64 —
+// negligible (3 B keys → ~1.6e-10), so collisions with the input set vanish
+// into the FP-rate noise.
+func measureFP(t *testing.T, shardPath string) {
+	t.Helper()
+	r, err := NewReaderSharded(shardPath)
+	if err != nil {
+		t.Fatalf("open sharded for fp probe: %v", err)
+	}
+	defer r.Close()
+
+	rng := rand.New(rand.NewPCG(7, 11))
+	const probes = 200_000
+	fp := 0
+	for i := 0; i < probes; i++ {
+		if r.ContainsHash(rng.Uint64()) {
+			fp++
+		}
+	}
+	t.Logf("sharded false-positive rate: %d/%d = %.4f%% (xorfilter[uint8] target ~0.39%%)", fp, probes, float64(fp)/float64(probes)*100)
+}
+
+// streamer is a re-runnable hash producer. Calling each() walks the underlying
+// file from the start and invokes fn for every hash; it can be called multiple
+// times (each call re-opens the file) so plain build, sharded build and parity
+// check each get a fresh pass.
+type streamer interface {
+	each(fn func(uint64) error) (int, error)
+}
+
+func streamerFor(path, mode string) (streamer, error) {
+	switch mode {
+	case "kv":
+		return &kvStreamer{path: path}, nil
+	case "raw":
+		return &rawStreamer{path: path}, nil
+	default:
+		return nil, fmt.Errorf("unknown FUSEFILTER_INPUT_MODE=%q (want kv or raw)", mode)
+	}
+}
+
+type kvStreamer struct{ path string }
+
+func (s *kvStreamer) each(fn func(uint64) error) (int, error) {
+	d, err := seg.NewDecompressor(s.path)
+	if err != nil {
+		return 0, fmt.Errorf("seg.NewDecompressor: %w", err)
+	}
+	defer d.Close()
+	g := d.MakeGetter()
+
+	const salt uint32 = 0
+	var key []byte
+	count := 0
+	keyTurn := true
+	for g.HasNext() {
+		key, _ = g.Next(key[:0])
+		if keyTurn {
+			hi, _ := murmur3.Sum128WithSeed(key, salt)
+			if err := fn(hi); err != nil {
+				return count, err
+			}
+			count++
+		}
+		keyTurn = !keyTurn
+	}
+	return count, nil
+}
+
+type rawStreamer struct{ path string }
+
+func (s *rawStreamer) each(fn func(uint64) error) (int, error) {
+	f, err := os.Open(s.path)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	st, err := f.Stat()
+	if err != nil {
+		return 0, err
+	}
+	if st.Size()%8 != 0 {
+		return 0, fmt.Errorf("raw file size %d not a multiple of 8", st.Size())
+	}
+	br := bufio.NewReaderSize(f, 1<<20)
+	var buf [8]byte
+	count := 0
+	for {
+		_, err := io.ReadFull(br, buf[:])
+		if errors.Is(err, io.EOF) {
+			return count, nil
+		}
+		if err != nil {
+			return count, err
+		}
+		if err := fn(binary.LittleEndian.Uint64(buf[:])); err != nil {
+			return count, err
+		}
+		count++
+	}
+}
+
+func mb(b uint64) float64 { return float64(b) / (1 << 20) }
+
+func pct(plain, sharded uint64) float64 {
+	if plain == 0 {
+		return 0
+	}
+	return (float64(sharded) - float64(plain)) / float64(plain) * 100
+}
+
+func pctDur(plain, sharded time.Duration) float64 {
+	if plain == 0 {
+		return 0
+	}
+	return (float64(sharded) - float64(plain)) / float64(plain) * 100
+}
+
+// TestIndexFromFile_SyntheticSmoke generates a small synthetic raw file and
+// runs the same code path to make sure the harness itself works end-to-end
+// without requiring a real .kv on the box. Skips unless explicitly enabled.
+func TestIndexFromFile_SyntheticSmoke(t *testing.T) {
+	if os.Getenv("FUSEFILTER_SMOKE") == "" {
+		t.Skip("set FUSEFILTER_SMOKE=1 to run the synthetic harness self-test")
+	}
+	tmp := t.TempDir()
+	rawPath := filepath.Join(tmp, "in.raw")
+
+	rng := rand.New(rand.NewPCG(42, 7))
+	const n = 50_000
+	f, err := os.Create(rawPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf [8]byte
+	for i := 0; i < n; i++ {
+		binary.LittleEndian.PutUint64(buf[:], rng.Uint64())
+		if _, err := f.Write(buf[:]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("FUSEFILTER_INPUT", rawPath)
+	t.Setenv("FUSEFILTER_INPUT_MODE", "raw")
+	TestIndexFromFile(t)
+}

--- a/db/datastruct/fusefilter/fusefilter_writer.go
+++ b/db/datastruct/fusefilter/fusefilter_writer.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"slices"
 	"unsafe"
 
 	"github.com/erigontech/erigon/common/dir"
@@ -26,22 +27,27 @@ type WriterOffHeap struct {
 	tmpFilePath string
 }
 
+func initFeatures() Features {
+	var f Features
+	if IsLittleEndian {
+		f |= IsLittleEndianFeature
+	}
+	return f
+}
+
 func NewWriterOffHeap(filePath string) (*WriterOffHeap, error) {
 	f, err := dir.CreateTempWithExtension(filePath, "existence.tmp")
 	if err != nil {
 		return nil, err
 	}
-	var features Features
-	if IsLittleEndian {
-		features |= IsLittleEndianFeature
-	}
-	return &WriterOffHeap{tmpFile: f, features: features, tmpFilePath: f.Name()}, nil
+	return &WriterOffHeap{tmpFile: f, features: initFeatures(), tmpFilePath: f.Name()}, nil
 }
 
 func (w *WriterOffHeap) Close() {
 	if w.tmpFile != nil {
 		w.tmpFile.Close()
 		dir.RemoveFile(w.tmpFilePath)
+		w.tmpFile = nil
 	}
 }
 
@@ -73,17 +79,19 @@ func (w *WriterOffHeap) build() (*xorfilter.BinaryFuse[uint8], error) {
 	return filter, nil
 }
 
-func (w *WriterOffHeap) write(filter *xorfilter.BinaryFuse[uint8], fw io.Writer) (int, error) {
+// filterBlobHeaderSize is the fixed header size of a serialised BinaryFuse[uint8] blob.
+const filterBlobHeaderSize = 1 + 3 + 4 + 4 + 8 + 4 + 4 + 8
+
+// writeFilter serialises a built BinaryFuse filter as a version-0 fusefilter blob.
+func writeFilter(features Features, filter *xorfilter.BinaryFuse[uint8], fw io.Writer) (int, error) {
 	if filter.SegmentCount > math.MaxUint32/2 {
 		return 0, fmt.Errorf("SegmentCount=%d cannot be greater than u32/2", filter.SegmentCount)
 	}
 	const version uint8 = 0
 	var header [headerSize]byte
 
-	// 1 byte - version, 3 bytes `Features`
-	binary.BigEndian.PutUint32(header[:], uint32(w.features)) //nolint:gocritic
+	binary.BigEndian.PutUint32(header[:], uint32(features)) //nolint:gocritic
 	header[0] = version
-
 	binary.BigEndian.PutUint32(header[4:], filter.SegmentCount)
 	binary.BigEndian.PutUint32(header[4+4:], filter.SegmentCountLength)
 	binary.BigEndian.PutUint64(header[4+4+4:], filter.Seed)
@@ -117,7 +125,7 @@ func (w *WriterOffHeap) BuildTo(to io.Writer) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("%s %w", w.tmpFilePath, err)
 	}
-	return w.write(filter, to)
+	return writeFilter(w.features, filter, to)
 }
 
 type Writer struct {
@@ -181,6 +189,154 @@ func (w *Writer) Close() {
 		w.data.Close()
 		w.data = nil
 	}
+}
+
+// WriterSharded shards keys into 256 sub-filters by first byte of keyHash (keyHash >> 56).
+// Produces fusefilter file version 1. Lookup checks only the one relevant shard.
+// Embeds WriterOffHeap for the shared page-buffer + temp-file machinery.
+type WriterSharded struct {
+	WriterOffHeap
+	filePath string
+	noFsync  bool
+}
+
+func NewWriterSharded(filePath string) (*WriterSharded, error) {
+	f, err := dir.CreateTempWithExtension(filePath, "existence-sharded.tmp")
+	if err != nil {
+		return nil, err
+	}
+	return &WriterSharded{
+		WriterOffHeap: WriterOffHeap{tmpFile: f, tmpFilePath: f.Name(), features: initFeatures()},
+		filePath:      filePath,
+	}, nil
+}
+
+func (w *WriterSharded) DisableFsync() { w.noFsync = true }
+
+// Build writes the sharded fusefilter to w.filePath using the same atomic
+// temp-then-rename pattern as Writer.Build.
+func (w *WriterSharded) Build() error {
+	f, err := dir.CreateTemp(w.filePath)
+	if err != nil {
+		return fmt.Errorf("%s %w", w.filePath, err)
+	}
+	defer dir.RemoveFile(f.Name())
+	defer f.Close()
+
+	fw := bufio.NewWriter(f)
+	if _, err = w.BuildTo(fw); err != nil {
+		return fmt.Errorf("%s %w", w.filePath, err)
+	}
+	if err = fw.Flush(); err != nil {
+		return err
+	}
+	if !w.noFsync {
+		if err = f.Sync(); err != nil {
+			return err
+		}
+	}
+	if err = f.Close(); err != nil {
+		return err
+	}
+	return os.Rename(f.Name(), w.filePath)
+}
+
+// BuildTo writes sharded fusefilter (file version 1) to fw.
+// Format: [4 bytes header] then 256 × [8 bytes size | blob] pairs (size==0 means absent).
+// Fully streaming: no intermediate files, one shard's fingerprints in RAM at a time.
+func (w *WriterSharded) BuildTo(fw io.Writer) (int, error) {
+	defer dir.RemoveFile(w.tmpFilePath)
+
+	if rem := w.count % len(w.page); rem != 0 {
+		if _, err := w.tmpFile.Write(castToBytes(w.page[:rem])); err != nil {
+			return 0, err
+		}
+	}
+
+	st, err := w.tmpFile.Stat()
+	if err != nil {
+		return 0, err
+	}
+	sz := int(st.Size())
+	if sz == 0 {
+		return 0, fmt.Errorf("WriterSharded: no keys added")
+	}
+
+	m, err := mmap.MapRegion(w.tmpFile, sz, mmap.RDWR, 0, 0)
+	if err != nil {
+		return 0, fmt.Errorf("%s %w", w.tmpFilePath, err)
+	}
+	defer m.Unmap()
+
+	all := castToArrU64(m[:sz])
+	slices.Sort(all) // ascending sort groups hashes by top byte = shard index
+
+	// Find the largest shard so MakeBinaryFuseBuilder preallocates buffers that
+	// fit every shard. Without this, sizing the builder to the average shard
+	// (len(all)/256) leaves xorfilter's reuseBuffer to grow buffers on the first
+	// above-average shard via `*buf = append((*buf)[:0], make([]T, size)...)`,
+	// which holds the old AND new buffers live until GC — doubling peak heap
+	// briefly. This prescan is one sequential walk over the just-sorted (and
+	// thus cache-warm) mmap, so it's essentially free.
+	var maxShardSize int
+	{
+		i := 0
+		for shard := range 256 {
+			start := i
+			for i < len(all) && all[i]>>56 == uint64(shard) {
+				i++
+			}
+			if sz := i - start; sz > maxShardSize {
+				maxShardSize = sz
+			}
+		}
+	}
+
+	const version1 uint8 = 1
+	var header [4]byte
+	binary.BigEndian.PutUint32(header[:], uint32(w.features))
+	header[0] = version1
+	if _, err := fw.Write(header[:]); err != nil {
+		return 0, err
+	}
+	total := 4
+
+	builder := xorfilter.MakeBinaryFuseBuilder[uint8](maxShardSize)
+	var sizeBuf [8]byte
+	i := 0
+	for shard := range 256 {
+		start := i
+		for i < len(all) && all[i]>>56 == uint64(shard) {
+			i++
+		}
+		if start == i {
+			binary.BigEndian.PutUint64(sizeBuf[:], 0)
+			if _, err := fw.Write(sizeBuf[:]); err != nil {
+				return 0, err
+			}
+			total += 8
+			continue
+		}
+		filter, err := xorfilter.BuildBinaryFuse[uint8](&builder, all[start:i])
+		if err != nil {
+			return 0, fmt.Errorf("shard %d: %w", shard, err)
+		}
+		blobSize := filterSize(&filter)
+		binary.BigEndian.PutUint64(sizeBuf[:], uint64(blobSize))
+		if _, err := fw.Write(sizeBuf[:]); err != nil {
+			return 0, err
+		}
+		n, err := writeFilter(w.features, &filter, fw)
+		if err != nil {
+			return 0, fmt.Errorf("shard %d: %w", shard, err)
+		}
+		total += 8 + n
+	}
+	return total, nil
+}
+
+func filterSize(f *xorfilter.BinaryFuse[uint8]) int {
+	return filterBlobHeaderSize + len(f.Fingerprints)
 }
 
 // castToBytes converts []uint64 to []byte without copying data

--- a/db/datastruct/fusefilter/fusefilter_writer_test.go
+++ b/db/datastruct/fusefilter/fusefilter_writer_test.go
@@ -3,6 +3,8 @@ package fusefilter
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"testing"
@@ -209,6 +211,281 @@ func TestWriterClose(t *testing.T) {
 	writer.Close()
 }
 
+func TestWriterShardedBasic(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+
+	w, err := NewWriterSharded(filepath.Join(dir, "sharded"))
+	require.NoError(err)
+	defer w.Close()
+
+	keys := []uint64{1, 2, 3, 0xFF << 56, 0xAB<<56 | 12345, 0x01<<56 | 99}
+	for _, k := range keys {
+		require.NoError(w.AddHash(k))
+	}
+
+	var buf bytes.Buffer
+	_, err = w.BuildTo(&buf)
+	require.NoError(err)
+
+	r, consumed, err := NewReaderShardedOnBytes(buf.Bytes(), "test")
+	require.NoError(err)
+	require.Equal(buf.Len(), consumed)
+
+	for _, k := range keys {
+		require.True(r.ContainsHash(k), "key %d missing", k)
+	}
+	// Keys in different shards are absent.
+	require.False(r.ContainsHash(0xBB<<56 | 99999))
+}
+
+func TestWriterShardedLarge(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+
+	w, err := NewWriterSharded(filepath.Join(dir, "sharded_large"))
+	require.NoError(err)
+	defer w.Close()
+
+	const n = 100_000
+	for i := range n {
+		require.NoError(w.AddHash(uint64(i)))
+	}
+
+	var buf bytes.Buffer
+	_, err = w.BuildTo(&buf)
+	require.NoError(err)
+
+	r, _, err := NewReaderShardedOnBytes(buf.Bytes(), "test")
+	require.NoError(err)
+
+	for i := range n {
+		require.True(r.ContainsHash(uint64(i)), "key %d missing", i)
+	}
+}
+
+func TestWriterShardedForceInMem(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+
+	w, err := NewWriterSharded(filepath.Join(dir, "sharded_mem"))
+	require.NoError(err)
+	defer w.Close()
+	require.NoError(w.AddHash(42))
+
+	var buf bytes.Buffer
+	_, err = w.BuildTo(&buf)
+	require.NoError(err)
+
+	r, _, err := NewReaderShardedOnBytes(buf.Bytes(), "test")
+	require.NoError(err)
+
+	sz := r.ForceInMem()
+	require.Greater(uint64(sz), uint64(0))
+	require.True(r.ContainsHash(42))
+}
+
+func TestWriterShardedSingleShard(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+
+	w, err := NewWriterSharded(filepath.Join(dir, "single_shard"))
+	require.NoError(err)
+	defer w.Close()
+
+	// All keys have high byte = 0x42 — only shard 0x42 is populated
+	const shard = uint64(0x42)
+	keys := []uint64{shard<<56 | 1, shard<<56 | 2, shard<<56 | 999, shard<<56 | 0xFFFF}
+	for _, k := range keys {
+		require.NoError(w.AddHash(k))
+	}
+
+	var buf bytes.Buffer
+	_, err = w.BuildTo(&buf)
+	require.NoError(err)
+
+	r, consumed, err := NewReaderShardedOnBytes(buf.Bytes(), "test")
+	require.NoError(err)
+	require.Equal(buf.Len(), consumed)
+
+	for _, k := range keys {
+		require.True(r.ContainsHash(k), "key %#x missing", k)
+	}
+	// All other shards absent
+	require.False(r.ContainsHash(uint64(0x00)<<56 | 1))
+	require.False(r.ContainsHash(uint64(0xFF)<<56 | 1))
+}
+
+func TestWriterShardedTruncated(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+
+	w, err := NewWriterSharded(filepath.Join(dir, "trunc"))
+	require.NoError(err)
+	defer w.Close()
+	for i := range 10 {
+		require.NoError(w.AddHash(uint64(i)))
+	}
+
+	var buf bytes.Buffer
+	_, err = w.BuildTo(&buf)
+	require.NoError(err)
+	full := buf.Bytes()
+
+	_, _, err = NewReaderShardedOnBytes(full[:2], "trunc") // shorter than 4-byte header
+	require.Error(err)
+
+	_, _, err = NewReaderShardedOnBytes(full[:5], "trunc") // header ok but truncated shard table
+	require.Error(err)
+}
+
+func TestWriterShardedSegmentCountRoundTrip(t *testing.T) {
+	// Regression: SegmentCount and SegmentCountLength were aliased (both read from offset 8).
+	require := require.New(t)
+	dir := t.TempDir()
+
+	filePath := filepath.Join(dir, "seg_count")
+	writer, err := NewWriter(filePath)
+	require.NoError(err)
+	defer writer.Close()
+
+	const n = 1000
+	for i := range n {
+		require.NoError(writer.AddHash(uint64(i)))
+	}
+	require.NoError(writer.Build())
+	writer.Close()
+
+	f, err := os.Open(filePath)
+	require.NoError(err)
+	defer f.Close()
+	raw, err := io.ReadAll(f)
+	require.NoError(err)
+
+	r, _, err := NewReaderOnBytes(raw, "seg_count")
+	require.NoError(err)
+	require.NotZero(r.inner.SegmentCount)
+	require.NotZero(r.inner.SegmentCountLength)
+	require.NotZero(r.inner.SegmentLength)
+}
+
+// 200K random keys, then probe 200K fresh randoms. Expects FP rate < 1%.
+func TestWriterShardedUniformDistribution(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "sharded_uniform")
+
+	rng := rand.New(rand.NewPCG(1, 2))
+	const keyCount = 200_000
+	keys := make(map[uint64]struct{}, keyCount)
+	for len(keys) < keyCount {
+		keys[rng.Uint64()] = struct{}{}
+	}
+
+	w, err := NewWriterSharded(filePath)
+	require.NoError(err)
+	w.DisableFsync()
+	for k := range keys {
+		require.NoError(w.AddHash(k))
+	}
+	require.NoError(w.Build())
+	w.Close()
+
+	r, err := NewReaderSharded(filePath)
+	require.NoError(err)
+	defer r.Close()
+
+	for k := range keys {
+		require.True(r.ContainsHash(k))
+	}
+
+	falsePositives := 0
+	const probes = 200_000
+	for i := 0; i < probes; i++ {
+		var k uint64
+		for {
+			k = rng.Uint64()
+			if _, ok := keys[k]; !ok {
+				break
+			}
+		}
+		if r.ContainsHash(k) {
+			falsePositives++
+		}
+	}
+	fpRate := float64(falsePositives) / float64(probes)
+	t.Logf("false positive rate: %d/%d = %.4f%%", falsePositives, probes, fpRate*100)
+	require.Less(fpRate, 0.01, "false positive rate unexpectedly high")
+}
+
+// Per-shard fill counts at 511/512/513 stress the page-flush boundary in
+// WriterOffHeap (page = 512 uint64s).
+func TestWriterShardedPageBoundary(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "sharded_pageboundary")
+
+	// v2 shards by high byte: pack shard id into the high byte.
+	plan := map[uint64]int{
+		0x01: 511,
+		0x02: 512,
+		0x03: 513,
+		0x04: 500,
+		0x05: 1024,
+		0x07: 100,
+	}
+	var allKeys []uint64
+	for shard, n := range plan {
+		for i := 0; i < n; i++ {
+			allKeys = append(allKeys, shard<<56|uint64(i))
+		}
+	}
+
+	w, err := NewWriterSharded(filePath)
+	require.NoError(err)
+	w.DisableFsync()
+	for _, k := range allKeys {
+		require.NoError(w.AddHash(k))
+	}
+	require.NoError(w.Build())
+	w.Close()
+
+	r, err := NewReaderSharded(filePath)
+	require.NoError(err)
+	defer r.Close()
+	for _, k := range allKeys {
+		require.True(r.ContainsHash(k))
+	}
+}
+
+// Feed duplicated hashes to one shard to exercise xorfilter's in-place
+// pruneDuplicates pass against the RDWR mmap of the temp file.
+func TestWriterShardedMmapMutationOnDuplicates(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "sharded_dedup")
+
+	const unique = 1000
+	w, err := NewWriterSharded(filePath)
+	require.NoError(err)
+	w.DisableFsync()
+	for i := 0; i < unique; i++ {
+		require.NoError(w.AddHash(uint64(i)))
+	}
+	for i := 0; i < 100; i++ {
+		require.NoError(w.AddHash(uint64(i))) // duplicates
+	}
+	require.NoError(w.Build())
+	w.Close()
+
+	r, err := NewReaderSharded(filePath)
+	require.NoError(err)
+	defer r.Close()
+	for i := 0; i < unique; i++ {
+		require.True(r.ContainsHash(uint64(i)))
+	}
+}
+
 // requireFilterEqual asserts every header field and fingerprint count match between two filters.
 func requireFilterEqual(t *testing.T, expected, got *xorfilter.BinaryFuse[uint8]) {
 	t.Helper()
@@ -236,7 +513,7 @@ func TestHeaderRoundTrip(t *testing.T) {
 	require.NoError(err)
 
 	var buf bytes.Buffer
-	_, err = w.write(original, &buf)
+	_, err = writeFilter(w.features, original, &buf)
 	require.NoError(err)
 
 	r, _, err := NewReaderOnBytes(buf.Bytes(), "test")

--- a/db/recsplit/index.go
+++ b/db/recsplit/index.go
@@ -105,6 +105,7 @@ type Index struct {
 	lessFalsePositives bool
 	existenceV0        []byte
 	existenceV1        *fusefilter.Reader
+	existenceV2        *fusefilter.ReaderSharded
 
 	readers         *sync.Pool
 	readAheadRefcnt atomic.Int32 // ref-counter: allow enable/disable read-ahead from goroutines. only when refcnt=0 - disable read-ahead once
@@ -243,19 +244,38 @@ func (idx *Index) init() (err error) {
 		offset += int(arrSz)
 	}
 
-	if idx.dataStructureVersion >= 1 && idx.lessFalsePositives && idx.keyCount > 0 {
-		var sz int
-		idx.existenceV1, sz, err = fusefilter.NewReaderOnBytes(idx.data[offset:], idx.fileName)
-		if err != nil {
-			return fmt.Errorf("NewReaderOnBytes: %w, %s", err, idx.fileName)
+	if idx.lessFalsePositives && idx.keyCount > 0 {
+		switch idx.dataStructureVersion {
+		case 0: // parsed above
+		case 1:
+			var sz int
+			idx.existenceV1, sz, err = fusefilter.NewReaderOnBytes(idx.data[offset:], idx.fileName)
+			if err != nil {
+				return fmt.Errorf("NewReaderOnBytes: %w, %s", err, idx.fileName)
+			}
+			if fusefilter.MadvWillNeedByDefault {
+				idx.existenceV1.MadvWillNeed()
+			}
+			if fusefilter.MadvNormalByDefault {
+				idx.existenceV1.MadvNormal()
+			}
+			offset += sz
+		case 2:
+			var sz int
+			idx.existenceV2, sz, err = fusefilter.NewReaderShardedOnBytes(idx.data[offset:], idx.fileName)
+			if err != nil {
+				return fmt.Errorf("NewReaderShardedOnBytes: %w, %s", err, idx.fileName)
+			}
+			if fusefilter.MadvWillNeedByDefault {
+				idx.existenceV2.MadvWillNeed()
+			}
+			if fusefilter.MadvNormalByDefault {
+				idx.existenceV2.MadvNormal()
+			}
+			offset += sz
+		default:
+			return fmt.Errorf("%w. unsupported existence filter version %d", IncompatibleErr, idx.dataStructureVersion)
 		}
-		if fusefilter.MadvWillNeedByDefault {
-			idx.existenceV1.MadvWillNeed()
-		}
-		if fusefilter.MadvNormalByDefault {
-			idx.existenceV1.MadvNormal()
-		}
-		offset += sz
 	}
 
 	// Size of golomb rice params
@@ -292,8 +312,13 @@ func (idx *Index) ForceExistenceFilterNormal() {
 	}
 }
 func (idx *Index) ForceExistenceFilterInRAM() datasize.ByteSize {
-	if idx.dataStructureVersion >= 1 && idx.lessFalsePositives && idx.keyCount > 0 {
-		return idx.existenceV1.ForceInMem()
+	if idx.lessFalsePositives && idx.keyCount > 0 {
+		switch idx.dataStructureVersion {
+		case 1:
+			return idx.existenceV1.ForceInMem()
+		case 2:
+			return idx.existenceV2.ForceInMem()
+		}
 	}
 	return 0
 }
@@ -376,9 +401,16 @@ func (idx *Index) Lookup(bucketHash, fingerprint uint64) (uint64, bool) {
 	if idx.keyCount == 1 {
 		return 0, true
 	}
-	if idx.dataStructureVersion == 1 && idx.lessFalsePositives {
-		if ok := idx.existenceV1.ContainsHash(bucketHash); !ok {
-			return 0, false
+	if idx.lessFalsePositives {
+		switch idx.dataStructureVersion {
+		case 1:
+			if ok := idx.existenceV1.ContainsHash(bucketHash); !ok {
+				return 0, false
+			}
+		case 2:
+			if ok := idx.existenceV2.ContainsHash(bucketHash); !ok {
+				return 0, false
+			}
 		}
 	}
 

--- a/db/recsplit/recsplit.go
+++ b/db/recsplit/recsplit.go
@@ -54,6 +54,22 @@ const RecSplitLogPrefix = "recsplit"
 
 const MaxLeafSize = 24
 
+// ExistenceFilterVersion selects the existence-filter format written for new index files.
+//
+//	0 = byte-array of first-bytes (legacy, no FuseFilter)
+//	1 = BinaryFuse[uint8] — monolithic FuseFilter (current default)
+//	2 = BinaryFuse[uint8] sharded by keyHash>>56 (256 shards; reduces build-time RAM 256×)
+const ExistenceFilterVersion version.DataStructureVersion = 2
+
+func newExistenceFilterWriter(filePath string, v version.DataStructureVersion) (v1 *fusefilter.WriterOffHeap, v2 *fusefilter.WriterSharded, err error) {
+	if v == 2 {
+		v2, err = fusefilter.NewWriterSharded(filePath)
+		return
+	}
+	v1, err = fusefilter.NewWriterOffHeap(filePath)
+	return
+}
+
 /** David Stafford's (http://zimbry.blogspot.com/2011/09/better-bit-mixing-improving-on.html)
  * 13th variant of the 64-bit finalizer function in Austin Appleby's
  * MurmurHash3 (https://github.com/aappleby/smhasher).
@@ -133,6 +149,9 @@ type RecSplit struct {
 	//v1 fields
 	existenceFV1 *fusefilter.WriterOffHeap
 
+	//v2 fields
+	existenceFV2 *fusefilter.WriterSharded
+
 	offsetFile   *os.File      // Temp file for offsets (already sorted, no need for etl.Collector)
 	offsetWriter *bufio.Writer // Buffered writer for offset file
 
@@ -187,7 +206,7 @@ type RecSplitArgs struct {
 	// if Enum=true:  must have sorted values (can have duplicates) - monotonically growing sequence
 	Enums              bool
 	LessFalsePositives bool
-	Version            uint8
+	Version            version.DataStructureVersion
 
 	IndexFile  string // File name where the index and the minimal perfect hash function will be written to
 	TmpDir     string
@@ -282,7 +301,7 @@ func NewRecSplit(args RecSplitArgs, logger log.Logger) (*RecSplit, error) {
 
 	}
 	if args.KeyCount > 0 && rs.lessFalsePositives && rs.dataStructureVersion >= 1 {
-		rs.existenceFV1, err = fusefilter.NewWriterOffHeap(rs.filePath)
+		rs.existenceFV1, rs.existenceFV2, err = newExistenceFilterWriter(rs.filePath, rs.dataStructureVersion)
 		if err != nil {
 			return nil, err
 		}
@@ -369,6 +388,10 @@ func (rs *RecSplit) Close() {
 	if rs.existenceFV1 != nil {
 		rs.existenceFV1.Close()
 		rs.existenceFV1 = nil
+	}
+	if rs.existenceFV2 != nil {
+		rs.existenceFV2.Close()
+		rs.existenceFV2 = nil
 	}
 	if rs.bucketCollector != nil {
 		rs.bucketCollector.Close()
@@ -535,9 +558,16 @@ func (rs *RecSplit) AddKey(key []byte, offset uint64) error {
 		}
 	}
 
-	if rs.lessFalsePositives && rs.dataStructureVersion >= 1 {
-		if err := rs.existenceFV1.AddHash(hi); err != nil {
-			return err
+	if rs.lessFalsePositives {
+		switch rs.dataStructureVersion {
+		case 1:
+			if err := rs.existenceFV1.AddHash(hi); err != nil {
+				return err
+			}
+		case 2:
+			if err := rs.existenceFV2.AddHash(hi); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -1089,10 +1119,16 @@ func (rs *RecSplit) flushExistenceFilter() error {
 		}
 	}
 
-	if rs.dataStructureVersion >= 1 && rs.keysAdded > 0 && rs.lessFalsePositives {
-		_, err := rs.existenceFV1.BuildTo(rs.indexW)
-		if err != nil {
-			return err
+	if rs.keysAdded > 0 && rs.lessFalsePositives {
+		switch rs.dataStructureVersion {
+		case 1:
+			if _, err := rs.existenceFV1.BuildTo(rs.indexW); err != nil {
+				return err
+			}
+		case 2:
+			if _, err := rs.existenceFV2.BuildTo(rs.indexW); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/db/recsplit/recsplit_test.go
+++ b/db/recsplit/recsplit_test.go
@@ -161,6 +161,11 @@ func TestIndexLookup(t *testing.T) {
 		cfg.Version = 1
 		test(t, cfg)
 	})
+	t.Run("v2", func(t *testing.T) {
+		cfg := cfg
+		cfg.Version = 2
+		test(t, cfg)
+	})
 }
 
 func TestFindBijection(t *testing.T) {
@@ -479,6 +484,11 @@ func TestTwoLayerIndex(t *testing.T) {
 	t.Run("v1", func(t *testing.T) {
 		cfg := cfg
 		cfg.Version = 1
+		test(t, cfg)
+	})
+	t.Run("v2", func(t *testing.T) {
+		cfg := cfg
+		cfg.Version = 2
 		test(t, cfg)
 	})
 }

--- a/db/snaptype/type.go
+++ b/db/snaptype/type.go
@@ -494,9 +494,9 @@ func BuildIndex(ctx context.Context, info FileInfo, indexVersion version.Version
 	cfg.KeyCount = d.Count()
 	idxVer := indexVersion.Current
 	cfg.IndexFile = filepath.Join(info.Dir(), info.Type.IdxFileName(idxVer, info.From, info.To))
-	versionOfRs := uint8(0)
+	versionOfRs := version.DataStructureVersion(0)
 	if !idxVer.Eq(version.V1_0) { // inner version=1 incompatible with .efi v1.0
-		versionOfRs = 1
+		versionOfRs = recsplit.ExistenceFilterVersion
 	}
 	cfg.Version = versionOfRs
 	rs, err := recsplit.NewRecSplit(cfg, logger)

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1050,9 +1050,9 @@ func (d *Domain) buildFiles(ctx context.Context, step kv.Step, collation Collati
 
 func (d *Domain) buildHashMapAccessor(ctx context.Context, fromStep, toStep kv.Step, data *seg.Reader, ps *background.ProgressSet) error {
 	idxPath := d.kviAccessorNewFilePath(fromStep, toStep)
-	versionOfRs := uint8(0)
-	if !d.FileVersion.AccessorKVI.Current.Eq(version.V1_0) { // inner version=1 incompatible with .efi v1.0
-		versionOfRs = 1
+	versionOfRs := version.DataStructureVersion(0)
+	if !d.FileVersion.AccessorKVI.Current.Eq(version.V1_0) { // v1.0 files predate FuseFilter; dataStructureVersion>=1 is incompatible with them
+		versionOfRs = recsplit.ExistenceFilterVersion
 	}
 	cfg := recsplit.RecSplitArgs{
 		Version:            versionOfRs,

--- a/db/state/inverted_index.go
+++ b/db/state/inverted_index.go
@@ -1159,9 +1159,9 @@ func (ii *InvertedIndex) buildFiles(ctx context.Context, step kv.Step, coll Inve
 
 func (ii *InvertedIndex) buildMapAccessor(ctx context.Context, fromStep, toStep kv.Step, data *seg.Reader, ps *background.ProgressSet) error {
 	idxPath := ii.efAccessorNewFilePath(fromStep, toStep)
-	versionOfRs := uint8(0)
-	if !ii.FileVersion.AccessorEFI.Current.Eq(version.V1_0) { // inner version=1 incompatible with .efi v1.0
-		versionOfRs = 1
+	versionOfRs := version.DataStructureVersion(0)
+	if !ii.FileVersion.AccessorEFI.Current.Eq(version.V1_0) { // v1.0 files predate FuseFilter; dataStructureVersion>=1 is incompatible with them
+		versionOfRs = recsplit.ExistenceFilterVersion
 	}
 	cfg := recsplit.RecSplitArgs{
 		BucketSize: recsplit.DefaultBucketSize,

--- a/scripts/fusefilter-bench/fuse_compare.sh
+++ b/scripts/fusefilter-bench/fuse_compare.sh
@@ -1,0 +1,319 @@
+#!/usr/bin/env bash
+# fuse_compare.sh — run one Erigon binary on /erigon-data/chiado_commit_gate
+# with .kvei/.efi accessor files removed, so the fusefilter build path
+# (WriterSharded vs legacy Writer) is exercised end-to-end. Polls Prometheus
+# memory metrics into a CSV so two runs can be compared side by side.
+#
+# Usage:
+#   scripts/fusefilter-bench/fuse_compare.sh <binary-path> <label>
+#
+# Example:
+#   scripts/fusefilter-bench/fuse_compare.sh ./build/bin/erigon_main    main
+#   scripts/fusefilter-bench/fuse_compare.sh ./build/bin/erigon_fusesharded sharded
+#
+# Stop the run with Ctrl+C — the script SIGINTs erigon, waits up to 60s for a
+# clean shutdown, then SIGKILLs as a fallback. A summary (peak RSS, peak heap)
+# is printed at exit and the CSV path is reported.
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <binary-path> <label>" >&2
+  exit 2
+fi
+
+BIN="$1"
+LABEL="$2"
+
+if [[ ! -x "$BIN" ]]; then
+  echo "binary not found or not executable: $BIN" >&2
+  exit 2
+fi
+
+DATADIR=/erigon-data/chiado_commit_gate
+LOGDIR=/erigon-logs
+METRICS_HOST=127.0.0.1
+METRICS_PORT=6061
+METRICS_URL=""                  # discovered after erigon starts (step 3a)
+POLL_INTERVAL=3                 # seconds between metric samples
+SHUTDOWN_GRACE=60               # seconds to wait after SIGINT before SIGKILL
+HARD_TIMEOUT_MIN=30             # safety cap — script self-stops after this many minutes if user forgets Ctrl+C
+
+mkdir -p "$LOGDIR"
+
+TS=$(date +%Y%m%d_%H%M%S)
+LOG="$LOGDIR/erigon-${LABEL}-${TS}.log"
+CSV="$LOGDIR/fuse-compare-${LABEL}-${TS}.csv"
+PIDFILE="$LOGDIR/erigon-${LABEL}.pid"
+
+# ---------- 1. Pre-flight: refuse if a previous run is still alive ---------- #
+if [[ -f "$PIDFILE" ]] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
+  echo "previous erigon with label '$LABEL' still running (PID $(cat "$PIDFILE")). kill it first." >&2
+  exit 3
+fi
+
+# ---------- 2. Wipe chaindata and recsplit accessor files ---------- #
+# The PR's WriterSharded path is reached via recsplit's flushExistenceFilter,
+# which embeds a fusefilter blob inside the recsplit index file (.efi/.kvi/.vi).
+# .kvei is a separate file written by existence.Filter — currently always in
+# bloom-filter mode (useFuse=false everywhere), so deleting it does NOT exercise
+# the PR. The recsplit indexes are what we need to force-rebuild.
+#
+# Removing chaindata/ on top forces erigon to re-execute and re-index from
+# snapshots, which is what triggers BuildMissedAccessors → recsplit → our
+# fusefilter writer.
+if [[ ! -d "$DATADIR" ]]; then
+  echo "datadir does not exist: $DATADIR" >&2
+  exit 2
+fi
+
+CHAINDATA="$DATADIR/chaindata"
+echo "==> wiping $CHAINDATA"
+if [[ -d "$CHAINDATA" ]]; then
+  CHAINDATA_SIZE=$(du -sh "$CHAINDATA" 2>/dev/null | awk '{print $1}')
+  echo "    size before: $CHAINDATA_SIZE"
+  rm -rf "$CHAINDATA"
+  echo "    removed."
+else
+  echo "    (already absent)"
+fi
+
+echo "==> wiping recsplit accessor files (.efi/.kvi/.vi) under $DATADIR"
+EFI_COUNT=$(find "$DATADIR" -type f -name '*.efi' | wc -l | tr -d ' ')
+KVI_COUNT=$(find "$DATADIR" -type f -name '*.kvi' | wc -l | tr -d ' ')
+VI_COUNT=$(find  "$DATADIR" -type f -name '*.vi'  | wc -l | tr -d ' ')
+echo "    found: .efi=$EFI_COUNT  .kvi=$KVI_COUNT  .vi=$VI_COUNT"
+find "$DATADIR" -type f \( -name '*.efi' -o -name '*.kvi' -o -name '*.vi' \) -delete
+echo "    deleted."
+
+# ---------- 3. Launch erigon ---------- #
+echo "==> launching erigon ($BIN) — log: $LOG"
+COLLECT_TABLE_SIZES_FREQUENCY=3s nohup "$BIN" \
+  --datadir "$DATADIR" \
+  --chain=chiado \
+  --private.api.addr=127.0.0.1:0 \
+  --metrics.port=$METRICS_PORT --metrics --metrics.addr=0.0.0.0 \
+  --nat=stun \
+  --torrent.download.rate 10G --torrent.upload.rate=1k \
+  --pprof --pprof.port=6062 \
+  --prune.mode=archive --persist.receipts \
+  --db.pagesize=4k \
+  --sync.loop.block.limit=10_000_000 \
+  --batchSize=512m --http=false \
+  --prune.experimental.include-commitment-history \
+  --database.verbosity=3 --log.console.verbosity=4 \
+  > "$LOG" 2>&1 &
+ERIGON_PID=$!
+echo "$ERIGON_PID" > "$PIDFILE"
+echo "    erigon PID=$ERIGON_PID"
+
+# ---------- 3a. Discover the working metrics endpoint ---------- #
+# Erigon may bind to IPv4-only (0.0.0.0), IPv6-only ([::]), or both, and the
+# metrics path may differ between versions. Try the cartesian product of
+# candidate hosts × paths until one returns Prometheus-shaped content.
+#
+# Observed gotcha: with --metrics.addr=0.0.0.0 erigon sometimes ends up bound
+# to [::]:6061 and the kernel won't accept an IPv4 connection to 127.0.0.1
+# unless net.ipv6.bindv6only=0. `curl 0.0.0.0:port` works around it via the
+# kernel's "connect-to-0.0.0.0 means 127.0.0.1" quirk; `localhost` resolves to
+# both IPv4 and IPv6 so curl falls through to whichever socket is live.
+CANDIDATE_HOSTS=(127.0.0.1 localhost 0.0.0.0 ::1)
+CANDIDATE_PATHS=(/debug/metrics/prometheus /debug/metrics /metrics)
+
+probe_metrics_endpoint() {
+  local host path url code
+  for host in "${CANDIDATE_HOSTS[@]}"; do
+    for path in "${CANDIDATE_PATHS[@]}"; do
+      if [[ "$host" == "::1" ]]; then
+        url="http://[${host}]:${METRICS_PORT}${path}"
+      else
+        url="http://${host}:${METRICS_PORT}${path}"
+      fi
+      code=$(curl -sS -m 2 -o /tmp/fuse_probe.$$ -w '%{http_code}' "$url" 2>/dev/null || echo 000)
+      if [[ "$code" == "200" ]] && grep -aq '^# HELP\|^# TYPE\|^process_resident_memory_bytes' /tmp/fuse_probe.$$ 2>/dev/null; then
+        rm -f /tmp/fuse_probe.$$ 2>/dev/null || true
+        echo "$url"
+        return 0
+      fi
+    done
+  done
+  rm -f /tmp/fuse_probe.$$ 2>/dev/null || true
+  return 1
+}
+
+echo "==> probing metrics endpoint (port $METRICS_PORT, 60s upfront budget)"
+METRICS_URL=""
+for ((wait_s=0; wait_s<60; wait_s++)); do
+  if url=$(probe_metrics_endpoint); then
+    METRICS_URL="$url"
+    echo "    metrics live at $METRICS_URL (after ${wait_s}s)"
+    break
+  fi
+  if ! kill -0 "$ERIGON_PID" 2>/dev/null; then
+    echo "    erigon exited before metrics came up (PID $ERIGON_PID gone)" >&2
+    break
+  fi
+  sleep 1
+done
+if [[ -z "$METRICS_URL" ]]; then
+  echo "    metrics not up in 60s — poller will keep retrying lazily."
+  echo "    manual check: curl -v http://0.0.0.0:${METRICS_PORT}/debug/metrics/prometheus  /  ss -ltnp | grep $METRICS_PORT"
+fi
+
+# ---------- 4. Metrics poller (background) ---------- #
+# Prometheus exposition is line-oriented `metric_name{labels} value timestamp`.
+# We grep for the exact metric names (no labels on these) and awk out the value.
+echo "ts_unix,ts_iso,elapsed_sec,label,rss_bytes,vsz_bytes,heap_alloc_bytes,heap_inuse_bytes,heap_sys_bytes,sys_bytes,next_gc_bytes,alloc_total_bytes,gc_sys_bytes,goroutines,cpu_seconds" > "$CSV"
+POLLER_LOG="$LOGDIR/poller-${LABEL}-${TS}.log"
+echo "    poller log: $POLLER_LOG"
+
+START_UNIX=$(date +%s)
+
+poller() {
+  # Disable strict-mode in the poller. The outer script runs with `set -euo pipefail`;
+  # in the poller we'd rather log a single bad sample (e.g. transient metrics blip,
+  # awk match failure, transient curl error) than have the entire loop die silently.
+  set +e
+  # Send stderr of every command in this function to a debug log so any unexpected
+  # failure leaves a trace; otherwise the function could exit on a hidden non-zero
+  # status with no signal.
+  exec 2>>"$POLLER_LOG"
+  local pid=$1
+  local first=1
+  while kill -0 "$pid" 2>/dev/null; do
+    # Late-binding: if upfront discovery didn't find a URL, keep trying every
+    # tick. Once found, latch it (subsequent ticks reuse the discovered URL).
+    if [[ -z "$METRICS_URL" ]]; then
+      if METRICS_URL=$(probe_metrics_endpoint); then
+        printf '[%s] late discovery: %s\n' "$(date +%H:%M:%S)" "$METRICS_URL" >> "$POLLER_LOG"
+      else
+        sleep "$POLL_INTERVAL"
+        continue
+      fi
+    fi
+
+    local body http_code curl_err
+    # Capture body + HTTP status + curl stderr separately so we can diagnose
+    # any failure mode (connection refused, timeout, wrong path, empty body).
+    body=$(curl -sS -m 3 -w '\n__HTTP__%{http_code}\n' "$METRICS_URL" 2>"$POLLER_LOG.curl_err" || true)
+    curl_err=$(cat "$POLLER_LOG.curl_err" 2>/dev/null || true)
+    http_code=$(printf '%s\n' "$body" | awk -F'__HTTP__' '/__HTTP__/ { print $2; exit }')
+    body=$(printf '%s' "$body" | awk '/__HTTP__/ { exit } { print }')
+
+    if [[ "$first" -eq 1 ]]; then
+      printf '[%s] first probe → http_code=%s body_bytes=%s curl_err=%q\n' \
+        "$(date +%H:%M:%S)" "${http_code:-NONE}" "${#body}" "$curl_err" >> "$POLLER_LOG"
+      first=0
+    fi
+
+    if [[ -n "$body" && "$http_code" =~ ^2 ]]; then
+      local now_unix now_iso elapsed
+      now_unix=$(date +%s)
+      now_iso=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+      elapsed=$((now_unix - START_UNIX))
+      # Extract scalar metrics. Empty if missing.
+      local rss vsz heap_alloc heap_inuse heap_sys sys next_gc alloc_total gc_sys goroutines cpu
+      rss=$(printf '%s\n' "$body"          | awk '/^process_resident_memory_bytes /  { print $2; exit }')
+      vsz=$(printf '%s\n' "$body"          | awk '/^process_virtual_memory_bytes /   { print $2; exit }')
+      heap_alloc=$(printf '%s\n' "$body"   | awk '/^go_memstats_heap_alloc_bytes /   { print $2; exit }')
+      heap_inuse=$(printf '%s\n' "$body"   | awk '/^go_memstats_heap_inuse_bytes /   { print $2; exit }')
+      heap_sys=$(printf '%s\n' "$body"     | awk '/^go_memstats_heap_sys_bytes /     { print $2; exit }')
+      sys=$(printf '%s\n' "$body"          | awk '/^go_memstats_sys_bytes /          { print $2; exit }')
+      next_gc=$(printf '%s\n' "$body"      | awk '/^go_memstats_next_gc_bytes /      { print $2; exit }')
+      alloc_total=$(printf '%s\n' "$body"  | awk '/^go_memstats_alloc_bytes_total /  { print $2; exit }')
+      gc_sys=$(printf '%s\n' "$body"       | awk '/^go_memstats_gc_sys_bytes /       { print $2; exit }')
+      goroutines=$(printf '%s\n' "$body"   | awk '/^go_goroutines /                  { print $2; exit }')
+      cpu=$(printf '%s\n' "$body"          | awk '/^process_cpu_seconds_total /      { print $2; exit }')
+      printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
+        "$now_unix" "$now_iso" "$elapsed" "$LABEL" \
+        "${rss:-}" "${vsz:-}" "${heap_alloc:-}" "${heap_inuse:-}" "${heap_sys:-}" "${sys:-}" \
+        "${next_gc:-}" "${alloc_total:-}" "${gc_sys:-}" "${goroutines:-}" "${cpu:-}" \
+        >> "$CSV"
+    else
+      printf '[%s] sample fail: http_code=%s body_bytes=%s curl_err=%q\n' \
+        "$(date +%H:%M:%S)" "${http_code:-NONE}" "${#body}" "$curl_err" >> "$POLLER_LOG"
+    fi
+    sleep "$POLL_INTERVAL"
+  done
+}
+poller "$ERIGON_PID" &
+POLLER_PID=$!
+
+# ---------- 5. Hard-timeout watchdog ---------- #
+# Use SIGTERM rather than SIGINT — empirically erigon under nohup doesn't react
+# to SIGINT sent from this script (works fine when delivered from htop or a
+# parent shell), but SIGTERM triggers the normal graceful-shutdown path.
+watchdog() {
+  sleep $((HARD_TIMEOUT_MIN * 60))
+  if kill -0 "$ERIGON_PID" 2>/dev/null; then
+    echo "==> hard timeout (${HARD_TIMEOUT_MIN}m) reached — sending SIGTERM" >&2
+    kill -TERM "$ERIGON_PID" 2>/dev/null || true
+  fi
+}
+watchdog &
+WATCHDOG_PID=$!
+
+# ---------- 6. Cleanup trap ---------- #
+cleanup() {
+  local exit_code=$?
+  set +e
+  echo
+  echo "==> stopping erigon (PID $ERIGON_PID)..."
+  if kill -0 "$ERIGON_PID" 2>/dev/null; then
+    # SIGTERM, not SIGINT — SIGINT under nohup doesn't reach erigon's signal
+    # handler reliably; SIGTERM (same signal htop sends on default kill) does.
+    kill -TERM "$ERIGON_PID" 2>/dev/null
+    # Wait up to SHUTDOWN_GRACE seconds for clean shutdown.
+    for ((i=0; i<SHUTDOWN_GRACE; i++)); do
+      kill -0 "$ERIGON_PID" 2>/dev/null || break
+      sleep 1
+    done
+    if kill -0 "$ERIGON_PID" 2>/dev/null; then
+      echo "    erigon did not exit after ${SHUTDOWN_GRACE}s — SIGKILL"
+      kill -9 "$ERIGON_PID" 2>/dev/null || true
+    fi
+  fi
+  [[ -n "${POLLER_PID:-}" ]]   && kill "$POLLER_PID"   2>/dev/null || true
+  [[ -n "${WATCHDOG_PID:-}" ]] && kill "$WATCHDOG_PID" 2>/dev/null || true
+  wait ${POLLER_PID:-} ${WATCHDOG_PID:-} 2>/dev/null || true
+  rm -f "$PIDFILE"
+
+  echo "==> summary (label=$LABEL)"
+  echo "    log: $LOG"
+  echo "    csv: $CSV"
+  # Quick peak summary from the CSV.
+  if [[ -s "$CSV" ]]; then
+    awk -F, 'NR>1 && $5!="" {
+      if ($5+0>r) r=$5+0;
+      if ($6+0>v) v=$6+0;
+      if ($7+0>ha) ha=$7+0;
+      if ($8+0>hi) hi=$8+0;
+      if ($9+0>hs) hs=$9+0;
+      n++
+    } END {
+      if (n==0) { print "    no metric samples captured"; exit }
+      printf "    samples=%d  peak_rss=%.1f MB  peak_vsz=%.1f MB  peak_heap_alloc=%.1f MB  peak_heap_inuse=%.1f MB  peak_heap_sys=%.1f MB\n",
+        n, r/1048576, v/1048576, ha/1048576, hi/1048576, hs/1048576
+    }' "$CSV"
+  fi
+  exit "$exit_code"
+}
+trap cleanup INT TERM EXIT
+
+# ---------- 7. Tail the log so the user can monitor and Ctrl+C ---------- #
+# Erigon log lines look like: `[INFO] [05-11|09:49:10.400] message...`
+# Run tail+grep in the foreground: Ctrl+C kills them first, then the EXIT/INT
+# trap stops erigon cleanly. --line-buffered flushes each line immediately.
+#
+# Background watcher: if erigon exits on its own (crash, OOM, completed run),
+# send SIGINT to this script so we don't hang in tail forever.
+( while kill -0 "$ERIGON_PID" 2>/dev/null; do sleep 2; done; kill -TERM $$ 2>/dev/null ) &
+EXIT_WATCH_PID=$!
+
+echo "==> tailing log (INFO only — Ctrl+C to stop the run)"
+echo
+# -a forces grep to treat the input as text. Without it, the first NUL byte in
+# the stream (e.g. raw bytes Caplin/p2p occasionally log) flips grep to
+# "binary file matches" mode and it stops printing matching lines.
+tail -F "$LOG" | grep --line-buffered -a '^\[INFO\]' || true
+kill "$EXIT_WATCH_PID" 2>/dev/null || true

--- a/scripts/fusefilter-bench/fuse_compare_diff.sh
+++ b/scripts/fusefilter-bench/fuse_compare_diff.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# fuse_compare_diff.sh — side-by-side summary of two fuse_compare.sh runs.
+#
+# Usage:
+#   scripts/fusefilter-bench/fuse_compare_diff.sh <csv1> <csv2>
+#
+# Reports peak / final / mean for each captured memory series, plus the
+# ratio (csv1 / csv2) — convenient when csv1 is the baseline (legacy Writer)
+# and csv2 is the candidate (WriterSharded).
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <baseline.csv> <candidate.csv>" >&2
+  exit 2
+fi
+
+A="$1"
+B="$2"
+[[ -s "$A" ]] || { echo "empty or missing: $A" >&2; exit 2; }
+[[ -s "$B" ]] || { echo "empty or missing: $B" >&2; exit 2; }
+
+# Print a per-CSV summary plus the cross-CSV ratio.
+awk -v a="$A" -v b="$B" '
+  function reset() {
+    n=0; rss_max=0; vsz_max=0; ha_max=0; hi_max=0; hs_max=0; sys_max=0;
+    rss_last=0; vsz_last=0; ha_last=0; hi_last=0; hs_last=0; sys_last=0;
+    rss_sum=0; ha_sum=0;
+    elapsed_last=0; label="";
+  }
+  function load(path,   line, f) {
+    reset();
+    getline line < path; # header
+    while ((getline line < path) > 0) {
+      split(line, f, ",");
+      if (f[5] == "") continue;
+      n++;
+      elapsed_last = f[3]+0; label = f[4];
+      rss_last = f[5]+0; vsz_last = f[6]+0;
+      ha_last = f[7]+0;  hi_last = f[8]+0; hs_last = f[9]+0; sys_last = f[10]+0;
+      if (rss_last > rss_max) rss_max = rss_last;
+      if (vsz_last > vsz_max) vsz_max = vsz_last;
+      if (ha_last  > ha_max)  ha_max  = ha_last;
+      if (hi_last  > hi_max)  hi_max  = hi_last;
+      if (hs_last  > hs_max)  hs_max  = hs_last;
+      if (sys_last > sys_max) sys_max = sys_last;
+      rss_sum += rss_last; ha_sum += ha_last;
+    }
+    close(path);
+  }
+  function ratio(num, den) {
+    if (den == 0) return "n/a";
+    return sprintf("%.2fx", num / den);
+  }
+  function mb(x) { return sprintf("%.1f", x / 1048576); }
+  BEGIN {
+    load(a);
+    Alabel=label; An=n; Aelapsed=elapsed_last;
+    Arss_max=rss_max; Avsz_max=vsz_max; Aha_max=ha_max; Ahi_max=hi_max; Ahs_max=hs_max; Asys_max=sys_max;
+    Arss_avg=(n?rss_sum/n:0); Aha_avg=(n?ha_sum/n:0);
+
+    load(b);
+    Blabel=label; Bn=n; Belapsed=elapsed_last;
+    Brss_max=rss_max; Bvsz_max=vsz_max; Bha_max=ha_max; Bhi_max=hi_max; Bhs_max=hs_max; Bsys_max=sys_max;
+    Brss_avg=(n?rss_sum/n:0); Bha_avg=(n?ha_sum/n:0);
+
+    printf "metric                         %-20s %-20s ratio (A/B)\n", Alabel, Blabel;
+    printf "samples                        %-20d %-20d\n", An, Bn;
+    printf "elapsed_sec                    %-20d %-20d\n", Aelapsed, Belapsed;
+    printf "peak_rss_mb                    %-20s %-20s %s\n", mb(Arss_max),  mb(Brss_max),  ratio(Arss_max,  Brss_max);
+    printf "peak_vsz_mb                    %-20s %-20s %s\n", mb(Avsz_max),  mb(Bvsz_max),  ratio(Avsz_max,  Bvsz_max);
+    printf "peak_heap_alloc_mb             %-20s %-20s %s\n", mb(Aha_max),   mb(Bha_max),   ratio(Aha_max,   Bha_max);
+    printf "peak_heap_inuse_mb             %-20s %-20s %s\n", mb(Ahi_max),   mb(Bhi_max),   ratio(Ahi_max,   Bhi_max);
+    printf "peak_heap_sys_mb               %-20s %-20s %s\n", mb(Ahs_max),   mb(Bhs_max),   ratio(Ahs_max,   Bhs_max);
+    printf "peak_go_sys_mb                 %-20s %-20s %s\n", mb(Asys_max),  mb(Bsys_max),  ratio(Asys_max,  Bsys_max);
+    printf "avg_rss_mb                     %-20s %-20s %s\n", mb(Arss_avg),  mb(Brss_avg),  ratio(Arss_avg,  Brss_avg);
+    printf "avg_heap_alloc_mb              %-20s %-20s %s\n", mb(Aha_avg),   mb(Bha_avg),   ratio(Aha_avg,   Bha_avg);
+  }
+' </dev/null


### PR DESCRIPTION
Cherry-pick of [be36d4fc16](https://github.com/erigontech/erigon/commit/be36d4fc166e031d55ab9a5c570c77ada83f0716) (original PR #20644) onto `performance`.

## Summary
- Shards `fusefilter` by `keyHash>>56` (256 shards) to cut FuseFilter build-time RAM ~256× on large `.efi` files (3B-key bloatnet case).
- Writer reuses one `xorfilter.BuildBinaryFuse` to build all shards; `ShardedReader` is a `[256]Reader` with lookup `shards[keyHash>>56].ContainsHash(hash)`.
- Adds `ExistenceFilterVersion = 2` (sharded format), keeps v1 (monolithic) and v0 (legacy) intact. `recsplit.RecSplitArgs.Version` is now `version.DataStructureVersion` (was `uint8`).
- Wires `snaptype.BuildIndex` to pick `recsplit.ExistenceFilterVersion` whenever the index version is not `v1.0` (v1.0 keeps inner v=0 for compat).
- Brings the full new test set: sharded writer/reader tests, corruption tests, fuzz tests, real-file tests, and benchmarks + `scripts/fusefilter-bench/`.

## Cherry-pick status
Clean cherry-pick. No manual conflict resolutions required — `performance` already has all the prerequisites the original commit assumed:
- `xorfilter v0.5.1` (provides `MakeBinaryFuseBuilder` / `BuildBinaryFuse`)
- Package-scope `headerSize` in `db/datastruct/fusefilter/fusefilter_reader.go`
- `offsetFile *os.File` / `offsetWriter *bufio.Writer` in `recsplit.RecSplit` (from PR #20722)

Auto-merge handled minor textual deltas in `.gitignore`, `fusefilter_reader.go`, `recsplit/index.go`, and `db/state/domain.go` without conflicts.

## Test plan
- [ ] `go build` of affected packages: passes locally (`db/recsplit/...`, `db/datastruct/fusefilter/...`, `db/snaptype/...`)
- [ ] `go test ./db/datastruct/fusefilter/... ./db/recsplit/...`
- [ ] CI on the branch

> Note: `./db/state/statecfg/...` fails to build with `undefined: InitSchemas` on `origin/performance` independently of this PR — pre-existing issue on the base branch, unrelated to the cherry-pick.

## References
- Original PR: https://github.com/erigontech/erigon/pull/20644
- Original issue: #20560

🤖 Generated with [Claude Code](https://claude.com/claude-code)