### PR TITLE
exec: fix committed-log metrics

### DIFF
--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -310,11 +310,10 @@ func ExecV3(ctx context.Context,
 					committedTransactions := currentTxNum - se.lastCommittedTxNum.Load()
 					se.lastCommittedTxNum.Store(currentTxNum)
 
-					commitStart := time.Now()
 					stepsInDb = rawdbhelpers.IdxStepsCountV3(applyTx, applyTx.Debug().StepSize())
 
 					if initialCycle {
-						se.LogCommitments(commitStart, 0, committedTransactions, 0, stepsInDb, commitment.CommitProgress{})
+						se.LogCommitments(0, committedTransactions, 0, stepsInDb, commitment.CommitProgress{})
 					}
 				case errors.Is(execErr, ErrWrongTrieRoot):
 					execErr = handleIncorrectRootHashError(

--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -313,7 +313,7 @@ func ExecV3(ctx context.Context,
 					stepsInDb = rawdbhelpers.IdxStepsCountV3(applyTx, applyTx.Debug().StepSize())
 
 					if initialCycle {
-						se.LogCommitments(0, committedTransactions, 0, stepsInDb, commitment.CommitProgress{})
+						se.LogCommitments(committedTransactions, stepsInDb, commitment.CommitProgress{})
 					}
 				case errors.Is(execErr, ErrWrongTrieRoot):
 					execErr = handleIncorrectRootHashError(

--- a/execution/stagedsync/exec3_metrics.go
+++ b/execution/stagedsync/exec3_metrics.go
@@ -482,7 +482,7 @@ type Progress struct {
 	prevCommitTime                 time.Time
 	prevCommittedBlockNum          uint64
 	prevCommittedTxNum             uint64
-	prevCommittedGas               int64
+	prevCommitLogGas               int64
 	prevCommitmentKeyCount         uint64
 	prevCommitmentAccountKeyCount  uint64
 	prevCommitmentStorageKeyCount  uint64
@@ -498,7 +498,7 @@ type Progress struct {
 
 type executor interface {
 	LogExecution()
-	LogCommitments(committedBlocks uint64, committedTransactions uint64, committedGas uint64, stepsInDb float64, lastProgress commitment.CommitProgress)
+	LogCommitments(committedTransactions uint64, stepsInDb float64, lastProgress commitment.CommitProgress)
 	LogComplete(stepsInDb float64)
 }
 
@@ -740,7 +740,8 @@ func (p *Progress) LogCommitments(rs *state.StateV3, ex executor, stepsInDb floa
 	currentTime := time.Now()
 	interval := currentTime.Sub(p.prevCommitTime)
 
-	committedGasSec := uint64(float64(te.executedGas.Load()-p.prevCommittedGas) / interval.Seconds())
+	executedGas := te.executedGas.Load()
+	gasSec := uint64(float64(executedGas-p.prevCommitLogGas) / interval.Seconds())
 	var committedTxSec uint64
 	if te.lastCommittedTxNum.Load() > p.prevCommittedTxNum {
 		committedTxSec = uint64(float64(te.lastCommittedTxNum.Load()-p.prevCommittedTxNum) / interval.Seconds())
@@ -809,7 +810,7 @@ func (p *Progress) LogCommitments(rs *state.StateV3, ex executor, stepsInDb floa
 	rs.Domains().Metrics().RUnlock()
 
 	p.log("committed", suffix, te, rs, interval, te.lastCommittedBlockNum.Load(), committedDiffBlocks,
-		te.lastCommittedTxNum.Load()-p.prevCommittedTxNum, committedTxSec, committedGasSec, 0, stepsInDb, commitVals)
+		te.lastCommittedTxNum.Load()-p.prevCommittedTxNum, committedTxSec, gasSec, 0, stepsInDb, commitVals)
 
 	p.prevDomainMetrics = updateExecDomainMetrics(te.doms.Metrics(), p.prevDomainMetrics, interval, false)
 
@@ -817,7 +818,7 @@ func (p *Progress) LogCommitments(rs *state.StateV3, ex executor, stepsInDb floa
 
 	if te.lastCommittedTxNum.Load() > 0 {
 		p.prevCommittedTxNum = te.lastCommittedTxNum.Load()
-		p.prevCommittedGas = te.executedGas.Load()
+		p.prevCommitLogGas = executedGas
 		p.prevCommittedBlockNum = te.lastCommittedBlockNum.Load()
 	}
 }

--- a/execution/stagedsync/exec3_metrics.go
+++ b/execution/stagedsync/exec3_metrics.go
@@ -498,7 +498,7 @@ type Progress struct {
 
 type executor interface {
 	LogExecution()
-	LogCommitments(commitStart time.Time, committedBlocks uint64, committedTransactions uint64, committedGas uint64, stepsInDb float64, lastProgress commitment.CommitProgress)
+	LogCommitments(committedBlocks uint64, committedTransactions uint64, committedGas uint64, stepsInDb float64, lastProgress commitment.CommitProgress)
 	LogComplete(stepsInDb float64)
 }
 
@@ -723,7 +723,7 @@ func (p *Progress) LogExecution(rs *state.StateV3, ex executor) {
 	}
 }
 
-func (p *Progress) LogCommitments(rs *state.StateV3, ex executor, commitStart time.Time, stepsInDb float64, lastProgress commitment.CommitProgress) {
+func (p *Progress) LogCommitments(rs *state.StateV3, ex executor, stepsInDb float64, lastProgress commitment.CommitProgress) {
 	var te *txExecutor
 	var suffix string
 
@@ -737,14 +737,10 @@ func (p *Progress) LogCommitments(rs *state.StateV3, ex executor, commitStart ti
 		suffix = " serial"
 	}
 
-	if p.prevCommitTime.Before(commitStart) {
-		p.prevCommitTime = commitStart
-	}
-
 	currentTime := time.Now()
 	interval := currentTime.Sub(p.prevCommitTime)
 
-	committedGasSec := uint64(float64(te.committedGas.Load()-p.prevCommittedGas) / interval.Seconds())
+	committedGasSec := uint64(float64(te.executedGas.Load()-p.prevCommittedGas) / interval.Seconds())
 	var committedTxSec uint64
 	if te.lastCommittedTxNum.Load() > p.prevCommittedTxNum {
 		committedTxSec = uint64(float64(te.lastCommittedTxNum.Load()-p.prevCommittedTxNum) / interval.Seconds())
@@ -821,7 +817,7 @@ func (p *Progress) LogCommitments(rs *state.StateV3, ex executor, commitStart ti
 
 	if te.lastCommittedTxNum.Load() > 0 {
 		p.prevCommittedTxNum = te.lastCommittedTxNum.Load()
-		p.prevCommittedGas = te.committedGas.Load()
+		p.prevCommittedGas = te.executedGas.Load()
 		p.prevCommittedBlockNum = te.lastCommittedBlockNum.Load()
 	}
 }

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -601,7 +601,7 @@ func (pe *parallelExecutor) exec(ctx context.Context, execStage *StageState, u U
 	// is updated in handleCommitResult when results are consumed.
 
 	if !hasLoggedCommittments.Load() && !commitStart.IsZero() {
-		pe.LogCommitments(commitStart, 0, 0, 0, stepsInDb, lastProgress)
+		pe.LogCommitments(0, 0, 0, stepsInDb, lastProgress)
 	}
 
 	if execErr != nil {
@@ -663,11 +663,11 @@ func (pe *parallelExecutor) LogExecution() {
 	}
 }
 
-func (pe *parallelExecutor) LogCommitments(commitStart time.Time, committedBlocks uint64, committedTransactions uint64, committedGas uint64, stepsInDb float64, lastProgress commitment.CommitProgress) {
+func (pe *parallelExecutor) LogCommitments(committedBlocks uint64, committedTransactions uint64, committedGas uint64, stepsInDb float64, lastProgress commitment.CommitProgress) {
 	pe.committedGas.Add(int64(committedGas))
 	pe.txExecutor.lastCommittedBlockNum.Add(committedBlocks)
 	pe.txExecutor.lastCommittedTxNum.Add(committedTransactions)
-	pe.progress.LogCommitments(pe.rs.StateV3, pe, commitStart, stepsInDb, lastProgress)
+	pe.progress.LogCommitments(pe.rs.StateV3, pe, stepsInDb, lastProgress)
 	if domainMetrics := pe.domains().LogMetrics(); len(domainMetrics) > 0 {
 		pe.logger.Info(fmt.Sprintf("[%s] domain reads", pe.logPrefix), domainMetrics...)
 	}

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -601,7 +601,7 @@ func (pe *parallelExecutor) exec(ctx context.Context, execStage *StageState, u U
 	// is updated in handleCommitResult when results are consumed.
 
 	if !hasLoggedCommittments.Load() && !commitStart.IsZero() {
-		pe.LogCommitments(0, 0, 0, stepsInDb, lastProgress)
+		pe.LogCommitments(0, stepsInDb, lastProgress)
 	}
 
 	if execErr != nil {
@@ -663,9 +663,7 @@ func (pe *parallelExecutor) LogExecution() {
 	}
 }
 
-func (pe *parallelExecutor) LogCommitments(committedBlocks uint64, committedTransactions uint64, committedGas uint64, stepsInDb float64, lastProgress commitment.CommitProgress) {
-	pe.committedGas.Add(int64(committedGas))
-	pe.txExecutor.lastCommittedBlockNum.Add(committedBlocks)
+func (pe *parallelExecutor) LogCommitments(committedTransactions uint64, stepsInDb float64, lastProgress commitment.CommitProgress) {
 	pe.txExecutor.lastCommittedTxNum.Add(committedTransactions)
 	pe.progress.LogCommitments(pe.rs.StateV3, pe, stepsInDb, lastProgress)
 	if domainMetrics := pe.domains().LogMetrics(); len(domainMetrics) > 0 {

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -288,11 +288,11 @@ func (se *serialExecutor) LogExecution() {
 	se.progress.LogExecution(se.rs.StateV3, se)
 }
 
-func (se *serialExecutor) LogCommitments(commitStart time.Time, committedBlocks uint64, committedTransactions uint64, committedGas uint64, stepsInDb float64, lastProgress commitment.CommitProgress) {
+func (se *serialExecutor) LogCommitments(committedBlocks uint64, committedTransactions uint64, committedGas uint64, stepsInDb float64, lastProgress commitment.CommitProgress) {
 	se.committedGas.Add(int64(committedGas))
 	se.txExecutor.lastCommittedBlockNum.Add(committedBlocks)
 	se.txExecutor.lastCommittedTxNum.Add(committedTransactions)
-	se.progress.LogCommitments(se.rs.StateV3, se, commitStart, stepsInDb, lastProgress)
+	se.progress.LogCommitments(se.rs.StateV3, se, stepsInDb, lastProgress)
 }
 
 func (se *serialExecutor) LogComplete(stepsInDb float64) {

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -288,9 +288,7 @@ func (se *serialExecutor) LogExecution() {
 	se.progress.LogExecution(se.rs.StateV3, se)
 }
 
-func (se *serialExecutor) LogCommitments(committedBlocks uint64, committedTransactions uint64, committedGas uint64, stepsInDb float64, lastProgress commitment.CommitProgress) {
-	se.committedGas.Add(int64(committedGas))
-	se.txExecutor.lastCommittedBlockNum.Add(committedBlocks)
+func (se *serialExecutor) LogCommitments(committedTransactions uint64, stepsInDb float64, lastProgress commitment.CommitProgress) {
 	se.txExecutor.lastCommittedTxNum.Add(committedTransactions)
 	se.progress.LogCommitments(se.rs.StateV3, se, stepsInDb, lastProgress)
 }


### PR DESCRIPTION
## Summary

- `gas/s=0`: `committedGas` accumulator was never incremented — all callers always passed `0`. Fixed by using `executedGas` (updated per block) as the gas baseline.
- `blk/s=633M`, `tx/s=12G`: `commitStart` was set to `time.Now()` immediately before `LogCommitments`, then overrode `prevCommitTime`, making the measured interval ~0ns. Fixed by removing the override so the interval always measures from the previous log call.

Cleanup from the above:
- Removed always-zero `committedBlocks` and `committedGas` parameters from the `LogCommitments` interface and all implementations
- Renamed `prevCommittedGas` → `prevCommitLogGas` to match what it actually tracks
- Snapshot `executedGas` once instead of two separate atomic loads