### PR TITLE
common/dbg, execution: PERF_PROFILES env knob + pprof labels for parallel exec phases

### DIFF
--- a/common/dbg/experiments.go
+++ b/common/dbg/experiments.go
@@ -122,7 +122,16 @@ var (
 
 	RpcDropResponse  = EnvBool("RPC_DROP_RESPONSE", false)
 	TipTrieWarmupers = EnvInt("TIP_TRIE_WARMUPERS", runtime.NumCPU()*8) //io-bound (not cpu-bound). it's ok to have `io-threads > cpus`
+
+	PerfProfiles = EnvBool("PERF_PROFILES", false)
 )
+
+func init() {
+	if PerfProfiles {
+		runtime.SetBlockProfileRate(1)
+		runtime.SetMutexProfileFraction(1)
+	}
+}
 
 func ReadMemStats(m *runtime.MemStats) {
 	if noMemstat {

--- a/execution/exec/state.go
+++ b/execution/exec/state.go
@@ -19,6 +19,7 @@ package exec
 import (
 	"context"
 	"fmt"
+	"runtime/pprof"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -331,6 +332,7 @@ func (rw *Worker) resetTx(chainTx kv.TemporalTx) error {
 }
 
 func (rw *Worker) Run() (err error) {
+	pprof.SetGoroutineLabels(pprof.WithLabels(rw.ctx, pprof.Labels("sub", "exec-worker")))
 	defer func() {
 		if rec := recover(); rec != nil {
 			err = fmt.Errorf("exec.Worker panic: %s, %s", rec, dbg.Stack())

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"runtime/pprof"
 	"sync"
 
 	"github.com/erigontech/erigon/common/dbg"
@@ -179,6 +180,7 @@ func (cc *commitmentCalculator) Stop() {
 }
 
 func (cc *commitmentCalculator) loop(ctx context.Context) {
+	pprof.SetGoroutineLabels(pprof.WithLabels(ctx, pprof.Labels("sub", "calculator")))
 	defer cc.wg.Done()
 	defer close(cc.out) // Signal apply loop that no more results will come.
 

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"os"
 	"runtime"
+	"runtime/pprof"
 	"sort"
 	"strings"
 	"sync"
@@ -153,6 +154,22 @@ func (pe *parallelExecutor) clearChangesetAccumulator() {
 }
 
 func (pe *parallelExecutor) exec(ctx context.Context, execStage *StageState, u Unwinder,
+	startBlockNum uint64, offsetFromBlockBeginning uint64, maxBlockNum uint64, blockLimit uint64,
+	initialTxNum uint64, inputTxNum uint64, initialCycle bool, rwTx kv.TemporalRwTx,
+	stepsInDb float64, accumulator *shards.Accumulator, readAhead chan uint64, logEvery *time.Ticker) (*types.Header, kv.TemporalRwTx, error) {
+	var (
+		outHeader *types.Header
+		outTx     kv.TemporalRwTx
+		outErr    error
+	)
+	pprof.Do(ctx, pprof.Labels("phase", "pe-exec"), func(lctx context.Context) {
+		outHeader, outTx, outErr = pe.execImpl(lctx, execStage, u, startBlockNum, offsetFromBlockBeginning,
+			maxBlockNum, blockLimit, initialTxNum, inputTxNum, initialCycle, rwTx, stepsInDb, accumulator, readAhead, logEvery)
+	})
+	return outHeader, outTx, outErr
+}
+
+func (pe *parallelExecutor) execImpl(ctx context.Context, execStage *StageState, u Unwinder,
 	startBlockNum uint64, offsetFromBlockBeginning uint64, maxBlockNum uint64, blockLimit uint64,
 	initialTxNum uint64, inputTxNum uint64, initialCycle bool, rwTx kv.TemporalRwTx,
 	stepsInDb float64, accumulator *shards.Accumulator, readAhead chan uint64, logEvery *time.Ticker) (*types.Header, kv.TemporalRwTx, error) {
@@ -792,6 +809,7 @@ func (pe *parallelExecutor) resetWorkers(ctx context.Context, rs *state.StateV3B
 }
 
 func (pe *parallelExecutor) execLoop(ctx context.Context) (err error) {
+	pprof.SetGoroutineLabels(pprof.WithLabels(ctx, pprof.Labels("sub", "exec-loop")))
 	// The exec loop is the owner of shutdown sequencing. On exit it
 	// closes commitResults then applyResults, causing the calculator
 	// and apply loop to drain and exit.


### PR DESCRIPTION
## Summary

Adds an opt-in profiling surface for the parallel execution stack. Two pieces, both default-off so this is a no-functional-change PR when the env knob is unset.

**1. `ERIGON_PERF_PROFILES=true` env knob** — at package init in `common/dbg`, enables `runtime.SetBlockProfileRate(1)` and `runtime.SetMutexProfileFraction(1)`, populating `/debug/pprof/{block,mutex}` for blocking and contention analysis. Default `false` matches today's behaviour.

**2. pprof goroutine labels on the parallel exec hot path** — fires unconditionally (cheap pointer writes to G-local label storage), but only useful when the CPU profiler is on. Labels:

| label | location |
|---|---|
| `phase=pe-exec` | `parallelExecutor.exec` is wrapped in `pprof.Do(...)`, so all child goroutines inherit via context |
| `sub=exec-worker` | `(*Worker).Run` per-task workers |
| `sub=exec-loop` | `parallelExecutor.execLoop` block scheduler |
| `sub=calculator` | `commitmentCalculator.loop` commitment computation |

These make it possible to filter `/debug/pprof/profile` to the parallel-exec phase via the pprof tags axis and separate dispatch from EVM from commitment without code-side wall-clock instrumentation.

## Why

Parallel-exec perf work needs to attribute CPU to four buckets — dispatch overhead, EVM execution, IO reads, and in-memory writes/version-map — to know where each optimisation lands. Without phase/sub labels, every pprof read mixes pe-exec CPU with txpool, p2p, GC, snapshot-build, etc. With this PR, one tags query separates them cleanly.

## Validation

Pulled two 30s CPU profiles against a mainnet node executing live with `ERIGON_PERF_PROFILES=true`.

### Catchup window (5000-block big-jump, 257% CPU)

\`\`\`
phase: Total 67.04s of 77.70s (86.28%)
        67.04s (86.28%): pe-exec

sub:   exec-worker  49.13s (63.23%)
       exec-loop    13.53s (17.41%)
       calculator    1.47s ( 1.89%)
\`\`\`

### Tip window (NewPayload at slot tip, 39.6% CPU, mostly idle)

\`\`\`
phase: Total 1.27s of 11.92s (10.65%)
        1.27s (10.65%): pe-exec

sub:   calculator   0.62s (5.20%)
       exec-worker  0.47s (3.94%)
       exec-loop    0.14s (1.17%)
\`\`\`

Different regimes flip which sub dominates — at catchup workers saturate, at tip commitment is the largest slice. The labels split both cleanly. CPU under `phase=pe-exec` with no sub is the apply-loop main goroutine (per-block result handling, ~3.7% in catchup, ~3% at tip).

## Test plan

- [x] \`make erigon\` clean
- [x] \`make lint\` clean (two passes — linter is non-deterministic)
- [x] Live on a mainnet node — process stable 6h+, no behaviour change vs main, RSS steady
- [x] \`/debug/pprof/profile\` tags axis populated as documented in catchup and tip windows
- [x] \`/debug/pprof/{block,mutex}\` populated when env knob is on