### PR TITLE
execution: optimise selfbalance worst-case benchmark

### DIFF
--- a/execution/vm/contract.go
+++ b/execution/vm/contract.go
@@ -53,6 +53,13 @@ type Contract struct {
 	CodeHash accounts.CodeHash
 
 	value uint256.Int
+
+	// selfBalance memoizes the result of SELFBALANCE for the lifetime of this
+	// frame. Invalidated by ops that can change the account's balance via a
+	// nested execution context (CALL, CALLCODE, DELEGATECALL, CREATE, CREATE2).
+	// STATICCALL is exempt: the entire subtree is read-only.
+	selfBalance       uint256.Int
+	selfBalanceCached bool
 }
 
 // around 64MB cache in the worst case.

--- a/execution/vm/contract.go
+++ b/execution/vm/contract.go
@@ -54,10 +54,11 @@ type Contract struct {
 
 	value uint256.Int
 
-	// selfBalance memoizes the result of SELFBALANCE for the lifetime of this
-	// frame. Invalidated by ops that can change the account's balance via a
-	// nested execution context (CALL, CALLCODE, DELEGATECALL, CREATE, CREATE2).
-	// STATICCALL is exempt: the entire subtree is read-only.
+	// selfBalance memoizes SELFBALANCE for the lifetime of this frame.
+	// Invalidated after opcodes that return control to this frame and may have
+	// changed the account's balance via a nested execution (CALL, CALLCODE,
+	// DELEGATECALL, CREATE, CREATE2). STATICCALL is exempt (whole subtree is
+	// read-only). SELFDESTRUCT is exempt because the frame halts.
 	selfBalance       uint256.Int
 	selfBalanceCached bool
 }

--- a/execution/vm/eips.go
+++ b/execution/vm/eips.go
@@ -95,11 +95,15 @@ func enable1884(jt *JumpTable) {
 }
 
 func opSelfBalance(pc uint64, evm *EVM, callContext *CallContext) (uint64, []byte, error) {
-	balance, err := evm.IntraBlockState().GetBalance(callContext.Contract.Address())
-	if err != nil {
-		return pc, nil, err
+	if !callContext.Contract.selfBalanceCached {
+		balance, err := evm.IntraBlockState().GetBalance(callContext.Contract.addr)
+		if err != nil {
+			return pc, nil, err
+		}
+		callContext.Contract.selfBalance = balance
+		callContext.Contract.selfBalanceCached = true
 	}
-	callContext.Stack.push(balance)
+	callContext.Stack.push(callContext.Contract.selfBalance)
 	return pc, nil, nil
 }
 

--- a/execution/vm/instructions.go
+++ b/execution/vm/instructions.go
@@ -1045,6 +1045,7 @@ func execCreate(pc uint64, evm *EVM, scope *CallContext, value uint256.Int, inpu
 	scope.stateGas = 0 // pass reservoir to child via callGas; restoreChildGas returns it
 
 	res, addr, returnGas, childUsed, suberr := evm.Create(scope.Contract.Address(), input, gas, value, salt, false)
+	scope.Contract.selfBalanceCached = false
 
 	// Push item on the stack based on the returned error. If the ruleset is
 	// homestead we must check for CodeStoreOutOfGasError (homestead only
@@ -1145,6 +1146,7 @@ func opCall(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) {
 	if evm.chainRules.IsAmsterdam && err == nil {
 		scope.frameStateUsed += childUsed.State
 	}
+	scope.Contract.selfBalanceCached = false
 	evm.returnData = ret
 	return pc, ret, nil
 }
@@ -1193,6 +1195,7 @@ func opCallCode(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error)
 	if evm.chainRules.IsAmsterdam && err == nil {
 		scope.frameStateUsed += childUsed.State
 	}
+	scope.Contract.selfBalanceCached = false
 	evm.returnData = ret
 	return pc, ret, nil
 }
@@ -1237,6 +1240,7 @@ func opDelegateCall(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, er
 	if evm.chainRules.IsAmsterdam && err == nil {
 		scope.frameStateUsed += childUsed.State
 	}
+	scope.Contract.selfBalanceCached = false
 	evm.returnData = ret
 	return pc, ret, nil
 }


### PR DESCRIPTION
for https://github.com/erigontech/erigon/issues/14522

## Why

`test_account_query.py::test_selfbalance` was the next slowest test in the compute suite for bal-devnet-7 on benchmarkoor https://benchmarkoor.core.ethpandaops.io/runs/1779597608_77e2df86_erigon-bal-full?page=1&pageSize=20&sortBy=order&sortDir=asc&heatmapSort=mgas. 

Pushing it up brings the suite average and minimum-MGas/s up too.

## Results

Benchmarkoor, `test_account_query.py::test_selfbalance`, 9 gas budgets, jochemnet snapshot at block 24,402,727 (hybrid datadir reset between baseline and optimized runs).

| Gas | Before (MGas/s) | After (MGas/s) | Speedup |
|----:|----------------:|---------------:|--------:|
| 140M | 151.13 | 2659.14 | **17.60x** |
| 160M | 130.24 | 3273.34 | **25.13x** |
| 180M | 162.58 | 3295.88 | **20.27x** |
| 200M | 147.48 | 3478.53 | **23.59x** |
| 220M | 170.08 | 3056.19 | **17.97x** |
| 240M | 187.32 | 3269.34 | **17.45x** |
| 260M | 174.95 | 3363.59 | **19.23x** |
| 280M | 172.15 | 3683.69 | **21.40x** |
| 300M | 181.31 | 3505.47 | **19.33x** |
| **avg** | **164.14** | **3287.24** | **20.03x** |

For 140M, `engine_newPayloadV5` went from **927 ms → 45 ms** of wall-clock, fully consuming the 140,000,000 gas. Profile-wise `opSelfBalance` cumulative time on the same capture window dropped from **3.77 s (41.7%)** to **0.05 s (1.0%)**.

## What

`SELFBALANCE` returns the contract's own balance, which is invariant within a
call frame except when the frame itself initiates a nested call that can move
value (CALL/CALLCODE/CREATE/CREATE2) or a callee SELFDESTRUCT-credits us.
Under BAL parallel exec, every opcode invocation was paying the full
`versionedRead → VersionMap.Read → RWMutex.RLock` price to return the same
constant.

Memoize the value on `Contract`, fill on first read, invalidate after the
opcodes that can change our balance via a nested context.

- `execution/vm/contract.go` — add `selfBalance uint256.Int` + `selfBalanceCached bool` on `Contract`. Lifetime matches the call frame for free because `Contract` is overwritten by value in `getCallContext` on every frame entry.
- `execution/vm/eips.go` — `opSelfBalance` reads the cache, populates on first call.
- `execution/vm/instructions.go` — invalidate after `evm.Call`, `evm.CallCode`, `evm.DelegateCall`, and `evm.Create` (covers CREATE and CREATE2 via `execCreate`). `STATICCALL` is exempt (the whole subtree is read-only); `SELFDESTRUCT` is exempt (frame is exiting).

DELEGATECALL/CALLCODE correctness is automatic: the cache is keyed off
`Contract.addr`, which `NewContract` already sets to the storage/balance
owner. BAL read-set semantics are preserved — `ReadSet` is a dedup'd map, so
recording the same `(addr, BalancePath)` once vs many times produces an
identical final set.
