### PR TITLE
eliasfano32: Seek returns position alongside value

### DIFF
--- a/db/recsplit/eliasfano32/elias_fano.go
+++ b/db/recsplit/eliasfano32/elias_fano.go
@@ -336,12 +336,12 @@ func (ef *EliasFano) upper(i uint64) uint64 {
 	return currWord*64 + uint64(sel) - i
 }
 
-func Seek(data []byte, n uint64) (uint64, bool) {
+func Seek(data []byte, n uint64) (uint64, uint64, bool) {
 	ef, _ := ReadEliasFano(data) //for better perf: app-code can use ef.Reset(data).Seek(n)
 	return ef.Seek(n)
 }
 
-func (ef *EliasFano) searchForward(v uint64) (nextV uint64, nextI uint64, ok bool) {
+func (ef *EliasFano) searchForward(v uint64) (val uint64, pos uint64, ok bool) {
 	if v == 0 {
 		return ef.Min(), 0, true // .Min() touching `mmap`
 	}
@@ -363,10 +363,10 @@ func (ef *EliasFano) searchForward(v uint64) (nextV uint64, nextI uint64, ok boo
 	if !found {
 		lo = ef.searchUpperForward(hi)
 	}
-	for j := lo; j <= ef.count; j++ {
-		val, _, _, _, _ := ef.get(j)
+	for pos = lo; pos <= ef.count; pos++ {
+		val, _, _, _, _ = ef.get(pos)
 		if val >= v {
-			return val, j, true
+			return val, pos, true
 		}
 	}
 	return 0, 0, false
@@ -469,7 +469,7 @@ func (ef *EliasFano) searchUpperReverse(hi uint64) uint64 {
 	return lo + uint64(i)
 }
 
-func (ef *EliasFano) searchReverse(v uint64) (nextV uint64, nextI uint64, ok bool) {
+func (ef *EliasFano) searchReverse(v uint64) (val uint64, pos uint64, ok bool) {
 	if v == 0 {
 		return 0, 0, ef.Min() == 0 // .Max() touching `mmap`
 	}
@@ -489,19 +489,18 @@ func (ef *EliasFano) searchReverse(v uint64) (nextV uint64, nextI uint64, ok boo
 		lo = ef.searchUpperReverse(hi)
 	}
 	for j := lo; j <= ef.count; j++ {
-		idx := ef.count - j
-		val, _, _, _, _ := ef.get(idx)
+		pos = ef.count - j
+		val, _, _, _, _ = ef.get(pos)
 		if val <= v {
-			return val, idx, true
+			return val, pos, true
 		}
 	}
 	return 0, 0, false
 }
 
-// Seek returns the value in the sequence, equal or greater than given value
-func (ef *EliasFano) Seek(v uint64) (uint64, bool) {
-	n, _, ok := ef.searchForward(v)
-	return n, ok
+// Seek returns the value and its 0-based position in the sequence, equal or greater than given value
+func (ef *EliasFano) Seek(v uint64) (uint64, uint64, bool) {
+	return ef.searchForward(v)
 }
 
 func (ef *EliasFano) Max() uint64 {

--- a/db/recsplit/eliasfano32/elias_fano_seek_bench_test.go
+++ b/db/recsplit/eliasfano32/elias_fano_seek_bench_test.go
@@ -145,7 +145,7 @@ func BenchmarkSeek(b *testing.B) {
 				b.ReportAllocs()
 				n := 0
 				for b.Loop() {
-					_, _ = ef.Seek(targets[n%nTargets])
+					_, _, _ = ef.Seek(targets[n%nTargets])
 					n++
 				}
 			})

--- a/db/recsplit/eliasfano32/elias_fano_test.go
+++ b/db/recsplit/eliasfano32/elias_fano_test.go
@@ -149,9 +149,10 @@ func TestEliasFanoSeek(t *testing.T) {
 	})
 
 	{
-		v2, ok2 := ef.Seek(ef.Max())
+		v2, pos2, ok2 := ef.Seek(ef.Max())
 		require.True(t, ok2, v2)
 		require.Equal(t, int(ef.Max()), int(v2))
+		require.Equal(t, int(ef.Count()-1), int(pos2))
 		it := ef.Iterator()
 		for i := 0; i < int(ef.Count()-1); i++ {
 			_, err := it.Next()
@@ -174,9 +175,10 @@ func TestEliasFanoSeek(t *testing.T) {
 	}
 
 	{
-		v2, ok2 := ef.Seek(ef.Min())
+		v2, pos2, ok2 := ef.Seek(ef.Min())
 		require.True(t, ok2, v2)
 		require.Equal(t, int(ef.Min()), int(v2))
+		require.Equal(t, 0, int(pos2))
 		it := ef.Iterator()
 		it.Seek(ef.Min())
 		require.True(t, it.HasNext(), v2)
@@ -186,9 +188,10 @@ func TestEliasFanoSeek(t *testing.T) {
 	}
 
 	{
-		v2, ok2 := ef.Seek(0)
+		v2, pos2, ok2 := ef.Seek(0)
 		require.True(t, ok2, v2)
 		require.Equal(t, int(ef.Min()), int(v2))
+		require.Equal(t, 0, int(pos2))
 		it := ef.Iterator()
 		it.Seek(0)
 		require.True(t, it.HasNext(), v2)
@@ -198,7 +201,7 @@ func TestEliasFanoSeek(t *testing.T) {
 	}
 
 	{
-		v2, ok2 := ef.Seek(math.MaxUint32)
+		v2, _, ok2 := ef.Seek(math.MaxUint32)
 		require.False(t, ok2, v2)
 		it := ef.Iterator()
 		it.Seek(math.MaxUint32)
@@ -206,7 +209,7 @@ func TestEliasFanoSeek(t *testing.T) {
 	}
 
 	{
-		v2, ok2 := ef.Seek((count+1)*123 + 1)
+		v2, _, ok2 := ef.Seek((count+1)*123 + 1)
 		require.False(t, ok2, v2)
 		it := ef.Iterator()
 		it.Seek((count+1)*123 + 1)
@@ -216,9 +219,10 @@ func TestEliasFanoSeek(t *testing.T) {
 	t.Run("search and seek can't return smaller", func(t *testing.T) {
 		for i := uint64(0); i < count; i++ {
 			search := i * 123
-			v, ok2 := ef.Seek(search)
+			v, pos, ok2 := ef.Seek(search)
 			require.True(t, ok2, search)
 			require.GreaterOrEqual(t, int(v), int(search))
+			require.Equal(t, v, ef.Get(pos), "Get(pos) must equal Seek value")
 			it := ef.Iterator()
 			it.Seek(search)
 			itV, err := it.Next()
@@ -227,6 +231,240 @@ func TestEliasFanoSeek(t *testing.T) {
 		}
 	})
 
+}
+
+func TestEliasFanoSeekPosition(t *testing.T) {
+	build := func(vals []uint64) *EliasFano {
+		ef := NewEliasFano(uint64(len(vals)), vals[len(vals)-1])
+		for _, v := range vals {
+			ef.AddOffset(v)
+		}
+		ef.Build()
+		return ef
+	}
+
+	cases := []struct {
+		name    string
+		vals    []uint64
+		seek    uint64
+		wantVal uint64
+		wantPos uint64
+		wantOk  bool
+	}{
+		// exact hits
+		{name: "first", vals: []uint64{10, 20, 30, 40, 100}, seek: 10, wantVal: 10, wantPos: 0, wantOk: true},
+		{name: "middle", vals: []uint64{10, 20, 30, 40, 100}, seek: 30, wantVal: 30, wantPos: 2, wantOk: true},
+		{name: "last", vals: []uint64{10, 20, 30, 40, 100}, seek: 100, wantVal: 100, wantPos: 4, wantOk: true},
+		{name: "second", vals: []uint64{10, 20, 30, 40, 100}, seek: 20, wantVal: 20, wantPos: 1, wantOk: true},
+		// between values
+		{name: "before first", vals: []uint64{10, 20, 30, 40, 100}, seek: 0, wantVal: 10, wantPos: 0, wantOk: true},
+		{name: "between 1 and 2", vals: []uint64{10, 20, 30, 40, 100}, seek: 15, wantVal: 20, wantPos: 1, wantOk: true},
+		{name: "between 3 and 4", vals: []uint64{10, 20, 30, 40, 100}, seek: 35, wantVal: 40, wantPos: 3, wantOk: true},
+		{name: "between 4 and 5", vals: []uint64{10, 20, 30, 40, 100}, seek: 50, wantVal: 100, wantPos: 4, wantOk: true},
+		// miss
+		{name: "after last", vals: []uint64{10, 20, 30, 40, 100}, seek: 101, wantOk: false},
+		// single element
+		{name: "single exact", vals: []uint64{42}, seek: 42, wantVal: 42, wantPos: 0, wantOk: true},
+		{name: "single before", vals: []uint64{42}, seek: 10, wantVal: 42, wantPos: 0, wantOk: true},
+		{name: "single after", vals: []uint64{42}, seek: 43, wantOk: false},
+		// two elements
+		{name: "two first", vals: []uint64{5, 10}, seek: 5, wantVal: 5, wantPos: 0, wantOk: true},
+		{name: "two second", vals: []uint64{5, 10}, seek: 10, wantVal: 10, wantPos: 1, wantOk: true},
+		{name: "two between", vals: []uint64{5, 10}, seek: 7, wantVal: 10, wantPos: 1, wantOk: true},
+		// large gaps
+		{name: "large gap pos0", vals: []uint64{0, 1_000_000, 2_000_000}, seek: 0, wantVal: 0, wantPos: 0, wantOk: true},
+		{name: "large gap pos1", vals: []uint64{0, 1_000_000, 2_000_000}, seek: 1_000_000, wantVal: 1_000_000, wantPos: 1, wantOk: true},
+		{name: "large gap pos2", vals: []uint64{0, 1_000_000, 2_000_000}, seek: 2_000_000, wantVal: 2_000_000, wantPos: 2, wantOk: true},
+		{name: "large gap between", vals: []uint64{0, 1_000_000, 2_000_000}, seek: 500_000, wantVal: 1_000_000, wantPos: 1, wantOk: true},
+		// seek at 0 fast-path (v==0)
+		{name: "seek zero fast-path", vals: []uint64{0, 5, 10}, seek: 0, wantVal: 0, wantPos: 0, wantOk: true},
+		// many elements — verify position = Get(pos)
+		{name: "dense pos5", vals: []uint64{2, 4, 6, 8, 10, 12, 14, 16, 18, 20}, seek: 12, wantVal: 12, wantPos: 5, wantOk: true},
+		{name: "dense pos9", vals: []uint64{2, 4, 6, 8, 10, 12, 14, 16, 18, 20}, seek: 20, wantVal: 20, wantPos: 9, wantOk: true},
+		{name: "dense between", vals: []uint64{2, 4, 6, 8, 10, 12, 14, 16, 18, 20}, seek: 13, wantVal: 14, wantPos: 6, wantOk: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ef := build(tc.vals)
+			gotVal, gotPos, gotOk := ef.Seek(tc.seek)
+			require.Equal(t, tc.wantOk, gotOk)
+			if tc.wantOk {
+				require.Equal(t, tc.wantVal, gotVal)
+				require.Equal(t, tc.wantPos, gotPos, "wrong position for seek=%d in %v", tc.seek, tc.vals)
+				require.Equal(t, gotVal, ef.Get(gotPos), "Get(pos) must equal Seek value")
+			}
+		})
+	}
+
+	// Exhaustive: for a known sequence, every exact seek must return correct position
+	t.Run("exhaustive positions", func(t *testing.T) {
+		const n = 1000
+		vals := make([]uint64, n)
+		for i := range vals {
+			vals[i] = uint64(i) * 37
+		}
+		ef := build(vals)
+		for i, v := range vals {
+			gotVal, gotPos, gotOk := ef.Seek(v)
+			require.True(t, gotOk)
+			require.Equal(t, v, gotVal)
+			require.Equal(t, uint64(i), gotPos, "position mismatch at i=%d v=%d", i, v)
+			require.Equal(t, gotVal, ef.Get(gotPos))
+		}
+	})
+}
+
+// TestEliasFanoSeekPositionLarge exercises searchUpperForward (the non-fast-lane path)
+// across block (q=256) and superblock (superQ=16384) boundaries, and under skewed
+// value distributions where the interpolation guess is maximally wrong.
+func TestEliasFanoSeekPositionLarge(t *testing.T) {
+	build := func(vals []uint64) *EliasFano {
+		ef := NewEliasFano(uint64(len(vals)), vals[len(vals)-1])
+		for _, v := range vals {
+			ef.AddOffset(v)
+		}
+		ef.Build()
+		return ef
+	}
+
+	// checkAllExact seeks every element of ef by its known value and verifies
+	// the returned position equals its index, and Get(pos)==val.
+	checkAllExact := func(t *testing.T, ef *EliasFano, vals []uint64) {
+		t.Helper()
+		for i, v := range vals {
+			gotVal, gotPos, gotOk := ef.Seek(v)
+			require.True(t, gotOk, "seek v=%d i=%d", v, i)
+			require.Equal(t, v, gotVal, "val mismatch at i=%d", i)
+			require.Equal(t, uint64(i), gotPos, "pos mismatch at i=%d v=%d", i, v)
+			require.Equal(t, gotVal, ef.Get(gotPos), "Get(pos)!=val at i=%d", i)
+		}
+	}
+
+	// checkBetween seeks the midpoint between each consecutive pair and verifies
+	// the returned value is vals[i+1] at position i+1.
+	checkBetween := func(t *testing.T, ef *EliasFano, vals []uint64) {
+		t.Helper()
+		for i := 0; i+1 < len(vals); i++ {
+			if vals[i+1]-vals[i] < 2 {
+				continue // no midpoint
+			}
+			mid := vals[i] + (vals[i+1]-vals[i])/2
+			gotVal, gotPos, gotOk := ef.Seek(mid)
+			require.True(t, gotOk, "seek mid=%d between i=%d,i+1=%d", mid, i, i+1)
+			require.Equal(t, vals[i+1], gotVal, "wrong val seeking mid=%d", mid)
+			require.Equal(t, uint64(i+1), gotPos, "wrong pos seeking mid=%d", mid)
+		}
+	}
+
+	t.Run("uniform spacing forces searchUpperForward", func(t *testing.T) {
+		// Sequence starts at 0; upper(0)=0, so any seek with hi>0 misses the fast-lane.
+		const n = 2000
+		const step = 1_000_000
+		vals := make([]uint64, n)
+		for i := range vals {
+			vals[i] = uint64(i) * step
+		}
+		ef := build(vals)
+		checkAllExact(t, ef, vals)
+		checkBetween(t, ef, vals)
+	})
+
+	t.Run("block boundary q=256", func(t *testing.T) {
+		// Seek to positions at and around every block boundary (multiples of q=256).
+		const n = 1500
+		const step = 100_000
+		vals := make([]uint64, n)
+		for i := range vals {
+			vals[i] = uint64(i) * step
+		}
+		ef := build(vals)
+		for _, boundary := range []int{255, 256, 257, 511, 512, 513, 767, 768, 769, 1023, 1024, 1025} {
+			if boundary >= n {
+				continue
+			}
+			gotVal, gotPos, gotOk := ef.Seek(vals[boundary])
+			require.True(t, gotOk, "boundary=%d", boundary)
+			require.Equal(t, vals[boundary], gotVal, "boundary=%d", boundary)
+			require.Equal(t, uint64(boundary), gotPos, "pos mismatch at block boundary=%d", boundary)
+		}
+	})
+
+	t.Run("superblock boundary superQ=16384", func(t *testing.T) {
+		// Must span at least two superblocks: n > 16384.
+		const n = 33000
+		const step = 10_000
+		vals := make([]uint64, n)
+		for i := range vals {
+			vals[i] = uint64(i) * step
+		}
+		ef := build(vals)
+		for _, boundary := range []int{16383, 16384, 16385, 32767, 32768, 32769} {
+			if boundary >= n {
+				continue
+			}
+			gotVal, gotPos, gotOk := ef.Seek(vals[boundary])
+			require.True(t, gotOk, "boundary=%d", boundary)
+			require.Equal(t, vals[boundary], gotVal, "boundary=%d", boundary)
+			require.Equal(t, uint64(boundary), gotPos, "pos mismatch at superblock boundary=%d", boundary)
+		}
+		checkBetween(t, ef, vals) // full slice: correct absolute positions
+	})
+
+	t.Run("clustered start: interpolation guesses too low", func(t *testing.T) {
+		// 90% of values in 0–999, 10% in 100000–109999.
+		// Seeking a late element: guess = (100000/110000)*1000 ≈ 909, actual ≈ 950.
+		// Forces forward bracket to overshoot, then binary search.
+		const n = 1000
+		vals := make([]uint64, n)
+		for i := 0; i < 900; i++ {
+			vals[i] = uint64(i)
+		}
+		for i := 900; i < n; i++ {
+			vals[i] = 100_000 + uint64(i-900)*100
+		}
+		ef := build(vals)
+		checkAllExact(t, ef, vals)
+	})
+
+	t.Run("clustered end: interpolation guesses too high", func(t *testing.T) {
+		// 10% of values sparse in 0–99000, 90% dense in 100000–100899.
+		// Seeking an early element: guess = (5000/100899)*1000 ≈ 50, actual ≈ 5.
+		// Forces backward bracket, then binary search.
+		const n = 1000
+		vals := make([]uint64, n)
+		for i := 0; i < 100; i++ {
+			vals[i] = uint64(i) * 1000
+		}
+		for i := 100; i < n; i++ {
+			vals[i] = 100_000 + uint64(i-100)
+		}
+		ef := build(vals)
+		checkAllExact(t, ef, vals)
+	})
+
+	t.Run("exponential gaps: guess off by many orders of magnitude", func(t *testing.T) {
+		// Values grow exponentially: 1, 2, 4, 8, ..., 2^29.
+		// Upper bits grow rapidly; interpolation is severely wrong for small indices.
+		vals := make([]uint64, 30)
+		for i := range vals {
+			vals[i] = uint64(1) << uint(i)
+		}
+		ef := build(vals)
+		checkAllExact(t, ef, vals)
+	})
+
+	t.Run("all-same-upper-bits: l captures all variance in lower bits", func(t *testing.T) {
+		// All values in [0, 255] — l=8 means upper bits are all 0; only lower bits differ.
+		// searchUpperForward is called for any hi>0 seek, but the upper scan has no variation.
+		vals := make([]uint64, 200)
+		for i := range vals {
+			vals[i] = uint64(i)
+		}
+		ef := build(vals)
+		checkAllExact(t, ef, vals)
+		checkBetween(t, ef, vals)
+	})
 }
 
 // TestSearchUpperReverseNoSolution exercises the n<=0 fast-path in searchUpperReverse.
@@ -272,17 +510,20 @@ func TestEliasFano(t *testing.T) {
 		offset1 := ef.Get(uint64(i))
 		assert.Equal(t, offset, offset1, "offset")
 	}
-	v, ok := ef.Seek(37)
+	v, pos, ok := ef.Seek(37)
 	assert.True(t, ok, "search1")
 	assert.Equal(t, uint64(37), v, "search1")
-	v, ok = ef.Seek(0)
+	assert.Equal(t, uint64(10), pos, "search1 pos")
+	v, pos, ok = ef.Seek(0)
 	assert.True(t, ok, "search2")
 	assert.Equal(t, uint64(1), v, "search2")
-	_, ok = ef.Seek(100)
+	assert.Equal(t, uint64(0), pos, "search2 pos")
+	_, _, ok = ef.Seek(100)
 	assert.False(t, ok, "search3")
-	v, ok = ef.Seek(11)
+	v, pos, ok = ef.Seek(11)
 	assert.True(t, ok, "search4")
 	assert.Equal(t, uint64(14), v, "search4")
+	assert.Equal(t, uint64(5), pos, "search4 pos")
 
 	buf := bytes.NewBuffer(nil)
 	err := ef.Write(buf)

--- a/db/recsplit/eliasfano32/rebased_elias_fano.go
+++ b/db/recsplit/eliasfano32/rebased_elias_fano.go
@@ -37,17 +37,17 @@ func (ref *RebasedEliasFano) Reset(baseNum uint64, raw []byte) { // no `return p
 	ref.ef.Reset(raw)
 }
 
-func (ref *RebasedEliasFano) Seek(v uint64) (uint64, bool) {
+func (ref *RebasedEliasFano) Seek(v uint64) (uint64, uint64, bool) {
 	if v < ref.baseNum {
 		v = ref.baseNum
 	}
 
-	n, found := ref.ef.Seek(v - ref.baseNum)
-	return ref.baseNum + n, found
+	n, pos, found := ref.ef.Seek(v - ref.baseNum)
+	return ref.baseNum + n, pos, found
 }
 
 func (ref *RebasedEliasFano) Has(v uint64) bool {
-	n, ok := ref.Seek(v)
+	n, _, ok := ref.Seek(v)
 	return ok && n == v
 }
 

--- a/db/recsplit/multiencseq/sequence_reader.go
+++ b/db/recsplit/multiencseq/sequence_reader.go
@@ -62,7 +62,7 @@ func Count(baseNum uint64, data []byte) uint64 {
 }
 
 // TODO: optimize me - to avoid object allocation (this TODO was inherited from elias_fano.go)
-func Seek(baseNum uint64, data []byte, n uint64) (uint64, bool) {
+func Seek(baseNum uint64, data []byte, n uint64) (uint64, uint64, bool) {
 	seq := ReadMultiEncSeq(baseNum, data)
 	return seq.Seek(n)
 }
@@ -146,7 +146,7 @@ func (s *SequenceReader) assertSorted() {
 	}
 }
 
-func (s *SequenceReader) Seek(v uint64) (uint64, bool) {
+func (s *SequenceReader) Seek(v uint64) (uint64, uint64, bool) {
 	switch s.currentEnc {
 	case SimpleEncoding:
 		return s.sseq.Seek(v)
@@ -158,7 +158,7 @@ func (s *SequenceReader) Seek(v uint64) (uint64, bool) {
 }
 
 func (s *SequenceReader) Has(v uint64) bool {
-	n, ok := s.Seek(v)
+	n, _, ok := s.Seek(v)
 	return ok && n == v
 }
 

--- a/db/recsplit/multiencseq/sequence_reader_test.go
+++ b/db/recsplit/multiencseq/sequence_reader_test.go
@@ -305,17 +305,17 @@ func TestMergeSeek(t *testing.T) {
 	result := ReadMultiEncSeq(1000, merged.AppendBytes(nil))
 
 	// Seek to existing value
-	n, ok := result.Seek(1010)
+	n, _, ok := result.Seek(1010)
 	require.True(t, ok)
 	require.Equal(t, uint64(1010), n)
 
 	// Seek to gap — returns next
-	n, ok = result.Seek(1011)
+	n, _, ok = result.Seek(1011)
 	require.True(t, ok)
 	require.Equal(t, uint64(1012), n)
 
 	// Seek past end
-	_, ok = result.Seek(1039)
+	_, _, ok = result.Seek(1039)
 	require.False(t, ok)
 
 	// Has
@@ -335,15 +335,15 @@ func TestBuilderFreeFunctions(t *testing.T) {
 
 	require.Equal(t, uint64(3), Count(baseNum, raw))
 
-	n, ok := Seek(baseNum, raw, 5006)
+	n, _, ok := Seek(baseNum, raw, 5006)
 	require.True(t, ok)
 	require.Equal(t, uint64(5007), n)
 
-	n, ok = Seek(baseNum, raw, 5007)
+	n, _, ok = Seek(baseNum, raw, 5007)
 	require.True(t, ok)
 	require.Equal(t, uint64(5007), n)
 
-	_, ok = Seek(baseNum, raw, 5016)
+	_, _, ok = Seek(baseNum, raw, 5016)
 	require.False(t, ok)
 }
 
@@ -491,19 +491,19 @@ func requireRawDataChecks(t *testing.T, b []byte) {
 	require.Equal(t, uint64(3), Count(1000, b))
 
 	// check search
-	n, found := Seek(1000, b, 1014)
+	n, _, found := Seek(1000, b, 1014)
 	require.True(t, found)
 	require.Equal(t, uint64(1015), n)
 
-	n, found = Seek(1000, b, 1015)
+	n, _, found = Seek(1000, b, 1015)
 	require.True(t, found)
 	require.Equal(t, uint64(1015), n)
 
-	_, found = Seek(1000, b, 1028)
+	_, _, found = Seek(1000, b, 1028)
 	require.False(t, found)
 
 	// check search before base num
-	n, found = Seek(1000, b, 999)
+	n, _, found = Seek(1000, b, 999)
 	require.True(t, found)
 	require.Equal(t, uint64(1000), n)
 }

--- a/db/recsplit/simpleseq/simple_sequence.go
+++ b/db/recsplit/simpleseq/simple_sequence.go
@@ -109,16 +109,16 @@ func (s *SimpleSequence) reverseSearch(seek uint64) (idx int, ok bool) {
 	return idx, idx >= 0
 }
 
-func (s *SimpleSequence) Seek(v uint64) (uint64, bool) {
+func (s *SimpleSequence) Seek(v uint64) (uint64, uint64, bool) {
 	idx, found := s.search(v)
 	if !found {
-		return 0, false
+		return 0, 0, false
 	}
-	return s.Get(uint64(idx)), true
+	return s.Get(uint64(idx)), uint64(idx), true
 }
 
 func (s *SimpleSequence) Has(v uint64) bool {
-	n, ok := s.Seek(v)
+	n, _, ok := s.Seek(v)
 	return ok && n == v
 }
 

--- a/db/recsplit/simpleseq/simple_sequence_test.go
+++ b/db/recsplit/simpleseq/simple_sequence_test.go
@@ -41,32 +41,37 @@ func TestSimpleSequence(t *testing.T) {
 
 	t.Run("seek", func(t *testing.T) {
 		// before baseNum
-		v, found := s.Seek(10)
+		v, pos, found := s.Seek(10)
 		require.True(t, found)
 		require.Equal(t, uint64(1001), v)
+		require.Equal(t, uint64(0), pos)
 
 		// at baseNum
-		v, found = s.Seek(1000)
+		v, pos, found = s.Seek(1000)
 		require.True(t, found)
 		require.Equal(t, uint64(1001), v)
+		require.Equal(t, uint64(0), pos)
 
 		// at elem
-		v, found = s.Seek(1007)
+		v, pos, found = s.Seek(1007)
 		require.True(t, found)
 		require.Equal(t, uint64(1007), v)
+		require.Equal(t, uint64(1), pos)
 
 		// between elems
-		v, found = s.Seek(1014)
+		v, pos, found = s.Seek(1014)
 		require.True(t, found)
 		require.Equal(t, uint64(1015), v)
+		require.Equal(t, uint64(2), pos)
 
 		// at last
-		v, found = s.Seek(1027)
+		v, pos, found = s.Seek(1027)
 		require.True(t, found)
 		require.Equal(t, uint64(1027), v)
+		require.Equal(t, uint64(3), pos)
 
 		// after last
-		v, found = s.Seek(1028)
+		v, _, found = s.Seek(1028)
 		require.False(t, found)
 		require.Equal(t, uint64(0), v)
 
@@ -305,11 +310,12 @@ func TestReadSimpleSequence(t *testing.T) {
 	require.Equal(t, uint64(1001), s.Min())
 	require.Equal(t, uint64(1027), s.Max())
 
-	v, found := s.Seek(1007)
+	v, pos, found := s.Seek(1007)
 	require.True(t, found)
 	require.Equal(t, uint64(1007), v)
+	require.Equal(t, uint64(1), pos)
 
-	v, found = s.Seek(9999)
+	v, _, found = s.Seek(9999)
 	require.False(t, found)
 	require.Equal(t, uint64(0), v)
 }

--- a/db/state/history_stream.go
+++ b/db/state/history_stream.go
@@ -136,7 +136,7 @@ func (hi *HistoryRangeAsOfFiles) advanceInFiles() error {
 		}
 
 		hi.seq.Reset(top.startTxNum, idxVal)
-		txNum, ok := hi.seq.Seek(hi.startTxNum)
+		txNum, _, ok := hi.seq.Seek(hi.startTxNum)
 		if !ok {
 			continue
 		}
@@ -445,7 +445,7 @@ func (hi *HistoryChangesIterFiles) advance() error {
 		}
 
 		hi.seq.Reset(top.startTxNum, idxVal)
-		txNum, ok := hi.seq.Seek(hi.startTxNum)
+		txNum, _, ok := hi.seq.Seek(hi.startTxNum)
 		if !ok {
 			continue
 		}

--- a/db/state/inverted_index.go
+++ b/db/state/inverted_index.go
@@ -565,7 +565,7 @@ func (iit *InvertedIndexRoTx) seekInFiles(key []byte, txNum uint64) (found bool,
 		encodedSeq, _ := g.Next(nil)
 
 		iit.reUsableSeq.Reset(iit.files[i].startTxNum, encodedSeq)
-		equalOrHigherTxNum, found = iit.reUsableSeq.Seek(txNum)
+		equalOrHigherTxNum, _, found = iit.reUsableSeq.Seek(txNum)
 		if !found {
 			continue
 		}


### PR DESCRIPTION
`EliasFano.Seek` now returns `(value, position, bool)` instead of `(value, bool)`, where `position` is the 0-based index of the returned element in the sorted sequence. This answers "which position in the list holds txnum=X?" without a separate lookup.

The position was already being computed inside `searchForward` (the loop counter `j`); the change stops discarding it.

## Changes

- `EliasFano.Seek` → `(uint64, uint64, bool)` (value, position, ok)
- Same cascaded to `RebasedEliasFano.Seek`, `SimpleSequence.Seek`, `SequenceReader.Seek`, and package-level `Seek` helpers in eliasfano32 and multiencseq
- Call sites in `db/state` that don't need position use `_`
- Renamed internal variables in `searchForward`/`searchReverse`: `nextV/nextI` → `val/pos`, loop `j` → `pos`

## Tests

- `TestEliasFanoSeekPosition`: 25 table-driven cases (exact hits, between-values, boundary, single element, two elements, large gaps) plus a 1000-element exhaustive loop asserting `ef.Get(pos) == val` for every element
- `TestEliasFanoSeekPositionLarge`: targets the `searchUpperForward` non-fast-lane path specifically — block boundaries (`q=256`), superblock boundaries (`superQ=16384`, spanning two superblocks with n=33000), clustered-start/end distributions where the interpolation guess is far off, exponential gaps, and all-same-upper-bits sequences
- Existing seek tests enhanced with position assertions at `Min`, `Max`, and exact-element boundaries