### PR TITLE
perf: parallel sender prefetch in newPayload + serial fast-paths for IBS state reads

### DIFF
--- a/execution/engineapi/engine_server.go
+++ b/execution/engineapi/engine_server.go
@@ -21,11 +21,13 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"runtime"
 	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/erigontech/secp256k1"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/holiman/uint256"
@@ -433,6 +435,15 @@ func (s *EngineServer) newPayload(ctx context.Context, req *engine_types.Executi
 			ValidationError: engine_types.NewStringifiedError(err),
 		}, nil
 	}
+
+	// Parallel sender recovery prefetch. The execution stage's TxTask.Sender
+	// falls back to a serial ECDSA recover on every tx whose `from` is not
+	// already cached — secp256k1_ext_ecdsa_recover is ~6% of total CPU on a
+	// warm rig. Doing the recovery here in parallel (one worker per
+	// secp256k1.ContextForThread slot) caches every sender on the tx, so the
+	// execution path hits the cache for all txs. Sequential fallback for
+	// trivial counts where the goroutine overhead would dominate.
+	prefetchSenders(transactions, s.config, uint64(req.BlockNumber), header.Time)
 
 	if version >= clparams.DenebVersion {
 		err := misc.ValidateBlobs(req.BlobGasUsed.Uint64(), s.config.GetMaxBlobGasPerBlock(header.Time), s.config.GetMaxBlobsPerBlock(header.Time), expectedBlobHashes, &transactions)
@@ -878,6 +889,60 @@ func (s *EngineServer) getPayloadBodiesByHash(ctx context.Context, request []com
 		resp[i] = extractPayloadBodyFromBody(body)
 	}
 	return resp, nil
+}
+
+// prefetchSenders populates tx.from for every transaction in parallel so that
+// the subsequent execution path skips the ECDSA recover step entirely. Each
+// worker uses its own secp256k1.Context to avoid contention on the default
+// context's mutex. Transactions whose sender is already set (e.g. a build-
+// time SetSender from the block builder) are skipped.
+func prefetchSenders(txs []types.Transaction, cfg *chain.Config, blockNum, blockTime uint64) {
+	if len(txs) == 0 {
+		return
+	}
+	signer := types.MakeSigner(cfg, blockNum, blockTime)
+	// Cap workers at NumOfContexts so every worker has a private secp256k1
+	// context, and at len(txs) so we don't spin idle goroutines.
+	numWorkers := runtime.NumCPU()
+	if maxCtx := secp256k1.NumOfContexts(); numWorkers > maxCtx {
+		numWorkers = maxCtx
+	}
+	if numWorkers > len(txs) {
+		numWorkers = len(txs)
+	}
+	if numWorkers <= 1 {
+		// Single tx (or no spare crypto contexts): use the default context
+		// and skip the worker dispatch overhead.
+		for _, tx := range txs {
+			if _, ok := tx.GetSender(); ok {
+				continue
+			}
+			if addr, err := signer.Sender(tx); err == nil {
+				tx.SetSender(addr)
+			}
+		}
+		return
+	}
+	var wg sync.WaitGroup
+	wg.Add(numWorkers)
+	for w := 0; w < numWorkers; w++ {
+		go func(workerID int) {
+			defer wg.Done()
+			ctx := secp256k1.ContextForThread(workerID)
+			for i := workerID; i < len(txs); i += numWorkers {
+				tx := txs[i]
+				if _, ok := tx.GetSender(); ok {
+					continue
+				}
+				if addr, err := signer.SenderWithContext(ctx, tx); err == nil {
+					tx.SetSender(addr)
+				}
+				// Errors are surfaced later by the standard execution path; we
+				// only prime the cache here.
+			}
+		}(w)
+	}
+	wg.Wait()
 }
 
 func extractPayloadBodyFromBody(body *types.RawBody) *engine_types.ExecutionPayloadBody {

--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -843,6 +843,26 @@ func (sdb *IntraBlockState) GetDelegatedDesignation(addr accounts.Address) (acco
 // GetState retrieves a value from the given account's storage trie.
 // DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) GetState(addr accounts.Address, key accounts.StorageKey) (uint256.Int, error) {
+	if sdb.versionMap == nil {
+		// Fast path: serial execution bypasses versionedRead's closure dispatch.
+		// SLOAD is the most frequent state read in EVM — generic+closure
+		// dispatch escapes both closures to the heap on every call. Inline
+		// the body to avoid that allocation. Matches the pattern of
+		// GetBalance / GetNonce above.
+		stateObject, err := sdb.getStateObject(addr, true)
+		if err != nil {
+			return u256.N0, err
+		}
+		var value uint256.Int
+		if stateObject != nil && !stateObject.deleted {
+			value, _ = stateObject.GetState(key)
+		}
+		if dbg.TraceTransactionIO && (sdb.trace || (dbg.TraceAccount(addr.Handle()) && traceKey(key))) {
+			fmt.Printf("%d (%d.%d) GetState (storage) %x, %x=%s\n", sdb.blockNum, sdb.txIndex, sdb.version, addr, key, value.Hex()[2:])
+		}
+		return value, nil
+	}
+
 	versionedValue, source, _, err := versionedRead(sdb, addr, StoragePath, key, false, u256.N0,
 		func(v uint256.Int) uint256.Int {
 			return v
@@ -865,6 +885,21 @@ func (sdb *IntraBlockState) GetState(addr accounts.Address, key accounts.Storage
 // GetCommittedState retrieves a value from the given account's committed storage trie.
 // DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) GetCommittedState(addr accounts.Address, key accounts.StorageKey) (uint256.Int, error) {
+	if sdb.versionMap == nil {
+		stateObject, err := sdb.getStateObject(addr, true)
+		if err != nil {
+			return u256.N0, err
+		}
+		var value uint256.Int
+		if stateObject != nil && !stateObject.deleted {
+			value, err = stateObject.GetCommittedState(key)
+		}
+		if dbg.TraceTransactionIO && (sdb.trace || dbg.TraceAccount(addr.Handle())) {
+			fmt.Printf("%d (%d.%d) GetCommittedState (storage) %x, %x=%s\n", sdb.blockNum, sdb.txIndex, sdb.version, addr, key, value.Hex()[2:])
+		}
+		return value, err
+	}
+
 	versionedValue, source, _, err := versionedRead(sdb, addr, StoragePath, key, true, u256.N0,
 		func(v uint256.Int) uint256.Int {
 			return v
@@ -885,6 +920,17 @@ func (sdb *IntraBlockState) GetCommittedState(addr accounts.Address, key account
 }
 
 func (sdb *IntraBlockState) HasSelfdestructed(addr accounts.Address) (bool, error) {
+	if sdb.versionMap == nil {
+		s, err := sdb.getStateObject(addr, true)
+		if err != nil {
+			return false, err
+		}
+		if s == nil || s.deleted || s.createdContract {
+			return false, nil
+		}
+		return s.selfdestructed, nil
+	}
+
 	destructed, _, _, err := versionedRead(sdb, addr, SelfDestructPath, accounts.NilKey, false, false,
 		func(v bool) bool { return v },
 		func(s *stateObject) (bool, error) {


### PR DESCRIPTION
## Summary

Two stacked optimizations cutting **main's newPayload p50 by ~9%** on the elbench A/B rig:

### 1. Parallel sender-recovery prefetch in newPayload (\`execution/engineapi\`)

CPU profile showed \`secp256k1_ext_ecdsa_recover\` at ~6% of total CPU (~26% of all cgocall time) on the warm rig. The recovers were happening serially inside the executor's \`TxTask.Sender\` "expensive lazy sender recovery" fallback, because the engine-API newPayload path never primes \`tx.from\` — only the staged-sync \`Senders\` stage does, and that stage isn't part of the engine-API pipeline.

Prime \`tx.from\` in parallel right after \`types.DecodeTransactions\`, with one worker per \`secp256k1.ContextForThread\` slot (workers capped at \`min(NumCPU, NumOfContexts, len(txs))\`). After the prefetch, every \`TxTask.Sender\` hits the cached \`tx.from\` and skips the ECDSA recover. Errors are swallowed — the standard execution path surfaces them.

### 2. Serial fast-path for hot IBS state reads (\`execution/state\`)

\`GetBalance\` / \`GetNonce\` / \`GetCode\` / \`GetCodeSize\` / \`GetCodeHash\` already short-circuit \`sdb.versionMap == nil\` (the default serial-execution path) and call the underlying stateObject method directly. \`GetState\` / \`GetCommittedState\` / \`HasSelfdestructed\` did not. \`versionedRead\` is generic over the return type and takes two closures (\`copyV\`, \`readStorage\`); under Go's escape analysis the closures escape to the heap on every call. \`IntraBlockState.GetState\` was 4.78 M flat allocs in the newPayload subtree alloc profile (SLOAD is the most frequent EVM state op).

Mirror the existing fast-path pattern for the three remaining hot methods. The version-map slow path is untouched, so parallel execution is unaffected.

## Rig measurement

Both ELs (main vs release/3.4) running on the elbench mux rig with matched newPayload pairs, fresh wipe protocol on both sides:

| Build | n | main p50 (ms) | r34 p50 (ms) | ratio | main absolute |
|--|--|--|--|--|--|
| Unpatched control (today's workload) | 154 | 84.4 | 67.4 | 1.24x | — |
| With this PR | 250 | **76.8** | 63.6 | **1.20x** | **-9.0%** |

- 9% reduction in main's newPayload p50 over the same-day workload.
- Workload-normalized (ratio vs r34): 1.24x → 1.20x = 3.2% relative.
- 15-min bucket stability check (post-warmup): ratio 1.15-1.21x across all buckets.

## Investigation context

erigontech/metarepo-internal-issues#18 (the rig-level investigation of the +9 ms p50 net regression on main vs release/3.4).

## Test plan

- [x] \`go build ./...\` clean
- [x] \`make lint\` clean
- [x] \`go test -short -race ./execution/engineapi/... ./execution/state/...\` green
- [x] Rig matched-pair A/B (above)
- [ ] Full CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)