### PR TITLE
execution/execmodule: add FCU notification dispatch metrics

### DIFF
--- a/execution/execmodule/forkchoice.go
+++ b/execution/execmodule/forkchoice.go
@@ -646,7 +646,10 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 		// released and flush/commit/prune can proceed without blocking the
 		// next FCU.
 		e.logger.Debug("[updateForkChoice] dispatching notifications", "head", blockHash, "bgCommit", e.fcuBackgroundCommit)
-		if err := e.dispatchNotificationsFromOverlay(currentContext, finishProgressBefore); err != nil {
+		notificationDispatchStart := time.Now()
+		err = e.dispatchNotificationsFromOverlay(currentContext, finishProgressBefore)
+		UpdateForkChoiceNotificationDispatchDuration(notificationDispatchStart)
+		if err != nil {
 			return sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, fmt.Errorf("fcu: dispatch notifications: %w", err), stateFlushingInParallel)
 		}
 
@@ -781,7 +784,9 @@ func (e *ExecModule) dispatchNotificationsFromOverlay(sd *execctx.SharedDomains,
 	// the BlockListener (overlay-aware shutter) sees the overlay as active
 	// before any StateChangeBatch arrives, so it can buffer events properly.
 	e.logger.Debug("[dispatchNotifications] publishing SD")
+	publishOverlayStart := time.Now()
 	dispatcher.PublishOverlay(sd)
+	UpdateForkChoiceNotificationPublishOverlayDuration(publishOverlayStart)
 
 	e.logger.Debug("[dispatchNotifications] dispatching", "finishBefore", finishProgressBefore, "finishAfter", finishProgressAfter)
 	if err := dispatcher.Dispatch(

--- a/execution/execmodule/metrics.go
+++ b/execution/execmodule/metrics.go
@@ -27,6 +27,12 @@ var (
 	updateForkChoiceDuration      = metrics.NewSummary(`update_fork_choice{type="execution_duration"}`)
 	updateForkChoiceDepth         = metrics.NewSummary(`update_fork_choice{type="fork_depth"}`)
 	updateForkChoicePruneDuration = metrics.NewSummary(`update_fork_choice{type="prune_duration"}`)
+
+	forkChoiceNotificationDispatchDuration       = metrics.NewSummary(`update_fork_choice_notification_dispatch_duration_seconds{stage="total"}`)
+	forkChoiceNotificationPublishOverlayDuration = metrics.NewSummary(`update_fork_choice_notification_dispatch_duration_seconds{stage="publish_overlay"}`)
+	forkChoiceNotificationReceiptsDuration       = metrics.NewSummary(`update_fork_choice_notification_dispatch_duration_seconds{stage="receipts"}`)
+	forkChoiceNotificationLogsDuration           = metrics.NewSummary(`update_fork_choice_notification_dispatch_duration_seconds{stage="logs"}`)
+	forkChoiceNotificationStateChangesDuration   = metrics.NewSummary(`update_fork_choice_notification_dispatch_duration_seconds{stage="state_changes"}`)
 )
 
 func UpdateForkChoiceArrivalDelay(blockTime uint64) {
@@ -44,4 +50,24 @@ func UpdateForkChoiceDepth(depth uint64) {
 
 func UpdateForkChoicePruneDuration(start time.Time) {
 	updateForkChoicePruneDuration.ObserveDuration(start)
+}
+
+func UpdateForkChoiceNotificationDispatchDuration(start time.Time) {
+	forkChoiceNotificationDispatchDuration.ObserveDuration(start)
+}
+
+func UpdateForkChoiceNotificationPublishOverlayDuration(start time.Time) {
+	forkChoiceNotificationPublishOverlayDuration.ObserveDuration(start)
+}
+
+func UpdateForkChoiceNotificationReceiptsDuration(start time.Time) {
+	forkChoiceNotificationReceiptsDuration.ObserveDuration(start)
+}
+
+func UpdateForkChoiceNotificationLogsDuration(start time.Time) {
+	forkChoiceNotificationLogsDuration.ObserveDuration(start)
+}
+
+func UpdateForkChoiceNotificationStateChangesDuration(start time.Time) {
+	forkChoiceNotificationStateChangesDuration.ObserveDuration(start)
 }

--- a/execution/execmodule/notification_dispatcher.go
+++ b/execution/execmodule/notification_dispatcher.go
@@ -18,6 +18,7 @@ package execmodule
 
 import (
 	"context"
+	"time"
 
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
@@ -117,13 +118,21 @@ func (d *Dispatcher) Dispatch(
 			return err
 		}
 		if recentReceipts != nil {
+			receiptsStart := time.Now()
 			recentReceipts.NotifyReceipts(d.events, notifyFrom, notifyTo, isUnwind)
+			UpdateForkChoiceNotificationReceiptsDuration(receiptsStart)
+
+			logsStart := time.Now()
 			recentReceipts.NotifyLogs(d.events, notifyFrom, notifyTo, isUnwind)
+			UpdateForkChoiceNotificationLogsDuration(logsStart)
 		}
 	}
 
+	stateChangesStart := time.Now()
 	currentHeader := rawdb.ReadCurrentHeader(tx)
 	if accumulator != nil && currentHeader != nil {
+		defer UpdateForkChoiceNotificationStateChangesDuration(stateChangesStart)
+
 		if changes := accumulator.Changes(); len(changes) == 0 || changes[len(changes)-1].BlockHeight < currentHeader.Number.Uint64() {
 			accumulator.StartChange(currentHeader, nil, false)
 		}

--- a/execution/stagedsync/metrics.go
+++ b/execution/stagedsync/metrics.go
@@ -1,11 +1,26 @@
 package stagedsync
 
 import (
+	"time"
+
 	"github.com/erigontech/erigon/diagnostics/metrics"
 	"github.com/erigontech/erigon/execution/stagedsync/stages"
 )
 
 var initialCycleDurationSecs = metrics.GetOrCreateGauge("initial_cycle_duration_secs")
+
+var (
+	notificationDispatchHeadersScanDuration = metrics.NewSummary(`update_fork_choice_notification_dispatch_duration_seconds{stage="headers_scan"}`)
+	notificationDispatchHeadersSendDuration = metrics.NewSummary(`update_fork_choice_notification_dispatch_duration_seconds{stage="headers_send"}`)
+)
+
+func updateNotificationDispatchHeadersScanDuration(start time.Time) {
+	notificationDispatchHeadersScanDuration.ObserveDuration(start)
+}
+
+func updateNotificationDispatchHeadersSendDuration(start time.Time) {
+	notificationDispatchHeadersSendDuration.ObserveDuration(start)
+}
 
 type metricsCache struct {
 	stageRunDurationSummaries    map[stages.SyncStage]metrics.Summary

--- a/execution/stagedsync/stage_finish.go
+++ b/execution/stagedsync/stage_finish.go
@@ -86,6 +86,7 @@ func NotifyNewHeaders(ctx context.Context, notifyFrom, notifyTo uint64, notifier
 	}
 	// Notify all headers we have (either canonical or not) in a maximum range span of 1024
 	var headersRlp [][]byte
+	headersScanStart := time.Now()
 	if err := tx.ForEach(kv.HeaderCanonical, hexutil.EncodeTs(notifyFrom), func(k, hash []byte) (err error) {
 		if len(hash) == 0 {
 			return nil
@@ -100,12 +101,16 @@ func NotifyNewHeaders(ctx context.Context, notifyFrom, notifyTo uint64, notifier
 		}
 		return common.Stopped(ctx.Done())
 	}); err != nil {
+		updateNotificationDispatchHeadersScanDuration(headersScanStart)
 		logger.Error("RPC Daemon notification failed", "err", err)
 		return err
 	}
+	updateNotificationDispatchHeadersScanDuration(headersScanStart)
 
 	if len(headersRlp) > 0 {
+		headersSendStart := time.Now()
 		notifier.OnNewHeader(headersRlp)
+		updateNotificationDispatchHeadersSendDuration(headersSendStart)
 		logger.Debug("RPC Daemon notified of new headers", "from", notifyFrom-1, "to", notifyTo, "amount", len(headersRlp))
 	}
 	return nil


### PR DESCRIPTION
## Summary

Add segmented metrics for the FCU notification dispatch path, which runs inline before the semaphore is released. The new `update_fork_choice_notification_dispatch_duration_seconds` summary records total dispatch time plus publish-overlay, header scan/send, receipt, log, and state-change phases.