### PR TITLE
execution/state: exclude own-tx writes from SD revival check

### DIFF
--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -273,17 +273,25 @@ func (vr *versionedStateReader) ReadAccountData(address accounts.Address) (*acco
 		if res := vr.versionMap.Read(address, SelfDestructPath, accounts.NilKey, vr.txIndex); res.Status() == MVReadResultDone {
 			if destructed, ok := res.Value().(bool); ok && destructed {
 				destructTxIndex := res.DepIdx()
+				// Cap at vr.txIndex-1 so a prior incarnation of the same
+				// tx (whose writes still sit in the versionMap at
+				// (vr.txIndex, prevIncarnation)) doesn't masquerade as
+				// a "later tx revived this account." versionMap.Read
+				// excludes the current tx via floor(txIdx-1); the
+				// LatestTxIndex bound is inclusive, so subtract one
+				// explicitly to keep both consistent.
+				revivalLimit := vr.txIndex - 1
 				revived := false
-				if hi, ok := vr.versionMap.LatestTxIndex(address, BalancePath, accounts.NilKey, vr.txIndex); ok && hi > destructTxIndex {
+				if hi, ok := vr.versionMap.LatestTxIndex(address, BalancePath, accounts.NilKey, revivalLimit); ok && hi > destructTxIndex {
 					revived = true
 				}
 				if !revived {
-					if hi, ok := vr.versionMap.LatestTxIndex(address, NoncePath, accounts.NilKey, vr.txIndex); ok && hi > destructTxIndex {
+					if hi, ok := vr.versionMap.LatestTxIndex(address, NoncePath, accounts.NilKey, revivalLimit); ok && hi > destructTxIndex {
 						revived = true
 					}
 				}
 				if !revived {
-					if hi, ok := vr.versionMap.LatestTxIndex(address, CodeHashPath, accounts.NilKey, vr.txIndex); ok && hi > destructTxIndex {
+					if hi, ok := vr.versionMap.LatestTxIndex(address, CodeHashPath, accounts.NilKey, revivalLimit); ok && hi > destructTxIndex {
 						revived = true
 					}
 				}
@@ -804,17 +812,32 @@ func versionedRead[T any](s *IntraBlockState, addr accounts.Address, path Accoun
 		// tipInsideBlock failing with gas exactly 4800 short under
 		// ERIGON_EXEC3_PARALLEL=true (matches EIP-2200's clear refund).
 		destructTxIndex := res.DepIdx()
+		// Cap the revival lookup at s.txIndex-1 so that a prior incarnation
+		// of the CURRENT tx — whose writes still sit in the versionMap at
+		// (s.txIndex, prevIncarnation) until the new incarnation rewrites
+		// them — doesn't masquerade as a "later tx revived this account."
+		// versionMap.Read uses floor(txIdx-1) for the same reason, but
+		// LatestTxIndex's upper bound is inclusive, so we have to subtract
+		// one explicitly. Without this, TX3 incarnation 1 of
+		// TestDeleteRecreateSlotsAcrossManyBlocks block 1 sees TX3
+		// incarnation 0's BalancePath write at txIndex=3, declares a
+		// spurious revival across TX2's SD at txIndex=2, falls through
+		// the SD short-circuit, reads TX1's stale hash(aaCode) for the
+		// CREATE2 collision check, fails the CREATE2 with
+		// ContractAddressCollision, and BB consumes the failed-child
+		// gas — that's the residual +1602 manifestation.
+		revivalLimit := s.txIndex - 1
 		revived := false
-		if hi, ok := s.versionMap.LatestTxIndex(addr, BalancePath, accounts.NilKey, s.txIndex); ok && hi > destructTxIndex {
+		if hi, ok := s.versionMap.LatestTxIndex(addr, BalancePath, accounts.NilKey, revivalLimit); ok && hi > destructTxIndex {
 			revived = true
 		}
 		if !revived {
-			if hi, ok := s.versionMap.LatestTxIndex(addr, NoncePath, accounts.NilKey, s.txIndex); ok && hi > destructTxIndex {
+			if hi, ok := s.versionMap.LatestTxIndex(addr, NoncePath, accounts.NilKey, revivalLimit); ok && hi > destructTxIndex {
 				revived = true
 			}
 		}
 		if !revived {
-			if hi, ok := s.versionMap.LatestTxIndex(addr, CodeHashPath, accounts.NilKey, s.txIndex); ok && hi > destructTxIndex {
+			if hi, ok := s.versionMap.LatestTxIndex(addr, CodeHashPath, accounts.NilKey, revivalLimit); ok && hi > destructTxIndex {
 				revived = true
 			}
 		}


### PR DESCRIPTION
## Summary

The SD revival check in both `versionedRead`'s SD short-circuit and `versionedStateReader.ReadAccountData` used `s.txIndex` / `vr.txIndex` as the upper bound for `versionMap.LatestTxIndex`. That bound is **inclusive** — so when a tx re-executes (incarnation `N+1`), the new incarnation sees writes from incarnation `N` at the same `TxIndex`, and the revival check declares a spurious revival across any intervening `SELFDESTRUCT`.

Concrete repro in `TestDeleteRecreateSlotsAcrossManyBlocks` block 1 under `EXEC3_PARALLEL=true GOMAXPROCS=2 -race`: TX3 incarnation 1 reads `CodeHashPath` for the CREATE2 collision check. TX3 inc 0 has already written `BalancePath` at `(txIndex=3, inc=0)`. The revival check finds that write at `txIndex=3 > destructTxIndex=2` (TX2's SD), declares revival, and bypasses the SD short-circuit. `CodeHashPath` then reads TX1's stale `hash(aaCode)` from the `versionMap`, CREATE2 fails with `ContractAddressCollision`, BB consumes the failed-child gas (gas remaining after CREATE2: 733 vs 2335 on success), and the per-tx gas accounting comes out exactly **1602** higher than the header.

## Fix

`versionMap.Read` uses `floor(txIdx-1)`, so it already excludes the current tx's own writes. `LatestTxIndex`'s bound is inclusive — that's the inconsistency. Subtract one explicitly at the callsite: `revivalLimit = txIndex - 1`. Applied symmetrically in `versionedRead` and `versionedStateReader.ReadAccountData`.

## Test plan

- [x] `make lint` clean.
- [x] Local stress: `GOMAXPROCS=2 EXEC3_PARALLEL=true go test -race -count=500 -run TestDeleteRecreateSlotsAcrossManyBlocks ./execution/tests/` — **500/500 pass** (vs ~15% failure rate baseline).
- [x] No regressions on the SD/recreate + broader blockchain family at `-count=2 -race`: `TestSelfDestructReceive`, `TestDeleteRecreateSlots`, `TestDeleteRecreateAccount`, `TestDeleteCreateRevert`, `TestCVE2020_26265`, `TestEIP161AccountRemoval`, `TestModes`, plus the reorg/EIP-155/EIP-2718/EIP-1559 tests.
- [ ] CI green on `race-tests / tests-linux (execution-tests)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)