### PR TITLE
cl/forkchoice: fix infinite loop in getState when state file is missing

### DIFF
--- a/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
+++ b/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
@@ -505,8 +505,8 @@ func (f *forkGraphDisk) getState(blockRoot common.Hash, alwaysCopy bool, addChai
 			if ok && bHeader.Slot%dumpSlotFrequency == 0 {
 				copyReferencedState, err = f.readBeaconStateFromDisk(currentIteratorRoot)
 				if err != nil {
-					log.Trace("Could not retrieve state: Missing header", "missing", currentIteratorRoot, "err", err)
-					copyReferencedState = nil
+					log.Trace("Could not retrieve state", "missing", currentIteratorRoot, "err", err)
+					return nil, nil
 				}
 				continue
 			}

--- a/cl/phase1/forkchoice/fork_graph/fork_graph_getstate_test.go
+++ b/cl/phase1/forkchoice/fork_graph/fork_graph_getstate_test.go
@@ -1,0 +1,56 @@
+package fork_graph
+
+import (
+	"testing"
+	"time"
+
+	"github.com/erigontech/erigon/cl/beacon/beacon_router_configuration"
+	"github.com/erigontech/erigon/cl/beacon/beaconevents"
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/phase1/core/state"
+	"github.com/erigontech/erigon/cl/utils"
+	"github.com/erigontech/erigon/common"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetState_InfiniteLoopOnMissingStateFile reproduces the infinite loop in
+// getState when a header exists at a dump slot but the corresponding state file
+// is missing from disk and the block is not in the blocks map.
+//
+// Before the fix, getState spins forever because the !isSegmentPresent branch
+// sets copyReferencedState = nil on readBeaconStateFromDisk failure and then
+// continues the loop without advancing currentIteratorRoot.
+func TestGetState_InfiniteLoopOnMissingStateFile(t *testing.T) {
+	anchorState := state.New(&clparams.MainnetBeaconConfig)
+	require.NoError(t, utils.DecodeSSZSnappy(anchorState, anchor, int(clparams.Phase0Version)))
+
+	emitter := beaconevents.NewEventEmitter()
+	fg := NewForkGraphDisk(anchorState, nil, afero.NewMemMapFs(), beacon_router_configuration.RouterConfiguration{}, emitter)
+	graph := fg.(*forkGraphDisk)
+
+	// Craft a fake root and header at a dump slot (slot % dumpSlotFrequency == 0).
+	fakeRoot := common.Hash{0xde, 0xad}
+	fakeHeader := &cltypes.BeaconBlockHeader{
+		Slot: dumpSlotFrequency * 100, // guaranteed to be a dump slot
+	}
+
+	// Store the header but NOT the block, and don't write a state file.
+	// This creates the exact condition: header exists, block absent, state file missing.
+	graph.headers.Store(fakeRoot, fakeHeader)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// getState should return (nil, nil), not loop forever.
+		graph.getState(fakeRoot, false, false)
+	}()
+
+	select {
+	case <-done:
+		// getState returned — no infinite loop.
+	case <-time.After(3 * time.Second):
+		t.Fatal("getState did not return within 3s — infinite loop detected")
+	}
+}


### PR DESCRIPTION
## Summary

- Fix infinite loop in `forkGraphDisk.getState` when walking backward through block roots
- When a header exists at a dump slot but the block is absent and `readBeaconStateFromDisk` fails, the loop retried the same root forever because `currentIteratorRoot` was never advanced
- Return `nil, nil` on failure instead of `continue`, consistent with the existing header-not-found path

Reported by @funnygiulio — Caplin gets stuck on mainnet with latest main.

## Root cause

`getState` (line 500-511) walks backward to find a saved beacon state. In the `!isSegmentPresent` branch (block absent, header present at dump slot), `readBeaconStateFromDisk` failure set `copyReferencedState = nil` and hit `continue` — but `currentIteratorRoot` is only advanced in the `isSegmentPresent` path (via `block.Block.ParentRoot`), creating an infinite retry loop.

## Test plan

- [x] `TestGetState_InfiniteLoopOnMissingStateFile` — reproduces the infinite loop (3s timeout before fix, 0.02s after)
- [x] All existing `fork_graph` tests pass
- [x] `make lint` clean (2 pre-existing gofmt issues in unrelated files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)