### PR TITLE
[wip] cl/phase1/forkchoice: use post-pull-up values in compute_pulled_up_tip

### DIFF
--- a/cl/phase1/forkchoice/get_head.go
+++ b/cl/phase1/forkchoice/get_head.go
@@ -329,20 +329,12 @@ func (f *ForkChoiceStore) getFilterBlockTree(blockRoot common.Hash, blocks map[c
 	blockEpoch := f.computeEpochAtSlot(header.Slot)
 	var votingSource solid.Checkpoint
 	if currentEpoch > blockEpoch {
-		var has bool
 		votingSource, has = f.getUnrealizedJustification(blockRoot)
-		if !has {
-			votingSource, has = f.forkGraph.GetCurrentJustifiedCheckpoint(blockRoot)
-			if !has {
-				return false
-			}
-		}
 	} else {
-		var has bool
 		votingSource, has = f.forkGraph.GetCurrentJustifiedCheckpoint(blockRoot)
-		if !has {
-			return false
-		}
+	}
+	if !has {
+		return false
 	}
 
 	genesisEpoch := f.beaconCfg.GenesisEpoch

--- a/cl/phase1/forkchoice/get_head.go
+++ b/cl/phase1/forkchoice/get_head.go
@@ -289,14 +289,18 @@ func (f *ForkChoiceStore) getHead(auxilliaryState *state.CachingBeaconState) (co
 // getFilteredBlockTree filters out dumb blocks.
 func (f *ForkChoiceStore) getFilteredBlockTree(base common.Hash) map[common.Hash]*cltypes.BeaconBlockHeader {
 	blocks := make(map[common.Hash]*cltypes.BeaconBlockHeader)
-	f.getFilterBlockTree(base, blocks)
+	// Snapshot the store epoch once for the whole walk: OnTick updates f.time
+	// without holding f.mu, so calling f.Slot() per-leaf can mix epochs across
+	// leaves around a slot boundary.
+	currentEpoch := f.computeEpochAtSlot(f.Slot())
+	f.getFilterBlockTree(base, blocks, currentEpoch)
 	return blocks
 }
 
 // getFilterBlockTree recursively traverses the block tree to identify viable blocks.
 // It takes a block hash and a map of viable blocks as input parameters, and returns a boolean value indicating
 // whether the current block is viable.
-func (f *ForkChoiceStore) getFilterBlockTree(blockRoot common.Hash, blocks map[common.Hash]*cltypes.BeaconBlockHeader) bool {
+func (f *ForkChoiceStore) getFilterBlockTree(blockRoot common.Hash, blocks map[common.Hash]*cltypes.BeaconBlockHeader, currentEpoch uint64) bool {
 	header, has := f.forkGraph.GetHeader(blockRoot)
 	if !has {
 		return false
@@ -308,7 +312,7 @@ func (f *ForkChoiceStore) getFilterBlockTree(blockRoot common.Hash, blocks map[c
 	if len(children) > 0 {
 		isAnyViable := false
 		for _, child := range children {
-			if f.getFilterBlockTree(child, blocks) {
+			if f.getFilterBlockTree(child, blocks, currentEpoch) {
 				isAnyViable = true
 			}
 		}
@@ -317,18 +321,24 @@ func (f *ForkChoiceStore) getFilterBlockTree(blockRoot common.Hash, blocks map[c
 		}
 		return isAnyViable
 	}
-	// Leaf node — check viability per spec filter_block_tree
-	//
-	// Justified check (spec): voting_source.epoch >= store.justified_checkpoint.epoch
-	// Note: the spec uses >= (not ==) so blocks with higher unrealized justification are viable.
-	// Also implements is_previous_epoch_justified fallback.
-	//
-	// Finalized check (spec): store.finalized_checkpoint.root == get_ancestor(store, block_root, finalized_slot)
-	// Note: checks that the block descends from the finalized block, not checkpoint equality.
+	// Leaf node — viability per spec filter_block_tree.
 
-	// Get voting source (unrealized justification for this block)
-	votingSource, has := f.getUnrealizedJustification(blockRoot)
-	if !has {
+	// Spec get_voting_source: pick unrealized only for prior-epoch blocks
+	// (pull-up justification view); current/future-epoch blocks use the
+	// block's realized state checkpoint.
+	blockEpoch := f.computeEpochAtSlot(header.Slot)
+	var votingSource solid.Checkpoint
+	if currentEpoch > blockEpoch {
+		var has bool
+		votingSource, has = f.getUnrealizedJustification(blockRoot)
+		if !has {
+			votingSource, has = f.forkGraph.GetCurrentJustifiedCheckpoint(blockRoot)
+			if !has {
+				return false
+			}
+		}
+	} else {
+		var has bool
 		votingSource, has = f.forkGraph.GetCurrentJustifiedCheckpoint(blockRoot)
 		if !has {
 			return false
@@ -337,32 +347,21 @@ func (f *ForkChoiceStore) getFilterBlockTree(blockRoot common.Hash, blocks map[c
 
 	genesisEpoch := f.beaconCfg.GenesisEpoch
 
-	// Spec: correct_justified = store.justified_checkpoint.epoch == GENESIS_EPOCH
-	//       or voting_source.epoch >= store.justified_checkpoint.epoch
+	// Spec correct_justified:
+	//   store.justified_checkpoint.epoch == GENESIS_EPOCH
+	//   || voting_source.epoch == store.justified_checkpoint.epoch
+	//   || voting_source.epoch + 2 >= current_epoch
 	justifiedOk := justifiedCheckpoint.Epoch == genesisEpoch ||
-		votingSource.Epoch >= justifiedCheckpoint.Epoch
+		votingSource.Epoch == justifiedCheckpoint.Epoch ||
+		votingSource.Epoch+2 >= currentEpoch
 
-	// is_previous_epoch_justified fallback:
-	// If not correct_justified and previous epoch is justified, check that
-	// the voting source is not more than two epochs ago.
-	if !justifiedOk {
-		currentEpoch := f.computeEpochAtSlot(f.Slot())
-		previousEpoch := currentEpoch - 1
-		if previousEpoch > currentEpoch { // underflow guard
-			previousEpoch = 0
-		}
-		if justifiedCheckpoint.Epoch == previousEpoch {
-			justifiedOk = votingSource.Epoch+2 >= currentEpoch
-		}
-	}
-
-	// Spec: correct_finalized = store.finalized_checkpoint.epoch == GENESIS_EPOCH
-	//       or store.finalized_checkpoint.root == get_ancestor(store, block_root, finalized_slot)
+	// Spec correct_finalized:
+	//   store.finalized_checkpoint.epoch == GENESIS_EPOCH
+	//   || store.finalized_checkpoint.root == get_checkpoint_block(block_root, finalized.epoch)
 	finalizedOk := finalizedCheckpoint.Epoch == genesisEpoch
 	if !finalizedOk {
 		finalizedSlot := f.computeStartSlotAtEpoch(finalizedCheckpoint.Epoch)
-		ancestor := f.Ancestor(blockRoot, finalizedSlot)
-		finalizedOk = finalizedCheckpoint.Root == ancestor.Root
+		finalizedOk = finalizedCheckpoint.Root == f.Ancestor(blockRoot, finalizedSlot).Root
 	}
 
 	if justifiedOk && finalizedOk {

--- a/cl/phase1/forkchoice/on_block.go
+++ b/cl/phase1/forkchoice/on_block.go
@@ -412,24 +412,33 @@ func (f *ForkChoiceStore) OnBlock(ctx context.Context, block *cltypes.SignedBeac
 	)
 	f.operationsPool.NotifyBlock(block.Block)
 
-	// Eagerly compute unrealized justification and finality
+	// Eagerly compute unrealized justification and finality (spec: compute_pulled_up_tip)
 	if err := statechange.ProcessJustificationBitsAndFinality(lastProcessedState, nil); err != nil {
 		return err
 	}
+	// Capture post-pull-up values BEFORE restoring lastProcessedState so the
+	// prior-epoch updateCheckpoints below can use them per spec
+	// (compute_pulled_up_tip uses state.current_justified_checkpoint AFTER
+	// process_justification_and_finalization, not before).
+	postPullupJustified := lastProcessedState.CurrentJustifiedCheckpoint()
+	postPullupFinalized := lastProcessedState.FinalizedCheckpoint()
 	// Store per-block unrealized checkpoints (spec: store.unrealized_justifications[block_root])
-	f.unrealizedJustifications.Store(common.Hash(blockRoot), lastProcessedState.CurrentJustifiedCheckpoint())
-	f.unrealizedFinalizations.Store(common.Hash(blockRoot), lastProcessedState.FinalizedCheckpoint())
-	f.updateUnrealizedCheckpoints(lastProcessedState.CurrentJustifiedCheckpoint(), lastProcessedState.FinalizedCheckpoint())
+	f.unrealizedJustifications.Store(common.Hash(blockRoot), postPullupJustified)
+	f.unrealizedFinalizations.Store(common.Hash(blockRoot), postPullupFinalized)
+	f.updateUnrealizedCheckpoints(postPullupJustified, postPullupFinalized)
 	// Set the changed value pre-simulation
 	lastProcessedState.SetPreviousJustifiedCheckpoint(previousJustifiedCheckpoint)
 	lastProcessedState.SetCurrentJustifiedCheckpoint(currentJustifiedCheckpoint)
 	lastProcessedState.SetFinalizedCheckpoint(stateFinalized)
 	lastProcessedState.SetJustificationBits(justificationBits)
 
-	// If the block is from a prior epoch, apply the realized values
+	// Spec compute_pulled_up_tip: if the block is from a prior epoch, apply the
+	// post-pull-up checkpoints to the store. Previously this used the restored
+	// pre-pull-up values, which meant store.justified/finalized lagged what
+	// the spec would have for late-arriving prior-epoch blocks.
 	currentEpoch := f.computeEpochAtSlot(f.Slot())
 	if blockEpoch < currentEpoch {
-		f.updateCheckpoints(lastProcessedState.CurrentJustifiedCheckpoint(), lastProcessedState.FinalizedCheckpoint())
+		f.updateCheckpoints(postPullupJustified, postPullupFinalized)
 	}
 	f.emitters.State().SendBlock(&beaconevents.BlockData{
 		Slot:                block.Block.Slot,


### PR DESCRIPTION
Stacked on top of #21327. Experimental fix to see if kurtosis-caplin-minimal goes green when we ALSO fix the `compute_pulled_up_tip` deviation alongside the spec-faithful `filter_block_tree`.

## Deviation

`on_block.go` previously used PRE-pull-up values when applying the conditional prior-epoch `updateCheckpoints` call. Spec `compute_pulled_up_tip` uses POST-pull-up values:

```python
def compute_pulled_up_tip(store, block_root):
    state = store.block_states[block_root].copy()
    process_justification_and_finalization(state)  # ← state is now POST-pull-up
    store.unrealized_justifications[block_root] = state.current_justified_checkpoint
    update_unrealized_checkpoints(store, state.current_justified_checkpoint, state.finalized_checkpoint)
    block_epoch = compute_epoch_at_slot(store.blocks[block_root].slot)
    current_epoch = get_current_store_epoch(store)
    if block_epoch < current_epoch:
        update_checkpoints(store, state.current_justified_checkpoint, state.finalized_checkpoint)
        #                       ↑ POST-pull-up values
```

Caplin's implementation in-place mutated lastProcessedState, restored it pre-pull-up before the conditional, and then passed the restored (pre-pull-up) values to `updateCheckpoints`. This made `store.justified` / `store.finalized` lag what spec would have for late-arriving prior-epoch blocks.

## Fix

Capture post-pull-up values into local vars before restoring `lastProcessedState`; use those locals for the conditional prior-epoch `updateCheckpoints` call.

## Why combined with #21327

The spec-faithful filter in #21327 expects `store.justified` to advance per spec. Without this fix, prior-epoch block imports leave `store.justified` one epoch behind, which the strict filter may then reject. CI on #21327 alone is failing kurtosis-caplin-minimal — this PR tests whether the combined fix recovers.

## Verification

Local build + lint clean.

CI signal: kurtosis-caplin-minimal must go green. If it does, fold this commit into #21327 (or land as a follow-up). If it doesn't, the kurtosis regression has another root cause and #21327 needs to revert to main's lenient filter (see analysis in #21327 thread).