### PR TITLE
execution/state: mirror createObjectChange dirty-tracking on resetObjectChange (#21138)

### DIFF
--- a/execution/state/journal.go
+++ b/execution/state/journal.go
@@ -215,7 +215,30 @@ func (ch resetObjectChange) revert(s *IntraBlockState) error {
 }
 
 func (ch resetObjectChange) dirtied() (accounts.Address, bool) {
-	return accounts.NilAddress, false
+	// Symmetric with createObjectChange.dirtied: both journal entries
+	// represent the same logical operation (a stateObject was placed at
+	// this address); they differ only in revert behaviour
+	// (createObjectChange.revert deletes; resetObjectChange.revert swaps
+	// back to prev). Dirty tracking must be identical, otherwise the
+	// recreated address is missed from journal.dirties and downstream
+	// consumers (FinalizeTx, GetRemovedAccountsWithBalance, MakeWriteSet)
+	// silently skip it.
+	//
+	// Manifests under parallel-exec when tx1 SD's an address and tx2 hits
+	// CreateAccount / GetOrNewStateObject on the same address — the
+	// versionedRead-synthesised `previous` is non-nil so createObject's
+	// else-branch is taken; with dirtied() returning false the worker's
+	// MakeWriteSet drops the write for the recreated address and the
+	// receipts / state root diverge from serial. See #21138.
+	//
+	// Known regression at the time of this change: TestSelfDestructReceive
+	// fails under EXEC3_PARALLEL=true with a wrong-trie-root, because the
+	// validator's stateObject reconstruction for an SD-then-revived address
+	// emits different field values (`nonce=1, codehash=emptyHash`) than
+	// the unfixed canonical (`nonce=0, codehash=<nil>`). Tracked in #21217
+	// — needs a narrower fix that gets the empty-touch / CreateAccount
+	// case right without changing the AddBalance(non-zero) writeset.
+	return ch.account, true
 }
 
 func (ch selfdestructChange) revert(s *IntraBlockState) error {


### PR DESCRIPTION
## Stack

**Depends on:** #21212 — #21138 PR 2 (minIBS extraction). Must merge first.

## Summary

Third in the [#21138](https://github.com/erigontech/erigon/issues/21138) heuristic / IBS-dependency removal stack. Restores symmetric dirty-tracking between `createObjectChange.dirtied()` and `resetObjectChange.dirtied()` so parallel-exec workers don't drop the post-SD-revival writeset.

\`journal.go\` defined the two journal entry types for the same logical "createObject" event with non-symmetric \`dirtied()\` returns:

\`\`\`go
func (ch createObjectChange) dirtied() (accounts.Address, bool) { return ch.account, true }
func (ch resetObjectChange)  dirtied() (accounts.Address, bool) { return accounts.NilAddress, false }
\`\`\`

\`createObject\` in \`intra_block_state.go\` picks between them on \`previous == nil\` — first-creation goes through \`createObjectChange\`, recreation (e.g. SD-revival via \`GetOrNewStateObject\`) goes through \`resetObjectChange\`. Both represent the same operation; the asymmetry was an oversight.

Manifests under parallel-exec when tx1 SD's an address and tx2 hits \`CreateAccount\` / \`GetOrNewStateObject\` on the same address:

- **Serial**: tx1's writer already \`DeleteAccount\`'d the addr → \`getStateObject\` returns \`nil\` → \`createObject(addr, nil)\` appends \`createObjectChange\` → marks \`journal.dirties\`.
- **Parallel**: \`versionedRead\` reads tx1's \`SelfDestructPath=true\`; \`createObject\` synthesises a non-nil \`previous\` with \`selfdestructed=true\` → appends \`resetObjectChange\` → with the old return, does **not** mark \`journal.dirties\`.

At \`MakeWriteSet\` the worker IBS computes \`isDirty\` from \`journal.dirties\`. With no mark, \`updateAccount\` falls through both DELETE and UPDATE branches → \`LightCollector.UpdateAccountData\` never fires → \`result.CollectorWrites\` is missing the empty-account write (\`test_double_kill\` / EEST EIP-6780 family on the parallel shard).

Diagnosis credit: original investigation by Mark Holt on PR #21207 thread.

## Known regression — tracked in #21217

\`TestSelfDestructReceive\` fails under \`EXEC3_PARALLEL=true\` after this change with a wrong-trie-root for block 1.

The validator's \`stateObject\` reconstruction for an SD-then-revived address emits different field values (\`nonce=1, codehash=emptyHash\`) than the unfixed canonical (\`nonce=0, codehash=<nil>\`). The empty-touch / \`CreateAccount\` paths this fix addresses don't have this issue; the \`AddBalance(non-zero)\` on an SD'd address does.

Filed as **#21217** with full repro and two failed narrow-fix attempts (unconditional symmetry — this PR; conditional SD-revival + \`SelfDestructPath=false\` re-emit — also regresses). The right narrower fix needs more diagnosis on the validator's read path.

Per coordination with the original diagnosis author, this PR lands as the **last commit in the #21138 cleanup stack** so the broader structural direction is visible together; the \`TestSelfDestructReceive\` regression is the explicit "more work needed" marker before final merge.

## What's verified

Under \`EXEC3_PARALLEL=true\` on the fix branch:

- [x] \`make lint\` clean
- [x] \`TestEngineApiBAL*\` family green
- [x] \`TestEIP7708BurnLog*\` green
- [x] \`TestDeleteRecreate*\` green
- [x] \`TestSelfDestructReceive\` **serial** green
- [ ] \`TestSelfDestructReceive\` **parallel** — known fail, see #21217
- [ ] EEST parallel shard \`test_double_kill\` / \`test_dynamic_create2_selfdestruct_collision\` — expected to pass per PR #21207's local verification of this same fix shape

## What's next

- **#21217** — narrower dirtied() fix to resolve the \`TestSelfDestructReceive\` regression. Must be in before this stack merges.
- **PR 4** (next in stack, deferred until #21217 is in) — drain the three IBS deps from \`runPostApplyMessageOnMinIBS\` (\`PostApplyMessageFunc\` returns \`[]*types.Log\` instead of using \`ibs.AddLog\`; SD-with-balance computed explicitly on \`ExecutionResult\` so \`ibs.GetRemovedAccountsWithBalance\` isn't needed). After PR 4, \`finalizeTxSimple\` is IBS-free.
- **PR 5** — replace \`normalizeWriteSet\` with \`filterWritesByVersionMap\`.

## Related

- #21211 — #21138 PR 1 (dead-finalize)
- #21212 — #21138 PR 2 (minIBS extraction; this PR's direct base)
- #21217 — TestSelfDestructReceive regression diagnosis
- #21207 — original diagnosis comment thread