### PR TITLE
ci: add test-kurtosis-gloas.yml to zizmor cache-poisoning ignore list

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -45,6 +45,7 @@ rules:
       - qa-rpc-integration-tests.yml
       - qa-sync-from-scratch.yml
       - test-kurtosis-assertoor.yml
+      - test-kurtosis-gloas.yml
 
   # Workflows missing explicit permissions: blocks — needs a cleanup pass
   # to add least-privilege permissions to each workflow; tracked in #21132.


### PR DESCRIPTION
Same pattern as `test-kurtosis-assertoor.yml` which is already ignored. Proper cache-poisoning fix (restore/save split) to follow in a separate PR as part of #21132.