### PR TITLE
faster genesis under `-race` 

### DIFF
--- a/db/rawdb/accessors_metadata.go
+++ b/db/rawdb/accessors_metadata.go
@@ -22,8 +22,9 @@ package rawdb
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
+
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/db/kv"
@@ -32,6 +33,8 @@ import (
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/polygon/bor/borcfg"
 )
+
+var json = jsoniter.ConfigFastest
 
 // ReadChainConfig retrieves the consensus settings based on the given genesis hash.
 func ReadChainConfig(db kv.Getter, hash common.Hash) (*chain.Config, error) {

--- a/db/rawdb/accessors_metadata.go
+++ b/db/rawdb/accessors_metadata.go
@@ -47,13 +47,13 @@ func ReadChainConfig(db kv.Getter, hash common.Hash) (*chain.Config, error) {
 	}
 
 	var config chain.Config
-	if err := json.Unmarshal(data, &config); err != nil {
+	if err := jsoniter.ConfigFastest.Unmarshal(data, &config); err != nil {
 		return nil, fmt.Errorf("invalid chain config JSON: %x, %w", hash, err)
 	}
 
 	if config.BorJSON != nil {
 		borConfig := &borcfg.BorConfig{}
-		if err := json.Unmarshal(config.BorJSON, borConfig); err != nil {
+		if err := jsoniter.ConfigFastest.Unmarshal(config.BorJSON, borConfig); err != nil {
 			return nil, fmt.Errorf("invalid chain config 'bor' JSON: %x, %w", hash, err)
 		}
 		config.Bor = borConfig
@@ -68,14 +68,14 @@ func WriteChainConfig(db kv.Putter, hash common.Hash, cfg *chain.Config) error {
 	}
 
 	if cfg.Bor != nil {
-		borJSON, err := json.Marshal(cfg.Bor)
+		borJSON, err := jsoniter.ConfigFastest.Marshal(cfg.Bor)
 		if err != nil {
 			return fmt.Errorf("failed to JSON encode chain config 'bor': %w", err)
 		}
 		cfg.BorJSON = borJSON
 	}
 
-	data, err := json.Marshal(cfg)
+	data, err := jsoniter.ConfigFastest.Marshal(cfg)
 	if err != nil {
 		return fmt.Errorf("failed to JSON encode chain config: %w", err)
 	}
@@ -96,7 +96,7 @@ func WriteGenesisIfNotExist(db kv.RwTx, g *types.Genesis) error {
 	}
 
 	// Marshal json g
-	val, err := json.Marshal(g)
+	val, err := jsoniter.ConfigFastest.Marshal(g)
 	if err != nil {
 		return err
 	}
@@ -112,7 +112,7 @@ func ReadGenesis(db kv.Getter) (*types.Genesis, error) {
 		return nil, nil
 	}
 	var g types.Genesis
-	if err := json.Unmarshal(val, &g); err != nil {
+	if err := jsoniter.ConfigFastest.Unmarshal(val, &g); err != nil {
 		return nil, err
 	}
 	return &g, nil

--- a/execution/engineapi/engineapitester/engine_x_test_runner.go
+++ b/execution/engineapi/engineapitester/engine_x_test_runner.go
@@ -18,6 +18,7 @@ package engineapitester
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -43,8 +44,6 @@ import (
 	"github.com/erigontech/erigon/node/ethconfig"
 )
 
-var json = jsoniter.ConfigFastest
-
 // NewEngineXTestRunner builds a runner that lazily creates engine-api testers
 // per (fork, preAllocHash) tuple. The supplied ctx is forwarded to each tester
 // at construction time. Options may be passed to customise the runner's
@@ -64,7 +63,7 @@ func NewEngineXTestRunner(ctx context.Context, logger log.Logger, preAllocsDir s
 			return err
 		}
 		var preAlloc PreAlloc
-		err = json.Unmarshal(b, &preAlloc)
+		err = jsoniter.ConfigFastest.Unmarshal(b, &preAlloc)
 		if err != nil {
 			return err
 		}

--- a/execution/engineapi/engineapitester/engine_x_test_runner.go
+++ b/execution/engineapi/engineapitester/engine_x_test_runner.go
@@ -18,7 +18,6 @@ package engineapitester
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -30,6 +29,7 @@ import (
 	"github.com/c2h5oh/datasize"
 	"github.com/holiman/uint256"
 	"github.com/jinzhu/copier"
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dir"
@@ -42,6 +42,8 @@ import (
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/node/ethconfig"
 )
+
+var json = jsoniter.ConfigFastest
 
 // NewEngineXTestRunner builds a runner that lazily creates engine-api testers
 // per (fork, preAllocHash) tuple. The supplied ctx is forwarded to each tester


### PR DESCRIPTION
```
go test -race -count=1 -run TestInvalidReceiptHashHighMgas -timeout=60s -v -cpuprofile=cpu_test.pprof -memprofile=mem_test.pprof ./execution/tests/
```

```
NewEngineXTestRunner.json.Unmarshal 25s -> 20s
WriteGenesisIfNotExist.json.Encode 15.2s -> 11.7s
```

Also: `jsoniter.ConfigFastest`  it's actually a buffers pool - means multiple tests runs in same time will re-use it.

It's not full solution to `TestInvalidReceiptHashHighMgas` speed under race. But step forward. 
