### PR TITLE
stagedsync/exec3_parallel: re-enable trie warmup on parallel path

### DIFF
--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -217,10 +217,13 @@ func (pe *parallelExecutor) exec(ctx context.Context, execStage *StageState, u U
 	pe.rs.Domains().SetInMemHistoryReads(true)
 	defer pe.rs.Domains().SetInMemHistoryReads(prevInMemHistoryReads)
 
-	// Disable trie warmup — the Warmuper uses sdCtx.updates which the
-	// calculator replaces via SetUpdates before ComputeCommitment.
-	pe.rs.Domains().EnableTrieWarmup(false)
-	defer pe.rs.Domains().EnableTrieWarmup(true)
+	// Trie warmup left enabled for the parallel path. Original disable was
+	// based on a calculator/warmer interaction concern that turned out to be
+	// overly conservative — the Warmuper's reads are independent of the
+	// calculator's SetUpdates call. Removing the disable produced an 8×
+	// throughput improvement on the perf-devnet-3 SSTORE-bloated benchmark
+	// (block 24358306) by letting the Warmuper pre-fetch branch data while
+	// EVM execution runs. See #20920 for the canonical perf measurement.
 
 	// Skip step-boundary commitment — the calculator handles this.
 	pe.rs.StateV3.SetSkipStepBoundaryCommitment(true)


### PR DESCRIPTION
## Summary

Re-enables the trie warmup workers on the parallel-execution path. The current code on `main` disables them at `execution/stagedsync/exec3_parallel.go:220-223` with a comment claiming the Warmuper interacts with `sdCtx.updates` — that claim is incorrect (the Warmuper struct has no `updates` field; it reads only via `cfg.CtxFactory`).

This is a cherry-pick of `ce8cce46e3` from #21380.

## Why

With warmup disabled on the parallel path, branch data is read cold during `ComputeCommitment` while in serial mode warmup workers pre-fetch into MDBX page cache. The result is a ~1.7× NewPayload regression at mainnet tip vs serial.

## Measurements (mainnet tip, fresh local sync, same datadir, lighthouse CL)

Each window 60–180 s of live mainnet at tip. Same blocks-per-block-class workload across runs:

| mode | NewPayload mean | commitment per call | unfold mean wall | keys/s |
|---|---|---|---|---|
| serial | 160.9 ms | 67.6 ms | 2.97 µs | 22.7k |
| parallel (current `main`) | 273.9 ms | 180.1 ms | 16.17 µs | 7.7k |
| **parallel + this patch** | **158.7 ms** | **70.5 ms** | **4.41 µs** | **18.7k** |

The patch closes 98% of the parallel-vs-serial gap. Validated separately against #21380 — that PR's commitment-tip perf matches this patch (the rest of #21380's wins are in non-tip paths: RPC reads, initial sync, fork validation).

The original `ce8cce46e3` commit references an 8× win on the perf-devnet-3 SSTORE-bloated benchmark (block 24358306, #20920). Same finding, different fixture.

## Soak

Patched binary ran at mainnet tip for [duration TBD — currently running] with no FATAL/panic/wrong-trie-root and steady ~25 blocks per 5-minute window (mainnet slot cadence).

## CI

Posting this PR partly to surface any hive/EEST/consensus-test regressions the warmup re-enable might introduce — none was documented as the reason for the original disable, but worth verifying broadly.