### PR TITLE
docs(fundamentals): add Architecture and Database pages

### DIFF
--- a/docs/site/docs/fundamentals/architecture.md
+++ b/docs/site/docs/fundamentals/architecture.md
@@ -1,0 +1,124 @@
+---
+title: "Architecture"
+description: "How Erigon is built — staged sync, modular processes, flat-DB on MDBX, immutable snapshots, and an embedded consensus layer."
+sidebar_position: 3
+---
+
+# Architecture
+
+Erigon is an Ethereum execution-layer client designed around three goals: **low disk footprint**, **predictable performance**, and **operational simplicity**. This page explains how those goals shape its internal design so you know what is happening when you run the binary.
+
+## At a glance
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                              erigon (one binary)                     │
+│                                                                      │
+│   ┌──────────┐   ┌──────────┐   ┌──────────┐   ┌──────────────────┐  │
+│   │  Sentry  │ → │Downloader│ → │ Execution│ → │  RPC Daemon      │  │
+│   │  (p2p)   │   │(snapshots│   │ (Staged  │   │  (JSON-RPC, WS,  │  │
+│   │          │   │  + EL)   │   │   Sync)  │   │   GraphQL, gRPC) │  │
+│   └──────────┘   └────┬─────┘   └────┬─────┘   └────────┬─────────┘  │
+│                       │              │                  │            │
+│                       ▼              ▼                  ▼            │
+│                  ┌─────────────────────────────────────────┐         │
+│                  │  Single MDBX key-value store + .seg     │         │
+│                  │  snapshot files on disk (the datadir)   │         │
+│                  └─────────────────────────────────────────┘         │
+│                                                                      │
+│   ┌────────┐                                ┌─────────────────┐      │
+│   │ TxPool │ ←──── private gRPC ─────────── │ Caplin (CL)     │      │
+│   │        │                                │ embedded by     │      │
+│   │        │                                │ default         │      │
+│   └────────┘                                └─────────────────┘      │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+Every box above is a Go package that runs **inside the `erigon` process by default**. The same binary can also be split into independent processes — see [Modular processes](#modular-processes).
+
+## Staged sync
+
+Erigon processes the chain in a series of **stages** rather than the traditional "fetch block → execute block → repeat" loop. Each stage runs to completion across the whole range before the next stage starts.
+
+A simplified pipeline:
+
+```
+1. Headers      → download and verify block headers
+2. Bodies       → download block bodies
+3. Snapshots    → fetch immutable history files via BitTorrent
+4. Execution    → re-execute transactions, write account/storage updates
+5. Commitment   → build the state Merkle trie incrementally
+6. Finalization → persist receipts, update canonical chain
+```
+
+Two consequences:
+
+- **Faster initial sync.** Stages are CPU/IO-bound in different ways, so the pipeline avoids waiting on a single bottleneck per block. Snapshot download (stage 3) parallelises with execution warm-up.
+- **Cheap restarts.** Each stage records its progress. Killing Erigon mid-sync and restarting resumes from the last completed checkpoint — Erigon does not re-execute from genesis.
+
+In Erigon 3, the Execution stage absorbs many previously-separate stages (`stage_hash_state`, `stage_trie`, `log_index`, `history_index`, `trace_index`) into a single pass, which is one reason Erigon 3 syncs faster than Erigon 2.
+
+## Modular processes
+
+Each of Sentry, Downloader, TxPool, RPC Daemon, and Caplin can run as an **independent process** that talks to the rest over a private gRPC API.
+
+Use the all-in-one binary by default. Split out a service when you have a concrete reason:
+
+- **Resource isolation** — pin the RPC Daemon to its own CPUs so a heavy `eth_call` cannot stall block production.
+- **Horizontal scaling** — run multiple RPC Daemons against one execution node to serve more concurrent clients.
+- **Replacement** — substitute Erigon's TxPool or Sentry with your own implementation.
+- **Security** — keep the p2p surface (Sentry) on a separate host from the JSON-RPC surface (RPC Daemon).
+
+See the [Modules](modules) section for per-component documentation, and the repository's [docker-compose.yml](https://github.com/erigontech/erigon/blob/main/docker-compose.yml) for a worked split-process example.
+
+## Storage model
+
+Erigon stores everything under a single **datadir**. Two kinds of files live there:
+
+| Kind | Path | Role | Mutable? |
+|------|------|------|----------|
+| Active state | `chaindata/` | Recent state and recent blocks, served from MDBX | Yes |
+| Historical data | `snapshots/` | Older blocks, history, indices — distributed as immutable `.seg` files | No |
+
+This split is what enables Erigon's small disk footprint relative to other archive nodes:
+
+- **`chaindata/` is small (~15 GB on Ethereum mainnet)** because it only holds latest state and recently-updated values.
+- **`snapshots/` is large but content-addressed.** Once a `.seg` file is finalised it is the *same file* on every Erigon node in the world — meaning it can be distributed via BitTorrent and verified by hash. There is no rewrite-amplification penalty for keeping history.
+
+For the exact directory layout, file sizes on mainnet, and how to split storage across fast/slow disks, see [Database](database) and [Optimizing Storage](optimizing-storage).
+
+## Embedded consensus (Caplin)
+
+Erigon ships with **Caplin**, a built-in consensus-layer client. By default `--internalcl` is on, so a single `erigon` invocation runs both the execution layer and the consensus layer with no extra processes, no JWT secret to manage, and no separate binary to upgrade.
+
+If you prefer to run an external CL (Lighthouse, Prysm, Teku, Nimbus), pass `--externalcl` and connect via the standard Engine API. The Engine-API path is identical to what Geth, Besu, or Reth exposes.
+
+See [Caplin](caplin) for full details.
+
+## Flat key-value state
+
+Where most clients store account state in a Merkle Patricia Trie *inside* the database, Erigon stores it as **flat key-value pairs** and computes the trie root incrementally during the Commitment stage. Trade-off:
+
+- **Read path is direct** — `getAccount(addr)` is a single key lookup, not a multi-level trie traversal.
+- **Write path defers trie hashing** — updates accumulate in the KV store and the trie is rebuilt only when state-root computation requires it.
+
+This is the single largest reason Erigon's RPC performance stays flat under load: there is no background trie compaction that can spike CPU during an `eth_call` burst.
+
+## Pruning is a retention decision, not a sync mode
+
+Erigon 3 has one sync pipeline. The user-facing choice is *what to retain after sync*, controlled by `--prune.mode`:
+
+| Mode | Retained | Use case |
+|---|---|---|
+| `archive` | All state, all blocks | Indexers, block explorers, deep historical queries |
+| `full` (default) | Latest state + post-Merge blocks | Most users, dApps, validators |
+| `minimal` | Latest state + recent blocks only | Solo stakers, constrained hardware |
+
+See [Prune Modes](prune-modes) for the full comparison.
+
+## Where to go next
+
+- [Database](database) — datadir layout, MDBX internals, mainnet sizing
+- [Modules](modules) — running RPC Daemon, TxPool, Sentry, Downloader as separate processes
+- [Prune Modes](prune-modes) — choosing what history to keep
+- [Optimizing Storage](optimizing-storage) — splitting datadir across fast and slow disks

--- a/docs/site/docs/fundamentals/architecture.md
+++ b/docs/site/docs/fundamentals/architecture.md
@@ -122,3 +122,4 @@ See [Prune Modes](prune-modes) for the full comparison.
 - [Modules](modules) — running RPC Daemon, TxPool, Sentry, Downloader as separate processes
 - [Prune Modes](prune-modes) — choosing what history to keep
 - [Optimizing Storage](optimizing-storage) — splitting datadir across fast and slow disks
+

--- a/docs/site/docs/fundamentals/architecture.md
+++ b/docs/site/docs/fundamentals/architecture.md
@@ -10,28 +10,35 @@ Erigon is an Ethereum execution-layer client designed around three goals: **low 
 
 ## At a glance
 
-```
-┌──────────────────────────────────────────────────────────────────────┐
-│                              erigon (one binary)                     │
-│                                                                      │
-│   ┌──────────┐   ┌──────────┐   ┌──────────┐   ┌──────────────────┐  │
-│   │  Sentry  │ → │Downloader│ → │ Execution│ → │  RPC Daemon      │  │
-│   │  (p2p)   │   │(snapshots│   │ (Staged  │   │  (JSON-RPC, WS,  │  │
-│   │          │   │  + EL)   │   │   Sync)  │   │   GraphQL, gRPC) │  │
-│   └──────────┘   └────┬─────┘   └────┬─────┘   └────────┬─────────┘  │
-│                       │              │                  │            │
-│                       ▼              ▼                  ▼            │
-│                  ┌─────────────────────────────────────────┐         │
-│                  │  Single MDBX key-value store + .seg     │         │
-│                  │  snapshot files on disk (the datadir)   │         │
-│                  └─────────────────────────────────────────┘         │
-│                                                                      │
-│   ┌────────┐                                ┌─────────────────┐      │
-│   │ TxPool │ ←──── private gRPC ─────────── │ Caplin (CL)     │      │
-│   │        │                                │ embedded by     │      │
-│   │        │                                │ default         │      │
-│   └────────┘                                └─────────────────┘      │
-└──────────────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TB
+    subgraph erigon["erigon (one binary)"]
+        direction TB
+        Sentry["Sentry<br/>(p2p)"]
+        Downloader["Downloader<br/>(snapshots + EL data)"]
+        Execution["Execution<br/>(Staged Sync)"]
+        RPC["RPC Daemon<br/>(JSON-RPC, WS,<br/>GraphQL, gRPC)"]
+        TxPool["TxPool"]
+        Caplin["Caplin (CL)<br/>embedded by default"]
+        Datadir[("datadir<br/>MDBX chaindata<br/>+ .seg snapshots")]
+
+        Sentry --> Downloader
+        Downloader --> Execution
+        Execution --> RPC
+
+        Downloader -.writes.-> Datadir
+        Execution -.reads/writes.-> Datadir
+        RPC -.reads.-> Datadir
+
+        TxPool <-- private gRPC --> Caplin
+        TxPool -.reads.-> Datadir
+        Caplin -.reads/writes.-> Datadir
+    end
+
+    classDef component fill:#fff5e6,stroke:#EF7716,stroke-width:1.5px,color:#000
+    classDef storage fill:#f0f0ff,stroke:#5860EF,stroke-width:1.5px,color:#000
+    class Sentry,Downloader,Execution,RPC,TxPool,Caplin component
+    class Datadir storage
 ```
 
 Every box above is a Go package that runs **inside the `erigon` process by default**. The same binary can also be split into independent processes — see [Modular processes](#modular-processes).

--- a/docs/site/docs/fundamentals/database.md
+++ b/docs/site/docs/fundamentals/database.md
@@ -75,17 +75,7 @@ snapshots/idx      430 GB
 snapshots TOTAL    2.3 TB
 ```
 
-```sh
-# bor-mainnet (Polygon PoS) — archive
-chaindata           20 GB
-snapshots/accessor 360 GB
-snapshots/domain   1.1 TB
-snapshots/history  750 GB
-snapshots/idx      1.5 TB
-snapshots TOTAL    4.9 TB
-```
-
-For non-archive footprints (`--prune.mode=full` or `minimal`), see [Hardware Requirements](../get-started/hardware-requirements).
+For up-to-date totals across all networks and prune modes, see [Hardware Requirements](../get-started/hardware-requirements).
 
 ## Why `chaindata/` stays so small
 
@@ -95,7 +85,7 @@ In Erigon 3, `chaindata/` only holds:
 - Recent blocks not yet folded into snapshots
 - Live txpool, peer state, sync stage progress
 
-Most of the bulk that other clients keep in the active database — historical state, ancient blocks, receipt logs — is in immutable snapshot files instead. This is why `chaindata/` rarely exceeds 20 GB even on Polygon archive nodes.
+Most of the bulk that other clients keep in the active database — historical state, ancient blocks, receipt logs — is in immutable snapshot files instead. This is why `chaindata/` rarely exceeds 20 GB even on archive nodes.
 
 It also means **`rm -rf chaindata/` is recoverable**: Erigon will rebuild it from snapshots on next start, given enough time. (You will still want a backup for fast recovery, but the cost of losing it is hours, not weeks.)
 

--- a/docs/site/docs/fundamentals/database.md
+++ b/docs/site/docs/fundamentals/database.md
@@ -1,0 +1,126 @@
+---
+title: "Database"
+description: "How Erigon stores chain data — MDBX engine, datadir layout, snapshot files, and real mainnet sizing numbers."
+sidebar_position: 15
+---
+
+# Database
+
+Erigon stores all chain data under a single **datadir**. Understanding what lives where is useful when you size hardware, debug disk-usage issues, or split storage across fast and slow drives.
+
+This page covers the *what* and *where* of Erigon's data. For the *why* — flat KV state, immutable snapshots — see [Architecture](architecture). For operational tuning (symlinks, multi-disk layout), see [Optimizing Storage](optimizing-storage).
+
+## The datadir at a glance
+
+```
+datadir/
+├── chaindata/        # Active state + recent blocks (MDBX). Small, hot, mutable.
+├── snapshots/        # Historical data as immutable .seg files. Large, cold.
+│   ├── domain/         # Latest state per domain (account, storage, code, commitment)
+│   ├── history/        # Historical values per domain
+│   ├── idx/            # Inverted indices — search/filter/intersect historical data
+│   └── accessor/       # Random-access indices over history (point lookups only)
+├── txpool/           # Pending transactions. Safe to delete; will repopulate from peers.
+├── nodes/            # p2p peer cache. Safe to delete; will repopulate.
+└── temp/             # External-sort buffers (~100 GB peak). Cleaned at startup.
+```
+
+The split between **`chaindata/`** (mutable) and **`snapshots/`** (immutable) is the central design decision. It is what makes Erigon's archive node 10× smaller than other clients while staying fast.
+
+## Storage engine: MDBX
+
+`chaindata/` is a single [MDBX](https://github.com/erthink/libmdbx) key-value store. MDBX is a B+ tree engine derived from LMDB, optimised for read-heavy workloads and predictable memory use.
+
+Properties that matter operationally:
+
+- **No background compaction.** Writes go directly into the B+ tree; there is no compaction thread that can spike CPU mid-RPC-call. This is why Erigon's RPC latency does not degrade under load the way LSM-based engines (LevelDB, RocksDB) can.
+- **Memory-mapped reads.** The OS page cache is the hot data cache. There is no separate per-process cache to tune. Multiple Erigon services on one machine share the same page cache automatically.
+- **Single-writer.** One process holds the write lock; readers are unlimited and lock-free. This is why splitting RPC Daemon out as a separate process for read scaling works cleanly — only one writer ever touches the file.
+
+## Snapshots: immutable history
+
+Older blocks and history are not stored in MDBX. They are written to **`.seg` files** in `snapshots/` and **never modified after creation**.
+
+Once a snapshot file is finalised it is the same bytes on every Erigon node in the world, identified by content hash. This unlocks two things:
+
+- **BitTorrent distribution.** New nodes fetch snapshots from peers in parallel rather than re-executing history from genesis. This is what OtterSync does.
+- **Backup / disaster recovery costs ~10× less.** Most of your datadir is content-addressed and can be re-downloaded from any peer if a disk fails. You only need to back up `chaindata/`.
+
+Snapshots come in four flavours, each in its own subdirectory:
+
+| Directory | What it holds | Access pattern |
+|---|---|---|
+| `snapshots/domain/` | Latest value per (domain, key). 4 domains: `account`, `storage`, `code`, `commitment` | Sequential + point lookup |
+| `snapshots/history/` | Every historical value per (domain, key, txn) | Point lookup keyed by transaction |
+| `snapshots/idx/` | Inverted indices over history — answers "which transactions touched key X?" | Search / filter / set intersection |
+| `snapshots/accessor/` | Pre-built random-access indices over history files | Random-touch point reads only |
+
+**Per-transaction granularity.** Erigon 3 indexes history at the **transaction** level, not the block level. This means:
+
+- You can replay a single historical transaction without re-executing its block.
+- If an account changes V1 → V2 → V1 within one block, `debug_getModifiedAccountsByNumber` correctly returns it.
+- Receipts are not stored — they are re-computed by re-executing the relevant transaction, which is cheap thanks to the index structure above.
+
+## What does it cost on disk?
+
+Real numbers from a Nov 2024 mainnet archive node:
+
+```sh
+# eth-mainnet — archive — prune.mode=archive
+chaindata           15 GB
+snapshots/accessor 120 GB
+snapshots/domain   300 GB
+snapshots/history  280 GB
+snapshots/idx      430 GB
+snapshots TOTAL    2.3 TB
+```
+
+```sh
+# bor-mainnet (Polygon PoS) — archive
+chaindata           20 GB
+snapshots/accessor 360 GB
+snapshots/domain   1.1 TB
+snapshots/history  750 GB
+snapshots/idx      1.5 TB
+snapshots TOTAL    4.9 TB
+```
+
+For non-archive footprints (`--prune.mode=full` or `minimal`), see [Hardware Requirements](../get-started/hardware-requirements).
+
+## Why `chaindata/` stays so small
+
+In Erigon 3, `chaindata/` only holds:
+
+- The very latest state values (post-snapshot tip)
+- Recent blocks not yet folded into snapshots
+- Live txpool, peer state, sync stage progress
+
+Most of the bulk that other clients keep in the active database — historical state, ancient blocks, receipt logs — is in immutable snapshot files instead. This is why `chaindata/` rarely exceeds 20 GB even on Polygon archive nodes.
+
+It also means **`rm -rf chaindata/` is recoverable**: Erigon will rebuild it from snapshots on next start, given enough time. (You will still want a backup for fast recovery, but the cost of losing it is hours, not weeks.)
+
+## Tuning knobs
+
+- **`--batchSize`** — controls how much state Erigon buffers in RAM before flushing to MDBX. Default is balanced; lower it (e.g. `--batchSize 1G`) if `chaindata/` grows unexpectedly.
+- **`--db.size.limit`** — caps the MDBX file size. Useful when running multiple Erigon instances on one disk to prevent one from starving the others.
+- **`--db.read.concurrency`** — number of concurrent MDBX read transactions. Increase when you run a high-throughput RPC Daemon against the same datadir.
+- **Symlinks for tiered storage.** Place `chaindata/` and `snapshots/domain/` on fast NVMe, leave `snapshots/idx/` and `snapshots/history/` on cheaper SATA. See [Optimizing Storage](optimizing-storage) for the recipe.
+
+## Safe-to-delete subdirectories
+
+If you need to reclaim space without resyncing from scratch:
+
+| Directory | Effect of deletion |
+|---|---|
+| `txpool/` | Pending transactions lost; pool refills from peers within minutes |
+| `nodes/` | Peer cache lost; reconnects on restart |
+| `temp/` | Cleaned automatically at startup anyway |
+| `chaindata/` | Rebuilds from snapshots on restart (hours, not days) |
+| `snapshots/` | **Do not delete** — would force a full resync |
+
+## Where to go next
+
+- [Architecture](architecture) — how this storage model fits into staged sync and the flat-KV state design
+- [Optimizing Storage](optimizing-storage) — concrete recipes for splitting the datadir across multiple disks
+- [Hardware Requirements](../get-started/hardware-requirements) — disk-size numbers for each `--prune.mode`
+- [Prune Modes](prune-modes) — choosing what history to keep

--- a/docs/site/docusaurus.config.ts
+++ b/docs/site/docusaurus.config.ts
@@ -59,6 +59,9 @@ export default async function createConfig(): Promise<Config> {
     onBrokenAnchors: 'throw',
     i18n: {defaultLocale: 'en', locales: ['en']},
 
+    markdown: {mermaid: true},
+    themes: ['@docusaurus/theme-mermaid'],
+
     customFields: {latestVersion},
 
     headTags: [

--- a/docs/site/package-lock.json
+++ b/docs/site/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@docusaurus/core": "3.10.0",
         "@docusaurus/preset-classic": "3.10.0",
+        "@docusaurus/theme-mermaid": "^3.10.0",
         "@easyops-cn/docusaurus-search-local": "^0.55.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
@@ -259,6 +260,19 @@
       },
       "engines": {
         "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1961,6 +1975,18 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -4022,6 +4048,34 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@docusaurus/theme-mermaid": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.10.0.tgz",
+      "integrity": "sha512-Y2xrlwhIJ80oOZIO3PXL6A7J869splfcMI87E3NKpYsy3zJxOyV+BP1QMtGi59ajKgU868HPuyyn6J+6BZGOBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.10.0",
+        "@docusaurus/module-type-aliases": "3.10.0",
+        "@docusaurus/theme-common": "3.10.0",
+        "@docusaurus/types": "3.10.0",
+        "@docusaurus/utils-validation": "3.10.0",
+        "mermaid": ">=11.6.0",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      },
+      "peerDependencies": {
+        "@mermaid-js/layout-elk": "^0.1.9",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@mermaid-js/layout-elk": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@docusaurus/theme-search-algolia": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.10.0.tgz",
@@ -4337,6 +4391,23 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.3.tgz",
+      "integrity": "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
       }
     },
     "node_modules/@jest/schemas": {
@@ -4890,6 +4961,15 @@
       "peerDependencies": {
         "@types/react": ">=16",
         "react": ">=16"
+      }
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
+      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.1"
       }
     },
     "node_modules/@noble/hashes": {
@@ -5766,6 +5846,259 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -5833,6 +6166,12 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/gtag.js": {
       "version": "0.0.20",
@@ -6070,6 +6409,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -6105,6 +6451,16 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
@@ -7710,6 +8066,15 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "8.3.6",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
@@ -8195,6 +8560,532 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/cytoscape": {
+      "version": "3.33.4",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.4.tgz",
+      "integrity": "sha512-HIN5Pmd9MrX9BkV7tDwnOcEJCSFvCpc8X97h3f508J6I5FsqAY65wKOCvgH2CuP42CaahWaz4tuh32SOOIH7ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
+    },
     "node_modules/debounce": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
@@ -8356,6 +9247,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -8492,6 +9392,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
+      "integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
@@ -8714,6 +9623,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
+      "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esast-util-from-estree": {
       "version": "2.0.0",
@@ -9751,6 +10670,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
     "node_modules/handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -10390,6 +11315,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -10437,6 +11372,15 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/invariant": {
       "version": "2.2.4",
@@ -10933,6 +11877,31 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -10941,6 +11910,11 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -10993,6 +11967,12 @@
         "picocolors": "^1.1.1",
         "shell-quote": "^1.8.3"
       }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -11067,6 +12047,12 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -11177,6 +12163,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {
@@ -11656,6 +12654,48 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
+      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.1",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.1.1",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.1",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.19",
+        "dompurify": "^3.3.1",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.25",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
+      }
+    },
+    "node_modules/mermaid/node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/methods": {
@@ -14021,6 +15061,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "license": "MIT"
+    },
     "node_modules/param-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -14160,6 +15206,12 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
@@ -14256,6 +15308,22 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/postcss": {
@@ -16688,6 +17756,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
     "node_modules/rtlcss": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-4.3.0.tgz",
@@ -16740,6 +17826,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -17573,6 +18665,12 @@
         "postcss": "^8.4.31"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -17770,6 +18868,15 @@
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
       "license": "MIT"
     },
+    "node_modules/tinyexec": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.2.tgz",
+      "integrity": "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinypool": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
@@ -17843,6 +18950,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/tslib": {

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@docusaurus/core": "3.10.0",
     "@docusaurus/preset-classic": "3.10.0",
+    "@docusaurus/theme-mermaid": "^3.10.0",
     "@easyops-cn/docusaurus-search-local": "^0.55.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -1422,28 +1422,35 @@ Erigon is an Ethereum execution-layer client designed around three goals: **low 
 
 ## At a glance
 
-```
-┌──────────────────────────────────────────────────────────────────────┐
-│                              erigon (one binary)                     │
-│                                                                      │
-│   ┌──────────┐   ┌──────────┐   ┌──────────┐   ┌──────────────────┐  │
-│   │  Sentry  │ → │Downloader│ → │ Execution│ → │  RPC Daemon      │  │
-│   │  (p2p)   │   │(snapshots│   │ (Staged  │   │  (JSON-RPC, WS,  │  │
-│   │          │   │  + EL)   │   │   Sync)  │   │   GraphQL, gRPC) │  │
-│   └──────────┘   └────┬─────┘   └────┬─────┘   └────────┬─────────┘  │
-│                       │              │                  │            │
-│                       ▼              ▼                  ▼            │
-│                  ┌─────────────────────────────────────────┐         │
-│                  │  Single MDBX key-value store + .seg     │         │
-│                  │  snapshot files on disk (the datadir)   │         │
-│                  └─────────────────────────────────────────┘         │
-│                                                                      │
-│   ┌────────┐                                ┌─────────────────┐      │
-│   │ TxPool │ ←──── private gRPC ─────────── │ Caplin (CL)     │      │
-│   │        │                                │ embedded by     │      │
-│   │        │                                │ default         │      │
-│   └────────┘                                └─────────────────┘      │
-└──────────────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TB
+    subgraph erigon["erigon (one binary)"]
+        direction TB
+        Sentry["Sentry<br/>(p2p)"]
+        Downloader["Downloader<br/>(snapshots + EL data)"]
+        Execution["Execution<br/>(Staged Sync)"]
+        RPC["RPC Daemon<br/>(JSON-RPC, WS,<br/>GraphQL, gRPC)"]
+        TxPool["TxPool"]
+        Caplin["Caplin (CL)<br/>embedded by default"]
+        Datadir[("datadir<br/>MDBX chaindata<br/>+ .seg snapshots")]
+
+        Sentry --> Downloader
+        Downloader --> Execution
+        Execution --> RPC
+
+        Downloader -.writes.-> Datadir
+        Execution -.reads/writes.-> Datadir
+        RPC -.reads.-> Datadir
+
+        TxPool <-- private gRPC --> Caplin
+        TxPool -.reads.-> Datadir
+        Caplin -.reads/writes.-> Datadir
+    end
+
+    classDef component fill:#fff5e6,stroke:#EF7716,stroke-width:1.5px,color:#000
+    classDef storage fill:#f0f0ff,stroke:#5860EF,stroke-width:1.5px,color:#000
+    class Sentry,Downloader,Execution,RPC,TxPool,Caplin component
+    class Datadir storage
 ```
 
 Every box above is a Go package that runs **inside the `erigon` process by default**. The same binary can also be split into independent processes — see [Modular processes](#modular-processes).
@@ -2448,17 +2455,7 @@ snapshots/idx      430 GB
 snapshots TOTAL    2.3 TB
 ```
 
-```sh
-# bor-mainnet (Polygon PoS) — archive
-chaindata           20 GB
-snapshots/accessor 360 GB
-snapshots/domain   1.1 TB
-snapshots/history  750 GB
-snapshots/idx      1.5 TB
-snapshots TOTAL    4.9 TB
-```
-
-For non-archive footprints (`--prune.mode=full` or `minimal`), see [Hardware Requirements](../get-started/hardware-requirements).
+For up-to-date totals across all networks and prune modes, see [Hardware Requirements](../get-started/hardware-requirements).
 
 ## Why `chaindata/` stays so small
 
@@ -2468,7 +2465,7 @@ In Erigon 3, `chaindata/` only holds:
 - Recent blocks not yet folded into snapshots
 - Live txpool, peer state, sync stage progress
 
-Most of the bulk that other clients keep in the active database — historical state, ancient blocks, receipt logs — is in immutable snapshot files instead. This is why `chaindata/` rarely exceeds 20 GB even on Polygon archive nodes.
+Most of the bulk that other clients keep in the active database — historical state, ancient blocks, receipt logs — is in immutable snapshot files instead. This is why `chaindata/` rarely exceeds 20 GB even on archive nodes.
 
 It also means **`rm -rf chaindata/` is recoverable**: Erigon will rebuild it from snapshots on next start, given enough time. (You will still want a backup for fast recovery, but the cost of losing it is hours, not weeks.)
 

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -1414,6 +1414,129 @@ The Minimal Node configuration (`--prune.mode=minimal`) is the smallest possible
 
 ---
 
+# Architecture
+URL: https://docs.erigon.tech/fundamentals/architecture
+
+
+Erigon is an Ethereum execution-layer client designed around three goals: **low disk footprint**, **predictable performance**, and **operational simplicity**. This page explains how those goals shape its internal design so you know what is happening when you run the binary.
+
+## At a glance
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                              erigon (one binary)                     │
+│                                                                      │
+│   ┌──────────┐   ┌──────────┐   ┌──────────┐   ┌──────────────────┐  │
+│   │  Sentry  │ → │Downloader│ → │ Execution│ → │  RPC Daemon      │  │
+│   │  (p2p)   │   │(snapshots│   │ (Staged  │   │  (JSON-RPC, WS,  │  │
+│   │          │   │  + EL)   │   │   Sync)  │   │   GraphQL, gRPC) │  │
+│   └──────────┘   └────┬─────┘   └────┬─────┘   └────────┬─────────┘  │
+│                       │              │                  │            │
+│                       ▼              ▼                  ▼            │
+│                  ┌─────────────────────────────────────────┐         │
+│                  │  Single MDBX key-value store + .seg     │         │
+│                  │  snapshot files on disk (the datadir)   │         │
+│                  └─────────────────────────────────────────┘         │
+│                                                                      │
+│   ┌────────┐                                ┌─────────────────┐      │
+│   │ TxPool │ ←──── private gRPC ─────────── │ Caplin (CL)     │      │
+│   │        │                                │ embedded by     │      │
+│   │        │                                │ default         │      │
+│   └────────┘                                └─────────────────┘      │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+Every box above is a Go package that runs **inside the `erigon` process by default**. The same binary can also be split into independent processes — see [Modular processes](#modular-processes).
+
+## Staged sync
+
+Erigon processes the chain in a series of **stages** rather than the traditional "fetch block → execute block → repeat" loop. Each stage runs to completion across the whole range before the next stage starts.
+
+A simplified pipeline:
+
+```
+1. Headers      → download and verify block headers
+2. Bodies       → download block bodies
+3. Snapshots    → fetch immutable history files via BitTorrent
+4. Execution    → re-execute transactions, write account/storage updates
+5. Commitment   → build the state Merkle trie incrementally
+6. Finalization → persist receipts, update canonical chain
+```
+
+Two consequences:
+
+- **Faster initial sync.** Stages are CPU/IO-bound in different ways, so the pipeline avoids waiting on a single bottleneck per block. Snapshot download (stage 3) parallelises with execution warm-up.
+- **Cheap restarts.** Each stage records its progress. Killing Erigon mid-sync and restarting resumes from the last completed checkpoint — Erigon does not re-execute from genesis.
+
+In Erigon 3, the Execution stage absorbs many previously-separate stages (`stage_hash_state`, `stage_trie`, `log_index`, `history_index`, `trace_index`) into a single pass, which is one reason Erigon 3 syncs faster than Erigon 2.
+
+## Modular processes
+
+Each of Sentry, Downloader, TxPool, RPC Daemon, and Caplin can run as an **independent process** that talks to the rest over a private gRPC API.
+
+Use the all-in-one binary by default. Split out a service when you have a concrete reason:
+
+- **Resource isolation** — pin the RPC Daemon to its own CPUs so a heavy `eth_call` cannot stall block production.
+- **Horizontal scaling** — run multiple RPC Daemons against one execution node to serve more concurrent clients.
+- **Replacement** — substitute Erigon's TxPool or Sentry with your own implementation.
+- **Security** — keep the p2p surface (Sentry) on a separate host from the JSON-RPC surface (RPC Daemon).
+
+See the [Modules](modules) section for per-component documentation, and the repository's [docker-compose.yml](https://github.com/erigontech/erigon/blob/main/docker-compose.yml) for a worked split-process example.
+
+## Storage model
+
+Erigon stores everything under a single **datadir**. Two kinds of files live there:
+
+| Kind | Path | Role | Mutable? |
+|------|------|------|----------|
+| Active state | `chaindata/` | Recent state and recent blocks, served from MDBX | Yes |
+| Historical data | `snapshots/` | Older blocks, history, indices — distributed as immutable `.seg` files | No |
+
+This split is what enables Erigon's small disk footprint relative to other archive nodes:
+
+- **`chaindata/` is small (~15 GB on Ethereum mainnet)** because it only holds latest state and recently-updated values.
+- **`snapshots/` is large but content-addressed.** Once a `.seg` file is finalised it is the *same file* on every Erigon node in the world — meaning it can be distributed via BitTorrent and verified by hash. There is no rewrite-amplification penalty for keeping history.
+
+For the exact directory layout, file sizes on mainnet, and how to split storage across fast/slow disks, see [Database](database) and [Optimizing Storage](optimizing-storage).
+
+## Embedded consensus (Caplin)
+
+Erigon ships with **Caplin**, a built-in consensus-layer client. By default `--internalcl` is on, so a single `erigon` invocation runs both the execution layer and the consensus layer with no extra processes, no JWT secret to manage, and no separate binary to upgrade.
+
+If you prefer to run an external CL (Lighthouse, Prysm, Teku, Nimbus), pass `--externalcl` and connect via the standard Engine API. The Engine-API path is identical to what Geth, Besu, or Reth exposes.
+
+See [Caplin](caplin) for full details.
+
+## Flat key-value state
+
+Where most clients store account state in a Merkle Patricia Trie *inside* the database, Erigon stores it as **flat key-value pairs** and computes the trie root incrementally during the Commitment stage. Trade-off:
+
+- **Read path is direct** — `getAccount(addr)` is a single key lookup, not a multi-level trie traversal.
+- **Write path defers trie hashing** — updates accumulate in the KV store and the trie is rebuilt only when state-root computation requires it.
+
+This is the single largest reason Erigon's RPC performance stays flat under load: there is no background trie compaction that can spike CPU during an `eth_call` burst.
+
+## Pruning is a retention decision, not a sync mode
+
+Erigon 3 has one sync pipeline. The user-facing choice is *what to retain after sync*, controlled by `--prune.mode`:
+
+| Mode | Retained | Use case |
+|---|---|---|
+| `archive` | All state, all blocks | Indexers, block explorers, deep historical queries |
+| `full` (default) | Latest state + post-Merge blocks | Most users, dApps, validators |
+| `minimal` | Latest state + recent blocks only | Solo stakers, constrained hardware |
+
+See [Prune Modes](prune-modes) for the full comparison.
+
+## Where to go next
+
+- [Database](database) — datadir layout, MDBX internals, mainnet sizing
+- [Modules](modules) — running RPC Daemon, TxPool, Sentry, Downloader as separate processes
+- [Prune Modes](prune-modes) — choosing what history to keep
+- [Optimizing Storage](optimizing-storage) — splitting datadir across fast and slow disks
+
+---
+
 # Supported Networks
 URL: https://docs.erigon.tech/fundamentals/supported-networks
 
@@ -2249,6 +2372,131 @@ Erigon itself consumes less than 2GB of RAM. Therefore, Erigon will benefit from
           - 192.168.255.138:6061
           - 192.168.255.138:6062
 ```
+
+---
+
+# Database
+URL: https://docs.erigon.tech/fundamentals/database
+
+
+Erigon stores all chain data under a single **datadir**. Understanding what lives where is useful when you size hardware, debug disk-usage issues, or split storage across fast and slow drives.
+
+This page covers the *what* and *where* of Erigon's data. For the *why* — flat KV state, immutable snapshots — see [Architecture](architecture). For operational tuning (symlinks, multi-disk layout), see [Optimizing Storage](optimizing-storage).
+
+## The datadir at a glance
+
+```
+datadir/
+├── chaindata/        # Active state + recent blocks (MDBX). Small, hot, mutable.
+├── snapshots/        # Historical data as immutable .seg files. Large, cold.
+│   ├── domain/         # Latest state per domain (account, storage, code, commitment)
+│   ├── history/        # Historical values per domain
+│   ├── idx/            # Inverted indices — search/filter/intersect historical data
+│   └── accessor/       # Random-access indices over history (point lookups only)
+├── txpool/           # Pending transactions. Safe to delete; will repopulate from peers.
+├── nodes/            # p2p peer cache. Safe to delete; will repopulate.
+└── temp/             # External-sort buffers (~100 GB peak). Cleaned at startup.
+```
+
+The split between **`chaindata/`** (mutable) and **`snapshots/`** (immutable) is the central design decision. It is what makes Erigon's archive node 10× smaller than other clients while staying fast.
+
+## Storage engine: MDBX
+
+`chaindata/` is a single [MDBX](https://github.com/erthink/libmdbx) key-value store. MDBX is a B+ tree engine derived from LMDB, optimised for read-heavy workloads and predictable memory use.
+
+Properties that matter operationally:
+
+- **No background compaction.** Writes go directly into the B+ tree; there is no compaction thread that can spike CPU mid-RPC-call. This is why Erigon's RPC latency does not degrade under load the way LSM-based engines (LevelDB, RocksDB) can.
+- **Memory-mapped reads.** The OS page cache is the hot data cache. There is no separate per-process cache to tune. Multiple Erigon services on one machine share the same page cache automatically.
+- **Single-writer.** One process holds the write lock; readers are unlimited and lock-free. This is why splitting RPC Daemon out as a separate process for read scaling works cleanly — only one writer ever touches the file.
+
+## Snapshots: immutable history
+
+Older blocks and history are not stored in MDBX. They are written to **`.seg` files** in `snapshots/` and **never modified after creation**.
+
+Once a snapshot file is finalised it is the same bytes on every Erigon node in the world, identified by content hash. This unlocks two things:
+
+- **BitTorrent distribution.** New nodes fetch snapshots from peers in parallel rather than re-executing history from genesis. This is what OtterSync does.
+- **Backup / disaster recovery costs ~10× less.** Most of your datadir is content-addressed and can be re-downloaded from any peer if a disk fails. You only need to back up `chaindata/`.
+
+Snapshots come in four flavours, each in its own subdirectory:
+
+| Directory | What it holds | Access pattern |
+|---|---|---|
+| `snapshots/domain/` | Latest value per (domain, key). 4 domains: `account`, `storage`, `code`, `commitment` | Sequential + point lookup |
+| `snapshots/history/` | Every historical value per (domain, key, txn) | Point lookup keyed by transaction |
+| `snapshots/idx/` | Inverted indices over history — answers "which transactions touched key X?" | Search / filter / set intersection |
+| `snapshots/accessor/` | Pre-built random-access indices over history files | Random-touch point reads only |
+
+**Per-transaction granularity.** Erigon 3 indexes history at the **transaction** level, not the block level. This means:
+
+- You can replay a single historical transaction without re-executing its block.
+- If an account changes V1 → V2 → V1 within one block, `debug_getModifiedAccountsByNumber` correctly returns it.
+- Receipts are not stored — they are re-computed by re-executing the relevant transaction, which is cheap thanks to the index structure above.
+
+## What does it cost on disk?
+
+Real numbers from a Nov 2024 mainnet archive node:
+
+```sh
+# eth-mainnet — archive — prune.mode=archive
+chaindata           15 GB
+snapshots/accessor 120 GB
+snapshots/domain   300 GB
+snapshots/history  280 GB
+snapshots/idx      430 GB
+snapshots TOTAL    2.3 TB
+```
+
+```sh
+# bor-mainnet (Polygon PoS) — archive
+chaindata           20 GB
+snapshots/accessor 360 GB
+snapshots/domain   1.1 TB
+snapshots/history  750 GB
+snapshots/idx      1.5 TB
+snapshots TOTAL    4.9 TB
+```
+
+For non-archive footprints (`--prune.mode=full` or `minimal`), see [Hardware Requirements](../get-started/hardware-requirements).
+
+## Why `chaindata/` stays so small
+
+In Erigon 3, `chaindata/` only holds:
+
+- The very latest state values (post-snapshot tip)
+- Recent blocks not yet folded into snapshots
+- Live txpool, peer state, sync stage progress
+
+Most of the bulk that other clients keep in the active database — historical state, ancient blocks, receipt logs — is in immutable snapshot files instead. This is why `chaindata/` rarely exceeds 20 GB even on Polygon archive nodes.
+
+It also means **`rm -rf chaindata/` is recoverable**: Erigon will rebuild it from snapshots on next start, given enough time. (You will still want a backup for fast recovery, but the cost of losing it is hours, not weeks.)
+
+## Tuning knobs
+
+- **`--batchSize`** — controls how much state Erigon buffers in RAM before flushing to MDBX. Default is balanced; lower it (e.g. `--batchSize 1G`) if `chaindata/` grows unexpectedly.
+- **`--db.size.limit`** — caps the MDBX file size. Useful when running multiple Erigon instances on one disk to prevent one from starving the others.
+- **`--db.read.concurrency`** — number of concurrent MDBX read transactions. Increase when you run a high-throughput RPC Daemon against the same datadir.
+- **Symlinks for tiered storage.** Place `chaindata/` and `snapshots/domain/` on fast NVMe, leave `snapshots/idx/` and `snapshots/history/` on cheaper SATA. See [Optimizing Storage](optimizing-storage) for the recipe.
+
+## Safe-to-delete subdirectories
+
+If you need to reclaim space without resyncing from scratch:
+
+| Directory | Effect of deletion |
+|---|---|
+| `txpool/` | Pending transactions lost; pool refills from peers within minutes |
+| `nodes/` | Peer cache lost; reconnects on restart |
+| `temp/` | Cleaned automatically at startup anyway |
+| `chaindata/` | Rebuilds from snapshots on restart (hours, not days) |
+| `snapshots/` | **Do not delete** — would force a full resync |
+
+## Where to go next
+
+- [Architecture](architecture) — how this storage model fits into staged sync and the flat-KV state design
+- [Optimizing Storage](optimizing-storage) — concrete recipes for splitting the datadir across multiple disks
+- [Hardware Requirements](../get-started/hardware-requirements) — disk-size numbers for each `--prune.mode`
+- [Prune Modes](prune-modes) — choosing what history to keep
 
 ---
 

--- a/docs/site/static/llms.txt
+++ b/docs/site/static/llms.txt
@@ -26,6 +26,7 @@
 - [Fundamentals](https://docs.erigon.tech/fundamentals): Core concepts for running Erigon — modules, CLI flags, prune modes, database internals, and node configuration.
 - [Basic Usage](https://docs.erigon.tech/fundamentals/basic-usage): Command-line flags, common arguments, and first steps running the Erigon binary.
 - [Prune Modes](https://docs.erigon.tech/fundamentals/prune-modes): Full, minimal, blocks, and archive prune modes explained — choose the right mode for your use case.
+- [Architecture](https://docs.erigon.tech/fundamentals/architecture): How Erigon is built — staged sync, modular processes, flat-DB on MDBX, immutable snapshots, and an embedded consensus layer.
 - [Supported Networks](https://docs.erigon.tech/fundamentals/supported-networks): Mainnet, testnets, Gnosis, Polygon, and all other chains Erigon can sync.
 - [Default ports](https://docs.erigon.tech/fundamentals/default-ports): Default listening ports for each Erigon service and how to override them.
 - [Layer 2 Networks](https://docs.erigon.tech/fundamentals/layer-2-networks): Running Erigon for Polygon PoS, Bor, and other Layer 2 networks.
@@ -37,6 +38,7 @@
 - [JWT Secret](https://docs.erigon.tech/fundamentals/jwt): Generating and configuring the JWT secret for Engine API communication.
 - [TLS Authentication](https://docs.erigon.tech/fundamentals/tls-authentication): Mutual TLS setup for securing gRPC and RPC daemon endpoints.
 - [Multiple instances / One machine](https://docs.erigon.tech/fundamentals/multiple-instances): Running several Erigon instances on a single machine without conflict.
+- [Database](https://docs.erigon.tech/fundamentals/database): How Erigon stores chain data — MDBX engine, datadir layout, snapshot files, and real mainnet sizing numbers.
 - [MCP Server](https://docs.erigon.tech/fundamentals/mcp): Model Context Protocol server for AI-assisted node interaction and queries.
 - [Creating a dashboard](https://docs.erigon.tech/fundamentals/creating-a-dashboard): Prometheus metrics export and Grafana dashboard setup for node monitoring.
 - [Docker Compose](https://docs.erigon.tech/fundamentals/docker-compose): Running Erigon and all its modules with Docker Compose.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1422,28 +1422,35 @@ Erigon is an Ethereum execution-layer client designed around three goals: **low 
 
 ## At a glance
 
-```
-┌──────────────────────────────────────────────────────────────────────┐
-│                              erigon (one binary)                     │
-│                                                                      │
-│   ┌──────────┐   ┌──────────┐   ┌──────────┐   ┌──────────────────┐  │
-│   │  Sentry  │ → │Downloader│ → │ Execution│ → │  RPC Daemon      │  │
-│   │  (p2p)   │   │(snapshots│   │ (Staged  │   │  (JSON-RPC, WS,  │  │
-│   │          │   │  + EL)   │   │   Sync)  │   │   GraphQL, gRPC) │  │
-│   └──────────┘   └────┬─────┘   └────┬─────┘   └────────┬─────────┘  │
-│                       │              │                  │            │
-│                       ▼              ▼                  ▼            │
-│                  ┌─────────────────────────────────────────┐         │
-│                  │  Single MDBX key-value store + .seg     │         │
-│                  │  snapshot files on disk (the datadir)   │         │
-│                  └─────────────────────────────────────────┘         │
-│                                                                      │
-│   ┌────────┐                                ┌─────────────────┐      │
-│   │ TxPool │ ←──── private gRPC ─────────── │ Caplin (CL)     │      │
-│   │        │                                │ embedded by     │      │
-│   │        │                                │ default         │      │
-│   └────────┘                                └─────────────────┘      │
-└──────────────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TB
+    subgraph erigon["erigon (one binary)"]
+        direction TB
+        Sentry["Sentry<br/>(p2p)"]
+        Downloader["Downloader<br/>(snapshots + EL data)"]
+        Execution["Execution<br/>(Staged Sync)"]
+        RPC["RPC Daemon<br/>(JSON-RPC, WS,<br/>GraphQL, gRPC)"]
+        TxPool["TxPool"]
+        Caplin["Caplin (CL)<br/>embedded by default"]
+        Datadir[("datadir<br/>MDBX chaindata<br/>+ .seg snapshots")]
+
+        Sentry --> Downloader
+        Downloader --> Execution
+        Execution --> RPC
+
+        Downloader -.writes.-> Datadir
+        Execution -.reads/writes.-> Datadir
+        RPC -.reads.-> Datadir
+
+        TxPool <-- private gRPC --> Caplin
+        TxPool -.reads.-> Datadir
+        Caplin -.reads/writes.-> Datadir
+    end
+
+    classDef component fill:#fff5e6,stroke:#EF7716,stroke-width:1.5px,color:#000
+    classDef storage fill:#f0f0ff,stroke:#5860EF,stroke-width:1.5px,color:#000
+    class Sentry,Downloader,Execution,RPC,TxPool,Caplin component
+    class Datadir storage
 ```
 
 Every box above is a Go package that runs **inside the `erigon` process by default**. The same binary can also be split into independent processes — see [Modular processes](#modular-processes).
@@ -2448,17 +2455,7 @@ snapshots/idx      430 GB
 snapshots TOTAL    2.3 TB
 ```
 
-```sh
-# bor-mainnet (Polygon PoS) — archive
-chaindata           20 GB
-snapshots/accessor 360 GB
-snapshots/domain   1.1 TB
-snapshots/history  750 GB
-snapshots/idx      1.5 TB
-snapshots TOTAL    4.9 TB
-```
-
-For non-archive footprints (`--prune.mode=full` or `minimal`), see [Hardware Requirements](../get-started/hardware-requirements).
+For up-to-date totals across all networks and prune modes, see [Hardware Requirements](../get-started/hardware-requirements).
 
 ## Why `chaindata/` stays so small
 
@@ -2468,7 +2465,7 @@ In Erigon 3, `chaindata/` only holds:
 - Recent blocks not yet folded into snapshots
 - Live txpool, peer state, sync stage progress
 
-Most of the bulk that other clients keep in the active database — historical state, ancient blocks, receipt logs — is in immutable snapshot files instead. This is why `chaindata/` rarely exceeds 20 GB even on Polygon archive nodes.
+Most of the bulk that other clients keep in the active database — historical state, ancient blocks, receipt logs — is in immutable snapshot files instead. This is why `chaindata/` rarely exceeds 20 GB even on archive nodes.
 
 It also means **`rm -rf chaindata/` is recoverable**: Erigon will rebuild it from snapshots on next start, given enough time. (You will still want a backup for fast recovery, but the cost of losing it is hours, not weeks.)
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1414,6 +1414,129 @@ The Minimal Node configuration (`--prune.mode=minimal`) is the smallest possible
 
 ---
 
+# Architecture
+URL: https://docs.erigon.tech/fundamentals/architecture
+
+
+Erigon is an Ethereum execution-layer client designed around three goals: **low disk footprint**, **predictable performance**, and **operational simplicity**. This page explains how those goals shape its internal design so you know what is happening when you run the binary.
+
+## At a glance
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                              erigon (one binary)                     │
+│                                                                      │
+│   ┌──────────┐   ┌──────────┐   ┌──────────┐   ┌──────────────────┐  │
+│   │  Sentry  │ → │Downloader│ → │ Execution│ → │  RPC Daemon      │  │
+│   │  (p2p)   │   │(snapshots│   │ (Staged  │   │  (JSON-RPC, WS,  │  │
+│   │          │   │  + EL)   │   │   Sync)  │   │   GraphQL, gRPC) │  │
+│   └──────────┘   └────┬─────┘   └────┬─────┘   └────────┬─────────┘  │
+│                       │              │                  │            │
+│                       ▼              ▼                  ▼            │
+│                  ┌─────────────────────────────────────────┐         │
+│                  │  Single MDBX key-value store + .seg     │         │
+│                  │  snapshot files on disk (the datadir)   │         │
+│                  └─────────────────────────────────────────┘         │
+│                                                                      │
+│   ┌────────┐                                ┌─────────────────┐      │
+│   │ TxPool │ ←──── private gRPC ─────────── │ Caplin (CL)     │      │
+│   │        │                                │ embedded by     │      │
+│   │        │                                │ default         │      │
+│   └────────┘                                └─────────────────┘      │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+Every box above is a Go package that runs **inside the `erigon` process by default**. The same binary can also be split into independent processes — see [Modular processes](#modular-processes).
+
+## Staged sync
+
+Erigon processes the chain in a series of **stages** rather than the traditional "fetch block → execute block → repeat" loop. Each stage runs to completion across the whole range before the next stage starts.
+
+A simplified pipeline:
+
+```
+1. Headers      → download and verify block headers
+2. Bodies       → download block bodies
+3. Snapshots    → fetch immutable history files via BitTorrent
+4. Execution    → re-execute transactions, write account/storage updates
+5. Commitment   → build the state Merkle trie incrementally
+6. Finalization → persist receipts, update canonical chain
+```
+
+Two consequences:
+
+- **Faster initial sync.** Stages are CPU/IO-bound in different ways, so the pipeline avoids waiting on a single bottleneck per block. Snapshot download (stage 3) parallelises with execution warm-up.
+- **Cheap restarts.** Each stage records its progress. Killing Erigon mid-sync and restarting resumes from the last completed checkpoint — Erigon does not re-execute from genesis.
+
+In Erigon 3, the Execution stage absorbs many previously-separate stages (`stage_hash_state`, `stage_trie`, `log_index`, `history_index`, `trace_index`) into a single pass, which is one reason Erigon 3 syncs faster than Erigon 2.
+
+## Modular processes
+
+Each of Sentry, Downloader, TxPool, RPC Daemon, and Caplin can run as an **independent process** that talks to the rest over a private gRPC API.
+
+Use the all-in-one binary by default. Split out a service when you have a concrete reason:
+
+- **Resource isolation** — pin the RPC Daemon to its own CPUs so a heavy `eth_call` cannot stall block production.
+- **Horizontal scaling** — run multiple RPC Daemons against one execution node to serve more concurrent clients.
+- **Replacement** — substitute Erigon's TxPool or Sentry with your own implementation.
+- **Security** — keep the p2p surface (Sentry) on a separate host from the JSON-RPC surface (RPC Daemon).
+
+See the [Modules](modules) section for per-component documentation, and the repository's [docker-compose.yml](https://github.com/erigontech/erigon/blob/main/docker-compose.yml) for a worked split-process example.
+
+## Storage model
+
+Erigon stores everything under a single **datadir**. Two kinds of files live there:
+
+| Kind | Path | Role | Mutable? |
+|------|------|------|----------|
+| Active state | `chaindata/` | Recent state and recent blocks, served from MDBX | Yes |
+| Historical data | `snapshots/` | Older blocks, history, indices — distributed as immutable `.seg` files | No |
+
+This split is what enables Erigon's small disk footprint relative to other archive nodes:
+
+- **`chaindata/` is small (~15 GB on Ethereum mainnet)** because it only holds latest state and recently-updated values.
+- **`snapshots/` is large but content-addressed.** Once a `.seg` file is finalised it is the *same file* on every Erigon node in the world — meaning it can be distributed via BitTorrent and verified by hash. There is no rewrite-amplification penalty for keeping history.
+
+For the exact directory layout, file sizes on mainnet, and how to split storage across fast/slow disks, see [Database](database) and [Optimizing Storage](optimizing-storage).
+
+## Embedded consensus (Caplin)
+
+Erigon ships with **Caplin**, a built-in consensus-layer client. By default `--internalcl` is on, so a single `erigon` invocation runs both the execution layer and the consensus layer with no extra processes, no JWT secret to manage, and no separate binary to upgrade.
+
+If you prefer to run an external CL (Lighthouse, Prysm, Teku, Nimbus), pass `--externalcl` and connect via the standard Engine API. The Engine-API path is identical to what Geth, Besu, or Reth exposes.
+
+See [Caplin](caplin) for full details.
+
+## Flat key-value state
+
+Where most clients store account state in a Merkle Patricia Trie *inside* the database, Erigon stores it as **flat key-value pairs** and computes the trie root incrementally during the Commitment stage. Trade-off:
+
+- **Read path is direct** — `getAccount(addr)` is a single key lookup, not a multi-level trie traversal.
+- **Write path defers trie hashing** — updates accumulate in the KV store and the trie is rebuilt only when state-root computation requires it.
+
+This is the single largest reason Erigon's RPC performance stays flat under load: there is no background trie compaction that can spike CPU during an `eth_call` burst.
+
+## Pruning is a retention decision, not a sync mode
+
+Erigon 3 has one sync pipeline. The user-facing choice is *what to retain after sync*, controlled by `--prune.mode`:
+
+| Mode | Retained | Use case |
+|---|---|---|
+| `archive` | All state, all blocks | Indexers, block explorers, deep historical queries |
+| `full` (default) | Latest state + post-Merge blocks | Most users, dApps, validators |
+| `minimal` | Latest state + recent blocks only | Solo stakers, constrained hardware |
+
+See [Prune Modes](prune-modes) for the full comparison.
+
+## Where to go next
+
+- [Database](database) — datadir layout, MDBX internals, mainnet sizing
+- [Modules](modules) — running RPC Daemon, TxPool, Sentry, Downloader as separate processes
+- [Prune Modes](prune-modes) — choosing what history to keep
+- [Optimizing Storage](optimizing-storage) — splitting datadir across fast and slow disks
+
+---
+
 # Supported Networks
 URL: https://docs.erigon.tech/fundamentals/supported-networks
 
@@ -2249,6 +2372,131 @@ Erigon itself consumes less than 2GB of RAM. Therefore, Erigon will benefit from
           - 192.168.255.138:6061
           - 192.168.255.138:6062
 ```
+
+---
+
+# Database
+URL: https://docs.erigon.tech/fundamentals/database
+
+
+Erigon stores all chain data under a single **datadir**. Understanding what lives where is useful when you size hardware, debug disk-usage issues, or split storage across fast and slow drives.
+
+This page covers the *what* and *where* of Erigon's data. For the *why* — flat KV state, immutable snapshots — see [Architecture](architecture). For operational tuning (symlinks, multi-disk layout), see [Optimizing Storage](optimizing-storage).
+
+## The datadir at a glance
+
+```
+datadir/
+├── chaindata/        # Active state + recent blocks (MDBX). Small, hot, mutable.
+├── snapshots/        # Historical data as immutable .seg files. Large, cold.
+│   ├── domain/         # Latest state per domain (account, storage, code, commitment)
+│   ├── history/        # Historical values per domain
+│   ├── idx/            # Inverted indices — search/filter/intersect historical data
+│   └── accessor/       # Random-access indices over history (point lookups only)
+├── txpool/           # Pending transactions. Safe to delete; will repopulate from peers.
+├── nodes/            # p2p peer cache. Safe to delete; will repopulate.
+└── temp/             # External-sort buffers (~100 GB peak). Cleaned at startup.
+```
+
+The split between **`chaindata/`** (mutable) and **`snapshots/`** (immutable) is the central design decision. It is what makes Erigon's archive node 10× smaller than other clients while staying fast.
+
+## Storage engine: MDBX
+
+`chaindata/` is a single [MDBX](https://github.com/erthink/libmdbx) key-value store. MDBX is a B+ tree engine derived from LMDB, optimised for read-heavy workloads and predictable memory use.
+
+Properties that matter operationally:
+
+- **No background compaction.** Writes go directly into the B+ tree; there is no compaction thread that can spike CPU mid-RPC-call. This is why Erigon's RPC latency does not degrade under load the way LSM-based engines (LevelDB, RocksDB) can.
+- **Memory-mapped reads.** The OS page cache is the hot data cache. There is no separate per-process cache to tune. Multiple Erigon services on one machine share the same page cache automatically.
+- **Single-writer.** One process holds the write lock; readers are unlimited and lock-free. This is why splitting RPC Daemon out as a separate process for read scaling works cleanly — only one writer ever touches the file.
+
+## Snapshots: immutable history
+
+Older blocks and history are not stored in MDBX. They are written to **`.seg` files** in `snapshots/` and **never modified after creation**.
+
+Once a snapshot file is finalised it is the same bytes on every Erigon node in the world, identified by content hash. This unlocks two things:
+
+- **BitTorrent distribution.** New nodes fetch snapshots from peers in parallel rather than re-executing history from genesis. This is what OtterSync does.
+- **Backup / disaster recovery costs ~10× less.** Most of your datadir is content-addressed and can be re-downloaded from any peer if a disk fails. You only need to back up `chaindata/`.
+
+Snapshots come in four flavours, each in its own subdirectory:
+
+| Directory | What it holds | Access pattern |
+|---|---|---|
+| `snapshots/domain/` | Latest value per (domain, key). 4 domains: `account`, `storage`, `code`, `commitment` | Sequential + point lookup |
+| `snapshots/history/` | Every historical value per (domain, key, txn) | Point lookup keyed by transaction |
+| `snapshots/idx/` | Inverted indices over history — answers "which transactions touched key X?" | Search / filter / set intersection |
+| `snapshots/accessor/` | Pre-built random-access indices over history files | Random-touch point reads only |
+
+**Per-transaction granularity.** Erigon 3 indexes history at the **transaction** level, not the block level. This means:
+
+- You can replay a single historical transaction without re-executing its block.
+- If an account changes V1 → V2 → V1 within one block, `debug_getModifiedAccountsByNumber` correctly returns it.
+- Receipts are not stored — they are re-computed by re-executing the relevant transaction, which is cheap thanks to the index structure above.
+
+## What does it cost on disk?
+
+Real numbers from a Nov 2024 mainnet archive node:
+
+```sh
+# eth-mainnet — archive — prune.mode=archive
+chaindata           15 GB
+snapshots/accessor 120 GB
+snapshots/domain   300 GB
+snapshots/history  280 GB
+snapshots/idx      430 GB
+snapshots TOTAL    2.3 TB
+```
+
+```sh
+# bor-mainnet (Polygon PoS) — archive
+chaindata           20 GB
+snapshots/accessor 360 GB
+snapshots/domain   1.1 TB
+snapshots/history  750 GB
+snapshots/idx      1.5 TB
+snapshots TOTAL    4.9 TB
+```
+
+For non-archive footprints (`--prune.mode=full` or `minimal`), see [Hardware Requirements](../get-started/hardware-requirements).
+
+## Why `chaindata/` stays so small
+
+In Erigon 3, `chaindata/` only holds:
+
+- The very latest state values (post-snapshot tip)
+- Recent blocks not yet folded into snapshots
+- Live txpool, peer state, sync stage progress
+
+Most of the bulk that other clients keep in the active database — historical state, ancient blocks, receipt logs — is in immutable snapshot files instead. This is why `chaindata/` rarely exceeds 20 GB even on Polygon archive nodes.
+
+It also means **`rm -rf chaindata/` is recoverable**: Erigon will rebuild it from snapshots on next start, given enough time. (You will still want a backup for fast recovery, but the cost of losing it is hours, not weeks.)
+
+## Tuning knobs
+
+- **`--batchSize`** — controls how much state Erigon buffers in RAM before flushing to MDBX. Default is balanced; lower it (e.g. `--batchSize 1G`) if `chaindata/` grows unexpectedly.
+- **`--db.size.limit`** — caps the MDBX file size. Useful when running multiple Erigon instances on one disk to prevent one from starving the others.
+- **`--db.read.concurrency`** — number of concurrent MDBX read transactions. Increase when you run a high-throughput RPC Daemon against the same datadir.
+- **Symlinks for tiered storage.** Place `chaindata/` and `snapshots/domain/` on fast NVMe, leave `snapshots/idx/` and `snapshots/history/` on cheaper SATA. See [Optimizing Storage](optimizing-storage) for the recipe.
+
+## Safe-to-delete subdirectories
+
+If you need to reclaim space without resyncing from scratch:
+
+| Directory | Effect of deletion |
+|---|---|
+| `txpool/` | Pending transactions lost; pool refills from peers within minutes |
+| `nodes/` | Peer cache lost; reconnects on restart |
+| `temp/` | Cleaned automatically at startup anyway |
+| `chaindata/` | Rebuilds from snapshots on restart (hours, not days) |
+| `snapshots/` | **Do not delete** — would force a full resync |
+
+## Where to go next
+
+- [Architecture](architecture) — how this storage model fits into staged sync and the flat-KV state design
+- [Optimizing Storage](optimizing-storage) — concrete recipes for splitting the datadir across multiple disks
+- [Hardware Requirements](../get-started/hardware-requirements) — disk-size numbers for each `--prune.mode`
+- [Prune Modes](prune-modes) — choosing what history to keep
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -26,6 +26,7 @@
 - [Fundamentals](https://docs.erigon.tech/fundamentals): Core concepts for running Erigon — modules, CLI flags, prune modes, database internals, and node configuration.
 - [Basic Usage](https://docs.erigon.tech/fundamentals/basic-usage): Command-line flags, common arguments, and first steps running the Erigon binary.
 - [Prune Modes](https://docs.erigon.tech/fundamentals/prune-modes): Full, minimal, blocks, and archive prune modes explained — choose the right mode for your use case.
+- [Architecture](https://docs.erigon.tech/fundamentals/architecture): How Erigon is built — staged sync, modular processes, flat-DB on MDBX, immutable snapshots, and an embedded consensus layer.
 - [Supported Networks](https://docs.erigon.tech/fundamentals/supported-networks): Mainnet, testnets, Gnosis, Polygon, and all other chains Erigon can sync.
 - [Default ports](https://docs.erigon.tech/fundamentals/default-ports): Default listening ports for each Erigon service and how to override them.
 - [Layer 2 Networks](https://docs.erigon.tech/fundamentals/layer-2-networks): Running Erigon for Polygon PoS, Bor, and other Layer 2 networks.
@@ -37,6 +38,7 @@
 - [JWT Secret](https://docs.erigon.tech/fundamentals/jwt): Generating and configuring the JWT secret for Engine API communication.
 - [TLS Authentication](https://docs.erigon.tech/fundamentals/tls-authentication): Mutual TLS setup for securing gRPC and RPC daemon endpoints.
 - [Multiple instances / One machine](https://docs.erigon.tech/fundamentals/multiple-instances): Running several Erigon instances on a single machine without conflict.
+- [Database](https://docs.erigon.tech/fundamentals/database): How Erigon stores chain data — MDBX engine, datadir layout, snapshot files, and real mainnet sizing numbers.
 - [MCP Server](https://docs.erigon.tech/fundamentals/mcp): Model Context Protocol server for AI-assisted node interaction and queries.
 - [Creating a dashboard](https://docs.erigon.tech/fundamentals/creating-a-dashboard): Prometheus metrics export and Grafana dashboard setup for node monitoring.
 - [Docker Compose](https://docs.erigon.tech/fundamentals/docker-compose): Running Erigon and all its modules with Docker Compose.


### PR DESCRIPTION
## Summary

Two new pages in **Fundamentals**:

- **`/fundamentals/architecture`** — staged sync, modular processes, storage split, embedded Caplin, flat-KV state. Mermaid component diagram at the top.
- **`/fundamentals/database`** — datadir layout, MDBX engine properties, immutable `.seg` snapshots, per-transaction history granularity, mainnet sizing, tuning flags, safe-to-delete table.

## Stacked on #21451

Rebased on top of `docs/prose-audit-2026-05-27` so links can target the renamed Prune Modes page. GitHub auto-retargets the base to `release/3.4` once #21451 merges.

## Verification

- `npm run build` passes with `onBrokenLinks`/`onBrokenAnchors: 'throw'`
- `docs-site / build` (incl. llms verification) ✓ pass
- llms.txt and llms-full.txt regenerated

## Notes

- Sourced from the Improving-public-docs spec and the `README.md` "Datadir structure" / "Erigon3 datadir size" / "Modularity" sections. Once this lands, those README sections become safe to delete per the spec.
- Adds `@docusaurus/theme-mermaid@^3.10.0` (used by the architecture diagram).