### PR TITLE
docs/site, tracetest: fix Dependabot npm alerts (uuid, ws)

### DIFF
--- a/docs/site/package-lock.json
+++ b/docs/site/package-lock.json
@@ -19468,12 +19468,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/value-equal": {
@@ -19799,9 +19803,9 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -51,6 +51,12 @@
     "webpack": "5.105.0",
     "@babel/plugin-transform-modules-systemjs": "^7.29.4",
     "fast-uri": "^3.1.2",
-    "serialize-javascript": "^7.0.5"
+    "serialize-javascript": "^7.0.5",
+    "sockjs": {
+      "uuid": "^11.1.1"
+    },
+    "webpack-dev-server": {
+      "ws": "^8.20.1"
+    }
   }
 }

--- a/execution/tracing/tracers/internal/tracetest/testgenerator/package-lock.json
+++ b/execution/tracing/tracers/internal/tracetest/testgenerator/package-lock.json
@@ -124,9 +124,9 @@
       "license": "MIT"
     },
     "node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/execution/tracing/tracers/internal/tracetest/testgenerator/package.json
+++ b/execution/tracing/tracers/internal/tracetest/testgenerator/package.json
@@ -15,5 +15,8 @@
   "devDependencies": {
     "@types/node": "^20.14.9",
     "typescript": "^5.5.2"
+  },
+  "overrides": {
+    "ws": "^8.20.1"
   }
 }


### PR DESCRIPTION
## Summary

Fixes all 3 open [Dependabot alerts](https://github.com/erigontech/erigon/security/dependabot) (3 medium) — two transitive npm deps across two lockfiles. Both are fixed with npm `overrides`, the same approach as #21168.

| Alert | Package | Lockfile | Bump |
|---|---|---|---|
| [84](https://github.com/erigontech/erigon/security/dependabot/84) | `uuid` (via `sockjs`) | `docs/site` | 8.3.2 → 11.1.1 |
| [82](https://github.com/erigontech/erigon/security/dependabot/82) | `ws` (via `webpack-dev-server`) | `docs/site` | 8.20.0 → 8.21.0 |
| [83](https://github.com/erigontech/erigon/security/dependabot/83) | `ws` (via `ethers`) | `execution/tracing/tracers/internal/tracetest/testgenerator` | 8.17.1 → 8.21.0 |

- `uuid` < 11.1.1 — [CVE-2026-41907](https://github.com/advisories/GHSA-w5hq-g745-h8pq) / GHSA-w5hq-g745-h8pq (medium): missing buffer bounds check in `v3`/`v5`/`v6` when `buf` is provided.
- `ws` >= 8.0.0, < 8.20.1 — [CVE-2026-45736](https://github.com/advisories/GHSA-58qx-3vcg-4xpx) / GHSA-58qx-3vcg-4xpx (medium): uninitialized memory disclosure.

The overrides are **scoped to the vulnerable consumers**, so the non-vulnerable sibling copies in `docs/site` are left untouched: `ws@7.5.10` (`webpack-bundle-analyzer`, which needs `^7`) and `uuid@14.0.0` (`mermaid`).

## Test plan

`docs/site` (mirrors the `Docs Site Build` CI workflow; run on Node 24):
- [x] `npm ci` — clean, lockfile in sync with `package.json`, **0 vulnerabilities**
- [x] `npm run typecheck` — passes
- [x] `npm run build` — succeeds

`testgenerator`:
- [x] `npm ci` — **0 vulnerabilities**
- [x] `npm run build` (`tsc`) — passes
