### PR TITLE
rpc/jsonrpc: filter redundant collapse-sibling nodes from debug_executionWitness

### DIFF
--- a/docs/plans/20260527-witness-collapse-sibling-filter.md
+++ b/docs/plans/20260527-witness-collapse-sibling-filter.md
@@ -278,16 +278,20 @@ post-condition that catches any over-drop.
 **Files:**
 - Modify: `rpc/jsonrpc/debug_execution_witness.go`
 
-- [ ] Add a helper (one-line docstring) that, given `witnessTrie`, `siblingPaths`, and the
+- [x] Add a helper (one-line docstring) that, given `witnessTrie`, `siblingPaths`, and the
       encoded node slice, returns the reduced slice. Map each sibling path → node → keccak
       hash; apply the Task-2 criterion to build a **drop-set of hashes**.
-- [ ] Rebuild `encodedNodes` in original DFS order skipping dropped hashes; **never drop
-      index 0**; assert the root hash survives. No map-iteration ordering.
-- [ ] Wire it into `buildWitnessTrie` before returning; leave `verifyWitnessStateless`
+      → `filterRedundantCollapseSiblings` (debug_execution_witness.go); node→hash via new
+      `(*trie.Trie).NodeHash` so the dedup key matches `RLPEncode`.
+- [x] Rebuild `encodedNodes` in original DFS order skipping dropped hashes; **never drop
+      index 0**; assert the root hash survives. No map-iteration ordering. → drop-set excludes
+      `keccak(encoded[0])`; output rebuilt by iterating `encoded` in order.
+- [x] Wire it into `buildWitnessTrie` before returning; leave `verifyWitnessStateless`
       untouched so it validates the filtered `result.State`. A verify failure is a hard error
       — no silent fallback to the unfiltered set.
-- [ ] Run Task 1 collapse tests — confirm GREEN (minimal set, verify passes).
-- [ ] Run `TestExecutionWitnessNoCollapseUnchanged` — still a no-op.
+- [x] Run Task 1 collapse tests — confirm GREEN (minimal set, verify passes). Account 6→5,
+      storage 8→7; `probeRedundantNodes` now empty for both.
+- [x] Run `TestExecutionWitnessNoCollapseUnchanged` — still a no-op.
 
 ### Task 4: Over-filtering counter-test (load-bearing sibling retained)
 

--- a/docs/plans/20260527-witness-collapse-sibling-filter.md
+++ b/docs/plans/20260527-witness-collapse-sibling-filter.md
@@ -1,0 +1,237 @@
+# Collapse-Sibling Output Filter for debug_executionWitness
+
+## Overview
+
+`debug_executionWitness` currently emits **more trie nodes than Geth** for the same
+block. Per the analysis in erigontech/erigon#21312, the residual extra nodes are all
+**sibling collapse nodes** — storage or account leaf nodes at full-depth (128-nibble)
+paths that Erigon's HexPatriciaHashed (HPH) witness builder emits as explicit entries
+so the parent branch hashes correctly. Geth's standard MPT keeps the sibling hash
+**inline** inside the parent branch RLP and never emits the sibling leaf as a separate
+witness node. Across the issue's test table Erigon is +1..+18 nodes vs Geth.
+
+This change removes the **redundant** collapse-sibling nodes from the witness output so
+Erigon's `state` array matches Geth's, **without** weakening the witness: a node is only
+dropped when stateless re-execution still reproduces the block's state root with it
+removed. We do **not** touch the HPH conversion (`toWitnessTrie`) — the fix is a filter
+at the output boundary plus the existing stateless-verification guardrail run on the
+filtered set.
+
+This is **Change 1 of 3** separate deliverables:
+1. zkevm witness test suite (separate branch `awskii/eest-zkevm-witness`, not a dependency here)
+2. **this change** — collapse-sibling output filter
+3. Amsterdam BAL access-set provider (separate plan)
+
+Scope is strictly the filter + its in-tree test. No BAL/Amsterdam work, no changes to the
+re-execution loop.
+
+## Context (from discovery)
+
+- **Branch:** `awskii/witness-collapse-sibling-filter` off `main`, worktree `/Users/awskii/org/wrk/erigon-exec-witness`.
+- **Handler:** `rpc/jsonrpc/debug_execution_witness.go`
+  - `ExecutionWitness` (~L524): re-executes block via `RecordingState`, collects access set, then:
+    - `detectCollapseSiblings` (~L891, STEP 1): commitment fold/unfold over a split reader; records every collapse path via `sdCtx.SetCollapseTracer(...)` into `siblingPaths`.
+    - `buildWitnessTrie` (~L945, STEP 2): re-seeks parent state, `touchAll` + `TouchHashedKey(siblingPath)` for each sibling path, calls `sdCtx.Witness(...)` → `witnessTrie.RLPEncode()`; returns `encodedNodes`. Result assigned to `result.State` (~L695).
+  - `verifyWitnessStateless` (~L1087): decodes `result.State`, re-executes statelessly, asserts resulting root == `block.Root()`. Gated off by `ERIGON_WITNESS_NO_VERIFY=true`. **Already runs on `result.State` after it is set**, so filtering before this point means the guardrail validates the filtered set for free.
+- **Witness trie / encoding:** `execution/commitment/trie/trie.go`
+  - `(*Trie).RLPEncode()` (L1450): DFS over merged trie, hashes each node, **dedups by keccak hash** (`seen` map), appends RLP for `ShortNode`/`DuoNode`/`FullNode` and `AccountNode.Storage`; `ValueNode`/`HashNode` emit nothing. Output is a flat hash-deduped `[][]byte` in **DFS order, root first**.
+  - `RLPDecode` (L1542): inverse, used by the stateless verifier. **Hard invariant:** `encodedNodes[0]` must be the root (`rootHash := crypto.Keccak256Hash(encodedNodes[0])`, ~L1559). Any filter must preserve slice order and never drop/move element 0.
+- **HPH witness build:** `execution/commitment/hex_patricia_hashed.go` — `GenerateWitness` → `toWitnessTrie`. **Not modified by this change.**
+- **Existing test harness:** `rpc/jsonrpc/debug_api_test.go`:
+  - `TestExecutionWitness` (~L754) is the **canonical commitment-history setup** to copy: `statecfg.EnableHistoricalCommitment()` + `rawdb.WriteDBCommitmentHistoryEnabled(tx, true)`.
+  - **It uses `rpcdaemontest.CreateTestExecModule` which inserts a FIXED canned 13-block chain** (`cmd/rpcdaemon/rpcdaemontest/test_util.go:127`, generator hard-coded ~L181) — it CANNOT author a controlled collapse. Use a bespoke-chain variant instead: model on `CreateTestExecModuleForTraces` / `...Collision` (test_util.go ~L463 / ~L573), or build directly via `execmoduletester.New(...)` + `blockgen.GenerateChain` with a caller-supplied block closure.
+  - The zkevm runner (`execution/tests/eest_zkevm_witness/...`) lives on the separate `awskii/eest-zkevm-witness` branch and is **not present in this worktree** — do not grep for it; it is a local cross-check only.
+
+## Development Approach
+
+- **Testing approach:** TDD (per repo CLAUDE.md) — failing test first, for the right reason, then minimal fix. **Never add a `t.Skip`** (forbidden for agents).
+- Complete each task fully (tests passing) before the next.
+- Small, focused changes. No comments unless an invariant the types don't enforce.
+- `make lint` after changes (non-deterministic — run until clean); `make erigon integration` before done.
+- Commit prefix: `rpc/jsonrpc: ...`.
+
+## Testing Strategy
+
+- **In-tree unit tests (the merge oracle, on `main`, no zkevm-suite dependency):**
+  - account-trie 2→1 collapse → redundant sibling absent, exact multiset, verify passes;
+  - storage-trie 2→1 collapse → same (different path/parent shape, not interchangeable);
+  - no-collapse block → filter is a strict no-op (golden output unchanged);
+  - load-bearing sibling → specific sibling hash **present**, verify passes (over-filter guard).
+  None set `ERIGON_WITNESS_NO_VERIFY`. Exact multiset assertions carry the minimality claim
+  (verify only proves safety, not minimality). This is what CI runs.
+- **Local cross-check (NOT in the PR):** run the zkevm suite
+  (`execution/tests/eest_zkevm_witness`) from a *scratch* layering `main + this change +
+  awskii/eest-zkevm-witness` to confirm exact `state` multiset parity on Amsterdam fixtures.
+  The zkevm branch must never become a dependency of this PR.
+- No e2e/UI tests in this repo.
+
+## Progress Tracking
+
+- Mark `[x]` immediately when done. New tasks ➕, blockers ⚠️. Keep this file in sync.
+
+## Solution Overview
+
+Filter the encoded node list inside `buildWitnessTrie`, where both the built `witnessTrie`
+and `siblingPaths` are in scope:
+
+1. Build the witness trie exactly as today.
+2. Compute the **candidate** set: the RLP nodes that correspond to the collapse
+   `siblingPaths` (walk the trie to each path, hash that node — it is in the encoded set
+   because it was force-touched via `TouchHashedKey`).
+3. Determine which candidates are **redundant** — their content is not required for a
+   standard-MPT verifier to reproduce the post-state because the parent branch already
+   carries the sibling's 32-byte hash inline and the branch does not actually collapse to a
+   single child during stateless re-execution. Drop only those.
+4. Return the reduced node list, **preserving DFS order with the root at index 0**.
+   `verifyWitnessStateless` then runs on the reduced `result.State` (existing call, no
+   relocation needed) and asserts the root still matches.
+
+**Guardrail asymmetry (important):** the verifier re-roots by doing real deletes
+(`s.t.Delete`/`DeleteSubtree`) then `s.t.Hash()` (debug_execution_witness.go ~L1703-1802), so
+a wrongly-dropped *load-bearing* sibling fails verification loudly. But verify only catches
+**over-filtering** (dropped a needed node). It does **not** catch **under-filtering** (kept a
+redundant node → verify still passes). So the verify guardrail proves *safety*, not
+*minimality*. The node-count/Geth-parity goal is enforced **solely** by the tests' exact
+multiset assertions — which therefore must cover the relevant collapse shapes.
+
+The precise redundancy criterion is the genuinely hard part (a real 2→1 collapse *does* need
+its surviving sibling). It is derived and **written down in Task 2 as an explicit decision**
+before any filter code is written, tied to how the stateless verifier re-roots, and stated
+with the set of collapse shapes it is proven against. We prefer a **sound structural
+criterion** over drop-and-retry so the result is deterministic and verify stays a pure
+assertion.
+
+## Technical Details
+
+- `siblingPaths [][]byte` are hashed-key nibble paths (1..128 nibbles) from the collapse
+  tracer. **Two distinct shapes, handled differently:**
+  - *Account-trie sibling*: path at `addrHash` depth, a leaf in the main trie.
+  - *Storage-trie sibling*: path at full `addrHash||slotHash` depth, living under an
+    `AccountNode.Storage` subtrie (`RLPEncode` recurses through the `AccountNode` case,
+    trie.go:1513-1518). The path→node walk and the "which branch is the parent" question
+    differ from the account case. Both must be covered by tests; they are NOT interchangeable.
+- A node is identified in `result.State` by `keccak256(nodeRLP)` (the dedup key in
+  `RLPEncode`). The filter works in hash space: for each sibling path, resolve the node at
+  that path in `witnessTrie`, hash it, and decide redundancy via the Task-2 criterion.
+- **Ordering invariant:** the filter MUST preserve slice order and MUST NOT drop element 0
+  (the root). Implement by computing a drop-set of hashes, then rebuilding the slice in the
+  original order skipping dropped hashes — never via map iteration. Assert the root hash
+  survives.
+- **No-collapse fast path:** when `siblingPaths` is empty the filter is a strict no-op and
+  output must equal today's byte-for-byte (regression-guarded by a test).
+- Filtering lives inside `buildWitnessTrie` (both `witnessTrie` and `siblingPaths` in scope),
+  before the `encodedNodes` slice is returned.
+
+## What Goes Where
+
+- **Implementation Steps** (checkboxes): the failing test, the filter, wiring, validation, docs.
+- **Post-Completion** (no checkboxes): zkevm scratch-layering cross-check, PR open.
+
+## Implementation Steps
+
+### Task 1: Bespoke-chain test harness + deterministic collapse fixtures (RED)
+
+**Files:**
+- Modify: `rpc/jsonrpc/debug_api_test.go`
+- Possibly Modify: `cmd/rpcdaemon/rpcdaemontest/test_util.go` (add a custom-chain constructor if none fits)
+
+- [ ] Stand up a witness test that authors its **own** chain (the canned
+      `CreateTestExecModule` 13-block chain cannot trigger a controlled collapse). Reuse the
+      bespoke-chain pattern from `CreateTestExecModuleForTraces`/`...Collision`, or
+      `execmoduletester.New(...)` + `blockgen.GenerateChain` with a block closure. Copy the
+      commitment-history setup verbatim from `TestExecutionWitness` (~L754):
+      `statecfg.EnableHistoricalCommitment()` + `rawdb.WriteDBCommitmentHistoryEnabled`.
+- [ ] **Deterministic shared-prefix key selection:** pick two addresses (account case) and two
+      storage slots (storage case) whose **keccak hashes share a leading nibble** so they sit
+      under one branch. Brute-force/search candidate keys in the test setup and assert the
+      shared-prefix precondition (so the test is self-validating, not relying on luck).
+- [ ] `TestExecutionWitnessCollapseSiblingAccount`: block creates both accounts, later block
+      deletes one (selfdestruct or balance/nonce→0 path) → account branch collapses 2→1.
+- [ ] `TestExecutionWitnessCollapseSiblingStorage`: contract with two shared-prefix slots set,
+      later block zeroes one → storage branch collapses 2→1.
+- [ ] For each: assert `verifyWitnessStateless` passes (block valid) **without** setting
+      `ERIGON_WITNESS_NO_VERIFY`, and assert the `state` set equals the expected **minimal**
+      multiset (exact, with the redundant sibling absent). Record the current buggy count to
+      prove RED is for the right reason (extra node present).
+- [ ] `TestExecutionWitnessNoCollapseUnchanged`: a block with no deletes → assert filter is a
+      strict no-op (witness identical to pre-change output / a recorded golden count).
+- [ ] Run the new tests — confirm RED on the collapse cases for the right reason; the no-op
+      case should already pass.
+
+### Task 2: Derive and document the redundancy criterion (decision, before any filter code)
+
+**Files:**
+- Modify: `docs/plans/20260527-witness-collapse-sibling-filter.md` (record the decision here)
+
+- [ ] Using the RED fixtures + reading the stateless re-root path
+      (`witnessStateless.Finalize` → `Delete`/`DeleteSubtree` → `Hash`, ~L1703-1802), write
+      down the exact rule for "redundant sibling = safe to drop." Candidate: *the sibling's
+      parent branch retains ≥2 live children after the block's deletes (no structural
+      collapse), so the parent's inline 32-byte hash is sufficient and the leaf is never
+      descended into.*
+- [ ] State explicitly which collapse shapes the rule is **proven** against
+      (account 2→1, storage 2→1) and which are **out of proven scope** (cascading/multi-level
+      collapse, 3→2 branch shrink that is not a collapse). Document cascading collapse as a
+      known limitation if not covered by a test, with the conservative behavior (keep the
+      sibling when unsure — safety over minimality).
+- [ ] Confirm the rule is computable from `witnessTrie` + `siblingPaths` alone (no extra
+      re-execution).
+
+### Task 3: Implement the collapse-sibling filter in buildWitnessTrie
+
+**Files:**
+- Modify: `rpc/jsonrpc/debug_execution_witness.go`
+
+- [ ] Add a helper (one-line docstring) that, given `witnessTrie`, `siblingPaths`, and the
+      encoded node slice, returns the reduced slice. Map each sibling path → node → keccak
+      hash; apply the Task-2 criterion to build a **drop-set of hashes**.
+- [ ] Rebuild `encodedNodes` in original DFS order skipping dropped hashes; **never drop
+      index 0**; assert the root hash survives. No map-iteration ordering.
+- [ ] Wire it into `buildWitnessTrie` before returning; leave `verifyWitnessStateless`
+      untouched so it validates the filtered `result.State`. A verify failure is a hard error
+      — no silent fallback to the unfiltered set.
+- [ ] Run Task 1 collapse tests — confirm GREEN (minimal set, verify passes).
+- [ ] Run `TestExecutionWitnessNoCollapseUnchanged` — still a no-op.
+
+### Task 4: Over-filtering counter-test (load-bearing sibling retained)
+
+**Files:**
+- Modify: `rpc/jsonrpc/debug_api_test.go`
+
+- [ ] Construct/identify a case where the surviving sibling **is** load-bearing (genuine 2→1
+      collapse whose promotion needs the preimage). Assert the **specific** sibling hash is
+      **present** in `state` (exact multiset, not just "verify passed") and verify passes.
+      This makes a degenerate "drop nothing" or "drop everything" filter fail.
+- [ ] Run all witness tests — green.
+
+### Task 5: Refactor and verify acceptance criteria
+
+**Files:**
+- Modify: `rpc/jsonrpc/debug_execution_witness.go`
+
+- [ ] Tidy the helper; no scenario comments; consistent naming.
+- [ ] Pre-Amsterdam `TestExecutionWitness` (all existing sub-cases) still pass unchanged.
+- [ ] All new tests green: account collapse minimal, storage collapse minimal, no-op
+      unchanged, load-bearing retained.
+- [ ] `make lint` (repeat until clean — non-deterministic).
+- [ ] `make erigon integration` builds.
+- [ ] `go test ./rpc/jsonrpc/...` and `go test ./execution/commitment/...` green.
+
+### Task 6: [Final] Docs and plan housekeeping
+- [ ] Update CLAUDE.md / package notes only if a genuinely new, non-obvious pattern emerged
+      (default: no change).
+- [ ] Move this plan to `docs/plans/completed/`.
+
+## Post-Completion
+*Manual / external — no checkboxes*
+
+**Local cross-check (not part of the PR):**
+- Create a scratch worktree layering `main + this change + awskii/eest-zkevm-witness`; run
+  `execution/tests/eest_zkevm_witness` (`make test-fixtures-zkevm` first) and confirm exact
+  `state` multiset parity on Amsterdam fixtures. Record the before/after node counts.
+
+**PR:**
+- Open against `main`. Title: `rpc/jsonrpc: filter redundant collapse-sibling nodes from executionWitness`.
+- Body links erigontech/erigon#21312 and notes the verify-guardrail correctness argument.
+- Note: full Amsterdam node-exactness also needs Change 3 (BAL access set); this change is
+  independent and lands on its own.

--- a/docs/plans/20260527-witness-collapse-sibling-filter.md
+++ b/docs/plans/20260527-witness-collapse-sibling-filter.md
@@ -186,19 +186,92 @@ assertion.
 **Files:**
 - Modify: `docs/plans/20260527-witness-collapse-sibling-filter.md` (record the decision here)
 
-- [ ] Using the RED fixtures + reading the stateless re-root path
+- [x] Using the RED fixtures + reading the stateless re-root path
       (`witnessStateless.Finalize` → `Delete`/`DeleteSubtree` → `Hash`, ~L1703-1802), write
-      down the exact rule for "redundant sibling = safe to drop." Candidate: *the sibling's
-      parent branch retains ≥2 live children after the block's deletes (no structural
-      collapse), so the parent's inline 32-byte hash is sufficient and the leaf is never
-      descended into.*
-- [ ] State explicitly which collapse shapes the rule is **proven** against
+      down the exact rule for "redundant sibling = safe to drop." Candidate (from initial
+      discovery): *the sibling's parent branch retains ≥2 live children after the block's
+      deletes (no structural collapse).* **This candidate was wrong** — it described the
+      no-collapse case (the tracer never even fires there). The correct, code-grounded rule is
+      below (DECISION).
+- [x] State explicitly which collapse shapes the rule is **proven** against
       (account 2→1, storage 2→1) and which are **out of proven scope** (cascading/multi-level
       collapse, 3→2 branch shrink that is not a collapse). Document cascading collapse as a
       known limitation if not covered by a test, with the conservative behavior (keep the
-      sibling when unsure — safety over minimality).
-- [ ] Confirm the rule is computable from `witnessTrie` + `siblingPaths` alone (no extra
-      re-execution).
+      sibling when unsure — safety over minimality). → see DECISION §"Proven scope".
+- [x] Confirm the rule is computable from `witnessTrie` + `siblingPaths` alone (no extra
+      re-execution). → see DECISION §"Computability".
+
+---
+
+#### DECISION — redundancy criterion (proven against account 2→1 and storage 2→1)
+
+**The rule.** A collapse-sibling node is **redundant (safe to drop)** iff the node it resolves
+to at its `siblingPath` in the witness trie is a **branch node** (`*FullNode` or `*DuoNode`,
+i.e. ≥2 children). It is **load-bearing (must keep)** in every other case — when the path
+resolves to a `*ShortNode` (leaf or extension), an `*AccountNode`, or a `ValueNode`.
+
+**Why this is exactly the right line — tied to how the verifier re-roots.** The stateless
+verifier's `Finalize` (debug_execution_witness.go ~L1703-1802) applies the block's deletes via
+`s.t.Delete` / `s.t.DeleteSubtree` and then calls `s.t.Hash()`. Those deletes run the standard
+MPT collapse in `execution/commitment/trie/trie.go`: when a `FullNode`/`DuoNode` drops to a
+single remaining child, the trie calls `convertToShortNode(child, pos)` (trie.go:1056). That
+function inspects the surviving child **only** through one type assertion:
+
+```go
+if short, ok := child.(*ShortNode); ok {
+    // merge: prepend the collapse nibble to short.Key — READS the ShortNode preimage
+    return NewShortNode(append([]byte{pos}, short.Key...), short.Val)
+}
+// child is a branch (FullNode/DuoNode) or a HashNode: wrapped by reference, NEVER inspected
+return NewShortNode([]byte{pos}, child)
+```
+
+- Surviving sibling is a **branch**: after `RLPDecode` a dropped subtree-root appears as a bare
+  `HashNode`; a kept one appears as a `FullNode`/`DuoNode`. Neither is a `*ShortNode`, so
+  `convertToShortNode` takes the second return and folds the **32-byte hash inline** without
+  ever reading the subtree's contents. Its preimage is therefore never needed → **droppable**.
+- Surviving sibling is a **ShortNode** (leaf or extension): `convertToShortNode` merges by
+  reading `short.Key`/`short.Val`, so the preimage **must** be present → **keep**. A bare
+  `HashNode` here would make the verifier fail/panic — exactly the over-filter the guardrail
+  catches.
+
+This matches the Task 1 probe ground truth: the subtree-root node is removable (account `[5]`,
+storage `[6]`), while a plain 2-leaf collapse's surviving leaf is **not** removable.
+
+**Mapping `siblingPath` → node.** `siblingPath` is built in HPH as
+`currentKey[:depth] + survivingNibble + survivingCell.hashedExtension`
+(hex_patricia_hashed.go:2394 / :2418). A leaf survivor carries a full-depth `hashedExtension`,
+so its path reaches terminal depth and resolves to a `ShortNode`/`AccountNode`/`ValueNode`. A
+branch survivor's path stops at the branch depth and resolves to a `FullNode`/`DuoNode`. So
+path length corroborates the type, but the **node type is the criterion** — do not key off
+length. The node is guaranteed present in `witnessTrie` because STEP 2 force-touches it via
+`TouchHashedKey(siblingPath)` before `RLPEncode`.
+
+**Computability.** Decidable from `witnessTrie` + `siblingPaths` alone, **no extra
+re-execution**: for each `siblingPath`, descend the witness trie along the nibble path, read the
+concrete node type at that path, and drop its keccak hash iff it is a `*FullNode`/`*DuoNode`.
+The verify guardrail (already running on the filtered `result.State`) remains a pure
+post-condition that catches any over-drop.
+
+**Proven scope.**
+- ✅ Account-trie 2→1 collapse onto a branch subtree — `TestExecutionWitnessCollapseSiblingAccount`.
+- ✅ Storage-trie 2→1 collapse onto a branch subtree — `TestExecutionWitnessCollapseSiblingStorage`.
+- ✅ Load-bearing counter-case (surviving sibling is a `ShortNode` leaf) — kept; Task 4 pins it.
+- ✅ No-collapse block — tracer never fires, `siblingPaths` empty, strict no-op.
+
+**Out of proven scope (conservative behavior = keep).**
+- **Cascading / multi-level collapse:** `detectCascadingCollapseAtRow` (hex_patricia_hashed.go:2412)
+  also emits sibling paths for collapses propagated upward by `fold()`. The branch-vs-ShortNode
+  rule is applied **per sibling path** and is inherently conservative — a cascading survivor
+  that is a `ShortNode` is automatically kept — but this shape is **not** yet covered by a test,
+  so it is a documented known limitation. Safety over minimality holds: an over-drop is still
+  caught by verify, and the rule only drops unambiguous branch nodes.
+- **Extension-node survivor:** a `ShortNode` whose `Val` is a branch (not a leaf) is treated as
+  **load-bearing** (the rule only drops `FullNode`/`DuoNode`), which is correct — `convertToShortNode`
+  merges its key.
+- **3→2 branch shrink (not a collapse):** the tracer fires only when `afterMap` has exactly one
+  remaining child (`bits.OnesCount16 == 1`, hex_patricia_hashed.go:2207); a 3→2 shrink keeps a
+  `DuoNode` and emits **no** sibling path, so it never reaches the filter. Not applicable.
 
 ### Task 3: Implement the collapse-sibling filter in buildWitnessTrie
 

--- a/docs/plans/20260527-witness-collapse-sibling-filter.md
+++ b/docs/plans/20260527-witness-collapse-sibling-filter.md
@@ -298,11 +298,23 @@ post-condition that catches any over-drop.
 **Files:**
 - Modify: `rpc/jsonrpc/debug_api_test.go`
 
-- [ ] Construct/identify a case where the surviving sibling **is** load-bearing (genuine 2→1
+- [x] Construct/identify a case where the surviving sibling **is** load-bearing (genuine 2→1
       collapse whose promotion needs the preimage). Assert the **specific** sibling hash is
       **present** in `state` (exact multiset, not just "verify passed") and verify passes.
       This makes a degenerate "drop nothing" or "drop everything" filter fail.
-- [ ] Run all witness tests — green.
+      → `TestExecutionWitnessCollapseSiblingLoadBearing` + helper `findLeafSiblingAddresses`
+      (two addresses sharing nibble 0, diverging at nibble 1 → an isolated 2-leaf depth-1
+      branch; deleting one collapses onto a `ShortNode` leaf survivor). "Specific sibling
+      present" is asserted structurally: `trie.RLPDecode(result.State)` then
+      `GetNode(hashedNibbles(sib,64))` must resolve to a concrete `*ShortNode`/`*AccountNode`,
+      **not** a bare `HashNode` — a `HashNode` is exactly what a dropped (over-filtered) sibling
+      decodes to, since the sibling only appears in the witness via the collapse touch. A naive
+      `NodeHash`-Contains match is unreliable (`RLPEncode` emits the wrapping `ShortNode` leaf
+      while `GetNode` at full depth returns the inner `AccountNode`), so the type-resolution
+      check is used instead. Exact count pinned at 5; `probeRedundantNodes` empty (the kept
+      sibling is load-bearing, nothing else redundant). Verify guardrail on (no `NO_VERIFY`).
+- [x] Run all witness tests — green. Account (5), storage (7), no-collapse, load-bearing (5)
+      all PASS; `make lint` clean (0 issues).
 
 ### Task 5: Refactor and verify acceptance criteria
 

--- a/docs/plans/20260527-witness-collapse-sibling-filter.md
+++ b/docs/plans/20260527-witness-collapse-sibling-filter.md
@@ -135,28 +135,51 @@ assertion.
 - Modify: `rpc/jsonrpc/debug_api_test.go`
 - Possibly Modify: `cmd/rpcdaemon/rpcdaemontest/test_util.go` (add a custom-chain constructor if none fits)
 
-- [ ] Stand up a witness test that authors its **own** chain (the canned
+- [x] Stand up a witness test that authors its **own** chain (the canned
       `CreateTestExecModule` 13-block chain cannot trigger a controlled collapse). Reuse the
       bespoke-chain pattern from `CreateTestExecModuleForTraces`/`...Collision`, or
       `execmoduletester.New(...)` + `blockgen.GenerateChain` with a block closure. Copy the
       commitment-history setup verbatim from `TestExecutionWitness` (~L754):
       `statecfg.EnableHistoricalCommitment()` + `rawdb.WriteDBCommitmentHistoryEnabled`.
-- [ ] **Deterministic shared-prefix key selection:** pick two addresses (account case) and two
+      → `rpc/jsonrpc/debug_witness_collapse_test.go`, helper `newWitnessTester`.
+- [x] **Deterministic shared-prefix key selection:** pick two addresses (account case) and two
       storage slots (storage case) whose **keccak hashes share a leading nibble** so they sit
       under one branch. Brute-force/search candidate keys in the test setup and assert the
       shared-prefix precondition (so the test is self-validating, not relying on luck).
-- [ ] `TestExecutionWitnessCollapseSiblingAccount`: block creates both accounts, later block
-      deletes one (selfdestruct or balance/nonce→0 path) → account branch collapses 2→1.
-- [ ] `TestExecutionWitnessCollapseSiblingStorage`: contract with two shared-prefix slots set,
-      later block zeroes one → storage branch collapses 2→1.
-- [ ] For each: assert `verifyWitnessStateless` passes (block valid) **without** setting
-      `ERIGON_WITNESS_NO_VERIFY`, and assert the `state` set equals the expected **minimal**
-      multiset (exact, with the redundant sibling absent). Record the current buggy count to
-      prove RED is for the right reason (extra node present).
-- [ ] `TestExecutionWitnessNoCollapseUnchanged`: a block with no deletes → assert filter is a
-      strict no-op (witness identical to pre-change output / a recorded golden count).
-- [ ] Run the new tests — confirm RED on the collapse cases for the right reason; the no-op
-      case should already pass.
+      → `findSubtreeSiblingAddresses` / `findSubtreeSiblingHashes`; self-validating via
+      `require` on the divergence nibble. Address search starts above the precompile range
+      (≥0x100000) — initial attempt landed on `0x05` (modexp precompile), so the call ran the
+      precompile instead of the contract's selfdestruct and no deletion occurred.
+- [x] `TestExecutionWitnessCollapseSiblingAccount`: block selfdestructs one account in a
+      2-child account-trie branch whose **other child is a 2-account subtree** → branch
+      collapses onto the subtree (subtree root needed only by hash = redundant).
+- [x] `TestExecutionWitnessCollapseSiblingStorage`: contract with three slots forming a
+      2-child storage branch (one slot vs a 2-slot subtree); block zeroes the lone slot →
+      branch collapses onto the subtree.
+- [x] For each: assert `verifyWitnessStateless` passes (block valid) **without** setting
+      `ERIGON_WITNESS_NO_VERIFY`, and assert the witness is **minimal** via a criterion-free
+      probe (`probeRedundantNodes`: a node is redundant iff removing it still re-roots to the
+      block root) plus an exact node-count pin. Buggy counts recorded below.
+- [x] `TestExecutionWitnessNoCollapseUnchanged`: a block with no deletes (plain value
+      transfer) → witness already minimal; filter must be a strict no-op.
+- [x] Run the new tests — confirm RED on the collapse cases for the right reason; the no-op
+      case should already pass. **Confirmed:** account RED (removable node `[5]`, 6→5),
+      storage RED (removable node `[6]`, 8→7), no-collapse PASS.
+
+➕ **Key finding (feeds Task 2 & Task 4):** a plain **2-leaf** 2→1 collapse's surviving
+  sibling is **load-bearing**, NOT redundant — the standard verifier needs the sibling leaf's
+  preimage to merge it up on collapse (probe finds zero removable nodes). The redundant
+  collapse-sibling (the actual #21312 bug) only appears when the surviving sibling is a
+  **subtree** (≥2 children) referenced by hash, so its preimage is never descended into. Task 1
+  fixtures therefore use subtree siblings. The 2-leaf shape is the **load-bearing** counter-case
+  for Task 4.
+
+➕ **Oracle choice:** instead of a hardcoded golden multiset, minimality is asserted with a
+  criterion-free removal probe (remove each non-root node, re-run `execBlockStatelessly`, a
+  removal that still reproduces the root means the node was redundant). This is robust and
+  directly encodes the Geth-parity/minimality claim; the verifier may *panic* on a missing
+  load-bearing node, so the probe recovers and treats a panic as "needed". Exact counts (5/7)
+  are also pinned.
 
 ### Task 2: Derive and document the redundancy criterion (decision, before any filter code)
 

--- a/docs/plans/20260527-witness-collapse-sibling-filter.md
+++ b/docs/plans/20260527-witness-collapse-sibling-filter.md
@@ -321,13 +321,14 @@ post-condition that catches any over-drop.
 **Files:**
 - Modify: `rpc/jsonrpc/debug_execution_witness.go`
 
-- [ ] Tidy the helper; no scenario comments; consistent naming.
-- [ ] Pre-Amsterdam `TestExecutionWitness` (all existing sub-cases) still pass unchanged.
-- [ ] All new tests green: account collapse minimal, storage collapse minimal, no-op
+- [x] Tidy the helper; no scenario comments; consistent naming. (already clean — single-sentence
+      docstring, consistent `drop`/`out`/`node`/`path` naming, no scenario comments; no code change needed.)
+- [x] Pre-Amsterdam `TestExecutionWitness` (all existing sub-cases) still pass unchanged.
+- [x] All new tests green: account collapse minimal, storage collapse minimal, no-op
       unchanged, load-bearing retained.
-- [ ] `make lint` (repeat until clean — non-deterministic).
-- [ ] `make erigon integration` builds.
-- [ ] `go test ./rpc/jsonrpc/...` and `go test ./execution/commitment/...` green.
+- [x] `make lint` (repeat until clean — non-deterministic). → 0 issues.
+- [x] `make erigon integration` builds.
+- [x] `go test ./rpc/jsonrpc/...` and `go test ./execution/commitment/...` green.
 
 ### Task 6: [Final] Docs and plan housekeeping
 - [ ] Update CLAUDE.md / package notes only if a genuinely new, non-obvious pattern emerged

--- a/docs/plans/completed/20260527-witness-collapse-sibling-filter.md
+++ b/docs/plans/completed/20260527-witness-collapse-sibling-filter.md
@@ -207,8 +207,14 @@ assertion.
 
 **The rule.** A collapse-sibling node is **redundant (safe to drop)** iff the node it resolves
 to at its `siblingPath` in the witness trie is a **branch node** (`*FullNode` or `*DuoNode`,
-i.e. ≥2 children). It is **load-bearing (must keep)** in every other case — when the path
-resolves to a `*ShortNode` (leaf or extension), an `*AccountNode`, or a `ValueNode`.
+i.e. ≥2 children) **whose children are all bare hashes** (`trie.HasExpandedChild` returns
+false). It is **load-bearing (must keep)** in every other case — when the path resolves to a
+`*ShortNode` (leaf or extension), an `*AccountNode`, or a `ValueNode`, **or when the branch has
+an expanded child**: a key below it was independently resolved in the same block, so the
+verifier must descend through the branch to reach that accessed leaf, and dropping the branch
+leaves an unresolved `HashNode` on the path (verifier panic). The expanded-child guard was added
+after the initial branch-only rule was found to over-drop; `TestExecutionWitnessCollapseSiblingAccessedSubtree`
+pins it.
 
 **Why this is exactly the right line — tied to how the verifier re-roots.** The stateless
 verifier's `Finalize` (debug_execution_witness.go ~L1703-1802) applies the block's deletes via
@@ -257,6 +263,8 @@ post-condition that catches any over-drop.
 - ✅ Account-trie 2→1 collapse onto a branch subtree — `TestExecutionWitnessCollapseSiblingAccount`.
 - ✅ Storage-trie 2→1 collapse onto a branch subtree — `TestExecutionWitnessCollapseSiblingStorage`.
 - ✅ Load-bearing counter-case (surviving sibling is a `ShortNode` leaf) — kept; Task 4 pins it.
+- ✅ Branch survivor with an independently-accessed descendant (expanded child) — kept;
+  `TestExecutionWitnessCollapseSiblingAccessedSubtree`.
 - ✅ No-collapse block — tracer never fires, `siblingPaths` empty, strict no-op.
 
 **Out of proven scope (conservative behavior = keep).**

--- a/docs/plans/completed/20260527-witness-collapse-sibling-filter.md
+++ b/docs/plans/completed/20260527-witness-collapse-sibling-filter.md
@@ -331,9 +331,11 @@ post-condition that catches any over-drop.
 - [x] `go test ./rpc/jsonrpc/...` and `go test ./execution/commitment/...` green.
 
 ### Task 6: [Final] Docs and plan housekeeping
-- [ ] Update CLAUDE.md / package notes only if a genuinely new, non-obvious pattern emerged
-      (default: no change).
-- [ ] Move this plan to `docs/plans/completed/`.
+- [x] Update CLAUDE.md / package notes only if a genuinely new, non-obvious pattern emerged
+      (default: no change). → no change: the redundancy criterion and collapse-sibling shapes
+      are fully captured in this plan's DECISION section; nothing is a reusable cross-cutting
+      pattern warranting a CLAUDE.md edit.
+- [x] Move this plan to `docs/plans/completed/`.
 
 ## Post-Completion
 *Manual / external — no checkboxes*

--- a/execution/commitment/trie/trie.go
+++ b/execution/commitment/trie/trie.go
@@ -1817,6 +1817,17 @@ func (t *Trie) GetNode(path []byte) Node {
 	return getNode(t.RootNode, path, 0)
 }
 
+// NodeHash returns the keccak256 of the node's RLP, the identity RLPEncode assigns it.
+func (t *Trie) NodeHash(n Node) (common.Hash, error) {
+	h := newHasher(t.valueNodesRLPEncoded)
+	defer returnHasherToPool(h)
+	nodeRLP, err := h.hashChildren(n, 0)
+	if err != nil {
+		return common.Hash{}, err
+	}
+	return crypto.Keccak256Hash(nodeRLP), nil
+}
+
 func getNode(n Node, path []byte, pos int) Node {
 	if n == nil {
 		return nil

--- a/execution/commitment/trie/trie.go
+++ b/execution/commitment/trie/trie.go
@@ -1817,6 +1817,31 @@ func (t *Trie) GetNode(path []byte) Node {
 	return getNode(t.RootNode, path, 0)
 }
 
+// HasExpandedChild reports whether branch node n has at least one child that is an
+// expanded node rather than a bare hash, meaning some key below n was independently
+// resolved into the trie. Returns false for non-branch nodes.
+func HasExpandedChild(n Node) bool {
+	expanded := func(c Node) bool {
+		switch c.(type) {
+		case nil, *HashNode:
+			return false
+		default:
+			return true
+		}
+	}
+	switch b := n.(type) {
+	case *FullNode:
+		for _, c := range b.Children {
+			if expanded(c) {
+				return true
+			}
+		}
+	case *DuoNode:
+		return expanded(b.child1) || expanded(b.child2)
+	}
+	return false
+}
+
 // NodeHash returns the keccak256 of the node's RLP, the identity RLPEncode assigns it.
 func (t *Trie) NodeHash(n Node) (common.Hash, error) {
 	h := newHasher(t.valueNodesRLPEncoded)

--- a/execution/commitment/trie/trie.go
+++ b/execution/commitment/trie/trie.go
@@ -1818,8 +1818,7 @@ func (t *Trie) GetNode(path []byte) Node {
 }
 
 // HasExpandedChild reports whether branch node n has at least one child that is an
-// expanded node rather than a bare hash, meaning some key below n was independently
-// resolved into the trie. Returns false for non-branch nodes.
+// expanded (non-hash) node. Returns false for non-branch nodes.
 func HasExpandedChild(n Node) bool {
 	expanded := func(c Node) bool {
 		switch c.(type) {

--- a/rpc/jsonrpc/debug_execution_witness.go
+++ b/rpc/jsonrpc/debug_execution_witness.go
@@ -992,10 +992,10 @@ func buildWitnessTrie(
 	return encodedNodes, nil
 }
 
-// filterRedundantCollapseSiblings drops collapse-sibling nodes that resolve to a
-// branch (*FullNode/*DuoNode), whose preimage the verifier never reads because it
-// folds the sibling inline by hash on re-root; the root (index 0) and slice order
-// are preserved.
+// filterRedundantCollapseSiblings drops collapse-sibling branch nodes whose subtree
+// is unexpanded, which the verifier folds inline by hash without reading the
+// preimage. A branch with an expanded child is load-bearing (a key below it was
+// accessed) and is kept; the root and slice order are preserved.
 func filterRedundantCollapseSiblings(witnessTrie *trie.Trie, siblingPaths [][]byte, encoded []hexutil.Bytes) ([]hexutil.Bytes, error) {
 	if len(siblingPaths) == 0 || len(encoded) == 0 {
 		return encoded, nil
@@ -1006,6 +1006,9 @@ func filterRedundantCollapseSiblings(witnessTrie *trie.Trie, siblingPaths [][]by
 		switch node.(type) {
 		case *trie.FullNode, *trie.DuoNode:
 		default:
+			continue
+		}
+		if trie.HasExpandedChild(node) {
 			continue
 		}
 		h, err := witnessTrie.NodeHash(node)

--- a/rpc/jsonrpc/debug_execution_witness.go
+++ b/rpc/jsonrpc/debug_execution_witness.go
@@ -985,7 +985,49 @@ func buildWitnessTrie(
 	for _, node := range allNodes {
 		encodedNodes = append(encodedNodes, common.Copy(node))
 	}
+	encodedNodes, err = filterRedundantCollapseSiblings(witnessTrie, siblingPaths, encodedNodes)
+	if err != nil {
+		return nil, err
+	}
 	return encodedNodes, nil
+}
+
+// filterRedundantCollapseSiblings drops collapse-sibling nodes that resolve to a
+// branch (*FullNode/*DuoNode), whose preimage the verifier never reads because it
+// folds the sibling inline by hash on re-root; the root (index 0) and slice order
+// are preserved.
+func filterRedundantCollapseSiblings(witnessTrie *trie.Trie, siblingPaths [][]byte, encoded []hexutil.Bytes) ([]hexutil.Bytes, error) {
+	if len(siblingPaths) == 0 || len(encoded) == 0 {
+		return encoded, nil
+	}
+	drop := make(map[common.Hash]struct{})
+	for _, path := range siblingPaths {
+		node := witnessTrie.GetNode(path)
+		switch node.(type) {
+		case *trie.FullNode, *trie.DuoNode:
+		default:
+			continue
+		}
+		h, err := witnessTrie.NodeHash(node)
+		if err != nil {
+			return nil, fmt.Errorf("hashing collapse-sibling node: %w", err)
+		}
+		drop[h] = struct{}{}
+	}
+	delete(drop, crypto.Keccak256Hash(encoded[0]))
+	if len(drop) == 0 {
+		return encoded, nil
+	}
+	out := make([]hexutil.Bytes, 0, len(encoded))
+	for i, node := range encoded {
+		if i != 0 {
+			if _, dropped := drop[crypto.Keccak256Hash(node)]; dropped {
+				continue
+			}
+		}
+		out = append(out, node)
+	}
+	return out, nil
 }
 
 // resolveWitnessBlock resolves the target block from blockNrOrHash and computes

--- a/rpc/jsonrpc/debug_witness_collapse_test.go
+++ b/rpc/jsonrpc/debug_witness_collapse_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/erigontech/erigon/db/rawdb"
 	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/commitment/trie"
 	"github.com/erigontech/erigon/execution/execmodule/execmoduletester"
 	"github.com/erigontech/erigon/execution/tests/blockgen"
 	"github.com/erigontech/erigon/execution/types"
@@ -139,6 +140,33 @@ func findSubtreeSiblingHashes(t *testing.T) (del, sib1, sib2 common.Hash) {
 	}
 	t.Fatalf("could not find storage slot to delete sharing prefix %x", prefix3)
 	return common.Hash{}, common.Hash{}, common.Hash{}
+}
+
+// findLeafSiblingAddresses brute-forces two addresses whose hashed keys share the
+// first nibble and diverge at the second, forming a 2-leaf branch at depth 1. With
+// no third account under that nibble, deleting one leaf collapses the branch onto
+// the other, which a standard verifier must read to promote — load-bearing, NOT
+// redundant. Addresses start above the precompile range so calls run their own code.
+func findLeafSiblingAddresses(t *testing.T, avoidFirst map[byte]struct{}) (del, sib common.Address) {
+	t.Helper()
+	const base = uint64(1) << 20
+	seen := map[byte][]common.Address{}
+	for c := base; c < base+10_000_000; c++ {
+		var a common.Address
+		binary.BigEndian.PutUint64(a[12:], c)
+		nib := hashedNibbles(a.Bytes(), 2)
+		if _, bad := avoidFirst[nib[0]]; bad {
+			continue
+		}
+		for _, prev := range seen[nib[0]] {
+			if hashedNibbles(prev.Bytes(), 2)[1] != nib[1] {
+				return prev, a
+			}
+		}
+		seen[nib[0]] = append(seen[nib[0]], a)
+	}
+	t.Fatalf("could not find 2-leaf sibling pair")
+	return common.Address{}, common.Address{}
 }
 
 // selfdestructCode: PUSH1 0x00; SELFDESTRUCT (beneficiary = address 0).
@@ -335,4 +363,55 @@ func TestExecutionWitnessNoCollapseUnchanged(t *testing.T) {
 
 	require.Empty(t, probeRedundantNodes(t, m, result, chainPack.Blocks[0]),
 		"a no-collapse witness is already minimal; the filter must not change it")
+}
+
+// TestExecutionWitnessCollapseSiblingLoadBearing is the over-filter counter-case:
+// a genuine 2-leaf 2→1 collapse whose surviving sibling is a ShortNode leaf, not a
+// branch subtree. The standard verifier must read that leaf's preimage to promote it
+// on collapse, so the filter must KEEP it. The test asserts the specific surviving
+// sibling resolves to a concrete leaf node present in the witness (not a bare
+// HashNode) — a degenerate "drop everything matching a sibling path" filter would
+// drop it and fail here.
+func TestExecutionWitnessCollapseSiblingLoadBearing(t *testing.T) {
+	bank := crypto.PubkeyToAddress(witnessTestKey.PublicKey)
+	bankNib := hashedNibbles(bank.Bytes(), 1)[0]
+	del, sib := findLeafSiblingAddresses(t, map[byte]struct{}{bankNib: {}})
+
+	gspec := &types.Genesis{
+		Config: chain.TestChainBerlinConfig,
+		Alloc: types.GenesisAlloc{
+			bank: {Balance: big.NewInt(1_000_000_000_000_000)},
+			del:  {Code: selfdestructCode, Nonce: 1, Balance: big.NewInt(0)},
+			sib:  {Balance: big.NewInt(111)},
+		},
+	}
+	m, api := newWitnessTester(t, gspec)
+	chainPack, err := blockgen.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 1, func(i int, b *blockgen.BlockGen) {
+		b.SetCoinbase(bank)
+		b.AddTx(signedCall(t, 0, del, nil))
+	})
+	require.NoError(t, err)
+	require.NoError(t, m.InsertChain(chainPack))
+
+	bn := rpc.BlockNumber(1)
+	result, err := api.ExecutionWitness(context.Background(), rpc.BlockNumberOrHash{BlockNumber: &bn})
+	require.NoError(t, err, "load-bearing sibling must verify: dropping it would fail verification")
+
+	encoded := make([][]byte, len(result.State))
+	for i, n := range result.State {
+		encoded[i] = n
+	}
+	decoded, err := trie.RLPDecode(encoded)
+	require.NoError(t, err)
+
+	sibNode := decoded.GetNode(hashedNibbles(sib.Bytes(), 64))
+	switch sibNode.(type) {
+	case *trie.ShortNode, *trie.AccountNode:
+	default:
+		t.Fatalf("surviving sibling must be kept as a resolved leaf, got %T (filter over-dropped a load-bearing node)", sibNode)
+	}
+
+	require.Empty(t, probeRedundantNodes(t, m, result, chainPack.Blocks[0]),
+		"load-bearing collapse witness must be minimal: the kept sibling is needed, nothing else is redundant")
+	require.Equal(t, 5, len(result.State), "load-bearing collapse witness node count")
 }

--- a/rpc/jsonrpc/debug_witness_collapse_test.go
+++ b/rpc/jsonrpc/debug_witness_collapse_test.go
@@ -1,0 +1,338 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package jsonrpc
+
+import (
+	"context"
+	"encoding/binary"
+	"math/big"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/crypto"
+	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/rawdb"
+	"github.com/erigontech/erigon/db/state/statecfg"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/execmodule/execmoduletester"
+	"github.com/erigontech/erigon/execution/tests/blockgen"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/execution/vm"
+	"github.com/erigontech/erigon/rpc"
+)
+
+// hashedNibbles returns the first n nibbles of the keccak hash of b.
+func hashedNibbles(b []byte, n int) []byte {
+	h := crypto.Keccak256Hash(b)
+	out := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if i%2 == 0 {
+			out[i] = h[i/2] >> 4
+		} else {
+			out[i] = h[i/2] & 0x0f
+		}
+	}
+	return out
+}
+
+func sameNibbles(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// findSubtreeSiblingAddresses brute-forces three distinct addresses: del shares
+// 2 leading hash-nibbles with sib1/sib2 but diverges at nibble 2, while sib1/sib2
+// share 3 leading nibbles (forming a subtree under nibble 2). Deleting del
+// collapses the depth-2 branch onto the sib1/sib2 subtree, whose root node is then
+// only referenced by hash — redundant for a standard verifier. The shared first
+// nibble avoids avoidFirst so the trio sits under one isolated branch. Addresses
+// start above the precompile range so calls run their own code.
+func findSubtreeSiblingAddresses(t *testing.T, avoidFirst map[byte]struct{}) (del, sib1, sib2 common.Address) {
+	t.Helper()
+	const base = uint64(1) << 20
+	seen3 := map[string]common.Address{}
+	var prefix3 []byte
+	for c := base; c < base+10_000_000; c++ {
+		var a common.Address
+		binary.BigEndian.PutUint64(a[12:], c)
+		nib := hashedNibbles(a.Bytes(), 3)
+		if _, bad := avoidFirst[nib[0]]; bad {
+			continue
+		}
+		key := string(nib)
+		if prev, ok := seen3[key]; ok {
+			require.False(t, sameNibbles(hashedNibbles(prev.Bytes(), 4), hashedNibbles(a.Bytes(), 4)),
+				"the two subtree siblings must differ at nibble 3")
+			sib1, sib2 = prev, a
+			prefix3 = nib
+			break
+		}
+		seen3[key] = a
+	}
+	require.NotNil(t, prefix3, "could not find subtree sibling pair")
+	for c := base; c < base+10_000_000; c++ {
+		var a common.Address
+		binary.BigEndian.PutUint64(a[12:], c)
+		nib := hashedNibbles(a.Bytes(), 3)
+		if nib[0] == prefix3[0] && nib[1] == prefix3[1] && nib[2] != prefix3[2] {
+			return a, sib1, sib2
+		}
+	}
+	t.Fatalf("could not find sibling to delete sharing prefix %x", prefix3)
+	return common.Address{}, common.Address{}, common.Address{}
+}
+
+// findSubtreeSiblingHashes is the storage-slot analogue of
+// findSubtreeSiblingAddresses.
+func findSubtreeSiblingHashes(t *testing.T) (del, sib1, sib2 common.Hash) {
+	t.Helper()
+	const base = uint64(1)
+	seen3 := map[string]common.Hash{}
+	var prefix3 []byte
+	for c := base; c < base+10_000_000; c++ {
+		var k common.Hash
+		binary.BigEndian.PutUint64(k[24:], c)
+		nib := hashedNibbles(k.Bytes(), 3)
+		key := string(nib)
+		if prev, ok := seen3[key]; ok {
+			require.False(t, sameNibbles(hashedNibbles(prev.Bytes(), 4), hashedNibbles(k.Bytes(), 4)),
+				"the two subtree storage siblings must differ at nibble 3")
+			sib1, sib2 = prev, k
+			prefix3 = nib
+			break
+		}
+		seen3[key] = k
+	}
+	require.NotNil(t, prefix3, "could not find subtree storage sibling pair")
+	for c := base; c < base+10_000_000; c++ {
+		var k common.Hash
+		binary.BigEndian.PutUint64(k[24:], c)
+		nib := hashedNibbles(k.Bytes(), 3)
+		if nib[0] == prefix3[0] && nib[1] == prefix3[1] && nib[2] != prefix3[2] {
+			return k, sib1, sib2
+		}
+	}
+	t.Fatalf("could not find storage slot to delete sharing prefix %x", prefix3)
+	return common.Hash{}, common.Hash{}, common.Hash{}
+}
+
+// selfdestructCode: PUSH1 0x00; SELFDESTRUCT (beneficiary = address 0).
+var selfdestructCode = []byte{byte(vm.PUSH1), 0x00, byte(vm.SELFDESTRUCT)}
+
+// storeZeroCode: SSTORE 0 into the slot supplied as calldata word 0; STOP.
+var storeZeroCode = []byte{
+	byte(vm.PUSH1), 0x00,
+	byte(vm.PUSH1), 0x00,
+	byte(vm.CALLDATALOAD),
+	byte(vm.SSTORE),
+	byte(vm.STOP),
+}
+
+var witnessTestKey, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+
+// newWitnessTester builds an ExecModuleTester with commitment history enabled and
+// returns a debug API wired to it. statecfg is restored on cleanup.
+func newWitnessTester(t *testing.T, gspec *types.Genesis) (*execmoduletester.ExecModuleTester, *DebugAPIImpl) {
+	t.Helper()
+	previousSchema := statecfg.Schema
+	statecfg.EnableHistoricalCommitment()
+	t.Cleanup(func() { statecfg.Schema = previousSchema })
+
+	m := execmoduletester.New(t,
+		execmoduletester.WithGenesisSpec(gspec),
+		execmoduletester.WithKey(witnessTestKey),
+		execmoduletester.WithoutExperimentalBAL())
+	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false)
+	require.NoError(t, m.DB.Update(context.Background(), func(tx kv.RwTx) error {
+		return rawdb.WriteDBCommitmentHistoryEnabled(tx, true)
+	}))
+	return m, api
+}
+
+func signedCall(t *testing.T, nonce uint64, to common.Address, data []byte) types.Transaction {
+	t.Helper()
+	txn, err := types.SignTx(&types.LegacyTx{
+		CommonTx: types.CommonTx{Nonce: nonce, To: &to, GasLimit: 100000, Value: uint256.Int{}, Data: data},
+		GasPrice: *uint256.NewInt(1),
+	}, *types.LatestSignerForChainID(nil), witnessTestKey)
+	require.NoError(t, err)
+	return txn
+}
+
+// probeRedundantNodes reports the indices of nodes in result.State whose removal
+// still lets the block verify statelessly — i.e. nodes a standard (Geth) verifier
+// would not need. Index 0 (the root) is never probed. An empty result means the
+// witness is minimal.
+func probeRedundantNodes(t *testing.T, m *execmoduletester.ExecModuleTester, result *ExecutionWitnessResult, block *types.Block) []int {
+	t.Helper()
+	var removable []int
+	for i := 1; i < len(result.State); i++ {
+		reduced := &ExecutionWitnessResult{
+			State:          make([]hexutil.Bytes, 0, len(result.State)-1),
+			Codes:          result.Codes,
+			Headers:        result.Headers,
+			headerByNumber: result.headerByNumber,
+		}
+		for j, n := range result.State {
+			if j == i {
+				continue
+			}
+			reduced.State = append(reduced.State, n)
+		}
+		if stillVerifies(reduced, block, m) {
+			removable = append(removable, i)
+		}
+	}
+	return removable
+}
+
+// stillVerifies reports whether the block re-roots to its canonical root using the
+// given (reduced) witness. A missing load-bearing node makes the verifier panic
+// while descending into an unresolved hash, which counts as a failure to verify.
+func stillVerifies(result *ExecutionWitnessResult, block *types.Block, m *execmoduletester.ExecModuleTester) (ok bool) {
+	defer func() {
+		if recover() != nil {
+			ok = false
+		}
+	}()
+	root, _, err := execBlockStatelessly(result, block, m.ChainConfig, m.Engine)
+	return err == nil && root == block.Root()
+}
+
+// TestExecutionWitnessCollapseSiblingAccount builds a block that selfdestructs one
+// account whose hashed-key sits in a 2-child account-trie branch, the other child
+// being a subtree of two untouched accounts. The delete collapses the branch onto
+// the subtree, whose root the standard verifier only needs by hash. Erigon
+// currently emits that subtree node as an explicit witness entry, so the witness is
+// non-minimal (RED until the collapse-sibling filter lands).
+func TestExecutionWitnessCollapseSiblingAccount(t *testing.T) {
+	bank := crypto.PubkeyToAddress(witnessTestKey.PublicKey)
+	bankNib := hashedNibbles(bank.Bytes(), 1)[0]
+	del, sib1, sib2 := findSubtreeSiblingAddresses(t, map[byte]struct{}{bankNib: {}})
+
+	gspec := &types.Genesis{
+		Config: chain.TestChainBerlinConfig,
+		Alloc: types.GenesisAlloc{
+			bank: {Balance: big.NewInt(1_000_000_000_000_000)},
+			del:  {Code: selfdestructCode, Nonce: 1, Balance: big.NewInt(0)},
+			sib1: {Balance: big.NewInt(111)},
+			sib2: {Balance: big.NewInt(222)},
+		},
+	}
+	m, api := newWitnessTester(t, gspec)
+	chainPack, err := blockgen.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 1, func(i int, b *blockgen.BlockGen) {
+		b.SetCoinbase(bank)
+		b.AddTx(signedCall(t, 0, del, nil))
+	})
+	require.NoError(t, err)
+	require.NoError(t, m.InsertChain(chainPack))
+
+	bn := rpc.BlockNumber(1)
+	result, err := api.ExecutionWitness(context.Background(), rpc.BlockNumberOrHash{BlockNumber: &bn})
+	require.NoError(t, err, "block must verify statelessly (verify guardrail is on)")
+
+	require.Empty(t, probeRedundantNodes(t, m, result, chainPack.Blocks[0]),
+		"witness must be minimal: no node may be dropped while still reproducing the root")
+	require.Equal(t, 5, len(result.State), "account collapse minimal witness node count")
+}
+
+// TestExecutionWitnessCollapseSiblingStorage is the storage-trie analogue: a
+// contract with three slots whose hashed keys form a 2-child branch (one slot vs a
+// 2-slot subtree). Zeroing the lone slot collapses the branch onto the subtree.
+func TestExecutionWitnessCollapseSiblingStorage(t *testing.T) {
+	bank := crypto.PubkeyToAddress(witnessTestKey.PublicKey)
+	del, sib1, sib2 := findSubtreeSiblingHashes(t)
+	contract := common.HexToAddress("0x00000000000000000000000000000000c0ffee01")
+
+	gspec := &types.Genesis{
+		Config: chain.TestChainBerlinConfig,
+		Alloc: types.GenesisAlloc{
+			bank: {Balance: big.NewInt(1_000_000_000_000_000)},
+			contract: {
+				Code:    storeZeroCode,
+				Nonce:   1,
+				Balance: big.NewInt(0),
+				Storage: map[common.Hash]common.Hash{
+					del:  common.HexToHash("0x01"),
+					sib1: common.HexToHash("0x02"),
+					sib2: common.HexToHash("0x03"),
+				},
+			},
+		},
+	}
+	m, api := newWitnessTester(t, gspec)
+	chainPack, err := blockgen.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 1, func(i int, b *blockgen.BlockGen) {
+		b.SetCoinbase(bank)
+		b.AddTx(signedCall(t, 0, contract, del.Bytes()))
+	})
+	require.NoError(t, err)
+	require.NoError(t, m.InsertChain(chainPack))
+
+	bn := rpc.BlockNumber(1)
+	result, err := api.ExecutionWitness(context.Background(), rpc.BlockNumberOrHash{BlockNumber: &bn})
+	require.NoError(t, err, "block must verify statelessly (verify guardrail is on)")
+
+	require.Empty(t, probeRedundantNodes(t, m, result, chainPack.Blocks[0]),
+		"witness must be minimal: no node may be dropped while still reproducing the root")
+	require.Equal(t, 7, len(result.State), "storage collapse minimal witness node count")
+}
+
+// TestExecutionWitnessNoCollapseUnchanged exercises a block that triggers no
+// collapse (a plain value transfer). The collapse-sibling filter must be a strict
+// no-op here, so the witness is already minimal both before and after the change.
+func TestExecutionWitnessNoCollapseUnchanged(t *testing.T) {
+	bank := crypto.PubkeyToAddress(witnessTestKey.PublicKey)
+	recipient := common.HexToAddress("0x00000000000000000000000000000000a11ce001")
+
+	gspec := &types.Genesis{
+		Config: chain.TestChainBerlinConfig,
+		Alloc: types.GenesisAlloc{
+			bank:      {Balance: big.NewInt(1_000_000_000_000_000)},
+			recipient: {Balance: big.NewInt(1)},
+		},
+	}
+	m, api := newWitnessTester(t, gspec)
+	chainPack, err := blockgen.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 1, func(i int, b *blockgen.BlockGen) {
+		b.SetCoinbase(bank)
+		txn, err := types.SignTx(&types.LegacyTx{
+			CommonTx: types.CommonTx{Nonce: 0, To: &recipient, GasLimit: 100000, Value: *uint256.NewInt(1000)},
+			GasPrice: *uint256.NewInt(1),
+		}, *types.LatestSignerForChainID(nil), witnessTestKey)
+		require.NoError(t, err)
+		b.AddTx(txn)
+	})
+	require.NoError(t, err)
+	require.NoError(t, m.InsertChain(chainPack))
+
+	bn := rpc.BlockNumber(1)
+	result, err := api.ExecutionWitness(context.Background(), rpc.BlockNumberOrHash{BlockNumber: &bn})
+	require.NoError(t, err)
+
+	require.Empty(t, probeRedundantNodes(t, m, result, chainPack.Blocks[0]),
+		"a no-collapse witness is already minimal; the filter must not change it")
+}

--- a/rpc/jsonrpc/debug_witness_collapse_test.go
+++ b/rpc/jsonrpc/debug_witness_collapse_test.go
@@ -330,6 +330,61 @@ func TestExecutionWitnessCollapseSiblingStorage(t *testing.T) {
 	require.Equal(t, 7, len(result.State), "storage collapse minimal witness node count")
 }
 
+// TestExecutionWitnessCollapseSiblingAccessedSubtree is the over-filter regression
+// case: a 2→1 collapse onto a 2-account subtree where the block ALSO sends value to
+// one of the subtree members. The collapse still records the subtree-root branch as
+// a sibling path, but that branch is now load-bearing — the verifier must descend
+// through it to reach the accessed member's leaf. The filter must KEEP it; dropping
+// it by the branch-node structural criterion alone corrupts the witness.
+func TestExecutionWitnessCollapseSiblingAccessedSubtree(t *testing.T) {
+	bank := crypto.PubkeyToAddress(witnessTestKey.PublicKey)
+	bankNib := hashedNibbles(bank.Bytes(), 1)[0]
+	del, sib1, sib2 := findSubtreeSiblingAddresses(t, map[byte]struct{}{bankNib: {}})
+
+	gspec := &types.Genesis{
+		Config: chain.TestChainBerlinConfig,
+		Alloc: types.GenesisAlloc{
+			bank: {Balance: big.NewInt(1_000_000_000_000_000)},
+			del:  {Code: selfdestructCode, Nonce: 1, Balance: big.NewInt(0)},
+			sib1: {Balance: big.NewInt(111)},
+			sib2: {Balance: big.NewInt(222)},
+		},
+	}
+	m, api := newWitnessTester(t, gspec)
+	chainPack, err := blockgen.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 1, func(i int, b *blockgen.BlockGen) {
+		b.SetCoinbase(bank)
+		b.AddTx(signedCall(t, 0, del, nil))
+		txn, err := types.SignTx(&types.LegacyTx{
+			CommonTx: types.CommonTx{Nonce: 1, To: &sib1, GasLimit: 100000, Value: *uint256.NewInt(7)},
+			GasPrice: *uint256.NewInt(1),
+		}, *types.LatestSignerForChainID(nil), witnessTestKey)
+		require.NoError(t, err)
+		b.AddTx(txn)
+	})
+	require.NoError(t, err)
+	require.NoError(t, m.InsertChain(chainPack))
+
+	bn := rpc.BlockNumber(1)
+	result, err := api.ExecutionWitness(context.Background(), rpc.BlockNumberOrHash{BlockNumber: &bn})
+	require.NoError(t, err, "block must verify statelessly: the accessed subtree branch must be kept")
+
+	encoded := make([][]byte, len(result.State))
+	for i, n := range result.State {
+		encoded[i] = n
+	}
+	decoded, err := trie.RLPDecode(encoded)
+	require.NoError(t, err)
+	sib1Node := decoded.GetNode(hashedNibbles(sib1.Bytes(), 64))
+	switch sib1Node.(type) {
+	case *trie.ShortNode, *trie.AccountNode:
+	default:
+		t.Fatalf("accessed subtree member must be reachable, got %T (filter over-dropped the load-bearing subtree branch)", sib1Node)
+	}
+
+	require.Empty(t, probeRedundantNodes(t, m, result, chainPack.Blocks[0]),
+		"witness must be minimal")
+}
+
 // TestExecutionWitnessNoCollapseUnchanged exercises a block that triggers no
 // collapse (a plain value transfer). The collapse-sibling filter must be a strict
 // no-op here, so the witness is already minimal both before and after the change.


### PR DESCRIPTION
Fixes the "more nodes than Geth" side of #21312.

## Problem

`debug_executionWitness` emits collapse-sibling nodes that Geth keeps inline as a 32-byte hash inside the parent branch. Erigon's HPH witness encoding emits the sibling as an explicit node so the parent branch hashes correctly; standard MPT does not. Result: +1..+18 nodes per block on the issue's test table.

## Fix

Filter at the output boundary inside `buildWitnessTrie` (`rpc/jsonrpc/debug_execution_witness.go`). A collapse-sibling node — identified via `siblingPaths` recorded by `detectCollapseSiblings` — is dropped iff its branch has no expanded child (`trie.HasExpandedChild == false`). Branches on the path to an independently-accessed key have an expanded child and are kept, so load-bearing siblings the verifier must descend into stay in the witness.

Two helpers in `execution/commitment/trie/trie.go`:

- `HasExpandedChild(n Node) bool` — branch-collapse classifier.
- `(*Trie).NodeHash(n Node) (common.Hash, error)` — mirrors `RLPEncode`'s dedup identity (keccak of `hashChildren(n,0)` with the same `valueNodesRLPEncoded` flag), so drop-set keys match `result.State`'s identity exactly.

`verifyWitnessStateless` runs on the filtered `result.State` as a hard error: any wrongly dropped node fails verification. No silent fallback. `toWitnessTrie` / HPH conversion is untouched. Pre-Amsterdam re-execution path unchanged.

DFS order preserved; root (`encoded[0]`) is never dropped.

## Tests

`rpc/jsonrpc/debug_witness_collapse_test.go`:

- `TestExecutionWitnessCollapseSiblingAccount` — deterministic 2→1 account collapse, redundant sibling absent, verify passes.
- `TestExecutionWitnessCollapseSiblingStorage` — same shape for storage trie.
- `TestExecutionWitnessCollapseSiblingAccessedSubtree` — sibling whose subtree is independently accessed is retained.
- `TestExecutionWitnessCollapseSiblingLoadBearing` — sibling required for re-rooting is retained (over-filter guard).
- `TestExecutionWitnessNoCollapseUnchanged` — block with no collapses, filter is a strict no-op.

## Out of scope

- A zkevm-corpus run shows ~4,128 fixtures where Erigon returns FEWER nodes than EEST. That's a separate bug — a filter can only remove, not add — not addressed here.
- Exact node-set parity on Amsterdam blocks additionally needs a BAL-driven access-set provider; separate PR.
- The zkevm test suite is a separate branch; used here as a local cross-check, not a dependency.
