### PR TITLE
cl/beacon: stabilize historical proposer duties

### DIFF
--- a/cl/beacon/handler/duties_proposer.go
+++ b/cl/beacon/handler/duties_proposer.go
@@ -17,20 +17,24 @@
 package handler
 
 import (
-	"crypto/sha256"
-	"encoding/binary"
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
-	"sync"
 
 	"github.com/erigontech/erigon/cl/beacon/beaconhttp"
 	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/cl/persistence/base_encoding"
+	"github.com/erigontech/erigon/cl/persistence/beacon_indicies"
 	state_accessors "github.com/erigontech/erigon/cl/persistence/state"
 	"github.com/erigontech/erigon/cl/phase1/core/state"
 	shuffling2 "github.com/erigontech/erigon/cl/phase1/core/state/shuffling"
 	"github.com/erigontech/erigon/cl/transition"
 	"github.com/erigontech/erigon/common"
 	log "github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/snapshotsync"
 )
 
 type proposerDuties struct {
@@ -50,19 +54,68 @@ func (a *ApiHandler) getDutiesProposer(w http.ResponseWriter, r *http.Request) (
 		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, err)
 	}
 
+	expectedSlot := epoch * a.beaconChainCfg.SlotsPerEpoch
+	isFinalized := expectedSlot <= a.forkchoiceStore.FinalizedSlot()
+
+	if isFinalized {
+		tx, err := a.indiciesDB.BeginRo(r.Context())
+		if err != nil {
+			return nil, err
+		}
+		defer tx.Rollback()
+		var view *snapshotsync.CaplinStateView
+		if a.caplinStateSnapshots != nil {
+			view = a.caplinStateSnapshots.View()
+			defer view.Close()
+		}
+		stateGetter := state_accessors.GetValFnTxAndSnapshot(tx, view)
+
+		dependentRoot, err := a.getHistoricalProposerDependentRoot(tx, stateGetter, epoch)
+		if err != nil {
+			return nil, err
+		}
+		duties, err := a.getHistoricalProposerDuties(r.Context(), tx, stateGetter, epoch, expectedSlot)
+		if err != nil {
+			return nil, err
+		}
+		return newBeaconResponse(duties).WithFinalized(true).WithVersion(a.beaconChainCfg.GetCurrentStateVersion(epoch)).With("dependent_root", dependentRoot), nil
+	}
+
 	dependentRoot, err := a.getDependentRoot(epoch, false)
 	if err != nil {
 		return nil, err
 	}
 
-	marginEpochs := uint64(2 << 13)
-
-	expectedSlot := epoch * a.beaconChainCfg.SlotsPerEpoch
-
 	duties := make([]proposerDuties, a.beaconChainCfg.SlotsPerEpoch)
-	wg := sync.WaitGroup{}
 
 	if err := a.syncedData.ViewHeadState(func(s *state.CachingBeaconState) error {
+		headEpoch := state.Epoch(s)
+		if epoch > headEpoch+maxEpochsLookaheadForDuties {
+			return beaconhttp.NewEndpointError(http.StatusBadRequest, fmt.Errorf("proposer duties: epoch %d is too far in the future", epoch))
+		}
+
+		targetVersion := a.beaconChainCfg.GetCurrentStateVersion(epoch)
+		if targetVersion.After(s.Version()) {
+			advancedState, copyErr := s.Copy()
+			if copyErr != nil {
+				return copyErr
+			}
+			if processErr := transition.DefaultMachine.ProcessSlots(advancedState, expectedSlot); processErr != nil {
+				log.Warn("getDutiesProposer: failed to advance state to target fork",
+					"epoch", epoch, "headEpoch", headEpoch, "err", processErr)
+				return processErr
+			}
+			return fillProposerDutiesFromState(duties, advancedState, epoch, expectedSlot)
+		}
+		if targetVersion.Before(s.Version()) {
+			versionedState, copyErr := s.Copy()
+			if copyErr != nil {
+				return copyErr
+			}
+			versionedState.SetVersion(targetVersion)
+			s = versionedState
+		}
+
 		// if the proposer duties are in the lookahead vector, we can use the lookahead vector to fetch the proposers
 		if a.isProposerDutyInLookaheadVector(s, epoch) {
 			lookaheadVector := s.GetProposerLookahead()
@@ -87,7 +140,6 @@ func (a *ApiHandler) getDutiesProposer(w http.ResponseWriter, r *http.Request) (
 		// When the target epoch is beyond the lookahead range (e.g. head is far
 		// behind), we must advance a copy of the state to the target epoch so
 		// that RANDAO mixes and proposer lookahead are correct.
-		headEpoch := state.Epoch(s)
 		if s.Version() >= clparams.FuluVersion && epoch > headEpoch+a.beaconChainCfg.MinSeedLookahead {
 			advancedState, copyErr := s.Copy()
 			if copyErr != nil {
@@ -98,98 +150,175 @@ func (a *ApiHandler) getDutiesProposer(w http.ResponseWriter, r *http.Request) (
 					"epoch", epoch, "headEpoch", headEpoch, "err", processErr)
 				return processErr
 			}
-			// After ProcessSlots the proposer lookahead covers the current epoch
-			proposerIndices, indErr := advancedState.GetBeaconProposerIndices(epoch)
-			if indErr != nil {
-				return indErr
-			}
-			for i := uint64(0); i < a.beaconChainCfg.SlotsPerEpoch; i++ {
-				proposerIndex := proposerIndices[i]
-				pk, pkErr := advancedState.ValidatorPublicKey(int(proposerIndex))
-				if pkErr != nil {
-					return pkErr
-				}
-				duties[i] = proposerDuties{
-					Pubkey:         pk,
-					ValidatorIndex: proposerIndex,
-					Slot:           (epoch * a.beaconChainCfg.SlotsPerEpoch) + i,
-				}
-			}
-			return nil
+			return fillProposerDutiesFromState(duties, advancedState, epoch, expectedSlot)
 		}
 
 		// Lets do proposer index computation (pre-Fulu or when epoch is within range)
 		mixPosition := (epoch + a.beaconChainCfg.EpochsPerHistoricalVector - a.beaconChainCfg.MinSeedLookahead - 1) %
 			a.beaconChainCfg.EpochsPerHistoricalVector
 
-		var mix common.Hash
-		if epoch+marginEpochs > a.forkchoiceStore.FinalizedCheckpoint().Epoch {
-			// Input for the seed hash.
-			mix = s.GetRandaoMix(int(mixPosition))
-		} else {
-			tx, err := a.indiciesDB.BeginRo(r.Context())
-			if err != nil {
-				return err
-			}
-			defer tx.Rollback()
-			view := a.caplinStateSnapshots.View()
-			defer view.Close()
+		mix := s.GetRandaoMix(int(mixPosition))
 
-			// read the mix from the database
-			mix, err = a.stateReader.ReadRandaoMixBySlotAndIndex(tx, state_accessors.GetValFnTxAndSnapshot(tx, view), expectedSlot, mixPosition)
-			if err != nil {
-				return err
-			}
-			if mix == (common.Hash{}) {
-				return beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("mix not found for slot %d and index %d. maybe block was not backfilled or range was pruned", expectedSlot, mixPosition))
-			}
+		input := shuffling2.GetSeed(a.beaconChainCfg, mix, epoch, a.beaconChainCfg.DomainBeaconProposer)
+		seedArray := [32]byte{}
+		copy(seedArray[:], input[:])
+		indices := s.GetActiveValidatorsIndices(epoch)
+		proposerIndices, err := shuffling2.ComputeProposerIndices(s.BeaconState, epoch, seedArray, indices)
+		if err != nil {
+			return err
 		}
-
-		for slot := expectedSlot; slot < expectedSlot+a.beaconChainCfg.SlotsPerEpoch; slot++ {
-
-			slotByteArray := make([]byte, 8)
-			binary.LittleEndian.PutUint64(slotByteArray, slot)
-
-			input := shuffling2.GetSeed(a.beaconChainCfg, mix, epoch, a.beaconChainCfg.DomainBeaconProposer)
-			// Add slot to the end of the input.
-			inputWithSlot := append(input[:], slotByteArray...)
-			hash := sha256.New()
-
-			// Calculate the hash.
-			hash.Write(inputWithSlot)
-			seed := hash.Sum(nil)
-
-			indices := s.GetActiveValidatorsIndices(epoch)
-
-			// Write the seed to an array.
-			seedArray := [32]byte{}
-			copy(seedArray[:], seed)
-			wg.Add(1)
-
-			// Do it in parallel
-			go func(i, slot uint64, indicies []uint64, seedArray [32]byte) {
-				defer wg.Done()
-				proposerIndex, err := shuffling2.ComputeProposerIndex(s.BeaconState, indices, seedArray)
-				if err != nil {
-					panic(err)
-				}
-				var pk common.Bytes48
-				pk, err = s.ValidatorPublicKey(int(proposerIndex))
-				if err != nil {
-					panic(err)
-				}
-				duties[i] = proposerDuties{
-					Pubkey:         pk,
-					ValidatorIndex: proposerIndex,
-					Slot:           slot,
-				}
-			}(slot-expectedSlot, slot, indices, seedArray)
-		}
-		wg.Wait()
-		return nil
+		return fillProposerDutiesFromIndices(duties, s, proposerIndices, expectedSlot)
 	}); err != nil {
 		return nil, err
 	}
 
-	return newBeaconResponse(duties).WithFinalized(false).WithVersion(a.beaconChainCfg.GetCurrentStateVersion(epoch)).With("dependent_root", dependentRoot), nil
+	return newBeaconResponse(duties).
+		WithFinalized(false).
+		WithOptimistic(a.forkchoiceStore.IsHeadOptimistic()).
+		WithVersion(a.beaconChainCfg.GetCurrentStateVersion(epoch)).
+		With("dependent_root", dependentRoot), nil
+}
+
+func fillProposerDutiesFromState(duties []proposerDuties, s *state.CachingBeaconState, epoch, expectedSlot uint64) error {
+	proposerIndices, err := s.GetBeaconProposerIndices(epoch)
+	if err != nil {
+		return err
+	}
+	return fillProposerDutiesFromIndices(duties, s, proposerIndices, expectedSlot)
+}
+
+func fillProposerDutiesFromIndices(duties []proposerDuties, s *state.CachingBeaconState, proposerIndices []uint64, expectedSlot uint64) error {
+	for i := uint64(0); i < s.BeaconConfig().SlotsPerEpoch; i++ {
+		proposerIndex := proposerIndices[i]
+		pk, err := s.ValidatorPublicKey(int(proposerIndex))
+		if err != nil {
+			return err
+		}
+		duties[i] = proposerDuties{
+			Pubkey:         pk,
+			ValidatorIndex: proposerIndex,
+			Slot:           expectedSlot + i,
+		}
+	}
+	return nil
+}
+
+func (a *ApiHandler) getHistoricalProposerDependentRoot(tx kv.Tx, stateGetter state_accessors.GetValFn, epoch uint64) (common.Hash, error) {
+	if epoch == 0 {
+		rootBytes, err := stateGetter(kv.BlockRoot, base_encoding.Encode64ToBytes4(0))
+		if err != nil {
+			return common.Hash{}, err
+		}
+		if len(rootBytes) == 32 {
+			return common.BytesToHash(rootBytes), nil
+		}
+		root, err := beacon_indicies.ReadCanonicalBlockRoot(tx, 0)
+		if err != nil {
+			return common.Hash{}, err
+		}
+		if root == (common.Hash{}) {
+			return common.Hash{}, beaconhttp.NewEndpointError(http.StatusNotFound, errors.New("genesis block not found"))
+		}
+		return root, nil
+	}
+
+	dependentRootSlot := epoch*a.beaconChainCfg.SlotsPerEpoch - 1
+	dependentRootBytes, err := stateGetter(kv.BlockRoot, base_encoding.Encode64ToBytes4(dependentRootSlot))
+	if err != nil {
+		return common.Hash{}, err
+	}
+	if len(dependentRootBytes) == 32 {
+		return common.BytesToHash(dependentRootBytes), nil
+	}
+
+	maxIterations := int(maxEpochsLookaheadForDuties * 2 * a.beaconChainCfg.SlotsPerEpoch)
+	for i := 0; i < maxIterations; i++ {
+		dependentRoot, err := beacon_indicies.ReadCanonicalBlockRoot(tx, dependentRootSlot)
+		if err != nil {
+			return common.Hash{}, err
+		}
+		if dependentRoot != (common.Hash{}) {
+			return dependentRoot, nil
+		}
+		if dependentRootSlot == 0 {
+			break
+		}
+		dependentRootSlot--
+	}
+	return common.Hash{}, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("dependent root not found for epoch %d", epoch))
+}
+
+func (a *ApiHandler) getHistoricalProposerDuties(ctx context.Context, tx kv.Tx, stateGetter state_accessors.GetValFn, epoch, expectedSlot uint64) ([]proposerDuties, error) {
+	stageStateProgress, err := state_accessors.GetStateProcessingProgress(tx)
+	if err != nil {
+		return nil, err
+	}
+	if a.caplinStateSnapshots != nil {
+		stageStateProgress = max(stageStateProgress, a.caplinStateSnapshots.BlocksAvailable())
+	}
+	if expectedSlot > stageStateProgress {
+		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, fmt.Errorf("proposer duties: epoch %d is not yet reconstructed", epoch))
+	}
+
+	if expectedSlot == a.beaconChainCfg.GenesisSlot {
+		genesisState, err := a.stateReader.ReadHistoricalState(ctx, tx, expectedSlot)
+		if err != nil {
+			return nil, err
+		}
+		if genesisState == nil {
+			return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("state not found for slot %d", expectedSlot))
+		}
+		duties := make([]proposerDuties, a.beaconChainCfg.SlotsPerEpoch)
+		if err := fillProposerDutiesFromState(duties, genesisState, epoch, expectedSlot); err != nil {
+			return nil, err
+		}
+		return duties, nil
+	}
+
+	validatorSet, err := a.stateReader.ReadValidatorsForHistoricalState(tx, stateGetter, expectedSlot)
+	if err != nil {
+		return nil, err
+	}
+	if validatorSet == nil {
+		return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("validators not found for slot %d", expectedSlot))
+	}
+	activeIndices := make([]uint64, 0, validatorSet.Length())
+	validatorSet.Range(func(validatorIndex int, validator solid.Validator, _ int) bool {
+		if validator.Active(epoch) {
+			activeIndices = append(activeIndices, uint64(validatorIndex))
+		}
+		return true
+	})
+	if len(activeIndices) == 0 {
+		return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("active validators not found for slot %d", expectedSlot))
+	}
+
+	mixPosition := (epoch + a.beaconChainCfg.EpochsPerHistoricalVector - a.beaconChainCfg.MinSeedLookahead - 1) %
+		a.beaconChainCfg.EpochsPerHistoricalVector
+	mix, err := a.stateReader.ReadRandaoMixBySlotAndIndex(tx, stateGetter, expectedSlot, mixPosition)
+	if err != nil {
+		return nil, err
+	}
+	if mix == (common.Hash{}) {
+		return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("mix not found for slot %d and index %d. maybe block was not backfilled or range was pruned", expectedSlot, mixPosition))
+	}
+
+	historicalState := state.New(a.beaconChainCfg)
+	historicalState.SetVersion(a.beaconChainCfg.GetCurrentStateVersion(epoch))
+	historicalState.SetSlot(expectedSlot)
+	historicalState.SetValidators(validatorSet)
+
+	epochSeed := shuffling2.GetSeed(a.beaconChainCfg, mix, epoch, a.beaconChainCfg.DomainBeaconProposer)
+	seedArray := [32]byte{}
+	copy(seedArray[:], epochSeed[:])
+	proposerIndices, err := shuffling2.ComputeProposerIndices(historicalState.BeaconState, epoch, seedArray, activeIndices)
+	if err != nil {
+		return nil, err
+	}
+
+	duties := make([]proposerDuties, a.beaconChainCfg.SlotsPerEpoch)
+	if err := fillProposerDutiesFromIndices(duties, historicalState, proposerIndices, expectedSlot); err != nil {
+		return nil, err
+	}
+	return duties, nil
 }

--- a/cl/beacon/handler/duties_proposer_test.go
+++ b/cl/beacon/handler/duties_proposer_test.go
@@ -1,0 +1,275 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/beacon/synced_data"
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/clparams/initial_state"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/cl/persistence/beacon_indicies"
+	state_accessors "github.com/erigontech/erigon/cl/persistence/state"
+	"github.com/erigontech/erigon/cl/persistence/state/historical_states_reader"
+	"github.com/erigontech/erigon/cl/phase1/core/state"
+	"github.com/erigontech/erigon/cl/transition"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/log/v3"
+	chainspec "github.com/erigontech/erigon/execution/chain/spec"
+)
+
+func TestGetDutiesProposerHistoricalEpochIgnoresHeadEffectiveBalance(t *testing.T) {
+	_, blocks, _, _, postState, handler, _, syncedData, fcu, _ := setupTestingHandler(t, clparams.BellatrixVersion, log.Root(), true)
+
+	headRoot, err := blocks[len(blocks)-1].Block.HashSSZ()
+	require.NoError(t, err)
+	fcu.HeadVal = headRoot
+	fcu.HeadSlotVal = postState.Slot()
+
+	epoch := uint64(3)
+	fcu.FinalizedCheckpointVal = solid.Checkpoint{Epoch: epoch, Root: headRoot}
+	fcu.FinalizedSlotVal = (epoch+1)*handler.beaconChainCfg.SlotsPerEpoch - 1
+
+	before := getProposerDutiesForEpoch(t, handler, epoch)
+	require.True(t, before.Finalized)
+	require.NotEmpty(t, before.DependentRoot)
+
+	headWithChangedBalances, err := postState.Copy()
+	require.NoError(t, err)
+	activeIndices := headWithChangedBalances.GetActiveValidatorsIndices(epoch)
+	require.NotEmpty(t, activeIndices)
+	chosenIndex := activeIndices[0]
+	for _, validatorIndex := range activeIndices {
+		headWithChangedBalances.SetEffectiveBalanceForValidatorAtIndex(int(validatorIndex), 0)
+	}
+	headWithChangedBalances.SetEffectiveBalanceForValidatorAtIndex(int(chosenIndex), handler.beaconChainCfg.MaxEffectiveBalanceForVersion(headWithChangedBalances.Version()))
+
+	manager, ok := syncedData.(*synced_data.SyncedDataManager)
+	require.True(t, ok)
+	require.NoError(t, manager.OnHeadStateWithBlockRoot(headWithChangedBalances, headRoot))
+
+	after := getProposerDutiesForEpoch(t, handler, epoch)
+	require.Equal(t, before, after)
+}
+
+func TestGetHistoricalProposerDependentRootEpochZeroReturnsGenesisRoot(t *testing.T) {
+	db, _, _, preState, _, handler, _, _, _, _ := setupTestingHandler(t, clparams.BellatrixVersion, log.Root(), true)
+
+	genesisRoot, err := preState.GetBlockRootAtSlot(0)
+	require.NoError(t, err)
+	tx, err := db.BeginRw(context.Background())
+	require.NoError(t, err)
+	defer tx.Rollback()
+	require.NoError(t, beacon_indicies.MarkRootCanonical(context.Background(), tx, 0, genesisRoot))
+	require.NoError(t, tx.Commit())
+
+	roTx, err := db.BeginRo(context.Background())
+	require.NoError(t, err)
+	defer roTx.Rollback()
+	dependentRoot, err := handler.getHistoricalProposerDependentRoot(roTx, state_accessors.GetValFnTxAndSnapshot(roTx, nil), 0)
+	require.NoError(t, err)
+	require.Equal(t, genesisRoot, dependentRoot)
+}
+
+func TestGetDutiesProposerEpochZeroReturnsGenesisRootAndDuties(t *testing.T) {
+	db, _, _, _, _, handler, _, _, fcu, _ := setupTestingHandler(t, clparams.Phase0Version, log.Root(), true)
+
+	genesisState, err := initial_state.GetGenesisState(chainspec.MainnetChainID)
+	require.NoError(t, err)
+	handler.stateReader = historical_states_reader.NewHistoricalStatesReader(handler.beaconChainCfg, nil, state_accessors.NewStaticValidatorTable(), genesisState, nil, handler.syncedData)
+
+	genesisRoot := common.Hash{1, 2, 3}
+	tx, err := db.BeginRw(context.Background())
+	require.NoError(t, err)
+	defer tx.Rollback()
+	require.NoError(t, beacon_indicies.MarkRootCanonical(context.Background(), tx, 0, genesisRoot))
+	require.NoError(t, tx.Commit())
+
+	fcu.FinalizedCheckpointVal = solid.Checkpoint{Epoch: 0, Root: genesisRoot}
+	fcu.FinalizedSlotVal = handler.beaconChainCfg.SlotsPerEpoch - 1
+
+	expectedProposers, err := genesisState.GetBeaconProposerIndices(0)
+	require.NoError(t, err)
+
+	response := getProposerDutiesForEpoch(t, handler, 0)
+	require.True(t, response.Finalized)
+	require.Equal(t, genesisRoot.String(), response.DependentRoot)
+	require.Len(t, response.Data, int(handler.beaconChainCfg.SlotsPerEpoch))
+	for i, duty := range response.Data {
+		require.Equal(t, uint64(i), duty.Slot)
+		require.Equal(t, expectedProposers[i], duty.ValidatorIndex)
+	}
+}
+
+func TestGetDutiesProposerAdvancesHeadCopyAcrossTargetFork(t *testing.T) {
+	_, blocks, _, _, postState, handler, _, syncedData, fcu, _ := setupTestingHandler(t, clparams.ElectraVersion, log.Root(), true)
+
+	headRoot, err := blocks[len(blocks)-1].Block.HashSSZ()
+	require.NoError(t, err)
+
+	headEpoch := postState.Slot() / handler.beaconChainCfg.SlotsPerEpoch
+	targetEpoch := headEpoch + 1
+	handler.beaconChainCfg.FuluForkEpoch = headEpoch
+	handler.beaconChainCfg.GloasForkEpoch = targetEpoch
+	handler.beaconChainCfg.InitializeForkSchedule()
+
+	stateCfg := *postState.BeaconConfig()
+	stateCfg.FuluForkEpoch = headEpoch
+	stateCfg.GloasForkEpoch = targetEpoch
+	stateCfg.InitializeForkSchedule()
+	encodedPostState, err := postState.EncodeSSZ(nil)
+	require.NoError(t, err)
+	isolatedPostState := state.New(&stateCfg)
+	require.NoError(t, isolatedPostState.DecodeSSZ(encodedPostState, int(clparams.ElectraVersion)))
+
+	fuluHead, err := isolatedPostState.Copy()
+	require.NoError(t, err)
+	require.NoError(t, fuluHead.UpgradeToFulu())
+	require.Equal(t, clparams.FuluVersion, fuluHead.Version())
+
+	fcu.HeadVal = headRoot
+	fcu.HeadSlotVal = fuluHead.Slot()
+
+	manager, ok := syncedData.(*synced_data.SyncedDataManager)
+	require.True(t, ok)
+	require.NoError(t, manager.OnHeadStateWithBlockRoot(fuluHead, headRoot))
+
+	expectedState, err := fuluHead.Copy()
+	require.NoError(t, err)
+	expectedSlot := targetEpoch * handler.beaconChainCfg.SlotsPerEpoch
+	require.NoError(t, transition.DefaultMachine.ProcessSlots(expectedState, expectedSlot))
+	require.Equal(t, clparams.GloasVersion, expectedState.Version())
+	expectedProposers, err := expectedState.GetBeaconProposerIndices(targetEpoch)
+	require.NoError(t, err)
+
+	response := getProposerDutiesForEpoch(t, handler, targetEpoch)
+	require.False(t, response.Finalized)
+	require.Equal(t, clparams.GloasVersion.String(), response.Version)
+	require.NoError(t, handler.syncedData.ViewHeadState(func(headState *state.CachingBeaconState) error {
+		require.Equal(t, clparams.FuluVersion, headState.Version())
+		return nil
+	}))
+	for i, duty := range response.Data {
+		require.Equal(t, expectedSlot+uint64(i), duty.Slot)
+		require.Equal(t, expectedProposers[i], duty.ValidatorIndex)
+	}
+}
+
+func TestGetDutiesProposerUsesTargetForkBeforeHeadFork(t *testing.T) {
+	_, blocks, _, _, postState, handler, _, syncedData, fcu, _ := setupTestingHandler(t, clparams.ElectraVersion, log.Root(), true)
+
+	headRoot, err := blocks[len(blocks)-1].Block.HashSSZ()
+	require.NoError(t, err)
+
+	headEpoch := postState.Slot() / handler.beaconChainCfg.SlotsPerEpoch
+	targetEpoch := headEpoch - 1
+	handler.beaconChainCfg.ElectraForkEpoch = headEpoch
+	handler.beaconChainCfg.FuluForkEpoch = headEpoch
+	handler.beaconChainCfg.GloasForkEpoch = headEpoch
+	handler.beaconChainCfg.InitializeForkSchedule()
+
+	stateCfg := *postState.BeaconConfig()
+	stateCfg.ElectraForkEpoch = headEpoch
+	stateCfg.FuluForkEpoch = headEpoch
+	stateCfg.GloasForkEpoch = headEpoch
+	stateCfg.InitializeForkSchedule()
+	encodedPostState, err := postState.EncodeSSZ(nil)
+	require.NoError(t, err)
+	isolatedPostState := state.New(&stateCfg)
+	require.NoError(t, isolatedPostState.DecodeSSZ(encodedPostState, int(clparams.ElectraVersion)))
+
+	gloasHead, err := isolatedPostState.Copy()
+	require.NoError(t, err)
+	require.NoError(t, gloasHead.UpgradeToFulu())
+	require.NoError(t, gloasHead.UpgradeToGloas())
+	require.Equal(t, clparams.GloasVersion, gloasHead.Version())
+
+	fcu.HeadVal = headRoot
+	fcu.HeadSlotVal = gloasHead.Slot()
+	fcu.FinalizedSlotVal = targetEpoch*handler.beaconChainCfg.SlotsPerEpoch - 1
+
+	manager, ok := syncedData.(*synced_data.SyncedDataManager)
+	require.True(t, ok)
+	require.NoError(t, manager.OnHeadStateWithBlockRoot(gloasHead, headRoot))
+
+	expectedState, err := gloasHead.Copy()
+	require.NoError(t, err)
+	expectedState.SetVersion(clparams.DenebVersion)
+	expectedProposers, err := expectedState.GetBeaconProposerIndices(targetEpoch)
+	require.NoError(t, err)
+	gloasProposers, err := gloasHead.GetBeaconProposerIndices(targetEpoch)
+	require.NoError(t, err)
+	require.NotEqual(t, gloasProposers, expectedProposers)
+
+	response := getProposerDutiesForEpoch(t, handler, targetEpoch)
+	require.False(t, response.Finalized)
+	require.Equal(t, clparams.DenebVersion.String(), response.Version)
+	require.NoError(t, handler.syncedData.ViewHeadState(func(headState *state.CachingBeaconState) error {
+		require.Equal(t, clparams.GloasVersion, headState.Version())
+		return nil
+	}))
+	expectedSlot := targetEpoch * handler.beaconChainCfg.SlotsPerEpoch
+	for i, duty := range response.Data {
+		require.Equal(t, expectedSlot+uint64(i), duty.Slot)
+		require.Equal(t, expectedProposers[i], duty.ValidatorIndex)
+	}
+}
+
+func TestGetDutiesProposerFutureEpochTooFarReturnsBadRequest(t *testing.T) {
+	_, blocks, _, _, postState, handler, _, _, fcu, _ := setupTestingHandler(t, clparams.BellatrixVersion, log.Root(), true)
+
+	headRoot, err := blocks[len(blocks)-1].Block.HashSSZ()
+	require.NoError(t, err)
+	fcu.HeadVal = headRoot
+	fcu.HeadSlotVal = postState.Slot()
+
+	headEpoch := postState.Slot() / handler.beaconChainCfg.SlotsPerEpoch
+	epoch := headEpoch + maxEpochsLookaheadForDuties + 1
+	request := httptest.NewRequest(http.MethodGet, "/eth/v1/validator/duties/proposer/"+strconv.FormatUint(epoch, 10), nil)
+	recorder := httptest.NewRecorder()
+	handler.mux.ServeHTTP(recorder, request)
+	require.Equal(t, http.StatusBadRequest, recorder.Code, recorder.Body.String())
+}
+
+type proposerDutiesResponse struct {
+	Data          []proposerDuties `json:"data"`
+	Finalized     bool             `json:"finalized"`
+	DependentRoot string           `json:"dependent_root"`
+	Version       string           `json:"version"`
+}
+
+func getProposerDutiesForEpoch(t *testing.T, handler *ApiHandler, epoch uint64) proposerDutiesResponse {
+	t.Helper()
+
+	request := httptest.NewRequest(http.MethodGet, "/eth/v1/validator/duties/proposer/"+strconv.FormatUint(epoch, 10), nil)
+	recorder := httptest.NewRecorder()
+	handler.mux.ServeHTTP(recorder, request)
+	require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+
+	var body proposerDutiesResponse
+	require.NoError(t, json.NewDecoder(recorder.Body).Decode(&body))
+	require.NotEmpty(t, body.Data)
+	return body
+}


### PR DESCRIPTION
## Summary
- compute finalized/historical proposer duties from historical state instead of head state
- return historical proposer dependent roots, including epoch 0 genesis-root handling
- preserve current/lookahead fast paths and normalize non-finalized fork-boundary proposer computation to the requested epoch version
- bound future non-finalized lookahead advancement

## Tests
- go test ./cl/beacon/handler -run 'Test(GetHistoricalProposerDependentRootEpochZeroReturnsGenesisRoot|GetDutiesProposer(EpochZeroReturnsGenesisRootAndDuties|AdvancesHeadCopyAcrossTargetFork|UsesTargetForkBeforeHeadFork|HistoricalEpochIgnoresHeadEffectiveBalance|FutureEpochTooFarReturnsBadRequest))' -count=1
- go test ./cl/beacon/handler -count=1
- make lint
- make erigon integration

Fixes #21582