### PR TITLE
cl, sentinel: quiet data column sidecar misses

### DIFF
--- a/cl/das/peer_das.go
+++ b/cl/das/peer_das.go
@@ -19,6 +19,7 @@ import (
 	"github.com/erigontech/erigon/cl/phase1/core/state/lru"
 	gossipmgr "github.com/erigontech/erigon/cl/phase1/network/gossip"
 	"github.com/erigontech/erigon/cl/rpc"
+	"github.com/erigontech/erigon/cl/sentinel/httpreqresp"
 	"github.com/erigontech/erigon/cl/utils/eth_clock"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/crypto/kzg"
@@ -822,6 +823,10 @@ mainloop:
 			}
 		case result := <-resultChan:
 			if result.err != nil {
+				if isExpectedColumnDownloadMiss(result.err) {
+					log.Trace("column sidecars unavailable from peer", "pid", result.pid, "err", result.err)
+					continue
+				}
 				log.Debug("failed to download columns from peer", "pid", result.pid, "err", result.err)
 				//d.rpc.BanPeer(result.pid)
 				continue
@@ -939,6 +944,17 @@ mainloop:
 	}
 
 	return nil
+}
+
+func isExpectedColumnDownloadMiss(err error) bool {
+	if err == nil {
+		return false
+	}
+	var peerErr *httpreqresp.PeerResponseError
+	if errors.As(err, &peerErr) {
+		return peerErr.Code == httpreqresp.ResponseCodeResourceUnavailable
+	}
+	return false
 }
 
 type downloadTableEntry struct {

--- a/cl/das/peer_das_test.go
+++ b/cl/das/peer_das_test.go
@@ -1,3 +1,19 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
 package das
 
 import (

--- a/cl/das/peer_das_test.go
+++ b/cl/das/peer_das_test.go
@@ -1,0 +1,30 @@
+package das
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/sentinel/httpreqresp"
+)
+
+func TestIsExpectedColumnDownloadMiss(t *testing.T) {
+	require.False(t, isExpectedColumnDownloadMiss(nil))
+	require.True(t, isExpectedColumnDownloadMiss(&httpreqresp.PeerResponseError{
+		Code: httpreqresp.ResponseCodeResourceUnavailable,
+	}))
+	require.True(t, isExpectedColumnDownloadMiss(fmt.Errorf("column miss: %w", &httpreqresp.PeerResponseError{
+		Code: httpreqresp.ResponseCodeResourceUnavailable,
+	})))
+	require.False(t, isExpectedColumnDownloadMiss(&httpreqresp.PeerResponseError{
+		Code:    httpreqresp.ResponseCodeServerError,
+		Message: "broken",
+	}))
+	require.False(t, isExpectedColumnDownloadMiss(&httpreqresp.HTTPError{
+		StatusCode: 400,
+		Body:       "Read Code: EOF",
+	}))
+	require.False(t, isExpectedColumnDownloadMiss(errors.New("peer error code: 2 (server error). Error message: broken")))
+}

--- a/cl/sentinel/handlers/data_cloumn_sidecar.go
+++ b/cl/sentinel/handlers/data_cloumn_sidecar.go
@@ -16,8 +16,7 @@ import (
 var errInvalidDataColumnIndex = errors.New("invalid column index")
 
 func writeDataColumnSidecarsEmptySuccess(s network.Stream) error {
-	_, err := s.Write([]byte{SuccessfulResponsePrefix})
-	return err
+	return nil
 }
 
 func (c *ConsensusHandlers) dataColumnSidecarsByRangeHandler(s network.Stream) error {
@@ -61,7 +60,7 @@ func (c *ConsensusHandlers) dataColumnSidecarsByRangeHandler(s network.Stream) e
 	}
 
 	// Consume additional rate-limit tokens: slots × columns per slot, capped at config max.
-	if cost := min(int(req.Count)*req.Columns.Length(), int(c.beaconConfig.MaxRequestDataColumnSidecars)) - 1; !c.consumeRateLimit(s, cost) {
+	if cost := dataColumnSidecarsRequestCost(endSlot-startSlot, uint64(req.Columns.Length()), c.beaconConfig.MaxRequestDataColumnSidecars); !c.consumeRateLimit(s, cost) {
 		return nil
 	}
 
@@ -167,9 +166,6 @@ func (c *ConsensusHandlers) dataColumnSidecarsByRootHandler(s network.Stream) er
 	if err := ssz_snappy.DecodeAndReadNoForkDigest(s, req, version); err != nil {
 		return ssz_snappy.EncodeAndWrite(s, &emptyString{}, InvalidRequestPrefix)
 	}
-	if curEpoch < c.beaconConfig.FuluForkEpoch {
-		return ssz_snappy.EncodeAndWrite(s, &emptyString{}, ResourceUnavailablePrefix)
-	}
 	if req.Len() > int(c.beaconConfig.MaxRequestBlocksDeneb) {
 		return ssz_snappy.EncodeAndWrite(s, &emptyString{}, InvalidRequestPrefix)
 	}
@@ -191,10 +187,13 @@ func (c *ConsensusHandlers) dataColumnSidecarsByRootHandler(s network.Stream) er
 		}
 		totalColumns += columns.Length()
 	}
+	if curEpoch < c.beaconConfig.FuluForkEpoch {
+		return ssz_snappy.EncodeAndWrite(s, &emptyString{}, ResourceUnavailablePrefix)
+	}
 	if totalColumns == 0 {
 		return writeDataColumnSidecarsEmptySuccess(s)
 	}
-	if cost := min(totalColumns, int(c.beaconConfig.MaxRequestDataColumnSidecars)) - 1; !c.consumeRateLimit(s, cost) {
+	if cost := dataColumnSidecarsRequestCost(1, uint64(totalColumns), c.beaconConfig.MaxRequestDataColumnSidecars); !c.consumeRateLimit(s, cost) {
 		return nil
 	}
 
@@ -289,4 +288,18 @@ func (c *ConsensusHandlers) dataColumnSidecarsByRootHandler(s network.Stream) er
 		return ssz_snappy.EncodeAndWrite(s, &emptyString{}, ResourceUnavailablePrefix)
 	}
 	return nil
+}
+
+func dataColumnSidecarsRequestCost(slots, columns, maxSidecars uint64) int {
+	if slots == 0 || columns == 0 || maxSidecars == 0 {
+		return 0
+	}
+	if slots > maxSidecars/columns {
+		return int(maxSidecars) - 1
+	}
+	sidecars := slots * columns
+	if sidecars > maxSidecars {
+		sidecars = maxSidecars
+	}
+	return int(sidecars) - 1
 }

--- a/cl/sentinel/handlers/data_cloumn_sidecar.go
+++ b/cl/sentinel/handlers/data_cloumn_sidecar.go
@@ -13,33 +13,52 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 )
 
+var errInvalidDataColumnIndex = errors.New("invalid column index")
+
+func writeDataColumnSidecarsEmptySuccess(s network.Stream) error {
+	_, err := s.Write([]byte{SuccessfulResponsePrefix})
+	return err
+}
+
 func (c *ConsensusHandlers) dataColumnSidecarsByRangeHandler(s network.Stream) error {
 	curEpoch := c.ethClock.GetCurrentEpoch()
-	if curEpoch < c.beaconConfig.FuluForkEpoch {
-		return nil
-	}
 
 	// Use current epoch's version for decoding (supports Fulu and GLOAS)
 	version := c.beaconConfig.GetCurrentStateVersion(curEpoch)
 	req := &cltypes.ColumnSidecarsByRangeRequest{}
 	if err := ssz_snappy.DecodeAndReadNoForkDigest(s, req, version); err != nil {
-		return err
+		return ssz_snappy.EncodeAndWrite(s, &emptyString{}, InvalidRequestPrefix)
+	}
+	if curEpoch < c.beaconConfig.FuluForkEpoch {
+		return writeDataColumnSidecarsEmptySuccess(s)
 	}
 
 	// check params.
 	var (
-		endSlot   = req.StartSlot + req.Count
-		startSlot = max(req.StartSlot, c.beaconConfig.FuluForkEpoch*c.beaconConfig.SlotsPerEpoch)
+		fuluStartSlot = c.beaconConfig.FuluForkEpoch * c.beaconConfig.SlotsPerEpoch
+		endSlot       = req.StartSlot + req.Count
 	)
-	if endSlot-startSlot > c.beaconConfig.MinEpochsForDataColumnSidecarsRequests*c.beaconConfig.SlotsPerEpoch {
-		return errors.New("request range is too large")
+	if endSlot < req.StartSlot {
+		return ssz_snappy.EncodeAndWrite(s, &emptyString{}, InvalidRequestPrefix)
 	}
-	solid.RangeErr(req.Columns, func(index int, columnIndex uint64, length int) error {
+	if req.Columns.Length() > int(c.beaconConfig.NumberOfColumns) {
+		return ssz_snappy.EncodeAndWrite(s, &emptyString{}, InvalidRequestPrefix)
+	}
+	if err := solid.RangeErr(req.Columns, func(index int, columnIndex uint64, length int) error {
 		if columnIndex >= c.beaconConfig.NumberOfColumns {
-			return errors.New("invalid column index")
+			return errInvalidDataColumnIndex
 		}
 		return nil
-	})
+	}); err != nil {
+		return ssz_snappy.EncodeAndWrite(s, &emptyString{}, InvalidRequestPrefix)
+	}
+	if req.Count == 0 || req.Columns.Length() == 0 || endSlot <= fuluStartSlot {
+		return writeDataColumnSidecarsEmptySuccess(s)
+	}
+	startSlot := max(req.StartSlot, fuluStartSlot)
+	if endSlot-startSlot > c.beaconConfig.MinEpochsForDataColumnSidecarsRequests*c.beaconConfig.SlotsPerEpoch {
+		return ssz_snappy.EncodeAndWrite(s, &emptyString{}, InvalidRequestPrefix)
+	}
 
 	// Consume additional rate-limit tokens: slots × columns per slot, capped at config max.
 	if cost := min(int(req.Count)*req.Columns.Length(), int(c.beaconConfig.MaxRequestDataColumnSidecars)) - 1; !c.consumeRateLimit(s, cost) {
@@ -47,6 +66,9 @@ func (c *ConsensusHandlers) dataColumnSidecarsByRangeHandler(s network.Stream) e
 	}
 
 	curSlot := c.ethClock.GetCurrentSlot()
+	if startSlot > curSlot {
+		return writeDataColumnSidecarsEmptySuccess(s)
+	}
 
 	tx, err := c.indiciesDB.BeginRo(c.ctx)
 	if err != nil {
@@ -55,6 +77,7 @@ func (c *ConsensusHandlers) dataColumnSidecarsByRangeHandler(s network.Stream) e
 	defer tx.Rollback()
 
 	count := 0
+	var responseErr error
 	for slot := startSlot; slot < endSlot; slot++ {
 		if slot > curSlot {
 			// slot is in the future
@@ -84,6 +107,7 @@ func (c *ConsensusHandlers) dataColumnSidecarsByRangeHandler(s network.Stream) e
 			exists, err := c.dataColumnStorage.ColumnSidecarExists(c.ctx, slot, blockRoot, int64(columnIndex))
 			if err != nil {
 				log.Debug("failed to check if data column sidecar exists", "error", err)
+				responseErr = err
 				return false
 			}
 			if !exists {
@@ -94,54 +118,81 @@ func (c *ConsensusHandlers) dataColumnSidecarsByRangeHandler(s network.Stream) e
 			forkDigest, err := c.ethClock.ComputeForkDigest(slot / c.beaconConfig.SlotsPerEpoch)
 			if err != nil {
 				log.Debug("failed to compute fork digest", "error", err)
+				responseErr = err
 				return false
 			}
 			if _, err := s.Write([]byte{SuccessfulResponsePrefix}); err != nil {
 				log.Debug("failed to write success byte", "error", err)
+				responseErr = err
 				return false
 			}
 
 			if _, err := s.Write(forkDigest[:]); err != nil {
 				log.Debug("failed to write fork digest", "error", err)
+				responseErr = err
 				return false
 			}
 
 			if err := c.dataColumnStorage.WriteStream(s, slot, blockRoot, columnIndex); err != nil {
 				log.Debug("failed to write stream data column sidecar", "error", err)
+				responseErr = err
 				return false
 			}
 			count++
 			return true
 		})
+		if responseErr != nil {
+			break
+		}
 		if count >= int(c.beaconConfig.MaxRequestDataColumnSidecars) {
 			// max number of sidecars reached
 			break
 		}
 	}
-
+	if responseErr != nil {
+		return responseErr
+	}
+	if count == 0 {
+		return writeDataColumnSidecarsEmptySuccess(s)
+	}
 	return nil
 }
 
 func (c *ConsensusHandlers) dataColumnSidecarsByRootHandler(s network.Stream) error {
 	curEpoch := c.ethClock.GetCurrentEpoch()
-	if curEpoch < c.beaconConfig.FuluForkEpoch {
-		return nil
-	}
 
 	// Use current epoch's version for decoding (supports Fulu and GLOAS)
 	version := c.beaconConfig.GetCurrentStateVersion(curEpoch)
 	req := solid.NewDynamicListSSZ[*cltypes.DataColumnsByRootIdentifier](int(c.beaconConfig.MaxRequestBlocksDeneb))
 	if err := ssz_snappy.DecodeAndReadNoForkDigest(s, req, version); err != nil {
-		return err
+		return ssz_snappy.EncodeAndWrite(s, &emptyString{}, InvalidRequestPrefix)
+	}
+	if curEpoch < c.beaconConfig.FuluForkEpoch {
+		return ssz_snappy.EncodeAndWrite(s, &emptyString{}, ResourceUnavailablePrefix)
 	}
 	if req.Len() > int(c.beaconConfig.MaxRequestBlocksDeneb) {
-		return errors.New("request is too large")
+		return ssz_snappy.EncodeAndWrite(s, &emptyString{}, InvalidRequestPrefix)
 	}
 
 	// Consume additional rate-limit tokens: sum of column counts across all roots.
 	totalColumns := 0
 	for i := 0; i < req.Len(); i++ {
-		totalColumns += req.Get(i).Columns.Length()
+		columns := req.Get(i).Columns
+		if columns.Length() > int(c.beaconConfig.NumberOfColumns) {
+			return ssz_snappy.EncodeAndWrite(s, &emptyString{}, InvalidRequestPrefix)
+		}
+		if err := solid.RangeErr(columns, func(index int, columnIndex uint64, length int) error {
+			if columnIndex >= c.beaconConfig.NumberOfColumns {
+				return errInvalidDataColumnIndex
+			}
+			return nil
+		}); err != nil {
+			return ssz_snappy.EncodeAndWrite(s, &emptyString{}, InvalidRequestPrefix)
+		}
+		totalColumns += columns.Length()
+	}
+	if totalColumns == 0 {
+		return writeDataColumnSidecarsEmptySuccess(s)
 	}
 	if cost := min(totalColumns, int(c.beaconConfig.MaxRequestDataColumnSidecars)) - 1; !c.consumeRateLimit(s, cost) {
 		return nil
@@ -157,6 +208,7 @@ func (c *ConsensusHandlers) dataColumnSidecarsByRootHandler(s network.Stream) er
 	defer tx.Rollback()
 
 	count := 0
+	var responseErr error
 	for i := 0; i < req.Len(); i++ {
 		id := req.Get(i)
 		blockRoot := id.BlockRoot
@@ -188,14 +240,11 @@ func (c *ConsensusHandlers) dataColumnSidecarsByRootHandler(s network.Stream) er
 				// max number of sidecars reached
 				return false
 			}
-			if columnIndex >= c.beaconConfig.NumberOfColumns {
-				// skip invalid column index
-				return true
-			}
 
 			exists, err := c.dataColumnStorage.ColumnSidecarExists(c.ctx, *slot, blockRoot, int64(columnIndex))
 			if err != nil {
 				log.Debug("failed to check if data column sidecar exists", "error", err)
+				responseErr = err
 				return false
 			}
 			if !exists {
@@ -206,25 +255,38 @@ func (c *ConsensusHandlers) dataColumnSidecarsByRootHandler(s network.Stream) er
 			forkDigest, err := c.ethClock.ComputeForkDigest(*slot / c.beaconConfig.SlotsPerEpoch)
 			if err != nil {
 				log.Debug("failed to compute fork digest", "error", err)
+				responseErr = err
 				return false
 			}
 			if _, err := s.Write([]byte{SuccessfulResponsePrefix}); err != nil {
 				log.Debug("failed to write success byte", "error", err)
+				responseErr = err
 				return false
 			}
 
 			if _, err := s.Write(forkDigest[:]); err != nil {
 				log.Debug("failed to write fork digest", "error", err)
+				responseErr = err
 				return false
 			}
 
 			if err := c.dataColumnStorage.WriteStream(s, *slot, blockRoot, columnIndex); err != nil {
 				log.Debug("failed to write stream data column sidecar", "error", err)
+				responseErr = err
 				return false
 			}
 			count++
 			return true
 		})
+		if responseErr != nil {
+			break
+		}
+	}
+	if responseErr != nil {
+		return responseErr
+	}
+	if count == 0 {
+		return ssz_snappy.EncodeAndWrite(s, &emptyString{}, ResourceUnavailablePrefix)
 	}
 	return nil
 }

--- a/cl/sentinel/handlers/data_column_sidecar_test.go
+++ b/cl/sentinel/handlers/data_column_sidecar_test.go
@@ -1,3 +1,19 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
 package handlers
 
 import (
@@ -73,6 +89,27 @@ func TestDataColumnSidecarsByRootBeforeFuluReturnsResourceUnavailable(t *testing
 	t.Cleanup(func() { stream.Close() })
 
 	expectDataColumnSidecarResourceUnavailable(t, stream, reqBuf.Bytes())
+}
+
+func TestDataColumnSidecarsByRootBeforeFuluInvalidColumnReturnsInvalidRequest(t *testing.T) {
+	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTestWithFuluForkEpoch(t, math.MaxUint64)
+
+	req := solid.NewDynamicListSSZ[*cltypes.DataColumnsByRootIdentifier](1)
+	id := &cltypes.DataColumnsByRootIdentifier{
+		BlockRoot: common.Hash{0x42},
+		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns) + 1),
+	}
+	id.Columns.Append(beaconCfg.NumberOfColumns)
+	req.Append(id)
+
+	var reqBuf bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&reqBuf, req))
+
+	stream, err := host1.NewStream(ctx, host.ID(), protocol.ID(communication.DataColumnSidecarsByRootProtocolV1))
+	require.NoError(t, err)
+	t.Cleanup(func() { stream.Close() })
+
+	expectDataColumnSidecarResponsePrefix(t, stream, reqBuf.Bytes(), InvalidRequestPrefix)
 }
 
 func TestDataColumnSidecarsByRootFoundSidecarReturnsSuccessWithoutTrailingResourceUnavailable(t *testing.T) {
@@ -478,11 +515,6 @@ func expectDataColumnSidecarEmptyResponse(t *testing.T, stream network.Stream, r
 
 	_, err := stream.Write(reqData)
 	require.NoError(t, err)
-
-	firstByte := make([]byte, 1)
-	_, err = io.ReadFull(stream, firstByte)
-	require.NoError(t, err)
-	require.Equal(t, byte(SuccessfulResponsePrefix), firstByte[0])
 
 	require.NoError(t, stream.SetReadDeadline(time.Now().Add(200*time.Millisecond)))
 	buf := make([]byte, 1)

--- a/cl/sentinel/handlers/data_column_sidecar_test.go
+++ b/cl/sentinel/handlers/data_column_sidecar_test.go
@@ -1,0 +1,492 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"math"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/antiquary/tests"
+	"github.com/erigontech/erigon/cl/beacon/beaconevents"
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/cl/persistence/blob_storage"
+	"github.com/erigontech/erigon/cl/phase1/forkchoice/mock_services"
+	"github.com/erigontech/erigon/cl/sentinel/communication"
+	"github.com/erigontech/erigon/cl/sentinel/communication/ssz_snappy"
+	"github.com/erigontech/erigon/cl/sentinel/peers"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/db/kv"
+)
+
+var initDataColumnSidecarTestConfig sync.Once
+
+func TestDataColumnSidecarsByRootMissingRootReturnsResourceUnavailable(t *testing.T) {
+	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTest(t)
+
+	req := solid.NewDynamicListSSZ[*cltypes.DataColumnsByRootIdentifier](1)
+	id := &cltypes.DataColumnsByRootIdentifier{
+		BlockRoot: common.Hash{0x42},
+		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns)),
+	}
+	id.Columns.Append(0)
+	req.Append(id)
+
+	var reqBuf bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&reqBuf, req))
+
+	stream, err := host1.NewStream(ctx, host.ID(), protocol.ID(communication.DataColumnSidecarsByRootProtocolV1))
+	require.NoError(t, err)
+	t.Cleanup(func() { stream.Close() })
+
+	expectDataColumnSidecarResourceUnavailable(t, stream, reqBuf.Bytes())
+}
+
+func TestDataColumnSidecarsByRootBeforeFuluReturnsResourceUnavailable(t *testing.T) {
+	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTestWithFuluForkEpoch(t, math.MaxUint64)
+
+	req := solid.NewDynamicListSSZ[*cltypes.DataColumnsByRootIdentifier](1)
+	id := &cltypes.DataColumnsByRootIdentifier{
+		BlockRoot: common.Hash{0x42},
+		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns)),
+	}
+	id.Columns.Append(0)
+	req.Append(id)
+
+	var reqBuf bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&reqBuf, req))
+
+	stream, err := host1.NewStream(ctx, host.ID(), protocol.ID(communication.DataColumnSidecarsByRootProtocolV1))
+	require.NoError(t, err)
+	t.Cleanup(func() { stream.Close() })
+
+	expectDataColumnSidecarResourceUnavailable(t, stream, reqBuf.Bytes())
+}
+
+func TestDataColumnSidecarsByRootFoundSidecarReturnsSuccessWithoutTrailingResourceUnavailable(t *testing.T) {
+	ctx, host, host1, beaconCfg, indiciesDB, columnStorage := setupDataColumnSidecarHandlerTestWithStore(t, 0)
+
+	tx, err := indiciesDB.BeginRw(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+	blocks := populateDatabaseWithBlocks(t, tests.NewMockBlockReader(), tx, getEthClock(t).GetCurrentSlot(), 0)
+	require.NoError(t, tx.Commit())
+
+	header := blocks[0].SignedBeaconBlockHeader()
+	slot := header.Header.Slot
+	blockRoot, err := header.Header.HashSSZ()
+	require.NoError(t, err)
+	columnIndex := uint64(0)
+	sidecar := cltypes.NewDataColumnSidecar()
+	sidecar.Index = columnIndex
+	sidecar.SignedBlockHeader.Header.Slot = slot
+	require.NoError(t, columnStorage.WriteColumnSidecars(ctx, blockRoot, int64(columnIndex), sidecar))
+
+	req := solid.NewDynamicListSSZ[*cltypes.DataColumnsByRootIdentifier](1)
+	id := &cltypes.DataColumnsByRootIdentifier{
+		BlockRoot: blockRoot,
+		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns)),
+	}
+	id.Columns.Append(columnIndex)
+	req.Append(id)
+
+	var reqBuf bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&reqBuf, req))
+
+	stream, err := host1.NewStream(ctx, host.ID(), protocol.ID(communication.DataColumnSidecarsByRootProtocolV1))
+	require.NoError(t, err)
+	t.Cleanup(func() { stream.Close() })
+	require.NoError(t, stream.SetDeadline(time.Now().Add(5*time.Second)))
+
+	_, err = stream.Write(reqBuf.Bytes())
+	require.NoError(t, err)
+
+	firstByte := make([]byte, 1)
+	_, err = io.ReadFull(stream, firstByte)
+	require.NoError(t, err)
+	require.Equal(t, byte(SuccessfulResponsePrefix), firstByte[0])
+
+	forkDigest := make([]byte, 4)
+	_, err = io.ReadFull(stream, forkDigest)
+	require.NoError(t, err)
+
+	got := cltypes.NewDataColumnSidecar()
+	require.NoError(t, ssz_snappy.DecodeAndReadNoForkDigest(stream, got, clparams.FuluVersion))
+	require.Equal(t, columnIndex, got.Index)
+
+	require.NoError(t, stream.SetReadDeadline(time.Now().Add(200*time.Millisecond)))
+	buf := make([]byte, 1)
+	n, err := stream.Read(buf)
+	require.Zero(t, n)
+	require.Error(t, err)
+}
+
+func TestDataColumnSidecarsByRootEmptyRequestReturnsEmptySuccess(t *testing.T) {
+	ctx, host, host1, _ := setupDataColumnSidecarHandlerTest(t)
+
+	req := solid.NewDynamicListSSZ[*cltypes.DataColumnsByRootIdentifier](1)
+
+	var reqBuf bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&reqBuf, req))
+
+	stream, err := host1.NewStream(ctx, host.ID(), protocol.ID(communication.DataColumnSidecarsByRootProtocolV1))
+	require.NoError(t, err)
+	t.Cleanup(func() { stream.Close() })
+
+	expectDataColumnSidecarEmptyResponse(t, stream, reqBuf.Bytes())
+}
+
+func TestDataColumnSidecarsByRootEmptyColumnsReturnsEmptySuccess(t *testing.T) {
+	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTest(t)
+
+	req := solid.NewDynamicListSSZ[*cltypes.DataColumnsByRootIdentifier](1)
+	req.Append(&cltypes.DataColumnsByRootIdentifier{
+		BlockRoot: common.Hash{0x42},
+		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns)),
+	})
+
+	var reqBuf bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&reqBuf, req))
+
+	stream, err := host1.NewStream(ctx, host.ID(), protocol.ID(communication.DataColumnSidecarsByRootProtocolV1))
+	require.NoError(t, err)
+	t.Cleanup(func() { stream.Close() })
+
+	expectDataColumnSidecarEmptyResponse(t, stream, reqBuf.Bytes())
+}
+
+func TestDataColumnSidecarsByRootInvalidColumnReturnsInvalidRequest(t *testing.T) {
+	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTest(t)
+
+	req := solid.NewDynamicListSSZ[*cltypes.DataColumnsByRootIdentifier](1)
+	id := &cltypes.DataColumnsByRootIdentifier{
+		BlockRoot: common.Hash{0x42},
+		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns) + 1),
+	}
+	id.Columns.Append(beaconCfg.NumberOfColumns)
+	req.Append(id)
+
+	var reqBuf bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&reqBuf, req))
+
+	stream, err := host1.NewStream(ctx, host.ID(), protocol.ID(communication.DataColumnSidecarsByRootProtocolV1))
+	require.NoError(t, err)
+	t.Cleanup(func() { stream.Close() })
+
+	expectDataColumnSidecarResponsePrefix(t, stream, reqBuf.Bytes(), InvalidRequestPrefix)
+}
+
+func TestDataColumnSidecarsByRootTooManyColumnsReturnsInvalidRequest(t *testing.T) {
+	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTest(t)
+
+	req := solid.NewDynamicListSSZ[*cltypes.DataColumnsByRootIdentifier](1)
+	id := &cltypes.DataColumnsByRootIdentifier{
+		BlockRoot: common.Hash{0x42},
+		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns) + 1),
+	}
+	for range beaconCfg.NumberOfColumns + 1 {
+		id.Columns.Append(0)
+	}
+	req.Append(id)
+
+	var reqBuf bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&reqBuf, req))
+
+	stream, err := host1.NewStream(ctx, host.ID(), protocol.ID(communication.DataColumnSidecarsByRootProtocolV1))
+	require.NoError(t, err)
+	t.Cleanup(func() { stream.Close() })
+
+	expectDataColumnSidecarResponsePrefix(t, stream, reqBuf.Bytes(), InvalidRequestPrefix)
+}
+
+func TestDataColumnSidecarsByRangeZeroCountReturnsEmptySuccess(t *testing.T) {
+	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTest(t)
+
+	req := &cltypes.ColumnSidecarsByRangeRequest{
+		StartSlot: 0,
+		Count:     0,
+		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns)),
+	}
+	req.Columns.Append(0)
+
+	var reqBuf bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&reqBuf, req))
+
+	stream, err := host1.NewStream(ctx, host.ID(), protocol.ID(communication.DataColumnSidecarsByRangeProtocolV1))
+	require.NoError(t, err)
+	t.Cleanup(func() { stream.Close() })
+
+	expectDataColumnSidecarEmptyResponse(t, stream, reqBuf.Bytes())
+}
+
+func TestDataColumnSidecarsByRangeEmptyColumnsReturnsEmptySuccess(t *testing.T) {
+	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTest(t)
+
+	req := &cltypes.ColumnSidecarsByRangeRequest{
+		StartSlot: 0,
+		Count:     1,
+		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns)),
+	}
+
+	var reqBuf bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&reqBuf, req))
+
+	stream, err := host1.NewStream(ctx, host.ID(), protocol.ID(communication.DataColumnSidecarsByRangeProtocolV1))
+	require.NoError(t, err)
+	t.Cleanup(func() { stream.Close() })
+
+	expectDataColumnSidecarEmptyResponse(t, stream, reqBuf.Bytes())
+}
+
+func TestDataColumnSidecarsByRangeMissingSidecarsReturnsEmptySuccess(t *testing.T) {
+	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTest(t)
+
+	req := &cltypes.ColumnSidecarsByRangeRequest{
+		StartSlot: 0,
+		Count:     1,
+		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns)),
+	}
+	req.Columns.Append(0)
+
+	var reqBuf bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&reqBuf, req))
+
+	stream, err := host1.NewStream(ctx, host.ID(), protocol.ID(communication.DataColumnSidecarsByRangeProtocolV1))
+	require.NoError(t, err)
+	t.Cleanup(func() { stream.Close() })
+
+	expectDataColumnSidecarEmptyResponse(t, stream, reqBuf.Bytes())
+}
+
+func TestDataColumnSidecarsByRangeFutureRangeReturnsEmptySuccess(t *testing.T) {
+	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTest(t)
+
+	req := &cltypes.ColumnSidecarsByRangeRequest{
+		StartSlot: getEthClock(t).GetCurrentSlot() + 1,
+		Count:     1,
+		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns)),
+	}
+	req.Columns.Append(0)
+
+	var reqBuf bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&reqBuf, req))
+
+	stream, err := host1.NewStream(ctx, host.ID(), protocol.ID(communication.DataColumnSidecarsByRangeProtocolV1))
+	require.NoError(t, err)
+	t.Cleanup(func() { stream.Close() })
+
+	expectDataColumnSidecarEmptyResponse(t, stream, reqBuf.Bytes())
+}
+
+func TestDataColumnSidecarsByRangeBeforeFuluReturnsEmptySuccess(t *testing.T) {
+	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTestWithFuluForkEpoch(t, 1)
+
+	req := &cltypes.ColumnSidecarsByRangeRequest{
+		StartSlot: 0,
+		Count:     beaconCfg.SlotsPerEpoch,
+		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns)),
+	}
+	req.Columns.Append(0)
+
+	var reqBuf bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&reqBuf, req))
+
+	stream, err := host1.NewStream(ctx, host.ID(), protocol.ID(communication.DataColumnSidecarsByRangeProtocolV1))
+	require.NoError(t, err)
+	t.Cleanup(func() { stream.Close() })
+
+	expectDataColumnSidecarEmptyResponse(t, stream, reqBuf.Bytes())
+}
+
+func TestDataColumnSidecarsByRangeInvalidColumnReturnsInvalidRequest(t *testing.T) {
+	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTest(t)
+
+	req := &cltypes.ColumnSidecarsByRangeRequest{
+		StartSlot: 0,
+		Count:     1,
+		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns) + 1),
+	}
+	req.Columns.Append(beaconCfg.NumberOfColumns)
+
+	var reqBuf bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&reqBuf, req))
+
+	stream, err := host1.NewStream(ctx, host.ID(), protocol.ID(communication.DataColumnSidecarsByRangeProtocolV1))
+	require.NoError(t, err)
+	t.Cleanup(func() { stream.Close() })
+
+	expectDataColumnSidecarResponsePrefix(t, stream, reqBuf.Bytes(), InvalidRequestPrefix)
+}
+
+func TestDataColumnSidecarsByRangeTooManyColumnsReturnsInvalidRequest(t *testing.T) {
+	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTest(t)
+
+	req := &cltypes.ColumnSidecarsByRangeRequest{
+		StartSlot: 0,
+		Count:     1,
+		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns) + 1),
+	}
+	for range beaconCfg.NumberOfColumns + 1 {
+		req.Columns.Append(0)
+	}
+
+	var reqBuf bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&reqBuf, req))
+
+	stream, err := host1.NewStream(ctx, host.ID(), protocol.ID(communication.DataColumnSidecarsByRangeProtocolV1))
+	require.NoError(t, err)
+	t.Cleanup(func() { stream.Close() })
+
+	expectDataColumnSidecarResponsePrefix(t, stream, reqBuf.Bytes(), InvalidRequestPrefix)
+}
+
+func TestDataColumnSidecarsByRangeOverflowReturnsInvalidRequest(t *testing.T) {
+	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTest(t)
+
+	req := &cltypes.ColumnSidecarsByRangeRequest{
+		StartSlot: math.MaxUint64,
+		Count:     1,
+		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns)),
+	}
+	req.Columns.Append(0)
+
+	var reqBuf bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&reqBuf, req))
+
+	stream, err := host1.NewStream(ctx, host.ID(), protocol.ID(communication.DataColumnSidecarsByRangeProtocolV1))
+	require.NoError(t, err)
+	t.Cleanup(func() { stream.Close() })
+
+	expectDataColumnSidecarResponsePrefix(t, stream, reqBuf.Bytes(), InvalidRequestPrefix)
+}
+
+func TestDataColumnSidecarsByRangeTooLargeReturnsInvalidRequest(t *testing.T) {
+	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTest(t)
+
+	req := &cltypes.ColumnSidecarsByRangeRequest{
+		StartSlot: 0,
+		Count:     beaconCfg.MinEpochsForDataColumnSidecarsRequests*beaconCfg.SlotsPerEpoch + 1,
+		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns)),
+	}
+	req.Columns.Append(0)
+
+	var reqBuf bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&reqBuf, req))
+
+	stream, err := host1.NewStream(ctx, host.ID(), protocol.ID(communication.DataColumnSidecarsByRangeProtocolV1))
+	require.NoError(t, err)
+	t.Cleanup(func() { stream.Close() })
+
+	expectDataColumnSidecarResponsePrefix(t, stream, reqBuf.Bytes(), InvalidRequestPrefix)
+}
+
+func setupDataColumnSidecarHandlerTest(t *testing.T) (context.Context, host.Host, host.Host, *clparams.BeaconChainConfig) {
+	ctx, server, client, beaconCfg, _, _ := setupDataColumnSidecarHandlerTestWithStore(t, 0)
+	return ctx, server, client, beaconCfg
+}
+
+func setupDataColumnSidecarHandlerTestWithFuluForkEpoch(t *testing.T, fuluForkEpoch uint64) (context.Context, host.Host, host.Host, *clparams.BeaconChainConfig) {
+	ctx, server, client, beaconCfg, _, _ := setupDataColumnSidecarHandlerTestWithStore(t, fuluForkEpoch)
+	return ctx, server, client, beaconCfg
+}
+
+func setupDataColumnSidecarHandlerTestWithStore(t *testing.T, fuluForkEpoch uint64) (context.Context, host.Host, host.Host, *clparams.BeaconChainConfig, kv.RwDB, blob_storage.DataColumnStorage) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	server, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, server.Close()) })
+
+	client, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	require.NoError(t, server.Connect(ctx, peer.AddrInfo{
+		ID:    client.ID(),
+		Addrs: client.Addrs(),
+	}))
+
+	_, indiciesDB := setupStore(t)
+	t.Cleanup(func() { indiciesDB.Close() })
+
+	ethClock := getEthClock(t)
+	_, mainnetCfg := clparams.GetConfigsByNetwork(1)
+	initDataColumnSidecarTestConfig.Do(func() {
+		if clparams.GetBeaconConfig() == nil {
+			clparams.InitGlobalStaticConfig(mainnetCfg, &clparams.CaplinConfig{})
+		}
+	})
+	beaconCfg := *mainnetCfg
+	beaconCfg.FuluForkEpoch = fuluForkEpoch
+	columnStorage := blob_storage.NewDataColumnStore(afero.NewMemMapFs(), 1000, &beaconCfg, ethClock, beaconevents.NewEventEmitter())
+
+	c := NewConsensusHandlers(
+		ctx,
+		tests.NewMockBlockReader(),
+		indiciesDB,
+		server,
+		peers.NewPool(server),
+		&clparams.NetworkConfig{},
+		nil,
+		&beaconCfg,
+		ethClock,
+		nil, &mock_services.ForkChoiceStorageMock{}, nil, columnStorage, nil, true,
+	)
+	c.Start()
+
+	return ctx, server, client, &beaconCfg, indiciesDB, columnStorage
+}
+
+func expectDataColumnSidecarResourceUnavailable(t *testing.T, stream network.Stream, reqData []byte) {
+	t.Helper()
+
+	expectDataColumnSidecarResponsePrefix(t, stream, reqData, ResourceUnavailablePrefix)
+}
+
+func expectDataColumnSidecarResponsePrefix(t *testing.T, stream network.Stream, reqData []byte, prefix byte) {
+	t.Helper()
+
+	require.NoError(t, stream.SetDeadline(time.Now().Add(5*time.Second)))
+
+	_, err := stream.Write(reqData)
+	require.NoError(t, err)
+
+	firstByte := make([]byte, 1)
+	_, err = io.ReadFull(stream, firstByte)
+	require.NoError(t, err)
+	require.Equal(t, prefix, firstByte[0])
+}
+
+func expectDataColumnSidecarEmptyResponse(t *testing.T, stream network.Stream, reqData []byte) {
+	t.Helper()
+
+	require.NoError(t, stream.SetDeadline(time.Now().Add(5*time.Second)))
+
+	_, err := stream.Write(reqData)
+	require.NoError(t, err)
+
+	firstByte := make([]byte, 1)
+	_, err = io.ReadFull(stream, firstByte)
+	require.NoError(t, err)
+	require.Equal(t, byte(SuccessfulResponsePrefix), firstByte[0])
+
+	require.NoError(t, stream.SetReadDeadline(time.Now().Add(200*time.Millisecond)))
+	buf := make([]byte, 1)
+	n, err := stream.Read(buf)
+	require.Zero(t, n)
+	require.Error(t, err)
+}

--- a/cl/sentinel/httpreqresp/errors.go
+++ b/cl/sentinel/httpreqresp/errors.go
@@ -1,0 +1,94 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package httpreqresp
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/golang/snappy"
+)
+
+type HTTPError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("SentinelHttp: %s", e.Body)
+}
+
+type PeerResponseError struct {
+	Code    ResponseCode
+	Message string
+}
+
+func (e *PeerResponseError) Error() string {
+	return fmt.Sprintf("peer error code: %d (%s). Error message: %s", e.Code, e.Code.String(), e.Message)
+}
+
+type ResponseCode int
+
+const (
+	ResponseCodeSuccess ResponseCode = iota
+	ResponseCodeInvalidRequest
+	ResponseCodeServerError
+	ResponseCodeResourceUnavailable
+)
+
+func (r ResponseCode) String() string {
+	switch r {
+	case ResponseCodeSuccess:
+		return "success"
+	case ResponseCodeInvalidRequest:
+		return "invalid request"
+	case ResponseCodeServerError:
+		return "server error"
+	case ResponseCodeResourceUnavailable:
+		return "resource unavailable"
+	}
+	return "unknown"
+}
+
+func (r ResponseCode) Success() bool {
+	return r == ResponseCodeSuccess
+}
+
+func (r ResponseCode) ErrorMessage(resp *http.Response) (string, error) {
+	if r == ResponseCodeSuccess || r == ResponseCodeInvalidRequest {
+		return "", nil
+	}
+	// Error response bodies are length-prefixed before the snappy payload.
+	rawReader := bufio.NewReader(resp.Body)
+	for {
+		b, err := rawReader.ReadByte()
+		if err != nil {
+			return "", err
+		}
+		if b&0x80 == 0 {
+			break
+		}
+	}
+	sr := snappy.NewReader(rawReader)
+	decoded, err := io.ReadAll(sr)
+	if err != nil {
+		return "", err
+	}
+	return string(decoded), nil
+}

--- a/cl/sentinel/httpreqresp/errors.go
+++ b/cl/sentinel/httpreqresp/errors.go
@@ -18,12 +18,17 @@ package httpreqresp
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 
 	"github.com/golang/snappy"
 )
+
+const maxErrorMessageBytes = 256
+
+var errMalformedErrorMessageLength = errors.New("malformed reqresp error message length")
 
 type HTTPError struct {
 	StatusCode int
@@ -76,17 +81,22 @@ func (r ResponseCode) ErrorMessage(resp *http.Response) (string, error) {
 	}
 	// Error response bodies are length-prefixed before the snappy payload.
 	rawReader := bufio.NewReader(resp.Body)
-	for {
+	lengthDone := false
+	for i := 0; i < 10; i++ {
 		b, err := rawReader.ReadByte()
 		if err != nil {
 			return "", err
 		}
 		if b&0x80 == 0 {
+			lengthDone = true
 			break
 		}
 	}
+	if !lengthDone {
+		return "", errMalformedErrorMessageLength
+	}
 	sr := snappy.NewReader(rawReader)
-	decoded, err := io.ReadAll(sr)
+	decoded, err := io.ReadAll(io.LimitReader(sr, maxErrorMessageBytes))
 	if err != nil {
 		return "", err
 	}

--- a/cl/sentinel/httpreqresp/server.go
+++ b/cl/sentinel/httpreqresp/server.go
@@ -305,7 +305,10 @@ func NewRequestHandler(host host.Host) http.HandlerFunc {
 		// we have 5 seconds to read the next byte. this is the 5 TTFB_TIMEOUT in the spec
 		stream.SetReadDeadline(time.Now().Add(5 * time.Second))
 		n, err := io.ReadFull(stream, code)
-		if err != nil {
+		synthesizedEmptySuccess := false
+		if err == io.EOF && n == 0 && communication.IsMultiChunkProtocol(topic) {
+			synthesizedEmptySuccess = true
+		} else if err != nil {
 			http.Error(w, "Read Code: "+err.Error()+", readBytes="+strconv.Itoa(n)+", bytesWritten="+strconv.FormatInt(bytesWritten, 10)+", contentLength="+strconv.FormatInt(r.ContentLength, 10)+", topic="+topic+", peer="+peerIdBase58, http.StatusBadRequest)
 			return
 		}
@@ -323,6 +326,10 @@ func NewRequestHandler(host host.Host) http.HandlerFunc {
 		w.Header().Set("REQRESP-PEER-ID", peerIdBase58)
 		w.Header().Set("REQRESP-TOPIC", topic)
 		w.Header().Set("REQRESP-RESPONSE-CODE", strconv.Itoa(int(code[0])))
+		if synthesizedEmptySuccess {
+			cw.setStreamingBody(io.NopCloser(bytes.NewReader(nil)))
+			return
+		}
 		// the deadline is 10 * expected chunk count, which the user can send. otherwise we will only wait 10 seconds
 		// this is technically incorrect, and more aggressive than the network might like.
 		stream.SetReadDeadline(time.Now().Add(10 * time.Second * time.Duration(chunks)))

--- a/cl/sentinel/httpreqresp/server_test.go
+++ b/cl/sentinel/httpreqresp/server_test.go
@@ -94,6 +94,15 @@ func TestMaxBytesReader(t *testing.T) {
 	}
 }
 
+func TestResponseCodeErrorMessageReturnsBodyReadError(t *testing.T) {
+	resp := &http.Response{
+		Body: io.NopCloser(newMaxBytesReader(bytes.NewReader(bytes.Repeat([]byte{0x80}, 8)), 4)),
+	}
+
+	_, err := ResponseCodeResourceUnavailable.ErrorMessage(resp)
+	require.ErrorIs(t, err, ErrResponseTooLarge)
+}
+
 // Do must not retain the handler's write buffer: callers such as http.Error hand Write fmt's
 // pooled buffer, which is reused after the call returns. If Do aliased it, a concurrent reuse of
 // that buffer would race with a caller reading resp.Body (the handshake.ValidatePeer path).

--- a/cl/sentinel/httpreqresp/server_test.go
+++ b/cl/sentinel/httpreqresp/server_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/golang/snappy"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -101,6 +102,32 @@ func TestResponseCodeErrorMessageReturnsBodyReadError(t *testing.T) {
 
 	_, err := ResponseCodeResourceUnavailable.ErrorMessage(resp)
 	require.ErrorIs(t, err, ErrResponseTooLarge)
+}
+
+func TestResponseCodeErrorMessageRejectsOverlongLengthVarint(t *testing.T) {
+	resp := &http.Response{
+		Body: io.NopCloser(bytes.NewReader(bytes.Repeat([]byte{0x80}, 10))),
+	}
+
+	_, err := ResponseCodeResourceUnavailable.ErrorMessage(resp)
+	require.ErrorIs(t, err, errMalformedErrorMessageLength)
+}
+
+func TestResponseCodeErrorMessageCapsDecodedMessage(t *testing.T) {
+	var body bytes.Buffer
+	body.WriteByte(0x01)
+	sw := snappy.NewBufferedWriter(&body)
+	_, err := sw.Write(bytes.Repeat([]byte{'x'}, maxErrorMessageBytes+1))
+	require.NoError(t, err)
+	require.NoError(t, sw.Close())
+
+	resp := &http.Response{
+		Body: io.NopCloser(&body),
+	}
+
+	msg, err := ResponseCodeResourceUnavailable.ErrorMessage(resp)
+	require.NoError(t, err)
+	require.Len(t, msg, maxErrorMessageBytes)
 }
 
 // Do must not retain the handler's write buffer: callers such as http.Error hand Write fmt's
@@ -272,6 +299,42 @@ func fetchPeerResponse(t *testing.T, topic string, payloadSize int, maxResponseB
 	return resp.StatusCode, resp.Header.Get("REQRESP-RESPONSE-CODE"), body, readErr
 }
 
+func fetchPeerEmptyCloseResponse(t *testing.T, topic string) (int, string, string, []byte, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	victim, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
+	require.NoError(t, err)
+	t.Cleanup(func() { victim.Close() })
+
+	peerHost, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
+	require.NoError(t, err)
+	t.Cleanup(func() { peerHost.Close() })
+
+	peerHost.SetStreamHandler(protocol.ID(topic), func(s network.Stream) {
+		defer s.Close()
+		_ = s.SetDeadline(time.Now().Add(10 * time.Second))
+		_, _ = io.Copy(io.Discard, s)
+	})
+
+	require.NoError(t, victim.Connect(ctx, peer.AddrInfo{ID: peerHost.ID(), Addrs: peerHost.Addrs()}))
+
+	req, err := http.NewRequestWithContext(ctx, "GET", "http://service.internal/", nil)
+	require.NoError(t, err)
+	req.Header.Set("REQRESP-PEER-ID", peerHost.ID().String())
+	req.Header.Set("REQRESP-TOPIC", topic)
+
+	mux := chi.NewRouter()
+	mux.Get("/", NewRequestHandler(victim))
+	resp, err := Do(mux, req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, readErr := io.ReadAll(resp.Body)
+	return resp.StatusCode, resp.Header.Get("REQRESP-RESPONSE-CODE"), resp.Header.Get("REQRESP-TOPIC"), body, readErr
+}
+
 // A peer that floods its response stream must not be able to make the node buffer an unbounded
 // amount of memory: a compliant single-object response streams through in full, but a flood is
 // bounded at the cap and surfaces an explicit ErrResponseTooLarge rather than being silently
@@ -289,6 +352,23 @@ func TestResponseBodyRejectedOnFlood(t *testing.T) {
 		"a single-object flood must surface an explicit too-large error, not be truncated and accepted")
 	require.LessOrEqual(t, len(body), maxSingleObjectResponse,
 		"the caller must never read more than the single-object cap from a flooding peer")
+}
+
+func TestMultiChunkEmptyCloseSynthesizesSuccess(t *testing.T) {
+	status, code, topic, body, err := fetchPeerEmptyCloseResponse(t, communication.DataColumnSidecarsByRangeProtocolV1)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status)
+	require.Equal(t, "0", code)
+	require.Equal(t, communication.DataColumnSidecarsByRangeProtocolV1, topic)
+	require.Empty(t, body)
+}
+
+func TestSingleChunkEmptyCloseReturnsBadRequest(t *testing.T) {
+	status, code, _, body, err := fetchPeerEmptyCloseResponse(t, communication.StatusProtocolV1)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Empty(t, code)
+	require.Contains(t, string(body), "Read Code: EOF")
 }
 
 // A multi-chunk request that reaches the handler without a caller budget (a caller that failed to

--- a/cl/sentinel/service/service.go
+++ b/cl/sentinel/service/service.go
@@ -17,7 +17,6 @@
 package service
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -27,7 +26,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/golang/snappy"
 	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/erigontech/erigon/cl/cltypes"
@@ -51,6 +49,10 @@ type SentinelServer struct {
 
 	logger log.Logger
 }
+
+type HTTPError = httpreqresp.HTTPError
+type PeerResponseError = httpreqresp.PeerResponseError
+type ResponseCode = httpreqresp.ResponseCode
 
 func NewSentinelServer(ctx context.Context, sentinel *sentinel.Sentinel, logger log.Logger) *SentinelServer {
 	return &SentinelServer{
@@ -110,7 +112,10 @@ func (s *SentinelServer) requestPeer(ctx context.Context, pid peer.ID, req *sent
 	// some standard http error code parsing
 	if resp.StatusCode < 200 || resp.StatusCode > 399 {
 		errBody, _ := io.ReadAll(resp.Body)
-		errorMessage := fmt.Errorf("SentinelHttp: %s", string(errBody))
+		errorMessage := &HTTPError{
+			StatusCode: resp.StatusCode,
+			Body:       string(errBody),
+		}
 		//if strings.Contains(errorMessage.Error(), "Read Code: EOF") {
 		// don't ban the peer.
 		//	return nil, errorMessage
@@ -131,12 +136,24 @@ func (s *SentinelServer) requestPeer(ctx context.Context, pid peer.ID, req *sent
 	// known error codes, just remove the peer
 	responseCode := ResponseCode(code)
 	if !responseCode.Success() {
-		if shouldBanOnFail {
+		errorMessage, err := responseCode.ErrorMessage(resp)
+		if err != nil {
+			if shouldBanOnFail {
+				s.sentinel.Peers().RemovePeer(pid)
+				s.sentinel.Host().Peerstore().RemovePeer(pid)
+				s.sentinel.Host().Network().ClosePeer(pid)
+			}
+			return nil, err
+		}
+		if shouldBanOnFail && responseCode != httpreqresp.ResponseCodeResourceUnavailable {
 			s.sentinel.Peers().RemovePeer(pid)
 			s.sentinel.Host().Peerstore().RemovePeer(pid)
 			s.sentinel.Host().Network().ClosePeer(pid)
 		}
-		return nil, fmt.Errorf("peer error code: %d (%s). Error message: %s", code, responseCode.String(), responseCode.ErrorMessage(resp))
+		return nil, &PeerResponseError{
+			Code:    responseCode,
+			Message: errorMessage,
+		}
 	}
 
 	// read the body from the response
@@ -272,53 +289,4 @@ func (s *SentinelServer) PeersInfo(ctx context.Context, r *sentinelproto.PeersIn
 
 func (s *SentinelServer) SetSubscribeExpiry(ctx context.Context, expiryReq *sentinelproto.RequestSubscribeExpiry) (*sentinelproto.EmptyMessage, error) {
 	panic("do not call this")
-}
-
-type ResponseCode int
-
-func (r ResponseCode) String() string {
-	switch r {
-	case 0:
-		return "success"
-	case 1:
-		return "invalid request"
-	case 2:
-		return "server error"
-	case 3:
-		return "resource unavailable"
-	}
-	return "unknown"
-}
-
-func (r ResponseCode) Success() bool {
-	return r == 0
-}
-
-func (r ResponseCode) ErrorMessage(resp *http.Response) string {
-	if r == 0 || r == 1 {
-		return ""
-	}
-	// Error response bodies are Snappy-compressed per the ETH2 req/resp spec.
-	// First read the varint-encoded length prefix, then decompress the payload.
-	rawReader := bufio.NewReader(resp.Body)
-	// Read and discard the varint length prefix (uncompressed length).
-	for {
-		b, err := rawReader.ReadByte()
-		if err != nil {
-			// Fallback: read raw body if varint parsing fails.
-			remaining, _ := io.ReadAll(rawReader)
-			return string(remaining)
-		}
-		if b&0x80 == 0 {
-			break // last byte of varint
-		}
-	}
-	sr := snappy.NewReader(rawReader)
-	decoded, err := io.ReadAll(sr)
-	if err != nil {
-		// Fallback: if snappy decode fails, read raw remaining bytes.
-		remaining, _ := io.ReadAll(rawReader)
-		return string(remaining)
-	}
-	return string(decoded)
 }


### PR DESCRIPTION
## Summary

Fixes the data column sidecar miss path so expected misses no longer produce noisy download logs, while keeping the wire behavior compatible with peers that signal an empty multi-chunk response by closing without a response code.

Closes #21670

## Details

- Return structured req/resp `resource unavailable` responses for by-root misses and valid pre-Fulu by-root requests, while validating malformed pre-Fulu by-root requests first so they return `invalid request`.
- Restore by-range empty-success responses to a zero-byte close, including zero-count, all-pre-Fulu, all-future, and missing-sidecar ranges.
- In the httpreqresp client bridge, synthesize success code 0 with an empty body when a negotiated multi-chunk protocol returns `io.EOF` before any response-code byte. Single-chunk EOFs, partial reads, and stream errors still surface as HTTP 400.
- Keep handler `responseErr` propagation for real storage/write errors. Across the Sentinel HTTP/gRPC boundary those transport failures can still be flattened by gRPC, while structured peer response codes are surfaced as typed `PeerResponseError` values.
- Bound peer error-message decoding to a 10-byte varint prefix and a 256-byte decoded message.
- Downgrade expected data column sidecar misses to trace while keeping other download errors at debug.

## Validation

- `go test ./cl/sentinel/httpreqresp ./cl/sentinel/service ./cl/sentinel/handlers ./cl/das -count=1`
- `make lint`