### PR TITLE
rpc/jsonrpc, execution/commitment: drop transient-collapse siblings from execution witness

### DIFF
--- a/execution/commitment/commitment.go
+++ b/execution/commitment/commitment.go
@@ -749,6 +749,14 @@ func (be *BranchEncoder) EncodeBranch(bitmap, touchMap, afterMap uint16, cells *
 
 type BranchData []byte
 
+// ChildCount returns the number of children present in the branch.
+func (branchData BranchData) ChildCount() int {
+	if len(branchData) < 4 {
+		return 0
+	}
+	return bits.OnesCount16(binary.BigEndian.Uint16(branchData[2:4]))
+}
+
 func (branchData BranchData) String() string {
 	if len(branchData) == 0 {
 		return ""

--- a/execution/commitment/commitmentdb/commitment_context.go
+++ b/execution/commitment/commitmentdb/commitment_context.go
@@ -23,6 +23,7 @@ import (
 	"github.com/erigontech/erigon/db/kv/rawdbv3"
 	"github.com/erigontech/erigon/diagnostics/metrics"
 	"github.com/erigontech/erigon/execution/commitment"
+	"github.com/erigontech/erigon/execution/commitment/nibbles"
 	"github.com/erigontech/erigon/execution/commitment/trie"
 	witnesstypes "github.com/erigontech/erigon/execution/commitment/witness"
 	"github.com/erigontech/erigon/execution/types/accounts"
@@ -292,6 +293,17 @@ func (sdc *SharedDomainsCommitmentContext) SetCollapseTracer(tracer commitment.C
 	if ok {
 		hexPatriciaHashed.SetCollapseTracer(tracer)
 	}
+}
+
+// BranchChildCount returns the child count of the branch at nibblePrefix, read
+// from the in-memory commitment domain (post-compute state).
+func (sdc *SharedDomainsCommitmentContext) BranchChildCount(tx kv.TemporalTx, nibblePrefix []byte) (int, error) {
+	key := nibbles.HexToCompact(nibblePrefix)
+	enc, _, err := sdc.sharedDomains.AsGetter(tx).GetLatest(kv.CommitmentDomain, key)
+	if err != nil {
+		return 0, err
+	}
+	return commitment.BranchData(enc).ChildCount(), nil
 }
 
 // ComputeCommitment Evaluates commitment for gathered updates.

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -202,6 +202,7 @@ func (hph *HexPatriciaHashed) resetForReuse() {
 	hph.capture = nil
 	hph.trace = false
 	hph.traceDomain = false
+	hph.collapseTracer = nil
 
 	// flags
 	hph.memoizationOff = false

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -55,11 +55,9 @@ type DomainPutter = stateifs.DomainPutter
 // CommitmentWrite represents a commitment domain write that needs to be added to changesets.
 type CommitmentWrite = stateifs.CommitmentWrite
 
-// CollapseTracer is a callback invoked when a trie node collapse occurs during updates to commitment.
-// When a FullNode is reduced to a single child (updateKindPropagate), the remaining child
-// may be a HashNode that needs to be resolved for proper witness generation.
-// The callback receives the hashed key path (in nibble format) to the remaining child.
-type CollapseTracer func(hashedKeyPath []byte)
+// CollapseTracer is invoked when a trie node collapses during a commitment update.
+// hashedKeyPath is the surviving child's nibble path; branchPrefix is the collapsing branch's.
+type CollapseTracer func(hashedKeyPath, branchPrefix []byte)
 
 // HexPatriciaHashed implements commitment based on patricia merkle tree with radix 16,
 // with keys pre-hashed by keccak256
@@ -2403,7 +2401,7 @@ func (hph *HexPatriciaHashed) detectCollapseBeforeDelete(hashedKey []byte) {
 		fmt.Printf("[collapse] found at parentRow=%d depth=%d: deleteNibble=%x, siblingNibble=%x, siblingPath=%s (len=%d), hashLen=%d, extLen=%d\n",
 			parentRow, depth, deleteNibble, siblingNibble, compactSibling, len(siblingPath), siblingCell.hashLen, siblingCell.hashedExtLen)
 	}
-	hph.collapseTracer(siblingPath)
+	hph.collapseTracer(siblingPath, common.Copy(hph.currentKey[:depth]))
 }
 
 // detectCascadingCollapseAtRow detects a FullNode→ShortNode collapse caused by
@@ -2427,7 +2425,7 @@ func (hph *HexPatriciaHashed) detectCascadingCollapseAtRow(row int) {
 		fmt.Printf("[cascade-collapse] found at row=%d depth=%d: survivingNibble=%x, siblingPath=%s (len=%d), hashLen=%d, hashedExtLen=%d\n",
 			row, depth, survivingNibble, compactSibling, len(siblingPath), survivingCell.hashLen, survivingCell.hashedExtLen)
 	}
-	hph.collapseTracer(siblingPath)
+	hph.collapseTracer(siblingPath, common.Copy(hph.currentKey[:depth]))
 }
 
 // fetches cell by key and set touch/after maps. Requires that prefix to be already unfolded

--- a/rpc/jsonrpc/debug_execution_witness.go
+++ b/rpc/jsonrpc/debug_execution_witness.go
@@ -950,6 +950,7 @@ func detectCollapseSiblings(
 			branchPrefix: common.Copy(branchPrefix),
 		})
 	})
+	defer sdCtx.SetCollapseTracer(nil)
 
 	computedRootHash, err := sdCtx.ComputeCommitment(ctx, tx, false, blockNum, firstTxNumInBlock, "debug_executionWitness_collapse_detection", nil)
 	if err != nil {
@@ -960,10 +961,10 @@ func detectCollapseSiblings(
 		return nil, fmt.Errorf("[debug_executionWitness] computedRootHash(%x)!= expectedRootHash(%x)", computedRootHash, expectedBlockRoot)
 	}
 
-	sdCtx.SetCollapseTracer(nil)
-
-	// A collapse refilled by a later insert in the same block leaves a final branch
-	// with >=2 children; its sibling is not in the witness, so drop it.
+	// The canonical witness (insert-before-delete order) does not touch the sibling of
+	// a branch whose net block change leaves it with >=2 children; erigon's replay can
+	// transiently collapse such a branch, so drop those siblings to match membership.
+	siblingPaths = make([][]byte, 0, len(candidates))
 	for _, c := range candidates {
 		childCount, err := sdCtx.BranchChildCount(tx, c.branchPrefix)
 		if err != nil {

--- a/rpc/jsonrpc/debug_execution_witness.go
+++ b/rpc/jsonrpc/debug_execution_witness.go
@@ -939,8 +939,16 @@ func detectCollapseSiblings(
 	preReader := commitmentdb.NewHistoryStateReader(tx, firstTxNumInBlock)
 	accessed.touchNonZeroKeys(sdCtx, splitStateReader, preReader, domains.StepSize())
 
-	sdCtx.SetCollapseTracer(func(hashedKeyPath []byte) {
-		siblingPaths = append(siblingPaths, common.Copy(hashedKeyPath))
+	type collapseCandidate struct {
+		siblingPath  []byte
+		branchPrefix []byte
+	}
+	var candidates []collapseCandidate
+	sdCtx.SetCollapseTracer(func(hashedKeyPath, branchPrefix []byte) {
+		candidates = append(candidates, collapseCandidate{
+			siblingPath:  common.Copy(hashedKeyPath),
+			branchPrefix: common.Copy(branchPrefix),
+		})
 	})
 
 	computedRootHash, err := sdCtx.ComputeCommitment(ctx, tx, false, blockNum, firstTxNumInBlock, "debug_executionWitness_collapse_detection", nil)
@@ -953,6 +961,21 @@ func detectCollapseSiblings(
 	}
 
 	sdCtx.SetCollapseTracer(nil)
+
+	// A collapse refilled by a later insert in the same block leaves a final branch
+	// with >=2 children; its sibling is not in the witness, so drop it.
+	for _, c := range candidates {
+		childCount, err := sdCtx.BranchChildCount(tx, c.branchPrefix)
+		if err != nil {
+			return nil, fmt.Errorf("[debug_executionWitness] read post-state branch for collapse filter: %w", err)
+		}
+		if childCount >= 2 {
+			log.Debug("[debug_executionWitness] dropping transient-collapse sibling",
+				"branchPrefix", commitment.NibblesToString(c.branchPrefix), "childCount", childCount)
+			continue
+		}
+		siblingPaths = append(siblingPaths, c.siblingPath)
+	}
 	return siblingPaths, nil
 }
 


### PR DESCRIPTION
## Problem

`debug_executionWitness` emits one extra state node for blocks that delete and re-insert keys under the same trie branch.

The canonical witness follows insert-before-delete ordering, under which such a branch never collapses. Erigon's post-state commitment replays the block's updates in a different order that can transiently reduce the branch to a single child; the collapse tracer then touches the surviving sibling into the witness. The block's net change leaves the branch with >=2 children, so that sibling is not part of the canonical witness.

Surfaced by EEST fixtures `eip8025_optional_proofs/witness_state_replay_order/*`, which are constructed to fail a replay that is not insert-before-delete.

## Fix

This does not change the replay order. It restores canonical node membership with a post-pass filter:

- `CollapseTracer` carries the collapsing branch's nibble prefix alongside the sibling path.
- After the post-state commitment, `detectCollapseSiblings` reads each candidate branch from the in-memory commitment domain and drops the sibling when the branch ended with >=2 children (transient collapse); siblings whose branch genuinely collapsed are kept.
- Adds `BranchData.ChildCount()` and `SharedDomainsCommitmentContext.BranchChildCount()`.

Producer-only; no consumer changes, no state-root impact.

## Testing

Verified against the EEST zkevm witness suite (#21487, which carries the fixtures): the two `witness_state_replay_order` fixtures pass and the full `for_amsterdam` run shows no new failures.

Part of #21307.