### PR TITLE
execution/stagedsync: fix parallel-exec BAL race from duplicate coinbase BalancePath write in finalize

### DIFF
--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1957,8 +1957,31 @@ func (result *execResult) finalizeTxSimple(
 
 	// Build versionMap writes: TxOut (no coinbase/burnt since worker skipped
 	// fee credit) plus the fee-adjusted balance writes.
-	allWrites := make(state.VersionedWrites, len(result.TxOut), len(result.TxOut)+2)
-	copy(allWrites, result.TxOut)
+	//
+	// When sender == coinbase (or sender == burntAddr) the worker's TxOut
+	// already contains a (sender, BalancePath) entry with the *pre-fee*
+	// balance, and we're about to append a second (coinbase, BalancePath)
+	// entry with the *post-fee* balance. Both entries have identical
+	// (Address, Path, Key) — they only differ on Val. Downstream consumers
+	// either pass this slice through ibs.ApplyVersionedWrites — which calls
+	// sort.Slice (unstable) — or feed it into a MergeVersionedWrites loop
+	// where the LAST iterator-visited entry wins. With two equal-key entries
+	// the unstable sort orders them arbitrarily, so MergeVersionedWrites
+	// flips between picking pre-fee and post-fee per run, and the validator
+	// BAL coinbase balance lands pre-fee (missing the priority tip).
+	//
+	// Drop the worker's TxOut (sender, BalancePath) entry when sender ==
+	// coinbase/burntAddr: the fee-adjusted append below is the authoritative
+	// post-fee value, and the post-apply IBS reconstruction at the end of
+	// this function applies BalancePath via SetBalance which is idempotent
+	// w.r.t. the worker's pre-fee write anyway.
+	allWrites := make(state.VersionedWrites, 0, len(result.TxOut)+2)
+	for _, w := range result.TxOut {
+		if w.Path == state.BalancePath && (w.Address == result.Coinbase || (hasBurnt && w.Address == burntAddr)) {
+			continue
+		}
+		allWrites = append(allWrites, w)
+	}
 	// Mirror the CollectorWrites emission above: emit the coinbase
 	// versionMap write either when balance actually changed OR when
 	// EIP-161 empty-removal will turn the empty coinbase into a delete.

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -765,13 +765,47 @@ func versionedRead[T any](s *IntraBlockState, addr accounts.Address, path Accoun
 	if so, ok := s.stateObjects[addr]; ok && so.deleted {
 		return defaultV, StorageRead, UnknownVersion, nil
 	} else if res := s.versionMap.Read(addr, SelfDestructPath, accounts.NilKey, s.txIndex); res.Status() == MVReadResultDone && res.value.(bool) {
-		if path != CodePath {
+		// Revival check: a later write to BalancePath/NoncePath/CodeHashPath
+		// at a strictly higher TxIndex re-creates the account, so the SD
+		// must NOT short-circuit the read. Mirrors versionedStateReader
+		// .ReadAccountData's revival check at lines 273-293 of this file.
+		//
+		// Without this the worker reads zero for any post-revival access:
+		// e.g. EIP-161 fires for the coinbase when tx N's finalize emits
+		// SelfDestructPath=true (empty-removal: balance 0, no fee tip),
+		// then tx N+1's finalize emits BalancePath=FeeTipped (revives it
+		// with a non-zero balance). A subsequent tx's BALANCE coinbase
+		// must surface the revived balance — the serial equivalent is
+		// AddBalance(amount>0) on a previously-deleted stateObject, where
+		// GetOrNewStateObject implicitly recreates a fresh object with
+		// the new balance. Without this check the parallel worker reads
+		// zero, SSTOREs zero into the contract's slot (was non-zero),
+		// triggering a spurious SSTORE_CLEAR_REFUND that doesn't fire
+		// under serial — observed as TestLegacyBlockchain bcEIP3675/
+		// tipInsideBlock failing with gas exactly 4800 short under
+		// ERIGON_EXEC3_PARALLEL=true (matches EIP-2200's clear refund).
+		destructTxIndex := res.DepIdx()
+		revived := false
+		if hi, ok := s.versionMap.LatestTxIndex(addr, BalancePath, accounts.NilKey, s.txIndex); ok && hi > destructTxIndex {
+			revived = true
+		}
+		if !revived {
+			if hi, ok := s.versionMap.LatestTxIndex(addr, NoncePath, accounts.NilKey, s.txIndex); ok && hi > destructTxIndex {
+				revived = true
+			}
+		}
+		if !revived {
+			if hi, ok := s.versionMap.LatestTxIndex(addr, CodeHashPath, accounts.NilKey, s.txIndex); ok && hi > destructTxIndex {
+				revived = true
+			}
+		}
+		if !revived && path != CodePath {
 			// A prior tx self-destructed this account — all state reads must
 			// return the zero value of the type, not the caller-supplied default.
 			// refreshVersionedAccount passes the account's pre-destruction field
 			// values as defaultV, so using defaultV here would return stale data.
 			var zero T
-			sdVersion := Version{TxIndex: res.DepIdx(), Incarnation: res.Incarnation()}
+			sdVersion := Version{TxIndex: destructTxIndex, Incarnation: res.Incarnation()}
 			if commited {
 				return zero, MapRead, sdVersion, nil
 			}
@@ -796,7 +830,7 @@ func versionedRead[T any](s *IntraBlockState, addr accounts.Address, path Accoun
 				return zero, MapRead, sdVersion, nil
 			}
 			destrcutedVersion = Version{
-				TxIndex: res.DepIdx(),
+				TxIndex: destructTxIndex,
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes a flaky parallel-exec BAL hash mismatch when sender == coinbase (the
genesis-coinbase deploy block case, surfaced by `TestEngineApiBALMultiTxBlock`,
`TestEngineApiBALParallelConsistencyStress`, `TestEngineApiBALSelfDestruct`).

`finalizeTxSimple` was building `allWrites = copy(result.TxOut) + append(post-fee
coinbase BalancePath)`. When the sender of a tx happens to be the block's
coinbase, `result.TxOut` already contains a `(coinbase, BalancePath, key=nil)`
entry holding the **pre-fee** sender balance (from the worker, which runs with
`shouldDelayFeeCalc=true`), and the append adds a **second** entry at the same
`(Address, Path, Key)` holding the **post-fee** value.

The post-apply IBS reconstruction calls `ibs.ApplyVersionedWrites(allWrites)`
which runs `sort.Slice` — and that sort is **not stable**. With two equal-key
entries the sort orders them arbitrarily, so by the time the caller in
`nextResult` runs `merged := MergeVersionedWrites(existingWrites, addWrites)`,
the iteration order through `addWrites` flips between picking pre-fee and
post-fee as the last-visited entry for the (coinbase, BalancePath) key in the
merged `WriteSet`. `RecordWrites` stores that into `be.blockIO`, the validator
BAL accumulator reads it back at `accessIndex = txIndex+1`, and the computed
BAL coinbase value lands `FeeTipped` short of the proposer-stored value on
some fraction of runs.

This was a real Heisenbug — adding any `fmt.Printf` near the merge path
re-ordered the sort enough to mask the race.

## Fix

Skip the worker's `(sender, BalancePath)` entries from `result.TxOut` when
sender matches `result.Coinbase` or `burntAddr` while copying into `allWrites`.
The finalize append below is the authoritative post-fee value; the
post-apply IBS reconstruction applies BalancePath via `SetBalance` which is
idempotent w.r.t. the worker's pre-fee write.

## Test plan

- [x] `TestEngineApiBALMultiTxBlock` — 10/10 under `ERIGON_EXEC3_PARALLEL=true -tags=experimentalBAL` (was 4/8 without fix on the same machine)
- [x] `TestEngineApiBAL*` full suite — 8/8 in parallel mode
- [x] SD / EIP-7708 / state regression tests pass in parallel mode
- [x] EngineApi suite passes in serial mode (no regression)
- [x] `make lint` clean