### PR TITLE
db: use named-return defer for constructor cleanup on error

### DIFF
--- a/cl/persistence/blob_storage/data_column_db.go
+++ b/cl/persistence/blob_storage/data_column_db.go
@@ -98,19 +98,19 @@ func (s *dataColumnStorageImpl) WriteColumnSidecars(ctx context.Context, blockRo
 	if err != nil {
 		return err
 	}
+	defer func() {
+		fh.Close()
+		if err != nil {
+			s.fs.Remove(filepath)
+		}
+	}()
 	// snappy of | length | ssz data |
-	if err := ssz_snappy.EncodeAndWrite(fh, columnData); err != nil {
-		fh.Close()
-		s.fs.Remove(filepath)
+	if err = ssz_snappy.EncodeAndWrite(fh, columnData); err != nil {
 		return err
 	}
-	if err := fh.Sync(); err != nil {
-		fh.Close()
-		s.fs.Remove(filepath)
+	if err = fh.Sync(); err != nil {
 		return err
 	}
-
-	fh.Close()
 	s.emitters.Operation().SendDataColumnSidecar(beaconevents.NewDataColumnSidecarData(columnData))
 	log.Trace("wrote data column sidecar", "slot", slot, "block_root", blockRoot.String(), "column_index", columnIndex)
 	return nil

--- a/db/datastruct/btindex/btree_index.go
+++ b/db/datastruct/btindex/btree_index.go
@@ -365,15 +365,19 @@ func CreateBtreeIndexWithDecompressor(indexPath string, M uint64, decompressor *
 
 // OpenBtreeIndexAndDataFile opens btree index file and data file and returns it along with BtIndex instance
 // Mostly useful for testing
-func OpenBtreeIndexAndDataFile(indexPath, dataPath string, M uint64, compressed seg.FileCompression, trace bool) (*seg.Decompressor, *BtIndex, error) {
+func OpenBtreeIndexAndDataFile(indexPath, dataPath string, M uint64, compressed seg.FileCompression, trace bool) (_ *seg.Decompressor, _ *BtIndex, err error) {
 	d, err := seg.NewDecompressor(dataPath)
 	if err != nil {
 		return nil, nil, err
 	}
+	defer func() {
+		if err != nil {
+			d.Close()
+		}
+	}()
 	kv := seg.NewReader(d.MakeGetter(), compressed)
 	bt, err := OpenBtreeIndexWithDecompressor(indexPath, M, kv)
 	if err != nil {
-		d.Close()
 		return nil, nil, err
 	}
 	return d, bt, nil

--- a/db/datastruct/fusefilter/fusefilter_reader.go
+++ b/db/datastruct/fusefilter/fusefilter_reader.go
@@ -45,27 +45,32 @@ var (
 	MadvNormalByDefault   = dbg.EnvBool("FUSE_MADV_NORMAL", false)
 )
 
-func NewReader(filePath string) (*Reader, error) {
+func NewReader(filePath string) (_ *Reader, err error) {
 	f, err := os.Open(filePath)
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if err != nil {
+			_ = f.Close() //nolint
+		}
+	}()
 	st, err := f.Stat()
 	if err != nil {
-		_ = f.Close() //nolint
 		return nil, err
 	}
 	sz := int(st.Size())
-	var content []byte
 	m, err := mmap.MapRegion(f, sz, mmap.RDONLY, 0, 0)
 	if err != nil {
-		_ = f.Close() //nolint
 		return nil, err
 	}
-	content = m
-
+	defer func() {
+		if err != nil {
+			_ = m.Unmap() //nolint
+		}
+	}()
 	_, fileName := filepath.Split(filePath)
-	r, _, err := NewReaderOnBytes(content, fileName)
+	r, _, err := NewReaderOnBytes(m, fileName)
 	if err != nil {
 		return nil, err
 	}
@@ -202,27 +207,33 @@ type ReaderSharded struct {
 	shards    [256]Reader
 }
 
-func NewReaderSharded(filePath string) (*ReaderSharded, error) {
+func NewReaderSharded(filePath string) (_ *ReaderSharded, err error) {
 	f, err := os.Open(filePath)
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if err != nil {
+			_ = f.Close() //nolint
+		}
+	}()
 	st, err := f.Stat()
 	if err != nil {
-		_ = f.Close() //nolint
 		return nil, err
 	}
 	sz := int(st.Size())
 	m, err := mmap.MapRegion(f, sz, mmap.RDONLY, 0, 0)
 	if err != nil {
-		_ = f.Close() //nolint
 		return nil, err
 	}
+	defer func() {
+		if err != nil {
+			_ = m.Unmap() //nolint
+		}
+	}()
 	_, fileName := filepath.Split(filePath)
 	r, _, err := NewReaderShardedOnBytes(m, fileName)
 	if err != nil {
-		_ = m.Unmap() //nolint
-		_ = f.Close() //nolint
 		return nil, err
 	}
 	r.f = f

--- a/db/kv/mdbx/kv_mdbx.go
+++ b/db/kv/mdbx/kv_mdbx.go
@@ -185,7 +185,7 @@ func (opts MdbxOpts) InMem(tb testing.TB, tmpDir string) MdbxOpts {
 
 var ErrDBDoesNotExists = errors.New("can't create database - because opening in `Accede` mode. probably another (main) process can create it")
 
-func (opts MdbxOpts) Open(ctx context.Context) (kv.RwDB, error) {
+func (opts MdbxOpts) Open(ctx context.Context) (_ kv.RwDB, err error) {
 	if dbg.DirtySpace() > 0 {
 		opts = opts.DirtySpace(dbg.DirtySpace()) //nolint
 	}
@@ -221,6 +221,11 @@ func (opts MdbxOpts) Open(ctx context.Context) (kv.RwDB, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if err != nil {
+			env.Close()
+		}
+	}()
 	if opts.label == dbcfg.ChainDB && opts.verbosity != -1 {
 		err = env.SetDebug(mdbx.LogLvl(opts.verbosity), mdbx.DbgDoNotChange, mdbx.LoggerDoNotChange) // temporary disable error, because it works if call it 1 time, but returns error if call it twice in same process (what often happening in tests)
 		if err != nil {
@@ -342,14 +347,12 @@ func (opts MdbxOpts) Open(ctx context.Context) (kv.RwDB, error) {
 
 	if opts.HasFlag(mdbx.SafeNoSync) && opts.syncPeriod != 0 {
 		if err = env.SetSyncPeriod(opts.syncPeriod); err != nil {
-			env.Close()
 			return nil, err
 		}
 	}
 
 	if opts.HasFlag(mdbx.SafeNoSync) && opts.syncBytes != nil {
 		if err = env.SetSyncBytes(uint(opts.syncBytes.Bytes())); err != nil {
-			env.Close()
 			return nil, err
 		}
 	}

--- a/db/recsplit/eliasfano32/elias_fano.go
+++ b/db/recsplit/eliasfano32/elias_fano.go
@@ -119,7 +119,7 @@ func fallocate(f *os.File, size int64) error {
 // NewEliasFanoOffHeap is like NewEliasFano but backs the data buffer with a
 // mmapped temp file. Use when the buffer would be too large for the Go heap
 // (multi-GB EFs during snapshot builds). Caller MUST Close() after Write.
-func NewEliasFanoOffHeap(count uint64, maxOffset uint64, tmpFilePath string) (*OffHeapBuilder, error) {
+func NewEliasFanoOffHeap(count uint64, maxOffset uint64, tmpFilePath string) (_ *OffHeapBuilder, err error) {
 	if count == 0 {
 		panic(fmt.Sprintf("too small count: %d", count))
 	}
@@ -138,17 +138,24 @@ func NewEliasFanoOffHeap(count uint64, maxOffset uint64, tmpFilePath string) (*O
 	if err != nil {
 		return nil, fmt.Errorf("create ef tmp file %q: %w", tmpFilePath, err)
 	}
+	defer func() {
+		if err != nil {
+			f.Close()
+			dir.RemoveFile(f.Name())
+		}
+	}()
 	if err := fallocate(f, sizeBytes); err != nil {
-		f.Close()
-		dir.RemoveFile(f.Name())
 		return nil, fmt.Errorf("pre-allocate ef tmp file: %w", err)
 	}
 	m, err := mmap.MapRegion(f, int(sizeBytes), mmap.RDWR, 0, 0)
 	if err != nil {
-		f.Close()
-		dir.RemoveFile(f.Name())
 		return nil, fmt.Errorf("mmap ef tmp file: %w", err)
 	}
+	defer func() {
+		if err != nil {
+			_ = m.Unmap() //nolint
+		}
+	}()
 	ef.data = unsafe.Slice((*uint64)(unsafe.Pointer(&m[0])), totalWords)
 	ef.wordsUpperBits = ef.deriveFields()
 	return &OffHeapBuilder{EliasFano: ef, backingMmap: m, backingFile: f}, nil

--- a/db/recsplit/index.go
+++ b/db/recsplit/index.go
@@ -119,9 +119,9 @@ func MustOpen(indexFile string) *Index {
 	return idx
 }
 
-func OpenIndex(indexFilePath string) (idx *Index, err error) {
+func OpenIndex(indexFilePath string) (_ *Index, err error) {
 	_, fName := filepath.Split(indexFilePath)
-	idx = &Index{
+	idx := &Index{
 		filePath: indexFilePath,
 		fileName: fName,
 	}
@@ -130,6 +130,11 @@ func OpenIndex(indexFilePath string) (idx *Index, err error) {
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if err != nil {
+			idx.Close()
+		}
+	}()
 	var stat os.FileInfo
 	if stat, err = idx.f.Stat(); err != nil {
 		return nil, err
@@ -141,7 +146,7 @@ func OpenIndex(indexFilePath string) (idx *Index, err error) {
 	}
 	idx.data = idx.mmapHandle1[:idx.size]
 
-	if err := idx.init(); err != nil {
+	if err = idx.init(); err != nil {
 		return nil, err
 	}
 

--- a/p2p/pipes/pipes.go
+++ b/p2p/pipes/pipes.go
@@ -24,7 +24,7 @@ import (
 )
 
 // TCPPipe creates an in process full duplex pipe based on a localhost TCP socket
-func TCPPipe() (net.Conn, net.Conn, error) {
+func TCPPipe() (_ net.Conn, _ net.Conn, err error) {
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return nil, nil, err
@@ -34,18 +34,22 @@ func TCPPipe() (net.Conn, net.Conn, error) {
 	var aconn net.Conn
 	aerr := make(chan error, 1)
 	go func() {
-		var err error
-		aconn, err = l.Accept()
-		aerr <- err
+		var lErr error
+		aconn, lErr = l.Accept()
+		aerr <- lErr
 	}()
 
-	dconn, err := net.Dial("tcp", l.Addr().String())
-	if err != nil {
+	var dconn net.Conn
+	if dconn, err = net.Dial("tcp", l.Addr().String()); err != nil {
 		<-aerr
 		return nil, nil, err
 	}
-	if err := <-aerr; err != nil {
-		dconn.Close()
+	defer func() {
+		if err != nil {
+			dconn.Close()
+		}
+	}()
+	if err = <-aerr; err != nil {
 		return nil, nil, err
 	}
 	return aconn, dconn, nil


### PR DESCRIPTION
Instead of scattering explicit `resource.Close()` calls in each error branch, consolidate constructor cleanup with a single deferred `if err != nil { resource.Close() }`.  Follows the principle that the constructor owns cleanup on failure.

Affected constructors:
- `fusefilter.NewReader` / `NewReaderSharded`
- `eliasfano32.NewEliasFanoOffHeap`
- `btindex.OpenBtreeIndexAndDataFile`
- `recsplit.OpenIndex` — also fixes silent fd/mmap leaks on `Stat`/`mmap.Mmap` failure (no cleanup existed there before)
- `mdbx.MdbxOpts.Open` — also fixes `env` leaks on all error paths, not just the two that had explicit `env.Close()`

Supersedes #21340 (which added per-branch cleanup to `NewReader`).