### PR TITLE
ethash: clean temp mmap artifacts on generation failure

### DIFF
--- a/execution/protocol/rules/ethash/ethash.go
+++ b/execution/protocol/rules/ethash/ethash.go
@@ -184,18 +184,18 @@ func memoryMapAndGenerate(path string, size uint64, lock bool, generator func(bu
 	data := buffer[len(dumpMagic):]
 	generator(data)
 
-	// Nil out mem/dump immediately after release so the deferred cleanup
-	// doesn't re-invoke Unmap/Close on a handle in an undefined state.
-	unmapErr := mem.Unmap()
+	// On error, leave mem/dump non-nil so the deferred cleanup retries
+	// Unmap/Close before RemoveFile — Windows refuses to unlink a file that
+	// is still mapped or open, so a retry can be the difference between a
+	// cleaned temp file and a leak.
+	if err := mem.Unmap(); err != nil {
+		return nil, nil, nil, err
+	}
 	mem = nil
-	if unmapErr != nil {
-		return nil, nil, nil, unmapErr
+	if err := dump.Close(); err != nil {
+		return nil, nil, nil, err
 	}
-	closeErr := dump.Close()
 	dump = nil
-	if closeErr != nil {
-		return nil, nil, nil, closeErr
-	}
 	if err := os.Rename(temp, path); err != nil {
 		return nil, nil, nil, err
 	}

--- a/execution/protocol/rules/ethash/ethash.go
+++ b/execution/protocol/rules/ethash/ethash.go
@@ -156,13 +156,27 @@ func memoryMapAndGenerate(path string, size uint64, lock bool, generator func(bu
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	cleanup := true
+	var mem mmap.MMap
+	defer func() {
+		if !cleanup {
+			return
+		}
+		if mem != nil {
+			_ = mem.Unmap()
+		}
+		if dump != nil {
+			_ = dump.Close()
+		}
+		_ = os.Remove(temp)
+	}()
 	if err = dump.Truncate(int64(len(dumpMagic))*4 + int64(size)); err != nil {
 		return nil, nil, nil, err
 	}
 	// Memory map the file for writing and fill it with the generator
-	mem, buffer, err := memoryMapFile(dump, true)
+	buffer := []uint32(nil)
+	mem, buffer, err = memoryMapFile(dump, true)
 	if err != nil {
-		dump.Close()
 		return nil, nil, nil, err
 	}
 	copy(buffer, dumpMagic)
@@ -173,12 +187,15 @@ func memoryMapAndGenerate(path string, size uint64, lock bool, generator func(bu
 	if err := mem.Unmap(); err != nil {
 		return nil, nil, nil, err
 	}
+	mem = nil
 	if err := dump.Close(); err != nil {
 		return nil, nil, nil, err
 	}
+	dump = nil
 	if err := os.Rename(temp, path); err != nil {
 		return nil, nil, nil, err
 	}
+	cleanup = false
 	return memoryMap(path, lock)
 }
 

--- a/execution/protocol/rules/ethash/ethash.go
+++ b/execution/protocol/rules/ethash/ethash.go
@@ -168,7 +168,7 @@ func memoryMapAndGenerate(path string, size uint64, lock bool, generator func(bu
 		if dump != nil {
 			_ = dump.Close()
 		}
-		_ = os.Remove(temp)
+		_ = dir2.RemoveFile(temp)
 	}()
 	if err = dump.Truncate(int64(len(dumpMagic))*4 + int64(size)); err != nil {
 		return nil, nil, nil, err
@@ -184,14 +184,18 @@ func memoryMapAndGenerate(path string, size uint64, lock bool, generator func(bu
 	data := buffer[len(dumpMagic):]
 	generator(data)
 
-	if err := mem.Unmap(); err != nil {
-		return nil, nil, nil, err
-	}
+	// Nil out mem/dump immediately after release so the deferred cleanup
+	// doesn't re-invoke Unmap/Close on a handle in an undefined state.
+	unmapErr := mem.Unmap()
 	mem = nil
-	if err := dump.Close(); err != nil {
-		return nil, nil, nil, err
+	if unmapErr != nil {
+		return nil, nil, nil, unmapErr
 	}
+	closeErr := dump.Close()
 	dump = nil
+	if closeErr != nil {
+		return nil, nil, nil, closeErr
+	}
 	if err := os.Rename(temp, path); err != nil {
 		return nil, nil, nil, err
 	}

--- a/execution/protocol/rules/ethash/ethash_test.go
+++ b/execution/protocol/rules/ethash/ethash_test.go
@@ -20,6 +20,7 @@
 package ethash
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -131,6 +132,13 @@ func TestMemoryMapAndGenerateCleansTempFileOnRenameFailure(t *testing.T) {
 	_, _, _, err := memoryMapAndGenerate(path, 1024, false, func(buffer []uint32) {})
 	if err == nil {
 		t.Fatal("expected rename failure, got nil")
+	}
+	// Pin the failure to os.Rename so the test fails loudly if a future change
+	// shifts the failure to an earlier step (Create/Truncate/mmap) — the cleanup
+	// path under test is the post-rename one.
+	var linkErr *os.LinkError
+	if !errors.As(err, &linkErr) || linkErr.Op != "rename" {
+		t.Fatalf("expected *os.LinkError with Op=rename, got: %v", err)
 	}
 
 	temps, globErr := filepath.Glob(path + ".*")

--- a/execution/protocol/rules/ethash/ethash_test.go
+++ b/execution/protocol/rules/ethash/ethash_test.go
@@ -20,6 +20,8 @@
 package ethash
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -114,5 +116,28 @@ func TestClosedRemoteSealer(t *testing.T) {
 
 	if res := api.SubmitHashRate(hexutil.Uint64(100), common.HexToHash("a")); res {
 		t.Error("expect to return false when submit hashrate to a stopped ethash")
+	}
+}
+
+func TestMemoryMapAndGenerateCleansTempFileOnRenameFailure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "target")
+
+	// Force rename failure by making the destination path a directory.
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatalf("failed to create destination directory: %v", err)
+	}
+
+	_, _, _, err := memoryMapAndGenerate(path, 1024, false, func(buffer []uint32) {})
+	if err == nil {
+		t.Fatal("expected rename failure, got nil")
+	}
+
+	temps, globErr := filepath.Glob(path + ".*")
+	if globErr != nil {
+		t.Fatalf("glob failed: %v", globErr)
+	}
+	if len(temps) != 0 {
+		t.Fatalf("temporary files were not cleaned up: %v", temps)
 	}
 }


### PR DESCRIPTION
Ensure memoryMapAndGenerate always unmaps, closes, and removes temp files on failure paths, preventing temp-file residue and handle leaks under I/O errors.