### PR TITLE
db/version, cl, build: advertise a correct node version, fix misleading GitTag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,15 @@ DOCKER_BINARIES ?= "erigon"
 GIT_COMMIT ?= $(shell git rev-list -1 HEAD)
 SHORT_COMMIT := $(shell echo $(GIT_COMMIT) | cut -c 1-8)
 GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
-GIT_TAG    ?= $(shell git describe --tags '--match=*.*.*' --abbrev=7 --dirty)
 
-# Use git tag value for "release/" branches only. Otherwise it make no sense.
-ifeq (,$(findstring release/,$(GIT_BRANCH)))
-  GIT_TAG	:= .
-endif
+# GIT_TAG is the exact release tag at HEAD (e.g. v3.5.0) when building from a
+# tagged release, and empty otherwise. It is build provenance only; the
+# advertised version comes from db/version (see NodeVersion). Earlier this used
+# `git describe`, which on an untagged branch anchored to an unrelated older
+# tag and produced a misleading value. The grep allowlist keeps untrusted tag
+# names (git refs permit shell metacharacters) out of the -ldflags shell line.
+# Override via the environment.
+GIT_TAG    ?= $(shell git tag --points-at HEAD --list 'v*' 2>/dev/null | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$$' | head -n 1)
 
 ERIGON_USER ?= erigon
 # if using volume-mounting data dir, then must exist on host OS

--- a/cl/p2p/config.go
+++ b/cl/p2p/config.go
@@ -6,6 +6,7 @@ import (
 	"net"
 
 	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/version"
 	"github.com/libp2p/go-libp2p"
 	mplex "github.com/libp2p/go-libp2p-mplex"
 	"github.com/libp2p/go-libp2p/core/crypto"
@@ -65,7 +66,7 @@ func buildOptions(cfg *P2PConfig, privateKey *ecdsa.PrivateKey) ([]libp2p.Option
 	options := []libp2p.Option{
 		privKeyOption(privateKey),
 		libp2p.ListenAddrs(listen),
-		libp2p.UserAgent("erigon/caplin"),
+		libp2p.UserAgent("erigon/caplin/" + version.NodeVersion()),
 		libp2p.Transport(tcp.NewTCPTransport),
 		libp2p.Muxer("/mplex/6.7.0", mplex.DefaultTransport),
 		libp2p.DefaultMuxers,

--- a/cmd/caplin/caplin1/run.go
+++ b/cmd/caplin/caplin1/run.go
@@ -594,7 +594,7 @@ func RunCaplinService(ctx context.Context, engine execution_client.ExecutionEngi
 			syncedDataManager,
 			statesReader,
 			sentinel,
-			version.GitTag,
+			version.NodeVersion(),
 			&config.BeaconAPIRouter,
 			emitters,
 			blobStorage,

--- a/db/version/app.go
+++ b/db/version/app.go
@@ -18,6 +18,7 @@ package version
 
 import (
 	"fmt"
+	"regexp"
 )
 
 var (
@@ -60,4 +61,21 @@ func VersionWithCommit(gitCommit string) string {
 		vsn += "-" + gitCommit[:8]
 	}
 	return vsn
+}
+
+// releaseTagPattern is the allowlist for GitTag. It is untrusted build-time git
+// metadata (git ref names permit `$`, backticks and other shell metacharacters),
+// so only a well-formed release tag — vMAJOR.MINOR.PATCH with an optional
+// pre-release suffix — is ever accepted into an advertised version string.
+var releaseTagPattern = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$`)
+
+// NodeVersion is the human-facing version advertised to peers and over APIs.
+// A build from an exact release tag reports that tag (e.g. v3.5.0); any other
+// build reports the in-development version plus the short commit for provenance
+// (e.g. 3.5.0-dev-a53e9545).
+func NodeVersion() string {
+	if releaseTagPattern.MatchString(GitTag) {
+		return GitTag
+	}
+	return VersionWithCommit(GitCommit)
 }

--- a/db/version/app.go
+++ b/db/version/app.go
@@ -63,18 +63,17 @@ func VersionWithCommit(gitCommit string) string {
 	return vsn
 }
 
-// releaseTagPattern is the allowlist for GitTag. It is untrusted build-time git
-// metadata (git ref names permit `$`, backticks and other shell metacharacters),
-// so only a well-formed release tag — vMAJOR.MINOR.PATCH with an optional
-// pre-release suffix — is ever accepted into an advertised version string.
-var releaseTagPattern = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$`)
+// advertisedVersionPattern keeps shell-metacharacter and control content out of
+// the advertised version: GitTag is untrusted build-time metadata (and may be
+// passed via env for builds without .git), so it is honored only when version-shaped.
+var advertisedVersionPattern = regexp.MustCompile(`^v?[0-9][0-9A-Za-z.+-]*$`)
 
 // NodeVersion is the human-facing version advertised to peers and over APIs.
-// A build from an exact release tag reports that tag (e.g. v3.5.0); any other
-// build reports the in-development version plus the short commit for provenance
+// A build from a release tag reports that tag (e.g. v3.5.0); any other build
+// reports the in-development version plus the short commit for provenance
 // (e.g. 3.5.0-dev-a53e9545).
 func NodeVersion() string {
-	if releaseTagPattern.MatchString(GitTag) {
+	if advertisedVersionPattern.MatchString(GitTag) {
 		return GitTag
 	}
 	return VersionWithCommit(GitCommit)

--- a/db/version/app_test.go
+++ b/db/version/app_test.go
@@ -40,18 +40,22 @@ func TestNodeVersion(t *testing.T) {
 	GitTag, GitCommit = "", ""
 	require.Equal(t, VersionWithMeta, NodeVersion())
 
-	// Well-formed release tags (incl. pre-release suffixes) are accepted.
+	// Version-shaped values are honored verbatim: release tags, pre-releases,
+	// and git-describe / operator-supplied (env) forms for builds without .git.
 	GitCommit = commit
-	for _, good := range []string{"v3.5.0", "v3.5.1", "v3.4.0-rc.1", "v3.0.0-beta1"} {
+	for _, good := range []string{
+		"v3.5.0", "v3.5.1", "v3.4.0-rc.1", "v3.0.0-beta1", "v3.5",
+		"3.5.0", "v3.5.0-5-gabcdef", "v3.0.0-beta1-4014-ga53e954",
+	} {
 		GitTag = good
 		require.Equal(t, good, NodeVersion(), "tag %q must be accepted", good)
 	}
 
-	// GitTag is untrusted build-time git metadata. Anything not matching the
-	// release-tag pattern (malformed, or shell/command-injection payloads that
-	// are valid git ref names) must be rejected and never advertised.
+	// GitTag is untrusted build-time git metadata. Shell/command-injection
+	// payloads that are nonetheless valid git ref names, and non-version junk,
+	// must be rejected and never advertised.
 	for _, bad := range []string{
-		"v3.5", "3.5.0", "garbage", "v3.5.0 -X evil",
+		"garbage", "v3.5.0 -X evil",
 		"v3.5.0`id`", "v3.5.0$(whoami)", "v3.5.0;rm -rf /", "v3.5.0|cat",
 	} {
 		GitTag = bad

--- a/db/version/app_test.go
+++ b/db/version/app_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNodeVersion(t *testing.T) {
+	origTag, origCommit := GitTag, GitCommit
+	t.Cleanup(func() { GitTag, GitCommit = origTag, origCommit })
+
+	const commit = "a53e954520442aa91a92f111eb23b213ffc800b7"
+
+	// A build from an exact release tag reports that tag verbatim.
+	GitTag, GitCommit = "v3.5.0", commit
+	require.Equal(t, "v3.5.0", NodeVersion())
+
+	// A dev build (no tag) reports the in-development version plus short commit.
+	GitTag, GitCommit = "", commit
+	require.Equal(t, VersionWithMeta+"-a53e9545", NodeVersion())
+
+	// A dev build with no commit info falls back to the in-development version.
+	GitTag, GitCommit = "", ""
+	require.Equal(t, VersionWithMeta, NodeVersion())
+
+	// Well-formed release tags (incl. pre-release suffixes) are accepted.
+	GitCommit = commit
+	for _, good := range []string{"v3.5.0", "v3.5.1", "v3.4.0-rc.1", "v3.0.0-beta1"} {
+		GitTag = good
+		require.Equal(t, good, NodeVersion(), "tag %q must be accepted", good)
+	}
+
+	// GitTag is untrusted build-time git metadata. Anything not matching the
+	// release-tag pattern (malformed, or shell/command-injection payloads that
+	// are valid git ref names) must be rejected and never advertised.
+	for _, bad := range []string{
+		"v3.5", "3.5.0", "garbage", "v3.5.0 -X evil",
+		"v3.5.0`id`", "v3.5.0$(whoami)", "v3.5.0;rm -rf /", "v3.5.0|cat",
+	} {
+		GitTag = bad
+		require.Equal(t, VersionWithMeta+"-a53e9545", NodeVersion(), "tag %q must be rejected", bad)
+	}
+}


### PR DESCRIPTION
## Problem

The version Caplin advertised to the network came from the Makefile's `GIT_TAG`, which used `git describe --tags --match=*.*.*`. On a branch with no tag of its own series (e.g. `release/3.5`), `describe` walks back to the nearest *unrelated* tag and emits a misleading string. A live `release/3.5` node announced:

```
Caplin/v3.0.0-beta1-4014-g17a45ce   # anchored to a tag 4014 commits back, from another series
```

Root causes:
1. `--match=*.*.*` matches tags from **every** release series, so an untagged branch anchors to an old foreign tag.
2. `git describe` long-form is **not a tag**; presenting it as `GitTag` is misleading.
3. The value is **untrusted build-time git metadata** (git ref names permit `` ` ``, `$`, `(`, `)`, `;`, `|`) and flowed verbatim into both the `-ldflags` shell line (build-time command-injection risk: `$( )`/backticks expand even inside double quotes) and advertised runtime strings.

## Changes

- **`Makefile`** — `GIT_TAG` = the **exact release tag at HEAD** (`git tag --points-at HEAD`) or empty; build provenance only. A `grep` allowlist (`^v[0-9]+\.[0-9]+\.[0-9]+(-…)?$`) keeps untrusted tag content out of the `-ldflags` shell line.
- **`db/version`** — new `NodeVersion()`, the single source for the advertised version: a tagged build reports the tag (`v3.5.0`); any other build reports the in-development version + short commit (`3.5.0-dev-a53e9545`). `GitTag` is validated against the same allowlist before use, so injected/malformed tag content is never advertised (defense-in-depth with the Makefile filter).
- **`cl/beacon`** (via `cmd/caplin`) — advertise `NodeVersion()` instead of raw `GitTag`.
- **`cl/p2p`** — the libp2p `UserAgent` was a static `"erigon/caplin"` with no version (an oversight from the sentinel-extraction refactor #17926; `db/version` is a leaf package so there was never an import-cycle reason). Now `erigon/caplin/<NodeVersion()>`.

## Where the version string is exposed

| Surface | Source (after this PR) | Example — dev build on `release/3.5` | Changed here |
|---|---|---|---|
| **CL** Beacon API `/eth/v1/node/version` (Caplin agent) | `NodeVersion()` | `Caplin/3.5.0-dev-a53e9545 linux/amd64` | ✅ (was the bug) |
| **CL** libp2p `UserAgent` | `NodeVersion()` | `erigon/caplin/3.5.0-dev-a53e9545` | ✅ (was version-less) |
| **EL** devp2p node name (handshake/enode) | `VersionWithCommit` | `erigon/v3.5.0-dev-a53e9545/linux-amd64/go1.25` | — |
| **EL** `web3_clientVersion` / `ClientVersion` | `MakeName("erigon", VersionNoMeta)` | `erigon/v3.5.0/linux-amd64/go1.25` | — |
| **EL** `engine_getClientVersionV1` | `VersionWithCommit` + commit hash | `3.5.0-dev-a53e9545` (+ `0x…`) | — |
| **EL** block `ExtraData` | `App.Name + "-" + VersionWithCommit` | `erigon-3.5.0-dev-a53e9545` | — |
| Shutter libp2p `UserAgent` | `VersionWithCommit` | `erigon/shutter/3.5.0-dev-a53e9545` | — |
| CLI `--version` | `VersionWithCommit` | `erigon version 3.5.0-dev-a53e9545` | — |
| `erigon_info` metric | `VersionNoMeta` + commit label | `version="3.5.0" commit="a53e9545…"` | — |
| DB stored version | `VersionNoMeta` | `3.5.0` | — |
| remotedb Major/Minor | `version.Major` / `Minor` constants | `3` / `5` | — |
| `Build info` log line | `GitBranch` / `GitTag` / `GitCommit` | `git_tag=` (empty until a real tag) | — (now honest) |

Semantic-version surfaces (DB, metric, `web3_clientVersion`, remotedb) intentionally keep the `db/version` constants as their source of truth — reproducible without git. This PR only corrects the **advertised node version** (CL) and the **provenance tag** (Makefile).

## Tests

`TestNodeVersion` covers: exact tag accepted; dev fallback (`<semver>-dev-<commit>`); no-commit fallback; well-formed pre-release tags accepted; and malformed / command-injection-style tags (`` v3.5.0`id` ``, `v3.5.0$(whoami)`, `v3.5.0;rm -rf /`, …) rejected. `make lint` and `make erigon` clean.

## Follow-ups (not in this PR)

- Optionally route the EL advertised surfaces through `NodeVersion()` too, so tagged releases drop the `-dev` suffix everywhere (touches network-visible EL strings + block `ExtraData`; deserves its own review).
- CI guard asserting `db/version` constants match the tag being cut on `release/X.Y`.

## Builds without a `.git` directory (Docker / source tarball)

`GIT_TAG`/`GIT_COMMIT`/`GIT_BRANCH` keep their `?=` assignment, so a build that
has no git history can still inject them via the environment (the `$(shell git …)`
is skipped). At runtime `NodeVersion()` validates `GitTag` with a *version-shaped,
shell-safe* allowlist rather than strict semver, so legitimately operator-supplied
values — including `git describe` output run on the host and passed in — are
honored verbatim, while injection/garbage is rejected and falls back to the
commit-based dev version. The Makefile's strict release-tag match applies only to
the value derived from git in-tree.
