### PR TITLE
cl: add per-directory spec maps for Caplin consensus code

### DIFF
--- a/cl/CLAUDE.md
+++ b/cl/CLAUDE.md
@@ -6,13 +6,13 @@ the upstream Ethereum consensus specifications, not only against local tests.
 Primary references:
 
 - Consensus specs repository: https://github.com/ethereum/consensus-specs
-- Phase0 fork choice: https://ethereum.github.io/consensus-specs/specs/phase0/fork-choice/
-- Bellatrix fork choice: https://ethereum.github.io/consensus-specs/specs/bellatrix/fork-choice/
-- Deneb fork choice: https://ethereum.github.io/consensus-specs/specs/deneb/fork-choice/
+- Phase0 fork choice: https://ethereum.github.io/consensus-specs/phase0/fork-choice/
+- Bellatrix fork choice: https://ethereum.github.io/consensus-specs/bellatrix/fork-choice/
+- Deneb fork choice: https://ethereum.github.io/consensus-specs/deneb/fork-choice/
 - Electra fork choice changes are inherited through Bellatrix/Deneb `on_block`
   execution-request plumbing and beacon-chain state transition rules.
-- Fulu fork choice: https://ethereum.github.io/consensus-specs/specs/fulu/fork-choice/
-- Gloas fork choice: https://ethereum.github.io/consensus-specs/specs/gloas/fork-choice/
+- Fulu fork choice: https://ethereum.github.io/consensus-specs/fulu/fork-choice/
+- Gloas fork choice: https://ethereum.github.io/consensus-specs/gloas/fork-choice/
 
 ## Forkchoice Spec Map
 
@@ -29,7 +29,7 @@ verified against the Go code in this repository.
 | `get_head.go`: `getFilteredBlockTree`, `getFilterBlockTree` | Phase0 `get_filtered_block_tree`, `filter_block_tree`, `get_voting_source`; Gloas inherits filtered-tree viability |
 | `weight_store.go`, `weight_store_indexed.go`: `GetWeight`, `GetAttestationScore`, `GetProposerScore`, `ShouldApplyProposerBoost`, `IndexVote`, `RemoveVote` | Phase0 `get_weight`, `get_attestation_score`, `get_proposer_score`; Gloas modified `get_weight`, `get_attestation_score`, `should_apply_proposer_boost`, `LatestMessage` indexing |
 | `payload_vote.go`: `notifyPtcMessages`, `applyPayloadAttestationVote` | Gloas `notify_ptc_messages`, `on_payload_attestation_message` vote application |
-| `payload_vote.go`: `isPayloadTimely`, `isPayloadDataAvailable` | Gloas `is_payload_timely`, `is_payload_data_available`; requires local envelope availability plus independent PTC majorities |
+| `payload_vote.go`: `isPayloadTimely`, `isPayloadDataAvailable` | Gloas `payload_timeliness`, `payload_data_availability`; requires local envelope availability plus independent PTC majorities |
 | `payload_vote.go`: `getParentPayloadStatus`, `isParentNodeFull`, `isSupportingVote` | Gloas `get_parent_payload_status`, `is_parent_node_full`, `is_supporting_vote` |
 | `payload_vote.go`: `ShouldExtendPayload`, `getPayloadStatusTiebreaker`, `getNodeChildren`, `validateParentPayloadPath` | Gloas `should_extend_payload`, `get_payload_status_tiebreaker`, `get_node_children`, modified `on_block` parent payload path checks |
 | `timing.go`: `getAttestationDueMs`, `getAggregateDueMs`, `getSyncMessageDueMs`, `getContributionDueMs`, `getPayloadAttestationDueMs` | Phase0 timing helpers; Gloas modified timing helpers and `get_payload_attestation_due_ms` |

--- a/cl/CLAUDE.md
+++ b/cl/CLAUDE.md
@@ -22,7 +22,7 @@ verified against the Go code in this repository.
 | Go file/function | Spec section |
 | --- | --- |
 | `forkchoice.go`: `NewForkChoiceStore` | Phase0 `get_forkchoice_store`; Gloas `get_forkchoice_store` and extended `Store` fields |
-| `forkchoice.go`: `GetRecentExecutionPayloadStatus`, `IsBlobDataAvailable`, pending EL payload helpers | Gloas `Store.payload_states`, `Store.payloads`; Gloas payload-attestation API support; Fulu data-column availability support |
+| `forkchoice.go`: `GetRecentExecutionPayloadStatus`, `IsBlobDataAvailable`, `HasEnvelope`, `ReadEnvelopeFromDisk`, pending EL payload helpers | Gloas `Store`, `on_execution_payload_envelope`; Gloas `Store.payload_states`, `Store.payloads`; Gloas payload-attestation API support; Fulu data-column availability support |
 | `types.go`: `LatestMessage`, `ForkChoiceNode` | Phase0 `LatestMessage`; Gloas modified `LatestMessage`, `ForkChoiceNode` |
 | `get_head.go`: `accountWeights`, `computeVotes`, `getHead`, `GetHead` | Phase0 `get_attestation_score`, `get_weight`, `get_head`; Gloas dispatch boundary for modified `get_head` |
 | `get_head.go`: `getHeadGloas` | Gloas `get_head`, `get_node_children`, `get_weight`, `get_payload_status_tiebreaker` |

--- a/cl/CLAUDE.md
+++ b/cl/CLAUDE.md
@@ -1,0 +1,127 @@
+# Caplin Spec Conformance Review Rules
+
+This directory contains consensus-critical Caplin code. Review changes against
+the upstream Ethereum consensus specifications, not only against local tests.
+
+Primary references:
+
+- Consensus specs repository: https://github.com/ethereum/consensus-specs
+- Phase0 fork choice: https://ethereum.github.io/consensus-specs/specs/phase0/fork-choice/
+- Bellatrix fork choice: https://ethereum.github.io/consensus-specs/specs/bellatrix/fork-choice/
+- Deneb fork choice: https://ethereum.github.io/consensus-specs/specs/deneb/fork-choice/
+- Electra fork choice changes are inherited through Bellatrix/Deneb `on_block`
+  execution-request plumbing and beacon-chain state transition rules.
+- Fulu fork choice: https://ethereum.github.io/consensus-specs/specs/fulu/fork-choice/
+- Gloas fork choice: https://ethereum.github.io/consensus-specs/specs/gloas/fork-choice/
+
+## Forkchoice Spec Map
+
+Use this map when reviewing `cl/phase1/forkchoice/`. Function names below are
+verified against the Go code in this repository.
+
+| Go file/function | Spec section |
+| --- | --- |
+| `forkchoice.go`: `NewForkChoiceStore` | Phase0 `get_forkchoice_store`; Gloas `get_forkchoice_store` and extended `Store` fields |
+| `forkchoice.go`: `GetRecentExecutionPayloadStatus`, `IsBlobDataAvailable`, pending EL payload helpers | Gloas `Store.payload_states`, `Store.payloads`; Gloas payload-attestation API support; Fulu data-column availability support |
+| `types.go`: `LatestMessage`, `ForkChoiceNode` | Phase0 `LatestMessage`; Gloas modified `LatestMessage`, `ForkChoiceNode` |
+| `get_head.go`: `accountWeights`, `computeVotes`, `getHead`, `GetHead` | Phase0 `get_attestation_score`, `get_weight`, `get_head`; Gloas dispatch boundary for modified `get_head` |
+| `get_head.go`: `getHeadGloas` | Gloas `get_head`, `get_node_children`, `get_weight`, `get_payload_status_tiebreaker` |
+| `get_head.go`: `getFilteredBlockTree`, `getFilterBlockTree` | Phase0 `get_filtered_block_tree`, `filter_block_tree`, `get_voting_source`; Gloas inherits filtered-tree viability |
+| `weight_store.go`, `weight_store_indexed.go`: `GetWeight`, `GetAttestationScore`, `GetProposerScore`, `ShouldApplyProposerBoost`, `IndexVote`, `RemoveVote` | Phase0 `get_weight`, `get_attestation_score`, `get_proposer_score`; Gloas modified `get_weight`, `get_attestation_score`, `should_apply_proposer_boost`, `LatestMessage` indexing |
+| `payload_vote.go`: `notifyPtcMessages`, `applyPayloadAttestationVote` | Gloas `notify_ptc_messages`, `on_payload_attestation_message` vote application |
+| `payload_vote.go`: `isPayloadTimely`, `isPayloadDataAvailable` | Gloas `is_payload_timely`, `is_payload_data_available`; requires local envelope availability plus independent PTC majorities |
+| `payload_vote.go`: `getParentPayloadStatus`, `isParentNodeFull`, `isSupportingVote` | Gloas `get_parent_payload_status`, `is_parent_node_full`, `is_supporting_vote` |
+| `payload_vote.go`: `ShouldExtendPayload`, `getPayloadStatusTiebreaker`, `getNodeChildren`, `validateParentPayloadPath` | Gloas `should_extend_payload`, `get_payload_status_tiebreaker`, `get_node_children`, modified `on_block` parent payload path checks |
+| `timing.go`: `getAttestationDueMs`, `getAggregateDueMs`, `getSyncMessageDueMs`, `getContributionDueMs`, `getPayloadAttestationDueMs` | Phase0 timing helpers; Gloas modified timing helpers and `get_payload_attestation_due_ms` |
+| `timing.go`: `recordBlockTimeliness`, `updateProposerBoostRoot`, `shouldApplyProposerBoostGloas` | Phase0 `record_block_timeliness`, `update_proposer_boost_root`; Gloas modified `record_block_timeliness`, `update_proposer_boost_root`, `should_apply_proposer_boost` |
+| `timing.go`: `isHeadLate`, `isHeadWeak`, `isParentStrong` | Phase0 proposer reorg helpers; Gloas modified `is_head_late`, `is_head_weak`, `is_parent_strong` |
+| `on_tick.go`: `OnTick`, `onTickPerSlot` | Phase0 `on_tick`, `on_tick_per_slot`; Gloas inherits proposer-boost reset and unrealized checkpoint promotion |
+| `on_block.go`: `OnBlock` | Phase0 `on_block`; Bellatrix execution payload validation; Deneb blob availability; Electra execution requests; Gloas deferred payload/envelope processing; Fulu modified `on_block` data availability call |
+| `on_block.go`: `verifyKzgCommitmentsAgainstTransactions` | Deneb execution payload blob versioned-hash checks; Electra/Fulu maximum blob count plumbing |
+| `on_block.go`: `isDataAvailable` | Deneb `is_data_available` for blob sidecars; pre-Gloas local blob storage path |
+| `on_block.go`: PeerDAS `IsDataAvailable` and `SyncColumnDataLater` branch inside `OnBlock` | Fulu modified `is_data_available`: data availability is checked by block root through data column sidecars, without passing `blob_kzg_commitments`; modified Fulu `on_block` calls it as `is_data_available(hash_tree_root(block))` |
+| `on_execution_payload.go`: `OnExecutionPayload`, `applyEnvelope`, `applyEnvelopeLocked`, `ApplyLocalSelfBuildEnvelope`, `StoreAnchorEnvelope` | Gloas `on_execution_payload_envelope`, `Store.payloads`, `Store.payload_timeliness_vote`, `Store.payload_data_availability_vote` |
+| `on_execution_payload.go`: `validateEnvelopeAgainstBlock`, `verifyEnvelopeBuilderSignature`, `checkDataAvailability`, `validatePayloadWithEL` | Gloas `on_execution_payload_envelope`; Gloas/Fulu data availability for committed bid blob data; Bellatrix `ExecutionEngine.notify_forkchoice_updated`/payload validation context |
+| `on_payload_attestation_message.go`: `OnPayloadAttestationMessage` | Gloas `on_payload_attestation_message`, PTC membership/signature/current-slot checks |
+| `on_attestation.go`: `OnAttestation`, `ProcessAttestingIndicies`, `ValidateOnAttestation`, `validateTargetEpochAgainstCurrentTime` | Phase0 `on_attestation`, `validate_on_attestation`, `validate_target_epoch_against_current_time`; Gloas modified `validate_on_attestation` |
+| `on_attestation.go`: `updateLatestMessages`, `updateLatestMessagesPreGloas`, `updateLatestMessagesGloas`, latest-message accessors | Phase0 `update_latest_messages`; Gloas modified `update_latest_messages` with slot ordering and payload-present tracking |
+| `on_attester_slashing.go`: `OnAttesterSlashing`, `onProcessAttesterSlashing`, `getIndexedAttestationPublicKeys` | Phase0 `on_attester_slashing`, `is_valid_indexed_attestation` |
+| `checkpoint_state.go`: `getAttestingIndicies`, `getActiveIndicies`, `committeeCount`, `getDomain`, `isValidIndexedAttestation`, `epochAtSlot` | Phase0 attestation helpers used by `on_attestation`; beacon-chain `get_attesting_indices`, `get_active_validator_indices`, `get_committee_count_per_slot`, `get_domain`, `is_valid_indexed_attestation`, `compute_epoch_at_slot`; Electra committee-index/aggregation changes |
+| `utils.go`: `updateCheckpoints`, `updateUnrealizedCheckpoints`, `Ancestor`, `getCheckpointState`, slot/epoch helpers | Phase0 `update_checkpoints`, `update_unrealized_checkpoints`, `get_ancestor`, `store_target_checkpoint_state`, slot/epoch helpers; Gloas modified `get_ancestor` returning payload status |
+| `blob_sidecars.go`: `AddPreverifiedBlobSidecar` | Deneb data availability support for `is_data_available`; pre-Fulu blob sidecar inventory |
+| `latest_messages_store.go` | Implementation storage for Phase0/Gloas `Store.latest_messages` |
+| `interface.go` | Local interface surface for the fork-choice handlers and readers above |
+| `fork_graph/interface.go`, `fork_graph/fork_graph_disk.go`, `fork_graph/fork_graph_disk_fs.go`, `fork_graph/participation_indicies_store.go` | Implementation storage for Phase0/Gloas `Store.blocks`, `Store.block_states`, `Store.checkpoint_states`, payload envelope persistence, and participation data |
+| `optimistic/optimistic.go`, `optimistic/optimistic_impl.go` | Optimistic sync support for execution payload validity tracking; review with Bellatrix execution payload validity and fork-choice update semantics |
+| `public_keys_registry/interface.go`, `public_keys_registry/in_memory_public_keys_registry.go`, `public_keys_registry/db_public_keys_registry.go` | Signature verification support for `is_valid_indexed_attestation` and payload attestation validation |
+
+## Fulu Review Notes
+
+- Fulu changes fork-choice data availability from Deneb blob-sidecar retrieval by
+  commitments to PeerDAS data-column retrieval by beacon block root. In this
+  codebase, review the `OnBlock` Fulu branch and any `peerDas.IsDataAvailable`
+  calls as the implementation of Fulu `is_data_available(beacon_block_root)`.
+- Fulu `on_block` only changes the data-availability assertion shape: it checks
+  `is_data_available(hash_tree_root(block))` before `state_transition` and store
+  mutation. Do not reintroduce a Fulu dependency on `block.body.blob_kzg_commitments`
+  in fork choice.
+- Deneb and Fulu data availability paths are not interchangeable. Deneb
+  `isDataAvailable(ctx, slot, blockRoot, blobKzgCommitments)` verifies blob
+  sidecars against commitments; Fulu uses PeerDAS/data-column availability and
+  may schedule deferred column-data sync.
+- Gloas separates beacon block processing from execution payload envelope
+  processing. For post-Gloas/Fulu blocks, check data availability in both the
+  `OnBlock` PeerDAS path and `OnExecutionPayload.checkDataAvailability` path
+  according to the caller's `checkDataAvaiability`/`checkBlobData` flags.
+
+## Review Checklist
+
+- Conditional vs fallback: if the spec says `if condition: return X; return Y`,
+  preserve that exact fallback behavior. Be suspicious of local shortcuts that
+  return `false`, zero roots, empty payload status, or `nil` when the spec would
+  continue through a later disjunct.
+- Missing disjuncts: compare every `or` in `filter_block_tree`,
+  `should_extend_payload`, `should_apply_proposer_boost`,
+  `validate_on_attestation`, `get_proposer_head`-related helpers, and payload
+  status tiebreaking. A missing permissive disjunct can reject a viable branch;
+  a missing restrictive disjunct can accept an invalid block or vote.
+- Epoch boundaries: explicitly test genesis epoch, first slot of an epoch,
+  current vs previous epoch attestations, and slots where
+  `compute_slots_since_epoch_start(slot) == 0`. These paths affect
+  `filter_block_tree`, `on_tick_per_slot`, pulled-up unrealized checkpoints, and
+  proposer reorg helper behavior.
+- Timeliness boundaries: check `<` vs `<=` against the spec for attestation,
+  aggregate, contribution, sync-message, PTC, and proposer reorg cutoffs. Tests
+  should cover exactly-at-threshold arrival.
+- Gloas payload status: when reviewing `PENDING`, `EMPTY`, and `FULL` handling,
+  trace both the beacon block root and the parent execution block hash. Confirm
+  `get_parent_payload_status`, `get_node_children`,
+  `get_payload_status_tiebreaker`, and `is_supporting_vote` agree on the same
+  status transition.
+- PTC votes: payload timeliness and blob-data availability are separate vote
+  vectors. A payload-present vote must not imply blob-data availability, and
+  local payload/envelope availability must still gate both spec helpers.
+- Equivocations: `equivocating_indices` must be excluded from latest-message
+  weight, but Gloas `is_head_weak` also adds back the specified committee
+  weight for equivocating validators. Review both sides together.
+- Store mutation safety: spec handlers that fail assertions must not mutate the
+  store. In Go, validate all reject/ignore conditions before writes to latest
+  messages, block trees, payload states, timeliness maps, and checkpoint fields.
+- Cache invalidation: any change to latest messages, payload status, block
+  timeliness, proposer boost root, checkpoints, or fork graph contents can make
+  cached head/weight data stale. Confirm invalidation happens on every mutating
+  path.
+- Pre-fork vs post-fork behavior: preserve Phase0/Bellatrix/Deneb behavior when
+  the current state version is pre-Gloas. Gloas-only logic should be gated by
+  the same fork-version or epoch boundary that the surrounding code uses.
+- Electra execution requests: for Electra and later, `OnBlock`/envelope EL
+  validation must pass execution requests consistently with the beacon block or
+  envelope source. Empty request lists and nil request lists are not equivalent
+  unless the surrounding code intentionally normalizes them.
+- Data availability: Deneb checks blob sidecars before accepting a block; Fulu
+  checks data column sidecars through PeerDAS by block root; Gloas checks
+  committed bid blob data during envelope processing. Review fork-version
+  branches so the check is neither skipped nor duplicated for the active fork.
+- Tests: add or update focused tests for any spec branch that changes. Prefer
+  table tests that name the spec condition, especially for conditional/fallback,
+  missing-disjunct, data-availability, and epoch-boundary cases.

--- a/cl/CLAUDE.md
+++ b/cl/CLAUDE.md
@@ -1,127 +1,32 @@
-# Caplin Spec Conformance Review Rules
+# Caplin Consensus Layer
 
-This directory contains consensus-critical Caplin code. Review changes against
-the upstream Ethereum consensus specifications, not only against local tests.
+This directory contains consensus-critical Caplin code. Review all changes
+against the upstream Ethereum consensus specifications, not only local tests.
 
-Primary references:
+Primary spec reference: https://github.com/ethereum/consensus-specs
 
-- Consensus specs repository: https://github.com/ethereum/consensus-specs
-- Phase0 fork choice: https://ethereum.github.io/consensus-specs/phase0/fork-choice/
-- Bellatrix fork choice: https://ethereum.github.io/consensus-specs/bellatrix/fork-choice/
-- Deneb fork choice: https://ethereum.github.io/consensus-specs/deneb/fork-choice/
-- Electra fork choice changes are inherited through Bellatrix/Deneb `on_block`
-  execution-request plumbing and beacon-chain state transition rules.
-- Fulu fork choice: https://ethereum.github.io/consensus-specs/fulu/fork-choice/
-- Gloas fork choice: https://ethereum.github.io/consensus-specs/gloas/fork-choice/
+## Per-Directory Spec Maps
 
-## Forkchoice Spec Map
+Each consensus-critical subdirectory has its own `CLAUDE.md` with function-level
+spec mappings and a domain-specific review checklist:
 
-Use this map when reviewing `cl/phase1/forkchoice/`. Function names below are
-verified against the Go code in this repository.
-
-| Go file/function | Spec section |
+| Directory | Scope |
 | --- | --- |
-| `forkchoice.go`: `NewForkChoiceStore` | Phase0 `get_forkchoice_store`; Gloas `get_forkchoice_store` and extended `Store` fields |
-| `forkchoice.go`: `GetRecentExecutionPayloadStatus`, `IsBlobDataAvailable`, `HasEnvelope`, `ReadEnvelopeFromDisk`, pending EL payload helpers | Gloas `Store`, `on_execution_payload_envelope`; Gloas `Store.payload_states`, `Store.payloads`; Gloas payload-attestation API support; Fulu data-column availability support |
-| `types.go`: `LatestMessage`, `ForkChoiceNode` | Phase0 `LatestMessage`; Gloas modified `LatestMessage`, `ForkChoiceNode` |
-| `get_head.go`: `accountWeights`, `computeVotes`, `getHead`, `GetHead` | Phase0 `get_attestation_score`, `get_weight`, `get_head`; Gloas dispatch boundary for modified `get_head` |
-| `get_head.go`: `getHeadGloas` | Gloas `get_head`, `get_node_children`, `get_weight`, `get_payload_status_tiebreaker` |
-| `get_head.go`: `getFilteredBlockTree`, `getFilterBlockTree` | Phase0 `get_filtered_block_tree`, `filter_block_tree`, `get_voting_source`; Gloas inherits filtered-tree viability |
-| `weight_store.go`, `weight_store_indexed.go`: `GetWeight`, `GetAttestationScore`, `GetProposerScore`, `ShouldApplyProposerBoost`, `IndexVote`, `RemoveVote` | Phase0 `get_weight`, `get_attestation_score`, `get_proposer_score`; Gloas modified `get_weight`, `get_attestation_score`, `should_apply_proposer_boost`, `LatestMessage` indexing |
-| `payload_vote.go`: `notifyPtcMessages`, `applyPayloadAttestationVote` | Gloas `notify_ptc_messages`, `on_payload_attestation_message` vote application |
-| `payload_vote.go`: `isPayloadTimely`, `isPayloadDataAvailable` | Gloas `payload_timeliness`, `payload_data_availability`; requires local envelope availability plus independent PTC majorities |
-| `payload_vote.go`: `getParentPayloadStatus`, `isParentNodeFull`, `isSupportingVote` | Gloas `get_parent_payload_status`, `is_parent_node_full`, `is_supporting_vote` |
-| `payload_vote.go`: `ShouldExtendPayload`, `getPayloadStatusTiebreaker`, `getNodeChildren`, `validateParentPayloadPath` | Gloas `should_extend_payload`, `get_payload_status_tiebreaker`, `get_node_children`, modified `on_block` parent payload path checks |
-| `timing.go`: `getAttestationDueMs`, `getAggregateDueMs`, `getSyncMessageDueMs`, `getContributionDueMs`, `getPayloadAttestationDueMs` | Phase0 timing helpers; Gloas modified timing helpers and `get_payload_attestation_due_ms` |
-| `timing.go`: `recordBlockTimeliness`, `updateProposerBoostRoot`, `shouldApplyProposerBoostGloas` | Phase0 `record_block_timeliness`, `update_proposer_boost_root`; Gloas modified `record_block_timeliness`, `update_proposer_boost_root`, `should_apply_proposer_boost` |
-| `timing.go`: `isHeadLate`, `isHeadWeak`, `isParentStrong` | Phase0 proposer reorg helpers; Gloas modified `is_head_late`, `is_head_weak`, `is_parent_strong` |
-| `on_tick.go`: `OnTick`, `onTickPerSlot` | Phase0 `on_tick`, `on_tick_per_slot`; Gloas inherits proposer-boost reset and unrealized checkpoint promotion |
-| `on_block.go`: `OnBlock` | Phase0 `on_block`; Bellatrix execution payload validation; Deneb blob availability; Electra execution requests; Gloas deferred payload/envelope processing; Fulu modified `on_block` data availability call |
-| `on_block.go`: `verifyKzgCommitmentsAgainstTransactions` | Deneb execution payload blob versioned-hash checks; Electra/Fulu maximum blob count plumbing |
-| `on_block.go`: `isDataAvailable` | Deneb `is_data_available` for blob sidecars; pre-Gloas local blob storage path |
-| `on_block.go`: PeerDAS `IsDataAvailable` and `SyncColumnDataLater` branch inside `OnBlock` | Fulu modified `is_data_available`: data availability is checked by block root through data column sidecars, without passing `blob_kzg_commitments`; modified Fulu `on_block` calls it as `is_data_available(hash_tree_root(block))` |
-| `on_execution_payload.go`: `OnExecutionPayload`, `applyEnvelope`, `applyEnvelopeLocked`, `ApplyLocalSelfBuildEnvelope`, `StoreAnchorEnvelope` | Gloas `on_execution_payload_envelope`, `Store.payloads`, `Store.payload_timeliness_vote`, `Store.payload_data_availability_vote` |
-| `on_execution_payload.go`: `validateEnvelopeAgainstBlock`, `verifyEnvelopeBuilderSignature`, `checkDataAvailability`, `validatePayloadWithEL` | Gloas `on_execution_payload_envelope`; Gloas/Fulu data availability for committed bid blob data; Bellatrix `ExecutionEngine.notify_forkchoice_updated`/payload validation context |
-| `on_payload_attestation_message.go`: `OnPayloadAttestationMessage` | Gloas `on_payload_attestation_message`, PTC membership/signature/current-slot checks |
-| `on_attestation.go`: `OnAttestation`, `ProcessAttestingIndicies`, `ValidateOnAttestation`, `validateTargetEpochAgainstCurrentTime` | Phase0 `on_attestation`, `validate_on_attestation`, `validate_target_epoch_against_current_time`; Gloas modified `validate_on_attestation` |
-| `on_attestation.go`: `updateLatestMessages`, `updateLatestMessagesPreGloas`, `updateLatestMessagesGloas`, latest-message accessors | Phase0 `update_latest_messages`; Gloas modified `update_latest_messages` with slot ordering and payload-present tracking |
-| `on_attester_slashing.go`: `OnAttesterSlashing`, `onProcessAttesterSlashing`, `getIndexedAttestationPublicKeys` | Phase0 `on_attester_slashing`, `is_valid_indexed_attestation` |
-| `checkpoint_state.go`: `getAttestingIndicies`, `getActiveIndicies`, `committeeCount`, `getDomain`, `isValidIndexedAttestation`, `epochAtSlot` | Phase0 attestation helpers used by `on_attestation`; beacon-chain `get_attesting_indices`, `get_active_validator_indices`, `get_committee_count_per_slot`, `get_domain`, `is_valid_indexed_attestation`, `compute_epoch_at_slot`; Electra committee-index/aggregation changes |
-| `utils.go`: `updateCheckpoints`, `updateUnrealizedCheckpoints`, `Ancestor`, `getCheckpointState`, slot/epoch helpers | Phase0 `update_checkpoints`, `update_unrealized_checkpoints`, `get_ancestor`, `store_target_checkpoint_state`, slot/epoch helpers; Gloas modified `get_ancestor` returning payload status |
-| `blob_sidecars.go`: `AddPreverifiedBlobSidecar` | Deneb data availability support for `is_data_available`; pre-Fulu blob sidecar inventory |
-| `latest_messages_store.go` | Implementation storage for Phase0/Gloas `Store.latest_messages` |
-| `interface.go` | Local interface surface for the fork-choice handlers and readers above |
-| `fork_graph/interface.go`, `fork_graph/fork_graph_disk.go`, `fork_graph/fork_graph_disk_fs.go`, `fork_graph/participation_indicies_store.go` | Implementation storage for Phase0/Gloas `Store.blocks`, `Store.block_states`, `Store.checkpoint_states`, payload envelope persistence, and participation data |
-| `optimistic/optimistic.go`, `optimistic/optimistic_impl.go` | Optimistic sync support for execution payload validity tracking; review with Bellatrix execution payload validity and fork-choice update semantics |
-| `public_keys_registry/interface.go`, `public_keys_registry/in_memory_public_keys_registry.go`, `public_keys_registry/db_public_keys_registry.go` | Signature verification support for `is_valid_indexed_attestation` and payload attestation validation |
+| [`phase1/forkchoice/CLAUDE.md`](phase1/forkchoice/CLAUDE.md) | Fork choice: `on_block`, `on_attestation`, `get_head`, payload votes, timing, data availability |
+| [`transition/CLAUDE.md`](transition/CLAUDE.md) | State transition: block operations, epoch processing, slot processing |
+| [`phase1/core/state/CLAUDE.md`](phase1/core/state/CLAUDE.md) | Beacon state helpers: accessors, mutators, builder/deposit routing |
 
-## Fulu Review Notes
+## Cross-Cutting Principles
 
-- Fulu changes fork-choice data availability from Deneb blob-sidecar retrieval by
-  commitments to PeerDAS data-column retrieval by beacon block root. In this
-  codebase, review the `OnBlock` Fulu branch and any `peerDas.IsDataAvailable`
-  calls as the implementation of Fulu `is_data_available(beacon_block_root)`.
-- Fulu `on_block` only changes the data-availability assertion shape: it checks
-  `is_data_available(hash_tree_root(block))` before `state_transition` and store
-  mutation. Do not reintroduce a Fulu dependency on `block.body.blob_kzg_commitments`
-  in fork choice.
-- Deneb and Fulu data availability paths are not interchangeable. Deneb
-  `isDataAvailable(ctx, slot, blockRoot, blobKzgCommitments)` verifies blob
-  sidecars against commitments; Fulu uses PeerDAS/data-column availability and
-  may schedule deferred column-data sync.
-- Gloas separates beacon block processing from execution payload envelope
-  processing. For post-Gloas/Fulu blocks, check data availability in both the
-  `OnBlock` PeerDAS path and `OnExecutionPayload.checkDataAvailability` path
-  according to the caller's `checkDataAvaiability`/`checkBlobData` flags.
-
-## Review Checklist
-
-- Conditional vs fallback: if the spec says `if condition: return X; return Y`,
-  preserve that exact fallback behavior. Be suspicious of local shortcuts that
-  return `false`, zero roots, empty payload status, or `nil` when the spec would
-  continue through a later disjunct.
-- Missing disjuncts: compare every `or` in `filter_block_tree`,
-  `should_extend_payload`, `should_apply_proposer_boost`,
-  `validate_on_attestation`, `get_proposer_head`-related helpers, and payload
-  status tiebreaking. A missing permissive disjunct can reject a viable branch;
-  a missing restrictive disjunct can accept an invalid block or vote.
-- Epoch boundaries: explicitly test genesis epoch, first slot of an epoch,
-  current vs previous epoch attestations, and slots where
-  `compute_slots_since_epoch_start(slot) == 0`. These paths affect
-  `filter_block_tree`, `on_tick_per_slot`, pulled-up unrealized checkpoints, and
-  proposer reorg helper behavior.
-- Timeliness boundaries: check `<` vs `<=` against the spec for attestation,
-  aggregate, contribution, sync-message, PTC, and proposer reorg cutoffs. Tests
-  should cover exactly-at-threshold arrival.
-- Gloas payload status: when reviewing `PENDING`, `EMPTY`, and `FULL` handling,
-  trace both the beacon block root and the parent execution block hash. Confirm
-  `get_parent_payload_status`, `get_node_children`,
-  `get_payload_status_tiebreaker`, and `is_supporting_vote` agree on the same
-  status transition.
-- PTC votes: payload timeliness and blob-data availability are separate vote
-  vectors. A payload-present vote must not imply blob-data availability, and
-  local payload/envelope availability must still gate both spec helpers.
-- Equivocations: `equivocating_indices` must be excluded from latest-message
-  weight, but Gloas `is_head_weak` also adds back the specified committee
-  weight for equivocating validators. Review both sides together.
-- Store mutation safety: spec handlers that fail assertions must not mutate the
-  store. In Go, validate all reject/ignore conditions before writes to latest
-  messages, block trees, payload states, timeliness maps, and checkpoint fields.
-- Cache invalidation: any change to latest messages, payload status, block
-  timeliness, proposer boost root, checkpoints, or fork graph contents can make
-  cached head/weight data stale. Confirm invalidation happens on every mutating
-  path.
-- Pre-fork vs post-fork behavior: preserve Phase0/Bellatrix/Deneb behavior when
-  the current state version is pre-Gloas. Gloas-only logic should be gated by
-  the same fork-version or epoch boundary that the surrounding code uses.
-- Electra execution requests: for Electra and later, `OnBlock`/envelope EL
-  validation must pass execution requests consistently with the beacon block or
-  envelope source. Empty request lists and nil request lists are not equivalent
-  unless the surrounding code intentionally normalizes them.
-- Data availability: Deneb checks blob sidecars before accepting a block; Fulu
-  checks data column sidecars through PeerDAS by block root; Gloas checks
-  committed bid blob data during envelope processing. Review fork-version
-  branches so the check is neither skipped nor duplicated for the active fork.
-- Tests: add or update focused tests for any spec branch that changes. Prefer
-  table tests that name the spec condition, especially for conditional/fallback,
-  missing-disjunct, data-availability, and epoch-boundary cases.
+- Before modifying consensus code, locate the spec section the function
+  implements. The spec maps above provide the mapping; if a function is missing
+  from a map, find the spec section yourself before changing behavior.
+- Partial lists vs full lists: when a loop processes a prefix of a queue (e.g.,
+  pending deposits, pending consolidations), the spec often intentionally uses
+  the partial accumulator — not the full list. Do not "fix" a partial list to
+  the full list without checking the spec.
+- Validate before mutating: spec handlers that fail assertions must not have
+  already changed state. In Go, check all reject/ignore conditions before writes.
+- Fork gates: every fork (Phase0 through Gloas) may change the same function's
+  behavior. Preserve pre-fork semantics when the state version is earlier than
+  the fork that introduced the change.

--- a/cl/phase1/core/state/CLAUDE.md
+++ b/cl/phase1/core/state/CLAUDE.md
@@ -1,0 +1,113 @@
+# Caplin Beacon State Helper Spec Map
+
+This directory contains consensus-critical beacon state helper logic used by
+fork choice and state transition. Review helpers as direct implementations of
+consensus spec accessors/mutators, even when the call site lives outside this
+directory.
+
+Primary references:
+
+- Phase0 beacon chain helpers: https://ethereum.github.io/consensus-specs/specs/phase0/beacon-chain/
+- Altair beacon chain helpers: https://ethereum.github.io/consensus-specs/specs/altair/beacon-chain/
+- Capella withdrawals: https://ethereum.github.io/consensus-specs/specs/capella/beacon-chain/
+- Electra beacon chain helpers: https://ethereum.github.io/consensus-specs/specs/electra/beacon-chain/
+- Fulu beacon chain helpers: https://ethereum.github.io/consensus-specs/specs/fulu/beacon-chain/
+- Gloas beacon chain helpers: https://ethereum.github.io/consensus-specs/specs/gloas/beacon-chain/
+
+## Accessor Spec Map
+
+Use this map when reviewing `accessors.go`, `cache_accessors.go`, `util.go`,
+and Gloas helper extensions in `epbs.go`.
+
+| Go file/function | Spec section |
+| --- | --- |
+| `accessors.go`: `GetEpochAtSlot`, `Epoch`, `PreviousEpoch` | Phase0 `compute_epoch_at_slot`, `get_current_epoch`, `get_previous_epoch` |
+| `accessors.go`: `IsAggregator` | Phase0 `is_aggregator` |
+| `accessors.go`: `GetTotalBalance` | Phase0 `get_total_balance` |
+| `accessors.go`: `GetTotalSlashingAmount` | Phase0 `get_total_slashing_amount` |
+| `accessors.go`: `GetBlockRoot` | Phase0 `get_block_root` |
+| `accessors.go`: `FinalityDelay`, `InactivityLeaking` | Phase0/Altair `get_finality_delay`, `is_in_inactivity_leak` |
+| `accessors.go`: `IsUnslashedParticipatingIndex`, `EligibleValidatorsIndicies` | Phase0/Altair `get_unslashed_participating_indices`, `get_eligible_validator_indices` |
+| `accessors.go`: `IsValidIndexedAttestation` | Phase0 `is_valid_indexed_attestation` |
+| `accessors.go`: `IsValidatorEligibleForActivationQueue` | Phase0 `is_eligible_for_activation_queue`; Electra modified `is_eligible_for_activation_queue` |
+| `accessors.go`: `IsMergeTransitionComplete` | Bellatrix `is_merge_transition_complete` |
+| `accessors.go`: `ComputeTimestampAtSlot` | Bellatrix `compute_timestamp_at_slot` |
+| `accessors.go`: `GetExpectedWithdrawals` | Capella `get_expected_withdrawals`; Electra pending partial withdrawals; Gloas builder withdrawals and builder sweep withdrawals |
+| `accessors.go`: `GetPendingPartialWithdrawals`, `getBalanceAfterWithdrawals` | Electra `get_expected_withdrawals` pending partial withdrawal pass |
+| `accessors.go`: `GetValidatorsSweepWithdrawals` | Capella/Electra validator sweep in `get_expected_withdrawals` |
+| `accessors.go`: `GetBuilderWithdrawals`, `GetBuildersSweepWithdrawals` | Gloas builder withdrawal passes in `get_expected_withdrawals` |
+| `accessors.go`: `GetNextSyncCommitteeIndices` | Altair `get_next_sync_committee_indices`; Gloas modified balance-weighted selection |
+| `util.go`: `GetIndexedAttestation` | Phase0 `get_indexed_attestation` |
+| `util.go`: `GetValidatorFromDeposit` | Phase0 deposit validator construction inside `process_deposit` |
+| `util.go`: `HasEth1WithdrawalCredential`, `HasCompoundingWithdrawalCredential`, `HasExecutionWithdrawalCredential` | Capella/Electra withdrawal credential helpers |
+| `util.go`: `ComputeActivationExitEpoch` | Phase0 `compute_activation_exit_epoch` |
+| `util.go`: `GetActivationExitChurnLimit`, `GetBalanceChurnLimit`, `GetConsolidationChurnLimit`, `QueueExcessActiveBalance` | Electra activation/exit balance churn and consolidation helpers |
+| `util.go`: `GetValidatorsCustodyRequirement` | Fulu data-column custody helper |
+| `util.go`: `IsAttestationSameSlot` | Gloas same-slot attestation helper for builder pending-payment weights |
+| `epbs.go`: `IsBuilderIndex`, `ConvertBuilderIndexToValidatorIndex`, `ConvertValidatorIndexToBuilderIndex` | Gloas builder-index encoding helpers |
+| `epbs.go`: `IsActiveBuilder`, `IsBuilderWithdrawalCredential` | Gloas builder registry and withdrawal-credential helpers |
+| `epbs.go`: `IsValidIndexedPayloadAttestation` | Gloas `is_valid_indexed_payload_attestation` |
+| `epbs.go`: `CanBuilderCoverBid`, `GetPendingBalanceToWithdrawForBuilder` | Gloas builder bid coverage and pending-withdrawal helpers |
+| `epbs.go`: `IsPendingValidator`, `IsBuilderPubkey` | Gloas deposit request routing helpers |
+| `util.go`: `GetMaxEffectiveBalanceByVersion` | Electra `get_max_effective_balance`; version-gated effective balance cap |
+| `cache_accessors.go`: `GetActiveValidatorsIndices` | Phase0 `get_active_validator_indices` |
+| `cache_accessors.go`: `GetTotalActiveBalance` | Phase0 `get_total_active_balance` |
+| `cache_accessors.go`: `ComputeCommittee` | Phase0 `compute_committee` |
+| `cache_accessors.go`: `GetBeaconProposerIndex`, `GetBeaconProposerIndices`, `GetBeaconProposerIndexForSlot` | Phase0 `get_beacon_proposer_index` |
+| `cache_accessors.go`: `BaseRewardPerIncrement`, `BaseReward` | Altair `get_base_reward_per_increment`, `get_base_reward` |
+| `cache_accessors.go`: `SyncRewards` | Altair sync committee reward computation |
+| `cache_accessors.go`: `CommitteeCount` | Phase0 `get_committee_count_per_slot` |
+| `cache_accessors.go`: `GetAttestationParticipationFlagIndicies` | Altair `get_attestation_participation_flag_indices` |
+| `cache_accessors.go`: `GetBeaconCommitee` | Phase0 `get_beacon_committee` |
+| `cache_accessors.go`: `ComputeNextSyncCommittee` | Altair `get_next_sync_committee` |
+| `cache_accessors.go`: `GetAttestingIndicies` | Phase0 `get_attesting_indices` |
+| `cache_accessors.go`: `GetValidatorChurnLimit` | Phase0 `get_validator_churn_limit` |
+| `cache_accessors.go`: `GetValidatorActivationChurnLimit` | Electra `get_validator_activation_churn_limit` |
+| `cache_accessors.go`: `GetPTC`, `GetPTCFromWindow`, `ComputePTC`, `InitializePtcWindow` | Gloas payload timeliness committee helpers |
+| `cache_accessors.go`: `GetIndexedPayloadAttestation` | Gloas `get_indexed_payload_attestation` |
+| `cache_accessors.go`: `GetBuilderPaymentQuorumThreshold` | Gloas builder payment quorum |
+| `epbs.go`: `IsValidDepositSignature` | Phase0/Gloas deposit proof-of-possession helper |
+| `epbs.go`: `GetIndexForNewBuilder`, `AddBuilderToRegistry`, `ApplyDepositForBuilder` | Gloas builder registry deposit helpers |
+
+## Mutator Spec Map
+
+Use this map when reviewing `mutators.go`, `cache_mutators.go`, and mutating
+helper paths in `epbs.go`.
+
+| Go file/function | Spec section |
+| --- | --- |
+| `mutators.go`: `IncreaseBalance` | Phase0 `increase_balance` |
+| `mutators.go`: `DecreaseBalance` | Phase0 `decrease_balance`; saturates at zero |
+| `cache_mutators.go`: `SlashValidator` | Phase0 `slash_validator`; whistleblower/proposer reward split |
+| `cache_mutators.go`: `InitiateValidatorExit` | Phase0 `initiate_validator_exit` |
+| `cache_mutators.go`: `ComputeExitEpochAndUpdateChurn` | Electra `compute_exit_epoch_and_update_churn` |
+| `cache_mutators.go`: `InitiateBuilderExit` | Gloas builder exit |
+| `epbs.go`: `AddBuilderToRegistry` | Gloas builder registry append/reuse during builder deposits |
+| `epbs.go`: `ApplyDepositForBuilder` | Gloas builder deposit application: new builder proof-of-possession or existing builder balance increase |
+
+## Review Checklist
+
+- Treat helpers as consensus code, not convenience wrappers. A small change here
+  can alter fork choice, block processing, epoch processing, or withdrawal
+  roots.
+- Preserve spec minimums and saturation behavior: `get_total_balance` must
+  return at least `EFFECTIVE_BALANCE_INCREMENT`, and `decrease_balance` must not
+  underflow.
+- Withdrawal helpers must keep ordering and limits stable across Capella,
+  Electra, and Gloas passes. Check `MAX_WITHDRAWALS_PER_PAYLOAD - 1` builder
+  limits separately from validator sweep limits.
+- When helpers consume a partial list or queue, use copy-on-write patterns if
+  the underlying SSZ list can share pointers across state copies.
+- Distinguish "pending" validators (have a pending deposit but not yet activated)
+  from "active" validators (past activation epoch, before exit epoch). These are
+  separate predicates; using one where the spec requires the other causes
+  deposit-routing and balance-accounting bugs.
+- Builder helpers must keep encoded builder indices distinct from validator
+  indices and must not accidentally look up a builder index in the validator
+  registry without conversion.
+- Signature helpers must use the exact spec domain and fork version. Deposit and
+  BLS-to-execution-change signatures are fork agnostic; attestations and payload
+  attestations are epoch/fork dependent.
+- Fork gates matter: Electra changes activation/withdrawal churn and pending
+  deposits; Fulu changes custody requirements; Gloas adds builders, PTC payload
+  attestations, and balance-weighted sync committee selection.

--- a/cl/phase1/forkchoice/CLAUDE.md
+++ b/cl/phase1/forkchoice/CLAUDE.md
@@ -1,0 +1,127 @@
+# Caplin Spec Conformance Review Rules
+
+This directory contains consensus-critical Caplin code. Review changes against
+the upstream Ethereum consensus specifications, not only against local tests.
+
+Primary references:
+
+- Consensus specs repository: https://github.com/ethereum/consensus-specs
+- Phase0 fork choice: https://ethereum.github.io/consensus-specs/phase0/fork-choice/
+- Bellatrix fork choice: https://ethereum.github.io/consensus-specs/bellatrix/fork-choice/
+- Deneb fork choice: https://ethereum.github.io/consensus-specs/deneb/fork-choice/
+- Electra fork choice changes are inherited through Bellatrix/Deneb `on_block`
+  execution-request plumbing and beacon-chain state transition rules.
+- Fulu fork choice: https://ethereum.github.io/consensus-specs/fulu/fork-choice/
+- Gloas fork choice: https://ethereum.github.io/consensus-specs/gloas/fork-choice/
+
+## Forkchoice Spec Map
+
+Use this map when reviewing `cl/phase1/forkchoice/`. Function names below are
+verified against the Go code in this repository.
+
+| Go file/function | Spec section |
+| --- | --- |
+| `forkchoice.go`: `NewForkChoiceStore` | Phase0 `get_forkchoice_store`; Gloas `get_forkchoice_store` and extended `Store` fields |
+| `forkchoice.go`: `GetRecentExecutionPayloadStatus`, `IsBlobDataAvailable`, `HasEnvelope`, `ReadEnvelopeFromDisk`, pending EL payload helpers | Gloas `Store`, `on_execution_payload_envelope`; Gloas `Store.payload_states`, `Store.payloads`; Gloas payload-attestation API support; Fulu data-column availability support |
+| `types.go`: `LatestMessage`, `ForkChoiceNode` | Phase0 `LatestMessage`; Gloas modified `LatestMessage`, `ForkChoiceNode` |
+| `get_head.go`: `accountWeights`, `computeVotes`, `getHead`, `GetHead` | Phase0 `get_attestation_score`, `get_weight`, `get_head`; Gloas dispatch boundary for modified `get_head` |
+| `get_head.go`: `getHeadGloas` | Gloas `get_head`, `get_node_children`, `get_weight`, `get_payload_status_tiebreaker` |
+| `get_head.go`: `getFilteredBlockTree`, `getFilterBlockTree` | Phase0 `get_filtered_block_tree`, `filter_block_tree`, `get_voting_source`; Gloas inherits filtered-tree viability |
+| `weight_store.go`, `weight_store_indexed.go`: `GetWeight`, `GetAttestationScore`, `GetProposerScore`, `ShouldApplyProposerBoost`, `IndexVote`, `RemoveVote` | Phase0 `get_weight`, `get_attestation_score`, `get_proposer_score`; Gloas modified `get_weight`, `get_attestation_score`, `should_apply_proposer_boost`, `LatestMessage` indexing |
+| `payload_vote.go`: `notifyPtcMessages`, `applyPayloadAttestationVote` | Gloas `notify_ptc_messages`, `on_payload_attestation_message` vote application |
+| `payload_vote.go`: `payloadTimeliness`, `payloadDataAvailability` | Gloas `payload_timeliness`, `payload_data_availability`; requires local envelope availability plus independent PTC majorities |
+| `payload_vote.go`: `getParentPayloadStatus`, `isParentNodeFull`, `isSupportingVote` | Gloas `get_parent_payload_status`, `is_parent_node_full`, `is_supporting_vote` |
+| `payload_vote.go`: `ShouldExtendPayload`, `getPayloadStatusTiebreaker`, `getNodeChildren`, `validateParentPayloadPath` | Gloas `should_extend_payload`, `get_payload_status_tiebreaker`, `get_node_children`, modified `on_block` parent payload path checks |
+| `timing.go`: `getAttestationDueMs`, `getAggregateDueMs`, `getSyncMessageDueMs`, `getContributionDueMs`, `getPayloadAttestationDueMs` | Phase0 timing helpers; Gloas modified timing helpers and `get_payload_attestation_due_ms` |
+| `timing.go`: `recordBlockTimeliness`, `updateProposerBoostRoot`, `shouldApplyProposerBoostGloas` | Phase0 `record_block_timeliness`, `update_proposer_boost_root`; Gloas modified `record_block_timeliness`, `update_proposer_boost_root`, `should_apply_proposer_boost` |
+| `timing.go`: `isHeadLate`, `isHeadWeak`, `isParentStrong` | Phase0 proposer reorg helpers; Gloas modified `is_head_late`, `is_head_weak`, `is_parent_strong` |
+| `on_tick.go`: `OnTick`, `onTickPerSlot` | Phase0 `on_tick`, `on_tick_per_slot`; Gloas inherits proposer-boost reset and unrealized checkpoint promotion |
+| `on_block.go`: `OnBlock` | Phase0 `on_block`; Bellatrix execution payload validation; Deneb blob availability; Electra execution requests; Gloas deferred payload/envelope processing; Fulu modified `on_block` data availability call |
+| `on_block.go`: `verifyKzgCommitmentsAgainstTransactions` | Deneb execution payload blob versioned-hash checks; Electra/Fulu maximum blob count plumbing |
+| `on_block.go`: `isDataAvailable` | Deneb `is_data_available` for blob sidecars; pre-Gloas local blob storage path |
+| `on_block.go`: PeerDAS `IsDataAvailable` and `SyncColumnDataLater` branch inside `OnBlock` | Fulu modified `is_data_available`: data availability is checked by block root through data column sidecars, without passing `blob_kzg_commitments`; modified Fulu `on_block` calls it as `is_data_available(hash_tree_root(block))` |
+| `on_execution_payload.go`: `OnExecutionPayload`, `applyEnvelope`, `applyEnvelopeLocked`, `ApplyLocalSelfBuildEnvelope`, `StoreAnchorEnvelope` | Gloas `on_execution_payload_envelope`, `Store.payloads`, `Store.payload_timeliness_vote`, `Store.payload_data_availability_vote` |
+| `on_execution_payload.go`: `validateEnvelopeAgainstBlock`, `verifyEnvelopeBuilderSignature`, `checkDataAvailability`, `validatePayloadWithEL` | Gloas `on_execution_payload_envelope`; Gloas/Fulu data availability for committed bid blob data; Bellatrix `ExecutionEngine.notify_forkchoice_updated`/payload validation context |
+| `on_payload_attestation_message.go`: `OnPayloadAttestationMessage` | Gloas `on_payload_attestation_message`, PTC membership/signature/current-slot checks |
+| `on_attestation.go`: `OnAttestation`, `ProcessAttestingIndicies`, `ValidateOnAttestation`, `validateTargetEpochAgainstCurrentTime` | Phase0 `on_attestation`, `validate_on_attestation`, `validate_target_epoch_against_current_time`; Gloas modified `validate_on_attestation` |
+| `on_attestation.go`: `updateLatestMessages`, `updateLatestMessagesPreGloas`, `updateLatestMessagesGloas`, latest-message accessors | Phase0 `update_latest_messages`; Gloas modified `update_latest_messages` with slot ordering and payload-present tracking |
+| `on_attester_slashing.go`: `OnAttesterSlashing`, `onProcessAttesterSlashing`, `getIndexedAttestationPublicKeys` | Phase0 `on_attester_slashing`, `is_valid_indexed_attestation` |
+| `checkpoint_state.go`: `getAttestingIndicies`, `getActiveIndicies`, `committeeCount`, `getDomain`, `isValidIndexedAttestation`, `epochAtSlot` | Phase0 attestation helpers used by `on_attestation`; beacon-chain `get_attesting_indices`, `get_active_validator_indices`, `get_committee_count_per_slot`, `get_domain`, `is_valid_indexed_attestation`, `compute_epoch_at_slot`; Electra committee-index/aggregation changes |
+| `utils.go`: `updateCheckpoints`, `updateUnrealizedCheckpoints`, `Ancestor`, `getCheckpointState`, slot/epoch helpers | Phase0 `update_checkpoints`, `update_unrealized_checkpoints`, `get_ancestor`, `store_target_checkpoint_state`, slot/epoch helpers; Gloas modified `get_ancestor` returning payload status |
+| `blob_sidecars.go`: `AddPreverifiedBlobSidecar` | Deneb data availability support for `is_data_available`; pre-Fulu blob sidecar inventory |
+| `latest_messages_store.go` | Implementation storage for Phase0/Gloas `Store.latest_messages` |
+| `interface.go` | Local interface surface for the fork-choice handlers and readers above |
+| `fork_graph/interface.go`, `fork_graph/fork_graph_disk.go`, `fork_graph/fork_graph_disk_fs.go`, `fork_graph/participation_indicies_store.go` | Implementation storage for Phase0/Gloas `Store.blocks`, `Store.block_states`, `Store.checkpoint_states`, payload envelope persistence, and participation data |
+| `optimistic/optimistic.go`, `optimistic/optimistic_impl.go` | Optimistic sync support for execution payload validity tracking; review with Bellatrix execution payload validity and fork-choice update semantics |
+| `public_keys_registry/interface.go`, `public_keys_registry/in_memory_public_keys_registry.go`, `public_keys_registry/db_public_keys_registry.go` | Signature verification support for `is_valid_indexed_attestation` and payload attestation validation |
+
+## Fulu Review Notes
+
+- Fulu changes fork-choice data availability from Deneb blob-sidecar retrieval by
+  commitments to PeerDAS data-column retrieval by beacon block root. In this
+  codebase, review the `OnBlock` Fulu branch and any `peerDas.IsDataAvailable`
+  calls as the implementation of Fulu `is_data_available(beacon_block_root)`.
+- Fulu `on_block` only changes the data-availability assertion shape: it checks
+  `is_data_available(hash_tree_root(block))` before `state_transition` and store
+  mutation. Do not reintroduce a Fulu dependency on `block.body.blob_kzg_commitments`
+  in fork choice.
+- Deneb and Fulu data availability paths are not interchangeable. Deneb
+  `isDataAvailable(ctx, slot, blockRoot, blobKzgCommitments)` verifies blob
+  sidecars against commitments; Fulu uses PeerDAS/data-column availability and
+  may schedule deferred column-data sync.
+- Gloas separates beacon block processing from execution payload envelope
+  processing. For post-Gloas/Fulu blocks, check data availability in both the
+  `OnBlock` PeerDAS path and `OnExecutionPayload.checkDataAvailability` path
+  according to the caller's `checkDataAvaiability`/`checkBlobData` flags.
+
+## Review Checklist
+
+- Conditional vs fallback: if the spec says `if condition: return X; return Y`,
+  preserve that exact fallback behavior. Be suspicious of local shortcuts that
+  return `false`, zero roots, empty payload status, or `nil` when the spec would
+  continue through a later disjunct.
+- Missing disjuncts: compare every `or` in `filter_block_tree`,
+  `should_extend_payload`, `should_apply_proposer_boost`,
+  `validate_on_attestation`, `get_proposer_head`-related helpers, and payload
+  status tiebreaking. A missing permissive disjunct can reject a viable branch;
+  a missing restrictive disjunct can accept an invalid block or vote.
+- Epoch boundaries: explicitly test genesis epoch, first slot of an epoch,
+  current vs previous epoch attestations, and slots where
+  `compute_slots_since_epoch_start(slot) == 0`. These paths affect
+  `filter_block_tree`, `on_tick_per_slot`, pulled-up unrealized checkpoints, and
+  proposer reorg helper behavior.
+- Timeliness boundaries: check `<` vs `<=` against the spec for attestation,
+  aggregate, contribution, sync-message, PTC, and proposer reorg cutoffs. Tests
+  should cover exactly-at-threshold arrival.
+- Gloas payload status: when reviewing `PENDING`, `EMPTY`, and `FULL` handling,
+  trace both the beacon block root and the parent execution block hash. Confirm
+  `get_parent_payload_status`, `get_node_children`,
+  `get_payload_status_tiebreaker`, and `is_supporting_vote` agree on the same
+  status transition.
+- PTC votes: payload timeliness and blob-data availability are separate vote
+  vectors. A payload-present vote must not imply blob-data availability, and
+  local payload/envelope availability must still gate both spec helpers.
+- Equivocations: `equivocating_indices` must be excluded from latest-message
+  weight, but Gloas `is_head_weak` also adds back the specified committee
+  weight for equivocating validators. Review both sides together.
+- Store mutation safety: spec handlers that fail assertions must not mutate the
+  store. In Go, validate all reject/ignore conditions before writes to latest
+  messages, block trees, payload states, timeliness maps, and checkpoint fields.
+- Cache invalidation: any change to latest messages, payload status, block
+  timeliness, proposer boost root, checkpoints, or fork graph contents can make
+  cached head/weight data stale. Confirm invalidation happens on every mutating
+  path.
+- Pre-fork vs post-fork behavior: preserve Phase0/Bellatrix/Deneb behavior when
+  the current state version is pre-Gloas. Gloas-only logic should be gated by
+  the same fork-version or epoch boundary that the surrounding code uses.
+- Electra execution requests: for Electra and later, `OnBlock`/envelope EL
+  validation must pass execution requests consistently with the beacon block or
+  envelope source. Empty request lists and nil request lists are not equivalent
+  unless the surrounding code intentionally normalizes them.
+- Data availability: Deneb checks blob sidecars before accepting a block; Fulu
+  checks data column sidecars through PeerDAS by block root; Gloas checks
+  committed bid blob data during envelope processing. Review fork-version
+  branches so the check is neither skipped nor duplicated for the active fork.
+- Tests: add or update focused tests for any spec branch that changes. Prefer
+  table tests that name the spec condition, especially for conditional/fallback,
+  missing-disjunct, data-availability, and epoch-boundary cases.

--- a/cl/transition/CLAUDE.md
+++ b/cl/transition/CLAUDE.md
@@ -1,0 +1,133 @@
+# Caplin State Transition Spec Map
+
+This directory contains the beacon state transition pipeline and the eth2
+operation implementations. Review changes against the upstream consensus specs,
+especially when fork-version branches change.
+
+Primary references:
+
+- Beacon chain state transition: https://ethereum.github.io/consensus-specs/specs/phase0/beacon-chain/
+- Altair beacon chain: https://ethereum.github.io/consensus-specs/specs/altair/beacon-chain/
+- Bellatrix beacon chain: https://ethereum.github.io/consensus-specs/specs/bellatrix/beacon-chain/
+- Capella beacon chain: https://ethereum.github.io/consensus-specs/specs/capella/beacon-chain/
+- Deneb beacon chain: https://ethereum.github.io/consensus-specs/specs/deneb/beacon-chain/
+- Electra beacon chain: https://ethereum.github.io/consensus-specs/specs/electra/beacon-chain/
+- Fulu beacon chain: https://ethereum.github.io/consensus-specs/specs/fulu/beacon-chain/
+- Gloas beacon chain: https://ethereum.github.io/consensus-specs/specs/gloas/beacon-chain/
+
+## Transition Pipeline Map
+
+Use this map when reviewing `cl/transition/machine/`.
+
+| Go file/function | Spec section |
+| --- | --- |
+| `machine/transition.go`: `TransitionState` | Phase0 `state_transition`: `process_slots`, block signature verification, `process_block`, final state-root assertion |
+| `machine/block.go`: `ProcessBlock` | Phase0 `process_block`; Bellatrix/Capella execution payload and withdrawals; Gloas modified `process_block` ordering with `process_parent_execution_payload`, `process_withdrawals`, and `process_execution_payload_bid` |
+| `machine/block.go`: `ProcessOperations` | Phase0 `process_operations`; Capella `process_bls_to_execution_change`; Electra execution requests; Gloas payload attestations |
+| `machine/block.go`: `processRandao` | Phase0 `process_randao`; batched signature collection for block-level validation |
+| `machine/block.go`: `processProposerSlashings` | Phase0 `process_proposer_slashing`; signature domain/signing-root validation |
+| `machine/block.go`: `processVoluntaryExits` | Phase0 `process_voluntary_exit`; Capella/Deneb voluntary-exit domain rule; Gloas builder-index exit signature source |
+| `machine/block.go`: `processBlsToExecutionChanges` | Capella `process_bls_to_execution_change`; fork-agnostic BLS-to-execution-change domain |
+| `machine/block.go`: `forEachProcess` | Local dispatcher for homogeneous SSZ operation lists; review with the operation-specific spec function |
+| `machine/helpers.go`: `executionEnabled` | Bellatrix `is_execution_enabled` merge-transition gate |
+| `impl/eth2/validation.go`: `VerifyTransition`, `VerifyBlockSignature` | Phase0 state-root assertion after `process_block`; `verify_block_signature` |
+| `impl/eth2/utils.go`: `transitionSlot`, `computeSigningRootEpoch` | Phase0 `process_slot` (state/block root caching, Gloas payload availability reset); signing-root helper |
+| `compat.go`: `TransitionState` | Top-level entry point wiring `DefaultMachine` and `ValidatingMachine` |
+| `machine/machine.go`: `Interface`, `BlockProcessor`, `BlockValidator`, `SlotProcessor`, `BlockHeaderProcessor`, `BlockOperationProcessor` | Local interface hierarchy for the spec functions implemented in `impl/eth2/` |
+
+## Block Operation Spec Map
+
+Use this map when reviewing `cl/transition/impl/eth2/operations.go`.
+
+| Go file/function | Spec section |
+| --- | --- |
+| `operations.go`: `FullValidate` | Local validation-mode switch; affects signature and Merkle proof assertions around spec processing |
+| `operations.go`: `ProcessProposerSlashing` | Phase0 `process_proposer_slashing`; Gloas builder pending-payment removal for slashed proposer window |
+| `operations.go`: `ProcessAttesterSlashing` | Phase0 `process_attester_slashing`; `is_slashable_attestation_data`; `is_valid_indexed_attestation` |
+| `operations.go`: `ProcessDeposit` | Phase0 `process_deposit`; Electra modified deposit queuing through `pending_deposits` |
+| `operations.go`: `getPendingBalanceToWithdraw` | Electra helper for `process_withdrawal_request`, `process_consolidation_request`, voluntary exits, and pending partial withdrawals |
+| `operations.go`: `IsVoluntaryExitApplicable`, `ProcessVoluntaryExit` | Phase0 `process_voluntary_exit`; Electra pending-partial-withdrawal guard; Gloas builder voluntary exits |
+| `operations.go`: `ProcessWithdrawals`, `processWithdrawalsPreGloas`, `processWithdrawalsGloas` | Capella `process_withdrawals`; Electra pending partial withdrawals; Gloas modified `process_withdrawals` with parent-empty early return and payload expected withdrawals |
+| `operations.go`: `applyWithdrawals` | Capella balance decreases; Gloas builder balance withdrawals |
+| `operations.go`: `updateNextWithdrawalIndex`, `updatePendingPartialWithdrawals`, `updateNextWithdrawalValidatorIndex`, `updatePayloadExpectedWithdrawals`, `updateBuilderPendingWithdrawals`, `updateNextWithdrawalBuilderIndex` | Capella/Electra/Gloas withdrawal cursor and queue updates |
+| `operations.go`: `ProcessExecutionPayloadBid`, `verifyExecutionPayloadBidSignature` | Gloas `process_execution_payload_bid`; builder activity, bid coverage, bid signature, blob limit, bid slot/parent/randao checks |
+| `operations.go`: `ApplyParentExecutionPayload`, `ProcessParentExecutionPayload` | Gloas `apply_parent_execution_payload`; `process_parent_execution_payload`; parent empty/full branching; execution request root commitment |
+| `operations.go`: `ProcessExecutionPayloadEnvelope` | Gloas `process_execution_payload_envelope`; committed bid consistency, execution requests root, timestamp, withdrawals root |
+| `operations_utils.go`: `verifyExecutionPayloadEnvelopeSignature` | Gloas envelope builder signature verification |
+| `operations.go`: `ProcessExecutionPayload` | Bellatrix `process_execution_payload`; Deneb/Fulu blob commitment limits; latest execution payload header update |
+| `operations.go`: `ProcessSyncAggregate`, `processSyncAggregate` | Altair `process_sync_aggregate`; sync committee participant/proposer rewards and signature check |
+| `operations.go`: `ProcessBlsToExecutionChange` | Capella `process_bls_to_execution_change` |
+| `operations.go`: `ProcessAttestations`, `processAttestation`, `IsAttestationApplicable` | Phase0 `process_attestation`; Altair participation flags; Deneb/Electra modified inclusion and committee-index checks |
+| `operations.go`: `processAttestationPhase0` | Phase0 `process_attestation`, pending attestation queues, matching source/target/head helpers |
+| `operations.go`: `processAttestationPostAltair` | Altair modified `process_attestation`; Electra committee bits; Gloas same-slot builder pending-payment weight accumulation |
+| `operations.go`: `verifyAttestations`, `batchVerifyAttestations` | Phase0 `is_valid_indexed_attestation`; local batched aggregate signature verification |
+| `operations.go`: `ProcessBlockHeader` | Phase0 `process_block_header` |
+| `operations.go`: `ProcessRandao` | Phase0 `process_randao` |
+| `operations.go`: `ProcessEth1Data` | Phase0 `process_eth1_data` |
+| `operations.go`: `ProcessSlots` | Phase0 `process_slots`, `process_slot`, `process_epoch`; local fork upgrades at epoch boundaries |
+| `operations.go`: `ProcessDepositRequest` | Electra `process_deposit_request`; Gloas builder deposit routing and deposit-request start-index behavior |
+| `operations.go`: `ProcessWithdrawalRequest`, `processBuilderWithdrawalRequest` | Electra `process_withdrawal_request`; Gloas builder withdrawal/full-exit request handling |
+| `operations.go`: `ProcessConsolidationRequest`, `isValidSwitchToCompoundingRequest`, `switchToCompoundingValidator`, `computeConsolidationEpochAndUpdateChurn` | Electra `process_consolidation_request`; `is_valid_switch_to_compounding_request`; `switch_to_compounding_validator`; `compute_consolidation_epoch_and_update_churn` |
+| `operations.go`: `ProcessPayloadAttestation` | Gloas `process_payload_attestation`; parent block root, previous slot, indexed payload attestation signature |
+
+## Epoch Processing Spec Map
+
+Use this map when reviewing `cl/transition/impl/eth2/statechange/`.
+
+| Go file/function | Spec section |
+| --- | --- |
+| `process_epoch.go`: `ProcessEpoch`, `GetUnslashedIndiciesSet` | Phase0/Altair `process_epoch`; `get_unslashed_participating_indices`; fork-version ordered epoch sub-transitions |
+| `finalization_and_justification.go`: `ProcessJustificationBitsAndFinality`, `weighJustificationAndFinalization`, `computePreviousAndCurrentTargetBalancePostAltair` | Phase0/Altair `process_justification_and_finalization`; target balance thresholds and justification bits |
+| `process_rewards_and_penalties.go`: `ProcessRewardsAndPenalties`, `processRewardsAndPenaltiesPhase0`, `processRewardsAndPenaltiesPostAltair`, `getFlagsTotalBalances` | Phase0/Altair `process_rewards_and_penalties`; base rewards, participation flags, inactivity penalties |
+| `process_registry_updates.go`: `ProcessRegistryUpdates`, `computeActivationExitEpoch` | Phase0 `process_registry_updates`; `compute_activation_exit_epoch`; Electra churn-aware activation/exit rules |
+| `process_effective_balance_update.go`: `ProcessEffectiveBalanceUpdates` | Phase0 `process_effective_balance_updates`; hysteresis thresholds; Electra max effective balance |
+| `process_slashings.go`: `ProcessSlashings`, `processSlashingsElectra` | Phase0/Electra `process_slashings`; proportional slashing penalties |
+| `process_historical_roots.go`: `ProcessParticipationRecordUpdates` | Phase0 `process_participation_record_updates` |
+| `process_historical_roots_update.go`: `ProcessHistoricalRootsUpdate` | Phase0 `process_historical_roots_update` |
+| `process_inactivity_scores.go`: `ProcessInactivityScores` | Altair `process_inactivity_updates` / `process_inactivity_scores` |
+| `process_sync_committee_update.go`: `ProcessSyncCommitteeUpdate` | Altair `process_sync_committee_updates` |
+| `resets.go`: `ProcessEth1DataReset`, `ProcessSlashingsReset`, `ProcessRandaoMixesReset`, `ProcessParticipationFlagUpdates` | Phase0/Altair epoch resets: eth1 data votes, slashings, randao mixes, participation flags |
+| `process_pending_deposits.go`: `ProcessPendingDeposits`, `applyPendingDeposit` | Electra `process_pending_deposits`; finalized deposit gating; churn consumption; postponed deposits; deposit signature/registry application |
+| `process_pending_consolidations.go`: `ProcessPendingConsolidations` | Electra `process_pending_consolidations` |
+| `process_builder_pending_payments.go`: `ProcessBuilderPendingPayments` | Gloas builder pending-payment epoch rotation and payment finalization |
+| `process_proposer_lookahead.go`: `ProcessProposerLookahead` | Gloas proposer lookahead update |
+| `process_ptc_window.go`: `ProcessPtcWindow` | Gloas PTC window update |
+| `utils.go`: `IsValidDepositSignature`, `AddValidatorToRegistry` | Phase0/Electra deposit helpers: deposit proof-of-possession and validator registry append |
+
+## Review Checklist
+
+- Preserve the spec order in `ProcessSlots`, `ProcessBlock`, and `ProcessEpoch`.
+  Gloas intentionally moves parent execution payload handling before block
+  header processing and moves execution-payload effects across block boundaries.
+- For every operation, separate reject/assert failures from ignore/no-op cases.
+  Execution requests often ignore invalid EL-triggered items, while block
+  operations such as slashings, attestations, and headers generally reject.
+- Validate before mutating state when the spec assertion can fail. Pay special
+  attention to deposits, attestations, execution payload bids/envelopes,
+  withdrawal cursors, and builder payment queues.
+- Review fork gates explicitly. Phase0, Altair, Bellatrix, Capella, Deneb,
+  Electra, Fulu, and Gloas branches must preserve pre-fork behavior and use the
+  same epoch/version boundary as the surrounding transition code.
+- Check partial-list queue updates with the local pattern from pending deposits:
+  iterate until the first unprocessed item, `ShallowCopy`, `Cut(processedCount)`,
+  append postponed items in order, then write the list back. Do not mutate a
+  shared list or drop postponed entries. Watch for code that processes only a
+  prefix and silently drops the tail, or that substitutes the full list where the
+  spec intentionally uses the partial accumulator.
+- Withdrawal processing has multiple independent cursors and queues:
+  `next_withdrawal_index`, `next_withdrawal_validator_index`,
+  `pending_partial_withdrawals`, Gloas `builder_pending_withdrawals`, and
+  `next_withdrawal_builder_index`. Verify each cursor advances from the same
+  processed count used by the spec helper.
+- In Gloas, distinguish `latest_block_hash`, `latest_execution_payload_bid`,
+  parent execution requests, payload expected withdrawals, and builder pending
+  payments. Empty parent blocks must not apply full-parent payload effects.
+- For attestations, test current vs previous epoch, exactly
+  `MIN_ATTESTATION_INCLUSION_DELAY`, Deneb's relaxed upper bound, Electra
+  committee bits, and Gloas same-slot builder-payment weight.
+- Execution payload validation changed across forks: Bellatrix checks payload
+  header consistency, Deneb/Fulu add blob commitment limits, Electra adds
+  execution requests, and Gloas verifies envelopes against committed bids.
+- Epoch processing tests should cover genesis/early epochs, finality delay,
+  inactivity leak entry/exit, slashed validators, churn exhaustion, postponed
+  deposits, and Gloas builder/PTC window rotations.


### PR DESCRIPTION
## Summary
- Split the monolithic `cl/CLAUDE.md` into per-directory spec maps so each consensus-critical subdirectory has its own function-to-spec mapping and review checklist
- `cl/CLAUDE.md` → concise top-level overview linking to subdirectories
- `cl/phase1/forkchoice/CLAUDE.md` → forkchoice spec map (Phase0 through Gloas/Fulu)
- `cl/transition/CLAUDE.md` → state transition: block operations + epoch processing
- `cl/phase1/core/state/CLAUDE.md` → beacon state accessors, mutators, cache helpers

## Motivation
Agent-assisted code changes in consensus-critical areas need spec grounding. Without function-level spec mappings, agents (and humans) can make changes that look locally correct but deviate from the spec — e.g., substituting a full list where the spec intentionally uses a partial accumulator.

## Test plan
- [ ] Docs-only change — no code modified
- [ ] All relative links verified to point at existing files
- [ ] All Go function names in spec maps verified against codebase (two rounds of subagent review, 100+ function names spot-checked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)