### PR TITLE
execution/state: per-path revival resolution in versionedRead

### DIFF
--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -812,34 +812,28 @@ func versionedRead[T any](s *IntraBlockState, addr accounts.Address, path Accoun
 		// tipInsideBlock failing with gas exactly 4800 short under
 		// ERIGON_EXEC3_PARALLEL=true (matches EIP-2200's clear refund).
 		destructTxIndex := res.DepIdx()
-		// Cap the revival lookup at s.txIndex-1 so that a prior incarnation
-		// of the CURRENT tx — whose writes still sit in the versionMap at
-		// (s.txIndex, prevIncarnation) until the new incarnation rewrites
-		// them — doesn't masquerade as a "later tx revived this account."
-		// versionMap.Read uses floor(txIdx-1) for the same reason, but
-		// LatestTxIndex's upper bound is inclusive, so we have to subtract
-		// one explicitly. Without this, TX3 incarnation 1 of
-		// TestDeleteRecreateSlotsAcrossManyBlocks block 1 sees TX3
-		// incarnation 0's BalancePath write at txIndex=3, declares a
-		// spurious revival across TX2's SD at txIndex=2, falls through
-		// the SD short-circuit, reads TX1's stale hash(aaCode) for the
-		// CREATE2 collision check, fails the CREATE2 with
-		// ContractAddressCollision, and BB consumes the failed-child
-		// gas — that's the residual +1602 manifestation.
-		revivalLimit := s.txIndex - 1
+		// Per-path revival resolution (issue #21319): the account was
+		// self-destructed at destructTxIndex. THIS field is revived iff the
+		// version map holds a write to THIS path at a strictly higher
+		// TxIndex. versionMap.Read floors at txIndex-1, so a prior
+		// incarnation of the current tx cannot masquerade as a later tx's
+		// revival (this is why the old explicit revivalLimit subtraction is
+		// no longer needed). Per-path (vs. the old Balance|Nonce|CodeHash
+		// account-wide scan) is precise: a field with no post-SD write
+		// reads as the fresh account's zero value — exactly correct for a
+		// value-transfer revival, where GetOrNewStateObject yields nonce 0
+		// and empty code — and never surfaces a stale pre-SD nonce/codeHash
+		// for an account revived only via BalancePath.
+		//
+		// An in-flight revival (Estimate cell → MVReadResultDependency) also
+		// counts as revived: it must fall through so the normal read below
+		// surfaces the dependency and re-executes, rather than being
+		// swallowed as a zero. This matches the old LatestTxIndex scan,
+		// which descended Estimate cells too.
 		revived := false
-		if hi, ok := s.versionMap.LatestTxIndex(addr, BalancePath, accounts.NilKey, revivalLimit); ok && hi > destructTxIndex {
+		if pathRevival := s.versionMap.Read(addr, path, key, s.txIndex); pathRevival.DepIdx() > destructTxIndex &&
+			(pathRevival.Status() == MVReadResultDone || pathRevival.Status() == MVReadResultDependency) {
 			revived = true
-		}
-		if !revived {
-			if hi, ok := s.versionMap.LatestTxIndex(addr, NoncePath, accounts.NilKey, revivalLimit); ok && hi > destructTxIndex {
-				revived = true
-			}
-		}
-		if !revived {
-			if hi, ok := s.versionMap.LatestTxIndex(addr, CodeHashPath, accounts.NilKey, revivalLimit); ok && hi > destructTxIndex {
-				revived = true
-			}
 		}
 		if !revived && path != CodePath {
 			// A prior tx self-destructed this account — all state reads must


### PR DESCRIPTION
## Summary

`versionedRead`'s self-destruct branch decides whether an SD'd account has been revived by a later transaction before short-circuiting a field read to zero. It did this with an **account-wide** scan: if `BalancePath`, `NoncePath` *or* `CodeHashPath` had a write above the destruct tx, the whole account was treated as revived and every field read fell through to the normal version-map read.

That account-wide verdict is imprecise. An account revived by a plain value transfer gets only a `BalancePath` write — `GetOrNewStateObject` yields nonce 0 and empty code — yet the scan marks it revived for *all* paths, so a `NoncePath`/`CodeHashPath` read falls through and surfaces the **stale pre-SD nonce/codeHash** instead of the fresh account's zero value.

This PR replaces the scan with a **per-path** check: *this* field is revived iff the version map holds a write to *this* path above `destructTxIndex`. A field with no post-SD write correctly reads as zero; a field with one reads the revival value.

- `versionMap.Read` floors at `txIndex-1`, so a prior incarnation of the current tx can no longer masquerade as a later tx's revival — the explicit `revivalLimit` subtraction is removed.
- An in-flight revival (Estimate cell → `MVReadResultDependency`) is also treated as revived, so it falls through to the normal read and re-executes via `ErrDependency` rather than being swallowed as a zero — matching the old `LatestTxIndex` scan, which descended Estimate cells.

`net -6 lines`, no new behavior outside the SD branch.

## Why now

Found while auditing parallel-exec heuristics for [#21319](https://github.com/erigontech/erigon/issues/21319). The account-wide scan is the read-time correctness logic the gas-4800 `tipInsideBlock` heuristic depends on; making it per-path is a strict precision improvement and removes a latent stale-nonce read.

Note: the twin account-wide scan in `versionedStateReader.ReadAccountData` is intentionally left as-is — that reader returns a whole `*accounts.Account`, so its revival decision is genuinely account-granular.

## Test plan

Verified under both `ERIGON_EXEC3_PARALLEL=true` and serial:

- [x] `make lint` clean
- [x] `TestLegacyBlockchain` `bcEIP3675/tipInsideBlock` — parallel ×10, serial ×3
- [x] `TestDeleteRecreateAccount`, `TestSelfDestructReceive`, `TestEIP161AccountRemoval`, `TestCVE2020_26265`, `TestDeleteRecreateSlotsAcrossManyBlocks` — parallel ×5
- [x] `TestRecreateAndRewind` — parallel ×5
- [x] `execution/state` package — parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)