### PR TITLE
cl: GLOAS audit fixes — clone aliasing, PTC consistency, memory leaks, nil panics

### DIFF
--- a/cl/cltypes/epbs_payload.go
+++ b/cl/cltypes/epbs_payload.go
@@ -514,8 +514,12 @@ func (s *SignedExecutionPayloadEnvelope) EncodingSizeSSZ() int {
 }
 
 func (s *SignedExecutionPayloadEnvelope) Clone() clonable.Clonable {
+	var message *ExecutionPayloadEnvelope
+	if s.Message != nil {
+		message = s.Message.Clone().(*ExecutionPayloadEnvelope)
+	}
 	return &SignedExecutionPayloadEnvelope{
-		Message:   s.Message.Clone().(*ExecutionPayloadEnvelope),
+		Message:   message,
 		Signature: s.Signature,
 		beaconCfg: s.beaconCfg,
 	}

--- a/cl/cltypes/epbs_payload.go
+++ b/cl/cltypes/epbs_payload.go
@@ -412,7 +412,7 @@ type ExecutionPayloadEnvelope struct {
 
 func NewExecutionPayloadEnvelope(cfg *clparams.BeaconChainConfig) *ExecutionPayloadEnvelope {
 	return &ExecutionPayloadEnvelope{
-		Payload:               NewEth1Block(clparams.BellatrixVersion, cfg),
+		Payload:               NewEth1Block(clparams.GloasVersion, cfg),
 		ExecutionRequests:     NewExecutionRequests(cfg),
 		BuilderIndex:          0,
 		BeaconBlockRoot:       common.Hash{},
@@ -468,14 +468,18 @@ func (e *ExecutionPayloadEnvelope) EncodingSizeSSZ() int {
 }
 
 func (e *ExecutionPayloadEnvelope) Clone() clonable.Clonable {
-	return &ExecutionPayloadEnvelope{
-		Payload:               e.Payload,
-		ExecutionRequests:     e.ExecutionRequests,
-		BuilderIndex:          e.BuilderIndex,
-		BeaconBlockRoot:       e.BeaconBlockRoot,
-		ParentBeaconBlockRoot: e.ParentBeaconBlockRoot,
-		beaconCfg:             e.beaconCfg,
+	cloned := NewExecutionPayloadEnvelope(e.beaconCfg)
+	if e.Payload == nil {
+		return cloned
 	}
+	encoded, err := e.EncodeSSZ(nil)
+	if err != nil {
+		return cloned
+	}
+	if err := cloned.DecodeSSZ(encoded, int(e.Payload.Version())); err != nil {
+		return cloned
+	}
+	return cloned
 }
 
 // SignedExecutionPayloadEnvelope represents a signed execution payload envelope.

--- a/cl/cltypes/epbs_payload.go
+++ b/cl/cltypes/epbs_payload.go
@@ -24,6 +24,7 @@ import (
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/clonable"
 	"github.com/erigontech/erigon/common/length"
+	log "github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/common/ssz"
 )
 
@@ -474,9 +475,11 @@ func (e *ExecutionPayloadEnvelope) Clone() clonable.Clonable {
 	}
 	encoded, err := e.EncodeSSZ(nil)
 	if err != nil {
+		log.Error("ExecutionPayloadEnvelope.Clone: EncodeSSZ failed", "err", err)
 		return cloned
 	}
 	if err := cloned.DecodeSSZ(encoded, int(e.Payload.Version())); err != nil {
+		log.Error("ExecutionPayloadEnvelope.Clone: DecodeSSZ failed", "err", err)
 		return cloned
 	}
 	return cloned

--- a/cl/cltypes/epbs_payload_test.go
+++ b/cl/cltypes/epbs_payload_test.go
@@ -1,0 +1,18 @@
+package cltypes
+
+import (
+	"testing"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSignedExecutionPayloadEnvelopeCloneNilMessage(t *testing.T) {
+	envelope := &SignedExecutionPayloadEnvelope{
+		Signature: common.Bytes96{1, 2, 3},
+	}
+
+	cloned := envelope.Clone().(*SignedExecutionPayloadEnvelope)
+	require.Nil(t, cloned.Message)
+	require.Equal(t, envelope.Signature, cloned.Signature)
+}

--- a/cl/phase1/core/state/cache_accessors.go
+++ b/cl/phase1/core/state/cache_accessors.go
@@ -517,7 +517,7 @@ func (b *CachingBeaconState) GetValidatorActivationChurnLimit() uint64 {
 // ptcWindow's 3-epoch range (e.g. state advanced far past the parent).
 func (b *CachingBeaconState) GetPTC(slot uint64) ([]uint64, error) {
 	if b.Version() >= clparams.GloasVersion {
-		ptc, err := b.getPTCFromWindow(slot)
+		ptc, err := b.GetPTCFromWindow(slot)
 		if err == nil {
 			return ptc, nil
 		}
@@ -526,14 +526,14 @@ func (b *CachingBeaconState) GetPTC(slot uint64) ([]uint64, error) {
 	return b.ComputePTC(slot)
 }
 
-// getPTCFromWindow reads the PTC for a given slot from the ptc_window state field.
+// GetPTCFromWindow reads the PTC for a given slot from the ptc_window state field.
 // Index calculation follows the spec's get_ptc:
 //   - previous epoch: index = slot % SLOTS_PER_EPOCH
 //   - current/lookahead: index = (epoch - state_epoch + 1) * SLOTS_PER_EPOCH + slot % SLOTS_PER_EPOCH
 //
 // The ptc_window only covers [stateEpoch-1, stateEpoch, stateEpoch+1]. Slots
 // outside this range return an error.
-func (b *CachingBeaconState) getPTCFromWindow(slot uint64) ([]uint64, error) {
+func (b *CachingBeaconState) GetPTCFromWindow(slot uint64) ([]uint64, error) {
 	cfg := b.BeaconConfig()
 	epoch := GetEpochAtSlot(cfg, slot)
 	stateEpoch := b.Slot() / cfg.SlotsPerEpoch
@@ -557,8 +557,11 @@ func (b *CachingBeaconState) getPTCFromWindow(slot uint64) ([]uint64, error) {
 	}
 
 	ptcWindow := b.GetPtcWindow()
+	if ptcWindow == nil {
+		return nil, errors.New("GetPTCFromWindow: ptcWindow is nil")
+	}
 	if index >= uint64(ptcWindow.Length()) {
-		return nil, fmt.Errorf("getPTCFromWindow: index %d out of range (window size %d)", index, ptcWindow.Length())
+		return nil, fmt.Errorf("GetPTCFromWindow: index %d out of range (window size %d)", index, ptcWindow.Length())
 	}
 
 	vec := ptcWindow.Get(int(index))

--- a/cl/phase1/forkchoice/forkchoice.go
+++ b/cl/phase1/forkchoice/forkchoice.go
@@ -22,6 +22,8 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/erigontech/erigon/common/log/v3"
+
 	"github.com/erigontech/erigon/cl/beacon/beaconevents"
 	"github.com/erigontech/erigon/cl/beacon/synced_data"
 	"github.com/erigontech/erigon/cl/clparams"
@@ -58,9 +60,11 @@ type ForkNode struct {
 }
 
 const (
-	checkpointsPerCache = 1024
-	allowedCachedStates = 8
-	queueCacheSize      = 128
+	checkpointsPerCache        = 1024
+	allowedCachedStates        = 8
+	queueCacheSize             = 128
+	pendingELPayloadsShrinkCap = 256 // drain releases the backing array when cap exceeds this
+	maxPendingELPayloads       = 1024
 )
 
 type randaoDelta struct {
@@ -951,6 +955,11 @@ func (f *ForkChoiceStore) GetProposerLookahead(slot uint64) (solid.Uint64VectorS
 func (f *ForkChoiceStore) addPendingELPayload(block *cltypes.SignedBeaconBlock, envelope *cltypes.SignedExecutionPayloadEnvelope) {
 	f.pendingELPayloadsMu.Lock()
 	defer f.pendingELPayloadsMu.Unlock()
+	if len(f.pendingELPayloads) >= maxPendingELPayloads {
+		log.Warn("addPendingELPayload: dropping oldest pending EL payload", "queueLen", len(f.pendingELPayloads))
+		copy(f.pendingELPayloads, f.pendingELPayloads[1:])
+		f.pendingELPayloads = f.pendingELPayloads[:len(f.pendingELPayloads)-1]
+	}
 	f.pendingELPayloads = append(f.pendingELPayloads, PendingELPayload{
 		Block:    block,
 		Envelope: envelope,
@@ -962,7 +971,17 @@ func (f *ForkChoiceStore) addPendingELPayload(block *cltypes.SignedBeaconBlock, 
 func (f *ForkChoiceStore) DrainPendingELPayloads() []PendingELPayload {
 	f.pendingELPayloadsMu.Lock()
 	defer f.pendingELPayloadsMu.Unlock()
-	payloads := f.pendingELPayloads
-	f.pendingELPayloads = nil
-	return payloads
+	if len(f.pendingELPayloads) == 0 {
+		return nil
+	}
+	if cap(f.pendingELPayloads) > pendingELPayloadsShrinkCap {
+		result := f.pendingELPayloads
+		f.pendingELPayloads = nil
+		return result
+	}
+	result := make([]PendingELPayload, len(f.pendingELPayloads))
+	copy(result, f.pendingELPayloads)
+	clear(f.pendingELPayloads)
+	f.pendingELPayloads = f.pendingELPayloads[:0]
+	return result
 }

--- a/cl/phase1/forkchoice/forkchoice.go
+++ b/cl/phase1/forkchoice/forkchoice.go
@@ -958,6 +958,7 @@ func (f *ForkChoiceStore) addPendingELPayload(block *cltypes.SignedBeaconBlock, 
 	if len(f.pendingELPayloads) >= maxPendingELPayloads {
 		log.Warn("addPendingELPayload: dropping oldest pending EL payload", "queueLen", len(f.pendingELPayloads))
 		copy(f.pendingELPayloads, f.pendingELPayloads[1:])
+		f.pendingELPayloads[len(f.pendingELPayloads)-1] = PendingELPayload{}
 		f.pendingELPayloads = f.pendingELPayloads[:len(f.pendingELPayloads)-1]
 	}
 	f.pendingELPayloads = append(f.pendingELPayloads, PendingELPayload{

--- a/cl/phase1/forkchoice/payload_vote.go
+++ b/cl/phase1/forkchoice/payload_vote.go
@@ -84,34 +84,21 @@ func (f *ForkChoiceStore) notifyPtcMessages(
 			continue
 		}
 
-		for j, validatorIndex := range cached.ptc {
+		for j := range cached.ptc {
 			if payloadAttestation.AggregationBits.GetBitAt(j) {
-				f.applyPayloadAttestationVote(validatorIndex, data, blockRoot, cached.ptc)
+				f.applyPayloadAttestationVote(j, data, blockRoot)
 			}
 		}
 	}
 }
 
-// applyPayloadAttestationVote updates PTC vote tracking for a single validator.
-// Used by notifyPtcMessages with pre-computed PTC to avoid redundant GetState/GetPTC calls.
+// applyPayloadAttestationVote updates PTC vote tracking for a single PTC position.
+// ptcIndex is the position in the PTC (the aggregation bit index).
 func (f *ForkChoiceStore) applyPayloadAttestationVote(
-	validatorIndex uint64,
+	ptcIndex int,
 	data *cltypes.PayloadAttestationData,
 	blockRoot common.Hash,
-	ptc []uint64,
 ) {
-	// Find the validator's position in the PTC
-	ptcIndex := -1
-	for i, idx := range ptc {
-		if idx == validatorIndex {
-			ptcIndex = i
-			break
-		}
-	}
-	if ptcIndex == -1 {
-		return
-	}
-
 	// Atomically update PTC vote arrays under mutex to prevent concurrent
 	// Load→modify→Store from losing votes. See also OnPayloadAttestationMessage.
 	f.ptcVoteMu.Lock()

--- a/cl/phase1/forkchoice/payload_vote.go
+++ b/cl/phase1/forkchoice/payload_vote.go
@@ -72,8 +72,8 @@ func (f *ForkChoiceStore) notifyPtcMessages(
 			if data.Slot != blockState.Slot() {
 				continue
 			}
-			ptc, ok := readPTCFromWindow(blockState, data.Slot)
-			if !ok {
+			ptc, err := blockState.GetPTCFromWindow(data.Slot)
+			if err != nil {
 				continue
 			}
 			cached = &cachedPTC{ptc: ptc}
@@ -90,35 +90,6 @@ func (f *ForkChoiceStore) notifyPtcMessages(
 			}
 		}
 	}
-}
-
-func readPTCFromWindow(s *state.CachingBeaconState, slot uint64) ([]uint64, bool) {
-	cfg := s.BeaconConfig()
-	epoch := state.GetEpochAtSlot(cfg, slot)
-	stateEpoch := s.Slot() / cfg.SlotsPerEpoch
-	if epoch+1 < stateEpoch || epoch > stateEpoch+1 {
-		return nil, false
-	}
-
-	slotInEpoch := slot % cfg.SlotsPerEpoch
-	var index uint64
-	if stateEpoch > 0 && epoch == stateEpoch-1 {
-		index = slotInEpoch
-	} else {
-		index = (epoch-stateEpoch+1)*cfg.SlotsPerEpoch + slotInEpoch
-	}
-
-	ptcWindow := s.GetPtcWindow()
-	if ptcWindow == nil || index >= uint64(ptcWindow.Length()) {
-		return nil, false
-	}
-
-	vec := ptcWindow.Get(int(index))
-	ptc := make([]uint64, vec.Length())
-	for i := 0; i < vec.Length(); i++ {
-		ptc[i] = vec.Get(i)
-	}
-	return ptc, true
 }
 
 // applyPayloadAttestationVote updates PTC vote tracking for a single validator.

--- a/cl/phase1/forkchoice/payload_vote.go
+++ b/cl/phase1/forkchoice/payload_vote.go
@@ -48,11 +48,10 @@ func (f *ForkChoiceStore) notifyPtcMessages(
 		return
 	}
 
-	// Pre-compute state and PTC per unique blockRoot to avoid redundant GetState + GetPTC
-	// calls for every attesting validator (PtcSize can be 512).
+	// Pre-compute PTC per unique blockRoot to avoid redundant state lookups
+	// for every attesting validator (PtcSize can be 512).
 	type cachedPTC struct {
-		state *state.CachingBeaconState
-		ptc   []uint64
+		ptc []uint64
 	}
 	ptcCache := make(map[common.Hash]*cachedPTC)
 
@@ -66,32 +65,60 @@ func (f *ForkChoiceStore) notifyPtcMessages(
 
 		cached, ok := ptcCache[blockRoot]
 		if !ok {
-			blockState, err := f.forkGraph.GetState(blockRoot, true)
+			blockState, err := f.forkGraph.GetState(blockRoot, false)
 			if err != nil || blockState == nil {
-				continue
-			}
-			ptc, err := blockState.GetPTC(data.Slot)
-			if err != nil {
 				continue
 			}
 			if data.Slot != blockState.Slot() {
 				continue
 			}
-			cached = &cachedPTC{state: blockState, ptc: ptc}
+			ptc, ok := readPTCFromWindow(blockState, data.Slot)
+			if !ok {
+				continue
+			}
+			cached = &cachedPTC{ptc: ptc}
 			ptcCache[blockRoot] = cached
 		}
 
-		indexedPayloadAttestation, err := s.GetIndexedPayloadAttestation(payloadAttestation)
-		if err != nil {
+		if payloadAttestation.AggregationBits == nil {
 			continue
 		}
 
-		attestingIndices := indexedPayloadAttestation.AttestingIndices
-		for j := 0; j < attestingIndices.Length(); j++ {
-			idx := attestingIndices.Get(j)
-			f.applyPayloadAttestationVote(idx, data, blockRoot, cached.ptc)
+		for j, validatorIndex := range cached.ptc {
+			if payloadAttestation.AggregationBits.GetBitAt(j) {
+				f.applyPayloadAttestationVote(validatorIndex, data, blockRoot, cached.ptc)
+			}
 		}
 	}
+}
+
+func readPTCFromWindow(s *state.CachingBeaconState, slot uint64) ([]uint64, bool) {
+	cfg := s.BeaconConfig()
+	epoch := state.GetEpochAtSlot(cfg, slot)
+	stateEpoch := s.Slot() / cfg.SlotsPerEpoch
+	if epoch+1 < stateEpoch || epoch > stateEpoch+1 {
+		return nil, false
+	}
+
+	slotInEpoch := slot % cfg.SlotsPerEpoch
+	var index uint64
+	if stateEpoch > 0 && epoch == stateEpoch-1 {
+		index = slotInEpoch
+	} else {
+		index = (epoch-stateEpoch+1)*cfg.SlotsPerEpoch + slotInEpoch
+	}
+
+	ptcWindow := s.GetPtcWindow()
+	if ptcWindow == nil || index >= uint64(ptcWindow.Length()) {
+		return nil, false
+	}
+
+	vec := ptcWindow.Get(int(index))
+	ptc := make([]uint64, vec.Length())
+	for i := 0; i < vec.Length(); i++ {
+		ptc[i] = vec.Get(i)
+	}
+	return ptc, true
 }
 
 // applyPayloadAttestationVote updates PTC vote tracking for a single validator.

--- a/cl/phase1/forkchoice/payload_vote.go
+++ b/cl/phase1/forkchoice/payload_vote.go
@@ -66,7 +66,7 @@ func (f *ForkChoiceStore) notifyPtcMessages(
 
 		cached, ok := ptcCache[blockRoot]
 		if !ok {
-			blockState, err := f.forkGraph.GetState(blockRoot, false)
+			blockState, err := f.forkGraph.GetState(blockRoot, true)
 			if err != nil || blockState == nil {
 				continue
 			}

--- a/cl/phase1/forkchoice/payload_vote_test.go
+++ b/cl/phase1/forkchoice/payload_vote_test.go
@@ -1,0 +1,46 @@
+package forkchoice
+
+import (
+	"testing"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	state2 "github.com/erigontech/erigon/cl/phase1/core/state"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadPTCFromWindow(t *testing.T) {
+	cfg := &clparams.MainnetBeaconConfig
+	s := state2.New(cfg)
+	s.SetVersion(clparams.GloasVersion)
+
+	slotsPerEpoch := cfg.SlotsPerEpoch
+	slot := 2*slotsPerEpoch + 5
+	s.SetSlot(slot)
+
+	ptcWindow := solid.NewUint64VectorOfVectors(int(3*slotsPerEpoch), 4)
+	windowIndex := slotsPerEpoch + slot%slotsPerEpoch
+	vec := ptcWindow.Get(int(windowIndex))
+	for i := 0; i < vec.Length(); i++ {
+		vec.Set(i, uint64(10+i))
+	}
+	s.SetPtcWindow(ptcWindow)
+
+	ptc, ok := readPTCFromWindow(s, slot)
+	require.True(t, ok)
+	require.Equal(t, []uint64{10, 11, 12, 13}, ptc)
+
+	ptc[0] = 99
+	require.Equal(t, uint64(10), ptcWindow.Get(int(windowIndex)).Get(0))
+}
+
+func TestReadPTCFromWindowRejectsSlotOutsideWindow(t *testing.T) {
+	cfg := &clparams.MainnetBeaconConfig
+	s := state2.New(cfg)
+	s.SetVersion(clparams.GloasVersion)
+	s.SetSlot(2*cfg.SlotsPerEpoch + 5)
+	s.SetPtcWindow(solid.NewUint64VectorOfVectors(int(3*cfg.SlotsPerEpoch), 4))
+
+	_, ok := readPTCFromWindow(s, 0)
+	require.False(t, ok)
+}

--- a/cl/phase1/forkchoice/payload_vote_test.go
+++ b/cl/phase1/forkchoice/payload_vote_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestReadPTCFromWindow(t *testing.T) {
+func TestGetPTCFromWindow(t *testing.T) {
 	cfg := &clparams.MainnetBeaconConfig
 	s := state2.New(cfg)
 	s.SetVersion(clparams.GloasVersion)
@@ -26,21 +26,21 @@ func TestReadPTCFromWindow(t *testing.T) {
 	}
 	s.SetPtcWindow(ptcWindow)
 
-	ptc, ok := readPTCFromWindow(s, slot)
-	require.True(t, ok)
+	ptc, err := s.GetPTCFromWindow(slot)
+	require.NoError(t, err)
 	require.Equal(t, []uint64{10, 11, 12, 13}, ptc)
 
 	ptc[0] = 99
 	require.Equal(t, uint64(10), ptcWindow.Get(int(windowIndex)).Get(0))
 }
 
-func TestReadPTCFromWindowRejectsSlotOutsideWindow(t *testing.T) {
+func TestGetPTCFromWindowRejectsSlotOutsideWindow(t *testing.T) {
 	cfg := &clparams.MainnetBeaconConfig
 	s := state2.New(cfg)
 	s.SetVersion(clparams.GloasVersion)
 	s.SetSlot(2*cfg.SlotsPerEpoch + 5)
 	s.SetPtcWindow(solid.NewUint64VectorOfVectors(int(3*cfg.SlotsPerEpoch), 4))
 
-	_, ok := readPTCFromWindow(s, 0)
-	require.False(t, ok)
+	_, err := s.GetPTCFromWindow(0)
+	require.Error(t, err)
 }

--- a/cl/phase1/forkchoice/pending_el_payload_test.go
+++ b/cl/phase1/forkchoice/pending_el_payload_test.go
@@ -1,0 +1,35 @@
+package forkchoice
+
+import (
+	"testing"
+
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPendingELPayloadsDropOldestAtCap(t *testing.T) {
+	f := &ForkChoiceStore{}
+
+	for i := 0; i < maxPendingELPayloads+1; i++ {
+		f.addPendingELPayload(&cltypes.SignedBeaconBlock{
+			Block: &cltypes.BeaconBlock{Slot: uint64(i)},
+		}, nil)
+	}
+
+	payloads := f.DrainPendingELPayloads()
+	require.Len(t, payloads, maxPendingELPayloads)
+	require.Equal(t, uint64(1), payloads[0].Block.Block.Slot)
+	require.Equal(t, uint64(maxPendingELPayloads), payloads[len(payloads)-1].Block.Block.Slot)
+}
+
+func TestDrainPendingELPayloadsReleasesLargeBackingArray(t *testing.T) {
+	f := &ForkChoiceStore{}
+
+	for i := 0; i < pendingELPayloadsShrinkCap+1; i++ {
+		f.addPendingELPayload(&cltypes.SignedBeaconBlock{}, nil)
+	}
+
+	payloads := f.DrainPendingELPayloads()
+	require.Len(t, payloads, pendingELPayloadsShrinkCap+1)
+	require.Nil(t, f.pendingELPayloads)
+}

--- a/cl/phase1/forkchoice/utils.go
+++ b/cl/phase1/forkchoice/utils.go
@@ -96,6 +96,15 @@ func (f *ForkChoiceStore) onNewFinalized(newFinalized solid.Checkpoint) {
 		}
 		return true
 	})
+	// Clean up block timeliness entries for finalized blocks.
+	f.blockTimeliness.Range(func(k, v any) bool {
+		blockRoot := k.(common.Hash)
+		header, has := f.forkGraph.GetHeader(blockRoot)
+		if !has || header.Slot <= finalizedSlot {
+			f.blockTimeliness.Delete(k)
+		}
+		return true
+	})
 	// Clean up GLOAS-specific payload votes for finalized blocks.
 	// Note: envelope files are cleaned up in forkGraph.Prune().
 	if newFinalized.Epoch >= f.beaconCfg.GloasForkEpoch {

--- a/cl/phase1/network/gossip/score.go
+++ b/cl/phase1/network/gossip/score.go
@@ -3,7 +3,6 @@ package gossip
 import (
 	"fmt"
 	"math"
-	"strings"
 	"time"
 
 	"github.com/erigontech/erigon/cl/gossip"
@@ -63,24 +62,22 @@ const (
 
 func (g *GossipManager) topicScoreParams(topic string) *pubsub.TopicScoreParams {
 	switch {
-	case strings.Contains(topic, gossip.TopicNameBeaconBlock) || gossip.IsTopicBlobSidecar(topic):
+	case topic == gossip.TopicNameBeaconBlock || gossip.IsTopicBlobSidecar(topic):
 		return g.defaultBlockTopicParams()
-	// execution_payload_bid must be checked before execution_payload (substring match).
-	case strings.Contains(topic, gossip.TopicNameExecutionPayloadBid):
-		return g.defaultExecutionPayloadBidTopicParams()
-	case strings.Contains(topic, gossip.TopicNameExecutionPayload):
+	case topic == gossip.TopicNameExecutionPayload:
 		return g.defaultExecutionPayloadTopicParams()
-	case strings.Contains(topic, gossip.TopicNamePayloadAttestation):
+	case topic == gossip.TopicNameExecutionPayloadBid:
+		return g.defaultExecutionPayloadBidTopicParams()
+	case topic == gossip.TopicNamePayloadAttestation:
 		return g.defaultPayloadAttestationTopicParams()
-	case strings.Contains(topic, gossip.TopicNameProposerPreferences):
+	case topic == gossip.TopicNameProposerPreferences:
 		return g.defaultProposerPreferencesTopicParams()
-	case strings.Contains(topic, gossip.TopicNameVoluntaryExit):
+	case topic == gossip.TopicNameVoluntaryExit:
 		return g.defaultVoluntaryExitTopicParams()
 	case gossip.IsTopicBeaconAttestation(topic):
 		return g.defaultAggregateSubnetTopicParams()
 	case gossip.IsTopicSyncCommittee(topic):
 		return g.defaultSyncSubnetTopicParams(g.activeIndicies)
-
 	default:
 		return nil
 	}

--- a/cl/phase1/network/gossip/score_test.go
+++ b/cl/phase1/network/gossip/score_test.go
@@ -1,0 +1,23 @@
+package gossip
+
+import (
+	"testing"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	gossipnames "github.com/erigontech/erigon/cl/gossip"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTopicScoreParamsExactTopicMatching(t *testing.T) {
+	g := &GossipManager{
+		beaconConfig: &clparams.BeaconChainConfig{
+			SlotsPerEpoch:  32,
+			SecondsPerSlot: 12,
+		},
+	}
+
+	require.Equal(t, executionPayloadWeight, g.topicScoreParams(gossipnames.TopicNameExecutionPayload).TopicWeight)
+	require.Equal(t, executionPayloadBidWeight, g.topicScoreParams(gossipnames.TopicNameExecutionPayloadBid).TopicWeight)
+	require.Nil(t, g.topicScoreParams(gossipnames.TopicNameExecutionPayload+"_extra"))
+	require.Nil(t, g.topicScoreParams(gossipnames.TopicNameBeaconBlock+"_extra"))
+}

--- a/cl/transition/impl/eth2/operations.go
+++ b/cl/transition/impl/eth2/operations.go
@@ -513,6 +513,9 @@ func updateNextWithdrawalBuilderIndex(s abstract.BeaconState, processedBuildersS
 // [New in Gloas:EIP7732]
 func (I *impl) ProcessExecutionPayloadBid(s abstract.BeaconState, block cltypes.GenericBeaconBlock) error {
 	signedBid := block.GetBody().GetSignedExecutionPayloadBid()
+	if signedBid == nil || signedBid.Message == nil {
+		return errors.New("processExecutionPayloadBid: signed bid or bid message is nil")
+	}
 	bid := signedBid.Message
 	builderIndex := bid.BuilderIndex
 	amount := bid.Value
@@ -727,6 +730,9 @@ func (I *impl) ProcessParentExecutionPayload(s abstract.BeaconState, block cltyp
 // [New in Gloas:EIP7732]
 func verifyExecutionPayloadBidSignature(s abstract.BeaconState, signedBid *cltypes.SignedExecutionPayloadBid) (bool, error) {
 	builders := s.GetBuilders()
+	if builders == nil || signedBid.Message.BuilderIndex >= uint64(builders.Len()) {
+		return false, fmt.Errorf("builder index %d out of range", signedBid.Message.BuilderIndex)
+	}
 	builder := builders.Get(int(signedBid.Message.BuilderIndex))
 
 	domain, err := s.GetDomain(s.BeaconConfig().DomainBeaconBuilder, state.Epoch(s))

--- a/cl/transition/impl/eth2/operations.go
+++ b/cl/transition/impl/eth2/operations.go
@@ -752,8 +752,14 @@ func verifyExecutionPayloadBidSignature(s abstract.BeaconState, signedBid *cltyp
 // ProcessExecutionPayloadEnvelope processes the execution payload envelope for the Gloas fork.
 // [New in Gloas:EIP7732]
 func (I *impl) ProcessExecutionPayloadEnvelope(s abstract.BeaconState, signedEnvelope *cltypes.SignedExecutionPayloadEnvelope) error {
+	if signedEnvelope == nil || signedEnvelope.Message == nil {
+		return errors.New("ProcessExecutionPayloadEnvelope: signed envelope or envelope message is nil")
+	}
 	envelope := signedEnvelope.Message
 	payload := envelope.Payload
+	if payload == nil {
+		return errors.New("ProcessExecutionPayloadEnvelope: envelope has nil payload")
+	}
 
 	// Verify signature
 	if I.FullValidation {
@@ -807,6 +813,9 @@ func (I *impl) ProcessExecutionPayloadEnvelope(s abstract.BeaconState, signedEnv
 
 	// Verify consistency with the committed bid
 	committedBid := s.GetLatestExecutionPayloadBid()
+	if committedBid == nil {
+		return errors.New("ProcessExecutionPayloadEnvelope: state has no latest execution payload bid")
+	}
 	if envelope.BuilderIndex != committedBid.BuilderIndex {
 		return fmt.Errorf("ProcessExecutionPayloadEnvelope: builder_index %d != committed bid builder_index %d", envelope.BuilderIndex, committedBid.BuilderIndex)
 	}
@@ -848,7 +857,13 @@ func (I *impl) ProcessExecutionPayloadEnvelope(s abstract.BeaconState, signedEnv
 
 	// Verify consistency with expected withdrawals
 	payloadWithdrawals := payload.Withdrawals
+	if payloadWithdrawals == nil {
+		return errors.New("ProcessExecutionPayloadEnvelope: payload has nil withdrawals")
+	}
 	expectedWithdrawals := s.GetPayloadExpectedWithdrawals()
+	if expectedWithdrawals == nil {
+		return errors.New("ProcessExecutionPayloadEnvelope: state has nil expected withdrawals")
+	}
 	payloadWithdrawalsRoot, err := payloadWithdrawals.HashSSZ()
 	if err != nil {
 		return fmt.Errorf("ProcessExecutionPayloadEnvelope: failed to hash payload withdrawals: %w", err)

--- a/cl/transition/impl/eth2/operations_gloas_test.go
+++ b/cl/transition/impl/eth2/operations_gloas_test.go
@@ -1,0 +1,22 @@
+package eth2_test
+
+import (
+	"testing"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/phase1/core/state"
+	"github.com/erigontech/erigon/cl/transition/impl/eth2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessExecutionPayloadEnvelopeRejectsNilEnvelope(t *testing.T) {
+	s := state.New(&clparams.MainnetBeaconConfig)
+	machine := &eth2.Impl{}
+
+	require.Error(t, machine.ProcessExecutionPayloadEnvelope(s, nil))
+	require.Error(t, machine.ProcessExecutionPayloadEnvelope(s, &cltypes.SignedExecutionPayloadEnvelope{}))
+	require.Error(t, machine.ProcessExecutionPayloadEnvelope(s, &cltypes.SignedExecutionPayloadEnvelope{
+		Message: &cltypes.ExecutionPayloadEnvelope{},
+	}))
+}


### PR DESCRIPTION
## Summary

- **Fix PTC consistency bug in `notifyPtcMessages`**: old code used two different states (`s` vs `blockState`) for PTC computation, causing validators to be mapped to wrong PTC positions. Now uses `blockState.GetPTCFromWindow` consistently and iterates aggregation bits directly, eliminating the intermediate `GetIndexedPayloadAttestation` allocation and sort.
- **Fix `ExecutionPayloadEnvelope.Clone()` shallow copy**: old Clone shared `Payload` and `ExecutionRequests` pointers (aliasing). Now deep-copies via SSZ roundtrip. Also fixes `NewExecutionPayloadEnvelope` to use `GloasVersion` instead of `BellatrixVersion`.
- **Add nil-panic guards** in `ProcessExecutionPayloadBid`, `verifyExecutionPayloadBidSignature`, and `ProcessExecutionPayloadEnvelope` for malformed SSZ inputs.
- **Cap `pendingELPayloads` at 1024** to prevent unbounded growth; `DrainPendingELPayloads` now reuses backing array when small, releases to GC when large.
- **Clean up `blockTimeliness` sync.Map** in `onNewFinalized` (was growing without bound).
- **Switch gossip topic scoring from `strings.Contains` to exact `==` match**, removing fragile ordering dependency between `execution_payload` and `execution_payload_bid`.

No pre-GLOAS behavior changes — all fixes are in GLOAS-specific code paths or produce identical results for pre-GLOAS topics.

## Test plan

- [x] `TestSignedExecutionPayloadEnvelopeCloneNilMessage` — nil Message Clone
- [x] `TestGetPTCFromWindow` / `TestGetPTCFromWindowRejectsSlotOutsideWindow` — PTC window accessor
- [x] `TestPendingELPayloadsDropOldestAtCap` / `TestDrainPendingELPayloadsReleasesLargeBackingArray` — cap limit and drain
- [x] `TestTopicScoreParamsExactTopicMatching` — exact topic match, rejects suffixed names
- [x] `TestProcessExecutionPayloadEnvelopeRejectsNilEnvelope` — nil envelope rejection
- [ ] `make lint` passes
- [ ] Existing CL tests pass (`make test-short`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)