### PR TITLE
cl/phase1/forkchoice: use post-pull-up values for prior-epoch updateCheckpoints

### DIFF
--- a/cl/phase1/forkchoice/on_block.go
+++ b/cl/phase1/forkchoice/on_block.go
@@ -302,25 +302,34 @@ func (f *ForkChoiceStore) OnBlock(ctx context.Context, block *cltypes.SignedBeac
 	)
 	f.operationsPool.NotifyBlock(block.Block)
 
-	// Eagerly compute unrealized justification and finality
+	// Eagerly compute unrealized justification and finality (spec: compute_pulled_up_tip)
 	if err := statechange.ProcessJustificationBitsAndFinality(lastProcessedState, nil); err != nil {
 		return err
 	}
+	// Capture post-pull-up values BEFORE restoring lastProcessedState so the
+	// prior-epoch updateCheckpoints below can use them per spec
+	// (compute_pulled_up_tip uses state.current_justified_checkpoint AFTER
+	// process_justification_and_finalization, not before).
+	postPullupJustified := lastProcessedState.CurrentJustifiedCheckpoint()
+	postPullupFinalized := lastProcessedState.FinalizedCheckpoint()
 	// Store per-block unrealized checkpoints (spec: store.unrealized_justifications[block_root])
-	f.unrealizedJustifications.Store(common.Hash(blockRoot), lastProcessedState.CurrentJustifiedCheckpoint())
-	f.unrealizedFinalizations.Store(common.Hash(blockRoot), lastProcessedState.FinalizedCheckpoint())
-	f.updateUnrealizedCheckpoints(lastProcessedState.CurrentJustifiedCheckpoint(), lastProcessedState.FinalizedCheckpoint())
+	f.unrealizedJustifications.Store(common.Hash(blockRoot), postPullupJustified)
+	f.unrealizedFinalizations.Store(common.Hash(blockRoot), postPullupFinalized)
+	f.updateUnrealizedCheckpoints(postPullupJustified, postPullupFinalized)
 	// Set the changed value pre-simulation
 	lastProcessedState.SetPreviousJustifiedCheckpoint(previousJustifiedCheckpoint)
 	lastProcessedState.SetCurrentJustifiedCheckpoint(currentJustifiedCheckpoint)
 	lastProcessedState.SetFinalizedCheckpoint(stateFinalized)
 	lastProcessedState.SetJustificationBits(justificationBits)
 
-	// If the block is from a prior epoch, apply the realized values
+	// Spec compute_pulled_up_tip: if the block is from a prior epoch, apply the
+	// post-pull-up checkpoints to the store. Previously this used the restored
+	// pre-pull-up values, which meant store.justified/finalized lagged what
+	// the spec would have for late-arriving prior-epoch blocks.
 	blockEpoch := f.computeEpochAtSlot(block.Block.Slot)
 	currentEpoch := f.computeEpochAtSlot(f.Slot())
 	if blockEpoch < currentEpoch {
-		f.updateCheckpoints(lastProcessedState.CurrentJustifiedCheckpoint(), lastProcessedState.FinalizedCheckpoint())
+		f.updateCheckpoints(postPullupJustified, postPullupFinalized)
 	}
 	f.emitters.State().SendBlock(&beaconevents.BlockData{
 		Slot:                block.Block.Slot,


### PR DESCRIPTION
## Summary

Follow-up to #21310. Fixes a remaining spec deviation in `OnBlock`'s prior-epoch `updateCheckpoints` call: per [`compute_pulled_up_tip`](https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/fork-choice.md), the prior-epoch update should use the post-pull-up checkpoints (after \`process_justification_and_finalization\` runs), not the realized values that were restored onto the state for replay purposes.

## The bug

In \`cl/phase1/forkchoice/on_block.go\`:

\`\`\`go
ProcessJustificationBitsAndFinality(lastProcessedState, nil)   // pull-up runs here
unrealizedJustifications.Store(.., lastProcessedState.CurrentJustifiedCheckpoint())
...
// restore pre-pull-up values onto lastProcessedState (for replay/simulation)
lastProcessedState.SetCurrentJustifiedCheckpoint(currentJustifiedCheckpoint)
lastProcessedState.SetFinalizedCheckpoint(stateFinalized)
...
if blockEpoch < currentEpoch {
    // BUG: now reads the just-restored pre-pull-up values, not the pulled-up ones
    updateCheckpoints(lastProcessedState.CurrentJustifiedCheckpoint(), lastProcessedState.FinalizedCheckpoint())
}
\`\`\`

Effect: \`store.justified_checkpoint\` / \`store.finalized_checkpoint\` get updated with realized values rather than the post-pull-up values for late-arriving prior-epoch blocks. The store ends up one epoch boundary behind what the spec would have.

## Fix

Capture the post-pull-up values into local variables right after \`ProcessJustificationBitsAndFinality\` and use them consistently in:

1. \`unrealizedJustifications.Store\` / \`unrealizedFinalizations.Store\` (already pull-up, no behavior change)
2. \`updateUnrealizedCheckpoints\` (already pull-up, no behavior change)
3. \`updateCheckpoints\` in the \`blockEpoch < currentEpoch\` branch (**this is the actual fix**)

## Test plan

- [x] Build clean
- [x] Runtime: validated alongside #21310 on bloatnet at chain tip — 23+ FCUs all at \`lagSlots=0\`, no large unwinds, no filter rejects after this change is applied
- [ ] CI green

Refs: #21301, #21310

## Already validated on main

This same change (commit `3cfb67d6ef`) is included in #21327 (`cp/21310-to-main` → `main`), where **all CI checks are passing**: lint, unit tests, race tests, integration tests, kurtosis, mainnet-rpc-integ, hive, reproducible build across linux/mac/windows. See https://github.com/erigontech/erigon/pull/21327.

So this PR is the same patch already exercised by CI on the main-branch flavor of #21310 — applying it to `performance` for parity.
