### PR TITLE
common/dbg: improve heap profile log output

### DIFF
--- a/common/dbg/experiments.go
+++ b/common/dbg/experiments.go
@@ -250,14 +250,16 @@ func SaveHeapProfileNearOOM(opts ...SaveHeapOption) {
 	}
 
 	totalMemory := estimate.TotalMemory()
+	aboveThreshold := memStats.Alloc < (totalMemory/100)*heapProfileThreshold
 	if logger != nil {
 		logger.Info(
 			"[Experiment] heap profile threshold check",
+			"aboveThreshold", aboveThreshold,
 			"alloc", common.ByteCount(memStats.Alloc),
 			"total", common.ByteCount(totalMemory),
 		)
 	}
-	if memStats.Alloc < (totalMemory/100)*heapProfileThreshold {
+	if aboveThreshold {
 		return
 	}
 

--- a/common/dbg/experiments.go
+++ b/common/dbg/experiments.go
@@ -263,7 +263,7 @@ func SaveHeapProfileNearOOM(opts ...SaveHeapOption) {
 			"total", common.ByteCount(totalMemory),
 		)
 	}
-	if aboveThreshold {
+	if !aboveThreshold {
 		return
 	}
 

--- a/common/dbg/experiments.go
+++ b/common/dbg/experiments.go
@@ -38,12 +38,13 @@ import (
 var (
 	MaxReorgDepth = EnvUint("MAX_REORG_DEPTH", 96)
 
-	noMemstat            = EnvBool("NO_MEMSTAT", false)
-	saveHeapProfile      = EnvBool("SAVE_HEAP_PROFILE", false)
-	heapProfileFilePath  = EnvString("HEAP_PROFILE_FILE_PATH", "")
-	heapProfileThreshold = EnvUint("HEAP_PROFILE_THRESHOLD", 35)
-	heapProfileFrequency = EnvDuration("HEAP_PROFILE_FREQUENCY", 30*time.Second)
-	StagesOnlyBlocks     = EnvBool("STAGES_ONLY_BLOCKS", false)
+	saveHeapProfile             = EnvBool("SAVE_HEAP_PROFILE", false)
+	heapProfileFilePath         = EnvString("HEAP_PROFILE_FILE_PATH", "")
+	heapProfileThresholdPercent = EnvUint("HEAP_PROFILE_THRESHOLD", 35)
+	heapProfileFrequency        = EnvDuration("HEAP_PROFILE_FREQUENCY", 30*time.Second)
+	noMemstat                   = EnvBool("NO_MEMSTAT", false)
+
+	StagesOnlyBlocks = EnvBool("STAGES_ONLY_BLOCKS", false)
 
 	MdbxLockInRam    = EnvBool("MDBX_LOCK_IN_RAM", false)
 	MdbxNoSync       = EnvBool("MDBX_NO_FSYNC", false)
@@ -250,12 +251,15 @@ func SaveHeapProfileNearOOM(opts ...SaveHeapOption) {
 	}
 
 	totalMemory := estimate.TotalMemory()
-	aboveThreshold := memStats.Alloc < (totalMemory/100)*heapProfileThreshold
+	threshold := (totalMemory / 100) * heapProfileThresholdPercent
+	aboveThreshold := memStats.Alloc >= threshold
 	if logger != nil {
 		logger.Info(
-			"[Experiment] heap profile threshold check",
-			"aboveThreshold", aboveThreshold,
+			"[Experiment] heap check",
+			"threshold", common.ByteCount(threshold),
 			"alloc", common.ByteCount(memStats.Alloc),
+			"aboveThreshold", aboveThreshold,
+			"sys", common.ByteCount(memStats.Sys),
 			"total", common.ByteCount(totalMemory),
 		)
 	}


### PR DESCRIPTION
Rename `heapProfileThreshold` → `heapProfileThresholdPercent` to make the unit explicit, extract `threshold` and `aboveThreshold` as named locals, and add both to the log line so the heap check is easy to read in logs.