### PR TITLE
execution/stagedsync: fix receipt transaction index in serial execution

### DIFF
--- a/db/rawdb/accessors_chain.go
+++ b/db/rawdb/accessors_chain.go
@@ -1365,6 +1365,9 @@ func WriteReceiptCacheV2(tx kv.TemporalPutDel, receipt *types.Receipt, txNum uin
 			if storageReceipt.FirstLogIndexWithinBlock != storageReceipt2.FirstLogIndexWithinBlock {
 				panic(fmt.Sprintf("assert: %x, %x\n", storageReceipt.FirstLogIndexWithinBlock, storageReceipt2.FirstLogIndexWithinBlock))
 			}
+			if storageReceipt.TransactionIndex != storageReceipt2.TransactionIndex {
+				panic(fmt.Sprintf("assert: TransactionIndex mismatch: %d, %d\n", storageReceipt.TransactionIndex, storageReceipt2.TransactionIndex))
+			}
 		}
 	} else {
 		toWrite = []byte{}

--- a/execution/exec/txtask_test.go
+++ b/execution/exec/txtask_test.go
@@ -21,7 +21,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/crypto"
+	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/execution/vm/evmtypes"
 )
 
 // TestAwaitDrainExitsOnContextCancel reproduces the infinite-loop described in
@@ -82,4 +89,68 @@ func TestAwaitDrainExitsOnContextCancel(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		t.Fatal("AwaitDrain did not respect context cancellation – infinite loop detected (issue #18252)")
 	}
+}
+
+// TestCreateReceiptTxIndex verifies the invariant that CreateReceipt assigns the local
+// block transaction index parameter directly to the receipt's TransactionIndex, preventing
+// regressions where the global TxNum is leaked into the receipt during partial block recovery.
+func TestCreateReceiptTxIndex(t *testing.T) {
+	t.Parallel()
+
+	const (
+		txIndex       = 196
+		firstLogIndex = 7
+	)
+	const (
+		txNum           uint64 = 3_548_828_125
+		priorCumGasUsed uint64 = 47_198_456
+		receiptGasUsed  uint64 = 21_000
+		blockNumber     uint64 = 25_200_946
+	)
+
+	key, err := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	require.NoError(t, err)
+	to := crypto.PubkeyToAddress(key.PublicKey)
+	config := chain.TestChainBerlinConfig
+	signer := types.MakeSigner(config, blockNumber, 0)
+	signedTx, err := types.SignTx(&types.LegacyTx{
+		CommonTx: types.CommonTx{
+			Nonce:    0,
+			To:       &to,
+			Value:    *uint256.NewInt(0),
+			GasLimit: receiptGasUsed,
+		},
+		GasPrice: *uint256.NewInt(1),
+	}, *signer, key)
+	require.NoError(t, err)
+
+	txs := make(types.Transactions, txIndex+1)
+	txs[txIndex] = signedTx
+	txTask := &TxTask{
+		TxNum:   txNum,
+		TxIndex: txIndex,
+		Header:  &types.Header{Number: *uint256.NewInt(blockNumber)},
+		Txs:     txs,
+		Config:  config,
+	}
+	result := &TxResult{
+		Task: txTask,
+		ExecutionResult: evmtypes.ExecutionResult{
+			ReceiptGasUsed: receiptGasUsed,
+		},
+		Logs: []*types.Log{{}},
+	}
+
+	receipt, err := result.CreateReceipt(txTask.TxIndex, priorCumGasUsed+result.ExecutionResult.ReceiptGasUsed, firstLogIndex)
+	require.NoError(t, err)
+
+	require.Equal(t, uint(txIndex), receipt.TransactionIndex)
+	require.NotEqual(t, uint(txNum), receipt.TransactionIndex)
+	require.Equal(t, signedTx.Hash(), receipt.TxHash)
+	require.Equal(t, txTask.BlockHash(), receipt.BlockHash)
+	require.Equal(t, priorCumGasUsed+receiptGasUsed, receipt.CumulativeGasUsed)
+	require.Equal(t, receiptGasUsed, receipt.GasUsed)
+	require.Equal(t, uint32(firstLogIndex), receipt.FirstLogIndexWithinBlock)
+	require.Len(t, receipt.Logs, 1)
+	require.Equal(t, hexutil.Uint(firstLogIndex), receipt.Logs[0].Index)
 }

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -461,7 +461,7 @@ func (se *serialExecutor) executeBlock(ctx context.Context, tasks []exec.Task, i
 					if err != nil {
 						return err
 					}
-					receipt, err = result.CreateReceipt(int(txTask.TxNum), cumGasUsed+result.ExecutionResult.ReceiptGasUsed, logIndexAfterTx)
+					receipt, err = result.CreateReceipt(txTask.TxIndex, cumGasUsed+result.ExecutionResult.ReceiptGasUsed, logIndexAfterTx)
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
### Issue
Actually, during sync, when Erigon resumes processing blocks from a snapshot boundary, it does a partial block execution. While executing this, the first receipt in the block was being reconstructed with a wrong transaction index. The code in `exec3_serial.go` was passing the global transaction number (`txTask.TxNum`, which is a very big number like 3.5 billion) instead of the within-block local index (`txTask.TxIndex`) to the `CreateReceipt` function. This wrong transaction index got persisted directly into the database `RCacheDomain` when `--persist.receipts=true` was enabled. Because of this, RPC methods like `eth_getTransactionReceipt` returned corrupted index values and `eth_getBlockReceipts` failed with out-of-range errors.

### Fix
updated the `CreateReceipt` call inside the partial block recovery path of `exec3_serial.go` to use `txTask.TxIndex` instead of `int(txTask.TxNum)`. This fixes the root logical issue and saves the correct transaction index in the database. We also added an assertion check in `WriteReceiptCacheV2` to make sure the `TransactionIndex` field is correctly serialized and deserialized during RLP encoding.

### Tests
added unit test `TestCreateReceiptTxIndex` inside `txtask_test.go` that verifies that `CreateReceipt` derives `TransactionIndex` from the local block transaction index parameter and not from the task's global `TxNum`. 

Closes: https://github.com/erigontech/erigon/issues/21658