### PR TITLE
[r3.5] execution/stagedsync: preserve real error through ErrExecAbortError wrap

### DIFF
--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1205,6 +1205,16 @@ func applyLoopFlushAsComplete(valid bool, cntInvalid int) bool {
 	return valid && cntInvalid == 0
 }
 
+// wrapAsExecAbort wraps origErr in ErrExecAbortError unless it already is one,
+// preserving the real origErr as OriginError instead of the zero-value an
+// inline type-assertion would substitute on the failure branch.
+func wrapAsExecAbort(origErr error, depTxIndex int) error {
+	if _, ok := origErr.(protocol.ErrExecAbortError); ok {
+		return origErr
+	}
+	return protocol.ErrExecAbortError{DependencyTxIndex: depTxIndex, OriginError: origErr}
+}
+
 // execLoopExitDecision is the result of evaluating the exec-loop's
 // per-blockResult exit conditions. Values are ordered by precedence:
 // later conditions only matter if no earlier one fired.
@@ -1944,9 +1954,7 @@ func (ev *taskVersion) Execute(evm *vm.EVM,
 		chainConfig, chainReader, dirs, !ev.shouldDelayFeeCalc)
 
 	if ibs.HadInvalidRead() || result.Err != nil {
-		if err, ok := result.Err.(protocol.ErrExecAbortError); !ok {
-			result.Err = protocol.ErrExecAbortError{DependencyTxIndex: ibs.DepTxIndex(), OriginError: err}
-		}
+		result.Err = wrapAsExecAbort(result.Err, ibs.DepTxIndex())
 	}
 
 	if result.Err != nil {

--- a/execution/stagedsync/exec3_parallel_robustness_test.go
+++ b/execution/stagedsync/exec3_parallel_robustness_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/execution/protocol"
 	"github.com/erigontech/erigon/execution/protocol/rules"
 	"github.com/erigontech/erigon/execution/state"
 	"github.com/erigontech/erigon/execution/types/accounts"
@@ -995,4 +996,64 @@ func TestApplyLoopFlush_InvalidTxWritesAreEstimate(t *testing.T) {
 	require.Equal(t, invalidTxIdx, res.DepIdx(),
 		"phantom write is recorded as Estimate, not deleted — downstream "+
 			"OCC must still see it as a dependency")
+}
+
+// Pins wrapAsExecAbort: a real underlying err must survive as OriginError
+// (or remain a true nil interface), never be substituted by a zero
+// ErrExecAbortError whose Error() reads "execution aborted due to dependency 0".
+func TestWrapAsExecAbort_PreservesOriginError(t *testing.T) {
+	realErr := errors.New("engine.Initialize: validator set call reverted")
+	tests := []struct {
+		name       string
+		origErr    error
+		depTxIndex int
+		check      func(t *testing.T, got error)
+	}{
+		{
+			name:       "nil err is wrapped with nil OriginError (no bogus dep-0 string)",
+			origErr:    nil,
+			depTxIndex: 5,
+			check: func(t *testing.T, got error) {
+				abort, ok := got.(protocol.ErrExecAbortError)
+				require.True(t, ok)
+				require.Equal(t, 5, abort.DependencyTxIndex)
+				require.Nil(t, abort.OriginError,
+					"OriginError must be a true nil interface so IsError() reports false")
+				require.False(t, abort.IsError(),
+					"a wrapped nil err must NOT classify as a genuine execution error")
+			},
+		},
+		{
+			name:       "non-abort err survives as OriginError",
+			origErr:    realErr,
+			depTxIndex: 0,
+			check: func(t *testing.T, got error) {
+				abort, ok := got.(protocol.ErrExecAbortError)
+				require.True(t, ok)
+				require.Equal(t, 0, abort.DependencyTxIndex)
+				require.True(t, abort.IsError())
+				require.Equal(t, realErr.Error(), abort.OriginError.Error(),
+					"real err must reach OriginError verbatim, not be replaced by "+
+						"a zero ErrExecAbortError whose Error() reads as "+
+						"\"execution aborted due to dependency 0\"")
+			},
+		},
+		{
+			name:       "already-wrapped err is returned unchanged",
+			origErr:    protocol.ErrExecAbortError{DependencyTxIndex: 7, OriginError: nil},
+			depTxIndex: 99,
+			check: func(t *testing.T, got error) {
+				abort, ok := got.(protocol.ErrExecAbortError)
+				require.True(t, ok)
+				require.Equal(t, 7, abort.DependencyTxIndex,
+					"depTxIndex of the passed-through err must not be overwritten")
+				require.Nil(t, abort.OriginError)
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.check(t, wrapAsExecAbort(tc.origErr, tc.depTxIndex))
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Fixes the misleading `"execution aborted due to dependency 0"` error class reported in #21719 (gnosis block 46,597,320, release/3.5).

The wrap site at `taskVersion.Execute` used the inline form

```go
if err, ok := result.Err.(protocol.ErrExecAbortError); !ok {
    result.Err = protocol.ErrExecAbortError{
        DependencyTxIndex: ibs.DepTxIndex(), OriginError: err}
}
```

Go sets the asserted local `err` to the **zero value** of the asserted type (not nil) when `ok` is false, so the wrap substituted a zero `ErrExecAbortError{}` for the real error. That zero value's `Error()` returns `"execution aborted due to dependency 0"` (DependencyTxIndex == 0 hits the dependency branch), which then propagated to `invalidBlockResult` at `exec3_parallel.go:2248` and masked the underlying failure.

The most likely producer of a non-`ErrExecAbortError` into this site is the block-init path (`TxIndex == -1`, e.g. AuRa `engine.Initialize` on gnosis): system-contract calls return plain errors that the inline form would silently swallow.

## What this PR does

- Extracts the wrap into `wrapAsExecAbort`, which uses `result.Err` directly — preserving either the real underlying error or a true nil interface as `OriginError`.
- Adds `TestWrapAsExecAbort_PreservesOriginError` pinning the contract: nil-in stays nil-out (no bogus dep-0 string), non-abort err survives as `OriginError`, already-abort err is returned unchanged.

## Test plan

- [x] `make lint` clean
- [x] `go test -run TestWrapAsExecAbort_PreservesOriginError ./execution/stagedsync/` passes on this branch
- [x] Same test fails to build on the pre-fix `release/3.5` tip (helper not defined) — confirms the test exercises the new code path
- [ ] Next QA `release/3.5` sync-from-scratch on gnosis surfaces the real error string at the previously-hit block (no longer "dependency 0")

## Cherry-pick

The same bug exists on `main`. After this lands a cherry-pick PR will follow.