### PR TITLE
cmd/evm, test-fixtures: bump eest zkevm corpus to tests-zkevm@v0.4.1

### DIFF
--- a/cmd/evm/zkevmrunner.go
+++ b/cmd/evm/zkevmrunner.go
@@ -106,24 +106,6 @@ func zkevmTestCmd(ctx *cli.Context) error {
 func newZkevmFailMatcher() *testutil.TestMatcher {
 	tm := new(testutil.TestMatcher)
 
-	// zkevm@v0.4.0 charges EIP-8037 AUTH_BASE state gas on EIP-7702 clears of an
-	// undelegated authority; current spec refunds it, so the fixtures' expected gas
-	// is stale and block import diverges. https://github.com/erigontech/erigon/issues/21563
-	const staleAuthBaseGas = "stale zkevm@v0.4.0 EIP-7702 AUTH_BASE gas, see #21563"
-	for _, p := range []string{
-		`delegation_clearing\.json/.*undelegated_account`,
-		`delegation_clearing_and_set\.json/.*undelegated_account`,
-		`delegation_clearing_tx_to\.json/.*undelegated_account`,
-		`double_auth\.json/.*first_delegation_DelegationTo\.RESET`,
-		`valid_tx_invalid_auth_signature\.json/.*s=SECP256K1N_OVER_2(-1)?\]`,
-		`tx_to_beacon_root_contract\.json/.*tx_type_4`,
-		`blobhash_gas_cost\.json/.*tx_type_4`,
-		`blobhash_opcode_contexts_tx_types\.json/.*tx_type_4`,
-		`bal_7702_null_address_delegation_no_code_change`,
-	} {
-		tm.Fails(p, staleAuthBaseGas)
-	}
-
 	// The eip8025_optional_proofs witness_validation_* fixtures are stateless-verifier
 	// negative tests storing a deliberately mutated executionWitness, so producer
 	// comparison always diverges until a stateless-verify consumer mode exists.

--- a/test-fixtures.json
+++ b/test-fixtures.json
@@ -16,9 +16,9 @@
     "size": 422845437
   },
   "eest_zkevm": {
-    "url": "https://github.com/ethereum/execution-spec-tests/releases/download/zkevm%40v0.4.0/fixtures_zkevm.tar.gz",
-    "sha256": "f1d6dbec741e325a08d1227c2292be1aa228a78003d6d62b4ab5b53aefc8480a",
-    "size": 221172523
+    "url": "https://github.com/ethereum/execution-specs/releases/download/tests-zkevm%40v0.4.1/fixtures_zkevm.tar.gz",
+    "sha256": "0e3ce037abe98c3190a18d7bb2403fdc2a5c09c904439c6a4e392995ac676f17",
+    "size": 360357871
   },
   "cl_mainnet": {
     "url": "https://github.com/ethereum/consensus-specs/releases/download/v1.7.0-alpha.8/mainnet.tar.gz",


### PR DESCRIPTION
Bumps the `eest_zkevm` execution-witness conformance corpus to `tests-zkevm@v0.4.1` and drops the now-fixed `#21563` expected-fails.

## Pin (`test-fixtures.json`)

- repo/tag: `ethereum/execution-spec-tests` `zkevm@v0.4.0` → `ethereum/execution-specs` `tests-zkevm@v0.4.1`
- sha256: `f1d6dbec741e325a08d1227c2292be1aa228a78003d6d62b4ab5b53aefc8480a` → `0e3ce037abe98c3190a18d7bb2403fdc2a5c09c904439c6a4e392995ac676f17`
- size: 221 MB → 360 MB

The corpus moved to `ethereum/execution-specs` with the `tests-` tag prefix, matching the `eest_benchmark` / `eest_devnet` entries. sha256/size verified by `tools/test-fixtures.sh` on extract.

## Matcher (`cmd/evm/zkevmrunner.go`)

The v0.4.0 EIP-7702 fixtures carried stale EIP-8037 AUTH_BASE gas (`#21563`) — erigon was correct, the fixtures were wrong, so they were registered as expected-fails. v0.4.1 regenerates them; they pass now, making those entries obsolete. Dropped the 9 `staleAuthBaseGas` patterns (Closes #21563); kept the `#21566` verifier-negative ones.

## Running

```sh
# CI shard: downloads tests-zkevm@v0.4.1, builds evm.race, runs the corpus under -race
make eest-spec-zkevm-witness-race
```

Faster, non-race:

```sh
make test-fixtures-zkevm evm
build/bin/evm zkevmtest --jsonout --workers 10 \
  test-fixtures-cache/eest_zkevm/fixtures/blockchain_tests
```

## Result

21604/21604 subtests pass; the `#21566` fixtures stay the only expected-fails.
