### PR TITLE
db/recsplit: speed up index lookups

### DIFF
--- a/db/recsplit/eliasfano16/elias_fano.go
+++ b/db/recsplit/eliasfano16/elias_fano.go
@@ -431,15 +431,10 @@ func (ef *DoubleEliasFano) get2(i uint64) (cumKeys, position uint64,
 	jumpSuperQ := (i / superQ) * superQSize * 2
 	jumpInsideSuperQ := (i % superQ) / q
 	idx16 := 4*(jumpSuperQ+2) + 2*jumpInsideSuperQ
-	idx64 = idx16 / 4
-	shift = 16 * (idx16 % 4)
-	mask := uint64(0xffff) << shift
-	jumpCumKeys := ef.jump[jumpSuperQ] + (ef.jump[idx64]&mask)>>shift
-	idx16++
-	idx64 = idx16 / 4
-	shift = 16 * (idx16 % 4)
-	mask = uint64(0xffff) << shift
-	jumpPosition := ef.jump[jumpSuperQ+1] + (ef.jump[idx64]&mask)>>shift
+	// idx16 is even, so both 16-bit entries live in the same jump word
+	w := ef.jump[idx16/4] >> (16 * (idx16 % 4))
+	jumpCumKeys := ef.jump[jumpSuperQ] + w&0xffff
+	jumpPosition := ef.jump[jumpSuperQ+1] + (w>>16)&0xffff
 	//fmt.Printf("i = %d, jumpCumKeys = %d, jumpPosition = %d\n", i, jumpCumKeys, jumpPosition)
 
 	currWordCumKeys = jumpCumKeys / 64

--- a/db/recsplit/index.go
+++ b/db/recsplit/index.go
@@ -96,6 +96,9 @@ type Index struct {
 	recMask              uint64
 	bytesPerRec          int
 	salt                 uint32
+	leafRecip            uint64 // multiply-shift reciprocals (exact for 16-bit dividends)
+	primaryRecip         uint64
+	secondaryRecip       uint64
 	leafSize             uint16 // Leaf size for recursive split algorithms
 	secondaryAggrBound   uint16 // The lower bound for secondary key aggregation (computed from leadSize)
 	primaryAggrBound     uint16 // The lower bound for primary key aggregation (computed from leafSize)
@@ -210,6 +213,9 @@ func (idx *Index) init() (err error) {
 	} else {
 		idx.secondaryAggrBound = idx.primaryAggrBound * uint16(math.Ceil(0.21*float64(idx.leafSize)+9./10.))
 	}
+	idx.leafRecip = reciprocal16(idx.leafSize)
+	idx.primaryRecip = reciprocal16(idx.primaryAggrBound)
+	idx.secondaryRecip = reciprocal16(idx.secondaryAggrBound)
 	// Salt
 	idx.salt = binary.BigEndian.Uint32(idx.data[offset:])
 	offset += 4
@@ -388,6 +394,15 @@ func (idx *Index) Close() {
 	idx.f = nil
 }
 
+func reciprocal16(d uint16) uint64 {
+	return (1<<32)/uint64(d) + 1
+}
+
+// div16 computes x/d via the reciprocal from reciprocal16(d); exact for any 16-bit x
+func div16(x uint16, recip uint64) uint16 {
+	return uint16((uint64(x) * recip) >> 32)
+}
+
 func (idx *Index) skipBits(m uint16) int {
 	return int(idx.golombRice[m] & 0xffff)
 }
@@ -444,7 +459,7 @@ func (idx *Index) Lookup(bucketHash, fingerprint uint64) (uint64, bool) {
 	for m > idx.secondaryAggrBound { // fanout = 2
 		d := gr.ReadNext(idx.golombParam(m))
 		hmod := remap16(remix(fingerprint+idx.startSeed[level]+d), m)
-		split := (((m+1)/2 + idx.secondaryAggrBound - 1) / idx.secondaryAggrBound) * idx.secondaryAggrBound
+		split := div16((m+1)/2+idx.secondaryAggrBound-1, idx.secondaryRecip) * idx.secondaryAggrBound
 		if hmod < split {
 			m = split
 		} else {
@@ -457,7 +472,7 @@ func (idx *Index) Lookup(bucketHash, fingerprint uint64) (uint64, bool) {
 	if m > idx.primaryAggrBound {
 		d := gr.ReadNext(idx.golombParam(m))
 		hmod := remap16(remix(fingerprint+idx.startSeed[level]+d), m)
-		part := hmod / idx.primaryAggrBound
+		part := div16(hmod, idx.primaryRecip)
 		m = min(idx.primaryAggrBound, m-part*idx.primaryAggrBound)
 		cumKeys += uint64(idx.primaryAggrBound * part)
 		if part != 0 {
@@ -469,7 +484,7 @@ func (idx *Index) Lookup(bucketHash, fingerprint uint64) (uint64, bool) {
 	if m > idx.leafSize {
 		d := gr.ReadNext(idx.golombParam(m))
 		hmod := remap16(remix(fingerprint+idx.startSeed[level]+d), m)
-		part := hmod / idx.leafSize
+		part := div16(hmod, idx.leafRecip)
 		m = min(idx.leafSize, m-part*idx.leafSize)
 		cumKeys += uint64(idx.leafSize * part)
 		if part != 0 {

--- a/db/recsplit/index.go
+++ b/db/recsplit/index.go
@@ -26,6 +26,7 @@ import (
 	"math/bits"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync/atomic"
 	"time"
 	"unsafe"
@@ -454,6 +455,11 @@ func (idx *Index) Lookup(bucketHash, fingerprint uint64) (uint64, bool) {
 	bucket := remap(bucketHash, idx.bucketCount)
 	cumKeys, cumKeysNext, bitPos := idx.ef.Get3(bucket)
 	m := uint16(cumKeysNext - cumKeys) // Number of keys in this bucket
+	if idx.enums {
+		// touch the fixed-bits word so its miss overlaps the unary-word miss in ReadReset
+		fixedWord := gr.data[bitPos>>6]
+		runtime.KeepAlive(fixedWord)
+	}
 	gr.ReadReset(int(bitPos), idx.skipBits(m))
 	var level int
 	for m > idx.secondaryAggrBound { // fanout = 2
@@ -492,6 +498,15 @@ func (idx *Index) Lookup(bucketHash, fingerprint uint64) (uint64, bool) {
 		}
 		level++
 	}
+	// rec is confined to [cumKeys, cumKeys+m); touch both ends of that range so the
+	// final offset load overlaps the remaining Golomb-Rice reads instead of following them
+	if idx.enums {
+		base := unsafe.Pointer(unsafe.SliceData(idx.data))
+		prefetch := *(*byte)(unsafe.Add(base, uintptr(1+8+idx.bytesPerRec*int(cumKeys+1))))
+		prefetch += *(*byte)(unsafe.Add(base, uintptr(1+8+idx.bytesPerRec*int(cumKeys+uint64(m)))))
+		runtime.KeepAlive(prefetch)
+	}
+
 	b := gr.ReadNext(idx.golombParam(m))
 	rec := int(cumKeys) + int(remap16(remix(fingerprint+idx.startSeed[level]+b), m))
 

--- a/db/recsplit/index_lookup_bench_test.go
+++ b/db/recsplit/index_lookup_bench_test.go
@@ -1,0 +1,158 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package recsplit
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/version"
+)
+
+var benchIndexCache = map[string]*Index{}
+
+// buildBenchIndex builds (or returns cached) index so -count=N reruns don't pay the build cost
+func buildBenchIndex(b *testing.B, keys [][]byte, enums, lessFalsePositives bool, version version.DataStructureVersion) *Index {
+	b.Helper()
+	cacheKey := fmt.Sprintf("%t_%t_%d_%x", enums, lessFalsePositives, version, keys[0][:4])
+	if idx, ok := benchIndexCache[cacheKey]; ok {
+		return idx
+	}
+	logger := log.New()
+	tmpDir, err := os.MkdirTemp("", "recsplit_lookup_bench")
+	if err != nil {
+		b.Fatal(err)
+	}
+	salt := uint32(1)
+	indexFile := filepath.Join(tmpDir, "index")
+	rs, err := NewRecSplit(RecSplitArgs{
+		KeyCount:           len(keys),
+		BucketSize:         DefaultBucketSize,
+		Salt:               &salt,
+		TmpDir:             tmpDir,
+		IndexFile:          indexFile,
+		LeafSize:           DefaultLeafSize,
+		Enums:              enums,
+		LessFalsePositives: lessFalsePositives,
+		Version:            version,
+		NoFsync:            true,
+	}, logger)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer rs.Close()
+	for j, key := range keys {
+		if err = rs.AddKey(key, uint64(j*17)); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if err := rs.Build(b.Context()); err != nil {
+		b.Fatal(err)
+	}
+	idx := MustOpen(indexFile)
+	benchIndexCache[cacheKey] = idx
+	return idx
+}
+
+// BenchmarkIndexLookupMiss mirrors the domain/ii read pattern: one key checked
+// against a list of files where it is absent — the existence-filter fast path.
+func BenchmarkIndexLookupMiss(b *testing.B) {
+	const KeysN = 250_000
+	const Files = 4
+	indexes := make([]*Index, Files)
+	for f := 0; f < Files; f++ {
+		keys := make([][]byte, KeysN)
+		rnd := rand.New(rand.NewSource(int64(100 + f)))
+		for j := range keys {
+			keys[j] = make([]byte, 20)
+			rnd.Read(keys[j])
+		}
+		indexes[f] = buildBenchIndex(b, keys, true, true, 2)
+	}
+	missKeys := make([][]byte, KeysN)
+	rnd := rand.New(rand.NewSource(999))
+	for j := range missKeys {
+		missKeys[j] = make([]byte, 20)
+		rnd.Read(missKeys[j])
+	}
+	readers := make([]*IndexReader, Files)
+	for f := range indexes {
+		readers[f] = NewIndexReader(indexes[f])
+	}
+	b.ResetTimer()
+	for i := 0; b.Loop(); i++ {
+		key := missKeys[int((uint64(i)*0xDEECE66D)%KeysN)]
+		hi, lo := readers[0].Sum(key)
+		for f := 0; f < Files; f++ {
+			if _, ok := readers[f].TwoLayerLookupByHash(hi, lo); ok {
+				break // false positive, ~0.4% per file
+			}
+		}
+	}
+}
+
+func BenchmarkIndexLookup(b *testing.B) {
+	const KeysN = 1_000_000
+	// 20-byte pseudo-random keys, like the address/hash keys of production .idx/.kvi files
+	keys := make([][]byte, KeysN)
+	rnd := rand.New(rand.NewSource(7))
+	for j := range keys {
+		keys[j] = make([]byte, 20)
+		rnd.Read(keys[j])
+	}
+
+	for _, tc := range []struct {
+		name               string
+		enums              bool
+		lessFalsePositives bool
+		version            version.DataStructureVersion
+		lookup2            bool
+	}{
+		{name: "plain", enums: false, lessFalsePositives: false, version: 0},
+		{name: "enums", enums: true, lessFalsePositives: false, version: 0},
+		{name: "enums_lfp_v2", enums: true, lessFalsePositives: true, version: 2},
+		// production Lookup2 targets (.vi files) are built without enums
+		{name: "lookup2", enums: false, lessFalsePositives: false, version: 0, lookup2: true},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			idx := buildBenchIndex(b, keys, tc.enums, tc.lessFalsePositives, tc.version)
+			reader := NewIndexReader(idx)
+			b.ResetTimer()
+			for i := 0; b.Loop(); i++ {
+				key := keys[int((uint64(i)*0xDEECE66D)%KeysN)]
+				var offset uint64
+				var ok bool
+				switch {
+				case tc.lookup2:
+					offset, ok = reader.Lookup2(key[:8], key[8:])
+				case tc.enums:
+					offset, ok = reader.TwoLayerLookup(key)
+				default:
+					offset, ok = reader.Lookup(key)
+				}
+				if !ok {
+					b.Fatalf("key not found: %s", key)
+				}
+				_ = offset
+			}
+		})
+	}
+}

--- a/db/recsplit/lookup2_bench_test.go
+++ b/db/recsplit/lookup2_bench_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/erigontech/erigon/common/log/v3"
 )
 
-// buildLookup2BenchIndex builds an enums index over 20-byte random keys,
+// buildLookup2BenchIndex builds an index over 20-byte random keys,
 // looked up as the txnKey(8)||key(12) split that production Lookup2 callers use.
 func buildLookup2BenchIndex(b *testing.B, keys [][]byte) *Index {
 	b.Helper()
@@ -39,7 +39,7 @@ func buildLookup2BenchIndex(b *testing.B, keys [][]byte) *Index {
 		TmpDir:     tmpDir,
 		IndexFile:  indexFile,
 		LeafSize:   DefaultLeafSize,
-		Enums:      true,
+		Enums:      false, // production Lookup2 targets (.vi files) are built without enums
 		NoFsync:    true,
 	}, logger)
 	if err != nil {


### PR DESCRIPTION
autoresearch on index lookup

Now based directly on `main` (#21622 — stateless IndexReader / in-package murmur3 — merged as 7428f796). This PR carries the `Index.Lookup` decoding-path optimizations.

## What

Read-path-only optimizations to RecSplit index lookups. **No file-format change**: the builder is untouched, no version bump, old files read with new code and vice versa.

- **Multiply-shift reciprocals** replace the 3-4 runtime `DIV` instructions per `Index.Lookup` (`/ secondaryAggrBound`, `/ primaryAggrBound`, `/ leafSize`). Reciprocals are computed once at `OpenIndex`; the quotient is exact for all 16-bit dividends.
- **Single jump-word load** in `eliasfano16.DoubleEliasFano.get2` — `idx16` is always even, so the cumKeys/position 16-bit jump entries share one word (−5 lines).
- **Enums-gated cache-line touches** in `Lookup` that overlap independent memory misses (Golomb-Rice fixed word ‖ unary word; offset-table range ‖ final Golomb-Rice reads). Gated on `enums` (`.efi`-style two-layer indexes) because A/B showed plain indexes lose more to the extra loads than they gain — confirmed on a real 7 GB commitment `.kvi` where ungated touches cost +13%.
- New benchmarks: `BenchmarkIndexLookup` with production-shaped configs (`DefaultBucketSize`/`DefaultLeafSize`, 1M random 20-byte keys; plain / enums / enums+LFP-v2 / lookup2-as-`.vi`-shape) and a multi-file miss-path benchmark mirroring the domain/ii probe pattern.

## Benchmarks (this PR alone, vs current `main`)

Interleaved A/B of two test binaries (alternating runs, min-of-8-rounds per sub), two independent sessions; per-sub deltas averaged:

| config | main | this PR | delta |
|---|---|---|---|
| enums (`.efi`-shape) | 497–503 ns/op | 460–464 ns/op | **≈ −7.5%** |
| enums_lfp_v2 | 558–583 | 514–531 | ≈ −8% |
| plain (`.kvi`/`.vi`-shape) | 372–374 | 356–362 | ≈ −4% |
| lookup2 (`.vi`-shape) | 377 | 362–377 | ≈ −2% |
| multi-file miss path | 316–332 | 305–334 | ≈ −1.5% |
| real 7.1 GB commitment `.kvi` (1.11 B keys, warm) | 777–853 | 762–830 | ≈ −2.4% |
| **geomean** | | | **−3.2% / −5.5%** (two sessions) |

Also validated no-regression on a real 9.4 GB `storage.efi` (1.49 B keys, enums=true), where the touches measured −2% on mins.

## Testing

- Existing recsplit unit tests + `FuzzRecSplit` seeds green, also under `-race`, for `recsplit`, `eliasfano16`, `eliasfano32`, `multiencseq`, `simpleseq`.
- `make lint` clean.

These are pure perf refactors with no behavior change, covered by the existing suite (the lookup benchmark was added and baselined before any optimization; each change was kept/discarded on measured effect — several attempted variants were dropped as regressions or noise).

Note: this PR also flips the merged `BenchmarkLookup2*` indexes to `Enums: false` to match production `.vi` files (history/domain build their hashmap accessors without enums; only ii `.efi` uses enums) — with `enums=true` those benchmarks exercised the touch path that real `Lookup2` targets never hit.

Possible follow-up for a separate discussion: defaulting `ExistenceFilterVersion` 1→2 (sharded fuse filter) for newly built files — on the real 1.49 B-key `.efi`, the v1 filter accounts for ~46% of lookup CPU and v2 should improve probe locality at that scale (not yet measured head-to-head).