### PR TITLE
exec: `avg mgas/s` robust calculation 

### DIFF
--- a/execution/execmodule/exec_module.go
+++ b/execution/execmodule/exec_module.go
@@ -217,8 +217,9 @@ type ExecModule struct {
 	fcuBackgroundPrune      bool
 	fcuBackgroundCommit     bool
 	onlySnapDownloadOnStart bool
-	// metrics for average mgas/sec
-	avgMgasSec float64
+	// gas-weighted EWMA: accumulate gas and time separately so near-empty blocks don't skew the average
+	accumGasMgas float64
+	accumTimeSec float64
 
 	lock           sync.RWMutex
 	currentContext *execctx.SharedDomains

--- a/execution/execmodule/forkchoice.go
+++ b/execution/execmodule/forkchoice.go
@@ -849,13 +849,14 @@ func (e *ExecModule) logHeadUpdated(blockHash common.Hash, fcuHeader *types.Head
 		const blockRange = 30 // ~1 hour
 		const alpha = 2.0 / (blockRange + 1)
 
-		if e.avgMgasSec == 0 || e.avgMgasSec == math.Inf(1) {
-			e.avgMgasSec = mgasPerSec
-		}
-		e.avgMgasSec = alpha*mgasPerSec + (1-alpha)*e.avgMgasSec
-		// if mgasPerSec or avgMgasPerSec are 0, Inf or -Inf, do not log it but dont return either
-		if mgasPerSec > 0 && mgasPerSec != math.Inf(1) && e.avgMgasSec > 0 && e.avgMgasSec != math.Inf(1) {
-			logArgs = append(logArgs, "mgas/s", fmt.Sprintf("%.2f", mgasPerSec), "avg mgas/s", fmt.Sprintf("%.2f", e.avgMgasSec))
+		// Gas-weighted EWMA: accumulate gas and time separately.
+		// Near-empty blocks contribute tiny values to both, so they barely move the ratio.
+		e.accumGasMgas = alpha*gasUsedMgas + (1-alpha)*e.accumGasMgas
+		e.accumTimeSec = alpha*totalTime.Seconds() + (1-alpha)*e.accumTimeSec
+		avgMgasSec := e.accumGasMgas / e.accumTimeSec
+		// if mgasPerSec or avgMgasSec are 0, Inf or -Inf, do not log it but dont return either
+		if mgasPerSec > 0 && mgasPerSec != math.Inf(1) && avgMgasSec > 0 && avgMgasSec != math.Inf(1) {
+			logArgs = append(logArgs, "mgas/s", fmt.Sprintf("%.2f", mgasPerSec), "avg mgas/s", fmt.Sprintf("%.2f", avgMgasSec))
 		}
 	}
 


### PR DESCRIPTION
Near-empty blocks (tiny gas, tiny execution time) skewed the per-block EWMA heavily downward. Replace single `avgMgasSec` accumulator with separate gas and time accumulators; the ratio gives a gas-weighted average where empty blocks barely move the metric.

**Before** — nearly-empty blocks cause large drops in avg:
```
[INFO] [05-27|06:08:53.416] head validated                           hash=0x6f0e18592acb69230317e0e0ff64f1201b7d59043ce37fe2fb665b7544f36b5a number=24710228 age=4d21h43m execution=3s mgas/s=387.39 avg mgas/s=387.39 alloc=17.7GB sys=17.8GB
[INFO] [05-27|06:08:57.168] head validated                           hash=0x6e743c69a98d2d8d16e67d663168428ff34b66bc34f46134c87d76d0627b0bec number=24710229 age=4d21h43m execution=3ms mgas/s=16.28 avg mgas/s=363.44 alloc=18.0GB sys=18.1GB
[INFO] [05-27|06:08:59.626] head validated                           hash=0x96426f969dbe902d1fc5fbfb8b9f6094f9c383d282c05163114bf8fe191758b6 number=24710230 age=4d21h42m execution=2s mgas/s=401.88 avg mgas/s=365.92 alloc=19.2GB sys=19.3GB
[INFO] [05-27|06:09:06.090] head validated                           hash=0x6cf1a5021b66a35e2468bfa0403770402fdb094c1982aa1178824fd72f216fd2 number=24710232 age=4d21h42m execution=2s mgas/s=432.71 avg mgas/s=348.15 alloc=20.2GB sys=20.4GB
[INFO] [05-27|06:09:11.105] head validated                           hash=0x6ef900e2c76911a85f1ae926ddbd8f09e49a7524efd3f830cbfc9c67910a6d1a number=24710234 age=4d21h41m execution=2s mgas/s=443.71 avg mgas/s=333.30 alloc=21.3GB sys=21.4GB
[INFO] [05-27|06:09:15.621] head validated                           hash=0xf8a906952e9f36ec39d40a78c35ca79004a9b24c9cfac0f8df98e03cc6f41054 number=24710235 age=4d21h41m execution=2ms mgas/s=24.88 avg mgas/s=313.40 alloc=21.3GB sys=21.5GB
[INFO] [05-27|06:09:18.045] head validated                           hash=0xbcadc850cf9ceb8451c8b628ad0cb38dd6799596079d34895f9762094b03bb6d number=24710236 age=4d21h41m execution=2s mgas/s=407.61 avg mgas/s=319.48 alloc=22.5GB sys=22.7GB
[INFO] [05-27|06:09:23.558] head validated                           hash=0x1410b0aef01883d20fb83074e83980378b76d0d732d86ca7fd819c2840d7ed98 number=24710237 age=4d21h40m execution=2s mgas/s=411.95 avg mgas/s=325.45 alloc=23.5GB sys=23.7GB
[INFO] [05-27|06:09:30.730] head validated                           hash=0x61f50189538693bcd4e6479436b5ed6510e1d49ae9e1c7899ae883c1afad6299 number=24710239 age=4d21h40m execution=2s mgas/s=407.20 avg mgas/s=311.08 alloc=24.7GB sys=25.0GB
[INFO] [05-27|06:09:34.552] head validated                           hash=0x39e4e19ed7a5496b121558b01ea7b1c317f6eb181e0eed7802ea1453d4650477 number=24710240 age=4d21h40m execution=2ms mgas/s=30.15 avg mgas/s=292.95 alloc=24.8GB sys=25.0GB
[INFO] [05-27|06:09:38.452] head validated                           hash=0xd2a34d202853c14d366d48338d64573b21e2db7c40ec6b36b42ba10c082a147d number=24710241 age=4d21h40m execution=2s mgas/s=438.63 avg mgas/s=302.35 alloc=25.8GB sys=26.1GB
[INFO] [05-27|06:09:46.726] head validated                           hash=0x0332ba6768dfea8b697a4c894bcb93082ebc9f0ff76b1bcb474751492c14890c number=24710243 age=4d21h39m execution=2s mgas/s=411.94 avg mgas/s=291.17 alloc=26.9GB sys=27.3GB
[INFO] [05-27|06:09:55.509] head validated                           hash=0xc42719bc177cefb1fe255360078774b347a45da42724b2f2ae0c39d29ed25d4f number=24710245 age=4d21h39m execution=2s mgas/s=431.69 avg mgas/s=282.67 alloc=27.8GB sys=28.1GB
[INFO] [05-27|06:10:02.628] head validated                           hash=0x2a64194617d70f7c8255cf2dc92d75b7e79fe06219d69cfa3aed6f97dad4d39e number=24710247 age=4d21h38m execution=2s mgas/s=489.25 avg mgas/s=278.93 alloc=28.6GB sys=29.0GB
[INFO] [05-27|06:10:09.208] head validated                           hash=0x1a597b00fb73fef7dc8536c880498b89a3002201cd40ce7333ea068cab6dec6e number=24710249 age=4d21h38m execution=2s mgas/s=487.99 avg mgas/s=275.59 alloc=29.6GB sys=30.0GB
[INFO] [05-27|06:10:15.759] head validated                           hash=0x3b2dd7964d157259c295265af102068343b1968bb02eddfa7f5bf0dc038e4d70 number=24710250 age=4d21h37m execution=2s mgas/s=459.72 avg mgas/s=287.47 alloc=30.8GB sys=31.2GB
[INFO] [05-27|06:10:22.879] head validated                           hash=0x0f26f4ebeb60ef4a7ee726c04ffc5e21c1bcf2d059ef93d4edf089b785187358 number=24710252 age=4d21h37m execution=2s mgas/s=410.53 avg mgas/s=278.06 alloc=32.1GB sys=32.6GB
[INFO] [05-27|06:10:31.493] head validated                           hash=0x205d94a206089ce9e2acdafc77c200cfe7aceb03f05ae03f7fd948ad01f0ee13 number=24710254 age=4d21h36m execution=2s mgas/s=458.14 avg mgas/s=272.89 alloc=18.8GB sys=33.0GB
[INFO] [05-27|06:10:37.783] head validated                           hash=0xf225b41fe0b8a020ab708e8a4856650b148eb7cb870e0bb7212ffaf141751743 number=24710255 age=4d21h36m execution=5ms mgas/s=5.63 avg mgas/s=255.65 alloc=18.8GB sys=33.0GB
[INFO] [05-27|06:10:39.969] head validated                           hash=0xc52aad0a13e8d5e5a32e7caf5dd217f4daa1c0b92bc6806d5154013029f74e06 number=24710256 age=4d21h36m execution=2s mgas/s=455.54 avg mgas/s=268.55 alloc=19.8GB sys=33.0GB
[INFO] [05-27|06:10:48.938] head validated                           hash=0x2d28243f989e91d2176dcd9f3cfea443780bc1e3c77a234772158c754b0a2944 number=24710258 age=4d21h36m execution=2s mgas/s=482.53 avg mgas/s=266.14 alloc=20.7GB sys=33.0GB
[INFO] [05-27|06:10:57.876] head validated                           hash=0x0b36d270ea191b7d3029875fbc7901bd918cf6d85e2465a5195bd56774c8e090 number=24710260 age=4d21h35m execution=3s mgas/s=340.25 avg mgas/s=254.86 alloc=21.7GB sys=33.0GB
[INFO] [05-27|06:11:02.344] head validated                           hash=0x91f6d86f82a1bac2f956375ba38f3bf0ca0bdfe7a073e82309cf5efdd5e6c9da number=24710261 age=4d21h35m execution=28ms mgas/s=1.43 avg mgas/s=238.51 alloc=22.2GB sys=33.0GB
[INFO] [05-27|06:11:05.399] head validated                           hash=0x5f1f16ce3f2b32cbca0ecac14e10c406aa432424bb22ef0c32d8b0204b7494a7 number=24710262 age=4d21h34m execution=3s mgas/s=325.67 avg mgas/s=244.13 alloc=23.6GB sys=33.0GB
[INFO] [05-27|06:11:20.506] head validated                           hash=0xc1fc46bfb80ae9828aab49c9cf7a9ce8d1a242dafc2a930a84755c0de19a9b22 number=24710263 age=4d21h34m execution=6s mgas/s=179.04 avg mgas/s=239.94 alloc=26.1GB sys=33.3GB
[INFO] [05-27|06:11:34.266] head validated                           hash=0x6f57279d596538357cdd64dadda82d7f5f9b297433614051355449b331ddb1fa number=24710265 age=4d21h34m execution=3s mgas/s=303.93 avg mgas/s=229.58 alloc=27.2GB sys=33.3GB
[INFO] [05-27|06:11:40.013] head validated                           hash=0xbbc4877db5e5504a0700653a4cc29e2502438cc9b9c330c10b5bfd4a4f718625 number=24710266 age=4d21h34m execution=27ms mgas/s=1.85 avg mgas/s=214.89 alloc=27.2GB sys=33.3GB
[INFO] [05-27|06:11:45.165] head validated                           hash=0xf3e38158d3aa7d719ff6703b94445f474ae034f45444d231bdf8501645c63da1 number=24710267 age=4d21h33m execution=3s mgas/s=327.54 avg mgas/s=222.16 alloc=28.2GB sys=33.3GB
[INFO] [05-27|06:11:54.701] head validated                           hash=0x818e1efacc77edd6b7fe459142c8340833e07c53693dca26792625b788c4d7fd number=24710269 age=4d21h33m execution=3s mgas/s=387.82 avg mgas/s=219.44 alloc=29.4GB sys=33.3GB
[INFO] [05-27|06:12:02.412] head validated                           hash=0x4c7756653fc1010b01ab31ccbc0402ca69650f7d80903bd845ff51783041e5f3 number=24710271 age=4d21h33m execution=3s mgas/s=360.18 avg mgas/s=215.27 alloc=30.1GB sys=33.3GB
[INFO] [05-27|06:12:05.660] head validated                           hash=0x1299373fa3ee4d2de547049040ed0b14fe7df6dd7ff7b00a2d55f3a82d94ac84 number=24710272 age=4d21h32m execution=8ms mgas/s=5.19 avg mgas/s=201.72 alloc=30.1GB sys=33.3GB
[INFO] [05-27|06:12:08.214] head validated                           hash=0xde76b74d8f7efe38b12a3f00a61b13c1a4af9d629900acf29c79252966dccc0e number=24710273 age=4d21h32m execution=3s mgas/s=390.94 avg mgas/s=213.93 alloc=30.9GB sys=33.3GB
[INFO] [05-27|06:12:13.558] head validated                           hash=0x23f70d7086b526ff6d0440ee746de8fc1909d33ace5b6ce27cff49c636c577c5 number=24710275 age=4d21h32m execution=3s mgas/s=386.36 avg mgas/s=212.14 alloc=31.9GB sys=33.3GB
[INFO] [05-27|06:12:20.312] head validated                           hash=0x0bda3e1e3d4c10ccc9d41155afb98c5d55e0eb1614bafbefb141b03238806669 number=24710277 age=4d21h31m execution=3s mgas/s=391.37 avg mgas/s=210.90 alloc=32.5GB sys=33.3GB
[INFO] [05-27|06:12:27.051] head validated                           hash=0xe6c0b92d4977d0b2a67d1cdd5e8d43bbd9b282c3594b9f26eea02e1fc7ed1fc1 number=24710278 age=4d21h31m execution=3s mgas/s=344.69 avg mgas/s=219.53 alloc=33.6GB sys=34.2GB
[INFO] [05-27|06:12:34.074] head validated                           hash=0x57f481df4567f341234c5a182266451236bf1d466d465192a6dfe3dd922ef95e number=24710280 age=4d21h30m execution=3s mgas/s=359.02 avg mgas/s=215.28 alloc=20.5GB sys=34.2GB
[INFO] [05-27|06:12:42.486] head validated                           hash=0x5767993d391a522e9181f07a598a2afd5d52b5de49ca9149272b08232c8f24b2 number=24710282 age=4d21h30m execution=3s mgas/s=317.70 avg mgas/s=208.90 alloc=21.3GB sys=34.2GB
[INFO] [05-27|06:12:48.375] head validated                           hash=0x552355da7808b868edb374ff04b6b894678c76ea313a700f963c0ebe121ee593 number=24710283 age=4d21h30m execution=39ms mgas/s=1.30 avg mgas/s=195.50 alloc=21.4GB sys=34.2GB
[INFO] [05-27|06:12:51.626] head validated                           hash=0x17e09eacf46660a60f242396d1dc2f11fda8ca7eb64b3bb04bdc78f851feab10 number=24710284 age=4d21h29m execution=3s mgas/s=305.10 avg mgas/s=202.57 alloc=22.3GB sys=34.2GB
[INFO] [05-27|06:13:00.074] head validated                           hash=0x703bf6365fab246a42453c1eac9f5f72f53f040524e475f6fd600efa8165de0e number=24710286 age=4d21h29m execution=3s mgas/s=308.81 avg mgas/s=197.20 alloc=23.3GB sys=34.2GB
[INFO] [05-27|06:13:09.975] head validated                           hash=0x6268cddb91eac70b96f8e0a79465856ce7fa071ce234558ff3e86e2253d9dbd0 number=24710288 age=4d21h28m execution=3s mgas/s=322.91 avg mgas/s=193.41 alloc=24.3GB sys=34.2GB
[INFO] [05-27|06:13:15.123] head validated                           hash=0x3f443f8f1ea2ac247913cc213028b8be1bc73b6977d59bd42c32bad992795156 number=24710289 age=4d21h28m execution=26ms mgas/s=1.55 avg mgas/s=181.03 alloc=24.3GB sys=34.2GB
[INFO] [05-27|06:13:18.257] head validated                           hash=0xff6af85a86c1e5edc880635f06876096de30367060406c8bbe7bd56c106895a1 number=24710290 age=4d21h28m execution=3s mgas/s=316.96 avg mgas/s=189.80 alloc=25.1GB sys=34.2GB
[INFO] [05-27|06:13:26.484] head validated                           hash=0x1c89f113165af8a35b4329e1a730b149659de4f643d0e811036ff9d91e629e89 number=24710291 age=4d21h28m execution=3s mgas/s=287.33 avg mgas/s=196.09 alloc=25.9GB sys=34.2GB
[INFO] [05-27|06:13:34.776] head validated                           hash=0x31b0820ea76e77d98ce292a677b0307a35cca25a71bdf734ccab2806817c3622 number=24710293 age=4d21h27m execution=3s mgas/s=321.16 avg mgas/s=192.33 alloc=26.9GB sys=34.2GB
[INFO] [05-27|06:13:40.067] head validated                           hash=0x781d3ef9c428f1b59ec81cf281d505d192d7a717bf3fba16416f7116255fa81a number=24710294 age=4d21h27m execution=35ms mgas/s=1.99 avg mgas/s=180.05 alloc=27.0GB sys=34.2GB
[INFO] [05-27|06:13:43.613] head validated                           hash=0xf4df61bfdee8ced53ea72fa1cfa1e0a6a7aa8c3688f62adc7e849a72783a14e3 number=24710295 age=4d21h27m execution=3s mgas/s=288.70 avg mgas/s=187.06 alloc=27.9GB sys=34.2GB
[INFO] [05-27|06:13:53.352] head validated                           hash=0xe17ef18d7128e5236b092ced21405ba475095e47a5d087e11ba05007d83e9d57 number=24710297 age=4d21h26m execution=3s mgas/s=316.23 avg mgas/s=184.10 alloc=28.8GB sys=34.2GB
[INFO] [05-27|06:14:01.982] head validated                           hash=0x2e5c77720658c702e479113c27142c5e96a352e201b6797f2d661242c5dd3ec9 number=24710299 age=4d21h26m execution=3s mgas/s=317.01 avg mgas/s=181.56 alloc=29.8GB sys=34.2GB
[INFO] [05-27|06:14:07.911] head validated                           hash=0x0cde23fc9121366300b9352588b733520d334779721ffa50259aae5cbad0978e number=24710300 age=4d21h26m execution=38ms mgas/s=0.81 avg mgas/s=169.90 alloc=29.9GB sys=34.2GB
[INFO] [05-27|06:14:11.105] head validated                           hash=0xa8f809f20898ccc811b2b240fc23dc5fca952b57108f4704969353144317c3a2 number=24710301 age=4d21h25m execution=3s mgas/s=311.16 avg mgas/s=179.02 alloc=30.6GB sys=34.2GB
[INFO] [05-27|06:14:19.084] head validated                           hash=0xc5590ed4cbc15417de9c62da2a09b016ee3f5b032cb8383755ef8f2fcc164408 number=24710303 age=4d21h25m execution=3s mgas/s=311.04 avg mgas/s=176.73 alloc=31.4GB sys=34.2GB
[INFO] [05-27|06:14:28.074] head validated                           hash=0xcc133dd9a90a6211537b06baca48730891a601349f4da3c796c6cc15e5bf2d85 number=24710304 age=4d21h25m execution=3s mgas/s=297.80 avg mgas/s=184.54 alloc=32.0GB sys=34.2GB
[INFO] [05-27|06:14:36.591] head validated                           hash=0x007dbd31d84afda0205563090aa9164cb2873755f12507b646880ad5c73df345 number=24710306 age=4d21h24m execution=3s mgas/s=287.80 avg mgas/s=180.06 alloc=20.0GB sys=34.2GB
[INFO] [05-27|06:14:45.701] head validated                           hash=0x2c9dec5c7c7ac8ae8d671c422b2d557080b671756be6efaa67d7d8b4457cec12 number=24710308 age=4d21h24m execution=4s mgas/s=280.96 avg mgas/s=175.71 alloc=21.0GB sys=34.2GB

```
Blocks with <50k gas dragged the EWMA down as much as heavy 30 Mgas blocks.

**After** — gas and time are each EWMAed separately, then divided:
```go
e.accumGasMgas = alpha*gasUsedMgas + (1-alpha)*e.accumGasMgas
e.accumTimeSec = alpha*totalTime.Seconds() + (1-alpha)*e.accumTimeSec
avgMgasSec := e.accumGasMgas / e.accumTimeSec
```
An empty block contributes proportionally tiny values to both numerator and denominator, so the ratio stays stable.