### PR TITLE
[r3.4] .github/workflows: retry test-all after go clean -cache

### DIFF
--- a/.github/workflows/test-all-erigon.yml
+++ b/.github/workflows/test-all-erigon.yml
@@ -108,7 +108,18 @@ jobs:
         env:
           SKIP_FLAKY_TESTS: 'true'
         if: needs.source-of-changes.outputs.changed_files != 'true'
-        run: GOGC=80 make test-all
+        run: |
+          if ! GOGC=80 make test-all; then
+            # Retry after clearing the Go build cache. Low disk space can cause
+            # severe, non-obvious build/test failures that don't surface a clear
+            # "no space left" message (e.g. linker mmap failure, SIGBUS in cgo
+            # mdbx_env_open). Tuning a cache size limit is too fragile; Go's own
+            # cache trimmer handles the common case, and this clobber handles
+            # the rest.
+            echo "::notice::make test-all failed; clearing Go build cache and retrying"
+            time go clean -cache
+            GOGC=80 make test-all
+          fi
 
       - name: SonarCloud scan in case OS Linux and changed_files is not true
         if: runner.os == 'Linux' && needs.source-of-changes.outputs.changed_files != 'true'


### PR DESCRIPTION
## Summary

Backport of the retry-on-failure pattern from `main`'s `test-all-erigon.yml` to the Linux/macOS leg of the `release/3.4` "All tests" workflow.

GitHub-hosted Linux runners periodically run out of disk during `make test-all` while compiling the test binaries + accumulating the Go build cache. The resulting failures are non-obvious — most recently in [run 26231133455](https://github.com/erigontech/erigon/actions/runs/26231133455/job/77191681721) the symptom surfaced as a linker `mapping output file failed: no space left on device` for `polygon/tests.test` and, in parallel, a `SIGBUS` inside cgo `mdbx_env_open` (mmap-backed MDBX page that the kernel could no longer extend). The runner process itself then died with `System.IO.IOException: No space left on device` while flushing its diagnostic log, which is what bubbles up in the job annotations.

On retry, `go clean -cache` typically frees several GB and the second `make test-all` run completes. `main` already carries this exact retry block with the same rationale; this PR copies it to `release/3.4`.

## r3.4-specific adaptations

- `main` calls into the `./.github/actions/setup-erigon` composite action and also enables `ramdisk: true` there; `release/3.4` doesn't use that composite, so only the retry wrapper around `make test-all` is ported. Adding `ramdisk` would require porting the action itself.
- The Windows leg already has a self-hosted post-run cleanup, so it's left unchanged.

## Test plan

- [ ] Re-run "All tests" workflow against `release/3.4` after merge.
- [ ] Watch for the `::notice::make test-all failed; clearing Go build cache and retrying` line on any disk-space flake, and confirm the second attempt succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)