### PR TITLE
deps: bump mdbx-go to v0.40.1 (libmdbx 0.14.2)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace github.com/holiman/bloomfilter/v2 => github.com/AskAlexSharov/bloomfilte
 require (
 	github.com/erigontech/erigon-snapshot v1.3.1-0.20260402120223-7bb412bc89cd
 	github.com/erigontech/go-libdeflate v0.1.0
-	github.com/erigontech/mdbx-go v0.39.17
+	github.com/erigontech/mdbx-go v0.40.1
 	github.com/erigontech/secp256k1 v1.2.1-0.20260218182123-377cc1bd6410
 )
 

--- a/go.sum
+++ b/go.sum
@@ -342,8 +342,8 @@ github.com/erigontech/go-eth-kzg v0.0.0-20260401161010-070339460d07 h1:0VpFIthaJ
 github.com/erigontech/go-eth-kzg v0.0.0-20260401161010-070339460d07/go.mod h1:J9/u5sWfznSObptgfa92Jq8rTswn6ahQWEuiLHOjCUI=
 github.com/erigontech/go-libdeflate v0.1.0 h1:WtKiuNpuAP/Qyq3mbPwFB0DoQikabtOeZFUgo9VGRsY=
 github.com/erigontech/go-libdeflate v0.1.0/go.mod h1:OCQBWlynNqNCYb1ckqNjY69H1LAhg2TyyfYZalO03BM=
-github.com/erigontech/mdbx-go v0.39.17 h1:+FQMaCuH/IB+t9HEXVDxTJaV5jvZTwC/6YgDHHKDDMo=
-github.com/erigontech/mdbx-go v0.39.17/go.mod h1:VTGwYzepS9Wg38jVfreOsSVlh73OBGPZluu7kHo6X6g=
+github.com/erigontech/mdbx-go v0.40.1 h1:d8aeokoiLnT4MrRq4bFdqnPO714743d7bd6hC2tKy1w=
+github.com/erigontech/mdbx-go v0.40.1/go.mod h1:VTGwYzepS9Wg38jVfreOsSVlh73OBGPZluu7kHo6X6g=
 github.com/erigontech/secp256k1 v1.2.1-0.20260218182123-377cc1bd6410 h1:5YD7JJ5PaqOdjKA84lTDtQby9nbI4podqrkUhyIyFDw=
 github.com/erigontech/secp256k1 v1.2.1-0.20260218182123-377cc1bd6410/go.mod h1:CnigLRUsfobnTYoUzwdT/De67fw9OhTA0KTkxa+svik=
 github.com/ettle/strcase v0.2.0 h1:fGNiVF21fHXpX1niBgk0aROov1LagYsOwV/xqKDKR/Q=


### PR DESCRIPTION
## Summary

Upgrade `github.com/erigontech/mdbx-go` from **v0.39.17 → v0.40.1**, the latest 0.40.x release. This rolls up the [v0.40.0](https://github.com/erigontech/mdbx-go/releases/tag/v0.40.0) and [v0.40.1](https://github.com/erigontech/mdbx-go/releases/tag/v0.40.1) releases, bringing in **libmdbx 0.14.2 \"Stormy Petre\"** plus binding improvements.

## libmdbx 0.14.1 → 0.14.2 highlights

**New features**
- **GC rewrite** with compact RKL containers — GC updates from O(1) to O(log N) by txn size, with early page-level GC cleanup.
- **Database defragmentation / compaction** + new `mdbx_defrag` utility.
- **Massive range delete**: `mdbx_cursor_bunch_delete()`, `mdbx_cursor_delete_range()` — drop adjacent items by excluding whole pages/branches.
- **New transaction primitives**: `mdbx_txn_refresh`, `mdbx_txn_checkpoint`, `mdbx_txn_commit_embark_read`, `mdbx_txn_amend`, `mdbx_txn_rollback`, `mdbx_txn_clone`, plus nested read-only transactions.
- **Cache getters**: `mdbx_cache_get()` / `mdbx_cache_get_SingleThreaded()`.
- **GC introspection**: `mdbx_gc_info()` for page usage / GC iteration.
- **Cursor scanning helpers**: `mdbx_cursor_distance`, `mdbx_cursor_scroll`, `mdbx_cursor_distribute`.
- `MDBX_CP_OVERWRITE` for the copy API (`mdbx_copy -f`).
- `MDBX_opt_split_reserve` to control page fullness on split.
- Branchless search + inlined default comparators (faster lookups).
- Page-fetch counters in txn statistics (`MDBX_ENABLE_PGET_STAT`).
- Harmony OS (OHOS) and Haiku OS support; `libm` dependency removed.

**Behavior changes**
- Page merge threshold default raised **25% → 33%**.
- Lock-acquire retry count tripled (fewer spurious `EAGAIN` on Android restart).
- Windows builds now use the Win10 SDK by default.
- `MDBX_WANNA_RECOVERY` no longer triggered when DB size is not a multiple of the VM allocation granularity (only when not a multiple of system page size).

**Notable fixes**
- **Critical fix** in `mdbx_env_resurrect_after_fork()` with SysV semaphores (OSX/POSIX with `MDBX_LOCKING=5`) that could lead to DB corruption.
- Copy API on non-Linux POSIX (mainly OSX) no longer returns spurious `EAGAIN`.
- Fixes for unexpected `MDBX_BAD_DBI`, `MDBX_DBS_FULL`, `SIGBUS` on a grown DB in nearly-full filesystems, TLS-destructor crashes, geometry auto-tuning regression, and more.

## mdbx-go binding improvements

- `ExactKeyValue` / `ExactKeyPair` navigation flags ([erigontech/mdbx-go#217](https://github.com/erigontech/mdbx-go/pull/217)).
- `Cursor.PutCurrent` for in-place dup replacement in DupSort tables ([erigontech/mdbx-go#207](https://github.com/erigontech/mdbx-go/pull/207)).
- Range-delete bindings ([erigontech/mdbx-go#201](https://github.com/erigontech/mdbx-go/pull/201)).
- `NoStickyThreads` env option exposed ([erigontech/mdbx-go#202](https://github.com/erigontech/mdbx-go/pull/202)).
- `EnvInfo.LatterReaderTxnID` ([erigontech/mdbx-go#204](https://github.com/erigontech/mdbx-go/pull/204)).
- Readers + GC metrics helpers ([erigontech/mdbx-go#214](https://github.com/erigontech/mdbx-go/pull/214), [#215](https://github.com/erigontech/mdbx-go/pull/215), [#216](https://github.com/erigontech/mdbx-go/pull/216)).
- `Cursor.Put` cgo heap-pointer overhead reduction ([erigontech/mdbx-go#205](https://github.com/erigontech/mdbx-go/pull/205)).
- `MDBX_USE_FALLOCATE` enabled in the build ([erigontech/mdbx-go#203](https://github.com/erigontech/mdbx-go/pull/203)).
- FD reviving fix ([erigontech/mdbx-go#200](https://github.com/erigontech/mdbx-go/pull/200)).
- `Env.Path()` fix ([erigontech/mdbx-go#198](https://github.com/erigontech/mdbx-go/pull/198)).

## Erigon-side impact

No erigon code changes required:

- The `GCDetails.Coalescences` profiling field (consumed in [db/kv/mdbx/kv_mdbx.go:1162](db/kv/mdbx/kv_mdbx.go:1162)) is preserved across the bump.
- The removed `MDBX_COALESCE` env option is not referenced anywhere in erigon (only `Coalescences` GC stats are).
- All call sites of `github.com/erigontech/mdbx-go/mdbx` ([cmd/integration/commands/stages.go](cmd/integration/commands/stages.go), [p2p/enode/nodedb.go](p2p/enode/nodedb.go), [db/kv/mdbx/kv_mdbx.go](db/kv/mdbx/kv_mdbx.go), [db/kv/mdbx/util.go](db/kv/mdbx/util.go), test files) continue to type-check against the v0.40.1 API.

## Test plan

- [x] `go get github.com/erigontech/mdbx-go@v0.40.1 && go mod tidy`
- [x] `go build ./...` — clean (only pre-existing cgo `-Wpedantic` / `-Wno-stringop-overread` warnings, no errors)
- [x] `go vet ./db/kv/mdbx/... ./p2p/enode/... ./cmd/integration/...` — clean
- [x] `go test -short ./db/kv/mdbx/...` — PASS
- [x] `make lint` — `0 issues`
- [ ] CI: full unit + integration test matrix
- [ ] CI: hive / kurtosis-assertoor (validate critical SysV-semaphore fix has no regression on Linux)
- [ ] Soak test against a real datadir (recommended before merging, since libmdbx 0.14.2 includes a GC rewrite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)