### PR TITLE
[r3.4] db/version: bump version to 3.4.2

### DIFF
--- a/db/version/app.go
+++ b/db/version/app.go
@@ -31,7 +31,7 @@ var (
 const (
 	Major                    = 3             // Major version component of the current release
 	Minor                    = 4             // Minor version component of the current release
-	Micro                    = 1             // Patch version component of the current release
+	Micro                    = 2             // Patch version component of the current release
 	Modifier                 = ""            // Modifier component of the current release
 	DefaultSnapshotGitBranch = "release/3.4" // Branch of erigontech/erigon-snapshot to use in OtterSync.
 	VersionKeyCreated        = "ErigonVersionCreated"


### PR DESCRIPTION
Bumps `db/version.Micro` from 1 to 2 ahead of the v3.4.2 release.

Release notes draft: #21337

🤖 Generated with [Claude Code](https://claude.com/claude-code)