### PR TITLE
execution: remove unnecessary block listener in mockcl

### DIFF
--- a/execution/engineapi/engineapitester/engine_api_tester.go
+++ b/execution/engineapi/engineapitester/engine_api_tester.go
@@ -372,9 +372,9 @@ func InitialiseEngineApiTester(ctx context.Context, args EngineApiTesterInitArgs
 	}
 	var mockCl *MockCl
 	if args.MockClState != nil {
-		mockCl = NewMockCl(ctx, logger, engineApiClient, ethBackend.StateDiffClient(), genesisBlock, args.Genesis.Config, WithMockClState(args.MockClState))
+		mockCl = NewMockCl(logger, engineApiClient, genesisBlock, args.Genesis.Config, WithMockClState(args.MockClState))
 	} else {
-		mockCl = NewMockCl(ctx, logger, engineApiClient, ethBackend.StateDiffClient(), genesisBlock, args.Genesis.Config)
+		mockCl = NewMockCl(logger, engineApiClient, genesisBlock, args.Genesis.Config)
 	}
 	if !args.NoEmptyBlock1 {
 		// build 1 empty block before proceeding to properly initialise everything

--- a/execution/engineapi/engineapitester/mock_cl.go
+++ b/execution/engineapi/engineapitester/mock_cl.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/holiman/uint256"
 	"github.com/jinzhu/copier"
-	"google.golang.org/grpc"
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/empty"
@@ -38,8 +37,6 @@ import (
 	enginetypes "github.com/erigontech/erigon/execution/engineapi/engine_types"
 	"github.com/erigontech/erigon/execution/protocol/rules/merge"
 	"github.com/erigontech/erigon/execution/types"
-	"github.com/erigontech/erigon/node/gointerfaces/remoteproto"
-	"github.com/erigontech/erigon/txnprovider/shutter"
 )
 
 type MockClOption func(*MockCl)
@@ -56,19 +53,13 @@ type MockCl struct {
 	suggestedFeeRecipient common.Address
 	genesis               common.Hash
 	state                 *MockClState
-	blockListener         *shutter.BlockListener
 	chainConfig           *chain.Config
 }
 
-type stateChangesClient interface {
-	StateChanges(ctx context.Context, in *remoteproto.StateChangeRequest, opts ...grpc.CallOption) (remoteproto.KV_StateChangesClient, error)
-}
-
-func NewMockCl(ctx context.Context, logger log.Logger, elClient *engineapi.JsonRpcClient, stateChangesClient stateChangesClient, genesis *types.Block, chainConfig *chain.Config, opts ...MockClOption) *MockCl {
+func NewMockCl(logger log.Logger, elClient *engineapi.JsonRpcClient, genesis *types.Block, chainConfig *chain.Config, opts ...MockClOption) *MockCl {
 	mcl := &MockCl{
 		logger:                logger,
 		engineApiClient:       elClient,
-		blockListener:         shutter.NewBlockListener(logger, stateChangesClient),
 		suggestedFeeRecipient: genesis.Coinbase(),
 		genesis:               genesis.Hash(),
 		chainConfig:           chainConfig,
@@ -82,7 +73,6 @@ func NewMockCl(ctx context.Context, logger log.Logger, elClient *engineapi.JsonR
 	for _, opt := range opts {
 		opt(mcl)
 	}
-	go mcl.blockListener.Run(ctx)
 	return mcl
 }
 
@@ -92,11 +82,6 @@ func (cl *MockCl) BuildCanonicalBlock(ctx context.Context, opts ...BlockBuilding
 	if err != nil {
 		return nil, fmt.Errorf("build new payload failed: %w", err)
 	}
-	lastBlock := make(chan uint64)
-	unregisterObserver := cl.blockListener.RegisterObserver(func(e shutter.BlockEvent) {
-		lastBlock <- e.LatestBlockNum
-	})
-	defer unregisterObserver()
 	status, err := cl.InsertNewPayload(ctx, clPayload)
 	if err != nil {
 		return nil, fmt.Errorf("insert new payload failed: %w", err)
@@ -108,9 +93,6 @@ func (cl *MockCl) BuildCanonicalBlock(ctx context.Context, opts ...BlockBuilding
 	if err != nil {
 		return nil, fmt.Errorf("update fork choice failed: %w", err)
 	}
-	// wait for the block t be published (note: we could just poll the rpc layer
-	// if we want to remove the internal api dependency)
-	<-lastBlock
 	return clPayload, nil
 }
 


### PR DESCRIPTION
## Title

execution/engineapi/engineapitester: remove blockListener from MockCl

## Summary

`MockCl.BuildCanonicalBlock` was using a `shutter.BlockListener` to wait for
state-change notifications after sending `engine_forkchoiceUpdated`, on the
assumption that the test driver had to block until the FCU "settled"
internally before returning.

That synchronization does not belong in the test harness. By the time
`engine_forkchoiceUpdated` returns `VALID`, the node is contractually
responsible for serving consistent reads against the new head — any
follow-up RPC or engine call from the test should observe the new state
without an out-of-band signal. If a test ever sees stale data after a
successful FCU, that is a node bug we want surfaced, not papered over
with a wait in the mock CL.

This change removes the listener and the surrounding plumbing so the
mock CL no longer hides consistency gaps. If any tests break as a
result, those are real bugs in the node's post-FCU consistency story
that we want to fix at the source.

## Changes

- `MockCl`: drop `blockListener` field and the `stateChangesClient`
  interface used only to construct it.
- `NewMockCl`: remove now-unused `ctx` and `stateChangesClient`
  parameters; no background goroutine to launch.
- `BuildCanonicalBlock`: remove the observer registration and the
  `<-lastBlock` wait after `UpdateForkChoice`.
- `engine_api_tester.go`: update both `NewMockCl(...)` call sites.
- Drop unused imports (`grpc`, `remoteproto`, `txnprovider/shutter`).

## Test plan

- [ ] `make lint`
- [ ] `make erigon integration`
- [ ] `go test ./execution/engineapi/...`
- [ ] `go test ./execution/tests/...` (covers
      `invalid_receipt_hash_high_mgas_test.go`)
- [ ] `go test ./rpc/jsonrpc/...` (covers
      `send_raw_transaction_sync_test.go`,
      `receipt_root_validation_test.go`)
- [ ] `go test ./txnprovider/shutter/...` (covers
      `block_building_integration_test.go`)
- [ ] Investigate any failures as candidate node-side consistency bugs
      rather than reintroducing the wait.
