### PR TITLE
ci: warm kurtosis GLOAS image cache via dedicated paths + scheduled workflow

### DIFF
--- a/.github/workflows/cache-warming-kurtosis-gloas-images.yml
+++ b/.github/workflows/cache-warming-kurtosis-gloas-images.yml
@@ -1,0 +1,40 @@
+name: Cache Warming — Kurtosis GLOAS images
+
+# Populates the base-branch docker-cl-* image cache that test-kurtosis-gloas.yml
+# restores. That workflow only saves the cache on non-PR events and has no push /
+# schedule trigger of its own, so without this its PR runs cold-pull every
+# third-party image from Docker Hub. GitHub cache scoping makes default-branch
+# caches readable from every PR, so warming on main/release is enough.
+#
+# Triggers:
+#   - push to a protected branch touching test-kurtosis-gloas.yml -> warm on a version bump
+#   - schedule (daily)                                            -> safety net if LRU-evicted
+#   - workflow_dispatch                                           -> manual (use once to bootstrap)
+#
+# The cache key is derived from the pinned image versions, which all live in
+# test-kurtosis-gloas.yml — hence the paths filter on that file.
+
+on:
+  push:
+    branches:
+      - main
+      - 'release/**'
+    paths:
+      - '.github/workflows/test-kurtosis-gloas.yml'
+  schedule:
+    - cron: '37 5 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  warm:
+    uses: ./.github/workflows/test-kurtosis-gloas.yml
+    with:
+      cl-images-only: true
+    secrets: inherit

--- a/.github/workflows/test-kurtosis-gloas.yml
+++ b/.github/workflows/test-kurtosis-gloas.yml
@@ -25,6 +25,12 @@ on:
       - synchronize
       - ready_for_review
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      cl-images-only:
+        description: "Only warm the third-party CL/kurtosis image cache; skip the tests"
+        type: boolean
+        default: false
 
 concurrency:
   group: >-
@@ -39,9 +45,70 @@ permissions:
   contents: read
 
 jobs:
+  # Warms the docker-cl-* cache on the default branch (where this workflow's PR
+  # runs restore it) via a dedicated workflow on a paths filter + daily schedule —
+  # the cache only changes when the pinned image versions in this file change.
+  # lookup-only makes it a no-op when the cache already exists.
+  warm-third-party-images:
+    if: ${{ inputs.cl-images-only }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Conditional Docker Login
+        if: |
+          github.repository == 'erigontech/erigon' &&
+          github.actor != 'dependabot[bot]' &&
+          !github.event.pull_request.head.repo.fork
+        continue-on-error: true
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_PULL_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
+
+      - name: Check whether third-party containers are already cached
+        id: cache-cl-images
+        uses: actions/cache/restore@v5
+        with:
+          path: /tmp/docker-cache
+          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}
+          lookup-only: true
+
+      - name: Pull third-party containers
+        if: steps.cache-cl-images.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p /tmp/docker-cache
+          pull() {
+            for n in 1 2 3; do
+              if docker pull "$1"; then return 0; fi
+              echo "docker pull $1 failed (attempt $n of 3)"
+              sleep $((10 * n))
+            done
+            return 1
+          }
+          pull "${LIGHTHOUSE_IMAGE}"
+          pull "${ASSERTOOR_IMAGE}"
+          pull "kurtosistech/engine:${KURTOSIS_VERSION}"
+          pull "kurtosistech/core:${KURTOSIS_VERSION}"
+          pull "kurtosistech/files-artifacts-expander:${KURTOSIS_VERSION}"
+          pull "${KURTOSIS_VECTOR_IMAGE}"
+          pull "${KURTOSIS_FLUENTBIT_IMAGE}"
+          docker save "${LIGHTHOUSE_IMAGE}" -o /tmp/docker-cache/lighthouse.tar
+          docker save "${ASSERTOOR_IMAGE}" -o /tmp/docker-cache/assertoor.tar
+          docker save "kurtosistech/engine:${KURTOSIS_VERSION}" -o /tmp/docker-cache/kurtosis-engine.tar
+          docker save "kurtosistech/core:${KURTOSIS_VERSION}" -o /tmp/docker-cache/kurtosis-core.tar
+          docker save "kurtosistech/files-artifacts-expander:${KURTOSIS_VERSION}" -o /tmp/docker-cache/kurtosis-expander.tar
+          docker save "${KURTOSIS_VECTOR_IMAGE}" -o /tmp/docker-cache/vector.tar
+          docker save "${KURTOSIS_FLUENTBIT_IMAGE}" -o /tmp/docker-cache/fluentbit.tar
+
+      - name: Save third-party containers to cache
+        if: steps.cache-cl-images.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: /tmp/docker-cache
+          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}
+
   gloas_test:
     name: gloas_${{ matrix.suite }}_test
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !inputs.cl-images-only && !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Problem

`test-kurtosis-gloas.yml` restores the `docker-cl-*` third-party image cache but nothing ever warms it on the default branch:

- It triggers on `pull_request` + `workflow_dispatch` only — no `push` / `merge_group` / `schedule`.
- Its cache `save` is gated `github.event_name != 'pull_request'` (since #21602), and its only non-PR trigger is manual `workflow_dispatch`.

So the cache is never systematically populated on the default branch, and gloas PR runs cold-pull all 7 third-party images from Docker Hub on ~every run — exposed to the same Docker Hub flakes as the assertoor workflow, protected only by the 3-attempt retry.

This is a **different cache key** from the assertoor warmer (#21695) — gloas's key omits `TEKU` — so that warmer doesn't cover it. And unlike assertoor, gloas does **not** run in `merge_group`, so a flake here fails a PR check rather than bouncing the merge queue — lower blast radius, same root gap.

## Fix

Mirror #21695 for gloas:

- Make `test-kurtosis-gloas.yml` callable (`workflow_call`) with a new **`cl-images-only`** input that runs *only* a new `warm-third-party-images` job; the `gloas_test` matrix is gated off under it.
- The warm job uses **`actions/cache/restore@v5` (`lookup-only`)** + an explicit **`actions/cache/save@v5`** on miss — a ~10 s no-op when the cache already exists, pull + save only on a genuine miss.
- New **`cache-warming-kurtosis-gloas-images.yml`** drives it on `push` to `main`/`release/**` filtered on `paths: [test-kurtosis-gloas.yml]` (re-warm on version bumps) + a daily `schedule` (repopulate after LRU eviction at the 500 GB cache ceiling) + `workflow_dispatch`.

Net effect: gloas PR runs restore the cache from the default branch instead of pulling from Docker Hub.

## Notes

- Follow-up to #21695 (assertoor CL cache); same pattern, gloas's own key/image set (no teku).
- The pinned image versions are duplicated across `test-kurtosis-assertoor.yml` and `test-kurtosis-gloas.yml` (and now their two warmers). Unifying them into a single source so one warmer covers both is a sensible future cleanup — called out, not done here.

## Validation

- `actionlint` clean on both workflows (the one `SC2086` info is pre-existing, in an untouched `run:` block).
- Gating: with `cl-images-only`, only `warm-third-party-images` runs; on `pull_request` / `workflow_dispatch` (no input), `gloas_test` runs as before. The PR-merge touches `test-kurtosis-gloas.yml`, so the `paths` trigger warms the cache on merge — no cold-start gap.
