### PR TITLE
batch call fcu along with InsertBlocks in block collector's flush

### DIFF
--- a/cl/phase1/execution_client/block_collector/persistent_block_collector.go
+++ b/cl/phase1/execution_client/block_collector/persistent_block_collector.go
@@ -254,6 +254,14 @@ func (p *PersistentBlockCollector) Flush(ctx context.Context) error {
 					if err := p.insertBatch(ctx, blocksBatch, &inserted, &lastInsertedBlock); err != nil {
 						return err
 					}
+					// Drive FCU after each batch so execution + prune can drain
+					// BlockTransaction as InsertBlocks proceeds. Without this,
+					// the entire backfill (potentially 100k+ blocks → 20+ GB
+					// of tx data) accumulates in chaindata before any drain
+					// can occur.
+					if lastInsertedBlock != nil {
+						p.doForkChoiceUpdate(ctx, lastInsertedBlock)
+					}
 					blocksBatch = []*types.Block{}
 				}
 			}
@@ -290,10 +298,6 @@ func (p *PersistentBlockCollector) Flush(ctx context.Context) error {
 		}
 	}
 
-	// Trigger a single ForkChoiceUpdate after all batches are flushed.
-	// Calling FCU inside insertBatch between batches destroys the EL's
-	// in-memory overlay that accumulates TDs across batches, causing
-	// "parent's total difficulty not found" on the next InsertBlocks call.
 	if lastInsertedBlock != nil {
 		p.doForkChoiceUpdate(ctx, lastInsertedBlock)
 	}

--- a/cl/phase1/execution_client/block_collector/persistent_block_collector_test.go
+++ b/cl/phase1/execution_client/block_collector/persistent_block_collector_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/execution/engineapi/engine_types"
 	"github.com/erigontech/erigon/execution/types"
 )
 
@@ -70,10 +71,11 @@ func blockHash(bb *cltypes.BeaconBlock) common.Hash {
 }
 
 // flushTestHarness wires a PersistentBlockCollector to a gomock ExecutionEngine
-// that records every batch passed to InsertBlocks.
+// that records every batch passed to InsertBlocks (and every FCU call).
 type flushTestHarness struct {
 	collector *PersistentBlockCollector
 	inserted  []*types.Block
+	fcuHeads  []common.Hash
 }
 
 // insertedNumbers returns the block numbers of every inserted block in call order.
@@ -98,7 +100,11 @@ func newFlushTestHarness(t *testing.T, frozen uint64) *flushTestHarness {
 			return nil
 		}).AnyTimes()
 	engine.EXPECT().CurrentHeader(gomock.Any()).Return(nil, nil).AnyTimes()
-	engine.EXPECT().ForkChoiceUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	engine.EXPECT().ForkChoiceUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _, _, head common.Hash, _ *engine_types.PayloadAttributes, _ clparams.StateVersion) ([]byte, error) {
+			h.fcuHeads = append(h.fcuHeads, head)
+			return nil, nil
+		}).AnyTimes()
 
 	persistDir := filepath.Join(t.TempDir(), "collector")
 	c := NewPersistentBlockCollector(log.New(), engine, &clparams.MainnetBeaconConfig, persistDir)
@@ -300,4 +306,61 @@ func TestFlushDropsRowsBelowFrozen(t *testing.T) {
 
 	require.Equal(t, []uint64{3}, h.insertedNumbers())
 	require.Equal(t, 0, countRowsAtOrAbove(t, h.collector.db, 0))
+}
+
+// TestFlushDrivesFCUPerBatch verifies the per-batch FCU pattern: when Flush()
+// is called with more blocks than batchSize, doForkChoiceUpdate is invoked
+// once per completed batch (so the engine can run execution + prune mid-flush
+// and bound BlockTransaction growth), plus one final FCU after the loop.
+func TestFlushDrivesFCUPerBatch(t *testing.T) {
+	// Temporarily lower batchSize so the test stays fast.
+	origBatchSize := batchSize
+	batchSize = 3
+	t.Cleanup(func() { batchSize = origBatchSize })
+
+	h := newFlushTestHarness(t, 0)
+
+	// 7 blocks: two full batches of 3 plus a tail of 1 → expect 3 FCUs
+	// (two per-batch + one final after the tail insert).
+	prev := common.Hash{}
+	blocks := make([]*cltypes.BeaconBlock, 7)
+	for i := 0; i < 7; i++ {
+		blocks[i] = makeBeaconBlock(t, uint64(i+1), 'a', prev)
+		require.NoError(t, h.collector.AddBlock(blocks[i]))
+		prev = blockHash(blocks[i])
+	}
+
+	require.NoError(t, h.collector.Flush(t.Context()))
+
+	require.Equal(t, []uint64{1, 2, 3, 4, 5, 6, 7}, h.insertedNumbers())
+	require.Len(t, h.fcuHeads, 3, "expected 2 per-batch FCUs + 1 final FCU")
+	require.Equal(t, blockHash(blocks[2]), h.fcuHeads[0], "first FCU should target the last block of batch 1 (block 3)")
+	require.Equal(t, blockHash(blocks[5]), h.fcuHeads[1], "second FCU should target the last block of batch 2 (block 6)")
+	require.Equal(t, blockHash(blocks[6]), h.fcuHeads[2], "final FCU should target the last inserted block (block 7)")
+}
+
+// TestFlushSingleFCUWhenBelowBatchSize verifies the baseline: when total
+// blocks fit in a single sub-batch (no per-batch FCU triggered), only the
+// final after-loop FCU fires.
+func TestFlushSingleFCUWhenBelowBatchSize(t *testing.T) {
+	origBatchSize := batchSize
+	batchSize = 100 // well above the 3 blocks we add
+	t.Cleanup(func() { batchSize = origBatchSize })
+
+	h := newFlushTestHarness(t, 0)
+
+	prev := common.Hash{}
+	var last *cltypes.BeaconBlock
+	for i := 0; i < 3; i++ {
+		b := makeBeaconBlock(t, uint64(i+1), 'a', prev)
+		require.NoError(t, h.collector.AddBlock(b))
+		prev = blockHash(b)
+		last = b
+	}
+
+	require.NoError(t, h.collector.Flush(t.Context()))
+
+	require.Equal(t, []uint64{1, 2, 3}, h.insertedNumbers())
+	require.Len(t, h.fcuHeads, 1, "with all blocks in a single sub-batch, only the final FCU fires")
+	require.Equal(t, blockHash(last), h.fcuHeads[0])
 }

--- a/execution/execmodule/exec_module_test.go
+++ b/execution/execmodule/exec_module_test.go
@@ -1825,3 +1825,228 @@ func TestEIP7708BurnLogWhenCoinbaseSelfDestructs(t *testing.T) {
 	err = insertValidateAndUfc1By1(ctx, m.ExecModule, chainPack.Blocks)
 	require.NoError(t, err)
 }
+
+// TestInsertBlocksWithBatchedFCU drives the Caplin persistent_block_collector
+// pattern: InsertBlocks(batch) → ForkChoiceUpdate(last block of batch),
+// repeated for each batch. Verifies parent TD continuity across batches —
+// the "parent's total difficulty not found" failure mode the collector
+// comment warns about does not actually occur on the catch-up path.
+func TestInsertBlocksWithBatchedFCU(t *testing.T) {
+	ctx := t.Context()
+	privKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	senderAddr := crypto.PubkeyToAddress(privKey.PublicKey)
+	genesis := &types.Genesis{
+		Config: chain.AllProtocolChanges,
+		Alloc: types.GenesisAlloc{
+			senderAddr: {Balance: new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)},
+		},
+	}
+	m := execmoduletester.New(t, execmoduletester.WithGenesisSpec(genesis), execmoduletester.WithKey(privKey))
+
+	const totalBlocks = 30
+	const batchSize = 10
+
+	chainPack, err := blockgen.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, totalBlocks, func(i int, b *blockgen.BlockGen) {
+		tx, err := types.SignTx(
+			types.NewTransaction(uint64(i), senderAddr, uint256.NewInt(1_000), 50000, uint256.NewInt(m.Genesis.BaseFee().Uint64()), nil),
+			*types.LatestSignerForChainID(nil),
+			privKey,
+		)
+		require.NoError(t, err)
+		b.AddTx(tx)
+	})
+	require.NoError(t, err)
+	require.Len(t, chainPack.Blocks, totalBlocks)
+
+	for start := 0; start < totalBlocks; start += batchSize {
+		end := start + batchSize
+		batch := chainPack.Blocks[start:end]
+
+		insRes, err := insertBlocks(ctx, m.ExecModule, batch)
+		require.NoError(t, err, "batch [%d..%d] InsertBlocks", start+1, end)
+		require.Equal(t, execmodule.ExecutionStatusSuccess, insRes)
+
+		last := batch[len(batch)-1].Header()
+		fcuRes, err := updateForkChoice(ctx, m.ExecModule, last)
+		require.NoError(t, err, "batch [%d..%d] FCU on block %d", start+1, end, last.Number.Uint64())
+		require.Equal(t, execmodule.ExecutionStatusSuccess, fcuRes.Status,
+			"FCU on block %d should succeed; validationError=%q", last.Number.Uint64(), fcuRes.ValidationError)
+
+		// After each batch's FCU, TxNums + execution must have advanced to
+		// the batch tip. The next batch's first block reads its parent's TD
+		// from this committed state.
+		require.NoError(t, m.DB.ViewTemporal(ctx, func(tx kv.TemporalTx) error {
+			lastTxNumBlock, _, err := rawdbv3.TxNums.Last(tx)
+			require.NoError(t, err)
+			require.Equal(t, last.Number.Uint64(), lastTxNumBlock, "TxNums.Last after batch ending at %d", last.Number.Uint64())
+
+			execProg, err := stages.GetStageProgress(tx, stages.Execution)
+			require.NoError(t, err)
+			require.Equal(t, last.Number.Uint64(), execProg, "Execution stage progress after batch ending at %d", last.Number.Uint64())
+
+			// First block of the just-inserted batch should have a readable TD
+			// (asserts the rawdb.WriteTd in InsertBlocks made it to DB).
+			firstOfBatch := batch[0].HeaderNoCopy()
+			td, err := rawdb.ReadTd(tx, firstOfBatch.Hash(), firstOfBatch.Number.Uint64())
+			require.NoError(t, err)
+			require.NotNil(t, td, "TD for block %d must be readable across the batch boundary", firstOfBatch.Number.Uint64())
+			return nil
+		}))
+	}
+}
+
+// runBatchedFCUBadBlockRecovery is the shared body for the foreground- and
+// background-commit variants of the bad-block recovery test. Both FCU
+// cleanup branches — local SD close (foreground) and the additional
+// currentContext reset (background) — must leave the next InsertBlocks+FCU
+// cycle able to recover.
+func runBatchedFCUBadBlockRecovery(t *testing.T, bgCommit bool) {
+	ctx := t.Context()
+	privKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	senderAddr := crypto.PubkeyToAddress(privKey.PublicKey)
+	genesis := &types.Genesis{
+		Config: chain.AllProtocolChanges,
+		Alloc: types.GenesisAlloc{
+			senderAddr: {Balance: new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)},
+		},
+	}
+	opts := []execmoduletester.Option{
+		execmoduletester.WithGenesisSpec(genesis),
+		execmoduletester.WithKey(privKey),
+	}
+	if bgCommit {
+		opts = append(opts, execmoduletester.WithFcuBackgroundCommit())
+	}
+	m := execmoduletester.New(t, opts...)
+
+	// Under background commit, a commit (including the genesis InsertBlocks inside
+	// New) lands asynchronously after the call returns. These polls let DB reads
+	// wait for the commit goroutine; both return immediately under foreground
+	// commit. Transient read errors are treated as "not ready yet" and retried.
+	waitForGenesis := func() {
+		require.Eventually(t, func() bool {
+			var funded bool
+			err := m.DB.ViewTemporal(ctx, func(tx kv.TemporalTx) error {
+				v, _, err := tx.GetLatest(kv.AccountsDomain, senderAddr[:])
+				if err != nil {
+					return err
+				}
+				funded = len(v) > 0
+				return nil
+			})
+			return err == nil && funded
+		}, 15*time.Second, 10*time.Millisecond, "genesis commit did not land")
+	}
+	waitForBlock := func(blockNum uint64) {
+		require.Eventually(t, func() bool {
+			var done bool
+			err := m.DB.ViewTemporal(ctx, func(tx kv.TemporalTx) error {
+				last, _, err := rawdbv3.TxNums.Last(tx)
+				if err != nil {
+					return err
+				}
+				done = last >= blockNum
+				return nil
+			})
+			return err == nil && done
+		}, 15*time.Second, 10*time.Millisecond, "commit of block %d did not land", blockNum)
+	}
+	// Genesis must be committed before GenerateChain reads its state.
+	waitForGenesis()
+
+	// Build a 6-block chain. First 5 are committed normally; block 6 is the
+	// recovery target.
+	chainPack, err := blockgen.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 6, func(i int, b *blockgen.BlockGen) {
+		tx, err := types.SignTx(
+			types.NewTransaction(uint64(i), senderAddr, uint256.NewInt(1_000), 50000, uint256.NewInt(m.Genesis.BaseFee().Uint64()), nil),
+			*types.LatestSignerForChainID(nil),
+			privKey,
+		)
+		require.NoError(t, err)
+		b.AddTx(tx)
+	})
+	require.NoError(t, err)
+	require.Len(t, chainPack.Blocks, 6)
+
+	// Phase 1: insert + FCU blocks 1..5 normally so state is at 5.
+	insRes, err := insertBlocks(ctx, m.ExecModule, chainPack.Blocks[:5])
+	require.NoError(t, err)
+	require.Equal(t, execmodule.ExecutionStatusSuccess, insRes)
+	res, err := updateForkChoice(ctx, m.ExecModule, chainPack.Blocks[4].Header())
+	require.NoError(t, err)
+	require.Equal(t, execmodule.ExecutionStatusSuccess, res.Status)
+	waitForBlock(5)
+
+	// Phase 2: forge a "bad block 6" sharing the canonical parent (block 5's
+	// hash) but with a corrupted state root. InsertBlocks accepts it
+	// (header-write only); FCU on it triggers execution which computes the
+	// real post-state root, finds the mismatch and returns BadBlock.
+	goodHeader6 := chainPack.Blocks[5].HeaderNoCopy()
+	badHeader6 := types.CopyHeader(goodHeader6)
+	badHeader6.Root = common.HexToHash("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	badBlock6 := types.NewBlockFromNetwork(badHeader6, &types.Body{
+		Transactions: chainPack.Blocks[5].Transactions(),
+		Uncles:       chainPack.Blocks[5].Uncles(),
+		Withdrawals:  chainPack.Blocks[5].Withdrawals(),
+	})
+
+	badRes, err := insertBlocks(ctx, m.ExecModule, []*types.Block{badBlock6})
+	require.NoError(t, err)
+	require.Equal(t, execmodule.ExecutionStatusSuccess, badRes, "InsertBlocks writes the header without validating state root")
+
+	fcuBad, err := updateForkChoice(ctx, m.ExecModule, badBlock6.Header())
+	require.NoError(t, err)
+	require.Equal(t, execmodule.ExecutionStatusBadBlock, fcuBad.Status,
+		"FCU on the bad block must return BadBlock (state-root mismatch); got %s validationError=%q", fcuBad.Status, fcuBad.ValidationError)
+
+	// Phase 3: recovery — insert the real block 6 and FCU on it. This must
+	// succeed even though the bad-block FCU just closed the local
+	// SharedDomains. The persistent e.currentContext is either still
+	// pointing to the prior SD (foreground) or has been nil'd (background);
+	// both paths must let the next InsertBlocks re-initialize the overlay
+	// cleanly.
+	recoverIns, err := insertBlocks(ctx, m.ExecModule, []*types.Block{chainPack.Blocks[5]})
+	require.NoError(t, err, "InsertBlocks of the good block after a bad-block FCU must not error")
+	require.Equal(t, execmodule.ExecutionStatusSuccess, recoverIns)
+
+	recoverFcu, err := updateForkChoice(ctx, m.ExecModule, chainPack.Blocks[5].Header())
+	require.NoError(t, err)
+	require.Equal(t, execmodule.ExecutionStatusSuccess, recoverFcu.Status,
+		"FCU on the good block after recovery must succeed; validationError=%q", recoverFcu.ValidationError)
+	waitForBlock(6)
+
+	// State must be at the good block 6 — TxNums.Last and Execution progress
+	// both at 6, parent TD readable.
+	require.NoError(t, m.DB.ViewTemporal(ctx, func(tx kv.TemporalTx) error {
+		lastTxNumBlock, _, err := rawdbv3.TxNums.Last(tx)
+		require.NoError(t, err)
+		require.Equal(t, uint64(6), lastTxNumBlock)
+
+		execProg, err := stages.GetStageProgress(tx, stages.Execution)
+		require.NoError(t, err)
+		require.Equal(t, uint64(6), execProg)
+
+		td, err := rawdb.ReadTd(tx, chainPack.Blocks[5].Hash(), 6)
+		require.NoError(t, err)
+		require.NotNil(t, td)
+		return nil
+	}))
+}
+
+// TestInsertBlocksWithBatchedFCU_BadBlockRecovery_Foreground covers the
+// foreground-commit cleanup path: a bad-block FCU closes the local
+// SharedDomains while the persistent currentContext remains, and the next
+// InsertBlocks must re-initialize the overlay on top of it.
+func TestInsertBlocksWithBatchedFCU_BadBlockRecovery_Foreground(t *testing.T) {
+	runBatchedFCUBadBlockRecovery(t, false)
+}
+
+// TestInsertBlocksWithBatchedFCU_BadBlockRecovery_Background covers the
+// background-commit cleanup path, where the bad-block FCU additionally resets
+// currentContext. Commits land asynchronously, so the shared body polls
+// committed state before asserting (see waitForGenesis/waitForBlock).
+func TestInsertBlocksWithBatchedFCU_BadBlockRecovery_Background(t *testing.T) {
+	runBatchedFCUBadBlockRecovery(t, true)
+}


### PR DESCRIPTION
## Problem

- On a minimal/pruned node catching up after a gap, Caplin's `persistent_block_collector.Flush` inserts the entire backfill via `InsertBlocks` and only issues a **single** `ForkChoiceUpdate` at the very end. So the whole backfill (potentially 100k+ blocks for 2 weeks) lands in `BlockTransaction` before execution + prune can drain any of it.
- it bloats up BlockTransaction table, which is highest initial contributor to mdbx size initially.

issue: https://github.com/erigontech/erigon/issues/21326

## Change

Drive a `ForkChoiceUpdate` after **each completed `InsertBlocks` batch**, so execution + prune run mid-flush and bound `BlockTransaction` growth instead of letting the full backfill accumulate first.

## Effect (minimal mainnet node, ~100k-block gap)

| metric | before | after |
| --- | --- | --- |
| peak `BlockTransaction` | ~4.6 GB | ~726 MB (**6.4×** lower) |
| peak `mdbx.dat` | ~19 GB | ~9.2 GB |

## Tests

- `TestFlushDrivesFCUPerBatch`, `TestFlushSingleFCUWhenBelowBatchSize` (collector)
- `TestInsertBlocksWithBatchedFCU`, `TestInsertBlocksWithBatchedFCU_BadBlockRecovery_{Foreground,Background}` (execmodule)

Draft — full `make lint` + integration verification pending.
