### PR TITLE
db/snapshotsync: make index building and opening segments safe with other files building events

### DIFF
--- a/db/snapshotsync/freezeblocks/block_snapshots.go
+++ b/db/snapshotsync/freezeblocks/block_snapshots.go
@@ -632,7 +632,10 @@ var BlockCompressCfg = seg.Cfg{
 func dumpRange(ctx context.Context, f snaptype.FileInfo, dumper dumpFunc, firstKey firstKeyGetter, chainDB kv.RoDB, chainConfig *chain.Config, tmpDir string, workers int, lvl log.Lvl, logger log.Logger, inProgress *snapshotsync.RoSnapshots) (uint64, error) {
 	// Claim this (type, range) so a concurrent OpenFolder doesn't pick up the
 	// .seg before its index is built and race our BuildIndexes below.
-	if inProgress != nil && inProgress.TryAcquireRange(f.Type.Enum(), f.From, f.To) {
+	if inProgress != nil {
+		if !inProgress.TryAcquireRange(f.Type.Enum(), f.From, f.To) {
+			return 0, fmt.Errorf("dump %s: range is already being built", f.Name())
+		}
 		defer inProgress.ReleaseRange(f.Type.Enum(), f.From, f.To)
 	}
 	var lastKeyValue uint64

--- a/db/snapshotsync/freezeblocks/block_snapshots.go
+++ b/db/snapshotsync/freezeblocks/block_snapshots.go
@@ -310,7 +310,7 @@ func (br *BlockRetire) retireBlocks(
 		logger.Log(lvl, "[snapshots] Retire Blocks", "range",
 			fmt.Sprintf("%s-%s", common.PrettyCounter(blockFrom), common.PrettyCounter(blockTo)))
 		// in future we will do it in background
-		if err := DumpBlocks(ctx, blockFrom, blockTo, br.chainConfig, tmpDir, snapshots.Dir(), db, int(workers), lvl, logger, blockReader, br.snCfg); err != nil {
+		if err := DumpBlocks(ctx, blockFrom, blockTo, br.chainConfig, tmpDir, snapshots.Dir(), db, int(workers), lvl, logger, blockReader, br.snCfg, &snapshots.RoSnapshots); err != nil {
 			return ok, fmt.Errorf("DumpBlocks: %w", err)
 		}
 
@@ -576,10 +576,10 @@ func (br *BlockRetire) DisableReadAhead() {
 	}
 }
 
-func DumpBlocks(ctx context.Context, blockFrom, blockTo uint64, chainConfig *chain.Config, tmpDir, snapDir string, chainDB kv.RoDB, workers int, lvl log.Lvl, logger log.Logger, blockReader services.FullBlockReader, snCfg *snapcfg.Cfg) error {
+func DumpBlocks(ctx context.Context, blockFrom, blockTo uint64, chainConfig *chain.Config, tmpDir, snapDir string, chainDB kv.RoDB, workers int, lvl log.Lvl, logger log.Logger, blockReader services.FullBlockReader, snCfg *snapcfg.Cfg, inProgress *snapshotsync.RoSnapshots) error {
 	firstTxNum := blockReader.FirstTxnNumNotInSnapshots()
 	for i := blockFrom; i < blockTo; i = chooseSegmentEnd(i, blockTo, snaptype2.Enums.Headers, snCfg) {
-		lastTxNum, err := dumpBlocksRange(ctx, i, chooseSegmentEnd(i, blockTo, snaptype2.Enums.Headers, snCfg), tmpDir, snapDir, firstTxNum, chainDB, chainConfig, workers, lvl, logger)
+		lastTxNum, err := dumpBlocksRange(ctx, i, chooseSegmentEnd(i, blockTo, snaptype2.Enums.Headers, snCfg), tmpDir, snapDir, firstTxNum, chainDB, chainConfig, workers, lvl, logger, inProgress)
 		if err != nil {
 			return err
 		}
@@ -588,7 +588,7 @@ func DumpBlocks(ctx context.Context, blockFrom, blockTo uint64, chainConfig *cha
 	return nil
 }
 
-func dumpBlocksRange(ctx context.Context, blockFrom, blockTo uint64, tmpDir, snapDir string, firstTxNum uint64, chainDB kv.RoDB, chainConfig *chain.Config, workers int, lvl log.Lvl, logger log.Logger) (lastTxNum uint64, err error) {
+func dumpBlocksRange(ctx context.Context, blockFrom, blockTo uint64, tmpDir, snapDir string, firstTxNum uint64, chainDB kv.RoDB, chainConfig *chain.Config, workers int, lvl log.Lvl, logger log.Logger, inProgress *snapshotsync.RoSnapshots) (lastTxNum uint64, err error) {
 	logEvery := time.NewTicker(20 * time.Second)
 	defer logEvery.Stop()
 
@@ -599,16 +599,16 @@ func dumpBlocksRange(ctx context.Context, blockFrom, blockTo uint64, tmpDir, sna
 	}
 
 	if _, err = dumpRange(ctx, snaptype2.Headers.FileInfo(snapDir, blockFrom, blockTo),
-		DumpHeaders, nil, chainDB, chainConfig, tmpDir, workers, lvl, logger); err != nil {
+		DumpHeaders, nil, chainDB, chainConfig, tmpDir, workers, lvl, logger, inProgress); err != nil {
 		return 0, err
 	}
 
 	if lastTxNum, err = dumpRange(ctx, snaptype2.Bodies.FileInfo(snapDir, blockFrom, blockTo),
-		DumpBodies, func(context.Context) uint64 { return firstTxNum }, chainDB, chainConfig, tmpDir, workers, lvl, logger); err != nil {
+		DumpBodies, func(context.Context) uint64 { return firstTxNum }, chainDB, chainConfig, tmpDir, workers, lvl, logger, inProgress); err != nil {
 		return lastTxNum, err
 	}
 	if _, err = dumpRange(ctx, snaptype2.Transactions.FileInfo(snapDir, blockFrom, blockTo),
-		DumpTxs, func(context.Context) uint64 { return firstTxNum }, chainDB, chainConfig, tmpDir, workers, lvl, logger); err != nil {
+		DumpTxs, func(context.Context) uint64 { return firstTxNum }, chainDB, chainConfig, tmpDir, workers, lvl, logger, inProgress); err != nil {
 		return lastTxNum, err
 	}
 
@@ -629,7 +629,12 @@ var BlockCompressCfg = seg.Cfg{
 	Workers:              1,
 }
 
-func dumpRange(ctx context.Context, f snaptype.FileInfo, dumper dumpFunc, firstKey firstKeyGetter, chainDB kv.RoDB, chainConfig *chain.Config, tmpDir string, workers int, lvl log.Lvl, logger log.Logger) (uint64, error) {
+func dumpRange(ctx context.Context, f snaptype.FileInfo, dumper dumpFunc, firstKey firstKeyGetter, chainDB kv.RoDB, chainConfig *chain.Config, tmpDir string, workers int, lvl log.Lvl, logger log.Logger, inProgress *snapshotsync.RoSnapshots) (uint64, error) {
+	// Claim this (type, range) so a concurrent OpenFolder doesn't pick up the
+	// .seg before its index is built and race our BuildIndexes below.
+	if inProgress != nil && inProgress.TryAcquireRange(f.Type.Enum(), f.From, f.To) {
+		defer inProgress.ReleaseRange(f.Type.Enum(), f.From, f.To)
+	}
 	var lastKeyValue uint64
 
 	compressCfg := BlockCompressCfg

--- a/db/snapshotsync/freezeblocks/block_snapshots.go
+++ b/db/snapshotsync/freezeblocks/block_snapshots.go
@@ -457,6 +457,10 @@ func (br *BlockRetire) RetireBlocksInBackground(
 			br.logger.Debug("[snapshots] bor data is not ready to be retired", "nextAttemptAt", br.borDataNotReadyBefore)
 			return
 		}
+		if errors.Is(err, snapshotsync.ErrRangeBuildInProgress) {
+			br.logger.Debug("[snapshots] retire blocks: deferred to in-flight build", "err", err)
+			return
+		}
 		if err != nil {
 			br.logger.Error("[snapshots] retire blocks", "err", err)
 			return
@@ -634,7 +638,7 @@ func dumpRange(ctx context.Context, f snaptype.FileInfo, dumper dumpFunc, firstK
 	// .seg before its index is built and race our BuildIndexes below.
 	if inProgress != nil {
 		if !inProgress.TryAcquireRange(f.Type.Enum(), f.From, f.To) {
-			return 0, fmt.Errorf("dump %s: range is already being built", f.Name())
+			return 0, fmt.Errorf("dump %s: %w", f.Name(), snapshotsync.ErrRangeBuildInProgress)
 		}
 		defer inProgress.ReleaseRange(f.Type.Enum(), f.From, f.To)
 	}

--- a/db/snapshotsync/freezeblocks/block_snapshots_test.go
+++ b/db/snapshotsync/freezeblocks/block_snapshots_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/snapshotsync"
 	snaptype2 "github.com/erigontech/erigon/db/snaptype2"
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/chain/networkname"
@@ -49,6 +50,6 @@ func TestDumpRangeErrorsWhenRangeAlreadyClaimed(t *testing.T) {
 	}
 
 	_, err := dumpRange(t.Context(), f, dumper, nil, nil, nil, dir, 1, log.LvlInfo, logger, &snapshots.RoSnapshots)
-	require.Error(t, err)
+	require.ErrorIs(t, err, snapshotsync.ErrRangeBuildInProgress)
 	require.False(t, dumperCalled)
 }

--- a/db/snapshotsync/freezeblocks/block_snapshots_test.go
+++ b/db/snapshotsync/freezeblocks/block_snapshots_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package freezeblocks
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
+	snaptype2 "github.com/erigontech/erigon/db/snaptype2"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/chain/networkname"
+	"github.com/erigontech/erigon/node/ethconfig"
+)
+
+func TestDumpRangeErrorsWhenRangeAlreadyClaimed(t *testing.T) {
+	logger := log.New()
+	dir := t.TempDir()
+	cfg := ethconfig.Defaults.Snapshot
+	cfg.ChainName = networkname.Mainnet
+	snapshots := NewRoSnapshots(cfg, dir, logger)
+	defer snapshots.Close()
+
+	f := snaptype2.Headers.FileInfo(dir, 0, 1000)
+	require.True(t, snapshots.TryAcquireRange(f.Type.Enum(), f.From, f.To))
+
+	dumperCalled := false
+	dumper := func(ctx context.Context, db kv.RoDB, chainConfig *chain.Config, blockFrom, blockTo uint64, firstKey firstKeyGetter, collector func(v []byte) error, workers int, lvl log.Lvl, logger log.Logger) (uint64, error) {
+		dumperCalled = true
+		return 0, errors.New("dumper must not run on a claimed range")
+	}
+
+	_, err := dumpRange(t.Context(), f, dumper, nil, nil, nil, dir, 1, log.LvlInfo, logger, &snapshots.RoSnapshots)
+	require.Error(t, err)
+	require.False(t, dumperCalled)
+}

--- a/db/snapshotsync/freezeblocks/dump_test.go
+++ b/db/snapshotsync/freezeblocks/dump_test.go
@@ -259,7 +259,7 @@ func TestDump(t *testing.T) {
 			snConfig, _ := snapcfg.KnownCfg(networkname.Mainnet)
 			snConfig.ExpectBlocks = math.MaxUint64
 
-			err := freezeblocks.DumpBlocks(m.Ctx, 0, uint64(test.chainSize), m.ChainConfig, tmpDir, snapDir, m.DB, 1, log.LvlInfo, logger, m.BlockReader, snConfig)
+			err := freezeblocks.DumpBlocks(m.Ctx, 0, uint64(test.chainSize), m.ChainConfig, tmpDir, snapDir, m.DB, 1, log.LvlInfo, logger, m.BlockReader, snConfig, nil)
 			require.NoError(err)
 		})
 	}

--- a/db/snapshotsync/merger.go
+++ b/db/snapshotsync/merger.go
@@ -167,6 +167,37 @@ func (m *Merger) Merge(
 		return nil
 	}
 
+	// Claim every (type, range) we're about to produce before writing any file,
+	// so openers skip the not-yet-indexed output and no other builder races us.
+	// A range we can't fully claim is being built elsewhere — skip it this pass.
+	claimed := make([]Range, 0, len(mergeRanges))
+	defer func() {
+		for _, r := range claimed {
+			for _, t := range snapTypes {
+				snapshots.ReleaseRange(t.Enum(), r.From(), r.To())
+			}
+		}
+	}()
+	for _, r := range mergeRanges {
+		ok := true
+		for i, t := range snapTypes {
+			if !snapshots.TryAcquireRange(t.Enum(), r.From(), r.To()) {
+				for _, t2 := range snapTypes[:i] {
+					snapshots.ReleaseRange(t2.Enum(), r.From(), r.To())
+				}
+				ok = false
+				break
+			}
+		}
+		if ok {
+			claimed = append(claimed, r)
+		}
+	}
+	if len(claimed) == 0 {
+		return nil
+	}
+	mergeRanges = claimed
+
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
 

--- a/db/snapshotsync/snapshots.go
+++ b/db/snapshotsync/snapshots.go
@@ -568,6 +568,34 @@ type RoSnapshots struct {
 	ready     ready
 	operators map[snaptype.Enum]*retireOperators
 	alignMin  bool // do we want to align all visible segments to the minimum available
+
+	// (type, from, to) of files a producer is currently building — a merge
+	// output, a dump, or a missed-index rebuild. The data file can be on disk
+	// before its index exists; openers skip these and other builders can't
+	// claim the same file, so nobody creates a duplicate segment or races the
+	// owner's index build.
+	rangesInProgress sync.Map // rangeKey -> struct{}
+}
+
+type rangeKey struct {
+	enum     snaptype.Enum
+	from, to uint64
+}
+
+// TryAcquireRange atomically claims (enum, from, to) for building. Returns false
+// if another builder already holds it, in which case the caller must skip it.
+func (s *RoSnapshots) TryAcquireRange(enum snaptype.Enum, from, to uint64) bool {
+	_, loaded := s.rangesInProgress.LoadOrStore(rangeKey{enum, from, to}, struct{}{})
+	return !loaded
+}
+
+func (s *RoSnapshots) ReleaseRange(enum snaptype.Enum, from, to uint64) {
+	s.rangesInProgress.Delete(rangeKey{enum, from, to})
+}
+
+func (s *RoSnapshots) isInProgress(enum snaptype.Enum, from, to uint64) bool {
+	_, ok := s.rangesInProgress.Load(rangeKey{enum, from, to})
+	return ok
 }
 
 type snapshotVisible struct {
@@ -1095,6 +1123,9 @@ func (s *RoSnapshots) openSegments(fileNames []string, open bool, optimistic boo
 		if !s.HasType(f.Type) {
 			continue
 		}
+		if s.isInProgress(f.Type.Enum(), f.From, f.To) {
+			continue
+		}
 
 		segtype := s.dirty[f.Type.Enum()]
 		if segtype == nil {
@@ -1474,6 +1505,11 @@ func (s *RoSnapshots) buildMissedIndices(logPrefix string, ctx context.Context, 
 				if segment.IsIndexed() {
 					continue
 				}
+				// Skip if a merge/dump/another recovery is already building this
+				// (type, range); otherwise claim it so we don't double-build.
+				if !s.TryAcquireRange(t, segment.From(), segment.To()) {
+					continue
+				}
 				info := segment.FileInfo(dir)
 
 				newIdxBuilt = true
@@ -1483,6 +1519,7 @@ func (s *RoSnapshots) buildMissedIndices(logPrefix string, ctx context.Context, 
 				indexBuilder := s.IndexBuilder(t.Type())
 
 				g.Go(func() error {
+					defer s.ReleaseRange(info.Type.Enum(), info.From, info.To)
 					p := &background.Progress{}
 					ps.Add(p)
 					defer notifySegmentIndexingFinished(info.Name())

--- a/db/snapshotsync/snapshots.go
+++ b/db/snapshotsync/snapshots.go
@@ -582,6 +582,10 @@ type rangeKey struct {
 	from, to uint64
 }
 
+// ErrRangeBuildInProgress means another builder holds the (type, range) claim;
+// the caller should retry later rather than treat it as a failure.
+var ErrRangeBuildInProgress = errors.New("range build is already in progress")
+
 // TryAcquireRange atomically claims (enum, from, to) for building. Returns false
 // if another builder already holds it, in which case the caller must skip it.
 func (s *RoSnapshots) TryAcquireRange(enum snaptype.Enum, from, to uint64) bool {

--- a/db/snapshotsync/snapshots.go
+++ b/db/snapshotsync/snapshots.go
@@ -1507,7 +1507,8 @@ func (s *RoSnapshots) buildMissedIndices(logPrefix string, ctx context.Context, 
 				}
 				// Skip if a merge/dump/another recovery is already building this
 				// (type, range); otherwise claim it so we don't double-build.
-				if !s.TryAcquireRange(t, segment.From(), segment.To()) {
+				from, to := segment.From(), segment.To()
+				if !s.TryAcquireRange(t, from, to) {
 					continue
 				}
 				info := segment.FileInfo(dir)
@@ -1519,7 +1520,7 @@ func (s *RoSnapshots) buildMissedIndices(logPrefix string, ctx context.Context, 
 				indexBuilder := s.IndexBuilder(t.Type())
 
 				g.Go(func() error {
-					defer s.ReleaseRange(info.Type.Enum(), info.From, info.To)
+					defer s.ReleaseRange(t, from, to)
 					p := &background.Progress{}
 					ps.Add(p)
 					defer notifySegmentIndexingFinished(info.Name())

--- a/db/snapshotsync/snapshots_test.go
+++ b/db/snapshotsync/snapshots_test.go
@@ -285,6 +285,45 @@ func TestMergeSnapshots(t *testing.T) {
 	// require.Equal(10, a)
 }
 
+func TestMergeSkipsPreClaimedRange(t *testing.T) {
+	logger := log.New()
+	dir, require := t.TempDir(), require.New(t)
+	for i := uint64(0); i < 4; i++ {
+		for _, snT := range snaptype2.BlockSnapshotTypes {
+			createTestSegmentFile(t, i*10_000, (i+1)*10_000, snT.Enum(), dir, version.V1_0, logger)
+		}
+	}
+	s := NewRoSnapshots(ethconfig.BlocksFreezing{ChainName: networkname.Mainnet}, dir, snaptype2.BlockSnapshotTypes, true, logger)
+	defer s.Close()
+	require.NoError(s.OpenFolder())
+
+	// pre-claim one type of the first range: Merge must skip that whole range,
+	// roll back its own partial claims, and leave the pre-claim intact
+	claimed, free := NewRange(0, 20_000), NewRange(20_000, 40_000)
+	require.True(s.TryAcquireRange(snaptype2.Transactions.Enum(), claimed.From(), claimed.To()))
+
+	merger := NewMerger(dir, 1, log.LvlInfo, nil, chainspec.Mainnet.Config, logger)
+	merger.DisableFsync()
+	require.NoError(merger.Merge(t.Context(), s, snaptype2.BlockSnapshotTypes, []Range{claimed, free}, s.Dir(), false, nil, nil))
+
+	skippedFile := filepath.Join(dir, snaptype.SegmentFileName(snaptype2.Transactions.Versions().Current, claimed.From(), claimed.To(), snaptype2.Transactions.Enum()))
+	exists, err := dir2.FileExist(skippedFile)
+	require.NoError(err)
+	require.False(exists)
+	require.False(s.TryAcquireRange(snaptype2.Transactions.Enum(), claimed.From(), claimed.To()))
+	require.True(s.TryAcquireRange(snaptype2.Headers.Enum(), claimed.From(), claimed.To()))
+	s.ReleaseRange(snaptype2.Headers.Enum(), claimed.From(), claimed.To())
+
+	for _, snT := range snaptype2.BlockSnapshotTypes {
+		mergedFile := filepath.Join(dir, snaptype.SegmentFileName(snT.Versions().Current, free.From(), free.To(), snT.Enum()))
+		exists, err := dir2.FileExist(mergedFile)
+		require.NoError(err)
+		require.True(exists)
+		require.True(s.TryAcquireRange(snT.Enum(), free.From(), free.To()))
+		s.ReleaseRange(snT.Enum(), free.From(), free.To())
+	}
+}
+
 func TestDeleteSnapshots(t *testing.T) {
 	if testing.Short() {
 		t.Skip()


### PR DESCRIPTION
## Problem

- BuildMissedIndices/openfolder/merge -- seem to have a race. e.g for ongoing merge if seg file is created and idx is not. And then we call `BuildMissedIndices`, it'll try to build the idx (even though merge goroutine is already building one).
- https://github.com/erigontech/erigon/pull/21526: allowing merge and RetireBlocks->BuildMissedIndices to run concurrently which exposes this issue. (before this PR, merge was under the semaphore, so collate+merge were okay)
- even without the above PR, BuildMissedIndices is not safe (it can be called when starting erigon) to use concurrently with collate/merge or other BuildMissedIndices
- this PR will make https://github.com/erigontech/erigon/pull/21526 safe to merge

## Fix
A per-`(type, from, to)` in-flight registry on `RoSnapshots`:
- `TryAcquireRange` / `ReleaseRange` — atomic claim (`LoadOrStore`); `false` ⇒ another builder owns it.
- `isInProgress` — read-only check.

Wired in:
- **merge** claims every `(type,range)` it produces before writing; a range it can't fully claim is being built elsewhere → skipped this pass; released after integrate.
- **dump** (`dumpRange`) claims its `(type,range)` across `.seg`+`.idx` build.
- **`BuildMissedIndices`** `TryAcquire`s per segment, skips if held — so it never rebuilds an in-flight file and concurrent recovery calls can't double-build.
- **`openSegments`** skips in-progress ranges (read-only), so it never creates a duplicate `DirtySegment` for a half-built file. Once the owning builder is done processing, it can readd to `dirtyFiles` and do `OpenFolder`, so we don't miss the new file.