### PR TITLE
disable usage of references when merging commitment files 

### DIFF
--- a/db/state/domain_committed.go
+++ b/db/state/domain_committed.go
@@ -49,9 +49,8 @@ func (at *AggregatorRoTx) replaceShortenedKeysInBranch(prefix []byte, branch com
 	logger := log.Root()
 	aggTx := at
 
-	commitmentUseReferencedBranches := at.a.Cfg(kv.CommitmentDomain).ReplaceKeysInValues
-	if !commitmentUseReferencedBranches || len(branch) == 0 || bytes.Equal(prefix, commitmentdb.KeyCommitmentState) ||
-		aggTx.TxNumsInFiles(kv.StateDomains...) == 0 || !ValuesPlainKeyReferencingThresholdReached(at.StepSize(), fStartTxNum, fEndTxNum) {
+	if len(branch) == 0 || bytes.Equal(prefix, commitmentdb.KeyCommitmentState) ||
+		aggTx.TxNumsInFiles(kv.StateDomains...) == 0 {
 
 		return branch, nil // do not transform, return as is
 	}

--- a/db/state/domain_committed.go
+++ b/db/state/domain_committed.go
@@ -58,10 +58,8 @@ func (at *AggregatorRoTx) replaceShortenedKeysInBranch(prefix []byte, branch com
 	sto := aggTx.d[kv.StorageDomain]
 	acc := aggTx.d[kv.AccountsDomain]
 
-	// Lazily resolve the storage/account file getters: a branch may contain only full keys
-	// (in particular once AggregatorSqueezeCommitmentValues is off and no past-threshold
-	// shortened files remain), in which case no per-key lookup is needed and we can skip
-	// the visible-file resolution entirely.
+	// Getters are resolved on first shortened-ref hit, per domain. Branches with only full
+	// keys (the common case once ReplaceKeysInValues is off) skip file resolution entirely.
 	var storageGetter, accountGetter *seg.Reader
 	ensureStorageGetter := func() error {
 		if storageGetter != nil {

--- a/db/state/domain_committed.go
+++ b/db/state/domain_committed.go
@@ -57,18 +57,37 @@ func (at *AggregatorRoTx) replaceShortenedKeysInBranch(prefix []byte, branch com
 
 	sto := aggTx.d[kv.StorageDomain]
 	acc := aggTx.d[kv.AccountsDomain]
-	storageItem, err := sto.lookupVisibleFileByRange(fStartTxNum, fEndTxNum)
-	if err != nil {
-		logger.Crit("dereference key during commitment read", "failed", err.Error())
-		return nil, err
+
+	// Lazily resolve the storage/account file getters: a branch may contain only full keys
+	// (in particular once AggregatorSqueezeCommitmentValues is off and no past-threshold
+	// shortened files remain), in which case no per-key lookup is needed and we can skip
+	// the visible-file resolution entirely.
+	var storageGetter, accountGetter *seg.Reader
+	ensureStorageGetter := func() error {
+		if storageGetter != nil {
+			return nil
+		}
+		item, err := sto.lookupVisibleFileByRange(fStartTxNum, fEndTxNum)
+		if err != nil {
+			logger.Crit("dereference key during commitment read", "failed", err.Error())
+			return err
+		}
+		storageGetter = sto.dataReader(item.decompressor)
+		return nil
 	}
-	accountItem, err := acc.lookupVisibleFileByRange(fStartTxNum, fEndTxNum)
-	if err != nil {
-		logger.Crit("dereference key during commitment read", "failed", err.Error())
-		return nil, err
+	ensureAccountGetter := func() error {
+		if accountGetter != nil {
+			return nil
+		}
+		item, err := acc.lookupVisibleFileByRange(fStartTxNum, fEndTxNum)
+		if err != nil {
+			logger.Crit("dereference key during commitment read", "failed", err.Error())
+			return err
+		}
+		accountGetter = acc.dataReader(item.decompressor)
+		return nil
 	}
-	storageGetter := sto.dataReader(storageItem.decompressor)
-	accountGetter := acc.dataReader(accountItem.decompressor)
+
 	metricI := 0
 	for i, f := range aggTx.d[kv.CommitmentDomain].files {
 		if i > 5 {
@@ -88,6 +107,9 @@ func (at *AggregatorRoTx) replaceShortenedKeysInBranch(prefix []byte, branch com
 			if dbg.KVReadLevelledMetrics {
 				defer branchKeyDerefSpent[metricI].ObserveDuration(time.Now())
 			}
+			if err := ensureStorageGetter(); err != nil {
+				return nil, err
+			}
 			// Optimised key referencing a state file record (file number and offset within the file)
 			storagePlainKey, found := sto.lookupByShortenedKey(key, storageGetter)
 			if !found {
@@ -105,6 +127,9 @@ func (at *AggregatorRoTx) replaceShortenedKeysInBranch(prefix []byte, branch com
 
 		if dbg.KVReadLevelledMetrics {
 			defer branchKeyDerefSpent[metricI].ObserveDuration(time.Now())
+		}
+		if err := ensureAccountGetter(); err != nil {
+			return nil, err
 		}
 		apkBuf, found := acc.lookupByShortenedKey(key, accountGetter)
 		if !found {

--- a/db/state/domain_committed.go
+++ b/db/state/domain_committed.go
@@ -252,149 +252,87 @@ func (dt *DomainRoTx) lookupByShortenedKey(shortKey []byte, getter *seg.Reader) 
 	return dt.lookupFullKey, true
 }
 
-// commitmentValTransform parses the value of the commitment record to extract references
-// to accounts and storage items, then looks them up in the new, merged files, and replaces them with
-// the updated references
+// commitmentValTransformDomain returns a per-value transform for merging commitment files.
+// For each branch value it expands any referenced keys back to full keys using the constituent
+// account/storage files, and emits full keys in the output. Re-encoding into shortened refs
+// (squeeze) is no longer performed here — squeeze runs separately. mergedAccount/mergedStorage
+// are kept in the signature for caller compatibility but are unused.
 func (dt *DomainRoTx) commitmentValTransformDomain(rng MergeRange, accounts, storage *DomainRoTx, mergedAccount, mergedStorage *FilesItem) (valueTransformer, error) {
 	if !rng.needMerge {
 		panic(fmt.Sprintf("assert: commitmentValTransformDomain called with domain.needMerge=false (from=%d to=%d): caller must guard with values.needMerge", rng.from, rng.to))
 	}
-	var keyBuf [60]byte // 52b key and 8b for inverted step
-	var err error
-	shortened := make([]byte, 16)
+	_ = mergedAccount
+	_ = mergedStorage
 
-	hadToLookupStorage := mergedStorage == nil
-	if mergedStorage == nil {
-		if mergedStorage, err = storage.lookupVisibleFileByRange(rng.from, rng.to); err != nil {
-			// TODO may allow to merge, but storage keys will be stored as plainkeys
-			return nil, err
-		}
-	}
-
-	hadToLookupAccount := mergedAccount == nil
-	if mergedAccount == nil {
-		if mergedAccount, err = accounts.lookupVisibleFileByRange(rng.from, rng.to); err != nil {
-			return nil, err
-		}
-	}
-
-	dr := DomainRanges{values: rng}
+	// Constituent-file getters resolve on first referenced-key hit, per (from,to) range.
+	// Branches whose keys are already full (the common case once ReplaceKeysInValues is off
+	// or noref files are released) skip file resolution entirely.
 	accountFileMap := make(map[uint64]map[uint64]*seg.Reader)
-	if accountList, _, _ := accounts.staticFilesInRange(dr); accountList != nil {
-		for _, f := range accountList {
-			if _, ok := accountFileMap[f.startTxNum]; !ok {
-				accountFileMap[f.startTxNum] = make(map[uint64]*seg.Reader)
-			}
-			accountFileMap[f.startTxNum][f.endTxNum] = accounts.dataReader(f.decompressor)
-		}
-	}
 	storageFileMap := make(map[uint64]map[uint64]*seg.Reader)
-	if storageList, _, _ := storage.staticFilesInRange(dr); storageList != nil {
-		for _, f := range storageList {
-			if _, ok := storageFileMap[f.startTxNum]; !ok {
-				storageFileMap[f.startTxNum] = make(map[uint64]*seg.Reader)
-			}
-			storageFileMap[f.startTxNum][f.endTxNum] = storage.dataReader(f.decompressor)
-		}
-	}
-
-	ms := storage.dataReader(mergedStorage.decompressor)
-	ma := accounts.dataReader(mergedAccount.decompressor)
-	dt.d.logger.Debug("prepare commitmentValTransformDomain", "merge", rng.String("range", dt.d.stepSize), "Mstorage", hadToLookupStorage, "Maccount", hadToLookupAccount)
 
 	vt := func(valBuf []byte, keyFromTxNum, keyEndTxNum uint64) (transValBuf []byte, err error) {
-		if !dt.d.ReplaceKeysInValues || len(valBuf) == 0 || !ValuesPlainKeyReferencingThresholdReached(dt.d.stepSize, rng.from, rng.to) {
+		if len(valBuf) == 0 {
 			return valBuf, nil
-		}
-		if _, ok := storageFileMap[keyFromTxNum]; !ok {
-			storageFileMap[keyFromTxNum] = make(map[uint64]*seg.Reader)
-		}
-		sig, ok := storageFileMap[keyFromTxNum][keyEndTxNum]
-		if !ok {
-			f, err := storage.lookupVisibleFileByRange(keyFromTxNum, keyEndTxNum)
-			if err != nil {
-				return nil, fmt.Errorf("storage file not found in visible files: %w", err)
-			}
-			sig = storage.dataReader(f.decompressor)
-			storageFileMap[keyFromTxNum][keyEndTxNum] = sig
-		}
-
-		if _, ok := accountFileMap[keyFromTxNum]; !ok {
-			accountFileMap[keyFromTxNum] = make(map[uint64]*seg.Reader)
-		}
-		aig, ok := accountFileMap[keyFromTxNum][keyEndTxNum]
-		if !ok {
-			f, err := accounts.lookupVisibleFileByRange(keyFromTxNum, keyEndTxNum)
-			if err != nil {
-				return nil, fmt.Errorf("account file not found in visible files: %w", err)
-			}
-			aig = accounts.dataReader(f.decompressor)
-			accountFileMap[keyFromTxNum][keyEndTxNum] = aig
 		}
 
 		replacer := func(key []byte, isStorage bool) ([]byte, error) {
-			var found bool
-			auxBuf := keyBuf[:0]
 			if isStorage {
 				if len(key) == length.Addr+length.Hash {
-					// Non-optimised key originating from a database record
-					auxBuf = append(auxBuf[:0], key...)
-				} else {
-					// Optimised key referencing a state file record (file number and offset within the file)
-					auxBuf, found = storage.lookupByShortenedKey(key, sig)
-					if !found {
-						dt.d.logger.Crit("valTransform: lost storage full key",
-							"shortened", hex.EncodeToString(key),
-							"merging", rng.String("", dt.d.stepSize),
-							"valBuf", fmt.Sprintf("l=%d %x", len(valBuf), valBuf),
-						)
-						return nil, fmt.Errorf("lookup lost storage full key %x", key)
-					}
+					return nil, nil // already a full storage key, keep as is
 				}
-
-				shortenedKeyOffset, found := storage.findShortenedKey(auxBuf, ms, mergedStorage)
-				if !found {
-					if len(auxBuf) == length.Addr+length.Hash {
-						return auxBuf, nil // if plain key is lost, we can save original fullkey
-					}
-					// if shortened key lost, we can't continue
-					dt.d.logger.Crit("valTransform: replacement for full storage key was not found",
-						"step", fmt.Sprintf("%d-%d", keyFromTxNum/dt.d.stepSize, keyEndTxNum/dt.d.stepSize),
-						"shortened", hex.EncodeToString(shortened), "toReplace", hex.EncodeToString(auxBuf))
-
-					return nil, fmt.Errorf("replacement not found for storage %x", auxBuf)
+				inner, ok := storageFileMap[keyFromTxNum]
+				if !ok {
+					inner = make(map[uint64]*seg.Reader)
+					storageFileMap[keyFromTxNum] = inner
 				}
-				shortened = EncodeReferenceKey(shortened[:0], shortenedKeyOffset)
-				return shortened, nil
-			}
-
-			if len(key) == length.Addr {
-				// Non-optimised key originating from a database record
-				auxBuf = append(auxBuf[:0], key...)
-			} else {
-				auxBuf, found = accounts.lookupByShortenedKey(key, aig)
+				sig, ok := inner[keyEndTxNum]
+				if !ok {
+					f, err := storage.lookupVisibleFileByRange(keyFromTxNum, keyEndTxNum)
+					if err != nil {
+						return nil, fmt.Errorf("storage file not found in visible files: %w", err)
+					}
+					sig = storage.dataReader(f.decompressor)
+					inner[keyEndTxNum] = sig
+				}
+				fullKey, found := storage.lookupByShortenedKey(key, sig)
 				if !found {
-					dt.d.logger.Crit("valTransform: lost account full key",
+					dt.d.logger.Crit("valTransform: lost storage full key",
 						"shortened", hex.EncodeToString(key),
 						"merging", rng.String("", dt.d.stepSize),
 						"valBuf", fmt.Sprintf("l=%d %x", len(valBuf), valBuf),
 					)
-					return nil, fmt.Errorf("lookup account full key: %x", key)
+					return nil, fmt.Errorf("lookup lost storage full key %x", key)
 				}
+				return fullKey, nil
 			}
 
-			shortenedKeyOffset, found := accounts.findShortenedKey(auxBuf, ma, mergedAccount)
-			if !found {
-				if len(auxBuf) == length.Addr {
-					return auxBuf, nil // if plain key is lost, we can save original fullkey
-				}
-				dt.d.logger.Crit("valTransform: replacement for full account key was not found",
-					"step", fmt.Sprintf("%d-%d", keyFromTxNum/dt.d.stepSize, keyEndTxNum/dt.d.stepSize),
-					"shortened", hex.EncodeToString(shortened), "toReplace", hex.EncodeToString(auxBuf))
-				return nil, fmt.Errorf("replacement not found for account  %x", auxBuf)
+			if len(key) == length.Addr {
+				return nil, nil // already a full account key, keep as is
 			}
-			shortened = EncodeReferenceKey(shortened[:0], shortenedKeyOffset)
-			return shortened, nil
+			inner, ok := accountFileMap[keyFromTxNum]
+			if !ok {
+				inner = make(map[uint64]*seg.Reader)
+				accountFileMap[keyFromTxNum] = inner
+			}
+			aig, ok := inner[keyEndTxNum]
+			if !ok {
+				f, err := accounts.lookupVisibleFileByRange(keyFromTxNum, keyEndTxNum)
+				if err != nil {
+					return nil, fmt.Errorf("account file not found in visible files: %w", err)
+				}
+				aig = accounts.dataReader(f.decompressor)
+				inner[keyEndTxNum] = aig
+			}
+			fullKey, found := accounts.lookupByShortenedKey(key, aig)
+			if !found {
+				dt.d.logger.Crit("valTransform: lost account full key",
+					"shortened", hex.EncodeToString(key),
+					"merging", rng.String("", dt.d.stepSize),
+					"valBuf", fmt.Sprintf("l=%d %x", len(valBuf), valBuf),
+				)
+				return nil, fmt.Errorf("lookup account full key: %x", key)
+			}
+			return fullKey, nil
 		}
 
 		branchData, err := commitment.BranchData(valBuf).ReplacePlainKeys(nil, replacer)

--- a/db/state/domain_committed.go
+++ b/db/state/domain_committed.go
@@ -58,35 +58,6 @@ func (at *AggregatorRoTx) replaceShortenedKeysInBranch(prefix []byte, branch com
 	sto := aggTx.d[kv.StorageDomain]
 	acc := aggTx.d[kv.AccountsDomain]
 
-	// Getters are resolved on first referenced-key hit, per domain. Branches with only
-	// noref keys (the common case once ReplaceKeysInValues is off or noref files are
-	// released) skip file resolution entirely.
-	var storageGetter, accountGetter *seg.Reader
-	ensureStorageGetter := func() error {
-		if storageGetter != nil {
-			return nil
-		}
-		item, err := sto.lookupVisibleFileByRange(fStartTxNum, fEndTxNum)
-		if err != nil {
-			logger.Crit("dereference key during commitment read", "failed", err.Error())
-			return err
-		}
-		storageGetter = sto.dataReader(item.decompressor)
-		return nil
-	}
-	ensureAccountGetter := func() error {
-		if accountGetter != nil {
-			return nil
-		}
-		item, err := acc.lookupVisibleFileByRange(fStartTxNum, fEndTxNum)
-		if err != nil {
-			logger.Crit("dereference key during commitment read", "failed", err.Error())
-			return err
-		}
-		accountGetter = acc.dataReader(item.decompressor)
-		return nil
-	}
-
 	metricI := 0
 	for i, f := range aggTx.d[kv.CommitmentDomain].files {
 		if i > 5 {
@@ -98,6 +69,11 @@ func (at *AggregatorRoTx) replaceShortenedKeysInBranch(prefix []byte, branch com
 		}
 	}
 
+	// Getters resolve inline on first referenced-key hit, per domain. Branches with only
+	// noref keys (the common case once ReplaceKeysInValues is off or noref files are
+	// released) skip file resolution entirely.
+	var storageGetter, accountGetter *seg.Reader
+
 	result, err := branch.ReplacePlainKeys(nil, func(key []byte, isStorage bool) ([]byte, error) {
 		if isStorage {
 			if len(key) == length.Addr+length.Hash {
@@ -106,8 +82,13 @@ func (at *AggregatorRoTx) replaceShortenedKeysInBranch(prefix []byte, branch com
 			if dbg.KVReadLevelledMetrics {
 				defer branchKeyDerefSpent[metricI].ObserveDuration(time.Now())
 			}
-			if err := ensureStorageGetter(); err != nil {
-				return nil, err
+			if storageGetter == nil {
+				item, err := sto.lookupVisibleFileByRange(fStartTxNum, fEndTxNum)
+				if err != nil {
+					logger.Crit("dereference key during commitment read", "failed", err.Error())
+					return nil, err
+				}
+				storageGetter = sto.dataReader(item.decompressor)
 			}
 			// Optimised key referencing a state file record (file number and offset within the file)
 			storagePlainKey, found := sto.lookupByShortenedKey(key, storageGetter)
@@ -127,8 +108,13 @@ func (at *AggregatorRoTx) replaceShortenedKeysInBranch(prefix []byte, branch com
 		if dbg.KVReadLevelledMetrics {
 			defer branchKeyDerefSpent[metricI].ObserveDuration(time.Now())
 		}
-		if err := ensureAccountGetter(); err != nil {
-			return nil, err
+		if accountGetter == nil {
+			item, err := acc.lookupVisibleFileByRange(fStartTxNum, fEndTxNum)
+			if err != nil {
+				logger.Crit("dereference key during commitment read", "failed", err.Error())
+				return nil, err
+			}
+			accountGetter = acc.dataReader(item.decompressor)
 		}
 		apkBuf, found := acc.lookupByShortenedKey(key, accountGetter)
 		if !found {

--- a/db/state/domain_committed.go
+++ b/db/state/domain_committed.go
@@ -58,8 +58,8 @@ func (at *AggregatorRoTx) replaceShortenedKeysInBranch(prefix []byte, branch com
 	sto := aggTx.d[kv.StorageDomain]
 	acc := aggTx.d[kv.AccountsDomain]
 
-	// Getters are resolved on first shortened-ref hit, per domain. Branches with only full
-	// keys (the common case once ReplaceKeysInValues is off) skip file resolution entirely.
+	// Getters are resolved on first referenced-key hit, per domain. Branches with only
+	// noref keys (the common case once ReplaceKeysInValues is off) skip file resolution entirely.
 	var storageGetter, accountGetter *seg.Reader
 	ensureStorageGetter := func() error {
 		if storageGetter != nil {

--- a/db/state/domain_committed.go
+++ b/db/state/domain_committed.go
@@ -59,7 +59,8 @@ func (at *AggregatorRoTx) replaceShortenedKeysInBranch(prefix []byte, branch com
 	acc := aggTx.d[kv.AccountsDomain]
 
 	// Getters are resolved on first referenced-key hit, per domain. Branches with only
-	// noref keys (the common case once ReplaceKeysInValues is off) skip file resolution entirely.
+	// noref keys (the common case once ReplaceKeysInValues is off or noref files are
+	// released) skip file resolution entirely.
 	var storageGetter, accountGetter *seg.Reader
 	ensureStorageGetter := func() error {
 		if storageGetter != nil {

--- a/db/state/statecfg/state_schema.go
+++ b/db/state/statecfg/state_schema.go
@@ -76,7 +76,7 @@ func Configure(Schema SchemaGen, a AggSetters, dirs datadir.Dirs, salt *uint32, 
 // AggregatorSqueezeCommitmentValues controls whether commitment aggregator should replace keys in values during merge once file range reaches threshold.
 // This can significantly reduce size of commitment values, but makes them non-human readable and requires additional processing during reads.
 // This is not needed for correctness, but can be used to save space if needed.
-const AggregatorSqueezeCommitmentValues = true
+const AggregatorSqueezeCommitmentValues = false
 
 const MaxNonFuriousDirtySpacePerTx = 64 * datasize.MB
 


### PR DESCRIPTION
## Summary

- Flip `AggregatorSqueezeCommitmentValues` to `false` so we can start experimenting with noref commitment immediately on existing datadirs (e.g. bloatnet) — without waiting for a fresh release of noref commitment files.
- Decouple read-side expansion in `replaceShortenedKeysInBranch` from the `ReplaceKeysInValues` flag so the flip is safe on a datadir that still has past-threshold referenced-key files. Drop the `ReplaceKeysInValues` and `ValuesPlainKeyReferencingThresholdReached` checks from the outer skip; keep the safety checks. The per-key callback already self-detects noref vs referenced by length (20B account / 52B storage → return as is; otherwise → `lookupByShortenedKey`).
- Decouple merge-side `commitmentValTransformDomain` from the same flag. Without this, merging constituent commitments that already contain referenced keys would silently copy them into the merged file, leaving the merged commitment refs pointing at constituent-storage offsets that are invalid against the merged storage file (observed as `lookupByShortenedKey failed offsetBigger=true` / `replace back lost storage full key` / panic on out-of-bounds slice). The per-key replacer dispatches by length and emits full keys; `findShortenedKey` re-encoding is dropped — merges always produce noref output now, and squeeze remains the only producer of referenced keys.
- Resolve acct/storage file getters lazily, per-domain, on first referenced-key hit (both read and merge paths). Once `ReplaceKeysInValues` is off (or, longer-term, noref files are released and existing referenced-key files are squeezed out), branches contain only noref keys and the function skips `lookupVisibleFileByRange` + `dataReader` entirely.

## Test plan

- [x] `go build ./...`
- [x] `go test -short ./db/state/...` (commitment + squeeze + merge tests)
- [x] `go test -short ./execution/commitment/...`
- [x] `make lint`
- [ ] Restart erigon on a datadir with pre-existing past-threshold referenced-key commitment files (`bloatnet_bak2`); verify state-root checks pass and that newly merged commitment files no longer trigger `replace back lost storage full key`.
- [ ] Measure CommitmentVals size growth per commit-cycle vs baseline.