### PR TITLE
chore(docs): refresh measured disk sizes — w22 2026 [main]

### DIFF
--- a/docs/site/src/data/disk-sizes.json
+++ b/docs/site/src/data/disk-sizes.json
@@ -1,5 +1,5 @@
 {
-  "ci_last_updated": "2025-09-01",
+  "ci_last_updated": "2026-06-02",
   "networks": {
     "mainnet": {
       "archive": {
@@ -9,16 +9,16 @@
         "source": "manual"
       },
       "full": {
-        "bytes": null,
-        "display": "920 GB",
-        "measured_at": "2025-09-01",
-        "source": "manual"
+        "bytes": 2025696615783,
+        "display": "2.03 TB",
+        "measured_at": "2026-06-02",
+        "source": "ci"
       },
       "minimal": {
-        "bytes": null,
-        "display": "350 GB",
-        "measured_at": "2025-09-01",
-        "source": "manual"
+        "bytes": 414818659805,
+        "display": "414.82 GB",
+        "measured_at": "2026-06-02",
+        "source": "ci"
       }
     },
     "gnosis": {
@@ -29,16 +29,16 @@
         "source": "manual"
       },
       "full": {
-        "bytes": null,
-        "display": "462 GB",
-        "measured_at": "2025-09-01",
-        "source": "manual"
+        "bytes": 657108940182,
+        "display": "657.11 GB",
+        "measured_at": "2026-06-02",
+        "source": "ci"
       },
       "minimal": {
-        "bytes": null,
-        "display": "128 GB",
-        "measured_at": "2025-09-01",
-        "source": "manual"
+        "bytes": 208469972033,
+        "display": "208.47 GB",
+        "measured_at": "2026-06-02",
+        "source": "ci"
       }
     }
   }


### PR DESCRIPTION
## Summary

Forward-port of #21577 (→ `release/3.4`) to `main`.

Weekly disk-size refresh from QA sync run [26744543873](https://github.com/erigontech/erigon/actions/runs/26744543873) (2026-06-01).

All four CI-measured entries were stale manual entries from 2025-09-01 (274 days old). Now sourced from the QA sync CI.

| Chain | Mode | Old | New | Source |
|---|---|---|---|---|
| mainnet | full | 920 GB (manual) | 2.03 TB | CI run 26744543873 |
| mainnet | minimal | 350 GB (manual) | 414.82 GB | CI run 26744543814 |
| gnosis | full | 462 GB (manual) | 657.11 GB | CI run 26744543873 |
| gnosis | minimal | 128 GB (manual) | 208.47 GB | CI run 26744543814 |

Archive values remain unchanged — manual update needed when snapshot machine access is available.