### PR TITLE
execution: extract EIP-8037 inclusion check, run it for parallel exec

### DIFF
--- a/execution/protocol/gaspool.go
+++ b/execution/protocol/gaspool.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"math"
 	"sync"
+
+	"github.com/erigontech/erigon/execution/protocol/params"
 )
 
 // GasPool tracks block-level gas availability across the two EIP-8037 dimensions.
@@ -164,6 +166,27 @@ func (gp *GasPool) SubBlobGas(amount uint64) error {
 		return ErrBlobGasLimitReached
 	}
 	gp.blobGas -= amount
+	return nil
+}
+
+// CheckBlockGasInclusion verifies the EIP-8037 per-dimension inclusion
+// rule against gp. Called from TxnExecutor.preCheck (serial path) and
+// parallelExecutor finalize (parallel path, where preCheck sees a
+// per-tx pool and so the check there is a no-op).
+func CheckBlockGasInclusion(gp *GasPool, txGas uint64, isAmsterdam bool) error {
+	if gp == nil {
+		return nil
+	}
+	regularContribution := txGas
+	if isAmsterdam {
+		regularContribution = min(regularContribution, params.MaxTxnGasLimit)
+	}
+	if regularContribution > gp.RegularGasAvailable() {
+		return ErrGasLimitReached
+	}
+	if isAmsterdam && txGas > gp.StateGasAvailable() {
+		return ErrGasLimitReached
+	}
 	return nil
 }
 

--- a/execution/protocol/txn_executor.go
+++ b/execution/protocol/txn_executor.go
@@ -303,20 +303,8 @@ func (st *TxnExecutor) preCheck(gasBailout bool, intrinsicGasResult mdgas.Intrin
 		}
 	}
 
-	// EIP-8037 inclusion check, per-dimension:
-	//   min(TX_MAX_GAS_LIMIT, tx.gas) <= regular_gas_available
-	//   tx.gas                         <= state_gas_available  (Amsterdam+)
-	if st.gp != nil {
-		regularContribution := st.msg.Gas()
-		if rules.IsAmsterdam {
-			regularContribution = min(regularContribution, params.MaxTxnGasLimit)
-		}
-		if regularContribution > st.gp.RegularGasAvailable() {
-			return ErrGasLimitReached
-		}
-		if rules.IsAmsterdam && st.msg.Gas() > st.gp.StateGasAvailable() {
-			return ErrGasLimitReached
-		}
+	if err := CheckBlockGasInclusion(st.gp, st.msg.Gas(), rules.IsAmsterdam); err != nil {
+		return err
 	}
 
 	// Make sure the transaction feeCap is greater than the block's baseFee.

--- a/execution/protocol/txn_executor_test.go
+++ b/execution/protocol/txn_executor_test.go
@@ -214,3 +214,83 @@ func TestEIP8037_GasPoolTracksRegularAndStateIndependently(t *testing.T) {
 	require.NotEqual(t, blockGasLimit-(max(r1, s1)+max(r2, s2)), gp.RegularGasAvailable(),
 		"regular pool must not be charged Σ max(r_i, s_i) — that is the pre-378d07cb bug")
 }
+
+// TestPreCheckErrorOrdering_GasBeforeFeeCap asserts the geth-aligned
+// validation ordering: a tx that fails both block-gas inclusion AND
+// EIP-1559 fee-cap must produce ErrGasLimitReached, not ErrFeeCapTooLow.
+//
+// Regression test for the parallel-exec gap that prompted PR #21237: the
+// parallel worker constructs a per-tx gas pool (trace_worker.go:121) so
+// preCheck's gp-branch is a no-op (tx.gas vs tx.gas) under parallel and
+// the fee-cap check fires first, mis-classifying the failure for
+// EEST/Hive mappers (expected GAS_ALLOWANCE_EXCEEDED, got
+// INSUFFICIENT_MAX_FEE_PER_GAS).
+//
+// The fix routes the same check through CheckBlockGasInclusion against
+// the block-level pool, so the ordering is preserved on both paths.
+func TestPreCheckErrorOrdering_GasBeforeFeeCap(t *testing.T) {
+	t.Parallel()
+
+	const blockGasLimit = 30_000_000
+	cfg := chain.TestChainAuraConfig // London rules active
+
+	sender := accounts.InternAddress(common.HexToAddress("0x1111111111111111111111111111111111111111"))
+	recipient := accounts.InternAddress(common.HexToAddress("0x2222222222222222222222222222222222222222"))
+
+	t.Run("tx-gas > block-gas-limit AND fee-cap < baseFee returns ErrGasLimitReached", func(t *testing.T) {
+		ibs := state.New(state.NewNoopReader())
+		blockCtx := evmtypes.BlockContext{
+			CanTransfer: CanTransfer,
+			Transfer:    misc.Transfer,
+			GasLimit:    blockGasLimit,
+			BaseFee:     *uint256.NewInt(100), // non-zero baseFee
+		}
+		evm := vm.NewEVM(blockCtx, evmtypes.TxContext{}, ibs, cfg, vm.Config{})
+
+		// feeCap=1, baseFee=100 -> would fail ErrFeeCapTooLow
+		// gas=blockGasLimit+1 -> must fail ErrGasLimitReached first
+		msg := types.NewMessage(
+			sender, recipient, 0, uint256.NewInt(0), blockGasLimit+1,
+			uint256.NewInt(1), uint256.NewInt(1), uint256.NewInt(1),
+			nil, nil,
+			false, false, true, false, nil,
+		)
+		gp := new(GasPool).AddGas(blockGasLimit)
+
+		st := NewTxnExecutor(evm, msg, gp)
+		_, err := st.Execute(true, false)
+
+		require.ErrorIs(t, err, ErrGasLimitReached,
+			"gas-pool inclusion must reject before fee-cap")
+		require.NotErrorIs(t, err, ErrFeeCapTooLow,
+			"fee-cap error must not leak past the gas-pool reject")
+	})
+
+	t.Run("CheckBlockGasInclusion rejects tx-gas > block-gas-limit", func(t *testing.T) {
+		gp := new(GasPool).AddGas(blockGasLimit)
+		require.ErrorIs(t, CheckBlockGasInclusion(gp, blockGasLimit+1, false), ErrGasLimitReached)
+	})
+
+	t.Run("CheckBlockGasInclusion accepts tx-gas <= block-gas-limit", func(t *testing.T) {
+		gp := new(GasPool).AddGas(blockGasLimit)
+		require.NoError(t, CheckBlockGasInclusion(gp, blockGasLimit, false))
+		require.NoError(t, CheckBlockGasInclusion(gp, blockGasLimit-1, false))
+	})
+
+	t.Run("CheckBlockGasInclusion is a no-op for nil gp (simulation paths)", func(t *testing.T) {
+		require.NoError(t, CheckBlockGasInclusion(nil, blockGasLimit*1000, false))
+		require.NoError(t, CheckBlockGasInclusion(nil, blockGasLimit*1000, true))
+	})
+
+	t.Run("CheckBlockGasInclusion Amsterdam state-dim rejects unclamped tx-gas", func(t *testing.T) {
+		// On Amsterdam+ a tx with gas > MaxTxnGasLimit gets its regular
+		// contribution clamped to MaxTxnGasLimit. The state-dimension
+		// check uses unclamped tx-gas, so a tx with gas > stateAvailable
+		// must still be rejected even when the clamped regular fits.
+		gp := NewGasPool(params.MaxTxnGasLimit+1000, 0)
+		require.ErrorIs(t,
+			CheckBlockGasInclusion(gp, params.MaxTxnGasLimit+10000, true),
+			ErrGasLimitReached,
+			"Amsterdam state-dim check must catch unclamped tx-gas > stateAvailable")
+	})
+}

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2582,14 +2582,20 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 					}
 				}
 
+				txTask := be.tasks[tx].Task
+
+				if txn := txTask.Tx(); txn != nil {
+					if err := protocol.CheckBlockGasInclusion(be.gasPool, txn.GetGasLimit(), txTask.Rules().IsAmsterdam); err != nil {
+						return nil, fmt.Errorf("%w, block=%d txIdx=%d: %w", rules.ErrInvalidBlock, be.blockNum, txVersion.TxIndex, err)
+					}
+				}
+
 				if err := be.gasPool.ConsumeRegular(txResult.ExecutionResult.BlockRegularGasUsed); err != nil {
 					return nil, fmt.Errorf("%w, block=%d: block regular gas overflow", rules.ErrInvalidBlock, be.blockNum)
 				}
 				if err := be.gasPool.ConsumeState(txResult.ExecutionResult.BlockStateGasUsed); err != nil {
 					return nil, fmt.Errorf("%w, block=%d: block state gas overflow", rules.ErrInvalidBlock, be.blockNum)
 				}
-
-				txTask := be.tasks[tx].Task
 
 				if txTask.Tx() != nil {
 					blobGasUsed := txTask.Tx().GetBlobGas()

--- a/execution/tests/insert_chain_bad_tx_gas_test.go
+++ b/execution/tests/insert_chain_bad_tx_gas_test.go
@@ -1,0 +1,81 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package executiontests
+
+import (
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/execmodule/execmoduletester"
+	"github.com/erigontech/erigon/execution/tests/blockgen"
+	"github.com/erigontech/erigon/execution/types"
+)
+
+// Asserts both serial and parallel reject a block whose tx-gas exceeds
+// header.GasLimit. Regression for the parallel-only gap where preCheck's
+// gp-branch is a no-op against the per-tx pool built in trace_worker.
+func TestInsertChain_TxGasExceedsBlockGasLimit_RejectsOnBothPaths(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow test")
+	}
+
+	data := getGenesis()
+	from := data.addresses[0]
+	fromKey := data.keys[0]
+	to := common.Address{1}
+
+	_, validChain, err := GenerateBlocks(t, data.genesisSpec, map[int]txn{
+		0: {getBlockTx(from, to, uint256.NewInt(1000)), fromKey},
+	})
+	require.NoError(t, err)
+	require.Len(t, validChain.Blocks, 1)
+
+	// Only divergence vs validChain: header.GasLimit dropped below the tx's
+	// 21000, so the sole invariant the bad block violates is the new one.
+	badHeader := types.CopyHeader(validChain.Headers[0])
+	badHeader.GasLimit = 20000
+
+	badBlock := types.NewBlock(badHeader, validChain.Blocks[0].Transactions(),
+		validChain.Blocks[0].Uncles(), validChain.Receipts[0], nil)
+	badChain := &blockgen.ChainPack{
+		Blocks:   []*types.Block{badBlock},
+		Headers:  []*types.Header{badHeader},
+		TopBlock: badBlock,
+	}
+
+	cases := []struct {
+		name string
+		opts []execmoduletester.Option
+	}{
+		{"parallel", nil},
+		{"serial", []execmoduletester.Option{execmoduletester.WithoutExperimentalBAL()}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := append([]execmoduletester.Option{
+				execmoduletester.WithGenesisSpec(data.genesisSpec),
+				execmoduletester.WithKey(fromKey),
+			}, tc.opts...)
+			m := execmoduletester.New(t, opts...)
+			require.Error(t, m.InsertChain(badChain),
+				"%s exec must reject tx-gas > block-gas-limit", tc.name)
+		})
+	}
+}


### PR DESCRIPTION
Extracts `protocol.CheckBlockGasInclusion` from the EIP-8037 gp-branch of `TxnExecutor.preCheck` and runs it from two places:

- `TxnExecutor.preCheck` — unchanged behaviour for serial.
- `exec3_parallel.go` finalize (before `ConsumeRegular` / `ConsumeState` / `SubBlobGas`) — fires the equivalent check against `be.gasPool` for parallel exec, which the per-tx pool in `trace_worker.go:121` would otherwise bypass.

Wraps `rules.ErrInvalidBlock` on the parallel reject. No new sentinel, no plumbing changes.