### PR TITLE
[r3.4] docs: refresh hardware-requirements disk sizes (Jun 2026)

### DIFF
--- a/docs/site/src/data/disk-sizes.json
+++ b/docs/site/src/data/disk-sizes.json
@@ -4,40 +4,40 @@
     "mainnet": {
       "archive": {
         "bytes": null,
-        "display": "1.77 TB",
-        "measured_at": "2025-09-01",
+        "display": "2.03 TB",
+        "measured_at": "2026-06-02",
         "source": "manual"
       },
       "full": {
         "bytes": null,
-        "display": "920 GB",
-        "measured_at": "2025-09-01",
+        "display": "1.2 TB",
+        "measured_at": "2026-06-02",
         "source": "manual"
       },
       "minimal": {
         "bytes": null,
-        "display": "350 GB",
-        "measured_at": "2025-09-01",
+        "display": "360 GB",
+        "measured_at": "2026-06-02",
         "source": "manual"
       }
     },
     "gnosis": {
       "archive": {
         "bytes": null,
-        "display": "539 GB",
-        "measured_at": "2025-09-01",
+        "display": "605 GB",
+        "measured_at": "2026-06-02",
         "source": "manual"
       },
       "full": {
         "bytes": null,
-        "display": "462 GB",
-        "measured_at": "2025-09-01",
+        "display": "645 GB",
+        "measured_at": "2026-06-02",
         "source": "manual"
       },
       "minimal": {
         "bytes": null,
-        "display": "128 GB",
-        "measured_at": "2025-09-01",
+        "display": "186 GB",
+        "measured_at": "2026-06-02",
         "source": "manual"
       }
     }


### PR DESCRIPTION
Refreshes the per-prune-mode disk usage figures rendered on the [hardware requirements](https://docs.erigon.tech/get-started/hardware-requirements#disk-size-and-ram-requirements) page. Values live in `docs/site/src/data/disk-sizes.json` and are interpolated into the Ethereum mainnet and Gnosis Chain tables.

| Chain   | Mode    | Old      | New (Jun 2026) |
| ------- | ------- | -------- | -------------: |
| Mainnet | Archive | 1.77 TB  |        2.03 TB |
| Mainnet | Full    | 920 GB   |         1.2 TB |
| Mainnet | Minimal | 350 GB   |         360 GB |
| Gnosis  | Archive | 539 GB   |         605 GB |
| Gnosis  | Full    | 462 GB   |         645 GB |
| Gnosis  | Minimal | 128 GB   |         186 GB |

The previous mainnet **Full** figure (920 GB) was actually an archive-mode datadir size reported under the wrong label. The corrected QA measurement harness (prune-mode-aware, measuring real disk blocks rather than apparent size, and excluding the transient `temp/` scratch dir) yields ~1.2 TB for a real full node.

The latest-release version shown across the docs is unaffected — it is fetched dynamically at build time from GitHub `releases/latest`, which already returns `v3.4.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)