### PR TITLE
execution/execmodule: apply runloop refactor with furious-prune fix

### DIFF
--- a/execution/execmodule/executor.go
+++ b/execution/execmodule/executor.go
@@ -26,6 +26,7 @@ import (
 	"github.com/erigontech/erigon/db/consensuschain"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/services"
+	dbstate "github.com/erigontech/erigon/db/state"
 	"github.com/erigontech/erigon/db/state/execctx"
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/protocol/rules"
@@ -114,70 +115,60 @@ func (pe *PipelineExecutor) RunPrune(ctx context.Context, tx kv.RwTx, initialCyc
 	return pe.sync.RunPrune(ctx, tx, initialCycle, timeout)
 }
 
-// CommitCycleFn is called between hasMore iterations to persist accumulated
-// state and obtain a fresh tx for the next iteration. Implementations must
-// flush the SharedDomains, commit, and return a fresh kv.TemporalRwTx.
-type CommitCycleFn func(ctx context.Context, sd *execctx.SharedDomains) (kv.TemporalRwTx, error)
+// CommitCycleFn is called after PruneFn to persist the iteration's writes
+// and refresh the loop's tx. Implementations typically open a fresh RwTx,
+// flush+clear the SharedDomains into it, commit, and re-open the read-side
+// tx. hasMore tells the impl whether another iteration follows — useful to
+// skip refreshing the tx on the final iter. May return (nil, nil) to leave
+// the loop's tx unchanged.
+// TODO: rename initialCycle to atTip (inverted polarity) across stage/prune
+// APIs so naming matches semantic.
+type CommitCycleFn func(ctx context.Context, hasMore bool, sd *execctx.SharedDomains) (kv.TemporalRwTx, error)
 
-// ShouldBreakFn is called after each iteration (after prune, before commit)
-// to check whether the loop should stop early. Return true to break.
+// PruneFn replaces the in-loop pe.sync.RunPrune call. It is called after
+// pe.sync.Run and before CommitCycle. Implementations typically close the
+// read-side tx (if separate) and run pruning on a tx of their choosing.
+type PruneFn func(ctx context.Context, initialCycle bool, rwtx kv.TemporalRwTx, sd *execctx.SharedDomains) error
+
+// ShouldBreakFn is an optional callback to stop the loop early (return true).
 type ShouldBreakFn func(tx kv.TemporalRwTx) (bool, error)
-
-// BeforeIterationFn is called before each pipeline Run (e.g. to set state cache).
-type BeforeIterationFn func(sd *execctx.SharedDomains)
 
 // RunLoopConfig configures a single RunLoop invocation.
 type RunLoopConfig struct {
-	InitialCycle    bool
-	FirstCycle      bool
-	PruneTimeout    time.Duration
-	CommitCycle     CommitCycleFn     // required when hasMore
-	ShouldBreak     ShouldBreakFn     // optional early exit
-	BeforeIteration BeforeIterationFn // optional per-iteration setup
+	InitialCycle bool
+	FirstCycle   bool
+	CommitCycle  CommitCycleFn
+	PruneFn      PruneFn
+	ShouldBreak  ShouldBreakFn // optional
 }
 
-// RunLoop executes the pipeline in a hasMore loop:
-//
-//	for hasMore {
-//	    [BeforeIteration] → sync.Run → RunPrune → [ShouldBreak] → if hasMore { CommitCycle }
-//	}
-//
-// RunPrune runs unconditionally on every iteration (including the last) to
-// match the original stageloop.ProcessFrozenBlocks behaviour. The loop
-// continues until Run returns hasMore=false, ShouldBreak returns true, or
-// an error occurs. The returned tx may differ from the input tx if
-// CommitCycle was called (which returns a fresh tx).
+// RunLoop runs sync.Run → PruneFn → ShouldBreak → CommitCycle in a hasMore loop.
+// Exits when Run returns hasMore=false, ShouldBreak returns true, or on error.
 func (pe *PipelineExecutor) RunLoop(ctx context.Context, sd *execctx.SharedDomains, tx kv.TemporalRwTx, cfg RunLoopConfig) (kv.TemporalRwTx, error) {
-	for hasMore := true; hasMore; {
-		if cfg.BeforeIteration != nil {
-			cfg.BeforeIteration(sd)
-		}
-
+	stop := false
+	for hasMore := true; hasMore && !stop; {
 		var err error
 		hasMore, err = pe.sync.Run(sd, tx, cfg.InitialCycle, cfg.FirstCycle)
 		if err != nil {
 			return tx, err
 		}
 
-		if err := pe.sync.RunPrune(ctx, tx, cfg.InitialCycle, cfg.PruneTimeout); err != nil {
+		if err := cfg.PruneFn(ctx, cfg.InitialCycle, tx, sd); err != nil {
 			return tx, err
 		}
 
 		if cfg.ShouldBreak != nil {
-			stop, err := cfg.ShouldBreak(tx)
+			stop, err = cfg.ShouldBreak(tx)
 			if err != nil {
 				return tx, err
-			}
-			if stop {
-				break
 			}
 		}
 
-		if hasMore {
-			newTx, err := cfg.CommitCycle(ctx, sd)
-			if err != nil {
-				return tx, err
-			}
+		newTx, err := cfg.CommitCycle(ctx, hasMore, sd)
+		if err != nil {
+			return tx, err
+		}
+		if newTx != nil {
 			tx = newTx
 		}
 	}
@@ -193,7 +184,9 @@ func (pe *PipelineExecutor) ProcessFrozenBlocks(ctx context.Context, hook *stage
 	if err != nil {
 		return err
 	}
-	defer tx.Rollback()
+	// Closure form: CommitCycle reassigns tx across iterations, so we need
+	// to roll back the current value at function exit, not the original.
+	defer func() { tx.Rollback() }()
 
 	// Run snapshots stage — downloads block files.
 	if err = pe.sync.RunSnapshots(nil, tx); err != nil {
@@ -228,15 +221,28 @@ func (pe *PipelineExecutor) ProcessFrozenBlocks(ctx context.Context, hook *stage
 
 	tx, err = pe.RunLoop(ctx, doms, tx, RunLoopConfig{
 		InitialCycle: true,
-		FirstCycle:   false,
-		PruneTimeout: 0,
-		CommitCycle: func(ctx context.Context, sd *execctx.SharedDomains) (kv.TemporalRwTx, error) {
+		PruneFn: func(ctx context.Context, initialCycle bool, rwtx kv.TemporalRwTx, sd *execctx.SharedDomains) error {
+			return pe.sync.RunPrune(ctx, rwtx, initialCycle, 0)
+		},
+		CommitCycle: func(ctx context.Context, hasMore bool, sd *execctx.SharedDomains) (kv.TemporalRwTx, error) {
 			if err := sd.Flush(ctx, tx); err != nil {
 				return nil, fmt.Errorf("ProcessFrozenBlocks: flush: %w", err)
 			}
 			sd.ClearRam(true)
 			if err := tx.Commit(); err != nil {
 				return nil, err
+			}
+			// Prune runs via PruneFn (sync.RunPrune); kick file building so
+			// snapshot files advance as PFB processes frozen blocks.
+			if hasAgg, ok := pe.db.(dbstate.HasAgg); ok {
+				if agg, ok := hasAgg.Agg().(*dbstate.Aggregator); ok && agg != nil {
+					toTxNum := agg.EndTxNumMinimax() + agg.StepSize()
+					agg.BuildFilesInBackground(toTxNum)
+				}
+			}
+			// Last iter: skip BeginTemporalRw — no next iter will use it.
+			if !hasMore {
+				return nil, nil
 			}
 			newTx, err := pe.db.BeginTemporalRw(ctx) //nolint:gocritic
 			if err != nil {
@@ -259,14 +265,6 @@ func (pe *PipelineExecutor) ProcessFrozenBlocks(ctx context.Context, hook *stage
 	})
 	if err != nil {
 		return fmt.Errorf("ProcessFrozenBlocks: %w", err)
-	}
-
-	if err := doms.Flush(ctx, tx); err != nil {
-		return fmt.Errorf("ProcessFrozenBlocks: final flush: %w", err)
-	}
-	doms.ClearRam(true)
-	if err := tx.Commit(); err != nil {
-		return err
 	}
 
 	if hook != nil {

--- a/execution/execmodule/forkchoice.go
+++ b/execution/execmodule/forkchoice.go
@@ -466,19 +466,35 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 		}
 		rawdb.WriteHeadBlockHash(tx, blockHash)
 	}
-	// Run the forkchoice
-	initialCycle := limitedBigJump
-	firstCycle := false
+	// Run the forkchoice.
+	// TODO: rename initialCycle → atTip (inverted polarity) across stage/prune APIs.
+	initialCycle := time.Since(time.Unix(int64(fcuHeader.Time), 0)) > time.Duration(10*e.config.SecondsPerSlot())*time.Second
 
 	tx, err = e.pipelineExecutor.RunLoop(ctx, currentContext, tx, RunLoopConfig{
-		InitialCycle:    initialCycle,
-		FirstCycle:      firstCycle,
-		PruneTimeout:    500 * time.Millisecond,
-		BeforeIteration: nil,
-		CommitCycle: func(ctx context.Context, sd *execctx.SharedDomains) (kv.TemporalRwTx, error) {
-			// Release the old RO snapshot before the flush so MDBX can
-			// reclaim retired pages while the RwTx is writing.
+		InitialCycle: initialCycle,
+		PruneFn: func(ctx context.Context, initialCycle bool, rwtx kv.TemporalRwTx, sd *execctx.SharedDomains) error {
+			// Chain tip (!initialCycle): only one block per FCU, so skip the
+			// in-loop work entirely — the post-RunLoop path handles
+			// flush+commit+prune. In catchup, run on every iter so the last
+			// batch gets the in-loop furious prune treatment too.
+			if !initialCycle {
+				return nil
+			}
+			// Release the old RO snapshot so MDBX can reclaim retired pages.
 			roTx.Rollback()
+			// In-loop PruneExecutionStage no-ops on the overlay; drain here on
+			// a real RW tx. Force initialCycle=false to always use the
+			// furious-prune budget (CollateAndPruneIfNeeded, own RW tx).
+			if _, pruneErr := e.runForkchoicePrune(true); pruneErr != nil && !errors.Is(pruneErr, context.Canceled) {
+				e.logger.Warn("[commit-cycle] prune failed", "err", pruneErr)
+			}
+			return nil
+		},
+		CommitCycle: func(ctx context.Context, hasMore bool, sd *execctx.SharedDomains) (kv.TemporalRwTx, error) {
+			// Chain tip: post-RunLoop path commits.
+			if !initialCycle {
+				return nil, nil
+			}
 			commitRwTx, err := e.db.BeginTemporalRw(ctx) //nolint:gocritic
 			if err != nil {
 				return nil, fmt.Errorf("updateForkChoice: begin rw after hasMore: %w", err)
@@ -488,14 +504,10 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 				return nil, fmt.Errorf("updateForkChoice: flush sd after hasMore: %w", err)
 			}
 			sd.ClearRam(true)
-			if err = commitRwTx.Commit(); err != nil {
+			if err := commitRwTx.Commit(); err != nil {
 				return nil, fmt.Errorf("updateForkChoice: tx commit after hasMore: %w", err)
 			}
-			// In-loop PruneExecutionStage runs on the overlay (RO-backed
-			// MemoryMutation) and silently no-ops. Drain here on a real RW tx.
-			if _, pruneErr := e.runForkchoicePrune(initialCycle); pruneErr != nil && !errors.Is(pruneErr, context.Canceled) {
-				e.logger.Warn("[commit-cycle] prune failed", "err", pruneErr)
-			}
+			// Recreate RO tx + block overlay on the fresh committed state.
 			roTx, err = e.db.BeginTemporalRo(ctx) //nolint:gocritic
 			if err != nil {
 				return nil, fmt.Errorf("updateForkChoice: begin ro after hasMore: %w", err)

--- a/execution/execmodule/forkchoice.go
+++ b/execution/execmodule/forkchoice.go
@@ -468,23 +468,22 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 	}
 	// Run the forkchoice.
 	// TODO: rename initialCycle → atTip (inverted polarity) across stage/prune APIs.
-	initialCycle := time.Since(time.Unix(int64(fcuHeader.Time), 0)) > time.Duration(10*e.config.SecondsPerSlot())*time.Second
+	const smallBlockJumpThreshold = 16
+	headNum := fcuHeader.Number.Uint64()
+	initialCycle := headNum > finishProgressBefore && headNum-finishProgressBefore > smallBlockJumpThreshold
 
 	tx, err = e.pipelineExecutor.RunLoop(ctx, currentContext, tx, RunLoopConfig{
 		InitialCycle: initialCycle,
 		PruneFn: func(ctx context.Context, initialCycle bool, rwtx kv.TemporalRwTx, sd *execctx.SharedDomains) error {
-			// Chain tip (!initialCycle): only one block per FCU, so skip the
-			// in-loop work entirely — the post-RunLoop path handles
-			// flush+commit+prune. In catchup, run on every iter so the last
-			// batch gets the in-loop furious prune treatment too.
+			// Chain tip (!initialCycle): no in-loop work — post-RunLoop path
+			// handles flush+commit+prune.
 			if !initialCycle {
 				return nil
 			}
-			// Release the old RO snapshot so MDBX can reclaim retired pages.
+			// Catchup: drain pipeline prune on a real RW tx (own tx via
+			// UpdateTemporal in runForkchoicePrune). initialCycle=true so
+			// PruneExecutionStage uses the catchup budget.
 			roTx.Rollback()
-			// In-loop PruneExecutionStage no-ops on the overlay; drain here on
-			// a real RW tx. Force initialCycle=false to always use the
-			// furious-prune budget (CollateAndPruneIfNeeded, own RW tx).
 			if _, pruneErr := e.runForkchoicePrune(true); pruneErr != nil && !errors.Is(pruneErr, context.Canceled) {
 				e.logger.Warn("[commit-cycle] prune failed", "err", pruneErr)
 			}
@@ -807,18 +806,6 @@ func (e *ExecModule) runForkchoicePrune(initialCycle bool) ([]any, error) {
 	pruneStart := time.Now()
 	defer UpdateForkChoicePruneDuration(pruneStart)
 	if err := e.db.UpdateTemporal(e.bacgroundCtx, func(tx kv.TemporalRwTx) error {
-		// check that the current header isn't less than a step, this
-		// is mainly to prevent noise in testing on short chains with
-		// no snapshots and no need for pruning
-		currentHeader := rawdb.ReadCurrentHeader(tx)
-		if currentHeader == nil {
-			return nil
-		}
-		maxTxNum, err := rawdbv3.TxNums.Max(e.bacgroundCtx, tx, currentHeader.Number.Uint64())
-		if err != nil || maxTxNum < (tx.Debug().StepSize()*5)/4 {
-			return nil
-		}
-
 		pruneTimeout := time.Duration(e.config.SecondsPerSlot()*1000/3) * time.Millisecond / 2
 		if err := e.pipelineExecutor.RunPrune(e.bacgroundCtx, tx, initialCycle, pruneTimeout); err != nil {
 			return err

--- a/execution/execmodule/forkchoice.go
+++ b/execution/execmodule/forkchoice.go
@@ -494,12 +494,12 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 			if !initialCycle {
 				return nil, nil
 			}
-			commitRwTx, err := e.db.BeginTemporalRw(ctx) //nolint:gocritic
+			commitRwTx, err := e.db.BeginTemporalRw(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("updateForkChoice: begin rw after hasMore: %w", err)
 			}
+			defer commitRwTx.Rollback() // safety net; idempotent after successful Commit
 			if err := sd.Flush(ctx, commitRwTx); err != nil {
-				commitRwTx.Rollback()
 				return nil, fmt.Errorf("updateForkChoice: flush sd after hasMore: %w", err)
 			}
 			sd.ClearRam(true)


### PR DESCRIPTION
Manual reapply of #21245 (runloop refactor: split prune from commit-cycle) onto the `performance` branch, plus follow-up fixes for the post-frozen-blocks prune-budget regression observed on bloatnet.

## Changes

- **Split `CommitCycleFn` from `PruneFn`** in `RunLoopConfig`; drop `BeforeIteration`/`PruneTimeout`/`FirstCycle`.
- **`ProcessFrozenBlocks`**: kicks `agg.BuildFilesInBackground` from the new `CommitCycle` callback so snapshot files advance during PFB (previously they only progressed after normal sync resumed). On the last iter (`!hasMore`) returns `(nil, nil)` to skip a wasted `BeginTemporalRw`. Outer `defer tx.Rollback()` is closure-form so it follows the closure's `tx` reassignments across iterations.
- **`updateForkChoice`**: `PruneFn` is a no-op at tip (post-RunLoop path handles flush+commit+prune); in catchup it drains pipeline prune via `runForkchoicePrune(true)` — `initialCycle=true` so `PruneExecutionStage` gets the catchup budget instead of the 2 s slot budget that can't keep up with 40-block bursts.
- **`initialCycle` predicate** — block-count delta against `finishProgressBefore`:
  ```go
  const smallBlockJumpThreshold = 16
  headNum := fcuHeader.Number.Uint64()
  initialCycle := headNum > finishProgressBefore && headNum-finishProgressBefore > smallBlockJumpThreshold
  ```
  The `headNum >` guard avoids `uint64` underflow when an FCU goes back (e.g. ePBS on Glamsterdam). Threshold 16 engages catchup mode for bloatnet's ~40-block bursts and stays out of the way for steady-state 1-block tip FCUs and test fixtures.
- **`runForkchoicePrune`**: short-chain skip-gate removed (`maxTxNum < (stepSize*5)/4`). The gate left `ChangeSets3` un-pruned on disk for short chains, which broke `MaxReorgDepth` enforcement in tests (`TestFcuReturnsReorgTooDeepCode38006` on the upstream `main` branch). Skip removal is also consistent with the `exec3/storage-component` direction (`c380b438e7`).
- **FCU `CommitCycle` safety**: `defer commitRwTx.Rollback()` immediately after `BeginTemporalRw` so the Commit-error path doesn't leak the RW tx. Rollback after a successful Commit is idempotent (per Copilot review on #21245).

## Why the predicate change matters — bloatnet

bloatnet stabilises at ~38 GB on tip only when `initialCycle=false` is held until execution actually reaches tip:

- A 40-block batch (what `--batchSize=100mb` settles on) writes ~1.4 GB into MDBX (lots of commitment trie changes).
- At-tip prune budget (`SecondsPerSlot/3` ≈ 2 s) removes less than one such batch.
- Flipping too early — while bursts are still arriving — lets writes outrun prune and MDBX runs away.

The earlier `!isSynced` and `wall-clock head-age` variants either flipped too eagerly (Caplin keeps headers/finish aligned during bursts) or never (test fixtures use ancient timestamps, regressing several rpc/jsonrpc + engineapi tests). Block-count delta with threshold 16 is a clean proxy and works for tests, mainnet tip, and bloatnet bursts.

| Cycle | Agg | Prune | initialCycle | db_size after |
|---|---|---|---|---|
| 1 | 2m12s | 39.3s | true | 36.29 GB |
| 2 | 2m23s | 34.6s | true | 36.57 GB |
| 3 | 2m24s | 38.6s | true | 36.76 GB |

Plateau holds across cycles vs. the prior failure mode where the file extended +6 GB/cycle once the predicate flipped early.

## Remaining differences vs #21245 (intentional)

- `Aggregator.MaxCollationTxNum()` getter and the `BuildFilesInBackground` cap pattern from #21245 are NOT ported here — the underlying `maxCollationTxNum` field doesn't exist on the `performance` branch lineage. Followup, requires also adding the field on this branch.
- `runForkchoicePrune` body uses `e.db.UpdateTemporal(...)` directly (matches this branch's storage design — `agg.CollateAndPruneIfNeeded` ownership is being moved out of the FCU path on the `exec3/storage-component` track), whereas #21245 still calls `CollateAndPruneIfNeeded` via this function.

## Test plan

- [ ] CI green on rerun (race-tests / tests-mac-linux all OSes; sonar).
- [x] Bloatnet → chain-tip; db_size stays bounded.
- [ ] Once at tip, confirm block-count delta predicate flips `initialCycle=false` for steady-state 1-block FCUs.
- [ ] Sanity-check mainnet behaviour (FCU bursts ≤16 blocks at tip).