### PR TITLE
[r3.5] db/version, cl, build: advertise a correct node version, fix misleading GitTag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,15 @@ DOCKER_BINARIES ?= "erigon"
 GIT_COMMIT ?= $(shell git rev-list -1 HEAD)
 SHORT_COMMIT := $(shell echo $(GIT_COMMIT) | cut -c 1-8)
 GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
-GIT_TAG    ?= $(shell git describe --tags '--match=*.*.*' --abbrev=7 --dirty)
 
-# Use git tag value for "release/" branches only. Otherwise it make no sense.
-ifeq (,$(findstring release/,$(GIT_BRANCH)))
-  GIT_TAG	:= .
-endif
+# GIT_TAG is the exact release tag at HEAD (e.g. v3.5.0) when building from a
+# tagged release, and empty otherwise. It is build provenance only; the
+# advertised version comes from db/version (see NodeVersion). Earlier this used
+# `git describe`, which on an untagged branch anchored to an unrelated older
+# tag and produced a misleading value. The grep allowlist keeps untrusted tag
+# names (git refs permit shell metacharacters) out of the -ldflags shell line.
+# Override via the environment.
+GIT_TAG    ?= $(shell git tag --points-at HEAD --list 'v*' 2>/dev/null | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$$' | head -n 1)
 
 ERIGON_USER ?= erigon
 # if using volume-mounting data dir, then must exist on host OS

--- a/cl/p2p/config.go
+++ b/cl/p2p/config.go
@@ -6,6 +6,7 @@ import (
 	"net"
 
 	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/version"
 	"github.com/libp2p/go-libp2p"
 	mplex "github.com/libp2p/go-libp2p-mplex"
 	"github.com/libp2p/go-libp2p/core/crypto"
@@ -65,7 +66,7 @@ func buildOptions(cfg *P2PConfig, privateKey *ecdsa.PrivateKey) ([]libp2p.Option
 	options := []libp2p.Option{
 		privKeyOption(privateKey),
 		libp2p.ListenAddrs(listen),
-		libp2p.UserAgent("erigon/caplin"),
+		libp2p.UserAgent("erigon/caplin/" + version.NodeVersion()),
 		libp2p.Transport(tcp.NewTCPTransport),
 		libp2p.Muxer("/mplex/6.7.0", mplex.DefaultTransport),
 		libp2p.DefaultMuxers,

--- a/cmd/caplin/caplin1/run.go
+++ b/cmd/caplin/caplin1/run.go
@@ -594,7 +594,7 @@ func RunCaplinService(ctx context.Context, engine execution_client.ExecutionEngi
 			syncedDataManager,
 			statesReader,
 			sentinel,
-			version.GitTag,
+			version.NodeVersion(),
 			&config.BeaconAPIRouter,
 			emitters,
 			blobStorage,

--- a/db/version/app.go
+++ b/db/version/app.go
@@ -18,6 +18,7 @@ package version
 
 import (
 	"fmt"
+	"regexp"
 )
 
 var (
@@ -60,4 +61,20 @@ func VersionWithCommit(gitCommit string) string {
 		vsn += "-" + gitCommit[:8]
 	}
 	return vsn
+}
+
+// advertisedVersionPattern keeps shell-metacharacter and control content out of
+// the advertised version: GitTag is untrusted build-time metadata (and may be
+// passed via env for builds without .git), so it is honored only when version-shaped.
+var advertisedVersionPattern = regexp.MustCompile(`^v?[0-9][0-9A-Za-z.+-]*$`)
+
+// NodeVersion is the human-facing version advertised to peers and over APIs.
+// A build from a release tag reports that tag (e.g. v3.5.0); any other build
+// reports the in-development version plus the short commit for provenance
+// (e.g. 3.5.0-dev-a53e9545).
+func NodeVersion() string {
+	if advertisedVersionPattern.MatchString(GitTag) {
+		return GitTag
+	}
+	return VersionWithCommit(GitCommit)
 }

--- a/db/version/app_test.go
+++ b/db/version/app_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNodeVersion(t *testing.T) {
+	origTag, origCommit := GitTag, GitCommit
+	t.Cleanup(func() { GitTag, GitCommit = origTag, origCommit })
+
+	const commit = "a53e954520442aa91a92f111eb23b213ffc800b7"
+
+	// A build from an exact release tag reports that tag verbatim.
+	GitTag, GitCommit = "v3.5.0", commit
+	require.Equal(t, "v3.5.0", NodeVersion())
+
+	// A dev build (no tag) reports the in-development version plus short commit.
+	GitTag, GitCommit = "", commit
+	require.Equal(t, VersionWithMeta+"-a53e9545", NodeVersion())
+
+	// A dev build with no commit info falls back to the in-development version.
+	GitTag, GitCommit = "", ""
+	require.Equal(t, VersionWithMeta, NodeVersion())
+
+	// Version-shaped values are honored verbatim: release tags, pre-releases,
+	// and git-describe / operator-supplied (env) forms for builds without .git.
+	GitCommit = commit
+	for _, good := range []string{
+		"v3.5.0", "v3.5.1", "v3.4.0-rc.1", "v3.0.0-beta1", "v3.5",
+		"3.5.0", "v3.5.0-5-gabcdef", "v3.0.0-beta1-4014-ga53e954",
+	} {
+		GitTag = good
+		require.Equal(t, good, NodeVersion(), "tag %q must be accepted", good)
+	}
+
+	// GitTag is untrusted build-time git metadata. Shell/command-injection
+	// payloads that are nonetheless valid git ref names, and non-version junk,
+	// must be rejected and never advertised.
+	for _, bad := range []string{
+		"garbage", "v3.5.0 -X evil",
+		"v3.5.0`id`", "v3.5.0$(whoami)", "v3.5.0;rm -rf /", "v3.5.0|cat",
+	} {
+		GitTag = bad
+		require.Equal(t, VersionWithMeta+"-a53e9545", NodeVersion(), "tag %q must be rejected", bad)
+	}
+}


### PR DESCRIPTION
Cherry-pick of #21707 to release/3.5 (squashes the two content commits into one).

Fixes Caplin advertising a misleading version (`Caplin/v3.0.0-beta1-4014-g17a45ce`) derived from `git describe`. See #21707 for full analysis, the version-surface table, the security hardening (untrusted git-tag allowlist), and no-.git/env build handling.

Clean cherry-pick; the touched files (Makefile, db/version, cl/p2p, cmd/caplin) are shared with main.
