### PR TITLE
perf: reduce workers amount 

### DIFF
--- a/common/dbg/experiments.go
+++ b/common/dbg/experiments.go
@@ -118,7 +118,7 @@ var (
 	TraceDeletion         = EnvBool("TRACE_DELETION", false)
 
 	RpcDropResponse  = EnvBool("RPC_DROP_RESPONSE", false)
-	TipTrieWarmupers = EnvInt("TIP_TRIE_WARMUPERS", runtime.NumCPU()*8) //io-bound (not cpu-bound). it's ok to have `io-threads > cpus`
+	TipTrieWarmupers = EnvInt("TIP_TRIE_WARMUPERS", estimate.AlmostAllCPUs()) //io-bound (not cpu-bound). it's ok to have `io-threads > cpus`
 )
 
 func ReadMemStats(m *runtime.MemStats) {

--- a/execution/commitment/commitment.go
+++ b/execution/commitment/commitment.go
@@ -37,6 +37,7 @@ import (
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/crypto"
 	"github.com/erigontech/erigon/common/empty"
+	"github.com/erigontech/erigon/common/estimate"
 	"github.com/erigontech/erigon/common/length"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/common/maphash"
@@ -620,7 +621,7 @@ func (be *BranchEncoder) CollectDeferredUpdate(
 	}
 
 	if needsFlush {
-		if err := be.ApplyDeferredUpdates(16, ctx.PutBranch); err != nil {
+		if err := be.ApplyDeferredUpdates(estimate.AlmostAllCPUs(), ctx.PutBranch); err != nil {
 			return err
 		}
 		be.ClearDeferred()

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -38,6 +38,7 @@ import (
 	"github.com/erigontech/erigon/common/crypto"
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/empty"
+	"github.com/erigontech/erigon/common/estimate"
 	"github.com/erigontech/erigon/common/length"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/state/stateifs"
@@ -1707,7 +1708,7 @@ func (hph *HexPatriciaHashed) toWitnessTrie(hashedKey []byte, codeReads map[comm
 func (hph *HexPatriciaHashed) readBranchAndCheckForFlushing(prefix []byte) ([]byte, error) {
 	be := hph.branchEncoder
 	if be.DeferUpdatesEnabled() && be.HasPendingPrefix(prefix) {
-		if err := be.ApplyDeferredUpdates(16, hph.ctx.PutBranch); err != nil {
+		if err := be.ApplyDeferredUpdates(estimate.AlmostAllCPUs(), hph.ctx.PutBranch); err != nil {
 			return nil, err
 		}
 		be.ClearDeferred()
@@ -2886,7 +2887,7 @@ func (hph *HexPatriciaHashed) Process(ctx context.Context, updates *Updates, log
 	}
 
 	if hph.branchEncoder.DeferUpdatesEnabled() && !hph.leaveDeferredForCaller {
-		if err = hph.branchEncoder.ApplyDeferredUpdates(runtime.NumCPU(), hph.ctx.PutBranch); err != nil {
+		if err = hph.branchEncoder.ApplyDeferredUpdates(estimate.AlmostAllCPUs(), hph.ctx.PutBranch); err != nil {
 			return nil, fmt.Errorf("apply deferred updates: %w", err)
 		}
 		hph.branchEncoder.ClearDeferred()
@@ -2973,7 +2974,7 @@ func (hph *HexPatriciaHashed) HasPendingDeferredUpdates() bool {
 
 // ApplyAndClearInlineDeferredUpdates applies deferred updates inline via ctx.PutBranch and clears them.
 func (hph *HexPatriciaHashed) ApplyAndClearInlineDeferredUpdates() error {
-	if err := hph.branchEncoder.ApplyDeferredUpdates(runtime.NumCPU(), hph.ctx.PutBranch); err != nil {
+	if err := hph.branchEncoder.ApplyDeferredUpdates(estimate.AlmostAllCPUs(), hph.ctx.PutBranch); err != nil {
 		return fmt.Errorf("apply deferred updates: %w", err)
 	}
 	hph.branchEncoder.ClearDeferred()

--- a/execution/commitment/warmuper.go
+++ b/execution/commitment/warmuper.go
@@ -165,7 +165,7 @@ func (w *Warmuper) Start() {
 		return
 	}
 
-	w.work = make(chan warmupWorkItem, w.numWorkers*64)
+	w.work = make(chan warmupWorkItem, w.numWorkers*32)
 	w.g, w.ctx = errgroup.WithContext(w.ctx)
 
 	for i := 0; i < w.numWorkers; i++ {


### PR DESCRIPTION
- to reduce RAM usage (current bottleneck)
- to reduce mutex contention (i see in warmupers cache)
