### PR TITLE
[r3.4] .github/workflows: fetch full history in source-of-changes to avoid shallow-deepen race

### DIFF
--- a/.github/workflows/test-all-erigon-race.yml
+++ b/.github/workflows/test-all-erigon-race.yml
@@ -23,6 +23,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          # See test-all-erigon.yml for the rationale: full history avoids the
+          # shallow-deepen race in dorny/paths-filter that was failing this
+          # workflow's source-of-changes preflight on pushes to release/3.4.
+          fetch-depth: 0
 
       - name: Check for changes within out-of-scope dirs or files
         id: filter

--- a/.github/workflows/test-all-erigon.yml
+++ b/.github/workflows/test-all-erigon.yml
@@ -30,6 +30,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          # dorny/paths-filter needs the merge-base between this ref and the
+          # default branch to diff the push. With the action's default shallow
+          # clone, it has to call `git fetch --deepen=...`, which intermittently
+          # fails on busy runners with `fatal: shallow file has changed since
+          # we read it` (exit 128) — sinking the whole "All tests" workflow
+          # because the matrix `needs: source-of-changes`. Fetching full history
+          # here avoids the deepen path entirely.
+          fetch-depth: 0
 
       - name: Check for changes within out-of-scope dirs or files
         id: filter


### PR DESCRIPTION
## Summary

The `source-of-changes` preflight in `test-all-erigon.yml` and `test-all-erigon-race.yml` has been failing on pushes to `release/3.4`, taking the whole **All tests** workflow with it because the test matrix declares `needs: source-of-changes`. The failure is in `dorny/paths-filter@v3`: it diffs against `main` via merge-base, the default shallow clone can't reach the merge-base, so the action calls `git fetch --deepen=200`, which races on busy runners:

```
fatal: shallow file has changed since we read it
##[error]The process '/usr/bin/git' failed with exit code 128
```

Setting `fetch-depth: 0` on the preflight's `actions/checkout` gives paths-filter the full history, so it never deepens and the race is impossible.

Recent failures on `release/3.4` HEAD `5743f3c3e7`:
- All tests: https://github.com/erigontech/erigon/actions/runs/26223675711
- All tests (with -race): https://github.com/erigontech/erigon/actions/runs/26223675615

## r3.4-specific adaptations

Not a cherry-pick — `main` no longer uses `dorny/paths-filter` for this gating (it was replaced by the `changes` job in `ci-gate.yml`, which uses `gh api .../pulls/.../files` and doesn't touch merge-bases), so this bug exists only on `release/3.4`.

## Test plan

- [ ] On push to this branch, observe the `source-of-changes` job pass in both `All tests` and `All tests (with -race)`.
- [ ] Confirm the dependent `tests-*` matrix jobs actually run (not `skipped`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)