### PR TITLE
execution/stagedsync: check batch fullness after every block

### DIFF
--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -58,9 +58,6 @@ func (se *serialExecutor) exec(ctx context.Context, execStage *StageState, u Unw
 
 	se.resetWorkers(ctx, se.rs, se.applyTx)
 
-	checkIsBatchFullEvery := time.NewTicker(5 * time.Second)
-	defer checkIsBatchFullEvery.Stop()
-
 	havePartialBlock := false
 	blockNum := startBlockNum
 
@@ -226,23 +223,21 @@ func (se *serialExecutor) exec(ctx context.Context, execStage *StageState, u Unw
 			if se.isApplyingBlocks {
 				se.LogExecution()
 			}
-		case <-checkIsBatchFullEvery.C:
-			if !se.isApplyingBlocks {
-				break
-			}
-			isBatchFull := se.readState().SizeEstimateBeforeCommitment() >= se.cfg.batchSize.Bytes()
-			needCalcRoot := isBatchFull || havePartialBlock
-			// If we have a partial first block it may not be validated, then we should compute root hash ASAP for fail-fast
-			// this will only happen for the first executed block
-			havePartialBlock = false
-			if !needCalcRoot {
-				break
-			}
+		default:
+		}
+
+		isBatchFull := se.isApplyingBlocks && se.readState().SizeEstimateBeforeCommitment() >= se.cfg.batchSize.Bytes()
+		// havePartialBlock: partial first block isn't validated, compute root ASAP for fail-fast.
+		needCalcRoot := se.isApplyingBlocks && (isBatchFull || havePartialBlock)
+		havePartialBlock = false
+
+		if needCalcRoot {
 			resetExecGauges(ctx)
 			ok, times, err := computeAndCheckCommitmentV3(ctx, b.HeaderNoCopy(), rwTx, se.doms, se.cfg, execStage, false, se.logger, u)
 			if err != nil {
 				return nil, rwTx, err
-			} else if !ok {
+			}
+			if !ok {
 				return b.HeaderNoCopy(), rwTx, nil
 			}
 			resetCommitmentGauges(ctx)
@@ -258,7 +253,6 @@ func (se *serialExecutor) exec(ctx context.Context, execStage *StageState, u Unw
 			if isBatchFull {
 				return b.HeaderNoCopy(), rwTx, &ErrLoopExhausted{From: startBlockNum, To: blockNum, Reason: "block batch is full"}
 			}
-		default:
 		}
 
 		select {


### PR DESCRIPTION
## Summary

Move the batch-fullness check out of a 5-second ticker and into per-block. When blocks process quickly, exec was overshooting the configured `--batchSize` by hundreds of MB between ticks. With 4 blk/s and 33 MB of CommitmentVals per block, 5 s of unchecked exec adds ~660 MB to the buffer — well past a configured 100 MB or 256 MB batchSize. Smaller batchSize → worse overshoot ratio.

The check itself is cheap (a single `readState().SizeEstimateBeforeCommitment()` call), so per-block is fine.

This lets `--batchSize` actually bound the per-commit working set, which directly bounds the per-CommitCycle trie-hash cost — the dominant slowdown source on heavy-state runs.

## Test plan

- [ ] CI on `performance`
- [ ] Mainnet sync still healthy