### PR TITLE
bloatnet: auto-nuke StateCache on low hit_rate

### DIFF
--- a/execution/cache/code_cache.go
+++ b/execution/cache/code_cache.go
@@ -22,6 +22,7 @@ import (
 	"unsafe"
 
 	"github.com/c2h5oh/datasize"
+
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/common/maphash"
@@ -34,7 +35,7 @@ func uint64AsBytes(v *uint64) []byte {
 
 const (
 	// DefaultCodeCacheBytes is the byte limit for code cache (512 MB)
-	DefaultCodeCacheBytes = 512 * datasize.MB
+	DefaultCodeCacheBytes = 256 * datasize.MB
 	// DefaultAddrCacheBytes is the byte limit for address cache (16 MB)
 	DefaultAddrCacheBytes = 16 * datasize.MB
 )

--- a/execution/cache/code_cache.go
+++ b/execution/cache/code_cache.go
@@ -34,9 +34,9 @@ func uint64AsBytes(v *uint64) []byte {
 }
 
 const (
-	// DefaultCodeCacheBytes is the byte limit for code cache (512 MB)
-	DefaultCodeCacheBytes = 256 * datasize.MB
-	// DefaultAddrCacheBytes is the byte limit for address cache (16 MB)
+	// DefaultCodeCacheBytes is the byte limit for code cache
+	DefaultCodeCacheBytes = 128 * datasize.MB
+	// DefaultAddrCacheBytes is the byte limit for address cache
 	DefaultAddrCacheBytes = 16 * datasize.MB
 )
 

--- a/execution/cache/generic_cache.go
+++ b/execution/cache/generic_cache.go
@@ -113,9 +113,8 @@ func (c *GenericCache[T]) Put(key []byte, value T) {
 	if c.currentSize.Load()+entrySize > int64(c.capacityB) {
 		hits := c.hits.Load()
 		total := hits + c.misses.Load()
-		hitRate := hits * 100 / total
 		// low-hit-ratio: nuke, high-hit-ratio: ignore key
-		if total >= nukeMinSamples && hitRate < nukeHitRateThreshold {
+		if total >= nukeMinSamples && hits*100/total < nukeHitRateThreshold {
 			c.Clear()
 			c.hits.Store(0)
 			c.misses.Store(0)

--- a/execution/cache/generic_cache.go
+++ b/execution/cache/generic_cache.go
@@ -114,7 +114,11 @@ func (c *GenericCache[T]) Put(key []byte, value T) {
 		hits := c.hits.Load()
 		total := hits + c.misses.Load()
 		// low-hit-ratio: nuke, high-hit-ratio: ignore key
-		if total >= nukeMinSamples && hits*100/total < nukeHitRateThreshold {
+		if total < nukeMinSamples {
+			return
+		}
+		hitRate := hits * 100 / total
+		if hitRate < nukeHitRateThreshold {
 			c.Clear()
 			c.hits.Store(0)
 			c.misses.Store(0)

--- a/execution/cache/generic_cache.go
+++ b/execution/cache/generic_cache.go
@@ -21,9 +21,15 @@ import (
 	"sync/atomic"
 
 	"github.com/c2h5oh/datasize"
+
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/common/maphash"
+)
+
+const (
+	nukeMinSamples       = 1000 // minimum accesses before considering a nuke
+	nukeHitRateThreshold = 10   // nuke if hit_rate < 10% when full
 )
 
 // GenericCache is a bounded concurrent cache for key-value data.
@@ -105,7 +111,15 @@ func (c *GenericCache[T]) Put(key []byte, value T) {
 
 	// New key
 	if c.currentSize.Load()+entrySize > int64(c.capacityB) {
-		return
+		hits := c.hits.Load()
+		total := hits + c.misses.Load()
+		if total >= nukeMinSamples && hits*100/total < nukeHitRateThreshold {
+			c.Clear()
+			c.hits.Store(0)
+			c.misses.Store(0)
+		} else {
+			return
+		}
 	}
 
 	c.data.Set(key, value)

--- a/execution/cache/generic_cache.go
+++ b/execution/cache/generic_cache.go
@@ -109,11 +109,13 @@ func (c *GenericCache[T]) Put(key []byte, value T) {
 		return
 	}
 
-	// New key
+	// Cache is full
 	if c.currentSize.Load()+entrySize > int64(c.capacityB) {
 		hits := c.hits.Load()
 		total := hits + c.misses.Load()
-		if total >= nukeMinSamples && hits*100/total < nukeHitRateThreshold {
+		hitRate := hits * 100 / total
+		// low-hit-ratio: nuke, high-hit-ratio: ignore key
+		if total >= nukeMinSamples && hitRate < nukeHitRateThreshold {
 			c.Clear()
 			c.hits.Store(0)
 			c.misses.Store(0)

--- a/execution/cache/state_cache.go
+++ b/execution/cache/state_cache.go
@@ -28,9 +28,9 @@ import (
 
 const (
 	// DefaultAccountCacheBytes is the byte limit for account cache (1 GB)
-	DefaultAccountCacheBytes = 512 * datasize.MB
+	DefaultAccountCacheBytes = 256 * datasize.MB
 	// DefaultStorageCacheBytes is the byte limit for storage cache (1 GB)
-	DefaultStorageCacheBytes = 512 * datasize.MB
+	DefaultStorageCacheBytes = 256 * datasize.MB
 	// DefaultCommitmentCacheBytes is the byte limit for commitment cache (128 MB)
 	DefaultCommitmentCacheBytes = 128 * datasize.MB
 )

--- a/execution/cache/state_cache.go
+++ b/execution/cache/state_cache.go
@@ -28,9 +28,9 @@ import (
 
 const (
 	// DefaultAccountCacheBytes is the byte limit for account cache (1 GB)
-	DefaultAccountCacheBytes = 256 * datasize.MB
+	DefaultAccountCacheBytes = 128 * datasize.MB
 	// DefaultStorageCacheBytes is the byte limit for storage cache (1 GB)
-	DefaultStorageCacheBytes = 256 * datasize.MB
+	DefaultStorageCacheBytes = 128 * datasize.MB
 	// DefaultCommitmentCacheBytes is the byte limit for commitment cache (128 MB)
 	DefaultCommitmentCacheBytes = 128 * datasize.MB
 )

--- a/execution/cache/state_cache.go
+++ b/execution/cache/state_cache.go
@@ -28,9 +28,9 @@ import (
 
 const (
 	// DefaultAccountCacheBytes is the byte limit for account cache (1 GB)
-	DefaultAccountCacheBytes = 1 * datasize.GB
+	DefaultAccountCacheBytes = 512 * datasize.MB
 	// DefaultStorageCacheBytes is the byte limit for storage cache (1 GB)
-	DefaultStorageCacheBytes = 1 * datasize.GB
+	DefaultStorageCacheBytes = 512 * datasize.MB
 	// DefaultCommitmentCacheBytes is the byte limit for commitment cache (128 MB)
 	DefaultCommitmentCacheBytes = 128 * datasize.MB
 )

--- a/execution/cache/state_cache.go
+++ b/execution/cache/state_cache.go
@@ -27,11 +27,11 @@ import (
 )
 
 const (
-	// DefaultAccountCacheBytes is the byte limit for account cache (1 GB)
+	// DefaultAccountCacheBytes is the byte limit for account cache
 	DefaultAccountCacheBytes = 64 * datasize.MB
-	// DefaultStorageCacheBytes is the byte limit for storage cache (1 GB)
+	// DefaultStorageCacheBytes is the byte limit for storage cache
 	DefaultStorageCacheBytes = 64 * datasize.MB
-	// DefaultCommitmentCacheBytes is the byte limit for commitment cache (128 MB)
+	// DefaultCommitmentCacheBytes is the byte limit for commitment cache
 	DefaultCommitmentCacheBytes = 128 * datasize.MB
 )
 

--- a/execution/cache/state_cache.go
+++ b/execution/cache/state_cache.go
@@ -28,9 +28,9 @@ import (
 
 const (
 	// DefaultAccountCacheBytes is the byte limit for account cache (1 GB)
-	DefaultAccountCacheBytes = 128 * datasize.MB
+	DefaultAccountCacheBytes = 64 * datasize.MB
 	// DefaultStorageCacheBytes is the byte limit for storage cache (1 GB)
-	DefaultStorageCacheBytes = 128 * datasize.MB
+	DefaultStorageCacheBytes = 64 * datasize.MB
 	// DefaultCommitmentCacheBytes is the byte limit for commitment cache (128 MB)
 	DefaultCommitmentCacheBytes = 128 * datasize.MB
 )


### PR DESCRIPTION

- StateCache using 2x more ram than limits say (because seems it doesn't account internal structures overhead): it using 5Gb RAM (and 90% of objects stored there). 
```
[DBUG] [05-27|01:47:58.589] Account cache stats                      hits=308 misses=1 hit_rate=99.676 entries=1007 size_mb=0 capacity_mb=1KB usage_pct=0.002                         
[DBUG] [05-27|01:47:58.589] Storage cache stats                      hits=538 misses=101324 hit_rate=0.528 entries=89480536 size_mb=1024 capacity_mb=1KB usage_pct=100.000            
[DBUG] [05-27|01:47:58.589] CodeCache stats                          addr_hits=124 addr_misses=2 addr_hit_rate=98.413 code_hits=124 code_misses=0 code_hit_rate=100.000       
```

```
bloatnet: `hits=538 misses=101324 hit_rate=0.528 entries=89480536 size_mb=1024` 
ethmainnet: `hits=1473 misses=157 hit_rate=90.368 entries=5878641 size_mb=86`
```

but after restart i see: it's 
```
[DBUG] [05-27|02:17:41.863] Storage cache stats                      hits=44578 misses=57351 hit_rate=43.734 entries=2465854
```

aha! it's because StateCache doesn't have any Eviction strategy - old keys fill cache and new cache can't get in. While Bloatnet is full of "new storage creation" attack vector
Okey: we have 2 options - to "nuke cache if it's full and hit_rate low", or add "eviction policy", or "nuke but have 2-generation cache"  


-----

Also i check - what if don't store non-existing keys markers in StateCache (seems get much worse): 
```
[DBUG] [05-27|03:45:20.050] Account cache stats                      hits=304 misses=2 hit_rate=99.346 entries=1006 size_mb=0 capacity_mb=64B usage_pct=0.033
[DBUG] [05-27|03:45:20.050] Storage cache stats                      hits=79 misses=101822 hit_rate=0.078 entries=2583927 size_mb=29 capacity_mb=64B usage_pct=46.203
```

---

Example of this PR on `bloatnet`. Filling empty cache happening within 1 block:
```
[DBUG] [05-27|05:29:02.454] Storage cache stats                      hits=44579 misses=57598 hit_rate=43.629 entries=5224592 size_mb=59 capacity_mb=64B usage_pct=93.422
[DBUG] [05-27|05:29:17.928] Storage cache stats                      hits=44599 misses=57491 hit_rate=43.686 entries=5282079 size_mb=60 capacity_mb=64B usage_pct=94.450
[DBUG] [05-27|05:29:32.689] Storage cache stats                      hits=44570 misses=57318 hit_rate=43.744 entries=5339388 size_mb=61 capacity_mb=64B usage_pct=95.475
[DBUG] [05-27|05:29:47.940] Storage cache stats                      hits=44573 misses=57253 hit_rate=43.774 entries=5396635 size_mb=61 capacity_mb=64B usage_pct=96.499
[DBUG] [05-27|05:30:03.060] Storage cache stats                      hits=44587 misses=57472 hit_rate=43.687 entries=5454103 size_mb=62 capacity_mb=64B usage_pct=97.526
[DBUG] [05-27|05:30:17.823] Storage cache stats                      hits=44593 misses=57446 hit_rate=43.702 entries=5511540 size_mb=63 capacity_mb=64B usage_pct=98.553
[DBUG] [05-27|05:30:40.004] Storage cache stats                      hits=44578 misses=57571 hit_rate=43.640 entries=5569105 size_mb=63 capacity_mb=64B usage_pct=99.583
[DBUG] [05-27|05:30:50.704] Storage cache stats                      hits=23418 misses=78678 hit_rate=22.937 entries=5592485 size_mb=64 capacity_mb=64B usage_pct=100.001
[DBUG] [05-27|05:30:56.140] Storage cache stats                      hits=8 misses=6 hit_rate=57.143 entries=5592485 size_mb=64 capacity_mb=64B usage_pct=100.001
[DBUG] [05-27|05:30:58.866] Storage cache stats                      hits=43847 misses=57244 hit_rate=43.374 entries=57243 size_mb=0 capacity_mb=64B usage_pct=1.023
[DBUG] [05-27|05:31:03.633] Storage cache stats                      hits=44589 misses=57511 hit_rate=43.672 entries=114755 size_mb=1 capacity_mb=64B usage_pct=2.052
[DBUG] [05-27|05:31:08.689] Storage cache stats                      hits=44625 misses=57427 hit_rate=43.728 entries=172184 size_mb=1 capacity_mb=64B usage_pct=3.079
[DBUG] [05-27|05:31:13.783] Storage cache stats                      hits=44608 misses=57345 hit_rate=43.753 entries=229530 size_mb=2 capacity_mb=64B usage_pct=4.104
[DBUG] [05-27|05:31:19.485] Storage cache stats                      hits=44623 misses=57642 hit_rate=43.635 entries=287174 size_mb=3 capacity_mb=64B usage_pct=5.135
[DBUG] [05-27|05:31:25.639] Storage cache stats                      hits=44621 misses=57309 hit_rate=43.776 entries=344475 size_mb=3 capacity_mb=64B usage_pct=6.159
[DBUG] [05-27|05:31:31.441] Storage cache stats                      hits=44583 misses=57351 hit_rate=43.737 entries=401828 size_mb=4 capacity_mb=64B usage_pct=7.185
[DBUG] [05-27|05:31:38.045] Storage cache stats                      hits=44584 misses=57449 hit_rate=43.696 entries=459279 size_mb=5 capacity_mb=64B usage_pct=8.212
[DBUG] [05-27|05:31:47.424] Storage cache stats                      hits=44549 misses=57386 hit_rate=43.703 entries=516660 size_mb=5 capacity_mb=64B usage_pct=9.238
[DBUG] [05-27|05:31:59.705] Storage cache stats                      hits=44555 misses=57526 hit_rate=43.647 entries=574185 size_mb=6 capacity_mb=64B usage_pct=10.267
[DBUG] [05-27|05:32:16.409] Storage cache stats                      hits=44535 misses=57694 hit_rate=43.564 entries=631876 size_mb=7 capacity_mb=64B usage_pct=11.298
[DBUG] [05-27|05:32:35.153] Storage cache stats                      hits=44543 misses=57437 hit_rate=43.678 entries=689302 size_mb=7 capacity_mb=64B usage_pct=12.325
[DBUG] [05-27|05:32:56.145] Storage cache stats                      hits=44563 misses=57449 hit_rate=43.684 entries=746741 size_mb=8 capacity_mb=64B usage_pct=13.352
[DBUG] [05-27|05:33:17.416] Storage cache stats                      hits=44587 misses=57522 hit_rate=43.666 entries=804246 size_mb=9 capacity_mb=64B usage_pct=14.381
```

--- 

Speed: `5tx/s -> 7tx/s` (from higher hit_rate, and from less RAM usage - faster Flush)