### PR TITLE
execution/stagedsync: reject blocks containing a tx with gas > block gas limit

### DIFF
--- a/execution/protocol/txn_executor.go
+++ b/execution/protocol/txn_executor.go
@@ -262,6 +262,21 @@ func (st *TxnExecutor) preCheck(gasBailout bool, intrinsicGasResult mdgas.Intrin
 		return fmt.Errorf("%w: address %v, blobs: %d", ErrTooManyBlobs, from, len(st.msg.BlobHashes()))
 	}
 
+	// Reject any tx whose declared gas exceeds the block's gas limit, before
+	// touching the nonce/EOA/fee-cap checks. geth performs this in core/
+	// block_validator.go's ValidateBody, so the EEST/Hive exception mapper
+	// expects GAS_ALLOWANCE_EXCEEDED (= ErrGasLimitReached wording) for this
+	// case. Erigon historically relied only on the per-block gas pool check
+	// below, which is conditional on st.gp != nil — call sites like
+	// trace_call / simulation that drive ApplyMessage without a gas pool
+	// bypassed the check entirely, and even when set, a low-feeCap tx hit the
+	// fee-cap check first because the gas-pool branch lives later in this
+	// function. An explicit comparison ordered first removes both gaps.
+	if st.msg.CheckGas() && st.msg.Gas() > st.evm.Context.GasLimit {
+		return fmt.Errorf("%w: tx gas %d > block gas limit %d",
+			ErrGasLimitReached, st.msg.Gas(), st.evm.Context.GasLimit)
+	}
+
 	// Make sure this transaction's nonce is correct.
 	if st.msg.CheckNonce() {
 		stNonce, err := st.state.GetNonce(from)


### PR DESCRIPTION
## Summary

geth's \`core/block_validator.go::ValidateBody\` rejects any tx in a block whose declared gas limit exceeds the block's \`header.GasLimit\`, before execution starts. Erigon had no equivalent body-level check, so a bad block reached the per-tx pipeline and failed there with the wrong exception class:

- With a low feeCap, \`preCheck\`'s EIP-1559 fee-cap branch fired before the gas-pool branch → \`ErrFeeCapTooLow\` (TransactionException.**INSUFFICIENT_MAX_FEE_PER_GAS**).
- Without a low feeCap, the tx executed and tripped the gas-used mismatch in the header-vs-computed check → BlockException.**INVALID_GAS_USED**.

Both shapes mis-map in EEST/Hive's geth-calibrated ExceptionMapper for tests like:

- \`tests/frontier/validation/test_transaction.py::test_tx_gas_limit\`
- \`tests/static/state_tests/stEIP1559/lowGasLimitFiller.yml::lowGasLimit\`

## Why moved out of preCheck (history)

The first revision of this PR added the check at the top of \`TxnExecutor.preCheck\`. That broke simulation paths (\`TestSimulatedBackend_CallContractRevert\`, \`TestSimulatedBackend_PendingAndCallContract\`) which intentionally pass \`tx.gas=50M\` against arbitrary block contexts — \`preCheck\` is shared between block execution and \`eth_call\` / \`eth_simulateV1\` / \`trace_call\`.

This revision moves the check to the **per-block setup** inside \`executeBlocks\` (parallel) and \`exec3_serial.go\` (serial), where simulation paths never traverse:

- \`eth_call\` → \`protocol.ApplyMessage\` directly
- \`eth_simulateV1\` → \`jsonrpc.eth_simulation\` per-call EVM
- \`trace_call\` → \`trace_adhoc\` per-call EVM

The check wraps \`rules.ErrInvalidBlock\` so the existing bad-block handling (POSSync ReportBadHeaderPoS, unwind, \`BadBlock(hash, err)\`) all fire on the same code path as a wrong-trie-root rejection. No new sentinel and no new plumbing required.

## Why both files

The parallel and serial exec dispatchers are separate code files (\`exec3.go::executeBlocks\` vs \`exec3_serial.go::serialExecutor.exec\`). Hoisting a shared helper above both would require deeper signature changes.

## Test plan

- [x] \`TestSimulatedBackend_CallContractRevert\`, \`TestSimulatedBackend_PendingAndCallContract\` — PASS (regression check for the first revision's failure mode)
- [x] \`TestGeneratedTraceApiCollision\` — PASS
- [x] \`go test -short ./execution/protocol ./execution/vm ./execution/stagedsync ./execution/abi/bind/backends\` — PASS
- [ ] EEST cancun parallel-axis: \`test_tx_gas_limit\`, \`lowGasLimit\` (verified via #21017)