### PR TITLE
db/state/execctx: fix AccountsDomain codeHash decode (DeserialiseV3) — correctness

### DIFF
--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -1121,7 +1121,12 @@ func decodeAccountCodeHash(enc []byte) []byte {
 		return nil
 	}
 	var acc accounts.Account
-	if err := acc.DecodeForStorage(enc); err != nil {
+	// AccountsDomain values are SerialiseV3-encoded, so they must be decoded
+	// with DeserialiseV3. DecodeForStorage is the legacy MDBX bitmask format
+	// with an incompatible binary layout; applied to V3 bytes it silently
+	// misparses and leaves CodeHash empty, so codeHashForAddr returned nil for
+	// every contract and the CodeDomain ethHash bypass never fired.
+	if err := accounts.DeserialiseV3(&acc, enc); err != nil {
 		return nil
 	}
 	if acc.CodeHash.IsEmpty() {


### PR DESCRIPTION
## Correctness fix

`codeHashForAddr` resolves an account's codeHash from the `AccountsDomain` so the `CodeDomain` ethHash bypass can serve shared bytecode (proxies, clones, ERC-20 holder sets) without an addr-keyed file read.

`decodeAccountCodeHash` decoded the account value with `acc.DecodeForStorage`, but `AccountsDomain` values are **`SerialiseV3`-encoded**. `DecodeForStorage` is the legacy MDBX bitmask format with an incompatible binary layout — applied to V3 bytes it silently misparses and leaves `CodeHash` empty.

Consequently `codeHashForAddr` returned `nil` for **every** account, and the ethHash bypass never engaged for any contract: every `CodeDomain` read that missed the addr cache fell through to a file read. This is a decoding-correctness bug — the wrong decoder applied to the stored encoding.

### Fix
Use `accounts.DeserialiseV3`, the matching decoder for `AccountsDomain` values. One-function change; no behaviour change for valid encodings other than producing the correct codeHash.

### Verification (instrumented mainnet-tip run)
The `codeHashForAddr` resolve path and ethHash bypass were instrumented:

| metric | before | after |
|---|---|---|
| ethHash bypass `served%` (cache, no file read) | 0 | 56 → 72 → 83% (climbs as dedup warms) |
| resolve produced no codeHash for a contract-with-code | ~99% | 0 |
| `GetByEthHash` calls | 0 (never reached) | active, 83% hit |

### Routing
The buggy `decodeAccountCodeHash`/`codeHashForAddr` is introduced by **#21386** (StateCache LRU) and does not exist on `main`, so the fix targets #21386 — the appropriate point in the perf stack. It flows up to #21414 / #21416 / #20893 (all stacked on this branch). To be cherry-picked into those branches as needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)