### PR TITLE
rpc/jsonrpc: exclude transient EIP-6780 contract bytecode from execution witness

### DIFF
--- a/rpc/jsonrpc/debug_execution_witness.go
+++ b/rpc/jsonrpc/debug_execution_witness.go
@@ -837,16 +837,34 @@ func collectAccessedState(rs *RecordingState) *accessedState {
 	}
 
 	accessedCode := rs.GetAccessedCode()
+	// Bytecode from a contract created and destroyed inside the same block is
+	// not part of the canonical end-state; only emit codes that have at least
+	// one source address still live after the block.
+	transient := func(addr common.Address) bool {
+		if _, deleted := rs.DeletedAccounts[addr]; !deleted {
+			return false
+		}
+		_, inPreState := rs.PreStateCode[addr]
+		return !inPreState
+	}
 	allCodesByHash := make(map[common.Hash][]byte)
-	for _, code := range accessedCode {
-		if len(code) > 0 {
-			h := crypto.Keccak256Hash(code)
-			allCodesByHash[h] = code
+	codeHasLiveSource := make(map[common.Hash]bool)
+	for addr, code := range accessedCode {
+		if len(code) == 0 {
+			continue
+		}
+		h := crypto.Keccak256Hash(code)
+		allCodesByHash[h] = code
+		if !transient(addr) {
+			codeHasLiveSource[h] = true
 		}
 	}
 
 	uniqueCodes := make([]codeWithHash, 0, len(allCodesByHash))
 	for h, code := range allCodesByHash {
+		if !codeHasLiveSource[h] {
+			continue
+		}
 		uniqueCodes = append(uniqueCodes, codeWithHash{code: code, hash: h})
 	}
 	slices.SortFunc(uniqueCodes, func(a, b codeWithHash) int {


### PR DESCRIPTION
Filters out bytecode for contracts created and `SELFDESTRUCT`ed in the same block from the `debug_executionWitness` `codes` array, matching Reth's Canonical witness rule. Refs #21307.

A contract that was `CREATE`d then `SELFDESTRUCT`ed in the same block isn't part of the canonical end-state — Reth's `ExecutionWitnessMode::Canonical` excludes its code; Erigon was emitting it because the in-between `CALL` populated `RecordingState.AccessedCode`, which is never unwound.

Discriminator: address is in `DeletedAccounts` and was never served from the pre-state reader (so the bytes came from the in-block `codeOverlay`). Codes whose only sources are such addresses are dropped.

`CreatedContracts ∩ DeletedAccounts` would not work — `IntraBlockState.Selfdestruct` clears `stateObject.createdContract`, so `stateWriter.CreateContract` is never called for an EIP-6780 contract.

Measured against the EEST `zkevm@v0.4.0` corpus via the witness suite in #21487, stacked on #21491:

| | base | + this PR |
|---|---:|---:|
| Fixtures passing | 2,711 / 2,871 | **2,726 / 2,871** |
| Codes mismatches | 1,176 | **924** |

5 fixtures newly fail (haven't bisected yet) and 599 cases of the `expected 5 → got 6` cluster survive — another +1 mechanism is still in play.

Orthogonal to #21491; diff applies cleanly to plain `main`.
