### PR TITLE
[3.5] db: commitment domain to take existance filter to RAM

### DIFF
--- a/db/state/dirty_files.go
+++ b/db/state/dirty_files.go
@@ -416,7 +416,7 @@ func (d *Domain) openDirtyFiles(dirEntries []string) (err error) {
 			if ok {
 				fName := filepath.Base(fPath)
 				d.FileVersion.AccessorKVI.MustSupport(fileVer, fName)
-				if item.index, err = recsplit.OpenIndex(fPath); err != nil {
+				if item.index, err = d.openHashMapAccessor(fPath); err != nil {
 					d.logger.Warn("[agg] Domain.openDirtyFiles", "err", err, "f", fName)
 					// don't interrupt on error. other files may be good
 				}
@@ -521,7 +521,7 @@ func (h *History) openDirtyFiles(dataEntries, accessorEntries []string) error {
 			if ok {
 				fName := filepath.Base(fPath)
 				h.FileVersion.AccessorVI.MustSupport(fileVer, fName)
-				if item.index, err = recsplit.OpenIndex(fPath); err != nil {
+				if item.index, err = h.openHashMapAccessor(fPath); err != nil {
 					h.logger.Warn("[agg] History.openDirtyFiles", "err", err, "f", fName)
 					// don't interrupt on error. other files may be good
 				}
@@ -584,7 +584,7 @@ func (ii *InvertedIndex) openDirtyFiles(dataEntries, accessorEntries []string) e
 			if ok {
 				fName := filepath.Base(fPath)
 				ii.FileVersion.AccessorEFI.MustSupport(fileVer, fName)
-				if item.index, err = recsplit.OpenIndex(fPath); err != nil {
+				if item.index, err = ii.openHashMapAccessor(fPath); err != nil {
 					ii.logger.Warn("[agg] InvertedIndex.openDirtyFiles", "err", err, "f", fName)
 					// don't interrupt on error. other files may be good
 				}


### PR DESCRIPTION
This PR taking Existance filter into RAM
on bloatnet it showed +30% of commitment speed