### PR TITLE
cl/forkchoice: fix Caplin stuck on mainnet after GLOAS merge

### DIFF
--- a/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
+++ b/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
@@ -95,8 +95,10 @@ type forkGraphDisk struct {
 	headers   sync.Map // set of headers
 	badBlocks sync.Map // blocks that are invalid and that leads to automatic fail of extension.
 
-	// current state data — protected by currentStateMu when accessed
-	// concurrently (e.g. getCheckpointState runs outside forkchoice mu).
+	// current state data — dual-protected. AddChainSegment is the sole writer
+	// and runs under the outer forkchoice f.mu, so reads taken under f.mu are
+	// already serialized against the writer and don't need currentStateMu.
+	// Reads outside f.mu (e.g. getCheckpointState) must take currentStateMu.
 	currentStateMu        sync.RWMutex
 	currentState          *state.CachingBeaconState
 	currentStateBlockRoot common.Hash // block root of the last processed block (avoids BlockRoot() zeroed-StateRoot issue)

--- a/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
+++ b/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
@@ -95,7 +95,9 @@ type forkGraphDisk struct {
 	headers   sync.Map // set of headers
 	badBlocks sync.Map // blocks that are invalid and that leads to automatic fail of extension.
 
-	// current state data
+	// current state data — protected by currentStateMu when accessed
+	// concurrently (e.g. getCheckpointState runs outside forkchoice mu).
+	currentStateMu        sync.RWMutex
 	currentState          *state.CachingBeaconState
 	currentStateBlockRoot common.Hash // block root of the last processed block (avoids BlockRoot() zeroed-StateRoot issue)
 
@@ -325,21 +327,25 @@ func (f *forkGraphDisk) AddChainSegment(signedBlock *cltypes.SignedBeaconBlock, 
 			log.Warn("Invalid beacon block", "slot", block.Slot, "blockRoot", common.Bytes2Hex(blockRoot[:]), "reason", invalidBlockErr)
 			f.blocks.Delete(common.Hash(blockRoot)) // remove early-stored block
 			f.badBlocks.Store(common.Hash(blockRoot), struct{}{})
+			f.currentStateMu.Lock()
 			f.currentState = nil
 			f.currentStateBlockRoot = common.Hash{}
+			f.currentStateMu.Unlock()
 			return nil, InvalidBlock, invalidBlockErr
 		}
 		f.blockRewards.Store(common.Hash(blockRoot), blockRewardsCollector)
 	}
 
+	f.currentStateMu.Lock()
 	f.currentState = newState
 	f.currentStateBlockRoot = common.Hash(blockRoot)
+	f.currentStateMu.Unlock()
 
 	// Verify currentState.BlockRoot() matches the actual block root.
-	if computedRoot, cerr := f.currentState.BlockRoot(); cerr == nil && computedRoot != common.Hash(blockRoot) {
+	if computedRoot, cerr := newState.BlockRoot(); cerr == nil && computedRoot != common.Hash(blockRoot) {
 		// Detailed diagnostics: compare state header fields with block fields.
-		hdr := f.currentState.LatestBlockHeader()
-		stateHashSSZ, _ := f.currentState.HashSSZ()
+		hdr := newState.LatestBlockHeader()
+		stateHashSSZ, _ := newState.HashSSZ()
 		log.Warn("AddChainSegment: BlockRoot MISMATCH after TransitionState",
 			"slot", block.Slot,
 			"expectedBlockRoot", common.Hash(blockRoot),
@@ -477,14 +483,22 @@ func (f *forkGraphDisk) useCachedStateIfPossible(blockRoot common.Hash, in *stat
 }
 
 func (f *forkGraphDisk) getState(blockRoot common.Hash, alwaysCopy bool, addChainSegment bool) (*state.CachingBeaconState, error) {
-	if f.currentState != nil && f.currentStateBlockRoot == blockRoot {
+	// Snapshot currentState/currentStateBlockRoot under RLock so that
+	// concurrent callers (getCheckpointState outside forkchoice mu)
+	// don't race with AddChainSegment writes.
+	f.currentStateMu.RLock()
+	cs := f.currentState
+	csRoot := f.currentStateBlockRoot
+	f.currentStateMu.RUnlock()
+
+	if cs != nil && csRoot == blockRoot {
 		if alwaysCopy {
-			return f.currentState.Copy()
+			return cs.Copy()
 		}
-		return f.currentState, nil
+		return cs, nil
 	}
 	if addChainSegment && !alwaysCopy {
-		if state, ok, err := f.useCachedStateIfPossible(blockRoot, f.currentState); ok {
+		if state, ok, err := f.useCachedStateIfPossible(blockRoot, cs); ok {
 			return state, err
 		}
 	}
@@ -535,8 +549,10 @@ func (f *forkGraphDisk) getState(blockRoot common.Hash, alwaysCopy bool, addChai
 	for i := len(blocksInTheWay) - 1; i >= 0; i-- {
 		if err := transition.TransitionState(copyReferencedState, blocksInTheWay[i], nil, false); err != nil {
 			if addChainSegment {
-				f.currentState = nil // reset the state if it fails here.
+				f.currentStateMu.Lock()
+				f.currentState = nil
 				f.currentStateBlockRoot = common.Hash{}
+				f.currentStateMu.Unlock()
 			}
 			return nil, err
 		}

--- a/cl/phase1/forkchoice/fork_graph/fork_graph_disk_fs.go
+++ b/cl/phase1/forkchoice/fork_graph/fork_graph_disk_fs.go
@@ -32,6 +32,12 @@ import (
 	"github.com/erigontech/erigon/common/log/v3"
 )
 
+// maxSSZObjectSize is a generous upper bound for any single SSZ object
+// (beacon state, envelope, etc.). Mainnet states with ~1.5M validators are
+// ~327 MB after decompression; 1 GiB leaves ample room for validator-set
+// growth while still catching clearly corrupt length fields before OOM.
+const maxSSZObjectSize = 1 << 30 // 1 GiB
+
 func getBeaconStateFilename(blockRoot common.Hash) string {
 	return fmt.Sprintf("%x.snappy_ssz", blockRoot)
 }
@@ -75,6 +81,9 @@ func (f *forkGraphDisk) readBeaconStateFromDisk(blockRoot common.Hash) (bs *stat
 	}
 
 	length := binary.BigEndian.Uint64(lengthBytes)
+	if length > maxSSZObjectSize {
+		return nil, fmt.Errorf("corrupt beacon state file: length %d exceeds max %d, root: %x", length, maxSSZObjectSize, blockRoot)
+	}
 	if length > uint64(cap(f.sszBuffer)) {
 		f.sszBuffer = make([]byte, length)
 	} else {
@@ -224,6 +233,9 @@ func (f *forkGraphDisk) ReadEnvelopeFromDisk(blockRoot common.Hash) (envelope *c
 	}
 
 	envelopeLength := binary.BigEndian.Uint64(lengthBytes)
+	if envelopeLength > maxSSZObjectSize {
+		return nil, fmt.Errorf("corrupt envelope file: length %d exceeds max %d, root: %x", envelopeLength, maxSSZObjectSize, blockRoot)
+	}
 	if envelopeLength > uint64(cap(f.sszBuffer)) {
 		f.sszBuffer = make([]byte, envelopeLength)
 	} else {

--- a/cl/phase1/forkchoice/fork_graph/fork_graph_disk_fs.go
+++ b/cl/phase1/forkchoice/fork_graph/fork_graph_disk_fs.go
@@ -32,8 +32,6 @@ import (
 	"github.com/erigontech/erigon/common/log/v3"
 )
 
-const maxSSZBufferSize = 128 << 20 // 128 MB
-
 func getBeaconStateFilename(blockRoot common.Hash) string {
 	return fmt.Sprintf("%x.snappy_ssz", blockRoot)
 }
@@ -77,9 +75,6 @@ func (f *forkGraphDisk) readBeaconStateFromDisk(blockRoot common.Hash) (bs *stat
 	}
 
 	length := binary.BigEndian.Uint64(lengthBytes)
-	if length > maxSSZBufferSize {
-		return nil, fmt.Errorf("corrupt beacon state file: length %d exceeds max %d, root: %x", length, maxSSZBufferSize, blockRoot)
-	}
 	if length > uint64(cap(f.sszBuffer)) {
 		f.sszBuffer = make([]byte, length)
 	} else {
@@ -94,13 +89,6 @@ func (f *forkGraphDisk) readBeaconStateFromDisk(blockRoot common.Hash) (bs *stat
 
 	if err = bs.DecodeSSZ(f.sszBuffer, int(v[0])); err != nil {
 		return nil, fmt.Errorf("failed to decode beacon state: %w, root: %x, len: %d, decLen: %d, bs: %+v", err, blockRoot, n, len(f.sszBuffer), bs)
-	}
-
-	// Re-initialize caches after SSZ decode. state.New() called InitBeaconState()
-	// on an empty state; after DecodeSSZ populates real data, caches like
-	// publicKeyIndicies are stale (empty). Reinitialize them from the decoded data.
-	if err = bs.InitBeaconState(); err != nil {
-		return nil, fmt.Errorf("failed to reinitialize caches after SSZ decode: %w, root: %x", err, blockRoot)
 	}
 
 	// Try to read the persisted previousStateRoot (appended after SSZ data).
@@ -236,9 +224,6 @@ func (f *forkGraphDisk) ReadEnvelopeFromDisk(blockRoot common.Hash) (envelope *c
 	}
 
 	envelopeLength := binary.BigEndian.Uint64(lengthBytes)
-	if envelopeLength > maxSSZBufferSize {
-		return nil, fmt.Errorf("corrupt envelope file: length %d exceeds max %d, root: %x", envelopeLength, maxSSZBufferSize, blockRoot)
-	}
 	if envelopeLength > uint64(cap(f.sszBuffer)) {
 		f.sszBuffer = make([]byte, envelopeLength)
 	} else {

--- a/cl/phase1/forkchoice/get_head.go
+++ b/cl/phase1/forkchoice/get_head.go
@@ -206,16 +206,17 @@ func (f *ForkChoiceStore) getHead(auxilliaryState *state.CachingBeaconState) (co
 	justifiedCheckpoint := f.justifiedCheckpoint.Load().(solid.Checkpoint)
 	var justificationState *checkpointState
 	var err error
-	// Take write lock here
-	f.mu.Lock()
-	defer f.mu.Unlock()
 	if auxilliaryState == nil {
-		// See which validators can be used for attestation score
+		// Compute checkpoint state BEFORE acquiring f.mu: this operation
+		// can read a large state from disk, which would block the OnTick
+		// goroutine if done under the lock.
 		justificationState, err = f.getCheckpointState(justifiedCheckpoint)
 		if err != nil {
 			return common.Hash{}, 0, err
 		}
 	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
 
 	// Retrieve att
 	f.headHash = justifiedCheckpoint.Root

--- a/cl/phase1/forkchoice/get_head.go
+++ b/cl/phase1/forkchoice/get_head.go
@@ -28,6 +28,7 @@ import (
 	"github.com/erigontech/erigon/cl/cltypes/solid"
 	"github.com/erigontech/erigon/cl/phase1/core/state"
 	"github.com/erigontech/erigon/common"
+	log "github.com/erigontech/erigon/common/log/v3"
 )
 
 // accountWeights updates the weights of the validators, given the vote and given an head leaf.
@@ -114,6 +115,18 @@ func (f *ForkChoiceStore) GetHead(auxilliaryState *state.CachingBeaconState) (co
 		return f.headHash, f.headSlot, nil
 	}
 	f.mu.RUnlock()
+
+	// After checkpoint sync the justified root may predate the anchor and
+	// not exist in the fork graph. Both getHead and getHeadGloas depend on
+	// the justified root being present (for getCheckpointState and
+	// getFilteredBlockTree respectively). Return the anchor as head until
+	// forward sync produces a resolvable justified checkpoint.
+	justifiedCheckpoint := f.justifiedCheckpoint.Load().(solid.Checkpoint)
+	if _, hasJustified := f.forkGraph.GetHeader(justifiedCheckpoint.Root); !hasJustified {
+		log.Debug("GetHead: justified root not in fork graph, using anchor as head",
+			"justifiedRoot", justifiedCheckpoint.Root)
+		return f.forkGraph.AnchorRoot(), f.forkGraph.AnchorSlot(), nil
+	}
 
 	currentEpoch := f.computeEpochAtSlot(f.Slot())
 	if f.beaconCfg.GetCurrentStateVersion(currentEpoch) >= clparams.GloasVersion {

--- a/cl/phase1/forkchoice/utils.go
+++ b/cl/phase1/forkchoice/utils.go
@@ -206,15 +206,6 @@ func (f *ForkChoiceStore) getCheckpointState(checkpoint solid.Checkpoint) (*chec
 		return nil, err
 	}
 	if baseState == nil {
-		// Checkpoint root not in fork graph (e.g. it predates the anchor
-		// after checkpoint sync). Fall back to the anchor state which is
-		// at the same or a nearby epoch and always available on disk.
-		baseState, err = f.forkGraph.GetState(f.forkGraph.AnchorRoot(), true)
-		if err != nil {
-			return nil, err
-		}
-	}
-	if baseState == nil {
 		return nil, errors.New("getCheckpointState: baseState not found in graph")
 	}
 	// By default use the no change encoding to signal that there is no future epoch here.

--- a/cl/phase1/forkchoice/utils.go
+++ b/cl/phase1/forkchoice/utils.go
@@ -206,6 +206,15 @@ func (f *ForkChoiceStore) getCheckpointState(checkpoint solid.Checkpoint) (*chec
 		return nil, err
 	}
 	if baseState == nil {
+		// Checkpoint root not in fork graph (e.g. it predates the anchor
+		// after checkpoint sync). Fall back to the anchor state which is
+		// at the same or a nearby epoch and always available on disk.
+		baseState, err = f.forkGraph.GetState(f.forkGraph.AnchorRoot(), true)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if baseState == nil {
 		return nil, errors.New("getCheckpointState: baseState not found in graph")
 	}
 	// By default use the no change encoding to signal that there is no future epoch here.


### PR DESCRIPTION
## Summary

Fixes #21272 — Caplin gets stuck with `baseState not found in graph` on mainnet after the GLOAS merge (#18956).

**Root cause**: The GLOAS PR added `maxSSZBufferSize = 128 MB` in `readBeaconStateFromDisk`. Mainnet beacon state with ~1.5M validators is ~327 MB after decompression, so every state read was rejected as "corrupt". This made `getCheckpointState` always fail.

Three additional issues compounded the problem:

- **Duplicate `InitBeaconState`**: `DecodeSSZ` already calls `InitBeaconState` internally (`ssz.go:40`). The explicit second call doubled the decode time by rebuilding the pubkey index for ~1.5M validators.

- **Lock contention**: `getHead` held `f.mu.Lock` while calling `getCheckpointState`, which reads and decodes a large state from disk. This blocked the `OnTick` goroutine for the entire duration.

- **Missing fallback**: After checkpoint sync, the justified checkpoint root may predate the anchor and not exist in the fork graph. Before GLOAS this was masked because forward sync always ran to completion (no stale timeout).

## Changes

- Replace 128 MB `maxSSZBufferSize` with a 1 GiB `maxSSZObjectSize` cap in `readBeaconStateFromDisk` / `ReadEnvelopeFromDisk` — ~3x headroom over current mainnet ~327 MB states while still bounding `make([]byte, length)` against a corrupt length field
- Remove duplicate `InitBeaconState()` in `readBeaconStateFromDisk`
- Move `getCheckpointState` before `f.mu.Lock()` in `getHead`
- Fall back to anchor state in `getCheckpointState` when checkpoint root is not in graph

## Test plan

- Verified on `dev-bm-e3-sepolia-n1` (mainnet, fresh datadir):
  - Before: `baseState not found in graph` on every ForkChoice round
  - After: `Imported chain segment` every ~12s, ForkChoice in ~2.9s
- Existing unit tests pass (`TestGetState_InfiniteLoopOnMissingStateFile`, `TestForkGraphInDisk`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)