### PR TITLE
execution/stagedsync: install the per-block changeset accumulator before any of the block's writes

### DIFF
--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -113,6 +113,43 @@ type parallelExecutor struct {
 	// block-end system calls) on SharedDomains.mem.
 	shouldGenerateChangesets bool
 	currentChangeSet         *changeset.StateChangeSet
+	// currentChangeSetBlock is the block number currentChangeSet belongs to
+	// (0 == none). Tracked so ensureChangesetAccumulator can be a no-op when the
+	// accumulator is already installed for the block whose writes are about to
+	// be applied — making changeset capture robust against blocks scheduled out
+	// of band (e.g. processRequest scheduling the first block of a new request
+	// after the blockExecutors map went empty mid-batch, with no preceding
+	// blockResult to trigger the install at the rotation site below).
+	currentChangeSetBlock uint64
+}
+
+// ensureChangesetAccumulator makes pe.currentChangeSet point at a fresh,
+// block-specific StateChangeSet before any of blockNum's sd.mem writes are
+// applied. Idempotent. Exec-loop only — it mutates SharedDomains.mem via
+// SetChangesetAccumulator, which must be single-writer (see the comment on
+// currentChangeSet).
+func (pe *parallelExecutor) ensureChangesetAccumulator(blockNum uint64) {
+	if !pe.shouldGenerateChangesets || blockNum == 0 || blockNum > pe.maxBlockNum {
+		return
+	}
+	if pe.currentChangeSet != nil && pe.currentChangeSetBlock == blockNum {
+		return
+	}
+	// A previous block's accumulator is normally saved+cleared at its
+	// blockResult; if one is still installed here for a different block the
+	// rotation was missed — overwrite (the previous block's changeset was
+	// already saved at its blockResult, so nothing is lost).
+	pe.currentChangeSet = &changeset.StateChangeSet{}
+	pe.currentChangeSetBlock = blockNum
+	pe.domains().SetChangesetAccumulator(pe.currentChangeSet)
+}
+
+// clearChangesetAccumulator detaches the current changeset accumulator after
+// its block's changeset has been saved. Exec-loop only.
+func (pe *parallelExecutor) clearChangesetAccumulator() {
+	pe.domains().SetChangesetAccumulator(nil)
+	pe.currentChangeSet = nil
+	pe.currentChangeSetBlock = 0
 }
 
 func (pe *parallelExecutor) exec(ctx context.Context, execStage *StageState, u Unwinder,
@@ -188,10 +225,7 @@ func (pe *parallelExecutor) exec(ctx context.Context, execStage *StageState, u U
 	// (per-block save/clear/install) so apply-loop and exec-loop sd.mem
 	// writes never race on SharedDomains.mem.
 	pe.shouldGenerateChangesets = shouldGenerateChangeSets(pe.cfg, startBlockNum, maxBlockNum)
-	if pe.shouldGenerateChangesets && startBlockNum > 0 {
-		pe.currentChangeSet = &changeset.StateChangeSet{}
-		pe.domains().SetChangesetAccumulator(pe.currentChangeSet)
-	}
+	pe.ensureChangesetAccumulator(startBlockNum)
 
 	// Start the commitment calculator. forcePerBlockCompute mirrors serial's
 	// per-block gate (exec3_serial.go: `if !dbg.BatchCommitments ||
@@ -853,14 +887,17 @@ func (pe *parallelExecutor) execLoop(ctx context.Context) (err error) {
 				// at line 893-895 is serialized with the exec loop's other
 				// sd.mem writes (system calls, finalize, ApplyStateWrites for
 				// the next block).
-				if pe.shouldGenerateChangesets && pe.currentChangeSet != nil {
+				// Belt-and-braces: an empty block (no tx-results reaching
+				// processResults) may not have triggered the install — create
+				// its (empty) accumulator so it gets saved like every other block.
+				pe.ensureChangesetAccumulator(blockResult.BlockNum)
+				if pe.currentChangeSet != nil {
 					pe.domains().SavePastChangesetAccumulator(blockResult.BlockHash, blockResult.BlockNum, pe.currentChangeSet)
 				}
 				if err := blockExecutor.sendResult(ctx, blockResult); err != nil {
 					return err
 				}
-				pe.domains().SetChangesetAccumulator(nil)
-				pe.currentChangeSet = nil
+				pe.clearChangesetAccumulator()
 
 				pe.Lock()
 				delete(pe.blockExecutors, blockResult.BlockNum)
@@ -899,13 +936,11 @@ func (pe *parallelExecutor) execLoop(ctx context.Context) (err error) {
 			pe.RUnlock()
 
 			if ok {
-				// Install a fresh changeset accumulator for the next block before
-				// any of its sd.mem writes start. Doing this here (still in the
-				// exec loop) keeps SharedDomains.mem mutations single-writer.
-				if pe.shouldGenerateChangesets && blockExecutor.blockNum > 0 && blockExecutor.blockNum <= pe.maxBlockNum {
-					pe.currentChangeSet = &changeset.StateChangeSet{}
-					pe.domains().SetChangesetAccumulator(pe.currentChangeSet)
-				}
+				// Fast-path install of the next block's changeset accumulator,
+				// still in the exec loop (single-writer). If the next block's
+				// executor isn't in the map yet this is a no-op; processResults
+				// then installs it lazily on the block's first apply.
+				pe.ensureChangesetAccumulator(blockExecutor.blockNum)
 				pe.onBlockStart(ctx, blockExecutor.blockNum, blockExecutor.blockHash)
 				blockExecutor.execStarted = time.Now()
 				blockExecutor.scheduleExecution(ctx, pe)
@@ -1222,6 +1257,11 @@ func (pe *parallelExecutor) processResults(ctx context.Context, applyTx kv.Tempo
 		if !ok {
 			return nil, fmt.Errorf("unknown block: %d", txResult.Version().BlockNum)
 		}
+
+		// Ensure this block's changeset accumulator is installed before its
+		// writes are applied — covers blocks scheduled out of band (with no
+		// preceding blockResult to trigger the fast-path install above).
+		pe.ensureChangesetAccumulator(txResult.Version().BlockNum)
 
 		blockResult, err = blockExecutor.nextResult(ctx, pe, txResult, applyTx)
 


### PR DESCRIPTION
## Summary

Fixes an intermittent `updateForkChoice: [4/6 Execution] domains.GetDiffset(N, 0x…): not found` under `EXEC3_PARALLEL=true` — a later unwind/FCU can't revert block N because block N's diffset was never saved. Surfaces as flaky fork-choice / reorg / RPC test failures under concurrent test load (e.g. the `execution/execmodule` package, `make test-all`). Not a memory data race (no `WARNING: DATA RACE`) — a logical hole in changeset-accumulator orchestration.

Root cause: the parallel executor keeps a single per-block changeset accumulator (`pe.currentChangeSet`), installed by the exec loop only (a) at exec start for `startBlockNum` and (b) at the rotation site after each block's `blockResult` — `install for blockResult.BlockNum+1` *if its executor is already in `pe.blockExecutors`*. A block whose executor isn't in the map at that moment — e.g. `processRequest` scheduling the first block of a new request after the map went empty mid-batch — gets scheduled with no accumulator; its `ApplyStateWrites` then write into a nil `domainWriters[i].diff`, the block's changeset stays empty, and its diffset is never saved (memory) or flushed (DB). Load-sensitive because whether the map empties in that window depends on how fast `executeBlocks` pumps blocks vs the exec loop drains them.

Fix: track `pe.currentChangeSetBlock`; `ensureChangesetAccumulator(blockNum)` installs a fresh accumulator iff one isn't already installed for `blockNum` (idempotent). Call it from `processResults` (the single exec-loop point that drains worker results) before each `be.nextResult`, so every block's accumulator is installed before its first apply regardless of how the block was scheduled — plus at exec start, at the rotation site (fast path), and at the `blockResult` save point (empty blocks). All `SetChangesetAccumulator` mutations stay in the exec loop (single-writer invariant unchanged).

Follow-up tracking: #21138. Note (recorded there): this whole `currentChangeSet` rotation machinery is itself a band-aid on the parallel orchestration and is on the removal list for the eventual rework where changeset generation runs post-validation, one block at a time.

A related, separate scenario is also noted in #21138 but **not** addressed here: `pe.shouldGenerateChangesets` is decided once per batch from `startBlockNum`, whereas serial decides per block — so a multi-block batch whose start is far from the tip but whose later blocks are within `MaxReorgDepth` generates no changesets for the batch; that's a different fix.

## Test plan

- [ ] `make lint`, `make erigon integration`
- [ ] `EXEC3_PARALLEL=true USE_STATE_CACHE=false go test -count=1 ./execution/... ./db/state/...` — no regressions
- [ ] `execution/execmodule` package under `EXEC3_PARALLEL=true`, repeated runs — no `GetDiffset(…): not found`
- [ ] `make test-group {execution-other, execution-tests, core-rpc} GO_FLAGS="-race"` under `EXEC3_PARALLEL=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)