### PR TITLE
txnprovider/shutter: follow up update for EIP-8037

### DIFF
--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -852,6 +852,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 		backend.shutterPool = shutter.NewPool(
 			logger,
 			config.Shutter,
+			backend.chainConfig,
 			baseTxnProvider,
 			contractBackend,
 			backend.stateDiffClient,

--- a/txnprovider/shutter/pool.go
+++ b/txnprovider/shutter/pool.go
@@ -29,6 +29,8 @@ import (
 
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/execution/abi/bind"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/protocol/mdgas"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/txnprovider"
 	"github.com/erigontech/erigon/txnprovider/shutter/internal/proto"
@@ -40,6 +42,7 @@ var _ txnprovider.TxnProvider = (*Pool)(nil)
 type Pool struct {
 	logger                  log.Logger
 	config                  shuttercfg.Config
+	chainConfig             *chain.Config
 	baseTxnProvider         txnprovider.TxnProvider
 	blockListener           *BlockListener
 	blockTracker            *BlockTracker
@@ -55,6 +58,7 @@ type Pool struct {
 func NewPool(
 	logger log.Logger,
 	config shuttercfg.Config,
+	chainConfig *chain.Config,
 	baseTxnProvider txnprovider.TxnProvider,
 	contractBackend bind.ContractBackend,
 	stateChangesClient stateChangesClient,
@@ -100,6 +104,7 @@ func NewPool(
 	return &Pool{
 		logger:                  logger,
 		config:                  config,
+		chainConfig:             chainConfig,
 		blockListener:           blockListener,
 		blockTracker:            blockTracker,
 		eonTracker:              eonTracker,
@@ -280,12 +285,9 @@ func (p *Pool) ProvideTxns(ctx context.Context, opts ...txnprovider.ProvideOptio
 		return p.baseTxnProvider.ProvideTxns(ctx, opts...)
 	}
 
-	// TODO(yperbasis): revisit Shutter gas filtering for EIP-8037.
-	// The shutter pool lacks chain config to compute intrinsic state gas,
-	// so txn.GetGasLimit() is used as a conservative proxy for both
-	// dimensions. State gas enforcement ultimately relies on best() in
-	// the base txpool (for additional public txns) and applyTransaction
-	// (for all txns).
+	isAmsterdam := p.chainConfig.IsAmsterdam(blockTime)
+	isEIP3860 := p.chainConfig.IsShanghai(blockTime)
+	isEIP7623 := p.chainConfig.IsPrague(blockTime)
 	availableGas := provideOpts.GasTarget
 	txnsIdFilter := provideOpts.TxnIdsFilter
 	txns := make([]types.Transaction, 0, len(decryptedTxns.Transactions))
@@ -294,15 +296,77 @@ func (p *Pool) ProvideTxns(ctx context.Context, opts ...txnprovider.ProvideOptio
 		if txnsIdFilter != nil && txnsIdFilter.Contains(txn.Hash()) {
 			continue
 		}
-		gasLimit := txn.GetGasLimit()
-		blobGas := txn.GetBlobGas()
-		if gasLimit > availableGas.Regular || gasLimit > availableGas.State || blobGas > availableGas.Blob {
+		accessList := txn.GetAccessList()
+		intrinsicGasResult, overflow := mdgas.IntrinsicGas(mdgas.IntrinsicGasCalcArgs{
+			Data:               txn.GetData(),
+			AuthorizationsLen:  uint64(len(txn.GetAuthorizations())),
+			AccessListLen:      uint64(len(accessList)),
+			StorageKeysLen:     uint64(accessList.StorageKeys()),
+			IsContractCreation: txn.IsContractDeploy(),
+			IsEIP2:             true,
+			IsEIP2028:          true,
+			IsEIP3860:          isEIP3860,
+			IsEIP7623:          isEIP7623,
+			IsEIP7976:          isAmsterdam,
+			IsEIP7981:          isAmsterdam,
+			IsEIP8037:          isAmsterdam,
+			IsAATxn:            txn.Type() == types.AccountAbstractionTxType,
+		})
+		if overflow {
+			sender, _ := txn.GetSender()
+			p.logger.Warn(
+				"skipping decrypted txn with intrinsic gas overflow",
+				"hash", txn.Hash(),
+				"type", txn.Type(),
+				"sender", sender,
+			)
 			continue
 		}
-		availableGas.Regular -= gasLimit
-		availableGas.State -= gasLimit
+		intrinsicRegularGas := intrinsicGasResult.RegularGas
+		if isEIP7623 && intrinsicGasResult.FloorGasCost > intrinsicRegularGas {
+			intrinsicRegularGas = intrinsicGasResult.FloorGasCost
+		}
+		blobGas := txn.GetBlobGas()
+		if intrinsicRegularGas > availableGas.Regular {
+			sender, _ := txn.GetSender()
+			p.logger.Warn(
+				"skipping decrypted txn: insufficient regular gas",
+				"hash", txn.Hash(),
+				"type", txn.Type(),
+				"sender", sender,
+				"intrinsicRegularGas", intrinsicRegularGas,
+				"availableRegular", availableGas.Regular,
+			)
+			continue
+		}
+		if intrinsicGasResult.StateGas > availableGas.State {
+			sender, _ := txn.GetSender()
+			p.logger.Warn(
+				"skipping decrypted txn: insufficient state gas",
+				"hash", txn.Hash(),
+				"type", txn.Type(),
+				"sender", sender,
+				"intrinsicStateGas", intrinsicGasResult.StateGas,
+				"availableState", availableGas.State,
+			)
+			continue
+		}
+		if blobGas > availableGas.Blob {
+			sender, _ := txn.GetSender()
+			p.logger.Warn(
+				"skipping decrypted txn: insufficient blob gas",
+				"hash", txn.Hash(),
+				"type", txn.Type(),
+				"sender", sender,
+				"blobGas", blobGas,
+				"availableBlob", availableGas.Blob,
+			)
+			continue
+		}
+		availableGas.Regular -= intrinsicRegularGas
+		availableGas.State -= intrinsicGasResult.StateGas
 		availableGas.Blob -= blobGas
-		decryptedTxnsGas += gasLimit
+		decryptedTxnsGas += txn.GetGasLimit()
 		txns = append(txns, txn)
 		if txnsIdFilter != nil {
 			txnsIdFilter.Add(txn.Hash())

--- a/txnprovider/shutter/pool_test.go
+++ b/txnprovider/shutter/pool_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/common/testlog"
 	"github.com/erigontech/erigon/execution/abi"
+	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/chain/networkname"
 	"github.com/erigontech/erigon/execution/protocol/mdgas"
 	"github.com/erigontech/erigon/execution/types"
@@ -311,6 +312,56 @@ func TestPoolProvideTxnsUsesGasTargetAndTxnsIdFilter(t *testing.T) {
 }
 
 //goland:noinspection DuplicatedCode
+func TestPoolProvideTxnsFiltersByIntrinsicGasNotFullGasLimit(t *testing.T) {
+	// EIP-8037: gas filtering uses intrinsic regular/state gas per dimension,
+	// not the full txn gas limit. A txn whose gas limit exceeds availableGas
+	// in one dimension must still be included as long as its intrinsic gas
+	// fits. Execution-time state gas is enforced later by applyTransaction.
+	t.Parallel()
+	pt := PoolTest{t}
+	pt.Run(func(ctx context.Context, t *testing.T, pool *shutter.Pool, handle PoolTestHandle) {
+		ekg, err := testhelpers.MockEonKeyGeneration(shutter.EonIndex(0), 1, 2, 1)
+		require.NoError(t, err)
+		handle.SimulateInitialEonRead(t, ekg)
+		handle.SimulateFilterLogs(common.HexToAddress(handle.config.SequencerContractAddress), []types.Log{})
+		err = handle.SimulateNewBlockChange(ctx)
+		require.NoError(t, err)
+		synctest.Wait()
+		// A simple transfer has intrinsic regular gas of TxGas=21_000 and
+		// intrinsic state gas of 0 — but its declared gas limit is 100_000.
+		const txnGasLimit uint64 = 100_000
+		encTxn := MockEncryptedTxn(t, handle.config.ChainId, ekg.Eon(), MockWithGasLimit(txnGasLimit))
+		err = handle.SimulateLogEvents(ctx, []types.Log{
+			MockTxnSubmittedEventLog(t, handle.config, ekg.Eon(), 1, encTxn),
+		})
+		require.NoError(t, err)
+		handle.SimulateCachedEonRead(t, ekg)
+		err = handle.SimulateNewBlockChange(ctx)
+		require.NoError(t, err)
+		synctest.Wait()
+		require.Len(t, pool.AllEncryptedTxns(), 1)
+		handle.SimulateCurrentSlot()
+		handle.SimulateDecryptionKeys(ctx, t, ekg, 1, encTxn.IdentityPreimage)
+		synctest.Wait()
+		require.Len(t, pool.AllDecryptedTxns(), 1)
+		// Budget enough regular gas for the intrinsic (21_000) but strictly
+		// less than the txn's declared gas limit (100_000), and zero state
+		// gas. The pre-fix logic compared txn.GetGasLimit() against both
+		// dimensions and would have rejected this txn; the EIP-8037 logic
+		// accepts it because intrinsic gas fits.
+		txns, err := pool.ProvideTxns(
+			ctx,
+			txnprovider.WithBlockTime(handle.nextBlockTime),
+			txnprovider.WithParentBlockNum(handle.nextBlockNum-1),
+			txnprovider.WithGasTarget(mdgas.NewFullMdGas(50_000, 0, 0)),
+		)
+		require.NoError(t, err)
+		require.Len(t, txns, 1)
+		require.Equal(t, encTxn.OriginalTxn.Hash(), txns[0].Hash())
+	})
+}
+
+//goland:noinspection DuplicatedCode
 func TestPoolWithDecryptionKeysThatDoNotFollowTxnIndexOrder(t *testing.T) {
 	// see https://github.com/erigontech/erigon/issues/18780
 	t.Parallel()
@@ -375,6 +426,7 @@ func (t PoolTest) Run(testCase func(ctx context.Context, t *testing.T, pool *shu
 		pool := shutter.NewPool(
 			logger,
 			config,
+			chain.AllProtocolChanges,
 			baseTxnProvider,
 			contractBackend,
 			stateChangesClient,
@@ -895,8 +947,14 @@ func MockTxnSubmittedEventData(
 	return data
 }
 
+type MockEncryptedTxnOption func(*types.LegacyTx)
+
+func MockWithGasLimit(gasLimit uint64) MockEncryptedTxnOption {
+	return func(tx *types.LegacyTx) { tx.GasLimit = gasLimit }
+}
+
 //goland:noinspection DuplicatedCode
-func MockEncryptedTxn(t *testing.T, chainId *uint256.Int, eon shutter.Eon) testhelpers.EncryptedSubmission {
+func MockEncryptedTxn(t *testing.T, chainId *uint256.Int, eon shutter.Eon, opts ...MockEncryptedTxnOption) testhelpers.EncryptedSubmission {
 	senderPrivKey, err := crypto.GenerateKey()
 	require.NoError(t, err)
 	senderAddr := crypto.PubkeyToAddress(senderPrivKey.PublicKey)
@@ -908,6 +966,9 @@ func MockEncryptedTxn(t *testing.T, chainId *uint256.Int, eon shutter.Eon) testh
 			Value:    *uint256.NewInt(123),
 		},
 		GasPrice: *uint256.NewInt(555),
+	}
+	for _, opt := range opts {
+		opt(txn)
 	}
 	signer := types.LatestSignerForChainID(chainId)
 	signedTxn, err := types.SignTx(txn, *signer, senderPrivKey)


### PR DESCRIPTION
## Summary

Addresses the `TODO(yperbasis): revisit Shutter gas filtering for EIP-8037` in `txnprovider/shutter/pool.go`.

## Why

The Shutter pool previously used `txn.GetGasLimit()` as a conservative proxy for both regular and state gas dimensions because it lacked access to the chain config needed to compute intrinsic gas. Two problems:

- Over-conservative: it deducted the full gas limit from both `availableGas.Regular` and `availableGas.State`, and rejected any txn whose gas limit exceeded either dimension — even when the actual intrinsic state gas was 0 (e.g., simple transfers).
- Misaligned with the base txpool's `best()`, which already filters by per-dimension intrinsic gas under EIP-8037.

## What

- Pass `*chain.Config` to `shutter.NewPool` so it can resolve fork flags from block time.
- Replace the `gasLimit`-as-proxy filter with EIP-8037-aware per-dimension intrinsic gas filtering, matching `txpool.best()`:
  - Compute per-dimension intrinsic gas via `mdgas.IntrinsicGas` with the right fork flags (EIP-3860 / 7623 / 7976 / 7981 / 8037).
  - Filter `intrinsicRegularGas` against `availableGas.Regular` and `intrinsicGasResult.StateGas` against `availableGas.State` independently.
  - Deduct only intrinsic gas from each dimension. Execution-time state gas remains enforced by `applyTransaction` in the block assembler.
- Add `Warn` logs at every skip branch (overflow, insufficient regular / state / blob gas) with txn `hash`, `type`, `sender`, plus the relevant intrinsic and available gas values for the failing dimension.
- New test `TestPoolProvideTxnsFiltersByIntrinsicGasNotFullGasLimit` — verified red against the previous code and green against the fix.

## Test plan

- [x] `go test ./txnprovider/shutter/...`
- [x] `make lint`
- [x] `make erigon`
- [x] TDD red/green verified by temporarily restoring the old filter loop
