### PR TITLE
[r3.4] db/state: prune TemporalMemBatch overlay entries past unwindToTxNum (#20625)

### DIFF
--- a/db/state/execctx/domain_shared_test.go
+++ b/db/state/execctx/domain_shared_test.go
@@ -170,6 +170,86 @@ Loop:
 	goto Loop
 }
 
+// TestSharedDomain_UnwindDoesNotRestoreOverlayForNewKey reproduces the
+// mainnet block-24898955 gas-used mismatch (diff = -17100 = SSTORE_RESET -
+// SSTORE_SET). After a forkchoice-driven unwind, the TemporalMemBatch overlay
+// still holds storage writes made INSIDE the unwound txNum range, because:
+//
+//   - `Unwind` stores `sd.unwindToTxNum` and `sd.unwindChangeset` but does
+//     NOT remove post-target entries from `sd.storage` / `sd.domains[...]`.
+//   - `getLatest` returns `dataWithTxNums[len(...)-1]` without comparing
+//     its txNum against `sd.unwindToTxNum`.
+//   - The `unwindChangeset` fallback only fires on an overlay miss.
+//
+// So a first-time storage write at `txNum=T_write > T_unwind` remains visible
+// after `Unwind(T_unwind)`, and a re-executed SSTORE on that slot charges
+// SSTORE_RESET (2900) instead of SSTORE_SET (20000) — the observed 17100 diff.
+func TestSharedDomain_UnwindDoesNotRestoreOverlayForNewKey(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
+	stepSize := uint64(100)
+	db := newTestDb(t, stepSize)
+	ctx := context.Background()
+
+	rwTx, err := db.BeginTemporalRw(ctx)
+	require.NoError(t, err)
+	defer rwTx.Rollback()
+
+	domains, err := execctx.NewSharedDomains(ctx, rwTx, log.New())
+	require.NoError(t, err)
+	defer domains.Close()
+
+	stateChangeset := &changeset.StateChangeSet{}
+	domains.SetChangesetAccumulator(stateChangeset)
+
+	// Storage key mirrors a USDT balance slot: 20-byte address + 32-byte slot hash.
+	addr := common.HexToAddress("0xdac17f958d2ee523a2206206994597c13d831ec7")
+	slot := common.HexToHash("0x5ac7102aad1a639901bc2657323aaed9e90e40c550747c49170f1c82fd664e4f")
+	key := composite(addr[:], slot[:])
+	value := []byte{0x01, 0x02, 0x03, 0x04}
+
+	const unwindTarget uint64 = 50 // pre-write txNum where slot is absent
+	const writeTxNum uint64 = 100  // txNum inside a block that will be unwound
+
+	// 1. Precondition: slot is absent at the unwind target.
+	domains.SetTxNum(unwindTarget)
+	v, _, err := domains.GetLatest(kv.StorageDomain, rwTx, key)
+	require.NoError(t, err)
+	require.Empty(t, v, "precondition: slot must be absent before any writes")
+
+	// 2. Advance txNum and write the slot for the first time (prevVal = nil).
+	domains.SetTxNum(writeTxNum)
+	require.NoError(t, domains.DomainPut(kv.StorageDomain, rwTx, key, value, writeTxNum, nil))
+
+	// 3. Sanity: write is visible through the overlay.
+	v, _, err = domains.GetLatest(kv.StorageDomain, rwTx, key)
+	require.NoError(t, err)
+	require.Equal(t, value, v, "sanity: write must be visible pre-unwind")
+
+	// 4. Build the domain diff set from the accumulator, then unwind past the write.
+	var diffSet [kv.DomainLen][]kv.DomainEntryDiff
+	for idx, d := range stateChangeset.Diffs {
+		diffSet[idx] = d.GetDiffSet()
+	}
+	domains.Unwind(unwindTarget, &diffSet)
+
+	// 5. Simulate re-execution starting at the unwind target.
+	domains.SetTxNum(unwindTarget)
+
+	// 6. Failing assertion: the slot must be absent again.
+	v, _, err = domains.GetLatest(kv.StorageDomain, rwTx, key)
+	require.NoError(t, err)
+	require.Empty(t, v,
+		"after Unwind(txNum=%d), overlay must not return the write made at txNum=%d (got %x). "+
+			"TemporalMemBatch.getLatest returns the latest entry from sd.storage without "+
+			"consulting sd.unwindToTxNum, and the unwindChangeset fallback is unreachable "+
+			"while the key remains in sd.storage.",
+		unwindTarget, writeTxNum, v)
+}
+
 // TestNewSharedDomains_StateAheadOfBlocks verifies that when the persisted
 // commitment state is ahead of the TxNums index (catch-up scenario),
 // NewSharedDomains returns ErrBehindCommitment but the SharedDomains itself

--- a/db/state/temporal_mem_batch.go
+++ b/db/state/temporal_mem_batch.go
@@ -413,7 +413,60 @@ func (sd *TemporalMemBatch) GetDiffset(tx kv.RwTx, blockHash common.Hash, blockN
 }
 
 func (sd *TemporalMemBatch) Unwind(unwindToTxNum uint64, changeset *[kv.DomainLen][]kv.DomainEntryDiff) {
+	sd.latestStateLock.Lock()
+	defer sd.latestStateLock.Unlock()
+
 	sd.unwindToTxNum = unwindToTxNum
+
+	// Drop overlay entries stamped with txNum > unwindToTxNum. Without this,
+	// getLatest returns entries written inside the unwound range because it
+	// picks dataWithTxNums[len-1] without consulting sd.unwindToTxNum — the
+	// unwindChangeset fallback below is only reachable on an overlay miss.
+	// Observed as post-Fusaka gas-used mismatches after forkchoice-driven
+	// unwinds (an SSTORE on a slot first-written inside the unwound range
+	// charges SSTORE_RESET instead of SSTORE_SET — a 17100 gas shortfall
+	// per slot). Keys whose slice empties out are removed so the
+	// unwindChangeset fallback can supply the pre-unwind answer.
+	pruneSlice := func(entries []dataWithTxNum) []dataWithTxNum {
+		kept := entries[:0]
+		for _, e := range entries {
+			if e.txNum <= unwindToTxNum {
+				kept = append(kept, e)
+			}
+		}
+		return kept
+	}
+	for d := range sd.domains {
+		for k, entries := range sd.domains[d] {
+			kept := pruneSlice(entries)
+			if len(kept) == 0 {
+				delete(sd.domains[d], k)
+			} else {
+				sd.domains[d][k] = kept
+			}
+		}
+	}
+	// Collect first, mutate after: btree.Scan doesn't allow Set/Delete during traversal.
+	type storageEdit struct {
+		key  string
+		kept []dataWithTxNum
+	}
+	var edits []storageEdit
+	sd.storage.Scan(func(k string, entries []dataWithTxNum) bool {
+		kept := pruneSlice(entries)
+		if len(kept) != len(entries) {
+			edits = append(edits, storageEdit{k, kept})
+		}
+		return true
+	})
+	for _, e := range edits {
+		if len(e.kept) == 0 {
+			sd.storage.Delete(e.key)
+		} else {
+			sd.storage.Set(e.key, e.kept)
+		}
+	}
+
 	var unwindChangeset *[kv.DomainLen]map[string]kv.DomainEntryDiff
 	var unwindChangesetRaw *[kv.DomainLen][]kv.DomainEntryDiff
 


### PR DESCRIPTION
Cherry-pick of #20625 to `release/3.4`.

## Why

Addresses #21515 — the `gas used mismatch` / state-leak after a tip reorg that recurs on v3.4.2. #21157 (already on `release/3.4`) fixed only the diffset-lookup-by-wrong-hash part of the bug. This is the second of the three reported sub-bugs: a stale read in the `TemporalMemBatch` in-memory overlay. `Unwind()` recorded `unwindToTxNum` + an `unwindChangeset` but never pruned `sd.domains` / `sd.storage`, so `getLatest` kept returning a write made *inside* the unwound `txNum` range — flipping an `SSTORE` from `SET (20000)` to `RESET (2900)`, i.e. the ~17100-gas-per-slot shortfall users reported (diffs 71016 / 73638).

The third sub-bug (#20710) is already on `release/3.4` as #20716 (`104e6d1a97`).

## Adaptations

None — clean cherry-pick, no `release/3.4`-specific changes were needed.

## Verification on release/3.4 + this patch

- `go build ./db/state/...` — clean
- `go vet ./db/state/...` — clean
- `go tool golangci-lint run ./db/state/...` — 0 issues
- regression test `TestSharedDomain_UnwindDoesNotRestoreOverlayForNewKey` — passes
- `go test -short ./db/state/...` — all pass
