### PR TITLE
[r3.4] execution/protocol: fix Osaka (EIP-7778) block gas to use pre-refund gas

### DIFF
--- a/execution/protocol/state_transition.go
+++ b/execution/protocol/state_transition.go
@@ -563,17 +563,22 @@ func (st *StateTransition) TransitionDb(refunds bool, gasBailout bool) (result *
 		if rules.IsLondon {
 			refundQuotient = params.RefundQuotientEIP3529
 		}
-		gasUsed := st.gasUsed()
-		st.blockGasUsed = gasUsed
+		gasUsedBeforeRefund := st.gasUsed()
+		gasUsed := gasUsedBeforeRefund
 		stateRefund := st.state.GetRefund()
 		refund := min(gasUsed/refundQuotient, stateRefund)
 		gasUsed = gasUsed - refund
 		if rules.IsPrague {
 			gasUsed = max(intrinsicGasResult.FloorGasCost, gasUsed)
 		}
-		if rules.IsAmsterdam {
-			// EIP-7778: Block Gas Accounting without Refunds
-			st.blockGasUsed = max(intrinsicGasResult.FloorGasCost, st.blockGasUsed)
+		if rules.IsOsaka {
+			// EIP-7778: Block Gas Accounting without Refunds (Osaka onwards).
+			// Block-level gas accounting uses the actual pre-refund execution gas:
+			// SSTORE refunds do not free up block capacity, and the EIP-7623
+			// calldata floor is a minimum ETH payment only — it must not inflate
+			// block gas. The receipt (what the user pays) still uses the
+			// post-refund, floored value via ReceiptGasUsed.
+			st.blockGasUsed = gasUsedBeforeRefund
 		} else {
 			st.blockGasUsed = gasUsed
 		}

--- a/execution/tests/block_test.go
+++ b/execution/tests/block_test.go
@@ -113,30 +113,28 @@ func TestExecutionSpecBlockchainDevnet(t *testing.T) {
 	//bt.whitelist(`.*amsterdam/eip8024_dupn_swapn_exchange.*`)
 
 	// TODO remove skips
-	bt.skipLoad(`^for_amsterdam/amsterdam/eip7928_block_level_access_lists/test_bal_invalid_`)                                                                  // BAL validation not yet implemented
-	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_contract_creation_tx.json`)                                                            // gas used by execution: 53064, in header: 131488
-	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_create_collision_no_log.json`)                                                         // gas used by execution: 197704, in header: 131488
-	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_create_initcode_stop_emits_log.json`)                                                  // gas used by execution: 53023, in header: 131488
-	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_create_insufficient_balance_no_log.json`)                                              // gas used by execution: 55226, in header: 131488
-	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_create_opcode_emits_log.json`)                                                         // gas used by execution: 75132, in header: 169056
-	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_create_out_of_gas_no_log.json`)                                                        // gas used by execution: 253215, in header: 166350
-	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_failed_create_with_value_no_log.json`)                                                 // gas used by execution: 495219, in header: 365427
-	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_finalization_burn_logs.json`)                                                          // gas used by execution: 224135, in header: 652744
-	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_initcode_calls_with_value.json`)                                                       // gas used by execution: 62369, in header: 131488
-	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_nested_calls_log_order.json`)                                                          // gas used by execution: 139210, in header: 131488
-	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_finalization_after_priority_fee.json`)                                    // gas used by execution: 100112, in header: 265324
-	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_mainnet.json`)                                                            // gas used by execution: 53603, in header: 131488
-	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_same_tx_via_call.json`)                                                   // gas used by execution: 72103, in header: 157316
-	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_then_transfer_same_block.json`)                                           // gas used by execution: 82206, in header: 131488
-	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_to_different_address_same_tx.json`)                                       // gas used by execution: 60625, in header: 131488
-	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_to_self_cross_tx_no_log.json`)                                            // gas used by execution: 79612, in header: 133836
-	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_to_self_same_tx.json`)                                                    // gas used by execution: 58024, in header: 131488
-	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_to_system_address.json`)                                                  // gas used by execution: 53603, in header: 131488
-	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_with_value_emits_log.json`)                                               // gas used by execution: 53603, in header: 131488
-	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_transfer_with_all_tx_types.json`)                                                      // gas used by execution: 86100, in header: 54004
-	bt.skipLoad(`^for_amsterdam/amsterdam/eip7778_block_gas_accounting_without_refunds/test_multiple_refund_types_in_one_tx.json`)                              // gas used by execution: 321052, in header: 270020
-	bt.skipLoad(`^for_amsterdam/amsterdam/eip7778_block_gas_accounting_without_refunds/test_simple_gas_accounting.json`)                                        // gas used by execution: 271002, in header: 270020
-	bt.skipLoad(`^for_amsterdam/amsterdam/eip7778_block_gas_accounting_without_refunds/test_varying_calldata_costs.json`)                                       // gas used by execution: 51122, in header: 33800
+	bt.skipLoad(`^for_amsterdam/amsterdam/eip7928_block_level_access_lists/test_bal_invalid_`)                               // BAL validation not yet implemented
+	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_contract_creation_tx.json`)                         // gas used by execution: 53064, in header: 131488
+	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_create_collision_no_log.json`)                      // gas used by execution: 197704, in header: 131488
+	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_create_initcode_stop_emits_log.json`)               // gas used by execution: 53023, in header: 131488
+	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_create_insufficient_balance_no_log.json`)           // gas used by execution: 55226, in header: 131488
+	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_create_opcode_emits_log.json`)                      // gas used by execution: 75132, in header: 169056
+	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_create_out_of_gas_no_log.json`)                     // gas used by execution: 253215, in header: 166350
+	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_failed_create_with_value_no_log.json`)              // gas used by execution: 495219, in header: 365427
+	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_finalization_burn_logs.json`)                       // gas used by execution: 224135, in header: 652744
+	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_initcode_calls_with_value.json`)                    // gas used by execution: 62369, in header: 131488
+	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_nested_calls_log_order.json`)                       // gas used by execution: 139210, in header: 131488
+	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_finalization_after_priority_fee.json`) // gas used by execution: 100112, in header: 265324
+	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_mainnet.json`)                         // gas used by execution: 53603, in header: 131488
+	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_same_tx_via_call.json`)                // gas used by execution: 72103, in header: 157316
+	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_then_transfer_same_block.json`)        // gas used by execution: 82206, in header: 131488
+	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_to_different_address_same_tx.json`)    // gas used by execution: 60625, in header: 131488
+	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_to_self_cross_tx_no_log.json`)         // gas used by execution: 79612, in header: 133836
+	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_to_self_same_tx.json`)                 // gas used by execution: 58024, in header: 131488
+	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_to_system_address.json`)               // gas used by execution: 53603, in header: 131488
+	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_with_value_emits_log.json`)            // gas used by execution: 53603, in header: 131488
+	bt.skipLoad(`^for_amsterdam/amsterdam/eip7708_eth_transfer_logs/test_transfer_with_all_tx_types.json`)                   // gas used by execution: 86100, in header: 54004
+	// EIP-7778 block gas accounting (Osaka onwards) now uses pre-refund gas — see state_transition.go.
 	bt.skipLoad(`^for_amsterdam/amsterdam/eip7843_slotnum/test_slotnum_gas_cost.json`)                                                                          // gas used by execution: 45726, in header: 37568
 	bt.skipLoad(`^for_amsterdam/amsterdam/eip7843_slotnum/test_slotnum_value.json`)                                                                             // gas used by execution: 43105, in header: 37568
 	bt.skipLoad(`^for_amsterdam/amsterdam/eip7928_block_level_access_lists/test_bal_2930_slot_listed_and_unlisted_writes.json`)                                 // gas used by execution: 67412, in header: 75136


### PR DESCRIPTION
## Problem

Mainnet execution fails at block **25202264** (Osaka) with:

```
[4/6 Execution] invalid block, txnIdx=338, gas used by execution: 33961963, in header: 33888325, headerNum=25202264
```

EIP-7778 (*Block Gas Accounting without Refunds*) ships in **Osaka**, but the block-level gas accounting in `TransitionDb` was gated on `rules.IsAmsterdam`. On Osaka mainnet (`IsOsaka=true`, `IsAmsterdam=false` — mainnet has no `amsterdamTime`) block gas fell through to the post-refund, EIP-7623-floored per-tx value:

```go
if rules.IsAmsterdam {          // never true on Osaka mainnet
    st.blockGasUsed = max(floor, st.blockGasUsed)
} else {
    st.blockGasUsed = gasUsed   // post-refund, WITH the EIP-7623 floor
}
```

For calldata-heavy txns the EIP-7623 floor exceeds actual execution gas, so summing the floored per-tx values over-counts the block vs. the canonical header. At block 25202264 the accumulated floor premium was **+73638** (33961963 vs 33888325).

## Fix

Gate the EIP-7778 accounting on `rules.IsOsaka` and use the actual **pre-refund** execution gas for block accounting: SSTORE refunds do not free up block capacity, and the EIP-7623 calldata floor is a minimum ETH payment only — it must not inflate block gas. The receipt (what the user pays) still uses the post-refund, floored value via `ReceiptGasUsed`, so receipts and `receiptHash` are unchanged.

This is the `release/3.4` equivalent of the `txn_executor.go` change on `main` (companion PR).

## Tests

Un-skips the `eip7778_block_gas_accounting_without_refunds` EEST fixtures, which were previously skipped with this exact error pattern (e.g. `test_varying_calldata_costs`: execution 51122 vs header 33800).

`make erigon` ✓ · `gofmt` / `go vet` ✓. (EEST fixtures run in CI.)
