### PR TITLE
sonar: exclude docs/** from analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,6 +5,7 @@ sonar.projectName=erigon
 sonar.sources=.
 sonar.exclusions=\
   .github/**,\
+  docs/**,\
   **/*.pb.go,\
   **/gen_*.go,\
   **/*_gen.go,\


### PR DESCRIPTION
## Summary
- Add `docs/**` to `sonar.exclusions` in `sonar-project.properties`.

The `docs/` directory contains only documentation (markdown, images, gitbook content). None of it is touched by the Erigon SonarCloud quality profile (Go/Python/JSON/YAML/TS/Docker/Shell), but the scanner still walks the tree and emits UTF-8 encoding warnings for every PNG / `.sketch` asset on every run. Excluding it cleans up the scan output without changing what's analysed.

Note: this does not measurably speed up the sonar job — indexing the whole repo takes ~330 ms either way, and the bulk of the wallclock is spent in `make test-sonar-coverage`. This is a hygiene change.

## Test plan
- [ ] CI sonar job runs and the UTF-8 warnings for `docs/**` PNG/SKETCH files no longer appear in the scan log

🤖 Generated with [Claude Code](https://claude.com/claude-code)