### PR TITLE
[DO-NOT-MERGE] ci: run all hive/hive-eest jobs on GitHub-hosted runners (experiment)

### DIFF
--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -11,8 +11,7 @@ concurrency:
 
 jobs:
   test-hive-eest:
-    runs-on:
-      group: hive
+    runs-on: ubuntu-latest
     name: test-hive-eest (${{ matrix.shard }}, ${{ matrix.exec_mode }})
     strategy:
       # In merge_group: cancel sibling shards on first failure so ci-gate's

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -17,8 +17,7 @@ jobs:
       ${{ !github.event.pull_request.number
       || (!github.event.pull_request.draft
       && !contains(github.event.pull_request.labels.*.name, 'skip-uncaching')) }}
-    runs-on:
-      group: hive
+    runs-on: ubuntu-latest
     strategy:
       # In merge_group: cancel sibling shards on first failure so ci-gate's
       # `needs` reach terminal state quickly and the broken PR can be evicted.


### PR DESCRIPTION
## What

Run **all** `test-hive` and `test-hive-eest` matrix legs on GitHub-hosted `ubuntu-latest` runners instead of the self-hosted `hive` group — a one-line change in each workflow:

```yaml
runs-on: ubuntu-latest
```

## Why

The `hive` group is 16 machines / 16 concurrent slots, but each `CI Gate` merge-queue run dispatches 23 hive-group jobs (12 `hive` + 11 `hive-eest`), so jobs queue heavily waiting for a runner (#21575 — median wait 13m, p95 ~1h44m, worst 4h+). Moving every leg to GitHub's elastic pool removes the hive jobs from the self-hosted pool entirely.

This is an experiment to see whether GitHub-hosted runners can carry the full hive load.

## Scope

- `test-hive`: all 12 legs → `ubuntu-latest`
- `test-hive-eest`: all 11 legs → `ubuntu-latest`
- The self-hosted `hive` group is no longer used by these workflows.

## What to watch

- **Fit:** standard `ubuntu-latest` is ~4 vCPU / 16 GB RAM / 14 GB disk — much smaller than the bare-metal `hive` boxes. The Docker-heavy legs are the risk; the heaviest (`rpc-compat`, `consume-engine` cancun/prague/osaka, `glamsterdam-devnet` pool-size 24) are the most likely to hit disk/RAM/timeout limits. The workflows' cleanup steps already note these jobs previously ran on GitHub-managed runners, so they're expected to fit, possibly slower.
- **Coverage on this PR:** `test-hive` runs on `pull_request`, so its legs are exercised by this PR's CI. `test-hive-eest` only runs on `merge_group` (`if: github.event_name != 'pull_request'`), so its legs are first exercised when this is in the merge queue.
- Standard GitHub-hosted runners are free on this public repo.

Experiment toward #21575.
