### PR TITLE
cl/gloas: gate fork choice on verified execution payloads

### DIFF
--- a/cl/phase1/forkchoice/forkchoice.go
+++ b/cl/phase1/forkchoice/forkchoice.go
@@ -107,6 +107,7 @@ type ForkChoiceStore struct {
 	// [New in Gloas:EIP7732] Track execution payload validation status by execution block hash.
 	// Used to check if parent execution payload has been validated/invalidated for gossip validation.
 	executionPayloadStatus *lru.Cache[common.Hash, execution_client.PayloadStatus]
+	payloadStatusByRoot    *lru.Cache[common.Hash, execution_client.PayloadStatus]
 	// [New in Gloas:EIP7732] Track execution payload gas_limit by execution block hash.
 	// Used for the is_gas_limit_target_compatible IGNORE check in bid gossip validation.
 	executionPayloadGasLimit *lru.Cache[common.Hash, uint64]
@@ -316,6 +317,10 @@ func NewForkChoiceStore(
 	if err != nil {
 		return nil, err
 	}
+	payloadStatusByRoot, err := lru.New[common.Hash, execution_client.PayloadStatus](checkpointsPerCache)
+	if err != nil {
+		return nil, err
+	}
 
 	// [New in Gloas:EIP7732] Track execution payload gas_limit by execution block hash
 	executionPayloadGasLimit, err := lru.New[common.Hash, uint64](checkpointsPerCache)
@@ -377,6 +382,7 @@ func NewForkChoiceStore(
 		pendingEnvelopes:               pendingEnvelopes,
 		pendingLocalSelfBuildEnvelopes: pendingLocalSelfBuildEnvelopes,
 		executionPayloadStatus:         executionPayloadStatus,
+		payloadStatusByRoot:            payloadStatusByRoot,
 		executionPayloadGasLimit:       executionPayloadGasLimit,
 		db:                             db,
 	}
@@ -425,6 +431,13 @@ func (f *ForkChoiceStore) GetPeerDas() das.PeerDas {
 // [New in Gloas:EIP7732]
 func (f *ForkChoiceStore) GetRecentExecutionPayloadStatus(executionBlockHash common.Hash) (execution_client.PayloadStatus, bool) {
 	return f.executionPayloadStatus.Get(executionBlockHash)
+}
+
+func (f *ForkChoiceStore) GetRecentExecutionPayloadStatusByRoot(blockRoot common.Hash) (execution_client.PayloadStatus, bool) {
+	if f.payloadStatusByRoot == nil {
+		return execution_client.PayloadStatusNone, false
+	}
+	return f.payloadStatusByRoot.Get(blockRoot)
 }
 
 // GetExecutionPayloadGasLimit returns the gas_limit of a recently validated execution payload.
@@ -780,9 +793,16 @@ func (f *ForkChoiceStore) MarkPayloadVerified(blockRoot common.Hash, executionBl
 		return
 	}
 	f.verifiedExecutionPayload.Add(blockRoot, struct{}{})
-	f.executionPayloadStatus.Add(executionBlockHash, execution_client.PayloadStatusValidated)
-	if err := f.optimisticStore.ValidateBlock(blockRoot, block); err != nil {
-		log.Warn("[MarkPayloadVerified] optimistic store update failed", "blockRoot", blockRoot, "err", err)
+	if f.executionPayloadStatus != nil {
+		f.executionPayloadStatus.Add(executionBlockHash, execution_client.PayloadStatusValidated)
+	}
+	if f.payloadStatusByRoot != nil {
+		f.payloadStatusByRoot.Add(blockRoot, execution_client.PayloadStatusValidated)
+	}
+	if block != nil && f.optimisticStore != nil {
+		if err := f.optimisticStore.ValidateBlock(blockRoot, block); err != nil {
+			log.Warn("[MarkPayloadVerified] optimistic store update failed", "blockRoot", blockRoot, "err", err)
+		}
 	}
 	f.mu.Lock()
 	f.headHash = common.Hash{}
@@ -799,8 +819,11 @@ func (f *ForkChoiceStore) MarkPayloadInvalid(blockRoot common.Hash, executionBlo
 	if f.executionPayloadStatus != nil {
 		f.executionPayloadStatus.Add(executionBlockHash, execution_client.PayloadStatusInvalidated)
 	}
+	if f.payloadStatusByRoot != nil {
+		f.payloadStatusByRoot.Add(blockRoot, execution_client.PayloadStatusInvalidated)
+	}
 	f.forkGraph.MarkHeaderAsInvalid(blockRoot)
-	if f.optimisticStore != nil {
+	if block != nil && f.optimisticStore != nil {
 		if err := f.optimisticStore.InvalidateBlock(blockRoot, block); err != nil {
 			log.Warn("[MarkPayloadInvalid] optimistic store update failed", "blockRoot", blockRoot, "err", err)
 		}
@@ -1035,6 +1058,14 @@ func (f *ForkChoiceStore) GetProposerLookahead(slot uint64) (solid.Uint64VectorS
 func (f *ForkChoiceStore) addPendingELPayload(block *cltypes.SignedBeaconBlock, envelope *cltypes.SignedExecutionPayloadEnvelope) {
 	f.pendingELPayloadsMu.Lock()
 	defer f.pendingELPayloadsMu.Unlock()
+	root, ok := pendingELPayloadRoot(PendingELPayload{Block: block, Envelope: envelope})
+	if ok {
+		for _, p := range f.pendingELPayloads {
+			if existingRoot, existingOk := pendingELPayloadRoot(p); existingOk && existingRoot == root {
+				return
+			}
+		}
+	}
 	if len(f.pendingELPayloads) >= maxPendingELPayloads {
 		log.Warn("addPendingELPayload: dropping oldest pending EL payload", "queueLen", len(f.pendingELPayloads))
 		copy(f.pendingELPayloads, f.pendingELPayloads[1:])
@@ -1045,6 +1076,13 @@ func (f *ForkChoiceStore) addPendingELPayload(block *cltypes.SignedBeaconBlock, 
 		Block:    block,
 		Envelope: envelope,
 	})
+}
+
+func pendingELPayloadRoot(p PendingELPayload) (common.Hash, bool) {
+	if p.Envelope != nil && p.Envelope.Message != nil && p.Envelope.Message.BeaconBlockRoot != (common.Hash{}) {
+		return p.Envelope.Message.BeaconBlockRoot, true
+	}
+	return common.Hash{}, false
 }
 
 // RequeuePendingELPayload queues a drained execution payload for another EL validation attempt.

--- a/cl/phase1/forkchoice/forkchoice.go
+++ b/cl/phase1/forkchoice/forkchoice.go
@@ -790,6 +790,27 @@ func (f *ForkChoiceStore) MarkPayloadVerified(blockRoot common.Hash, executionBl
 	f.mu.Unlock()
 }
 
+// MarkPayloadInvalid records that the execution payload has been rejected by the EL.
+// [New in Gloas:EIP7732]
+func (f *ForkChoiceStore) MarkPayloadInvalid(blockRoot common.Hash, executionBlockHash common.Hash, block *cltypes.BeaconBlock) {
+	if f.verifiedExecutionPayload != nil {
+		f.verifiedExecutionPayload.Remove(blockRoot)
+	}
+	if f.executionPayloadStatus != nil {
+		f.executionPayloadStatus.Add(executionBlockHash, execution_client.PayloadStatusInvalidated)
+	}
+	f.forkGraph.MarkHeaderAsInvalid(blockRoot)
+	if f.optimisticStore != nil {
+		if err := f.optimisticStore.InvalidateBlock(blockRoot, block); err != nil {
+			log.Warn("[MarkPayloadInvalid] optimistic store update failed", "blockRoot", blockRoot, "err", err)
+		}
+	}
+	f.mu.Lock()
+	f.headHash = common.Hash{}
+	f.headPayloadStatus = cltypes.PayloadStatusPending
+	f.mu.Unlock()
+}
+
 // ReadEnvelopeFromDisk delegates to forkGraph.ReadEnvelopeFromDisk.
 // [New in Gloas:EIP7732]
 func (f *ForkChoiceStore) ReadEnvelopeFromDisk(blockRoot common.Hash) (*cltypes.SignedExecutionPayloadEnvelope, error) {

--- a/cl/phase1/forkchoice/forkchoice.go
+++ b/cl/phase1/forkchoice/forkchoice.go
@@ -784,11 +784,13 @@ func (f *ForkChoiceStore) IsPayloadVerified(blockRoot common.Hash) bool {
 	return f.verifiedExecutionPayload.Contains(blockRoot)
 }
 
-// MarkPayloadVerified records that the execution payload has been accepted by the EL
-// and updates all associated state: verified-payload cache, execution-payload-status
-// LRU, optimistic store, and head cache invalidation.
-// [New in Gloas:EIP7732]
-func (f *ForkChoiceStore) MarkPayloadVerified(blockRoot common.Hash, executionBlockHash common.Hash, block *cltypes.BeaconBlock) {
+func (f *ForkChoiceStore) MarkPayloadVerified(blockRoot common.Hash, executionBlockHash common.Hash) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.markPayloadVerifiedLocked(blockRoot, executionBlockHash)
+}
+
+func (f *ForkChoiceStore) markPayloadVerifiedLocked(blockRoot common.Hash, executionBlockHash common.Hash) {
 	if f.verifiedExecutionPayload == nil {
 		return
 	}
@@ -799,20 +801,17 @@ func (f *ForkChoiceStore) MarkPayloadVerified(blockRoot common.Hash, executionBl
 	if f.payloadStatusByRoot != nil {
 		f.payloadStatusByRoot.Add(blockRoot, execution_client.PayloadStatusValidated)
 	}
-	if block != nil && f.optimisticStore != nil {
-		if err := f.optimisticStore.ValidateBlock(blockRoot, block); err != nil {
-			log.Warn("[MarkPayloadVerified] optimistic store update failed", "blockRoot", blockRoot, "err", err)
-		}
-	}
-	f.mu.Lock()
 	f.headHash = common.Hash{}
 	f.headPayloadStatus = cltypes.PayloadStatusPending
-	f.mu.Unlock()
 }
 
-// MarkPayloadInvalid records that the execution payload has been rejected by the EL.
-// [New in Gloas:EIP7732]
-func (f *ForkChoiceStore) MarkPayloadInvalid(blockRoot common.Hash, executionBlockHash common.Hash, block *cltypes.BeaconBlock) {
+func (f *ForkChoiceStore) MarkPayloadInvalid(blockRoot common.Hash, executionBlockHash common.Hash) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.markPayloadInvalidLocked(blockRoot, executionBlockHash)
+}
+
+func (f *ForkChoiceStore) markPayloadInvalidLocked(blockRoot common.Hash, executionBlockHash common.Hash) {
 	if f.verifiedExecutionPayload != nil {
 		f.verifiedExecutionPayload.Remove(blockRoot)
 	}
@@ -823,15 +822,8 @@ func (f *ForkChoiceStore) MarkPayloadInvalid(blockRoot common.Hash, executionBlo
 		f.payloadStatusByRoot.Add(blockRoot, execution_client.PayloadStatusInvalidated)
 	}
 	f.forkGraph.MarkHeaderAsInvalid(blockRoot)
-	if block != nil && f.optimisticStore != nil {
-		if err := f.optimisticStore.InvalidateBlock(blockRoot, block); err != nil {
-			log.Warn("[MarkPayloadInvalid] optimistic store update failed", "blockRoot", blockRoot, "err", err)
-		}
-	}
-	f.mu.Lock()
 	f.headHash = common.Hash{}
 	f.headPayloadStatus = cltypes.PayloadStatusPending
-	f.mu.Unlock()
 }
 
 // ReadEnvelopeFromDisk delegates to forkGraph.ReadEnvelopeFromDisk.

--- a/cl/phase1/forkchoice/forkchoice.go
+++ b/cl/phase1/forkchoice/forkchoice.go
@@ -761,6 +761,35 @@ func (f *ForkChoiceStore) HasEnvelope(blockRoot common.Hash) bool {
 	return f.forkGraph.HasEnvelope(blockRoot)
 }
 
+// IsPayloadVerified returns whether the execution payload for the beacon block root
+// has been accepted by the execution layer.
+// [New in Gloas:EIP7732]
+func (f *ForkChoiceStore) IsPayloadVerified(blockRoot common.Hash) bool {
+	if f.verifiedExecutionPayload == nil {
+		return false
+	}
+	return f.verifiedExecutionPayload.Contains(blockRoot)
+}
+
+// MarkPayloadVerified records that the execution payload has been accepted by the EL
+// and updates all associated state: verified-payload cache, execution-payload-status
+// LRU, optimistic store, and head cache invalidation.
+// [New in Gloas:EIP7732]
+func (f *ForkChoiceStore) MarkPayloadVerified(blockRoot common.Hash, executionBlockHash common.Hash, block *cltypes.BeaconBlock) {
+	if f.verifiedExecutionPayload == nil {
+		return
+	}
+	f.verifiedExecutionPayload.Add(blockRoot, struct{}{})
+	f.executionPayloadStatus.Add(executionBlockHash, execution_client.PayloadStatusValidated)
+	if err := f.optimisticStore.ValidateBlock(blockRoot, block); err != nil {
+		log.Warn("[MarkPayloadVerified] optimistic store update failed", "blockRoot", blockRoot, "err", err)
+	}
+	f.mu.Lock()
+	f.headHash = common.Hash{}
+	f.headPayloadStatus = cltypes.PayloadStatusPending
+	f.mu.Unlock()
+}
+
 // ReadEnvelopeFromDisk delegates to forkGraph.ReadEnvelopeFromDisk.
 // [New in Gloas:EIP7732]
 func (f *ForkChoiceStore) ReadEnvelopeFromDisk(blockRoot common.Hash) (*cltypes.SignedExecutionPayloadEnvelope, error) {
@@ -997,8 +1026,14 @@ func (f *ForkChoiceStore) addPendingELPayload(block *cltypes.SignedBeaconBlock, 
 	})
 }
 
+// RequeuePendingELPayload queues a drained execution payload for another EL validation attempt.
+// [New in Gloas:EIP7732]
+func (f *ForkChoiceStore) RequeuePendingELPayload(p PendingELPayload) {
+	f.addPendingELPayload(p.Block, p.Envelope)
+}
+
 // DrainPendingELPayloads returns and clears all queued EL payloads.
-// The stages layer calls this before Flush() to add them to blockCollector.
+// The stages layer calls this before Flush() to retry them with engine.NewPayload.
 func (f *ForkChoiceStore) DrainPendingELPayloads() []PendingELPayload {
 	f.pendingELPayloadsMu.Lock()
 	defer f.pendingELPayloadsMu.Unlock()

--- a/cl/phase1/forkchoice/interface.go
+++ b/cl/phase1/forkchoice/interface.go
@@ -75,8 +75,11 @@ type ForkChoiceStorageReader interface {
 	GetBlock(blockRoot common.Hash) (*cltypes.SignedBeaconBlock, bool)
 	// [New in Gloas:EIP7732] HasEnvelope checks if a signed execution payload envelope exists.
 	HasEnvelope(blockRoot common.Hash) bool
+	// [New in Gloas:EIP7732] IsPayloadVerified checks whether the execution payload was accepted by the EL.
+	IsPayloadVerified(blockRoot common.Hash) bool
 	// [New in Gloas:EIP7732] ReadEnvelopeFromDisk reads a signed execution payload envelope from disk.
 	ReadEnvelopeFromDisk(blockRoot common.Hash) (*cltypes.SignedExecutionPayloadEnvelope, error)
+	GetRecentExecutionPayloadStatusByRoot(blockRoot common.Hash) (execution_client.PayloadStatus, bool)
 	// [New in Gloas:EIP7732] IsBlobDataAvailable returns the local node's assessment of whether
 	// blob data is available for the given block. Used by the payload_attestation_data API so PTC
 	// validators can set the blob_data_available flag independently of payload_present.

--- a/cl/phase1/forkchoice/mock_services/forkchoice_mock.go
+++ b/cl/phase1/forkchoice/mock_services/forkchoice_mock.go
@@ -69,6 +69,7 @@ type ForkChoiceStorageMock struct {
 	Headers                   map[common.Hash]*cltypes.BeaconBlockHeader
 	Blocks                    map[common.Hash]*cltypes.SignedBeaconBlock
 	Envelopes                 map[common.Hash]*cltypes.SignedExecutionPayloadEnvelope
+	VerifiedPayloads          map[common.Hash]bool
 	GetBeaconCommitteeMock    func(slot, committeeIndex uint64) ([]uint64, error)
 
 	Pool pool.OperationsPool
@@ -82,6 +83,7 @@ type ForkChoiceStorageMock struct {
 
 	// [New in Gloas:EIP7732] Execution payload status by execution block hash
 	ExecutionPayloadStatusMap map[common.Hash]execution_client.PayloadStatus
+	PayloadStatusByRootMap    map[common.Hash]execution_client.PayloadStatus
 	// [New in Gloas:EIP7732] Execution payload gas limit by execution block hash
 	ExecutionPayloadGasLimitMap map[common.Hash]uint64
 }
@@ -213,6 +215,7 @@ func NewForkChoiceStorageMock(t *testing.T) *ForkChoiceStorageMock {
 		SyncContributionPool:        makeSyncContributionPoolMock(t),
 		MockPeerDas:                 mockPeerDas,
 		ExecutionPayloadStatusMap:   make(map[common.Hash]execution_client.PayloadStatus),
+		PayloadStatusByRootMap:      make(map[common.Hash]execution_client.PayloadStatus),
 		ExecutionPayloadGasLimitMap: make(map[common.Hash]uint64),
 	}
 }
@@ -426,6 +429,13 @@ func (f *ForkChoiceStorageMock) HasEnvelope(blockRoot common.Hash) bool {
 	return ok
 }
 
+func (f *ForkChoiceStorageMock) IsPayloadVerified(blockRoot common.Hash) bool {
+	if f.VerifiedPayloads == nil {
+		return false
+	}
+	return f.VerifiedPayloads[blockRoot]
+}
+
 func (f *ForkChoiceStorageMock) ReadEnvelopeFromDisk(blockRoot common.Hash) (*cltypes.SignedExecutionPayloadEnvelope, error) {
 	return f.Envelopes[blockRoot], nil
 }
@@ -527,6 +537,11 @@ func (f *ForkChoiceStorageMock) GetProposerLookahead(slot uint64) (solid.Uint64V
 // [New in Gloas:EIP7732]
 func (f *ForkChoiceStorageMock) GetRecentExecutionPayloadStatus(executionBlockHash common.Hash) (execution_client.PayloadStatus, bool) {
 	status, ok := f.ExecutionPayloadStatusMap[executionBlockHash]
+	return status, ok
+}
+
+func (f *ForkChoiceStorageMock) GetRecentExecutionPayloadStatusByRoot(blockRoot common.Hash) (execution_client.PayloadStatus, bool) {
+	status, ok := f.PayloadStatusByRootMap[blockRoot]
 	return status, ok
 }
 

--- a/cl/phase1/forkchoice/on_attestation.go
+++ b/cl/phase1/forkchoice/on_attestation.go
@@ -282,7 +282,7 @@ func (f *ForkChoiceStore) ValidateOnAttestation(attestation *solid.Attestation) 
 			return errors.New("attestation index must be 0 when block_slot equals attestation_slot")
 		}
 		// PTC attestation (index 1): payload must be verified
-		if attestation.Data.CommitteeIndex == 1 && !f.forkGraph.HasEnvelope(attestation.Data.BeaconBlockRoot) {
+		if attestation.Data.CommitteeIndex == 1 && !f.IsPayloadVerified(attestation.Data.BeaconBlockRoot) {
 			return errors.New("PTC attestation requires verified payload envelope")
 		}
 	}

--- a/cl/phase1/forkchoice/on_execution_payload.go
+++ b/cl/phase1/forkchoice/on_execution_payload.go
@@ -451,24 +451,21 @@ func (f *ForkChoiceStore) applyEnvelopeLocked(ctx context.Context, signedEnvelop
 // on disk to resolve parent execution payloads for subsequent blocks.
 // [New in Gloas:EIP7732]
 func (f *ForkChoiceStore) StoreAnchorEnvelope(blockRoot common.Hash, signedEnvelope *cltypes.SignedExecutionPayloadEnvelope) error {
-	if signedEnvelope == nil || signedEnvelope.Message == nil {
+	if signedEnvelope == nil || signedEnvelope.Message == nil || signedEnvelope.Message.Payload == nil {
 		return errors.New("StoreAnchorEnvelope: nil envelope")
 	}
 	envelope := signedEnvelope.Message
+	if envelope.BeaconBlockRoot != blockRoot {
+		return fmt.Errorf("StoreAnchorEnvelope: envelope root %v does not match block root %v", envelope.BeaconBlockRoot, blockRoot)
+	}
 
 	f.mu.Lock()
-	// Update eth2Roots mapping so FCU can resolve the EL block hash
-	if envelope.Payload != nil {
-		f.eth2Roots.Add(blockRoot, envelope.Payload.BlockHash)
-	}
-	// Persist to disk so HasEnvelope() returns true and forward sync can find it
 	if err := f.forkGraph.DumpEnvelopeOnDisk(blockRoot, signedEnvelope); err != nil {
 		f.mu.Unlock()
 		return fmt.Errorf("StoreAnchorEnvelope: failed to dump envelope: %w", err)
 	}
 	f.mu.Unlock()
 
-	// Write DB indices outside the lock
 	if f.db != nil {
 		ctx := context.Background()
 		if err := f.db.Update(ctx, func(tx kv.RwTx) error {
@@ -477,6 +474,12 @@ func (f *ForkChoiceStore) StoreAnchorEnvelope(blockRoot common.Hash, signedEnvel
 			return fmt.Errorf("StoreAnchorEnvelope: failed to write indices: %w", err)
 		}
 	}
+
+	f.mu.Lock()
+	f.eth2Roots.Add(blockRoot, envelope.Payload.BlockHash)
+	f.headHash = common.Hash{}
+	f.headPayloadStatus = cltypes.PayloadStatusPending
+	f.mu.Unlock()
 	return nil
 }
 

--- a/cl/phase1/forkchoice/on_execution_payload.go
+++ b/cl/phase1/forkchoice/on_execution_payload.go
@@ -296,19 +296,11 @@ func (f *ForkChoiceStore) validatePayloadWithEL(
 		}
 	case execution_client.PayloadStatusInvalidated:
 		log.Warn("validatePayloadWithEL: payload is invalid", "beaconBlockRoot", beaconBlockRoot, "err", err)
-		f.forkGraph.MarkHeaderAsInvalid(beaconBlockRoot)
-		// remove from optimistic candidate
-		if err := f.optimisticStore.InvalidateBlock(beaconBlockRoot, block.Block); err != nil {
-			return fmt.Errorf("failed to remove block from optimistic store: %v", err)
-		}
+		f.markPayloadInvalidLocked(beaconBlockRoot, executionBlockHash)
 		return errors.New("execution payload is invalid")
 	case execution_client.PayloadStatusValidated:
 		log.Trace("validatePayloadWithEL: payload is validated", "beaconBlockRoot", beaconBlockRoot)
-		// remove from optimistic candidate
-		if err := f.optimisticStore.ValidateBlock(beaconBlockRoot, block.Block); err != nil {
-			return fmt.Errorf("failed to validate block in optimistic store: %v", err)
-		}
-		f.verifiedExecutionPayload.Add(beaconBlockRoot, struct{}{})
+		f.markPayloadVerifiedLocked(beaconBlockRoot, executionBlockHash)
 	}
 
 	if err != nil {
@@ -464,6 +456,9 @@ func (f *ForkChoiceStore) StoreAnchorEnvelope(blockRoot common.Hash, signedEnvel
 		f.mu.Unlock()
 		return fmt.Errorf("StoreAnchorEnvelope: failed to dump envelope: %w", err)
 	}
+	f.eth2Roots.Add(blockRoot, envelope.Payload.BlockHash)
+	f.headHash = common.Hash{}
+	f.headPayloadStatus = cltypes.PayloadStatusPending
 	f.mu.Unlock()
 
 	if f.db != nil {
@@ -475,11 +470,6 @@ func (f *ForkChoiceStore) StoreAnchorEnvelope(blockRoot common.Hash, signedEnvel
 		}
 	}
 
-	f.mu.Lock()
-	f.eth2Roots.Add(blockRoot, envelope.Payload.BlockHash)
-	f.headHash = common.Hash{}
-	f.headPayloadStatus = cltypes.PayloadStatusPending
-	f.mu.Unlock()
 	return nil
 }
 

--- a/cl/phase1/forkchoice/on_execution_payload.go
+++ b/cl/phase1/forkchoice/on_execution_payload.go
@@ -432,10 +432,6 @@ func (f *ForkChoiceStore) applyEnvelopeLocked(ctx context.Context, signedEnvelop
 		return false, fmt.Errorf("OnExecutionPayload: failed to dump envelope: %w", err)
 	}
 
-	if !elBehind {
-		f.verifiedExecutionPayload.Add(beaconBlockRoot, struct{}{})
-	}
-
 	// Invalidate head cache — payload status may have changed from PENDING to FULL.
 	// This forces GetHead to recompute on next call so GetHeadPayloadStatus is fresh.
 	f.headHash = common.Hash{}

--- a/cl/phase1/forkchoice/on_execution_payload.go
+++ b/cl/phase1/forkchoice/on_execution_payload.go
@@ -432,6 +432,10 @@ func (f *ForkChoiceStore) applyEnvelopeLocked(ctx context.Context, signedEnvelop
 		return false, fmt.Errorf("OnExecutionPayload: failed to dump envelope: %w", err)
 	}
 
+	if !elBehind {
+		f.verifiedExecutionPayload.Add(beaconBlockRoot, struct{}{})
+	}
+
 	// Invalidate head cache — payload status may have changed from PENDING to FULL.
 	// This forces GetHead to recompute on next call so GetHeadPayloadStatus is fresh.
 	f.headHash = common.Hash{}

--- a/cl/phase1/forkchoice/on_execution_payload_test.go
+++ b/cl/phase1/forkchoice/on_execution_payload_test.go
@@ -19,12 +19,16 @@ package forkchoice
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/hashicorp/golang-lru/v2"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/cl/phase1/execution_client"
 	"github.com/erigontech/erigon/common"
 )
 
@@ -270,4 +274,91 @@ func TestValidatePayloadWithEL_NoEngine(t *testing.T) {
 
 	err := f.validatePayloadWithEL(context.TODO(), envelope, block, common.Hash{})
 	require.NoError(t, err)
+}
+
+func TestValidatePayloadWithELDoesNotRelockForkChoiceMu(t *testing.T) {
+	cfg := &clparams.MainnetBeaconConfig
+	for _, tt := range []struct {
+		name       string
+		status     execution_client.PayloadStatus
+		wantErr    bool
+		wantVerify bool
+	}{
+		{
+			name:       "validated",
+			status:     execution_client.PayloadStatusValidated,
+			wantVerify: true,
+		},
+		{
+			name:    "invalidated",
+			status:  execution_client.PayloadStatusInvalidated,
+			wantErr: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			engine := execution_client.NewMockExecutionEngine(ctrl)
+			engine.EXPECT().
+				NewPayload(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(tt.status, nil)
+
+			verifiedExecutionPayload, err := lru.New[common.Hash, struct{}](16)
+			require.NoError(t, err)
+			executionPayloadStatus, err := lru.New[common.Hash, execution_client.PayloadStatus](16)
+			require.NoError(t, err)
+			payloadStatusByRoot, err := lru.New[common.Hash, execution_client.PayloadStatus](16)
+			require.NoError(t, err)
+			executionPayloadGasLimit, err := lru.New[common.Hash, uint64](16)
+			require.NoError(t, err)
+
+			blockRoot := common.HexToHash("0x1234")
+			executionBlockHash := common.HexToHash("0xabcd")
+			invalidatedHeader := common.Hash{}
+			f := &ForkChoiceStore{
+				beaconCfg:                cfg,
+				engine:                   engine,
+				forkGraph:                payloadVoteForkGraph{invalidatedHeader: &invalidatedHeader},
+				verifiedExecutionPayload: verifiedExecutionPayload,
+				executionPayloadStatus:   executionPayloadStatus,
+				payloadStatusByRoot:      payloadStatusByRoot,
+				executionPayloadGasLimit: executionPayloadGasLimit,
+			}
+			envelope := &cltypes.ExecutionPayloadEnvelope{
+				Payload: &cltypes.Eth1Block{BlockHash: executionBlockHash},
+			}
+			body := cltypes.NewBeaconBody(cfg, clparams.GloasVersion)
+			body.SignedExecutionPayloadBid = &cltypes.SignedExecutionPayloadBid{
+				Message: &cltypes.ExecutionPayloadBid{
+					BlobKzgCommitments: *solid.NewStaticListSSZ[*cltypes.KZGCommitment](0, 48),
+				},
+			}
+			block := &cltypes.SignedBeaconBlock{
+				Block: &cltypes.BeaconBlock{
+					Body: body,
+				},
+			}
+
+			done := make(chan error, 1)
+			go func() {
+				f.mu.Lock()
+				defer f.mu.Unlock()
+				done <- f.validatePayloadWithEL(context.Background(), envelope, block, blockRoot)
+			}()
+
+			select {
+			case err := <-done:
+				if tt.wantErr {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("validatePayloadWithEL blocked while forkchoice mutex was already held")
+			}
+			require.Equal(t, tt.wantVerify, f.IsPayloadVerified(blockRoot))
+			if tt.status == execution_client.PayloadStatusInvalidated {
+				require.Equal(t, blockRoot, invalidatedHeader)
+			}
+		})
+	}
 }

--- a/cl/phase1/forkchoice/payload_vote.go
+++ b/cl/phase1/forkchoice/payload_vote.go
@@ -136,7 +136,10 @@ func (f *ForkChoiceStore) payloadTimeliness(root common.Hash, timely bool) bool 
 	if !ok {
 		return false
 	}
-	if !f.forkGraph.HasEnvelope(root) {
+
+	// If the payload has not been accepted by the execution layer, the payload
+	// is not considered available regardless of the PTC vote.
+	if !f.IsPayloadVerified(root) {
 		return false
 	}
 	votes := voteRaw.([clparams.PtcSize]int8)
@@ -158,7 +161,10 @@ func (f *ForkChoiceStore) payloadDataAvailability(root common.Hash, available bo
 	if !ok {
 		return false
 	}
-	if !f.forkGraph.HasEnvelope(root) {
+
+	// If the payload has not been accepted by the execution layer, the blob data
+	// is not considered available regardless of the PTC vote.
+	if !f.IsPayloadVerified(root) {
 		return false
 	}
 	votes := voteRaw.([clparams.PtcSize]int8)
@@ -266,8 +272,7 @@ func (f *ForkChoiceStore) isSupportingVote(node ForkChoiceNode, message LatestMe
 // Used by prepare_execution_payload to decide FULL vs EMPTY path.
 // [New in Gloas:EIP7732]
 func (f *ForkChoiceStore) ShouldExtendPayload(root common.Hash) bool {
-	// is_payload_verified: the envelope must exist locally
-	if !f.forkGraph.HasEnvelope(root) {
+	if !f.IsPayloadVerified(root) {
 		return false
 	}
 
@@ -353,13 +358,7 @@ func (f *ForkChoiceStore) getNodeChildren(node ForkChoiceNode, blocks map[common
 		children := []ForkChoiceNode{
 			{Root: node.Root, PayloadStatus: cltypes.PayloadStatusEmpty},
 		}
-		// Check disk for envelope existence to determine if FULL status is available.
-		// Spec: is_payload_verified(store, node.root) — in the spec, store.payloads is populated
-		// only after EL returns VALID. During forward sync the EL returns SYNCING for most
-		// payloads, so requiring verifiedExecutionPayload would block the FULL path entirely.
-		// Using HasEnvelope (disk persistence) as a pragmatic proxy; verifiedExecutionPayload
-		// can be added once the EL catches up and validates payloads retroactively.
-		if f.forkGraph.HasEnvelope(node.Root) {
+		if f.IsPayloadVerified(node.Root) {
 			children = append(children, ForkChoiceNode{
 				Root: node.Root, PayloadStatus: cltypes.PayloadStatusFull,
 			})

--- a/cl/phase1/forkchoice/payload_vote_test.go
+++ b/cl/phase1/forkchoice/payload_vote_test.go
@@ -3,13 +3,17 @@ package forkchoice
 import (
 	"testing"
 
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/stretchr/testify/require"
+
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
 	state2 "github.com/erigontech/erigon/cl/phase1/core/state"
+	"github.com/erigontech/erigon/cl/phase1/execution_client"
 	"github.com/erigontech/erigon/cl/phase1/forkchoice/fork_graph"
+	"github.com/erigontech/erigon/cl/phase1/forkchoice/optimistic"
 	"github.com/erigontech/erigon/common"
-	"github.com/stretchr/testify/require"
 )
 
 type ptcVoteForkGraph struct {
@@ -19,6 +23,30 @@ type ptcVoteForkGraph struct {
 
 func (g ptcVoteForkGraph) HasEnvelope(root common.Hash) bool {
 	return g.envelopes[root]
+}
+
+type payloadVoteForkGraph struct {
+	fork_graph.ForkGraph
+	hasEnvelope       bool
+	dumpedEnvelope    *common.Hash
+	invalidatedHeader *common.Hash
+}
+
+func (g payloadVoteForkGraph) HasEnvelope(common.Hash) bool {
+	return g.hasEnvelope
+}
+
+func (g payloadVoteForkGraph) DumpEnvelopeOnDisk(blockRoot common.Hash, _ *cltypes.SignedExecutionPayloadEnvelope) error {
+	if g.dumpedEnvelope != nil {
+		*g.dumpedEnvelope = blockRoot
+	}
+	return nil
+}
+
+func (g payloadVoteForkGraph) MarkHeaderAsInvalid(blockRoot common.Hash) {
+	if g.invalidatedHeader != nil {
+		*g.invalidatedHeader = blockRoot
+	}
 }
 
 func TestGetPTCFromWindow(t *testing.T) {
@@ -211,13 +239,117 @@ func TestPtcShouldBuildOnFullWithUnavailableMajority(t *testing.T) {
 	}))
 }
 
+func TestGloasForkChoiceRequiresVerifiedPayload(t *testing.T) {
+	root := common.HexToHash("0x1234")
+
+	tests := []struct {
+		name          string
+		hasEnvelope   bool
+		verified      bool
+		wantFullChild bool
+	}{
+		{
+			name:          "envelope present but not verified means EMPTY only",
+			hasEnvelope:   true,
+			verified:      false,
+			wantFullChild: false,
+		},
+		{
+			name:          "envelope present and verified produces FULL child",
+			hasEnvelope:   true,
+			verified:      true,
+			wantFullChild: true,
+		},
+		{
+			name:          "no envelope means EMPTY only",
+			hasEnvelope:   false,
+			verified:      false,
+			wantFullChild: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newPayloadVoteTestStore(t, root, tt.hasEnvelope, tt.verified)
+
+			children := f.getNodeChildren(ForkChoiceNode{
+				Root:          root,
+				PayloadStatus: cltypes.PayloadStatusPending,
+			}, nil)
+			require.Equal(t, tt.wantFullChild, hasPayloadStatus(children, cltypes.PayloadStatusFull))
+			require.True(t, hasPayloadStatus(children, cltypes.PayloadStatusEmpty))
+
+			require.Equal(t, tt.wantFullChild, f.ShouldExtendPayload(root))
+			require.Equal(t, tt.wantFullChild, f.payloadTimeliness(root, true))
+			require.Equal(t, tt.wantFullChild, f.payloadDataAvailability(root, true))
+		})
+	}
+}
+
+func TestIsPayloadVerifiedStrictSemantics(t *testing.T) {
+	root := common.HexToHash("0x5678")
+
+	t.Run("envelope on disk but not EL-verified", func(t *testing.T) {
+		f := newPayloadVoteTestStore(t, root, true, false)
+		require.False(t, f.IsPayloadVerified(root))
+	})
+
+	t.Run("EL-verified and envelope present", func(t *testing.T) {
+		f := newPayloadVoteTestStore(t, root, true, true)
+		require.True(t, f.IsPayloadVerified(root))
+	})
+
+	t.Run("mark verified", func(t *testing.T) {
+		f := newPayloadVoteTestStore(t, root, true, false)
+		execHash := common.HexToHash("0xabcd")
+		block := cltypes.NewBeaconBlock(&clparams.MainnetBeaconConfig, clparams.GloasVersion)
+		f.MarkPayloadVerified(root, execHash, block)
+		require.True(t, f.IsPayloadVerified(root))
+	})
+
+	t.Run("nil cache returns false", func(t *testing.T) {
+		f := &ForkChoiceStore{}
+		require.False(t, f.IsPayloadVerified(root))
+	})
+}
+
 func newPtcVoteTestStore(root common.Hash) *ForkChoiceStore {
+	verifiedExecutionPayload, _ := lru.New[common.Hash, struct{}](16)
+	verifiedExecutionPayload.Add(root, struct{}{})
 	return &ForkChoiceStore{
-		beaconCfg: &clparams.MainnetBeaconConfig,
+		beaconCfg:                &clparams.MainnetBeaconConfig,
+		verifiedExecutionPayload: verifiedExecutionPayload,
 		forkGraph: ptcVoteForkGraph{
 			envelopes: map[common.Hash]bool{root: true},
 		},
 	}
+}
+
+func newPayloadVoteTestStore(t *testing.T, root common.Hash, hasEnvelope, verified bool) *ForkChoiceStore {
+	t.Helper()
+
+	verifiedExecutionPayload, err := lru.New[common.Hash, struct{}](16)
+	require.NoError(t, err)
+	if verified {
+		verifiedExecutionPayload.Add(root, struct{}{})
+	}
+	executionPayloadStatus, err := lru.New[common.Hash, execution_client.PayloadStatus](16)
+	require.NoError(t, err)
+
+	f := &ForkChoiceStore{
+		beaconCfg:                &clparams.MainnetBeaconConfig,
+		forkGraph:                payloadVoteForkGraph{hasEnvelope: hasEnvelope},
+		verifiedExecutionPayload: verifiedExecutionPayload,
+		executionPayloadStatus:   executionPayloadStatus,
+		optimisticStore:          optimistic.NewOptimisticStore(),
+	}
+	f.proposerBoostRoot.Store(common.Hash{})
+
+	majority := int(f.beaconCfg.PtcSize/2) + 1
+	f.payloadTimelinessVote.Store(root, ptcVotes(majority, 0))
+	f.payloadDataAvailabilityVote.Store(root, ptcVotes(majority, 0))
+
+	return f
 }
 
 func ptcVoteThreshold() int {
@@ -233,4 +365,13 @@ func ptcVotes(trueVotes, falseVotes int) [clparams.PtcSize]int8 {
 		votes[i] = boolToVote(false)
 	}
 	return votes
+}
+
+func hasPayloadStatus(nodes []ForkChoiceNode, status cltypes.PayloadStatus) bool {
+	for _, node := range nodes {
+		if node.PayloadStatus == status {
+			return true
+		}
+	}
+	return false
 }

--- a/cl/phase1/forkchoice/payload_vote_test.go
+++ b/cl/phase1/forkchoice/payload_vote_test.go
@@ -302,8 +302,7 @@ func TestIsPayloadVerifiedStrictSemantics(t *testing.T) {
 	t.Run("mark verified", func(t *testing.T) {
 		f := newPayloadVoteTestStore(t, root, true, false)
 		execHash := common.HexToHash("0xabcd")
-		block := cltypes.NewBeaconBlock(&clparams.MainnetBeaconConfig, clparams.GloasVersion)
-		f.MarkPayloadVerified(root, execHash, block)
+		f.MarkPayloadVerified(root, execHash)
 		require.True(t, f.IsPayloadVerified(root))
 
 		status, ok := f.GetRecentExecutionPayloadStatusByRoot(root)
@@ -327,9 +326,7 @@ func TestMarkPayloadInvalidRecordsELRejection(t *testing.T) {
 		hasEnvelope:       true,
 		invalidatedHeader: &invalidatedHeader,
 	}
-	block := cltypes.NewBeaconBlock(&clparams.MainnetBeaconConfig, clparams.GloasVersion)
-
-	f.MarkPayloadInvalid(root, execHash, block)
+	f.MarkPayloadInvalid(root, execHash)
 
 	require.False(t, f.IsPayloadVerified(root))
 	status, ok := f.GetRecentExecutionPayloadStatus(execHash)

--- a/cl/phase1/forkchoice/payload_vote_test.go
+++ b/cl/phase1/forkchoice/payload_vote_test.go
@@ -305,6 +305,10 @@ func TestIsPayloadVerifiedStrictSemantics(t *testing.T) {
 		block := cltypes.NewBeaconBlock(&clparams.MainnetBeaconConfig, clparams.GloasVersion)
 		f.MarkPayloadVerified(root, execHash, block)
 		require.True(t, f.IsPayloadVerified(root))
+
+		status, ok := f.GetRecentExecutionPayloadStatusByRoot(root)
+		require.True(t, ok)
+		require.Equal(t, execution_client.PayloadStatus(execution_client.PayloadStatusValidated), status)
 	})
 
 	t.Run("nil cache returns false", func(t *testing.T) {
@@ -331,7 +335,52 @@ func TestMarkPayloadInvalidRecordsELRejection(t *testing.T) {
 	status, ok := f.GetRecentExecutionPayloadStatus(execHash)
 	require.True(t, ok)
 	require.Equal(t, execution_client.PayloadStatus(execution_client.PayloadStatusInvalidated), status)
+	status, ok = f.GetRecentExecutionPayloadStatusByRoot(root)
+	require.True(t, ok)
+	require.Equal(t, execution_client.PayloadStatus(execution_client.PayloadStatusInvalidated), status)
 	require.Equal(t, root, invalidatedHeader)
+}
+
+func TestStoreAnchorEnvelopePersistsWithoutMarkingVerified(t *testing.T) {
+	root := common.HexToHash("0x5678")
+	execHash := common.HexToHash("0xabcd")
+	dumpedEnvelope := common.Hash{}
+
+	f := newPayloadVoteTestStore(t, root, true, false)
+	f.forkGraph = payloadVoteForkGraph{dumpedEnvelope: &dumpedEnvelope}
+	envelope := &cltypes.SignedExecutionPayloadEnvelope{
+		Message: &cltypes.ExecutionPayloadEnvelope{
+			BeaconBlockRoot: root,
+			Payload:         &cltypes.Eth1Block{BlockHash: execHash},
+		},
+	}
+
+	require.NoError(t, f.StoreAnchorEnvelope(root, envelope))
+	require.False(t, f.IsPayloadVerified(root))
+	status, ok := f.GetRecentExecutionPayloadStatus(execHash)
+	require.False(t, ok)
+	require.Equal(t, execution_client.PayloadStatus(0), status)
+	require.Equal(t, root, dumpedEnvelope)
+}
+
+func TestStoreAnchorEnvelopeRejectsRootMismatch(t *testing.T) {
+	root := common.HexToHash("0x5678")
+	otherRoot := common.HexToHash("0x9999")
+	execHash := common.HexToHash("0xabcd")
+
+	f := newPayloadVoteTestStore(t, root, true, false)
+	envelope := &cltypes.SignedExecutionPayloadEnvelope{
+		Message: &cltypes.ExecutionPayloadEnvelope{
+			BeaconBlockRoot: otherRoot,
+			Payload:         &cltypes.Eth1Block{BlockHash: execHash},
+		},
+	}
+
+	err := f.StoreAnchorEnvelope(root, envelope)
+	require.Error(t, err)
+	require.False(t, f.IsPayloadVerified(root))
+	_, ok := f.GetRecentExecutionPayloadStatus(execHash)
+	require.False(t, ok)
 }
 
 func newPtcVoteTestStore(root common.Hash) *ForkChoiceStore {
@@ -356,12 +405,18 @@ func newPayloadVoteTestStore(t *testing.T, root common.Hash, hasEnvelope, verifi
 	}
 	executionPayloadStatus, err := lru.New[common.Hash, execution_client.PayloadStatus](16)
 	require.NoError(t, err)
+	payloadStatusByRoot, err := lru.New[common.Hash, execution_client.PayloadStatus](16)
+	require.NoError(t, err)
+	eth2Roots, err := lru.New[common.Hash, common.Hash](16)
+	require.NoError(t, err)
 
 	f := &ForkChoiceStore{
 		beaconCfg:                &clparams.MainnetBeaconConfig,
 		forkGraph:                payloadVoteForkGraph{hasEnvelope: hasEnvelope},
+		eth2Roots:                eth2Roots,
 		verifiedExecutionPayload: verifiedExecutionPayload,
 		executionPayloadStatus:   executionPayloadStatus,
+		payloadStatusByRoot:      payloadStatusByRoot,
 		optimisticStore:          optimistic.NewOptimisticStore(),
 	}
 	f.proposerBoostRoot.Store(common.Hash{})

--- a/cl/phase1/forkchoice/payload_vote_test.go
+++ b/cl/phase1/forkchoice/payload_vote_test.go
@@ -313,6 +313,27 @@ func TestIsPayloadVerifiedStrictSemantics(t *testing.T) {
 	})
 }
 
+func TestMarkPayloadInvalidRecordsELRejection(t *testing.T) {
+	root := common.HexToHash("0x5678")
+	execHash := common.HexToHash("0xabcd")
+	invalidatedHeader := common.Hash{}
+
+	f := newPayloadVoteTestStore(t, root, true, true)
+	f.forkGraph = payloadVoteForkGraph{
+		hasEnvelope:       true,
+		invalidatedHeader: &invalidatedHeader,
+	}
+	block := cltypes.NewBeaconBlock(&clparams.MainnetBeaconConfig, clparams.GloasVersion)
+
+	f.MarkPayloadInvalid(root, execHash, block)
+
+	require.False(t, f.IsPayloadVerified(root))
+	status, ok := f.GetRecentExecutionPayloadStatus(execHash)
+	require.True(t, ok)
+	require.Equal(t, execution_client.PayloadStatus(execution_client.PayloadStatusInvalidated), status)
+	require.Equal(t, root, invalidatedHeader)
+}
+
 func newPtcVoteTestStore(root common.Hash) *ForkChoiceStore {
 	verifiedExecutionPayload, _ := lru.New[common.Hash, struct{}](16)
 	verifiedExecutionPayload.Add(root, struct{}{})

--- a/cl/phase1/forkchoice/pending_el_payload_test.go
+++ b/cl/phase1/forkchoice/pending_el_payload_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,4 +33,21 @@ func TestDrainPendingELPayloadsReleasesLargeBackingArray(t *testing.T) {
 	payloads := f.DrainPendingELPayloads()
 	require.Len(t, payloads, pendingELPayloadsShrinkCap+1)
 	require.Nil(t, f.pendingELPayloads)
+}
+
+func TestPendingELPayloadsDeduplicateByEnvelopeRoot(t *testing.T) {
+	f := &ForkChoiceStore{}
+	root := common.HexToHash("0x1234")
+	envelope := &cltypes.SignedExecutionPayloadEnvelope{
+		Message: &cltypes.ExecutionPayloadEnvelope{
+			BeaconBlockRoot: root,
+		},
+	}
+
+	f.addPendingELPayload(&cltypes.SignedBeaconBlock{Block: &cltypes.BeaconBlock{Slot: 1}}, envelope)
+	f.addPendingELPayload(&cltypes.SignedBeaconBlock{Block: &cltypes.BeaconBlock{Slot: 2}}, envelope)
+
+	payloads := f.DrainPendingELPayloads()
+	require.Len(t, payloads, 1)
+	require.Equal(t, uint64(1), payloads[0].Block.Block.Slot)
 }

--- a/cl/phase1/network/services/aggregate_and_proof_service.go
+++ b/cl/phase1/network/services/aggregate_and_proof_service.go
@@ -271,18 +271,9 @@ func (a *aggregateAndProofServiceImpl) ProcessMessage(
 				return errors.New("invalid committee_index in aggregate and proof: must be 0 when block.slot == aggregate.data.slot")
 			}
 
-			// [New in GLOAS] When index=1 (payload-present attestation), the execution
-			// payload envelope for the block must have been received and validated.
-			// Spec conditions:
-			//   [IGNORE] The signed execution payload envelope has been seen.
-			//   [REJECT] The signed execution payload envelope has been validated (processed by forkchoice).
-			// In our implementation, HasEnvelope returns true only after OnExecutionPayload
-			// has successfully processed and persisted the envelope, so it implies both
-			// "seen" and "validated". We use IGNORE disposition here because the envelope
-			// may simply not have arrived yet (timing issue, not a protocol violation).
 			if aggregate.Data.CommitteeIndex == 1 {
-				if !a.forkchoiceStore.HasEnvelope(aggregateData.BeaconBlockRoot) {
-					return fmt.Errorf("%w: execution payload envelope not seen/validated for block %v", ErrIgnore, aggregateData.BeaconBlockRoot)
+				if !a.forkchoiceStore.IsPayloadVerified(aggregateData.BeaconBlockRoot) {
+					return unverifiedGloasPayloadError(a.forkchoiceStore, aggregateData.BeaconBlockRoot)
 				}
 			}
 		}

--- a/cl/phase1/network/services/aggregate_and_proof_service_test.go
+++ b/cl/phase1/network/services/aggregate_and_proof_service_test.go
@@ -523,9 +523,13 @@ func TestAggregateAndProofGloasIgnoreIndex1EnvelopeNotVerified(t *testing.T) {
 		Slot: agg.SignedAggregateAndProof.Message.Aggregate.Data.Slot - 1,
 	}
 	fcu.Envelopes[blockRoot] = &cltypes.SignedExecutionPayloadEnvelope{
-		Message: &cltypes.ExecutionPayloadEnvelope{BeaconBlockRoot: blockRoot},
+		Message: &cltypes.ExecutionPayloadEnvelope{
+			BeaconBlockRoot: blockRoot,
+			Payload:         &cltypes.Eth1Block{BlockHash: common.HexToHash("0x1234")},
+		},
 	}
 	fcu.VerifiedPayloads = map[common.Hash]bool{blockRoot: false}
+	fcu.ExecutionPayloadStatusMap[common.HexToHash("0x1234")] = execution_client.PayloadStatusInvalidated
 
 	err := aggService.ProcessMessage(context.Background(), nil, agg)
 	require.Error(t, err)

--- a/cl/phase1/network/services/aggregate_and_proof_service_test.go
+++ b/cl/phase1/network/services/aggregate_and_proof_service_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
 	"github.com/erigontech/erigon/cl/phase1/core/state"
+	"github.com/erigontech/erigon/cl/phase1/execution_client"
 	"github.com/erigontech/erigon/cl/phase1/forkchoice"
 	"github.com/erigontech/erigon/cl/phase1/forkchoice/mock_services"
 	"github.com/erigontech/erigon/cl/pool"
@@ -409,6 +410,7 @@ func TestAggregateAndProofGloasAllowIndex1WhenSlotsDiffer(t *testing.T) {
 
 	// Set envelope as seen/validated (required for index=1)
 	fcu.Envelopes[blockRoot] = &cltypes.SignedExecutionPayloadEnvelope{}
+	fcu.VerifiedPayloads = map[common.Hash]bool{blockRoot: true}
 
 	// Should pass (index=1 is allowed when slots differ and envelope exists)
 	err := aggService.ProcessMessage(context.Background(), nil, agg)
@@ -456,7 +458,7 @@ func TestAggregateAndProofGloasAllowIndex0WhenSlotsMatch(t *testing.T) {
 }
 
 // TestAggregateAndProofGloasIgnoreIndex1NoEnvelope tests that GLOAS ignores
-// aggregate.data.index == 1 when the execution payload envelope has NOT been seen.
+// aggregate.data.index == 1 when the execution payload has not been verified.
 func TestAggregateAndProofGloasIgnoreIndex1NoEnvelope(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -493,7 +495,82 @@ func TestAggregateAndProofGloasIgnoreIndex1NoEnvelope(t *testing.T) {
 	err := aggService.ProcessMessage(context.Background(), nil, agg)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrIgnore)
-	require.Contains(t, err.Error(), "execution payload envelope not seen/validated")
+	require.Contains(t, err.Error(), "execution payload not verified")
+}
+
+func TestAggregateAndProofGloasIgnoreIndex1EnvelopeNotVerified(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cfg := clparams.MainnetBeaconConfig
+	cfg.AltairForkEpoch = 0
+	cfg.BellatrixForkEpoch = 0
+	cfg.CapellaForkEpoch = 0
+	cfg.DenebForkEpoch = 0
+	cfg.ElectraForkEpoch = 0
+	cfg.FuluForkEpoch = 0
+	cfg.GloasForkEpoch = 0
+
+	agg, s := getAggregateAndProofAndStateForVersion(t, clparams.GloasVersion)
+	agg.SignedAggregateAndProof.Message.Aggregate.Data.CommitteeIndex = 1
+	blockRoot := agg.SignedAggregateAndProof.Message.Aggregate.Data.BeaconBlockRoot
+
+	aggService, sd, fcu := setupAggregateAndProofTestWithConfig(t, &cfg)
+	sd.OnHeadState(s)
+	fcu.FinalizedCheckpointVal = s.FinalizedCheckpoint()
+	fcu.Ancestors[s.FinalizedCheckpoint().Epoch*32] = forkchoice.ForkChoiceNode{Root: s.FinalizedCheckpoint().Root}
+	fcu.Headers[blockRoot] = &cltypes.BeaconBlockHeader{
+		Slot: agg.SignedAggregateAndProof.Message.Aggregate.Data.Slot - 1,
+	}
+	fcu.Envelopes[blockRoot] = &cltypes.SignedExecutionPayloadEnvelope{
+		Message: &cltypes.ExecutionPayloadEnvelope{BeaconBlockRoot: blockRoot},
+	}
+	fcu.VerifiedPayloads = map[common.Hash]bool{blockRoot: false}
+
+	err := aggService.ProcessMessage(context.Background(), nil, agg)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrIgnore)
+	require.Contains(t, err.Error(), "execution payload not verified")
+}
+
+func TestAggregateAndProofGloasRejectIndex1InvalidPayload(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cfg := clparams.MainnetBeaconConfig
+	cfg.AltairForkEpoch = 0
+	cfg.BellatrixForkEpoch = 0
+	cfg.CapellaForkEpoch = 0
+	cfg.DenebForkEpoch = 0
+	cfg.ElectraForkEpoch = 0
+	cfg.FuluForkEpoch = 0
+	cfg.GloasForkEpoch = 0
+
+	agg, s := getAggregateAndProofAndStateForVersion(t, clparams.GloasVersion)
+	agg.SignedAggregateAndProof.Message.Aggregate.Data.CommitteeIndex = 1
+	blockRoot := agg.SignedAggregateAndProof.Message.Aggregate.Data.BeaconBlockRoot
+	execHash := common.HexToHash("0x1234")
+
+	aggService, sd, fcu := setupAggregateAndProofTestWithConfig(t, &cfg)
+	sd.OnHeadState(s)
+	fcu.FinalizedCheckpointVal = s.FinalizedCheckpoint()
+	fcu.Ancestors[s.FinalizedCheckpoint().Epoch*32] = forkchoice.ForkChoiceNode{Root: s.FinalizedCheckpoint().Root}
+	fcu.Headers[blockRoot] = &cltypes.BeaconBlockHeader{
+		Slot: agg.SignedAggregateAndProof.Message.Aggregate.Data.Slot - 1,
+	}
+	fcu.Envelopes[blockRoot] = &cltypes.SignedExecutionPayloadEnvelope{
+		Message: &cltypes.ExecutionPayloadEnvelope{
+			BeaconBlockRoot: blockRoot,
+			Payload:         &cltypes.Eth1Block{BlockHash: execHash},
+		},
+	}
+	fcu.VerifiedPayloads = map[common.Hash]bool{blockRoot: false}
+	fcu.PayloadStatusByRootMap[blockRoot] = execution_client.PayloadStatusInvalidated
+
+	err := aggService.ProcessMessage(context.Background(), nil, agg)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrIgnore)
+	require.Contains(t, err.Error(), "execution payload is invalid")
 }
 
 // TestAggregateAndProofGloasIndex0NoEnvelopeOk tests that GLOAS does NOT require

--- a/cl/phase1/network/services/attestation_service.go
+++ b/cl/phase1/network/services/attestation_service.go
@@ -312,6 +312,9 @@ func (s *attestationService) ProcessMessage(ctx context.Context, subnet *uint64,
 		if blockHeader.Slot == data.Slot && data.CommitteeIndex != 0 {
 			return errors.New("attestation data index must be 0 when block slot equals attestation slot")
 		}
+		if data.CommitteeIndex == 1 && !s.forkchoiceStore.IsPayloadVerified(root) {
+			return unverifiedGloasPayloadError(s.forkchoiceStore, root)
+		}
 	}
 
 	// [REJECT] The attestation's target block is an ancestor of the block named in the LMD vote -- i.e.

--- a/cl/phase1/network/services/gloas_payload_status.go
+++ b/cl/phase1/network/services/gloas_payload_status.go
@@ -14,12 +14,5 @@ func unverifiedGloasPayloadError(store forkchoice.ForkChoiceStorageReader, block
 	if ok && status == execution_client.PayloadStatusInvalidated {
 		return errors.New("execution payload is invalid")
 	}
-	envelope, err := store.ReadEnvelopeFromDisk(blockRoot)
-	if err == nil && envelope != nil && envelope.Message != nil && envelope.Message.Payload != nil {
-		status, ok = store.GetRecentExecutionPayloadStatus(envelope.Message.Payload.BlockHash)
-		if ok && status == execution_client.PayloadStatusInvalidated {
-			return errors.New("execution payload is invalid")
-		}
-	}
 	return fmt.Errorf("%w: execution payload not verified for block %v", ErrIgnore, blockRoot)
 }

--- a/cl/phase1/network/services/gloas_payload_status.go
+++ b/cl/phase1/network/services/gloas_payload_status.go
@@ -1,0 +1,25 @@
+package services
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/erigontech/erigon/cl/phase1/execution_client"
+	"github.com/erigontech/erigon/cl/phase1/forkchoice"
+	"github.com/erigontech/erigon/common"
+)
+
+func unverifiedGloasPayloadError(store forkchoice.ForkChoiceStorageReader, blockRoot common.Hash) error {
+	status, ok := store.GetRecentExecutionPayloadStatusByRoot(blockRoot)
+	if ok && status == execution_client.PayloadStatusInvalidated {
+		return errors.New("execution payload is invalid")
+	}
+	envelope, err := store.ReadEnvelopeFromDisk(blockRoot)
+	if err == nil && envelope != nil && envelope.Message != nil && envelope.Message.Payload != nil {
+		status, ok = store.GetRecentExecutionPayloadStatus(envelope.Message.Payload.BlockHash)
+		if ok && status == execution_client.PayloadStatusInvalidated {
+			return errors.New("execution payload is invalid")
+		}
+	}
+	return fmt.Errorf("%w: execution payload not verified for block %v", ErrIgnore, blockRoot)
+}

--- a/cl/phase1/stages/chain_tip_sync.go
+++ b/cl/phase1/stages/chain_tip_sync.go
@@ -512,6 +512,7 @@ func drainPendingGloasPayloads(ctx context.Context, cfg *Cfg) {
 		case execution_client.PayloadStatusNone, execution_client.PayloadStatusNotValidated:
 			cfg.forkChoice.RequeuePendingELPayload(p)
 		case execution_client.PayloadStatusInvalidated:
+			cfg.forkChoice.MarkPayloadInvalid(beaconRoot, execHash, p.Block.Block)
 			log.Warn("[chainTipSync] pending GLOAS payload invalidated by EL", "slot", p.Block.Block.Slot, "blockRoot", beaconRoot)
 		}
 	}
@@ -571,6 +572,7 @@ func verifyUnverifiedGloasPayloads(ctx context.Context, cfg *Cfg) {
 		case execution_client.PayloadStatusNone, execution_client.PayloadStatusNotValidated:
 			cfg.forkChoice.RequeuePendingELPayload(forkchoice.PendingELPayload{Block: item.block, Envelope: envelope})
 		case execution_client.PayloadStatusInvalidated:
+			cfg.forkChoice.MarkPayloadInvalid(item.root, execHash, item.block.Block)
 			log.Warn("[chainTipSync] GLOAS verification sweep found invalid payload", "slot", item.block.Block.Slot, "blockRoot", item.root)
 		}
 	}

--- a/cl/phase1/stages/chain_tip_sync.go
+++ b/cl/phase1/stages/chain_tip_sync.go
@@ -3,14 +3,20 @@ package stages
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sort"
 	"time"
 
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/cl/phase1/execution_client"
+	"github.com/erigontech/erigon/cl/phase1/forkchoice"
 	network "github.com/erigontech/erigon/cl/phase1/network"
 	"github.com/erigontech/erigon/cl/sentinel/peers"
+	"github.com/erigontech/erigon/cl/utils"
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/common/log/v3"
 )
 
@@ -439,6 +445,137 @@ func pollForEnvelope(ctx context.Context, cfg *Cfg, headRoot common.Hash, timeou
 	}
 }
 
+func buildGloasNewPayloadArgs(cfg *Cfg, block *cltypes.SignedBeaconBlock, envelope *cltypes.SignedExecutionPayloadEnvelope) ([]common.Hash, []hexutil.Bytes, error) {
+	if block == nil || block.Block == nil {
+		return nil, nil, errors.New("missing beacon block")
+	}
+	if envelope == nil || envelope.Message == nil || envelope.Message.Payload == nil {
+		return nil, nil, errors.New("missing execution payload envelope")
+	}
+
+	committedBid := block.Block.Body.GetSignedExecutionPayloadBid()
+	if committedBid == nil || committedBid.Message == nil {
+		return nil, nil, errors.New("missing execution payload bid")
+	}
+
+	versionedHashes := make([]common.Hash, 0)
+	blobCommitments := &committedBid.Message.BlobKzgCommitments
+	if blobCommitments.Len() > 0 {
+		versionedHashes = make([]common.Hash, 0, blobCommitments.Len())
+		if err := solid.RangeErr[*cltypes.KZGCommitment](blobCommitments, func(_ int, k *cltypes.KZGCommitment, _ int) error {
+			versionedHash, err := utils.KzgCommitmentToVersionedHash(common.Bytes48(*k))
+			if err != nil {
+				return err
+			}
+			versionedHashes = append(versionedHashes, versionedHash)
+			return nil
+		}); err != nil {
+			return nil, nil, fmt.Errorf("failed to compute versioned hashes: %w", err)
+		}
+	}
+
+	var executionRequestsList []hexutil.Bytes
+	if envelope.Message.ExecutionRequests != nil {
+		executionRequestsList = cltypes.GetExecutionRequestsList(cfg.beaconCfg, envelope.Message.ExecutionRequests)
+	}
+	return versionedHashes, executionRequestsList, nil
+}
+
+func retryGloasPayloadWithEL(ctx context.Context, cfg *Cfg, block *cltypes.SignedBeaconBlock, envelope *cltypes.SignedExecutionPayloadEnvelope) (execution_client.PayloadStatus, error) {
+	versionedHashes, executionRequestsList, err := buildGloasNewPayloadArgs(cfg, block, envelope)
+	if err != nil {
+		return execution_client.PayloadStatusNone, err
+	}
+	parentRoot := block.Block.ParentRoot
+	return cfg.executionClient.NewPayload(ctx, envelope.Message.Payload, &parentRoot, versionedHashes, executionRequestsList)
+}
+
+func drainPendingGloasPayloads(ctx context.Context, cfg *Cfg) {
+	for _, p := range cfg.forkChoice.DrainPendingELPayloads() {
+		if p.Block == nil || p.Envelope == nil || p.Envelope.Message == nil || p.Envelope.Message.Payload == nil {
+			continue
+		}
+		blockRoot, err := p.Block.Block.HashSSZ()
+		if err != nil {
+			log.Warn("[chainTipSync] failed to hash pending GLOAS block", "slot", p.Block.Block.Slot, "err", err)
+			continue
+		}
+		status, err := retryGloasPayloadWithEL(ctx, cfg, p.Block, p.Envelope)
+		if err != nil {
+			log.Warn("[chainTipSync] pending GLOAS NewPayload failed", "slot", p.Block.Block.Slot, "status", status, "err", err)
+		}
+		beaconRoot := common.Hash(blockRoot)
+		execHash := p.Envelope.Message.Payload.BlockHash
+		switch status {
+		case execution_client.PayloadStatusValidated:
+			cfg.forkChoice.MarkPayloadVerified(beaconRoot, execHash, p.Block.Block)
+		case execution_client.PayloadStatusNone, execution_client.PayloadStatusNotValidated:
+			cfg.forkChoice.RequeuePendingELPayload(p)
+		case execution_client.PayloadStatusInvalidated:
+			log.Warn("[chainTipSync] pending GLOAS payload invalidated by EL", "slot", p.Block.Block.Slot, "blockRoot", beaconRoot)
+		}
+	}
+}
+
+func verifyUnverifiedGloasPayloads(ctx context.Context, cfg *Cfg) {
+	headRoot := cfg.forkChoice.HighestSeenRoot()
+	if headRoot == (common.Hash{}) {
+		return
+	}
+
+	finalizedSlot := cfg.forkChoice.FinalizedSlot()
+	var blocks []struct {
+		root  common.Hash
+		block *cltypes.SignedBeaconBlock
+	}
+
+	for root := headRoot; root != (common.Hash{}); {
+		block, ok := cfg.forkChoice.GetBlock(root)
+		if !ok || block == nil {
+			break
+		}
+		if block.Block.Slot <= finalizedSlot {
+			break
+		}
+		epoch := block.Block.Slot / cfg.beaconCfg.SlotsPerEpoch
+		if cfg.beaconCfg.GetCurrentStateVersion(epoch) < clparams.GloasVersion {
+			break
+		}
+		if cfg.forkChoice.HasEnvelope(root) && !cfg.forkChoice.IsPayloadVerified(root) {
+			blocks = append(blocks, struct {
+				root  common.Hash
+				block *cltypes.SignedBeaconBlock
+			}{root: root, block: block})
+		}
+		root = common.Hash(block.Block.ParentRoot)
+	}
+
+	for i := len(blocks) - 1; i >= 0; i-- {
+		item := blocks[i]
+		if cfg.forkChoice.IsPayloadVerified(item.root) {
+			continue
+		}
+		envelope, err := cfg.forkChoice.ReadEnvelopeFromDisk(item.root)
+		if err != nil {
+			log.Debug("[chainTipSync] failed to read GLOAS envelope for verification sweep", "slot", item.block.Block.Slot, "blockRoot", item.root, "err", err)
+			continue
+		}
+		status, err := retryGloasPayloadWithEL(ctx, cfg, item.block, envelope)
+		if err != nil {
+			log.Warn("[chainTipSync] GLOAS verification sweep NewPayload failed", "slot", item.block.Block.Slot, "blockRoot", item.root, "status", status, "err", err)
+		}
+		execHash := envelope.Message.Payload.BlockHash
+		switch status {
+		case execution_client.PayloadStatusValidated:
+			cfg.forkChoice.MarkPayloadVerified(item.root, execHash, item.block.Block)
+		case execution_client.PayloadStatusNone, execution_client.PayloadStatusNotValidated:
+			cfg.forkChoice.RequeuePendingELPayload(forkchoice.PendingELPayload{Block: item.block, Envelope: envelope})
+		case execution_client.PayloadStatusInvalidated:
+			log.Warn("[chainTipSync] GLOAS verification sweep found invalid payload", "slot", item.block.Block.Slot, "blockRoot", item.root)
+		}
+	}
+}
+
 // chainTipSync synchronizes the chain tip by fetching blocks from the highest seen block up to the target slot by listening to incoming blocks.
 // or by fetching blocks that might have been missed by gossip after a delay.
 func chainTipSync(ctx context.Context, logger log.Logger, cfg *Cfg, args Args) error {
@@ -453,16 +590,8 @@ func chainTipSync(ctx context.Context, logger log.Logger, cfg *Cfg, args Args) e
 	// DrainPendingELPayloads and blockCollector require local insertion support.
 	if cfg.executionClient != nil && cfg.executionClient.SupportInsertion() {
 		// [New in Gloas:EIP7732] Drain execution blocks whose CL transition succeeded
-		// but whose EL newPayload failed (EL was behind).  Adding them to the collector
-		// before Flush ensures they are inserted into EL in block-number order, filling
-		// the gap that would otherwise permanently break the EL chain.
-		for _, p := range cfg.forkChoice.DrainPendingELPayloads() {
-			if p.Envelope != nil && p.Envelope.Message != nil && p.Envelope.Message.Payload != nil {
-				if addErr := cfg.blockCollector.AddGloasBlock(p.Block.Block, p.Envelope); addErr != nil {
-					log.Warn("[chainTipSync] failed to add pending EL payload to collector", "err", addErr)
-				}
-			}
-		}
+		// but whose EL newPayload previously returned SYNCING/ACCEPTED.
+		drainPendingGloasPayloads(ctx, cfg)
 		if err := cfg.blockCollector.Flush(context.Background()); err != nil {
 			log.Warn("[chainTipSync] blockCollector.Flush failed (EL may still be catching up)", "err", err)
 		}
@@ -477,6 +606,9 @@ func chainTipSync(ctx context.Context, logger log.Logger, cfg *Cfg, args Args) e
 			headRoot := cfg.forkChoice.HighestSeenRoot()
 			if headRoot != (common.Hash{}) && !cfg.forkChoice.HasEnvelope(headRoot) {
 				pollForEnvelope(ctx, cfg, headRoot, 2*time.Second)
+			}
+			if cfg.executionClient != nil && cfg.executionClient.SupportInsertion() {
+				verifyUnverifiedGloasPayloads(ctx, cfg)
 			}
 			// NOTE: recoverMissingEnvelopes runs unconditionally above (before
 			// SupportInsertion check), so it covers every cycle.

--- a/cl/phase1/stages/chain_tip_sync.go
+++ b/cl/phase1/stages/chain_tip_sync.go
@@ -20,6 +20,48 @@ import (
 	"github.com/erigontech/erigon/common/log/v3"
 )
 
+const maxGloasVerificationSweepPerCycle = 32
+
+func gloasVersionedHashes(blobCommitments *solid.ListSSZ[*cltypes.KZGCommitment]) ([]common.Hash, error) {
+	if blobCommitments == nil || blobCommitments.Len() == 0 {
+		return nil, nil
+	}
+	versionedHashes := make([]common.Hash, 0, blobCommitments.Len())
+	if err := solid.RangeErr[*cltypes.KZGCommitment](blobCommitments, func(_ int, k *cltypes.KZGCommitment, _ int) error {
+		versionedHash, err := utils.KzgCommitmentToVersionedHash(common.Bytes48(*k))
+		if err != nil {
+			return err
+		}
+		versionedHashes = append(versionedHashes, versionedHash)
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("failed to compute versioned hashes: %w", err)
+	}
+	return versionedHashes, nil
+}
+
+func gloasExecutionRequestsList(beaconCfg *clparams.BeaconChainConfig, requests *cltypes.ExecutionRequests) []hexutil.Bytes {
+	if requests == nil {
+		return nil
+	}
+	return cltypes.GetExecutionRequestsList(beaconCfg, requests)
+}
+
+func validPendingGloasPayload(p forkchoice.PendingELPayload) bool {
+	return p.Block != nil && p.Block.Block != nil && p.Envelope != nil && p.Envelope.Message != nil && p.Envelope.Message.Payload != nil
+}
+
+func gloasEnvelopePayloadHash(envelope *cltypes.SignedExecutionPayloadEnvelope) (common.Hash, bool) {
+	if envelope == nil || envelope.Message == nil || envelope.Message.Payload == nil {
+		return common.Hash{}, false
+	}
+	return envelope.Message.Payload.BlockHash, true
+}
+
+func canRetryGloasPayloads(cfg *Cfg) bool {
+	return cfg.executionClient != nil && cfg.executionClient.SupportInsertion()
+}
+
 // waitForExecutionEngineToBeFinished checks if the execution engine is ready within a specified timeout.
 // It periodically checks the readiness of the execution client and returns true if the client is ready before
 // the timeout occurs. If the context is canceled or a timeout occurs, it returns false with the corresponding error.
@@ -215,7 +257,7 @@ MainLoop:
 				if block.Version() >= clparams.GloasVersion && len(envelopes) > 0 {
 					parentRoot := block.Block.ParentRoot
 					if env, ok := envelopes[common.Hash(parentRoot)]; ok {
-						if envErr := cfg.forkChoice.OnExecutionPayload(ctx, env, false, true); envErr != nil {
+						if envErr := cfg.forkChoice.OnExecutionPayload(ctx, env, false, canRetryGloasPayloads(cfg)); envErr != nil {
 							log.Debug("[chainTipSync] failed to apply parent envelope", "slot", block.Block.Slot, "err", envErr)
 						}
 					}
@@ -252,9 +294,7 @@ func fetchAndApplyEnvelopes(ctx context.Context, cfg *Cfg, roots [][32]byte) {
 		return
 	}
 	for _, env := range envelopes {
-		// validatePayload=true so recovered envelopes are sent to EL via NewPayload.
-		// If EL is behind, errELBehind will queue them as pending EL payloads.
-		if err := cfg.forkChoice.OnExecutionPayload(ctx, env, true, true); err != nil {
+		if err := cfg.forkChoice.OnExecutionPayload(ctx, env, true, canRetryGloasPayloads(cfg)); err != nil {
 			log.Debug("[chainTipSync] failed to apply recovered GLOAS envelope", "beaconBlockRoot", env.Message.BeaconBlockRoot, "err", err)
 		}
 	}
@@ -458,27 +498,11 @@ func buildGloasNewPayloadArgs(cfg *Cfg, block *cltypes.SignedBeaconBlock, envelo
 		return nil, nil, errors.New("missing execution payload bid")
 	}
 
-	versionedHashes := make([]common.Hash, 0)
-	blobCommitments := &committedBid.Message.BlobKzgCommitments
-	if blobCommitments.Len() > 0 {
-		versionedHashes = make([]common.Hash, 0, blobCommitments.Len())
-		if err := solid.RangeErr[*cltypes.KZGCommitment](blobCommitments, func(_ int, k *cltypes.KZGCommitment, _ int) error {
-			versionedHash, err := utils.KzgCommitmentToVersionedHash(common.Bytes48(*k))
-			if err != nil {
-				return err
-			}
-			versionedHashes = append(versionedHashes, versionedHash)
-			return nil
-		}); err != nil {
-			return nil, nil, fmt.Errorf("failed to compute versioned hashes: %w", err)
-		}
+	versionedHashes, err := gloasVersionedHashes(&committedBid.Message.BlobKzgCommitments)
+	if err != nil {
+		return nil, nil, err
 	}
-
-	var executionRequestsList []hexutil.Bytes
-	if envelope.Message.ExecutionRequests != nil {
-		executionRequestsList = cltypes.GetExecutionRequestsList(cfg.beaconCfg, envelope.Message.ExecutionRequests)
-	}
-	return versionedHashes, executionRequestsList, nil
+	return versionedHashes, gloasExecutionRequestsList(cfg.beaconCfg, envelope.Message.ExecutionRequests), nil
 }
 
 func retryGloasPayloadWithEL(ctx context.Context, cfg *Cfg, block *cltypes.SignedBeaconBlock, envelope *cltypes.SignedExecutionPayloadEnvelope) (execution_client.PayloadStatus, error) {
@@ -491,36 +515,32 @@ func retryGloasPayloadWithEL(ctx context.Context, cfg *Cfg, block *cltypes.Signe
 }
 
 func isGloasPayloadKnownInvalid(cfg *Cfg, envelope *cltypes.SignedExecutionPayloadEnvelope) bool {
-	if envelope == nil || envelope.Message == nil || envelope.Message.Payload == nil {
+	executionBlockHash, ok := gloasEnvelopePayloadHash(envelope)
+	if !ok {
 		return false
 	}
-	status, ok := cfg.forkChoice.GetRecentExecutionPayloadStatus(envelope.Message.Payload.BlockHash)
+	status, ok := cfg.forkChoice.GetRecentExecutionPayloadStatus(executionBlockHash)
 	return ok && status == execution_client.PayloadStatusInvalidated
 }
 
 func drainPendingGloasPayloads(ctx context.Context, cfg *Cfg) {
 	for _, p := range cfg.forkChoice.DrainPendingELPayloads() {
-		if p.Block == nil || p.Envelope == nil || p.Envelope.Message == nil || p.Envelope.Message.Payload == nil {
-			continue
-		}
-		blockRoot, err := p.Block.Block.HashSSZ()
-		if err != nil {
-			log.Warn("[chainTipSync] failed to hash pending GLOAS block", "slot", p.Block.Block.Slot, "err", err)
+		if !validPendingGloasPayload(p) {
 			continue
 		}
 		status, err := retryGloasPayloadWithEL(ctx, cfg, p.Block, p.Envelope)
 		if err != nil {
 			log.Warn("[chainTipSync] pending GLOAS NewPayload failed", "slot", p.Block.Block.Slot, "status", status, "err", err)
 		}
-		beaconRoot := common.Hash(blockRoot)
+		beaconRoot := p.Envelope.Message.BeaconBlockRoot
 		execHash := p.Envelope.Message.Payload.BlockHash
 		switch status {
 		case execution_client.PayloadStatusValidated:
-			cfg.forkChoice.MarkPayloadVerified(beaconRoot, execHash, p.Block.Block)
+			cfg.forkChoice.MarkPayloadVerified(beaconRoot, execHash)
 		case execution_client.PayloadStatusNone, execution_client.PayloadStatusNotValidated:
 			cfg.forkChoice.RequeuePendingELPayload(p)
 		case execution_client.PayloadStatusInvalidated:
-			cfg.forkChoice.MarkPayloadInvalid(beaconRoot, execHash, p.Block.Block)
+			cfg.forkChoice.MarkPayloadInvalid(beaconRoot, execHash)
 			log.Warn("[chainTipSync] pending GLOAS payload invalidated by EL", "slot", p.Block.Block.Slot, "blockRoot", beaconRoot)
 		}
 	}
@@ -555,10 +575,14 @@ func verifyUnverifiedGloasPayloads(ctx context.Context, cfg *Cfg) {
 				root  common.Hash
 				block *cltypes.SignedBeaconBlock
 			}{root: root, block: block})
+			if len(blocks) >= maxGloasVerificationSweepPerCycle {
+				break
+			}
 		}
 		root = common.Hash(block.Block.ParentRoot)
 	}
 
+	swept := 0
 	for i := len(blocks) - 1; i >= 0; i-- {
 		item := blocks[i]
 		if cfg.forkChoice.IsPayloadVerified(item.root) {
@@ -569,24 +593,32 @@ func verifyUnverifiedGloasPayloads(ctx context.Context, cfg *Cfg) {
 			log.Debug("[chainTipSync] failed to read GLOAS envelope for verification sweep", "slot", item.block.Block.Slot, "blockRoot", item.root, "err", err)
 			continue
 		}
+		execHash, ok := gloasEnvelopePayloadHash(envelope)
+		if !ok {
+			log.Warn("[chainTipSync] missing GLOAS envelope payload during verification sweep", "slot", item.block.Block.Slot, "blockRoot", item.root)
+			continue
+		}
 		if isGloasPayloadKnownInvalid(cfg, envelope) {
-			cfg.forkChoice.MarkPayloadInvalid(item.root, envelope.Message.Payload.BlockHash, item.block.Block)
+			cfg.forkChoice.MarkPayloadInvalid(item.root, execHash)
 			continue
 		}
 		status, err := retryGloasPayloadWithEL(ctx, cfg, item.block, envelope)
 		if err != nil {
 			log.Warn("[chainTipSync] GLOAS verification sweep NewPayload failed", "slot", item.block.Block.Slot, "blockRoot", item.root, "status", status, "err", err)
 		}
-		execHash := envelope.Message.Payload.BlockHash
 		switch status {
 		case execution_client.PayloadStatusValidated:
-			cfg.forkChoice.MarkPayloadVerified(item.root, execHash, item.block.Block)
+			cfg.forkChoice.MarkPayloadVerified(item.root, execHash)
 		case execution_client.PayloadStatusNone, execution_client.PayloadStatusNotValidated:
 			cfg.forkChoice.RequeuePendingELPayload(forkchoice.PendingELPayload{Block: item.block, Envelope: envelope})
 		case execution_client.PayloadStatusInvalidated:
-			cfg.forkChoice.MarkPayloadInvalid(item.root, execHash, item.block.Block)
+			cfg.forkChoice.MarkPayloadInvalid(item.root, execHash)
 			log.Warn("[chainTipSync] GLOAS verification sweep found invalid payload", "slot", item.block.Block.Slot, "blockRoot", item.root)
 		}
+		swept++
+	}
+	if swept > 0 || len(blocks) >= maxGloasVerificationSweepPerCycle {
+		log.Info("[chainTipSync] GLOAS verification sweep", "swept", swept, "queued", len(blocks), "limit", maxGloasVerificationSweepPerCycle)
 	}
 }
 
@@ -628,9 +660,9 @@ func retryUnverifiedAnchorPayload(ctx context.Context, cfg *Cfg) {
 	execHash := envelope.Message.Payload.BlockHash
 	switch status {
 	case execution_client.PayloadStatusValidated:
-		cfg.forkChoice.MarkPayloadVerified(anchorRoot, execHash, nil)
+		cfg.forkChoice.MarkPayloadVerified(anchorRoot, execHash)
 	case execution_client.PayloadStatusInvalidated:
-		cfg.forkChoice.MarkPayloadInvalid(anchorRoot, execHash, nil)
+		cfg.forkChoice.MarkPayloadInvalid(anchorRoot, execHash)
 		log.Warn("[chainTipSync] anchor payload invalidated by EL", "anchorRoot", anchorRoot)
 	}
 }
@@ -645,15 +677,13 @@ func chainTipSync(ctx context.Context, logger log.Logger, cfg *Cfg, args Args) e
 	// insertion — so it must run regardless of SupportInsertion().
 	recoverMissingEnvelopes(ctx, cfg)
 
-	if cfg.executionClient != nil {
+	if canRetryGloasPayloads(cfg) {
 		// [New in Gloas:EIP7732] Drain execution blocks whose CL transition succeeded
 		// but whose EL newPayload previously returned SYNCING/ACCEPTED.
 		drainPendingGloasPayloads(ctx, cfg)
 		retryUnverifiedAnchorPayload(ctx, cfg)
-		if cfg.executionClient.SupportInsertion() {
-			if err := cfg.blockCollector.Flush(context.Background()); err != nil {
-				log.Warn("[chainTipSync] blockCollector.Flush failed (EL may still be catching up)", "err", err)
-			}
+		if err := cfg.blockCollector.Flush(context.Background()); err != nil {
+			log.Warn("[chainTipSync] blockCollector.Flush failed (EL may still be catching up)", "err", err)
 		}
 	}
 
@@ -667,7 +697,7 @@ func chainTipSync(ctx context.Context, logger log.Logger, cfg *Cfg, args Args) e
 			if headRoot != (common.Hash{}) && !cfg.forkChoice.HasEnvelope(headRoot) {
 				pollForEnvelope(ctx, cfg, headRoot, 2*time.Second)
 			}
-			if cfg.executionClient != nil {
+			if canRetryGloasPayloads(cfg) {
 				verifyUnverifiedGloasPayloads(ctx, cfg)
 			}
 			// NOTE: recoverMissingEnvelopes runs unconditionally above (before

--- a/cl/phase1/stages/chain_tip_sync.go
+++ b/cl/phase1/stages/chain_tip_sync.go
@@ -596,7 +596,7 @@ func retryUnverifiedAnchorPayload(ctx context.Context, cfg *Cfg) {
 	if cfg.beaconCfg.GetCurrentStateVersion(epoch) < clparams.GloasVersion {
 		return
 	}
-	anchorRoot := cfg.forkChoice.FinalizedCheckpoint().Root
+	anchorRoot := cfg.forkChoice.AnchorRoot()
 	if anchorRoot == (common.Hash{}) || cfg.forkChoice.IsPayloadVerified(anchorRoot) || !cfg.forkChoice.HasEnvelope(anchorRoot) {
 		return
 	}

--- a/cl/phase1/stages/chain_tip_sync.go
+++ b/cl/phase1/stages/chain_tip_sync.go
@@ -590,6 +590,51 @@ func verifyUnverifiedGloasPayloads(ctx context.Context, cfg *Cfg) {
 	}
 }
 
+func retryUnverifiedAnchorPayload(ctx context.Context, cfg *Cfg) {
+	anchorSlot := cfg.forkChoice.AnchorSlot()
+	epoch := anchorSlot / cfg.beaconCfg.SlotsPerEpoch
+	if cfg.beaconCfg.GetCurrentStateVersion(epoch) < clparams.GloasVersion {
+		return
+	}
+	anchorRoot := cfg.forkChoice.FinalizedCheckpoint().Root
+	if anchorRoot == (common.Hash{}) || cfg.forkChoice.IsPayloadVerified(anchorRoot) || !cfg.forkChoice.HasEnvelope(anchorRoot) {
+		return
+	}
+	if status, ok := cfg.forkChoice.GetRecentExecutionPayloadStatusByRoot(anchorRoot); ok && status == execution_client.PayloadStatusInvalidated {
+		return
+	}
+	anchorState, err := cfg.forkChoice.GetStateAtBlockRoot(anchorRoot, true)
+	if err != nil || anchorState == nil {
+		log.Debug("[chainTipSync] anchor state not available for payload retry", "anchorRoot", anchorRoot, "err", err)
+		return
+	}
+	bid := anchorState.GetLatestExecutionPayloadBid()
+	if bid == nil {
+		return
+	}
+	envelope, err := cfg.forkChoice.ReadEnvelopeFromDisk(anchorRoot)
+	if err != nil {
+		log.Debug("[chainTipSync] failed to read anchor envelope for payload retry", "anchorRoot", anchorRoot, "err", err)
+		return
+	}
+	if err := validateAnchorEnvelope(cfg.beaconCfg, anchorState, anchorRoot, bid, envelope); err != nil {
+		log.Warn("[chainTipSync] invalid anchor envelope during payload retry", "anchorRoot", anchorRoot, "err", err)
+		return
+	}
+	status, err := validateAnchorPayloadWithEL(ctx, cfg, bid, envelope)
+	if err != nil {
+		log.Warn("[chainTipSync] anchor payload NewPayload retry failed", "anchorRoot", anchorRoot, "status", status, "err", err)
+	}
+	execHash := envelope.Message.Payload.BlockHash
+	switch status {
+	case execution_client.PayloadStatusValidated:
+		cfg.forkChoice.MarkPayloadVerified(anchorRoot, execHash, nil)
+	case execution_client.PayloadStatusInvalidated:
+		cfg.forkChoice.MarkPayloadInvalid(anchorRoot, execHash, nil)
+		log.Warn("[chainTipSync] anchor payload invalidated by EL", "anchorRoot", anchorRoot)
+	}
+}
+
 // chainTipSync synchronizes the chain tip by fetching blocks from the highest seen block up to the target slot by listening to incoming blocks.
 // or by fetching blocks that might have been missed by gossip after a delay.
 func chainTipSync(ctx context.Context, logger log.Logger, cfg *Cfg, args Args) error {
@@ -604,6 +649,7 @@ func chainTipSync(ctx context.Context, logger log.Logger, cfg *Cfg, args Args) e
 		// [New in Gloas:EIP7732] Drain execution blocks whose CL transition succeeded
 		// but whose EL newPayload previously returned SYNCING/ACCEPTED.
 		drainPendingGloasPayloads(ctx, cfg)
+		retryUnverifiedAnchorPayload(ctx, cfg)
 		if cfg.executionClient.SupportInsertion() {
 			if err := cfg.blockCollector.Flush(context.Background()); err != nil {
 				log.Warn("[chainTipSync] blockCollector.Flush failed (EL may still be catching up)", "err", err)

--- a/cl/phase1/stages/chain_tip_sync.go
+++ b/cl/phase1/stages/chain_tip_sync.go
@@ -490,6 +490,14 @@ func retryGloasPayloadWithEL(ctx context.Context, cfg *Cfg, block *cltypes.Signe
 	return cfg.executionClient.NewPayload(ctx, envelope.Message.Payload, &parentRoot, versionedHashes, executionRequestsList)
 }
 
+func isGloasPayloadKnownInvalid(cfg *Cfg, envelope *cltypes.SignedExecutionPayloadEnvelope) bool {
+	if envelope == nil || envelope.Message == nil || envelope.Message.Payload == nil {
+		return false
+	}
+	status, ok := cfg.forkChoice.GetRecentExecutionPayloadStatus(envelope.Message.Payload.BlockHash)
+	return ok && status == execution_client.PayloadStatusInvalidated
+}
+
 func drainPendingGloasPayloads(ctx context.Context, cfg *Cfg) {
 	for _, p := range cfg.forkChoice.DrainPendingELPayloads() {
 		if p.Block == nil || p.Envelope == nil || p.Envelope.Message == nil || p.Envelope.Message.Payload == nil {
@@ -561,6 +569,10 @@ func verifyUnverifiedGloasPayloads(ctx context.Context, cfg *Cfg) {
 			log.Debug("[chainTipSync] failed to read GLOAS envelope for verification sweep", "slot", item.block.Block.Slot, "blockRoot", item.root, "err", err)
 			continue
 		}
+		if isGloasPayloadKnownInvalid(cfg, envelope) {
+			cfg.forkChoice.MarkPayloadInvalid(item.root, envelope.Message.Payload.BlockHash, item.block.Block)
+			continue
+		}
 		status, err := retryGloasPayloadWithEL(ctx, cfg, item.block, envelope)
 		if err != nil {
 			log.Warn("[chainTipSync] GLOAS verification sweep NewPayload failed", "slot", item.block.Block.Slot, "blockRoot", item.root, "status", status, "err", err)
@@ -588,14 +600,14 @@ func chainTipSync(ctx context.Context, logger log.Logger, cfg *Cfg, args Args) e
 	// insertion — so it must run regardless of SupportInsertion().
 	recoverMissingEnvelopes(ctx, cfg)
 
-	// Flush any collected blocks to the execution engine before ForkChoice.
-	// DrainPendingELPayloads and blockCollector require local insertion support.
-	if cfg.executionClient != nil && cfg.executionClient.SupportInsertion() {
+	if cfg.executionClient != nil {
 		// [New in Gloas:EIP7732] Drain execution blocks whose CL transition succeeded
 		// but whose EL newPayload previously returned SYNCING/ACCEPTED.
 		drainPendingGloasPayloads(ctx, cfg)
-		if err := cfg.blockCollector.Flush(context.Background()); err != nil {
-			log.Warn("[chainTipSync] blockCollector.Flush failed (EL may still be catching up)", "err", err)
+		if cfg.executionClient.SupportInsertion() {
+			if err := cfg.blockCollector.Flush(context.Background()); err != nil {
+				log.Warn("[chainTipSync] blockCollector.Flush failed (EL may still be catching up)", "err", err)
+			}
 		}
 	}
 
@@ -609,7 +621,7 @@ func chainTipSync(ctx context.Context, logger log.Logger, cfg *Cfg, args Args) e
 			if headRoot != (common.Hash{}) && !cfg.forkChoice.HasEnvelope(headRoot) {
 				pollForEnvelope(ctx, cfg, headRoot, 2*time.Second)
 			}
-			if cfg.executionClient != nil && cfg.executionClient.SupportInsertion() {
+			if cfg.executionClient != nil {
 				verifyUnverifiedGloasPayloads(ctx, cfg)
 			}
 			// NOTE: recoverMissingEnvelopes runs unconditionally above (before

--- a/cl/phase1/stages/forward_sync.go
+++ b/cl/phase1/stages/forward_sync.go
@@ -19,7 +19,6 @@ import (
 	"github.com/erigontech/erigon/cl/phase1/execution_client"
 	"github.com/erigontech/erigon/cl/phase1/forkchoice"
 	network2 "github.com/erigontech/erigon/cl/phase1/network"
-	"github.com/erigontech/erigon/cl/utils"
 	"github.com/erigontech/erigon/cl/utils/bls"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/hexutil"
@@ -490,22 +489,30 @@ func ensureAnchorEnvelopeOnce(ctx context.Context, cfg *Cfg) error {
 	if err := cfg.forkChoice.StoreAnchorEnvelope(anchorRoot, env); err != nil {
 		return fmt.Errorf("failed to store anchor envelope: %w", err)
 	}
-	if cfg.executionClient != nil {
-		status, err := validateAnchorPayloadWithEL(ctx, cfg, bid, env)
-		if err != nil {
-			log.Warn("[Caplin] Anchor envelope EL validation failed", "anchorSlot", anchorSlot, "anchorRoot", common.Hash(anchorRoot), "status", status, "err", err)
-		}
-		switch status {
-		case execution_client.PayloadStatusValidated:
-			cfg.forkChoice.MarkPayloadVerified(anchorRoot, env.Message.Payload.BlockHash, nil)
-		case execution_client.PayloadStatusInvalidated:
-			cfg.forkChoice.MarkPayloadInvalid(anchorRoot, env.Message.Payload.BlockHash, nil)
-			return fmt.Errorf("anchor execution payload invalidated by EL")
-		}
+	if err := validateAnchorPayloadIfLocalEL(ctx, cfg, anchorRoot, bid, env); err != nil {
+		return err
 	}
 
 	log.Info("[Caplin] Anchor envelope stored successfully (checkpoint sync)",
 		"anchorSlot", anchorSlot, "anchorRoot", common.Hash(anchorRoot))
+	return nil
+}
+
+func validateAnchorPayloadIfLocalEL(ctx context.Context, cfg *Cfg, anchorRoot common.Hash, bid *cltypes.ExecutionPayloadBid, env *cltypes.SignedExecutionPayloadEnvelope) error {
+	if !canRetryGloasPayloads(cfg) {
+		return nil
+	}
+	status, err := validateAnchorPayloadWithEL(ctx, cfg, bid, env)
+	if err != nil {
+		log.Warn("[Caplin] Anchor envelope EL validation failed", "anchorRoot", anchorRoot, "status", status, "err", err)
+	}
+	switch status {
+	case execution_client.PayloadStatusValidated:
+		cfg.forkChoice.MarkPayloadVerified(anchorRoot, env.Message.Payload.BlockHash)
+	case execution_client.PayloadStatusInvalidated:
+		cfg.forkChoice.MarkPayloadInvalid(anchorRoot, env.Message.Payload.BlockHash)
+		return fmt.Errorf("anchor execution payload invalidated by EL")
+	}
 	return nil
 }
 
@@ -620,16 +627,9 @@ func validateAnchorPayloadWithEL(ctx context.Context, cfg *Cfg, bid *cltypes.Exe
 }
 
 func buildAnchorNewPayloadArgs(beaconCfg *clparams.BeaconChainConfig, bid *cltypes.ExecutionPayloadBid, env *cltypes.SignedExecutionPayloadEnvelope) ([]common.Hash, []hexutil.Bytes, error) {
-	versionedHashes := make([]common.Hash, 0, bid.BlobKzgCommitments.Len())
-	if err := solid.RangeErr[*cltypes.KZGCommitment](&bid.BlobKzgCommitments, func(_ int, k *cltypes.KZGCommitment, _ int) error {
-		versionedHash, err := utils.KzgCommitmentToVersionedHash(common.Bytes48(*k))
-		if err != nil {
-			return err
-		}
-		versionedHashes = append(versionedHashes, versionedHash)
-		return nil
-	}); err != nil {
-		return nil, nil, fmt.Errorf("failed to compute versioned hashes: %w", err)
+	versionedHashes, err := gloasVersionedHashes(&bid.BlobKzgCommitments)
+	if err != nil {
+		return nil, nil, err
 	}
-	return versionedHashes, cltypes.GetExecutionRequestsList(beaconCfg, env.Message.ExecutionRequests), nil
+	return versionedHashes, gloasExecutionRequestsList(beaconCfg, env.Message.ExecutionRequests), nil
 }

--- a/cl/phase1/stages/forward_sync.go
+++ b/cl/phase1/stages/forward_sync.go
@@ -11,13 +11,18 @@ import (
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/cl/fork"
 	"github.com/erigontech/erigon/cl/persistence/beacon_indicies"
 	"github.com/erigontech/erigon/cl/persistence/blob_storage"
 	"github.com/erigontech/erigon/cl/phase1/core/checkpoint_sync"
 	"github.com/erigontech/erigon/cl/phase1/core/state"
+	"github.com/erigontech/erigon/cl/phase1/execution_client"
 	"github.com/erigontech/erigon/cl/phase1/forkchoice"
 	network2 "github.com/erigontech/erigon/cl/phase1/network"
+	"github.com/erigontech/erigon/cl/utils"
+	"github.com/erigontech/erigon/cl/utils/bls"
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
 )
@@ -426,8 +431,8 @@ func ensureAnchorEnvelopeOnce(ctx context.Context, cfg *Cfg) error {
 
 	// Get anchor block root from state
 	anchorRoot := cfg.forkChoice.FinalizedCheckpoint().Root
-	if cfg.forkChoice.HasEnvelope(anchorRoot) {
-		return nil // Already have it
+	if cfg.forkChoice.IsPayloadVerified(anchorRoot) {
+		return nil
 	}
 
 	// Optimistically fetch the anchor envelope. If the anchor was EMPTY, the envelope
@@ -448,24 +453,34 @@ func ensureAnchorEnvelopeOnce(ctx context.Context, cfg *Cfg) error {
 		"anchorSlot", anchorSlot, "anchorRoot", common.Hash(anchorRoot),
 		"bidBlockHash", bid.BlockHash)
 
-	// Try HTTP API first (checkpoint sync endpoint), then fall back to P2P.
-	// HTTP is more reliable on devnets with few peers.
 	var env *cltypes.SignedExecutionPayloadEnvelope
-	if httpEnv := checkpoint_sync.FetchFinalizedEnvelope(ctx, cfg.beaconCfg, cfg.caplinConfig); httpEnv != nil {
-		log.Info("[Caplin] Anchor envelope fetched via HTTP checkpoint sync", "anchorSlot", anchorSlot)
-		env = httpEnv
-	} else {
-		// Fall back to P2P
-		log.Info("[Caplin] HTTP envelope fetch returned nil, trying P2P...", "anchorSlot", anchorSlot)
-		envMap, err := network2.RequestEnvelopesFrantically(ctx, cfg.rpc, [][32]byte{anchorRoot})
+	if cfg.forkChoice.HasEnvelope(anchorRoot) {
+		env, err = cfg.forkChoice.ReadEnvelopeFromDisk(anchorRoot)
 		if err != nil {
-			return fmt.Errorf("failed to request anchor envelope: %w", err)
+			return fmt.Errorf("failed to read anchor envelope: %w", err)
 		}
-		env = envMap[common.Hash(anchorRoot)]
+	} else {
+		// Try HTTP API first (checkpoint sync endpoint), then fall back to P2P.
+		// HTTP is more reliable on devnets with few peers.
+		if httpEnv := checkpoint_sync.FetchFinalizedEnvelope(ctx, cfg.beaconCfg, cfg.caplinConfig); httpEnv != nil {
+			log.Info("[Caplin] Anchor envelope fetched via HTTP checkpoint sync", "anchorSlot", anchorSlot)
+			env = httpEnv
+		} else {
+			// Fall back to P2P
+			log.Info("[Caplin] HTTP envelope fetch returned nil, trying P2P...", "anchorSlot", anchorSlot)
+			envMap, err := network2.RequestEnvelopesFrantically(ctx, cfg.rpc, [][32]byte{anchorRoot})
+			if err != nil {
+				return fmt.Errorf("failed to request anchor envelope: %w", err)
+			}
+			env = envMap[common.Hash(anchorRoot)]
+		}
 	}
 	if env == nil {
 		log.Info("[Caplin] Anchor envelope not received (block may be EMPTY)", "anchorSlot", anchorSlot)
 		return nil // Not fatal — if EMPTY, envelope doesn't exist
+	}
+	if err := validateAnchorEnvelope(cfg.beaconCfg, anchorState, anchorRoot, bid, env); err != nil {
+		return fmt.Errorf("invalid anchor envelope: %w", err)
 	}
 
 	// Use StoreAnchorEnvelope instead of OnExecutionPayload because the checkpoint
@@ -475,8 +490,146 @@ func ensureAnchorEnvelopeOnce(ctx context.Context, cfg *Cfg) error {
 	if err := cfg.forkChoice.StoreAnchorEnvelope(anchorRoot, env); err != nil {
 		return fmt.Errorf("failed to store anchor envelope: %w", err)
 	}
+	if cfg.executionClient != nil {
+		status, err := validateAnchorPayloadWithEL(ctx, cfg, bid, env)
+		if err != nil {
+			log.Warn("[Caplin] Anchor envelope EL validation failed", "anchorSlot", anchorSlot, "anchorRoot", common.Hash(anchorRoot), "status", status, "err", err)
+		}
+		switch status {
+		case execution_client.PayloadStatusValidated:
+			cfg.forkChoice.MarkPayloadVerified(anchorRoot, env.Message.Payload.BlockHash, nil)
+		case execution_client.PayloadStatusInvalidated:
+			cfg.forkChoice.MarkPayloadInvalid(anchorRoot, env.Message.Payload.BlockHash, nil)
+			return fmt.Errorf("anchor execution payload invalidated by EL")
+		}
+	}
 
 	log.Info("[Caplin] Anchor envelope stored successfully (checkpoint sync)",
 		"anchorSlot", anchorSlot, "anchorRoot", common.Hash(anchorRoot))
 	return nil
+}
+
+func validateAnchorEnvelope(beaconCfg *clparams.BeaconChainConfig, anchorState *state.CachingBeaconState, anchorRoot common.Hash, bid *cltypes.ExecutionPayloadBid, env *cltypes.SignedExecutionPayloadEnvelope) error {
+	if bid == nil {
+		return errors.New("nil execution payload bid")
+	}
+	if env == nil || env.Message == nil || env.Message.Payload == nil {
+		return errors.New("nil execution payload envelope")
+	}
+	envelope := env.Message
+	payload := envelope.Payload
+	if envelope.BeaconBlockRoot != anchorRoot {
+		return fmt.Errorf("beacon block root mismatch: envelope=%v anchor=%v", envelope.BeaconBlockRoot, anchorRoot)
+	}
+	if envelope.ParentBeaconBlockRoot != bid.ParentBlockRoot {
+		return fmt.Errorf("parent beacon block root mismatch: envelope=%v bid=%v", envelope.ParentBeaconBlockRoot, bid.ParentBlockRoot)
+	}
+	if envelope.BuilderIndex != bid.BuilderIndex {
+		return fmt.Errorf("builder index mismatch: envelope=%d bid=%d", envelope.BuilderIndex, bid.BuilderIndex)
+	}
+	if payload.BlockHash != bid.BlockHash {
+		return fmt.Errorf("block hash mismatch: envelope=%v bid=%v", payload.BlockHash, bid.BlockHash)
+	}
+	if payload.ParentHash != bid.ParentBlockHash {
+		return fmt.Errorf("parent block hash mismatch: envelope=%v bid=%v", payload.ParentHash, bid.ParentBlockHash)
+	}
+	if payload.PrevRandao != bid.PrevRandao {
+		return fmt.Errorf("prev randao mismatch: envelope=%v bid=%v", payload.PrevRandao, bid.PrevRandao)
+	}
+	if payload.FeeRecipient != bid.FeeRecipient {
+		return fmt.Errorf("fee recipient mismatch: envelope=%v bid=%v", payload.FeeRecipient, bid.FeeRecipient)
+	}
+	if payload.GasLimit != bid.GasLimit {
+		return fmt.Errorf("gas limit mismatch: envelope=%d bid=%d", payload.GasLimit, bid.GasLimit)
+	}
+	if payload.SlotNumber != bid.Slot {
+		return fmt.Errorf("slot mismatch: envelope=%d bid=%d", payload.SlotNumber, bid.Slot)
+	}
+	if envelope.ExecutionRequests == nil {
+		return errors.New("nil execution requests")
+	}
+	requestsRoot, err := envelope.ExecutionRequests.HashSSZ()
+	if err != nil {
+		return fmt.Errorf("execution requests root: %w", err)
+	}
+	if requestsRoot != bid.ExecutionRequestsRoot {
+		return fmt.Errorf("execution requests root mismatch: envelope=%v bid=%v", requestsRoot, bid.ExecutionRequestsRoot)
+	}
+	requestsHash := cltypes.ComputeExecutionRequestHash(cltypes.GetExecutionRequestsList(beaconCfg, envelope.ExecutionRequests))
+	header, err := payload.RlpHeader(&envelope.ParentBeaconBlockRoot, requestsHash)
+	if err != nil {
+		return fmt.Errorf("payload header: %w", err)
+	}
+	if header.Hash() != payload.BlockHash {
+		return fmt.Errorf("payload block hash mismatch: header=%v payload=%v", header.Hash(), payload.BlockHash)
+	}
+	if err := verifyAnchorEnvelopeSignature(beaconCfg, anchorState, env, bid.Slot); err != nil {
+		return err
+	}
+	return nil
+}
+
+func verifyAnchorEnvelopeSignature(beaconCfg *clparams.BeaconChainConfig, anchorState *state.CachingBeaconState, env *cltypes.SignedExecutionPayloadEnvelope, slot uint64) error {
+	var pk [48]byte
+	if env.Message.BuilderIndex == clparams.BuilderIndexSelfBuild {
+		proposerIndex := anchorState.LatestBlockHeader().ProposerIndex
+		validator, err := anchorState.ValidatorForValidatorIndex(int(proposerIndex))
+		if err != nil {
+			return fmt.Errorf("proposer validator: %w", err)
+		}
+		pk = validator.PublicKey()
+	} else {
+		builders := anchorState.GetBuilders()
+		if builders == nil {
+			return errors.New("builders not found")
+		}
+		if env.Message.BuilderIndex >= uint64(builders.Len()) {
+			return fmt.Errorf("builder index %d out of range", env.Message.BuilderIndex)
+		}
+		builder := builders.Get(int(env.Message.BuilderIndex))
+		if builder == nil {
+			return errors.New("builder not found")
+		}
+		pk = builder.Pubkey
+	}
+	epoch := state.GetEpochAtSlot(beaconCfg, slot)
+	domain, err := anchorState.GetDomain(beaconCfg.DomainBeaconBuilder, epoch)
+	if err != nil {
+		return fmt.Errorf("builder domain: %w", err)
+	}
+	signingRoot, err := fork.ComputeSigningRoot(env.Message, domain)
+	if err != nil {
+		return fmt.Errorf("builder signing root: %w", err)
+	}
+	valid, err := bls.Verify(env.Signature[:], signingRoot[:], pk[:])
+	if err != nil {
+		return fmt.Errorf("builder signature: %w", err)
+	}
+	if !valid {
+		return errors.New("invalid builder signature")
+	}
+	return nil
+}
+
+func validateAnchorPayloadWithEL(ctx context.Context, cfg *Cfg, bid *cltypes.ExecutionPayloadBid, env *cltypes.SignedExecutionPayloadEnvelope) (execution_client.PayloadStatus, error) {
+	versionedHashes, executionRequestsList, err := buildAnchorNewPayloadArgs(cfg.beaconCfg, bid, env)
+	if err != nil {
+		return execution_client.PayloadStatusNone, err
+	}
+	return cfg.executionClient.NewPayload(ctx, env.Message.Payload, &bid.ParentBlockRoot, versionedHashes, executionRequestsList)
+}
+
+func buildAnchorNewPayloadArgs(beaconCfg *clparams.BeaconChainConfig, bid *cltypes.ExecutionPayloadBid, env *cltypes.SignedExecutionPayloadEnvelope) ([]common.Hash, []hexutil.Bytes, error) {
+	versionedHashes := make([]common.Hash, 0, bid.BlobKzgCommitments.Len())
+	if err := solid.RangeErr[*cltypes.KZGCommitment](&bid.BlobKzgCommitments, func(_ int, k *cltypes.KZGCommitment, _ int) error {
+		versionedHash, err := utils.KzgCommitmentToVersionedHash(common.Bytes48(*k))
+		if err != nil {
+			return err
+		}
+		versionedHashes = append(versionedHashes, versionedHash)
+		return nil
+	}); err != nil {
+		return nil, nil, fmt.Errorf("failed to compute versioned hashes: %w", err)
+	}
+	return versionedHashes, cltypes.GetExecutionRequestsList(beaconCfg, env.Message.ExecutionRequests), nil
 }

--- a/cl/phase1/stages/forward_sync.go
+++ b/cl/phase1/stages/forward_sync.go
@@ -420,8 +420,9 @@ func ensureAnchorEnvelopeOnce(ctx context.Context, cfg *Cfg) error {
 		return nil // Pre-GLOAS anchor, nothing to do
 	}
 
+	anchorRoot := cfg.forkChoice.AnchorRoot()
 	// Find the anchor block root via the header stored in the fork graph
-	anchorHeader, ok := cfg.forkChoice.GetHeader(cfg.forkChoice.FinalizedCheckpoint().Root)
+	anchorHeader, ok := cfg.forkChoice.GetHeader(anchorRoot)
 	if !ok {
 		// Try to find by iterating — the anchor root should be the finalized root
 		log.Debug("[ensureAnchorEnvelopeOnce] anchor header not found, skipping")
@@ -430,7 +431,6 @@ func ensureAnchorEnvelopeOnce(ctx context.Context, cfg *Cfg) error {
 	_ = anchorHeader
 
 	// Get anchor block root from state
-	anchorRoot := cfg.forkChoice.FinalizedCheckpoint().Root
 	if cfg.forkChoice.IsPayloadVerified(anchorRoot) {
 		return nil
 	}

--- a/cl/phase1/stages/gloas_payload_test.go
+++ b/cl/phase1/stages/gloas_payload_test.go
@@ -1,0 +1,429 @@
+package stages
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/cl/fork"
+	state2 "github.com/erigontech/erigon/cl/phase1/core/state"
+	"github.com/erigontech/erigon/cl/phase1/execution_client"
+	"github.com/erigontech/erigon/cl/phase1/forkchoice"
+	"github.com/erigontech/erigon/cl/utils"
+	"github.com/erigontech/erigon/cl/utils/bls"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/empty"
+	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/execution/engineapi/engine_types"
+	"github.com/erigontech/erigon/execution/protocol/rules/merge"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/node/gointerfaces/typesproto"
+)
+
+func TestValidateAnchorEnvelope(t *testing.T) {
+	cfg, st, bid, env, anchorRoot := validAnchorEnvelopeFixture(t, 1)
+
+	require.NoError(t, validateAnchorEnvelope(cfg, st, anchorRoot, bid, env))
+
+	tests := []struct {
+		name    string
+		mutate  func(*cltypes.ExecutionPayloadBid, *cltypes.SignedExecutionPayloadEnvelope)
+		wantErr string
+	}{
+		{
+			name: "beacon root mismatch",
+			mutate: func(_ *cltypes.ExecutionPayloadBid, env *cltypes.SignedExecutionPayloadEnvelope) {
+				env.Message.BeaconBlockRoot = common.HexToHash("0x99")
+			},
+			wantErr: "beacon block root mismatch",
+		},
+		{
+			name: "parent root mismatch",
+			mutate: func(_ *cltypes.ExecutionPayloadBid, env *cltypes.SignedExecutionPayloadEnvelope) {
+				env.Message.ParentBeaconBlockRoot = common.HexToHash("0x98")
+			},
+			wantErr: "parent beacon block root mismatch",
+		},
+		{
+			name: "builder index mismatch",
+			mutate: func(_ *cltypes.ExecutionPayloadBid, env *cltypes.SignedExecutionPayloadEnvelope) {
+				env.Message.BuilderIndex++
+			},
+			wantErr: "builder index mismatch",
+		},
+		{
+			name: "block hash mismatch",
+			mutate: func(bid *cltypes.ExecutionPayloadBid, _ *cltypes.SignedExecutionPayloadEnvelope) {
+				bid.BlockHash = common.HexToHash("0x97")
+			},
+			wantErr: "block hash mismatch",
+		},
+		{
+			name: "parent block hash mismatch",
+			mutate: func(_ *cltypes.ExecutionPayloadBid, env *cltypes.SignedExecutionPayloadEnvelope) {
+				env.Message.Payload.ParentHash = common.HexToHash("0x96")
+			},
+			wantErr: "parent block hash mismatch",
+		},
+		{
+			name: "prev randao mismatch",
+			mutate: func(_ *cltypes.ExecutionPayloadBid, env *cltypes.SignedExecutionPayloadEnvelope) {
+				env.Message.Payload.PrevRandao = common.HexToHash("0x95")
+			},
+			wantErr: "prev randao mismatch",
+		},
+		{
+			name: "fee recipient mismatch",
+			mutate: func(_ *cltypes.ExecutionPayloadBid, env *cltypes.SignedExecutionPayloadEnvelope) {
+				env.Message.Payload.FeeRecipient = common.HexToAddress("0x0000000000000000000000000000000000000094")
+			},
+			wantErr: "fee recipient mismatch",
+		},
+		{
+			name: "gas limit mismatch",
+			mutate: func(_ *cltypes.ExecutionPayloadBid, env *cltypes.SignedExecutionPayloadEnvelope) {
+				env.Message.Payload.GasLimit++
+			},
+			wantErr: "gas limit mismatch",
+		},
+		{
+			name: "slot mismatch",
+			mutate: func(_ *cltypes.ExecutionPayloadBid, env *cltypes.SignedExecutionPayloadEnvelope) {
+				env.Message.Payload.SlotNumber++
+			},
+			wantErr: "slot mismatch",
+		},
+		{
+			name: "nil execution requests",
+			mutate: func(_ *cltypes.ExecutionPayloadBid, env *cltypes.SignedExecutionPayloadEnvelope) {
+				env.Message.ExecutionRequests = nil
+			},
+			wantErr: "nil execution requests",
+		},
+		{
+			name: "execution requests root mismatch",
+			mutate: func(bid *cltypes.ExecutionPayloadBid, _ *cltypes.SignedExecutionPayloadEnvelope) {
+				bid.ExecutionRequestsRoot = common.HexToHash("0x93")
+			},
+			wantErr: "execution requests root mismatch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, st, bid, env, anchorRoot := validAnchorEnvelopeFixture(t, 1)
+			tt.mutate(bid, env)
+			require.ErrorContains(t, validateAnchorEnvelope(cfg, st, anchorRoot, bid, env), tt.wantErr)
+		})
+	}
+}
+
+func TestVerifyAnchorEnvelopeSignature(t *testing.T) {
+	_, st, bid, env, _ := validAnchorEnvelopeFixture(t, 2)
+	require.NoError(t, verifyAnchorEnvelopeSignature(st.BeaconConfig(), st, env, bid.Slot))
+
+	cfg, st, bid, env, _ := validAnchorEnvelopeFixture(t, clparams.BuilderIndexSelfBuild)
+	require.NoError(t, verifyAnchorEnvelopeSignature(cfg, st, env, bid.Slot))
+
+	t.Run("invalid signature", func(t *testing.T) {
+		cfg, st, bid, env, _ := validAnchorEnvelopeFixture(t, 1)
+		env.Signature[0] ^= 0x01
+		require.Error(t, verifyAnchorEnvelopeSignature(cfg, st, env, bid.Slot))
+	})
+
+	t.Run("builder index out of range", func(t *testing.T) {
+		cfg, st, bid, env, _ := validAnchorEnvelopeFixture(t, 1)
+		env.Message.BuilderIndex = 63
+		require.ErrorContains(t, verifyAnchorEnvelopeSignature(cfg, st, env, bid.Slot), "builder index 63 out of range")
+	})
+
+	t.Run("nil builders", func(t *testing.T) {
+		cfg, st, bid, env, _ := validAnchorEnvelopeFixture(t, 1)
+		st.SetBuilders(nil)
+		require.ErrorContains(t, verifyAnchorEnvelopeSignature(cfg, st, env, bid.Slot), "builders not found")
+	})
+}
+
+func TestGloasPayloadHelpers(t *testing.T) {
+	require.False(t, validPendingGloasPayload(forkchoice.PendingELPayload{}))
+	require.False(t, validPendingGloasPayload(forkchoice.PendingELPayload{Block: &cltypes.SignedBeaconBlock{}}))
+
+	hash, ok := gloasEnvelopePayloadHash(&cltypes.SignedExecutionPayloadEnvelope{})
+	require.False(t, ok)
+	require.Equal(t, common.Hash{}, hash)
+
+	want := common.HexToHash("0x1234")
+	hash, ok = gloasEnvelopePayloadHash(&cltypes.SignedExecutionPayloadEnvelope{
+		Message: &cltypes.ExecutionPayloadEnvelope{
+			Payload: &cltypes.Eth1Block{BlockHash: want},
+		},
+	})
+	require.True(t, ok)
+	require.Equal(t, want, hash)
+}
+
+func TestStandaloneExecutionClientDoesNotRunLocalGloasRetry(t *testing.T) {
+	require.False(t, canRetryGloasPayloads(&Cfg{}))
+	require.False(t, canRetryGloasPayloads(&Cfg{executionClient: &testExecutionEngine{supportInsertion: false}}))
+	require.True(t, canRetryGloasPayloads(&Cfg{executionClient: &testExecutionEngine{supportInsertion: true}}))
+}
+
+func TestValidateAnchorPayloadIfLocalELFollowsSupportInsertion(t *testing.T) {
+	cfg, _, bid, env, anchorRoot := validAnchorEnvelopeFixture(t, 1)
+	remoteEL := &testExecutionEngine{
+		supportInsertion: false,
+		payloadStatus:    execution_client.PayloadStatusInvalidated,
+	}
+
+	require.NoError(t, validateAnchorPayloadIfLocalEL(context.Background(), &Cfg{
+		beaconCfg:       cfg,
+		executionClient: remoteEL,
+		forkChoice:      &forkchoice.ForkChoiceStore{},
+	}, anchorRoot, bid, env))
+	require.Equal(t, 0, remoteEL.newPayloadCalls)
+
+	localEL := &testExecutionEngine{
+		supportInsertion: true,
+		payloadStatus:    execution_client.PayloadStatusValidated,
+	}
+	require.NoError(t, validateAnchorPayloadIfLocalEL(context.Background(), &Cfg{
+		beaconCfg:       cfg,
+		executionClient: localEL,
+		forkChoice:      &forkchoice.ForkChoiceStore{},
+	}, anchorRoot, bid, env))
+	require.Equal(t, 1, localEL.newPayloadCalls)
+}
+
+func TestDrainPendingGloasPayloadsRequeuesNotValidatedPayload(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	clparams.ApplyMinimalPreset(&cfg)
+	blockRoot := common.HexToHash("0x1234")
+	parentRoot := common.HexToHash("0x5678")
+	execHash := common.HexToHash("0x9abc")
+	fc := &forkchoice.ForkChoiceStore{}
+	engine := &testExecutionEngine{
+		supportInsertion: true,
+		payloadStatus:    execution_client.PayloadStatusNotValidated,
+	}
+	payload := cltypes.NewEth1Block(clparams.GloasVersion, &cfg)
+	payload.BlockHash = execHash
+	pending := forkchoice.PendingELPayload{
+		Block: &cltypes.SignedBeaconBlock{
+			Block: &cltypes.BeaconBlock{
+				Slot:       1,
+				ParentRoot: parentRoot,
+				Body: &cltypes.BeaconBody{
+					Version: clparams.GloasVersion,
+					SignedExecutionPayloadBid: &cltypes.SignedExecutionPayloadBid{
+						Message: &cltypes.ExecutionPayloadBid{
+							BlobKzgCommitments: *solid.NewStaticListSSZ[*cltypes.KZGCommitment](cltypes.MaxBlobsCommittmentsPerBlock, 48),
+						},
+					},
+				},
+			},
+		},
+		Envelope: &cltypes.SignedExecutionPayloadEnvelope{
+			Message: &cltypes.ExecutionPayloadEnvelope{
+				BeaconBlockRoot: blockRoot,
+				Payload:         payload,
+			},
+		},
+	}
+	fc.RequeuePendingELPayload(pending)
+
+	drainPendingGloasPayloads(context.Background(), &Cfg{
+		beaconCfg:       &cfg,
+		executionClient: engine,
+		forkChoice:      fc,
+	})
+
+	require.Equal(t, 1, engine.newPayloadCalls)
+	queued := fc.DrainPendingELPayloads()
+	require.Len(t, queued, 1)
+	require.Equal(t, blockRoot, queued[0].Envelope.Message.BeaconBlockRoot)
+}
+
+func validAnchorEnvelopeFixture(t *testing.T, builderIndex uint64) (*clparams.BeaconChainConfig, *state2.CachingBeaconState, *cltypes.ExecutionPayloadBid, *cltypes.SignedExecutionPayloadEnvelope, common.Hash) {
+	t.Helper()
+
+	cfg := clparams.MainnetBeaconConfig
+	clparams.ApplyMinimalPreset(&cfg)
+	cfg.GloasForkEpoch = 0
+	cfg.GloasForkVersion = 0x80000038
+	cfg.InitializeForkSchedule()
+
+	st := state2.New(&cfg)
+	st.SetVersion(clparams.GloasVersion)
+	st.SetSlot(64)
+	st.SetGenesisValidatorsRoot(common.HexToHash("0x01"))
+	st.SetFork(&cltypes.Fork{
+		PreviousVersion: utils.Uint32ToBytes4(uint32(cfg.GloasForkVersion)),
+		CurrentVersion:  utils.Uint32ToBytes4(uint32(cfg.GloasForkVersion)),
+		Epoch:           0,
+	})
+	st.SetLatestBlockHeader(&cltypes.BeaconBlockHeader{ProposerIndex: 0})
+
+	privKey, err := bls.NewPrivateKeyFromIKM([]byte("01234567890123456789012345678901"))
+	require.NoError(t, err)
+	pubkey := common.Bytes48(bls.CompressPublicKey(privKey.PublicKey()))
+
+	st.AddValidator(solid.NewValidatorFromParameters(pubkey, common.Hash{}, cfg.MaxEffectiveBalance, false, 0, 0, cfg.FarFutureEpoch, cfg.FarFutureEpoch), cfg.MaxEffectiveBalance)
+	builders := solid.NewStaticListSSZ[*cltypes.Builder](64, 73)
+	if builderIndex != clparams.BuilderIndexSelfBuild {
+		for i := uint64(0); i <= builderIndex; i++ {
+			builders.Append(&cltypes.Builder{Pubkey: pubkey})
+		}
+	}
+	st.SetBuilders(builders)
+
+	anchorRoot := common.HexToHash("0x12")
+	parentRoot := common.HexToHash("0x11")
+	parentHash := common.HexToHash("0x10")
+	prevRandao := common.HexToHash("0x13")
+	feeRecipient := common.HexToAddress("0x0000000000000000000000000000000000000014")
+	requests := cltypes.NewExecutionRequests(&cfg)
+	requestsRoot, err := requests.HashSSZ()
+	require.NoError(t, err)
+	requestsHash := cltypes.ComputeExecutionRequestHash(cltypes.GetExecutionRequestsList(&cfg, requests))
+
+	payload := cltypes.NewEth1Block(clparams.GloasVersion, &cfg)
+	payload.ParentHash = parentHash
+	payload.FeeRecipient = feeRecipient
+	payload.PrevRandao = prevRandao
+	payload.GasLimit = 30_000_000
+	payload.SlotNumber = 64
+	payload.Extra = solid.NewExtraData()
+	payload.Transactions = &solid.TransactionsSSZ{}
+	payload.Withdrawals = solid.NewStaticListSSZ[*cltypes.Withdrawal](int(cfg.MaxWithdrawalsPerPayload), 44)
+	payload.BlockAccessList = solid.NewByteListSSZ(cfg.MaxBytesPerTransaction)
+	payload.BlockHash = anchorPayloadHeaderHash(t, payload, parentRoot, requestsHash)
+
+	bid := &cltypes.ExecutionPayloadBid{
+		ParentBlockHash:       parentHash,
+		ParentBlockRoot:       parentRoot,
+		BlockHash:             payload.BlockHash,
+		PrevRandao:            prevRandao,
+		FeeRecipient:          feeRecipient,
+		GasLimit:              payload.GasLimit,
+		BuilderIndex:          builderIndex,
+		Slot:                  payload.SlotNumber,
+		BlobKzgCommitments:    *solid.NewStaticListSSZ[*cltypes.KZGCommitment](cltypes.MaxBlobsCommittmentsPerBlock, 48),
+		ExecutionRequestsRoot: requestsRoot,
+	}
+	env := &cltypes.SignedExecutionPayloadEnvelope{
+		Message: &cltypes.ExecutionPayloadEnvelope{
+			Payload:               payload,
+			ExecutionRequests:     requests,
+			BuilderIndex:          builderIndex,
+			BeaconBlockRoot:       anchorRoot,
+			ParentBeaconBlockRoot: parentRoot,
+		},
+	}
+	signAnchorEnvelope(t, st, privKey, env, bid.Slot)
+	return &cfg, st, bid, env, anchorRoot
+}
+
+func signAnchorEnvelope(t *testing.T, st *state2.CachingBeaconState, privKey *bls.PrivateKey, env *cltypes.SignedExecutionPayloadEnvelope, slot uint64) {
+	t.Helper()
+
+	domain, err := st.GetDomain(st.BeaconConfig().DomainBeaconBuilder, state2.GetEpochAtSlot(st.BeaconConfig(), slot))
+	require.NoError(t, err)
+	signingRoot, err := fork.ComputeSigningRoot(env.Message, domain)
+	require.NoError(t, err)
+	copy(env.Signature[:], privKey.Sign(signingRoot[:]).Bytes())
+}
+
+func anchorPayloadHeaderHash(t *testing.T, payload *cltypes.Eth1Block, parentRoot common.Hash, requestsHash common.Hash) common.Hash {
+	t.Helper()
+
+	withdrawalsHash := types.DeriveSha(types.Withdrawals(nil))
+	blobGasUsed := payload.BlobGasUsed
+	excessBlobGas := payload.ExcessBlobGas
+	blockAccessListHash := empty.BlockAccessListHash
+	slotNumber := payload.SlotNumber
+	header := &types.Header{
+		ParentHash:            payload.ParentHash,
+		UncleHash:             empty.UncleHash,
+		Coinbase:              payload.FeeRecipient,
+		Root:                  payload.StateRoot,
+		TxHash:                types.DeriveSha(types.BinaryTransactions(nil)),
+		ReceiptHash:           payload.ReceiptsRoot,
+		Bloom:                 payload.LogsBloom,
+		Difficulty:            *merge.ProofOfStakeDifficulty,
+		GasLimit:              payload.GasLimit,
+		GasUsed:               payload.GasUsed,
+		Time:                  payload.Time,
+		Extra:                 nil,
+		MixDigest:             payload.PrevRandao,
+		Nonce:                 merge.ProofOfStakeNonce,
+		BaseFee:               new(uint256.Int),
+		WithdrawalsHash:       &withdrawalsHash,
+		ParentBeaconBlockRoot: &parentRoot,
+		BlobGasUsed:           &blobGasUsed,
+		ExcessBlobGas:         &excessBlobGas,
+		RequestsHash:          &requestsHash,
+		BlockAccessListHash:   &blockAccessListHash,
+		SlotNumber:            &slotNumber,
+	}
+	header.Number.SetUint64(payload.BlockNumber)
+	return header.Hash()
+}
+
+type testExecutionEngine struct {
+	supportInsertion bool
+	payloadStatus    execution_client.PayloadStatus
+	newPayloadCalls  int
+}
+
+func (t *testExecutionEngine) NewPayload(context.Context, *cltypes.Eth1Block, *common.Hash, []common.Hash, []hexutil.Bytes) (execution_client.PayloadStatus, error) {
+	t.newPayloadCalls++
+	return t.payloadStatus, nil
+}
+
+func (t *testExecutionEngine) ForkChoiceUpdate(context.Context, common.Hash, common.Hash, common.Hash, *engine_types.PayloadAttributes, clparams.StateVersion) ([]byte, error) {
+	return nil, nil
+}
+
+func (t *testExecutionEngine) SupportInsertion() bool { return t.supportInsertion }
+
+func (t *testExecutionEngine) InsertBlocks(context.Context, []*types.Block, bool) error { return nil }
+
+func (t *testExecutionEngine) InsertBlock(context.Context, *types.Block) error { return nil }
+
+func (t *testExecutionEngine) CurrentHeader(context.Context) (*types.Header, error) { return nil, nil }
+
+func (t *testExecutionEngine) IsCanonicalHash(context.Context, common.Hash) (bool, error) {
+	return false, nil
+}
+
+func (t *testExecutionEngine) Ready(context.Context) (bool, error) { return true, nil }
+
+func (t *testExecutionEngine) GetBodiesByRange(context.Context, uint64, uint64) ([]*types.RawBody, error) {
+	return nil, nil
+}
+
+func (t *testExecutionEngine) GetBodiesByHashes(context.Context, []common.Hash) ([]*types.RawBody, error) {
+	return nil, nil
+}
+
+func (t *testExecutionEngine) HasBlock(context.Context, common.Hash) (bool, error) { return false, nil }
+
+func (t *testExecutionEngine) FrozenBlocks(context.Context) uint64 { return 0 }
+
+func (t *testExecutionEngine) HasGapInSnapshots(context.Context) bool { return false }
+
+func (t *testExecutionEngine) GetAssembledBlock(context.Context, []byte, clparams.StateVersion) (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
+	return nil, nil, nil, nil, nil
+}
+
+func (t *testExecutionEngine) GetBlobs(context.Context, []common.Hash, clparams.StateVersion) ([][]byte, [][][]byte, error) {
+	return nil, nil, nil
+}
+
+var _ execution_client.ExecutionEngine = (*testExecutionEngine)(nil)

--- a/cl/spectest/consensus_tests/fork_choice.go
+++ b/cl/spectest/consensus_tests/fork_choice.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/fs"
 	"math"
+	"math/big"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -38,6 +39,7 @@ import (
 	"github.com/erigontech/erigon/cl/das"
 	peerdasstate "github.com/erigontech/erigon/cl/das/state"
 	"github.com/erigontech/erigon/cl/persistence/blob_storage"
+	"github.com/erigontech/erigon/cl/phase1/execution_client"
 	"github.com/erigontech/erigon/cl/phase1/forkchoice"
 	"github.com/erigontech/erigon/cl/phase1/forkchoice/fork_graph"
 	"github.com/erigontech/erigon/cl/phase1/forkchoice/public_keys_registry"
@@ -47,11 +49,65 @@ import (
 	"github.com/erigontech/erigon/cl/utils/eth_clock"
 	"github.com/erigontech/erigon/cl/validator/validator_params"
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/db/kv/dbcfg"
 	"github.com/erigontech/erigon/db/kv/memdb"
 	chainspec "github.com/erigontech/erigon/execution/chain/spec"
+	"github.com/erigontech/erigon/execution/engineapi/engine_types"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/node/gointerfaces/typesproto"
 	"github.com/erigontech/erigon/p2p/enode"
 )
+
+type forkChoiceSpectestEngine struct{}
+
+func (forkChoiceSpectestEngine) NewPayload(context.Context, *cltypes.Eth1Block, *common.Hash, []common.Hash, []hexutil.Bytes) (execution_client.PayloadStatus, error) {
+	return execution_client.PayloadStatusValidated, nil
+}
+
+func (forkChoiceSpectestEngine) ForkChoiceUpdate(context.Context, common.Hash, common.Hash, common.Hash, *engine_types.PayloadAttributes, clparams.StateVersion) ([]byte, error) {
+	return nil, nil
+}
+
+func (forkChoiceSpectestEngine) SupportInsertion() bool { return false }
+
+func (forkChoiceSpectestEngine) InsertBlocks(context.Context, []*types.Block, bool) error { return nil }
+
+func (forkChoiceSpectestEngine) InsertBlock(context.Context, *types.Block) error { return nil }
+
+func (forkChoiceSpectestEngine) CurrentHeader(context.Context) (*types.Header, error) {
+	return nil, nil
+}
+
+func (forkChoiceSpectestEngine) IsCanonicalHash(context.Context, common.Hash) (bool, error) {
+	return false, nil
+}
+
+func (forkChoiceSpectestEngine) Ready(context.Context) (bool, error) { return true, nil }
+
+func (forkChoiceSpectestEngine) GetBodiesByRange(context.Context, uint64, uint64) ([]*types.RawBody, error) {
+	return nil, nil
+}
+
+func (forkChoiceSpectestEngine) GetBodiesByHashes(context.Context, []common.Hash) ([]*types.RawBody, error) {
+	return nil, nil
+}
+
+func (forkChoiceSpectestEngine) HasBlock(context.Context, common.Hash) (bool, error) {
+	return false, nil
+}
+
+func (forkChoiceSpectestEngine) FrozenBlocks(context.Context) uint64 { return 0 }
+
+func (forkChoiceSpectestEngine) HasGapInSnapshots(context.Context) bool { return false }
+
+func (forkChoiceSpectestEngine) GetAssembledBlock(context.Context, []byte, clparams.StateVersion) (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
+	return nil, nil, nil, nil, nil
+}
+
+func (forkChoiceSpectestEngine) GetBlobs(context.Context, []common.Hash, clparams.StateVersion) ([][]byte, [][][]byte, error) {
+	return nil, nil, nil
+}
 
 func (f *ForkChoiceStep) StepType() string {
 	if f.PayloadStatus != nil {
@@ -248,7 +304,7 @@ func (b *ForkChoice) Run(t *testing.T, root fs.FS, c spectest.TestCase) (err err
 	localValidators := validator_params.NewValidatorParams()
 
 	forkStore, err := forkchoice.NewForkChoiceStore(
-		ethClock, anchorState, nil, pool.NewOperationsPool(&clparams.MainnetBeaconConfig),
+		ethClock, anchorState, forkChoiceSpectestEngine{}, pool.NewOperationsPool(&clparams.MainnetBeaconConfig),
 		fork_graph.NewForkGraphDisk(anchorState, nil, afero.NewMemMapFs(), beacon_router_configuration.RouterConfiguration{}, emitters),
 		emitters, synced_data.NewSyncedDataManager(&clparams.MainnetBeaconConfig, true), blobStorage, public_keys_registry.NewInMemoryPublicKeysRegistry(),
 		localValidators, false, nil)
@@ -355,7 +411,7 @@ func (b *ForkChoice) Run(t *testing.T, root fs.FS, c spectest.TestCase) (err err
 			}
 			err := spectest.ReadSsz(root, c.Version(), step.GetExecutionPayload()+".ssz_snappy", envelope)
 			require.NoError(t, err, stepstr)
-			err = forkStore.OnExecutionPayload(ctx, envelope, false, false)
+			err = forkStore.OnExecutionPayload(ctx, envelope, false, true)
 			if step.GetValid() {
 				require.NoError(t, err, stepstr)
 			} else {


### PR DESCRIPTION
## Summary

- Replace `HasEnvelope` (disk existence) with `verifiedExecutionPayload` (EL returned VALID) in GLOAS fork choice logic
- Add `MarkPayloadVerified` / `IsPayloadVerified` / `RequeuePendingELPayload` on `ForkChoiceStore`
- Change local-EL drain path in `chainTipSync` from `InsertBlocks` to per-payload `NewPayload`: VALID -> mark verified, SYNCING/ACCEPTED -> re-queue
- Add a bounded verification sweep at chain tip for unverified blocks between finalized and head
- Gate local-EL retry/sweep machinery by `SupportInsertion()` so standalone Caplin with a remote EL is unaffected
- Add stages coverage for anchor envelope validation, builder/self-build signatures, pending payload retry helpers, and standalone gating

Closes #21131

## Test plan

- [x] `go test ./cl/phase1/forkchoice/... -count=1`
- [x] `go test ./cl/phase1/stages -count=1`
- [x] `go test ./cl/phase1/network/services -count=1`
- [x] `go test -tags=spectest ./cl/spectest -run '^$' -count=1`
- [x] `make lint`
- [x] `make erigon integration`