### PR TITLE
execution/stagedsync: use applyTx for commitment txNum to avoid stale fallback

### DIFF
--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -767,21 +767,18 @@ func computeAndCheckCommitmentV3(ctx context.Context, header *types.Header, appl
 		return true, times, nil
 	}
 
-	// Open a thread-local roTx for domain reads during commitment.
-	// The rwTx (applyTx) is only needed for stage updates above.
-	commitRoTx, err := cfg.db.BeginTemporalRo(ctx)
-	if err != nil {
-		return false, times, fmt.Errorf("commitment: open roTx: %w", err)
-	}
-	defer commitRoTx.Rollback()
-
-	// Get current txNum from the block being committed
+	// Use applyTx, not a fresh BeginTemporalRo: Headers wrote MaxTxNum for
+	// header.Number to applyTx in this batch and a fresh RO snapshot would
+	// miss it, silently falling back to the previous block's max txNum via
+	// c.Last(). Pairing that stale txNum with header.Number in
+	// KeyCommitmentState makes the next iter's SeekCommitment loop back —
+	// see issue #21171.
 	txNumsReader := cfg.blockReader.TxnumReader()
-	blockTxNum, err := txNumsReader.Max(ctx, commitRoTx, header.Number.Uint64())
+	blockTxNum, err := txNumsReader.Max(ctx, applyTx, header.Number.Uint64())
 	if err != nil {
 		return false, times, err
 	}
-	computedRootHash, err := doms.ComputeCommitment(ctx, commitRoTx, true, header.Number.Uint64(), blockTxNum, e.LogPrefix(), nil)
+	computedRootHash, err := doms.ComputeCommitment(ctx, applyTx, true, header.Number.Uint64(), blockTxNum, e.LogPrefix(), nil)
 
 	times.ComputeCommitment = time.Since(start)
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes #21171.

`computeAndCheckCommitmentV3` resolved `txNumsReader.Max(header.Number)` against a fresh `BeginTemporalRo` snapshot and stored the result alongside `header.Number` in `KeyCommitmentState`. The fresh RO snapshot doesn't see this iteration's Stage Headers writes to `kv.MaxTxNum`, so `Max(currentBlock)` finds no row and silently falls back to `c.Last()` — the previous batch's last block's max txNum. Pairing that stale txNum with the current `header.Number` writes an internally inconsistent `(txNum, blockNum)` to `KeyCommitmentState`.

Next iteration's `SeekCommitment` returns the stored pair, `restoreTxNum`'s `FindBlockNum(staleTxNum)` lands on the previous block, advances to its successor (= first block of the just-finished batch), and execution tries to re-run a block whose state has already been written → "nonce too low" → stuck, with FCU rejecting unwinds as "too far unwind".

Triggered any time a batch ends early via the buffer-byte limit instead of the cycle's block-limit, so it bites on initial sync within minutes of Execution stage starting (mainnet block ~25070888 in our repro).

## Why this is safe

`computeAndCheckCommitmentV3` is only called from the serial path (`exec3_serial.go` periodic-commit and `exec3.go` post-exec wrap-up, both with `parallel=false`). The parallel commitment calculator has its own `txNum` source (`blockResult.lastTxNum` from the apply goroutine) and is unaffected.

In the serial path there is no goroutine ownership split — `applyTx`'s dirty pages are a strict superset of what `commitRoTx` would see, and the commitment-trie reads inside `doms.ComputeCommitment` hit `sd.mem` first and only fall through to the tx for previously-committed state. Dropping the redundant RO tx is sound.

## Repro / verification

Mainnet, `EXEC3_PARALLEL=false`, `USE_STATE_CACHE=false`. Sync from scratch.

**Before:**

```
[4/6 Execution] DONE  block=25070888         ← batch 2 ends early (buf > 512MB)
[4/6 Execution] serial starting from=25070000 initialTxNum=3509508520   ← bug: from < DONE
[4/6 Execution] Execution failed block=25070000 err="nonce too low: state 16828 tx 16734"
Cannot update chain head ... too far unwind. requested=25069999, minAllowed=25070888
... (retries identically every ~30s) ...
```

Direct DB inspection of `KeyCommitmentState`: `(txNum=3509508520, blockNum=25070888)` — but `TxNums.Max(25070888)=3509765966`, so `3509508520` is actually the max of **block 25069999**. Cross-block pair → bug.

**After:**

```
[4/6 Execution] DONE  block=25070888         ← same early-exit
[4/6 Execution] serial starting from=25070889 initialTxNum=3509765966   ← correct
[4/6 Execution] serial committed blk=25072190 ...                       ← next batch progresses
[4/6 Execution] serial starting from=25072191 initialTxNum=3510156365   ← and the next
```

`initialTxNum=3509765966` matches `TxNums.Max(25070888)` from direct inspection.

## Follow-ups (not in this PR)

- Assert `(txNum, blockNum)` invariance at the `PutBranch(KeyCommitmentState)` call site.
- Add a `MaxStrict` variant of `TxnumReader.Max` that errors on not-found instead of silent `c.Last()` fallback (the silent-fallback semantics enabled this and is a recurring foot-gun).

## Test plan

- [x] `make lint` clean
- [x] `make erigon` builds
- [x] Manual: mainnet fresh sync, serial mode, advances past the early-exit batch boundary cleanly (was stuck at b25070888 before)
- [ ] CI to run the standard test matrix