### PR TITLE
execution/stagedsync: parallel-exec - flush invalid-tx writes as Estimate

### DIFF
--- a/execution/exec/txtask.go
+++ b/execution/exec/txtask.go
@@ -223,7 +223,6 @@ type TxTask struct {
 	HistoryExecution   bool // use history reader for that txn instead of state reader
 	BalanceIncreaseSet map[accounts.Address]uint256.Int
 
-	Incarnation           int
 	Tracer                *calltracer.CallTracer
 	Hooks                 *tracing.Hooks
 	Config                *chain.Config

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1707,17 +1707,6 @@ func (result *execResult) calcFees(
 	// and normalizeWriteSet's sdSet filter drops them.
 	coinbaseEmptyPre := (coinbaseAcc == nil || coinbaseAcc.Balance.IsZero()) &&
 		coinbaseNonce == 0 && coinbaseEmptyCodeHash && !coinbaseHasCodeHashWrite
-	// vsReader hides Estimate-flagged prior writes as "not found"; emptiness
-	// is indeterminate when any account-state path has an Estimate floor, so
-	// suppress the EIP-161 SD-emit path until re-execution sees a Done write.
-	if coinbaseEmptyPre {
-		for _, p := range [...]state.AccountPath{state.AddressPath, state.BalancePath, state.NoncePath, state.CodeHashPath} {
-			if vm.Read(result.Coinbase, p, accounts.NilKey, txIndex).Status() == state.MVReadResultDependency {
-				coinbaseEmptyPre = false
-				break
-			}
-		}
-	}
 	emitCoinbase := newCoinbaseBalance != oldCoinbaseBalance ||
 		(emptyRemoval && coinbaseEmptyPre && newCoinbaseBalance.IsZero())
 

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1185,24 +1185,6 @@ func (pe *parallelExecutor) processRequest(ctx context.Context, execRequest *exe
 // path into a spurious InvalidBlock error — the BenchmarkFeeHistory
 // 200-block fixture exhausts the 5MB batch budget at block 114 and
 // previously errored despite blocks 1..114 being applied cleanly.
-//
-// applyLoopFlushAsComplete decides the `complete` flag the apply loop passes
-// to versionMap.FlushVersionedWrites. A tx's writes can only be flagged Done
-// (vs Estimate) when:
-//   - this tx itself passed validation (`valid`), AND
-//   - no prior tx in the same validation iteration failed (`cntInvalid == 0`).
-//
-// The `valid` term is the regression guard for the gnosis-block-18,483,405
-// phantom-write bug: `cntInvalid` counts *prior* invalid txs in the iteration
-// only, so a current tx with VersionInvalid verdict would otherwise be flushed
-// as Done and become visible to downstream OCC readers as committed state.
-// See TestApplyLoopFlush_InvalidTxWritesAreEstimate.
-func applyLoopFlushAsComplete(valid bool, cntInvalid int) bool {
-	return valid && cntInvalid == 0
-}
-
-// Pure function — extracted from the apply loop's channel-close branch
-// so the invariant is unit-testable. See TestApplyLoopMissingBlocks.
 func applyLoopMissingBlocks(txResultBlocks, appliedBlocks map[uint64]struct{}) []uint64 {
 	var missing []uint64
 	for n := range txResultBlocks {
@@ -1211,6 +1193,16 @@ func applyLoopMissingBlocks(txResultBlocks, appliedBlocks map[uint64]struct{}) [
 		}
 	}
 	return missing
+}
+
+// applyLoopFlushAsComplete returns the `complete` flag for
+// versionMap.FlushVersionedWrites. cntInvalid counts only prior
+// VersionTooEarly txs in the current iteration — not the current tx's own
+// VersionInvalid verdict — so the `valid` term is required to prevent an
+// invalidated tx's writes being flushed as Done and read as committed by
+// downstream OCC consumers.
+func applyLoopFlushAsComplete(valid bool, cntInvalid int) bool {
+	return valid && cntInvalid == 0
 }
 
 // execLoopExitDecision is the result of evaluating the exec-loop's
@@ -2389,12 +2381,9 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 		tx := toValidate[i]
 		txTask := be.tasks[tx].Task
 		txResult := be.results[tx]
-		// Each scheduled run wraps the task in a fresh *taskVersion whose
-		// Version() carries the current Incarnation (set in scheduleExecution).
-		// Reading from the result's task surfaces that incarnation; reading
-		// from be.tasks[tx].Task (the bare TxTask) returns the structural
-		// Version() which never advances Incarnation past 0 — making this
-		// txVersion misleading on retries.
+		// txResult.Task is the *taskVersion wrapper from this scheduled run,
+		// carrying the current Incarnation. be.tasks[tx].Task is the bare
+		// TxTask whose Version().Incarnation never advances past 0.
 		txVersion := txResult.Task.Version()
 
 		var trace bool
@@ -2462,16 +2451,6 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 
 		be.versionMap.SetTrace(trace)
 		writeSet := be.blockIO.WriteSet(txVersion.TxIndex)
-		// OCC invariant: `Done` means committed. `cntInvalid` here only counts
-		// *prior* tooEarly txs in this iteration, so it does NOT include this
-		// tx's own VersionInvalid verdict. Without `valid` an invalidated tx's
-		// writes would be flushed as Done and become visible to downstream
-		// readers as committed phantoms (see
-		// TestApplyLoopFlush_InvalidTxWritesAreEstimate). The Estimate flag
-		// instead causes downstream reads of these cells to return
-		// MVReadResultDependency, which the validator treats as
-		// VersionInvalid — forcing the dependent tx to re-execute after the
-		// retry settles, restoring OCC's "Done = committed" invariant.
 		be.versionMap.FlushVersionedWrites(writeSet, applyLoopFlushAsComplete(valid, cntInvalid), tracePrefix)
 		be.versionMap.SetTrace(false)
 

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1183,6 +1183,21 @@ func (pe *parallelExecutor) processRequest(ctx context.Context, execRequest *exe
 // 200-block fixture exhausts the 5MB batch budget at block 114 and
 // previously errored despite blocks 1..114 being applied cleanly.
 //
+// applyLoopFlushAsComplete decides the `complete` flag the apply loop passes
+// to versionMap.FlushVersionedWrites. A tx's writes can only be flagged Done
+// (vs Estimate) when:
+//   - this tx itself passed validation (`valid`), AND
+//   - no prior tx in the same validation iteration failed (`cntInvalid == 0`).
+//
+// The `valid` term is the regression guard for the gnosis-block-18,483,405
+// phantom-write bug: `cntInvalid` counts *prior* invalid txs in the iteration
+// only, so a current tx with VersionInvalid verdict would otherwise be flushed
+// as Done and become visible to downstream OCC readers as committed state.
+// See TestApplyLoopFlush_InvalidTxWritesAreEstimate.
+func applyLoopFlushAsComplete(valid bool, cntInvalid int) bool {
+	return valid && cntInvalid == 0
+}
+
 // Pure function — extracted from the apply loop's channel-close branch
 // so the invariant is unit-testable. See TestApplyLoopMissingBlocks.
 func applyLoopMissingBlocks(txResultBlocks, appliedBlocks map[uint64]struct{}) []uint64 {
@@ -2369,9 +2384,15 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 		be.cntTotalValidations++
 
 		tx := toValidate[i]
-		txVersion := be.tasks[tx].Task.Version()
 		txTask := be.tasks[tx].Task
 		txResult := be.results[tx]
+		// Each scheduled run wraps the task in a fresh *taskVersion whose
+		// Version() carries the current Incarnation (set in scheduleExecution).
+		// Reading from the result's task surfaces that incarnation; reading
+		// from be.tasks[tx].Task (the bare TxTask) returns the structural
+		// Version() which never advances Incarnation past 0 — making this
+		// txVersion misleading on retries.
+		txVersion := txResult.Task.Version()
 
 		var trace bool
 		var tracePrefix string
@@ -2438,7 +2459,17 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 
 		be.versionMap.SetTrace(trace)
 		writeSet := be.blockIO.WriteSet(txVersion.TxIndex)
-		be.versionMap.FlushVersionedWrites(writeSet, cntInvalid == 0, tracePrefix)
+		// OCC invariant: `Done` means committed. `cntInvalid` here only counts
+		// *prior* tooEarly txs in this iteration, so it does NOT include this
+		// tx's own VersionInvalid verdict. Without `valid` an invalidated tx's
+		// writes would be flushed as Done and become visible to downstream
+		// readers as committed phantoms (see
+		// TestApplyLoopFlush_InvalidTxWritesAreEstimate). The Estimate flag
+		// instead causes downstream reads of these cells to return
+		// MVReadResultDependency, which the validator treats as
+		// VersionInvalid — forcing the dependent tx to re-execute after the
+		// retry settles, restoring OCC's "Done = committed" invariant.
+		be.versionMap.FlushVersionedWrites(writeSet, applyLoopFlushAsComplete(valid, cntInvalid), tracePrefix)
 		be.versionMap.SetTrace(false)
 
 		if valid {

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1707,6 +1707,17 @@ func (result *execResult) calcFees(
 	// and normalizeWriteSet's sdSet filter drops them.
 	coinbaseEmptyPre := (coinbaseAcc == nil || coinbaseAcc.Balance.IsZero()) &&
 		coinbaseNonce == 0 && coinbaseEmptyCodeHash && !coinbaseHasCodeHashWrite
+	// vsReader hides Estimate-flagged prior writes as "not found"; emptiness
+	// is indeterminate when any account-state path has an Estimate floor, so
+	// suppress the EIP-161 SD-emit path until re-execution sees a Done write.
+	if coinbaseEmptyPre {
+		for _, p := range [...]state.AccountPath{state.AddressPath, state.BalancePath, state.NoncePath, state.CodeHashPath} {
+			if vm.Read(result.Coinbase, p, accounts.NilKey, txIndex).Status() == state.MVReadResultDependency {
+				coinbaseEmptyPre = false
+				break
+			}
+		}
+	}
 	emitCoinbase := newCoinbaseBalance != oldCoinbaseBalance ||
 		(emptyRemoval && coinbaseEmptyPre && newCoinbaseBalance.IsZero())
 

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1196,9 +1196,9 @@ func applyLoopMissingBlocks(txResultBlocks, appliedBlocks map[uint64]struct{}) [
 }
 
 // applyLoopFlushAsComplete returns the `complete` flag for
-// versionMap.FlushVersionedWrites. cntInvalid counts only prior
-// VersionTooEarly txs in the current iteration — not the current tx's own
-// VersionInvalid verdict — so the `valid` term is required to prevent an
+// versionMap.FlushVersionedWrites. cntInvalid counts prior VersionTooEarly
+// and VersionInvalid txs seen earlier in this iteration but excludes the
+// current tx's own verdict, so the `valid` term is required to prevent an
 // invalidated tx's writes being flushed as Done and read as committed by
 // downstream OCC consumers.
 func applyLoopFlushAsComplete(valid bool, cntInvalid int) bool {

--- a/execution/stagedsync/exec3_parallel_robustness_test.go
+++ b/execution/stagedsync/exec3_parallel_robustness_test.go
@@ -18,8 +18,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/execution/protocol/rules"
+	"github.com/erigontech/erigon/execution/state"
+	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
 // TestApplyLoopMissingBlocks covers the pure completeness-check helper.
@@ -781,4 +787,131 @@ func sameSet(a, b []uint64) bool {
 		}
 	}
 	return true
+}
+
+// TestApplyLoopFlushAsComplete covers the helper that decides the `complete`
+// flag the apply loop passes to versionMap.FlushVersionedWrites. The `valid`
+// term in this helper is the regression guard for the gnosis-block-18,483,405
+// phantom-write bug: a current tx with a VersionInvalid verdict must NOT
+// flush its writes as Done, otherwise downstream OCC readers see them as
+// committed.
+func TestApplyLoopFlushAsComplete(t *testing.T) {
+	tests := []struct {
+		name       string
+		valid      bool
+		cntInvalid int
+		want       bool
+	}{
+		{
+			name:       "valid current tx, no prior invalids → Done",
+			valid:      true,
+			cntInvalid: 0,
+			want:       true,
+		},
+		{
+			// Regression guard for the gnosis-18,483,405 phantom-write bug:
+			// before this fix the apply loop only checked cntInvalid (which
+			// counts *prior* invalids), so an invalid current tx fell through
+			// as `complete=true → Done` and produced phantom committed entries.
+			name:       "INVALID current tx → must NOT be Done (phantom-write guard)",
+			valid:      false,
+			cntInvalid: 0,
+			want:       false,
+		},
+		{
+			name:       "valid current but prior invalid in iteration → Estimate",
+			valid:      true,
+			cntInvalid: 1,
+			want:       false,
+		},
+		{
+			name:       "INVALID current and prior invalid → Estimate",
+			valid:      false,
+			cntInvalid: 1,
+			want:       false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, applyLoopFlushAsComplete(tc.valid, tc.cntInvalid),
+				"applyLoopFlushAsComplete(valid=%v, cntInvalid=%d)", tc.valid, tc.cntInvalid)
+		})
+	}
+}
+
+// TestApplyLoopFlush_InvalidTxWritesAreEstimate reproduces the bug-scenario
+// at the VersionMap layer using the production flush-decision helper.
+//
+// Repro recipe from gnosis block 18,483,405:
+//
+//  1. tx[3] inc=0 executed, EVM did NOT revert, and emitted 28 storage writes
+//     (one of them: contract 0x18b2b767… slot 0x08 = `aabS…0b886…5981`).
+//  2. Apply loop's ValidateVersionBlock returned VersionInvalid (some read no
+//     longer matched versionMap).
+//  3. Apply loop then called FlushVersionedWrites with `cntInvalid == 0` as
+//     the `complete` flag — true, because cntInvalid counts only *prior*
+//     invalid txs in the current iteration. The 28 writes were stored as
+//     flag=Done.
+//  4. tx[16] subsequently read slot 8, got `aabS…` via MapRead, recorded
+//     readVersion=tx[3]:inc0. Version-only validation passed.
+//  5. Downstream gas-mismatch ~80K blocks later from the phantom-derived state
+//     cascading through the tx queue.
+//
+// The fix at exec3_parallel.go:applyLoopFlushAsComplete folds `valid` into
+// the gating so an invalidated tx's writes are flushed as Estimate. This test
+// asserts the downstream effect: a tx that later reads the slot must see
+// MVReadResultDependency (the validator treats this as VersionInvalid and
+// forces re-execution), not MVReadResultDone.
+func TestApplyLoopFlush_InvalidTxWritesAreEstimate(t *testing.T) {
+	addr := accounts.InternAddress(common.HexToAddress("0x18b2b7673c6d661923e9460d592699617828b293"))
+	slot := accounts.InternKey(common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000008"))
+
+	vm := state.NewVersionMap(nil)
+
+	// Simulate the apply loop processing tx=3 with validity=VersionInvalid in
+	// the first iteration of toValidate (cntInvalid starts at 0).
+	const invalidTxIdx = 3
+	const invalidTxInc = 0
+	phantomVal := *uint256.NewInt(0xaabb)
+
+	invalidTxWrites := state.VersionedWrites{
+		{
+			Address: addr,
+			Path:    state.StoragePath,
+			Key:     slot,
+			Version: state.Version{TxIndex: invalidTxIdx, Incarnation: invalidTxInc},
+			Val:     phantomVal,
+		},
+	}
+
+	// Drive the production flush-decision helper end-to-end.
+	valid := false  // validity == VersionInvalid
+	cntInvalid := 0 // no prior invalids in this iteration
+	complete := applyLoopFlushAsComplete(valid, cntInvalid)
+	require.False(t, complete,
+		"invalidated tx must flush as Estimate (not Done) — see "+
+			"TestApplyLoopFlushAsComplete for the unit-level guard")
+
+	vm.FlushVersionedWrites(invalidTxWrites, complete, "")
+
+	// Downstream tx=16 reads the slot — this is the read that committed
+	// phantom state in the bug.
+	const downstreamTxIdx = 16
+	res := vm.Read(addr, state.StoragePath, slot, downstreamTxIdx)
+
+	// MVReadResultDependency: the validator will treat any read of this cell
+	// as VersionInvalid, forcing the reader to re-execute. This is correct
+	// OCC behavior when an invalidated tx is awaiting retry.
+	require.Equal(t, state.MVReadResultDependency, res.Status(),
+		"invalid tx's writes must be flushed as Estimate so downstream reads "+
+			"return MVReadResultDependency. Pre-fix, this returned "+
+			"MVReadResultDone and downstream txs committed phantom state "+
+			"(gnosis block 18,483,405 repro).")
+
+	// Sanity: the entry IS recorded against tx[3] in versionMap (Estimate, not
+	// absent), so downstream readers' OCC dependency tracking still works.
+	require.Equal(t, invalidTxIdx, res.DepIdx(),
+		"phantom write is recorded as Estimate, not deleted — downstream "+
+			"OCC must still see it as a dependency")
 }

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -352,7 +352,11 @@ func (vr *versionedStateReader) ReadAccountData(address accounts.Address) (*acco
 }
 
 func versionedUpdate[T any](versionMap *VersionMap, addr accounts.Address, path AccountPath, key accounts.StorageKey, txIndex int) (T, bool) {
-	if res := versionMap.Read(addr, path, key, txIndex); res.Status() == MVReadResultDone {
+	// A Dependency (Estimate) cell holds the same latest in-block write a Done
+	// cell does; finalize reconstruction must consume it, not fall back to the
+	// pre-block DB value — doing so commits stale state once invalidated txs
+	// flush Estimate instead of Done.
+	if res := versionMap.Read(addr, path, key, txIndex); res.Status() != MVReadResultNone {
 		return res.Value().(T), true
 	}
 	var v T


### PR DESCRIPTION
## Summary

Fixes a parallel-exec OCC correctness bug: the apply loop was flushing
writes from txs that **failed validation** (`VersionInvalid`) with the
`complete=Done` flag, leaking phantom committed state into the versionMap
where downstream readers picked it up.

## Symptoms before this fix

- **Intermittent wrong-trie-root failures** during from-genesis parallel
  sync (PR #21591 made `EXEC3_PARALLEL=true` the default).
- **Pattern-2 family**: gas-mismatch failures on DEX strategy contracts,
  especially in the gnosis 14.8M-18.5M block range.
- **Cascading mis-execution**: a phantom write at tx[N] is picked up by
  tx[N+k] via `MapRead`. Version-only validation passes because
  `readVersion == writtenVersion`. The downstream tx commits state derived
  from the phantom, and the divergence surfaces as a gas-mismatch tens of
  thousands of blocks later.

Captured deterministically at gnosis block **18,483,405**: tx[3] inc=0
was flagged Invalid by `ValidateVersionBlock`, but its 28 writes were
flushed with `complete=true` because `cntInvalid == 0` (the counter only
tracks *prior* `VersionTooEarly` txs). Slot 0x08 on contract
`0x18b2b7673c6d661923e9460d592699617828b293` was stored with value
`aabS...5981`. tx[16] subsequently read that phantom via `MapRead` and
committed phantom-derived state. The cascade surfaced as a gas-mismatch
roughly 80K blocks downstream.

## Fix

New helper `applyLoopFlushAsComplete(valid, cntInvalid) = valid && cntInvalid == 0`
gates the `complete` flag. An invalidated tx now flushes as **Estimate**,
which causes downstream reads of those cells to return
`MVReadResultDependency`. The validator treats that as `VersionInvalid`,
forcing the dependent tx to re-execute after the retry settles - restoring
OCC's \`Done = committed\` invariant.

Companion clarity changes in the same files:

- \`exec3_parallel.go\`: read \`txVersion\` from \`txResult.Task.Version()\`
  (the \`*taskVersion\` wrapper that carries the current \`Incarnation\`)
  instead of bare \`TxTask\` which always returns \`Incarnation=0\`. Logs
  and traces now show the correct incarnation on retries.
- \`txtask.go\`: drop the dead \`TxTask.Incarnation\` field. Live source of
  truth is the \`txIncarnations\` counter plus the \`taskVersion\` wrapper.

## Verification

- **Unit tests** (\`execution/stagedsync/exec3_parallel_robustness_test.go\`):
  - \`TestApplyLoopFlushAsComplete\` - 4-case truth-table on the helper,
    including the regression guard case "INVALID current tx -> must NOT be Done".
  - \`TestApplyLoopFlush_InvalidTxWritesAreEstimate\` - drives the
    production helper through a real \`VersionMap\` using the gnosis
    18,483,405 contract+slot, asserts downstream read returns
    \`MVReadResultDependency\` (not \`MVReadResultDone\`).
  - Both confirmed to FAIL with the helper temporarily reverted to
    \`cntInvalid == 0\`, PASS with the fix.

- **Gnosis oracle CHECK** (live): swept blocks **18.46M-18.70M+ end-to-end**
  with zero \`STATE-ORACLE-DIVERGENCE\` events, zero gas-mismatch, zero
  wrong-trie-root.

- **From-genesis resync** (live): currently past historical fail blocks
  **14,837,280 / 14,845,967 / 16,420,113** without recurrence; still in
  progress through the rest of the 14.8M-18.5M range.

## Milestone

**Needs to be merged before 3.5 is cut.** With PR #21591 making
\`EXEC3_PARALLEL=true\` the default on main, this bug class affects all
3.5+ users running parallel execution. Marked for the 3.5.0 milestone.

## Test plan

- [ ] CI green
- [ ] Reviewer checks the helper's truth-table covers all four
      \`(valid, cntInvalid)\` cases
- [ ] Reviewer confirms the \`MVReadResultDependency\` -> validator
      -> re-exec path closes the OCC invariant