### PR TITLE
db/kv/prune: fix prune leaving stranded old-step dups in dupsort domains

### DIFF
--- a/db/kv/prune/prune.go
+++ b/db/kv/prune/prune.go
@@ -341,7 +341,8 @@ func tableScanningPrune(
 		// Different storage modes have different dup-iteration orders:
 		//   - StepValueStorageMode (^step||val): FirstDup = newest, LastDup = oldest
 		//   - PrefixValStorageMode (txNum||val): FirstDup = oldest, LastDup = newest
-		// Be encoding-agnostic: read both endpoints, derive min/max.
+		// Be encoding-agnostic: read both endpoints, derive min/max, and infer
+		// iteration direction (firstIsOldest) for the selective branch's break.
 		txNumAtFirst := txNumGetter(val, txNumBytes)
 
 		lastDupTxNumB, err := valDelCursor.LastDup()
@@ -351,7 +352,8 @@ func tableScanningPrune(
 		txNumAtLast := txNumGetter(val, lastDupTxNumB)
 
 		minTxNum, maxTxNum := txNumAtFirst, txNumAtLast
-		if minTxNum > maxTxNum {
+		firstIsOldest := txNumAtFirst <= txNumAtLast
+		if !firstIsOldest {
 			minTxNum, maxTxNum = maxTxNum, minTxNum
 		}
 
@@ -360,14 +362,8 @@ func tableScanningPrune(
 			continue
 		}
 
-		stat.MinTxNum = min(stat.MinTxNum, minTxNum)
-		stat.MaxTxNum = max(stat.MaxTxNum, maxTxNum)
-
-		if asserts && minTxNum < txFrom && maxTxNum >= txTo {
-			// dups straddle on both sides — unusual; let selective branch handle
-		}
-
 		// All dups in prune range [txFrom, txTo): safe bulk delete.
+		// Stats reflect what is actually deleted: the full [minTxNum, maxTxNum] span.
 		if minTxNum >= txFrom && maxTxNum < txTo {
 			if throttling != nil {
 				time.Sleep(*throttling)
@@ -384,12 +380,17 @@ func tableScanningPrune(
 				stat.DupsDeleted += dups
 			}
 			stat.PruneCountValues += dups
+			stat.MinTxNum = min(stat.MinTxNum, minTxNum)
+			stat.MaxTxNum = max(stat.MaxTxNum, maxTxNum)
 			goto nextKey
 		}
 
 		// Partial overlap: iterate dups and delete those in range.
-		// Encoding-agnostic — use `continue` for all out-of-range cases
-		// (no early `break`, since iteration direction varies by storage mode).
+		// Stats are updated only for actually-deleted dups (per-dup below) so
+		// out-of-range survivors don't inflate Min/MaxTxNum.
+		// Order-aware early-break preserves the optimization from before the fix:
+		//   - firstIsOldest (PrefixVal): once we cross txTo, all remaining are newer.
+		//   - !firstIsOldest (StepValue): once we cross under txFrom, all are older.
 		{
 			_, err = valDelCursor.FirstDup()
 			if err != nil {
@@ -400,8 +401,20 @@ func tableScanningPrune(
 					return nil, fmt.Errorf("iterate over %s index keys: %w", filenameBase, err)
 				}
 				txNumDup := txNumGetter(val, txNumBytes)
-				if txNumDup < txFrom || txNumDup >= txTo {
-					continue
+				if firstIsOldest {
+					if txNumDup < txFrom {
+						continue
+					}
+					if txNumDup >= txTo {
+						break
+					}
+				} else {
+					if txNumDup >= txTo {
+						continue
+					}
+					if txNumDup < txFrom {
+						break
+					}
 				}
 				if throttling != nil {
 					time.Sleep(*throttling)

--- a/db/kv/prune/prune.go
+++ b/db/kv/prune/prune.go
@@ -188,7 +188,7 @@ type StartPos struct {
 func TableScanningPrune(
 	ctx context.Context,
 	name, filenameBase string,
-	txFrom, txTo, limit, stepSize uint64,
+	txFrom, txTo, stepSize uint64,
 	logEvery *time.Ticker,
 	logger log.Logger,
 	keysCursor kv.RwCursorDupSort, valDelCursor kv.PseudoDupSortRwCursor,
@@ -199,16 +199,13 @@ func TableScanningPrune(
 	stat = &Stat{MinTxNum: math.MaxUint64}
 	start := time.Now()
 	defer func() {
-		logger.Trace("scan prune res", "name", name, "txFrom", txFrom, "txTo", txTo, "limit", limit, "keys",
+		logger.Trace("scan prune res", "name", name, "txFrom", txFrom, "txTo", txTo, "keys",
 			stat.PruneCountTx, "vals", stat.PruneCountValues, "dups", stat.DupsDeleted,
 			"spent ms", time.Since(start).Milliseconds(),
 			"key prune status", stat.KeyProgress.String(),
 			"val prune status", stat.ValueProgress.String())
 	}()
 
-	if limit == 0 { // limits amount of txn to be pruned
-		limit = math.MaxUint64
-	}
 	var throttling *time.Duration
 	if v := ctx.Value("throttle"); v != nil {
 		throttling = v.(*time.Duration)

--- a/db/kv/prune/prune.go
+++ b/db/kv/prune/prune.go
@@ -338,27 +338,37 @@ func tableScanningPrune(
 			return common.Copy(val), nil
 		}
 
-		txNum := txNumGetter(val, txNumBytes)
-		// Early skip: avoid LastDup/FirstDup/CountDuplicates cursor ops for out-of-range entries
-		if txNum >= txTo {
-			continue
-		}
-
-		if asserts && txNum < txFrom {
-			panic(fmt.Errorf("assert: index pruning txn=%d [%d-%d)", txNum, txFrom, txTo))
-		}
+		// Different storage modes have different dup-iteration orders:
+		//   - StepValueStorageMode (^step||val): FirstDup = newest, LastDup = oldest
+		//   - PrefixValStorageMode (txNum||val): FirstDup = oldest, LastDup = newest
+		// Be encoding-agnostic: read both endpoints, derive min/max.
+		txNumAtFirst := txNumGetter(val, txNumBytes)
 
 		lastDupTxNumB, err := valDelCursor.LastDup()
 		if err != nil {
 			return nil, fmt.Errorf("LastDup iterate over %s index keys: %w", filenameBase, err)
 		}
-		lastDupTxNum := txNumGetter(val, lastDupTxNumB)
+		txNumAtLast := txNumGetter(val, lastDupTxNumB)
 
-		stat.MinTxNum = min(stat.MinTxNum, txNum)
-		stat.MaxTxNum = max(stat.MaxTxNum, txNum)
+		minTxNum, maxTxNum := txNumAtFirst, txNumAtLast
+		if minTxNum > maxTxNum {
+			minTxNum, maxTxNum = maxTxNum, minTxNum
+		}
 
-		// All dups in prune range: bulk delete without repositioning cursor
-		if lastDupTxNum < txTo && txNum >= txFrom {
+		// All dups outside [txFrom, txTo): nothing to prune for this key.
+		if maxTxNum < txFrom || minTxNum >= txTo {
+			continue
+		}
+
+		stat.MinTxNum = min(stat.MinTxNum, minTxNum)
+		stat.MaxTxNum = max(stat.MaxTxNum, maxTxNum)
+
+		if asserts && minTxNum < txFrom && maxTxNum >= txTo {
+			// dups straddle on both sides — unusual; let selective branch handle
+		}
+
+		// All dups in prune range [txFrom, txTo): safe bulk delete.
+		if minTxNum >= txFrom && maxTxNum < txTo {
 			if throttling != nil {
 				time.Sleep(*throttling)
 			}
@@ -374,8 +384,13 @@ func tableScanningPrune(
 				stat.DupsDeleted += dups
 			}
 			stat.PruneCountValues += dups
-		} else {
-			// Selective per-dup deletion: reposition to first dup for iteration
+			goto nextKey
+		}
+
+		// Partial overlap: iterate dups and delete those in range.
+		// Encoding-agnostic — use `continue` for all out-of-range cases
+		// (no early `break`, since iteration direction varies by storage mode).
+		{
 			_, err = valDelCursor.FirstDup()
 			if err != nil {
 				return nil, fmt.Errorf("FirstDup iterate over %s index keys: %w", filenameBase, err)
@@ -385,11 +400,8 @@ func tableScanningPrune(
 					return nil, fmt.Errorf("iterate over %s index keys: %w", filenameBase, err)
 				}
 				txNumDup := txNumGetter(val, txNumBytes)
-				if txNumDup < txFrom {
+				if txNumDup < txFrom || txNumDup >= txTo {
 					continue
-				}
-				if txNumDup >= txTo {
-					break
 				}
 				if throttling != nil {
 					time.Sleep(*throttling)
@@ -406,6 +418,7 @@ func tableScanningPrune(
 				stat.PruneCountValues++
 			}
 		}
+	nextKey:
 
 		select {
 		case <-logEvery.C:

--- a/db/kv/prune/prune_test.go
+++ b/db/kv/prune/prune_test.go
@@ -380,8 +380,8 @@ func TestDupSortPrune_MultipleDupsAllInRange(t *testing.T) {
 }
 
 // TestDupSortPrune_MixedDupsPartialRange: each user-key has dups at multiple
-// steps, some in range and some beyond. Exercises the selective-deletion path
-// (line ~378 in prune.go).
+// steps, some in range and some beyond. Exercises the partial-overlap
+// selective-deletion branch of tableScanningPrune.
 func TestDupSortPrune_MixedDupsPartialRange(t *testing.T) {
 	db := openTestDupSortDB(t)
 	defer db.Close()

--- a/db/kv/prune/prune_test.go
+++ b/db/kv/prune/prune_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 const testTxLookupTable = "TestTxLookup"
+const testDupSortTable = "TestDupSort"
 
 func openTestDB(tb testing.TB) kv.RwDB {
 	tb.Helper()
@@ -39,6 +40,15 @@ func openTestDB(tb testing.TB) kv.RwDB {
 		InMem(tb, tb.TempDir()).
 		WithTableCfg(func(_ kv.TableCfg) kv.TableCfg {
 			return kv.TableCfg{testTxLookupTable: {}}
+		}).MustOpen()
+}
+
+func openTestDupSortDB(tb testing.TB) kv.RwDB {
+	tb.Helper()
+	return mdbx2.New(dbcfg.ChainDB, log.New()).
+		InMem(tb, tb.TempDir()).
+		WithTableCfg(func(_ kv.TableCfg) kv.TableCfg {
+			return kv.TableCfg{testDupSortTable: {Flags: kv.DupSort}}
 		}).MustOpen()
 }
 
@@ -233,6 +243,256 @@ func TestTableScanningPrune_CtxCancelOnOutOfRange(t *testing.T) {
 		"interrupted scan must save cursor position for resume")
 	require.EqualValues(t, 0, stat.PruneCountValues,
 		"no entries should be deleted — all are out of range")
+}
+
+// --- DupSort domain prune tests (mirrors commitmentvals: StepValueStorageMode) ---
+
+// encodeStepVal builds the value bytes a domain writes for a (step,value) pair:
+//
+//	value = ^step (BE u64) || actualValue
+//
+// This is the layout for non-largeValues domains like commitmentvals (see
+// domain.go:addValue and StepValueStorageMode decoder).
+func encodeStepVal(step uint64, val []byte) []byte {
+	buf := make([]byte, 8+len(val))
+	binary.BigEndian.PutUint64(buf[:8], ^step)
+	copy(buf[8:], val)
+	return buf
+}
+
+// userKey returns a 20-byte address-shaped key for test determinism.
+func userKey(i uint64) []byte {
+	k := make([]byte, 20)
+	binary.BigEndian.PutUint64(k[12:], i)
+	return k
+}
+
+func openDupSortPseudoCursor(tb testing.TB, tx kv.RwTx) kv.PseudoDupSortRwCursor {
+	tb.Helper()
+	raw, err := tx.RwCursorDupSort(testDupSortTable) //nolint:gocritic // caller owns the returned cursor and calls Close() on it
+	require.NoError(tb, err)
+	c, ok := raw.(kv.PseudoDupSortRwCursor)
+	require.True(tb, ok)
+	return c
+}
+
+func countDupSortTable(tb testing.TB, tx kv.Tx) (keys, dups int) {
+	tb.Helper()
+	c, err := tx.Cursor(testDupSortTable)
+	require.NoError(tb, err)
+	defer c.Close()
+	for k, _, err := c.First(); k != nil; k, _, err = c.Next() {
+		require.NoError(tb, err)
+		dups++
+	}
+	c2, err := tx.CursorDupSort(testDupSortTable)
+	require.NoError(tb, err)
+	defer c2.Close()
+	for k, _, err := c2.First(); k != nil; k, _, err = c2.NextNoDup() {
+		require.NoError(tb, err)
+		keys++
+	}
+	return keys, dups
+}
+
+// TestDupSortPrune_SingleDupAllInRange: every user-key has exactly one dup,
+// every step is < txTo. After one scan, table must be empty.
+// This is the simplest case: no cursor-state shenanigans from AllDups delete.
+func TestDupSortPrune_SingleDupAllInRange(t *testing.T) {
+	db := openTestDupSortDB(t)
+	defer db.Close()
+
+	tx, err := db.BeginRw(t.Context())
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	const N = 50
+	const stepSize uint64 = 16
+	// 50 user keys; each gets a single dup at step=1 (txNum in [16,32)).
+	for i := uint64(0); i < N; i++ {
+		require.NoError(t, tx.Put(testDupSortTable, userKey(i), encodeStepVal(1, []byte{byte(i)})))
+	}
+
+	logEvery := time.NewTicker(time.Hour)
+	defer logEvery.Stop()
+
+	cur := openDupSortPseudoCursor(t, tx)
+	defer cur.Close()
+
+	// txTo = 64 → prune steps 0,1,2,3.
+	stat, err := prune.TableScanningPrune(
+		t.Context(), "test", "dup",
+		0, 64, 0, stepSize, logEvery, log.New(),
+		nil, cur, false, &prune.Stat{}, prune.StepValueStorageMode,
+	)
+	require.NoError(t, err)
+	require.Equal(t, prune.Done, stat.ValueProgress)
+	require.EqualValues(t, N, stat.PruneCountValues, "all N entries deleted")
+
+	keys, dups := countDupSortTable(t, tx)
+	require.Equal(t, 0, keys, "no keys remain")
+	require.Equal(t, 0, dups, "no dups remain")
+}
+
+// TestDupSortPrune_MultipleDupsAllInRange: every user-key has 3 dups at
+// different steps, ALL in range. Exercises the bulk-AllDups delete path
+// followed by NextNoDup — the suspected production bug site.
+func TestDupSortPrune_MultipleDupsAllInRange(t *testing.T) {
+	db := openTestDupSortDB(t)
+	defer db.Close()
+
+	tx, err := db.BeginRw(t.Context())
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	const N = 50
+	const stepSize uint64 = 16
+	// Three dups per key, at steps 1,2,3 (txNums 16,32,48 — all < txTo=64).
+	for i := uint64(0); i < N; i++ {
+		k := userKey(i)
+		require.NoError(t, tx.Put(testDupSortTable, k, encodeStepVal(1, []byte{0xa})))
+		require.NoError(t, tx.Put(testDupSortTable, k, encodeStepVal(2, []byte{0xb})))
+		require.NoError(t, tx.Put(testDupSortTable, k, encodeStepVal(3, []byte{0xc})))
+	}
+
+	keysBefore, dupsBefore := countDupSortTable(t, tx)
+	require.Equal(t, N, keysBefore)
+	require.Equal(t, 3*N, dupsBefore)
+
+	logEvery := time.NewTicker(time.Hour)
+	defer logEvery.Stop()
+
+	cur := openDupSortPseudoCursor(t, tx)
+	defer cur.Close()
+
+	stat, err := prune.TableScanningPrune(
+		t.Context(), "test", "dup",
+		0, 64, 0, stepSize, logEvery, log.New(),
+		nil, cur, false, &prune.Stat{}, prune.StepValueStorageMode,
+	)
+	require.NoError(t, err)
+	require.Equal(t, prune.Done, stat.ValueProgress)
+	require.EqualValues(t, 3*N, stat.PruneCountValues, "all 3N dups deleted")
+
+	keys, dups := countDupSortTable(t, tx)
+	require.Equal(t, 0, keys, "no keys remain after scan claimed Done")
+	require.Equal(t, 0, dups, "no dups remain after scan claimed Done")
+}
+
+// TestDupSortPrune_MixedDupsPartialRange: each user-key has dups at multiple
+// steps, some in range and some beyond. Exercises the selective-deletion path
+// (line ~378 in prune.go).
+func TestDupSortPrune_MixedDupsPartialRange(t *testing.T) {
+	db := openTestDupSortDB(t)
+	defer db.Close()
+
+	tx, err := db.BeginRw(t.Context())
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	const N = 30
+	const stepSize uint64 = 16
+	// Two dups per key:
+	//   - step 1 (txNum 16) — in range
+	//   - step 5 (txNum 80) — out of range when txTo=64
+	for i := uint64(0); i < N; i++ {
+		k := userKey(i)
+		require.NoError(t, tx.Put(testDupSortTable, k, encodeStepVal(1, []byte{0xa})))
+		require.NoError(t, tx.Put(testDupSortTable, k, encodeStepVal(5, []byte{0xe})))
+	}
+
+	logEvery := time.NewTicker(time.Hour)
+	defer logEvery.Stop()
+
+	cur := openDupSortPseudoCursor(t, tx)
+	defer cur.Close()
+
+	stat, err := prune.TableScanningPrune(
+		t.Context(), "test", "dup",
+		0, 64, 0, stepSize, logEvery, log.New(),
+		nil, cur, false, &prune.Stat{}, prune.StepValueStorageMode,
+	)
+	require.NoError(t, err)
+	require.Equal(t, prune.Done, stat.ValueProgress)
+	require.EqualValues(t, N, stat.PruneCountValues, "exactly N step-1 dups deleted")
+
+	keys, dups := countDupSortTable(t, tx)
+	require.Equal(t, N, keys, "all keys still present (step-5 dup remains)")
+	require.Equal(t, N, dups, "exactly N dups remain (step-5)")
+}
+
+// TestDupSortPrune_ProductionLike mirrors the commitmentvals residue pattern.
+// Build a table where some keys are only present in OLD steps, others have
+// their newest write in the ACTIVE (out-of-range) step. Prune with txTo at the
+// active-step boundary. Every dup whose txNum < txTo must be gone.
+func TestDupSortPrune_ProductionLike(t *testing.T) {
+	db := openTestDupSortDB(t)
+	defer db.Close()
+
+	tx, err := db.BeginRw(t.Context())
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	const stepSize uint64 = 16
+	const activeStep uint64 = 10 // tip
+	// txTo = start of activeStep — everything in steps [0, activeStep) prunable.
+	txTo := activeStep * stepSize
+
+	// Group A: 20 keys with dups only at old step 2 — should be fully deleted.
+	for i := uint64(0); i < 20; i++ {
+		k := userKey(i)
+		require.NoError(t, tx.Put(testDupSortTable, k, encodeStepVal(2, []byte{0x1})))
+	}
+	// Group B: 20 keys (offset by 100) with dups at steps 2 AND activeStep (out of range).
+	// Step-2 dups must still be deleted; step-activeStep dups must remain.
+	for i := uint64(100); i < 120; i++ {
+		k := userKey(i)
+		require.NoError(t, tx.Put(testDupSortTable, k, encodeStepVal(2, []byte{0x1})))
+		require.NoError(t, tx.Put(testDupSortTable, k, encodeStepVal(activeStep, []byte{0xa})))
+	}
+	// Group C: 20 keys (offset 200) with dups across many old steps (5,6,7,8) AND activeStep.
+	// All old-step dups must be deleted; activeStep dup must remain.
+	for i := uint64(200); i < 220; i++ {
+		k := userKey(i)
+		for s := uint64(5); s <= 8; s++ {
+			require.NoError(t, tx.Put(testDupSortTable, k, encodeStepVal(s, []byte{byte(s)})))
+		}
+		require.NoError(t, tx.Put(testDupSortTable, k, encodeStepVal(activeStep, []byte{0xa})))
+	}
+
+	logEvery := time.NewTicker(time.Hour)
+	defer logEvery.Stop()
+
+	cur := openDupSortPseudoCursor(t, tx)
+	defer cur.Close()
+
+	_, err = prune.TableScanningPrune(
+		t.Context(), "test", "dup",
+		0, txTo, 0, stepSize, logEvery, log.New(),
+		nil, cur, false, &prune.Stat{}, prune.StepValueStorageMode,
+	)
+	require.NoError(t, err)
+
+	// Verify table state: walk each remaining row and check its step.
+	c, err := tx.CursorDupSort(testDupSortTable)
+	require.NoError(t, err)
+	defer c.Close()
+	type remaining struct{ keyIdx, step uint64 }
+	got := make([]remaining, 0)
+	for k, v, err := c.First(); k != nil; k, v, err = c.Next() {
+		require.NoError(t, err)
+		idx := binary.BigEndian.Uint64(k[12:])
+		step := ^binary.BigEndian.Uint64(v[:8])
+		got = append(got, remaining{idx, step})
+	}
+	// Allowed survivors: Group B (idx 100..119) and Group C (idx 200..219) at activeStep only.
+	for _, r := range got {
+		if r.step*stepSize >= txTo {
+			continue // out of range → allowed
+		}
+		t.Errorf("BUG: in-range row survived: key=%d step=%d (txTo=%d)", r.keyIdx, r.step, txTo)
+	}
+	t.Logf("survivors=%d", len(got))
 }
 
 func BenchmarkTableScanningPrune(b *testing.B) {

--- a/db/kv/prune/prune_test.go
+++ b/db/kv/prune/prune_test.go
@@ -116,7 +116,7 @@ func TestTableScanningPrune_Basic(t *testing.T) {
 
 	stat, err := prune.TableScanningPrune(
 		t.Context(), "test", "txlookup",
-		5, 15, 0, 1, logEvery, log.New(),
+		5, 15, 1, logEvery, log.New(),
 		nil, cur, false, &prune.Stat{}, prune.ValueOffset8StorageMode,
 	)
 	require.NoError(t, err)
@@ -165,7 +165,7 @@ func TestTableScanningPrune_RollingCursor(t *testing.T) {
 	cur := openPseudoCursor(t, tx)
 	stat1, err := prune.TableScanningPrune(
 		t.Context(), "test", "txlookup",
-		0, 8, 0, 1, logEvery, log.New(),
+		0, 8, 1, logEvery, log.New(),
 		nil, cur, false, prevStat, prune.ValueOffset8StorageMode,
 	)
 	cur.Close()
@@ -188,7 +188,7 @@ func TestTableScanningPrune_RollingCursor(t *testing.T) {
 	cur = openPseudoCursor(t, tx)
 	stat2, err := prune.TableScanningPrune(
 		t.Context(), "test", "txlookup",
-		0, 10, 0, 1, logEvery, log.New(),
+		0, 10, 1, logEvery, log.New(),
 		nil, cur, false, newRotStat, prune.ValueOffset8StorageMode,
 	)
 	cur.Close()
@@ -228,7 +228,7 @@ func TestTableScanningPrune_CtxCancelOnOutOfRange(t *testing.T) {
 
 	stat, err := prune.TableScanningPrune(
 		ctx, "test", "txlookup",
-		0, 5, 0, 1, logEvery, log.New(),
+		0, 5, 1, logEvery, log.New(),
 		nil, cur, false, &prune.Stat{}, prune.ValueOffset8StorageMode,
 	)
 	require.NoError(t, err)
@@ -322,7 +322,7 @@ func TestDupSortPrune_SingleDupAllInRange(t *testing.T) {
 	// txTo = 64 → prune steps 0,1,2,3.
 	stat, err := prune.TableScanningPrune(
 		t.Context(), "test", "dup",
-		0, 64, 0, stepSize, logEvery, log.New(),
+		0, 64, stepSize, logEvery, log.New(),
 		nil, cur, false, &prune.Stat{}, prune.StepValueStorageMode,
 	)
 	require.NoError(t, err)
@@ -367,7 +367,7 @@ func TestDupSortPrune_MultipleDupsAllInRange(t *testing.T) {
 
 	stat, err := prune.TableScanningPrune(
 		t.Context(), "test", "dup",
-		0, 64, 0, stepSize, logEvery, log.New(),
+		0, 64, stepSize, logEvery, log.New(),
 		nil, cur, false, &prune.Stat{}, prune.StepValueStorageMode,
 	)
 	require.NoError(t, err)
@@ -409,7 +409,7 @@ func TestDupSortPrune_MixedDupsPartialRange(t *testing.T) {
 
 	stat, err := prune.TableScanningPrune(
 		t.Context(), "test", "dup",
-		0, 64, 0, stepSize, logEvery, log.New(),
+		0, 64, stepSize, logEvery, log.New(),
 		nil, cur, false, &prune.Stat{}, prune.StepValueStorageMode,
 	)
 	require.NoError(t, err)
@@ -468,7 +468,7 @@ func TestDupSortPrune_ProductionLike(t *testing.T) {
 
 	_, err = prune.TableScanningPrune(
 		t.Context(), "test", "dup",
-		0, txTo, 0, stepSize, logEvery, log.New(),
+		0, txTo, stepSize, logEvery, log.New(),
 		nil, cur, false, &prune.Stat{}, prune.StepValueStorageMode,
 	)
 	require.NoError(t, err)
@@ -514,7 +514,7 @@ func BenchmarkTableScanningPrune(b *testing.B) {
 		cur := openPseudoCursor(b, tx)
 		prune.TableScanningPrune( //nolint:errcheck
 			b.Context(), "bench", "txlookup",
-			0, N/2, 0, 1, logEvery, logger,
+			0, N/2, 1, logEvery, logger,
 			nil, cur, false, &prune.Stat{}, prune.ValueOffset8StorageMode,
 		)
 		cur.Close()

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1934,7 +1934,7 @@ func (dt *DomainRoTx) prune(ctx context.Context, rwTx kv.RwTx, step kv.Step, txF
 
 	prg.KeyProgress = prune.Done // domains don't have key tables
 
-	pruneStat, err := prune.TableScanningPrune(ctx, "domain "+dt.name.String(), dt.d.FilenameBase, txFrom, txTo, limit, dt.stepSize,
+	pruneStat, err := prune.TableScanningPrune(ctx, "domain "+dt.name.String(), dt.d.FilenameBase, txFrom, txTo, dt.stepSize,
 		logEvery, dt.d.logger, nil, valsCursor, asserts, prg, mode)
 	if err != nil {
 		return stat, err

--- a/db/state/inverted_index.go
+++ b/db/state/inverted_index.go
@@ -819,7 +819,7 @@ func (iit *InvertedIndexRoTx) TableScanningPrune(ctx context.Context, tx kv.RwTx
 	if txTo == MaxUint64 {
 		return iit.hashSeekingPrune(ctx, tx, txFrom, txTo, limit, logEvery, valDelCursor, pruneSizeMetric, mode)
 	}
-	return iit.tableScanningPrune(ctx, tx, txFrom, txTo, limit, logEvery, valDelCursor, valTable, pruneSizeMetric, mode)
+	return iit.tableScanningPrune(ctx, tx, txFrom, txTo, logEvery, valDelCursor, valTable, pruneSizeMetric, mode)
 }
 
 func (iit *InvertedIndexRoTx) HashSeekingPrune(ctx context.Context, tx kv.RwTx, txFrom, txTo, limit uint64, logEvery *time.Ticker, forced bool, valDelCursor kv.PseudoDupSortRwCursor, pruneSizeMetric metrics.Counter, mode prune.StorageMode) (stat *InvertedIndexPruneStat, err error) {
@@ -872,7 +872,7 @@ func (iit *InvertedIndexRoTx) hashSeekingPrune(ctx context.Context, rwTx kv.RwTx
 	}, nil
 }
 
-func (iit *InvertedIndexRoTx) tableScanningPrune(ctx context.Context, rwTx kv.RwTx, txFrom, txTo, limit uint64, logEvery *time.Ticker, valDelCursor kv.PseudoDupSortRwCursor, valTable *string, pruneSizeMetric metrics.Counter, mode prune.StorageMode) (stat *InvertedIndexPruneStat, err error) {
+func (iit *InvertedIndexRoTx) tableScanningPrune(ctx context.Context, rwTx kv.RwTx, txFrom, txTo uint64, logEvery *time.Ticker, valDelCursor kv.PseudoDupSortRwCursor, valTable *string, pruneSizeMetric metrics.Counter, mode prune.StorageMode) (stat *InvertedIndexPruneStat, err error) {
 	mxPruneInProgress.Inc()
 	defer mxPruneInProgress.Dec()
 	defer func(t time.Time) { mxPruneTookIndex.ObserveDuration(t) }(time.Now())
@@ -923,7 +923,7 @@ func (iit *InvertedIndexRoTx) tableScanningPrune(ctx context.Context, rwTx kv.Rw
 	prs.TxFrom = txFrom
 	prs.TxTo = txTo
 
-	pruneStat, err := prune.TableScanningPrune(ctx, name, iit.ii.FilenameBase, txFrom, txTo, limit, iit.stepSize,
+	pruneStat, err := prune.TableScanningPrune(ctx, name, iit.ii.FilenameBase, txFrom, txTo, iit.stepSize,
 		logEvery, iit.ii.logger, keysCursor, valDelCursor, asserts, prs, mode)
 	if err != nil {
 		iit.ii.logger.Error("prune table", iit.ii.FilenameBase, "err", err)

--- a/execution/stagedsync/stage_txlookup.go
+++ b/execution/stagedsync/stage_txlookup.go
@@ -290,7 +290,7 @@ func PruneTxLookup(s *PruneState, tx kv.RwTx, cfg TxLookupCfg, ctx context.Conte
 	pruneCtx, pruneCancel := context.WithTimeout(ctx, pruneTimeout)
 	defer pruneCancel()
 
-	pruneStat, err := prune.TableScanningPrune(pruneCtx, logPrefix, "txlookup", txFrom, txTo, 0, 1,
+	pruneStat, err := prune.TableScanningPrune(pruneCtx, logPrefix, "txlookup", txFrom, txTo, 1,
 		logEvery, logger, nil, valsCursor, false, prevStat, prune.ValueOffset8StorageMode)
 	if err != nil {
 		return fmt.Errorf("prune TxLookup: %w", err)


### PR DESCRIPTION
## Bug
dust kvs are collecting in previous step of commitment table (and other tables too); this is even after multiple rounds of 12h-budget `PruneSmallBatches`, which is actually saying `"domain skipped: marker says Done"`
```
CommitmentVals scan complete in 3.2s
Total dup entries:     9898765
Total key+val bytes:   5127822864 (4.78 GB)
Distinct steps:        12
Step range:            187458..187469

Per-step breakdown (step: entries, bytes):
  step 187458:      73757 entries  0.04 GB
  step 187459:      75102 entries  0.04 GB
  step 187460:      77276 entries  0.04 GB
  step 187461:      80850 entries  0.04 GB
  step 187462:      86646 entries  0.05 GB
  step 187463:      95994 entries  0.05 GB
  step 187464:     110614 entries  0.06 GB
  step 187465:     135487 entries  0.07 GB
  step 187466:     174316 entries  0.10 GB
  step 187467:     246904 entries  0.14 GB
  step 187468:     504618 entries  0.29 GB
  step 187469:    8237201 entries  3.85 GB
```

## Summary

- `TableScanningPrune` had an early-skip that bailed on a key as soon as the cursor's first dup was out of the prune range. For domain values (`StepValueStorageMode`, `^step||val`) the first dup is the **newest** step, so any key written in the active step was skipped entirely — leaving its older in-range dups in the DB forever. Once the prune marker was stamped `Done` for that `txTo`, future PSB calls early-returned without ever revisiting.
- This is the source of the per-step "dust" we see in `commitmentvals` (and any other dupsort domain values table): keys that were re-touched in the active step kept their old-step entries even after the file boundary advanced past them.
- Fix makes the per-key range decision encoding-agnostic: read both `FirstDup` and `LastDup`, derive min/max, and only bulk-delete when `[min, max] ⊆ [txFrom, txTo)`. Otherwise iterate dups and use `continue` (no early `break`) since iteration direction varies by storage mode (`StepValueStorageMode` is newest→oldest, `PrefixValStorageMode` is oldest→newest).
- the incorrect skip should fix on next aggregation when prune progress resets

## Test plan
- [x] `go test ./db/kv/prune/ -count=1` — new dupsort reproducers (`TestDupSortPrune_*`) all pass; pre-fix `MixedDupsPartialRange` and `ProductionLike` failed.
- [x] `go test ./db/state/ -count=1` — full state suite green (covers `TestDomain_PruneAfterAggregation`, `TestDomain_MergeFiles`, `TestDomain_ScanFiles` which exercise the integrated Domain.Prune path for both values + history).
- [x] `make lint`

