### PR TITLE
ChangeLog: catch up on 3.3.x/3.4.x

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -83,7 +83,325 @@ Affected RPC methods: `debug_traceTransaction`, `debug_traceBlockByHash`, `debug
 
 ---
 
-## [3.3.0] – 2025-11-17
+## [3.4.2] "Splashing Saga" – TBD
+
+v3.4.2 is a bugfix release recommended for all users.
+
+**Bugfixes**
+
+- execution/stagedsync: find diffset by actually-executed hash on unwind (#21157) by @JkLondon — fixes a
+  state-leak bug in `unwindExec3` that surfaces as `gas used mismatch` / `Cannot update chain head` after
+  a tip reorg whose unwound block deployed a contract via `CREATE`/`CREATE2` to a counterfactual address
+  (safe-wallets, EIP-1167 clone factories, ERC-4337 accounts, deterministic deployers). The unwind now
+  walks every header at the height to find the diffset of the block actually executed, instead of
+  assuming the (already-flipped) canonical hash matches.
+- rawdb: ignore invalid receipt cache transaction indexes (#21262) by @Sahil-4555
+
+**Improvements**
+
+- db/state, ethconfig: bound domain merge; add `--erigondb.domain.steps-in-frozen-file` (#21148) by
+  @wmitsuda
+
+**Full Changelog**: https://github.com/erigontech/erigon/compare/v3.4.1...v3.4.2
+
+---
+
+## [3.4.1] "Splashing Saga" – 2026-05-11
+
+**Bugfixes**
+
+- commitment: segfault fix - caused by branch slice returned by TrieContext.Branch (#21044) by @awskii
+
+**Full Changelog**: https://github.com/erigontech/erigon/compare/v3.4.0...v3.4.1
+
+---
+
+## [3.4.0] "Splashing Saga" – 2026-04-28
+
+Erigon 3.4.0 is a major update for node operators and validators, focused on stability, performance, and
+efficiency at ChainTip. It is a drop-in upgrade for 3.3.x users — no data migration or re-sync required.
+
+### Key Features
+
+- **Fast restart on ChainTip**: no more blocking indexing or pruning at startup; Caplin doesn't lose its
+  download progress.
+- **4x smaller Chaindata (~20 GB)**: improves ChainTip speed. Available via re-sync, or by running
+  `./build/bin/erigon seg step-rebase --datadir=<your_path> --new-step-size=390625` (takes ~10 seconds).
+- **Historical `eth_getProof`**: is no longer experimental. Recommended: 32 GB+ RAM. Re-sync with
+  `--prune.include-commitment-history` to apply the latest data fixes.
+- **New RPC endpoints**: `trace_rawTransaction`, `eth_getStorageValues`, `admin_addTrustedPeer`,
+  `admin_removeTrustedPeer`, flat tracers, `engine_getBlobsV3`.
+- **Reduced impact on ChainTip performance**: from RPC, background file merging, pruning, and optional
+  heavy flags (`--persist.receipts`, `--prune.include-commitment-history`).
+
+### Breaking Changes
+
+- Minimum Go version: 1.25
+- `--rpc.blockrange.limit=1_000` new limit. Maximum block range (end - begin) allowed for range queries
+  over RPC. 0 - means unlimited. Default: 1_000
+- `--rpc.logs.maxresults=20_000` new limit. Maximum number of logs returned by eth_getLogs,
+  erigon_getLogs, erigon_getLatestLogs. 0 - means unlimited. Default: 20_000
+- `--rpc.max.concurrency=0` new limit. Maximum number of concurrent HTTP RPC requests (HTTP admission
+  control). 0 = use db.read.concurrency, -1 = unlimited (no admission control). Default: 0
+- p2p: switched to `discv5`. `discv4` disabled by default.
+
+### Added
+
+#### RPC Endpoints
+
+- `trace_rawTransaction`: execute and trace a raw signed transaction without broadcasting it (#19524)
+- `eth_getStorageValues`: batch fetch of multiple storage slots in a single call (#19442)
+- `admin_addTrustedPeer` / `admin_removeTrustedPeer`: manage trusted peers at runtime (#19413)
+- Call flat tracers (`trace_call` family): flat trace output format support (#18556)
+- `engine_getBlobsV3`: Engine API blob retrieval v3 (#18512)
+- `trace_call`: `StateOverrides` precompile support (#18401, #18492)
+
+#### Consensus & Execution
+
+- Fusaka scheduled for Chiado (Gnosis Chain testnet) at slot 21 651 456, epoch 1 353 216, timestamp
+  1 773 653 580 (Mon 16 Mar 2026 09:33:00 UTC) (#19682)
+- Chiado bootstrap nodes updated to match the Lighthouse built-in Chiado network config (#19693)
+- Balancer hard fork for Gnosis Chain mainnet (#18122)
+- Amsterdam signer support and BAL non-determinism fix (#19434)
+- BAL selfdestruct net-zero fix (#19528)
+- Parallel execution fixes for block-access-list (BAL) workloads (#17319)
+- execution/vm: EIP-8024 (`SWAPN`, `DUPN`, `EXCHANGE`) opcodes implemented (#18670)
+- Pectra requests-hash validation: fix partial block receipt reconstruction when execution resumes from
+  a snapshot boundary mid-block — resolves `invalid requests root hash in header` on mainnet re-sync at
+  block 24966723 (#20452)
+
+#### Caplin (Consensus Layer)
+
+- Persistent historical download — Caplin now persists and resumes historical beacon block downloads
+  across restarts (#18320)
+- Discovery v5 enabled by default — `discv5` is now the default peer discovery protocol (#18578)
+- cl/p2p, cl/sentinel: fix DISCV5 ENR missing IP when the discovery address is unspecified (#19585)
+- Fix missing attestations by using GossipSub for subnet peer coverage (#19523)
+- cl/gossip: fix conditions forwarding, ENR lifecycle, and epoch-mismatch — prevents false peer banning,
+  reduces log flooding from redundant ENR updates, and guards against stale RANDAO committee
+  computation (#20777)
+- cl/beacon: add `single_attestation` event topic support (#18142)
+- cl/beacon: set `Eth-Consensus-Version` header when versioned (#18377)
+
+### Changed
+
+#### RPC Reliability
+
+- `eth_getBlockReceipts`: limit over-concurrency — prevents latency growth and out-of-memory (OOM) at
+  high request rates (#19725)
+- `debug_traceCallMany`: fix global `BlockOverrides` and `StateOverrides` not being applied (#19547)
+- `debug_traceCall`: fix state and block overrides interaction (#18480)
+- `eth_blobBaseFee`: fix incorrect value returned (#18506)
+- `eth_getBalance` and others: fix block-not-found error for certain historical queries (#18457)
+- Block-hash canonicality check added to APIs that accept a block hash and state (#19356)
+- rpc: fix batch limit exceeded error to comply with the JSON-RPC spec (#18260)
+- `trace_replayTransaction()`: add stack info for `TLOAD` opcode (#19550)
+- `eth_feeHistory`: performance optimisation and pending block support (#19526, #19455)
+- `debug_trace*`: zero-alloc memory word encoding in `JsonStreamLogger` — eliminates per-word heap
+  allocations and prevents OOM on large block traces (#20754)
+- prestateTracer: fix diff mode missing deleted accounts to match geth behaviour (#20775)
+- rpc/mcp: fix `tools/call` hanging indefinitely under DB load by switching the SSE context to
+  non-blocking read-tx acquire (#20778)
+
+#### TxPool
+
+- Zombie queued transactions: transactions exceeding `MaxNonceGap` are now evicted (#19449)
+- txnprovider/shutter: fix premature encrypted txn pool cleanup and peer drops (#18351)
+- txpool: cache `pendingBaseFee` for queue comparisons to reduce recomputation (#18341)
+
+#### P2P
+
+- p2p/sentry: fix wrong OR in case statement for `wit` protocol messages (#19580)
+- p2p: better handling of RLP errors in `wit` (#19569)
+- discv4 disabled by default on mainnet (discv5 preferred) (#18640)
+
+#### Snapshot & Storage
+
+- merge: prioritize Domain merge over History — 2x less disk space required, and less impact to
+  ChainTip from history-merge (#19441)
+- merge: fix O(n²) InvertedIndex re-merge — eliminates quadratic time complexity during re-merge
+  (#19680)
+- `SequenceBuilder`: avoids an intermediate Elias-Fano representation during sequence building and
+  merge (#19552, #19567)
+- Faster startup: state-file index building deferred to reduce restart latency (#19583, #19407)
+- Graceful restart in history download: `SpawnStageHistoryDownload` now honours the stage context, so
+  Ctrl+C during history download exits promptly instead of waiting for the download to finish (#20766)
+- DB integrity checks: time budget added so checks no longer run unbounded (#20714)
+- Commitment-history integrity: skip the integrity check when commitment history is disabled (#20835)
+- `seg ls`: report dictionary size and memory usage in the output (#20790)
+- anacrolix/torrent: fix peerconn panic on bad reads while serving peer requests (#20748)
+
+### Security
+
+- github.com/buger/jsonparser: bump 1.1.1 → 1.1.2 to address CVE-2026-32285 (HIGH, CVSS 7.5 —
+  out-of-bounds read) (#20018)
+
+**Full Changelog**: https://github.com/erigontech/erigon/compare/v3.3.10...v3.4.0
+
+---
+
+## [3.3.10] "Rocky Romp" – 2026-03-27
+
+This release schedules Fusaka on **Gnosis Chain mainnet** at **Tue 14 April 2026, 12:06:20 UTC** and
+thus is **mandatory for all Gnosis users**. It is also recommended for all users in general.
+
+**Changes**
+
+- Schedule Gnosis Fusaka (#20090) by @domiwei
+- txpool: fully discard pre-Osaka blob txns in best() (#20120) by @yperbasis
+- rpc: auto-convert legacy blob sidecar to v1 cell proofs after Osaka (#20087) by @domiwei
+- rpc: add blockRangeLimit param for API works on blocks range (#19614) by @lupin012
+- cl: fall back to local head state when remote checkpoint sync fails (#20003) by @domiwei
+- cl: fix fork choice block validation and error propagation (#19927) by @domiwei
+- cl: re-enable voluntary_exit gossip topic subscription (#19764) by @Giulio2002
+
+**Full Changelog**: https://github.com/erigontech/erigon/compare/v3.3.9...v3.3.10
+
+---
+
+## [3.3.9] "Rocky Romp" – 2026-03-09
+
+This release schedules Fusaka on Chiado on **Mon 16 March 2026, 09:33:00 UTC** and thus is mandatory
+for all Chiado users.
+
+**Changes**
+
+- fix(txpool): evict zombie queued txns exceeding MaxNonceGap (cherry-pick #19449 → release/3.3)
+  (#19591) by @Giulio2002
+- cl/sentinel: fix DISCV5 ENR missing IP when discovery address is unspecified (#19647) by @lystopad
+- rpc: accept only canonical hash for block receipts (#19649) by @canepat
+- Schedule Fusaka for Chiado (#19681) by @yperbasis
+- cl: amend Chiado bootstrap nodes (#19692) by @yperbasis
+
+**Full Changelog**: https://github.com/erigontech/erigon/compare/v3.3.8...v3.3.9
+
+---
+
+## [3.3.8] "Rocky Romp" – 2026-02-20
+
+**Changes**
+
+- New Chiado boot nodes (cherry-pick #18867) (#19241) by @sudeepdino008
+- eth_getLogs: receipts availability check to be aware about `--persist.receipts` and
+  `--prune.mode=minimal` (#19226) by @AskAlexSharov
+- txnprovider/shutter: fix decryption keys processing when keys do not follow txnIndex order (#18951)
+  (#18959) by @taratorio
+- execution: fix Chiado re-exec from genesis (#18887) by @yperbasis
+
+**Bugfixes**
+
+- execution/tests: minor fix chainmaker add withdrawals in shanghai (#18886) by @taratorio
+- Reduce impact of background merge/compress to ChainTip (#18995) by @AskAlexSharov
+- fix(caplin): Fixes for DataColumnSidecar (#18268) (#19003) by @taratorio
+- rpc: bound checks in receipts cache V2 and generator (#19046) by @canepat
+- execution/execmodule: fix unwinding logic when side forks go back in height (#18993) (#19063) by
+  @taratorio
+- p2p: fix nil pointer crash with --nodiscover (#19056) by @sudeepdino008
+- rpc: add check on latest executed block (#19133) by @canepat
+- protect History from events duplication (#19230) by @AskAlexSharov
+
+**Full Changelog**: https://github.com/erigontech/erigon/compare/v3.3.7...v3.3.8
+
+---
+
+## [3.3.7] "Rocky Romp" – 2026-01-30
+
+P2P stability. Prune performance.
+
+**Changes**
+
+- prune: remove early-exit based on DirtySpace() (#18787) by @AskAlexSharov
+- execution: fix commitment state key txNum when last block tx is at step boundary (#18858) by
+  @taratorio
+- p2p deadlock fix (#18862) by @Copilot
+- Forward compatibility: Fixed index building for v0 snapshot format (#18824) by @eastorski
+- Backward compatibility: Add --v5disc alias (#18785) by @anacrolix
+- Show the default P2P discovery bools in --help (#18819) by @anacrolix
+
+**Full Changelog**: https://github.com/erigontech/erigon/compare/v3.3.4...v3.3.7
+
+---
+
+## [3.3.4] "Rocky Romp" – 2026-01-23
+
+v3.3.4 is a bugfix release recommended for all users.
+
+**Changes**
+
+- Fix for missing rcache at stepBoundary (#18698) by @sudeepdino008
+- execution/stagedsync: port --experimental.always-generate-changesets flag for gas repricing
+  benchmarks (#18733) by @taratorio
+- execution: add --fcu.timeout and --fcu.background.prune flags (#18723) by @taratorio
+- Not needed collector erased in prune domains (#18665) by @JkLondon
+- Forward compatible snapshots format (#18746) by @eastorski
+
+**Full Changelog**: https://github.com/erigontech/erigon/compare/v3.3.3...v3.3.4
+
+---
+
+## [3.3.3] "Rocky Romp" – 2026-01-14
+
+v3.3.3 is a bugfix release recommended for all users.
+
+**Fixes**
+
+- CL: Fix incorrect committee count in process_attestation (#18316) by @domiwei
+- CL: Fix for periodic retry of not-ready response (#18376) by @taratorio
+- Shutter: fix premature encrypted txn pool cleanup bug and peer drops (#18264) by @taratorio
+- Half block exec fix in receipts (#18426, #18505) by @sudeepdino008
+- p2p: resolve security vulnerability (#18650) by @yperbasis
+
+**Improvements**
+
+- p2p: Turn on discovery v5 by default (#18639) by @anacrolix
+
+**Full Changelog**: https://github.com/erigontech/erigon/compare/v3.3.2...v3.3.3
+
+---
+
+## [3.3.2] "Rocky Romp" – 2025-12-13
+
+Gnosis hardfork support.
+
+**Changes**
+
+- rpc: fix panic on `GetEthV1BeaconBlobs` (#17992) (#18232) by @domiwei
+- rpc: fix invalid key error code in `eth_getStorageAt` (#18238) by @canepat
+- cl/beacon: add single_attestation event topic support (#18142) (#18277) by @domiwei
+- Gnosis Balancer (#18282) by @mh0lt
+- bittorrent: torrent excessive wantPeers event fix (#18256) by @anacrolix
+
+**Full Changelog**: https://github.com/erigontech/erigon/compare/v3.3.1...v3.3.2
+
+---
+
+## [3.3.1] "Rocky Romp" – 2025-12-07
+
+- We have new Docs and HelpCenter: https://docs.erigon.tech/
+- Support of historical `eth_getProof` (https://github.com/erigontech/erigon/issues/12984). It requires
+  `--prune.include-commitment-history` flag.
+
+**RPC**
+
+- rpc: fix txpool_content crash: unknown (#18120) by @canepat
+
+**CL**
+
+- Caplin: Simplified peer refreshing (#18123) (#18152) by @domiwei
+
+**TxPool**
+
+- txpool: remove double PopWorst() in pending pool overflow (#18159) by @AskAlexSharov
+
+**Sync**
+
+- Torrent client fixes (#18179) by @anacrolix
+
+**Full Changelog**: https://github.com/erigontech/erigon/compare/v3.3.0...v3.3.1
+
+---
+
+## [3.3.0] – 2025-11-27
 
 ### Added
 
@@ -137,6 +455,16 @@ Affected RPC methods: `debug_traceTransaction`, `debug_traceBlockByHash`, `debug
 - SkipAnalysis VM optimization removed (#17217)
 
 **Full Changelog**: https://github.com/erigontech/erigon/compare/v3.2.2...v3.3.0
+
+---
+
+## [3.2.3] "Quirky Quests" – 2025-11-25
+
+**Changes**
+
+- Caplin: add getBlobs support (fusaka) (#17840) by @Giulio2002
+
+**Full Changelog**: https://github.com/erigontech/erigon/compare/v3.2.2...v3.2.3
 
 ---
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -83,7 +83,7 @@ Affected RPC methods: `debug_traceTransaction`, `debug_traceBlockByHash`, `debug
 
 ---
 
-## [3.4.2] "Splashing Saga" – TBD
+## [3.4.2] "Splashing Saga" – 2026-05-22
 
 v3.4.2 is a bugfix release recommended for all users.
 


### PR DESCRIPTION
## Summary

Forward-port of #21337 to `main`.

`main`'s `ChangeLog.md` jumped directly from `[3.3.0]` to `[3.5.0] – TBD`, with no entries for any of the 3.3.x patch releases, none of the 3.4.x line, and a missing v3.2.3 entry between 3.2.2 and 3.3.0.

This PR splices in the catch-up entries from `release/3.4` (#21337), covering:

- v3.2.3 (2025-11-25)
- v3.3.1 – v3.3.10
- v3.4.0 (2026-04-28)
- v3.4.1 (2026-05-11)
- v3.4.2 (draft, TBD)

It also corrects v3.3.0's date from 2025-11-17 → 2025-11-27 to match the GitHub publish date.

## Test plan

- [ ] Skim the rendered changelog on GitHub for formatting / heading ordering.
- [ ] Confirm the v3.4.2 draft contents stay in sync with the eventual `release/3.4` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)