### PR TITLE
ci: extend merge_group fail-fast and auto-dequeue failed PRs

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -28,11 +28,14 @@ concurrency:
 
 # actions: write lets merge-queue runs call `gh run cancel` on a leaf
 # failure so the gate doesn't stall waiting for still-running siblings.
+# pull-requests: write lets the gate call the `dequeuePullRequest` GraphQL
+# mutation on its own merge-group PR when a required check actually fails,
+# since GitHub does not auto-remove UNMERGEABLE entries from the queue.
 # Reusable leaves inherit these from the caller.
 permissions:
   actions: write
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   # Fast path: detect whether any non-docs files changed.
@@ -194,3 +197,52 @@ jobs:
             exit 1
           fi
           echo "All required jobs passed or were skipped."
+
+      # GitHub does not auto-remove UNMERGEABLE entries from the merge queue
+      # when their required checks fail — they sit at the queue position with
+      # state UNMERGEABLE until someone manually dequeues. This step does that
+      # automatically on real failures (not queue-reshuffle cancellations,
+      # where all needs come back as `cancelled` and GitHub re-creates a fresh
+      # merge_group event for us).
+      - name: Dequeue failed merge-queue PR
+        if: failure() && github.event_name == 'merge_group'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEEDS: ${{ toJSON(needs) }}
+          REF: ${{ github.ref_name }}
+          OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          if ! echo "$NEEDS" | jq -e 'to_entries[] | select(.value.result == "failure")' > /dev/null; then
+            echo "No gate need failed (only cancellations) — likely a queue reshuffle, skipping dequeue."
+            exit 0
+          fi
+          pr_number=$(echo "$REF" | grep -oE 'pr-[0-9]+' | head -1 | cut -d- -f2)
+          if [ -z "$pr_number" ]; then
+            echo "::warning::Could not parse PR number from ref $REF"
+            exit 0
+          fi
+          # $owner/$name/$number/$id in the query strings are GraphQL variables, not shell.
+          # shellcheck disable=SC2016
+          pr_id=$(gh api graphql \
+            -F owner="$OWNER" \
+            -F name="$REPO_NAME" \
+            -F number="$pr_number" \
+            -f query='query($owner: String!, $name: String!, $number: Int!) {
+              repository(owner: $owner, name: $name) {
+                pullRequest(number: $number) { id }
+              }
+            }' --jq '.data.repository.pullRequest.id')
+          if [ -z "$pr_id" ] || [ "$pr_id" = "null" ]; then
+            echo "::warning::Could not resolve PR #$pr_number to a GraphQL node ID"
+            exit 0
+          fi
+          echo "Dequeuing PR #$pr_number ($pr_id) after ci-gate failure"
+          # shellcheck disable=SC2016
+          gh api graphql \
+            -F id="$pr_id" \
+            -f query='mutation($id: ID!) {
+              dequeuePullRequest(input: {id: $id}) {
+                mergeQueueEntry { position }
+              }
+            }' || echo "::warning::dequeuePullRequest mutation failed (already dequeued, or insufficient permissions)"

--- a/.github/workflows/test-all-erigon-race.yml
+++ b/.github/workflows/test-all-erigon-race.yml
@@ -38,7 +38,11 @@ jobs:
     needs: load-matrix
     timeout-minutes: 90
     strategy:
-      fail-fast: false
+      # In merge_group: cancel sibling shards on first failure so ci-gate's
+      # `needs` reach terminal state quickly and the broken PR can be evicted.
+      # In PR runs: keep all shards going so authors see the full failure
+      # picture across every shard.
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         os:
           - ubuntu-latest

--- a/.github/workflows/test-all-erigon.yml
+++ b/.github/workflows/test-all-erigon.yml
@@ -11,7 +11,11 @@ defaults:
 jobs:
   tests-mac-linux:
     strategy:
-      fail-fast: false
+      # In merge_group: cancel sibling shards on first failure so ci-gate's
+      # `needs` reach terminal state quickly and the broken PR can be evicted.
+      # In PR runs: keep all shards going so authors see the full failure
+      # picture across every shard.
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         os:
           - ubuntu-24.04

--- a/.github/workflows/test-bench.yml
+++ b/.github/workflows/test-bench.yml
@@ -25,7 +25,11 @@ jobs:
     name: benchmarks (${{ matrix.exec_mode }})
     runs-on: ubuntu-24.04
     strategy:
-      fail-fast: false
+      # In merge_group: cancel sibling shards on first failure so ci-gate's
+      # `needs` reach terminal state quickly and the broken PR can be evicted.
+      # In PR runs: keep all shards going so authors see the full failure
+      # picture across every shard.
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         # Each entry runs on its own GitHub-hosted runner — wall-clock
         # unchanged, runner-minutes doubled. Bench numbers are reported

--- a/.github/workflows/test-eest-spec.yml
+++ b/.github/workflows/test-eest-spec.yml
@@ -29,7 +29,11 @@ jobs:
     needs: load-matrix
     name: eest-spec-${{ matrix.shard }}
     strategy:
-      fail-fast: false
+      # In merge_group: cancel sibling shards on first failure so ci-gate's
+      # `needs` reach terminal state quickly and the broken PR can be evicted.
+      # In PR runs: keep all shards going so authors see the full failure
+      # picture across every shard.
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         include: ${{ fromJson(needs.load-matrix.outputs.matrix) }}
     runs-on: ubuntu-24.04

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -20,7 +20,11 @@ jobs:
     runs-on:
       group: hive
     strategy:
-      fail-fast: false
+      # In merge_group: cancel sibling shards on first failure so ci-gate's
+      # `needs` reach terminal state quickly and the broken PR can be evicted.
+      # In PR runs: keep all shards going so authors see the full failure
+      # picture across every shard.
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         # Each (sim, sim-limit) pair is run twice — once with serial exec
         # (ERIGON_EXEC3_PARALLEL=false) and once with parallel — so engine-API

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -82,7 +82,11 @@ jobs:
     if: ${{ !inputs.cache-warming-only && !contains(github.event.pull_request.labels.*.name, 'skip-uncaching') }}
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      # In merge_group: cancel sibling shards on first failure so ci-gate's
+      # `needs` reach terminal state quickly and the broken PR can be evicted.
+      # In PR runs: keep all shards going so authors see the full failure
+      # picture across every shard.
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         # test_timeout_minutes is a per-suite wall-clock cap for the Kurtosis+assertoor
         # step. Observed happy-path durations are roughly:


### PR DESCRIPTION
## Background

#21483 added `fail-fast: ${{ github.event_name == 'merge_group' }}` to `test-hive-eest.yml` only, with the explicit note that other matrix-bearing reusable workflows could get the same treatment "if another workflow becomes the bottleneck." It has — and there is also a second problem #21483 didn't address: **GitHub does not auto-remove the failed PR from the merge queue**.

CI Gate run [26573584442](https://github.com/erigontech/erigon/actions/runs/26573584442) for PR #21374 demonstrated both gaps:

- `hive-eest / rlp, serial` failed at 14:29:49 from a transient Docker Hub blip (`alpine:latest` manifest HEAD returned `unknown:` while building `hive/hiveproxy`).
- hive-eest's `fail-fast` cancelled siblings in **1 second**; `hive / test-hive` (still on `fail-fast: false`) kept dispatching matrix legs — `engine, api, serial` and `engine, cancun, parallel` started at 14:36:01 / 14:36:17 (~7 min *after* `gh run cancel`) and ran to `success`. ci-gate couldn't reach a terminal state until those finished at 14:43:54, delaying eviction by **~14 minutes**.
- Even once ci-gate reported `conclusion: failure` at 14:44:05, GitHub did **not** remove PR #21374 from the queue: the entry stayed at position 2 with state `UNMERGEABLE`. The queue only advanced because PR #21483 was manually `jump`ed over it.

## Changes

### 1. Roll out merge_group fail-fast to the remaining matrix workflows

Same gating as #21483 (`${{ github.event_name == 'merge_group' }}`), applied to:

- `test-hive.yml`
- `test-all-erigon.yml`
- `test-all-erigon-race.yml`
- `test-eest-spec.yml`
- `test-bench.yml`
- `test-kurtosis-assertoor.yml`

Behaviour matches #21483: in `merge_group`, first failed shard cancels its siblings at the GitHub API layer (no waiting for runner drain); in `pull_request` / `schedule` / `workflow_dispatch`, all shards continue so authors keep the full per-shard breakdown.

### 2. Auto-dequeue UNMERGEABLE PRs whose required check failed

New step at the end of `ci-gate.yml`'s ci-gate job:

```yaml
- name: Dequeue failed merge-queue PR
  if: failure() && github.event_name == 'merge_group'
  ...
```

The step:

1. **Inspects `needs.*.result` and skips when all are `cancelled` with no `failure`.** That pattern is a queue reshuffle (a PR ahead of us merged, our merge-group SHA is stale), where GitHub re-creates a new merge_group event for us; dequeuing here would be wrong. Confirmed by run [26573568764](https://github.com/erigontech/erigon/actions/runs/26573568764), where ci-gate's job conclusion was `failure` (needs cancelled → `Check all required jobs` exits 1) but the *run* was cancelled by GitHub during a reshuffle.
2. Parses the PR number from `gh-readonly-queue/<base>/pr-<N>-<sha>` (handles multi-segment bases like `release/3.4`).
3. Resolves the PR number to a GraphQL node ID and calls the `dequeuePullRequest` mutation. Soft-fails on errors (warning, not non-zero exit) so a dequeue glitch never masks ci-gate's own failure signal.

Permissions bumped from `pull-requests: read` to `pull-requests: write` for the mutation.

## Why both in one PR

Both target the same incident class (broken PR sits at the head of the queue blocking everything else). The fail-fast change shrinks time-to-fail for ci-gate from ~14 min to seconds; the dequeue actually evicts the failed PR. Either alone is a partial fix — having both means a broken PR's run goes red fast *and* the queue advances without anyone needing to manually jump over it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)