### PR TITLE
ci: cancel orphaned merge-queue runs when their queue branch is deleted

### DIFF
--- a/.github/workflows/cancel-orphaned-merge-queue-runs.yml
+++ b/.github/workflows/cancel-orphaned-merge-queue-runs.yml
@@ -1,0 +1,37 @@
+name: Cancel orphaned merge-queue runs
+
+# GitHub's merge queue creates `gh-readonly-queue/<base>/pr-<N>-<sha>` branches
+# and deletes them when entries leave the queue (reshuffle, removal, successful
+# merge). CI Gate runs against those branches do not auto-cancel on deletion —
+# their concurrency key for merge_group is per-run_id (see ci-gate.yml) — so
+# orphaned runs keep burning runner-minutes until they finish naturally. This
+# workflow cancels them the moment the underlying queue branch is deleted.
+
+on:
+  delete:
+
+permissions:
+  actions: write
+
+jobs:
+  cancel-orphans:
+    if: github.event.ref_type == 'branch' && startsWith(github.event.ref, 'gh-readonly-queue/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel active runs against deleted queue branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DELETED_REF: ${{ github.event.ref }}
+        run: |
+          set -euo pipefail
+          echo "Deleted merge-queue branch: ${DELETED_REF}"
+          encoded_ref=$(jq -rn --arg b "${DELETED_REF}" '$b|@uri')
+          gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/actions/runs?branch=${encoded_ref}&per_page=100" \
+            --jq '.workflow_runs[] | select(.status != "completed") | .id' \
+          | while IFS= read -r id; do
+              [ -z "$id" ] && continue
+              [ "$id" = "$GITHUB_RUN_ID" ] && continue
+              echo "Cancelling orphaned run ${id}"
+              gh run cancel "${id}" -R "${GITHUB_REPOSITORY}" || true
+            done

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -18,6 +18,8 @@ on:
 concurrency:
   # For PRs: one run per branch; new push cancels the old run.
   # For push/merge_group/workflow_dispatch: unique per run so runs never cancel each other.
+  # merge_group orphans from queue reshuffles are cancelled by
+  # cancel-orphaned-merge-queue-runs.yml when the ephemeral branch is deleted.
   group: >-
     ${{
       github.event_name == 'pull_request' &&


### PR DESCRIPTION
## Summary
- When GitHub's merge queue reshuffles, it deletes the old ephemeral `gh-readonly-queue/<base>/pr-<N>-<sha>` branch and creates a new one. CI Gate runs against the deleted branch are not auto-cancelled — the `merge_group` concurrency key in `ci-gate.yml` is per-`run_id` — so they keep running on orphan refs until they happen to finish, burning runner-minutes (especially on the self-hosted `hive` group) and cluttering the dashboard.
- Add `cancel-orphaned-merge-queue-runs.yml`: a `delete`-event workflow that, when a `gh-readonly-queue/*` branch is deleted, finds every still-active workflow run against that branch and cancels it. Workflows must live on the default branch for `delete` events to fire, so this needs to land on `main`.
- Add a pointer comment in `ci-gate.yml` next to the existing concurrency block so future readers understand why merge_group runs are not cancel-in-progress and where the cleanup actually happens.

The expression-only nature of `concurrency:` keys means we cannot extract the PR number from `github.ref` (no substring/regex), so a same-workflow concurrency-group fix is not viable. A `delete`-event handler is the cleanest mechanism.

Concrete situation that prompted this: snapshot taken at ~12:10 UTC on 2026-05-28 had **6 orphan runs** (3 in_progress from 08:03–08:51, 3 queued from 12:05) burning hive runners against deleted queue branches. Those have been cancelled manually; this PR prevents recurrence.

## Test plan
- [ ] After merge, observe the next merge-queue reshuffle and confirm runs against the now-deleted branch flip to `cancelled` within seconds.
- [ ] Verify no runs against still-live `gh-readonly-queue/*` branches are touched.
- [ ] Verify the workflow's own run doesn't cancel itself (`GITHUB_RUN_ID` guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)