### PR TITLE
docs: refresh RELEASE_INSTRUCTIONS.md for moved files and version vars

### DIFF
--- a/RELEASE_INSTRUCTIONS.md
+++ b/RELEASE_INSTRUCTIONS.md
@@ -2,14 +2,14 @@
 
 ## Update DB Schema version if required
 
-In the file `common/dbutils/bucket.go` there is variable `DBSchemaVersion` that needs to be updated if there are any changes in the database schema, leading to data migrations.
+In the file `db/kv/tables.go` there is variable `DBSchemaVersion` that needs to be updated if there are any changes in the database schema, leading to data migrations.
 In most cases, it is enough to bump minor version.
 
 ## Update remote KV version if required
 
-In the file `ethdb/remote/remotedbserver/server.go` there is variable `KvServiceAPIVersion` that needs to be updated if there are any changes in the remote KV interface, or
+In the file `db/kv/remotedbserver/remotedbserver.go` there is variable `KvServiceAPIVersion` that needs to be updated if there are any changes in the remote KV interface, or
 database schema, leading to data migrations.
-In most cases, it is enough to bump minor version. It is best to change both DB schema version and remove KV version together.
+In most cases, it is enough to bump minor version. It is best to change both DB schema version and remote KV version together.
 
 ## Compact the state domains if a regeneration is done
 
@@ -19,9 +19,9 @@ make integration
 ./build/bin/integration compact_domains --datadir=<path to datadir> --replace-in-datadir
 ````
 
-## Update version.go
+## Update app.go
 
-After a release branch has been created, update `erigon/db/version/version.go`.
-Let's say you're releasing Erigon v3.1.0.
-Then in branch `release/3.1` of [erigon](https://github.com/erigontech/erigon) set `Major = 3`, `Minor = 1`, `Patch = 0`, `Modifier = ""`, and `DefaultSnapshotGitBranch = "release/3.1"`. (Don't forget to create branch `release/3.1` of [erigon-snapshot](https://github.com/erigontech/erigon-snapshot).)
-In branch `main` of [erigon](https://github.com/erigontech/erigon) set `Major = 3`, `Minor = 2`, `Patch = 0`, `Modifier = "dev"`, and `DefaultSnapshotGitBranch = "main"`.
+After a release branch has been created, update `db/version/app.go`.
+Let's say you're releasing Erigon v3.6.0.
+Then in branch `release/3.6` of [erigon](https://github.com/erigontech/erigon) set `Major = 3`, `Minor = 6`, `Micro = 0`, `Modifier = ""`, and `DefaultSnapshotGitBranch = "release/3.6"`. (Don't forget to create branch `release/3.6` of [erigon-snapshot](https://github.com/erigontech/erigon-snapshot).)
+In branch `main` of [erigon](https://github.com/erigontech/erigon) set `Major = 3`, `Minor = 7`, `Micro = 0`, and `Modifier = "dev"`.


### PR DESCRIPTION
Refreshes `RELEASE_INSTRUCTIONS.md`, which pointed at paths that moved during the `db/` reorg, plus a renamed version field:

- `common/dbutils/bucket.go` → `db/kv/tables.go` (home of `DBSchemaVersion`)
- `ethdb/remote/remotedbserver/server.go` → `db/kv/remotedbserver/remotedbserver.go` (home of `KvServiceAPIVersion`)
- `erigon/db/version/version.go` → `db/version/app.go` (section header updated too)
- `Patch` → `Micro` (the actual field name in `app.go`)
- dropped the stale `DefaultSnapshotGitBranch = "main"` directive for the `main` branch
- bumped the worked example from 3.1 to 3.6
- fixed a "remove KV" → "remote KV" typo

Docs-only; no code changes.
