### PR TITLE
execution: fix exec to not return ErrLoopExhausted on last block

### DIFF
--- a/execution/engineapi/engineapitester/engine_api_tester.go
+++ b/execution/engineapi/engineapitester/engine_api_tester.go
@@ -294,9 +294,6 @@ func InitialiseEngineApiTester(ctx context.Context, args EngineApiTesterInitArgs
 		BatchSize:             512 * datasize.MB,
 		KeepStoredChainConfig: true,
 	}
-	if args.BatchSize > 0 {
-		ethConfig.BatchSize = args.BatchSize
-	}
 	if args.EthConfigTweaker != nil {
 		args.EthConfigTweaker(&ethConfig)
 	}
@@ -409,7 +406,6 @@ type EngineApiTesterInitArgs struct {
 	Genesis                *types.Genesis
 	CoinbaseKey            *ecdsa.PrivateKey
 	EthConfigTweaker       func(*ethconfig.Config)
-	BatchSize              datasize.ByteSize
 	MockClState            *MockClState
 	NoEmptyBlock1          bool
 	EngineApiClientTimeout *time.Duration

--- a/execution/engineapi/engineapitester/engine_x_test_runner.go
+++ b/execution/engineapi/engineapitester/engine_x_test_runner.go
@@ -342,8 +342,6 @@ func (extr *EngineXTestRunner) createTester(fork Fork, preAllocHash PreAllocHash
 		Genesis:                &genesis,
 		NoEmptyBlock1:          true,
 		EngineApiClientTimeout: &engineApiClientTimeout,
-		// benchmark fixtures at 150M-gas peak ~2.75GB SizeEstimate
-		BatchSize: 4 * datasize.GB,
 		EthConfigTweaker: func(config *ethconfig.Config) {
 			config.MaxReorgDepth = 512
 			config.WarmupKzgCtxOnInit = extr.warmupKzgCtxOnInit

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -258,7 +258,7 @@ func (se *serialExecutor) exec(ctx context.Context, execStage *StageState, u Unw
 				"commitment", times.ComputeCommitment,
 			)
 			stateCache.PrintStatsAndReset()
-			if isBatchFull {
+			if isBatchFull && blockNum != maxBlockNum {
 				return b.HeaderNoCopy(), rwTx, &ErrLoopExhausted{From: startBlockNum, To: blockNum, Reason: "block batch is full"}
 			}
 		}


### PR DESCRIPTION
## Why

#21163 worked around "unexpected state step has more work" errors in the EEST engine-x benchmarks by setting `BatchSize: 4 * datasize.GB` on the engine-x test runner. That hid a real bug rather than fixing it: the serial exec path was returning `ErrLoopExhausted` for the "block batch is full" case even when it was at `maxBlockNum`. For `StateStep` (driven by `NewPayload` → `ValidateChain`, single block per call), `startBlockNum == maxBlockNum`, so any `ErrLoopExhausted` return surfaces as `hasMore=true` and trips the `"unexpected state step has more work"` guard. The right fix is to not signal "more work" when we are already at the last block — there is nothing left to resume.

## What

- Drop the 4GB `BatchSize` override in `engine_x_test_runner.go`; runner now uses the default 512MB.
- Remove the `BatchSize` field from `EngineApiTesterInitArgs` and its conditional assignment in `InitialiseEngineApiTester`.
- `exec3_serial.go`: add `&& blockNum != maxBlockNum` guard to the "block batch is full" `ErrLoopExhausted` return, mirroring the existing guard already on the "block limit reached" path a few lines below.

The parallel path already handles this correctly via the apply-loop exit branch (`lastBlockResult.BlockNum >= pe.maxBlockNum && no missing blocks → return nil`); no change needed there.

## Test plan

- [x] All 14 EEST engine-x benchmark shards pass with default 512MB `BatchSize`:
      `enginextests-benchmark-{1m,5m,10m,30m,60m,100m,150m}-{sequential,parallel}` — 0 failures each.
- [x] `make lint` clean (3 runs).
- [x] `make erigon integration` builds cleanly.
