### PR TITLE
execution/execmodule: prune chaindata in CommitCycle (+ release roTx, bloatnet collation gate)

### DIFF
--- a/execution/execmodule/forkchoice.go
+++ b/execution/execmodule/forkchoice.go
@@ -491,6 +491,11 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 			if err = commitRwTx.Commit(); err != nil {
 				return nil, fmt.Errorf("updateForkChoice: tx commit after hasMore: %w", err)
 			}
+			// In-loop PruneExecutionStage runs on the overlay (RO-backed
+			// MemoryMutation) and silently no-ops. Drain here on a real RW tx.
+			if _, pruneErr := e.runForkchoicePrune(initialCycle); pruneErr != nil && !errors.Is(pruneErr, context.Canceled) {
+				e.logger.Warn("[commit-cycle] prune failed", "err", pruneErr)
+			}
 			roTx, err = e.db.BeginTemporalRo(ctx) //nolint:gocritic
 			if err != nil {
 				return nil, fmt.Errorf("updateForkChoice: begin ro after hasMore: %w", err)

--- a/execution/execmodule/forkchoice.go
+++ b/execution/execmodule/forkchoice.go
@@ -476,7 +476,9 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 		PruneTimeout:    500 * time.Millisecond,
 		BeforeIteration: nil,
 		CommitCycle: func(ctx context.Context, sd *execctx.SharedDomains) (kv.TemporalRwTx, error) {
-			// Flush SD + overlay to a brief RwTx to relieve memory pressure.
+			// Release the old RO snapshot before the flush so MDBX can
+			// reclaim retired pages while the RwTx is writing.
+			roTx.Rollback()
 			commitRwTx, err := e.db.BeginTemporalRw(ctx) //nolint:gocritic
 			if err != nil {
 				return nil, fmt.Errorf("updateForkChoice: begin rw after hasMore: %w", err)
@@ -489,8 +491,6 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 			if err = commitRwTx.Commit(); err != nil {
 				return nil, fmt.Errorf("updateForkChoice: tx commit after hasMore: %w", err)
 			}
-			// Recreate RO tx + block overlay on the fresh committed state.
-			roTx.Rollback()
 			roTx, err = e.db.BeginTemporalRo(ctx) //nolint:gocritic
 			if err != nil {
 				return nil, fmt.Errorf("updateForkChoice: begin ro after hasMore: %w", err)

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -72,6 +72,7 @@ import (
 	"github.com/erigontech/erigon/diagnostics/mem"
 	"github.com/erigontech/erigon/execution/builder"
 	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/chain/networkname"
 	chainspec "github.com/erigontech/erigon/execution/chain/spec"
 	"github.com/erigontech/erigon/execution/engineapi"
 	"github.com/erigontech/erigon/execution/engineapi/engine_block_downloader"
@@ -1299,7 +1300,11 @@ func SetUpBlockReader(ctx context.Context, db kv.RwDB, dirs datadir.Dirs, snConf
 	}
 	agg.SetSnapshotBuildSema(blockSnapBuildSema)
 	agg.SetProduceMod(snConfig.Snapshot.ProduceE3)
-	agg.SetFrozenBlocksProvider(blockReader)
+	// On bloatnet, skip the block-snapshot collation gate so state
+	// aggregation can advance independently of block retire.
+	if chainConfig.ChainName != networkname.Bloatnet {
+		agg.SetFrozenBlocksProvider(blockReader)
+	}
 
 	allSegmentsDownloadComplete, err := rawdb.AllSegmentsDownloadCompleteFromDB(db)
 	if err != nil {


### PR DESCRIPTION
## Summary

Three fixes to keep chaindata size bounded during long FCU catch-ups on `bloatnet`:

- **Release roTx before CommitCycle flush.** Lets MDBX reclaim retired pages while the brief RwTx is writing. Flush/ClearRam don't read through roTx, so closing it early is safe.
- **Prune chaindata in CommitCycle.** The in-loop PruneExecutionStage runs on the SharedDomains' block overlay (MemoryMutation backed by an RO tx). `MemoryMutation.PruneSmallBatches` silently no-ops when its backing tx isn't a `TemporalRwTx`, so prune doesn't fire for the entire duration of a hasMore loop — aggregated steps accumulate in chaindata domain tables for hours. After commit, invoke `runForkchoicePrune` on a fresh real RW tx so prune actually drains.
- **Skip state-collation block-snapshot gate on bloatnet.** Aggregator's `readyForCollation` capTxNum is gated on block snapshots catching up. On a paused chain that gate blocks state aggregation → blocks prune → CommitmentVals grows unboundedly. For mainnet/sepolia/etc the gate stays.

## Observed on bloatnet

In a 100m batchSize catch-up:
- chaindata growth per cycle: ~2 GB → step-boundary drain ~−9 GB
- file size oscillates instead of growing unboundedly (~35 GB ceiling vs >100 GB without the fix)

## Test plan

- [ ] CI on `performance` passes
- [ ] Mainnet sync still healthy (the only path-sensitive change is the CommitCycle prune call; same code as `runForkchoicePrune` used elsewhere)