### PR TITLE
node, cl: migrate gopkg.in/yaml.v2 → gopkg.in/yaml.v3

### DIFF
--- a/cl/clparams/config.go
+++ b/cl/clparams/config.go
@@ -26,7 +26,7 @@ import (
 	"sort"
 	"time"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/c2h5oh/datasize"
 

--- a/cl/cltypes/partial_data_column_test.go
+++ b/cl/cltypes/partial_data_column_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"

--- a/cl/spectest/consensus_tests/ssz_static.go
+++ b/cl/spectest/consensus_tests/ssz_static.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"

--- a/go.mod
+++ b/go.mod
@@ -123,7 +123,6 @@ require (
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
-	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	sigs.k8s.io/yaml v1.6.0
 )

--- a/node/cli/config_file.go
+++ b/node/cli/config_file.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/pelletier/go-toml/v2"
 	"github.com/urfave/cli/v2"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 func SetFlagsFromConfigFile(ctx *cli.Context, filePath string) error {
@@ -101,25 +101,9 @@ func flattenConfig(m map[string]any, prefix string) map[string]any {
 			for fk, fv := range flattenConfig(nested, key) {
 				result[fk] = fv
 			}
-		} else if nested, ok := v.(map[any]any); ok {
-			// gopkg.in/yaml.v2 unmarshals maps as map[interface{}]interface{}
-			converted := convertYAMLMap(nested)
-			for fk, fv := range flattenConfig(converted, key) {
-				result[fk] = fv
-			}
 		} else {
 			result[key] = v
 		}
-	}
-	return result
-}
-
-// convertYAMLMap converts a map[any]any (produced by gopkg.in/yaml.v2) to
-// map[string]any so it can be processed uniformly.
-func convertYAMLMap(m map[any]any) map[string]any {
-	result := make(map[string]any, len(m))
-	for k, v := range m {
-		result[fmt.Sprintf("%v", k)] = v
 	}
 	return result
 }

--- a/node/cli/config_file_test.go
+++ b/node/cli/config_file_test.go
@@ -25,6 +25,77 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+func TestSetFlagsFromConfigFile_YAML(t *testing.T) {
+	staticPeersFlag := cli.StringFlag{Name: "staticpeers", Value: ""}
+	sentinelStaticPeersFlag := cli.StringSliceFlag{Name: "sentinel.staticpeers"}
+	datadirFlag := cli.StringFlag{Name: "datadir", Value: ""}
+
+	tests := []struct {
+		name                    string
+		ext                     string // ".yaml" or ".yml"
+		yaml                    string
+		wantStaticPeers         string
+		wantSentinelStaticPeers []string
+		wantDatadir             string
+	}{
+		{
+			name:        "flat scalar value, .yaml extension",
+			ext:         ".yaml",
+			yaml:        "datadir: /tmp/erigon\n",
+			wantDatadir: "/tmp/erigon",
+		},
+		{
+			name:        "flat scalar value, .yml extension",
+			ext:         ".yml",
+			yaml:        "datadir: /tmp/erigon\n",
+			wantDatadir: "/tmp/erigon",
+		},
+		{
+			name:            "YAML sequence for staticpeers",
+			ext:             ".yaml",
+			yaml:            "staticpeers:\n  - enode://abc@1.2.3.4:30303\n  - enode://def@5.6.7.8:30303\n",
+			wantStaticPeers: "enode://abc@1.2.3.4:30303,enode://def@5.6.7.8:30303",
+		},
+		{
+			// Nested YAML map: yaml.v3 decodes these as map[string]any directly,
+			// whereas yaml.v2 produced map[interface{}]interface{} and required
+			// the now-deleted convertYAMLMap workaround.
+			name:                    "nested YAML map for sentinel.staticpeers",
+			ext:                     ".yaml",
+			yaml:                    "sentinel:\n  staticpeers:\n    - enode://abc@1.2.3.4:9000\n    - enode://def@5.6.7.8:9000\n",
+			wantSentinelStaticPeers: []string{"enode://abc@1.2.3.4:9000", "enode://def@5.6.7.8:9000"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfgFile := filepath.Join(t.TempDir(), "erigon"+tt.ext)
+			require.NoError(t, os.WriteFile(cfgFile, []byte(tt.yaml), 0o600))
+
+			app := cli.NewApp()
+			app.Flags = []cli.Flag{&staticPeersFlag, &sentinelStaticPeersFlag, &datadirFlag}
+			app.Action = func(ctx *cli.Context) error {
+				err := SetFlagsFromConfigFile(ctx, cfgFile)
+				require.NoError(t, err)
+
+				if tt.wantDatadir != "" {
+					require.Equal(t, tt.wantDatadir, ctx.String("datadir"))
+				}
+				if tt.wantStaticPeers != "" {
+					require.True(t, ctx.IsSet("staticpeers"))
+					require.Equal(t, tt.wantStaticPeers, ctx.String("staticpeers"))
+				}
+				if tt.wantSentinelStaticPeers != nil {
+					require.True(t, ctx.IsSet("sentinel.staticpeers"))
+					require.Equal(t, tt.wantSentinelStaticPeers, ctx.StringSlice("sentinel.staticpeers"))
+				}
+				return nil
+			}
+			require.NoError(t, app.Run([]string{"erigon"}))
+		})
+	}
+}
+
 func TestSetFlagsFromConfigFile_StaticPeers(t *testing.T) {
 	staticPeersFlag := cli.StringFlag{
 		Name:  "staticpeers",

--- a/node/debug/flags.go
+++ b/node/debug/flags.go
@@ -32,7 +32,7 @@ import (
 	"github.com/pelletier/go-toml/v2"
 	"github.com/spf13/cobra"
 	"github.com/urfave/cli/v2"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/disk"


### PR DESCRIPTION
Migrates all direct uses of `gopkg.in/yaml.v2` to `gopkg.in/yaml.v3` (5 files).

yaml.v3 decodes maps into `map[string]interface{}` instead of yaml.v2's `map[interface{}]interface{}`, so the `convertYAMLMap` helper and its corresponding branch in `flattenConfig` (`node/cli/config_file.go`) are removed as dead code.

`gopkg.in/yaml.v2` is removed from direct deps in `go.mod`; it remains an indirect dep via other modules.