### PR TITLE
grwoslice: use `slices.Grow` instead of hand-rolled grow funcs

### DIFF
--- a/db/compress/compress.go
+++ b/db/compress/compress.go
@@ -2,19 +2,11 @@ package compress
 
 import (
 	"fmt"
+	"slices"
 	"sync"
 
 	"github.com/klauspost/compress/zstd"
 )
-
-// growslice ensures b has the wanted length by either expanding it to its capacity
-// or allocating a new slice if b has insufficient capacity.
-func growslice(b []byte, wantLength int) []byte {
-	if cap(b) >= wantLength {
-		return b[:wantLength]
-	}
-	return make([]byte, wantLength, max(wantLength, 2*cap(b)))
-}
 
 var (
 	// Decoder side: saw 2x higher throughput (parallel RPC with much decoding if use `zstdDecPool` (sync.Pool) vs single `zstd.NewReader`. So, keep pool for decoders.
@@ -40,7 +32,7 @@ func EncodeZstdIfNeed(buf, v []byte, enabled bool) (outBuf []byte, compressed []
 		return buf, v
 	}
 	bound := len(v) + len(v)/255 + 16
-	buf = growslice(buf, bound)
+	buf = slices.Grow(buf[:0], bound)[:bound]
 
 	// EncodeAll uses buf[:0] to reuse the backing array
 	buf = zstdEnc.EncodeAll(v, buf[:0])
@@ -53,7 +45,7 @@ func DecodeZstdIfNeed(buf, v []byte, enabled bool) ([]byte, []byte, error) {
 	if !enabled {
 		return buf, v, nil
 	}
-	buf = growslice(buf, len(v))
+	buf = slices.Grow(buf[:0], len(v))[:len(v)]
 
 	dec := zstdDecPool.Get().(*zstd.Decoder)
 	defer putDec(dec)

--- a/db/etl/buffers.go
+++ b/db/etl/buffers.go
@@ -193,8 +193,12 @@ func (b *sortableBuffer) Get(i int) ([]byte, []byte) {
 }
 
 func (b *sortableBuffer) Prealloc(predictKeysAmount, predictDataSize int) Buffer {
-	b.entries = make([]entryLoc, 0, predictKeysAmount)
-	b.data = make([]byte, 0, predictDataSize)
+	if cap(b.entries) < predictKeysAmount {
+		b.entries = make([]entryLoc, 0, predictKeysAmount)
+	}
+	if cap(b.data) < predictDataSize {
+		b.data = make([]byte, 0, predictDataSize)
+	}
 	return b
 }
 
@@ -315,8 +319,10 @@ func (b *appendSortableBuffer) Reset() {
 	b.size = 0
 }
 func (b *appendSortableBuffer) Prealloc(predictKeysAmount, predictDataSize int) Buffer {
-	b.entries = make(map[string][]byte, predictKeysAmount)
-	b.sortedBuf = make([]sortableBufferEntry, 0, predictKeysAmount)
+	b.entries = make(map[string][]byte, predictKeysAmount) // maps have no cap(), always recreate
+	if cap(b.sortedBuf) < predictKeysAmount {
+		b.sortedBuf = make([]sortableBufferEntry, 0, predictKeysAmount)
+	}
 	return b
 }
 
@@ -389,8 +395,10 @@ func (b *oldestEntrySortableBuffer) Reset() {
 	b.size = 0
 }
 func (b *oldestEntrySortableBuffer) Prealloc(predictKeysAmount, predictDataSize int) Buffer {
-	b.entries = make(map[string][]byte, predictKeysAmount)
-	b.sortedBuf = make([]sortableBufferEntry, 0, predictKeysAmount)
+	b.entries = make(map[string][]byte, predictKeysAmount) // maps have no cap(), always recreate
+	if cap(b.sortedBuf) < predictKeysAmount {
+		b.sortedBuf = make([]sortableBufferEntry, 0, predictKeysAmount)
+	}
 	return b
 }
 

--- a/db/seg/sais/sais.go
+++ b/db/seg/sais/sais.go
@@ -9,7 +9,10 @@
 
 package sais
 
-import "bytes"
+import (
+	"bytes"
+	"slices"
+)
 
 // copy of stdlib `index/suffixarray` SA-IS implementation
 // because Go's stdlib doesn't provide enough low-level api to call necessary funcs
@@ -34,7 +37,7 @@ func Sais(data []byte, sa []int32, buf *[]int32) error {
 	// Pre-size buf to n/2 so recurse_32's "len(tmp) < numLMS" check never triggers.
 	// numLMS is at most n/2, so a buf of n/2 ints is sufficient for all recursion levels.
 	needed := max(512, n/2)
-	*buf = growslice32(*buf, needed)
+	*buf = slices.Grow((*buf)[:0], needed)[:needed]
 	sais_8_32(data, 256, sa, *buf)
 	return nil
 }
@@ -432,11 +435,4 @@ func induceS_8_32(text []byte, sa, freq, bucket []int32) {
 		b--
 		sa[b] = int32(k)
 	}
-}
-
-func growslice32(b []int32, wantLength int) []int32 {
-	if cap(b) >= wantLength {
-		return b[:wantLength]
-	}
-	return make([]int32, wantLength, max(wantLength, 2*cap(b)))
 }

--- a/db/seg/seg_paged_rw.go
+++ b/db/seg/seg_paged_rw.go
@@ -22,6 +22,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"slices"
 	"sync"
 
 	"golang.org/x/sync/errgroup"
@@ -525,9 +526,9 @@ func (c *PagedWriter) bytesUncompressed() (wholePage []byte, notEmpty bool) {
 func pageHeaderTo(buf []byte, kLengths, vLengths []uint32, capacityHint int) []byte {
 	headerSize := 1 + len(kLengths)*2*4
 	if capacityHint > headerSize {
-		buf = growslice(buf, capacityHint)[:headerSize]
+		buf = slices.Grow(buf[:0], capacityHint)[:headerSize]
 	} else {
-		buf = growslice(buf, headerSize)
+		buf = slices.Grow(buf[:0], headerSize)[:headerSize]
 	}
 	buf[0] = uint8(len(kLengths))
 	lensBuf := buf[1:]
@@ -559,15 +560,6 @@ func (c *PagedWriter) SetMetadata(metadata []byte) {
 
 type disableFsycn interface {
 	DisableFsync()
-}
-
-// growslice ensures b has the wanted length by either expanding it to its capacity
-// or allocating a new slice if b has insufficient capacity.
-func growslice(b []byte, wantLength int) []byte {
-	if cap(b) >= wantLength {
-		return b[:wantLength]
-	}
-	return make([]byte, wantLength, max(wantLength, 2*cap(b)))
 }
 
 // Global pools for page work items and results - optimized for GC

--- a/p2p/rlpx/buffer.go
+++ b/p2p/rlpx/buffer.go
@@ -125,12 +125,3 @@ func putUint24(v uint32, b []byte) {
 	b[1] = byte(v >> 8)
 	b[2] = byte(v)
 }
-
-// growslice ensures b has the wanted length by either expanding it to its capacity
-// or allocating a new slice if b has insufficient capacity.
-func growslice(b []byte, wantLength int) []byte {
-	if cap(b) >= wantLength {
-		return b[:wantLength]
-	}
-	return make([]byte, wantLength, max(wantLength, 2*cap(b)))
-}

--- a/p2p/rlpx/rlpx.go
+++ b/p2p/rlpx/rlpx.go
@@ -34,6 +34,7 @@ import (
 	"io"
 	mrand "math/rand"
 	"net"
+	"slices"
 	"time"
 
 	keccak "github.com/erigontech/fastkeccak"
@@ -156,7 +157,7 @@ func (c *Conn) Read() (code uint64, data []byte, wireSize int, err error) {
 		if actualSize > maxUint24 {
 			return code, nil, 0, errPlainMessageTooLarge
 		}
-		c.snappyReadBuffer = growslice(c.snappyReadBuffer, actualSize)
+		c.snappyReadBuffer = slices.Grow(c.snappyReadBuffer[:0], actualSize)[:actualSize]
 		data, err = snappy.Decode(c.snappyReadBuffer, data)
 	}
 	return code, data, wireSize, err
@@ -222,7 +223,8 @@ func (c *Conn) Write(code uint64, data []byte) (uint32, error) {
 		// Ensure the buffer has sufficient size.
 		// Package snappy will allocate its own buffer if the provided
 		// one is smaller than MaxEncodedLen.
-		c.snappyWriteBuffer = growslice(c.snappyWriteBuffer, snappy.MaxEncodedLen(len(data)))
+		snappyBound := snappy.MaxEncodedLen(len(data))
+		c.snappyWriteBuffer = slices.Grow(c.snappyWriteBuffer[:0], snappyBound)[:snappyBound]
 		data = snappy.Encode(c.snappyWriteBuffer, data)
 	}
 


### PR DESCRIPTION
Cherry-pick of #21439 to performance.

Note: `node/rpcstack.go` conflict resolved by keeping the performance-branch version (libdeflate integration is not yet on performance, so the `gzDstGrow` removal doesn't apply).