### PR TITLE
graphql: fix blocks range validation and arg contract

### DIFF
--- a/cmd/rpcdaemon/graphql/graph/generated.go
+++ b/cmd/rpcdaemon/graphql/graph/generated.go
@@ -119,7 +119,7 @@ type ComplexityRoot struct {
 
 	Query struct {
 		Block                func(childComplexity int, number *string, hash *string) int
-		Blocks               func(childComplexity int, from *uint64, to *uint64) int
+		Blocks               func(childComplexity int, from uint64, to *uint64) int
 		ChainID              func(childComplexity int) int
 		GasPrice             func(childComplexity int) int
 		Logs                 func(childComplexity int, filter model.FilterCriteria) int
@@ -190,7 +190,7 @@ type MutationResolver interface {
 }
 type QueryResolver interface {
 	Block(ctx context.Context, number *string, hash *string) (*model.Block, error)
-	Blocks(ctx context.Context, from *uint64, to *uint64) ([]*model.Block, error)
+	Blocks(ctx context.Context, from uint64, to *uint64) ([]*model.Block, error)
 	Pending(ctx context.Context) (*model.Pending, error)
 	Transaction(ctx context.Context, hash string) (*model.Transaction, error)
 	Logs(ctx context.Context, filter model.FilterCriteria) ([]*model.Log, error)
@@ -647,7 +647,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.ComplexityRoot.Query.Blocks(childComplexity, args["from"].(*uint64), args["to"].(*uint64)), true
+		return e.ComplexityRoot.Query.Blocks(childComplexity, args["from"].(uint64), args["to"].(*uint64)), true
 	case "Query.chainID":
 		if e.ComplexityRoot.Query.ChainID == nil {
 			break
@@ -1214,7 +1214,7 @@ func (ec *executionContext) field_Query_block_args(ctx context.Context, rawArgs 
 func (ec *executionContext) field_Query_blocks_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
-	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "from", ec.unmarshalOLong2ᚖuint64)
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "from", ec.unmarshalNLong2uint64)
 	if err != nil {
 		return nil, err
 	}
@@ -3771,7 +3771,7 @@ func (ec *executionContext) _Query_blocks(ctx context.Context, field graphql.Col
 		ec.fieldContext_Query_blocks,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.Resolvers.Query().Blocks(ctx, fc.Args["from"].(*uint64), fc.Args["to"].(*uint64))
+			return ec.Resolvers.Query().Blocks(ctx, fc.Args["from"].(uint64), fc.Args["to"].(*uint64))
 		},
 		nil,
 		ec.marshalNBlock2ᚕᚖgithubᚗcomᚋerigontechᚋerigonᚋcmdᚋrpcdaemonᚋgraphqlᚋgraphᚋmodelᚐBlockᚄ,

--- a/cmd/rpcdaemon/graphql/graph/schema.graphqls
+++ b/cmd/rpcdaemon/graphql/graph/schema.graphqls
@@ -331,7 +331,7 @@ type Query {
   block(number: BlockNum, hash: Bytes32): Block
   # Blocks returns all the blocks between two numbers, inclusive. If
   # to is not supplied, it defaults to the most recent known block.
-  blocks(from: Long, to: Long): [Block!]!
+  blocks(from: Long!, to: Long): [Block!]!
   # Pending returns the current pending state.
   pending: Pending!
   # Transaction returns a transaction specified by its hash.

--- a/cmd/rpcdaemon/graphql/graph/schema.resolvers.go
+++ b/cmd/rpcdaemon/graphql/graph/schema.resolvers.go
@@ -104,12 +104,8 @@ func (r *queryResolver) Block(ctx context.Context, number *string, hash *string)
 }
 
 // Blocks is the resolver for the blocks field.
-func (r *queryResolver) Blocks(ctx context.Context, from *uint64, to *uint64) ([]*model.Block, error) {
-	if from == nil {
-		return nil, &rpc.InvalidParamsError{Message: "Invalid params"}
-	}
-
-	fromBlockNumber := *from
+func (r *queryResolver) Blocks(ctx context.Context, from uint64, to *uint64) ([]*model.Block, error) {
+	fromBlockNumber := from
 
 	var toBlockNumber uint64
 	if to != nil {
@@ -127,7 +123,7 @@ func (r *queryResolver) Blocks(ctx context.Context, from *uint64, to *uint64) ([
 	}
 
 	const maxBlocks = 25
-	if toBlockNumber-fromBlockNumber+1 >= maxBlocks {
+	if toBlockNumber-fromBlockNumber+1 > maxBlocks {
 		return nil, &rpc.InvalidParamsError{Message: "Invalid params"}
 	}
 
@@ -138,9 +134,10 @@ func (r *queryResolver) Blocks(ctx context.Context, from *uint64, to *uint64) ([
 		if err != nil {
 			return nil, err
 		}
-		if block != nil {
-			blocks = append(blocks, block)
+		if block == nil {
+			return nil, &rpc.InvalidParamsError{Message: "Invalid params"}
 		}
+		blocks = append(blocks, block)
 	}
 
 	return blocks, ctx.Err()


### PR DESCRIPTION
This patch fixes the blocks range off-by-one and fail-closed behavior for missing blocks, and aligns the GraphQL schema/generated contract by requiring from.