### PR TITLE
rpc fix legacy witness missing "0x" for new empty-code accounts

### DIFF
--- a/rpc/jsonrpc/debug_execution_witness.go
+++ b/rpc/jsonrpc/debug_execution_witness.go
@@ -142,11 +142,6 @@ func (s *RecordingState) ReadAccountData(address accounts.Address) (*accounts.Ac
 		return acc, nil
 	}
 	acc, err := s.inner.ReadAccountData(address)
-	if acc != nil && acc.IsEmptyCodeHash() {
-		// Pre-state load of an empty-code account materializes the empty
-		// bytecode (legacy's single empty entry); overlay reads are post-state.
-		s.emptyCodeAccessed = true
-	}
 	if s.tracing(addr) {
 		if acc != nil {
 			fmt.Printf("[TRACE] ReadAccountData %s -> inner nonce=%d balance=%d codeHash=%x\n", addr.Hex(), acc.Nonce, &acc.Balance, acc.CodeHash)
@@ -270,9 +265,8 @@ func (s *RecordingState) ReadAccountCode(address accounts.Address) ([]byte, erro
 				s.PreStateCode[addr] = code
 			}
 		}
-	} else {
-		s.emptyCodeAccessed = true
 	}
+	// Empty code means this is an EOA read, not a deployed-empty-code contract; do not set emptyCodeAccessed.
 	if s.tracing(addr) {
 		fmt.Printf("[TRACE] ReadAccountCode %s -> inner len=%d\n", addr.Hex(), len(code))
 	}
@@ -353,6 +347,8 @@ func (s *RecordingState) UpdateAccountCode(address accounts.Address, incarnation
 	s.ModifiedCode[addr] = common.Copy(code)
 	if len(code) > 0 {
 		s.createdCodeHashes[codeHash.Value()] = struct{}{}
+	} else {
+		s.emptyCodeAccessed = true
 	}
 	// Keep accountOverlay CodeHash in sync so ReadAccountData returns a
 	// consistent CodeHash even before UpdateAccountData is called.
@@ -984,6 +980,36 @@ func collectAccessedState(rs *RecordingState, mode witnessMode) *accessedState {
 			}
 		}
 		emptyEntry = rs.emptyCodeAccessed
+		// A CREATE that deploys empty code: Erigon's SetCode skips UpdateAccountCode
+		// when bytes.Equal(nil, []byte{}) is true, so emptyCodeAccessed is never set
+		// via UpdateAccountCode. Detect it here: any newly created contract whose
+		// final code hash is empty → one "0x" entry (matching Reth's bundle_state.contracts).
+		if !emptyEntry {
+			for addr := range rs.CreatedContracts {
+				if acc, ok := rs.accountOverlay[addr]; ok && acc != nil && acc.CodeHash.IsEmpty() {
+					emptyEntry = true
+					break
+				}
+			}
+		}
+
+		// Also emit "0x" when any account in accountOverlay has KECCAK_EMPTY code but
+		// did not exist in the pre-state. This mirrors Reth's has_new_contract() which
+		// fires when an account's code hash transitions from None (non-existent) to
+		// KECCAK_EMPTY. Covers: coinbase receiving fees for the first time, ETH
+		// transfers to brand-new addresses, etc.
+		if !emptyEntry {
+			for addr, overlaidAcc := range rs.accountOverlay {
+				if overlaidAcc == nil || !overlaidAcc.CodeHash.IsEmpty() {
+					continue
+				}
+				preAcc, _ := rs.inner.ReadAccountData(accounts.InternAddress(addr))
+				if preAcc == nil {
+					emptyEntry = true
+					break
+				}
+			}
+		}
 	}
 
 	uniqueCodes := make([][]byte, 0, len(allCodesByHash)+1)

--- a/rpc/jsonrpc/debug_execution_witness_test.go
+++ b/rpc/jsonrpc/debug_execution_witness_test.go
@@ -103,38 +103,91 @@ func hasEmptyCode(accessed *accessedState) bool {
 	return false
 }
 
-// TestEmptyCodeTrigger_OnAccountLoad asserts the legacy empty-`0x` entry is
-// emitted when an empty-code account is materialized, which happens on a plain
-// account load (ReadAccountData) as well as on a code load (ReadAccountCode).
-func TestEmptyCodeTrigger_OnAccountLoad(t *testing.T) {
-	emptyAcc := common.HexToAddress("0x1111111111111111111111111111111111111111")
+// TestEmptyCodeTrigger asserts when the legacy empty-"0x" entry is emitted and
+// when it is not. The trigger fires only when an account transitions from
+// non-existent (None) to existing-with-empty-code — matching Reth's
+// has_new_contract() — or when empty bytecode is explicitly deployed via
+// UpdateAccountCode. Reading an existing EOA must NOT trigger the entry.
+func TestEmptyCodeTrigger(t *testing.T) {
+	existingEOA := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	newAddr := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	contractAddr := common.HexToAddress("0x3333333333333333333333333333333333333333")
+
 	inner := &fakeStateReader{accounts: map[common.Address]*accounts.Account{
-		emptyAcc: {Nonce: 1},
+		existingEOA: {Nonce: 1},
 	}}
 
-	t.Run("data read triggers", func(t *testing.T) {
+	// Reading an existing EOA must NOT emit "0x" (regression: old code set
+	// emptyCodeAccessed on every empty-code account read, producing spurious entries).
+	t.Run("existing EOA data read does not trigger", func(t *testing.T) {
 		rs := NewRecordingState(inner)
-		if _, err := rs.ReadAccountData(accounts.InternAddress(emptyAcc)); err != nil {
+		if _, err := rs.ReadAccountData(accounts.InternAddress(existingEOA)); err != nil {
 			t.Fatal(err)
 		}
-		if !rs.emptyCodeAccessed {
-			t.Error("emptyCodeAccessed not set by an empty-code account data read")
-		}
-		if !hasEmptyCode(collectAccessedState(rs, witnessModeLegacy)) {
-			t.Error("empty 0x code entry missing after an empty-code account load")
+		if hasEmptyCode(collectAccessedState(rs, witnessModeLegacy)) {
+			t.Error("existing EOA read must not emit 0x in the legacy witness")
 		}
 	})
 
-	t.Run("code load triggers", func(t *testing.T) {
+	t.Run("existing EOA code read does not trigger", func(t *testing.T) {
 		rs := NewRecordingState(inner)
-		if _, err := rs.ReadAccountCode(accounts.InternAddress(emptyAcc)); err != nil {
+		if _, err := rs.ReadAccountCode(accounts.InternAddress(existingEOA)); err != nil {
 			t.Fatal(err)
 		}
-		if !rs.emptyCodeAccessed {
-			t.Error("emptyCodeAccessed not set by a code load")
+		if hasEmptyCode(collectAccessedState(rs, witnessModeLegacy)) {
+			t.Error("existing EOA code read must not emit 0x in the legacy witness")
+		}
+	})
+
+	// UpdateAccountCode with empty bytecode (e.g. CREATE2 deploying nothing) triggers.
+	t.Run("UpdateAccountCode empty code triggers", func(t *testing.T) {
+		rs := NewRecordingState(inner)
+		if err := rs.UpdateAccountCode(accounts.InternAddress(contractAddr), 1, accounts.EmptyCodeHash, []byte{}); err != nil {
+			t.Fatal(err)
 		}
 		if !hasEmptyCode(collectAccessedState(rs, witnessModeLegacy)) {
-			t.Error("empty 0x code entry missing after a code load")
+			t.Error("0x entry missing after UpdateAccountCode with empty bytecode")
+		}
+	})
+
+	// ETH transfer / coinbase receiving fees for the first time: account is new
+	// (not in pre-state) and ends up with empty code in the overlay.
+	t.Run("new account in overlay triggers", func(t *testing.T) {
+		rs := NewRecordingState(inner)
+		// newAddr is not in inner (pre-state); simulate its creation via the public API.
+		if err := rs.UpdateAccountData(accounts.InternAddress(newAddr), nil, &accounts.Account{Nonce: 0}); err != nil {
+			t.Fatal(err)
+		}
+		if !hasEmptyCode(collectAccessedState(rs, witnessModeLegacy)) {
+			t.Error("0x entry missing for a brand-new account with empty code in the overlay")
+		}
+	})
+
+	// An existing account modified in-block keeps its empty code but must NOT
+	// trigger an extra "0x" — it already existed in the pre-state.
+	t.Run("existing account updated in overlay does not trigger", func(t *testing.T) {
+		rs := NewRecordingState(inner)
+		original := &accounts.Account{Nonce: 1}
+		if err := rs.UpdateAccountData(accounts.InternAddress(existingEOA), original, &accounts.Account{Nonce: 2}); err != nil {
+			t.Fatal(err)
+		}
+		if hasEmptyCode(collectAccessedState(rs, witnessModeLegacy)) {
+			t.Error("updating an existing EOA in the overlay must not emit 0x")
+		}
+	})
+
+	// CREATE that deploys empty bytecode detected via CreatedContracts loop
+	// (Erigon's SetCode skips UpdateAccountCode when code is nil/empty).
+	t.Run("CreateContract with empty code overlay triggers", func(t *testing.T) {
+		rs := NewRecordingState(inner)
+		if err := rs.CreateContract(accounts.InternAddress(contractAddr)); err != nil {
+			t.Fatal(err)
+		}
+		if err := rs.UpdateAccountData(accounts.InternAddress(contractAddr), nil, &accounts.Account{}); err != nil {
+			t.Fatal(err)
+		}
+		if !hasEmptyCode(collectAccessedState(rs, witnessModeLegacy)) {
+			t.Error("0x entry missing for a CREATE with empty code detected via CreatedContracts")
 		}
 	})
 }


### PR DESCRIPTION
In legacy mode, debug_executionWitness must emit a single "0x" entry in the codes array whenever an account transitions from non-existent to existing-with-empty-code (KECCAK_EMPTY). This mirrors Reth's has_new_contract() which fires on a None→KECCAK_EMPTY code-hash transition and covers: coinbase receiving fees for the first time, ETH transfers to brand-new addresses, and CREATEs that deploy empty bytecode.

Previously emptyCodeAccessed was set on every read of any EOA with empty code, producing spurious "0x" entries for pre-existing accounts. Now the flag is set only in UpdateAccountCode (explicit empty-code deploy) and via two post-execution scans in collectAccessedState:
- CreatedContracts loop: catches CREATEs where Erigon's SetCode skips UpdateAccountCode for nil/empty bytecode
- accountOverlay loop: catches coinbase and ETH-transfer recipients whose pre-state entry is nil

Update TestEmptyCodeTrigger to cover the new semantics and add regression sub-tests asserting that reading an existing EOA no longer triggers the empty-code entry.

Note:
debug_executionWitness() is run against all Hive chain blocks in both legacy and canonical modes, and now the codes field matches Reth's response in every case.