### PR TITLE
[wip] stagedsync, stageloop, storage: informative assert messages for HasAgg type-assertion panics

### DIFF
--- a/execution/stagedsync/stage_execute.go
+++ b/execution/stagedsync/stage_execute.go
@@ -486,10 +486,10 @@ func PruneExecutionStage(ctx context.Context, s *PruneState, tx kv.RwTx, cfg Exe
 				quickPruneTimeout = maxTimeout
 			}
 		} else {
-			panic("assert")
+			panic("assert: cfg.db.(state.HasAgg).Agg() must return a non-nil *state.Aggregator; got " + fmt.Sprintf("%T", hasAgg.Agg()))
 		}
 	} else {
-		panic("assert")
+		panic("assert: cfg.db must implement state.HasAgg; got " + fmt.Sprintf("%T", cfg.db))
 	}
 
 	if timeout > 0 && timeout > quickPruneTimeout {

--- a/execution/stagedsync/stageloop/stageloop.go
+++ b/execution/stagedsync/stageloop/stageloop.go
@@ -224,7 +224,7 @@ func ProcessFrozenBlocks(ctx context.Context, db kv.TemporalRwDB, blockReader se
 				return fmt.Errorf("ProcessFrozenBlocks: collate+prune: %w", err)
 			}
 		} else {
-			panic("assert")
+			panic("assert: db must implement state.HasAgg; got " + fmt.Sprintf("%T", db))
 		}
 
 		// Lock commitGate so background collation RO txs are closed
@@ -243,7 +243,7 @@ func ProcessFrozenBlocks(ctx context.Context, db kv.TemporalRwDB, blockReader se
 				}
 			}()
 		} else {
-			panic("assert")
+			panic("assert: db must implement state.HasAgg; got " + fmt.Sprintf("%T", db))
 		}
 
 		// Flush execution state + overlay via brief RwTx, then commit.
@@ -270,7 +270,7 @@ func ProcessFrozenBlocks(ctx context.Context, db kv.TemporalRwDB, blockReader se
 			a.Agg().(*state.Aggregator).UnlockCollation()
 			collationLocked = false
 		} else {
-			panic("assert")
+			panic("assert: db must implement state.HasAgg; got " + fmt.Sprintf("%T", db))
 		}
 
 		// Read the actual committed txNum from the DB "state" key.
@@ -287,6 +287,8 @@ func ProcessFrozenBlocks(ctx context.Context, db kv.TemporalRwDB, blockReader se
 				committedTxNum := binary.BigEndian.Uint64(v[:8])
 				if a, ok := db.(state.HasAgg); ok {
 					a.Agg().(*state.Aggregator).SetLastFlushedCommitmentTxNum(committedTxNum)
+				} else {
+					panic("assert: db must implement state.HasAgg; got " + fmt.Sprintf("%T", db))
 				}
 			}
 			verifyTx.Rollback()
@@ -388,7 +390,7 @@ func StageLoopIteration(ctx context.Context, db kv.TemporalRwDB, sync *stagedsyn
 				return err
 			}
 		} else {
-			panic("assert")
+			panic("assert: db must implement state.HasAgg; got " + fmt.Sprintf("%T", db))
 		}
 	}
 	return nil

--- a/node/components/storage/provider.go
+++ b/node/components/storage/provider.go
@@ -149,10 +149,10 @@ func (p *Provider) Initialize(deps Deps) error {
 		if agg, ok := hasAgg.Agg().(*dbstate.Aggregator); ok && agg != nil {
 			p.BlockRetire.(*freezeblocks.BlockRetire).SetCommitGate(agg.CommitGate())
 		} else {
-			panic("assert")
+			panic("assert: p.ChainDB.(dbstate.HasAgg).Agg() must return a non-nil *dbstate.Aggregator; got " + fmt.Sprintf("%T", hasAgg.Agg()))
 		}
 	} else {
-		panic("assert")
+		panic("assert: p.ChainDB must implement dbstate.HasAgg; got " + fmt.Sprintf("%T", p.ChainDB))
 	}
 
 	// Wire file-change callbacks so completed snapshots are seeded and


### PR DESCRIPTION
Replace bare `panic("assert")` with messages that include the actual concrete type of the failing value, making runtime panics self-diagnosing.

Also adds the missing `else { panic(...) }` to the `SetLastFlushedCommitmentTxNum` branch in `stageloop.go`.

Files changed:
- `execution/stagedsync/stage_execute.go`
- `execution/stagedsync/stageloop/stageloop.go`
- `node/components/storage/provider.go`