### PR TITLE
docs: set mobile browser theme-color to Erigon orange

### DIFF
--- a/docs/site/docusaurus.config.ts
+++ b/docs/site/docusaurus.config.ts
@@ -177,6 +177,7 @@ export default async function createConfig(): Promise<Config> {
       },
       metadata: [
         {name: 'description', content: 'Official documentation for Erigon — the efficient, modular Ethereum execution client built for performance and low disk footprint.'},
+        {name: 'theme-color', content: '#EF7716'},
         {property: 'og:type', content: 'website'},
         {property: 'og:site_name', content: 'Erigon Documentation'},
         {property: 'og:image', content: 'https://docs.erigon.tech/img/og-image.png'},


### PR DESCRIPTION
@
Adds a `theme-color` meta tag to the docs site so mobile browsers tint the address/status bar with the Erigon brand orange — the same behavior the main website, Cocoon and Zilkworm docs already have.

## Change

One line in `themeConfig.metadata` (`docs/site/docusaurus.config.ts`):

```ts
{name: "theme-color", content: "#EF7716"},
```

`#EF7716` matches `--ifm-color-primary` in `custom.css`, so the mobile browser chrome lines up with the navbar/brand orange. Renders as `<meta name="theme-color" content="#EF7716">`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@