### PR TITLE
cp #21192: prune chaindata in CommitCycle

### DIFF
--- a/execution/execmodule/forkchoice.go
+++ b/execution/execmodule/forkchoice.go
@@ -508,7 +508,9 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 		PruneTimeout:    500 * time.Millisecond,
 		BeforeIteration: nil,
 		CommitCycle: func(ctx context.Context, sd *execctx.SharedDomains) (kv.TemporalRwTx, error) {
-			// Flush SD + overlay to a brief RwTx to relieve memory pressure.
+			// Release the old RO snapshot before the flush so MDBX can
+			// reclaim retired pages while the RwTx is writing.
+			roTx.Rollback()
 			commitRwTx, err := e.db.BeginTemporalRw(ctx) //nolint:gocritic
 			if err != nil {
 				return nil, fmt.Errorf("updateForkChoice: begin rw after hasMore: %w", err)
@@ -518,13 +520,13 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 				return nil, fmt.Errorf("updateForkChoice: flush sd after hasMore: %w", err)
 			}
 			sd.ClearRam(true)
-			// Release the outer RO tx BEFORE commit so MDBX sees openTxs=1 at
-			// commit time and can release freelist pages to the GC immediately
-			// (same pattern as runForkchoiceFlushCommit). SD.Flush is done; the
-			// commit does not need to read from roTx.
-			roTx.Rollback()
 			if err = commitRwTx.Commit(); err != nil {
 				return nil, fmt.Errorf("updateForkChoice: tx commit after hasMore: %w", err)
+			}
+			// In-loop PruneExecutionStage runs on the overlay (RO-backed
+			// MemoryMutation) and silently no-ops. Drain here on a real RW tx.
+			if _, pruneErr := e.runForkchoicePrune(initialCycle); pruneErr != nil && !errors.Is(pruneErr, context.Canceled) {
+				e.logger.Warn("[commit-cycle] prune failed", "err", pruneErr)
 			}
 			// Recreate RO tx + block overlay on the fresh committed state.
 			roTx, err = e.db.BeginTemporalRo(ctx) //nolint:gocritic


### PR DESCRIPTION
Cherry-pick of #21192, restricted to the `execution/execmodule/forkchoice.go` changes (release roTx + prune in CommitCycle).

The `node/eth/backend.go` bloatnet block-snapshot collation gate from the original PR is intentionally omitted.