### PR TITLE
ci: drop redundant glamsterdam serial exec leg from kurtosis-assertoor

### DIFF
--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -128,11 +128,6 @@ jobs:
             # Unpin to main once CI is upgraded to Kurtosis 1.18.1.
             ethereum_package_branch: "6.1.0"
             test_timeout_minutes: 20
-            exec_mode: serial
-          - suite: glamsterdam
-            package_args: .github/workflows/kurtosis/glamsterdam.io
-            ethereum_package_branch: "6.1.0"
-            test_timeout_minutes: 20
             exec_mode: parallel
           - suite: caplin-minimal
             package_args: .github/workflows/kurtosis/caplin-minimal-assertoor.io


### PR DESCRIPTION
Removes the `glamsterdam` `exec_mode: serial` entry from the `test-kurtosis-assertoor` matrix, leaving glamsterdam parallel-only.

## Why

`glamsterdam.io` passes `--experimental.bal`, and executor selection is `dbg.Exec3Parallel || cfg.experimentalBAL` (`execution/stagedsync/stage_execute.go`). So the BAL flag forces parallel exec regardless of the `ERIGON_EXEC3_PARALLEL=false` that the serial leg sets — the serial entry never actually ran serial, it just duplicated the parallel run (doubling runner-minutes for zero added signal). Serial exec also hard-fails on Amsterdam blocks by design (`execution/stagedsync/exec3_serial.go`).

This matches `test-hive-eest.yml`, whose `glamsterdam-devnet` shard is already parallel-only.

## Validation

- `actionlint` clean on the changed workflow
- YAML re-parses; matrix is now `regular`(×2), `pectra`(×2), `glamsterdam`(parallel), `caplin-minimal`(×2)