### PR TITLE
shutdown: propagate ctx in FillDBFromSnapshots

### DIFF
--- a/execution/stagedsync/rawdbreset/reset_stages.go
+++ b/execution/stagedsync/rawdbreset/reset_stages.go
@@ -345,7 +345,7 @@ func FillDBFromSnapshots(logPrefix string, ctx context.Context, tx kv.RwTx, dirs
 			}); err != nil {
 				return err
 			}
-			if err := h2n.Load(tx, kv.HeaderNumber, etl.IdentityLoadFunc, etl.TransformArgs{}); err != nil {
+			if err := h2n.Load(tx, kv.HeaderNumber, etl.IdentityLoadFunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
 				return err
 			}
 			canonicalHash, ok, err := blockReader.CanonicalHash(ctx, tx, blocksAvailable)


### PR DESCRIPTION
With `SortAndFlushInBackground(true)`, `h2n.Load` in `FillDBFromSnapshots` calls `provider.Wait()` on async sort goroutines and then runs `mergeSortFiles` which checks `args.Quit` every 1024 records via `common.Stopped`. The empty `TransformArgs{}` left `Quit` nil, so `common.Stopped(nil)` always returned nil — SIGINT during the merge-sort/load phase was silently ignored.

Fix: pass `Quit: ctx.Done()` so context cancellation propagates through the load phase.