### PR TITLE
.claude/rules: generalize branch-naming.md beyond Alex's convention

### DIFF
--- a/.claude/rules/branch-naming.md
+++ b/.claude/rules/branch-naming.md
@@ -6,18 +6,31 @@
 - `release/3.4` — Stable 3.4.x (current)
 - `main` — Next feature release (3.5)
 
-## Developer branches (alex's convention)
+## Developer branches
 
-Format: `alex/<short_desc>_<release_num>[_suffix]`
+The repo-wide convention is `<github-username>/<short-desc>`. Case style of the description varies by individual — kebab-case (`alice-bob/fix-foo-bar`) and snake_case (`alice_bob/fix_foo_bar`) are both in use. Pick one and stay consistent within your own branches.
 
-Release number is two digits without the dot: `34` = release/3.4, `35` = main, `33` = release/3.3.
+Examples seen on `origin`:
 
-Examples: `alex/seg_header_meta2_34`, `alex/integ_trie_root_35`, `alex/all7_34_dbg`
+- `yperbasis/overlay-flush-append`
+- `mh/parallel-exec-heuristic-removal`
+- `lupin012/fix_vrs_null_mainnet`
+- `awskii/eest-witness-newmain`
 
-Suffixes: `_dbg` (debug), `_auto` (automated), `_<n>` (revision). Short descs use underscores.
+When creating a branch for someone else, sample their recent branches first (`git for-each-ref refs/remotes/origin --sort=-committerdate | grep <username>/`) and match their style — do not impose a different one.
+
+### Optional variants
+
+Some contributors append a release-number suffix to mark which release the branch targets — Alex's convention is `alex/<short_desc>_<release_num>[_suffix]` (e.g. `alex/seg_header_meta2_34`, `alex/all7_34_dbg`). Release number is two digits without the dot: `34` = release/3.4, `35` = main, `33` = release/3.3. Suffixes: `_dbg` (debug), `_auto` (automated), `_<n>` (revision). This is one contributor's personal scheme — do not apply it to others.
+
+Non-personal prefixes that show up for cross-cutting work:
+
+- `feature/<username>/<desc>` — feature-branch namespace
+- `cp/<pr-number>-to-<target>` — cherry-pick branches (e.g. `cp/21328-to-main`)
+- `ci-fix/<desc>`, `wip/<desc>` — purpose-prefixed when ownership is shared or unclear
 
 ## Choosing a base branch
 
 - Bug for current stable release → base on `release/3.4`
 - New feature → base on `main`
-- Backport / cherry-pick → branch off target release branch, prefix PR title with `[rX.Y]`
+- Backport / cherry-pick → branch off the target release branch, prefix the PR title with `[rX.Y]` (dominant form `[r3.4]`)


### PR DESCRIPTION
## Summary

Previous version of the doc described only Alex's `alex/<short_desc>_<release_num>` scheme, which is one personal style — not a repo-wide rule. Generalize to `<github-username>/<short-desc>` (the actual live convention) with Alex's release-suffix scheme demoted to a documented variant. Add the `cp/` cherry-pick prefix and `feature/<username>/<desc>` form that already show up on origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)