### PR TITLE
execution: fix parallel exec to produce changesets at end of each batch as serial

### DIFF
--- a/execution/execmodule/exec_module_test.go
+++ b/execution/execmodule/exec_module_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/rawdbv3"
 	"github.com/erigontech/erigon/db/rawdb"
+	"github.com/erigontech/erigon/db/state/changeset"
 	"github.com/erigontech/erigon/execution/builder"
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
@@ -2049,4 +2050,114 @@ func TestInsertBlocksWithBatchedFCU_BadBlockRecovery_Foreground(t *testing.T) {
 // committed state before asserting (see waitForGenesis/waitForBlock).
 func TestInsertBlocksWithBatchedFCU_BadBlockRecovery_Background(t *testing.T) {
 	runBatchedFCUBadBlockRecovery(t, true)
+}
+
+// transferGen returns a deterministic per-block tx generator: identical
+// inputs produce identical blocks, which lets tests build forks that share
+// a prefix with the canonical chain (requires a pre-Cancun config — Cancun+
+// blocks get a random ParentBeaconBlockRoot in blockgen).
+func transferGen(t *testing.T, key *ecdsa.PrivateKey, to common.Address, amount uint64) func(int, *blockgen.BlockGen) {
+	return func(i int, b *blockgen.BlockGen) {
+		tx, err := types.SignTx(
+			types.NewTransaction(uint64(i), to, uint256.NewInt(amount), 50000, uint256.NewInt(1), nil),
+			*types.LatestSignerForChainID(nil),
+			key,
+		)
+		require.NoError(t, err)
+		b.AddTx(tx)
+	}
+}
+
+// A batch longer than MaxReorgDepth must still produce changesets for the
+// last MaxReorgDepth blocks, otherwise no reorg of any depth is possible
+// after the batch.
+func TestLargeBatchExecGeneratesChangesetsForReorgWindow(t *testing.T) {
+	ctx := t.Context()
+	privKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	senderAddr := crypto.PubkeyToAddress(privKey.PublicKey)
+	m := execmoduletester.New(t,
+		execmoduletester.WithKey(privKey),
+		execmoduletester.WithAlwaysGenerateChangesets(false),
+	)
+
+	maxReorgDepth := m.Cfg().Sync.MaxReorgDepth
+	chainLen := int(maxReorgDepth) + 14
+
+	chainPack, err := blockgen.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, chainLen,
+		transferGen(t, privKey, senderAddr, 1_000))
+	require.NoError(t, err)
+
+	insRes, err := insertBlocks(ctx, m.ExecModule, chainPack.Blocks)
+	require.NoError(t, err)
+	require.Equal(t, execmodule.ExecutionStatusSuccess, insRes)
+	fcuRes, err := updateForkChoice(ctx, m.ExecModule, chainPack.TopBlock.Header())
+	require.NoError(t, err)
+	require.Equal(t, execmodule.ExecutionStatusSuccess, fcuRes.Status)
+
+	require.NoError(t, m.DB.ViewTemporal(ctx, func(tx kv.TemporalTx) error {
+		lowest, err := changeset.ReadLowestUnwindableBlock(tx)
+		require.NoError(t, err)
+		require.Equal(t, uint64(chainLen)-maxReorgDepth, lowest,
+			"changesets must cover the last MaxReorgDepth blocks of the batch")
+		return nil
+	}))
+}
+
+// After a single batch execution longer than MaxReorgDepth, an FCU onto a
+// fork branching a few blocks below the tip must unwind and re-execute
+// instead of failing with ReorgTooDeep.
+func TestUpdateForkChoiceShallowReorgAfterLargeBatchExec(t *testing.T) {
+	ctx := t.Context()
+	privKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	senderAddr := crypto.PubkeyToAddress(privKey.PublicKey)
+	m := execmoduletester.New(t,
+		execmoduletester.WithKey(privKey),
+		execmoduletester.WithAlwaysGenerateChangesets(false),
+	)
+
+	maxReorgDepth := m.Cfg().Sync.MaxReorgDepth
+	chainLen := int(maxReorgDepth) + 14
+	const reorgDepth = 4
+	divergeFrom := chainLen - reorgDepth
+
+	canonical, err := blockgen.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, chainLen,
+		transferGen(t, privKey, senderAddr, 1_000))
+	require.NoError(t, err)
+	fork, err := blockgen.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, chainLen,
+		func(i int, b *blockgen.BlockGen) {
+			amount := uint64(1_000)
+			if i >= divergeFrom {
+				amount = 2_000
+			}
+			transferGen(t, privKey, senderAddr, amount)(i, b)
+		})
+	require.NoError(t, err)
+	require.Equal(t, canonical.Blocks[divergeFrom-1].Hash(), fork.Blocks[divergeFrom-1].Hash())
+	require.NotEqual(t, canonical.Blocks[divergeFrom].Hash(), fork.Blocks[divergeFrom].Hash())
+
+	insRes, err := insertBlocks(ctx, m.ExecModule, canonical.Blocks)
+	require.NoError(t, err)
+	require.Equal(t, execmodule.ExecutionStatusSuccess, insRes)
+	fcuRes, err := updateForkChoice(ctx, m.ExecModule, canonical.TopBlock.Header())
+	require.NoError(t, err)
+	require.Equal(t, execmodule.ExecutionStatusSuccess, fcuRes.Status)
+
+	insRes, err = insertBlocks(ctx, m.ExecModule, fork.Blocks[divergeFrom:])
+	require.NoError(t, err)
+	require.Equal(t, execmodule.ExecutionStatusSuccess, insRes)
+	fcuRes, err = updateForkChoice(ctx, m.ExecModule, fork.TopBlock.Header())
+	require.NoError(t, err)
+	require.Equal(t, execmodule.ExecutionStatusSuccess, fcuRes.Status,
+		"shallow reorg of %d blocks after a %d-block batch must succeed; status=%s validationError=%q",
+		reorgDepth, chainLen, fcuRes.Status, fcuRes.ValidationError)
+
+	require.NoError(t, m.DB.ViewTemporal(ctx, func(tx kv.TemporalTx) error {
+		execProg, err := stages.GetStageProgress(tx, stages.Execution)
+		require.NoError(t, err)
+		require.Equal(t, uint64(chainLen), execProg)
+		require.Equal(t, fork.TopBlock.Hash(), rawdb.ReadHeadBlockHash(tx))
+		return nil
+	}))
 }

--- a/execution/execmodule/execmoduletester/exec_module_tester.go
+++ b/execution/execmodule/execmoduletester/exec_module_tester.go
@@ -333,6 +333,16 @@ func WithFcuBackgroundCommit() Option {
 	}
 }
 
+// WithAlwaysGenerateChangesets pins --experimental.always-generate-changesets
+// regardless of the tester default: true for tests that reorg deeper than
+// MaxReorgDepth, false for tests that rely on the windowed-changesets
+// production behaviour.
+func WithAlwaysGenerateChangesets(v bool) Option {
+	return func(opts *options) {
+		opts.alwaysGenerateChangesets = &v
+	}
+}
+
 func WithFcuBackgroundPrune() Option {
 	return func(opts *options) {
 		opts.fcuBackgroundPrune = true
@@ -340,17 +350,18 @@ func WithFcuBackgroundPrune() Option {
 }
 
 type options struct {
-	stepSize            *uint64
-	experimentalBAL     bool
-	genesis             *types.Genesis
-	chainConfig         *chain.Config
-	key                 *ecdsa.PrivateKey
-	engine              rules.Engine
-	pruneMode           *prune.Mode
-	withTxPool          bool
-	enableDomains       []kv.Domain
-	fcuBackgroundCommit bool
-	fcuBackgroundPrune  bool
+	stepSize                 *uint64
+	experimentalBAL          bool
+	genesis                  *types.Genesis
+	chainConfig              *chain.Config
+	key                      *ecdsa.PrivateKey
+	engine                   rules.Engine
+	pruneMode                *prune.Mode
+	withTxPool               bool
+	enableDomains            []kv.Domain
+	fcuBackgroundCommit      bool
+	fcuBackgroundPrune       bool
+	alwaysGenerateChangesets *bool
 }
 
 func applyOptions(opts []Option) options {
@@ -420,7 +431,9 @@ func New(tb testing.TB, opts ...Option) *ExecModuleTester {
 	cfg.Sync.BodyDownloadTimeoutSeconds = 10
 	cfg.TxPool.Disable = !withTxPool
 	cfg.Dirs = dirs
-	cfg.AlwaysGenerateChangesets = true
+	if opt.alwaysGenerateChangesets != nil {
+		cfg.AlwaysGenerateChangesets = *opt.alwaysGenerateChangesets
+	}
 	cfg.PersistReceiptsCacheV2 = true
 	cfg.ChaosMonkey = false
 	cfg.Snapshot.ChainName = gspec.Config.ChainName

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -109,6 +109,13 @@ type commitmentCalculator struct {
 	// LAST block's changeset, which is wrong for per-block unwind.
 	forcePerBlockCompute bool
 
+	// perBlockFrom is the batch's changeset window start: blocks >= it
+	// compute per-block (their changesets must record per-block branch
+	// deltas); blocks below it accumulate in batch mode. The last
+	// pre-window block triggers a transition compute (computeTransition)
+	// so no pre-window branch deltas leak into a window block's changeset.
+	perBlockFrom uint64
+
 	wg   sync.WaitGroup
 	done chan struct{}
 }
@@ -120,6 +127,7 @@ func newCommitmentCalculator(
 	logPrefix string,
 	logger log.Logger,
 	forcePerBlockCompute bool,
+	perBlockFrom uint64,
 	in chan applyResult,
 	out chan commitmentResult,
 ) (*commitmentCalculator, error) {
@@ -162,6 +170,7 @@ func newCommitmentCalculator(
 		in:                   in,
 		out:                  out,
 		forcePerBlockCompute: forcePerBlockCompute,
+		perBlockFrom:         perBlockFrom,
 		done:                 make(chan struct{}),
 	}, nil
 }
@@ -250,8 +259,9 @@ func (cc *commitmentCalculator) handleMessage(ctx context.Context, msg applyResu
 		// serial's gate (exec3_serial.go around the `if !dbg.BatchCommitments
 		// || shouldGenerateChangesets || ...` check) — per-block compute is
 		// required when changesets must record per-block branch deltas
-		// (reorg support, KeepExecutionProofs).
-		if !dbg.BatchCommitments || cc.forcePerBlockCompute {
+		// (reorg support, KeepExecutionProofs). Blocks from the changeset
+		// window (perBlockFrom) onward compute per-block for the same reason.
+		if !dbg.BatchCommitments || cc.forcePerBlockCompute || r.BlockNum >= cc.perBlockFrom {
 			if cc.lastComputedBlock == 0 && r.isPartial {
 				// First block is partial (resumed mid-block).
 				// Compute it (like serial does) to save trie state, then
@@ -261,6 +271,18 @@ func (cc *commitmentCalculator) handleMessage(ctx context.Context, msg applyResu
 			} else {
 				cc.computeAndCheck(ctx, r)
 			}
+			if r.BlockNum+1 == cc.perBlockFrom {
+				// Pre-window per-block computes (BatchCommitments off) defer
+				// branch writes too — flush the boundary block's pending update
+				// outside any changeset before the first window block's compute
+				// routes into its saved CS.
+				cc.flushPendingUpdatesWithoutChangeset(ctx, r)
+			}
+		} else if r.BlockNum+1 == cc.perBlockFrom {
+			// Last pre-window block: fold everything accumulated in batch
+			// mode now, so the first window block's per-block compute (and
+			// changeset) covers only its own deltas.
+			cc.computeTransition(ctx, r)
 		}
 		// In BatchCommitments mode (without forcePerBlockCompute): just
 		// accumulate — compute only on explicit commitComputeRequest from
@@ -441,6 +463,79 @@ func (cc *commitmentCalculator) computeAndCheck(ctx context.Context, br *blockRe
 
 	// Only publish on mismatch — success is silent.
 	if mismatch := !bytes.Equal(rh, br.StateRoot[:]); mismatch {
+		cc.publish(ctx, commitmentResult{
+			blockNum: br.BlockNum,
+			txNum:    br.lastTxNum,
+			rootHash: rh,
+			err:      fmt.Errorf("%w: block %d root %x expected %x", ErrWrongTrieRoot, br.BlockNum, rh, br.StateRoot),
+		})
+	}
+}
+
+// flushPendingUpdatesWithoutChangeset eagerly applies the pending deferred
+// update under a nil accumulator — a pre-window block's branch deltas must
+// not pend into the first window block's changeset-routed compute.
+func (cc *commitmentCalculator) flushPendingUpdatesWithoutChangeset(ctx context.Context, br *blockResult) {
+	cc.doms.LockChangesetAccumulator()
+	prev := cc.doms.GetChangesetAccumulatorLocked()
+	cc.doms.SetChangesetAccumulatorLocked(nil)
+	err := cc.doms.FlushPendingUpdatesLocked(ctx, cc.roTx)
+	cc.doms.SetChangesetAccumulatorLocked(prev)
+	cc.doms.UnlockChangesetAccumulator()
+	if err != nil {
+		cc.publish(ctx, commitmentResult{
+			blockNum: br.BlockNum,
+			txNum:    br.lastTxNum,
+			err:      fmt.Errorf("commitmentCalculator: %w", err),
+		})
+	}
+}
+
+// computeTransition folds all batch-mode blocks at the last pre-window block
+// so the first window block's compute (and changeset) covers only its own
+// deltas. Branch writes and the deferred-update flush run under a nil
+// accumulator — pre-window deltas must not land in any block's changeset.
+func (cc *commitmentCalculator) computeTransition(ctx context.Context, br *blockResult) {
+	if err := cc.state.LazyLoadErr(); err != nil {
+		cc.publish(ctx, commitmentResult{
+			blockNum: br.BlockNum,
+			txNum:    br.lastTxNum,
+			err:      fmt.Errorf("commitmentCalculator: lazy-load failed: %w", err),
+		})
+		return
+	}
+	cc.state.FlushToUpdates(cc.updates)
+	cc.state.ResetBlockFlags()
+
+	sdCtx := cc.doms.GetCommitmentContext()
+	sdCtx.SetUpdates(cc.updates)
+	cc.updates = cc.updates.NewEmpty()
+
+	cc.asOfReader.txNum = br.lastTxNum + 1
+	sdCtx.SetStateReader(cc.asOfReader)
+
+	cc.doms.LockChangesetAccumulator()
+	prev := cc.doms.GetChangesetAccumulatorLocked()
+	cc.doms.SetChangesetAccumulatorLocked(nil)
+	rh, err := cc.doms.ComputeCommitmentLocked(ctx, cc.roTx, true, br.BlockNum, br.lastTxNum, cc.logPrefix, nil)
+	if err == nil {
+		err = cc.doms.FlushPendingUpdatesLocked(ctx, cc.roTx)
+	}
+	cc.doms.SetChangesetAccumulatorLocked(prev)
+	cc.doms.UnlockChangesetAccumulator()
+	if err != nil {
+		cc.publish(ctx, commitmentResult{
+			blockNum: br.BlockNum,
+			txNum:    br.lastTxNum,
+			err:      fmt.Errorf("commitmentCalculator: %w", err),
+		})
+		return
+	}
+
+	cc.lastComputedBlock = br.BlockNum
+	cc.hasComputed = true
+
+	if !bytes.Equal(rh, br.StateRoot[:]) {
 		cc.publish(ctx, commitmentResult{
 			blockNum: br.BlockNum,
 			txNum:    br.lastTxNum,

--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -833,4 +834,23 @@ func shouldGenerateChangeSets(cfg ExecuteBlockCfg, blockNum, maxBlockNum uint64)
 	// Generate changesets for blocks within the reorg window of the batch end,
 	// so the node can handle reorgs at the tip.
 	return blockNum+cfg.syncCfg.MaxReorgDepth >= maxBlockNum
+}
+
+// changesetWindowStart returns the first block in [startBlockNum, maxBlockNum]
+// for which shouldGenerateChangeSets is true, or math.MaxUint64 when there is
+// none. Parallel exec gates per-block changeset capture and the commitment
+// calculator's per-block mode on this boundary.
+func changesetWindowStart(alwaysGenerateChangesets bool, maxReorgDepth uint64, frozenBlocks uint64, startBlockNum uint64, maxBlockNum uint64) uint64 {
+	if alwaysGenerateChangesets {
+		return startBlockNum
+	}
+	windowStart := startBlockNum
+	if maxBlockNum > maxReorgDepth {
+		windowStart = max(windowStart, maxBlockNum-maxReorgDepth)
+	}
+	windowStart = max(windowStart, frozenBlocks)
+	if windowStart > maxBlockNum {
+		return math.MaxUint64
+	}
+	return windowStart
 }

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -112,8 +112,11 @@ type parallelExecutor struct {
 	// goroutine and avoids the data race between SetChangesetAccumulator
 	// (apply loop) and ApplyStateWrites (exec loop, via SysCallContract for
 	// block-end system calls) on SharedDomains.mem.
-	shouldGenerateChangesets bool
-	currentChangeSet         *changeset.StateChangeSet
+	// changesetWindowStart is the first block of the batch that must capture
+	// a changeset (see changesetWindowStart in exec3.go); blocks below it run
+	// without an accumulator.
+	changesetWindowStart uint64
+	currentChangeSet     *changeset.StateChangeSet
 	// currentChangeSetBlock is the block number currentChangeSet belongs to
 	// (0 == none). Tracked so ensureChangesetAccumulator can be a no-op when the
 	// accumulator is already installed for the block whose writes are about to
@@ -130,7 +133,7 @@ type parallelExecutor struct {
 // SetChangesetAccumulator, which must be single-writer (see the comment on
 // currentChangeSet).
 func (pe *parallelExecutor) ensureChangesetAccumulator(blockNum uint64) {
-	if !pe.shouldGenerateChangesets || blockNum == 0 || blockNum > pe.maxBlockNum {
+	if blockNum < pe.changesetWindowStart || blockNum == 0 || blockNum > pe.maxBlockNum {
 		return
 	}
 	if pe.currentChangeSet != nil && pe.currentChangeSetBlock == blockNum {
@@ -256,18 +259,18 @@ func (pe *parallelExecutor) execImpl(ctx context.Context, execStage *StageState,
 	// exec loop owns all subsequent SetChangesetAccumulator transitions
 	// (per-block save/clear/install) so apply-loop and exec-loop sd.mem
 	// writes never race on SharedDomains.mem.
-	pe.shouldGenerateChangesets = shouldGenerateChangeSets(pe.cfg, startBlockNum, maxBlockNum)
+	pe.changesetWindowStart = changesetWindowStart(pe.cfg.syncCfg.AlwaysGenerateChangesets,
+		pe.cfg.syncCfg.MaxReorgDepth, pe.cfg.blockReader.FrozenBlocks(), startBlockNum, maxBlockNum)
 	pe.ensureChangesetAccumulator(startBlockNum)
 
-	// Start the commitment calculator. forcePerBlockCompute mirrors serial's
-	// per-block gate (exec3_serial.go: `if !dbg.BatchCommitments ||
-	// shouldGenerateChangesets || KeepExecutionProofs`). When changesets
-	// must be generated (for unwind/reorg) the calculator must compute
-	// per-block — otherwise batch-mode dedupes branch updates across the
-	// batch and flushes them all into the last block's changeset, which
-	// fails on subsequent reorgs.
-	forcePerBlockCompute := pe.shouldGenerateChangesets || pe.cfg.syncCfg.KeepExecutionProofs
-	calculator, err := newCommitmentCalculator(executorContext, pe.rs.Domains(), pe.cfg.db, pe.logPrefix, pe.logger, forcePerBlockCompute, commitResults, rootResults)
+	// Start the commitment calculator. It mirrors serial's per-block gate
+	// (exec3_serial.go: `if !dbg.BatchCommitments || shouldGenerateChangesets
+	// || KeepExecutionProofs`): blocks from the changeset window onward must
+	// compute per-block — otherwise batch-mode dedupes branch updates across
+	// the batch and flushes them all into one block's changeset, which fails
+	// on subsequent reorgs.
+	forcePerBlockCompute := pe.cfg.syncCfg.KeepExecutionProofs
+	calculator, err := newCommitmentCalculator(executorContext, pe.rs.Domains(), pe.cfg.db, pe.logPrefix, pe.logger, forcePerBlockCompute, pe.changesetWindowStart, commitResults, rootResults)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -310,7 +313,7 @@ func (pe *parallelExecutor) execImpl(ctx context.Context, execStage *StageState,
 		}
 		defer applyRoTx.Rollback()
 
-		// pe.shouldGenerateChangesets and pe.currentChangeSet were set up
+		// pe.changesetWindowStart and pe.currentChangeSet were set up
 		// before pe.run/executeBlocks launched their goroutines (above the
 		// calculator.Start call). Per-block accumulator save/clear/install
 		// transitions are driven from the exec loop's blockResult handler.
@@ -978,7 +981,7 @@ func (pe *parallelExecutor) execLoop(ctx context.Context) (err error) {
 				// blockResult, so that the commitment calculator (which consumes
 				// blockResults on a separate goroutine) can find this block's
 				// saved changeset via GetChangesetByBlockNum at compute time.
-				// In per-block compute mode (shouldGenerateChangesets), the
+				// In per-block compute mode (changeset window), the
 				// calculator switches the accumulator to this saved CS for the
 				// duration of ComputeCommitment (committer.go:computeWithBlockAccumulator)
 				// so branch writes land in block N's CS rather than whatever the

--- a/execution/stagedsync/exec3_parallel_robustness_test.go
+++ b/execution/stagedsync/exec3_parallel_robustness_test.go
@@ -12,6 +12,7 @@ package stagedsync
 import (
 	"context"
 	"errors"
+	"math"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -21,6 +22,86 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/execution/protocol/rules"
 )
+
+// TestChangesetWindowStart covers the pure helper that decides where the
+// changeset window of a batch begins. Evaluating the window once at
+// startBlockNum (instead of per block) would leave any batch longer than
+// MaxReorgDepth without changesets, making the node unable to reorg
+// afterwards.
+func TestChangesetWindowStart(t *testing.T) {
+	cases := []struct {
+		name                     string
+		alwaysGenerateChangesets bool
+		maxReorgDepth            uint64
+		frozenBlocks             uint64
+		startBlockNum            uint64
+		maxBlockNum              uint64
+		want                     uint64
+	}{
+		{
+			name:          "big batch: window covers the last maxReorgDepth blocks",
+			maxReorgDepth: 96,
+			startBlockNum: 1,
+			maxBlockNum:   1000,
+			want:          904,
+		},
+		{
+			name:          "small batch: whole batch in window",
+			maxReorgDepth: 96,
+			startBlockNum: 950,
+			maxBlockNum:   1000,
+			want:          950,
+		},
+		{
+			name:          "batch end below maxReorgDepth: window from batch start",
+			maxReorgDepth: 96,
+			startBlockNum: 1,
+			maxBlockNum:   96,
+			want:          1,
+		},
+		{
+			name:                     "alwaysGenerateChangesets overrides depth and frozen gates",
+			alwaysGenerateChangesets: true,
+			maxReorgDepth:            96,
+			frozenBlocks:             2000,
+			startBlockNum:            1,
+			maxBlockNum:              1000,
+			want:                     1,
+		},
+		{
+			name:          "frozen blocks push the window up",
+			maxReorgDepth: 96,
+			frozenBlocks:  950,
+			startBlockNum: 1,
+			maxBlockNum:   1000,
+			want:          950,
+		},
+		{
+			name:          "fully frozen batch has no window",
+			maxReorgDepth: 96,
+			frozenBlocks:  2000,
+			startBlockNum: 1,
+			maxBlockNum:   1000,
+			want:          math.MaxUint64,
+		},
+		{
+			name:          "long catch-up batch keeps a shallow reorg below its tip unwindable",
+			maxReorgDepth: 96,
+			startBlockNum: 5138,
+			maxBlockNum:   6137,
+			want:          6041,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := changesetWindowStart(tc.alwaysGenerateChangesets, tc.maxReorgDepth, tc.frozenBlocks, tc.startBlockNum, tc.maxBlockNum)
+			if got != tc.want {
+				t.Fatalf("changesetWindowStart got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
 
 // TestApplyLoopMissingBlocks covers the pure completeness-check helper.
 // Every entry asserts a single invariant — see the comment on each case.

--- a/execution/tests/blockchain_test.go
+++ b/execution/tests/blockchain_test.go
@@ -1230,7 +1230,9 @@ func TestLargeReorgTrieGC(t *testing.T) {
 	t.Parallel()
 	// Generate the original common chain segment and the two competing forks
 
-	m, m2 := execmoduletester.New(t), execmoduletester.New(t)
+	// The competitor fork reorgs ~2*triesInMemory blocks deep — beyond
+	// MaxReorgDepth, so the inserting node needs changesets for every block.
+	m, m2 := execmoduletester.New(t), execmoduletester.New(t, execmoduletester.WithAlwaysGenerateChangesets(true))
 
 	shared, err := blockgen.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 64, func(i int, b *blockgen.BlockGen) {
 		b.SetCoinbase(common.Address{1})
@@ -1317,8 +1319,9 @@ func TestLowDiffLongChain(t *testing.T) {
 		t.Fatalf("generate fork: %v", err)
 	}
 
-	// Import the canonical chain
-	m2 := execmoduletester.New(t)
+	// Import the canonical chain. The fork branches at block 11 — far beyond
+	// MaxReorgDepth — so the inserting node needs changesets for every block.
+	m2 := execmoduletester.New(t, execmoduletester.WithAlwaysGenerateChangesets(true))
 
 	if err := m2.InsertChain(chain); err != nil {
 		t.Fatalf("failed to insert into chain: %v", err)


### PR DESCRIPTION
Fixes #21650

## Problem

Parallel exec evaluated `shouldGenerateChangeSets` once per batch, at `startBlockNum` (`exec3_parallel.go`), while serial exec evaluates it per block. The predicate ("is this block within `MaxReorgDepth` of the batch end") therefore degenerated into "is the whole batch shorter than `MaxReorgDepth`": any batch longer than 96 blocks produced **zero** changesets, including for its last 96 blocks.

After a large catch-up batch (initial sync, restart recovery, post-downtime catch-up), the node could not unwind even one block: `CanUnwindToBlockNum` found an empty `ChangeSets3` table, fell back to the latest commitment block (= the tip itself), and every FCU requiring a shallow reorg was rejected with `-38006 Too deep reorg`, permanently. Latent since before the exec3 split; exposed by #20495 (changesets near tip during initialCycle) and first hit on glamsterdam-devnet-5 (4-block reorg after a batch-executed tip, node bricked for 16h). Not devnet-specific: `EXEC3_PARALLEL` defaults to true, so any chain executing a >96-block batch was affected.

## Fix

- `changesetWindowStart` (new pure helper, `exec3.go`): first block of `[startBlockNum, maxBlockNum]` for which `shouldGenerateChangeSets` is true; `MaxUint64` when none. Single source of truth for both sides of the pipeline.
- Exec loop: `pe.shouldGenerateChangesets bool` → `pe.changesetWindowStart uint64`; `ensureChangesetAccumulator` gates per block, so the existing lazy install sites start capturing exactly at the window.
- Commitment calculator: new `perBlockFrom` — blocks `>= perBlockFrom` compute per-block (changesets get correct per-block branch deltas); the last pre-window block triggers `computeTransition`, which folds the accumulated batch prefix under a **nil** changeset accumulator and eagerly flushes the deferred branch update under the same swap. Without that, the no-saved-CS fallbacks (`computeWithBlockAccumulator`, `flushPendingUpdates`) would leak pre-window branch deltas into the first window block's changeset and corrupt the very unwind being enabled. A boundary flush also covers `BATCH_COMMITMENTS=false`, where pre-window blocks compute per-block too.

Serial exec is untouched.

## Tests

- `TestChangesetWindowStart` — table test for the window helper.
- `TestLargeBatchExecGeneratesChangesetsForReorgWindow` — e2e: a 110-block single-batch FCU must leave `ReadLowestUnwindableBlock == tip−96` (was `MaxUint64`).
- `TestUpdateForkChoiceShallowReorgAfterLargeBatchExec` — e2e incident replay: 110-block batch, then FCU onto a fork branching 4 blocks below tip must unwind + re-execute (was `ReorgTooDeep`). Also covers the calculator transition: leaked branch deltas would wrong-trie-root the fork re-exec.

Both e2e tests were written first and failed with the exact production error codes.

`execmoduletester` no longer hardcodes `AlwaysGenerateChangesets=true` (which had masked this bug from the entire suite) — it now inherits production defaults. Tests that intentionally reorg deeper than `MaxReorgDepth` (`TestLowDiffLongChain`, `TestLargeReorgTrieGC`) opt in via the new `WithAlwaysGenerateChangesets(true)`, mirroring `--experimental.always-generate-changesets`; the new regression tests pin `false`.

## Validation

- `make lint` clean; full `execution/...` + rpc/db/cl/polygon tester-consumer suites green; race detector on the new concurrency path.
- Live on glamsterdam-devnet-5 (erigon this branch + Prysm `glamsterdam-devnet-5` image): synced 0→tip through 5,000-block FCU batches; after every completed batch `reorgSafeBlock = batchEnd−96`; `mdbx_dump` of `ChangeSets3` shows exactly `[head−96, head]`; graceful restart + resync to tip with zero unwind-related errors.
