### PR TITLE
bloatnet: disable referenced keys

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -42,8 +42,9 @@ jobs:
           go-version: ${{ steps.goversion.outputs.version }}
       - run: make downloader
       - run: echo $ModModified
-      - run: ./build/bin/downloader manifest-verify --chain mainnet     --webseed 'https://erigon36-v1-snapshots-mainnet.erigon.network'
-      - run: ./build/bin/downloader manifest-verify --chain gnosis      --webseed 'https://erigon36-v1-snapshots-gnosis.erigon.network'
-      - run: ./build/bin/downloader manifest-verify --chain chiado      --webseed 'https://erigon36-v1-snapshots-chiado.erigon.network'
-      - run: ./build/bin/downloader manifest-verify --chain sepolia     --webseed 'https://erigon36-v1-snapshots-sepolia.erigon.network'
-      - run: ./build/bin/downloader manifest-verify --chain hoodi       --webseed 'https://erigon36-v1-snapshots-hoodi.erigon.network'
+      - run: ./build/bin/downloader manifest-verify --chain mainnet     --webseed 'https://erigon34-v1-snapshots-mainnet.erigon.network'
+      - run: ./build/bin/downloader manifest-verify --chain gnosis      --webseed 'https://erigon34-v1-snapshots-gnosis.erigon.network'
+      - run: ./build/bin/downloader manifest-verify --chain chiado      --webseed 'https://erigon34-v1-snapshots-chiado.erigon.network'
+      - run: ./build/bin/downloader manifest-verify --chain sepolia     --webseed 'https://erigon34-v1-snapshots-sepolia.erigon.network'
+      - run: ./build/bin/downloader manifest-verify --chain hoodi       --webseed 'https://erigon34-v1-snapshots-hoodi.erigon.network'
+      - run: ./build/bin/downloader manifest-verify --chain bloatnet    --webseed 'https://erigon36-v1-snapshots-bloatnet.erigon.network'

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -42,8 +42,8 @@ jobs:
           go-version: ${{ steps.goversion.outputs.version }}
       - run: make downloader
       - run: echo $ModModified
-      - run: ./build/bin/downloader manifest-verify --chain mainnet     --webseed 'https://erigon34-v1-snapshots-mainnet.erigon.network'
-      - run: ./build/bin/downloader manifest-verify --chain gnosis      --webseed 'https://erigon34-v1-snapshots-gnosis.erigon.network'
-      - run: ./build/bin/downloader manifest-verify --chain chiado      --webseed 'https://erigon34-v1-snapshots-chiado.erigon.network'
-      - run: ./build/bin/downloader manifest-verify --chain sepolia     --webseed 'https://erigon34-v1-snapshots-sepolia.erigon.network'
-      - run: ./build/bin/downloader manifest-verify --chain hoodi       --webseed 'https://erigon34-v1-snapshots-hoodi.erigon.network'
+      - run: ./build/bin/downloader manifest-verify --chain mainnet     --webseed 'https://erigon36-v1-snapshots-mainnet.erigon.network'
+      - run: ./build/bin/downloader manifest-verify --chain gnosis      --webseed 'https://erigon36-v1-snapshots-gnosis.erigon.network'
+      - run: ./build/bin/downloader manifest-verify --chain chiado      --webseed 'https://erigon36-v1-snapshots-chiado.erigon.network'
+      - run: ./build/bin/downloader manifest-verify --chain sepolia     --webseed 'https://erigon36-v1-snapshots-sepolia.erigon.network'
+      - run: ./build/bin/downloader manifest-verify --chain hoodi       --webseed 'https://erigon36-v1-snapshots-hoodi.erigon.network'

--- a/db/seg/compress.go
+++ b/db/seg/compress.go
@@ -222,8 +222,8 @@ func (c *Compressor) Count() int { return int(c.wordsCount) }
 // parallel small unit-tests which each create many small files and bufio
 // readers/writers — pooling avoids the allocation pressure in that scenario.
 var (
-	bufioWriterPool = sync.Pool{New: func() any { return bufio.NewWriterSize(nil, int(256*datasize.KB)) }}
-	bufioReaderPool = sync.Pool{New: func() any { return bufio.NewReaderSize(nil, int(256*datasize.KB)) }}
+	bufioWriterPool = sync.Pool{New: func() any { return bufio.NewWriterSize(nil, int(512*datasize.KB)) }}
+	bufioReaderPool = sync.Pool{New: func() any { return bufio.NewReaderSize(nil, int(512*datasize.KB)) }}
 )
 
 func getBufioWriter(w io.Writer) *bufio.Writer {

--- a/db/state/statecfg/state_schema.go
+++ b/db/state/statecfg/state_schema.go
@@ -76,7 +76,7 @@ func Configure(Schema SchemaGen, a AggSetters, dirs datadir.Dirs, salt *uint32, 
 // AggregatorSqueezeCommitmentValues controls whether commitment aggregator should replace keys in values during merge once file range reaches threshold.
 // This can significantly reduce size of commitment values, but makes them non-human readable and requires additional processing during reads.
 // This is not needed for correctness, but can be used to save space if needed.
-const AggregatorSqueezeCommitmentValues = true
+const AggregatorSqueezeCommitmentValues = false
 
 const MaxNonFuriousDirtySpacePerTx = 64 * datasize.MB
 

--- a/db/version/app.go
+++ b/db/version/app.go
@@ -33,7 +33,7 @@ const (
 	Minor                    = 5             // Minor version component of the current release
 	Micro                    = 0             // Patch version component of the current release
 	Modifier                 = "dev"         // Modifier component of the current release
-	DefaultSnapshotGitBranch = "performance" // Branch of erigontech/erigon-snapshot to use in OtterSync.
+	DefaultSnapshotGitBranch = "release/3.6" // Branch of erigontech/erigon-snapshot to use in OtterSync.
 	VersionKeyCreated        = "ErigonVersionCreated"
 	VersionKeyFinished       = "ErigonVersionFinished"
 	ClientName               = "erigon"

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.7
 replace github.com/holiman/bloomfilter/v2 => github.com/AskAlexSharov/bloomfilter/v2 v2.0.9
 
 require (
-	github.com/erigontech/erigon-snapshot v1.3.1-0.20260505095143-9dd31a2190a1
+	github.com/erigontech/erigon-snapshot v1.3.1-0.20260522023950-e98e9800e987
 	github.com/erigontech/mdbx-go v0.39.17
 	github.com/erigontech/secp256k1 v1.2.1-0.20260218182123-377cc1bd6410
 )

--- a/go.sum
+++ b/go.sum
@@ -336,8 +336,8 @@ github.com/elastic/go-freelru v0.16.0 h1:gG2HJ1WXN2tNl5/p40JS/l59HjvjRhjyAa+oFTR
 github.com/elastic/go-freelru v0.16.0/go.mod h1:bSdWT4M0lW79K8QbX6XY2heQYSCqD7THoYf82pT/H3I=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/erigontech/erigon-snapshot v1.3.1-0.20260505095143-9dd31a2190a1 h1:QXH5nIpbQr7b0P1XfeRKJlGukIywfzSRhBjhn60qaz4=
-github.com/erigontech/erigon-snapshot v1.3.1-0.20260505095143-9dd31a2190a1/go.mod h1:ooHlCl+eEYzebiPu+FP6Q6SpPUeMADn8Jxabv3IKb9M=
+github.com/erigontech/erigon-snapshot v1.3.1-0.20260522023950-e98e9800e987 h1:alaA15t5byvuHbpweNm5eUbHITXGrjuZFjJ7Gb+69Hg=
+github.com/erigontech/erigon-snapshot v1.3.1-0.20260522023950-e98e9800e987/go.mod h1:ooHlCl+eEYzebiPu+FP6Q6SpPUeMADn8Jxabv3IKb9M=
 github.com/erigontech/evmone_precompiles v0.0.0-20260414072133-b8b2bdc99de2 h1:BoHriVEyPxNCO/gY+e0ZrGz0GSnAbXlXNQ7Skn907g8=
 github.com/erigontech/evmone_precompiles v0.0.0-20260414072133-b8b2bdc99de2/go.mod h1:WQvAqmoairhdM5RFNFDKK9oT6dzuZEbWMJH+ZdRTjP0=
 github.com/erigontech/fastkeccak v0.1.1-0.20260408010752-08e7b6602268 h1:NHl4+DjblLuHBJradIg9KriKmtByjRvLqLhkVODibac=


### PR DESCRIPTION
Plan:
- release files from 3.6 snapshotter
- create PR to perf branch - which pointing to 3.6 buckets
- test
- then merge PR to `performance`

(after all done)
- then merge `performance` to `performance-stable` 
- then switch `3.6` snapshotter to `performance-stable`
- then decomission `3.4` snapshotter