### PR TITLE
cmd/utils/app: import all RLP files in a single process

### DIFF
--- a/cmd/utils/app/import_cmd.go
+++ b/cmd/utils/app/import_cmd.go
@@ -87,6 +87,7 @@ func importChain(cliCtx *cli.Context) error {
 		utils.NATFlag.Name:               "none",
 		utils.NoDownloaderFlag.Name:      "true",
 		utils.ExternalConsensusFlag.Name: "true",
+		utils.MCPDisableFlag.Name:        "true",
 	} {
 		if err := cliCtx.Set(flag, value); err != nil {
 			return fmt.Errorf("importChain: set %s=%s: %w", flag, value, err)
@@ -116,10 +117,23 @@ func importChain(cliCtx *cli.Context) error {
 		return err
 	}
 
-	if err := ImportChain(ethereum, ethereum.ChainDB(), cliCtx.Args().First(), logger); err != nil {
-		return err
-	}
+	return importFiles(cliCtx.Args().Slice(), func(fn string) error {
+		return ImportChain(ethereum, ethereum.ChainDB(), fn, logger)
+	}, logger)
+}
 
+// importFiles imports each file via importOne, reusing one node for the whole
+// batch; with several files a per-file failure is logged and skipped, with a
+// single file it is fatal.
+func importFiles(files []string, importOne func(string) error, logger log.Logger) error {
+	for _, fn := range files {
+		if err := importOne(fn); err != nil {
+			if len(files) == 1 {
+				return err
+			}
+			logger.Warn("import: skipping file after error", "file", fn, "err", err)
+		}
+	}
 	return nil
 }
 

--- a/cmd/utils/app/import_cmd_test.go
+++ b/cmd/utils/app/import_cmd_test.go
@@ -1,0 +1,66 @@
+// Copyright 2024 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package app
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/log/v3"
+)
+
+func quietLogger() log.Logger {
+	l := log.New()
+	l.SetHandler(log.DiscardHandler())
+	return l
+}
+
+func TestImportFilesImportsEveryFileInOrder(t *testing.T) {
+	files := []string{"0001.rlp", "0002.rlp", "0003.rlp"}
+	var seen []string
+	err := importFiles(files, func(fn string) error {
+		seen = append(seen, fn)
+		return nil
+	}, quietLogger())
+	require.NoError(t, err)
+	assert.Equal(t, files, seen)
+}
+
+func TestImportFilesSingleFileErrorIsFatal(t *testing.T) {
+	wantErr := errors.New("bad block")
+	err := importFiles([]string{"only.rlp"}, func(string) error {
+		return wantErr
+	}, quietLogger())
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestImportFilesMultiFileToleratesPerFileError(t *testing.T) {
+	files := []string{"0001.rlp", "bad.rlp", "0003.rlp"}
+	var seen []string
+	err := importFiles(files, func(fn string) error {
+		seen = append(seen, fn)
+		if fn == "bad.rlp" {
+			return errors.New("bad block")
+		}
+		return nil
+	}, quietLogger())
+	require.NoError(t, err)
+	assert.Equal(t, files, seen)
+}


### PR DESCRIPTION
## Problem

The nightly `ethpandaops/hive-tests` `legacy` (ethereum/consensus) suite fails 9 tests against erigon `main` — all variants of `ForkStressTest` (×5) and `walletReorganizeOwners` (×4). They are **timeouts, not consensus failures**: each ran ~180.5s (hive's `--client.checktimelimit=180s`) and was killed mid-import with no errors.

Root cause: the consensus simulator feeds **one RLP block per file** (`/blocks/NNNN.rlp`, no `chain.rlp`), and erigon's hive entrypoint invoked `erigon import` **once per file**. Each invocation is a full node startup (DB open, P2P networking, private gRPC RPC, MCP server) costing ~0.66s before a single block is read. Reorg-stress tests have hundreds of blocks (ForkStressTest = 303, walletReorganizeOwners = 259), so 303 × 0.66s ≈ 200s > 180s → the client never becomes RPC-ready in time. The other 32 607 tests have few blocks and pass.

## Fix

`importChain` documented multi-file support (`<filename> (<filename 2> ... <filename N>)`) but only imported `cliCtx.Args().First()`. It now imports **every file in one node process** via `importFiles`, tolerating per-file failures when several files are given (fatal for a single file) — matching the documented contract and preserving the InvalidBlocks-test behavior the old per-process loop provided. The MCP server is also force-disabled for the one-shot import, alongside the existing NAT/downloader/external-consensus disables.

This is the binary half of the fix. The load-bearing companion batches the per-file loop in hive's `clients/erigon/erigon.sh` into one `erigon import` invocation (separate PR to `ethereum/hive`); **both are needed** to clear the suite.

## Validation

Reconstructed the exact hive scenario from the local legacy-tests fixtures + client logs and ran the rebuilt binary:

| Test | Blocks | Processes | Time | Resulting head |
|---|---|---|---|---|
| ForkStressTest_Frontier (12-fork reorg) | 303 | **1** | <1s | `0xc14ab05e…` ✅ = `lastblockhash` |
| walletReorganizeOwners_Homestead | 259 | **1** | <1s | `0xda82854c…` ✅ = `lastblockhash` |
| ForkStressTest + injected malformed files | — | 1 | — | bad files skipped (no panic), head still `0xc14ab05e…` ✅ |

The in-process side-chain/reorg logic yields the correct canonical head ~200× faster. This mirrors the native `testutil.BlockTest` harness, which already loops `InsertChain` per block in a single process for these same tests.

- `make lint` → 0 issues
- `make erigon integration` build clean
- New unit test `import_cmd_test.go` (TDD, Red→Green): all-files-imported + single-file-fatal + multi-file-tolerant

🤖 Generated with [Claude Code](https://claude.com/claude-code)