### PR TITLE
ci: retry Docker Buildx setup on transient failure

### DIFF
--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -62,6 +62,14 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
 
       - name: Set up Docker Buildx
+        id: buildx_setup
+        continue-on-error: true
+        uses: docker/setup-buildx-action@v4
+
+      # setup-buildx boots BuildKit by pulling moby/buildkit from Docker Hub;
+      # retry once so a transient registry failure doesn't fail the job.
+      - name: Retry Docker Buildx setup on transient failure
+        if: steps.buildx_setup.outcome == 'failure'
         uses: docker/setup-buildx-action@v4
 
       - name: Build erigon Docker image (with BuildKit layer cache)


### PR DESCRIPTION
In merge-queue run [27280175556](https://github.com/erigontech/erigon/actions/runs/27280175556/job/80572198019) `kurtosis / build-erigon-image` failed in the "Set up Docker Buildx" step: booting BuildKit pulls `moby/buildkit:buildx-stable-1` from Docker Hub, and the pull timed out (`Get "https://registry-1.docker.io/v2/": context deadline exceeded`), failing the CI Gate for #21723.

The job already retries the erigon image build on transient failures, but the buildx setup step runs before that retry and wasn't covered. This applies the same pattern: the first setup attempt is `continue-on-error`, and a second attempt runs only if the first failed. Both attempts failing still fails the job.