### PR TITLE
cl/forkchoice: dump beacon state in AddChainSegment to prevent death spiral

### DIFF
--- a/cl/phase1/forkchoice/fork_choice_test.go
+++ b/cl/phase1/forkchoice/fork_choice_test.go
@@ -227,3 +227,237 @@ func TestForkChoiceChainBellatrix(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, common.Hash(bsRoot), common.HexToHash("0x58a3f366bcefe6c30fb3a6506bed726f9a51bb272c77a8a3ed88c34435d44cb7"))
 }
+
+// TestGetHeadAfterProcessingBlocks verifies that GetHead succeeds after
+// processing blocks through OnBlock. This exercises the full path:
+// GetHead → getCheckpointState → getState (backward walk + state file read).
+// This is the exact path that fails in production with "baseState not found".
+func TestGetHeadAfterProcessingBlocks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow test")
+	}
+	ctx := context.Background()
+	blocks, anchorState, _ := tests.GetBellatrixRandom()
+
+	pool := pool.NewOperationsPool(&clparams.MainnetBeaconConfig)
+	emitters := beaconevents.NewEventEmitter()
+	sd := synced_data.NewSyncedDataManager(&clparams.MainnetBeaconConfig, true)
+
+	genesisState, err := initial_state.GetGenesisState(1)
+	require.NoError(t, err)
+	ethClock := eth_clock.NewEthereumClock(genesisState.GenesisTime(), genesisState.GenesisValidatorsRoot(), &clparams.MainnetBeaconConfig)
+	blobStorage := blob_storage.NewBlobStore(memdb.NewTestDB(t, dbcfg.ChainDB), afero.NewMemMapFs(), math.MaxUint64, &clparams.MainnetBeaconConfig, ethClock)
+	localValidators := validator_params.NewValidatorParams()
+
+	store, err := forkchoice.NewForkChoiceStore(
+		ethClock,
+		anchorState,
+		nil,
+		pool,
+		fork_graph.NewForkGraphDisk(anchorState, nil, afero.NewMemMapFs(), beacon_router_configuration.RouterConfiguration{
+			Beacon: true,
+		}, emitters),
+		emitters,
+		sd,
+		blobStorage,
+		public_keys_registry.NewInMemoryPublicKeysRegistry(),
+		localValidators,
+		false,
+		nil,
+	)
+	require.NoError(t, err)
+
+	// Advance store time so blocks are not in the future.
+	store.OnTick(2000)
+
+	// Process all 96 blocks (3 epochs).
+	for i, block := range blocks {
+		err := store.OnBlock(ctx, block, false, true, false)
+		require.NoError(t, err, "OnBlock failed at block %d (slot %d)", i, block.Block.Slot)
+	}
+
+	// Log the justified/finalized state for debugging.
+	justified := store.JustifiedCheckpoint()
+	finalized := store.FinalizedCheckpoint()
+	t.Logf("After processing %d blocks:", len(blocks))
+	t.Logf("  Justified: epoch=%d root=%x", justified.Epoch, justified.Root)
+	t.Logf("  Finalized: epoch=%d root=%x", finalized.Epoch, finalized.Root)
+	t.Logf("  HighestSeen: %d", store.HighestSeen())
+
+	// Verify the justified root is accessible via GetStateAtBlockRoot.
+	justifiedState, err := store.GetStateAtBlockRoot(justified.Root, true)
+	require.NoError(t, err, "GetStateAtBlockRoot failed for justified root %x", justified.Root)
+	require.NotNil(t, justifiedState, "GetStateAtBlockRoot returned nil for justified root %x", justified.Root)
+	t.Logf("  Justified state slot: %d", justifiedState.Slot())
+
+	// Now call GetHead — this is the exact call that fails in production.
+	headRoot, headSlot, err := store.GetHead(nil)
+	require.NoError(t, err, "GetHead failed: %v", err)
+	t.Logf("  Head: slot=%d root=%x", headSlot, headRoot)
+
+	// The head should be at or near the last processed block.
+	lastBlock := blocks[len(blocks)-1]
+	lastRoot, err := lastBlock.Block.HashSSZ()
+	require.NoError(t, err)
+	require.Equal(t, common.Hash(lastRoot), headRoot, "head should be the last block")
+}
+
+// TestGetStateAfterPrune verifies that getState still works after Prune
+// deletes old blocks and state files. This simulates the production scenario
+// where onNewFinalized calls Prune, and then getCheckpointState needs to
+// recover the justified checkpoint state from disk.
+func TestGetStateAfterPrune(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow test")
+	}
+	ctx := context.Background()
+	blocks, anchorState, _ := tests.GetBellatrixRandom()
+
+	pool := pool.NewOperationsPool(&clparams.MainnetBeaconConfig)
+	emitters := beaconevents.NewEventEmitter()
+	sd := synced_data.NewSyncedDataManager(&clparams.MainnetBeaconConfig, true)
+
+	genesisState, err := initial_state.GetGenesisState(1)
+	require.NoError(t, err)
+	ethClock := eth_clock.NewEthereumClock(genesisState.GenesisTime(), genesisState.GenesisValidatorsRoot(), &clparams.MainnetBeaconConfig)
+	blobStorage := blob_storage.NewBlobStore(memdb.NewTestDB(t, dbcfg.ChainDB), afero.NewMemMapFs(), math.MaxUint64, &clparams.MainnetBeaconConfig, ethClock)
+	localValidators := validator_params.NewValidatorParams()
+
+	fg := fork_graph.NewForkGraphDisk(anchorState, nil, afero.NewMemMapFs(), beacon_router_configuration.RouterConfiguration{
+		Beacon: true,
+	}, emitters)
+
+	store, err := forkchoice.NewForkChoiceStore(
+		ethClock,
+		anchorState,
+		nil,
+		pool,
+		fg,
+		emitters,
+		sd,
+		blobStorage,
+		public_keys_registry.NewInMemoryPublicKeysRegistry(),
+		localValidators,
+		false,
+		nil,
+	)
+	require.NoError(t, err)
+	store.OnTick(2000)
+
+	// Process all 96 blocks.
+	for i, block := range blocks {
+		err := store.OnBlock(ctx, block, false, true, false)
+		require.NoError(t, err, "OnBlock failed at block %d (slot %d)", i, block.Block.Slot)
+	}
+
+	justified := store.JustifiedCheckpoint()
+	finalized := store.FinalizedCheckpoint()
+	t.Logf("Justified: epoch=%d root=%x", justified.Epoch, justified.Root)
+	t.Logf("Finalized: epoch=%d root=%x", finalized.Epoch, finalized.Root)
+
+	// Verify GetState works before prune.
+	preState, err := store.GetStateAtBlockRoot(justified.Root, true)
+	require.NoError(t, err)
+	require.NotNil(t, preState, "pre-prune: state should exist for justified root")
+	t.Logf("Pre-prune justified state slot: %d", preState.Slot())
+
+	// Prune blocks below a slot that's below the justified root but high enough
+	// to delete some early blocks. The justified root is at epoch 3 (slot 96).
+	// Prune at slot 80 to delete old blocks while keeping justified root intact.
+	pruneSlot := uint64(80)
+	t.Logf("Pruning at slot %d", pruneSlot)
+	require.NoError(t, fg.Prune(pruneSlot))
+
+	// After prune, the justified root (slot 96) should still be in the fork graph.
+	_, hasHeader := fg.GetHeader(justified.Root)
+	require.True(t, hasHeader, "justified root header should survive prune (slot 96 > prune slot 80)")
+
+	// GetState should still work for the justified root.
+	postState, err := store.GetStateAtBlockRoot(justified.Root, true)
+	require.NoError(t, err)
+	require.NotNil(t, postState, "post-prune: state should still be retrievable for justified root")
+	t.Logf("Post-prune justified state slot: %d", postState.Slot())
+
+	// GetHead should still work.
+	headRoot, headSlot, err := store.GetHead(nil)
+	require.NoError(t, err, "GetHead failed after prune")
+	t.Logf("Post-prune head: slot=%d root=%x", headSlot, headRoot)
+}
+
+// TestGetStateWalkAfterAggressivePrune verifies that getState's backward walk
+// works correctly when pruning removes most blocks, forcing the walk to traverse
+// through blocks close to the justified root. This tests:
+// 1. State files exist at slot % 4 == 0 boundaries (from AddChainSegment dump)
+// 2. The backward walk correctly finds and reads these state files
+// 3. GetHead (→ getCheckpointState → getState) still works after Prune
+func TestGetStateWalkAfterAggressivePrune(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow test")
+	}
+	ctx := context.Background()
+	blocks, anchorState, _ := tests.GetBellatrixRandom()
+
+	pool := pool.NewOperationsPool(&clparams.MainnetBeaconConfig)
+	emitters := beaconevents.NewEventEmitter()
+	sd := synced_data.NewSyncedDataManager(&clparams.MainnetBeaconConfig, true)
+
+	genesisState, err := initial_state.GetGenesisState(1)
+	require.NoError(t, err)
+	ethClock := eth_clock.NewEthereumClock(genesisState.GenesisTime(), genesisState.GenesisValidatorsRoot(), &clparams.MainnetBeaconConfig)
+	blobStorage := blob_storage.NewBlobStore(memdb.NewTestDB(t, dbcfg.ChainDB), afero.NewMemMapFs(), math.MaxUint64, &clparams.MainnetBeaconConfig, ethClock)
+	localValidators := validator_params.NewValidatorParams()
+
+	fg := fork_graph.NewForkGraphDisk(anchorState, nil, afero.NewMemMapFs(), beacon_router_configuration.RouterConfiguration{
+		Beacon: true,
+	}, emitters)
+
+	store, err := forkchoice.NewForkChoiceStore(
+		ethClock,
+		anchorState,
+		nil,
+		pool,
+		fg,
+		emitters,
+		sd,
+		blobStorage,
+		public_keys_registry.NewInMemoryPublicKeysRegistry(),
+		localValidators,
+		false,
+		nil,
+	)
+	require.NoError(t, err)
+	store.OnTick(2000)
+
+	// Process all 96 blocks.
+	for i, block := range blocks {
+		err := store.OnBlock(ctx, block, false, true, false)
+		require.NoError(t, err, "OnBlock failed at block %d (slot %d)", i, block.Block.Slot)
+	}
+
+	justified := store.JustifiedCheckpoint()
+	t.Logf("Justified: epoch=%d root=%x", justified.Epoch, justified.Root)
+
+	justifiedHeader, hasJH := fg.GetHeader(justified.Root)
+	require.True(t, hasJH, "justified root must be in headers")
+	t.Logf("Justified block slot: %d, slot%%4=%d", justifiedHeader.Slot, justifiedHeader.Slot%4)
+
+	// Prune aggressively — up to 2 slots below the justified root.
+	// This simulates a production scenario where the prune boundary is close to
+	// but still below the justified checkpoint. The justified root (and its nearby
+	// ancestors with state files) must survive.
+	pruneSlot := justifiedHeader.Slot - 2
+	t.Logf("Pruning at slot %d (justified at slot %d)", pruneSlot, justifiedHeader.Slot)
+	require.NoError(t, fg.Prune(pruneSlot))
+
+	// Verify GetState still works for the justified root.
+	state, err := store.GetStateAtBlockRoot(justified.Root, true)
+	require.NoError(t, err, "GetStateAtBlockRoot failed for justified root after aggressive prune")
+	require.NotNil(t, state, "state nil for justified root (slot %d) after prune at slot %d",
+		justifiedHeader.Slot, pruneSlot)
+	t.Logf("Post-prune justified state slot: %d", state.Slot())
+
+	// GetHead should succeed — this is the exact path that fails in production.
+	headRoot, headSlot, err := store.GetHead(nil)
+	require.NoError(t, err, "GetHead failed after aggressive prune")
+	t.Logf("Post-prune head: slot=%d root=%x", headSlot, headRoot)
+}

--- a/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
+++ b/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
@@ -501,7 +501,9 @@ func (f *forkGraphDisk) getState(blockRoot common.Hash, alwaysCopy bool, addChai
 	var err error
 
 	// try and find the point of reconnection
+	walkSteps := 0
 	for copyReferencedState == nil {
+		walkSteps++
 		block, isSegmentPresent := f.GetBlock(currentIteratorRoot)
 		if !isSegmentPresent {
 			// check if it is in the header
@@ -509,18 +511,22 @@ func (f *forkGraphDisk) getState(blockRoot common.Hash, alwaysCopy bool, addChai
 			if ok && bHeader.Slot%dumpSlotFrequency == 0 {
 				copyReferencedState, err = f.readBeaconStateFromDisk(currentIteratorRoot)
 				if err != nil {
-					log.Trace("Could not retrieve state", "missing", currentIteratorRoot, "err", err)
+					log.Warn("[getState] header-only root state read failed", "root", currentIteratorRoot, "slot", bHeader.Slot, "err", err, "walkSteps", walkSteps, "startRoot", blockRoot)
 					return nil, nil
 				}
 				continue
 			}
-			log.Trace("Could not retrieve state: Missing header", "missing", currentIteratorRoot)
+			if ok {
+				log.Warn("[getState] header-only root slot not aligned", "root", currentIteratorRoot, "slot", bHeader.Slot, "slotMod4", bHeader.Slot%dumpSlotFrequency, "walkSteps", walkSteps, "startRoot", blockRoot)
+			} else {
+				log.Warn("[getState] root not in blocks or headers", "root", currentIteratorRoot, "walkSteps", walkSteps, "startRoot", blockRoot, "anchorRoot", f.anchorRoot, "anchorSlot", f.anchorSlot)
+			}
 			return nil, nil
 		}
 		if block.Block.Slot%dumpSlotFrequency == 0 {
 			copyReferencedState, err = f.readBeaconStateFromDisk(currentIteratorRoot)
 			if err != nil {
-				log.Trace("Could not retrieve state: Missing header", "missing", currentIteratorRoot, "err", err)
+				log.Warn("[getState] block state read failed, continuing walk", "root", currentIteratorRoot, "slot", block.Block.Slot, "err", err, "walkSteps", walkSteps, "startRoot", blockRoot)
 			}
 			if copyReferencedState != nil {
 				break
@@ -590,6 +596,7 @@ func (f *forkGraphDisk) Prune(pruneSlot uint64) (err error) {
 		return true
 	})
 	if pruneSlot >= highestStoredBeaconStateSlot {
+		log.Debug("[Prune] skipped: pruneSlot >= highestStoredBeaconStateSlot", "pruneSlot", pruneSlot, "highestStoredBeaconStateSlot", highestStoredBeaconStateSlot)
 		return
 	}
 
@@ -597,8 +604,12 @@ func (f *forkGraphDisk) Prune(pruneSlot uint64) (err error) {
 	f.currentIndicies.prune(pruneSlot / f.beaconCfg.SlotsPerEpoch)
 	f.previousIndicies.prune(pruneSlot / f.beaconCfg.SlotsPerEpoch)
 
+	stateFilesDeleted := 0
 	f.lowestAvailableBlock.Store(pruneSlot + 1)
 	for _, root := range oldRoots {
+		if f.hasBeaconState(root) {
+			stateFilesDeleted++
+		}
 		f.badBlocks.Delete(root)
 		f.blocks.Delete(root)
 		f.lightclientBootstraps.Delete(root)
@@ -611,7 +622,7 @@ func (f *forkGraphDisk) Prune(pruneSlot uint64) (err error) {
 		f.envelopeExists.Delete(root)
 		f.fs.Remove(getEnvelopeFilename(root))
 	}
-	log.Debug("Pruned old blocks", "pruneSlot", pruneSlot)
+	log.Debug("Pruned old blocks", "pruneSlot", pruneSlot, "blocksRemoved", len(oldRoots), "stateFilesDeleted", stateFilesDeleted, "highestStoredBeaconStateSlot", highestStoredBeaconStateSlot)
 	return
 }
 

--- a/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
+++ b/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
@@ -397,6 +397,10 @@ func (f *forkGraphDisk) AddChainSegment(signedBlock *cltypes.SignedBeaconBlock, 
 	f.currentJustifiedCheckpoints.Store(common.Hash(blockRoot), newState.CurrentJustifiedCheckpoint())
 	f.finalizedCheckpoints.Store(common.Hash(blockRoot), newState.FinalizedCheckpoint())
 
+	if err := f.DumpBeaconStateOnDisk(common.Hash(blockRoot), newState, false); err != nil {
+		return nil, LogisticError, err
+	}
+
 	return newState, Success, nil
 }
 

--- a/cl/phase1/forkchoice/utils.go
+++ b/cl/phase1/forkchoice/utils.go
@@ -206,6 +206,24 @@ func (f *ForkChoiceStore) getCheckpointState(checkpoint solid.Checkpoint) (*chec
 		return nil, err
 	}
 	if baseState == nil {
+		block, hasBlock := f.forkGraph.GetBlock(checkpoint.Root)
+		header, hasHeader := f.forkGraph.GetHeader(checkpoint.Root)
+		blockSlot := uint64(0)
+		if hasBlock {
+			blockSlot = block.Block.Slot
+		} else if hasHeader {
+			blockSlot = header.Slot
+		}
+		log.Warn("[getCheckpointState] baseState not found",
+			"checkpointRoot", checkpoint.Root,
+			"checkpointEpoch", checkpoint.Epoch,
+			"blockSlot", blockSlot,
+			"slotMod4", blockSlot%4,
+			"inBlocks", hasBlock,
+			"inHeaders", hasHeader,
+			"anchorSlot", f.forkGraph.AnchorSlot(),
+			"anchorRoot", f.forkGraph.AnchorRoot(),
+		)
 		return nil, errors.New("getCheckpointState: baseState not found in graph")
 	}
 	// By default use the no change encoding to signal that there is no future epoch here.


### PR DESCRIPTION
## Summary

- Adds `DumpBeaconStateOnDisk` call in `AddChainSegment` to ensure state files are written every `dumpSlotFrequency` (4) slots during all stages, not just ForwardSync and ForkChoice.

## Problem

After PR #21188 fixed the infinite loop in `getState`, a deeper issue surfaced: Caplin enters a **permanent death spiral** where the ForkChoice stage fails with `"baseState not found in graph"` on every invocation.

**Root cause:**

State files were only written in two places:
1. **ForwardSync** — every 64 slots (`forward_sync.go:235`)
2. **ForkChoice stage** — after successful head computation (`forkchoice.go:356`)

`AddChainSegment` itself never dumped state files. This created a fatal gap:

```
ForwardSync ends → ChainTipSync processes blocks via OnBlock
  → updateCheckpoints → onNewFinalized → Prune (deletes old blocks + state files)
  → ForkChoice stage runs → GetHead → getCheckpointState → getState(justifiedRoot)
  → backward walk hits pruned blocks → returns nil → "baseState not found"
  → ForkChoice fails BEFORE reaching DumpBeaconStateOnDisk
  → No new state files created → Prune continues deleting remaining files
  → Permanent failure loop
```

Reproduced on `dev-bm-e3-sepolia-n1.erigon.io` running mainnet with Caplin — 814+ consecutive failures over 3 hours, with only 2 state files remaining on disk (anchor + one ForwardSync dump).

## Fix

Call `DumpBeaconStateOnDisk` at the end of `AddChainSegment`. The `forced=false` parameter ensures it only writes at `slot % dumpSlotFrequency == 0` (every 4 slots), matching what `getState` expects when walking backward.

## Test plan

- [x] Existing `TestForkGraphInDisk` passes
- [x] `TestGetState_InfiniteLoopOnMissingStateFile` passes
- [x] `make erigon` builds successfully
- [ ] Verify on mainnet node that ForkChoice no longer gets stuck after ForwardSync catchup

🤖 Generated with [Claude Code](https://claude.com/claude-code)