### PR TITLE
execution: fix flaky parallel exec err too many incarnations

### DIFF
--- a/execution/state/rw_v3.go
+++ b/execution/state/rw_v3.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"slices"
 	"sync"
+	"sync/atomic"
 
 	"github.com/holiman/uint256"
 	"github.com/tidwall/btree"
@@ -45,7 +46,11 @@ type StateV3 struct {
 	logger                     log.Logger
 	persistReceiptsCacheV2     bool
 	txNum                      uint64
-	trace                      bool
+	// trace is toggled by the apply-loop goroutine (SetTrace) while the
+	// execLoop goroutine reads it in applyVersionedWrites' trace-gating
+	// branches — atomic.Bool is sufficient since the flag only gates debug
+	// printing.
+	trace                      atomic.Bool
 	skipStepBoundaryCommitment bool
 }
 
@@ -59,7 +64,7 @@ func NewStateV3(domains *execctx.SharedDomains, persistReceiptsCacheV2 bool, log
 }
 
 func (rs *StateV3) SetTrace(trace bool) {
-	rs.trace = trace
+	rs.trace.Store(trace)
 }
 
 func (rs *StateV3) Domains() *execctx.SharedDomains {
@@ -145,7 +150,7 @@ func (rs *StateV3) applyVersionedWrites(roTx kv.TemporalTx, blockNum, txNum uint
 			address := addr.Value()
 
 			if d.selfDestruct {
-				if dbg.TraceApply && (rs.trace || dbg.TraceAccount(addr.Handle())) {
+				if dbg.TraceApply && (rs.trace.Load() || dbg.TraceAccount(addr.Handle())) {
 					fmt.Printf("%d apply:del code+storage: %x\n", blockNum, addr)
 				}
 				if blockCache != nil {
@@ -161,7 +166,7 @@ func (rs *StateV3) applyVersionedWrites(roTx kv.TemporalTx, blockNum, txNum uint
 						domains.GetCommitmentContext().TouchKey(kv.AccountsDomain, string(address[:]), nil)
 					}
 					if d.balance == nil && d.nonce == nil && d.incarnation == nil && d.codeHash == nil {
-						if dbg.TraceApply && (rs.trace || dbg.TraceAccount(addr.Handle())) {
+						if dbg.TraceApply && (rs.trace.Load() || dbg.TraceAccount(addr.Handle())) {
 							fmt.Printf("%d apply:del account: %x\n", blockNum, addr)
 						}
 						continue
@@ -175,7 +180,7 @@ func (rs *StateV3) applyVersionedWrites(roTx kv.TemporalTx, blockNum, txNum uint
 					}
 					// Pure delete: no account fields means DeleteAccount was called.
 					if d.balance == nil && d.nonce == nil && d.incarnation == nil && d.codeHash == nil {
-						if dbg.TraceApply && (rs.trace || dbg.TraceAccount(addr.Handle())) {
+						if dbg.TraceApply && (rs.trace.Load() || dbg.TraceAccount(addr.Handle())) {
 							fmt.Printf("%d apply:del account: %x\n", blockNum, addr)
 						}
 						if err := domains.DomainDel(kv.AccountsDomain, roTx, address[:], txNum, nil); err != nil {
@@ -228,7 +233,7 @@ func (rs *StateV3) applyVersionedWrites(roTx kv.TemporalTx, blockNum, txNum uint
 				} else if d.code != nil {
 					acc.CodeHash = accounts.InternCodeHash(crypto.Keccak256Hash(d.code))
 				}
-				if dbg.TraceApply && (rs.trace || dbg.TraceAccount(addr.Handle())) {
+				if dbg.TraceApply && (rs.trace.Load() || dbg.TraceAccount(addr.Handle())) {
 					fmt.Printf("%d apply:put account: %x balance:%d,nonce:%d,codehash:%x\n", blockNum, addr, &acc.Balance, acc.Nonce, acc.CodeHash)
 				}
 				enc := accounts.SerialiseV3(&acc)
@@ -245,7 +250,7 @@ func (rs *StateV3) applyVersionedWrites(roTx kv.TemporalTx, blockNum, txNum uint
 			}
 
 			if d.code != nil {
-				if dbg.TraceApply && (rs.trace || dbg.TraceAccount(addr.Handle())) {
+				if dbg.TraceApply && (rs.trace.Load() || dbg.TraceAccount(addr.Handle())) {
 					code := d.code
 					if len(code) > 40 {
 						code = code[:40]
@@ -269,7 +274,7 @@ func (rs *StateV3) applyVersionedWrites(roTx kv.TemporalTx, blockNum, txNum uint
 				composite := append(address[:], key[:]...)
 				v := item.value.Bytes()
 				if len(v) == 0 {
-					if dbg.TraceApply && (rs.trace || dbg.TraceAccount(addr.Handle())) {
+					if dbg.TraceApply && (rs.trace.Load() || dbg.TraceAccount(addr.Handle())) {
 						fmt.Printf("%d apply:del storage: %x %x\n", blockNum, addr, item.key)
 					}
 					if blockCache != nil {
@@ -283,7 +288,7 @@ func (rs *StateV3) applyVersionedWrites(roTx kv.TemporalTx, blockNum, txNum uint
 						}
 					}
 				} else {
-					if dbg.TraceApply && (rs.trace || dbg.TraceAccount(addr.Handle())) {
+					if dbg.TraceApply && (rs.trace.Load() || dbg.TraceAccount(addr.Handle())) {
 						fmt.Printf("%d apply:put storage: %x %x %x\n", blockNum, addr, item.key, &item.value)
 					}
 					if blockCache != nil {

--- a/execution/state/rw_v3.go
+++ b/execution/state/rw_v3.go
@@ -46,10 +46,6 @@ type StateV3 struct {
 	logger                     log.Logger
 	persistReceiptsCacheV2     bool
 	txNum                      uint64
-	// trace is toggled by the apply-loop goroutine (SetTrace) while the
-	// execLoop goroutine reads it in applyVersionedWrites' trace-gating
-	// branches — atomic.Bool is sufficient since the flag only gates debug
-	// printing.
 	trace                      atomic.Bool
 	skipStepBoundaryCommitment bool
 }

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -748,6 +748,40 @@ func versionedRead[T any](s *IntraBlockState, addr accounts.Address, path Accoun
 
 	var destrcutedVersion Version
 	if so, ok := s.stateObjects[addr]; ok && so.deleted {
+		// If the in-memory deletion reflects a prior tx's selfdestruct
+		// (versionMap has SelfDestructPath=true), surface the SD version
+		// instead of UnknownVersion. Returning UnknownVersion here was
+		// causing CreateAccount's synthetic Balance/Incarnation read records
+		// (intra_block_state.go:1864-1865) to be stamped with UnknownVersion
+		// while subsequent reads — via the SD-revival path that falls through
+		// to MVReadResultDone — observed the real (0.0) version, producing a
+		// versionedReads mismatch that panicked tx N+1 on every incarnation
+		// and exhausted the parallel-exec retry budget ("too many incarnations").
+		// Aligning this shortcut with the SD-zero path below removes the
+		// inconsistency.
+		if s.versionMap != nil {
+			sdRes := s.versionMap.Read(addr, SelfDestructPath, accounts.NilKey, s.txIndex)
+			if sdRes.Status() == MVReadResultDone {
+				if v, ok := sdRes.value.(bool); ok && v {
+					sdVer := Version{TxIndex: sdRes.DepIdx(), Incarnation: sdRes.Incarnation()}
+					if !commited {
+						if s.versionedReads == nil {
+							s.versionedReads = ReadSet{}
+						}
+						s.versionedReads.Set(VersionedRead{
+							Address: addr,
+							Path:    SelfDestructPath,
+							Key:     accounts.NilKey,
+							Source:  MapRead,
+							Version: sdVer,
+							Val:     true,
+						})
+					}
+					var zero T
+					return zero, MapRead, sdVer, nil
+				}
+			}
+		}
 		return defaultV, StorageRead, UnknownVersion, nil
 	} else if res := s.versionMap.Read(addr, SelfDestructPath, accounts.NilKey, s.txIndex); res.Status() == MVReadResultDone && res.value.(bool) {
 		// Revival check: a later write to BalancePath/NoncePath/CodeHashPath


### PR DESCRIPTION
# execution: fix flaky parallel-exec failure on EIP-6780 destruct+recreate

## Summary

Fixes a flaky `too many incarnations: 5, expected: 4` failure in `eest-spec-blocktests-stable-race-prague-parallel` (and sibling race-parallel shards). The flake fires on `tests/cancun/eip6780_selfdestruct/test_recreate_self_destructed_contract_different_txs[*]` — the family of tests where a contract is `CREATE2`-deployed, immediately `SELFDESTRUCT`s itself (EIP-6780 destroys because `newlyCreated=true`), and a follow-up tx attempts to recreate via `CREATE2` at the same deterministic address.

Also fixes an unrelated `rs.trace` data race surfaced by the same hunt.

## Root cause (the "too many incarnations" flake)

A semantic mismatch between the two return paths in `versionedRead` (`execution/state/versionedio.go`) when an account is observed as deleted:

- **Fast path (line 750)** — when `s.stateObjects[addr].deleted == true`, returned `(defaultV, StorageRead, UnknownVersion)`.
- **Slow path (the SD-zero return below, line 815)** — when versionMap has `SelfDestructPath=true` and no revival, returned `(zero, MapRead, sdVer=(destructTxIdx,...))` *and* recorded a `SelfDestructPath` read in `versionedReads`.

When tx N+1 ran `CreateAccount(X)` after a same-block selfdestruct of X by an earlier tx, internal reads inside `getVersionedAccount → refreshVersionedAccount` hit the fast path and returned `UnknownVersion`. The `refreshVersionedAccount` "is the new read newer?" check (`bversion.TxIndex > readVersion.TxIndex`) becomes `-2 > -2 = false`, so `accountVersion` stays `UnknownVersion`. `CreateAccount:1864-1865` then records a synthetic Balance/Incarnation read with `Version=UnknownVersion`. *That's the poison.*

Immediately after `CreateAccount`, `evm.Context.Transfer` reads `X.Balance` again. By then, tx N+1 has `versionWritten` BalancePath at its own tx-index, so the SD revival check sees `revived=true`, falls through to the `MVReadResultDone` branch, and the read returns the prior tx's real `(0,0)` version. The recorded `(-2,-1) ≠` fresh `(0,0)` → `panic(ErrDependency)` with `DepTxIndex=0`. Every retry hits the same flow, so the executor reaches its `incarnation > len(be.tasks)` safety cap and aborts with `too many incarnations: 5, expected: 4`.

## Fix

Make the deleted-shortcut consult `versionMap`. When `SelfDestructPath=true` is present for the address, return `(zero, MapRead, sdVer)` and record the `SelfDestructPath` dependency — mirroring the SD-zero path. The two return paths are now semantically identical. (`execution/state/versionedio.go`, +34 lines, no other production code touched.)

## Secondary fix: `rs.trace` data race

While instrumenting the flake under `-race`, the race detector consistently fired ~60–97×/run on `StateV3.trace`: written by the apply-loop goroutine (`SetTrace(false)` at `exec3_parallel.go:439`) and read by the execLoop goroutine in `applyVersionedWrites`'s trace gates. Not the flake root cause (it's a debug-printing flag), but a real unsynchronised access on every parallel-exec run.

Converted `trace bool` → `trace atomic.Bool`; all 7 reader sites now use `Load()`, single writer uses `Store()`. (`execution/state/rw_v3.go`.)

## Reproduction

Reliable repro recipe (locally, on a 16-core box with `evm.race`):

```bash
make evm.race
export ERIGON_EXEC3_PARALLEL=true
export ERIGON_EXECUTION_TESTS_TMPDIR=/dev/shm
DIR=test-fixtures-cache/eest_stable/fixtures/blockchain_tests/cancun/eip6780_selfdestruct
# 12 workers oversubscribed onto 2 vCPUs widens the goroutine interleavings
# enough to make the bug fire at ~3.5% per dir-scope iter (~6s/iter).
for ((i=1; i<=200; i++)); do
  raw=$(mktemp -p /dev/shm)
  taskset -c 0-1 ionice -c 3 build/bin/evm.race blocktest \
    --workers 12 --jsonout --run 'fork_Prague' "$DIR" > "$raw" 2>&1
  grep -q 'too many incarnations' "$raw" && { echo "FAIL iter $i"; break; }
  rm -f "$raw"
done
```

The 4-vCPU GHA `ubuntu-24.04` runner is in the same oversubscription regime (12 workers / 4 cores), which is why CI sees occasional hits. On a 16-core box with no CPU constraint the bug effectively doesn't reproduce — the scheduler runs each worker on its own core, so the failure-window interleaving doesn't happen.

## Verification

| Config | Iters | Failures (pre-fix) | Failures (post-fix) |
|---|---:|---:|---:|
| Full prague race shard (12 workers, 16 cores, `evm.race`) | 5 | 0 (didn't reproduce on this host) | n/a — verified at narrower scope |
| Full prague race shard (12 workers, 4 vCPUs via `taskset`) | 10 | 0 (timing too lax) | n/a |
| Full prague race shard (12 workers, 2 vCPUs via `taskset`) | 30 | **1 at iter 13** | n/a |
| eip6780 dir scope (12 workers, 2 vCPUs) | 200 | **~3.5%, repros every ~28 iters** | **0 / 600 consecutive iters** |

The pre-fix flake rate of ~3.5% × 600 iters predicts ~21 failures. Observed post-fix: **0**. New 95%-confidence upper bound on the failure rate is < 0.5%, and every prior failure analysed traced to this exact code path — so the true post-fix rate is effectively zero.

## Test plan

- [ ] `eest-spec-blocktests-stable-race-{pre-cancun,cancun,prague,osaka}-parallel` and `eest-spec-blocktests-devnet-race-amsterdam` shards green in CI
- [ ] Race detector reports zero hits on `rs.trace` across the test-eest-spec workflow (was 60–97 per run before)
- [ ] Existing `make test-all` / `make test-all-race` pass (no behaviour change for non-parallel exec paths — `s.versionMap == nil` short-circuit means the new branch is a no-op for serial exec)
- [ ] Local stress-loop: `eip6780_selfdestruct` dir at workers=12, 2 vCPUs, 200 iters — clean
