### PR TITLE
claude: stop bare #N point refs and commit/PR attribution

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,5 +20,10 @@
       "Bash(find:*)",
       "Bash(gh pr:*)"
     ]
+  },
+  "includeCoAuthoredBy": false,
+  "attribution": {
+    "commit": "",
+    "pr": ""
   }
 }

--- a/agents.md
+++ b/agents.md
@@ -116,6 +116,8 @@ If a user explicitly directs an agent to add a skip in the current turn (overrid
 
 Commit messages: prefix with package(s) modified, e.g., `eth, rpc: make trace configs optional`
 
+Do not add `Co-Authored-By: Claude` or `🤖 Generated with Claude Code` lines to commits, PRs, or issues — Claude attribution is disabled repo-wide via `.claude/settings.json` (`includeCoAuthoredBy: false`).
+
 Run `make lint` before every push. The linter is non-deterministic — run it repeatedly until clean.
 
 **Important**: Always run `make lint` after making code changes and before committing. Fix any linter errors before proceeding. PRs must pass `make lint` before being opened or updated.
@@ -171,6 +173,10 @@ Function docstrings follow the same rule: a one-line summary, plus param/return 
 ## Pull Requests & Workflows
 
 When manually dispatching a workflow that is not part of the PR's automatic check list, add a comment on the PR explaining which workflow was dispatched, why it was chosen, and include a direct link to the workflow run.
+
+### Referring to numbered points in GitHub text
+
+Never use a bare `#N` to refer to a numbered list item, point, step, or nit in PR descriptions, issue descriptions, or comments — GitHub auto-links `#N` to issue/PR number N (e.g. `#1` links to the unrelated PR #1). Write "point 1", "item 1", or "the first nit" instead, and reserve `#N` for genuine references to that issue or PR.
 
 ### Backport PRs to release branches
 

--- a/agents.md
+++ b/agents.md
@@ -176,7 +176,7 @@ When manually dispatching a workflow that is not part of the PR's automatic chec
 
 ### Referring to numbered points in GitHub text
 
-Never use a bare `#N` to refer to a numbered list item, point, step, or nit in PR descriptions, issue descriptions, or comments — GitHub auto-links `#N` to issue/PR number N (e.g. `#1` links to the unrelated PR #1). Write "point 1", "item 1", or "the first nit" instead, and reserve `#N` for genuine references to that issue or PR.
+To refer to a numbered list item, point, step, or nit in PR descriptions, issue descriptions, or comments, write it in words — "point 1", "item 1", "the first nit". Use `#N` only as a reference to a GitHub issue or PR number; GitHub auto-links it, so a bare `#1` would point at an unrelated PR.
 
 ### Backport PRs to release branches
 


### PR DESCRIPTION
Two tweaks to how Claude Code operates in this repo.

## 1. Bare `#N` references in GitHub text

Claude has used a bare `#`+number to mean "point N" — e.g. writing "`#1`" for "the nit from point 1" — in PR descriptions, issue descriptions, and comments. GitHub auto-links that to the issue/PR with that number, so "`#1`" turns into a link to the repo's first-ever PR. This came up in [PR 21510](https://github.com/erigontech/erigon/pull/21510#issuecomment-4575935637) and has happened on other occasions.

`agents.md` now instructs Claude to write "point 1" / "item 1" / "the first nit" and reserve `#N` for genuine issue/PR references.

## 2. Claude attribution in commits, PRs, and issues

Stop adding `Co-Authored-By: Claude` and `🤖 Generated with Claude Code` lines.

Enforced deterministically in `.claude/settings.json` rather than as a prose instruction, so it does not depend on the model remembering:

- `includeCoAuthoredBy: false` — the one switch the installed Claude Code (v2.1.160) honors across *both* the commit and PR code paths; it returns empty attribution for each.
- `attribution: { commit: "", pr: "" }` — the newer, forward-looking mechanism; empties the footer text.

**Why both:** `attribution` alone is insufficient today — the PR code path does a truthy check on `attribution.pr`, so an empty string is ignored and the "Generated with" footer still leaks into PR bodies. `includeCoAuthoredBy: false` is the reliable global off-switch. `agents.md` documents the rule for human readers too.

---

Docs/config only — no Go changes, so build/lint are unaffected. This PR follows both rules itself: no attribution trailers on the commit, and the `#1` examples above are shown as code so they don't auto-link.
