### PR TITLE
execution/state: finalize reader must consume Estimate cells, not just Done

### DIFF
--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1707,17 +1707,6 @@ func (result *execResult) calcFees(
 	// and normalizeWriteSet's sdSet filter drops them.
 	coinbaseEmptyPre := (coinbaseAcc == nil || coinbaseAcc.Balance.IsZero()) &&
 		coinbaseNonce == 0 && coinbaseEmptyCodeHash && !coinbaseHasCodeHashWrite
-	// vsReader hides Estimate-flagged prior writes as "not found"; emptiness
-	// is indeterminate when any account-state path has an Estimate floor, so
-	// suppress the EIP-161 SD-emit path until re-execution sees a Done write.
-	if coinbaseEmptyPre {
-		for _, p := range [...]state.AccountPath{state.AddressPath, state.BalancePath, state.NoncePath, state.CodeHashPath} {
-			if vm.Read(result.Coinbase, p, accounts.NilKey, txIndex).Status() == state.MVReadResultDependency {
-				coinbaseEmptyPre = false
-				break
-			}
-		}
-	}
 	emitCoinbase := newCoinbaseBalance != oldCoinbaseBalance ||
 		(emptyRemoval && coinbaseEmptyPre && newCoinbaseBalance.IsZero())
 

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -352,7 +352,11 @@ func (vr *versionedStateReader) ReadAccountData(address accounts.Address) (*acco
 }
 
 func versionedUpdate[T any](versionMap *VersionMap, addr accounts.Address, path AccountPath, key accounts.StorageKey, txIndex int) (T, bool) {
-	if res := versionMap.Read(addr, path, key, txIndex); res.Status() == MVReadResultDone {
+	// A Dependency (Estimate) cell holds the same latest in-block write a Done
+	// cell does; finalize reconstruction must consume it, not fall back to the
+	// pre-block DB value — doing so commits stale state once invalidated txs
+	// flush Estimate instead of Done.
+	if res := versionMap.Read(addr, path, key, txIndex); res.Status() != MVReadResultNone {
 		return res.Value().(T), true
 	}
 	var v T


### PR DESCRIPTION
## Summary

Root-cause fix for the nondeterministic wrong-state-root regression on this branch, generalizing the Estimate-read handling that `d7f7a40c5d` patched for one case.

`versionedUpdate` (the `versionedStateReader` used for finalize / system-tx reconstruction) only consumed a versionMap floor flagged `Done`, treating an `Estimate` (`MVReadResultDependency`) floor as "not found" and falling back to the pre-block DB value. Since `221007e6a1` flushes invalidated txs' writes as `Estimate`, the finalize path resurrects stale pre-block state whenever a prior in-flight write exists — committing a wrong write set, producing **nondeterministic wrong state roots** in EL-requests blocks under parallel execution.

`d7f7a40c5d` fixed one manifestation (the coinbase EIP-161 SD check in `calcFees`) with a targeted probe; that commit's own message names the general defect ("versionedStateReader only honours Done floors and treats MVReadResultDependency … as not found"). This PR fixes it at the source, so every finalize-path read (storage, all account fields, code) is covered.

## Commits

1. **finalize reader must consume Estimate cells** — `versionedUpdate` now consumes a floor that is `Done` *or* `Estimate`. An Estimate floor holds the same latest in-block write a Done floor does; finalize reads are re-validated (the tx re-executes) if the writer's value later changes — the same OCC safety net the rest of the apply loop relies on. The worker read-path, which aborts on an Estimate read, is unchanged, so the phantom-write fix this branch targets is preserved.
2. **Revert the `calcFees` coinbase probe** (`d7f7a40c5d`) — now redundant: `vsReader` returns the coinbase's in-flight value, so `coinbaseEmptyPre` is computed from the real balance rather than a spurious nil.

## Verification

The net change is `versionedUpdate` only (the revert cancels `d7f7a40c5d`), so the branch is code-identical to "this branch before the coinbase probe, plus the versionedUpdate fix" — the configuration that was load-tested:

- **eip7685 EL-requests**, 16-worker load, interleaved on one machine: unfixed branch ~4/30 (blocktest) and 9/25 (engine-x) → **0** with this fix.
- **Full prague** (2,490 tests) × 4 passes: **0** failures, **0** regressions vs the serial baseline.
- **Full-prague sensitivity** (5 passes): unfixed 1/5 → **0/5**.
- `execution/stagedsync` + `execution/state` unit tests green (incl. this branch's phantom-write guard); `go vet` + `make lint` clean.

Single-test runs pass; the bug only surfaces under load (CPU contention perturbs exec3 scheduling), which is why CI caught it but a one-off run does not.

Targets `mh/parallel-exec-flush-invalid-as-estimate` so it lands before #21667 merges.
