### PR TITLE
[TEST] Simplify voting source selection

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: read
       issues: read
       id-token: write
 

--- a/cl/phase1/forkchoice/get_head.go
+++ b/cl/phase1/forkchoice/get_head.go
@@ -323,18 +323,15 @@ func (f *ForkChoiceStore) getFilterBlockTree(blockRoot common.Hash, blocks map[c
 	}
 	// Leaf node — viability per spec filter_block_tree.
 
-	// Spec get_voting_source: pick unrealized only for prior-epoch blocks
-	// (pull-up justification view); current/future-epoch blocks use the
-	// block's realized state checkpoint.
-	blockEpoch := f.computeEpochAtSlot(header.Slot)
+	// Use per-block unrealized justifications (spec: store.unrealized_justifications[block_root])
+	// Fall back to realized checkpoints if unrealized not available
 	var votingSource solid.Checkpoint
-	if currentEpoch > blockEpoch {
-		votingSource, has = f.getUnrealizedJustification(blockRoot)
-	} else {
-		votingSource, has = f.forkGraph.GetCurrentJustifiedCheckpoint(blockRoot)
-	}
+	votingSource, has = f.getUnrealizedJustification(blockRoot)
 	if !has {
-		return false
+		votingSource, has = f.forkGraph.GetCurrentJustifiedCheckpoint(blockRoot)
+		if !has {
+			return false
+		}
 	}
 
 	genesisEpoch := f.beaconCfg.GenesisEpoch


### PR DESCRIPTION
## Test PR — Do Not Merge

This PR deliberately introduces a spec deviation in `getFilterBlockTree` to test whether the Claude Code Review Action catches it using the spec conformance rules in `cl/CLAUDE.md`.

**Deliberate deviation**: Changed `get_voting_source` from spec-faithful conditional branch (unrealized for prior-epoch, realized for current-epoch) to unconditional unrealized-first fallback. This is the exact pattern that caused the epoch-boundary head regression in #20035.

Expected: Claude review should flag this as a spec deviation.