### PR TITLE
execution/engineapi: add SSZ-REST Engine API transport

### DIFF
--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -962,11 +962,20 @@ func createHandler(cfg *httpcfg.HttpCfg, apiList []rpc.API, httpHandler http.Han
 			return
 		}
 
+		if jwtSecret != nil && AuthenticatedEngineRESTHandler != nil && strings.HasPrefix(r.URL.Path, "/engine/") {
+			AuthenticatedEngineRESTHandler.ServeHTTP(w, r)
+			return
+		}
+
 		httpHandler.ServeHTTP(w, r)
 	})
 
 	return handler, nil
 }
+
+// AuthenticatedEngineRESTHandler is installed by the in-process Engine API
+// server and is invoked only after the same JWT check as authenticated JSON-RPC.
+var AuthenticatedEngineRESTHandler http.Handler
 
 func createEngineListener(cfg *httpcfg.HttpCfg, engineApi []rpc.API, logger log.Logger) (*http.Server, *rpc.Server, string, error) {
 	engineHttpEndpoint := fmt.Sprintf("tcp://%s:%d", cfg.AuthRpcHTTPListenAddress, cfg.AuthRpcPort)

--- a/devnet/ssz-rest-kurtosis/README.md
+++ b/devnet/ssz-rest-kurtosis/README.md
@@ -1,0 +1,61 @@
+# SSZ-REST Engine API Kurtosis Devnet
+
+This devnet runs local Erigon as EL, Prysm as CL, and Spamoor transaction load with a 4 second slot time. Erigon's authenticated Engine API port is used for both JSON-RPC bootstrap negotiation and SSZ-REST Engine API calls.
+
+## Prerequisites
+
+- Docker
+- Kurtosis CLI
+- A Prysm image built from OffchainLabs/prysm PR `16447`, or an equivalent image that advertises and uses SSZ-REST Engine API endpoint capabilities.
+
+Use Prysm images built from the PR branch and tag them for this devnet:
+
+```bash
+docker tag local-prysm:ssz-rest-16447 local-prysm:ssz-rest
+docker tag local-prysm-validator:ssz-rest-16447 local-prysm-validator:ssz-rest
+```
+
+## Run
+
+From the Erigon repo root:
+
+```bash
+./devnet/ssz-rest-kurtosis/run.sh
+```
+
+The script builds `local-erigon:ssz-rest`, launches a Kurtosis Ethereum devnet, starts Spamoor, and prints the enclave name plus log commands for Erigon, Prysm, and Spamoor.
+
+By default it pins `github.com/ethpandaops/ethereum-package@87df9d9d15e493ea91db788161e54324c39f6a6e`, the pre-Heze package revision compatible with the Prysm PR `16447` image. Override `ETHEREUM_PACKAGE` only when using a Prysm build that supports newer package config fields.
+
+The generated Kurtosis params explicitly set:
+
+- `seconds_per_slot: 4`
+- EL client: local Erigon image
+- CL client: Prysm image with PR `16447` SSZ-REST semantics
+- Engine API JWT auth enabled on the normal authenticated engine port
+- Spamoor load pointed at the devnet public RPC endpoint
+- Deneb/Electra active at genesis; later fork epochs stay on the pinned package defaults so the generated Prysm execution genesis header matches Erigon's imported genesis block hash.
+
+## Evidence Checks
+
+After the network has run for at least 10 minutes:
+
+```bash
+kurtosis enclave inspect ssz-rest-erigon
+kurtosis service logs ssz-rest-erigon el-1-erigon-prysm
+kurtosis service logs ssz-rest-erigon cl-1-prysm-erigon
+kurtosis service logs ssz-rest-erigon spamoor
+```
+
+Look for:
+
+- Prysm exchanging capabilities with Erigon and receiving strings such as `POST /engine/v4/payloads`.
+- Erigon log lines containing `[SSZ-REST] handled forkchoice`, `[SSZ-REST] handled new payload`, `[SSZ-REST] handled get payload`, or `[SSZ-REST] handled get blobs`.
+- Produced and finalized beacon blocks in Prysm logs.
+- Spamoor successful transaction submission and inclusion without Engine API auth failures, malformed SSZ loops, invalid payload loops, panics, or repeated fallback-to-JSON after SSZ capabilities are negotiated.
+
+## Cleanup
+
+```bash
+kurtosis enclave rm -f ssz-rest-erigon
+```

--- a/devnet/ssz-rest-kurtosis/network-params.yaml
+++ b/devnet/ssz-rest-kurtosis/network-params.yaml
@@ -1,0 +1,31 @@
+participants:
+  - el_type: erigon
+    el_image: local-erigon:ssz-rest
+    el_extra_params:
+      - --authrpc.addr=0.0.0.0
+      - --authrpc.port=8551
+      - --authrpc.vhosts=*
+      - --http
+      - --http.addr=0.0.0.0
+      - --http.api=eth,net,web3,erigon,admin
+    cl_type: prysm
+    cl_image: local-prysm:ssz-rest
+    cl_extra_params:
+      - --enable-ssz-rest-engine-api
+    vc_image: local-prysm-validator:ssz-rest
+network_params:
+  seconds_per_slot: 4
+  deneb_fork_epoch: 0
+  electra_fork_epoch: 0
+additional_services:
+  - spamoor
+spamoor_params:
+  image: ethpandaops/spamoor:latest
+  spammers:
+    - scenario: eoatx
+      name: ssz-rest-eoatx
+      config:
+        throughput: 25
+        max_pending: 100
+        max_wallets: 50
+  extra_args: []

--- a/devnet/ssz-rest-kurtosis/run.sh
+++ b/devnet/ssz-rest-kurtosis/run.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ENCLAVE_NAME="${ENCLAVE_NAME:-ssz-rest-erigon}"
+ERIGON_IMAGE="${ERIGON_IMAGE:-local-erigon:ssz-rest}"
+PRYSM_IMAGE="${PRYSM_IMAGE:-local-prysm:ssz-rest}"
+PRYSM_VALIDATOR_IMAGE="${PRYSM_VALIDATOR_IMAGE:-local-prysm-validator:ssz-rest}"
+SPAMOOR_IMAGE="${SPAMOOR_IMAGE:-ethpandaops/spamoor:latest}"
+PARAMS_FILE="${PARAMS_FILE:-/tmp/${ENCLAVE_NAME}-network-params.yaml}"
+ETHEREUM_PACKAGE="${ETHEREUM_PACKAGE:-github.com/ethpandaops/ethereum-package@87df9d9d15e493ea91db788161e54324c39f6a6e}"
+
+cd "${ROOT_DIR}"
+
+docker build -t "${ERIGON_IMAGE}" .
+
+cat > "${PARAMS_FILE}" <<YAML
+participants:
+  - el_type: erigon
+    el_image: ${ERIGON_IMAGE}
+    el_extra_params:
+      - --authrpc.addr=0.0.0.0
+      - --authrpc.port=8551
+      - --authrpc.vhosts=*
+      - --http
+      - --http.addr=0.0.0.0
+      - --http.api=eth,net,web3,erigon,admin
+    cl_type: prysm
+    cl_image: ${PRYSM_IMAGE}
+    cl_extra_params:
+      - --enable-ssz-rest-engine-api
+    vc_image: ${PRYSM_VALIDATOR_IMAGE}
+network_params:
+  seconds_per_slot: 4
+  deneb_fork_epoch: 0
+  electra_fork_epoch: 0
+additional_services:
+  - spamoor
+spamoor_params:
+  image: ${SPAMOOR_IMAGE}
+  spammers:
+    - scenario: eoatx
+      name: ssz-rest-eoatx
+      config:
+        throughput: 25
+        max_pending: 100
+        max_wallets: 50
+  extra_args: []
+YAML
+
+kurtosis enclave rm -f "${ENCLAVE_NAME}" >/dev/null 2>&1 || true
+kurtosis run "${ETHEREUM_PACKAGE}" --enclave "${ENCLAVE_NAME}" --args-file "${PARAMS_FILE}"
+
+cat <<EOF
+Enclave: ${ENCLAVE_NAME}
+Erigon logs:  kurtosis service logs ${ENCLAVE_NAME} el-1-erigon-prysm
+Prysm logs:   kurtosis service logs ${ENCLAVE_NAME} cl-1-prysm-erigon
+Spamoor logs: kurtosis service logs ${ENCLAVE_NAME} spamoor
+
+Verify 4 second slots and SSZ-REST calls:
+  kurtosis enclave inspect ${ENCLAVE_NAME}
+  kurtosis service logs ${ENCLAVE_NAME} el-1-erigon-prysm | grep -E '\\[SSZ-REST\\]|/engine/v.*/(payloads|forkchoice|blobs|capabilities)'
+  kurtosis service logs ${ENCLAVE_NAME} cl-1-prysm-erigon | grep -E 'finalized|POST /engine|GET /engine|SSZ'
+EOF

--- a/execution/engineapi/engine_api_methods.go
+++ b/execution/engineapi/engine_api_methods.go
@@ -64,6 +64,26 @@ var ourCapabilities = []string{
 	"engine_getBlobsV1",
 	"engine_getBlobsV2",
 	"engine_getBlobsV3",
+	"POST /engine/v1/payloads",
+	"POST /engine/v2/payloads",
+	"POST /engine/v3/payloads",
+	"POST /engine/v4/payloads",
+	"POST /engine/v5/payloads",
+	"GET /engine/v1/payloads/{payload_id}",
+	"GET /engine/v2/payloads/{payload_id}",
+	"GET /engine/v3/payloads/{payload_id}",
+	"GET /engine/v4/payloads/{payload_id}",
+	"GET /engine/v5/payloads/{payload_id}",
+	"GET /engine/v6/payloads/{payload_id}",
+	"POST /engine/v1/forkchoice",
+	"POST /engine/v2/forkchoice",
+	"POST /engine/v3/forkchoice",
+	"POST /engine/v4/forkchoice",
+	"POST /engine/v1/blobs",
+	"POST /engine/v2/blobs",
+	"POST /engine/v3/blobs",
+	"POST /engine/v1/client/version",
+	"POST /engine/v1/capabilities",
 }
 
 // Returns the most recent version of the payload(for the payloadID) at the time of receiving the call
@@ -193,8 +213,6 @@ func (e *EngineServer) NewPayloadV3(ctx context.Context, payload *engine_types.E
 // See https://github.com/ethereum/execution-apis/blob/main/src/engine/prague.md#engine_newpayloadv4
 func (e *EngineServer) NewPayloadV4(ctx context.Context, payload *engine_types.ExecutionPayload,
 	expectedBlobHashes []common.Hash, parentBeaconBlockRoot *common.Hash, executionRequests []hexutil.Bytes) (*engine_types.PayloadStatus, error) {
-	// TODO(racytech): add proper version or refactor this part
-	// add all version ralated checks here so the newpayload doesn't have to deal with checks
 	return e.newPayload(ctx, payload, expectedBlobHashes, parentBeaconBlockRoot, executionRequests, clparams.ElectraVersion)
 }
 

--- a/execution/engineapi/engine_server.go
+++ b/execution/engineapi/engine_server.go
@@ -142,6 +142,7 @@ func (e *EngineServer) Start(
 ) error {
 	e.filters = filters
 	e.events = events
+	cli.AuthenticatedEngineRESTHandler = e.SSZRESTHandler()
 
 	var eg errgroup.Group
 	if !e.internalCL {

--- a/execution/engineapi/engine_types/jsonrpc.go
+++ b/execution/engineapi/engine_types/jsonrpc.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/execution/types"
@@ -32,25 +33,26 @@ import (
 
 // ExecutionPayload represents an execution payload (aka block)
 type ExecutionPayload struct {
-	ParentHash      common.Hash         `json:"parentHash"    gencodec:"required"`
-	FeeRecipient    common.Address      `json:"feeRecipient"  gencodec:"required"`
-	StateRoot       common.Hash         `json:"stateRoot"     gencodec:"required"`
-	ReceiptsRoot    common.Hash         `json:"receiptsRoot"  gencodec:"required"`
-	LogsBloom       hexutil.Bytes       `json:"logsBloom"     gencodec:"required"`
-	PrevRandao      common.Hash         `json:"prevRandao"    gencodec:"required"`
-	BlockNumber     hexutil.Uint64      `json:"blockNumber"   gencodec:"required"`
-	GasLimit        hexutil.Uint64      `json:"gasLimit"      gencodec:"required"`
-	GasUsed         hexutil.Uint64      `json:"gasUsed"       gencodec:"required"`
-	Timestamp       hexutil.Uint64      `json:"timestamp"     gencodec:"required"`
-	ExtraData       hexutil.Bytes       `json:"extraData"     gencodec:"required"`
-	BaseFeePerGas   *hexutil.Big        `json:"baseFeePerGas" gencodec:"required"`
-	BlockHash       common.Hash         `json:"blockHash"     gencodec:"required"`
-	Transactions    []hexutil.Bytes     `json:"transactions"  gencodec:"required"`
-	Withdrawals     []*types.Withdrawal `json:"withdrawals"`
-	BlobGasUsed     *hexutil.Uint64     `json:"blobGasUsed"`
-	ExcessBlobGas   *hexutil.Uint64     `json:"excessBlobGas"`
-	SlotNumber      *hexutil.Uint64     `json:"slotNumber,omitempty"`
-	BlockAccessList hexutil.Bytes       `json:"blockAccessList,omitempty"`
+	ParentHash      common.Hash           `json:"parentHash"    gencodec:"required"`
+	FeeRecipient    common.Address        `json:"feeRecipient"  gencodec:"required"`
+	StateRoot       common.Hash           `json:"stateRoot"     gencodec:"required"`
+	ReceiptsRoot    common.Hash           `json:"receiptsRoot"  gencodec:"required"`
+	LogsBloom       hexutil.Bytes         `json:"logsBloom"     gencodec:"required"`
+	PrevRandao      common.Hash           `json:"prevRandao"    gencodec:"required"`
+	BlockNumber     hexutil.Uint64        `json:"blockNumber"   gencodec:"required"`
+	GasLimit        hexutil.Uint64        `json:"gasLimit"      gencodec:"required"`
+	GasUsed         hexutil.Uint64        `json:"gasUsed"       gencodec:"required"`
+	Timestamp       hexutil.Uint64        `json:"timestamp"     gencodec:"required"`
+	ExtraData       hexutil.Bytes         `json:"extraData"     gencodec:"required"`
+	BaseFeePerGas   *hexutil.Big          `json:"baseFeePerGas" gencodec:"required"`
+	BlockHash       common.Hash           `json:"blockHash"     gencodec:"required"`
+	Transactions    []hexutil.Bytes       `json:"transactions"  gencodec:"required"`
+	Withdrawals     []*types.Withdrawal   `json:"withdrawals"`
+	BlobGasUsed     *hexutil.Uint64       `json:"blobGasUsed"`
+	ExcessBlobGas   *hexutil.Uint64       `json:"excessBlobGas"`
+	SlotNumber      *hexutil.Uint64       `json:"slotNumber,omitempty"`
+	BlockAccessList hexutil.Bytes         `json:"blockAccessList,omitempty"`
+	SSZVersion      clparams.StateVersion `json:"-"`
 }
 
 // PayloadAttributes represent the attributes required to start assembling a payload
@@ -62,12 +64,13 @@ type ForkChoiceState struct {
 
 // PayloadAttributes represent the attributes required to start assembling a payload
 type PayloadAttributes struct {
-	Timestamp             hexutil.Uint64      `json:"timestamp"             gencodec:"required"`
-	PrevRandao            common.Hash         `json:"prevRandao"            gencodec:"required"`
-	SuggestedFeeRecipient common.Address      `json:"suggestedFeeRecipient" gencodec:"required"`
-	Withdrawals           []*types.Withdrawal `json:"withdrawals"`
-	ParentBeaconBlockRoot *common.Hash        `json:"parentBeaconBlockRoot"`
-	SlotNumber            *hexutil.Uint64     `json:"slotNumber"`
+	Timestamp             hexutil.Uint64        `json:"timestamp"             gencodec:"required"`
+	PrevRandao            common.Hash           `json:"prevRandao"            gencodec:"required"`
+	SuggestedFeeRecipient common.Address        `json:"suggestedFeeRecipient" gencodec:"required"`
+	Withdrawals           []*types.Withdrawal   `json:"withdrawals"`
+	ParentBeaconBlockRoot *common.Hash          `json:"parentBeaconBlockRoot"`
+	SlotNumber            *hexutil.Uint64       `json:"slotNumber"`
+	SSZVersion            clparams.StateVersion `json:"-"`
 }
 
 // TransitionConfiguration represents the correct configurations of the CL and the EL
@@ -81,9 +84,10 @@ type TransitionConfiguration struct {
 // It covers both BlobsBundleV1 (https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md#blobsbundlev1)
 // and BlobsBundleV2 (https://github.com/ethereum/execution-apis/blob/main/src/engine/osaka.md#blobsbundlev2)
 type BlobsBundle struct {
-	Commitments []hexutil.Bytes `json:"commitments" gencodec:"required"`
-	Proofs      []hexutil.Bytes `json:"proofs"      gencodec:"required"`
-	Blobs       []hexutil.Bytes `json:"blobs"       gencodec:"required"`
+	Commitments []hexutil.Bytes       `json:"commitments" gencodec:"required"`
+	Proofs      []hexutil.Bytes       `json:"proofs"      gencodec:"required"`
+	Blobs       []hexutil.Bytes       `json:"blobs"       gencodec:"required"`
+	SSZVersion  clparams.StateVersion `json:"-"`
 }
 
 // BlobsBundleFromTransactions builds a BlobsBundle by extracting blobs,

--- a/execution/engineapi/engine_types/ssz.go
+++ b/execution/engineapi/engine_types/ssz.go
@@ -5,7 +5,6 @@ package engine_types
 
 import (
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -173,41 +172,20 @@ func ExecutionPayloadFromSSZBlock(block *cltypes.Eth1Block, version clparams.Sta
 	return p
 }
 
-type sszWithdrawalList struct {
-	List *solid.ListSSZ[*cltypes.Withdrawal]
-}
-
-func newSSZWithdrawalList(ws []*types.Withdrawal) *sszWithdrawalList {
+func newWithdrawalList(ws []*types.Withdrawal) *solid.ListSSZ[*cltypes.Withdrawal] {
 	l := solid.NewStaticListSSZ[*cltypes.Withdrawal](int(mainnetBeaconCfg.MaxWithdrawalsPerPayload), 44)
 	for _, w := range ws {
 		l.Append(&cltypes.Withdrawal{Index: w.Index, Validator: w.Validator, Address: w.Address, Amount: w.Amount})
 	}
-	return &sszWithdrawalList{List: l}
+	return l
 }
-func (l *sszWithdrawalList) Static() bool { return false }
-func (l *sszWithdrawalList) EncodeSSZ(dst []byte) ([]byte, error) {
-	if l.List == nil {
-		l.List = solid.NewStaticListSSZ[*cltypes.Withdrawal](int(mainnetBeaconCfg.MaxWithdrawalsPerPayload), 44)
-	}
-	return l.List.EncodeSSZ(dst)
-}
-func (l *sszWithdrawalList) DecodeSSZ(buf []byte, version int) error {
-	l.List = solid.NewStaticListSSZ[*cltypes.Withdrawal](int(mainnetBeaconCfg.MaxWithdrawalsPerPayload), 44)
-	return l.List.DecodeSSZ(buf, version)
-}
-func (l *sszWithdrawalList) EncodingSizeSSZ() int {
-	if l.List == nil {
-		return 0
-	}
-	return l.List.EncodingSizeSSZ()
-}
-func (*sszWithdrawalList) Clone() clonable.Clonable { return &sszWithdrawalList{} }
-func (l *sszWithdrawalList) withdrawals() []*types.Withdrawal {
-	if l.List == nil {
+
+func withdrawalsFromList(l *solid.ListSSZ[*cltypes.Withdrawal]) []*types.Withdrawal {
+	if l == nil {
 		return nil
 	}
-	out := make([]*types.Withdrawal, 0, l.List.Len())
-	l.List.Range(func(_ int, w *cltypes.Withdrawal, _ int) bool {
+	out := make([]*types.Withdrawal, 0, l.Len())
+	l.Range(func(_ int, w *cltypes.Withdrawal, _ int) bool {
 		out = append(out, &types.Withdrawal{Index: w.Index, Validator: w.Validator, Address: w.Address, Amount: w.Amount})
 		return true
 	})
@@ -315,7 +293,7 @@ func (a *PayloadAttributes) Static() bool { return false }
 
 func (a *PayloadAttributes) EncodeSSZ(dst []byte) ([]byte, error) {
 	version := a.payloadAttributesSSZVersion()
-	withdrawals := newSSZWithdrawalList(a.Withdrawals)
+	withdrawals := newWithdrawalList(a.Withdrawals)
 	var root common.Hash
 	if a.ParentBeaconBlockRoot != nil {
 		root = *a.ParentBeaconBlockRoot
@@ -338,7 +316,7 @@ func (a *PayloadAttributes) EncodeSSZ(dst []byte) ([]byte, error) {
 
 func (a *PayloadAttributes) DecodeSSZ(buf []byte, version int) error {
 	a.SSZVersion = clparams.StateVersion(version)
-	withdrawals := &sszWithdrawalList{}
+	withdrawals := newWithdrawalList(nil)
 	var timestamp uint64
 	var root common.Hash
 	var slot uint64
@@ -351,18 +329,18 @@ func (a *PayloadAttributes) DecodeSSZ(buf []byte, version int) error {
 		if err := ssz2.UnmarshalSSZ(buf, version, &timestamp, a.PrevRandao[:], a.SuggestedFeeRecipient[:], withdrawals); err != nil {
 			return err
 		}
-		a.Withdrawals = withdrawals.withdrawals()
+		a.Withdrawals = withdrawalsFromList(withdrawals)
 	case clparams.DenebVersion:
 		if err := ssz2.UnmarshalSSZ(buf, version, &timestamp, a.PrevRandao[:], a.SuggestedFeeRecipient[:], withdrawals, root[:]); err != nil {
 			return err
 		}
-		a.Withdrawals = withdrawals.withdrawals()
+		a.Withdrawals = withdrawalsFromList(withdrawals)
 		a.ParentBeaconBlockRoot = &root
 	default:
 		if err := ssz2.UnmarshalSSZ(buf, version, &timestamp, a.PrevRandao[:], a.SuggestedFeeRecipient[:], withdrawals, root[:], &slot); err != nil {
 			return err
 		}
-		a.Withdrawals = withdrawals.withdrawals()
+		a.Withdrawals = withdrawalsFromList(withdrawals)
 		a.ParentBeaconBlockRoot = &root
 		slotNumber := hexutil.Uint64(slot)
 		a.SlotNumber = &slotNumber
@@ -422,99 +400,23 @@ func (v *ClientVersionV1) HashSSZ() ([32]byte, error) {
 }
 func (*ClientVersionV1) Clone() clonable.Clonable { return &ClientVersionV1{} }
 
-type sszFixedBytes struct {
-	Bytes []byte
-	Size  int
-}
-
-func newSSZFixedBytes(size int, in []byte) *sszFixedBytes {
-	out := &sszFixedBytes{Bytes: make([]byte, size), Size: size}
-	copy(out.Bytes, in)
-	return out
-}
-func (b *sszFixedBytes) Static() bool { return true }
-func (b *sszFixedBytes) EncodingSizeSSZ() int {
-	if b.Size == 0 {
-		return len(b.Bytes)
-	}
-	return b.Size
-}
-func (b *sszFixedBytes) EncodeSSZ(dst []byte) ([]byte, error) {
-	size := b.EncodingSizeSSZ()
-	if len(b.Bytes) != size {
-		return nil, fmt.Errorf("fixed bytes length %d, want %d", len(b.Bytes), size)
-	}
-	return append(dst, b.Bytes...), nil
-}
-func (b *sszFixedBytes) DecodeSSZ(buf []byte, _ int) error {
-	size := b.EncodingSizeSSZ()
-	if len(buf) < size {
-		return errors.New("short fixed bytes")
-	}
-	b.Bytes = common.Copy(buf[:size])
-	return nil
-}
-func (b *sszFixedBytes) HashSSZ() ([32]byte, error) {
-	var h common.Hash
-	copy(h[:], b.Bytes)
-	return h, nil
-}
-func (b *sszFixedBytes) Clone() clonable.Clonable {
-	if b == nil {
-		return &sszFixedBytes{}
-	}
-	return &sszFixedBytes{Size: b.Size}
-}
-
-type sszKZGVector struct{ Bytes [sszKZGBytes]byte }
-
-func newSSZKZGVector(in []byte) *sszKZGVector {
-	var out sszKZGVector
-	copy(out.Bytes[:], in)
+func newKZGCommitment(in []byte) *cltypes.KZGCommitment {
+	var out cltypes.KZGCommitment
+	copy(out[:], in)
 	return &out
 }
-func (*sszKZGVector) Static() bool         { return true }
-func (*sszKZGVector) EncodingSizeSSZ() int { return sszKZGBytes }
-func (b *sszKZGVector) EncodeSSZ(dst []byte) ([]byte, error) {
-	return append(dst, b.Bytes[:]...), nil
-}
-func (b *sszKZGVector) DecodeSSZ(buf []byte, _ int) error {
-	if len(buf) < sszKZGBytes {
-		return errors.New("short kzg vector")
-	}
-	copy(b.Bytes[:], buf[:sszKZGBytes])
-	return nil
-}
-func (b *sszKZGVector) HashSSZ() ([32]byte, error) {
-	var h common.Hash
-	copy(h[:], b.Bytes[:])
-	return h, nil
-}
-func (*sszKZGVector) Clone() clonable.Clonable { return &sszKZGVector{} }
 
-type sszBlobVector struct{ Bytes [sszBlobBytes]byte }
-
-func newSSZBlobVector(in []byte) *sszBlobVector {
-	var out sszBlobVector
-	copy(out.Bytes[:], in)
+func newKZGProof(in []byte) *cltypes.KZGProof {
+	var out cltypes.KZGProof
+	copy(out[:], in)
 	return &out
 }
-func (*sszBlobVector) Static() bool         { return true }
-func (*sszBlobVector) EncodingSizeSSZ() int { return sszBlobBytes }
-func (b *sszBlobVector) EncodeSSZ(dst []byte) ([]byte, error) {
-	return append(dst, b.Bytes[:]...), nil
+
+func newBlob(in []byte) *cltypes.Blob {
+	var out cltypes.Blob
+	copy(out[:], in)
+	return &out
 }
-func (b *sszBlobVector) DecodeSSZ(buf []byte, _ int) error {
-	if len(buf) < sszBlobBytes {
-		return errors.New("short blob vector")
-	}
-	copy(b.Bytes[:], buf[:sszBlobBytes])
-	return nil
-}
-func (b *sszBlobVector) HashSSZ() ([32]byte, error) {
-	return common.Hash{}, nil
-}
-func (*sszBlobVector) Clone() clonable.Clonable { return &sszBlobVector{} }
 
 func NewBlobsBundleSSZ(version clparams.StateVersion) *BlobsBundle {
 	return &BlobsBundle{SSZVersion: version}
@@ -527,17 +429,17 @@ func (b *BlobsBundle) EncodeSSZ(dst []byte) ([]byte, error) {
 	if b.blobsBundleSSZVersion() >= clparams.FuluVersion {
 		proofsLimit = sszMaxCellProofs
 	}
-	commitments := solid.NewStaticListSSZ[*sszKZGVector](sszMaxBlobHashes, sszKZGBytes)
-	proofs := solid.NewStaticListSSZ[*sszKZGVector](proofsLimit, sszKZGBytes)
-	blobs := solid.NewStaticListSSZ[*sszBlobVector](sszMaxBlobHashes, sszBlobBytes)
+	commitments := solid.NewStaticListSSZ[*cltypes.KZGCommitment](sszMaxBlobHashes, sszKZGBytes)
+	proofs := solid.NewStaticListSSZ[*cltypes.KZGProof](proofsLimit, sszKZGBytes)
+	blobs := solid.NewStaticListSSZ[*cltypes.Blob](sszMaxBlobHashes, sszBlobBytes)
 	for _, commitment := range b.Commitments {
-		commitments.Append(newSSZKZGVector(commitment))
+		commitments.Append(newKZGCommitment(commitment))
 	}
 	for _, proof := range b.Proofs {
-		proofs.Append(newSSZKZGVector(proof))
+		proofs.Append(newKZGProof(proof))
 	}
 	for _, blob := range b.Blobs {
-		blobs.Append(newSSZBlobVector(blob))
+		blobs.Append(newBlob(blob))
 	}
 	return ssz2.MarshalSSZ(dst, commitments, proofs, blobs)
 }
@@ -548,15 +450,15 @@ func (b *BlobsBundle) DecodeSSZ(buf []byte, version int) error {
 	if b.SSZVersion >= clparams.FuluVersion {
 		proofsLimit = sszMaxCellProofs
 	}
-	commitments := solid.NewStaticListSSZ[*sszKZGVector](sszMaxBlobHashes, sszKZGBytes)
-	proofs := solid.NewStaticListSSZ[*sszKZGVector](proofsLimit, sszKZGBytes)
-	blobs := solid.NewStaticListSSZ[*sszBlobVector](sszMaxBlobHashes, sszBlobBytes)
+	commitments := solid.NewStaticListSSZ[*cltypes.KZGCommitment](sszMaxBlobHashes, sszKZGBytes)
+	proofs := solid.NewStaticListSSZ[*cltypes.KZGProof](proofsLimit, sszKZGBytes)
+	blobs := solid.NewStaticListSSZ[*cltypes.Blob](sszMaxBlobHashes, sszBlobBytes)
 	if err := ssz2.UnmarshalSSZ(buf, version, commitments, proofs, blobs); err != nil {
 		return err
 	}
-	b.Commitments = kzgVectorsBytes(commitments)
-	b.Proofs = kzgVectorsBytes(proofs)
-	b.Blobs = blobVectorsBytes(blobs)
+	b.Commitments = kzgCommitmentBytes(commitments)
+	b.Proofs = kzgProofBytes(proofs)
+	b.Blobs = blobBytes(blobs)
 	return nil
 }
 
@@ -572,19 +474,31 @@ func (b *BlobsBundle) blobsBundleSSZVersion() clparams.StateVersion {
 	return clparams.DenebVersion
 }
 
-func kzgVectorsBytes(list *solid.ListSSZ[*sszKZGVector]) []hexutil.Bytes {
+func kzgCommitmentBytes(list *solid.ListSSZ[*cltypes.KZGCommitment]) []hexutil.Bytes {
 	out := make([]hexutil.Bytes, 0, list.Len())
-	list.Range(func(_ int, v *sszKZGVector, _ int) bool {
-		out = append(out, common.Copy(v.Bytes[:]))
+	list.Range(func(_ int, v *cltypes.KZGCommitment, _ int) bool {
+		value := *v
+		out = append(out, common.Copy(value[:]))
 		return true
 	})
 	return out
 }
 
-func blobVectorsBytes(list *solid.ListSSZ[*sszBlobVector]) []hexutil.Bytes {
+func kzgProofBytes(list *solid.ListSSZ[*cltypes.KZGProof]) []hexutil.Bytes {
 	out := make([]hexutil.Bytes, 0, list.Len())
-	list.Range(func(_ int, v *sszBlobVector, _ int) bool {
-		out = append(out, common.Copy(v.Bytes[:]))
+	list.Range(func(_ int, v *cltypes.KZGProof, _ int) bool {
+		value := *v
+		out = append(out, common.Copy(value[:]))
+		return true
+	})
+	return out
+}
+
+func blobBytes(list *solid.ListSSZ[*cltypes.Blob]) []hexutil.Bytes {
+	out := make([]hexutil.Bytes, 0, list.Len())
+	list.Range(func(_ int, v *cltypes.Blob, _ int) bool {
+		value := *v
+		out = append(out, common.Copy(value[:]))
 		return true
 	})
 	return out
@@ -593,16 +507,16 @@ func blobVectorsBytes(list *solid.ListSSZ[*sszBlobVector]) []hexutil.Bytes {
 func (*BlobAndProofV1) Static() bool         { return true }
 func (*BlobAndProofV1) EncodingSizeSSZ() int { return sszBlobBytes + sszKZGBytes }
 func (b *BlobAndProofV1) EncodeSSZ(dst []byte) ([]byte, error) {
-	return ssz2.MarshalSSZ(dst, newSSZFixedBytes(sszBlobBytes, b.Blob), newSSZFixedBytes(sszKZGBytes, b.Proof))
+	return ssz2.MarshalSSZ(dst, newBlob(b.Blob), newKZGProof(b.Proof))
 }
 func (b *BlobAndProofV1) DecodeSSZ(buf []byte, version int) error {
-	blob := &sszFixedBytes{Size: sszBlobBytes}
-	proof := &sszFixedBytes{Size: sszKZGBytes}
+	blob := &cltypes.Blob{}
+	proof := &cltypes.KZGProof{}
 	if err := ssz2.UnmarshalSSZ(buf, version, blob, proof); err != nil {
 		return err
 	}
-	b.Blob = blob.Bytes
-	b.Proof = proof.Bytes
+	b.Blob = common.Copy(blob[:])
+	b.Proof = common.Copy(proof[:])
 	return nil
 }
 func (b *BlobAndProofV1) HashSSZ() ([32]byte, error) { return [32]byte{}, nil }
@@ -610,22 +524,60 @@ func (*BlobAndProofV1) Clone() clonable.Clonable     { return &BlobAndProofV1{} 
 
 func (*BlobAndProofV2) Static() bool { return false }
 func (b *BlobAndProofV2) EncodeSSZ(dst []byte) ([]byte, error) {
-	proofs := solid.NewStaticListSSZ[*sszKZGVector](sszCellsPerExtBlob, sszKZGBytes)
+	proofs := solid.NewStaticListSSZ[*cltypes.KZGProof](sszCellsPerExtBlob, sszKZGBytes)
 	for _, proof := range b.CellProofs {
-		proofs.Append(newSSZKZGVector(proof))
+		proofs.Append(newKZGProof(proof))
 	}
-	return ssz2.MarshalSSZ(dst, newSSZFixedBytes(sszBlobBytes, b.Blob), proofs)
+	return ssz2.MarshalSSZ(dst, newBlob(b.Blob), proofs)
 }
 func (b *BlobAndProofV2) DecodeSSZ(buf []byte, version int) error {
-	blob := &sszFixedBytes{Size: sszBlobBytes}
-	proofs := solid.NewStaticListSSZ[*sszKZGVector](sszCellsPerExtBlob, sszKZGBytes)
+	blob := &cltypes.Blob{}
+	proofs := solid.NewStaticListSSZ[*cltypes.KZGProof](sszCellsPerExtBlob, sszKZGBytes)
 	if err := ssz2.UnmarshalSSZ(buf, version, blob, proofs); err != nil {
 		return err
 	}
-	b.Blob = blob.Bytes
-	b.CellProofs = kzgVectorsBytes(proofs)
+	b.Blob = common.Copy(blob[:])
+	b.CellProofs = kzgProofBytes(proofs)
 	return nil
 }
 func (b *BlobAndProofV2) EncodingSizeSSZ() int       { out, _ := b.EncodeSSZ(nil); return len(out) }
 func (b *BlobAndProofV2) HashSSZ() ([32]byte, error) { return [32]byte{}, nil }
 func (*BlobAndProofV2) Clone() clonable.Clonable     { return &BlobAndProofV2{} }
+
+type NullableBlobAndProofV2 struct {
+	BlobAndProof *BlobAndProofV2
+}
+
+func NewNullableBlobAndProofV2(blob *BlobAndProofV2) *NullableBlobAndProofV2 {
+	return &NullableBlobAndProofV2{BlobAndProof: blob}
+}
+
+func (n *NullableBlobAndProofV2) Static() bool { return false }
+
+func (n *NullableBlobAndProofV2) EncodeSSZ(dst []byte) ([]byte, error) {
+	blobAndProof := solid.NewDynamicListSSZ[*BlobAndProofV2](1)
+	if n != nil && n.BlobAndProof != nil {
+		blobAndProof.Append(n.BlobAndProof)
+	}
+	return ssz2.MarshalSSZ(dst, blobAndProof)
+}
+
+func (n *NullableBlobAndProofV2) DecodeSSZ(buf []byte, version int) error {
+	blobAndProof := solid.NewDynamicListSSZ[*BlobAndProofV2](1)
+	if err := ssz2.UnmarshalSSZ(buf, version, blobAndProof); err != nil {
+		return err
+	}
+	n.BlobAndProof = nil
+	if blobAndProof.Len() != 0 {
+		n.BlobAndProof = blobAndProof.Get(0)
+	}
+	return nil
+}
+
+func (n *NullableBlobAndProofV2) EncodingSizeSSZ() int { out, _ := n.EncodeSSZ(nil); return len(out) }
+func (n *NullableBlobAndProofV2) HashSSZ() ([32]byte, error) {
+	return [32]byte{}, nil
+}
+func (*NullableBlobAndProofV2) Clone() clonable.Clonable {
+	return &NullableBlobAndProofV2{}
+}

--- a/execution/engineapi/engine_types/ssz.go
+++ b/execution/engineapi/engine_types/ssz.go
@@ -1,0 +1,631 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+
+package engine_types
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/holiman/uint256"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	ssz2 "github.com/erigontech/erigon/cl/ssz"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/clonable"
+	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/execution/types"
+)
+
+const (
+	sszMaxBlobHashes          = 4096
+	sszMaxGetBlobHashes       = 128
+	sszMaxBytesPerTransaction = 0x40000000
+	sszMaxValidationError     = 1024
+	sszBlobBytes              = 0x20000
+	sszKZGBytes               = 48
+	sszCellsPerExtBlob        = 128
+	sszMaxCellProofs          = 33554432
+)
+
+var mainnetBeaconCfg = &clparams.MainnetBeaconConfig
+
+func NewExecutionPayloadSSZ(version clparams.StateVersion) *ExecutionPayload {
+	return &ExecutionPayload{SSZVersion: version}
+}
+
+func (p *ExecutionPayload) Static() bool { return false }
+
+func (p *ExecutionPayload) EncodeSSZ(dst []byte) ([]byte, error) {
+	block, err := p.ToSSZBlock(p.sszVersion())
+	if err != nil {
+		return nil, err
+	}
+	return block.EncodeSSZ(dst)
+}
+
+func (p *ExecutionPayload) DecodeSSZ(buf []byte, version int) error {
+	p.SSZVersion = clparams.StateVersion(version)
+	block := cltypes.NewEth1Block(p.SSZVersion, mainnetBeaconCfg)
+	if err := block.DecodeSSZ(buf, version); err != nil {
+		return err
+	}
+	*p = *ExecutionPayloadFromSSZBlock(block, p.SSZVersion)
+	return nil
+}
+
+func (p *ExecutionPayload) EncodingSizeSSZ() int {
+	block, err := p.ToSSZBlock(p.sszVersion())
+	if err != nil {
+		return cltypes.NewEth1Block(p.sszVersion(), mainnetBeaconCfg).EncodingSizeSSZ()
+	}
+	return block.EncodingSizeSSZ()
+}
+
+func (p *ExecutionPayload) Clone() clonable.Clonable { return NewExecutionPayloadSSZ(p.sszVersion()) }
+
+func (p *ExecutionPayload) sszVersion() clparams.StateVersion {
+	if p != nil && p.SSZVersion != 0 {
+		return p.SSZVersion
+	}
+	return clparams.BellatrixVersion
+}
+
+func (p *ExecutionPayload) ToSSZBlock(version clparams.StateVersion) (*cltypes.Eth1Block, error) {
+	block := cltypes.NewEth1Block(version, mainnetBeaconCfg)
+	block.ParentHash = p.ParentHash
+	block.FeeRecipient = p.FeeRecipient
+	block.StateRoot = p.StateRoot
+	block.ReceiptsRoot = p.ReceiptsRoot
+	if len(p.LogsBloom) != 0 && len(p.LogsBloom) != len(block.LogsBloom) {
+		return nil, fmt.Errorf("invalid logsBloom length %d", len(p.LogsBloom))
+	}
+	if len(p.LogsBloom) != 0 {
+		copy(block.LogsBloom[:], p.LogsBloom)
+	}
+	block.PrevRandao = p.PrevRandao
+	block.BlockNumber = uint64(p.BlockNumber)
+	block.GasLimit = uint64(p.GasLimit)
+	block.GasUsed = uint64(p.GasUsed)
+	block.Time = uint64(p.Timestamp)
+	block.Extra = solid.NewExtraData()
+	block.Extra.SetBytes(p.ExtraData)
+	if p.BaseFeePerGas != nil {
+		baseFee := uint256.MustFromBig(p.BaseFeePerGas.ToInt())
+		baseFeeBytes := baseFee.Bytes32()
+		for i, j := 0, len(baseFeeBytes)-1; i < j; i, j = i+1, j-1 {
+			baseFeeBytes[i], baseFeeBytes[j] = baseFeeBytes[j], baseFeeBytes[i]
+		}
+		copy(block.BaseFeePerGas[:], baseFeeBytes[:])
+	}
+	block.BlockHash = p.BlockHash
+	txs := make([][]byte, len(p.Transactions))
+	for i, tx := range p.Transactions {
+		txs[i] = tx
+	}
+	block.Transactions = solid.NewTransactionsSSZFromTransactions(txs)
+	if version >= clparams.CapellaVersion {
+		block.Withdrawals = solid.NewStaticListSSZ[*cltypes.Withdrawal](int(mainnetBeaconCfg.MaxWithdrawalsPerPayload), 44)
+		for _, w := range p.Withdrawals {
+			block.Withdrawals.Append(&cltypes.Withdrawal{Index: w.Index, Validator: w.Validator, Address: w.Address, Amount: w.Amount})
+		}
+	}
+	if p.BlobGasUsed != nil {
+		block.BlobGasUsed = uint64(*p.BlobGasUsed)
+	}
+	if p.ExcessBlobGas != nil {
+		block.ExcessBlobGas = uint64(*p.ExcessBlobGas)
+	}
+	if version >= clparams.GloasVersion {
+		block.BlockAccessList = solid.NewByteListSSZ(sszMaxBytesPerTransaction)
+		if err := block.BlockAccessList.SetBytes(p.BlockAccessList); err != nil {
+			return nil, err
+		}
+		if p.SlotNumber != nil {
+			block.SlotNumber = uint64(*p.SlotNumber)
+		}
+	}
+	return block, nil
+}
+
+func ExecutionPayloadFromSSZBlock(block *cltypes.Eth1Block, version clparams.StateVersion) *ExecutionPayload {
+	baseFeeBytes := common.Copy(block.BaseFeePerGas[:])
+	for i, j := 0, len(baseFeeBytes)-1; i < j; i, j = i+1, j-1 {
+		baseFeeBytes[i], baseFeeBytes[j] = baseFeeBytes[j], baseFeeBytes[i]
+	}
+	baseFee := new(uint256.Int).SetBytes(baseFeeBytes)
+	body := block.Body()
+	p := &ExecutionPayload{
+		ParentHash:    block.ParentHash,
+		FeeRecipient:  block.FeeRecipient,
+		StateRoot:     block.StateRoot,
+		ReceiptsRoot:  block.ReceiptsRoot,
+		LogsBloom:     block.LogsBloom[:],
+		PrevRandao:    block.PrevRandao,
+		BlockNumber:   hexutil.Uint64(block.BlockNumber),
+		GasLimit:      hexutil.Uint64(block.GasLimit),
+		GasUsed:       hexutil.Uint64(block.GasUsed),
+		Timestamp:     hexutil.Uint64(block.Time),
+		ExtraData:     block.Extra.Bytes(),
+		BaseFeePerGas: (*hexutil.Big)(baseFee.ToBig()),
+		BlockHash:     block.BlockHash,
+		Withdrawals:   body.Withdrawals,
+		SSZVersion:    version,
+	}
+	for _, tx := range body.Transactions {
+		p.Transactions = append(p.Transactions, tx)
+	}
+	if version >= clparams.DenebVersion {
+		bg, ebg := hexutil.Uint64(block.BlobGasUsed), hexutil.Uint64(block.ExcessBlobGas)
+		p.BlobGasUsed, p.ExcessBlobGas = &bg, &ebg
+	}
+	if version >= clparams.GloasVersion {
+		if block.BlockAccessList != nil {
+			p.BlockAccessList = block.BlockAccessList.Bytes()
+		}
+		slot := hexutil.Uint64(block.SlotNumber)
+		p.SlotNumber = &slot
+	}
+	return p
+}
+
+type sszWithdrawalList struct {
+	List *solid.ListSSZ[*cltypes.Withdrawal]
+}
+
+func newSSZWithdrawalList(ws []*types.Withdrawal) *sszWithdrawalList {
+	l := solid.NewStaticListSSZ[*cltypes.Withdrawal](int(mainnetBeaconCfg.MaxWithdrawalsPerPayload), 44)
+	for _, w := range ws {
+		l.Append(&cltypes.Withdrawal{Index: w.Index, Validator: w.Validator, Address: w.Address, Amount: w.Amount})
+	}
+	return &sszWithdrawalList{List: l}
+}
+func (l *sszWithdrawalList) Static() bool { return false }
+func (l *sszWithdrawalList) EncodeSSZ(dst []byte) ([]byte, error) {
+	if l.List == nil {
+		l.List = solid.NewStaticListSSZ[*cltypes.Withdrawal](int(mainnetBeaconCfg.MaxWithdrawalsPerPayload), 44)
+	}
+	return l.List.EncodeSSZ(dst)
+}
+func (l *sszWithdrawalList) DecodeSSZ(buf []byte, version int) error {
+	l.List = solid.NewStaticListSSZ[*cltypes.Withdrawal](int(mainnetBeaconCfg.MaxWithdrawalsPerPayload), 44)
+	return l.List.DecodeSSZ(buf, version)
+}
+func (l *sszWithdrawalList) EncodingSizeSSZ() int {
+	if l.List == nil {
+		return 0
+	}
+	return l.List.EncodingSizeSSZ()
+}
+func (*sszWithdrawalList) Clone() clonable.Clonable { return &sszWithdrawalList{} }
+func (l *sszWithdrawalList) withdrawals() []*types.Withdrawal {
+	if l.List == nil {
+		return nil
+	}
+	out := make([]*types.Withdrawal, 0, l.List.Len())
+	l.List.Range(func(_ int, w *cltypes.Withdrawal, _ int) bool {
+		out = append(out, &types.Withdrawal{Index: w.Index, Validator: w.Validator, Address: w.Address, Amount: w.Amount})
+		return true
+	})
+	return out
+}
+
+func (s *PayloadStatus) Static() bool { return false }
+
+func (s *PayloadStatus) EncodeSSZ(dst []byte) ([]byte, error) {
+	status, err := payloadStatusByte(s.Status)
+	if err != nil {
+		return nil, err
+	}
+	var latest []common.Hash
+	if s.LatestValidHash != nil {
+		latest = []common.Hash{*s.LatestValidHash}
+	}
+	latestHashes := solid.NewHashList(1)
+	for _, hash := range latest {
+		latestHashes.Append(hash)
+	}
+	errBytes := solid.NewByteListSSZ(sszMaxValidationError)
+	if s.ValidationError != nil && s.ValidationError.Error() != nil {
+		msg := []byte(s.ValidationError.Error().Error())
+		if len(msg) > sszMaxValidationError {
+			msg = msg[:sszMaxValidationError]
+		}
+		_ = errBytes.SetBytes(msg)
+	}
+	return ssz2.MarshalSSZ(dst, []byte{status}, latestHashes, errBytes)
+}
+
+func (s *PayloadStatus) DecodeSSZ(buf []byte, version int) error {
+	latest := solid.NewHashList(1)
+	errBytes := solid.NewByteListSSZ(sszMaxValidationError)
+	status := []byte{0}
+	if err := ssz2.UnmarshalSSZ(buf, version, status, latest, errBytes); err != nil {
+		return err
+	}
+	engineStatus, err := payloadStatusFromByte(status[0])
+	if err != nil {
+		return err
+	}
+	s.Status = engineStatus
+	if latest.Length() > 0 {
+		hash := latest.Get(0)
+		s.LatestValidHash = &hash
+	}
+	if msg := string(errBytes.Bytes()); msg != "" {
+		s.ValidationError = NewStringifiedErrorFromString(msg)
+	}
+	return nil
+}
+
+func (s *PayloadStatus) EncodingSizeSSZ() int { out, _ := s.EncodeSSZ(nil); return len(out) }
+func (*PayloadStatus) Clone() clonable.Clonable {
+	return &PayloadStatus{}
+}
+
+func payloadStatusByte(status EngineStatus) (uint8, error) {
+	switch status {
+	case ValidStatus:
+		return 0, nil
+	case InvalidStatus:
+		return 1, nil
+	case SyncingStatus:
+		return 2, nil
+	case AcceptedStatus:
+		return 3, nil
+	default:
+		return 0, fmt.Errorf("unknown payload status %q", status)
+	}
+}
+
+func payloadStatusFromByte(status uint8) (EngineStatus, error) {
+	switch status {
+	case 0:
+		return ValidStatus, nil
+	case 1:
+		return InvalidStatus, nil
+	case 2:
+		return SyncingStatus, nil
+	case 3:
+		return AcceptedStatus, nil
+	default:
+		return "", fmt.Errorf("unknown payload status %d", status)
+	}
+}
+
+func (*ForkChoiceState) Static() bool         { return true }
+func (*ForkChoiceState) EncodingSizeSSZ() int { return 96 }
+func (s *ForkChoiceState) EncodeSSZ(dst []byte) ([]byte, error) {
+	return ssz2.MarshalSSZ(dst, s.HeadHash[:], s.SafeBlockHash[:], s.FinalizedBlockHash[:])
+}
+func (s *ForkChoiceState) DecodeSSZ(buf []byte, version int) error {
+	return ssz2.UnmarshalSSZ(buf, version, s.HeadHash[:], s.SafeBlockHash[:], s.FinalizedBlockHash[:])
+}
+func (*ForkChoiceState) Clone() clonable.Clonable { return &ForkChoiceState{} }
+
+func NewPayloadAttributesSSZ(version clparams.StateVersion) *PayloadAttributes {
+	return &PayloadAttributes{SSZVersion: version}
+}
+
+func (a *PayloadAttributes) Static() bool { return false }
+
+func (a *PayloadAttributes) EncodeSSZ(dst []byte) ([]byte, error) {
+	version := a.payloadAttributesSSZVersion()
+	withdrawals := newSSZWithdrawalList(a.Withdrawals)
+	var root common.Hash
+	if a.ParentBeaconBlockRoot != nil {
+		root = *a.ParentBeaconBlockRoot
+	}
+	var slot uint64
+	if a.SlotNumber != nil {
+		slot = uint64(*a.SlotNumber)
+	}
+	switch version {
+	case clparams.BellatrixVersion:
+		return ssz2.MarshalSSZ(dst, uint64(a.Timestamp), a.PrevRandao[:], a.SuggestedFeeRecipient[:])
+	case clparams.CapellaVersion:
+		return ssz2.MarshalSSZ(dst, uint64(a.Timestamp), a.PrevRandao[:], a.SuggestedFeeRecipient[:], withdrawals)
+	case clparams.DenebVersion:
+		return ssz2.MarshalSSZ(dst, uint64(a.Timestamp), a.PrevRandao[:], a.SuggestedFeeRecipient[:], withdrawals, root[:])
+	default:
+		return ssz2.MarshalSSZ(dst, uint64(a.Timestamp), a.PrevRandao[:], a.SuggestedFeeRecipient[:], withdrawals, root[:], slot)
+	}
+}
+
+func (a *PayloadAttributes) DecodeSSZ(buf []byte, version int) error {
+	a.SSZVersion = clparams.StateVersion(version)
+	withdrawals := &sszWithdrawalList{}
+	var timestamp uint64
+	var root common.Hash
+	var slot uint64
+	switch a.SSZVersion {
+	case clparams.BellatrixVersion:
+		if err := ssz2.UnmarshalSSZ(buf, version, &timestamp, a.PrevRandao[:], a.SuggestedFeeRecipient[:]); err != nil {
+			return err
+		}
+	case clparams.CapellaVersion:
+		if err := ssz2.UnmarshalSSZ(buf, version, &timestamp, a.PrevRandao[:], a.SuggestedFeeRecipient[:], withdrawals); err != nil {
+			return err
+		}
+		a.Withdrawals = withdrawals.withdrawals()
+	case clparams.DenebVersion:
+		if err := ssz2.UnmarshalSSZ(buf, version, &timestamp, a.PrevRandao[:], a.SuggestedFeeRecipient[:], withdrawals, root[:]); err != nil {
+			return err
+		}
+		a.Withdrawals = withdrawals.withdrawals()
+		a.ParentBeaconBlockRoot = &root
+	default:
+		if err := ssz2.UnmarshalSSZ(buf, version, &timestamp, a.PrevRandao[:], a.SuggestedFeeRecipient[:], withdrawals, root[:], &slot); err != nil {
+			return err
+		}
+		a.Withdrawals = withdrawals.withdrawals()
+		a.ParentBeaconBlockRoot = &root
+		slotNumber := hexutil.Uint64(slot)
+		a.SlotNumber = &slotNumber
+	}
+	a.Timestamp = hexutil.Uint64(timestamp)
+	return nil
+}
+
+func (a *PayloadAttributes) EncodingSizeSSZ() int { out, _ := a.EncodeSSZ(nil); return len(out) }
+func (a *PayloadAttributes) Clone() clonable.Clonable {
+	return NewPayloadAttributesSSZ(a.payloadAttributesSSZVersion())
+}
+func (a *PayloadAttributes) HashSSZ() ([32]byte, error) { return [32]byte{}, nil }
+
+func (a *PayloadAttributes) payloadAttributesSSZVersion() clparams.StateVersion {
+	if a != nil && a.SSZVersion != 0 {
+		return a.SSZVersion
+	}
+	return clparams.BellatrixVersion
+}
+
+func (v *ClientVersionV1) Static() bool { return false }
+
+func (v *ClientVersionV1) EncodeSSZ(dst []byte) ([]byte, error) {
+	code := solid.NewByteListSSZ(2)
+	name := solid.NewByteListSSZ(64)
+	version := solid.NewByteListSSZ(64)
+	_ = code.SetBytes([]byte(v.Code))
+	_ = name.SetBytes([]byte(v.Name))
+	_ = version.SetBytes([]byte(v.Version))
+	var commit [4]byte
+	ch := strings.TrimPrefix(v.Commit, "0x")
+	if b, err := hex.DecodeString(ch); err == nil && len(b) >= 4 {
+		copy(commit[:], b[:4])
+	}
+	return ssz2.MarshalSSZ(dst, code, name, version, commit[:])
+}
+
+func (v *ClientVersionV1) DecodeSSZ(buf []byte, version int) error {
+	code := solid.NewByteListSSZ(2)
+	name := solid.NewByteListSSZ(64)
+	ver := solid.NewByteListSSZ(64)
+	var commit [4]byte
+	if err := ssz2.UnmarshalSSZ(buf, version, code, name, ver, commit[:]); err != nil {
+		return err
+	}
+	v.Code = string(code.Bytes())
+	v.Name = string(name.Bytes())
+	v.Version = string(ver.Bytes())
+	v.Commit = "0x" + hex.EncodeToString(commit[:])
+	return nil
+}
+
+func (v *ClientVersionV1) EncodingSizeSSZ() int { out, _ := v.EncodeSSZ(nil); return len(out) }
+func (v *ClientVersionV1) HashSSZ() ([32]byte, error) {
+	return [32]byte{}, nil
+}
+func (*ClientVersionV1) Clone() clonable.Clonable { return &ClientVersionV1{} }
+
+type sszFixedBytes struct {
+	Bytes []byte
+	Size  int
+}
+
+func newSSZFixedBytes(size int, in []byte) *sszFixedBytes {
+	out := &sszFixedBytes{Bytes: make([]byte, size), Size: size}
+	copy(out.Bytes, in)
+	return out
+}
+func (b *sszFixedBytes) Static() bool { return true }
+func (b *sszFixedBytes) EncodingSizeSSZ() int {
+	if b.Size == 0 {
+		return len(b.Bytes)
+	}
+	return b.Size
+}
+func (b *sszFixedBytes) EncodeSSZ(dst []byte) ([]byte, error) {
+	size := b.EncodingSizeSSZ()
+	if len(b.Bytes) != size {
+		return nil, fmt.Errorf("fixed bytes length %d, want %d", len(b.Bytes), size)
+	}
+	return append(dst, b.Bytes...), nil
+}
+func (b *sszFixedBytes) DecodeSSZ(buf []byte, _ int) error {
+	size := b.EncodingSizeSSZ()
+	if len(buf) < size {
+		return errors.New("short fixed bytes")
+	}
+	b.Bytes = common.Copy(buf[:size])
+	return nil
+}
+func (b *sszFixedBytes) HashSSZ() ([32]byte, error) {
+	var h common.Hash
+	copy(h[:], b.Bytes)
+	return h, nil
+}
+func (b *sszFixedBytes) Clone() clonable.Clonable {
+	if b == nil {
+		return &sszFixedBytes{}
+	}
+	return &sszFixedBytes{Size: b.Size}
+}
+
+type sszKZGVector struct{ Bytes [sszKZGBytes]byte }
+
+func newSSZKZGVector(in []byte) *sszKZGVector {
+	var out sszKZGVector
+	copy(out.Bytes[:], in)
+	return &out
+}
+func (*sszKZGVector) Static() bool         { return true }
+func (*sszKZGVector) EncodingSizeSSZ() int { return sszKZGBytes }
+func (b *sszKZGVector) EncodeSSZ(dst []byte) ([]byte, error) {
+	return append(dst, b.Bytes[:]...), nil
+}
+func (b *sszKZGVector) DecodeSSZ(buf []byte, _ int) error {
+	if len(buf) < sszKZGBytes {
+		return errors.New("short kzg vector")
+	}
+	copy(b.Bytes[:], buf[:sszKZGBytes])
+	return nil
+}
+func (b *sszKZGVector) HashSSZ() ([32]byte, error) {
+	var h common.Hash
+	copy(h[:], b.Bytes[:])
+	return h, nil
+}
+func (*sszKZGVector) Clone() clonable.Clonable { return &sszKZGVector{} }
+
+type sszBlobVector struct{ Bytes [sszBlobBytes]byte }
+
+func newSSZBlobVector(in []byte) *sszBlobVector {
+	var out sszBlobVector
+	copy(out.Bytes[:], in)
+	return &out
+}
+func (*sszBlobVector) Static() bool         { return true }
+func (*sszBlobVector) EncodingSizeSSZ() int { return sszBlobBytes }
+func (b *sszBlobVector) EncodeSSZ(dst []byte) ([]byte, error) {
+	return append(dst, b.Bytes[:]...), nil
+}
+func (b *sszBlobVector) DecodeSSZ(buf []byte, _ int) error {
+	if len(buf) < sszBlobBytes {
+		return errors.New("short blob vector")
+	}
+	copy(b.Bytes[:], buf[:sszBlobBytes])
+	return nil
+}
+func (b *sszBlobVector) HashSSZ() ([32]byte, error) {
+	return common.Hash{}, nil
+}
+func (*sszBlobVector) Clone() clonable.Clonable { return &sszBlobVector{} }
+
+func NewBlobsBundleSSZ(version clparams.StateVersion) *BlobsBundle {
+	return &BlobsBundle{SSZVersion: version}
+}
+
+func (b *BlobsBundle) Static() bool { return false }
+
+func (b *BlobsBundle) EncodeSSZ(dst []byte) ([]byte, error) {
+	proofsLimit := sszMaxBlobHashes
+	if b.blobsBundleSSZVersion() >= clparams.FuluVersion {
+		proofsLimit = sszMaxCellProofs
+	}
+	commitments := solid.NewStaticListSSZ[*sszKZGVector](sszMaxBlobHashes, sszKZGBytes)
+	proofs := solid.NewStaticListSSZ[*sszKZGVector](proofsLimit, sszKZGBytes)
+	blobs := solid.NewStaticListSSZ[*sszBlobVector](sszMaxBlobHashes, sszBlobBytes)
+	for _, commitment := range b.Commitments {
+		commitments.Append(newSSZKZGVector(commitment))
+	}
+	for _, proof := range b.Proofs {
+		proofs.Append(newSSZKZGVector(proof))
+	}
+	for _, blob := range b.Blobs {
+		blobs.Append(newSSZBlobVector(blob))
+	}
+	return ssz2.MarshalSSZ(dst, commitments, proofs, blobs)
+}
+
+func (b *BlobsBundle) DecodeSSZ(buf []byte, version int) error {
+	b.SSZVersion = clparams.StateVersion(version)
+	proofsLimit := sszMaxBlobHashes
+	if b.SSZVersion >= clparams.FuluVersion {
+		proofsLimit = sszMaxCellProofs
+	}
+	commitments := solid.NewStaticListSSZ[*sszKZGVector](sszMaxBlobHashes, sszKZGBytes)
+	proofs := solid.NewStaticListSSZ[*sszKZGVector](proofsLimit, sszKZGBytes)
+	blobs := solid.NewStaticListSSZ[*sszBlobVector](sszMaxBlobHashes, sszBlobBytes)
+	if err := ssz2.UnmarshalSSZ(buf, version, commitments, proofs, blobs); err != nil {
+		return err
+	}
+	b.Commitments = kzgVectorsBytes(commitments)
+	b.Proofs = kzgVectorsBytes(proofs)
+	b.Blobs = blobVectorsBytes(blobs)
+	return nil
+}
+
+func (b *BlobsBundle) EncodingSizeSSZ() int { out, _ := b.EncodeSSZ(nil); return len(out) }
+func (b *BlobsBundle) Clone() clonable.Clonable {
+	return NewBlobsBundleSSZ(b.blobsBundleSSZVersion())
+}
+
+func (b *BlobsBundle) blobsBundleSSZVersion() clparams.StateVersion {
+	if b != nil && b.SSZVersion != 0 {
+		return b.SSZVersion
+	}
+	return clparams.DenebVersion
+}
+
+func kzgVectorsBytes(list *solid.ListSSZ[*sszKZGVector]) []hexutil.Bytes {
+	out := make([]hexutil.Bytes, 0, list.Len())
+	list.Range(func(_ int, v *sszKZGVector, _ int) bool {
+		out = append(out, common.Copy(v.Bytes[:]))
+		return true
+	})
+	return out
+}
+
+func blobVectorsBytes(list *solid.ListSSZ[*sszBlobVector]) []hexutil.Bytes {
+	out := make([]hexutil.Bytes, 0, list.Len())
+	list.Range(func(_ int, v *sszBlobVector, _ int) bool {
+		out = append(out, common.Copy(v.Bytes[:]))
+		return true
+	})
+	return out
+}
+
+func (*BlobAndProofV1) Static() bool         { return true }
+func (*BlobAndProofV1) EncodingSizeSSZ() int { return sszBlobBytes + sszKZGBytes }
+func (b *BlobAndProofV1) EncodeSSZ(dst []byte) ([]byte, error) {
+	return ssz2.MarshalSSZ(dst, newSSZFixedBytes(sszBlobBytes, b.Blob), newSSZFixedBytes(sszKZGBytes, b.Proof))
+}
+func (b *BlobAndProofV1) DecodeSSZ(buf []byte, version int) error {
+	blob := &sszFixedBytes{Size: sszBlobBytes}
+	proof := &sszFixedBytes{Size: sszKZGBytes}
+	if err := ssz2.UnmarshalSSZ(buf, version, blob, proof); err != nil {
+		return err
+	}
+	b.Blob = blob.Bytes
+	b.Proof = proof.Bytes
+	return nil
+}
+func (b *BlobAndProofV1) HashSSZ() ([32]byte, error) { return [32]byte{}, nil }
+func (*BlobAndProofV1) Clone() clonable.Clonable     { return &BlobAndProofV1{} }
+
+func (*BlobAndProofV2) Static() bool { return false }
+func (b *BlobAndProofV2) EncodeSSZ(dst []byte) ([]byte, error) {
+	proofs := solid.NewStaticListSSZ[*sszKZGVector](sszCellsPerExtBlob, sszKZGBytes)
+	for _, proof := range b.CellProofs {
+		proofs.Append(newSSZKZGVector(proof))
+	}
+	return ssz2.MarshalSSZ(dst, newSSZFixedBytes(sszBlobBytes, b.Blob), proofs)
+}
+func (b *BlobAndProofV2) DecodeSSZ(buf []byte, version int) error {
+	blob := &sszFixedBytes{Size: sszBlobBytes}
+	proofs := solid.NewStaticListSSZ[*sszKZGVector](sszCellsPerExtBlob, sszKZGBytes)
+	if err := ssz2.UnmarshalSSZ(buf, version, blob, proofs); err != nil {
+		return err
+	}
+	b.Blob = blob.Bytes
+	b.CellProofs = kzgVectorsBytes(proofs)
+	return nil
+}
+func (b *BlobAndProofV2) EncodingSizeSSZ() int       { out, _ := b.EncodeSSZ(nil); return len(out) }
+func (b *BlobAndProofV2) HashSSZ() ([32]byte, error) { return [32]byte{}, nil }
+func (*BlobAndProofV2) Clone() clonable.Clonable     { return &BlobAndProofV2{} }

--- a/execution/engineapi/sszrest_handler.go
+++ b/execution/engineapi/sszrest_handler.go
@@ -128,6 +128,11 @@ func writeSSZ(w http.ResponseWriter, obj interface {
 	_, _ = w.Write(out)
 }
 
+func writeSSZBytes(w http.ResponseWriter, out []byte) {
+	w.Header().Set("Content-Type", sszRestContentType)
+	_, _ = w.Write(out)
+}
+
 func writeSSZError(w http.ResponseWriter, code int, msg string) {
 	http.Error(w, msg, code)
 }
@@ -167,12 +172,11 @@ func (e *EngineServer) handleSSZNewPayload(w http.ResponseWriter, r *http.Reques
 		writeSSZError(w, http.StatusRequestEntityTooLarge, err.Error())
 		return
 	}
-	req := newSSZNewPayloadRequest(sv)
-	if err := req.DecodeSSZ(body, int(sv)); err != nil {
+	payload, blobHashes, parentRoot, executionRequests, err := decodeNewPayloadRequest(body, sv)
+	if err != nil {
 		writeSSZError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	payload := req.Payload
 	var status *engine_types.PayloadStatus
 	switch version {
 	case 1:
@@ -180,14 +184,11 @@ func (e *EngineServer) handleSSZNewPayload(w http.ResponseWriter, r *http.Reques
 	case 2:
 		status, err = e.NewPayloadV2(r.Context(), payload)
 	case 3:
-		root := req.ParentBeaconBlockRoot
-		status, err = e.NewPayloadV3(r.Context(), payload, hashListValues(req.ExpectedBlobHashes), &root)
+		status, err = e.NewPayloadV3(r.Context(), payload, hashListValues(blobHashes), &parentRoot)
 	case 4:
-		root := req.ParentBeaconBlockRoot
-		status, err = e.NewPayloadV4(r.Context(), payload, hashListValues(req.ExpectedBlobHashes), &root, transactionsBytes(req.ExecutionRequests))
+		status, err = e.NewPayloadV4(r.Context(), payload, hashListValues(blobHashes), &parentRoot, transactionsBytes(executionRequests))
 	case 5:
-		root := req.ParentBeaconBlockRoot
-		status, err = e.NewPayloadV5(r.Context(), payload, hashListValues(req.ExpectedBlobHashes), &root, transactionsBytes(req.ExecutionRequests))
+		status, err = e.NewPayloadV5(r.Context(), payload, hashListValues(blobHashes), &parentRoot, transactionsBytes(executionRequests))
 	}
 	if err != nil {
 		writeEngineError(w, err)
@@ -224,13 +225,13 @@ func (e *EngineServer) handleSSZGetPayload(w http.ResponseWriter, r *http.Reques
 			return
 		}
 		sv, _ := sszGetPayloadVersion(version)
-		out, err := newSSZGetPayloadResponse(resp, sv)
+		out, err := encodeGetPayloadResponse(resp, sv)
 		if err != nil {
 			writeSSZError(w, http.StatusInternalServerError, err.Error())
 			return
 		}
 		e.logger.Info("[SSZ-REST] handled get payload", "path", r.URL.Path)
-		writeSSZ(w, out)
+		writeSSZBytes(w, out)
 	}
 }
 
@@ -274,33 +275,33 @@ func (e *EngineServer) handleSSZForkchoice(w http.ResponseWriter, r *http.Reques
 		writeSSZError(w, http.StatusRequestEntityTooLarge, err.Error())
 		return
 	}
-	req := newSSZRESTMessage(sszMessageForkchoiceRequest, sv)
-	if err := req.DecodeSSZ(body, int(sv)); err != nil {
+	state, attrs, err := decodeForkchoiceRequest(body, sv)
+	if err != nil {
 		writeSSZError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	var resp *engine_types.ForkChoiceUpdatedResponse
 	switch version {
 	case 1:
-		resp, err = e.ForkchoiceUpdatedV1(r.Context(), &req.State, req.payloadAttributes())
+		resp, err = e.ForkchoiceUpdatedV1(r.Context(), &state, attrs)
 	case 2:
-		resp, err = e.ForkchoiceUpdatedV2(r.Context(), &req.State, req.payloadAttributes())
+		resp, err = e.ForkchoiceUpdatedV2(r.Context(), &state, attrs)
 	case 3:
-		resp, err = e.ForkchoiceUpdatedV3(r.Context(), &req.State, req.payloadAttributes())
+		resp, err = e.ForkchoiceUpdatedV3(r.Context(), &state, attrs)
 	case 4:
-		resp, err = e.ForkchoiceUpdatedV4(r.Context(), &req.State, req.payloadAttributes())
+		resp, err = e.ForkchoiceUpdatedV4(r.Context(), &state, attrs)
 	}
 	if err != nil {
 		writeEngineError(w, err)
 		return
 	}
-	out, err := forkchoiceResponseToSSZ(resp)
+	out, err := encodeForkchoiceResponse(resp)
 	if err != nil {
 		writeSSZError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 	e.logger.Info("[SSZ-REST] handled forkchoice", "path", r.URL.Path)
-	writeSSZ(w, out)
+	writeSSZBytes(w, out)
 }
 
 func (e *EngineServer) handleSSZGetBlobs(w http.ResponseWriter, r *http.Request, version int) {
@@ -330,7 +331,12 @@ func (e *EngineServer) handleSSZGetBlobs(w http.ResponseWriter, r *http.Request,
 			return
 		}
 		e.logger.Info("[SSZ-REST] handled get blobs", "path", r.URL.Path)
-		writeSSZ(w, newSSZGetBlobsV1Response(resp))
+		out, err := encodeGetBlobsV1Response(resp)
+		if err != nil {
+			writeSSZError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeSSZBytes(w, out)
 		return
 	case 2:
 		resp, err := e.GetBlobsV2(r.Context(), hashListValues(hashes))
@@ -339,7 +345,12 @@ func (e *EngineServer) handleSSZGetBlobs(w http.ResponseWriter, r *http.Request,
 			return
 		}
 		e.logger.Info("[SSZ-REST] handled get blobs", "path", r.URL.Path)
-		writeSSZ(w, newSSZGetBlobsV2Response(resp))
+		out, err := encodeGetBlobsV2Response(resp)
+		if err != nil {
+			writeSSZError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeSSZBytes(w, out)
 		return
 	case 3:
 		resp, err := e.GetBlobsV3(r.Context(), hashListValues(hashes))
@@ -348,7 +359,12 @@ func (e *EngineServer) handleSSZGetBlobs(w http.ResponseWriter, r *http.Request,
 			return
 		}
 		e.logger.Info("[SSZ-REST] handled get blobs", "path", r.URL.Path)
-		writeSSZ(w, newSSZGetBlobsV3Response(resp))
+		out, err := encodeGetBlobsV3Response(resp)
+		if err != nil {
+			writeSSZError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeSSZBytes(w, out)
 		return
 	}
 }
@@ -359,18 +375,23 @@ func (e *EngineServer) handleSSZClientVersion(w http.ResponseWriter, r *http.Req
 		writeSSZError(w, http.StatusRequestEntityTooLarge, err.Error())
 		return
 	}
-	req := newSSZRESTMessage(sszMessageClientVersionRequest, 0)
-	if err := req.DecodeSSZ(body, 0); err != nil {
+	clientVersion, err := decodeClientVersionRequest(body)
+	if err != nil {
 		writeSSZError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	resp, err := e.GetClientVersionV1(r.Context(), req.ClientVersion)
+	resp, err := e.GetClientVersionV1(r.Context(), clientVersion)
 	if err != nil {
 		writeEngineError(w, err)
 		return
 	}
 	e.logger.Info("[SSZ-REST] handled client version", "path", r.URL.Path)
-	writeSSZ(w, newSSZClientVersionResponse(resp))
+	out, err := encodeClientVersionResponse(resp)
+	if err != nil {
+		writeSSZError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeSSZBytes(w, out)
 }
 
 func ptr[T any](v T) *T { return &v }
@@ -381,14 +402,19 @@ func (e *EngineServer) handleSSZCapabilities(w http.ResponseWriter, r *http.Requ
 		writeSSZError(w, http.StatusRequestEntityTooLarge, err.Error())
 		return
 	}
-	req := newSSZRESTMessage(sszMessageCapabilities, 0)
-	if err := req.DecodeSSZ(body, 0); err != nil {
+	capabilities, err := decodeCapabilities(body, 0)
+	if err != nil {
 		writeSSZError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	resp := e.ExchangeCapabilities(req.capabilityNames())
+	resp := e.ExchangeCapabilities(capabilities)
 	e.logger.Info("[SSZ-REST] handled capabilities", "path", r.URL.Path)
-	writeSSZ(w, newSSZCapabilities(resp))
+	out, err := encodeCapabilities(resp)
+	if err != nil {
+		writeSSZError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeSSZBytes(w, out)
 }
 
 func hashesToCommon(in []common.Hash) []common.Hash { return in }

--- a/execution/engineapi/sszrest_handler.go
+++ b/execution/engineapi/sszrest_handler.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/execution/engineapi/engine_helpers"
@@ -171,7 +172,7 @@ func (e *EngineServer) handleSSZNewPayload(w http.ResponseWriter, r *http.Reques
 		writeSSZError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	payload := sszToExecutionPayload(req.Payload)
+	payload := req.Payload
 	var status *engine_types.PayloadStatus
 	switch version {
 	case 1:
@@ -180,25 +181,20 @@ func (e *EngineServer) handleSSZNewPayload(w http.ResponseWriter, r *http.Reques
 		status, err = e.NewPayloadV2(r.Context(), payload)
 	case 3:
 		root := req.ParentBeaconBlockRoot
-		status, err = e.NewPayloadV3(r.Context(), payload, req.ExpectedBlobHashes.hashes(), &root)
+		status, err = e.NewPayloadV3(r.Context(), payload, hashListValues(req.ExpectedBlobHashes), &root)
 	case 4:
 		root := req.ParentBeaconBlockRoot
-		status, err = e.NewPayloadV4(r.Context(), payload, req.ExpectedBlobHashes.hashes(), &root, req.ExecutionRequests.bytes())
+		status, err = e.NewPayloadV4(r.Context(), payload, hashListValues(req.ExpectedBlobHashes), &root, req.ExecutionRequests.bytes())
 	case 5:
 		root := req.ParentBeaconBlockRoot
-		status, err = e.NewPayloadV5(r.Context(), payload, req.ExpectedBlobHashes.hashes(), &root, req.ExecutionRequests.bytes())
+		status, err = e.NewPayloadV5(r.Context(), payload, hashListValues(req.ExpectedBlobHashes), &root, req.ExecutionRequests.bytes())
 	}
 	if err != nil {
 		writeEngineError(w, err)
 		return
 	}
-	sszStatus, err := payloadStatusToSSZ(status)
-	if err != nil {
-		writeSSZError(w, http.StatusInternalServerError, err.Error())
-		return
-	}
 	e.logger.Info("[SSZ-REST] handled new payload", "path", r.URL.Path)
-	writeSSZ(w, sszStatus)
+	writeSSZ(w, status)
 }
 
 func (e *EngineServer) handleSSZGetPayload(w http.ResponseWriter, r *http.Request, version int, payloadID string) {
@@ -218,13 +214,9 @@ func (e *EngineServer) handleSSZGetPayload(w http.ResponseWriter, r *http.Reques
 			writeEngineError(w, err)
 			return
 		}
-		p, err := executionPayloadToSSZ(resp, clparams.BellatrixVersion)
-		if err != nil {
-			writeSSZError(w, http.StatusInternalServerError, err.Error())
-			return
-		}
+		resp.SSZVersion = clparams.BellatrixVersion
 		e.logger.Info("[SSZ-REST] handled get payload", "path", r.URL.Path)
-		writeSSZ(w, p)
+		writeSSZ(w, resp)
 	default:
 		resp, err := callGetPayload(r.Context(), e, version, id)
 		if err != nil {
@@ -290,13 +282,13 @@ func (e *EngineServer) handleSSZForkchoice(w http.ResponseWriter, r *http.Reques
 	var resp *engine_types.ForkChoiceUpdatedResponse
 	switch version {
 	case 1:
-		resp, err = e.ForkchoiceUpdatedV1(r.Context(), req.State.engine(), req.payloadAttributes())
+		resp, err = e.ForkchoiceUpdatedV1(r.Context(), &req.State, req.payloadAttributes())
 	case 2:
-		resp, err = e.ForkchoiceUpdatedV2(r.Context(), req.State.engine(), req.payloadAttributes())
+		resp, err = e.ForkchoiceUpdatedV2(r.Context(), &req.State, req.payloadAttributes())
 	case 3:
-		resp, err = e.ForkchoiceUpdatedV3(r.Context(), req.State.engine(), req.payloadAttributes())
+		resp, err = e.ForkchoiceUpdatedV3(r.Context(), &req.State, req.payloadAttributes())
 	case 4:
-		resp, err = e.ForkchoiceUpdatedV4(r.Context(), req.State.engine(), req.payloadAttributes())
+		resp, err = e.ForkchoiceUpdatedV4(r.Context(), &req.State, req.payloadAttributes())
 	}
 	if err != nil {
 		writeEngineError(w, err)
@@ -321,18 +313,18 @@ func (e *EngineServer) handleSSZGetBlobs(w http.ResponseWriter, r *http.Request,
 		writeSSZError(w, http.StatusRequestEntityTooLarge, err.Error())
 		return
 	}
-	hashes := &sszHashList{Limit: sszMaxGetBlobHashes}
+	hashes := solid.NewHashList(sszMaxGetBlobHashes)
 	if err := hashes.DecodeSSZ(body, 0); err != nil {
 		writeSSZError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if len(hashes.hashes()) > sszMaxGetBlobHashes {
+	if hashes.Length() > sszMaxGetBlobHashes {
 		writeSSZError(w, http.StatusRequestEntityTooLarge, "too many blob hashes")
 		return
 	}
 	switch version {
 	case 1:
-		resp, err := e.GetBlobsV1(r.Context(), hashes.hashes())
+		resp, err := e.GetBlobsV1(r.Context(), hashListValues(hashes))
 		if err != nil {
 			writeEngineError(w, err)
 			return
@@ -341,7 +333,7 @@ func (e *EngineServer) handleSSZGetBlobs(w http.ResponseWriter, r *http.Request,
 		writeSSZ(w, newSSZGetBlobsV1Response(resp))
 		return
 	case 2:
-		resp, err := e.GetBlobsV2(r.Context(), hashes.hashes())
+		resp, err := e.GetBlobsV2(r.Context(), hashListValues(hashes))
 		if err != nil {
 			writeEngineError(w, err)
 			return
@@ -350,7 +342,7 @@ func (e *EngineServer) handleSSZGetBlobs(w http.ResponseWriter, r *http.Request,
 		writeSSZ(w, newSSZGetBlobsV2Response(resp))
 		return
 	case 3:
-		resp, err := e.GetBlobsV3(r.Context(), hashes.hashes())
+		resp, err := e.GetBlobsV3(r.Context(), hashListValues(hashes))
 		if err != nil {
 			writeEngineError(w, err)
 			return
@@ -372,7 +364,7 @@ func (e *EngineServer) handleSSZClientVersion(w http.ResponseWriter, r *http.Req
 		writeSSZError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	resp, err := e.GetClientVersionV1(r.Context(), ptr(req.ClientVersion.engine()))
+	resp, err := e.GetClientVersionV1(r.Context(), req.ClientVersion)
 	if err != nil {
 		writeEngineError(w, err)
 		return

--- a/execution/engineapi/sszrest_handler.go
+++ b/execution/engineapi/sszrest_handler.go
@@ -1,0 +1,402 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+
+package engineapi
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/execution/engineapi/engine_helpers"
+	"github.com/erigontech/erigon/execution/engineapi/engine_types"
+	"github.com/erigontech/erigon/rpc"
+)
+
+const sszRestContentType = "application/octet-stream"
+
+func (e *EngineServer) SSZRESTHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		e.handleSSZREST(w, r)
+	})
+}
+
+func (e *EngineServer) handleSSZREST(w http.ResponseWriter, r *http.Request) {
+	path := strings.Trim(r.URL.Path, "/")
+	parts := strings.Split(path, "/")
+	if len(parts) < 3 || parts[0] != "engine" || !strings.HasPrefix(parts[1], "v") {
+		http.NotFound(w, nil)
+		return
+	}
+	version, err := strconv.Atoi(strings.TrimPrefix(parts[1], "v"))
+	if err != nil {
+		writeSSZError(w, http.StatusNotFound, "invalid engine version")
+		return
+	}
+
+	switch {
+	case r.Method == http.MethodPost && len(parts) == 3 && parts[2] == "payloads":
+		e.handleSSZNewPayload(w, r, version)
+	case r.Method == http.MethodGet && len(parts) == 4 && parts[2] == "payloads":
+		e.handleSSZGetPayload(w, r, version, parts[3])
+	case r.Method == http.MethodPost && len(parts) == 3 && parts[2] == "forkchoice":
+		e.handleSSZForkchoice(w, r, version)
+	case r.Method == http.MethodPost && len(parts) == 3 && parts[2] == "blobs":
+		e.handleSSZGetBlobs(w, r, version)
+	case r.Method == http.MethodPost && len(parts) == 4 && parts[2] == "client" && parts[3] == "version" && version == 1:
+		e.handleSSZClientVersion(w, r)
+	case r.Method == http.MethodPost && len(parts) == 3 && parts[2] == "capabilities" && version == 1:
+		e.handleSSZCapabilities(w, r)
+	default:
+		writeSSZError(w, http.StatusNotFound, "unknown SSZ-REST Engine API endpoint")
+	}
+}
+
+func sszNewPayloadVersion(version int) (clparams.StateVersion, bool) {
+	switch version {
+	case 1:
+		return clparams.BellatrixVersion, true
+	case 2:
+		return clparams.CapellaVersion, true
+	case 3:
+		return clparams.DenebVersion, true
+	case 4:
+		return clparams.ElectraVersion, true
+	case 5:
+		return clparams.GloasVersion, true
+	default:
+		return 0, false
+	}
+}
+
+func sszGetPayloadVersion(version int) (clparams.StateVersion, bool) {
+	switch version {
+	case 1:
+		return clparams.BellatrixVersion, true
+	case 2:
+		return clparams.CapellaVersion, true
+	case 3:
+		return clparams.DenebVersion, true
+	case 4:
+		return clparams.ElectraVersion, true
+	case 5:
+		return clparams.FuluVersion, true
+	case 6:
+		return clparams.GloasVersion, true
+	default:
+		return 0, false
+	}
+}
+
+func sszForkchoiceVersion(version int) (clparams.StateVersion, bool) {
+	switch version {
+	case 1:
+		return clparams.BellatrixVersion, true
+	case 2:
+		return clparams.CapellaVersion, true
+	case 3:
+		return clparams.DenebVersion, true
+	case 4:
+		return clparams.GloasVersion, true
+	default:
+		return 0, false
+	}
+}
+
+func readSSZBody(r *http.Request) ([]byte, error) {
+	defer r.Body.Close()
+	return io.ReadAll(http.MaxBytesReader(nil, r.Body, 128<<20))
+}
+
+func writeSSZ(w http.ResponseWriter, obj interface {
+	EncodeSSZ([]byte) ([]byte, error)
+}) {
+	out, err := obj.EncodeSSZ(nil)
+	if err != nil {
+		writeSSZError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.Header().Set("Content-Type", sszRestContentType)
+	_, _ = w.Write(out)
+}
+
+func writeSSZError(w http.ResponseWriter, code int, msg string) {
+	http.Error(w, msg, code)
+}
+
+func writeEngineError(w http.ResponseWriter, err error) {
+	if err == nil {
+		return
+	}
+	var rpcErr rpc.Error
+	if errors.As(err, &rpcErr) {
+		switch rpcErr.ErrorCode() {
+		case engine_helpers.UnknownPayloadErr.Code:
+			writeSSZError(w, http.StatusNotFound, err.Error())
+			return
+		case engine_helpers.InvalidForkchoiceStateErr.Code:
+			writeSSZError(w, http.StatusConflict, err.Error())
+			return
+		case engine_helpers.InvalidPayloadAttributesErr.Code:
+			writeSSZError(w, http.StatusUnprocessableEntity, err.Error())
+			return
+		case engine_helpers.TooLargeRequestErr.Code:
+			writeSSZError(w, http.StatusRequestEntityTooLarge, err.Error())
+			return
+		}
+	}
+	writeSSZError(w, http.StatusInternalServerError, err.Error())
+}
+
+func (e *EngineServer) handleSSZNewPayload(w http.ResponseWriter, r *http.Request, version int) {
+	if version < 1 || version > 5 {
+		writeSSZError(w, http.StatusNotFound, "unsupported new payload version")
+		return
+	}
+	sv, _ := sszNewPayloadVersion(version)
+	body, err := readSSZBody(r)
+	if err != nil {
+		writeSSZError(w, http.StatusRequestEntityTooLarge, err.Error())
+		return
+	}
+	req := newSSZNewPayloadRequest(sv)
+	if err := req.DecodeSSZ(body, int(sv)); err != nil {
+		writeSSZError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	payload := sszToExecutionPayload(req.Payload)
+	var status *engine_types.PayloadStatus
+	switch version {
+	case 1:
+		status, err = e.NewPayloadV1(r.Context(), payload)
+	case 2:
+		status, err = e.NewPayloadV2(r.Context(), payload)
+	case 3:
+		root := req.ParentBeaconBlockRoot
+		status, err = e.NewPayloadV3(r.Context(), payload, req.ExpectedBlobHashes.hashes(), &root)
+	case 4:
+		root := req.ParentBeaconBlockRoot
+		status, err = e.NewPayloadV4(r.Context(), payload, req.ExpectedBlobHashes.hashes(), &root, req.ExecutionRequests.bytes())
+	case 5:
+		root := req.ParentBeaconBlockRoot
+		status, err = e.NewPayloadV5(r.Context(), payload, req.ExpectedBlobHashes.hashes(), &root, req.ExecutionRequests.bytes())
+	}
+	if err != nil {
+		writeEngineError(w, err)
+		return
+	}
+	sszStatus, err := payloadStatusToSSZ(status)
+	if err != nil {
+		writeSSZError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	e.logger.Info("[SSZ-REST] handled new payload", "path", r.URL.Path)
+	writeSSZ(w, sszStatus)
+}
+
+func (e *EngineServer) handleSSZGetPayload(w http.ResponseWriter, r *http.Request, version int, payloadID string) {
+	if version < 1 || version > 6 {
+		writeSSZError(w, http.StatusNotFound, "unsupported get payload version")
+		return
+	}
+	id, err := parsePayloadIDPath(payloadID)
+	if err != nil {
+		writeSSZError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	switch version {
+	case 1:
+		resp, err := e.GetPayloadV1(r.Context(), id)
+		if err != nil {
+			writeEngineError(w, err)
+			return
+		}
+		p, err := executionPayloadToSSZ(resp, clparams.BellatrixVersion)
+		if err != nil {
+			writeSSZError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		e.logger.Info("[SSZ-REST] handled get payload", "path", r.URL.Path)
+		writeSSZ(w, p)
+	default:
+		resp, err := callGetPayload(r.Context(), e, version, id)
+		if err != nil {
+			writeEngineError(w, err)
+			return
+		}
+		sv, _ := sszGetPayloadVersion(version)
+		out, err := newSSZGetPayloadResponse(resp, sv)
+		if err != nil {
+			writeSSZError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		e.logger.Info("[SSZ-REST] handled get payload", "path", r.URL.Path)
+		writeSSZ(w, out)
+	}
+}
+
+func callGetPayload(ctx context.Context, e *EngineServer, version int, id hexutil.Bytes) (*engine_types.GetPayloadResponse, error) {
+	switch version {
+	case 2:
+		return e.GetPayloadV2(ctx, id)
+	case 3:
+		return e.GetPayloadV3(ctx, id)
+	case 4:
+		return e.GetPayloadV4(ctx, id)
+	case 5:
+		return e.GetPayloadV5(ctx, id)
+	case 6:
+		return e.GetPayloadV6(ctx, id)
+	default:
+		return nil, &rpc.UnsupportedForkError{Message: "unsupported get payload version"}
+	}
+}
+
+func parsePayloadIDPath(s string) (hexutil.Bytes, error) {
+	s = strings.TrimPrefix(s, "0x")
+	if len(s) != 16 {
+		return nil, errors.New("invalid payload ID length")
+	}
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		return nil, err
+	}
+	return hexutil.Bytes(b), nil
+}
+
+func (e *EngineServer) handleSSZForkchoice(w http.ResponseWriter, r *http.Request, version int) {
+	if version < 1 || version > 4 {
+		writeSSZError(w, http.StatusNotFound, "unsupported forkchoice version")
+		return
+	}
+	sv, _ := sszForkchoiceVersion(version)
+	body, err := readSSZBody(r)
+	if err != nil {
+		writeSSZError(w, http.StatusRequestEntityTooLarge, err.Error())
+		return
+	}
+	req := &sszForkchoiceRequest{version: sv}
+	if err := req.DecodeSSZ(body, int(sv)); err != nil {
+		writeSSZError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	var resp *engine_types.ForkChoiceUpdatedResponse
+	switch version {
+	case 1:
+		resp, err = e.ForkchoiceUpdatedV1(r.Context(), req.State.engine(), req.payloadAttributes())
+	case 2:
+		resp, err = e.ForkchoiceUpdatedV2(r.Context(), req.State.engine(), req.payloadAttributes())
+	case 3:
+		resp, err = e.ForkchoiceUpdatedV3(r.Context(), req.State.engine(), req.payloadAttributes())
+	case 4:
+		resp, err = e.ForkchoiceUpdatedV4(r.Context(), req.State.engine(), req.payloadAttributes())
+	}
+	if err != nil {
+		writeEngineError(w, err)
+		return
+	}
+	out, err := forkchoiceResponseToSSZ(resp)
+	if err != nil {
+		writeSSZError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	e.logger.Info("[SSZ-REST] handled forkchoice", "path", r.URL.Path)
+	writeSSZ(w, out)
+}
+
+func (e *EngineServer) handleSSZGetBlobs(w http.ResponseWriter, r *http.Request, version int) {
+	if version < 1 || version > 3 {
+		writeSSZError(w, http.StatusNotFound, "unsupported get blobs version")
+		return
+	}
+	body, err := readSSZBody(r)
+	if err != nil {
+		writeSSZError(w, http.StatusRequestEntityTooLarge, err.Error())
+		return
+	}
+	hashes := &sszHashList{Limit: sszMaxGetBlobHashes}
+	if err := hashes.DecodeSSZ(body, 0); err != nil {
+		writeSSZError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if len(hashes.hashes()) > sszMaxGetBlobHashes {
+		writeSSZError(w, http.StatusRequestEntityTooLarge, "too many blob hashes")
+		return
+	}
+	switch version {
+	case 1:
+		resp, err := e.GetBlobsV1(r.Context(), hashes.hashes())
+		if err != nil {
+			writeEngineError(w, err)
+			return
+		}
+		e.logger.Info("[SSZ-REST] handled get blobs", "path", r.URL.Path)
+		writeSSZ(w, newSSZGetBlobsV1Response(resp))
+		return
+	case 2:
+		resp, err := e.GetBlobsV2(r.Context(), hashes.hashes())
+		if err != nil {
+			writeEngineError(w, err)
+			return
+		}
+		e.logger.Info("[SSZ-REST] handled get blobs", "path", r.URL.Path)
+		writeSSZ(w, newSSZGetBlobsV2Response(resp))
+		return
+	case 3:
+		resp, err := e.GetBlobsV3(r.Context(), hashes.hashes())
+		if err != nil {
+			writeEngineError(w, err)
+			return
+		}
+		e.logger.Info("[SSZ-REST] handled get blobs", "path", r.URL.Path)
+		writeSSZ(w, newSSZGetBlobsV3Response(resp))
+		return
+	}
+}
+
+func (e *EngineServer) handleSSZClientVersion(w http.ResponseWriter, r *http.Request) {
+	body, err := readSSZBody(r)
+	if err != nil {
+		writeSSZError(w, http.StatusRequestEntityTooLarge, err.Error())
+		return
+	}
+	req := &sszClientVersionRequest{}
+	if err := req.DecodeSSZ(body, 0); err != nil {
+		writeSSZError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	resp, err := e.GetClientVersionV1(r.Context(), ptr(req.ClientVersion.engine()))
+	if err != nil {
+		writeEngineError(w, err)
+		return
+	}
+	e.logger.Info("[SSZ-REST] handled client version", "path", r.URL.Path)
+	writeSSZ(w, newSSZClientVersionResponse(resp))
+}
+
+func ptr[T any](v T) *T { return &v }
+
+func (e *EngineServer) handleSSZCapabilities(w http.ResponseWriter, r *http.Request) {
+	body, err := readSSZBody(r)
+	if err != nil {
+		writeSSZError(w, http.StatusRequestEntityTooLarge, err.Error())
+		return
+	}
+	req := &sszCapabilities{}
+	if err := req.DecodeSSZ(body, 0); err != nil {
+		writeSSZError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	resp := e.ExchangeCapabilities(req.names())
+	e.logger.Info("[SSZ-REST] handled capabilities", "path", r.URL.Path)
+	writeSSZ(w, newSSZCapabilities(resp))
+}
+
+func hashesToCommon(in []common.Hash) []common.Hash { return in }

--- a/execution/engineapi/sszrest_handler.go
+++ b/execution/engineapi/sszrest_handler.go
@@ -274,7 +274,7 @@ func (e *EngineServer) handleSSZForkchoice(w http.ResponseWriter, r *http.Reques
 		writeSSZError(w, http.StatusRequestEntityTooLarge, err.Error())
 		return
 	}
-	req := &forkchoiceRequest{version: sv}
+	req := newSSZRESTMessage(sszMessageForkchoiceRequest, sv)
 	if err := req.DecodeSSZ(body, int(sv)); err != nil {
 		writeSSZError(w, http.StatusBadRequest, err.Error())
 		return
@@ -359,7 +359,7 @@ func (e *EngineServer) handleSSZClientVersion(w http.ResponseWriter, r *http.Req
 		writeSSZError(w, http.StatusRequestEntityTooLarge, err.Error())
 		return
 	}
-	req := &clientVersionRequest{}
+	req := newSSZRESTMessage(sszMessageClientVersionRequest, 0)
 	if err := req.DecodeSSZ(body, 0); err != nil {
 		writeSSZError(w, http.StatusBadRequest, err.Error())
 		return
@@ -381,12 +381,12 @@ func (e *EngineServer) handleSSZCapabilities(w http.ResponseWriter, r *http.Requ
 		writeSSZError(w, http.StatusRequestEntityTooLarge, err.Error())
 		return
 	}
-	req := &capabilities{}
+	req := newSSZRESTMessage(sszMessageCapabilities, 0)
 	if err := req.DecodeSSZ(body, 0); err != nil {
 		writeSSZError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	resp := e.ExchangeCapabilities(req.names())
+	resp := e.ExchangeCapabilities(req.capabilityNames())
 	e.logger.Info("[SSZ-REST] handled capabilities", "path", r.URL.Path)
 	writeSSZ(w, newSSZCapabilities(resp))
 }

--- a/execution/engineapi/sszrest_handler.go
+++ b/execution/engineapi/sszrest_handler.go
@@ -274,7 +274,7 @@ func (e *EngineServer) handleSSZForkchoice(w http.ResponseWriter, r *http.Reques
 		writeSSZError(w, http.StatusRequestEntityTooLarge, err.Error())
 		return
 	}
-	req := &sszForkchoiceRequest{version: sv}
+	req := &forkchoiceRequest{version: sv}
 	if err := req.DecodeSSZ(body, int(sv)); err != nil {
 		writeSSZError(w, http.StatusBadRequest, err.Error())
 		return
@@ -359,7 +359,7 @@ func (e *EngineServer) handleSSZClientVersion(w http.ResponseWriter, r *http.Req
 		writeSSZError(w, http.StatusRequestEntityTooLarge, err.Error())
 		return
 	}
-	req := &sszClientVersionRequest{}
+	req := &clientVersionRequest{}
 	if err := req.DecodeSSZ(body, 0); err != nil {
 		writeSSZError(w, http.StatusBadRequest, err.Error())
 		return
@@ -381,7 +381,7 @@ func (e *EngineServer) handleSSZCapabilities(w http.ResponseWriter, r *http.Requ
 		writeSSZError(w, http.StatusRequestEntityTooLarge, err.Error())
 		return
 	}
-	req := &sszCapabilities{}
+	req := &capabilities{}
 	if err := req.DecodeSSZ(body, 0); err != nil {
 		writeSSZError(w, http.StatusBadRequest, err.Error())
 		return

--- a/execution/engineapi/sszrest_handler.go
+++ b/execution/engineapi/sszrest_handler.go
@@ -184,10 +184,10 @@ func (e *EngineServer) handleSSZNewPayload(w http.ResponseWriter, r *http.Reques
 		status, err = e.NewPayloadV3(r.Context(), payload, hashListValues(req.ExpectedBlobHashes), &root)
 	case 4:
 		root := req.ParentBeaconBlockRoot
-		status, err = e.NewPayloadV4(r.Context(), payload, hashListValues(req.ExpectedBlobHashes), &root, req.ExecutionRequests.bytes())
+		status, err = e.NewPayloadV4(r.Context(), payload, hashListValues(req.ExpectedBlobHashes), &root, transactionsBytes(req.ExecutionRequests))
 	case 5:
 		root := req.ParentBeaconBlockRoot
-		status, err = e.NewPayloadV5(r.Context(), payload, hashListValues(req.ExpectedBlobHashes), &root, req.ExecutionRequests.bytes())
+		status, err = e.NewPayloadV5(r.Context(), payload, hashListValues(req.ExpectedBlobHashes), &root, transactionsBytes(req.ExecutionRequests))
 	}
 	if err != nil {
 		writeEngineError(w, err)

--- a/execution/engineapi/sszrest_test.go
+++ b/execution/engineapi/sszrest_test.go
@@ -28,7 +28,7 @@ func TestSSZRESTCapabilitiesCodecRoundTrip(t *testing.T) {
 	enc, err := in.EncodeSSZ(nil)
 	require.NoError(t, err)
 
-	var out sszCapabilities
+	var out capabilities
 	require.NoError(t, out.DecodeSSZ(enc, 0))
 	require.Equal(t, []string{"engine_newPayloadV1", "POST /engine/v1/payloads"}, out.names())
 }
@@ -75,11 +75,11 @@ func TestSSZRESTRequestCodecsRoundTrip(t *testing.T) {
 		{"newPayloadV5", clparams.GloasVersion, newSSZNewPayloadRequest(clparams.GloasVersion), func() interface{ DecodeSSZ([]byte, int) error } {
 			return newSSZNewPayloadRequest(clparams.GloasVersion)
 		}},
-		{"forkchoiceV1", clparams.BellatrixVersion, &sszForkchoiceRequest{version: clparams.BellatrixVersion}, func() interface{ DecodeSSZ([]byte, int) error } {
-			return &sszForkchoiceRequest{}
+		{"forkchoiceV1", clparams.BellatrixVersion, &forkchoiceRequest{version: clparams.BellatrixVersion}, func() interface{ DecodeSSZ([]byte, int) error } {
+			return &forkchoiceRequest{}
 		}},
-		{"forkchoiceV4", clparams.GloasVersion, &sszForkchoiceRequest{version: clparams.GloasVersion}, func() interface{ DecodeSSZ([]byte, int) error } {
-			return &sszForkchoiceRequest{}
+		{"forkchoiceV4", clparams.GloasVersion, &forkchoiceRequest{version: clparams.GloasVersion}, func() interface{ DecodeSSZ([]byte, int) error } {
+			return &forkchoiceRequest{}
 		}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -112,21 +112,21 @@ func TestSSZRESTGetBlobsCodecsRoundTrip(t *testing.T) {
 			name: "v1",
 			obj:  newSSZGetBlobsV1Response([]*engine_types.BlobAndProofV1{{Blob: blob, Proof: proof}, nil}),
 			empty: func() interface{ DecodeSSZ([]byte, int) error } {
-				return &sszGetBlobsV1Response{}
+				return &getBlobsV1Response{}
 			},
 		},
 		{
 			name: "v2",
 			obj:  newSSZGetBlobsV2Response([]*engine_types.BlobAndProofV2{{Blob: blob, CellProofs: proofs}, nil}),
 			empty: func() interface{ DecodeSSZ([]byte, int) error } {
-				return &sszGetBlobsV2Response{}
+				return &getBlobsV2Response{}
 			},
 		},
 		{
 			name: "v3",
 			obj:  newSSZGetBlobsV3Response([]*engine_types.BlobAndProofV2{{Blob: blob, CellProofs: proofs}, nil}),
 			empty: func() interface{ DecodeSSZ([]byte, int) error } {
-				return &sszGetBlobsV3Response{}
+				return &getBlobsV3Response{}
 			},
 		},
 	} {
@@ -149,7 +149,7 @@ func TestSSZRESTCapabilitiesRoute(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Equal(t, sszRestContentType, rec.Header().Get("Content-Type"))
-	var resp sszCapabilities
+	var resp capabilities
 	require.NoError(t, resp.DecodeSSZ(rec.Body.Bytes(), 0))
 	require.Contains(t, resp.names(), "engine_newPayloadV1")
 	require.Contains(t, resp.names(), "POST /engine/v4/payloads")
@@ -252,7 +252,7 @@ func TestSSZRESTForkchoiceV4UsesGloasPayloadAttributesSchema(t *testing.T) {
 		SlotNumber:            &slotNumber,
 		SSZVersion:            clparams.GloasVersion,
 	}
-	req := &sszForkchoiceRequest{
+	req := &forkchoiceRequest{
 		version:   clparams.GloasVersion,
 		AttrsList: solid.NewDynamicListSSZ[*engine_types.PayloadAttributes](1),
 	}
@@ -263,7 +263,7 @@ func TestSSZRESTForkchoiceV4UsesGloasPayloadAttributesSchema(t *testing.T) {
 
 	wireVersion, ok := sszForkchoiceVersion(4)
 	require.True(t, ok)
-	var out sszForkchoiceRequest
+	var out forkchoiceRequest
 	require.NoError(t, out.DecodeSSZ(enc, int(wireVersion)))
 	out.version = wireVersion
 

--- a/execution/engineapi/sszrest_test.go
+++ b/execution/engineapi/sszrest_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	ssz2 "github.com/erigontech/erigon/cl/ssz"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/common/log/v3"
@@ -23,13 +25,12 @@ import (
 )
 
 func TestSSZRESTCapabilitiesCodecRoundTrip(t *testing.T) {
-	in := newSSZCapabilities([]string{"engine_newPayloadV1", "POST /engine/v1/payloads"})
-	enc, err := in.EncodeSSZ(nil)
+	enc, err := encodeCapabilities([]string{"engine_newPayloadV1", "POST /engine/v1/payloads"})
 	require.NoError(t, err)
 
-	out := newSSZRESTMessage(sszMessageCapabilities, 0)
-	require.NoError(t, out.DecodeSSZ(enc, 0))
-	require.Equal(t, []string{"engine_newPayloadV1", "POST /engine/v1/payloads"}, out.capabilityNames())
+	out, err := decodeCapabilities(enc, 0)
+	require.NoError(t, err)
+	require.Equal(t, []string{"engine_newPayloadV1", "POST /engine/v1/payloads"}, out)
 }
 
 func TestSSZRESTPayloadStatusEnumRoundTrip(t *testing.T) {
@@ -54,39 +55,41 @@ func TestSSZRESTRequestCodecsRoundTrip(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
 		version clparams.StateVersion
-		obj     interface {
-			EncodeSSZ([]byte) ([]byte, error)
-			DecodeSSZ([]byte, int) error
-		}
-		empty func() interface {
-			DecodeSSZ([]byte, int) error
-		}
+		encode  func(clparams.StateVersion) ([]byte, error)
+		decode  func([]byte, clparams.StateVersion) error
 	}{
-		{"newPayloadV1", clparams.BellatrixVersion, newSSZNewPayloadRequest(clparams.BellatrixVersion), func() interface{ DecodeSSZ([]byte, int) error } {
-			return newSSZNewPayloadRequest(clparams.BellatrixVersion)
-		}},
-		{"newPayloadV2", clparams.CapellaVersion, newSSZNewPayloadRequest(clparams.CapellaVersion), func() interface{ DecodeSSZ([]byte, int) error } {
-			return newSSZNewPayloadRequest(clparams.CapellaVersion)
-		}},
-		{"newPayloadV3", clparams.DenebVersion, newSSZNewPayloadRequest(clparams.DenebVersion), func() interface{ DecodeSSZ([]byte, int) error } {
-			return newSSZNewPayloadRequest(clparams.DenebVersion)
-		}},
-		{"newPayloadV5", clparams.GloasVersion, newSSZNewPayloadRequest(clparams.GloasVersion), func() interface{ DecodeSSZ([]byte, int) error } {
-			return newSSZNewPayloadRequest(clparams.GloasVersion)
-		}},
-		{"forkchoiceV1", clparams.BellatrixVersion, newSSZRESTMessage(sszMessageForkchoiceRequest, clparams.BellatrixVersion), func() interface{ DecodeSSZ([]byte, int) error } {
-			return newSSZRESTMessage(sszMessageForkchoiceRequest, clparams.BellatrixVersion)
-		}},
-		{"forkchoiceV4", clparams.GloasVersion, newSSZRESTMessage(sszMessageForkchoiceRequest, clparams.GloasVersion), func() interface{ DecodeSSZ([]byte, int) error } {
-			return newSSZRESTMessage(sszMessageForkchoiceRequest, clparams.GloasVersion)
-		}},
+		{"newPayloadV1", clparams.BellatrixVersion, encodeEmptyNewPayloadRequest, decodeEmptyNewPayloadRequest},
+		{"newPayloadV2", clparams.CapellaVersion, encodeEmptyNewPayloadRequest, decodeEmptyNewPayloadRequest},
+		{"newPayloadV3", clparams.DenebVersion, encodeEmptyNewPayloadRequest, decodeEmptyNewPayloadRequest},
+		{"newPayloadV5", clparams.GloasVersion, encodeEmptyNewPayloadRequest, decodeEmptyNewPayloadRequest},
+		{"forkchoiceV1", clparams.BellatrixVersion, encodeEmptyForkchoiceRequest, decodeEmptyForkchoiceRequest},
+		{"forkchoiceV4", clparams.GloasVersion, encodeEmptyForkchoiceRequest, decodeEmptyForkchoiceRequest},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			enc, err := tc.obj.EncodeSSZ(nil)
+			enc, err := tc.encode(tc.version)
 			require.NoError(t, err)
-			require.NoError(t, tc.empty().DecodeSSZ(enc, int(tc.version)))
+			require.NoError(t, tc.decode(enc, tc.version))
 		})
 	}
+}
+
+func encodeEmptyNewPayloadRequest(version clparams.StateVersion) ([]byte, error) {
+	return encodeNewPayloadRequest(version, engine_types.NewExecutionPayloadSSZ(version), solid.NewHashList(sszMaxBlobHashes), common.Hash{}, &solid.TransactionsSSZ{})
+}
+
+func decodeEmptyNewPayloadRequest(buf []byte, version clparams.StateVersion) error {
+	_, _, _, _, err := decodeNewPayloadRequest(buf, version)
+	return err
+}
+
+func encodeEmptyForkchoiceRequest(version clparams.StateVersion) ([]byte, error) {
+	state := engine_types.ForkChoiceState{}
+	return encodeForkchoiceRequest(version, &state, nil)
+}
+
+func decodeEmptyForkchoiceRequest(buf []byte, version clparams.StateVersion) error {
+	_, _, err := decodeForkchoiceRequest(buf, version)
+	return err
 }
 
 func TestSSZRESTGetBlobsCodecsRoundTrip(t *testing.T) {
@@ -99,47 +102,48 @@ func TestSSZRESTGetBlobsCodecsRoundTrip(t *testing.T) {
 
 	for _, tc := range []struct {
 		name string
-		obj  interface {
-			EncodeSSZ([]byte) ([]byte, error)
-			DecodeSSZ([]byte, int) error
-		}
-		empty func() interface {
-			DecodeSSZ([]byte, int) error
-		}
+		enc  func() ([]byte, error)
+		dec  func([]byte) error
 	}{
 		{
 			name: "v1",
-			obj:  newSSZGetBlobsV1Response([]*engine_types.BlobAndProofV1{{Blob: blob, Proof: proof}, nil}),
-			empty: func() interface{ DecodeSSZ([]byte, int) error } {
-				return newSSZRESTMessage(sszMessageGetBlobsV1Response, 0)
+			enc: func() ([]byte, error) {
+				return encodeGetBlobsV1Response([]*engine_types.BlobAndProofV1{{Blob: blob, Proof: proof}, nil})
+			},
+			dec: func(buf []byte) error {
+				return ssz2.UnmarshalSSZ(buf, 0, solid.NewStaticListSSZ[*engine_types.BlobAndProofV1](sszMaxGetBlobHashes, sszBlobBytes+sszKZGBytes))
 			},
 		},
 		{
 			name: "v2",
-			obj:  newSSZGetBlobsV2Response([]*engine_types.BlobAndProofV2{{Blob: blob, CellProofs: proofs}, nil}),
-			empty: func() interface{ DecodeSSZ([]byte, int) error } {
-				return newSSZRESTMessage(sszMessageGetBlobsV2Response, 0)
+			enc: func() ([]byte, error) {
+				return encodeGetBlobsV2Response([]*engine_types.BlobAndProofV2{{Blob: blob, CellProofs: proofs}, nil})
+			},
+			dec: func(buf []byte) error {
+				return ssz2.UnmarshalSSZ(buf, 0, solid.NewDynamicListSSZ[*engine_types.BlobAndProofV2](sszMaxGetBlobHashes))
 			},
 		},
 		{
 			name: "v3",
-			obj:  newSSZGetBlobsV3Response([]*engine_types.BlobAndProofV2{{Blob: blob, CellProofs: proofs}, nil}),
-			empty: func() interface{ DecodeSSZ([]byte, int) error } {
-				return newSSZRESTMessage(sszMessageGetBlobsV3Response, 0)
+			enc: func() ([]byte, error) {
+				return encodeGetBlobsV3Response([]*engine_types.BlobAndProofV2{{Blob: blob, CellProofs: proofs}, nil})
+			},
+			dec: func(buf []byte) error {
+				return ssz2.UnmarshalSSZ(buf, 0, solid.NewDynamicListSSZ[*engine_types.NullableBlobAndProofV2](sszMaxGetBlobHashes))
 			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			enc, err := tc.obj.EncodeSSZ(nil)
+			enc, err := tc.enc()
 			require.NoError(t, err)
-			require.NoError(t, tc.empty().DecodeSSZ(enc, 0))
+			require.NoError(t, tc.dec(enc))
 		})
 	}
 }
 
 func TestSSZRESTCapabilitiesRoute(t *testing.T) {
 	srv := NewEngineServer(log.New(), &chain.Config{}, nil, nil, false, true, false, false, nil, 0, 0)
-	body, err := newSSZCapabilities([]string{"engine_newPayloadV1"}).EncodeSSZ(nil)
+	body, err := encodeCapabilities([]string{"engine_newPayloadV1"})
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodPost, "/engine/v1/capabilities", bytes.NewReader(body))
@@ -148,11 +152,11 @@ func TestSSZRESTCapabilitiesRoute(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Equal(t, sszRestContentType, rec.Header().Get("Content-Type"))
-	resp := newSSZRESTMessage(sszMessageCapabilities, 0)
-	require.NoError(t, resp.DecodeSSZ(rec.Body.Bytes(), 0))
-	require.Contains(t, resp.capabilityNames(), "engine_newPayloadV1")
-	require.Contains(t, resp.capabilityNames(), "POST /engine/v4/payloads")
-	require.NotContains(t, resp.capabilityNames(), "engine_exchangeCapabilities")
+	resp, err := decodeCapabilities(rec.Body.Bytes(), 0)
+	require.NoError(t, err)
+	require.Contains(t, resp, "engine_newPayloadV1")
+	require.Contains(t, resp, "POST /engine/v4/payloads")
+	require.NotContains(t, resp, "engine_exchangeCapabilities")
 }
 
 func TestSSZRESTAdvertisedRoutes(t *testing.T) {
@@ -223,23 +227,22 @@ func TestSSZRESTEndpointVersionMapping(t *testing.T) {
 }
 
 func TestSSZRESTNewPayloadV5UsesGloasPayloadSchema(t *testing.T) {
-	req := newSSZNewPayloadRequest(clparams.GloasVersion)
+	payload := engine_types.NewExecutionPayloadSSZ(clparams.GloasVersion)
 	slot := hexutil.Uint64(123)
-	req.Payload.SlotNumber = &slot
-	req.Payload.BlockAccessList = hexutil.Bytes{0x01, 0x02, 0x03}
+	payload.SlotNumber = &slot
+	payload.BlockAccessList = hexutil.Bytes{0x01, 0x02, 0x03}
 
-	enc, err := req.EncodeSSZ(nil)
+	enc, err := encodeNewPayloadRequest(clparams.GloasVersion, payload, solid.NewHashList(sszMaxBlobHashes), common.Hash{}, &solid.TransactionsSSZ{})
 	require.NoError(t, err)
 
 	wireVersion, ok := sszNewPayloadVersion(5)
 	require.True(t, ok)
-	out := newSSZNewPayloadRequest(wireVersion)
-	require.NoError(t, out.DecodeSSZ(enc, int(wireVersion)))
+	out, _, _, _, err := decodeNewPayloadRequest(enc, wireVersion)
+	require.NoError(t, err)
 
-	payload := out.Payload
-	require.NotNil(t, payload.SlotNumber)
-	require.Equal(t, hexutil.Uint64(123), *payload.SlotNumber)
-	require.Equal(t, hexutil.Bytes{0x01, 0x02, 0x03}, payload.BlockAccessList)
+	require.NotNil(t, out.SlotNumber)
+	require.Equal(t, hexutil.Uint64(123), *out.SlotNumber)
+	require.Equal(t, hexutil.Bytes{0x01, 0x02, 0x03}, out.BlockAccessList)
 }
 
 func TestSSZRESTForkchoiceV4UsesGloasPayloadAttributesSchema(t *testing.T) {
@@ -251,19 +254,15 @@ func TestSSZRESTForkchoiceV4UsesGloasPayloadAttributesSchema(t *testing.T) {
 		SlotNumber:            &slotNumber,
 		SSZVersion:            clparams.GloasVersion,
 	}
-	req := newSSZRESTMessage(sszMessageForkchoiceRequest, clparams.GloasVersion)
-	req.AttrsList.Append(attrs)
-
-	enc, err := req.EncodeSSZ(nil)
+	state := engine_types.ForkChoiceState{}
+	enc, err := encodeForkchoiceRequest(clparams.GloasVersion, &state, attrs)
 	require.NoError(t, err)
 
 	wireVersion, ok := sszForkchoiceVersion(4)
 	require.True(t, ok)
-	out := newSSZRESTMessage(sszMessageForkchoiceRequest, clparams.GloasVersion)
-	require.NoError(t, out.DecodeSSZ(enc, int(wireVersion)))
-	out.version = wireVersion
+	_, engineAttrs, err := decodeForkchoiceRequest(enc, wireVersion)
+	require.NoError(t, err)
 
-	engineAttrs := out.payloadAttributes()
 	require.NotNil(t, engineAttrs)
 	require.NotNil(t, engineAttrs.SlotNumber)
 	require.Equal(t, hexutil.Uint64(456), *engineAttrs.SlotNumber)

--- a/execution/engineapi/sszrest_test.go
+++ b/execution/engineapi/sszrest_test.go
@@ -1,0 +1,309 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+
+package engineapi
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/engineapi/engine_helpers"
+	"github.com/erigontech/erigon/execution/engineapi/engine_types"
+)
+
+func TestSSZRESTCapabilitiesCodecRoundTrip(t *testing.T) {
+	in := newSSZCapabilities([]string{"engine_newPayloadV1", "POST /engine/v1/payloads"})
+	enc, err := in.EncodeSSZ(nil)
+	require.NoError(t, err)
+
+	var out sszCapabilities
+	require.NoError(t, out.DecodeSSZ(enc, 0))
+	require.Equal(t, []string{"engine_newPayloadV1", "POST /engine/v1/payloads"}, out.names())
+}
+
+func TestSSZRESTPayloadStatusEnumRoundTrip(t *testing.T) {
+	latest := common.HexToHash("0x1234")
+	wire, err := payloadStatusToSSZ(&engine_types.PayloadStatus{
+		Status:          engine_types.AcceptedStatus,
+		LatestValidHash: &latest,
+		ValidationError: engine_types.NewStringifiedErrorFromString("no"),
+	})
+	require.NoError(t, err)
+	enc, err := wire.EncodeSSZ(nil)
+	require.NoError(t, err)
+
+	var out sszPayloadStatus
+	require.NoError(t, out.DecodeSSZ(enc, 0))
+	require.Equal(t, uint8(3), out.Status)
+	require.Equal(t, []common.Hash{latest}, out.LatestValidHash.hashes())
+	require.Equal(t, []byte("no"), out.ValidationError.Bytes())
+}
+
+func TestSSZRESTRequestCodecsRoundTrip(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		version clparams.StateVersion
+		obj     interface {
+			EncodeSSZ([]byte) ([]byte, error)
+			DecodeSSZ([]byte, int) error
+		}
+		empty func() interface {
+			DecodeSSZ([]byte, int) error
+		}
+	}{
+		{"newPayloadV1", clparams.BellatrixVersion, newSSZNewPayloadRequest(clparams.BellatrixVersion), func() interface{ DecodeSSZ([]byte, int) error } {
+			return newSSZNewPayloadRequest(clparams.BellatrixVersion)
+		}},
+		{"newPayloadV2", clparams.CapellaVersion, newSSZNewPayloadRequest(clparams.CapellaVersion), func() interface{ DecodeSSZ([]byte, int) error } {
+			return newSSZNewPayloadRequest(clparams.CapellaVersion)
+		}},
+		{"newPayloadV3", clparams.DenebVersion, newSSZNewPayloadRequest(clparams.DenebVersion), func() interface{ DecodeSSZ([]byte, int) error } {
+			return newSSZNewPayloadRequest(clparams.DenebVersion)
+		}},
+		{"newPayloadV5", clparams.GloasVersion, newSSZNewPayloadRequest(clparams.GloasVersion), func() interface{ DecodeSSZ([]byte, int) error } {
+			return newSSZNewPayloadRequest(clparams.GloasVersion)
+		}},
+		{"forkchoiceV1", clparams.BellatrixVersion, &sszForkchoiceRequest{version: clparams.BellatrixVersion}, func() interface{ DecodeSSZ([]byte, int) error } {
+			return &sszForkchoiceRequest{}
+		}},
+		{"forkchoiceV4", clparams.GloasVersion, &sszForkchoiceRequest{version: clparams.GloasVersion}, func() interface{ DecodeSSZ([]byte, int) error } {
+			return &sszForkchoiceRequest{}
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			enc, err := tc.obj.EncodeSSZ(nil)
+			require.NoError(t, err)
+			require.NoError(t, tc.empty().DecodeSSZ(enc, int(tc.version)))
+		})
+	}
+}
+
+func TestSSZRESTGetBlobsCodecsRoundTrip(t *testing.T) {
+	blob := bytes.Repeat([]byte{0x11}, sszBlobBytes)
+	proof := bytes.Repeat([]byte{0x22}, sszKZGBytes)
+	proofs := make([]hexutil.Bytes, sszCellsPerExtBlob)
+	for i := range proofs {
+		proofs[i] = proof
+	}
+
+	for _, tc := range []struct {
+		name string
+		obj  interface {
+			EncodeSSZ([]byte) ([]byte, error)
+			DecodeSSZ([]byte, int) error
+		}
+		empty func() interface {
+			DecodeSSZ([]byte, int) error
+		}
+	}{
+		{
+			name: "v1",
+			obj:  newSSZGetBlobsV1Response([]*engine_types.BlobAndProofV1{{Blob: blob, Proof: proof}, nil}),
+			empty: func() interface{ DecodeSSZ([]byte, int) error } {
+				return &sszGetBlobsV1Response{}
+			},
+		},
+		{
+			name: "v2",
+			obj:  newSSZGetBlobsV2Response([]*engine_types.BlobAndProofV2{{Blob: blob, CellProofs: proofs}, nil}),
+			empty: func() interface{ DecodeSSZ([]byte, int) error } {
+				return &sszGetBlobsV2Response{}
+			},
+		},
+		{
+			name: "v3",
+			obj:  newSSZGetBlobsV3Response([]*engine_types.BlobAndProofV2{{Blob: blob, CellProofs: proofs}, nil}),
+			empty: func() interface{ DecodeSSZ([]byte, int) error } {
+				return &sszGetBlobsV3Response{}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			enc, err := tc.obj.EncodeSSZ(nil)
+			require.NoError(t, err)
+			require.NoError(t, tc.empty().DecodeSSZ(enc, 0))
+		})
+	}
+}
+
+func TestSSZRESTCapabilitiesRoute(t *testing.T) {
+	srv := NewEngineServer(log.New(), &chain.Config{}, nil, nil, false, true, false, false, nil, 0, 0)
+	body, err := newSSZCapabilities([]string{"engine_newPayloadV1"}).EncodeSSZ(nil)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/engine/v1/capabilities", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.SSZRESTHandler().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, sszRestContentType, rec.Header().Get("Content-Type"))
+	var resp sszCapabilities
+	require.NoError(t, resp.DecodeSSZ(rec.Body.Bytes(), 0))
+	require.Contains(t, resp.names(), "engine_newPayloadV1")
+	require.Contains(t, resp.names(), "POST /engine/v4/payloads")
+	require.NotContains(t, resp.names(), "engine_exchangeCapabilities")
+}
+
+func TestSSZRESTAdvertisedRoutes(t *testing.T) {
+	srv := NewEngineServer(log.New(), &chain.Config{}, nil, nil, false, true, false, false, nil, 0, 0)
+	for _, route := range []struct {
+		method string
+		path   string
+		code   int
+	}{
+		{http.MethodPost, "/engine/v1/payloads", http.StatusBadRequest},
+		{http.MethodPost, "/engine/v2/payloads", http.StatusBadRequest},
+		{http.MethodPost, "/engine/v3/payloads", http.StatusBadRequest},
+		{http.MethodPost, "/engine/v4/payloads", http.StatusBadRequest},
+		{http.MethodPost, "/engine/v5/payloads", http.StatusBadRequest},
+		{http.MethodGet, "/engine/v1/payloads/not-a-payload-id", http.StatusBadRequest},
+		{http.MethodGet, "/engine/v2/payloads/not-a-payload-id", http.StatusBadRequest},
+		{http.MethodGet, "/engine/v3/payloads/not-a-payload-id", http.StatusBadRequest},
+		{http.MethodGet, "/engine/v4/payloads/not-a-payload-id", http.StatusBadRequest},
+		{http.MethodGet, "/engine/v5/payloads/not-a-payload-id", http.StatusBadRequest},
+		{http.MethodGet, "/engine/v6/payloads/not-a-payload-id", http.StatusBadRequest},
+		{http.MethodPost, "/engine/v1/forkchoice", http.StatusBadRequest},
+		{http.MethodPost, "/engine/v2/forkchoice", http.StatusBadRequest},
+		{http.MethodPost, "/engine/v3/forkchoice", http.StatusBadRequest},
+		{http.MethodPost, "/engine/v4/forkchoice", http.StatusBadRequest},
+		{http.MethodPost, "/engine/v1/blobs", http.StatusBadRequest},
+		{http.MethodPost, "/engine/v2/blobs", http.StatusBadRequest},
+		{http.MethodPost, "/engine/v3/blobs", http.StatusBadRequest},
+		{http.MethodPost, "/engine/v1/client/version", http.StatusBadRequest},
+	} {
+		t.Run(route.method+" "+route.path, func(t *testing.T) {
+			req := httptest.NewRequest(route.method, route.path, strings.NewReader("bad-ssz"))
+			rec := httptest.NewRecorder()
+			srv.SSZRESTHandler().ServeHTTP(rec, req)
+			require.Equal(t, route.code, rec.Code)
+		})
+	}
+}
+
+func TestSSZRESTEndpointVersionMapping(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		fn   func(int) (clparams.StateVersion, bool)
+		in   int
+		want clparams.StateVersion
+	}{
+		{"newPayloadV1", sszNewPayloadVersion, 1, clparams.BellatrixVersion},
+		{"newPayloadV2", sszNewPayloadVersion, 2, clparams.CapellaVersion},
+		{"newPayloadV3", sszNewPayloadVersion, 3, clparams.DenebVersion},
+		{"newPayloadV4", sszNewPayloadVersion, 4, clparams.ElectraVersion},
+		{"newPayloadV5", sszNewPayloadVersion, 5, clparams.GloasVersion},
+		{"getPayloadV1", sszGetPayloadVersion, 1, clparams.BellatrixVersion},
+		{"getPayloadV2", sszGetPayloadVersion, 2, clparams.CapellaVersion},
+		{"getPayloadV3", sszGetPayloadVersion, 3, clparams.DenebVersion},
+		{"getPayloadV4", sszGetPayloadVersion, 4, clparams.ElectraVersion},
+		{"getPayloadV5", sszGetPayloadVersion, 5, clparams.FuluVersion},
+		{"getPayloadV6", sszGetPayloadVersion, 6, clparams.GloasVersion},
+		{"forkchoiceV1", sszForkchoiceVersion, 1, clparams.BellatrixVersion},
+		{"forkchoiceV2", sszForkchoiceVersion, 2, clparams.CapellaVersion},
+		{"forkchoiceV3", sszForkchoiceVersion, 3, clparams.DenebVersion},
+		{"forkchoiceV4", sszForkchoiceVersion, 4, clparams.GloasVersion},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := tc.fn(tc.in)
+			require.True(t, ok)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestSSZRESTNewPayloadV5UsesGloasPayloadSchema(t *testing.T) {
+	req := newSSZNewPayloadRequest(clparams.GloasVersion)
+	req.Payload.Block.SlotNumber = 123
+	req.Payload.Block.BlockAccessList = solid.NewByteListSSZ(sszMaxBytesPerTransaction)
+	require.NoError(t, req.Payload.Block.BlockAccessList.SetBytes([]byte{0x01, 0x02, 0x03}))
+
+	enc, err := req.EncodeSSZ(nil)
+	require.NoError(t, err)
+
+	wireVersion, ok := sszNewPayloadVersion(5)
+	require.True(t, ok)
+	out := newSSZNewPayloadRequest(wireVersion)
+	require.NoError(t, out.DecodeSSZ(enc, int(wireVersion)))
+
+	payload := sszToExecutionPayload(out.Payload)
+	require.NotNil(t, payload.SlotNumber)
+	require.Equal(t, hexutil.Uint64(123), *payload.SlotNumber)
+	require.Equal(t, hexutil.Bytes{0x01, 0x02, 0x03}, payload.BlockAccessList)
+}
+
+func TestSSZRESTForkchoiceV4UsesGloasPayloadAttributesSchema(t *testing.T) {
+	attrs := &sszPayloadAttributes{
+		Timestamp:             1,
+		SuggestedFeeRecipient: common.HexToAddress("0x1234"),
+		Withdrawals:           &sszWithdrawalList{},
+		SlotNumber:            456,
+		version:               clparams.GloasVersion,
+	}
+	req := &sszForkchoiceRequest{
+		version:   clparams.GloasVersion,
+		AttrsList: solid.NewDynamicListSSZ[*sszPayloadAttributes](1),
+	}
+	req.AttrsList.Append(attrs)
+
+	enc, err := req.EncodeSSZ(nil)
+	require.NoError(t, err)
+
+	wireVersion, ok := sszForkchoiceVersion(4)
+	require.True(t, ok)
+	var out sszForkchoiceRequest
+	require.NoError(t, out.DecodeSSZ(enc, int(wireVersion)))
+	out.version = wireVersion
+
+	engineAttrs := out.payloadAttributes()
+	require.NotNil(t, engineAttrs)
+	require.NotNil(t, engineAttrs.SlotNumber)
+	require.Equal(t, hexutil.Uint64(456), *engineAttrs.SlotNumber)
+}
+
+func TestExchangeCapabilitiesAdvertisesJSONRPCAndSSZREST(t *testing.T) {
+	srv := NewEngineServer(log.New(), &chain.Config{}, nil, nil, false, true, false, false, nil, 0, 0)
+	caps := srv.ExchangeCapabilities([]string{"engine_newPayloadV1"})
+	require.Contains(t, caps, "engine_newPayloadV1")
+	require.Contains(t, caps, "engine_getPayloadV6")
+	require.Contains(t, caps, "POST /engine/v1/capabilities")
+	require.Contains(t, caps, "GET /engine/v6/payloads/{payload_id}")
+	require.NotContains(t, caps, "engine_exchangeCapabilities")
+}
+
+func TestSSZRESTGetPayloadIDPathParsing(t *testing.T) {
+	id, err := parsePayloadIDPath("0x0102030405060708")
+	require.NoError(t, err)
+	require.Equal(t, hexutil.Bytes{1, 2, 3, 4, 5, 6, 7, 8}, id)
+
+	_, err = parsePayloadIDPath("0x01")
+	require.Error(t, err)
+}
+
+func TestSSZRESTErrorMapping(t *testing.T) {
+	for _, tc := range []struct {
+		err  error
+		code int
+	}{
+		{&engine_helpers.UnknownPayloadErr, http.StatusNotFound},
+		{&engine_helpers.InvalidForkchoiceStateErr, http.StatusConflict},
+		{&engine_helpers.InvalidPayloadAttributesErr, http.StatusUnprocessableEntity},
+		{&engine_helpers.TooLargeRequestErr, http.StatusRequestEntityTooLarge},
+		{errors.New("boom"), http.StatusInternalServerError},
+	} {
+		rec := httptest.NewRecorder()
+		writeEngineError(rec, tc.err)
+		require.Equal(t, tc.code, rec.Code)
+	}
+}

--- a/execution/engineapi/sszrest_test.go
+++ b/execution/engineapi/sszrest_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/cl/clparams"
-	"github.com/erigontech/erigon/cl/cltypes/solid"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/common/log/v3"
@@ -28,9 +27,9 @@ func TestSSZRESTCapabilitiesCodecRoundTrip(t *testing.T) {
 	enc, err := in.EncodeSSZ(nil)
 	require.NoError(t, err)
 
-	var out capabilities
+	out := newSSZRESTMessage(sszMessageCapabilities, 0)
 	require.NoError(t, out.DecodeSSZ(enc, 0))
-	require.Equal(t, []string{"engine_newPayloadV1", "POST /engine/v1/payloads"}, out.names())
+	require.Equal(t, []string{"engine_newPayloadV1", "POST /engine/v1/payloads"}, out.capabilityNames())
 }
 
 func TestSSZRESTPayloadStatusEnumRoundTrip(t *testing.T) {
@@ -75,11 +74,11 @@ func TestSSZRESTRequestCodecsRoundTrip(t *testing.T) {
 		{"newPayloadV5", clparams.GloasVersion, newSSZNewPayloadRequest(clparams.GloasVersion), func() interface{ DecodeSSZ([]byte, int) error } {
 			return newSSZNewPayloadRequest(clparams.GloasVersion)
 		}},
-		{"forkchoiceV1", clparams.BellatrixVersion, &forkchoiceRequest{version: clparams.BellatrixVersion}, func() interface{ DecodeSSZ([]byte, int) error } {
-			return &forkchoiceRequest{}
+		{"forkchoiceV1", clparams.BellatrixVersion, newSSZRESTMessage(sszMessageForkchoiceRequest, clparams.BellatrixVersion), func() interface{ DecodeSSZ([]byte, int) error } {
+			return newSSZRESTMessage(sszMessageForkchoiceRequest, clparams.BellatrixVersion)
 		}},
-		{"forkchoiceV4", clparams.GloasVersion, &forkchoiceRequest{version: clparams.GloasVersion}, func() interface{ DecodeSSZ([]byte, int) error } {
-			return &forkchoiceRequest{}
+		{"forkchoiceV4", clparams.GloasVersion, newSSZRESTMessage(sszMessageForkchoiceRequest, clparams.GloasVersion), func() interface{ DecodeSSZ([]byte, int) error } {
+			return newSSZRESTMessage(sszMessageForkchoiceRequest, clparams.GloasVersion)
 		}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -112,21 +111,21 @@ func TestSSZRESTGetBlobsCodecsRoundTrip(t *testing.T) {
 			name: "v1",
 			obj:  newSSZGetBlobsV1Response([]*engine_types.BlobAndProofV1{{Blob: blob, Proof: proof}, nil}),
 			empty: func() interface{ DecodeSSZ([]byte, int) error } {
-				return &getBlobsV1Response{}
+				return newSSZRESTMessage(sszMessageGetBlobsV1Response, 0)
 			},
 		},
 		{
 			name: "v2",
 			obj:  newSSZGetBlobsV2Response([]*engine_types.BlobAndProofV2{{Blob: blob, CellProofs: proofs}, nil}),
 			empty: func() interface{ DecodeSSZ([]byte, int) error } {
-				return &getBlobsV2Response{}
+				return newSSZRESTMessage(sszMessageGetBlobsV2Response, 0)
 			},
 		},
 		{
 			name: "v3",
 			obj:  newSSZGetBlobsV3Response([]*engine_types.BlobAndProofV2{{Blob: blob, CellProofs: proofs}, nil}),
 			empty: func() interface{ DecodeSSZ([]byte, int) error } {
-				return &getBlobsV3Response{}
+				return newSSZRESTMessage(sszMessageGetBlobsV3Response, 0)
 			},
 		},
 	} {
@@ -149,11 +148,11 @@ func TestSSZRESTCapabilitiesRoute(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Equal(t, sszRestContentType, rec.Header().Get("Content-Type"))
-	var resp capabilities
+	resp := newSSZRESTMessage(sszMessageCapabilities, 0)
 	require.NoError(t, resp.DecodeSSZ(rec.Body.Bytes(), 0))
-	require.Contains(t, resp.names(), "engine_newPayloadV1")
-	require.Contains(t, resp.names(), "POST /engine/v4/payloads")
-	require.NotContains(t, resp.names(), "engine_exchangeCapabilities")
+	require.Contains(t, resp.capabilityNames(), "engine_newPayloadV1")
+	require.Contains(t, resp.capabilityNames(), "POST /engine/v4/payloads")
+	require.NotContains(t, resp.capabilityNames(), "engine_exchangeCapabilities")
 }
 
 func TestSSZRESTAdvertisedRoutes(t *testing.T) {
@@ -252,10 +251,7 @@ func TestSSZRESTForkchoiceV4UsesGloasPayloadAttributesSchema(t *testing.T) {
 		SlotNumber:            &slotNumber,
 		SSZVersion:            clparams.GloasVersion,
 	}
-	req := &forkchoiceRequest{
-		version:   clparams.GloasVersion,
-		AttrsList: solid.NewDynamicListSSZ[*engine_types.PayloadAttributes](1),
-	}
+	req := newSSZRESTMessage(sszMessageForkchoiceRequest, clparams.GloasVersion)
 	req.AttrsList.Append(attrs)
 
 	enc, err := req.EncodeSSZ(nil)
@@ -263,7 +259,7 @@ func TestSSZRESTForkchoiceV4UsesGloasPayloadAttributesSchema(t *testing.T) {
 
 	wireVersion, ok := sszForkchoiceVersion(4)
 	require.True(t, ok)
-	var out forkchoiceRequest
+	out := newSSZRESTMessage(sszMessageForkchoiceRequest, clparams.GloasVersion)
 	require.NoError(t, out.DecodeSSZ(enc, int(wireVersion)))
 	out.version = wireVersion
 

--- a/execution/engineapi/sszrest_test.go
+++ b/execution/engineapi/sszrest_test.go
@@ -35,20 +35,20 @@ func TestSSZRESTCapabilitiesCodecRoundTrip(t *testing.T) {
 
 func TestSSZRESTPayloadStatusEnumRoundTrip(t *testing.T) {
 	latest := common.HexToHash("0x1234")
-	wire, err := payloadStatusToSSZ(&engine_types.PayloadStatus{
+	wire := &engine_types.PayloadStatus{
 		Status:          engine_types.AcceptedStatus,
 		LatestValidHash: &latest,
 		ValidationError: engine_types.NewStringifiedErrorFromString("no"),
-	})
-	require.NoError(t, err)
+	}
 	enc, err := wire.EncodeSSZ(nil)
 	require.NoError(t, err)
 
-	var out sszPayloadStatus
+	var out engine_types.PayloadStatus
 	require.NoError(t, out.DecodeSSZ(enc, 0))
-	require.Equal(t, uint8(3), out.Status)
-	require.Equal(t, []common.Hash{latest}, out.LatestValidHash.hashes())
-	require.Equal(t, []byte("no"), out.ValidationError.Bytes())
+	require.Equal(t, engine_types.AcceptedStatus, out.Status)
+	require.NotNil(t, out.LatestValidHash)
+	require.Equal(t, latest, *out.LatestValidHash)
+	require.Equal(t, "no", out.ValidationError.Error().Error())
 }
 
 func TestSSZRESTRequestCodecsRoundTrip(t *testing.T) {
@@ -225,9 +225,9 @@ func TestSSZRESTEndpointVersionMapping(t *testing.T) {
 
 func TestSSZRESTNewPayloadV5UsesGloasPayloadSchema(t *testing.T) {
 	req := newSSZNewPayloadRequest(clparams.GloasVersion)
-	req.Payload.Block.SlotNumber = 123
-	req.Payload.Block.BlockAccessList = solid.NewByteListSSZ(sszMaxBytesPerTransaction)
-	require.NoError(t, req.Payload.Block.BlockAccessList.SetBytes([]byte{0x01, 0x02, 0x03}))
+	slot := hexutil.Uint64(123)
+	req.Payload.SlotNumber = &slot
+	req.Payload.BlockAccessList = hexutil.Bytes{0x01, 0x02, 0x03}
 
 	enc, err := req.EncodeSSZ(nil)
 	require.NoError(t, err)
@@ -237,23 +237,24 @@ func TestSSZRESTNewPayloadV5UsesGloasPayloadSchema(t *testing.T) {
 	out := newSSZNewPayloadRequest(wireVersion)
 	require.NoError(t, out.DecodeSSZ(enc, int(wireVersion)))
 
-	payload := sszToExecutionPayload(out.Payload)
+	payload := out.Payload
 	require.NotNil(t, payload.SlotNumber)
 	require.Equal(t, hexutil.Uint64(123), *payload.SlotNumber)
 	require.Equal(t, hexutil.Bytes{0x01, 0x02, 0x03}, payload.BlockAccessList)
 }
 
 func TestSSZRESTForkchoiceV4UsesGloasPayloadAttributesSchema(t *testing.T) {
-	attrs := &sszPayloadAttributes{
+	slotNumber := hexutil.Uint64(456)
+	attrs := &engine_types.PayloadAttributes{
 		Timestamp:             1,
 		SuggestedFeeRecipient: common.HexToAddress("0x1234"),
-		Withdrawals:           &sszWithdrawalList{},
-		SlotNumber:            456,
-		version:               clparams.GloasVersion,
+		Withdrawals:           nil,
+		SlotNumber:            &slotNumber,
+		SSZVersion:            clparams.GloasVersion,
 	}
 	req := &sszForkchoiceRequest{
 		version:   clparams.GloasVersion,
-		AttrsList: solid.NewDynamicListSSZ[*sszPayloadAttributes](1),
+		AttrsList: solid.NewDynamicListSSZ[*engine_types.PayloadAttributes](1),
 	}
 	req.AttrsList.Append(attrs)
 

--- a/execution/engineapi/sszrest_wire.go
+++ b/execution/engineapi/sszrest_wire.go
@@ -1,0 +1,1132 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package engineapi
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/holiman/uint256"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	ssz2 "github.com/erigontech/erigon/cl/ssz"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/clonable"
+	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/execution/engineapi/engine_types"
+	"github.com/erigontech/erigon/execution/types"
+)
+
+const (
+	sszMaxBlobHashes          = 4096
+	sszMaxGetBlobHashes       = 128
+	sszMaxExecutionRequests   = 256
+	sszMaxCapabilityNameBytes = 64
+	sszMaxCapabilities        = 64
+	sszMaxValidationError     = 1024
+	sszMaxBytesPerTransaction = 0x40000000
+	sszBlobBytes              = 0x20000
+	sszKZGBytes               = 48
+	sszCellsPerExtBlob        = 128
+	sszMaxCellProofs          = 33554432
+)
+
+var mainnetBeaconCfg = &clparams.MainnetBeaconConfig
+
+type sszPayload struct {
+	Block   *cltypes.Eth1Block
+	version clparams.StateVersion
+}
+
+func newSSZPayload(version clparams.StateVersion) *sszPayload {
+	return &sszPayload{Block: cltypes.NewEth1Block(version, mainnetBeaconCfg), version: version}
+}
+
+func (p *sszPayload) Static() bool { return false }
+
+func (p *sszPayload) EncodeSSZ(dst []byte) ([]byte, error) {
+	if p.Block == nil {
+		p.Block = cltypes.NewEth1Block(p.version, mainnetBeaconCfg)
+	}
+	return p.Block.EncodeSSZ(dst)
+}
+
+func (p *sszPayload) DecodeSSZ(buf []byte, version int) error {
+	p.version = clparams.StateVersion(version)
+	p.Block = cltypes.NewEth1Block(p.version, mainnetBeaconCfg)
+	return p.Block.DecodeSSZ(buf, version)
+}
+
+func (p *sszPayload) EncodingSizeSSZ() int {
+	if p.Block == nil {
+		return cltypes.NewEth1Block(p.version, mainnetBeaconCfg).EncodingSizeSSZ()
+	}
+	return p.Block.EncodingSizeSSZ()
+}
+func (p *sszPayload) Clone() clonable.Clonable { return newSSZPayload(p.version) }
+
+func executionPayloadToSSZ(ep *engine_types.ExecutionPayload, version clparams.StateVersion) (*sszPayload, error) {
+	block := cltypes.NewEth1Block(version, mainnetBeaconCfg)
+	block.ParentHash = ep.ParentHash
+	block.FeeRecipient = ep.FeeRecipient
+	block.StateRoot = ep.StateRoot
+	block.ReceiptsRoot = ep.ReceiptsRoot
+	if len(ep.LogsBloom) != len(block.LogsBloom) {
+		return nil, fmt.Errorf("invalid logsBloom length %d", len(ep.LogsBloom))
+	}
+	copy(block.LogsBloom[:], ep.LogsBloom)
+	block.PrevRandao = ep.PrevRandao
+	block.BlockNumber = uint64(ep.BlockNumber)
+	block.GasLimit = uint64(ep.GasLimit)
+	block.GasUsed = uint64(ep.GasUsed)
+	block.Time = uint64(ep.Timestamp)
+	block.Extra = solid.NewExtraData()
+	block.Extra.SetBytes(ep.ExtraData)
+	if ep.BaseFeePerGas != nil {
+		baseFee := uint256.MustFromBig(ep.BaseFeePerGas.ToInt())
+		baseFeeBytes := baseFee.Bytes32()
+		for i, j := 0, len(baseFeeBytes)-1; i < j; i, j = i+1, j-1 {
+			baseFeeBytes[i], baseFeeBytes[j] = baseFeeBytes[j], baseFeeBytes[i]
+		}
+		copy(block.BaseFeePerGas[:], baseFeeBytes[:])
+	}
+	block.BlockHash = ep.BlockHash
+	txs := make([][]byte, len(ep.Transactions))
+	for i, tx := range ep.Transactions {
+		txs[i] = tx
+	}
+	block.Transactions = solid.NewTransactionsSSZFromTransactions(txs)
+	if version >= clparams.CapellaVersion {
+		block.Withdrawals = solid.NewStaticListSSZ[*cltypes.Withdrawal](int(mainnetBeaconCfg.MaxWithdrawalsPerPayload), 44)
+		for _, w := range ep.Withdrawals {
+			block.Withdrawals.Append(&cltypes.Withdrawal{Index: w.Index, Validator: w.Validator, Address: w.Address, Amount: w.Amount})
+		}
+	}
+	if ep.BlobGasUsed != nil {
+		block.BlobGasUsed = uint64(*ep.BlobGasUsed)
+	}
+	if ep.ExcessBlobGas != nil {
+		block.ExcessBlobGas = uint64(*ep.ExcessBlobGas)
+	}
+	if version >= clparams.GloasVersion {
+		block.BlockAccessList = solid.NewByteListSSZ(sszMaxBytesPerTransaction)
+		if err := block.BlockAccessList.SetBytes(ep.BlockAccessList); err != nil {
+			return nil, err
+		}
+		if ep.SlotNumber != nil {
+			block.SlotNumber = uint64(*ep.SlotNumber)
+		}
+	}
+	return &sszPayload{Block: block, version: version}, nil
+}
+
+func sszToExecutionPayload(p *sszPayload) *engine_types.ExecutionPayload {
+	block := p.Block
+	baseFeeBytes := common.Copy(block.BaseFeePerGas[:])
+	for i, j := 0, len(baseFeeBytes)-1; i < j; i, j = i+1, j-1 {
+		baseFeeBytes[i], baseFeeBytes[j] = baseFeeBytes[j], baseFeeBytes[i]
+	}
+	baseFee := new(uint256.Int).SetBytes(baseFeeBytes)
+	body := block.Body()
+	ep := &engine_types.ExecutionPayload{
+		ParentHash:    block.ParentHash,
+		FeeRecipient:  block.FeeRecipient,
+		StateRoot:     block.StateRoot,
+		ReceiptsRoot:  block.ReceiptsRoot,
+		LogsBloom:     block.LogsBloom[:],
+		PrevRandao:    block.PrevRandao,
+		BlockNumber:   hexutil.Uint64(block.BlockNumber),
+		GasLimit:      hexutil.Uint64(block.GasLimit),
+		GasUsed:       hexutil.Uint64(block.GasUsed),
+		Timestamp:     hexutil.Uint64(block.Time),
+		ExtraData:     block.Extra.Bytes(),
+		BaseFeePerGas: (*hexutil.Big)(baseFee.ToBig()),
+		BlockHash:     block.BlockHash,
+		Withdrawals:   body.Withdrawals,
+	}
+	for _, tx := range body.Transactions {
+		ep.Transactions = append(ep.Transactions, tx)
+	}
+	if p.version >= clparams.DenebVersion {
+		bg, ebg := hexutil.Uint64(block.BlobGasUsed), hexutil.Uint64(block.ExcessBlobGas)
+		ep.BlobGasUsed, ep.ExcessBlobGas = &bg, &ebg
+	}
+	if p.version >= clparams.GloasVersion {
+		if block.BlockAccessList != nil {
+			ep.BlockAccessList = block.BlockAccessList.Bytes()
+		}
+		slot := hexutil.Uint64(block.SlotNumber)
+		ep.SlotNumber = &slot
+	}
+	return ep
+}
+
+type sszHashList struct {
+	List  *solid.ListSSZ[*sszHash]
+	Limit int
+}
+
+type sszHash struct{ Hash common.Hash }
+
+func (*sszHash) Static() bool                           { return true }
+func (*sszHash) EncodingSizeSSZ() int                   { return 32 }
+func (h *sszHash) EncodeSSZ(dst []byte) ([]byte, error) { return append(dst, h.Hash[:]...), nil }
+func (h *sszHash) DecodeSSZ(buf []byte, _ int) error {
+	if len(buf) < 32 {
+		return errors.New("short hash")
+	}
+	copy(h.Hash[:], buf[:32])
+	return nil
+}
+func (h *sszHash) HashSSZ() ([32]byte, error) { return h.Hash, nil }
+func (*sszHash) Clone() clonable.Clonable     { return &sszHash{} }
+
+func newSSZHashList(limit int, hashes []common.Hash) *sszHashList {
+	l := solid.NewStaticListSSZ[*sszHash](limit, 32)
+	for _, h := range hashes {
+		l.Append(&sszHash{Hash: h})
+	}
+	return &sszHashList{List: l, Limit: limit}
+}
+func (l *sszHashList) Static() bool { return false }
+func (l *sszHashList) EncodeSSZ(dst []byte) ([]byte, error) {
+	if l.List == nil {
+		l.List = solid.NewStaticListSSZ[*sszHash](l.Limit, 32)
+	}
+	return l.List.EncodeSSZ(dst)
+}
+func (l *sszHashList) DecodeSSZ(buf []byte, version int) error {
+	l.List = solid.NewStaticListSSZ[*sszHash](l.Limit, 32)
+	return l.List.DecodeSSZ(buf, version)
+}
+func (l *sszHashList) EncodingSizeSSZ() int {
+	if l.List == nil {
+		return 0
+	}
+	return l.List.EncodingSizeSSZ()
+}
+func (l *sszHashList) Clone() clonable.Clonable { return &sszHashList{Limit: l.Limit} }
+func (l *sszHashList) hashes() []common.Hash {
+	if l.List == nil {
+		return nil
+	}
+	out := make([]common.Hash, 0, l.List.Len())
+	l.List.Range(func(_ int, v *sszHash, _ int) bool { out = append(out, v.Hash); return true })
+	return out
+}
+
+type sszByteListList struct {
+	List  *solid.ListSSZ[*solid.ByteListSSZ]
+	Limit int
+}
+
+func newSSZByteListList(limit int, items []hexutil.Bytes) *sszByteListList {
+	l := solid.NewDynamicListSSZ[*solid.ByteListSSZ](limit)
+	for _, item := range items {
+		b := solid.NewByteListSSZ(sszMaxBytesPerTransaction)
+		_ = b.SetBytes(item)
+		l.Append(b)
+	}
+	return &sszByteListList{List: l, Limit: limit}
+}
+func (l *sszByteListList) Static() bool { return false }
+func (l *sszByteListList) EncodeSSZ(dst []byte) ([]byte, error) {
+	if l.List == nil {
+		l.List = solid.NewDynamicListSSZ[*solid.ByteListSSZ](l.Limit)
+	}
+	return l.List.EncodeSSZ(dst)
+}
+func (l *sszByteListList) DecodeSSZ(buf []byte, version int) error {
+	l.List = solid.NewDynamicListSSZ[*solid.ByteListSSZ](l.Limit)
+	return l.List.DecodeSSZ(buf, version)
+}
+func (l *sszByteListList) EncodingSizeSSZ() int {
+	if l.List == nil {
+		return 0
+	}
+	return l.List.EncodingSizeSSZ()
+}
+func (l *sszByteListList) Clone() clonable.Clonable { return &sszByteListList{Limit: l.Limit} }
+func (l *sszByteListList) bytes() []hexutil.Bytes {
+	if l.List == nil {
+		return nil
+	}
+	out := make([]hexutil.Bytes, 0, l.List.Len())
+	l.List.Range(func(_ int, v *solid.ByteListSSZ, _ int) bool { out = append(out, v.Bytes()); return true })
+	return out
+}
+
+type sszWithdrawalList struct {
+	List *solid.ListSSZ[*cltypes.Withdrawal]
+}
+
+func newSSZWithdrawalList(ws []*types.Withdrawal) *sszWithdrawalList {
+	l := solid.NewStaticListSSZ[*cltypes.Withdrawal](int(mainnetBeaconCfg.MaxWithdrawalsPerPayload), 44)
+	for _, w := range ws {
+		l.Append(&cltypes.Withdrawal{Index: w.Index, Validator: w.Validator, Address: w.Address, Amount: w.Amount})
+	}
+	return &sszWithdrawalList{List: l}
+}
+func (l *sszWithdrawalList) Static() bool { return false }
+func (l *sszWithdrawalList) EncodeSSZ(dst []byte) ([]byte, error) {
+	if l.List == nil {
+		l.List = solid.NewStaticListSSZ[*cltypes.Withdrawal](int(mainnetBeaconCfg.MaxWithdrawalsPerPayload), 44)
+	}
+	return l.List.EncodeSSZ(dst)
+}
+func (l *sszWithdrawalList) DecodeSSZ(buf []byte, version int) error {
+	l.List = solid.NewStaticListSSZ[*cltypes.Withdrawal](int(mainnetBeaconCfg.MaxWithdrawalsPerPayload), 44)
+	return l.List.DecodeSSZ(buf, version)
+}
+func (l *sszWithdrawalList) EncodingSizeSSZ() int {
+	if l.List == nil {
+		return 0
+	}
+	return l.List.EncodingSizeSSZ()
+}
+func (*sszWithdrawalList) Clone() clonable.Clonable { return &sszWithdrawalList{} }
+func (l *sszWithdrawalList) withdrawals() []*types.Withdrawal {
+	if l.List == nil {
+		return nil
+	}
+	out := make([]*types.Withdrawal, 0, l.List.Len())
+	l.List.Range(func(_ int, w *cltypes.Withdrawal, _ int) bool {
+		out = append(out, &types.Withdrawal{Index: w.Index, Validator: w.Validator, Address: w.Address, Amount: w.Amount})
+		return true
+	})
+	return out
+}
+
+type sszPayloadStatus struct {
+	Status          uint8
+	LatestValidHash *sszHashList
+	ValidationError *solid.ByteListSSZ
+}
+
+func (s *sszPayloadStatus) Static() bool { return false }
+func (s *sszPayloadStatus) EncodeSSZ(dst []byte) ([]byte, error) {
+	if s.LatestValidHash == nil {
+		s.LatestValidHash = newSSZHashList(1, nil)
+	}
+	if s.ValidationError == nil {
+		s.ValidationError = solid.NewByteListSSZ(sszMaxValidationError)
+	}
+	return ssz2.MarshalSSZ(dst, []byte{s.Status}, s.LatestValidHash, s.ValidationError)
+}
+func (s *sszPayloadStatus) DecodeSSZ(buf []byte, version int) error {
+	s.LatestValidHash = &sszHashList{Limit: 1}
+	s.ValidationError = solid.NewByteListSSZ(sszMaxValidationError)
+	status := []byte{0}
+	if err := ssz2.UnmarshalSSZ(buf, version, status, s.LatestValidHash, s.ValidationError); err != nil {
+		return err
+	}
+	s.Status = status[0]
+	return nil
+}
+func (s *sszPayloadStatus) EncodingSizeSSZ() int {
+	return 1 + 4 + 4 + s.LatestValidHash.EncodingSizeSSZ() + s.ValidationError.EncodingSizeSSZ()
+}
+func (*sszPayloadStatus) Clone() clonable.Clonable { return &sszPayloadStatus{} }
+
+func payloadStatusToSSZ(ps *engine_types.PayloadStatus) (*sszPayloadStatus, error) {
+	status := uint8(0)
+	switch ps.Status {
+	case engine_types.ValidStatus:
+		status = 0
+	case engine_types.InvalidStatus:
+		status = 1
+	case engine_types.SyncingStatus:
+		status = 2
+	case engine_types.AcceptedStatus:
+		status = 3
+	default:
+		return nil, fmt.Errorf("unknown payload status %q", ps.Status)
+	}
+	var latest []common.Hash
+	if ps.LatestValidHash != nil {
+		latest = []common.Hash{*ps.LatestValidHash}
+	}
+	errBytes := solid.NewByteListSSZ(sszMaxValidationError)
+	if ps.ValidationError != nil && ps.ValidationError.Error() != nil {
+		msg := []byte(ps.ValidationError.Error().Error())
+		if len(msg) > sszMaxValidationError {
+			msg = msg[:sszMaxValidationError]
+		}
+		_ = errBytes.SetBytes(msg)
+	}
+	return &sszPayloadStatus{Status: status, LatestValidHash: newSSZHashList(1, latest), ValidationError: errBytes}, nil
+}
+
+type sszForkchoiceState struct {
+	HeadHash           common.Hash
+	SafeBlockHash      common.Hash
+	FinalizedBlockHash common.Hash
+}
+
+func (*sszForkchoiceState) Static() bool         { return true }
+func (*sszForkchoiceState) EncodingSizeSSZ() int { return 96 }
+func (s *sszForkchoiceState) EncodeSSZ(dst []byte) ([]byte, error) {
+	return ssz2.MarshalSSZ(dst, s.HeadHash[:], s.SafeBlockHash[:], s.FinalizedBlockHash[:])
+}
+func (s *sszForkchoiceState) DecodeSSZ(buf []byte, version int) error {
+	return ssz2.UnmarshalSSZ(buf, version, s.HeadHash[:], s.SafeBlockHash[:], s.FinalizedBlockHash[:])
+}
+func (*sszForkchoiceState) Clone() clonable.Clonable { return &sszForkchoiceState{} }
+
+func forkchoiceStateFromEngine(s *engine_types.ForkChoiceState) sszForkchoiceState {
+	return sszForkchoiceState{HeadHash: s.HeadHash, SafeBlockHash: s.SafeBlockHash, FinalizedBlockHash: s.FinalizedBlockHash}
+}
+func (s sszForkchoiceState) engine() *engine_types.ForkChoiceState {
+	return &engine_types.ForkChoiceState{HeadHash: s.HeadHash, SafeBlockHash: s.SafeBlockHash, FinalizedBlockHash: s.FinalizedBlockHash}
+}
+
+type sszPayloadAttributes struct {
+	Timestamp             uint64
+	PrevRandao            common.Hash
+	SuggestedFeeRecipient common.Address
+	Withdrawals           *sszWithdrawalList
+	ParentBeaconBlockRoot common.Hash
+	SlotNumber            uint64
+	version               clparams.StateVersion
+}
+
+func (a *sszPayloadAttributes) Static() bool { return false }
+func (a *sszPayloadAttributes) EncodeSSZ(dst []byte) ([]byte, error) {
+	switch a.version {
+	case clparams.BellatrixVersion:
+		return ssz2.MarshalSSZ(dst, a.Timestamp, a.PrevRandao[:], a.SuggestedFeeRecipient[:])
+	case clparams.CapellaVersion:
+		return ssz2.MarshalSSZ(dst, a.Timestamp, a.PrevRandao[:], a.SuggestedFeeRecipient[:], a.Withdrawals)
+	case clparams.DenebVersion:
+		return ssz2.MarshalSSZ(dst, a.Timestamp, a.PrevRandao[:], a.SuggestedFeeRecipient[:], a.Withdrawals, a.ParentBeaconBlockRoot[:])
+	default:
+		return ssz2.MarshalSSZ(dst, a.Timestamp, a.PrevRandao[:], a.SuggestedFeeRecipient[:], a.Withdrawals, a.ParentBeaconBlockRoot[:], a.SlotNumber)
+	}
+}
+func (a *sszPayloadAttributes) DecodeSSZ(buf []byte, version int) error {
+	a.version = clparams.StateVersion(version)
+	a.Withdrawals = &sszWithdrawalList{}
+	switch a.version {
+	case clparams.BellatrixVersion:
+		return ssz2.UnmarshalSSZ(buf, version, &a.Timestamp, a.PrevRandao[:], a.SuggestedFeeRecipient[:])
+	case clparams.CapellaVersion:
+		return ssz2.UnmarshalSSZ(buf, version, &a.Timestamp, a.PrevRandao[:], a.SuggestedFeeRecipient[:], a.Withdrawals)
+	case clparams.DenebVersion:
+		return ssz2.UnmarshalSSZ(buf, version, &a.Timestamp, a.PrevRandao[:], a.SuggestedFeeRecipient[:], a.Withdrawals, a.ParentBeaconBlockRoot[:])
+	default:
+		return ssz2.UnmarshalSSZ(buf, version, &a.Timestamp, a.PrevRandao[:], a.SuggestedFeeRecipient[:], a.Withdrawals, a.ParentBeaconBlockRoot[:], &a.SlotNumber)
+	}
+}
+func (a *sszPayloadAttributes) EncodingSizeSSZ() int { b, _ := a.EncodeSSZ(nil); return len(b) }
+func (*sszPayloadAttributes) Clone() clonable.Clonable {
+	return &sszPayloadAttributes{}
+}
+func (a *sszPayloadAttributes) HashSSZ() ([32]byte, error) { return [32]byte{}, nil }
+func (a *sszPayloadAttributes) engine() *engine_types.PayloadAttributes {
+	pa := &engine_types.PayloadAttributes{Timestamp: hexutil.Uint64(a.Timestamp), PrevRandao: a.PrevRandao, SuggestedFeeRecipient: a.SuggestedFeeRecipient}
+	if a.version >= clparams.CapellaVersion {
+		pa.Withdrawals = a.Withdrawals.withdrawals()
+	}
+	if a.version >= clparams.DenebVersion {
+		root := a.ParentBeaconBlockRoot
+		pa.ParentBeaconBlockRoot = &root
+	}
+	if a.version >= clparams.GloasVersion {
+		slot := hexutil.Uint64(a.SlotNumber)
+		pa.SlotNumber = &slot
+	}
+	return pa
+}
+
+type sszForkchoiceRequest struct {
+	State     sszForkchoiceState
+	AttrsList *solid.ListSSZ[*sszPayloadAttributes]
+	version   clparams.StateVersion
+}
+
+func (r *sszForkchoiceRequest) Static() bool { return false }
+func (r *sszForkchoiceRequest) EncodeSSZ(dst []byte) ([]byte, error) {
+	if r.AttrsList == nil {
+		r.AttrsList = solid.NewDynamicListSSZ[*sszPayloadAttributes](1)
+	}
+	return ssz2.MarshalSSZ(dst, &r.State, r.AttrsList)
+}
+func (r *sszForkchoiceRequest) DecodeSSZ(buf []byte, version int) error {
+	r.version = clparams.StateVersion(version)
+	r.AttrsList = solid.NewDynamicListSSZ[*sszPayloadAttributes](1)
+	return ssz2.UnmarshalSSZ(buf, version, &r.State, r.AttrsList)
+}
+func (r *sszForkchoiceRequest) EncodingSizeSSZ() int { b, _ := r.EncodeSSZ(nil); return len(b) }
+func (r *sszForkchoiceRequest) Clone() clonable.Clonable {
+	return &sszForkchoiceRequest{version: r.version}
+}
+func (r *sszForkchoiceRequest) payloadAttributes() *engine_types.PayloadAttributes {
+	if r.AttrsList == nil || r.AttrsList.Len() == 0 {
+		return nil
+	}
+	a := r.AttrsList.Get(0)
+	a.version = r.version
+	return a.engine()
+}
+
+type sszForkchoiceResponse struct {
+	Status    *sszPayloadStatus
+	PayloadID *solid.ListSSZ[*sszBytes8]
+}
+
+type sszBytes8 struct{ Bytes [8]byte }
+
+func (*sszBytes8) Static() bool                           { return true }
+func (*sszBytes8) EncodingSizeSSZ() int                   { return 8 }
+func (b *sszBytes8) EncodeSSZ(dst []byte) ([]byte, error) { return append(dst, b.Bytes[:]...), nil }
+func (b *sszBytes8) DecodeSSZ(buf []byte, _ int) error {
+	if len(buf) < 8 {
+		return errors.New("short bytes8")
+	}
+	copy(b.Bytes[:], buf[:8])
+	return nil
+}
+func (b *sszBytes8) HashSSZ() ([32]byte, error) {
+	var h [32]byte
+	copy(h[:], b.Bytes[:])
+	return h, nil
+}
+func (*sszBytes8) Clone() clonable.Clonable { return &sszBytes8{} }
+
+func (r *sszForkchoiceResponse) Static() bool { return false }
+func (r *sszForkchoiceResponse) EncodeSSZ(dst []byte) ([]byte, error) {
+	return ssz2.MarshalSSZ(dst, r.Status, r.PayloadID)
+}
+func (r *sszForkchoiceResponse) DecodeSSZ(buf []byte, version int) error {
+	r.Status = &sszPayloadStatus{}
+	r.PayloadID = solid.NewStaticListSSZ[*sszBytes8](1, 8)
+	return ssz2.UnmarshalSSZ(buf, version, r.Status, r.PayloadID)
+}
+func (r *sszForkchoiceResponse) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
+func (*sszForkchoiceResponse) Clone() clonable.Clonable { return &sszForkchoiceResponse{} }
+
+func forkchoiceResponseToSSZ(resp *engine_types.ForkChoiceUpdatedResponse) (*sszForkchoiceResponse, error) {
+	status, err := payloadStatusToSSZ(resp.PayloadStatus)
+	if err != nil {
+		return nil, err
+	}
+	pids := solid.NewStaticListSSZ[*sszBytes8](1, 8)
+	if resp.PayloadId != nil && len(*resp.PayloadId) == 8 {
+		var id [8]byte
+		copy(id[:], *resp.PayloadId)
+		pids.Append(&sszBytes8{Bytes: id})
+	}
+	return &sszForkchoiceResponse{Status: status, PayloadID: pids}, nil
+}
+
+type sszNewPayloadRequest struct {
+	Payload               *sszPayload
+	ExpectedBlobHashes    *sszHashList
+	ParentBeaconBlockRoot common.Hash
+	ExecutionRequests     *sszByteListList
+	version               clparams.StateVersion
+}
+
+func newSSZNewPayloadRequest(version clparams.StateVersion) *sszNewPayloadRequest {
+	return &sszNewPayloadRequest{Payload: newSSZPayload(version), ExpectedBlobHashes: &sszHashList{Limit: sszMaxBlobHashes}, ExecutionRequests: &sszByteListList{Limit: sszMaxExecutionRequests}, version: version}
+}
+func (r *sszNewPayloadRequest) Static() bool { return false }
+func (r *sszNewPayloadRequest) EncodeSSZ(dst []byte) ([]byte, error) {
+	switch r.version {
+	case clparams.BellatrixVersion, clparams.CapellaVersion:
+		return ssz2.MarshalSSZ(dst, r.Payload)
+	case clparams.DenebVersion:
+		return ssz2.MarshalSSZ(dst, r.Payload, r.ExpectedBlobHashes, r.ParentBeaconBlockRoot[:])
+	default:
+		return ssz2.MarshalSSZ(dst, r.Payload, r.ExpectedBlobHashes, r.ParentBeaconBlockRoot[:], r.ExecutionRequests)
+	}
+}
+func (r *sszNewPayloadRequest) DecodeSSZ(buf []byte, version int) error {
+	r.version = clparams.StateVersion(version)
+	r.Payload = newSSZPayload(r.version)
+	r.ExpectedBlobHashes = &sszHashList{Limit: sszMaxBlobHashes}
+	r.ExecutionRequests = &sszByteListList{Limit: sszMaxExecutionRequests}
+	switch r.version {
+	case clparams.BellatrixVersion, clparams.CapellaVersion:
+		return ssz2.UnmarshalSSZ(buf, version, r.Payload)
+	case clparams.DenebVersion:
+		return ssz2.UnmarshalSSZ(buf, version, r.Payload, r.ExpectedBlobHashes, r.ParentBeaconBlockRoot[:])
+	default:
+		return ssz2.UnmarshalSSZ(buf, version, r.Payload, r.ExpectedBlobHashes, r.ParentBeaconBlockRoot[:], r.ExecutionRequests)
+	}
+}
+func (r *sszNewPayloadRequest) EncodingSizeSSZ() int     { b, _ := r.EncodeSSZ(nil); return len(b) }
+func (r *sszNewPayloadRequest) Clone() clonable.Clonable { return newSSZNewPayloadRequest(r.version) }
+
+type sszCapability struct{ Name *solid.ByteListSSZ }
+
+func newSSZCapability(s string) *sszCapability {
+	b := solid.NewByteListSSZ(sszMaxCapabilityNameBytes)
+	_ = b.SetBytes([]byte(s))
+	return &sszCapability{Name: b}
+}
+func (c *sszCapability) Static() bool { return false }
+func (c *sszCapability) EncodeSSZ(dst []byte) ([]byte, error) {
+	if c.Name == nil {
+		c.Name = solid.NewByteListSSZ(sszMaxCapabilityNameBytes)
+	}
+	return ssz2.MarshalSSZ(dst, c.Name)
+}
+func (c *sszCapability) DecodeSSZ(buf []byte, version int) error {
+	c.Name = solid.NewByteListSSZ(sszMaxCapabilityNameBytes)
+	return ssz2.UnmarshalSSZ(buf, version, c.Name)
+}
+func (c *sszCapability) EncodingSizeSSZ() int       { return 4 + c.Name.EncodingSizeSSZ() }
+func (c *sszCapability) HashSSZ() ([32]byte, error) { return c.Name.HashSSZ() }
+func (*sszCapability) Clone() clonable.Clonable {
+	return &sszCapability{Name: solid.NewByteListSSZ(sszMaxCapabilityNameBytes)}
+}
+
+type sszCapabilities struct {
+	List *solid.ListSSZ[*sszCapability]
+}
+
+func newSSZCapabilities(names []string) *sszCapabilities {
+	l := solid.NewDynamicListSSZ[*sszCapability](sszMaxCapabilities)
+	for _, name := range names {
+		l.Append(newSSZCapability(name))
+	}
+	return &sszCapabilities{List: l}
+}
+func (c *sszCapabilities) Static() bool { return false }
+func (c *sszCapabilities) EncodeSSZ(dst []byte) ([]byte, error) {
+	if c.List == nil {
+		c.List = solid.NewDynamicListSSZ[*sszCapability](sszMaxCapabilities)
+	}
+	return ssz2.MarshalSSZ(dst, c.List)
+}
+func (c *sszCapabilities) DecodeSSZ(buf []byte, version int) error {
+	c.List = solid.NewDynamicListSSZ[*sszCapability](sszMaxCapabilities)
+	return ssz2.UnmarshalSSZ(buf, version, c.List)
+}
+func (c *sszCapabilities) EncodingSizeSSZ() int   { b, _ := c.EncodeSSZ(nil); return len(b) }
+func (*sszCapabilities) Clone() clonable.Clonable { return &sszCapabilities{} }
+func (c *sszCapabilities) names() []string {
+	if c.List == nil {
+		return nil
+	}
+	out := make([]string, 0, c.List.Len())
+	c.List.Range(func(_ int, v *sszCapability, _ int) bool { out = append(out, string(v.Name.Bytes())); return true })
+	return out
+}
+
+type sszClientVersion struct {
+	Code    *solid.ByteListSSZ
+	Name    *solid.ByteListSSZ
+	Version *solid.ByteListSSZ
+	Commit  [4]byte
+}
+
+func newSSZClientVersion(v engine_types.ClientVersionV1) *sszClientVersion {
+	code, name, ver := solid.NewByteListSSZ(2), solid.NewByteListSSZ(64), solid.NewByteListSSZ(64)
+	_ = code.SetBytes([]byte(v.Code))
+	_ = name.SetBytes([]byte(v.Name))
+	_ = ver.SetBytes([]byte(v.Version))
+	var commit [4]byte
+	ch := strings.TrimPrefix(v.Commit, "0x")
+	if b, err := hex.DecodeString(ch); err == nil && len(b) >= 4 {
+		copy(commit[:], b[:4])
+	}
+	return &sszClientVersion{Code: code, Name: name, Version: ver, Commit: commit}
+}
+func (v *sszClientVersion) Static() bool { return false }
+func (v *sszClientVersion) EncodeSSZ(dst []byte) ([]byte, error) {
+	return ssz2.MarshalSSZ(dst, v.Code, v.Name, v.Version, v.Commit[:])
+}
+func (v *sszClientVersion) DecodeSSZ(buf []byte, version int) error {
+	v.Code, v.Name, v.Version = solid.NewByteListSSZ(2), solid.NewByteListSSZ(64), solid.NewByteListSSZ(64)
+	return ssz2.UnmarshalSSZ(buf, version, v.Code, v.Name, v.Version, v.Commit[:])
+}
+func (v *sszClientVersion) EncodingSizeSSZ() int       { b, _ := v.EncodeSSZ(nil); return len(b) }
+func (v *sszClientVersion) HashSSZ() ([32]byte, error) { return [32]byte{}, nil }
+func (*sszClientVersion) Clone() clonable.Clonable     { return &sszClientVersion{} }
+func (v *sszClientVersion) engine() engine_types.ClientVersionV1 {
+	return engine_types.ClientVersionV1{Code: string(v.Code.Bytes()), Name: string(v.Name.Bytes()), Version: string(v.Version.Bytes()), Commit: "0x" + hex.EncodeToString(v.Commit[:])}
+}
+
+type sszClientVersionRequest struct{ ClientVersion *sszClientVersion }
+
+func (r *sszClientVersionRequest) Static() bool { return false }
+func (r *sszClientVersionRequest) EncodeSSZ(dst []byte) ([]byte, error) {
+	return ssz2.MarshalSSZ(dst, r.ClientVersion)
+}
+func (r *sszClientVersionRequest) DecodeSSZ(buf []byte, version int) error {
+	r.ClientVersion = &sszClientVersion{}
+	return ssz2.UnmarshalSSZ(buf, version, r.ClientVersion)
+}
+func (r *sszClientVersionRequest) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
+func (*sszClientVersionRequest) Clone() clonable.Clonable { return &sszClientVersionRequest{} }
+
+type sszClientVersionResponse struct {
+	Versions *solid.ListSSZ[*sszClientVersion]
+}
+
+func newSSZClientVersionResponse(versions []engine_types.ClientVersionV1) *sszClientVersionResponse {
+	l := solid.NewDynamicListSSZ[*sszClientVersion](4)
+	for _, v := range versions {
+		l.Append(newSSZClientVersion(v))
+	}
+	return &sszClientVersionResponse{Versions: l}
+}
+func (r *sszClientVersionResponse) Static() bool { return false }
+func (r *sszClientVersionResponse) EncodeSSZ(dst []byte) ([]byte, error) {
+	return ssz2.MarshalSSZ(dst, r.Versions)
+}
+func (r *sszClientVersionResponse) DecodeSSZ(buf []byte, version int) error {
+	r.Versions = solid.NewDynamicListSSZ[*sszClientVersion](4)
+	return ssz2.UnmarshalSSZ(buf, version, r.Versions)
+}
+func (r *sszClientVersionResponse) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
+func (*sszClientVersionResponse) Clone() clonable.Clonable { return &sszClientVersionResponse{} }
+
+func blockValueBytes(v *hexutil.Big) []byte {
+	out := make([]byte, 32)
+	if v == nil {
+		return out
+	}
+	u := uint256.MustFromBig((*big.Int)(v))
+	b := u.Bytes32()
+	for i := range b {
+		out[i] = b[31-i]
+	}
+	return out
+}
+
+type sszBool struct{ Value bool }
+
+func (*sszBool) Static() bool         { return true }
+func (*sszBool) EncodingSizeSSZ() int { return 1 }
+func (b *sszBool) EncodeSSZ(dst []byte) ([]byte, error) {
+	if b.Value {
+		return append(dst, 1), nil
+	}
+	return append(dst, 0), nil
+}
+func (b *sszBool) DecodeSSZ(buf []byte, _ int) error {
+	if len(buf) < 1 {
+		return errors.New("short bool")
+	}
+	b.Value = buf[0] != 0
+	return nil
+}
+func (*sszBool) Clone() clonable.Clonable { return &sszBool{} }
+
+type sszBlobsBundle struct {
+	Commitments *solid.ListSSZ[*sszKZGVector]
+	Proofs      *solid.ListSSZ[*sszKZGVector]
+	Blobs       *solid.ListSSZ[*sszBlobVector]
+	ProofsLimit int
+}
+
+func newSSZBlobsBundle(b *engine_types.BlobsBundle, version clparams.StateVersion) *sszBlobsBundle {
+	proofsLimit := sszMaxBlobHashes
+	if version >= clparams.FuluVersion {
+		proofsLimit = sszMaxCellProofs
+	}
+	bundle := &sszBlobsBundle{
+		Commitments: solid.NewStaticListSSZ[*sszKZGVector](sszMaxBlobHashes, sszKZGBytes),
+		Proofs:      solid.NewStaticListSSZ[*sszKZGVector](proofsLimit, sszKZGBytes),
+		Blobs:       solid.NewStaticListSSZ[*sszBlobVector](sszMaxBlobHashes, sszBlobBytes),
+		ProofsLimit: proofsLimit,
+	}
+	var commitments, proofs, blobs []hexutil.Bytes
+	if b != nil {
+		commitments, proofs, blobs = b.Commitments, b.Proofs, b.Blobs
+	}
+	for _, commitment := range commitments {
+		bundle.Commitments.Append(newSSZKZGVector(commitment))
+	}
+	for _, proof := range proofs {
+		bundle.Proofs.Append(newSSZKZGVector(proof))
+	}
+	for _, blob := range blobs {
+		bundle.Blobs.Append(newSSZBlobVector(blob))
+	}
+	return bundle
+}
+func (b *sszBlobsBundle) Static() bool { return false }
+func (b *sszBlobsBundle) EncodeSSZ(dst []byte) ([]byte, error) {
+	if b.Commitments == nil {
+		if b.ProofsLimit == 0 {
+			b.ProofsLimit = sszMaxBlobHashes
+		}
+		b.Commitments = solid.NewStaticListSSZ[*sszKZGVector](sszMaxBlobHashes, sszKZGBytes)
+		b.Proofs = solid.NewStaticListSSZ[*sszKZGVector](b.ProofsLimit, sszKZGBytes)
+		b.Blobs = solid.NewStaticListSSZ[*sszBlobVector](sszMaxBlobHashes, sszBlobBytes)
+	}
+	return ssz2.MarshalSSZ(dst, b.Commitments, b.Proofs, b.Blobs)
+}
+func (b *sszBlobsBundle) DecodeSSZ(buf []byte, version int) error {
+	if b.ProofsLimit == 0 {
+		b.ProofsLimit = sszMaxBlobHashes
+	}
+	b.Commitments = solid.NewStaticListSSZ[*sszKZGVector](sszMaxBlobHashes, sszKZGBytes)
+	b.Proofs = solid.NewStaticListSSZ[*sszKZGVector](b.ProofsLimit, sszKZGBytes)
+	b.Blobs = solid.NewStaticListSSZ[*sszBlobVector](sszMaxBlobHashes, sszBlobBytes)
+	return ssz2.UnmarshalSSZ(buf, version, b.Commitments, b.Proofs, b.Blobs)
+}
+func (b *sszBlobsBundle) EncodingSizeSSZ() int   { out, _ := b.EncodeSSZ(nil); return len(out) }
+func (*sszBlobsBundle) Clone() clonable.Clonable { return &sszBlobsBundle{} }
+
+type sszGetPayloadResponse struct {
+	Payload               *sszPayload
+	BlockValue            *sszFixedBytes
+	BlobsBundle           *sszBlobsBundle
+	ShouldOverrideBuilder *sszBool
+	ExecutionRequests     *cltypes.ExecutionRequests
+	version               clparams.StateVersion
+}
+
+func newSSZGetPayloadResponse(resp *engine_types.GetPayloadResponse, version clparams.StateVersion) (*sszGetPayloadResponse, error) {
+	payload, err := executionPayloadToSSZ(resp.ExecutionPayload, version)
+	if err != nil {
+		return nil, err
+	}
+	executionRequests, err := executionRequestsFromList(resp.ExecutionRequests, version)
+	if err != nil {
+		return nil, err
+	}
+	return &sszGetPayloadResponse{
+		Payload:               payload,
+		BlockValue:            newSSZFixedBytes(32, blockValueBytes(resp.BlockValue)),
+		BlobsBundle:           newSSZBlobsBundle(resp.BlobsBundle, version),
+		ShouldOverrideBuilder: &sszBool{Value: resp.ShouldOverrideBuilder},
+		ExecutionRequests:     executionRequests,
+		version:               version,
+	}, nil
+}
+func (r *sszGetPayloadResponse) Static() bool { return false }
+func (r *sszGetPayloadResponse) EncodeSSZ(dst []byte) ([]byte, error) {
+	switch r.version {
+	case clparams.CapellaVersion:
+		return ssz2.MarshalSSZ(dst, r.Payload, r.BlockValue)
+	case clparams.DenebVersion:
+		return ssz2.MarshalSSZ(dst, r.Payload, r.BlockValue, r.BlobsBundle, r.ShouldOverrideBuilder)
+	default:
+		return ssz2.MarshalSSZ(dst, r.Payload, r.BlockValue, r.BlobsBundle, r.ShouldOverrideBuilder, r.ExecutionRequests)
+	}
+}
+func (r *sszGetPayloadResponse) DecodeSSZ(buf []byte, version int) error {
+	r.version = clparams.StateVersion(version)
+	r.Payload = newSSZPayload(r.version)
+	r.BlockValue = newSSZFixedBytes(32, nil)
+	proofsLimit := sszMaxBlobHashes
+	if r.version >= clparams.FuluVersion {
+		proofsLimit = sszMaxCellProofs
+	}
+	r.BlobsBundle = &sszBlobsBundle{ProofsLimit: proofsLimit}
+	r.ShouldOverrideBuilder = &sszBool{}
+	r.ExecutionRequests = cltypes.NewExecutionRequests(mainnetBeaconCfg)
+	switch r.version {
+	case clparams.CapellaVersion:
+		return ssz2.UnmarshalSSZ(buf, version, r.Payload, r.BlockValue)
+	case clparams.DenebVersion:
+		return ssz2.UnmarshalSSZ(buf, version, r.Payload, r.BlockValue, r.BlobsBundle, r.ShouldOverrideBuilder)
+	default:
+		return ssz2.UnmarshalSSZ(buf, version, r.Payload, r.BlockValue, r.BlobsBundle, r.ShouldOverrideBuilder, r.ExecutionRequests)
+	}
+}
+func (r *sszGetPayloadResponse) EncodingSizeSSZ() int { out, _ := r.EncodeSSZ(nil); return len(out) }
+func (r *sszGetPayloadResponse) Clone() clonable.Clonable {
+	return &sszGetPayloadResponse{version: r.version}
+}
+
+func executionRequestsFromList(requests []hexutil.Bytes, version clparams.StateVersion) (*cltypes.ExecutionRequests, error) {
+	out := cltypes.NewExecutionRequests(mainnetBeaconCfg)
+	for _, request := range requests {
+		if len(request) == 0 {
+			continue
+		}
+		data := request[1:]
+		switch request[0] {
+		case types.DepositRequestType:
+			if err := out.Deposits.DecodeSSZ(data, int(version)); err != nil {
+				return nil, err
+			}
+		case types.WithdrawalRequestType:
+			if err := out.Withdrawals.DecodeSSZ(data, int(version)); err != nil {
+				return nil, err
+			}
+		case types.ConsolidationRequestType:
+			if err := out.Consolidations.DecodeSSZ(data, int(version)); err != nil {
+				return nil, err
+			}
+		default:
+			return nil, fmt.Errorf("unknown execution request type %d", request[0])
+		}
+	}
+	return out, nil
+}
+
+type sszFixedBytes struct {
+	Bytes []byte
+	Size  int
+}
+
+func newSSZFixedBytes(size int, in []byte) *sszFixedBytes {
+	out := &sszFixedBytes{Bytes: make([]byte, size), Size: size}
+	copy(out.Bytes, in)
+	return out
+}
+func (b *sszFixedBytes) Static() bool { return true }
+func (b *sszFixedBytes) EncodingSizeSSZ() int {
+	if b.Size == 0 {
+		return len(b.Bytes)
+	}
+	return b.Size
+}
+func (b *sszFixedBytes) EncodeSSZ(dst []byte) ([]byte, error) {
+	size := b.EncodingSizeSSZ()
+	if len(b.Bytes) != size {
+		return nil, fmt.Errorf("fixed bytes length %d, want %d", len(b.Bytes), size)
+	}
+	return append(dst, b.Bytes...), nil
+}
+func (b *sszFixedBytes) DecodeSSZ(buf []byte, _ int) error {
+	size := b.EncodingSizeSSZ()
+	if len(buf) < size {
+		return errors.New("short fixed bytes")
+	}
+	b.Bytes = common.Copy(buf[:size])
+	return nil
+}
+func (b *sszFixedBytes) HashSSZ() ([32]byte, error) {
+	var h common.Hash
+	copy(h[:], b.Bytes)
+	return h, nil
+}
+func (b *sszFixedBytes) Clone() clonable.Clonable {
+	if b == nil {
+		return &sszFixedBytes{}
+	}
+	return &sszFixedBytes{Size: b.Size}
+}
+
+type sszKZGVector struct{ Bytes [sszKZGBytes]byte }
+
+func newSSZKZGVector(in []byte) *sszKZGVector {
+	var out sszKZGVector
+	copy(out.Bytes[:], in)
+	return &out
+}
+func (*sszKZGVector) Static() bool         { return true }
+func (*sszKZGVector) EncodingSizeSSZ() int { return sszKZGBytes }
+func (b *sszKZGVector) EncodeSSZ(dst []byte) ([]byte, error) {
+	return append(dst, b.Bytes[:]...), nil
+}
+func (b *sszKZGVector) DecodeSSZ(buf []byte, _ int) error {
+	if len(buf) < sszKZGBytes {
+		return errors.New("short kzg vector")
+	}
+	copy(b.Bytes[:], buf[:sszKZGBytes])
+	return nil
+}
+func (b *sszKZGVector) HashSSZ() ([32]byte, error) {
+	var h common.Hash
+	copy(h[:], b.Bytes[:])
+	return h, nil
+}
+func (*sszKZGVector) Clone() clonable.Clonable { return &sszKZGVector{} }
+
+type sszBlobVector struct{ Bytes [sszBlobBytes]byte }
+
+func newSSZBlobVector(in []byte) *sszBlobVector {
+	var out sszBlobVector
+	copy(out.Bytes[:], in)
+	return &out
+}
+func (*sszBlobVector) Static() bool         { return true }
+func (*sszBlobVector) EncodingSizeSSZ() int { return sszBlobBytes }
+func (b *sszBlobVector) EncodeSSZ(dst []byte) ([]byte, error) {
+	return append(dst, b.Bytes[:]...), nil
+}
+func (b *sszBlobVector) DecodeSSZ(buf []byte, _ int) error {
+	if len(buf) < sszBlobBytes {
+		return errors.New("short blob vector")
+	}
+	copy(b.Bytes[:], buf[:sszBlobBytes])
+	return nil
+}
+func (b *sszBlobVector) HashSSZ() ([32]byte, error) {
+	return common.Hash{}, nil
+}
+func (*sszBlobVector) Clone() clonable.Clonable { return &sszBlobVector{} }
+
+type sszBlobAndProofV1 struct {
+	Blob  *sszFixedBytes
+	Proof *sszFixedBytes
+}
+
+func newSSZBlobAndProofV1(in *engine_types.BlobAndProofV1) *sszBlobAndProofV1 {
+	return &sszBlobAndProofV1{
+		Blob:  newSSZFixedBytes(sszBlobBytes, in.Blob),
+		Proof: newSSZFixedBytes(sszKZGBytes, in.Proof),
+	}
+}
+func (*sszBlobAndProofV1) Static() bool         { return true }
+func (*sszBlobAndProofV1) EncodingSizeSSZ() int { return sszBlobBytes + sszKZGBytes }
+func (b *sszBlobAndProofV1) EncodeSSZ(dst []byte) ([]byte, error) {
+	return ssz2.MarshalSSZ(dst, b.Blob, b.Proof)
+}
+func (b *sszBlobAndProofV1) DecodeSSZ(buf []byte, version int) error {
+	b.Blob = &sszFixedBytes{Size: sszBlobBytes}
+	b.Proof = &sszFixedBytes{Size: sszKZGBytes}
+	return ssz2.UnmarshalSSZ(buf, version, b.Blob, b.Proof)
+}
+func (b *sszBlobAndProofV1) HashSSZ() ([32]byte, error) { return [32]byte{}, nil }
+func (*sszBlobAndProofV1) Clone() clonable.Clonable     { return &sszBlobAndProofV1{} }
+
+type sszGetBlobsV1Response struct {
+	BlobsAndProofs *solid.ListSSZ[*sszBlobAndProofV1]
+}
+
+func newSSZGetBlobsV1Response(blobs []*engine_types.BlobAndProofV1) *sszGetBlobsV1Response {
+	l := solid.NewStaticListSSZ[*sszBlobAndProofV1](sszMaxGetBlobHashes, sszBlobBytes+sszKZGBytes)
+	for _, blob := range blobs {
+		if blob != nil {
+			l.Append(newSSZBlobAndProofV1(blob))
+		}
+	}
+	return &sszGetBlobsV1Response{BlobsAndProofs: l}
+}
+func (r *sszGetBlobsV1Response) Static() bool { return false }
+func (r *sszGetBlobsV1Response) EncodeSSZ(dst []byte) ([]byte, error) {
+	if r.BlobsAndProofs == nil {
+		r.BlobsAndProofs = solid.NewStaticListSSZ[*sszBlobAndProofV1](sszMaxGetBlobHashes, sszBlobBytes+sszKZGBytes)
+	}
+	return ssz2.MarshalSSZ(dst, r.BlobsAndProofs)
+}
+func (r *sszGetBlobsV1Response) DecodeSSZ(buf []byte, version int) error {
+	r.BlobsAndProofs = solid.NewStaticListSSZ[*sszBlobAndProofV1](sszMaxGetBlobHashes, sszBlobBytes+sszKZGBytes)
+	return ssz2.UnmarshalSSZ(buf, version, r.BlobsAndProofs)
+}
+func (r *sszGetBlobsV1Response) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
+func (*sszGetBlobsV1Response) Clone() clonable.Clonable { return &sszGetBlobsV1Response{} }
+
+type sszBlobAndProofV2 struct {
+	Blob   *sszFixedBytes
+	Proofs *solid.ListSSZ[*sszKZGVector]
+}
+
+func newSSZBlobAndProofV2(in *engine_types.BlobAndProofV2) *sszBlobAndProofV2 {
+	proofs := solid.NewStaticListSSZ[*sszKZGVector](sszCellsPerExtBlob, sszKZGBytes)
+	for _, proof := range in.CellProofs {
+		proofs.Append(newSSZKZGVector(proof))
+	}
+	return &sszBlobAndProofV2{Blob: newSSZFixedBytes(sszBlobBytes, in.Blob), Proofs: proofs}
+}
+func (*sszBlobAndProofV2) Static() bool { return false }
+func (b *sszBlobAndProofV2) EncodeSSZ(dst []byte) ([]byte, error) {
+	if b.Proofs == nil {
+		b.Proofs = solid.NewStaticListSSZ[*sszKZGVector](sszCellsPerExtBlob, sszKZGBytes)
+	}
+	return ssz2.MarshalSSZ(dst, b.Blob, b.Proofs)
+}
+func (b *sszBlobAndProofV2) DecodeSSZ(buf []byte, version int) error {
+	b.Blob = &sszFixedBytes{Size: sszBlobBytes}
+	b.Proofs = solid.NewStaticListSSZ[*sszKZGVector](sszCellsPerExtBlob, sszKZGBytes)
+	return ssz2.UnmarshalSSZ(buf, version, b.Blob, b.Proofs)
+}
+func (b *sszBlobAndProofV2) EncodingSizeSSZ() int       { out, _ := b.EncodeSSZ(nil); return len(out) }
+func (b *sszBlobAndProofV2) HashSSZ() ([32]byte, error) { return [32]byte{}, nil }
+func (*sszBlobAndProofV2) Clone() clonable.Clonable {
+	return &sszBlobAndProofV2{Blob: &sszFixedBytes{Size: sszBlobBytes}, Proofs: solid.NewStaticListSSZ[*sszKZGVector](sszCellsPerExtBlob, sszKZGBytes)}
+}
+
+type sszGetBlobsV2Response struct {
+	BlobsAndProofs *solid.ListSSZ[*sszBlobAndProofV2]
+}
+
+func newSSZGetBlobsV2Response(blobs []*engine_types.BlobAndProofV2) *sszGetBlobsV2Response {
+	l := solid.NewDynamicListSSZ[*sszBlobAndProofV2](sszMaxGetBlobHashes)
+	for _, blob := range blobs {
+		if blob != nil {
+			l.Append(newSSZBlobAndProofV2(blob))
+		}
+	}
+	return &sszGetBlobsV2Response{BlobsAndProofs: l}
+}
+func (r *sszGetBlobsV2Response) Static() bool { return false }
+func (r *sszGetBlobsV2Response) EncodeSSZ(dst []byte) ([]byte, error) {
+	if r.BlobsAndProofs == nil {
+		r.BlobsAndProofs = solid.NewDynamicListSSZ[*sszBlobAndProofV2](sszMaxGetBlobHashes)
+	}
+	return ssz2.MarshalSSZ(dst, r.BlobsAndProofs)
+}
+func (r *sszGetBlobsV2Response) DecodeSSZ(buf []byte, version int) error {
+	r.BlobsAndProofs = solid.NewDynamicListSSZ[*sszBlobAndProofV2](sszMaxGetBlobHashes)
+	return ssz2.UnmarshalSSZ(buf, version, r.BlobsAndProofs)
+}
+func (r *sszGetBlobsV2Response) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
+func (*sszGetBlobsV2Response) Clone() clonable.Clonable { return &sszGetBlobsV2Response{} }
+
+type sszNullableBlobAndProofV2 struct {
+	BlobAndProof *solid.ListSSZ[*sszBlobAndProofV2]
+}
+
+func newSSZNullableBlobAndProofV2(blob *engine_types.BlobAndProofV2) *sszNullableBlobAndProofV2 {
+	l := solid.NewDynamicListSSZ[*sszBlobAndProofV2](1)
+	if blob != nil {
+		l.Append(newSSZBlobAndProofV2(blob))
+	}
+	return &sszNullableBlobAndProofV2{BlobAndProof: l}
+}
+func (n *sszNullableBlobAndProofV2) Static() bool { return false }
+func (n *sszNullableBlobAndProofV2) EncodeSSZ(dst []byte) ([]byte, error) {
+	if n.BlobAndProof == nil {
+		n.BlobAndProof = solid.NewDynamicListSSZ[*sszBlobAndProofV2](1)
+	}
+	return ssz2.MarshalSSZ(dst, n.BlobAndProof)
+}
+func (n *sszNullableBlobAndProofV2) DecodeSSZ(buf []byte, version int) error {
+	n.BlobAndProof = solid.NewDynamicListSSZ[*sszBlobAndProofV2](1)
+	return ssz2.UnmarshalSSZ(buf, version, n.BlobAndProof)
+}
+func (n *sszNullableBlobAndProofV2) EncodingSizeSSZ() int { b, _ := n.EncodeSSZ(nil); return len(b) }
+func (n *sszNullableBlobAndProofV2) HashSSZ() ([32]byte, error) {
+	return [32]byte{}, nil
+}
+func (*sszNullableBlobAndProofV2) Clone() clonable.Clonable {
+	return &sszNullableBlobAndProofV2{}
+}
+
+type sszGetBlobsV3Response struct {
+	BlobsAndProofs *solid.ListSSZ[*sszNullableBlobAndProofV2]
+}
+
+func newSSZGetBlobsV3Response(blobs []*engine_types.BlobAndProofV2) *sszGetBlobsV3Response {
+	l := solid.NewDynamicListSSZ[*sszNullableBlobAndProofV2](sszMaxGetBlobHashes)
+	for _, blob := range blobs {
+		l.Append(newSSZNullableBlobAndProofV2(blob))
+	}
+	return &sszGetBlobsV3Response{BlobsAndProofs: l}
+}
+func (r *sszGetBlobsV3Response) Static() bool { return false }
+func (r *sszGetBlobsV3Response) EncodeSSZ(dst []byte) ([]byte, error) {
+	if r.BlobsAndProofs == nil {
+		r.BlobsAndProofs = solid.NewDynamicListSSZ[*sszNullableBlobAndProofV2](sszMaxGetBlobHashes)
+	}
+	return ssz2.MarshalSSZ(dst, r.BlobsAndProofs)
+}
+func (r *sszGetBlobsV3Response) DecodeSSZ(buf []byte, version int) error {
+	r.BlobsAndProofs = solid.NewDynamicListSSZ[*sszNullableBlobAndProofV2](sszMaxGetBlobHashes)
+	return ssz2.UnmarshalSSZ(buf, version, r.BlobsAndProofs)
+}
+func (r *sszGetBlobsV3Response) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
+func (*sszGetBlobsV3Response) Clone() clonable.Clonable { return &sszGetBlobsV3Response{} }

--- a/execution/engineapi/sszrest_wire.go
+++ b/execution/engineapi/sszrest_wire.go
@@ -9,11 +9,9 @@
 package engineapi
 
 import (
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
-	"strings"
 
 	"github.com/holiman/uint256"
 
@@ -34,195 +32,23 @@ const (
 	sszMaxExecutionRequests   = 256
 	sszMaxCapabilityNameBytes = 64
 	sszMaxCapabilities        = 64
-	sszMaxValidationError     = 1024
 	sszMaxBytesPerTransaction = 0x40000000
 	sszBlobBytes              = 0x20000
 	sszKZGBytes               = 48
 	sszCellsPerExtBlob        = 128
-	sszMaxCellProofs          = 33554432
 )
 
 var mainnetBeaconCfg = &clparams.MainnetBeaconConfig
 
-type sszPayload struct {
-	Block   *cltypes.Eth1Block
-	version clparams.StateVersion
-}
-
-func newSSZPayload(version clparams.StateVersion) *sszPayload {
-	return &sszPayload{Block: cltypes.NewEth1Block(version, mainnetBeaconCfg), version: version}
-}
-
-func (p *sszPayload) Static() bool { return false }
-
-func (p *sszPayload) EncodeSSZ(dst []byte) ([]byte, error) {
-	if p.Block == nil {
-		p.Block = cltypes.NewEth1Block(p.version, mainnetBeaconCfg)
-	}
-	return p.Block.EncodeSSZ(dst)
-}
-
-func (p *sszPayload) DecodeSSZ(buf []byte, version int) error {
-	p.version = clparams.StateVersion(version)
-	p.Block = cltypes.NewEth1Block(p.version, mainnetBeaconCfg)
-	return p.Block.DecodeSSZ(buf, version)
-}
-
-func (p *sszPayload) EncodingSizeSSZ() int {
-	if p.Block == nil {
-		return cltypes.NewEth1Block(p.version, mainnetBeaconCfg).EncodingSizeSSZ()
-	}
-	return p.Block.EncodingSizeSSZ()
-}
-func (p *sszPayload) Clone() clonable.Clonable { return newSSZPayload(p.version) }
-
-func executionPayloadToSSZ(ep *engine_types.ExecutionPayload, version clparams.StateVersion) (*sszPayload, error) {
-	block := cltypes.NewEth1Block(version, mainnetBeaconCfg)
-	block.ParentHash = ep.ParentHash
-	block.FeeRecipient = ep.FeeRecipient
-	block.StateRoot = ep.StateRoot
-	block.ReceiptsRoot = ep.ReceiptsRoot
-	if len(ep.LogsBloom) != len(block.LogsBloom) {
-		return nil, fmt.Errorf("invalid logsBloom length %d", len(ep.LogsBloom))
-	}
-	copy(block.LogsBloom[:], ep.LogsBloom)
-	block.PrevRandao = ep.PrevRandao
-	block.BlockNumber = uint64(ep.BlockNumber)
-	block.GasLimit = uint64(ep.GasLimit)
-	block.GasUsed = uint64(ep.GasUsed)
-	block.Time = uint64(ep.Timestamp)
-	block.Extra = solid.NewExtraData()
-	block.Extra.SetBytes(ep.ExtraData)
-	if ep.BaseFeePerGas != nil {
-		baseFee := uint256.MustFromBig(ep.BaseFeePerGas.ToInt())
-		baseFeeBytes := baseFee.Bytes32()
-		for i, j := 0, len(baseFeeBytes)-1; i < j; i, j = i+1, j-1 {
-			baseFeeBytes[i], baseFeeBytes[j] = baseFeeBytes[j], baseFeeBytes[i]
-		}
-		copy(block.BaseFeePerGas[:], baseFeeBytes[:])
-	}
-	block.BlockHash = ep.BlockHash
-	txs := make([][]byte, len(ep.Transactions))
-	for i, tx := range ep.Transactions {
-		txs[i] = tx
-	}
-	block.Transactions = solid.NewTransactionsSSZFromTransactions(txs)
-	if version >= clparams.CapellaVersion {
-		block.Withdrawals = solid.NewStaticListSSZ[*cltypes.Withdrawal](int(mainnetBeaconCfg.MaxWithdrawalsPerPayload), 44)
-		for _, w := range ep.Withdrawals {
-			block.Withdrawals.Append(&cltypes.Withdrawal{Index: w.Index, Validator: w.Validator, Address: w.Address, Amount: w.Amount})
-		}
-	}
-	if ep.BlobGasUsed != nil {
-		block.BlobGasUsed = uint64(*ep.BlobGasUsed)
-	}
-	if ep.ExcessBlobGas != nil {
-		block.ExcessBlobGas = uint64(*ep.ExcessBlobGas)
-	}
-	if version >= clparams.GloasVersion {
-		block.BlockAccessList = solid.NewByteListSSZ(sszMaxBytesPerTransaction)
-		if err := block.BlockAccessList.SetBytes(ep.BlockAccessList); err != nil {
-			return nil, err
-		}
-		if ep.SlotNumber != nil {
-			block.SlotNumber = uint64(*ep.SlotNumber)
-		}
-	}
-	return &sszPayload{Block: block, version: version}, nil
-}
-
-func sszToExecutionPayload(p *sszPayload) *engine_types.ExecutionPayload {
-	block := p.Block
-	baseFeeBytes := common.Copy(block.BaseFeePerGas[:])
-	for i, j := 0, len(baseFeeBytes)-1; i < j; i, j = i+1, j-1 {
-		baseFeeBytes[i], baseFeeBytes[j] = baseFeeBytes[j], baseFeeBytes[i]
-	}
-	baseFee := new(uint256.Int).SetBytes(baseFeeBytes)
-	body := block.Body()
-	ep := &engine_types.ExecutionPayload{
-		ParentHash:    block.ParentHash,
-		FeeRecipient:  block.FeeRecipient,
-		StateRoot:     block.StateRoot,
-		ReceiptsRoot:  block.ReceiptsRoot,
-		LogsBloom:     block.LogsBloom[:],
-		PrevRandao:    block.PrevRandao,
-		BlockNumber:   hexutil.Uint64(block.BlockNumber),
-		GasLimit:      hexutil.Uint64(block.GasLimit),
-		GasUsed:       hexutil.Uint64(block.GasUsed),
-		Timestamp:     hexutil.Uint64(block.Time),
-		ExtraData:     block.Extra.Bytes(),
-		BaseFeePerGas: (*hexutil.Big)(baseFee.ToBig()),
-		BlockHash:     block.BlockHash,
-		Withdrawals:   body.Withdrawals,
-	}
-	for _, tx := range body.Transactions {
-		ep.Transactions = append(ep.Transactions, tx)
-	}
-	if p.version >= clparams.DenebVersion {
-		bg, ebg := hexutil.Uint64(block.BlobGasUsed), hexutil.Uint64(block.ExcessBlobGas)
-		ep.BlobGasUsed, ep.ExcessBlobGas = &bg, &ebg
-	}
-	if p.version >= clparams.GloasVersion {
-		if block.BlockAccessList != nil {
-			ep.BlockAccessList = block.BlockAccessList.Bytes()
-		}
-		slot := hexutil.Uint64(block.SlotNumber)
-		ep.SlotNumber = &slot
-	}
-	return ep
-}
-
-type sszHashList struct {
-	List  *solid.ListSSZ[*sszHash]
-	Limit int
-}
-
-type sszHash struct{ Hash common.Hash }
-
-func (*sszHash) Static() bool                           { return true }
-func (*sszHash) EncodingSizeSSZ() int                   { return 32 }
-func (h *sszHash) EncodeSSZ(dst []byte) ([]byte, error) { return append(dst, h.Hash[:]...), nil }
-func (h *sszHash) DecodeSSZ(buf []byte, _ int) error {
-	if len(buf) < 32 {
-		return errors.New("short hash")
-	}
-	copy(h.Hash[:], buf[:32])
-	return nil
-}
-func (h *sszHash) HashSSZ() ([32]byte, error) { return h.Hash, nil }
-func (*sszHash) Clone() clonable.Clonable     { return &sszHash{} }
-
-func newSSZHashList(limit int, hashes []common.Hash) *sszHashList {
-	l := solid.NewStaticListSSZ[*sszHash](limit, 32)
-	for _, h := range hashes {
-		l.Append(&sszHash{Hash: h})
-	}
-	return &sszHashList{List: l, Limit: limit}
-}
-func (l *sszHashList) Static() bool { return false }
-func (l *sszHashList) EncodeSSZ(dst []byte) ([]byte, error) {
-	if l.List == nil {
-		l.List = solid.NewStaticListSSZ[*sszHash](l.Limit, 32)
-	}
-	return l.List.EncodeSSZ(dst)
-}
-func (l *sszHashList) DecodeSSZ(buf []byte, version int) error {
-	l.List = solid.NewStaticListSSZ[*sszHash](l.Limit, 32)
-	return l.List.DecodeSSZ(buf, version)
-}
-func (l *sszHashList) EncodingSizeSSZ() int {
-	if l.List == nil {
-		return 0
-	}
-	return l.List.EncodingSizeSSZ()
-}
-func (l *sszHashList) Clone() clonable.Clonable { return &sszHashList{Limit: l.Limit} }
-func (l *sszHashList) hashes() []common.Hash {
-	if l.List == nil {
+func hashListValues(l solid.HashListSSZ) []common.Hash {
+	if l == nil {
 		return nil
 	}
-	out := make([]common.Hash, 0, l.List.Len())
-	l.List.Range(func(_ int, v *sszHash, _ int) bool { out = append(out, v.Hash); return true })
+	out := make([]common.Hash, 0, l.Length())
+	l.Range(func(_ int, hash common.Hash, _ int) bool {
+		out = append(out, hash)
+		return true
+	})
 	return out
 }
 
@@ -267,204 +93,22 @@ func (l *sszByteListList) bytes() []hexutil.Bytes {
 	return out
 }
 
-type sszWithdrawalList struct {
-	List *solid.ListSSZ[*cltypes.Withdrawal]
-}
-
-func newSSZWithdrawalList(ws []*types.Withdrawal) *sszWithdrawalList {
-	l := solid.NewStaticListSSZ[*cltypes.Withdrawal](int(mainnetBeaconCfg.MaxWithdrawalsPerPayload), 44)
-	for _, w := range ws {
-		l.Append(&cltypes.Withdrawal{Index: w.Index, Validator: w.Validator, Address: w.Address, Amount: w.Amount})
-	}
-	return &sszWithdrawalList{List: l}
-}
-func (l *sszWithdrawalList) Static() bool { return false }
-func (l *sszWithdrawalList) EncodeSSZ(dst []byte) ([]byte, error) {
-	if l.List == nil {
-		l.List = solid.NewStaticListSSZ[*cltypes.Withdrawal](int(mainnetBeaconCfg.MaxWithdrawalsPerPayload), 44)
-	}
-	return l.List.EncodeSSZ(dst)
-}
-func (l *sszWithdrawalList) DecodeSSZ(buf []byte, version int) error {
-	l.List = solid.NewStaticListSSZ[*cltypes.Withdrawal](int(mainnetBeaconCfg.MaxWithdrawalsPerPayload), 44)
-	return l.List.DecodeSSZ(buf, version)
-}
-func (l *sszWithdrawalList) EncodingSizeSSZ() int {
-	if l.List == nil {
-		return 0
-	}
-	return l.List.EncodingSizeSSZ()
-}
-func (*sszWithdrawalList) Clone() clonable.Clonable { return &sszWithdrawalList{} }
-func (l *sszWithdrawalList) withdrawals() []*types.Withdrawal {
-	if l.List == nil {
-		return nil
-	}
-	out := make([]*types.Withdrawal, 0, l.List.Len())
-	l.List.Range(func(_ int, w *cltypes.Withdrawal, _ int) bool {
-		out = append(out, &types.Withdrawal{Index: w.Index, Validator: w.Validator, Address: w.Address, Amount: w.Amount})
-		return true
-	})
-	return out
-}
-
-type sszPayloadStatus struct {
-	Status          uint8
-	LatestValidHash *sszHashList
-	ValidationError *solid.ByteListSSZ
-}
-
-func (s *sszPayloadStatus) Static() bool { return false }
-func (s *sszPayloadStatus) EncodeSSZ(dst []byte) ([]byte, error) {
-	if s.LatestValidHash == nil {
-		s.LatestValidHash = newSSZHashList(1, nil)
-	}
-	if s.ValidationError == nil {
-		s.ValidationError = solid.NewByteListSSZ(sszMaxValidationError)
-	}
-	return ssz2.MarshalSSZ(dst, []byte{s.Status}, s.LatestValidHash, s.ValidationError)
-}
-func (s *sszPayloadStatus) DecodeSSZ(buf []byte, version int) error {
-	s.LatestValidHash = &sszHashList{Limit: 1}
-	s.ValidationError = solid.NewByteListSSZ(sszMaxValidationError)
-	status := []byte{0}
-	if err := ssz2.UnmarshalSSZ(buf, version, status, s.LatestValidHash, s.ValidationError); err != nil {
-		return err
-	}
-	s.Status = status[0]
-	return nil
-}
-func (s *sszPayloadStatus) EncodingSizeSSZ() int {
-	return 1 + 4 + 4 + s.LatestValidHash.EncodingSizeSSZ() + s.ValidationError.EncodingSizeSSZ()
-}
-func (*sszPayloadStatus) Clone() clonable.Clonable { return &sszPayloadStatus{} }
-
-func payloadStatusToSSZ(ps *engine_types.PayloadStatus) (*sszPayloadStatus, error) {
-	status := uint8(0)
-	switch ps.Status {
-	case engine_types.ValidStatus:
-		status = 0
-	case engine_types.InvalidStatus:
-		status = 1
-	case engine_types.SyncingStatus:
-		status = 2
-	case engine_types.AcceptedStatus:
-		status = 3
-	default:
-		return nil, fmt.Errorf("unknown payload status %q", ps.Status)
-	}
-	var latest []common.Hash
-	if ps.LatestValidHash != nil {
-		latest = []common.Hash{*ps.LatestValidHash}
-	}
-	errBytes := solid.NewByteListSSZ(sszMaxValidationError)
-	if ps.ValidationError != nil && ps.ValidationError.Error() != nil {
-		msg := []byte(ps.ValidationError.Error().Error())
-		if len(msg) > sszMaxValidationError {
-			msg = msg[:sszMaxValidationError]
-		}
-		_ = errBytes.SetBytes(msg)
-	}
-	return &sszPayloadStatus{Status: status, LatestValidHash: newSSZHashList(1, latest), ValidationError: errBytes}, nil
-}
-
-type sszForkchoiceState struct {
-	HeadHash           common.Hash
-	SafeBlockHash      common.Hash
-	FinalizedBlockHash common.Hash
-}
-
-func (*sszForkchoiceState) Static() bool         { return true }
-func (*sszForkchoiceState) EncodingSizeSSZ() int { return 96 }
-func (s *sszForkchoiceState) EncodeSSZ(dst []byte) ([]byte, error) {
-	return ssz2.MarshalSSZ(dst, s.HeadHash[:], s.SafeBlockHash[:], s.FinalizedBlockHash[:])
-}
-func (s *sszForkchoiceState) DecodeSSZ(buf []byte, version int) error {
-	return ssz2.UnmarshalSSZ(buf, version, s.HeadHash[:], s.SafeBlockHash[:], s.FinalizedBlockHash[:])
-}
-func (*sszForkchoiceState) Clone() clonable.Clonable { return &sszForkchoiceState{} }
-
-func forkchoiceStateFromEngine(s *engine_types.ForkChoiceState) sszForkchoiceState {
-	return sszForkchoiceState{HeadHash: s.HeadHash, SafeBlockHash: s.SafeBlockHash, FinalizedBlockHash: s.FinalizedBlockHash}
-}
-func (s sszForkchoiceState) engine() *engine_types.ForkChoiceState {
-	return &engine_types.ForkChoiceState{HeadHash: s.HeadHash, SafeBlockHash: s.SafeBlockHash, FinalizedBlockHash: s.FinalizedBlockHash}
-}
-
-type sszPayloadAttributes struct {
-	Timestamp             uint64
-	PrevRandao            common.Hash
-	SuggestedFeeRecipient common.Address
-	Withdrawals           *sszWithdrawalList
-	ParentBeaconBlockRoot common.Hash
-	SlotNumber            uint64
-	version               clparams.StateVersion
-}
-
-func (a *sszPayloadAttributes) Static() bool { return false }
-func (a *sszPayloadAttributes) EncodeSSZ(dst []byte) ([]byte, error) {
-	switch a.version {
-	case clparams.BellatrixVersion:
-		return ssz2.MarshalSSZ(dst, a.Timestamp, a.PrevRandao[:], a.SuggestedFeeRecipient[:])
-	case clparams.CapellaVersion:
-		return ssz2.MarshalSSZ(dst, a.Timestamp, a.PrevRandao[:], a.SuggestedFeeRecipient[:], a.Withdrawals)
-	case clparams.DenebVersion:
-		return ssz2.MarshalSSZ(dst, a.Timestamp, a.PrevRandao[:], a.SuggestedFeeRecipient[:], a.Withdrawals, a.ParentBeaconBlockRoot[:])
-	default:
-		return ssz2.MarshalSSZ(dst, a.Timestamp, a.PrevRandao[:], a.SuggestedFeeRecipient[:], a.Withdrawals, a.ParentBeaconBlockRoot[:], a.SlotNumber)
-	}
-}
-func (a *sszPayloadAttributes) DecodeSSZ(buf []byte, version int) error {
-	a.version = clparams.StateVersion(version)
-	a.Withdrawals = &sszWithdrawalList{}
-	switch a.version {
-	case clparams.BellatrixVersion:
-		return ssz2.UnmarshalSSZ(buf, version, &a.Timestamp, a.PrevRandao[:], a.SuggestedFeeRecipient[:])
-	case clparams.CapellaVersion:
-		return ssz2.UnmarshalSSZ(buf, version, &a.Timestamp, a.PrevRandao[:], a.SuggestedFeeRecipient[:], a.Withdrawals)
-	case clparams.DenebVersion:
-		return ssz2.UnmarshalSSZ(buf, version, &a.Timestamp, a.PrevRandao[:], a.SuggestedFeeRecipient[:], a.Withdrawals, a.ParentBeaconBlockRoot[:])
-	default:
-		return ssz2.UnmarshalSSZ(buf, version, &a.Timestamp, a.PrevRandao[:], a.SuggestedFeeRecipient[:], a.Withdrawals, a.ParentBeaconBlockRoot[:], &a.SlotNumber)
-	}
-}
-func (a *sszPayloadAttributes) EncodingSizeSSZ() int { b, _ := a.EncodeSSZ(nil); return len(b) }
-func (*sszPayloadAttributes) Clone() clonable.Clonable {
-	return &sszPayloadAttributes{}
-}
-func (a *sszPayloadAttributes) HashSSZ() ([32]byte, error) { return [32]byte{}, nil }
-func (a *sszPayloadAttributes) engine() *engine_types.PayloadAttributes {
-	pa := &engine_types.PayloadAttributes{Timestamp: hexutil.Uint64(a.Timestamp), PrevRandao: a.PrevRandao, SuggestedFeeRecipient: a.SuggestedFeeRecipient}
-	if a.version >= clparams.CapellaVersion {
-		pa.Withdrawals = a.Withdrawals.withdrawals()
-	}
-	if a.version >= clparams.DenebVersion {
-		root := a.ParentBeaconBlockRoot
-		pa.ParentBeaconBlockRoot = &root
-	}
-	if a.version >= clparams.GloasVersion {
-		slot := hexutil.Uint64(a.SlotNumber)
-		pa.SlotNumber = &slot
-	}
-	return pa
-}
-
 type sszForkchoiceRequest struct {
-	State     sszForkchoiceState
-	AttrsList *solid.ListSSZ[*sszPayloadAttributes]
+	State     engine_types.ForkChoiceState
+	AttrsList *solid.ListSSZ[*engine_types.PayloadAttributes]
 	version   clparams.StateVersion
 }
 
 func (r *sszForkchoiceRequest) Static() bool { return false }
 func (r *sszForkchoiceRequest) EncodeSSZ(dst []byte) ([]byte, error) {
 	if r.AttrsList == nil {
-		r.AttrsList = solid.NewDynamicListSSZ[*sszPayloadAttributes](1)
+		r.AttrsList = solid.NewDynamicListSSZ[*engine_types.PayloadAttributes](1)
 	}
 	return ssz2.MarshalSSZ(dst, &r.State, r.AttrsList)
 }
 func (r *sszForkchoiceRequest) DecodeSSZ(buf []byte, version int) error {
 	r.version = clparams.StateVersion(version)
-	r.AttrsList = solid.NewDynamicListSSZ[*sszPayloadAttributes](1)
+	r.AttrsList = solid.NewDynamicListSSZ[*engine_types.PayloadAttributes](1)
 	return ssz2.UnmarshalSSZ(buf, version, &r.State, r.AttrsList)
 }
 func (r *sszForkchoiceRequest) EncodingSizeSSZ() int { b, _ := r.EncodeSSZ(nil); return len(b) }
@@ -476,12 +120,12 @@ func (r *sszForkchoiceRequest) payloadAttributes() *engine_types.PayloadAttribut
 		return nil
 	}
 	a := r.AttrsList.Get(0)
-	a.version = r.version
-	return a.engine()
+	a.SSZVersion = r.version
+	return a
 }
 
 type sszForkchoiceResponse struct {
-	Status    *sszPayloadStatus
+	Status    *engine_types.PayloadStatus
 	PayloadID *solid.ListSSZ[*sszBytes8]
 }
 
@@ -509,7 +153,7 @@ func (r *sszForkchoiceResponse) EncodeSSZ(dst []byte) ([]byte, error) {
 	return ssz2.MarshalSSZ(dst, r.Status, r.PayloadID)
 }
 func (r *sszForkchoiceResponse) DecodeSSZ(buf []byte, version int) error {
-	r.Status = &sszPayloadStatus{}
+	r.Status = &engine_types.PayloadStatus{}
 	r.PayloadID = solid.NewStaticListSSZ[*sszBytes8](1, 8)
 	return ssz2.UnmarshalSSZ(buf, version, r.Status, r.PayloadID)
 }
@@ -517,29 +161,25 @@ func (r *sszForkchoiceResponse) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(ni
 func (*sszForkchoiceResponse) Clone() clonable.Clonable { return &sszForkchoiceResponse{} }
 
 func forkchoiceResponseToSSZ(resp *engine_types.ForkChoiceUpdatedResponse) (*sszForkchoiceResponse, error) {
-	status, err := payloadStatusToSSZ(resp.PayloadStatus)
-	if err != nil {
-		return nil, err
-	}
 	pids := solid.NewStaticListSSZ[*sszBytes8](1, 8)
 	if resp.PayloadId != nil && len(*resp.PayloadId) == 8 {
 		var id [8]byte
 		copy(id[:], *resp.PayloadId)
 		pids.Append(&sszBytes8{Bytes: id})
 	}
-	return &sszForkchoiceResponse{Status: status, PayloadID: pids}, nil
+	return &sszForkchoiceResponse{Status: resp.PayloadStatus, PayloadID: pids}, nil
 }
 
 type sszNewPayloadRequest struct {
-	Payload               *sszPayload
-	ExpectedBlobHashes    *sszHashList
+	Payload               *engine_types.ExecutionPayload
+	ExpectedBlobHashes    solid.HashListSSZ
 	ParentBeaconBlockRoot common.Hash
 	ExecutionRequests     *sszByteListList
 	version               clparams.StateVersion
 }
 
 func newSSZNewPayloadRequest(version clparams.StateVersion) *sszNewPayloadRequest {
-	return &sszNewPayloadRequest{Payload: newSSZPayload(version), ExpectedBlobHashes: &sszHashList{Limit: sszMaxBlobHashes}, ExecutionRequests: &sszByteListList{Limit: sszMaxExecutionRequests}, version: version}
+	return &sszNewPayloadRequest{Payload: engine_types.NewExecutionPayloadSSZ(version), ExpectedBlobHashes: solid.NewHashList(sszMaxBlobHashes), ExecutionRequests: &sszByteListList{Limit: sszMaxExecutionRequests}, version: version}
 }
 func (r *sszNewPayloadRequest) Static() bool { return false }
 func (r *sszNewPayloadRequest) EncodeSSZ(dst []byte) ([]byte, error) {
@@ -554,8 +194,8 @@ func (r *sszNewPayloadRequest) EncodeSSZ(dst []byte) ([]byte, error) {
 }
 func (r *sszNewPayloadRequest) DecodeSSZ(buf []byte, version int) error {
 	r.version = clparams.StateVersion(version)
-	r.Payload = newSSZPayload(r.version)
-	r.ExpectedBlobHashes = &sszHashList{Limit: sszMaxBlobHashes}
+	r.Payload = engine_types.NewExecutionPayloadSSZ(r.version)
+	r.ExpectedBlobHashes = solid.NewHashList(sszMaxBlobHashes)
 	r.ExecutionRequests = &sszByteListList{Limit: sszMaxExecutionRequests}
 	switch r.version {
 	case clparams.BellatrixVersion, clparams.CapellaVersion:
@@ -626,61 +266,27 @@ func (c *sszCapabilities) names() []string {
 	return out
 }
 
-type sszClientVersion struct {
-	Code    *solid.ByteListSSZ
-	Name    *solid.ByteListSSZ
-	Version *solid.ByteListSSZ
-	Commit  [4]byte
-}
-
-func newSSZClientVersion(v engine_types.ClientVersionV1) *sszClientVersion {
-	code, name, ver := solid.NewByteListSSZ(2), solid.NewByteListSSZ(64), solid.NewByteListSSZ(64)
-	_ = code.SetBytes([]byte(v.Code))
-	_ = name.SetBytes([]byte(v.Name))
-	_ = ver.SetBytes([]byte(v.Version))
-	var commit [4]byte
-	ch := strings.TrimPrefix(v.Commit, "0x")
-	if b, err := hex.DecodeString(ch); err == nil && len(b) >= 4 {
-		copy(commit[:], b[:4])
-	}
-	return &sszClientVersion{Code: code, Name: name, Version: ver, Commit: commit}
-}
-func (v *sszClientVersion) Static() bool { return false }
-func (v *sszClientVersion) EncodeSSZ(dst []byte) ([]byte, error) {
-	return ssz2.MarshalSSZ(dst, v.Code, v.Name, v.Version, v.Commit[:])
-}
-func (v *sszClientVersion) DecodeSSZ(buf []byte, version int) error {
-	v.Code, v.Name, v.Version = solid.NewByteListSSZ(2), solid.NewByteListSSZ(64), solid.NewByteListSSZ(64)
-	return ssz2.UnmarshalSSZ(buf, version, v.Code, v.Name, v.Version, v.Commit[:])
-}
-func (v *sszClientVersion) EncodingSizeSSZ() int       { b, _ := v.EncodeSSZ(nil); return len(b) }
-func (v *sszClientVersion) HashSSZ() ([32]byte, error) { return [32]byte{}, nil }
-func (*sszClientVersion) Clone() clonable.Clonable     { return &sszClientVersion{} }
-func (v *sszClientVersion) engine() engine_types.ClientVersionV1 {
-	return engine_types.ClientVersionV1{Code: string(v.Code.Bytes()), Name: string(v.Name.Bytes()), Version: string(v.Version.Bytes()), Commit: "0x" + hex.EncodeToString(v.Commit[:])}
-}
-
-type sszClientVersionRequest struct{ ClientVersion *sszClientVersion }
+type sszClientVersionRequest struct{ ClientVersion *engine_types.ClientVersionV1 }
 
 func (r *sszClientVersionRequest) Static() bool { return false }
 func (r *sszClientVersionRequest) EncodeSSZ(dst []byte) ([]byte, error) {
 	return ssz2.MarshalSSZ(dst, r.ClientVersion)
 }
 func (r *sszClientVersionRequest) DecodeSSZ(buf []byte, version int) error {
-	r.ClientVersion = &sszClientVersion{}
+	r.ClientVersion = &engine_types.ClientVersionV1{}
 	return ssz2.UnmarshalSSZ(buf, version, r.ClientVersion)
 }
 func (r *sszClientVersionRequest) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
 func (*sszClientVersionRequest) Clone() clonable.Clonable { return &sszClientVersionRequest{} }
 
 type sszClientVersionResponse struct {
-	Versions *solid.ListSSZ[*sszClientVersion]
+	Versions *solid.ListSSZ[*engine_types.ClientVersionV1]
 }
 
 func newSSZClientVersionResponse(versions []engine_types.ClientVersionV1) *sszClientVersionResponse {
-	l := solid.NewDynamicListSSZ[*sszClientVersion](4)
-	for _, v := range versions {
-		l.Append(newSSZClientVersion(v))
+	l := solid.NewDynamicListSSZ[*engine_types.ClientVersionV1](4)
+	for i := range versions {
+		l.Append(&versions[i])
 	}
 	return &sszClientVersionResponse{Versions: l}
 }
@@ -689,7 +295,7 @@ func (r *sszClientVersionResponse) EncodeSSZ(dst []byte) ([]byte, error) {
 	return ssz2.MarshalSSZ(dst, r.Versions)
 }
 func (r *sszClientVersionResponse) DecodeSSZ(buf []byte, version int) error {
-	r.Versions = solid.NewDynamicListSSZ[*sszClientVersion](4)
+	r.Versions = solid.NewDynamicListSSZ[*engine_types.ClientVersionV1](4)
 	return ssz2.UnmarshalSSZ(buf, version, r.Versions)
 }
 func (r *sszClientVersionResponse) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
@@ -706,6 +312,14 @@ func blockValueBytes(v *hexutil.Big) []byte {
 		out[i] = b[31-i]
 	}
 	return out
+}
+
+func newBlobsBundleSSZ(b *engine_types.BlobsBundle, version clparams.StateVersion) *engine_types.BlobsBundle {
+	if b == nil {
+		return engine_types.NewBlobsBundleSSZ(version)
+	}
+	b.SSZVersion = version
+	return b
 }
 
 type sszBool struct{ Value bool }
@@ -727,77 +341,18 @@ func (b *sszBool) DecodeSSZ(buf []byte, _ int) error {
 }
 func (*sszBool) Clone() clonable.Clonable { return &sszBool{} }
 
-type sszBlobsBundle struct {
-	Commitments *solid.ListSSZ[*sszKZGVector]
-	Proofs      *solid.ListSSZ[*sszKZGVector]
-	Blobs       *solid.ListSSZ[*sszBlobVector]
-	ProofsLimit int
-}
-
-func newSSZBlobsBundle(b *engine_types.BlobsBundle, version clparams.StateVersion) *sszBlobsBundle {
-	proofsLimit := sszMaxBlobHashes
-	if version >= clparams.FuluVersion {
-		proofsLimit = sszMaxCellProofs
-	}
-	bundle := &sszBlobsBundle{
-		Commitments: solid.NewStaticListSSZ[*sszKZGVector](sszMaxBlobHashes, sszKZGBytes),
-		Proofs:      solid.NewStaticListSSZ[*sszKZGVector](proofsLimit, sszKZGBytes),
-		Blobs:       solid.NewStaticListSSZ[*sszBlobVector](sszMaxBlobHashes, sszBlobBytes),
-		ProofsLimit: proofsLimit,
-	}
-	var commitments, proofs, blobs []hexutil.Bytes
-	if b != nil {
-		commitments, proofs, blobs = b.Commitments, b.Proofs, b.Blobs
-	}
-	for _, commitment := range commitments {
-		bundle.Commitments.Append(newSSZKZGVector(commitment))
-	}
-	for _, proof := range proofs {
-		bundle.Proofs.Append(newSSZKZGVector(proof))
-	}
-	for _, blob := range blobs {
-		bundle.Blobs.Append(newSSZBlobVector(blob))
-	}
-	return bundle
-}
-func (b *sszBlobsBundle) Static() bool { return false }
-func (b *sszBlobsBundle) EncodeSSZ(dst []byte) ([]byte, error) {
-	if b.Commitments == nil {
-		if b.ProofsLimit == 0 {
-			b.ProofsLimit = sszMaxBlobHashes
-		}
-		b.Commitments = solid.NewStaticListSSZ[*sszKZGVector](sszMaxBlobHashes, sszKZGBytes)
-		b.Proofs = solid.NewStaticListSSZ[*sszKZGVector](b.ProofsLimit, sszKZGBytes)
-		b.Blobs = solid.NewStaticListSSZ[*sszBlobVector](sszMaxBlobHashes, sszBlobBytes)
-	}
-	return ssz2.MarshalSSZ(dst, b.Commitments, b.Proofs, b.Blobs)
-}
-func (b *sszBlobsBundle) DecodeSSZ(buf []byte, version int) error {
-	if b.ProofsLimit == 0 {
-		b.ProofsLimit = sszMaxBlobHashes
-	}
-	b.Commitments = solid.NewStaticListSSZ[*sszKZGVector](sszMaxBlobHashes, sszKZGBytes)
-	b.Proofs = solid.NewStaticListSSZ[*sszKZGVector](b.ProofsLimit, sszKZGBytes)
-	b.Blobs = solid.NewStaticListSSZ[*sszBlobVector](sszMaxBlobHashes, sszBlobBytes)
-	return ssz2.UnmarshalSSZ(buf, version, b.Commitments, b.Proofs, b.Blobs)
-}
-func (b *sszBlobsBundle) EncodingSizeSSZ() int   { out, _ := b.EncodeSSZ(nil); return len(out) }
-func (*sszBlobsBundle) Clone() clonable.Clonable { return &sszBlobsBundle{} }
-
 type sszGetPayloadResponse struct {
-	Payload               *sszPayload
+	Payload               *engine_types.ExecutionPayload
 	BlockValue            *sszFixedBytes
-	BlobsBundle           *sszBlobsBundle
+	BlobsBundle           *engine_types.BlobsBundle
 	ShouldOverrideBuilder *sszBool
 	ExecutionRequests     *cltypes.ExecutionRequests
 	version               clparams.StateVersion
 }
 
 func newSSZGetPayloadResponse(resp *engine_types.GetPayloadResponse, version clparams.StateVersion) (*sszGetPayloadResponse, error) {
-	payload, err := executionPayloadToSSZ(resp.ExecutionPayload, version)
-	if err != nil {
-		return nil, err
-	}
+	payload := resp.ExecutionPayload
+	payload.SSZVersion = version
 	executionRequests, err := executionRequestsFromList(resp.ExecutionRequests, version)
 	if err != nil {
 		return nil, err
@@ -805,7 +360,7 @@ func newSSZGetPayloadResponse(resp *engine_types.GetPayloadResponse, version clp
 	return &sszGetPayloadResponse{
 		Payload:               payload,
 		BlockValue:            newSSZFixedBytes(32, blockValueBytes(resp.BlockValue)),
-		BlobsBundle:           newSSZBlobsBundle(resp.BlobsBundle, version),
+		BlobsBundle:           newBlobsBundleSSZ(resp.BlobsBundle, version),
 		ShouldOverrideBuilder: &sszBool{Value: resp.ShouldOverrideBuilder},
 		ExecutionRequests:     executionRequests,
 		version:               version,
@@ -824,13 +379,9 @@ func (r *sszGetPayloadResponse) EncodeSSZ(dst []byte) ([]byte, error) {
 }
 func (r *sszGetPayloadResponse) DecodeSSZ(buf []byte, version int) error {
 	r.version = clparams.StateVersion(version)
-	r.Payload = newSSZPayload(r.version)
+	r.Payload = engine_types.NewExecutionPayloadSSZ(r.version)
 	r.BlockValue = newSSZFixedBytes(32, nil)
-	proofsLimit := sszMaxBlobHashes
-	if r.version >= clparams.FuluVersion {
-		proofsLimit = sszMaxCellProofs
-	}
-	r.BlobsBundle = &sszBlobsBundle{ProofsLimit: proofsLimit}
+	r.BlobsBundle = engine_types.NewBlobsBundleSSZ(r.version)
 	r.ShouldOverrideBuilder = &sszBool{}
 	r.ExecutionRequests = cltypes.NewExecutionRequests(mainnetBeaconCfg)
 	switch r.version {
@@ -918,89 +469,15 @@ func (b *sszFixedBytes) Clone() clonable.Clonable {
 	return &sszFixedBytes{Size: b.Size}
 }
 
-type sszKZGVector struct{ Bytes [sszKZGBytes]byte }
-
-func newSSZKZGVector(in []byte) *sszKZGVector {
-	var out sszKZGVector
-	copy(out.Bytes[:], in)
-	return &out
-}
-func (*sszKZGVector) Static() bool         { return true }
-func (*sszKZGVector) EncodingSizeSSZ() int { return sszKZGBytes }
-func (b *sszKZGVector) EncodeSSZ(dst []byte) ([]byte, error) {
-	return append(dst, b.Bytes[:]...), nil
-}
-func (b *sszKZGVector) DecodeSSZ(buf []byte, _ int) error {
-	if len(buf) < sszKZGBytes {
-		return errors.New("short kzg vector")
-	}
-	copy(b.Bytes[:], buf[:sszKZGBytes])
-	return nil
-}
-func (b *sszKZGVector) HashSSZ() ([32]byte, error) {
-	var h common.Hash
-	copy(h[:], b.Bytes[:])
-	return h, nil
-}
-func (*sszKZGVector) Clone() clonable.Clonable { return &sszKZGVector{} }
-
-type sszBlobVector struct{ Bytes [sszBlobBytes]byte }
-
-func newSSZBlobVector(in []byte) *sszBlobVector {
-	var out sszBlobVector
-	copy(out.Bytes[:], in)
-	return &out
-}
-func (*sszBlobVector) Static() bool         { return true }
-func (*sszBlobVector) EncodingSizeSSZ() int { return sszBlobBytes }
-func (b *sszBlobVector) EncodeSSZ(dst []byte) ([]byte, error) {
-	return append(dst, b.Bytes[:]...), nil
-}
-func (b *sszBlobVector) DecodeSSZ(buf []byte, _ int) error {
-	if len(buf) < sszBlobBytes {
-		return errors.New("short blob vector")
-	}
-	copy(b.Bytes[:], buf[:sszBlobBytes])
-	return nil
-}
-func (b *sszBlobVector) HashSSZ() ([32]byte, error) {
-	return common.Hash{}, nil
-}
-func (*sszBlobVector) Clone() clonable.Clonable { return &sszBlobVector{} }
-
-type sszBlobAndProofV1 struct {
-	Blob  *sszFixedBytes
-	Proof *sszFixedBytes
-}
-
-func newSSZBlobAndProofV1(in *engine_types.BlobAndProofV1) *sszBlobAndProofV1 {
-	return &sszBlobAndProofV1{
-		Blob:  newSSZFixedBytes(sszBlobBytes, in.Blob),
-		Proof: newSSZFixedBytes(sszKZGBytes, in.Proof),
-	}
-}
-func (*sszBlobAndProofV1) Static() bool         { return true }
-func (*sszBlobAndProofV1) EncodingSizeSSZ() int { return sszBlobBytes + sszKZGBytes }
-func (b *sszBlobAndProofV1) EncodeSSZ(dst []byte) ([]byte, error) {
-	return ssz2.MarshalSSZ(dst, b.Blob, b.Proof)
-}
-func (b *sszBlobAndProofV1) DecodeSSZ(buf []byte, version int) error {
-	b.Blob = &sszFixedBytes{Size: sszBlobBytes}
-	b.Proof = &sszFixedBytes{Size: sszKZGBytes}
-	return ssz2.UnmarshalSSZ(buf, version, b.Blob, b.Proof)
-}
-func (b *sszBlobAndProofV1) HashSSZ() ([32]byte, error) { return [32]byte{}, nil }
-func (*sszBlobAndProofV1) Clone() clonable.Clonable     { return &sszBlobAndProofV1{} }
-
 type sszGetBlobsV1Response struct {
-	BlobsAndProofs *solid.ListSSZ[*sszBlobAndProofV1]
+	BlobsAndProofs *solid.ListSSZ[*engine_types.BlobAndProofV1]
 }
 
 func newSSZGetBlobsV1Response(blobs []*engine_types.BlobAndProofV1) *sszGetBlobsV1Response {
-	l := solid.NewStaticListSSZ[*sszBlobAndProofV1](sszMaxGetBlobHashes, sszBlobBytes+sszKZGBytes)
+	l := solid.NewStaticListSSZ[*engine_types.BlobAndProofV1](sszMaxGetBlobHashes, sszBlobBytes+sszKZGBytes)
 	for _, blob := range blobs {
 		if blob != nil {
-			l.Append(newSSZBlobAndProofV1(blob))
+			l.Append(blob)
 		}
 	}
 	return &sszGetBlobsV1Response{BlobsAndProofs: l}
@@ -1008,56 +485,26 @@ func newSSZGetBlobsV1Response(blobs []*engine_types.BlobAndProofV1) *sszGetBlobs
 func (r *sszGetBlobsV1Response) Static() bool { return false }
 func (r *sszGetBlobsV1Response) EncodeSSZ(dst []byte) ([]byte, error) {
 	if r.BlobsAndProofs == nil {
-		r.BlobsAndProofs = solid.NewStaticListSSZ[*sszBlobAndProofV1](sszMaxGetBlobHashes, sszBlobBytes+sszKZGBytes)
+		r.BlobsAndProofs = solid.NewStaticListSSZ[*engine_types.BlobAndProofV1](sszMaxGetBlobHashes, sszBlobBytes+sszKZGBytes)
 	}
 	return ssz2.MarshalSSZ(dst, r.BlobsAndProofs)
 }
 func (r *sszGetBlobsV1Response) DecodeSSZ(buf []byte, version int) error {
-	r.BlobsAndProofs = solid.NewStaticListSSZ[*sszBlobAndProofV1](sszMaxGetBlobHashes, sszBlobBytes+sszKZGBytes)
+	r.BlobsAndProofs = solid.NewStaticListSSZ[*engine_types.BlobAndProofV1](sszMaxGetBlobHashes, sszBlobBytes+sszKZGBytes)
 	return ssz2.UnmarshalSSZ(buf, version, r.BlobsAndProofs)
 }
 func (r *sszGetBlobsV1Response) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
 func (*sszGetBlobsV1Response) Clone() clonable.Clonable { return &sszGetBlobsV1Response{} }
 
-type sszBlobAndProofV2 struct {
-	Blob   *sszFixedBytes
-	Proofs *solid.ListSSZ[*sszKZGVector]
-}
-
-func newSSZBlobAndProofV2(in *engine_types.BlobAndProofV2) *sszBlobAndProofV2 {
-	proofs := solid.NewStaticListSSZ[*sszKZGVector](sszCellsPerExtBlob, sszKZGBytes)
-	for _, proof := range in.CellProofs {
-		proofs.Append(newSSZKZGVector(proof))
-	}
-	return &sszBlobAndProofV2{Blob: newSSZFixedBytes(sszBlobBytes, in.Blob), Proofs: proofs}
-}
-func (*sszBlobAndProofV2) Static() bool { return false }
-func (b *sszBlobAndProofV2) EncodeSSZ(dst []byte) ([]byte, error) {
-	if b.Proofs == nil {
-		b.Proofs = solid.NewStaticListSSZ[*sszKZGVector](sszCellsPerExtBlob, sszKZGBytes)
-	}
-	return ssz2.MarshalSSZ(dst, b.Blob, b.Proofs)
-}
-func (b *sszBlobAndProofV2) DecodeSSZ(buf []byte, version int) error {
-	b.Blob = &sszFixedBytes{Size: sszBlobBytes}
-	b.Proofs = solid.NewStaticListSSZ[*sszKZGVector](sszCellsPerExtBlob, sszKZGBytes)
-	return ssz2.UnmarshalSSZ(buf, version, b.Blob, b.Proofs)
-}
-func (b *sszBlobAndProofV2) EncodingSizeSSZ() int       { out, _ := b.EncodeSSZ(nil); return len(out) }
-func (b *sszBlobAndProofV2) HashSSZ() ([32]byte, error) { return [32]byte{}, nil }
-func (*sszBlobAndProofV2) Clone() clonable.Clonable {
-	return &sszBlobAndProofV2{Blob: &sszFixedBytes{Size: sszBlobBytes}, Proofs: solid.NewStaticListSSZ[*sszKZGVector](sszCellsPerExtBlob, sszKZGBytes)}
-}
-
 type sszGetBlobsV2Response struct {
-	BlobsAndProofs *solid.ListSSZ[*sszBlobAndProofV2]
+	BlobsAndProofs *solid.ListSSZ[*engine_types.BlobAndProofV2]
 }
 
 func newSSZGetBlobsV2Response(blobs []*engine_types.BlobAndProofV2) *sszGetBlobsV2Response {
-	l := solid.NewDynamicListSSZ[*sszBlobAndProofV2](sszMaxGetBlobHashes)
+	l := solid.NewDynamicListSSZ[*engine_types.BlobAndProofV2](sszMaxGetBlobHashes)
 	for _, blob := range blobs {
 		if blob != nil {
-			l.Append(newSSZBlobAndProofV2(blob))
+			l.Append(blob)
 		}
 	}
 	return &sszGetBlobsV2Response{BlobsAndProofs: l}
@@ -1065,37 +512,37 @@ func newSSZGetBlobsV2Response(blobs []*engine_types.BlobAndProofV2) *sszGetBlobs
 func (r *sszGetBlobsV2Response) Static() bool { return false }
 func (r *sszGetBlobsV2Response) EncodeSSZ(dst []byte) ([]byte, error) {
 	if r.BlobsAndProofs == nil {
-		r.BlobsAndProofs = solid.NewDynamicListSSZ[*sszBlobAndProofV2](sszMaxGetBlobHashes)
+		r.BlobsAndProofs = solid.NewDynamicListSSZ[*engine_types.BlobAndProofV2](sszMaxGetBlobHashes)
 	}
 	return ssz2.MarshalSSZ(dst, r.BlobsAndProofs)
 }
 func (r *sszGetBlobsV2Response) DecodeSSZ(buf []byte, version int) error {
-	r.BlobsAndProofs = solid.NewDynamicListSSZ[*sszBlobAndProofV2](sszMaxGetBlobHashes)
+	r.BlobsAndProofs = solid.NewDynamicListSSZ[*engine_types.BlobAndProofV2](sszMaxGetBlobHashes)
 	return ssz2.UnmarshalSSZ(buf, version, r.BlobsAndProofs)
 }
 func (r *sszGetBlobsV2Response) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
 func (*sszGetBlobsV2Response) Clone() clonable.Clonable { return &sszGetBlobsV2Response{} }
 
 type sszNullableBlobAndProofV2 struct {
-	BlobAndProof *solid.ListSSZ[*sszBlobAndProofV2]
+	BlobAndProof *solid.ListSSZ[*engine_types.BlobAndProofV2]
 }
 
 func newSSZNullableBlobAndProofV2(blob *engine_types.BlobAndProofV2) *sszNullableBlobAndProofV2 {
-	l := solid.NewDynamicListSSZ[*sszBlobAndProofV2](1)
+	l := solid.NewDynamicListSSZ[*engine_types.BlobAndProofV2](1)
 	if blob != nil {
-		l.Append(newSSZBlobAndProofV2(blob))
+		l.Append(blob)
 	}
 	return &sszNullableBlobAndProofV2{BlobAndProof: l}
 }
 func (n *sszNullableBlobAndProofV2) Static() bool { return false }
 func (n *sszNullableBlobAndProofV2) EncodeSSZ(dst []byte) ([]byte, error) {
 	if n.BlobAndProof == nil {
-		n.BlobAndProof = solid.NewDynamicListSSZ[*sszBlobAndProofV2](1)
+		n.BlobAndProof = solid.NewDynamicListSSZ[*engine_types.BlobAndProofV2](1)
 	}
 	return ssz2.MarshalSSZ(dst, n.BlobAndProof)
 }
 func (n *sszNullableBlobAndProofV2) DecodeSSZ(buf []byte, version int) error {
-	n.BlobAndProof = solid.NewDynamicListSSZ[*sszBlobAndProofV2](1)
+	n.BlobAndProof = solid.NewDynamicListSSZ[*engine_types.BlobAndProofV2](1)
 	return ssz2.UnmarshalSSZ(buf, version, n.BlobAndProof)
 }
 func (n *sszNullableBlobAndProofV2) EncodingSizeSSZ() int { b, _ := n.EncodeSSZ(nil); return len(b) }

--- a/execution/engineapi/sszrest_wire.go
+++ b/execution/engineapi/sszrest_wire.go
@@ -9,7 +9,7 @@
 package engineapi
 
 import (
-	"errors"
+	"encoding/binary"
 	"fmt"
 	"math/big"
 
@@ -62,29 +62,29 @@ func transactionsBytes(txs *solid.TransactionsSSZ) []hexutil.Bytes {
 	return out
 }
 
-type sszForkchoiceRequest struct {
+type forkchoiceRequest struct {
 	State     engine_types.ForkChoiceState
 	AttrsList *solid.ListSSZ[*engine_types.PayloadAttributes]
 	version   clparams.StateVersion
 }
 
-func (r *sszForkchoiceRequest) Static() bool { return false }
-func (r *sszForkchoiceRequest) EncodeSSZ(dst []byte) ([]byte, error) {
+func (r *forkchoiceRequest) Static() bool { return false }
+func (r *forkchoiceRequest) EncodeSSZ(dst []byte) ([]byte, error) {
 	if r.AttrsList == nil {
 		r.AttrsList = solid.NewDynamicListSSZ[*engine_types.PayloadAttributes](1)
 	}
 	return ssz2.MarshalSSZ(dst, &r.State, r.AttrsList)
 }
-func (r *sszForkchoiceRequest) DecodeSSZ(buf []byte, version int) error {
+func (r *forkchoiceRequest) DecodeSSZ(buf []byte, version int) error {
 	r.version = clparams.StateVersion(version)
 	r.AttrsList = solid.NewDynamicListSSZ[*engine_types.PayloadAttributes](1)
 	return ssz2.UnmarshalSSZ(buf, version, &r.State, r.AttrsList)
 }
-func (r *sszForkchoiceRequest) EncodingSizeSSZ() int { b, _ := r.EncodeSSZ(nil); return len(b) }
-func (r *sszForkchoiceRequest) Clone() clonable.Clonable {
-	return &sszForkchoiceRequest{version: r.version}
+func (r *forkchoiceRequest) EncodingSizeSSZ() int { b, _ := r.EncodeSSZ(nil); return len(b) }
+func (r *forkchoiceRequest) Clone() clonable.Clonable {
+	return &forkchoiceRequest{version: r.version}
 }
-func (r *sszForkchoiceRequest) payloadAttributes() *engine_types.PayloadAttributes {
+func (r *forkchoiceRequest) payloadAttributes() *engine_types.PayloadAttributes {
 	if r.AttrsList == nil || r.AttrsList.Len() == 0 {
 		return nil
 	}
@@ -93,53 +93,53 @@ func (r *sszForkchoiceRequest) payloadAttributes() *engine_types.PayloadAttribut
 	return a
 }
 
-type sszForkchoiceResponse struct {
+type forkchoiceResponse struct {
 	Status    *engine_types.PayloadStatus
-	PayloadID *solid.ListSSZ[*sszBytes8]
+	PayloadID *solid.ByteListSSZ
 }
 
-type sszBytes8 struct{ Bytes [8]byte }
-
-func (*sszBytes8) Static() bool                           { return true }
-func (*sszBytes8) EncodingSizeSSZ() int                   { return 8 }
-func (b *sszBytes8) EncodeSSZ(dst []byte) ([]byte, error) { return append(dst, b.Bytes[:]...), nil }
-func (b *sszBytes8) DecodeSSZ(buf []byte, _ int) error {
-	if len(buf) < 8 {
-		return errors.New("short bytes8")
+func validatePayloadIDList(id *solid.ByteListSSZ) error {
+	if id == nil {
+		return nil
 	}
-	copy(b.Bytes[:], buf[:8])
+	if l := id.Len(); l != 0 && l != 8 {
+		return fmt.Errorf("payload ID length %d, want 0 or 8", l)
+	}
 	return nil
 }
-func (b *sszBytes8) HashSSZ() ([32]byte, error) {
-	var h [32]byte
-	copy(h[:], b.Bytes[:])
-	return h, nil
-}
-func (*sszBytes8) Clone() clonable.Clonable { return &sszBytes8{} }
 
-func (r *sszForkchoiceResponse) Static() bool { return false }
-func (r *sszForkchoiceResponse) EncodeSSZ(dst []byte) ([]byte, error) {
+func (r *forkchoiceResponse) Static() bool { return false }
+func (r *forkchoiceResponse) EncodeSSZ(dst []byte) ([]byte, error) {
+	if r.PayloadID == nil {
+		r.PayloadID = solid.NewByteListSSZ(8)
+	}
+	if err := validatePayloadIDList(r.PayloadID); err != nil {
+		return nil, err
+	}
 	return ssz2.MarshalSSZ(dst, r.Status, r.PayloadID)
 }
-func (r *sszForkchoiceResponse) DecodeSSZ(buf []byte, version int) error {
+func (r *forkchoiceResponse) DecodeSSZ(buf []byte, version int) error {
 	r.Status = &engine_types.PayloadStatus{}
-	r.PayloadID = solid.NewStaticListSSZ[*sszBytes8](1, 8)
-	return ssz2.UnmarshalSSZ(buf, version, r.Status, r.PayloadID)
-}
-func (r *sszForkchoiceResponse) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
-func (*sszForkchoiceResponse) Clone() clonable.Clonable { return &sszForkchoiceResponse{} }
-
-func forkchoiceResponseToSSZ(resp *engine_types.ForkChoiceUpdatedResponse) (*sszForkchoiceResponse, error) {
-	pids := solid.NewStaticListSSZ[*sszBytes8](1, 8)
-	if resp.PayloadId != nil && len(*resp.PayloadId) == 8 {
-		var id [8]byte
-		copy(id[:], *resp.PayloadId)
-		pids.Append(&sszBytes8{Bytes: id})
+	r.PayloadID = solid.NewByteListSSZ(8)
+	if err := ssz2.UnmarshalSSZ(buf, version, r.Status, r.PayloadID); err != nil {
+		return err
 	}
-	return &sszForkchoiceResponse{Status: resp.PayloadStatus, PayloadID: pids}, nil
+	return validatePayloadIDList(r.PayloadID)
+}
+func (r *forkchoiceResponse) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
+func (*forkchoiceResponse) Clone() clonable.Clonable { return &forkchoiceResponse{} }
+
+func forkchoiceResponseToSSZ(resp *engine_types.ForkChoiceUpdatedResponse) (*forkchoiceResponse, error) {
+	pid := solid.NewByteListSSZ(8)
+	if resp.PayloadId != nil && len(*resp.PayloadId) == 8 {
+		if err := pid.SetBytes(*resp.PayloadId); err != nil {
+			return nil, err
+		}
+	}
+	return &forkchoiceResponse{Status: resp.PayloadStatus, PayloadID: pid}, nil
 }
 
-type sszNewPayloadRequest struct {
+type newPayloadRequest struct {
 	Payload               *engine_types.ExecutionPayload
 	ExpectedBlobHashes    solid.HashListSSZ
 	ParentBeaconBlockRoot common.Hash
@@ -147,11 +147,11 @@ type sszNewPayloadRequest struct {
 	version               clparams.StateVersion
 }
 
-func newSSZNewPayloadRequest(version clparams.StateVersion) *sszNewPayloadRequest {
-	return &sszNewPayloadRequest{Payload: engine_types.NewExecutionPayloadSSZ(version), ExpectedBlobHashes: solid.NewHashList(sszMaxBlobHashes), ExecutionRequests: &solid.TransactionsSSZ{}, version: version}
+func newSSZNewPayloadRequest(version clparams.StateVersion) *newPayloadRequest {
+	return &newPayloadRequest{Payload: engine_types.NewExecutionPayloadSSZ(version), ExpectedBlobHashes: solid.NewHashList(sszMaxBlobHashes), ExecutionRequests: &solid.TransactionsSSZ{}, version: version}
 }
-func (r *sszNewPayloadRequest) Static() bool { return false }
-func (r *sszNewPayloadRequest) EncodeSSZ(dst []byte) ([]byte, error) {
+func (r *newPayloadRequest) Static() bool { return false }
+func (r *newPayloadRequest) EncodeSSZ(dst []byte) ([]byte, error) {
 	switch r.version {
 	case clparams.BellatrixVersion, clparams.CapellaVersion:
 		return ssz2.MarshalSSZ(dst, r.Payload)
@@ -161,7 +161,7 @@ func (r *sszNewPayloadRequest) EncodeSSZ(dst []byte) ([]byte, error) {
 		return ssz2.MarshalSSZ(dst, r.Payload, r.ExpectedBlobHashes, r.ParentBeaconBlockRoot[:], r.ExecutionRequests)
 	}
 }
-func (r *sszNewPayloadRequest) DecodeSSZ(buf []byte, version int) error {
+func (r *newPayloadRequest) DecodeSSZ(buf []byte, version int) error {
 	r.version = clparams.StateVersion(version)
 	r.Payload = engine_types.NewExecutionPayloadSSZ(r.version)
 	r.ExpectedBlobHashes = solid.NewHashList(sszMaxBlobHashes)
@@ -175,100 +175,136 @@ func (r *sszNewPayloadRequest) DecodeSSZ(buf []byte, version int) error {
 		return ssz2.UnmarshalSSZ(buf, version, r.Payload, r.ExpectedBlobHashes, r.ParentBeaconBlockRoot[:], r.ExecutionRequests)
 	}
 }
-func (r *sszNewPayloadRequest) EncodingSizeSSZ() int     { b, _ := r.EncodeSSZ(nil); return len(b) }
-func (r *sszNewPayloadRequest) Clone() clonable.Clonable { return newSSZNewPayloadRequest(r.version) }
+func (r *newPayloadRequest) EncodingSizeSSZ() int     { b, _ := r.EncodeSSZ(nil); return len(b) }
+func (r *newPayloadRequest) Clone() clonable.Clonable { return newSSZNewPayloadRequest(r.version) }
 
-type sszCapability struct{ Name *solid.ByteListSSZ }
-
-func newSSZCapability(s string) *sszCapability {
+func capabilityName(s string) *solid.ByteListSSZ {
 	b := solid.NewByteListSSZ(sszMaxCapabilityNameBytes)
 	_ = b.SetBytes([]byte(s))
-	return &sszCapability{Name: b}
-}
-func (c *sszCapability) Static() bool { return false }
-func (c *sszCapability) EncodeSSZ(dst []byte) ([]byte, error) {
-	if c.Name == nil {
-		c.Name = solid.NewByteListSSZ(sszMaxCapabilityNameBytes)
-	}
-	return ssz2.MarshalSSZ(dst, c.Name)
-}
-func (c *sszCapability) DecodeSSZ(buf []byte, version int) error {
-	c.Name = solid.NewByteListSSZ(sszMaxCapabilityNameBytes)
-	return ssz2.UnmarshalSSZ(buf, version, c.Name)
-}
-func (c *sszCapability) EncodingSizeSSZ() int       { return 4 + c.Name.EncodingSizeSSZ() }
-func (c *sszCapability) HashSSZ() ([32]byte, error) { return c.Name.HashSSZ() }
-func (*sszCapability) Clone() clonable.Clonable {
-	return &sszCapability{Name: solid.NewByteListSSZ(sszMaxCapabilityNameBytes)}
+	return b
 }
 
-type sszCapabilities struct {
-	List *solid.ListSSZ[*sszCapability]
+type capabilities struct {
+	List []*solid.ByteListSSZ
 }
 
-func newSSZCapabilities(names []string) *sszCapabilities {
-	l := solid.NewDynamicListSSZ[*sszCapability](sszMaxCapabilities)
+func newSSZCapabilities(names []string) *capabilities {
+	l := make([]*solid.ByteListSSZ, 0, len(names))
 	for _, name := range names {
-		l.Append(newSSZCapability(name))
+		l = append(l, capabilityName(name))
 	}
-	return &sszCapabilities{List: l}
+	return &capabilities{List: l}
 }
-func (c *sszCapabilities) Static() bool { return false }
-func (c *sszCapabilities) EncodeSSZ(dst []byte) ([]byte, error) {
-	if c.List == nil {
-		c.List = solid.NewDynamicListSSZ[*sszCapability](sszMaxCapabilities)
+func (c *capabilities) Static() bool { return false }
+func (c *capabilities) EncodeSSZ(dst []byte) ([]byte, error) {
+	if len(c.List) > sszMaxCapabilities {
+		return nil, fmt.Errorf("too many capabilities: %d", len(c.List))
 	}
-	return ssz2.MarshalSSZ(dst, c.List)
+	offset := len(c.List) * 4
+	for _, capability := range c.List {
+		if capability == nil {
+			capability = solid.NewByteListSSZ(sszMaxCapabilityNameBytes)
+		}
+		dst = append(dst, 0, 0, 0, 0)
+		binary.LittleEndian.PutUint32(dst[len(dst)-4:], uint32(offset))
+		offset += capability.EncodingSizeSSZ()
+	}
+	for _, capability := range c.List {
+		if capability == nil {
+			capability = solid.NewByteListSSZ(sszMaxCapabilityNameBytes)
+		}
+		var err error
+		dst, err = capability.EncodeSSZ(dst)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return dst, nil
 }
-func (c *sszCapabilities) DecodeSSZ(buf []byte, version int) error {
-	c.List = solid.NewDynamicListSSZ[*sszCapability](sszMaxCapabilities)
-	return ssz2.UnmarshalSSZ(buf, version, c.List)
+func (c *capabilities) DecodeSSZ(buf []byte, version int) error {
+	c.List = nil
+	if len(buf) == 0 {
+		return nil
+	}
+	if len(buf) < 4 {
+		return fmt.Errorf("capabilities: short offset table")
+	}
+	firstOffset := binary.LittleEndian.Uint32(buf[:4])
+	if firstOffset%4 != 0 || firstOffset > uint32(len(buf)) {
+		return fmt.Errorf("capabilities: bad first offset %d", firstOffset)
+	}
+	count := int(firstOffset / 4)
+	if count > sszMaxCapabilities {
+		return fmt.Errorf("too many capabilities: %d", count)
+	}
+	offsets := make([]uint32, count+1)
+	offsets[count] = uint32(len(buf))
+	for i := 0; i < count; i++ {
+		offsets[i] = binary.LittleEndian.Uint32(buf[i*4:])
+		if i > 0 && offsets[i] < offsets[i-1] {
+			return fmt.Errorf("capabilities: non-monotonic offset %d", i)
+		}
+		if offsets[i] > uint32(len(buf)) {
+			return fmt.Errorf("capabilities: offset %d out of bounds", i)
+		}
+	}
+	c.List = make([]*solid.ByteListSSZ, 0, count)
+	for i := 0; i < count; i++ {
+		capability := solid.NewByteListSSZ(sszMaxCapabilityNameBytes)
+		if err := capability.DecodeSSZ(buf[offsets[i]:offsets[i+1]], version); err != nil {
+			return err
+		}
+		c.List = append(c.List, capability)
+	}
+	return nil
 }
-func (c *sszCapabilities) EncodingSizeSSZ() int   { b, _ := c.EncodeSSZ(nil); return len(b) }
-func (*sszCapabilities) Clone() clonable.Clonable { return &sszCapabilities{} }
-func (c *sszCapabilities) names() []string {
+func (c *capabilities) EncodingSizeSSZ() int   { b, _ := c.EncodeSSZ(nil); return len(b) }
+func (*capabilities) Clone() clonable.Clonable { return &capabilities{} }
+func (c *capabilities) names() []string {
 	if c.List == nil {
 		return nil
 	}
-	out := make([]string, 0, c.List.Len())
-	c.List.Range(func(_ int, v *sszCapability, _ int) bool { out = append(out, string(v.Name.Bytes())); return true })
+	out := make([]string, 0, len(c.List))
+	for _, v := range c.List {
+		out = append(out, string(v.Bytes()))
+	}
 	return out
 }
 
-type sszClientVersionRequest struct{ ClientVersion *engine_types.ClientVersionV1 }
+type clientVersionRequest struct{ ClientVersion *engine_types.ClientVersionV1 }
 
-func (r *sszClientVersionRequest) Static() bool { return false }
-func (r *sszClientVersionRequest) EncodeSSZ(dst []byte) ([]byte, error) {
+func (r *clientVersionRequest) Static() bool { return false }
+func (r *clientVersionRequest) EncodeSSZ(dst []byte) ([]byte, error) {
 	return ssz2.MarshalSSZ(dst, r.ClientVersion)
 }
-func (r *sszClientVersionRequest) DecodeSSZ(buf []byte, version int) error {
+func (r *clientVersionRequest) DecodeSSZ(buf []byte, version int) error {
 	r.ClientVersion = &engine_types.ClientVersionV1{}
 	return ssz2.UnmarshalSSZ(buf, version, r.ClientVersion)
 }
-func (r *sszClientVersionRequest) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
-func (*sszClientVersionRequest) Clone() clonable.Clonable { return &sszClientVersionRequest{} }
+func (r *clientVersionRequest) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
+func (*clientVersionRequest) Clone() clonable.Clonable { return &clientVersionRequest{} }
 
-type sszClientVersionResponse struct {
+type clientVersionResponse struct {
 	Versions *solid.ListSSZ[*engine_types.ClientVersionV1]
 }
 
-func newSSZClientVersionResponse(versions []engine_types.ClientVersionV1) *sszClientVersionResponse {
+func newSSZClientVersionResponse(versions []engine_types.ClientVersionV1) *clientVersionResponse {
 	l := solid.NewDynamicListSSZ[*engine_types.ClientVersionV1](4)
 	for i := range versions {
 		l.Append(&versions[i])
 	}
-	return &sszClientVersionResponse{Versions: l}
+	return &clientVersionResponse{Versions: l}
 }
-func (r *sszClientVersionResponse) Static() bool { return false }
-func (r *sszClientVersionResponse) EncodeSSZ(dst []byte) ([]byte, error) {
+func (r *clientVersionResponse) Static() bool { return false }
+func (r *clientVersionResponse) EncodeSSZ(dst []byte) ([]byte, error) {
 	return ssz2.MarshalSSZ(dst, r.Versions)
 }
-func (r *sszClientVersionResponse) DecodeSSZ(buf []byte, version int) error {
+func (r *clientVersionResponse) DecodeSSZ(buf []byte, version int) error {
 	r.Versions = solid.NewDynamicListSSZ[*engine_types.ClientVersionV1](4)
 	return ssz2.UnmarshalSSZ(buf, version, r.Versions)
 }
-func (r *sszClientVersionResponse) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
-func (*sszClientVersionResponse) Clone() clonable.Clonable { return &sszClientVersionResponse{} }
+func (r *clientVersionResponse) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
+func (*clientVersionResponse) Clone() clonable.Clonable { return &clientVersionResponse{} }
 
 func blockValueHash(v *hexutil.Big) common.Hash {
 	var out common.Hash
@@ -291,7 +327,7 @@ func newBlobsBundleSSZ(b *engine_types.BlobsBundle, version clparams.StateVersio
 	return b
 }
 
-type sszGetPayloadResponse struct {
+type getPayloadResponse struct {
 	Payload               *engine_types.ExecutionPayload
 	BlockValue            common.Hash
 	BlobsBundle           *engine_types.BlobsBundle
@@ -300,14 +336,14 @@ type sszGetPayloadResponse struct {
 	version               clparams.StateVersion
 }
 
-func newSSZGetPayloadResponse(resp *engine_types.GetPayloadResponse, version clparams.StateVersion) (*sszGetPayloadResponse, error) {
+func newSSZGetPayloadResponse(resp *engine_types.GetPayloadResponse, version clparams.StateVersion) (*getPayloadResponse, error) {
 	payload := resp.ExecutionPayload
 	payload.SSZVersion = version
 	executionRequests, err := executionRequestsFromList(resp.ExecutionRequests, version)
 	if err != nil {
 		return nil, err
 	}
-	return &sszGetPayloadResponse{
+	return &getPayloadResponse{
 		Payload:               payload,
 		BlockValue:            blockValueHash(resp.BlockValue),
 		BlobsBundle:           newBlobsBundleSSZ(resp.BlobsBundle, version),
@@ -316,8 +352,8 @@ func newSSZGetPayloadResponse(resp *engine_types.GetPayloadResponse, version clp
 		version:               version,
 	}, nil
 }
-func (r *sszGetPayloadResponse) Static() bool { return false }
-func (r *sszGetPayloadResponse) EncodeSSZ(dst []byte) ([]byte, error) {
+func (r *getPayloadResponse) Static() bool { return false }
+func (r *getPayloadResponse) EncodeSSZ(dst []byte) ([]byte, error) {
 	switch r.version {
 	case clparams.CapellaVersion:
 		return ssz2.MarshalSSZ(dst, r.Payload, r.BlockValue[:])
@@ -327,7 +363,7 @@ func (r *sszGetPayloadResponse) EncodeSSZ(dst []byte) ([]byte, error) {
 		return ssz2.MarshalSSZ(dst, r.Payload, r.BlockValue[:], r.BlobsBundle, r.ShouldOverrideBuilder, r.ExecutionRequests)
 	}
 }
-func (r *sszGetPayloadResponse) DecodeSSZ(buf []byte, version int) error {
+func (r *getPayloadResponse) DecodeSSZ(buf []byte, version int) error {
 	r.version = clparams.StateVersion(version)
 	r.Payload = engine_types.NewExecutionPayloadSSZ(r.version)
 	r.BlobsBundle = engine_types.NewBlobsBundleSSZ(r.version)
@@ -341,9 +377,9 @@ func (r *sszGetPayloadResponse) DecodeSSZ(buf []byte, version int) error {
 		return ssz2.UnmarshalSSZ(buf, version, r.Payload, r.BlockValue[:], r.BlobsBundle, &r.ShouldOverrideBuilder, r.ExecutionRequests)
 	}
 }
-func (r *sszGetPayloadResponse) EncodingSizeSSZ() int { out, _ := r.EncodeSSZ(nil); return len(out) }
-func (r *sszGetPayloadResponse) Clone() clonable.Clonable {
-	return &sszGetPayloadResponse{version: r.version}
+func (r *getPayloadResponse) EncodingSizeSSZ() int { out, _ := r.EncodeSSZ(nil); return len(out) }
+func (r *getPayloadResponse) Clone() clonable.Clonable {
+	return &getPayloadResponse{version: r.version}
 }
 
 func executionRequestsFromList(requests []hexutil.Bytes, version clparams.StateVersion) (*cltypes.ExecutionRequests, error) {
@@ -373,81 +409,81 @@ func executionRequestsFromList(requests []hexutil.Bytes, version clparams.StateV
 	return out, nil
 }
 
-type sszGetBlobsV1Response struct {
+type getBlobsV1Response struct {
 	BlobsAndProofs *solid.ListSSZ[*engine_types.BlobAndProofV1]
 }
 
-func newSSZGetBlobsV1Response(blobs []*engine_types.BlobAndProofV1) *sszGetBlobsV1Response {
+func newSSZGetBlobsV1Response(blobs []*engine_types.BlobAndProofV1) *getBlobsV1Response {
 	l := solid.NewStaticListSSZ[*engine_types.BlobAndProofV1](sszMaxGetBlobHashes, sszBlobBytes+sszKZGBytes)
 	for _, blob := range blobs {
 		if blob != nil {
 			l.Append(blob)
 		}
 	}
-	return &sszGetBlobsV1Response{BlobsAndProofs: l}
+	return &getBlobsV1Response{BlobsAndProofs: l}
 }
-func (r *sszGetBlobsV1Response) Static() bool { return false }
-func (r *sszGetBlobsV1Response) EncodeSSZ(dst []byte) ([]byte, error) {
+func (r *getBlobsV1Response) Static() bool { return false }
+func (r *getBlobsV1Response) EncodeSSZ(dst []byte) ([]byte, error) {
 	if r.BlobsAndProofs == nil {
 		r.BlobsAndProofs = solid.NewStaticListSSZ[*engine_types.BlobAndProofV1](sszMaxGetBlobHashes, sszBlobBytes+sszKZGBytes)
 	}
 	return ssz2.MarshalSSZ(dst, r.BlobsAndProofs)
 }
-func (r *sszGetBlobsV1Response) DecodeSSZ(buf []byte, version int) error {
+func (r *getBlobsV1Response) DecodeSSZ(buf []byte, version int) error {
 	r.BlobsAndProofs = solid.NewStaticListSSZ[*engine_types.BlobAndProofV1](sszMaxGetBlobHashes, sszBlobBytes+sszKZGBytes)
 	return ssz2.UnmarshalSSZ(buf, version, r.BlobsAndProofs)
 }
-func (r *sszGetBlobsV1Response) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
-func (*sszGetBlobsV1Response) Clone() clonable.Clonable { return &sszGetBlobsV1Response{} }
+func (r *getBlobsV1Response) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
+func (*getBlobsV1Response) Clone() clonable.Clonable { return &getBlobsV1Response{} }
 
-type sszGetBlobsV2Response struct {
+type getBlobsV2Response struct {
 	BlobsAndProofs *solid.ListSSZ[*engine_types.BlobAndProofV2]
 }
 
-func newSSZGetBlobsV2Response(blobs []*engine_types.BlobAndProofV2) *sszGetBlobsV2Response {
+func newSSZGetBlobsV2Response(blobs []*engine_types.BlobAndProofV2) *getBlobsV2Response {
 	l := solid.NewDynamicListSSZ[*engine_types.BlobAndProofV2](sszMaxGetBlobHashes)
 	for _, blob := range blobs {
 		if blob != nil {
 			l.Append(blob)
 		}
 	}
-	return &sszGetBlobsV2Response{BlobsAndProofs: l}
+	return &getBlobsV2Response{BlobsAndProofs: l}
 }
-func (r *sszGetBlobsV2Response) Static() bool { return false }
-func (r *sszGetBlobsV2Response) EncodeSSZ(dst []byte) ([]byte, error) {
+func (r *getBlobsV2Response) Static() bool { return false }
+func (r *getBlobsV2Response) EncodeSSZ(dst []byte) ([]byte, error) {
 	if r.BlobsAndProofs == nil {
 		r.BlobsAndProofs = solid.NewDynamicListSSZ[*engine_types.BlobAndProofV2](sszMaxGetBlobHashes)
 	}
 	return ssz2.MarshalSSZ(dst, r.BlobsAndProofs)
 }
-func (r *sszGetBlobsV2Response) DecodeSSZ(buf []byte, version int) error {
+func (r *getBlobsV2Response) DecodeSSZ(buf []byte, version int) error {
 	r.BlobsAndProofs = solid.NewDynamicListSSZ[*engine_types.BlobAndProofV2](sszMaxGetBlobHashes)
 	return ssz2.UnmarshalSSZ(buf, version, r.BlobsAndProofs)
 }
-func (r *sszGetBlobsV2Response) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
-func (*sszGetBlobsV2Response) Clone() clonable.Clonable { return &sszGetBlobsV2Response{} }
+func (r *getBlobsV2Response) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
+func (*getBlobsV2Response) Clone() clonable.Clonable { return &getBlobsV2Response{} }
 
-type sszGetBlobsV3Response struct {
+type getBlobsV3Response struct {
 	BlobsAndProofs *solid.ListSSZ[*engine_types.NullableBlobAndProofV2]
 }
 
-func newSSZGetBlobsV3Response(blobs []*engine_types.BlobAndProofV2) *sszGetBlobsV3Response {
+func newSSZGetBlobsV3Response(blobs []*engine_types.BlobAndProofV2) *getBlobsV3Response {
 	l := solid.NewDynamicListSSZ[*engine_types.NullableBlobAndProofV2](sszMaxGetBlobHashes)
 	for _, blob := range blobs {
 		l.Append(engine_types.NewNullableBlobAndProofV2(blob))
 	}
-	return &sszGetBlobsV3Response{BlobsAndProofs: l}
+	return &getBlobsV3Response{BlobsAndProofs: l}
 }
-func (r *sszGetBlobsV3Response) Static() bool { return false }
-func (r *sszGetBlobsV3Response) EncodeSSZ(dst []byte) ([]byte, error) {
+func (r *getBlobsV3Response) Static() bool { return false }
+func (r *getBlobsV3Response) EncodeSSZ(dst []byte) ([]byte, error) {
 	if r.BlobsAndProofs == nil {
 		r.BlobsAndProofs = solid.NewDynamicListSSZ[*engine_types.NullableBlobAndProofV2](sszMaxGetBlobHashes)
 	}
 	return ssz2.MarshalSSZ(dst, r.BlobsAndProofs)
 }
-func (r *sszGetBlobsV3Response) DecodeSSZ(buf []byte, version int) error {
+func (r *getBlobsV3Response) DecodeSSZ(buf []byte, version int) error {
 	r.BlobsAndProofs = solid.NewDynamicListSSZ[*engine_types.NullableBlobAndProofV2](sszMaxGetBlobHashes)
 	return ssz2.UnmarshalSSZ(buf, version, r.BlobsAndProofs)
 }
-func (r *sszGetBlobsV3Response) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
-func (*sszGetBlobsV3Response) Clone() clonable.Clonable { return &sszGetBlobsV3Response{} }
+func (r *getBlobsV3Response) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
+func (*getBlobsV3Response) Clone() clonable.Clonable { return &getBlobsV3Response{} }

--- a/execution/engineapi/sszrest_wire.go
+++ b/execution/engineapi/sszrest_wire.go
@@ -62,40 +62,80 @@ func transactionsBytes(txs *solid.TransactionsSSZ) []hexutil.Bytes {
 	return out
 }
 
-type forkchoiceRequest struct {
+type sszRESTMessageKind uint8
+
+const (
+	sszMessageForkchoiceRequest sszRESTMessageKind = iota
+	sszMessageForkchoiceResponse
+	sszMessageNewPayloadRequest
+	sszMessageCapabilities
+	sszMessageClientVersionRequest
+	sszMessageClientVersionResponse
+	sszMessageGetPayloadResponse
+	sszMessageGetBlobsV1Response
+	sszMessageGetBlobsV2Response
+	sszMessageGetBlobsV3Response
+)
+
+type sszRESTMessage struct {
+	kind    sszRESTMessageKind
+	version clparams.StateVersion
+
 	State     engine_types.ForkChoiceState
 	AttrsList *solid.ListSSZ[*engine_types.PayloadAttributes]
-	version   clparams.StateVersion
-}
-
-func (r *forkchoiceRequest) Static() bool { return false }
-func (r *forkchoiceRequest) EncodeSSZ(dst []byte) ([]byte, error) {
-	if r.AttrsList == nil {
-		r.AttrsList = solid.NewDynamicListSSZ[*engine_types.PayloadAttributes](1)
-	}
-	return ssz2.MarshalSSZ(dst, &r.State, r.AttrsList)
-}
-func (r *forkchoiceRequest) DecodeSSZ(buf []byte, version int) error {
-	r.version = clparams.StateVersion(version)
-	r.AttrsList = solid.NewDynamicListSSZ[*engine_types.PayloadAttributes](1)
-	return ssz2.UnmarshalSSZ(buf, version, &r.State, r.AttrsList)
-}
-func (r *forkchoiceRequest) EncodingSizeSSZ() int { b, _ := r.EncodeSSZ(nil); return len(b) }
-func (r *forkchoiceRequest) Clone() clonable.Clonable {
-	return &forkchoiceRequest{version: r.version}
-}
-func (r *forkchoiceRequest) payloadAttributes() *engine_types.PayloadAttributes {
-	if r.AttrsList == nil || r.AttrsList.Len() == 0 {
-		return nil
-	}
-	a := r.AttrsList.Get(0)
-	a.SSZVersion = r.version
-	return a
-}
-
-type forkchoiceResponse struct {
 	Status    *engine_types.PayloadStatus
 	PayloadID *solid.ByteListSSZ
+
+	Payload               *engine_types.ExecutionPayload
+	ExpectedBlobHashes    solid.HashListSSZ
+	ParentBeaconBlockRoot common.Hash
+	ExecutionRequests     *solid.TransactionsSSZ
+
+	Capabilities    []*solid.ByteListSSZ
+	ClientVersion   *engine_types.ClientVersionV1
+	ClientVersions  *solid.ListSSZ[*engine_types.ClientVersionV1]
+	BlockValue      common.Hash
+	BlobsBundle     *engine_types.BlobsBundle
+	OverrideBuilder bool
+	PayloadRequests *cltypes.ExecutionRequests
+
+	BlobsAndProofsV1 *solid.ListSSZ[*engine_types.BlobAndProofV1]
+	BlobsAndProofsV2 *solid.ListSSZ[*engine_types.BlobAndProofV2]
+	BlobsAndProofsV3 *solid.ListSSZ[*engine_types.NullableBlobAndProofV2]
+}
+
+func newSSZRESTMessage(kind sszRESTMessageKind, version clparams.StateVersion) *sszRESTMessage {
+	m := &sszRESTMessage{kind: kind, version: version}
+	m.init()
+	return m
+}
+
+func (m *sszRESTMessage) init() {
+	switch m.kind {
+	case sszMessageForkchoiceRequest:
+		m.AttrsList = solid.NewDynamicListSSZ[*engine_types.PayloadAttributes](1)
+	case sszMessageForkchoiceResponse:
+		m.Status = &engine_types.PayloadStatus{}
+		m.PayloadID = solid.NewByteListSSZ(8)
+	case sszMessageNewPayloadRequest:
+		m.Payload = engine_types.NewExecutionPayloadSSZ(m.version)
+		m.ExpectedBlobHashes = solid.NewHashList(sszMaxBlobHashes)
+		m.ExecutionRequests = &solid.TransactionsSSZ{}
+	case sszMessageClientVersionRequest:
+		m.ClientVersion = &engine_types.ClientVersionV1{}
+	case sszMessageClientVersionResponse:
+		m.ClientVersions = solid.NewDynamicListSSZ[*engine_types.ClientVersionV1](4)
+	case sszMessageGetPayloadResponse:
+		m.Payload = engine_types.NewExecutionPayloadSSZ(m.version)
+		m.BlobsBundle = engine_types.NewBlobsBundleSSZ(m.version)
+		m.PayloadRequests = cltypes.NewExecutionRequests(mainnetBeaconCfg)
+	case sszMessageGetBlobsV1Response:
+		m.BlobsAndProofsV1 = solid.NewStaticListSSZ[*engine_types.BlobAndProofV1](sszMaxGetBlobHashes, sszBlobBytes+sszKZGBytes)
+	case sszMessageGetBlobsV2Response:
+		m.BlobsAndProofsV2 = solid.NewDynamicListSSZ[*engine_types.BlobAndProofV2](sszMaxGetBlobHashes)
+	case sszMessageGetBlobsV3Response:
+		m.BlobsAndProofsV3 = solid.NewDynamicListSSZ[*engine_types.NullableBlobAndProofV2](sszMaxGetBlobHashes)
+	}
 }
 
 func validatePayloadIDList(id *solid.ByteListSSZ) error {
@@ -108,100 +148,132 @@ func validatePayloadIDList(id *solid.ByteListSSZ) error {
 	return nil
 }
 
-func (r *forkchoiceResponse) Static() bool { return false }
-func (r *forkchoiceResponse) EncodeSSZ(dst []byte) ([]byte, error) {
-	if r.PayloadID == nil {
-		r.PayloadID = solid.NewByteListSSZ(8)
-	}
-	if err := validatePayloadIDList(r.PayloadID); err != nil {
-		return nil, err
-	}
-	return ssz2.MarshalSSZ(dst, r.Status, r.PayloadID)
-}
-func (r *forkchoiceResponse) DecodeSSZ(buf []byte, version int) error {
-	r.Status = &engine_types.PayloadStatus{}
-	r.PayloadID = solid.NewByteListSSZ(8)
-	if err := ssz2.UnmarshalSSZ(buf, version, r.Status, r.PayloadID); err != nil {
-		return err
-	}
-	return validatePayloadIDList(r.PayloadID)
-}
-func (r *forkchoiceResponse) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
-func (*forkchoiceResponse) Clone() clonable.Clonable { return &forkchoiceResponse{} }
-
-func forkchoiceResponseToSSZ(resp *engine_types.ForkChoiceUpdatedResponse) (*forkchoiceResponse, error) {
-	pid := solid.NewByteListSSZ(8)
-	if resp.PayloadId != nil && len(*resp.PayloadId) == 8 {
-		if err := pid.SetBytes(*resp.PayloadId); err != nil {
+func (m *sszRESTMessage) Static() bool { return false }
+func (m *sszRESTMessage) EncodeSSZ(dst []byte) ([]byte, error) {
+	switch m.kind {
+	case sszMessageForkchoiceRequest:
+		if m.AttrsList == nil {
+			m.AttrsList = solid.NewDynamicListSSZ[*engine_types.PayloadAttributes](1)
+		}
+		return ssz2.MarshalSSZ(dst, &m.State, m.AttrsList)
+	case sszMessageForkchoiceResponse:
+		if m.PayloadID == nil {
+			m.PayloadID = solid.NewByteListSSZ(8)
+		}
+		if err := validatePayloadIDList(m.PayloadID); err != nil {
 			return nil, err
 		}
-	}
-	return &forkchoiceResponse{Status: resp.PayloadStatus, PayloadID: pid}, nil
-}
-
-type newPayloadRequest struct {
-	Payload               *engine_types.ExecutionPayload
-	ExpectedBlobHashes    solid.HashListSSZ
-	ParentBeaconBlockRoot common.Hash
-	ExecutionRequests     *solid.TransactionsSSZ
-	version               clparams.StateVersion
-}
-
-func newSSZNewPayloadRequest(version clparams.StateVersion) *newPayloadRequest {
-	return &newPayloadRequest{Payload: engine_types.NewExecutionPayloadSSZ(version), ExpectedBlobHashes: solid.NewHashList(sszMaxBlobHashes), ExecutionRequests: &solid.TransactionsSSZ{}, version: version}
-}
-func (r *newPayloadRequest) Static() bool { return false }
-func (r *newPayloadRequest) EncodeSSZ(dst []byte) ([]byte, error) {
-	switch r.version {
-	case clparams.BellatrixVersion, clparams.CapellaVersion:
-		return ssz2.MarshalSSZ(dst, r.Payload)
-	case clparams.DenebVersion:
-		return ssz2.MarshalSSZ(dst, r.Payload, r.ExpectedBlobHashes, r.ParentBeaconBlockRoot[:])
+		return ssz2.MarshalSSZ(dst, m.Status, m.PayloadID)
+	case sszMessageNewPayloadRequest:
+		switch m.version {
+		case clparams.BellatrixVersion, clparams.CapellaVersion:
+			return ssz2.MarshalSSZ(dst, m.Payload)
+		case clparams.DenebVersion:
+			return ssz2.MarshalSSZ(dst, m.Payload, m.ExpectedBlobHashes, m.ParentBeaconBlockRoot[:])
+		default:
+			return ssz2.MarshalSSZ(dst, m.Payload, m.ExpectedBlobHashes, m.ParentBeaconBlockRoot[:], m.ExecutionRequests)
+		}
+	case sszMessageCapabilities:
+		return m.encodeCapabilities(dst)
+	case sszMessageClientVersionRequest:
+		return ssz2.MarshalSSZ(dst, m.ClientVersion)
+	case sszMessageClientVersionResponse:
+		return ssz2.MarshalSSZ(dst, m.ClientVersions)
+	case sszMessageGetPayloadResponse:
+		switch m.version {
+		case clparams.CapellaVersion:
+			return ssz2.MarshalSSZ(dst, m.Payload, m.BlockValue[:])
+		case clparams.DenebVersion:
+			return ssz2.MarshalSSZ(dst, m.Payload, m.BlockValue[:], m.BlobsBundle, m.OverrideBuilder)
+		default:
+			return ssz2.MarshalSSZ(dst, m.Payload, m.BlockValue[:], m.BlobsBundle, m.OverrideBuilder, m.PayloadRequests)
+		}
+	case sszMessageGetBlobsV1Response:
+		if m.BlobsAndProofsV1 == nil {
+			m.BlobsAndProofsV1 = solid.NewStaticListSSZ[*engine_types.BlobAndProofV1](sszMaxGetBlobHashes, sszBlobBytes+sszKZGBytes)
+		}
+		return ssz2.MarshalSSZ(dst, m.BlobsAndProofsV1)
+	case sszMessageGetBlobsV2Response:
+		if m.BlobsAndProofsV2 == nil {
+			m.BlobsAndProofsV2 = solid.NewDynamicListSSZ[*engine_types.BlobAndProofV2](sszMaxGetBlobHashes)
+		}
+		return ssz2.MarshalSSZ(dst, m.BlobsAndProofsV2)
+	case sszMessageGetBlobsV3Response:
+		if m.BlobsAndProofsV3 == nil {
+			m.BlobsAndProofsV3 = solid.NewDynamicListSSZ[*engine_types.NullableBlobAndProofV2](sszMaxGetBlobHashes)
+		}
+		return ssz2.MarshalSSZ(dst, m.BlobsAndProofsV3)
 	default:
-		return ssz2.MarshalSSZ(dst, r.Payload, r.ExpectedBlobHashes, r.ParentBeaconBlockRoot[:], r.ExecutionRequests)
+		return nil, fmt.Errorf("unknown SSZ REST message kind %d", m.kind)
 	}
 }
-func (r *newPayloadRequest) DecodeSSZ(buf []byte, version int) error {
-	r.version = clparams.StateVersion(version)
-	r.Payload = engine_types.NewExecutionPayloadSSZ(r.version)
-	r.ExpectedBlobHashes = solid.NewHashList(sszMaxBlobHashes)
-	r.ExecutionRequests = &solid.TransactionsSSZ{}
-	switch r.version {
-	case clparams.BellatrixVersion, clparams.CapellaVersion:
-		return ssz2.UnmarshalSSZ(buf, version, r.Payload)
-	case clparams.DenebVersion:
-		return ssz2.UnmarshalSSZ(buf, version, r.Payload, r.ExpectedBlobHashes, r.ParentBeaconBlockRoot[:])
+
+func (m *sszRESTMessage) DecodeSSZ(buf []byte, version int) error {
+	m.version = clparams.StateVersion(version)
+	m.init()
+	switch m.kind {
+	case sszMessageForkchoiceRequest:
+		return ssz2.UnmarshalSSZ(buf, version, &m.State, m.AttrsList)
+	case sszMessageForkchoiceResponse:
+		if err := ssz2.UnmarshalSSZ(buf, version, m.Status, m.PayloadID); err != nil {
+			return err
+		}
+		return validatePayloadIDList(m.PayloadID)
+	case sszMessageNewPayloadRequest:
+		switch m.version {
+		case clparams.BellatrixVersion, clparams.CapellaVersion:
+			return ssz2.UnmarshalSSZ(buf, version, m.Payload)
+		case clparams.DenebVersion:
+			return ssz2.UnmarshalSSZ(buf, version, m.Payload, m.ExpectedBlobHashes, m.ParentBeaconBlockRoot[:])
+		default:
+			return ssz2.UnmarshalSSZ(buf, version, m.Payload, m.ExpectedBlobHashes, m.ParentBeaconBlockRoot[:], m.ExecutionRequests)
+		}
+	case sszMessageCapabilities:
+		return m.decodeCapabilities(buf, version)
+	case sszMessageClientVersionRequest:
+		return ssz2.UnmarshalSSZ(buf, version, m.ClientVersion)
+	case sszMessageClientVersionResponse:
+		return ssz2.UnmarshalSSZ(buf, version, m.ClientVersions)
+	case sszMessageGetPayloadResponse:
+		switch m.version {
+		case clparams.CapellaVersion:
+			return ssz2.UnmarshalSSZ(buf, version, m.Payload, m.BlockValue[:])
+		case clparams.DenebVersion:
+			return ssz2.UnmarshalSSZ(buf, version, m.Payload, m.BlockValue[:], m.BlobsBundle, &m.OverrideBuilder)
+		default:
+			return ssz2.UnmarshalSSZ(buf, version, m.Payload, m.BlockValue[:], m.BlobsBundle, &m.OverrideBuilder, m.PayloadRequests)
+		}
+	case sszMessageGetBlobsV1Response:
+		return ssz2.UnmarshalSSZ(buf, version, m.BlobsAndProofsV1)
+	case sszMessageGetBlobsV2Response:
+		return ssz2.UnmarshalSSZ(buf, version, m.BlobsAndProofsV2)
+	case sszMessageGetBlobsV3Response:
+		return ssz2.UnmarshalSSZ(buf, version, m.BlobsAndProofsV3)
 	default:
-		return ssz2.UnmarshalSSZ(buf, version, r.Payload, r.ExpectedBlobHashes, r.ParentBeaconBlockRoot[:], r.ExecutionRequests)
+		return fmt.Errorf("unknown SSZ REST message kind %d", m.kind)
 	}
 }
-func (r *newPayloadRequest) EncodingSizeSSZ() int     { b, _ := r.EncodeSSZ(nil); return len(b) }
-func (r *newPayloadRequest) Clone() clonable.Clonable { return newSSZNewPayloadRequest(r.version) }
 
-func capabilityName(s string) *solid.ByteListSSZ {
-	b := solid.NewByteListSSZ(sszMaxCapabilityNameBytes)
-	_ = b.SetBytes([]byte(s))
-	return b
+func (m *sszRESTMessage) EncodingSizeSSZ() int { b, _ := m.EncodeSSZ(nil); return len(b) }
+func (m *sszRESTMessage) Clone() clonable.Clonable {
+	return newSSZRESTMessage(m.kind, m.version)
 }
 
-type capabilities struct {
-	List []*solid.ByteListSSZ
-}
-
-func newSSZCapabilities(names []string) *capabilities {
-	l := make([]*solid.ByteListSSZ, 0, len(names))
-	for _, name := range names {
-		l = append(l, capabilityName(name))
+func (m *sszRESTMessage) payloadAttributes() *engine_types.PayloadAttributes {
+	if m.AttrsList == nil || m.AttrsList.Len() == 0 {
+		return nil
 	}
-	return &capabilities{List: l}
+	a := m.AttrsList.Get(0)
+	a.SSZVersion = m.version
+	return a
 }
-func (c *capabilities) Static() bool { return false }
-func (c *capabilities) EncodeSSZ(dst []byte) ([]byte, error) {
-	if len(c.List) > sszMaxCapabilities {
-		return nil, fmt.Errorf("too many capabilities: %d", len(c.List))
+
+func (m *sszRESTMessage) encodeCapabilities(dst []byte) ([]byte, error) {
+	if len(m.Capabilities) > sszMaxCapabilities {
+		return nil, fmt.Errorf("too many capabilities: %d", len(m.Capabilities))
 	}
-	offset := len(c.List) * 4
-	for _, capability := range c.List {
+	offset := len(m.Capabilities) * 4
+	for _, capability := range m.Capabilities {
 		if capability == nil {
 			capability = solid.NewByteListSSZ(sszMaxCapabilityNameBytes)
 		}
@@ -209,7 +281,7 @@ func (c *capabilities) EncodeSSZ(dst []byte) ([]byte, error) {
 		binary.LittleEndian.PutUint32(dst[len(dst)-4:], uint32(offset))
 		offset += capability.EncodingSizeSSZ()
 	}
-	for _, capability := range c.List {
+	for _, capability := range m.Capabilities {
 		if capability == nil {
 			capability = solid.NewByteListSSZ(sszMaxCapabilityNameBytes)
 		}
@@ -221,8 +293,9 @@ func (c *capabilities) EncodeSSZ(dst []byte) ([]byte, error) {
 	}
 	return dst, nil
 }
-func (c *capabilities) DecodeSSZ(buf []byte, version int) error {
-	c.List = nil
+
+func (m *sszRESTMessage) decodeCapabilities(buf []byte, version int) error {
+	m.Capabilities = nil
 	if len(buf) == 0 {
 		return nil
 	}
@@ -248,63 +321,65 @@ func (c *capabilities) DecodeSSZ(buf []byte, version int) error {
 			return fmt.Errorf("capabilities: offset %d out of bounds", i)
 		}
 	}
-	c.List = make([]*solid.ByteListSSZ, 0, count)
+	m.Capabilities = make([]*solid.ByteListSSZ, 0, count)
 	for i := 0; i < count; i++ {
 		capability := solid.NewByteListSSZ(sszMaxCapabilityNameBytes)
 		if err := capability.DecodeSSZ(buf[offsets[i]:offsets[i+1]], version); err != nil {
 			return err
 		}
-		c.List = append(c.List, capability)
+		m.Capabilities = append(m.Capabilities, capability)
 	}
 	return nil
 }
-func (c *capabilities) EncodingSizeSSZ() int   { b, _ := c.EncodeSSZ(nil); return len(b) }
-func (*capabilities) Clone() clonable.Clonable { return &capabilities{} }
-func (c *capabilities) names() []string {
-	if c.List == nil {
+
+func (m *sszRESTMessage) capabilityNames() []string {
+	if m.Capabilities == nil {
 		return nil
 	}
-	out := make([]string, 0, len(c.List))
-	for _, v := range c.List {
+	out := make([]string, 0, len(m.Capabilities))
+	for _, v := range m.Capabilities {
 		out = append(out, string(v.Bytes()))
 	}
 	return out
 }
 
-type clientVersionRequest struct{ ClientVersion *engine_types.ClientVersionV1 }
-
-func (r *clientVersionRequest) Static() bool { return false }
-func (r *clientVersionRequest) EncodeSSZ(dst []byte) ([]byte, error) {
-	return ssz2.MarshalSSZ(dst, r.ClientVersion)
-}
-func (r *clientVersionRequest) DecodeSSZ(buf []byte, version int) error {
-	r.ClientVersion = &engine_types.ClientVersionV1{}
-	return ssz2.UnmarshalSSZ(buf, version, r.ClientVersion)
-}
-func (r *clientVersionRequest) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
-func (*clientVersionRequest) Clone() clonable.Clonable { return &clientVersionRequest{} }
-
-type clientVersionResponse struct {
-	Versions *solid.ListSSZ[*engine_types.ClientVersionV1]
+func capabilityName(s string) *solid.ByteListSSZ {
+	b := solid.NewByteListSSZ(sszMaxCapabilityNameBytes)
+	_ = b.SetBytes([]byte(s))
+	return b
 }
 
-func newSSZClientVersionResponse(versions []engine_types.ClientVersionV1) *clientVersionResponse {
-	l := solid.NewDynamicListSSZ[*engine_types.ClientVersionV1](4)
-	for i := range versions {
-		l.Append(&versions[i])
+func forkchoiceResponseToSSZ(resp *engine_types.ForkChoiceUpdatedResponse) (*sszRESTMessage, error) {
+	msg := newSSZRESTMessage(sszMessageForkchoiceResponse, 0)
+	msg.Status = resp.PayloadStatus
+	if resp.PayloadId != nil && len(*resp.PayloadId) == 8 {
+		if err := msg.PayloadID.SetBytes(*resp.PayloadId); err != nil {
+			return nil, err
+		}
 	}
-	return &clientVersionResponse{Versions: l}
+	return msg, nil
 }
-func (r *clientVersionResponse) Static() bool { return false }
-func (r *clientVersionResponse) EncodeSSZ(dst []byte) ([]byte, error) {
-	return ssz2.MarshalSSZ(dst, r.Versions)
+
+func newSSZNewPayloadRequest(version clparams.StateVersion) *sszRESTMessage {
+	return newSSZRESTMessage(sszMessageNewPayloadRequest, version)
 }
-func (r *clientVersionResponse) DecodeSSZ(buf []byte, version int) error {
-	r.Versions = solid.NewDynamicListSSZ[*engine_types.ClientVersionV1](4)
-	return ssz2.UnmarshalSSZ(buf, version, r.Versions)
+
+func newSSZCapabilities(names []string) *sszRESTMessage {
+	msg := newSSZRESTMessage(sszMessageCapabilities, 0)
+	msg.Capabilities = make([]*solid.ByteListSSZ, 0, len(names))
+	for _, name := range names {
+		msg.Capabilities = append(msg.Capabilities, capabilityName(name))
+	}
+	return msg
 }
-func (r *clientVersionResponse) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
-func (*clientVersionResponse) Clone() clonable.Clonable { return &clientVersionResponse{} }
+
+func newSSZClientVersionResponse(versions []engine_types.ClientVersionV1) *sszRESTMessage {
+	msg := newSSZRESTMessage(sszMessageClientVersionResponse, 0)
+	for i := range versions {
+		msg.ClientVersions.Append(&versions[i])
+	}
+	return msg
+}
 
 func blockValueHash(v *hexutil.Big) common.Hash {
 	var out common.Hash
@@ -327,59 +402,20 @@ func newBlobsBundleSSZ(b *engine_types.BlobsBundle, version clparams.StateVersio
 	return b
 }
 
-type getPayloadResponse struct {
-	Payload               *engine_types.ExecutionPayload
-	BlockValue            common.Hash
-	BlobsBundle           *engine_types.BlobsBundle
-	ShouldOverrideBuilder bool
-	ExecutionRequests     *cltypes.ExecutionRequests
-	version               clparams.StateVersion
-}
-
-func newSSZGetPayloadResponse(resp *engine_types.GetPayloadResponse, version clparams.StateVersion) (*getPayloadResponse, error) {
+func newSSZGetPayloadResponse(resp *engine_types.GetPayloadResponse, version clparams.StateVersion) (*sszRESTMessage, error) {
 	payload := resp.ExecutionPayload
 	payload.SSZVersion = version
 	executionRequests, err := executionRequestsFromList(resp.ExecutionRequests, version)
 	if err != nil {
 		return nil, err
 	}
-	return &getPayloadResponse{
-		Payload:               payload,
-		BlockValue:            blockValueHash(resp.BlockValue),
-		BlobsBundle:           newBlobsBundleSSZ(resp.BlobsBundle, version),
-		ShouldOverrideBuilder: resp.ShouldOverrideBuilder,
-		ExecutionRequests:     executionRequests,
-		version:               version,
-	}, nil
-}
-func (r *getPayloadResponse) Static() bool { return false }
-func (r *getPayloadResponse) EncodeSSZ(dst []byte) ([]byte, error) {
-	switch r.version {
-	case clparams.CapellaVersion:
-		return ssz2.MarshalSSZ(dst, r.Payload, r.BlockValue[:])
-	case clparams.DenebVersion:
-		return ssz2.MarshalSSZ(dst, r.Payload, r.BlockValue[:], r.BlobsBundle, r.ShouldOverrideBuilder)
-	default:
-		return ssz2.MarshalSSZ(dst, r.Payload, r.BlockValue[:], r.BlobsBundle, r.ShouldOverrideBuilder, r.ExecutionRequests)
-	}
-}
-func (r *getPayloadResponse) DecodeSSZ(buf []byte, version int) error {
-	r.version = clparams.StateVersion(version)
-	r.Payload = engine_types.NewExecutionPayloadSSZ(r.version)
-	r.BlobsBundle = engine_types.NewBlobsBundleSSZ(r.version)
-	r.ExecutionRequests = cltypes.NewExecutionRequests(mainnetBeaconCfg)
-	switch r.version {
-	case clparams.CapellaVersion:
-		return ssz2.UnmarshalSSZ(buf, version, r.Payload, r.BlockValue[:])
-	case clparams.DenebVersion:
-		return ssz2.UnmarshalSSZ(buf, version, r.Payload, r.BlockValue[:], r.BlobsBundle, &r.ShouldOverrideBuilder)
-	default:
-		return ssz2.UnmarshalSSZ(buf, version, r.Payload, r.BlockValue[:], r.BlobsBundle, &r.ShouldOverrideBuilder, r.ExecutionRequests)
-	}
-}
-func (r *getPayloadResponse) EncodingSizeSSZ() int { out, _ := r.EncodeSSZ(nil); return len(out) }
-func (r *getPayloadResponse) Clone() clonable.Clonable {
-	return &getPayloadResponse{version: r.version}
+	msg := newSSZRESTMessage(sszMessageGetPayloadResponse, version)
+	msg.Payload = payload
+	msg.BlockValue = blockValueHash(resp.BlockValue)
+	msg.BlobsBundle = newBlobsBundleSSZ(resp.BlobsBundle, version)
+	msg.OverrideBuilder = resp.ShouldOverrideBuilder
+	msg.PayloadRequests = executionRequests
+	return msg, nil
 }
 
 func executionRequestsFromList(requests []hexutil.Bytes, version clparams.StateVersion) (*cltypes.ExecutionRequests, error) {
@@ -409,81 +445,30 @@ func executionRequestsFromList(requests []hexutil.Bytes, version clparams.StateV
 	return out, nil
 }
 
-type getBlobsV1Response struct {
-	BlobsAndProofs *solid.ListSSZ[*engine_types.BlobAndProofV1]
-}
-
-func newSSZGetBlobsV1Response(blobs []*engine_types.BlobAndProofV1) *getBlobsV1Response {
-	l := solid.NewStaticListSSZ[*engine_types.BlobAndProofV1](sszMaxGetBlobHashes, sszBlobBytes+sszKZGBytes)
+func newSSZGetBlobsV1Response(blobs []*engine_types.BlobAndProofV1) *sszRESTMessage {
+	msg := newSSZRESTMessage(sszMessageGetBlobsV1Response, 0)
 	for _, blob := range blobs {
 		if blob != nil {
-			l.Append(blob)
+			msg.BlobsAndProofsV1.Append(blob)
 		}
 	}
-	return &getBlobsV1Response{BlobsAndProofs: l}
-}
-func (r *getBlobsV1Response) Static() bool { return false }
-func (r *getBlobsV1Response) EncodeSSZ(dst []byte) ([]byte, error) {
-	if r.BlobsAndProofs == nil {
-		r.BlobsAndProofs = solid.NewStaticListSSZ[*engine_types.BlobAndProofV1](sszMaxGetBlobHashes, sszBlobBytes+sszKZGBytes)
-	}
-	return ssz2.MarshalSSZ(dst, r.BlobsAndProofs)
-}
-func (r *getBlobsV1Response) DecodeSSZ(buf []byte, version int) error {
-	r.BlobsAndProofs = solid.NewStaticListSSZ[*engine_types.BlobAndProofV1](sszMaxGetBlobHashes, sszBlobBytes+sszKZGBytes)
-	return ssz2.UnmarshalSSZ(buf, version, r.BlobsAndProofs)
-}
-func (r *getBlobsV1Response) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
-func (*getBlobsV1Response) Clone() clonable.Clonable { return &getBlobsV1Response{} }
-
-type getBlobsV2Response struct {
-	BlobsAndProofs *solid.ListSSZ[*engine_types.BlobAndProofV2]
+	return msg
 }
 
-func newSSZGetBlobsV2Response(blobs []*engine_types.BlobAndProofV2) *getBlobsV2Response {
-	l := solid.NewDynamicListSSZ[*engine_types.BlobAndProofV2](sszMaxGetBlobHashes)
+func newSSZGetBlobsV2Response(blobs []*engine_types.BlobAndProofV2) *sszRESTMessage {
+	msg := newSSZRESTMessage(sszMessageGetBlobsV2Response, 0)
 	for _, blob := range blobs {
 		if blob != nil {
-			l.Append(blob)
+			msg.BlobsAndProofsV2.Append(blob)
 		}
 	}
-	return &getBlobsV2Response{BlobsAndProofs: l}
-}
-func (r *getBlobsV2Response) Static() bool { return false }
-func (r *getBlobsV2Response) EncodeSSZ(dst []byte) ([]byte, error) {
-	if r.BlobsAndProofs == nil {
-		r.BlobsAndProofs = solid.NewDynamicListSSZ[*engine_types.BlobAndProofV2](sszMaxGetBlobHashes)
-	}
-	return ssz2.MarshalSSZ(dst, r.BlobsAndProofs)
-}
-func (r *getBlobsV2Response) DecodeSSZ(buf []byte, version int) error {
-	r.BlobsAndProofs = solid.NewDynamicListSSZ[*engine_types.BlobAndProofV2](sszMaxGetBlobHashes)
-	return ssz2.UnmarshalSSZ(buf, version, r.BlobsAndProofs)
-}
-func (r *getBlobsV2Response) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
-func (*getBlobsV2Response) Clone() clonable.Clonable { return &getBlobsV2Response{} }
-
-type getBlobsV3Response struct {
-	BlobsAndProofs *solid.ListSSZ[*engine_types.NullableBlobAndProofV2]
+	return msg
 }
 
-func newSSZGetBlobsV3Response(blobs []*engine_types.BlobAndProofV2) *getBlobsV3Response {
-	l := solid.NewDynamicListSSZ[*engine_types.NullableBlobAndProofV2](sszMaxGetBlobHashes)
+func newSSZGetBlobsV3Response(blobs []*engine_types.BlobAndProofV2) *sszRESTMessage {
+	msg := newSSZRESTMessage(sszMessageGetBlobsV3Response, 0)
 	for _, blob := range blobs {
-		l.Append(engine_types.NewNullableBlobAndProofV2(blob))
+		msg.BlobsAndProofsV3.Append(engine_types.NewNullableBlobAndProofV2(blob))
 	}
-	return &getBlobsV3Response{BlobsAndProofs: l}
+	return msg
 }
-func (r *getBlobsV3Response) Static() bool { return false }
-func (r *getBlobsV3Response) EncodeSSZ(dst []byte) ([]byte, error) {
-	if r.BlobsAndProofs == nil {
-		r.BlobsAndProofs = solid.NewDynamicListSSZ[*engine_types.NullableBlobAndProofV2](sszMaxGetBlobHashes)
-	}
-	return ssz2.MarshalSSZ(dst, r.BlobsAndProofs)
-}
-func (r *getBlobsV3Response) DecodeSSZ(buf []byte, version int) error {
-	r.BlobsAndProofs = solid.NewDynamicListSSZ[*engine_types.NullableBlobAndProofV2](sszMaxGetBlobHashes)
-	return ssz2.UnmarshalSSZ(buf, version, r.BlobsAndProofs)
-}
-func (r *getBlobsV3Response) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
-func (*getBlobsV3Response) Clone() clonable.Clonable { return &getBlobsV3Response{} }

--- a/execution/engineapi/sszrest_wire.go
+++ b/execution/engineapi/sszrest_wire.go
@@ -29,10 +29,8 @@ import (
 const (
 	sszMaxBlobHashes          = 4096
 	sszMaxGetBlobHashes       = 128
-	sszMaxExecutionRequests   = 256
 	sszMaxCapabilityNameBytes = 64
 	sszMaxCapabilities        = 64
-	sszMaxBytesPerTransaction = 0x40000000
 	sszBlobBytes              = 0x20000
 	sszKZGBytes               = 48
 	sszCellsPerExtBlob        = 128
@@ -52,44 +50,15 @@ func hashListValues(l solid.HashListSSZ) []common.Hash {
 	return out
 }
 
-type sszByteListList struct {
-	List  *solid.ListSSZ[*solid.ByteListSSZ]
-	Limit int
-}
-
-func newSSZByteListList(limit int, items []hexutil.Bytes) *sszByteListList {
-	l := solid.NewDynamicListSSZ[*solid.ByteListSSZ](limit)
-	for _, item := range items {
-		b := solid.NewByteListSSZ(sszMaxBytesPerTransaction)
-		_ = b.SetBytes(item)
-		l.Append(b)
-	}
-	return &sszByteListList{List: l, Limit: limit}
-}
-func (l *sszByteListList) Static() bool { return false }
-func (l *sszByteListList) EncodeSSZ(dst []byte) ([]byte, error) {
-	if l.List == nil {
-		l.List = solid.NewDynamicListSSZ[*solid.ByteListSSZ](l.Limit)
-	}
-	return l.List.EncodeSSZ(dst)
-}
-func (l *sszByteListList) DecodeSSZ(buf []byte, version int) error {
-	l.List = solid.NewDynamicListSSZ[*solid.ByteListSSZ](l.Limit)
-	return l.List.DecodeSSZ(buf, version)
-}
-func (l *sszByteListList) EncodingSizeSSZ() int {
-	if l.List == nil {
-		return 0
-	}
-	return l.List.EncodingSizeSSZ()
-}
-func (l *sszByteListList) Clone() clonable.Clonable { return &sszByteListList{Limit: l.Limit} }
-func (l *sszByteListList) bytes() []hexutil.Bytes {
-	if l.List == nil {
+func transactionsBytes(txs *solid.TransactionsSSZ) []hexutil.Bytes {
+	if txs == nil {
 		return nil
 	}
-	out := make([]hexutil.Bytes, 0, l.List.Len())
-	l.List.Range(func(_ int, v *solid.ByteListSSZ, _ int) bool { out = append(out, v.Bytes()); return true })
+	out := make([]hexutil.Bytes, 0)
+	txs.ForEach(func(tx []byte, _ int, _ int) bool {
+		out = append(out, tx)
+		return true
+	})
 	return out
 }
 
@@ -174,12 +143,12 @@ type sszNewPayloadRequest struct {
 	Payload               *engine_types.ExecutionPayload
 	ExpectedBlobHashes    solid.HashListSSZ
 	ParentBeaconBlockRoot common.Hash
-	ExecutionRequests     *sszByteListList
+	ExecutionRequests     *solid.TransactionsSSZ
 	version               clparams.StateVersion
 }
 
 func newSSZNewPayloadRequest(version clparams.StateVersion) *sszNewPayloadRequest {
-	return &sszNewPayloadRequest{Payload: engine_types.NewExecutionPayloadSSZ(version), ExpectedBlobHashes: solid.NewHashList(sszMaxBlobHashes), ExecutionRequests: &sszByteListList{Limit: sszMaxExecutionRequests}, version: version}
+	return &sszNewPayloadRequest{Payload: engine_types.NewExecutionPayloadSSZ(version), ExpectedBlobHashes: solid.NewHashList(sszMaxBlobHashes), ExecutionRequests: &solid.TransactionsSSZ{}, version: version}
 }
 func (r *sszNewPayloadRequest) Static() bool { return false }
 func (r *sszNewPayloadRequest) EncodeSSZ(dst []byte) ([]byte, error) {
@@ -196,7 +165,7 @@ func (r *sszNewPayloadRequest) DecodeSSZ(buf []byte, version int) error {
 	r.version = clparams.StateVersion(version)
 	r.Payload = engine_types.NewExecutionPayloadSSZ(r.version)
 	r.ExpectedBlobHashes = solid.NewHashList(sszMaxBlobHashes)
-	r.ExecutionRequests = &sszByteListList{Limit: sszMaxExecutionRequests}
+	r.ExecutionRequests = &solid.TransactionsSSZ{}
 	switch r.version {
 	case clparams.BellatrixVersion, clparams.CapellaVersion:
 		return ssz2.UnmarshalSSZ(buf, version, r.Payload)
@@ -301,8 +270,8 @@ func (r *sszClientVersionResponse) DecodeSSZ(buf []byte, version int) error {
 func (r *sszClientVersionResponse) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
 func (*sszClientVersionResponse) Clone() clonable.Clonable { return &sszClientVersionResponse{} }
 
-func blockValueBytes(v *hexutil.Big) []byte {
-	out := make([]byte, 32)
+func blockValueHash(v *hexutil.Big) common.Hash {
+	var out common.Hash
 	if v == nil {
 		return out
 	}
@@ -322,30 +291,11 @@ func newBlobsBundleSSZ(b *engine_types.BlobsBundle, version clparams.StateVersio
 	return b
 }
 
-type sszBool struct{ Value bool }
-
-func (*sszBool) Static() bool         { return true }
-func (*sszBool) EncodingSizeSSZ() int { return 1 }
-func (b *sszBool) EncodeSSZ(dst []byte) ([]byte, error) {
-	if b.Value {
-		return append(dst, 1), nil
-	}
-	return append(dst, 0), nil
-}
-func (b *sszBool) DecodeSSZ(buf []byte, _ int) error {
-	if len(buf) < 1 {
-		return errors.New("short bool")
-	}
-	b.Value = buf[0] != 0
-	return nil
-}
-func (*sszBool) Clone() clonable.Clonable { return &sszBool{} }
-
 type sszGetPayloadResponse struct {
 	Payload               *engine_types.ExecutionPayload
-	BlockValue            *sszFixedBytes
+	BlockValue            common.Hash
 	BlobsBundle           *engine_types.BlobsBundle
-	ShouldOverrideBuilder *sszBool
+	ShouldOverrideBuilder bool
 	ExecutionRequests     *cltypes.ExecutionRequests
 	version               clparams.StateVersion
 }
@@ -359,9 +309,9 @@ func newSSZGetPayloadResponse(resp *engine_types.GetPayloadResponse, version clp
 	}
 	return &sszGetPayloadResponse{
 		Payload:               payload,
-		BlockValue:            newSSZFixedBytes(32, blockValueBytes(resp.BlockValue)),
+		BlockValue:            blockValueHash(resp.BlockValue),
 		BlobsBundle:           newBlobsBundleSSZ(resp.BlobsBundle, version),
-		ShouldOverrideBuilder: &sszBool{Value: resp.ShouldOverrideBuilder},
+		ShouldOverrideBuilder: resp.ShouldOverrideBuilder,
 		ExecutionRequests:     executionRequests,
 		version:               version,
 	}, nil
@@ -370,27 +320,25 @@ func (r *sszGetPayloadResponse) Static() bool { return false }
 func (r *sszGetPayloadResponse) EncodeSSZ(dst []byte) ([]byte, error) {
 	switch r.version {
 	case clparams.CapellaVersion:
-		return ssz2.MarshalSSZ(dst, r.Payload, r.BlockValue)
+		return ssz2.MarshalSSZ(dst, r.Payload, r.BlockValue[:])
 	case clparams.DenebVersion:
-		return ssz2.MarshalSSZ(dst, r.Payload, r.BlockValue, r.BlobsBundle, r.ShouldOverrideBuilder)
+		return ssz2.MarshalSSZ(dst, r.Payload, r.BlockValue[:], r.BlobsBundle, r.ShouldOverrideBuilder)
 	default:
-		return ssz2.MarshalSSZ(dst, r.Payload, r.BlockValue, r.BlobsBundle, r.ShouldOverrideBuilder, r.ExecutionRequests)
+		return ssz2.MarshalSSZ(dst, r.Payload, r.BlockValue[:], r.BlobsBundle, r.ShouldOverrideBuilder, r.ExecutionRequests)
 	}
 }
 func (r *sszGetPayloadResponse) DecodeSSZ(buf []byte, version int) error {
 	r.version = clparams.StateVersion(version)
 	r.Payload = engine_types.NewExecutionPayloadSSZ(r.version)
-	r.BlockValue = newSSZFixedBytes(32, nil)
 	r.BlobsBundle = engine_types.NewBlobsBundleSSZ(r.version)
-	r.ShouldOverrideBuilder = &sszBool{}
 	r.ExecutionRequests = cltypes.NewExecutionRequests(mainnetBeaconCfg)
 	switch r.version {
 	case clparams.CapellaVersion:
-		return ssz2.UnmarshalSSZ(buf, version, r.Payload, r.BlockValue)
+		return ssz2.UnmarshalSSZ(buf, version, r.Payload, r.BlockValue[:])
 	case clparams.DenebVersion:
-		return ssz2.UnmarshalSSZ(buf, version, r.Payload, r.BlockValue, r.BlobsBundle, r.ShouldOverrideBuilder)
+		return ssz2.UnmarshalSSZ(buf, version, r.Payload, r.BlockValue[:], r.BlobsBundle, &r.ShouldOverrideBuilder)
 	default:
-		return ssz2.UnmarshalSSZ(buf, version, r.Payload, r.BlockValue, r.BlobsBundle, r.ShouldOverrideBuilder, r.ExecutionRequests)
+		return ssz2.UnmarshalSSZ(buf, version, r.Payload, r.BlockValue[:], r.BlobsBundle, &r.ShouldOverrideBuilder, r.ExecutionRequests)
 	}
 }
 func (r *sszGetPayloadResponse) EncodingSizeSSZ() int { out, _ := r.EncodeSSZ(nil); return len(out) }
@@ -423,50 +371,6 @@ func executionRequestsFromList(requests []hexutil.Bytes, version clparams.StateV
 		}
 	}
 	return out, nil
-}
-
-type sszFixedBytes struct {
-	Bytes []byte
-	Size  int
-}
-
-func newSSZFixedBytes(size int, in []byte) *sszFixedBytes {
-	out := &sszFixedBytes{Bytes: make([]byte, size), Size: size}
-	copy(out.Bytes, in)
-	return out
-}
-func (b *sszFixedBytes) Static() bool { return true }
-func (b *sszFixedBytes) EncodingSizeSSZ() int {
-	if b.Size == 0 {
-		return len(b.Bytes)
-	}
-	return b.Size
-}
-func (b *sszFixedBytes) EncodeSSZ(dst []byte) ([]byte, error) {
-	size := b.EncodingSizeSSZ()
-	if len(b.Bytes) != size {
-		return nil, fmt.Errorf("fixed bytes length %d, want %d", len(b.Bytes), size)
-	}
-	return append(dst, b.Bytes...), nil
-}
-func (b *sszFixedBytes) DecodeSSZ(buf []byte, _ int) error {
-	size := b.EncodingSizeSSZ()
-	if len(buf) < size {
-		return errors.New("short fixed bytes")
-	}
-	b.Bytes = common.Copy(buf[:size])
-	return nil
-}
-func (b *sszFixedBytes) HashSSZ() ([32]byte, error) {
-	var h common.Hash
-	copy(h[:], b.Bytes)
-	return h, nil
-}
-func (b *sszFixedBytes) Clone() clonable.Clonable {
-	if b == nil {
-		return &sszFixedBytes{}
-	}
-	return &sszFixedBytes{Size: b.Size}
 }
 
 type sszGetBlobsV1Response struct {
@@ -523,56 +427,26 @@ func (r *sszGetBlobsV2Response) DecodeSSZ(buf []byte, version int) error {
 func (r *sszGetBlobsV2Response) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }
 func (*sszGetBlobsV2Response) Clone() clonable.Clonable { return &sszGetBlobsV2Response{} }
 
-type sszNullableBlobAndProofV2 struct {
-	BlobAndProof *solid.ListSSZ[*engine_types.BlobAndProofV2]
-}
-
-func newSSZNullableBlobAndProofV2(blob *engine_types.BlobAndProofV2) *sszNullableBlobAndProofV2 {
-	l := solid.NewDynamicListSSZ[*engine_types.BlobAndProofV2](1)
-	if blob != nil {
-		l.Append(blob)
-	}
-	return &sszNullableBlobAndProofV2{BlobAndProof: l}
-}
-func (n *sszNullableBlobAndProofV2) Static() bool { return false }
-func (n *sszNullableBlobAndProofV2) EncodeSSZ(dst []byte) ([]byte, error) {
-	if n.BlobAndProof == nil {
-		n.BlobAndProof = solid.NewDynamicListSSZ[*engine_types.BlobAndProofV2](1)
-	}
-	return ssz2.MarshalSSZ(dst, n.BlobAndProof)
-}
-func (n *sszNullableBlobAndProofV2) DecodeSSZ(buf []byte, version int) error {
-	n.BlobAndProof = solid.NewDynamicListSSZ[*engine_types.BlobAndProofV2](1)
-	return ssz2.UnmarshalSSZ(buf, version, n.BlobAndProof)
-}
-func (n *sszNullableBlobAndProofV2) EncodingSizeSSZ() int { b, _ := n.EncodeSSZ(nil); return len(b) }
-func (n *sszNullableBlobAndProofV2) HashSSZ() ([32]byte, error) {
-	return [32]byte{}, nil
-}
-func (*sszNullableBlobAndProofV2) Clone() clonable.Clonable {
-	return &sszNullableBlobAndProofV2{}
-}
-
 type sszGetBlobsV3Response struct {
-	BlobsAndProofs *solid.ListSSZ[*sszNullableBlobAndProofV2]
+	BlobsAndProofs *solid.ListSSZ[*engine_types.NullableBlobAndProofV2]
 }
 
 func newSSZGetBlobsV3Response(blobs []*engine_types.BlobAndProofV2) *sszGetBlobsV3Response {
-	l := solid.NewDynamicListSSZ[*sszNullableBlobAndProofV2](sszMaxGetBlobHashes)
+	l := solid.NewDynamicListSSZ[*engine_types.NullableBlobAndProofV2](sszMaxGetBlobHashes)
 	for _, blob := range blobs {
-		l.Append(newSSZNullableBlobAndProofV2(blob))
+		l.Append(engine_types.NewNullableBlobAndProofV2(blob))
 	}
 	return &sszGetBlobsV3Response{BlobsAndProofs: l}
 }
 func (r *sszGetBlobsV3Response) Static() bool { return false }
 func (r *sszGetBlobsV3Response) EncodeSSZ(dst []byte) ([]byte, error) {
 	if r.BlobsAndProofs == nil {
-		r.BlobsAndProofs = solid.NewDynamicListSSZ[*sszNullableBlobAndProofV2](sszMaxGetBlobHashes)
+		r.BlobsAndProofs = solid.NewDynamicListSSZ[*engine_types.NullableBlobAndProofV2](sszMaxGetBlobHashes)
 	}
 	return ssz2.MarshalSSZ(dst, r.BlobsAndProofs)
 }
 func (r *sszGetBlobsV3Response) DecodeSSZ(buf []byte, version int) error {
-	r.BlobsAndProofs = solid.NewDynamicListSSZ[*sszNullableBlobAndProofV2](sszMaxGetBlobHashes)
+	r.BlobsAndProofs = solid.NewDynamicListSSZ[*engine_types.NullableBlobAndProofV2](sszMaxGetBlobHashes)
 	return ssz2.UnmarshalSSZ(buf, version, r.BlobsAndProofs)
 }
 func (r *sszGetBlobsV3Response) EncodingSizeSSZ() int   { b, _ := r.EncodeSSZ(nil); return len(b) }

--- a/execution/engineapi/sszrest_wire.go
+++ b/execution/engineapi/sszrest_wire.go
@@ -20,7 +20,6 @@ import (
 	"github.com/erigontech/erigon/cl/cltypes/solid"
 	ssz2 "github.com/erigontech/erigon/cl/ssz"
 	"github.com/erigontech/erigon/common"
-	"github.com/erigontech/erigon/common/clonable"
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/execution/engineapi/engine_types"
 	"github.com/erigontech/erigon/execution/types"
@@ -62,82 +61,6 @@ func transactionsBytes(txs *solid.TransactionsSSZ) []hexutil.Bytes {
 	return out
 }
 
-type sszRESTMessageKind uint8
-
-const (
-	sszMessageForkchoiceRequest sszRESTMessageKind = iota
-	sszMessageForkchoiceResponse
-	sszMessageNewPayloadRequest
-	sszMessageCapabilities
-	sszMessageClientVersionRequest
-	sszMessageClientVersionResponse
-	sszMessageGetPayloadResponse
-	sszMessageGetBlobsV1Response
-	sszMessageGetBlobsV2Response
-	sszMessageGetBlobsV3Response
-)
-
-type sszRESTMessage struct {
-	kind    sszRESTMessageKind
-	version clparams.StateVersion
-
-	State     engine_types.ForkChoiceState
-	AttrsList *solid.ListSSZ[*engine_types.PayloadAttributes]
-	Status    *engine_types.PayloadStatus
-	PayloadID *solid.ByteListSSZ
-
-	Payload               *engine_types.ExecutionPayload
-	ExpectedBlobHashes    solid.HashListSSZ
-	ParentBeaconBlockRoot common.Hash
-	ExecutionRequests     *solid.TransactionsSSZ
-
-	Capabilities    []*solid.ByteListSSZ
-	ClientVersion   *engine_types.ClientVersionV1
-	ClientVersions  *solid.ListSSZ[*engine_types.ClientVersionV1]
-	BlockValue      common.Hash
-	BlobsBundle     *engine_types.BlobsBundle
-	OverrideBuilder bool
-	PayloadRequests *cltypes.ExecutionRequests
-
-	BlobsAndProofsV1 *solid.ListSSZ[*engine_types.BlobAndProofV1]
-	BlobsAndProofsV2 *solid.ListSSZ[*engine_types.BlobAndProofV2]
-	BlobsAndProofsV3 *solid.ListSSZ[*engine_types.NullableBlobAndProofV2]
-}
-
-func newSSZRESTMessage(kind sszRESTMessageKind, version clparams.StateVersion) *sszRESTMessage {
-	m := &sszRESTMessage{kind: kind, version: version}
-	m.init()
-	return m
-}
-
-func (m *sszRESTMessage) init() {
-	switch m.kind {
-	case sszMessageForkchoiceRequest:
-		m.AttrsList = solid.NewDynamicListSSZ[*engine_types.PayloadAttributes](1)
-	case sszMessageForkchoiceResponse:
-		m.Status = &engine_types.PayloadStatus{}
-		m.PayloadID = solid.NewByteListSSZ(8)
-	case sszMessageNewPayloadRequest:
-		m.Payload = engine_types.NewExecutionPayloadSSZ(m.version)
-		m.ExpectedBlobHashes = solid.NewHashList(sszMaxBlobHashes)
-		m.ExecutionRequests = &solid.TransactionsSSZ{}
-	case sszMessageClientVersionRequest:
-		m.ClientVersion = &engine_types.ClientVersionV1{}
-	case sszMessageClientVersionResponse:
-		m.ClientVersions = solid.NewDynamicListSSZ[*engine_types.ClientVersionV1](4)
-	case sszMessageGetPayloadResponse:
-		m.Payload = engine_types.NewExecutionPayloadSSZ(m.version)
-		m.BlobsBundle = engine_types.NewBlobsBundleSSZ(m.version)
-		m.PayloadRequests = cltypes.NewExecutionRequests(mainnetBeaconCfg)
-	case sszMessageGetBlobsV1Response:
-		m.BlobsAndProofsV1 = solid.NewStaticListSSZ[*engine_types.BlobAndProofV1](sszMaxGetBlobHashes, sszBlobBytes+sszKZGBytes)
-	case sszMessageGetBlobsV2Response:
-		m.BlobsAndProofsV2 = solid.NewDynamicListSSZ[*engine_types.BlobAndProofV2](sszMaxGetBlobHashes)
-	case sszMessageGetBlobsV3Response:
-		m.BlobsAndProofsV3 = solid.NewDynamicListSSZ[*engine_types.NullableBlobAndProofV2](sszMaxGetBlobHashes)
-	}
-}
-
 func validatePayloadIDList(id *solid.ByteListSSZ) error {
 	if id == nil {
 		return nil
@@ -148,199 +71,132 @@ func validatePayloadIDList(id *solid.ByteListSSZ) error {
 	return nil
 }
 
-func (m *sszRESTMessage) Static() bool { return false }
-func (m *sszRESTMessage) EncodeSSZ(dst []byte) ([]byte, error) {
-	switch m.kind {
-	case sszMessageForkchoiceRequest:
-		if m.AttrsList == nil {
-			m.AttrsList = solid.NewDynamicListSSZ[*engine_types.PayloadAttributes](1)
-		}
-		return ssz2.MarshalSSZ(dst, &m.State, m.AttrsList)
-	case sszMessageForkchoiceResponse:
-		if m.PayloadID == nil {
-			m.PayloadID = solid.NewByteListSSZ(8)
-		}
-		if err := validatePayloadIDList(m.PayloadID); err != nil {
+func newPayloadRequestSchema(version clparams.StateVersion, payload *engine_types.ExecutionPayload, blobHashes solid.HashListSSZ, parentRoot *common.Hash, requests *solid.TransactionsSSZ) []any {
+	switch version {
+	case clparams.BellatrixVersion, clparams.CapellaVersion:
+		return []any{payload}
+	case clparams.DenebVersion:
+		return []any{payload, blobHashes, parentRoot[:]}
+	default:
+		return []any{payload, blobHashes, parentRoot[:], requests}
+	}
+}
+
+func decodeNewPayloadRequest(buf []byte, version clparams.StateVersion) (*engine_types.ExecutionPayload, solid.HashListSSZ, common.Hash, *solid.TransactionsSSZ, error) {
+	payload := engine_types.NewExecutionPayloadSSZ(version)
+	blobHashes := solid.NewHashList(sszMaxBlobHashes)
+	parentRoot := common.Hash{}
+	requests := &solid.TransactionsSSZ{}
+	err := ssz2.UnmarshalSSZ(buf, int(version), newPayloadRequestSchema(version, payload, blobHashes, &parentRoot, requests)...)
+	return payload, blobHashes, parentRoot, requests, err
+}
+
+func encodeNewPayloadRequest(version clparams.StateVersion, payload *engine_types.ExecutionPayload, blobHashes solid.HashListSSZ, parentRoot common.Hash, requests *solid.TransactionsSSZ) ([]byte, error) {
+	return ssz2.MarshalSSZ(nil, newPayloadRequestSchema(version, payload, blobHashes, &parentRoot, requests)...)
+}
+
+func decodeForkchoiceRequest(buf []byte, version clparams.StateVersion) (engine_types.ForkChoiceState, *engine_types.PayloadAttributes, error) {
+	state := engine_types.ForkChoiceState{}
+	attrsList := solid.NewDynamicListSSZ[*engine_types.PayloadAttributes](1)
+	if err := ssz2.UnmarshalSSZ(buf, int(version), &state, attrsList); err != nil {
+		return state, nil, err
+	}
+	if attrsList.Len() == 0 {
+		return state, nil, nil
+	}
+	attrs := attrsList.Get(0)
+	attrs.SSZVersion = version
+	return state, attrs, nil
+}
+
+func encodeForkchoiceRequest(version clparams.StateVersion, state *engine_types.ForkChoiceState, attrs *engine_types.PayloadAttributes) ([]byte, error) {
+	attrsList := solid.NewDynamicListSSZ[*engine_types.PayloadAttributes](1)
+	if attrs != nil {
+		attrs.SSZVersion = version
+		attrsList.Append(attrs)
+	}
+	return ssz2.MarshalSSZ(nil, state, attrsList)
+}
+
+func encodeForkchoiceResponse(resp *engine_types.ForkChoiceUpdatedResponse) ([]byte, error) {
+	payloadID := solid.NewByteListSSZ(8)
+	if resp.PayloadId != nil && len(*resp.PayloadId) == 8 {
+		if err := payloadID.SetBytes(*resp.PayloadId); err != nil {
 			return nil, err
 		}
-		return ssz2.MarshalSSZ(dst, m.Status, m.PayloadID)
-	case sszMessageNewPayloadRequest:
-		switch m.version {
-		case clparams.BellatrixVersion, clparams.CapellaVersion:
-			return ssz2.MarshalSSZ(dst, m.Payload)
-		case clparams.DenebVersion:
-			return ssz2.MarshalSSZ(dst, m.Payload, m.ExpectedBlobHashes, m.ParentBeaconBlockRoot[:])
-		default:
-			return ssz2.MarshalSSZ(dst, m.Payload, m.ExpectedBlobHashes, m.ParentBeaconBlockRoot[:], m.ExecutionRequests)
-		}
-	case sszMessageCapabilities:
-		return m.encodeCapabilities(dst)
-	case sszMessageClientVersionRequest:
-		return ssz2.MarshalSSZ(dst, m.ClientVersion)
-	case sszMessageClientVersionResponse:
-		return ssz2.MarshalSSZ(dst, m.ClientVersions)
-	case sszMessageGetPayloadResponse:
-		switch m.version {
-		case clparams.CapellaVersion:
-			return ssz2.MarshalSSZ(dst, m.Payload, m.BlockValue[:])
-		case clparams.DenebVersion:
-			return ssz2.MarshalSSZ(dst, m.Payload, m.BlockValue[:], m.BlobsBundle, m.OverrideBuilder)
-		default:
-			return ssz2.MarshalSSZ(dst, m.Payload, m.BlockValue[:], m.BlobsBundle, m.OverrideBuilder, m.PayloadRequests)
-		}
-	case sszMessageGetBlobsV1Response:
-		if m.BlobsAndProofsV1 == nil {
-			m.BlobsAndProofsV1 = solid.NewStaticListSSZ[*engine_types.BlobAndProofV1](sszMaxGetBlobHashes, sszBlobBytes+sszKZGBytes)
-		}
-		return ssz2.MarshalSSZ(dst, m.BlobsAndProofsV1)
-	case sszMessageGetBlobsV2Response:
-		if m.BlobsAndProofsV2 == nil {
-			m.BlobsAndProofsV2 = solid.NewDynamicListSSZ[*engine_types.BlobAndProofV2](sszMaxGetBlobHashes)
-		}
-		return ssz2.MarshalSSZ(dst, m.BlobsAndProofsV2)
-	case sszMessageGetBlobsV3Response:
-		if m.BlobsAndProofsV3 == nil {
-			m.BlobsAndProofsV3 = solid.NewDynamicListSSZ[*engine_types.NullableBlobAndProofV2](sszMaxGetBlobHashes)
-		}
-		return ssz2.MarshalSSZ(dst, m.BlobsAndProofsV3)
-	default:
-		return nil, fmt.Errorf("unknown SSZ REST message kind %d", m.kind)
 	}
+	if err := validatePayloadIDList(payloadID); err != nil {
+		return nil, err
+	}
+	return ssz2.MarshalSSZ(nil, resp.PayloadStatus, payloadID)
 }
 
-func (m *sszRESTMessage) DecodeSSZ(buf []byte, version int) error {
-	m.version = clparams.StateVersion(version)
-	m.init()
-	switch m.kind {
-	case sszMessageForkchoiceRequest:
-		return ssz2.UnmarshalSSZ(buf, version, &m.State, m.AttrsList)
-	case sszMessageForkchoiceResponse:
-		if err := ssz2.UnmarshalSSZ(buf, version, m.Status, m.PayloadID); err != nil {
-			return err
-		}
-		return validatePayloadIDList(m.PayloadID)
-	case sszMessageNewPayloadRequest:
-		switch m.version {
-		case clparams.BellatrixVersion, clparams.CapellaVersion:
-			return ssz2.UnmarshalSSZ(buf, version, m.Payload)
-		case clparams.DenebVersion:
-			return ssz2.UnmarshalSSZ(buf, version, m.Payload, m.ExpectedBlobHashes, m.ParentBeaconBlockRoot[:])
-		default:
-			return ssz2.UnmarshalSSZ(buf, version, m.Payload, m.ExpectedBlobHashes, m.ParentBeaconBlockRoot[:], m.ExecutionRequests)
-		}
-	case sszMessageCapabilities:
-		return m.decodeCapabilities(buf, version)
-	case sszMessageClientVersionRequest:
-		return ssz2.UnmarshalSSZ(buf, version, m.ClientVersion)
-	case sszMessageClientVersionResponse:
-		return ssz2.UnmarshalSSZ(buf, version, m.ClientVersions)
-	case sszMessageGetPayloadResponse:
-		switch m.version {
-		case clparams.CapellaVersion:
-			return ssz2.UnmarshalSSZ(buf, version, m.Payload, m.BlockValue[:])
-		case clparams.DenebVersion:
-			return ssz2.UnmarshalSSZ(buf, version, m.Payload, m.BlockValue[:], m.BlobsBundle, &m.OverrideBuilder)
-		default:
-			return ssz2.UnmarshalSSZ(buf, version, m.Payload, m.BlockValue[:], m.BlobsBundle, &m.OverrideBuilder, m.PayloadRequests)
-		}
-	case sszMessageGetBlobsV1Response:
-		return ssz2.UnmarshalSSZ(buf, version, m.BlobsAndProofsV1)
-	case sszMessageGetBlobsV2Response:
-		return ssz2.UnmarshalSSZ(buf, version, m.BlobsAndProofsV2)
-	case sszMessageGetBlobsV3Response:
-		return ssz2.UnmarshalSSZ(buf, version, m.BlobsAndProofsV3)
-	default:
-		return fmt.Errorf("unknown SSZ REST message kind %d", m.kind)
+func encodeCapabilities(names []string) ([]byte, error) {
+	capabilities := make([]*solid.ByteListSSZ, 0, len(names))
+	for _, name := range names {
+		capabilities = append(capabilities, capabilityName(name))
 	}
-}
-
-func (m *sszRESTMessage) EncodingSizeSSZ() int { b, _ := m.EncodeSSZ(nil); return len(b) }
-func (m *sszRESTMessage) Clone() clonable.Clonable {
-	return newSSZRESTMessage(m.kind, m.version)
-}
-
-func (m *sszRESTMessage) payloadAttributes() *engine_types.PayloadAttributes {
-	if m.AttrsList == nil || m.AttrsList.Len() == 0 {
-		return nil
+	if len(capabilities) > sszMaxCapabilities {
+		return nil, fmt.Errorf("too many capabilities: %d", len(capabilities))
 	}
-	a := m.AttrsList.Get(0)
-	a.SSZVersion = m.version
-	return a
-}
-
-func (m *sszRESTMessage) encodeCapabilities(dst []byte) ([]byte, error) {
-	if len(m.Capabilities) > sszMaxCapabilities {
-		return nil, fmt.Errorf("too many capabilities: %d", len(m.Capabilities))
-	}
-	offset := len(m.Capabilities) * 4
-	for _, capability := range m.Capabilities {
+	out := make([]byte, 0)
+	offset := len(capabilities) * 4
+	for _, capability := range capabilities {
 		if capability == nil {
 			capability = solid.NewByteListSSZ(sszMaxCapabilityNameBytes)
 		}
-		dst = append(dst, 0, 0, 0, 0)
-		binary.LittleEndian.PutUint32(dst[len(dst)-4:], uint32(offset))
+		out = append(out, 0, 0, 0, 0)
+		binary.LittleEndian.PutUint32(out[len(out)-4:], uint32(offset))
 		offset += capability.EncodingSizeSSZ()
 	}
-	for _, capability := range m.Capabilities {
+	for _, capability := range capabilities {
 		if capability == nil {
 			capability = solid.NewByteListSSZ(sszMaxCapabilityNameBytes)
 		}
 		var err error
-		dst, err = capability.EncodeSSZ(dst)
+		out, err = capability.EncodeSSZ(out)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return dst, nil
+	return out, nil
 }
 
-func (m *sszRESTMessage) decodeCapabilities(buf []byte, version int) error {
-	m.Capabilities = nil
+func decodeCapabilities(buf []byte, version int) ([]string, error) {
 	if len(buf) == 0 {
-		return nil
+		return nil, nil
 	}
 	if len(buf) < 4 {
-		return fmt.Errorf("capabilities: short offset table")
+		return nil, fmt.Errorf("capabilities: short offset table")
 	}
 	firstOffset := binary.LittleEndian.Uint32(buf[:4])
 	if firstOffset%4 != 0 || firstOffset > uint32(len(buf)) {
-		return fmt.Errorf("capabilities: bad first offset %d", firstOffset)
+		return nil, fmt.Errorf("capabilities: bad first offset %d", firstOffset)
 	}
 	count := int(firstOffset / 4)
 	if count > sszMaxCapabilities {
-		return fmt.Errorf("too many capabilities: %d", count)
+		return nil, fmt.Errorf("too many capabilities: %d", count)
 	}
 	offsets := make([]uint32, count+1)
 	offsets[count] = uint32(len(buf))
 	for i := 0; i < count; i++ {
 		offsets[i] = binary.LittleEndian.Uint32(buf[i*4:])
 		if i > 0 && offsets[i] < offsets[i-1] {
-			return fmt.Errorf("capabilities: non-monotonic offset %d", i)
+			return nil, fmt.Errorf("capabilities: non-monotonic offset %d", i)
 		}
 		if offsets[i] > uint32(len(buf)) {
-			return fmt.Errorf("capabilities: offset %d out of bounds", i)
+			return nil, fmt.Errorf("capabilities: offset %d out of bounds", i)
 		}
 	}
-	m.Capabilities = make([]*solid.ByteListSSZ, 0, count)
+	out := make([]string, 0, count)
 	for i := 0; i < count; i++ {
 		capability := solid.NewByteListSSZ(sszMaxCapabilityNameBytes)
 		if err := capability.DecodeSSZ(buf[offsets[i]:offsets[i+1]], version); err != nil {
-			return err
+			return nil, err
 		}
-		m.Capabilities = append(m.Capabilities, capability)
+		out = append(out, string(capability.Bytes()))
 	}
-	return nil
-}
-
-func (m *sszRESTMessage) capabilityNames() []string {
-	if m.Capabilities == nil {
-		return nil
-	}
-	out := make([]string, 0, len(m.Capabilities))
-	for _, v := range m.Capabilities {
-		out = append(out, string(v.Bytes()))
-	}
-	return out
+	return out, nil
 }
 
 func capabilityName(s string) *solid.ByteListSSZ {
@@ -349,36 +205,20 @@ func capabilityName(s string) *solid.ByteListSSZ {
 	return b
 }
 
-func forkchoiceResponseToSSZ(resp *engine_types.ForkChoiceUpdatedResponse) (*sszRESTMessage, error) {
-	msg := newSSZRESTMessage(sszMessageForkchoiceResponse, 0)
-	msg.Status = resp.PayloadStatus
-	if resp.PayloadId != nil && len(*resp.PayloadId) == 8 {
-		if err := msg.PayloadID.SetBytes(*resp.PayloadId); err != nil {
-			return nil, err
-		}
-	}
-	return msg, nil
-}
-
-func newSSZNewPayloadRequest(version clparams.StateVersion) *sszRESTMessage {
-	return newSSZRESTMessage(sszMessageNewPayloadRequest, version)
-}
-
-func newSSZCapabilities(names []string) *sszRESTMessage {
-	msg := newSSZRESTMessage(sszMessageCapabilities, 0)
-	msg.Capabilities = make([]*solid.ByteListSSZ, 0, len(names))
-	for _, name := range names {
-		msg.Capabilities = append(msg.Capabilities, capabilityName(name))
-	}
-	return msg
-}
-
-func newSSZClientVersionResponse(versions []engine_types.ClientVersionV1) *sszRESTMessage {
-	msg := newSSZRESTMessage(sszMessageClientVersionResponse, 0)
+func encodeClientVersionResponse(versions []engine_types.ClientVersionV1) ([]byte, error) {
+	list := solid.NewDynamicListSSZ[*engine_types.ClientVersionV1](4)
 	for i := range versions {
-		msg.ClientVersions.Append(&versions[i])
+		list.Append(&versions[i])
 	}
-	return msg
+	return ssz2.MarshalSSZ(nil, list)
+}
+
+func decodeClientVersionRequest(buf []byte) (*engine_types.ClientVersionV1, error) {
+	version := &engine_types.ClientVersionV1{}
+	if err := ssz2.UnmarshalSSZ(buf, 0, version); err != nil {
+		return nil, err
+	}
+	return version, nil
 }
 
 func blockValueHash(v *hexutil.Big) common.Hash {
@@ -402,20 +242,23 @@ func newBlobsBundleSSZ(b *engine_types.BlobsBundle, version clparams.StateVersio
 	return b
 }
 
-func newSSZGetPayloadResponse(resp *engine_types.GetPayloadResponse, version clparams.StateVersion) (*sszRESTMessage, error) {
+func encodeGetPayloadResponse(resp *engine_types.GetPayloadResponse, version clparams.StateVersion) ([]byte, error) {
 	payload := resp.ExecutionPayload
 	payload.SSZVersion = version
 	executionRequests, err := executionRequestsFromList(resp.ExecutionRequests, version)
 	if err != nil {
 		return nil, err
 	}
-	msg := newSSZRESTMessage(sszMessageGetPayloadResponse, version)
-	msg.Payload = payload
-	msg.BlockValue = blockValueHash(resp.BlockValue)
-	msg.BlobsBundle = newBlobsBundleSSZ(resp.BlobsBundle, version)
-	msg.OverrideBuilder = resp.ShouldOverrideBuilder
-	msg.PayloadRequests = executionRequests
-	return msg, nil
+	blockValue := blockValueHash(resp.BlockValue)
+	blobsBundle := newBlobsBundleSSZ(resp.BlobsBundle, version)
+	switch version {
+	case clparams.CapellaVersion:
+		return ssz2.MarshalSSZ(nil, payload, blockValue[:])
+	case clparams.DenebVersion:
+		return ssz2.MarshalSSZ(nil, payload, blockValue[:], blobsBundle, resp.ShouldOverrideBuilder)
+	default:
+		return ssz2.MarshalSSZ(nil, payload, blockValue[:], blobsBundle, resp.ShouldOverrideBuilder, executionRequests)
+	}
 }
 
 func executionRequestsFromList(requests []hexutil.Bytes, version clparams.StateVersion) (*cltypes.ExecutionRequests, error) {
@@ -445,30 +288,30 @@ func executionRequestsFromList(requests []hexutil.Bytes, version clparams.StateV
 	return out, nil
 }
 
-func newSSZGetBlobsV1Response(blobs []*engine_types.BlobAndProofV1) *sszRESTMessage {
-	msg := newSSZRESTMessage(sszMessageGetBlobsV1Response, 0)
+func encodeGetBlobsV1Response(blobs []*engine_types.BlobAndProofV1) ([]byte, error) {
+	list := solid.NewStaticListSSZ[*engine_types.BlobAndProofV1](sszMaxGetBlobHashes, sszBlobBytes+sszKZGBytes)
 	for _, blob := range blobs {
 		if blob != nil {
-			msg.BlobsAndProofsV1.Append(blob)
+			list.Append(blob)
 		}
 	}
-	return msg
+	return ssz2.MarshalSSZ(nil, list)
 }
 
-func newSSZGetBlobsV2Response(blobs []*engine_types.BlobAndProofV2) *sszRESTMessage {
-	msg := newSSZRESTMessage(sszMessageGetBlobsV2Response, 0)
+func encodeGetBlobsV2Response(blobs []*engine_types.BlobAndProofV2) ([]byte, error) {
+	list := solid.NewDynamicListSSZ[*engine_types.BlobAndProofV2](sszMaxGetBlobHashes)
 	for _, blob := range blobs {
 		if blob != nil {
-			msg.BlobsAndProofsV2.Append(blob)
+			list.Append(blob)
 		}
 	}
-	return msg
+	return ssz2.MarshalSSZ(nil, list)
 }
 
-func newSSZGetBlobsV3Response(blobs []*engine_types.BlobAndProofV2) *sszRESTMessage {
-	msg := newSSZRESTMessage(sszMessageGetBlobsV3Response, 0)
+func encodeGetBlobsV3Response(blobs []*engine_types.BlobAndProofV2) ([]byte, error) {
+	list := solid.NewDynamicListSSZ[*engine_types.NullableBlobAndProofV2](sszMaxGetBlobHashes)
 	for _, blob := range blobs {
-		msg.BlobsAndProofsV3.Append(engine_types.NewNullableBlobAndProofV2(blob))
+		list.Append(engine_types.NewNullableBlobAndProofV2(blob))
 	}
-	return msg
+	return ssz2.MarshalSSZ(nil, list)
 }


### PR DESCRIPTION
## Summary

Adds an authenticated SSZ-REST transport for the Engine API alongside the existing JSON-RPC path.

- Adds `/engine/v*/payloads`, `/engine/v*/forkchoice`, `/engine/v*/blobs`, `/engine/v1/client/version`, and `/engine/v1/capabilities` handlers.
- Advertises SSZ endpoint capabilities through `engine_exchangeCapabilities` while preserving JSON-RPC fallback.
- Implements Erigon-native SSZ wire types using `cl/ssz` encode/decode patterns.
- Adds focused SSZ-REST handler/wire tests.
- Adds Kurtosis devnet material for Prysm + Erigon + Spamoor with 4s slots.

## Verification

- Agent verifier completed all checks under `/root/gevm-erigon/agi/sszrest_verifier`.
- Live Kurtosis interop run completed with Prysm + Erigon + Spamoor.
- Devnet used 4 second slots (`seconds_per_slot = 4`, `slot_duration_ms = 4000`).
- Erigon logs showed SSZ-REST `getPayload`, `newPayload`, and `forkchoice` traffic.
- Prysm synced blocks and issued forkchoice updates.
- Spamoor confirmed transactions.
- Final verifier scan found no fatal Engine API errors.
