### PR TITLE
db/recsplit: make IndexReader stateless

### DIFF
--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -684,7 +684,7 @@ func checkCommitmentFileHasRoot(filePath string) (hasState, broken bool, label s
 		}
 		defer idx.Close()
 
-		rd := idx.GetReaderFromPool()
+		rd := idx.Reader()
 		defer rd.Close()
 		if rd.Empty() {
 			log.Warn("[dbg] allow files deletion because accessor broken", "accessor", idx.FileName())

--- a/db/integrity/integrity_kvi.go
+++ b/db/integrity/integrity_kvi.go
@@ -185,7 +185,7 @@ func CheckKvi(ctx context.Context, kviPath string, kvPath string, kvCompression 
 
 	for range numWorkers {
 		eg.Go(func() error {
-			kviReader := kvi.GetReaderFromPool()
+			kviReader := kvi.Reader()
 			defer kviReader.Close()
 			for {
 				select {

--- a/db/recsplit/index.go
+++ b/db/recsplit/index.go
@@ -26,7 +26,6 @@ import (
 	"math/bits"
 	"os"
 	"path/filepath"
-	"sync"
 	"sync/atomic"
 	"time"
 	"unsafe"
@@ -107,7 +106,7 @@ type Index struct {
 	existenceV1        *fusefilter.Reader
 	existenceV2        *fusefilter.ReaderSharded
 
-	readers         *sync.Pool
+	sharedReader    *IndexReader // IndexReader is stateless, so one instance serves all goroutines
 	readAheadRefcnt atomic.Int32 // ref-counter: allow enable/disable read-ahead from goroutines. only when refcnt=0 - disable read-ahead once
 }
 
@@ -163,11 +162,7 @@ func OpenIndex(indexFilePath string) (_ *Index, err error) {
 	//	//}
 	//}
 
-	idx.readers = &sync.Pool{
-		New: func() any {
-			return NewIndexReader(idx)
-		},
-	}
+	idx.sharedReader = NewIndexReader(idx)
 	return idx, nil
 }
 
@@ -416,7 +411,7 @@ func (idx *Index) KeyCount() uint64 { return idx.keyCount }
 func (idx *Index) LeafSize() uint16 { return idx.leafSize }
 func (idx *Index) BucketSize() int  { return idx.bucketSize }
 
-// Lookup is not thread-safe because it used id.hasher
+// Lookup is safe for concurrent use: it only reads the index's immutable state
 func (idx *Index) Lookup(bucketHash, fingerprint uint64) (uint64, bool) {
 	if idx.keyCount == 0 {
 		_, fName := filepath.Split(idx.filePath)
@@ -604,6 +599,6 @@ func (idx *Index) MadvWillNeed() *Index {
 	return idx
 }
 
-func (idx *Index) GetReaderFromPool() *IndexReader {
-	return idx.readers.Get().(*IndexReader)
+func (idx *Index) Reader() *IndexReader {
+	return idx.sharedReader
 }

--- a/db/recsplit/index_reader.go
+++ b/db/recsplit/index_reader.go
@@ -16,17 +16,10 @@
 
 package recsplit
 
-import (
-	"sync"
-)
-
 // IndexReader encapsulates Hash128 to allow concurrent access to Index
 type IndexReader struct {
 	index *Index
 	salt  uint32
-
-	bufLock sync.RWMutex
-	buf     []byte
 }
 
 // NewIndexReader creates new IndexReader
@@ -48,12 +41,9 @@ func (r *IndexReader) Lookup(key []byte) (uint64, bool) {
 	return r.index.Lookup(bucketHash, fingerprint)
 }
 
+// Lookup2 looks up the concatenation key1||key2 without materializing it
 func (r *IndexReader) Lookup2(key1, key2 []byte) (uint64, bool) {
-	r.bufLock.Lock()
-	// hash of 2 concatenated keys is equal to 2 separated calls of `.Write`
-	r.buf = append(append(r.buf[:0], key1...), key2...)
-	bucketHash, fingerprint := murmur128WithSeed(r.buf, r.salt)
-	r.bufLock.Unlock()
+	bucketHash, fingerprint := murmur128PairWithSeed(key1, key2, r.salt)
 	return r.index.Lookup(bucketHash, fingerprint)
 }
 

--- a/db/recsplit/index_reader.go
+++ b/db/recsplit/index_reader.go
@@ -18,8 +18,6 @@ package recsplit
 
 import (
 	"sync"
-
-	"github.com/spaolacci/murmur3"
 )
 
 // IndexReader encapsulates Hash128 to allow concurrent access to Index
@@ -40,9 +38,8 @@ func NewIndexReader(index *Index) *IndexReader {
 }
 
 func (r *IndexReader) Sum(key []byte) (uint64, uint64) {
-	// this inlinable alloc-free version, it's faster than pre-allocated `hasher` object
-	// because `hasher` object is interface and need call many methods on it
-	return murmur3.Sum128WithSeed(key, r.salt)
+	// in-package murmur3 port is bit-identical to the library but faster for short keys
+	return murmur128WithSeed(key, r.salt)
 }
 
 // Lookup wraps index Lookup
@@ -55,7 +52,7 @@ func (r *IndexReader) Lookup2(key1, key2 []byte) (uint64, bool) {
 	r.bufLock.Lock()
 	// hash of 2 concatenated keys is equal to 2 separated calls of `.Write`
 	r.buf = append(append(r.buf[:0], key1...), key2...)
-	bucketHash, fingerprint := murmur3.Sum128WithSeed(r.buf, r.salt)
+	bucketHash, fingerprint := murmur128WithSeed(r.buf, r.salt)
 	r.bufLock.Unlock()
 	return r.index.Lookup(bucketHash, fingerprint)
 }

--- a/db/recsplit/index_reader.go
+++ b/db/recsplit/index_reader.go
@@ -51,12 +51,8 @@ func (r *IndexReader) Empty() bool {
 	return r.index.Empty()
 }
 
-func (r *IndexReader) Close() {
-	if r == nil || r.index == nil {
-		return
-	}
-	r.index.readers.Put(r)
-}
+// Close is a no-op kept for API compatibility: readers are stateless and shared
+func (r *IndexReader) Close() {}
 
 func (r *IndexReader) OrdinalLookup(id uint64) uint64 { return r.index.OrdinalLookup(id) }
 func (r *IndexReader) twoLayerLookup(key []byte) (uint64, bool) {

--- a/db/recsplit/lookup2_bench_test.go
+++ b/db/recsplit/lookup2_bench_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package recsplit
+
+import (
+	"math/rand"
+	"path/filepath"
+	"testing"
+
+	"github.com/erigontech/erigon/common/log/v3"
+)
+
+// buildLookup2BenchIndex builds an enums index over 20-byte random keys,
+// looked up as the txnKey(8)||key(12) split that production Lookup2 callers use.
+func buildLookup2BenchIndex(b *testing.B, keys [][]byte) *Index {
+	b.Helper()
+	logger := log.New()
+	tmpDir := b.TempDir()
+	salt := uint32(1)
+	indexFile := filepath.Join(tmpDir, "index")
+	rs, err := NewRecSplit(RecSplitArgs{
+		KeyCount:   len(keys),
+		BucketSize: DefaultBucketSize,
+		Salt:       &salt,
+		TmpDir:     tmpDir,
+		IndexFile:  indexFile,
+		LeafSize:   DefaultLeafSize,
+		Enums:      true,
+		NoFsync:    true,
+	}, logger)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer rs.Close()
+	for j, key := range keys {
+		if err = rs.AddKey(key, uint64(j*17)); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if err := rs.Build(b.Context()); err != nil {
+		b.Fatal(err)
+	}
+	idx := MustOpen(indexFile)
+	b.Cleanup(idx.Close)
+	return idx
+}
+
+func lookup2BenchKeys(b *testing.B) [][]byte {
+	b.Helper()
+	const KeysN = 200_000
+	keys := make([][]byte, KeysN)
+	rnd := rand.New(rand.NewSource(7))
+	for j := range keys {
+		keys[j] = make([]byte, 20)
+		rnd.Read(keys[j])
+	}
+	return keys
+}
+
+func BenchmarkLookup2(b *testing.B) {
+	keys := lookup2BenchKeys(b)
+	reader := NewIndexReader(buildLookup2BenchIndex(b, keys))
+	b.ResetTimer()
+	for i := uint64(0); b.Loop(); i++ {
+		key := keys[int((i*0xDEECE66D)%uint64(len(keys)))]
+		if _, ok := reader.Lookup2(key[:8], key[8:]); !ok {
+			b.Fatal("not found")
+		}
+	}
+}
+
+func BenchmarkLookup2Parallel(b *testing.B) {
+	keys := lookup2BenchKeys(b)
+	reader := NewIndexReader(buildLookup2BenchIndex(b, keys)) // one shared reader, like a shared pool entry under load
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := uint64(0)
+		for pb.Next() {
+			key := keys[int((i*0xDEECE66D)%uint64(len(keys)))]
+			if _, ok := reader.Lookup2(key[:8], key[8:]); !ok {
+				b.Fatal("not found")
+			}
+			i++
+		}
+	})
+}

--- a/db/recsplit/murmur128.go
+++ b/db/recsplit/murmur128.go
@@ -1,0 +1,123 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package recsplit
+
+import (
+	"encoding/binary"
+	"math/bits"
+)
+
+const (
+	murmurC1 = 0x87c37b91114253d5
+	murmurC2 = 0x4cf5ad432745937f
+)
+
+// murmur128WithSeed is MurmurHash3 x64 128-bit, bit-identical to
+// github.com/spaolacci/murmur3.Sum128WithSeed but allocation- and
+// indirection-free, which is measurably faster for the short keys
+// hashed on every index lookup.
+func murmur128WithSeed(key []byte, seed uint32) (uint64, uint64) {
+	h1, h2 := uint64(seed), uint64(seed)
+	clen := len(key)
+
+	for len(key) >= 16 {
+		k1 := binary.LittleEndian.Uint64(key)
+		k2 := binary.LittleEndian.Uint64(key[8:])
+
+		k1 *= murmurC1
+		k1 = bits.RotateLeft64(k1, 31)
+		k1 *= murmurC2
+		h1 ^= k1
+
+		h1 = bits.RotateLeft64(h1, 27)
+		h1 += h2
+		h1 = h1*5 + 0x52dce729
+
+		k2 *= murmurC2
+		k2 = bits.RotateLeft64(k2, 33)
+		k2 *= murmurC1
+		h2 ^= k2
+
+		h2 = bits.RotateLeft64(h2, 31)
+		h2 += h1
+		h2 = h2*5 + 0x38495ab5
+
+		key = key[16:]
+	}
+
+	if n := len(key); n > 0 {
+		var k1 uint64
+		if n > 8 {
+			// overlapping load of the last 8 bytes, shifted so only bytes 8..n-1 remain
+			k2 := binary.LittleEndian.Uint64(key[n-8:]) >> (8 * (16 - n))
+			k2 *= murmurC2
+			k2 = bits.RotateLeft64(k2, 33)
+			k2 *= murmurC1
+			h2 ^= k2
+			k1 = binary.LittleEndian.Uint64(key)
+		} else {
+			k1 = loadPartial(key, n)
+		}
+		k1 *= murmurC1
+		k1 = bits.RotateLeft64(k1, 31)
+		k1 *= murmurC2
+		h1 ^= k1
+	}
+
+	h1 ^= uint64(clen)
+	h2 ^= uint64(clen)
+
+	h1 += h2
+	h2 += h1
+
+	h1 = murmurFmix64(h1)
+	h2 = murmurFmix64(h2)
+
+	h1 += h2
+	h2 += h1
+
+	return h1, h2
+}
+
+// loadPartial reads 1..8 bytes little-endian without crossing the slice end
+func loadPartial(p []byte, n int) uint64 {
+	if n >= 8 {
+		return binary.LittleEndian.Uint64(p)
+	}
+	if n >= 4 {
+		lo := uint64(binary.LittleEndian.Uint32(p))
+		hi := uint64(binary.LittleEndian.Uint32(p[n-4:]))
+		return lo | hi<<(8*(n-4))
+	}
+	v := uint64(p[0])
+	if n >= 2 {
+		v |= uint64(p[1]) << 8
+	}
+	if n == 3 {
+		v |= uint64(p[2]) << 16
+	}
+	return v
+}
+
+func murmurFmix64(k uint64) uint64 {
+	k ^= k >> 33
+	k *= 0xff51afd7ed558ccd
+	k ^= k >> 33
+	k *= 0xc4ceb9fe1a85ec53
+	k ^= k >> 33
+	return k
+}

--- a/db/recsplit/murmur128.go
+++ b/db/recsplit/murmur128.go
@@ -93,6 +93,103 @@ func murmur128WithSeed(key []byte, seed uint32) (uint64, uint64) {
 	return h1, h2
 }
 
+func murmurBlock(h1, h2, k1, k2 uint64) (uint64, uint64) {
+	k1 *= murmurC1
+	k1 = bits.RotateLeft64(k1, 31)
+	k1 *= murmurC2
+	h1 ^= k1
+
+	h1 = bits.RotateLeft64(h1, 27)
+	h1 += h2
+	h1 = h1*5 + 0x52dce729
+
+	k2 *= murmurC2
+	k2 = bits.RotateLeft64(k2, 33)
+	k2 *= murmurC1
+	h2 ^= k2
+
+	h2 = bits.RotateLeft64(h2, 31)
+	h2 += h1
+	h2 = h2*5 + 0x38495ab5
+	return h1, h2
+}
+
+func murmurTail(h1, h2 uint64, tail []byte, clen int) (uint64, uint64) {
+	if n := len(tail); n > 0 {
+		var k1 uint64
+		if n > 8 {
+			k2 := binary.LittleEndian.Uint64(tail[n-8:]) >> (8 * (16 - n))
+			k2 *= murmurC2
+			k2 = bits.RotateLeft64(k2, 33)
+			k2 *= murmurC1
+			h2 ^= k2
+			k1 = binary.LittleEndian.Uint64(tail)
+		} else {
+			k1 = loadPartial(tail, n)
+		}
+		k1 *= murmurC1
+		k1 = bits.RotateLeft64(k1, 31)
+		k1 *= murmurC2
+		h1 ^= k1
+	}
+
+	h1 ^= uint64(clen)
+	h2 ^= uint64(clen)
+
+	h1 += h2
+	h2 += h1
+
+	h1 = murmurFmix64(h1)
+	h2 = murmurFmix64(h2)
+
+	h1 += h2
+	h2 += h1
+
+	return h1, h2
+}
+
+// murmur128PairWithSeed hashes the virtual concatenation key1||key2, bit-identical
+// to murmur128WithSeed on the concatenated bytes but without materializing them.
+func murmur128PairWithSeed(key1, key2 []byte, seed uint32) (uint64, uint64) {
+	if len(key1) == 0 {
+		return murmur128WithSeed(key2, seed)
+	}
+	if len(key2) == 0 {
+		return murmur128WithSeed(key1, seed)
+	}
+	h1, h2 := uint64(seed), uint64(seed)
+	clen := len(key1) + len(key2)
+
+	for len(key1) >= 16 {
+		h1, h2 = murmurBlock(h1, h2, binary.LittleEndian.Uint64(key1), binary.LittleEndian.Uint64(key1[8:]))
+		key1 = key1[16:]
+	}
+	if r := len(key1); r > 0 {
+		switch {
+		case r+len(key2) < 16:
+			var buf [16]byte
+			n := copy(buf[:], key1)
+			n += copy(buf[n:], key2)
+			return murmurTail(h1, h2, buf[:n], clen)
+		case r == 8:
+			// the common txnKey||key case: boundary block needs no copying
+			h1, h2 = murmurBlock(h1, h2, binary.LittleEndian.Uint64(key1), binary.LittleEndian.Uint64(key2))
+			key2 = key2[8:]
+		default:
+			var buf [16]byte
+			copy(buf[:], key1)
+			copy(buf[r:], key2)
+			h1, h2 = murmurBlock(h1, h2, binary.LittleEndian.Uint64(buf[:]), binary.LittleEndian.Uint64(buf[8:]))
+			key2 = key2[16-r:]
+		}
+	}
+	for len(key2) >= 16 {
+		h1, h2 = murmurBlock(h1, h2, binary.LittleEndian.Uint64(key2), binary.LittleEndian.Uint64(key2[8:]))
+		key2 = key2[16:]
+	}
+	return murmurTail(h1, h2, key2, clen)
+}
+
 // loadPartial reads 1..8 bytes little-endian without crossing the slice end
 func loadPartial(p []byte, n int) uint64 {
 	if n >= 8 {

--- a/db/recsplit/murmur128_test.go
+++ b/db/recsplit/murmur128_test.go
@@ -23,6 +23,44 @@ import (
 	"github.com/spaolacci/murmur3"
 )
 
+// Reference vectors from the source library (spaolacci/murmur3 murmur_test.go),
+// kept verbatim so correctness does not rest solely on the differential tests.
+var murmurRefVectors = []struct {
+	seed   uint32
+	h1, h2 uint64
+	s      string
+}{
+	{0x00, 0x0000000000000000, 0x0000000000000000, ""},
+	{0x00, 0xcbd8a7b341bd9b02, 0x5b1e906a48ae1d19, "hello"},
+	{0x00, 0x342fac623a5ebc8e, 0x4cdcbc079642414d, "hello, world"},
+	{0x00, 0xb89e5988b737affc, 0x664fc2950231b2cb, "19 Jan 2038 at 3:14:07 AM"},
+	{0x00, 0xcd99481f9ee902c9, 0x695da1a38987b6e7, "The quick brown fox jumps over the lazy dog."},
+	{0x01, 0x4610abe56eff5cb5, 0x51622daa78f83583, ""},
+	{0x01, 0xa78ddff5adae8d10, 0x128900ef20900135, "hello"},
+	{0x01, 0x8b95f808840725c6, 0x1597ed5422bd493b, "hello, world"},
+	{0x01, 0x2a929de9c8f97b2f, 0x56a41d99af43a2db, "19 Jan 2038 at 3:14:07 AM"},
+	{0x01, 0xfb3325171f9744da, 0xaaf8b92a5f722952, "The quick brown fox jumps over the lazy dog."},
+	{0x2a, 0xf02aa77dfa1b8523, 0xd1016610da11cbb9, ""},
+	{0x2a, 0xc4b8b3c960af6f08, 0x2334b875b0efbc7a, "hello"},
+	{0x2a, 0xb91864d797caa956, 0xd5d139a55afe6150, "hello, world"},
+	{0x2a, 0xfd8f19ebdc8c6b6a, 0xd30fdc310fa08ff9, "19 Jan 2038 at 3:14:07 AM"},
+	{0x2a, 0x74f33c659cda5af7, 0x4ec7a891caf316f0, "The quick brown fox jumps over the lazy dog."},
+}
+
+func TestMurmur128RefVectors(t *testing.T) {
+	for _, v := range murmurRefVectors {
+		key := []byte(v.s)
+		if h1, h2 := murmur128WithSeed(key, v.seed); h1 != v.h1 || h2 != v.h2 {
+			t.Errorf("key %q seed %d: got (%x,%x) want (%x,%x)", v.s, v.seed, h1, h2, v.h1, v.h2)
+		}
+		for split := 0; split <= len(key); split++ {
+			if h1, h2 := murmur128PairWithSeed(key[:split], key[split:], v.seed); h1 != v.h1 || h2 != v.h2 {
+				t.Errorf("key %q seed %d split %d: got (%x,%x) want (%x,%x)", v.s, v.seed, split, h1, h2, v.h1, v.h2)
+			}
+		}
+	}
+}
+
 // murmur128PairWithSeed(k1, k2) must equal hashing the concatenation k1||k2
 func TestMurmur128PairEquivalence(t *testing.T) {
 	rnd := rand.New(rand.NewSource(43))

--- a/db/recsplit/murmur128_test.go
+++ b/db/recsplit/murmur128_test.go
@@ -23,6 +23,27 @@ import (
 	"github.com/spaolacci/murmur3"
 )
 
+// murmur128PairWithSeed(k1, k2) must equal hashing the concatenation k1||k2
+func TestMurmur128PairEquivalence(t *testing.T) {
+	rnd := rand.New(rand.NewSource(43))
+	for len1 := 0; len1 <= 40; len1++ {
+		for len2 := 0; len2 <= 40; len2++ {
+			key1 := make([]byte, len1)
+			key2 := make([]byte, len2)
+			rnd.Read(key1)
+			rnd.Read(key2)
+			seed := rnd.Uint32()
+			concat := append(append([]byte{}, key1...), key2...)
+			wantHi, wantLo := murmur3.Sum128WithSeed(concat, seed)
+			gotHi, gotLo := murmur128PairWithSeed(key1, key2, seed)
+			if gotHi != wantHi || gotLo != wantLo {
+				t.Fatalf("mismatch len1=%d len2=%d seed=%d: got (%x,%x) want (%x,%x)",
+					len1, len2, seed, gotHi, gotLo, wantHi, wantLo)
+			}
+		}
+	}
+}
+
 // murmur128WithSeed must be bit-identical to the library used to build existing index files
 func TestMurmur128Equivalence(t *testing.T) {
 	rnd := rand.New(rand.NewSource(42))

--- a/db/recsplit/murmur128_test.go
+++ b/db/recsplit/murmur128_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package recsplit
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/spaolacci/murmur3"
+)
+
+// murmur128WithSeed must be bit-identical to the library used to build existing index files
+func TestMurmur128Equivalence(t *testing.T) {
+	rnd := rand.New(rand.NewSource(42))
+	for length := 0; length <= 130; length++ {
+		for trial := 0; trial < 20; trial++ {
+			key := make([]byte, length)
+			rnd.Read(key)
+			seed := rnd.Uint32()
+			wantHi, wantLo := murmur3.Sum128WithSeed(key, seed)
+			gotHi, gotLo := murmur128WithSeed(key, seed)
+			if gotHi != wantHi || gotLo != wantLo {
+				t.Fatalf("mismatch len=%d seed=%d key=%x: got (%x,%x) want (%x,%x)",
+					length, seed, key, gotHi, gotLo, wantHi, wantLo)
+			}
+		}
+	}
+}

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1472,7 +1472,7 @@ func (dt *DomainRoTx) statelessIdxReader(i int) *recsplit.IndexReader {
 		dt.mapReaders = make([]*recsplit.IndexReader, len(dt.files))
 	}
 	if dt.mapReaders[i] == nil {
-		dt.mapReaders[i] = dt.files[i].src.index.GetReaderFromPool()
+		dt.mapReaders[i] = dt.files[i].src.index.Reader()
 	}
 	return dt.mapReaders[i]
 }

--- a/db/state/history.go
+++ b/db/state/history.go
@@ -959,7 +959,7 @@ func (ht *HistoryRoTx) statelessIdxReader(i int) *recsplit.IndexReader {
 	}
 	r := ht.readers[i]
 	if r == nil {
-		r = ht.files[i].src.index.GetReaderFromPool()
+		r = ht.files[i].src.index.Reader()
 		ht.readers[i] = r
 	}
 	return r

--- a/db/state/integrity.go
+++ b/db/state/integrity.go
@@ -124,7 +124,7 @@ func (dt *DomainRoTx) IntegrityKey(k []byte) error {
 			needClose = true
 		}
 
-		reader := accessor.GetReaderFromPool()
+		reader := accessor.Reader()
 		offset, ok := reader.Lookup(k)
 		reader.Close()
 		if !ok {

--- a/db/state/inverted_index.go
+++ b/db/state/inverted_index.go
@@ -507,7 +507,7 @@ func (iit *InvertedIndexRoTx) statelessIdxReader(i int) *recsplit.IndexReader {
 	}
 	r := iit.readers[i]
 	if r == nil {
-		r = iit.files[i].src.index.GetReaderFromPool()
+		r = iit.files[i].src.index.Reader()
 		iit.readers[i] = r
 	}
 	return r
@@ -686,7 +686,7 @@ func (iit *InvertedIndexRoTx) iterateRangeOnFiles(key []byte, startTxNum, endTxN
 			}
 			it.stack = append(it.stack, iit.files[i])
 			it.stack[len(it.stack)-1].getter = it.stack[len(it.stack)-1].src.decompressor.MakeGetter()
-			it.stack[len(it.stack)-1].reader = it.stack[len(it.stack)-1].src.index.GetReaderFromPool()
+			it.stack[len(it.stack)-1].reader = it.stack[len(it.stack)-1].src.index.Reader()
 			it.hasNext = true
 		}
 	} else {
@@ -707,7 +707,7 @@ func (iit *InvertedIndexRoTx) iterateRangeOnFiles(key []byte, startTxNum, endTxN
 			}
 			it.stack = append(it.stack, iit.files[i])
 			it.stack[len(it.stack)-1].getter = it.stack[len(it.stack)-1].src.decompressor.MakeGetter()
-			it.stack[len(it.stack)-1].reader = it.stack[len(it.stack)-1].src.index.GetReaderFromPool()
+			it.stack[len(it.stack)-1].reader = it.stack[len(it.stack)-1].src.index.Reader()
 			it.hasNext = true
 		}
 	}

--- a/db/state/proto_forkable.go
+++ b/db/state/proto_forkable.go
@@ -349,7 +349,7 @@ func (a *ProtoForkableTx) StatelessIdxReader(i int) *recsplit.IndexReader {
 
 	r := a.readers[i]
 	if r == nil {
-		r = a.files[i].src.index.GetReaderFromPool()
+		r = a.files[i].src.index.Reader()
 		a.readers[i] = r
 	}
 


### PR DESCRIPTION
## What

Makes `IndexReader` fully stateless and `Lookup2` lock-free, in three steps:

1. **In-package murmur3-128** (`murmur128.go`) — bit-identical port of `github.com/spaolacci/murmur3.Sum128WithSeed` (equivalence test sweeps key lengths 0–130), without digest-struct indirection and with word-sized tail loads. Existing index files keep working: the hash function is unchanged.
2. **`murmur128PairWithSeed(key1, key2)`** hashes the virtual concatenation `key1||key2` without materializing it (pair-equivalence test sweeps len1×len2 = 0..40×0..40), with a copy-free boundary block for the 8-byte `txnKey` first part that all three production `Lookup2` callers pass. This lets `Lookup2` drop its `sync.RWMutex` + scratch buffer.
3. With the buffer gone, `IndexReader` is reduced to `{index, salt}` — both immutable — so the **per-index `sync.Pool` of readers is removed**: `GetReaderFromPool` returns one shared instance, `Close` stays as a no-op for API compatibility. Net code deletion; callers unchanged.

`Lookup2` is the `history.GetAsOf` path (`db/state/history.go`) and history streams — every historical state read.

## Benchmarks (vs `main`)

`BenchmarkLookup2` — single-threaded, 20-byte keys split `8||12`, min of 5 interleaved A/B rounds:

| | main (mutex + copy + library hash) | this PR | delta |
|---|---|---|---|
| ns/op | 423 | 392 | **−7%** |

`BenchmarkLookup2Parallel` — one shared reader hammered by all 20 cores (the pool-sharing worst case):

| | main | this PR |
|---|---|---|
| ns/op | 488–726 (lock convoy) | 24–43 (**~20–25×**, scales linearly) |

(numbers re-measured after a review fix: the parallel benchmark previously included index-build time in ns/op on both sides)

The contended row is the headline: the old mutex made a shared `Lookup2` reader slower than single-threaded; now it scales with cores.

## Testing

- `TestMurmur128Equivalence` and `TestMurmur128PairEquivalence` written before the implementations (red→green) — they prove the file-format-compatibility-critical property: identical hashes
- Full recsplit suite green under `-race`; `db/state` short tests green; `make lint` clean
- No file-format change anywhere