### PR TITLE
db/integrity: check txnum lookup misses

### DIFF
--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -1919,10 +1919,14 @@ func doCheckRCacheRootAtBlkRange(cliCtx *cli.Context, logger log.Logger) error {
 			return err
 		}
 		defer tx.Rollback()
-		rcacheTip, _, err := blockReader.TxnumReader().FindBlockNum(ctx, tx, tx.Debug().DomainProgress(kv.RCacheDomain))
+		rcacheDomainProgress := tx.Debug().DomainProgress(kv.RCacheDomain)
+		rcacheTip, ok, err := blockReader.TxnumReader().FindBlockNum(ctx, tx, rcacheDomainProgress)
 		tx.Rollback()
 		if err != nil {
 			return err
+		}
+		if !ok {
+			return fmt.Errorf("findBlockNum(%d) not found", rcacheDomainProgress)
 		}
 		to = rcacheTip + 1 // exclusive upper bound
 		logger.Info("[check-rcache-root-at-blk-range] auto-detected --to", "to", to)

--- a/db/integrity/rcache_no_duplicates.go
+++ b/db/integrity/rcache_no_duplicates.go
@@ -30,7 +30,13 @@ func CheckRCacheNoDups(ctx context.Context, sc SamplerCfg, db kv.TemporalRoDB, b
 
 	rcacheDomainProgress := tx.Debug().DomainProgress(kv.RCacheDomain)
 	fromBlock := uint64(1)
-	toBlock, _, _ := txNumsReader.FindBlockNum(ctx, tx, rcacheDomainProgress)
+	toBlock, ok, err := txNumsReader.FindBlockNum(ctx, tx, rcacheDomainProgress)
+	if err != nil {
+		return fmt.Errorf("findBlockNum(%d) fails: %w", rcacheDomainProgress, err)
+	}
+	if !ok {
+		return fmt.Errorf("findBlockNum(%d) not found", rcacheDomainProgress)
+	}
 
 	if err := ValidateDomainProgress(ctx, db, kv.RCacheDomain, txNumsReader); err != nil {
 		return err

--- a/db/integrity/rcache_receipt_root.go
+++ b/db/integrity/rcache_receipt_root.go
@@ -50,7 +50,13 @@ func CheckReceiptRootIntegrity(ctx context.Context, sc SamplerCfg, db kv.Tempora
 	defer tx.Rollback()
 
 	rcacheDomainProgress := tx.Debug().DomainProgress(kv.RCacheDomain)
-	rcacheTip, _, _ := txNumsReader.FindBlockNum(ctx, tx, rcacheDomainProgress)
+	rcacheTip, ok, err := txNumsReader.FindBlockNum(ctx, tx, rcacheDomainProgress)
+	if err != nil {
+		return fmt.Errorf("findBlockNum(%d) fails: %w", rcacheDomainProgress, err)
+	}
+	if !ok {
+		return fmt.Errorf("findBlockNum(%d) not found", rcacheDomainProgress)
+	}
 
 	if err := ValidateDomainProgress(ctx, db, kv.RCacheDomain, txNumsReader); err != nil {
 		return err

--- a/db/integrity/receipts_no_duplicates.go
+++ b/db/integrity/receipts_no_duplicates.go
@@ -33,7 +33,13 @@ func CheckReceiptsNoDups(ctx context.Context, sc SamplerCfg, db kv.TemporalRoDB,
 
 	receiptProgress := tx.Debug().DomainProgress(kv.ReceiptDomain)
 	fromBlock := uint64(1)
-	toBlock, _, _ := txNumsReader.FindBlockNum(ctx, tx, receiptProgress)
+	toBlock, ok, err := txNumsReader.FindBlockNum(ctx, tx, receiptProgress)
+	if err != nil {
+		return fmt.Errorf("findBlockNum(%d) fails: %w", receiptProgress, err)
+	}
+	if !ok {
+		return fmt.Errorf("findBlockNum(%d) not found", receiptProgress)
+	}
 
 	log.Info("[integrity] ReceiptsNoDups starting", "fromBlock", fromBlock, "toBlock", toBlock)
 	return parallelChunkCheck(ctx, sc.NewSampler(), fromBlock, toBlock, db, blockReader, failFast, string(ReceiptsNoDups), ReceiptsNoDupsRange)


### PR DESCRIPTION
## Summary

- Check the `ok` result from `FindBlockNum` before deriving integrity check block ranges from domain progress.
- Return a diagnostic error when receipt or rcache progress cannot be mapped to a block.
- Apply the same guard to `check-rcache-root-at-blk-range` auto-detection.