### PR TITLE
p2p/protocols/eth: refresh eth/71 doc comments for post-#11553 sentinel split

### DIFF
--- a/p2p/protocols/eth/protocol.go
+++ b/p2p/protocols/eth/protocol.go
@@ -408,12 +408,16 @@ type GetBlockAccessListsPacket66 struct {
 // of a types.BlockAccessList per EIP-7928, passed through as RawValue since
 // rawdb stores it in that exact form.
 //
-// An empty RLP list (0xc0) in slot i has two possible meanings and MUST be
-// disambiguated by the caller via the corresponding header's
-// BlockAccessListHash:
-//   - "peer does not have this BAL" — hash will not match the header
-//   - "block has a genuinely empty BAL" — hash will equal the empty-list hash
-//     (see common/empty.BlockAccessListHash)
+// EIP-8159 (post ethereum/EIPs#11553) defines three wire-distinguishable
+// entry shapes:
+//   - 0x80 (RLP empty string) — "peer does not have this BAL". The caller
+//     should treat the slot as missing and may retry from another peer.
+//   - 0xc0 (RLP empty list) — "block has a genuinely empty BAL". Valid only
+//     when the corresponding header's BlockAccessListHash equals the
+//     empty-BAL hash (see common/empty.BlockAccessListHash); otherwise the
+//     peer is misbehaving.
+//   - any other payload — actual BAL bytes whose keccak256 MUST match the
+//     header's BlockAccessListHash.
 type BlockAccessListsPacket []rlp.RawValue
 
 // BlockAccessListsPacket66 wraps BlockAccessListsPacket in the eth/66

--- a/p2p/protocols/eth/protocol_test.go
+++ b/p2p/protocols/eth/protocol_test.go
@@ -242,9 +242,9 @@ func TestEth66Messages(t *testing.T) {
 
 // TestBlockAccessListsPacket66RoundTrip verifies the eth/71 (EIP-8159) BAL
 // exchange packet types encode and decode losslessly at every cardinality that
-// matters in production: nil, empty list, single RLP-empty-list ("not available"
-// or "genuinely empty BAL"), and a multi-entry response with heterogeneous
-// payloads.
+// matters in production: nil, empty list, single RLP-empty-list (the
+// "genuinely empty BAL" sentinel under the post-#11553 spec), and a multi-entry
+// response with heterogeneous payloads.
 func TestBlockAccessListsPacket66RoundTrip(t *testing.T) {
 	const reqID uint64 = 0x12345678
 
@@ -260,7 +260,7 @@ func TestBlockAccessListsPacket66RoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("encode stub BAL: %v", err)
 	}
-	emptyRLPList := common.FromHex("c0") // EIP-8159: empty list = "not available" OR "genuinely empty"
+	emptyRLPList := common.FromHex("c0") // EIP-8159 (post-#11553): 0xc0 = "genuinely empty BAL" (0x80 = "not available")
 
 	t.Run("GetBlockAccessLists", func(t *testing.T) {
 		cases := [][]common.Hash{
@@ -297,9 +297,9 @@ func TestBlockAccessListsPacket66RoundTrip(t *testing.T) {
 		cases := [][]rlp.RawValue{
 			nil,
 			{},
-			{emptyRLPList},           // single "not available / empty" entry
+			{emptyRLPList},           // single "genuinely empty BAL" entry
 			{bal},                    // single populated BAL
-			{bal, emptyRLPList, bal}, // mixed — some available, one not
+			{bal, emptyRLPList, bal}, // mixed — populated and genuinely-empty BALs
 		}
 		for i, bals := range cases {
 			msg := BlockAccessListsPacket66{RequestId: reqID, BlockAccessListsPacket: bals}

--- a/p2p/protocols/eth/protocol_test.go
+++ b/p2p/protocols/eth/protocol_test.go
@@ -241,10 +241,10 @@ func TestEth66Messages(t *testing.T) {
 }
 
 // TestBlockAccessListsPacket66RoundTrip verifies the eth/71 (EIP-8159) BAL
-// exchange packet types encode and decode losslessly at every cardinality that
-// matters in production: nil, empty list, single RLP-empty-list (the
-// "genuinely empty BAL" sentinel under the post-#11553 spec), and a multi-entry
-// response with heterogeneous payloads.
+// exchange packet types encode and decode losslessly across the entry shapes
+// covered here: nil, empty list, the "genuinely empty BAL" sentinel (0xc0,
+// per post-#11553 spec), populated BAL bytes, and a multi-entry mix. The
+// "not available" sentinel (0x80) is not exercised by this test.
 func TestBlockAccessListsPacket66RoundTrip(t *testing.T) {
 	const reqID uint64 = 0x12345678
 


### PR DESCRIPTION
## Summary

- EIP-8159 ([ethereum/EIPs#11553](https://github.com/ethereum/EIPs/pull/11553), merged 2026-04-21) split the BAL response "not available" and "genuinely empty BAL" sentinels onto distinct wire values: `0x80` (RLP empty string) for unavailable, `0xc0` (RLP empty list) for an empty BAL. They no longer need header-hash disambiguation.
- The server handler (`AnswerGetBlockAccessListsQuery`) and the BAL fetcher (`bal_fetcher.go`) were already updated to that semantics in #20794 / #20795, but the `BlockAccessListsPacket` docstring in `protocol.go` and the round-trip test in `protocol_test.go` still described the old ambiguous-0xc0 behaviour.
- This PR aligns those comments and test-case labels with the current spec. No behavioural change — comments only.

## Test plan

- [x] `make lint` clean
- [x] Existing `TestBlockAccessListsPacket66RoundTrip` still passes (encoding/decoding paths untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)