### PR TITLE
rpc/jsonrpc: lex-order executionWitness codes and state

### DIFF
--- a/rpc/jsonrpc/debug_execution_witness.go
+++ b/rpc/jsonrpc/debug_execution_witness.go
@@ -705,6 +705,10 @@ func (api *DebugAPIImpl) ExecutionWitness(ctx context.Context, blockNrOrHash rpc
 		return nil, err
 	}
 
+	slices.SortFunc(result.State, func(a, b hexutil.Bytes) int {
+		return bytes.Compare(a, b)
+	})
+
 	return result, nil
 }
 
@@ -833,11 +837,6 @@ func collectAccessedState(rs *RecordingState) *accessedState {
 	})
 	out.SortedKeys = sortedKeys
 
-	type codeWithHash struct {
-		code []byte
-		hash common.Hash
-	}
-
 	preStateCode := rs.GetPreStateCode()
 	allCodesByHash := make(map[common.Hash][]byte)
 	for _, code := range preStateCode {
@@ -847,15 +846,13 @@ func collectAccessedState(rs *RecordingState) *accessedState {
 		}
 	}
 
-	uniqueCodes := make([]codeWithHash, 0, len(allCodesByHash))
-	for h, code := range allCodesByHash {
-		uniqueCodes = append(uniqueCodes, codeWithHash{code: code, hash: h})
+	uniqueCodes := make([][]byte, 0, len(allCodesByHash))
+	for _, code := range allCodesByHash {
+		uniqueCodes = append(uniqueCodes, code)
 	}
-	slices.SortFunc(uniqueCodes, func(a, b codeWithHash) int {
-		return bytes.Compare(a.hash[:], b.hash[:])
-	})
+	slices.SortFunc(uniqueCodes, bytes.Compare)
 	for _, c := range uniqueCodes {
-		out.SortedCodes = append(out.SortedCodes, c.code)
+		out.SortedCodes = append(out.SortedCodes, c)
 	}
 
 	preCode := rs.GetPreStateCode()

--- a/rpc/jsonrpc/debug_execution_witness.go
+++ b/rpc/jsonrpc/debug_execution_witness.go
@@ -705,6 +705,7 @@ func (api *DebugAPIImpl) ExecutionWitness(ctx context.Context, blockNrOrHash rpc
 		return nil, err
 	}
 
+	// Sort after verifyWitnessStateless: RLPDecode treats result.State[0] as the trie root.
 	slices.SortFunc(result.State, func(a, b hexutil.Bytes) int {
 		return bytes.Compare(a, b)
 	})


### PR DESCRIPTION
Order `codes` and `state` lex-ascending by content (was: codes by codehash, state by trie-traversal). Confirmed against zkevm@v0.4.0 fixtures.

`state` is sorted after `verifyWitnessStateless` — its `RLPDecode` treats node 0 as the trie root, so the witness stays root-first through verification.

No pass-rate change (multiset compare); serialization alignment only.

Builds on #21518. Refs #20534 (causes 1 & 3).