### PR TITLE
db/state: raise domain compression SamplingFactor to 4

### DIFF
--- a/db/state/statecfg/state_schema.go
+++ b/db/state/statecfg/state_schema.go
@@ -425,7 +425,7 @@ var DomainCompressCfg = seg.Cfg{
 	DictReducerSoftLimit: 2000000,
 	MinPatternLen:        20,
 	MaxPatternLen:        128,
-	SamplingFactor:       1,
+	SamplingFactor:       4,
 	MaxDictPatterns:      64 * 1024,
 	Workers:              1,
 }


### PR DESCRIPTION
One-liner per review feedback on #21625: domains were the only files still using `SamplingFactor: 1`; this matches `seg.DefaultCfg`.

On a real bloatnet storage merge (187400-187416, 766M input through `DomainRoTx.mergeFiles`, `Workers=1`) this alone is **30% faster** (382.6s → 269.2s) and the merged `.kv` came out **1.4% smaller**; merged content verified identical against an independent re-merge of the inputs.

Note: due to #21628, `SamplingFactor>1` currently means "dictionary from the first 16MB" rather than a true 25% sample — i.e. this makes domains consistent with the actual long-standing behavior of all other file types. The proper sampling semantics are being handled in #21628.
