### PR TITLE
skill: fix mdbx_copy destination path in erigon-mdbx-compact

### DIFF
--- a/.claude/skills/erigon-mdbx-compact/SKILL.md
+++ b/.claude/skills/erigon-mdbx-compact/SKILL.md
@@ -54,15 +54,15 @@ This places `mdbx_copy` at `./build/bin/mdbx_copy`.
 
 ### 5. Run Compaction
 
-Create a sibling directory for the compacted output. The destination argument to `mdbx_copy` must be a **file path**, not a directory.
+Create a sibling directory for the compacted output. Both arguments to `mdbx_copy` are **directories** — do NOT include `mdbx.dat` in either path.
 
 ```bash
 mkdir -p <datadir>/chaindata-compacted
-./build/bin/mdbx_copy -c <datadir>/chaindata <datadir>/chaindata-compacted/mdbx.dat
+./build/bin/mdbx_copy -c <datadir>/chaindata <datadir>/chaindata-compacted
 ```
 
 - Source is the **directory** `<datadir>/chaindata`
-- Destination is a **file** `<datadir>/chaindata-compacted/mdbx.dat`
+- Destination is the **directory** `<datadir>/chaindata-compacted` (mdbx_copy writes `mdbx.dat` inside it)
 
 This can take hours to days for large databases. Run in background.
 


### PR DESCRIPTION
## Summary
- `mdbx_copy`'s destination argument is a **directory**, not a file path — it writes `mdbx.dat` inside the destination directory itself.
- The previous skill instructions appended `/mdbx.dat` to the destination, which is incorrect.

## Test plan
- [ ] Manual: follow the corrected steps against a real chaindata dir and confirm `mdbx_copy` produces `<dst>/mdbx.dat`.