### PR TITLE
ci: sanitize hive workspace-log artifact names

### DIFF
--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -248,12 +248,21 @@ jobs:
           run_suite "${{ matrix.sim }}" "${{ matrix.sim-limit }}" "${{ matrix.max-allowed-failures }}"
         continue-on-error: true
 
+      # matrix.sim and matrix.sim-limit contain characters that are invalid in
+      # artifact names ("/" in ethereum/*, "|" and "*" in sim limits), which made
+      # upload-artifact reject the name and the workspace logs silently vanish.
+      - name: Compute artifact name
+        id: artifact-name
+        env:
+          RAW_NAME: hive-workspace-log-${{ matrix.sim }}-${{ matrix.sim-limit }}-${{ matrix.exec_mode }}
+        run: echo "name=${RAW_NAME//[^A-Za-z0-9._-]/_}" >> "$GITHUB_OUTPUT"
+
       - name: Upload output log
         uses: actions/upload-artifact@v7
         with:
           # exec_mode in the artifact name keeps the two matrix entries from
           # clobbering each other's logs on the same artifact key.
-          name: hive-workspace-log-${{ matrix.sim }}-${{ matrix.sim-limit }}-${{ matrix.exec_mode }}
+          name: ${{ steps.artifact-name.outputs.name }}
           path: hive/workspace/logs
         continue-on-error: true
 


### PR DESCRIPTION
## Summary

Hive workspace logs (simulator output + erigon client logs) are uploaded with the matrix values interpolated into the artifact name:

```
name: hive-workspace-log-${{ matrix.sim }}-${{ matrix.sim-limit }}-${{ matrix.exec_mode }}
```

`actions/upload-artifact` forbids `/`, `|` and `*` in artifact names, so the upload fails for every leg whose name contains them — i.e. all `ethereum/engine`, `ethereum/rpc-compat` (`.*` limit) and `devp2p`-`eth|discv5` legs. The failure is masked by the step's `continue-on-error: true`, so the logs just silently vanish:

```
##[error]The artifact name is not valid: hive-workspace-log-devp2p-eth|discv5-parallel. Contains the following character:  Vertical bar |
```

Only `hive-workspace-log-devp2p-eth-serial` ever uploaded. This bit during the investigation of the `BlobViolations` flake behind #21597: the failing parallel-leg run (https://github.com/erigontech/erigon/actions/runs/26867180780) had no workspace-log artifact, and the root-cause analysis had to be reconstructed from the job stdout.

## Fix

Compute the artifact name in a small step that replaces any character outside `[A-Za-z0-9._-]` with `_`. Resulting names per leg:

| before (invalid ones rejected) | after |
|---|---|
| `hive-workspace-log-ethereum/engine-exchange-capabilities\|auth-serial` | `hive-workspace-log-ethereum_engine-exchange-capabilities_auth-serial` |
| `hive-workspace-log-ethereum/engine-cancun-parallel` | `hive-workspace-log-ethereum_engine-cancun-parallel` |
| `hive-workspace-log-ethereum/rpc-compat-.*-serial` | `hive-workspace-log-ethereum_rpc-compat-._-serial` |
| `hive-workspace-log-devp2p-eth\|discv5-parallel` | `hive-workspace-log-devp2p-eth_discv5-parallel` |
| `hive-workspace-log-devp2p-eth-serial` (worked) | unchanged |

`test-hive-eest.yml` (`matrix.shard` values like `paris+shanghai`; `+` is allowed) and `release.yml` artifact names contain no forbidden characters, so they are left alone.

Validated with `actionlint` and by evaluating the substitution against every matrix combination.
