### PR TITLE
db/downloader: lock torrentsByName read in allActiveSnapshots

### DIFF
--- a/db/downloader/downloader.go
+++ b/db/downloader/downloader.go
@@ -884,6 +884,8 @@ func (d *Downloader) decDownloadRequests() {
 // Returns all torrents, with names, because if a Torrent info isn't available, we can't just yank
 // the name from there.
 func (d *Downloader) allActiveSnapshots() (ret []snapshot) {
+	d.lock.RLock()
+	defer d.lock.RUnlock()
 	for name, t := range d.torrentsByName {
 		ret = append(ret, snapshot{
 			Name:     name,

--- a/db/downloader/downloader_test.go
+++ b/db/downloader/downloader_test.go
@@ -83,15 +83,17 @@ func TestAllActiveSnapshotsConcurrentWithWrites(t *testing.T) {
 			}
 		}
 	}()
+	// Stop the reader on every exit path, including a require failure (Goexit).
+	defer func() {
+		close(stop)
+		wg.Wait()
+	}()
 
 	for i := range 64 {
 		name := fmt.Sprintf("v1-%06d-%06d-headers.seg", i, i+1)
 		ih := snaptype.Hex2InfoHash(fmt.Sprintf("%040x", i+1))
 		require.NoError(t, d.testStartSingleDownloadNoWait(ctx, ih, name))
 	}
-
-	close(stop)
-	wg.Wait()
 }
 
 func TestChangeInfoHashOfSameFile(t *testing.T) {

--- a/db/downloader/downloader_test.go
+++ b/db/downloader/downloader_test.go
@@ -18,10 +18,12 @@ package downloader
 
 import (
 	"context"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -57,6 +59,39 @@ func TestConcurrentDownload(t *testing.T) {
 		// Make sure we don't get stuck. The torrents shouldn't exist, and the Downloader is closed.
 		w(t.Context())
 	}
+}
+
+// TestAllActiveSnapshotsConcurrentWithWrites pins that allActiveSnapshots may run concurrently
+// with torrentsByName mutations; it data-races under -race unless the map read holds d.lock.
+func TestAllActiveSnapshotsConcurrentWithWrites(t *testing.T) {
+	test := newDownloaderTest(t)
+	d := test.downloader
+	ctx := t.Context()
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				d.allActiveSnapshots()
+			}
+		}
+	}()
+
+	for i := range 64 {
+		name := fmt.Sprintf("v1-%06d-%06d-headers.seg", i, i+1)
+		ih := snaptype.Hex2InfoHash(fmt.Sprintf("%040x", i+1))
+		require.NoError(t, d.testStartSingleDownloadNoWait(ctx, ih, name))
+	}
+
+	close(stop)
+	wg.Wait()
 }
 
 func TestChangeInfoHashOfSameFile(t *testing.T) {


### PR DESCRIPTION
## Problem

`Downloader.allActiveSnapshots()` iterated `d.torrentsByName` **without holding `d.lock`**, while every mutator of that map (`addTorrent` via the download path, and `Delete`) writes it under `d.lock`. The background-logger goroutine calls `allActiveSnapshots()` periodically, so it could iterate the map at the same moment a concurrent `Delete` (or torrent add) mutated it.

This tripped Go's runtime guard **`fatal error: concurrent map iteration and map write`**, which is non-recoverable and crashed the node mid-sync.

Observed in the `release/3.5` *QA - Sync from scratch* run after ~6.7h of syncing (block ~25.23M): https://github.com/erigontech/erigon/actions/runs/27142178289/job/80110054705

```
fatal error: concurrent map iteration and map write

goroutine 8450 [running]:
...
db/downloader.(*Downloader).allActiveSnapshots(...)   downloader.go:887   ← lock-free range
db/downloader.(*Downloader).backgroundLogging(...)    downloader.go:926

  (concurrent, holding d.lock:)
db/downloader.(*Downloader).Delete(...)               downloader.go:1656  ← g.MustDelete(d.torrentsByName, name)
db/downloader.(*GrpcServer).Delete(...)
```

`allActiveSnapshots` was the only lock-free reader of `torrentsByName`; all other accesses already run under `d.lock`.

## Fix

Take `d.lock.RLock()` around the map iteration in `allActiveSnapshots()`.

Deadlock-free: the only resulting lock order is `activeDownloadRequestsLock → d.lock` (from the in-loop call site in `backgroundLogging`); no path anywhere acquires those two in the reverse order, and `allActiveSnapshots` is never called while `d.lock` is already held.

## Testing

- Added `TestAllActiveSnapshotsConcurrentWithWrites`, which hammers `allActiveSnapshots()` against the real download path. It reports the exact production data race (`addTorrent` write vs `allActiveSnapshots` read on the same map) under `-race` before the fix, and passes after.
- Full `db/downloader` package green under `go test -race` (no deadlock).
- `make lint` clean; `make erigon integration` builds.

## Backport

The same bug is present on `release/3.5` (where it crashed) and `main`. A `[r3.5]` cherry-pick should follow this merge.
