### PR TITLE
p2p/sentry: don't duplicate SendMessageById across shared-store sentries

### DIFF
--- a/p2p/sentry/sentry_grpc_server.go
+++ b/p2p/sentry/sentry_grpc_server.go
@@ -1568,6 +1568,14 @@ func (ss *GrpcServer) SendMessageById(_ context.Context, inreq *sentryproto.Send
 		return reply, fmt.Errorf("msgcode not found for message Id: %s (peer protocol %d)", inreq.Data.Id, peerInfo.EthProtocol())
 	}
 
+	// With a shared PeerStore every sentry resolves the same PeerInfo, so only
+	// the sentry matching the peer's negotiated eth version may write — same
+	// rule as SendMessageToAll — or the peer receives one copy per sentry.
+	if protocolName, _ := ss.protocolForMessageID(inreq.Data.Id); protocolName == eth.ProtocolName &&
+		!protocolVersions.Contains(peerInfo.EthProtocol()) {
+		return reply, nil
+	}
+
 	ss.writePeer("[sentry] sendMessageById", peerInfo, inreq.Data.Id, msgcode, inreq.Data.Data, 0)
 	reply.Peers = []*typesproto.H512{inreq.PeerId}
 	return reply, nil

--- a/p2p/sentry/sentry_grpc_server_test.go
+++ b/p2p/sentry/sentry_grpc_server_test.go
@@ -1462,3 +1462,80 @@ func TestGrpcServer_PeerEvents_ReplayFiltersByVersion(t *testing.T) {
 	require.Len(t, stream.events, 1, "PeerEvents replay must only emit Connect for the ETH68 peer")
 	require.Equal(t, sentryproto.PeerEvent_Connect, stream.events[0].EventId)
 }
+
+// countingMsgReadWriter counts WriteMsg calls; ReadMsg is never used by the
+// outbound write path under test.
+type countingMsgReadWriter struct {
+	mu     sync.Mutex
+	writes int
+}
+
+func (w *countingMsgReadWriter) ReadMsg() (p2p.Msg, error) {
+	return p2p.Msg{}, io.EOF
+}
+
+func (w *countingMsgReadWriter) WriteMsg(msg p2p.Msg) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.writes++
+	return nil
+}
+
+func (w *countingMsgReadWriter) count() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.writes
+}
+
+// TestGrpcServer_SendMessageById_SharedStore_NoDuplicateWrites: in shared
+// p2p.Server mode there is one GrpcServer per eth version, all backed by one
+// PeerStore, and clients (e.g. the txpool) fan SendMessageById out across
+// every sentry. The message must reach the peer once — via the sentry whose
+// version the peer negotiated — not once per sentry.
+func TestGrpcServer_SendMessageById_SharedStore_NoDuplicateWrites(t *testing.T) {
+	shared := NewPeerStore()
+	versions := []uint{direct.ETH69, direct.ETH70, direct.ETH71}
+	servers := make([]*GrpcServer, 0, len(versions))
+	for _, v := range versions {
+		ss := &GrpcServer{
+			statusReady: make(chan struct{}),
+			ethVersion:  v,
+			logger:      log.New(),
+			Protocols: []p2p.Protocol{{
+				Name:      eth.ProtocolName,
+				Version:   v,
+				FromProto: eth.FromProto[v],
+			}},
+		}
+		ss.peers.Store(NewPeerStore())
+		ss.SetSharedPeerStore(shared)
+		servers = append(servers, ss)
+	}
+
+	pi, peerID := newTestPeerInfoWithEth(t)
+	rw := &countingMsgReadWriter{}
+	pi.SetEthRw(rw)
+	pi.SetEthProtocol(direct.ETH70)
+	store := servers[0].peers.Load()
+	store.mu.Lock()
+	store.peers[peerID] = pi
+	store.mu.Unlock()
+
+	req := &sentryproto.SendMessageByIdRequest{
+		PeerId: gointerfaces.ConvertHashToH512(peerID),
+		Data: &sentryproto.OutboundMessageData{
+			Id:   sentryproto.MessageId_NEW_POOLED_TRANSACTION_HASHES_68,
+			Data: []byte{0xc0},
+		},
+	}
+	for _, ss := range servers {
+		_, err := ss.SendMessageById(context.Background(), req)
+		require.NoError(t, err)
+	}
+
+	// Writes happen on the peer's async worker; wait for the first, then
+	// allow a settle window to catch duplicates from the other sentries.
+	require.Eventually(t, func() bool { return rw.count() >= 1 }, time.Second, 5*time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, 1, rw.count(), "peer negotiated eth/70: only the eth/70 sentry must write")
+}

--- a/p2p/sentry/sentry_grpc_server_test.go
+++ b/p2p/sentry/sentry_grpc_server_test.go
@@ -733,6 +733,8 @@ func newTestPeerInfoWithEth(t *testing.T) (*PeerInfo, [64]byte) {
 	t.Cleanup(rw.Close)
 
 	pi := NewPeerInfo(peer)
+	// Stop the per-peer worker goroutine started by NewPeerInfo.
+	t.Cleanup(pi.Close)
 	pi.SetEthRw(rw)
 	// Mark eth handshake as done so WaitForEth returns immediately.
 	pi.SetEthProtocol(direct.ETH68)


### PR DESCRIPTION
## Summary

Fixes the hive devp2p `BlobViolations` flake (`expected disconnect on blob violation, got msg code: 24`) seen on the CI Gate run for #21524 (parallel leg) and on a runner-experiment branch the day before (serial leg) — and the gossip-duplication regression behind it.

## Root cause

Since #21335 all per-eth-version sentry `GrpcServer`s share one `p2p.Server` and one `PeerStore`. `SendMessageById` resolves the target peer in the shared store, so callers that fan a by-id send out across every sentry client — e.g. the txpool's new-peer pool sync (`PropagatePooledTxnsToPeersList`) — now deliver the same frame once per sentry: three identical `NewPooledTransactionHashes` messages per new peer on the default eth/69+70+71 build. Before #21335 each sentry had its own peer set, so the off-sentry sends were silent no-ops.

`SendMessageToAll` and `SendMessageToRandomPeers` already guard against this with `protocolVersions.Contains(peerInfo.EthProtocol())`; `SendMessageById` was the only outbound path without the negotiated-version check.

The BlobViolations failure sequence, reproduced locally with wire-level logging (hive `--sim devp2p --sim.limit eth` against an instrumented image; failed on the second loop iteration with the exact CI error):

1. The test peers, announces two blob txs (one with a lying size/type), delivers them, and waits for a disconnect.
2. The violating `PooledTransactions` reply sits in the txpool fetcher's 250 ms inbound batch before the announcement check kicks the peer.
3. If the 5 s `syncToNewPeersEvery` tick lands in that window, the all-pool announcement (~70 KB — about 2000 hashes accumulated by earlier suite tests) is written to the test peer three times:

```
08:16:32.606  inbound NPTH68            peer=de6008eb count=2
08:16:32.607  WRITE GET_POOLED_TXS_66   peer=de6008eb
08:16:32.607  sync-to-new-peers         entries=2002            <- 5s tick fires
08:16:32.608  WRITE NPTH68 70084 bytes  peer=de6008eb           <- one write
08:16:32.608  WRITE NPTH68 70084 bytes  peer=de6008eb           <- per
08:16:32.608  WRITE NPTH68 70084 bytes  peer=de6008eb           <- sentry
08:16:32.855  VIOLATION -> PenalizePeer peer=de6008eb           <- next 250ms batch flush
```

4. The devp2p test deliberately tolerates one pre-disconnect hash announcement (go-ethereum commit 88c8459, Sept 2024, "sometimes we'll get a blob transaction hashes announcement before the disconnect"); the duplicated second copy arrives before the kick and fails the test.

In the failed CI run the timing lines up exactly: the txpool started at 06:33:04.64 and the test failed at 06:33:14.644 — the tick+10s sync.

With the duplication fixed, at most one announcement can precede the disconnect in that window, which the test tolerates by design. Beyond the test, every new peer was receiving the full pool sync in triplicate.

## Fix

Apply the same negotiated-eth-version guard in `SendMessageById` that the other outbound paths use. Eth-protocol messages only; wit is unaffected (it is deduplicated to a single `GrpcServer` at shared-server construction). This also restores the routing contract documented at `FetchBlockAccessLists` ("sentryIndex MUST be the sentry where peerID is actually connected"): sends via a non-matching sentry are silent no-ops again, as they were with per-sentry peer sets.

Not present on `release/3.4` (#21335 is main-only), so no backport is needed.

## Testing

- New regression test `TestGrpcServer_SendMessageById_SharedStore_NoDuplicateWrites` (TDD): three `GrpcServer`s (eth/69/70/71) sharing a `PeerStore`, peer negotiated eth/70, by-id fan-out across all three must produce exactly one write. Red before the fix (`expected: 1, actual: 3`), green after.
- `go test ./p2p/sentry/... ./txnprovider/txpool/...` clean.
- Local hive validation in a loop: before the fix `not ok 18 BlobViolations` reproduced on iteration 2; after the fix 12/12 iterations green, with instrumented logs showing exactly one `NEW_POOLED_TRANSACTION_HASHES_68` write per new peer where there were three.
- `make lint` (repeatedly) and `make erigon integration` clean.
