### PR TITLE
execution: trace EIP-7702 state-gas refund per auth and incarnation

### DIFF
--- a/.github/workflows/test-eest-spec.yml
+++ b/.github/workflows/test-eest-spec.yml
@@ -70,6 +70,18 @@ jobs:
           restore-keys: |
             test-fixtures-eest-${{ runner.os }}-
 
+      # blocktests-devnet has been observed to flake on
+      # test_pointer_resets_an_empty_code_account_with_storage[fork_Amsterdam]
+      # under parallel exec — captures the per-auth refund and full receipt
+      # set on the next fire so the diagnosis is one log read away. Scoped to
+      # this shard only because TRACE_AUTH_REFUND emits a line per EIP-7702
+      # auth across all txs.
+      - name: Enable EIP-7702 + receipt-mismatch diagnostics
+        if: matrix.shard == 'blocktests-devnet'
+        run: |
+          echo "ERIGON_TRACE_AUTH_REFUND=true" >> "$GITHUB_ENV"
+          echo "ERIGON_LOG_HASH_MISMATCH_REASON=true" >> "$GITHUB_ENV"
+
       - name: Run eest-spec-${{ matrix.shard }}
         env:
           EEST_SPEC_MAX_FAILURES: ${{ matrix.max-allowed-failures }}

--- a/common/dbg/experiments.go
+++ b/common/dbg/experiments.go
@@ -106,6 +106,7 @@ var (
 	TraceBlocks           = EnvUints("TRACE_BLOCKS", ",", nil)
 	TraceTxIndexes        = EnvInts("TRACE_TXINDEXES", ",", nil)
 	TraceUnwinds          = EnvBool("TRACE_UNWINDS", false)
+	TraceAuthRefund       = EnvBool("TRACE_AUTH_REFUND", false)
 	traceDomains          = EnvStrings("TRACE_DOMAINS", ",", nil)
 	StopAfterBlock        = EnvUint("STOP_AFTER_BLOCK", 0)
 	BadBlockHalt          = EnvBool("BAD_BLOCK_HALT", false)

--- a/execution/protocol/txn_executor.go
+++ b/execution/protocol/txn_executor.go
@@ -736,6 +736,7 @@ func (st *TxnExecutor) verifyAuthorities(auths []types.Authorization, contractCr
 		if trace {
 			tracePrefix = fmt.Sprintf("[auth-refund] block=%d txIdx=%d inc=%d", st.state.BlockNumber(), st.state.TxIndex(), st.state.Incarnation())
 		}
+		applied := 0
 		var b [32]byte
 		data := bytes.NewBuffer(nil)
 		for i, auth := range auths {
@@ -825,6 +826,7 @@ func (st *TxnExecutor) verifyAuthorities(auths []types.Authorization, contractCr
 			} else if exists {
 				st.state.AddRefund(params.PerEmptyAccountCost - params.PerAuthBaseCost)
 			}
+			applied++
 			if trace {
 				fmt.Printf("%s i=%d authority=%x auth.addr=%x auth.nonce=%d stateNonce=%d codeEmpty=%t hasDelegation=%t exists=%t +sgna=%d +sgab=%d\n", tracePrefix, i, authority, auth.Address, auth.Nonce, authorityNonce, codeHash.IsEmpty(), hasDelegation, exists, sgna, sgab)
 			}
@@ -846,7 +848,7 @@ func (st *TxnExecutor) verifyAuthorities(auths []types.Authorization, contractCr
 			}
 		}
 		if trace {
-			fmt.Printf("%s TOTAL refund=%d verified=%d auths=%d\n", tracePrefix, stateIgasRefund, len(verifiedAuthorities), len(auths))
+			fmt.Printf("%s TOTAL refund=%d recovered=%d applied=%d auths=%d\n", tracePrefix, stateIgasRefund, len(verifiedAuthorities), applied, len(auths))
 		}
 	}
 

--- a/execution/protocol/txn_executor.go
+++ b/execution/protocol/txn_executor.go
@@ -731,6 +731,11 @@ func (st *TxnExecutor) verifyAuthorities(auths []types.Authorization, contractCr
 		if len(auths) == 0 {
 			return nil, stateIgasRefund, errors.New("SetCode transaction must have at least one authorization")
 		}
+		trace := dbg.TraceAuthRefund
+		var tracePrefix string
+		if trace {
+			tracePrefix = fmt.Sprintf("[auth-refund] block=%d txIdx=%d inc=%d", st.state.BlockNumber(), st.state.TxIndex(), st.state.Incarnation())
+		}
 		var b [32]byte
 		data := bytes.NewBuffer(nil)
 		for i, auth := range auths {
@@ -739,6 +744,9 @@ func (st *TxnExecutor) verifyAuthorities(auths []types.Authorization, contractCr
 			// 1. chainId check
 			if !auth.ChainID.IsZero() && chainID != auth.ChainID.String() {
 				log.Debug("invalid chainID, skipping", "chainId", auth.ChainID, "auth index", i)
+				if trace {
+					fmt.Printf("%s i=%d SKIP reason=chainID auth.chainId=%s\n", tracePrefix, i, auth.ChainID.String())
+				}
 				continue
 			}
 
@@ -746,6 +754,9 @@ func (st *TxnExecutor) verifyAuthorities(auths []types.Authorization, contractCr
 			authorityPtr, err := auth.RecoverSigner(data, b[:])
 			if err != nil {
 				log.Trace("authority recover failed, skipping", "err", err, "auth index", i)
+				if trace {
+					fmt.Printf("%s i=%d SKIP reason=recover-failed err=%v\n", tracePrefix, i, err)
+				}
 				continue
 			}
 			authority := accounts.InternAddress(*authorityPtr)
@@ -770,6 +781,9 @@ func (st *TxnExecutor) verifyAuthorities(auths []types.Authorization, contractCr
 				}
 				if !ok {
 					log.Debug("authority code is not empty or not delegated, skipping", "auth index", i)
+					if trace {
+						fmt.Printf("%s i=%d authority=%x SKIP reason=code-not-empty-not-delegated codeHash=%x\n", tracePrefix, i, authority, codeHash)
+					}
 					continue
 				}
 				hasDelegation = true
@@ -782,6 +796,9 @@ func (st *TxnExecutor) verifyAuthorities(auths []types.Authorization, contractCr
 			}
 			if authorityNonce != auth.Nonce {
 				log.Trace("invalid nonce, skipping", "auth index", i)
+				if trace {
+					fmt.Printf("%s i=%d authority=%x SKIP reason=nonce-mismatch auth.nonce=%d stateNonce=%d codeEmpty=%t hasDelegation=%t\n", tracePrefix, i, authority, auth.Nonce, authorityNonce, codeHash.IsEmpty(), hasDelegation)
+				}
 				continue
 			}
 
@@ -794,15 +811,22 @@ func (st *TxnExecutor) verifyAuthorities(auths []types.Authorization, contractCr
 			if err != nil {
 				return nil, stateIgasRefund, fmt.Errorf("%w: %w", ErrTxnExecutionFailed, err)
 			}
+			sgna := uint64(0)
+			sgab := uint64(0)
 			if st.evm.ChainRules().IsAmsterdam {
 				if exists {
-					stateIgasRefund += params.StateGasNewAccount
+					sgna = params.StateGasNewAccount
+					stateIgasRefund += sgna
 				}
 				if hasDelegation || auth.Address == (common.Address{}) {
-					stateIgasRefund += params.StateGasAuthBase
+					sgab = params.StateGasAuthBase
+					stateIgasRefund += sgab
 				}
 			} else if exists {
 				st.state.AddRefund(params.PerEmptyAccountCost - params.PerAuthBaseCost)
+			}
+			if trace {
+				fmt.Printf("%s i=%d authority=%x auth.addr=%x auth.nonce=%d stateNonce=%d codeEmpty=%t hasDelegation=%t exists=%t +sgna=%d +sgab=%d\n", tracePrefix, i, authority, auth.Address, auth.Nonce, authorityNonce, codeHash.IsEmpty(), hasDelegation, exists, sgna, sgab)
 			}
 
 			// 7. set authority code
@@ -820,6 +844,9 @@ func (st *TxnExecutor) verifyAuthorities(auths []types.Authorization, contractCr
 			if err := st.state.SetNonce(authority, authorityNonce+1, tracing.NonceChangeAuthorization); err != nil {
 				return nil, stateIgasRefund, fmt.Errorf("%w: %w", ErrTxnExecutionFailed, err)
 			}
+		}
+		if trace {
+			fmt.Printf("%s TOTAL refund=%d verified=%d auths=%d\n", tracePrefix, stateIgasRefund, len(verifiedAuthorities), len(auths))
 		}
 	}
 

--- a/execution/protocol/txn_executor.go
+++ b/execution/protocol/txn_executor.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"os"
 	"slices"
 
 	"github.com/holiman/uint256"
@@ -746,7 +747,7 @@ func (st *TxnExecutor) verifyAuthorities(auths []types.Authorization, contractCr
 			if !auth.ChainID.IsZero() && chainID != auth.ChainID.String() {
 				log.Debug("invalid chainID, skipping", "chainId", auth.ChainID, "auth index", i)
 				if trace {
-					fmt.Printf("%s i=%d SKIP reason=chainID auth.chainId=%s\n", tracePrefix, i, auth.ChainID.String())
+					fmt.Fprintf(os.Stderr, "%s i=%d SKIP reason=chainID auth.chainId=%s\n", tracePrefix, i, auth.ChainID.String())
 				}
 				continue
 			}
@@ -756,7 +757,7 @@ func (st *TxnExecutor) verifyAuthorities(auths []types.Authorization, contractCr
 			if err != nil {
 				log.Trace("authority recover failed, skipping", "err", err, "auth index", i)
 				if trace {
-					fmt.Printf("%s i=%d SKIP reason=recover-failed err=%v\n", tracePrefix, i, err)
+					fmt.Fprintf(os.Stderr, "%s i=%d SKIP reason=recover-failed err=%v\n", tracePrefix, i, err)
 				}
 				continue
 			}
@@ -783,7 +784,7 @@ func (st *TxnExecutor) verifyAuthorities(auths []types.Authorization, contractCr
 				if !ok {
 					log.Debug("authority code is not empty or not delegated, skipping", "auth index", i)
 					if trace {
-						fmt.Printf("%s i=%d authority=%x SKIP reason=code-not-empty-not-delegated codeHash=%x\n", tracePrefix, i, authority, codeHash)
+						fmt.Fprintf(os.Stderr, "%s i=%d authority=%x SKIP reason=code-not-empty-not-delegated codeHash=%x\n", tracePrefix, i, authority, codeHash)
 					}
 					continue
 				}
@@ -798,7 +799,7 @@ func (st *TxnExecutor) verifyAuthorities(auths []types.Authorization, contractCr
 			if authorityNonce != auth.Nonce {
 				log.Trace("invalid nonce, skipping", "auth index", i)
 				if trace {
-					fmt.Printf("%s i=%d authority=%x SKIP reason=nonce-mismatch auth.nonce=%d stateNonce=%d codeEmpty=%t hasDelegation=%t\n", tracePrefix, i, authority, auth.Nonce, authorityNonce, codeHash.IsEmpty(), hasDelegation)
+					fmt.Fprintf(os.Stderr, "%s i=%d authority=%x SKIP reason=nonce-mismatch auth.nonce=%d stateNonce=%d codeEmpty=%t hasDelegation=%t\n", tracePrefix, i, authority, auth.Nonce, authorityNonce, codeHash.IsEmpty(), hasDelegation)
 				}
 				continue
 			}
@@ -828,7 +829,7 @@ func (st *TxnExecutor) verifyAuthorities(auths []types.Authorization, contractCr
 			}
 			applied++
 			if trace {
-				fmt.Printf("%s i=%d authority=%x auth.addr=%x auth.nonce=%d stateNonce=%d codeEmpty=%t hasDelegation=%t exists=%t +sgna=%d +sgab=%d\n", tracePrefix, i, authority, auth.Address, auth.Nonce, authorityNonce, codeHash.IsEmpty(), hasDelegation, exists, sgna, sgab)
+				fmt.Fprintf(os.Stderr, "%s i=%d authority=%x auth.addr=%x auth.nonce=%d stateNonce=%d codeEmpty=%t hasDelegation=%t exists=%t +sgna=%d +sgab=%d\n", tracePrefix, i, authority, auth.Address, auth.Nonce, authorityNonce, codeHash.IsEmpty(), hasDelegation, exists, sgna, sgab)
 			}
 
 			// 7. set authority code
@@ -848,7 +849,7 @@ func (st *TxnExecutor) verifyAuthorities(auths []types.Authorization, contractCr
 			}
 		}
 		if trace {
-			fmt.Printf("%s TOTAL refund=%d recovered=%d applied=%d auths=%d\n", tracePrefix, stateIgasRefund, len(verifiedAuthorities), applied, len(auths))
+			fmt.Fprintf(os.Stderr, "%s TOTAL refund=%d recovered=%d applied=%d auths=%d\n", tracePrefix, stateIgasRefund, len(verifiedAuthorities), applied, len(auths))
 		}
 	}
 

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2468,6 +2468,14 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 				if err != nil {
 					return nil, err
 				}
+				if dbg.TraceAuthRefund && txResult.Receipt != nil {
+					resultInc := -1
+					if rv := txResult.Version(); rv.TxIndex >= 0 {
+						resultInc = rv.Incarnation
+					}
+					fmt.Printf("[auth-refund] block=%d txIdx=%d FINALIZE resultInc=%d receiptGas=%d cumGas=%d\n",
+						be.blockNum, txVersion.TxIndex, resultInc, txResult.Receipt.GasUsed, txResult.Receipt.CumulativeGasUsed)
+				}
 				addWrites := finalizeWrites
 
 				// Merge any additional reads/writes produced during finalize (fee calc, post apply, etc)

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2469,7 +2469,7 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 					return nil, err
 				}
 				if dbg.TraceAuthRefund && txResult.Receipt != nil {
-					fmt.Printf("[auth-refund] block=%d txIdx=%d FINALIZE resultInc=%d receiptGas=%d cumGas=%d\n",
+					fmt.Fprintf(os.Stderr, "[auth-refund] block=%d txIdx=%d FINALIZE resultInc=%d receiptGas=%d cumGas=%d\n",
 						be.blockNum, txVersion.TxIndex, txResult.Version().Incarnation, txResult.Receipt.GasUsed, txResult.Receipt.CumulativeGasUsed)
 				}
 				addWrites := finalizeWrites

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2469,12 +2469,8 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 					return nil, err
 				}
 				if dbg.TraceAuthRefund && txResult.Receipt != nil {
-					resultInc := -1
-					if rv := txResult.Version(); rv.TxIndex >= 0 {
-						resultInc = rv.Incarnation
-					}
 					fmt.Printf("[auth-refund] block=%d txIdx=%d FINALIZE resultInc=%d receiptGas=%d cumGas=%d\n",
-						be.blockNum, txVersion.TxIndex, resultInc, txResult.Receipt.GasUsed, txResult.Receipt.CumulativeGasUsed)
+						be.blockNum, txVersion.TxIndex, txResult.Version().Incarnation, txResult.Receipt.GasUsed, txResult.Receipt.CumulativeGasUsed)
 				}
 				addWrites := finalizeWrites
 


### PR DESCRIPTION
## Summary

Adds a new `ERIGON_TRACE_AUTH_REFUND` debug flag to diagnose flaky receipt-hash mismatches under parallel exec on EIP-7702 SET_CODE_TX block tests (e.g. the `test_pointer_resets_an_empty_code_account_with_storage[fork_Amsterdam]` flake on `eest-spec-blocktests-devnet`), and enables the flag (plus the existing `ERIGON_LOG_HASH_MISMATCH_REASON`) on that one shard via the workflow.

Original flaky CI run: [erigontech/erigon#26571263592 job 78278757674 (PR #21485)](https://github.com/erigontech/erigon/actions/runs/26571263592/job/78278757674?pr=21485) — `receiptHash mismatch: fea59da…40c66 != dd4f3a7d…64e8be5` on block 1.

When the flag is set, three new traces are emitted:

1. **Per-auth, per-incarnation** (from `verifyAuthorities`): authority, auth.address, auth.nonce vs state-side nonce, codeEmpty, hasDelegation, exists, and the resulting `+sgna` / `+sgab` contributions (or the skip reason).
2. **Per-tx total**: `stateIgasRefund` total and verified-auth count.
3. **Apply-loop FINALIZE**: which incarnation's `TxResult` reached the receipt, plus its `GasUsed` / `CumulativeGasUsed`.

Sample output on the flaky test (local, parallel exec, passing run — tx 2 had to re-execute once):

```
[auth-refund] block=1 txIdx=2 inc=0 i=0 authority=c0f6... auth.addr=0000... auth.nonce=1 stateNonce=1 codeEmpty=true  hasDelegation=false exists=false +sgna=0      +sgab=35190
[auth-refund] block=1 txIdx=2 inc=0 i=1 authority=1ad9... auth.addr=0000... auth.nonce=4 stateNonce=4 codeEmpty=false hasDelegation=true  exists=true  +sgna=183600 +sgab=35190
[auth-refund] block=1 txIdx=2 inc=0 TOTAL refund=253980 verified=2 auths=2

[auth-refund] block=1 txIdx=2 inc=1 i=0 authority=c0f6... auth.addr=0000... auth.nonce=1 stateNonce=1 codeEmpty=false hasDelegation=true  exists=true  +sgna=183600 +sgab=35190
[auth-refund] block=1 txIdx=2 inc=1 i=1 authority=1ad9... auth.addr=0000... auth.nonce=4 stateNonce=4 codeEmpty=false hasDelegation=true  exists=true  +sgna=183600 +sgab=35190
[auth-refund] block=1 txIdx=2 inc=1 TOTAL refund=437580 verified=2 auths=2

[auth-refund] block=1 txIdx=2 FINALIZE resultInc=1 receiptGas=36000 cumGas=758684
```

The 183,600 delta between incarnations 0 and 1 is exactly `StateGasNewAccount` — the trace cleanly identifies the per-auth refund divergence. The local pass means inc=1 won; the CI flake is when inc=0's receipt slips through instead.

## Motivation

Local repro of the actual receipt-hash mismatch was not reachable (380+ macOS-arm64 iterations, 6× GOMAXPROCS settings, full Amsterdam shard on Docker linux/amd64 emulated under qemu — all green) so a code-level fix without a real divergence trace is guessing. The flake's signal on CI is just `receiptHash mismatch: <a> != <b>` with no per-tx breakdown; this PR is the minimum diagnostic surface needed to turn that into "incarnation X of tx Y had refund Z, expected W" on the next CI fire.

## Workflow wiring

The second commit (`.github: enable …`) sets both `ERIGON_TRACE_AUTH_REFUND=true` and `ERIGON_LOG_HASH_MISMATCH_REASON=true` on the `eest-spec-blocktests-devnet` matrix entry only — so the next time that specific shard flakes, the run's logs already carry the diagnostic, no manual re-trigger needed. Scoped to one shard because `TRACE_AUTH_REFUND` emits a line per EIP-7702 auth across all txs; spreading it everywhere would add log volume to runs that don't need it.

## What stays free when the flag is off

- No allocations
- No branches in hot paths beyond a single `if dbg.TraceAuthRefund` (which is a package-level `bool` initialised once at process start)
- No behavior change

The flag follows the existing `TraceXxx` / `LogHashMismatchReason` env-flag pattern in `common/dbg`. Per the established convention for those flags (`TraceTransactionIO`, `TraceDomainIO`, `TraceGas`, etc.), no dedicated unit test is added — the value is only realized when the flag is set in a CI re-run.

## How to use manually

Set `ERIGON_TRACE_AUTH_REFUND=true` (and optionally `ERIGON_LOG_HASH_MISMATCH_REASON=true`) when running any blocktest that might surface receipt-hash mismatches on EIP-7702 SET_CODE_TX paths. The CI shard now does this automatically.

## Test plan

- [x] `make lint` clean (0 issues, run multiple times due to non-determinism)
- [x] `go test -short ./common/dbg/ ./execution/state/ ./execution/protocol/` green
- [x] `go test -short ./execution/stagedsync/...` green
- [x] Smoke test: flag on, blocktest produces the documented log lines and the test still passes (no behavior change)
- [x] Smoke test: flag off, no output produced (default state matches main)
- [x] Workflow YAML parses cleanly via `yq`; new step is correctly scoped via `if: matrix.shard == 'blocktests-devnet'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)