### PR TITLE
simplify state aggregation and pruning logic

### DIFF
--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -94,11 +94,6 @@ type Aggregator struct {
 	ctx       context.Context
 	ctxCancel context.CancelFunc
 
-	// maxCollationTxNum caps BuildFiles to not extend past available block files.
-	// Set by the caller (exec3.go) based on the block reader's max txNum.
-	// 0 means no cap.
-	maxCollationTxNum atomic.Uint64
-
 	// lastFlushedCommitmentTxNum is the highest txNum at which commitment
 	// data (branch nodes, state key) has been flushed to MDBX. Collation
 	// must not proceed for a step unless the step's commitment boundary has
@@ -837,12 +832,12 @@ func (a *Aggregator) buildFiles(ctx context.Context, step kv.Step) error {
 	a.LockWorkersEditing()
 	defer a.UnlockWorkersEditing()
 
-	lastBlockInStep, lastBlockInDB, lastTxInDB, ok, err := a.readyForCollation(ctx, step)
+	ok, err := a.readyForCollation(ctx, step)
 	if err != nil {
 		return err
 	}
 	if !ok {
-		a.logger.Debug("[agg] step not ready for collation", "step", step, "lastTxInStep", lastTxNumOfStep(step, a.StepSize()), "lastBlockInStep", lastBlockInStep, "lastTxInDB", lastTxInDB, "lastBlockInDB", lastBlockInDB)
+		a.logger.Debug("[agg] step not ready for collation", "step", step, "lastTxInStep", lastTxNumOfStep(step, a.StepSize()))
 		return errStepNotReady
 	}
 	var (
@@ -983,52 +978,59 @@ func (a *Aggregator) buildFiles(ctx context.Context, step kv.Step) error {
 	return nil
 }
 
-func (a *Aggregator) readyForCollation(ctx context.Context, step kv.Step) (lastBlockInStep, lastBlockInDB, lastTxInDB uint64, ok bool, err error) {
-	if a.reorgBlockDepth == 0 {
-		return 0, 0, 0, true, nil
+func (a *Aggregator) readyForCollation(ctx context.Context, step kv.Step) (ok bool, err error) {
+	if a.reorgBlockDepth == 0 && a.frozenBlocks == nil {
+		return true, nil
 	}
 	a.commitGate.RLock()
 	defer a.commitGate.RUnlock()
 
+	if a.frozenBlocks != nil {
+		var capTxNum, lstTxNum uint64
+		if err := a.db.View(ctx, func(tx kv.Tx) error {
+			var err error
+			capTxNum, err = rawdbv3.TxNums.Max(ctx, tx, a.frozenBlocks.FrozenBlocks())
+			if err != nil {
+				return err
+			}
+			lst, _ := kv.LastKey(tx, kv.TblAccountHistoryKeys)
+			if len(lst) >= 8 {
+				lstTxNum = binary.BigEndian.Uint64(lst)
+			}
+			return nil
+		}); err != nil {
+			return false, fmt.Errorf("read max collatable txNum: %w", err)
+		}
+		if uint64(step+1)*a.StepSize() > capTxNum {
+			a.logger.Info("[snapshots] holding state collation at block snapshot boundary",
+				"blockSnapshotsStepCompleted", capTxNum/a.StepSize()-1,
+				"lastCollatableStepInDB", lstTxNum/a.StepSize())
+			return false, nil
+		}
+		return true, nil
+	}
+
+	// frozenBlocks == nil && reorgBlockDepth > 0: legacy safety net.
+	var lastBlockInStep, lastBlockInDB uint64
 	err = a.db.View(ctx, func(tx kv.Tx) error {
-		lastBlockInStep, ok, err = rawdbv3.TxNums.FindBlockNum(ctx, tx, lastTxNumOfStep(step, a.stepSize.Load()))
+		var found bool
+		lastBlockInStep, found, err = rawdbv3.TxNums.FindBlockNum(ctx, tx, lastTxNumOfStep(step, a.stepSize.Load()))
 		if err != nil {
 			return err
 		}
-		if !ok {
+		if !found {
 			lastBlockInStep = 0
 		}
-		lastBlockInDB, lastTxInDB, err = rawdbv3.TxNums.Last(tx)
+		lastBlockInDB, _, err = rawdbv3.TxNums.Last(tx)
 		return err
 	})
 	if err != nil {
-		return 0, 0, 0, false, err
+		return false, err
 	}
-	if a.frozenBlocks != nil {
-		var capTxNum uint64
-		if err = a.db.View(ctx, func(tx kv.Tx) error {
-			var err error
-			capTxNum, err = rawdbv3.TxNums.Max(ctx, tx, a.frozenBlocks.FrozenBlocks())
-			return err
-		}); err != nil {
-			return 0, 0, 0, false, fmt.Errorf("read max collatable txNum: %w", err)
-		}
-		if uint64(step+1)*a.StepSize() > capTxNum {
-			lastStepInDb := kv.Step(lastTxInDB / a.StepSize())
-			a.logger.Info("[snapshots] holding state collation at block snapshot boundary",
-				"blockSnapshotsStepCompleted", capTxNum/a.StepSize()-1,
-				"lastCollatableStepInDb", lastStepInDb-1)
-			return 0, 0, 0, false, nil
-		}
-	}
-	ok = err == nil && lastBlockInDB > lastBlockInStep+a.reorgBlockDepth
-	return
+	return lastBlockInDB > lastBlockInStep+a.reorgBlockDepth, nil
 }
 
 func (a *Aggregator) BuildFiles(toTxNum uint64) (err error) {
-	if cap := a.maxCollationTxNum.Load(); cap > 0 && toTxNum > cap {
-		toTxNum = cap
-	}
 	finished := a.buildFilesInBackground(toTxNum, true)
 	if !(a.buildingFiles.Load() || a.mergingFiles.Load()) {
 		return nil
@@ -1569,20 +1571,6 @@ func (a *Aggregator) StepsInDB(ctx context.Context, db kv.RoDB) (float64, error)
 	return steps, nil
 }
 
-// CollateAndPruneIfNeeded runs synchronous collate when stepsInDB exceeds
-// 1.5 steps, looping until it drops to 1 or below. Then runs prune in a
-// separate transaction so MDBX GC can reclaim freed pages.
-// This prevents step accumulation during initial sync when background
-// collate can't keep up with execution throughput.
-// SetMaxCollationTxNum caps all collation (BuildFiles, CollateAndPruneIfNeeded)
-// to not extend past the given txNum. Use this when block snapshot files don't
-// cover all txNums (e.g. --no-downloader or lagging block file builder).
-// Set to 0 to remove the cap.
-func (a *Aggregator) SetMaxCollationTxNum(txNum uint64) { a.maxCollationTxNum.Store(txNum) }
-
-// MaxCollationTxNum returns the current collation cap (0 = uncapped).
-func (a *Aggregator) MaxCollationTxNum() uint64 { return a.maxCollationTxNum.Load() }
-
 // SetLastFlushedCommitmentTxNum records the highest txNum at which commitment
 // data has been flushed to MDBX. Call after each commit that includes
 // commitment writes (step boundary or batch-end commitment).
@@ -1619,83 +1607,19 @@ func (a *Aggregator) UnlockCollation() { a.commitGate.Unlock() }
 // around BeginTemporalRw to drain old readers.
 func (a *Aggregator) CommitGate() *sync.RWMutex { return &a.commitGate }
 
-// CollateAndPrune kicks background file building and prunes already-collated
-// steps until stepsInDB drops to the target range. This is the single entry
-// point for collation+prune — called from both ProcessFrozenBlocks and FCU.
-//
-// The pattern: kick BuildFilesInBackground, then loop pruning what's available
-// while waiting for collation to produce more files. Exits when stepsInDB ≤
-// targetSteps or no progress is made.
+// CollateAndPrune runs a single prune pass and kicks background file
+// building. The block-snapshot-boundary gate inside readyForCollation
+// keeps state files from extending past block files, so no external cap
+// is needed.
 func (a *Aggregator) CollateAndPrune(ctx context.Context, db kv.TemporalRwDB, pruneFn func(tx kv.TemporalRwTx) error, logger log.Logger) error {
-	const targetSteps = 1.5
-
-	// Kick background collation, capped to maxCollationTxNum if set.
-	// This cap (set by the caller from FrozenBlocks/TxNums boundary)
-	// prevents state files from extending past block files.
-	toTxNum := a.EndTxNumMinimax() + a.StepSize()
-	if cap := a.maxCollationTxNum.Load(); cap > 0 && toTxNum > cap {
-		toTxNum = cap
-	}
-	a.BuildFilesInBackground(toTxNum)
-
-	prevSteps := float64(0)
-	for {
-		// Prune already-collated steps. RunPrune includes block retirement
-		// which advances FrozenBlocks, so update the collation cap after.
-		err := func() error {
-			a.commitGate.Lock()
-			defer a.commitGate.Unlock()
-			return db.UpdateTemporal(ctx, pruneFn)
-		}()
-		if err != nil {
-			return err
-		}
-
-		stepsInDB, err := a.StepsInDB(ctx, db)
-		if err != nil || stepsInDB <= targetSteps {
-			return nil
-		}
-
-		// No progress — collation can't produce files (e.g., blocks not
-		// yet retired, or cap prevents collation). Exit to let execution
-		// continue and retry next cycle.
-		if stepsInDB >= prevSteps && prevSteps > 0 {
-			return nil
-		}
-		prevSteps = stepsInDB
-
-		// Kick next step build if not already running.
-		// Re-read cap since block retirement may have advanced it.
-		toTxNum = a.EndTxNumMinimax() + a.StepSize()
-		if cap := a.maxCollationTxNum.Load(); cap > 0 && toTxNum > cap {
-			toTxNum = cap
-		}
-		a.BuildFilesInBackground(toTxNum)
-
-		// Brief wait for collation to produce the next file.
-		time.Sleep(100 * time.Millisecond)
-	}
-}
-
-// CollateAndPruneIfNeeded is a backwards-compatible wrapper that only
-// runs collation+prune when stepsInDB exceeds the threshold.
-func (a *Aggregator) CollateAndPruneIfNeeded(ctx context.Context, db kv.TemporalRwDB, pruneFn func(tx kv.TemporalRwTx) error, logger log.Logger) error {
-	// Always kick background collation — at the tip this keeps file
-	// building progressing even when stepsInDB is below the threshold.
-	toTxNum := a.EndTxNumMinimax() + a.StepSize()
-	a.BuildFilesInBackground(toTxNum)
-
-	stepsInDB, err := a.StepsInDB(ctx, db)
+	a.commitGate.Lock()
+	err := db.UpdateTemporal(ctx, pruneFn)
+	a.commitGate.Unlock()
 	if err != nil {
 		return err
 	}
-	if stepsInDB <= 1.5 {
-		// Still run one prune pass for any already-collated data.
-		a.commitGate.Lock()
-		defer a.commitGate.Unlock()
-		return db.UpdateTemporal(ctx, pruneFn)
-	}
-	return a.CollateAndPrune(ctx, db, pruneFn, logger)
+	a.BuildFilesInBackground(a.EndTxNumMinimax() + a.StepSize())
+	return nil
 }
 func (a *Aggregator) FilesAmount() (res []int) {
 	for _, d := range a.d {
@@ -2227,14 +2151,6 @@ func (a *Aggregator) buildFilesInBackground(txNum uint64, doMerge bool) chan str
 						"Removing only the snapshots is not enough: an earlier build may have already populated chaindata with values read from a corrupt snapshot file.")
 				close(fin)
 				return
-			}
-		}
-
-		// Cap to maxCollationTxNum if set (prevents domain files extending past block files).
-		if cap := a.maxCollationTxNum.Load(); cap > 0 {
-			maxStep := kv.Step(cap / a.StepSize())
-			if lastInDB > maxStep {
-				lastInDB = maxStep
 			}
 		}
 

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -94,13 +94,6 @@ type Aggregator struct {
 	ctx       context.Context
 	ctxCancel context.CancelFunc
 
-	// lastFlushedCommitmentTxNum is the highest txNum at which commitment
-	// data (branch nodes, state key) has been flushed to MDBX. Collation
-	// must not proceed for a step unless the step's commitment boundary has
-	// been flushed — otherwise the collated file captures pre-computation
-	// branch data that differs from the final MDBX state.
-	lastFlushedCommitmentTxNum atomic.Uint64
-
 	// commitGate serializes background db.View() txs against commit+prune.
 	// Background readers (collation, sentry, etc.) hold RLock; commit+prune
 	// path holds Lock (exclusive). This ensures no background RO tx is open
@@ -1571,13 +1564,6 @@ func (a *Aggregator) StepsInDB(ctx context.Context, db kv.RoDB) (float64, error)
 	return steps, nil
 }
 
-// SetLastFlushedCommitmentTxNum records the highest txNum at which commitment
-// data has been flushed to MDBX. Call after each commit that includes
-// commitment writes (step boundary or batch-end commitment).
-func (a *Aggregator) SetLastFlushedCommitmentTxNum(txNum uint64) {
-	a.lastFlushedCommitmentTxNum.Store(txNum)
-}
-
 // MaxPrunableStepsBacklog returns the largest prunable-step count across the
 // state domains (accounts, storage, code, commitment). Used by FCU to size
 // the prune-cycle budget — a larger backlog gets more time. Reads the same
@@ -2151,22 +2137,6 @@ func (a *Aggregator) buildFilesInBackground(txNum uint64, doMerge bool) chan str
 						"Removing only the snapshots is not enough: an earlier build may have already populated chaindata with values read from a corrupt snapshot file.")
 				close(fin)
 				return
-			}
-		}
-
-		// Cap to the last fully-flushed step. Step S is safe to collate only
-		// when all data through its end boundary has been flushed to MDBX.
-		// Without this, collation captures partial step data — when prune
-		// later deletes the MDBX entry, the incomplete file value becomes
-		// authoritative, causing silent state corruption.
-		if flushedTxNum := a.lastFlushedCommitmentTxNum.Load(); flushedTxNum > 0 {
-			stepSize := a.StepSize()
-			// Mirror stepFullyCommitted: step S is fully committed iff
-			// flushedTxNum+1 >= (S+1)*stepSize. The exclusive upper bound on
-			// safe-to-build steps is therefore (flushedTxNum+1)/stepSize.
-			safeStep := kv.Step((flushedTxNum + 1) / stepSize)
-			if lastInDB > safeStep {
-				lastInDB = safeStep
 			}
 		}
 

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -2161,9 +2161,11 @@ func (a *Aggregator) buildFilesInBackground(txNum uint64, doMerge bool) chan str
 		// authoritative, causing silent state corruption.
 		if flushedTxNum := a.lastFlushedCommitmentTxNum.Load(); flushedTxNum > 0 {
 			stepSize := a.StepSize()
-			// The highest step S where (S+1)*stepSize <= flushedTxNum
-			safeStep := kv.Step(flushedTxNum/stepSize) - 1
-			if flushedTxNum >= stepSize && lastInDB > safeStep {
+			// Mirror stepFullyCommitted: step S is fully committed iff
+			// flushedTxNum+1 >= (S+1)*stepSize. The exclusive upper bound on
+			// safe-to-build steps is therefore (flushedTxNum+1)/stepSize.
+			safeStep := kv.Step((flushedTxNum + 1) / stepSize)
+			if lastInDB > safeStep {
 				lastInDB = safeStep
 			}
 		}

--- a/execution/execmodule/executor.go
+++ b/execution/execmodule/executor.go
@@ -234,11 +234,7 @@ func (pe *PipelineExecutor) ProcessFrozenBlocks(ctx context.Context, hook *stage
 			// snapshot files advance as PFB processes frozen blocks.
 			if hasAgg, ok := pe.db.(dbstate.HasAgg); ok {
 				if agg, ok := hasAgg.Agg().(*dbstate.Aggregator); ok && agg != nil {
-					toTxNum := agg.EndTxNumMinimax() + agg.StepSize()
-					if cap := agg.MaxCollationTxNum(); cap > 0 && toTxNum > cap {
-						toTxNum = cap
-					}
-					agg.BuildFilesInBackground(toTxNum)
+					agg.BuildFilesInBackground(agg.EndTxNumMinimax() + agg.StepSize())
 				}
 			}
 			// Last iter: skip BeginTemporalRw — no next iter will use it.

--- a/execution/execmodule/forkchoice.go
+++ b/execution/execmodule/forkchoice.go
@@ -831,35 +831,6 @@ func (e *ExecModule) runForkchoiceFlushCommit(sd *execctx.SharedDomains, roTxToC
 	}
 	timings = append(timings, "commit", common.Round(time.Since(commitStart), 0))
 
-	// Track the highest fully-flushed commitment txNum so the aggregator's
-	// collation safety cap (aggregator.go: stepFullyCommitted gate) advances
-	// during normal FCU operation. Without this update, the cap stays at its
-	// initial-cycle value forever and `lastFlushedCommitmentTxNum > 0` guard
-	// at aggregator.go:2140 stops capping correctly — the calculator-port
-	// flushes through commitment domain into MDBX every commit but the
-	// aggregator never learns about it. Mirrors stageloop.go:266.
-	if hasAgg, ok := e.db.(dbstate.HasAgg); ok {
-		if agg, ok := hasAgg.Agg().(*dbstate.Aggregator); ok && agg != nil {
-			if verifyTx, verifyErr := e.db.BeginTemporalRo(e.bacgroundCtx); verifyErr == nil { //nolint:gocritic // Rollback below; defer would shadow named-tx scope
-				defer verifyTx.Rollback() //nolint:gocritic // safety net alongside the explicit Rollback below
-				v, _, getErr := verifyTx.GetLatest(kv.CommitmentDomain, commitmentdb.KeyCommitmentState)
-				if getErr != nil {
-					// Log but do not fail FCU — aggregator stays at its prior watermark; the
-					// next commit's GetLatest will retry. Silent failure here is what motivated
-					// this fix in the first place: a stale watermark caused the aggregator to
-					// never learn about flushes and broke collation capping.
-					e.logger.Warn("[fcu] SetLastFlushedCommitmentTxNum: GetLatest failed; aggregator watermark unchanged", "err", getErr)
-				} else if len(v) >= 16 {
-					committedTxNum, _ := commitmentdb.DecodeTxBlockNums(v)
-					agg.SetLastFlushedCommitmentTxNum(committedTxNum)
-				}
-				verifyTx.Rollback()
-			} else {
-				e.logger.Warn("[fcu] SetLastFlushedCommitmentTxNum: BeginTemporalRo failed; aggregator watermark unchanged", "err", verifyErr)
-			}
-		}
-	}
-
 	// Update head and announce block range (notifications already dispatched).
 	if e.hook != nil {
 		if err := e.db.View(e.bacgroundCtx, func(tx kv.Tx) error {

--- a/execution/execmodule/forkchoice.go
+++ b/execution/execmodule/forkchoice.go
@@ -888,7 +888,7 @@ func (e *ExecModule) runForkchoicePrune(initialCycle bool) ([]any, error) {
 	// keeps writing to MDBX above the file boundary, but no new file is
 	// built so the data above never becomes prunable. Result: MDBX grows
 	// unbounded (commitment domain especially) until the next initial-cycle
-	// trip through StageLoopIteration. CollateAndPruneIfNeeded internally
+	// trip through StageLoopIteration. CollateAndPrune internally
 	// opens its own RW tx and calls the pruneFn callback inside it.
 	if hasAgg, ok := e.db.(dbstate.HasAgg); ok {
 		if agg, ok := hasAgg.Agg().(*dbstate.Aggregator); ok && agg != nil {
@@ -900,7 +900,7 @@ func (e *ExecModule) runForkchoicePrune(initialCycle bool) ([]any, error) {
 			if pruneTimeout > maxTimeout {
 				pruneTimeout = maxTimeout
 			}
-			if err := agg.CollateAndPruneIfNeeded(e.bacgroundCtx, e.db, func(tx kv.TemporalRwTx) error {
+			if err := agg.CollateAndPrune(e.bacgroundCtx, e.db, func(tx kv.TemporalRwTx) error {
 				return e.pipelineExecutor.RunPrune(e.bacgroundCtx, tx, initialCycle, pruneTimeout)
 			}, e.logger); err != nil {
 				return nil, err

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -138,7 +138,7 @@ func newCommitmentCalculator(
 	// roTx lives for the calculator's lifetime — rolled back in Stop(), not
 	// deferred here. Safe across collate/prune cycles because the calculator
 	// is constructed in pe.exec() and its `defer Stop()` runs *before* the
-	// stageloop's rwTx.Commit(), and CollateAndPruneIfNeeded only fires
+	// stageloop's rwTx.Commit(), and CollateAndPrune only fires
 	// between batches via FCU. So this roTx never spans a prune — by the
 	// time prune holds commitGate.Lock(), Stop() has already rolled this tx
 	// back and the calculator goroutine is gone.

--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -136,18 +136,9 @@ func ExecV3(ctx context.Context,
 		return nil
 	}
 
-	if execStage.SyncMode() == stages.ModeApplyingBlocks {
-		// Cap collation to the max txNum covered by block files.
-		// Without this, collation creates domain files past the block
-		// file boundary, causing "behind commitment" errors.
-		if maxTxNum, err := cfg.blockReader.TxnumReader().Max(ctx, rwTx, maxBlockNum); err == nil && maxTxNum > 0 {
-			agg.SetMaxCollationTxNum(maxTxNum)
-		}
-		// Background collation removed from exec code — collation is now managed
-		// by CollateAndPruneIfNeeded in the FCU/stage loop (forkchoice.go).
-		// This avoids background collation db.View() txs overlapping with
-		// commit+prune, which prevented MDBX GC page reclamation.
-	}
+	// Background collation removed from exec code — collation is now managed
+	// by CollateAndPrune in the FCU/stage loop (forkchoice.go).
+	// Block-snapshot boundary gating happens inside readyForCollation.
 
 	var (
 		inputTxNum               uint64

--- a/execution/stagedsync/stageloop/stageloop.go
+++ b/execution/stagedsync/stageloop/stageloop.go
@@ -211,13 +211,6 @@ func ProcessFrozenBlocks(ctx context.Context, db kv.TemporalRwDB, blockReader se
 		// Collate+prune OLD data (its own RwTx).
 		if a, ok := db.(state.HasAgg); ok {
 			agg := a.Agg().(*state.Aggregator)
-			if capRoTx, capErr := db.BeginTemporalRo(ctx); capErr == nil {
-				if maxTxNum, e := rawdbv3.TxNums.Max(ctx, capRoTx, blockReader.FrozenBlocks()); e == nil && maxTxNum > 0 {
-					stepSize := agg.StepSize()
-					agg.SetMaxCollationTxNum((maxTxNum / stepSize) * stepSize)
-				}
-				capRoTx.Rollback()
-			}
 			if err := agg.CollateAndPrune(ctx, db, func(pruneTx kv.TemporalRwTx) error {
 				return sync.RunPrune(ctx, pruneTx, initialCycle, 0)
 			}, logger); err != nil {
@@ -376,7 +369,7 @@ func StageLoopIteration(ctx context.Context, db kv.TemporalRwDB, sync *stagedsyn
 		// Collate (if steps accumulated) + prune in separate transaction.
 		if a, ok := db.(state.HasAgg); ok {
 			agg := a.Agg().(*state.Aggregator)
-			if err := agg.CollateAndPruneIfNeeded(ctx, db, func(tx kv.TemporalRwTx) error {
+			if err := agg.CollateAndPrune(ctx, db, func(tx kv.TemporalRwTx) error {
 				return sync.RunPrune(ctx, tx, initialCycle, 0)
 			}, logger); err != nil {
 				return err

--- a/execution/stagedsync/stageloop/stageloop.go
+++ b/execution/stagedsync/stageloop/stageloop.go
@@ -18,7 +18,6 @@ package stageloop
 
 import (
 	"context"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"runtime"
@@ -36,7 +35,6 @@ import (
 	"github.com/erigontech/erigon/db/state"
 	"github.com/erigontech/erigon/db/state/execctx"
 	"github.com/erigontech/erigon/execution/chain"
-	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
 	"github.com/erigontech/erigon/execution/exec"
 	"github.com/erigontech/erigon/execution/metrics"
 	execp2p "github.com/erigontech/erigon/execution/p2p"
@@ -258,27 +256,6 @@ func ProcessFrozenBlocks(ctx context.Context, db kv.TemporalRwDB, blockReader se
 		if a, ok := db.(state.HasAgg); ok {
 			a.Agg().(*state.Aggregator).UnlockCollation()
 			collationLocked = false
-		}
-
-		// Read the actual committed txNum from the DB "state" key.
-		// This is the authoritative source for what's been committed —
-		// use it to cap collation so files don't capture uncommitted data.
-		if verifyTx, verifyErr := db.BeginTemporalRo(ctx); verifyErr == nil {
-			v, _, getErr := verifyTx.GetLatest(kv.CommitmentDomain, commitmentdb.KeyCommitmentState)
-			if getErr != nil {
-				// Log but continue — aggregator stays at its prior watermark; the next iteration
-				// will retry. Silent failure here is the failure mode that motivated the fix:
-				// without the watermark refresh, collation files capture uncommitted data.
-				logger.Warn("[stageloop frozen] SetLastFlushedCommitmentTxNum: GetLatest failed; aggregator watermark unchanged", "err", getErr)
-			} else if len(v) >= 16 {
-				committedTxNum := binary.BigEndian.Uint64(v[:8])
-				if a, ok := db.(state.HasAgg); ok {
-					a.Agg().(*state.Aggregator).SetLastFlushedCommitmentTxNum(committedTxNum)
-				}
-			}
-			verifyTx.Rollback()
-		} else {
-			logger.Warn("[stageloop frozen] SetLastFlushedCommitmentTxNum: BeginTemporalRo failed; aggregator watermark unchanged", "err", verifyErr)
 		}
 
 		// Reopen RO tx and reinit block overlay on same doms.


### PR DESCRIPTION
issue: #21326.


  ## Summary
  - The `reorgBlockDepth` gate is skipped when `frozenBlocks` is wired (block-snapshot retirement already factors `reorgBlockDepth` in, so the boundary check transitively inherits it). The legacy `reorgBlockDepth>0 + frozenBlocks=nil` arm is preserved.
    - bloatnet has `frozenBlocks` disabled -- that's why reorgBlockDepth is still maintained. Might be possible to remove once some decisions on https://github.com/erigontech/erigon/issues/21366 is made.
  - `CollateAndPrune` collapsed to one prune + one `BuildFilesInBackground` call. `targetSteps=1.5`, the spin loop, and `CollateAndPruneIfNeeded` are gone — the inner `buildFilesInBackground` loop already drains every uncollated step in DB per invocation.
  - `SetMaxCollationTxNum` / `MaxCollationTxNum` / `maxCollationTxNum` atomic removed. The block-snapshot boundary gate inside `readyForCollation` is the single source of truth for "don't collate past block files"; the three external cap callers (`exec3.go`, `stageloop.go`, `executor.go`) were either redundant with that gate or strictly more permissive.
  -  `lastFlushedCommitmentTxNum` removed; `stepFullyCommitted` -- does the same thing. So it was a duplicate mechanism. I'm sceptical of `stepFullyCommitted` too, but not convinced enough to remove it.
  -  `readyForCollation` now reads `lastCollatableStepInDB` from `TblAccountHistoryKeys.LastKey` (matches `StepsInDB`) instead of `TxNums.Last`, which actually reflected chain head and made the log line misleading. 

  ## Test plan
  - [x] `make lint` (two passes, 0 issues)
  - [x] `make erigon integration` (clean build)
  - [x] Smoke test on mirrored mainnet minimal datadir: `stepsInDB` stayed ~1.5, `holding state collation at block snapshot boundary`
  fired with the renamed `lastCollatableStepInDB` field, no errors/panics. Cap math verified: step 9059 collated (allowed), step 9060
  held (`(9060+1)*stepSize > capTxNum`).
  - [ ] CI: full test suite + race
