### PR TITLE
ci: scope DockerHub publish creds to a GitHub Environment

### DIFF
--- a/.github/workflows/ci-cd-main-branch-docker-images.yml
+++ b/.github/workflows/ci-cd-main-branch-docker-images.yml
@@ -93,8 +93,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  ## v4.0.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_PUSH_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PUSH_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -150,8 +150,8 @@ jobs:
           HTTP_RESP=$(curl -s -o ./resp1 -w "%{http_code}" \
             -X POST -H "Content-Type: application/json" \
             -d '{
-                  "identifier": "'"${{ secrets.DOCKERHUB_USERNAME }}"'",
-                  "secret": "'"${{ secrets.DOCKERHUB_TOKEN }}"'"
+                  "identifier": "'"${{ secrets.DOCKERHUB_PUSH_USERNAME }}"'",
+                  "secret": "'"${{ secrets.DOCKERHUB_PUSH_TOKEN }}"'"
                 }' \
             https://hub.docker.com/v2/auth/token/)
 

--- a/.github/workflows/ci-cd-main-branch-docker-images.yml
+++ b/.github/workflows/ci-cd-main-branch-docker-images.yml
@@ -28,6 +28,7 @@ jobs:
   Build:
     # runs-on: ubuntu-latest
     runs-on: [devops-01-self-hosted]
+    environment: dockerhub-publish
     timeout-minutes: 45
     outputs:
       docker_build_tag: ${{ steps.built_tag_export.outputs.docker_build_tag }}
@@ -92,8 +93,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  ## v4.0.0
         with:
-          username: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_USERNAME }}
-          password: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -149,8 +150,8 @@ jobs:
           HTTP_RESP=$(curl -s -o ./resp1 -w "%{http_code}" \
             -X POST -H "Content-Type: application/json" \
             -d '{
-                  "identifier": "'"${{ secrets.ORG_DOCKERHUB_ERIGONTECH_USERNAME }}"'",
-                  "secret": "'"${{ secrets.ORG_DOCKERHUB_ERIGONTECH_TOKEN }}"'"
+                  "identifier": "'"${{ secrets.DOCKERHUB_USERNAME }}"'",
+                  "secret": "'"${{ secrets.DOCKERHUB_TOKEN }}"'"
                 }' \
             https://hub.docker.com/v2/auth/token/)
 

--- a/.github/workflows/docker-image-remove.yml
+++ b/.github/workflows/docker-image-remove.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Run API Call
         env:
-          TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          TOKEN: ${{ secrets.DOCKERHUB_PUSH_TOKEN }}
           DOCKER_IMAGE_TAG: ${{ inputs.docker_image_tag }}
         run: |
           output_code=$(curl --write-out %{http_code} --output curl-output.log \

--- a/.github/workflows/docker-image-remove.yml
+++ b/.github/workflows/docker-image-remove.yml
@@ -21,6 +21,7 @@ jobs:
 
   build-release:
     runs-on: ubuntu-latest
+    environment: dockerhub-publish
     timeout-minutes: 15
     name: Remove docker image
 
@@ -28,7 +29,7 @@ jobs:
 
       - name: Run API Call
         env:
-          TOKEN: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_TOKEN }}
+          TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
           DOCKER_IMAGE_TAG: ${{ inputs.docker_image_tag }}
         run: |
           output_code=$(curl --write-out %{http_code} --output curl-output.log \

--- a/.github/workflows/qa-txpool-performance-test.yml
+++ b/.github/workflows/qa-txpool-performance-test.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_USERNAME }}
-          password: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_PULL_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
 
       - name: Docker build current branch
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,8 +198,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  ## v4.0.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_PUSH_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PUSH_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  ## v4.0.0
@@ -569,8 +569,8 @@ jobs:
     - name: Login to Docker Hub
       uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  ## v4.0.0
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        username: ${{ secrets.DOCKERHUB_PUSH_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PUSH_TOKEN }}
 
     - name: Push multi-platform docker images (${{ env.BUILD_VERSION }}${{ inputs.publish_latest_tag == true && ' and latest tag'}}) in case perform_release is true
       if: ${{ inputs.perform_release }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
       contents: read  # github.token used in curl to check existing GitHub release
     #runs-on: ubuntu-latest
     runs-on: [devops-01-self-hosted]
+    environment: dockerhub-publish
     timeout-minutes: 60
     name: Build and publish Release Artifacts
     outputs:
@@ -197,8 +198,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  ## v4.0.0
         with:
-          username: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_USERNAME }}
-          password: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  ## v4.0.0
@@ -551,6 +552,7 @@ jobs:
       contains(needs.build-release.result, 'success') &&
       !contains(needs.test-release.result, 'failure')
     runs-on: ubuntu-latest
+    environment: dockerhub-publish
     timeout-minutes: 30
     name: Docker image
 
@@ -567,8 +569,8 @@ jobs:
     - name: Login to Docker Hub
       uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  ## v4.0.0
       with:
-        username: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_USERNAME }}
-        password: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_TOKEN }}
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Push multi-platform docker images (${{ env.BUILD_VERSION }}${{ inputs.publish_latest_tag == true && ' and latest tag'}}) in case perform_release is true
       if: ${{ inputs.perform_release }}

--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -121,8 +121,8 @@ jobs:
         continue-on-error: true
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_USERNAME }}
-          password: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_PULL_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
 
       - name: Setup go env and cache
         uses: actions/setup-go@v6

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -86,8 +86,8 @@ jobs:
         continue-on-error: true
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_USERNAME }}
-          password: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_PULL_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
 
       # Targeting the clients/erigon/Dockerfile.git in the Hive directory -
       # this builds the container from github and uses it for tests

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -72,8 +72,8 @@ jobs:
         continue-on-error: true
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_USERNAME }}
-          password: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_PULL_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/test-kurtosis-gloas.yml
+++ b/.github/workflows/test-kurtosis-gloas.yml
@@ -60,8 +60,8 @@ jobs:
         continue-on-error: true
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_USERNAME }}
-          password: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_PULL_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
Closes https://github.com/ethereum-bounty/erigon/issues/9

## Summary

- Split `ORG_DOCKERHUB_ERIGONTECH_*` into a write-scoped pair (`DOCKERHUB_PUSH_USERNAME` / `DOCKERHUB_PUSH_TOKEN`, materialised only in the `dockerhub-publish` GitHub Environment, branch-filtered to `main` / `release/*` / tags) and a read-only pair (`DOCKERHUB_PULL_USERNAME` / `DOCKERHUB_PULL_TOKEN`) for rate-limit-avoidance pulls.
- Four publishing jobs declare `environment: dockerhub-publish`: `release.yml::build-release`, `release.yml::publish-docker-image`, `ci-cd-main-branch-docker-images.yml::Build`, `docker-image-remove.yml::build-release`.
- Five PR-reachable workflows (`test-hive`, `test-hive-eest`, `test-kurtosis-assertoor`, `test-kurtosis-gloas`, `qa-txpool-performance-test`) switch to the read-only token.

Defense-in-depth: publish credentials are no longer materialised in workflow runs that execute PR-controlled code.

**Prereq (already provisioned out-of-band):** the `dockerhub-publish` Environment with branch filter + the two token pairs.

## Test plan

- [ ] Push to `main` runs `ci-cd-main-branch-docker-images.yml` — `Build` job shows the badge; image push and the tag-cleanup curl both succeed
- [ ] Dispatch `docker-image-remove.yml` against a throwaway tag — delete succeeds
- [ ] Open a draft PR that triggers `test-kurtosis-gloas.yml` — login with the read-only token succeeds
- [ ] After everything green: delete the old `ORG_DOCKERHUB_ERIGONTECH_TOKEN` on Docker Hub and audit recent `erigontech/*` pushes for tampering

🤖 Generated with [Claude Code](https://claude.com/claude-code)