### PR TITLE
execution/stagedsync: drop stale eth/71 TODO in bal_create

### DIFF
--- a/execution/stagedsync/bal_create.go
+++ b/execution/stagedsync/bal_create.go
@@ -77,9 +77,8 @@ func ProcessBAL(tx kv.TemporalRwTx, h *types.Header, vio *state.VersionedIO, isE
 	if err != nil {
 		return fmt.Errorf("block %d: read stored block access list: %w", blockNum, err)
 	}
-	// BAL data may not be stored for blocks downloaded via backward
-	// block downloader (p2p sync) since it does not carry BAL sidecars.
-	// Remove after eth/71 has been implemented.
+	// A stored BAL sidecar may be absent — eth/71 backfill is best-effort and
+	// never blocks stage progress — so cross-check it only when present.
 	if dbBALBytes != nil {
 		dbBAL, err := types.DecodeBlockAccessListBytes(dbBALBytes)
 		if err != nil {


### PR DESCRIPTION
## What

`ProcessBAL`'s `if dbBALBytes != nil` guard carried the comment _"Remove after eth/71 has been implemented."_ This drops that stale instruction and rewords the comment to document why the nil-check must stay. Comment-only; no behaviour change.

## Why

eth/71 (EIP-8159, Block Access List Exchange) **is** now implemented — BAL sidecars are fetched over the wire by the always-on background `BALDownloader` (`p2p/sentry/sentry_multi_client/bal_downloader.go`) and served via `AnswerGetBlockAccessListsQuery`. So the premise behind the TODO — _"once eth/71 lands, BALs will always be stored, so this guard becomes dead"_ — no longer holds.

The downloader is best-effort by design and **never blocks stage progress** (per its own header doc); `ProcessBAL` regenerates and validates the BAL locally regardless, so a missing p2p-delivered BAL "is never a correctness issue — only a CPU-cost optimisation." A missing stored BAL (`dbBALBytes == nil`) therefore remains a normal, expected state, and the guard is still required — removing it would turn that normal state into a hard failure.

Net: eth/71 being implemented **invalidates** the TODO rather than enabling it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)