### PR TITLE
ci: fix Go cache namespace so warming reaches gate runs, collapse eest-spec keys

### DIFF
--- a/.github/actions/cleanup-erigon/action.yml
+++ b/.github/actions/cleanup-erigon/action.yml
@@ -4,19 +4,41 @@ description: Save build and module caches, and report uncached test packages
 runs:
   using: composite
   steps:
+    # Sibling matrix jobs can share one primary key; skip the prune/tar/upload
+    # when another job in this run has already saved the exact entry.
+    - name: Check for existing build cache entry
+      id: gocache-probe
+      if: ${{ always() && env.ERIGON_CI_GOCACHE_PATH != '' && env.ERIGON_CI_GOCACHE_KEY != '' }}
+      continue-on-error: true
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ env.ERIGON_CI_GOCACHE_PATH }}
+        key: ${{ env.ERIGON_CI_GOCACHE_KEY }}
+        lookup-only: true
+
     - name: Prune Go build cache
-      if: ${{ always() && env.ERIGON_CI_GOCACHE_PATH != '' }}
+      if: ${{ always() && env.ERIGON_CI_GOCACHE_PATH != '' && steps.gocache-probe.outputs.cache-hit != 'true' }}
       shell: bash
       run: python3 tools/prune-gocache "$ERIGON_CI_GOCACHE_PATH"
 
     - uses: ./.github/actions/save-build-cache
-      if: ${{ always() && env.ERIGON_CI_GOCACHE_PATH != '' }}
+      if: ${{ always() && env.ERIGON_CI_GOCACHE_PATH != '' && steps.gocache-probe.outputs.cache-hit != 'true' }}
       with:
         gocache: ${{ env.ERIGON_CI_GOCACHE_PATH }}
         key: ${{ env.ERIGON_CI_GOCACHE_KEY }}
 
+    - name: Check for existing module cache entry
+      id: modcache-probe
+      if: ${{ always() && env.ERIGON_CI_MODCACHE != '' && env.ERIGON_CI_MODCACHE_KEY != '' }}
+      continue-on-error: true
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ env.ERIGON_CI_MODCACHE }}/cache/download
+        key: ${{ env.ERIGON_CI_MODCACHE_KEY }}
+        lookup-only: true
+
     - uses: ./.github/actions/save-mod-cache
-      if: ${{ always() && env.ERIGON_CI_MODCACHE != '' }}
+      if: ${{ always() && env.ERIGON_CI_MODCACHE != '' && steps.modcache-probe.outputs.cache-hit != 'true' }}
       with:
         modcache-path: ${{ env.ERIGON_CI_MODCACHE }}
         key: ${{ env.ERIGON_CI_MODCACHE_KEY }}

--- a/.github/actions/setup-erigon/action.yml
+++ b/.github/actions/setup-erigon/action.yml
@@ -22,6 +22,13 @@ inputs:
     description: "Extra segment appended to build cache key (e.g. matrix.test-group)"
     required: false
     default: ''
+  cache-namespace:
+    description: >
+      Workflow segment of the Go cache keys. Defaults to the top-level workflow
+      file basename, which differs between ci-gate and cache-warming runs;
+      reusable workflows should pass their own basename so keys match across both.
+    required: false
+    default: ''
   ramdisk:
     description: "Create a RAM disk and export its path as ERIGON_EXECUTION_TESTS_TMPDIR"
     required: false
@@ -227,6 +234,9 @@ runs:
         go-version: ${{ steps.goversion.outputs.version }}
         # We have our own caching because we smrt.
         cache: false
+        # Resolve 1.N.x to the same patch release on every runner regardless of
+        # what the image tool cache ships, so GOVERSION-keyed cache keys don't split.
+        check-latest: true
 
     # TODO: Make this optional, it's possibly not needed for lints and a few other quick things.
     - name: Install dependencies on Linux
@@ -259,11 +269,13 @@ runs:
     - name: Get Go environment paths
       id: go-env
       shell: bash
+      env:
+        CACHE_NAMESPACE: ${{ inputs.cache-namespace }}
       run: |
         echo "goversion=$(go env GOVERSION)" >> "$GITHUB_OUTPUT"
         echo "build=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
         echo "modcache=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
-        workflow=$(basename "${GITHUB_WORKFLOW_REF%%@*}" .yml)
+        workflow="${CACHE_NAMESPACE:-$(basename "${GITHUB_WORKFLOW_REF%%@*}" .yml)}"
         echo "workflow=$workflow" >> "$GITHUB_OUTPUT"
         echo "ERIGON_CI_GOCACHE_PATH=$(go env GOCACHE)" >> "$GITHUB_ENV"
         echo "ERIGON_CI_MODCACHE=$(go env GOMODCACHE)" >> "$GITHUB_ENV"

--- a/.github/workflows/cache-warming.yml
+++ b/.github/workflows/cache-warming.yml
@@ -6,14 +6,15 @@ name: Cache Warming
 # on a branch are only accessible to that branch and its base branch — so
 # without a push trigger on main, every PR opens to a cold cache.
 #
-# Calls the same reusable sub-workflows that ci-gate uses. Because GitHub
-# sets GITHUB_WORKFLOW_REF to the called workflow's own path, cache keys
-# produced here are identical to those from ci-gate runs.
+# Calls the same reusable sub-workflows that ci-gate uses. GITHUB_WORKFLOW_REF
+# points at the top-level workflow (cache-warming here, ci-gate in gate runs),
+# so each sub-workflow passes a fixed cache-namespace to setup-erigon to keep
+# cache keys identical across both paths.
 #
 # Workflows that benefit from Go test result caching (tests, race-tests,
 # caplin) run their full test suites. Workflows where test result caching
-# is not possible or useful (bench, sonar) use cache-warming-only: true to
-# compile test binaries only, keeping those runs fast.
+# is not possible or useful (bench, sonar, eest-spec) use
+# cache-warming-only: true to compile only, keeping those runs fast.
 
 on:
   push:
@@ -39,6 +40,12 @@ jobs:
 
   bench:
     uses: ./.github/workflows/test-bench.yml
+    with:
+      cache-warming-only: true
+    secrets: inherit
+
+  eest-spec:
+    uses: ./.github/workflows/test-eest-spec.yml
     with:
       cache-warming-only: true
     secrets: inherit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,6 +56,8 @@ jobs:
 
       - uses: ./.github/actions/setup-erigon
         id: erigon
+        with:
+          cache-namespace: lint
 
       # golangci-lint internally trims cache entries unused for 5 days,
       # so the cache is self-cleaning even as we save new versions.

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -23,6 +23,8 @@ jobs:
 
       - uses: ./.github/actions/setup-erigon
         id: erigon
+        with:
+          cache-namespace: reproducible-build
 
       - name: Build all
         run: make all

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -37,6 +37,7 @@ jobs:
           submodules: true
           cleanup-space: true
           ramdisk: true
+          cache-namespace: sonar
 
       # The merge queue fast-forwards the target branch to the already-tested
       # merge commit, so the pushed SHA equals a merge-queue run's head SHA and

--- a/.github/workflows/test-all-erigon-race.yml
+++ b/.github/workflows/test-all-erigon-race.yml
@@ -74,6 +74,7 @@ jobs:
           cleanup-space: true
           build-cache-extra-key: ${{ matrix.test-group }}
           ramdisk: true
+          cache-namespace: test-all-erigon-race
 
       - name: Run ${{ matrix.test-group }} tests on ${{ matrix.os }} (${{ matrix.exec_mode }} exec)
         env:

--- a/.github/workflows/test-all-erigon.yml
+++ b/.github/workflows/test-all-erigon.yml
@@ -57,6 +57,7 @@ jobs:
           submodules: true
           cleanup-space: true
           ramdisk: true
+          cache-namespace: test-all-erigon
 
       - name: Run all tests on ${{ matrix.os }} (${{ matrix.exec_mode }} exec)
         env:

--- a/.github/workflows/test-bench.yml
+++ b/.github/workflows/test-bench.yml
@@ -53,6 +53,7 @@ jobs:
         id: erigon
         with:
           cleanup-space: true
+          cache-namespace: test-bench
 
       - name: Run benchmarks
         if: '!inputs.cache-warming-only'

--- a/.github/workflows/test-eest-spec.yml
+++ b/.github/workflows/test-eest-spec.yml
@@ -3,6 +3,11 @@ name: EEST spec tests
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      cache-warming-only:
+        description: "Build the evm binaries only; skip fixture runs (for cache warming runs)"
+        type: boolean
+        default: false
 
 defaults:
   run:
@@ -22,8 +27,17 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 1
+      # Warming runs replace the shard matrix with one build per cache class;
+      # the -race suffix routes build-cache-extra-key below.
       - id: load
-        run: echo "matrix=$(yq -o=json -I=0 '.' tools/eest-spec-shards.yml)" >> "$GITHUB_OUTPUT"
+        env:
+          CACHE_WARMING_ONLY: ${{ inputs.cache-warming-only }}
+        run: |
+          if [ "$CACHE_WARMING_ONLY" = "true" ]; then
+            echo 'matrix=[{"shard":"build","target":"evm"},{"shard":"build-race","target":"evm.race"}]' >> "$GITHUB_OUTPUT"
+          else
+            echo "matrix=$(yq -o=json -I=0 '.' tools/eest-spec-shards.yml)" >> "$GITHUB_OUTPUT"
+          fi
 
   eest-spec-tests:
     needs: load-matrix
@@ -54,9 +68,12 @@ jobs:
         id: erigon
         with:
           submodules: false
-          cleanup-space: true
-          ramdisk: true
-          build-cache-extra-key: eest-spec-${{ matrix.shard }}
+          cleanup-space: ${{ !inputs.cache-warming-only }}
+          ramdisk: ${{ !inputs.cache-warming-only }}
+          cache-namespace: test-eest-spec
+          # All non-race shards build the same evm binary and all race shards the
+          # same evm.race, so the cache splits by class rather than by shard.
+          build-cache-extra-key: eest-spec${{ contains(matrix.shard, '-race') && '-race' || '' }}
 
       # Restore-only: PR / merge_group runs never SAVE, so they don't mint a
       # per-ref ~1.6GB duplicate every run. The base-branch (main) entry is
@@ -64,6 +81,7 @@ jobs:
       # readable from every PR. A miss here self-heals (tools/test-fixtures.sh
       # re-downloads), and the warmer repopulates main.
       - name: Restore EEST tarballs
+        if: '!inputs.cache-warming-only'
         uses: actions/cache/restore@v5
         with:
           # Only the .tar.gz files are cached; tools/test-fixtures.sh re-extracts
@@ -79,10 +97,17 @@ jobs:
             test-fixtures-eest-${{ runner.os }}-
 
       - name: Run eest-spec-${{ matrix.shard }}
+        if: '!inputs.cache-warming-only'
         env:
           EEST_SPEC_MAX_FAILURES: ${{ matrix.max-allowed-failures }}
           EEST_SPEC_WORKERS: ${{ matrix.workers }}
         run: make eest-spec-${{ matrix.shard }}
+
+      - name: Build evm binary (cache warming)
+        if: inputs.cache-warming-only
+        env:
+          TARGET: ${{ matrix.target }}
+        run: make "$TARGET"
 
       - uses: ./.github/actions/cleanup-erigon
         if: always()

--- a/.github/workflows/test-integration-caplin.yml
+++ b/.github/workflows/test-integration-caplin.yml
@@ -23,6 +23,8 @@ jobs:
 
       - uses: ./.github/actions/setup-erigon
         id: erigon
+        with:
+          cache-namespace: test-integration-caplin
 
       - name: Cache cl_mainnet tarball
         uses: actions/cache@v5
@@ -71,6 +73,8 @@ jobs:
 
       - uses: ./.github/actions/setup-erigon
         id: erigon
+        with:
+          cache-namespace: test-integration-caplin
 
       - name: Cache cl_mainnet tarball
         uses: actions/cache@v5


### PR DESCRIPTION
## Problem

CI's Go build/module caches almost never hit where they matter, despite ~285GB of gocache entries in the repo's Actions cache:

1. **Warming never reaches gate runs.** Cache keys embed the top-level workflow basename (from `GITHUB_WORKFLOW_REF`), so cache-warming runs save under `gocache|cache-warming|...` while ci-gate runs restore `gocache|ci-gate|...` — disjoint namespaces. cache-warming.yml's header comment claimed `GITHUB_WORKFLOW_REF` points at the *called* workflow; it points at the top-level one (verified against live cache keys). Since ci-gate has no `push` trigger, nothing ever saved gate-restorable keys on `main`, so every merge-queue run cold-builds. Verified in run 27250038739: both Go caches missed in the `tests` job and in every eest shard.
2. **eest-spec keys are per-shard for identical content.** All 21 non-race shards build the same `evm` binary and all 10 race shards the same `evm.race`, yet each shard kept its own key — 508 near-duplicate entries totalling ~170GB (about a third of the repo's whole Actions cache), nearly all unreachable (saved on PR refs or dead merge-queue refs). Nothing warms eest keys on `main` at all.
3. **Go patch-version skew splits keys.** Keys embed the full `GOVERSION` while runner images resolve `1.25.x` to different patch releases depending on their tool cache; a same-PR re-push missed its gocache purely on a go1.25.10/go1.25.11 flip (run 27244607150).

Measured cost per eest shard: module download + cold `evm` build is 216s vs 89s warm — across 32 shard jobs that's roughly a runner-hour per merge-queue run, plus ~2 min off each shard's wall clock.

## Changes

- **setup-erigon**: new `cache-namespace` input overriding the workflow segment of the cache keys; each reusable workflow passes its own basename so warming and gate runs produce identical keys. Also `check-latest: true` on setup-go so every runner resolves `1.25.x` to the same patch release.
- **test-eest-spec**: `build-cache-extra-key` collapsed to two classes (`eest-spec`, `eest-spec-race`); new `cache-warming-only` input (same pattern as sonar/bench) that swaps the 31-shard matrix for two build-only jobs (`make evm`, `make evm.race`) — no fixtures, ramdisk, or cleanup-space; wired into cache-warming.yml.
- **cleanup-erigon**: probe the exact key (`lookup-only: true`) before saving and skip the prune/tar/upload when a sibling matrix job already saved it. With collapsed class keys, ~29 eest shards per run would otherwise each waste 1–2 min compressing a cache that loses the save race and emit a "Cache save failed." warning; this also quiets the same pre-existing duplicate-save noise in test-all-erigon's matrix.
- **cache-warming.yml**: corrected the header comment that documented the wrong `GITHUB_WORKFLOW_REF` behavior, added the eest-spec warming job.

## Rollout

The namespace change orphans existing cache entries once: the first push to `main` after merge repopulates main-scoped caches via cache-warming, and PR branches self-warm on their next run.

CI-only change, no Go code touched, so TDD does not apply; validated with the repo's lint tooling (actionlint clean, zizmor shows zero new findings vs the same files on HEAD) plus `make evm` / `make evm.race` dry-runs.
