### PR TITLE
[r3.4] db/state, cmd/integration: 4x larger commitment rebuild shard, squeeze flag transparent

### DIFF
--- a/cmd/integration/commands/flags.go
+++ b/cmd/integration/commands/flags.go
@@ -117,7 +117,7 @@ func withYes(cmd *cobra.Command) {
 }
 
 func withSqueeze(cmd *cobra.Command) {
-	cmd.Flags().BoolVar(&squeeze, "squeeze", true, "use offset-pointers from commitment.kv to account.kv")
+	cmd.Flags().BoolVar(&squeeze, "squeeze", false, "use offset-pointers from commitment.kv to account.kv")
 }
 
 func withClearCommitment(cmd *cobra.Command) {

--- a/db/state/squeeze.go
+++ b/db/state/squeeze.go
@@ -1038,14 +1038,14 @@ func RebuildCommitmentFiles(ctx context.Context, rwDb kv.TemporalRwDB, txNumsRea
 
 	acRo.Close()
 
-	if !squeeze && !statecfg.Schema.CommitmentDomain.ReplaceKeysInValues {
+	if !squeeze {
 		return latestRoot, nil
 	}
 	logger.Info("[squeeze] starting")
 	a.recalcVisibleFiles(a.dirtyFilesEndTxNumMinimax())
 
 	logger.Info(fmt.Sprintf("[squeeze] latest root %x", latestRoot))
-	a.ForTestReplaceKeysInValues(kv.CommitmentDomain, true)
+	a.ForTestReplaceKeysInValues(kv.CommitmentDomain, squeeze)
 
 	actx := a.BeginFilesRo()
 	defer actx.Close()

--- a/db/state/squeeze.go
+++ b/db/state/squeeze.go
@@ -899,8 +899,7 @@ func RebuildCommitmentFiles(ctx context.Context, rwDb kv.TemporalRwDB, txNumsRea
 		stepsInShard := uint64(shardTo - shardFrom)
 		keysPerStep := totalKeys / stepsInShard // how many keys in just one step?
 
-		// shardStepsSize := kv.Step(2)
-		shardStepsSize := kv.Step(min(uint64(math.Pow(2, math.Log2(float64(stepsInShard)))), 16))
+		shardStepsSize := kv.Step(min(uint64(math.Pow(2, math.Log2(float64(stepsInShard)))), 64))
 		if uint64(shardStepsSize) != stepsInShard { // processing shard in several smaller steps
 			shardTo = shardFrom + shardStepsSize // if shard is quite big, we will process it in several steps
 		}


### PR DESCRIPTION
## Summary

Two tuning/transparency changes for commitment rebuild on `release/3.4`. Subset of `awskii/r34-inc-shard-def-size` — the `minStepsForReferencing` and `AggregatorSqueezeCommitmentValues` constant changes from that branch are **intentionally excluded** here.

- **`db/state/squeeze.go`**: raise `shardStepsSize` cap from 16 → 64 steps during `RebuildCommitmentFiles`. Larger shards cut per-shard overhead on long rebuilds.
- **`db/state/squeeze.go`**: stop forcing `ReplaceKeysInValues=true` inside the rebuild's squeeze path. The post-rebuild squeeze now actually honours the caller's `squeeze` flag — `if !squeeze { return }` (was `if !squeeze && !statecfg.Schema.CommitmentDomain.ReplaceKeysInValues`), and `ForTestReplaceKeysInValues(..., squeeze)` (was hardcoded `true`).
- **`cmd/integration/commands/flags.go`**: flip the `--squeeze` flag default from `true` → `false` so the integration `commitment_rebuild` command no longer squeezes by default.

Net effect: rebuild is faster (bigger shards) and squeeze is opt-in via flag, not silently forced.