### PR TITLE
[r3.4] execution/p2p, execution/engineapi: fail-fast NewPayload backward download when gap exceeds limit

### DIFF
--- a/execution/engineapi/engine_block_downloader/block_downloader.go
+++ b/execution/engineapi/engine_block_downloader/block_downloader.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/common/math"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/services"
 	"github.com/erigontech/erigon/execution/chain"
@@ -127,12 +128,22 @@ func (e *EngineBlockDownloader) download(ctx context.Context, req BackwardDownlo
 	err := e.processReq(ctx, req)
 	if err != nil {
 		args := append(req.LogArgs(), "err", err)
-		e.logger.Warn("[EngineBlockDownloader] could not process backward download request", args...)
+		if errors.Is(err, p2p.ErrChainLengthExceedsLimit) {
+			// Expected: gap is unbridgeable by a chain-length-limited download; the EL relies on FCU or staged sync.
+			e.logger.Info("[EngineBlockDownloader] backward download skipped — gap exceeds limit, awaiting FCU/staged sync", args...)
+		} else {
+			e.logger.Warn("[EngineBlockDownloader] could not process backward download request", args...)
+		}
 		e.status.Store(Idle)
 		return
 	}
 	e.logger.Info("[EngineBlockDownloader] backward download request successfully processed", req.LogArgs()...)
 	e.status.Store(Synced)
+}
+
+// newPayloadGapExceedsLimit reports whether the head-to-parent gap exceeds maxReorgDepth in either direction.
+func newPayloadGapExceedsLimit(currentHeadNum, missingBlockNum, maxReorgDepth uint64) bool {
+	return math.AbsoluteDifference(currentHeadNum, missingBlockNum) > maxReorgDepth
 }
 
 func (e *EngineBlockDownloader) processReq(ctx context.Context, req BackwardDownloadRequest) error {
@@ -166,7 +177,6 @@ func (e *EngineBlockDownloader) processReq(ctx context.Context, req BackwardDown
 }
 
 func (e *EngineBlockDownloader) downloadBlocks(ctx context.Context, req BackwardDownloadRequest) error {
-	e.logger.Info("[EngineBlockDownloader] processing backward download of blocks", req.LogArgs()...)
 	blocksBatchSize := min(500, uint64(e.syncCfg.LoopBlockLimit))
 	opts := []p2p.BbdOption{p2p.WithBlocksBatchSize(blocksBatchSize)}
 	if req.Trigger == NewPayloadTrigger {
@@ -174,11 +184,22 @@ func (e *EngineBlockDownloader) downloadBlocks(ctx context.Context, req Backward
 		currentHeader := e.chainRW.CurrentHeader(ctx)
 		if currentHeader != nil {
 			opts = append(opts, p2p.WithChainLengthCurrentHead(currentHeader.Number.Uint64()))
+			if req.ValidateChainTip != nil &&
+				newPayloadGapExceedsLimit(currentHeader.Number.Uint64(), req.ValidateChainTip.NumberU64()-1, e.syncCfg.MaxReorgDepth) {
+				return fmt.Errorf(
+					"%w: currentHead=%d, parent=%d, limit=%d",
+					p2p.ErrChainLengthExceedsLimit,
+					currentHeader.Number.Uint64(),
+					req.ValidateChainTip.NumberU64()-1,
+					e.syncCfg.MaxReorgDepth,
+				)
+			}
 		}
 	}
 	if req.Trigger == SegmentRecoveryTrigger {
 		opts = append(opts, p2p.WithChainLengthLimit(uint64(e.syncCfg.LoopBlockLimit)))
 	}
+	e.logger.Info("[EngineBlockDownloader] processing backward download of blocks", req.LogArgs()...)
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel() // need to cancel the ctx so that we cancel the download request processing if we err out prematurely

--- a/execution/engineapi/engine_block_downloader/block_downloader_test.go
+++ b/execution/engineapi/engine_block_downloader/block_downloader_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package engine_block_downloader
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPayloadGapExceedsLimit(t *testing.T) {
+	tests := []struct {
+		name        string
+		currentHead uint64
+		missingNum  uint64
+		limit       uint64
+		want        bool
+	}{
+		{"behind by more than limit", 100, 500, 96, true},
+		{"ahead by more than limit", 500, 100, 96, true},
+		{"behind by exact limit", 100, 196, 96, false},
+		{"behind by one over limit", 100, 197, 96, true},
+		{"ahead by exact limit", 196, 100, 96, false},
+		{"ahead by one over limit", 197, 100, 96, true},
+		{"same block", 100, 100, 96, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, newPayloadGapExceedsLimit(tt.currentHead, tt.missingNum, tt.limit))
+		})
+	}
+}

--- a/execution/p2p/bbd.go
+++ b/execution/p2p/bbd.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/common/math"
 	"github.com/erigontech/erigon/db/etl"
 	"github.com/erigontech/erigon/db/kv/dbutils"
 	"github.com/erigontech/erigon/execution/rlp"
@@ -210,7 +211,7 @@ func (bbd *BackwardBlockDownloader) downloadInitialHeader(
 		return nil, fmt.Errorf("asked to download hash at num 0: %s", hash)
 	}
 	currentHead := config.chainLengthCurrentHead
-	if currentHead != nil && *currentHead > headerNum && *currentHead-headerNum > config.chainLengthLimit {
+	if currentHead != nil && math.AbsoluteDifference(*currentHead, headerNum) > config.chainLengthLimit {
 		return nil, fmt.Errorf(
 			"%w: num=%d, hash=%s, currentHead=%d, limit=%d",
 			ErrChainLengthExceedsLimit,

--- a/execution/p2p/bbd_test.go
+++ b/execution/p2p/bbd_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package p2p
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/common/testlog"
+	"github.com/erigontech/erigon/execution/types"
+)
+
+// stubBbdFetcher serves the initial-header backward fetch and counts calls so tests can assert fail-fast behaviour.
+type stubBbdFetcher struct {
+	initialHeader         *types.Header
+	headersBackwardsCalls atomic.Int64
+}
+
+func (s *stubBbdFetcher) FetchHeaders(context.Context, uint64, uint64, *PeerId, ...FetcherOption) (FetcherResponse[[]*types.Header], error) {
+	return FetcherResponse[[]*types.Header]{}, errors.New("not implemented")
+}
+
+func (s *stubBbdFetcher) FetchHeadersBackwards(_ context.Context, hash common.Hash, amount uint64, _ *PeerId, _ ...FetcherOption) (FetcherResponse[[]*types.Header], error) {
+	s.headersBackwardsCalls.Add(1)
+	if amount == 1 && hash == s.initialHeader.Hash() {
+		return FetcherResponse[[]*types.Header]{Data: []*types.Header{s.initialHeader}}, nil
+	}
+	return FetcherResponse[[]*types.Header]{}, errors.New("unexpected backward header fetch")
+}
+
+func (s *stubBbdFetcher) FetchBodies(context.Context, []*types.Header, *PeerId, ...FetcherOption) (FetcherResponse[[]*types.Body], error) {
+	return FetcherResponse[[]*types.Body]{}, errors.New("not implemented")
+}
+
+func (s *stubBbdFetcher) FetchBlocksBackwardsByHash(context.Context, common.Hash, uint64, *PeerId, ...FetcherOption) (FetcherResponse[[]*types.Block], error) {
+	return FetcherResponse[[]*types.Block]{}, errors.New("not implemented")
+}
+
+type stubBbdHeaderReader struct{}
+
+func (stubBbdHeaderReader) HeaderByHash(context.Context, common.Hash) (*types.Header, error) {
+	return nil, nil
+}
+
+func newTestBbd(t *testing.T, fetcher Fetcher) *BackwardBlockDownloader {
+	t.Helper()
+	logger := testlog.Logger(t, log.LvlCrit)
+	peerTracker := NewPeerTracker(logger, nil)
+	peerTracker.PeerConnected(PeerIdFromUint64(1))
+	return NewBackwardBlockDownloader(logger, fetcher, &PeerPenalizer{}, peerTracker, t.TempDir())
+}
+
+// EL behind the requested header by more than the limit: fail-fast at initial-header step.
+func TestBackwardBlockDownloader_GapBehindCurrentHead_FailsFast(t *testing.T) {
+	initialHeader := &types.Header{Number: *uint256.NewInt(500)}
+	fetcher := &stubBbdFetcher{initialHeader: initialHeader}
+	bbd := newTestBbd(t, fetcher)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	feed, err := bbd.DownloadBlocksBackwards(ctx, initialHeader.Hash(), stubBbdHeaderReader{},
+		WithChainLengthLimit(96),
+		WithChainLengthCurrentHead(100),
+	)
+	require.NoError(t, err)
+
+	_, err = feed.Next(ctx)
+	require.ErrorIs(t, err, ErrChainLengthExceedsLimit)
+	require.EqualValues(t, 1, fetcher.headersBackwardsCalls.Load(),
+		"should fail-fast at the initial-header check without fetching a header batch")
+}
+
+// EL ahead of the requested header by more than the limit (deep reorg backward): fail-fast at initial-header step.
+func TestBackwardBlockDownloader_GapAheadOfCurrentHead_FailsFast(t *testing.T) {
+	initialHeader := &types.Header{Number: *uint256.NewInt(100)}
+	fetcher := &stubBbdFetcher{initialHeader: initialHeader}
+	bbd := newTestBbd(t, fetcher)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	feed, err := bbd.DownloadBlocksBackwards(ctx, initialHeader.Hash(), stubBbdHeaderReader{},
+		WithChainLengthLimit(96),
+		WithChainLengthCurrentHead(500),
+	)
+	require.NoError(t, err)
+
+	_, err = feed.Next(ctx)
+	require.ErrorIs(t, err, ErrChainLengthExceedsLimit)
+	require.EqualValues(t, 1, fetcher.headersBackwardsCalls.Load(),
+		"should fail-fast at the initial-header check without fetching a header batch")
+}


### PR DESCRIPTION
Cherry-pick of #21489 to `release/3.4`.

## r3.4-specific adaptations

- `execution/engineapi/engine_block_downloader/block_downloader_test.go` did not exist on `release/3.4` (file was introduced by #21362, not backported). The cherry-pick keeps only the new `TestNewPayloadGapExceedsLimit` test added by #21489; the unrelated `TestBadHeader_*` tests from #21362 are not pulled in.