### PR TITLE
execution/state, stagedsync: parallel-exec SD-revival and metamorphic-CREATE2 fixes

### DIFF
--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1691,8 +1691,12 @@ func (result *execResult) calcFees(
 	// that a sender==coinbase tx whose worker wrote a non-empty Nonce isn't
 	// mistakenly treated as empty here when FeeTipped==0.
 	emptyRemoval := chainRules.IsSpuriousDragon
-	coinbaseEmptyPre := coinbaseAcc == nil ||
-		(coinbaseAcc.Balance.IsZero() && coinbaseNonce == 0 && coinbaseEmptyCodeHash && !coinbaseHasCodeHashWrite)
+	// nil pre-state must not short-circuit to empty=true: a worker may
+	// have already bumped Nonce or set CodeHash, and EIP-161 emptiness
+	// must respect those writes — otherwise SelfDestructPath is emitted
+	// and normalizeWriteSet's sdSet filter drops them.
+	coinbaseEmptyPre := (coinbaseAcc == nil || coinbaseAcc.Balance.IsZero()) &&
+		coinbaseNonce == 0 && coinbaseEmptyCodeHash && !coinbaseHasCodeHashWrite
 	emitCoinbase := newCoinbaseBalance != oldCoinbaseBalance ||
 		(emptyRemoval && coinbaseEmptyPre && newCoinbaseBalance.IsZero())
 
@@ -3154,14 +3158,26 @@ func normalizeWriteSet(writes state.VersionedWrites, vm *state.VersionMap, txInd
 					continue
 				}
 			} else if stateReader != nil {
-				// No prior TX wrote this key — compare against pre-block value.
-				preVal, found, err := stateReader.ReadAccountStorage(w.Address, w.Key)
-				if err == nil {
-					if !found && writeVal.IsZero() {
-						continue // both zero — no-op
+				// SD-then-revival: latest SelfDestructPath may be false (a
+				// later TxIdx revived), but the SD's per-slot DELETE cascade
+				// already fixed the baseline at zero for any post-SD write.
+				// History scan catches that; the sdOk latest-value read above
+				// misses it. Narrower than an IncarnationPath probe: pure
+				// CREATE (no prior SD=true) doesn't wipe pre-existing storage,
+				// so its same-value SSTOREs still no-op against pre-block.
+				if vm.AnyDoneBoolWriteEquals(w.Address, state.SelfDestructPath, accounts.NilKey, txIndex-1, true) {
+					if writeVal.IsZero() {
+						continue
 					}
-					if found && writeVal.Eq(&preVal) {
-						continue // same as pre-block — no-op
+				} else {
+					preVal, found, err := stateReader.ReadAccountStorage(w.Address, w.Key)
+					if err == nil {
+						if !found && writeVal.IsZero() {
+							continue
+						}
+						if found && writeVal.Eq(&preVal) {
+							continue
+						}
 					}
 				}
 			}

--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -1053,6 +1053,43 @@ func (sdb *IntraBlockState) getVersionedAccount(addr accounts.Address, readStora
 		if readAccount == nil || err != nil {
 			return nil, StorageRead, UnknownVersion, err
 		}
+
+		// CachedReaderV3 bypasses the versionMap, so a prior in-block SD'd
+		// address still returns its pre-SD record. Without this gate the
+		// stale nonce/codeHash flows through refreshVersionedAccount (which
+		// only overwrites fields a versionMap cell exists for), so Empty()
+		// returns false and the EVM misses CallNewAccountGas.
+		if sdRes := sdb.versionMap.Read(addr, SelfDestructPath, accounts.NilKey, sdb.txIndex); sdRes.Status() == MVReadResultDone {
+			if destructed, ok := sdRes.Value().(bool); ok && destructed {
+				destructTxIndex := sdRes.DepIdx()
+				revivalLimit := sdb.txIndex - 1
+				revived := false
+				// Same-tx re-creation (metamorphic SD+CREATE2): both
+				// SelfDestructPath and AddressPath are written at the SAME
+				// TxIdx, so >= (not strict >) is needed on AddressPath.
+				if hi, ok := sdb.versionMap.LatestTxIndex(addr, AddressPath, accounts.NilKey, revivalLimit); ok && hi >= destructTxIndex {
+					revived = true
+				}
+				if !revived {
+					if hi, ok := sdb.versionMap.LatestTxIndex(addr, BalancePath, accounts.NilKey, revivalLimit); ok && hi > destructTxIndex {
+						revived = true
+					}
+				}
+				if !revived {
+					if hi, ok := sdb.versionMap.LatestTxIndex(addr, NoncePath, accounts.NilKey, revivalLimit); ok && hi > destructTxIndex {
+						revived = true
+					}
+				}
+				if !revived {
+					if hi, ok := sdb.versionMap.LatestTxIndex(addr, CodeHashPath, accounts.NilKey, revivalLimit); ok && hi > destructTxIndex {
+						revived = true
+					}
+				}
+				if !revived {
+					return nil, StorageRead, UnknownVersion, nil
+				}
+			}
+		}
 	}
 
 	return sdb.refreshVersionedAccount(addr, readAccount, source, version)
@@ -1771,16 +1808,13 @@ func (sdb *IntraBlockState) CreateAccount(addr accounts.Address, contractCreatio
 		}()
 	}
 
-	source := StorageRead
-	version := UnknownVersion
-
 	if sdb.versionMap == nil {
 		previous, err = sdb.getStateObject(addr, true)
 		if err != nil {
 			return err
 		}
 	} else {
-		readAccount, accountSource, accountVersion, err := sdb.getVersionedAccount(addr, true)
+		readAccount, _, _, err := sdb.getVersionedAccount(addr, true)
 
 		if err != nil {
 			return err
@@ -1807,8 +1841,6 @@ func (sdb *IntraBlockState) CreateAccount(addr accounts.Address, contractCreatio
 					// so.deleted early exit.  Reuse the cached stateObject to preserve the
 					// correct selfdestructed flag and accumulated incarnation.
 					previous = so
-					source = accountSource
-					version = accountVersion
 				} else if sdb.versionMap != nil {
 					// Fresh-IBS worker path (e.g. InsertChain parallel executor): no stateObjects
 					// cache, but the versionMap may have SelfDestructPath=true from a prior tx.
@@ -1836,8 +1868,6 @@ func (sdb *IntraBlockState) CreateAccount(addr accounts.Address, contractCreatio
 			if previous == nil {
 				previous = newObject(sdb, addr, account, account)
 				previous.selfdestructed = destructed
-				source = accountSource
-				version = accountVersion
 			}
 		} else if so, ok := sdb.stateObjects[addr]; ok && so.deleted {
 			// The account was selfdestructed in an earlier transaction within the
@@ -1878,7 +1908,11 @@ func (sdb *IntraBlockState) CreateAccount(addr accounts.Address, contractCreatio
 	// read's version. IncarnationPath is only ever written by
 	// CreateAccount/Selfdestruct, so a present cell always reflects a real
 	// prior in-block create/destruct that the new incarnation must exceed.
-	incSource, incVersion := source, version
+	// Don't inherit outer (source, version): it may carry
+	// refreshVersionedAccount's BalancePath promotion (MapRead, V_bal),
+	// which stamps IncarnationPath with a cell vm never wrote and trips
+	// the validator's recursive AddressPath check.
+	incSource, incVersion := StorageRead, UnknownVersion
 	if sdb.versionMap != nil {
 		if res := sdb.versionMap.Read(addr, IncarnationPath, accounts.NilKey, sdb.txIndex); res.Status() == MVReadResultDone {
 			incSource = MapRead
@@ -1897,7 +1931,8 @@ func (sdb *IntraBlockState) CreateAccount(addr accounts.Address, contractCreatio
 	// versionMap entry at a different version → ErrDependency panic → the
 	// worker spins in a non-converging dep-abort retry loop ("too many
 	// incarnations"). Mirrors the IncarnationPath treatment above.
-	balSource, balVersion := source, version
+	// Same default as IncarnationPath above.
+	balSource, balVersion := StorageRead, UnknownVersion
 	if sdb.versionMap != nil {
 		if res := sdb.versionMap.Read(addr, BalancePath, accounts.NilKey, sdb.txIndex); res.Status() == MVReadResultDone {
 			balSource = MapRead
@@ -1950,7 +1985,13 @@ func (sdb *IntraBlockState) CreateAccount(addr accounts.Address, contractCreatio
 	versionRead[uint256.Int](sdb, addr, BalancePath, accounts.NilKey, balSource, balVersion, newObj.Balance())
 	versionRead[uint256.Int](sdb, addr, IncarnationPath, accounts.NilKey, incSource, incVersion, prevInc)
 	versionWritten(sdb, addr, BalancePath, accounts.NilKey, newObj.Balance())
-	versionWritten(sdb, addr, IncarnationPath, accounts.NilKey, newObj.data.Incarnation)
+	// Only emit on real contract creation. CreateAccount(false) leaves
+	// newObj.data.Incarnation at 0; emitting it would clobber a prior
+	// tx's SD-side IncarnationPath cell and break a same-block CREATE2's
+	// prevInc lookup.
+	if contractCreation {
+		versionWritten(sdb, addr, IncarnationPath, accounts.NilKey, newObj.data.Incarnation)
+	}
 	if previous == nil || previous.selfdestructed && !newObj.selfdestructed {
 		versionWritten(sdb, addr, SelfDestructPath, accounts.NilKey, false)
 	}
@@ -2494,6 +2535,16 @@ func (sdb *IntraBlockState) AccessedAddresses() AccessSet {
 func (sdb *IntraBlockState) accountRead(addr accounts.Address, account *accounts.Account, source ReadSource, version Version) {
 	if sdb.versionMap != nil {
 		data := *account
+		// A sub-field cell may promote (source, version) to MapRead without
+		// a matching AddressPath cell. Stamping AddressPath with that
+		// promotion makes the validator non-converging when vm.Read returns
+		// None for AddressPath.
+		if source == MapRead {
+			if res := sdb.versionMap.Read(addr, AddressPath, accounts.NilKey, sdb.txIndex); res.Status() != MVReadResultDone {
+				source = StorageRead
+				version = UnknownVersion
+			}
+		}
 		versionRead[*accounts.Account](sdb, addr, AddressPath, accounts.NilKey, source, version, &data)
 	}
 }

--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -1985,13 +1985,7 @@ func (sdb *IntraBlockState) CreateAccount(addr accounts.Address, contractCreatio
 	versionRead[uint256.Int](sdb, addr, BalancePath, accounts.NilKey, balSource, balVersion, newObj.Balance())
 	versionRead[uint256.Int](sdb, addr, IncarnationPath, accounts.NilKey, incSource, incVersion, prevInc)
 	versionWritten(sdb, addr, BalancePath, accounts.NilKey, newObj.Balance())
-	// Only emit on real contract creation. CreateAccount(false) leaves
-	// newObj.data.Incarnation at 0; emitting it would clobber a prior
-	// tx's SD-side IncarnationPath cell and break a same-block CREATE2's
-	// prevInc lookup.
-	if contractCreation {
-		versionWritten(sdb, addr, IncarnationPath, accounts.NilKey, newObj.data.Incarnation)
-	}
+	versionWritten(sdb, addr, IncarnationPath, accounts.NilKey, newObj.data.Incarnation)
 	if previous == nil || previous.selfdestructed && !newObj.selfdestructed {
 		versionWritten(sdb, addr, SelfDestructPath, accounts.NilKey, false)
 	}

--- a/execution/state/rw_v3.go
+++ b/execution/state/rw_v3.go
@@ -743,7 +743,11 @@ func (c *LightCollector) UpdateAccountData(address accounts.Address, original, a
 	if accountCopy.Nonce != original.Nonce {
 		c.writes = append(c.writes, &VersionedWrite{Address: address, Path: NoncePath, Val: accountCopy.Nonce})
 	}
-	if accountCopy.Incarnation != original.Incarnation {
+	// Emit only on up-revs. A value-transfer to a same-block SD'd address
+	// leaves newObj.Incarnation at 0 while original carries the prior
+	// block's value; emitting the down-rev would clobber the SD-side
+	// IncarnationPath cell and break a same-block CREATE2's prevInc.
+	if accountCopy.Incarnation > original.Incarnation {
 		c.writes = append(c.writes, &VersionedWrite{Address: address, Path: IncarnationPath, Val: accountCopy.Incarnation})
 	}
 	if accountCopy.CodeHash != original.CodeHash {

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -283,8 +283,16 @@ func (vr *versionedStateReader) ReadAccountData(address accounts.Address) (*acco
 				// explicitly to keep both consistent.
 				revivalLimit := vr.txIndex - 1
 				revived := false
-				if hi, ok := vr.versionMap.LatestTxIndex(address, BalancePath, accounts.NilKey, revivalLimit); ok && hi > destructTxIndex {
+				// Same-tx re-creation (metamorphic SD+CREATE2): AddressPath
+				// at TxIdx >= destructTxIndex signals re-creation within or
+				// after the destruct.
+				if hi, ok := vr.versionMap.LatestTxIndex(address, AddressPath, accounts.NilKey, revivalLimit); ok && hi >= destructTxIndex {
 					revived = true
+				}
+				if !revived {
+					if hi, ok := vr.versionMap.LatestTxIndex(address, BalancePath, accounts.NilKey, revivalLimit); ok && hi > destructTxIndex {
+						revived = true
+					}
 				}
 				if !revived {
 					if hi, ok := vr.versionMap.LatestTxIndex(address, NoncePath, accounts.NilKey, revivalLimit); ok && hi > destructTxIndex {

--- a/execution/state/versionedio_test.go
+++ b/execution/state/versionedio_test.go
@@ -1274,10 +1274,11 @@ func TestGetVersionedAccount_PriorTxSelfDestruct_ReturnsNil(t *testing.T) {
 	vm.Write(addr, IncarnationPath, accounts.NilKey,
 		Version{TxIndex: 3, Incarnation: 0}, uint64(1), true)
 
-	// Tx 4's worker IBS. The test's stateReader (analogous to
-	// CachedReaderV3) returns the pre-SD account; only getVersionedAccount's
-	// versionMap check should convert that to nil.
-	ibs := New(NewVersionedStateReader(4, nil, vm, reader))
+	// Tx 4's worker IBS. The reader (analogous to CachedReaderV3) returns
+	// the pre-SD account directly — no versionMap-aware wrapper short-circuits
+	// the SD case. Only getVersionedAccount's versionMap check should convert
+	// that to nil.
+	ibs := New(reader)
 	ibs.SetTxContext(0, 4)
 	ibs.SetVersion(0)
 	ibs.SetVersionMap(vm)

--- a/execution/state/versionedio_test.go
+++ b/execution/state/versionedio_test.go
@@ -1156,3 +1156,182 @@ func findRead(reads ReadSet, addr accounts.Address, path AccountPath) *Versioned
 	}
 	return nil
 }
+
+// When a prior tx wrote a sub-field (e.g. BalancePath via AddBalance) without
+// writing AddressPath, refreshVersionedAccount promotes the sub-field version
+// onto accountRead's AddressPath stamp. The validator's vm.Read(AddressPath)
+// must not invalidate that stamp — otherwise OCC re-execution races
+// identically until the retry budget exhausts.
+func TestAccountRead_BalancePathPromotion_DoesNotInvalidate(t *testing.T) {
+	t.Parallel()
+
+	addr := accounts.InternAddress(common.HexToAddress("0xB19A240E"))
+	reader := newAccountStateReader(addr)
+	reader.accounts[addr].Balance = *uint256.NewInt(50_000_000_000_000_000)
+
+	postWithdrawalBalance := *uint256.NewInt(100_000_000_000_000_000)
+	vm := NewVersionMap(nil)
+	vm.Write(addr, BalancePath, accounts.NilKey,
+		Version{TxIndex: 0, Incarnation: 0},
+		postWithdrawalBalance, true)
+
+	ibs := New(NewVersionedStateReader(1, nil, vm, reader))
+	ibs.SetTxContext(0, 1)
+	ibs.SetVersion(0)
+	ibs.SetVersionMap(vm)
+
+	// Simulate refreshVersionedAccount's promoted return value:
+	// BalancePath at (0,0) bumped (source, version) above the
+	// account-record's own.
+	acc := accounts.NewAccount()
+	acc.Balance = postWithdrawalBalance
+	acc.CodeHash = accounts.EmptyCodeHash
+	ibs.accountRead(addr, &acc, MapRead, Version{TxIndex: 0, Incarnation: 0})
+
+	// Same call the parallel-exec scheduler makes between worker
+	// completion and apply.
+	io := NewVersionedIO(1)
+	io.RecordReads(Version{TxIndex: 1, Incarnation: 0}, ibs.VersionedReads())
+
+	checkVersionEqual := func(rv, wv Version) VersionValidity {
+		if rv == wv {
+			return VersionValid
+		}
+		return VersionInvalid
+	}
+	valid := vm.ValidateVersion(1, io, checkVersionEqual, true, "TestAccountRead_BalancePathPromotion")
+
+	require.Equal(t, VersionValid, valid,
+		"tx 1's account read should validate against a versionMap with only "+
+			"a BalancePath write at TxIdx=0 — promoting the sub-field's "+
+			"version onto an AddressPath cell that does not exist is what "+
+			"makes validation fail and produces the cross-chain OCC livelock")
+}
+
+// When CreateAccount runs on an address whose only versionMap entry is a
+// sub-field (e.g. BalancePath from a prior credit), the synthetic
+// IncarnationPath read must default to (StorageRead, UnknownVersion), not
+// the outer (MapRead, V_bal) promotion — same livelock class as the
+// accountRead path.
+func TestCreateAccount_SyntheticIncarnationStamp_DoesNotInvalidate(t *testing.T) {
+	t.Parallel()
+
+	addr := accounts.InternAddress(common.HexToAddress("0xB19A240E"))
+	reader := newAccountStateReader(addr)
+	reader.accounts[addr].Balance = *uint256.NewInt(50_000_000_000_000_000)
+
+	postWithdrawalBalance := *uint256.NewInt(100_000_000_000_000_000)
+	vm := NewVersionMap(nil)
+	vm.Write(addr, BalancePath, accounts.NilKey,
+		Version{TxIndex: 0, Incarnation: 0},
+		postWithdrawalBalance, true)
+
+	ibs := New(NewVersionedStateReader(1, nil, vm, reader))
+	ibs.SetTxContext(0, 1)
+	ibs.SetVersion(0)
+	ibs.SetVersionMap(vm)
+
+	require.NoError(t, ibs.CreateAccount(addr, false))
+
+	io := NewVersionedIO(1)
+	io.RecordReads(Version{TxIndex: 1, Incarnation: 0}, ibs.VersionedReads())
+
+	checkVersionEqual := func(rv, wv Version) VersionValidity {
+		if rv == wv {
+			return VersionValid
+		}
+		return VersionInvalid
+	}
+	valid := vm.ValidateVersion(1, io, checkVersionEqual, true, "TestCreateAccount_SyntheticIncarnationStamp")
+
+	require.Equal(t, VersionValid, valid,
+		"CreateAccount on an address with only a BalancePath cell must not "+
+			"stamp the synthetic IncarnationPath read with the promoted "+
+			"BalancePath version")
+}
+
+// getVersionedAccount must honour a prior tx's SelfDestructPath cell even
+// when stateReader (which doesn't consult the versionMap) returns the pre-SD
+// record. Without this gate Empty() returns false and a CALL-with-value to
+// the SD'd address misses CallNewAccountGas.
+func TestGetVersionedAccount_PriorTxSelfDestruct_ReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	addr := accounts.InternAddress(common.HexToAddress("0xF1F5555B"))
+	reader := newAccountStateReader(addr)
+	// Pre-SD record: a deployed contract with nonce=1 and a real codeHash.
+	reader.accounts[addr].Nonce = 1
+	codeHash := accounts.InternCodeHash(common.HexToHash("0x31537ad3f3619e1f93aac0ddfdb0d8a0013bd170b427d81dd5abbee4f3f5248e"))
+	reader.accounts[addr].CodeHash = codeHash
+
+	vm := NewVersionMap(nil)
+	// Tx 3 self-destructs: SelfDestructPath=true only — SD doesn't write
+	// Nonce/CodeHash into the versionMap.
+	vm.Write(addr, SelfDestructPath, accounts.NilKey,
+		Version{TxIndex: 3, Incarnation: 0}, true, true)
+	vm.Write(addr, BalancePath, accounts.NilKey,
+		Version{TxIndex: 3, Incarnation: 0}, uint256.Int{}, true)
+	vm.Write(addr, IncarnationPath, accounts.NilKey,
+		Version{TxIndex: 3, Incarnation: 0}, uint64(1), true)
+
+	// Tx 4's worker IBS. The test's stateReader (analogous to
+	// CachedReaderV3) returns the pre-SD account; only getVersionedAccount's
+	// versionMap check should convert that to nil.
+	ibs := New(NewVersionedStateReader(4, nil, vm, reader))
+	ibs.SetTxContext(0, 4)
+	ibs.SetVersion(0)
+	ibs.SetVersionMap(vm)
+
+	account, _, _, err := ibs.getVersionedAccount(addr, true)
+	require.NoError(t, err)
+	require.Nil(t, account,
+		"getVersionedAccount must return nil for an address self-destructed "+
+			"by a prior tx with no revival, even when the underlying "+
+			"stateReader still surfaces the pre-SD record")
+}
+
+// Metamorphic SD+CREATE2 in one tx: SelfDestructPath=true and a fresh
+// AddressPath land at the SAME TxIdx. A strict hi > destructTxIndex
+// revival check would miss this; getVersionedAccount must recognise
+// AddressPath at TxIdx >= destructTxIndex as revival.
+func TestGetVersionedAccount_SameTxMetamorphicRecreate_ReturnsAccount(t *testing.T) {
+	t.Parallel()
+
+	addr := accounts.InternAddress(common.HexToAddress("0x140DA4236"))
+	reader := newAccountStateReader(addr)
+	reader.accounts[addr].Nonce = 1
+	reader.accounts[addr].CodeHash = accounts.InternCodeHash(common.HexToHash("0xc8c04ce6368db80967fe4c88faa37d1a3d3becb3b9e442a62a5dc8c1df6e14ee"))
+
+	// Tx 3: SD + CREATE2 re-deploy. All writes land at (TxIdx=3, Inc=0).
+	vm := NewVersionMap(nil)
+	vm.Write(addr, SelfDestructPath, accounts.NilKey,
+		Version{TxIndex: 3, Incarnation: 0}, true, true)
+	vm.Write(addr, BalancePath, accounts.NilKey,
+		Version{TxIndex: 3, Incarnation: 0}, uint256.Int{}, true)
+	vm.Write(addr, IncarnationPath, accounts.NilKey,
+		Version{TxIndex: 3, Incarnation: 0}, uint64(2), true)
+	// Fresh AddressPath at the same TxIdx as the SD.
+	recreatedAcc := &accounts.Account{
+		Nonce:       1,
+		Incarnation: 2,
+		CodeHash:    accounts.InternCodeHash(common.HexToHash("0xdeadbeefcafebabe1111111111111111111111111111111111111111111111ff")),
+	}
+	vm.Write(addr, AddressPath, accounts.NilKey,
+		Version{TxIndex: 3, Incarnation: 0}, recreatedAcc, true)
+
+	// Tx 4 reads addr. Strict-greater on subfields wouldn't see the
+	// same-TxIdx Balance/Nonce/CodeHash; the AddressPath >= destructTxIndex
+	// branch is what surfaces the re-created account.
+	ibs := New(NewVersionedStateReader(4, nil, vm, reader))
+	ibs.SetTxContext(0, 4)
+	ibs.SetVersion(0)
+	ibs.SetVersionMap(vm)
+
+	account, _, _, err := ibs.getVersionedAccount(addr, true)
+	require.NoError(t, err)
+	require.NotNil(t, account,
+		"same-tx SD+CREATE2 (metamorphic) re-creates the contract; "+
+			"getVersionedAccount must surface the re-created account, not nil")
+	require.Equal(t, uint64(2), account.Incarnation,
+		"the re-created account's Incarnation should reflect the CREATE2 (not the pre-SD value)")
+}

--- a/execution/state/versionmap.go
+++ b/execution/state/versionmap.go
@@ -283,6 +283,35 @@ func (vm *VersionMap) LatestTxIndex(addr accounts.Address, path AccountPath, key
 	return highest, true
 }
 
+// AnyDoneBoolWriteEquals reports whether any Done write at TxIdx ≤
+// txIdxLimit has data == target. Detects a prior in-block
+// SelfDestructPath=true write that a later revival flipped back to false
+// — a case Read alone (latest-only) misses.
+func (vm *VersionMap) AnyDoneBoolWriteEquals(addr accounts.Address, path AccountPath, key accounts.StorageKey, txIdxLimit int, target bool) bool {
+	if vm == nil {
+		return false
+	}
+	vm.mu.RLock()
+	defer vm.mu.RUnlock()
+
+	cells := vm.getKeyCells(addr, path, key, nil)
+	if cells == nil {
+		return false
+	}
+	found := false
+	cells.Descend(txIdxLimit, func(_ int, v *WriteCell) bool {
+		if v.flag != FlagDone {
+			return true
+		}
+		if b, ok := v.data.(bool); ok && b == target {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
 // FlushVersionedWrites atomically flushes all writes to the version map
 // under a single lock acquisition. This prevents concurrent readers from
 // observing a partially-flushed state (e.g. seeing an AddressPath write


### PR DESCRIPTION
Closes #20711.

## Summary

Correctness fixes for parallel execution around the SELFDESTRUCT-revival and metamorphic-CREATE2 patterns. Surfaced as a chiado from-0 wrong-trie-root and a sepolia tx-4 missed `CallNewAccountGas` (25,000); both classes resolved by this PR.

Interrelated sub-fixes:

- **`execution/stagedsync/exec3_parallel.go` — `calcFees`**: nil pre-state must not short-circuit EIP-161 emptyPre when the worker has already bumped Nonce or set CodeHash, otherwise the emitted `SelfDestructPath=true` wipes those writes via `normalizeWriteSet`'s sdSet filter.
- **`execution/stagedsync/exec3_parallel.go` — `normalizeWriteSet`**: detect SD-then-revival by scanning the versionMap history for any prior `SelfDestructPath=true` write (new `AnyDoneBoolWriteEquals` helper) rather than relying on the latest-value read, which a revival flips back to false. Narrower than an `IncarnationPath` probe: pure CREATE (no prior SD=true) doesn't wipe pre-existing storage, so its same-value SSTOREs still no-op against pre-block.
- **`execution/state/intra_block_state.go` — `getVersionedAccount`**: honour prior-tx `SelfDestructPath` cell even when `CachedReaderV3` (which bypasses the versionMap) returns the pre-SD record. Includes the same-tx metamorphic SD+CREATE2 revival check (`AddressPath` at TxIdx `>=` destructTxIndex is the signal; strict `>` misses it).
- **`execution/state/intra_block_state.go` — `CreateAccount`**: default the synthetic `IncarnationPath`/`BalancePath` reads to `(StorageRead, UnknownVersion)` rather than inheriting the outer (source, version) which may carry `refreshVersionedAccount`'s `BalancePath` promotion and trip the validator.
- **`execution/state/intra_block_state.go` — `accountRead`**: drop the `(MapRead, V)` promotion when `vm.Read(AddressPath)` returns None, to avoid a non-converging validator livelock.
- **`execution/state/versionedio.go` — `versionedStateReader.ReadAccountData`**: mirror IBS's same-tx metamorphic-recreation check (`AddressPath` at TxIdx `>=` destructTxIndex before falling back to strict `>` subfield checks).
- **`execution/state/versionmap.go`**: new `VersionMap.AnyDoneBoolWriteEquals` helper scans cells for a `Done` write at TxIdx `<=` limit whose data equals target. Used by the narrowed `normalizeWriteSet` filter above.

> Note: an earlier revision of this PR also gated `CreateAccount`'s `IncarnationPath` emit behind `contractCreation=true` and changed `LightCollector.UpdateAccountData` to a strict-greater check. Both were dropped in commit f33af66f57: the first goes red on `TestDeleteRecreateAccount`; the second is currently inert because `CollectorWrites` are captured but never flushed to the versionMap. They aren't part of this PR's final fix surface.

## Test plan

- [x] **Unit tests** — four regression tests in `execution/state/versionedio_test.go`: `TestAccountRead_BalancePathPromotion_DoesNotInvalidate`, `TestCreateAccount_SyntheticIncarnationStamp_DoesNotInvalidate`, `TestGetVersionedAccount_PriorTxSelfDestruct_ReturnsNil` (strengthened to use the raw `accountStateReader` so the IBS gate is actually load-bearing — red on `origin/main`, green here), `TestGetVersionedAccount_SameTxMetamorphicRecreate_ReturnsAccount`. All pass.
- [x] **Chiado from-0 to tip** — 21.44M blocks, `EXEC3_PARALLEL=true`, `--prune.mode=archive`. Passed the original #20711 regression block (7,221,794) cleanly and reached tip.
- [x] **Sepolia from-0 past 4,913,058** — confirmed at 16:08 UTC on 2026-06-02; chain currently past 6M with no failures. (The `0x140da4236…` metamorphic-deploy pattern at 4,913,056-57 was the original sepolia regression motivating this work.)
- [x] **Hoodi from-0 to tip** — clean.
- [x] `make lint` clean.

## Follow-ups

- **`>=` revival check vs `calcFees` coinbase tip-credit**: for a coinbase contract that self-destructs without recreate, `calcFees` emits `AddressPath@N` alongside `SelfDestructPath=true@N`. The `>=` revival check in `getVersionedAccount` could then surface that as a "revived" account in tx N+1, causing tx N+1's `calcFees` to emit `tip_N + tip_{N+1}` carrying pre-SD nonce/codeHash — while serial burns `tip_N` via EIP-7708 case 2. Mainnet block 25,151,825 tx 31 (the MEV pattern cited in the `calcFees` comment) is the target for a re-exec confirmation. To be addressed as a follow-up; the discriminator is likely "AddressPath revival only counts when paired with a CREATE-signal (non-empty CodeHash or bumped Incarnation), not a bare `calcFees` tip-credit emission".
- An unrelated parallel-exec failure class surfaced on gnosis at 14.5M-16.4M and on mainnet at 5.09M/5.22M during the soaks — see [docs/plans/20260602-gnosis-parallel-exec-race-14594499.md](https://github.com/erigontech/erigon/blob/main/docs/plans/20260602-gnosis-parallel-exec-race-14594499.md). Not addressed by this PR.