### PR TITLE
execution/stagedsync: move coinbase/burnt tip credit out of finalize into apply-loop pre-validate step

### DIFF
--- a/execution/stagedsync/exec3_finalize_test.go
+++ b/execution/stagedsync/exec3_finalize_test.go
@@ -1,6 +1,7 @@
 package stagedsync
 
 import (
+	"crypto/ecdsa"
 	"testing"
 
 	"github.com/holiman/uint256"
@@ -8,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/crypto"
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/exec"
 	"github.com/erigontech/erigon/execution/state"
@@ -16,6 +18,31 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 	"github.com/erigontech/erigon/execution/vm/evmtypes"
 )
+
+// senderIsCoinbaseKeyHolder pairs a deterministic test key with its derived
+// address in both raw common.Address (needed by SignTx + Tx.To) and interned
+// accounts.Address (needed by the versioned write set) forms.
+type senderIsCoinbaseKeyHolder struct {
+	key        *ecdsa.PrivateKey
+	rawAddress common.Address
+	address    accounts.Address
+}
+
+// senderIsCoinbaseKey is a deterministic test key whose derived address is
+// used as BOTH the sender and the coinbase in the sender==coinbase regression
+// scenarios. The same hex constant appears in stage_senders_test.go.
+var senderIsCoinbaseKey = func() *senderIsCoinbaseKeyHolder {
+	k, err := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	if err != nil {
+		panic(err)
+	}
+	rawAddr := crypto.PubkeyToAddress(k.PublicKey)
+	return &senderIsCoinbaseKeyHolder{
+		key:        k,
+		rawAddress: rawAddr,
+		address:    accounts.InternAddress(rawAddr),
+	}
+}()
 
 // mapStateReader is a test StateReader backed by in-memory maps.
 type mapStateReader struct {
@@ -92,6 +119,10 @@ type testFinalizeScenario struct {
 	rules           *chain.Rules
 	config          *chain.Config
 	header          *types.Header
+	// txs is optional: when set, buildExecResult attaches it to the TxTask
+	// so finalizeTxSimple's TxMessage().From() call returns the signer's
+	// derived sender. Required for senderIsCoinbase test coverage.
+	txs []types.Transaction
 }
 
 // copyReadSet makes a shallow copy of a ReadSet for test isolation.
@@ -134,6 +165,7 @@ func (s *testFinalizeScenario) buildExecResult() *execResult {
 		TxNum:   1,
 		TxIndex: 0,
 		Config:  s.config,
+		Txs:     s.txs, // nil when scenario doesn't need TxMessage().From()
 		EvmBlockContext: evmtypes.BlockContext{
 			BlockNumber: blockNum,
 		},
@@ -164,6 +196,67 @@ func (s *testFinalizeScenario) buildExecResult() *execResult {
 	}
 
 	return &execResult{TxResult: txResult}
+}
+
+// signSelfSendTx builds a legacy transaction where sender == recipient ==
+// the senderIsCoinbaseKey's derived address (and BOTH will be the
+// scenario's coinbase). The signer is derived from `config` at block 1, so
+// `config` must have all the relevant pre-fork blocks set to 0 (e.g.
+// TestChainBerlinConfig). Returns the signed transaction.
+//
+// Using a real signed tx (rather than fabricating a *types.Message
+// directly) is necessary because finalizeTxSimple's senderIsCoinbase
+// detection calls txTask.TxMessage(), which lazy-derives the message from
+// the signed tx via the chain's signer — there is no public setter for the
+// unexported `message` field on *exec.TxTask.
+func signSelfSendTx(t *testing.T, nonce uint64, value uint64, gasPrice uint64, gasLimit uint64, config *chain.Config, blockTime uint64) types.Transaction {
+	t.Helper()
+	signer := types.MakeSigner(config, 1, blockTime)
+	tx := &types.LegacyTx{
+		CommonTx: types.CommonTx{
+			Nonce:    nonce,
+			To:       &senderIsCoinbaseKey.rawAddress,
+			Value:    *uint256.NewInt(value),
+			GasLimit: gasLimit,
+		},
+		GasPrice: *uint256.NewInt(gasPrice),
+	}
+	signed, err := types.SignTx(tx, *signer, senderIsCoinbaseKey.key)
+	require.NoError(t, err, "SignTx must succeed for the deterministic test key")
+	return signed
+}
+
+// TestSignSelfSendTx_SmokeTestForScaffolding verifies that the
+// signSelfSendTx helper produces a transaction whose recovered sender
+// matches senderIsCoinbaseKey.address. This is the critical contract the
+// senderIsCoinbase test family depends on — without it, those tests would
+// silently exercise the wrong code path inside finalizeTxSimple.
+func TestSignSelfSendTx_SmokeTestForScaffolding(t *testing.T) {
+	t.Parallel()
+
+	config := chain.TestChainBerlinConfig
+	signedTx := signSelfSendTx(t, 0 /* nonce */, 0 /* value */, 1 /* gasPrice */, 21000 /* gasLimit */, config, 0 /* blockTime */)
+
+	// Construct a minimal TxTask carrying this signed tx, then call
+	// TxMessage() — same path finalizeTxSimple uses.
+	header := &types.Header{Number: *uint256.NewInt(1)}
+	txTask := &exec.TxTask{
+		Header:  header,
+		TxNum:   1,
+		TxIndex: 0,
+		Config:  config,
+		Txs:     []types.Transaction{signedTx},
+	}
+
+	msg, err := txTask.TxMessage()
+	require.NoError(t, err, "TxMessage must succeed on a properly signed tx")
+	require.NotNil(t, msg, "TxMessage must return a non-nil message")
+
+	// msg.From() returns common.Address — intern it to match how
+	// finalizeTxSimple's senderIsCoinbase check works.
+	recovered := accounts.InternAddress(msg.From().Value())
+	require.Equal(t, senderIsCoinbaseKey.address, recovered,
+		"recovered sender must equal the key's derived address; otherwise the senderIsCoinbase tests are unsound")
 }
 
 func fAddr(name string) accounts.Address {
@@ -278,6 +371,112 @@ func londonTransferScenario() *testFinalizeScenario {
 	return s
 }
 
+// senderIsCoinbaseScenario builds a scenario where sender == coinbase (via
+// a real signed tx so finalizeTxSimple's TxMessage().From() == result.Coinbase
+// check returns true). The TxOut and CollectorWrites shapes are minimal
+// baselines — each test customizes them to exercise its specific case.
+//
+// preBlockCoinbaseBal is the pre-block coinbase balance written into the
+// reader's accts map. tip is the FeeTipped value the worker-skipped tip
+// credit must be re-added on top of by finalizeTxSimple.
+//
+// london controls whether the chain config has LondonBlock=0 (and the rules
+// have IsLondon=true) and whether a burnt contract address + FeeBurnt are
+// populated on the result.
+func senderIsCoinbaseScenario(t *testing.T, value uint64, preBlockCoinbaseBal uint64, tip uint64, london bool) *testFinalizeScenario {
+	t.Helper()
+
+	coinbase := senderIsCoinbaseKey.address
+
+	var config *chain.Config
+	var rules *chain.Rules
+	var header *types.Header
+	if london {
+		// London-enabled config + rules — fresh construction (cannot
+		// dereference-copy chain.Config; it embeds sync.Once via noCopy).
+		config = &chain.Config{
+			ChainID:               uint256.NewInt(1337),
+			Rules:                 chain.EtHashRules,
+			HomesteadBlock:        common.NewUint64(0),
+			TangerineWhistleBlock: common.NewUint64(0),
+			SpuriousDragonBlock:   common.NewUint64(0),
+			ByzantiumBlock:        common.NewUint64(0),
+			ConstantinopleBlock:   common.NewUint64(0),
+			PetersburgBlock:       common.NewUint64(0),
+			IstanbulBlock:         common.NewUint64(0),
+			MuirGlacierBlock:      common.NewUint64(0),
+			BerlinBlock:           common.NewUint64(0),
+			LondonBlock:           common.NewUint64(0),
+			Ethash:                new(chain.EthashConfig),
+		}
+		rules = &chain.Rules{IsSpuriousDragon: true, IsLondon: true}
+		header = &types.Header{
+			Number:   *uint256.NewInt(1),
+			GasLimit: 30_000_000,
+			GasUsed:  21000,
+			BaseFee:  uint256.NewInt(1), // required for IsLondon signer
+		}
+	} else {
+		config = chain.TestChainBerlinConfig
+		rules = &chain.Rules{IsSpuriousDragon: true}
+		header = &types.Header{
+			Number:   *uint256.NewInt(1),
+			GasLimit: 30_000_000,
+			GasUsed:  21000,
+		}
+	}
+
+	signed := signSelfSendTx(t, 0 /* nonce */, value, 1 /* gasPrice */, 21000 /* gasLimit */, config, 0 /* blockTime */)
+
+	// Baseline TxOut: sender (=coinbase) nonce bumped to 1. Tests customise
+	// the coinbase BalancePath entry to exercise specific worker-output
+	// shapes.
+	txOut := state.VersionedWrites{
+		{Address: coinbase, Path: state.NoncePath, Val: uint64(1)},
+	}
+
+	// Baseline CollectorWrites: matches TxOut by default. Tests customise
+	// to exercise the senderIsCoinbase discriminator.
+	collectorWrites := state.VersionedWrites{
+		{Address: coinbase, Path: state.NoncePath, Val: uint64(1)},
+		{Address: coinbase, Path: state.IncarnationPath, Val: uint64(1)},
+		{Address: coinbase, Path: state.CodeHashPath, Val: accounts.EmptyCodeHash},
+	}
+
+	// Baseline TxIn: sender (=coinbase) balance + nonce reads.
+	txIn := state.ReadSet{}
+	txIn.Set(state.VersionedRead{Address: coinbase, Path: state.AddressPath, Val: fMakeAccount(preBlockCoinbaseBal, 0)})
+	txIn.Set(state.VersionedRead{Address: coinbase, Path: state.BalancePath, Val: *uint256.NewInt(preBlockCoinbaseBal)})
+	txIn.Set(state.VersionedRead{Address: coinbase, Path: state.NoncePath, Val: uint64(0)})
+
+	scenario := &testFinalizeScenario{
+		name: "sender_is_coinbase",
+		accts: map[accounts.Address]*accounts.Account{
+			coinbase: fMakeAccount(preBlockCoinbaseBal, 0),
+		},
+		txIn:            txIn,
+		txOut:           txOut,
+		collectorWrites: collectorWrites,
+		feeTipped:       *uint256.NewInt(tip),
+		coinbase:        coinbase,
+		burntAddr:       accounts.NilAddress,
+		rules:           rules,
+		config:          config,
+		header:          header,
+		txs:             []types.Transaction{signed},
+	}
+
+	if london {
+		// Post-London: include a burnt contract address + a small FeeBurnt.
+		burntAddr := fAddr("burntcontract")
+		scenario.burntAddr = burntAddr
+		scenario.feeBurnt = *uint256.NewInt(1000)
+		scenario.accts[burntAddr] = fMakeAccount(500_000, 0)
+	}
+
+	return scenario
+}
+
 func findWrite(writes state.VersionedWrites, addr accounts.Address, path state.AccountPath) *state.VersionedWrite {
 	for _, w := range writes {
 		if w.Address == addr && w.Path == path {
@@ -346,6 +545,367 @@ func TestFinalizeTxSimple_BasicFeeCredit(t *testing.T) {
 	expected := new(uint256.Int).Add(priorBalance, &s.feeTipped)
 	assert.Equal(t, *expected, coinbaseBalance,
 		"coinbase should be priorBalance + FeeTipped (no delta, no double-count)")
+}
+
+// TestFinalizeTxSimple_SenderIsCoinbase_TxOutValueWins is the regression
+// pin for bug #1 of #21017. The block-218957 manifestation:
+//
+//   - Sender == coinbase (a Frontier-style miner self-send)
+//   - Worker runs with shouldDelayFeeCalc=true so noFeeBurnAndTip=true.
+//     buyGas still debits the sender; the tip credit to coinbase is skipped
+//     (it's what finalize must add back).
+//   - The worker's IBS therefore has coinbase Balance debited by the gas
+//     amount. TxOut (raw IBS.VersionedWrites output) carries this debited
+//     value.
+//   - For Frontier miner self-sends, CollectorWrites (IBS net-change via
+//     LightCollector) suppresses the coinbase entry under specific
+//     conditions documented at exec3_parallel.go:1641-1673 — historically
+//     the load-bearing case the bug originally hit.
+//
+// Pre-fix: finalizeTxSimple scanned CollectorWrites only. The suppression
+// meant no override → newCoinbaseBalance stayed at the versionMap base
+// (pre-this-tx value) → adding FeeTipped on top over-credited the coinbase
+// by exactly one tip.
+//
+// Post-fix: when senderIsCoinbase, finalizeTxSimple scans TxOut instead,
+// finds the worker's debited value, overrides newCoinbaseBalance, then
+// adds FeeTipped. The net result equals the canonical post-tx state
+// (debit and tip cancel for a miner self-send).
+//
+// This test pins the discriminator: when sender==coinbase AND TxOut has
+// a coinbase BalancePath entry that disagrees with the versionMap base,
+// finalize MUST use the TxOut value as the base for the tip credit.
+func TestFinalizeTxSimple_SenderIsCoinbase_TxOutValueWins(t *testing.T) {
+	t.Parallel()
+
+	const (
+		preBlockBal   = uint64(1_000_000)
+		gasCost       = uint64(21_000) // gasLimit * gasPrice for the test tx
+		postDebitBal  = preBlockBal - gasCost
+		tip           = gasCost // Frontier: effectiveTip = gasPrice; tip = gasUsed * gasPrice = gasCost
+		expectedFinal = postDebitBal + tip
+		_             = expectedFinal // documents the invariant: cancels back to preBlockBal
+	)
+
+	s := senderIsCoinbaseScenario(t, 0 /* value=0: pure miner self-send */, preBlockBal, tip, false /* pre-London */)
+
+	// TxOut: worker debited coinbase by gas — emit the post-debit value.
+	// CollectorWrites: SUPPRESS the coinbase BalancePath entry (mimicking
+	// the bug-trigger condition). The two disagree; the senderIsCoinbase
+	// discriminator must pick TxOut's value.
+	s.txOut = append(s.txOut, &state.VersionedWrite{
+		Address: s.coinbase,
+		Path:    state.BalancePath,
+		Val:     *uint256.NewInt(postDebitBal),
+	})
+	// (s.collectorWrites left as the baseline — no coinbase BalancePath entry)
+
+	writes := s.runFinalizeTxSimple(t, nil /* no prior tx in this block */)
+
+	coinbaseWrite := findWrite(writes, s.coinbase, state.BalancePath)
+	require.NotNil(t, coinbaseWrite, "finalize must produce a coinbase BalancePath write")
+
+	got := coinbaseWrite.Val.(uint256.Int)
+	want := uint256.NewInt(expectedFinal)
+	assert.Equal(t, *want, got,
+		"senderIsCoinbase: finalize must use TxOut value (%d) + tip (%d) = %d, NOT versionMap base (%d) + tip (%d) = %d (the bug)",
+		postDebitBal, tip, expectedFinal, preBlockBal, tip, preBlockBal+tip)
+}
+
+// TestFinalizeTxSimple_SenderNotCoinbase_CollectorWritesValueWins is the
+// negative control for TxOutValueWins. Same TxOut shape (coinbase
+// BalancePath present), but sender != coinbase, so the senderIsCoinbase
+// discriminator falls into the else branch (scan CollectorWrites instead).
+//
+// CollectorWrites has NO coinbase BalancePath entry, so no override
+// happens — finalizeTxSimple uses the versionMap base + tip. Proves that
+// the senderIsCoinbase branch in TxOutValueWins is the load-bearing
+// reason that test passes (i.e. flipping just the sender flips the
+// outcome), rather than some unrelated code path masking the bug.
+func TestFinalizeTxSimple_SenderNotCoinbase_CollectorWritesValueWins(t *testing.T) {
+	t.Parallel()
+
+	// Use simpleTransferScenario: sender (fAddr("sender")) != coinbase
+	// (fAddr("coinbase")). No s.txs set → txTask.TxMessage() returns nil
+	// → senderIsCoinbase stays false → scans CollectorWrites only.
+	s := simpleTransferScenario()
+
+	// Force the same TxOut-only-coinbase shape as the positive test:
+	// coinbase BalancePath = some-non-zero value in TxOut, NO coinbase
+	// BalancePath in CollectorWrites. Pre-block coinbase balance is 0
+	// (from simpleTransferScenario.accts).
+	const (
+		txOutCoinbaseBal = uint64(979_000) // arbitrary "post-debit" value
+		preBlockCoinbase = uint64(0)       // simpleTransferScenario default
+		tip              = uint64(21_000)  // from scenario.feeTipped
+	)
+	s.txOut = append(s.txOut, &state.VersionedWrite{
+		Address: s.coinbase,
+		Path:    state.BalancePath,
+		Val:     *uint256.NewInt(txOutCoinbaseBal),
+	})
+	// CollectorWrites unchanged — no coinbase BalancePath entry in baseline.
+
+	writes := s.runFinalizeTxSimple(t, nil)
+
+	coinbaseWrite := findWrite(writes, s.coinbase, state.BalancePath)
+	require.NotNil(t, coinbaseWrite, "finalize should produce a coinbase BalancePath write")
+
+	got := coinbaseWrite.Val.(uint256.Int)
+	expected := uint256.NewInt(preBlockCoinbase + tip)
+	assert.Equal(t, *expected, got,
+		"sender != coinbase: finalize must use versionMap base (%d) + tip (%d) = %d, NOT TxOut value (%d) + tip = %d",
+		preBlockCoinbase, tip, preBlockCoinbase+tip, txOutCoinbaseBal, txOutCoinbaseBal+tip)
+}
+
+// TestFinalizeTxSimple_SenderIsCoinbase_TxOutWinsOverCollectorWrites
+// strengthens TxOutValueWins by adding a coinbase BalancePath entry to
+// CollectorWrites at a DIFFERENT value than TxOut. The discriminator must
+// firmly pick TxOut when senderIsCoinbase=true — even when CollectorWrites
+// is non-empty and would have given a different answer.
+//
+// Maps to cleanup memory case #2: sender == coinbase, value > 0, Frontier.
+// In real EVM exec, a sender==coinbase value-bearing self-send produces a
+// different CollectorWrites shape than a value=0 self-send because the
+// IBS journal records the self-transfer's SubBalance/AddBalance pair (net
+// zero on the address but tracked by LightCollector's per-call deltas). The
+// test pins that the discriminator's choice does not depend on whether
+// CollectorWrites has an entry.
+func TestFinalizeTxSimple_SenderIsCoinbase_TxOutWinsOverCollectorWrites(t *testing.T) {
+	t.Parallel()
+
+	const (
+		preBlockBal   = uint64(1_000_000)
+		postDebitBal  = uint64(979_000)   // TxOut: gas-debited value
+		collectorBal  = uint64(1_500_000) // CollectorWrites: different, wrong value
+		tip           = uint64(21_000)
+		expectedFinal = postDebitBal + tip // 1,000,000 — must use TxOut, not CollectorWrites
+	)
+
+	s := senderIsCoinbaseScenario(t, 100 /* value > 0 self-send */, preBlockBal, tip, false)
+
+	s.txOut = append(s.txOut, &state.VersionedWrite{
+		Address: s.coinbase,
+		Path:    state.BalancePath,
+		Val:     *uint256.NewInt(postDebitBal),
+	})
+	// Add a contradictory CollectorWrites entry to prove the discriminator
+	// firmly picks TxOut. If finalize ever falls through to scanning
+	// CollectorWrites under senderIsCoinbase=true, the assertion below
+	// would fail with the collectorBal+tip value.
+	s.collectorWrites = append(s.collectorWrites, &state.VersionedWrite{
+		Address: s.coinbase,
+		Path:    state.BalancePath,
+		Val:     *uint256.NewInt(collectorBal),
+	})
+
+	writes := s.runFinalizeTxSimple(t, nil)
+
+	coinbaseWrite := findWrite(writes, s.coinbase, state.BalancePath)
+	require.NotNil(t, coinbaseWrite, "finalize must produce coinbase BalancePath write")
+
+	got := coinbaseWrite.Val.(uint256.Int)
+	want := uint256.NewInt(expectedFinal)
+	assert.Equal(t, *want, got,
+		"senderIsCoinbase=true: TxOut value (%d) + tip (%d) = %d MUST WIN over CollectorWrites value (%d) + tip = %d",
+		postDebitBal, tip, expectedFinal, collectorBal, collectorBal+tip)
+}
+
+// TestFinalizeTxSimple_SenderIsCoinbase_PostLondon verifies the
+// senderIsCoinbase discriminator still picks TxOut for the coinbase under
+// post-London rules (IsLondon=true, separate burnt contract address). The
+// burnt path runs in parallel for a non-sender burnt contract — its
+// FeeBurnt is added to its versionMap base via the regular (non-sender)
+// CollectorWrites scan.
+//
+// Maps to cleanup memory case #3: sender == coinbase, value > 0, post-London.
+func TestFinalizeTxSimple_SenderIsCoinbase_PostLondon(t *testing.T) {
+	t.Parallel()
+
+	const (
+		preBlockBal      = uint64(1_000_000)
+		postDebitBal     = uint64(979_000)
+		tip              = uint64(11_000)
+		burn             = uint64(10_000)
+		burntPreBlockBal = uint64(500_000)
+		expectedCoinbase = postDebitBal + tip      // 990,000
+		expectedBurntBal = burntPreBlockBal + burn // 510,000
+	)
+
+	s := senderIsCoinbaseScenario(t, 0, preBlockBal, tip, true /* london */)
+	s.feeBurnt = *uint256.NewInt(burn) // override scenario default
+
+	s.txOut = append(s.txOut, &state.VersionedWrite{
+		Address: s.coinbase,
+		Path:    state.BalancePath,
+		Val:     *uint256.NewInt(postDebitBal),
+	})
+	// CollectorWrites: no coinbase, no burnt — finalize reads burnt base
+	// from versionMap (= burntPreBlockBal from scenario.accts) and adds burn.
+
+	writes := s.runFinalizeTxSimple(t, nil)
+
+	coinbaseWrite := findWrite(writes, s.coinbase, state.BalancePath)
+	require.NotNil(t, coinbaseWrite, "coinbase BalancePath write must exist")
+	gotCoinbase := coinbaseWrite.Val.(uint256.Int)
+	assert.Equal(t, *uint256.NewInt(expectedCoinbase), gotCoinbase,
+		"coinbase: TxOut (%d) + tip (%d) = %d expected", postDebitBal, tip, expectedCoinbase)
+
+	burntWrite := findWrite(writes, s.burntAddr, state.BalancePath)
+	require.NotNil(t, burntWrite, "burnt BalancePath write must exist under London")
+	gotBurnt := burntWrite.Val.(uint256.Int)
+	assert.Equal(t, *uint256.NewInt(expectedBurntBal), gotBurnt,
+		"burnt: versionMap base (%d) + burn (%d) = %d expected", burntPreBlockBal, burn, expectedBurntBal)
+}
+
+// TestFinalizeTxSimple_SenderIsCoinbase_AccumulatedAcrossTxs runs three
+// successive sender==coinbase txs through finalize, verifying that the tip
+// credit accumulates correctly across the txs even when the discriminator
+// uses TxOut on each call. Mirrors the existing
+// TestFinalizeTxSimple_AccumulatedFees but for sender==coinbase.
+//
+// Maps to cleanup memory case #6: multiple sender == coinbase txs in same
+// block. Pins that the per-tx TxOut-override doesn't break across-tx
+// accumulation — each tx's worker debit + finalize tip credit cancel,
+// so the coinbase balance stays at preBlockBal across all N txs.
+func TestFinalizeTxSimple_SenderIsCoinbase_AccumulatedAcrossTxs(t *testing.T) {
+	t.Parallel()
+
+	const (
+		preBlockBal  = uint64(1_000_000)
+		gasCost      = uint64(21_000)
+		postDebitBal = preBlockBal - gasCost
+		tip          = gasCost
+		numTxs       = 3
+	)
+
+	// One scenario sets up the stateReader + chain config. Each tx uses
+	// a freshly built execResult to avoid state leakage between iterations.
+	baseScenario := senderIsCoinbaseScenario(t, 0, preBlockBal, tip, false)
+	vm := state.NewVersionMap(nil)
+	reader := baseScenario.makeReader()
+
+	for txIdx := 0; txIdx < numTxs; txIdx++ {
+		s := senderIsCoinbaseScenario(t, 0, preBlockBal, tip, false)
+		// Each tx: TxOut has coinbase at postDebitBal. Since each tx
+		// nets coinbase back to preBlockBal after finalize, the next
+		// tx still sees preBlockBal as its base.
+		s.txOut = append(s.txOut, &state.VersionedWrite{
+			Address: s.coinbase,
+			Path:    state.BalancePath,
+			Val:     *uint256.NewInt(postDebitBal),
+		})
+
+		// Stamp each TxOut entry with this iteration's Version before
+		// flushing so the writes land at (txIdx, 0). Without this, the
+		// scenario baseline's unstamped writes default to (0, 0) and
+		// collide with the prior iteration's finalize tip-credit writes
+		// at (prevTxIdx, 1) — versionMap.writeLocked panics when the new
+		// incarnation is lower than the existing cell's.
+		iterVersion := state.Version{BlockNum: 1, TxNum: uint64(txIdx + 1), TxIndex: txIdx, Incarnation: 0}
+		for _, w := range s.txOut {
+			w.Version = iterVersion
+		}
+
+		result := s.buildExecResult()
+		result.TxIn = copyReadSet(s.txIn)
+		result.TxOut = copyWrites(s.txOut)
+		result.CollectorWrites = copyWrites(s.collectorWrites)
+
+		// Set this tx's version explicitly so versionMap reads land on
+		// the right tx-index for the floor-read semantics.
+		task := result.Task.(*taskVersion)
+		task.version = iterVersion
+
+		vm.FlushVersionedWrites(result.TxOut, true, "")
+
+		txTask := task.Task.(*exec.TxTask)
+		_, _, writes, err := result.finalizeTxSimple(
+			task, txTask, nil, nil, vm, reader,
+			s.rules, false, false, "",
+		)
+		require.NoError(t, err, "tx %d: finalizeTxSimple", txIdx)
+
+		// Flush finalize writes so the next tx sees them via versionMap.
+		vm.FlushVersionedWrites(writes, true, "")
+
+		coinbaseWrite := findWrite(writes, s.coinbase, state.BalancePath)
+		require.NotNil(t, coinbaseWrite, "tx %d: coinbase BalancePath write must exist (workerWroteCoinbase gate fires when newBal==oldBal)", txIdx)
+		got := coinbaseWrite.Val.(uint256.Int)
+		want := uint256.NewInt(postDebitBal + tip) // = preBlockBal: each tx cancels back
+		assert.Equal(t, *want, got, "tx %d: coinbase must net to preBlockBal", txIdx)
+	}
+}
+
+// TestFinalizeTxSimple_SenderIsCoinbase_ReExecutedIncarnation pins that
+// when the worker re-executes at incarnation > 0 and emits a different
+// TxOut value than the abandoned incarnation 0, finalize uses the
+// RE-EXECUTED value (from the latest TxOut), not the abandoned one.
+//
+// Maps to cleanup memory case #7: sender == coinbase with worker
+// re-execution. Tests that the TxOut scan in finalize is on the CURRENT
+// execResult's TxOut (not stashed from a prior incarnation).
+func TestFinalizeTxSimple_SenderIsCoinbase_ReExecutedIncarnation(t *testing.T) {
+	t.Parallel()
+
+	const (
+		preBlockBal       = uint64(1_000_000)
+		abandonedPostBal  = uint64(950_000) // what incarnation 0's worker would have produced (e.g. wrong gas)
+		reExecutedPostBal = uint64(979_000) // what incarnation 1's worker produced (correct)
+		tip               = uint64(21_000)
+		expectedFinal     = reExecutedPostBal + tip // = 1,000,000
+	)
+
+	s := senderIsCoinbaseScenario(t, 0, preBlockBal, tip, false)
+
+	// Simulate the abandoned incarnation 0 write already in versionMap.
+	// finalize's vsReader uses floor(txIndex-1) so it WON'T read this
+	// value (TxIndex=0), but recording it documents the scenario.
+	// What matters for the test is that the CURRENT result.TxOut is what
+	// finalize scans.
+	s.txOut = append(s.txOut, &state.VersionedWrite{
+		Address: s.coinbase,
+		Path:    state.BalancePath,
+		Val:     *uint256.NewInt(reExecutedPostBal), // the re-executed (correct) value
+	})
+
+	// Set incarnation > 0 on the task to reflect re-execution.
+	result := s.buildExecResult()
+	result.TxIn = copyReadSet(s.txIn)
+	result.TxOut = copyWrites(s.txOut)
+	result.CollectorWrites = copyWrites(s.collectorWrites)
+
+	task := result.Task.(*taskVersion)
+	task.version.Incarnation = 1 // re-execution
+
+	vm := state.NewVersionMap(nil)
+	reader := s.makeReader()
+
+	// Pre-populate versionMap with the abandoned incarnation 0 value at
+	// (txIndex=0, incarnation=0). The re-execution at incarnation=1 should
+	// produce a write that masks this; finalize must NOT use this stale
+	// abandoned value.
+	vm.Write(s.coinbase, state.BalancePath, accounts.NilKey,
+		state.Version{TxIndex: 0, Incarnation: 0},
+		*uint256.NewInt(abandonedPostBal), true)
+
+	// Now flush the re-executed TxOut at incarnation 1.
+	vm.FlushVersionedWrites(result.TxOut, true, "")
+
+	txTask := task.Task.(*exec.TxTask)
+	_, _, writes, err := result.finalizeTxSimple(
+		task, txTask, nil, nil, vm, reader,
+		s.rules, false, false, "",
+	)
+	require.NoError(t, err)
+
+	coinbaseWrite := findWrite(writes, s.coinbase, state.BalancePath)
+	require.NotNil(t, coinbaseWrite, "coinbase BalancePath write must exist")
+	got := coinbaseWrite.Val.(uint256.Int)
+	want := uint256.NewInt(expectedFinal)
+	assert.Equal(t, *want, got,
+		"re-execution: finalize must use re-executed TxOut value (%d) + tip (%d) = %d, NOT abandoned incarnation-0 value (%d) + tip = %d",
+		reExecutedPostBal, tip, expectedFinal, abandonedPostBal, abandonedPostBal+tip)
 }
 
 // TestFinalizeTxSimple_VersionOnWrites verifies that all finalize writes

--- a/execution/stagedsync/exec3_finalize_test.go
+++ b/execution/stagedsync/exec3_finalize_test.go
@@ -965,34 +965,29 @@ func TestFinalizeTxSimple_AccumulatedFees(t *testing.T) {
 }
 
 // TestFinalizeTxSimple_FeeWriteInvalidatesStaleCoinbaseRead exercises the
-// fix for the parallel-exec lost-coinbase-fee race. finalize credits the
-// coinbase tip as an implicit write the worker never made (it ran with
-// shouldDelayFeeCalc=true). That write must be stamped at the worker's
-// incarnation + 1: a later tx that speculatively read the coinbase BEFORE
-// this finalize ran recorded the worker's incarnation, and the bumped
-// version makes the MapRead version check fail so that tx is invalidated
-// and re-executed against the post-fee balance. Reusing the worker's
-// incarnation makes the stale read indistinguishable from a fresh one and
-// silently drops the fee.
+// fix for the parallel-exec lost-coinbase-fee race. The apply-loop tip
+// credit (calcFees) writes coinbase BalancePath BEFORE validate runs.
+// Under the post-#21387 architecture calcFees stamps at the worker's own
+// incarnation (not incarnation+1 as in the pre-#21017 code); invalidation
+// of a stale dependent read flows through the value-tiebreaker at validate
+// time (versionmap.go's StorageRead-with-Done-entry branch). A reader that
+// recorded the pre-tip baseline via stateReader sees the versionMap now
+// holds the post-tip value, and validate marks the read invalid so the
+// dependent tx re-executes against the post-fee balance.
 func TestFinalizeTxSimple_FeeWriteInvalidatesStaleCoinbaseRead(t *testing.T) {
 	t.Parallel()
 	s := simpleTransferScenario()
 
-	writes := s.runFinalizeTxSimple(t, nil)
+	writes := s.runFinalizeTx(t, nil)
 	coinbaseWrite := findWrite(writes, s.coinbase, state.BalancePath)
-	require.NotNil(t, coinbaseWrite, "finalize should produce a coinbase BalancePath write")
+	require.NotNil(t, coinbaseWrite, "calcFees should produce a coinbase BalancePath write")
 
-	// The producer tx executed at incarnation 0; its implicit fee write
-	// must carry incarnation 1 — a distinct version from the worker's.
 	require.Equal(t, 0, coinbaseWrite.Version.TxIndex)
-	require.Equal(t, 1, coinbaseWrite.Version.Incarnation,
-		"finalize coinbase fee write must be stamped at worker incarnation + 1")
+	require.Equal(t, 0, coinbaseWrite.Version.Incarnation,
+		"calcFees stamps coinbase write at worker incarnation (no +1 bump under post-#21387 architecture)")
 
-	// Reflect the producer tx in a versionMap: the worker's pre-fee
-	// coinbase write at (0,0), then finalize's fee write at (0,1).
+	// Reflect calcFees in the versionMap.
 	vm := state.NewVersionMap(nil)
-	vm.Write(s.coinbase, state.BalancePath, accounts.NilKey,
-		state.Version{TxIndex: 0, Incarnation: 0}, uint256.Int{}, true)
 	vm.FlushVersionedWrites(state.VersionedWrites{coinbaseWrite}, true, "")
 
 	checkVersion := func(readV, writeV state.Version) state.VersionValidity {
@@ -1003,45 +998,48 @@ func TestFinalizeTxSimple_FeeWriteInvalidatesStaleCoinbaseRead(t *testing.T) {
 	}
 
 	// validateCoinbaseRead validates a dependent tx (txIndex 1) whose only
-	// recorded read is the coinbase balance, read at the given incarnation.
-	validateCoinbaseRead := func(readAtIncarnation int) state.VersionValidity {
+	// recorded read is the coinbase balance.
+	validateCoinbaseRead := func(source state.ReadSource, readVal uint256.Int) state.VersionValidity {
 		io := state.NewVersionedIO(2)
 		rs := state.ReadSet{}
 		rs.Set(state.VersionedRead{
 			Address: s.coinbase,
 			Path:    state.BalancePath,
-			Source:  state.MapRead,
-			Version: state.Version{TxIndex: 0, Incarnation: readAtIncarnation},
+			Source:  source,
+			Version: state.Version{TxIndex: 0, Incarnation: 0},
+			Val:     readVal,
 		})
 		io.RecordReads(state.Version{TxIndex: 1}, rs)
 		return vm.ValidateVersion(1, io, checkVersion, false, "")
 	}
 
-	// Early-read timing — the dependent read the coinbase before finalize
-	// ran, recording the worker's version (0,0). It must be invalidated.
-	assert.Equal(t, state.VersionInvalid, validateCoinbaseRead(0),
-		"a tx that read the coinbase before the fee finalize must fail validation")
+	// Stale timing — the dependent worker read the coinbase via stateReader
+	// before tx 0's calcFees ran, recording the pre-tip baseline (zero).
+	// Validate's value-tiebreaker catches the mismatch.
+	assert.Equal(t, state.VersionInvalid, validateCoinbaseRead(state.StorageRead, uint256.Int{}),
+		"a stale read of pre-tip baseline (via stateReader) must be invalidated by validate's value-tiebreaker")
 
-	// Late-read timing — the dependent read after finalize, recording the
-	// fee write's version (0,1). It must stay valid.
-	assert.Equal(t, state.VersionValid, validateCoinbaseRead(1),
-		"a tx that read the coinbase after the fee finalize must stay valid")
+	// Late timing — the dependent worker read after calcFees, recording the
+	// post-tip value at the worker's version (MapRead). Validate passes.
+	coinbaseVal := coinbaseWrite.Val.(uint256.Int)
+	assert.Equal(t, state.VersionValid, validateCoinbaseRead(state.MapRead, coinbaseVal),
+		"a fresh read of post-tip value at the same version must stay valid")
 }
 
-// TestFinalizeTxSimple_BurntFeeWriteBumpsIncarnation verifies the burnt
-// contract's implicit FeeBurnt write gets the same incarnation+1 stamp as
-// the coinbase tip write.
-func TestFinalizeTxSimple_BurntFeeWriteBumpsIncarnation(t *testing.T) {
+// TestFinalizeTxSimple_BurntFeeWriteStampsWorkerIncarnation verifies the
+// burnt contract's implicit FeeBurnt write is stamped at the worker's own
+// incarnation (same as coinbase under the post-#21387 architecture).
+func TestFinalizeTxSimple_BurntFeeWriteStampsWorkerIncarnation(t *testing.T) {
 	t.Parallel()
 	s := londonTransferScenario()
 
-	writes := s.runFinalizeTxSimple(t, nil)
+	writes := s.runFinalizeTx(t, nil)
 	burntWrite := findWrite(writes, s.burntAddr, state.BalancePath)
-	require.NotNil(t, burntWrite, "finalize should produce a burnt contract BalancePath write")
+	require.NotNil(t, burntWrite, "calcFees should produce a burnt contract BalancePath write")
 
 	assert.Equal(t, 0, burntWrite.Version.TxIndex)
-	assert.Equal(t, 1, burntWrite.Version.Incarnation,
-		"finalize burnt-fee write must be stamped at worker incarnation + 1")
+	assert.Equal(t, 0, burntWrite.Version.Incarnation,
+		"calcFees stamps burnt write at worker incarnation (no +1 bump under post-#21387 architecture)")
 }
 
 // TestResolveStorageWrites_IBSvsSimple compares the storage write sets

--- a/execution/stagedsync/exec3_finalize_test.go
+++ b/execution/stagedsync/exec3_finalize_test.go
@@ -490,11 +490,11 @@ func findWrite(writes state.VersionedWrites, addr accounts.Address, path state.A
 // These test the split fee logic: worker debits sender only,
 // finalize credits coinbase/burnt. No StripBalanceWrite or delta computation.
 
-// runFinalizeTx sets up the versionMap with prior TX's finalize writes and
-// runs the apply-loop tip credit (creditTipPreValidate). Returns the
-// tip-credit writes for assertion. finalizeTx itself only adds the receipt
-// and PostApplyMessage logs — no additional writes — so tests that assert
-// on writes need only the creditTipPreValidate output.
+// runFinalizeTx runs the apply-loop tip credit (calcFees) and returns the
+// resulting writes. priorCoinbaseBalance is the pre-block baseline returned
+// by stateReader.ReadAccountData(coinbase). calcFees reads at txIndex
+// (floor txIndex-1) — strictly prior tx — so for the first tx of a block
+// the baseline comes from stateReader, not the versionMap.
 func (s *testFinalizeScenario) runFinalizeTx(t *testing.T, priorCoinbaseBalance *uint256.Int) state.VersionedWrites {
 	t.Helper()
 	result := s.buildExecResult()
@@ -507,19 +507,20 @@ func (s *testFinalizeScenario) runFinalizeTx(t *testing.T, priorCoinbaseBalance 
 	vm := state.NewVersionMap(nil)
 	reader := s.makeReader()
 
-	// Simulate prior TX's finalize writing coinbase BalancePath to the versionMap.
 	if priorCoinbaseBalance != nil {
-		vm.Write(s.coinbase, state.BalancePath, accounts.NilKey,
-			state.Version{TxIndex: 0, Incarnation: 0}, *priorCoinbaseBalance, true)
+		acc, ok := reader.accounts[s.coinbase]
+		if !ok {
+			acc = &accounts.Account{}
+			reader.accounts[s.coinbase] = acc
+		}
+		acc.Balance = *priorCoinbaseBalance
 	}
 
-	// Flush the worker's TxOut to the versionMap (mirrors apply-loop's
-	// FlushVersionedWrites re-flush before validate).
 	vm.FlushVersionedWrites(result.TxOut, true, "")
 
 	task := result.Task.(*taskVersion)
 
-	writes, err := result.creditTipPreValidate(task, vm, reader, s.rules)
+	writes, err := result.calcFees(task, vm, reader, s.rules)
 	require.NoError(t, err)
 	return writes
 }
@@ -616,7 +617,7 @@ func TestFinalizeTxSimple_SenderIsCoinbase_TxOutValueWins(t *testing.T) {
 // (Removed: TestFinalizeTxSimple_SenderNotCoinbase_CollectorWritesValueWins
 // was a negative control for the prior code's senderIsCoinbase discriminator
 // — it asserted that flipping sender to non-coinbase made finalize ignore
-// TxOut and use versionMap base + tip. The new apply-loop creditTipPreValidate
+// TxOut and use versionMap base + tip. The new apply-loop calcFees
 // step uses vm.Read(..., txIndex+1) for the base, which reads whatever is
 // most recently in versionMap at or before this tx — including the TxOut
 // entry flushed by the test setup. The discriminator code path no longer
@@ -785,8 +786,8 @@ func TestFinalizeTxSimple_SenderIsCoinbase_AccumulatedAcrossTxs(t *testing.T) {
 
 		vm.FlushVersionedWrites(result.TxOut, true, "")
 
-		writes, err := result.creditTipPreValidate(task, vm, reader, s.rules)
-		require.NoError(t, err, "tx %d: creditTipPreValidate", txIdx)
+		writes, err := result.calcFees(task, vm, reader, s.rules)
+		require.NoError(t, err, "tx %d: calcFees", txIdx)
 
 		// Flush finalize writes so the next tx sees them via versionMap.
 		vm.FlushVersionedWrites(writes, true, "")
@@ -854,7 +855,7 @@ func TestFinalizeTxSimple_SenderIsCoinbase_ReExecutedIncarnation(t *testing.T) {
 	// Now flush the re-executed TxOut at incarnation 1.
 	vm.FlushVersionedWrites(result.TxOut, true, "")
 
-	writes, err := result.creditTipPreValidate(task, vm, reader, s.rules)
+	writes, err := result.calcFees(task, vm, reader, s.rules)
 	require.NoError(t, err)
 
 	coinbaseWrite := findWrite(writes, s.coinbase, state.BalancePath)
@@ -948,7 +949,7 @@ func TestFinalizeTxSimple_AccumulatedFees(t *testing.T) {
 		// Flush TxOut to versionMap (simulates line 1928).
 		vm.FlushVersionedWrites(result.TxOut, true, "")
 
-		writes, err := result.creditTipPreValidate(task, vm, reader, s.rules)
+		writes, err := result.calcFees(task, vm, reader, s.rules)
 		require.NoError(t, err)
 
 		// Flush finalize writes to versionMap for next TX.

--- a/execution/stagedsync/exec3_finalize_test.go
+++ b/execution/stagedsync/exec3_finalize_test.go
@@ -526,12 +526,11 @@ func (s *testFinalizeScenario) runFinalizeTx(t *testing.T, priorCoinbaseBalance 
 }
 
 // TestFinalizeTxSimple_BasicFeeCredit verifies that the apply-loop tip
-// credit adds FeeTipped to the coinbase balance from the versionMap.
-// Previously t.Skip'd under #20962: the prior code's vsReader at txIndex
-// (floor(txIdx-1)) didn't see a prior write stamped at TxIndex=0 when
-// the test ran at TxIndex=0. The new apply-loop step reads at
-// vm.Read(..., txIndex+1) = floor(txIndex), which includes the prior
-// write — same as IBS AddBalance.
+// credit adds FeeTipped to the coinbase balance. calcFees reads at
+// vm.Read(..., txIndex) = floor(txIndex-1), i.e. strictly prior tx; for
+// the test's TxIndex=0 case that falls through to stateReader (where
+// runFinalizeTx places the prior balance), and the worker's
+// current-tx execution effects come in via the TxOut scan.
 func TestFinalizeTxSimple_BasicFeeCredit(t *testing.T) {
 	t.Parallel()
 	s := simpleTransferScenario()

--- a/execution/stagedsync/exec3_finalize_test.go
+++ b/execution/stagedsync/exec3_finalize_test.go
@@ -1683,3 +1683,63 @@ func countPath(writes state.VersionedWrites, path state.AccountPath) int {
 	}
 	return n
 }
+
+// TestCalcFees_EmitsAddressPathForCoinbase pins the fix for the mainnet
+// block 25151825 tx 31 +25k gas bug. Background:
+//
+//   - Tx 31 SELFDESTRUCTs and CREATE2s the block coinbase
+//     (0xa8ca1e5afd68d7387ac7daefb7b3aa78fd7b3bc7) and CALLs it with value
+//     mid-tx — an MEV builder settlement pattern.
+//   - Coinbase has no pre-block storage record (fresh EOA-style address).
+//   - In serial-exec, prior txs (0-30) each call AddBalance(coinbase, tip)
+//     which CREATES the stateObject on first credit. By tx 31, the
+//     account exists with balance=accumulated tips, nonce=0, codeEmpty=true.
+//     CALL gas check: Empty(coinbase)=false (balance>0); no
+//     CallNewAccountGas (+25000).
+//   - In parallel-exec, calcFees previously wrote only BalancePath to the
+//     versionMap. Tx 31's getVersionedAccount(coinbase) returned nil
+//     (no AddressPath entry, no stateReader hit). Empty(coinbase)=true.
+//     CALL gas check fires CallNewAccountGas (+25000), inflating
+//     tx 31's gasUsed from 148,667 (serial) to 173,667 (parallel) and
+//     producing a wrong-trie-root.
+//
+// The fix: calcFees must emit an AddressPath sibling write alongside
+// BalancePath when crediting coinbase/burnt, mirroring what serial's
+// AddBalance does implicitly (create-on-first-credit). This makes the
+// account visible to downstream parallel-tx getVersionedAccount calls.
+//
+// This test verifies the contract: calcFees produces both
+// (coinbase, BalancePath) and (coinbase, AddressPath) writes, and the
+// AddressPath account's Balance matches the BalancePath value.
+func TestCalcFees_EmitsAddressPathForCoinbase(t *testing.T) {
+	t.Parallel()
+	s := simpleTransferScenario()
+
+	// No prior coinbase balance — first credit of the block.
+	writes := s.runFinalizeTx(t, nil)
+
+	coinbaseBalance := findWrite(writes, s.coinbase, state.BalancePath)
+	require.NotNil(t, coinbaseBalance,
+		"calcFees should emit coinbase BalancePath write")
+	balVal, ok := coinbaseBalance.Val.(uint256.Int)
+	require.True(t, ok, "BalancePath value must be uint256.Int")
+	require.Equal(t, s.feeTipped, balVal,
+		"BalancePath value must equal feeTipped (no prior balance)")
+
+	coinbaseAddress := findWrite(writes, s.coinbase, state.AddressPath)
+	require.NotNil(t, coinbaseAddress,
+		"calcFees MUST emit coinbase AddressPath sibling write so "+
+			"downstream parallel txs see the account record (mainnet "+
+			"25151825 tx 31 SD+CREATE2-on-coinbase +25k regression pin)")
+
+	addrAcc, ok := coinbaseAddress.Val.(*accounts.Account)
+	require.True(t, ok, "AddressPath value must be *accounts.Account")
+	require.NotNil(t, addrAcc, "AddressPath account must not be nil")
+	require.Equal(t, s.feeTipped, addrAcc.Balance,
+		"AddressPath account.Balance must equal the BalancePath value, "+
+			"otherwise downstream getVersionedAccount returns a stale balance")
+	require.True(t, addrAcc.IsEmptyCodeHash(),
+		"freshly-created coinbase has empty code (no pre-block contract)")
+	require.Equal(t, coinbaseBalance.Version, coinbaseAddress.Version,
+		"AddressPath sibling must share version with the BalancePath write")
+}

--- a/execution/stagedsync/exec3_finalize_test.go
+++ b/execution/stagedsync/exec3_finalize_test.go
@@ -490,9 +490,12 @@ func findWrite(writes state.VersionedWrites, addr accounts.Address, path state.A
 // These test the split fee logic: worker debits sender only,
 // finalize credits coinbase/burnt. No StripBalanceWrite or delta computation.
 
-// runFinalizeTxSimple sets up the versionMap with prior TX's finalize writes
-// and runs finalizeTxSimple, verifying the fee credit logic.
-func (s *testFinalizeScenario) runFinalizeTxSimple(t *testing.T, priorCoinbaseBalance *uint256.Int) state.VersionedWrites {
+// runFinalizeTx sets up the versionMap with prior TX's finalize writes and
+// runs the apply-loop tip credit (creditTipPreValidate). Returns the
+// tip-credit writes for assertion. finalizeTx itself only adds the receipt
+// and PostApplyMessage logs — no additional writes — so tests that assert
+// on writes need only the creditTipPreValidate output.
+func (s *testFinalizeScenario) runFinalizeTx(t *testing.T, priorCoinbaseBalance *uint256.Int) state.VersionedWrites {
 	t.Helper()
 	result := s.buildExecResult()
 	result.TxIn = copyReadSet(s.txIn)
@@ -510,33 +513,31 @@ func (s *testFinalizeScenario) runFinalizeTxSimple(t *testing.T, priorCoinbaseBa
 			state.Version{TxIndex: 0, Incarnation: 0}, *priorCoinbaseBalance, true)
 	}
 
-	// Flush the worker's TxOut to the versionMap (simulates line 1928).
+	// Flush the worker's TxOut to the versionMap (mirrors apply-loop's
+	// FlushVersionedWrites re-flush before validate).
 	vm.FlushVersionedWrites(result.TxOut, true, "")
 
 	task := result.Task.(*taskVersion)
-	txTask := task.Task.(*exec.TxTask)
 
-	_, _, writes, err := result.finalizeTxSimple(
-		task, txTask, nil, nil, vm, reader,
-		s.rules, false, false, "",
-	)
+	writes, err := result.creditTipPreValidate(task, vm, reader, s.rules)
 	require.NoError(t, err)
 	return writes
 }
 
-// TestFinalizeTxSimple_BasicFeeCredit verifies that finalizeTxSimple adds
-// FeeTipped to the coinbase balance from the versionMap.
+// TestFinalizeTxSimple_BasicFeeCredit verifies that the apply-loop tip
+// credit adds FeeTipped to the coinbase balance from the versionMap.
+// Previously t.Skip'd under #20962: the prior code's vsReader at txIndex
+// (floor(txIdx-1)) didn't see a prior write stamped at TxIndex=0 when
+// the test ran at TxIndex=0. The new apply-loop step reads at
+// vm.Read(..., txIndex+1) = floor(txIndex), which includes the prior
+// write — same as IBS AddBalance.
 func TestFinalizeTxSimple_BasicFeeCredit(t *testing.T) {
-	// TODO(#20962): scenario writes priorBalance into versionMap at TxIndex=0
-	// then reads at TxIndex=0; floor semantics changed and the prior write
-	// is no longer visible. Sibling AccumulatedFees test (txIdx 1..N) passes.
-	t.Skip("stale coinbase-handling expectation, see #20962")
 	t.Parallel()
 	s := simpleTransferScenario()
 
 	// Coinbase starts with 1 ETH (from prior TX's finalize).
 	priorBalance := uint256.NewInt(1_000_000_000_000_000_000)
-	writes := s.runFinalizeTxSimple(t, priorBalance)
+	writes := s.runFinalizeTx(t, priorBalance)
 
 	coinbaseWrite := findWrite(writes, s.coinbase, state.BalancePath)
 	require.NotNil(t, coinbaseWrite, "finalize should produce coinbase BalancePath write")
@@ -600,7 +601,7 @@ func TestFinalizeTxSimple_SenderIsCoinbase_TxOutValueWins(t *testing.T) {
 	})
 	// (s.collectorWrites left as the baseline — no coinbase BalancePath entry)
 
-	writes := s.runFinalizeTxSimple(t, nil /* no prior tx in this block */)
+	writes := s.runFinalizeTx(t, nil /* no prior tx in this block */)
 
 	coinbaseWrite := findWrite(writes, s.coinbase, state.BalancePath)
 	require.NotNil(t, coinbaseWrite, "finalize must produce a coinbase BalancePath write")
@@ -612,51 +613,16 @@ func TestFinalizeTxSimple_SenderIsCoinbase_TxOutValueWins(t *testing.T) {
 		postDebitBal, tip, expectedFinal, preBlockBal, tip, preBlockBal+tip)
 }
 
-// TestFinalizeTxSimple_SenderNotCoinbase_CollectorWritesValueWins is the
-// negative control for TxOutValueWins. Same TxOut shape (coinbase
-// BalancePath present), but sender != coinbase, so the senderIsCoinbase
-// discriminator falls into the else branch (scan CollectorWrites instead).
-//
-// CollectorWrites has NO coinbase BalancePath entry, so no override
-// happens — finalizeTxSimple uses the versionMap base + tip. Proves that
-// the senderIsCoinbase branch in TxOutValueWins is the load-bearing
-// reason that test passes (i.e. flipping just the sender flips the
-// outcome), rather than some unrelated code path masking the bug.
-func TestFinalizeTxSimple_SenderNotCoinbase_CollectorWritesValueWins(t *testing.T) {
-	t.Parallel()
-
-	// Use simpleTransferScenario: sender (fAddr("sender")) != coinbase
-	// (fAddr("coinbase")). No s.txs set → txTask.TxMessage() returns nil
-	// → senderIsCoinbase stays false → scans CollectorWrites only.
-	s := simpleTransferScenario()
-
-	// Force the same TxOut-only-coinbase shape as the positive test:
-	// coinbase BalancePath = some-non-zero value in TxOut, NO coinbase
-	// BalancePath in CollectorWrites. Pre-block coinbase balance is 0
-	// (from simpleTransferScenario.accts).
-	const (
-		txOutCoinbaseBal = uint64(979_000) // arbitrary "post-debit" value
-		preBlockCoinbase = uint64(0)       // simpleTransferScenario default
-		tip              = uint64(21_000)  // from scenario.feeTipped
-	)
-	s.txOut = append(s.txOut, &state.VersionedWrite{
-		Address: s.coinbase,
-		Path:    state.BalancePath,
-		Val:     *uint256.NewInt(txOutCoinbaseBal),
-	})
-	// CollectorWrites unchanged — no coinbase BalancePath entry in baseline.
-
-	writes := s.runFinalizeTxSimple(t, nil)
-
-	coinbaseWrite := findWrite(writes, s.coinbase, state.BalancePath)
-	require.NotNil(t, coinbaseWrite, "finalize should produce a coinbase BalancePath write")
-
-	got := coinbaseWrite.Val.(uint256.Int)
-	expected := uint256.NewInt(preBlockCoinbase + tip)
-	assert.Equal(t, *expected, got,
-		"sender != coinbase: finalize must use versionMap base (%d) + tip (%d) = %d, NOT TxOut value (%d) + tip = %d",
-		preBlockCoinbase, tip, preBlockCoinbase+tip, txOutCoinbaseBal, txOutCoinbaseBal+tip)
-}
+// (Removed: TestFinalizeTxSimple_SenderNotCoinbase_CollectorWritesValueWins
+// was a negative control for the prior code's senderIsCoinbase discriminator
+// — it asserted that flipping sender to non-coinbase made finalize ignore
+// TxOut and use versionMap base + tip. The new apply-loop creditTipPreValidate
+// step uses vm.Read(..., txIndex+1) for the base, which reads whatever is
+// most recently in versionMap at or before this tx — including the TxOut
+// entry flushed by the test setup. The discriminator code path no longer
+// exists, and the synthetic scenario the test constructed doesn't map to
+// any real execution behavior. The SenderIsCoinbase positive tests still
+// pin the correctness of the new read semantics.)
 
 // TestFinalizeTxSimple_SenderIsCoinbase_TxOutWinsOverCollectorWrites
 // strengthens TxOutValueWins by adding a coinbase BalancePath entry to
@@ -699,7 +665,7 @@ func TestFinalizeTxSimple_SenderIsCoinbase_TxOutWinsOverCollectorWrites(t *testi
 		Val:     *uint256.NewInt(collectorBal),
 	})
 
-	writes := s.runFinalizeTxSimple(t, nil)
+	writes := s.runFinalizeTx(t, nil)
 
 	coinbaseWrite := findWrite(writes, s.coinbase, state.BalancePath)
 	require.NotNil(t, coinbaseWrite, "finalize must produce coinbase BalancePath write")
@@ -743,7 +709,7 @@ func TestFinalizeTxSimple_SenderIsCoinbase_PostLondon(t *testing.T) {
 	// CollectorWrites: no coinbase, no burnt — finalize reads burnt base
 	// from versionMap (= burntPreBlockBal from scenario.accts) and adds burn.
 
-	writes := s.runFinalizeTxSimple(t, nil)
+	writes := s.runFinalizeTx(t, nil)
 
 	coinbaseWrite := findWrite(writes, s.coinbase, state.BalancePath)
 	require.NotNil(t, coinbaseWrite, "coinbase BalancePath write must exist")
@@ -819,12 +785,8 @@ func TestFinalizeTxSimple_SenderIsCoinbase_AccumulatedAcrossTxs(t *testing.T) {
 
 		vm.FlushVersionedWrites(result.TxOut, true, "")
 
-		txTask := task.Task.(*exec.TxTask)
-		_, _, writes, err := result.finalizeTxSimple(
-			task, txTask, nil, nil, vm, reader,
-			s.rules, false, false, "",
-		)
-		require.NoError(t, err, "tx %d: finalizeTxSimple", txIdx)
+		writes, err := result.creditTipPreValidate(task, vm, reader, s.rules)
+		require.NoError(t, err, "tx %d: creditTipPreValidate", txIdx)
 
 		// Flush finalize writes so the next tx sees them via versionMap.
 		vm.FlushVersionedWrites(writes, true, "")
@@ -892,11 +854,7 @@ func TestFinalizeTxSimple_SenderIsCoinbase_ReExecutedIncarnation(t *testing.T) {
 	// Now flush the re-executed TxOut at incarnation 1.
 	vm.FlushVersionedWrites(result.TxOut, true, "")
 
-	txTask := task.Task.(*exec.TxTask)
-	_, _, writes, err := result.finalizeTxSimple(
-		task, txTask, nil, nil, vm, reader,
-		s.rules, false, false, "",
-	)
+	writes, err := result.creditTipPreValidate(task, vm, reader, s.rules)
 	require.NoError(t, err)
 
 	coinbaseWrite := findWrite(writes, s.coinbase, state.BalancePath)
@@ -914,7 +872,7 @@ func TestFinalizeTxSimple_VersionOnWrites(t *testing.T) {
 	t.Parallel()
 	s := simpleTransferScenario()
 	priorBalance := uint256.NewInt(1_000_000_000_000_000_000)
-	writes := s.runFinalizeTxSimple(t, priorBalance)
+	writes := s.runFinalizeTx(t, priorBalance)
 
 	for _, w := range writes {
 		if w.Address == s.coinbase && w.Path == state.BalancePath {
@@ -936,7 +894,7 @@ func TestFinalizeTxSimple_LondonBurntFees(t *testing.T) {
 	t.Parallel()
 	s := londonTransferScenario()
 	priorBalance := uint256.NewInt(1_000_000_000_000_000_000)
-	writes := s.runFinalizeTxSimple(t, priorBalance)
+	writes := s.runFinalizeTx(t, priorBalance)
 
 	burntWrite := findWrite(writes, s.burntAddr, state.BalancePath)
 	require.NotNil(t, burntWrite, "finalize should produce burnt contract BalancePath write")
@@ -956,7 +914,7 @@ func TestFinalizeTxSimple_NoCoinbaseInVersionMap(t *testing.T) {
 	s := simpleTransferScenario()
 
 	// No prior coinbase balance — reads from stateReader (balance 0).
-	writes := s.runFinalizeTxSimple(t, nil)
+	writes := s.runFinalizeTx(t, nil)
 
 	coinbaseWrite := findWrite(writes, s.coinbase, state.BalancePath)
 	require.NotNil(t, coinbaseWrite, "finalize should produce coinbase BalancePath write")
@@ -990,11 +948,7 @@ func TestFinalizeTxSimple_AccumulatedFees(t *testing.T) {
 		// Flush TxOut to versionMap (simulates line 1928).
 		vm.FlushVersionedWrites(result.TxOut, true, "")
 
-		txTask := task.Task.(*exec.TxTask)
-		_, _, writes, err := result.finalizeTxSimple(
-			task, txTask, nil, nil, vm, reader,
-			s.rules, false, false, "",
-		)
+		writes, err := result.creditTipPreValidate(task, vm, reader, s.rules)
 		require.NoError(t, err)
 
 		// Flush finalize writes to versionMap for next TX.

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1698,6 +1698,30 @@ func (result *execResult) calcFees(
 				Version:             taskVersion,
 				BalanceChangeReason: tracing.BalanceIncreaseRewardTransactionFee,
 			})
+			// Emit an AddressPath sibling write so downstream parallel txs
+			// reading this address see an account record. Serial's AddBalance
+			// implicitly creates the account on first credit; parallel calcFees
+			// must mirror that, otherwise getVersionedAccount returns nil for
+			// a freshly-credited coinbase (no pre-block storage entry, no
+			// versionMap AddressPath) and Empty() returns true — charging the
+			// stale CallNewAccountGas (+25000) for a CALL-with-value to the
+			// coinbase mid-tx. Mainnet block 25151825 tx 31's SD+CREATE2-on-
+			// coinbase MEV pattern surfaced this divergence.
+			addrAcc := &accounts.Account{Balance: newCoinbaseBalance}
+			if coinbaseAcc != nil {
+				addrAcc.Nonce = coinbaseAcc.Nonce
+				addrAcc.Incarnation = coinbaseAcc.Incarnation
+				addrAcc.CodeHash = coinbaseAcc.CodeHash
+			} else {
+				addrAcc.Nonce = coinbaseNonce
+				addrAcc.CodeHash = accounts.EmptyCodeHash
+			}
+			addWrites = append(addWrites, &state.VersionedWrite{
+				Address: result.Coinbase,
+				Path:    state.AddressPath,
+				Val:     addrAcc,
+				Version: taskVersion,
+			})
 		}
 	}
 	if hasBurnt && newBurntBalance != oldBurntBalance {
@@ -1710,6 +1734,21 @@ func (result *execResult) calcFees(
 			Val:                 newBurntBalance,
 			Version:             taskVersion,
 			BalanceChangeReason: tracing.BalanceDecreaseGasBuy,
+		})
+		// Mirror the AddressPath emission above for the burnt address.
+		burntAddrAcc := &accounts.Account{Balance: newBurntBalance}
+		if burntAcc != nil {
+			burntAddrAcc.Nonce = burntAcc.Nonce
+			burntAddrAcc.Incarnation = burntAcc.Incarnation
+			burntAddrAcc.CodeHash = burntAcc.CodeHash
+		} else {
+			burntAddrAcc.CodeHash = accounts.EmptyCodeHash
+		}
+		addWrites = append(addWrites, &state.VersionedWrite{
+			Address: burntAddr,
+			Path:    state.AddressPath,
+			Val:     burntAddrAcc,
+			Version: taskVersion,
 		})
 	}
 

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1621,21 +1621,39 @@ func (result *execResult) calcFees(
 		}
 	}
 	// Worker writes coinbase/burnt to TxOut when sender matches (gas-debit
-	// applied to sender under shouldDelayFeeCalc=true).
+	// applied to sender under shouldDelayFeeCalc=true). Track Nonce / CodeHash
+	// alongside Balance so the EIP-161 empty-removal check below sees the
+	// worker's post-write coinbase state, not the stale pre-tx snapshot.
+	coinbaseNonce := uint64(0)
+	coinbaseHasCodeHashWrite := false
+	if coinbaseAcc != nil {
+		coinbaseNonce = coinbaseAcc.Nonce
+	}
+	coinbaseEmptyCodeHash := coinbaseAcc == nil || coinbaseAcc.IsEmptyCodeHash()
 	for _, w := range result.TxOut {
-		if w.Path != state.BalancePath {
+		if w.Address != result.Coinbase && (!hasBurnt || w.Address != burntAddr) {
 			continue
 		}
-		v, ok := w.Val.(uint256.Int)
-		if !ok {
-			continue
-		}
-		switch w.Address {
-		case result.Coinbase:
-			newCoinbaseBalance = v
-		case burntAddr:
-			if hasBurnt {
+		switch w.Path {
+		case state.BalancePath:
+			v, ok := w.Val.(uint256.Int)
+			if !ok {
+				continue
+			}
+			if w.Address == result.Coinbase {
+				newCoinbaseBalance = v
+			} else {
 				newBurntBalance = v
+			}
+		case state.NoncePath:
+			if w.Address == result.Coinbase {
+				if n, ok := w.Val.(uint64); ok {
+					coinbaseNonce = n
+				}
+			}
+		case state.CodeHashPath:
+			if w.Address == result.Coinbase {
+				coinbaseHasCodeHashWrite = true
 			}
 		}
 	}
@@ -1650,9 +1668,13 @@ func (result *execResult) calcFees(
 	// the coinbase must be "touched" so the commitment calculator sees the
 	// empty-account delete. Matches serial executor's AddBalance(coinbase, 0)
 	// → TouchAccount → MakeWriteSet emits a SelfDestructPath delete.
+	//
+	// Use the worker's post-write Nonce / CodeHash (not pre-tx coinbaseAcc) so
+	// that a sender==coinbase tx whose worker wrote a non-empty Nonce isn't
+	// mistakenly treated as empty here when FeeTipped==0.
 	emptyRemoval := chainRules.IsSpuriousDragon
 	coinbaseEmptyPre := coinbaseAcc == nil ||
-		(coinbaseAcc.Balance.IsZero() && coinbaseAcc.Nonce == 0 && coinbaseAcc.IsEmptyCodeHash())
+		(coinbaseAcc.Balance.IsZero() && coinbaseNonce == 0 && coinbaseEmptyCodeHash && !coinbaseHasCodeHashWrite)
 	emitCoinbase := newCoinbaseBalance != oldCoinbaseBalance ||
 		(emptyRemoval && coinbaseEmptyPre && newCoinbaseBalance.IsZero())
 
@@ -2298,8 +2320,15 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 		}
 
 		// Credit tip pre-validate for regular TXs so the validator sees the
-		// post-tip coinbase write. Downstream txs that read coinbase pre-tip
-		// invalidate through the standard version-mismatch path.
+		// post-tip coinbase write. Caveat: the tip write is stamped at the
+		// same (TxIndex, Incarnation) as the worker's coinbase write, so a
+		// downstream tx that read coinbase via versionMap between the worker
+		// write and the tip write records the same Version the validator
+		// observes — the version-only validator will NOT catch that case.
+		// In practice this is unusual: only sender==coinbase produces a
+		// worker coinbase write, and downstream BALANCE(coinbase) reads
+		// across this window are rare. Value-aware validation would close
+		// the gap if it surfaces.
 		if txVersion.TxIndex >= 0 && !txTask.IsBlockEnd() && txResult != nil && txResult.Err == nil {
 			taskVer, ok := txResult.Task.(*taskVersion)
 			if !ok {

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1498,7 +1498,7 @@ type execResult struct {
 	writes state.VersionedWrites
 }
 
-func (result *execResult) finalize(prevReceipt *types.Receipt, engine rules.Engine, vm *state.VersionMap, stateReader state.StateReader, stateWriter state.StateWriter, balActive bool) (*types.Receipt, state.ReadSet, state.VersionedWrites, error) {
+func (result *execResult) finalize(prevReceipt *types.Receipt, engine rules.Engine, vm *state.VersionMap, stateReader state.StateReader, stateWriter state.StateWriter) (*types.Receipt, state.ReadSet, state.VersionedWrites, error) {
 	task, ok := result.Task.(*taskVersion)
 
 	if !ok {
@@ -1512,18 +1512,15 @@ func (result *execResult) finalize(prevReceipt *types.Receipt, engine rules.Engi
 	txTrace := dbg.TraceTransactionIO &&
 		(dbg.TraceTx(blockNum, txIndex) || dbg.TraceAccount(result.Coinbase.Handle()) || dbg.TraceAccount(result.ExecutionResult.BurntContractAddress.Handle()))
 
-	var tracePrefix string
 	if txTrace {
-		tracePrefix = fmt.Sprintf("%d (%d.%d)", blockNum, txIndex, txIncarnation)
+		tracePrefix := fmt.Sprintf("%d (%d.%d)", blockNum, txIndex, txIncarnation)
 		fmt.Println(tracePrefix, "finalize")
 		defer fmt.Println(tracePrefix, "done finalize")
 	}
 
-	// With split fee logic: the worker debits the sender (gas payment +
-	// refund) but does NOT credit coinbase or burnt contract
-	// (shouldDelayFeeCalc=true → noFeeBurnAndTip=true). The finalize
-	// reads the correct coinbase/burnt base from the versionMap and
-	// adds FeeTipped/FeeBurnt. No StripBalanceWrite needed.
+	// Regular-tx tip credit ran in the apply loop's creditTipPreValidate
+	// step before validation, not here. finalize handles only the
+	// PostApplyMessage callback and receipt building.
 
 	txTask, ok := task.Task.(*exec.TxTask)
 
@@ -1547,10 +1544,7 @@ func (result *execResult) finalize(prevReceipt *types.Receipt, engine rules.Engi
 		return result.finalizeSystemTx(task, txTask, rules, vm, stateReader, stateWriter)
 	}
 
-	// Regular TXs: finalize reads correct coinbase/burnt base from
-	// versionMap, adds FeeTipped/FeeBurnt. No delta computation needed.
-	return result.finalizeTxSimple(task, txTask, prevReceipt, engine, vm, stateReader,
-		rules, balActive, txTrace, tracePrefix)
+	return result.finalizeTx(task, txTask, prevReceipt, engine, vm, stateReader)
 }
 
 // finalizeSystemTx handles block-end and system TXs (txIndex < 0) via full
@@ -1595,290 +1589,156 @@ func (result *execResult) finalizeSystemTx(
 	return nil, ibs.VersionedReads(), ibs.VersionedWrites(false), nil
 }
 
-// finalizeTxSimple handles regular TXs with split fee logic:
-// the worker debited the sender but did NOT credit coinbase/burnt
-// (shouldDelayFeeCalc=true). This function reads the correct coinbase/burnt
-// base from the versionMap and adds FeeTipped/FeeBurnt.
-func (result *execResult) finalizeTxSimple(
+// creditTipPreValidate is the apply-loop step that credits the priority
+// tip (FeeTipped) to the coinbase and the burnt amount (FeeBurnt) to the
+// burnt contract before this tx is validated. The worker ran with
+// shouldDelayFeeCalc=true (calcFees=false → ApplyMessageNoFeeBurnOrTip)
+// and skipped both credits; this method authors them.
+//
+// Read semantics mirror IBS AddBalance: vm.Read(..., txIndex+1) does
+// floor(txIndex), returning this tx's worker write if any, otherwise the
+// latest prior-tx settled value. No need for the senderIsCoinbase /
+// CollectorWrites discriminator the prior finalize-time path needed —
+// reading at the worker's own version naturally includes the worker's
+// contribution (e.g. the gas-debit for sender == coinbase miner self-sends).
+//
+// Writes go to versionMap at task.Version() — the SAME version as the
+// worker's writes — overwriting in place. No (Inc+1) masking writes.
+// The (Inc+1) trick existed to invalidate future txs that had read the
+// worker's pre-tip coinbase from versionMap; under same-version overwrite
+// the cell value updates but the cell version doesn't, so version-based
+// validate no longer catches that race. Real BALANCE(coinbase) reads are
+// rare enough in practice that this trade-off is accepted; if the race
+// surfaces, the validator can be made value-aware for MapRead reads.
+func (result *execResult) creditTipPreValidate(
+	task *taskVersion,
+	vm *state.VersionMap,
+	stateReader state.StateReader,
+	chainRules *chain.Rules,
+) (state.VersionedWrites, error) {
+	txIndex := task.Version().TxIndex
+	taskVersion := task.Version()
+
+	// vm.Read uses floor(txIdx-1) semantics, so passing txIndex+1 yields
+	// floor(txIndex) — this tx's worker write if present, else the prior
+	// tx's settled value. Same as IBS AddBalance's read step.
+	vsReader := state.NewVersionedStateReader(txIndex+1, nil, vm, stateReader)
+
+	coinbaseAcc, err := vsReader.ReadAccountData(result.Coinbase)
+	if err != nil {
+		return nil, err
+	}
+	var newCoinbaseBalance uint256.Int
+	if coinbaseAcc != nil {
+		newCoinbaseBalance = coinbaseAcc.Balance
+	}
+	oldCoinbaseBalance := newCoinbaseBalance
+	newCoinbaseBalance.Add(&newCoinbaseBalance, &result.ExecutionResult.FeeTipped)
+
+	burntAddr := result.ExecutionResult.BurntContractAddress
+	hasBurnt := !burntAddr.IsNil()
+	var newBurntBalance, oldBurntBalance uint256.Int
+	var burntAcc *accounts.Account
+	if hasBurnt {
+		burntAcc, err = vsReader.ReadAccountData(burntAddr)
+		if err != nil {
+			return nil, err
+		}
+		if burntAcc != nil {
+			newBurntBalance = burntAcc.Balance
+		}
+		oldBurntBalance = newBurntBalance
+		if chainRules.IsLondon {
+			newBurntBalance.Add(&newBurntBalance, &result.ExecutionResult.FeeBurnt)
+		}
+	}
+
+	// EIP-161 empty-removal: even when the tip is zero (newBal == oldBal)
+	// the coinbase must be "touched" so the commitment calculator sees the
+	// empty-account delete. Matches serial executor's AddBalance(coinbase, 0)
+	// → TouchAccount → MakeWriteSet emits a SelfDestructPath delete.
+	emptyRemoval := chainRules.IsSpuriousDragon
+	coinbaseEmptyPre := coinbaseAcc == nil ||
+		(coinbaseAcc.Balance.IsZero() && coinbaseAcc.Nonce == 0 && coinbaseAcc.IsEmptyCodeHash())
+	emitCoinbase := newCoinbaseBalance != oldCoinbaseBalance ||
+		(emptyRemoval && coinbaseEmptyPre && newCoinbaseBalance.IsZero())
+
+	var addWrites state.VersionedWrites
+	if emitCoinbase {
+		// Update CollectorWrites for the BlockStateCache view.
+		result.CollectorWrites = result.CollectorWrites.SetAccountBalanceOrDelete(
+			result.Coinbase, coinbaseAcc, newCoinbaseBalance,
+			tracing.BalanceIncreaseRewardTransactionFee, emptyRemoval)
+		// Emit at task.Version() — same incarnation as the worker. The
+		// worker's pre-tip coinbase write (if any) is overwritten in place
+		// by this post-tip value.
+		if emptyRemoval && coinbaseEmptyPre && newCoinbaseBalance.IsZero() {
+			addWrites = append(addWrites, &state.VersionedWrite{
+				Address: result.Coinbase,
+				Path:    state.SelfDestructPath,
+				Val:     true,
+				Version: taskVersion,
+			})
+		} else {
+			addWrites = append(addWrites, &state.VersionedWrite{
+				Address:             result.Coinbase,
+				Path:                state.BalancePath,
+				Val:                 newCoinbaseBalance,
+				Version:             taskVersion,
+				BalanceChangeReason: tracing.BalanceIncreaseRewardTransactionFee,
+			})
+		}
+	}
+	if hasBurnt && newBurntBalance != oldBurntBalance {
+		result.CollectorWrites = result.CollectorWrites.SetAccountBalanceOrDelete(
+			burntAddr, burntAcc, newBurntBalance,
+			tracing.BalanceDecreaseGasBuy, emptyRemoval)
+		addWrites = append(addWrites, &state.VersionedWrite{
+			Address:             burntAddr,
+			Path:                state.BalancePath,
+			Val:                 newBurntBalance,
+			Version:             taskVersion,
+			BalanceChangeReason: tracing.BalanceDecreaseGasBuy,
+		})
+	}
+
+	return addWrites, nil
+}
+
+// finalizeTx handles regular TXs after the apply-loop tip credit
+// (creditTipPreValidate) has already authored the post-tip versionMap
+// writes. This function runs the engine's PostApplyMessage callback
+// (e.g. AuRa system calls, EIP-7708 burn-log emission via
+// LogSelfDestructedAccounts) and builds the receipt.
+//
+// Renamed from finalizeTxSimple — the bookkeeping that motivated the
+// "simple" tag (split fee logic, source-discriminator scanning,
+// (Inc+1) masking writes) all moved into creditTipPreValidate; what
+// remains is the receipt-and-PostApplyMessage tail.
+func (result *execResult) finalizeTx(
 	task *taskVersion,
 	txTask *exec.TxTask,
 	prevReceipt *types.Receipt,
 	engine rules.Engine,
 	vm *state.VersionMap,
 	stateReader state.StateReader,
-	chainRules *chain.Rules,
-	balActive bool,
-	txTrace bool, tracePrefix string,
 ) (*types.Receipt, state.ReadSet, state.VersionedWrites, error) {
-	blockNum := task.Version().BlockNum
-	txIndex := task.Version().TxIndex
-
-	// Read coinbase/burnt base from the versionMap. Use txIndex (NOT
-	// txIndex+1) so versionMap.Read(floor(txIndex)) returns the PRIOR
-	// tx's cumulative balance — the correct base before this tx's tip.
-	// When the block has a BAL sidecar, the versionMap is pre-populated
-	// with the BAL's per-tx cumulative values via NewVersionMap →
-	// WriteChanges. Reading at txIndex+1 would return THIS tx's BAL
-	// entry (already includes its own tip), and adding FeeTipped on top
-	// would double-count. The current tx's worker writes (e.g. ETH
-	// transfers to coinbase) are picked up below via CollectorWrites.
-	vsReader := state.NewVersionedStateReader(txIndex, nil, vm, stateReader)
-
-	// --- Coinbase: base (including execution effects) + FeeTipped ---
-	coinbaseAcc, err := vsReader.ReadAccountData(result.Coinbase)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	// Start from the versionMap base (correct accumulated balance from
-	// prior finalizes). If the worker's execution also sent ETH to the
-	// coinbase (via CALL with value), CollectorWrites has the execution-
-	// adjusted balance. We must account for both the execution delta
-	// and the fee tip.
-	var newCoinbaseBalance uint256.Int
-	if coinbaseAcc != nil {
-		newCoinbaseBalance = coinbaseAcc.Balance
-	}
-	// Detect the worker's coinbase Balance write so we can start the
-	// finalize from the worker's post-execution value rather than the
-	// pre-tx versionMap value. Scan result.TxOut (the raw worker output,
-	// where every intermediate write lands) — NOT result.CollectorWrites,
-	// which is the IBS's "net change" set and SUPPRESSES the coinbase
-	// entry when sender == coinbase and the per-tx net balance change is
-	// zero in the IBS's view (e.g. Frontier miner-self-send: gas pre-pay
-	// + value-transfer + refund net to zero in the IBS journal, but the
-	// worker's intermediate balance under shouldDelayFeeCalc=true still
-	// debited the gas-used portion which the finalize must re-credit via
-	// the tip).
-	//
-	// Without this, finalize uses the stale pre-tx versionMap value as
-	// base and adds the tip on top — over-crediting the coinbase by one
-	// tip per sender==coinbase tx. Observed at mainnet block 218957 with
-	// canonical/parallel divergence of exactly one tip (1.05e15 wei).
-	// Detect the worker's coinbase write. Two cases produce a coinbase
-	// Balance write from the worker's execution:
-	//   1. sender == coinbase — the worker's gas-pre-pay debit lands on
-	//      the coinbase address. For Frontier-era miner self-sends this
-	//      is the load-bearing case (#21017, block 218957) where the
-	//      CollectorWrites set suppresses the entry due to per-tx net
-	//      balance change == 0.
-	//   2. sender != coinbase but the tx body does a balance transfer to
-	//      the coinbase (CALL with value, SELFDESTRUCT beneficiary, etc.)
-	//      — historically read from CollectorWrites because the IBS's
-	//      net-change view captures the explicit transfer correctly.
-	//
-	// For #1 we MUST scan TxOut (the raw worker output), because that's
-	// where the gas debit lives. For #2 we scan CollectorWrites, because
-	// TxOut can contain artifact entries (e.g. SELFDESTRUCT bookkeeping
-	// that touches the zero address when coinbase == zero address) that
-	// would mislead us. Switch source by the sender-vs-coinbase test.
-	workerWroteCoinbase := false
-	senderIsCoinbase := false
-	if msg, err := txTask.TxMessage(); err == nil && msg != nil {
-		senderIsCoinbase = (msg.From() == result.Coinbase)
-	}
-	if senderIsCoinbase {
-		for _, w := range result.TxOut {
-			if w.Address == result.Coinbase && w.Path == state.BalancePath {
-				workerWroteCoinbase = true
-				if execBal, ok := w.Val.(uint256.Int); ok {
-					newCoinbaseBalance = execBal
-				}
-				break
-			}
-		}
-	} else if result.CollectorWrites != nil {
-		for _, w := range result.CollectorWrites {
-			if w.Address == result.Coinbase && w.Path == state.BalancePath {
-				workerWroteCoinbase = true
-				if execBal, ok := w.Val.(uint256.Int); ok {
-					newCoinbaseBalance = execBal
-				}
-				break
-			}
-		}
-	}
-	newCoinbaseBalance.Add(&newCoinbaseBalance, &result.ExecutionResult.FeeTipped)
-
-	// --- Burnt contract: base + FeeBurnt ---
-	var newBurntBalance uint256.Int
-	var burntAcc *accounts.Account
 	burntAddr := result.ExecutionResult.BurntContractAddress
 	hasBurnt := !burntAddr.IsNil()
-	workerWroteBurnt := false
-	if hasBurnt {
-		burntAcc, err = vsReader.ReadAccountData(burntAddr)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		if burntAcc != nil {
-			newBurntBalance = burntAcc.Balance
-		}
-		// Mirror the coinbase source-selection rule: scan TxOut only when
-		// the burnt contract is the sender (analogous to the
-		// sender==coinbase miner-self-send case); otherwise scan
-		// CollectorWrites so we don't pick up artifact entries.
-		senderIsBurnt := false
-		if msg, err := txTask.TxMessage(); err == nil && msg != nil {
-			senderIsBurnt = (msg.From() == burntAddr)
-		}
-		if senderIsBurnt {
-			for _, w := range result.TxOut {
-				if w.Address == burntAddr && w.Path == state.BalancePath {
-					workerWroteBurnt = true
-					if execBal, ok := w.Val.(uint256.Int); ok {
-						newBurntBalance = execBal
-					}
-					break
-				}
-			}
-		} else if result.CollectorWrites != nil {
-			for _, w := range result.CollectorWrites {
-				if w.Address == burntAddr && w.Path == state.BalancePath {
-					workerWroteBurnt = true
-					if execBal, ok := w.Val.(uint256.Int); ok {
-						newBurntBalance = execBal
-					}
-					break
-				}
-			}
-		}
-		if txTask.Config.IsLondon(blockNum) {
-			newBurntBalance.Add(&newBurntBalance, &result.ExecutionResult.FeeBurnt)
-		}
-	}
-
-	// Update CollectorWrites with fee-adjusted balances.
-	emptyRemoval := chainRules.IsSpuriousDragon
-	coinbaseEmptyPre := coinbaseAcc == nil ||
-		(coinbaseAcc.Balance.IsZero() && coinbaseAcc.Nonce == 0 && coinbaseAcc.IsEmptyCodeHash())
-	var oldCoinbaseBalance uint256.Int
-	if coinbaseAcc != nil {
-		oldCoinbaseBalance = coinbaseAcc.Balance
-	}
-	// Match the serial executor: even when no fee is being credited
-	// (tipped == 0 means newBalance == oldBalance) the coinbase must be
-	// "touched" so the commitment calculator sees the EIP-161
-	// empty-removal delete.
-	//
-	// Also emit when the worker wrote to the coinbase BalancePath: the
-	// worker's incarnation-0 write went to versionMap with the pre-fee
-	// value; the finalize-fee write at incarnation+1 must land regardless
-	// of value equality so it masks the stale worker entry. Covers the
-	// Frontier miner-self-send case where (in IBS terms) net balance
-	// change is zero but versionMap carries a stale intermediate value.
-	emitCoinbase := newCoinbaseBalance != oldCoinbaseBalance ||
-		workerWroteCoinbase ||
-		(emptyRemoval && coinbaseEmptyPre && newCoinbaseBalance.IsZero())
-	if emitCoinbase {
-		result.CollectorWrites = result.CollectorWrites.SetAccountBalanceOrDelete(
-			result.Coinbase, coinbaseAcc, newCoinbaseBalance, tracing.BalanceIncreaseRewardTransactionFee, emptyRemoval)
-	}
-	if hasBurnt {
-		var oldBurntBalance uint256.Int
-		if burntAcc != nil {
-			oldBurntBalance = burntAcc.Balance
-		}
-		// Same staleness-masking reasoning as coinbase above.
-		if newBurntBalance != oldBurntBalance || workerWroteBurnt {
-			result.CollectorWrites = result.CollectorWrites.SetAccountBalanceOrDelete(
-				burntAddr, burntAcc, newBurntBalance, tracing.BalanceDecreaseGasBuy, emptyRemoval)
-		}
-	}
-
-	// Build versionMap writes: TxOut (no coinbase/burnt since worker skipped
-	// fee credit) plus the fee-adjusted balance writes.
-	//
-	// When sender == coinbase (or sender == burntAddr) the worker's TxOut
-	// already contains a (sender, BalancePath) entry with the *pre-fee*
-	// balance, and we're about to append a second (coinbase, BalancePath)
-	// entry with the *post-fee* balance. Both entries have identical
-	// (Address, Path, Key) — they only differ on Val. Downstream consumers
-	// either pass this slice through ibs.ApplyVersionedWrites — which calls
-	// sort.Slice (unstable) — or feed it into a MergeVersionedWrites loop
-	// where the LAST iterator-visited entry wins. With two equal-key entries
-	// the unstable sort orders them arbitrarily, so MergeVersionedWrites
-	// flips between picking pre-fee and post-fee per run, and the validator
-	// BAL coinbase balance lands pre-fee (missing the priority tip).
-	//
-	// Drop the worker's TxOut (sender, BalancePath) entry when sender ==
-	// coinbase/burntAddr: the fee-adjusted append below is the authoritative
-	// post-fee value, and the post-apply IBS reconstruction at the end of
-	// this function applies BalancePath via SetBalance which is idempotent
-	// w.r.t. the worker's pre-fee write anyway.
-	allWrites := make(state.VersionedWrites, 0, len(result.TxOut)+2)
-	for _, w := range result.TxOut {
-		if w.Path == state.BalancePath && (w.Address == result.Coinbase || (hasBurnt && w.Address == burntAddr)) {
-			continue
-		}
-		allWrites = append(allWrites, w)
-	}
-	// The coinbase/burnt fee credits are implicit writes: the worker ran
-	// with shouldDelayFeeCalc=true and never produced them, so finalize
-	// authors them here. Stamp them at incarnation+1 — a distinct version
-	// from the worker's own pre-fee coinbase/burnt write. A later tx that
-	// speculatively read the coinbase/burnt before this finalize ran
-	// recorded the worker's version; the bumped version makes the MapRead
-	// checkVersion comparison fail, so that tx is invalidated and
-	// re-executed against the post-fee balance. Without the bump finalize
-	// reuses the worker's version and the version-only validator cannot
-	// tell the stale read apart.
-	feeVersion := task.Version()
-	feeVersion.Incarnation++
-	// Mirror the CollectorWrites emission above: emit the coinbase
-	// versionMap write either when balance actually changed OR when
-	// EIP-161 empty-removal will turn the empty coinbase into a delete.
-	if emitCoinbase {
-		if emptyRemoval && coinbaseEmptyPre && newCoinbaseBalance.IsZero() {
-			allWrites = append(allWrites, &state.VersionedWrite{
-				Address: result.Coinbase,
-				Path:    state.SelfDestructPath,
-				Val:     true,
-				Version: task.Version(),
-			})
-		} else {
-			allWrites = append(allWrites, &state.VersionedWrite{
-				Address:             result.Coinbase,
-				Path:                state.BalancePath,
-				Val:                 newCoinbaseBalance,
-				Version:             feeVersion,
-				BalanceChangeReason: tracing.BalanceIncreaseRewardTransactionFee,
-			})
-		}
-	}
-	if hasBurnt {
-		var oldBurntBalance uint256.Int
-		if burntAcc != nil {
-			oldBurntBalance = burntAcc.Balance
-		}
-		// Same staleness-masking reasoning as coinbase above.
-		if newBurntBalance != oldBurntBalance || workerWroteBurnt {
-			allWrites = append(allWrites, &state.VersionedWrite{
-				Address:             burntAddr,
-				Path:                state.BalancePath,
-				Val:                 newBurntBalance,
-				Version:             feeVersion,
-				BalanceChangeReason: tracing.BalanceDecreaseGasBuy,
-			})
-		}
-	}
 
 	// Engine post-apply message (e.g., AuRa system calls, EIP-7708 burn logs).
 	if err := result.runPostApplyMessageOnMinIBS(task, txTask, engine, vm, stateReader, hasBurnt, burntAddr); err != nil {
 		return nil, nil, nil, err
 	}
 
-	// Compute receipt.
+	// Compute receipt. Tip-credit writes for coinbase/burnt are authored
+	// separately by creditTipPreValidate (called from the apply loop
+	// before validate); finalizeTx returns no addWrites.
 	receipt, err := result.CreateNextReceipt(prevReceipt)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-
-	// The finalize reads (coinbase/burnt base) come from vsReader which
-	// doesn't track reads. These reads are implicit — the versionMap
-	// entries from the finalize's writes will cause invalidation of
-	// subsequent TXs that read stale coinbase/burnt values.
-
-	return receipt, nil, allWrites, nil
+	return receipt, nil, nil, nil
 }
 
 // runPostApplyMessageOnMinIBS runs the engine's PostApplyMessage callback
@@ -2547,11 +2407,49 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 
 				collector := state.NewVersionedWriteCollector(pe.rs)
 
-				balActive := pe.cfg.experimentalBAL || pe.cfg.chainConfig.IsAmsterdam(txTask.BlockTime())
-				_, addReads, addWrites, err := txResult.finalize(prevReceipt, pe.cfg.engine, be.versionMap, stateReader, collector, balActive)
+				// Apply-loop tip credit: for regular TXs, author the
+				// coinbase/burnt post-tip writes BEFORE finalize. The
+				// validator now sees the tip-adjusted versionMap (relevant
+				// to the NEXT tx's validate, which reads from versionMap
+				// via floor lookup); this tx's own reads are unaffected
+				// since they use floor(txIndex-1) semantics. See
+				// creditTipPreValidate docstring for the version-stamping
+				// rationale.
+				//
+				// Block-end / system TXs are skipped here — they carry no
+				// tip and go through finalizeSystemTx (full IBS
+				// reconstruction) via the finalize dispatcher. The
+				// dispatcher's branch in finalize() uses the SAME
+				// predicate (txIndex<0 || IsBlockEnd).
+				var tipWrites state.VersionedWrites
+				if txVersion.TxIndex >= 0 && !txTask.IsBlockEnd() {
+					taskVer, ok := txResult.Task.(*taskVersion)
+					if !ok {
+						return nil, fmt.Errorf("apply loop: unexpected task type for tx %d: result.Task=%T", tx, txResult.Task)
+					}
+					chainRules := txTask.Rules()
+					var err error
+					tipWrites, err = txResult.creditTipPreValidate(taskVer, be.versionMap, stateReader, chainRules)
+					if err != nil {
+						return nil, err
+					}
+				}
 
+				// finalize returns no addWrites for regular TXs (tip credit
+				// moved out); finalizeSystemTx still returns a write set for
+				// block-end / system TXs via full IBS reconstruction. Keep
+				// both paths' writes for the merge below.
+				_, addReads, finalizeWrites, err := txResult.finalize(prevReceipt, pe.cfg.engine, be.versionMap, stateReader, collector)
 				if err != nil {
 					return nil, err
+				}
+				addWrites := finalizeWrites
+				if len(tipWrites) > 0 {
+					if len(addWrites) == 0 {
+						addWrites = tipWrites
+					} else {
+						addWrites = MergeVersionedWrites(addWrites, tipWrites)
+					}
 				}
 
 				// Merge any additional reads/writes produced during finalize (fee calc, post apply, etc)

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1518,10 +1518,6 @@ func (result *execResult) finalize(prevReceipt *types.Receipt, engine rules.Engi
 		defer fmt.Println(tracePrefix, "done finalize")
 	}
 
-	// Regular-tx tip credit ran in the apply loop's creditTipPreValidate
-	// step before validation, not here. finalize handles only the
-	// PostApplyMessage callback and receipt building.
-
 	txTask, ok := task.Task.(*exec.TxTask)
 
 	if !ok {
@@ -1589,28 +1585,7 @@ func (result *execResult) finalizeSystemTx(
 	return nil, ibs.VersionedReads(), ibs.VersionedWrites(false), nil
 }
 
-// creditTipPreValidate is the apply-loop step that credits the priority
-// tip (FeeTipped) to the coinbase and the burnt amount (FeeBurnt) to the
-// burnt contract before this tx is validated. The worker ran with
-// shouldDelayFeeCalc=true (calcFees=false → ApplyMessageNoFeeBurnOrTip)
-// and skipped both credits; this method authors them.
-//
-// Read semantics mirror IBS AddBalance: vm.Read(..., txIndex+1) does
-// floor(txIndex), returning this tx's worker write if any, otherwise the
-// latest prior-tx settled value. No need for the senderIsCoinbase /
-// CollectorWrites discriminator the prior finalize-time path needed —
-// reading at the worker's own version naturally includes the worker's
-// contribution (e.g. the gas-debit for sender == coinbase miner self-sends).
-//
-// Writes go to versionMap at task.Version() — the SAME version as the
-// worker's writes — overwriting in place. No (Inc+1) masking writes.
-// The (Inc+1) trick existed to invalidate future txs that had read the
-// worker's pre-tip coinbase from versionMap; under same-version overwrite
-// the cell value updates but the cell version doesn't, so version-based
-// validate no longer catches that race. Real BALANCE(coinbase) reads are
-// rare enough in practice that this trade-off is accepted; if the race
-// surfaces, the validator can be made value-aware for MapRead reads.
-func (result *execResult) creditTipPreValidate(
+func (result *execResult) calcFees(
 	task *taskVersion,
 	vm *state.VersionMap,
 	stateReader state.StateReader,
@@ -1619,10 +1594,10 @@ func (result *execResult) creditTipPreValidate(
 	txIndex := task.Version().TxIndex
 	taskVersion := task.Version()
 
-	// vm.Read uses floor(txIdx-1) semantics, so passing txIndex+1 yields
-	// floor(txIndex) — this tx's worker write if present, else the prior
-	// tx's settled value. Same as IBS AddBalance's read step.
-	vsReader := state.NewVersionedStateReader(txIndex+1, nil, vm, stateReader)
+	// Read at txIndex (floor txIndex-1) — strictly prior tx, excluding this tx's
+	// own prior incarnations that would double-apply the tip on re-execution.
+	// Worker writes for the current tx are picked up below via TxOut.
+	vsReader := state.NewVersionedStateReader(txIndex, nil, vm, stateReader)
 
 	coinbaseAcc, err := vsReader.ReadAccountData(result.Coinbase)
 	if err != nil {
@@ -1632,12 +1607,9 @@ func (result *execResult) creditTipPreValidate(
 	if coinbaseAcc != nil {
 		newCoinbaseBalance = coinbaseAcc.Balance
 	}
-	oldCoinbaseBalance := newCoinbaseBalance
-	newCoinbaseBalance.Add(&newCoinbaseBalance, &result.ExecutionResult.FeeTipped)
-
 	burntAddr := result.ExecutionResult.BurntContractAddress
 	hasBurnt := !burntAddr.IsNil()
-	var newBurntBalance, oldBurntBalance uint256.Int
+	var newBurntBalance uint256.Int
 	var burntAcc *accounts.Account
 	if hasBurnt {
 		burntAcc, err = vsReader.ReadAccountData(burntAddr)
@@ -1647,10 +1619,31 @@ func (result *execResult) creditTipPreValidate(
 		if burntAcc != nil {
 			newBurntBalance = burntAcc.Balance
 		}
-		oldBurntBalance = newBurntBalance
-		if chainRules.IsLondon {
-			newBurntBalance.Add(&newBurntBalance, &result.ExecutionResult.FeeBurnt)
+	}
+	// Worker writes coinbase/burnt to TxOut when sender matches (gas-debit
+	// applied to sender under shouldDelayFeeCalc=true).
+	for _, w := range result.TxOut {
+		if w.Path != state.BalancePath {
+			continue
 		}
+		v, ok := w.Val.(uint256.Int)
+		if !ok {
+			continue
+		}
+		switch w.Address {
+		case result.Coinbase:
+			newCoinbaseBalance = v
+		case burntAddr:
+			if hasBurnt {
+				newBurntBalance = v
+			}
+		}
+	}
+	oldCoinbaseBalance := newCoinbaseBalance
+	newCoinbaseBalance.Add(&newCoinbaseBalance, &result.ExecutionResult.FeeTipped)
+	oldBurntBalance := newBurntBalance
+	if hasBurnt && chainRules.IsLondon {
+		newBurntBalance.Add(&newBurntBalance, &result.ExecutionResult.FeeBurnt)
 	}
 
 	// EIP-161 empty-removal: even when the tip is zero (newBal == oldBal)
@@ -1665,13 +1658,9 @@ func (result *execResult) creditTipPreValidate(
 
 	var addWrites state.VersionedWrites
 	if emitCoinbase {
-		// Update CollectorWrites for the BlockStateCache view.
 		result.CollectorWrites = result.CollectorWrites.SetAccountBalanceOrDelete(
 			result.Coinbase, coinbaseAcc, newCoinbaseBalance,
 			tracing.BalanceIncreaseRewardTransactionFee, emptyRemoval)
-		// Emit at task.Version() — same incarnation as the worker. The
-		// worker's pre-tip coinbase write (if any) is overwritten in place
-		// by this post-tip value.
 		if emptyRemoval && coinbaseEmptyPre && newCoinbaseBalance.IsZero() {
 			addWrites = append(addWrites, &state.VersionedWrite{
 				Address: result.Coinbase,
@@ -1705,16 +1694,6 @@ func (result *execResult) creditTipPreValidate(
 	return addWrites, nil
 }
 
-// finalizeTx handles regular TXs after the apply-loop tip credit
-// (creditTipPreValidate) has already authored the post-tip versionMap
-// writes. This function runs the engine's PostApplyMessage callback
-// (e.g. AuRa system calls, EIP-7708 burn-log emission via
-// LogSelfDestructedAccounts) and builds the receipt.
-//
-// Renamed from finalizeTxSimple — the bookkeeping that motivated the
-// "simple" tag (split fee logic, source-discriminator scanning,
-// (Inc+1) masking writes) all moved into creditTipPreValidate; what
-// remains is the receipt-and-PostApplyMessage tail.
 func (result *execResult) finalizeTx(
 	task *taskVersion,
 	txTask *exec.TxTask,
@@ -1731,9 +1710,6 @@ func (result *execResult) finalizeTx(
 		return nil, nil, nil, err
 	}
 
-	// Compute receipt. Tip-credit writes for coinbase/burnt are authored
-	// separately by creditTipPreValidate (called from the apply loop
-	// before validate); finalizeTx returns no addWrites.
 	receipt, err := result.CreateNextReceipt(prevReceipt)
 	if err != nil {
 		return nil, nil, nil, err
@@ -2311,12 +2287,40 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 
 		tx := toValidate[i]
 		txVersion := be.tasks[tx].Task.Version()
+		txTask := be.tasks[tx].Task
+		txResult := be.results[tx]
 
 		var trace bool
 		var tracePrefix string
 
 		if trace = dbg.TraceTransactionIO && dbg.TraceTx(be.blockNum, txVersion.TxIndex); trace {
 			tracePrefix = fmt.Sprintf("%d (%d.%d)", be.blockNum, txVersion.TxIndex, txVersion.Incarnation)
+		}
+
+		// Credit tip pre-validate for regular TXs so the validator sees the
+		// post-tip coinbase write. Downstream txs that read coinbase pre-tip
+		// invalidate through the standard version-mismatch path.
+		if txVersion.TxIndex >= 0 && !txTask.IsBlockEnd() && txResult != nil && txResult.Err == nil {
+			taskVer, ok := txResult.Task.(*taskVersion)
+			if !ok {
+				return nil, fmt.Errorf("apply loop: unexpected task type for tx %d: result.Task=%T", tx, txResult.Task)
+			}
+			if stateReader == nil {
+				if txTask.IsHistoric() {
+					stateReader = state.NewHistoryReaderV3WithBlockCache(applyTx, pe.rs.Domains(), be.blockStateCache, txTask.Version().TxNum)
+				} else {
+					stateReader = state.NewCurrentCachedReaderV3(pe.rs.Domains().AsGetter(applyTx), be.blockStateCache)
+				}
+			}
+			tipWrites, err := txResult.calcFees(taskVer, be.versionMap, stateReader, txTask.Rules())
+			if err != nil {
+				return nil, err
+			}
+			if len(tipWrites) > 0 {
+				existingWrites := be.blockIO.WriteSet(txVersion.TxIndex)
+				merged := MergeVersionedWrites(existingWrites, tipWrites)
+				be.blockIO.RecordWrites(txVersion, merged)
+			}
 		}
 
 		validity := be.versionMap.ValidateVersion(txVersion.TxIndex, be.blockIO,
@@ -2351,7 +2355,6 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 			if cntInvalid == 0 {
 				be.validateTasks.markComplete(tx)
 
-				txResult := be.results[tx]
 				be.finalizedResults[tx] = txResult
 
 				var prevReceipt *types.Receipt
@@ -2360,8 +2363,6 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 						prevReceipt = prev.Receipt
 					}
 				}
-
-				txTask := be.tasks[tx].Task
 
 				if txn := txTask.Tx(); txn != nil {
 					regularContribution, stateContribution := protocol.InclusionContributions(txn.GetGasLimit(), txResult.ExecutionResult.IntrinsicGas, txTask.Rules().IsAmsterdam)
@@ -2387,70 +2388,19 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 
 				if stateReader == nil {
 					if txTask.IsHistoric() {
-						// Chain blockCache → sd.mem → applyTx so historic-mode
-						// finalize reads see every prior-tx write from the
-						// current block. The per-tx finalize path (fee calc,
-						// post-apply hooks) uses this reader for base reads
-						// not satisfied by the versionMap; omitting blockCache
-						// would let a later tx read a pre-block balance that
-						// an earlier tx already updated in-batch.
 						stateReader = state.NewHistoryReaderV3WithBlockCache(applyTx, pe.rs.Domains(), be.blockStateCache, txTask.Version().TxNum)
 					} else {
-						// Use CachedReaderV3 with readCurrent=true so the
-						// finalize (including system TXs) reads from the
-						// BlockStateCache write buffer. This ensures the
-						// system TX sees all accumulated state from prior
-						// TXs in the block, not stale sd.mem values.
 						stateReader = state.NewCurrentCachedReaderV3(pe.rs.Domains().AsGetter(applyTx), be.blockStateCache)
 					}
 				}
 
 				collector := state.NewVersionedWriteCollector(pe.rs)
 
-				// Apply-loop tip credit: for regular TXs, author the
-				// coinbase/burnt post-tip writes BEFORE finalize. The
-				// validator now sees the tip-adjusted versionMap (relevant
-				// to the NEXT tx's validate, which reads from versionMap
-				// via floor lookup); this tx's own reads are unaffected
-				// since they use floor(txIndex-1) semantics. See
-				// creditTipPreValidate docstring for the version-stamping
-				// rationale.
-				//
-				// Block-end / system TXs are skipped here — they carry no
-				// tip and go through finalizeSystemTx (full IBS
-				// reconstruction) via the finalize dispatcher. The
-				// dispatcher's branch in finalize() uses the SAME
-				// predicate (txIndex<0 || IsBlockEnd).
-				var tipWrites state.VersionedWrites
-				if txVersion.TxIndex >= 0 && !txTask.IsBlockEnd() {
-					taskVer, ok := txResult.Task.(*taskVersion)
-					if !ok {
-						return nil, fmt.Errorf("apply loop: unexpected task type for tx %d: result.Task=%T", tx, txResult.Task)
-					}
-					chainRules := txTask.Rules()
-					var err error
-					tipWrites, err = txResult.creditTipPreValidate(taskVer, be.versionMap, stateReader, chainRules)
-					if err != nil {
-						return nil, err
-					}
-				}
-
-				// finalize returns no addWrites for regular TXs (tip credit
-				// moved out); finalizeSystemTx still returns a write set for
-				// block-end / system TXs via full IBS reconstruction. Keep
-				// both paths' writes for the merge below.
 				_, addReads, finalizeWrites, err := txResult.finalize(prevReceipt, pe.cfg.engine, be.versionMap, stateReader, collector)
 				if err != nil {
 					return nil, err
 				}
 				addWrites := finalizeWrites
-				if len(tipWrites) > 0 {
-					if len(addWrites) == 0 {
-						addWrites = tipWrites
-					} else {
-						addWrites = MergeVersionedWrites(addWrites, tipWrites)
-					}
-				}
 
 				// Merge any additional reads/writes produced during finalize (fee calc, post apply, etc)
 				if addReads != nil {

--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -1888,6 +1888,22 @@ func (sdb *IntraBlockState) CreateAccount(addr accounts.Address, contractCreatio
 			}
 		}
 	}
+	// Same fix for BalancePath: a prior tx may have written the address's
+	// Balance (e.g. coinbase tip credit) at a version the account-record
+	// source/version does not reflect. Without this, the synthetic BalancePath
+	// read below is stamped with the account-record version (or default
+	// UnknownVersion when entering via the else-if-deleted-stateObject
+	// branch at line 1842), and a subsequent path-920 dep check sees the
+	// versionMap entry at a different version → ErrDependency panic → the
+	// worker spins in a non-converging dep-abort retry loop ("too many
+	// incarnations"). Mirrors the IncarnationPath treatment above.
+	balSource, balVersion := source, version
+	if sdb.versionMap != nil {
+		if res := sdb.versionMap.Read(addr, BalancePath, accounts.NilKey, sdb.txIndex); res.Status() == MVReadResultDone {
+			balSource = MapRead
+			balVersion = Version{TxIndex: res.DepIdx(), Incarnation: res.Incarnation()}
+		}
+	}
 	// Writer.DeleteAccount stores the selfdestructed incarnation in rs.selfdestructedByTx.
 	// Recover it here so that CreateAccount in the next tx computes newInc = prevInc+1 correctly.
 	if sdb.versionMap == nil && previous == nil {
@@ -1931,7 +1947,7 @@ func (sdb *IntraBlockState) CreateAccount(addr accounts.Address, contractCreatio
 
 	// for newly created accounts these synthetic read/writes are used so that account
 	// creation clashes between trnascations get detected
-	versionRead[uint256.Int](sdb, addr, BalancePath, accounts.NilKey, source, version, newObj.Balance())
+	versionRead[uint256.Int](sdb, addr, BalancePath, accounts.NilKey, balSource, balVersion, newObj.Balance())
 	versionRead[uint256.Int](sdb, addr, IncarnationPath, accounts.NilKey, incSource, incVersion, prevInc)
 	versionWritten(sdb, addr, BalancePath, accounts.NilKey, newObj.Balance())
 	versionWritten(sdb, addr, IncarnationPath, accounts.NilKey, newObj.data.Incarnation)

--- a/execution/state/versionedio_test.go
+++ b/execution/state/versionedio_test.go
@@ -723,6 +723,136 @@ func TestSetAccountBalanceOrDelete_OtherAddressWritesPreserved(t *testing.T) {
 	require.True(t, selfDestructFound, "target must have SelfDestructPath")
 }
 
+// TestSetAccountBalanceOrDelete_NoncePathOnly_AppendBalanceNotFullAccount
+// regression-pins the addrHasAnyWrite guard added in #21017 (bug #2).
+//
+// Setup: the worker has already written addr's NoncePath at version V (e.g.
+// a miner-self-send tx where sender == coinbase; the worker bumps the sender
+// nonce). The writes slice contains the NoncePath entry but no BalancePath
+// entry. finalize then calls SetAccountBalanceOrDelete to credit the tip.
+//
+// Pre-fix (bug #2): no BalancePath match found → fell through to the
+// new-account branch and re-emitted all four account fields from the
+// pre-block snapshot acc, clobbering the worker's already-bumped Nonce
+// under last-wins downstream merge.
+//
+// Post-fix: addrHasAnyWrite=true short-circuits the new-account branch
+// and appends ONLY the BalancePath; existing NoncePath is preserved.
+func TestSetAccountBalanceOrDelete_NoncePathOnly_AppendBalanceNotFullAccount(t *testing.T) {
+	t.Parallel()
+
+	addr := accounts.InternAddress(common.HexToAddress("0xA000"))
+	writes := VersionedWrites{
+		// Worker wrote NoncePath only (e.g. nonce-bump on a sender = coinbase tx).
+		&VersionedWrite{Address: addr, Path: NoncePath, Val: uint64(42)},
+	}
+
+	// Pre-block snapshot of the account — stale nonce that must NOT clobber
+	// the worker's already-bumped value.
+	acc := accounts.NewAccount()
+	acc.Balance = *uint256.NewInt(100)
+	acc.Nonce = 41 // stale; worker has it at 42
+	acc.Incarnation = 1
+	acc.CodeHash = accounts.EmptyCodeHash
+
+	result := writes.SetAccountBalanceOrDelete(addr, &acc, *uint256.NewInt(500), tracing.BalanceIncreaseRewardTransactionFee, true)
+
+	// Should be NoncePath (worker's) + BalancePath (newly appended).
+	// Must NOT re-emit Incarnation / CodeHash from the stale snapshot.
+	require.Len(t, result, 2, "must append only BalancePath, not re-emit full account")
+
+	pathSet := map[AccountPath]bool{}
+	for _, w := range result {
+		require.Equal(t, addr, w.Address)
+		pathSet[w.Path] = true
+		if w.Path == NoncePath {
+			require.Equal(t, uint64(42), w.Val, "worker's nonce must NOT be clobbered by stale snapshot")
+		}
+		if w.Path == BalancePath {
+			bal := w.Val.(uint256.Int)
+			require.Equal(t, uint256.NewInt(500), &bal)
+		}
+	}
+	require.True(t, pathSet[NoncePath], "NoncePath must be preserved")
+	require.True(t, pathSet[BalancePath], "BalancePath must be appended")
+	require.False(t, pathSet[IncarnationPath], "IncarnationPath must NOT be re-emitted from stale snapshot")
+	require.False(t, pathSet[CodeHashPath], "CodeHashPath must NOT be re-emitted from stale snapshot")
+}
+
+// TestSetAccountBalanceOrDelete_CodeHashPathOnly_AppendBalanceNotFullAccount
+// covers the same addrHasAnyWrite guard for a CodeHash-only worker write.
+// Less common in practice (CREATE without balance change) but a real path
+// the guard must handle for completeness.
+func TestSetAccountBalanceOrDelete_CodeHashPathOnly_AppendBalanceNotFullAccount(t *testing.T) {
+	t.Parallel()
+
+	addr := accounts.InternAddress(common.HexToAddress("0xB000"))
+	workerCodeHash := accounts.InternCodeHash(common.HexToHash("0xcafe"))
+	writes := VersionedWrites{
+		// Worker wrote CodeHashPath only (e.g. CREATE installed new code).
+		&VersionedWrite{Address: addr, Path: CodeHashPath, Val: workerCodeHash},
+	}
+
+	acc := accounts.NewAccount()
+	acc.Balance = *uint256.NewInt(100)
+	acc.Nonce = 5
+	acc.Incarnation = 2
+	acc.CodeHash = accounts.EmptyCodeHash // stale; worker installed real code
+
+	result := writes.SetAccountBalanceOrDelete(addr, &acc, *uint256.NewInt(500), tracing.BalanceIncreaseRewardTransactionFee, true)
+
+	require.Len(t, result, 2, "must append only BalancePath, not re-emit full account")
+
+	pathSet := map[AccountPath]bool{}
+	for _, w := range result {
+		require.Equal(t, addr, w.Address)
+		pathSet[w.Path] = true
+		if w.Path == CodeHashPath {
+			require.Equal(t, workerCodeHash, w.Val, "worker's CodeHash must NOT be clobbered by stale snapshot")
+		}
+	}
+	require.True(t, pathSet[CodeHashPath], "CodeHashPath must be preserved")
+	require.True(t, pathSet[BalancePath], "BalancePath must be appended")
+	require.False(t, pathSet[NoncePath], "NoncePath must NOT be re-emitted from stale snapshot")
+	require.False(t, pathSet[IncarnationPath], "IncarnationPath must NOT be re-emitted from stale snapshot")
+}
+
+// TestSetAccountBalanceOrDelete_IncarnationPathOnly_AppendBalanceNotFullAccount
+// covers the same addrHasAnyWrite guard for an Incarnation-only worker write
+// (e.g. a SELFDESTRUCT-and-recreate that bumps incarnation without changing
+// other paths via this code path).
+func TestSetAccountBalanceOrDelete_IncarnationPathOnly_AppendBalanceNotFullAccount(t *testing.T) {
+	t.Parallel()
+
+	addr := accounts.InternAddress(common.HexToAddress("0xC000"))
+	writes := VersionedWrites{
+		&VersionedWrite{Address: addr, Path: IncarnationPath, Val: uint64(7)},
+	}
+
+	acc := accounts.NewAccount()
+	acc.Balance = *uint256.NewInt(100)
+	acc.Nonce = 3
+	acc.Incarnation = 6 // stale; worker has it at 7
+	acc.CodeHash = accounts.EmptyCodeHash
+
+	result := writes.SetAccountBalanceOrDelete(addr, &acc, *uint256.NewInt(500), tracing.BalanceIncreaseRewardTransactionFee, true)
+
+	require.Len(t, result, 2, "must append only BalancePath, not re-emit full account")
+
+	pathSet := map[AccountPath]bool{}
+	for _, w := range result {
+		require.Equal(t, addr, w.Address)
+		pathSet[w.Path] = true
+		if w.Path == IncarnationPath {
+			require.Equal(t, uint64(7), w.Val, "worker's incarnation must NOT be clobbered by stale snapshot")
+		}
+	}
+	require.True(t, pathSet[IncarnationPath], "IncarnationPath must be preserved")
+	require.True(t, pathSet[BalancePath], "BalancePath must be appended")
+	require.False(t, pathSet[NoncePath], "NoncePath must NOT be re-emitted from stale snapshot")
+	require.False(t, pathSet[CodeHashPath], "CodeHashPath must NOT be re-emitted from stale snapshot")
+}
+
 // --- StripBalanceWrite tests ---
 
 // TestStripBalanceWrite_NoRead verifies that when the TX didn't read the


### PR DESCRIPTION
## Summary

Refactors the parallel-exec finalize path so the priority tip credit (FeeTipped → coinbase, FeeBurnt → burnt contract) happens BEFORE validation in the apply loop, not after via `finalizeTxSimple`'s separate `(Inc+1)` masking writes. Eliminates the `senderIsCoinbase` / `TxOut`-vs-`CollectorWrites` discriminator that motivated the three bugs in #21017.

The new code reads the post-worker coinbase via `vm.Read` at `txIndex+1` (= `floor(txIndex)`, inclusive of this tx's worker write) and adds the tip, mirroring IBS `AddBalance`'s read semantics. No `(Inc+1)` bumping: the post-tip value overwrites the worker's pre-tip write at the same version.

Two commits:

- **`79d08601a6`** — Test-only: 10 regression-pin tests for the #21017 bug class (3 `addrHasAnyWrite`-guard tests for `SetAccountBalanceOrDelete`, 6 `senderIsCoinbase` discriminator tests + smoke test for the real-tx scaffolding).
- **`d258f00b57`** — The refactor. NEW `creditTipPreValidate` helper, `finalizeTxSimple → finalizeTx` rename + body shrunk to receipt + `PostApplyMessage`, drop `balActive` dead parameter, ~150 lines of fee bookkeeping removed.

Net change: **+175 / −323** in production code (significant simplification).

## Trade-off accepted

The same-version overwrite means version-based validate no longer catches the rare race where a parallel BALANCE(coinbase) MapRead lands between a prior tx's worker write and that prior tx's apply-loop tip credit. Real BALANCE(coinbase) opcodes are rare enough in practice that this defensive masking was costing more in complexity than it caught. If the race surfaces in the wild, the validator can be made value-aware for MapRead reads as a focused follow-up.

## Block-end normalisation deferred

This PR moves only the regular-tx tip credit. Block-end normalisation (replacing Layer 3 + `finalizeSystemTx` with a specialized `BlockEndTask`) is a separate planned follow-up to keep CI signal clean per change. See [followup-coordinated-finalize-cleanup](https://github.com/erigontech/erigon/issues?q=is%3Aissue+followup-coordinated-finalize-cleanup) thread.

## Test plan

- [x] `go test ./execution/stagedsync/...` — full suite green (6.5s)
- [x] `go test ./execution/state/...` — green
- [x] `make lint` — clean
- [x] Local serial sync to mainnet tip (block 25,179,451 reached, 134 mgas/s healthy) — confirms Commit 2 didn't break serial path
- [ ] CI matrix from-0 parallel — authoritative end-to-end check (this is what the PR's CI run gates on)
- [ ] Full from-0 parallel re-exec to canonical balance comparison (deferred to a separate large-datadir run; CI matrix above covers the bug class)