### PR TITLE
db/state: backwards compatibility for ref commitment files (wip)

### DIFF
--- a/db/seg/compress.go
+++ b/db/seg/compress.go
@@ -222,8 +222,8 @@ func (c *Compressor) Count() int { return int(c.wordsCount) }
 // parallel small unit-tests which each create many small files and bufio
 // readers/writers — pooling avoids the allocation pressure in that scenario.
 var (
-	bufioWriterPool = sync.Pool{New: func() any { return bufio.NewWriterSize(nil, int(256*datasize.KB)) }}
-	bufioReaderPool = sync.Pool{New: func() any { return bufio.NewReaderSize(nil, int(256*datasize.KB)) }}
+	bufioWriterPool = sync.Pool{New: func() any { return bufio.NewWriterSize(nil, int(512*datasize.KB)) }}
+	bufioReaderPool = sync.Pool{New: func() any { return bufio.NewReaderSize(nil, int(512*datasize.KB)) }}
 )
 
 func getBufioWriter(w io.Writer) *bufio.Writer {

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -1768,12 +1768,17 @@ func (at *AggregatorRoTx) mergeFiles(ctx context.Context, files *SelectedStaticF
 
 		g.Go(func() (err error) {
 			var vt valueTransformer
-			if commitmentUseReferencedBranches && kid == kv.CommitmentDomain && r.domain[kid].values.needMerge {
-				accStorageMerged.Wait()
+			if kid == kv.CommitmentDomain && r.domain[kid].values.needMerge {
+				if commitmentUseReferencedBranches {
+					accStorageMerged.Wait()
+				}
 
-				// prepare transformer callback to correctly dereference previously merged accounts/storage plain keys
+				// Always install vt for commitment merges. With produceRefs=false the transform
+				// dereferences any source-side refs (from older v2.0 files) back to full keys so
+				// the merged v2.1 destination is purely noref; noref source files pass through
+				// without walking keys. The merged-acct/storage args are unused in that mode.
 				vt, err = at.d[kv.CommitmentDomain].commitmentValTransformDomain(r.domain[kid].values, at.d[kv.AccountsDomain], at.d[kv.StorageDomain],
-					mf.d[kv.AccountsDomain], mf.d[kv.StorageDomain])
+					mf.d[kv.AccountsDomain], mf.d[kv.StorageDomain], false)
 
 				if err != nil {
 					return fmt.Errorf("failed to create commitment value transformer: %w", err)

--- a/db/state/dirty_files.go
+++ b/db/state/dirty_files.go
@@ -59,6 +59,11 @@ type FilesItem struct {
 	existence            *existence.Filter
 	startTxNum, endTxNum uint64 //[startTxNum, endTxNum)
 
+	// dataVer is the version parsed from the data file's name (kv for domains, v for history, ef for II).
+	// Used to distinguish format variants whose payload differs but the file extension does not — e.g.
+	// commitment .kv files at v2.0 may contain shortened referenced keys, v2.1+ are noref-only.
+	dataVer version.Version
+
 	// Frozen: file containing Aggregator.stepsInFrozenFile steps. Completely immutable.
 	// Cold: file containing < Aggregator.stepsInFrozenFile steps. Immutable, but can be closed/removed after merge to bigger file.
 	// Hot: Stored in DB. Providing Snapshot-Isolation by CopyOnWrite.
@@ -369,6 +374,7 @@ func (d *Domain) openDirtyFiles(dirEntries []string) (err error) {
 					// don't interrupt on error. other files may be good. but skip indices open.
 					continue
 				}
+				item.dataVer = fileVer
 			}
 
 			if item.index == nil && d.Accessors.Has(statecfg.AccessorHashMap) {

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1234,6 +1234,7 @@ func (d *Domain) integrateDirtyFiles(sf StaticFiles, txNumFrom, txNumTo uint64) 
 	fi.index = sf.valuesIdx
 	fi.bindex = sf.valuesBt
 	fi.existence = sf.existenceFilter
+	fi.dataVer = d.FileVersion.DataKV.Current
 	d.dirtyFiles.Set(fi)
 }
 

--- a/db/state/domain_committed.go
+++ b/db/state/domain_committed.go
@@ -31,6 +31,7 @@ import (
 	"github.com/erigontech/erigon/db/recsplit"
 	"github.com/erigontech/erigon/db/seg"
 	"github.com/erigontech/erigon/db/state/statecfg"
+	"github.com/erigontech/erigon/db/version"
 	"github.com/erigontech/erigon/execution/commitment"
 	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
 )
@@ -43,35 +44,43 @@ func ValuesPlainKeyReferencingThresholdReached(stepSize, from, to uint64) bool {
 	return (to-from)/stepSize >= minStepsForReferencing
 }
 
+// CommitmentFileMayContainRef reports whether a commitment .kv file at this version
+// may contain shortened referenced keys. v2.0 (and earlier) produced refs above the
+// step threshold when AggregatorSqueezeCommitmentValues was on; v2.1+ are noref-only.
+func CommitmentFileMayContainRef(dataVer version.Version) bool {
+	return dataVer.Less(version.V2_1)
+}
+
 // replaceShortenedKeysInBranch expands shortened key references (file offsets) in branch data back to full keys
 // by looking them up in the account and storage domain files.
 func (at *AggregatorRoTx) replaceShortenedKeysInBranch(prefix []byte, branch commitment.BranchData, fStartTxNum uint64, fEndTxNum uint64) (commitment.BranchData, error) {
 	logger := log.Root()
 	aggTx := at
 
-	commitmentUseReferencedBranches := at.a.Cfg(kv.CommitmentDomain).ReplaceKeysInValues
-	if !commitmentUseReferencedBranches || len(branch) == 0 || bytes.Equal(prefix, commitmentdb.KeyCommitmentState) ||
+	// Independent of the writer-side ReplaceKeysInValues flag: a noref-configured node may
+	// still read a referenced-key file produced by an older datadir, so the read path can't
+	// skip on config alone. Below-threshold ranges never contained refs in any version.
+	if len(branch) == 0 || bytes.Equal(prefix, commitmentdb.KeyCommitmentState) ||
 		aggTx.TxNumsInFiles(kv.StateDomains...) == 0 || !ValuesPlainKeyReferencingThresholdReached(at.StepSize(), fStartTxNum, fEndTxNum) {
 
 		return branch, nil // do not transform, return as is
 	}
 
+	com := aggTx.d[kv.CommitmentDomain]
+	comItem, err := com.lookupVisibleFileByRange(fStartTxNum, fEndTxNum)
+	if err != nil {
+		logger.Crit("dereference key during commitment read", "failed", err.Error())
+		return nil, err
+	}
+	// Fast path: v2.1+ commitment files are guaranteed noref — skip the per-key walk entirely.
+	if !CommitmentFileMayContainRef(comItem.dataVer) {
+		return branch, nil
+	}
+
 	sto := aggTx.d[kv.StorageDomain]
 	acc := aggTx.d[kv.AccountsDomain]
-	storageItem, err := sto.lookupVisibleFileByRange(fStartTxNum, fEndTxNum)
-	if err != nil {
-		logger.Crit("dereference key during commitment read", "failed", err.Error())
-		return nil, err
-	}
-	accountItem, err := acc.lookupVisibleFileByRange(fStartTxNum, fEndTxNum)
-	if err != nil {
-		logger.Crit("dereference key during commitment read", "failed", err.Error())
-		return nil, err
-	}
-	storageGetter := sto.dataReader(storageItem.decompressor)
-	accountGetter := acc.dataReader(accountItem.decompressor)
 	metricI := 0
-	for i, f := range aggTx.d[kv.CommitmentDomain].files {
+	for i, f := range com.files {
 		if i > 5 {
 			metricI = 5
 			break
@@ -81,6 +90,10 @@ func (at *AggregatorRoTx) replaceShortenedKeysInBranch(prefix []byte, branch com
 		}
 	}
 
+	// Getters resolve on first referenced-key hit, per domain. Branches with only full keys
+	// (the common case once ReplaceKeysInValues is off) skip file resolution entirely.
+	var storageGetter, accountGetter *seg.Reader
+
 	result, err := branch.ReplacePlainKeys(nil, func(key []byte, isStorage bool) ([]byte, error) {
 		if isStorage {
 			if len(key) == length.Addr+length.Hash {
@@ -88,6 +101,14 @@ func (at *AggregatorRoTx) replaceShortenedKeysInBranch(prefix []byte, branch com
 			}
 			if dbg.KVReadLevelledMetrics {
 				defer branchKeyDerefSpent[metricI].ObserveDuration(time.Now())
+			}
+			if storageGetter == nil {
+				item, err := sto.lookupVisibleFileByRange(fStartTxNum, fEndTxNum)
+				if err != nil {
+					logger.Crit("dereference key during commitment read", "failed", err.Error())
+					return nil, err
+				}
+				storageGetter = sto.dataReader(item.decompressor)
 			}
 			// Optimised key referencing a state file record (file number and offset within the file)
 			storagePlainKey, found := sto.lookupByShortenedKey(key, storageGetter)
@@ -106,6 +127,14 @@ func (at *AggregatorRoTx) replaceShortenedKeysInBranch(prefix []byte, branch com
 
 		if dbg.KVReadLevelledMetrics {
 			defer branchKeyDerefSpent[metricI].ObserveDuration(time.Now())
+		}
+		if accountGetter == nil {
+			item, err := acc.lookupVisibleFileByRange(fStartTxNum, fEndTxNum)
+			if err != nil {
+				logger.Crit("dereference key during commitment read", "failed", err.Error())
+				return nil, err
+			}
+			accountGetter = acc.dataReader(item.decompressor)
 		}
 		apkBuf, found := acc.lookupByShortenedKey(key, accountGetter)
 		if !found {
@@ -243,149 +272,182 @@ func (dt *DomainRoTx) lookupByShortenedKey(shortKey []byte, getter *seg.Reader) 
 	return dt.lookupFullKey, true
 }
 
-// commitmentValTransform parses the value of the commitment record to extract references
-// to accounts and storage items, then looks them up in the new, merged files, and replaces them with
-// the updated references
-func (dt *DomainRoTx) commitmentValTransformDomain(rng MergeRange, accounts, storage *DomainRoTx, mergedAccount, mergedStorage *FilesItem) (valueTransformer, error) {
+// commitmentValTransformDomain returns a per-value transform for rewriting commitment values.
+//
+// produceRefs=false (merge path): deref any source-side refs back to full keys; pass full-source
+// values through unchanged. Output is always noref. Used when merging into a v2.1 destination.
+// mergedAccount/mergedStorage are unused in this mode.
+//
+// produceRefs=true (squeeze path): deref any source-side refs, then re-encode each key as a ref
+// against the merged account/storage file (or pass through as full if the merged file has no
+// matching record). Output is the legacy referenced encoding. Used by SqueezeCommitmentFiles.
+//
+// Per-source-range fast path: if source commitment file is v2.1+ (noref) and produceRefs=false,
+// the value passes through without walking keys.
+func (dt *DomainRoTx) commitmentValTransformDomain(rng MergeRange, accounts, storage *DomainRoTx, mergedAccount, mergedStorage *FilesItem, produceRefs bool) (valueTransformer, error) {
 	if !rng.needMerge {
 		panic(fmt.Sprintf("assert: commitmentValTransformDomain called with domain.needMerge=false (from=%d to=%d): caller must guard with values.needMerge", rng.from, rng.to))
 	}
-	var keyBuf [60]byte // 52b key and 8b for inverted step
-	var err error
-	shortened := make([]byte, 16)
 
-	hadToLookupStorage := mergedStorage == nil
-	if mergedStorage == nil {
-		if mergedStorage, err = storage.lookupVisibleFileByRange(rng.from, rng.to); err != nil {
-			// TODO may allow to merge, but storage keys will be stored as plainkeys
-			return nil, err
-		}
-	}
-
-	hadToLookupAccount := mergedAccount == nil
-	if mergedAccount == nil {
-		if mergedAccount, err = accounts.lookupVisibleFileByRange(rng.from, rng.to); err != nil {
-			return nil, err
-		}
-	}
-
-	dr := DomainRanges{values: rng}
-	accountFileMap := make(map[uint64]map[uint64]*seg.Reader)
-	if accountList, _, _ := accounts.staticFilesInRange(dr); accountList != nil {
-		for _, f := range accountList {
-			if _, ok := accountFileMap[f.startTxNum]; !ok {
-				accountFileMap[f.startTxNum] = make(map[uint64]*seg.Reader)
+	var ms, ma *seg.Reader
+	if produceRefs {
+		var err error
+		if mergedStorage == nil {
+			if mergedStorage, err = storage.lookupVisibleFileByRange(rng.from, rng.to); err != nil {
+				return nil, err
 			}
-			accountFileMap[f.startTxNum][f.endTxNum] = accounts.dataReader(f.decompressor)
 		}
-	}
-	storageFileMap := make(map[uint64]map[uint64]*seg.Reader)
-	if storageList, _, _ := storage.staticFilesInRange(dr); storageList != nil {
-		for _, f := range storageList {
-			if _, ok := storageFileMap[f.startTxNum]; !ok {
-				storageFileMap[f.startTxNum] = make(map[uint64]*seg.Reader)
+		if mergedAccount == nil {
+			if mergedAccount, err = accounts.lookupVisibleFileByRange(rng.from, rng.to); err != nil {
+				return nil, err
 			}
-			storageFileMap[f.startTxNum][f.endTxNum] = storage.dataReader(f.decompressor)
 		}
+		ms = storage.dataReader(mergedStorage.decompressor)
+		ma = accounts.dataReader(mergedAccount.decompressor)
 	}
 
-	ms := storage.dataReader(mergedStorage.decompressor)
-	ma := accounts.dataReader(mergedAccount.decompressor)
-	dt.d.logger.Debug("prepare commitmentValTransformDomain", "merge", rng.String("range", dt.d.stepSize), "Mstorage", hadToLookupStorage, "Maccount", hadToLookupAccount)
+	// Cache per source range (keyFromTxNum,keyEndTxNum): the source commitment file's data
+	// version (so noref sources skip the per-key walk in the merge path), plus account/storage
+	// getters resolved on first referenced-key hit.
+	type srcCache struct {
+		srcVerKnown   bool
+		mayContainRef bool
+		accountGetter *seg.Reader
+		storageGetter *seg.Reader
+	}
+	perRange := make(map[uint64]map[uint64]*srcCache)
+	getCache := func(from, to uint64) *srcCache {
+		inner, ok := perRange[from]
+		if !ok {
+			inner = make(map[uint64]*srcCache)
+			perRange[from] = inner
+		}
+		c, ok := inner[to]
+		if !ok {
+			c = &srcCache{}
+			inner[to] = c
+		}
+		return c
+	}
 
 	vt := func(valBuf []byte, keyFromTxNum, keyEndTxNum uint64) (transValBuf []byte, err error) {
-		if !dt.d.ReplaceKeysInValues || len(valBuf) == 0 || !ValuesPlainKeyReferencingThresholdReached(dt.d.stepSize, rng.from, rng.to) {
+		if len(valBuf) == 0 {
 			return valBuf, nil
 		}
-		if _, ok := storageFileMap[keyFromTxNum]; !ok {
-			storageFileMap[keyFromTxNum] = make(map[uint64]*seg.Reader)
+		// Below-threshold source ranges never produced refs in any version, and refs are not
+		// produced below threshold either — nothing to do regardless of produceRefs.
+		if !ValuesPlainKeyReferencingThresholdReached(dt.d.stepSize, keyFromTxNum, keyEndTxNum) {
+			return valBuf, nil
 		}
-		sig, ok := storageFileMap[keyFromTxNum][keyEndTxNum]
-		if !ok {
-			f, err := storage.lookupVisibleFileByRange(keyFromTxNum, keyEndTxNum)
+		c := getCache(keyFromTxNum, keyEndTxNum)
+		if !c.srcVerKnown {
+			srcCom, err := dt.lookupVisibleFileByRange(keyFromTxNum, keyEndTxNum)
 			if err != nil {
-				return nil, fmt.Errorf("storage file not found in visible files: %w", err)
+				return nil, fmt.Errorf("commitment src file not found: %w", err)
 			}
-			sig = storage.dataReader(f.decompressor)
-			storageFileMap[keyFromTxNum][keyEndTxNum] = sig
+			c.mayContainRef = CommitmentFileMayContainRef(srcCom.dataVer)
+			c.srcVerKnown = true
+		}
+		// Pass-through only when source has no refs AND we're not emitting refs.
+		if !c.mayContainRef && !produceRefs {
+			return valBuf, nil
 		}
 
-		if _, ok := accountFileMap[keyFromTxNum]; !ok {
-			accountFileMap[keyFromTxNum] = make(map[uint64]*seg.Reader)
-		}
-		aig, ok := accountFileMap[keyFromTxNum][keyEndTxNum]
-		if !ok {
-			f, err := accounts.lookupVisibleFileByRange(keyFromTxNum, keyEndTxNum)
-			if err != nil {
-				return nil, fmt.Errorf("account file not found in visible files: %w", err)
+		// derefStorage / derefAccount return the full key, dereffing source refs if needed.
+		derefStorage := func(key []byte) ([]byte, error) {
+			if len(key) == length.Addr+length.Hash {
+				return key, nil
 			}
-			aig = accounts.dataReader(f.decompressor)
-			accountFileMap[keyFromTxNum][keyEndTxNum] = aig
+			if c.storageGetter == nil {
+				f, err := storage.lookupVisibleFileByRange(keyFromTxNum, keyEndTxNum)
+				if err != nil {
+					return nil, fmt.Errorf("storage src file not found: %w", err)
+				}
+				c.storageGetter = storage.dataReader(f.decompressor)
+			}
+			fullKey, found := storage.lookupByShortenedKey(key, c.storageGetter)
+			if !found {
+				dt.d.logger.Crit("valTransform: lost storage full key",
+					"shortened", hex.EncodeToString(key),
+					"src", fmt.Sprintf("%d-%d", keyFromTxNum/dt.d.stepSize, keyEndTxNum/dt.d.stepSize),
+					"merging", rng.String("", dt.d.stepSize),
+					"valBuf", fmt.Sprintf("l=%d %x", len(valBuf), valBuf),
+				)
+				return nil, fmt.Errorf("lookup lost storage full key %x", key)
+			}
+			return fullKey, nil
+		}
+		derefAccount := func(key []byte) ([]byte, error) {
+			if len(key) == length.Addr {
+				return key, nil
+			}
+			if c.accountGetter == nil {
+				f, err := accounts.lookupVisibleFileByRange(keyFromTxNum, keyEndTxNum)
+				if err != nil {
+					return nil, fmt.Errorf("account src file not found: %w", err)
+				}
+				c.accountGetter = accounts.dataReader(f.decompressor)
+			}
+			fullKey, found := accounts.lookupByShortenedKey(key, c.accountGetter)
+			if !found {
+				dt.d.logger.Crit("valTransform: lost account full key",
+					"shortened", hex.EncodeToString(key),
+					"src", fmt.Sprintf("%d-%d", keyFromTxNum/dt.d.stepSize, keyEndTxNum/dt.d.stepSize),
+					"merging", rng.String("", dt.d.stepSize),
+					"valBuf", fmt.Sprintf("l=%d %x", len(valBuf), valBuf),
+				)
+				return nil, fmt.Errorf("lookup account full key: %x", key)
+			}
+			return fullKey, nil
 		}
 
 		replacer := func(key []byte, isStorage bool) ([]byte, error) {
-			var found bool
-			auxBuf := keyBuf[:0]
 			if isStorage {
-				if len(key) == length.Addr+length.Hash {
-					// Non-optimised key originating from a database record
-					auxBuf = append(auxBuf[:0], key...)
-				} else {
-					// Optimised key referencing a state file record (file number and offset within the file)
-					auxBuf, found = storage.lookupByShortenedKey(key, sig)
-					if !found {
-						dt.d.logger.Crit("valTransform: lost storage full key",
-							"shortened", hex.EncodeToString(key),
-							"merging", rng.String("", dt.d.stepSize),
-							"valBuf", fmt.Sprintf("l=%d %x", len(valBuf), valBuf),
-						)
-						return nil, fmt.Errorf("lookup lost storage full key %x", key)
-					}
+				fullKey, err := derefStorage(key)
+				if err != nil {
+					return nil, err
 				}
-
-				shortenedKeyOffset, found := storage.findShortenedKey(auxBuf, ms, mergedStorage)
-				if !found {
-					if len(auxBuf) == length.Addr+length.Hash {
-						return auxBuf, nil // if plain key is lost, we can save original fullkey
+				if !produceRefs {
+					if len(key) == length.Addr+length.Hash {
+						return nil, nil // unchanged full key
 					}
-					// if shortened key lost, we can't continue
+					return fullKey, nil
+				}
+				// produceRefs: re-encode against merged storage file.
+				off, found := storage.findShortenedKey(fullKey, ms, mergedStorage)
+				if !found {
+					if len(fullKey) == length.Addr+length.Hash {
+						return fullKey, nil // lost shortening — save full key
+					}
 					dt.d.logger.Crit("valTransform: replacement for full storage key was not found",
 						"step", fmt.Sprintf("%d-%d", keyFromTxNum/dt.d.stepSize, keyEndTxNum/dt.d.stepSize),
-						"shortened", hex.EncodeToString(shortened), "toReplace", hex.EncodeToString(auxBuf))
-
-					return nil, fmt.Errorf("replacement not found for storage %x", auxBuf)
+						"toReplace", hex.EncodeToString(fullKey))
+					return nil, fmt.Errorf("replacement not found for storage %x", fullKey)
 				}
-				shortened = EncodeReferenceKey(shortened[:0], shortenedKeyOffset)
-				return shortened, nil
+				return EncodeReferenceKey(nil, off), nil
 			}
 
-			if len(key) == length.Addr {
-				// Non-optimised key originating from a database record
-				auxBuf = append(auxBuf[:0], key...)
-			} else {
-				auxBuf, found = accounts.lookupByShortenedKey(key, aig)
-				if !found {
-					dt.d.logger.Crit("valTransform: lost account full key",
-						"shortened", hex.EncodeToString(key),
-						"merging", rng.String("", dt.d.stepSize),
-						"valBuf", fmt.Sprintf("l=%d %x", len(valBuf), valBuf),
-					)
-					return nil, fmt.Errorf("lookup account full key: %x", key)
-				}
+			fullKey, err := derefAccount(key)
+			if err != nil {
+				return nil, err
 			}
-
-			shortenedKeyOffset, found := accounts.findShortenedKey(auxBuf, ma, mergedAccount)
+			if !produceRefs {
+				if len(key) == length.Addr {
+					return nil, nil
+				}
+				return fullKey, nil
+			}
+			off, found := accounts.findShortenedKey(fullKey, ma, mergedAccount)
 			if !found {
-				if len(auxBuf) == length.Addr {
-					return auxBuf, nil // if plain key is lost, we can save original fullkey
+				if len(fullKey) == length.Addr {
+					return fullKey, nil
 				}
 				dt.d.logger.Crit("valTransform: replacement for full account key was not found",
 					"step", fmt.Sprintf("%d-%d", keyFromTxNum/dt.d.stepSize, keyEndTxNum/dt.d.stepSize),
-					"shortened", hex.EncodeToString(shortened), "toReplace", hex.EncodeToString(auxBuf))
-				return nil, fmt.Errorf("replacement not found for account  %x", auxBuf)
+					"toReplace", hex.EncodeToString(fullKey))
+				return nil, fmt.Errorf("replacement not found for account %x", fullKey)
 			}
-			shortened = EncodeReferenceKey(shortened[:0], shortenedKeyOffset)
-			return shortened, nil
+			return EncodeReferenceKey(nil, off), nil
 		}
 
 		branchData, err := commitment.BranchData(valBuf).ReplacePlainKeys(nil, replacer)

--- a/db/state/merge.go
+++ b/db/state/merge.go
@@ -569,6 +569,7 @@ func (dt *DomainRoTx) mergeFiles(ctx context.Context, domainFiles, indexFiles, h
 	if valuesIn.decompressor, err = seg.NewDecompressor(kvFilePath); err != nil {
 		return nil, nil, nil, fmt.Errorf("merge %s decompressor [%d-%d]: %w", dt.d.FilenameBase, r.values.from, r.values.to, err)
 	}
+	valuesIn.dataVer = dt.d.FileVersion.DataKV.Current
 
 	if dt.d.Accessors.Has(statecfg.AccessorBTree) {
 		btPath := dt.d.kvBtAccessorNewFilePath(fromStep, toStep)

--- a/db/state/merge_test.go
+++ b/db/state/merge_test.go
@@ -779,7 +779,7 @@ func TestCommitmentValTransformDomainPanicsWithNeedMergeFalse(t *testing.T) {
 	defer dc.Close()
 
 	require.Panics(t, func() {
-		dc.commitmentValTransformDomain(MergeRange{needMerge: false}, dc, dc, nil, nil)
+		dc.commitmentValTransformDomain(MergeRange{needMerge: false}, dc, dc, nil, nil, false)
 	})
 }
 

--- a/db/state/ref_compat_test.go
+++ b/db/state/ref_compat_test.go
@@ -1,0 +1,207 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/dir"
+	"github.com/erigontech/erigon/common/length"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/state"
+	"github.com/erigontech/erigon/db/state/execctx"
+	"github.com/erigontech/erigon/db/state/statecfg"
+	"github.com/erigontech/erigon/db/version"
+	"github.com/erigontech/erigon/execution/commitment"
+	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
+)
+
+// TestUpgrade_RefV20Sources_ReadsCorrectly_in_V21World simulates the 3.4 → 3.6 upgrade scenario:
+// the on-disk datadir contains v2.0 commitment .kv files whose merged ranges carry referenced
+// (shortened) keys, but the running code has AggregatorSqueezeCommitmentValues=false and the
+// schema's current commitment kv version is v2.1. The read path must still deref source refs —
+// it can no longer gate on the writer-side config flag, because that flag is off but the source
+// files still contain refs.
+func TestUpgrade_RefV20Sources_ReadsCorrectly_in_V21World(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	// Phase 1: 3.4-era setup — force schema commitment kv to v2.0 so freshly written files
+	// land at v2.0.
+	prevVer := statecfg.Schema.CommitmentDomain.FileVersion.DataKV
+	statecfg.Schema.CommitmentDomain.FileVersion.DataKV = version.Versions{
+		Current:      version.V2_0,
+		MinSupported: version.V1_0,
+	}
+	t.Cleanup(func() {
+		statecfg.Schema.CommitmentDomain.FileVersion.DataKV = prevVer
+	})
+
+	cfg := &testAggConfig{stepSize: 10, disableCommitmentBranchTransform: false}
+	db, agg := testDbAggregatorWithFiles(t, cfg)
+	dirs := agg.Dirs()
+
+	// Squeeze the merged commitment files so they actually carry refs (the build pipeline's
+	// own merge path produces full-key output regardless of config; squeeze is now the only
+	// producer of referenced keys, mirroring how older datadirs reached this state).
+	// Squeeze removes the old .kvi/.bt accessors when it rewrites the .kv file, so we have
+	// to reopen the folder and rebuild the missed accessors before any read path is exercised.
+	{
+		rwTx, err := db.BeginTemporalRw(t.Context())
+		require.NoError(t, err)
+		defer rwTx.Rollback()
+		agg.ForTestReplaceKeysInValues(kv.CommitmentDomain, true)
+		require.NoError(t, state.SqueezeCommitmentFiles(t.Context(), state.AggTx(rwTx), log.New()))
+		require.NoError(t, rwTx.Commit())
+		require.NoError(t, agg.OpenFolder())
+		require.NoError(t, agg.BuildMissedAccessors(t.Context(), 4))
+		require.NoError(t, agg.OpenFolder())
+	}
+
+	// Confirm at least one v2.0 commitment kv file is now on disk — sanity check that the
+	// schema override took effect.
+	files, err := dir.ListFiles(dirs.SnapDomain, ".kv")
+	require.NoError(t, err)
+	var v20Files []string
+	for _, f := range files {
+		if strings.Contains(f, "commitment") && strings.Contains(f, "v2.0-") {
+			v20Files = append(v20Files, f)
+		}
+	}
+	require.NotEmpty(t, v20Files, "expected v2.0 commitment kv files on disk after squeeze")
+
+	// Capture the pre-upgrade root from the v2.0 ref files.
+	preRoot := readStateRoot(t, db)
+	require.NotEmpty(t, preRoot)
+
+	// Phase 2: switch to the 3.6 world — schema's current kv version is v2.1 and the
+	// ReplaceKeysInValues flag is off. Existing files keep their v2.0 dataVer (parsed from
+	// the filename at open time), but new merges would emit v2.1 noref.
+	statecfg.Schema.CommitmentDomain.FileVersion.DataKV = version.Versions{
+		Current:      version.V2_1,
+		MinSupported: version.V1_0,
+	}
+	agg.ForTestReplaceKeysInValues(kv.CommitmentDomain, false)
+	require.NoError(t, agg.OpenFolder())
+
+	// Read the root through replaceShortenedKeysInBranch with the writer flag off. The
+	// function must still walk the branch and dereference the source refs against the
+	// per-range account/storage files — otherwise the recovered state would be garbage.
+	postRoot := readStateRoot(t, db)
+	require.Equal(t, preRoot, postRoot,
+		"read of v2.0 ref source in v2.1 world must dereference refs and recover the same root")
+}
+
+// TestUpgrade_NewMergesProduceNorefV21 verifies that with the schema at v2.1 and refs off,
+// any newly-built commitment .kv files (including those produced by merges that consume v2.0
+// ref source files) land as v2.1 with full-key payload.
+func TestUpgrade_NewMergesProduceNorefV21(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	cfg := &testAggConfig{stepSize: 10, disableCommitmentBranchTransform: true}
+	db, agg := testDbAggregatorWithFiles(t, cfg)
+	dirs := agg.Dirs()
+	_ = db
+
+	// Sanity: schema current version is v2.1 (the branch state we're stacking on top of).
+	require.Equal(t, version.V2_1, statecfg.Schema.CommitmentDomain.FileVersion.DataKV.Current,
+		"this test assumes the v2.1 schema bump is in effect")
+
+	// Any commitment kv file produced by this default build must be tagged v2.1 and carry no
+	// referenced keys (the writer-side config disables ref production for non-squeeze flows).
+	files, err := dir.ListFiles(dirs.SnapDomain, ".kv")
+	require.NoError(t, err)
+	var commitmentFiles []string
+	for _, f := range files {
+		if strings.Contains(f, "commitment") {
+			commitmentFiles = append(commitmentFiles, f)
+		}
+	}
+	require.NotEmpty(t, commitmentFiles, "expected at least one commitment kv file")
+
+	for _, f := range commitmentFiles {
+		require.Contains(t, f, "v2.1-",
+			"new merges/builds must tag commitment kv files as v2.1, got %s", f)
+		assertCommitmentFileIsNoref(t, f)
+	}
+}
+
+func readStateRoot(t *testing.T, db kv.TemporalRwDB) []byte {
+	t.Helper()
+	rwTx, err := db.BeginTemporalRw(t.Context())
+	require.NoError(t, err)
+	defer rwTx.Rollback()
+	domains, err := execctx.NewSharedDomains(t.Context(), rwTx, log.New())
+	require.NoError(t, err)
+	defer domains.Close()
+	// false → don't save; recomputes root by reading account values + commitment branches.
+	// The branch read path goes through replaceShortenedKeysInBranch — that's what we're
+	// validating handles both ref (v2.0) and noref (v2.1) sources.
+	root, err := domains.ComputeCommitment(t.Context(), rwTx, false, 0, 0, "", nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, root)
+	return root
+}
+
+// assertCommitmentFileIsNoref opens a commitment .kv file and walks every branch value,
+// asserting that all account / storage keys are at full length (20B / 52B). Any shorter key
+// would be a shortened ref encoding — illegal in a noref file.
+func assertCommitmentFileIsNoref(t *testing.T, path string) {
+	t.Helper()
+	d, err := seg.NewDecompressor(path)
+	require.NoError(t, err)
+	defer d.Close()
+
+	g := seg.NewReader(d.MakeGetter(), seg.CompressNone)
+	g.Reset(0)
+	var k, v []byte
+	for g.HasNext() {
+		k, _ = g.Next(k[:0])
+		if !g.HasNext() {
+			break
+		}
+		v, _ = g.Next(v[:0])
+		if len(v) == 0 {
+			continue
+		}
+		// The state key carries hex-trie state metadata, not a BranchData encoding — skip.
+		if bytes.Equal(k, commitmentdb.KeyCommitmentState) {
+			continue
+		}
+		_, err := commitment.BranchData(v).ReplacePlainKeys(nil, func(key []byte, isStorage bool) ([]byte, error) {
+			if isStorage {
+				require.Equal(t, length.Addr+length.Hash, len(key),
+					"noref file %s: storage key length %d (expected %d, shorter implies ref encoding)",
+					path, len(key), length.Addr+length.Hash)
+			} else {
+				require.Equal(t, length.Addr, len(key),
+					"noref file %s: account key length %d (expected %d, shorter implies ref encoding)",
+					path, len(key), length.Addr)
+			}
+			return nil, nil
+		})
+		require.NoError(t, err)
+	}
+}

--- a/db/state/squeeze.go
+++ b/db/state/squeeze.go
@@ -238,7 +238,7 @@ func SqueezeCommitmentFiles(ctx context.Context, at *AggregatorRoTx, logger log.
 			reader.Reset(0)
 
 			rng := MergeRange{needMerge: true, from: af.startTxNum, to: af.endTxNum}
-			vt, err := commitment.commitmentValTransformDomain(rng, accounts, storage, af, sf)
+			vt, err := commitment.commitmentValTransformDomain(rng, accounts, storage, af, sf, true)
 			if err != nil {
 				return fmt.Errorf("failed to create commitment value transformer: %w", err)
 			}

--- a/db/state/statecfg/state_schema.go
+++ b/db/state/statecfg/state_schema.go
@@ -76,7 +76,7 @@ func Configure(Schema SchemaGen, a AggSetters, dirs datadir.Dirs, salt *uint32, 
 // AggregatorSqueezeCommitmentValues controls whether commitment aggregator should replace keys in values during merge once file range reaches threshold.
 // This can significantly reduce size of commitment values, but makes them non-human readable and requires additional processing during reads.
 // This is not needed for correctness, but can be used to save space if needed.
-const AggregatorSqueezeCommitmentValues = true
+const AggregatorSqueezeCommitmentValues = false
 
 const MaxNonFuriousDirtySpacePerTx = 64 * datasize.MB
 

--- a/db/state/statecfg/version_schema_gen.go
+++ b/db/state/statecfg/version_schema_gen.go
@@ -21,7 +21,7 @@ func InitSchemasGen() {
 	Schema.CodeDomain.Hist.FileVersion.AccessorVI = version.Versions{version.Version{1, 1}, version.Version{1, 0}}
 	Schema.CodeDomain.Hist.IiCfg.FileVersion.DataEF = version.Versions{version.Version{3, 0}, version.Version{1, 0}}
 	Schema.CodeDomain.Hist.IiCfg.FileVersion.AccessorEFI = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
-	Schema.CommitmentDomain.FileVersion.DataKV = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
+	Schema.CommitmentDomain.FileVersion.DataKV = version.Versions{version.Version{2, 1}, version.Version{1, 0}}
 	Schema.CommitmentDomain.FileVersion.AccessorKVI = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
 	Schema.CommitmentDomain.Hist.FileVersion.DataV = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
 	Schema.CommitmentDomain.Hist.FileVersion.AccessorVI = version.Versions{version.Version{1, 1}, version.Version{1, 0}}

--- a/db/state/statecfg/versions.yaml
+++ b/db/state/statecfg/versions.yaml
@@ -59,7 +59,7 @@ code:
 commitment:
     domain:
         kv:
-            current: v2.0
+            current: v2.1
             min: v1.0
         kvi:
             current: v2.0


### PR DESCRIPTION
## Summary

Stacks on top of #21375 (`performance-36`, which bumps commitment kv to v2.1 + flips `AggregatorSqueezeCommitmentValues=false`). This PR keeps the read and merge paths working over a mixed datadir: a 3.4-era datadir whose merged commitment `.kv` files at ranges ≥2 steps still carry **shortened referenced keys** (offsets into the same-range account/storage `.kv`) opened by code that produces noref output going forward.

Without this PR:
- Read: `replaceShortenedKeysInBranch` early-returns on `ReplaceKeysInValues=false`, so any v2.0 branch with refs would be served back to the trie as raw bytes — corruption.
- Merge: `commitmentValTransformDomain` is a pass-through with the flag off, so source refs are propagated verbatim into the merged file, with offsets pointing at obsolete account/storage files.

## How we tell ref from noref

Single source of truth: the `.kv` file version parsed from the filename at open.

- `v2.0` (and earlier) commitment kv files **may** contain refs at ranges ≥ `minStepsForReferencing`.
- `v2.1+` commitment kv files are noref-only by construction.

New helper: `CommitmentFileMayContainRef(dataVer) bool` (true iff `< V2_1`).
New field: `FilesItem.dataVer`, populated on open from `version.MatchVersionedFile` and on collation/merge output from `FileVersion.DataKV.Current`.

## Read path — `replaceShortenedKeysInBranch`

- Drops the `commitmentUseReferencedBranches` gate. The writer flag can't be trusted; the file on disk is authoritative.
- Keeps `ValuesPlainKeyReferencingThresholdReached` (below threshold, no version ever produced refs).
- After the other early-exits, looks up the source commitment FilesItem once and returns the branch as-is when `!CommitmentFileMayContainRef(dataVer)` — fast path for v2.1 sources, avoiding the per-key `ReplacePlainKeys` walk.
- Per-key storage/account getters resolved **lazily** on first ref hit (branches with only full keys never resolve the source-range files at all).

## Merge path — `commitmentValTransformDomain` + caller

- New `produceRefs bool` param.
  - `false` (merge): deref source refs → full keys; pass through v2.1 sources via the dataVer fast path. Merged output is always noref.
  - `true` (squeeze): preserves the legacy deref-then-re-ref behavior so the squeeze pipeline keeps working.
- Source-range account/storage getters lazily resolved per (from,to) on first ref hit, cached for reuse.
- Merge call site in `aggregator.mergeFiles` drops the `commitmentUseReferencedBranches` gate so the transformer always installs for commitment merges. Without this, on the current `AggregatorSqueezeCommitmentValues=false` config, the merger would copy v2.0 source refs verbatim.

## Tests (new file `db/state/ref_compat_test.go`)

- `TestUpgrade_RefV20Sources_ReadsCorrectly_in_V21World` — forces schema to v2.0, builds + squeezes to produce real v2.0 ref commitment files, switches schema to v2.1 + `ReplaceKeysInValues=false`, verifies `ComputeCommitment` recovers the same root through the deref'd read path.
- `TestUpgrade_NewMergesProduceNorefV21` — under default v2.1 schema, every newly-built commitment kv on disk is `v2.1-` tagged and every branch value's keys are full-length (20B account / 52B storage).

Existing tests touched / still pass: `TestAggregator_SqueezeCommitment`, `TestAggregator_RebuildCommitmentBasedOnFiles`, `TestCommitmentValTransformDomainPanicsWithNeedMergeFalse`, `TestMergeFiles`, `TestMergeFilesWithDependency`.

## Open items

- Cross-version merge (a single merge pass consuming both a v2.0 ref source and a v2.1 noref source) isn't directly exercised yet — the per-key length dispatch + per-source dataVer cache handles it, but adding a focused test that extends data past the initial build range is a follow-up.
- `SnapshotRepo.DeleteFilesAfterMerge` still uses the eager `refcount==0 → closeFilesAndRemove` branch; unrelated, but worth aligning later for consistency with the rest of the merge cleanup model.

## Test plan
- [x] `go build ./...`
- [x] `go test -short ./db/state/... ./execution/commitment/...`
- [x] Long tests: `go test -run 'TestAggregator_SqueezeCommitment|TestAggregator_RebuildCommitmentBasedOnFiles|TestCommitmentValTransform|TestMergeFiles|TestUpgrade_' -timeout 10m ./db/state/`
- [x] `make lint` (clean for files in this PR)
- [ ] Real datadir validation: open a 3.4-era datadir with this build, confirm state-root checks pass and that the next merge cycle produces v2.1 noref output.