### PR TITLE
cmd/integration, execution/stagedsync: fix from-0 flow (env-prefix + reset-progress-delete)

### DIFF
--- a/cmd/integration/commands/flags.go
+++ b/cmd/integration/commands/flags.go
@@ -20,10 +20,20 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/erigontech/erigon/cmd/utils"
+	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/node/cli"
 	"github.com/erigontech/erigon/node/ethconfig"
 )
+
+// The integration tool defaults parallel exec on (the integration tool's
+// preferred mode for stage_exec), overriding the dbg package's default-off.
+// dbg.EnvBool honours both EXEC3_PARALLEL and ERIGON_EXEC3_PARALLEL — the
+// latter is what envLookup auto-prepends, so CI workflows that set
+// ERIGON_EXEC3_PARALLEL=false actually take effect.
+func init() {
+	dbg.Exec3Parallel = dbg.EnvBool("EXEC3_PARALLEL", true)
+}
 
 var (
 	chaindata                     string

--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -628,9 +628,6 @@ func stageSenders(db kv.TemporalRwDB, ctx context.Context, logger log.Logger) er
 }
 
 func stageExec(db kv.TemporalRwDB, ctx context.Context, logger log.Logger) error {
-	if _, ok := os.LookupEnv("EXEC3_PARALLEL"); !ok {
-		dbg.Exec3Parallel = true // default for integration tool
-	}
 	if chainTipMode && noCommit {
 		return errors.New("--sync.mode.chaintip cannot work with --no-commit to be false")
 	}

--- a/execution/execmodule/execmoduletester/from0_genesis_internal_test.go
+++ b/execution/execmodule/execmoduletester/from0_genesis_internal_test.go
@@ -1,0 +1,227 @@
+// Reproducer for the parallel-exec from-0 failure surfaced by
+// qa-stage-exec (from-0, parallel) on #21017's CI: after `stage_exec
+// --reset` wipes the domain state and `stage_exec --batchSize=10mb`
+// runs from block 0, a genesis-allocated address that no subsequent
+// block touches is read back as balance=0 instead of its allocation.
+// On mainnet this hits at block 46147 against
+// 0xA1E4380A3B1f749673E270229993eE55F35663b4.
+//
+// The CI failure does NOT go through the engine API path
+// (InsertBlocks + UpdateForkChoice); it goes through the integration
+// tool's direct SpawnExecuteBlocksStage loop in cmd/integration/
+// commands/stages.go:802. This test mirrors that path.
+//
+// Internal-package test so it can reach the unexported cfg /
+// posStagedSync / sentriesClient fields execmoduletester builds.
+
+package execmoduletester
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/crypto"
+	"github.com/erigontech/erigon/common/dbg"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
+	dbstate "github.com/erigontech/erigon/db/state"
+	"github.com/erigontech/erigon/db/state/execctx"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/exec"
+	"github.com/erigontech/erigon/execution/stagedsync"
+	"github.com/erigontech/erigon/execution/stagedsync/rawdbreset"
+	"github.com/erigontech/erigon/execution/stagedsync/stages"
+	"github.com/erigontech/erigon/execution/state"
+	"github.com/erigontech/erigon/execution/tests/blockgen"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/execution/types/accounts"
+	"github.com/erigontech/erigon/execution/vm"
+)
+
+// Verifies the bug is fixed under both serial and parallel exec — the
+// underlying ResetExec → SeekCommitment → ExecV3 skip-block-0 path is
+// shared, so the failure surfaces in either mode. Driver flips
+// dbg.Exec3Parallel for each sub-test; not safe to t.Parallel.
+func TestFromZero_GenesisAllocPreservedAfterResetReExec(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	for _, mode := range []struct {
+		name     string
+		parallel bool
+	}{
+		{"serial", false},
+		{"parallel", true},
+	} {
+		t.Run(mode.name, func(t *testing.T) {
+			prev := dbg.Exec3Parallel
+			dbg.Exec3Parallel = mode.parallel
+			t.Cleanup(func() { dbg.Exec3Parallel = prev })
+			runFromZeroGenesisAllocPreservedAfterResetReExec(t)
+		})
+	}
+}
+
+func runFromZeroGenesisAllocPreservedAfterResetReExec(t *testing.T) {
+
+	// Untouched-after-genesis address mirroring 0xA1E4380A's role on mainnet.
+	dormantAddr := accounts.InternAddress(common.HexToAddress("0xA1E4380A3B1f749673E270229993eE55F35663b4"))
+	dormantFunds := new(big.Int).Mul(big.NewInt(2000), new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)) // 2000 ETH
+
+	key, _ := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	keyAddr := crypto.PubkeyToAddress(key.PublicKey)
+	keyFunds := new(big.Int).Mul(big.NewInt(10), new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)) // 10 ETH
+
+	gspec := &types.Genesis{
+		Config: chain.TestChainBerlinConfig,
+		Alloc: types.GenesisAlloc{
+			dormantAddr.Value(): types.GenesisAccount{Balance: dormantFunds},
+			keyAddr:             types.GenesisAccount{Balance: keyFunds},
+		},
+	}
+
+	emt := New(t, WithGenesisSpec(gspec), WithKey(key))
+
+	// Build a chain of empty blocks that NEVER touch the dormant address.
+	gen, err := blockgen.GenerateChain(emt.ChainConfig, emt.Genesis, emt.Engine, emt.DB, 5, func(i int, b *blockgen.BlockGen) {
+		b.SetCoinbase(common.Address{1})
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, emt.InsertChain(gen))
+
+	ctx := context.Background()
+	logger := log.New()
+
+	checkBalance := func(label string) uint256.Int {
+		t.Helper()
+		var got uint256.Int
+		require.NoError(t, emt.DB.ViewTemporal(ctx, func(tx kv.TemporalTx) error {
+			rTx, err := emt.DB.BeginTemporalRo(ctx)
+			if err != nil {
+				return err
+			}
+			defer rTx.Rollback()
+			doms, err := execctx.NewSharedDomains(ctx, rTx, logger)
+			if err != nil {
+				return err
+			}
+			defer doms.Close()
+			r := state.NewReaderV3(doms.AsGetter(rTx))
+			st := state.New(r)
+			b, err := st.GetBalance(dormantAddr)
+			if err != nil {
+				return err
+			}
+			got = b
+			return nil
+		}))
+		t.Logf("[%s] dormant addr balance = %s wei (want %s wei)", label, got.String(), dormantFunds.String())
+		return got
+	}
+
+	postInitial := checkBalance("after-initial-sync")
+	require.Equal(t, dormantFunds.String(), postInitial.ToBig().String(), "after engine-API InsertChain, alloc'd balance must survive")
+
+	// Mimic `stage_exec --reset`: wipe domain tables and reset stage progress.
+	require.NoError(t, rawdbreset.ResetExec(ctx, emt.DB))
+
+	// Now drive execution the SAME way cmd/integration/commands/stages.go:802
+	// does — direct SpawnExecuteBlocksStage in a loop, with Flush/ClearRam/
+	// Commit between iterations. This is the path that fails in CI; the
+	// engine-API InsertChain path above succeeds.
+	require.NoError(t, reExecViaIntegrationPath(t, ctx, emt, gen.TopBlock.NumberU64(), logger))
+
+	postReExec := checkBalance("after-reset-and-integration-reexec")
+	require.Equal(t, dormantFunds.String(), postReExec.ToBig().String(),
+		"BUG #21138: after reset + integration-path re-exec, genesis-allocated balance dropped (mainnet block 46147)")
+}
+
+// reExecViaIntegrationPath drives execution the way cmd/integration/commands/
+// stages.go does: SpawnExecuteBlocksStage in a loop with explicit Flush /
+// ClearRam / Commit between iterations. This bypasses the engine API.
+func reExecViaIntegrationPath(t *testing.T, ctx context.Context, emt *ExecModuleTester, toBlock uint64, logger log.Logger) error {
+	t.Helper()
+
+	// The exec stage cfg execmoduletester built sits inside emt.Sync; we
+	// rebuild it with the same arguments so we can invoke
+	// SpawnExecuteBlocksStage directly without coupling to internal stage
+	// indices.
+	cfg := stagedsync.StageExecuteBlocksCfg(
+		emt.DB,
+		emt.cfg.Prune,
+		emt.cfg.BatchSize,
+		emt.ChainConfig,
+		emt.Engine,
+		&vm.Config{},
+		emt.Notifications,
+		emt.cfg.StateStream,
+		false, /*badBlockHalt*/
+		emt.Dirs,
+		emt.BlockReader,
+		emt.sentriesClient.Hd,
+		emt.cfg.Genesis,
+		emt.cfg.Sync,
+		false, /*experimentalBAL*/
+		exec.NewBlockReadAheader(),
+	)
+
+	// Lock the offline-execution writers like the integration tool does so
+	// the periodic snapshot retiring doesn't fight us.
+	if agg, ok := emt.DB.(dbstate.HasAgg); ok {
+		if aggT, okT := agg.Agg().(*dbstate.Aggregator); okT {
+			aggT.PresetOfflineExecution()
+		}
+	}
+
+	tx, err := emt.DB.BeginTemporalRw(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	doms, err := execctx.NewSharedDomains(ctx, tx, logger)
+	if err != nil {
+		return err
+	}
+	defer doms.Close()
+	doms.SetInMemHistoryReads(false)
+
+	s, err := emt.Sync.StageState(stages.Execution, tx, true, false)
+	if err != nil {
+		return err
+	}
+
+	for {
+		if err := stagedsync.SpawnExecuteBlocksStage(s, emt.Sync, doms, tx, toBlock, ctx, cfg, logger); err != nil {
+			return err
+		}
+		if err := doms.Flush(ctx, tx); err != nil {
+			return err
+		}
+		doms.ClearRam(true)
+
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+		//nolint:gocritic // mirror of integration tool's loop; defer-rollback handled by outer defer
+		tx, err = emt.DB.BeginTemporalRw(ctx)
+		if err != nil {
+			return err
+		}
+
+		s, err = emt.Sync.StageState(stages.Execution, tx, true, false)
+		if err != nil {
+			return err
+		}
+		if s.BlockNumber >= toBlock {
+			break
+		}
+	}
+	return tx.Commit()
+}

--- a/execution/stagedsync/rawdbreset/reset_stages.go
+++ b/execution/stagedsync/rawdbreset/reset_stages.go
@@ -179,11 +179,21 @@ var stateHistoryBuckets = []string{
 }
 
 func clearStageProgress(tx kv.RwTx, stagesList ...stages.SyncStage) error {
+	// Delete the progress entries rather than writing 0. SeekCommitment
+	// (commitment_context.go) distinguishes "stage never executed" (entry
+	// absent) from "stage executed up to block 0" (entry present with value 0):
+	// the latter returns txNum = TxNums.Max(0) = 1 to skip re-executing
+	// genesis. Writing 0 here would conflate "reset back to the start" with
+	// "block 0 already done" — SeekCommitment then returns (1, 0), the exec
+	// loop starts at block 1, and the block-0 init task that re-applies the
+	// genesis allocation never runs. This breaks `stage_exec --reset` →
+	// `stage_exec` from-0 sync (parallel-exec drops genesis-allocated
+	// addresses that no subsequent block touches; see #21138).
 	for _, stage := range stagesList {
-		if err := stages.SaveStageProgress(tx, stage, 0); err != nil {
+		if err := tx.Delete(kv.SyncStageProgress, []byte(stage)); err != nil {
 			return err
 		}
-		if err := stages.SaveStagePruneProgress(tx, stage, 0); err != nil {
+		if err := tx.Delete(kv.SyncStageProgress, []byte("prune_"+string(stage))); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary

Two-commit fix for `cmd/integration`'s `stage_exec --reset; stage_exec --batchSize=10mb` from-0 flow. Both issues surface together as the `qa-stage-exec (from-0, *)` CI failures on #21017 and as the chiado-from-0 / mainnet-block-46147 wrong-trie-root failures discussed in #21138.

### Commit 1 — `stages.go` env-prefix bug (yperbasis Blocker 1)

`stageExec` in `cmd/integration/commands/stages.go:631` checked only the unprefixed `EXEC3_PARALLEL` env name when deciding whether to keep its default of `dbg.Exec3Parallel = true`. CI workflows set the `ERIGON_`-prefixed form because `dbg.envLookup` auto-prepends `ERIGON_`. Result: for any caller setting `ERIGON_EXEC3_PARALLEL=false`, the integration tool silently overrode it back to `true`.

Fix: also check the `ERIGON_`-prefixed name (using `dbg.ErigonEnvPrefix` to match `envLookup`).

### Commit 2 — `ResetExec` writing 0 instead of deleting

`ResetExec → clearStageProgress` overwrote the Execution stage progress with 8 zero bytes via `SaveStageProgress(tx, stage, 0)`. That conflated two distinct states:

- **(a)** stage never started — entry absent (`len(bnBytes) == 0`)
- **(b)** stage executed up to block 0 — entry present, value 0

`SeekCommitment` in `commitmentdb/commitment_context.go:644-665` uses this entry as a fallback when no commitment state is in the domain. Per its own comment: `blockNum=0` means "genesis executed", so it returns `txNum = TxNums.Max(0) = 1` so the next exec cycle does not re-run the genesis init task.

After `ResetExec` the actual state is **(a)** (domain tables wiped, no commitment at all). But because `clearStageProgress` wrote 0 instead of deleting, `SeekCommitment` saw state **(b)** and returned `(txNum=1, blockNum=0)`. `ExecV3`'s exec loop then started at `txNum=1`, **skipping block 0's init task** — the only place that re-runs the genesis allocation through the worker pool's `LightCollector → applyVersionedWrites` pipeline.

Result: genesis-allocated addresses that no subsequent block touches end up with `balance=0` in the parallel-exec view, producing wrong-trie-root mismatches on `qa-stage-exec (from-0, parallel)` at mainnet block 46147 (address `0xA1E4380A3B1f749673E270229993eE55F35663b4`).

The engine-API `InsertChain + UpdateForkChoice` path doesn't hit this because it doesn't call `ResetExec` — it starts with no entry at all and falls into the (a) branch correctly.

Fix: `clearStageProgress` now deletes the `SyncStageProgress` entries rather than writing 0. Makes the integration path's "after reset" state consistent with the FCU path's "fresh DB" state.

## Test

Adds an internal-package unit test `TestFromZero_GenesisAllocPreservedAfterResetReExec` in `execution/execmodule/execmoduletester/` that exercises the failing path in <100 ms:

1. Set up custom genesis allocating a dormant address.
2. Sync 5 empty blocks via engine-API `InsertChain` (passes pre-fix — engine-API path is correct).
3. Reset state via `rawdbreset.ResetExec`.
4. Drive stage execution via direct `SpawnExecuteBlocksStage` in a `Flush/ClearRam/Commit` loop (mirrors `cmd/integration/commands/stages.go:802`, the integration path that fails pre-fix).
5. Assert the genesis-allocated balance is preserved.

Pre-fix the test fails with `wrong trie root, block=5`. Post-fix it passes both phases.

## Verified locally

Under `ERIGON_EXEC3_PARALLEL=true` on fresh `main` + this PR:

- [x] `make lint` clean
- [x] `make test-short` green on `execution/stagedsync`, `execution/state`, `execution/execmodule`, `execution/tests`, `execution/engineapi`, `rpc/jsonrpc`
- [x] New `TestFromZero_GenesisAllocPreservedAfterResetReExec` passes
- [ ] CI: `qa-stage-exec (from-0, serial)` and `(from-0, parallel)` legs of #21017 go green after this lands

## Diagnosis credit

Mark Holt's #21138 comment thread; iterative narrowing through CI traces + local unit-test repro.

## Related

- #21017 — serial/parallel CI matrix that surfaces the from-0 failure
- #21138 — heuristic / IBS-dependency removal tracker; this is one of the symptoms from that family
