### PR TITLE
db/state: fix Aggregator & ForkableAgg Close vs background MergeLoop WaitGroup race

### DIFF
--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -1053,8 +1053,10 @@ func (a *Aggregator) BuildFiles2(ctx context.Context, fromStep, toStep kv.Step, 
 		}
 
 		if doMerge {
+			a.wg.Add(1)
 			go func() {
-				if err := a.MergeLoop(ctx); err != nil {
+				defer a.wg.Done()
+				if err := a.mergeLoop(ctx); err != nil {
 					panic(err)
 				}
 			}()
@@ -1097,7 +1099,13 @@ func (a *Aggregator) RemoveOverlapsAfterMerge(ctx context.Context) (err error) {
 	return nil
 }
 
-func (a *Aggregator) MergeLoop(ctx context.Context) (err error) {
+func (a *Aggregator) MergeLoop(ctx context.Context) error {
+	a.wg.Add(1)
+	defer a.wg.Done()
+	return a.mergeLoop(ctx)
+}
+
+func (a *Aggregator) mergeLoop(ctx context.Context) (err error) {
 	if dbg.NoMerge() || !a.mergingFiles.CompareAndSwap(false, true) {
 		return nil // currently merging or merge is prohibited
 	}
@@ -1110,8 +1118,6 @@ func (a *Aggregator) MergeLoop(ctx context.Context) (err error) {
 		}
 	}()
 
-	a.wg.Add(1)
-	defer a.wg.Done()
 	defer a.mergingFiles.Store(false)
 
 	mergeThrottleMs := dbg.MergeThrottleMs
@@ -2149,9 +2155,11 @@ func (a *Aggregator) buildFilesInBackground(txNum uint64, doMerge bool) chan str
 		if !doMerge {
 			return
 		}
+		a.wg.Add(1)
 		go func() {
+			defer a.wg.Done()
 			defer close(fin)
-			if err := a.MergeLoop(a.ctx); err != nil {
+			if err := a.mergeLoop(a.ctx); err != nil {
 				if errors.Is(err, context.Canceled) || errors.Is(err, common.ErrStopped) {
 					return
 				}

--- a/db/state/aggregator_close_test.go
+++ b/db/state/aggregator_close_test.go
@@ -1,0 +1,46 @@
+// Copyright 2024 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/kv/dbcfg"
+	"github.com/erigontech/erigon/db/kv/mdbx"
+)
+
+// The merge goroutine BuildFiles2 spawns must register on wg before the build
+// goroutine's wg.Done, so wg.Wait (what Close does) never races that Add from zero.
+func TestAggregatorCloseWaitsForBackgroundMerge(t *testing.T) {
+	logger := log.New()
+	for range 64 {
+		dirs := datadir.New(t.TempDir())
+		db := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
+		agg := NewTest(dirs).StepSize(16).Logger(logger).MustOpen(t.Context(), db)
+		require.NoError(t, agg.OpenFolder())
+
+		require.NoError(t, agg.BuildFiles2(t.Context(), 0, 0, true))
+		agg.wg.Wait()
+		agg.Close()
+		db.Close()
+	}
+}

--- a/db/state/forkable_agg.go
+++ b/db/state/forkable_agg.go
@@ -177,11 +177,13 @@ func (r *ForkableAgg) BuildFilesInBackground(num RootNum) chan struct{} {
 			}
 		}
 
+		r.wg.Add(1)
 		go func() {
+			defer r.wg.Done()
 			defer func() {
 				close(fin)
 			}()
-			if err := r.MergeLoop(r.ctx); err != nil {
+			if err := r.mergeLoop(r.ctx); err != nil {
 				if errors.Is(err, context.Canceled) || errors.Is(err, common.ErrStopped) {
 					r.logger.Debug("[fork_agg] MergeLoop cancelled/stopped", "err", err)
 					return
@@ -215,7 +217,13 @@ func (a *ForkableAgg) WaitForBuildAndMerge(ctx context.Context) chan struct{} {
 	return res
 }
 
-func (r *ForkableAgg) MergeLoop(ctx context.Context) (err error) {
+func (r *ForkableAgg) MergeLoop(ctx context.Context) error {
+	r.wg.Add(1)
+	defer r.wg.Done()
+	return r.mergeLoop(ctx)
+}
+
+func (r *ForkableAgg) mergeLoop(ctx context.Context) (err error) {
 	if dbg.NoMerge() || r.mergeDisabled.Load() || !r.mergingFiles.CompareAndSwap(false, true) {
 		r.logger.Debug("[fork_agg] MergeLoop disabled or already in progress. Skipping...")
 		return nil
@@ -228,8 +236,6 @@ func (r *ForkableAgg) MergeLoop(ctx context.Context) (err error) {
 		}
 	}()
 
-	r.wg.Add(1)
-	defer r.wg.Done()
 	defer r.mergingFiles.Store(false)
 
 	somethingMerged := true

--- a/db/state/forkable_agg_test.go
+++ b/db/state/forkable_agg_test.go
@@ -660,3 +660,20 @@ func TestUnmarkedForkableUnwindDeletesVals(t *testing.T) {
 		require.Nil(t, v)
 	}
 }
+
+// The merge goroutine BuildFilesInBackground spawns must register on wg before the
+// build goroutine's wg.Done, so wg.Wait (what Close does) never races that Add from zero.
+func TestForkableAggCloseWaitsForBackgroundMerge(t *testing.T) {
+	dirs, db, logger := setupDb(t)
+	_, header := setupHeader(t, db, logger, dirs)
+
+	agg := NewForkableAgg(t.Context(), dirs, db, logger)
+	t.Cleanup(agg.Close)
+	agg.RegisterMarkedForkable(header)
+	require.NoError(t, agg.OpenFolder())
+
+	for range 64 {
+		agg.BuildFilesInBackground(RootNum(10))
+		agg.wg.Wait()
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #21521 — the data race between `Aggregator.Close` (`wg.Wait`) and the background `MergeLoop` goroutine spawned by `BuildFiles2` / `buildFilesInBackground`. The sibling `ForkableAgg` carried the identical latent race and gets the same fix here.

## Root cause

Both background-build sites spawn the merge goroutine **inside** the build goroutine:

```go
a.wg.Add(1)
go func() {            // build goroutine
    defer a.wg.Done()
    ... build ...
    if doMerge {
        go func() { a.MergeLoop(ctx) }()   // merge goroutine — MergeLoop does its own wg.Add
    }
}()                    // build goroutine returns → wg.Done
```

`MergeLoop`'s `wg.Add(1)` runs in the merge goroutine, which can be scheduled **after** the build goroutine's `wg.Done()` has already dropped the counter to zero. A positive `Add` from a zero counter, concurrent with `Close`'s `wg.Wait()`, is `sync.WaitGroup` reuse — undefined behavior, flagged by `-race` and by the runtime's own `panic: sync: WaitGroup is reused before previous Wait has returned`.

It is pre-existing (the structure predates #21499, which only touched `commitment_context.go`); CI load just made the merge goroutine starve long enough to surface it.

## Fix

Register the merge goroutine on `wg` **before** spawning it, so the `Add` happens-before the build goroutine's `Done` and the counter never reaches zero while a merge is pending. `MergeLoop` is split into a self-accounting public wrapper (unchanged contract for the external callers — `snapshots_cmd`, `kv_temporal`, `backend`, tests) and a private `mergeLoop` body used by the two in-file background sites.

## Test (TDD)

`db/state/aggregator_close_test.go` drives the real `BuildFiles2(…, doMerge=true)` then `wg.Wait()` (what `Close` does at `aggregator.go:541`). The empty-aggregator merge is a clean no-op that touches only `agg.wg`, so the only possible race is the reported one.

- **Red** (before the fix): reproduces the exact trace — `MergeLoop` `wg.Add` at `aggregator.go:1113` via `BuildFiles2.func1.1` at `:1057` racing the `wg.Wait`, plus the runtime `WaitGroup is reused` panic.
- **Green** (after the fix): deterministic — counter path `1→2→1→0`, no reuse.

## Note on `buildFilesInBackground`

`buildFilesInBackground` (`aggregator.go:2155`) has the identical bug and gets the identical fix, but isn't covered by an isolated test: its early-return guards (`hasData`, committed-txNum) mean an empty aggregator never reaches the merge spawn, so a focused test would need heavy real-data setup. The full `db/state` `-race` suite, which exercises that path, stays green.

## ForkableAgg twin (same defect)

`ForkableAgg.BuildFilesInBackground` (`forkable_agg.go`) mirrors the same structure and carried the same race: the merge goroutine was spawned with **no preceding `wg.Add`**, and `ForkableAgg.MergeLoop` did its own `wg.Add(1)` on the merge goroutine — racing `ForkableAgg.Close`'s `wg.Wait()`. `ForkableAgg.Close` goes straight to `ctxCancel` + `wg.Wait` with **no `WaitForFiles()` pre-drain** (unlike `Aggregator.Close`), so it relies on `wg.Wait` alone to drain — if anything, more exposed.

Same fix (pre-register on `wg` before the spawn; `MergeLoop` → self-accounting public wrapper + private `mergeLoop`). Unlike `buildFilesInBackground`, this path **is** covered by an isolated test: `TestForkableAggCloseWaitsForBackgroundMerge` drives `BuildFilesInBackground` then `wg.Wait` over an empty aggregator (one no-op forkable). Red reproduced the exact `WaitGroup is reused` panic plus the `-race` report on the first run; Green is deterministic.

## Verification

- `go test -race -count=3 -run TestAggregatorCloseWaitsForBackgroundMerge ./db/state/` — pass
- `go test -race -count=3 -run TestForkableAggCloseWaitsForBackgroundMerge ./db/state/` — pass
- `go test -race ./db/state/` — pass (no race)
- `go test -race -run 'Merge' ./db/test/` (direct `MergeLoop` callers) — pass
- `make lint` — 0 issues
- `make erigon integration` — both binaries build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
