### PR TITLE
execution/p2p: log peer penalization on bad BAL response

### DIFF
--- a/execution/p2p/bal_fetcher.go
+++ b/execution/p2p/bal_fetcher.go
@@ -149,6 +149,7 @@ func (f *balFetcher) fetchFromPeer(ctx context.Context, reqs []BALRequest, peerI
 	}
 	out, badPeer, err := validateBALResponse(reqs, response)
 	if badPeer {
+		f.logger.Debug("[p2p.bal] penalizing peer for bad BAL response", "peerId", peerId, "err", err)
 		f.penalize(ctx, peerId)
 	}
 	return out, err


### PR DESCRIPTION
The eth/71 BAL fetcher penalizes (kicks) a peer when its `GetBlockAccessLists` response fails validation — an over-long response, an empty (`0xc0`) BAL where the header commits to a non-empty one, or a payload whose keccak256 doesn't match the committed `blockAccessListHash` (`validateBALResponse` → `badPeer` → `penalize` → `PenaltyKind_Kick`).

That penalization is currently invisible in logs:

- `penalize()` only logs when penalizing *fails*, not when it happens.
- The existing `[p2p.bal] peer did not serve BALs` line fires for every BAL fetch error (timeouts, peer-not-found, and bad-BAL alike), so it doesn't indicate whether a peer was actually kicked — or why.

This adds a `Debug` line at the penalize point with the `peerId` and the validation `err`, so peer churn caused by BAL disagreements becomes diagnosable (e.g. a peer kicked for a bad BAL then surfacing as `peer not found` on subsequent body fetches).

Logging-only; no behaviour change.
