### PR TITLE
execution: reuse receipt blooms in post validation

### DIFF
--- a/execution/protocol/block_exec.go
+++ b/execution/protocol/block_exec.go
@@ -405,10 +405,16 @@ func BlockPostValidation(blockGasUsed, blobGasUsed uint64, checkReceipts, checkB
 			blobGasUsed, *h.BlobGasUsed, h.Number.Uint64(), h.Hash())
 	}
 
+	var lbloom types.Bloom
+	bloomFromReceipts := false
 	if checkReceipts && !alwaysSkipReceiptCheck {
 		for _, r := range receipts {
 			r.Bloom = types.CreateBloom(types.Receipts{r})
+			if checkBloom && len(r.Logs) != 0 {
+				lbloom.Or(r.Bloom)
+			}
 		}
+		bloomFromReceipts = checkBloom
 		receiptHash := types.DeriveSha(receipts)
 		if receiptHash != h.ReceiptHash {
 			if dbg.LogHashMismatchReason() {
@@ -426,7 +432,9 @@ func BlockPostValidation(blockGasUsed, blobGasUsed uint64, checkReceipts, checkB
 	// a pre-Byzantium block (e.g. hive bcInvalidHeaderTest/log1_wrongBloom)
 	// is silently accepted.
 	if checkBloom && !alwaysSkipReceiptCheck {
-		lbloom := types.CreateBloom(receipts)
+		if !bloomFromReceipts {
+			lbloom = types.CreateBloom(receipts)
+		}
 		if lbloom != h.Bloom {
 			return fmt.Errorf("invalid bloom (remote: %x  local: %x)", h.Bloom, lbloom)
 		}

--- a/execution/protocol/block_exec.go
+++ b/execution/protocol/block_exec.go
@@ -406,15 +406,14 @@ func BlockPostValidation(blockGasUsed, blobGasUsed uint64, checkReceipts, checkB
 	}
 
 	var lbloom types.Bloom
-	bloomFromReceipts := false
+	bloomFromReceipts := checkReceipts && checkBloom && !alwaysSkipReceiptCheck
 	if checkReceipts && !alwaysSkipReceiptCheck {
 		for _, r := range receipts {
 			r.Bloom = types.CreateBloom(types.Receipts{r})
-			if checkBloom && len(r.Logs) != 0 {
-				lbloom.Or(r.Bloom)
+			if bloomFromReceipts {
+				lbloom.Or(&r.Bloom)
 			}
 		}
-		bloomFromReceipts = checkBloom
 		receiptHash := types.DeriveSha(receipts)
 		if receiptHash != h.ReceiptHash {
 			if dbg.LogHashMismatchReason() {

--- a/execution/protocol/block_post_validation_test.go
+++ b/execution/protocol/block_post_validation_test.go
@@ -84,3 +84,69 @@ func TestBlockPostValidation_PreByzantiumBloomMismatch(t *testing.T) {
 		t.Fatalf("checkBloom=false should skip bloom validation, got: %v", err)
 	}
 }
+
+func TestBlockPostValidation_ReceiptBloomReuse(t *testing.T) {
+	t.Parallel()
+
+	cfg := &chain.Config{ChainID: uint256.NewInt(1)}
+	receipts := types.Receipts{
+		{
+			Status:            types.ReceiptStatusSuccessful,
+			CumulativeGasUsed: 21_000,
+			Logs: []*types.Log{
+				{
+					Address: common.HexToAddress("0x1111111111111111111111111111111111111111"),
+					Topics:  []common.Hash{common.HexToHash("0x01"), common.HexToHash("0x02")},
+				},
+				{
+					Address: common.HexToAddress("0x2222222222222222222222222222222222222222"),
+					Topics:  []common.Hash{common.HexToHash("0x03")},
+				},
+			},
+		},
+		{
+			Status:            types.ReceiptStatusSuccessful,
+			CumulativeGasUsed: 42_000,
+			Logs: []*types.Log{
+				{
+					Address: common.HexToAddress("0x3333333333333333333333333333333333333333"),
+					Topics:  []common.Hash{common.HexToHash("0x04")},
+				},
+			},
+		},
+	}
+	expectedBloom := types.CreateBloom(receipts)
+	if expectedBloom == (types.Bloom{}) {
+		t.Fatal("test setup: non-empty logs should produce a non-zero bloom")
+	}
+	for _, receipt := range receipts {
+		receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
+	}
+	receiptHash := types.DeriveSha(receipts)
+	for _, receipt := range receipts {
+		receipt.Bloom = types.Bloom{}
+	}
+
+	header := &types.Header{
+		Number:      *uint256.NewInt(4_370_000),
+		GasUsed:     42_000,
+		ReceiptHash: receiptHash,
+		Bloom:       expectedBloom,
+	}
+
+	const checkReceipts = true
+	const checkBloom = true
+
+	if err := BlockPostValidation(42_000, 0, checkReceipts, checkBloom, receipts, header, nil, cfg, log.New()); err != nil {
+		t.Fatalf("expected receipt+bloom validation to accept OR-merged bloom: %v", err)
+	}
+
+	header.Bloom = types.Bloom{}
+	err := BlockPostValidation(42_000, 0, checkReceipts, checkBloom, receipts, header, nil, cfg, log.New())
+	if err == nil {
+		t.Fatal("expected bloom-mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid bloom") {
+		t.Fatalf("expected \"invalid bloom\" error, got: %v", err)
+	}
+}

--- a/execution/protocol/block_post_validation_test.go
+++ b/execution/protocol/block_post_validation_test.go
@@ -90,7 +90,7 @@ func TestBlockPostValidation_ReceiptBloomReuse(t *testing.T) {
 
 	cfg := &chain.Config{ChainID: uint256.NewInt(1)}
 	receipts := types.Receipts{
-		&types.Receipt{
+		{
 			Status:            types.ReceiptStatusSuccessful,
 			CumulativeGasUsed: 21_000,
 			Logs: []*types.Log{
@@ -104,7 +104,7 @@ func TestBlockPostValidation_ReceiptBloomReuse(t *testing.T) {
 				},
 			},
 		},
-		&types.Receipt{
+		{
 			Status:            types.ReceiptStatusSuccessful,
 			CumulativeGasUsed: 42_000,
 			Logs: []*types.Log{

--- a/execution/protocol/block_post_validation_test.go
+++ b/execution/protocol/block_post_validation_test.go
@@ -90,7 +90,7 @@ func TestBlockPostValidation_ReceiptBloomReuse(t *testing.T) {
 
 	cfg := &chain.Config{ChainID: uint256.NewInt(1)}
 	receipts := types.Receipts{
-		{
+		&types.Receipt{
 			Status:            types.ReceiptStatusSuccessful,
 			CumulativeGasUsed: 21_000,
 			Logs: []*types.Log{
@@ -104,7 +104,7 @@ func TestBlockPostValidation_ReceiptBloomReuse(t *testing.T) {
 				},
 			},
 		},
-		{
+		&types.Receipt{
 			Status:            types.ReceiptStatusSuccessful,
 			CumulativeGasUsed: 42_000,
 			Logs: []*types.Log{

--- a/execution/types/bloom9.go
+++ b/execution/types/bloom9.go
@@ -108,10 +108,8 @@ func (b Bloom) Test(topic []byte) bool {
 
 // Or merges another bloom filter into b.
 func (b *Bloom) Or(other *Bloom) {
-	bb := unsafe.Slice((*uint64)(unsafe.Pointer(&b[0])), BloomByteLength/8)
-	ob := unsafe.Slice((*uint64)(unsafe.Pointer(&other[0])), BloomByteLength/8)
-	for i := 0; i < BloomByteLength/8; i++ {
-		bb[i] |= ob[i]
+	for i := 0; i < BloomByteLength; i += 8 {
+		binary.LittleEndian.PutUint64(b[i:], binary.LittleEndian.Uint64(b[i:])|binary.LittleEndian.Uint64(other[i:]))
 	}
 }
 

--- a/execution/types/bloom9.go
+++ b/execution/types/bloom9.go
@@ -107,9 +107,11 @@ func (b Bloom) Test(topic []byte) bool {
 }
 
 // Or merges another bloom filter into b.
-func (b *Bloom) Or(other Bloom) {
-	for i := range b {
-		b[i] |= other[i]
+func (b *Bloom) Or(other *Bloom) {
+	bb := unsafe.Slice((*uint64)(unsafe.Pointer(&b[0])), BloomByteLength/8)
+	ob := unsafe.Slice((*uint64)(unsafe.Pointer(&other[0])), BloomByteLength/8)
+	for i := 0; i < BloomByteLength/8; i++ {
+		bb[i] |= ob[i]
 	}
 }
 

--- a/execution/types/bloom9.go
+++ b/execution/types/bloom9.go
@@ -108,8 +108,10 @@ func (b Bloom) Test(topic []byte) bool {
 
 // Or merges another bloom filter into b.
 func (b *Bloom) Or(other *Bloom) {
-	for i := 0; i < BloomByteLength; i += 8 {
-		binary.LittleEndian.PutUint64(b[i:], binary.LittleEndian.Uint64(b[i:])|binary.LittleEndian.Uint64(other[i:]))
+	bb := unsafe.Slice((*uint64)(unsafe.Pointer(&b[0])), BloomByteLength/8)
+	ob := unsafe.Slice((*uint64)(unsafe.Pointer(&other[0])), BloomByteLength/8)
+	for i := 0; i < BloomByteLength/8; i++ {
+		bb[i] |= ob[i]
 	}
 }
 

--- a/execution/types/bloom9.go
+++ b/execution/types/bloom9.go
@@ -106,6 +106,13 @@ func (b Bloom) Test(topic []byte) bool {
 		v3 == v3&b[i3]
 }
 
+// Or merges another bloom filter into b.
+func (b *Bloom) Or(other Bloom) {
+	for i := range b {
+		b[i] |= other[i]
+	}
+}
+
 // MarshalText encodes b as a hex string with 0x prefix.
 func (b Bloom) MarshalText() ([]byte, error) {
 	return hexutil.Bytes(b[:]).MarshalText()

--- a/execution/types/bloom9_test.go
+++ b/execution/types/bloom9_test.go
@@ -83,6 +83,28 @@ func TestBloomExtensively(t *testing.T) {
 	}
 }
 
+func TestBloomOr(t *testing.T) {
+	t.Parallel()
+
+	var left Bloom
+	left.Add([]byte("left"))
+	var right Bloom
+	right.Add([]byte("right"))
+
+	merged := left
+	merged.Or(right)
+
+	if !merged.Test([]byte("left")) {
+		t.Fatal("expected merged bloom to contain left input")
+	}
+	if !merged.Test([]byte("right")) {
+		t.Fatal("expected merged bloom to contain right input")
+	}
+	if left.Test([]byte("right")) {
+		t.Fatal("Or should not mutate the source bloom")
+	}
+}
+
 func BenchmarkBloom9(b *testing.B) {
 	test := []byte("testestestest")
 	for b.Loop() {

--- a/execution/types/bloom9_test.go
+++ b/execution/types/bloom9_test.go
@@ -92,7 +92,7 @@ func TestBloomOr(t *testing.T) {
 	right.Add([]byte("right"))
 
 	merged := left
-	merged.Or(right)
+	merged.Or(&right)
 
 	if !merged.Test([]byte("left")) {
 		t.Fatal("expected merged bloom to contain left input")
@@ -102,6 +102,22 @@ func TestBloomOr(t *testing.T) {
 	}
 	if left.Test([]byte("right")) {
 		t.Fatal("Or should not mutate the source bloom")
+	}
+
+	r1 := &Receipt{Logs: []*Log{{
+		Address: common.HexToAddress("0x1111111111111111111111111111111111111111"),
+		Topics:  []common.Hash{common.HexToHash("0x01")},
+	}}}
+	r2 := &Receipt{Logs: []*Log{{
+		Address: common.HexToAddress("0x2222222222222222222222222222222222222222"),
+		Topics:  []common.Hash{common.HexToHash("0x02"), common.HexToHash("0x03")},
+	}}}
+	combined := CreateBloom(Receipts{r1, r2})
+	acc := CreateBloom(Receipts{r1})
+	r2Bloom := CreateBloom(Receipts{r2})
+	acc.Or(&r2Bloom)
+	if acc != combined {
+		t.Fatal("expected OR of receipt blooms to match CreateBloom over all receipts")
 	}
 }
 
@@ -159,6 +175,12 @@ func BenchmarkCreateBloom(b *testing.B) {
 	for i := 0; i < 200; i += 2 {
 		copy(rLarge[i:], rSmall)
 	}
+	var rLargeWithBloom = make(Receipts, len(rLarge))
+	for i, receipt := range rLarge {
+		cpy := *receipt
+		cpy.Bloom = CreateBloom(Receipts{&cpy})
+		rLargeWithBloom[i] = &cpy
+	}
 	b.Run("small", func(b *testing.B) {
 		b.ReportAllocs()
 		var bl Bloom
@@ -177,6 +199,22 @@ func BenchmarkCreateBloom(b *testing.B) {
 		var bl Bloom
 		for b.Loop() {
 			bl = CreateBloom(rLarge)
+		}
+		b.StopTimer()
+		var exp = common.HexToHash("c384c56ece49458a427c67b90fefe979ebf7104795be65dc398b280f24104949")
+		got := crypto.Keccak256Hash(bl.Bytes())
+		if got != exp {
+			b.Errorf("Got %x, exp %x", got, exp)
+		}
+	})
+	b.Run("large/or-receipt-blooms", func(b *testing.B) {
+		b.ReportAllocs()
+		var bl Bloom
+		for b.Loop() {
+			bl = Bloom{}
+			for _, receipt := range rLargeWithBloom {
+				bl.Or(&receipt.Bloom)
+			}
 		}
 		b.StopTimer()
 		var exp = common.HexToHash("c384c56ece49458a427c67b90fefe979ebf7104795be65dc398b280f24104949")


### PR DESCRIPTION
## Summary

- Reuse receipt-level blooms while `BlockPostValidation` recomputes receipts for the receipt root.
- Merge those blooms into the block bloom instead of hashing the same logs/topics again.
- Keep the log-based bloom calculation for bloom-only validation, including pre-Byzantium blocks.