### PR TITLE
node: fix HTTP RPC vhost checks for mixed-case Host headers

### DIFF
--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -506,7 +506,7 @@ func (h *virtualHostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.next.ServeHTTP(w, r)
 		return
 	}
-	if _, exist := h.vhosts[strings.ToLower(host)]; exist {
+	if _, exist := h.vhosts[host]; exist {
 		h.next.ServeHTTP(w, r)
 		return
 	}

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -490,6 +490,7 @@ func (h *virtualHostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// Either invalid (too many colons) or no port specified
 		host = r.Host
 	}
+	host = strings.ToLower(host)
 	if ipAddr := net.ParseIP(host); ipAddr != nil {
 		// It's an IP address, we can serve that
 		h.next.ServeHTTP(w, r)

--- a/node/rpcstack_test.go
+++ b/node/rpcstack_test.go
@@ -69,6 +69,10 @@ func TestVhosts(t *testing.T) {
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
+	respUpper := rpcRequest(t, url, "host", "TeSt:1234")
+	defer respUpper.Body.Close()
+	assert.Equal(t, http.StatusOK, respUpper.StatusCode)
+
 	resp2 := rpcRequest(t, url, "host", "bad")
 	defer resp2.Body.Close()
 	assert.Equal(t, http.StatusForbidden, resp2.StatusCode)


### PR DESCRIPTION
## Summary

This PR fixes HTTP RPC virtual-host validation so Host header checks are handled case-insensitively.

Previously, configured vhosts were normalized to lowercase, but the incoming request host was compared as-is. Because of that, a valid request like `Host: TeSt:1234` could be rejected with `403 Forbidden` even when `test` was included in `--http.vhosts`.

## Changes

- Lowercase the parsed request host before checking it against the allowed vhosts.
- Add a regression test for mixed-case Host headers with an explicit port.

## Reproduction

Before this fix, running HTTP RPC with `test` in `--http.vhosts` and sending:

```bash
curl -i \
  -H 'Host: TeSt:1234' \
  -H 'Content-Type: application/json' \
  --data '{"jsonrpc":"2.0","id":1,"method":"web3_clientVersion","params":[]}' \
  http://127.0.0.1:8545
```
could incorrectly return 403 Forbidden.