### PR TITLE
cl/clstages: recover from panics in stage ActionFunc

### DIFF
--- a/cl/clstages/clstages.go
+++ b/cl/clstages/clstages.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/log/v3"
 )
 
@@ -48,6 +49,14 @@ func (s *StageGraph[CONFIG, ARGUMENTS]) StartWithStage(ctx context.Context, star
 		errch := make(chan error)
 		start := time.Now()
 		go func() {
+			// Recover so a panic in a stage (e.g. from a malformed peer response) degrades
+			// to a stage error instead of terminating the whole node.
+			defer func() {
+				if r := recover(); r != nil {
+					lg.Error("[Caplin] panic in clstage", "err", r, "stack", dbg.Stack())
+					errch <- fmt.Errorf("panic in clstage: %v", r)
+				}
+			}()
 			// we run this is a goroutine so that the process can exit in the middle of a stage
 			// since caplin is designed to always be able to recover regardless of db state, this should be safe
 			select {

--- a/cl/clstages/clstages_test.go
+++ b/cl/clstages/clstages_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package clstages_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/clstages"
+	"github.com/erigontech/erigon/common/log/v3"
+)
+
+// A panic in a stage's ActionFunc must be recovered and surfaced as a stage
+// error, never propagate out of the stage goroutine and terminate the process.
+func TestStartWithStageRecoversFromActionFuncPanic(t *testing.T) {
+	var transitionErr error
+	graph := &clstages.StageGraph[any, any]{
+		ArgsFunc: func(ctx context.Context, cfg any) any { return nil },
+		Stages: map[string]clstages.Stage[any, any]{
+			"boom": {
+				Description: "panics on purpose",
+				ActionFunc: func(ctx context.Context, logger log.Logger, cfg any, args any) error {
+					panic("kaboom")
+				},
+				TransitionFunc: func(cfg any, args any, err error) string {
+					transitionErr = err
+					return "terminal"
+				},
+			},
+		},
+	}
+
+	err := graph.StartWithStage(context.Background(), "boom", log.Root(), nil)
+
+	require.ErrorContains(t, err, "unknown stage: terminal")
+	require.Error(t, transitionErr)
+	require.ErrorContains(t, transitionErr, "kaboom")
+}


### PR DESCRIPTION
## What

Add a `recover()` to the stage goroutine in `clstages.StartWithStage` so a panic in any Caplin stage's `ActionFunc` is converted into a stage error (logged at `Error` with a stack trace) instead of propagating out of the unrecovered goroutine and terminating the whole erigon process.

## Why

Caplin stages process peer-controlled req/resp responses. A malformed response that trips a nil-pointer dereference — or any other panic — inside a stage currently crashes the entire node, because the goroutine in `StartWithStage` has no `defer recover()`:

```go
go func() {
    select {
    case errch <- currentStage.ActionFunc(ctx, lg, cfg, args):
    case <-ctx.Done():
        errch <- ctx.Err()
    }
}()
```

An unrecovered panic in this goroutine is a remote, unauthenticated crash (DoS) vector. This change is defense-in-depth that covers **every** current and future stage, not just whichever call site happens to be reachable today. It matches the `recover()` patterns already used elsewhere in Caplin (`cl/sentinel/handlers`, `cl/phase1/network/gossip`) and the stage loop's own stated intent — *"caplin is designed to always be able to recover regardless of db state"*.

## Change

```go
// Recover so a panic in a stage (e.g. from a malformed peer response) degrades
// to a stage error instead of terminating the whole node.
defer func() {
    if r := recover(); r != nil {
        lg.Error("[Caplin] panic in clstage", "err", r, "stack", dbg.Stack())
        errch <- fmt.Errorf("panic in clstage: %v", r)
    }
}()
```

The recovered panic is surfaced to the stage's `TransitionFunc` as an error, so the stage loop continues exactly as it would for any other stage error.

## Test

`TestStartWithStageRecoversFromActionFuncPanic` (added TDD red→green): a stage whose `ActionFunc` panics. Without the recover the test binary crashes with `panic: kaboom` (out of the goroutine at `clstages.go:50`); with it, the panic is surfaced as a stage error and `StartWithStage` returns normally.

## Verification

- `go test ./cl/clstages/` ✅
- `make lint` ✅ (0 issues)
- `make erigon integration` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
