### PR TITLE
[r3.5] cl/phase1/forkchoice: don't maintain GLOAS indexed weight store pre-GLOAS

### DIFF
--- a/cl/phase1/forkchoice/on_attestation.go
+++ b/cl/phase1/forkchoice/on_attestation.go
@@ -151,9 +151,10 @@ func (f *ForkChoiceStore) verifyAttestationWithState(
 	return attestationIndicies, nil
 }
 
-func (f *ForkChoiceStore) setLatestMessage(index uint64, message LatestMessage) {
-	// Update indexed weight store if present: read old value BEFORE overwriting
-	if f.indexedWeightStore != nil {
+func (f *ForkChoiceStore) setLatestMessage(index uint64, message LatestMessage, maintainIndexedVotes bool) {
+	// The indexed weight store is only read by GLOAS get_head; maintaining it on
+	// the pre-GLOAS path is wasted per-vote work under the fork-choice lock.
+	if maintainIndexedVotes && f.indexedWeightStore != nil {
 		if oldMessage, has := f.latestMessages.get(int(index)); has && oldMessage != (LatestMessage{}) {
 			f.indexedWeightStore.RemoveVote(index, oldMessage.Root)
 		}
@@ -161,8 +162,7 @@ func (f *ForkChoiceStore) setLatestMessage(index uint64, message LatestMessage) 
 
 	f.latestMessages.set(int(index), message)
 
-	// Add new vote to index (balance looked up internally)
-	if f.indexedWeightStore != nil {
+	if maintainIndexedVotes && f.indexedWeightStore != nil {
 		f.indexedWeightStore.IndexVote(index, message)
 	}
 }
@@ -225,7 +225,7 @@ func (f *ForkChoiceStore) updateLatestMessagesPreGloas(
 				Epoch: target.Epoch,
 				Root:  beaconBlockRoot,
 				Slot:  slot, // Set slot for GLOAS compatibility at fork boundary
-			})
+			}, false)
 		}
 	}
 }
@@ -251,7 +251,7 @@ func (f *ForkChoiceStore) updateLatestMessagesGloas(
 				Slot:           slot,
 				Root:           beaconBlockRoot,
 				PayloadPresent: payloadPresent,
-			})
+			}, true)
 		}
 	}
 }

--- a/cl/phase1/forkchoice/weight_store_indexed_test.go
+++ b/cl/phase1/forkchoice/weight_store_indexed_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package forkchoice
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/common"
+)
+
+func newIndexedWeightStoreTestStore() *ForkChoiceStore {
+	f := &ForkChoiceStore{
+		beaconCfg:      &clparams.MainnetBeaconConfig,
+		latestMessages: newLatestMessagesStore(16),
+	}
+	f.justifiedCheckpoint.Store(solid.Checkpoint{})
+	f.indexedWeightStore = NewIndexedWeightStore(f)
+	return f
+}
+
+// Pre-GLOAS fork choice computes head with the non-indexed weightStore, so the
+// GLOAS-only indexedWeightStore must not be maintained on the pre-GLOAS vote
+// path. Maintaining it there is wasted work (per-vote allocation and balance
+// lookups under the fork-choice lock) whose result is never read.
+func TestPreGloasDoesNotMaintainIndexedWeightStore(t *testing.T) {
+	f := newIndexedWeightStoreTestStore()
+
+	att := &solid.Attestation{
+		Data: &solid.AttestationData{
+			Slot:            64,
+			BeaconBlockRoot: common.HexToHash("0xbeef"),
+			Target:          solid.Checkpoint{Epoch: 2, Root: common.HexToHash("0xaaaa")},
+		},
+	}
+	f.updateLatestMessagesPreGloas(att, []uint64{1, 2, 3})
+
+	msg, has := f.getLatestMessage(2)
+	require.True(t, has, "pre-GLOAS path must still record the latest message")
+	require.Equal(t, att.Data.BeaconBlockRoot, msg.Root)
+
+	require.Empty(t, f.indexedWeightStore.directVotes,
+		"pre-GLOAS must not populate the GLOAS indexed weight store")
+}
+
+// The GLOAS vote path must keep maintaining the indexed weight store.
+func TestGloasMaintainsIndexedWeightStore(t *testing.T) {
+	f := newIndexedWeightStoreTestStore()
+
+	att := &solid.Attestation{
+		Data: &solid.AttestationData{
+			Slot:            64,
+			BeaconBlockRoot: common.HexToHash("0xbeef"),
+			Target:          solid.Checkpoint{Epoch: 2, Root: common.HexToHash("0xaaaa")},
+		},
+	}
+	f.updateLatestMessagesGloas(att, []uint64{1, 2, 3})
+
+	require.Len(t, f.indexedWeightStore.directVotes[att.Data.BeaconBlockRoot], 3,
+		"GLOAS path must index votes for the voted root")
+}


### PR DESCRIPTION
Cherry-pick of #21698 to release/3.5.

Fixes the Caplin pre-GLOAS attestation head-vote regression: the GLOAS `indexedWeightStore` was maintained on every vote regardless of fork (top CPU hotspot + GC pressure under the fork-choice lock) but never read pre-GLOAS, delaying head updates past the attestation deadline. Validated on a live Hoodi node (node CPU ~7.5%->`<2%`, head-vote misses 40%->0%).

Clean cherry-pick; `on_attestation.go` is identical between `main` and `release/3.5`.
