### PR TITLE
p2p: clean up partial startup resources

### DIFF
--- a/cl/p2p/p2p.go
+++ b/cl/p2p/p2p.go
@@ -110,6 +110,18 @@ func NewP2Pmanager(ctx context.Context, cfg *P2PConfig, logger log.Logger, ethCl
 		ethClock:    ethClock,
 		bannedPeers: lru.NewWithTTL[peer.ID, struct{}]("bannedPeers", 1_000, 30*time.Minute),
 	}
+	started := false
+	defer func() {
+		if started {
+			return
+		}
+		if p.udpv5 != nil {
+			p.udpv5.Close()
+		}
+		if p.host != nil {
+			_ = p.host.Close()
+		}
+	}()
 
 	// pubsub
 	pubsub.TimeCacheDuration = gossipSubSeenTTL * gossipSubHeartbeatInterval
@@ -139,6 +151,7 @@ func NewP2Pmanager(ctx context.Context, cfg *P2PConfig, logger log.Logger, ethCl
 	}
 	go p.updateENR()
 	go p.peerMonitor(ctx)
+	started = true
 	return &p, nil
 }
 

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -373,7 +373,16 @@ func (srv *Server) Start(ctx context.Context, logger log.Logger) error {
 		return errors.New("server already running")
 	}
 	srv.lock.Lock()
-	defer srv.lock.Unlock()
+	started := false
+	defer func() {
+		if !started {
+			srv.stopPartialStart()
+			srv.lock.Unlock()
+			srv.loopWG.Wait()
+			return
+		}
+		srv.lock.Unlock()
+	}()
 
 	srv.logger = logger
 	if srv.clock == nil {
@@ -423,7 +432,34 @@ func (srv *Server) Start(ctx context.Context, logger log.Logger) error {
 	srv.running.Store(true)
 	srv.loopWG.Add(1)
 	go srv.run()
+	started = true
 	return nil
+}
+
+func (srv *Server) stopPartialStart() {
+	if srv.quitFunc != nil {
+		srv.quitFunc()
+	}
+	if srv.listener != nil {
+		_ = srv.listener.Close()
+		srv.listener = nil
+	}
+	if srv.discv4 != nil {
+		srv.discv4.Close()
+		srv.discv4 = nil
+	}
+	if srv.discv5 != nil {
+		srv.discv5.Close()
+		srv.discv5 = nil
+	}
+	if srv.discmix != nil {
+		srv.discmix.Close()
+		srv.discmix = nil
+	}
+	if srv.nodedb != nil {
+		srv.nodedb.Close()
+		srv.nodedb = nil
+	}
 }
 
 func (srv *Server) updateLocalNodeStaticAddrCache() {
@@ -501,6 +537,12 @@ func (srv *Server) setupDiscovery(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	keepConn := false
+	defer func() {
+		if !keepConn {
+			_ = conn.Close()
+		}
+	}()
 
 	var (
 		sconn     discover.UDPConn = conn
@@ -565,6 +607,7 @@ func (srv *Server) setupDiscovery(ctx context.Context) error {
 			return err
 		}
 	}
+	keepConn = srv.discv4 != nil || srv.discv5 != nil
 
 	// Add protocol-specific discovery sources.
 	added := make(map[string]bool)


### PR DESCRIPTION
## Summary

- Close opened P2P resources when startup fails after partial initialization.
- Release DevP2P UDP listeners on discovery setup errors and close Caplin host/discv5 resources on constructor failures.