### PR TITLE
flush block overlay after each InsertBlocks batch (fix OOM)

### DIFF
--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -527,6 +527,12 @@ func (sd *SharedDomains) SetParent(parent *SharedDomains) { sd.parent = parent }
 // Returns nil if no overlay has been initialized via InitBlockOverlay.
 func (sd *SharedDomains) BlockOverlay() *membatchwithdb.MemoryMutation { return sd.blockOverlay.Load() }
 
+func (sd *SharedDomains) CloseBlockOverlay() {
+	if overlay := sd.blockOverlay.Swap(nil); overlay != nil {
+		overlay.Close()
+	}
+}
+
 // BlockOverlayTemporalTx returns a read-only temporal view of the block overlay.
 // This allows consumers (RPC, shutter) to read uncommitted block data with
 // temporal (state history) support. Returns nil if no overlay is active.
@@ -637,9 +643,7 @@ func (sd *SharedDomains) Close() {
 
 	sd.mem.Close()
 
-	if overlay := sd.blockOverlay.Swap(nil); overlay != nil {
-		overlay.Close()
-	}
+	sd.CloseBlockOverlay()
 
 	sd.sdCtx.Close()
 	sd.sdCtx = nil

--- a/execution/execmodule/inserters.go
+++ b/execution/execmodule/inserters.go
@@ -30,6 +30,28 @@ import (
 	"github.com/erigontech/erigon/execution/types"
 )
 
+// flushBlockOverlayToDB flushes the block overlay to DB, bounding memory
+// during bulk inserts. Not called for single-block chain-tip inserts.
+func (e *ExecModule) flushBlockOverlayToDB(ctx context.Context, sd *execctx.SharedDomains) error {
+	overlay := sd.BlockOverlay()
+	if overlay == nil {
+		return nil
+	}
+	rwTx, err := e.db.BeginTemporalRw(ctx)
+	if err != nil {
+		return fmt.Errorf("ethereumExecutionModule.InsertBlocks: begin rw for overlay flush: %w", err)
+	}
+	defer rwTx.Rollback()
+	if err := overlay.Flush(ctx, rwTx); err != nil {
+		return fmt.Errorf("ethereumExecutionModule.InsertBlocks: flush overlay: %w", err)
+	}
+	if err := rwTx.Commit(); err != nil {
+		return fmt.Errorf("ethereumExecutionModule.InsertBlocks: commit overlay: %w", err)
+	}
+	sd.CloseBlockOverlay()
+	return nil
+}
+
 func (e *ExecModule) InsertBlocks(ctx context.Context, blocks []*types.RawBlock) (ExecutionStatus, error) {
 	if !e.semaphore.TryAcquire(1) {
 		e.logger.Trace("ethereumExecutionModule.InsertBlocks: ExecutionStatus_Busy")
@@ -125,8 +147,12 @@ func (e *ExecModule) InsertBlocks(ctx context.Context, blocks []*types.RawBlock)
 		e.logger.Trace("Inserted block", "hash", header.Hash(), "number", header.Number)
 	}
 
-	// Writes stay in the block overlay on currentContext — no flush or commit here.
-	// ValidateChain reads from the overlay; UpdateForkChoice flushes everything
-	// in a single commit at the end.
+	// On ChainTip - store blocks in Overlay
+	// On Non-ChainTip - flush to db because batches are big
+	if len(blocks) > 16 {
+		if err := e.flushBlockOverlayToDB(ctx, sd); err != nil {
+			return 0, err
+		}
+	}
 	return ExecutionStatusSuccess, nil
 }


### PR DESCRIPTION
## Problem

During historical backfill the `BlockCollector` inserts tens of thousands of blocks via repeated `InsertBlocks` calls. Each call accumulated block data (headers, TDs, raw transaction bodies) in the in-memory `MemoryMutation` (block overlay) without ever flushing — the design deferred the flush until `UpdateForkChoice`. This caused OOM.

Heap profile showed the root cause clearly:
- `PersistentBlockCollector.Flush` → `insertBatch` → `ExecModule.InsertBlocks` → `MemoryMutation.Append` → `bytes.Clone` = **4.7 GB** live

## Fix

Flush and close the block overlay at the end of each `InsertBlocks` call via a short-lived RwTx. Memory is now bounded to one 1000-block batch at a time.

The next `InsertBlocks` call opens a fresh `roTx` that sees the committed TDs, so parent-TD lookups across batch boundaries still work. `UpdateForkChoice` reads block data from MDBX (via its own `roTx` base) when `hasOverlay=false`.

Also close `e.currentContext` unconditionally in the FCU success path — previously it was only closed when `hasOverlay=true`, which would leak `AggregatorRoTx` handles now that the overlay is always flushed ahead of FCU.

## Prior art

`release/3.4` had no overlay at all — `InsertBlocks` used a plain `BeginRw` + `tx.Commit()` per call. This fix restores equivalent per-call commit semantics on `main`.