### PR TITLE
execution/state: exclude no-op storage writes from the block access list

### DIFF
--- a/execution/engineapi/engine_api_bal_test.go
+++ b/execution/engineapi/engine_api_bal_test.go
@@ -375,8 +375,11 @@ func TestEngineApiBALStorageNoOpWriteOmitted(t *testing.T) {
 		_, err = eat.RpcApiClient.SendTransaction(secondCall)
 		require.NoError(t, err)
 
+		// A node accepts its own BAL, so the block stays VALID even without the
+		// fix (assembler and parallel validator compute the same wrong BAL); the
+		// storage_changes assertion below is what catches the leaked no-op write.
 		payload, err := eat.MockCl.BuildCanonicalBlock(ctx)
-		require.NoError(t, err, "BAL divergence: a repeated same-value SSTORE was recorded as a storage_change")
+		require.NoError(t, err)
 		require.NoError(t, eat.TxnInclusionVerifier.VerifyTxnsInclusion(ctx, payload.ExecutionPayload, firstCall.Hash(), secondCall.Hash()))
 
 		bal := decodeAndValidateBAL(t, payload)

--- a/execution/engineapi/engine_api_bal_test.go
+++ b/execution/engineapi/engine_api_bal_test.go
@@ -310,6 +310,85 @@ func TestEngineApiBALStorageWrites(t *testing.T) {
 	})
 }
 
+// TestEngineApiBALStorageNoOpWriteOmitted exercises the EIP-7928 no-op rule
+// end-to-end through the parallel executor: a write storing the value a slot
+// already holds must not appear in storage_changes. The contract does
+// SSTORE(0,2);SSTORE(0,1) so the final write is recorded even though it equals
+// the slot's prior value — a plain same-value SSTORE would be skipped before
+// reaching the access list. Called twice in one block, the second call is a
+// no-op whose write must be excluded.
+func TestEngineApiBALStorageNoOpWriteOmitted(t *testing.T) {
+	if !dbg.Exec3Parallel {
+		t.Skip("requires parallel exec")
+	}
+	ctx := t.Context()
+	logger := testlog.Logger(t, log.LvlDebug)
+	eat, err := engineapitester.DefaultEngineApiTester(ctx, logger, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := eat.Close()
+		require.NoError(t, err)
+	})
+	eat.Run(t, func(ctx context.Context, t *testing.T, eat engineapitester.EngineApiTester) {
+		signer := types.LatestSignerForChainID(eat.ChainConfig.ChainID)
+		coinbaseAddr := crypto.PubkeyToAddress(eat.CoinbaseKey.PublicKey)
+		gasPrice, err := eat.RpcApiClient.GasPrice()
+		require.NoError(t, err)
+		gasPriceU256, overflow := uint256.FromBig(gasPrice)
+		require.False(t, overflow)
+
+		// init: 600b600c600039600b6000f3   -> return the 11-byte runtime
+		// code: 6002600055 6001600055 00   -> SSTORE(0,2); SSTORE(0,1); STOP
+		initCode := common.FromHex("600b600c600039600b6000f36002600055600160005500")
+
+		signTx := func(nonce uint64, to *common.Address, data []byte, gas uint64) types.Transaction {
+			tx, err := types.SignTx(&types.LegacyTx{
+				CommonTx: types.CommonTx{Nonce: nonce, GasLimit: gas, To: to, Value: uint256.Int{}, Data: data},
+				GasPrice: *gasPriceU256,
+			}, *signer, eat.CoinbaseKey)
+			require.NoError(t, err)
+			return tx
+		}
+
+		// Block 1: deploy the contract.
+		deployNonce, err := eat.RpcApiClient.GetTransactionCount(coinbaseAddr, rpc.PendingBlock)
+		require.NoError(t, err)
+		deployTx := signTx(deployNonce.Uint64(), nil, initCode, 1_000_000)
+		_, err = eat.RpcApiClient.SendTransaction(deployTx)
+		require.NoError(t, err)
+		_, err = eat.MockCl.BuildCanonicalBlock(ctx)
+		require.NoError(t, err)
+
+		contractAddr := types.CreateAddress(coinbaseAddr, deployNonce.Uint64())
+		code, err := eat.RpcApiClient.GetCode(contractAddr, rpc.LatestBlock)
+		require.NoError(t, err)
+		require.NotEmpty(t, code, "contract must be deployed")
+
+		// Block 2: two calls to the contract in the same block. Same sender, so
+		// they execute in nonce order — fully deterministic, no scheduling race.
+		callNonce, err := eat.RpcApiClient.GetTransactionCount(coinbaseAddr, rpc.PendingBlock)
+		require.NoError(t, err)
+		firstCall := signTx(callNonce.Uint64(), &contractAddr, nil, 1_000_000)
+		secondCall := signTx(callNonce.Uint64()+1, &contractAddr, nil, 1_000_000)
+		_, err = eat.RpcApiClient.SendTransaction(firstCall)
+		require.NoError(t, err)
+		_, err = eat.RpcApiClient.SendTransaction(secondCall)
+		require.NoError(t, err)
+
+		payload, err := eat.MockCl.BuildCanonicalBlock(ctx)
+		require.NoError(t, err, "BAL divergence: a repeated same-value SSTORE was recorded as a storage_change")
+		require.NoError(t, eat.TxnInclusionVerifier.VerifyTxnsInclusion(ctx, payload.ExecutionPayload, firstCall.Hash(), secondCall.Hash()))
+
+		bal := decodeAndValidateBAL(t, payload)
+		cc := findAccountChanges(bal, accounts.InternAddress(contractAddr))
+		require.NotNilf(t, cc, "contract must appear in BAL\n%s", bal.DebugString())
+		require.Lenf(t, cc.StorageChanges, 1, "contract writes exactly one slot\n%s", bal.DebugString())
+		require.Lenf(t, cc.StorageChanges[0].Changes, 1,
+			"slot 0 must record only the first call's real change (0->1); the second call leaves the value unchanged, so the no-op write must not appear in storage_changes\n%s",
+			bal.DebugString())
+	})
+}
+
 func TestEngineApiBALMultiTxBlock(t *testing.T) {
 	if !dbg.Exec3Parallel {
 		t.Skip("requires parallel exec")

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -1589,17 +1589,9 @@ func ensureAccountState(accounts map[accounts.Address]*accountState, addr accoun
 func (account *accountState) updateWrite(vw *VersionedWrite, accessIndex uint32) {
 	switch vw.Path {
 	case StoragePath:
-		// Skip intra-tx net-zero storage writes: if this is the first write
-		// to the slot (no prior tx wrote to it) and the written value equals
-		// the original read value, it's a no-op that should remain as a read.
-		if !hasStorageWrite(account.changes, vw.Key) {
-			if val, ok := vw.Val.(uint256.Int); ok {
-				if origVal, wasRead := account.storageReadValues[vw.Key]; wasRead && val.Eq(&origVal) {
-					return
-				}
-			}
+		if val, ok := vw.Val.(uint256.Int); ok {
+			account.addStorageUpdate(vw.Key, accessIndex, val)
 		}
-		addStorageUpdate(account.changes, vw, accessIndex)
 	case BalancePath:
 		val, ok := vw.Val.(uint256.Int)
 		if !ok {
@@ -1714,28 +1706,29 @@ func (account *accountState) updateRead(vr *VersionedRead) {
 	}
 }
 
-func addStorageUpdate(ac *types.AccountChanges, vw *VersionedWrite, txIndex uint32) {
-	// If we already recorded a read for this slot, drop it because a write takes precedence.
-	removeStorageRead(ac, vw.Key)
-
-	if ac.StorageChanges == nil {
-		ac.StorageChanges = []*types.SlotChanges{{
-			Slot:    vw.Key,
-			Changes: []*types.StorageChange{{Index: txIndex, Value: vw.Val.(uint256.Int)}},
-		}}
-		return
-	}
-
+// addStorageUpdate records a value-changing storage write in a single pass over
+// the slot's changes, applying the EIP-7928 no-op filter: a write whose value
+// equals the slot's current value — the most recent earlier write this block,
+// or the pre-block read value for the first write — is not a change and is
+// omitted (the slot stays a read).
+func (account *accountState) addStorageUpdate(slot accounts.StorageKey, accessIndex uint32, val uint256.Int) {
+	ac := account.changes
 	for _, slotChange := range ac.StorageChanges {
-		if slotChange.Slot == vw.Key {
-			slotChange.Changes = append(slotChange.Changes, &types.StorageChange{Index: txIndex, Value: vw.Val.(uint256.Int)})
+		if slotChange.Slot == slot {
+			if n := len(slotChange.Changes); n > 0 && val.Eq(&slotChange.Changes[n-1].Value) {
+				return
+			}
+			slotChange.Changes = append(slotChange.Changes, &types.StorageChange{Index: accessIndex, Value: val})
 			return
 		}
 	}
-
+	if origVal, wasRead := account.storageReadValues[slot]; wasRead && val.Eq(&origVal) {
+		return
+	}
+	removeStorageRead(ac, slot) // a real write supersedes any recorded read
 	ac.StorageChanges = append(ac.StorageChanges, &types.SlotChanges{
-		Slot:    vw.Key,
-		Changes: []*types.StorageChange{{Index: txIndex, Value: vw.Val.(uint256.Int)}},
+		Slot:    slot,
+		Changes: []*types.StorageChange{{Index: accessIndex, Value: val}},
 	})
 }
 

--- a/execution/state/versionedio_test.go
+++ b/execution/state/versionedio_test.go
@@ -431,6 +431,49 @@ func TestVersionedIO_PostWriteBalanceReadDoesNotPoisonInitialBalance(t *testing.
 	require.True(t, found, "burn target address must appear in BAL")
 }
 
+// TestVersionedIO_StorageNoOpWriteAfterChangeOmittedFromBAL verifies the
+// EIP-7928 rule that, for a slot written multiple times in a block, a write
+// storing the value an earlier write already set is a no-op and must be
+// excluded from storage_changes — only value-changing writes are recorded.
+func TestVersionedIO_StorageNoOpWriteAfterChangeOmittedFromBAL(t *testing.T) {
+	t.Parallel()
+
+	addr := accounts.InternAddress(common.HexToAddress("0xc0ffee"))
+	slot := accounts.InternKey(common.HexToHash("0x01"))
+	valA := *uint256.NewInt(0x111)
+	valB := *uint256.NewInt(0x222)
+
+	io := NewVersionedIO(4)
+	write := func(txIndex int, v uint256.Int) {
+		io.RecordWrites(Version{TxIndex: txIndex}, VersionedWrites{
+			&VersionedWrite{Address: addr, Path: StoragePath, Key: slot, Version: Version{TxIndex: txIndex}, Val: v},
+		})
+	}
+	write(0, valA) // slot: 0 -> A  (real change)
+	write(1, valB) // slot: A -> B  (real change)
+	write(2, valB) // slot: B -> B  (no-op)
+	write(3, valB) // slot: B -> B  (no-op)
+
+	bal := io.AsBlockAccessList()
+
+	found := false
+	for _, ac := range bal {
+		if ac.Address != addr {
+			continue
+		}
+		found = true
+		require.Lenf(t, ac.StorageChanges, 1, "one slot expected\n%s", bal.DebugString())
+		changes := ac.StorageChanges[0].Changes
+		require.Lenf(t, changes, 2,
+			"no-op repeated-value writes (idx 3,4) must be excluded from storage_changes\n%s", bal.DebugString())
+		require.Equal(t, uint32(1), changes[0].Index)
+		require.True(t, changes[0].Value.Eq(&valA))
+		require.Equal(t, uint32(2), changes[1].Index)
+		require.True(t, changes[1].Value.Eq(&valB))
+	}
+	require.True(t, found, "contract must appear in BAL")
+}
+
 // fallthroughStateReader returns a fixed account and a fixed storage value, so
 // a test can observe whether a versionedRead fell through to the underlying
 // state (vs. returning a version-map value or aborting).


### PR DESCRIPTION
## Summary

Fixes an EIP-7928 block-access-list (BAL) bug where erigon recorded spurious
`storage_changes` for no-op SSTOREs, producing a BAL hash that diverged from the
block header. The node rejected otherwise-valid blocks with
`block access list mismatch` and forked off the canonical chain (observed on
bal-devnet-7 at block 94626).

## Root cause

`(*VersionedIO).AsBlockAccessList` filtered no-op storage writes only for the
**first** write to a slot; any later write was recorded unconditionally.
EIP-7928 requires comparing **each** write against the slot's value immediately
before its block-access index — a write storing the value the slot already holds
is a no-op and must stay a read, not appear in `storage_changes`.

So when a transaction wrote a slot the value an earlier transaction in the same
block had already set, the parallel executor's BAL gained a spurious
`storage_change`, diverging from the canonical BAL.

## Fix

`addStorageUpdate` now compares every storage write against the slot's most
recent recorded value (falling back to the pre-block read value for the first
write) and skips no-ops, in a single pass.

## Testing

- **Unit** — `TestVersionedIO_StorageNoOpWriteAfterChangeOmittedFromBAL`.
- **Integration (parallel exec)** — `TestEngineApiBALStorageNoOpWriteOmitted`: a
  contract doing `SSTORE(B); SSTORE(A)` called twice in one block (the second
  call a per-tx no-op). Red without the fix, green with it.
- **EEST `blocktests-devnet` shard** (`devnets/bal/7`) — passes 82,941 / 0
  failures under parallel exec.
- **Upstream spec test** — the new test in ethereum/execution-specs#2946
  (`test_bal_intra_tx_round_trip_after_prior_tx_write`), filled against the
  matching devnet spec and run via `evm blocktest`: **passes with the fix, fails
  with `block access list mismatch` without it.**
- **Devnet** — a node previously stuck at block 94626 now validates it and syncs
  to the network head.
