### PR TITLE
node/app/workerpool: de-flake TestWaitingQueueSizeRace

### DIFF
--- a/node/app/workerpool/workerpool_test.go
+++ b/node/app/workerpool/workerpool_test.go
@@ -396,15 +396,18 @@ func TestWaitingQueueSizeRace(t *testing.T) {
 	wp := New(workers)
 	defer wp.Stop()
 
+	// Block every worker so that, once all are busy, the dispatcher must put
+	// further tasks on the waiting queue — making a non-zero WaitingQueueSize
+	// deterministic rather than dependent on goroutine scheduling.
+	release := make(chan struct{})
+
 	maxChan := make(chan int)
 	for g := 0; g < goroutines; g++ {
 		go func() {
 			max := 0
-			// Submit 100 tasks, checking waiting queue size each time.  Report
-			// the maximum queue size seen.
 			for i := 0; i < tasks; i++ {
 				wp.Submit(func() {
-					time.Sleep(time.Microsecond)
+					<-release
 				})
 				waiting := wp.WaitingQueueSize()
 				if waiting > max {
@@ -429,6 +432,9 @@ func TestWaitingQueueSizeRace(t *testing.T) {
 	if maxMax >= goroutines*tasks {
 		t.Error("should not have seen all tasks on waiting queue")
 	}
+
+	// Unblock workers so the deferred Stop can drain and join them.
+	close(release)
 }
 
 func TestPause(t *testing.T) {


### PR DESCRIPTION
## Problem

`TestWaitingQueueSizeRace` is timing-dependent and flakes intermittently with:

```
--- FAIL: TestWaitingQueueSizeRace
    workerpool_test.go: expected to see waiting queue size > 0
```

It surfaced on the `sonar` (coverage) job of an unrelated docs PR (#21534), reddening `ci-gate`.

## Root cause

The submitted tasks only `time.Sleep(time.Microsecond)`. `Submit` serializes every task through a single unbuffered handoff to the dispatcher, and the waiting queue only grows when **all** `maxWorkers` are simultaneously busy. With ~1µs tasks, a worker is almost always free by the time the next serialized task reaches the dispatcher, so `p.waiting` is frequently never observed `> 0` — and the assertion trips. Coverage instrumentation perturbs timing enough to expose it; the dedicated `-race` jobs happened to stay green.

## Fix

Block the workers on a `release` channel instead of sleeping. Once all `maxWorkers` are busy, the dispatcher is **forced** to enqueue every further task, so a non-zero `WaitingQueueSize` is deterministic regardless of scheduling. The concurrent `WaitingQueueSize` reads that this `-race` test exists to exercise are unchanged. Workers are released after the maximum is collected so the deferred `Stop` can drain and join them (and `goleak` stays happy).

The upper-bound assertion still holds with margin: at most `maxWorkers` (5) tasks are in workers, so the queue peaks at `goroutines*tasks - 5` = 195 < 200.

## Verification

- `-race`, 2000×: pass
- coverage + `GOMAXPROCS=1`, 2000× (the regime that flaked on sonar): pass
- full package under `-race`, 3×: pass
- `make lint`: 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)