### PR TITLE
[r3.4] rawdb: ignore invalid receipt cache transaction indexes

### DIFF
--- a/db/rawdb/accessors_chain.go
+++ b/db/rawdb/accessors_chain.go
@@ -1323,6 +1323,7 @@ func ReadReceiptsCacheV2(tx kv.TemporalTx, block *types.Block, txNumReader rawdb
 		return
 	}
 
+	receiptIdx := 0
 	for txNum := minTxNum; txNum < maxTxNum+1; txNum++ {
 		v, ok, err := tx.HistorySeek(kv.RCacheDomain, receiptCacheKey, txNum+1)
 		if err != nil {
@@ -1342,16 +1343,17 @@ func ReadReceiptsCacheV2(tx kv.TemporalTx, block *types.Block, txNumReader rawdb
 		}
 		x := (*types.Receipt)(receipt)
 		txnIdx := int(receipt.TransactionIndex)
-		if txnIdx < 0 || txnIdx != len(res) || txnIdx >= len(transactions) {
-			// RCacheV2 entries are ordered by txNum. If the stored transaction
-			// index does not match that order, this block must be derived instead.
+		if txnIdx < 0 || txnIdx != receiptIdx || txnIdx >= len(transactions) {
+			// RCacheV2 is read in txNum order. The stored transaction index must
+			// match the next receipt position, otherwise derive the block instead.
 			return nil, nil
 		}
 		txn := transactions[txnIdx]
 		x.DeriveFieldsV4ForCachedReceipt(blockHash, blockNum, txn.Hash(), true)
 		res = append(res, x)
+		receiptIdx++
 	}
-	if len(res) != len(transactions) {
+	if receiptIdx != len(transactions) {
 		// Block receipt RPCs require the full ordered receipt set.
 		return nil, nil
 	}

--- a/db/rawdb/accessors_chain.go
+++ b/db/rawdb/accessors_chain.go
@@ -1312,6 +1312,7 @@ func ReadReceiptCacheV2(tx kv.TemporalTx, query RCacheV2Query) (*types.Receipt, 
 func ReadReceiptsCacheV2(tx kv.TemporalTx, block *types.Block, txNumReader rawdbv3.TxNumsReader) (res types.Receipts, err error) {
 	blockHash := block.Hash()
 	blockNum := block.NumberU64()
+	transactions := block.Transactions()
 
 	minTxNum, err := txNumReader.Min(context.Background(), tx, blockNum)
 	if err != nil {
@@ -1340,14 +1341,19 @@ func ReadReceiptsCacheV2(tx kv.TemporalTx, block *types.Block, txNumReader rawdb
 			return nil, fmt.Errorf("ReadReceiptsCacheV2: deserialize %d, len(v)=%d, %w", blockNum, len(v), err)
 		}
 		x := (*types.Receipt)(receipt)
-		transactions := block.Transactions()
 		txnIdx := int(receipt.TransactionIndex)
-		if txnIdx < 0 || txnIdx >= len(transactions) {
-			return nil, fmt.Errorf("ReadReceiptsCacheV2: out of range txnIdx=%d, len(transactions)=%d", txnIdx, len(transactions))
+		if txnIdx < 0 || txnIdx != len(res) || txnIdx >= len(transactions) {
+			// RCacheV2 entries are ordered by txNum. If the stored transaction
+			// index does not match that order, this block must be derived instead.
+			return nil, nil
 		}
 		txn := transactions[txnIdx]
 		x.DeriveFieldsV4ForCachedReceipt(blockHash, blockNum, txn.Hash(), true)
 		res = append(res, x)
+	}
+	if len(res) != len(transactions) {
+		// Block receipt RPCs require the full ordered receipt set.
+		return nil, nil
 	}
 	return res, nil
 }

--- a/db/rawdb/accessors_chain_test.go
+++ b/db/rawdb/accessors_chain_test.go
@@ -885,7 +885,7 @@ func TestBlockReceiptStorage(t *testing.T) {
 	require.NotNil(b)
 }
 
-func TestReadReceiptsCacheV2CacheMissOnInvalidTransactionIndex(t *testing.T) {
+func TestReadReceiptsCacheV2BadTxIndex(t *testing.T) {
 	t.Parallel()
 	m := execmoduletester.New(t, execmoduletester.WithEnableDomain(kv.RCacheDomain))
 	tx, err := m.DB.BeginTemporalRw(m.Ctx)
@@ -936,7 +936,7 @@ func TestReadReceiptsCacheV2CacheMissOnInvalidTransactionIndex(t *testing.T) {
 	require.Empty(t, rs)
 }
 
-func TestReadReceiptsCacheV2CacheMissOnNonSequentialTransactionIndex(t *testing.T) {
+func TestReadReceiptsCacheV2UnorderedTxIndex(t *testing.T) {
 	t.Parallel()
 	m := execmoduletester.New(t, execmoduletester.WithEnableDomain(kv.RCacheDomain))
 	tx, err := m.DB.BeginTemporalRw(m.Ctx)

--- a/db/rawdb/accessors_chain_test.go
+++ b/db/rawdb/accessors_chain_test.go
@@ -52,10 +52,10 @@ func newTestLegacyTx(nonce uint64, to common.Address, value uint256.Int, gasLimi
 		CommonTx: types.CommonTx{
 			Nonce:    nonce,
 			To:       &toAddr,
-			Value:    value,
+			Value:    &value,
 			GasLimit: gasLimit,
 		},
-		GasPrice: gasPrice,
+		GasPrice: &gasPrice,
 	}
 }
 

--- a/db/rawdb/accessors_chain_test.go
+++ b/db/rawdb/accessors_chain_test.go
@@ -46,6 +46,19 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
+func newTestLegacyTx(nonce uint64, to common.Address, value uint256.Int, gasLimit uint64, gasPrice uint256.Int) *types.LegacyTx {
+	toAddr := to
+	return &types.LegacyTx{
+		CommonTx: types.CommonTx{
+			Nonce:    nonce,
+			To:       &toAddr,
+			Value:    value,
+			GasLimit: gasLimit,
+		},
+		GasPrice: gasPrice,
+	}
+}
+
 func TestWriteRawTransactions(t *testing.T) {
 	_, tx := memdb.NewTestTx(t)
 	defer tx.Rollback()
@@ -776,8 +789,8 @@ func TestBlockReceiptStorage(t *testing.T) {
 	ctx := m.Ctx
 
 	// Create a live block since we need metadata to reconstruct the receipt
-	tx1 := types.NewTransaction(1, common.HexToAddress("0x1"), &u256.Num1, 1, &u256.Num1, nil)
-	tx2 := types.NewTransaction(2, common.HexToAddress("0x2"), &u256.Num2, 2, &u256.Num2, nil)
+	tx1 := newTestLegacyTx(1, common.HexToAddress("0x1"), u256.Num1, 1, u256.Num1)
+	tx2 := newTestLegacyTx(2, common.HexToAddress("0x2"), u256.Num2, 2, u256.Num2)
 
 	header := &types.Header{Number: *common.Num1}
 	body := &types.Body{Transactions: types.Transactions{tx1, tx2}}
@@ -870,6 +883,108 @@ func TestBlockReceiptStorage(t *testing.T) {
 	b, _, err = br.BlockWithSenders(ctx, tx, hash, 1)
 	require.NoError(err)
 	require.NotNil(b)
+}
+
+func TestReadReceiptsCacheV2CacheMissOnInvalidTransactionIndex(t *testing.T) {
+	t.Parallel()
+	m := execmoduletester.New(t, execmoduletester.WithEnableDomain(kv.RCacheDomain))
+	tx, err := m.DB.BeginTemporalRw(m.Ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+	br := m.BlockReader
+	txNumReader := br.TxnumReader()
+	ctx := m.Ctx
+
+	tx1 := newTestLegacyTx(1, common.HexToAddress("0x1"), u256.Num1, 1, u256.Num1)
+	tx2 := newTestLegacyTx(2, common.HexToAddress("0x2"), u256.Num2, 2, u256.Num2)
+
+	header := &types.Header{Number: *common.Num1}
+	hash := header.Hash()
+	body := &types.Body{Transactions: types.Transactions{tx1, tx2}}
+	require.NoError(t, rawdb.WriteCanonicalHash(tx, hash, header.Number.Uint64()))
+	require.NoError(t, rawdb.WriteHeader(tx, header))
+	require.NoError(t, rawdb.WriteBody(tx, hash, 1, body))
+	require.NoError(t, rawdb.WriteSenders(tx, hash, 1, body.SendersFromTxs()))
+
+	badReceipt := &types.Receipt{
+		Status:            types.ReceiptStatusSuccessful,
+		CumulativeGasUsed: 1,
+		GasUsed:           1,
+		BlockNumber:       &header.Number,
+		BlockHash:         hash,
+		TransactionIndex:  3_468_750_000,
+	}
+
+	blockNum := header.Number.Uint64()
+	sd, err := execctx.NewSharedDomains(t.Context(), tx, log.New())
+	require.NoError(t, err)
+	defer sd.Close()
+	base, err := txNumReader.Min(t.Context(), tx, blockNum)
+	require.NoError(t, err)
+	require.NoError(t, rawdb.WriteReceiptCacheV2(sd.AsPutDel(tx), nil, base))
+	require.NoError(t, rawdb.WriteReceiptCacheV2(sd.AsPutDel(tx), badReceipt, base+1))
+	require.NoError(t, rawdb.WriteReceiptCacheV2(sd.AsPutDel(tx), nil, base+2))
+	_, err = sd.ComputeCommitment(ctx, tx, true, blockNum, base+2, "flush-commitment", nil)
+	require.NoError(t, err)
+	require.NoError(t, sd.Flush(ctx, tx))
+
+	b, _, err := br.BlockWithSenders(ctx, tx, hash, 1)
+	require.NoError(t, err)
+	require.NotNil(t, b)
+	rs, err := rawdb.ReadReceiptsCacheV2(tx, b, txNumReader)
+	require.NoError(t, err)
+	require.Empty(t, rs)
+}
+
+func TestReadReceiptsCacheV2CacheMissOnNonSequentialTransactionIndex(t *testing.T) {
+	t.Parallel()
+	m := execmoduletester.New(t, execmoduletester.WithEnableDomain(kv.RCacheDomain))
+	tx, err := m.DB.BeginTemporalRw(m.Ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+	br := m.BlockReader
+	txNumReader := br.TxnumReader()
+	ctx := m.Ctx
+
+	tx1 := newTestLegacyTx(1, common.HexToAddress("0x1"), u256.Num1, 1, u256.Num1)
+	tx2 := newTestLegacyTx(2, common.HexToAddress("0x2"), u256.Num2, 2, u256.Num2)
+
+	header := &types.Header{Number: *common.Num1}
+	hash := header.Hash()
+	body := &types.Body{Transactions: types.Transactions{tx1, tx2}}
+	require.NoError(t, rawdb.WriteCanonicalHash(tx, hash, header.Number.Uint64()))
+	require.NoError(t, rawdb.WriteHeader(tx, header))
+	require.NoError(t, rawdb.WriteBody(tx, hash, 1, body))
+	require.NoError(t, rawdb.WriteSenders(tx, hash, 1, body.SendersFromTxs()))
+
+	receipt1 := &types.Receipt{
+		Status:            types.ReceiptStatusSuccessful,
+		CumulativeGasUsed: 1,
+		GasUsed:           1,
+		BlockNumber:       &header.Number,
+		BlockHash:         hash,
+		TransactionIndex:  1,
+	}
+
+	blockNum := header.Number.Uint64()
+	sd, err := execctx.NewSharedDomains(t.Context(), tx, log.New())
+	require.NoError(t, err)
+	defer sd.Close()
+	base, err := txNumReader.Min(t.Context(), tx, blockNum)
+	require.NoError(t, err)
+	require.NoError(t, rawdb.WriteReceiptCacheV2(sd.AsPutDel(tx), nil, base))
+	require.NoError(t, rawdb.WriteReceiptCacheV2(sd.AsPutDel(tx), receipt1, base+1))
+	require.NoError(t, rawdb.WriteReceiptCacheV2(sd.AsPutDel(tx), nil, base+2))
+	_, err = sd.ComputeCommitment(ctx, tx, true, blockNum, base+2, "flush-commitment", nil)
+	require.NoError(t, err)
+	require.NoError(t, sd.Flush(ctx, tx))
+
+	b, _, err := br.BlockWithSenders(ctx, tx, hash, 1)
+	require.NoError(t, err)
+	require.NotNil(t, b)
+	rs, err := rawdb.ReadReceiptsCacheV2(tx, b, txNumReader)
+	require.NoError(t, err)
+	require.Empty(t, rs)
 }
 
 // Tests block storage and retrieval operations with withdrawals.

--- a/execution/execmodule/execmoduletester/exec_module_tester.go
+++ b/execution/execmodule/execmoduletester/exec_module_tester.go
@@ -53,6 +53,7 @@ import (
 	"github.com/erigontech/erigon/db/services"
 	"github.com/erigontech/erigon/db/snapshotsync/freezeblocks"
 	"github.com/erigontech/erigon/db/snaptype"
+	dbstate "github.com/erigontech/erigon/db/state"
 	"github.com/erigontech/erigon/db/state/execctx"
 	"github.com/erigontech/erigon/execution/builder"
 	"github.com/erigontech/erigon/execution/builder/builderstages"
@@ -321,6 +322,12 @@ func WithChainConfig(cfg *chain.Config) Option {
 	}
 }
 
+func WithEnableDomain(domain kv.Domain) Option {
+	return func(opts *options) {
+		opts.enableDomains = append(opts.enableDomains, domain)
+	}
+}
+
 type options struct {
 	stepSize        *uint64
 	experimentalBAL bool
@@ -331,6 +338,7 @@ type options struct {
 	pruneMode       *prune.Mode
 	blockBufferSize int
 	withTxPool      bool
+	enableDomains   []kv.Domain
 }
 
 func applyOptions(opts []Option) options {
@@ -429,6 +437,13 @@ func New(tb testing.TB, opts ...Option) *ExecModuleTester {
 		db = temporaltest.NewTestDBWithStepSize(tb, dirs, *opt.stepSize)
 	} else {
 		db = temporaltest.NewTestDB(tb, dirs)
+	}
+
+	if len(opt.enableDomains) > 0 {
+		agg := db.(dbstate.HasAgg).Agg().(*dbstate.Aggregator)
+		for _, domain := range opt.enableDomains {
+			agg.EnableDomain(domain)
+		}
 	}
 
 	if _, err := snaptype.LoadSalt(dirs.Snap, true, logger); err != nil {


### PR DESCRIPTION
Cherry-pick of #21249 to release/3.4.