### PR TITLE
ci: build hive & hive-eest erigon clients from local source, not an ephemeral merge-queue ref

### DIFF
--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -173,21 +173,16 @@ jobs:
         with:
           go-version: '>=1.25'
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      # Build erigon from the checked-out commit and wrap it with Hive's
-      # prebuilt-image client Dockerfile. Avoids cloning the commit inside
-      # Hive's builder: the merge_group ref is ephemeral and can be deleted
-      # mid-run (queue re-form / slow runner), which fails the clone.
+      # Build erigon from the checked-out commit, then wrap it with Hive's
+      # prebuilt-image client Dockerfile — avoids cloning the ephemeral
+      # merge_group ref inside Hive's builder.
+      # Plain docker build (host daemon's persistent cache), not a shared
+      # type=gha scope: many matrix jobs writing one gha scope risks 504s
+      # (cf. the centralized build in test-kurtosis-assertoor.yml).
       - name: Build erigon image from local source
-        uses: docker/build-push-action@v6
-        with:
-          context: erigon-full
-          load: true
-          tags: hive/erigon:cilocal
-          cache-from: type=gha,scope=hive-erigon-build
-          cache-to: type=gha,mode=max,scope=hive-erigon-build
+        env:
+          DOCKER_BUILDKIT: "1"
+        run: docker build -t hive/erigon:cilocal erigon-full
 
       - name: Get dependencies and build hive
         env:

--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -132,19 +132,14 @@ jobs:
           fi
           echo "Pruning docker system..."
           docker system prune -af --volumes
-      - name: Checkout Erigon meta
+      - name: Checkout Erigon
         uses: actions/checkout@v6
         with:
-          sparse-checkout: |
-            go.mod
-            .github/workflows/hive-versions.json
-            test-fixtures.json
-          sparse-checkout-cone-mode: false
-          path: erigon-src
+          path: erigon-full
 
       - name: Read pinned Hive ref
         id: hive-version
-        run: echo "ref=$(jq -r .hive_ref erigon-src/.github/workflows/hive-versions.json)" >> "$GITHUB_OUTPUT"
+        run: echo "ref=$(jq -r .hive_ref erigon-full/.github/workflows/hive-versions.json)" >> "$GITHUB_OUTPUT"
 
       - name: Checkout Hive
         uses: actions/checkout@v6
@@ -178,28 +173,35 @@ jobs:
         with:
           go-version: '>=1.25'
 
-      # Targeting the clients/erigon/Dockerfile.git in the Hive director -
-      # this builds the container from github and uses it for tests
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      # Build erigon from the checked-out commit and wrap it with Hive's
+      # prebuilt-image client Dockerfile. Avoids cloning the commit inside
+      # Hive's builder: the merge_group ref is ephemeral and can be deleted
+      # mid-run (queue re-form / slow runner), which fails the clone.
+      - name: Build erigon image from local source
+        uses: docker/build-push-action@v6
+        with:
+          context: erigon-full
+          load: true
+          tags: hive/erigon:cilocal
+          cache-from: type=gha,scope=hive-erigon-build
+          cache-to: type=gha,mode=max,scope=hive-erigon-build
+
       - name: Get dependencies and build hive
         env:
-          SOURCE_REPO: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          # Toggle dbg.Exec3Parallel inside the hive-built erigon container.
+          # Toggle dbg.Exec3Parallel inside the hive erigon container.
           # Baked as an ENV directive into the client Dockerfile so every
           # erigon instance hive launches inherits it.
           ERIGON_EXEC3_PARALLEL: ${{ matrix.exec_mode == 'parallel' && 'true' || 'false' }}
         run: |
           cd hive
-          git status
           go get . >> buildlogs.log
-          rm clients/erigon/Dockerfile
-          mv clients/erigon/Dockerfile.git clients/erigon/Dockerfile
-          branch_name=$(echo ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}} | sed 's/[&/\]/\\&/g')
-          echo Building Hive with Erigon repo - ${SOURCE_REPO}, branch - $branch_name
-          sed -i "s|^ARG github=erigontech/erigon$|ARG github=${SOURCE_REPO}|" clients/erigon/Dockerfile
-          sed -i "s/^ARG tag=main$/ARG tag=${branch_name}/" clients/erigon/Dockerfile
-          go_version=$(go mod edit -json ../erigon-src/go.mod | jq -r .Go)
-          echo "Patching builder Go version to ${go_version}"
-          sed -i "s|golang:[0-9.]*-|golang:${go_version}-|" clients/erigon/Dockerfile
+          # Point hive's default (prebuilt-image) erigon client at the image we
+          # built locally above, instead of cloning erigon inside the builder.
+          sed -i "s|^ARG baseimage=erigontech/erigon$|ARG baseimage=hive/erigon|" clients/erigon/Dockerfile
+          sed -i "s|^ARG tag=main-latest$|ARG tag=cilocal|" clients/erigon/Dockerfile
           # Inject ERIGON_EXEC3_PARALLEL into the runtime image so the
           # erigon process inside hive picks it up. Append as the last layer
           # so it doesn't invalidate earlier build caches.
@@ -219,8 +221,8 @@ jobs:
       # We also fail if more than half the tests fail
       - name: Run hive tests and parse output
         run: |
-          fixtures_url=$(jq -r --arg t '${{ matrix.fixtures-tarball }}' '.[$t].url' erigon-src/test-fixtures.json)
-          branch=$(jq -r --arg t '${{ matrix.fixtures-tarball }}' '.[$t].branch // empty' erigon-src/test-fixtures.json)
+          fixtures_url=$(jq -r --arg t '${{ matrix.fixtures-tarball }}' '.[$t].url' erigon-full/test-fixtures.json)
+          branch=$(jq -r --arg t '${{ matrix.fixtures-tarball }}' '.[$t].branch // empty' erigon-full/test-fixtures.json)
           branch_arg=""
           if [ -n "$branch" ]; then
             branch_arg="--sim.buildarg branch=$branch"

--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -197,6 +197,13 @@ jobs:
           # built locally above, instead of cloning erigon inside the builder.
           sed -i "s|^ARG baseimage=erigontech/erigon$|ARG baseimage=hive/erigon|" clients/erigon/Dockerfile
           sed -i "s|^ARG tag=main-latest$|ARG tag=cilocal|" clients/erigon/Dockerfile
+          # Fail fast if the sed didn't apply (upstream Dockerfile ARGs changed),
+          # otherwise hive would silently use the remote erigontech/erigon image.
+          if ! grep -q "^ARG baseimage=hive/erigon$" clients/erigon/Dockerfile \
+             || ! grep -q "^ARG tag=cilocal$" clients/erigon/Dockerfile; then
+            echo "ERROR: failed to repoint hive's erigon client Dockerfile at hive/erigon:cilocal"
+            exit 1
+          fi
           # Inject ERIGON_EXEC3_PARALLEL into the runtime image so the
           # erigon process inside hive picks it up. Append as the last layer
           # so it doesn't invalidate earlier build caches.

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -125,21 +125,16 @@ jobs:
           username: ${{ secrets.DOCKERHUB_PULL_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      # Build erigon from the checked-out commit and wrap it with Hive's
-      # prebuilt-image client Dockerfile. Avoids cloning the commit inside
-      # Hive's builder: the merge_group ref is ephemeral and can be deleted
-      # mid-run (queue re-form / slow runner), which fails the clone.
+      # Build erigon from the checked-out commit, then wrap it with Hive's
+      # prebuilt-image client Dockerfile — avoids cloning the ephemeral
+      # merge_group ref inside Hive's builder.
+      # Plain docker build (host daemon's persistent cache), not a shared
+      # type=gha scope: many matrix jobs writing one gha scope risks 504s
+      # (cf. the centralized build in test-kurtosis-assertoor.yml).
       - name: Build erigon image from local source
-        uses: docker/build-push-action@v6
-        with:
-          context: erigon-full
-          load: true
-          tags: hive/erigon:cilocal
-          cache-from: type=gha,scope=hive-erigon-build
-          cache-to: type=gha,mode=max,scope=hive-erigon-build
+        env:
+          DOCKER_BUILDKIT: "1"
+        run: docker build -t hive/erigon:cilocal erigon-full
 
       - name: Get dependencies and build hive
         env:

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -84,13 +84,9 @@ jobs:
             max-allowed-failures: 0
             exec_mode: parallel
     steps:
-      - name: Checkout Erigon meta
+      - name: Checkout Erigon
         uses: actions/checkout@v6
         with:
-          sparse-checkout: |
-            go.mod
-            .github/workflows/hive-versions.json
-          sparse-checkout-cone-mode: false
           path: erigon-src
 
       - name: Read pinned versions
@@ -129,32 +125,40 @@ jobs:
           username: ${{ secrets.DOCKERHUB_PULL_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
 
-      # Targeting the clients/erigon/Dockerfile.git in the Hive directory -
-      # this builds the container from github and uses it for tests
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      # Build erigon from the checked-out commit and wrap it with Hive's
+      # prebuilt-image client Dockerfile. Avoids cloning the commit inside
+      # Hive's builder: the merge_group ref is ephemeral and can be deleted
+      # mid-run (queue re-form / slow runner), which fails the clone.
+      - name: Build erigon image from local source
+        uses: docker/build-push-action@v6
+        with:
+          context: erigon-src
+          load: true
+          tags: hive/erigon:cilocal
+          cache-from: type=gha,scope=hive-erigon-build
+          cache-to: type=gha,mode=max,scope=hive-erigon-build
+
       - name: Get dependencies and build hive
         env:
-          SOURCE_REPO: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           EXECUTION_APIS_REF: ${{ steps.hive-version.outputs.execution_apis_ref }}
-          # Toggle dbg.Exec3Parallel inside the hive-built erigon container.
+          # Toggle dbg.Exec3Parallel inside the hive erigon container.
           # We bake this as an ENV directive into the client Dockerfile so
           # every erigon instance hive launches inherits it.
           ERIGON_EXEC3_PARALLEL: ${{ matrix.exec_mode == 'parallel' && 'true' || 'false' }}
         run: |
           cd hive
           go get . >> buildlogs.log
-          rm clients/erigon/Dockerfile
-          mv clients/erigon/Dockerfile.git clients/erigon/Dockerfile
-          branch_name=$(echo ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}} | sed 's/[&/\]/\\&/g')
-          echo Building Hive with Erigon repo - ${SOURCE_REPO}, branch - $branch_name
-          sed -i "s|^ARG github=erigontech/erigon$|ARG github=${SOURCE_REPO}|" clients/erigon/Dockerfile
-          sed -i "s/^ARG tag=main$/ARG tag=${branch_name}/" clients/erigon/Dockerfile
+          # Point hive's default (prebuilt-image) erigon client at the image we
+          # built locally above, instead of cloning erigon inside the builder.
+          sed -i "s|^ARG baseimage=erigontech/erigon$|ARG baseimage=hive/erigon|" clients/erigon/Dockerfile
+          sed -i "s|^ARG tag=main-latest$|ARG tag=cilocal|" clients/erigon/Dockerfile
           # Inject ERIGON_EXEC3_PARALLEL into the runtime image so the
           # erigon process inside hive picks it up. Append as the last layer
           # so it doesn't invalidate earlier build caches.
           echo "ENV ERIGON_EXEC3_PARALLEL=${ERIGON_EXEC3_PARALLEL}" >> clients/erigon/Dockerfile
-          go_version=$(go mod edit -json ../erigon-src/go.mod | jq -r .Go)
-          echo "Patching builder Go version to ${go_version}"
-          sed -i "s|golang:[0-9.]*-|golang:${go_version}-|" clients/erigon/Dockerfile
           # Pin the execution-apis ref used by the rpc-compat simulator so that
           # upstream test additions don't break CI unexpectedly.
           # SECURITY: value comes from hive-versions.json which fork PRs can modify;

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -150,6 +150,13 @@ jobs:
           # built locally above, instead of cloning erigon inside the builder.
           sed -i "s|^ARG baseimage=erigontech/erigon$|ARG baseimage=hive/erigon|" clients/erigon/Dockerfile
           sed -i "s|^ARG tag=main-latest$|ARG tag=cilocal|" clients/erigon/Dockerfile
+          # Fail fast if the sed didn't apply (upstream Dockerfile ARGs changed),
+          # otherwise hive would silently use the remote erigontech/erigon image.
+          if ! grep -q "^ARG baseimage=hive/erigon$" clients/erigon/Dockerfile \
+             || ! grep -q "^ARG tag=cilocal$" clients/erigon/Dockerfile; then
+            echo "ERROR: failed to repoint hive's erigon client Dockerfile at hive/erigon:cilocal"
+            exit 1
+          fi
           # Inject ERIGON_EXEC3_PARALLEL into the runtime image so the
           # erigon process inside hive picks it up. Append as the last layer
           # so it doesn't invalidate earlier build caches.

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -87,13 +87,13 @@ jobs:
       - name: Checkout Erigon
         uses: actions/checkout@v6
         with:
-          path: erigon-src
+          path: erigon-full
 
       - name: Read pinned versions
         id: hive-version
         run: |
-          echo "ref=$(jq -r .hive_ref erigon-src/.github/workflows/hive-versions.json)" >> "$GITHUB_OUTPUT"
-          echo "execution_apis_ref=$(jq -r '.execution_apis_ref // empty' erigon-src/.github/workflows/hive-versions.json)" >> "$GITHUB_OUTPUT"
+          echo "ref=$(jq -r .hive_ref erigon-full/.github/workflows/hive-versions.json)" >> "$GITHUB_OUTPUT"
+          echo "execution_apis_ref=$(jq -r '.execution_apis_ref // empty' erigon-full/.github/workflows/hive-versions.json)" >> "$GITHUB_OUTPUT"
 
       - name: Checkout Hive
         uses: actions/checkout@v6
@@ -135,7 +135,7 @@ jobs:
       - name: Build erigon image from local source
         uses: docker/build-push-action@v6
         with:
-          context: erigon-src
+          context: erigon-full
           load: true
           tags: hive/erigon:cilocal
           cache-from: type=gha,scope=hive-erigon-build

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -188,11 +188,9 @@ jobs:
             echo -e "\n\n============================================================"
             echo "Running test: ${1}-${2}"
             echo -e "\n"
-            ./hive -docker.auth --sim "${1}" --sim.limit="${2}" --sim.limit.exact=false --sim.parallelism=8 --sim.timelimit 15m --docker.output --client erigon 2>&1 | tee output.log || {
-              if [ $? -gt 0 ]; then
-                echo "Exitcode gt 0"
-              fi
-            }
+            if ! ./hive -docker.auth --sim "${1}" --sim.limit="${2}" --sim.limit.exact=false --sim.parallelism=8 --sim.timelimit 15m --docker.output --client erigon 2>&1 | tee output.log; then
+              echo "hive exited non-zero; continuing to parse results from output.log"
+            fi
             status_line=$(tail -2 output.log | head -1 | sed -r "s/\x1B\[[0-9;]*[a-zA-Z]//g")
             suites=$(echo "$status_line" | sed -n 's/.*suites=\([0-9]*\).*/\1/p')
             if [ -z "$suites" ]; then

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -44,6 +44,7 @@ rules:
       - qa-rpc-integration-tests-gnosis.yml
       - qa-rpc-integration-tests.yml
       - qa-sync-from-scratch.yml
+      - test-hive-eest.yml
       - test-hive.yml
       - test-kurtosis-assertoor.yml
       - test-kurtosis-gloas.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -44,6 +44,7 @@ rules:
       - qa-rpc-integration-tests-gnosis.yml
       - qa-rpc-integration-tests.yml
       - qa-sync-from-scratch.yml
+      - test-hive.yml
       - test-kurtosis-assertoor.yml
       - test-kurtosis-gloas.yml
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -44,8 +44,6 @@ rules:
       - qa-rpc-integration-tests-gnosis.yml
       - qa-rpc-integration-tests.yml
       - qa-sync-from-scratch.yml
-      - test-hive-eest.yml
-      - test-hive.yml
       - test-kurtosis-assertoor.yml
       - test-kurtosis-gloas.yml
 


### PR DESCRIPTION
## Problem

In the merge queue, hive / hive-eest jobs intermittently fail with **all clients failed to build**:

```
Cloning: erigontech/erigon - gh-readonly-queue/main/pr-XXXXX-<sha>
fatal: Remote branch gh-readonly-queue/main/pr-XXXXX-<sha> not found in upstream origin
→ image build failed (128) → "too few tests" → ci-gate failure
```

`test-hive.yml` / `test-hive-eest.yml` build the hive erigon client via `clients/erigon/Dockerfile.git`, which runs `git clone --depth 1 --branch $tag https://github.com/$github`. For `merge_group` events `GITHUB_HEAD_REF` is empty, so `$tag` falls back to `${GITHUB_REF#refs/heads/}` = the **ephemeral** `gh-readonly-queue/...` ref. When the queue re-forms the group or a runner is slow to start, GitHub deletes that ref before the in-container clone runs → the clone fails. This evicts PRs from the merge queue (e.g. #21421), independent of the failing PR's code.

`actions/checkout` doesn't hit this — GitHub reliably provides the `merge_group` commit to the run; only the *independent* `git clone --branch <ephemeral-ref>` inside hive's builder races the ref's deletion.

## Fix

Build the erigon image from the **checked-out commit** and wrap it with hive's default *prebuilt-image* `Dockerfile` (`FROM $baseimage:$tag`), in both hive workflows:

- check out the full erigon source into a fresh **`erigon-full`** path. The old sparse `erigon-src` path leaves a stale `.git/info/sparse-checkout` on the **reused** self-hosted hive runners; a full checkout into that same path doesn't clear it, so the tree stays sparse, `cmd/erigon` is missing, and the build fails (`cd ./cmd/erigon: No such file or directory`). A fresh path no sparse run has touched avoids that.
- plain **`docker build -t hive/erigon:cilocal`** on the host daemon (persistent layer cache on the reused runners) — *not* a shared `type=gha` cache, so no concurrent-writer 504s and no cross-workflow scope contention (the failure mode `test-kurtosis-assertoor.yml` centralizes its build to avoid).
- point hive's default client Dockerfile at that local image (`baseimage=hive/erigon`, `tag=cilocal`) instead of `mv`-ing in `Dockerfile.git`.
- drop the now-unused `SOURCE_REPO` / `branch_name` / clone-arg / builder-Go-version plumbing.

`-docker.pull` defaults to false (CI doesn't pass it), so `FROM hive/erigon:cilocal` resolves from the local daemon, never force-pulled. erigon's image is `debian:13-slim` with `erigon` on PATH, so hive's default Dockerfile (`apt-get`, `erigon --version`) layers on top cleanly — on both `ethereum/hive` and the `erigontech/hive` fork used by hive-eest.