### PR TITLE
cmd/utils/app: skip .tmp files in state snapshot integrity check

### DIFF
--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -2147,6 +2147,9 @@ func checkStateSnapshotFiles(dirs datadir.Dirs, persistReceiptCache, commitmentH
 		if info.IsDir() {
 			return nil
 		}
+		if filepath.Ext(info.Name()) == ".tmp" {
+			return nil
+		}
 
 		res, _, ok := snaptype.ParseFileName(dirs.SnapDomain, info.Name())
 		if !ok {
@@ -2250,6 +2253,9 @@ func checkStateSnapshotFiles(dirs datadir.Dirs, persistReceiptCache, commitmentH
 			return err
 		}
 		if info.IsDir() {
+			return nil
+		}
+		if filepath.Ext(info.Name()) == ".tmp" {
 			return nil
 		}
 


### PR DESCRIPTION
## Summary
- An interrupted fusefilter build (`WriterSharded`/`Writer`) can leave `*.existence-sharded.tmp` (or other `*.tmp`) artifacts in `SnapDomain` / `SnapIdx`.
- `checkStateSnapshotFiles` walks every file and calls `snaptype.ParseFileName`, which doesn't recognize the `.tmp` suffix — the whole publishable check fails with `unparseable snapshot filename` until the temp is removed by hand.
- Skip `.tmp` entries in both walks so leftover temps don't break the check.

Example failure this fixes:
```
[EROR] [integrity] err="Publishable: unparseable snapshot filename: v2.0-commitment.187400-187520.kvi.4086944983.existence-sharded.tmp"
```

## Test plan
- [x] `make lint`
- [x] Re-run `erigon seg integrity` against a datadir containing a leftover `*.existence-sharded.tmp` and confirm it no longer errors