### PR TITLE
ci: cache kurtosis engine-bootstrap images (curl-jq, traefik, alpine)

### DIFF
--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -17,6 +17,13 @@ env:
   KURTOSIS_VERSION: "1.15.2"
   KURTOSIS_VECTOR_IMAGE: "timberio/vector:0.45.0-debian"
   KURTOSIS_FLUENTBIT_IMAGE: "fluent/fluent-bit:4.0.0"
+  # Engine-bootstrap helpers (logs-aggregator healthcheck, reverse proxy,
+  # volume init) — also dictated by the Kurtosis release; sync when bumping.
+  # Without these cached, `kurtosis engine start` still needs Docker Hub and
+  # dies on registry outages despite all the caching above.
+  KURTOSIS_CURL_JQ_IMAGE: "badouralix/curl-jq:latest"
+  KURTOSIS_TRAEFIK_IMAGE: "traefik:2.10.6"
+  KURTOSIS_ALPINE_IMAGE: "alpine:3.17"
 
 on:
   workflow_dispatch:
@@ -126,7 +133,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: /tmp/docker-cache
-          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.TEKU_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}
+          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.TEKU_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}-${{ env.KURTOSIS_CURL_JQ_IMAGE }}-${{ env.KURTOSIS_TRAEFIK_IMAGE }}-${{ env.KURTOSIS_ALPINE_IMAGE }}
           lookup-only: true
 
       - name: Pull third-party containers
@@ -149,6 +156,9 @@ jobs:
           pull "kurtosistech/files-artifacts-expander:${KURTOSIS_VERSION}"
           pull "${KURTOSIS_VECTOR_IMAGE}"
           pull "${KURTOSIS_FLUENTBIT_IMAGE}"
+          pull "${KURTOSIS_CURL_JQ_IMAGE}"
+          pull "${KURTOSIS_TRAEFIK_IMAGE}"
+          pull "${KURTOSIS_ALPINE_IMAGE}"
           docker save "${LIGHTHOUSE_IMAGE}" -o /tmp/docker-cache/lighthouse.tar
           docker save "${TEKU_IMAGE}" -o /tmp/docker-cache/teku.tar
           docker save "${ASSERTOOR_IMAGE}" -o /tmp/docker-cache/assertoor.tar
@@ -157,13 +167,16 @@ jobs:
           docker save "kurtosistech/files-artifacts-expander:${KURTOSIS_VERSION}" -o /tmp/docker-cache/kurtosis-expander.tar
           docker save "${KURTOSIS_VECTOR_IMAGE}" -o /tmp/docker-cache/vector.tar
           docker save "${KURTOSIS_FLUENTBIT_IMAGE}" -o /tmp/docker-cache/fluentbit.tar
+          docker save "${KURTOSIS_CURL_JQ_IMAGE}" -o /tmp/docker-cache/curl-jq.tar
+          docker save "${KURTOSIS_TRAEFIK_IMAGE}" -o /tmp/docker-cache/traefik.tar
+          docker save "${KURTOSIS_ALPINE_IMAGE}" -o /tmp/docker-cache/alpine.tar
 
       - name: Save third-party containers to cache
         if: steps.cache-cl-images.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: /tmp/docker-cache
-          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.TEKU_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}
+          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.TEKU_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}-${{ env.KURTOSIS_CURL_JQ_IMAGE }}-${{ env.KURTOSIS_TRAEFIK_IMAGE }}-${{ env.KURTOSIS_ALPINE_IMAGE }}
 
   assertoor_test:
     name: assertoor_${{ matrix.suite }}_${{ matrix.exec_mode }}_test
@@ -256,7 +269,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: /tmp/docker-cache
-          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.TEKU_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}
+          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.TEKU_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}-${{ env.KURTOSIS_CURL_JQ_IMAGE }}-${{ env.KURTOSIS_TRAEFIK_IMAGE }}-${{ env.KURTOSIS_ALPINE_IMAGE }}
 
       - name: Load cached containers into daemon
         if: steps.cache-cl-images.outputs.cache-hit == 'true'
@@ -269,6 +282,9 @@ jobs:
           docker load -i /tmp/docker-cache/kurtosis-expander.tar
           docker load -i /tmp/docker-cache/vector.tar
           docker load -i /tmp/docker-cache/fluentbit.tar
+          docker load -i /tmp/docker-cache/curl-jq.tar
+          docker load -i /tmp/docker-cache/traefik.tar
+          docker load -i /tmp/docker-cache/alpine.tar
 
       - name: Pull third-party containers and save to cache
         if: steps.cache-cl-images.outputs.cache-hit != 'true'
@@ -290,6 +306,9 @@ jobs:
           pull "kurtosistech/files-artifacts-expander:${KURTOSIS_VERSION}"
           pull "${KURTOSIS_VECTOR_IMAGE}"
           pull "${KURTOSIS_FLUENTBIT_IMAGE}"
+          pull "${KURTOSIS_CURL_JQ_IMAGE}"
+          pull "${KURTOSIS_TRAEFIK_IMAGE}"
+          pull "${KURTOSIS_ALPINE_IMAGE}"
           docker save "${LIGHTHOUSE_IMAGE}" -o /tmp/docker-cache/lighthouse.tar
           docker save "${TEKU_IMAGE}" -o /tmp/docker-cache/teku.tar
           docker save "${ASSERTOOR_IMAGE}" -o /tmp/docker-cache/assertoor.tar
@@ -298,6 +317,9 @@ jobs:
           docker save "kurtosistech/files-artifacts-expander:${KURTOSIS_VERSION}" -o /tmp/docker-cache/kurtosis-expander.tar
           docker save "${KURTOSIS_VECTOR_IMAGE}" -o /tmp/docker-cache/vector.tar
           docker save "${KURTOSIS_FLUENTBIT_IMAGE}" -o /tmp/docker-cache/fluentbit.tar
+          docker save "${KURTOSIS_CURL_JQ_IMAGE}" -o /tmp/docker-cache/curl-jq.tar
+          docker save "${KURTOSIS_TRAEFIK_IMAGE}" -o /tmp/docker-cache/traefik.tar
+          docker save "${KURTOSIS_ALPINE_IMAGE}" -o /tmp/docker-cache/alpine.tar
 
       - name: Install Kurtosis CLI and start engine
         # The engine otherwise bootstraps inside `kurtosis run`, mid-action,

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -19,6 +19,8 @@ env:
   KURTOSIS_FLUENTBIT_IMAGE: "fluent/fluent-bit:4.0.0"
   # Engine-bootstrap helpers (logs-aggregator healthcheck, reverse proxy,
   # volume init) — also dictated by the Kurtosis release; sync when bumping.
+  # curl-jq is untagged upstream, so the cache intentionally serves the
+  # `latest` digest from the last warm rather than tracking live `latest`.
   # Without these cached, `kurtosis engine start` still needs Docker Hub and
   # dies on registry outages despite all the caching above.
   KURTOSIS_CURL_JQ_IMAGE: "badouralix/curl-jq:latest"

--- a/.github/workflows/test-kurtosis-gloas.yml
+++ b/.github/workflows/test-kurtosis-gloas.yml
@@ -15,6 +15,8 @@ env:
   KURTOSIS_FLUENTBIT_IMAGE: "fluent/fluent-bit:4.0.0"
   # Engine-bootstrap helpers (logs-aggregator healthcheck, reverse proxy,
   # volume init) — also dictated by the Kurtosis release; sync when bumping.
+  # curl-jq is untagged upstream, so the cache intentionally serves the
+  # `latest` digest from the last warm rather than tracking live `latest`.
   # Without these cached, `kurtosis engine start` still needs Docker Hub and
   # dies on registry outages despite all the caching above.
   KURTOSIS_CURL_JQ_IMAGE: "badouralix/curl-jq:latest"

--- a/.github/workflows/test-kurtosis-gloas.yml
+++ b/.github/workflows/test-kurtosis-gloas.yml
@@ -13,6 +13,13 @@ env:
   KURTOSIS_VERSION: "1.15.2"
   KURTOSIS_VECTOR_IMAGE: "timberio/vector:0.45.0-debian"
   KURTOSIS_FLUENTBIT_IMAGE: "fluent/fluent-bit:4.0.0"
+  # Engine-bootstrap helpers (logs-aggregator healthcheck, reverse proxy,
+  # volume init) — also dictated by the Kurtosis release; sync when bumping.
+  # Without these cached, `kurtosis engine start` still needs Docker Hub and
+  # dies on registry outages despite all the caching above.
+  KURTOSIS_CURL_JQ_IMAGE: "badouralix/curl-jq:latest"
+  KURTOSIS_TRAEFIK_IMAGE: "traefik:2.10.6"
+  KURTOSIS_ALPINE_IMAGE: "alpine:3.17"
 
 on:
   pull_request:
@@ -69,7 +76,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: /tmp/docker-cache
-          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}
+          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}-${{ env.KURTOSIS_CURL_JQ_IMAGE }}-${{ env.KURTOSIS_TRAEFIK_IMAGE }}-${{ env.KURTOSIS_ALPINE_IMAGE }}
           lookup-only: true
 
       - name: Pull third-party containers
@@ -91,6 +98,9 @@ jobs:
           pull "kurtosistech/files-artifacts-expander:${KURTOSIS_VERSION}"
           pull "${KURTOSIS_VECTOR_IMAGE}"
           pull "${KURTOSIS_FLUENTBIT_IMAGE}"
+          pull "${KURTOSIS_CURL_JQ_IMAGE}"
+          pull "${KURTOSIS_TRAEFIK_IMAGE}"
+          pull "${KURTOSIS_ALPINE_IMAGE}"
           docker save "${LIGHTHOUSE_IMAGE}" -o /tmp/docker-cache/lighthouse.tar
           docker save "${ASSERTOOR_IMAGE}" -o /tmp/docker-cache/assertoor.tar
           docker save "kurtosistech/engine:${KURTOSIS_VERSION}" -o /tmp/docker-cache/kurtosis-engine.tar
@@ -98,13 +108,16 @@ jobs:
           docker save "kurtosistech/files-artifacts-expander:${KURTOSIS_VERSION}" -o /tmp/docker-cache/kurtosis-expander.tar
           docker save "${KURTOSIS_VECTOR_IMAGE}" -o /tmp/docker-cache/vector.tar
           docker save "${KURTOSIS_FLUENTBIT_IMAGE}" -o /tmp/docker-cache/fluentbit.tar
+          docker save "${KURTOSIS_CURL_JQ_IMAGE}" -o /tmp/docker-cache/curl-jq.tar
+          docker save "${KURTOSIS_TRAEFIK_IMAGE}" -o /tmp/docker-cache/traefik.tar
+          docker save "${KURTOSIS_ALPINE_IMAGE}" -o /tmp/docker-cache/alpine.tar
 
       - name: Save third-party containers to cache
         if: steps.cache-cl-images.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: /tmp/docker-cache
-          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}
+          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}-${{ env.KURTOSIS_CURL_JQ_IMAGE }}-${{ env.KURTOSIS_TRAEFIK_IMAGE }}-${{ env.KURTOSIS_ALPINE_IMAGE }}
 
   gloas_test:
     name: gloas_${{ matrix.suite }}_test
@@ -146,7 +159,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: /tmp/docker-cache
-          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}
+          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}-${{ env.KURTOSIS_CURL_JQ_IMAGE }}-${{ env.KURTOSIS_TRAEFIK_IMAGE }}-${{ env.KURTOSIS_ALPINE_IMAGE }}
 
       - name: Load cached containers into daemon
         if: steps.cache-cl-images.outputs.cache-hit == 'true'
@@ -158,6 +171,9 @@ jobs:
           docker load -i /tmp/docker-cache/kurtosis-expander.tar
           docker load -i /tmp/docker-cache/vector.tar
           docker load -i /tmp/docker-cache/fluentbit.tar
+          docker load -i /tmp/docker-cache/curl-jq.tar
+          docker load -i /tmp/docker-cache/traefik.tar
+          docker load -i /tmp/docker-cache/alpine.tar
 
       - name: Pull third-party containers and save to cache
         if: steps.cache-cl-images.outputs.cache-hit != 'true'
@@ -178,6 +194,9 @@ jobs:
           pull "kurtosistech/files-artifacts-expander:${KURTOSIS_VERSION}"
           pull "${KURTOSIS_VECTOR_IMAGE}"
           pull "${KURTOSIS_FLUENTBIT_IMAGE}"
+          pull "${KURTOSIS_CURL_JQ_IMAGE}"
+          pull "${KURTOSIS_TRAEFIK_IMAGE}"
+          pull "${KURTOSIS_ALPINE_IMAGE}"
           docker save "${LIGHTHOUSE_IMAGE}" -o /tmp/docker-cache/lighthouse.tar
           docker save "${ASSERTOOR_IMAGE}" -o /tmp/docker-cache/assertoor.tar
           docker save "kurtosistech/engine:${KURTOSIS_VERSION}" -o /tmp/docker-cache/kurtosis-engine.tar
@@ -185,13 +204,16 @@ jobs:
           docker save "kurtosistech/files-artifacts-expander:${KURTOSIS_VERSION}" -o /tmp/docker-cache/kurtosis-expander.tar
           docker save "${KURTOSIS_VECTOR_IMAGE}" -o /tmp/docker-cache/vector.tar
           docker save "${KURTOSIS_FLUENTBIT_IMAGE}" -o /tmp/docker-cache/fluentbit.tar
+          docker save "${KURTOSIS_CURL_JQ_IMAGE}" -o /tmp/docker-cache/curl-jq.tar
+          docker save "${KURTOSIS_TRAEFIK_IMAGE}" -o /tmp/docker-cache/traefik.tar
+          docker save "${KURTOSIS_ALPINE_IMAGE}" -o /tmp/docker-cache/alpine.tar
 
       - name: Save third-party containers to cache
         if: steps.cache-cl-images.outputs.cache-hit != 'true' && github.event_name != 'pull_request'
         uses: actions/cache/save@v5
         with:
           path: /tmp/docker-cache
-          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}
+          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}-${{ env.KURTOSIS_CURL_JQ_IMAGE }}-${{ env.KURTOSIS_TRAEFIK_IMAGE }}-${{ env.KURTOSIS_ALPINE_IMAGE }}
 
       - name: Install Kurtosis CLI and start engine
         # The engine otherwise bootstraps inside `kurtosis run`, mid-action,


### PR DESCRIPTION
## Problem

`kurtosis / assertoor_regular_serial_test` failed on #21646 ([job link](https://github.com/erigontech/erigon/actions/runs/27271494252/job/80543276225)): the runner lost Docker Hub connectivity for the entire job (even the Docker login step timed out against `registry-1.docker.io`), and `kurtosis engine start` exhausted all 3 retries failing to pull `badouralix/curl-jq:latest` — the logs-aggregator healthcheck container. A sibling job on a different runner passed at the same time, so this was per-runner registry egress, i.e. exactly the class of flake the cached-image setup exists to absorb.

## Root cause

The `docker-cl-*` cache covers the CL images plus kurtosis engine/core/expander/vector/fluent-bit, but `kurtosis engine start` launches **three more** helper containers, none of them cached:

- `badouralix/curl-jq:latest` — logs-aggregator healthcheck (`logs_aggregator_functions/shared_helpers.go` in kurtosis-tech/kurtosis)
- `traefik:2.10.6` — reverse proxy (`reverse_proxy_functions/implementations/traefik/consts.go`)
- `alpine:3.17` — volume-init helper (`engine_functions`/`logs_collector_functions`)

A passing run's log confirms these are the only three images pulled at engine start (every cached image shows no pull line), so the engine-start step — whose stated purpose is to keep registry blips out of the test step — still had a hard Docker Hub dependency.

## Fix

Add the three images to the existing pull → `docker save` → cache → `docker load` pipeline and cache keys in both `test-kurtosis-assertoor.yml` and `test-kurtosis-gloas.yml`, following the established vector/fluent-bit pattern. Kurtosis uses image download mode "missing", so pre-loaded images are used without contacting the registry (verified in the passing run: vector/fluent-bit are started without pull lines). After this, `kurtosis engine start` is fully cache-served.

## Rollout

- The cache key changes, so this PR's own kurtosis runs cold-pull once and exercise the new pull/save path.
- On merge, the push touching these files triggers `cache-warming-kurtosis-cl-images.yml` and `cache-warming-kurtosis-gloas-images.yml` (paths filters) which re-warm the main-scope cache under the new key. No manual action needed.

## Residual exposure (out of scope)

Enclave-time images with intentionally mutable tags (`ethpandaops/ethereum-genesis-generator`, `rpc-snooper:latest`, `spamoor:master`, suite-specific CL devnet tags, …) are still pulled from Docker Hub during `kurtosis run`. Pinning/caching those would change test semantics (they deliberately track moving tags), so they stay as-is.

## Validation

- `actionlint`: no new findings (the two pre-existing SC2086 infos in the apt-get line are unchanged)
- YAML parse clean; resolved cache key ≈ 209 chars (limit 512)
- `make lint`: 0 issues