### PR TITLE
rawdb: ignore invalid receipt cache transaction indexes

### DIFF
--- a/db/rawdb/accessors_chain.go
+++ b/db/rawdb/accessors_chain.go
@@ -1298,6 +1298,7 @@ func ReadReceiptCacheV2(tx kv.TemporalTx, query RCacheV2Query) (*types.Receipt, 
 func ReadReceiptsCacheV2(tx kv.TemporalTx, block *types.Block, txNumReader rawdbv3.TxNumsReader) (res types.Receipts, err error) {
 	blockHash := block.Hash()
 	blockNum := block.NumberU64()
+	transactions := block.Transactions()
 
 	minTxNum, err := txNumReader.Min(context.Background(), tx, blockNum)
 	if err != nil {
@@ -1326,14 +1327,19 @@ func ReadReceiptsCacheV2(tx kv.TemporalTx, block *types.Block, txNumReader rawdb
 			return nil, fmt.Errorf("ReadReceiptsCacheV2: deserialize %d, len(v)=%d, %w", blockNum, len(v), err)
 		}
 		x := (*types.Receipt)(receipt)
-		transactions := block.Transactions()
 		txnIdx := int(receipt.TransactionIndex)
-		if txnIdx < 0 || txnIdx >= len(transactions) {
-			return nil, fmt.Errorf("ReadReceiptsCacheV2: out of range txnIdx=%d, len(transactions)=%d", txnIdx, len(transactions))
+		if txnIdx < 0 || txnIdx != len(res) || txnIdx >= len(transactions) {
+			// RCacheV2 entries are ordered by txNum. If the stored transaction
+			// index does not match that order, this block must be derived instead.
+			return nil, nil
 		}
 		txn := transactions[txnIdx]
 		x.DeriveFieldsV4ForCachedReceipt(blockHash, blockNum, txn.Hash(), true)
 		res = append(res, x)
+	}
+	if len(res) != len(transactions) {
+		// Block receipt RPCs require the full ordered receipt set.
+		return nil, nil
 	}
 	return res, nil
 }

--- a/db/rawdb/accessors_chain.go
+++ b/db/rawdb/accessors_chain.go
@@ -1309,6 +1309,7 @@ func ReadReceiptsCacheV2(tx kv.TemporalTx, block *types.Block, txNumReader rawdb
 		return
 	}
 
+	receiptIdx := 0
 	for txNum := minTxNum; txNum < maxTxNum+1; txNum++ {
 		v, ok, err := tx.HistorySeek(kv.RCacheDomain, receiptCacheKey, txNum+1)
 		if err != nil {
@@ -1328,16 +1329,17 @@ func ReadReceiptsCacheV2(tx kv.TemporalTx, block *types.Block, txNumReader rawdb
 		}
 		x := (*types.Receipt)(receipt)
 		txnIdx := int(receipt.TransactionIndex)
-		if txnIdx < 0 || txnIdx != len(res) || txnIdx >= len(transactions) {
-			// RCacheV2 entries are ordered by txNum. If the stored transaction
-			// index does not match that order, this block must be derived instead.
+		if txnIdx < 0 || txnIdx != receiptIdx || txnIdx >= len(transactions) {
+			// RCacheV2 is read in txNum order. The stored transaction index must
+			// match the next receipt position, otherwise derive the block instead.
 			return nil, nil
 		}
 		txn := transactions[txnIdx]
 		x.DeriveFieldsV4ForCachedReceipt(blockHash, blockNum, txn.Hash(), true)
 		res = append(res, x)
+		receiptIdx++
 	}
-	if len(res) != len(transactions) {
+	if receiptIdx != len(transactions) {
 		// Block receipt RPCs require the full ordered receipt set.
 		return nil, nil
 	}

--- a/db/rawdb/accessors_chain_test.go
+++ b/db/rawdb/accessors_chain_test.go
@@ -43,6 +43,19 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
+func newTestLegacyTx(nonce uint64, to common.Address, value uint256.Int, gasLimit uint64, gasPrice uint256.Int) *types.LegacyTx {
+	toAddr := to
+	return &types.LegacyTx{
+		CommonTx: types.CommonTx{
+			Nonce:    nonce,
+			To:       &toAddr,
+			Value:    value,
+			GasLimit: gasLimit,
+		},
+		GasPrice: gasPrice,
+	}
+}
+
 func TestWriteRawTransactions(t *testing.T) {
 	_, tx := memdb.NewTestTx(t)
 	defer tx.Rollback()
@@ -771,8 +784,8 @@ func TestBlockReceiptStorage(t *testing.T) {
 	ctx := m.Ctx
 
 	// Create a live block since we need metadata to reconstruct the receipt
-	tx1 := types.NewTransaction(1, common.HexToAddress("0x1"), &u256.Num1, 1, &u256.Num1, nil)
-	tx2 := types.NewTransaction(2, common.HexToAddress("0x2"), &u256.Num2, 2, &u256.Num2, nil)
+	tx1 := newTestLegacyTx(1, common.HexToAddress("0x1"), u256.Num1, 1, u256.Num1)
+	tx2 := newTestLegacyTx(2, common.HexToAddress("0x2"), u256.Num2, 2, u256.Num2)
 
 	header := &types.Header{Number: *common.Num1}
 	body := &types.Body{Transactions: types.Transactions{tx1, tx2}}
@@ -865,6 +878,108 @@ func TestBlockReceiptStorage(t *testing.T) {
 	b, _, err = br.BlockWithSenders(ctx, tx, hash, 1)
 	require.NoError(err)
 	require.NotNil(b)
+}
+
+func TestReadReceiptsCacheV2CacheMissOnInvalidTransactionIndex(t *testing.T) {
+	t.Parallel()
+	m := execmoduletester.New(t, execmoduletester.WithEnableDomain(kv.RCacheDomain))
+	tx, err := m.DB.BeginTemporalRw(m.Ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+	br := m.BlockReader
+	txNumReader := br.TxnumReader()
+	ctx := m.Ctx
+
+	tx1 := newTestLegacyTx(1, common.HexToAddress("0x1"), u256.Num1, 1, u256.Num1)
+	tx2 := newTestLegacyTx(2, common.HexToAddress("0x2"), u256.Num2, 2, u256.Num2)
+
+	header := &types.Header{Number: *common.Num1}
+	hash := header.Hash()
+	body := &types.Body{Transactions: types.Transactions{tx1, tx2}}
+	require.NoError(t, rawdb.WriteCanonicalHash(tx, hash, header.Number.Uint64()))
+	require.NoError(t, rawdb.WriteHeader(tx, header))
+	require.NoError(t, rawdb.WriteBody(tx, hash, 1, body))
+	require.NoError(t, rawdb.WriteSenders(tx, hash, 1, body.SendersFromTxs()))
+
+	badReceipt := &types.Receipt{
+		Status:            types.ReceiptStatusSuccessful,
+		CumulativeGasUsed: 1,
+		GasUsed:           1,
+		BlockNumber:       &header.Number,
+		BlockHash:         hash,
+		TransactionIndex:  3_468_750_000,
+	}
+
+	blockNum := header.Number.Uint64()
+	sd, err := execctx.NewSharedDomains(t.Context(), tx, log.New())
+	require.NoError(t, err)
+	defer sd.Close()
+	base, err := txNumReader.Min(t.Context(), tx, blockNum)
+	require.NoError(t, err)
+	require.NoError(t, rawdb.WriteReceiptCacheV2(sd.AsPutDel(tx), nil, base))
+	require.NoError(t, rawdb.WriteReceiptCacheV2(sd.AsPutDel(tx), badReceipt, base+1))
+	require.NoError(t, rawdb.WriteReceiptCacheV2(sd.AsPutDel(tx), nil, base+2))
+	_, err = sd.ComputeCommitment(ctx, tx, true, blockNum, base+2, "flush-commitment", nil)
+	require.NoError(t, err)
+	require.NoError(t, sd.Flush(ctx, tx))
+
+	b, _, err := br.BlockWithSenders(ctx, tx, hash, 1)
+	require.NoError(t, err)
+	require.NotNil(t, b)
+	rs, err := rawdb.ReadReceiptsCacheV2(tx, b, txNumReader)
+	require.NoError(t, err)
+	require.Empty(t, rs)
+}
+
+func TestReadReceiptsCacheV2CacheMissOnNonSequentialTransactionIndex(t *testing.T) {
+	t.Parallel()
+	m := execmoduletester.New(t, execmoduletester.WithEnableDomain(kv.RCacheDomain))
+	tx, err := m.DB.BeginTemporalRw(m.Ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+	br := m.BlockReader
+	txNumReader := br.TxnumReader()
+	ctx := m.Ctx
+
+	tx1 := newTestLegacyTx(1, common.HexToAddress("0x1"), u256.Num1, 1, u256.Num1)
+	tx2 := newTestLegacyTx(2, common.HexToAddress("0x2"), u256.Num2, 2, u256.Num2)
+
+	header := &types.Header{Number: *common.Num1}
+	hash := header.Hash()
+	body := &types.Body{Transactions: types.Transactions{tx1, tx2}}
+	require.NoError(t, rawdb.WriteCanonicalHash(tx, hash, header.Number.Uint64()))
+	require.NoError(t, rawdb.WriteHeader(tx, header))
+	require.NoError(t, rawdb.WriteBody(tx, hash, 1, body))
+	require.NoError(t, rawdb.WriteSenders(tx, hash, 1, body.SendersFromTxs()))
+
+	receipt1 := &types.Receipt{
+		Status:            types.ReceiptStatusSuccessful,
+		CumulativeGasUsed: 1,
+		GasUsed:           1,
+		BlockNumber:       &header.Number,
+		BlockHash:         hash,
+		TransactionIndex:  1,
+	}
+
+	blockNum := header.Number.Uint64()
+	sd, err := execctx.NewSharedDomains(t.Context(), tx, log.New())
+	require.NoError(t, err)
+	defer sd.Close()
+	base, err := txNumReader.Min(t.Context(), tx, blockNum)
+	require.NoError(t, err)
+	require.NoError(t, rawdb.WriteReceiptCacheV2(sd.AsPutDel(tx), nil, base))
+	require.NoError(t, rawdb.WriteReceiptCacheV2(sd.AsPutDel(tx), receipt1, base+1))
+	require.NoError(t, rawdb.WriteReceiptCacheV2(sd.AsPutDel(tx), nil, base+2))
+	_, err = sd.ComputeCommitment(ctx, tx, true, blockNum, base+2, "flush-commitment", nil)
+	require.NoError(t, err)
+	require.NoError(t, sd.Flush(ctx, tx))
+
+	b, _, err := br.BlockWithSenders(ctx, tx, hash, 1)
+	require.NoError(t, err)
+	require.NotNil(t, b)
+	rs, err := rawdb.ReadReceiptsCacheV2(tx, b, txNumReader)
+	require.NoError(t, err)
+	require.Empty(t, rs)
 }
 
 // Tests block storage and retrieval operations with withdrawals.

--- a/db/rawdb/accessors_chain_test.go
+++ b/db/rawdb/accessors_chain_test.go
@@ -880,7 +880,7 @@ func TestBlockReceiptStorage(t *testing.T) {
 	require.NotNil(b)
 }
 
-func TestReadReceiptsCacheV2CacheMissOnInvalidTransactionIndex(t *testing.T) {
+func TestReadReceiptsCacheV2BadTxIndex(t *testing.T) {
 	t.Parallel()
 	m := execmoduletester.New(t, execmoduletester.WithEnableDomain(kv.RCacheDomain))
 	tx, err := m.DB.BeginTemporalRw(m.Ctx)
@@ -931,7 +931,7 @@ func TestReadReceiptsCacheV2CacheMissOnInvalidTransactionIndex(t *testing.T) {
 	require.Empty(t, rs)
 }
 
-func TestReadReceiptsCacheV2CacheMissOnNonSequentialTransactionIndex(t *testing.T) {
+func TestReadReceiptsCacheV2UnorderedTxIndex(t *testing.T) {
 	t.Parallel()
 	m := execmoduletester.New(t, execmoduletester.WithEnableDomain(kv.RCacheDomain))
 	tx, err := m.DB.BeginTemporalRw(m.Ctx)


### PR DESCRIPTION
### Issue 
This PR fixes an `eth_getBlockReceipts` failure when the persisted receipt cache contains invalid transaction-index metadata for a block.

`ReadReceiptsCacheV2` reads block receipts from `RCacheV2` by walking the block’s txNum range and decoding each cached receipt. The decoded receipt metadata includes `TransactionIndex`, which is then used to pick the corresponding transaction from `block.Transactions()` before deriving RPC fields such as transaction hash, block hash, log indexes, and bloom.

Before this change, an invalid cached `TransactionIndex` was treated as a hard error. For example, block `24,952,410` has `543` transactions, but the cached receipt path could decode a receipt with `TransactionIndex = 3,468,750,000`
. That index can never be valid for the block, so ReadReceiptsCacheV2 returned:

```
ReadReceiptsCacheV2: out of range txnIdx=3468750000, len(transactions)=543
```
That error then propagated to `eth_getBlockReceipts`, even though the receipt cache is only an acceleration path and receipts can still be derived from canonical block/state data.

For production users, this matters because corrupted, stale, or otherwise inconsistent receipt-cache metadata should not make block receipt RPCs fail when Erigon can regenerate the correct receipts.

### Fix

This change makes block-level `RCacheV2` reads validate the cached receipt set before using it.

`ReadReceiptsCacheV2` now checks that cached receipts match the block transaction order. Since cache entries are read in txNum order, each decoded receipt must have a `TransactionIndex` equal to the next expected receipt position and must be within the block transaction list.

If a cached receipt has an impossible or non-sequential transaction index, the cache read is treated as a cache miss. The caller can then fall back to deriving receipts instead of returning an internal cache error to the RPC client.

The reader also checks that the cache produced a complete receipt set for the block. Partial cache contents are not enough for block receipt RPCs, which require the full ordered receipt list.

The fix is intentionally small and keeps the cache semantics clear: valid cache data is used as before, while invalid or incomplete cache data is ignored and regenerated from canonical data.

### Tests
This PR adds focused coverage for the `ReadReceiptsCacheV2` block receipt cache path.

`TestReadReceiptsCacheV2BadTxIndex` writes a cached receipt with the reported invalid transaction index, `3,468,750,000`, for a block with two transactions. It verifies that the cache reader returns a cache miss instead of surfacing an out-of-range error.

`TestReadReceiptsCacheV2UnorderedTxIndex` writes a cached receipt whose transaction index is in range but does not match the txNum order. This covers stale or inconsistent cache metadata that would otherwise attach a receipt to the wrong transaction.

The existing `TestBlockReceiptStorage` coverage continues to verify that a valid ordered receipt cache is still read successfully.

Closes: https://github.com/erigontech/erigon/issues/21194