### PR TITLE
cl/phase1/forkchoice: align getFilterBlockTree with consensus spec

### DIFF
--- a/cl/phase1/forkchoice/get_head.go
+++ b/cl/phase1/forkchoice/get_head.go
@@ -289,14 +289,18 @@ func (f *ForkChoiceStore) getHead(auxilliaryState *state.CachingBeaconState) (co
 // getFilteredBlockTree filters out dumb blocks.
 func (f *ForkChoiceStore) getFilteredBlockTree(base common.Hash) map[common.Hash]*cltypes.BeaconBlockHeader {
 	blocks := make(map[common.Hash]*cltypes.BeaconBlockHeader)
-	f.getFilterBlockTree(base, blocks)
+	// Snapshot the store epoch once for the whole walk: OnTick updates f.time
+	// without holding f.mu, so calling f.Slot() per-leaf can mix epochs across
+	// leaves around a slot boundary.
+	currentEpoch := f.computeEpochAtSlot(f.Slot())
+	f.getFilterBlockTree(base, blocks, currentEpoch)
 	return blocks
 }
 
 // getFilterBlockTree recursively traverses the block tree to identify viable blocks.
 // It takes a block hash and a map of viable blocks as input parameters, and returns a boolean value indicating
 // whether the current block is viable.
-func (f *ForkChoiceStore) getFilterBlockTree(blockRoot common.Hash, blocks map[common.Hash]*cltypes.BeaconBlockHeader) bool {
+func (f *ForkChoiceStore) getFilterBlockTree(blockRoot common.Hash, blocks map[common.Hash]*cltypes.BeaconBlockHeader, currentEpoch uint64) bool {
 	header, has := f.forkGraph.GetHeader(blockRoot)
 	if !has {
 		return false
@@ -308,7 +312,7 @@ func (f *ForkChoiceStore) getFilterBlockTree(blockRoot common.Hash, blocks map[c
 	if len(children) > 0 {
 		isAnyViable := false
 		for _, child := range children {
-			if f.getFilterBlockTree(child, blocks) {
+			if f.getFilterBlockTree(child, blocks, currentEpoch) {
 				isAnyViable = true
 			}
 		}
@@ -317,18 +321,16 @@ func (f *ForkChoiceStore) getFilterBlockTree(blockRoot common.Hash, blocks map[c
 		}
 		return isAnyViable
 	}
-	// Leaf node — check viability per spec filter_block_tree
-	//
-	// Justified check (spec): voting_source.epoch >= store.justified_checkpoint.epoch
-	// Note: the spec uses >= (not ==) so blocks with higher unrealized justification are viable.
-	// Also implements is_previous_epoch_justified fallback.
-	//
-	// Finalized check (spec): store.finalized_checkpoint.root == get_ancestor(store, block_root, finalized_slot)
-	// Note: checks that the block descends from the finalized block, not checkpoint equality.
-
-	// Get voting source (unrealized justification for this block)
-	votingSource, has := f.getUnrealizedJustification(blockRoot)
-	if !has {
+	blockEpoch := f.computeEpochAtSlot(header.Slot)
+	var votingSource solid.Checkpoint
+	if currentEpoch > blockEpoch {
+		var has bool
+		votingSource, has = f.getUnrealizedJustification(blockRoot)
+		if !has {
+			return false
+		}
+	} else {
+		var has bool
 		votingSource, has = f.forkGraph.GetCurrentJustifiedCheckpoint(blockRoot)
 		if !has {
 			return false
@@ -336,28 +338,10 @@ func (f *ForkChoiceStore) getFilterBlockTree(blockRoot common.Hash, blocks map[c
 	}
 
 	genesisEpoch := f.beaconCfg.GenesisEpoch
-
-	// Spec: correct_justified = store.justified_checkpoint.epoch == GENESIS_EPOCH
-	//       or voting_source.epoch >= store.justified_checkpoint.epoch
 	justifiedOk := justifiedCheckpoint.Epoch == genesisEpoch ||
-		votingSource.Epoch >= justifiedCheckpoint.Epoch
+		votingSource.Epoch == justifiedCheckpoint.Epoch ||
+		votingSource.Epoch+2 >= currentEpoch
 
-	// is_previous_epoch_justified fallback:
-	// If not correct_justified and previous epoch is justified, check that
-	// the voting source is not more than two epochs ago.
-	if !justifiedOk {
-		currentEpoch := f.computeEpochAtSlot(f.Slot())
-		previousEpoch := currentEpoch - 1
-		if previousEpoch > currentEpoch { // underflow guard
-			previousEpoch = 0
-		}
-		if justifiedCheckpoint.Epoch == previousEpoch {
-			justifiedOk = votingSource.Epoch+2 >= currentEpoch
-		}
-	}
-
-	// Spec: correct_finalized = store.finalized_checkpoint.epoch == GENESIS_EPOCH
-	//       or store.finalized_checkpoint.root == get_ancestor(store, block_root, finalized_slot)
 	finalizedOk := finalizedCheckpoint.Epoch == genesisEpoch
 	if !finalizedOk {
 		finalizedSlot := f.computeStartSlotAtEpoch(finalizedCheckpoint.Epoch)


### PR DESCRIPTION
## Summary

Cherry-pick / port of #21310 to `main`, combined with the finalized ancestor-descent check that was already on `main` (from #18956, commit `f3ad70f1f7`).

`main` already has a partial spec-faithful rewrite of `getFilterBlockTree` — the finalized side now does ancestor descent (correct per spec) — but the justified side still deviates from `filter_block_tree` / `get_voting_source` in two ways. This PR fixes those.

## Spec reference

[filter_block_tree](https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/fork-choice.md#filter_block_tree):

```python
voting_source = get_voting_source(store, block_root)
correct_justified = (
    store.justified_checkpoint.epoch == GENESIS_EPOCH
    or voting_source.epoch == store.justified_checkpoint.epoch
    or voting_source.epoch + 2 >= current_epoch
)
finalized_checkpoint_block = get_checkpoint_block(store, block_root, store.finalized_checkpoint.epoch)
correct_finalized = (
    store.finalized_checkpoint.epoch == GENESIS_EPOCH
    or store.finalized_checkpoint.root == finalized_checkpoint_block
)
```

[get_voting_source](https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/fork-choice.md#get_voting_source):

```python
if current_epoch > block_epoch:
    return store.unrealized_justifications[block_root]   # pull-up
else:
    return head_state.current_justified_checkpoint        # realized
```

## Changes

1. **Voting source selection**: was unrealized-with-fallback unconditional. Now branched on `current_epoch > block_epoch` as the spec requires — unrealized only for prior-epoch blocks; current-epoch (or future) blocks use the block's realized `current_justified_checkpoint`.

2. **`correct_justified`**: was `voting_source.Epoch >= justifiedCheckpoint.Epoch` with an `is_previous_epoch_justified`-gated `+2` fallback. Now the three flat disjuncts straight from the spec: `epoch == GENESIS` or `voting_source.epoch == justified.epoch` or `voting_source.epoch + 2 >= current_epoch`. (The previous `>=` accepts cases spec rejects; the previous gated `+2` rejects cases spec accepts.)

3. **`correct_finalized`**: unchanged — keeps the ancestor-descent check from `f3ad70f1f7` (`finalizedCheckpoint.Root == f.Ancestor(blockRoot, finalizedSlot).Root`).

## Background

Original observed symptom on bloatnet was ~30-block execution unwinds every ~6 minutes (every epoch boundary). Root cause: `getFilterBlockTree` rejected the leaf at each new epoch's first slot, Caplin's head fell back to an older block, and execution unwound to follow. Both pre-existing deviations contributed:

- Unconditional unrealized fed a stale checkpoint into the check for current-epoch leaves.
- Strict `Equal` (or `>=` with the gated fallback) rejected leaves whose voting source's epoch was within 2 of `current_epoch` but not equal to `justified.epoch`.

Issue: erigontech/erigon#21301
Original performance-branch PR: #21310

## Test plan

- [x] Spec-faithful: code matches the consensus-specs Python source line-for-line
- [x] `go build ./cl/phase1/forkchoice/` clean
- [x] Bloatnet runtime validation on `performance` (#21310): 1 hour at chain tip, 5+ epoch boundaries, zero unwinds, zero filterTree rejects, `Caplin lagSlots=0` on all 172 FCU events
- [ ] CI green on `main`
- [ ] Caplin unit tests pass