### PR TITLE
rpc/jsonrpc: omit empty keys and order witness headers ascending

### DIFF
--- a/rpc/jsonrpc/debug_execution_witness.go
+++ b/rpc/jsonrpc/debug_execution_witness.go
@@ -499,8 +499,9 @@ type ExecutionWitnessResult struct {
 	// matching Geth's witness.AddCode semantics. Code that was deployed/modified but never
 	// read (e.g. CREATE without a subsequent call) is intentionally excluded.
 	Codes []hexutil.Bytes `json:"codes"`
-	// Keys is always null (reserved for future use, included for Geth compatibility)
-	Keys []hexutil.Bytes `json:"keys"`
+	// Keys is reserved for future use; omitted while empty so the response matches
+	// the canonical {state, codes, headers} shape.
+	Keys []hexutil.Bytes `json:"keys,omitempty"`
 	// Headers is a list of block headers (as JSON objects) needed for BLOCKHASH opcode support.
 	// For blocks that touch state, always includes the parent block header plus any blocks accessed
 	// via BLOCKHASH. Omitted (nil) for empty-touch blocks, where ExecutionWitness returns early
@@ -1109,12 +1110,9 @@ func (api *DebugAPIImpl) collectAccessedHeaders(
 			oldest = bn
 		}
 	}
-	for bn := parentNum; ; bn-- {
+	for bn := oldest; bn <= parentNum; bn++ {
 		if err := addHeader(bn); err != nil {
 			return nil, nil, err
-		}
-		if bn == oldest {
-			break
 		}
 	}
 

--- a/rpc/jsonrpc/debug_execution_witness.go
+++ b/rpc/jsonrpc/debug_execution_witness.go
@@ -26,12 +26,12 @@ import (
 	"github.com/erigontech/erigon/execution/protocol"
 	"github.com/erigontech/erigon/execution/protocol/params"
 	"github.com/erigontech/erigon/execution/protocol/rules"
+	"github.com/erigontech/erigon/execution/rlp"
 	"github.com/erigontech/erigon/execution/state"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/execution/types/accounts"
 	"github.com/erigontech/erigon/execution/vm"
 	"github.com/erigontech/erigon/rpc"
-	"github.com/erigontech/erigon/rpc/ethapi"
 	"github.com/erigontech/erigon/rpc/rpchelper"
 	"github.com/erigontech/erigon/rpc/transactions"
 )
@@ -460,25 +460,6 @@ func (s *RecordingState) GetModifiedCode() map[common.Address][]byte {
 	return result
 }
 
-// marshalWitnessHeader converts a block header to the JSON map format used in
-// debug_executionWitness responses, matching Geth's output format.
-func marshalWitnessHeader(h *types.Header) map[string]any {
-	m := ethapi.RPCMarshalHeader(h)
-
-	// Geth always emits these optional fields as null when absent.
-	nullFields := []string{
-		"baseFeePerGas", "blobGasUsed", "blockAccessListHash", "excessBlobGas", "parentBeaconBlockRoot", "requestsHash", "slotNumber", "withdrawalsRoot"}
-
-	for _, field := range nullFields {
-		if _, ok := m[field]; !ok {
-			m[field] = nil
-		}
-	}
-	delete(m, "size")
-
-	return m
-}
-
 // witnessBlockInfo bundles the inputs that downstream witness-building phases need
 // after resolving the target block: the block itself plus its txnum range and the
 // parent block number. BlockNum is stored as a field (rather than recomputed via
@@ -502,11 +483,9 @@ type ExecutionWitnessResult struct {
 	// Keys is reserved for future use; omitted while empty so the response matches
 	// the canonical {state, codes, headers} shape.
 	Keys []hexutil.Bytes `json:"keys,omitempty"`
-	// Headers is a list of block headers (as JSON objects) needed for BLOCKHASH opcode support.
-	// For blocks that touch state, always includes the parent block header plus any blocks accessed
-	// via BLOCKHASH. Omitted (nil) for empty-touch blocks, where ExecutionWitness returns early
-	// before headers are collected.
-	Headers []map[string]any `json:"headers,omitempty"`
+	// Headers is the contiguous chain of RLP-encoded ancestor headers from the parent
+	// back to the oldest block reached via BLOCKHASH.
+	Headers []hexutil.Bytes `json:"headers,omitempty"`
 
 	// lookup map for BLOCKHASH opcode, not serialized to JSON
 	headerByNumber map[uint64]*types.Header
@@ -1082,8 +1061,8 @@ func (api *DebugAPIImpl) collectAccessedHeaders(
 	tx kv.TemporalTx,
 	parentNum uint64,
 	accessedBlockNums []uint64,
-) (headers []map[string]any, byNumber map[uint64]*types.Header, err error) {
-	headers = []map[string]any{}
+) (headers []hexutil.Bytes, byNumber map[uint64]*types.Header, err error) {
+	headers = []hexutil.Bytes{}
 	byNumber = make(map[uint64]*types.Header)
 
 	addHeader := func(bn uint64) error {
@@ -1098,7 +1077,11 @@ func (api *DebugAPIImpl) collectAccessedHeaders(
 		if h == nil {
 			return fmt.Errorf("missing header for block %d", bn)
 		}
-		headers = append(headers, marshalWitnessHeader(h))
+		encoded, err := rlp.EncodeToBytes(h)
+		if err != nil {
+			return fmt.Errorf("failed to encode header for block %d: %w", bn, err)
+		}
+		headers = append(headers, encoded)
 		byNumber[h.Number.Uint64()] = h
 
 		return nil


### PR DESCRIPTION
Two canonical-shape fixes:
- `keys`: omitempty. Never populated, so it always serialized as `"keys": null`; canonical shape is `{state, codes, headers}`.
- `headers`: emit ascending by block number (was descending).

Order doesn't affect tests (multiset compare) and `keys` carries no data — serialization alignment only.

Stacked on #21529. Refs #20534.