### PR TITLE
execution/protocol: fix Osaka (EIP-7778) block gas to use pre-refund gas

### DIFF
--- a/execution/protocol/txn_executor.go
+++ b/execution/protocol/txn_executor.go
@@ -622,7 +622,15 @@ func (st *TxnExecutor) Execute(refunds bool, gasBailout bool) (result *evmtypes.
 			st.txnGasUsedB4Refunds = imdGas.Regular + gasUsed.Regular
 			refund := min(st.txnGasUsedB4Refunds/refundQuotient, st.state.GetRefund())
 			st.txnGasUsed = max(intrinsicGasResult.FloorGasCost, st.txnGasUsedB4Refunds-refund)
-			st.blockRegularGasUsed = st.txnGasUsed
+			if rules.IsOsaka {
+				// EIP-7778: For Osaka (non-Amsterdam), block gas uses actual
+				// pre-refund gas consumed. SSTORE refunds do not free up block
+				// capacity, and the EIP-7623 calldata floor is a minimum ETH
+				// payment only — it does not inflate block gas.
+				st.blockRegularGasUsed = st.txnGasUsedB4Refunds
+			} else {
+				st.blockRegularGasUsed = st.txnGasUsed
+			}
 		} else {
 			st.txnGasUsedB4Refunds = imdGas.Regular + gasUsed.Regular
 			refund := min(st.txnGasUsedB4Refunds/refundQuotient, st.state.GetRefund())


### PR DESCRIPTION
## Problem

EIP-7778 (*Block Gas Accounting without Refunds*) ships in **Osaka**, but the Prague branch of `TxnExecutor.Execute` used the post-refund, EIP-7623-floored `txnGasUsed` for `blockRegularGasUsed` on Osaka as well:

```go
} else if rules.IsPrague {
    ...
    st.txnGasUsed = max(intrinsicGasResult.FloorGasCost, st.txnGasUsedB4Refunds-refund)
    st.blockRegularGasUsed = st.txnGasUsed   // wrong for Osaka
}
```

That inflates the block gas counter and causes `gas used by execution: X, in header: Y` failures on Osaka mainnet (observed at block **25202264**: execution 33961963 vs header 33888325, diff **+73638** — the accumulated EIP-7623 calldata-floor premium).

## Fix

For Osaka (non-Amsterdam) use `txnGasUsedB4Refunds` for block accounting: SSTORE refunds do not free up block capacity, and the EIP-7623 calldata floor is a minimum ETH payment only — it must not inflate block gas. The receipt (`txnGasUsed`) is unchanged.

Companion PR backports the equivalent change to `release/3.4` (where this logic lives in `state_transition.go`).

`make erigon` ✓ · `gofmt` / `go vet` ✓.
