### PR TITLE
execution/types: clear AuRa/PoS fields on Header decode to stop hoisted-reuse leak

### DIFF
--- a/execution/types/block.go
+++ b/execution/types/block.go
@@ -410,6 +410,10 @@ func (h *Header) DecodeRLP(s *rlp.Stream) error {
 		return fmt.Errorf("read MixDigest: %w", err)
 	}
 	if size != 32 { // AuRa
+		// Reused *Header may carry stale MixDigest/Nonce from a previous
+		// non-AuRa decode; Hash() encoding depends on which branch is set.
+		h.MixDigest = common.Hash{}
+		h.Nonce = BlockNonce{}
 		if h.AuRaStep, err = s.Uint64(); err != nil {
 			return fmt.Errorf("read AuRaStep: %w", err)
 		}
@@ -417,6 +421,10 @@ func (h *Header) DecodeRLP(s *rlp.Stream) error {
 			return fmt.Errorf("read AuRaSeal: %w", err)
 		}
 	} else {
+		// Symmetric: clear any stale AuRa fields so EncodeRLP's
+		// len(AuRaSeal)>0 branch select stays correct.
+		h.AuRaStep = 0
+		h.AuRaSeal = h.AuRaSeal[:0]
 		if err = s.ReadBytes(h.MixDigest[:]); err != nil {
 			return fmt.Errorf("read MixDigest: %w", err)
 		}

--- a/execution/types/block_test.go
+++ b/execution/types/block_test.go
@@ -495,6 +495,84 @@ func TestAuRaHeaderEncoding(t *testing.T) {
 	require.Nil(t, deep.Equal(&header, &decoded))
 }
 
+// TestDecodeHeader_HoistedReuseAcrossAuRaTransition exercises the hoisted
+// *Header pattern used by ForEachHeader at the AuRa/PoS boundary. The
+// inactive branch's fields must be cleared on each decode so a reused
+// struct does not leak AuRaStep/AuRaSeal (or, symmetrically, MixDigest/
+// Nonce) into the next header, which would make Header.EncodeRLP take the
+// wrong branch and yield a wrong Hash().
+func TestDecodeHeader_HoistedReuseAcrossAuRaTransition(t *testing.T) {
+	t.Parallel()
+
+	auraDifficulty, err := uint256.FromDecimal("8398142613866510000000000000000000000000000000")
+	require.NoError(t, err)
+	aura := Header{
+		ParentHash:  common.HexToHash("0x8b00fcf1e541d371a3a1b79cc999a85cc3db5ee5637b5159646e1acd3613fd15"),
+		UncleHash:   common.HexToHash("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"),
+		Coinbase:    common.HexToAddress("0x571846e42308df2dad8ed792f44a8bfddf0acb4d"),
+		Root:        common.HexToHash("0x351780124dae86b84998c6d4fe9a88acfb41b4856b4f2c56767b51a4e2f94dd4"),
+		TxHash:      common.HexToHash("0x6a35133fbff7ea2cb5ee7635c9fb623f96d31d689d806a2bfe40a2b1d90ee99c"),
+		ReceiptHash: common.HexToHash("0x324f54860e214ea896ea7a05bda30f85541be3157de77a9059a04fdb1e86badd"),
+		Difficulty:  *auraDifficulty,
+		Number:      *uint256.NewInt(24_679_923),
+		GasLimit:    30_000_000,
+		GasUsed:     3_074_345,
+		Time:        1_666_343_339,
+		Extra:       common.FromHex("0x1234"),
+		BaseFee:     uint256.NewInt(7_000_000_000),
+		AuRaStep:    13_078,
+		AuRaSeal:    common.FromHex("0x75bda30f85541be059646e1acd3613fd100846e42308df2dad8ed79b9a9e91c9db994386599a683820a1394684d41fc139c4805684142e6b15a722a2e9cc51f7ee"),
+	}
+
+	pos := Header{
+		ParentHash:  common.HexToHash("0xaaaa000000000000000000000000000000000000000000000000000000000000"),
+		UncleHash:   common.HexToHash("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"),
+		Coinbase:    common.HexToAddress("0xbbbb000000000000000000000000000000000000"),
+		Root:        common.HexToHash("0xcccc000000000000000000000000000000000000000000000000000000000000"),
+		TxHash:      common.HexToHash("0x6a35133fbff7ea2cb5ee7635c9fb623f96d31d689d806a2bfe40a2b1d90ee99c"),
+		ReceiptHash: common.HexToHash("0x324f54860e214ea896ea7a05bda30f85541be3157de77a9059a04fdb1e86badd"),
+		Difficulty:  *common.Num0,
+		Number:      *uint256.NewInt(25_528_811),
+		GasLimit:    30_000_000,
+		GasUsed:     1_234_567,
+		Time:        1_700_000_000,
+		Extra:       common.FromHex("0xdeadbeef"),
+		MixDigest:   common.HexToHash("0x7f04e338b206ef863a1fad30e082bbb61571c74e135df8d1677e3f8b8171a09b"),
+		Nonce:       BlockNonce{1, 2, 3, 4, 5, 6, 7, 8},
+		BaseFee:     uint256.NewInt(7_000_000_000),
+	}
+
+	auraHash := aura.Hash()
+	posHash := pos.Hash()
+
+	auraRLP, err := rlp.EncodeToBytes(&aura)
+	require.NoError(t, err)
+	posRLP, err := rlp.EncodeToBytes(&pos)
+	require.NoError(t, err)
+
+	t.Run("aura_then_pos", func(t *testing.T) {
+		var h Header
+		require.NoError(t, DecodeHeader(auraRLP, &h))
+		require.Equal(t, auraHash, h.Hash(), "AuRa decode hash mismatch")
+
+		require.NoError(t, DecodeHeader(posRLP, &h))
+		require.Zero(t, h.AuRaStep, "AuRaStep leaked from previous AuRa decode")
+		require.Empty(t, h.AuRaSeal, "AuRaSeal leaked from previous AuRa decode")
+		require.Equal(t, posHash, h.Hash(), "post-merge hash wrong after AuRa->PoS reuse")
+	})
+
+	t.Run("pos_then_aura", func(t *testing.T) {
+		var h Header
+		require.NoError(t, DecodeHeader(posRLP, &h))
+		require.Equal(t, posHash, h.Hash(), "PoS decode hash mismatch")
+
+		require.NoError(t, DecodeHeader(auraRLP, &h))
+		require.Equal(t, common.Hash{}, h.MixDigest, "MixDigest leaked from previous PoS decode")
+		require.Equal(t, BlockNonce{}, h.Nonce, "Nonce leaked from previous PoS decode")
+		require.Equal(t, auraHash, h.Hash(), "AuRa hash wrong after PoS->AuRa reuse")
+	})
+}
+
 func TestWithdrawalsEncoding(t *testing.T) {
 	t.Parallel()
 	header := Header{


### PR DESCRIPTION
## Summary

Fixes #21424.

`(*Header).DecodeRLP` reuses the existing struct (since #21287's hoisted-`var header` walker in `ForEachHeader`), but the AuRa-vs-PoS branch never clears the inactive set:

- After an AuRa decode, `AuRaStep`/`AuRaSeal` stay set.
- A subsequent non-AuRa decode reads `MixDigest`/`Nonce` but leaves the old AuRa values in place.
- `EncodeRLP` picks its branch by `len(h.AuRaSeal) > 0`, so `Header.Hash()` on the post-merge header returns a hash computed over the wrong RLP (AuRaStep/AuRaSeal instead of MixDigest/Nonce).

In production this matters in exactly one place: `FillDBFromSnapshots` walks the frozen header range through `ForEachHeader` and writes TD records keyed by `(blockNum, header.Hash())`. On Gnosis/Chiado the merge transition is in-range, so every post-merge frozen header gets its TD stored under a corrupt hash. The first parent-TD lookup past the snapshot tip then misses with `parent's total difficulty not found with hash 3646…0d1 and height 46301999: <nil>`, blocking both the Caplin `BlockCollector` flush and the engine-API backward downloader. Mainnet never used AuRa so it never hits the leak.

## Fix

Clear the inactive branch's fields at the top of the matching branch in `(*Header).DecodeRLP`. For AuRa→PoS we zero `MixDigest`/`Nonce`; for PoS→AuRa we zero `AuRaStep` and shrink `AuRaSeal` to length 0 (keeping the backing slice the way the AuRa branch already does for its own scratch).

## Test plan

New `TestDecodeHeader_HoistedReuseAcrossAuRaTransition` in `execution/types/block_test.go` with two subtests covering both directions of the transition. Each decodes one header into a fresh hoisted `Header` then decodes the other into the same struct, and asserts both the inactive fields are zero and `Hash()` matches the canonical hash computed before any reuse.

Confirmed:

- Both subtests fail on `main` (AuRaStep=13078 leak; MixDigest leak) and pass on this branch.
- `go test ./execution/types/...` green
- `go test ./db/snapshotsync/freezeblocks/...` green
- `go test ./execution/rlp/... ./execution/stagedsync/rawdbreset/...` green
- `make lint` clean
- `make erigon integration` builds

Beyond that, the QA `Sync-from-scratch` jobs on gnosis/chiado that started failing 2026-05-21 are the ones this targets — they are the way to validate the fix end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)