### PR TITLE
commitment: rebind concurrent-trie metrics, harden CSV/warmup config

### DIFF
--- a/execution/commitment/config.go
+++ b/execution/commitment/config.go
@@ -9,7 +9,6 @@ const (
 	DefaultMaxDeferredUpdates     = 50_000
 	DefaultRebuildShardMaxSteps   = 64
 	DefaultKeyReferencingMinSteps = 2
-	DefaultWarmupNumWorkers       = 16
 )
 
 // TrieConfig holds configuration for commitment tries. It is passed through the
@@ -26,7 +25,7 @@ type TrieConfig struct {
 	MemoizationOff         bool        // disable memoized hashes in computeCellHash (default: false)
 
 	// WarmupNumWorkers is the number of parallel workers used by the MDBX page-cache
-	// warmup during commitment. 0 = use DefaultWarmupNumWorkers (16).
+	// warmup during commitment. 0 = use dbg.TipTrieWarmupers (env TIP_TRIE_WARMUPERS).
 	WarmupNumWorkers int
 }
 
@@ -49,14 +48,11 @@ func (c TrieConfig) Subtrie() TrieConfig {
 }
 
 // WarmupNumWorkersOrDefault resolves the warmup worker count: the configured
-// value if set, otherwise the env-tunable dbg.TipTrieWarmupers (default NumCPU*8),
-// falling back to DefaultWarmupNumWorkers when that is non-positive.
+// value if set, otherwise the env-tunable dbg.TipTrieWarmupers (default NumCPU*8).
+// An explicit dbg.TipTrieWarmupers of 0 propagates as 0, disabling the warmup pool.
 func (c TrieConfig) WarmupNumWorkersOrDefault() int {
 	if c.WarmupNumWorkers != 0 {
 		return c.WarmupNumWorkers
 	}
-	if dbg.TipTrieWarmupers > 0 {
-		return dbg.TipTrieWarmupers
-	}
-	return DefaultWarmupNumWorkers
+	return dbg.TipTrieWarmupers
 }

--- a/execution/commitment/config_test.go
+++ b/execution/commitment/config_test.go
@@ -38,17 +38,23 @@ func TestDefaultTrieConfig(t *testing.T) {
 
 func TestTrieConfig_OrDefaultHelpers(t *testing.T) {
 	cfg := TrieConfig{}
-	wantUnset := DefaultWarmupNumWorkers
-	if dbg.TipTrieWarmupers > 0 {
-		wantUnset = dbg.TipTrieWarmupers
-	}
-	if got := cfg.WarmupNumWorkersOrDefault(); got != wantUnset {
-		t.Errorf("WarmupNumWorkersOrDefault: expected %d, got %d", wantUnset, got)
+	if got := cfg.WarmupNumWorkersOrDefault(); got != dbg.TipTrieWarmupers {
+		t.Errorf("WarmupNumWorkersOrDefault: expected %d, got %d", dbg.TipTrieWarmupers, got)
 	}
 
 	cfg = TrieConfig{WarmupNumWorkers: 3}
 	if got := cfg.WarmupNumWorkersOrDefault(); got != 3 {
 		t.Errorf("WarmupNumWorkersOrDefault: expected 3, got %d", got)
+	}
+}
+
+func TestTrieConfig_WarmupNumWorkers_EnvDisable(t *testing.T) {
+	old := dbg.TipTrieWarmupers
+	dbg.TipTrieWarmupers = 0
+	defer func() { dbg.TipTrieWarmupers = old }()
+
+	if got := (TrieConfig{}).WarmupNumWorkersOrDefault(); got != 0 {
+		t.Errorf("explicit TIP_TRIE_WARMUPERS=0 must propagate as 0 (warmup disabled), got %d", got)
 	}
 }
 

--- a/execution/commitment/hex_concurrent_patricia_hashed.go
+++ b/execution/commitment/hex_concurrent_patricia_hashed.go
@@ -54,6 +54,12 @@ func NewConcurrentPatriciaHashed(root *HexPatriciaHashed, ctx PatriciaContext) *
 
 	for i := range p.mounts {
 		p.mounts[i] = p.root.SpawnSubTrie(ctx, i)
+		// Mounts fold into the root, so their fold/load stats must land in the
+		// single metrics object Process writes to CSV.
+		if p.root.metrics.writeCommitmentMetrics {
+			p.mounts[i].metrics = p.root.metrics
+			p.mounts[i].branchEncoder.setMetrics(p.root.metrics)
+		}
 	}
 	return p
 }
@@ -192,6 +198,8 @@ func (p *ConcurrentPatriciaHashed) EnableCsvMetrics(filePathPrefix string) {
 	p.root.EnableCsvMetrics(filePathPrefix)
 	for i := range p.mounts {
 		p.mounts[i].EnableCsvMetrics(filePathPrefix)
+		p.mounts[i].metrics = p.root.metrics
+		p.mounts[i].branchEncoder.setMetrics(p.root.metrics)
 	}
 }
 

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -152,9 +152,7 @@ func (hph *HexPatriciaHashed) applyConfig(cfg TrieConfig) {
 	hph.leaveDeferredForCaller = cfg.LeaveDeferredForCaller
 	hph.enableWarmupCache = cfg.EnableWarmupCache
 	hph.memoizationOff = cfg.MemoizationOff
-	if cfg.CsvMetricsFilePrefix != "" {
-		hph.metrics.EnableCsvMetrics(cfg.CsvMetricsFilePrefix)
-	}
+	hph.metrics.SetCsvMetrics(cfg.CsvMetricsFilePrefix)
 }
 
 func newHexPatriciaHashed() *HexPatriciaHashed {

--- a/execution/commitment/hex_patricia_hashed_test.go
+++ b/execution/commitment/hex_patricia_hashed_test.go
@@ -822,7 +822,9 @@ func Test_HexPatriciaHashed_DeferredBranchUpdates(t *testing.T) {
 		Storage("68ee6c0e9cdc73b2b2d52dbd79f19d24fe25e2f9", "d1664244ae1a8a05f8f1d41e45548fbb7aa54609b985d6439ee5fd9bb0da619f", "9898").
 		Build()
 
-	trieNormal := NewHexPatriciaHashed(length.Addr, stateNormal, DefaultTrieConfig())
+	normalCfg := DefaultTrieConfig()
+	normalCfg.DeferBranchUpdates = false
+	trieNormal := NewHexPatriciaHashed(length.Addr, stateNormal, normalCfg)
 	deferredCfg := DefaultTrieConfig()
 	deferredCfg.DeferBranchUpdates = true
 	trieDeferred := NewHexPatriciaHashed(length.Addr, stateDeferred, deferredCfg)

--- a/execution/commitment/metrics.go
+++ b/execution/commitment/metrics.go
@@ -40,9 +40,9 @@ type Metrics struct {
 	updateBranch    atomic.Uint64
 	loadDepths      [10]uint64
 	unfolds         atomic.Uint64
-	spentUnfolding  time.Duration
-	spentFolding    time.Duration
-	spentProcessing time.Duration
+	spentUnfolding  atomic.Int64
+	spentFolding    atomic.Int64
+	spentProcessing atomic.Int64
 	// metric config related
 	metricsFilePrefix        string
 	collectCommitmentMetrics bool
@@ -94,13 +94,31 @@ func NewMetrics(csvPrefix string) *Metrics {
 		Branches:                 NewBranches(),
 		collectCommitmentMetrics: dbg.KVReadLevelledMetrics,
 	}
-	if csvPrefix == "" {
-		csvPrefix = dbg.EnvString("ERIGON_COMMITMENT_CSV_METRICS_FILE_PATH_PREFIX", "")
-	}
-	if csvPrefix != "" {
-		metrics.EnableCsvMetrics(csvPrefix)
-	}
+	metrics.SetCsvMetrics(csvPrefix)
 	return metrics
+}
+
+// SetCsvMetrics enables CSV metrics for filePathPrefix, falling back to the
+// ERIGON_COMMITMENT_CSV_METRICS_FILE_PATH_PREFIX env var when it is empty. An
+// empty prefix with no env var disables CSV metrics, so a pooled Metrics reused
+// without a prefix does not keep writing to a stale file.
+var csvMetricsEnvPrefix = sync.OnceValue(func() string {
+	return dbg.EnvString("ERIGON_COMMITMENT_CSV_METRICS_FILE_PATH_PREFIX", "")
+})
+
+func (m *Metrics) SetCsvMetrics(filePathPrefix string) {
+	if filePathPrefix == "" {
+		filePathPrefix = csvMetricsEnvPrefix()
+	}
+	if filePathPrefix != "" {
+		m.EnableCsvMetrics(filePathPrefix)
+		return
+	}
+	m.metricsFilePrefix = ""
+	m.writeCommitmentMetrics = false
+	m.collectCommitmentMetrics = dbg.KVReadLevelledMetrics
+	m.Accounts.writeCommitmentMetrics = false
+	m.Branches.writeCommitmentMetrics = false
 }
 
 func (m *Metrics) EnableCsvMetrics(filePathPrefix string) {
@@ -131,9 +149,9 @@ func (m *Metrics) AsValues() MetricValues {
 		UpdateBranch:    m.updateBranch.Load(),
 		LoadDepths:      m.loadDepths,
 		Unfolds:         m.unfolds.Load(),
-		SpentUnfolding:  m.spentUnfolding,
-		SpentFolding:    m.spentFolding,
-		SpentProcessing: m.spentProcessing,
+		SpentUnfolding:  time.Duration(m.spentUnfolding.Load()),
+		SpentFolding:    time.Duration(m.spentFolding.Load()),
+		SpentProcessing: time.Duration(m.spentProcessing.Load()),
 	}
 }
 
@@ -161,8 +179,8 @@ func (m *Metrics) logMetrics() []any {
 		"cs", common.PrettyCounter(m.cacheStorage.Load()),
 		"mb", common.PrettyCounter(m.missBranch.Load()), "ma", common.PrettyCounter(m.missAccount.Load()),
 		"ms", common.PrettyCounter(m.missStorage.Load()),
-		"fld", common.PrettyCounter(m.unfolds.Load()), "pdur", common.Round(m.spentProcessing, 0).String(),
-		"fdur", common.Round(m.spentFolding, 0).String(), "ufdur", common.Round(m.spentUnfolding, 0),
+		"fld", common.PrettyCounter(m.unfolds.Load()), "pdur", common.Round(time.Duration(m.spentProcessing.Load()), 0).String(),
+		"fdur", common.Round(time.Duration(m.spentFolding.Load()), 0).String(), "ufdur", common.Round(time.Duration(m.spentUnfolding.Load()), 0),
 	}
 }
 
@@ -213,9 +231,9 @@ func (m *Metrics) Values() [][]string {
 			strconv.FormatUint(m.loadDepths[6], 10) + "/" + strconv.FormatUint(m.loadDepths[7], 10),
 			strconv.FormatUint(m.loadDepths[8], 10) + "/" + strconv.FormatUint(m.loadDepths[9], 10),
 			strconv.FormatUint(m.unfolds.Load(), 10),
-			strconv.FormatInt(m.spentUnfolding.Milliseconds(), 10),
-			strconv.FormatInt(m.spentFolding.Milliseconds(), 10),
-			strconv.FormatInt(m.spentProcessing.Milliseconds(), 10),
+			strconv.FormatInt(time.Duration(m.spentUnfolding.Load()).Milliseconds(), 10),
+			strconv.FormatInt(time.Duration(m.spentFolding.Load()).Milliseconds(), 10),
+			strconv.FormatInt(time.Duration(m.spentProcessing.Load()).Milliseconds(), 10),
 		},
 	}
 	if have, want := len(vals[0]), len(m.Headers()); have != want {
@@ -262,11 +280,11 @@ func UnmarshallMetricsCsv(filePath string) ([]*Metrics, error) {
 			}
 			current.unfolds.Store(mustParseUintCsvCell(row, col, filePath))
 			col++
-			current.spentUnfolding = mustParseMillisecondsCsvCell(row, col, filePath)
+			current.spentUnfolding.Store(int64(mustParseMillisecondsCsvCell(row, col, filePath)))
 			col++
-			current.spentFolding = mustParseMillisecondsCsvCell(row, col, filePath)
+			current.spentFolding.Store(int64(mustParseMillisecondsCsvCell(row, col, filePath)))
 			col++
-			current.spentProcessing = mustParseMillisecondsCsvCell(row, col, filePath)
+			current.spentProcessing.Store(int64(mustParseMillisecondsCsvCell(row, col, filePath)))
 			if cols := col + 1; cols != len(row) {
 				return nil, fmt.Errorf("invalid number of columns processed: row=%d, have=%d, want=%d, file=%s", i, cols, len(row), filePath)
 			}
@@ -295,9 +313,9 @@ func (m *Metrics) Reset() {
 
 	m.Accounts.Reset()
 	m.Branches.Reset()
-	m.spentUnfolding = 0
-	m.spentFolding = 0
-	m.spentProcessing = 0
+	m.spentUnfolding.Store(0)
+	m.spentFolding.Store(0)
+	m.spentProcessing.Store(0)
 }
 
 func (m *Metrics) CollectFileDepthStats(endTxNumStats map[uint64]skipStat) {
@@ -365,7 +383,7 @@ func (m *Metrics) StartUnfolding(plainKey []byte) func() {
 		start := time.Now()
 		return func() {
 			d := time.Since(start)
-			m.spentUnfolding += d
+			m.spentUnfolding.Add(int64(d))
 			m.Accounts.collect(plainKey, func(mx *AccountStats) {
 				mx.SpentUnfolding += d
 			})
@@ -379,7 +397,7 @@ func (m *Metrics) StartFolding(plainKey []byte) func() {
 		start := time.Now()
 		return func() {
 			d := time.Since(start)
-			m.spentFolding += d
+			m.spentFolding.Add(int64(d))
 			m.Accounts.collect(plainKey, func(mx *AccountStats) {
 				mx.SpentFolding += d
 			})
@@ -390,7 +408,7 @@ func (m *Metrics) StartFolding(plainKey []byte) func() {
 
 func (m *Metrics) TotalProcessingTimeInc(t time.Time) {
 	if m.collectCommitmentMetrics {
-		m.spentProcessing += time.Since(t)
+		m.spentProcessing.Add(int64(time.Since(t)))
 	}
 }
 

--- a/execution/commitment/metrics_test.go
+++ b/execution/commitment/metrics_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package commitment
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// A Metrics object enabled for CSV then re-applied with an empty prefix (as
+// happens when a pooled HexPatriciaHashed is reused with default config) must
+// stop writing CSV, otherwise it keeps appending to a stale file.
+func TestMetrics_SetCsvMetricsClearsStaleState(t *testing.T) {
+	m := NewMetrics("")
+	m.EnableCsvMetrics("/tmp/erigon-commitment-metrics-test")
+	if !m.writeCommitmentMetrics || !m.Accounts.writeCommitmentMetrics || !m.Branches.writeCommitmentMetrics {
+		t.Fatal("EnableCsvMetrics should turn on write flags")
+	}
+
+	m.SetCsvMetrics("")
+
+	wantEnabled := csvMetricsEnvPrefix() != ""
+	if m.writeCommitmentMetrics != wantEnabled {
+		t.Errorf("after SetCsvMetrics(\"\"): writeCommitmentMetrics=%v, want %v", m.writeCommitmentMetrics, wantEnabled)
+	}
+	if m.Accounts.writeCommitmentMetrics != wantEnabled || m.Branches.writeCommitmentMetrics != wantEnabled {
+		t.Errorf("after SetCsvMetrics(\"\"): account/branch write flags not reset to %v", wantEnabled)
+	}
+	if !wantEnabled && m.metricsFilePrefix != "" {
+		t.Errorf("after SetCsvMetrics(\"\"): prefix should be cleared, got %q", m.metricsFilePrefix)
+	}
+}
+
+// Concurrent sub-tries share a single Metrics object, so the duration
+// accumulators must be safe under concurrent writes (run with -race).
+func TestMetrics_ConcurrentDurationAccumulation(t *testing.T) {
+	m := NewMetrics("")
+	m.collectCommitmentMetrics = true
+
+	const goroutines, perGoroutine = 8, 2000
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Go(func() {
+			for range perGoroutine {
+				m.StartUnfolding(nil)()
+				m.StartFolding(nil)()
+				m.TotalProcessingTimeInc(time.Now())
+			}
+		})
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Follow-up to #20559 (merged). Splits out the Copilot review findings that weren't part of the SharedDomains options refactor, to keep that PR scoped to @taratorio's feedback.

## Changes

- **Concurrent-trie metrics aggregation** — sub-trie mounts share the root `Metrics` when CSV metrics are on, so their fold/load counters land in the single object `Process` writes to CSV. Mount stats were dropped before. (`hex_concurrent_patricia_hashed.go`)
- **Atomic durations** — `spent{Unfolding,Folding,Processing}` are `atomic.Int64`. Mounts share one `Metrics`, so these accumulators raced under `-race`. (`metrics.go`)
- **CSV reuse** — `SetCsvMetrics` clears the write flags and prefix, so a pooled `HexPatriciaHashed` reused with an empty prefix stops writing to the previous CSV file instead of appending to it. (`metrics.go`, `hex_patricia_hashed.go`)
- **Warmup workers** — `WarmupNumWorkersOrDefault` returns `dbg.TipTrieWarmupers` directly; an explicit `TIP_TRIE_WARMUPERS=0` disables the warmup pool instead of falling back to 16. `WarmKey`/`Wait`/`DrainPending` already guard `numWorkers <= 0`, so 0 is safe. Doc updated. (`config.go`)
- `resetForReuse` clears `collapseTracer` so it doesn't leak across pool reuse. (`hex_patricia_hashed.go`)

## Tests

- `TestMetrics_SetCsvMetricsClearsStaleState` — pooled `Metrics` stops writing CSV after an empty-prefix re-apply.
- `TestMetrics_ConcurrentDurationAccumulation` — duration accumulators under `-race`.
- `TestTrieConfig_WarmupNumWorkers_EnvDisable` — `TIP_TRIE_WARMUPERS=0` propagates as 0.

Builds and tests green.
