### PR TITLE
common, ethash: bound unsafe slice views

### DIFF
--- a/common/bitutil/bitutil.go
+++ b/common/bitutil/bitutil.go
@@ -30,9 +30,9 @@ func fastANDBytes(dst, a, b []byte) int {
 	n := min(len(b), len(a))
 	w := n / wordSize
 	if w > 0 {
-		dw := *(*[]uintptr)(unsafe.Pointer(&dst))
-		aw := *(*[]uintptr)(unsafe.Pointer(&a))
-		bw := *(*[]uintptr)(unsafe.Pointer(&b))
+		dw := unsafe.Slice((*uintptr)(unsafe.Pointer(&dst[0])), w)
+		aw := unsafe.Slice((*uintptr)(unsafe.Pointer(&a[0])), w)
+		bw := unsafe.Slice((*uintptr)(unsafe.Pointer(&b[0])), w)
 		for i := 0; i < w; i++ {
 			dw[i] = aw[i] & bw[i]
 		}
@@ -68,9 +68,9 @@ func fastORBytes(dst, a, b []byte) int {
 	n := min(len(b), len(a))
 	w := n / wordSize
 	if w > 0 {
-		dw := *(*[]uintptr)(unsafe.Pointer(&dst))
-		aw := *(*[]uintptr)(unsafe.Pointer(&a))
-		bw := *(*[]uintptr)(unsafe.Pointer(&b))
+		dw := unsafe.Slice((*uintptr)(unsafe.Pointer(&dst[0])), w)
+		aw := unsafe.Slice((*uintptr)(unsafe.Pointer(&a[0])), w)
+		bw := unsafe.Slice((*uintptr)(unsafe.Pointer(&b[0])), w)
 		for i := 0; i < w; i++ {
 			dw[i] = aw[i] | bw[i]
 		}
@@ -105,7 +105,7 @@ func fastTestBytes(p []byte) bool {
 	n := len(p)
 	w := n / wordSize
 	if w > 0 {
-		pw := *(*[]uintptr)(unsafe.Pointer(&p))
+		pw := unsafe.Slice((*uintptr)(unsafe.Pointer(&p[0])), w)
 		for i := 0; i < w; i++ {
 			if pw[i] != 0 {
 				return true

--- a/execution/protocol/rules/ethash/algorithm.go
+++ b/execution/protocol/rules/ethash/algorithm.go
@@ -24,7 +24,6 @@ import (
 	"encoding/binary"
 	"hash"
 	"math/big"
-	"reflect"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -192,12 +191,7 @@ func generateCache(dest []uint32, epoch uint64, seed []byte) {
 		logFn("Generated ethash verification cache", "elapsed", common.PrettyDuration(elapsed))
 	}()
 	// Convert our destination slice to a byte buffer
-	var cache []byte
-	cacheHdr := (*reflect.SliceHeader)(unsafe.Pointer(&cache))
-	dstHdr := (*reflect.SliceHeader)(unsafe.Pointer(&dest))
-	cacheHdr.Data = dstHdr.Data
-	cacheHdr.Len = dstHdr.Len * 4
-	cacheHdr.Cap = dstHdr.Cap * 4
+	cache := unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(dest))), len(dest)*4)
 
 	// Calculate the number of theoretical rows (we'll store in one buffer nonetheless)
 	size := uint64(len(cache))
@@ -352,12 +346,7 @@ func generateDataset(dest []uint32, epoch uint64, cache []uint32) {
 	swapped := !isLittleEndian()
 
 	// Convert our destination slice to a byte buffer
-	var dataset []byte
-	datasetHdr := (*reflect.SliceHeader)(unsafe.Pointer(&dataset))
-	destHdr := (*reflect.SliceHeader)(unsafe.Pointer(&dest))
-	datasetHdr.Data = destHdr.Data
-	datasetHdr.Len = destHdr.Len * 4
-	datasetHdr.Cap = destHdr.Cap * 4
+	dataset := unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(dest))), len(dest)*4)
 
 	// Generate the dataset on many goroutines since it takes a while
 	threads := runtime.GOMAXPROCS(-1)


### PR DESCRIPTION
## Summary

Follow up on #18552 by tightening the remaining unsafe slice reinterpretation sites that still relied on slice-header metadata across different element types.

#18552 fixed a concrete ethash panic caused by incorrect slice-header length setup. This change applies the same rule in nearby code: construct unsafe views with explicit element counts so the view length matches the element type being read or written.

`common/bitutil` now bounds uintptr views to the number of whole machine words being processed. `ethash` cache and dataset generation now use `unsafe.Slice` over the destination backing array instead of manually populating `reflect.SliceHeader`.