### PR TITLE
docs: May 2026 w22 — v3.4.2 update

### DIFF
--- a/docs/site/docs/fundamentals/configuring-erigon/index.mdx
+++ b/docs/site/docs/fundamentals/configuring-erigon/index.mdx
@@ -84,6 +84,8 @@ These flags control database performance and memory usage.
   * Default: `0MB`
 * `--sync.parallel-state-flushing`: Enables parallel state flushing.
   * Default: `true`
+* `--erigondb.domain.steps-in-frozen-file value`: Overrides the `steps_in_frozen_file` setting in `erigondb.toml` for the domain merge cap only (history and inverted-index merges are unaffected). Pass a positive integer to set an explicit cap, or `"Inf"` to leave the domain merge unbounded.
+  * Default: unset (the value from `erigondb.toml` is used)
 
 ### Pruning and Snapshots
 

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -2879,6 +2879,8 @@ These flags control database performance and memory usage.
   * Default: `0MB`
 * `--sync.parallel-state-flushing`: Enables parallel state flushing.
   * Default: `true`
+* `--erigondb.domain.steps-in-frozen-file value`: Overrides the `steps_in_frozen_file` setting in `erigondb.toml` for the domain merge cap only (history and inverted-index merges are unaffected). Pass a positive integer to set an explicit cap, or `"Inf"` to leave the domain merge unbounded.
+  * Default: unset (the value from `erigondb.toml` is used)
 
 ### Pruning and Snapshots
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2879,6 +2879,8 @@ These flags control database performance and memory usage.
   * Default: `0MB`
 * `--sync.parallel-state-flushing`: Enables parallel state flushing.
   * Default: `true`
+* `--erigondb.domain.steps-in-frozen-file value`: Overrides the `steps_in_frozen_file` setting in `erigondb.toml` for the domain merge cap only (history and inverted-index merges are unaffected). Pass a positive integer to set an explicit cap, or `"Inf"` to leave the domain merge unbounded.
+  * Default: unset (the value from `erigondb.toml` is used)
 
 ### Pruning and Snapshots
 


### PR DESCRIPTION
## Summary

New in v3.4.2 (PR #21148): `--erigondb.domain.steps-in-frozen-file`

**What it does:** Overrides the `steps_in_frozen_file` setting in `erigondb.toml` for the domain merge cap only (history and inverted-index merges are unaffected). Accepts a positive integer or `"Inf"` to leave unbounded.

**Verification:**
- Defined in `cmd/utils/flags.go` as `ErigondbDomainStepsInFrozenFileFlag`
- Registered in `node/cli/default_flags.go` (confirmed in #21148 diff)
- Not present on `main` — no `main` PR needed for this change

**Docs placement:** Database and Caching section in `configuring-erigon/index.mdx`