### PR TITLE
cmd/utils/app: fix publishable check failing on empty caplin state tables

### DIFF
--- a/cmd/utils/app/publishable_check_test.go
+++ b/cmd/utils/app/publishable_check_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/snapshotsync"
 	"github.com/erigontech/erigon/db/snaptype"
 	"github.com/stretchr/testify/require"
@@ -169,6 +170,32 @@ func Test_VersionMoreThanCurrent(t *testing.T) {
 
 	delFile(t, dirs.SnapCaplin, "v20.0-000010-000020-ActiveValidatorIndicies.idx")
 	require.NoError(t, checkIfCaplinSnapshotsPublishable(dirs, false))
+}
+
+// A pre-GLOAS datadir registers the GLOAS (EIP-7732) state tables but has no
+// files for them. Publishable must tolerate fully-empty registered tables and
+// must not depend on map iteration order (the empty tables must not poison the
+// last-file-to reference of the present ones).
+func Test_CheckEmptyFutureForkTablesTolerated(t *testing.T) {
+	emptyTables := []string{
+		kv.Builders, kv.BuildersDump,
+		kv.BuilderPendingWithdrawals, kv.BuilderPendingWithdrawalsDump,
+		kv.PayloadExpectedWithdrawals, kv.PayloadExpectedWithdrawalsDump,
+		kv.ExecutionPayloadAvailabilityTable, kv.BuilderPendingPaymentsTable,
+		kv.PtcWindowTable, kv.LatestExecutionPayloadBidTable,
+	}
+	ranges := []snapRange{{0, 10}, {10, 20}, {20, 30}}
+	for i := 0; i < 30; i++ {
+		dirs := datadir.New(t.TempDir())
+		touchFiles(t, dirs, ranges)
+		for _, table := range emptyTables {
+			for _, r := range ranges {
+				delFile(t, dirs.SnapCaplin, fmt.Sprintf("v1.0-%06d-%06d-%s.seg", r.fromStep, r.toStep, table))
+				delFile(t, dirs.SnapCaplin, fmt.Sprintf("v1.0-%06d-%06d-%s.idx", r.fromStep, r.toStep, table))
+			}
+		}
+		require.NoError(t, checkIfCaplinSnapshotsPublishable(dirs, true))
+	}
 }
 
 type snapRange struct {

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -2105,7 +2105,6 @@ func checkIfCaplinSnapshotsPublishable(dirs datadir.Dirs, emptyOk bool) error {
 	}
 
 	to := int64(-1)
-	somethingPresent, somethingEmpty := false, false
 	for table := range stateSnapTypes.KeyValueGetters {
 		uto, empty, err := CheckFilesForSchema(caplinSchema.GetState(table), CheckFilesParams{
 			checkLastFileTo: to,
@@ -2114,14 +2113,9 @@ func checkIfCaplinSnapshotsPublishable(dirs datadir.Dirs, emptyOk bool) error {
 		if err != nil {
 			return err
 		}
-		somethingPresent = somethingPresent || !empty
-		somethingEmpty = somethingEmpty || empty
-
-		to = int64(uto)
-	}
-
-	if somethingEmpty && somethingPresent {
-		return fmt.Errorf("some state snapshot files are empty while others are present")
+		if !empty {
+			to = int64(uto)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
- The caplin state publishable check iterates `stateSnapTypes.KeyValueGetters` (a Go map, random order) and cross-checks every table's last file ends at the same `to`. An empty table returned `uto=0`, and `to = int64(uto)` set the reference to 0 unconditionally, so the next non-empty table iterated after it failed with `last <X> snapshot file must end at 0, found at <N>` — an order-dependent, misleading error.
- Pre-GLOAS (EIP-7732) datadirs legitimately have zero files for the registered GLOAS state tables (Builders, BuilderPendingWithdrawals, PtcWindow, etc.), which tripped both this poisoning and the obsolete `some state snapshot files are empty while others are present` all-or-nothing guard, making every such datadir unpublishable.
- Only update `to` from non-empty tables and drop the all-or-nothing guard, so fully-empty future-fork tables are tolerated while each present table is still fully validated (gaps, start-at-0, accessors, versions, consistent `to`).
- Adds a test reproducing a pre-GLOAS datadir (present tables consistent, GLOAS tables empty) across many iterations to guard against the map-order regression.