### PR TITLE
ci: retry SonarCloud scan once on transient failure

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -44,8 +44,24 @@ jobs:
         if: inputs.cache-warming-only
         run: go test -run=^$ -cover ./...
 
+      # The scan reaches external services (scanner-binaries CDN, GPG keyserver,
+      # sonarcloud.io) that intermittently 403 or time out; one spaced retry
+      # rides out short blips instead of failing the gate.
       - name: SonarCloud scan
+        id: scan
         if: '!inputs.cache-warming-only'
+        continue-on-error: true
+        uses: SonarSource/sonarqube-scan-action@v8
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: Wait before SonarCloud scan retry
+        if: "!inputs.cache-warming-only && steps.scan.outcome == 'failure'"
+        run: sleep 90
+
+      - name: SonarCloud scan (retry)
+        if: "!inputs.cache-warming-only && steps.scan.outcome == 'failure'"
         uses: SonarSource/sonarqube-scan-action@v8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

Two merge-queue evictions in the last 3 weeks were caused by the SonarCloud scan failing to download the scanner CLI from `binaries.sonarsource.com` — not by anything in the queued code:

- [Jun 3 run](https://github.com/erigontech/erigon/actions/runs/26882242018): instant `Unexpected HTTP response: 403` (the action does not retry 4xx) — evicted #21597 from the queue with all sibling jobs green or still running
- [Jun 1 run](https://github.com/erigontech/erigon/actions/runs/26751990487): download kept failing through the action's three internal attempts (~40s), then gave up

In the merge queue the sonar job fast-cancels the whole CI Gate run on failure, so a CDN blip cancels ~40 min of green sibling jobs and `github-merge-queue` removes the PR with `failed_checks`. Per CI-GUIDELINES.md, merge-queue checks must have no false positives; CDN weather is one.

## Fix

Give the scan one spaced retry:

- the first attempt runs with `continue-on-error: true`
- if it failed, wait 90s and run the action again
- if the retry also fails, the job fails as before — a persistent outage still blocks correctly

`cache-warming-only` runs are unaffected (scan skipped → outcome is `skipped`, so the retry steps skip too). A `continue-on-error` step reports `conclusion: success` to the jobs API, so ci-gate's root-cause detection won't flag a run recovered by the retry; a double failure is attributed to `SonarCloud scan (retry)`.

## Alternatives considered

- **Pre-seeding the runner tool cache**: impossible — the action's `tc.find()` lookup can never match SonarSource's 4-segment version string (`semver.clean("8.1.0.6389")` is `null`), so the action's internal tool-cache path is dead code on any runner.
- **Mirroring the scanner zip via `scannerBinariesUrl`**: removes the CDN dependency entirely but adds hosting and per-upgrade maintenance, and the GPG keyserver dependency remains. Can revisit if 403s persist despite the retry.

No tests: CI workflow YAML change (TDD not applicable); validated with `actionlint` and `make lint`.
