### PR TITLE
ci: use preinstalled JDK for SonarCloud scanner, cache scanner engine jar

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Use preinstalled JDK for SonarCloud scanner
         if: '!inputs.cache-warming-only'
         run: |
-          if [ -x "${JAVA_HOME_21_X64}/bin/java" ]; then
+          if [ -n "${JAVA_HOME_21_X64}" ] && [ -x "${JAVA_HOME_21_X64}/bin/java" ]; then
             echo "SONAR_SCANNER_SKIP_JRE_PROVISIONING=true" >> "$GITHUB_ENV"
             echo "SONAR_SCANNER_JAVA_EXE_PATH=${JAVA_HOME_21_X64}/bin/java" >> "$GITHUB_ENV"
           fi

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -44,6 +44,17 @@ jobs:
         if: inputs.cache-warming-only
         run: go test -run=^$ -cover ./...
 
+      # The runner image ships the same JRE major version the scanner would
+      # otherwise download from scanner.sonarcloud.io (a 403-prone CDN);
+      # if the image ever drops it, the scanner falls back to downloading.
+      - name: Use preinstalled JDK for SonarCloud scanner
+        if: '!inputs.cache-warming-only'
+        run: |
+          if [ -x "${JAVA_HOME_21_X64}/bin/java" ]; then
+            echo "SONAR_SCANNER_SKIP_JRE_PROVISIONING=true" >> "$GITHUB_ENV"
+            echo "SONAR_SCANNER_JAVA_EXE_PATH=${JAVA_HOME_21_X64}/bin/java" >> "$GITHUB_ENV"
+          fi
+
       # The scan reaches external services (scanner-binaries CDN, GPG keyserver,
       # sonarcloud.io) that intermittently 403 or time out; one spaced retry
       # rides out short blips instead of failing the gate.

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -44,6 +44,57 @@ jobs:
         if: inputs.cache-warming-only
         run: go test -run=^$ -cover ./...
 
+      # The scanner engine jar is the other artifact scans pull from
+      # scanner.sonarcloud.io (a 403-prone CDN), so push runs seed it into the
+      # actions cache for PR and merge-queue scans to restore. Seeding is
+      # best-effort: on failure the next push retries, and scans fall back to
+      # downloading.
+      - name: Look up current SonarCloud scanner engine
+        id: engine
+        if: inputs.cache-warming-only
+        continue-on-error: true
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          meta=$(curl -fsSL --retry 5 --retry-all-errors \
+            -H "Authorization: Bearer ${SONAR_TOKEN}" \
+            https://api.sonarcloud.io/analysis/engine)
+          {
+            echo "filename=$(jq -er .filename <<<"$meta")"
+            echo "sha256=$(jq -er .sha256 <<<"$meta")"
+            echo "url=$(jq -er .downloadUrl <<<"$meta")"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Check SonarCloud scanner engine cache
+        id: engine-cache
+        if: inputs.cache-warming-only && steps.engine.outcome == 'success'
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.sonar/cache
+          key: sonar-scanner-engine|${{ steps.engine.outputs.sha256 }}
+          lookup-only: true
+
+      - name: Download SonarCloud scanner engine
+        id: engine-download
+        if: inputs.cache-warming-only && steps.engine.outcome == 'success' && steps.engine-cache.outputs.cache-hit != 'true'
+        continue-on-error: true
+        env:
+          ENGINE_FILENAME: ${{ steps.engine.outputs.filename }}
+          ENGINE_SHA256: ${{ steps.engine.outputs.sha256 }}
+          ENGINE_URL: ${{ steps.engine.outputs.url }}
+        run: |
+          dir="$HOME/.sonar/cache/${ENGINE_SHA256}"
+          mkdir -p "$dir"
+          curl -fsSL --retry 5 --retry-all-errors -o "$dir/${ENGINE_FILENAME}" "$ENGINE_URL"
+          echo "${ENGINE_SHA256}  $dir/${ENGINE_FILENAME}" | sha256sum -c
+
+      - name: Save SonarCloud scanner engine cache
+        if: inputs.cache-warming-only && steps.engine-download.outcome == 'success'
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.sonar/cache
+          key: sonar-scanner-engine|${{ steps.engine.outputs.sha256 }}
+
       # The runner image ships the same JRE major version the scanner would
       # otherwise download from scanner.sonarcloud.io (a 403-prone CDN);
       # if the image ever drops it, the scanner falls back to downloading.
@@ -54,6 +105,18 @@ jobs:
             echo "SONAR_SCANNER_SKIP_JRE_PROVISIONING=true" >> "$GITHUB_ENV"
             echo "SONAR_SCANNER_JAVA_EXE_PATH=${JAVA_HOME_21_X64}/bin/java" >> "$GITHUB_ENV"
           fi
+
+      # The scanner resolves the engine jar by sha256 in ~/.sonar/cache before
+      # downloading, so restoring the seeded jar removes the per-scan fetch from
+      # scanner.sonarcloud.io. A miss (engine version rotated since the last
+      # base-branch push) falls back to downloading plus the retry below.
+      - name: Restore SonarCloud scanner engine cache
+        if: '!inputs.cache-warming-only'
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.sonar/cache
+          key: sonar-scanner-engine|
+          restore-keys: sonar-scanner-engine|
 
       # The scan reaches external services (scanner-binaries CDN, GPG keyserver,
       # sonarcloud.io) that intermittently 403 or time out; one spaced retry


### PR DESCRIPTION
## Problem

The sonar job pulls two artifacts from `scanner.sonarcloud.io` on every scan: a JRE ("JRE provisioning") and the scanner-engine jar. That CDN intermittently 403s GitHub-runner IPs, and the blocks outlive the spaced retry added in #21604:

- [CI Gate merge-queue run](https://github.com/erigontech/erigon/actions/runs/26994431020/job/79661154435): scan and retry both hit `HTTP 403 Forbidden` on the JRE tarball, failing the gate and bouncing #21562 out of the merge queue — after the coverage suite had already passed.
- [CI Gate run on this PR](https://github.com/erigontech/erigon/actions/runs/27003084716/job/79687976307): with JRE provisioning eliminated, scan and retry both 403'd on the engine jar instead.

The 403s are IP-scoped blocking, not artifact availability: the exact jar URL that failed serves 200 from outside the runners (published Jun 1, still on the CDN), and `api.sonarcloud.io` answered fine in the same failing run — only the `scanner.sonarcloud.io` host blocks, and for longer than the 90s retry spacing, so a same-runner retry cannot ride it out.

## Fix

Remove both per-scan dependencies on that host.

**JRE**: skip provisioning and point the scanner at the JDK already baked into the runner image, via the scanner's documented switches:

- `SONAR_SCANNER_SKIP_JRE_PROVISIONING=true`
- `SONAR_SCANNER_JAVA_EXE_PATH=$JAVA_HOME_21_X64/bin/java`

The ubuntu-24.04 image ships Temurin 21 — the same major version Sonar provisions (the failing artifact was `OpenJDK21U-jre_...21.0.9`). The env vars go through `$GITHUB_ENV`, so both the scan and the retry step inherit them. `cleanup-space` in setup-erigon does not remove the preinstalled JDKs.

**Engine jar**: seed it into the actions cache from cache-warming push runs; PR and merge-queue scans restore it. The seed step queries `api.sonarcloud.io/analysis/engine` (the host that stays reachable; returns `{filename, sha256, downloadUrl}`), downloads the jar with retries, sha256-verifies it, and saves it in the scanner's content-addressed download-cache layout — `~/.sonar/cache/<sha256>/<filename>`, cache key `sonar-scanner-engine|<sha256>`. At scan time the bootstrapper asks the API for the prescribed sha and, finding it in the local cache, never contacts the CDN.

Verified end-to-end with scanner CLI 8.1.0.6389 against a cache seeded exactly as the workflow does it: the debug log shows the metadata call, zero requests to `scanner.sonarcloud.io`, and the engine launched straight from the cached jar.

Cache-warming runs on every push to main/release, and SonarCloud rotates engines every few days (12.37 published Jun 1, 12.38 on Jun 5), so seeds refresh within hours of a rotation.

## Failure modes considered

- Runner image drops Temurin 21: the `[ -x ... ]` guard leaves the env vars unset and the scanner falls back to downloading, i.e. current behavior.
- SonarCloud raises its minimum JRE above 21: the scan fails deterministically with a version error (historically preceded by months of deprecation warnings in the scan log); fix is bumping the env var to `JAVA_HOME_25_X64`, which the image already ships.
- Engine cache miss (version rotated since the last base-branch push, or cache evicted): the scanner falls back to the direct download plus the existing retry — today's behavior, never worse.
- Seeding fails (the CDN 403s the cache-warming runner too, or the bootstrap API contract changes): the lookup and download steps are `continue-on-error`, no cache is saved, and the next push to the branch retries; scans fall back as above.

The scanner CLI zip and GPG key still come per run from `binaries.sonarsource.com` and the keyserver; those hosts have not been the ones failing, and the existing retry covers them.

Note: the first engine seed only materializes once this merges (cache-warming triggers on push to main), so this PR's own sonar runs still use the fallback download path.
