### PR TITLE
node: replace sort.Slice with slices.Sort for natural ordering

### DIFF
--- a/node/components/storage/snapshot/inventory.go
+++ b/node/components/storage/snapshot/inventory.go
@@ -17,7 +17,7 @@
 package snapshot
 
 import (
-	"sort"
+	"slices"
 	"sync"
 )
 
@@ -250,7 +250,7 @@ func (inv *Inventory) Domains() []Domain {
 			domains = append(domains, d)
 		}
 	}
-	sort.Slice(domains, func(i, j int) bool { return domains[i] < domains[j] })
+	slices.Sort(domains)
 	return domains
 }
 


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices#Sort) added in the go1.21 standard library, which can make the code more concise and easy to read.

Inspired by https://github.com/erigontech/erigon/pull/18775 