### PR TITLE
ci: retry transient image-build/registry failures in hive CI gate

### DIFF
--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -187,7 +187,16 @@ jobs:
       - name: Build erigon image from local source
         env:
           DOCKER_BUILDKIT: "1"
-        run: docker build -t hive/erigon:cilocal erigon-full
+        run: |
+          retry() {
+            local max=$1 n=1; shift
+            until "$@"; do
+              if (( n >= max )); then echo "::error::'$*' failed after ${max} attempts" >&2; return 1; fi
+              echo "::warning::'$*' failed (attempt ${n}/${max}); retrying in $((n*15))s" >&2
+              sleep $((n*15)); n=$((n+1))
+            done
+          }
+          retry 3 docker build -t hive/erigon:cilocal erigon-full
 
       - name: Get dependencies and build hive
         env:
@@ -197,7 +206,15 @@ jobs:
           ERIGON_EXEC3_PARALLEL: ${{ matrix.exec_mode == 'parallel' && 'true' || 'false' }}
         run: |
           cd hive
-          go get . >> buildlogs.log
+          retry() {
+            local max=$1 n=1; shift
+            until "$@"; do
+              if (( n >= max )); then echo "::error::'$*' failed after ${max} attempts" >&2; return 1; fi
+              echo "::warning::'$*' failed (attempt ${n}/${max}); retrying in $((n*15))s" >&2
+              sleep $((n*15)); n=$((n+1))
+            done
+          }
+          retry 3 go get . >> buildlogs.log
           # Point hive's default (prebuilt-image) erigon client at the image we
           # built locally above, instead of cloning erigon inside the builder.
           sed -i "s|^ARG baseimage=erigontech/erigon$|ARG baseimage=hive/erigon|" clients/erigon/Dockerfile
@@ -222,7 +239,7 @@ jobs:
               exit 1
             fi
           fi
-          go build . >> buildlogs.log
+          retry 3 go build . >> buildlogs.log
       # Depends on the last line of hive output that prints the number of suites, tests and failed
       # Currently, we fail even if suites and tests are too few, indicating the tests did not run
       # We also fail if more than half the tests fail
@@ -240,19 +257,23 @@ jobs:
             echo -e "\n\n============================================================"
             echo "Running test: ${1}"
             echo -e "\n"
-            ./hive -docker.output -docker.auth --sim ethereum/eels/"${1}" --sim.limit="${2}" --sim.parallelism=12 --client.pool.size=${{ matrix.pool-size }} --client erigon --docker.nocache=true --sim.limit.exact=false --sim.buildarg fixtures="${fixtures_url}" ${branch_arg} ${{ matrix.extra-hive-flags }} 2>&1 | tee output.log || {
-              if [ $? -gt 0 ]; then
-                echo "Exitcode gt 0"
-              fi
-            }
-            status_line=$(tail -2 output.log | head -1 | sed -r "s/\x1B\[[0-9;]*[a-zA-Z]//g")
-            suites=$(echo "$status_line" | sed -n 's/.*suites=\([0-9]*\).*/\1/p')
-            if [ -z "$suites" ]; then
-              status_line=$(tail -1 output.log | sed -r "s/\x1B\[[0-9;]*[a-zA-Z]//g")
+            # Retry only on the "too few tests parsed" signal (a transient
+            # image-build/registry/clone failure); a completed run is judged on its first result.
+            local attempt=1 max_attempts=3
+            while true; do
+              ./hive -docker.output -docker.auth --sim ethereum/eels/"${1}" --sim.limit="${2}" --sim.parallelism=12 --client.pool.size=${{ matrix.pool-size }} --client erigon --docker.nocache=true --sim.limit.exact=false --sim.buildarg fixtures="${fixtures_url}" ${branch_arg} ${{ matrix.extra-hive-flags }} 2>&1 | tee output.log || true
+              status_line=$(tail -2 output.log | head -1 | sed -r "s/\x1B\[[0-9;]*[a-zA-Z]//g")
               suites=$(echo "$status_line" | sed -n 's/.*suites=\([0-9]*\).*/\1/p')
-            fi 
-            tests=$(echo "$status_line" | sed -n 's/.*tests=\([0-9]*\).*/\1/p')
-            failed=$(echo "$status_line" | sed -n 's/.*failed=\([0-9]*\).*/\1/p')
+              if [ -z "$suites" ]; then
+                status_line=$(tail -1 output.log | sed -r "s/\x1B\[[0-9;]*[a-zA-Z]//g")
+                suites=$(echo "$status_line" | sed -n 's/.*suites=\([0-9]*\).*/\1/p')
+              fi
+              tests=$(echo "$status_line" | sed -n 's/.*tests=\([0-9]*\).*/\1/p')
+              failed=$(echo "$status_line" | sed -n 's/.*failed=\([0-9]*\).*/\1/p')
+              if (( ${tests:-0} >= 4 )) || (( attempt >= max_attempts )); then break; fi
+              echo "::warning title=Retrying hive::Only ${tests:-0} tests parsed for ${{ matrix.shard }} (attempt ${attempt}/${max_attempts}); likely transient image-build/registry/clone error — retrying in $((attempt*20))s"
+              sleep $((attempt*20)); attempt=$((attempt+1))
+            done
 
             echo -e "\n"
             message="-----------   Results for ${1} (${{ matrix.shard }})    -----------\nTests: $tests, Failed: $failed\n\n============================================================"

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -134,7 +134,16 @@ jobs:
       - name: Build erigon image from local source
         env:
           DOCKER_BUILDKIT: "1"
-        run: docker build -t hive/erigon:cilocal erigon-full
+        run: |
+          retry() {
+            local max=$1 n=1; shift
+            until "$@"; do
+              if (( n >= max )); then echo "::error::'$*' failed after ${max} attempts" >&2; return 1; fi
+              echo "::warning::'$*' failed (attempt ${n}/${max}); retrying in $((n*15))s" >&2
+              sleep $((n*15)); n=$((n+1))
+            done
+          }
+          retry 3 docker build -t hive/erigon:cilocal erigon-full
 
       - name: Get dependencies and build hive
         env:
@@ -145,7 +154,15 @@ jobs:
           ERIGON_EXEC3_PARALLEL: ${{ matrix.exec_mode == 'parallel' && 'true' || 'false' }}
         run: |
           cd hive
-          go get . >> buildlogs.log
+          retry() {
+            local max=$1 n=1; shift
+            until "$@"; do
+              if (( n >= max )); then echo "::error::'$*' failed after ${max} attempts" >&2; return 1; fi
+              echo "::warning::'$*' failed (attempt ${n}/${max}); retrying in $((n*15))s" >&2
+              sleep $((n*15)); n=$((n+1))
+            done
+          }
+          retry 3 go get . >> buildlogs.log
           # Point hive's default (prebuilt-image) erigon client at the image we
           # built locally above, instead of cloning erigon inside the builder.
           sed -i "s|^ARG baseimage=erigontech/erigon$|ARG baseimage=hive/erigon|" clients/erigon/Dockerfile
@@ -173,7 +190,7 @@ jobs:
             echo "Pinning rpc-compat execution-apis ref to ${EXECUTION_APIS_REF}"
             sed -i "s/^ARG branch=main$/ARG branch=${EXECUTION_APIS_REF}/" simulators/ethereum/rpc-compat/Dockerfile
           fi
-          go build . >> buildlogs.log
+          retry 3 go build . >> buildlogs.log
       # Depends on the last line of hive output that prints the number of suites, tests and failed
       # Currently, we fail even if suites and tests are too few, indicating the tests did not run
       # We also fail if more than half the tests fail
@@ -190,17 +207,25 @@ jobs:
             echo -e "\n\n============================================================"
             echo "Running test: ${1}-${2}"
             echo -e "\n"
-            if ! ./hive -docker.auth --sim "${1}" --sim.limit="${2}" --sim.limit.exact=false --sim.parallelism=8 --sim.timelimit 15m --docker.output --client erigon 2>&1 | tee output.log; then
-              echo "hive exited non-zero; continuing to parse results from output.log"
-            fi
-            status_line=$(tail -2 output.log | head -1 | sed -r "s/\x1B\[[0-9;]*[a-zA-Z]//g")
-            suites=$(echo "$status_line" | sed -n 's/.*suites=\([0-9]*\).*/\1/p')
-            if [ -z "$suites" ]; then
-              status_line=$(tail -1 output.log | sed -r "s/\x1B\[[0-9;]*[a-zA-Z]//g")
+            # Retry only on the "too few tests parsed" signal (a transient
+            # image-build/registry/clone failure); a completed run is judged on its first result.
+            local attempt=1 max_attempts=3
+            while true; do
+              if ! ./hive -docker.auth --sim "${1}" --sim.limit="${2}" --sim.limit.exact=false --sim.parallelism=8 --sim.timelimit 15m --docker.output --client erigon 2>&1 | tee output.log; then
+                echo "hive exited non-zero; continuing to parse results from output.log"
+              fi
+              status_line=$(tail -2 output.log | head -1 | sed -r "s/\x1B\[[0-9;]*[a-zA-Z]//g")
               suites=$(echo "$status_line" | sed -n 's/.*suites=\([0-9]*\).*/\1/p')
-            fi
-            tests=$(echo "$status_line" | sed -n 's/.*tests=\([0-9]*\).*/\1/p')
-            failed=$(echo "$status_line" | sed -n 's/.*failed=\([0-9]*\).*/\1/p')
+              if [ -z "$suites" ]; then
+                status_line=$(tail -1 output.log | sed -r "s/\x1B\[[0-9;]*[a-zA-Z]//g")
+                suites=$(echo "$status_line" | sed -n 's/.*suites=\([0-9]*\).*/\1/p')
+              fi
+              tests=$(echo "$status_line" | sed -n 's/.*tests=\([0-9]*\).*/\1/p')
+              failed=$(echo "$status_line" | sed -n 's/.*failed=\([0-9]*\).*/\1/p')
+              if (( ${tests:-0} >= 4 )) || (( attempt >= max_attempts )); then break; fi
+              echo "::warning title=Retrying hive::Only ${tests:-0} tests parsed for ${1}-${2} (attempt ${attempt}/${max_attempts}); likely transient image-build/registry/clone error — retrying in $((attempt*20))s"
+              sleep $((attempt*20)); attempt=$((attempt+1))
+            done
 
             echo -e "\n"
             echo "-----------   Results for ${1}-${2}    -----------"


### PR DESCRIPTION
## Why

Both merge-queue failures of #21374 were transient CI infrastructure blips on network-dependent steps that had **no retry** — not problems with the PR's code:

- **Docker Hub registry error** building hive's `hiveproxy` image: `Head https://registry-1.docker.io/v2/library/alpine/manifests/latest: unknown:` → `Tests: , Failed:` (zero tests ran).
- **github.com 403** during the in-builder erigon clone (`fatal: unable to access 'https://github.com/erigontech/erigon/': 403`). That specific path is already largely addressed by #21447 (build erigon locally instead of cloning inside hive's builder), but the Docker Hub base-image pulls remain in both `docker build` and `./hive`.

The merge-queue contract (per `CI-GUIDELINES.md`) is "a failure means the code is wrong — zero false positives." These infra blips are exactly the false positives that contract forbids, and they re-queue whole batches.

## What

Add a small retry to the network-dependent steps in both `test-hive.yml` and `test-hive-eest.yml`:

- **Build steps** (`docker build` of the local erigon image, `go get`, `go build`): wrapped in a `retry()` helper — 3 attempts, linear backoff.
- **`./hive` run**: retried **only when too few tests were parsed** (`tests < 4`) — the signature of a setup/image-build failure. A completed run (`tests >= 4`) is judged on its first result and never retried.

## Why this is safe for the merge queue

- A **genuine test failure is never retried** — only the *fast* infra-setup failure path is, so the retry cannot mask a real regression.
- Because retries only trigger on the fast-fail (image build dying in seconds), added latency is seconds + backoff, not multiplied test runtime.
- This is step-level resilience, not reliance on merge-queue re-runs (which `CI-GUIDELINES.md` explicitly discourages as a flake mask).

## Testing

- Verified the retry logic locally under `bash -e -o pipefail` (the shell GitHub uses for `run:` steps): infra-fail-then-recover → passes after retry; genuine failure → not retried, fails immediately; persistent infra failure → retries to max then fails.
- `actionlint` clean — no new shellcheck findings (and removes one pre-existing SC2181).
- `make lint` → 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
