### PR TITLE
execution/exec: return on empty AA validation results

### DIFF
--- a/execution/exec/historical_trace_worker.go
+++ b/execution/exec/historical_trace_worker.go
@@ -302,6 +302,7 @@ func (rw *HistoricalTraceWorker) execAATxn(txTask *TxTask, tracer *calltracer.Ca
 
 	if len(result.ValidationResults) == 0 {
 		result.Err = fmt.Errorf("found RIP-7560 but no remaining validation results, txIndex %d", txTask.TxIndex)
+		return result
 	}
 
 	aaTxn := txTask.Tx().(*types.AccountAbstractionTransaction) // type cast checked earlier

--- a/execution/exec/txtask.go
+++ b/execution/exec/txtask.go
@@ -654,6 +654,7 @@ func (txTask *TxTask) executeAA(aaTxn *types.AccountAbstractionTransaction,
 
 	if len(result.ValidationResults) == 0 {
 		result.Err = fmt.Errorf("found RIP-7560 but no remaining validation results, txIndex %d", txTask.TxIndex)
+		return &result
 	}
 
 	aaTxn = txTask.Tx().(*types.AccountAbstractionTransaction) // type cast checked earlier


### PR DESCRIPTION
## Summary

Return immediately after AA execution records an empty `ValidationResults` error in both the regular execution path and the historical trace path. This keeps the code from falling through to `ValidationResults[0]` after the error has already been set.