### PR TITLE
.github: skip Claude review on fork PRs; allow erigon-copilot bot

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,9 +12,12 @@ on:
 
 jobs:
   claude-review:
-    # Skip Dependabot PRs: the action rejects bot actors and CLAUDE_CODE_OAUTH_TOKEN
-    # is not available to Dependabot workflows anyway.
-    if: github.actor != 'dependabot[bot]'
+    # Skip fork PRs and Dependabot: neither can read secrets or mint an OIDC
+    # token, so the review would always fail red. Maintainers can still trigger
+    # a review on a fork PR by commenting `@claude` (handled by claude.yml).
+    if: >-
+      github.actor != 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -33,6 +36,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Scope to specific trusted bots, never '*': this is a public repo and
+          # '*' would let external Apps invoke the action with prompts they control.
+          allowed_bots: 'erigon-copilot'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Problem

`Claude Code Review` (`claude-code-review.yml`) goes red on every PR from an external contributor's fork (e.g. #21434). It is **not** a review finding — fork `pull_request` runs get a read-only token with no secrets and no `id-token`, so `claude-code-action` can't mint its OIDC token and fails at startup:

> Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?

The workflow already requests `id-token: write`, but GitHub does not honor it for fork PRs — a `permissions:` block can only narrow a token, never widen it in that untrusted context.

## Changes

- **Skip the job on fork PRs** via `github.event.pull_request.head.repo.full_name == github.repository`. Fork PRs now report *skipped* (neutral), not red. The explicit Dependabot skip is kept — Dependabot pushes same-repo branches, so the fork check wouldn't cover it.
- **Allow the `erigon-copilot` bot** through the action's human-actor check (`allowed_bots`). This was a separate failure on internal copilot PRs (e.g. #21448: `non-human actor: erigon-copilot`). Scoped to the specific bot, not `*`, since on a public repo `*` would let external Apps invoke the action with prompts they control.

## Notes

- `claude-review` is not a required status check (only `ci-gate` is), so skipping has no merge-gating impact.
- Fork PRs can still be reviewed on demand by commenting `@claude` (handled by `claude.yml`, which triggers in the trusted base context).
- Validated with `actionlint`. YAML-only change — no Go code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)