### PR TITLE
.github: grant claude-code-action contents:write so it can push

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,7 +19,7 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write # Required so Claude can push commits to branches it creates
       pull-requests: read
       issues: read
       id-token: write


### PR DESCRIPTION
## Summary

- The Claude Code workflow currently grants the `GITHUB_TOKEN` only `contents: read`, so when `anthropics/claude-code-action` commits locally and tries to push the branch back, the push is rejected.
- Concrete symptom: in [#21325 follow-up comment](https://github.com/erigontech/erigon/pull/21325#issuecomment-4505715559) Claude finished its work, committed `4ba6d31` on `claude/pr-21325-20260521-0723`, but had to ask the user to push manually because the token lacked write access. The job log shows 8 permission denials and a 404 on `compare/main...claude/pr-21325-20260521-0723` because the branch never made it to the remote.
- Raising the token to `contents: write` unblocks the bot's `git push` for branches it creates while keeping all other scopes unchanged.

## Test plan

- [ ] After merge, trigger Claude on a comment that asks for a code edit and confirm the bot can push its branch without manual intervention.