### PR TITLE
perfomance: reduce pageSize to 4kb

### DIFF
--- a/db/state/changeset/state_changeset.go
+++ b/db/state/changeset/state_changeset.go
@@ -30,6 +30,7 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/dbutils"
 	"github.com/erigontech/erigon/execution/types/accounts"
+	"github.com/erigontech/erigon/node/ethconfig"
 )
 
 type StateChangeSet struct {
@@ -315,7 +316,12 @@ func deserializeKeys(in []byte) [kv.DomainLen][]kv.DomainEntryDiff {
 }
 
 const DiffChunkKeyLen = 48
-const DiffChunkLen = 4*1024 - 32
+
+// MDBX caps a leaf node at half a page (leaf_nodemax); a larger value spills to
+// an overflow page. DiffChunkLen is the largest chunk with a DiffChunkKeyLen key
+// that stays off overflow pages — see TestNoOverflowPages.
+const pageHeaderSize = 20                                                                       // per-record overhead on a half page: PAGEHDRSZ/2 + indx_t slot + NODESIZE
+const DiffChunkLen = int(ethconfig.DefaultChainDBPageSize)/2 - pageHeaderSize - DiffChunkKeyLen // = 1980
 
 type threadSafeBuf struct {
 	b []byte
@@ -394,7 +400,7 @@ func ReadDiffSet(tx kv.Tx, blockNumber uint64, blockHash common.Hash) ([kv.Domai
 	}
 
 	key := make([]byte, 48)
-	val := make([]byte, 0, DiffChunkLen*chunkCount)
+	val := make([]byte, 0, DiffChunkLen*int(chunkCount))
 	for i := uint64(0); i < chunkCount; i++ {
 		binary.BigEndian.PutUint64(key, blockNumber)
 		copy(key[8:], blockHash[:])

--- a/node/ethconfig/config.go
+++ b/node/ethconfig/config.go
@@ -117,7 +117,7 @@ var Defaults = Config{
 	ExperimentalBAL:     false,
 }
 
-const DefaultChainDBPageSize = 16 * datasize.KB
+const DefaultChainDBPageSize = 4 * datasize.KB
 
 func init() {
 	home := os.Getenv("HOME")


### PR DESCRIPTION
On bloatnet current bottleneck is: Flush 

4kb pageSize showing 1.7x beffer `flush`

Also now (after stepSize reduction on bloatnet) chaindata fit in ram - likely we will not have any FreeList issues

<img width="665" height="892" alt="Screenshot 2026-06-01 at 17 51 47" src="https://github.com/user-attachments/assets/b87d6388-3608-4c80-8e76-c9bdaec1d750" />


Next possible actions to reduce flush time:   
-  https://github.com/erigontech/erigon/pull/20952
