### PR TITLE
ci(docs): name disk-sizes commit author per workflow run

### DIFF
--- a/.github/workflows/update-disk-sizes.yml
+++ b/.github/workflows/update-disk-sizes.yml
@@ -162,9 +162,11 @@ jobs:
 
       - name: Configure git
         if: steps.diff.outputs.changed == 'true'
+        env:
+          RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
-          git config user.name "github-actions[bot]"
+          git config user.name "github-workflow-update-disk-sizes-run-${RUN_ID}"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Commit and push to update branch


### PR DESCRIPTION
## Summary

Addresses [lystopad's review comment](https://github.com/erigontech/erigon/pull/21100#discussion_r4293085954) on #21100, which merged before it could be addressed.

The `Configure git` step in `update-disk-sizes.yml` was using the generic `github-actions[bot]` author. Lystopad's feedback:

> Please, use another name here which would clearly points to this workflow. For example something like:
> ```
> git config user.name "github-workflow-update-disk-sizes-run-${RUN_ID}"
> ```
> Otherwise it would be hard to understand source of the change in target repo.

## What changed

`.github/workflows/update-disk-sizes.yml` — `Configure git` step:

```diff
       - name: Configure git
         if: steps.diff.outputs.changed == 'true'
+        env:
+          RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
-          git config user.name "github-actions[bot]"
+          git config user.name "github-workflow-update-disk-sizes-run-${RUN_ID}"
           git config user.email "github-actions[bot]@users.noreply.github.com"
```

- **Name change**: `github-actions[bot]` → `github-workflow-update-disk-sizes-run-<run-id>`. The auto-update commit now names the specific workflow and the exact run, so anyone investigating the commit in the target repo can jump straight to the run that produced it.
- **`RUN_ID` propagated via `env:` block**, consistent with the rest of the workflow's anti-template-injection pattern (no template substitution into shell).
- **`user.email` unchanged** — `github-actions[bot]@users.noreply.github.com` still keeps the commit attributed to the bot. Lystopad's suggestion only addressed `user.name`.

## Test plan

- [x] YAML syntax check (`yamllint`-style by visual inspection — single `env:` insertion)
- [ ] First `update-disk-sizes` workflow run after merge: confirm the produced `chore(docs): auto-update measured disk sizes` commit has author `github-workflow-update-disk-sizes-run-<id>` (where `<id>` matches the workflow run ID linked from the commit annotation)

Related: #21100, #21271