### PR TITLE
cl/block_collector: validate persistent block values

### DIFF
--- a/cl/phase1/execution_client/block_collector/persistent_block_collector.go
+++ b/cl/phase1/execution_client/block_collector/persistent_block_collector.go
@@ -363,12 +363,18 @@ func (p *PersistentBlockCollector) decodeBlock(v []byte) (*types.Block, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(v) < 33 {
+		return nil, fmt.Errorf("persistent block value too short: have %d, want at least 33", len(v))
+	}
 
 	version := clparams.StateVersion(v[0])
 	parentRoot := common.BytesToHash(v[1:33])
 	requestsHash := common.Hash{}
 
 	if version >= clparams.ElectraVersion {
+		if len(v) < 65 {
+			return nil, fmt.Errorf("persistent block value too short for execution requests: have %d, want at least 65", len(v))
+		}
 		requestsHash = common.BytesToHash(v[33:65])
 		v = v[65:]
 	} else {

--- a/cl/phase1/execution_client/block_collector/persistent_block_collector_test.go
+++ b/cl/phase1/execution_client/block_collector/persistent_block_collector_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/phase1/execution_client"
+	"github.com/erigontech/erigon/cl/utils"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
@@ -129,6 +130,20 @@ func countRowsAtOrAbove(t *testing.T, db kv.RoDB, minNumber uint64) int {
 		return nil
 	}))
 	return count
+}
+
+func TestDecodeBlockRejectsShortPersistentValue(t *testing.T) {
+	c := &PersistentBlockCollector{}
+	for name, raw := range map[string][]byte{
+		"empty decompressed value": nil,
+		"missing parent root":      {byte(clparams.DenebVersion)},
+		"missing requests hash":    append([]byte{byte(clparams.ElectraVersion)}, make([]byte, 32)...),
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := c.decodeBlock(utils.CompressSnappy(raw))
+			require.ErrorContains(t, err, "persistent block value too short")
+		})
+	}
 }
 
 func TestFlushSkipsDuplicateBlockNumbers(t *testing.T) {


### PR DESCRIPTION
## Summary

- Validate the decompressed persistent block value before reading the version, parent root, and execution requests hash.
- Return a diagnostic decode error for truncated persisted rows instead of panicking on slice bounds.
- Add coverage for empty, pre-Electra, and Electra-style truncated values.