### PR TITLE
ci: fix update-disk-sizes push rejection (use GitHub App token)

### DIFF
--- a/.github/workflows/update-disk-sizes.yml
+++ b/.github/workflows/update-disk-sizes.yml
@@ -91,10 +91,19 @@ jobs:
             printf 'base_branch=release/3.4\n' >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Generate GitHub App token
+        id: app_token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  ## v3.1.1
+        with:
+          client-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
+          repositories: "erigon"
+
       - name: Checkout base branch
         uses: actions/checkout@v6
         with:
           ref: ${{ steps.determine.outputs.base_branch }}
+          token: ${{ steps.app_token.outputs.token }}
           persist-credentials: true
 
       - name: Prepare update branch
@@ -183,7 +192,7 @@ jobs:
       - name: Create or update draft PR
         if: steps.diff.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
           BASE_BRANCH: ${{ steps.determine.outputs.base_branch }}
         run: |
           set -euo pipefail

--- a/docs/site/src/data/disk-sizes.json
+++ b/docs/site/src/data/disk-sizes.json
@@ -40,6 +40,66 @@
         "measured_at": "2025-09-01",
         "source": "manual"
       }
+    },
+    "chiado": {
+      "archive": {
+        "bytes": null,
+        "display": null,
+        "measured_at": null,
+        "source": "ci"
+      },
+      "full": {
+        "bytes": null,
+        "display": null,
+        "measured_at": null,
+        "source": "ci"
+      },
+      "minimal": {
+        "bytes": null,
+        "display": null,
+        "measured_at": null,
+        "source": "ci"
+      }
+    },
+    "sepolia": {
+      "archive": {
+        "bytes": null,
+        "display": null,
+        "measured_at": null,
+        "source": "ci"
+      },
+      "full": {
+        "bytes": null,
+        "display": null,
+        "measured_at": null,
+        "source": "ci"
+      },
+      "minimal": {
+        "bytes": null,
+        "display": null,
+        "measured_at": null,
+        "source": "ci"
+      }
+    },
+    "hoodi": {
+      "archive": {
+        "bytes": null,
+        "display": null,
+        "measured_at": null,
+        "source": "ci"
+      },
+      "full": {
+        "bytes": null,
+        "display": null,
+        "measured_at": null,
+        "source": "ci"
+      },
+      "minimal": {
+        "bytes": null,
+        "display": null,
+        "measured_at": null,
+        "source": "ci"
+      }
     }
   }
 }

--- a/docs/site/src/data/disk-sizes.json
+++ b/docs/site/src/data/disk-sizes.json
@@ -40,66 +40,6 @@
         "measured_at": "2025-09-01",
         "source": "manual"
       }
-    },
-    "chiado": {
-      "archive": {
-        "bytes": null,
-        "display": null,
-        "measured_at": null,
-        "source": "ci"
-      },
-      "full": {
-        "bytes": null,
-        "display": null,
-        "measured_at": null,
-        "source": "ci"
-      },
-      "minimal": {
-        "bytes": null,
-        "display": null,
-        "measured_at": null,
-        "source": "ci"
-      }
-    },
-    "sepolia": {
-      "archive": {
-        "bytes": null,
-        "display": null,
-        "measured_at": null,
-        "source": "ci"
-      },
-      "full": {
-        "bytes": null,
-        "display": null,
-        "measured_at": null,
-        "source": "ci"
-      },
-      "minimal": {
-        "bytes": null,
-        "display": null,
-        "measured_at": null,
-        "source": "ci"
-      }
-    },
-    "hoodi": {
-      "archive": {
-        "bytes": null,
-        "display": null,
-        "measured_at": null,
-        "source": "ci"
-      },
-      "full": {
-        "bytes": null,
-        "display": null,
-        "measured_at": null,
-        "source": "ci"
-      },
-      "minimal": {
-        "bytes": null,
-        "display": null,
-        "measured_at": null,
-        "source": "ci"
-      }
     }
   }
 }


### PR DESCRIPTION
## Problem

The **Docs - Update disk sizes** workflow has been failing consistently since 2026-06-03 at the **Commit and push to update branch** step with:

```
! [remote rejected] docs/auto/disk-sizes-release-3.4 -> docs/auto/disk-sizes-release-3.4
(Unable to determine if workflow can be created or updated due to timeout; `workflows` scope may be required.)
```

`GITHUB_TOKEN` doesn't have the `workflows` scope. When GitHub times out verifying whether the push modifies workflow files, it rejects the push as a safety measure — even though the branch only contains `disk-sizes.json` changes.

## Fix

Use the same `RELEASE_BOT_APP_ID` / `RELEASE_BOT_APP_KEY` GitHub App token pattern already established in `release.yml`. The app token is:
- Passed to `actions/checkout` via `token:` so `persist-credentials: true` picks it up for the subsequent `git push`
- Used as `GH_TOKEN` in the `gh pr create` step

No other changes — artifacts download keeps `GITHUB_TOKEN` which is sufficient for `actions/download-artifact`.

## Checklist
- [x] Matches the established pattern in `release.yml`
- [x] `RELEASE_BOT_APP_ID` / `RELEASE_BOT_APP_KEY` secrets already exist in this repo