### PR TITLE
execution: remove unnecessary allocs due to Hash.Bytes() and Address.Bytes()

### DIFF
--- a/cl/phase1/core/state/epbs_test.go
+++ b/cl/phase1/core/state/epbs_test.go
@@ -21,7 +21,8 @@ func TestIsBuilderWithdrawalCredential_0x03(t *testing.T) {
 
 	var creds common.Hash
 	creds[0] = 0x03
-	copy(creds[12:], common.HexToAddress("0xdeadbeef").Bytes())
+	addr := common.HexToAddress("0xdeadbeef")
+	copy(creds[12:], addr[:])
 
 	require.True(t, state2.IsBuilderWithdrawalCredential(creds, &cfg),
 		"0x03 prefix must be recognised as builder withdrawal credential")
@@ -176,7 +177,7 @@ func makeValidBuilderDeposit(t *testing.T, cfg *clparams.BeaconChainConfig) (
 
 	// Build withdrawal credentials: 0x03 + 11 zero bytes + 20-byte address.
 	withdrawalCredentials[0] = byte(cfg.BuilderWithdrawalPrefix)
-	copy(withdrawalCredentials[12:], feeRecipient.Bytes())
+	copy(withdrawalCredentials[12:], feeRecipient[:])
 
 	amount = cfg.MinDepositAmount // 1e9 Gwei
 

--- a/cl/phase1/network/services/aggregate_and_proof_service.go
+++ b/cl/phase1/network/services/aggregate_and_proof_service.go
@@ -432,7 +432,8 @@ func AggregateAndProofSignature(
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	signingRoot := utils.Sha256(merkle_tree.Uint64Root(slot).Bytes(), domain)
+	slotRoot := merkle_tree.Uint64Root(slot)
+	signingRoot := utils.Sha256(slotRoot[:], domain)
 	return aggregate.SelectionProof[:], signingRoot[:], publicKey[:], nil
 }
 

--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -91,7 +91,7 @@ func MakePreState(chainRules *chain.Rules, tx kv.TemporalRwTx, sd *execctx.Share
 		statedb.SetBalance(addr, balance, tracing.BalanceIncreaseGenesisBalance)
 		for k, v := range account.Storage {
 			key := accounts.InternKey(k)
-			val := uint256.NewInt(0).SetBytes(v.Bytes())
+			val := uint256.NewInt(0).SetBytes(v[:])
 			statedb.SetState(addr, key, *val)
 		}
 

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -232,7 +232,7 @@ func runStateTest(ctx *cli.Context, cfg vm.Config, fname string) ([]testResult, 
 					h := common.Hash(root)
 					result.Root = &h
 					if emitStateRoot {
-						if _, printErr := fmt.Fprintf(os.Stderr, "{\"stateRoot\": \"%#x\"}\n", h.Bytes()); printErr != nil {
+						if _, printErr := fmt.Fprintf(os.Stderr, "{\"stateRoot\": \"%#x\"}\n", h[:]); printErr != nil {
 							log.Warn("Failed to write to stderr", "err", printErr)
 						}
 					}

--- a/cmd/rpctest/rpctest/account_range_verify.go
+++ b/cmd/rpctest/rpctest/account_range_verify.go
@@ -109,7 +109,7 @@ func CompareAccountRange(logger log.Logger, erigonURL, gethURL, tmpDataDir, geth
 				if innerErr != nil {
 					return innerErr
 				}
-				err = db.Put(accountDumpBucket, addr.Bytes(), b)
+				err = db.Put(accountDumpBucket, addr[:], b)
 				if err != nil {
 					return err
 				}

--- a/cmd/rpctest/rpctest/bench1.go
+++ b/cmd/rpctest/rpctest/bench1.go
@@ -255,8 +255,9 @@ func Bench1(erigonURL, gethURL string, needCompare bool, fullTest bool, blockFro
 			}
 			fmt.Printf("Done blocks %d-%d, modified accounts: %d\n", prevBn, bn, len(mag.Result))
 
-			page := common.Hash{}.Bytes()
-			pageGeth := common.Hash{}.Bytes()
+			zeroHash := common.Hash{}
+			page := zeroHash[:]
+			pageGeth := zeroHash[:]
 
 			var accRangeErigon map[common.Address]state.DumpAccount
 			var accRangeGeth map[common.Address]state.DumpAccount

--- a/cmd/rpctest/rpctest/bench3.go
+++ b/cmd/rpctest/rpctest/bench3.go
@@ -35,7 +35,8 @@ func Bench3(erigon_url, geth_url string) error {
 	req_id++
 	template := `{ "jsonrpc": "2.0", "method": "debug_accountRange", "params": ["0x1", "%s", %d, true, true, true], "id":%d}`
 
-	page := common.Hash{}.Bytes()
+	zeroHash := common.Hash{}
+	page := zeroHash[:]
 
 	accRangeTG := make(map[common.Address]state.DumpAccount)
 
@@ -56,7 +57,7 @@ func Bench3(erigon_url, geth_url string) error {
 
 	accRangeGeth := make(map[common.Address]state.DumpAccount)
 
-	page = common.Hash{}.Bytes()
+	page = zeroHash[:]
 	for len(page) > 0 {
 		encodedKey := base64.StdEncoding.EncodeToString(page)
 		var sr DebugAccountRange

--- a/cmd/rpctest/rpctest/bench9.go
+++ b/cmd/rpctest/rpctest/bench9.go
@@ -43,7 +43,8 @@ func Bench9(erigonURL, gethURL string, needCompare, latest bool) error {
 	fmt.Printf("Last block: %d\n", lastBlock)
 	// Go back 256 blocks
 	bn := uint64(lastBlock) - 256
-	page := common.Hash{}.Bytes()
+	zeroHash := common.Hash{}
+	page := zeroHash[:]
 
 	var resultsCh chan CallResult = nil
 	if !needCompare {

--- a/cmd/rpctest/rpctest/request_generator_test.go
+++ b/cmd/rpctest/rpctest/request_generator_test.go
@@ -414,6 +414,9 @@ func TestRequestGenerator_getLogs2(t *testing.T) {
 }
 
 func TestRequestGenerator_accountRange(t *testing.T) {
+	hash1 := common.HexToHash("0x6f9e34c00812a80fa87df26208bbe69411e36d6a9f00b35444ef4181f6c483ca")
+	hash2 := common.HexToHash("0x1cfe7ce95a1694d8969365cb472ce4a0d3eed812c540fd7708bbe6941e34c4de")
+	hash3 := common.HexToHash("0x1cd73c7adf5b31f3cf94c67b9e251e699559d91c27664463fb5978b97f8b2d1b")
 	testCases := []struct {
 		reqId    int
 		blockNum uint64
@@ -424,21 +427,21 @@ func TestRequestGenerator_accountRange(t *testing.T) {
 		{
 			1,
 			4756370,
-			common.HexToHash("0x6f9e34c00812a80fa87df26208bbe69411e36d6a9f00b35444ef4181f6c483ca").Bytes(),
+			hash1[:],
 			1,
 			`{ "jsonrpc": "2.0", "method": "debug_accountRange", "params": ["0x489392", "b540wAgSqA+offJiCLvmlBHjbWqfALNURO9BgfbEg8o=", 1, false, false], "id":1}`,
 		},
 		{
 			2,
 			0,
-			common.HexToHash("0x1cfe7ce95a1694d8969365cb472ce4a0d3eed812c540fd7708bbe6941e34c4de").Bytes(),
+			hash2[:],
 			2,
 			`{ "jsonrpc": "2.0", "method": "debug_accountRange", "params": ["0x0", "HP586VoWlNiWk2XLRyzkoNPu2BLFQP13CLvmlB40xN4=", 2, false, false], "id":2}`,
 		},
 		{
 			3,
 			1234567,
-			common.HexToHash("0x1cd73c7adf5b31f3cf94c67b9e251e699559d91c27664463fb5978b97f8b2d1b").Bytes(),
+			hash3[:],
 			3,
 			`{ "jsonrpc": "2.0", "method": "debug_accountRange", "params": ["0x12d687", "HNc8et9bMfPPlMZ7niUeaZVZ2RwnZkRj+1l4uX+LLRs=", 3, false, false], "id":3}`,
 		},

--- a/common/address.go
+++ b/common/address.go
@@ -57,9 +57,6 @@ func IsHexAddress(s string) bool {
 	return len(s) == 2*length.Addr && hexutil.IsHex(s)
 }
 
-// Bytes gets the string representation of the underlying address.
-func (a Address) Bytes() []byte { return a[:] }
-
 // Hash converts an address to a hash by left-padding it with zeros.
 func (a Address) Hash() Hash { return BytesToHash(a[:]) }
 

--- a/common/hash.go
+++ b/common/hash.go
@@ -63,9 +63,6 @@ func (h Hash) Cmp(other Hash) int {
 	return bytes.Compare(h[:], other[:])
 }
 
-// Bytes gets the byte representation of the underlying hash.
-func (h Hash) Bytes() []byte { return h[:] }
-
 // Big converts a hash to a big integer.
 func (h Hash) Big() *big.Int { return new(big.Int).SetBytes(h[:]) }
 

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -119,7 +119,7 @@ func TestAddressUnmarshalJSON(t *testing.T) {
 			if test.ShouldErr {
 				t.Errorf("test #%d: expected error, got none", i)
 			}
-			if got := new(big.Int).SetBytes(v.Bytes()); got.Cmp(test.Output) != 0 {
+			if got := new(big.Int).SetBytes(v[:]); got.Cmp(test.Output) != 0 {
 				t.Errorf("test #%d: address mismatch: have %v, want %v", i, got, test.Output)
 			}
 		}

--- a/db/kv/dbutils/composite_keys.go
+++ b/db/kv/dbutils/composite_keys.go
@@ -71,8 +71,8 @@ func GenerateCompositeTrieKey(addressHash common.Hash, seckey common.Hash) []byt
 // Address + storageLocationHash
 func GenerateStoragePlainKey(address common.Address, storageKey common.Hash) []byte {
 	storagePlainKey := make([]byte, 0, length.Addr+length.Hash)
-	storagePlainKey = append(storagePlainKey, address.Bytes()...)
-	storagePlainKey = append(storagePlainKey, storageKey.Bytes()...)
+	storagePlainKey = append(storagePlainKey, address[:]...)
+	storagePlainKey = append(storagePlainKey, storageKey[:]...)
 	return storagePlainKey
 }
 

--- a/db/kv/temporal/kv_temporal_test.go
+++ b/db/kv/temporal/kv_temporal_test.go
@@ -42,14 +42,14 @@ func TestTemporalTx_HasPrefix_StorageDomain(t *testing.T) {
 
 	acc1 := common.HexToAddress("0x1234567890123456789012345678901234567890")
 	acc1slot1 := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001")
-	storageK1 := append(append([]byte{}, acc1.Bytes()...), acc1slot1.Bytes()...)
+	storageK1 := append(append([]byte{}, acc1[:]...), acc1slot1[:]...)
 	acc2 := common.HexToAddress("0x1234567890123456789012345678901234567891")
 	acc2slot2 := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002")
-	storageK2 := append(append([]byte{}, acc2.Bytes()...), acc2slot2.Bytes()...)
+	storageK2 := append(append([]byte{}, acc2[:]...), acc2slot2[:]...)
 
 	// --- check 1: non-existing storage ---
 	{
-		firstKey, firstVal, ok, err := rwTtx1.HasPrefix(kv.StorageDomain, acc1.Bytes())
+		firstKey, firstVal, ok, err := rwTtx1.HasPrefix(kv.StorageDomain, acc1[:])
 		require.NoError(t, err)
 		require.False(t, ok)
 		require.Nil(t, firstKey)
@@ -75,7 +75,7 @@ func TestTemporalTx_HasPrefix_StorageDomain(t *testing.T) {
 		defer c1.Close()
 		k, v, err := c1.Next()
 		require.NoError(t, err)
-		require.Equal(t, append(append([]byte{}, acc1.Bytes()...), acc1slot1.Bytes()...), k)
+		require.Equal(t, append(append([]byte{}, acc1[:]...), acc1slot1[:]...), k)
 		wantValueBytes := make([]byte, 8)                      // 8 bytes for uint64 step num
 		binary.BigEndian.PutUint64(wantValueBytes, ^uint64(1)) // step num
 		wantValueBytes = append(wantValueBytes, byte(1))       // value we wrote to the storage slot
@@ -95,14 +95,14 @@ func TestTemporalTx_HasPrefix_StorageDomain(t *testing.T) {
 		require.Equal(t, uint64(0), roTtx1.Debug().TxNumsInFiles(kv.StorageDomain))
 
 		// finally, verify TemporalTx.HasPrefix returns true
-		firstKey, firstVal, ok, err := roTtx1.HasPrefix(kv.StorageDomain, acc1.Bytes())
+		firstKey, firstVal, ok, err := roTtx1.HasPrefix(kv.StorageDomain, acc1[:])
 		require.NoError(t, err)
 		require.True(t, ok)
-		require.Equal(t, append(append([]byte{}, acc1.Bytes()...), acc1slot1.Bytes()...), firstKey)
+		require.Equal(t, append(append([]byte{}, acc1[:]...), acc1slot1[:]...), firstKey)
 		require.Equal(t, []byte{1}, firstVal)
 
 		// check some other non-existing storages for non-existence after write operation
-		firstKey, firstVal, ok, err = roTtx1.HasPrefix(kv.StorageDomain, acc2.Bytes())
+		firstKey, firstVal, ok, err = roTtx1.HasPrefix(kv.StorageDomain, acc2[:])
 		require.NoError(t, err)
 		require.False(t, ok)
 		require.Nil(t, firstKey)
@@ -145,7 +145,7 @@ func TestTemporalTx_HasPrefix_StorageDomain(t *testing.T) {
 		defer c2.Close()
 		k, v, err := c2.Next() // acc2 storage from step 2 will be there
 		require.NoError(t, err)
-		require.Equal(t, append(append([]byte{}, acc2.Bytes()...), acc2slot2.Bytes()...), k)
+		require.Equal(t, append(append([]byte{}, acc2[:]...), acc2slot2[:]...), k)
 		wantValueBytes := make([]byte, 8)                      // 8 bytes for uint64 step num
 		binary.BigEndian.PutUint64(wantValueBytes, ^uint64(2)) // step num
 		wantValueBytes = append(wantValueBytes, byte(2))       // value we wrote to the storage slot
@@ -162,10 +162,10 @@ func TestTemporalTx_HasPrefix_StorageDomain(t *testing.T) {
 		require.Equal(t, uint64(2), roTtx2.Debug().TxNumsInFiles(kv.StorageDomain))
 
 		// finally, verify TemporalTx.HasPrefix returns true
-		firstKey, firstVal, ok, err := roTtx2.HasPrefix(kv.StorageDomain, acc1.Bytes())
+		firstKey, firstVal, ok, err := roTtx2.HasPrefix(kv.StorageDomain, acc1[:])
 		require.NoError(t, err)
 		require.True(t, ok)
-		require.Equal(t, append(append([]byte{}, acc1.Bytes()...), acc1slot1.Bytes()...), firstKey)
+		require.Equal(t, append(append([]byte{}, acc1[:]...), acc1slot1[:]...), firstKey)
 		require.Equal(t, []byte{1}, firstVal)
 	}
 
@@ -174,7 +174,7 @@ func TestTemporalTx_HasPrefix_StorageDomain(t *testing.T) {
 		rwTtx4, err := temporalDb.BeginTemporalRw(ctx)
 		require.NoError(t, err)
 		defer rwTtx4.Rollback()
-		err = sd.DomainDelPrefix(kv.StorageDomain, rwTtx4, acc1.Bytes(), 3)
+		err = sd.DomainDelPrefix(kv.StorageDomain, rwTtx4, acc1[:], 3)
 		require.NoError(t, err)
 		err = sd.Flush(ctx, rwTtx4)
 		require.NoError(t, err)
@@ -185,7 +185,7 @@ func TestTemporalTx_HasPrefix_StorageDomain(t *testing.T) {
 		require.NoError(t, err)
 		defer roTtx3.Rollback()
 
-		firstKey, firstVal, ok, err := roTtx3.HasPrefix(kv.StorageDomain, acc1.Bytes())
+		firstKey, firstVal, ok, err := roTtx3.HasPrefix(kv.StorageDomain, acc1[:])
 		require.NoError(t, err)
 		require.False(t, ok)
 		require.Nil(t, firstKey)
@@ -208,10 +208,10 @@ func TestTemporalTx_HasPrefix_StorageDomain(t *testing.T) {
 		require.NoError(t, err)
 		defer roTtx4.Rollback()
 
-		firstKey, firstVal, ok, err := roTtx4.HasPrefix(kv.StorageDomain, acc1.Bytes())
+		firstKey, firstVal, ok, err := roTtx4.HasPrefix(kv.StorageDomain, acc1[:])
 		require.NoError(t, err)
 		require.True(t, ok)
-		require.Equal(t, append(append([]byte{}, acc1.Bytes()...), acc1slot1.Bytes()...), firstKey)
+		require.Equal(t, append(append([]byte{}, acc1[:]...), acc1slot1[:]...), firstKey)
 		require.Equal(t, []byte{3}, firstVal)
 	}
 }
@@ -232,8 +232,8 @@ func TestTemporalTx_RangeAsOf_StorageDomain(t *testing.T) {
 	// empty range when nothing has been written yet
 	acc1 := common.HexToAddress("0x1234567890123456789012345678901234567890")
 	acc1slot1 := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001")
-	storageK1 := append(append([]byte{}, acc1.Bytes()...), acc1slot1.Bytes()...)
-	nextSubTree, ok := kv.NextSubtree(acc1.Bytes())
+	storageK1 := append(append([]byte{}, acc1[:]...), acc1slot1[:]...)
+	nextSubTree, ok := kv.NextSubtree(acc1[:])
 	require.True(t, ok)
 
 	// write storage at txn num 1, update it at txn num 2, then delete it at txn num 3, then write to it again
@@ -265,7 +265,7 @@ func TestTemporalTx_RangeAsOf_StorageDomain(t *testing.T) {
 	rwTtx3, err := temporalDb.BeginTemporalRw(ctx)
 	require.NoError(t, err)
 	defer rwTtx3.Rollback()
-	err = sd.DomainDelPrefix(kv.StorageDomain, rwTtx3, acc1.Bytes(), 3)
+	err = sd.DomainDelPrefix(kv.StorageDomain, rwTtx3, acc1[:], 3)
 	require.NoError(t, err)
 	err = sd.Flush(ctx, rwTtx3)
 	require.NoError(t, err)
@@ -287,58 +287,58 @@ func TestTemporalTx_RangeAsOf_StorageDomain(t *testing.T) {
 	roTtx1, err := temporalDb.BeginTemporalRo(ctx)
 	require.NoError(t, err)
 	defer roTtx1.Rollback()
-	it1, err := roTtx1.RangeAsOf(kv.StorageDomain, acc1.Bytes(), nextSubTree, 1, order.Asc, kv.Unlim)
+	it1, err := roTtx1.RangeAsOf(kv.StorageDomain, acc1[:], nextSubTree, 1, order.Asc, kv.Unlim)
 	require.NoError(t, err)
 	defer it1.Close()
 
 	require.True(t, it1.HasNext())
 	k, v, err := it1.Next()
 	require.NoError(t, err)
-	require.Equal(t, append(append([]byte{}, acc1.Bytes()...), acc1slot1.Bytes()...), k)
+	require.Equal(t, append(append([]byte{}, acc1[:]...), acc1slot1[:]...), k)
 	require.Len(t, v, 0)
 	require.False(t, it1.HasNext())
 
 	// value 1 at txn num 1
-	it2, err := roTtx1.RangeAsOf(kv.StorageDomain, acc1.Bytes(), nextSubTree, 2, order.Asc, kv.Unlim)
+	it2, err := roTtx1.RangeAsOf(kv.StorageDomain, acc1[:], nextSubTree, 2, order.Asc, kv.Unlim)
 	require.NoError(t, err)
 	defer it2.Close()
 	require.True(t, it2.HasNext())
 	k, v, err = it2.Next()
 	require.NoError(t, err)
-	require.Equal(t, append(append([]byte{}, acc1.Bytes()...), acc1slot1.Bytes()...), k)
+	require.Equal(t, append(append([]byte{}, acc1[:]...), acc1slot1[:]...), k)
 	require.Equal(t, []byte{1}, v)
 	require.False(t, it2.HasNext())
 
 	// value 2 at txn num 2
-	it3, err := roTtx1.RangeAsOf(kv.StorageDomain, acc1.Bytes(), nextSubTree, 3, order.Asc, kv.Unlim)
+	it3, err := roTtx1.RangeAsOf(kv.StorageDomain, acc1[:], nextSubTree, 3, order.Asc, kv.Unlim)
 	require.NoError(t, err)
 	defer it3.Close()
 	require.True(t, it3.HasNext())
 	k, v, err = it3.Next()
 	require.NoError(t, err)
-	require.Equal(t, append(append([]byte{}, acc1.Bytes()...), acc1slot1.Bytes()...), k)
+	require.Equal(t, append(append([]byte{}, acc1[:]...), acc1slot1[:]...), k)
 	require.Equal(t, []byte{2}, v)
 	require.False(t, it3.HasNext())
 
 	// empty value at txn num 3
-	it4, err := roTtx1.RangeAsOf(kv.StorageDomain, acc1.Bytes(), nextSubTree, 4, order.Asc, kv.Unlim)
+	it4, err := roTtx1.RangeAsOf(kv.StorageDomain, acc1[:], nextSubTree, 4, order.Asc, kv.Unlim)
 	require.NoError(t, err)
 	defer it4.Close()
 	require.True(t, it4.HasNext())
 	k, v, err = it4.Next()
 	require.NoError(t, err)
-	require.Equal(t, append(append([]byte{}, acc1.Bytes()...), acc1slot1.Bytes()...), k)
+	require.Equal(t, append(append([]byte{}, acc1[:]...), acc1slot1[:]...), k)
 	require.Len(t, v, 0)
 	require.False(t, it4.HasNext())
 
 	// value 3 at txn num 4 - note under the hood this will use latest vals instead of historical
-	it5, err := roTtx1.RangeAsOf(kv.StorageDomain, acc1.Bytes(), nextSubTree, 5, order.Asc, kv.Unlim)
+	it5, err := roTtx1.RangeAsOf(kv.StorageDomain, acc1[:], nextSubTree, 5, order.Asc, kv.Unlim)
 	require.NoError(t, err)
 	defer it5.Close()
 	require.True(t, it5.HasNext())
 	k, v, err = it5.Next()
 	require.NoError(t, err)
-	require.Equal(t, append(append([]byte{}, acc1.Bytes()...), acc1slot1.Bytes()...), k)
+	require.Equal(t, append(append([]byte{}, acc1[:]...), acc1slot1[:]...), k)
 	require.Equal(t, []byte{3}, v)
 	require.False(t, it5.HasNext())
 }

--- a/db/rawdb/accessors_chain.go
+++ b/db/rawdb/accessors_chain.go
@@ -58,7 +58,7 @@ func ReadCanonicalHash(db kv.Getter, number uint64) (common.Hash, error) {
 
 // WriteCanonicalHash stores the hash assigned to a canonical block number.
 func WriteCanonicalHash(db kv.Putter, hash common.Hash, number uint64) error {
-	if err := db.Put(kv.HeaderCanonical, hexutil.EncodeTs(number), hash.Bytes()); err != nil {
+	if err := db.Put(kv.HeaderCanonical, hexutil.EncodeTs(number), hash[:]); err != nil {
 		return fmt.Errorf("failed to store number to hash mapping: %w", err)
 	}
 	return nil
@@ -145,7 +145,7 @@ func IsCanonicalHash(db kv.Getter, hash common.Hash, number uint64) (bool, error
 
 // ReadHeaderNumber returns the header number assigned to a hash.
 func ReadHeaderNumber(db kv.Getter, hash common.Hash) *uint64 {
-	data, err := db.GetOne(kv.HeaderNumber, hash.Bytes())
+	data, err := db.GetOne(kv.HeaderNumber, hash[:])
 	if err != nil {
 		log.Error("ReadHeaderNumber failed", "err", err)
 	}
@@ -160,7 +160,7 @@ func ReadHeaderNumber(db kv.Getter, hash common.Hash) *uint64 {
 	return &number
 }
 func ReadBadHeaderNumber(db kv.Getter, hash common.Hash) (*uint64, error) {
-	data, err := db.GetOne(kv.BadHeaderNumber, hash.Bytes())
+	data, err := db.GetOne(kv.BadHeaderNumber, hash[:])
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +200,7 @@ func ReadHeadHeaderHash(db kv.Getter) common.Hash {
 // It is updated in stage_headers, updateForkChoice.
 // See: WriteHeadBlockHash
 func WriteHeadHeaderHash(db kv.Putter, hash common.Hash) error {
-	if err := db.Put(kv.HeadHeaderKey, []byte(kv.HeadHeaderKey), hash.Bytes()); err != nil {
+	if err := db.Put(kv.HeadHeaderKey, []byte(kv.HeadHeaderKey), hash[:]); err != nil {
 		return fmt.Errorf("failed to store last header's hash: %w", err)
 	}
 	return nil
@@ -224,7 +224,7 @@ func ReadHeadBlockHash(db kv.Getter) common.Hash {
 // It is updated in stage_finish.
 // See: kv.HeadBlockKey
 func WriteHeadBlockHash(db kv.Putter, hash common.Hash) {
-	if err := db.Put(kv.HeadBlockKey, []byte(kv.HeadBlockKey), hash.Bytes()); err != nil {
+	if err := db.Put(kv.HeadBlockKey, []byte(kv.HeadBlockKey), hash[:]); err != nil {
 		log.Crit("Failed to store last block's hash", "err", err)
 	}
 }
@@ -406,7 +406,7 @@ func DeleteHeader(db kv.Putter, hash common.Hash, number uint64) {
 	if err := db.Delete(kv.Headers, dbutils.HeaderKey(number, hash)); err != nil {
 		log.Crit("Failed to delete header", "err", err)
 	}
-	if err := db.Delete(kv.HeaderNumber, hash.Bytes()); err != nil {
+	if err := db.Delete(kv.HeaderNumber, hash[:]); err != nil {
 		log.Crit("Failed to delete hash to number mapping", "err", err)
 	}
 }

--- a/db/rawdb/accessors_chain_test.go
+++ b/db/rawdb/accessors_chain_test.go
@@ -808,8 +808,9 @@ func TestBlockReceiptStorage(t *testing.T) {
 	}
 	receipt1.Bloom = types.CreateBloom(types.Receipts{receipt1})
 
+	receipt2PostState := common.Hash{2}
 	receipt2 := &types.Receipt{
-		PostState:         common.Hash{2}.Bytes(),
+		PostState:         receipt2PostState[:],
 		CumulativeGasUsed: 2,
 		Logs: []*types.Log{
 			{Address: common.BytesToAddress([]byte{0x22})},

--- a/db/rawdb/accessors_indexes.go
+++ b/db/rawdb/accessors_indexes.go
@@ -31,7 +31,7 @@ import (
 // ReadTxLookupEntry retrieves the positional metadata associated with a transaction
 // hash to allow retrieving the transaction or receipt by hash.
 func ReadTxLookupEntry(db kv.Getter, txnHash common.Hash) (blockNumber *uint64, txNum *uint64, err error) {
-	data, err := db.GetOne(kv.TxLookup, txnHash.Bytes())
+	data, err := db.GetOne(kv.TxLookup, txnHash[:])
 	if err != nil {
 		return nil, nil, err
 	}
@@ -52,7 +52,8 @@ func WriteTxLookupEntries(db kv.Putter, block *types.Block, txNum uint64) {
 		binary.BigEndian.PutUint64(data[:8], block.NumberU64())
 		binary.BigEndian.PutUint64(data[8:], txNum+uint64(i)+1)
 
-		if err := db.Put(kv.TxLookup, txn.Hash().Bytes(), data); err != nil {
+		txHash := txn.Hash()
+		if err := db.Put(kv.TxLookup, txHash[:], data); err != nil {
 			log.Crit("Failed to store transaction lookup entry", "err", err)
 		}
 	}
@@ -60,5 +61,5 @@ func WriteTxLookupEntries(db kv.Putter, block *types.Block, txNum uint64) {
 
 // DeleteTxLookupEntry removes all transaction data associated with a hash.
 func DeleteTxLookupEntry(db kv.Putter, hash common.Hash) error {
-	return db.Delete(kv.TxLookup, hash.Bytes())
+	return db.Delete(kv.TxLookup, hash[:])
 }

--- a/db/rawdb/utils/block_max_heap_test.go
+++ b/db/rawdb/utils/block_max_heap_test.go
@@ -77,6 +77,6 @@ func newB(id uint64, hash []byte) *utils.BlockId {
 }
 
 func lastByte(b *utils.BlockId) byte {
-	by := b.Hash.Bytes()
+	by := b.Hash[:]
 	return by[len(by)-1]
 }

--- a/db/snapshotsync/freezeblocks/block_reader_bench_test.go
+++ b/db/snapshotsync/freezeblocks/block_reader_bench_test.go
@@ -71,22 +71,25 @@ func realisticHeader(blockNum uint64) *types.Header {
 		}
 		return
 	}
+	coinbaseBytes := fill32(1)
+	extraBytes := fill32(4)
+	bloomBytes := fill32(6)
 	h := &types.Header{
 		Number:      *uint256.NewInt(blockNum),
 		ParentHash:  fill32(0),
 		UncleHash:   fill32(7),
-		Coinbase:    common.BytesToAddress(fill32(1).Bytes()),
+		Coinbase:    common.BytesToAddress(coinbaseBytes[:]),
 		Root:        fill32(2),
 		TxHash:      fill32(8),
 		ReceiptHash: fill32(3),
 		GasLimit:    30_000_000,
 		GasUsed:     seed % 30_000_000,
 		Time:        1_700_000_000 + seed,
-		Extra:       fill32(4).Bytes(),
+		Extra:       extraBytes[:],
 		MixDigest:   fill32(5),
 		BaseFee:     uint256.NewInt(seed % 1_000_000_000),
 	}
-	copy(h.Bloom[:], fill32(6).Bytes())
+	copy(h.Bloom[:], bloomBytes[:])
 	return h
 }
 

--- a/db/state/aggregator_fuzz_test.go
+++ b/db/state/aggregator_fuzz_test.go
@@ -83,10 +83,10 @@ func Fuzz_AggregatorV3_Merge(f *testing.F) {
 				Incarnation: 0,
 			}
 			buf := accounts.SerialiseV3(&acc)
-			err = domains.DomainPut(kv.AccountsDomain, rwTx, addrs[txNum].Bytes(), buf, txNum, nil)
+			err = domains.DomainPut(kv.AccountsDomain, rwTx, addrs[txNum][:], buf, txNum, nil)
 			require.NoError(t, err)
 
-			err = domains.DomainPut(kv.StorageDomain, rwTx, composite(addrs[txNum].Bytes(), locs[txNum].Bytes()), []byte{addrs[txNum].Bytes()[0], locs[txNum].Bytes()[0]}, txNum, nil)
+			err = domains.DomainPut(kv.StorageDomain, rwTx, composite(addrs[txNum][:], locs[txNum][:]), []byte{addrs[txNum][:][0], locs[txNum][:][0]}, txNum, nil)
 			require.NoError(t, err)
 
 			var v [8]byte
@@ -194,11 +194,11 @@ func Fuzz_AggregatorV3_MergeValTransform(f *testing.F) {
 				Incarnation: 0,
 			}
 			buf := accounts.SerialiseV3(&acc)
-			err = domains.DomainPut(kv.AccountsDomain, rwTx, addrs[txNum].Bytes(), buf, txNum, nil)
+			err = domains.DomainPut(kv.AccountsDomain, rwTx, addrs[txNum][:], buf, txNum, nil)
 			require.NoError(t, err)
 
-			k := composite(addrs[txNum].Bytes(), locs[txNum].Bytes())
-			v := []byte{addrs[txNum].Bytes()[0], locs[txNum].Bytes()[0]}
+			k := composite(addrs[txNum][:], locs[txNum][:])
+			v := []byte{addrs[txNum][:][0], locs[txNum][:][0]}
 			err = domains.DomainPut(kv.StorageDomain, rwTx, k, v, txNum, nil)
 			require.NoError(t, err)
 
@@ -207,8 +207,8 @@ func Fuzz_AggregatorV3_MergeValTransform(f *testing.F) {
 				require.NoError(t, err)
 			}
 
-			state[string(addrs[txNum].Bytes())] = buf
-			state[string(addrs[txNum].Bytes())+string(locs[txNum].Bytes())] = []byte{addrs[txNum].Bytes()[0], locs[txNum].Bytes()[0]}
+			state[string(addrs[txNum][:])] = buf
+			state[string(addrs[txNum][:])+string(locs[txNum][:])] = []byte{addrs[txNum][:][0], locs[txNum][:][0]}
 		}
 
 		err = domains.Flush(t.Context(), rwTx)

--- a/db/state/execctx/domain_shared_test.go
+++ b/db/state/execctx/domain_shared_test.go
@@ -1228,14 +1228,14 @@ func TestSharedDomain_HasPrefix_StorageDomain(t *testing.T) {
 
 	acc1 := common.HexToAddress("0x1234567890123456789012345678901234567890")
 	acc1slot1 := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001")
-	storageK1 := append(append([]byte{}, acc1.Bytes()...), acc1slot1.Bytes()...)
+	storageK1 := append(append([]byte{}, acc1[:]...), acc1slot1[:]...)
 	acc2 := common.HexToAddress("0x1234567890123456789012345678901234567891")
 	acc2slot2 := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002")
-	storageK2 := append(append([]byte{}, acc2.Bytes()...), acc2slot2.Bytes()...)
+	storageK2 := append(append([]byte{}, acc2[:]...), acc2slot2[:]...)
 
 	// --- check 1: non-existing storage ---
 	{
-		firstKey, firstVal, ok, err := sd.HasPrefix(kv.StorageDomain, acc1.Bytes(), rwTtx1)
+		firstKey, firstVal, ok, err := sd.HasPrefix(kv.StorageDomain, acc1[:], rwTtx1)
 		require.NoError(t, err)
 		require.False(t, ok)
 		require.Nil(t, firstKey)
@@ -1248,10 +1248,10 @@ func TestSharedDomain_HasPrefix_StorageDomain(t *testing.T) {
 		err = sd.DomainPut(kv.StorageDomain, rwTtx1, storageK1, []byte{1}, 1, nil)
 		require.NoError(t, err)
 		// check before flush
-		firstKey, firstVal, ok, err := sd.HasPrefix(kv.StorageDomain, acc1.Bytes(), rwTtx1)
+		firstKey, firstVal, ok, err := sd.HasPrefix(kv.StorageDomain, acc1[:], rwTtx1)
 		require.NoError(t, err)
 		require.True(t, ok)
-		require.Equal(t, append(append([]byte{}, acc1.Bytes()...), acc1slot1.Bytes()...), firstKey)
+		require.Equal(t, append(append([]byte{}, acc1[:]...), acc1slot1[:]...), firstKey)
 		require.Equal(t, []byte{1}, firstVal)
 		// check after flush
 		err = sd.Flush(ctx, rwTtx1)
@@ -1268,7 +1268,7 @@ func TestSharedDomain_HasPrefix_StorageDomain(t *testing.T) {
 		t.Cleanup(c1.Close)
 		k, v, err := c1.Next()
 		require.NoError(t, err)
-		require.Equal(t, append(append([]byte{}, acc1.Bytes()...), acc1slot1.Bytes()...), k)
+		require.Equal(t, append(append([]byte{}, acc1[:]...), acc1slot1[:]...), k)
 		wantValueBytes := make([]byte, 8)                      // 8 bytes for uint64 step num
 		binary.BigEndian.PutUint64(wantValueBytes, ^uint64(1)) // step num
 		wantValueBytes = append(wantValueBytes, byte(1))       // value we wrote to the storage slot
@@ -1288,14 +1288,14 @@ func TestSharedDomain_HasPrefix_StorageDomain(t *testing.T) {
 		require.Equal(t, uint64(0), roTtx1.Debug().TxNumsInFiles(kv.StorageDomain))
 
 		// finally, verify SharedDomains.HasPrefix returns true
-		firstKey, firstVal, ok, err = sd.HasPrefix(kv.StorageDomain, acc1.Bytes(), roTtx1)
+		firstKey, firstVal, ok, err = sd.HasPrefix(kv.StorageDomain, acc1[:], roTtx1)
 		require.NoError(t, err)
 		require.True(t, ok)
-		require.Equal(t, append(append([]byte{}, acc1.Bytes()...), acc1slot1.Bytes()...), firstKey)
+		require.Equal(t, append(append([]byte{}, acc1[:]...), acc1slot1[:]...), firstKey)
 		require.Equal(t, []byte{1}, firstVal)
 
 		// check some other non-existing storages for non-existence after write operation
-		firstKey, firstVal, ok, err = sd.HasPrefix(kv.StorageDomain, acc2.Bytes(), roTtx1)
+		firstKey, firstVal, ok, err = sd.HasPrefix(kv.StorageDomain, acc2[:], roTtx1)
 		require.NoError(t, err)
 		require.False(t, ok)
 		require.Nil(t, firstKey)
@@ -1313,10 +1313,10 @@ func TestSharedDomain_HasPrefix_StorageDomain(t *testing.T) {
 		err = sd.DomainPut(kv.StorageDomain, rwTtx2, storageK2, []byte{2}, 2, nil)
 		require.NoError(t, err)
 		// check before flush
-		firstKey, firstVal, ok, err := sd.HasPrefix(kv.StorageDomain, acc1.Bytes(), rwTtx2)
+		firstKey, firstVal, ok, err := sd.HasPrefix(kv.StorageDomain, acc1[:], rwTtx2)
 		require.NoError(t, err)
 		require.True(t, ok)
-		require.Equal(t, append(append([]byte{}, acc1.Bytes()...), acc1slot1.Bytes()...), firstKey)
+		require.Equal(t, append(append([]byte{}, acc1[:]...), acc1slot1[:]...), firstKey)
 		require.Equal(t, []byte{1}, firstVal)
 		// check after flush
 		err = sd.Flush(ctx, rwTtx2)
@@ -1347,7 +1347,7 @@ func TestSharedDomain_HasPrefix_StorageDomain(t *testing.T) {
 		t.Cleanup(c2.Close)
 		k, v, err := c2.Next() // acc2 storage from step 2 will be there
 		require.NoError(t, err)
-		require.Equal(t, append(append([]byte{}, acc2.Bytes()...), acc2slot2.Bytes()...), k)
+		require.Equal(t, append(append([]byte{}, acc2[:]...), acc2slot2[:]...), k)
 		wantValueBytes := make([]byte, 8)                      // 8 bytes for uint64 step num
 		binary.BigEndian.PutUint64(wantValueBytes, ^uint64(2)) // step num
 		wantValueBytes = append(wantValueBytes, byte(2))       // value we wrote to the storage slot
@@ -1364,10 +1364,10 @@ func TestSharedDomain_HasPrefix_StorageDomain(t *testing.T) {
 		require.Equal(t, uint64(2), roTtx2.Debug().TxNumsInFiles(kv.StorageDomain))
 
 		// finally, verify SharedDomains.HasPrefix returns true
-		firstKey, firstVal, ok, err = sd.HasPrefix(kv.StorageDomain, acc1.Bytes(), roTtx2)
+		firstKey, firstVal, ok, err = sd.HasPrefix(kv.StorageDomain, acc1[:], roTtx2)
 		require.NoError(t, err)
 		require.True(t, ok)
-		require.Equal(t, append(append([]byte{}, acc1.Bytes()...), acc1slot1.Bytes()...), firstKey)
+		require.Equal(t, append(append([]byte{}, acc1[:]...), acc1slot1[:]...), firstKey)
 		require.Equal(t, []byte{1}, firstVal)
 		roTtx2.Rollback()
 	}
@@ -1377,10 +1377,10 @@ func TestSharedDomain_HasPrefix_StorageDomain(t *testing.T) {
 		rwTtx4, err := db.BeginTemporalRw(ctx)
 		require.NoError(t, err)
 		t.Cleanup(rwTtx4.Rollback)
-		err = sd.DomainDelPrefix(kv.StorageDomain, rwTtx4, acc1.Bytes(), 3)
+		err = sd.DomainDelPrefix(kv.StorageDomain, rwTtx4, acc1[:], 3)
 		require.NoError(t, err)
 		// check before flush
-		firstKey, firstVal, ok, err := sd.HasPrefix(kv.StorageDomain, acc1.Bytes(), rwTtx4)
+		firstKey, firstVal, ok, err := sd.HasPrefix(kv.StorageDomain, acc1[:], rwTtx4)
 		require.NoError(t, err)
 		require.False(t, ok)
 		require.Nil(t, firstKey)
@@ -1394,7 +1394,7 @@ func TestSharedDomain_HasPrefix_StorageDomain(t *testing.T) {
 		roTtx3, err := db.BeginTemporalRo(ctx)
 		require.NoError(t, err)
 		t.Cleanup(roTtx3.Rollback)
-		firstKey, firstVal, ok, err = sd.HasPrefix(kv.StorageDomain, acc1.Bytes(), roTtx3)
+		firstKey, firstVal, ok, err = sd.HasPrefix(kv.StorageDomain, acc1[:], roTtx3)
 		require.NoError(t, err)
 		require.False(t, ok)
 		require.Nil(t, firstKey)
@@ -1410,10 +1410,10 @@ func TestSharedDomain_HasPrefix_StorageDomain(t *testing.T) {
 		err = sd.DomainPut(kv.StorageDomain, rwTtx5, storageK1, []byte{3}, 4, nil)
 		require.NoError(t, err)
 		// check before flush
-		firstKey, firstVal, ok, err := sd.HasPrefix(kv.StorageDomain, acc1.Bytes(), rwTtx5)
+		firstKey, firstVal, ok, err := sd.HasPrefix(kv.StorageDomain, acc1[:], rwTtx5)
 		require.NoError(t, err)
 		require.True(t, ok)
-		require.Equal(t, append(append([]byte{}, acc1.Bytes()...), acc1slot1.Bytes()...), firstKey)
+		require.Equal(t, append(append([]byte{}, acc1[:]...), acc1slot1[:]...), firstKey)
 		require.Equal(t, []byte{3}, firstVal)
 		// check after flush
 		err = sd.Flush(ctx, rwTtx5)
@@ -1424,10 +1424,10 @@ func TestSharedDomain_HasPrefix_StorageDomain(t *testing.T) {
 		roTtx4, err := db.BeginTemporalRo(ctx)
 		require.NoError(t, err)
 		t.Cleanup(roTtx4.Rollback)
-		firstKey, firstVal, ok, err = sd.HasPrefix(kv.StorageDomain, acc1.Bytes(), roTtx4)
+		firstKey, firstVal, ok, err = sd.HasPrefix(kv.StorageDomain, acc1[:], roTtx4)
 		require.NoError(t, err)
 		require.True(t, ok)
-		require.Equal(t, append(append([]byte{}, acc1.Bytes()...), acc1slot1.Bytes()...), firstKey)
+		require.Equal(t, append(append([]byte{}, acc1[:]...), acc1slot1[:]...), firstKey)
 		require.Equal(t, []byte{3}, firstVal)
 		roTtx4.Rollback()
 	}
@@ -1615,7 +1615,7 @@ func TestSharedDomain_TouchChangedKeysFromHistory(t *testing.T) {
 
 	acc1Addr := common.HexToAddress("0x1234567890123456789012345678901234567890")
 	acc1Slot := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001")
-	storageK1 := append(append([]byte{}, acc1Addr.Bytes()...), acc1Slot.Bytes()...)
+	storageK1 := append(append([]byte{}, acc1Addr[:]...), acc1Slot[:]...)
 	storageV1 := []byte{1}
 	acc1 := accounts.NewAccount()
 	acc1.Balance.SetUint64(1)
@@ -1623,24 +1623,24 @@ func TestSharedDomain_TouchChangedKeysFromHistory(t *testing.T) {
 
 	// --- check 1: non-existing account & storage and empty commitment trie ---
 	{
-		acc1Value, _, err := sd1.GetLatest(kv.AccountsDomain, db1RwTx, acc1Addr.Bytes())
+		acc1Value, _, err := sd1.GetLatest(kv.AccountsDomain, db1RwTx, acc1Addr[:])
 		require.NoError(t, err)
 		require.Nil(t, acc1Value)
 
-		acc1SlotValue, _, err := sd1.GetLatest(kv.StorageDomain, db1RwTx, acc1Slot.Bytes())
+		acc1SlotValue, _, err := sd1.GetLatest(kv.StorageDomain, db1RwTx, acc1Slot[:])
 		require.NoError(t, err)
 		require.Nil(t, acc1SlotValue)
 
 		rootHash, err := sd1.GetCommitmentContext().Trie().RootHash()
 		require.NoError(t, err)
-		require.Equal(t, empty.RootHash.Bytes(), rootHash)
+		require.Equal(t, empty.RootHash[:], rootHash)
 	}
 
 	// --- check 2: write state in db1 and verify is present in history ---
 	txNum := uint64(1)
 	{
 		// write account and storage in db1
-		err = sd1.DomainPut(kv.AccountsDomain, db1RwTx, acc1Addr.Bytes(), acc1Encoded, txNum, nil)
+		err = sd1.DomainPut(kv.AccountsDomain, db1RwTx, acc1Addr[:], acc1Encoded, txNum, nil)
 		require.NoError(t, err)
 		err = sd1.DomainPut(kv.StorageDomain, db1RwTx, storageK1, storageV1, txNum, nil)
 		require.NoError(t, err)
@@ -1660,7 +1660,7 @@ func TestSharedDomain_TouchChangedKeysFromHistory(t *testing.T) {
 		t.Cleanup(c1.Close)
 		k, v, err := c1.Next()
 		require.NoError(t, err)
-		require.Equal(t, acc1Addr.Bytes(), k)
+		require.Equal(t, acc1Addr[:], k)
 		wantValueBytes := make([]byte, 8)                       // 8 bytes for uint64 step num
 		binary.BigEndian.PutUint64(wantValueBytes, ^uint64(1))  // step num
 		wantValueBytes = append(wantValueBytes, acc1Encoded...) // value we wrote to the account
@@ -1674,7 +1674,7 @@ func TestSharedDomain_TouchChangedKeysFromHistory(t *testing.T) {
 		t.Cleanup(c2.Close)
 		k, v, err = c2.Next()
 		require.NoError(t, err)
-		require.Equal(t, append(append([]byte{}, acc1Addr.Bytes()...), acc1Slot.Bytes()...), k)
+		require.Equal(t, append(append([]byte{}, acc1Addr[:]...), acc1Slot[:]...), k)
 		wantValueBytes = make([]byte, 8)                       // 8 bytes for uint64 step num
 		binary.BigEndian.PutUint64(wantValueBytes, ^uint64(1)) // step num
 		wantValueBytes = append(wantValueBytes, storageV1...)  // value we wrote to the storage slot
@@ -1714,7 +1714,7 @@ func TestSharedDomain_TouchChangedKeysFromHistory(t *testing.T) {
 		// check that the initial commitment trie is empty in db2
 		initialRootHash, err := sd2.GetCommitmentContext().Trie().RootHash()
 		require.NoError(t, err)
-		require.Equal(t, empty.RootHash.Bytes(), initialRootHash)
+		require.Equal(t, empty.RootHash[:], initialRootHash)
 
 		// double-check: if we try to compute the initial commitment trie root in db2, it is empty
 		initialRootHash, err = sd2.ComputeCommitment(ctx, roTx2, false, blockNum, toTxNum, "", nil)
@@ -1722,7 +1722,7 @@ func TestSharedDomain_TouchChangedKeysFromHistory(t *testing.T) {
 			return
 		}
 		require.NoError(t, err)
-		require.Equal(t, empty.RootHash.Bytes(), initialRootHash)
+		require.Equal(t, empty.RootHash[:], initialRootHash)
 
 		// test core: touch in sd2 the changed keys in [fromTxNum, toTxNum+1) using historical state changes from db1
 		accountChanges, storageChanges, err := sd2.TouchChangedKeysFromHistory(db1RoTx, fromTxNum, toTxNum+1)

--- a/db/state/forkable_agg_test.go
+++ b/db/state/forkable_agg_test.go
@@ -571,7 +571,8 @@ func fillForkables(t *testing.T, rwtx kv.RwTx, headerTx, bodyTx MarkedTxI, amoun
 			// just use different value
 			HEADER_M, BODY_M = 200, 201
 		}
-		hash := tr.RandHash().Bytes()
+		rh := tr.RandHash()
+		hash := rh[:]
 		err := headerTx.Put(Num(i), hash, Num(i*HEADER_M).EncTo8Bytes(), rwtx)
 		require.NoError(t, err)
 

--- a/db/state/squeeze_concurrent_rebuild_test.go
+++ b/db/state/squeeze_concurrent_rebuild_test.go
@@ -375,7 +375,7 @@ func TestConcurrentRebuildCommitment(t *testing.T) {
 
 	// --- Record original sizes and generation root ---
 	require.NotEmpty(t, lastRoot, "generation root must be non-empty")
-	require.NotEqual(t, empty.RootHash.Bytes(), lastRoot, "generation root must differ from empty trie root")
+	require.NotEqual(t, empty.RootHash[:], lastRoot, "generation root must differ from empty trie root")
 
 	originalSizes := collectCommitmentFiles(t, dirs)
 
@@ -421,7 +421,7 @@ func TestConcurrentRebuildCommitment(t *testing.T) {
 		fileSizes: seqSizes,
 	}
 	require.NotEmpty(t, sequentialResult.root, "sequential rebuild root must be non-empty")
-	require.NotEqual(t, empty.RootHash.Bytes(), sequentialResult.root, "sequential rebuild root must differ from empty trie root")
+	require.NotEqual(t, empty.RootHash[:], sequentialResult.root, "sequential rebuild root must differ from empty trie root")
 
 	t.Logf("Sequential rebuild: root=%x time=%s files=%d",
 		sequentialResult.root, sequentialResult.duration, len(sequentialResult.fileSizes))
@@ -592,7 +592,7 @@ func TestConcurrentRebuildCommitmentNoSqueeze(t *testing.T) {
 	seqRoot, err := state.RebuildCommitmentFiles(ctx, db, &rawdbv3.TxNums, log.New(), false)
 	require.NoError(t, err)
 	require.NotEmpty(t, seqRoot)
-	require.NotEqual(t, empty.RootHash.Bytes(), seqRoot)
+	require.NotEqual(t, empty.RootHash[:], seqRoot)
 	seqSizes := collectCommitmentFiles(t, dirs)
 	require.NotEmpty(t, seqSizes, "sequential rebuild must produce commitment files")
 	t.Logf("Sequential: root=%x files=%d", seqRoot, len(seqSizes))

--- a/db/state/squeeze_test.go
+++ b/db/state/squeeze_test.go
@@ -260,7 +260,7 @@ func TestAggregator_SqueezeCommitment(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, root)
 	require.Equal(t, latestRoot, root)
-	require.NotEqual(t, empty.RootHash.Bytes(), root)
+	require.NotEqual(t, empty.RootHash[:], root)
 }
 
 func TestAggregator_RebuildCommitmentBasedOnFiles(t *testing.T) {
@@ -332,7 +332,7 @@ func TestAggregator_RebuildCommitmentBasedOnFiles(t *testing.T) {
 	finalRoot, err := state.RebuildCommitmentFiles(ctx, db, &rawdbv3.TxNums, log.New(), true)
 	require.NoError(t, err)
 	require.NotEmpty(t, finalRoot)
-	require.NotEqual(t, empty.RootHash.Bytes(), finalRoot)
+	require.NotEqual(t, empty.RootHash[:], finalRoot)
 
 	require.Equal(t, rootInFiles, finalRoot)
 }
@@ -716,7 +716,7 @@ func TestGenerateCommitmentRebuildData(t *testing.T) {
 
 	// Validate
 	require.NotEmpty(t, lastRoot, "final root must be non-empty")
-	require.NotEqual(t, empty.RootHash.Bytes(), lastRoot, "final root must differ from empty trie root")
+	require.NotEqual(t, empty.RootHash[:], lastRoot, "final root must differ from empty trie root")
 
 	t.Logf("Done. Final root: %x", lastRoot)
 	t.Logf("Output datadir: %s", dirs.DataDir)

--- a/db/state/trie_reader_integration_test.go
+++ b/db/state/trie_reader_integration_test.go
@@ -95,7 +95,7 @@ func TestTrieReader_IntegrationWithRealData(t *testing.T) {
 			rh, err := domains.ComputeCommitment(ctx, rwTx, true, blockNum, txNum, "", nil)
 			require.NoError(t, err)
 			require.NotEmpty(t, rh)
-			require.NotEqual(t, empty.RootHash.Bytes(), rh)
+			require.NotEqual(t, empty.RootHash[:], rh)
 			require.NoError(t, domains.Flush(ctx, rwTx))
 			require.NoError(t, rawdbv3.TxNums.Append(rwTx, blockNum, txNum))
 			blockNum++

--- a/db/test/marked_forkable_test.go
+++ b/db/test/marked_forkable_test.go
@@ -110,7 +110,8 @@ func TestMarked_PutToDb(t *testing.T) {
 	defer rwtx.Rollback()
 
 	num := Num(1)
-	hash := common.HexToHash("0x1234").Bytes()
+	hashVal := common.HexToHash("0x1234")
+	hash := hashVal[:]
 	value := []byte{1, 2, 3, 4, 5}
 
 	err = ma_tx.Put(num, hash, value, rwtx)
@@ -161,7 +162,8 @@ func TestPrune(t *testing.T) {
 				err = header.EncodeRLP(buffer)
 				require.NoError(t, err)
 
-				return Num(i), header.Hash().Bytes(), buffer.Bytes()
+				headerHash := header.Hash()
+				return Num(i), headerHash[:], buffer.Bytes()
 			}
 
 			for i := range int(entries_count) {
@@ -250,7 +252,8 @@ func TestBuildFiles_Marked(t *testing.T) {
 		err = header.EncodeRLP(buffer)
 		require.NoError(t, err)
 
-		return Num(i), header.Hash().Bytes(), buffer.Bytes()
+		headerHash := header.Hash()
+		return Num(i), headerHash[:], buffer.Bytes()
 	}
 
 	for i := range int(entries_count) {

--- a/execution/abi/abi.go
+++ b/execution/abi/abi.go
@@ -248,7 +248,7 @@ func (abi *ABI) MethodById(sigdata []byte) (*Method, error) {
 // It returns an error if no event is found.
 func (abi *ABI) EventByID(topic common.Hash) (*Event, error) {
 	for _, event := range abi.Events {
-		if bytes.Equal(event.ID.Bytes(), topic.Bytes()) {
+		if bytes.Equal(event.ID[:], topic[:]) {
 			return &event, nil
 		}
 	}

--- a/execution/abi/bind/auth.go
+++ b/execution/abi/bind/auth.go
@@ -50,7 +50,8 @@ func NewKeyedTransactorWithChainID(key *ecdsa.PrivateKey, chainID *uint256.Int) 
 			if address != keyAddr {
 				return nil, ErrNotAuthorized
 			}
-			signature, err := crypto.Sign(txn.SigningHash(chainID).Bytes(), key)
+			sigHash := txn.SigningHash(chainID)
+			signature, err := crypto.Sign(sigHash[:], key)
 			if err != nil {
 				return nil, err
 			}

--- a/execution/abi/bind/base_test.go
+++ b/execution/abi/bind/base_test.go
@@ -186,7 +186,7 @@ func TestUnpackIndexedArrayTyLogIntoMap(t *testing.T) {
 
 func TestUnpackIndexedFuncTyLogIntoMap(t *testing.T) {
 	mockAddress := common.HexToAddress("0x376c47978271565f56DEB45495afa69E59c16Ab2")
-	addrBytes := mockAddress.Bytes()
+	addrBytes := mockAddress[:]
 	hash := crypto.Keccak256Hash([]byte("mockFunction(address,uint)"))
 	functionSelector := hash[:4]
 	functionTyBytes := append(addrBytes, functionSelector...)

--- a/execution/abi/topics.go
+++ b/execution/abi/topics.go
@@ -182,14 +182,14 @@ func parseTopicWithSetter(fields Arguments, topics []common.Hash, setter func(Ar
 			reconstr = topics[i]
 		case FunctionTy:
 			if garbage := binary.BigEndian.Uint64(topics[i][0:8]); garbage != 0 {
-				return fmt.Errorf("bind: got improperly encoded function type, got %v", topics[i].Bytes())
+				return fmt.Errorf("bind: got improperly encoded function type, got %v", topics[i][:])
 			}
 			var tmp [24]byte
 			copy(tmp[:], topics[i][8:32])
 			reconstr = tmp
 		default:
 			var err error
-			reconstr, err = toGoType(0, arg.Type, topics[i].Bytes())
+			reconstr, err = toGoType(0, arg.Type, topics[i][:])
 			if err != nil {
 				return err
 			}

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -287,7 +287,7 @@ func (f loadFlags) addFlag(loadFlags loadFlags) loadFlags {
 }
 
 var (
-	emptyRootHashBytes = empty.RootHash.Bytes()
+	emptyRootHashBytes = empty.RootHash[:]
 )
 
 func (cell *cell) hashAccKey(keccak keccak.KeccakState, depth int16, hashBuf []byte) error {

--- a/execution/commitment/trie/account_node_test.go
+++ b/execution/commitment/trie/account_node_test.go
@@ -90,8 +90,10 @@ func TestAddSomeValuesToAccountAndCheckDeepHashForThem(t *testing.T) {
 		t.Fatal("not equal", keyAcc)
 	}
 
-	value1 := common.HexToHash("0x3").Bytes()
-	value2 := common.HexToHash("0x5").Bytes()
+	value1Hash := common.HexToHash("0x3")
+	value2Hash := common.HexToHash("0x5")
+	value1 := value1Hash[:]
+	value2 := value2Hash[:]
 
 	storageKey1 := common.HexToHash("0x1")
 	storageKey2 := common.HexToHash("0x5")
@@ -103,10 +105,10 @@ func TestAddSomeValuesToAccountAndCheckDeepHashForThem(t *testing.T) {
 	trie.Update(fullStorageKey2, value2)
 
 	expectedTrie := newEmpty()
-	expectedTrie.Update(storageKey1.Bytes(), value1)
-	expectedTrie.Update(storageKey2.Bytes(), value2)
+	expectedTrie.Update(storageKey1[:], value1)
+	expectedTrie.Update(storageKey2[:], value2)
 
-	_, h1 := trie.DeepHash(addrHash.Bytes())
+	_, h1 := trie.DeepHash(addrHash[:])
 	h2 := expectedTrie.Hash()
 	if h1 != h2 {
 		t.Fatal("not equals", h1.String(), h2.String())
@@ -141,9 +143,9 @@ func TestHash(t *testing.T) {
 	trie := New(common.Hash{})
 	trie2 := NewTestRLPTrie(common.Hash{})
 
-	trie.UpdateAccount(addr1.Bytes(), acc1)
-	trie.UpdateAccount(addr2.Bytes(), acc2)
-	trie.UpdateAccount(addr3.Bytes(), acc3)
+	trie.UpdateAccount(addr1[:], acc1)
+	trie.UpdateAccount(addr2[:], acc2)
+	trie.UpdateAccount(addr3[:], acc3)
 
 	b1 := make([]byte, acc1.EncodingLengthForHashing())
 	b2 := make([]byte, acc2.EncodingLengthForHashing())
@@ -151,9 +153,9 @@ func TestHash(t *testing.T) {
 	acc1.EncodeForHashing(b1)
 	acc2.EncodeForHashing(b2)
 	acc3.EncodeForHashing(b3)
-	trie2.Update(addr1.Bytes(), b1)
-	trie2.Update(addr2.Bytes(), b2)
-	trie2.Update(addr3.Bytes(), b3)
+	trie2.Update(addr1[:], b1)
+	trie2.Update(addr2[:], b2)
+	trie2.Update(addr3[:], b3)
 
 	if trie.Hash().String() != trie2.Hash().String() {
 		t.FailNow()

--- a/execution/commitment/trie/delete_subrtee_test.go
+++ b/execution/commitment/trie/delete_subrtee_test.go
@@ -83,7 +83,7 @@ func TestTrieDeleteSubtree_ShortNode_Debug(t *testing.T) {
 	trie.Update(key1, val)
 	trie.Update(key2, val)
 
-	trie.DeleteSubtree(addrHash1.Bytes())
+	trie.DeleteSubtree(addrHash1[:])
 
 	v, ok := trie.Get(key2)
 	if ok == false || bytes.Equal(v, val) == false {
@@ -377,13 +377,14 @@ func TestAccountNotRemovedAfterRemovingSubtrieAfterAccount(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	addrHash, err := common.HashData(crypto.PubkeyToAddress(key.PublicKey).Bytes())
+	pubAddr := crypto.PubkeyToAddress(key.PublicKey)
+	addrHash, err := common.HashData(pubAddr[:])
 	if err != nil {
 		t.Fatal(err)
 	}
-	trie.UpdateAccount(addrHash.Bytes(), acc)
+	trie.UpdateAccount(addrHash[:], acc)
 
-	accRes1, _ := trie.GetAccount(addrHash.Bytes())
+	accRes1, _ := trie.GetAccount(addrHash[:])
 	if reflect.DeepEqual(acc, accRes1) == false {
 		t.Fatal("not equal", addrHash)
 	}
@@ -406,9 +407,9 @@ func TestAccountNotRemovedAfterRemovingSubtrieAfterAccount(t *testing.T) {
 	trie.Update(ck1, val1)
 	trie.Update(ck2, val2)
 
-	trie.DeleteSubtree(addrHash.Bytes())
+	trie.DeleteSubtree(addrHash[:])
 
-	accRes2, _ := trie.GetAccount(addrHash.Bytes())
+	accRes2, _ := trie.GetAccount(addrHash[:])
 	if reflect.DeepEqual(acc, accRes2) == false {
 		t.Fatal("account was deleted", addrHash)
 	}

--- a/execution/commitment/trie/trie.go
+++ b/execution/commitment/trie/trie.go
@@ -1292,7 +1292,10 @@ func concat(s1 []byte, s2 ...byte) []byte {
 // Root returns the root hash of the trie.
 //
 // Deprecated: use Hash instead.
-func (t *Trie) Root() []byte { return t.Hash().Bytes() }
+func (t *Trie) Root() []byte {
+	h := t.Hash()
+	return h[:]
+}
 
 // Hash returns the root hash of the trie. It does not write to the
 // database and can be used even if the trie doesn't have one.

--- a/execution/commitment/trie/trie_test.go
+++ b/execution/commitment/trie/trie_test.go
@@ -755,7 +755,7 @@ func TestRLPEncodeDecodeWithAccountsAndStorage(t *testing.T) {
 	// Hash the addresses for trie keys
 	addrHashes := make([]common.Hash, len(addresses))
 	for i, addr := range addresses {
-		addrHashes[i] = crypto.Keccak256Hash(addr.Bytes())
+		addrHashes[i] = crypto.Keccak256Hash(addr[:])
 	}
 
 	// Create accounts
@@ -788,20 +788,24 @@ func TestRLPEncodeDecodeWithAccountsAndStorage(t *testing.T) {
 
 	// Insert accounts using UpdateAccount (creates AccountNode entries)
 	for i, addr := range addresses {
-		key := crypto.Keccak256(addr.Bytes())
+		key := crypto.Keccak256(addr[:])
 		stateTrie.UpdateAccount(key, testAccounts[i])
 	}
 
 	// Define storage for contract at index 1
 	contract1AddrHash := addrHashes[1]
+	v1 := common.HexToHash("0x1")
+	v2 := common.HexToHash("0xdeadbeef")
+	v3 := common.HexToHash("0x1234567890abcdef")
+	v4 := common.HexToHash("0xff")
 	storageSlots1 := []struct {
 		slot  common.Hash
 		value []byte
 	}{
-		{common.HexToHash("0x0"), common.HexToHash("0x1").Bytes()},
-		{common.HexToHash("0x1"), common.HexToHash("0xdeadbeef").Bytes()},
-		{common.HexToHash("0x2"), common.HexToHash("0x1234567890abcdef").Bytes()},
-		{common.HexToHash("0x100"), common.HexToHash("0xff").Bytes()},
+		{common.HexToHash("0x0"), v1[:]},
+		{common.HexToHash("0x1"), v2[:]},
+		{common.HexToHash("0x2"), v3[:]},
+		{common.HexToHash("0x100"), v4[:]},
 	}
 
 	// Insert storage using composite keys: addressHash + keccak256(slot)
@@ -809,24 +813,26 @@ func TestRLPEncodeDecodeWithAccountsAndStorage(t *testing.T) {
 	for _, slot := range storageSlots1 {
 		compositeKey := make([]byte, 64)
 		copy(compositeKey[:32], contract1AddrHash[:])
-		copy(compositeKey[32:], crypto.Keccak256(slot.slot.Bytes()))
+		copy(compositeKey[32:], crypto.Keccak256(slot.slot[:]))
 		stateTrie.Update(compositeKey, slot.value)
 	}
 
 	// Define storage for contract at index 3
 	contract2AddrHash := addrHashes[3]
+	v5 := common.HexToHash("0xabcd")
+	v6 := common.HexToHash("0x9999")
 	storageSlots2 := []struct {
 		slot  common.Hash
 		value []byte
 	}{
-		{common.HexToHash("0x0"), common.HexToHash("0xabcd").Bytes()},
-		{common.HexToHash("0x5"), common.HexToHash("0x9999").Bytes()},
+		{common.HexToHash("0x0"), v5[:]},
+		{common.HexToHash("0x5"), v6[:]},
 	}
 
 	for _, slot := range storageSlots2 {
 		compositeKey := make([]byte, 64)
 		copy(compositeKey[:32], contract2AddrHash[:])
-		copy(compositeKey[32:], crypto.Keccak256(slot.slot.Bytes()))
+		copy(compositeKey[32:], crypto.Keccak256(slot.slot[:]))
 		stateTrie.Update(compositeKey, slot.value)
 	}
 
@@ -861,7 +867,7 @@ func TestRLPEncodeDecodeWithAccountsAndStorage(t *testing.T) {
 	require.GreaterOrEqual(t, len(encoded), 10, "should have multiple nodes for accounts + storage")
 
 	for i, addr := range addresses {
-		key := crypto.Keccak256(addr.Bytes())
+		key := crypto.Keccak256(addr[:])
 		acc, ok := decodedStateTrie.GetAccount(key)
 		require.True(t, ok)
 		require.EqualValues(t, testAccounts[i], acc)

--- a/execution/commitment/trie/witness.go
+++ b/execution/commitment/trie/witness.go
@@ -172,7 +172,7 @@ func (w *Witness) WriteDiff(w2 *Witness, output io.Writer) {
 			if !ok {
 				fmt.Fprintf(output, "o1[%d] = %T %+v; o2[%d] = %T %+v\n", i, o1, o1, i, o2, o2)
 			}
-			if !bytes.Equal(o1.Hash.Bytes(), o2.Hash.Bytes()) {
+			if !bytes.Equal(o1.Hash[:], o2.Hash[:]) {
 				fmt.Fprintf(output, "o1[%d].Hash = %s; o2[%d].Hash = %s\n", i, o1.Hash.Hex(), i, o2.Hash.Hex())
 			}
 		case *OperatorCode:

--- a/execution/execmodule/bal_selfdestruct_systemaddress_test.go
+++ b/execution/execmodule/bal_selfdestruct_systemaddress_test.go
@@ -37,7 +37,7 @@ import (
 func pushAddrSelfdestruct(addr common.Address) []byte {
 	out := make([]byte, 0, 22)
 	out = append(out, 0x73)
-	out = append(out, addr.Bytes()...)
+	out = append(out, addr[:]...)
 	out = append(out, 0xff)
 	return out
 }

--- a/execution/protocol/misc/eip2935.go
+++ b/execution/protocol/misc/eip2935.go
@@ -45,6 +45,6 @@ func StoreBlockHashesEip2935(header *types.Header, state *state.IntraBlockState)
 func storeHash(num uint64, hash common.Hash, state *state.IntraBlockState) error {
 	slotNum := num % params.BlockHashHistoryServeWindow
 	storageSlot := common.BytesToHash(uint256.NewInt(slotNum).Bytes())
-	parentHashInt := uint256.NewInt(0).SetBytes32(hash.Bytes())
+	parentHashInt := uint256.NewInt(0).SetBytes32(hash[:])
 	return state.SetState(params.HistoryStorageAddress, accounts.InternKey(storageSlot), *parentHashInt)
 }

--- a/execution/protocol/misc/eip4788.go
+++ b/execution/protocol/misc/eip4788.go
@@ -42,7 +42,7 @@ func ApplyBeaconRootEip4788(
 		defer tracer.OnSystemCallEnd()
 	}
 
-	_, err := syscall(params.BeaconRootsAddress, parentBeaconBlockRoot.Bytes())
+	_, err := syscall(params.BeaconRootsAddress, parentBeaconBlockRoot[:])
 	if err != nil {
 		log.Warn("Failed to call beacon roots contract", "err", err)
 	}

--- a/execution/protocol/rules/ethash/forkchoice.go
+++ b/execution/protocol/rules/ethash/forkchoice.go
@@ -39,5 +39,5 @@ func ShouldReorg(localTd *uint256.Int, localHeight uint64, localHash common.Hash
 	if newHeight != localHeight {
 		return newHeight < localHeight
 	}
-	return bytes.Compare(localHash.Bytes(), newHash.Bytes()) < 0
+	return bytes.Compare(localHash[:], newHash[:]) < 0
 }

--- a/execution/protocol/rules/ethash/rules.go
+++ b/execution/protocol/rules/ethash/rules.go
@@ -354,6 +354,7 @@ func (ethash *Ethash) verifySeal(header *types.Header, fulldag bool) error { //n
 	}
 	// Recompute the digest and PoW values
 	number := header.Number.Uint64()
+	sealHash := ethash.SealHash(header)
 
 	var (
 		digest []byte
@@ -363,7 +364,7 @@ func (ethash *Ethash) verifySeal(header *types.Header, fulldag bool) error { //n
 	if fulldag {
 		dataset := ethash.dataset(number, true)
 		if dataset.generated() {
-			digest, result = hashimotoFull(dataset.dataset, ethash.SealHash(header).Bytes(), header.Nonce.Uint64())
+			digest, result = hashimotoFull(dataset.dataset, sealHash[:], header.Nonce.Uint64())
 
 			// Datasets are unmapped in a finalizer. Ensure that the dataset stays alive
 			// until after the call to hashimotoFull so it's not unmapped while being used.
@@ -381,7 +382,7 @@ func (ethash *Ethash) verifySeal(header *types.Header, fulldag bool) error { //n
 		if ethash.config.PowMode == ethashcfg.ModeTest {
 			size = 32 * 1024
 		}
-		digest, result = hashimotoLight(size, cache.cache, ethash.SealHash(header).Bytes(), header.Nonce.Uint64())
+		digest, result = hashimotoLight(size, cache.cache, sealHash[:], header.Nonce.Uint64())
 
 		// Caches are unmapped in a finalizer. Ensure that the cache stays alive
 		// until after the call to hashimotoLight so it's not unmapped while being used.

--- a/execution/stagedsync/bodydownload/body_algos.go
+++ b/execution/stagedsync/bodydownload/body_algos.go
@@ -155,10 +155,10 @@ func (bd *BodyDownload) RequestMoreBodies(tx kv.RwTx, blockReader services.FullB
 		}
 		if request {
 			var bodyHashes BodyHashes
-			copy(bodyHashes[:], header.UncleHash.Bytes())
-			copy(bodyHashes[length.Hash:], header.TxHash.Bytes())
+			copy(bodyHashes[:], header.UncleHash[:])
+			copy(bodyHashes[length.Hash:], header.TxHash[:])
 			if header.WithdrawalsHash != nil {
-				copy(bodyHashes[2*length.Hash:], header.WithdrawalsHash.Bytes())
+				copy(bodyHashes[2*length.Hash:], header.WithdrawalsHash[:])
 			}
 			bd.requestedMap[bodyHashes] = blockNum
 			blockNums = append(blockNums, blockNum)
@@ -295,12 +295,12 @@ Loop:
 		for i := range txs {
 			var bodyHashes BodyHashes
 			uncleHash := types.CalcUncleHash(uncles[i])
-			copy(bodyHashes[:], uncleHash.Bytes())
+			copy(bodyHashes[:], uncleHash[:])
 			txHash := types.DeriveSha(RawTransactions(txs[i]))
-			copy(bodyHashes[length.Hash:], txHash.Bytes())
+			copy(bodyHashes[length.Hash:], txHash[:])
 			if withdrawals[i] != nil {
 				withdrawalsHash := types.DeriveSha(withdrawals[i])
-				copy(bodyHashes[2*length.Hash:], withdrawalsHash.Bytes())
+				copy(bodyHashes[2*length.Hash:], withdrawalsHash[:])
 			}
 
 			// Block numbers are added to the bd.delivered bitmap here, only for blocks for which the body has been received, and their double hashes are present in the bd.requestedMap

--- a/execution/stagedsync/calc_state_test.go
+++ b/execution/stagedsync/calc_state_test.go
@@ -420,7 +420,8 @@ func TestSDOfPreExistingContract_FullPipeline(t *testing.T) {
 
 	updates := newTestUpdates()
 	cs.FlushToUpdates(updates)
-	got := lookupKeyUpdate(t, updates, string(addr.Value().Bytes()))
+	addrVal := addr.Value()
+	got := lookupKeyUpdate(t, updates, string(addrVal[:]))
 
 	// EIP-161-style DeleteUpdate (matches serial's DomainDel for a pure SD).
 	assert.Equal(t, commitment.DeleteUpdate, got.Flags,

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -338,7 +338,7 @@ func (cc *commitmentCalculator) computeAndPublish(ctx context.Context, br *block
 	}
 
 	// Check against expected root from the block header.
-	if !bytes.Equal(rh, br.StateRoot.Bytes()) {
+	if !bytes.Equal(rh, br.StateRoot[:]) {
 		r.err = fmt.Errorf("%w: block %d root %x expected %x", ErrWrongTrieRoot, br.BlockNum, rh, br.StateRoot)
 	}
 
@@ -438,7 +438,7 @@ func (cc *commitmentCalculator) computeAndCheck(ctx context.Context, br *blockRe
 	cc.hasComputed = true
 
 	// Only publish on mismatch — success is silent.
-	if mismatch := !bytes.Equal(rh, br.StateRoot.Bytes()); mismatch {
+	if mismatch := !bytes.Equal(rh, br.StateRoot[:]); mismatch {
 		cc.publish(ctx, commitmentResult{
 			blockNum: br.BlockNum,
 			txNum:    br.lastTxNum,

--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -779,8 +779,8 @@ func computeAndCheckCommitmentV3(ctx context.Context, header *types.Header, appl
 		return false, times, fmt.Errorf("compute commitment: %w", err)
 	}
 
-	if !bytes.Equal(computedRootHash, header.Root.Bytes()) {
-		logger.Warn(fmt.Sprintf("[%s] Wrong trie root of block %d: %x, expected (from header): %x. Block hash: %x", e.LogPrefix(), header.Number.Uint64(), computedRootHash, header.Root.Bytes(), header.Hash()))
+	if !bytes.Equal(computedRootHash, header.Root[:]) {
+		logger.Warn(fmt.Sprintf("[%s] Wrong trie root of block %d: %x, expected (from header): %x. Block hash: %x", e.LogPrefix(), header.Number.Uint64(), computedRootHash, header.Root[:], header.Hash()))
 		err = handleIncorrectRootHashError(header.Number.Uint64(), header.Hash(), header.ParentHash, applyTx, cfg, e, logger, u)
 		return false, times, err
 	}

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -203,8 +203,8 @@ func (se *serialExecutor) exec(ctx context.Context, execStage *StageState, u Unw
 			}
 			se.doms.SetChangesetAccumulator(nil)
 
-			if !bytes.Equal(rh, header.Root.Bytes()) {
-				se.logger.Error(fmt.Sprintf("[%s] Wrong trie root of block %d: %x, expected (from header): %x. Block hash: %x", se.logPrefix, header.Number.Uint64(), rh, header.Root.Bytes(), header.Hash()))
+			if !bytes.Equal(rh, header.Root[:]) {
+				se.logger.Error(fmt.Sprintf("[%s] Wrong trie root of block %d: %x, expected (from header): %x. Block hash: %x", se.logPrefix, header.Number.Uint64(), rh, header.Root[:], header.Hash()))
 				return b.HeaderNoCopy(), rwTx, fmt.Errorf("%w, block=%d", ErrWrongTrieRoot, blockNum)
 			}
 		}

--- a/execution/stagedsync/headerdownload/header_algo_test.go
+++ b/execution/stagedsync/headerdownload/header_algo_test.go
@@ -79,9 +79,11 @@ func TestSideChainInsert(t *testing.T) {
 	// Same side chain (in terms of number and difficulty) but different hash
 	chain7 := createTestChain(2, genesis.Hash(), 5, []byte("side7"))
 
-	finalExpectedHash := chain5[len(chain5)-1].Hash()
-	if bytes.Compare(chain5[len(chain5)-1].Hash().Bytes(), chain7[len(chain7)-1].Hash().Bytes()) < 0 {
-		finalExpectedHash = chain7[len(chain7)-1].Hash()
+	chain5Last := chain5[len(chain5)-1].Hash()
+	chain7Last := chain7[len(chain7)-1].Hash()
+	finalExpectedHash := chain5Last
+	if bytes.Compare(chain5Last[:], chain7Last[:]) < 0 {
+		finalExpectedHash = chain7Last
 	}
 
 	testCases := []struct {

--- a/execution/stagedsync/stage_txlookup.go
+++ b/execution/stagedsync/stage_txlookup.go
@@ -133,7 +133,8 @@ func txnLookupTransform(logPrefix string, tx kv.RwTx, blockFrom, blockTo uint64,
 
 		for i, txn := range body.Transactions {
 			binary.BigEndian.PutUint64(data[8:], firstTxNumInBlock+uint64(i)+1)
-			if err := next(k, txn.Hash().Bytes(), data); err != nil {
+			txHash := txn.Hash()
+			if err := next(k, txHash[:], data); err != nil {
 				return err
 			}
 		}
@@ -328,7 +329,8 @@ func deleteTxLookupRange(tx kv.RwTx, logPrefix string, blockFrom, blockTo uint64
 		}
 
 		for _, txn := range body.Transactions {
-			if err := next(k, txn.Hash().Bytes(), nil); err != nil {
+			txHash := txn.Hash()
+			if err := next(k, txHash[:], nil); err != nil {
 				return err
 			}
 		}

--- a/execution/state/dump.go
+++ b/execution/state/dump.go
@@ -228,11 +228,12 @@ func (d *Dumper) DumpToCollector(ctx context.Context, c DumpCollector, excludeCo
 				loc := k[20:]
 				account.Storage[common.BytesToHash(loc).String()] = common.Bytes2Hex(vs)
 				h, _ := common.HashData(loc)
-				t.Update(h.Bytes(), common.Copy(vs))
+				t.Update(h[:], common.Copy(vs))
 			}
 			r.Close()
 
-			account.Root = t.Hash().Bytes()
+			tHash := t.Hash()
+			account.Root = tHash[:]
 		}
 		account.Address = &addr
 		seckey, secErr := common.HashData(addr[:])

--- a/execution/state/genesiswrite/genesis_write.go
+++ b/execution/state/genesiswrite/genesis_write.go
@@ -439,7 +439,7 @@ func ComputeGenesisCommitment(ctx context.Context, g *types.Genesis, tx kv.Tempo
 		}
 		var slotVal uint256.Int
 		for key, value := range account.Storage {
-			slotVal.SetBytes(value.Bytes())
+			slotVal.SetBytes(value[:])
 			err = statedb.SetState(address, accounts.InternKey(key), slotVal)
 			if err != nil {
 				return nil, nil, err
@@ -580,7 +580,7 @@ func sortedAllocKeys(m types.GenesisAlloc) []string {
 	keys := make([]string, len(m))
 	i := 0
 	for k := range m {
-		keys[i] = string(k.Bytes())
+		keys[i] = string(k[:])
 		i++
 	}
 	slices.Sort(keys)

--- a/execution/state/triedb_state.go
+++ b/execution/state/triedb_state.go
@@ -386,7 +386,7 @@ func (tds *TrieDbState) buildAccountAddressReads() ([][]byte, [][]byte) {
 			panic("could not reproduce addrHash found in the map")
 		}
 		accountAddresses = append(accountAddresses, addressValue[:])
-		accountAddressHashes = append(accountAddressHashes, addrHash.Bytes())
+		accountAddressHashes = append(accountAddressHashes, addrHash[:])
 	}
 
 	// Create a slice of indices to track original positions

--- a/execution/tests/blockchain_test.go
+++ b/execution/tests/blockchain_test.go
@@ -1196,8 +1196,10 @@ func TestBlockchainHeaderchainReorgConsistency(t *testing.T) {
 				return err
 			}
 			h := rawdb.ReadCurrentHeader(tx)
-			if b.Hash() != h.Hash() {
-				t.Errorf("block %d: current block/header mismatch: block #%d [%x…], header #%d [%x…]", i, b.Number(), b.Hash().Bytes()[:4], h.Number, h.Hash().Bytes()[:4])
+			bHash := b.Hash()
+			hHash := h.Hash()
+			if bHash != hHash {
+				t.Errorf("block %d: current block/header mismatch: block #%d [%x…], header #%d [%x…]", i, b.Number(), bHash[:4], h.Number, hHash[:4])
 			}
 			if err := m2.InsertChain(forks[i]); err != nil {
 				t.Fatalf(" fork %d: failed to insert into chain: %v", i, err)
@@ -1207,8 +1209,10 @@ func TestBlockchainHeaderchainReorgConsistency(t *testing.T) {
 				return err
 			}
 			h = rawdb.ReadCurrentHeader(tx)
-			if b.Hash() != h.Hash() {
-				t.Errorf(" fork %d: current block/header mismatch: block #%d [%x…], header #%d [%x…]", i, b.Number(), b.Hash().Bytes()[:4], h.Number, h.Hash().Bytes()[:4])
+			bHash2 := b.Hash()
+			hHash2 := h.Hash()
+			if bHash2 != hHash2 {
+				t.Errorf(" fork %d: current block/header mismatch: block #%d [%x…], header #%d [%x…]", i, b.Number(), bHash2[:4], h.Number, hHash2[:4])
 			}
 			return nil
 		}); err != nil {

--- a/execution/tests/testutil/block_test_util.go
+++ b/execution/tests/testutil/block_test_util.go
@@ -228,11 +228,13 @@ func (bt *BlockTest) Run(t *testing.T) error {
 
 	bt.br = m.BlockReader
 	// import pre accounts & construct test genesis block & state root
-	if m.Genesis.Hash() != bt.json.Genesis.Hash {
-		return fmt.Errorf("genesis block hash doesn't match test: computed=%x, test=%x", m.Genesis.Hash().Bytes()[:6], bt.json.Genesis.Hash[:6])
+	genesisHash := m.Genesis.Hash()
+	if genesisHash != bt.json.Genesis.Hash {
+		return fmt.Errorf("genesis block hash doesn't match test: computed=%x, test=%x", genesisHash[:6], bt.json.Genesis.Hash[:6])
 	}
-	if m.Genesis.Root() != bt.json.Genesis.StateRoot {
-		return fmt.Errorf("genesis block state root does not match test: computed=%x, test=%x", m.Genesis.Root().Bytes()[:6], bt.json.Genesis.StateRoot[:6])
+	genesisRoot := m.Genesis.Root()
+	if genesisRoot != bt.json.Genesis.StateRoot {
+		return fmt.Errorf("genesis block state root does not match test: computed=%x, test=%x", genesisRoot[:6], bt.json.Genesis.StateRoot[:6])
 	}
 
 	validBlocks, err := bt.insertBlocks(m)
@@ -270,11 +272,13 @@ func (bt *BlockTest) RunCLI() error {
 
 	bt.br = m.BlockReader
 	// import pre accounts & construct test genesis block & state root
-	if m.Genesis.Hash() != bt.json.Genesis.Hash {
-		return fmt.Errorf("genesis block hash doesn't match test: computed=%x, test=%x", m.Genesis.Hash().Bytes()[:6], bt.json.Genesis.Hash[:6])
+	genesisHash := m.Genesis.Hash()
+	if genesisHash != bt.json.Genesis.Hash {
+		return fmt.Errorf("genesis block hash doesn't match test: computed=%x, test=%x", genesisHash[:6], bt.json.Genesis.Hash[:6])
 	}
-	if m.Genesis.Root() != bt.json.Genesis.StateRoot {
-		return fmt.Errorf("genesis block state root does not match test: computed=%x, test=%x", m.Genesis.Root().Bytes()[:6], bt.json.Genesis.StateRoot[:6])
+	genesisRoot := m.Genesis.Root()
+	if genesisRoot != bt.json.Genesis.StateRoot {
+		return fmt.Errorf("genesis block state root does not match test: computed=%x, test=%x", genesisRoot[:6], bt.json.Genesis.StateRoot[:6])
 	}
 
 	validBlocks, err := bt.insertBlocks(m)
@@ -515,7 +519,7 @@ func (bt *BlockTest) validatePostState(statedb *state.IntraBlockState) error {
 			return fmt.Errorf("account balance mismatch for addr: %x, want: %d, have: %d", addr, acct.Balance, &balance2)
 		}
 		for loc, val := range acct.Storage {
-			val1 := uint256.NewInt(0).SetBytes(val.Bytes())
+			val1 := uint256.NewInt(0).SetBytes(val[:])
 			val2, _ := statedb.GetState(address, accounts.InternKey(loc))
 			if !val1.Eq(&val2) {
 				return fmt.Errorf("storage mismatch for addr: %x loc: %x want: %d have: %d", addr, loc, val1, &val2)

--- a/execution/tests/testutil/state_test_util.go
+++ b/execution/tests/testutil/state_test_util.go
@@ -435,7 +435,7 @@ func MakePreState(rules *chain.Rules, tx kv.TemporalRwTx, alloc types.GenesisAll
 		statedb.SetBalance(address, balance, tracing.BalanceIncreaseGenesisBalance)
 		for k, v := range a.Storage {
 			key := accounts.InternKey(k)
-			val := uint256.NewInt(0).SetBytes(v.Bytes())
+			val := uint256.NewInt(0).SetBytes(v[:])
 			statedb.SetState(address, key, *val)
 		}
 

--- a/execution/tracing/tracers/js/goja.go
+++ b/execution/tracing/tracers/js/goja.go
@@ -148,10 +148,10 @@ func newJsTracer(code string, ctx *tracers.Context, cfg json.RawMessage) (*trace
 		ctx = new(tracers.Context)
 	}
 	if ctx.BlockHash != (common.Hash{}) {
-		t.ctx["blockHash"] = vm.ToValue(ctx.BlockHash.Bytes())
+		t.ctx["blockHash"] = vm.ToValue(ctx.BlockHash[:])
 		if ctx.TxHash != (common.Hash{}) {
 			t.ctx["txIndex"] = vm.ToValue(ctx.TxIndex)
-			t.ctx["txHash"] = vm.ToValue(ctx.TxHash.Bytes())
+			t.ctx["txHash"] = vm.ToValue(ctx.TxHash[:])
 		}
 	}
 
@@ -449,7 +449,8 @@ func (t *jsTracer) setBuiltinFunctions() {
 			vm.Interrupt(err)
 			return nil
 		}
-		b = common.BytesToHash(b).Bytes()
+		word := common.BytesToHash(b)
+		b = word[:]
 		res, err := t.toBuf(vm, b)
 		if err != nil {
 			vm.Interrupt(err)
@@ -463,7 +464,8 @@ func (t *jsTracer) setBuiltinFunctions() {
 			vm.Interrupt(err)
 			return nil
 		}
-		a = common.BytesToAddress(a).Bytes()
+		addr := common.BytesToAddress(a)
+		a = addr[:]
 		res, err := t.toBuf(vm, a)
 		if err != nil {
 			vm.Interrupt(err)
@@ -478,7 +480,8 @@ func (t *jsTracer) setBuiltinFunctions() {
 			return nil
 		}
 		addr := common.BytesToAddress(a)
-		b := types.CreateAddress(addr, uint64(nonce)).Bytes()
+		contractAddr := types.CreateAddress(addr, uint64(nonce))
+		b := contractAddr[:]
 		res, err := t.toBuf(vm, b)
 		if err != nil {
 			vm.Interrupt(err)
@@ -500,7 +503,8 @@ func (t *jsTracer) setBuiltinFunctions() {
 		}
 		code = common.Copy(code)
 		codeHash := accounts.InternCodeHash(crypto.HashData(code))
-		b := types.CreateAddress2(addr, common.HexToHash(salt), codeHash).Bytes()
+		contractAddr := types.CreateAddress2(addr, common.HexToHash(salt), codeHash)
+		b := contractAddr[:]
 		res, err := t.toBuf(vm, b)
 		if err != nil {
 			vm.Interrupt(err)

--- a/execution/types/aa_abi.go
+++ b/execution/types/aa_abi.go
@@ -103,9 +103,9 @@ func EncodeRIP7560TransactionEvent(
 		return nil, nil, err
 	}
 	topics = []common.Hash{id, {}, {}, {}}
-	topics[1] = [32]byte(common.LeftPadBytes(sender.Bytes(), 32))
-	topics[2] = [32]byte(common.LeftPadBytes(paymaster.Bytes(), 32))
-	topics[3] = [32]byte(common.LeftPadBytes(deployer.Bytes(), 32))
+	topics[1] = [32]byte(common.LeftPadBytes(sender[:], 32))
+	topics[2] = [32]byte(common.LeftPadBytes(paymaster[:], 32))
+	topics[3] = [32]byte(common.LeftPadBytes(deployer[:], 32))
 	return topics, data, nil
 }
 
@@ -118,9 +118,9 @@ func EncodeRIP7560AccountDeployedEvent(paymaster, deployer, sender *common.Addre
 		deployer = &common.Address{}
 	}
 	topics = []common.Hash{id, {}, {}, {}}
-	topics[1] = [32]byte(common.LeftPadBytes(sender.Bytes(), 32))
-	topics[2] = [32]byte(common.LeftPadBytes(paymaster.Bytes(), 32))
-	topics[3] = [32]byte(common.LeftPadBytes(deployer.Bytes(), 32))
+	topics[1] = [32]byte(common.LeftPadBytes(sender[:], 32))
+	topics[2] = [32]byte(common.LeftPadBytes(paymaster[:], 32))
+	topics[3] = [32]byte(common.LeftPadBytes(deployer[:], 32))
 	return topics, make([]byte, 0), nil
 }
 
@@ -141,7 +141,7 @@ func EncodeRIP7560TransactionRevertReasonEvent(
 		return nil, nil, err
 	}
 	topics = []common.Hash{id, {}}
-	topics[1] = [32]byte(common.LeftPadBytes(sender.Bytes(), 32))
+	topics[1] = [32]byte(common.LeftPadBytes(sender[:], 32))
 	return topics, data, nil
 }
 
@@ -165,8 +165,8 @@ func EncodeRIP7560TransactionPostOpRevertReasonEvent(
 		return nil, nil, err
 	}
 	topics = []common.Hash{id, {}, {}}
-	topics[1] = [32]byte(common.LeftPadBytes(sender.Bytes(), 32))
-	topics[2] = [32]byte(common.LeftPadBytes(paymaster.Bytes(), 32))
+	topics[1] = [32]byte(common.LeftPadBytes(sender[:], 32))
+	topics[2] = [32]byte(common.LeftPadBytes(paymaster[:], 32))
 	return topics, data, nil
 }
 

--- a/execution/types/authorization.go
+++ b/execution/types/authorization.go
@@ -86,7 +86,7 @@ func RecoverSignerFromRLP(rlp []byte, yParity uint8, r uint256.Int, s uint256.In
 		return nil, errors.New("invalid signature")
 	}
 
-	pubKey, err := crypto.Ecrecover(hash.Bytes(), sig[:])
+	pubKey, err := crypto.Ecrecover(hash[:], sig[:])
 	if err != nil {
 		return nil, err
 	}

--- a/execution/types/block.go
+++ b/execution/types/block.go
@@ -1183,7 +1183,7 @@ func CopyHeader(h *Header) *Header {
 	}
 	if h.WithdrawalsHash != nil {
 		cpy.WithdrawalsHash = new(common.Hash)
-		cpy.WithdrawalsHash.SetBytes(h.WithdrawalsHash.Bytes())
+		cpy.WithdrawalsHash.SetBytes(h.WithdrawalsHash[:])
 	}
 	if h.BlobGasUsed != nil {
 		blobGasUsed := *h.BlobGasUsed
@@ -1195,15 +1195,15 @@ func CopyHeader(h *Header) *Header {
 	}
 	if h.ParentBeaconBlockRoot != nil {
 		cpy.ParentBeaconBlockRoot = new(common.Hash)
-		cpy.ParentBeaconBlockRoot.SetBytes(h.ParentBeaconBlockRoot.Bytes())
+		cpy.ParentBeaconBlockRoot.SetBytes(h.ParentBeaconBlockRoot[:])
 	}
 	if h.RequestsHash != nil {
 		cpy.RequestsHash = new(common.Hash)
-		cpy.RequestsHash.SetBytes(h.RequestsHash.Bytes())
+		cpy.RequestsHash.SetBytes(h.RequestsHash[:])
 	}
 	if h.BlockAccessListHash != nil {
 		cpy.BlockAccessListHash = new(common.Hash)
-		cpy.BlockAccessListHash.SetBytes(h.BlockAccessListHash.Bytes())
+		cpy.BlockAccessListHash.SetBytes(h.BlockAccessListHash[:])
 	}
 	if h.SlotNumber != nil {
 		slotNumber := *h.SlotNumber

--- a/execution/types/bloom9_test.go
+++ b/execution/types/bloom9_test.go
@@ -145,6 +145,7 @@ func BenchmarkCreateBloom(b *testing.B) {
 		NewContractCreation(1, one, 1, one, nil),
 		NewTransaction(2, common.HexToAddress("0x2"), two, 2, two, nil),
 	}
+	postState := common.Hash{2}
 	var rSmall = Receipts{
 		&Receipt{
 			Status:            ReceiptStatusFailed,
@@ -158,7 +159,7 @@ func BenchmarkCreateBloom(b *testing.B) {
 			GasUsed:         1,
 		},
 		&Receipt{
-			PostState:         common.Hash{2}.Bytes(),
+			PostState:         postState[:],
 			CumulativeGasUsed: 3,
 			Logs: []*Log{
 				{Address: common.BytesToAddress([]byte{0x22})},

--- a/execution/vm/eips.go
+++ b/execution/vm/eips.go
@@ -273,7 +273,7 @@ func opBlobHash(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error)
 	idx := scope.Stack.peek()
 	if idx.LtUint64(uint64(len(evm.BlobHashes))) {
 		hash := evm.BlobHashes[idx.Uint64()]
-		idx.SetBytes(hash.Bytes())
+		idx.SetBytes(hash[:])
 	} else {
 		idx.Clear()
 	}

--- a/execution/vm/instructions.go
+++ b/execution/vm/instructions.go
@@ -691,7 +691,7 @@ func opBlockhash(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error
 			arg.Clear()
 			return pc, nil, err
 		}
-		arg.SetBytes(hash.Bytes())
+		arg.SetBytes(hash[:])
 	} else {
 		arg.Clear()
 	}
@@ -736,7 +736,7 @@ func opDifficulty(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, erro
 	var v uint256.Int
 	if evm.Context.PrevRanDao != nil {
 		// EIP-4399: Supplant DIFFICULTY opcode with PREVRANDAO
-		v.SetBytes32(evm.Context.PrevRanDao.Bytes())
+		v.SetBytes32(evm.Context.PrevRanDao[:])
 	} else {
 		v = evm.Context.Difficulty
 	}

--- a/execution/vm/instructions_test.go
+++ b/execution/vm/instructions_test.go
@@ -691,7 +691,7 @@ func TestCreate2Addreses(t *testing.T) {
 			fmt.Printf("Example %d\n* address `0x%x`\n* salt `0x%x`\n* init_code `0x%x`\n* gas (assuming no mem expansion): `%v`\n* result: `%s`\n\n", i,origin, salt, code, gas, address.String())
 		*/
 		expected := common.BytesToAddress(common.FromHex(tt.expected))
-		if !bytes.Equal(expected.Bytes(), address.Bytes()) {
+		if !bytes.Equal(expected[:], address[:]) {
 			t.Errorf("test %d: expected %s, got %s", i, expected.String(), address.String())
 		}
 	}

--- a/execution/vm/program/program.go
+++ b/execution/vm/program/program.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/holiman/uint256"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/execution/vm"
 )
 
@@ -128,11 +129,14 @@ func (p *Program) Push(val any) *Program {
 		p.doPush(new(uint256.Int).SetBytes(v))
 	case byte:
 		p.doPush(new(uint256.Int).SetUint64(uint64(v)))
-	case interface{ Bytes() []byte }:
-		// Here, we jump through some hoops in order to avoid depending on
-		// go-ethereum accounts.Address and common.Hash, and instead use the
-		// interface. This works on both values and pointers!
-		p.doPush(new(uint256.Int).SetBytes(v.Bytes()))
+	case common.Address:
+		p.doPush(new(uint256.Int).SetBytes(v[:]))
+	case *common.Address:
+		p.doPush(new(uint256.Int).SetBytes(v[:]))
+	case common.Hash:
+		p.doPush(new(uint256.Int).SetBytes(v[:]))
+	case *common.Hash:
+		p.doPush(new(uint256.Int).SetBytes(v[:]))
 	case nil:
 		p.doPush(nil)
 	default:

--- a/node/privateapi/logsfilter_test.go
+++ b/node/privateapi/logsfilter_test.go
@@ -43,7 +43,7 @@ var (
 
 func init() {
 	var a common.Address
-	a.SetBytes(address1.Bytes())
+	a.SetBytes(address1[:])
 	address160 = gointerfaces.ConvertAddressToH160(a)
 	topic1H256 = gointerfaces.ConvertHashToH256(topic1)
 }
@@ -191,7 +191,7 @@ func TestLogsFilter_AllAddressesAndTopicsFilter_DistributesLogRegardless(t *test
 
 	lg = createLog()
 	var addr common.Address
-	addr.SetBytes(address1.Bytes())
+	addr.SetBytes(address1[:])
 	lg.Address = addr
 	_ = agg.distributeLogs([]*notifications.LogNotification{lg})
 	if len(srv.sent) != 3 {
@@ -271,7 +271,7 @@ func TestLogsFilter_AddressFilter_OnlyAllowsThatAddressThrough(t *testing.T) {
 
 	lg = createLog()
 	var addr common.Address
-	addr.SetBytes(address1.Bytes())
+	addr.SetBytes(address1[:])
 	lg.Address = addr
 	_ = agg.distributeLogs([]*notifications.LogNotification{lg})
 	if len(srv.sent) != 1 {

--- a/node/shards/state_cache.go
+++ b/node/shards/state_cache.go
@@ -147,7 +147,7 @@ type CacheWriteItem interface {
 }
 
 func compare_code_code(i1 *CodeItem, i2 *CodeItem) int {
-	c := bytes.Compare(i1.addrHash.Bytes(), i2.addrHash.Bytes())
+	c := bytes.Compare(i1.addrHash[:], i2.addrHash[:])
 	if c != 0 {
 		return c
 	}
@@ -163,9 +163,9 @@ func compare_code_code(i1 *CodeItem, i2 *CodeItem) int {
 func (r *AccountSeek) Less(than btree.Item) bool {
 	switch i := than.(type) {
 	case *AccountItem:
-		return bytes.Compare(r.seek, i.addrHash.Bytes()) < 0
+		return bytes.Compare(r.seek, i.addrHash[:]) < 0
 	case *AccountWriteItem:
-		return bytes.Compare(r.seek, i.ai.addrHash.Bytes()) < 0
+		return bytes.Compare(r.seek, i.ai.addrHash[:]) < 0
 	default:
 		panic(fmt.Sprintf("unexpected type: %T", than))
 	}
@@ -174,23 +174,23 @@ func (r *AccountSeek) Less(than btree.Item) bool {
 func (r *StorageSeek) Less(than btree.Item) bool {
 	switch i := than.(type) {
 	case *StorageItem:
-		c := bytes.Compare(r.addrHash.Bytes(), i.addrHash.Bytes())
+		c := bytes.Compare(r.addrHash[:], i.addrHash[:])
 		if c != 0 {
 			return c < 0
 		}
 		if r.incarnation < i.incarnation {
 			return true
 		}
-		return bytes.Compare(r.seek, i.locHash.Bytes()) < 0
+		return bytes.Compare(r.seek, i.locHash[:]) < 0
 	case *StorageWriteItem:
-		c := bytes.Compare(r.addrHash.Bytes(), i.si.addrHash.Bytes())
+		c := bytes.Compare(r.addrHash[:], i.si.addrHash[:])
 		if c != 0 {
 			return c < 0
 		}
 		if r.incarnation < i.si.incarnation {
 			return true
 		}
-		return bytes.Compare(r.seek, i.si.locHash.Bytes()) < 0
+		return bytes.Compare(r.seek, i.si.locHash[:]) < 0
 	default:
 		panic(fmt.Sprintf("unexpected type: %T", than))
 	}
@@ -199,11 +199,11 @@ func (r *StorageSeek) Less(than btree.Item) bool {
 func (ai *AccountItem) Less(than btree.Item) bool {
 	switch i := than.(type) {
 	case *AccountItem:
-		return bytes.Compare(ai.addrHash.Bytes(), i.addrHash.Bytes()) < 0
+		return bytes.Compare(ai.addrHash[:], i.addrHash[:]) < 0
 	case *AccountWriteItem:
-		return bytes.Compare(ai.addrHash.Bytes(), i.ai.addrHash.Bytes()) < 0
+		return bytes.Compare(ai.addrHash[:], i.ai.addrHash[:]) < 0
 	case *AccountSeek:
-		return bytes.Compare(ai.addrHash.Bytes(), i.seek) < 0
+		return bytes.Compare(ai.addrHash[:], i.seek) < 0
 	default:
 		panic(fmt.Sprintf("unexpected type: %T", than))
 	}
@@ -244,32 +244,32 @@ func (swi *StorageWriteItem) GetSize() int                { return storageWriteI
 func (si *StorageItem) Less(than btree.Item) bool {
 	switch i := than.(type) {
 	case *StorageItem:
-		c := bytes.Compare(si.addrHash.Bytes(), i.addrHash.Bytes())
+		c := bytes.Compare(si.addrHash[:], i.addrHash[:])
 		if c != 0 {
 			return c < 0
 		}
 		if si.incarnation < i.incarnation {
 			return true
 		}
-		return bytes.Compare(si.locHash.Bytes(), i.locHash.Bytes()) < 0
+		return bytes.Compare(si.locHash[:], i.locHash[:]) < 0
 	case *StorageWriteItem:
-		c := bytes.Compare(si.addrHash.Bytes(), i.si.addrHash.Bytes())
+		c := bytes.Compare(si.addrHash[:], i.si.addrHash[:])
 		if c != 0 {
 			return c < 0
 		}
 		if si.incarnation < i.si.incarnation {
 			return true
 		}
-		return bytes.Compare(si.locHash.Bytes(), i.si.locHash.Bytes()) < 0
+		return bytes.Compare(si.locHash[:], i.si.locHash[:]) < 0
 	case *StorageSeek:
-		c := bytes.Compare(si.addrHash.Bytes(), i.addrHash.Bytes())
+		c := bytes.Compare(si.addrHash[:], i.addrHash[:])
 		if c != 0 {
 			return c < 0
 		}
 		if si.incarnation < i.incarnation {
 			return true
 		}
-		return bytes.Compare(si.locHash.Bytes(), i.seek) < 0
+		return bytes.Compare(si.locHash[:], i.seek) < 0
 	default:
 		panic(fmt.Sprintf("unexpected type: %T", than))
 	}
@@ -300,7 +300,7 @@ func (ci *CodeItem) Less(than btree.Item) bool {
 
 func (cwi *CodeWriteItem) Less(than btree.Item) bool {
 	i := than.(*CodeWriteItem)
-	c := bytes.Compare(cwi.address.Bytes(), i.address.Bytes())
+	c := bytes.Compare(cwi.address[:], i.address[:])
 	if c == 0 {
 		return cwi.ci.incarnation < i.ci.incarnation
 	}
@@ -453,7 +453,7 @@ func (sc *StateCache) HasAccountWithInPrefix(addrHashPrefix []byte) bool {
 	seek := &AccountSeek{seek: addrHashPrefix}
 	var found bool
 	sc.readWrites[id(seek)].AscendGreaterOrEqual(seek, func(i btree.Item) bool {
-		found = bytes.HasPrefix(i.(*AccountItem).addrHash.Bytes(), addrHashPrefix)
+		found = bytes.HasPrefix(i.(*AccountItem).addrHash[:], addrHashPrefix)
 		return false
 	})
 	return found
@@ -575,7 +575,7 @@ func (sc *StateCache) SetAccountRead(address []byte, account *accounts.Account) 
 
 func (sc *StateCache) GetAccountByHashedAddress(addrHash common.Hash) (*accounts.Account, bool) {
 	var key AccountItem
-	key.addrHash.SetBytes(addrHash.Bytes())
+	key.addrHash.SetBytes(addrHash[:])
 	if item, ok := sc.get(&key); ok {
 		if item != nil {
 			return &item.(*AccountItem).account, true
@@ -886,31 +886,31 @@ func WalkWrites(
 			switch it := i.(type) {
 			case *AccountWriteItem:
 				if it.ai.flags&AbsentFlag != 0 {
-					if err = accountDelete(it.address.Bytes(), &it.ai.account); err != nil {
+					if err = accountDelete(it.address[:], &it.ai.account); err != nil {
 						return false
 					}
 				} else {
-					if err = accountWrite(it.address.Bytes(), &it.ai.account); err != nil {
+					if err = accountWrite(it.address[:], &it.ai.account); err != nil {
 						return false
 					}
 				}
 			case *StorageWriteItem:
 				if it.si.flags&AbsentFlag != 0 {
-					if err = storageDelete(it.address.Bytes(), it.si.incarnation, it.location.Bytes()); err != nil {
+					if err = storageDelete(it.address[:], it.si.incarnation, it.location[:]); err != nil {
 						return false
 					}
 				} else {
-					if err = storageWrite(it.address.Bytes(), it.si.incarnation, it.location.Bytes(), it.si.value.Bytes()); err != nil {
+					if err = storageWrite(it.address[:], it.si.incarnation, it.location[:], it.si.value.Bytes()); err != nil {
 						return false
 					}
 				}
 			case *CodeWriteItem:
 				if it.ci.flags&AbsentFlag != 0 {
-					if err = codeDelete(it.address.Bytes(), it.ci.incarnation); err != nil {
+					if err = codeDelete(it.address[:], it.ci.incarnation); err != nil {
 						return false
 					}
 				} else {
-					if err = codeWrite(it.address.Bytes(), it.ci.incarnation, it.ci.code); err != nil {
+					if err = codeWrite(it.address[:], it.ci.incarnation, it.ci.code); err != nil {
 						return false
 					}
 				}

--- a/node/shards/state_cache_test.go
+++ b/node/shards/state_cache_test.go
@@ -34,9 +34,9 @@ func TestCacheBtreeOrderAccountStorage2(t *testing.T) {
 	sc := NewStateCache(32, datasize.ByteSize(128*accountItemSize))
 	var a1 common.Address
 	a1[0] = 1
-	sc.SetAccountRead(a1.Bytes(), &accounts.Account{})
-	sc.SetAccountWrite(a1.Bytes(), &accounts.Account{Incarnation: 2})
-	x, ok := sc.GetAccount(a1.Bytes())
+	sc.SetAccountRead(a1[:], &accounts.Account{})
+	sc.SetAccountWrite(a1[:], &accounts.Account{Incarnation: 2})
+	x, ok := sc.GetAccount(a1[:])
 	fmt.Printf("%+v,%t\n", x.Incarnation, ok)
 
 }
@@ -47,12 +47,12 @@ func TestCacheBtreeOrderAccountStorage(t *testing.T) {
 	var a1, a2 common.Address
 	a1[0] = 1
 	a2[0] = 2
-	sc.SetAccountWrite(a2.Bytes(), &accounts.Account{})
-	sc.SetAccountWrite(a1.Bytes(), &accounts.Account{})
+	sc.SetAccountWrite(a2[:], &accounts.Account{})
+	sc.SetAccountWrite(a1[:], &accounts.Account{})
 	lastK := make([]byte, 0, 128)
 	curK := make([]byte, 0, 128)
 	if err := sc.WalkAccounts([]byte{}, func(addrHash common.Hash, account *accounts.Account) (bool, error) {
-		curK = append(curK[:0], addrHash.Bytes()...)
+		curK = append(curK[:0], addrHash[:]...)
 		assert.Negative(t, bytes.Compare(lastK, curK))
 		lastK = append(lastK[:0], curK...)
 		return true, nil
@@ -63,30 +63,30 @@ func TestCacheBtreeOrderAccountStorage(t *testing.T) {
 	l1[0] = 42
 	l2[0] = 2
 	l3[0] = 3
-	sc.SetStorageWrite(a1.Bytes(), 1, l1.Bytes(), nil)
-	sc.SetStorageWrite(a1.Bytes(), 1, l2.Bytes(), nil)
-	sc.SetStorageWrite(a2.Bytes(), 1, l3.Bytes(), nil)
+	sc.SetStorageWrite(a1[:], 1, l1[:], nil)
+	sc.SetStorageWrite(a1[:], 1, l2[:], nil)
+	sc.SetStorageWrite(a2[:], 1, l3[:], nil)
 	lastK = lastK[:0]
-	if err := sc.WalkStorage(common.BytesToHash(keccak.NewFastKeccak().Sum(a1.Bytes())), 1, nil, func(locHash common.Hash, val []byte) error {
-		curK = append(curK[:0], locHash.Bytes()...)
+	if err := sc.WalkStorage(common.BytesToHash(keccak.NewFastKeccak().Sum(a1[:])), 1, nil, func(locHash common.Hash, val []byte) error {
+		curK = append(curK[:0], locHash[:]...)
 		assert.Negative(t, bytes.Compare(lastK, curK))
 		lastK = append(lastK[:0], curK...)
 		return nil
 	}); err != nil {
 		t.Fatal(err)
 	}
-	sc.SetCodeWrite(a1.Bytes(), 1, []byte{1})
-	sc.SetCodeWrite(a2.Bytes(), 1, []byte{2})
+	sc.SetCodeWrite(a1[:], 1, []byte{1})
+	sc.SetCodeWrite(a2[:], 1, []byte{2})
 	lastK = lastK[:0]
 	//if err := WalkWrites(sc.PrepareWrites(), nil, nil, nil, nil, func(address []byte, incarnation uint64, code []byte) error {
 	//	i++
 	//	if i == 1 {
-	//		assert.Equal(t, a1.Bytes(), address)
+	//		assert.Equal(t, a1[:], address)
 	//		assert.Equal(t, 1, incarnation)
 	//		assert.Equal(t, []byte{1}, code)
 	//	}
 	//	if i == 2 {
-	//		assert.Equal(t, a2.Bytes(), address)
+	//		assert.Equal(t, a2[:], address)
 	//		assert.Equal(t, 1, incarnation)
 	//		assert.Equal(t, []byte{2}, code)
 	//	}
@@ -103,19 +103,19 @@ func TestAccountReads(t *testing.T) {
 	account1.Balance.SetUint64(1)
 	var addr1 common.Address
 	addr1[0] = 1
-	sc.SetAccountRead(addr1.Bytes(), &account1)
-	if _, ok := sc.GetAccount(addr1.Bytes()); !ok {
+	sc.SetAccountRead(addr1[:], &account1)
+	if _, ok := sc.GetAccount(addr1[:]); !ok {
 		t.Fatalf("Expected to find account with addr1")
 	}
 	var addr2 common.Address
 	addr2[0] = 2
-	if _, ok := sc.GetAccount(addr2.Bytes()); ok {
+	if _, ok := sc.GetAccount(addr2[:]); ok {
 		t.Fatalf("Did not expect account with addr2")
 	}
 	var addr3 common.Address
 	addr3[0] = 3
-	sc.SetAccountAbsent(addr3.Bytes())
-	if a, ok := sc.GetAccount(addr3.Bytes()); !ok || a != nil {
+	sc.SetAccountAbsent(addr3[:])
+	if a, ok := sc.GetAccount(addr3[:]); !ok || a != nil {
 		t.Fatalf("Expected account with addr3 to be absent")
 	}
 	for i := 4; i <= 6; i++ {
@@ -123,11 +123,11 @@ func TestAccountReads(t *testing.T) {
 		account.Balance.SetUint64(uint64(i))
 		var addr common.Address
 		addr[0] = byte(i)
-		sc.SetAccountRead(addr.Bytes(), &account)
+		sc.SetAccountRead(addr[:], &account)
 	}
 	// Out of 6 addresses, one was not associated with an account or absence record. So 5 records would be in the cache
 	// But since the limit is 4, the first addr will be evicted
-	if _, ok := sc.GetAccount(addr1.Bytes()); ok {
+	if _, ok := sc.GetAccount(addr1[:]); ok {
 		t.Fatalf("Expected addr1 to be evicted")
 	}
 	for i := 4; i <= 6; i++ {
@@ -135,7 +135,7 @@ func TestAccountReads(t *testing.T) {
 		account.Balance.SetUint64(uint64(i))
 		var addr common.Address
 		addr[0] = byte(i)
-		if _, ok := sc.GetAccount(addr.Bytes()); !ok {
+		if _, ok := sc.GetAccount(addr[:]); !ok {
 			t.Fatalf("Expected to find account with addr %x", addr)
 		}
 	}
@@ -148,8 +148,8 @@ func TestAccountReadWrites(t *testing.T) {
 	account1.Balance.SetUint64(1)
 	var addr1 common.Address
 	addr1[0] = 1
-	sc.SetAccountWrite(addr1.Bytes(), &account1)
-	if _, ok := sc.GetAccount(addr1.Bytes()); !ok {
+	sc.SetAccountWrite(addr1[:], &account1)
+	if _, ok := sc.GetAccount(addr1[:]); !ok {
 		t.Fatalf("Expected to find account with addr1")
 	}
 	if sc.WriteCount() != 1 {
@@ -158,8 +158,8 @@ func TestAccountReadWrites(t *testing.T) {
 	// Replace the existing value
 	var account11 accounts.Account
 	account11.Balance.SetUint64(11)
-	sc.SetAccountWrite(addr1.Bytes(), &account11)
-	if a, ok := sc.GetAccount(addr1.Bytes()); !ok {
+	sc.SetAccountWrite(addr1[:], &account11)
+	if a, ok := sc.GetAccount(addr1[:]); !ok {
 		t.Fatalf("Expected to find account with addr1")
 	} else {
 		if a.Balance.Uint64() != 11 {
@@ -174,15 +174,15 @@ func TestAccountReadWrites(t *testing.T) {
 	account2.Balance.SetUint64(2)
 	var addr2 common.Address
 	addr2[0] = 2
-	sc.SetAccountRead(addr2.Bytes(), &account2)
+	sc.SetAccountRead(addr2[:], &account2)
 	// Check that readQueue is empty
 	if sc.readQueuesLen() != 1 {
 		t.Fatalf("Read queue is expected to be 1 element")
 	}
 	var account22 accounts.Account
 	account22.Balance.SetUint64(22)
-	sc.SetAccountWrite(addr2.Bytes(), &account22)
-	if a, ok := sc.GetAccount(addr2.Bytes()); !ok {
+	sc.SetAccountWrite(addr2[:], &account22)
+	if a, ok := sc.GetAccount(addr2[:]); !ok {
 		t.Fatalf("Expected to find account with addr2")
 	} else {
 		if a.Balance.Uint64() != 22 {
@@ -201,9 +201,9 @@ func TestAccountReadWrites(t *testing.T) {
 	account3.Balance.SetUint64(3)
 	var addr3 common.Address
 	addr3[0] = 3
-	sc.SetAccountWrite(addr3.Bytes(), &account3)
-	sc.SetAccountDelete(addr3.Bytes())
-	if a, ok := sc.GetAccount(addr3.Bytes()); !ok || a != nil {
+	sc.SetAccountWrite(addr3[:], &account3)
+	sc.SetAccountDelete(addr3[:])
+	if a, ok := sc.GetAccount(addr3[:]); !ok || a != nil {
 		t.Fatalf("Expected account addr3 to be deleted")
 	}
 	if sc.WriteCount() != 3 {
@@ -214,9 +214,9 @@ func TestAccountReadWrites(t *testing.T) {
 	account4.Balance.SetUint64(4)
 	var addr4 common.Address
 	addr4[0] = 4
-	sc.SetAccountRead(addr4.Bytes(), &account4)
-	sc.SetAccountDelete(addr4.Bytes())
-	if a, ok := sc.GetAccount(addr4.Bytes()); !ok || a != nil {
+	sc.SetAccountRead(addr4[:], &account4)
+	sc.SetAccountDelete(addr4[:])
+	if a, ok := sc.GetAccount(addr4[:]); !ok || a != nil {
 		t.Fatalf("Expected account addr4 to be deleted")
 	}
 	if sc.WriteCount() != 4 {
@@ -229,8 +229,8 @@ func TestAccountReadWrites(t *testing.T) {
 	// Deleting account not seen before
 	var addr5 common.Address
 	addr5[0] = 5
-	sc.SetAccountDelete(addr5.Bytes())
-	if a, ok := sc.GetAccount(addr5.Bytes()); !ok || a != nil {
+	sc.SetAccountDelete(addr5[:])
+	if a, ok := sc.GetAccount(addr5[:]); !ok || a != nil {
 		t.Fatalf("Expected account addr5 to be deleted")
 	}
 	if sc.WriteCount() != 5 {
@@ -246,7 +246,7 @@ func TestReplaceAccountReadsWithWrites(t *testing.T) {
 		addr[0] = byte(i)
 		var account accounts.Account
 		account.Balance.SetUint64(uint64(i))
-		sc.SetAccountWrite(addr.Bytes(), &account)
+		sc.SetAccountWrite(addr[:], &account)
 	}
 	writes := sc.PrepareWrites()
 	sc.TurnWritesToReads(writes)
@@ -262,7 +262,7 @@ func TestReplaceAccountReadsWithWrites(t *testing.T) {
 		addr[0] = byte(i)
 		var account accounts.Account
 		account.Balance.SetUint64(uint64(i))
-		sc.SetAccountWrite(addr.Bytes(), &account)
+		sc.SetAccountWrite(addr[:], &account)
 	}
 	if sc.WriteCount() != 4 {
 		t.Fatalf("Write queue is expected to have 4 elements, got: %d", sc.WriteCount())
@@ -274,7 +274,7 @@ func TestReplaceAccountReadsWithWrites(t *testing.T) {
 	for i := 1; i <= 2; i++ {
 		var addr common.Address
 		addr[0] = byte(i)
-		if _, ok := sc.GetAccount(addr.Bytes()); ok {
+		if _, ok := sc.GetAccount(addr[:]); ok {
 			t.Fatalf("Expected not to find address %d", i)
 		}
 	}
@@ -282,7 +282,7 @@ func TestReplaceAccountReadsWithWrites(t *testing.T) {
 	for i := 3; i <= 8; i++ {
 		var addr common.Address
 		addr[0] = byte(i)
-		if _, ok := sc.GetAccount(addr.Bytes()); !ok {
+		if _, ok := sc.GetAccount(addr[:]); !ok {
 			t.Errorf("Expected to find address %d", i)
 		}
 	}
@@ -294,13 +294,13 @@ func TestReadAccountExisting(t *testing.T) {
 	var account1 accounts.Account
 	account1.Balance.SetUint64(1)
 	var addr1 common.Address
-	sc.SetAccountRead(addr1.Bytes(), &account1)
+	sc.SetAccountRead(addr1[:], &account1)
 	defer func() {
 		//nolint:staticcheck
 		if r := recover(); r != nil {
 		}
 	}()
-	sc.SetAccountRead(addr1.Bytes(), &account1)
+	sc.SetAccountRead(addr1[:], &account1)
 	t.Fatalf("Expected to panic")
 }
 
@@ -317,7 +317,7 @@ func TestWriteAccountExceedLimit(t *testing.T) {
 		addr[0] = byte(i)
 		var account accounts.Account
 		account.Balance.SetUint64(uint64(i))
-		sc.SetAccountWrite(addr.Bytes(), &account)
+		sc.SetAccountWrite(addr[:], &account)
 	}
 }
 
@@ -329,16 +329,16 @@ func TestGetDeletedAccount(t *testing.T) {
 	account1.Incarnation = 1
 	var addr1 common.Address
 	addr1[0] = 1
-	sc.SetAccountRead(addr1.Bytes(), &account1)
+	sc.SetAccountRead(addr1[:], &account1)
 	var account11 accounts.Account
 	account11.Incarnation = 2
-	sc.SetAccountWrite(addr1.Bytes(), &account11)
-	acc := sc.GetDeletedAccount(addr1.Bytes())
+	sc.SetAccountWrite(addr1[:], &account11)
+	acc := sc.GetDeletedAccount(addr1[:])
 	if acc != nil {
 		t.Fatalf("Did not expect to find deleted account before deletion")
 	}
-	sc.SetAccountDelete(addr1.Bytes())
-	acc = sc.GetDeletedAccount(addr1.Bytes())
+	sc.SetAccountDelete(addr1[:])
+	acc = sc.GetDeletedAccount(addr1[:])
 	if acc == nil {
 		t.Fatalf("Expected to find deleted account")
 	}
@@ -356,7 +356,7 @@ func TestReadWriteAbsentDeleteStorage(t *testing.T) {
 		addr[0] = byte(i)
 		var loc common.Hash
 		loc[1] = byte(i)
-		sc.SetStorageAbsent(addr.Bytes(), 1, loc.Bytes())
+		sc.SetStorageAbsent(addr[:], 1, loc[:])
 	}
 	if sc.readQueuesLen() != 4 {
 		t.Fatalf("expected 4 reads got: %d", sc.readQueuesLen())
@@ -366,7 +366,7 @@ func TestReadWriteAbsentDeleteStorage(t *testing.T) {
 		addr[0] = byte(i)
 		var loc common.Hash
 		loc[1] = byte(i)
-		if s, ok := sc.GetStorage(addr.Bytes(), 1, loc.Bytes()); !ok || s != nil {
+		if s, ok := sc.GetStorage(addr[:], 1, loc[:]); !ok || s != nil {
 			t.Fatalf("expected entry with %x,1,%x not to exist", addr, loc)
 		}
 	}
@@ -378,7 +378,7 @@ func TestReadWriteAbsentDeleteStorage(t *testing.T) {
 		loc[1] = byte(i)
 		var val common.Hash
 		val[2] = byte(i)
-		sc.SetStorageRead(addr.Bytes(), 2, loc.Bytes(), val.Bytes())
+		sc.SetStorageRead(addr[:], 2, loc[:], val[:])
 	}
 	if sc.readQueuesLen() != 4 {
 		t.Fatalf("expected 4 reads got: %d", sc.readQueuesLen())
@@ -389,7 +389,7 @@ func TestReadWriteAbsentDeleteStorage(t *testing.T) {
 		addr[0] = byte(i)
 		var loc common.Hash
 		loc[1] = byte(i)
-		if _, ok := sc.GetStorage(addr.Bytes(), 2, loc.Bytes()); ok {
+		if _, ok := sc.GetStorage(addr[:], 2, loc[:]); ok {
 			t.Fatalf("expected entry with %x,2,%x to be evicted", addr, loc)
 		}
 	}
@@ -399,7 +399,7 @@ func TestReadWriteAbsentDeleteStorage(t *testing.T) {
 		addr[0] = byte(i)
 		var loc common.Hash
 		loc[1] = byte(i)
-		if _, ok := sc.GetStorage(addr.Bytes(), 2, loc.Bytes()); !ok {
+		if _, ok := sc.GetStorage(addr[:], 2, loc[:]); !ok {
 			t.Errorf("expected entry with %x,2,%x to exist", addr, loc)
 		}
 	}
@@ -409,7 +409,7 @@ func TestReadWriteAbsentDeleteStorage(t *testing.T) {
 		addr[0] = byte(i)
 		var loc common.Hash
 		loc[1] = byte(i)
-		sc.SetStorageDelete(addr.Bytes(), 1, loc.Bytes())
+		sc.SetStorageDelete(addr[:], 1, loc[:])
 	}
 	if sc.readQueuesLen() != 0 {
 		t.Fatalf("expected 0 reads got: %d", sc.readQueuesLen())
@@ -419,7 +419,7 @@ func TestReadWriteAbsentDeleteStorage(t *testing.T) {
 		addr[0] = byte(i)
 		var loc common.Hash
 		loc[1] = byte(i)
-		if s, ok := sc.GetStorage(addr.Bytes(), 1, loc.Bytes()); !ok || s != nil {
+		if s, ok := sc.GetStorage(addr[:], 1, loc[:]); !ok || s != nil {
 			t.Fatalf("expected entry with %x,1,%x not to exist", addr, loc)
 		}
 	}
@@ -431,7 +431,7 @@ func TestReadWriteAbsentDeleteStorage(t *testing.T) {
 		loc[1] = byte(i)
 		var val common.Hash
 		val[2] = byte(i)
-		sc.SetStorageWrite(addr.Bytes(), 1, loc.Bytes(), val.Bytes())
+		sc.SetStorageWrite(addr[:], 1, loc[:], val[:])
 	}
 	if sc.WriteCount() != 4 {
 		t.Fatalf("expected 4 writes, got %d", sc.WriteCount())
@@ -441,7 +441,7 @@ func TestReadWriteAbsentDeleteStorage(t *testing.T) {
 		addr[0] = byte(i)
 		var loc common.Hash
 		loc[1] = byte(i)
-		if _, ok := sc.GetStorage(addr.Bytes(), 1, loc.Bytes()); !ok {
+		if _, ok := sc.GetStorage(addr[:], 1, loc[:]); !ok {
 			t.Fatalf("expected entry with %x,1,%x to exist", addr, loc)
 		}
 	}
@@ -455,13 +455,13 @@ func TestReadStorageExisting(t *testing.T) {
 	var loc1 common.Hash
 	var val1 common.Hash
 	val1[2] = 1
-	sc.SetStorageRead(addr1.Bytes(), 1, loc1.Bytes(), val1.Bytes())
+	sc.SetStorageRead(addr1[:], 1, loc1[:], val1[:])
 	defer func() {
 		//nolint:staticcheck
 		if r := recover(); r != nil {
 		}
 	}()
-	sc.SetStorageRead(addr1.Bytes(), 1, loc1.Bytes(), val1.Bytes())
+	sc.SetStorageRead(addr1[:], 1, loc1[:], val1[:])
 	t.Fatalf("Expected to panic")
 }
 
@@ -480,7 +480,7 @@ func TestWriteStorageExceedLimit(t *testing.T) {
 		loc[1] = byte(i)
 		var val common.Hash
 		val[2] = byte(i)
-		sc.SetStorageWrite(addr.Bytes(), 1, loc.Bytes(), val.Bytes())
+		sc.SetStorageWrite(addr[:], 1, loc[:], val[:])
 	}
 }
 
@@ -491,7 +491,7 @@ func TestCodeReadWriteAbsentDelete(t *testing.T) {
 	for i := 1; i <= 4; i++ {
 		var addr common.Address
 		addr[0] = byte(i)
-		sc.SetCodeAbsent(addr.Bytes(), 1)
+		sc.SetCodeAbsent(addr[:], 1)
 	}
 	if sc.readQueuesLen() != 4 {
 		t.Fatalf("expected 4 reads got: %d", sc.readQueuesLen())
@@ -499,7 +499,7 @@ func TestCodeReadWriteAbsentDelete(t *testing.T) {
 	for i := 1; i <= 4; i++ {
 		var addr common.Address
 		addr[0] = byte(i)
-		if c, ok := sc.GetCode(addr.Bytes(), 1); !ok || c != nil {
+		if c, ok := sc.GetCode(addr[:], 1); !ok || c != nil {
 			t.Fatalf("expected entry with %x,1 not to exist", addr)
 		}
 	}
@@ -508,7 +508,7 @@ func TestCodeReadWriteAbsentDelete(t *testing.T) {
 		var addr common.Address
 		addr[0] = byte(i)
 		var code = []byte{byte(i), 2, 3}
-		sc.SetCodeRead(addr.Bytes(), 2, code)
+		sc.SetCodeRead(addr[:], 2, code)
 	}
 	if sc.readQueuesLen() != 4 {
 		t.Fatalf("expected 4 reads got: %d", sc.readQueuesLen())
@@ -517,7 +517,7 @@ func TestCodeReadWriteAbsentDelete(t *testing.T) {
 	for i := 1; i <= 2; i++ {
 		var addr common.Address
 		addr[0] = byte(i)
-		if _, ok := sc.GetCode(addr.Bytes(), 2); ok {
+		if _, ok := sc.GetCode(addr[:], 2); ok {
 			t.Fatalf("expected entry with %x,2 to be evicted", addr)
 		}
 	}
@@ -525,7 +525,7 @@ func TestCodeReadWriteAbsentDelete(t *testing.T) {
 	for i := 3; i <= 6; i++ {
 		var addr common.Address
 		addr[0] = byte(i)
-		if _, ok := sc.GetCode(addr.Bytes(), 2); !ok {
+		if _, ok := sc.GetCode(addr[:], 2); !ok {
 			t.Errorf("expected entry with %x,2 to exist", addr)
 		}
 	}
@@ -533,7 +533,7 @@ func TestCodeReadWriteAbsentDelete(t *testing.T) {
 	for i := 1; i <= 4; i++ {
 		var addr common.Address
 		addr[0] = byte(i)
-		sc.SetCodeDelete(addr.Bytes(), 1)
+		sc.SetCodeDelete(addr[:], 1)
 	}
 	if sc.readQueuesLen() != 0 {
 		t.Fatalf("expected 0 reads got: %d", sc.readQueuesLen())
@@ -541,7 +541,7 @@ func TestCodeReadWriteAbsentDelete(t *testing.T) {
 	for i := 1; i <= 4; i++ {
 		var addr common.Address
 		addr[0] = byte(i)
-		if c, ok := sc.GetCode(addr.Bytes(), 1); !ok || c != nil {
+		if c, ok := sc.GetCode(addr[:], 1); !ok || c != nil {
 			t.Fatalf("expected entry with %x,1 not to exist", addr)
 		}
 	}
@@ -550,7 +550,7 @@ func TestCodeReadWriteAbsentDelete(t *testing.T) {
 		var addr common.Address
 		addr[0] = byte(i)
 		var code = []byte{byte(i), 2, 3}
-		sc.SetCodeWrite(addr.Bytes(), 1, code)
+		sc.SetCodeWrite(addr[:], 1, code)
 	}
 	if sc.WriteCount() != 4 {
 		t.Fatalf("expected 4 writes, got %d", sc.WriteCount())
@@ -558,7 +558,7 @@ func TestCodeReadWriteAbsentDelete(t *testing.T) {
 	for i := 1; i <= 4; i++ {
 		var addr common.Address
 		addr[0] = byte(i)
-		if _, ok := sc.GetCode(addr.Bytes(), 1); !ok {
+		if _, ok := sc.GetCode(addr[:], 1); !ok {
 			t.Fatalf("expected entry with %x,1 to exist", addr)
 		}
 	}
@@ -570,13 +570,13 @@ func TestReadCodeExisting(t *testing.T) {
 	var addr1 common.Address
 	addr1[0] = 1
 	code1 := []byte{1, 2, 3}
-	sc.SetCodeRead(addr1.Bytes(), 1, code1)
+	sc.SetCodeRead(addr1[:], 1, code1)
 	defer func() {
 		//nolint:staticcheck
 		if r := recover(); r != nil {
 		}
 	}()
-	sc.SetCodeRead(addr1.Bytes(), 1, code1)
+	sc.SetCodeRead(addr1[:], 1, code1)
 	t.Fatalf("Expected to panic")
 }
 
@@ -592,6 +592,6 @@ func TestWriteCodeExceedLimit(t *testing.T) {
 		var addr common.Address
 		addr[0] = byte(i)
 		code := []byte{byte(i), 2, 3}
-		sc.SetCodeWrite(addr.Bytes(), 1, code)
+		sc.SetCodeWrite(addr[:], 1, code)
 	}
 }

--- a/node/shards/trie_cache.go
+++ b/node/shards/trie_cache.go
@@ -118,7 +118,7 @@ func (wi *StorageHashWriteItem) Less(than btree.Item) bool {
 
 func (shi *StorageHashItem) Less(than btree.Item) bool {
 	i := than.(*StorageHashItem)
-	c := bytes.Compare(shi.addrHash.Bytes(), i.addrHash.Bytes())
+	c := bytes.Compare(shi.addrHash[:], i.addrHash[:])
 	if c != 0 {
 		return c < 0
 	}
@@ -613,7 +613,7 @@ func (sc *StateCache) StorageHashesSeek(addrHash common.Hash, incarnation uint64
 	var cur *StorageHashItem
 	seek := &StorageHashItem{}
 	id := id(seek)
-	seek.addrHash.SetBytes(addrHash.Bytes())
+	seek.addrHash.SetBytes(addrHash[:])
 	seek.incarnation = incarnation
 	seek.locHashPrefix = prefix
 	sc.readWrites[id].AscendGreaterOrEqual(seek, func(i btree.Item) bool {

--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -360,7 +360,8 @@ func New(
 		accounts.ZeroAddress,
 		func(_ accounts.Address, _ string, i []byte) ([]byte, error) {
 			// return an error to prevent panics
-			return nil, &heimdall.UnauthorizedSignerError{Number: 0, Signer: common.Address{}.Bytes()}
+			zeroAddr := common.Address{}
+			return nil, &heimdall.UnauthorizedSignerError{Number: 0, Signer: zeroAddr[:]}
 		},
 	})
 

--- a/polygon/bor/types/bor_receipt.go
+++ b/polygon/bor/types/bor_receipt.go
@@ -38,7 +38,7 @@ func ComputeBorTxHash(blockNumber uint64, blockHash common.Hash) common.Hash {
 	txKeyPlain := make([]byte, 0, len(BorTxKeyPrefix)+8+32)
 	txKeyPlain = append(txKeyPlain, BorTxKeyPrefix...)
 	txKeyPlain = append(txKeyPlain, BorReceiptKey(blockNumber)...)
-	txKeyPlain = append(txKeyPlain, blockHash.Bytes()...)
+	txKeyPlain = append(txKeyPlain, blockHash[:]...)
 	return common.BytesToHash(crypto.Keccak256(txKeyPlain))
 }
 

--- a/polygon/bridge/mdbx_store.go
+++ b/polygon/bridge/mdbx_store.go
@@ -465,7 +465,7 @@ func (s txStore) PutEventTxnToBlockNum(ctx context.Context, eventTxnToBlockNum m
 
 	vBigNum := new(big.Int)
 	for k, v := range eventTxnToBlockNum {
-		err := tx.Put(kv.BorTxLookup, k.Bytes(), vBigNum.SetUint64(v).Bytes())
+		err := tx.Put(kv.BorTxLookup, k[:], vBigNum.SetUint64(v).Bytes())
 		if err != nil {
 			return err
 		}
@@ -477,7 +477,7 @@ func (s txStore) PutEventTxnToBlockNum(ctx context.Context, eventTxnToBlockNum m
 func (s txStore) EventTxnToBlockNum(ctx context.Context, borTxHash common.Hash) (uint64, bool, error) {
 	var blockNum uint64
 
-	v, err := s.tx.GetOne(kv.BorTxLookup, borTxHash.Bytes())
+	v, err := s.tx.GetOne(kv.BorTxLookup, borTxHash[:])
 	if err != nil {
 		return blockNum, false, err
 	}

--- a/polygon/heimdall/validator_set.go
+++ b/polygon/heimdall/validator_set.go
@@ -92,7 +92,7 @@ func (v *Validator) Cmp(other *Validator) *Validator {
 		return other
 	}
 
-	result := bytes.Compare(v.Address.Bytes(), other.Address.Bytes())
+	result := bytes.Compare(v.Address[:], other.Address[:])
 
 	if result == 0 {
 		panic("Cannot compare identical validators")
@@ -121,7 +121,7 @@ func (v *Validator) String() string {
 // HeaderBytes return header bytes
 func (v *Validator) HeaderBytes() []byte {
 	result := make([]byte, 40)
-	copy(result[:20], v.Address.Bytes())
+	copy(result[:20], v.Address[:])
 	copy(result[20:], v.PowerBytes())
 
 	return result
@@ -411,7 +411,7 @@ func (vals *ValidatorSet) GetByIndex(index int) (address []byte, val *Validator)
 
 	val = vals.Validators[index]
 
-	return val.Address.Bytes(), val.Copy()
+	return val.Address[:], val.Copy()
 }
 
 // Size returns the length of the validator set.
@@ -465,7 +465,7 @@ func (vals *ValidatorSet) GetProposer() (proposer *Validator) {
 func (vals *ValidatorSet) findProposer() *Validator {
 	var proposer *Validator
 	for _, val := range vals.Validators {
-		if proposer == nil || !bytes.Equal(val.Address.Bytes(), proposer.Address.Bytes()) {
+		if proposer == nil || !bytes.Equal(val.Address[:], proposer.Address[:]) {
 			proposer = proposer.Cmp(val)
 		}
 	}
@@ -520,7 +520,7 @@ func processChanges(origChanges []*Validator) (updates, removals []*Validator, e
 
 	// Scan changes by address and append valid validators to updates or removals lists.
 	for i, valUpdate := range changes {
-		if i > 0 && bytes.Equal(valUpdate.Address.Bytes(), prevAddr.Bytes()) {
+		if i > 0 && bytes.Equal(valUpdate.Address[:], prevAddr[:]) {
 			err = fmt.Errorf("duplicate entry %v in %v", valUpdate, changes)
 			return nil, nil, err
 		}
@@ -625,13 +625,13 @@ func (vals *ValidatorSet) applyUpdates(updates []*Validator) {
 	i := 0
 
 	for len(existing) > 0 && len(updates) > 0 {
-		if bytes.Compare(existing[0].Address.Bytes(), updates[0].Address.Bytes()) < 0 { // unchanged validator
+		if bytes.Compare(existing[0].Address[:], updates[0].Address[:]) < 0 { // unchanged validator
 			merged[i] = existing[0]
 			existing = existing[1:]
 		} else {
 			// Apply add or update.
 			merged[i] = updates[0]
-			if bytes.Equal(existing[0].Address.Bytes(), updates[0].Address.Bytes()) {
+			if bytes.Equal(existing[0].Address[:], updates[0].Address[:]) {
 				// Validator is present in both, advance existing.
 				existing = existing[1:]
 			}
@@ -685,7 +685,7 @@ func (vals *ValidatorSet) applyRemovals(deletes []*Validator) {
 
 	// Loop over deletes until we removed all of them.
 	for len(deletes) > 0 {
-		if bytes.Equal(existing[0].Address.Bytes(), deletes[0].Address.Bytes()) {
+		if bytes.Equal(existing[0].Address[:], deletes[0].Address[:]) {
 			deletes = deletes[1:]
 		} else { // Leave it in the resulting slice.
 			merged[i] = existing[0]
@@ -821,7 +821,7 @@ func (vals *ValidatorSet) GetSignerSuccessionNumber(signer accounts.Address, num
 
 	proposerIndex, _ := vals.GetByAddress(accounts.InternAddress(proposer.Address))
 	if proposerIndex < 0 {
-		return -1, &UnauthorizedProposerError{Number: number, Proposer: proposer.Address.Bytes()}
+		return -1, &UnauthorizedProposerError{Number: number, Proposer: proposer.Address[:]}
 	}
 
 	signerIndex, _ := vals.GetByAddress(signer)
@@ -886,7 +886,7 @@ func (valz ValidatorsByAddress) Len() int {
 }
 
 func (valz ValidatorsByAddress) Less(i, j int) bool {
-	return bytes.Compare(valz[i].Address.Bytes(), valz[j].Address.Bytes()) == -1
+	return bytes.Compare(valz[i].Address[:], valz[j].Address[:]) == -1
 }
 
 func (valz ValidatorsByAddress) Swap(i, j int) {
@@ -975,7 +975,7 @@ func GetUpdatedValidatorSet(oldValidatorSet *ValidatorSet, newVals []*Validator,
 
 func validatorContains(a []*Validator, x *Validator) (*Validator, bool) {
 	for _, n := range a {
-		if bytes.Equal(n.Address.Bytes(), x.Address.Bytes()) {
+		if bytes.Equal(n.Address[:], x.Address[:]) {
 			return n, true
 		}
 	}

--- a/polygon/sync/canonical_chain_builder.go
+++ b/polygon/sync/canonical_chain_builder.go
@@ -223,7 +223,7 @@ func compareForkTreeNodes(node1 *forkTreeNode, node2 *forkTreeNode) int {
 	if blockNumDiff != 0 {
 		return -blockNumDiff
 	}
-	return bytes.Compare(node1.headerHash.Bytes(), node2.headerHash.Bytes())
+	return bytes.Compare(node1.headerHash[:], node2.headerHash[:])
 }
 
 func (ccb *CanonicalChainBuilder) updateTipIfNeeded(tipCandidate *forkTreeNode) {

--- a/polygon/sync/waypoint_headers_verifier.go
+++ b/polygon/sync/waypoint_headers_verifier.go
@@ -42,7 +42,8 @@ func VerifyCheckpointHeaders(waypoint heimdall.Waypoint, headers []*types.Header
 		return fmt.Errorf("VerifyCheckpointHeaders: %w: %w", ErrFailedToComputeHeadersRootHash, err)
 	}
 
-	if !bytes.Equal(rootHash, waypoint.RootHash().Bytes()) {
+	wpRoot := waypoint.RootHash()
+	if !bytes.Equal(rootHash, wpRoot[:]) {
 		return fmt.Errorf("VerifyCheckpointHeaders: %w", ErrBadHeadersRootHash)
 	}
 

--- a/rpc/ethapi/state_overrides.go
+++ b/rpc/ethapi/state_overrides.go
@@ -66,7 +66,7 @@ func (so *StateOverrides) override(ibs *state.IntraBlockState, addrs []accounts.
 		if account.State != nil {
 			intState := map[accounts.StorageKey]uint256.Int{}
 			for key, value := range *account.State {
-				intValue := *new(uint256.Int).SetBytes32(value.Bytes())
+				intValue := *new(uint256.Int).SetBytes32(value[:])
 				intState[accounts.InternKey(key)] = intValue
 			}
 			if err := ibs.SetStorage(addr, intState); err != nil {
@@ -76,7 +76,7 @@ func (so *StateOverrides) override(ibs *state.IntraBlockState, addrs []accounts.
 		// Apply state diff into specified accounts.
 		if account.StateDiff != nil {
 			for key, value := range *account.StateDiff {
-				intValue := *new(uint256.Int).SetBytes32(value.Bytes())
+				intValue := *new(uint256.Int).SetBytes32(value[:])
 				if err := ibs.SetState(addr, accounts.InternKey(key), intValue); err != nil {
 					return err
 				}

--- a/rpc/jsonrpc/bor_helper.go
+++ b/rpc/jsonrpc/bor_helper.go
@@ -66,7 +66,8 @@ func ecrecover(header *types.Header, c *borcfg.BorConfig) (common.Address, error
 	signature := header.Extra[len(header.Extra)-extraSeal:]
 
 	// Recover the public key and the Ethereum address
-	pubkey, err := crypto.Ecrecover(bor.SealHash(header, c).Bytes(), signature)
+	sealHash := bor.SealHash(header, c)
+	pubkey, err := crypto.Ecrecover(sealHash[:], signature)
 	if err != nil {
 		return common.Address{}, err
 	}

--- a/rpc/jsonrpc/debug_api_test.go
+++ b/rpc/jsonrpc/debug_api_test.go
@@ -324,7 +324,7 @@ func TestStorageRangeAt(t *testing.T) {
 		}
 
 		// start from something, limited
-		result, err = api.StorageRangeAt(m.Ctx, latestBlock.Hash(), 0, addr, expect.NextKey.Bytes(), 2)
+		result, err = api.StorageRangeAt(m.Ctx, latestBlock.Hash(), 0, addr, expect.NextKey[:], 2)
 		require.NoError(t, err)
 		expect = StorageRangeResult{storageMap{keys[4]: storage[keys[4]], keys[6]: storage[keys[6]]}, nil}
 		if !reflect.DeepEqual(result, expect) {
@@ -384,7 +384,7 @@ func TestStorageRangeAtGethCompat(t *testing.T) {
 		}
 
 		// start from nextKey (hashed), limited — pagination
-		result, err = api.StorageRangeAt(m.Ctx, latestBlock.Hash(), 0, addr, expect.NextKey.Bytes(), 2)
+		result, err = api.StorageRangeAt(m.Ctx, latestBlock.Hash(), 0, addr, expect.NextKey[:], 2)
 		require.NoError(t, err)
 		expect = StorageRangeResult{storageMap{keys[4]: storage[keys[4]], keys[6]: storage[keys[6]]}, nil}
 		if !reflect.DeepEqual(result, expect) {

--- a/rpc/jsonrpc/debug_execution_witness.go
+++ b/rpc/jsonrpc/debug_execution_witness.go
@@ -734,16 +734,16 @@ func (a *accessedState) isEmpty() bool {
 // first, then storage, then code.
 func (a *accessedState) touchAll(sdCtx *commitmentdb.SharedDomainsCommitmentContext) {
 	for addr := range a.Addresses {
-		sdCtx.TouchKey(kv.AccountsDomain, string(addr.Bytes()), nil)
+		sdCtx.TouchKey(kv.AccountsDomain, string(addr[:]), nil)
 	}
 	for addr, keys := range a.Storage {
 		for key := range keys {
-			storageKey := string(append(addr.Bytes(), key.Bytes()...))
+			storageKey := string(append(addr[:], key[:]...))
 			sdCtx.TouchKey(kv.StorageDomain, storageKey, nil)
 		}
 	}
 	for addr := range a.CodeAddrs {
-		sdCtx.TouchKey(kv.CodeDomain, string(addr.Bytes()), nil)
+		sdCtx.TouchKey(kv.CodeDomain, string(addr[:]), nil)
 	}
 }
 
@@ -818,11 +818,11 @@ func collectAccessedState(rs *RecordingState) *accessedState {
 
 	sortedKeys := make([]hexutil.Bytes, 0, len(out.Addresses))
 	for addr := range out.Addresses {
-		sortedKeys = append(sortedKeys, addr.Bytes())
+		sortedKeys = append(sortedKeys, addr[:])
 	}
 	for addr, keys := range out.Storage {
 		for key := range keys {
-			composite := append(addr.Bytes(), key.Bytes()...)
+			composite := append(addr[:], key[:]...)
 			sortedKeys = append(sortedKeys, composite)
 		}
 	}
@@ -860,7 +860,7 @@ func collectAccessedState(rs *RecordingState) *accessedState {
 	for addr, code := range preCode {
 		if len(code) > 0 {
 			codeHash := crypto.Keccak256Hash(code)
-			addrHash := crypto.Keccak256Hash(addr.Bytes())
+			addrHash := crypto.Keccak256Hash(addr[:])
 			out.CodeReads[addrHash] = witnesstypes.CodeWithHash{
 				Code:     code,
 				CodeHash: accounts.InternCodeHash(codeHash),
@@ -1154,11 +1154,11 @@ func (api *DebugAPIImpl) buildExpectedPostState(
 
 	// Touch all modified accounts and storage keys for the post-state trie
 	for _, addr := range writeAddresses {
-		postSdCtx.TouchKey(kv.AccountsDomain, string(addr.Bytes()), nil)
+		postSdCtx.TouchKey(kv.AccountsDomain, string(addr[:]), nil)
 	}
 	for addr, keys := range writeStorageKeys {
 		for _, key := range keys {
-			storageKey := string(append(addr.Bytes(), key.Bytes()...))
+			storageKey := string(append(addr[:], key[:]...))
 			postSdCtx.TouchKey(kv.StorageDomain, storageKey, nil)
 		}
 	}
@@ -1170,7 +1170,8 @@ func (api *DebugAPIImpl) buildExpectedPostState(
 	}
 
 	// Verify the post-state root matches the block's state root
-	if !bytes.Equal(postRoot, block.Root().Bytes()) {
+	blockRoot := block.Root()
+	if !bytes.Equal(postRoot, blockRoot[:]) {
 		// only warn, so we can see comparison later
 		fmt.Printf("Warning: post-state trie root %x doesn't match block root %x\n", postRoot, block.Root())
 	}
@@ -1178,12 +1179,12 @@ func (api *DebugAPIImpl) buildExpectedPostState(
 	// Read account data from the post-state trie (with correct storage roots)
 	// Include both read and write addresses
 	for _, addr := range readAddresses {
-		addrHash := crypto.Keccak256(addr.Bytes())
+		addrHash := crypto.Keccak256(addr[:])
 		acc, _ := postTrie.GetAccount(addrHash)
 		expectedState[addr] = acc
 	}
 	for _, addr := range writeAddresses {
-		addrHash := crypto.Keccak256(addr.Bytes())
+		addrHash := crypto.Keccak256(addr[:])
 		acc, _ := postTrie.GetAccount(addrHash)
 		expectedState[addr] = acc
 	}

--- a/rpc/jsonrpc/eth_block.go
+++ b/rpc/jsonrpc/eth_block.go
@@ -202,12 +202,12 @@ func (api *APIImpl) CallBundle(ctx context.Context, txHashes []common.Hash, stat
 			return nil, err
 		}
 
-		txHash := txn.Hash().String()
+		txHash := txn.Hash()
 		jsonResult := map[string]any{
-			"txHash":  txHash,
+			"txHash":  txHash.String(),
 			"gasUsed": result.ReceiptGasUsed,
 		}
-		bundleHash.Write(txn.Hash().Bytes())
+		bundleHash.Write(txHash[:])
 		if result.Err != nil {
 			jsonResult["error"] = result.Err.Error()
 		} else {

--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -494,7 +494,7 @@ func (api *APIImpl) getProof(ctx context.Context, roTx kv.TemporalTx, address co
 	}
 
 	// touch account
-	sdCtx.TouchKey(kv.AccountsDomain, string(address.Bytes()), nil)
+	sdCtx.TouchKey(kv.AccountsDomain, string(address[:]), nil)
 
 	// generate the trie for proofs, this works by loading the merkle paths to the touched keys
 	proofTrie, calculatedAccountProofRoot, err := sdCtx.Witness(ctx, nil, "eth_getProof")
@@ -516,14 +516,14 @@ func (api *APIImpl) getProof(ctx context.Context, roTx kv.TemporalTx, address co
 	}
 
 	// get account proof
-	accountProof, err := proofTrie.Prove(crypto.Keccak256(address.Bytes()), 0, false)
+	accountProof, err := proofTrie.Prove(crypto.Keccak256(address[:]), 0, false)
 	if err != nil {
 		return nil, err
 	}
 	proof.AccountProof = *(*[]hexutil.Bytes)(unsafe.Pointer(&accountProof))
 
 	// get account data from the trie
-	acc, _ := proofTrie.GetAccount(crypto.Keccak256(address.Bytes()))
+	acc, _ := proofTrie.GetAccount(crypto.Keccak256(address[:]))
 	if acc == nil {
 		for i, storageKey := range storageKeys {
 			proof.StorageProof[i] = accounts.StorProofResult{
@@ -545,7 +545,7 @@ func (api *APIImpl) getProof(ctx context.Context, roTx kv.TemporalTx, address co
 	proof.StorageHash = acc.Root
 
 	// if storage is not empty touch keys and build trie
-	if proof.StorageHash.Cmp(common.BytesToHash(empty.RootHash.Bytes())) != 0 && len(storageKeys) != 0 {
+	if proof.StorageHash.Cmp(common.BytesToHash(empty.RootHash[:])) != 0 && len(storageKeys) != 0 {
 		// touch storage keys
 		for _, storageKey := range storageKeys {
 			sdCtx.TouchKey(kv.StorageDomain, string(common.FromHex(address.Hex()[2:]+storageKey.Hash.String()[2:])), nil)
@@ -575,15 +575,15 @@ func (api *APIImpl) getProof(ctx context.Context, roTx kv.TemporalTx, address co
 		}
 		proof.StorageProof[i].Key = getKey(storageKey)
 		// if we have simple non contract account just set values directly without requesting any key proof
-		if proof.StorageHash.Cmp(common.BytesToHash(empty.RootHash.Bytes())) == 0 {
+		if proof.StorageHash.Cmp(common.BytesToHash(empty.RootHash[:])) == 0 {
 			proof.StorageProof[i].Proof = []hexutil.Bytes{}
 			proof.StorageProof[i].Value = new(hexutil.Big)
 			continue
 		}
 
 		// prepare key path (keccak(address) | keccak(key))
-		addrHash := crypto.HashData(address.Bytes())
-		keyHash := crypto.HashData(storageKey.Hash.Bytes())
+		addrHash := crypto.HashData(address[:])
+		keyHash := crypto.HashData(storageKey.Hash[:])
 		fullKey := make([]byte, 0, 64)
 		fullKey = append(fullKey, addrHash[:]...)
 		fullKey = append(fullKey, keyHash[:]...)
@@ -798,8 +798,9 @@ func (api *BaseAPI) getWitness(ctx context.Context, db kv.TemporalRoDB, blockNrO
 	if err != nil {
 		return nil, err
 	}
-	if !bytes.Equal(newStateRoot.Bytes(), block.Root().Bytes()) {
-		fmt.Printf("state root mismatch after stateless execution actual(%x) != expected(%x)\n", newStateRoot.Bytes(), block.Root().Bytes())
+	blockRoot := block.Root()
+	if !bytes.Equal(newStateRoot[:], blockRoot[:]) {
+		fmt.Printf("state root mismatch after stateless execution actual(%x) != expected(%x)\n", newStateRoot[:], blockRoot[:])
 	}
 	witnessBufBytes := witnessBuffer.Bytes()
 	witnessBufBytesCopy := common.Copy(witnessBufBytes)

--- a/rpc/jsonrpc/eth_call_test.go
+++ b/rpc/jsonrpc/eth_call_test.go
@@ -265,7 +265,7 @@ func TestGetProof(t *testing.T) {
 	key := func(b byte) hexutil.Bytes {
 		result := common.Hash{}
 		result[31] = b
-		return result.Bytes()
+		return result[:]
 	}
 	_ = bankAddr
 

--- a/rpc/jsonrpc/eth_mining.go
+++ b/rpc/jsonrpc/eth_mining.go
@@ -85,7 +85,7 @@ func (api *APIImpl) GetWork(ctx context.Context) ([4]string, error) {
 // It returns an indication if the work was accepted.
 // Note either an invalid solution, a stale work a non-existent work will return false.
 func (api *APIImpl) SubmitWork(ctx context.Context, nonce types.BlockNonce, powHash, digest common.Hash) (bool, error) {
-	repl, err := api.mining.SubmitWork(ctx, &txpoolproto.SubmitWorkRequest{BlockNonce: nonce[:], PowHash: powHash.Bytes(), Digest: digest.Bytes()})
+	repl, err := api.mining.SubmitWork(ctx, &txpoolproto.SubmitWorkRequest{BlockNonce: nonce[:], PowHash: powHash[:], Digest: digest[:]})
 	if err != nil {
 		if s, ok := status.FromError(err); ok {
 			return false, errors.New(s.Message())
@@ -101,7 +101,7 @@ func (api *APIImpl) SubmitWork(ctx context.Context, nonce types.BlockNonce, powH
 //
 // It accepts the miner hash rate and an identifier which must be unique
 func (api *APIImpl) SubmitHashrate(ctx context.Context, hashRate hexutil.Uint64, id common.Hash) (bool, error) {
-	repl, err := api.mining.SubmitHashRate(ctx, &txpoolproto.SubmitHashRateRequest{Rate: uint64(hashRate), Id: id.Bytes()})
+	repl, err := api.mining.SubmitHashRate(ctx, &txpoolproto.SubmitHashRateRequest{Rate: uint64(hashRate), Id: id[:]})
 	if err != nil {
 		if s, ok := status.FromError(err); ok {
 			return false, errors.New(s.Message())

--- a/rpc/jsonrpc/eth_receipts.go
+++ b/rpc/jsonrpc/eth_receipts.go
@@ -450,7 +450,7 @@ func getTopicsBitmapV3(tx kv.TemporalTx, topics [][]common.Hash, from, to uint64
 
 		var topicsUnion stream.U64
 		for _, topic := range sub {
-			it, err := tx.IndexRange(kv.LogTopicIdx, topic.Bytes(), int(from), int(to), asc, kv.Unlim)
+			it, err := tx.IndexRange(kv.LogTopicIdx, topic[:], int(from), int(to), asc, kv.Unlim)
 			if err != nil {
 				return nil, err
 			}

--- a/rpc/jsonrpc/eth_simulation.go
+++ b/rpc/jsonrpc/eth_simulation.go
@@ -1162,11 +1162,13 @@ func (s *simulator) computeCommitmentFromStateHistory(
 		tsd.GetCommitmentCtx().SetStateReader(newSimulateStateReader(ttx, tx, tsd, sd))
 		storageFullKey := make([]byte, length.Addr+length.Hash)
 		for address, locations := range touched {
-			addressKey := address.Value().Bytes()
+			addrValue := address.Value()
+			addressKey := addrValue[:]
 			tsd.GetCommitmentCtx().TouchKey(kv.AccountsDomain, string(addressKey), nil)
 			s.logger.Debug("Touch key", "domain", kv.AccountsDomain, "key", address.Value().Hex()[2:])
 			for _, loc := range locations {
-				locationKey := loc.Value().Bytes()
+				locValue := loc.Value()
+				locationKey := locValue[:]
 				copy(storageFullKey[:length.Addr], addressKey)
 				copy(storageFullKey[length.Addr:], locationKey)
 				tsd.GetCommitmentCtx().TouchKey(kv.StorageDomain, string(storageFullKey), nil)

--- a/rpc/jsonrpc/otterscan_block_details.go
+++ b/rpc/jsonrpc/otterscan_block_details.go
@@ -81,7 +81,7 @@ func (api *OtterscanAPIImpl) GetBlockDetailsByHash(ctx context.Context, hash com
 		return nil, err
 	}
 	if blockNumber == nil {
-		return nil, fmt.Errorf("couldn't find block number for hash %v", hash.Bytes())
+		return nil, fmt.Errorf("couldn't find block number for hash %v", hash[:])
 	}
 
 	err = api.BaseAPI.checkPruneHistory(ctx, tx, *blockNumber)

--- a/rpc/jsonrpc/storage_range.go
+++ b/rpc/jsonrpc/storage_range.go
@@ -84,8 +84,8 @@ func storageRangeAt(ttx kv.TemporalTx, contractAddress common.Address, start []b
 func storageRangeAtErigon(ttx kv.TemporalTx, contractAddress common.Address, start []byte, txNum uint64, maxResult int) (StorageRangeResult, error) {
 	result := StorageRangeResult{Storage: storageMap{}}
 
-	fromKey := append(common.Copy(contractAddress.Bytes()), start...)
-	toKey, _ := kv.NextSubtree(contractAddress.Bytes())
+	fromKey := append(common.Copy(contractAddress[:]), start...)
+	toKey, _ := kv.NextSubtree(contractAddress[:])
 
 	r, err := ttx.RangeAsOf(kv.StorageDomain, fromKey, toKey, txNum, order.Asc, kv.Unlim) //no limit because need skip empty records
 	if err != nil {
@@ -137,7 +137,7 @@ func storageRangeAtGethCompat(ttx kv.TemporalTx, contractAddress common.Address,
 
 	// Always scan all storage for this contract — we need to sort by hashed key
 	// to match Geth's trie-based iteration order.
-	fromKey := common.Copy(contractAddress.Bytes())
+	fromKey := common.Copy(contractAddress[:])
 	toKey, _ := kv.NextSubtree(fromKey)
 
 	r, err := ttx.RangeAsOf(kv.StorageDomain, fromKey, toKey, txNum, order.Asc, kv.Unlim)

--- a/rpc/jsonrpc/trace_filtering.go
+++ b/rpc/jsonrpc/trace_filtering.go
@@ -253,8 +253,9 @@ func (api *TraceAPIImpl) Block(ctx context.Context, blockNr rpc.BlockNumber, gas
 		rewardAction.RewardType = rewardKindToString(r.Kind)
 		rewardAction.Value.ToInt().Set(r.Amount.ToBig())
 		tr.Action = rewardAction
+		blockHash := block.Hash()
 		tr.BlockHash = &common.Hash{}
-		copy(tr.BlockHash[:], block.Hash().Bytes())
+		copy(tr.BlockHash[:], blockHash[:])
 		tr.BlockNumber = new(uint64)
 		*tr.BlockNumber = block.NumberU64()
 		tr.Type = rewardTraceType
@@ -272,7 +273,7 @@ func traceFilterBitmapsV3(tx kv.TemporalTx, req TraceFilterRequest, from, to uin
 
 	for _, addr := range req.FromAddress {
 		if addr != nil {
-			it, err := tx.IndexRange(kv.TracesFromIdx, addr.Bytes(), int(from), int(to), order.Asc, kv.Unlim)
+			it, err := tx.IndexRange(kv.TracesFromIdx, addr[:], int(from), int(to), order.Asc, kv.Unlim)
 			if err != nil {
 				return nil, nil, nil, err
 			}
@@ -283,7 +284,7 @@ func traceFilterBitmapsV3(tx kv.TemporalTx, req TraceFilterRequest, from, to uin
 
 	for _, addr := range req.ToAddress {
 		if addr != nil {
-			it, err := tx.IndexRange(kv.TracesToIdx, addr.Bytes(), int(from), int(to), order.Asc, kv.Unlim)
+			it, err := tx.IndexRange(kv.TracesToIdx, addr[:], int(from), int(to), order.Asc, kv.Unlim)
 			if err != nil {
 				return nil, nil, nil, err
 			}
@@ -514,7 +515,7 @@ func (api *TraceAPIImpl) filterV3(ctx context.Context, dbtx kv.TemporalTx, fromB
 				rewardAction.Value.ToInt().Set(minerReward.ToBig())
 				tr.Action = rewardAction
 				tr.BlockHash = &common.Hash{}
-				copy(tr.BlockHash[:], lastBlockHash.Bytes())
+				copy(tr.BlockHash[:], lastBlockHash[:])
 				tr.BlockNumber = new(uint64)
 				*tr.BlockNumber = blockNum
 				tr.Type = rewardTraceType

--- a/rpc/rpchelper/filters_test.go
+++ b/rpc/rpchelper/filters_test.go
@@ -284,7 +284,7 @@ func TestFilters_ThreeSubscriptionsWithDifferentCriteria(t *testing.T) {
 
 	// now a log that the subscription cares about
 	var a common.Address
-	a.SetBytes(address1.Bytes())
+	a.SetBytes(address1[:])
 	log.Address = gointerfaces.ConvertAddressToH160(a)
 
 	f.OnNewLogs(log)

--- a/rpc/rpchelper/logtracer.go
+++ b/rpc/rpchelper/logtracer.go
@@ -123,7 +123,8 @@ func (t *LogTracer) captureTransfer(from, to accounts.Address, value *uint256.In
 		common.BytesToHash(fromValue[:]),
 		common.BytesToHash(toValue[:]),
 	}
-	t.captureLog(transferAddress, topics, common.BigToHash(value.ToBig()).Bytes())
+	valueHash := common.BigToHash(value.ToBig())
+	t.captureLog(transferAddress, topics, valueHash[:])
 }
 
 // Reset prepares the LogTracer for the next transaction.

--- a/txnprovider/shutter/decryption_keys_signature_data.go
+++ b/txnprovider/shutter/decryption_keys_signature_data.go
@@ -80,7 +80,7 @@ func IdentityPreimageFromBytes(b []byte) (*IdentityPreimage, error) {
 func IdentityPreimageFromSenderPrefix(prefix [32]byte, sender common.Address) *IdentityPreimage {
 	var ip IdentityPreimage
 	copy(ip[:len(prefix)], prefix[:])
-	copy(ip[len(prefix):], sender.Bytes())
+	copy(ip[len(prefix):], sender[:])
 	return &ip
 }
 

--- a/txnprovider/shutter/internal/testhelpers/identity_preimage_mock_data.go
+++ b/txnprovider/shutter/internal/testhelpers/identity_preimage_mock_data.go
@@ -66,8 +66,10 @@ func MakeSlotIdentityPreimage(slot uint64) (*shutter.IdentityPreimage, error) {
 	// zeros as well). This ensures the block identity preimage is always alphanumerically before
 	// any transaction identity preimages, because sender addresses cannot be that small.
 	var buf bytes.Buffer
-	buf.Write(common.BigToHash(common.Big0).Bytes())
-	buf.Write(common.BigToHash(new(big.Int).SetUint64(slot)).Bytes()[12:])
+	zeroHash := common.BigToHash(common.Big0)
+	slotHash := common.BigToHash(new(big.Int).SetUint64(slot))
+	buf.Write(zeroHash[:])
+	buf.Write(slotHash[12:])
 	return shutter.IdentityPreimageFromBytes(buf.Bytes())
 }
 

--- a/txnprovider/shutter/validator_registry_msg.go
+++ b/txnprovider/shutter/validator_registry_msg.go
@@ -44,7 +44,7 @@ func (m *AggregateRegistrationMessage) Marshal() []byte {
 	b := make([]byte, 0, expectedLength)
 	b = append(b, m.Version)
 	b = binary.BigEndian.AppendUint64(b, m.ChainId)
-	b = append(b, m.ValidatorRegistryAddress.Bytes()...)
+	b = append(b, m.ValidatorRegistryAddress[:]...)
 	b = binary.BigEndian.AppendUint64(b, m.ValidatorIndex)
 	b = binary.BigEndian.AppendUint32(b, m.Count)
 	b = binary.BigEndian.AppendUint32(b, m.Nonce)
@@ -105,7 +105,7 @@ func (m *LegacyRegistrationMessage) Marshal() []byte {
 	b := make([]byte, 0, expectedLength)
 	b = append(b, m.Version)
 	b = binary.BigEndian.AppendUint64(b, m.ChainId)
-	b = append(b, m.ValidatorRegistryAddress.Bytes()...)
+	b = append(b, m.ValidatorRegistryAddress[:]...)
 	b = binary.BigEndian.AppendUint64(b, m.ValidatorIndex)
 	b = binary.BigEndian.AppendUint64(b, m.Nonce)
 	if m.IsRegistration {

--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -857,7 +857,7 @@ func (p *TxPool) best(ctx context.Context, n int, txns *TxnsRlp, onTopOf uint64,
 		if mt.TxnSlot.TxType() != types.BlobTxType {
 			txns.ParsedTxn[count] = mt.TxnSlot.Txn
 		}
-		copy(txns.Senders.At(count), sender.Bytes())
+		copy(txns.Senders.At(count), sender[:])
 		txns.IsLocal[count] = isLocal
 		if yielded != nil {
 			yielded.Add(mt.TxnSlot.IDHash)
@@ -2601,7 +2601,7 @@ func (p *TxPool) flushLocked(tx kv.RwTx) (err error) {
 			continue
 		}
 
-		copy(v[:20], addr.Bytes())
+		copy(v[:20], addr[:])
 		copy(v[20:], metaTx.TxnSlot.Rlp)
 
 		has, err := tx.Has(kv.PoolTransaction, []byte(txHash))

--- a/txnprovider/txpool/pool_test.go
+++ b/txnprovider/txpool/pool_test.go
@@ -441,7 +441,7 @@ func TestRecoverSignerFromRLP_ValidData(t *testing.T) {
 	hash := crypto.Keccak256Hash(hashData)
 
 	// Sign the hash
-	sig, err := crypto.Sign(hash.Bytes(), privateKey)
+	sig, err := crypto.Sign(hash[:], privateKey)
 	require.NoError(t, err)
 
 	// Separate signature components

--- a/txnprovider/txpool/pool_txn_parser.go
+++ b/txnprovider/txpool/pool_txn_parser.go
@@ -563,10 +563,10 @@ func (tx *TxnSlot) ToProtoAccountAbstractionTxn() *typesproto.AccountAbstraction
 		deployerData = aaTx.DeployerData
 	}
 	if aaTx.Paymaster != nil {
-		paymaster = aaTx.Paymaster.Bytes()
+		paymaster = aaTx.Paymaster[:]
 	}
 	if aaTx.Deployer != nil {
-		deployer = aaTx.Deployer.Bytes()
+		deployer = aaTx.Deployer[:]
 	}
 	if aaTx.BuilderFee != nil {
 		builderFee = aaTx.BuilderFee.Bytes()

--- a/txnprovider/txpool/senders.go
+++ b/txnprovider/txpool/senders.go
@@ -217,7 +217,7 @@ func (sc *sendersBatch) info(cacheView kvcache.CacheView, id uint64) (uint64, ui
 	if !ok {
 		panic("must not happen")
 	}
-	encoded, err := cacheView.Get(addr.Bytes())
+	encoded, err := cacheView.Get(addr[:])
 	if err != nil {
 		return 0, uint256.Int{}, err
 	}


### PR DESCRIPTION
for https://github.com/erigontech/erigon/issues/14522

---

## Summary

Remove `Hash.Bytes()` and `Address.Bytes()` methods from `common/` and replace
all call sites with `hash[:]` / `addr[:]`. The methods returned `h[:]` /
`a[:]` but were called on receiver values, which caused the underlying array
to escape to the heap. Using the slice expression directly on an addressable
variable avoids the escape.

## Changes

- `common/hash.go`: drop `func (h Hash) Bytes() []byte`
- `common/address.go`: drop `func (a Address) Bytes() []byte`
- Mechanically rewrote ~80 call sites across production code, tests, and benchmarks
- Function-call returns and composite literals (e.g. `txn.Hash().Bytes()`,
  `crypto.PubkeyToAddress(k).Bytes()`, `common.Hash{}.Bytes()`) — assigned the
  result to a local first since slice expressions require an addressable operand

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean (no new findings; pre-existing warnings in
      `statecfg/version_schema_gen.go` and CL persistence WriteTo/ReadFrom
      signatures are unrelated)
- [x] `make lint` clean (run twice due to non-determinism)
- [x] `make erigon` builds
- [ ] CI green
