### PR TITLE
bloatnet: cli flag defaults

### DIFF
--- a/node/cli/flags.go
+++ b/node/cli/flags.go
@@ -34,6 +34,7 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/kvcache"
 	"github.com/erigontech/erigon/db/kv/prune"
+	"github.com/erigontech/erigon/execution/chain/networkname"
 	"github.com/erigontech/erigon/node/ethconfig"
 	"github.com/erigontech/erigon/node/nodecfg"
 	"github.com/erigontech/erigon/rpc/rpccfg"
@@ -316,6 +317,18 @@ func applyRemainingEthFlags(ctx *cli.Context, cfg *ethconfig.Config, logger log.
 
 	if ctx.Bool(utils.ChaosMonkeyFlag.Name) {
 		cfg.ChaosMonkey = true
+	}
+
+	if cfg.Snapshot.ChainName == networkname.Bloatnet {
+		applyBloatnetDefaults(ctx, cfg)
+	}
+}
+
+// applyBloatnetDefaults applies bloatnet-optimised values for flags the user did not explicitly set.
+// Add new overrides here as needed.
+func applyBloatnetDefaults(ctx *cli.Context, cfg *ethconfig.Config) {
+	if !ctx.IsSet(BatchSizeFlag.Name) {
+		_ = cfg.BatchSize.UnmarshalText([]byte("256M"))
 	}
 }
 

--- a/node/cli/flags.go
+++ b/node/cli/flags.go
@@ -328,7 +328,7 @@ func applyRemainingEthFlags(ctx *cli.Context, cfg *ethconfig.Config, logger log.
 // Add new overrides here as needed.
 func applyBloatnetDefaults(ctx *cli.Context, cfg *ethconfig.Config) {
 	if !ctx.IsSet(BatchSizeFlag.Name) {
-		_ = cfg.BatchSize.UnmarshalText([]byte("128m"))
+		_ = cfg.BatchSize.UnmarshalText([]byte("128m")) // ram: 42g -> 26g. chaindata size: 50g -> 35g
 	}
 }
 

--- a/node/cli/flags.go
+++ b/node/cli/flags.go
@@ -328,7 +328,7 @@ func applyRemainingEthFlags(ctx *cli.Context, cfg *ethconfig.Config, logger log.
 // Add new overrides here as needed.
 func applyBloatnetDefaults(ctx *cli.Context, cfg *ethconfig.Config) {
 	if !ctx.IsSet(BatchSizeFlag.Name) {
-		_ = cfg.BatchSize.UnmarshalText([]byte("256M"))
+		_ = cfg.BatchSize.UnmarshalText([]byte("128m"))
 	}
 }
 


### PR DESCRIPTION
Adds `applyBloatnetDefaults` — a single function grouping all bloatnet-specific parameter adjustments. Each override uses `ctx.IsSet()` so explicit user flags always take precedence.

Current overrides:
- `--batchSize`: defaults to `128M` on bloatnet (global default is `512M`)