### PR TITLE
commitment: de-flake Test_Trie_CorrectSwitchForConcurrentAndSequential

### DIFF
--- a/execution/commitment/hex_patricia_hashed_test.go
+++ b/execution/commitment/hex_patricia_hashed_test.go
@@ -257,8 +257,32 @@ func Test_Trie_CorrectSwitchForConcurrentAndSequential(t *testing.T) {
 	hph := NewHexPatriciaHashed(length.Addr, ms, DefaultTrieConfig())
 	hph.SetTrace(false)
 
-	// generate list of updates diverging from first nibble (good case for parallelization))
-	plainKeysList, _ := generatePlainKeysWithSameHashPrefix(t, nil, length.Addr, 0, 150)
+	// generate list of updates diverging from first nibble (good case for parallelization).
+	// Use a local fixed-seed RNG instead of generatePlainKeysWithSameHashPrefix: that helper
+	// seeds from a package-global counter shared by parallel tests, so the key set (and the
+	// resulting trie shape) depended on test interleaving and occasionally violated the
+	// CanDoConcurrentNext precondition (issue #21715). Seed 45 yields hashed keys covering
+	// all 16 first nibbles, with 13 keys under first nibble 0 diverging in 11 second nibbles.
+	rnd := rand.New(rand.NewSource(45))
+	plainKeysList := make([][]byte, 150)
+	firstNibbles := make(map[byte]struct{})      // distinct first nibbles of hashed keys
+	zeroSecondNibbles := make(map[byte]struct{}) // distinct second nibbles of hashed keys with first nibble 0
+	for i := range plainKeysList {
+		plainKeysList[i] = make([]byte, length.Addr)
+		rnd.Read(plainKeysList[i])
+		hashed := KeyToHexNibbleHash(plainKeysList[i])
+		firstNibbles[hashed[0]] = struct{}{}
+		if hashed[0] == 0 {
+			zeroSecondNibbles[hashed[1]] = struct{}{}
+		}
+	}
+	// CanDoConcurrentNext requires a root branch without extension (>=2 distinct first nibbles)
+	// and a branch node at nibble path [0] (>=2 keys under first nibble 0 diverging at the
+	// second nibble). Guard the fixture so a future change to key generation fails loudly here
+	// instead of flaking on the canParallel assertion below.
+	require.GreaterOrEqual(t, len(firstNibbles), 2, "fixture must hash to >=2 distinct first nibbles (root branch without extension)")
+	require.GreaterOrEqual(t, len(zeroSecondNibbles), 2, "fixture must have >=2 keys with first hashed nibble 0 diverging at the second nibble (branch at path [0])")
+
 	builder := NewUpdateBuilder()
 	for i := 0; i < len(plainKeysList); i++ {
 		builder.Balance(common.Bytes2Hex(plainKeysList[i]), uint64(i))


### PR DESCRIPTION
Fixes #21715

The test builds its 150-key set via `generatePlainKeysWithSameHashPrefix`, which seeds from the package-global `keyGenCounter`. Under `t.Parallel()` the counter start depends on how the package's tests interleave, so the key set (and trie shape) varies run-to-run. A sweep over counter starts in [0, 1e6] found 912 starts (~0.09%) where 0-1 keys land under first nibble 0 (or all share the second nibble), leaving no branch node at path `[0]` — `CanDoConcurrentNext()` returns false and the `canParallel` assertion at line 281 fails. The flake can't reproduce with the test in isolation: in a fresh process the counter starts at 0, which passes — it needs package-level interleaving.

Fix: generate the keys from a local fixed-seed RNG (seed 45, picked from a 60-seed scan for margin: hashed keys cover all 16 first nibbles, 13 keys under first nibble 0 diverging in 11 second nibbles) and assert the parallelization precondition with two explicit fixture guards. A future fixture change fails loudly at the guard instead of flaking at `canParallel`. No helper signatures or other tests touched.

Validation: `go test -race -run Test_Trie_CorrectSwitchForConcurrentAndSequential -count=300 ./execution/commitment/` passes; full package `-race` passes twice; vet/gofmt clean.