### PR TITLE
rpc/jsonrpc: source executionWitness codes from pre-state reads

### DIFF
--- a/rpc/jsonrpc/debug_execution_witness.go
+++ b/rpc/jsonrpc/debug_execution_witness.go
@@ -749,8 +749,10 @@ func (a *accessedState) touchAll(sdCtx *commitmentdb.SharedDomainsCommitmentCont
 
 // collectAccessedState rolls the RecordingState read/write maps and the three
 // code-tracking maps into a single accessedState. SortedCodes is sourced from
-// rs.GetAccessedCode() to match Geth's witness.AddCode semantics (only code
-// reached via GetCode/GetCodeSize, not all deployed code).
+// rs.GetPreStateCode() (pre-block reads only): the witness must carry the
+// bytecode that existed at the start of the block, not code created in-block.
+// A stateless verifier re-derives in-block-created code by replaying the
+// transactions, so emitting it would be redundant over-inclusion.
 //
 // SortedCodes is initialized to an empty (non-nil) slice so callers can assign
 // result.Codes = accessed.SortedCodes without risking a "codes": null JSON
@@ -836,9 +838,9 @@ func collectAccessedState(rs *RecordingState) *accessedState {
 		hash common.Hash
 	}
 
-	accessedCode := rs.GetAccessedCode()
+	preStateCode := rs.GetPreStateCode()
 	allCodesByHash := make(map[common.Hash][]byte)
-	for _, code := range accessedCode {
+	for _, code := range preStateCode {
 		if len(code) > 0 {
 			h := crypto.Keccak256Hash(code)
 			allCodesByHash[h] = code


### PR DESCRIPTION
## Problem

`debug_executionWitness`'s `codes` field is built from `RecordingState.GetAccessedCode()` — every bytecode reached via `GetCode`/`GetCodeSize` during execution, **including contracts created in-block**. That matches Geth's `witness.AddCode` semantics, but EEST fixtures (and the canonical stateless-witness format) are filled by **Reth's `Canonical` mode**, which only emits bytecodes loaded from **pre-state by codehash** and excludes in-block-created code. A stateless verifier re-derives created code by replaying the block, so emitting it is redundant over-inclusion.

This is the dominant remaining source of `codes`-witness divergence: a per-block +1 (sometimes +2) over-inclusion.

## Fix

Source the witness `codes` from `GetPreStateCode()` (inner-reader / pre-block reads only) instead of `GetAccessedCode()`. One-line change plus a corrected doc comment.

The stateless verifier (`witnessStateless.ReadAccountCode`) already resolves in-block-created code from `codeUpdates` (written during re-execution) **before** consulting the witness `codeMap`, so the verify path does not regress.

## Evidence (EEST `zkevm@v0.4.0` corpus, ~2,881 fixtures)

| Metric | before (`main` codes path) | after |
|---|---:|---:|
| Pass rate | 94.6% | **98.5%** |
| `codes` witness mismatches | 924 | **11** |
| stateless-exec failures | 0 | 0 |
| state-root mismatches | 0 | 0 |

A static sweep over all 924 pre-fix `codes` mismatches found that **100% (925/925)** of the over-included bytecodes were absent from pre-state — every one was created in-block (278 survive into post-state, e.g. cross-tx selfdestruct-to-self and in-block EIP-7702 delegation markers; the rest transient). Zero regressions vs the prior best; 111 newly-passing fixtures.

The residual 11 `codes` mismatches are EEST `eip8025_optional_proofs/witness_validation_codes/*` **negative-validation** fixtures (deliberately truncated/padded witnesses that test a verifier's rejection path), plus one same-codehash edge case (`witness_codes_create_same_hash_then_read`).

## Notes

- This supersedes the narrower EIP-6780 transient-code filter approach (it covered only the `deleted ∧ ∉ pre-state` subset; the pre-state rule covers all in-block-created code).
- `RecordingState.GetAccessedCode()` / `OnCodeAccess` are now unused by the witness builder but remain wired into the IBS code-read path; removing that machinery is deferred to keep this diff surgical.

Refs #21307.