### PR TITLE
execution/protocol: fix EIP-7702 AUTH_BASE state-gas over-refund on Amsterdam

### DIFF
--- a/execution/protocol/txn_executor.go
+++ b/execution/protocol/txn_executor.go
@@ -785,11 +785,12 @@ func (st *TxnExecutor) verifyAuthorities(auths []types.Authorization, contractCr
 				continue
 			}
 
-			// 6. Refund intrinsic state gas the auth wasn't going to spend:
-			//    NEW_ACCOUNT for existing account leaves, AUTH_BASE when no new
-			//    delegation-indicator bytes are written — either overwriting an
-			//    existing indicator or clearing against `0x0`. Pre-Amsterdam
-			//    keeps the legacy regular-gas refund (EIP-7702).
+			// 6. Refund intrinsic state gas the auth won't spend: NEW_ACCOUNT when
+			//    the authority account already exists, and AUTH_BASE when it already
+			//    carries a delegation indicator (overwriting or clearing one writes
+			//    no new state). A fresh write or a no-op clear of an undelegated
+			//    authority keeps AUTH_BASE. Pre-Amsterdam keeps the legacy
+			//    regular-gas refund (EIP-7702).
 			exists, err := st.state.Exist(authority)
 			if err != nil {
 				return nil, stateIgasRefund, fmt.Errorf("%w: %w", ErrTxnExecutionFailed, err)
@@ -798,7 +799,7 @@ func (st *TxnExecutor) verifyAuthorities(auths []types.Authorization, contractCr
 				if exists {
 					stateIgasRefund += params.StateGasNewAccount
 				}
-				if hasDelegation || auth.Address == (common.Address{}) {
+				if hasDelegation {
 					stateIgasRefund += params.StateGasAuthBase
 				}
 			} else if exists {


### PR DESCRIPTION
`verifyAuthorities` refunded the EIP-8037 per-auth AUTH_BASE state gas for any delegation clear (`auth.Address == 0x0`), even when the authority had no pre-existing delegation. AUTH_BASE = `STATE_BYTES_PER_AUTH_BASE (23) * CPSB (1530, cost-per-state-byte) = params.StateGasAuthBase = 35190`. Clearing/overwriting an existing indicator writes no new state, but a no-op clear of an undelegated authority must keep the charge.

Result: Amsterdam blocks under-charged by one AUTH_BASE per undelegated-clearing auth → import fails with `gas used = header - 35190`.

Fix: refund AUTH_BASE only when `hasDelegation`.

Verified on EEST `zkevm@v0.4.0` `for_amsterdam`: 12 distinct gas mismatches → 0. `make lint` clean.