### PR TITLE
Fixes for EEST max-allowed-failures: 0 shards

### DIFF
--- a/db/kv/kv_interface.go
+++ b/db/kv/kv_interface.go
@@ -536,6 +536,7 @@ type TemporalMemBatch interface {
 	Unwind(txNumUnwindTo uint64, changeset *[DomainLen][]DomainEntryDiff)
 	GetAsOf(domain Domain, key []byte, ts uint64) (v []byte, ok bool, err error)
 	SetInMemHistoryReads(v bool)
+	InMemHistoryReads() bool
 }
 
 type WithFreezeInfo interface {

--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -514,6 +514,7 @@ func (sd *SharedDomains) CommitmentCapture() bool {
 
 func (sd *SharedDomains) GetMemBatch() kv.TemporalMemBatch { return sd.mem }
 func (sd *SharedDomains) SetInMemHistoryReads(v bool)      { sd.mem.SetInMemHistoryReads(v) }
+func (sd *SharedDomains) InMemHistoryReads() bool          { return sd.mem.InMemHistoryReads() }
 
 // SetParent sets a parent SD for read-through domain chaining. Domain reads
 // that miss in the local mem batch will check the parent's mem batch before

--- a/db/state/temporal_mem_batch.go
+++ b/db/state/temporal_mem_batch.go
@@ -127,6 +127,7 @@ func NewTemporalMemBatch(tx kv.TemporalTx, ioMetrics any) *TemporalMemBatch {
 }
 
 func (sd *TemporalMemBatch) SetInMemHistoryReads(v bool) { sd.inMemHistoryReads = v }
+func (sd *TemporalMemBatch) InMemHistoryReads() bool     { return sd.inMemHistoryReads }
 
 func (sd *TemporalMemBatch) DomainPut(domain kv.Domain, k string, v []byte, txNum uint64, preval []byte) error {
 	sd.putLatest(domain, k, v, txNum)

--- a/execution/protocol/gaspool.go
+++ b/execution/protocol/gaspool.go
@@ -23,8 +23,6 @@ import (
 	"fmt"
 	"math"
 	"sync"
-
-	"github.com/erigontech/erigon/execution/protocol/params"
 )
 
 // GasPool tracks block-level gas availability across the two EIP-8037 dimensions.
@@ -169,22 +167,19 @@ func (gp *GasPool) SubBlobGas(amount uint64) error {
 	return nil
 }
 
-// CheckBlockGasInclusion verifies the EIP-8037 per-dimension inclusion
-// rule against gp. Called from TxnExecutor.preCheck (serial path) and
-// parallelExecutor finalize (parallel path, where preCheck sees a
-// per-tx pool and so the check there is a no-op).
-func CheckBlockGasInclusion(gp *GasPool, txGas uint64, isAmsterdam bool) error {
+// CheckBlockGasInclusion verifies that the supplied per-dimension gas
+// values fit in the remaining EIP-8037 reservoirs. Callers compute the
+// dimension contributions for their context: pre-execution uses
+// min(MaxTxnGasLimit, tx.gas) and tx.gas; post-execution uses the
+// realised BlockRegularGasUsed and BlockStateGasUsed.
+func CheckBlockGasInclusion(gp *GasPool, regularGas, stateGas uint64) error {
 	if gp == nil {
 		return nil
 	}
-	regularContribution := txGas
-	if isAmsterdam {
-		regularContribution = min(regularContribution, params.MaxTxnGasLimit)
-	}
-	if regularContribution > gp.RegularGasAvailable() {
+	if regularGas > gp.RegularGasAvailable() {
 		return ErrGasLimitReached
 	}
-	if isAmsterdam && txGas > gp.StateGasAvailable() {
+	if stateGas > gp.StateGasAvailable() {
 		return ErrGasLimitReached
 	}
 	return nil

--- a/execution/protocol/txn_executor.go
+++ b/execution/protocol/txn_executor.go
@@ -303,7 +303,15 @@ func (st *TxnExecutor) preCheck(gasBailout bool, intrinsicGasResult mdgas.Intrin
 		}
 	}
 
-	if err := CheckBlockGasInclusion(st.gp, st.msg.Gas(), rules.IsAmsterdam); err != nil {
+	regularContribution := st.msg.Gas()
+	var stateContribution uint64
+	if rules.IsAmsterdam {
+		stateContribution = regularContribution
+		if regularContribution > params.MaxTxnGasLimit {
+			regularContribution = params.MaxTxnGasLimit
+		}
+	}
+	if err := CheckBlockGasInclusion(st.gp, regularContribution, stateContribution); err != nil {
 		return err
 	}
 

--- a/execution/protocol/txn_executor_test.go
+++ b/execution/protocol/txn_executor_test.go
@@ -266,31 +266,33 @@ func TestPreCheckErrorOrdering_GasBeforeFeeCap(t *testing.T) {
 			"fee-cap error must not leak past the gas-pool reject")
 	})
 
-	t.Run("CheckBlockGasInclusion rejects tx-gas > block-gas-limit", func(t *testing.T) {
+	t.Run("CheckBlockGasInclusion rejects regular contribution > regular pool", func(t *testing.T) {
 		gp := new(GasPool).AddGas(blockGasLimit)
-		require.ErrorIs(t, CheckBlockGasInclusion(gp, blockGasLimit+1, false), ErrGasLimitReached)
+		require.ErrorIs(t, CheckBlockGasInclusion(gp, blockGasLimit+1, 0), ErrGasLimitReached)
 	})
 
-	t.Run("CheckBlockGasInclusion accepts tx-gas <= block-gas-limit", func(t *testing.T) {
+	t.Run("CheckBlockGasInclusion accepts contribution <= reservoirs", func(t *testing.T) {
 		gp := new(GasPool).AddGas(blockGasLimit)
-		require.NoError(t, CheckBlockGasInclusion(gp, blockGasLimit, false))
-		require.NoError(t, CheckBlockGasInclusion(gp, blockGasLimit-1, false))
+		require.NoError(t, CheckBlockGasInclusion(gp, blockGasLimit, 0))
+		require.NoError(t, CheckBlockGasInclusion(gp, blockGasLimit-1, 0))
 	})
 
-	t.Run("CheckBlockGasInclusion is a no-op for nil gp (simulation paths)", func(t *testing.T) {
-		require.NoError(t, CheckBlockGasInclusion(nil, blockGasLimit*1000, false))
-		require.NoError(t, CheckBlockGasInclusion(nil, blockGasLimit*1000, true))
+	t.Run("CheckBlockGasInclusion is a no-op for nil gp", func(t *testing.T) {
+		require.NoError(t, CheckBlockGasInclusion(nil, blockGasLimit*1000, blockGasLimit*1000))
 	})
 
-	t.Run("CheckBlockGasInclusion Amsterdam state-dim rejects unclamped tx-gas", func(t *testing.T) {
-		// On Amsterdam+ a tx with gas > MaxTxnGasLimit gets its regular
-		// contribution clamped to MaxTxnGasLimit. The state-dimension
-		// check uses unclamped tx-gas, so a tx with gas > stateAvailable
-		// must still be rejected even when the clamped regular fits.
-		gp := NewGasPool(params.MaxTxnGasLimit+1000, 0)
-		require.ErrorIs(t,
-			CheckBlockGasInclusion(gp, params.MaxTxnGasLimit+10000, true),
-			ErrGasLimitReached,
-			"Amsterdam state-dim check must catch unclamped tx-gas > stateAvailable")
+	t.Run("CheckBlockGasInclusion rejects state contribution > state pool", func(t *testing.T) {
+		gp := NewGasPool(100_000, 0)
+		require.ErrorIs(t, CheckBlockGasInclusion(gp, 50_000, 200_000), ErrGasLimitReached)
+	})
+
+	t.Run("CheckBlockGasInclusion rejects regular contribution > regular pool (Amsterdam shape)", func(t *testing.T) {
+		gp := NewGasPool(100_000, 0)
+		require.ErrorIs(t, CheckBlockGasInclusion(gp, 200_000, 50_000), ErrGasLimitReached)
+	})
+
+	t.Run("CheckBlockGasInclusion accepts when both contributions fit", func(t *testing.T) {
+		gp := NewGasPool(100_000, 0)
+		require.NoError(t, CheckBlockGasInclusion(gp, 50_000, 80_000))
 	})
 }

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -222,6 +222,23 @@ func (cc *commitmentCalculator) handleMessage(ctx context.Context, msg applyResu
 		}
 
 	case *blockResult:
+		// Block-validity rejection (set by the worker-result path in
+		// nextResult — insufficient funds, gas overflow, finalize error,
+		// scheduler-exhausted incarnations). The apply loop's case
+		// *blockResult fast-paths Err != nil and returns it directly;
+		// we must NOT compute commitment for this block because (a)
+		// sd.mem may contain partial-tx writes from txs that succeeded
+		// before the failing one, so the computed root would be
+		// non-canonical, and (b) computing here would emit an
+		// ErrWrongTrieRoot through rootResults that races with the apply
+		// loop's Err return — the wrong-trie-root error wins and masks
+		// the original validation diagnostic (EEST assertions on the
+		// underlying exception class then fail). Skip silently and let
+		// the apply loop surface the worker's diagnosis.
+		if r.Err != nil {
+			return
+		}
+
 		// Track the latest block boundary.
 		cc.lastBlockResult = r
 

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -450,6 +450,26 @@ func (pe *parallelExecutor) exec(ctx context.Context, execStage *StageState, u U
 					blockApplyCount += len(applyResult.writes)
 					pe.rs.SetTrace(false)
 				case *blockResult:
+					// Apply loop is the canonical error-emission point for
+					// block-validity rejections (insufficient funds, gas
+					// overflow, finalize rejection, scheduler-exhausted
+					// incarnations). The worker plumbs the diagnosis through
+					// blockResult.Err via nextResult → processResults → the
+					// exec loop's sendResult — and the exec loop exits
+					// immediately after sending (see the matching guard in
+					// the exec loop). The calculator skips its compute for
+					// this block (see committer.go case *blockResult). So
+					// here, on the apply side: mark the block applied (so
+					// the channel-close completeness check doesn't
+					// double-report as silent miss), drop pending
+					// accumulator notifications (we never announce invalid
+					// blocks), and surface the worker's err. Single emission
+					// point — no errors.Join of competing diagnostics.
+					if applyResult.Err != nil {
+						appliedBlocks[applyResult.BlockNum] = struct{}{}
+						pendingAccumulatorWrites = pendingAccumulatorWrites[:0]
+						return applyResult.Err
+					}
 					// StartChange + NotifyAccumulator must both run in the apply
 					// goroutine — keeps all accumulator access single-threaded
 					// (avoids data race with the executor goroutine).
@@ -844,6 +864,11 @@ func (pe *parallelExecutor) execLoop(ctx context.Context) (err error) {
 							if err := blockExecutor.sendResult(ctx, blockResult); err != nil {
 								return err
 							}
+							// See main exec-loop path: invalid blockResult is
+							// the apply loop's signal — don't schedule next.
+							if blockResult.Err != nil {
+								return nil
+							}
 							pe.Lock()
 							delete(pe.blockExecutors, blockResult.BlockNum)
 							pe.Unlock()
@@ -922,6 +947,21 @@ func (pe *parallelExecutor) execLoop(ctx context.Context) (err error) {
 					return err
 				}
 				pe.clearChangesetAccumulator()
+
+				// Block-validity rejection: the apply loop will consume
+				// blockResult and return its Err; the calculator skips the
+				// commitment compute (see committer.go case *blockResult).
+				// Exit the exec loop here so we don't schedule the next
+				// pending block on top of partial / now-discarded state —
+				// the apply loop's Err is the canonical signal, surfaced
+				// through errgroup to the caller. Leaving scheduling running
+				// would race with the apply loop's Err return: the
+				// commitment calculator could compute on partial state, the
+				// next block's executor could start against stale sd.mem,
+				// and errors.Join would weld competing diagnostics.
+				if blockResult.Err != nil {
+					return nil
+				}
 
 				pe.Lock()
 				delete(pe.blockExecutors, blockResult.BlockNum)
@@ -2394,6 +2434,21 @@ func newBlockExec(blockNum uint64, blockHash common.Hash, gasPool *protocol.GasP
 	}
 }
 
+// invalidBlockResult wraps a block-validity failure (insufficient funds, gas
+// overflow, finalize rejection, etc.) as a *blockResult carrying Err. Returning
+// this from the worker-result processing path lets the apply loop see that the
+// block completed (with a rejection) rather than treating the dangling
+// tx-results as a silent miss. The apply loop's case *blockResult fast-paths
+// Err != nil at the top: marks the block applied so the channel-close
+// completeness check doesn't double-report, and surfaces the error.
+func (be *blockExecutor) invalidBlockResult(err error) *blockResult {
+	return &blockResult{
+		BlockNum:  be.blockNum,
+		BlockHash: be.blockHash,
+		Err:       err,
+	}
+}
+
 func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, res *exec.TxResult, applyTx kv.TemporalTx) (result *blockResult, err error) {
 	task, ok := res.Task.(*taskVersion)
 
@@ -2406,18 +2461,30 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 	if res.Err != nil {
 		if execErr, ok := res.Err.(protocol.ErrExecAbortError); ok {
 			if execErr.OriginError != nil && be.skipCheck[tx] {
-				// If the transaction failed when we know it should not fail, this means the transaction itself is
-				// bad (e.g. wrong nonce), and we should exit the execution immediately
+				// Worker hit a legitimate VM rejection (insufficient funds, wrong
+				// nonce, low gas limit, …). Surface the diagnosis through a
+				// blockResult so the apply loop counts the block as completed-
+				// as-invalid; returning (nil, err) here would race with the
+				// channel-close completeness check at the top of the apply loop
+				// and produce a doubled ErrInvalidBlock error chain.
 				version := res.Version()
-				return nil, fmt.Errorf("%w: could not apply tx %d:%d [%d:%v]: %w", rules.ErrInvalidBlock, be.blockNum, version.TxIndex, version.TxNum, task.TxHash(), execErr.OriginError)
+				return be.invalidBlockResult(fmt.Errorf("%w: could not apply tx %d:%d [%d:%v]: %w", rules.ErrInvalidBlock, be.blockNum, version.TxIndex, version.TxNum, task.TxHash(), execErr.OriginError)), nil
 			}
 
 			if res.Version().Incarnation > len(be.tasks) {
+				// Parallel scheduler exhausted retries for this tx. Surface
+				// through blockResult.Err for the same reason as the other
+				// block-validity bailouts above: (nil, err) would race with
+				// the apply loop's channel-close completeness check and
+				// produce a doubled error chain. The underlying scheduler
+				// behaviour (why this test ordering hits the incarnation
+				// limit) is a separate investigation — see
+				// TestDeleteRecreateSlotsAcrossManyBlocks under
+				// GOMAXPROCS=2 -race for a stress repro.
 				if execErr.OriginError != nil {
-					return nil, fmt.Errorf("could not apply tx %d:%d [%v]: %w: too many incarnations: %d, expected: %d", be.blockNum, res.Version().TxIndex, task.TxHash(), execErr.OriginError, res.Version().Incarnation, len(be.tasks))
-				} else {
-					return nil, fmt.Errorf("could not apply tx %d:%d [%v]: too many incarnations: %d, expected: %d", be.blockNum, res.Version().TxIndex, task.TxHash(), res.Version().Incarnation, len(be.tasks))
+					return be.invalidBlockResult(fmt.Errorf("%w: could not apply tx %d:%d [%v]: %w: too many incarnations: %d, expected: %d", rules.ErrInvalidBlock, be.blockNum, res.Version().TxIndex, task.TxHash(), execErr.OriginError, res.Version().Incarnation, len(be.tasks))), nil
 				}
+				return be.invalidBlockResult(fmt.Errorf("%w: could not apply tx %d:%d [%v]: too many incarnations: %d, expected: %d", rules.ErrInvalidBlock, be.blockNum, res.Version().TxIndex, task.TxHash(), res.Version().Incarnation, len(be.tasks))), nil
 			}
 			if dbg.TraceTransactionIO && be.txIncarnations[tx] > 1 {
 				fmt.Println(be.blockNum, "err", execErr)
@@ -2603,16 +2670,16 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 				}
 
 				if err := be.gasPool.ConsumeRegular(txResult.ExecutionResult.BlockRegularGasUsed); err != nil {
-					return nil, fmt.Errorf("%w, block=%d: block regular gas overflow", rules.ErrInvalidBlock, be.blockNum)
+					return be.invalidBlockResult(fmt.Errorf("%w, block=%d: block regular gas overflow", rules.ErrInvalidBlock, be.blockNum)), nil
 				}
 				if err := be.gasPool.ConsumeState(txResult.ExecutionResult.BlockStateGasUsed); err != nil {
-					return nil, fmt.Errorf("%w, block=%d: block state gas overflow", rules.ErrInvalidBlock, be.blockNum)
+					return be.invalidBlockResult(fmt.Errorf("%w, block=%d: block state gas overflow", rules.ErrInvalidBlock, be.blockNum)), nil
 				}
 
 				if txTask.Tx() != nil {
 					blobGasUsed := txTask.Tx().GetBlobGas()
 					if err := be.gasPool.SubBlobGas(blobGasUsed); err != nil {
-						return nil, fmt.Errorf("%w, block=%d blob gas used overflow: %w", rules.ErrInvalidBlock, be.blockNum, err)
+						return be.invalidBlockResult(fmt.Errorf("%w, block=%d blob gas used overflow: %w", rules.ErrInvalidBlock, be.blockNum, err)), nil
 					}
 					be.blobGasUsed += blobGasUsed
 				}
@@ -2931,7 +2998,7 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 				if _, err := pe.cfg.engine.Finalize(
 					pe.cfg.chainConfig, types.CopyHeader(tt.Header), ibs, tt.Uncles, receipts,
 					tt.Withdrawals, chainReader, syscall, false, pe.logger); err != nil {
-					return nil, fmt.Errorf("%w: can't finalize block %d: %v", rules.ErrInvalidBlock, be.blockNum, err)
+					return be.invalidBlockResult(fmt.Errorf("%w: can't finalize block %d: %v", rules.ErrInvalidBlock, be.blockNum, err)), nil
 				}
 
 				// syscallIBS == ibs unconditionally now; no separate write

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -202,8 +202,20 @@ func (pe *parallelExecutor) exec(ctx context.Context, execStage *StageState, u U
 	// via its own Updates buffer (TouchUpdates from VersionedWrites).
 	pe.rs.Domains().SetDisableInlineTouchKey(true)
 	defer pe.rs.Domains().SetDisableInlineTouchKey(false)
+	// Parallel exec needs in-mem history reads enabled for the calculator
+	// goroutine. Capture the caller's setting first and restore it on exit
+	// — the previous defer-to-false (b72aa7b4f7 #20805) hardcoded the
+	// post-exec value to false regardless of what the caller had set,
+	// which broke post-exec callers (engine API forkchoice_updated's
+	// GetAsOf, post-batch trie-root computation, RPC reads) with
+	// "GetAsOf called on TemporalMemBatch with inMemHistoryReads disabled"
+	// or with partial-state reads. Repro: EEST
+	// test_gas_limit_below_minimum[gas_limit_5000] in parallel mode; same
+	// root cause likely behind mainnet from-0 parallel wrong-trie-root at
+	// block 131578.
+	prevInMemHistoryReads := pe.rs.Domains().InMemHistoryReads()
 	pe.rs.Domains().SetInMemHistoryReads(true)
-	defer pe.rs.Domains().SetInMemHistoryReads(false)
+	defer pe.rs.Domains().SetInMemHistoryReads(prevInMemHistoryReads)
 
 	// Disable trie warmup — the Warmuper uses sdCtx.updates which the
 	// calculator replaces via SetUpdates before ComputeCommitment.

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -3469,12 +3469,28 @@ func normalizeWriteSet(writes state.VersionedWrites, vm *state.VersionMap, txInd
 			}
 		}
 
+		// Only emit post-SD defaults when this TX created a new contract
+		// (CREATE/CREATE2). A value-transfer resurrect (no CreateContractPath)
+		// inherits the pre-SD account fields via the versionMap last-write-wins
+		// chain — that matches GenerateChain's accumulate-across-txs behaviour
+		// (no per-tx FinalizeTx). Forcing defaults here resets nonce/codeHash
+		// against that canonical state (TestSelfDestructReceive).
+		hasCreateContract := false
+		for _, w := range writes {
+			if w.Address == addr && w.Path == state.CreateContractPath {
+				if v, ok := w.Val.(bool); ok && v {
+					hasCreateContract = true
+					break
+				}
+			}
+		}
+
 		// For each missing field, try versionMap then stateReader.
 		for _, path := range []state.AccountPath{state.BalancePath, state.NoncePath, state.IncarnationPath, state.CodeHashPath} {
 			if fields != nil && fields[path] {
 				continue // already in output
 			}
-			if sdEarlier {
+			if sdEarlier && hasCreateContract {
 				var val any
 				switch path {
 				case state.BalancePath:

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2664,7 +2664,7 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 				txTask := be.tasks[tx].Task
 
 				if txn := txTask.Tx(); txn != nil {
-					if err := protocol.CheckBlockGasInclusion(be.gasPool, txn.GetGasLimit(), txTask.Rules().IsAmsterdam); err != nil {
+					if err := protocol.CheckBlockGasInclusion(be.gasPool, txResult.ExecutionResult.BlockRegularGasUsed, txResult.ExecutionResult.BlockStateGasUsed); err != nil {
 						return nil, fmt.Errorf("%w, block=%d txIdx=%d: %w", rules.ErrInvalidBlock, be.blockNum, txVersion.TxIndex, err)
 					}
 				}

--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -1854,6 +1854,14 @@ func (sdb *IntraBlockState) CreateAccount(addr accounts.Address, contractCreatio
 	}
 
 	newObj := sdb.createObject(addr, previous)
+	if previous != nil && previous.selfdestructed {
+		// resetObjectChange.dirtied() returns false, so without this the
+		// parallel worker's MakeWriteSet drops the resurrect write
+		// (test_double_kill / EIP-6780 family on the parallel shard).
+		// Confined to CreateAccount — the GetOrNewStateObject AddBalance
+		// path must NOT mark dirty here (regresses TestSelfDestructReceive).
+		sdb.journal.dirty(addr)
+	}
 	if previous != nil && !previous.selfdestructed {
 		newObj.data.Balance.Set(&previous.data.Balance)
 	}


### PR DESCRIPTION
## Summary

Parallel-exec correctness fixes that the EEST `max-allowed-failures: 0` shards depend on. Each commit addresses a class of failure surfaced once the EEST shards started rejecting any failed test (vs. the old tolerant default).

## Commits

1. **execution/stagedsync: capture-and-restore inMemHistoryReads around parallel exec** — parallel workers were leaving the shared-domains `inMemHistoryReads` flag in a non-canonical state when they exited; serial exec then read a different history view than expected.

2. **execution/stagedsync: surface block-validity errors via blockResult.Err** — the commitment calculator was racing with the apply-loop on `*blockResult` handling: a worker-side validation failure (insufficient funds, gas overflow, scheduler-exhausted incarnations) could be masked by an `ErrWrongTrieRoot` emitted by the commitment goroutine on a partial sd.mem state. Skip commitment when `blockResult.Err != nil` so the apply-loop's diagnosis wins.

3. **execution: EIP-8037 inclusion uses per-dimension contribution** — `CheckBlockGasInclusion` now checks `min(MaxTxnGasLimit, tx.gas)` against the regular reservoir and `tx.gas` against the state reservoir, matching the EIP-8037 contribution semantics. Replaces the prior intrinsic-floor variant (too weak) and the original tx.gas-only check (over-rejected valid 2-D scenarios). Verified against `stEIP1559/test_low_gas_limit` (Amsterdam) and the full `statetests-devnet` shard.

4. **execution: fix parallel-exec SD-then-resurrect** — two coordinated changes for the SD-then-recreate scenario family (CREATE2-recreate, value-transfer-resurrect, pre-Spurious-Dragon empty-touch):
   - `IntraBlockState.CreateAccount` marks `journal.dirty(addr)` when `previous.selfdestructed`. `resetObjectChange.dirtied()` returns false, so without this the parallel worker's `MakeWriteSet` revert-non-dirty block dropped every resurrect write (test_double_kill / EIP-6780 family).
   - `normalizeWriteSet` only emits post-SD defaults (Balance=0, Nonce=0, Incarnation=0, CodeHash=EmptyCodeHash) when the current tx wrote `CreateContractPath`. A value-transfer resurrect inherits pre-SD account fields via the versionMap last-write-wins chain — matching `GenerateChain`'s accumulate-across-txs behaviour. Forcing defaults there reset nonce/codeHash against the canonical state (TestSelfDestructReceive).

## Test plan

- [x] `make lint` clean
- [x] `make erigon` builds
- [x] TestSelfDestructReceive, TestDeleteRecreate*, TestCVE2020_26265 pass under ERIGON_EXEC3_PARALLEL=true locally
- [x] EEST blocktests-stable-parallel (69256/0), blocktests-devnet (82896/0), statetests-devnet (65171/0) pass locally
- [ ] CI green

## Context

These commits were carried on #21017 (the serial-vs-parallel CI matrix PR) to keep its EEST shards green. Splitting them out so the matrix PR is purely workflow/config.