### PR TITLE
cl/phase1/stages: fix EL backfill slot/block unit mix

### DIFF
--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -84,11 +84,8 @@ func StageHistoryReconstruction(downloader *network.BackwardBeaconDownloader, an
 	}
 }
 
-// elBackfillFinished reports whether the execution-layer history backfill has
-// reached its destination. destinationSlot is a beacon slot (normal Deneb
-// backfill toward the merge); destinationBlock is an EL block number (set when
-// filling a snapshot gap). The two are different units: the EL block progress
-// must be compared to destinationBlock, never the beacon slot.
+// elBackfillFinished reports whether the EL history backfill reached its floor:
+// the beacon slot, or for a snapshot gap the EL block number (compared to elBlock).
 func elBackfillFinished(slot, elBlock, destinationSlot, destinationBlock uint64) bool {
 	if destinationSlot != math.MaxUint64 && slot <= destinationSlot {
 		return true
@@ -129,9 +126,8 @@ func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Co
 	if cfg.engine != nil && cfg.engine.SupportInsertion() && cfg.beaconCfg.DenebForkEpoch != math.MaxUint64 {
 		destinationSlotForEL = cfg.beaconCfg.BellatrixForkEpoch * cfg.beaconCfg.SlotsPerEpoch
 	}
-	// EL block-number floor used when filling a snapshot gap. Kept separate from
-	// destinationSlotForEL because the two carry different units (EL block number
-	// vs beacon slot) and must never be compared against each other.
+	// EL block-number floor for snapshot-gap backfill, kept separate from the
+	// beacon-slot destinationSlotForEL since the units must not be mixed.
 	destinationBlockForEL := uint64(math.MaxUint64)
 	// Set up onNewBlock callback
 	// [Modified in Gloas:EIP7732] envelope is non-nil for GLOAS FULL blocks, nil for EMPTY or pre-GLOAS.

--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -84,6 +84,21 @@ func StageHistoryReconstruction(downloader *network.BackwardBeaconDownloader, an
 	}
 }
 
+// elBackfillFinished reports whether the execution-layer history backfill has
+// reached its destination. destinationSlot is a beacon slot (normal Deneb
+// backfill toward the merge); destinationBlock is an EL block number (set when
+// filling a snapshot gap). The two are different units: the EL block progress
+// must be compared to destinationBlock, never the beacon slot.
+func elBackfillFinished(slot, elBlock, destinationSlot, destinationBlock uint64) bool {
+	if destinationSlot != math.MaxUint64 && slot <= destinationSlot {
+		return true
+	}
+	if destinationBlock != math.MaxUint64 && elBlock != 0 && elBlock <= destinationBlock {
+		return true
+	}
+	return false
+}
+
 // SpawnStageBeaconsForward spawn the beacon forward stage
 func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Context, logger log.Logger) error {
 	// Wait for execution engine to be ready.
@@ -114,6 +129,10 @@ func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Co
 	if cfg.engine != nil && cfg.engine.SupportInsertion() && cfg.beaconCfg.DenebForkEpoch != math.MaxUint64 {
 		destinationSlotForEL = cfg.beaconCfg.BellatrixForkEpoch * cfg.beaconCfg.SlotsPerEpoch
 	}
+	// EL block-number floor used when filling a snapshot gap. Kept separate from
+	// destinationSlotForEL because the two carry different units (EL block number
+	// vs beacon slot) and must never be compared against each other.
+	destinationBlockForEL := uint64(math.MaxUint64)
 	// Set up onNewBlock callback
 	// [Modified in Gloas:EIP7732] envelope is non-nil for GLOAS FULL blocks, nil for EMPTY or pre-GLOAS.
 	cfg.downloader.SetOnNewBlock(func(blk *cltypes.SignedBeaconBlock, envelope *cltypes.SignedExecutionPayloadEnvelope) (finished bool, err error) {
@@ -235,7 +254,7 @@ func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Co
 				isInElSnapshots = frozenBlocksInEL > blk.Block.Body.ExecutionPayload.BlockNumber
 			}
 			if cfg.engine.HasGapInSnapshots(ctx) && frozenBlocksInEL > 0 {
-				destinationSlotForEL = frozenBlocksInEL - 1
+				destinationBlockForEL = frozenBlocksInEL - 1
 			}
 		}
 
@@ -244,7 +263,7 @@ func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Co
 		}
 		return hasDownloadEnoughForImmediateBlobsBackfilling &&
 				(!cfg.caplinConfig.ArchiveBlocks || slot <= cfg.sn.SegmentsMax()) &&
-				((destinationSlotForEL != math.MaxUint64 && slot <= destinationSlotForEL) || isInElSnapshots),
+				(elBackfillFinished(slot, uint64(currEth1Progress.Load()), destinationSlotForEL, destinationBlockForEL) || isInElSnapshots),
 			tx.Commit()
 	})
 

--- a/cl/phase1/stages/stage_history_download_test.go
+++ b/cl/phase1/stages/stage_history_download_test.go
@@ -1,0 +1,64 @@
+// Copyright 2024 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package stages
+
+import (
+	"math"
+	"testing"
+)
+
+// On any post-merge chain the EL block number is far larger than the beacon
+// slot (e.g. mainnet block ~25.2M vs slot ~14.46M). When a snapshot gap sets
+// an EL block-number floor, the backfill-finished decision must compare EL
+// block progress against that floor — comparing the beacon slot instead trips
+// trivially true and stops the backfill at the chain tip, leaving the gap
+// unfilled (manifesting downstream as "parent's total difficulty not found").
+func TestELBackfillFinished_GapUsesBlockNotSlot(t *testing.T) {
+	const (
+		bellatrixSlot = uint64(4_636_672) // a real beacon-slot floor
+		frozenBlock   = uint64(25_073_000)
+		headSlot      = uint64(14_460_640)
+		headBlock     = uint64(25_224_522)
+	)
+	destBlock := frozenBlock - 1
+
+	// At the chain tip, with a gap still to fill down to the frozen tip, the
+	// backfill must NOT be considered finished.
+	if elBackfillFinished(headSlot, headBlock, bellatrixSlot, destBlock) {
+		t.Fatalf("backfill reported finished at the tip (slot=%d block=%d) while gap down to block %d is unfilled",
+			headSlot, headBlock, destBlock)
+	}
+
+	// Once EL block progress has descended to the frozen tip, it is finished.
+	if !elBackfillFinished(headSlot-150_000, destBlock, bellatrixSlot, destBlock) {
+		t.Fatalf("backfill should be finished once EL block progress reaches the frozen tip (block %d)", destBlock)
+	}
+}
+
+// Without a snapshot gap, the EL block floor is unset and completion is driven
+// purely by the beacon-slot floor (normal Deneb backfill toward the merge).
+func TestELBackfillFinished_NoGapUsesSlotFloor(t *testing.T) {
+	const bellatrixSlot = uint64(4_636_672)
+	noBlockFloor := uint64(math.MaxUint64)
+
+	if elBackfillFinished(bellatrixSlot+1, 20_000_000, bellatrixSlot, noBlockFloor) {
+		t.Fatal("backfill must continue while still above the beacon-slot floor")
+	}
+	if !elBackfillFinished(bellatrixSlot, 20_000_000, bellatrixSlot, noBlockFloor) {
+		t.Fatal("backfill must finish once the beacon-slot floor is reached")
+	}
+}

--- a/cl/phase1/stages/stage_history_download_test.go
+++ b/cl/phase1/stages/stage_history_download_test.go
@@ -21,12 +21,8 @@ import (
 	"testing"
 )
 
-// On any post-merge chain the EL block number is far larger than the beacon
-// slot (e.g. mainnet block ~25.2M vs slot ~14.46M). When a snapshot gap sets
-// an EL block-number floor, the backfill-finished decision must compare EL
-// block progress against that floor — comparing the beacon slot instead trips
-// trivially true and stops the backfill at the chain tip, leaving the gap
-// unfilled (manifesting downstream as "parent's total difficulty not found").
+// Post-merge the EL block number exceeds the beacon slot, so a snapshot-gap
+// floor must be compared against EL block progress, not the slot.
 func TestELBackfillFinished_GapUsesBlockNotSlot(t *testing.T) {
 	const (
 		bellatrixSlot = uint64(4_636_672) // a real beacon-slot floor
@@ -36,8 +32,6 @@ func TestELBackfillFinished_GapUsesBlockNotSlot(t *testing.T) {
 	)
 	destBlock := frozenBlock - 1
 
-	// At the chain tip, with a gap still to fill down to the frozen tip, the
-	// backfill must NOT be considered finished.
 	if elBackfillFinished(headSlot, headBlock, bellatrixSlot, destBlock) {
 		t.Fatalf("backfill reported finished at the tip (slot=%d block=%d) while gap down to block %d is unfilled",
 			headSlot, headBlock, destBlock)


### PR DESCRIPTION
## Problem

`destinationSlotForEL` is a beacon slot, but the snapshot-gap path stored an EL block number (`frozenBlocksInEL-1`) in it. Post-merge the block number exceeds the slot, so the finished-gate (`slot <= destinationSlotForEL`) and the wait loop (`Progress() > destinationSlotForEL`) misfire: the EL history backfill reports finished at the chain tip and downloads nothing. The tip-to-head gap never fills, and the block collector loops:

```
[BlockCollector] Failed to insert blocks err="parent's total difficulty not found with hash 275c70ad... and height 25224521: <nil>"
```

Hits any behind-node restart where `HasGapInSnapshots` is true.

## Fix

Track the gap floor as a separate EL block number compared against EL block progress (`currEth1Progress`), not the beacon slot. Decision extracted to `elBackfillFinished` with a unit test for the gap and no-gap paths.