### PR TITLE
rpc: add Reth-compatible format for debug_executionWitness

### DIFF
--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -135,6 +135,7 @@ func RootCommand() (*cobra.Command, *httpcfg.HttpCfg) {
 	rootCmd.PersistentFlags().IntVar(&cfg.WsMaxConnections, utils.WsMaxConnectionsFlag.Name, utils.WsMaxConnectionsFlag.Value, utils.WsMaxConnectionsFlag.Usage)
 	rootCmd.PersistentFlags().BoolVar(&cfg.TraceCompatibility, "trace.compat", false, "Bug for bug compatibility with OE for trace_ routines")
 	rootCmd.PersistentFlags().BoolVar(&cfg.GethCompatibility, "rpc.gethcompat", false, "Enables Geth-compatible storage iteration order for debug_storageRangeAt (sorted by keccak256 hash). Disabled by default for performance.")
+	rootCmd.PersistentFlags().BoolVar(&cfg.WitnessGethCompat, utils.RpcWitnessCompatFlag.Name, false, utils.RpcWitnessCompatFlag.Usage)
 	rootCmd.PersistentFlags().StringVar(&cfg.TxPoolApiAddr, "txpool.api.addr", "", "txpool api network address, for example: 127.0.0.1:9090 (default: use value of --private.api.addr)")
 
 	rootCmd.PersistentFlags().StringVar(&stateCacheStr, "state.cache", "0MB", "Amount of data to store in StateCache (enabled if no --datadir set). Set 0 to disable StateCache. Defaults to 0MB RAM")

--- a/cmd/rpcdaemon/cli/httpcfg/http_cfg.go
+++ b/cmd/rpcdaemon/cli/httpcfg/http_cfg.go
@@ -77,6 +77,7 @@ type HttpCfg struct {
 	WsMaxConnections                  int  // WebSocket connection limit; 0 = unlimited
 	TraceCompatibility                bool // Bug for bug compatibility for trace_ routines with OpenEthereum
 	GethCompatibility                 bool // Geth-compatible storage iteration order for debug_storageRangeAt
+	WitnessGethCompat                 bool // Geth-compatible debug_executionWitness response format
 	TxPoolApiAddr                     string
 	StateCache                        kvcache.CoherentConfig
 	Snap                              ethconfig.BlocksFreezing

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -448,6 +448,10 @@ var (
 		Name:  "rpc.gethcompat",
 		Usage: "Enables Geth-compatible storage iteration order for debug_storageRangeAt (sorted by keccak256 hash). Disabled by default for performance.",
 	}
+	RpcWitnessCompatFlag = cli.BoolFlag{
+		Name:  "rpc.witness.gethcompat",
+		Usage: "Use Geth-compatible debug_executionWitness response format (JSON headers). Default: Reth-compatible format (RLP-encoded headers).",
+	}
 	RpcTxSyncDefaultTimeoutFlag = cli.DurationFlag{
 		Name:  "rpc.txsync.defaulttimeout",
 		Usage: "Default timeout for eth_sendRawTransactionSync (default: 25 secs).",

--- a/node/cli/default_flags.go
+++ b/node/cli/default_flags.go
@@ -96,6 +96,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.RpcAccessListFlag,
 	&utils.RpcTraceCompatFlag,
 	&utils.RpcGethCompatFlag,
+	&utils.RpcWitnessCompatFlag,
 	&utils.RpcGasCapFlag,
 	&utils.RpcBlockRangeLimit,
 	&utils.RpcGetLogsMaxResults,

--- a/node/cli/flags.go
+++ b/node/cli/flags.go
@@ -474,6 +474,7 @@ func setEmbeddedRpcDaemon(ctx *cli.Context, cfg *nodecfg.Config, logger log.Logg
 		MaxTraces:           ctx.Uint64(utils.TraceMaxtracesFlag.Name),
 		TraceCompatibility:  ctx.Bool(utils.RpcTraceCompatFlag.Name),
 		GethCompatibility:   ctx.Bool(utils.RpcGethCompatFlag.Name),
+		WitnessGethCompat:   ctx.Bool(utils.RpcWitnessCompatFlag.Name),
 		BatchLimit:          ctx.Int(utils.RpcBatchLimit.Name),
 		ReturnDataLimit:     ctx.Int(utils.RpcReturnDataLimit.Name),
 		AllowUnprotectedTxs: ctx.Bool(utils.AllowUnprotectedTxs.Name),

--- a/rpc/jsonrpc/daemon.go
+++ b/rpc/jsonrpc/daemon.go
@@ -54,7 +54,7 @@ func APIList(db kv.TemporalRoDB, eth rpchelper.ApiBackend, txPool txpoolproto.Tx
 	erigonImpl := NewErigonAPI(base, db, eth)
 	txpoolImpl := NewTxPoolAPI(base, db, txPool)
 	netImpl := NewNetAPIImpl(eth)
-	debugImpl := NewPrivateDebugAPI(base, db, eth, cfg.Gascap, cfg.GethCompatibility)
+	debugImpl := NewPrivateDebugAPI(base, db, eth, cfg.Gascap, cfg.GethCompatibility, cfg.WitnessGethCompat)
 	traceImpl := NewTraceAPI(base, db, cfg)
 	web3Impl := NewWeb3APIImpl(eth)
 	adminImpl := NewAdminAPI(eth)

--- a/rpc/jsonrpc/debug_api.go
+++ b/rpc/jsonrpc/debug_api.go
@@ -82,16 +82,18 @@ type DebugAPIImpl struct {
 	ethBackend        rpchelper.ApiBackend
 	GasCap            uint64
 	gethCompatibility bool // Geth-compatible storage iteration order for debug_storageRangeAt
+	witnessGethCompat bool // Geth-compatible debug_executionWitness response format
 }
 
 // NewPrivateDebugAPI returns PrivateDebugAPIImpl instance
-func NewPrivateDebugAPI(base *BaseAPI, db kv.TemporalRoDB, ethBackend rpchelper.ApiBackend, gascap uint64, gethCompatibility bool) *DebugAPIImpl {
+func NewPrivateDebugAPI(base *BaseAPI, db kv.TemporalRoDB, ethBackend rpchelper.ApiBackend, gascap uint64, gethCompatibility bool, witnessGethCompat bool) *DebugAPIImpl {
 	return &DebugAPIImpl{
 		BaseAPI:           base,
 		db:                db,
 		ethBackend:        ethBackend,
 		GasCap:            gascap,
 		gethCompatibility: gethCompatibility,
+		witnessGethCompat: witnessGethCompat,
 	}
 }
 

--- a/rpc/jsonrpc/debug_api_test.go
+++ b/rpc/jsonrpc/debug_api_test.go
@@ -91,7 +91,7 @@ func TestTraceBlockByNumber(t *testing.T) {
 	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
 	baseApi := NewBaseApi(nil, stateCache, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0)
 	ethApi := newEthApiForTest(baseApi, m.DB, nil, nil)
-	api := NewPrivateDebugAPI(baseApi, m.DB, nil, 0, false)
+	api := NewPrivateDebugAPI(baseApi, m.DB, nil, 0, false, false)
 	for _, tt := range debugTraceTransactionTests {
 		var buf bytes.Buffer
 		s := jsonstream.New(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096))
@@ -142,7 +142,7 @@ func TestTraceBlockByNumber(t *testing.T) {
 func TestTraceBlockByHash(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
 	ethApi := newEthApiForTest(newBaseApiForTest(m), m.DB, nil, nil)
-	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false)
+	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false, false)
 	for _, tt := range debugTraceTransactionTests {
 		var buf bytes.Buffer
 		s := jsonstream.New(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096))
@@ -173,7 +173,7 @@ func TestTraceBlockByHash(t *testing.T) {
 
 func TestTraceTransaction(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false)
+	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false, false)
 	for _, tt := range debugTraceTransactionTests {
 		var buf bytes.Buffer
 		s := jsonstream.New(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096))
@@ -202,7 +202,7 @@ func TestTraceTransaction(t *testing.T) {
 
 func TestTraceTransactionNotFound(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false)
+	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false, false)
 
 	var buf bytes.Buffer
 	s := jsonstream.New(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096))
@@ -212,7 +212,7 @@ func TestTraceTransactionNotFound(t *testing.T) {
 
 func TestTraceTransactionNoRefund(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false)
+	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false, false)
 	for _, tt := range debugTraceTransactionNoRefundTests {
 		var buf bytes.Buffer
 		s := jsonstream.New(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096))
@@ -242,7 +242,7 @@ func TestTraceTransactionNoRefund(t *testing.T) {
 
 func TestStorageRangeAt(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false)
+	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false, false)
 	t.Run("invalid addr", func(t *testing.T) {
 		var block4 *types.Block
 		var err error
@@ -336,7 +336,7 @@ func TestStorageRangeAt(t *testing.T) {
 
 func TestStorageRangeAtGethCompat(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, true) // gethCompatibility=true
+	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, true, false) // gethCompatibility=true
 	t.Run("block latest, addr 1", func(t *testing.T) {
 		var latestBlock *types.Block
 		err := m.DB.View(m.Ctx, func(tx kv.Tx) (err error) {
@@ -402,7 +402,7 @@ func TestStorageRangeAtGethCompat(t *testing.T) {
 
 func TestAccountRange(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false)
+	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false, false)
 
 	t.Run("valid account", func(t *testing.T) {
 		addr := common.HexToAddress("0x537e697c7ab75a26f9ecf0ce810e3154dfcaaf55")
@@ -461,7 +461,7 @@ func TestAccountRange(t *testing.T) {
 
 func TestGetModifiedAccountsByNumber(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false)
+	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false, false)
 
 	t.Run("correct input", func(t *testing.T) {
 		n, n2 := rpc.BlockNumber(1), rpc.BlockNumber(2)
@@ -576,7 +576,7 @@ func TestMapTxNum2BlockNum(t *testing.T) {
 
 func TestAccountAt(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false)
+	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false, false)
 
 	var blockHash0, blockHash1, blockHash3, blockHash10, blockHashNonExistent common.Hash
 	_ = m.DB.View(m.Ctx, func(tx kv.Tx) error {
@@ -639,7 +639,7 @@ func TestAccountAt(t *testing.T) {
 
 func TestGetBadBlocks(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 5000000, false)
+	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 5000000, false, false)
 	ctx := context.Background()
 
 	require := require.New(t)
@@ -712,7 +712,7 @@ func TestGetBadBlocks(t *testing.T) {
 
 func TestGetRawTransaction(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 5000000, false)
+	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 5000000, false, false)
 	ctx := context.Background()
 
 	require := require.New(t)
@@ -760,7 +760,7 @@ func TestExecutionWitness(t *testing.T) {
 	})
 
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false)
+	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false, false)
 	ctx := context.Background()
 
 	// Write the DB flag so that debug_executionWitness accepts the request.
@@ -799,8 +799,8 @@ func TestExecutionWitness(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		require.NotNil(t, result.State, "State should not be nil")
-		require.Nil(t, result.Keys, "Keys must remain nil (Geth compatibility)")
-		if len(result.Headers) > 0 {
+		require.NotNil(t, result.Keys, "Keys must be set in Reth-compatible mode")
+		if len(result.headerByNumber) > 0 {
 			require.Contains(t, result.headerByNumber, uint64(0), "parent header (block 0) must be present in lookup map when Headers is non-empty")
 		}
 	})
@@ -917,7 +917,7 @@ func TestSetHead(t *testing.T) {
 		backendServer := privateapi.NewEthBackendServer(ctx, mock, m.DB, m.Notifications, m.BlockReader, nil, logger, builder.NewLatestBlockBuiltStore(), nil)
 		backendClient := direct.NewEthBackendClientDirect(backendServer)
 		backend := rpcservices.NewRemoteBackend(backendClient, m.DB, m.BlockReader)
-		return NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, backend, 0, false)
+		return NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, backend, 0, false, false)
 	}
 
 	// Rewinding one block below the current head is the simplest valid rewind.

--- a/rpc/jsonrpc/debug_execution_witness.go
+++ b/rpc/jsonrpc/debug_execution_witness.go
@@ -26,6 +26,7 @@ import (
 	"github.com/erigontech/erigon/execution/protocol"
 	"github.com/erigontech/erigon/execution/protocol/params"
 	"github.com/erigontech/erigon/execution/protocol/rules"
+	"github.com/erigontech/erigon/execution/rlp"
 	"github.com/erigontech/erigon/execution/state"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/execution/types/accounts"
@@ -460,6 +461,26 @@ func (s *RecordingState) GetModifiedCode() map[common.Address][]byte {
 	return result
 }
 
+func witnessHeadersToJSON(headers []*types.Header) []map[string]any {
+	result := make([]map[string]any, len(headers))
+	for i, h := range headers {
+		result[i] = marshalWitnessHeader(h)
+	}
+	return result
+}
+
+func witnessHeadersToRLP(headers []*types.Header) ([]hexutil.Bytes, error) {
+	result := make([]hexutil.Bytes, len(headers))
+	for i, h := range headers {
+		encoded, err := rlp.EncodeToBytes(h)
+		if err != nil {
+			return nil, fmt.Errorf("failed to RLP-encode header %d: %w", h.Number.Uint64(), err)
+		}
+		result[i] = encoded
+	}
+	return result, nil
+}
+
 // marshalWitnessHeader converts a block header to the JSON map format used in
 // debug_executionWitness responses, matching Geth's output format.
 func marshalWitnessHeader(h *types.Header) map[string]any {
@@ -501,14 +522,15 @@ type ExecutionWitnessResult struct {
 	Codes []hexutil.Bytes `json:"codes"`
 	// Keys is always null (reserved for future use, included for Geth compatibility)
 	Keys []hexutil.Bytes `json:"keys"`
-	// Headers is a list of block headers (as JSON objects) needed for BLOCKHASH opcode support.
-	// For blocks that touch state, always includes the parent block header plus any blocks accessed
-	// via BLOCKHASH. Omitted (nil) for empty-touch blocks, where ExecutionWitness returns early
-	// before headers are collected.
-	Headers []map[string]any `json:"headers,omitempty"`
+	// Headers is a list of block headers needed for BLOCKHASH opcode support.
+	// Format depends on the --rpc.witness.gethcompat flag: JSON objects (Geth) or RLP-encoded bytes (Reth).
+	// Omitted for empty-touch blocks where ExecutionWitness returns early.
+	Headers any `json:"headers,omitempty"`
 
 	// lookup map for BLOCKHASH opcode, not serialized to JSON
 	headerByNumber map[uint64]*types.Header
+	// allCodes holds all accessed + newly deployed code (unfiltered) for stateless verification
+	allCodes []hexutil.Bytes
 }
 
 func (m *ExecutionWitnessResult) getHashFn(blockNum uint64) (common.Hash, error) {
@@ -640,12 +662,16 @@ func (api *DebugAPIImpl) ExecutionWitness(ctx context.Context, blockNrOrHash rpc
 		return nil, fmt.Errorf("failed to commit block: %w", err)
 	}
 
-	accessed := collectAccessedState(recordingState)
+	accessed := collectAccessedState(recordingState, api.witnessGethCompat)
 
 	result := &ExecutionWitnessResult{
 		State:          []hexutil.Bytes{},
 		Codes:          accessed.SortedCodes,
+		allCodes:       accessed.AllCodes,
 		headerByNumber: make(map[uint64]*types.Header),
+	}
+	if !api.witnessGethCompat {
+		result.Keys = accessed.SortedKeys
 	}
 
 	// Build merkle proofs for all accessed accounts
@@ -694,12 +720,19 @@ func (api *DebugAPIImpl) ExecutionWitness(ctx context.Context, blockNrOrHash rpc
 	}
 	result.State = nodes
 
-	headers, byNumber, err := api.collectAccessedHeaders(ctx, tx, parentNum, accessedBlockHashes)
+	ordered, byNumber, err := api.collectAccessedHeaders(ctx, tx, parentNum, accessedBlockHashes)
 	if err != nil {
 		return nil, err
 	}
-	result.Headers = headers
 	result.headerByNumber = byNumber
+	if api.witnessGethCompat {
+		result.Headers = witnessHeadersToJSON(ordered)
+	} else {
+		result.Headers, err = witnessHeadersToRLP(ordered)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if err := api.verifyWitnessStateless(ctx, tx, result, block, fullEngine); err != nil {
 		return nil, err
@@ -711,14 +744,14 @@ func (api *DebugAPIImpl) ExecutionWitness(ctx context.Context, blockNrOrHash rpc
 // accessedState summarizes everything the witness needs from a recorded execution:
 // the deduplicated set of accessed accounts/storage/code addresses, the sorted code
 // blobs that go into result.Codes, and the pre-state code reads that feed witness
-// trie generation. SortedKeys is built for symmetry with PR #21227 but currently
-// vestigial — result.Keys is intentionally always null per Geth compatibility.
+// trie generation.
 type accessedState struct {
 	SortedKeys  []hexutil.Bytes
 	Addresses   map[common.Address]struct{}
 	Storage     map[common.Address]map[common.Hash]struct{}
 	CodeAddrs   map[common.Address]struct{}
-	SortedCodes []hexutil.Bytes
+	SortedCodes []hexutil.Bytes // code for accounts in the witness, filtered by state access (Reth semantics)
+	AllCodes    []hexutil.Bytes // all accessed + newly deployed, unfiltered (for stateless verification)
 	CodeReads   map[common.Hash]witnesstypes.CodeWithHash
 }
 
@@ -748,21 +781,18 @@ func (a *accessedState) touchAll(sdCtx *commitmentdb.SharedDomainsCommitmentCont
 }
 
 // collectAccessedState rolls the RecordingState read/write maps and the three
-// code-tracking maps into a single accessedState. SortedCodes is sourced from
-// rs.GetPreStateCode() (pre-block reads only): the witness must carry the
-// bytecode that existed at the start of the block, not code created in-block.
-// A stateless verifier re-derives in-block-created code by replaying the
-// transactions, so emitting it would be redundant over-inclusion.
+// code-tracking maps into a single accessedState.
 //
 // SortedCodes is initialized to an empty (non-nil) slice so callers can assign
 // result.Codes = accessed.SortedCodes without risking a "codes": null JSON
 // regression for empty-touch blocks; the Codes field has no omitempty.
-func collectAccessedState(rs *RecordingState) *accessedState {
+func collectAccessedState(rs *RecordingState, gethCompat bool) *accessedState {
 	out := &accessedState{
 		Addresses:   make(map[common.Address]struct{}),
 		Storage:     make(map[common.Address]map[common.Hash]struct{}),
 		CodeAddrs:   make(map[common.Address]struct{}),
 		SortedCodes: []hexutil.Bytes{},
+		AllCodes:    []hexutil.Bytes{},
 		CodeReads:   make(map[common.Hash]witnesstypes.CodeWithHash),
 	}
 
@@ -822,10 +852,9 @@ func collectAccessedState(rs *RecordingState) *accessedState {
 	for addr := range out.Addresses {
 		sortedKeys = append(sortedKeys, addr[:])
 	}
-	for addr, keys := range out.Storage {
+	for _, keys := range out.Storage {
 		for key := range keys {
-			composite := append(addr[:], key[:]...)
-			sortedKeys = append(sortedKeys, composite)
+			sortedKeys = append(sortedKeys, key[:])
 		}
 	}
 	slices.SortFunc(sortedKeys, func(a, b hexutil.Bytes) int {
@@ -838,25 +867,49 @@ func collectAccessedState(rs *RecordingState) *accessedState {
 		hash common.Hash
 	}
 
-	preStateCode := rs.GetPreStateCode()
+	accessedCode := rs.GetAccessedCode()
+	modCode := rs.GetModifiedCode()
+
+	sortedCodesSlice := func(m map[common.Hash][]byte) []hexutil.Bytes {
+		items := make([]codeWithHash, 0, len(m))
+		for h, code := range m {
+			items = append(items, codeWithHash{code: code, hash: h})
+		}
+		slices.SortFunc(items, func(a, b codeWithHash) int {
+			return bytes.Compare(a.hash[:], b.hash[:])
+		})
+		result := make([]hexutil.Bytes, 0, len(items))
+		for _, c := range items {
+			result = append(result, c.code)
+		}
+		return result
+	}
+
 	allCodesByHash := make(map[common.Hash][]byte)
-	for _, code := range preStateCode {
+	filteredCodesByHash := make(map[common.Hash][]byte)
+	for addr, code := range accessedCode {
+		if len(code) > 0 {
+			h := crypto.Keccak256Hash(code)
+			allCodesByHash[h] = code
+			if _, inState := out.Addresses[addr]; inState {
+				filteredCodesByHash[h] = code
+			}
+		}
+	}
+
+	out.SortedCodes = sortedCodesSlice(filteredCodesByHash)
+	if !gethCompat {
+		out.SortedCodes = filterEIP7702Codes(out.SortedCodes, accessedCode)
+	}
+
+	// AllCodes: add newly deployed code into allCodesByHash, then sort
+	for _, code := range modCode {
 		if len(code) > 0 {
 			h := crypto.Keccak256Hash(code)
 			allCodesByHash[h] = code
 		}
 	}
-
-	uniqueCodes := make([]codeWithHash, 0, len(allCodesByHash))
-	for h, code := range allCodesByHash {
-		uniqueCodes = append(uniqueCodes, codeWithHash{code: code, hash: h})
-	}
-	slices.SortFunc(uniqueCodes, func(a, b codeWithHash) int {
-		return bytes.Compare(a.hash[:], b.hash[:])
-	})
-	for _, c := range uniqueCodes {
-		out.SortedCodes = append(out.SortedCodes, c.code)
-	}
+	out.AllCodes = sortedCodesSlice(allCodesByHash)
 
 	preCode := rs.GetPreStateCode()
 	for addr, code := range preCode {
@@ -870,7 +923,6 @@ func collectAccessedState(rs *RecordingState) *accessedState {
 		}
 	}
 
-	modCode := rs.GetModifiedCode()
 	for addr := range preCode {
 		out.CodeAddrs[addr] = struct{}{}
 	}
@@ -879,6 +931,32 @@ func collectAccessedState(rs *RecordingState) *accessedState {
 	}
 
 	return out
+}
+
+// filterEIP7702Codes removes EIP-7702 delegation designator codes (0xef0100||address)
+// and their corresponding target contract codes from the given codes slice.
+func filterEIP7702Codes(codes []hexutil.Bytes, accessedCode map[common.Address][]byte) []hexutil.Bytes {
+	excluded := make(map[common.Hash]struct{})
+	for _, code := range accessedCode {
+		if len(code) == 23 && code[0] == 0xef && code[1] == 0x01 && code[2] == 0x00 {
+			excluded[crypto.Keccak256Hash(code)] = struct{}{}
+			var target common.Address
+			copy(target[:], code[3:23])
+			if targetCode, ok := accessedCode[target]; ok && len(targetCode) > 0 {
+				excluded[crypto.Keccak256Hash(targetCode)] = struct{}{}
+			}
+		}
+	}
+	if len(excluded) == 0 {
+		return codes
+	}
+	filtered := make([]hexutil.Bytes, 0, len(codes))
+	for _, code := range codes {
+		if _, skip := excluded[crypto.Keccak256Hash(code)]; !skip {
+			filtered = append(filtered, code)
+		}
+	}
+	return filtered
 }
 
 // detectCollapseSiblings runs STEP 1 of witness construction: compute the full
@@ -1049,8 +1127,7 @@ func (api *DebugAPIImpl) collectAccessedHeaders(
 	tx kv.TemporalTx,
 	parentNum uint64,
 	accessedBlockNums []uint64,
-) (headers []map[string]any, byNumber map[uint64]*types.Header, err error) {
-	headers = []map[string]any{}
+) (ordered []*types.Header, byNumber map[uint64]*types.Header, err error) {
 	byNumber = make(map[uint64]*types.Header)
 
 	addHeader := func(bn uint64) error {
@@ -1065,7 +1142,7 @@ func (api *DebugAPIImpl) collectAccessedHeaders(
 		if h == nil {
 			return fmt.Errorf("missing header for block %d", bn)
 		}
-		headers = append(headers, marshalWitnessHeader(h))
+		ordered = append(ordered, h)
 		byNumber[h.Number.Uint64()] = h
 
 		return nil
@@ -1080,7 +1157,7 @@ func (api *DebugAPIImpl) collectAccessedHeaders(
 		}
 	}
 
-	return headers, byNumber, nil
+	return ordered, byNumber, nil
 }
 
 // verifyWitnessStateless optionally re-executes the block statelessly against the
@@ -1354,9 +1431,9 @@ func newWitnessStateless(result *ExecutionWitnessResult) (*witnessStateless, err
 		return nil, fmt.Errorf("failed to decode witness trie: %w", err)
 	}
 
-	// Build code map from codes list
+	// Build code map from all accessed codes (pre-existing + newly deployed)
 	codeMap := make(map[common.Hash][]byte)
-	for _, code := range result.Codes {
+	for _, code := range result.allCodes {
 		codeHash := crypto.Keccak256Hash(code)
 		codeMap[codeHash] = code
 	}

--- a/rpc/jsonrpc/gen_traces_test.go
+++ b/rpc/jsonrpc/gen_traces_test.go
@@ -47,7 +47,7 @@ func TestGeneratedDebugApi(t *testing.T) {
 	m := rpcdaemontest.CreateTestExecModuleForTraces(t)
 	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
 	baseApi := NewBaseApi(nil, stateCache, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0)
-	api := NewPrivateDebugAPI(baseApi, m.DB, nil, 0, false)
+	api := NewPrivateDebugAPI(baseApi, m.DB, nil, 0, false, false)
 	var buf bytes.Buffer
 	stream := jsonstream.New(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096))
 	callTracer := "callTracer"


### PR DESCRIPTION
Before this PR the debug_executionWitness ()  returns data according Geth.

This PR permit to return debug_executionWitness () in two formats: Reth (canonical) [default] and Geth using a config param

In debug_execution_witness.go:
  - ExecutionWitnessResult.Headers changed from []map[string]any to any (holds either JSON objects or RLP-encoded bytes depending on the flag)
  - Added internal allCodes field for stateless verification (unfiltered: accessed + newly deployed code)
  - New witnessHeadersToJSON and witnessHeadersToRLP serialisation helpers
  - New filterEIP7702Codes — removes EIP-7702 delegation designator codes and their targets from codes in Reth-compat mode
  - collectAccessedState accepts gethCompat bool and integrates the EIP-7702 filter internally, avoiding a second GetAccessedCode() call
  - collectAccessedHeaders now returns []*types.Header; serialisation to wire format happens at the call site
  - Storage keys: emit key.Bytes() only (previously addr || key composite)
  - Local sortedCodesSlice helper eliminates the duplicated sort-and-collect pattern used for both SortedCodes and AllCodes
  - Stateless verifier uses allCodes instead of Codes so contracts deployed within the block are available during re-execution

- Reth-compatible (defualt):
    * headers RLP-encoded, 
    * keys populated (EIP-7702 delegation codes filtered out)
    * code see Reth canonical
    * state
 
- --rpc.witness.gethcompat: Geth-compatible:
    * headers json object 
    * keys null
    * code 
    * state

I've run some tests on Hive (50 blocks), and Erigon returns the exact same responses as Geth and Reth (canonical) for all fields except for state.
For the state field in a few tests on hive:
- Erigon provides fewer MPT nodes than Geth, and 
- other few even fewer than Reth canonical.
It's possible that these extra/missing nodes aren't actually essential for the witness.

I haven't run any tests on mainnet comparing with Reth (canonical), but
 I have run a few mainnet tests comparing with Geth using the --rpc.witness.gethcompat flag
