### PR TITLE
[r3.4] execution/stagedsync: find diffset by actually-executed hash on unwind

### DIFF
--- a/execution/stagedsync/stage_execute.go
+++ b/execution/stagedsync/stage_execute.go
@@ -156,6 +156,83 @@ func (cfg ExecuteBlockCfg) WithAuthor(author accounts.Address) ExecuteBlockCfg {
 
 var ErrTooDeepUnwind = errors.New("too deep unwind")
 
+// findExecutedDiffsetAtHeight locates the DomainEntryDiff set that was stored
+// when the block at `currentBlock` was executed. It looks up the diffset under
+// the current canonical hash first, then falls back to every other header
+// stored at that height.
+//
+// The fallback is required when the headers stage just re-canonicalised the
+// chain to a new hash *before* this unwind reached this height: the diffset
+// was written under the previously-canonical (now sidechain) hash, but
+// br.CanonicalHash() returns the new canonical. Without the fallback the
+// diffset is silently missed, sd.unwindChangesetRaw stays nil at Flush time,
+// and AggregatorRoTx.Unwind never runs — leaving the domain (latest) tables
+// reflecting the sidechain state, which becomes a phantom for any
+// re-execution of the new canonical chain. CREATE2 against a counterfactual
+// address is the typical victim: collision with the phantom contract burns
+// the entire gas limit, surfacing as `gas used mismatch` at the next block.
+//
+// Returns (changeset, executedHash, found, err). When found is false the
+// changeset is the zero value; callers should treat that as "no diffs stored
+// at this height under any known header hash" (an edge case the surrounding
+// loop handles by continuing past the first iteration only).
+func findExecutedDiffsetAtHeight(
+	ctx context.Context,
+	rwTx kv.TemporalRwTx,
+	br services.FullBlockReader,
+	doms *execctx.SharedDomains,
+	currentBlock uint64,
+) (cs [kv.DomainLen][]kv.DomainEntryDiff, executedHash common.Hash, found bool, err error) {
+	currentHash, ok, err := br.CanonicalHash(ctx, rwTx, currentBlock)
+	if err != nil {
+		return cs, common.Hash{}, false, err
+	}
+	if !ok {
+		// No canonical hash at this height: we executed a sidechain block
+		// that never got marked canonical. Pick the only known header.
+		nonCanonicalHeaders, herr := rawdb.ReadHeadersByNumber(rwTx, currentBlock)
+		if herr != nil {
+			return cs, common.Hash{}, false, herr
+		}
+		switch {
+		case len(nonCanonicalHeaders) == 0:
+			return cs, common.Hash{}, false, fmt.Errorf("can't find diffsets for: %d", currentBlock)
+		case len(nonCanonicalHeaders) == 1:
+			currentHash = nonCanonicalHeaders[0].Hash()
+		default:
+			return cs, common.Hash{}, false, fmt.Errorf("diffsets ambiguous for: %d, have %d headers", currentBlock, len(nonCanonicalHeaders))
+		}
+	}
+	cs, ok, err = doms.GetDiffset(rwTx, currentHash, currentBlock)
+	if err != nil {
+		return cs, common.Hash{}, false, err
+	}
+	if ok {
+		return cs, currentHash, true, nil
+	}
+	// Diffset not under the (possibly newly re-canonicalised) current hash.
+	// Walk every header we have at this height; the one whose diffset is
+	// stored is the block we actually executed.
+	allHeaders, err := rawdb.ReadHeadersByNumber(rwTx, currentBlock)
+	if err != nil {
+		return cs, common.Hash{}, false, err
+	}
+	for _, h := range allHeaders {
+		hh := h.Hash()
+		if hh == currentHash {
+			continue
+		}
+		cs, ok, err = doms.GetDiffset(rwTx, hh, currentBlock)
+		if err != nil {
+			return cs, common.Hash{}, false, err
+		}
+		if ok {
+			return cs, hh, true, nil
+		}
+	}
+	return cs, common.Hash{}, false, nil
+}
+
 func unwindExec3(u *UnwindState, s *StageState, doms *execctx.SharedDomains, rwTx kv.TemporalRwTx, ctx context.Context, cfg ExecuteBlockCfg, accumulator *shards.Accumulator, logger log.Logger) (err error) {
 	br := cfg.blockReader
 	txNumsReader := br.TxnumReader()
@@ -168,28 +245,16 @@ func unwindExec3(u *UnwindState, s *StageState, doms *execctx.SharedDomains, rwT
 
 	t := time.Now()
 	var changeSet *[kv.DomainLen][]kv.DomainEntryDiff
+	// lastExecHash tracks the hash of the actually-executed block at u.CurrentBlockNumber
+	// (which may differ from the current canonical hash at that height — see comment in
+	// findExecutedDiffsetAtHeight). RevertWithDiffset needs this hash to surgically
+	// invalidate the state cache instead of falling back to a full clear.
+	var lastExecHash common.Hash
 	for currentBlock := u.CurrentBlockNumber; currentBlock > u.UnwindPoint; currentBlock-- {
-		currentHash, ok, err := br.CanonicalHash(ctx, rwTx, currentBlock)
+		currentKeys, executedHash, ok, err := findExecutedDiffsetAtHeight(ctx, rwTx, br, doms, currentBlock)
 		if err != nil {
 			return err
 		}
-		if !ok {
-			// we may have executed blocks which are not in the canonical chain
-			nonCanonicalHeaders, err := rawdb.ReadHeadersByNumber(rwTx, currentBlock)
-			if err != nil {
-				return err
-			}
-			switch {
-			case len(nonCanonicalHeaders) == 0:
-				return fmt.Errorf("can't find diffsets for: %d", currentBlock)
-			case len(nonCanonicalHeaders) == 1:
-				currentHash = nonCanonicalHeaders[0].Hash()
-			default:
-				return fmt.Errorf("diffsets ambiguous for: %d, have %d headers", currentBlock, len(nonCanonicalHeaders))
-			}
-		}
-		var currentKeys [kv.DomainLen][]kv.DomainEntryDiff
-		currentKeys, ok, err = doms.GetDiffset(rwTx, currentHash, currentBlock)
 		if !ok {
 			if changeSet == nil {
 				// this handles the edge case where we're traversing backwards from
@@ -200,10 +265,10 @@ func unwindExec3(u *UnwindState, s *StageState, doms *execctx.SharedDomains, rwT
 				// all previous blocks
 				continue
 			}
-			return fmt.Errorf("domains.GetDiffset(%d, %s): not found", currentBlock, currentHash)
+			return fmt.Errorf("domains.GetDiffset(%d): not found under any known header hash", currentBlock)
 		}
-		if err != nil {
-			return err
+		if currentBlock == u.CurrentBlockNumber {
+			lastExecHash = executedHash
 		}
 		if changeSet == nil {
 			changeSet = &currentKeys
@@ -212,12 +277,6 @@ func unwindExec3(u *UnwindState, s *StageState, doms *execctx.SharedDomains, rwT
 				changeSet[i] = changeset.MergeDiffSets(changeSet[i], currentKeys[i])
 			}
 		}
-	}
-	// Get the hash of the last executed block (the tip we're unwinding from)
-	// so RevertWithDiffset can detect if the cache was modified by a rolled-back tx.
-	lastExecHash, _, err := br.CanonicalHash(ctx, rwTx, u.CurrentBlockNumber)
-	if err != nil {
-		lastExecHash = common.Hash{}
 	}
 	if err := unwindExec3State(ctx, doms, rwTx, u.UnwindPoint, txNum, accumulator, changeSet, lastExecHash, logger); err != nil {
 		return fmt.Errorf("unwindExec3State(%d->%d): %w, took %s", s.BlockNumber, u.UnwindPoint, err, time.Since(t))

--- a/execution/stagedsync/stage_execute.go
+++ b/execution/stagedsync/stage_execute.go
@@ -245,9 +245,9 @@ func unwindExec3(u *UnwindState, s *StageState, doms *execctx.SharedDomains, rwT
 
 	t := time.Now()
 	var changeSet *[kv.DomainLen][]kv.DomainEntryDiff
-	// lastExecHash tracks the hash of the actually-executed block at u.CurrentBlockNumber
-	// (which may differ from the current canonical hash at that height — see comment in
-	// findExecutedDiffsetAtHeight). RevertWithDiffset needs this hash to surgically
+	// lastExecHash tracks the hash of the topmost actually-executed block in the
+	// unwound range (may differ from the current canonical hash at that height —
+	// see findExecutedDiffsetAtHeight). RevertWithDiffset needs it to surgically
 	// invalidate the state cache instead of falling back to a full clear.
 	var lastExecHash common.Hash
 	for currentBlock := u.CurrentBlockNumber; currentBlock > u.UnwindPoint; currentBlock-- {
@@ -267,10 +267,14 @@ func unwindExec3(u *UnwindState, s *StageState, doms *execctx.SharedDomains, rwT
 			}
 			return fmt.Errorf("domains.GetDiffset(%d): not found under any known header hash", currentBlock)
 		}
-		if currentBlock == u.CurrentBlockNumber {
-			lastExecHash = executedHash
-		}
 		if changeSet == nil {
+			// First diffset found = topmost executed block in the unwound range.
+			// Capture lastExecHash here, not on the very first loop iteration:
+			// when u.CurrentBlockNumber itself has no diffset (the
+			// "has not been processed yet" edge case above), we skipped it, so
+			// taking the hash from that iteration would leave lastExecHash
+			// zero and RevertWithDiffset would degrade to a full cache clear.
+			lastExecHash = executedHash
 			changeSet = &currentKeys
 		} else {
 			for i := range currentKeys {

--- a/execution/stagedsync/stage_execute_unwind_test.go
+++ b/execution/stagedsync/stage_execute_unwind_test.go
@@ -1,0 +1,154 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package stagedsync
+
+import (
+	"context"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/dbcfg"
+	"github.com/erigontech/erigon/db/kv/mdbx"
+	"github.com/erigontech/erigon/db/kv/temporal"
+	"github.com/erigontech/erigon/db/rawdb"
+	"github.com/erigontech/erigon/db/snapshotsync/freezeblocks"
+	dbstate "github.com/erigontech/erigon/db/state"
+	"github.com/erigontech/erigon/db/state/changeset"
+	"github.com/erigontech/erigon/db/state/execctx"
+	"github.com/erigontech/erigon/execution/chain/networkname"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/node/ethconfig"
+)
+
+// TestFindExecutedDiffsetAtHeight_FallsBackAfterCanonicalReorg is a
+// regression test for the CREATE2-collision-after-reorg bug that surfaced on
+// hoodi at block 2 789 993 (release/3.4).
+//
+// Repro of the original chain of events:
+//
+//  1. Erigon executes a sidechain block H_old at height N. Its diffset is
+//     stored under (N, H_old) in kv.ChangeSets3. H_old is briefly canonical.
+//  2. Headers stage receives the canonical chain, re-canonicalises height N
+//     to H_new. The canonical pointer flips before execution stage unwinds.
+//  3. unwindExec3 asks for the diffset under the *current* canonical hash
+//     (H_new) — but the diffset was stored under H_old.
+//
+// Before the fix, step 3 returned !ok and was silently treated as "nothing
+// to unwind" (changeSet stays nil → sd.unwindChangesetRaw stays nil → no
+// tombstones written to AccountsDomain/CodeDomain → phantom CREATE2 state
+// remains in latest-state tables). Re-executing the canonical chain over
+// the phantom triggered an EIP-684/EIP-1014 collision on the next CREATE2
+// to the same counterfactual address, consuming the entire gas limit and
+// surfacing as `gas used mismatch` at the boundary block.
+//
+// The helper findExecutedDiffsetAtHeight must now fall back from the
+// current canonical hash to the previously-applied sidechain hash.
+func TestFindExecutedDiffsetAtHeight_FallsBackAfterCanonicalReorg(t *testing.T) {
+	t.Parallel()
+
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	rawDb := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).MustOpen()
+	t.Cleanup(rawDb.Close)
+
+	agg, err := dbstate.NewTest(dirs).StepSize(16).Logger(logger).Open(context.Background(), rawDb)
+	require.NoError(t, err)
+	t.Cleanup(agg.Close)
+
+	db, err := temporal.New(rawDb, agg)
+	require.NoError(t, err)
+
+	// Block reader backed only by MDBX — no snapshots needed because the unwind
+	// range is at the tip, well above any frozen snapshot boundary.
+	snaps := freezeblocks.NewRoSnapshots(ethconfig.BlocksFreezing{ChainName: networkname.Mainnet}, dirs.Snap, logger)
+	t.Cleanup(snaps.Close)
+	br := freezeblocks.NewBlockReader(snaps, nil)
+
+	ctx := context.Background()
+	tx, err := db.BeginTemporalRw(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	doms, err := execctx.NewSharedDomains(ctx, tx, logger)
+	require.NoError(t, err)
+	defer doms.Close()
+
+	const height = uint64(10)
+	hOld := makeHeader(height, common.Hash{0x01})
+	hNew := makeHeader(height, common.Hash{0x02})
+	require.NoError(t, rawdb.WriteHeader(tx, hOld))
+	require.NoError(t, rawdb.WriteHeader(tx, hNew))
+
+	// Diffset is stored under hOld — this is the block we actually executed.
+	addr := common.Address{0xde, 0xad}
+	stepBytes := [8]byte{} // step 0 in inverted big-endian
+	diffKey := string(append(addr.Bytes(), stepBytes[:]...))
+	cs := &changeset.StateChangeSet{}
+	cs.Diffs[kv.AccountsDomain].DomainUpdate([]byte(diffKey)[:len(addr.Bytes())], kv.Step(0), nil /* prev=nil → []byte{} tombstone on unwind */)
+	require.NoError(t, changeset.WriteDiffSet(tx, height, hOld.Hash(), cs))
+
+	// Phase 1: hOld is canonical → direct hit under the current canonical hash.
+	require.NoError(t, rawdb.WriteCanonicalHash(tx, hOld.Hash(), height))
+	got, executed, found, err := findExecutedDiffsetAtHeight(ctx, tx, br, doms, height)
+	require.NoError(t, err)
+	require.True(t, found, "diffset must be found when canonical hash matches stored hash")
+	require.Equal(t, hOld.Hash(), executed, "executedHash must be hOld when canonical points at hOld")
+	require.NotEmpty(t, got[kv.AccountsDomain], "AccountsDomain diff list must be non-empty")
+
+	// Phase 2: headers stage re-canonicalises to hNew (which has no diffset).
+	// Before the fix the lookup returns !ok, the unwind silently no-ops and
+	// the phantom state survives. The fix must locate the diffset by walking
+	// the other header(s) at this height.
+	require.NoError(t, rawdb.WriteCanonicalHash(tx, hNew.Hash(), height))
+
+	// Document the pre-fix failure mode: a direct lookup against the now-
+	// canonical hash returns !ok, which is precisely the unwind regression.
+	_, ok, err := doms.GetDiffset(tx, hNew.Hash(), height)
+	require.NoError(t, err)
+	require.False(t, ok, "sanity: pre-fix code path (direct GetDiffset under new canonical) must miss — this is the bug")
+
+	got, executed, found, err = findExecutedDiffsetAtHeight(ctx, tx, br, doms, height)
+	require.NoError(t, err)
+	require.True(t, found, "diffset must be located via fallback after canonical flip")
+	require.Equal(t, hOld.Hash(), executed, "executedHash must remain hOld (the actually-executed block) after canonical flip")
+	require.NotEmpty(t, got[kv.AccountsDomain], "AccountsDomain diff list must survive the fallback")
+
+	// Phase 3: there is genuinely no stored diffset at this height under any
+	// known header — found must be false (no spurious matches).
+	const heightEmpty = uint64(11)
+	hEmpty := makeHeader(heightEmpty, common.Hash{0x03})
+	require.NoError(t, rawdb.WriteHeader(tx, hEmpty))
+	require.NoError(t, rawdb.WriteCanonicalHash(tx, hEmpty.Hash(), heightEmpty))
+	_, _, found, err = findExecutedDiffsetAtHeight(ctx, tx, br, doms, heightEmpty)
+	require.NoError(t, err)
+	require.False(t, found, "must report not-found when no header at this height has a stored diffset")
+}
+
+func makeHeader(num uint64, parentMarker common.Hash) *types.Header {
+	return &types.Header{
+		Number:     *uint256.NewInt(num),
+		ParentHash: parentMarker,
+		Difficulty: *uint256.NewInt(1),
+		Extra:      parentMarker.Bytes(), // make the hash distinct per `parentMarker`
+	}
+}

--- a/execution/stagedsync/stage_execute_unwind_test.go
+++ b/execution/stagedsync/stage_execute_unwind_test.go
@@ -101,10 +101,8 @@ func TestFindExecutedDiffsetAtHeight_FallsBackAfterCanonicalReorg(t *testing.T) 
 
 	// Diffset is stored under hOld — this is the block we actually executed.
 	addr := common.Address{0xde, 0xad}
-	stepBytes := [8]byte{} // step 0 in inverted big-endian
-	diffKey := string(append(addr.Bytes(), stepBytes[:]...))
 	cs := &changeset.StateChangeSet{}
-	cs.Diffs[kv.AccountsDomain].DomainUpdate([]byte(diffKey)[:len(addr.Bytes())], kv.Step(0), nil /* prev=nil → []byte{} tombstone on unwind */)
+	cs.Diffs[kv.AccountsDomain].DomainUpdate(addr.Bytes(), kv.Step(0), nil /* prev=nil → []byte{} tombstone on unwind */)
 	require.NoError(t, changeset.WriteDiffSet(tx, height, hOld.Hash(), cs))
 
 	// Phase 1: hOld is canonical → direct hit under the current canonical hash.


### PR DESCRIPTION
## Summary

Fixes a state-leak bug in `unwindExec3` that surfaces as a `gas used mismatch` and `Cannot update chain head` after any reorg at the tip whose unwound block deployed a contract via `CREATE`/`CREATE2` to a counterfactual address (safe-wallets, EIP-1167 clone factories, ERC-4337 accounts, deterministic deployers). Reproduced on hoodi at block **2 789 993** on a node running `release/3.4` — local sidechain head `0x706b073b…`, canonical `0x72c42d17…` / `0xc4c75456…`, divergence `+72 524` gas in tx `0x73652205af0b85e7…` (idx 7) which goes from `status=1, gasUsed=171 004` on canonical to `status=0, gasUsed=243 528` (consume-all-gas) locally.

This is **not** a cherry-pick of a merged PR. The fix originated on `release/3.4` after diagnosing the hoodi snapshotter incident on 2026-05-11. The corresponding bug is also present on `main` (see "Cherry-pick to main" below).

## Root cause

`unwindExec3` looks up the per-block `DomainEntryDiff` set via `doms.GetDiffset(rwTx, br.CanonicalHash(currentBlock), currentBlock)`. The diffset, however, is keyed by the hash of the block that was **actually executed**, not by whatever the current canonical hash happens to be at unwind time.

The headers stage processes a reorg in two steps inside a single transaction ([`execution/stagedsync/stage_headers.go`](execution/stagedsync/stage_headers.go)):

1. `u.UnwindTo(unwindTo, …)` — schedules an unwind for subsequent stages.
2. `fixCanonicalChain(…)` — overwrites `kv.HeaderCanonical` to point at the new chain.

The canonical pointer flip happens **before** the execution-stage unwind actually runs. When `unwindExec3` then asks for `br.CanonicalHash(currentBlock)` it gets the new canonical hash, but the diffset for that height is sitting in `ChangeSets3` under the previous (now sidechain) hash that was actually applied.

The pre-existing fallback at [`stage_execute.go:191-204`](execution/stagedsync/stage_execute.go) only handled the case where `CanonicalHash` returns `!ok` (no canonical pointer at this height — meaning we executed a block that was never marked canonical). It did **not** handle the case where `CanonicalHash` returns the *new* canonical and the diffset is missing **under that new hash**. In that case the code treated the miss as the "first block in traversal, nothing to unwind yet" edge case and silently `continue`d.

The downstream effect is severe:

- `changeSet` stays `nil` → `unwindExec3State` gets `nil` → the loop that collects state changes into `stateChanges` is skipped → `sd.Unwind(txUnwindTo, nil)` → `sd.unwindChangesetRaw = nil`.
- At `TemporalMemBatch.Flush` the guard `if sd.unwindChangesetRaw != nil` ([`temporal_mem_batch.go:596-606`](db/state/temporal_mem_batch.go)) skips `AggregatorRoTx.Unwind` entirely.
- No empty-tombstones are written into the latest `AccountsDomain` / `CodeDomain` rows for the contracts deployed in the unwound sidechain block. The previous tombstone-restore fix [#20627 / e1526bf](https://github.com/erigontech/erigon/commit/e1526bfd5a5654b760b0b98b2ccf2c5c09358407) is therefore bypassed entirely — its `[]byte{}` tombstone write never gets a chance to run because the diffset that drives it is "not found".

The execution stage progress is then rolled back through the staged-sync machinery (`Headers`, `Bodies`, `Senders` reset), but the **domain (latest state) tables in MDBX still reflect the sidechain**. On the next forward execution the canonical chain re-attempts the same CREATE2 against the now-phantom contract. EIP-684 / EIP-1014 collision rules consume all remaining gas of that tx — exactly what shows up in logs:

```
[WARN] gas used mismatch  block=2789993  header=4279886  execution=4352410  diff=72524  txCount=34  receiptCount=34
  tx gas detail  block=2789993 txIdx=7 txHash=0x73652205af0b85e7 gasUsed=243528 ... status=0
```

`243528` is the tx gas limit; `171004` is what canonical reference RPC (`https://rpc.hoodi.ethpandaops.io`) reports for the same tx; `243528 − 171004 = 72524`, matching the entire block-level mismatch.

## Fix

Localised to one function. Does **not** require any of the parallel-commitment / SD-recreate infrastructure that landed in main (`bfa03df625`, `95d96627ce`, etc.) — the diffset lookup is the only place that was making an incorrect assumption about canonical-hash stability across stages.

New helper `findExecutedDiffsetAtHeight` in `execution/stagedsync/stage_execute.go`:

1. Tries the diffset under the current canonical hash (previous behaviour for the common case).
2. If `!ok`, walks every header stored at this height via `rawdb.ReadHeadersByNumber` and tries each one. The header whose diffset is present is by construction the block that was actually executed.
3. Returns the recovered diffset together with the `executedHash` for the caller.

`unwindExec3` is updated to:

- Use the helper instead of the inline lookup.
- Track `lastExecHash` from the helper-returned `executedHash` for the topmost unwound block (`u.CurrentBlockNumber`), rather than re-reading `br.CanonicalHash(u.CurrentBlockNumber)` afterwards (which would suffer the same canonical-flip miscompare).
- Pass that hash to `unwindExec3State`, which forwards it to `stateCache.RevertWithDiffset(changeset, lastExecutedBlockHash, unwindToHash)`. The cache's `RevertWithDiffset` compares its own stored `blockHash` against `revertFromHash` — with the corrected hash, surgical eviction works and the cache no longer degrades to a full clear after every tip reorg.

The fallback search is bounded by the number of headers stored at a given height (effectively 1 in the common case, 2 in a 1-deep reorg, and so on). Order of headers returned by `ReadHeadersByNumber` is by storage prefix, but only one of them has a stored diffset, so the search is deterministic.

## Regression test

`execution/stagedsync/stage_execute_unwind_test.go` covers three phases:

1. Canonical hash points to the actually-executed block — direct hit, `executedHash = hOld`.
2. Headers stage re-canonicalises the height to a different hash (`hNew`) — the test first asserts that the pre-fix direct `doms.GetDiffset(tx, hNew, height)` returns `!ok` (documenting the bug), then asserts that `findExecutedDiffsetAtHeight` recovers via fallback and still returns `executedHash = hOld` with the original diff list intact.
3. A height with no stored diffset under any known header — `found=false`, no spurious matches.

Test runs in ~100 ms and exercises the helper against a real `mdbx + Aggregator + temporal.New` stack with a `freezeblocks.BlockReader` (no snapshots required, the unwind range is at the tip).

## Limitations / what this does NOT cover

- **Multiple distinct executed sidechains at the same height.** If a node reorg'd back-and-forth and `ChangeSets3` ends up holding diffsets for more than one block at the same height, the fallback returns the first non-canonical hash whose diffset is present. In practice the staged-sync unwind path immediately invalidates the stored diffset of any unwound block (via the subsequent forward execution), so this is rare; but a fully robust fix would persist a separate `execution-applied head hash` per height. Out of scope here.
- **The race itself** (headers stage rewriting `kv.HeaderCanonical` before execution stage unwind runs) is unchanged. This PR makes the execution-stage unwind robust against that ordering rather than restructuring stage interaction.

## How to verify on a stuck node

The runbook for an already-affected datadir (no rebuild required, snapshots are not contaminated because the phantom lives only in the MDBX `latest` domain tables at the tip) is:

```bash
sudo systemctl stop erigon
./build/bin/integration reset_state --datadir=<DD> --chain=hoodi
sudo systemctl start erigon
```

With the fix in place, future reorgs at the tip that involve CREATE2-to-counterfactual transactions will unwind cleanly and the same scenario will not recur.

## Test plan

- [x] `go test -count=1 -short ./execution/stagedsync/... ./db/state/...` — green.
- [x] New `TestFindExecutedDiffsetAtHeight_FallsBackAfterCanonicalReorg` — green; embeds a sanity-assert that the pre-fix direct lookup misses (so the test fails if the fallback is reverted).
- [ ] Manual: run on a node holding the hoodi-2789993 datadir state; after `reset_state` and restart, block 2 789 993 must be accepted with hash `0xc4c754565911f13b96a841782095a21a32806f927307ffa71695ecd99801c236`.
- [ ] CI: full unit-test + lint pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
