### PR TITLE
tools: fail EEST spec shards on race-detector exit code 66

### DIFF
--- a/tools/run-eest-spec-test.sh
+++ b/tools/run-eest-spec-test.sh
@@ -165,13 +165,22 @@ echo "running: $evm_bin $cmd ${extra[*]:-} --workers $workers --jsonout $path"
 echo "tmpdir:  $TMPDIR"
 echo "max-allowed-failures: $max"
 
-# Don't fail on non-zero — the runners report all results via JSON regardless,
-# and we want to inspect the JSON to drive the pass/fail decision. The grep
-# filter strips any init-time log lines (e.g. dbg.envLookup's "[WARN] [env]"
-# message when ERIGON_EXEC3_PARALLEL is set fires before cmd/evm sets the log
-# handler, and the default log handler writes to stdout) so jq sees only JSON.
+# Don't fail on most non-zero exits — the runners report all results via JSON
+# regardless, and we want to inspect the JSON to drive the pass/fail decision
+# (crashes surface as missing/truncated JSON below). The one exception is exit
+# code 66: the Go race runtime's "data race detected" signal, emitted even when
+# the run completes and the JSON parses clean, so it must be checked explicitly.
+# The grep filter strips any init-time log lines (e.g. dbg.envLookup's
+# "[WARN] [env]" message when ERIGON_EXEC3_PARALLEL is set fires before cmd/evm
+# sets the log handler, and the default log handler writes to stdout) so jq
+# sees only JSON.
 raw_file=$(mktemp)
-"$evm_bin" "$cmd" --workers "$workers" --jsonout "${extra[@]}" "$path" > "$raw_file" || true
+rc=0
+"$evm_bin" "$cmd" --workers "$workers" --jsonout "${extra[@]}" "$path" > "$raw_file" || rc=$?
+if (( rc == 66 )); then
+	echo "ERROR: data race detected (race runtime exit code 66); see WARNING: DATA RACE in the log above" >&2
+	exit 1
+fi
 grep -v '^\[[A-Z][A-Z]*\]' "$raw_file" > "$result_file"
 rm -f "$raw_file"
 


### PR DESCRIPTION
## Problem

`tools/run-eest-spec-test.sh` invokes the cmd/evm runner with `|| true` and decides shard pass/fail from the `--jsonout` report alone. That design is correct for the non-race shards (the runners always exit 0 and report via JSON; crashes surface as missing/truncated JSON, which the script catches via the `total == 0` check and `set -euo pipefail` on jq).

It is wrong for the `*-race-*` shards: the Go race runtime reports detected races to **stderr** and overrides the process exit code to **66** (even through `os.Exit(0)`), while the run completes normally and the JSON stays fully valid with every test passing. The `|| true` discards that exit code, so a race shard whose binary detected a data race still went green — the `WARNING: DATA RACE` report only visible in the job log. The race detector's whole value is catching races that *don't* happen to corrupt results, so this silently weakened the guarantee of every race shard:

```
blocktests-stable-race-{pre-cancun,cancun,prague,osaka}-{sequential,parallel}
blocktests-devnet-race-amsterdam
```

(and `zkevm-witness-race-all` once #21629 lands).

Pre-existing since the shards were introduced in #21092; surfaced while reviewing #21629, which doubles the corpus running under the race detector.

## Fix

Capture the runner's exit code and fail the shard explicitly on 66 with a pointer to the race report above it in the log. All other exit-code tolerance is unchanged.

## Verification (local repro)

Built a minimal `-race` Go binary containing a genuine data race that emits valid passing JSON (`[{"name":"t1","pass":true}]`) and calls `os.Exit(0)`, then ran it through the real script as `EVM_BIN` against `blocktests-stable-race-cancun-sequential`:

- **Before** (unmodified script): binary prints `Found 1 data race(s)` and exits 66 → script prints `ran 1 tests, 0 failed` and exits **0** (green despite the race).
- **After**: same run exits **1** with `ERROR: data race detected (race runtime exit code 66); see WARNING: DATA RACE in the log above`.

Regression matrix with stub binaries through the patched script, confirming only the race case changes behavior:

| Scenario | Before | After |
|---|---|---|
| race detected (exit 66, valid passing JSON) | exit 0 | **exit 1** |
| clean pass (exit 0) | exit 0 | exit 0 |
| non-zero exit ≠ 66 with valid JSON | exit 0 (tolerated by design) | exit 0 |
| test failures over budget | exit 1 | exit 1 |

`shellcheck --severity=warning` (the lint-workflow invocation) is clean on the modified script; `make lint` clean.

The race shards running on this PR exercise the patched path end-to-end in CI (race-free run → `rc=0` → behavior identical to before).

## Note on TDD

This is a shell-script CI guard with no test harness; the Red → Green cycle above (reproduce the masked exit code through the unmodified script, then flip it with the fix) stands in for a checked-in failing test.

## End-to-end verification with a real race in erigon code

Repeated the verification with the full production pipeline instead of stub binaries: planted a deliberate data race in `IntraBlockState.CommitBlock` (two unsynchronized goroutines incrementing a package var, executed once per imported block — never committed), built the real `evm.race` via `make evm.race`, and ran a single real EEST fixture (`cancun/eip1153_tstore/test_basic_tload_after_store.json`, one `fork_Cancun` test) through the `blocktests-stable-race-cancun-sequential` shard:

- **old script** (origin/main): race report correctly attributes `intra_block_state.go` in `CommitBlock.func1`, binary prints `Found 1 data race(s)` and exits 66 → script prints `ran 1 tests, 0 failed`, **exit 0** — green despite the race.
- **this PR's script**: same binary, same fixture → **exit 1**, last line `ERROR: data race detected (race runtime exit code 66); see WARNING: DATA RACE in the log above`.
- **control**: race reverted, `evm.race` rebuilt clean, same fixture through this PR's script → 0 race warnings, `ran 1 tests, 0 failed`, **exit 0** — no false positive.
