### PR TITLE
execution/engineapi/engineapitester: respect caller deadline in RetryEngine

### DIFF
--- a/execution/engineapi/engineapitester/mock_cl.go
+++ b/execution/engineapi/engineapitester/mock_cl.go
@@ -321,9 +321,17 @@ func RetryEngine[T any](ctx context.Context, retryStatuses []enginetypes.EngineS
 		}
 		return res, nil
 	}
-	// don't retry for too long
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
-	defer cancel()
+	// Honour the caller's deadline if it has one (test contexts carry
+	// the -timeout flag). Without this, slow CI environments — especially
+	// -race + GOMAXPROCS<=2 on the 4-vCPU GHA runner — hit the cap on
+	// high-mgas blocks (TestInvalidReceiptHashHighMgas) before the engine
+	// returns Valid. Absent any caller deadline, cap at 30 min so a stuck
+	// engine still fails the test rather than hanging.
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, 30*time.Minute)
+		defer cancel()
+	}
 	var backOff backoff.BackOff
 	backOff = backoff.NewConstantBackOff(50 * time.Millisecond)
 	backOff = backoff.WithContext(backOff, ctx)


### PR DESCRIPTION
## Summary

The hard-coded `10*time.Minute` cap in `RetryEngine` truncated the caller's context even when the test passed one with a longer deadline. Under `-race + GOMAXPROCS<=2` on the 4-vCPU GHA runner, the high-mgas payload in `TestInvalidReceiptHashHighMgas` takes >10 min to validate; the engine keeps returning `SYNCING` and the retry context expires before the engine reports `Valid`.

CI repro: subtest ran 677s before `context deadline exceeded`. Test timeout was 60 min; only the inner cap was tight.

## Fix

Honour the caller's deadline if one is set. Fall back to 30 min only when the caller passed an unbounded context. Test callers pass `t.Context()` carrying the `-timeout` flag; the lone non-test caller (`cmd/evm/enginexrunner.go`) passes an unbounded context and uses the 30-min fallback (up from 10 min).

## Test plan

- [x] `make lint` clean
- [x] `make erigon` builds
- [ ] CI green on `race-tests / tests-linux (execution-tests, parallel)`