### PR TITLE
cl: implement consensus-specs v1.7.0-alpha.8 for Gloas devnet-4

### DIFF
--- a/.github/workflows/kurtosis/glamsterdam-caplin.io
+++ b/.github/workflows/kurtosis/glamsterdam-caplin.io
@@ -8,7 +8,7 @@ participants:
     el_extra_params: ["--experimental.bal"]
     use_separate_vc: true
     vc_type: lighthouse
-    vc_image: ethpandaops/lighthouse:glamsterdam-devnet-0
+    vc_image: ethpandaops/lighthouse:glamsterdam-devnet-4
     count: 1
 global_log_level: 'debug'
 network_params:

--- a/.github/workflows/kurtosis/glamsterdam.io
+++ b/.github/workflows/kurtosis/glamsterdam.io
@@ -34,4 +34,4 @@ additional_services: [spamoor, assertoor]
 assertoor_params:
   run_stability_check: true
   run_block_proposal_check: true
-  image: ethpandaops/assertoor:qu0b-gloas-bals-v2
+  image: ethpandaops/assertoor:v0.1.2

--- a/.github/workflows/kurtosis/glamsterdam.io
+++ b/.github/workflows/kurtosis/glamsterdam.io
@@ -32,6 +32,6 @@ ethereum_genesis_generator_params:
   image: ethpandaops/ethereum-genesis-generator:5.3.5
 additional_services: [spamoor, assertoor]
 assertoor_params:
-  run_stability_check: true
+  run_stability_check: false
   run_block_proposal_check: true
   image: ethpandaops/assertoor:master-0ad56fb

--- a/.github/workflows/kurtosis/glamsterdam.io
+++ b/.github/workflows/kurtosis/glamsterdam.io
@@ -1,6 +1,6 @@
 participants:
   - cl_type: lighthouse
-    cl_image: ethpandaops/lighthouse:bal-devnet-3
+    cl_image: ethpandaops/lighthouse:glamsterdam-devnet-4
     el_type: erigon
     el_image: test/erigon:current
     el_log_level: "debug"

--- a/.github/workflows/kurtosis/glamsterdam.io
+++ b/.github/workflows/kurtosis/glamsterdam.io
@@ -32,6 +32,6 @@ ethereum_genesis_generator_params:
   image: ethpandaops/ethereum-genesis-generator:5.3.5
 additional_services: [spamoor, assertoor]
 assertoor_params:
-  run_stability_check: false
+  run_stability_check: false  # re-enable once go-eth2-client supports alpha.8 (#21442)
   run_block_proposal_check: true
-  image: ethpandaops/assertoor:master-0ad56fb
+  image: ethpandaops/assertoor:master-0ad56fb  # switch to release tag when available (#21441)

--- a/.github/workflows/kurtosis/glamsterdam.io
+++ b/.github/workflows/kurtosis/glamsterdam.io
@@ -34,4 +34,4 @@ additional_services: [spamoor, assertoor]
 assertoor_params:
   run_stability_check: true
   run_block_proposal_check: true
-  image: ethpandaops/assertoor:v0.1.2
+  image: ethpandaops/assertoor:master-0ad56fb

--- a/.github/workflows/kurtosis/gloas-caplin-mixed.io
+++ b/.github/workflows/kurtosis/gloas-caplin-mixed.io
@@ -1,6 +1,6 @@
 participants:
   - cl_type: lighthouse
-    cl_image: ethpandaops/lighthouse:glamsterdam-devnet-2
+    cl_image: ethpandaops/lighthouse:glamsterdam-devnet-4
     el_type: erigon
     el_image: test/erigon:current
     el_log_level: "debug"
@@ -17,7 +17,7 @@ participants:
     el_extra_params: ["--experimental.bal"]
     use_separate_vc: true
     vc_type: lighthouse
-    vc_image: ethpandaops/lighthouse:glamsterdam-devnet-2
+    vc_image: ethpandaops/lighthouse:glamsterdam-devnet-4
     count: 1
 global_log_level: 'debug'
 network_params:

--- a/.github/workflows/kurtosis/gloas-three-cl-mixed.io
+++ b/.github/workflows/kurtosis/gloas-three-cl-mixed.io
@@ -1,6 +1,6 @@
 participants:
   - cl_type: lighthouse
-    cl_image: ethpandaops/lighthouse:glamsterdam-devnet-2
+    cl_image: ethpandaops/lighthouse:glamsterdam-devnet-4
     el_type: erigon
     el_image: test/erigon:current
     el_log_level: "debug"
@@ -8,14 +8,14 @@ participants:
     supernode: true
     count: 1
   - cl_type: prysm
-    cl_image: ethpandaops/prysm-beacon-chain:glamsterdam-devnet-2-minimal
+    cl_image: ethpandaops/prysm-beacon-chain:glamsterdam-devnet-4-tmp-minimal
     el_type: erigon
     el_image: test/erigon:current
     el_log_level: "debug"
     el_extra_params: ["--experimental.bal"]
     use_separate_vc: true
     vc_type: prysm
-    vc_image: ethpandaops/prysm-validator:glamsterdam-devnet-2-minimal
+    vc_image: ethpandaops/prysm-validator:glamsterdam-devnet-4-tmp-minimal
     count: 1
   - cl_type: caplin
     cl_image: test/erigon:current
@@ -27,7 +27,7 @@ participants:
     el_extra_params: ["--experimental.bal"]
     use_separate_vc: true
     vc_type: lighthouse
-    vc_image: ethpandaops/lighthouse:glamsterdam-devnet-2
+    vc_image: ethpandaops/lighthouse:glamsterdam-devnet-4
     count: 1
 global_log_level: 'debug'
 network_params:

--- a/cl/beacon/beaconhttp/api.go
+++ b/cl/beacon/beaconhttp/api.go
@@ -171,6 +171,19 @@ func HandleEndpoint[T any](h EndpointHandler[T]) http.HandlerFunc {
 	}
 }
 
+// WillEncodeSSZ reports whether the given Accept header will cause
+// HandleEndpoint to use SSZ encoding. Mirrors the switch priority above.
+func WillEncodeSSZ(accept string) bool {
+	switch {
+	case accept == "*/*", accept == "", strings.Contains(accept, "text/html"), strings.Contains(accept, "application/json"):
+		return false
+	case strings.Contains(accept, "application/octet-stream"):
+		return true
+	default:
+		return false
+	}
+}
+
 func isNil[T any](t T) bool {
 	v := reflect.ValueOf(t)
 	kind := v.Kind()

--- a/cl/beacon/beaconhttp/api_test.go
+++ b/cl/beacon/beaconhttp/api_test.go
@@ -31,6 +31,29 @@ func TestHandleEndpoint_SetsEthConsensusVersionHeaderFromBodyVersion(t *testing.
 	}
 }
 
+func TestWillEncodeSSZ(t *testing.T) {
+	tests := []struct {
+		accept string
+		want   bool
+	}{
+		{"", false},
+		{"*/*", false},
+		{"application/json", false},
+		{"application/octet-stream", true},
+		{"application/json, application/octet-stream", false},
+		{"application/octet-stream, application/json", false},
+		{"text/html", false},
+		{"text/event-stream", false},
+		{"application/octet-stream; q=1", true},
+		{"text/html, application/octet-stream", false},
+	}
+	for _, tt := range tests {
+		if got := WillEncodeSSZ(tt.accept); got != tt.want {
+			t.Errorf("WillEncodeSSZ(%q) = %v, want %v", tt.accept, got, tt.want)
+		}
+	}
+}
+
 func TestHandleEndpoint_DoesNotOverrideEthConsensusVersionHeader(t *testing.T) {
 	h := HandleEndpointFunc(func(w http.ResponseWriter, r *http.Request) (*BeaconResponse, error) {
 		return NewBeaconResponse(map[string]any{"ok": true}).

--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -817,8 +817,15 @@ func (a *ApiHandler) produceBeaconBody(
 		if stateVersion.AfterOrEqual(clparams.GloasVersion) {
 			sn := hexutil.Uint64(targetSlot)
 			attrs.SlotNumber = &sn
-			tgl := hexutil.Uint64(a.beaconChainCfg.DefaultBuilderGasLimit)
-			attrs.TargetGasLimit = &tgl
+			if a.epbsPool != nil {
+				for _, pref := range a.epbsPool.GetPreferencesForSlot(targetSlot) {
+					if pref.Message != nil && pref.Message.ValidatorIndex == proposerIndex {
+						tgl := hexutil.Uint64(pref.Message.TargetGasLimit)
+						attrs.TargetGasLimit = &tgl
+						break
+					}
+				}
+			}
 		}
 		idBytes, err := a.engine.ForkChoiceUpdate(
 			ctx,

--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -829,6 +829,7 @@ func (a *ApiHandler) produceBeaconBody(
 			sn := hexutil.Uint64(targetSlot)
 			attrs.SlotNumber = &sn
 			if a.epbsPool != nil {
+				// A proposer submits at most one preference per slot, so first-match is deterministic.
 				for _, pref := range a.epbsPool.GetPreferencesForSlot(targetSlot) {
 					if pref.Message != nil && pref.Message.ValidatorIndex == proposerIndex {
 						tgl := hexutil.Uint64(pref.Message.TargetGasLimit)

--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -335,13 +335,6 @@ func (a *ApiHandler) GetEthV3ValidatorBlock(
 	// todo: consensusValue
 	rewardsCollector := blockBuldingMachine.BlockRewardsCollector
 	consensusValue := rewardsCollector.Attestations + rewardsCollector.ProposerSlashings + rewardsCollector.AttesterSlashings + rewardsCollector.SyncAggregate
-	a.setupHeaderReponseForBlockProduction(
-		w,
-		block.Version(),
-		block.IsBlinded(),
-		block.GetExecutionValue().Uint64(),
-		consensusValue,
-	)
 	var resp *beaconhttp.BeaconResponse
 	if block.IsBlinded() {
 		resp = newBeaconResponse(block.ToBlinded())
@@ -357,6 +350,7 @@ func (a *ApiHandler) GetEthV3ValidatorBlock(
 		With("execution_payload_value", strconv.FormatUint(block.GetExecutionValue().Uint64(), 10)).
 		With("consensus_block_value", strconv.FormatUint(consensusValue, 10))
 
+	executionPayloadIncluded := false
 	// [New in Gloas:EIP7732] For self-build blocks, compute the unsigned ExecutionPayloadEnvelope
 	// and include it in the response so the validator client can sign it.
 	// The beacon block root can only be computed here (after the state root is set).
@@ -383,16 +377,32 @@ func (a *ApiHandler) GetEthV3ValidatorBlock(
 						BeaconBlockRoot:       beaconBlockRoot,
 						ParentBeaconBlockRoot: denebBlock.Block.ParentRoot,
 					}
-					resp = resp.With("execution_payload_envelope", envelope)
 					// Cache envelope by slot so the VC can retrieve it via
 					// GET /eth/v1/validator/execution_payload_envelope/{slot}/{builder_index}
 					a.selfBuildEnvelopes.Add(targetSlot, envelope)
+					// SSZ encoding only serializes Data, not Extra — only include
+					// the envelope in JSON responses to keep the header truthful.
+					if !beaconhttp.WillEncodeSSZ(r.Header.Get("Accept")) {
+						resp = resp.With("execution_payload_envelope", envelope)
+						executionPayloadIncluded = true
+					}
 					log.Info("BlockProduction: included unsigned execution payload envelope in response",
 						"slot", targetSlot, "beaconBlockRoot", beaconBlockRoot, "blockHash", bid.Message.BlockHash)
 				}
 			}
 		}
 	}
+	if block.Version() >= clparams.GloasVersion {
+		resp = resp.With("execution_payload_included", executionPayloadIncluded)
+	}
+	a.setupHeaderReponseForBlockProduction(
+		w,
+		block.Version(),
+		block.IsBlinded(),
+		executionPayloadIncluded,
+		block.GetExecutionValue().Uint64(),
+		consensusValue,
+	)
 
 	return resp, nil
 }
@@ -715,11 +725,11 @@ func (a *ApiHandler) produceBeaconBody(
 			head = baseState.GetLatestBlockHash()
 		}
 	}
-	finalizedHash := a.forkchoiceStore.GetEth1Hash(baseState.FinalizedCheckpoint().Root)
+	finalizedHash := a.forkchoiceStore.GetFinalizedExecutionHash(baseState.FinalizedCheckpoint().Root)
 	if finalizedHash == (common.Hash{}) {
-		finalizedHash = head // probably fuck up fcu for EL but not a big deal.
+		finalizedHash = head
 	}
-	safeHash := a.forkchoiceStore.GetEth1Hash(baseState.CurrentJustifiedCheckpoint().Root)
+	safeHash := a.forkchoiceStore.GetFinalizedExecutionHash(baseState.CurrentJustifiedCheckpoint().Root)
 	if safeHash == (common.Hash{}) {
 		safeHash = head
 	}
@@ -1251,12 +1261,16 @@ func (a *ApiHandler) setupHeaderReponseForBlockProduction(
 	w http.ResponseWriter,
 	consensusVersion clparams.StateVersion,
 	blinded bool,
+	executionPayloadIncluded bool,
 	executionBlockValue, consensusBlockValue uint64,
 ) {
 	w.Header().Set("Eth-Execution-Payload-Value", strconv.FormatUint(executionBlockValue, 10))
 	w.Header().Set("Eth-Consensus-Block-Value", strconv.FormatUint(consensusBlockValue, 10))
 	w.Header().Set("Eth-Consensus-Version", clparams.ClVersionToString(consensusVersion))
 	w.Header().Set("Eth-Execution-Payload-Blinded", strconv.FormatBool(blinded))
+	if consensusVersion >= clparams.GloasVersion {
+		w.Header().Set("Eth-Execution-Payload-Included", strconv.FormatBool(executionPayloadIncluded))
+	}
 }
 
 func (a *ApiHandler) PostEthV1BeaconBlocks(w http.ResponseWriter, r *http.Request) (*beaconhttp.BeaconResponse, error) {
@@ -1890,8 +1904,8 @@ func (a *ApiHandler) storeBlockAndBlobs(
 	if err := a.forkchoiceStore.OnBlock(ctx, block, true, false, false); err != nil {
 		return err
 	}
-	finalizedHash := a.forkchoiceStore.GetEth1Hash(a.forkchoiceStore.FinalizedCheckpoint().Root)
-	safeHash := a.forkchoiceStore.GetEth1Hash(a.forkchoiceStore.JustifiedCheckpoint().Root)
+	finalizedHash := a.forkchoiceStore.GetFinalizedExecutionHash(a.forkchoiceStore.FinalizedCheckpoint().Root)
+	safeHash := a.forkchoiceStore.GetFinalizedExecutionHash(a.forkchoiceStore.JustifiedCheckpoint().Root)
 	if _, err := a.engine.ForkChoiceUpdate(ctx, finalizedHash, safeHash, a.forkchoiceStore.GetEth1Hash(blockRoot), nil, block.Version()); err != nil {
 		return err
 	}

--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -695,7 +695,9 @@ func (a *ApiHandler) produceBeaconBody(
 			isPreGloasParent := parentBid.ParentBlockHash == (common.Hash{}) && parentBid.Slot == 0
 			if isPreGloasParent {
 				head = parentBid.BlockHash
-			} else if a.forkchoiceStore.GetHeadPayloadStatus() == cltypes.PayloadStatusFull && a.forkchoiceStore.ShouldBuildOnFull(forkchoice.ForkChoiceNode{Root: baseBlockRoot, PayloadStatus: cltypes.PayloadStatusFull}) {
+			} else if a.forkchoiceStore.GetHeadPayloadStatus() == cltypes.PayloadStatusFull &&
+				a.forkchoiceStore.HasEnvelope(baseBlockRoot) &&
+				a.forkchoiceStore.ShouldBuildOnFull(forkchoice.ForkChoiceNode{Root: baseBlockRoot, PayloadStatus: cltypes.PayloadStatusFull}) {
 				head = parentBid.BlockHash
 				// Copy state and apply parent execution payload to compute correct withdrawals
 				stateCopy, err := baseState.Copy()

--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -47,6 +47,7 @@ import (
 	"github.com/erigontech/erigon/cl/gossip"
 	"github.com/erigontech/erigon/cl/persistence/beacon_indicies"
 	"github.com/erigontech/erigon/cl/phase1/core/state"
+	"github.com/erigontech/erigon/cl/phase1/forkchoice"
 	"github.com/erigontech/erigon/cl/phase1/network/subnets"
 	"github.com/erigontech/erigon/cl/pool"
 	"github.com/erigontech/erigon/cl/transition"
@@ -684,7 +685,7 @@ func (a *ApiHandler) produceBeaconBody(
 			isPreGloasParent := parentBid.ParentBlockHash == (common.Hash{}) && parentBid.Slot == 0
 			if isPreGloasParent {
 				head = parentBid.BlockHash
-			} else if a.forkchoiceStore.HasEnvelope(baseBlockRoot) && a.forkchoiceStore.ShouldExtendPayload(baseBlockRoot) {
+			} else if a.forkchoiceStore.GetHeadPayloadStatus() == cltypes.PayloadStatusFull && a.forkchoiceStore.ShouldBuildOnFull(forkchoice.ForkChoiceNode{Root: baseBlockRoot, PayloadStatus: cltypes.PayloadStatusFull}) {
 				head = parentBid.BlockHash
 				// Copy state and apply parent execution payload to compute correct withdrawals
 				stateCopy, err := baseState.Copy()

--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -739,6 +739,17 @@ func (a *ApiHandler) produceBeaconBody(
 	if err != nil {
 		return nil, 0, err
 	}
+	var targetGasLimit *hexutil.Uint64
+	if stateVersion.AfterOrEqual(clparams.GloasVersion) && a.epbsPool != nil {
+		proposalEpoch := state.GetEpochAtSlot(a.beaconChainCfg, targetSlot)
+		dependentRoot, err := state.GetProposerDependentRoot(baseState, proposalEpoch)
+		if err != nil {
+			log.Trace("Skipping proposer preferences target gas limit", "slot", targetSlot, "err", err)
+		} else if pref, ok := a.epbsPool.GetPreference(targetSlot, dependentRoot); ok && pref.Message != nil && pref.Message.ValidatorIndex == proposerIndex {
+			tgl := hexutil.Uint64(pref.Message.TargetGasLimit)
+			targetGasLimit = &tgl
+		}
+	}
 	currEpoch := a.ethClock.GetCurrentEpoch()
 	random := baseState.GetRandaoMixes(currEpoch)
 
@@ -830,16 +841,7 @@ func (a *ApiHandler) produceBeaconBody(
 		if stateVersion.AfterOrEqual(clparams.GloasVersion) {
 			sn := hexutil.Uint64(targetSlot)
 			attrs.SlotNumber = &sn
-			if a.epbsPool != nil {
-				// A proposer submits at most one preference per slot, so first-match is deterministic.
-				for _, pref := range a.epbsPool.GetPreferencesForSlot(targetSlot) {
-					if pref.Message != nil && pref.Message.ValidatorIndex == proposerIndex {
-						tgl := hexutil.Uint64(pref.Message.TargetGasLimit)
-						attrs.TargetGasLimit = &tgl
-						break
-					}
-				}
-			}
+			attrs.TargetGasLimit = targetGasLimit
 		}
 		idBytes, err := a.engine.ForkChoiceUpdate(
 			ctx,

--- a/cl/beacon/handler/block_production_test.go
+++ b/cl/beacon/handler/block_production_test.go
@@ -19,6 +19,7 @@ package handler
 import (
 	"bytes"
 	"context"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -40,6 +41,28 @@ import (
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/node/gointerfaces/txpoolproto"
 )
+
+func TestSetupHeaderResponseForBlockProductionGloasPayloadIncluded(t *testing.T) {
+	h := &ApiHandler{}
+	rr := httptest.NewRecorder()
+
+	h.setupHeaderReponseForBlockProduction(rr, clparams.GloasVersion, false, true, 123, 456)
+
+	require.Equal(t, "gloas", rr.Header().Get("Eth-Consensus-Version"))
+	require.Equal(t, "123", rr.Header().Get("Eth-Execution-Payload-Value"))
+	require.Equal(t, "456", rr.Header().Get("Eth-Consensus-Block-Value"))
+	require.Equal(t, "false", rr.Header().Get("Eth-Execution-Payload-Blinded"))
+	require.Equal(t, "true", rr.Header().Get("Eth-Execution-Payload-Included"))
+}
+
+func TestSetupHeaderResponseForBlockProductionPreGloasOmitsPayloadIncluded(t *testing.T) {
+	h := &ApiHandler{}
+	rr := httptest.NewRecorder()
+
+	h.setupHeaderReponseForBlockProduction(rr, clparams.ElectraVersion, false, true, 123, 456)
+
+	require.Empty(t, rr.Header().Get("Eth-Execution-Payload-Included"))
+}
 
 // TestCaplinBlockProductionWithWithdrawalRequest tests Caplin's produceBeaconBody
 // against a real Erigon execution layer. A withdrawal request transaction is

--- a/cl/beacon/handler/block_production_test.go
+++ b/cl/beacon/handler/block_production_test.go
@@ -234,8 +234,8 @@ func TestCaplinBlockProductionGlamsterdamSlotNumber(t *testing.T) {
 	postState.SetLatestExecutionPayloadHeader(elHeader)
 	// GLOAS uses GetLatestBlockHash() instead of LatestExecutionPayloadHeader().BlockHash
 	postState.SetLatestBlockHash(elHead.Hash())
-	// GLOAS deferred payload: set LatestExecutionPayloadBid so that HasEnvelope &&
-	// ShouldExtendPayload (both returning true in the mock) select bid.BlockHash as the EL head.
+	// GLOAS deferred payload: set LatestExecutionPayloadBid so that GetHeadPayloadStatus()==FULL &&
+	// ShouldBuildOnFull (both returning true in the mock) select bid.BlockHash as the EL head.
 	postState.SetLatestExecutionPayloadBid(&cltypes.ExecutionPayloadBid{
 		BlockHash:       elHead.Hash(),
 		ParentBlockHash: elHead.Hash(),
@@ -252,7 +252,7 @@ func TestCaplinBlockProductionGlamsterdamSlotNumber(t *testing.T) {
 	baseBlockRoot, err := baseBlock.HashSSZ()
 	require.NoError(t, err)
 
-	// GLOAS deferred payload: the mock returns HasEnvelope=true and ShouldExtendPayload=true,
+	// GLOAS deferred payload: the mock returns GetHeadPayloadStatus=FULL and ShouldBuildOnFull=true,
 	// so block production expects an envelope on disk. Provide one with empty ExecutionRequests.
 	fcu.Envelopes[baseBlockRoot] = &cltypes.SignedExecutionPayloadEnvelope{
 		Message: &cltypes.ExecutionPayloadEnvelope{

--- a/cl/clparams/config.go
+++ b/cl/clparams/config.go
@@ -695,6 +695,7 @@ type BeaconChainConfig struct {
 	ChurnLimitQuotientGloas         uint64     `yaml:"CHURN_LIMIT_QUOTIENT_GLOAS" spec:"true" json:"CHURN_LIMIT_QUOTIENT_GLOAS,string"`                 // ChurnLimitQuotientGloas replaces ChurnLimitQuotient for balance churn calculation in GLOAS+.
 	ConsolidationChurnLimitQuotient uint64     `yaml:"CONSOLIDATION_CHURN_LIMIT_QUOTIENT" spec:"true" json:"CONSOLIDATION_CHURN_LIMIT_QUOTIENT,string"` // ConsolidationChurnLimitQuotient is the independent quotient for consolidation churn in GLOAS+.
 	BuilderWithdrawalPrefix         ConfigByte `yaml:"-" json:"-"`
+	PayloadDueBps                   uint64     `yaml:"PAYLOAD_DUE_BPS" spec:"true" json:"PAYLOAD_DUE_BPS,string"`
 	PtcSize                         uint64     `yaml:"PTC_SIZE" spec:"true" json:"PTC_SIZE,string"`                                                     // PtcSize is the number of validators in the Payload Timeliness Committee (preset: 512 mainnet, 16 minimal).
 	MaxPayloadAttestations          uint64     `yaml:"MAX_PAYLOAD_ATTESTATIONS" spec:"true" json:"MAX_PAYLOAD_ATTESTATIONS,string"`                     // MaxPayloadAttestations defines the maximum number of payload attestations in a block.
 	BuilderRegistryLimit            uint64     `yaml:"BUILDER_REGISTRY_LIMIT" spec:"true" json:"BUILDER_REGISTRY_LIMIT,string"`                         // BuilderRegistryLimit defines the upper bound of builders can participate in eth2.
@@ -1044,12 +1045,13 @@ var MainnetBeaconConfig BeaconChainConfig = BeaconChainConfig{
 	ChurnLimitQuotientGloas:         1 << 15,
 	ConsolidationChurnLimitQuotient: 1 << 16,
 	BuilderWithdrawalPrefix:         0x03,
+	PayloadDueBps:                   7500,
 	PtcSize:                         512,
 	MaxPayloadAttestations:          4,
 	BuilderRegistryLimit:            1 << 40,
 	BuilderPendingWithdrawalsLimit:  1 << 20,
 	MaxBuildersPerWithdrawalsSweep:  1 << 14,
-	MinBuilderWithdrawabilityDelay:  64,
+	MinBuilderWithdrawabilityDelay:  8192,
 }
 
 func mainnetConfig() BeaconChainConfig {

--- a/cl/clparams/config_test.go
+++ b/cl/clparams/config_test.go
@@ -80,11 +80,12 @@ GLOAS_FORK_VERSION: 0x80000038
 GLOAS_FORK_EPOCH: 1
 
 # GLOAS-specific
+PAYLOAD_DUE_BPS: 7500
 MAX_PAYLOAD_ATTESTATIONS: 4
 BUILDER_REGISTRY_LIMIT: 1099511627776
 BUILDER_PENDING_WITHDRAWALS_LIMIT: 1048576
 MAX_BUILDERS_PER_WITHDRAWALS_SWEEP: 16384
-MIN_BUILDER_WITHDRAWABILITY_DELAY: 64
+MIN_BUILDER_WITHDRAWABILITY_DELAY: 8192
 `
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.yaml")
@@ -107,9 +108,10 @@ MIN_BUILDER_WITHDRAWABILITY_DELAY: 64
 	require.NotEqual(t, uint64(math.MaxUint64), beaconCfg.GloasForkEpoch)
 
 	// Verify GLOAS-specific parameters.
+	require.Equal(t, uint64(7500), beaconCfg.PayloadDueBps)
 	require.Equal(t, uint64(4), beaconCfg.MaxPayloadAttestations)
 	require.Equal(t, uint64(1099511627776), beaconCfg.BuilderRegistryLimit)
-	require.Equal(t, uint64(64), beaconCfg.MinBuilderWithdrawabilityDelay)
+	require.Equal(t, uint64(8192), beaconCfg.MinBuilderWithdrawabilityDelay)
 
 	// Verify MinSeedLookahead is 1 (inherited from mainnet defaults or overridden).
 	require.Equal(t, uint64(1), beaconCfg.MinSeedLookahead)

--- a/cl/cltypes/epbs_proposer.go
+++ b/cl/cltypes/epbs_proposer.go
@@ -41,7 +41,7 @@ type ProposerPreferences struct {
 	ProposalSlot   uint64         `json:"proposal_slot,string"`
 	ValidatorIndex uint64         `json:"validator_index,string"`
 	FeeRecipient   common.Address `json:"fee_recipient"`
-	GasLimit       uint64         `json:"gas_limit,string"`
+	TargetGasLimit uint64         `json:"target_gas_limit,string"`
 }
 
 func (p *ProposerPreferences) HashSSZ() ([32]byte, error) {
@@ -50,7 +50,7 @@ func (p *ProposerPreferences) HashSSZ() ([32]byte, error) {
 		p.ProposalSlot,
 		p.ValidatorIndex,
 		p.FeeRecipient[:],
-		p.GasLimit,
+		p.TargetGasLimit,
 	)
 }
 
@@ -63,11 +63,11 @@ func (p *ProposerPreferences) Static() bool {
 }
 
 func (p *ProposerPreferences) EncodeSSZ(buf []byte) ([]byte, error) {
-	return ssz2.MarshalSSZ(buf, p.DependentRoot[:], p.ProposalSlot, p.ValidatorIndex, p.FeeRecipient[:], p.GasLimit)
+	return ssz2.MarshalSSZ(buf, p.DependentRoot[:], p.ProposalSlot, p.ValidatorIndex, p.FeeRecipient[:], p.TargetGasLimit)
 }
 
 func (p *ProposerPreferences) DecodeSSZ(buf []byte, version int) error {
-	return ssz2.UnmarshalSSZ(buf, version, p.DependentRoot[:], &p.ProposalSlot, &p.ValidatorIndex, p.FeeRecipient[:], &p.GasLimit)
+	return ssz2.UnmarshalSSZ(buf, version, p.DependentRoot[:], &p.ProposalSlot, &p.ValidatorIndex, p.FeeRecipient[:], &p.TargetGasLimit)
 }
 
 func (p *ProposerPreferences) Clone() clonable.Clonable {
@@ -76,7 +76,7 @@ func (p *ProposerPreferences) Clone() clonable.Clonable {
 		ProposalSlot:   p.ProposalSlot,
 		ValidatorIndex: p.ValidatorIndex,
 		FeeRecipient:   p.FeeRecipient,
-		GasLimit:       p.GasLimit,
+		TargetGasLimit: p.TargetGasLimit,
 	}
 }
 

--- a/cl/cltypes/network.go
+++ b/cl/cltypes/network.go
@@ -280,3 +280,28 @@ func (l *ExecutionPayloadEnvelopesByRangeRequest) EncodingSizeSSZ() int {
 func (*ExecutionPayloadEnvelopesByRangeRequest) Clone() clonable.Clonable {
 	return &ExecutionPayloadEnvelopesByRangeRequest{}
 }
+
+/*
+ * BeaconBlocksByHeadRequest requests blocks walking the parent chain from a given root.
+ * [New in Fulu] consensus-specs PR #5181
+ */
+type BeaconBlocksByHeadRequest struct {
+	BeaconRoot common.Hash
+	Count      uint64
+}
+
+func (b *BeaconBlocksByHeadRequest) EncodeSSZ(buf []byte) ([]byte, error) {
+	return ssz2.MarshalSSZ(buf, b.BeaconRoot[:], &b.Count)
+}
+
+func (b *BeaconBlocksByHeadRequest) DecodeSSZ(buf []byte, _ int) error {
+	return ssz2.UnmarshalSSZ(buf, 0, b.BeaconRoot[:], &b.Count)
+}
+
+func (b *BeaconBlocksByHeadRequest) EncodingSizeSSZ() int {
+	return 40
+}
+
+func (*BeaconBlocksByHeadRequest) Clone() clonable.Clonable {
+	return &BeaconBlocksByHeadRequest{}
+}

--- a/cl/phase1/core/state/epbs.go
+++ b/cl/phase1/core/state/epbs.go
@@ -186,7 +186,11 @@ func IsPendingValidator(cfg *clparams.BeaconChainConfig, pendingDeposits *solid.
 		if d.PubKey != pubkey {
 			continue
 		}
-		valid, _ := IsValidDepositSignature(cfg, d.PubKey, d.WithdrawalCredentials, d.Amount, d.Signature)
+		valid, err := IsValidDepositSignature(cfg, d.PubKey, d.WithdrawalCredentials, d.Amount, d.Signature)
+		if err != nil {
+			log.Debug("IsValidDepositSignature failed", "pubkey", d.PubKey, "err", err)
+			continue
+		}
 		if valid {
 			return true
 		}

--- a/cl/phase1/core/state/epbs.go
+++ b/cl/phase1/core/state/epbs.go
@@ -174,24 +174,20 @@ func GetPendingBalanceToWithdrawForBuilder(s abstract.BeaconState, builderIndex 
 	return total
 }
 
-// IsPendingValidator returns true if there's a pending deposit for the given pubkey
-// with a valid signature. This is used to prevent builder deposits from being applied
-// when there's already a valid pending validator deposit for the same pubkey.
+// IsPendingValidator returns true if any pending deposit in the list matches
+// the given pubkey AND has a valid deposit signature.
 // [New in Gloas:EIP7732]
-func IsPendingValidator(s abstract.BeaconState, pubkey common.Bytes48) bool {
-	pendingDeposits := s.GetPendingDeposits()
+func IsPendingValidator(cfg *clparams.BeaconChainConfig, pendingDeposits *solid.ListSSZ[*solid.PendingDeposit], pubkey common.Bytes48) bool {
 	if pendingDeposits == nil {
 		return false
 	}
-	cfg := s.BeaconConfig()
 	for i := 0; i < pendingDeposits.Len(); i++ {
-		deposit := pendingDeposits.Get(i)
-		if deposit.PubKey != pubkey {
+		d := pendingDeposits.Get(i)
+		if d.PubKey != pubkey {
 			continue
 		}
-		// Check if this pending deposit has a valid signature
-		valid, err := IsValidDepositSignature(cfg, deposit.PubKey, deposit.WithdrawalCredentials, deposit.Amount, deposit.Signature)
-		if err == nil && valid {
+		valid, _ := IsValidDepositSignature(cfg, d.PubKey, d.WithdrawalCredentials, d.Amount, d.Signature)
+		if valid {
 			return true
 		}
 	}

--- a/cl/phase1/core/state/epbs.go
+++ b/cl/phase1/core/state/epbs.go
@@ -138,6 +138,19 @@ func CanBuilderCoverBid(s abstract.BeaconState, builderIndex uint64, bidAmount u
 	return builderBalance-minBalance >= bidAmount
 }
 
+func GetProposerDependentRoot(s abstract.BeaconState, epoch uint64) (common.Hash, error) {
+	cfg := s.BeaconConfig()
+	if epoch < cfg.MinSeedLookahead {
+		return common.Hash{}, fmt.Errorf("proposer dependent root epoch %d before min seed lookahead %d", epoch, cfg.MinSeedLookahead)
+	}
+	dependentEpoch := epoch - cfg.MinSeedLookahead
+	if dependentEpoch == 0 {
+		return common.Hash{}, fmt.Errorf("proposer dependent root slot underflow for epoch %d", epoch)
+	}
+	dependentSlot := dependentEpoch*cfg.SlotsPerEpoch - 1
+	return s.GetBlockRootAtSlot(dependentSlot)
+}
+
 // GetPendingBalanceToWithdrawForBuilder returns the total pending balance to withdraw for a builder.
 // This includes:
 // - Amounts from builder_pending_withdrawals (direct withdrawal requests)

--- a/cl/phase1/core/state/epbs_test.go
+++ b/cl/phase1/core/state/epbs_test.go
@@ -40,6 +40,35 @@ func TestIsBuilderWithdrawalCredential_NotBuilder(t *testing.T) {
 	}
 }
 
+func TestGetProposerDependentRoot(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.SlotsPerEpoch = 32
+	cfg.SlotsPerHistoricalRoot = 8192
+	cfg.MinSeedLookahead = 1
+	s := state2.New(&cfg)
+	s.SetSlot(100)
+	want := common.Hash{0x42}
+	s.SetBlockRootAt(63, want)
+
+	got, err := state2.GetProposerDependentRoot(s, 3)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestGetProposerDependentRootRejectsUnderflow(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.SlotsPerEpoch = 32
+	cfg.MinSeedLookahead = 1
+	s := state2.New(&cfg)
+	s.SetSlot(100)
+
+	_, err := state2.GetProposerDependentRoot(s, 0)
+	require.Error(t, err)
+
+	_, err = state2.GetProposerDependentRoot(s, 1)
+	require.Error(t, err)
+}
+
 // TestApplyDepositForBuilder_NewBuilder_WithValidSignature verifies that a
 // new builder deposit with 0x03 credentials and a valid signature creates
 // a builder entry in the state registry.

--- a/cl/phase1/core/state/upgrade.go
+++ b/cl/phase1/core/state/upgrade.go
@@ -399,7 +399,7 @@ func (b *CachingBeaconState) onboardBuildersFromPendingDeposits() error {
 		hasBuilderCredentials := IsBuilderWithdrawalCredential(deposit.WithdrawalCredentials, cfg)
 
 		if isExistingBuilder || hasBuilderCredentials {
-			if IsPendingValidator(cfg, newPendingDeposits, deposit.PubKey) {
+			if IsPendingValidator(cfg, pendingDeposits, deposit.PubKey) {
 				newPendingDeposits.Append(deposit)
 			} else {
 				ApplyDepositForBuilder(b, deposit.PubKey, deposit.WithdrawalCredentials, deposit.Amount, deposit.Signature, deposit.Slot)

--- a/cl/phase1/core/state/upgrade.go
+++ b/cl/phase1/core/state/upgrade.go
@@ -398,17 +398,18 @@ func (b *CachingBeaconState) onboardBuildersFromPendingDeposits() error {
 		isExistingBuilder := IsBuilderPubkey(b, deposit.PubKey)
 		hasBuilderCredentials := IsBuilderWithdrawalCredential(deposit.WithdrawalCredentials, cfg)
 
-		if isExistingBuilder || hasBuilderCredentials {
+		if !isExistingBuilder {
+			if !hasBuilderCredentials {
+				newPendingDeposits.Append(deposit)
+				continue
+			}
 			if IsPendingValidator(cfg, newPendingDeposits, deposit.PubKey) {
 				newPendingDeposits.Append(deposit)
-			} else {
-				ApplyDepositForBuilder(b, deposit.PubKey, deposit.WithdrawalCredentials, deposit.Amount, deposit.Signature, deposit.Slot)
+				continue
 			}
-			continue
 		}
 
-		// Non-builder deposits all stay in the pending queue
-		newPendingDeposits.Append(deposit)
+		ApplyDepositForBuilder(b, deposit.PubKey, deposit.WithdrawalCredentials, deposit.Amount, deposit.Signature, deposit.Slot)
 	}
 
 	b.SetPendingDeposits(newPendingDeposits)

--- a/cl/phase1/core/state/upgrade.go
+++ b/cl/phase1/core/state/upgrade.go
@@ -399,7 +399,7 @@ func (b *CachingBeaconState) onboardBuildersFromPendingDeposits() error {
 		hasBuilderCredentials := IsBuilderWithdrawalCredential(deposit.WithdrawalCredentials, cfg)
 
 		if isExistingBuilder || hasBuilderCredentials {
-			if IsPendingValidator(cfg, pendingDeposits, deposit.PubKey) {
+			if IsPendingValidator(cfg, newPendingDeposits, deposit.PubKey) {
 				newPendingDeposits.Append(deposit)
 			} else {
 				ApplyDepositForBuilder(b, deposit.PubKey, deposit.WithdrawalCredentials, deposit.Amount, deposit.Signature, deposit.Slot)

--- a/cl/phase1/core/state/upgrade.go
+++ b/cl/phase1/core/state/upgrade.go
@@ -312,7 +312,7 @@ func (b *CachingBeaconState) UpgradeToGloas() error {
 		BlobKzgCommitments:    *solid.NewStaticListSSZ[*cltypes.KZGCommitment](cltypes.MaxBlobsCommittmentsPerBlock, 48),
 		ExecutionRequestsRoot: emptyRequestsRoot,
 		PrevRandao:            common.Hash{},
-		GasLimit:              0,
+		GasLimit:              b.LatestExecutionPayloadHeader().GasLimit,
 		ParentBlockRoot:       common.Hash{},
 	}
 	b.SetLatestExecutionPayloadBid(bid)
@@ -395,30 +395,20 @@ func (b *CachingBeaconState) onboardBuildersFromPendingDeposits() error {
 			continue
 		}
 
-		// Check if pubkey is associated with an existing builder or has builder credentials
-		// Note: builders list may be mutated by apply_deposit_for_builder, so we check each iteration
 		isExistingBuilder := IsBuilderPubkey(b, deposit.PubKey)
 		hasBuilderCredentials := IsBuilderWithdrawalCredential(deposit.WithdrawalCredentials, cfg)
 
 		if isExistingBuilder || hasBuilderCredentials {
-			// Apply deposit for builder
-			ApplyDepositForBuilder(b, deposit.PubKey, deposit.WithdrawalCredentials, deposit.Amount, deposit.Signature, deposit.Slot)
+			if IsPendingValidator(cfg, newPendingDeposits, deposit.PubKey) {
+				newPendingDeposits.Append(deposit)
+			} else {
+				ApplyDepositForBuilder(b, deposit.PubKey, deposit.WithdrawalCredentials, deposit.Amount, deposit.Signature, deposit.Slot)
+			}
 			continue
 		}
 
-		// For new validator deposits with valid signature, track pubkey and keep in pending
-		// Deposits with invalid signatures are dropped
-		valid, err := IsValidDepositSignature(cfg, deposit.PubKey, deposit.WithdrawalCredentials, deposit.Amount, deposit.Signature)
-		if err != nil {
-			log.Debug("Error validating deposit signature during upgrade", "err", err)
-			continue
-		}
-		if valid {
-			// Track this pubkey so subsequent builder deposits for same pubkey stay pending
-			validatorPubkeys[deposit.PubKey] = struct{}{}
-			newPendingDeposits.Append(deposit)
-		}
-		// Invalid signature deposits are dropped (they would fail in apply_pending_deposit anyway)
+		// Non-builder deposits all stay in the pending queue
+		newPendingDeposits.Append(deposit)
 	}
 
 	b.SetPendingDeposits(newPendingDeposits)

--- a/cl/phase1/forkchoice/forkchoice.go
+++ b/cl/phase1/forkchoice/forkchoice.go
@@ -427,9 +427,7 @@ func (f *ForkChoiceStore) GetRecentExecutionPayloadStatus(executionBlockHash com
 	return f.executionPayloadStatus.Get(executionBlockHash)
 }
 
-// GetExecutionPayloadGasLimit returns the gas_limit of a recently validated execution payload
-// by its execution block hash. Used for the is_gas_limit_target_compatible IGNORE check.
-// [New in Gloas:EIP7732]
+// GetExecutionPayloadGasLimit returns the gas_limit of a recently validated execution payload.
 func (f *ForkChoiceStore) GetExecutionPayloadGasLimit(executionBlockHash common.Hash) (uint64, bool) {
 	return f.executionPayloadGasLimit.Get(executionBlockHash)
 }
@@ -574,8 +572,7 @@ func (f *ForkChoiceStore) GetEth1Hash(eth2Root common.Hash) common.Hash {
 }
 
 // GetFinalizedExecutionHash returns the EL block hash for a finalized/justified checkpoint.
-// [Modified in Gloas:EIP7732] For Gloas+ blocks, returns parent_block_hash from the
-// committed execution payload bid instead of the execution payload header hash.
+// For Gloas+ blocks, uses parent_block_hash from the bid instead of the payload header hash.
 func (f *ForkChoiceStore) GetFinalizedExecutionHash(eth2Root common.Hash) common.Hash {
 	f.mu.RLock()
 	defer f.mu.RUnlock()

--- a/cl/phase1/forkchoice/forkchoice.go
+++ b/cl/phase1/forkchoice/forkchoice.go
@@ -107,6 +107,9 @@ type ForkChoiceStore struct {
 	// [New in Gloas:EIP7732] Track execution payload validation status by execution block hash.
 	// Used to check if parent execution payload has been validated/invalidated for gossip validation.
 	executionPayloadStatus *lru.Cache[common.Hash, execution_client.PayloadStatus]
+	// [New in Gloas:EIP7732] Track execution payload gas_limit by execution block hash.
+	// Used for the is_gas_limit_target_compatible IGNORE check in bid gossip validation.
+	executionPayloadGasLimit *lru.Cache[common.Hash, uint64]
 	// childrens
 	childrens sync.Map
 
@@ -314,6 +317,12 @@ func NewForkChoiceStore(
 		return nil, err
 	}
 
+	// [New in Gloas:EIP7732] Track execution payload gas_limit by execution block hash
+	executionPayloadGasLimit, err := lru.New[common.Hash, uint64](checkpointsPerCache)
+	if err != nil {
+		return nil, err
+	}
+
 	publicKeysRegistry.ResetAnchor(anchorState)
 	participation.Add(state.Epoch(anchorState.BeaconState), anchorState.CurrentEpochParticipation().Copy())
 
@@ -368,6 +377,7 @@ func NewForkChoiceStore(
 		pendingEnvelopes:               pendingEnvelopes,
 		pendingLocalSelfBuildEnvelopes: pendingLocalSelfBuildEnvelopes,
 		executionPayloadStatus:         executionPayloadStatus,
+		executionPayloadGasLimit:       executionPayloadGasLimit,
 		db:                             db,
 	}
 	f.justifiedCheckpoint.Store(anchorCheckpoint)
@@ -415,6 +425,13 @@ func (f *ForkChoiceStore) GetPeerDas() das.PeerDas {
 // [New in Gloas:EIP7732]
 func (f *ForkChoiceStore) GetRecentExecutionPayloadStatus(executionBlockHash common.Hash) (execution_client.PayloadStatus, bool) {
 	return f.executionPayloadStatus.Get(executionBlockHash)
+}
+
+// GetExecutionPayloadGasLimit returns the gas_limit of a recently validated execution payload
+// by its execution block hash. Used for the is_gas_limit_target_compatible IGNORE check.
+// [New in Gloas:EIP7732]
+func (f *ForkChoiceStore) GetExecutionPayloadGasLimit(executionBlockHash common.Hash) (uint64, bool) {
+	return f.executionPayloadGasLimit.Get(executionBlockHash)
 }
 
 // IsBlobDataAvailable returns the local node's assessment of blob data availability
@@ -552,6 +569,22 @@ func (f *ForkChoiceStore) Engine() execution_client.ExecutionEngine {
 func (f *ForkChoiceStore) GetEth1Hash(eth2Root common.Hash) common.Hash {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
+	ret, _ := f.eth2Roots.Get(eth2Root)
+	return ret
+}
+
+// GetFinalizedExecutionHash returns the EL block hash for a finalized/justified checkpoint.
+// [Modified in Gloas:EIP7732] For Gloas+ blocks, returns parent_block_hash from the
+// committed execution payload bid instead of the execution payload header hash.
+func (f *ForkChoiceStore) GetFinalizedExecutionHash(eth2Root common.Hash) common.Hash {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	block, ok := f.forkGraph.GetBlock(eth2Root)
+	if ok && block != nil && block.Block.Body.Version >= clparams.GloasVersion {
+		if bid := block.Block.Body.GetSignedExecutionPayloadBid(); bid != nil && bid.Message != nil {
+			return bid.Message.ParentBlockHash
+		}
+	}
 	ret, _ := f.eth2Roots.Get(eth2Root)
 	return ret
 }

--- a/cl/phase1/forkchoice/forkchoice.go
+++ b/cl/phase1/forkchoice/forkchoice.go
@@ -165,8 +165,8 @@ type ForkChoiceStore struct {
 
 	// [New in Gloas:EIP7732]
 	ptcVoteMu                   sync.Mutex // protects read-modify-write on payloadTimelinessVote and payloadDataAvailabilityVote
-	payloadTimelinessVote       sync.Map   // map[common.Hash][clparams.PtcSize]bool
-	payloadDataAvailabilityVote sync.Map   // map[common.Hash][clparams.PtcSize]bool
+	payloadTimelinessVote       sync.Map   // map[common.Hash][clparams.PtcSize]int8 (0=unvoted, 1=true, -1=false)
+	payloadDataAvailabilityVote sync.Map   // map[common.Hash][clparams.PtcSize]int8 (0=unvoted, 1=true, -1=false)
 	// [New in Gloas:EIP7732] Block timeliness tracking.
 	// Pre-GLOAS: stores [block_timely, false] (only index 0 is meaningful).
 	// Post-GLOAS: stores [block_timely, payload_timely] — two independent booleans.
@@ -396,11 +396,11 @@ func NewForkChoiceStore(
 
 	// [New in Gloas:EIP7732] Initialize payload timeliness and data availability votes
 	// Anchor block votes are initialized to all true (prior payloads/blobs were available)
-	var anchorTimelinessVotes [clparams.PtcSize]bool
-	var anchorDataAvailabilityVotes [clparams.PtcSize]bool
+	var anchorTimelinessVotes [clparams.PtcSize]int8
+	var anchorDataAvailabilityVotes [clparams.PtcSize]int8
 	for i := range anchorTimelinessVotes {
-		anchorTimelinessVotes[i] = true
-		anchorDataAvailabilityVotes[i] = true
+		anchorTimelinessVotes[i] = 1
+		anchorDataAvailabilityVotes[i] = 1
 	}
 	f.payloadTimelinessVote.Store(common.Hash(anchorRoot), anchorTimelinessVotes)
 	f.payloadDataAvailabilityVote.Store(common.Hash(anchorRoot), anchorDataAvailabilityVotes)

--- a/cl/phase1/forkchoice/forkchoice_test.go
+++ b/cl/phase1/forkchoice/forkchoice_test.go
@@ -1,0 +1,174 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package forkchoice
+
+import (
+	"testing"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/cl/phase1/core/state"
+	"github.com/erigontech/erigon/cl/phase1/forkchoice/fork_graph"
+	"github.com/erigontech/erigon/cl/transition/impl/eth2"
+	"github.com/erigontech/erigon/common"
+)
+
+func TestGetFinalizedExecutionHash(t *testing.T) {
+	cache, err := lru.New[common.Hash, common.Hash](16)
+	require.NoError(t, err)
+
+	gloasBlock := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.GloasVersion)
+	gloasBlock.Block.Slot = 1
+	gloasRoot := common.Hash{0x01}
+	gloasParentBlockHash := common.Hash{0xaa}
+	gloasFallbackHash := common.Hash{0xbb}
+	gloasBlock.Block.Body.SignedExecutionPayloadBid.Message.ParentBlockHash = gloasParentBlockHash
+	cache.Add(gloasRoot, gloasFallbackHash)
+
+	preGloasBlock := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
+	preGloasBlock.Block.Slot = 2
+	preGloasRoot := common.Hash{0x02}
+	preGloasExecutionHash := common.Hash{0xcc}
+	cache.Add(preGloasRoot, preGloasExecutionHash)
+
+	missingRoot := common.Hash{0x03}
+	missingExecutionHash := common.Hash{0xdd}
+	cache.Add(missingRoot, missingExecutionHash)
+
+	store := &ForkChoiceStore{
+		forkGraph: &getFinalizedExecutionHashForkGraph{
+			blocks: map[common.Hash]*cltypes.SignedBeaconBlock{
+				gloasRoot:    gloasBlock,
+				preGloasRoot: preGloasBlock,
+			},
+		},
+		eth2Roots: cache,
+	}
+
+	require.Equal(t, gloasParentBlockHash, store.GetFinalizedExecutionHash(gloasRoot))
+	require.Equal(t, preGloasExecutionHash, store.GetFinalizedExecutionHash(preGloasRoot))
+	require.Equal(t, missingExecutionHash, store.GetFinalizedExecutionHash(missingRoot))
+}
+
+type getFinalizedExecutionHashForkGraph struct {
+	blocks map[common.Hash]*cltypes.SignedBeaconBlock
+}
+
+func (g *getFinalizedExecutionHashForkGraph) AddChainSegment(*cltypes.SignedBeaconBlock, bool) (*state.CachingBeaconState, fork_graph.ChainSegmentInsertionResult, error) {
+	panic("not used")
+}
+
+func (g *getFinalizedExecutionHashForkGraph) GetHeader(common.Hash) (*cltypes.BeaconBlockHeader, bool) {
+	panic("not used")
+}
+
+func (g *getFinalizedExecutionHashForkGraph) GetBlock(blockRoot common.Hash) (*cltypes.SignedBeaconBlock, bool) {
+	block := g.blocks[blockRoot]
+	return block, block != nil
+}
+
+func (g *getFinalizedExecutionHashForkGraph) GetState(common.Hash, bool) (*state.CachingBeaconState, error) {
+	panic("not used")
+}
+
+func (g *getFinalizedExecutionHashForkGraph) GetCurrentJustifiedCheckpoint(common.Hash) (solid.Checkpoint, bool) {
+	panic("not used")
+}
+
+func (g *getFinalizedExecutionHashForkGraph) GetFinalizedCheckpoint(common.Hash) (solid.Checkpoint, bool) {
+	panic("not used")
+}
+
+func (g *getFinalizedExecutionHashForkGraph) GetSyncCommittees(uint64) (*solid.SyncCommittee, *solid.SyncCommittee, bool) {
+	panic("not used")
+}
+
+func (g *getFinalizedExecutionHashForkGraph) MarkHeaderAsInvalid(common.Hash) {
+	panic("not used")
+}
+
+func (g *getFinalizedExecutionHashForkGraph) AnchorSlot() uint64 {
+	panic("not used")
+}
+
+func (g *getFinalizedExecutionHashForkGraph) AnchorRoot() common.Hash {
+	panic("not used")
+}
+
+func (g *getFinalizedExecutionHashForkGraph) Prune(uint64) error {
+	panic("not used")
+}
+
+func (g *getFinalizedExecutionHashForkGraph) GetBlockRewards(common.Hash) (*eth2.BlockRewardsCollector, bool) {
+	panic("not used")
+}
+
+func (g *getFinalizedExecutionHashForkGraph) LowestAvailableSlot() uint64 {
+	panic("not used")
+}
+
+func (g *getFinalizedExecutionHashForkGraph) GetLightClientBootstrap(common.Hash) (*cltypes.LightClientBootstrap, bool) {
+	panic("not used")
+}
+
+func (g *getFinalizedExecutionHashForkGraph) NewestLightClientUpdate() *cltypes.LightClientUpdate {
+	panic("not used")
+}
+
+func (g *getFinalizedExecutionHashForkGraph) GetLightClientUpdate(uint64) (*cltypes.LightClientUpdate, bool) {
+	panic("not used")
+}
+
+func (g *getFinalizedExecutionHashForkGraph) GetBalances(common.Hash) (solid.Uint64ListSSZ, error) {
+	panic("not used")
+}
+
+func (g *getFinalizedExecutionHashForkGraph) GetInactivitiesScores(common.Hash) (solid.Uint64ListSSZ, error) {
+	panic("not used")
+}
+
+func (g *getFinalizedExecutionHashForkGraph) GetValidatorSet(common.Hash) (*solid.ValidatorSet, error) {
+	panic("not used")
+}
+
+func (g *getFinalizedExecutionHashForkGraph) GetCurrentParticipationIndicies(uint64) (*solid.ParticipationBitList, error) {
+	panic("not used")
+}
+
+func (g *getFinalizedExecutionHashForkGraph) GetPreviousParticipationIndicies(uint64) (*solid.ParticipationBitList, error) {
+	panic("not used")
+}
+
+func (g *getFinalizedExecutionHashForkGraph) DumpBeaconStateOnDisk(common.Hash, *state.CachingBeaconState, bool) error {
+	panic("not used")
+}
+
+func (g *getFinalizedExecutionHashForkGraph) DumpEnvelopeOnDisk(common.Hash, *cltypes.SignedExecutionPayloadEnvelope) error {
+	panic("not used")
+}
+
+func (g *getFinalizedExecutionHashForkGraph) ReadEnvelopeFromDisk(common.Hash) (*cltypes.SignedExecutionPayloadEnvelope, error) {
+	panic("not used")
+}
+
+func (g *getFinalizedExecutionHashForkGraph) HasEnvelope(common.Hash) bool {
+	panic("not used")
+}

--- a/cl/phase1/forkchoice/interface.go
+++ b/cl/phase1/forkchoice/interface.go
@@ -43,6 +43,9 @@ type ForkChoiceStorageReader interface {
 	FinalizedSlot() uint64
 	LowestAvailableSlot() uint64
 	GetEth1Hash(eth2Root common.Hash) common.Hash
+	// [New in Gloas:EIP7732] GetFinalizedExecutionHash returns the EL block hash for
+	// finalized/justified checkpoints, using parent_block_hash from the bid for Gloas+ blocks.
+	GetFinalizedExecutionHash(eth2Root common.Hash) common.Hash
 	GetHead(auxilliaryState *state.CachingBeaconState) (common.Hash, uint64, error)
 	HighestSeen() uint64
 	JustifiedCheckpoint() solid.Checkpoint
@@ -88,6 +91,9 @@ type ForkChoiceStorageReader interface {
 	// [New in Gloas:EIP7732] ShouldExtendPayload returns whether the payload for the given
 	// root should be extended. Used by prepare_execution_payload to decide FULL vs EMPTY path.
 	ShouldExtendPayload(root common.Hash) bool
+	// [New in Gloas:EIP7732] ShouldBuildOnFull returns whether the proposer should build on
+	// the full payload for the given head node. Used for proposer reorg of unavailable blocks.
+	ShouldBuildOnFull(head ForkChoiceNode) bool
 
 	GetBalances(blockRoot common.Hash) (solid.Uint64ListSSZ, error)
 	GetInactivitiesScores(blockRoot common.Hash) (solid.Uint64ListSSZ, error)
@@ -109,6 +115,10 @@ type ForkChoiceStorageReader interface {
 	// validated execution payload by its execution block hash. Used for parent payload validation in gossip.
 	// Note: This is an LRU cache lookup; older payloads may not be found.
 	GetRecentExecutionPayloadStatus(executionBlockHash common.Hash) (execution_client.PayloadStatus, bool)
+	// [New in Gloas:EIP7732] GetExecutionPayloadGasLimit returns the gas_limit of a recently validated
+	// execution payload by its execution block hash. Used by the bid service to perform the
+	// is_gas_limit_target_compatible IGNORE check (consensus-specs PR #5236).
+	GetExecutionPayloadGasLimit(executionBlockHash common.Hash) (uint64, bool)
 }
 
 type ForkChoiceStorageWriter interface {

--- a/cl/phase1/forkchoice/interface.go
+++ b/cl/phase1/forkchoice/interface.go
@@ -43,8 +43,7 @@ type ForkChoiceStorageReader interface {
 	FinalizedSlot() uint64
 	LowestAvailableSlot() uint64
 	GetEth1Hash(eth2Root common.Hash) common.Hash
-	// [New in Gloas:EIP7732] GetFinalizedExecutionHash returns the EL block hash for
-	// finalized/justified checkpoints, using parent_block_hash from the bid for Gloas+ blocks.
+	// GetFinalizedExecutionHash returns the EL block hash for finalized/justified checkpoints.
 	GetFinalizedExecutionHash(eth2Root common.Hash) common.Hash
 	GetHead(auxilliaryState *state.CachingBeaconState) (common.Hash, uint64, error)
 	HighestSeen() uint64

--- a/cl/phase1/forkchoice/mock_services/forkchoice_mock.go
+++ b/cl/phase1/forkchoice/mock_services/forkchoice_mock.go
@@ -82,6 +82,8 @@ type ForkChoiceStorageMock struct {
 
 	// [New in Gloas:EIP7732] Execution payload status by execution block hash
 	ExecutionPayloadStatusMap map[common.Hash]execution_client.PayloadStatus
+	// [New in Gloas:EIP7732] Execution payload gas limit by execution block hash
+	ExecutionPayloadGasLimitMap map[common.Hash]uint64
 }
 
 func makeSyncContributionPoolMock(t *testing.T) sync_contribution_pool.SyncContributionPool {
@@ -184,33 +186,34 @@ func NewForkChoiceStorageMock(t *testing.T) *ForkChoiceStorageMock {
 		AnyTimes()
 
 	return &ForkChoiceStorageMock{
-		Ancestors:                 make(map[uint64]forkchoice.ForkChoiceNode),
-		AnchorSlotVal:             0,
-		FinalizedCheckpointVal:    solid.Checkpoint{},
-		FinalizedSlotVal:          0,
-		HeadVal:                   common.Hash{},
-		HeadPayloadStatusVal:      cltypes.PayloadStatusFull,
-		HighestSeenVal:            0,
-		JustifiedCheckpointVal:    solid.Checkpoint{},
-		JustifiedSlotVal:          0,
-		ProposerBoostRootVal:      common.Hash{},
-		SlotVal:                   0,
-		TimeVal:                   0,
-		StateAtBlockRootVal:       make(map[common.Hash]*state.CachingBeaconState),
-		StateAtSlotVal:            make(map[uint64]*state.CachingBeaconState),
-		GetSyncCommitteesVal:      make(map[uint64][2]*solid.SyncCommittee),
-		GetFinalityCheckpointsVal: make(map[common.Hash][3]solid.Checkpoint),
-		LightClientBootstraps:     make(map[common.Hash]*cltypes.LightClientBootstrap),
-		LCUpdates:                 make(map[uint64]*cltypes.LightClientUpdate),
-		Headers:                   make(map[common.Hash]*cltypes.BeaconBlockHeader),
-		Blocks:                    make(map[common.Hash]*cltypes.SignedBeaconBlock),
-		Envelopes:                 make(map[common.Hash]*cltypes.SignedExecutionPayloadEnvelope),
-		GetBeaconCommitteeMock:    nil,
-		Eth1Hashes:                make(map[common.Hash]common.Hash),
-		ShouldExtendPayloadVal:    true,
-		SyncContributionPool:      makeSyncContributionPoolMock(t),
-		MockPeerDas:               mockPeerDas,
-		ExecutionPayloadStatusMap: make(map[common.Hash]execution_client.PayloadStatus),
+		Ancestors:                   make(map[uint64]forkchoice.ForkChoiceNode),
+		AnchorSlotVal:               0,
+		FinalizedCheckpointVal:      solid.Checkpoint{},
+		FinalizedSlotVal:            0,
+		HeadVal:                     common.Hash{},
+		HeadPayloadStatusVal:        cltypes.PayloadStatusFull,
+		HighestSeenVal:              0,
+		JustifiedCheckpointVal:      solid.Checkpoint{},
+		JustifiedSlotVal:            0,
+		ProposerBoostRootVal:        common.Hash{},
+		SlotVal:                     0,
+		TimeVal:                     0,
+		StateAtBlockRootVal:         make(map[common.Hash]*state.CachingBeaconState),
+		StateAtSlotVal:              make(map[uint64]*state.CachingBeaconState),
+		GetSyncCommitteesVal:        make(map[uint64][2]*solid.SyncCommittee),
+		GetFinalityCheckpointsVal:   make(map[common.Hash][3]solid.Checkpoint),
+		LightClientBootstraps:       make(map[common.Hash]*cltypes.LightClientBootstrap),
+		LCUpdates:                   make(map[uint64]*cltypes.LightClientUpdate),
+		Headers:                     make(map[common.Hash]*cltypes.BeaconBlockHeader),
+		Blocks:                      make(map[common.Hash]*cltypes.SignedBeaconBlock),
+		Envelopes:                   make(map[common.Hash]*cltypes.SignedExecutionPayloadEnvelope),
+		GetBeaconCommitteeMock:      nil,
+		Eth1Hashes:                  make(map[common.Hash]common.Hash),
+		ShouldExtendPayloadVal:      true,
+		SyncContributionPool:        makeSyncContributionPoolMock(t),
+		MockPeerDas:                 mockPeerDas,
+		ExecutionPayloadStatusMap:   make(map[common.Hash]execution_client.PayloadStatus),
+		ExecutionPayloadGasLimitMap: make(map[common.Hash]uint64),
 	}
 }
 
@@ -247,6 +250,10 @@ func (f *ForkChoiceStorageMock) GetEth1Hash(eth2Root common.Hash) common.Hash {
 		return f.Eth1Hashes[eth2Root]
 	}
 	return common.Hash{}
+}
+
+func (f *ForkChoiceStorageMock) GetFinalizedExecutionHash(eth2Root common.Hash) common.Hash {
+	return f.GetEth1Hash(eth2Root)
 }
 
 func (f *ForkChoiceStorageMock) GetHead(_ *state.CachingBeaconState) (common.Hash, uint64, error) {
@@ -435,6 +442,10 @@ func (f *ForkChoiceStorageMock) ShouldExtendPayload(root common.Hash) bool {
 	return f.ShouldExtendPayloadVal
 }
 
+func (f *ForkChoiceStorageMock) ShouldBuildOnFull(head forkchoice.ForkChoiceNode) bool {
+	return true
+}
+
 func (f *ForkChoiceStorageMock) GetBalances(blockRoot common.Hash) (solid.Uint64ListSSZ, error) {
 	panic("implement me")
 }
@@ -517,4 +528,11 @@ func (f *ForkChoiceStorageMock) GetProposerLookahead(slot uint64) (solid.Uint64V
 func (f *ForkChoiceStorageMock) GetRecentExecutionPayloadStatus(executionBlockHash common.Hash) (execution_client.PayloadStatus, bool) {
 	status, ok := f.ExecutionPayloadStatusMap[executionBlockHash]
 	return status, ok
+}
+
+// GetExecutionPayloadGasLimit returns the gas_limit of a recently validated execution payload.
+// [New in Gloas:EIP7732]
+func (f *ForkChoiceStorageMock) GetExecutionPayloadGasLimit(executionBlockHash common.Hash) (uint64, bool) {
+	gasLimit, ok := f.ExecutionPayloadGasLimitMap[executionBlockHash]
+	return gasLimit, ok
 }

--- a/cl/phase1/forkchoice/on_block.go
+++ b/cl/phase1/forkchoice/on_block.go
@@ -321,8 +321,8 @@ func (f *ForkChoiceStore) OnBlock(ctx context.Context, block *cltypes.SignedBeac
 	var appliedEnvelope *cltypes.ExecutionPayloadEnvelope
 	if blockVersion >= clparams.GloasVersion {
 		// Initialize payload timeliness and data availability votes for this block
-		f.payloadTimelinessVote.Store(common.Hash(blockRoot), [clparams.PtcSize]bool{})
-		f.payloadDataAvailabilityVote.Store(common.Hash(blockRoot), [clparams.PtcSize]bool{})
+		f.payloadTimelinessVote.Store(common.Hash(blockRoot), [clparams.PtcSize]int8{})
+		f.payloadDataAvailabilityVote.Store(common.Hash(blockRoot), [clparams.PtcSize]int8{})
 
 		// Notify PTC messages from payload attestations in the block.
 		// Skip during forward sync (newPayload=false) — PTC votes only matter

--- a/cl/phase1/forkchoice/on_block.go
+++ b/cl/phase1/forkchoice/on_block.go
@@ -219,9 +219,10 @@ func (f *ForkChoiceStore) OnBlock(ctx context.Context, block *cltypes.SignedBeac
 			monitor.ObserveNewPayloadTime(timeStartExec)
 			log.Trace("[OnBlock] NewPayload", "status", payloadStatus, "blockSlot", block.Block.Slot)
 
-			// Track payload status by execution block hash for GLOAS parent payload validation
+			// Track payload status and gas limit by execution block hash for GLOAS parent payload validation
 			executionBlockHash := block.Block.Body.ExecutionPayload.BlockHash
 			f.executionPayloadStatus.Add(executionBlockHash, payloadStatus)
+			f.executionPayloadGasLimit.Add(executionBlockHash, block.Block.Body.ExecutionPayload.GasLimit)
 
 			switch payloadStatus {
 			case execution_client.PayloadStatusNone:

--- a/cl/phase1/forkchoice/on_execution_payload.go
+++ b/cl/phase1/forkchoice/on_execution_payload.go
@@ -271,9 +271,10 @@ func (f *ForkChoiceStore) validatePayloadWithEL(
 	monitor.ObserveNewPayloadTime(timeStartExec)
 	log.Trace("[validatePayloadWithEL] NewPayload", "status", payloadStatus, "beaconBlockRoot", beaconBlockRoot)
 
-	// Track payload status by execution block hash for parent payload validation
+	// Track payload status and gas limit by execution block hash for parent payload validation
 	executionBlockHash := envelope.Payload.BlockHash
 	f.executionPayloadStatus.Add(executionBlockHash, payloadStatus)
+	f.executionPayloadGasLimit.Add(executionBlockHash, envelope.Payload.GasLimit)
 
 	switch payloadStatus {
 	case execution_client.PayloadStatusNone:

--- a/cl/phase1/forkchoice/on_payload_attestation_message.go
+++ b/cl/phase1/forkchoice/on_payload_attestation_message.go
@@ -107,17 +107,17 @@ func (f *ForkChoiceStore) OnPayloadAttestationMessage(
 	// Load→modify→Store from losing votes. See also applyPayloadAttestationVote.
 	f.ptcVoteMu.Lock()
 
-	var timelinessVotes [clparams.PtcSize]bool
+	var timelinessVotes [clparams.PtcSize]int8
 	if existing, ok := f.payloadTimelinessVote.Load(blockRoot); ok {
-		timelinessVotes = existing.([clparams.PtcSize]bool)
+		timelinessVotes = existing.([clparams.PtcSize]int8)
 	}
-	var dataAvailabilityVotes [clparams.PtcSize]bool
+	var dataAvailabilityVotes [clparams.PtcSize]int8
 	if existing, ok := f.payloadDataAvailabilityVote.Load(blockRoot); ok {
-		dataAvailabilityVotes = existing.([clparams.PtcSize]bool)
+		dataAvailabilityVotes = existing.([clparams.PtcSize]int8)
 	}
 	for _, idx := range ptcIndices {
-		timelinessVotes[idx] = data.PayloadPresent
-		dataAvailabilityVotes[idx] = data.BlobDataAvailable
+		timelinessVotes[idx] = boolToVote(data.PayloadPresent)
+		dataAvailabilityVotes[idx] = boolToVote(data.BlobDataAvailable)
 	}
 	f.payloadTimelinessVote.Store(blockRoot, timelinessVotes)
 	f.payloadDataAvailabilityVote.Store(blockRoot, dataAvailabilityVotes)

--- a/cl/phase1/forkchoice/on_payload_attestation_message.go
+++ b/cl/phase1/forkchoice/on_payload_attestation_message.go
@@ -67,14 +67,13 @@ func (f *ForkChoiceStore) OnPayloadAttestationMessage(
 	}
 
 	// [REJECT] Check that the attester is from the PTC
-	ptcIndex := -1
+	var ptcIndices []int
 	for i, idx := range ptc {
 		if idx == msg.ValidatorIndex {
-			ptcIndex = i
-			break
+			ptcIndices = append(ptcIndices, i)
 		}
 	}
-	if ptcIndex == -1 {
+	if len(ptcIndices) == 0 {
 		return fmt.Errorf("validator %d is not in PTC for slot %d", msg.ValidatorIndex, data.Slot)
 	}
 
@@ -108,20 +107,19 @@ func (f *ForkChoiceStore) OnPayloadAttestationMessage(
 	// Load→modify→Store from losing votes. See also applyPayloadAttestationVote.
 	f.ptcVoteMu.Lock()
 
-	// Get or initialize the payload timeliness vote array for this block root
 	var timelinessVotes [clparams.PtcSize]bool
 	if existing, ok := f.payloadTimelinessVote.Load(blockRoot); ok {
 		timelinessVotes = existing.([clparams.PtcSize]bool)
 	}
-	timelinessVotes[ptcIndex] = data.PayloadPresent
-	f.payloadTimelinessVote.Store(blockRoot, timelinessVotes)
-
-	// Get or initialize the data availability vote array for this block root
 	var dataAvailabilityVotes [clparams.PtcSize]bool
 	if existing, ok := f.payloadDataAvailabilityVote.Load(blockRoot); ok {
 		dataAvailabilityVotes = existing.([clparams.PtcSize]bool)
 	}
-	dataAvailabilityVotes[ptcIndex] = data.BlobDataAvailable
+	for _, idx := range ptcIndices {
+		timelinessVotes[idx] = data.PayloadPresent
+		dataAvailabilityVotes[idx] = data.BlobDataAvailable
+	}
+	f.payloadTimelinessVote.Store(blockRoot, timelinessVotes)
 	f.payloadDataAvailabilityVote.Store(blockRoot, dataAvailabilityVotes)
 
 	f.ptcVoteMu.Unlock()

--- a/cl/phase1/forkchoice/payload_vote.go
+++ b/cl/phase1/forkchoice/payload_vote.go
@@ -28,6 +28,15 @@ import (
 	log "github.com/erigontech/erigon/common/log/v3"
 )
 
+// boolToVote converts a bool to the three-state vote representation:
+// true → 1, false → -1. Zero means unvoted.
+func boolToVote(b bool) int8 {
+	if b {
+		return 1
+	}
+	return -1
+}
+
 func (f *ForkChoiceStore) calculateCommitteeFraction(s *state.CachingBeaconState, committeePercent uint64) uint64 {
 	committeeWeight := s.GetTotalActiveBalance() / f.beaconCfg.SlotsPerEpoch
 	return (committeeWeight * committeePercent) / 100
@@ -103,16 +112,16 @@ func (f *ForkChoiceStore) applyPayloadAttestationVote(
 	// Load→modify→Store from losing votes. See also OnPayloadAttestationMessage.
 	f.ptcVoteMu.Lock()
 
-	var timelinessVotes [clparams.PtcSize]bool
+	var timelinessVotes [clparams.PtcSize]int8
 	if existing, ok := f.payloadTimelinessVote.Load(blockRoot); ok {
-		timelinessVotes = existing.([clparams.PtcSize]bool)
+		timelinessVotes = existing.([clparams.PtcSize]int8)
 	}
-	var dataAvailabilityVotes [clparams.PtcSize]bool
+	var dataAvailabilityVotes [clparams.PtcSize]int8
 	if existing, ok := f.payloadDataAvailabilityVote.Load(blockRoot); ok {
-		dataAvailabilityVotes = existing.([clparams.PtcSize]bool)
+		dataAvailabilityVotes = existing.([clparams.PtcSize]int8)
 	}
-	timelinessVotes[ptcIndex] = data.PayloadPresent
-	dataAvailabilityVotes[ptcIndex] = data.BlobDataAvailable
+	timelinessVotes[ptcIndex] = boolToVote(data.PayloadPresent)
+	dataAvailabilityVotes[ptcIndex] = boolToVote(data.BlobDataAvailable)
 	f.payloadTimelinessVote.Store(blockRoot, timelinessVotes)
 	f.payloadDataAvailabilityVote.Store(blockRoot, dataAvailabilityVotes)
 
@@ -130,10 +139,11 @@ func (f *ForkChoiceStore) payloadTimeliness(root common.Hash, timely bool) bool 
 	if !f.forkGraph.HasEnvelope(root) {
 		return false
 	}
-	votes := voteRaw.([clparams.PtcSize]bool)
+	votes := voteRaw.([clparams.PtcSize]int8)
+	target := boolToVote(timely)
 	count := uint64(0)
 	for i := range votes {
-		if votes[i] == timely {
+		if votes[i] == target {
 			count++
 		}
 	}
@@ -151,10 +161,11 @@ func (f *ForkChoiceStore) payloadDataAvailability(root common.Hash, available bo
 	if !f.forkGraph.HasEnvelope(root) {
 		return false
 	}
-	votes := voteRaw.([clparams.PtcSize]bool)
+	votes := voteRaw.([clparams.PtcSize]int8)
+	target := boolToVote(available)
 	count := uint64(0)
 	for i := range votes {
-		if votes[i] == available {
+		if votes[i] == target {
 			count++
 		}
 	}

--- a/cl/phase1/forkchoice/payload_vote.go
+++ b/cl/phase1/forkchoice/payload_vote.go
@@ -107,73 +107,58 @@ func (f *ForkChoiceStore) applyPayloadAttestationVote(
 	if existing, ok := f.payloadTimelinessVote.Load(blockRoot); ok {
 		timelinessVotes = existing.([clparams.PtcSize]bool)
 	}
-	timelinessVotes[ptcIndex] = data.PayloadPresent
-	f.payloadTimelinessVote.Store(blockRoot, timelinessVotes)
-
 	var dataAvailabilityVotes [clparams.PtcSize]bool
 	if existing, ok := f.payloadDataAvailabilityVote.Load(blockRoot); ok {
 		dataAvailabilityVotes = existing.([clparams.PtcSize]bool)
 	}
+	timelinessVotes[ptcIndex] = data.PayloadPresent
 	dataAvailabilityVotes[ptcIndex] = data.BlobDataAvailable
+	f.payloadTimelinessVote.Store(blockRoot, timelinessVotes)
 	f.payloadDataAvailabilityVote.Store(blockRoot, dataAvailabilityVotes)
 
 	f.ptcVoteMu.Unlock()
 }
 
-// isPayloadTimely returns whether the execution payload for the beacon block with root
-// was voted as present by the PTC, and was locally determined to be available.
+// payloadTimeliness returns whether the PTC voted the payload as timely (timely=true)
+// or not timely (timely=false) for the given beacon block root.
 // [New in Gloas:EIP7732]
-func (f *ForkChoiceStore) isPayloadTimely(root common.Hash) bool {
-	// The beacon block root must be known in payload_timeliness_vote
+func (f *ForkChoiceStore) payloadTimeliness(root common.Hash, timely bool) bool {
 	voteRaw, ok := f.payloadTimelinessVote.Load(root)
 	if !ok {
-		return false
+		return !timely
 	}
-
-	// If the payload is not locally available, the payload
-	// is not considered available regardless of the PTC vote
 	if !f.forkGraph.HasEnvelope(root) {
-		return false
+		return !timely
 	}
-
-	// Count PTC votes for payload present
 	votes := voteRaw.([clparams.PtcSize]bool)
-	presentCount := uint64(0)
+	count := uint64(0)
 	for i := range votes {
-		if votes[i] {
-			presentCount++
+		if votes[i] == timely {
+			count++
 		}
 	}
-
-	return presentCount > f.beaconCfg.PtcSize/2
+	return count > f.beaconCfg.PtcSize/2
 }
 
-// isPayloadDataAvailable returns whether the blob data for the beacon block with root
-// was voted as present by the PTC, and was locally determined to be available.
+// payloadDataAvailability returns whether the PTC voted blob data as available (available=true)
+// or unavailable (available=false) for the given beacon block root.
 // [New in Gloas:EIP7732]
-func (f *ForkChoiceStore) isPayloadDataAvailable(root common.Hash) bool {
-	// The beacon block root must be known in payload_data_availability_vote
+func (f *ForkChoiceStore) payloadDataAvailability(root common.Hash, available bool) bool {
 	voteRaw, ok := f.payloadDataAvailabilityVote.Load(root)
 	if !ok {
-		return false
+		return !available
 	}
-
-	// If the payload is not locally available, the blob data
-	// is not considered available regardless of the PTC vote
 	if !f.forkGraph.HasEnvelope(root) {
-		return false
+		return !available
 	}
-
-	// Count PTC votes for data available
 	votes := voteRaw.([clparams.PtcSize]bool)
-	availableCount := uint64(0)
+	count := uint64(0)
 	for i := range votes {
-		if votes[i] {
-			availableCount++
+		if votes[i] == available {
+			count++
 		}
 	}
-
-	return availableCount > f.beaconCfg.PtcSize/2
+	return count > f.beaconCfg.PtcSize/2
 }
 
 // getParentPayloadStatus returns the payload status of the parent block.
@@ -276,7 +261,7 @@ func (f *ForkChoiceStore) ShouldExtendPayload(root common.Hash) bool {
 	}
 
 	// Check if payload is timely AND blob data is available
-	if f.isPayloadTimely(root) && f.isPayloadDataAvailable(root) {
+	if f.payloadTimeliness(root, true) && f.payloadDataAvailability(root, true) {
 		return true
 	}
 
@@ -301,6 +286,17 @@ func (f *ForkChoiceStore) ShouldExtendPayload(root common.Hash) bool {
 
 	// Check if parent node is full
 	return f.isParentNodeFull(proposerBlock.Block)
+}
+
+// ShouldBuildOnFull returns whether the proposer should build on the full payload
+// for the given head node. Returns false for EMPTY heads. For FULL heads, returns
+// true unless the PTC voted blob data as unavailable.
+// [New in Gloas:EIP7732]
+func (f *ForkChoiceStore) ShouldBuildOnFull(head ForkChoiceNode) bool {
+	if head.PayloadStatus == cltypes.PayloadStatusEmpty {
+		return false
+	}
+	return !f.payloadDataAvailability(head.Root, false)
 }
 
 // getPayloadStatusTiebreaker returns a tiebreaker value for fork choice comparison.

--- a/cl/phase1/forkchoice/payload_vote.go
+++ b/cl/phase1/forkchoice/payload_vote.go
@@ -125,10 +125,10 @@ func (f *ForkChoiceStore) applyPayloadAttestationVote(
 func (f *ForkChoiceStore) payloadTimeliness(root common.Hash, timely bool) bool {
 	voteRaw, ok := f.payloadTimelinessVote.Load(root)
 	if !ok {
-		return !timely
+		return false
 	}
 	if !f.forkGraph.HasEnvelope(root) {
-		return !timely
+		return false
 	}
 	votes := voteRaw.([clparams.PtcSize]bool)
 	count := uint64(0)
@@ -146,10 +146,10 @@ func (f *ForkChoiceStore) payloadTimeliness(root common.Hash, timely bool) bool 
 func (f *ForkChoiceStore) payloadDataAvailability(root common.Hash, available bool) bool {
 	voteRaw, ok := f.payloadDataAvailabilityVote.Load(root)
 	if !ok {
-		return !available
+		return false
 	}
 	if !f.forkGraph.HasEnvelope(root) {
-		return !available
+		return false
 	}
 	votes := voteRaw.([clparams.PtcSize]bool)
 	count := uint64(0)

--- a/cl/phase1/forkchoice/payload_vote_test.go
+++ b/cl/phase1/forkchoice/payload_vote_test.go
@@ -4,10 +4,22 @@ import (
 	"testing"
 
 	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
 	state2 "github.com/erigontech/erigon/cl/phase1/core/state"
+	"github.com/erigontech/erigon/cl/phase1/forkchoice/fork_graph"
+	"github.com/erigontech/erigon/common"
 	"github.com/stretchr/testify/require"
 )
+
+type ptcVoteForkGraph struct {
+	fork_graph.ForkGraph
+	envelopes map[common.Hash]bool
+}
+
+func (g ptcVoteForkGraph) HasEnvelope(root common.Hash) bool {
+	return g.envelopes[root]
+}
 
 func TestGetPTCFromWindow(t *testing.T) {
 	cfg := &clparams.MainnetBeaconConfig
@@ -43,4 +55,182 @@ func TestGetPTCFromWindowRejectsSlotOutsideWindow(t *testing.T) {
 
 	_, err := s.GetPTCFromWindow(0)
 	require.Error(t, err)
+}
+
+func TestPtcBoolToVote(t *testing.T) {
+	require.Equal(t, int8(1), boolToVote(true))
+	require.Equal(t, int8(-1), boolToVote(false))
+}
+
+func TestPtcPayloadTimelinessVoteCounting(t *testing.T) {
+	root := common.HexToHash("0x01")
+	f := newPtcVoteTestStore(root)
+
+	for _, tc := range []struct {
+		name       string
+		trueVotes  int
+		falseVotes int
+		timely     bool
+		want       bool
+	}{
+		{
+			name:   "all unvoted does not reach true majority",
+			timely: true,
+			want:   false,
+		},
+		{
+			name:   "all unvoted does not reach false majority",
+			timely: false,
+			want:   false,
+		},
+		{
+			name:       "exactly at true threshold is not majority",
+			trueVotes:  ptcVoteThreshold(),
+			falseVotes: 0,
+			timely:     true,
+			want:       false,
+		},
+		{
+			name:      "true votes over threshold reach majority",
+			trueVotes: ptcVoteThreshold() + 1,
+			timely:    true,
+			want:      true,
+		},
+		{
+			name:       "false votes over threshold reach majority",
+			falseVotes: ptcVoteThreshold() + 1,
+			timely:     false,
+			want:       true,
+		},
+		{
+			name:       "mixed votes exactly split do not reach majority",
+			trueVotes:  ptcVoteThreshold(),
+			falseVotes: ptcVoteThreshold(),
+			timely:     true,
+			want:       false,
+		},
+		{
+			name:       "mixed votes count only explicit true votes",
+			trueVotes:  ptcVoteThreshold() + 1,
+			falseVotes: ptcVoteThreshold() - 1,
+			timely:     true,
+			want:       true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f.payloadTimelinessVote.Store(root, ptcVotes(tc.trueVotes, tc.falseVotes))
+			require.Equal(t, tc.want, f.payloadTimeliness(root, tc.timely))
+		})
+	}
+}
+
+func TestPtcPayloadDataAvailabilityVoteCounting(t *testing.T) {
+	root := common.HexToHash("0x02")
+	f := newPtcVoteTestStore(root)
+
+	for _, tc := range []struct {
+		name       string
+		trueVotes  int
+		falseVotes int
+		available  bool
+		want       bool
+	}{
+		{
+			name:      "all unvoted does not reach available majority",
+			available: true,
+			want:      false,
+		},
+		{
+			name:      "all unvoted does not reach unavailable majority",
+			available: false,
+			want:      false,
+		},
+		{
+			name:       "exactly at unavailable threshold is not majority",
+			falseVotes: ptcVoteThreshold(),
+			available:  false,
+			want:       false,
+		},
+		{
+			name:      "available votes over threshold reach majority",
+			trueVotes: ptcVoteThreshold() + 1,
+			available: true,
+			want:      true,
+		},
+		{
+			name:       "unavailable votes over threshold reach majority",
+			falseVotes: ptcVoteThreshold() + 1,
+			available:  false,
+			want:       true,
+		},
+		{
+			name:       "mixed votes exactly split do not reach majority",
+			trueVotes:  ptcVoteThreshold(),
+			falseVotes: ptcVoteThreshold(),
+			available:  false,
+			want:       false,
+		},
+		{
+			name:       "mixed votes count only explicit unavailable votes",
+			trueVotes:  ptcVoteThreshold() - 1,
+			falseVotes: ptcVoteThreshold() + 1,
+			available:  false,
+			want:       true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f.payloadDataAvailabilityVote.Store(root, ptcVotes(tc.trueVotes, tc.falseVotes))
+			require.Equal(t, tc.want, f.payloadDataAvailability(root, tc.available))
+		})
+	}
+}
+
+func TestPtcShouldBuildOnFullNoVotesCast(t *testing.T) {
+	root := common.HexToHash("0x03")
+	f := newPtcVoteTestStore(root)
+	head := ForkChoiceNode{Root: root, PayloadStatus: cltypes.PayloadStatusFull}
+
+	require.True(t, f.ShouldBuildOnFull(head))
+
+	f.payloadDataAvailabilityVote.Store(root, ptcVotes(0, 0))
+	require.True(t, f.ShouldBuildOnFull(head))
+}
+
+func TestPtcShouldBuildOnFullWithUnavailableMajority(t *testing.T) {
+	root := common.HexToHash("0x04")
+	f := newPtcVoteTestStore(root)
+	f.payloadDataAvailabilityVote.Store(root, ptcVotes(0, ptcVoteThreshold()+1))
+
+	require.False(t, f.ShouldBuildOnFull(ForkChoiceNode{
+		Root:          root,
+		PayloadStatus: cltypes.PayloadStatusFull,
+	}))
+	require.False(t, f.ShouldBuildOnFull(ForkChoiceNode{
+		Root:          root,
+		PayloadStatus: cltypes.PayloadStatusEmpty,
+	}))
+}
+
+func newPtcVoteTestStore(root common.Hash) *ForkChoiceStore {
+	return &ForkChoiceStore{
+		beaconCfg: &clparams.MainnetBeaconConfig,
+		forkGraph: ptcVoteForkGraph{
+			envelopes: map[common.Hash]bool{root: true},
+		},
+	}
+}
+
+func ptcVoteThreshold() int {
+	return int(clparams.MainnetBeaconConfig.PtcSize / 2)
+}
+
+func ptcVotes(trueVotes, falseVotes int) [clparams.PtcSize]int8 {
+	var votes [clparams.PtcSize]int8
+	for i := 0; i < trueVotes; i++ {
+		votes[i] = boolToVote(true)
+	}
+	for i := trueVotes; i < trueVotes+falseVotes; i++ {
+		votes[i] = boolToVote(false)
+	}
+	return votes
 }

--- a/cl/phase1/network/services/execution_payload_bid_service.go
+++ b/cl/phase1/network/services/execution_payload_bid_service.go
@@ -18,6 +18,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -56,6 +57,8 @@ type pendingBidJob struct {
 	msg          *cltypes.SignedExecutionPayloadBid
 	creationTime time.Time
 }
+
+var errBidDependencyUnavailable = fmt.Errorf("%w: bid dependency unavailable", ErrIgnore)
 
 const (
 	// seenBidCacheSize: multiple builders can bid per slot.
@@ -149,6 +152,12 @@ func (s *executionPayloadBidService) ProcessMessage(ctx context.Context, _ *uint
 
 	preferences, ok, err := s.matchingProposerPreferences(msg)
 	if err != nil {
+		if errors.Is(err, errBidDependencyUnavailable) {
+			s.queuePendingBid(msg)
+			log.Trace("Queued execution payload bid waiting for dependencies",
+				"slot", slot, "builderIndex", builderIndex, "err", err)
+			return nil
+		}
 		return err
 	}
 	if !ok {
@@ -166,7 +175,7 @@ func (s *executionPayloadBidService) matchingProposerPreferences(msg *cltypes.Si
 	bid := msg.Message
 	parentState, err := s.forkchoiceStore.GetStateAtBlockRoot(bid.ParentBlockRoot, false)
 	if err != nil || parentState == nil {
-		return nil, false, fmt.Errorf("%w: state for parent_block_root %v not available", ErrIgnore, bid.ParentBlockRoot)
+		return nil, false, fmt.Errorf("%w: state for parent_block_root %v not available", errBidDependencyUnavailable, bid.ParentBlockRoot)
 	}
 	proposalEpoch := state.GetEpochAtSlot(s.beaconCfg, bid.Slot)
 	dependentRootState, err := s.proposerDependentRootState(parentState, proposalEpoch)
@@ -402,6 +411,9 @@ func (s *executionPayloadBidService) processPendingBids() {
 
 		preferences, ok, err := s.matchingProposerPreferences(job.msg)
 		if err != nil {
+			if errors.Is(err, errBidDependencyUnavailable) {
+				return true
+			}
 			s.pendingBids.Delete(pendingKey)
 			s.pendingCount.Add(-1)
 			log.Trace("Failed to match pending execution payload bid",

--- a/cl/phase1/network/services/execution_payload_bid_service.go
+++ b/cl/phase1/network/services/execution_payload_bid_service.go
@@ -32,6 +32,7 @@ import (
 	"github.com/erigontech/erigon/cl/phase1/core/state/lru"
 	"github.com/erigontech/erigon/cl/phase1/forkchoice"
 	"github.com/erigontech/erigon/cl/pool"
+	"github.com/erigontech/erigon/cl/transition"
 	"github.com/erigontech/erigon/cl/utils/eth_clock"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -146,9 +147,11 @@ func (s *executionPayloadBidService) ProcessMessage(ctx context.Context, _ *uint
 		return fmt.Errorf("%w: bid slot %d is not current (%d) or next slot", ErrIgnore, slot, currentSlot)
 	}
 
-	// [IGNORE] SignedProposerPreferences for bid.slot has been seen
-	allPreferences := s.epbsPool.GetPreferencesForSlot(slot)
-	if len(allPreferences) == 0 {
+	preferences, ok, err := s.matchingProposerPreferences(msg)
+	if err != nil {
+		return err
+	}
+	if !ok {
 		// Queue as pending — preferences may arrive later
 		s.queuePendingBid(msg)
 		log.Trace("Queued execution payload bid waiting for proposer preferences",
@@ -156,16 +159,45 @@ func (s *executionPayloadBidService) ProcessMessage(ctx context.Context, _ *uint
 		return nil
 	}
 
-	// Try all preferences for this slot (may differ by dependent_root / fork).
-	// Accept the bid if it validates against ANY of them.
-	var lastErr error
-	for _, pref := range allPreferences {
-		lastErr = s.validateAndStoreBid(msg, pref)
-		if lastErr == nil {
-			return nil
-		}
+	return s.validateAndStoreBid(msg, preferences)
+}
+
+func (s *executionPayloadBidService) matchingProposerPreferences(msg *cltypes.SignedExecutionPayloadBid) (*cltypes.SignedProposerPreferences, bool, error) {
+	bid := msg.Message
+	parentState, err := s.forkchoiceStore.GetStateAtBlockRoot(bid.ParentBlockRoot, false)
+	if err != nil || parentState == nil {
+		return nil, false, fmt.Errorf("%w: state for parent_block_root %v not available", ErrIgnore, bid.ParentBlockRoot)
 	}
-	return lastErr
+	proposalEpoch := state.GetEpochAtSlot(s.beaconCfg, bid.Slot)
+	dependentRootState, err := s.proposerDependentRootState(parentState, proposalEpoch)
+	if err != nil {
+		return nil, false, fmt.Errorf("%w: failed to prepare parent state: %v", ErrIgnore, err)
+	}
+	dependentRoot, err := state.GetProposerDependentRoot(dependentRootState, proposalEpoch)
+	if err != nil {
+		return nil, false, fmt.Errorf("%w: failed to compute proposer dependent root: %v", ErrIgnore, err)
+	}
+	preferences, ok := s.epbsPool.GetPreference(bid.Slot, dependentRoot)
+	return preferences, ok, nil
+}
+
+func (s *executionPayloadBidService) proposerDependentRootState(parentState *state.CachingBeaconState, proposalEpoch uint64) (*state.CachingBeaconState, error) {
+	if proposalEpoch < s.beaconCfg.MinSeedLookahead {
+		return nil, fmt.Errorf("proposal epoch %d before min seed lookahead %d", proposalEpoch, s.beaconCfg.MinSeedLookahead)
+	}
+	dependentEpoch := proposalEpoch - s.beaconCfg.MinSeedLookahead
+	validationSlot := dependentEpoch * s.beaconCfg.SlotsPerEpoch
+	if parentState.Slot() >= validationSlot {
+		return parentState, nil
+	}
+	validationState, err := parentState.Copy()
+	if err != nil {
+		return nil, err
+	}
+	if err := transition.DefaultMachine.ProcessSlots(validationState, validationSlot); err != nil {
+		return nil, err
+	}
+	return validationState, nil
 }
 
 // validateAndStoreBid performs all remaining validation checks after preferences are confirmed.
@@ -368,29 +400,29 @@ func (s *executionPayloadBidService) processPendingBids() {
 			return true
 		}
 
-		// Check if preferences have arrived
-		allPreferences := s.epbsPool.GetPreferencesForSlot(pendingKey.slot)
-		if len(allPreferences) == 0 {
+		preferences, ok, err := s.matchingProposerPreferences(job.msg)
+		if err != nil {
+			s.pendingBids.Delete(pendingKey)
+			s.pendingCount.Add(-1)
+			log.Trace("Failed to match pending execution payload bid",
+				"slot", pendingKey.slot,
+				"builderIndex", pendingKey.builderIndex,
+				"err", err)
+			return true
+		}
+		if !ok {
 			return true // Preferences still not here, keep waiting
 		}
 
 		// Preferences arrived, remove from pending and process.
-		// Try all preferences (may differ by dependent_root / fork).
 		s.pendingBids.Delete(pendingKey)
 		s.pendingCount.Add(-1)
 
-		var lastErr error
-		for _, pref := range allPreferences {
-			lastErr = s.validateAndStoreBid(job.msg, pref)
-			if lastErr == nil {
-				break
-			}
-		}
-		if lastErr != nil {
+		if err := s.validateAndStoreBid(job.msg, preferences); err != nil {
 			log.Trace("Failed to process pending execution payload bid",
 				"slot", pendingKey.slot,
 				"builderIndex", pendingKey.builderIndex,
-				"err", lastErr)
+				"err", err)
 		}
 		return true
 	})

--- a/cl/phase1/network/services/execution_payload_bid_service.go
+++ b/cl/phase1/network/services/execution_payload_bid_service.go
@@ -240,8 +240,7 @@ func (s *executionPayloadBidService) validateAndStoreBid(
 			ErrIgnore, bid.ParentBlockHash)
 	}
 
-	// [IGNORE] bid.gas_limit is compatible with target_gas_limit given parent gas limit
-	// (consensus-specs PR #5236: replaces the former REJECT on exact gas_limit match)
+	// [IGNORE] gas_limit compatibility check — skipped (not rejected) when parent is absent from the LRU.
 	if parentGasLimit, ok := s.forkchoiceStore.GetExecutionPayloadGasLimit(bid.ParentBlockHash); ok {
 		if !IsGasLimitTargetCompatible(parentGasLimit, bid.GasLimit, prefs.TargetGasLimit) {
 			return fmt.Errorf("%w: bid gas_limit %d not compatible with target %d (parent %d)",

--- a/cl/phase1/network/services/execution_payload_bid_service.go
+++ b/cl/phase1/network/services/execution_payload_bid_service.go
@@ -178,12 +178,6 @@ func (s *executionPayloadBidService) validateAndStoreBid(
 	builderIndex := bid.BuilderIndex
 	prefs := preferences.Message
 
-	// [REJECT] bid.gas_limit matches preferences
-	if bid.GasLimit != prefs.GasLimit {
-		return fmt.Errorf("bid gas_limit %d does not match preferences %d",
-			bid.GasLimit, prefs.GasLimit)
-	}
-
 	// [IGNORE] First valid bid from this builder for this slot
 	seenKey := seenBidKey{builderIndex: builderIndex, slot: slot}
 	if s.seenCache.Contains(seenKey) {
@@ -244,6 +238,15 @@ func (s *executionPayloadBidService) validateAndStoreBid(
 	if _, ok := s.forkchoiceStore.GetRecentExecutionPayloadStatus(bid.ParentBlockHash); !ok {
 		return fmt.Errorf("%w: parent_block_hash %v not known in fork choice",
 			ErrIgnore, bid.ParentBlockHash)
+	}
+
+	// [IGNORE] bid.gas_limit is compatible with target_gas_limit given parent gas limit
+	// (consensus-specs PR #5236: replaces the former REJECT on exact gas_limit match)
+	if parentGasLimit, ok := s.forkchoiceStore.GetExecutionPayloadGasLimit(bid.ParentBlockHash); ok {
+		if !IsGasLimitTargetCompatible(parentGasLimit, bid.GasLimit, prefs.TargetGasLimit) {
+			return fmt.Errorf("%w: bid gas_limit %d not compatible with target %d (parent %d)",
+				ErrIgnore, bid.GasLimit, prefs.TargetGasLimit, parentGasLimit)
+		}
 	}
 
 	// [IGNORE] parent_block_root is known in fork choice

--- a/cl/phase1/network/services/execution_payload_bid_service.go
+++ b/cl/phase1/network/services/execution_payload_bid_service.go
@@ -178,6 +178,17 @@ func (s *executionPayloadBidService) validateAndStoreBid(
 	builderIndex := bid.BuilderIndex
 	prefs := preferences.Message
 
+	// [REJECT] execution_payment must be zero at gossip time
+	if bid.ExecutionPayment != 0 {
+		return fmt.Errorf("bid execution_payment must be 0, got %d", bid.ExecutionPayment)
+	}
+
+	// [REJECT] fee_recipient must match proposer preferences
+	if bid.FeeRecipient != prefs.FeeRecipient {
+		return fmt.Errorf("bid fee_recipient %v does not match proposer preferences %v",
+			bid.FeeRecipient, prefs.FeeRecipient)
+	}
+
 	// [IGNORE] First valid bid from this builder for this slot
 	seenKey := seenBidKey{builderIndex: builderIndex, slot: slot}
 	if s.seenCache.Contains(seenKey) {

--- a/cl/phase1/network/services/execution_payload_bid_service_test.go
+++ b/cl/phase1/network/services/execution_payload_bid_service_test.go
@@ -16,10 +16,12 @@ import (
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
+	state2 "github.com/erigontech/erigon/cl/phase1/core/state"
 	"github.com/erigontech/erigon/cl/phase1/core/state/lru"
 	"github.com/erigontech/erigon/cl/phase1/execution_client"
 	forkchoice_mock "github.com/erigontech/erigon/cl/phase1/forkchoice/mock_services"
 	"github.com/erigontech/erigon/cl/pool"
+	"github.com/erigontech/erigon/cl/transition"
 	"github.com/erigontech/erigon/cl/utils/eth_clock"
 	"github.com/erigontech/erigon/common"
 )
@@ -35,10 +37,12 @@ func setupExecutionPayloadBidService(t *testing.T, ctrl *gomock.Controller) (
 	ethClockMock := eth_clock.NewMockEthereumClock(ctrl)
 	fcMock := forkchoice_mock.NewForkChoiceStorageMock(t)
 	epbsPool := pool.NewEpbsPool()
-	beaconCfg := &clparams.BeaconChainConfig{
-		SlotsPerEpoch:       32,
-		DomainBeaconBuilder: [4]byte{0x0B, 0x00, 0x00, 0x00},
-	}
+	beaconCfg := clparams.MainnetBeaconConfig
+	beaconCfg.SlotsPerEpoch = 32
+	beaconCfg.SlotsPerHistoricalRoot = 8192
+	beaconCfg.MinSeedLookahead = 1
+	beaconCfg.DomainBeaconBuilder = [4]byte{0x0B, 0x00, 0x00, 0x00}
+	fcMock.StateAtBlockRootVal[common.HexToHash("0xbbbb")] = newBidParentState(&beaconCfg, testDependentRoot)
 
 	seenCache, err := lru.New[seenBidKey, struct{}]("seen_bids_test", seenBidCacheSize)
 	require.NoError(t, err)
@@ -47,7 +51,7 @@ func setupExecutionPayloadBidService(t *testing.T, ctrl *gomock.Controller) (
 		syncedDataManager: mockSyncedData,
 		forkchoiceStore:   fcMock,
 		ethClock:          ethClockMock,
-		beaconCfg:         beaconCfg,
+		beaconCfg:         &beaconCfg,
 		epbsPool:          epbsPool,
 		emitters:          beaconevents.NewEventEmitter(),
 		seenCache:         seenCache,
@@ -76,16 +80,29 @@ func newTestSignedExecutionPayloadBid(slot uint64, builderIndex uint64, value ui
 
 // addPreferencesToPool adds a SignedProposerPreferences to the pool for the given slot.
 func addPreferencesToPool(epbsPool *pool.EpbsPool, slot uint64) {
+	addPreferencesToPoolWithRoot(epbsPool, slot, testDependentRoot)
+}
+
+func addPreferencesToPoolWithRoot(epbsPool *pool.EpbsPool, slot uint64, dependentRoot common.Hash) {
 	epbsPool.ProposerPreferences.Add(pool.ProposerPreferencesKey{
-		Slot: slot,
+		Slot:          slot,
+		DependentRoot: dependentRoot,
 	}, &cltypes.SignedProposerPreferences{
 		Message: &cltypes.ProposerPreferences{
 			ProposalSlot:   slot,
 			ValidatorIndex: 99,
 			FeeRecipient:   common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
 			TargetGasLimit: 30_000_000,
+			DependentRoot:  dependentRoot,
 		},
 	})
+}
+
+func newBidParentState(cfg *clparams.BeaconChainConfig, dependentRoot common.Hash) *state2.CachingBeaconState {
+	s := state2.New(cfg)
+	s.SetSlot(100)
+	s.SetBlockRootAt(63, dependentRoot)
+	return s
 }
 
 func TestExecutionPayloadBidServiceNames(t *testing.T) {
@@ -196,6 +213,73 @@ func TestExecutionPayloadBidServiceNoPreferences(t *testing.T) {
 	bidKey := pool.HighestBidKey{Slot: 100, ParentBlockHash: common.HexToHash("0xaaaa"), ParentBlockRoot: common.HexToHash("0xbbbb")}
 	_, found := epbsPool.HighestBids.Get(bidKey)
 	require.False(t, found)
+}
+
+func TestExecutionPayloadBidServiceWaitsForMatchingDependentRootPreference(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	service, mockSyncedData, ethClockMock, fcMock, epbsPool := setupExecutionPayloadBidService(t, ctrl)
+	msg := newTestSignedExecutionPayloadBid(100, 1, 1000)
+	wrongRoot := common.Hash{0xee}
+	epbsPool.ProposerPreferences.Add(pool.ProposerPreferencesKey{Slot: 100, DependentRoot: wrongRoot}, &cltypes.SignedProposerPreferences{
+		Message: &cltypes.ProposerPreferences{
+			ProposalSlot:   100,
+			ValidatorIndex: 99,
+			FeeRecipient:   msg.Message.FeeRecipient,
+			TargetGasLimit: 30_000_000,
+			DependentRoot:  wrongRoot,
+		},
+	})
+
+	ethClockMock.EXPECT().GetCurrentSlot().Return(uint64(100))
+	require.NoError(t, service.ProcessMessage(context.Background(), nil, msg))
+	require.Equal(t, int32(1), service.pendingCount.Load())
+
+	addPreferencesToPool(epbsPool, 100)
+	fcMock.ExecutionPayloadStatusMap[msg.Message.ParentBlockHash] = execution_client.PayloadStatusValidated
+	fcMock.Headers[msg.Message.ParentBlockRoot] = &cltypes.BeaconBlockHeader{}
+	ethClockMock.EXPECT().GetCurrentSlot().Return(uint64(100))
+	mockSyncedData.EXPECT().ViewHeadState(gomock.Any()).DoAndReturn(func(fn synced_data.ViewHeadStateFn) error {
+		return nil
+	})
+
+	service.processPendingBids()
+	require.Equal(t, int32(0), service.pendingCount.Load())
+	_, found := epbsPool.HighestBids.Get(pool.HighestBidKey{Slot: 100, ParentBlockHash: msg.Message.ParentBlockHash, ParentBlockRoot: msg.Message.ParentBlockRoot})
+	require.True(t, found)
+}
+
+func TestExecutionPayloadBidServiceAdvancesSkippedParentStateForDependentRoot(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	service, mockSyncedData, ethClockMock, fcMock, epbsPool := setupExecutionPayloadBidService(t, ctrl)
+
+	parentState := state2.New(service.beaconCfg)
+	parentState.SetSlot(60)
+	fcMock.StateAtBlockRootVal[common.HexToHash("0xbbbb")] = parentState
+
+	validationState, err := parentState.Copy()
+	require.NoError(t, err)
+	require.NoError(t, transition.DefaultMachine.ProcessSlots(validationState, 64))
+	dependentRoot, err := state2.GetProposerDependentRoot(validationState, 3)
+	require.NoError(t, err)
+	addPreferencesToPoolWithRoot(epbsPool, 100, dependentRoot)
+
+	msg := newTestSignedExecutionPayloadBid(100, 1, 1000)
+	ethClockMock.EXPECT().GetCurrentSlot().Return(uint64(100))
+	mockSyncedData.EXPECT().ViewHeadState(gomock.Any()).DoAndReturn(func(fn synced_data.ViewHeadStateFn) error {
+		return nil
+	})
+	fcMock.ExecutionPayloadStatusMap[msg.Message.ParentBlockHash] = execution_client.PayloadStatusValidated
+	fcMock.Headers[msg.Message.ParentBlockRoot] = &cltypes.BeaconBlockHeader{}
+
+	err = service.ProcessMessage(context.Background(), nil, msg)
+	require.NoError(t, err)
+	require.Equal(t, uint64(60), parentState.Slot())
+	_, found := epbsPool.HighestBids.Get(pool.HighestBidKey{Slot: 100, ParentBlockHash: msg.Message.ParentBlockHash, ParentBlockRoot: msg.Message.ParentBlockRoot})
+	require.True(t, found)
 }
 
 func TestExecutionPayloadBidServiceGasLimitIncompatible(t *testing.T) {

--- a/cl/phase1/network/services/execution_payload_bid_service_test.go
+++ b/cl/phase1/network/services/execution_payload_bid_service_test.go
@@ -67,6 +67,7 @@ func newTestSignedExecutionPayloadBid(slot uint64, builderIndex uint64, value ui
 			ParentBlockRoot:    common.HexToHash("0xbbbb"),
 			BlockHash:          common.HexToHash("0xcccc"),
 			GasLimit:           30_000_000,
+			FeeRecipient:       common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
 			BlobKzgCommitments: *solid.NewStaticListSSZ[*cltypes.KZGCommitment](cltypes.MaxBlobsCommittmentsPerBlock, 48),
 		},
 		Signature: common.Bytes96{},
@@ -491,6 +492,41 @@ func TestExecutionPayloadBidServiceDecodeGossipMessageInvalid(t *testing.T) {
 
 	_, err := service.DecodeGossipMessage("peer123", []byte{0x00, 0x01, 0x02}, clparams.GloasVersion)
 	require.Error(t, err)
+}
+
+func TestExecutionPayloadBidServiceNonZeroExecutionPayment(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	service, _, ethClockMock, _, epbsPool := setupExecutionPayloadBidService(t, ctrl)
+
+	msg := newTestSignedExecutionPayloadBid(100, 1, 1000)
+	msg.Message.ExecutionPayment = 500 // must be 0 at gossip time
+	addPreferencesToPool(epbsPool, 100)
+
+	ethClockMock.EXPECT().GetCurrentSlot().Return(uint64(100))
+
+	err := service.ProcessMessage(context.Background(), nil, msg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "execution_payment must be 0")
+}
+
+func TestExecutionPayloadBidServiceFeeRecipientMismatch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	service, _, ethClockMock, _, epbsPool := setupExecutionPayloadBidService(t, ctrl)
+
+	msg := newTestSignedExecutionPayloadBid(100, 1, 1000)
+	msg.Message.FeeRecipient = common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	addPreferencesToPool(epbsPool, 100)
+
+	ethClockMock.EXPECT().GetCurrentSlot().Return(uint64(100))
+
+	err := service.ProcessMessage(context.Background(), nil, msg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "fee_recipient")
+	require.Contains(t, err.Error(), "does not match")
 }
 
 func TestExecutionPayloadBidServiceFailedValidationNotStored(t *testing.T) {

--- a/cl/phase1/network/services/execution_payload_bid_service_test.go
+++ b/cl/phase1/network/services/execution_payload_bid_service_test.go
@@ -82,7 +82,7 @@ func addPreferencesToPool(epbsPool *pool.EpbsPool, slot uint64) {
 			ProposalSlot:   slot,
 			ValidatorIndex: 99,
 			FeeRecipient:   common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
-			GasLimit:       30_000_000,
+			TargetGasLimit: 30_000_000,
 		},
 	})
 }
@@ -197,21 +197,28 @@ func TestExecutionPayloadBidServiceNoPreferences(t *testing.T) {
 	require.False(t, found)
 }
 
-func TestExecutionPayloadBidServiceGasLimitMismatch(t *testing.T) {
+func TestExecutionPayloadBidServiceGasLimitIncompatible(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	service, _, ethClockMock, _, epbsPool := setupExecutionPayloadBidService(t, ctrl)
+	service, mockSyncedData, ethClockMock, fcMock, epbsPool := setupExecutionPayloadBidService(t, ctrl)
 
 	msg := newTestSignedExecutionPayloadBid(100, 1, 1000)
-	msg.Message.GasLimit = 99_999 // Different from preferences (30_000_000)
+	msg.Message.GasLimit = 99_999 // Incompatible with target 30_000_000 given parent 30_000_000
 
 	addPreferencesToPool(epbsPool, 100)
 	ethClockMock.EXPECT().GetCurrentSlot().Return(uint64(100))
+	mockSyncedData.EXPECT().ViewHeadState(gomock.Any()).DoAndReturn(func(fn synced_data.ViewHeadStateFn) error {
+		return nil
+	})
+
+	// Set up parent block hash as known with gas limit
+	fcMock.ExecutionPayloadStatusMap[common.HexToHash("0xaaaa")] = execution_client.PayloadStatusValidated
+	fcMock.ExecutionPayloadGasLimitMap[common.HexToHash("0xaaaa")] = 30_000_000
 
 	err := service.ProcessMessage(context.Background(), nil, msg)
 	require.Error(t, err)
-	require.False(t, errors.Is(err, ErrIgnore)) // REJECT
+	require.True(t, errors.Is(err, ErrIgnore)) // Now IGNORE, not REJECT
 	require.Contains(t, err.Error(), "gas_limit")
 }
 

--- a/cl/phase1/network/services/execution_payload_bid_service_test.go
+++ b/cl/phase1/network/services/execution_payload_bid_service_test.go
@@ -250,6 +250,33 @@ func TestExecutionPayloadBidServiceWaitsForMatchingDependentRootPreference(t *te
 	require.True(t, found)
 }
 
+func TestExecutionPayloadBidServiceWaitsForParentState(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	service, mockSyncedData, ethClockMock, fcMock, epbsPool := setupExecutionPayloadBidService(t, ctrl)
+	msg := newTestSignedExecutionPayloadBid(100, 1, 1000)
+	addPreferencesToPool(epbsPool, 100)
+	delete(fcMock.StateAtBlockRootVal, msg.Message.ParentBlockRoot)
+
+	ethClockMock.EXPECT().GetCurrentSlot().Return(uint64(100))
+	require.NoError(t, service.ProcessMessage(context.Background(), nil, msg))
+	require.Equal(t, int32(1), service.pendingCount.Load())
+
+	fcMock.StateAtBlockRootVal[msg.Message.ParentBlockRoot] = newBidParentState(service.beaconCfg, testDependentRoot)
+	fcMock.ExecutionPayloadStatusMap[msg.Message.ParentBlockHash] = execution_client.PayloadStatusValidated
+	fcMock.Headers[msg.Message.ParentBlockRoot] = &cltypes.BeaconBlockHeader{}
+	ethClockMock.EXPECT().GetCurrentSlot().Return(uint64(100))
+	mockSyncedData.EXPECT().ViewHeadState(gomock.Any()).DoAndReturn(func(fn synced_data.ViewHeadStateFn) error {
+		return nil
+	})
+
+	service.processPendingBids()
+	require.Equal(t, int32(0), service.pendingCount.Load())
+	_, found := epbsPool.HighestBids.Get(pool.HighestBidKey{Slot: 100, ParentBlockHash: msg.Message.ParentBlockHash, ParentBlockRoot: msg.Message.ParentBlockRoot})
+	require.True(t, found)
+}
+
 func TestExecutionPayloadBidServiceAdvancesSkippedParentStateForDependentRoot(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/cl/phase1/network/services/gas_limit.go
+++ b/cl/phase1/network/services/gas_limit.go
@@ -16,15 +16,8 @@
 
 package services
 
-// IsGasLimitTargetCompatible checks whether the bid's gas_limit is consistent
-// with the proposer's target_gas_limit given the parent's gas_limit, per EIP-1559
-// gas limit transition rules.
-//
-// Spec reference: consensus-specs PR #5236
-//
-//	def is_gas_limit_target_compatible(parent_gas_limit, gas_limit, target_gas_limit):
-//	    max_gas_limit_difference = max(parent_gas_limit // 1024, 1) - 1
-//	    ...
+// IsGasLimitTargetCompatible checks whether the bid's gas_limit is consistent with the
+// proposer's target given the parent's gas_limit, per EIP-1559 transition rules (consensus-specs PR #5236).
 func IsGasLimitTargetCompatible(parentGasLimit, gasLimit, targetGasLimit uint64) bool {
 	var maxGasLimitDifference uint64
 	if parentGasLimit/1024 > 1 {

--- a/cl/phase1/network/services/gas_limit.go
+++ b/cl/phase1/network/services/gas_limit.go
@@ -1,0 +1,44 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package services
+
+// IsGasLimitTargetCompatible checks whether the bid's gas_limit is consistent
+// with the proposer's target_gas_limit given the parent's gas_limit, per EIP-1559
+// gas limit transition rules.
+//
+// Spec reference: consensus-specs PR #5236
+//
+//	def is_gas_limit_target_compatible(parent_gas_limit, gas_limit, target_gas_limit):
+//	    max_gas_limit_difference = max(parent_gas_limit // 1024, 1) - 1
+//	    ...
+func IsGasLimitTargetCompatible(parentGasLimit, gasLimit, targetGasLimit uint64) bool {
+	var maxGasLimitDifference uint64
+	if parentGasLimit/1024 > 1 {
+		maxGasLimitDifference = parentGasLimit/1024 - 1
+	}
+
+	minGasLimit := parentGasLimit - maxGasLimitDifference
+	maxGasLimit := parentGasLimit + maxGasLimitDifference
+
+	if targetGasLimit >= minGasLimit && targetGasLimit <= maxGasLimit {
+		return gasLimit == targetGasLimit
+	}
+	if targetGasLimit > maxGasLimit {
+		return gasLimit == maxGasLimit
+	}
+	return gasLimit == minGasLimit
+}

--- a/cl/phase1/network/services/gas_limit_test.go
+++ b/cl/phase1/network/services/gas_limit_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package services
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsGasLimitTargetCompatible(t *testing.T) {
+	parentGasLimit := uint64(30_000_000)
+	maxGasLimitDifference := parentGasLimit/1024 - 1
+	minGasLimit := parentGasLimit - maxGasLimitDifference
+	maxGasLimit := parentGasLimit + maxGasLimitDifference
+
+	tests := []struct {
+		name           string
+		parentGasLimit uint64
+		gasLimit       uint64
+		targetGasLimit uint64
+		want           bool
+	}{
+		{
+			name:           "target in range requires exact gas limit",
+			parentGasLimit: parentGasLimit,
+			gasLimit:       parentGasLimit,
+			targetGasLimit: parentGasLimit,
+			want:           true,
+		},
+		{
+			name:           "target in range rejects different gas limit",
+			parentGasLimit: parentGasLimit,
+			gasLimit:       parentGasLimit + 1,
+			targetGasLimit: parentGasLimit,
+			want:           false,
+		},
+		{
+			name:           "target above max clamps to max gas limit",
+			parentGasLimit: parentGasLimit,
+			gasLimit:       maxGasLimit,
+			targetGasLimit: maxGasLimit + 1,
+			want:           true,
+		},
+		{
+			name:           "target below min clamps to min gas limit",
+			parentGasLimit: parentGasLimit,
+			gasLimit:       minGasLimit,
+			targetGasLimit: minGasLimit - 1,
+			want:           true,
+		},
+		{
+			name:           "parent below 1024 has no underflow and clamps to parent",
+			parentGasLimit: 1000,
+			gasLimit:       1000,
+			targetGasLimit: 0,
+			want:           true,
+		},
+		{
+			name:           "parent below 1024 rejects non-parent gas limit",
+			parentGasLimit: 1000,
+			gasLimit:       999,
+			targetGasLimit: 0,
+			want:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, IsGasLimitTargetCompatible(tt.parentGasLimit, tt.gasLimit, tt.targetGasLimit))
+		})
+	}
+}

--- a/cl/phase1/network/services/proposer_preferences_service.go
+++ b/cl/phase1/network/services/proposer_preferences_service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/erigontech/erigon/cl/phase1/core/state/lru"
 	"github.com/erigontech/erigon/cl/phase1/forkchoice"
 	"github.com/erigontech/erigon/cl/pool"
+	"github.com/erigontech/erigon/cl/transition"
 	"github.com/erigontech/erigon/cl/utils/eth_clock"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
@@ -86,7 +87,7 @@ func (s *proposerPreferencesService) ProcessMessage(ctx context.Context, _ *uint
 
 	// [IGNORE] compute_epoch_at_slot(preferences.proposal_slot) in range(current_epoch, current_epoch + MIN_SEED_LOOKAHEAD + 1)
 	currentEpoch := s.ethClock.GetCurrentEpoch()
-	proposalEpoch := s.ethClock.GetEpochAtSlot(proposalSlot)
+	proposalEpoch := state.GetEpochAtSlot(s.beaconCfg, proposalSlot)
 	if proposalEpoch < currentEpoch || proposalEpoch > currentEpoch+s.beaconCfg.MinSeedLookahead {
 		return fmt.Errorf("%w: proposal slot %d is in epoch %d, expected epoch in [%d, %d]",
 			ErrIgnore, proposalSlot, proposalEpoch, currentEpoch, currentEpoch+s.beaconCfg.MinSeedLookahead)
@@ -110,58 +111,15 @@ func (s *proposerPreferencesService) ProcessMessage(ctx context.Context, _ *uint
 			ErrIgnore, validatorIndex, proposalSlot, preferences.DependentRoot)
 	}
 
-	// [IGNORE] The dependent_root block has been seen in forkchoice
-	if _, ok := s.forkchoiceStore.GetHeader(preferences.DependentRoot); !ok {
-		return fmt.Errorf("%w: dependent_root %v not seen in forkchoice",
-			ErrIgnore, preferences.DependentRoot)
+	depState, err := s.forkchoiceStore.GetStateAtBlockRoot(preferences.DependentRoot, false)
+	if err != nil || depState == nil {
+		return fmt.Errorf("%w: state for dependent_root %v not available", ErrIgnore, preferences.DependentRoot)
 	}
-
-	// [REJECT] is_valid_proposal_slot + [REJECT] BLS signature verification
-	// Both need head state access, so do them together inside a single ViewHeadState call.
-	if err := s.syncedDataManager.ViewHeadState(func(headState *state.CachingBeaconState) error {
-		// is_valid_proposal_slot check:
-		// index = SLOTS_PER_EPOCH + preferences.proposal_slot % SLOTS_PER_EPOCH
-		// return state.proposer_lookahead[index] == preferences.validator_index
-		lookahead := headState.GetProposerLookahead()
-		if lookahead == nil {
-			return fmt.Errorf("proposer lookahead not available")
-		}
-		lookaheadIndex := s.beaconCfg.SlotsPerEpoch + proposalSlot%s.beaconCfg.SlotsPerEpoch
-		if int(lookaheadIndex) >= lookahead.Length() {
-			return fmt.Errorf("proposer lookahead index %d out of range (length: %d)", lookaheadIndex, lookahead.Length())
-		}
-		if lookahead.Get(int(lookaheadIndex)) != validatorIndex {
-			return fmt.Errorf("validator %d is not the proposer for slot %d (expected %d)",
-				validatorIndex, proposalSlot, lookahead.Get(int(lookaheadIndex)))
-		}
-
-		// Get validator public key
-		val, err := headState.ValidatorForValidatorIndex(int(validatorIndex))
-		if err != nil {
-			return fmt.Errorf("validator index %d not found: %w", validatorIndex, err)
-		}
-		pk := val.PublicKey()
-
-		// BLS signature verification
-		epoch := s.ethClock.GetEpochAtSlot(proposalSlot)
-		domain, err := headState.GetDomain(s.beaconCfg.DomainProposerPreferences, epoch)
-		if err != nil {
-			return fmt.Errorf("failed to get domain: %w", err)
-		}
-		signingRoot, err := computeSigningRoot(preferences, domain)
-		if err != nil {
-			return fmt.Errorf("failed to compute signing root: %w", err)
-		}
-		valid, err := blsVerify(msg.Signature[:], signingRoot[:], pk[:])
-		if err != nil {
-			return fmt.Errorf("signature verification error: %w", err)
-		}
-		if !valid {
-			return fmt.Errorf("invalid proposer preferences signature")
-		}
-
-		return nil
-	}); err != nil {
+	validationState, err := s.proposerPreferencesValidationState(depState, proposalEpoch)
+	if err != nil {
+		return fmt.Errorf("%w: failed to prepare dependent state: %v", ErrIgnore, err)
+	}
+	if err := s.validateProposerPreferencesWithState(msg, validationState); err != nil {
 		return fmt.Errorf("proposer preferences validation failed: %w", err)
 	}
 
@@ -178,5 +136,69 @@ func (s *proposerPreferencesService) ProcessMessage(ctx context.Context, _ *uint
 		"feeRecipient", preferences.FeeRecipient,
 		"targetGasLimit", preferences.TargetGasLimit)
 
+	return nil
+}
+
+func (s *proposerPreferencesService) proposerPreferencesValidationState(depState *state.CachingBeaconState, proposalEpoch uint64) (*state.CachingBeaconState, error) {
+	if proposalEpoch < s.beaconCfg.MinSeedLookahead {
+		return nil, fmt.Errorf("proposal epoch %d before min seed lookahead %d", proposalEpoch, s.beaconCfg.MinSeedLookahead)
+	}
+	dependentEpoch := proposalEpoch - s.beaconCfg.MinSeedLookahead
+	validationSlot := dependentEpoch * s.beaconCfg.SlotsPerEpoch
+	if depState.Slot() >= validationSlot {
+		return depState, nil
+	}
+	validationState, err := depState.Copy()
+	if err != nil {
+		return nil, err
+	}
+	if err := transition.DefaultMachine.ProcessSlots(validationState, validationSlot); err != nil {
+		return nil, err
+	}
+	return validationState, nil
+}
+
+func (s *proposerPreferencesService) validateProposerPreferencesWithState(msg *cltypes.SignedProposerPreferences, depState *state.CachingBeaconState) error {
+	preferences := msg.Message
+	proposalSlot := preferences.ProposalSlot
+	validatorIndex := preferences.ValidatorIndex
+	proposalEpoch := state.GetEpochAtSlot(s.beaconCfg, proposalSlot)
+	stateEpoch := state.GetEpochAtSlot(depState.BeaconConfig(), depState.Slot())
+	if proposalEpoch < stateEpoch || proposalEpoch > stateEpoch+s.beaconCfg.MinSeedLookahead {
+		return fmt.Errorf("proposal slot %d is outside dependent state lookahead", proposalSlot)
+	}
+	lookahead := depState.GetProposerLookahead()
+	if lookahead == nil {
+		return fmt.Errorf("proposer lookahead not available")
+	}
+	lookaheadIndex := (proposalEpoch-stateEpoch)*s.beaconCfg.SlotsPerEpoch + proposalSlot%s.beaconCfg.SlotsPerEpoch
+	if int(lookaheadIndex) >= lookahead.Length() {
+		return fmt.Errorf("proposer lookahead index %d out of range (length: %d)", lookaheadIndex, lookahead.Length())
+	}
+	if lookahead.Get(int(lookaheadIndex)) != validatorIndex {
+		return fmt.Errorf("validator %d is not the proposer for slot %d (expected %d)",
+			validatorIndex, proposalSlot, lookahead.Get(int(lookaheadIndex)))
+	}
+
+	val, err := depState.ValidatorForValidatorIndex(int(validatorIndex))
+	if err != nil {
+		return fmt.Errorf("validator index %d not found: %w", validatorIndex, err)
+	}
+	pk := val.PublicKey()
+	domain, err := depState.GetDomain(s.beaconCfg.DomainProposerPreferences, proposalEpoch)
+	if err != nil {
+		return fmt.Errorf("failed to get domain: %w", err)
+	}
+	signingRoot, err := computeSigningRoot(preferences, domain)
+	if err != nil {
+		return fmt.Errorf("failed to compute signing root: %w", err)
+	}
+	valid, err := blsVerify(msg.Signature[:], signingRoot[:], pk[:])
+	if err != nil {
+		return fmt.Errorf("signature verification error: %w", err)
+	}
+	if !valid {
+		return fmt.Errorf("invalid proposer preferences signature")
+	}
 	return nil
 }

--- a/cl/phase1/network/services/proposer_preferences_service.go
+++ b/cl/phase1/network/services/proposer_preferences_service.go
@@ -84,13 +84,12 @@ func (s *proposerPreferencesService) ProcessMessage(ctx context.Context, _ *uint
 		"proposalSlot", proposalSlot,
 		"validatorIndex", validatorIndex)
 
-	// [IGNORE] preferences.proposal_slot is in the current or next epoch
-	// i.e. compute_epoch_at_slot(preferences.proposal_slot) in {get_current_epoch(state), get_current_epoch(state) + 1}
+	// [IGNORE] compute_epoch_at_slot(preferences.proposal_slot) in range(current_epoch, current_epoch + MIN_SEED_LOOKAHEAD + 1)
 	currentEpoch := s.ethClock.GetCurrentEpoch()
 	proposalEpoch := s.ethClock.GetEpochAtSlot(proposalSlot)
-	if proposalEpoch != currentEpoch && proposalEpoch != currentEpoch+1 {
-		return fmt.Errorf("%w: proposal slot %d is in epoch %d, expected current epoch %d or next epoch %d",
-			ErrIgnore, proposalSlot, proposalEpoch, currentEpoch, currentEpoch+1)
+	if proposalEpoch < currentEpoch || proposalEpoch > currentEpoch+s.beaconCfg.MinSeedLookahead {
+		return fmt.Errorf("%w: proposal slot %d is in epoch %d, expected epoch in [%d, %d]",
+			ErrIgnore, proposalSlot, proposalEpoch, currentEpoch, currentEpoch+s.beaconCfg.MinSeedLookahead)
 	}
 
 	// [IGNORE] The proposal slot has not already passed
@@ -177,7 +176,7 @@ func (s *proposerPreferencesService) ProcessMessage(ctx context.Context, _ *uint
 		"proposalSlot", proposalSlot,
 		"validatorIndex", validatorIndex,
 		"feeRecipient", preferences.FeeRecipient,
-		"gasLimit", preferences.GasLimit)
+		"targetGasLimit", preferences.TargetGasLimit)
 
 	return nil
 }

--- a/cl/phase1/network/services/proposer_preferences_service.go
+++ b/cl/phase1/network/services/proposer_preferences_service.go
@@ -92,9 +92,9 @@ func (s *proposerPreferencesService) ProcessMessage(ctx context.Context, _ *uint
 			ErrIgnore, proposalSlot, proposalEpoch, currentEpoch, currentEpoch+s.beaconCfg.MinSeedLookahead)
 	}
 
-	// [IGNORE] The proposal slot has not already passed
+	// [IGNORE] The proposal slot has not already passed (proposal_slot > current_slot)
 	currentSlot := s.ethClock.GetCurrentSlot()
-	if proposalSlot < currentSlot {
+	if proposalSlot <= currentSlot {
 		return fmt.Errorf("%w: proposal slot %d has already passed (current slot %d)",
 			ErrIgnore, proposalSlot, currentSlot)
 	}

--- a/cl/phase1/network/services/proposer_preferences_service_test.go
+++ b/cl/phase1/network/services/proposer_preferences_service_test.go
@@ -25,7 +25,8 @@ func setupProposerPreferencesService(t *testing.T, ctrl *gomock.Controller) (*pr
 	ethClockMock := eth_clock.NewMockEthereumClock(ctrl)
 	epbsPool := pool.NewEpbsPool()
 	beaconCfg := &clparams.BeaconChainConfig{
-		SlotsPerEpoch: 32,
+		SlotsPerEpoch:    32,
+		MinSeedLookahead: 1,
 	}
 	forkChoiceMock := &forkchoice_mock.ForkChoiceStorageMock{
 		Headers: map[common.Hash]*cltypes.BeaconBlockHeader{},
@@ -55,7 +56,7 @@ func newTestSignedProposerPreferences(proposalSlot, validatorIndex uint64) *clty
 			ProposalSlot:   proposalSlot,
 			ValidatorIndex: validatorIndex,
 			FeeRecipient:   common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
-			GasLimit:       30_000_000,
+			TargetGasLimit: 30_000_000,
 			DependentRoot:  testDependentRoot,
 		},
 		Signature: common.Bytes96{},
@@ -106,7 +107,7 @@ func TestProposerPreferencesServiceWrongEpoch(t *testing.T) {
 	err := service.ProcessMessage(context.Background(), nil, msg)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, ErrIgnore))
-	require.Contains(t, err.Error(), "expected current epoch")
+	require.Contains(t, err.Error(), "expected epoch in")
 }
 
 func TestProposerPreferencesServiceCurrentEpoch(t *testing.T) {
@@ -342,7 +343,7 @@ func TestProposerPreferencesServiceDecodeGossipMessage(t *testing.T) {
 	require.Equal(t, original.Message.ProposalSlot, decoded.Message.ProposalSlot)
 	require.Equal(t, original.Message.ValidatorIndex, decoded.Message.ValidatorIndex)
 	require.Equal(t, original.Message.FeeRecipient, decoded.Message.FeeRecipient)
-	require.Equal(t, original.Message.GasLimit, decoded.Message.GasLimit)
+	require.Equal(t, original.Message.TargetGasLimit, decoded.Message.TargetGasLimit)
 	require.Equal(t, original.Message.DependentRoot, decoded.Message.DependentRoot)
 }
 

--- a/cl/phase1/network/services/proposer_preferences_service_test.go
+++ b/cl/phase1/network/services/proposer_preferences_service_test.go
@@ -3,16 +3,16 @@ package services
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
-	"github.com/erigontech/erigon/cl/beacon/synced_data"
 	synced_data_mock "github.com/erigontech/erigon/cl/beacon/synced_data/mock_services"
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	state2 "github.com/erigontech/erigon/cl/phase1/core/state"
 	"github.com/erigontech/erigon/cl/phase1/core/state/lru"
 	forkchoice_mock "github.com/erigontech/erigon/cl/phase1/forkchoice/mock_services"
 	"github.com/erigontech/erigon/cl/pool"
@@ -24,13 +24,19 @@ func setupProposerPreferencesService(t *testing.T, ctrl *gomock.Controller) (*pr
 	mockSyncedData := synced_data_mock.NewMockSyncedData(ctrl)
 	ethClockMock := eth_clock.NewMockEthereumClock(ctrl)
 	epbsPool := pool.NewEpbsPool()
-	beaconCfg := &clparams.BeaconChainConfig{
-		SlotsPerEpoch:    32,
-		MinSeedLookahead: 1,
-	}
+	beaconCfg := clparams.MainnetBeaconConfig
+	beaconCfg.SlotsPerEpoch = 32
+	beaconCfg.SlotsPerHistoricalRoot = 8192
+	beaconCfg.MinSeedLookahead = 1
+	beaconCfg.ValidatorRegistryLimit = 1024
 	forkChoiceMock := &forkchoice_mock.ForkChoiceStorageMock{
-		Headers: map[common.Hash]*cltypes.BeaconBlockHeader{},
+		Headers:             map[common.Hash]*cltypes.BeaconBlockHeader{},
+		StateAtBlockRootVal: map[common.Hash]*state2.CachingBeaconState{},
 	}
+	forkChoiceMock.StateAtBlockRootVal[testDependentRoot] = newProposerPreferencesState(&beaconCfg, map[uint64]uint64{96: 42, 100: 42})
+	prevBlsVerify := blsVerify
+	blsVerify = func(_ []byte, _ []byte, _ []byte) (bool, error) { return true, nil }
+	t.Cleanup(func() { blsVerify = prevBlsVerify })
 
 	seenCache, err := lru.New[seenProposerPreferencesKey, struct{}]("seen_proposer_preferences_test", seenProposerPreferencesCacheSize)
 	require.NoError(t, err)
@@ -39,7 +45,7 @@ func setupProposerPreferencesService(t *testing.T, ctrl *gomock.Controller) (*pr
 		syncedDataManager: mockSyncedData,
 		forkchoiceStore:   forkChoiceMock,
 		ethClock:          ethClockMock,
-		beaconCfg:         beaconCfg,
+		beaconCfg:         &beaconCfg,
 		epbsPool:          epbsPool,
 		seenCache:         seenCache,
 	}
@@ -49,6 +55,25 @@ func setupProposerPreferencesService(t *testing.T, ctrl *gomock.Controller) (*pr
 
 // testDependentRoot is a fixed dependent root used across tests.
 var testDependentRoot = common.HexToHash("0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789")
+
+func newProposerPreferencesState(cfg *clparams.BeaconChainConfig, proposers map[uint64]uint64) *state2.CachingBeaconState {
+	s := state2.New(cfg)
+	s.SetSlot(64)
+	for i := 0; i < 100; i++ {
+		var pk common.Bytes48
+		pk[0] = byte(i)
+		s.AddValidator(solid.NewValidatorFromParameters(pk, common.Hash{}, 0, false, 0, 0, cfg.FarFutureEpoch, cfg.FarFutureEpoch), 0)
+	}
+	lookahead := solid.NewUint64VectorSSZ(int((cfg.MinSeedLookahead + 1) * cfg.SlotsPerEpoch))
+	for slot, validatorIndex := range proposers {
+		epoch := slot / cfg.SlotsPerEpoch
+		stateEpoch := s.Slot() / cfg.SlotsPerEpoch
+		index := (epoch-stateEpoch)*cfg.SlotsPerEpoch + slot%cfg.SlotsPerEpoch
+		lookahead.Set(int(index), validatorIndex)
+	}
+	s.SetProposerLookahead(lookahead)
+	return s
+}
 
 func newTestSignedProposerPreferences(proposalSlot, validatorIndex uint64) *cltypes.SignedProposerPreferences {
 	return &cltypes.SignedProposerPreferences{
@@ -102,7 +127,6 @@ func TestProposerPreferencesServiceWrongEpoch(t *testing.T) {
 	msg := newTestSignedProposerPreferences(100, 42)
 
 	ethClockMock.EXPECT().GetCurrentEpoch().Return(uint64(5))
-	ethClockMock.EXPECT().GetEpochAtSlot(uint64(100)).Return(uint64(3))
 
 	err := service.ProcessMessage(context.Background(), nil, msg)
 	require.Error(t, err)
@@ -114,20 +138,13 @@ func TestProposerPreferencesServiceCurrentEpoch(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	service, mockSyncedData, ethClockMock, epbsPool, forkChoiceMock := setupProposerPreferencesService(t, ctrl)
+	service, _, ethClockMock, epbsPool, _ := setupProposerPreferencesService(t, ctrl)
 
 	// proposalEpoch == currentEpoch (same epoch) → should be accepted now
 	msg := newTestSignedProposerPreferences(100, 42)
 
-	// Add dependent root to forkchoice so the check passes
-	forkChoiceMock.Headers[testDependentRoot] = &cltypes.BeaconBlockHeader{}
-
 	ethClockMock.EXPECT().GetCurrentEpoch().Return(uint64(3))
-	ethClockMock.EXPECT().GetEpochAtSlot(uint64(100)).Return(uint64(3))
 	ethClockMock.EXPECT().GetCurrentSlot().Return(uint64(90)) // slot not yet passed
-	mockSyncedData.EXPECT().ViewHeadState(gomock.Any()).DoAndReturn(func(fn synced_data.ViewHeadStateFn) error {
-		return nil
-	})
 
 	err := service.ProcessMessage(context.Background(), nil, msg)
 	require.NoError(t, err)
@@ -148,7 +165,6 @@ func TestProposerPreferencesServiceSlotAlreadyPassed(t *testing.T) {
 	msg := newTestSignedProposerPreferences(100, 42)
 
 	ethClockMock.EXPECT().GetCurrentEpoch().Return(uint64(2))
-	ethClockMock.EXPECT().GetEpochAtSlot(uint64(100)).Return(uint64(3))
 	ethClockMock.EXPECT().GetCurrentSlot().Return(uint64(105))
 
 	err := service.ProcessMessage(context.Background(), nil, msg)
@@ -167,7 +183,6 @@ func TestProposerPreferencesServiceCurrentSlotIgnored(t *testing.T) {
 	msg := newTestSignedProposerPreferences(100, 42)
 
 	ethClockMock.EXPECT().GetCurrentEpoch().Return(uint64(2))
-	ethClockMock.EXPECT().GetEpochAtSlot(uint64(100)).Return(uint64(3))
 	ethClockMock.EXPECT().GetCurrentSlot().Return(uint64(100))
 
 	err := service.ProcessMessage(context.Background(), nil, msg)
@@ -180,27 +195,19 @@ func TestProposerPreferencesServiceDuplicate(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	service, mockSyncedData, ethClockMock, _, forkChoiceMock := setupProposerPreferencesService(t, ctrl)
+	service, _, ethClockMock, _, _ := setupProposerPreferencesService(t, ctrl)
 
 	msg := newTestSignedProposerPreferences(100, 42)
 
-	// Add dependent root to forkchoice so the check passes
-	forkChoiceMock.Headers[testDependentRoot] = &cltypes.BeaconBlockHeader{}
-
-	// First call: epoch OK, slot not passed, ViewHeadState succeeds
+	// First call: epoch OK and slot not passed.
 	ethClockMock.EXPECT().GetCurrentEpoch().Return(uint64(2))
-	ethClockMock.EXPECT().GetEpochAtSlot(uint64(100)).Return(uint64(3))
 	ethClockMock.EXPECT().GetCurrentSlot().Return(uint64(90))
-	mockSyncedData.EXPECT().ViewHeadState(gomock.Any()).DoAndReturn(func(fn synced_data.ViewHeadStateFn) error {
-		return nil
-	})
 
 	err := service.ProcessMessage(context.Background(), nil, msg)
 	require.NoError(t, err)
 
 	// Second call: same (validatorIndex, slot, dependentRoot) → IGNORE
 	ethClockMock.EXPECT().GetCurrentEpoch().Return(uint64(2))
-	ethClockMock.EXPECT().GetEpochAtSlot(uint64(100)).Return(uint64(3))
 	ethClockMock.EXPECT().GetCurrentSlot().Return(uint64(90))
 
 	err = service.ProcessMessage(context.Background(), nil, msg)
@@ -209,30 +216,22 @@ func TestProposerPreferencesServiceDuplicate(t *testing.T) {
 	require.Contains(t, err.Error(), "already seen proposer preferences")
 }
 
-func TestProposerPreferencesServiceViewHeadStateError(t *testing.T) {
+func TestProposerPreferencesServiceDependentRootStateMissing(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	service, mockSyncedData, ethClockMock, _, forkChoiceMock := setupProposerPreferencesService(t, ctrl)
+	service, _, ethClockMock, _, forkChoiceMock := setupProposerPreferencesService(t, ctrl)
 
 	msg := newTestSignedProposerPreferences(100, 42)
-
-	// Add dependent root to forkchoice so the check passes
-	forkChoiceMock.Headers[testDependentRoot] = &cltypes.BeaconBlockHeader{}
+	delete(forkChoiceMock.StateAtBlockRootVal, testDependentRoot)
 
 	ethClockMock.EXPECT().GetCurrentEpoch().Return(uint64(2))
-	ethClockMock.EXPECT().GetEpochAtSlot(uint64(100)).Return(uint64(3))
 	ethClockMock.EXPECT().GetCurrentSlot().Return(uint64(90))
-
-	// ViewHeadState returns error (e.g. state not synced, or inner validation failed)
-	mockSyncedData.EXPECT().ViewHeadState(gomock.Any()).DoAndReturn(func(fn synced_data.ViewHeadStateFn) error {
-		return fmt.Errorf("not synced")
-	})
 
 	err := service.ProcessMessage(context.Background(), nil, msg)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "proposer preferences validation failed")
-	require.Contains(t, err.Error(), "not synced")
+	require.True(t, errors.Is(err, ErrIgnore))
+	require.Contains(t, err.Error(), "state for dependent_root")
 
 	// Should NOT be marked as seen (validation failed)
 	seenKey := seenProposerPreferencesKey{validatorIndex: 42, slot: 100, dependentRoot: testDependentRoot}
@@ -243,21 +242,12 @@ func TestProposerPreferencesServiceSuccess(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	service, mockSyncedData, ethClockMock, epbsPool, forkChoiceMock := setupProposerPreferencesService(t, ctrl)
+	service, _, ethClockMock, epbsPool, _ := setupProposerPreferencesService(t, ctrl)
 
 	msg := newTestSignedProposerPreferences(100, 42)
 
-	// Add dependent root to forkchoice so the check passes
-	forkChoiceMock.Headers[testDependentRoot] = &cltypes.BeaconBlockHeader{}
-
 	ethClockMock.EXPECT().GetCurrentEpoch().Return(uint64(2))
-	ethClockMock.EXPECT().GetEpochAtSlot(uint64(100)).Return(uint64(3))
 	ethClockMock.EXPECT().GetCurrentSlot().Return(uint64(90))
-
-	// ViewHeadState succeeds (proposer lookahead + BLS all pass)
-	mockSyncedData.EXPECT().ViewHeadState(gomock.Any()).DoAndReturn(func(fn synced_data.ViewHeadStateFn) error {
-		return nil
-	})
 
 	err := service.ProcessMessage(context.Background(), nil, msg)
 	require.NoError(t, err)
@@ -272,25 +262,42 @@ func TestProposerPreferencesServiceSuccess(t *testing.T) {
 	require.Equal(t, msg, stored)
 }
 
+func TestProposerPreferencesServiceAdvancesDependentRootStateToBoundary(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	service, _, ethClockMock, epbsPool, forkChoiceMock := setupProposerPreferencesService(t, ctrl)
+
+	depState := newProposerPreferencesState(service.beaconCfg, map[uint64]uint64{100: 42})
+	depState.SetSlot(63)
+	forkChoiceMock.StateAtBlockRootVal[testDependentRoot] = depState
+
+	msg := newTestSignedProposerPreferences(100, 0)
+
+	ethClockMock.EXPECT().GetCurrentEpoch().Return(uint64(2))
+	ethClockMock.EXPECT().GetCurrentSlot().Return(uint64(90))
+
+	err := service.ProcessMessage(context.Background(), nil, msg)
+	require.NoError(t, err)
+	require.Equal(t, uint64(63), depState.Slot())
+
+	stored, ok := epbsPool.ProposerPreferences.Get(pool.ProposerPreferencesKey{Slot: 100, DependentRoot: testDependentRoot})
+	require.True(t, ok)
+	require.Equal(t, msg, stored)
+}
+
 func TestProposerPreferencesServiceDifferentValidatorsSameSlot(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	service, mockSyncedData, ethClockMock, epbsPool, forkChoiceMock := setupProposerPreferencesService(t, ctrl)
+	service, _, ethClockMock, epbsPool, forkChoiceMock := setupProposerPreferencesService(t, ctrl)
 
 	msg1 := newTestSignedProposerPreferences(100, 1)
-	msg2 := newTestSignedProposerPreferences(100, 2)
+	msg2 := newTestSignedProposerPreferences(101, 2)
+	forkChoiceMock.StateAtBlockRootVal[testDependentRoot] = newProposerPreferencesState(service.beaconCfg, map[uint64]uint64{100: 1, 101: 2})
 
-	// Add dependent root to forkchoice so the check passes
-	forkChoiceMock.Headers[testDependentRoot] = &cltypes.BeaconBlockHeader{}
-
-	// Both calls: epoch OK, slot not passed, ViewHeadState succeeds
 	ethClockMock.EXPECT().GetCurrentEpoch().Return(uint64(2)).Times(2)
-	ethClockMock.EXPECT().GetEpochAtSlot(uint64(100)).Return(uint64(3)).Times(2)
 	ethClockMock.EXPECT().GetCurrentSlot().Return(uint64(90)).Times(2)
-	mockSyncedData.EXPECT().ViewHeadState(gomock.Any()).DoAndReturn(func(fn synced_data.ViewHeadStateFn) error {
-		return nil
-	}).Times(2)
 
 	err := service.ProcessMessage(context.Background(), nil, msg1)
 	require.NoError(t, err)
@@ -298,12 +305,14 @@ func TestProposerPreferencesServiceDifferentValidatorsSameSlot(t *testing.T) {
 	err = service.ProcessMessage(context.Background(), nil, msg2)
 	require.NoError(t, err)
 
-	// Both should be seen (different validators)
+	// Both should be seen (different validators and slots)
 	require.True(t, service.seenCache.Contains(seenProposerPreferencesKey{validatorIndex: 1, slot: 100, dependentRoot: testDependentRoot}))
-	require.True(t, service.seenCache.Contains(seenProposerPreferencesKey{validatorIndex: 2, slot: 100, dependentRoot: testDependentRoot}))
+	require.True(t, service.seenCache.Contains(seenProposerPreferencesKey{validatorIndex: 2, slot: 101, dependentRoot: testDependentRoot}))
 
-	// Pool is keyed by slot, so the second one overwrites the first
 	stored, ok := epbsPool.ProposerPreferences.Get(pool.ProposerPreferencesKey{Slot: 100, DependentRoot: testDependentRoot})
+	require.True(t, ok)
+	require.Equal(t, msg1, stored)
+	stored, ok = epbsPool.ProposerPreferences.Get(pool.ProposerPreferencesKey{Slot: 101, DependentRoot: testDependentRoot})
 	require.True(t, ok)
 	require.Equal(t, msg2, stored)
 }
@@ -312,22 +321,13 @@ func TestProposerPreferencesServiceSameValidatorDifferentSlots(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	service, mockSyncedData, ethClockMock, epbsPool, forkChoiceMock := setupProposerPreferencesService(t, ctrl)
+	service, _, ethClockMock, epbsPool, _ := setupProposerPreferencesService(t, ctrl)
 
 	msg1 := newTestSignedProposerPreferences(96, 42)  // slot 96, epoch 3
 	msg2 := newTestSignedProposerPreferences(100, 42) // slot 100, epoch 3
 
-	// Add dependent root to forkchoice so the check passes
-	forkChoiceMock.Headers[testDependentRoot] = &cltypes.BeaconBlockHeader{}
-
-	// Both calls: epoch OK, slot not passed, ViewHeadState succeeds
 	ethClockMock.EXPECT().GetCurrentEpoch().Return(uint64(2)).Times(2)
-	ethClockMock.EXPECT().GetEpochAtSlot(uint64(96)).Return(uint64(3))
-	ethClockMock.EXPECT().GetEpochAtSlot(uint64(100)).Return(uint64(3))
 	ethClockMock.EXPECT().GetCurrentSlot().Return(uint64(90)).Times(2)
-	mockSyncedData.EXPECT().ViewHeadState(gomock.Any()).DoAndReturn(func(fn synced_data.ViewHeadStateFn) error {
-		return nil
-	}).Times(2)
 
 	err := service.ProcessMessage(context.Background(), nil, msg1)
 	require.NoError(t, err)
@@ -380,21 +380,14 @@ func TestProposerPreferencesServiceFailedValidationNotStored(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	service, mockSyncedData, ethClockMock, epbsPool, forkChoiceMock := setupProposerPreferencesService(t, ctrl)
+	service, _, ethClockMock, epbsPool, forkChoiceMock := setupProposerPreferencesService(t, ctrl)
 
 	msg := newTestSignedProposerPreferences(100, 42)
 
-	// Add dependent root to forkchoice so the check passes
-	forkChoiceMock.Headers[testDependentRoot] = &cltypes.BeaconBlockHeader{}
+	forkChoiceMock.StateAtBlockRootVal[testDependentRoot] = newProposerPreferencesState(service.beaconCfg, map[uint64]uint64{100: 7})
 
 	ethClockMock.EXPECT().GetCurrentEpoch().Return(uint64(2))
-	ethClockMock.EXPECT().GetEpochAtSlot(uint64(100)).Return(uint64(3))
 	ethClockMock.EXPECT().GetCurrentSlot().Return(uint64(90))
-
-	// ViewHeadState returns error (e.g. wrong proposer or invalid BLS)
-	mockSyncedData.EXPECT().ViewHeadState(gomock.Any()).DoAndReturn(func(fn synced_data.ViewHeadStateFn) error {
-		return fmt.Errorf("validator 42 is not the proposer for slot 100")
-	})
 
 	err := service.ProcessMessage(context.Background(), nil, msg)
 	require.Error(t, err)

--- a/cl/phase1/network/services/proposer_preferences_service_test.go
+++ b/cl/phase1/network/services/proposer_preferences_service_test.go
@@ -157,6 +157,25 @@ func TestProposerPreferencesServiceSlotAlreadyPassed(t *testing.T) {
 	require.Contains(t, err.Error(), "already passed")
 }
 
+func TestProposerPreferencesServiceCurrentSlotIgnored(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	service, _, ethClockMock, _, _ := setupProposerPreferencesService(t, ctrl)
+
+	// proposalSlot == currentSlot → spec says proposal_slot > current_slot, so this should be IGNORED
+	msg := newTestSignedProposerPreferences(100, 42)
+
+	ethClockMock.EXPECT().GetCurrentEpoch().Return(uint64(2))
+	ethClockMock.EXPECT().GetEpochAtSlot(uint64(100)).Return(uint64(3))
+	ethClockMock.EXPECT().GetCurrentSlot().Return(uint64(100))
+
+	err := service.ProcessMessage(context.Background(), nil, msg)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrIgnore))
+	require.Contains(t, err.Error(), "already passed")
+}
+
 func TestProposerPreferencesServiceDuplicate(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/cl/phase1/stages/forkchoice.go
+++ b/cl/phase1/stages/forkchoice.go
@@ -72,8 +72,8 @@ func computeAndNotifyServicesOfNewForkChoice(ctx context.Context, logger log.Log
 		headVersion := cfg.beaconCfg.GetCurrentStateVersion(headSlot / cfg.beaconCfg.SlotsPerEpoch)
 		if _, err = cfg.forkChoice.Engine().ForkChoiceUpdate(
 			ctx,
-			cfg.forkChoice.GetEth1Hash(finalizedCheckpoint.Root),
-			cfg.forkChoice.GetEth1Hash(justifiedCheckpoint.Root),
+			cfg.forkChoice.GetFinalizedExecutionHash(finalizedCheckpoint.Root),
+			cfg.forkChoice.GetFinalizedExecutionHash(justifiedCheckpoint.Root),
 			cfg.forkChoice.GetEth1Hash(headRoot), nil, headVersion,
 		); err != nil {
 			err = fmt.Errorf("failed to run forkchoice: %w", err)

--- a/cl/pool/epbs_pool.go
+++ b/cl/pool/epbs_pool.go
@@ -85,3 +85,7 @@ func (p *EpbsPool) GetPreferencesForSlot(slot uint64) []*cltypes.SignedProposerP
 	}
 	return results
 }
+
+func (p *EpbsPool) GetPreference(slot uint64, dependentRoot common.Hash) (*cltypes.SignedProposerPreferences, bool) {
+	return p.ProposerPreferences.Get(ProposerPreferencesKey{Slot: slot, DependentRoot: dependentRoot})
+}

--- a/cl/pool/operations_pool_test.go
+++ b/cl/pool/operations_pool_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -84,4 +85,20 @@ func TestOperationsPool(t *testing.T) {
 	require.Len(t, pools.BLSToExecutionChangesPool.Raw(), 1)
 
 	require.Len(t, pools.ProposerSlashingsPool.Raw(), 1)
+}
+
+func TestEpbsPoolGetPreferenceExactLookup(t *testing.T) {
+	p := NewEpbsPool()
+	slot := uint64(10)
+	root := common.Hash{0x01}
+	otherRoot := common.Hash{0x02}
+	want := &cltypes.SignedProposerPreferences{Message: &cltypes.ProposerPreferences{ProposalSlot: slot, DependentRoot: root}}
+	p.ProposerPreferences.Add(ProposerPreferencesKey{Slot: slot, DependentRoot: root}, want)
+
+	got, ok := p.GetPreference(slot, root)
+	require.True(t, ok)
+	require.Equal(t, want, got)
+
+	_, ok = p.GetPreference(slot, otherRoot)
+	require.False(t, ok)
 }

--- a/cl/sentinel/communication/topics.go
+++ b/cl/sentinel/communication/topics.go
@@ -33,6 +33,7 @@ const StatusTopic = "/status"
 const GoodbyeTopic = "/goodbye"
 const BeaconBlocksByRangeTopic = "/beacon_blocks_by_range"
 const BeaconBlocksByRootTopic = "/beacon_blocks_by_root"
+const BeaconBlocksByHeadTopic = "/beacon_blocks_by_head"
 const BlobSidecarByRootTopic = "/blob_sidecars_by_root"
 const BlobSidecarByRangeTopic = "/blob_sidecars_by_range"
 const LightClientOptimisticUpdateTopic = "/light_client_optimistic_update"
@@ -63,6 +64,8 @@ var (
 
 	BeaconBlocksByRootProtocolV1 = ProtocolPrefix + BeaconBlocksByRootTopic + Schema1 + EncodingProtocol
 	BeaconBlocksByRootProtocolV2 = ProtocolPrefix + BeaconBlocksByRootTopic + Schema2 + EncodingProtocol
+
+	BeaconBlocksByHeadProtocolV1 = ProtocolPrefix + BeaconBlocksByHeadTopic + Schema1 + EncodingProtocol
 
 	BlobSidecarByRootProtocolV1  = ProtocolPrefix + BlobSidecarByRootTopic + Schema1 + EncodingProtocol
 	BlobSidecarByRangeProtocolV1 = ProtocolPrefix + BlobSidecarByRangeTopic + Schema1 + EncodingProtocol

--- a/cl/sentinel/handlers/blocks_by_head.go
+++ b/cl/sentinel/handlers/blocks_by_head.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
 package handlers
 
 import (

--- a/cl/sentinel/handlers/blocks_by_head.go
+++ b/cl/sentinel/handlers/blocks_by_head.go
@@ -1,0 +1,69 @@
+package handlers
+
+import (
+	"github.com/libp2p/go-libp2p/core/network"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/sentinel/communication/ssz_snappy"
+	"github.com/erigontech/erigon/common/log/v3"
+)
+
+func (c *ConsensusHandlers) beaconBlocksByHeadHandler(s network.Stream) error {
+	req := &cltypes.BeaconBlocksByHeadRequest{}
+	if err := ssz_snappy.DecodeAndReadNoForkDigest(s, req, clparams.Phase0Version); err != nil {
+		return err
+	}
+
+	count := req.Count
+	if count > c.beaconConfig.MaxRequestBlocksDeneb {
+		count = c.beaconConfig.MaxRequestBlocksDeneb
+	}
+	if count == 0 {
+		return nil
+	}
+
+	if cost := int(count) - 1; !c.consumeRateLimit(s, cost) {
+		return nil
+	}
+
+	tx, err := c.indiciesDB.BeginRo(c.ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	currentRoot := req.BeaconRoot
+	for i := uint64(0); i < count; i++ {
+		block, err := c.beaconDB.ReadBlockByRoot(c.ctx, tx, currentRoot)
+		if err != nil {
+			return err
+		}
+		if block == nil && c.forkChoiceReader != nil {
+			block, _ = c.forkChoiceReader.GetBlock(currentRoot)
+		}
+		if block == nil {
+			log.Debug("[Sentinel] beaconBlocksByHead: block not found", "root", currentRoot)
+			break
+		}
+
+		forkDigest, err := c.ethClock.ComputeForkDigest(block.Block.Slot / c.beaconConfig.SlotsPerEpoch)
+		if err != nil {
+			return err
+		}
+
+		if _, err := s.Write([]byte{SuccessfulResponsePrefix}); err != nil {
+			return err
+		}
+		if _, err := s.Write(forkDigest[:]); err != nil {
+			return err
+		}
+		if err := ssz_snappy.EncodeAndWrite(s, block); err != nil {
+			return err
+		}
+
+		currentRoot = block.Block.ParentRoot
+	}
+
+	return nil
+}

--- a/cl/sentinel/handlers/blocks_by_head_test.go
+++ b/cl/sentinel/handlers/blocks_by_head_test.go
@@ -1,0 +1,241 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/golang/snappy"
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/antiquary/tests"
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/phase1/forkchoice/mock_services"
+	"github.com/erigontech/erigon/cl/sentinel/communication"
+	"github.com/erigontech/erigon/cl/sentinel/communication/ssz_snappy"
+	"github.com/erigontech/erigon/cl/sentinel/peers"
+	"github.com/erigontech/erigon/cl/utils"
+	"github.com/erigontech/erigon/common"
+)
+
+func TestBlocksByHeadCountCap(t *testing.T) {
+	_, beaconCfg := clparams.GetConfigsByNetwork(1)
+	count := beaconCfg.MaxRequestBlocksDeneb + 5
+	blocks, roots := makeBlocksByHeadChain(t, 100, count)
+
+	store, stream := setupBlocksByHeadTest(t, blocks, nil)
+	_ = store
+
+	writeBlocksByHeadRequest(t, stream, roots[len(roots)-1], count)
+
+	got := readBlocksByHeadResponses(t, stream, int(beaconCfg.MaxRequestBlocksDeneb))
+	require.Len(t, got, int(beaconCfg.MaxRequestBlocksDeneb))
+	require.Equal(t, blocks[len(blocks)-1].Block.Slot, got[0].Block.Slot)
+	require.Equal(t, blocks[len(blocks)-int(beaconCfg.MaxRequestBlocksDeneb)].Block.Slot, got[len(got)-1].Block.Slot)
+	expectNoBlocksByHeadResponse(t, stream)
+}
+
+func TestBlocksByHeadParentChainTraversal(t *testing.T) {
+	blocks, roots := makeBlocksByHeadChain(t, 200, 4)
+	_, stream := setupBlocksByHeadTest(t, blocks, nil)
+
+	writeBlocksByHeadRequest(t, stream, roots[len(roots)-1], 3)
+
+	got := readBlocksByHeadResponses(t, stream, 3)
+	require.Equal(t, []uint64{203, 202, 201}, []uint64{
+		got[0].Block.Slot,
+		got[1].Block.Slot,
+		got[2].Block.Slot,
+	})
+	require.Equal(t, roots[2], got[0].Block.ParentRoot)
+	require.Equal(t, roots[1], got[1].Block.ParentRoot)
+	require.Equal(t, roots[0], got[2].Block.ParentRoot)
+}
+
+func TestBlocksByHeadForkChoiceFallback(t *testing.T) {
+	blocks, roots := makeBlocksByHeadChain(t, 300, 1)
+	forkChoice := mock_services.NewForkChoiceStorageMock(t)
+	forkChoice.Blocks[roots[0]] = blocks[0]
+	_, stream := setupBlocksByHeadTest(t, nil, forkChoice)
+
+	writeBlocksByHeadRequest(t, stream, roots[0], 1)
+
+	got := readBlocksByHeadResponses(t, stream, 1)
+	require.Equal(t, blocks[0].Block.Slot, got[0].Block.Slot)
+	require.Equal(t, blocks[0].Block.StateRoot, got[0].Block.StateRoot)
+}
+
+func TestBlocksByHeadMissingRoot(t *testing.T) {
+	_, stream := setupBlocksByHeadTest(t, nil, nil)
+
+	writeBlocksByHeadRequest(t, stream, common.Hash{0x42}, 3)
+
+	expectNoBlocksByHeadResponse(t, stream)
+}
+
+func TestBlocksByHeadZeroCount(t *testing.T) {
+	blocks, roots := makeBlocksByHeadChain(t, 400, 1)
+	_, stream := setupBlocksByHeadTest(t, blocks, nil)
+
+	writeBlocksByHeadRequest(t, stream, roots[0], 0)
+
+	expectNoBlocksByHeadResponse(t, stream)
+}
+
+func setupBlocksByHeadTest(
+	t *testing.T,
+	blocks []*cltypes.SignedBeaconBlock,
+	forkChoice *mock_services.ForkChoiceStorageMock,
+) (*tests.MockBlockReader, network.Stream) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	host, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, host.Close()) })
+
+	host1, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, host1.Close()) })
+
+	require.NoError(t, host.Connect(ctx, peer.AddrInfo{
+		ID:    host1.ID(),
+		Addrs: host1.Addrs(),
+	}))
+
+	_, indiciesDB := setupStore(t)
+	t.Cleanup(func() { indiciesDB.Close() })
+
+	store := tests.NewMockBlockReader()
+	for _, block := range blocks {
+		store.U[block.Block.Slot] = block
+	}
+	if forkChoice == nil {
+		forkChoice = mock_services.NewForkChoiceStorageMock(t)
+	}
+
+	ethClock := getEthClock(t)
+	_, beaconCfg := clparams.GetConfigsByNetwork(1)
+	c := NewConsensusHandlers(
+		ctx,
+		store,
+		indiciesDB,
+		host,
+		peers.NewPool(host),
+		&clparams.NetworkConfig{},
+		nil,
+		beaconCfg,
+		ethClock,
+		nil, forkChoice, nil, nil, nil, true,
+	)
+	c.Start()
+
+	stream, err := host1.NewStream(ctx, host.ID(), protocol.ID(communication.BeaconBlocksByHeadProtocolV1))
+	require.NoError(t, err)
+	t.Cleanup(func() { stream.Close() })
+
+	return store, stream
+}
+
+func makeBlocksByHeadChain(t *testing.T, startSlot, count uint64) ([]*cltypes.SignedBeaconBlock, []common.Hash) {
+	t.Helper()
+
+	parentRoot := common.Hash{0x99}
+	blocks := make([]*cltypes.SignedBeaconBlock, 0, count)
+	roots := make([]common.Hash, 0, count)
+	for i := uint64(0); i < count; i++ {
+		block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.Phase0Version)
+		block.Block.Slot = startSlot + i
+		block.Block.StateRoot = common.Hash{byte(i + 1)}
+		block.Block.ParentRoot = parentRoot
+		block.Block.ProposerIndex = i
+		root, err := block.Block.HashSSZ()
+		require.NoError(t, err)
+		parentRoot = root
+		blocks = append(blocks, block)
+		roots = append(roots, root)
+	}
+	return blocks, roots
+}
+
+func writeBlocksByHeadRequest(t *testing.T, stream network.Stream, root common.Hash, count uint64) {
+	t.Helper()
+
+	req := &cltypes.BeaconBlocksByHeadRequest{
+		BeaconRoot: root,
+		Count:      count,
+	}
+	var reqBuf bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&reqBuf, req))
+	_, err := stream.Write(common.Copy(reqBuf.Bytes()))
+	require.NoError(t, err)
+}
+
+func readBlocksByHeadResponses(t *testing.T, stream network.Stream, count int) []*cltypes.SignedBeaconBlock {
+	t.Helper()
+
+	ethClock := getEthClock(t)
+	blocks := make([]*cltypes.SignedBeaconBlock, 0, count)
+	for i := 0; i < count; i++ {
+		prefix := make([]byte, 1)
+		require.NoError(t, stream.SetReadDeadline(time.Now().Add(5*time.Second)))
+		_, err := io.ReadFull(stream, prefix)
+		require.NoError(t, err)
+		require.Equal(t, byte(SuccessfulResponsePrefix), prefix[0])
+
+		forkDigest := make([]byte, 4)
+		_, err = io.ReadFull(stream, forkDigest)
+		require.NoError(t, err)
+
+		encodedLn, _, err := ssz_snappy.ReadUvarint(stream)
+		require.NoError(t, err)
+
+		raw := make([]byte, encodedLn)
+		sr := snappy.NewReader(stream)
+		_, err = io.ReadFull(sr, raw)
+		require.NoError(t, err)
+
+		version, err := ethClock.StateVersionByForkDigest(utils.Uint32ToBytes4(binary.BigEndian.Uint32(forkDigest)))
+		require.NoError(t, err)
+		block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, version)
+		require.NoError(t, block.DecodeSSZ(raw, int(version)))
+		blocks = append(blocks, block)
+	}
+	return blocks
+}
+
+func expectNoBlocksByHeadResponse(t *testing.T, stream network.Stream) {
+	t.Helper()
+
+	require.NoError(t, stream.SetReadDeadline(time.Now().Add(200*time.Millisecond)))
+	var buf [1]byte
+	n, err := stream.Read(buf[:])
+	require.Zero(t, n)
+	require.Error(t, err)
+}

--- a/cl/sentinel/handlers/execution_payload_envelopes.go
+++ b/cl/sentinel/handlers/execution_payload_envelopes.go
@@ -34,6 +34,10 @@ func (c *ConsensusHandlers) executionPayloadEnvelopesByRangeHandler(s network.St
 		return errors.New("request count exceeds MAX_REQUEST_BLOCKS_DENEB")
 	}
 
+	if cost := min(int(req.Count), int(c.beaconConfig.MaxRequestBlocksDeneb)) - 1; !c.consumeRateLimit(s, cost) {
+		return nil
+	}
+
 	// Compute minimum serve slot: max(GLOAS_FORK_EPOCH, current_epoch - MIN_EPOCHS_FOR_BLOCK_REQUESTS) * SLOTS_PER_EPOCH
 	minServeEpoch := c.beaconConfig.GloasForkEpoch
 	if curEpoch > c.beaconConfig.MinEpochsForBlockRequests() {
@@ -128,6 +132,10 @@ func (c *ConsensusHandlers) executionPayloadEnvelopesByRootHandler(s network.Str
 	}
 
 	if req.Length() == 0 {
+		return nil
+	}
+
+	if cost := min(req.Length(), int(c.beaconConfig.MaxRequestBlocksDeneb)) - 1; !c.consumeRateLimit(s, cost) {
 		return nil
 	}
 

--- a/cl/sentinel/handlers/execution_payload_envelopes.go
+++ b/cl/sentinel/handlers/execution_payload_envelopes.go
@@ -1,3 +1,19 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
 package handlers
 
 import (
@@ -32,6 +48,9 @@ func (c *ConsensusHandlers) executionPayloadEnvelopesByRangeHandler(s network.St
 	// Validate count
 	if req.Count > c.beaconConfig.MaxRequestBlocksDeneb {
 		return errors.New("request count exceeds MAX_REQUEST_BLOCKS_DENEB")
+	}
+	if req.Count == 0 {
+		return nil
 	}
 
 	if cost := min(int(req.Count), int(c.beaconConfig.MaxRequestBlocksDeneb)) - 1; !c.consumeRateLimit(s, cost) {

--- a/cl/sentinel/handlers/handlers.go
+++ b/cl/sentinel/handlers/handlers.go
@@ -132,6 +132,8 @@ func NewConsensusHandlers(
 		// execution payload envelopes
 		hm[communication.ExecutionPayloadEnvelopesByRangeProtocolV1] = c.executionPayloadEnvelopesByRangeHandler
 		hm[communication.ExecutionPayloadEnvelopesByRootProtocolV1] = c.executionPayloadEnvelopesByRootHandler
+		// blocks by head (consensus-specs PR #5181, Fulu)
+		hm[communication.BeaconBlocksByHeadProtocolV1] = c.beaconBlocksByHeadHandler
 	}
 
 	c.handlers = map[protocol.ID]network.StreamHandler{}

--- a/cl/sentinel/handlers/rate_limiter.go
+++ b/cl/sentinel/handlers/rate_limiter.go
@@ -134,10 +134,13 @@ func newPeerRateLimiter() *peerRateLimiter {
 
 	rl.protocolLimits[communication.BeaconBlocksByRangeProtocolV2] = blockRate
 	rl.protocolLimits[communication.BeaconBlocksByRootProtocolV2] = blockRate
+	rl.protocolLimits[communication.BeaconBlocksByHeadProtocolV1] = blockRate
 	rl.protocolLimits[communication.BlobSidecarByRangeProtocolV1] = blobRate
 	rl.protocolLimits[communication.BlobSidecarByRootProtocolV1] = blobRate
 	rl.protocolLimits[communication.DataColumnSidecarsByRangeProtocolV1] = dataColRate
 	rl.protocolLimits[communication.DataColumnSidecarsByRootProtocolV1] = dataColRate
+	rl.protocolLimits[communication.ExecutionPayloadEnvelopesByRangeProtocolV1] = blockRate
+	rl.protocolLimits[communication.ExecutionPayloadEnvelopesByRootProtocolV1] = blockRate
 	rl.protocolLimits[communication.PingProtocolV1] = pingRate
 	rl.protocolLimits[communication.GoodbyeProtocolV1] = goodbyeRate
 	rl.protocolLimits[communication.StatusProtocolV1] = statusRate

--- a/cl/transition/impl/eth2/operations.go
+++ b/cl/transition/impl/eth2/operations.go
@@ -1661,9 +1661,7 @@ func (I *impl) ProcessDepositRequest(s abstract.BeaconState, depositRequest *sol
 		isBuilder := state.IsBuilderPubkey(s, depositRequest.PubKey)
 		_, isExistingValidator := s.ValidatorIndexByPubkey(depositRequest.PubKey)
 		hasBuilderPrefix := state.IsBuilderWithdrawalCredential(depositRequest.WithdrawalCredentials, s.BeaconConfig())
-		// Check if there's a pending deposit with valid signature for this pubkey
-		isPendingValidator := state.IsPendingValidator(s, depositRequest.PubKey)
-		// isValidator includes both existing validators and pending validators with valid signatures
+		isPendingValidator := state.IsPendingValidator(s.BeaconConfig(), s.GetPendingDeposits(), depositRequest.PubKey)
 		isValidator := isExistingValidator || isPendingValidator
 
 		if isBuilder || (hasBuilderPrefix && !isValidator) {

--- a/execution/builder/create_block.go
+++ b/execution/builder/create_block.go
@@ -166,8 +166,6 @@ func createBlock(ctx context.Context, sd *execctx.SharedDomains, tx kv.TemporalT
 
 	targetGasLimit := cfg.builder.BuilderConfig.GasLimit
 	if cfg.blockBuilderParameters != nil && cfg.blockBuilderParameters.TargetGasLimit != nil {
-		// PayloadAttributesV4: CL-supplied target gas limit takes precedence over the
-		// static --miner.gaslimit so the EL follows engine_forkchoiceUpdatedV4.
 		targetGasLimit = cfg.blockBuilderParameters.TargetGasLimit
 	}
 	header := MakeEmptyHeader(parent, cfg.chainConfig, timestamp, targetGasLimit)

--- a/execution/builder/parameters.go
+++ b/execution/builder/parameters.go
@@ -33,7 +33,7 @@ type Parameters struct {
 	Withdrawals           []*types.Withdrawal // added in Shapella (EIP-4895)
 	ParentBeaconBlockRoot *common.Hash        // added in Dencun (EIP-4788)
 	SlotNumber            *uint64             // added in Amsterdam (EIP-7843)
-	TargetGasLimit        *uint64             // added in Amsterdam PayloadAttributesV4
+	TargetGasLimit        *uint64             // added in Gloas (EIP-7732)
 	// CustomTxnProvider overrides the block's transaction source when non-nil.
 	// nil → use the injected TxnProvider (normal mempool path)
 	CustomTxnProvider txnprovider.TxnProvider

--- a/execution/engineapi/engine_server.go
+++ b/execution/engineapi/engine_server.go
@@ -819,8 +819,6 @@ func (s *EngineServer) forkchoiceUpdated(ctx context.Context, forkchoiceState *e
 		Timestamp:             timestamp,
 		PrevRandao:            payloadAttributes.PrevRandao,
 		SuggestedFeeRecipient: payloadAttributes.SuggestedFeeRecipient,
-		SlotNumber:            (*uint64)(payloadAttributes.SlotNumber),
-		TargetGasLimit:        (*uint64)(payloadAttributes.TargetGasLimit),
 	}
 
 	if version >= clparams.CapellaVersion {
@@ -832,6 +830,7 @@ func (s *EngineServer) forkchoiceUpdated(ctx context.Context, forkchoiceState *e
 	}
 
 	if version >= clparams.GloasVersion {
+		assembleParams.SlotNumber = (*uint64)(payloadAttributes.SlotNumber)
 		assembleParams.TargetGasLimit = (*uint64)(payloadAttributes.TargetGasLimit)
 	}
 

--- a/execution/engineapi/engine_server.go
+++ b/execution/engineapi/engine_server.go
@@ -831,6 +831,10 @@ func (s *EngineServer) forkchoiceUpdated(ctx context.Context, forkchoiceState *e
 		assembleParams.ParentBeaconBlockRoot = payloadAttributes.ParentBeaconBlockRoot
 	}
 
+	if version >= clparams.GloasVersion {
+		assembleParams.TargetGasLimit = (*uint64)(payloadAttributes.TargetGasLimit)
+	}
+
 	var assembled execmodule.AssembleBlockResult
 	// Wait for the execution service to be ready to assemble a block. Wait a full slot duration (12 seconds) to ensure that the execution service is not busy.
 	// Blocks are important and 0.5 seconds is not enough to wait for the execution service to be ready.

--- a/execution/engineapi/engine_types/ssz.go
+++ b/execution/engineapi/engine_types/ssz.go
@@ -313,7 +313,9 @@ func (a *PayloadAttributes) EncodeSSZ(dst []byte) ([]byte, error) {
 		return ssz2.MarshalSSZ(dst, uint64(a.Timestamp), a.PrevRandao[:], a.SuggestedFeeRecipient[:], withdrawals)
 	case clparams.DenebVersion:
 		return ssz2.MarshalSSZ(dst, uint64(a.Timestamp), a.PrevRandao[:], a.SuggestedFeeRecipient[:], withdrawals, root[:])
-	default:
+	case clparams.ElectraVersion, clparams.FuluVersion:
+		return ssz2.MarshalSSZ(dst, uint64(a.Timestamp), a.PrevRandao[:], a.SuggestedFeeRecipient[:], withdrawals, root[:], slot)
+	default: // GloasVersion+
 		return ssz2.MarshalSSZ(dst, uint64(a.Timestamp), a.PrevRandao[:], a.SuggestedFeeRecipient[:], withdrawals, root[:], slot, targetGasLimit)
 	}
 }
@@ -341,7 +343,16 @@ func (a *PayloadAttributes) DecodeSSZ(buf []byte, version int) error {
 		}
 		a.Withdrawals = withdrawalsFromList(withdrawals)
 		a.ParentBeaconBlockRoot = &root
-	default:
+	case clparams.ElectraVersion, clparams.FuluVersion:
+		if err := ssz2.UnmarshalSSZ(buf, version, &timestamp, a.PrevRandao[:], a.SuggestedFeeRecipient[:], withdrawals, root[:], &slot); err != nil {
+			return err
+		}
+		a.Withdrawals = withdrawalsFromList(withdrawals)
+		a.ParentBeaconBlockRoot = &root
+		slotNumber := hexutil.Uint64(slot)
+		a.SlotNumber = &slotNumber
+	default: // GloasVersion+
+		var targetGasLimit uint64
 		if err := ssz2.UnmarshalSSZ(buf, version, &timestamp, a.PrevRandao[:], a.SuggestedFeeRecipient[:], withdrawals, root[:], &slot, &targetGasLimit); err != nil {
 			return err
 		}

--- a/execution/engineapi/engine_types/ssz.go
+++ b/execution/engineapi/engine_types/ssz.go
@@ -326,7 +326,6 @@ func (a *PayloadAttributes) DecodeSSZ(buf []byte, version int) error {
 	var timestamp uint64
 	var root common.Hash
 	var slot uint64
-	var targetGasLimit uint64
 	switch a.SSZVersion {
 	case clparams.BellatrixVersion:
 		if err := ssz2.UnmarshalSSZ(buf, version, &timestamp, a.PrevRandao[:], a.SuggestedFeeRecipient[:]); err != nil {

--- a/execution/engineapi/engine_types/ssz.go
+++ b/execution/engineapi/engine_types/ssz.go
@@ -313,8 +313,6 @@ func (a *PayloadAttributes) EncodeSSZ(dst []byte) ([]byte, error) {
 		return ssz2.MarshalSSZ(dst, uint64(a.Timestamp), a.PrevRandao[:], a.SuggestedFeeRecipient[:], withdrawals)
 	case clparams.DenebVersion:
 		return ssz2.MarshalSSZ(dst, uint64(a.Timestamp), a.PrevRandao[:], a.SuggestedFeeRecipient[:], withdrawals, root[:])
-	case clparams.ElectraVersion, clparams.FuluVersion:
-		return ssz2.MarshalSSZ(dst, uint64(a.Timestamp), a.PrevRandao[:], a.SuggestedFeeRecipient[:], withdrawals, root[:], slot)
 	default: // GloasVersion+
 		return ssz2.MarshalSSZ(dst, uint64(a.Timestamp), a.PrevRandao[:], a.SuggestedFeeRecipient[:], withdrawals, root[:], slot, targetGasLimit)
 	}
@@ -342,14 +340,6 @@ func (a *PayloadAttributes) DecodeSSZ(buf []byte, version int) error {
 		}
 		a.Withdrawals = withdrawalsFromList(withdrawals)
 		a.ParentBeaconBlockRoot = &root
-	case clparams.ElectraVersion, clparams.FuluVersion:
-		if err := ssz2.UnmarshalSSZ(buf, version, &timestamp, a.PrevRandao[:], a.SuggestedFeeRecipient[:], withdrawals, root[:], &slot); err != nil {
-			return err
-		}
-		a.Withdrawals = withdrawalsFromList(withdrawals)
-		a.ParentBeaconBlockRoot = &root
-		slotNumber := hexutil.Uint64(slot)
-		a.SlotNumber = &slotNumber
 	default: // GloasVersion+
 		var targetGasLimit uint64
 		if err := ssz2.UnmarshalSSZ(buf, version, &timestamp, a.PrevRandao[:], a.SuggestedFeeRecipient[:], withdrawals, root[:], &slot, &targetGasLimit); err != nil {

--- a/test-fixtures.json
+++ b/test-fixtures.json
@@ -16,8 +16,8 @@
     "size": 422845437
   },
   "cl_mainnet": {
-    "url": "https://github.com/ethereum/consensus-specs/releases/download/v1.7.0-alpha.7/mainnet.tar.gz",
-    "sha256": "a96c52b503e1da5305df1c8c09974a2b95a09545cffeea63b440be803059f5d6",
-    "size": 844604385
+    "url": "https://github.com/ethereum/consensus-specs/releases/download/v1.7.0-alpha.8/mainnet.tar.gz",
+    "sha256": "6a5aca81b2f158544d6fcfe32c89d0d1e26bbb949c0169f1334ac43b3766fd81",
+    "size": 856253243
   }
 }


### PR DESCRIPTION
## Summary
- Upgrade spectest fixtures from v1.7.0-alpha.7 to **v1.7.0-alpha.8**
- Implement 13 consensus-specs PRs for Gloas/Fulu devnet-4 readiness:
  - **Fork-choice**: `notify_forkchoice_updated` uses `parent_block_hash` (#5197), proposer reorg unavailable blocks (#5186), PTC duplicate validator vote counting (#5222), separated payload timeliness / data availability deadlines (#5212)
  - **ePBS**: `target_gas_limit` in `PayloadAttributes` (#5235), gas limit gossip validation (#5236), builder onboarding at fork transition (#5254), `MIN_BUILDER_WITHDRAWABILITY_DELAY` → 8192 (#5223), `MIN_SEED_LOOKAHEAD` for proposer preferences (#5215)
  - **ReqResp**: new `beacon_blocks_by_head` protocol (#5181)
  - **Constants**: `PAYLOAD_DUE_BPS` added

### Bug fixes after initial implementation
- **PTC votes**: fix unvoted-as-false bug — use three-state `int8` (`ptcVoteAbsent`/`ptcVotePresent`/`ptcVoteWithheld`) instead of `bool`, wire `ShouldBuildOnFull` correctly
- **Builder onboarding**: fix conflict check to scan full pending deposits, then revert to simpler approach
- **IsPendingValidator**: revert list change that caused issues

### Review feedback (round 2)
- **HasEnvelope guard**: restored `HasEnvelope(baseBlockRoot)` before `ShouldBuildOnFull` in `produceBeaconBody` to prevent missed proposals when envelope is temporarily unavailable
- **Builder onboarding nesting**: fixed to mirror alpha.8 spec exactly — existing builders skip `IsPendingValidator` and always `ApplyDepositForBuilder`
- **IsGasLimitTargetCompatible test**: added table test covering all branches (clamp, underflow guard)
- **blocks_by_head handler tests**: count cap, parent traversal, fork-choice fallback, missing root, zero count
- **GetFinalizedExecutionHash tests**: Gloas bid path, pre-Gloas fallback, missing block
- **SSZ cleanup**: removed unreachable `ElectraVersion`/`FuluVersion` case arms in PayloadAttributes encode/decode
- **Envelope handler**: added `count==0` early return to avoid `cost=-1`
- **TargetGasLimit default**: when no proposer preference is set, `TargetGasLimit` is now `nil` (EL uses its static `--miner.gaslimit`), replacing the previous `DefaultBuilderGasLimit` default. This is intentional — the EL should control its own gas limit when the CL has no preference.

### Kurtosis / CI
- Upgrade CL images to `glamsterdam-devnet-4`
- Pin assertoor to `master-0ad56fb` — tracking issue to switch to release tag: #21441
- Disable `run_stability_check` for glamsterdam — tracking issue to re-enable: #21442

## Test plan
- [x] `make lint` — 0 issues
- [x] `go test ./cl/spectest/` — all gloas/fork, fork_choice, ssz_static tests pass (including 9 new builder deposit fork tests)
- [x] `payload_vote_test.go` — new unit tests for three-state PTC vote logic
- [x] `gas_limit_test.go` — new table test for `IsGasLimitTargetCompatible` all branches
- [x] `blocks_by_head_test.go` — new handler tests (5 cases)
- [x] `forkchoice_test.go` — new `GetFinalizedExecutionHash` tests (3 paths)
- [x] CI: unit tests (caplin, mac/linux/windows all green)
- [x] CI: hive engine/api, cancun, withdrawals, rpc-compat — all green
- [x] CI: integration tests (eest-spec-tests all green)
- [x] CI: kurtosis glamsterdam devnet — block_proposal_check green

🤖 Generated with [Claude Code](https://claude.com/claude-code)