### PR TITLE
fusefilter: cleanup NewReader mmap/file on parse failure

### DIFF
--- a/db/datastruct/fusefilter/fusefilter_reader.go
+++ b/db/datastruct/fusefilter/fusefilter_reader.go
@@ -67,6 +67,8 @@ func NewReader(filePath string) (*Reader, error) {
 	_, fileName := filepath.Split(filePath)
 	r, _, err := NewReaderOnBytes(content, fileName)
 	if err != nil {
+		_ = m.Unmap() //nolint
+		_ = f.Close() //nolint
 		return nil, err
 	}
 	r.f = f


### PR DESCRIPTION
NewReader now unmaps and closes the file when NewReaderOnBytes fails, preventing deterministic mmap and file-descriptor leaks on corrupt filter inputs.