### PR TITLE
node/cli: register --rpc.logs.maxresults in DefaultFlags so it takes effect via CLI

### DIFF
--- a/node/cli/default_flags.go
+++ b/node/cli/default_flags.go
@@ -98,6 +98,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.RpcGethCompatFlag,
 	&utils.RpcGasCapFlag,
 	&utils.RpcBlockRangeLimit,
+	&utils.RpcGetLogsMaxResults,
 	&utils.RpcBatchLimit,
 	&utils.RpcReturnDataLimit,
 	&utils.AllowUnprotectedTxs,


### PR DESCRIPTION
## Summary

Forward-port of #21389 to `main`.

`RpcGetLogsMaxResults` was defined in `cmd/utils/flags.go` and consumed in `node/cli/flags.go` (`ApplyFlagsForHttpCfg` populates `GetLogsMaxResults`), but it was never added to the `DefaultFlags` slice in `node/cli/default_flags.go`. As a result the `erigon` binary does not register the flag and rejects it at startup:

```
Error: flag provided but not defined: -rpc.logs.maxresults
Run 'erigon --help' for usage.
```

Same bug that #21372 reported against `release/3.4`; the fix landed there as #21389. `main` was missed.

One-line addition, placing the entry next to the already-registered `--rpc.blockrange.limit`:

```diff
 &utils.RpcBlockRangeLimit,
+&utils.RpcGetLogsMaxResults,
 &utils.RpcBatchLimit,
```

## Test plan

- [x] `make lint` clean
- [x] `go build ./node/cli/...` clean
- [ ] CI passes
- [ ] After merge: confirm `erigon --rpc.logs.maxresults=10000 ...` starts (no "flag provided but not defined")

🤖 Generated with [Claude Code](https://claude.com/claude-code)