### PR TITLE
execution/protocol/rules/ethash: drop in-memory + on-disk cache

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -150,25 +150,6 @@ var (
 		Name:  "trusted-setup-file",
 		Usage: "Absolute path to trusted_setup.json file",
 	}
-	// Ethash settings
-	EthashCachesInMemoryFlag = cli.IntFlag{
-		Name:  "ethash.cachesinmem",
-		Usage: "Number of recent ethash caches to keep in memory (16MB each)",
-		Value: ethconfig.Defaults.Ethash.CachesInMem,
-	}
-	EthashCachesLockMmapFlag = cli.BoolFlag{
-		Name:  "ethash.cacheslockmmap",
-		Usage: "Lock memory maps of recent ethash caches",
-	}
-	EthashDatasetDirFlag = flags.DirectoryFlag{
-		Name:  "ethash.dagdir",
-		Usage: "Directory to store the ethash mining DAGs",
-		Value: flags.DirectoryString(ethconfig.Defaults.Ethash.DatasetDir),
-	}
-	EthashDatasetsLockMmapFlag = cli.BoolFlag{
-		Name:  "ethash.dagslockmmap",
-		Usage: "Lock memory maps for recent ethash mining DAGs",
-	}
 	ExternalConsensusFlag = cli.BoolFlag{
 		Name:  "externalcl",
 		Usage: "Enables the external consensus layer",
@@ -1684,23 +1665,9 @@ func setShutter(ctx *cli.Context, chainName string, nodeConfig *nodecfg.Config, 
 	ethConfig.Shutter = config
 }
 
-func setEthash(ctx *cli.Context, datadir string, cfg *ethconfig.Config) {
-	if ctx.IsSet(EthashDatasetDirFlag.Name) {
-		cfg.Ethash.DatasetDir = ctx.String(EthashDatasetDirFlag.Name)
-	} else {
-		cfg.Ethash.DatasetDir = filepath.Join(datadir, "ethash-dags")
-	}
-	if ctx.IsSet(EthashCachesInMemoryFlag.Name) {
-		cfg.Ethash.CachesInMem = ctx.Int(EthashCachesInMemoryFlag.Name)
-	}
-	if ctx.IsSet(EthashCachesLockMmapFlag.Name) {
-		cfg.Ethash.CachesLockMmap = ctx.Bool(EthashCachesLockMmapFlag.Name)
-	}
+func setEthash(ctx *cli.Context, cfg *ethconfig.Config) {
 	if ctx.IsSet(FakePoWFlag.Name) {
 		cfg.Ethash.PowMode = ethashcfg.ModeFake
-	}
-	if ctx.IsSet(EthashDatasetsLockMmapFlag.Name) {
-		cfg.Ethash.DatasetsLockMmap = ctx.Bool(EthashDatasetsLockMmapFlag.Name)
 	}
 }
 
@@ -1978,7 +1945,7 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 	setTxPool(ctx, nodeConfig.Dirs.TxPool, cfg)
 	setShutter(ctx, chain, nodeConfig, cfg)
 
-	setEthash(ctx, nodeConfig.Dirs.DataDir, cfg)
+	setEthash(ctx, cfg)
 	setBuilder(ctx, &cfg.Builder)
 	setWhitelist(ctx, cfg)
 	setBorConfig(ctx, cfg, nodeConfig, logger)

--- a/execution/protocol/rules/ethash/algorithm.go
+++ b/execution/protocol/rules/ethash/algorithm.go
@@ -55,6 +55,13 @@ const (
 	loopAccesses       = 64      // Number of accesses in hashimoto loop
 )
 
+// isLittleEndian returns whether the local system is running in little or big
+// endian byte order.
+func isLittleEndian() bool {
+	n := uint32(0x01020304)
+	return *(*byte)(unsafe.Pointer(&n)) == 0x04
+}
+
 // cacheSize returns the size of the ethash verification cache that belongs to a certain
 // block number.
 func cacheSize(block uint64) uint64 {

--- a/execution/protocol/rules/ethash/algorithm_test.go
+++ b/execution/protocol/rules/ethash/algorithm_test.go
@@ -27,8 +27,6 @@ import (
 	"testing"
 
 	"github.com/erigontech/erigon/common/hexutil"
-
-	"github.com/erigontech/erigon/common/length"
 )
 
 // prepare converts an ethash cache or dataset from a byte stream into the internal
@@ -739,26 +737,6 @@ func BenchmarkHashimotoFullSmall(b *testing.B) {
 	for b.Loop() {
 		hashimotoFull(dataset, hash, 0)
 	}
-}
-
-func benchmarkHashimotoFullMmap(b *testing.B, name string, lock bool) {
-	b.Run(name, func(b *testing.B) {
-		tmpdir := b.TempDir()
-		d := &dataset{epoch: 0}
-		d.generate(tmpdir, 1, lock, testing.Short())
-		var hash [length.Hash]byte
-		b.ResetTimer()
-		for i := 0; b.Loop(); i++ {
-			binary.PutVarint(hash[:], int64(i))
-			hashimotoFull(d.dataset, hash[:], 0)
-		}
-	})
-}
-
-// Benchmarks the full verification performance for mmap
-func BenchmarkHashimotoFullMmap(b *testing.B) {
-	benchmarkHashimotoFullMmap(b, "WithLock", true)
-	benchmarkHashimotoFullMmap(b, "WithoutLock", false)
 }
 
 func BenchmarkSeedHash(b *testing.B) {

--- a/execution/protocol/rules/ethash/ethash.go
+++ b/execution/protocol/rules/ethash/ethash.go
@@ -21,26 +21,11 @@
 package ethash
 
 import (
-	"errors"
-	"fmt"
 	"math/big"
 	"math/rand"
-	"os"
-	"path/filepath"
-	"reflect"
-	"runtime"
-	"strconv"
 	"sync"
-	"sync/atomic"
-	"unsafe"
 
-	"github.com/edsrzf/mmap-go"
-	"github.com/hashicorp/golang-lru/v2/simplelru"
-
-	"github.com/erigontech/erigon/common/dbg"
-	dir2 "github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/log/v3"
-	"github.com/erigontech/erigon/common/math"
 	"github.com/erigontech/erigon/execution/protocol/misc"
 	"github.com/erigontech/erigon/execution/protocol/rules"
 	"github.com/erigontech/erigon/execution/protocol/rules/ethash/ethashcfg"
@@ -49,10 +34,6 @@ import (
 	"github.com/erigontech/erigon/rpc"
 )
 
-const doNotStoreCachesOnDisk = ""
-
-var ErrInvalidDumpMagic = errors.New("invalid dump magic")
-
 var (
 	// two256 is a big integer representing 2^256
 	two256 = new(big.Int).Exp(big.NewInt(2), big.NewInt(256), big.NewInt(0))
@@ -60,359 +41,19 @@ var (
 	// sharedEthash is a full instance that can be shared between multiple users.
 	sharedEthashOnce sync.Once
 	sharedEthash     *Ethash
-
-	// algorithmRevision is the data structure version used for file naming.
-	algorithmRevision = 23
-
-	// dumpMagic is a dataset dump header to sanity check a data dump.
-	dumpMagic = []uint32{0xbaddcafe, 0xfee1dead}
 )
 
-// sharedEthash is a full instance that can be shared between multiple users.
+// GetSharedEthash returns a process-wide shared Ethash instance.
 func GetSharedEthash() *Ethash {
 	sharedEthashOnce.Do(func() {
-		sharedConfig := ethashcfg.Config{
-			PowMode:       ethashcfg.ModeNormal,
-			CachesInMem:   3,
-			DatasetsInMem: 1,
-		}
-		sharedEthash = New(sharedConfig, false)
+		sharedEthash = New(ethashcfg.Config{PowMode: ethashcfg.ModeNormal}, false)
 	})
 	return sharedEthash
-}
-
-// isLittleEndian returns whether the local system is running in little or big
-// endian byte order.
-func isLittleEndian() bool {
-	n := uint32(0x01020304)
-	return *(*byte)(unsafe.Pointer(&n)) == 0x04
-}
-
-// memoryMap tries to memory map a file of uint32s for read only access.
-func memoryMap(path string, lock bool) (*os.File, mmap.MMap, []uint32, error) {
-	file, err := os.OpenFile(path, os.O_RDONLY, 0644)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	mem, buffer, err := memoryMapFile(file, false)
-	if err != nil {
-		file.Close()
-		return nil, nil, nil, err
-	}
-	for i, magic := range dumpMagic {
-		if buffer[i] != magic {
-			mem.Unmap()
-			file.Close()
-			return nil, nil, nil, ErrInvalidDumpMagic
-		}
-	}
-	if lock {
-		if err2 := mem.Lock(); err2 != nil {
-			mem.Unmap() //nolint:errcheck
-			file.Close()
-			return nil, nil, nil, err2
-		}
-	}
-	return file, mem, buffer[len(dumpMagic):], err
-}
-
-// memoryMapFile tries to memory map an already opened file descriptor.
-func memoryMapFile(file *os.File, write bool) (mmap.MMap, []uint32, error) {
-	// Try to memory map the file
-	flag := mmap.RDONLY
-	if write {
-		flag = mmap.RDWR
-	}
-	mem, err := mmap.Map(file, flag, 0)
-	if err != nil {
-		return nil, nil, err
-	}
-	// The file is now memory-mapped. Create a []uint32 view of the file.
-	var view []uint32
-	header := (*reflect.SliceHeader)(unsafe.Pointer(&view))
-	header.Data = (*reflect.SliceHeader)(unsafe.Pointer(&mem)).Data
-	header.Len = len(mem) / 4
-	header.Cap = cap(mem) / 4
-
-	return mem, view, nil
-}
-
-// memoryMapAndGenerate tries to memory map a temporary file of uint32s for write
-// access, fill it with the data from a generator and then move it into the final
-// path requested.
-func memoryMapAndGenerate(path string, size uint64, lock bool, generator func(buffer []uint32)) (*os.File, mmap.MMap, []uint32, error) {
-	// Ensure the data folder exists
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return nil, nil, nil, err
-	}
-	suffix, err := math.RandInt64()
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to get random integer: %v", err)
-	}
-	// Create a huge temporary empty file to fill with data
-	temp := path + "." + strconv.Itoa(int(suffix))
-
-	dump, err := os.Create(temp)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	if err = dump.Truncate(int64(len(dumpMagic))*4 + int64(size)); err != nil {
-		return nil, nil, nil, err
-	}
-	// Memory map the file for writing and fill it with the generator
-	mem, buffer, err := memoryMapFile(dump, true)
-	if err != nil {
-		dump.Close()
-		return nil, nil, nil, err
-	}
-	copy(buffer, dumpMagic)
-
-	data := buffer[len(dumpMagic):]
-	generator(data)
-
-	if err := mem.Unmap(); err != nil {
-		return nil, nil, nil, err
-	}
-	if err := dump.Close(); err != nil {
-		return nil, nil, nil, err
-	}
-	if err := os.Rename(temp, path); err != nil {
-		return nil, nil, nil, err
-	}
-	return memoryMap(path, lock)
-}
-
-// lru tracks caches or datasets by their last use time, keeping at most N of them.
-type lru struct {
-	what string
-	new  func(epoch uint64) any
-	mu   sync.Mutex
-	// Items are kept in a LRU cache, but there is a special case:
-	// We always keep an item for (highest seen epoch) + 1 as the 'future item'.
-	cache      *simplelru.LRU[uint64, any]
-	future     uint64
-	futureItem any
-}
-
-// newlru create a new least-recently-used cache for either the verification caches
-// or the mining datasets.
-func newlru(what string, maxItems int, new func(epoch uint64) any) *lru {
-	if maxItems <= 0 {
-		maxItems = 1
-	}
-	cache, _ := simplelru.NewLRU[uint64, any](maxItems, func(key uint64, value any) {
-		log.Trace("Evicted ethash "+what, "epoch", key)
-	})
-	return &lru{what: what, new: new, cache: cache}
-}
-
-// get retrieves or creates an item for the given epoch. The first return value is always
-// non-nil. The second return value is non-nil if lru thinks that an item will be useful in
-// the near future.
-func (lru *lru) get(epoch uint64) (item, future any) {
-	lru.mu.Lock()
-	defer lru.mu.Unlock()
-
-	// Get or create the item for the requested epoch.
-	item, ok := lru.cache.Get(epoch)
-	if !ok {
-		if lru.future > 0 && lru.future == epoch {
-			item = lru.futureItem
-		} else {
-			log.Trace("Requiring new ethash "+lru.what, "epoch", epoch)
-			item = lru.new(epoch)
-		}
-		lru.cache.Add(epoch, item)
-	}
-	// Update the 'future item' if epoch is larger than previously seen.
-	if epoch < maxEpoch-1 && lru.future < epoch+1 {
-		log.Trace("Requiring new future ethash "+lru.what, "epoch", epoch+1)
-		future = lru.new(epoch + 1)
-		lru.future = epoch + 1
-		lru.futureItem = future
-	}
-	return item, future
-}
-
-// cache wraps an ethash cache with some metadata to allow easier concurrent use.
-type cache struct {
-	epoch uint64    // Epoch for which this cache is relevant
-	dump  *os.File  // File descriptor of the memory mapped cache
-	mmap  mmap.MMap // Memory map itself to unmap before releasing
-	cache []uint32  // The actual cache data content (may be memory mapped)
-	once  sync.Once // Ensures the cache is generated only once
-}
-
-// newCache creates a new ethash verification cache and returns it as a plain Go
-// interface to be usable in an LRU cache.
-func newCache(epoch uint64) any {
-	return &cache{epoch: epoch}
-}
-
-// generate ensures that the cache content is generated before use.
-func (c *cache) generate(dir string, limit int, lock bool, test bool) {
-	c.once.Do(func() {
-		defer dbg.LogPanic()
-		size := cacheSize(c.epoch*epochLength + 1)
-		seed := seedHash(c.epoch*epochLength + 1)
-		if test {
-			size = 1024
-		}
-		// If we don't store anything on disk, generate and return.
-		if dir == "" {
-			c.cache = make([]uint32, size/4)
-			generateCache(c.cache, c.epoch, seed)
-			return
-		}
-		// Disk storage is needed, this will get fancy
-		var endian string
-		if !isLittleEndian() {
-			endian = ".be"
-		}
-		path := filepath.Join(dir, fmt.Sprintf("cache-R%d-%x%s", algorithmRevision, seed[:8], endian))
-		logger := log.New("epoch", c.epoch)
-
-		// We're about to mmap the file, ensure that the mapping is cleaned up when the
-		// cache becomes unused.
-		runtime.SetFinalizer(c, (*cache).finalizer)
-
-		// Try to load the file from disk and memory map it
-		var err error
-		c.dump, c.mmap, c.cache, err = memoryMap(path, lock)
-		if err == nil {
-			logger.Debug("Loaded old ethash cache from disk")
-			return
-		}
-		logger.Debug("Failed to load old ethash cache", "err", err)
-
-		// No previous cache available, create a new cache file to fill
-		c.dump, c.mmap, c.cache, err = memoryMapAndGenerate(path, size, lock, func(buffer []uint32) { generateCache(buffer, c.epoch, seed) })
-		if err != nil {
-			logger.Error("Failed to generate mapped ethash cache", "err", err)
-
-			c.cache = make([]uint32, size/4)
-			generateCache(c.cache, c.epoch, seed)
-		}
-		// Iterate over all previous instances and delete old ones
-		for ep := int(c.epoch) - limit; ep >= 0; ep-- {
-			seed := seedHash(uint64(ep)*epochLength + 1)
-			path := filepath.Join(dir, fmt.Sprintf("cache-R%d-%x%s", algorithmRevision, seed[:8], endian))
-			dir2.RemoveFile(path)
-		}
-	})
-}
-
-// finalizer unmaps the memory and closes the file.
-func (c *cache) finalizer() {
-	if c.mmap != nil {
-		c.mmap.Unmap()
-		c.dump.Close()
-		c.mmap, c.dump = nil, nil
-	}
-}
-
-// dataset wraps an ethash dataset with some metadata to allow easier concurrent use.
-type dataset struct {
-	epoch   uint64      // Epoch for which this cache is relevant
-	dump    *os.File    // File descriptor of the memory mapped cache
-	mmap    mmap.MMap   // Memory map itself to unmap before releasing
-	dataset []uint32    // The actual cache data content
-	once    sync.Once   // Ensures the cache is generated only once
-	done    atomic.Bool // Atomic flag to determine generation status
-}
-
-// newDataset creates a new ethash mining dataset and returns it as a plain Go
-// interface to be usable in an LRU cache.
-func newDataset(epoch uint64) any {
-	return &dataset{epoch: epoch}
-}
-
-// generate ensures that the dataset content is generated before use.
-func (d *dataset) generate(dir string, limit int, lock bool, test bool) {
-	d.once.Do(func() {
-		// Mark the dataset generated after we're done. This is needed for remote
-		defer d.done.Store(true)
-
-		csize := cacheSize(d.epoch*epochLength + 1)
-		dsize := datasetSize(d.epoch*epochLength + 1)
-		seed := seedHash(d.epoch*epochLength + 1)
-		if test {
-			csize = 1024
-			dsize = 32 * 1024
-		}
-		// If we don't store anything on disk, generate and return
-		if dir == "" {
-			cache := make([]uint32, csize/4)
-			generateCache(cache, d.epoch, seed)
-
-			d.dataset = make([]uint32, dsize/4)
-			generateDataset(d.dataset, d.epoch, cache)
-
-			return
-		}
-		// Disk storage is needed, this will get fancy
-		var endian string
-		if !isLittleEndian() {
-			endian = ".be"
-		}
-		path := filepath.Join(dir, fmt.Sprintf("full-R%d-%x%s", algorithmRevision, seed[:8], endian))
-		logger := log.New("epoch", d.epoch)
-
-		// We're about to mmap the file, ensure that the mapping is cleaned up when the
-		// cache becomes unused.
-		runtime.SetFinalizer(d, (*dataset).finalizer)
-
-		// Try to load the file from disk and memory map it
-		var err error
-		d.dump, d.mmap, d.dataset, err = memoryMap(path, lock)
-		if err == nil {
-			logger.Debug("Loaded old ethash dataset from disk")
-			return
-		}
-		logger.Debug("Failed to load old ethash dataset", "err", err)
-
-		// No previous dataset available, create a new dataset file to fill
-		cache := make([]uint32, csize/4)
-		generateCache(cache, d.epoch, seed)
-
-		d.dump, d.mmap, d.dataset, err = memoryMapAndGenerate(path, dsize, lock, func(buffer []uint32) { generateDataset(buffer, d.epoch, cache) })
-		if err != nil {
-			logger.Error("Failed to generate mapped ethash dataset", "err", err)
-
-			d.dataset = make([]uint32, dsize/2)
-			generateDataset(d.dataset, d.epoch, cache)
-		}
-		// Iterate over all previous instances and delete old ones
-		for ep := int(d.epoch) - limit; ep >= 0; ep-- {
-			seed := seedHash(uint64(ep)*epochLength + 1)
-			path := filepath.Join(dir, fmt.Sprintf("full-R%d-%x%s", algorithmRevision, seed[:8], endian))
-			dir2.RemoveFile(path)
-		}
-	})
-}
-
-// generated returns whether this particular dataset finished generating already
-// or not (it may not have been started at all). This is useful for remote miners
-// to default to verification caches instead of blocking on DAG generations.
-func (d *dataset) generated() bool {
-	return d.done.Load()
-}
-
-// finalizer closes any file handlers and memory maps open.
-func (d *dataset) finalizer() {
-	if d.mmap != nil {
-		d.mmap.Unmap()
-		d.dump.Close()
-		d.mmap, d.dump = nil, nil
-	}
 }
 
 // Ethash is a rules engine based on proof-of-work implementing the ethash algorithm.
 type Ethash struct {
 	config ethashcfg.Config
-
-	caches   *lru // In memory caches to avoid regenerating too often
-	datasets *lru // In memory datasets to avoid regenerating too often
 
 	// Mining related fields
 	rand     *rand.Rand     // Properly seeded random source for nonces
@@ -422,7 +63,7 @@ type Ethash struct {
 	// The fields below are hooks for testing
 	shared *Ethash // Shared PoW verifier to avoid cache regeneration
 
-	lock      sync.Mutex // Ensures thread safety for the in-memory caches and mining fields
+	lock      sync.Mutex // Ensures thread safety for the mining fields
 	closeOnce sync.Once  // Ensures exit channel will not be closed twice.
 }
 
@@ -433,17 +74,8 @@ func New(config ethashcfg.Config, noverify bool) *Ethash {
 	if config.Log == nil {
 		config.Log = log.Root()
 	}
-	if config.CachesInMem <= 0 {
-		config.Log.Warn("One ethash cache must always be in memory", "requested", config.CachesInMem)
-		config.CachesInMem = 1
-	}
-	if config.DatasetDir != "" && config.DatasetsOnDisk > 0 {
-		config.Log.Info("Disk storage enabled for ethash DAGs", "dir", config.DatasetDir, "count", config.DatasetsOnDisk)
-	}
 	ethash := &Ethash{
 		config:   config,
-		caches:   newlru("cache", config.CachesInMem, newCache),
-		datasets: newlru("dataset", config.DatasetsInMem, newDataset),
 		hashrate: newHashRateMeter(),
 	}
 	if config.PowMode == ethashcfg.ModeShared {
@@ -476,60 +108,6 @@ func (ethash *Ethash) Close() error {
 		<-ethash.remote.exitCh
 	})
 	return nil
-}
-
-// cache tries to retrieve a verification cache for the specified block number
-// by first checking against a list of in-memory caches, then against caches
-// stored on disk, and finally generating one if none can be found.
-func (ethash *Ethash) cache(block uint64) *cache {
-	epoch := block / epochLength
-	currentI, futureI := ethash.caches.get(epoch)
-	current := currentI.(*cache)
-
-	// Wait for generation finish.
-	current.generate(doNotStoreCachesOnDisk, 0, ethash.config.CachesLockMmap, ethash.config.PowMode == ethashcfg.ModeTest)
-
-	// If we need a new future cache, now's a good time to regenerate it.
-	if futureI != nil {
-		future := futureI.(*cache)
-		go future.generate(doNotStoreCachesOnDisk, 0, ethash.config.CachesLockMmap, ethash.config.PowMode == ethashcfg.ModeTest)
-	}
-	return current
-}
-
-// dataset tries to retrieve a mining dataset for the specified block number
-// by first checking against a list of in-memory datasets, then against DAGs
-// stored on disk, and finally generating one if none can be found.
-//
-// If async is specified, not only the future but the current DAG is also
-// generates on a background thread.
-func (ethash *Ethash) dataset(block uint64, async bool) *dataset {
-	// Retrieve the requested ethash dataset
-	epoch := block / epochLength
-	currentI, futureI := ethash.datasets.get(epoch)
-	current := currentI.(*dataset)
-
-	// If async is specified, generate everything in a background thread
-	if async && !current.generated() {
-		go func() {
-			defer dbg.LogPanic()
-			current.generate(ethash.config.DatasetDir, ethash.config.DatasetsOnDisk, ethash.config.DatasetsLockMmap, ethash.config.PowMode == ethashcfg.ModeTest)
-
-			if futureI != nil {
-				future := futureI.(*dataset)
-				future.generate(ethash.config.DatasetDir, ethash.config.DatasetsOnDisk, ethash.config.DatasetsLockMmap, ethash.config.PowMode == ethashcfg.ModeTest)
-			}
-		}()
-	} else {
-		// Either blocking generation was requested, or already done
-		current.generate(ethash.config.DatasetDir, ethash.config.DatasetsOnDisk, ethash.config.DatasetsLockMmap, ethash.config.PowMode == ethashcfg.ModeTest)
-
-		if futureI != nil {
-			future := futureI.(*dataset)
-			go future.generate(ethash.config.DatasetDir, ethash.config.DatasetsOnDisk, ethash.config.DatasetsLockMmap, ethash.config.PowMode == ethashcfg.ModeTest)
-		}
-	}
-	return current
 }
 
 // Hashrate implements PoW, returning the measured rate of the search invocations

--- a/execution/protocol/rules/ethash/ethashcfg/ethashcfg.go
+++ b/execution/protocol/rules/ethash/ethashcfg/ethashcfg.go
@@ -22,13 +22,7 @@ import (
 
 // Config are the configuration parameters of the ethash.
 type Config struct {
-	CachesInMem      int
-	CachesLockMmap   bool
-	DatasetDir       string
-	DatasetsInMem    int
-	DatasetsOnDisk   int
-	DatasetsLockMmap bool
-	PowMode          Mode
+	PowMode Mode
 
 	Log log.Logger `toml:"-"`
 }

--- a/execution/protocol/rules/ethash/rules.go
+++ b/execution/protocol/rules/ethash/rules.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"runtime"
 	"time"
 
 	mapset "github.com/deckarep/golang-set/v2"
@@ -336,57 +335,37 @@ func CalcDifficulty(config *chain.Config, time, parentTime uint64, parentDifficu
 // VerifySeal implements rules.Engine, checking whether the given block satisfies
 // the PoW difficulty requirements.
 func (ethash *Ethash) VerifySeal(_ rules.ChainHeaderReader, header *types.Header) error {
-	return ethash.verifySeal(header, false)
+	return ethash.verifySeal(header)
 }
 
-// verifySeal checks whether a block satisfies the PoW difficulty requirements,
-// either using the usual ethash cache for it, or alternatively using a full DAG
-// to make remote mining fast.
-func (ethash *Ethash) verifySeal(header *types.Header, fulldag bool) error { //nolint:unparam
+// verifySeal checks whether a block satisfies the PoW difficulty requirements
+// using a freshly generated ethash verification cache. The cache is not retained:
+// post-Merge ethash is only used for tests and historical re-execution, so the
+// memory savings outweigh recomputation cost.
+func (ethash *Ethash) verifySeal(header *types.Header) error {
 	// If we're running a shared PoW, delegate verification to it
 	if ethash.shared != nil {
-		return ethash.shared.verifySeal(header, fulldag)
+		return ethash.shared.verifySeal(header)
 	}
 
 	// Ensure that we have a valid difficulty for the block
 	if header.Difficulty.Sign() <= 0 {
 		return errInvalidDifficulty
 	}
-	// Recompute the digest and PoW values
 	number := header.Number.Uint64()
+	epoch := number / epochLength
 
-	var (
-		digest []byte
-		result []byte
-	)
-	// If fast-but-heavy PoW verification was requested, use an ethash dataset
-	if fulldag {
-		dataset := ethash.dataset(number, true)
-		if dataset.generated() {
-			digest, result = hashimotoFull(dataset.dataset, ethash.SealHash(header).Bytes(), header.Nonce.Uint64())
-
-			// Datasets are unmapped in a finalizer. Ensure that the dataset stays alive
-			// until after the call to hashimotoFull so it's not unmapped while being used.
-			runtime.KeepAlive(dataset)
-		} else {
-			// Dataset not yet generated, don't hang, use a cache instead
-			fulldag = false
-		}
+	csize := cacheSize(number)
+	dsize := datasetSize(number)
+	if ethash.config.PowMode == ethashcfg.ModeTest {
+		csize = 1024
+		dsize = 32 * 1024
 	}
-	// If slow-but-light PoW verification was requested (or DAG not yet ready), use an ethash cache
-	if !fulldag {
-		cache := ethash.cache(number)
+	cache := make([]uint32, csize/4)
+	generateCache(cache, epoch, seedHash(number))
 
-		size := datasetSize(number)
-		if ethash.config.PowMode == ethashcfg.ModeTest {
-			size = 32 * 1024
-		}
-		digest, result = hashimotoLight(size, cache.cache, ethash.SealHash(header).Bytes(), header.Nonce.Uint64())
+	digest, result := hashimotoLight(dsize, cache, ethash.SealHash(header).Bytes(), header.Nonce.Uint64())
 
-		// Caches are unmapped in a finalizer. Ensure that the cache stays alive
-		// until after the call to hashimotoLight so it's not unmapped while being used.
-		runtime.KeepAlive(cache)
-	}
 	// Verify the calculated values against the ones provided in the header
 	if !bytes.Equal(header.MixDigest[:], digest) {
 		return errInvalidMixDigest

--- a/execution/protocol/rules/ethash/sealer.go
+++ b/execution/protocol/rules/ethash/sealer.go
@@ -243,7 +243,7 @@ func (s *remoteSealer) submitWork(nonce types.BlockNonce, mixDigest common.Hash,
 
 	start := time.Now()
 	if !s.noverify {
-		if err := s.ethash.verifySeal(header, true); err != nil {
+		if err := s.ethash.verifySeal(header); err != nil {
 			s.ethash.config.Log.Warn("Invalid proof-of-work submitted", "sealhash", sealhash, "elapsed", common.PrettyDuration(time.Since(start)), "err", err)
 			return false
 		}

--- a/node/cli/default_flags.go
+++ b/node/cli/default_flags.go
@@ -25,7 +25,6 @@ import (
 // DefaultFlags contains all flags that are used and supported by Erigon binary.
 var DefaultFlags = []cli.Flag{
 	&utils.DataDirFlag,
-	&utils.EthashDatasetDirFlag,
 	&utils.ExternalConsensusFlag,
 	&utils.TxPoolDisableFlag,
 	&utils.TxPoolPriceLimitFlag,

--- a/node/ethconfig/config.go
+++ b/node/ethconfig/config.go
@@ -22,10 +22,6 @@ package ethconfig
 
 import (
 	"math/big"
-	"os"
-	"os/user"
-	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
@@ -93,13 +89,6 @@ var Defaults = Config{
 		AlwaysGenerateChangesets: !dbg.BatchCommitments,
 		MaxReorgDepth:            dbg.MaxReorgDepth,
 	},
-	Ethash: ethashcfg.Config{
-		CachesInMem:      2,
-		CachesLockMmap:   false,
-		DatasetsInMem:    1,
-		DatasetsOnDisk:   2,
-		DatasetsLockMmap: false,
-	},
 	NetworkID:   1,
 	Prune:       prune.DefaultMode,
 	TxPool:      txpoolcfg.DefaultConfig,
@@ -118,30 +107,6 @@ var Defaults = Config{
 }
 
 const DefaultChainDBPageSize = 16 * datasize.KB
-
-func init() {
-	home := os.Getenv("HOME")
-	if home == "" {
-		if user, err := user.Current(); err == nil {
-			home = user.HomeDir
-		}
-	}
-	if runtime.GOOS == "darwin" {
-		Defaults.Ethash.DatasetDir = filepath.Join(home, "Library", "erigon-ethash")
-	} else if runtime.GOOS == "windows" {
-		localappdata := os.Getenv("LOCALAPPDATA")
-		if localappdata != "" {
-			Defaults.Ethash.DatasetDir = filepath.Join(localappdata, "erigon-thash")
-		} else {
-			Defaults.Ethash.DatasetDir = filepath.Join(home, "AppData", "Local", "erigon-ethash")
-		}
-	} else {
-		if xdgDataDir := os.Getenv("XDG_DATA_HOME"); xdgDataDir != "" {
-			Defaults.Ethash.DatasetDir = filepath.Join(xdgDataDir, "erigon-ethash")
-		}
-		Defaults.Ethash.DatasetDir = filepath.Join(home, ".local/share/erigon-ethash") //nolint:gocritic
-	}
-}
 
 //go:generate gencodec -dir . -type Config -formats toml -out gen_config.go
 

--- a/node/rulesconfig/config.go
+++ b/node/rulesconfig/config.go
@@ -59,14 +59,7 @@ func CreateRulesEngine(ctx context.Context, nodeConfig *nodecfg.Config, chainCon
 			logger.Warn("Ethash used in shared mode")
 			eng = ethash.NewShared()
 		default:
-			eng = ethash.New(ethashcfg.Config{
-				CachesInMem:      consensusCfg.CachesInMem,
-				CachesLockMmap:   consensusCfg.CachesLockMmap,
-				DatasetDir:       consensusCfg.DatasetDir,
-				DatasetsInMem:    consensusCfg.DatasetsInMem,
-				DatasetsOnDisk:   consensusCfg.DatasetsOnDisk,
-				DatasetsLockMmap: consensusCfg.DatasetsLockMmap,
-			}, noVerify)
+			eng = ethash.New(ethashcfg.Config{}, noVerify)
 		}
 	case *chain.AuRaConfig:
 		if chainConfig.Aura != nil {


### PR DESCRIPTION
## Summary

- Post-Merge ethash is only used for tests and historical re-execution, so the LRU cache + mmap-backed on-disk persistence around the verification cache and mining DAG no longer earns its keep. `verifySeal` now allocates a fresh cache per call and runs `hashimotoLight` directly. The dataset (fulldag) verification path is gone.
- Removes the related `ethashcfg` fields (`CachesInMem`, `CachesLockMmap`, `DatasetDir`, `DatasetsInMem`, `DatasetsOnDisk`, `DatasetsLockMmap`), their defaults, CLI flags (`--ethash.cachesinmem`, `--ethash.cacheslockmmap`, `--ethash.dagdir`, `--ethash.dagslockmmap`), and the OS-specific DAG-dir `init()`.
- `ethash.go` shrinks from 594 → 171 lines; overall diff is +31 / -571.

## Test plan

- [x] `go test -short ./execution/protocol/rules/ethash/...`
- [x] `go test -short ./execution/tests/... ./execution/stagedsync/bodydownload/... ./rpc/jsonrpc/...` (the other packages that touch ethash via tests)
- [x] `make erigon integration`
- [x] `make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)