### PR TITLE
execution/stagedsync: pre-write tx nonces to drop sender-based scheduling in parallel exec

### DIFF
--- a/common/dbg/experiments.go
+++ b/common/dbg/experiments.go
@@ -113,6 +113,7 @@ var (
 	BatchCommitments      = EnvBool("BATCH_COMMITMENTS", true)
 	CaplinEfficientReorg  = EnvBool("CAPLIN_EFFICIENT_REORG", true)
 	UseTxDependencies     = EnvBool("USE_TX_DEPENDENCIES", false)
+	Exec3NoncePreWrites   = EnvBool("EXEC3_NONCE_PREWRITES", true)
 	UseStateCache         = EnvBool("USE_STATE_CACHE", true)
 	AssertStateCache      = EnvBool("ASSERT_STATE_CACHE", false)
 	ReadAhead             = EnvBool("READ_AHEAD", true)

--- a/execution/stagedsync/exec3_nonce_prewrite_test.go
+++ b/execution/stagedsync/exec3_nonce_prewrite_test.go
@@ -1,0 +1,193 @@
+package stagedsync
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/dbg"
+	"github.com/erigontech/erigon/execution/exec"
+	"github.com/erigontech/erigon/execution/state"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+// schedTestTask wraps TxTask so processRequest's state-cache validation
+// (which needs SharedDomains) is skipped; scheduling behaviour is unchanged.
+type schedTestTask struct {
+	*exec.TxTask
+}
+
+func newSchedTask(txIndex int, txs []types.Transaction) *schedTestTask {
+	return &schedTestTask{
+		TxTask: &exec.TxTask{
+			Header:  &types.Header{Number: *uint256.NewInt(1)},
+			TxNum:   uint64(txIndex + 2),
+			TxIndex: txIndex,
+			Txs:     txs,
+		},
+	}
+}
+
+func transferTx(sender accounts.Address, nonce uint64) types.Transaction {
+	to := common.HexToAddress("0x00000000000000000000000000000000000000aa")
+	txn := &types.LegacyTx{
+		CommonTx: types.CommonTx{Nonce: nonce, GasLimit: 21_000, To: &to, Value: *uint256.NewInt(1)},
+		GasPrice: *uint256.NewInt(1),
+	}
+	txn.SetSender(sender)
+	return txn
+}
+
+func withNoncePreWrites(t *testing.T, enabled bool) {
+	t.Helper()
+	prev := dbg.Exec3NoncePreWrites
+	dbg.Exec3NoncePreWrites = enabled
+	t.Cleanup(func() { dbg.Exec3NoncePreWrites = prev })
+}
+
+// processSchedRequest feeds one block of txs (plus the block-end task) through
+// processRequest on a quiescent executor with no workers, so the initial
+// dispatch wave and the version map can be inspected afterwards.
+func processSchedRequest(t *testing.T, txs []types.Transaction) (*parallelExecutor, *blockExecutor) {
+	t.Helper()
+
+	tasks := make([]exec.Task, 0, len(txs)+1)
+	for i := range txs {
+		tasks = append(tasks, newSchedTask(i, txs))
+	}
+	tasks = append(tasks, newSchedTask(len(txs), txs))
+
+	pe := &parallelExecutor{
+		txExecutor: txExecutor{
+			blockExecMetrics: newBlockExecMetrics(),
+		},
+		in: exec.NewQueueWithRetry(len(tasks) + 1),
+	}
+
+	require.NoError(t, pe.processRequest(context.Background(), &execRequest{blockNum: 1, tasks: tasks}))
+
+	be := pe.blockExecutors[1]
+	require.NotNil(t, be)
+	return pe, be
+}
+
+func requireNoncePreWrite(t *testing.T, vm *state.VersionMap, sender accounts.Address, txIndex int, txNonce uint64) {
+	t.Helper()
+	res := vm.Read(sender, state.NoncePath, accounts.NilKey, txIndex+1)
+	require.Equal(t, state.MVReadResultDone, res.Status(), "expected a pre-written nonce at txIndex %d", txIndex)
+	require.Equal(t, txIndex, res.DepIdx())
+	require.Equal(t, 0, res.Incarnation())
+	require.Equal(t, txNonce+1, res.Value())
+}
+
+func TestProcessRequestPreWritesNonces(t *testing.T) {
+	withNoncePreWrites(t, true)
+	senderA := accounts.InternAddress(common.HexToAddress("0x1000000000000000000000000000000000000001"))
+	senderB := accounts.InternAddress(common.HexToAddress("0x1000000000000000000000000000000000000002"))
+
+	txs := []types.Transaction{
+		transferTx(senderA, 5),
+		transferTx(senderA, 6),
+		transferTx(senderA, 7),
+		transferTx(senderB, 0),
+	}
+	pe, be := processSchedRequest(t, txs)
+
+	// No sender-based serialization: every task (incl. block end) is
+	// dispatched in the initial wave.
+	require.Equal(t, len(txs)+1, pe.in.NewTasksLen())
+	for i := range txs {
+		require.False(t, be.execTasks.isBlocked(i), "tx %d should not be blocked", i)
+	}
+
+	requireNoncePreWrite(t, be.versionMap, senderA, 0, 5)
+	requireNoncePreWrite(t, be.versionMap, senderA, 1, 6)
+	requireNoncePreWrite(t, be.versionMap, senderA, 2, 7)
+	requireNoncePreWrite(t, be.versionMap, senderB, 3, 0)
+
+	// A tx reads the floor below its own index: the same-sender successor
+	// sees its predecessor's pre-written output nonce, never its own.
+	res := be.versionMap.Read(senderA, state.NoncePath, accounts.NilKey, 2)
+	require.Equal(t, state.MVReadResultDone, res.Status())
+	require.Equal(t, 1, res.DepIdx())
+	require.Equal(t, uint64(7), res.Value())
+}
+
+func TestProcessRequestPreWritesNoncesSetCodeTx(t *testing.T) {
+	withNoncePreWrites(t, true)
+	sender := accounts.InternAddress(common.HexToAddress("0x1000000000000000000000000000000000000003"))
+	to := common.HexToAddress("0x00000000000000000000000000000000000000bb")
+
+	setCodeTx := &types.SetCodeTransaction{
+		DynamicFeeTransaction: types.DynamicFeeTransaction{
+			CommonTx: types.CommonTx{Nonce: 3, GasLimit: 100_000, To: &to},
+			ChainID:  *uint256.NewInt(1),
+		},
+		Authorizations: []types.Authorization{{Nonce: 4}},
+	}
+	setCodeTx.SetSender(sender)
+
+	_, be := processSchedRequest(t, []types.Transaction{transferTx(sender, 2), setCodeTx})
+
+	// The pre-write is the declared tx nonce + 1 regardless of authorizations;
+	// a valid self-authorization bump diverges from it and is corrected by the
+	// execution write at flush time.
+	requireNoncePreWrite(t, be.versionMap, sender, 0, 2)
+	requireNoncePreWrite(t, be.versionMap, sender, 1, 3)
+}
+
+func TestProcessRequestNoPreWriteForAATxs(t *testing.T) {
+	withNoncePreWrites(t, true)
+	sender := accounts.InternAddress(common.HexToAddress("0x1000000000000000000000000000000000000004"))
+
+	aaTx := func(nonce uint64) types.Transaction {
+		return &types.AccountAbstractionTransaction{
+			Nonce:         nonce,
+			ChainID:       uint256.NewInt(1),
+			Tip:           uint256.NewInt(1),
+			FeeCap:        uint256.NewInt(1),
+			GasLimit:      100_000,
+			SenderAddress: sender,
+		}
+	}
+	txs := []types.Transaction{aaTx(0), aaTx(1)}
+	pe, be := processSchedRequest(t, txs)
+
+	// AA nonce semantics differ (RIP-7560), so AA txs keep the sender-based
+	// dependency: the second tx is held out of the initial wave.
+	require.Equal(t, 2, pe.in.NewTasksLen())
+	require.True(t, be.execTasks.isBlocked(1))
+	res := be.versionMap.Read(sender, state.NoncePath, accounts.NilKey, len(txs))
+	require.Equal(t, state.MVReadResultNone, res.Status())
+}
+
+func TestProcessRequestNoPreWriteForMaxNonce(t *testing.T) {
+	withNoncePreWrites(t, true)
+	sender := accounts.InternAddress(common.HexToAddress("0x1000000000000000000000000000000000000005"))
+
+	txs := []types.Transaction{transferTx(sender, math.MaxUint64)}
+	_, be := processSchedRequest(t, txs)
+
+	// nonce+1 would overflow; such a tx makes the block invalid, so don't
+	// inject a wrapped value into the version map.
+	res := be.versionMap.Read(sender, state.NoncePath, accounts.NilKey, len(txs))
+	require.Equal(t, state.MVReadResultNone, res.Status())
+}
+
+func TestProcessRequestSenderDepsWithPreWritesDisabled(t *testing.T) {
+	withNoncePreWrites(t, false)
+	sender := accounts.InternAddress(common.HexToAddress("0x1000000000000000000000000000000000000006"))
+
+	txs := []types.Transaction{transferTx(sender, 0), transferTx(sender, 1)}
+	pe, be := processSchedRequest(t, txs)
+
+	require.Equal(t, 2, pe.in.NewTasksLen())
+	require.True(t, be.execTasks.isBlocked(1))
+	res := be.versionMap.Read(sender, state.NoncePath, accounts.NilKey, len(txs))
+	require.Equal(t, state.MVReadResultNone, res.Status())
+}

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"math"
 	"os"
 	"runtime"
 	"runtime/pprof"
@@ -1130,11 +1131,23 @@ func (pe *parallelExecutor) processRequest(ctx context.Context, execRequest *exe
 			// concurrency
 			break
 		default:
+			txn := t.Tx()
+			if txn == nil {
+				break
+			}
 			sender, err := t.TxSender()
 			if err != nil {
 				return err
 			}
-			if !sender.IsNil() {
+			if sender.IsNil() {
+				break
+			}
+			if dbg.Exec3NoncePreWrites && txn.Type() != types.AccountAbstractionTxType && txn.GetNonce() < math.MaxUint64 {
+				// The tx declares its own output nonce, so pre-write it and
+				// schedule optimistically: a same-sender successor reads it
+				// instead of waiting on a scheduler dependency.
+				executor.versionMap.Write(sender, state.NoncePath, accounts.NilKey, t.Version(), txn.GetNonce()+1, true)
+			} else {
 				if tx, ok := prevSenderTx[sender]; ok {
 					executor.execTasks.addDependency(tx, i)
 					executor.execTasks.clearPending(i)

--- a/execution/tests/parallel_exec_same_sender_test.go
+++ b/execution/tests/parallel_exec_same_sender_test.go
@@ -1,0 +1,174 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package executiontests
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/execution/execmodule/execmoduletester"
+	"github.com/erigontech/erigon/execution/tests/blockgen"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+// Acceptance test for dependency-free speculative execution (nonce pre-writes
+// instead of sender-based scheduling): a block packed with same-sender txs must
+// produce exactly the serial executor's state — correct final nonces with no
+// double-increment — under both executors. The state root is cross-checked by
+// InsertChain against the serially-generated header.
+func TestSameSenderTxsInOneBlock(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow test")
+	}
+
+	data := getGenesis()
+	senderA, keyA := data.addresses[0], data.keys[0]
+	senderB, keyB := data.addresses[1], data.keys[1]
+	recipients := []common.Address{{0xaa}, {0xab}, {0xac}, {0xad}}
+
+	signer := types.LatestSignerForChainID(nil)
+	signedTransfer := func(t *testing.T, key *ecdsa.PrivateKey, nonce uint64, to common.Address) types.Transaction {
+		t.Helper()
+		txn := &types.LegacyTx{
+			CommonTx: types.CommonTx{Nonce: nonce, GasLimit: 21_000, To: &to, Value: *uint256.NewInt(1_000)},
+			GasPrice: *uint256.NewInt(1),
+		}
+		signed, err := types.SignTx(txn, *signer, key)
+		require.NoError(t, err)
+		return signed
+	}
+
+	m := execmoduletester.New(t,
+		execmoduletester.WithGenesisSpec(data.genesisSpec),
+		execmoduletester.WithKey(keyA),
+		execmoduletester.WithExperimentalBAL())
+
+	contractAddress := types.CreateAddress(senderA, 2)
+	chain, err := blockgen.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 1, func(i int, block *blockgen.BlockGen) {
+		block.AddTx(signedTransfer(t, keyA, block.TxNonce(senderA), recipients[0]))
+		block.AddTx(signedTransfer(t, keyA, block.TxNonce(senderA), recipients[1]))
+		creation := &types.LegacyTx{
+			CommonTx: types.CommonTx{Nonce: block.TxNonce(senderA), GasLimit: 60_000},
+			GasPrice: *uint256.NewInt(1),
+		}
+		signedCreation, err := types.SignTx(creation, *signer, keyA)
+		require.NoError(t, err)
+		block.AddTx(signedCreation)
+		block.AddTx(signedTransfer(t, keyA, block.TxNonce(senderA), recipients[2]))
+		block.AddTx(signedTransfer(t, keyB, block.TxNonce(senderB), recipients[3]))
+		block.AddTx(signedTransfer(t, keyA, block.TxNonce(senderA), recipients[0]))
+	})
+	require.NoError(t, err)
+
+	readAccounts := func(t *testing.T, m *execmoduletester.ExecModuleTester) map[common.Address]accounts.Account {
+		t.Helper()
+		out := map[common.Address]accounts.Account{}
+		addrs := append([]common.Address{senderA, senderB, contractAddress}, recipients...)
+		require.NoError(t, m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
+			reader := m.NewStateReader(tx)
+			for _, addr := range addrs {
+				acc, err := reader.ReadAccountData(accounts.InternAddress(addr))
+				if err != nil {
+					return err
+				}
+				require.NotNil(t, acc, "account %x must exist", addr)
+				out[addr] = *acc
+			}
+			return nil
+		}))
+		return out
+	}
+
+	require.NoError(t, m.InsertChain(chain))
+	parallelState := readAccounts(t, m)
+
+	require.Equal(t, uint64(5), parallelState[senderA].Nonce)
+	require.Equal(t, uint64(1), parallelState[senderB].Nonce)
+	require.Equal(t, uint64(1), parallelState[contractAddress].Nonce)
+	require.Equal(t, *uint256.NewInt(2_000), parallelState[recipients[0]].Balance)
+	require.Equal(t, *uint256.NewInt(1_000), parallelState[recipients[3]].Balance)
+
+	mSerial := execmoduletester.New(t,
+		execmoduletester.WithGenesisSpec(data.genesisSpec),
+		execmoduletester.WithKey(keyA),
+		execmoduletester.WithoutExperimentalBAL())
+	require.NoError(t, mSerial.InsertChain(chain))
+	require.Equal(t, readAccounts(t, mSerial), parallelState)
+}
+
+// A same-sender nonce gap must be rejected by both executors: with optimistic
+// scheduling the gapped tx reads its predecessor's pre-written nonce, fails the
+// nonce check and invalidates the block — same verdict as serial.
+func TestSameSenderNonceGapRejected(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow test")
+	}
+
+	data := getGenesis()
+	from := data.addresses[0]
+	fromKey := data.keys[0]
+	to := common.Address{1}
+
+	_, validChain, err := GenerateBlocks(t, data.genesisSpec, map[int]txn{
+		0: {getBlockTx(from, to, uint256.NewInt(1_000)), fromKey},
+	})
+	require.NoError(t, err)
+	require.Len(t, validChain.Blocks, 1)
+
+	signer := types.LatestSignerForChainID(nil)
+	gapped := &types.LegacyTx{
+		CommonTx: types.CommonTx{Nonce: 2, GasLimit: 21_000, To: &to, Value: *uint256.NewInt(1_000)},
+		GasPrice: *uint256.NewInt(1),
+	}
+	signedGapped, err := types.SignTx(gapped, *signer, fromKey)
+	require.NoError(t, err)
+
+	badHeader := types.CopyHeader(validChain.Headers[0])
+	badBlock := types.NewBlock(badHeader, append(validChain.Blocks[0].Transactions(), signedGapped),
+		validChain.Blocks[0].Uncles(), validChain.Receipts[0], nil)
+	badChain := &blockgen.ChainPack{
+		Blocks:   []*types.Block{badBlock},
+		Headers:  []*types.Header{badBlock.Header()},
+		TopBlock: badBlock,
+	}
+
+	cases := []struct {
+		name string
+		opts []execmoduletester.Option
+	}{
+		{"parallel", []execmoduletester.Option{execmoduletester.WithExperimentalBAL()}},
+		{"serial", []execmoduletester.Option{execmoduletester.WithoutExperimentalBAL()}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := append([]execmoduletester.Option{
+				execmoduletester.WithGenesisSpec(data.genesisSpec),
+				execmoduletester.WithKey(fromKey),
+			}, tc.opts...)
+			m := execmoduletester.New(t, opts...)
+			require.Error(t, m.InsertChain(badChain),
+				"%s exec must reject a same-sender nonce gap", tc.name)
+		})
+	}
+}


### PR DESCRIPTION
Fixes erigontech/metarepo-internal-issues#19.

## What

On the no-BAL parallel-execution path, every tx with a same-sender predecessor used to be `clearPending`'d out of the initial wave (sender-based dependency scheduling). The only state that actually *requires* this serialization is the sender nonce — and the nonce is declared by the tx itself, so it is statically known for any valid block.

`processRequest` now pre-writes each tx's output nonce (`tx.Nonce + 1`, plain `uint64`, matching what `SetNonce`/BAL pre-population store at `NoncePath`) into the block's `VersionMap` at the tx's own index, and schedules everything optimistically — same as the BAL branch. A same-sender successor's `GetNonce` (preCheck) reads its predecessor's pre-written output via the normal MVCC floor read instead of failing with nonce-too-high and waiting on a scheduler dependency.

Type check requested by the issue ("Verify before coding"): the `NoncePath` versioned value is a plain `uint64` everywhere (`versionWritten` from `SetNonce`, BAL `WriteChanges`, `valuesEqual`, `versionedUpdate[uint64]`), so the pre-write carries `uint64(tx.Nonce()+1)` — byte/type-exact.

Kept as-is per the issue:
- the `Dependencies()` branch (Polygon/Bor; `USE_TX_DEPENDENCIES`),
- the BAL branch (`len(accessList) != 0`) — BALs already pre-populate nonces.

Excluded from pre-writes (these keep the legacy sender-dependency path):
- AA txs (RIP-7560 nonce semantics differ — `NonceManager`),
- `tx.Nonce == MaxUint64` (`+1` would wrap; such a tx invalidates the block anyway, so don't inject a wrapped value into the shared map).

Kill switch: `EXEC3_NONCE_PREWRITES` (default `true`); `false` restores sender-based scheduling — handy for devnet A/B comparison (including `IGNORE_BAL=true` runs on BAL devnets, which take exactly this branch).

## Deviation from the issue: step 3 ("validate rather than apply") is not needed

The issue proposed making the nonce increment at `txn_executor.go:535` (and the EIP-7702 authority bump) validate-only in pre-write mode, to guard against a double increment. After tracing the MVCC read/write paths I left the state transition untouched, because the double increment is structurally impossible and skipping the write would actually break things:

- **No self-read:** `VersionMap.Read(addr, path, key, txIdx)` floors at `txIdx-1` — a tx can never observe its *own* pre-written entry. `GetNonce` returns the predecessor's value, so `SetNonce(nonce+1)` writes exactly the pre-written value: the flush is an idempotent same-value overwrite at the same `(TxIndex, Incarnation=0)` in the common case.
- **The three-way assert already exists:** `mapvalue == txvalue` is preCheck's nonce check (`GetNonce` reads the map under versioned execution), and `read == post-predecessor state` is Block-STM read validation. A divergence either rejects the tx (genuinely invalid nonce) or re-executes it via the normal path — exactly the issue's intended semantics.
- **Skipping the write would break read-your-own-writes:** the EIP-7702 self-authorization check reads the authority nonce *after* the tx-level bump (`verifyAuthorities`, step 5); without the local versioned write it would read the stale predecessor value from the map.
- **Skipping the write would break EIP-7928 BAL generation:** `AsBlockAccessList` builds nonce changes from the per-tx write sets (`blockIO` outputs); removing the nonce from `TxOut` would drop nonce changes from generated BALs.
- **Self-correcting divergence:** for a valid self-authorization (authority == sender) the real output nonce is `tx.Nonce + 2`; the execution write overwrites the pre-written `tx.Nonce + 1` at flush time, so successors re-validate against the correct value.
- **The pre-written cell can never be deleted:** every successful incarnation re-emits the sender nonce write (so the re-execution `prevWrites` cleanup never deletes the cell), failed incarnations never record writes, the sender is always dirty in its own tx (so `MakeWriteSet`'s reverted-address `DeleteAll` never fires for it), and block-end finalize uses a separate local version map.

## Expected effect

Same-sender txs now run fully in the initial parallel wave (the IO-warming speculative pass from the issue/profiling discussion). They typically still re-execute once on the genuine sender-*balance* (gas debit) conflict after their predecessor flushes — as the issue states, that is an ordinary per-path version-map conflict, identical to any two txs touching the same account, and the re-run hits warm state.

## Tests (TDD)

Red → green unit tests driving the scheduler change (`execution/stagedsync/exec3_nonce_prewrite_test.go`, run `processRequest` directly and inspect the dispatch wave + version map):
- `TestProcessRequestPreWritesNonces` — same-sender txs all dispatched in the initial wave; `NoncePath` cells at each tx's own index with value `nonce+1`, incarnation 0; floor read returns the predecessor's pre-write (red on main: 3/5 dispatched, no cells).
- `TestProcessRequestPreWritesNoncesSetCodeTx` — type-4 txs pre-write `tx.Nonce+1` regardless of authorizations (red on main).
- `TestProcessRequestNoPreWriteForAATxs`, `TestProcessRequestNoPreWriteForMaxNonce`, `TestProcessRequestSenderDepsWithPreWritesDisabled` — exclusions and kill switch keep legacy behavior.

End-to-end acceptance tests (`execution/tests/parallel_exec_same_sender_test.go`); these are regression guards per the issue's acceptance list — correctness was already preserved by the old serialization, so they pass before and after, but now exercise the optimistic path:
- `TestSameSenderTxsInOneBlock` — one block with 5 same-sender txs (incl. a contract creation, which bumps the nonce inside `evm.Create`) plus another sender; inserted under the parallel executor (`WithExperimentalBAL` forces it) and the serial executor; asserts final nonces (no double increment: sender ends at exactly 5, created contract at 1) and that the two executors produce identical account records; the state root is cross-checked by `InsertChain` against the serially-generated header.
- `TestSameSenderNonceGapRejected` — a hand-built block with a same-sender nonce gap is rejected by both executors (the gapped tx fails preCheck against the predecessor's pre-written nonce).

EIP-7702 authority-nonce edge cases (incl. authority == a later in-block sender) are covered by the eest fixtures that CI runs under the `EXEC3_PARALLEL=true` leg; building a Prague `GenerateChain` harness for an in-repo e2e was out of proportion for this PR.

## Verification

- Instrumented `processRequest` with a temporary probe to confirm the e2e test really engages the parallel executor and the new branch (6 probe hits, one per tx) before removing it.
- `go test ./execution/stagedsync ./execution/state/... ./execution/exec/...` green.
- `go test -race ./execution/stagedsync` green; `EXEC3_PARALLEL=true go test -race ./execution/tests -run 'TestSameSender|TestSelfDestructReceive|TestInsertChain'` green.
- `EXEC3_PARALLEL=true go test ./execution/tests` (full parallel leg) green.
- `EXEC3_NONCE_PREWRITES=false go test ./execution/stagedsync` green (kill-switch leg).
- `make lint` clean; `make erigon integration` build.

## Out of scope (per the issue)

- Removing `USE_TX_DEPENDENCIES` / the Polygon `Dependencies()` path.
- Raising the IO-bound worker pool above `NumCPU` (`EXEC3_WORKERS` companion lever — tracked separately).
- Cross-block state cache for the speculative pass.
