### PR TITLE
rpc/jsonrpc: keep system address in executionWitness when a tx opcode touches it

### DIFF
--- a/rpc/jsonrpc/debug_execution_witness.go
+++ b/rpc/jsonrpc/debug_execution_witness.go
@@ -71,6 +71,11 @@ type RecordingState struct {
 
 	// for debugging: addresses to trace operations on
 	accountsToTrace map[common.Address]struct{}
+
+	// The system address is touched as msg.sender on every block's system calls;
+	// that alone is not a witness access. A real opcode access during a user tx
+	// (seen via the per-tx access set) sets this so it is kept (EIP-7928).
+	systemAddrTouchedInTx bool
 }
 
 // NewRecordingState creates a new RecordingState wrapping the given inner reader.
@@ -93,6 +98,10 @@ func NewRecordingState(inner state.StateReader) *RecordingState {
 		CreatedContracts:      make(map[common.Address]struct{}),
 	}
 }
+
+// MarkSystemAddrTouchedInTx records that a user transaction accessed the system
+// address via an opcode, so it is kept in the witness even without a state change.
+func (s *RecordingState) MarkSystemAddrTouchedInTx() { s.systemAddrTouchedInTx = true }
 
 func (s *RecordingState) SetAccountsToTrace(addrs []common.Address) {
 	if len(addrs) == 0 {
@@ -601,6 +610,13 @@ func (api *DebugAPIImpl) ExecutionWitness(ctx context.Context, blockNrOrHash rpc
 		ibs.SetTxContext(blockNum, txIndex)
 
 		_, err = protocol.ApplyMessage(evm, msg, gp, true /* refunds */, false /* gasBailout */, engine)
+		// A user tx that accesses the system address via an opcode keeps it in the
+		// witness; the per-tx access set captures this even on state-cache hits.
+		if acc := ibs.AccessedAddresses(); acc != nil {
+			if _, ok := acc[params.SystemAddress]; ok {
+				recordingState.MarkSystemAddrTouchedInTx()
+			}
+		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to apply tx %d: %w", txIndex, err)
 		}
@@ -839,7 +855,7 @@ func collectAccessedState(rs *RecordingState) *accessedState {
 			postExists = preExists
 		}
 		existenceChanged := preExists != postExists
-		if !reallyChanged && !hasStorage && !existenceChanged {
+		if !reallyChanged && !hasStorage && !existenceChanged && !rs.systemAddrTouchedInTx {
 			delete(out.Addresses, sysAddr)
 		}
 	}


### PR DESCRIPTION
`debug_executionWitness` dropped the system address (`0xff..fe`) from the witness unless it had a state change — the rationale being it's only ever the `msg.sender` of begin/end-block system calls. But a user transaction can access it via an account-accessing opcode (`BALANCE`/`EXTCODESIZE`/`EXTCODEHASH`/`EXTCODECOPY`/`CALL`/`STATICCALL`); per EIP-7928 that's an account-only entry the witness must carry. Such a read usually hits the state-object cache (the account was loaded during the system call), so the `RecordingState` reader never sees it.

Fix: detect the access via the per-transaction access set (`ibs.AccessedAddresses()`) and keep the system address when a user tx touched it.

Verified against the EEST zkevm witness suite: `bal_account_touch_system_address` (all 6 opcode variants: balance/call/extcodesize/extcodehash/extcodecopy/staticcall) goes green, full `for_amsterdam` corpus shows no regressions. The zkevm suite lives on #21487 until merged, so its CI coverage of this fixture arrives once that lands. `make lint` clean.