### PR TITLE
db/snapcfg, cmd/utils, node: add --snap.chaintoml-url override

### DIFF
--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -120,7 +120,8 @@ var (
 var cobraFlagValues struct {
 	webseeds string
 	//preverifiedSource string
-	datadir string
+	datadir      string
+	chainTomlURL string
 }
 
 func init() {
@@ -130,6 +131,7 @@ func init() {
 	withChainFlag(rootCmd)
 
 	rootCmd.Flags().StringVar(&cobraFlagValues.webseeds, utils.WebSeedsFlag.Name, utils.WebSeedsFlag.Value, utils.WebSeedsFlag.Usage)
+	rootCmd.Flags().StringVar(&cobraFlagValues.chainTomlURL, utils.SnapChainTomlURLFlag.Name, utils.SnapChainTomlURLFlag.Value, utils.SnapChainTomlURLFlag.Usage)
 	rootCmd.Flags().StringVar(&natSetting, "nat", utils.NATFlag.Value, utils.NATFlag.Usage)
 	rootCmd.Flags().StringVar(&downloaderApiAddr, "downloader.api.addr", "127.0.0.1:9093", "external downloader api network address, for example: 127.0.0.1:9093 serves remote downloader interface")
 	rootCmd.Flags().StringVar(&downloadRateStr, "torrent.download.rate", utils.TorrentDownloadRateFlag.Value, utils.TorrentDownloadRateFlag.Usage)
@@ -279,7 +281,7 @@ func Downloader(cmd *cobra.Command, logger log.Logger) error {
 		webseedsList = append(webseedsList, known...)
 	}
 	if seedbox {
-		err = downloadercfg.LoadSnapshotsHashes(ctx, dirs, chain)
+		err = downloadercfg.LoadSnapshotsHashes(ctx, dirs, chain, strings.TrimSpace(cobraFlagValues.chainTomlURL))
 		if err != nil {
 			return err
 		}

--- a/cmd/utils/app/reset-datadir.go
+++ b/cmd/utils/app/reset-datadir.go
@@ -90,7 +90,7 @@ func resetCliAction(cliCtx *cli.Context) (err error) {
 	}
 	defer unlock()
 
-	err = snapcfg.LoadPreverified(cliCtx.Context, PreverifiedFlag.Get(cliCtx), &dirs, chainName)
+	err = snapcfg.LoadPreverified(cliCtx.Context, PreverifiedFlag.Get(cliCtx), &dirs, chainName, "")
 	if err != nil {
 		return
 	}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -708,6 +708,10 @@ var (
 		Name:  "snap.p2p-manifest",
 		Usage: "Discover snapshot manifest (chain.toml) from P2P peers via ENR instead of using centralized preverified.toml",
 	}
+	SnapChainTomlURLFlag = cli.StringFlag{
+		Name:  "snap.chaintoml-url",
+		Usage: "Fetch the preverified chain.toml directly from this URL instead of the default R2/GitHub CDN. A local preverified.toml in the datadir still takes precedence; delete it to re-fetch from the URL.",
+	}
 	SnapDownloadToBlockFlag = cli.Uint64Flag{
 		Name:    "snap.download.to.block",
 		Usage:   "Download snapshots up to the given block number (exclusive). Disabled by default. Useful for testing and shadow forks.",
@@ -1941,6 +1945,7 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 	cfg.Snapshot.DisableDownloadE3 = ctx.Bool(SnapSkipStateSnapshotDownloadFlag.Name)
 	cfg.Snapshot.NoDownloader = ctx.Bool(NoDownloaderFlag.Name)
 	cfg.Snapshot.P2PManifest = ctx.Bool(SnapP2PManifestFlag.Name)
+	cfg.Snapshot.ChainTomlURL = strings.TrimSpace(ctx.String(SnapChainTomlURLFlag.Name))
 	cfg.Snapshot.DownloaderAddr = strings.TrimSpace(ctx.String(DownloaderAddrFlag.Name))
 	cfg.Snapshot.ChainName = chain
 	nodeConfig.Http.Snap = cfg.Snapshot

--- a/db/downloader/downloadercfg/downloadercfg.go
+++ b/db/downloader/downloadercfg/downloadercfg.go
@@ -307,7 +307,9 @@ func New(
 
 // LoadSnapshotsHashes checks local preverified.toml. If file exists, used local hashes.
 // If there are no such file, try to fetch hashes from the web and create local file.
-func LoadSnapshotsHashes(ctx context.Context, dirs datadir.Dirs, chainName string) error {
+//
+// forceChainTomlURL is forwarded to snapcfg.LoadRemotePreverified — see its docstring.
+func LoadSnapshotsHashes(ctx context.Context, dirs datadir.Dirs, chainName string, forceChainTomlURL string) error {
 	cfg, known := snapcfg.KnownCfg(chainName)
 	if !known {
 		log.Root().Warn("No snapshot hashes for chain", "chain", chainName)
@@ -328,7 +330,7 @@ func LoadSnapshotsHashes(ctx context.Context, dirs datadir.Dirs, chainName strin
 		snapcfg.SetToml(chainName, haveToml, true)
 	} else {
 		// Fetch the snapshot hashes from the web
-		err := snapcfg.LoadRemotePreverified(ctx, chainName)
+		err := snapcfg.LoadRemotePreverified(ctx, chainName, forceChainTomlURL)
 		if err != nil {
 			log.Root().Crit("Snapshot hashes for supported networks was not loaded. Please check your network connection and/or GitHub status here https://www.githubstatus.com/", "chain", chainName, "err", err)
 			return fmt.Errorf("failed to fetch remote snapshot hashes for chain %s", chainName)

--- a/db/downloader/webseeds/verify.go
+++ b/db/downloader/webseeds/verify.go
@@ -73,7 +73,7 @@ func Verify(
 	for _, chain := range chains {
 		// Shift left?
 		//
-		err = snapcfg.LoadPreverified(ctx, preverifiedFlagValue, &dirs, chain)
+		err = snapcfg.LoadPreverified(ctx, preverifiedFlagValue, &dirs, chain, "")
 		if err != nil {
 			return
 		}

--- a/db/snapcfg/preverified.go
+++ b/db/snapcfg/preverified.go
@@ -12,13 +12,15 @@ import (
 
 // Loads preverified from locations other than just remote. Usually for utility commands that want
 // to test different preverified sources.
-func LoadPreverified(ctx context.Context, flagValue string, dirs *datadir.Dirs, chainName string) (err error) {
+//
+// forceChainTomlURL is forwarded to LoadRemotePreverified — see its docstring.
+func LoadPreverified(ctx context.Context, flagValue string, dirs *datadir.Dirs, chainName string, forceChainTomlURL string) (err error) {
 	switch flagValue {
 	case "local":
 		panicif.Err(os.Setenv(RemotePreverifiedEnvKey, dirs.PreverifiedPath()))
 		fallthrough
 	case "remote":
-		err = LoadRemotePreverified(ctx, chainName)
+		err = LoadRemotePreverified(ctx, chainName, forceChainTomlURL)
 		if err != nil {
 			// TODO: Check if we should continue? What if we ask for a git revision and
 			// can't get it? What about a branch?

--- a/db/snapcfg/util.go
+++ b/db/snapcfg/util.go
@@ -507,18 +507,59 @@ func FetchChainToml(ctx context.Context, source SnapshotSource, branch, chain st
 	return res, nil
 }
 
-// LoadRemotePreverified fetches and loads snapshot hashes for a single chain.
-func LoadRemotePreverified(ctx context.Context, chainName string) error {
-	var hashes []byte
-	if s, ok := os.LookupEnv(RemotePreverifiedEnvKey); ok {
-		log.Info("Loading local preverified override file", "file", s)
+// FetchTomlFromURL fetches a chain.toml file from an arbitrary URL. Plain HTTP
+// GET, no CDN-specific headers. Used by the --snap.chaintoml-url override.
+func FetchTomlFromURL(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch snapshot hashes from overridden URL %q: status code %d %s", url, resp.StatusCode, resp.Status)
+	}
+	res, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if len(res) == 0 {
+		return nil, fmt.Errorf("empty response from overridden URL %s", url)
+	}
+	return res, nil
+}
 
-		b, err := os.ReadFile(s)
+// LoadRemotePreverified fetches and loads snapshot hashes for a single chain.
+//
+// forceChainTomlURL, when non-empty, replaces the default R2/GitHub fetch with
+// a single HTTP GET to that exact URL. There is no fallback — if the URL fetch
+// fails the function returns the error and the registry is not modified. The
+// ERIGON_REMOTE_PREVERIFIED env var (local-file override) still takes
+// precedence over both forceChainTomlURL and the default path.
+func LoadRemotePreverified(ctx context.Context, chainName string, forceChainTomlURL string) error {
+	var hashes []byte
+	switch {
+	case os.Getenv(RemotePreverifiedEnvKey) != "":
+		path := os.Getenv(RemotePreverifiedEnvKey)
+		log.Info("Loading local preverified override file", "file", path)
+
+		b, err := os.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("reading remote preverified override file: %w", err)
 		}
 		hashes = b
-	} else {
+	case forceChainTomlURL != "":
+		log.Info("Loading snapshot hashes from forced URL", "chain", chainName, "url", forceChainTomlURL)
+
+		b, err := FetchTomlFromURL(ctx, forceChainTomlURL)
+		if err != nil {
+			return fmt.Errorf("fetching forced chain.toml URL %q: %w", forceChainTomlURL, err)
+		}
+		hashes = b
+	default:
 		log.Info("Loading remote snapshot hashes", "chain", chainName)
 
 		var err error

--- a/node/cli/default_flags.go
+++ b/node/cli/default_flags.go
@@ -128,6 +128,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.SnapStateStopFlag,
 	&utils.SnapSkipStateSnapshotDownloadFlag,
 	&utils.SnapP2PManifestFlag,
+	&utils.SnapChainTomlURLFlag,
 	&utils.SnapDownloadToBlockFlag,
 	&utils.DbPageSizeFlag,
 	&utils.DbSizeLimitFlag,

--- a/node/components/downloader/provider.go
+++ b/node/components/downloader/provider.go
@@ -85,7 +85,7 @@ func (p *Provider) Initialize(ctx context.Context) error {
 
 	// Load snapshot hashes
 	if p.cfg != nil && p.cfg.ChainName != "" {
-		if err := downloadercfg.LoadSnapshotsHashes(ctx, p.cfg.Dirs, p.cfg.ChainName); err != nil {
+		if err := downloadercfg.LoadSnapshotsHashes(ctx, p.cfg.Dirs, p.cfg.ChainName, p.snapshotCfg.ChainTomlURL); err != nil {
 			return fmt.Errorf("load snapshot hashes: %w", err)
 		}
 	}

--- a/node/ethconfig/config.go
+++ b/node/ethconfig/config.go
@@ -155,6 +155,10 @@ type BlocksFreezing struct {
 	DisableDownloadE3 bool // disable download state snapshots
 	DownloaderAddr    string
 	ChainName         string
+	// ChainTomlURL, when non-empty, overrides the default R2/GitHub fetch of
+	// the preverified chain.toml with a direct HTTP GET to this URL. Local
+	// preverified.toml in the datadir still takes precedence.
+	ChainTomlURL string
 	// ManifestReady is closed when P2P manifest discovery completes.
 	// Set by the backend when P2PManifest is enabled. Nil otherwise.
 	ManifestReady <-chan struct{}


### PR DESCRIPTION
## Why

Lets you point Erigon at a specific (e.g. older) `chain.toml` from the
`erigon-snapshot` GitHub repo straight from the CLI. By default Erigon fetches
the **latest published** manifest, but for testing you sometimes want a
**previous** one — for example, to validate against a specific manifest before
changing the step size.

**Caveat:** this only works as long as the older `.torrent`s still exist and the
underlying data is still available in the torrent network.

## What

Adds a `--snap.chaintoml-url` flag that fetches the preverified snapshot
manifest (`chain.toml`) directly from an arbitrary URL, bypassing the default
R2/GitHub CDN.

## Precedence

From highest to lowest:

1. `ERIGON_REMOTE_PREVERIFIED` env var (local file override)
2. `--snap.chaintoml-url` (the new override — single plain HTTP GET, **no fallback**)
3. Default R2/GitHub CDN fetch

A local `preverified.toml` in the datadir still wins over all of these — delete
it to re-fetch from the URL.

The URL override has no fallback: a failed fetch returns the error and leaves
the registry untouched.

## Changes

- `db/snapcfg/util.go` — new `FetchTomlFromURL` (plain GET, no CDN headers);
  `LoadRemotePreverified` gains a `forceChainTomlURL` param and its env/remote
  branch is rewritten as a 3-way switch.
- `cmd/utils/flags.go`, `node/cli/default_flags.go` — define and register
  `SnapChainTomlURLFlag`.
- `node/ethconfig/config.go` — new `Snapshot.ChainTomlURL` field.
- `cmd/downloader/main.go` — wire the flag into the standalone downloader.
- Param threaded through `LoadSnapshotsHashes`, `LoadPreverified`, and
  `provider.go`; non-using call sites pass `""`.

## Notes

Pure new functionality gated behind an opt-in flag; default behavior is
unchanged when the flag is empty.
